### PR TITLE
feat(account): enforce configurable password policy on change-password (ADR-025)

### DIFF
--- a/configs/keyorix.yaml.tpl
+++ b/configs/keyorix.yaml.tpl
@@ -97,6 +97,19 @@ security:
   auto_fix_file_permissions: true
   allow_unsafe_file_permissions: false
 
+password_policy:
+  # Rules enforced when a user sets a new password (e.g. self-service change).
+  # Omit this whole block to use the conservative built-in defaults (shown
+  # below). Lab installs may relax these, e.g. min_length: 8 and the require_*
+  # flags false. Note: reject_common_passwords / history / max-age expiry are
+  # not yet enforced (ADR-025 follow-ups).
+  min_length: 16
+  require_uppercase: true
+  require_lowercase: true
+  require_digit: true
+  require_special: true
+  reject_personal_info: true   # reject if it contains the user's username/email/display name
+
 soft_delete:
   # Enable soft-deletion for all database entities
   enabled: true

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,6 +19,29 @@ type Config struct {
 	Security    SecurityConfig   `yaml:"security"`
 	SoftDelete  SoftDeleteConfig `yaml:"soft_delete"`
 	Purge       PurgeConfig      `yaml:"purge"`
+
+	// PasswordPolicy is optional. When the block is absent (zero value), the
+	// server keeps its conservative built-in defaults (see core.DefaultPasswordPolicy);
+	// when present, the install's values fully replace them.
+	PasswordPolicy PasswordPolicyConfig `yaml:"password_policy"`
+}
+
+// PasswordPolicyConfig mirrors the synchronous password rules from ADR-025.
+// Stateful rules (reject_common_passwords, history_count, max_age_days) are not
+// part of this first slice and are intentionally omitted here.
+type PasswordPolicyConfig struct {
+	MinLength          int  `yaml:"min_length"`
+	RequireUppercase   bool `yaml:"require_uppercase"`
+	RequireLowercase   bool `yaml:"require_lowercase"`
+	RequireDigit       bool `yaml:"require_digit"`
+	RequireSpecial     bool `yaml:"require_special"`
+	RejectPersonalInfo bool `yaml:"reject_personal_info"`
+}
+
+// IsZero reports whether the password_policy block was effectively absent, so
+// the caller can fall back to the built-in defaults instead of an all-off policy.
+func (p PasswordPolicyConfig) IsZero() bool {
+	return p == PasswordPolicyConfig{}
 }
 
 type LocaleConfig struct {

--- a/internal/core/account.go
+++ b/internal/core/account.go
@@ -14,10 +14,6 @@ import (
 	"golang.org/x/crypto/bcrypt"
 )
 
-// minPasswordLength is the conservative floor enforced on self-service password
-// changes. Full configurable password policy is a later item (ADR-025).
-const minPasswordLength = 8
-
 // UpdateOwnProfile updates the caller's display name and email only. It delegates
 // to UpdateUser (which enforces email uniqueness) but constructs the request from
 // the authenticated userID, so a caller can never change username/is_active or
@@ -42,9 +38,6 @@ func (c *KeyorixCore) ChangePassword(ctx context.Context, userID uint, current, 
 	if userID == 0 {
 		return fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "user ID is required")
 	}
-	if len(newPassword) < minPasswordLength {
-		return fmt.Errorf("%s: new password must be at least %d characters", i18n.T("ErrorValidation", nil), minPasswordLength)
-	}
 
 	user, err := c.storage.GetUser(ctx, userID)
 	if err != nil {
@@ -52,6 +45,12 @@ func (c *KeyorixCore) ChangePassword(ctx context.Context, userID uint, current, 
 	}
 	if err := bcrypt.CompareHashAndPassword([]byte(user.PasswordHash), []byte(current)); err != nil {
 		return fmt.Errorf("%s: current password is incorrect", i18n.T("ErrorValidation", nil))
+	}
+	// Enforce the configured password policy (ADR-025). Done after the
+	// current-password check so an attacker can't probe the policy without
+	// already holding valid credentials.
+	if err := c.passwordPolicy.Validate(newPassword, user); err != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorValidation", nil), err)
 	}
 
 	hash, err := bcrypt.GenerateFromPassword([]byte(newPassword), bcrypt.DefaultCost)

--- a/internal/core/account_test.go
+++ b/internal/core/account_test.go
@@ -62,10 +62,11 @@ func TestChangePassword(t *testing.T) {
 		ms.On("GetSession", ctx, "current-token").Return(&models.Session{ID: 7, UserID: 1}, nil)
 		ms.On("DeleteSessionsForUserExcept", ctx, uint(1), uint(7)).Return(nil)
 
-		err := c.ChangePassword(ctx, 1, "oldpassword", "brandnewpassword", "current-token")
+		const newPw = "Brandnew#Passw0rd!" // policy-compliant: 16+, upper/lower/digit/special
+		err := c.ChangePassword(ctx, 1, "oldpassword", newPw, "current-token")
 		require.NoError(t, err)
 		// The new password verifies against the freshly stored hash.
-		assert.NoError(t, bcrypt.CompareHashAndPassword([]byte(user.PasswordHash), []byte("brandnewpassword")))
+		assert.NoError(t, bcrypt.CompareHashAndPassword([]byte(user.PasswordHash), []byte(newPw)))
 		ms.AssertCalled(t, "DeleteSessionsForUserExcept", ctx, uint(1), uint(7))
 	})
 
