### PR TITLE
feat(account): finish ADR-025 password policy — common-password denylist, history, expiry

### DIFF
--- a/configs/keyorix.yaml.tpl
+++ b/configs/keyorix.yaml.tpl
@@ -101,14 +101,16 @@ password_policy:
   # Rules enforced when a user sets a new password (e.g. self-service change).
   # Omit this whole block to use the conservative built-in defaults (shown
   # below). Lab installs may relax these, e.g. min_length: 8 and the require_*
-  # flags false. Note: reject_common_passwords / history / max-age expiry are
-  # not yet enforced (ADR-025 follow-ups).
+  # flags false.
   min_length: 16
   require_uppercase: true
   require_lowercase: true
   require_digit: true
   require_special: true
-  reject_personal_info: true   # reject if it contains the user's username/email/display name
+  reject_personal_info: true     # reject if it contains the user's username/email/display name
+  reject_common_passwords: true  # reject passwords on the curated common-password denylist
+  history_count: 5               # forbid reusing the last N passwords (0 = off)
+  max_age_days: 0                # expire a password after N days (0 = never; login flags it)
 
 soft_delete:
   # Enable soft-deletion for all database entities

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -27,9 +27,9 @@ type Config struct {
 	PasswordPolicy PasswordPolicyConfig `yaml:"password_policy"`
 }
 
-// PasswordPolicyConfig mirrors the synchronous password rules from ADR-025.
-// Stateful rules (reject_common_passwords, history_count, max_age_days) are not
-// part of this first slice and are intentionally omitted here.
+// PasswordPolicyConfig mirrors the password rules from ADR-025: synchronous
+// complexity rules plus the stateful rules (reject_common_passwords,
+// history_count, max_age_days) backed by the password-history table.
 type PasswordPolicyConfig struct {
 	MinLength          int  `yaml:"min_length"`
 	RequireUppercase   bool `yaml:"require_uppercase"`
@@ -37,6 +37,12 @@ type PasswordPolicyConfig struct {
 	RequireDigit       bool `yaml:"require_digit"`
 	RequireSpecial     bool `yaml:"require_special"`
 	RejectPersonalInfo bool `yaml:"reject_personal_info"`
+	// RejectCommonPasswords rejects passwords on the curated common-password list.
+	RejectCommonPasswords bool `yaml:"reject_common_passwords"`
+	// HistoryCount forbids reusing the last N passwords (0 = no history check).
+	HistoryCount int `yaml:"history_count"`
+	// MaxAgeDays expires a password after N days (0 = never expires).
+	MaxAgeDays int `yaml:"max_age_days"`
 }
 
 // IsZero reports whether the password_policy block was effectively absent, so

--- a/internal/core/account.go
+++ b/internal/core/account.go
@@ -8,6 +8,7 @@ package core
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
@@ -52,15 +53,28 @@ func (c *KeyorixCore) ChangePassword(ctx context.Context, userID uint, current, 
 	if err := c.passwordPolicy.Validate(newPassword, user); err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorValidation", nil), err)
 	}
+	// Stateful history rule: forbid reuse of the last N passwords (ADR-025).
+	if c.passwordReused(ctx, user, newPassword) {
+		return fmt.Errorf("%s: password must not reuse a recent password", i18n.T("ErrorValidation", nil))
+	}
 
 	hash, err := bcrypt.GenerateFromPassword([]byte(newPassword), bcrypt.DefaultCost)
 	if err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}
+	now := c.now()
 	user.PasswordHash = string(hash)
-	user.UpdatedAt = c.now()
+	user.PasswordChangedAt = &now
+	user.UpdatedAt = now
 	if _, err := c.storage.UpdateUser(ctx, user); err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+
+	// Record the new hash in history and prune to the configured depth.
+	// Best-effort: the password change itself has already succeeded.
+	if c.passwordPolicy.HistoryCount > 0 {
+		_ = c.storage.AddPasswordHistory(ctx, userID, string(hash), now)
+		_ = c.storage.PrunePasswordHistory(ctx, userID, c.passwordPolicy.HistoryCount)
 	}
 
 	// Drop other sessions. Best-effort: the password change itself has succeeded.
