### PR TITLE
feat(cli): keyorix machine lifecycle commands (ADR-023)

### DIFF
--- a/internal/cli/machine/create.go
+++ b/internal/cli/machine/create.go
@@ -1,0 +1,71 @@
+package machine
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/spf13/cobra"
+)
+
+var (
+	createProjectName string
+	createName        string
+	createType        string
+	createDescription string
+)
+
+var createCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create a machine identity in a project",
+	RunE:  runCreate,
+}
+
+func init() {
+	createCmd.Flags().StringVar(&createProjectName, "project", "", "Project name (defaults to the active project)")
+	createCmd.Flags().StringVar(&createName, "name", "", "Machine identity name (required)")
+	createCmd.Flags().StringVar(&createType, "type", "other", "Identity type: ci | k8s | service | automation | other")
+	createCmd.Flags().StringVar(&createDescription, "description", "", "Description")
+}
+
+func runCreate(cmd *cobra.Command, args []string) error {
+	if createName == "" {
+		return fmt.Errorf("--name is required")
+	}
+	ctx := context.Background()
+	_, projectID, err := resolveProjectContext(createProjectName)
+	if err != nil {
+		return err
+	}
+
+	if rc, ok := common.NewRemoteClient(); ok {
+		body := map[string]interface{}{
+			"name":          createName,
+			"identity_type": createType,
+			"description":   createDescription,
+		}
+		var resp struct {
+			MachineIdentity models.MachineIdentity `json:"machine_identity"`
+		}
+		path := fmt.Sprintf("/api/v1/projects/%d/machine-identities", projectID)
+		if err := rc.Post(ctx, path, body, &resp); err != nil {
+			return fmt.Errorf("failed to create machine identity: %w", err)
+		}
+		fmt.Printf("Machine identity created: id=%d name=%q type=%s state=%s\n",
+			resp.MachineIdentity.ID, resp.MachineIdentity.Name, resp.MachineIdentity.IdentityType, resp.MachineIdentity.State)
+		return nil
+	}
+
+	svc, err := common.InitializeCoreService()
+	if err != nil {
+		return fmt.Errorf("failed to initialize service: %w", err)
+	}
+	// Local mode has no authenticated user; record a system (0) creator.
+	m, err := svc.CreateMachineIdentity(ctx, projectID, createName, createType, createDescription, 0)
+	if err != nil {
+		return fmt.Errorf("failed to create machine identity: %w", err)
+	}
+	fmt.Printf("Machine identity created: id=%d name=%q type=%s state=%s\n", m.ID, m.Name, m.IdentityType, m.State)
+	return nil
+}

--- a/internal/cli/machine/describe.go
+++ b/internal/cli/machine/describe.go
@@ -1,0 +1,48 @@
+package machine
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var describeProjectName string
+
+var describeCmd = &cobra.Command{
+	Use:   "describe <name|id>",
+	Short: "Show details of a machine identity",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runDescribe,
+}
+
+func init() {
+	describeCmd.Flags().StringVar(&describeProjectName, "project", "", "Project name (defaults to the active project)")
+}
+
+func runDescribe(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+	_, projectID, err := resolveProjectContext(describeProjectName)
+	if err != nil {
+		return err
+	}
+	m, err := findMachineByRef(ctx, projectID, args[0])
+	if err != nil {
+		return err
+	}
+	fmt.Printf("ID:          %d\n", m.ID)
+	fmt.Printf("Name:        %s\n", m.Name)
+	fmt.Printf("Type:        %s\n", m.IdentityType)
+	fmt.Printf("State:       %s\n", m.State)
+	fmt.Printf("Project ID:  %d\n", m.ProjectID)
+	if m.Description != "" {
+		fmt.Printf("Description: %s\n", m.Description)
+	}
+	if m.LastSeenAt != nil {
+		fmt.Printf("Last seen:   %s\n", m.LastSeenAt.Format("2006-01-02 15:04:05 MST"))
+	}
+	if m.RevokedAt != nil {
+		fmt.Printf("Revoked at:  %s\n", m.RevokedAt.Format("2006-01-02 15:04:05 MST"))
+	}
+	return nil
+}

