### PR TITLE
feat(membership): project membership lifecycle state machine (ADR-022)

### DIFF
--- a/configs/keyorix.yaml.tpl
+++ b/configs/keyorix.yaml.tpl
@@ -145,3 +145,10 @@ logging:
   file: "keyorix.log"
   # Log format
   log_format: "text"  
+membership:
+  # Project membership onboarding (ADR-022). validation_mode controls how a new
+  # invite onboards into a project:
+  #   open      - invite is active immediately (self-serve)
+  #   allowlist - an admin steps the membership through each lifecycle state
+  #   idp       - IdP-resolved users skip the early states; others start invited
+  validation_mode: "allowlist"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,6 +20,7 @@ type Config struct {
 	SoftDelete  SoftDeleteConfig `yaml:"soft_delete"`
 	Purge       PurgeConfig      `yaml:"purge"`
 	Audit       AuditConfig      `yaml:"audit"`
+	Membership  MembershipConfig `yaml:"membership"`
 
 	// PasswordPolicy is optional. When the block is absent (zero value), the
 	// server keeps its conservative built-in defaults (see core.DefaultPasswordPolicy);
@@ -214,6 +215,14 @@ type SoftDeleteConfig struct {
 // AuditConfig groups audit-log delivery integrations.
 type AuditConfig struct {
 	SIEM SIEMConfig `yaml:"siem"`
+}
+
+// MembershipConfig configures the project membership lifecycle (ADR-022).
+type MembershipConfig struct {
+	// ValidationMode controls how a new invite onboards: "open" (active
+	// immediately), "allowlist" (admin steps through each state), or "idp"
+	// (IdP-resolved users skip the early states). Empty = allowlist.
+	ValidationMode string `yaml:"validation_mode"`
 }
 
 // SIEMConfig configures native push of audit events to an external SIEM.

--- a/internal/core/membership_lifecycle.go
+++ b/internal/core/membership_lifecycle.go
@@ -1,0 +1,226 @@
+// membership_lifecycle.go — project membership onboarding state machine (ADR-022).
+//
+// A ProjectMembership tracks a user's onboarding into a project, separate from
+// the role grant (user_roles). The lifecycle is a 5-state machine:
+//
+//	invited → identity_verified → provisioned → active   (revoked is terminal,
+//	                                                       reachable from any
+//	                                                       non-terminal state)
+//
+// The actual project role is granted (via AssignRole) only when a membership
+// reaches `active`, and removed when it is revoked. An install's validation mode
+// controls how much of the chain a new invite must traverse:
+//
+//	open      — self-serve: an invite lands directly in `active`.
+//	allowlist — an admin steps the membership through each state explicitly.
+//	idp       — IdP-resolved users skip invited/identity_verified (provisioned),
+//	            others start at `invited`.
+//
+// Every transition writes a discrete audit event. Email/setup-link delivery
+// (ADR-024) and inviter notifications are separate follow-ups.
+package core
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// Membership states.
+const (
+	MembershipInvited          = "invited"
+	MembershipIdentityVerified = "identity_verified"
+	MembershipProvisioned      = "provisioned"
+	MembershipActive           = "active"
+	MembershipRevoked          = "revoked"
+)
+
+// Validation modes (install-level).
+const (
+	ValidationModeOpen      = "open"
+	ValidationModeAllowlist = "allowlist"
+	ValidationModeIDP       = "idp"
+)
+
+// membershipTransitions lists the allowed next states for each state. revoked is
+// terminal (no outgoing transitions); every non-terminal state may go to revoked.
+var membershipTransitions = map[string][]string{
+	MembershipInvited:          {MembershipIdentityVerified, MembershipRevoked},
+	MembershipIdentityVerified: {MembershipProvisioned, MembershipRevoked},
+	MembershipProvisioned:      {MembershipActive, MembershipRevoked},
+	MembershipActive:           {MembershipRevoked},
+	MembershipRevoked:          {},
+}
+
+// canTransition reports whether a membership may move from → to.
+func canTransition(from, to string) bool {
+	for _, next := range membershipTransitions[from] {
+		if next == to {
+			return true
+		}
+	}
+	return false
+}
+
+// SetMembershipValidationMode overrides the install validation mode (default
+// ValidationModeAllowlist). The server calls this at startup from config.
+func (c *KeyorixCore) SetMembershipValidationMode(mode string) {
+	switch mode {
+	case ValidationModeOpen, ValidationModeAllowlist, ValidationModeIDP:
+		c.membershipValidationMode = mode
+	}
+}
+
+func (c *KeyorixCore) validationMode() string {
+	if c.membershipValidationMode == "" {
+		return ValidationModeAllowlist
+	}
+	return c.membershipValidationMode
+}
+
+// InviteMember starts a membership for userID in projectID with the given
+// intended role. The initial state depends on the install validation mode (and,
+// for idp, whether the user is IdP-resolved). Rejects a duplicate non-revoked
+// membership. When the mode lands the membership directly in `active`, the role
+// grant is applied immediately.
+func (c *KeyorixCore) InviteMember(ctx context.Context, projectID, userID uint, role string, invitedBy uint, idpResolved bool) (*models.ProjectMembership, error) {
+	if projectID == 0 || userID == 0 {
+		return nil, fmt.Errorf("project and user IDs are required")
+	}
+	if role == "" {
+		return nil, fmt.Errorf("a project role is required")
+	}
+	if _, err := c.storage.GetRoleByName(ctx, role); err != nil {
+		return nil, fmt.Errorf("unknown role %q: %w", role, err)
+	}
+	// One active onboarding per (project, user).
+	if existing, err := c.storage.GetActiveProjectMembership(ctx, projectID, userID); err == nil && existing != nil {
+		return nil, fmt.Errorf("user already has a %s membership in this project", existing.State)
+	}
+
+	now := c.now()
+	initial := c.initialMembershipState(idpResolved)
+	m := &models.ProjectMembership{
+		ProjectID: projectID,
+		UserID:    userID,
+		Role:      role,
+		State:     initial,
+		InvitedBy: invitedBy,
+		InvitedAt: now,
+		UpdatedAt: now,
+	}
+	if initial == MembershipActive {
+		t := now
+		m.ActivatedAt = &t
+	}
+	created, err := c.storage.CreateProjectMembership(ctx, m)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create membership: %w", err)
+	}
+
+	// If the mode put us straight into active, grant the role now.
+	if created.State == MembershipActive {
+		if err := c.AddProjectMember(ctx, projectID, userID, role); err != nil {
+			return nil, fmt.Errorf("failed to grant role on activation: %w", err)
+		}
+	}
+	c.logMembershipEvent(ctx, "membership.invited", created, invitedBy)
+	if created.State == MembershipActive {
+		c.logMembershipEvent(ctx, "membership.activated", created, invitedBy)
+	}
+	return created, nil
+}
+
+// initialMembershipState resolves the starting state for a new invite.
+func (c *KeyorixCore) initialMembershipState(idpResolved bool) string {
+	switch c.validationMode() {
+	case ValidationModeOpen:
+		return MembershipActive
+	case ValidationModeIDP:
+		if idpResolved {
+			return MembershipProvisioned // skip invited/identity_verified
+		}
+		return MembershipInvited
+	default: // allowlist
+		return MembershipInvited
+	}
+}
+
+// TransitionMembership advances a membership to the next state, enforcing the
+// state machine. Reaching `active` grants the project role; `revoked` removes it.
+// actorID is the user performing the transition (for the audit trail).
+func (c *KeyorixCore) TransitionMembership(ctx context.Context, membershipID uint, to string, actorID uint) (*models.ProjectMembership, error) {
+	m, err := c.storage.GetProjectMembership(ctx, membershipID)
+	if err != nil {
+		return nil, fmt.Errorf("membership not found")
+	}
+	if !canTransition(m.State, to) {
+		return nil, fmt.Errorf("cannot transition membership from %s to %s", m.State, to)
+	}
+
+	now := c.now()
+	m.State = to
+	m.UpdatedAt = now
+	switch to {
+	case MembershipActive:
+		m.ActivatedAt = &now
+	case MembershipRevoked:
+		m.RevokedAt = &now
+	}
+	if err := c.storage.UpdateProjectMembership(ctx, m); err != nil {
+		return nil, fmt.Errorf("failed to update membership: %w", err)
+	}
+
+	// Side effects on the role grant.
+	switch to {
+	case MembershipActive:
+		if err := c.AddProjectMember(ctx, m.ProjectID, m.UserID, m.Role); err != nil {
+			return nil, fmt.Errorf("failed to grant role on activation: %w", err)
+		}
+	case MembershipRevoked:
+		// Best-effort: the membership is already revoked; a missing grant is fine.
+		_ = c.RemoveProjectMember(ctx, m.ProjectID, m.UserID)
+	}
+
+	c.logMembershipEvent(ctx, "membership."+transitionVerb(to), m, actorID)
+	return m, nil
+}
+
+// (helpers below)
+
+// transitionVerb maps a target state to the audit event suffix.
+func transitionVerb(to string) string {
+	switch to {
+	case MembershipIdentityVerified:
+		return "identity_verified"
+	case MembershipProvisioned:
+		return "provisioned"
+	case MembershipActive:
+		return "activated"
+	case MembershipRevoked:
+		return "revoked"
+	default:
+		return to
+	}
+}
+
+// ListProjectMemberships returns all membership rows for a project.
+func (c *KeyorixCore) ListProjectMemberships(ctx context.Context, projectID uint) ([]*models.ProjectMembership, error) {
+	return c.storage.ListProjectMemberships(ctx, projectID)
+}
+
+// StaleInvites returns memberships still in `invited` state older than the cutoff
+// (ADR-022 stale-invite warnings; default surfaced at >7 days).
+func (c *KeyorixCore) StaleInvites(ctx context.Context, olderThan time.Duration) ([]*models.ProjectMembership, error) {
+	before := c.now().Add(-olderThan)
+	return c.storage.ListStaleInvitedMemberships(ctx, before)
+}
+
+// logMembershipEvent writes an audit event for a membership transition.
+func (c *KeyorixCore) logMembershipEvent(ctx context.Context, eventType string, m *models.ProjectMembership, actorID uint) {
+	aid, pid := actorID, m.ProjectID
+	c.writeAuditEventFull(ctx, eventType, &aid, nil, &pid, "",
+		fmt.Sprintf("membership %d for user %d in project %d → %s", m.ID, m.UserID, m.ProjectID, m.State))
+}

--- a/internal/core/membership_lifecycle_test.go
+++ b/internal/core/membership_lifecycle_test.go
@@ -1,0 +1,180 @@
+package core
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func newMembershipCore(store *MockStorage) *KeyorixCore {
+	fixed := time.Date(2026, 6, 4, 12, 0, 0, 0, time.UTC)
+	c := &KeyorixCore{storage: store, now: func() time.Time { return fixed }}
+	return c
+}
+
+func TestCanTransition(t *testing.T) {
+	valid := [][2]string{
+		{MembershipInvited, MembershipIdentityVerified},
+		{MembershipIdentityVerified, MembershipProvisioned},
+		{MembershipProvisioned, MembershipActive},
+		{MembershipInvited, MembershipRevoked},
+		{MembershipActive, MembershipRevoked},
+	}
+	for _, tc := range valid {
+		assert.True(t, canTransition(tc[0], tc[1]), "%s→%s should be allowed", tc[0], tc[1])
+	}
+	invalid := [][2]string{
+		{MembershipInvited, MembershipProvisioned}, // can't skip
+		{MembershipInvited, MembershipActive},
+		{MembershipRevoked, MembershipInvited}, // terminal
+		{MembershipRevoked, MembershipActive},
+		{MembershipActive, MembershipProvisioned}, // no going back
+	}
+	for _, tc := range invalid {
+		assert.False(t, canTransition(tc[0], tc[1]), "%s→%s should be rejected", tc[0], tc[1])
+	}
+}
+
+func TestInitialMembershipState(t *testing.T) {
+	c := &KeyorixCore{}
+	c.membershipValidationMode = ValidationModeOpen
+	assert.Equal(t, MembershipActive, c.initialMembershipState(false))
+
+	c.membershipValidationMode = ValidationModeAllowlist
+	assert.Equal(t, MembershipInvited, c.initialMembershipState(true))
+
+	c.membershipValidationMode = ValidationModeIDP
+	assert.Equal(t, MembershipProvisioned, c.initialMembershipState(true), "idp-resolved skips early states")
+	assert.Equal(t, MembershipInvited, c.initialMembershipState(false), "non-idp starts invited")
+
+	c.membershipValidationMode = "" // default
+	assert.Equal(t, MembershipInvited, c.initialMembershipState(false))
+}
+
+func TestInviteMember_AllowlistStartsInvited(t *testing.T) {
+	store := new(MockStorage)
+	c := newMembershipCore(store)
+	c.membershipValidationMode = ValidationModeAllowlist
+	ctx := context.Background()
+
+	store.On("GetRoleByName", ctx, "project_developer").Return(&models.Role{ID: 5, Name: "project_developer"}, nil)
+	store.On("GetActiveProjectMembership", ctx, uint(1), uint(2)).Return(nil, fmt.Errorf("not found"))
+	store.On("CreateProjectMembership", ctx, mock.MatchedBy(func(m *models.ProjectMembership) bool {
+		return m.State == MembershipInvited && m.ProjectID == 1 && m.UserID == 2 && m.InvitedBy == 9
+	})).Return(&models.ProjectMembership{ID: 50, ProjectID: 1, UserID: 2, State: MembershipInvited}, nil)
+	store.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
+
+	m, err := c.InviteMember(ctx, 1, 2, "project_developer", 9, false)
+	require.NoError(t, err)
+	assert.Equal(t, MembershipInvited, m.State)
+	// No role granted yet in allowlist mode.
+	store.AssertNotCalled(t, "AssignRole", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestInviteMember_OpenGrantsRoleImmediately(t *testing.T) {
+	store := new(MockStorage)
+	c := newMembershipCore(store)
+	c.membershipValidationMode = ValidationModeOpen
+	ctx := context.Background()
+
+	store.On("GetRoleByName", ctx, "project_developer").Return(&models.Role{ID: 5, Name: "project_developer"}, nil)
+	store.On("GetActiveProjectMembership", ctx, uint(1), uint(2)).Return(nil, fmt.Errorf("not found"))
+	store.On("CreateProjectMembership", ctx, mock.MatchedBy(func(m *models.ProjectMembership) bool {
+		return m.State == MembershipActive && m.ActivatedAt != nil
+	})).Return(&models.ProjectMembership{ID: 51, ProjectID: 1, UserID: 2, Role: "project_developer", State: MembershipActive}, nil)
+	// Active → role granted: AddProjectMember resolves the role and assigns it.
+	store.On("AssignRole", ctx, uint(2), uint(5), storage.Scope{ProjectID: 1}).Return(nil)
+	store.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
+
+	m, err := c.InviteMember(ctx, 1, 2, "project_developer", 9, false)
+	require.NoError(t, err)
+	assert.Equal(t, MembershipActive, m.State)
+	store.AssertCalled(t, "AssignRole", ctx, uint(2), uint(5), storage.Scope{ProjectID: 1})
+}
+
+func TestInviteMember_RejectsDuplicate(t *testing.T) {
+	store := new(MockStorage)
+	c := newMembershipCore(store)
+	ctx := context.Background()
+	store.On("GetRoleByName", ctx, "project_viewer").Return(&models.Role{ID: 6, Name: "project_viewer"}, nil)
+	store.On("GetActiveProjectMembership", ctx, uint(1), uint(2)).
+		Return(&models.ProjectMembership{ID: 1, State: MembershipActive}, nil)
+
+	_, err := c.InviteMember(ctx, 1, 2, "project_viewer", 9, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already has")
+	store.AssertNotCalled(t, "CreateProjectMembership", mock.Anything, mock.Anything)
+}
+
+func TestTransitionMembership_RejectsIllegalJump(t *testing.T) {
+	store := new(MockStorage)
+	c := newMembershipCore(store)
+	ctx := context.Background()
+	store.On("GetProjectMembership", ctx, uint(50)).
+		Return(&models.ProjectMembership{ID: 50, State: MembershipInvited}, nil)
+
+	_, err := c.TransitionMembership(ctx, 50, MembershipActive, 9)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot transition")
+	store.AssertNotCalled(t, "UpdateProjectMembership", mock.Anything, mock.Anything)
+}
+
+func TestTransitionMembership_ActivateGrantsRole(t *testing.T) {
+	store := new(MockStorage)
+	c := newMembershipCore(store)
+	ctx := context.Background()
+	m := &models.ProjectMembership{ID: 50, ProjectID: 1, UserID: 2, Role: "project_developer", State: MembershipProvisioned}
+	store.On("GetProjectMembership", ctx, uint(50)).Return(m, nil)
+	store.On("UpdateProjectMembership", ctx, mock.MatchedBy(func(x *models.ProjectMembership) bool {
+		return x.State == MembershipActive && x.ActivatedAt != nil
+	})).Return(nil)
+	store.On("GetRoleByName", ctx, "project_developer").Return(&models.Role{ID: 5}, nil)
+	store.On("AssignRole", ctx, uint(2), uint(5), storage.Scope{ProjectID: 1}).Return(nil)
+	store.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
+
+	out, err := c.TransitionMembership(ctx, 50, MembershipActive, 9)
+	require.NoError(t, err)
+	assert.Equal(t, MembershipActive, out.State)
+	store.AssertCalled(t, "AssignRole", ctx, uint(2), uint(5), storage.Scope{ProjectID: 1})
+}
+
+func TestTransitionMembership_RevokeRemovesRole(t *testing.T) {
+	store := new(MockStorage)
+	c := newMembershipCore(store)
+	ctx := context.Background()
+	m := &models.ProjectMembership{ID: 50, ProjectID: 1, UserID: 2, State: MembershipActive}
+	store.On("GetProjectMembership", ctx, uint(50)).Return(m, nil)
+	store.On("UpdateProjectMembership", ctx, mock.MatchedBy(func(x *models.ProjectMembership) bool {
+		return x.State == MembershipRevoked && x.RevokedAt != nil
+	})).Return(nil)
+	// RemoveProjectMember resolves and drops the role grant (best-effort).
+	store.On("GetUserRoleIDsExact", ctx, uint(2), storage.Scope{ProjectID: 1}).Return([]uint{5}, nil)
+	store.On("RemoveRole", ctx, uint(2), uint(5), storage.Scope{ProjectID: 1}).Return(nil)
+	store.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
+
+	out, err := c.TransitionMembership(ctx, 50, MembershipRevoked, 9)
+	require.NoError(t, err)
+	assert.Equal(t, MembershipRevoked, out.State)
+	store.AssertCalled(t, "RemoveRole", ctx, uint(2), uint(5), storage.Scope{ProjectID: 1})
+}
+
+func TestStaleInvites_PassesCutoff(t *testing.T) {
+	store := new(MockStorage)
+	c := newMembershipCore(store)
+	ctx := context.Background()
+	want := c.now().Add(-7 * 24 * time.Hour)
+	store.On("ListStaleInvitedMemberships", ctx, want).
+		Return([]*models.ProjectMembership{{ID: 1, State: MembershipInvited}}, nil)
+
+	out, err := c.StaleInvites(ctx, 7*24*time.Hour)
+	require.NoError(t, err)
+	assert.Len(t, out, 1)
+	store.AssertCalled(t, "ListStaleInvitedMemberships", ctx, want)
+}

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -872,3 +872,49 @@ func (m *MockStorage) ListMachineIdentities(ctx context.Context, projectID uint)
 	}
 	return args.Get(0).([]*models.MachineIdentity), args.Error(1)
 }
+
+// Project membership lifecycle (ADR-022).
+func (m *MockStorage) CreateProjectMembership(ctx context.Context, pm *models.ProjectMembership) (*models.ProjectMembership, error) {
+	args := m.Called(ctx, pm)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.ProjectMembership), args.Error(1)
+}
+
+func (m *MockStorage) GetProjectMembership(ctx context.Context, id uint) (*models.ProjectMembership, error) {
+	args := m.Called(ctx, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.ProjectMembership), args.Error(1)
+}
+
+func (m *MockStorage) UpdateProjectMembership(ctx context.Context, pm *models.ProjectMembership) error {
+	args := m.Called(ctx, pm)
+	return args.Error(0)
+}
+
+func (m *MockStorage) ListProjectMemberships(ctx context.Context, projectID uint) ([]*models.ProjectMembership, error) {
+	args := m.Called(ctx, projectID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*models.ProjectMembership), args.Error(1)
+}
+
+func (m *MockStorage) GetActiveProjectMembership(ctx context.Context, projectID, userID uint) (*models.ProjectMembership, error) {
+	args := m.Called(ctx, projectID, userID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.ProjectMembership), args.Error(1)
+}
+
+func (m *MockStorage) ListStaleInvitedMemberships(ctx context.Context, before time.Time) ([]*models.ProjectMembership, error) {
+	args := m.Called(ctx, before)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*models.ProjectMembership), args.Error(1)
+}

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -27,6 +27,9 @@ type KeyorixCore struct {
 	now            func() time.Time // For testability
 	passwordPolicy PasswordPolicy
 	auditForwarder AuditForwarder
+	// membershipValidationMode is the ADR-022 install-level onboarding mode;
+	// "" = allowlist default. Set via SetMembershipValidationMode.
+	membershipValidationMode string
 }
 
 // AuditForwarder ships persisted audit events to an external sink (e.g. a SIEM).

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -45,6 +45,18 @@ type Storage interface {
 	UpdateMachineIdentity(ctx context.Context, m *models.MachineIdentity) error
 	ListMachineIdentities(ctx context.Context, projectID uint) ([]*models.MachineIdentity, error)
 
+	// Project membership lifecycle (ADR-022). Separate from the role grant.
+	CreateProjectMembership(ctx context.Context, m *models.ProjectMembership) (*models.ProjectMembership, error)
+	GetProjectMembership(ctx context.Context, id uint) (*models.ProjectMembership, error)
+	UpdateProjectMembership(ctx context.Context, m *models.ProjectMembership) error
+	ListProjectMemberships(ctx context.Context, projectID uint) ([]*models.ProjectMembership, error)
+	// GetActiveProjectMembership returns the user's non-revoked membership in a
+	// project, or an error if none exists.
+	GetActiveProjectMembership(ctx context.Context, projectID, userID uint) (*models.ProjectMembership, error)
+	// ListStaleInvitedMemberships returns memberships still in `invited` state
+	// that were invited before the cutoff.
+	ListStaleInvitedMemberships(ctx context.Context, before time.Time) ([]*models.ProjectMembership, error)
+
 	// Secret Management
 	CreateSecret(ctx context.Context, secret *models.SecretNode) (*models.SecretNode, error)
 	GetSecret(ctx context.Context, id uint) (*models.SecretNode, error)

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -228,6 +228,7 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 	accessReqExists := tableExists(db, "access_requests")
 	pwHistExists := tableExists(db, "password_histories")
 	machineExists := tableExists(db, "machine_identities")
+	membershipExists := tableExists(db, "project_memberships")
 
 	// Create rotation_policies if missing (additive, safe on existing DBs).
 	if !rotationExists {
@@ -266,6 +267,13 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 	if !machineExists {
 		if err := db.AutoMigrate(&models.MachineIdentity{}); err != nil {
 			return fmt.Errorf("failed to migrate machine_identities table: %w", err)
+		}
+	}
+
+	// Create project_memberships if missing (ADR-022 membership lifecycle, additive).
+	if !membershipExists {
+		if err := db.AutoMigrate(&models.ProjectMembership{}); err != nil {
+			return fmt.Errorf("failed to migrate project_memberships table: %w", err)
 		}
 	}
 

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -447,3 +447,24 @@ type MachineIdentity struct {
 	LastSeenAt   *time.Time
 	RevokedAt    *time.Time
 }
+
+// ProjectMembership tracks the onboarding lifecycle of a user into a project
+// (ADR-022), separate from the actual role grant (user_roles). It carries a
+// 5-state machine: invited → identity_verified → provisioned → active, with
+// revoked as a terminal state reachable from any non-terminal state. The role
+// grant is applied only when the membership reaches active.
+type ProjectMembership struct {
+	ID        uint `gorm:"primaryKey"`
+	ProjectID uint `gorm:"index"`
+	UserID    uint `gorm:"index"`
+	Role      string
+	State     string // invited | identity_verified | provisioned | active | revoked
+	// Uniqueness of a non-revoked membership per (project, user) is enforced in
+	// core (see InviteMember), not by a DB constraint — so a revoked membership
+	// can be followed by a fresh invite without a unique-index collision.
+	InvitedBy   uint
+	InvitedAt   time.Time
+	ActivatedAt *time.Time
+	RevokedAt   *time.Time
+	UpdatedAt   time.Time
+}

--- a/internal/storage/store/local_memberships.go
+++ b/internal/storage/store/local_memberships.go
@@ -1,0 +1,71 @@
+// local_memberships.go — project membership lifecycle persistence (ADR-022).
+//
+// The ProjectMembership table tracks onboarding state, separate from the role
+// grant in user_roles. For the remote (HTTP) equivalent see remote_memberships.go.
+package store
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+func (ls *LocalStorage) CreateProjectMembership(ctx context.Context, m *models.ProjectMembership) (*models.ProjectMembership, error) {
+	if err := ls.db.WithContext(ctx).Create(m).Error; err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	return m, nil
+}
+
+func (ls *LocalStorage) GetProjectMembership(ctx context.Context, id uint) (*models.ProjectMembership, error) {
+	var m models.ProjectMembership
+	if err := ls.db.WithContext(ctx).First(&m, id).Error; err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorNotFound", nil), err)
+	}
+	return &m, nil
+}
+
+func (ls *LocalStorage) UpdateProjectMembership(ctx context.Context, m *models.ProjectMembership) error {
+	if err := ls.db.WithContext(ctx).Save(m).Error; err != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	return nil
+}
+
+func (ls *LocalStorage) ListProjectMemberships(ctx context.Context, projectID uint) ([]*models.ProjectMembership, error) {
+	var rows []*models.ProjectMembership
+	err := ls.db.WithContext(ctx).
+		Where("project_id = ?", projectID).
+		Order("invited_at DESC").
+		Find(&rows).Error
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	return rows, nil
+}
+
+func (ls *LocalStorage) GetActiveProjectMembership(ctx context.Context, projectID, userID uint) (*models.ProjectMembership, error) {
+	var m models.ProjectMembership
+	err := ls.db.WithContext(ctx).
+		Where("project_id = ? AND user_id = ? AND state <> ?", projectID, userID, "revoked").
+		First(&m).Error
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorNotFound", nil), err)
+	}
+	return &m, nil
+}
+
+func (ls *LocalStorage) ListStaleInvitedMemberships(ctx context.Context, before time.Time) ([]*models.ProjectMembership, error) {
+	var rows []*models.ProjectMembership
+	err := ls.db.WithContext(ctx).
+		Where("state = ? AND invited_at < ?", "invited", before).
+		Order("invited_at ASC").
+		Find(&rows).Error
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	return rows, nil
+}

