### PR TITLE
feat(machine-identities): non-human project identities + lifecycle (ADR-023 foundation)

### DIFF
--- a/internal/core/machine_identities.go
+++ b/internal/core/machine_identities.go
@@ -1,0 +1,136 @@
+// machine_identities.go — non-human project identities and their lifecycle (ADR-023).
+//
+// A machine identity (CI runner, k8s workload, service, automation) is a
+// first-class project member kept separate from human users so the Members view
+// can segment the two. Lifecycle is a 4-state machine:
+//
+//	pending → active → suspended ⇄ active        (revoked is terminal, reachable
+//	                                              from any non-revoked state)
+//
+// `pending` is the credential-awaiting state for the (future) machine-token
+// issuance flow; identities created today start `active`. Every transition is
+// audited. Machine-token authentication itself is a deliberate follow-up.
+package core
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// Machine identity types.
+const (
+	MachineTypeCI         = "ci"
+	MachineTypeK8s        = "k8s"
+	MachineTypeService    = "service"
+	MachineTypeAutomation = "automation"
+	MachineTypeOther      = "other"
+)
+
+var validMachineTypes = map[string]struct{}{
+	MachineTypeCI: {}, MachineTypeK8s: {}, MachineTypeService: {},
+	MachineTypeAutomation: {}, MachineTypeOther: {},
+}
+
+// Machine identity states.
+const (
+	MachinePending   = "pending"
+	MachineActive    = "active"
+	MachineSuspended = "suspended"
+	MachineRevoked   = "revoked"
+)
+
+// machineTransitions lists allowed next states. revoked is terminal.
+var machineTransitions = map[string][]string{
+	MachinePending:   {MachineActive, MachineRevoked},
+	MachineActive:    {MachineSuspended, MachineRevoked},
+	MachineSuspended: {MachineActive, MachineRevoked},
+	MachineRevoked:   {},
+}
+
+func canTransitionMachine(from, to string) bool {
+	for _, next := range machineTransitions[from] {
+		if next == to {
+			return true
+		}
+	}
+	return false
+}
+
+// CreateMachineIdentity creates an active machine identity in a project.
+func (c *KeyorixCore) CreateMachineIdentity(ctx context.Context, projectID uint, name, identityType, description string, createdBy uint) (*models.MachineIdentity, error) {
+	if projectID == 0 || name == "" {
+		return nil, fmt.Errorf("project ID and name are required")
+	}
+	if identityType == "" {
+		identityType = MachineTypeOther
+	}
+	if _, ok := validMachineTypes[identityType]; !ok {
+		return nil, fmt.Errorf("invalid identity_type %q (want ci|k8s|service|automation|other)", identityType)
+	}
+	now := c.now()
+	m := &models.MachineIdentity{
+		ProjectID:    projectID,
+		Name:         name,
+		IdentityType: identityType,
+		State:        MachineActive,
+		Description:  description,
+		CreatedBy:    createdBy,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	}
+	created, err := c.storage.CreateMachineIdentity(ctx, m)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create machine identity: %w", err)
+	}
+	c.logMachineEvent(ctx, "machine_identity.created", created, createdBy)
+	return created, nil
+}
+
+// ListMachineIdentities returns the machine identities in a project.
+func (c *KeyorixCore) ListMachineIdentities(ctx context.Context, projectID uint) ([]*models.MachineIdentity, error) {
+	return c.storage.ListMachineIdentities(ctx, projectID)
+}
+
+// TransitionMachineIdentity advances a machine identity to a new state,
+// enforcing the state machine, and audits the change.
+func (c *KeyorixCore) TransitionMachineIdentity(ctx context.Context, id uint, to string, actorID uint) (*models.MachineIdentity, error) {
+	m, err := c.storage.GetMachineIdentity(ctx, id)
+	if err != nil {
+		return nil, fmt.Errorf("machine identity not found")
+	}
+	if !canTransitionMachine(m.State, to) {
+		return nil, fmt.Errorf("cannot transition machine identity from %s to %s", m.State, to)
+	}
+	now := c.now()
+	m.State = to
+	m.UpdatedAt = now
+	if to == MachineRevoked {
+		m.RevokedAt = &now
+	}
+	if err := c.storage.UpdateMachineIdentity(ctx, m); err != nil {
+		return nil, fmt.Errorf("failed to update machine identity: %w", err)
+	}
+	c.logMachineEvent(ctx, "machine_identity."+machineVerb(to), m, actorID)
+	return m, nil
+}
+
+func machineVerb(to string) string {
+	switch to {
+	case MachineActive:
+		return "activated"
+	case MachineSuspended:
+		return "suspended"
+	case MachineRevoked:
+		return "revoked"
+	default:
+		return to
+	}
+}
+
+func (c *KeyorixCore) logMachineEvent(ctx context.Context, eventType string, m *models.MachineIdentity, actorID uint) {
+	aid, pid := actorID, m.ProjectID
+	c.writeAuditEventFull(ctx, eventType, &aid, nil, &pid, "",
+		fmt.Sprintf("machine identity %q (%s) in project %d → %s", m.Name, m.IdentityType, m.ProjectID, m.State))
+}