--- a/internal/cli/machine/lifecycle.go
+++ b/internal/cli/machine/lifecycle.go
@@ -1,0 +1,74 @@
+package machine
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/spf13/cobra"
+)
+
+var lifecycleProjectName string
+
+var suspendCmd = &cobra.Command{
+	Use:   "suspend <name|id>",
+	Short: "Suspend a machine identity",
+	Args:  cobra.ExactArgs(1),
+	RunE:  lifecycleRunE("suspend", core.MachineSuspended),
+}
+
+var reactivateCmd = &cobra.Command{
+	Use:   "reactivate <name|id>",
+	Short: "Reactivate a suspended machine identity",
+	Args:  cobra.ExactArgs(1),
+	RunE:  lifecycleRunE("activate", core.MachineActive),
+}
+
+var revokeCmd = &cobra.Command{
+	Use:   "revoke <name|id>",
+	Short: "Revoke a machine identity (terminal)",
+	Args:  cobra.ExactArgs(1),
+	RunE:  lifecycleRunE("revoke", core.MachineRevoked),
+}
+
+func init() {
+	for _, c := range []*cobra.Command{suspendCmd, reactivateCmd, revokeCmd} {
+		c.Flags().StringVar(&lifecycleProjectName, "project", "", "Project name (defaults to the active project)")
+	}
+}
+
+// lifecycleRunE returns a RunE that transitions the referenced machine identity
+// to targetState. action is the API verb (activate/suspend/revoke).
+func lifecycleRunE(action, targetState string) func(*cobra.Command, []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		ctx := context.Background()
+		_, projectID, err := resolveProjectContext(lifecycleProjectName)
+		if err != nil {
+			return err
+		}
+		m, err := findMachineByRef(ctx, projectID, args[0])
+		if err != nil {
+			return err
+		}
+
+		if rc, ok := common.NewRemoteClient(); ok {
+			path := fmt.Sprintf("/api/v1/projects/%d/machine-identities/%d", projectID, m.ID)
+			if err := rc.Put(ctx, path, map[string]interface{}{"action": action}, nil); err != nil {
+				return fmt.Errorf("failed to %s machine identity: %w", action, err)
+			}
+			fmt.Printf("Machine identity %q → %s\n", m.Name, targetState)
+			return nil
+		}
+
+		svc, err := common.InitializeCoreService()
+		if err != nil {
+			return fmt.Errorf("failed to initialize service: %w", err)
+		}
+		if _, err := svc.TransitionMachineIdentity(ctx, m.ID, targetState, 0); err != nil {
+			return fmt.Errorf("failed to %s machine identity: %w", action, err)
+		}
+		fmt.Printf("Machine identity %q → %s\n", m.Name, targetState)
+		return nil
+	}
+}

--- a/internal/cli/machine/list.go
+++ b/internal/cli/machine/list.go
@@ -1,0 +1,51 @@
+package machine
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/spf13/cobra"
+)
+
+var listProjectName string
+
+var listCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List machine identities in a project",
+	RunE:  runList,
+}
+
+func init() {
+	listCmd.Flags().StringVar(&listProjectName, "project", "", "Project name (defaults to the active project)")
+}
+
+func runList(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+	projectName, projectID, err := resolveProjectContext(listProjectName)
+	if err != nil {
+		return err
+	}
+	identities, err := fetchMachineIdentities(ctx, projectID)
+	if err != nil {
+		return fmt.Errorf("failed to list machine identities: %w", err)
+	}
+	printMachineTable(identities, projectName)
+	return nil
+}
+
+func printMachineTable(identities []*models.MachineIdentity, projectName string) {
+	if len(identities) == 0 {
+		fmt.Printf("No machine identities found for project %q.\n", projectName)
+		return
+	}
+	fmt.Printf("%-5s %-24s %-12s %-10s %s\n", "ID", "NAME", "TYPE", "STATE", "DESCRIPTION")
+	fmt.Printf("%-5s %-24s %-12s %-10s %s\n", "-----", "------------------------", "------------", "----------", "-----------")
+	for _, m := range identities {
+		desc := m.Description
+		if len(desc) > 40 {
+			desc = desc[:37] + "..."
+		}
+		fmt.Printf("%-5d %-24s %-12s %-10s %s\n", m.ID, m.Name, m.IdentityType, m.State, desc)
+	}
+}