--- a/internal/storage/store/memberships_test.go
+++ b/internal/storage/store/memberships_test.go
@@ -1,0 +1,85 @@
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func newMembershipStore(t *testing.T) *LocalStorage {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.ProjectMembership{}))
+	return NewLocalStorage(db)
+}
+
+func TestProjectMembership_RoundTrip(t *testing.T) {
+	ctx := context.Background()
+	ls := newMembershipStore(t)
+	now := time.Date(2026, 6, 4, 9, 0, 0, 0, time.UTC)
+
+	created, err := ls.CreateProjectMembership(ctx, &models.ProjectMembership{
+		ProjectID: 1, UserID: 2, Role: "project_developer",
+		State: "invited", InvitedBy: 9, InvitedAt: now, UpdatedAt: now,
+	})
+	require.NoError(t, err)
+	require.NotZero(t, created.ID)
+
+	// Get + update through a transition.
+	got, err := ls.GetProjectMembership(ctx, created.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "invited", got.State)
+
+	got.State = "active"
+	require.NoError(t, ls.UpdateProjectMembership(ctx, got))
+	reloaded, err := ls.GetProjectMembership(ctx, created.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "active", reloaded.State)
+
+	// Active membership is the non-revoked one for (project, user).
+	active, err := ls.GetActiveProjectMembership(ctx, 1, 2)
+	require.NoError(t, err)
+	assert.Equal(t, created.ID, active.ID)
+}
+
+func TestGetActiveProjectMembership_IgnoresRevoked(t *testing.T) {
+	ctx := context.Background()
+	ls := newMembershipStore(t)
+	now := time.Now().UTC()
+	_, err := ls.CreateProjectMembership(ctx, &models.ProjectMembership{
+		ProjectID: 1, UserID: 2, State: "revoked", InvitedAt: now, UpdatedAt: now,
+	})
+	require.NoError(t, err)
+
+	_, err = ls.GetActiveProjectMembership(ctx, 1, 2)
+	assert.Error(t, err, "a revoked membership must not count as active")
+}
+
+func TestListStaleInvitedMemberships(t *testing.T) {
+	ctx := context.Background()
+	ls := newMembershipStore(t)
+	now := time.Date(2026, 6, 4, 9, 0, 0, 0, time.UTC)
+
+	mk := func(state string, invitedAt time.Time) {
+		_, err := ls.CreateProjectMembership(ctx, &models.ProjectMembership{
+			ProjectID: 1, UserID: 2, State: state, InvitedAt: invitedAt, UpdatedAt: invitedAt,
+		})
+		require.NoError(t, err)
+	}
+	mk("invited", now.Add(-10*24*time.Hour)) // stale
+	mk("invited", now.Add(-1*time.Hour))     // fresh
+	mk("active", now.Add(-30*24*time.Hour))  // old but not invited
+
+	cutoff := now.Add(-7 * 24 * time.Hour)
+	stale, err := ls.ListStaleInvitedMemberships(ctx, cutoff)
+	require.NoError(t, err)
+	require.Len(t, stale, 1, "only the old invited membership is stale")
+	assert.Equal(t, "invited", stale[0].State)
+}