--- a/internal/core/machine_identities_test.go
+++ b/internal/core/machine_identities_test.go
@@ -1,0 +1,123 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func newMachineCore(store *MockStorage) *KeyorixCore {
+	fixed := time.Date(2026, 6, 5, 12, 0, 0, 0, time.UTC)
+	return &KeyorixCore{storage: store, now: func() time.Time { return fixed }}
+}
+
+func TestCanTransitionMachine(t *testing.T) {
+	valid := [][2]string{
+		{MachinePending, MachineActive},
+		{MachineActive, MachineSuspended},
+		{MachineSuspended, MachineActive},
+		{MachineActive, MachineRevoked},
+		{MachineSuspended, MachineRevoked},
+		{MachinePending, MachineRevoked},
+	}
+	for _, tc := range valid {
+		assert.True(t, canTransitionMachine(tc[0], tc[1]), "%s→%s allowed", tc[0], tc[1])
+	}
+	invalid := [][2]string{
+		{MachinePending, MachineSuspended},
+		{MachineRevoked, MachineActive}, // terminal
+		{MachineActive, MachinePending},
+	}
+	for _, tc := range invalid {
+		assert.False(t, canTransitionMachine(tc[0], tc[1]), "%s→%s rejected", tc[0], tc[1])
+	}
+}
+
+func TestCreateMachineIdentity(t *testing.T) {
+	t.Run("creates an active identity and audits", func(t *testing.T) {
+		store := new(MockStorage)
+		c := newMachineCore(store)
+		ctx := context.Background()
+		store.On("CreateMachineIdentity", ctx, mock.MatchedBy(func(m *models.MachineIdentity) bool {
+			return m.State == MachineActive && m.IdentityType == MachineTypeCI && m.ProjectID == 1
+		})).Return(&models.MachineIdentity{ID: 10, ProjectID: 1, Name: "ci-runner", IdentityType: MachineTypeCI, State: MachineActive}, nil)
+		store.On("LogAuditEvent", ctx, mock.MatchedBy(func(e *models.AuditEvent) bool {
+			return e.EventType == "machine_identity.created"
+		})).Return(nil)
+
+		m, err := c.CreateMachineIdentity(ctx, 1, "ci-runner", MachineTypeCI, "GitHub Actions", 9)
+		require.NoError(t, err)
+		assert.Equal(t, MachineActive, m.State)
+		store.AssertExpectations(t)
+	})
+
+	t.Run("rejects an unknown identity type", func(t *testing.T) {
+		store := new(MockStorage)
+		c := newMachineCore(store)
+		_, err := c.CreateMachineIdentity(context.Background(), 1, "x", "robot", "", 9)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid identity_type")
+		store.AssertNotCalled(t, "CreateMachineIdentity", mock.Anything, mock.Anything)
+	})
+
+	t.Run("defaults a blank type to other", func(t *testing.T) {
+		store := new(MockStorage)
+		c := newMachineCore(store)
+		ctx := context.Background()
+		store.On("CreateMachineIdentity", ctx, mock.MatchedBy(func(m *models.MachineIdentity) bool {
+			return m.IdentityType == MachineTypeOther
+		})).Return(&models.MachineIdentity{ID: 11, IdentityType: MachineTypeOther, State: MachineActive}, nil)
+		store.On("LogAuditEvent", ctx, mock.Anything).Return(nil)
+
+		_, err := c.CreateMachineIdentity(ctx, 1, "x", "", "", 9)
+		require.NoError(t, err)
+	})
+}
+
+func TestTransitionMachineIdentity(t *testing.T) {
+	t.Run("suspends an active identity", func(t *testing.T) {
+		store := new(MockStorage)
+		c := newMachineCore(store)
+		ctx := context.Background()
+		store.On("GetMachineIdentity", ctx, uint(10)).Return(&models.MachineIdentity{ID: 10, ProjectID: 1, State: MachineActive}, nil)
+		store.On("UpdateMachineIdentity", ctx, mock.MatchedBy(func(m *models.MachineIdentity) bool {
+			return m.State == MachineSuspended
+		})).Return(nil)
+		store.On("LogAuditEvent", ctx, mock.Anything).Return(nil)
+
+		m, err := c.TransitionMachineIdentity(ctx, 10, MachineSuspended, 9)
+		require.NoError(t, err)
+		assert.Equal(t, MachineSuspended, m.State)
+	})
+
+	t.Run("revoke stamps revoked_at", func(t *testing.T) {
+		store := new(MockStorage)
+		c := newMachineCore(store)
+		ctx := context.Background()
+		store.On("GetMachineIdentity", ctx, uint(10)).Return(&models.MachineIdentity{ID: 10, ProjectID: 1, State: MachineActive}, nil)
+		store.On("UpdateMachineIdentity", ctx, mock.MatchedBy(func(m *models.MachineIdentity) bool {
+			return m.State == MachineRevoked && m.RevokedAt != nil
+		})).Return(nil)
+		store.On("LogAuditEvent", ctx, mock.Anything).Return(nil)
+
+		_, err := c.TransitionMachineIdentity(ctx, 10, MachineRevoked, 9)
+		require.NoError(t, err)
+	})
+
+	t.Run("rejects an illegal transition", func(t *testing.T) {
+		store := new(MockStorage)
+		c := newMachineCore(store)
+		ctx := context.Background()
+		store.On("GetMachineIdentity", ctx, uint(10)).Return(&models.MachineIdentity{ID: 10, State: MachineRevoked}, nil)
+
+		_, err := c.TransitionMachineIdentity(ctx, 10, MachineActive, 9)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot transition")
+		store.AssertNotCalled(t, "UpdateMachineIdentity", mock.Anything, mock.Anything)
+	})
+}

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -842,3 +842,33 @@ func (m *MockStorage) UpdateRotationPolicy(_ context.Context, _ *models.Rotation
 func (m *MockStorage) DeleteRotationPolicy(_ context.Context, _ uint) error {
 	return nil
 }
+
+// Machine identities (ADR-023).
+func (m *MockStorage) CreateMachineIdentity(ctx context.Context, mi *models.MachineIdentity) (*models.MachineIdentity, error) {
+	args := m.Called(ctx, mi)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.MachineIdentity), args.Error(1)
+}
+
+func (m *MockStorage) GetMachineIdentity(ctx context.Context, id uint) (*models.MachineIdentity, error) {
+	args := m.Called(ctx, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.MachineIdentity), args.Error(1)
+}
+
+func (m *MockStorage) UpdateMachineIdentity(ctx context.Context, mi *models.MachineIdentity) error {
+	args := m.Called(ctx, mi)
+	return args.Error(0)
+}
+
+func (m *MockStorage) ListMachineIdentities(ctx context.Context, projectID uint) ([]*models.MachineIdentity, error) {
+	args := m.Called(ctx, projectID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*models.MachineIdentity), args.Error(1)
+}

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -39,6 +39,11 @@ type Storage interface {
 	GetAccessRequest(ctx context.Context, id uint) (*models.AccessRequest, error)
 	UpdateAccessRequest(ctx context.Context, req *models.AccessRequest) error
 	ListAccessRequests(ctx context.Context, projectID uint) ([]*models.AccessRequest, error)
+	// Machine identities (ADR-023) — non-human project members.
+	CreateMachineIdentity(ctx context.Context, m *models.MachineIdentity) (*models.MachineIdentity, error)
+	GetMachineIdentity(ctx context.Context, id uint) (*models.MachineIdentity, error)
+	UpdateMachineIdentity(ctx context.Context, m *models.MachineIdentity) error
+	ListMachineIdentities(ctx context.Context, projectID uint) ([]*models.MachineIdentity, error)
 
 	// Secret Management
 	CreateSecret(ctx context.Context, secret *models.SecretNode) (*models.SecretNode, error)

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -227,6 +227,7 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 	invitationsExists := tableExists(db, "project_invitations")
 	accessReqExists := tableExists(db, "access_requests")
 	pwHistExists := tableExists(db, "password_histories")
+	machineExists := tableExists(db, "machine_identities")
 
 	// Create rotation_policies if missing (additive, safe on existing DBs).
 	if !rotationExists {
@@ -258,6 +259,13 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 	if !pwHistExists {
 		if err := db.AutoMigrate(&models.PasswordHistory{}); err != nil {
 			return fmt.Errorf("failed to migrate password_histories table: %w", err)
+		}
+	}
+
+	// Create machine_identities if missing (ADR-023, additive, safe on existing DBs).
+	if !machineExists {
+		if err := db.AutoMigrate(&models.MachineIdentity{}); err != nil {
+			return fmt.Errorf("failed to migrate machine_identities table: %w", err)
 		}
 	}
 

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -428,3 +428,22 @@ type AnomalyAlert struct {
 	Acknowledged bool      `gorm:"default:false"`
 	CreatedAt    time.Time
 }
+
+// MachineIdentity is a non-human project member (ADR-023): a CI runner, a
+// Kubernetes workload, a service, or other automation. It carries its own
+// lifecycle, separate from human users, so the Members view can segment the two.
+// Authentication for a machine identity (its own token) is a follow-up; this is
+// the identity record + lifecycle.
+type MachineIdentity struct {
+	ID           uint   `gorm:"primaryKey"`
+	ProjectID    uint   `gorm:"index"`
+	Name         string `gorm:"not null"`
+	IdentityType string // ci | k8s | service | automation | other
+	State        string // pending | active | suspended | revoked
+	Description  string
+	CreatedBy    uint
+	CreatedAt    time.Time
+	UpdatedAt    time.Time
+	LastSeenAt   *time.Time
+	RevokedAt    *time.Time
+}

--- a/internal/storage/store/local_machine_identities.go
+++ b/internal/storage/store/local_machine_identities.go
@@ -1,0 +1,46 @@
+// local_machine_identities.go — machine identity persistence (ADR-023).
+//
+// For the remote (HTTP) equivalent see remote_machine_identities.go.
+package store
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+func (ls *LocalStorage) CreateMachineIdentity(ctx context.Context, m *models.MachineIdentity) (*models.MachineIdentity, error) {
+	if err := ls.db.WithContext(ctx).Create(m).Error; err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	return m, nil
+}
+
+func (ls *LocalStorage) GetMachineIdentity(ctx context.Context, id uint) (*models.MachineIdentity, error) {
+	var m models.MachineIdentity
+	if err := ls.db.WithContext(ctx).First(&m, id).Error; err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorNotFound", nil), err)
+	}
+	return &m, nil
+}
+
+func (ls *LocalStorage) UpdateMachineIdentity(ctx context.Context, m *models.MachineIdentity) error {
+	if err := ls.db.WithContext(ctx).Save(m).Error; err != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	return nil
+}
+
+func (ls *LocalStorage) ListMachineIdentities(ctx context.Context, projectID uint) ([]*models.MachineIdentity, error) {
+	var rows []*models.MachineIdentity
+	err := ls.db.WithContext(ctx).
+		Where("project_id = ?", projectID).
+		Order("created_at DESC").
+		Find(&rows).Error
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	return rows, nil
+}

--- a/internal/storage/store/machine_identities_test.go
+++ b/internal/storage/store/machine_identities_test.go
@@ -1,0 +1,65 @@
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func newMachineStore(t *testing.T) *LocalStorage {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.MachineIdentity{}))
+	return NewLocalStorage(db)
+}
+
+func TestMachineIdentity_RoundTrip(t *testing.T) {
+	ctx := context.Background()
+	ls := newMachineStore(t)
+	now := time.Date(2026, 6, 5, 9, 0, 0, 0, time.UTC)
+
+	created, err := ls.CreateMachineIdentity(ctx, &models.MachineIdentity{
+		ProjectID: 1, Name: "ci-runner", IdentityType: "ci", State: "active",
+		CreatedBy: 9, CreatedAt: now, UpdatedAt: now,
+	})
+	require.NoError(t, err)
+	require.NotZero(t, created.ID)
+
+	got, err := ls.GetMachineIdentity(ctx, created.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "ci", got.IdentityType)
+	assert.Equal(t, "active", got.State)
+
+	got.State = "suspended"
+	require.NoError(t, ls.UpdateMachineIdentity(ctx, got))
+	reloaded, err := ls.GetMachineIdentity(ctx, created.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "suspended", reloaded.State)
+}
+
+func TestListMachineIdentities_ScopedToProject(t *testing.T) {
+	ctx := context.Background()
+	ls := newMachineStore(t)
+	now := time.Now().UTC()
+	mk := func(projectID uint, name string) {
+		_, err := ls.CreateMachineIdentity(ctx, &models.MachineIdentity{
+			ProjectID: projectID, Name: name, IdentityType: "service", State: "active",
+			CreatedAt: now, UpdatedAt: now,
+		})
+		require.NoError(t, err)
+	}
+	mk(1, "a")
+	mk(1, "b")
+	mk(2, "c")
+
+	got, err := ls.ListMachineIdentities(ctx, 1)
+	require.NoError(t, err)
+	assert.Len(t, got, 2, "only project 1's identities")
+}

