### PR TITLE
feat(anomaly): dedup alerts on re-run + server-side acknowledged filter

### DIFF
--- a/internal/core/anomaly.go
+++ b/internal/core/anomaly.go
@@ -18,7 +18,7 @@ type AnomalyDetector struct {
 type StorageInterface = interface {
 	ListSecretAccessLogs(ctx context.Context, secretID uint, since time.Time) ([]models.SecretAccessLog, error)
 	CreateAnomalyAlert(ctx context.Context, alert *models.AnomalyAlert) error
-	ListAnomalyAlerts(ctx context.Context, unacknowledgedOnly bool) ([]models.AnomalyAlert, error)
+	ListAnomalyAlerts(ctx context.Context, acknowledged *bool) ([]models.AnomalyAlert, error)
 	AcknowledgeAnomalyAlert(ctx context.Context, id uint) error
 }
 
@@ -143,9 +143,10 @@ func detectAnomalies(secret models.SecretNode, log models.SecretAccessLog, basel
 	return alerts
 }
 
-// ListAlerts returns anomaly alerts, optionally filtering to unacknowledged only.
-func (d *AnomalyDetector) ListAlerts(ctx context.Context, unacknowledgedOnly bool) ([]models.AnomalyAlert, error) {
-	return d.storage.ListAnomalyAlerts(ctx, unacknowledgedOnly)
+// ListAlerts returns anomaly alerts. acknowledged filters by state: nil returns
+// all, &true only acknowledged, &false only unacknowledged.
+func (d *AnomalyDetector) ListAlerts(ctx context.Context, acknowledged *bool) ([]models.AnomalyAlert, error) {
+	return d.storage.ListAnomalyAlerts(ctx, acknowledged)
 }
 
 // AcknowledgeAlert marks an alert as acknowledged.

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -500,8 +500,8 @@ func (m *MockStorage) CreateAnomalyAlert(ctx context.Context, alert *models.Anom
 	return args.Error(0)
 }
 
-func (m *MockStorage) ListAnomalyAlerts(ctx context.Context, unacknowledgedOnly bool) ([]models.AnomalyAlert, error) {
-	args := m.Called(ctx, unacknowledgedOnly)
+func (m *MockStorage) ListAnomalyAlerts(ctx context.Context, acknowledged *bool) ([]models.AnomalyAlert, error) {
+	args := m.Called(ctx, acknowledged)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -125,7 +125,7 @@ type Storage interface {
 	CreateSecretAccessLog(ctx context.Context, log *models.SecretAccessLog) error
 	ListSecretAccessLogs(ctx context.Context, secretID uint, since time.Time) ([]models.SecretAccessLog, error)
 	CreateAnomalyAlert(ctx context.Context, alert *models.AnomalyAlert) error
-	ListAnomalyAlerts(ctx context.Context, unacknowledgedOnly bool) ([]models.AnomalyAlert, error)
+	ListAnomalyAlerts(ctx context.Context, acknowledged *bool) ([]models.AnomalyAlert, error)
 	AcknowledgeAnomalyAlert(ctx context.Context, id uint) error
 	GetAuditLogs(ctx context.Context, filter *AuditFilter) ([]*models.AuditEvent, int64, error)
 	GetRBACAuditLogs(ctx context.Context, filter *RBACAuditFilter) ([]*RBACAuditLog, int64, error)

--- a/internal/storage/store/anomaly_test.go
+++ b/internal/storage/store/anomaly_test.go
@@ -1,0 +1,104 @@
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func newAnomalyTestStore(t *testing.T) *LocalStorage {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.AnomalyAlert{}))
+	return NewLocalStorage(db)
+}
+
+func boolPtr(b bool) *bool { return &b }
+
+func countAlerts(t *testing.T, ls *LocalStorage) int {
+	t.Helper()
+	all, err := ls.ListAnomalyAlerts(context.Background(), nil)
+	require.NoError(t, err)
+	return len(all)
+}
+
+// CreateAnomalyAlert is idempotent within the dedup window: re-inserting an
+// equivalent alert (same secret/type/actor/IP) is a no-op, but a different IP
+// or a later window still produces a fresh alert.
+func TestCreateAnomalyAlert_DedupsWithinWindow(t *testing.T) {
+	ctx := context.Background()
+	ls := newAnomalyTestStore(t)
+	now := time.Now().UTC()
+
+	base := func(ip string, at time.Time) *models.AnomalyAlert {
+		return &models.AnomalyAlert{
+			SecretNodeID: 1, SecretName: "db-pw", AlertType: "new_ip", Severity: "high",
+			AccessedBy: "alice", IPAddress: ip, DetectedAt: at,
+		}
+	}
+
+	// First insert lands.
+	require.NoError(t, ls.CreateAnomalyAlert(ctx, base("10.0.0.1", now)))
+	assert.Equal(t, 1, countAlerts(t, ls))
+
+	// Identical alert in the same window is suppressed.
+	require.NoError(t, ls.CreateAnomalyAlert(ctx, base("10.0.0.1", now)))
+	assert.Equal(t, 1, countAlerts(t, ls), "duplicate within window must not insert")
+
+	// Different IP is a distinct alert.
+	require.NoError(t, ls.CreateAnomalyAlert(ctx, base("10.0.0.2", now)))
+	assert.Equal(t, 2, countAlerts(t, ls))
+
+	// Same identity but a later window (beyond the dedup window) inserts again.
+	require.NoError(t, ls.CreateAnomalyAlert(ctx, base("10.0.0.1", now.Add(2*time.Hour))))
+	assert.Equal(t, 3, countAlerts(t, ls), "a genuine later recurrence still alerts")
+}
+
+// A different alert type for the same access is not deduped against another type.
+func TestCreateAnomalyAlert_DistinctTypesNotDeduped(t *testing.T) {
+	ctx := context.Background()
+	ls := newAnomalyTestStore(t)
+	now := time.Now().UTC()
+
+	require.NoError(t, ls.CreateAnomalyAlert(ctx, &models.AnomalyAlert{
+		SecretNodeID: 1, AlertType: "new_ip", AccessedBy: "alice", IPAddress: "10.0.0.1", DetectedAt: now,
+	}))
+	require.NoError(t, ls.CreateAnomalyAlert(ctx, &models.AnomalyAlert{
+		SecretNodeID: 1, AlertType: "off_hours", AccessedBy: "alice", IPAddress: "10.0.0.1", DetectedAt: now,
+	}))
+	assert.Equal(t, 2, countAlerts(t, ls))
+}
+
+// ListAnomalyAlerts filters by acknowledged state: nil=all, &true, &false.
+func TestListAnomalyAlerts_AcknowledgedFilter(t *testing.T) {
+	ctx := context.Background()
+	ls := newAnomalyTestStore(t)
+	now := time.Now().UTC()
+
+	a1 := &models.AnomalyAlert{SecretNodeID: 1, AlertType: "new_ip", AccessedBy: "alice", IPAddress: "10.0.0.1", DetectedAt: now}
+	a2 := &models.AnomalyAlert{SecretNodeID: 2, AlertType: "new_user", AccessedBy: "bob", IPAddress: "10.0.0.2", DetectedAt: now}
+	require.NoError(t, ls.CreateAnomalyAlert(ctx, a1))
+	require.NoError(t, ls.CreateAnomalyAlert(ctx, a2))
+	require.NoError(t, ls.AcknowledgeAnomalyAlert(ctx, a1.ID))
+
+	all, err := ls.ListAnomalyAlerts(ctx, nil)
+	require.NoError(t, err)
+	assert.Len(t, all, 2)
+
+	acked, err := ls.ListAnomalyAlerts(ctx, boolPtr(true))
+	require.NoError(t, err)
+	require.Len(t, acked, 1)
+	assert.Equal(t, a1.ID, acked[0].ID)
+
+	unacked, err := ls.ListAnomalyAlerts(ctx, boolPtr(false))
+	require.NoError(t, err)
+	require.Len(t, unacked, 1)
+	assert.Equal(t, a2.ID, unacked[0].ID)
+}

--- a/internal/storage/store/local_audit.go
+++ b/internal/storage/store/local_audit.go
@@ -84,15 +84,43 @@ func (ls *LocalStorage) GetRBACAuditLogs(_ context.Context, _ *storage.RBACAudit
 
 // --- Anomaly alerts ---
 
+// anomalyDedupWindow bounds how long an equivalent alert suppresses duplicates.
+// It matches RunDetection's 1-hour analysis window: re-running detection over
+// the same window must not re-insert identical alerts, but a genuine later
+// recurrence (a new access in a new window) still produces a fresh alert.
+const anomalyDedupWindow = time.Hour
+
+// CreateAnomalyAlert inserts an alert, idempotently. If an equivalent alert
+// (same secret, type, actor, and IP) was already recorded within the dedup
+// window, the insert is skipped and nil is returned — so re-running detection
+// over the same window does not pile up duplicates.
 func (ls *LocalStorage) CreateAnomalyAlert(ctx context.Context, alert *models.AnomalyAlert) error {
+	cutoff := alert.DetectedAt
+	if cutoff.IsZero() {
+		cutoff = time.Now().UTC()
+	}
+	cutoff = cutoff.Add(-anomalyDedupWindow)
+
+	var existing int64
+	if err := ls.db.WithContext(ctx).Model(&models.AnomalyAlert{}).
+		Where("secret_node_id = ? AND alert_type = ? AND accessed_by = ? AND ip_address = ? AND detected_at > ?",
+			alert.SecretNodeID, alert.AlertType, alert.AccessedBy, alert.IPAddress, cutoff).
+		Count(&existing).Error; err != nil {
+		return err
+	}
+	if existing > 0 {
+		return nil
+	}
 	return ls.db.WithContext(ctx).Create(alert).Error
 }
 
-func (ls *LocalStorage) ListAnomalyAlerts(ctx context.Context, unacknowledgedOnly bool) ([]models.AnomalyAlert, error) {
+// ListAnomalyAlerts returns alerts newest-first. acknowledged filters by state:
+// nil returns all, &true only acknowledged, &false only unacknowledged.
+func (ls *LocalStorage) ListAnomalyAlerts(ctx context.Context, acknowledged *bool) ([]models.AnomalyAlert, error) {
 	var alerts []models.AnomalyAlert
 	query := ls.db.WithContext(ctx)
-	if unacknowledgedOnly {
-		query = query.Where("acknowledged = ?", false)
+	if acknowledged != nil {
+		query = query.Where("acknowledged = ?", *acknowledged)
 	}
 	result := query.Order("detected_at DESC").Find(&alerts)
 	return alerts, result.Error

--- a/internal/storage/store/remote_audit.go
+++ b/internal/storage/store/remote_audit.go
@@ -120,7 +120,7 @@ func (rs *RemoteStorage) CreateAnomalyAlert(_ context.Context, _ *models.Anomaly
 }
 
 // ListAnomalyAlerts is not available in remote mode.
-func (rs *RemoteStorage) ListAnomalyAlerts(_ context.Context, _ bool) ([]models.AnomalyAlert, error) {
+func (rs *RemoteStorage) ListAnomalyAlerts(_ context.Context, _ *bool) ([]models.AnomalyAlert, error) {
 	return nil, fmt.Errorf("ListAnomalyAlerts not available in remote mode")
 }
 

--- a/server/http/handlers/audit_anomaly.go
+++ b/server/http/handlers/audit_anomaly.go
@@ -19,9 +19,18 @@ func ListAnomalyAlerts(w http.ResponseWriter, r *http.Request) {
 		sendError(w, "InternalError", "Core service not available", http.StatusInternalServerError, nil)
 		return
 	}
-	unacknowledgedOnly := r.URL.Query().Get("unacknowledged") == "true"
+	// ?acknowledged=true|false filters server-side; nil (param absent) returns
+	// all. ?unacknowledged=true is the legacy alias (still used by the CLI).
+	var acknowledged *bool
+	if v := r.URL.Query().Get("acknowledged"); v != "" {
+		b := v == "true" || v == "1"
+		acknowledged = &b
+	} else if r.URL.Query().Get("unacknowledged") == "true" {
+		b := false
+		acknowledged = &b
+	}
 	detector := core.NewAnomalyDetector(coreService.Storage())
-	alerts, err := detector.ListAlerts(r.Context(), unacknowledgedOnly)
+	alerts, err := detector.ListAlerts(r.Context(), acknowledged)
 	if err != nil {
 		sendError(w, "InternalError", "Failed to list anomaly alerts", http.StatusInternalServerError, nil)
 		return


### PR DESCRIPTION
## Summary

Two anomaly-alert fixes (both were open backlog items).

### Dedup on re-run
`RunDetection`'s doc claimed it was *"idempotent per detection window"* — but it wasn't. `DetectedAt` is the run time, so re-running detection over the same 1-hour window re-inserted identical alerts.

`CreateAnomalyAlert` is now idempotent: it skips the insert when an equivalent alert (same `secret_node_id` + `alert_type` + `accessed_by` + `ip_address`) already exists with `detected_at` inside a 1-hour dedup window (matching the detection window). A different IP, a different alert type, or a genuine later recurrence in a new window all still produce a fresh alert.

### Server-side `?acknowledged=` filter
`ListAnomalyAlerts` took `unacknowledgedOnly bool` (only "unacknowledged-only" or "all"). It now takes a tri-state `acknowledged *bool`:
- param absent → all
- `?acknowledged=true` → acknowledged only
- `?acknowledged=false` → unacknowledged only

`?unacknowledged=true` is kept as a **back-compat alias** (the CLI still sends it). Filtering stays server-side.

## Scope
Storage interface + all impls (local / remote / mock) + the detector wrapper + the list handler.

## Testing
Added store tests for the dedup window (distinct-IP, distinct-type, later-window cases) and the tri-state filter — the anomaly store had **no tests** before. `build` / `vet` / `go test ./...` green (19 pkgs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