@@ -72,6 +86,46 @@ func (c *KeyorixCore) ChangePassword(ctx context.Context, userID uint, current, 
 	}
 	_ = c.storage.DeleteSessionsForUserExcept(ctx, userID, keepID)
 	return nil
+}
+
+// passwordReused reports whether newPassword matches the user's current password
+// or any of the most recent HistoryCount stored hashes (ADR-025 history_count).
+// Returns false when the history rule is disabled.
+func (c *KeyorixCore) passwordReused(ctx context.Context, user *models.User, newPassword string) bool {
+	if c.passwordPolicy.HistoryCount <= 0 {
+		return false
+	}
+	if bcrypt.CompareHashAndPassword([]byte(user.PasswordHash), []byte(newPassword)) == nil {
+		return true
+	}
+	hashes, err := c.storage.RecentPasswordHashes(ctx, user.ID, c.passwordPolicy.HistoryCount)
+	if err != nil {
+		return false // best-effort: a history lookup failure must not block a change
+	}
+	for _, h := range hashes {
+		if bcrypt.CompareHashAndPassword([]byte(h), []byte(newPassword)) == nil {
+			return true
+		}
+	}
+	return false
+}
+
+// PasswordExpired reports whether the user's password has exceeded the policy's
+// max age (ADR-025 max_age_days). Returns false when expiry is disabled. For
+// legacy rows with no PasswordChangedAt, the account creation time is used.
+func (c *KeyorixCore) PasswordExpired(user *models.User) bool {
+	if user == nil || c.passwordPolicy.MaxAgeDays <= 0 {
+		return false
+	}
+	set := user.PasswordChangedAt
+	if set == nil {
+		if user.CreatedAt.IsZero() {
+			return false
+		}
+		set = &user.CreatedAt
+	}
+	maxAge := time.Duration(c.passwordPolicy.MaxAgeDays) * 24 * time.Hour
+	return c.now().Sub(*set) > maxAge
 }
 
 // CurrentSessionID returns the session ID backing a session token, or 0 if the

