### PR TITLE
feat(audit): native SIEM push + cursor export endpoint (ADR audit-design)

### DIFF
--- a/configs/keyorix.yaml.tpl
+++ b/configs/keyorix.yaml.tpl
@@ -116,9 +116,23 @@ soft_delete:
   retention_days: 30
 
 purge:
-  # Enable periodic purge of expired/deleted database entities 
+  # Enable periodic purge of expired/deleted database entities
   enabled: true
   schedule: "0 0 * * *"
+
+audit:
+  # Native SIEM push: forward every audit event to an external SIEM.
+  # Audit events carry no plaintext secret values, so they are safe to ship.
+  siem:
+    enabled: false
+    # provider: splunk | datadog | webhook
+    provider: "splunk"
+    # Full destination URL (e.g. a Splunk HEC collector endpoint).
+    endpoint: ""
+    # HEC token / DD-API-KEY / bearer token. Prefer the KEYORIX_SIEM_TOKEN env var.
+    token: ""
+    # Skip TLS verification for self-signed SIEM endpoints (not recommended).
+    insecure_skip_verify: false
 
 logging:
   # Enable logging

--- a/internal/audit/siem/forwarder.go
+++ b/internal/audit/siem/forwarder.go
@@ -1,0 +1,242 @@
+// Package siem forwards Keyorix audit events to external SIEM systems.
+//
+// It supports Splunk HEC, Datadog Logs intake, and a generic authenticated
+// webhook. Forwarding is asynchronous and best-effort: Forward enqueues onto a
+// bounded buffer and returns immediately, so a slow or unreachable SIEM never
+// blocks or fails an audited operation. If the buffer is full, events are
+// dropped (and counted) rather than applying backpressure to the request path.
+//
+// SECURITY: audit events carry no plaintext secret values (the value diff is a
+// {"changed":true} marker only — see internal/core/audit_diff.go), so an audit
+// payload is safe to ship off-box.
+package siem
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// Provider identifies the destination SIEM format.
+type Provider string
+
+const (
+	ProviderSplunk  Provider = "splunk"
+	ProviderDatadog Provider = "datadog"
+	ProviderWebhook Provider = "webhook"
+)
+
+// Config configures a Forwarder.
+type Config struct {
+	Enabled            bool
+	Provider           Provider
+	Endpoint           string // full destination URL (e.g. Splunk HEC collector URL)
+	Token              string // HEC token / DD-API-KEY / bearer token
+	InsecureSkipVerify bool   // skip TLS verification (self-signed SIEM endpoints)
+}
+
+// queueSize bounds in-flight events; httpTimeout bounds a single delivery.
+const (
+	queueSize   = 1024
+	httpTimeout = 5 * time.Second
+)
+
+// Forwarder ships audit events to a configured SIEM asynchronously.
+type Forwarder struct {
+	cfg    Config
+	client *http.Client
+	queue  chan *models.AuditEvent
+	wg     sync.WaitGroup
+
+	mu      sync.Mutex
+	dropped int64
+}
+
+// New validates cfg and starts the background delivery worker. It returns
+// (nil, nil) when SIEM forwarding is disabled, so callers can wire it
+// unconditionally.
+func New(cfg Config) (*Forwarder, error) {
+	if !cfg.Enabled {
+		return nil, nil
+	}
+	if cfg.Endpoint == "" {
+		return nil, fmt.Errorf("siem: endpoint is required when enabled")
+	}
+	switch cfg.Provider {
+	case ProviderSplunk, ProviderDatadog, ProviderWebhook:
+	default:
+		return nil, fmt.Errorf("siem: unknown provider %q (want splunk|datadog|webhook)", cfg.Provider)
+	}
+
+	transport := &http.Transport{}
+	if cfg.InsecureSkipVerify {
+		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} // #nosec G402 — operator opt-in for self-signed SIEM
+	}
+	f := &Forwarder{
+		cfg:    cfg,
+		client: &http.Client{Timeout: httpTimeout, Transport: transport},
+		queue:  make(chan *models.AuditEvent, queueSize),
+	}
+	f.wg.Add(1)
+	go f.worker()
+	return f, nil
+}
+
+// Forward enqueues an event for delivery. Non-blocking: if the buffer is full
+// the event is dropped and counted (Dropped), never blocking the caller.
+func (f *Forwarder) Forward(event *models.AuditEvent) {
+	if f == nil || event == nil {
+		return
+	}
+	select {
+	case f.queue <- event:
+	default:
+		f.mu.Lock()
+		f.dropped++
+		dropped := f.dropped
+		f.mu.Unlock()
+		log.Printf("siem: audit forward queue full, dropped event (total dropped: %d)", dropped)
+	}
+}
+
+// Dropped returns the number of events dropped due to a full queue.
+func (f *Forwarder) Dropped() int64 {
+	if f == nil {
+		return 0
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.dropped
+}
+
+// Close stops accepting events and waits for the in-flight queue to drain.
+func (f *Forwarder) Close() {
+	if f == nil {
+		return
+	}
+	close(f.queue)
+	f.wg.Wait()
+}
+
+func (f *Forwarder) worker() {
+	defer f.wg.Done()
+	for event := range f.queue {
+		if err := f.send(context.Background(), event); err != nil {
+			log.Printf("siem: failed to forward audit event %d: %v", event.ID, err)
+		}
+	}
+}
+
+// eventPayload is the stable, snake_case wire shape sent to SIEMs. AuditEvent
+// has no JSON tags, so we never marshal the model directly.
+type eventPayload struct {
+	ID             uint            `json:"id"`
+	EventType      string          `json:"event_type"`
+	Timestamp      string          `json:"timestamp"`
+	UserID         *uint           `json:"user_id,omitempty"`
+	ProjectID      *uint           `json:"project_id,omitempty"`
+	SecretID       *uint           `json:"secret_id,omitempty"`
+	Description    string          `json:"description"`
+	IPAddress      string          `json:"ip_address,omitempty"`
+	Success        bool            `json:"success"`
+	Diff           json.RawMessage `json:"diff,omitempty"`
+	Impersonation  bool            `json:"impersonation,omitempty"`
+	ImpersonatedBy *uint           `json:"impersonated_by,omitempty"`
+	ActingAs       *uint           `json:"acting_as,omitempty"`
+}
+
+func toPayload(e *models.AuditEvent) eventPayload {
+	success := true
+	if e.Success != nil {
+		success = *e.Success
+	}
+	p := eventPayload{
+		ID:             e.ID,
+		EventType:      e.EventType,
+		Timestamp:      e.EventTime.UTC().Format(time.RFC3339),
+		UserID:         e.UserID,
+		ProjectID:      e.ProjectID,
+		SecretID:       e.SecretNodeID,
+		Description:    e.Description,
+		IPAddress:      e.IPAddress,
+		Success:        success,
+		Impersonation:  e.Impersonation,
+		ImpersonatedBy: e.ImpersonatedBy,
+		ActingAs:       e.ActingAs,
+	}
+	if e.Diff != "" {
+		p.Diff = json.RawMessage(e.Diff)
+	}
+	return p
+}
+
+// buildRequest produces the provider-specific HTTP request body + headers.
+func (f *Forwarder) buildRequest(ctx context.Context, e *models.AuditEvent) (*http.Request, error) {
+	payload := toPayload(e)
+	var body []byte
+	var err error
+	headers := map[string]string{"Content-Type": "application/json"}
+
+	switch f.cfg.Provider {
+	case ProviderSplunk:
+		// Splunk HEC event envelope.
+		body, err = json.Marshal(map[string]any{
+			"time":       e.EventTime.UTC().Unix(),
+			"source":     "keyorix",
+			"sourcetype": "keyorix:audit",
+			"event":      payload,
+		})
+		headers["Authorization"] = "Splunk " + f.cfg.Token
+	case ProviderDatadog:
+		// Datadog Logs intake: enrich with ddsource/service for routing.
+		body, err = json.Marshal(map[string]any{
+			"ddsource": "keyorix",
+			"service":  "keyorix",
+			"message":  e.Description,
+			"audit":    payload,
+		})
+		headers["DD-API-KEY"] = f.cfg.Token
+	default: // webhook
+		body, err = json.Marshal(payload)
+		if f.cfg.Token != "" {
+			headers["Authorization"] = "Bearer " + f.cfg.Token
+		}
+	}
+	if err != nil {
+		return nil, fmt.Errorf("marshal payload: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, f.cfg.Endpoint, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	return req, nil
+}
+
+func (f *Forwarder) send(ctx context.Context, e *models.AuditEvent) error {
+	req, err := f.buildRequest(ctx, e)
+	if err != nil {
+		return err
+	}
+	resp, err := f.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("siem endpoint returned %s", strings.TrimSpace(resp.Status))
+	}
+	return nil
+}

--- a/internal/audit/siem/forwarder_test.go
+++ b/internal/audit/siem/forwarder_test.go
@@ -1,0 +1,161 @@
+package siem
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+func sampleEvent() *models.AuditEvent {
+	t := true
+	uid, pid := uint(7), uint(3)
+	return &models.AuditEvent{
+		ID: 42, EventType: "secret.updated", UserID: &uid, ProjectID: &pid,
+		Description: "User alice updated secret db-password", IPAddress: "10.0.0.5",
+		Success: &t, EventTime: time.Date(2026, 6, 4, 10, 0, 0, 0, time.UTC),
+		Diff: `{"value":{"changed":true}}`,
+	}
+}
+
+// capture spins up a one-shot server recording the request it receives.
+type capture struct {
+	mu      sync.Mutex
+	headers http.Header
+	body    []byte
+	hits    int
+}
+
+func newCaptureServer(t *testing.T, status int) (*httptest.Server, *capture) {
+	t.Helper()
+	c := &capture{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		c.mu.Lock()
+		c.headers = r.Header.Clone()
+		c.body = b
+		c.hits++
+		c.mu.Unlock()
+		w.WriteHeader(status)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, c
+}
+
+func TestNew_DisabledReturnsNil(t *testing.T) {
+	f, err := New(Config{Enabled: false})
+	if err != nil || f != nil {
+		t.Fatalf("disabled forwarder should be (nil,nil), got (%v,%v)", f, err)
+	}
+}
+
+func TestNew_RejectsBadConfig(t *testing.T) {
+	if _, err := New(Config{Enabled: true, Provider: ProviderSplunk}); err == nil {
+		t.Error("expected error when endpoint missing")
+	}
+	if _, err := New(Config{Enabled: true, Endpoint: "http://x", Provider: "nope"}); err == nil {
+		t.Error("expected error for unknown provider")
+	}
+}
+
+func TestSend_SplunkFormat(t *testing.T) {
+	srv, cap := newCaptureServer(t, http.StatusOK)
+	f, err := New(Config{Enabled: true, Provider: ProviderSplunk, Endpoint: srv.URL, Token: "hec-tok"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(f.Close)
+
+	if err := f.send(context.Background(), sampleEvent()); err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	if got := cap.headers.Get("Authorization"); got != "Splunk hec-tok" {
+		t.Errorf("Splunk auth header = %q", got)
+	}
+	var envelope map[string]json.RawMessage
+	if err := json.Unmarshal(cap.body, &envelope); err != nil {
+		t.Fatalf("body not JSON: %v", err)
+	}
+	if _, ok := envelope["event"]; !ok {
+		t.Errorf("Splunk body missing event envelope: %s", cap.body)
+	}
+	if string(cap.body) == "" {
+		t.Error("empty body")
+	}
+	// The plaintext value must never appear anywhere in the forwarded payload.
+	if containsValueLeak(cap.body) {
+		t.Errorf("payload appears to leak a value before/after: %s", cap.body)
+	}
+}
+
+func TestSend_DatadogHeader(t *testing.T) {
+	srv, cap := newCaptureServer(t, http.StatusAccepted)
+	f, _ := New(Config{Enabled: true, Provider: ProviderDatadog, Endpoint: srv.URL, Token: "dd-key"})
+	t.Cleanup(f.Close)
+
+	if err := f.send(context.Background(), sampleEvent()); err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	if got := cap.headers.Get("DD-API-KEY"); got != "dd-key" {
+		t.Errorf("Datadog API key header = %q", got)
+	}
+}
+
+func TestSend_WebhookBearer(t *testing.T) {
+	srv, cap := newCaptureServer(t, http.StatusOK)
+	f, _ := New(Config{Enabled: true, Provider: ProviderWebhook, Endpoint: srv.URL, Token: "bear"})
+	t.Cleanup(f.Close)
+
+	if err := f.send(context.Background(), sampleEvent()); err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	if got := cap.headers.Get("Authorization"); got != "Bearer bear" {
+		t.Errorf("webhook auth header = %q", got)
+	}
+	var p eventPayload
+	if err := json.Unmarshal(cap.body, &p); err != nil {
+		t.Fatalf("webhook body not the payload shape: %v", err)
+	}
+	if p.ID != 42 || p.EventType != "secret.updated" {
+		t.Errorf("unexpected payload: %+v", p)
+	}
+}
+
+func TestSend_Non2xxIsError(t *testing.T) {
+	srv, _ := newCaptureServer(t, http.StatusInternalServerError)
+	f, _ := New(Config{Enabled: true, Provider: ProviderWebhook, Endpoint: srv.URL})
+	t.Cleanup(f.Close)
+	if err := f.send(context.Background(), sampleEvent()); err == nil {
+		t.Error("expected an error on a 500 response")
+	}
+}
+
+func TestForward_AsyncDeliversThenClose(t *testing.T) {
+	srv, cap := newCaptureServer(t, http.StatusOK)
+	f, _ := New(Config{Enabled: true, Provider: ProviderWebhook, Endpoint: srv.URL})
+
+	f.Forward(sampleEvent())
+	f.Forward(sampleEvent())
+	f.Close() // drains the queue
+
+	cap.mu.Lock()
+	hits := cap.hits
+	cap.mu.Unlock()
+	if hits != 2 {
+		t.Errorf("expected 2 delivered events, got %d", hits)
+	}
+}
+
+// containsValueLeak reports whether the JSON appears to carry a plaintext value
+// before/after under the value diff (which must never be forwarded).
+func containsValueLeak(body []byte) bool {
+	s := string(body)
+	return strings.Contains(s, `"value":{"before"`) || strings.Contains(s, `"value":{"after"`)
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,6 +19,7 @@ type Config struct {
 	Security    SecurityConfig   `yaml:"security"`
 	SoftDelete  SoftDeleteConfig `yaml:"soft_delete"`
 	Purge       PurgeConfig      `yaml:"purge"`
+	Audit       AuditConfig      `yaml:"audit"`
 
 	// PasswordPolicy is optional. When the block is absent (zero value), the
 	// server keeps its conservative built-in defaults (see core.DefaultPasswordPolicy);
@@ -202,6 +203,27 @@ type SecurityConfig struct {
 type SoftDeleteConfig struct {
 	Enabled       bool `yaml:"enabled"`
 	RetentionDays int  `yaml:"retention_days"`
+}
+
+// AuditConfig groups audit-log delivery integrations.
+type AuditConfig struct {
+	SIEM SIEMConfig `yaml:"siem"`
+}
+
+// SIEMConfig configures native push of audit events to an external SIEM.
+// The token is resolved from KEYORIX_SIEM_TOKEN when that env var is set, so it
+// need not be written into the config file.
+type SIEMConfig struct {
+	Enabled            bool   `yaml:"enabled"`
+	Provider           string `yaml:"provider"` // splunk | datadog | webhook
+	Endpoint           string `yaml:"endpoint"`
+	Token              string `yaml:"token"` // use KEYORIX_SIEM_TOKEN env var instead
+	InsecureSkipVerify bool   `yaml:"insecure_skip_verify"`
+}
+
+// GetToken returns the resolved SIEM token, preferring the environment variable.
+func (s *SIEMConfig) GetToken() string {
+	return resolveSecret("KEYORIX_SIEM_TOKEN", s.Token)
 }
 
 type PurgeConfig struct {

--- a/internal/core/audit.go
+++ b/internal/core/audit.go
@@ -41,7 +41,7 @@ func (c *KeyorixCore) writeAuditEventDiff(ctx context.Context, eventType string,
 		event.ActingAs = userID
 		event.Impersonation = true
 	}
-	_ = c.storage.LogAuditEvent(ctx, event)
+	c.emitAudit(ctx, event)
 }
 
 // writeAuditEventFailed persists a failed audit event (Success=false).
@@ -55,7 +55,7 @@ func (c *KeyorixCore) writeAuditEventFailed(ctx context.Context, eventType strin
 		Success:     &f,
 		EventTime:   time.Now(),
 	}
-	_ = c.storage.LogAuditEvent(ctx, event)
+	c.emitAudit(ctx, event)
 }
 
 // writeAccessLog persists a secret_access_logs row.

--- a/internal/core/impersonation.go
+++ b/internal/core/impersonation.go
@@ -125,5 +125,5 @@ func (c *KeyorixCore) writeImpersonationEvent(ctx context.Context, eventType str
 		ActingAs:       &ta,
 		Impersonation:  true,
 	}
-	_ = c.storage.LogAuditEvent(ctx, event)
+	c.emitAudit(ctx, event)
 }

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -26,6 +26,30 @@ type KeyorixCore struct {
 	encryption     *encryption.SecretEncryption
 	now            func() time.Time // For testability
 	passwordPolicy PasswordPolicy
+	auditForwarder AuditForwarder
+}
+
+// AuditForwarder ships persisted audit events to an external sink (e.g. a SIEM).
+// Implementations must be non-blocking and best-effort: Forward is called on the
+// audit write path and must never block or fail the audited operation. Defined
+// here (not in the siem package) so core has no dependency on the forwarder impl.
+type AuditForwarder interface {
+	Forward(event *models.AuditEvent)
+}
+
+// SetAuditForwarder wires an audit forwarder. The server calls this at startup
+// when the install configures an audit.siem block. nil disables forwarding.
+func (c *KeyorixCore) SetAuditForwarder(f AuditForwarder) {
+	c.auditForwarder = f
+}
+
+// emitAudit persists an audit event and forwards it to the configured sink.
+// All core audit writers funnel through here so SIEM forwarding is uniform.
+func (c *KeyorixCore) emitAudit(ctx context.Context, event *models.AuditEvent) {
+	_ = c.storage.LogAuditEvent(ctx, event)
+	if c.auditForwarder != nil {
+		c.auditForwarder.Forward(event)
+	}
 }
 
 // NewKeyorixCore creates a new instance of the core business logic.

--- a/internal/core/sharing_audit.go
+++ b/internal/core/sharing_audit.go
@@ -63,7 +63,7 @@ func (c *KeyorixCore) LogShareCreated(ctx context.Context, auditCtx *ShareAuditC
 	}
 
 	// Log the event (ignore errors to not block the main operation)
-	_ = c.storage.LogAuditEvent(ctx, event)
+	c.emitAudit(ctx, event)
 }
 
 // LogShareUpdated logs a share permission update event
@@ -83,7 +83,7 @@ func (c *KeyorixCore) LogShareUpdated(ctx context.Context, auditCtx *ShareAuditC
 	}
 
 	// Log the event (ignore errors to not block the main operation)
-	_ = c.storage.LogAuditEvent(ctx, event)
+	c.emitAudit(ctx, event)
 }
 
 // LogShareRevoked logs a share revocation event
@@ -102,7 +102,7 @@ func (c *KeyorixCore) LogShareRevoked(ctx context.Context, auditCtx *ShareAuditC
 	}
 
 	// Log the event (ignore errors to not block the main operation)
-	_ = c.storage.LogAuditEvent(ctx, event)
+	c.emitAudit(ctx, event)
 }
 
 // LogSharedSecretAccessed logs when a user accesses a shared secret
@@ -116,7 +116,7 @@ func (c *KeyorixCore) LogSharedSecretAccessed(ctx context.Context, auditCtx *Sha
 	}
 
 	// Log the event (ignore errors to not block the main operation)
-	_ = c.storage.LogAuditEvent(ctx, event)
+	c.emitAudit(ctx, event)
 }
 
 // LogGroupShareCreated logs a group share creation event
@@ -130,7 +130,7 @@ func (c *KeyorixCore) LogGroupShareCreated(ctx context.Context, auditCtx *ShareA
 	}
 
 	// Log the event (ignore errors to not block the main operation)
-	_ = c.storage.LogAuditEvent(ctx, event)
+	c.emitAudit(ctx, event)
 }
 
 // LogGroupShareUpdated logs a group share permission update event
@@ -145,7 +145,7 @@ func (c *KeyorixCore) LogGroupShareUpdated(ctx context.Context, auditCtx *ShareA
 	}
 
 	// Log the event (ignore errors to not block the main operation)
-	_ = c.storage.LogAuditEvent(ctx, event)
+	c.emitAudit(ctx, event)
 }
 
 // LogGroupShareRevoked logs a group share revocation event