--- a/internal/cli/machine/machine.go
+++ b/internal/cli/machine/machine.go
@@ -1,0 +1,116 @@
+// machine.go — CLI commands for managing machine identities (ADR-023).
+//
+// Commands: machine list, machine create, machine describe, machine suspend,
+//
+//	machine reactivate, machine revoke.
+//
+// Each command works in both remote mode (against the server API) and local
+// mode (directly against the core service), mirroring the project CLI. Machine
+// identities are project-scoped, so every command resolves a project from
+// --project / KEYORIX_PROJECT / the active project. Machine-token issuance and
+// authentication are a separate follow-up (they need the machine-principal
+// model); this CLI manages the identity lifecycle.
+package machine
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/spf13/cobra"
+)
+
+// MachineCmd is the root command for machine identity management.
+var MachineCmd = &cobra.Command{
+	Use:   "machine",
+	Short: "Manage machine identities",
+	Long:  "Commands for listing, creating, and managing the lifecycle of project machine identities (CI, k8s, services, automation).",
+}
+
+func init() {
+	MachineCmd.AddCommand(listCmd)
+	MachineCmd.AddCommand(createCmd)
+	MachineCmd.AddCommand(describeCmd)
+	MachineCmd.AddCommand(suspendCmd)
+	MachineCmd.AddCommand(reactivateCmd)
+	MachineCmd.AddCommand(revokeCmd)
+}
+
+// resolveProjectContext resolves a project name (flag / env / active) to its
+// numeric ID, in both remote and local modes.
+func resolveProjectContext(flagValue string) (string, uint, error) {
+	name, err := common.ResolveProject(flagValue)
+	if err != nil {
+		return "", 0, err
+	}
+	ctx := context.Background()
+	if rc, ok := common.NewRemoteClient(); ok {
+		var resp struct {
+			Data struct {
+				Projects []struct {
+					ID   uint   `json:"id"`
+					Name string `json:"name"`
+				} `json:"projects"`
+			} `json:"data"`
+		}
+		if err := rc.Get(ctx, "/api/v1/projects", &resp); err != nil {
+			return "", 0, fmt.Errorf("failed to list projects: %w", err)
+		}
+		for _, p := range resp.Data.Projects {
+			if p.Name == name {
+				return name, p.ID, nil
+			}
+		}
+		return "", 0, fmt.Errorf("project %q not found", name)
+	}
+	svc, err := common.InitializeCoreService()
+	if err != nil {
+		return "", 0, fmt.Errorf("failed to initialize service: %w", err)
+	}
+	projects, err := svc.ListProjects(ctx)
+	if err != nil {
+		return "", 0, fmt.Errorf("failed to list projects: %w", err)
+	}
+	for _, p := range projects {
+		if p.Name == name {
+			return name, p.ID, nil
+		}
+	}
+	return "", 0, fmt.Errorf("project %q not found", name)
+}
+
+// fetchMachineIdentities lists a project's machine identities (remote or local).
+func fetchMachineIdentities(ctx context.Context, projectID uint) ([]*models.MachineIdentity, error) {
+	if rc, ok := common.NewRemoteClient(); ok {
+		var resp struct {
+			Data struct {
+				MachineIdentities []*models.MachineIdentity `json:"machine_identities"`
+			} `json:"data"`
+		}
+		path := fmt.Sprintf("/api/v1/projects/%d/machine-identities", projectID)
+		if err := rc.Get(ctx, path, &resp); err != nil {
+			return nil, err
+		}
+		return resp.Data.MachineIdentities, nil
+	}
+	svc, err := common.InitializeCoreService()
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize service: %w", err)
+	}
+	return svc.ListMachineIdentities(ctx, projectID)
+}
+
+// findMachineByRef finds a machine identity in a project by numeric ID or name.
+func findMachineByRef(ctx context.Context, projectID uint, ref string) (*models.MachineIdentity, error) {
+	identities, err := fetchMachineIdentities(ctx, projectID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list machine identities: %w", err)
+	}
+	for _, m := range identities {
+		if m.Name == ref || fmt.Sprintf("%d", m.ID) == ref {
+			return m, nil
+		}
+	}
+	return nil, fmt.Errorf("machine identity %q not found in project", ref)
+}