--- a/internal/storage/store/remote_memberships.go
+++ b/internal/storage/store/remote_memberships.go
@@ -1,0 +1,37 @@
+// remote_memberships.go — project membership lifecycle for RemoteStorage.
+//
+// Membership lifecycle is processed server-side in remote mode; these are stubs.
+// For the local (GORM) equivalent see local_memberships.go.
+package store
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+func (rs *RemoteStorage) CreateProjectMembership(_ context.Context, _ *models.ProjectMembership) (*models.ProjectMembership, error) {
+	return nil, fmt.Errorf("CreateProjectMembership not implemented for remote storage")
+}
+
+func (rs *RemoteStorage) GetProjectMembership(_ context.Context, _ uint) (*models.ProjectMembership, error) {
+	return nil, fmt.Errorf("GetProjectMembership not implemented for remote storage")
+}
+
+func (rs *RemoteStorage) UpdateProjectMembership(_ context.Context, _ *models.ProjectMembership) error {
+	return fmt.Errorf("UpdateProjectMembership not implemented for remote storage")
+}
+
+func (rs *RemoteStorage) ListProjectMemberships(_ context.Context, _ uint) ([]*models.ProjectMembership, error) {
+	return nil, fmt.Errorf("ListProjectMemberships not implemented for remote storage")
+}
+
+func (rs *RemoteStorage) GetActiveProjectMembership(_ context.Context, _, _ uint) (*models.ProjectMembership, error) {
+	return nil, fmt.Errorf("GetActiveProjectMembership not implemented for remote storage")
+}
+
+func (rs *RemoteStorage) ListStaleInvitedMemberships(_ context.Context, _ time.Time) ([]*models.ProjectMembership, error) {
+	return nil, fmt.Errorf("ListStaleInvitedMemberships not implemented for remote storage")
+}

