### PR TITLE
feat(auth): surface role, roles, and permissions in login + profile responses

### DIFF
--- a/internal/core/identity.go
+++ b/internal/core/identity.go
@@ -1,0 +1,78 @@
+package core
+
+import "context"
+
+// UserIdentity summarises a user's roles and permissions for the login and
+// profile responses, so the web UI can do coarse, server-truthful gating (e.g.
+// show/hide admin nav). The backend still enforces real, scope-aware checks on
+// every request via Authorize — this summary is for UI convenience, not a
+// security boundary.
+type UserIdentity struct {
+	Role        string   `json:"role"`        // highest-privilege role, for single-role consumers
+	Roles       []string `json:"roles"`       // all assigned role names
+	Permissions []string `json:"permissions"` // distinct permission names across the user's roles
+}
+
+// rolePrecedence ranks role names from most to least privileged (lower = higher
+// privilege). Used to pick one "primary" role for clients that want a single
+// value. Roles not listed (unknown/custom) rank below all known roles.
+var rolePrecedence = map[string]int{
+	"super_admin":       0,
+	"system_admin":      1,
+	"admin":             2,
+	"system_auditor":    3,
+	"auditor":           4,
+	"editor":            5,
+	"project_admin":     6,
+	"project_developer": 7,
+	"project_auditor":   8,
+	"project_viewer":    9,
+	"system_viewer":     10,
+	"viewer":            11,
+}
+
+// primaryRole returns the highest-privilege role name from names, or "" if empty.
+func primaryRole(names []string) string {
+	const unknownRank = 1000
+	best, bestRank := "", int(^uint(0)>>1)
+	for _, n := range names {
+		rank, ok := rolePrecedence[n]
+		if !ok {
+			rank = unknownRank
+		}
+		if rank < bestRank {
+			best, bestRank = n, rank
+		}
+	}
+	return best
+}
+
+// GetUserIdentity assembles the role/permission summary for a user. Roles are
+// every role the user holds (any scope); permissions are the distinct union
+// across those roles. Both slices are non-nil (empty, not null) so JSON clients
+// get [] rather than null.
+func (c *KeyorixCore) GetUserIdentity(ctx context.Context, userID uint) (UserIdentity, error) {
+	roles, err := c.GetUserRolesByID(ctx, userID)
+	if err != nil {
+		return UserIdentity{}, err
+	}
+	roleNames := make([]string, 0, len(roles))
+	for _, r := range roles {
+		roleNames = append(roleNames, r.Name)
+	}
+
+	perms, err := c.storage.GetUserPermissions(ctx, userID)
+	if err != nil {
+		return UserIdentity{}, err
+	}
+	permNames := make([]string, 0, len(perms))
+	for _, p := range perms {
+		permNames = append(permNames, p.Name)
+	}
+
+	return UserIdentity{
+		Role:        primaryRole(roleNames),
+		Roles:       roleNames,
+		Permissions: permNames,
+	}, nil
+}

--- a/internal/core/identity_test.go
+++ b/internal/core/identity_test.go
@@ -1,0 +1,69 @@
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrimaryRole(t *testing.T) {
+	cases := []struct {
+		name  string
+		roles []string
+		want  string
+	}{
+		{"empty", nil, ""},
+		{"single", []string{"viewer"}, "viewer"},
+		{"admin beats viewer regardless of order", []string{"viewer", "admin"}, "admin"},
+		{"system_admin outranks admin", []string{"admin", "system_admin"}, "system_admin"},
+		{"super_admin tops all", []string{"admin", "super_admin", "system_admin"}, "super_admin"},
+		{"project roles below system_viewer", []string{"system_viewer", "project_admin"}, "project_admin"},
+		{"unknown role ranks last", []string{"custom_thing", "viewer"}, "viewer"},
+		{"only unknown is returned", []string{"custom_thing"}, "custom_thing"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, primaryRole(tc.roles))
+		})
+	}
+}
+
+func TestGetUserIdentity(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("assembles primary role, all roles, and permission union", func(t *testing.T) {
+		ms := new(MockStorage)
+		c := NewKeyorixCore(ms)
+		ms.On("GetUserRoles", ctx, uint(1)).Return([]*models.Role{
+			{ID: 1, Name: "viewer"}, {ID: 2, Name: "admin"},
+		}, nil)
+		ms.On("GetUserPermissions", ctx, uint(1)).Return([]*storage.Permission{
+			{Name: "secrets.read"}, {Name: "users.read"},
+		}, nil)
+
+		id, err := c.GetUserIdentity(ctx, 1)
+		require.NoError(t, err)
+		assert.Equal(t, "admin", id.Role)
+		assert.Equal(t, []string{"viewer", "admin"}, id.Roles)
+		assert.ElementsMatch(t, []string{"secrets.read", "users.read"}, id.Permissions)
+	})
+
+	t.Run("user with no roles yields empty (non-nil) slices and blank primary", func(t *testing.T) {
+		ms := new(MockStorage)
+		c := NewKeyorixCore(ms)
+		ms.On("GetUserRoles", ctx, uint(2)).Return([]*models.Role{}, nil)
+		ms.On("GetUserPermissions", ctx, uint(2)).Return([]*storage.Permission{}, nil)
+
+		id, err := c.GetUserIdentity(ctx, 2)
+		require.NoError(t, err)
+		assert.Equal(t, "", id.Role)
+		assert.NotNil(t, id.Roles)
+		assert.NotNil(t, id.Permissions)
+		assert.Empty(t, id.Roles)
+		assert.Empty(t, id.Permissions)
+	})
+}