--- a/internal/storage/store/remote_machine_identities.go
+++ b/internal/storage/store/remote_machine_identities.go
@@ -1,0 +1,28 @@
+// remote_machine_identities.go — machine identities for RemoteStorage (ADR-023).
+//
+// Machine identity management is processed server-side in remote mode; stubs.
+// For the local (GORM) equivalent see local_machine_identities.go.
+package store
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+func (rs *RemoteStorage) CreateMachineIdentity(_ context.Context, _ *models.MachineIdentity) (*models.MachineIdentity, error) {
+	return nil, fmt.Errorf("CreateMachineIdentity not implemented for remote storage")
+}
+
+func (rs *RemoteStorage) GetMachineIdentity(_ context.Context, _ uint) (*models.MachineIdentity, error) {
+	return nil, fmt.Errorf("GetMachineIdentity not implemented for remote storage")
+}
+
+func (rs *RemoteStorage) UpdateMachineIdentity(_ context.Context, _ *models.MachineIdentity) error {
+	return fmt.Errorf("UpdateMachineIdentity not implemented for remote storage")
+}
+
+func (rs *RemoteStorage) ListMachineIdentities(_ context.Context, _ uint) ([]*models.MachineIdentity, error) {
+	return nil, fmt.Errorf("ListMachineIdentities not implemented for remote storage")
+}