--- a/server/http/handlers/project_memberships.go
+++ b/server/http/handlers/project_memberships.go
@@ -1,0 +1,151 @@
+// project_memberships.go — project membership lifecycle endpoints (ADR-022).
+//
+// These drive the onboarding state machine (invited → identity_verified →
+// provisioned → active, revoked terminal), separate from the role-grant
+// endpoints in project_members.go. All are project-scoped and gated by
+// roles.assign at the project scope (so a project_admin can run onboarding).
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/server/middleware"
+)
+
+// staleInviteThreshold is when an unaccepted invite is surfaced as stale (ADR-022).
+const staleInviteThreshold = 7 * 24 * time.Hour
+
+// ListProjectMemberships handles GET /api/v1/projects/{id}/memberships.
+// With ?stale=true it returns only invited memberships older than 7 days.
+func (h *CatalogHandler) ListProjectMemberships(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		sendError(w, "InvalidParameter", "Invalid project ID", http.StatusBadRequest, nil)
+		return
+	}
+	if r.URL.Query().Get("stale") == "true" {
+		all, err := h.coreService.StaleInvites(r.Context(), staleInviteThreshold)
+		if err != nil {
+			sendError(w, "Error", err.Error(), http.StatusInternalServerError, nil)
+			return
+		}
+		// StaleInvites is install-wide; narrow to this project for the endpoint.
+		stale := make([]interface{}, 0, len(all))
+		for _, m := range all {
+			if m.ProjectID == uint(id) {
+				stale = append(stale, m)
+			}
+		}
+		sendSuccess(w, map[string]interface{}{"memberships": stale}, "")
+		return
+	}
+	memberships, err := h.coreService.ListProjectMemberships(r.Context(), uint(id))
+	if err != nil {
+		sendError(w, "Error", err.Error(), http.StatusInternalServerError, nil)
+		return
+	}
+	sendSuccess(w, map[string]interface{}{"memberships": memberships}, "")
+}
+
+// InviteMember handles POST /api/v1/projects/{id}/memberships.
+func (h *CatalogHandler) InviteMember(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		sendError(w, "InvalidParameter", "Invalid project ID", http.StatusBadRequest, nil)
+		return
+	}
+	actor := middleware.GetUserFromContext(r.Context())
+	if actor == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	var body struct {
+		UserID      uint   `json:"user_id"`
+		Role        string `json:"role"`
+		IDPResolved bool   `json:"idp_resolved"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		sendError(w, "InvalidJSON", "Invalid request body", http.StatusBadRequest, nil)
+		return
+	}
+	if body.UserID == 0 || body.Role == "" {
+		sendError(w, "ValidationError", "user_id and role are required", http.StatusBadRequest, nil)
+		return
+	}
+	m, err := h.coreService.InviteMember(r.Context(), uint(id), body.UserID, body.Role, actor.UserID, body.IDPResolved)
+	if err != nil {
+		status := http.StatusInternalServerError
+		switch {
+		case strings.Contains(err.Error(), "already has"):
+			status = http.StatusConflict
+		case strings.Contains(err.Error(), "unknown role"), strings.Contains(err.Error(), "required"):
+			status = http.StatusBadRequest
+		}
+		sendError(w, "Error", err.Error(), status, nil)
+		return
+	}
+	w.WriteHeader(http.StatusCreated)
+	sendSuccess(w, map[string]interface{}{"membership": m}, "Member invited")
+}
+
+// TransitionMembership handles PUT /api/v1/projects/{id}/memberships/{membershipId}.
+// Body: {"action": "verify" | "provision" | "activate" | "revoke"}.
+func (h *CatalogHandler) TransitionMembership(w http.ResponseWriter, r *http.Request) {
+	membershipID, err := strconv.ParseUint(chi.URLParam(r, "membershipId"), 10, 32)
+	if err != nil {
+		sendError(w, "InvalidParameter", "Invalid membership ID", http.StatusBadRequest, nil)
+		return
+	}
+	actor := middleware.GetUserFromContext(r.Context())
+	if actor == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	var body struct {
+		Action string `json:"action"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		sendError(w, "InvalidJSON", "Invalid request body", http.StatusBadRequest, nil)
+		return
+	}
+	to, ok := membershipActionState(body.Action)
+	if !ok {
+		sendError(w, "ValidationError", "action must be verify, provision, activate, or revoke", http.StatusBadRequest, nil)
+		return
+	}
+	m, err := h.coreService.TransitionMembership(r.Context(), uint(membershipID), to, actor.UserID)
+	if err != nil {
+		status := http.StatusInternalServerError
+		switch {
+		case strings.Contains(err.Error(), "not found"):
+			status = http.StatusNotFound
+		case strings.Contains(err.Error(), "cannot transition"):
+			status = http.StatusConflict
+		}
+		sendError(w, "Error", err.Error(), status, nil)
+		return
+	}
+	sendSuccess(w, map[string]interface{}{"membership": m}, "Membership updated")
+}
+
+// membershipActionState maps a request action verb to its target state.
+func membershipActionState(action string) (string, bool) {
+	switch action {
+	case "verify":
+		return core.MembershipIdentityVerified, true
+	case "provision":
+		return core.MembershipProvisioned, true
+	case "activate":
+		return core.MembershipActive, true
+	case "revoke":
+		return core.MembershipRevoked, true
+	default:
+		return "", false
+	}
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -157,6 +157,11 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		r.With(customMiddleware.RequireScopedPermission("roles.assign", projectScope)).Post("/projects/{id}/members", catalogHandler.AddProjectMember)
 		r.With(customMiddleware.RequireScopedPermission("roles.assign", projectScope)).Put("/projects/{id}/members/{userId}", catalogHandler.UpdateProjectMember)
 		r.With(customMiddleware.RequireScopedPermission("roles.assign", projectScope)).Delete("/projects/{id}/members/{userId}", catalogHandler.RemoveProjectMember)
+		// Membership lifecycle (ADR-022): onboarding state machine, separate from
+		// the role grant above. List is project-read; mutations need roles.assign.
+		r.With(customMiddleware.RequireScopedPermission("users.read", projectScope)).Get("/projects/{id}/memberships", catalogHandler.ListProjectMemberships)
+		r.With(customMiddleware.RequireScopedPermission("roles.assign", projectScope)).Post("/projects/{id}/memberships", catalogHandler.InviteMember)
+		r.With(customMiddleware.RequireScopedPermission("roles.assign", projectScope)).Put("/projects/{id}/memberships/{membershipId}", catalogHandler.TransitionMembership)
 		// Invitations (ADR-024): admin-driven (roles.assign at the project scope).
 		r.With(customMiddleware.RequireScopedPermission("users.read", projectScope)).Get("/projects/{id}/invitations", catalogHandler.ListInvitations)
 		r.With(customMiddleware.RequireScopedPermission("roles.assign", projectScope)).Post("/projects/{id}/invitations", catalogHandler.CreateInvitation)

--- a/server/main.go
+++ b/server/main.go
@@ -210,6 +210,11 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 		coreService.SetAuditForwarder(forwarder)
 		log.Printf("SIEM audit forwarding enabled (provider=%s)", sc.Provider)
 	}