--- a/server/http/handlers/auth.go
+++ b/server/http/handlers/auth.go
@@ -70,12 +70,15 @@ type loginRequestBody struct {
 }
 
 type loginResponseBody struct {
-	Token       string `json:"token"`
-	ExpiresAt   string `json:"expires_at,omitempty"`
-	UserID      uint   `json:"user_id"`
-	Username    string `json:"username"`
-	Email       string `json:"email"`
-	DisplayName string `json:"display_name"`
+	Token       string   `json:"token"`
+	ExpiresAt   string   `json:"expires_at,omitempty"`
+	UserID      uint     `json:"user_id"`
+	Username    string   `json:"username"`
+	Email       string   `json:"email"`
+	DisplayName string   `json:"display_name"`
+	Role        string   `json:"role"`        // primary (highest-privilege) role
+	Roles       []string `json:"roles"`       // all assigned role names
+	Permissions []string `json:"permissions"` // distinct permissions across roles
 }
 
 type passwordResetRequestBody struct {
@@ -129,9 +132,16 @@ func (h *AuthHandler) Login(w http.ResponseWriter, r *http.Request) {
 		Username:    user.Username,
 		Email:       user.Email,
 		DisplayName: user.DisplayName,
+		Roles:       []string{},
+		Permissions: []string{},
 	}
 	if session.ExpiresAt != nil {
 		resp.ExpiresAt = session.ExpiresAt.UTC().Format(time.RFC3339)
+	}
+	// Surface roles + permissions so the UI can gate nav/routes. Best-effort:
+	// a failure here must not block an otherwise-successful login.
+	if id, ierr := h.coreService.GetUserIdentity(r.Context(), user.ID); ierr == nil {
+		resp.Role, resp.Roles, resp.Permissions = id.Role, id.Roles, id.Permissions
 	}
 
 	// Audit log + last-login stamp (both non-blocking)
@@ -209,11 +219,28 @@ func (h *AuthHandler) Profile(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	sendSuccess(w, userProfileMap(user), "")
+	sendSuccess(w, userProfileMap(user, h.userIdentity(r, userCtx.UserID)), "")
+}
+
+// userIdentity returns the user's role/permission summary for the profile DTO.
+// Best-effort: on error it returns an empty identity so the profile still renders.
+func (h *AuthHandler) userIdentity(r *http.Request, userID uint) core.UserIdentity {
+	id, err := h.coreService.GetUserIdentity(r.Context(), userID)
+	if err != nil {
+		return core.UserIdentity{Roles: []string{}, Permissions: []string{}}
+	}
+	return id
 }
 
 // userProfileMap is the shared self-profile DTO returned by GET and PUT /auth/profile.
-func userProfileMap(user *models.User) map[string]interface{} {
+func userProfileMap(user *models.User, id core.UserIdentity) map[string]interface{} {
+	roles, permissions := id.Roles, id.Permissions
+	if roles == nil {
+		roles = []string{}
+	}
+	if permissions == nil {
+		permissions = []string{}
+	}
 	profile := map[string]interface{}{
 		"id":            user.ID,
 		"username":      user.Username,
@@ -222,6 +249,9 @@ func userProfileMap(user *models.User) map[string]interface{} {
 		"is_active":     user.IsActive,
 		"created_at":    user.CreatedAt,
 		"last_login_at": nil,
+		"role":          id.Role,
+		"roles":         roles,
+		"permissions":   permissions,
 	}
 	if user.LastLoginAt != nil {
 		profile["last_login_at"] = user.LastLoginAt.UTC().Format(time.RFC3339)
@@ -259,7 +289,7 @@ func (h *AuthHandler) UpdateProfile(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	sendSuccess(w, userProfileMap(user), "Profile updated")
+	sendSuccess(w, userProfileMap(user, h.userIdentity(r, userCtx.UserID)), "Profile updated")
 }
 
 type changePasswordRequestBody struct {


### PR DESCRIPTION
## Summary

Root-cause fix for **non-functional client-side authorization**.

The frontend computes `isAdmin = (user.role === 'admin')` and `hasPermission(p)` from `user.permissions` — but the backend **never returned either field**. Login and profile responses carried only identity/contact fields, so `user.role` defaulted to `'user'` and `permissions` to `[]` for *everyone, including real admins*. All client-side gating was dead.

Backend RBAC still enforces every API (scope-aware `Authorize`), so this was a UX / defense-in-depth gap, **not** a data leak — but it's exactly why `AdminRoute` was never wired into `App.tsx`: doing so would have locked everyone out.

## Changes
- **`core.GetUserIdentity(userID)` → `{Role, Roles, Permissions}`** — all assigned role names + the distinct permission union, plus a single *primary* role (highest-privilege, via an explicit precedence over the ADR-021 catalog: `super_admin > system_admin > admin > … > viewer`) for single-role consumers. Slices are always non-nil → JSON `[]`, never `null`.
- **Login** response gains `role` / `roles` / `permissions` (best-effort — never blocks an otherwise-successful login).
- **GET/PUT `/auth/profile`** gain the same via a shared helper.

## Why (unblocks)
This is the backend half of fixing admin gating. The follow-up **frontend PR** will: consume `roles`/`permissions`, fix `isAdmin` to recognise `admin`/`system_admin`, wire `AdminRoute` onto `/admin/*`, and gate the Access Control sidebar group.

## Testing
`primaryRole` precedence table + `GetUserIdentity` (permission union, empty-user → `[]`/blank primary). `build` / `vet` / `go test ./...` green (19 pkgs).

⚠️ **Verification note:** live login round-trip was blocked by the empty dev DB — `POST /system/init` returns 401 on a fresh install (a separate, pre-existing bootstrap quirk). This PR relies on the unit tests; flagging the init quirk separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