@@ -159,7 +159,7 @@ func (c *KeyorixCore) LogGroupShareRevoked(ctx context.Context, auditCtx *ShareA
 	}
 
 	// Log the event (ignore errors to not block the main operation)
-	_ = c.storage.LogAuditEvent(ctx, event)
+	c.emitAudit(ctx, event)
 }
 
 // LogSelfRemovalFromShare logs when a user removes themselves from a shared secret
@@ -173,5 +173,5 @@ func (c *KeyorixCore) LogSelfRemovalFromShare(ctx context.Context, auditCtx *Sha
 	}
 
 	// Log the event (ignore errors to not block the main operation)
-	_ = c.storage.LogAuditEvent(ctx, event)
+	c.emitAudit(ctx, event)
 }

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -234,6 +234,12 @@ type AuditFilter struct {
 	EndTime   *time.Time
 	Page      int
 	PageSize  int
+
+	// Cursor pagination for incremental SIEM export. When AfterID is set the
+	// query returns events with id > *AfterID in ascending id order (a stable
+	// forward cursor), ignoring Page. Use with the /audit/export endpoint.
+	AfterID   *uint
+	Ascending bool
 }
 
 // RBACAuditFilter defines filtering options for RBAC audit log queries

--- a/internal/storage/store/audit_export_test.go
+++ b/internal/storage/store/audit_export_test.go
@@ -1,0 +1,51 @@
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// GetAuditLogs in cursor mode (Ascending + AfterID) returns events in ascending
+// id order with id > cursor — the stable forward cursor used by /audit/export.
+func TestGetAuditLogs_CursorExport(t *testing.T) {
+	ctx := context.Background()
+	ls := newAuditTestStore(t)
+	base := time.Date(2026, 6, 4, 9, 0, 0, 0, time.UTC)
+
+	// Insert 5 events; event_time DESCENDING vs id so we can prove the cursor
+	// orders by id, not by time.
+	for i := 0; i < 5; i++ {
+		require.NoError(t, ls.LogAuditEvent(ctx, &models.AuditEvent{
+			EventType: "secret.read",
+			EventTime: base.Add(time.Duration(-i) * time.Minute),
+		}))
+	}
+
+	// First page from the start.
+	page1, _, err := ls.GetAuditLogs(ctx, &storage.AuditFilter{Ascending: true, PageSize: 2})
+	require.NoError(t, err)
+	require.Len(t, page1, 2)
+	assert.Equal(t, uint(1), page1[0].ID)
+	assert.Equal(t, uint(2), page1[1].ID)
+
+	// Advance the cursor past id=2.
+	after := page1[1].ID
+	page2, _, err := ls.GetAuditLogs(ctx, &storage.AuditFilter{Ascending: true, PageSize: 2, AfterID: &after})
+	require.NoError(t, err)
+	require.Len(t, page2, 2)
+	assert.Equal(t, uint(3), page2[0].ID)
+	assert.Equal(t, uint(4), page2[1].ID)
+
+	// Final partial page.
+	after = page2[1].ID
+	page3, _, err := ls.GetAuditLogs(ctx, &storage.AuditFilter{Ascending: true, PageSize: 2, AfterID: &after})
+	require.NoError(t, err)
+	require.Len(t, page3, 1)
+	assert.Equal(t, uint(5), page3[0].ID)
+}