--- a/internal/core/account_test.go
+++ b/internal/core/account_test.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/stretchr/testify/assert"
@@ -61,6 +62,10 @@ func TestChangePassword(t *testing.T) {
 		ms.On("UpdateUser", ctx, mock.AnythingOfType("*models.User")).Return(user, nil)
 		ms.On("GetSession", ctx, "current-token").Return(&models.Session{ID: 7, UserID: 1}, nil)
 		ms.On("DeleteSessionsForUserExcept", ctx, uint(1), uint(7)).Return(nil)
+		// History rule (default HistoryCount=5): no prior hashes, then record + prune.
+		ms.On("RecentPasswordHashes", ctx, uint(1), 5).Return([]string{}, nil)
+		ms.On("AddPasswordHistory", ctx, uint(1), mock.AnythingOfType("string"), mock.Anything).Return(nil)
+		ms.On("PrunePasswordHistory", ctx, uint(1), 5).Return(nil)
 
 		const newPw = "Brandnew#Passw0rd!" // policy-compliant: 16+, upper/lower/digit/special
 		err := c.ChangePassword(ctx, 1, "oldpassword", newPw, "current-token")
@@ -68,6 +73,38 @@ func TestChangePassword(t *testing.T) {
 		// The new password verifies against the freshly stored hash.
 		assert.NoError(t, bcrypt.CompareHashAndPassword([]byte(user.PasswordHash), []byte(newPw)))
 		ms.AssertCalled(t, "DeleteSessionsForUserExcept", ctx, uint(1), uint(7))
+		ms.AssertCalled(t, "AddPasswordHistory", ctx, uint(1), mock.AnythingOfType("string"), mock.Anything)
+	})
+
+	t.Run("rejects reuse of a recent password", func(t *testing.T) {
+		ms := new(MockStorage)
+		c := NewKeyorixCore(ms)
+		// The new password is a former one whose hash is in history.
+		const reused = "Recycled#Passw0rd!"
+		reusedHash, _ := bcrypt.GenerateFromPassword([]byte(reused), bcrypt.DefaultCost)
+		user := &models.User{ID: 1, Username: acctTestUser, PasswordHash: string(oldHash)}
+		ms.On("GetUser", ctx, uint(1)).Return(user, nil)
+		ms.On("RecentPasswordHashes", ctx, uint(1), 5).Return([]string{string(reusedHash)}, nil)
+
+		err := c.ChangePassword(ctx, 1, "oldpassword", reused, "current-token")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "reuse a recent password")
+		ms.AssertNotCalled(t, "UpdateUser", mock.Anything, mock.Anything)
+	})
+
+	t.Run("rejects reuse of the current password", func(t *testing.T) {
+		ms := new(MockStorage)
+		c := NewKeyorixCore(ms)
+		// A policy-compliant current password that the user tries to "change" to itself.
+		const cur = "Current#Passw0rd!"
+		curHash, _ := bcrypt.GenerateFromPassword([]byte(cur), bcrypt.DefaultCost)
+		user := &models.User{ID: 1, Username: acctTestUser, PasswordHash: string(curHash)}
+		ms.On("GetUser", ctx, uint(1)).Return(user, nil)
+
+		err := c.ChangePassword(ctx, 1, cur, cur, "current-token")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "reuse a recent password")
+		ms.AssertNotCalled(t, "UpdateUser", mock.Anything, mock.Anything)
 	})
 
 	t.Run("rejects an incorrect current password without writing", func(t *testing.T) {
@@ -95,6 +132,37 @@ func TestChangePassword(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "password must")
 		ms.AssertNotCalled(t, "UpdateUser", mock.Anything, mock.Anything)
+	})
+}
+
+func TestPasswordExpired(t *testing.T) {
+	ms := new(MockStorage)
+	c := NewKeyorixCore(ms)
+	fixed := time.Date(2026, 6, 4, 12, 0, 0, 0, time.UTC)
+	c.now = func() time.Time { return fixed }
+
+	t.Run("disabled when MaxAgeDays is zero", func(t *testing.T) {
+		c.passwordPolicy = PasswordPolicy{MaxAgeDays: 0}
+		old := fixed.Add(-365 * 24 * time.Hour)
+		assert.False(t, c.PasswordExpired(&models.User{PasswordChangedAt: &old}))
+	})
+
+	t.Run("expired past max age", func(t *testing.T) {
+		c.passwordPolicy = PasswordPolicy{MaxAgeDays: 90}
+		set := fixed.Add(-100 * 24 * time.Hour)
+		assert.True(t, c.PasswordExpired(&models.User{PasswordChangedAt: &set}))
+	})
+
+	t.Run("not expired within max age", func(t *testing.T) {
+		c.passwordPolicy = PasswordPolicy{MaxAgeDays: 90}
+		set := fixed.Add(-30 * 24 * time.Hour)
+		assert.False(t, c.PasswordExpired(&models.User{PasswordChangedAt: &set}))
+	})
+
+	t.Run("legacy nil falls back to created_at", func(t *testing.T) {
+		c.passwordPolicy = PasswordPolicy{MaxAgeDays: 90}
+		created := fixed.Add(-200 * 24 * time.Hour)
+		assert.True(t, c.PasswordExpired(&models.User{CreatedAt: created}))
 	})
 }
 