--- a/server/http/handlers/machine_identities.go
+++ b/server/http/handlers/machine_identities.go
@@ -1,0 +1,122 @@
+// machine_identities.go — machine identity endpoints (ADR-023).
+//
+// Non-human project members, segmented from human members in the Members view.
+// Project-scoped: list is users.read; create/transition need roles.assign.
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/server/middleware"
+)
+
+// ListMachineIdentities handles GET /api/v1/projects/{id}/machine-identities.
+func (h *CatalogHandler) ListMachineIdentities(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		sendError(w, "InvalidParameter", "Invalid project ID", http.StatusBadRequest, nil)
+		return
+	}
+	identities, err := h.coreService.ListMachineIdentities(r.Context(), uint(id))
+	if err != nil {
+		sendError(w, "Error", err.Error(), http.StatusInternalServerError, nil)
+		return
+	}
+	sendSuccess(w, map[string]interface{}{"machine_identities": identities}, "")
+}
+
+// CreateMachineIdentity handles POST /api/v1/projects/{id}/machine-identities.
+func (h *CatalogHandler) CreateMachineIdentity(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		sendError(w, "InvalidParameter", "Invalid project ID", http.StatusBadRequest, nil)
+		return
+	}
+	actor := middleware.GetUserFromContext(r.Context())
+	if actor == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	var body struct {
+		Name         string `json:"name"`
+		IdentityType string `json:"identity_type"`
+		Description  string `json:"description"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		sendError(w, "InvalidJSON", "Invalid request body", http.StatusBadRequest, nil)
+		return
+	}
+	if body.Name == "" {
+		sendError(w, "ValidationError", "name is required", http.StatusBadRequest, nil)
+		return
+	}
+	m, err := h.coreService.CreateMachineIdentity(r.Context(), uint(id), body.Name, body.IdentityType, body.Description, actor.UserID)
+	if err != nil {
+		status := http.StatusInternalServerError
+		if strings.Contains(err.Error(), "invalid identity_type") || strings.Contains(err.Error(), "required") {
+			status = http.StatusBadRequest
+		}
+		sendError(w, "Error", err.Error(), status, nil)
+		return
+	}
+	w.WriteHeader(http.StatusCreated)
+	sendSuccess(w, map[string]interface{}{"machine_identity": m}, "Machine identity created")
+}
+
+// TransitionMachineIdentity handles PUT /api/v1/projects/{id}/machine-identities/{machineId}.
+// Body: {"action": "activate" | "suspend" | "revoke"}.
+func (h *CatalogHandler) TransitionMachineIdentity(w http.ResponseWriter, r *http.Request) {
+	machineID, err := strconv.ParseUint(chi.URLParam(r, "machineId"), 10, 32)
+	if err != nil {
+		sendError(w, "InvalidParameter", "Invalid machine identity ID", http.StatusBadRequest, nil)
+		return
+	}
+	actor := middleware.GetUserFromContext(r.Context())
+	if actor == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	var body struct {
+		Action string `json:"action"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		sendError(w, "InvalidJSON", "Invalid request body", http.StatusBadRequest, nil)
+		return
+	}
+	to, ok := machineActionState(body.Action)
+	if !ok {
+		sendError(w, "ValidationError", "action must be activate, suspend, or revoke", http.StatusBadRequest, nil)
+		return
+	}
+	m, err := h.coreService.TransitionMachineIdentity(r.Context(), uint(machineID), to, actor.UserID)
+	if err != nil {
+		status := http.StatusInternalServerError
+		switch {
+		case strings.Contains(err.Error(), "not found"):
+			status = http.StatusNotFound
+		case strings.Contains(err.Error(), "cannot transition"):
+			status = http.StatusConflict
+		}
+		sendError(w, "Error", err.Error(), status, nil)
+		return
+	}
+	sendSuccess(w, map[string]interface{}{"machine_identity": m}, "Machine identity updated")
+}
+
+func machineActionState(action string) (string, bool) {
+	switch action {
+	case "activate":
+		return core.MachineActive, true
+	case "suspend":
+		return core.MachineSuspended, true
+	case "revoke":
+		return core.MachineRevoked, true
+	default:
+		return "", false
+	}
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -168,6 +168,10 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		r.Post("/projects/{id}/access-requests", catalogHandler.CreateAccessRequest)
 		r.With(customMiddleware.RequireScopedPermission("roles.assign", projectScope)).Put("/projects/{id}/access-requests/{requestId}", catalogHandler.ResolveAccessRequest)
 		r.Post("/projects/{id}/access-requests/{requestId}/withdraw", catalogHandler.WithdrawAccessRequest)
+		// Machine identities (ADR-023): non-human members, segmented from humans.
+		r.With(customMiddleware.RequireScopedPermission("users.read", projectScope)).Get("/projects/{id}/machine-identities", catalogHandler.ListMachineIdentities)
+		r.With(customMiddleware.RequireScopedPermission("roles.assign", projectScope)).Post("/projects/{id}/machine-identities", catalogHandler.CreateMachineIdentity)
+		r.With(customMiddleware.RequireScopedPermission("roles.assign", projectScope)).Put("/projects/{id}/machine-identities/{machineId}", catalogHandler.TransitionMachineIdentity)
 		r.With(customMiddleware.RequireScopedPermission("secrets.read", projectScope)).Get("/projects/{id}/environments", catalogHandler.ListProjectEnvironments)
 		r.With(customMiddleware.RequireScopedPermission("secrets.write", projectScope)).Post("/projects/{id}/environments", catalogHandler.CreateProjectEnvironment)
 		// Environment restore is nested under the project so the scope resolves


### PR DESCRIPTION
Machine identities (CI runners, k8s workloads, services, automation) as first-class project members, segmented from human users.

- Model `MachineIdentity` (identity_type: ci|k8s|service|automation|other) + additive pgx-safe table create.
- 4-state lifecycle: `pending → active → suspended ⇄ active`, `revoked` terminal. `pending` is the credential-awaiting state for the future machine-token flow; identities created today start active. Type validation; every transition audited (`machine_identity.*`).
- Storage: 4 interface methods, local GORM impl, remote stubs, mock.
- HTTP (project-scoped — users.read list / roles.assign mutate): `GET/POST /projects/{id}/machine-identities`, `PUT .../{machineId}` (activate|suspend|revoke).

Tests: transition table, create (type validation + default + audit), transitions, store round-trip + project-scoped list. Full gate green.

**Deferred ADR-023 follow-ups (kept out for a clean foundation):**
- machine-token issuance + auth-path integration (security-sensitive; its own PR).
- audit `actor_type` field — held back to avoid colliding with the `AuditEvent` changes in #8; land after #8 merges.
- `keyorix machine` CLI + `keyorix migrate user-to-machine` helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)