--- a/internal/storage/store/local_audit.go
+++ b/internal/storage/store/local_audit.go
@@ -58,6 +58,9 @@ func (ls *LocalStorage) GetAuditLogs(ctx context.Context, filter *storage.AuditF
 		if filter.Success != nil {
 			query = query.Where("success = ?", *filter.Success)
 		}
+		if filter.AfterID != nil {
+			query = query.Where("id > ?", *filter.AfterID)
+		}
 		if filter.Page > 1 {
 			page = filter.Page
 		}
@@ -68,6 +71,16 @@ func (ls *LocalStorage) GetAuditLogs(ctx context.Context, filter *storage.AuditF
 
 	var total int64
 	query.Count(&total)
+
+	// Cursor mode (SIEM export): ascending by id, no page offset — the caller
+	// advances by passing the last seen id as AfterID on the next request.
+	if filter != nil && filter.Ascending {
+		var events []*models.AuditEvent
+		if err := query.Order("id ASC").Limit(pageSize).Find(&events).Error; err != nil {
+			return nil, 0, fmt.Errorf("failed to get audit logs: %w", err)
+		}
+		return events, total, nil
+	}
 
 	var events []*models.AuditEvent
 	offset := (page - 1) * pageSize

--- a/internal/storage/store/remote_audit.go
+++ b/internal/storage/store/remote_audit.go
@@ -76,6 +76,7 @@ func buildAuditFilterPath(filter *storage.AuditFilter) string {
 	params.addBool("success", filter.Success)
 	params.addTime("start_time", filter.StartTime)
 	params.addTime("end_time", filter.EndTime)
+	params.addUint("after_id", filter.AfterID)
 	params.addPage(filter.Page, filter.PageSize)
 	return "/api/v1/audit/events" + params.String()
 }

--- a/server/http/handlers/audit.go
+++ b/server/http/handlers/audit.go
@@ -137,6 +137,107 @@ func (h *AuditHandler) GetAuditLogs(w http.ResponseWriter, r *http.Request) {
 	}, "")
 }
 