--- a/internal/core/common_passwords.go
+++ b/internal/core/common_passwords.go
@@ -1,0 +1,42 @@
+// common_passwords.go — curated common-password denylist for ADR-025's
+// reject_common_passwords rule. This is an offline, dependency-free check
+// against the most frequently breached/guessed passwords; an online HIBP
+// range check is a possible later enhancement. Matching is case-insensitive.
+package core
+
+import "strings"
+
+// commonPasswords is a curated set of the most common passwords (and a few
+// obvious keyboard walks / Keyorix-relevant terms). The conservative default
+// MinLength of 16 already rejects most of these, but the rule still catches
+// long-but-trivial choices and applies when an install relaxes the length.
+var commonPasswords = func() map[string]struct{} {
+	list := []string{
+		"123456", "123456789", "12345678", "1234567890", "1234567",
+		"password", "password1", "password123", "passw0rd", "p@ssw0rd",
+		"qwerty", "qwerty123", "qwertyuiop", "1q2w3e4r", "1qaz2wsx",
+		"admin", "administrator", "root", "letmein", "welcome",
+		"welcome1", "welcome123", "iloveyou", "monkey", "dragon",
+		"abc123", "abcd1234", "111111", "000000", "123123",
+		"sunshine", "princess", "football", "baseball", "superman",
+		"trustno1", "master", "michael", "shadow", "ashley",
+		"changeme", "changeme123", "default", "secret", "secret123",
+		"keyorix", "keyorix123", "vault", "vault123", "azerty",
+		"login", "test", "test123", "guest", "user",
+		"qazwsx", "zaq12wsx", "passpass", "pa55word", "p@ssword",
+		"hello123", "whatever", "freedom", "starwars", "computer",
+		"password!", "password1!", "p@ssw0rd!", "admin123", "root123",
+		"correcthorsebatterystaple", "letmein123", "welcometokeyorix",
+	}
+	m := make(map[string]struct{}, len(list))
+	for _, p := range list {
+		m[p] = struct{}{}
+	}
+	return m
+}()
+
+// isCommonPassword reports whether pw is on the curated denylist (case-insensitive).
+func isCommonPassword(pw string) bool {
+	_, ok := commonPasswords[strings.ToLower(strings.TrimSpace(pw))]
+	return ok
+}

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -369,6 +369,24 @@ func (m *MockStorage) GetUserGroups(ctx context.Context, userID uint) ([]*models
 	return args.Get(0).([]*models.Group), args.Error(1)
 }
 
