### PR TITLE
feat(account): ADR-025 account state machine + restricted-session login gate

### DIFF
--- a/internal/core/account.go
+++ b/internal/core/account.go
@@ -65,6 +65,9 @@ func (c *KeyorixCore) ChangePassword(ctx context.Context, userID uint, current, 
 	now := c.now()
 	user.PasswordHash = string(hash)
 	user.PasswordChangedAt = &now
+	// A successful password change clears a restricted account back to active
+	// (ADR-025): pending_first_login / password_reset_required are satisfied.
+	user.AccountState = clearRestrictionOnPasswordChange(user.AccountState)
 	user.UpdatedAt = now
 	if _, err := c.storage.UpdateUser(ctx, user); err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)

--- a/internal/core/account_state.go
+++ b/internal/core/account_state.go
@@ -1,0 +1,100 @@
+// account_state.go — user account lifecycle state machine (ADR-025).
+//
+// States:
+//
+//	active                    — normal; full access.
+//	pending_first_login       — provisioned by an admin; must set a password
+//	                            before doing anything else (restricted session).
+//	password_reset_required   — admin forced a reset; restricted until changed.
+//	suspended                 — login is refused entirely.
+//
+// A "restricted" session (pending_first_login / password_reset_required)
+// authenticates but the auth middleware blocks every endpoint except the
+// password-change / profile allowlist, returning 403 so the client redirects to
+// change-password. Completing a password change clears the restriction back to
+// active. Admin transitions are audited.
+package core
+
+import (
+	"context"
+	"fmt"
+)
+
+// Account states.
+const (
+	AccountActive                = "active"
+	AccountPendingFirstLogin     = "pending_first_login"
+	AccountPasswordResetRequired = "password_reset_required"
+	AccountSuspended             = "suspended"
+)
+
+// NormalizeAccountState maps the empty legacy value to active.
+func NormalizeAccountState(state string) string {
+	if state == "" {
+		return AccountActive
+	}
+	return state
+}
+
+// AccountRestricted reports whether a state forces a password change before the
+// user may use any non-allowlisted endpoint.
+func AccountRestricted(state string) bool {
+	switch NormalizeAccountState(state) {
+	case AccountPendingFirstLogin, AccountPasswordResetRequired:
+		return true
+	default:
+		return false
+	}
+}
+
+// AccountLoginBlocked reports whether a state refuses login outright.
+func AccountLoginBlocked(state string) bool {
+	return NormalizeAccountState(state) == AccountSuspended
+}
+
+// SuspendUser blocks a user's login. Admin action; audited. The bootstrap/admin
+// caller is responsible for not suspending themselves into a lockout.
+func (c *KeyorixCore) SuspendUser(ctx context.Context, adminID, userID uint) error {
+	return c.setAccountState(ctx, adminID, userID, AccountSuspended, "account.suspended")
+}
+
+// ReactivateUser returns a suspended (or otherwise non-active) user to active.
+func (c *KeyorixCore) ReactivateUser(ctx context.Context, adminID, userID uint) error {
+	return c.setAccountState(ctx, adminID, userID, AccountActive, "account.reactivated")
+}
+
+// RequirePasswordReset forces the user into a restricted session until they
+// change their password. Admin action; audited.
+func (c *KeyorixCore) RequirePasswordReset(ctx context.Context, adminID, userID uint) error {
+	return c.setAccountState(ctx, adminID, userID, AccountPasswordResetRequired, "account.password_reset_required")
+}
+
+// setAccountState persists a new account state and writes an audit event.
+func (c *KeyorixCore) setAccountState(ctx context.Context, adminID, userID uint, state, eventType string) error {
+	if userID == 0 {
+		return fmt.Errorf("user ID is required")
+	}
+	user, err := c.storage.GetUser(ctx, userID)
+	if err != nil {
+		return fmt.Errorf("user not found: %w", err)
+	}
+	user.AccountState = state
+	user.UpdatedAt = c.now()
+	if _, err := c.storage.UpdateUser(ctx, user); err != nil {
+		return fmt.Errorf("failed to update account state: %w", err)
+	}
+	aid := adminID
+	c.writeAuditEventFull(ctx, eventType, &aid, nil, nil, "",
+		fmt.Sprintf("user %d account state set to %s", userID, state))
+	return nil
+}
+
+// clearRestrictionOnPasswordChange returns the account state a user should hold
+// after a successful password change: a restricted state clears to active; any
+// other state is left unchanged.
+func clearRestrictionOnPasswordChange(state string) string {
+	if AccountRestricted(state) {
+		return AccountActive
+	}
+	return NormalizeAccountState(state)
+}

