### PR TITLE
feat(catalog): expose last-activity on the projects-with-counts list

### DIFF
--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -289,8 +289,9 @@ type ProjectWithCounts struct {
 	Description      string `json:"Description"`
 	SecretCount      int64  `json:"secret_count"`
 	EnvironmentCount int64  `json:"environment_count"`
-	Deleted          bool   `json:"deleted"`              // true when soft-deleted (only returned when includeDeleted)
-	DeletedAt        string `json:"deleted_at,omitempty"` // RFC3339 timestamp when soft-deleted
+	LastActivity     string `json:"last_activity,omitempty"` // most recent of project update or any secret change
+	Deleted          bool   `json:"deleted"`                 // true when soft-deleted (only returned when includeDeleted)
+	DeletedAt        string `json:"deleted_at,omitempty"`    // RFC3339 timestamp when soft-deleted
 }
 
 // ProjectMember is a user who holds a role at a project's scope (ADR-021).

--- a/internal/storage/store/local_secrets.go
+++ b/internal/storage/store/local_secrets.go
@@ -41,14 +41,15 @@ func (ls *LocalStorage) ListProjects(ctx context.Context) ([]*models.Project, er
 // bypasses GORM's soft-delete scope, so the deleted_at filters are explicit.
 func (ls *LocalStorage) ListProjectsWithCounts(ctx context.Context, includeDeleted bool) ([]storage.ProjectWithCounts, error) {
 	type row struct {
-		ID               uint
-		Name             string
-		Description      string
-		SecretCount      int64
-		EnvironmentCount int64
-		DeletedAt        *string
-		CreatedAt        string
-		UpdatedAt        string
+		ID                 uint
+		Name               string
+		Description        string
+		SecretCount        int64
+		EnvironmentCount   int64
+		DeletedAt          *string
+		CreatedAt          string
+		UpdatedAt          string
+		LastSecretActivity *string
 	}
 	where := "WHERE p.deleted_at IS NULL"
 	if includeDeleted {
@@ -58,7 +59,8 @@ func (ls *LocalStorage) ListProjectsWithCounts(ctx context.Context, includeDelet
 	err := ls.db.WithContext(ctx).Raw(`
 		SELECT p.id, p.name, p.description, p.created_at, p.updated_at, p.deleted_at,
 		       COUNT(DISTINCT s.id) AS secret_count,
-		       COUNT(DISTINCT e.id) AS environment_count
+		       COUNT(DISTINCT e.id) AS environment_count,
+		       MAX(s.updated_at) AS last_secret_activity
 		FROM projects p
 		LEFT JOIN secret_nodes s ON s.project_id = p.id
 		LEFT JOIN environments e ON e.project_id = p.id AND e.deleted_at IS NULL
@@ -77,6 +79,14 @@ func (ls *LocalStorage) ListProjectsWithCounts(ctx context.Context, includeDelet
 			Description:      r.Description,
 			SecretCount:      r.SecretCount,
 			EnvironmentCount: r.EnvironmentCount,
+		}
+		// Last activity = most recent of the project's own update or any of its
+		// secrets' updates. Computed in Go (not SQL GREATEST) so the query works
+		// on both Postgres and the SQLite-backed tests; the two columns share a
+		// format within a given DB, so a lexical compare is a valid time compare.
+		pc.LastActivity = r.UpdatedAt
+		if r.LastSecretActivity != nil && *r.LastSecretActivity > pc.LastActivity {
+			pc.LastActivity = *r.LastSecretActivity
 		}
 		if r.DeletedAt != nil {
 			pc.Deleted = true

--- a/internal/storage/store/projects_counts_test.go
+++ b/internal/storage/store/projects_counts_test.go
@@ -1,0 +1,56 @@
+package store
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestListProjectsWithCounts_CountsAndActivity covers the aggregate fields the
+// Projects list page renders: secret/environment counts and a last-activity
+// timestamp (most recent of the project's own update or any secret change).
+func TestListProjectsWithCounts_CountsAndActivity(t *testing.T) {
+	ctx := context.Background()
+	ls := newRestoreTestStore(t)
+
+	proj, err := ls.CreateProject(ctx, &models.Project{Name: "app"})
+	require.NoError(t, err)
+	for _, name := range []string{"dev", "prod"} {
+		_, err = ls.CreateEnvironment(ctx, &models.Environment{Name: name, ProjectID: proj.ID})
+		require.NoError(t, err)
+	}
+	for _, name := range []string{"db-pw", "api-key", "token"} {
+		_, err = ls.CreateSecret(ctx, &models.SecretNode{
+			ProjectID: proj.ID, EnvironmentID: 1, Name: name, IsSecret: true, Type: "text", Status: "active",
+		})
+		require.NoError(t, err)
+	}
+
+	got, err := ls.ListProjectsWithCounts(ctx, false)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, int64(3), got[0].SecretCount)
+	assert.Equal(t, int64(2), got[0].EnvironmentCount)
+	assert.NotEmpty(t, got[0].LastActivity, "last activity should reflect the most recent secret update")
+}
+
+// A project with no secrets still reports a last-activity timestamp, falling
+// back to the project's own updated_at (MAX over zero secret rows is NULL).
+func TestListProjectsWithCounts_LastActivityFallsBackToProject(t *testing.T) {
+	ctx := context.Background()
+	ls := newRestoreTestStore(t)
+
+	proj, err := ls.CreateProject(ctx, &models.Project{Name: "empty"})
+	require.NoError(t, err)
+	_, err = ls.CreateEnvironment(ctx, &models.Environment{Name: "dev", ProjectID: proj.ID})
+	require.NoError(t, err)
+
+	got, err := ls.ListProjectsWithCounts(ctx, false)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, int64(0), got[0].SecretCount)
+	assert.NotEmpty(t, got[0].LastActivity, "no secrets → fall back to the project's own updated_at")
+}


### PR DESCRIPTION
## Summary

The Projects list page renders **secret count**, **environment count**, and a **last-activity timestamp** per row — but the list endpoint never returned a timestamp. `ProjectWithCounts` carried only the two counts, so the frontend's `lastActivity` always resolved to empty and the date never appeared.

This adds `LastActivity` to `ProjectWithCounts`, computed as the most recent of the project's own `updated_at` or any of its secrets' `updated_at`.

## Cross-DB note

The query aggregates `MAX(s.updated_at)` and the greater-of is resolved **in Go**, not via SQL `GREATEST` — `GREATEST` is Postgres-only and would break the SQLite-backed store tests. The two timestamp columns share a format within a given DB, so a lexical compare is a valid time compare.

## Testing

- New tests: counts + last-activity population, and the no-secrets fallback to the project's own `updated_at`
- `build` / `vet` / `go test ./...` green
- The new aggregate shape (`GROUP BY p.id` + `p.*` columns + `MAX(...)` over a LEFT JOIN, nullable result) verified valid against live Postgres

> Pairs with keyorix-web — the frontend reads the new `last_activity` field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