+func (m *MockStorage) AddPasswordHistory(ctx context.Context, userID uint, hash string, at time.Time) error {
+	args := m.Called(ctx, userID, hash, at)
+	return args.Error(0)
+}
+
+func (m *MockStorage) RecentPasswordHashes(ctx context.Context, userID uint, limit int) ([]string, error) {
+	args := m.Called(ctx, userID, limit)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]string), args.Error(1)
+}
+
+func (m *MockStorage) PrunePasswordHistory(ctx context.Context, userID uint, keep int) error {
+	args := m.Called(ctx, userID, keep)
+	return args.Error(0)
+}
+
 func (m *MockStorage) CreateGroup(ctx context.Context, group *models.Group) (*models.Group, error) {
 	args := m.Called(ctx, group)
 	if args.Get(0) == nil {

--- a/internal/core/password_policy.go
+++ b/internal/core/password_policy.go
@@ -8,30 +8,39 @@ import (
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
-// PasswordPolicy is the set of synchronous, stateless rules a new password must
-// satisfy (ADR-025). Stateful rules from the ADR — reject-common-passwords,
-// history (no reuse of last N), and max-age expiry — need extra storage and are
-// deliberately out of this first slice; see the package follow-ups.
+// PasswordPolicy is the full set of password rules from ADR-025. The complexity
+// rules (length, character classes, personal-info, common-password) are
+// stateless and enforced by Validate. The stateful rules — HistoryCount (no
+// reuse of the last N passwords) and MaxAgeDays (expiry) — are enforced by core
+// against the password-history table and PasswordChangedAt (see account.go).
 type PasswordPolicy struct {
-	MinLength          int
-	RequireUppercase   bool
-	RequireLowercase   bool
-	RequireDigit       bool
-	RequireSpecial     bool
-	RejectPersonalInfo bool // reject if the password contains the user's email/display name/username
+	MinLength             int
+	RequireUppercase      bool
+	RequireLowercase      bool
+	RequireDigit          bool
+	RequireSpecial        bool
+	RejectPersonalInfo    bool // reject if the password contains the user's email/display name/username
+	RejectCommonPasswords bool // reject passwords on the curated common-password list
+	HistoryCount          int  // forbid reuse of the last N passwords (0 = off)
+	MaxAgeDays            int  // expire a password after N days (0 = never)
 }
 
 // DefaultPasswordPolicy returns the conservative, NIS2/DORA-aligned defaults
 // from ADR-025. Installs may relax these per-config (e.g. lab installs), but the
-// built-in default is intentionally not lab-grade.
+// built-in default is intentionally not lab-grade. MaxAgeDays defaults to 0
+// (no forced rotation) — expiry is opt-in until the account-state-machine ships
+// the restricted-session gate, so a default can't silently lock anyone out.
 func DefaultPasswordPolicy() PasswordPolicy {
 	return PasswordPolicy{
-		MinLength:          16,
-		RequireUppercase:   true,
-		RequireLowercase:   true,
-		RequireDigit:       true,
-		RequireSpecial:     true,
-		RejectPersonalInfo: true,
+		MinLength:             16,
+		RequireUppercase:      true,
+		RequireLowercase:      true,
+		RequireDigit:          true,
+		RequireSpecial:        true,
+		RejectPersonalInfo:    true,
+		RejectCommonPasswords: true,
+		HistoryCount:          5,
+		MaxAgeDays:            0,
 	}
 }
 
@@ -73,6 +82,10 @@ func (p PasswordPolicy) Validate(pw string, user *models.User) error {
 
 	if p.RejectPersonalInfo && user != nil && containsPersonalInfo(pw, user) {
 		failures = append(failures, "not contain your username, email, or display name")
+	}
+
+	if p.RejectCommonPasswords && isCommonPassword(pw) {
+		failures = append(failures, "not be a commonly-used password")
 	}
 
 	if len(failures) > 0 {

--- a/internal/core/password_policy_test.go
+++ b/internal/core/password_policy_test.go
@@ -65,3 +65,22 @@ func TestPasswordPolicy_Relaxed(t *testing.T) {
 	assert.Contains(t, err.Error(), "at least 8 characters")
 	assert.False(t, strings.Contains(err.Error(), "uppercase"), "disabled checks not reported")
 }
+
+// The common-password rule rejects denylisted passwords (case-insensitive) and
+// is independent of the complexity checks.
+func TestPasswordPolicy_RejectsCommonPasswords(t *testing.T) {
+	p := PasswordPolicy{RejectCommonPasswords: true}
+	for _, pw := range []string{"password", "PASSWORD", "Keyorix123", "letmein"} {
+		err := p.Validate(pw, nil)
+		require.Error(t, err, "expected %q to be rejected", pw)
+		assert.Contains(t, err.Error(), "commonly-used password")
+	}
+	// A strong, non-listed password passes the common-password rule.
+	assert.NoError(t, p.Validate("Z6!txQ9mAe2vПЛh", nil))
+}
+
+func TestIsCommonPassword(t *testing.T) {
+	assert.True(t, isCommonPassword("qwerty"))
+	assert.True(t, isCommonPassword("  Admin  "), "trimmed + lowercased")
+	assert.False(t, isCommonPassword("a-genuinely-unusual-passphrase-42"))
+}

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -78,6 +78,13 @@ type Storage interface {
 	GetUserByUsername(ctx context.Context, username string) (*models.User, error)
 	GetUserGroups(ctx context.Context, userID uint) ([]*models.Group, error)
 
+	// Password history (ADR-025 history_count). AddPasswordHistory records a
+	// bcrypt hash; RecentPasswordHashes returns the most recent `limit` hashes
+	// (newest first); PrunePasswordHistory keeps only the newest `keep` rows.
+	AddPasswordHistory(ctx context.Context, userID uint, hash string, at time.Time) error
+	RecentPasswordHashes(ctx context.Context, userID uint, limit int) ([]string, error)
+	PrunePasswordHistory(ctx context.Context, userID uint, keep int) error
+
 	// Group Management
 	CreateGroup(ctx context.Context, group *models.Group) (*models.Group, error)
 	GetGroup(ctx context.Context, id uint) (*models.Group, error)

--- a/internal/core/users.go
+++ b/internal/core/users.go
@@ -51,18 +51,25 @@ func (c *KeyorixCore) CreateUser(ctx context.Context, req *CreateUserRequest) (*
 		active = *req.IsActive
 	}
 	user := &models.User{
-		Username:     req.Username,
-		Email:        req.Email,
-		DisplayName:  displayName,
-		PasswordHash: string(hash),
-		IsActive:     active,
-		CreatedAt:    now,
-		UpdatedAt:    now,
+		Username:          req.Username,
+		Email:             req.Email,
+		DisplayName:       displayName,
+		PasswordHash:      string(hash),
+		IsActive:          active,
+		PasswordChangedAt: &now, // baseline for max-age expiry (ADR-025)
+		CreatedAt:         now,
+		UpdatedAt:         now,
 	}
 
 	createdUser, err := c.storage.CreateUser(ctx, user)
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+
+	// Seed password history with the initial password so the no-reuse rule
+	// (ADR-025) counts it. Best-effort — user creation has already succeeded.
+	if c.passwordPolicy.HistoryCount > 0 {
+		_ = c.storage.AddPasswordHistory(ctx, createdUser.ID, string(hash), now)
 	}
 
 	// Auto-assign the system_viewer role (ADR-021): a minimal install-wide

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -149,6 +149,11 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 		db.Exec("ALTER TABLE users ADD COLUMN last_login_at TIMESTAMP WITH TIME ZONE")
 	}
 
+	// Track when the current password was set, for max-age expiry (ADR-025).
+	if tableExists(db, "users") && !columnExists(db, "users", "password_changed_at") {
+		db.Exec("ALTER TABLE users ADD COLUMN password_changed_at TIMESTAMP WITH TIME ZONE")
+	}
+
 	// Enrich sessions for the My Account "active sessions" view (device/IP/last-active).
 	if tableExists(db, "sessions") {
 		if !columnExists(db, "sessions", "user_agent") {
@@ -216,6 +221,7 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 	patExists := tableExists(db, "personal_access_tokens")
 	invitationsExists := tableExists(db, "project_invitations")
 	accessReqExists := tableExists(db, "access_requests")
+	pwHistExists := tableExists(db, "password_histories")
 
 	// Create rotation_policies if missing (additive, safe on existing DBs).
 	if !rotationExists {
@@ -240,6 +246,13 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 	if !accessReqExists {
 		if err := db.AutoMigrate(&models.AccessRequest{}); err != nil {
 			return fmt.Errorf("failed to migrate access_requests table: %w", err)
+		}
+	}
+
+	// Create password_histories if missing (ADR-025 history_count, additive).
+	if !pwHistExists {
+		if err := db.AutoMigrate(&models.PasswordHistory{}); err != nil {
+			return fmt.Errorf("failed to migrate password_histories table: %w", err)
 		}
 	}
 

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -68,9 +68,22 @@ type User struct {
 	PasswordHash string
 	IsActive     bool       `gorm:"default:true"`
 	LastLoginAt  *time.Time // stamped on each successful auth.login; nil = never logged in
+	// PasswordChangedAt is when the current password was set. Drives max-age
+	// expiry (ADR-025). nil on legacy rows = treat as set at account creation.
+	PasswordChangedAt *time.Time
+	CreatedAt         time.Time
+	UpdatedAt         time.Time
+	DeletedAt         gorm.DeletedAt `gorm:"index"` // soft delete — set by DELETE /users/{id}, cleared by restore
+}
+
+// PasswordHistory records prior password hashes per user so the policy can
+// forbid reuse of the last N passwords (ADR-025 history_count). Only bcrypt
+// hashes are stored — never plaintext.
+type PasswordHistory struct {
+	ID           uint `gorm:"primaryKey"`
+	UserID       uint `gorm:"index"`
+	PasswordHash string
 	CreatedAt    time.Time
-	UpdatedAt    time.Time
-	DeletedAt    gorm.DeletedAt `gorm:"index"` // soft delete — set by DELETE /users/{id}, cleared by restore
 }
 
 type Role struct {

--- a/internal/storage/store/local_users.go
+++ b/internal/storage/store/local_users.go
@@ -259,3 +259,57 @@ func (ls *LocalStorage) ListGroupMembers(ctx context.Context, groupID uint) ([]*
 	}
 	return users, nil
 }
+
+// --- Password history (ADR-025) ---
+
+// AddPasswordHistory records a bcrypt hash for the user.
+func (ls *LocalStorage) AddPasswordHistory(ctx context.Context, userID uint, hash string, at time.Time) error {
+	row := &models.PasswordHistory{UserID: userID, PasswordHash: hash, CreatedAt: at}
+	if err := ls.db.WithContext(ctx).Create(row).Error; err != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	return nil
+}
+
+// RecentPasswordHashes returns the most recent `limit` hashes (newest first).
+func (ls *LocalStorage) RecentPasswordHashes(ctx context.Context, userID uint, limit int) ([]string, error) {
+	if limit <= 0 {
+		return nil, nil
+	}
+	var rows []models.PasswordHistory
+	err := ls.db.WithContext(ctx).
+		Where("user_id = ?", userID).
+		Order("created_at DESC").Limit(limit).
+		Find(&rows).Error
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	hashes := make([]string, len(rows))
+	for i, r := range rows {
+		hashes[i] = r.PasswordHash
+	}
+	return hashes, nil
+}
+
+// PrunePasswordHistory deletes all but the newest `keep` history rows for a user.
+func (ls *LocalStorage) PrunePasswordHistory(ctx context.Context, userID uint, keep int) error {
+	if keep < 0 {
+		keep = 0
+	}
+	// Find the cutoff: the id of the keep-th newest row. Anything older is pruned.
+	var ids []uint
+	if err := ls.db.WithContext(ctx).Model(&models.PasswordHistory{}).
+		Where("user_id = ?", userID).
+		Order("created_at DESC").Limit(keep).
+		Pluck("id", &ids).Error; err != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	q := ls.db.WithContext(ctx).Where("user_id = ?", userID)
+	if len(ids) > 0 {
+		q = q.Where("id NOT IN ?", ids)
+	}
+	if err := q.Delete(&models.PasswordHistory{}).Error; err != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	return nil
+}

--- a/internal/storage/store/password_history_test.go
+++ b/internal/storage/store/password_history_test.go
@@ -1,0 +1,60 @@
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func newPasswordHistoryStore(t *testing.T) *LocalStorage {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.PasswordHistory{}))
+	return NewLocalStorage(db)
+}
+
+// AddPasswordHistory + RecentPasswordHashes return newest-first; PrunePasswordHistory
+// keeps only the newest N rows for the user.
+func TestPasswordHistory_RecentAndPrune(t *testing.T) {
+	ctx := context.Background()
+	ls := newPasswordHistoryStore(t)
+	base := time.Date(2026, 6, 4, 9, 0, 0, 0, time.UTC)
+
+	// Insert 4 hashes for user 1 at increasing times, plus one for user 2.
+	for i, h := range []string{"h1", "h2", "h3", "h4"} {
+		require.NoError(t, ls.AddPasswordHistory(ctx, 1, h, base.Add(time.Duration(i)*time.Minute)))
+	}
+	require.NoError(t, ls.AddPasswordHistory(ctx, 2, "other", base))
+
+	// Newest-first, limited to 2.
+	recent, err := ls.RecentPasswordHashes(ctx, 1, 2)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"h4", "h3"}, recent)
+
+	// Prune to the newest 2; h1/h2 go.
+	require.NoError(t, ls.PrunePasswordHistory(ctx, 1, 2))
+	all, err := ls.RecentPasswordHashes(ctx, 1, 10)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"h4", "h3"}, all)
+
+	// User 2's row is untouched.
+	other, err := ls.RecentPasswordHashes(ctx, 2, 10)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"other"}, other)
+}
+
+func TestRecentPasswordHashes_ZeroLimit(t *testing.T) {
+	ctx := context.Background()
+	ls := newPasswordHistoryStore(t)
+	require.NoError(t, ls.AddPasswordHistory(ctx, 1, "h1", time.Now()))
+	got, err := ls.RecentPasswordHashes(ctx, 1, 0)
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}