--- a/internal/cli/machine/machine_test.go
+++ b/internal/cli/machine/machine_test.go
@@ -1,0 +1,39 @@
+package machine
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMachineCmd_Subcommands(t *testing.T) {
+	want := map[string]bool{
+		"list": false, "create": false, "describe": false,
+		"suspend": false, "reactivate": false, "revoke": false,
+	}
+	for _, c := range MachineCmd.Commands() {
+		want[c.Name()] = true
+	}
+	for name, found := range want {
+		assert.True(t, found, "expected machine subcommand %q to be registered", name)
+	}
+}
+
+func TestMachineCmd_LifecycleCommandsTakeOneArg(t *testing.T) {
+	for _, name := range []string{"suspend", "reactivate", "revoke", "describe"} {
+		cmd, _, err := MachineCmd.Find([]string{name})
+		require.NoError(t, err)
+		// ExactArgs(1): zero args must be rejected, one accepted.
+		assert.Error(t, cmd.Args(cmd, []string{}), "%s should require a ref", name)
+		assert.NoError(t, cmd.Args(cmd, []string{"my-runner"}), "%s should accept one ref", name)
+	}
+}
+
+func TestMachineCmd_ProjectFlag(t *testing.T) {
+	for _, name := range []string{"list", "create", "describe", "suspend", "reactivate", "revoke"} {
+		cmd, _, err := MachineCmd.Find([]string{name})
+		require.NoError(t, err)
+		assert.NotNil(t, cmd.Flags().Lookup("project"), "%s should have a --project flag", name)
+	}
+}

--- a/internal/cli/main.go
+++ b/internal/cli/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/keyorixhq/keyorix/internal/cli/encryption"
 	"github.com/keyorixhq/keyorix/internal/cli/group"
 	"github.com/keyorixhq/keyorix/internal/cli/invite"
+	"github.com/keyorixhq/keyorix/internal/cli/machine"
 	"github.com/keyorixhq/keyorix/internal/cli/project"
 	"github.com/keyorixhq/keyorix/internal/cli/rbac"
 	"github.com/keyorixhq/keyorix/internal/cli/request"
@@ -38,6 +39,7 @@ func init() {
 	rootCmd.AddCommand(run.RunCmd)
 	rootCmd.AddCommand(secret.SecretCmd)
 	rootCmd.AddCommand(project.ProjectCmd)
+	rootCmd.AddCommand(machine.MachineCmd)
 	rootCmd.AddCommand(user.UserCmd)
 	rootCmd.AddCommand(group.GroupCmd)
 	rootCmd.AddCommand(invite.InviteCmd)


### PR DESCRIPTION
**Stacked on #13** (base is `feat/machine-identities`; retarget to `main` after #13 merges).

`keyorix machine` manages project machine identities from the CLI, driving the API/core from #13. Mirrors the project CLI — remote mode (server API) + local mode (core service), project resolved from `--project` / `KEYORIX_PROJECT` / active project.

- `machine list`
- `machine create --name --type --description`
- `machine describe <name|id>`
- `machine suspend|reactivate|revoke <name|id>`

Refs accept a name or numeric id. Local mode records a system (0) actor (no authenticated CLI user); remote uses the token's user. Verified `keyorix machine --help`. Tests cover subcommand registration, ExactArgs(1), `--project` flag. Full gate green.

**Deferred (own follow-up):** `machine token` issuance + machine-token **authentication** — needs the machine-principal / RBAC model (a machine identity isn't a user), which deserves its own ADR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)