--- a/internal/core/account_state_test.go
+++ b/internal/core/account_state_test.go
@@ -1,0 +1,103 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/bcrypt"
+)
+
+func TestAccountStateHelpers(t *testing.T) {
+	assert.Equal(t, AccountActive, NormalizeAccountState(""))
+	assert.Equal(t, AccountSuspended, NormalizeAccountState(AccountSuspended))
+
+	assert.True(t, AccountRestricted(AccountPendingFirstLogin))
+	assert.True(t, AccountRestricted(AccountPasswordResetRequired))
+	assert.False(t, AccountRestricted(AccountActive))
+	assert.False(t, AccountRestricted("")) // legacy → active
+
+	assert.True(t, AccountLoginBlocked(AccountSuspended))
+	assert.False(t, AccountLoginBlocked(AccountActive))
+
+	// A restricted state clears to active on password change; others unchanged.
+	assert.Equal(t, AccountActive, clearRestrictionOnPasswordChange(AccountPasswordResetRequired))
+	assert.Equal(t, AccountActive, clearRestrictionOnPasswordChange(AccountPendingFirstLogin))
+	assert.Equal(t, AccountSuspended, clearRestrictionOnPasswordChange(AccountSuspended))
+	assert.Equal(t, AccountActive, clearRestrictionOnPasswordChange(""))
+}
+
+func newAccountCore(store *MockStorage) *KeyorixCore {
+	fixed := time.Date(2026, 6, 5, 12, 0, 0, 0, time.UTC)
+	return &KeyorixCore{storage: store, now: func() time.Time { return fixed }, passwordPolicy: DefaultPasswordPolicy()}
+}
+
+func TestAdminAccountTransitions(t *testing.T) {
+	cases := []struct {
+		name      string
+		call      func(c *KeyorixCore, ctx context.Context) error
+		wantState string
+		event     string
+	}{
+		{"suspend", func(c *KeyorixCore, ctx context.Context) error { return c.SuspendUser(ctx, 1, 2) }, AccountSuspended, "account.suspended"},
+		{"reactivate", func(c *KeyorixCore, ctx context.Context) error { return c.ReactivateUser(ctx, 1, 2) }, AccountActive, "account.reactivated"},
+		{"require reset", func(c *KeyorixCore, ctx context.Context) error { return c.RequirePasswordReset(ctx, 1, 2) }, AccountPasswordResetRequired, "account.password_reset_required"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := new(MockStorage)
+			c := newAccountCore(store)
+			ctx := context.Background()
+			store.On("GetUser", ctx, uint(2)).Return(&models.User{ID: 2, AccountState: AccountActive}, nil)
+			store.On("UpdateUser", ctx, mock.MatchedBy(func(u *models.User) bool {
+				return u.AccountState == tc.wantState
+			})).Return(&models.User{ID: 2}, nil)
+			store.On("LogAuditEvent", ctx, mock.MatchedBy(func(e *models.AuditEvent) bool {
+				return e.EventType == tc.event
+			})).Return(nil)
+
+			require.NoError(t, tc.call(c, ctx))
+			store.AssertExpectations(t)
+		})
+	}
+}
+
+func TestLogin_BlocksSuspended(t *testing.T) {
+	store := new(MockStorage)
+	c := newAccountCore(store)
+	ctx := context.Background()
+	hash, _ := bcrypt.GenerateFromPassword([]byte("Secret#Passw0rd!"), bcrypt.DefaultCost)
+	store.On("GetUserByUsername", ctx, "bob").
+		Return(&models.User{ID: 2, Username: "bob", PasswordHash: string(hash), AccountState: AccountSuspended}, nil)
+
+	_, _, err := c.Login(ctx, &LoginRequest{Username: "bob", Password: "Secret#Passw0rd!"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "suspended")
+	store.AssertNotCalled(t, "CreateSession", mock.Anything, mock.Anything)
+}
+
+func TestChangePassword_ClearsRestriction(t *testing.T) {
+	store := new(MockStorage)
+	c := newAccountCore(store)
+	ctx := context.Background()
+	oldHash, _ := bcrypt.GenerateFromPassword([]byte("oldpassword"), bcrypt.DefaultCost)
+	user := &models.User{ID: 1, Username: "alice", PasswordHash: string(oldHash), AccountState: AccountPasswordResetRequired}
+
+	store.On("GetUser", ctx, uint(1)).Return(user, nil)
+	store.On("RecentPasswordHashes", ctx, uint(1), 5).Return([]string{}, nil)
+	store.On("UpdateUser", ctx, mock.MatchedBy(func(u *models.User) bool {
+		return u.AccountState == AccountActive // restriction cleared
+	})).Return(user, nil)
+	store.On("AddPasswordHistory", ctx, uint(1), mock.AnythingOfType("string"), mock.Anything).Return(nil)
+	store.On("PrunePasswordHistory", ctx, uint(1), 5).Return(nil)
+	store.On("GetSession", ctx, "tok").Return(&models.Session{ID: 7, UserID: 1}, nil)
+	store.On("DeleteSessionsForUserExcept", ctx, uint(1), uint(7)).Return(nil)
+
+	err := c.ChangePassword(ctx, 1, "oldpassword", "Brandnew#Passw0rd!", "tok")
+	require.NoError(t, err)
+	store.AssertExpectations(t)
+}

--- a/internal/core/auth.go
+++ b/internal/core/auth.go
@@ -34,6 +34,12 @@ func (c *KeyorixCore) Login(ctx context.Context, req *LoginRequest) (*models.Ses
 	if err := bcrypt.CompareHashAndPassword([]byte(user.PasswordHash), []byte(req.Password)); err != nil {
 		return nil, nil, fmt.Errorf("invalid credentials")
 	}
+	// A suspended account is refused login outright (ADR-025). Restricted states
+	// (pending_first_login / password_reset_required) still log in, but the auth
+	// middleware confines the session to the password-change allowlist.
+	if AccountLoginBlocked(user.AccountState) {
+		return nil, nil, fmt.Errorf("account suspended")
+	}
 	token, err := generateSecureToken()
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to generate session token: %w", err)

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -154,6 +154,11 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 		db.Exec("ALTER TABLE users ADD COLUMN password_changed_at TIMESTAMP WITH TIME ZONE")
 	}
 
+	// Account lifecycle state (ADR-025). Existing rows default to active.
+	if tableExists(db, "users") && !columnExists(db, "users", "account_state") {
+		db.Exec("ALTER TABLE users ADD COLUMN account_state TEXT NOT NULL DEFAULT 'active'")
+	}
+
 	// Enrich sessions for the My Account "active sessions" view (device/IP/last-active).
 	if tableExists(db, "sessions") {
 		if !columnExists(db, "sessions", "user_agent") {

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -71,9 +71,12 @@ type User struct {
 	// PasswordChangedAt is when the current password was set. Drives max-age
 	// expiry (ADR-025). nil on legacy rows = treat as set at account creation.
 	PasswordChangedAt *time.Time
-	CreatedAt         time.Time
-	UpdatedAt         time.Time
-	DeletedAt         gorm.DeletedAt `gorm:"index"` // soft delete — set by DELETE /users/{id}, cleared by restore
+	// AccountState is the ADR-025 lifecycle state: active | pending_first_login |
+	// password_reset_required | suspended. Empty (legacy rows) is treated as active.
+	AccountState string `gorm:"default:'active'"`
+	CreatedAt    time.Time
+	UpdatedAt    time.Time
+	DeletedAt    gorm.DeletedAt `gorm:"index"` // soft delete — set by DELETE /users/{id}, cleared by restore
 }
 
 // PasswordHistory records prior password hashes per user so the policy can

--- a/server/http/handlers/auth.go
+++ b/server/http/handlers/auth.go
@@ -80,8 +80,10 @@ type loginResponseBody struct {
 	Roles       []string `json:"roles"`       // all assigned role names
 	Permissions []string `json:"permissions"` // distinct permissions across roles
 	// PasswordChangeRequired is true when the password has exceeded the policy's
-	// max age (ADR-025 max_age_days) — the UI should route to change-password.
-	PasswordChangeRequired bool `json:"password_change_required,omitempty"`
+	// max age (ADR-025 max_age_days) or the account is in a restricted state — the
+	// UI should route to change-password.
+	PasswordChangeRequired bool   `json:"password_change_required,omitempty"`
+	AccountState           string `json:"account_state,omitempty"`
 }
 
 type passwordResetRequestBody struct {
@@ -147,7 +149,8 @@ func (h *AuthHandler) Login(w http.ResponseWriter, r *http.Request) {
 		resp.Role, resp.Roles, resp.Permissions = id.Role, id.Roles, id.Permissions
 	}
 	// Flag an expired password so the UI can require a change (ADR-025).
-	resp.PasswordChangeRequired = h.coreService.PasswordExpired(user)
+	resp.AccountState = core.NormalizeAccountState(user.AccountState)
+	resp.PasswordChangeRequired = h.coreService.PasswordExpired(user) || core.AccountRestricted(user.AccountState)
 
 	// Audit log + last-login stamp (both non-blocking)
 	ip, ua := r.RemoteAddr, r.Header.Get("User-Agent")
@@ -316,7 +319,8 @@ func (h *AuthHandler) ChangePassword(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err := h.coreService.ChangePassword(r.Context(), userCtx.UserID, body.CurrentPassword, body.NewPassword, extractBearerToken(r))
+	token := extractBearerToken(r)
+	err := h.coreService.ChangePassword(r.Context(), userCtx.UserID, body.CurrentPassword, body.NewPassword, token)
 	if err != nil {
 		if strings.Contains(err.Error(), "incorrect") {
 			sendError(w, "Unauthorized", "Current password is incorrect", http.StatusUnauthorized, nil)
@@ -325,6 +329,9 @@ func (h *AuthHandler) ChangePassword(w http.ResponseWriter, r *http.Request) {
 		sendError(w, "BadRequest", err.Error(), http.StatusBadRequest, nil)
 		return
 	}
+	// Evict the cached identity so a restriction cleared by this change (ADR-025)
+	// takes effect on the next request instead of lingering for the cache TTL.
+	middleware.InvalidateTokenCache(token)
 	sendSuccess(w, nil, "Password changed")
 }
 

--- a/server/http/handlers/users_crud.go
+++ b/server/http/handlers/users_crud.go
@@ -5,6 +5,7 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"log"
 	"net/http"
@@ -197,4 +198,48 @@ func (h *UserHandler) RestoreUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	sendSuccess(w, nil, "User restored successfully")
+}
+
+// accountStateAction is the shared handler body for the admin account-state
+// transitions (ADR-025). transition performs the state change.
+func (h *UserHandler) accountStateAction(w http.ResponseWriter, r *http.Request, okMessage string, transition func(ctx context.Context, adminID, userID uint) error) {
+	admin := middleware.GetUserFromContext(r.Context())
+	if admin == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		sendError(w, "InvalidParameter", "Invalid user ID", http.StatusBadRequest, nil)
+		return
+	}
+	// A global admin must not suspend / lock themselves out of admin access.
+	if uint(id) == admin.UserID {
+		sendError(w, "BadRequest", "Cannot change your own account state", http.StatusBadRequest, nil)
+		return
+	}
+	if err := transition(r.Context(), admin.UserID, uint(id)); err != nil {
+		status := http.StatusInternalServerError
+		if strings.Contains(err.Error(), "not found") {
+			status = http.StatusNotFound
+		}
+		sendError(w, "Error", err.Error(), status, nil)
+		return
+	}
+	sendSuccess(w, nil, okMessage)
+}
+
+// SuspendUser handles POST /api/v1/users/{id}/suspend.
+func (h *UserHandler) SuspendUser(w http.ResponseWriter, r *http.Request) {
+	h.accountStateAction(w, r, "User suspended", h.coreService.SuspendUser)
+}
+
+// ReactivateUser handles POST /api/v1/users/{id}/reactivate.
+func (h *UserHandler) ReactivateUser(w http.ResponseWriter, r *http.Request) {
+	h.accountStateAction(w, r, "User reactivated", h.coreService.ReactivateUser)
+}
+
+// RequirePasswordReset handles POST /api/v1/users/{id}/require-password-reset.
+func (h *UserHandler) RequirePasswordReset(w http.ResponseWriter, r *http.Request) {
+	h.accountStateAction(w, r, "Password reset required", h.coreService.RequirePasswordReset)
 }

--- a/server/http/handlers/users_handler.go
+++ b/server/http/handlers/users_handler.go
@@ -73,6 +73,7 @@ func userToAPIResponse(u *models.User) map[string]interface{} {
 		"email":         u.Email,
 		"display_name":  dn,
 		"active":        u.IsActive,
+		"account_state": core.NormalizeAccountState(u.AccountState),
 		"created_at":    u.CreatedAt.UTC().Format(time.RFC3339),
 		"updated_at":    u.UpdatedAt.UTC().Format(time.RFC3339),
 		"last_login_at": nil,
@@ -264,4 +265,31 @@ func RestoreUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	defaultUserHandler.RestoreUser(w, r)
+}
+
+// SuspendUser handles POST /api/v1/users/{id}/suspend (ADR-025).
+func SuspendUser(w http.ResponseWriter, r *http.Request) {
+	if defaultUserHandler == nil {
+		sendError(w, "ServiceUnavailable", "User handler not initialised", http.StatusServiceUnavailable, nil)
+		return
+	}
+	defaultUserHandler.SuspendUser(w, r)
+}
+
+// ReactivateUser handles POST /api/v1/users/{id}/reactivate (ADR-025).
+func ReactivateUser(w http.ResponseWriter, r *http.Request) {
+	if defaultUserHandler == nil {
+		sendError(w, "ServiceUnavailable", "User handler not initialised", http.StatusServiceUnavailable, nil)
+		return
+	}
+	defaultUserHandler.ReactivateUser(w, r)
+}
+
+// RequirePasswordReset handles POST /api/v1/users/{id}/require-password-reset (ADR-025).
+func RequirePasswordReset(w http.ResponseWriter, r *http.Request) {
+	if defaultUserHandler == nil {
+		sendError(w, "ServiceUnavailable", "User handler not initialised", http.StatusServiceUnavailable, nil)
+		return
+	}
+	defaultUserHandler.RequirePasswordReset(w, r)
 }

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -117,6 +117,9 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 	r.Route("/api/v1", func(r chi.Router) {
 		// Authentication middleware for API routes
 		r.Use(customMiddleware.Authentication(coreService))
+		// Confine restricted (must-change-password) sessions to the password-change
+		// allowlist (ADR-025).
+		r.Use(customMiddleware.EnforceAccountRestriction)
 
 		// Self-service account endpoints (My Account). Authenticated but not
 		// permission-gated — every user manages their own profile, password,
@@ -229,6 +232,10 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.Put("/{id}", handlers.UpdateUser)
 			r.Delete("/{id}", handlers.DeleteUser)
 			r.Post("/{id}/restore", handlers.RestoreUser)
+			// Account state transitions (ADR-025).
+			r.With(customMiddleware.RequirePermission("users.write")).Post("/{id}/suspend", handlers.SuspendUser)
+			r.With(customMiddleware.RequirePermission("users.write")).Post("/{id}/reactivate", handlers.ReactivateUser)
+			r.With(customMiddleware.RequirePermission("users.write")).Post("/{id}/require-password-reset", handlers.RequirePasswordReset)
 			r.Get("/{id}/roles", usersRolesHandler.GetUserRolesForUser)
 			r.Put("/{id}/roles", usersRolesHandler.UpdateUserRoles)
 		})

--- a/server/middleware/account_restriction_test.go
+++ b/server/middleware/account_restriction_test.go
@@ -1,0 +1,61 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEnforceAccountRestriction(t *testing.T) {
+	nextCalled := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := EnforceAccountRestriction(next)
+
+	run := func(userCtx *UserContext, path string) *httptest.ResponseRecorder {
+		nextCalled = false
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		if userCtx != nil {
+			req = req.WithContext(context.WithValue(req.Context(), userContextKey, userCtx))
+		}
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+		return rr
+	}
+
+	t.Run("unrestricted account passes through", func(t *testing.T) {
+		rr := run(&UserContext{UserID: 1, Restricted: false}, "/api/v1/secrets")
+		assert.Equal(t, http.StatusOK, rr.Code)
+		assert.True(t, nextCalled)
+	})
+
+	t.Run("restricted account is blocked on a normal endpoint", func(t *testing.T) {
+		rr := run(&UserContext{UserID: 1, Restricted: true}, "/api/v1/secrets")
+		assert.Equal(t, http.StatusForbidden, rr.Code)
+		assert.False(t, nextCalled)
+		assert.Contains(t, rr.Body.String(), "PasswordChangeRequired")
+	})
+
+	t.Run("restricted account may reach change-password", func(t *testing.T) {
+		rr := run(&UserContext{UserID: 1, Restricted: true}, "/api/v1/auth/change-password")
+		assert.Equal(t, http.StatusOK, rr.Code)
+		assert.True(t, nextCalled)
+	})
+
+	t.Run("restricted account may reach its profile", func(t *testing.T) {
+		rr := run(&UserContext{UserID: 1, Restricted: true}, "/api/v1/auth/profile")
+		assert.Equal(t, http.StatusOK, rr.Code)
+		assert.True(t, nextCalled)
+	})
+
+	t.Run("no user context passes through (auth handles it)", func(t *testing.T) {
+		rr := run(nil, "/api/v1/secrets")
+		assert.Equal(t, http.StatusOK, rr.Code)
+		assert.True(t, nextCalled)
+	})
+}

--- a/server/middleware/auth.go
+++ b/server/middleware/auth.go
@@ -45,6 +45,10 @@ type UserContext struct {
 	// session (nil otherwise). Cached with the rest of the identity, so a single
 	// per-token lookup decides it. Used to tag downstream audit events.
 	ImpersonatedBy *uint `json:"impersonated_by,omitempty"`
+	// AccountState is the ADR-025 lifecycle state; Restricted is true when the
+	// account must change its password before using non-allowlisted endpoints.
+	AccountState string `json:"account_state,omitempty"`
+	Restricted   bool   `json:"-"`
 }
 
 // contextKey is used for context keys to avoid collisions
@@ -240,6 +244,41 @@ func RequirePermission(permission string) func(next http.Handler) http.Handler {
 	return RequireScopedPermission(permission, ScopeGlobal)
 }
 
+// restrictedAllowedSuffixes are the only endpoints a restricted (must-change-
+// password) session may reach, beyond logout (registered at the root router).
+var restrictedAllowedSuffixes = []string{
+	"/auth/change-password",
+	"/auth/profile",
+}
+
+// EnforceAccountRestriction blocks a restricted account (ADR-025
+// pending_first_login / password_reset_required) from every endpoint except the
+// password-change allowlist, returning 403 with a PasswordChangeRequired code so
+// the client redirects to change-password. Applied inside the authenticated API
+// group, after Authentication has populated the user context.
+func EnforceAccountRestriction(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		userCtx := GetUserFromContext(r.Context())
+		if userCtx == nil || !userCtx.Restricted {
+			next.ServeHTTP(w, r)
+			return
+		}
+		for _, suffix := range restrictedAllowedSuffixes {
+			if strings.HasSuffix(r.URL.Path, suffix) {
+				next.ServeHTTP(w, r)
+				return
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"error":   "PasswordChangeRequired",
+			"message": "You must change your password before continuing.",
+			"code":    http.StatusForbidden,
+		})
+	})
+}
+
 // ScopeGlobal always resolves to the global scope.
 func ScopeGlobal(_ *http.Request, _ *core.KeyorixCore) (core.Scope, error) {
 	return core.Scope{}, nil
@@ -423,10 +462,12 @@ func validateToken(ctx context.Context, validator sessionValidator, token string
 		return nil, err
 	}
 	return &UserContext{
-		UserID:   user.ID,
-		Username: user.Username,
-		Email:    user.Email,
-		Roles:    roleNames,
+		UserID:       user.ID,
+		Username:     user.Username,
+		Email:        user.Email,
+		Roles:        roleNames,
+		AccountState: core.NormalizeAccountState(user.AccountState),
+		Restricted:   core.AccountRestricted(user.AccountState),
 	}, nil
 }
 


### PR DESCRIPTION
**Stacked on #10** (base is `feat/password-history-policy`; retarget to `main` after #10 merges).

Adds the account lifecycle + the hard login gate that #10's soft `password_change_required` flag stood in for.

States (`User.account_state`; legacy/empty = active): `active`, `pending_first_login`, `password_reset_required`, `suspended`.

- **Login gate** — suspended ⇒ login refused; restricted (pending_first_login / password_reset_required) ⇒ authenticates but `EnforceAccountRestriction` middleware confines the session to change-password + profile, else 403 `PasswordChangeRequired`. State resolved per token (cached with identity).
- **Clearing** — a successful `ChangePassword` flips restricted → active and evicts the token cache so it lifts immediately.
- **Admin transitions** — `POST /users/{id}/{suspend,reactivate,require-password-reset}` (users.write; self-target rejected), each audited.
- **Surfacing** — `account_state` on the user DTO + login response.

Additive `account_state` migration (existing rows → active). Tests: state helpers, admin transitions, Login-blocks-suspended, ChangePassword-clears-restriction, middleware gate per path/state. Full gate green.

**Deferred (ADR-025):** the admin direct-creation dialog + credential delivery (SMTP setup-link / out-of-band) that sets `pending_first_login` at provisioning — that onboarding flow isn't built yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)