+
+	// Apply the project membership validation mode (ADR-022). Empty = allowlist.
+	if vm := cfg.Membership.ValidationMode; vm != "" {
+		coreService.SetMembershipValidationMode(vm)
+	}
 	return coreService, encSvc, nil
 }
 


### PR DESCRIPTION
ADR-022 onboarding lifecycle as a `project_memberships` table, separate from the ADR-021 role grant (`user_roles`).

5-state machine: `invited → identity_verified → provisioned → active` (revoked terminal, reachable from any non-terminal). The project role is granted only when a membership reaches `active`, dropped on revoke — so the lifecycle gates real access and the role-assignment path stays the enforcement boundary.

Validation modes (`membership.validation_mode`): **open** (active immediately), **allowlist** (admin steps each state, default), **idp** (IdP-resolved users skip early states).

- Core: transition table + guard; `InviteMember` (mode-aware initial state, dup-non-revoked rejection); `TransitionMembership` (grants/removes role on activate/revoke); `StaleInvites` (>cutoff). Discrete `membership.*` audit event per transition.
- Storage: 6 interface methods, local GORM impl, remote stubs, mock. Additive pgx-safe table create; non-revoked uniqueness enforced in core so re-invite after revoke works.
- HTTP (project-scoped): `GET/POST /projects/{id}/memberships`, `PUT /projects/{id}/memberships/{membershipId}` (action: verify/provision/activate/revoke), `?stale=true`.

Tests: full transition table + illegal jumps + terminal, initial-state per mode, invite allowlist/open/dup, transition activate-grants/revoke-removes/illegal, stale cutoff (mock core); store round-trip + ignores-revoked + stale window (SQLite). Full gate green.

**Deferred (ADR-022/024):** inviter notifications, invitation email/setup-link flow, deeper IdP resolution, Members-tab frontend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)