@@ -75,18 +76,25 @@ func TestChangePassword(t *testing.T) {
 		user := &models.User{ID: 1, PasswordHash: string(oldHash)}
 		ms.On("GetUser", ctx, uint(1)).Return(user, nil)
 
-		err := c.ChangePassword(ctx, 1, "wrongpassword", "brandnewpassword", "current-token")
+		err := c.ChangePassword(ctx, 1, "wrongpassword", "Brandnew#Passw0rd!", "current-token")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "incorrect")
 		ms.AssertNotCalled(t, "UpdateUser", mock.Anything, mock.Anything)
 	})
 
-	t.Run("rejects a too-short new password", func(t *testing.T) {
+	t.Run("rejects a new password that violates the policy", func(t *testing.T) {
 		ms := new(MockStorage)
 		c := NewKeyorixCore(ms)
+		user := &models.User{ID: 1, Username: acctTestUser, PasswordHash: string(oldHash)}
+		ms.On("GetUser", ctx, uint(1)).Return(user, nil)
+
+		// Current password is correct, but the new one is too short / not complex.
+		// Policy is checked after the current-password check, so the new password
+		// is rejected and nothing is written.
 		err := c.ChangePassword(ctx, 1, "oldpassword", "short", "current-token")
 		require.Error(t, err)
-		ms.AssertNotCalled(t, "GetUser", mock.Anything, mock.Anything)
+		assert.Contains(t, err.Error(), "password must")
+		ms.AssertNotCalled(t, "UpdateUser", mock.Anything, mock.Anything)
 	})
 }
 

--- a/internal/core/password_policy.go
+++ b/internal/core/password_policy.go
@@ -1,0 +1,104 @@
+package core
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// PasswordPolicy is the set of synchronous, stateless rules a new password must
+// satisfy (ADR-025). Stateful rules from the ADR — reject-common-passwords,
+// history (no reuse of last N), and max-age expiry — need extra storage and are
+// deliberately out of this first slice; see the package follow-ups.
+type PasswordPolicy struct {
+	MinLength          int
+	RequireUppercase   bool
+	RequireLowercase   bool
+	RequireDigit       bool
+	RequireSpecial     bool
+	RejectPersonalInfo bool // reject if the password contains the user's email/display name/username
+}
+
+// DefaultPasswordPolicy returns the conservative, NIS2/DORA-aligned defaults
+// from ADR-025. Installs may relax these per-config (e.g. lab installs), but the
+// built-in default is intentionally not lab-grade.
+func DefaultPasswordPolicy() PasswordPolicy {
+	return PasswordPolicy{
+		MinLength:          16,
+		RequireUppercase:   true,
+		RequireLowercase:   true,
+		RequireDigit:       true,
+		RequireSpecial:     true,
+		RejectPersonalInfo: true,
+	}
+}
+
+// Validate checks pw against the policy. user may be nil (personal-info checks
+// are skipped when it is). It returns a single error listing every unmet
+// requirement, so the caller can surface all of them at once.
+func (p PasswordPolicy) Validate(pw string, user *models.User) error {
+	var failures []string
+
+	if len(pw) < p.MinLength {
+		failures = append(failures, fmt.Sprintf("be at least %d characters", p.MinLength))
+	}
+
+	var hasUpper, hasLower, hasDigit, hasSpecial bool
+	for _, r := range pw {
+		switch {
+		case unicode.IsUpper(r):
+			hasUpper = true
+		case unicode.IsLower(r):
+			hasLower = true
+		case unicode.IsDigit(r):
+			hasDigit = true
+		case unicode.IsPunct(r) || unicode.IsSymbol(r) || unicode.IsSpace(r):
+			hasSpecial = true
+		}
+	}
+	if p.RequireUppercase && !hasUpper {
+		failures = append(failures, "contain an uppercase letter")
+	}
+	if p.RequireLowercase && !hasLower {
+		failures = append(failures, "contain a lowercase letter")
+	}
+	if p.RequireDigit && !hasDigit {
+		failures = append(failures, "contain a digit")
+	}
+	if p.RequireSpecial && !hasSpecial {
+		failures = append(failures, "contain a special character")
+	}
+
+	if p.RejectPersonalInfo && user != nil && containsPersonalInfo(pw, user) {
+		failures = append(failures, "not contain your username, email, or display name")
+	}
+
+	if len(failures) > 0 {
+		return fmt.Errorf("password must %s", strings.Join(failures, ", "))
+	}
+	return nil
+}
+
+// containsPersonalInfo reports whether pw embeds the user's username, the local
+// part of their email, or any word (3+ chars) of their display name — all
+// case-insensitively.
+func containsPersonalInfo(pw string, user *models.User) bool {
+	lpw := strings.ToLower(pw)
+
+	candidates := []string{strings.ToLower(strings.TrimSpace(user.Username))}
+	if at := strings.IndexByte(user.Email, '@'); at > 0 {
+		candidates = append(candidates, strings.ToLower(user.Email[:at]))
+	}
+	for _, word := range strings.Fields(strings.ToLower(user.DisplayName)) {
+		candidates = append(candidates, word)
+	}
+
+	for _, c := range candidates {
+		if len(c) >= 3 && strings.Contains(lpw, c) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/core/password_policy_test.go
+++ b/internal/core/password_policy_test.go
@@ -1,0 +1,67 @@
+package core
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPasswordPolicy_Default(t *testing.T) {
+	p := DefaultPasswordPolicy()
+	user := &models.User{Username: "alice", Email: "alice@example.com", DisplayName: "Alice Smith"}
+
+	cases := []struct {
+		name    string
+		pw      string
+		wantErr string // substring expected in the error; "" means must pass
+	}{
+		{"compliant", "Str0ng#Passphrase!", ""},
+		{"too short", "Ab1!xyz", "at least 16 characters"},
+		{"no uppercase", "str0ng#passphrase!", "uppercase"},
+		{"no lowercase", "STR0NG#PASSPHRASE!", "lowercase"},
+		{"no digit", "Strong#Passphrase!", "digit"},
+		{"no special", "Str0ngPassphrase00", "special character"},
+		{"contains username", "alice#Str0ngPassword", "username, email, or display name"},
+		{"contains email local part", "Str0ng#alicePassword", "username, email, or display name"},
+		{"contains display-name word", "Str0ng#smithPassword", "username, email, or display name"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := p.Validate(tc.pw, user)
+			if tc.wantErr == "" {
+				assert.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}
+
+// All unmet requirements are reported together, not just the first.
+func TestPasswordPolicy_ReportsAllFailures(t *testing.T) {
+	p := DefaultPasswordPolicy()
+	err := p.Validate("abc", nil) // short, no upper, no digit, no special
+	require.Error(t, err)
+	for _, want := range []string{"16 characters", "uppercase", "digit", "special"} {
+		assert.Contains(t, err.Error(), want)
+	}
+	// Personal-info check is skipped when user is nil.
+	assert.NotContains(t, err.Error(), "display name")
+}
+
+// A relaxed (lab) policy accepts a simple password and skips disabled checks.
+func TestPasswordPolicy_Relaxed(t *testing.T) {
+	p := PasswordPolicy{MinLength: 8} // complexity + personal-info off
+	user := &models.User{Username: "alice"}
+	assert.NoError(t, p.Validate("simplepw", user))
+	assert.NoError(t, p.Validate("aliceeee", user), "personal-info check off → username allowed")
+
+	err := p.Validate("short", user)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "at least 8 characters")
+	assert.False(t, strings.Contains(err.Error(), "uppercase"), "disabled checks not reported")
+}

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -22,27 +22,37 @@ import (
 //   - dashboard.go     — Dashboard stats and activity feed
 //   - catalog.go       — Project / environment passthrough
 type KeyorixCore struct {
-	storage    storage.Storage
-	encryption *encryption.SecretEncryption
-	now        func() time.Time // For testability
+	storage        storage.Storage
+	encryption     *encryption.SecretEncryption
+	now            func() time.Time // For testability
+	passwordPolicy PasswordPolicy
 }
 
 // NewKeyorixCore creates a new instance of the core business logic.
 func NewKeyorixCore(storage storage.Storage) *KeyorixCore {
 	return &KeyorixCore{
-		storage:    storage,
-		encryption: nil,
-		now:        time.Now,
+		storage:        storage,
+		encryption:     nil,
+		now:            time.Now,
+		passwordPolicy: DefaultPasswordPolicy(),
 	}
 }
 
 // NewKeyorixCoreWithEncryption creates a new instance with encryption support.
 func NewKeyorixCoreWithEncryption(storage storage.Storage, enc *encryption.SecretEncryption) *KeyorixCore {
 	return &KeyorixCore{
-		storage:    storage,
-		encryption: enc,
-		now:        time.Now,
+		storage:        storage,
+		encryption:     enc,
+		now:            time.Now,
+		passwordPolicy: DefaultPasswordPolicy(),
 	}
+}
+
+// SetPasswordPolicy overrides the password policy (which defaults to
+// DefaultPasswordPolicy). The server calls this at startup when the install
+// configures a password_policy block.
+func (c *KeyorixCore) SetPasswordPolicy(p PasswordPolicy) {
+	c.passwordPolicy = p
 }
 
 // Storage returns the underlying storage interface (used by ancillary services such as AnomalyDetector).

--- a/server/main.go
+++ b/server/main.go
@@ -176,6 +176,19 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 	} else {
 		coreService = core.NewKeyorixCore(store)
 	}
+
+	// Apply a configured password policy, if any. An absent block leaves the
+	// core's conservative built-in defaults in place (ADR-025).
+	if pp := cfg.PasswordPolicy; !pp.IsZero() {
+		coreService.SetPasswordPolicy(core.PasswordPolicy{
+			MinLength:          pp.MinLength,
+			RequireUppercase:   pp.RequireUppercase,
+			RequireLowercase:   pp.RequireLowercase,
+			RequireDigit:       pp.RequireDigit,
+			RequireSpecial:     pp.RequireSpecial,
+			RejectPersonalInfo: pp.RejectPersonalInfo,
+		})
+	}
 	return coreService, encSvc, nil
 }
 


### PR DESCRIPTION
## Summary

First slice of the **ADR-025** user-provisioning track: a synchronous, stateless **password policy**, enforced when a user sets a new password.

- **`core.PasswordPolicy` validator** — min length + require upper/lower/digit/special + reject-personal-info (username / email local-part / display-name words). Reports *every* unmet rule at once, so the user sees all requirements.
- **`DefaultPasswordPolicy()`** — the ADR's conservative NIS2/DORA-aligned defaults (16 chars, all complexity, reject personal info). `KeyorixCore` defaults to it; installs override via a new **`password_policy`** config block (absent block → built-in defaults; documented in `keyorix.yaml.tpl`).
- **Wired into `ChangePassword`**, deliberately *after* the current-password check so the policy can't be probed without valid credentials. Supersedes the old bare `minPasswordLength(8)` check.

## Deferred (explicitly out of this slice)
The stateful ADR-025 rules need extra storage/auth and are follow-ups:
- `reject_common_passwords` (curated / HIBP list)
- `history_count` (no reuse of last N)
- `max_age_days` (expiry + login-time enforcement)

## Testing
Validator table tests (each rule, multi-failure aggregation, relaxed/lab policy) + updated `ChangePassword` tests for the new ordering. `build` / `vet` / `go test ./...` green (19 pkgs). Server boots clean with the built-in defaults (no config block).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