+// AuditExportEntry is the full-fidelity wire shape for SIEM ingestion. Unlike
+// AuditLogEntry (UI-oriented) it preserves the raw IDs, success flag, diff, and
+// impersonation attribution so an external system can index every field.
+type AuditExportEntry struct {
+	ID             uint            `json:"id"`
+	EventType      string          `json:"event_type"`
+	Timestamp      time.Time       `json:"timestamp"`
+	Actor          string          `json:"actor"`
+	UserID         *uint           `json:"user_id,omitempty"`
+	ProjectID      *uint           `json:"project_id,omitempty"`
+	SecretID       *uint           `json:"secret_id,omitempty"`
+	Description    string          `json:"description"`
+	IPAddress      string          `json:"ip_address,omitempty"`
+	Success        bool            `json:"success"`
+	Diff           json.RawMessage `json:"diff,omitempty"`
+	Impersonation  bool            `json:"impersonation,omitempty"`
+	ImpersonatedBy string          `json:"impersonated_by,omitempty"`
+	ActingAs       string          `json:"acting_as,omitempty"`
+}
+
+// ExportAuditLogs handles GET /api/v1/audit/export — a cursor-paginated,
+// full-fidelity audit feed for SIEM pull. Authenticated as a normal API caller
+// (a SIEM uses a personal access token) and gated by audit.read. Advance the
+// cursor by passing the last returned id as ?after_id= on the next request;
+// next_cursor in the response is the id to use, or null when caught up.
+func (h *AuditHandler) ExportAuditLogs(w http.ResponseWriter, r *http.Request) {
+	if middleware.GetUserFromContext(r.Context()) == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+
+	limit := 100
+	if l, err := strconv.Atoi(r.URL.Query().Get("limit")); err == nil && l > 0 && l <= 1000 {
+		limit = l
+	}
+	filter := &storage.AuditFilter{Ascending: true, PageSize: limit}
+	if aidStr := r.URL.Query().Get("after_id"); aidStr != "" {
+		if aid, err := strconv.ParseUint(aidStr, 10, 32); err == nil {
+			a := uint(aid)
+			filter.AfterID = &a
+		}
+	}
+	if st := r.URL.Query().Get("since"); st != "" {
+		if t, err := time.Parse(time.RFC3339, st); err == nil {
+			filter.StartTime = &t
+		}
+	}
+
+	events, _, err := h.coreService.Storage().GetAuditLogs(r.Context(), filter)
+	if err != nil {
+		sendError(w, "InternalServerError", "Failed to export audit logs", http.StatusInternalServerError, nil)
+		return
+	}
+
+	actorNames := h.coreService.ResolveUsernames(r.Context(), events)
+	name := func(id *uint) string {
+		if id == nil {
+			return ""
+		}
+		return actorNames[*id]
+	}
+
+	entries := make([]AuditExportEntry, 0, len(events))
+	var nextCursor *uint
+	for _, e := range events {
+		success := true
+		if e.Success != nil {
+			success = *e.Success
+		}
+		entry := AuditExportEntry{
+			ID:          e.ID,
+			EventType:   e.EventType,
+			Timestamp:   e.EventTime,
+			Actor:       name(e.UserID),
+			UserID:      e.UserID,
+			ProjectID:   e.ProjectID,
+			SecretID:    e.SecretNodeID,
+			Description: e.Description,
+			IPAddress:   e.IPAddress,
+			Success:     success,
+		}
+		if e.Diff != "" {
+			entry.Diff = json.RawMessage(e.Diff)
+		}
+		if e.Impersonation {
+			entry.Impersonation = true
+			entry.ImpersonatedBy = name(e.ImpersonatedBy)
+			entry.ActingAs = name(e.ActingAs)
+		}
+		entries = append(entries, entry)
+		id := e.ID
+		nextCursor = &id
+	}
+
+	sendSuccess(w, map[string]interface{}{
+		"events":      entries,
+		"count":       len(entries),
+		"next_cursor": nextCursor,
+	}, "")
+}
+
 // GetRBACAuditLogs handles GET /api/v1/audit/rbac-logs (stub — returns empty).
 func (h *AuditHandler) GetRBACAuditLogs(w http.ResponseWriter, r *http.Request) {
 	userCtx := middleware.GetUserFromContext(r.Context())

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -303,6 +303,7 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		r.Route("/audit", func(r chi.Router) {
 			r.Use(customMiddleware.RequirePermission("audit.read"))
 			r.Get("/logs", auditHandler.GetAuditLogs)
+			r.Get("/export", auditHandler.ExportAuditLogs)
 			r.Get("/rbac-logs", auditHandler.GetRBACAuditLogs)
 			r.Get("/anomalies", handlers.ListAnomalyAlerts)
 			r.Post("/anomalies/{id}/acknowledge", handlers.AcknowledgeAnomalyAlert)

--- a/server/main.go
+++ b/server/main.go
@@ -33,6 +33,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/keyorixhq/keyorix/internal/audit/siem"
 	"github.com/keyorixhq/keyorix/internal/config"
 	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/keyorixhq/keyorix/internal/encryption"
@@ -188,6 +189,23 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 			RequireSpecial:     pp.RequireSpecial,
 			RejectPersonalInfo: pp.RejectPersonalInfo,
 		})
+	}
+
+	// Wire native SIEM audit forwarding if configured. New returns (nil, nil)
+	// when disabled, so SetAuditForwarder(nil) keeps forwarding off.
+	if sc := cfg.Audit.SIEM; sc.Enabled {
+		forwarder, ferr := siem.New(siem.Config{
+			Enabled:            sc.Enabled,
+			Provider:           siem.Provider(sc.Provider),
+			Endpoint:           sc.Endpoint,
+			Token:              sc.GetToken(),
+			InsecureSkipVerify: sc.InsecureSkipVerify,
+		})
+		if ferr != nil {
+			return nil, nil, fmt.Errorf("failed to init SIEM audit forwarder: %w", ferr)
+		}
+		coreService.SetAuditForwarder(forwarder)
+		log.Printf("SIEM audit forwarding enabled (provider=%s)", sc.Provider)
 	}
 	return coreService, encSvc, nil
 }


### PR DESCRIPTION
**Stacked on #8** (base is `feat/audit-diff-impersonation`; retarget to `main` after #8 merges).

Completes the "native SIEM connectors" audit-design item.

## Push connectors (`internal/audit/siem`)
Forwards each persisted audit event to Splunk HEC / Datadog Logs / generic webhook. Async + best-effort: bounded queue + worker, 5s timeout, drop-and-count on full queue so a slow SIEM never blocks an audited op. Stable snake_case payload. **No plaintext** ever forwarded (value diff is a marker only — asserted by test).

Wiring: core gains an `AuditForwarder` interface (no dependency on the siem impl) + `SetAuditForwarder`; all 11 core audit writers funnel through one `emitAudit` helper. Server builds it from a new `audit.siem` config block (token via `KEYORIX_SIEM_TOKEN`).

## Cursor export
`GET /api/v1/audit/export` — full-fidelity, cursor-paginated feed for SIEM pull (diff + impersonation attribution resolved to usernames). `AuditFilter` gains `AfterID`/`Ascending`; response carries `next_cursor`.

Tests: forwarder validation + per-provider formatting/auth via httptest + no-leak assert + async drain; cursor ordering/advance/partial-page. Full gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)