### PR TITLE
chore(dev): make `make run` work out of the box

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ BUILD_DIR=./bin
 VERSION?=dev
 LDFLAGS=-ldflags "-X github.com/keyorixhq/keyorix/internal/cli.version=$(VERSION)"
 
-.PHONY: build build-cli build-server install install-cli install-server clean run dev docker-build docker-up docker-down docker-logs
+.PHONY: build build-cli build-server install install-cli install-server clean run db-up dev docker-build docker-up docker-down docker-logs
 
 build: build-cli build-server
 
@@ -22,8 +22,15 @@ install-server: build-server
 
 install: install-cli install-server
 
-run:
-	KEYORIX_DB_PASSWORD=keyorix123 KEYORIX_MASTER_PASSWORD=keyorix123 go run server/main.go
+# Run the server locally against the docker-compose Postgres, using the
+# committed dev config. `db-up` ensures Postgres is running first.
+run: db-up
+	KEYORIX_CONFIG_PATH=configs/dev.yaml KEYORIX_DB_PASSWORD=keyorix123 KEYORIX_MASTER_PASSWORD=keyorix123 go run server/main.go
+
+# Start only the Postgres service (not the full stack — `make run` runs the
+# server on :8080 itself, so we don't want the compose server container too).
+db-up:
+	docker compose up -d postgres
 
 dev: install-cli
 	@echo "✓ keyorix CLI installed to /usr/local/bin"

--- a/configs/dev.yaml
+++ b/configs/dev.yaml
@@ -1,0 +1,25 @@
+# Local development configuration used by `make run`.
+#
+# Connects to the PostgreSQL instance defined in docker-compose.yml (`make run`
+# starts it automatically). Credentials are NEVER stored here — they come from
+# the environment (KEYORIX_DB_PASSWORD / KEYORIX_MASTER_PASSWORD), which the
+# `run` target sets to the docker-compose dev defaults.
+#
+# This is a committed, secret-free dev config. For a personal/local override,
+# copy configs/keyorix.yaml.tpl to ./keyorix.yaml (gitignored) and run the
+# server with KEYORIX_CONFIG_PATH=./keyorix.yaml.
+environment: development
+server:
+  http:
+    enabled: true
+    port: "8080"
+storage:
+  type: postgres
+  database:
+    host: localhost
+    port: "5432"
+    name: keyorix
+    user: keyorix
+    ssl_mode: disable
+encryption:
+  enabled: true


### PR DESCRIPTION
## Summary

Bare `make run` failed on a fresh tree with `open keyorix.yaml: no such file` — the target set no `KEYORIX_CONFIG_PATH` and relied on a `./keyorix.yaml` that's **gitignored**, so a clean clone had no config. (It already set `KEYORIX_DB_PASSWORD=keyorix123` — the docker-compose Postgres password — so it always intended Postgres, not the SQLite template.)

- **`configs/dev.yaml`** — a committed, secret-free dev config pointing at the docker-compose Postgres on `localhost:5432`. Credentials still come from env, never the file.
- **`make run`** now uses it via `KEYORIX_CONFIG_PATH` and depends on a new **`db-up`** target that starts *only* the Postgres service (not `docker compose up -d`, which would also bind `:8080` with the server container).

## Testing

Verified end-to-end: `make run` brings up Postgres and boots the server; `/health` reports `database`, `encryption` (AES-256-GCM), and `storage` all healthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