--- a/internal/storage/store/remote_users.go
+++ b/internal/storage/store/remote_users.go
@@ -200,3 +200,19 @@ func (rs *RemoteStorage) RemoveUserFromGroup(_ context.Context, _, _ uint) error
 func (rs *RemoteStorage) ListGroupMembers(_ context.Context, _ uint) ([]*models.User, error) {
 	return nil, fmt.Errorf("ListGroupMembers not implemented for remote storage")
 }
+
+// --- Password history (ADR-025) ---
+// Password changes are processed server-side in remote mode, so history is
+// recorded and checked there; these are stubs.
+
+func (rs *RemoteStorage) AddPasswordHistory(_ context.Context, _ uint, _ string, _ time.Time) error {
+	return nil
+}
+
+func (rs *RemoteStorage) RecentPasswordHashes(_ context.Context, _ uint, _ int) ([]string, error) {
+	return nil, nil
+}
+
+func (rs *RemoteStorage) PrunePasswordHistory(_ context.Context, _ uint, _ int) error {
+	return nil
+}

--- a/server/http/handlers/auth.go
+++ b/server/http/handlers/auth.go
@@ -79,6 +79,9 @@ type loginResponseBody struct {
 	Role        string   `json:"role"`        // primary (highest-privilege) role
 	Roles       []string `json:"roles"`       // all assigned role names
 	Permissions []string `json:"permissions"` // distinct permissions across roles
+	// PasswordChangeRequired is true when the password has exceeded the policy's
+	// max age (ADR-025 max_age_days) — the UI should route to change-password.
+	PasswordChangeRequired bool `json:"password_change_required,omitempty"`
 }
 
 type passwordResetRequestBody struct {
@@ -143,6 +146,8 @@ func (h *AuthHandler) Login(w http.ResponseWriter, r *http.Request) {
 	if id, ierr := h.coreService.GetUserIdentity(r.Context(), user.ID); ierr == nil {
 		resp.Role, resp.Roles, resp.Permissions = id.Role, id.Roles, id.Permissions
 	}
+	// Flag an expired password so the UI can require a change (ADR-025).
+	resp.PasswordChangeRequired = h.coreService.PasswordExpired(user)
 
 	// Audit log + last-login stamp (both non-blocking)
 	ip, ua := r.RemoteAddr, r.Header.Get("User-Agent")

--- a/server/main.go
+++ b/server/main.go
@@ -182,12 +182,15 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 	// core's conservative built-in defaults in place (ADR-025).
 	if pp := cfg.PasswordPolicy; !pp.IsZero() {
 		coreService.SetPasswordPolicy(core.PasswordPolicy{
-			MinLength:          pp.MinLength,
-			RequireUppercase:   pp.RequireUppercase,
-			RequireLowercase:   pp.RequireLowercase,
-			RequireDigit:       pp.RequireDigit,
-			RequireSpecial:     pp.RequireSpecial,
-			RejectPersonalInfo: pp.RejectPersonalInfo,
+			MinLength:             pp.MinLength,
+			RequireUppercase:      pp.RequireUppercase,
+			RequireLowercase:      pp.RequireLowercase,
+			RequireDigit:          pp.RequireDigit,
+			RequireSpecial:        pp.RequireSpecial,
+			RejectPersonalInfo:    pp.RejectPersonalInfo,
+			RejectCommonPasswords: pp.RejectCommonPasswords,
+			HistoryCount:          pp.HistoryCount,
+			MaxAgeDays:            pp.MaxAgeDays,
 		})
 	}
 


### PR DESCRIPTION
Completes the stateful half of ADR-025 (the first slice in `d11b90b` covered only synchronous complexity rules).

- **reject_common_passwords** — curated, dependency-free denylist checked in `PasswordPolicy.Validate` (case-insensitive). HIBP online check is a possible later enhancement.
- **history_count** — new `password_histories` table (bcrypt hashes only); `ChangePassword` rejects reuse of the current or last N passwords, then records + prunes. `CreateUser` seeds the initial password.
- **max_age_days** — `User.password_changed_at` stamped on create/change; `core.PasswordExpired` computes expiry (legacy nil → created_at); login response carries `password_change_required` (soft gate — the hard restricted-session 403 belongs with the ADR-025 account-state-machine and is intentionally not bundled here).

Defaults: reject-common ON, history 5, max-age 0 (expiry opt-in so a default can't silently lock anyone out). Additive pgx-safe migration. Tests: common-password rejection, reuse-of-recent/current rejection, history record/prune, PasswordExpired matrix, store recent/prune/isolation. Full gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)