### PR TITLE
feat(access): ADR-024 project invitations + access requests

### DIFF
--- a/internal/cli/invite/invite.go
+++ b/internal/cli/invite/invite.go
@@ -1,0 +1,44 @@
+// Package invite provides the `keyorix invite` CLI commands for project
+// invitations (ADR-024): send, list, and revoke. These operate on the local
+// core service directly, mirroring the admin-gated HTTP surface
+// (POST/GET/DELETE /projects/{id}/invitations).
+package invite
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/spf13/cobra"
+)
+
+// InviteCmd is the root command for invitation operations.
+var InviteCmd = &cobra.Command{
+	Use:   "invite",
+	Short: "Manage project invitations",
+	Long:  "Send, list, and revoke project invitations (ADR-024).",
+}
+
+func init() {
+	InviteCmd.AddCommand(sendCmd)
+	InviteCmd.AddCommand(listCmd)
+	InviteCmd.AddCommand(revokeCmd)
+}
+
+// resolveUserID resolves an email address to a user ID via the core service.
+func resolveUserID(ctx context.Context, service *core.KeyorixCore, email string) (uint, error) {
+	u, err := service.GetUserByEmail(ctx, email)
+	if err != nil {
+		return 0, fmt.Errorf("no user found for %q: %w", email, err)
+	}
+	return u.ID, nil
+}
+
+// fmtTime renders an optional timestamp for table output.
+func fmtTime(t *time.Time) string {
+	if t == nil {
+		return "-"
+	}
+	return t.Format("2006-01-02 15:04")
+}

--- a/internal/cli/invite/invite_test.go
+++ b/internal/cli/invite/invite_test.go
@@ -1,0 +1,45 @@
+package invite
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInviteCommandStructure(t *testing.T) {
+	assert.Equal(t, "invite", InviteCmd.Use)
+
+	names := make([]string, 0)
+	for _, c := range InviteCmd.Commands() {
+		names = append(names, c.Use)
+	}
+	for _, expected := range []string{"send", "list", "revoke"} {
+		assert.Contains(t, names, expected, "expected subcommand %q", expected)
+	}
+}
+
+func TestInviteSendRequiredFlags(t *testing.T) {
+	for _, name := range []string{"project", "email", "role", "by"} {
+		assert.NotNil(t, sendCmd.Flags().Lookup(name), "send should have --%s", name)
+	}
+	for _, name := range []string{"email", "role", "by"} {
+		ann := sendCmd.Flags().Lookup(name).Annotations[cobraRequired]
+		assert.NotEmpty(t, ann, "--%s should be marked required", name)
+	}
+}
+
+func TestInviteRevokeRequiredFlags(t *testing.T) {
+	for _, name := range []string{"id", "by"} {
+		f := revokeCmd.Flags().Lookup(name)
+		assert.NotNil(t, f, "revoke should have --%s", name)
+		assert.NotEmpty(t, f.Annotations[cobraRequired], "--%s should be required", name)
+	}
+}
+
+func TestInviteListFlags(t *testing.T) {
+	assert.NotNil(t, listCmd.Flags().Lookup("project"))
+	assert.NotNil(t, listCmd.Flags().Lookup("stale-days"))
+}
+
+// cobraRequired is the annotation key cobra uses to mark required flags.
+const cobraRequired = "cobra_annotation_bash_completion_one_required_flag"

--- a/internal/cli/invite/list.go
+++ b/internal/cli/invite/list.go
@@ -1,0 +1,65 @@
+package invite
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/spf13/cobra"
+)
+
+var (
+	listProject   string
+	listStaleDays int
+)
+
+var listCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List project invitations",
+	Long:  "List a project's invitations. With --stale-days, show only pending invites older than N days.",
+	RunE:  runList,
+}
+
+func init() {
+	listCmd.Flags().StringVar(&listProject, "project", "", "Project name (or use KEYORIX_PROJECT / active project)")
+	listCmd.Flags().IntVar(&listStaleDays, "stale-days", 0, "Show only pending invitations older than this many days")
+}
+
+func runList(cmd *cobra.Command, args []string) error {
+	service, err := common.InitializeCoreService()
+	if err != nil {
+		return fmt.Errorf("failed to initialize service: %w", err)
+	}
+	ctx := context.Background()
+
+	projectName, err := common.ResolveProject(listProject)
+	if err != nil {
+		return err
+	}
+	projectID, err := common.LookupProjectIDByName(ctx, service.Storage(), projectName)
+	if err != nil {
+		return err
+	}
+
+	var invitations []*models.ProjectInvitation
+	if listStaleDays > 0 {
+		invitations, err = service.StaleInvitations(ctx, projectID, time.Duration(listStaleDays)*24*time.Hour)
+	} else {
+		invitations, err = service.ListProjectInvitations(ctx, projectID)
+	}
+	if err != nil {
+		return fmt.Errorf("failed to list invitations: %w", err)
+	}
+
+	if len(invitations) == 0 {
+		fmt.Println("No invitations found.")
+		return nil
+	}
+	fmt.Printf("%-6s %-30s %-16s %-10s %s\n", "ID", "EMAIL", "ROLE", "STATE", "EXPIRES")
+	for _, inv := range invitations {
+		fmt.Printf("%-6d %-30s %-16s %-10s %s\n", inv.ID, inv.Email, inv.Role, inv.State, fmtTime(inv.ExpiresAt))
+	}
+	return nil
+}

--- a/internal/cli/invite/revoke.go
+++ b/internal/cli/invite/revoke.go
@@ -1,0 +1,49 @@
+package invite
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/spf13/cobra"
+)
+
+var (
+	revokeID uint
+	revokeBy string
+)
+
+var revokeCmd = &cobra.Command{
+	Use:   "revoke",
+	Short: "Revoke a pending invitation",
+	Long:  "Cancel a pending project invitation by ID (ADR-024).",
+	RunE:  runRevoke,
+}
+
+func init() {
+	revokeCmd.Flags().UintVar(&revokeID, "id", 0, "Invitation ID (required)")
+	revokeCmd.Flags().StringVar(&revokeBy, "by", "", "Revoker email address (required, for audit)")
+	_ = revokeCmd.MarkFlagRequired("id")
+	_ = revokeCmd.MarkFlagRequired("by")
+}
+
+func runRevoke(cmd *cobra.Command, args []string) error {
+	if revokeID == 0 {
+		return fmt.Errorf("--id is required")
+	}
+	service, err := common.InitializeCoreService()
+	if err != nil {
+		return fmt.Errorf("failed to initialize service: %w", err)
+	}
+	ctx := context.Background()
+
+	actorID, err := resolveUserID(ctx, service, revokeBy)
+	if err != nil {
+		return err
+	}
+	if err := service.RevokeInvitation(ctx, revokeID, actorID); err != nil {
+		return fmt.Errorf("failed to revoke invitation: %w", err)
+	}
+	fmt.Printf("Invitation %d revoked.\n", revokeID)
+	return nil
+}

--- a/internal/cli/invite/send.go
+++ b/internal/cli/invite/send.go
@@ -1,0 +1,66 @@
+package invite
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/spf13/cobra"
+)
+
+var (
+	sendProject string
+	sendEmail   string
+	sendRole    string
+	sendBy      string
+)
+
+var sendCmd = &cobra.Command{
+	Use:   "send",
+	Short: "Send a project invitation",
+	Long:  "Invite an email address to a project with an intended role (admin-driven, ADR-024).",
+	RunE:  runSend,
+}
+
+func init() {
+	sendCmd.Flags().StringVar(&sendProject, "project", "", "Project name (or use KEYORIX_PROJECT / active project)")
+	sendCmd.Flags().StringVar(&sendEmail, "email", "", "Invitee email address (required)")
+	sendCmd.Flags().StringVar(&sendRole, "role", "", "Intended project role (required)")
+	sendCmd.Flags().StringVar(&sendBy, "by", "", "Inviter email address (required, for audit)")
+	_ = sendCmd.MarkFlagRequired("email")
+	_ = sendCmd.MarkFlagRequired("role")
+	_ = sendCmd.MarkFlagRequired("by")
+}
+
+func runSend(cmd *cobra.Command, args []string) error {
+	if sendEmail == "" || sendRole == "" {
+		return errors.New("--email and --role are required")
+	}
+	service, err := common.InitializeCoreService()
+	if err != nil {
+		return fmt.Errorf("failed to initialize service: %w", err)
+	}
+	ctx := context.Background()
+
+	projectName, err := common.ResolveProject(sendProject)
+	if err != nil {
+		return err
+	}
+	projectID, err := common.LookupProjectIDByName(ctx, service.Storage(), projectName)
+	if err != nil {
+		return err
+	}
+	invitedBy, err := resolveUserID(ctx, service, sendBy)
+	if err != nil {
+		return err
+	}
+
+	inv, err := service.InviteToProject(ctx, projectID, sendEmail, sendRole, invitedBy)
+	if err != nil {
+		return fmt.Errorf("failed to send invitation: %w", err)
+	}
+	fmt.Printf("Invitation sent: id=%d email=%s role=%s project=%s expires=%s\n",
+		inv.ID, inv.Email, inv.Role, projectName, fmtTime(inv.ExpiresAt))
+	return nil
+}

--- a/internal/cli/main.go
+++ b/internal/cli/main.go
@@ -10,8 +10,10 @@ import (
 	"github.com/keyorixhq/keyorix/internal/cli/connect"
 	"github.com/keyorixhq/keyorix/internal/cli/encryption"
 	"github.com/keyorixhq/keyorix/internal/cli/group"
+	"github.com/keyorixhq/keyorix/internal/cli/invite"
 	"github.com/keyorixhq/keyorix/internal/cli/project"
 	"github.com/keyorixhq/keyorix/internal/cli/rbac"
+	"github.com/keyorixhq/keyorix/internal/cli/request"
 	"github.com/keyorixhq/keyorix/internal/cli/run"
 	"github.com/keyorixhq/keyorix/internal/cli/secret"
 	"github.com/keyorixhq/keyorix/internal/cli/share"
@@ -38,6 +40,8 @@ func init() {
 	rootCmd.AddCommand(project.ProjectCmd)
 	rootCmd.AddCommand(user.UserCmd)
 	rootCmd.AddCommand(group.GroupCmd)
+	rootCmd.AddCommand(invite.InviteCmd)
+	rootCmd.AddCommand(request.RequestCmd)
 	rootCmd.AddCommand(share.ShareCmd)
 	rootCmd.AddCommand(auth.AuthCmd)
 	rootCmd.AddCommand(config.ConfigCmd)

--- a/internal/cli/request/access.go
+++ b/internal/cli/request/access.go
@@ -1,0 +1,70 @@
+package request
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/spf13/cobra"
+)
+
+var (
+	accessProject string
+	accessUser    string
+	accessRole    string
+	accessReason  string
+)
+
+var accessCmd = &cobra.Command{
+	Use:   "access",
+	Short: "Request access to a project",
+	Long:  "Create a pending access request for a user to a project, optionally suggesting a role (ADR-024).",
+	RunE:  runAccess,
+}
+
+func init() {
+	accessCmd.Flags().StringVar(&accessProject, "project", "", "Project name (or use KEYORIX_PROJECT / active project)")
+	accessCmd.Flags().StringVar(&accessUser, "user", "", "Requester email address (required)")
+	accessCmd.Flags().StringVar(&accessRole, "role", "", "Suggested project role (optional)")
+	accessCmd.Flags().StringVar(&accessReason, "reason", "", "Reason for the request (optional)")
+	_ = accessCmd.MarkFlagRequired("user")
+}
+
+func runAccess(cmd *cobra.Command, args []string) error {
+	if accessUser == "" {
+		return fmt.Errorf("--user is required")
+	}
+	service, err := common.InitializeCoreService()
+	if err != nil {
+		return fmt.Errorf("failed to initialize service: %w", err)
+	}
+	ctx := context.Background()
+
+	projectName, err := common.ResolveProject(accessProject)
+	if err != nil {
+		return err
+	}
+	projectID, err := common.LookupProjectIDByName(ctx, service.Storage(), projectName)
+	if err != nil {
+		return err
+	}
+	userID, err := resolveUserID(ctx, service, accessUser)
+	if err != nil {
+		return err
+	}
+
+	req, err := service.RequestProjectAccess(ctx, projectID, userID, accessRole, accessReason)
+	if err != nil {
+		return fmt.Errorf("failed to request access: %w", err)
+	}
+	fmt.Printf("Access requested: id=%d project=%s suggested-role=%s state=%s\n",
+		req.ID, projectName, dashIfEmpty(req.SuggestedRole), req.State)
+	return nil
+}
+
+func dashIfEmpty(s string) string {
+	if s == "" {
+		return "-"
+	}
+	return s
+}

--- a/internal/cli/request/list.go
+++ b/internal/cli/request/list.go
@@ -1,0 +1,56 @@
+package request
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/spf13/cobra"
+)
+
+var listProject string
+
+var listCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List a project's access requests",
+	Long:  "List all access requests for a project, expiring stale pending ones on read (ADR-024).",
+	RunE:  runList,
+}
+
+func init() {
+	listCmd.Flags().StringVar(&listProject, "project", "", "Project name (or use KEYORIX_PROJECT / active project)")
+}
+
+func runList(cmd *cobra.Command, args []string) error {
+	service, err := common.InitializeCoreService()
+	if err != nil {
+		return fmt.Errorf("failed to initialize service: %w", err)
+	}
+	ctx := context.Background()
+
+	projectName, err := common.ResolveProject(listProject)
+	if err != nil {
+		return err
+	}
+	projectID, err := common.LookupProjectIDByName(ctx, service.Storage(), projectName)
+	if err != nil {
+		return err
+	}
+
+	requests, err := service.ListAccessRequests(ctx, projectID)
+	if err != nil {
+		return fmt.Errorf("failed to list access requests: %w", err)
+	}
+
+	if len(requests) == 0 {
+		fmt.Println("No access requests found.")
+		return nil
+	}
+	fmt.Printf("%-6s %-24s %-14s %-14s %-11s %s\n", "ID", "USER", "SUGGESTED", "GRANTED", "STATE", "REASON")
+	for _, req := range requests {
+		fmt.Printf("%-6d %-24s %-14s %-14s %-11s %s\n",
+			req.ID, userLabel(ctx, service, req.UserID), dashIfEmpty(req.SuggestedRole),
+			dashIfEmpty(req.GrantedRole), req.State, dashIfEmpty(req.Reason))
+	}
+	return nil
+}

--- a/internal/cli/request/request.go
+++ b/internal/cli/request/request.go
@@ -1,0 +1,46 @@
+// Package request provides the `keyorix request` CLI commands for project
+// access requests (ADR-024): access (create), list, withdraw, and review
+// (approve/reject). Requesting and withdrawing are self-service; review is
+// admin-driven. These mirror the HTTP surface under /projects/{id}/access-requests.
+package request
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/spf13/cobra"
+)
+
+// RequestCmd is the root command for access-request operations.
+var RequestCmd = &cobra.Command{
+	Use:   "request",
+	Short: "Manage project access requests",
+	Long:  "Request access to a project, list, withdraw, and review (approve/reject) requests (ADR-024).",
+}
+
+func init() {
+	RequestCmd.AddCommand(accessCmd)
+	RequestCmd.AddCommand(listCmd)
+	RequestCmd.AddCommand(withdrawCmd)
+	RequestCmd.AddCommand(reviewCmd)
+}
+
+// resolveUserID resolves an email address to a user ID via the core service.
+func resolveUserID(ctx context.Context, service *core.KeyorixCore, email string) (uint, error) {
+	u, err := service.GetUserByEmail(ctx, email)
+	if err != nil {
+		return 0, fmt.Errorf("no user found for %q: %w", email, err)
+	}
+	return u.ID, nil
+}
+
+// userLabel renders a user ID as "username (#id)", falling back to "#id" if the
+// lookup fails.
+func userLabel(ctx context.Context, service *core.KeyorixCore, id uint) string {
+	u, err := service.GetUser(ctx, id)
+	if err != nil || u == nil {
+		return fmt.Sprintf("#%d", id)
+	}
+	return fmt.Sprintf("%s (#%d)", u.Username, id)
+}

--- a/internal/cli/request/request_test.go
+++ b/internal/cli/request/request_test.go
@@ -1,0 +1,46 @@
+package request
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// cobraRequired is the annotation key cobra uses to mark required flags.
+const cobraRequired = "cobra_annotation_bash_completion_one_required_flag"
+
+func TestRequestCommandStructure(t *testing.T) {
+	assert.Equal(t, "request", RequestCmd.Use)
+
+	names := make([]string, 0)
+	for _, c := range RequestCmd.Commands() {
+		names = append(names, c.Use)
+	}
+	for _, expected := range []string{"access", "list", "withdraw", "review"} {
+		assert.Contains(t, names, expected, "expected subcommand %q", expected)
+	}
+}
+
+func TestRequestAccessFlags(t *testing.T) {
+	for _, name := range []string{"project", "user", "role", "reason"} {
+		assert.NotNil(t, accessCmd.Flags().Lookup(name), "access should have --%s", name)
+	}
+	assert.NotEmpty(t, accessCmd.Flags().Lookup("user").Annotations[cobraRequired], "--user should be required")
+}
+
+func TestRequestWithdrawRequiredFlags(t *testing.T) {
+	for _, name := range []string{"id", "user"} {
+		f := withdrawCmd.Flags().Lookup(name)
+		assert.NotNil(t, f, "withdraw should have --%s", name)
+		assert.NotEmpty(t, f.Annotations[cobraRequired], "--%s should be required", name)
+	}
+}
+
+func TestRequestReviewRequiredFlags(t *testing.T) {
+	for _, name := range []string{"id", "action", "role", "reason", "by"} {
+		assert.NotNil(t, reviewCmd.Flags().Lookup(name), "review should have --%s", name)
+	}
+	for _, name := range []string{"id", "action", "by"} {
+		assert.NotEmpty(t, reviewCmd.Flags().Lookup(name).Annotations[cobraRequired], "--%s should be required", name)
+	}
+}

--- a/internal/cli/request/review.go
+++ b/internal/cli/request/review.go
@@ -1,0 +1,73 @@
+package request
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/spf13/cobra"
+)
+
+var (
+	reviewID     uint
+	reviewAction string
+	reviewRole   string
+	reviewReason string
+	reviewBy     string
+)
+
+var reviewCmd = &cobra.Command{
+	Use:   "review",
+	Short: "Approve or reject a pending access request",
+	Long: "Resolve a pending access request (admin-driven, ADR-024).\n" +
+		"Approving grants the role at the project scope (--role overrides the suggested role);\n" +
+		"rejecting records a --reason.",
+	RunE: runReview,
+}
+
+func init() {
+	reviewCmd.Flags().UintVar(&reviewID, "id", 0, "Access request ID (required)")
+	reviewCmd.Flags().StringVar(&reviewAction, "action", "", "approve | reject (required)")
+	reviewCmd.Flags().StringVar(&reviewRole, "role", "", "Role to grant on approve (defaults to the suggested role)")
+	reviewCmd.Flags().StringVar(&reviewReason, "reason", "", "Reason on reject")
+	reviewCmd.Flags().StringVar(&reviewBy, "by", "", "Reviewer email address (required, for audit)")
+	_ = reviewCmd.MarkFlagRequired("id")
+	_ = reviewCmd.MarkFlagRequired("action")
+	_ = reviewCmd.MarkFlagRequired("by")
+}
+
+func runReview(cmd *cobra.Command, args []string) error {
+	if reviewID == 0 {
+		return fmt.Errorf("--id is required")
+	}
+	if reviewAction != "approve" && reviewAction != "reject" {
+		return fmt.Errorf("--action must be approve or reject")
+	}
+	service, err := common.InitializeCoreService()
+	if err != nil {
+		return fmt.Errorf("failed to initialize service: %w", err)
+	}
+	ctx := context.Background()
+
+	approverID, err := resolveUserID(ctx, service, reviewBy)
+	if err != nil {
+		return err
+	}
+
+	switch reviewAction {
+	case "approve":
+		req, err := service.ApproveAccessRequest(ctx, reviewID, approverID, reviewRole)
+		if err != nil {
+			return fmt.Errorf("failed to approve access request: %w", err)
+		}
+		fmt.Printf("Access request %d approved: granted role %q to %s.\n",
+			req.ID, req.GrantedRole, userLabel(ctx, service, req.UserID))
+	case "reject":
+		req, err := service.RejectAccessRequest(ctx, reviewID, approverID, reviewReason)
+		if err != nil {
+			return fmt.Errorf("failed to reject access request: %w", err)
+		}
+		fmt.Printf("Access request %d rejected.\n", req.ID)
+	}
+	return nil
+}

--- a/internal/cli/request/withdraw.go
+++ b/internal/cli/request/withdraw.go
@@ -1,0 +1,49 @@
+package request
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/spf13/cobra"
+)
+
+var (
+	withdrawID   uint
+	withdrawUser string
+)
+
+var withdrawCmd = &cobra.Command{
+	Use:   "withdraw",
+	Short: "Withdraw your own pending access request",
+	Long:  "Cancel a pending access request you own, by ID (self-service, ADR-024).",
+	RunE:  runWithdraw,
+}
+
+func init() {
+	withdrawCmd.Flags().UintVar(&withdrawID, "id", 0, "Access request ID (required)")
+	withdrawCmd.Flags().StringVar(&withdrawUser, "user", "", "Requester email address (required — must own the request)")
+	_ = withdrawCmd.MarkFlagRequired("id")
+	_ = withdrawCmd.MarkFlagRequired("user")
+}
+
+func runWithdraw(cmd *cobra.Command, args []string) error {
+	if withdrawID == 0 {
+		return fmt.Errorf("--id is required")
+	}
+	service, err := common.InitializeCoreService()
+	if err != nil {
+		return fmt.Errorf("failed to initialize service: %w", err)
+	}
+	ctx := context.Background()
+
+	userID, err := resolveUserID(ctx, service, withdrawUser)
+	if err != nil {
+		return err
+	}
+	if err := service.WithdrawAccessRequest(ctx, withdrawID, userID); err != nil {
+		return fmt.Errorf("failed to withdraw access request: %w", err)
+	}
+	fmt.Printf("Access request %d withdrawn.\n", withdrawID)
+	return nil
+}

--- a/internal/core/invitations.go
+++ b/internal/core/invitations.go
@@ -1,0 +1,272 @@
+// invitations.go — project invitations + access requests (ADR-024).
+//
+// Two related onboarding flows:
+//
+//   - Invitations: an admin invites an email to a project with an intended role.
+//     State: pending → accepted / revoked / expired. The email/setup-link
+//     consumption (accept) is a follow-up; this tracks the pending invite so it
+//     can be listed, revoked, and aged out.
+//   - Access requests: a user asks for a role in a project. State: pending →
+//     approved / rejected / withdrawn / expired. Approval grants the (possibly
+//     adjusted) role at the project scope. No auto-approval.
+//
+// Every transition is audited. TTLs: invitations 14 days, access requests 7 days.
+package core
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// Invitation states.
+const (
+	InvitationPending  = "pending"
+	InvitationAccepted = "accepted"
+	InvitationRevoked  = "revoked"
+	InvitationExpired  = "expired"
+)
+
+// Access request states.
+const (
+	AccessRequestPending   = "pending"
+	AccessRequestApproved  = "approved"
+	AccessRequestRejected  = "rejected"
+	AccessRequestWithdrawn = "withdrawn"
+	AccessRequestExpired   = "expired"
+)
+
+// TTLs (ADR-024).
+const (
+	invitationTTL    = 14 * 24 * time.Hour
+	accessRequestTTL = 7 * 24 * time.Hour
+)
+
+// ── Invitations ────────────────────────────────────────────────────────────
+
+// InviteToProject creates a pending invitation for an email to a project with an
+// intended role. It snapshots the current validation mode and sets a 14-day TTL.
+func (c *KeyorixCore) InviteToProject(ctx context.Context, projectID uint, email, role string, invitedBy uint) (*models.ProjectInvitation, error) {
+	if projectID == 0 || email == "" || role == "" {
+		return nil, fmt.Errorf("project ID, email, and role are required")
+	}
+	if _, err := c.storage.GetRoleByName(ctx, role); err != nil {
+		return nil, fmt.Errorf("unknown role %q: %w", role, err)
+	}
+	now := c.now()
+	expires := now.Add(invitationTTL)
+	inv := &models.ProjectInvitation{
+		ProjectID: projectID,
+		Email:     email,
+		Role:      role,
+		State:     InvitationPending,
+		InvitedBy: invitedBy,
+		// Snapshot left empty here; once the membership validation-mode config
+		// (ADR-022) lands, capture it so consumption honours the mode at invite time.
+		ValidationModeAtInvite: "",
+		ExpiresAt:              &expires,
+		CreatedAt:              now,
+	}
+	created, err := c.storage.CreateProjectInvitation(ctx, inv)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create invitation: %w", err)
+	}
+	c.auditProjectScoped(ctx, "invitation.created", invitedBy, projectID,
+		fmt.Sprintf("invited %s to project %d as %s", email, projectID, role))
+	return created, nil
+}
+
+// ListProjectInvitations returns a project's invitations, marking any pending
+// invite past its TTL as expired (lazily, on read).
+func (c *KeyorixCore) ListProjectInvitations(ctx context.Context, projectID uint) ([]*models.ProjectInvitation, error) {
+	rows, err := c.storage.ListProjectInvitations(ctx, projectID)
+	if err != nil {
+		return nil, err
+	}
+	now := c.now()
+	for _, inv := range rows {
+		if inv.State == InvitationPending && inv.ExpiresAt != nil && now.After(*inv.ExpiresAt) {
+			inv.State = InvitationExpired
+			_ = c.storage.UpdateProjectInvitation(ctx, inv)
+		}
+	}
+	return rows, nil
+}
+
+// RevokeInvitation cancels a pending invitation.
+func (c *KeyorixCore) RevokeInvitation(ctx context.Context, invitationID, actorID uint) error {
+	inv, err := c.storage.GetProjectInvitation(ctx, invitationID)
+	if err != nil {
+		return fmt.Errorf("invitation not found")
+	}
+	if inv.State != InvitationPending {
+		return fmt.Errorf("only a pending invitation can be revoked (state is %s)", inv.State)
+	}
+	now := c.now()
+	inv.State = InvitationRevoked
+	inv.RevokedAt = &now
+	if err := c.storage.UpdateProjectInvitation(ctx, inv); err != nil {
+		return fmt.Errorf("failed to revoke invitation: %w", err)
+	}
+	c.auditProjectScoped(ctx, "invitation.revoked", actorID, inv.ProjectID,
+		fmt.Sprintf("revoked invitation %d (%s)", inv.ID, inv.Email))
+	return nil
+}
+
+// StaleInvitations returns pending invitations older than the cutoff.
+func (c *KeyorixCore) StaleInvitations(ctx context.Context, projectID uint, olderThan time.Duration) ([]*models.ProjectInvitation, error) {
+	rows, err := c.storage.ListProjectInvitations(ctx, projectID)
+	if err != nil {
+		return nil, err
+	}
+	cutoff := c.now().Add(-olderThan)
+	var stale []*models.ProjectInvitation
+	for _, inv := range rows {
+		if inv.State == InvitationPending && inv.CreatedAt.Before(cutoff) {
+			stale = append(stale, inv)
+		}
+	}
+	return stale, nil
+}
+
+// ── Access requests ──────────────────────────────────────────────────────────
+
+// RequestProjectAccess creates a pending access request for a user to a project.
+func (c *KeyorixCore) RequestProjectAccess(ctx context.Context, projectID, userID uint, suggestedRole, reason string) (*models.AccessRequest, error) {
+	if projectID == 0 || userID == 0 {
+		return nil, fmt.Errorf("project and user IDs are required")
+	}
+	if suggestedRole != "" {
+		if _, err := c.storage.GetRoleByName(ctx, suggestedRole); err != nil {
+			return nil, fmt.Errorf("unknown role %q: %w", suggestedRole, err)
+		}
+	}
+	now := c.now()
+	expires := now.Add(accessRequestTTL)
+	req := &models.AccessRequest{
+		ProjectID:     projectID,
+		UserID:        userID,
+		SuggestedRole: suggestedRole,
+		State:         AccessRequestPending,
+		Reason:        reason,
+		ExpiresAt:     &expires,
+		CreatedAt:     now,
+	}
+	created, err := c.storage.CreateAccessRequest(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create access request: %w", err)
+	}
+	c.auditProjectScoped(ctx, "access_request.created", userID, projectID,
+		fmt.Sprintf("user %d requested %s access to project %d", userID, suggestedRole, projectID))
+	return created, nil
+}
+
+// ListAccessRequests returns a project's access requests, expiring stale pending
+// ones lazily on read.
+func (c *KeyorixCore) ListAccessRequests(ctx context.Context, projectID uint) ([]*models.AccessRequest, error) {
+	rows, err := c.storage.ListAccessRequests(ctx, projectID)
+	if err != nil {
+		return nil, err
+	}
+	now := c.now()
+	for _, req := range rows {
+		if req.State == AccessRequestPending && req.ExpiresAt != nil && now.After(*req.ExpiresAt) {
+			req.State = AccessRequestExpired
+			_ = c.storage.UpdateAccessRequest(ctx, req)
+		}
+	}
+	return rows, nil
+}
+
+// ApproveAccessRequest approves a pending request, granting grantedRole (falling
+// back to the suggested role) at the project scope. No auto-approval — an admin
+// performs this explicitly.
+func (c *KeyorixCore) ApproveAccessRequest(ctx context.Context, requestID, approverID uint, grantedRole string) (*models.AccessRequest, error) {
+	req, err := c.storage.GetAccessRequest(ctx, requestID)
+	if err != nil {
+		return nil, fmt.Errorf("access request not found")
+	}
+	if req.State != AccessRequestPending {
+		return nil, fmt.Errorf("only a pending request can be approved (state is %s)", req.State)
+	}
+	role := grantedRole
+	if role == "" {
+		role = req.SuggestedRole
+	}
+	if role == "" {
+		return nil, fmt.Errorf("a role to grant is required")
+	}
+	roleModel, err := c.storage.GetRoleByName(ctx, role)
+	if err != nil {
+		return nil, fmt.Errorf("unknown role %q: %w", role, err)
+	}
+	// Grant the role at the project scope.
+	if err := c.storage.AssignRole(ctx, req.UserID, roleModel.ID, storage.Scope{ProjectID: req.ProjectID}); err != nil {
+		return nil, fmt.Errorf("failed to grant role: %w", err)
+	}
+	now := c.now()
+	req.State = AccessRequestApproved
+	req.GrantedRole = role
+	req.ResolvedBy = approverID
+	req.ResolvedAt = &now
+	if err := c.storage.UpdateAccessRequest(ctx, req); err != nil {
+		return nil, fmt.Errorf("failed to update access request: %w", err)
+	}
+	c.auditProjectScoped(ctx, "access_request.approved", approverID, req.ProjectID,
+		fmt.Sprintf("approved access request %d for user %d as %s", req.ID, req.UserID, role))
+	return req, nil
+}
+
+// RejectAccessRequest rejects a pending request with a reason.
+func (c *KeyorixCore) RejectAccessRequest(ctx context.Context, requestID, approverID uint, reason string) (*models.AccessRequest, error) {
+	req, err := c.storage.GetAccessRequest(ctx, requestID)
+	if err != nil {
+		return nil, fmt.Errorf("access request not found")
+	}
+	if req.State != AccessRequestPending {
+		return nil, fmt.Errorf("only a pending request can be rejected (state is %s)", req.State)
+	}
+	now := c.now()
+	req.State = AccessRequestRejected
+	req.Reason = reason
+	req.ResolvedBy = approverID
+	req.ResolvedAt = &now
+	if err := c.storage.UpdateAccessRequest(ctx, req); err != nil {
+		return nil, fmt.Errorf("failed to update access request: %w", err)
+	}
+	c.auditProjectScoped(ctx, "access_request.rejected", approverID, req.ProjectID,
+		fmt.Sprintf("rejected access request %d for user %d", req.ID, req.UserID))
+	return req, nil
+}
+
+// WithdrawAccessRequest lets the requester cancel their own pending request.
+func (c *KeyorixCore) WithdrawAccessRequest(ctx context.Context, requestID, userID uint) error {
+	req, err := c.storage.GetAccessRequest(ctx, requestID)
+	if err != nil {
+		return fmt.Errorf("access request not found")
+	}
+	if req.UserID != userID {
+		return fmt.Errorf("not your access request")
+	}
+	if req.State != AccessRequestPending {
+		return fmt.Errorf("only a pending request can be withdrawn (state is %s)", req.State)
+	}
+	now := c.now()
+	req.State = AccessRequestWithdrawn
+	req.ResolvedAt = &now
+	if err := c.storage.UpdateAccessRequest(ctx, req); err != nil {
+		return fmt.Errorf("failed to update access request: %w", err)
+	}
+	c.auditProjectScoped(ctx, "access_request.withdrawn", userID, req.ProjectID,
+		fmt.Sprintf("withdrew access request %d", req.ID))
+	return nil
+}
+
+// auditProjectScoped writes a project-scoped audit event with an actor.
+func (c *KeyorixCore) auditProjectScoped(ctx context.Context, eventType string, actorID, projectID uint, description string) {
+	aid, pid := actorID, projectID
+	c.writeAuditEventFull(ctx, eventType, &aid, nil, &pid, "", description)
+}

--- a/internal/core/invitations_test.go
+++ b/internal/core/invitations_test.go
@@ -1,0 +1,133 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func newInviteCore(store *MockStorage) *KeyorixCore {
+	fixed := time.Date(2026, 6, 5, 12, 0, 0, 0, time.UTC)
+	return &KeyorixCore{storage: store, now: func() time.Time { return fixed }}
+}
+
+func TestInviteToProject(t *testing.T) {
+	store := new(MockStorage)
+	c := newInviteCore(store)
+	ctx := context.Background()
+	store.On("GetRoleByName", ctx, "project_developer").Return(&models.Role{ID: 5}, nil)
+	store.On("CreateProjectInvitation", ctx, mock.MatchedBy(func(inv *models.ProjectInvitation) bool {
+		return inv.State == InvitationPending && inv.Email == "a@b.com" && inv.ProjectID == 1 && inv.ExpiresAt != nil
+	})).Return(&models.ProjectInvitation{ID: 7, State: InvitationPending}, nil)
+	store.On("LogAuditEvent", ctx, mock.MatchedBy(func(e *models.AuditEvent) bool {
+		return e.EventType == "invitation.created"
+	})).Return(nil)
+
+	inv, err := c.InviteToProject(ctx, 1, "a@b.com", "project_developer", 9)
+	require.NoError(t, err)
+	assert.Equal(t, InvitationPending, inv.State)
+	store.AssertExpectations(t)
+}
+
+func TestRevokeInvitation_RejectsNonPending(t *testing.T) {
+	store := new(MockStorage)
+	c := newInviteCore(store)
+	ctx := context.Background()
+	store.On("GetProjectInvitation", ctx, uint(7)).Return(&models.ProjectInvitation{ID: 7, State: InvitationAccepted}, nil)
+
+	err := c.RevokeInvitation(ctx, 7, 9)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "only a pending")
+	store.AssertNotCalled(t, "UpdateProjectInvitation", mock.Anything, mock.Anything)
+}
+
+func TestApproveAccessRequest_GrantsRole(t *testing.T) {
+	store := new(MockStorage)
+	c := newInviteCore(store)
+	ctx := context.Background()
+	store.On("GetAccessRequest", ctx, uint(3)).Return(&models.AccessRequest{
+		ID: 3, ProjectID: 1, UserID: 2, SuggestedRole: "project_viewer", State: AccessRequestPending,
+	}, nil)
+	// Admin upgrades the grant to developer.
+	store.On("GetRoleByName", ctx, "project_developer").Return(&models.Role{ID: 5}, nil)
+	store.On("AssignRole", ctx, uint(2), uint(5), storage.Scope{ProjectID: 1}).Return(nil)
+	store.On("UpdateAccessRequest", ctx, mock.MatchedBy(func(r *models.AccessRequest) bool {
+		return r.State == AccessRequestApproved && r.GrantedRole == "project_developer" && r.ResolvedBy == 9
+	})).Return(nil)
+	store.On("LogAuditEvent", ctx, mock.MatchedBy(func(e *models.AuditEvent) bool {
+		return e.EventType == "access_request.approved"
+	})).Return(nil)
+
+	out, err := c.ApproveAccessRequest(ctx, 3, 9, "project_developer")
+	require.NoError(t, err)
+	assert.Equal(t, AccessRequestApproved, out.State)
+	store.AssertCalled(t, "AssignRole", ctx, uint(2), uint(5), storage.Scope{ProjectID: 1})
+}
+
+func TestApproveAccessRequest_FallsBackToSuggestedRole(t *testing.T) {
+	store := new(MockStorage)
+	c := newInviteCore(store)
+	ctx := context.Background()
+	store.On("GetAccessRequest", ctx, uint(3)).Return(&models.AccessRequest{
+		ID: 3, ProjectID: 1, UserID: 2, SuggestedRole: "project_viewer", State: AccessRequestPending,
+	}, nil)
+	store.On("GetRoleByName", ctx, "project_viewer").Return(&models.Role{ID: 6}, nil)
+	store.On("AssignRole", ctx, uint(2), uint(6), storage.Scope{ProjectID: 1}).Return(nil)
+	store.On("UpdateAccessRequest", ctx, mock.Anything).Return(nil)
+	store.On("LogAuditEvent", ctx, mock.Anything).Return(nil)
+
+	// Empty grantedRole → uses the suggested role.
+	out, err := c.ApproveAccessRequest(ctx, 3, 9, "")
+	require.NoError(t, err)
+	assert.Equal(t, "project_viewer", out.GrantedRole)
+}
+
+func TestApproveAccessRequest_RejectsNonPending(t *testing.T) {
+	store := new(MockStorage)
+	c := newInviteCore(store)
+	ctx := context.Background()
+	store.On("GetAccessRequest", ctx, uint(3)).Return(&models.AccessRequest{ID: 3, State: AccessRequestApproved}, nil)
+
+	_, err := c.ApproveAccessRequest(ctx, 3, 9, "project_viewer")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "only a pending")
+	store.AssertNotCalled(t, "AssignRole", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestWithdrawAccessRequest_OwnershipChecked(t *testing.T) {
+	store := new(MockStorage)
+	c := newInviteCore(store)
+	ctx := context.Background()
+	store.On("GetAccessRequest", ctx, uint(3)).Return(&models.AccessRequest{ID: 3, UserID: 2, State: AccessRequestPending}, nil)
+
+	// A different user cannot withdraw it.
+	err := c.WithdrawAccessRequest(ctx, 3, 99)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not your")
+	store.AssertNotCalled(t, "UpdateAccessRequest", mock.Anything, mock.Anything)
+}
+
+func TestListProjectInvitations_LazyExpire(t *testing.T) {
+	store := new(MockStorage)
+	c := newInviteCore(store)
+	ctx := context.Background()
+	past := c.now().Add(-1 * time.Hour)
+	store.On("ListProjectInvitations", ctx, uint(1)).Return([]*models.ProjectInvitation{
+		{ID: 1, State: InvitationPending, ExpiresAt: &past},
+	}, nil)
+	// The expired pending invite is persisted as expired.
+	store.On("UpdateProjectInvitation", ctx, mock.MatchedBy(func(inv *models.ProjectInvitation) bool {
+		return inv.State == InvitationExpired
+	})).Return(nil)
+
+	out, err := c.ListProjectInvitations(ctx, 1)
+	require.NoError(t, err)
+	require.Len(t, out, 1)
+	assert.Equal(t, InvitationExpired, out[0].State)
+}

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -74,6 +74,64 @@ func (m *MockStorage) ListProjectMembers(_ context.Context, _ uint) ([]storage.P
 	return nil, nil
 }
 
+func (m *MockStorage) CreateProjectInvitation(ctx context.Context, inv *models.ProjectInvitation) (*models.ProjectInvitation, error) {
+	args := m.Called(ctx, inv)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.ProjectInvitation), args.Error(1)
+}
+
+func (m *MockStorage) GetProjectInvitation(ctx context.Context, id uint) (*models.ProjectInvitation, error) {
+	args := m.Called(ctx, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.ProjectInvitation), args.Error(1)
+}
+
+func (m *MockStorage) UpdateProjectInvitation(ctx context.Context, inv *models.ProjectInvitation) error {
+	args := m.Called(ctx, inv)
+	return args.Error(0)
+}
+
+func (m *MockStorage) ListProjectInvitations(ctx context.Context, projectID uint) ([]*models.ProjectInvitation, error) {
+	args := m.Called(ctx, projectID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*models.ProjectInvitation), args.Error(1)
+}
+
+func (m *MockStorage) CreateAccessRequest(ctx context.Context, req *models.AccessRequest) (*models.AccessRequest, error) {
+	args := m.Called(ctx, req)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.AccessRequest), args.Error(1)
+}
+
+func (m *MockStorage) GetAccessRequest(ctx context.Context, id uint) (*models.AccessRequest, error) {
+	args := m.Called(ctx, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.AccessRequest), args.Error(1)
+}
+
+func (m *MockStorage) UpdateAccessRequest(ctx context.Context, req *models.AccessRequest) error {
+	args := m.Called(ctx, req)
+	return args.Error(0)
+}
+
+func (m *MockStorage) ListAccessRequests(ctx context.Context, projectID uint) ([]*models.AccessRequest, error) {
+	args := m.Called(ctx, projectID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*models.AccessRequest), args.Error(1)
+}
+
 func (m *MockStorage) GetEnvironment(_ context.Context, id uint) (*models.Environment, error) {
 	return &models.Environment{ID: id, ProjectID: 1, Name: "test"}, nil
 }

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -28,6 +28,18 @@ type Storage interface {
 	ListEnvironmentsByProjectIncludingDeleted(ctx context.Context, projectID uint) ([]*models.Environment, error)
 	ListProjectMembers(ctx context.Context, projectID uint) ([]ProjectMember, error)
 
+	// Project invitations (ADR-024).
+	CreateProjectInvitation(ctx context.Context, inv *models.ProjectInvitation) (*models.ProjectInvitation, error)
+	GetProjectInvitation(ctx context.Context, id uint) (*models.ProjectInvitation, error)
+	UpdateProjectInvitation(ctx context.Context, inv *models.ProjectInvitation) error
+	ListProjectInvitations(ctx context.Context, projectID uint) ([]*models.ProjectInvitation, error)
+
+	// Access requests (ADR-024).
+	CreateAccessRequest(ctx context.Context, req *models.AccessRequest) (*models.AccessRequest, error)
+	GetAccessRequest(ctx context.Context, id uint) (*models.AccessRequest, error)
+	UpdateAccessRequest(ctx context.Context, req *models.AccessRequest) error
+	ListAccessRequests(ctx context.Context, projectID uint) ([]*models.AccessRequest, error)
+
 	// Secret Management
 	CreateSecret(ctx context.Context, secret *models.SecretNode) (*models.SecretNode, error)
 	GetSecret(ctx context.Context, id uint) (*models.SecretNode, error)

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -188,6 +188,8 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 	projectsExists := tableExists(db, "projects")
 	rotationExists := tableExists(db, "rotation_policies")
 	patExists := tableExists(db, "personal_access_tokens")
+	invitationsExists := tableExists(db, "project_invitations")
+	accessReqExists := tableExists(db, "access_requests")
 
 	// Create rotation_policies if missing (additive, safe on existing DBs).
 	if !rotationExists {
@@ -200,6 +202,18 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 	if !patExists {
 		if err := db.AutoMigrate(&models.PersonalAccessToken{}); err != nil {
 			return fmt.Errorf("failed to migrate personal_access_tokens table: %w", err)
+		}
+	}
+
+	// Create project_invitations / access_requests if missing (ADR-024, additive).
+	if !invitationsExists {
+		if err := db.AutoMigrate(&models.ProjectInvitation{}); err != nil {
+			return fmt.Errorf("failed to migrate project_invitations table: %w", err)
+		}
+	}
+	if !accessReqExists {
+		if err := db.AutoMigrate(&models.AccessRequest{}); err != nil {
+			return fmt.Errorf("failed to migrate access_requests table: %w", err)
 		}
 	}
 

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -24,6 +24,42 @@ type Environment struct {
 	DeletedAt gorm.DeletedAt `gorm:"index"` // soft delete
 }
 
+// ProjectInvitation tracks an admin's intent to grant an email address a role in
+// a project (ADR-024). State machine: pending → accepted / revoked / expired.
+// The email/setup-link consumption (accept) is a follow-up; this record tracks
+// the pending invite so it can be listed, revoked, and aged out.
+type ProjectInvitation struct {
+	ID                     uint   `gorm:"primaryKey"`
+	ProjectID              uint   `gorm:"index"`
+	Email                  string `gorm:"index"`
+	Role                   string // intended project role
+	State                  string // pending | accepted | revoked | expired
+	InvitedBy              uint
+	ValidationModeAtInvite string // snapshot of the install validation mode at invite time
+	ExpiresAt              *time.Time
+	CreatedAt              time.Time
+	AcceptedAt             *time.Time
+	RevokedAt              *time.Time
+}
+
+// AccessRequest is a user's request for a role in a project (ADR-024). State
+// machine: pending → approved / rejected / withdrawn / expired. On approval the
+// granted role (which may differ from the suggested one) is assigned at the
+// project scope. No auto-approval.
+type AccessRequest struct {
+	ID            uint   `gorm:"primaryKey"`
+	ProjectID     uint   `gorm:"index"`
+	UserID        uint   `gorm:"index"`
+	SuggestedRole string // role the requester asks for
+	GrantedRole   string // role actually granted on approval
+	State         string // pending | approved | rejected | withdrawn | expired
+	Reason        string // requester's note, or the rejecter's reason
+	ResolvedBy    uint
+	ExpiresAt     *time.Time
+	CreatedAt     time.Time
+	ResolvedAt    *time.Time
+}
+
 type User struct {
 	ID           uint   `gorm:"primaryKey"`
 	Username     string `gorm:"uniqueIndex;not null"`

--- a/internal/storage/store/invitations_test.go
+++ b/internal/storage/store/invitations_test.go
@@ -1,0 +1,73 @@
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func newInviteStore(t *testing.T) *LocalStorage {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.ProjectInvitation{}, &models.AccessRequest{}))
+	return NewLocalStorage(db)
+}
+
+func TestProjectInvitation_RoundTrip(t *testing.T) {
+	ctx := context.Background()
+	ls := newInviteStore(t)
+	now := time.Date(2026, 6, 5, 9, 0, 0, 0, time.UTC)
+
+	created, err := ls.CreateProjectInvitation(ctx, &models.ProjectInvitation{
+		ProjectID: 1, Email: "a@b.com", Role: "project_developer", State: "pending",
+		InvitedBy: 9, CreatedAt: now,
+	})
+	require.NoError(t, err)
+	require.NotZero(t, created.ID)
+
+	got, err := ls.GetProjectInvitation(ctx, created.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "pending", got.State)
+
+	got.State = "revoked"
+	require.NoError(t, ls.UpdateProjectInvitation(ctx, got))
+
+	// Scoped list.
+	_, err = ls.CreateProjectInvitation(ctx, &models.ProjectInvitation{ProjectID: 2, Email: "c@d.com", State: "pending", CreatedAt: now})
+	require.NoError(t, err)
+	list, err := ls.ListProjectInvitations(ctx, 1)
+	require.NoError(t, err)
+	assert.Len(t, list, 1)
+	assert.Equal(t, "revoked", list[0].State)
+}
+
+func TestAccessRequest_RoundTrip(t *testing.T) {
+	ctx := context.Background()
+	ls := newInviteStore(t)
+	now := time.Date(2026, 6, 5, 9, 0, 0, 0, time.UTC)
+
+	created, err := ls.CreateAccessRequest(ctx, &models.AccessRequest{
+		ProjectID: 1, UserID: 2, SuggestedRole: "project_viewer", State: "pending", CreatedAt: now,
+	})
+	require.NoError(t, err)
+	require.NotZero(t, created.ID)
+
+	created.State = "approved"
+	created.GrantedRole = "project_viewer"
+	require.NoError(t, ls.UpdateAccessRequest(ctx, created))
+
+	got, err := ls.GetAccessRequest(ctx, created.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "approved", got.State)
+
+	list, err := ls.ListAccessRequests(ctx, 1)
+	require.NoError(t, err)
+	assert.Len(t, list, 1)
+}

--- a/internal/storage/store/local_invitations.go
+++ b/internal/storage/store/local_invitations.go
@@ -1,0 +1,84 @@
+// local_invitations.go — project invitations + access requests persistence (ADR-024).
+//
+// For the remote (HTTP) equivalent see remote_invitations.go.
+package store
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// --- Project invitations ---
+
+func (ls *LocalStorage) CreateProjectInvitation(ctx context.Context, inv *models.ProjectInvitation) (*models.ProjectInvitation, error) {
+	if err := ls.db.WithContext(ctx).Create(inv).Error; err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	return inv, nil
+}
+
+func (ls *LocalStorage) GetProjectInvitation(ctx context.Context, id uint) (*models.ProjectInvitation, error) {
+	var inv models.ProjectInvitation
+	if err := ls.db.WithContext(ctx).First(&inv, id).Error; err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorNotFound", nil), err)
+	}
+	return &inv, nil
+}
+
+func (ls *LocalStorage) UpdateProjectInvitation(ctx context.Context, inv *models.ProjectInvitation) error {
+	if err := ls.db.WithContext(ctx).Save(inv).Error; err != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	return nil
+}
+
+func (ls *LocalStorage) ListProjectInvitations(ctx context.Context, projectID uint) ([]*models.ProjectInvitation, error) {
+	var rows []*models.ProjectInvitation
+	err := ls.db.WithContext(ctx).
+		Where("project_id = ?", projectID).
+		Order("created_at DESC").
+		Find(&rows).Error
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	return rows, nil
+}
+
+// --- Access requests ---
+
+func (ls *LocalStorage) CreateAccessRequest(ctx context.Context, req *models.AccessRequest) (*models.AccessRequest, error) {
+	if err := ls.db.WithContext(ctx).Create(req).Error; err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	return req, nil
+}
+
+func (ls *LocalStorage) GetAccessRequest(ctx context.Context, id uint) (*models.AccessRequest, error) {
+	var req models.AccessRequest
+	if err := ls.db.WithContext(ctx).First(&req, id).Error; err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorNotFound", nil), err)
+	}
+	return &req, nil
+}
+
+func (ls *LocalStorage) UpdateAccessRequest(ctx context.Context, req *models.AccessRequest) error {
+	if err := ls.db.WithContext(ctx).Save(req).Error; err != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	return nil
+}
+
+func (ls *LocalStorage) ListAccessRequests(ctx context.Context, projectID uint) ([]*models.AccessRequest, error) {
+	var rows []*models.AccessRequest
+	err := ls.db.WithContext(ctx).
+		Where("project_id = ?", projectID).
+		Order("created_at DESC").
+		Find(&rows).Error
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	return rows, nil
+}

--- a/internal/storage/store/remote_invitations.go
+++ b/internal/storage/store/remote_invitations.go
@@ -1,0 +1,44 @@
+// remote_invitations.go — invitations + access requests for RemoteStorage (ADR-024).
+//
+// Processed server-side in remote mode; stubs. For the local (GORM) equivalent
+// see local_invitations.go.
+package store
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+func (rs *RemoteStorage) CreateProjectInvitation(_ context.Context, _ *models.ProjectInvitation) (*models.ProjectInvitation, error) {
+	return nil, fmt.Errorf("CreateProjectInvitation not implemented for remote storage")
+}
+
+func (rs *RemoteStorage) GetProjectInvitation(_ context.Context, _ uint) (*models.ProjectInvitation, error) {
+	return nil, fmt.Errorf("GetProjectInvitation not implemented for remote storage")
+}
+
+func (rs *RemoteStorage) UpdateProjectInvitation(_ context.Context, _ *models.ProjectInvitation) error {
+	return fmt.Errorf("UpdateProjectInvitation not implemented for remote storage")
+}
+
+func (rs *RemoteStorage) ListProjectInvitations(_ context.Context, _ uint) ([]*models.ProjectInvitation, error) {
+	return nil, fmt.Errorf("ListProjectInvitations not implemented for remote storage")
+}
+
+func (rs *RemoteStorage) CreateAccessRequest(_ context.Context, _ *models.AccessRequest) (*models.AccessRequest, error) {
+	return nil, fmt.Errorf("CreateAccessRequest not implemented for remote storage")
+}
+
+func (rs *RemoteStorage) GetAccessRequest(_ context.Context, _ uint) (*models.AccessRequest, error) {
+	return nil, fmt.Errorf("GetAccessRequest not implemented for remote storage")
+}
+
+func (rs *RemoteStorage) UpdateAccessRequest(_ context.Context, _ *models.AccessRequest) error {
+	return fmt.Errorf("UpdateAccessRequest not implemented for remote storage")
+}
+
+func (rs *RemoteStorage) ListAccessRequests(_ context.Context, _ uint) ([]*models.AccessRequest, error) {
+	return nil, fmt.Errorf("ListAccessRequests not implemented for remote storage")
+}

--- a/server/http/handlers/invitations.go
+++ b/server/http/handlers/invitations.go
@@ -1,0 +1,221 @@
+// invitations.go — project invitation + access-request endpoints (ADR-024).
+//
+// Invitations are admin-driven (roles.assign). Access requests are user-driven:
+// requesting and withdrawing are self-service (any authenticated user — the
+// whole point is the user does NOT yet have project access), while listing and
+// approving/rejecting require roles.assign at the project scope.
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/keyorixhq/keyorix/server/middleware"
+)
+
+// ── Invitations ────────────────────────────────────────────────────────────
+
+// ListInvitations handles GET /api/v1/projects/{id}/invitations.
+func (h *CatalogHandler) ListInvitations(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		sendError(w, "InvalidParameter", "Invalid project ID", http.StatusBadRequest, nil)
+		return
+	}
+	invitations, err := h.coreService.ListProjectInvitations(r.Context(), uint(id))
+	if err != nil {
+		sendError(w, "Error", err.Error(), http.StatusInternalServerError, nil)
+		return
+	}
+	sendSuccess(w, map[string]interface{}{"invitations": invitations}, "")
+}
+
+// CreateInvitation handles POST /api/v1/projects/{id}/invitations.
+func (h *CatalogHandler) CreateInvitation(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		sendError(w, "InvalidParameter", "Invalid project ID", http.StatusBadRequest, nil)
+		return
+	}
+	actor := middleware.GetUserFromContext(r.Context())
+	if actor == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	var body struct {
+		Email string `json:"email"`
+		Role  string `json:"role"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		sendError(w, "InvalidJSON", "Invalid request body", http.StatusBadRequest, nil)
+		return
+	}
+	if body.Email == "" || body.Role == "" {
+		sendError(w, "ValidationError", "email and role are required", http.StatusBadRequest, nil)
+		return
+	}
+	inv, err := h.coreService.InviteToProject(r.Context(), uint(id), body.Email, body.Role, actor.UserID)
+	if err != nil {
+		status := http.StatusInternalServerError
+		if strings.Contains(err.Error(), "unknown role") || strings.Contains(err.Error(), "required") {
+			status = http.StatusBadRequest
+		}
+		sendError(w, "Error", err.Error(), status, nil)
+		return
+	}
+	w.WriteHeader(http.StatusCreated)
+	sendSuccess(w, map[string]interface{}{"invitation": inv}, "Invitation created")
+}
+
+// RevokeInvitation handles DELETE /api/v1/projects/{id}/invitations/{invitationId}.
+func (h *CatalogHandler) RevokeInvitation(w http.ResponseWriter, r *http.Request) {
+	invID, err := strconv.ParseUint(chi.URLParam(r, "invitationId"), 10, 32)
+	if err != nil {
+		sendError(w, "InvalidParameter", "Invalid invitation ID", http.StatusBadRequest, nil)
+		return
+	}
+	actor := middleware.GetUserFromContext(r.Context())
+	if actor == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	if err := h.coreService.RevokeInvitation(r.Context(), uint(invID), actor.UserID); err != nil {
+		status := http.StatusInternalServerError
+		switch {
+		case strings.Contains(err.Error(), "not found"):
+			status = http.StatusNotFound
+		case strings.Contains(err.Error(), "only a pending"):
+			status = http.StatusConflict
+		}
+		sendError(w, "Error", err.Error(), status, nil)
+		return
+	}
+	sendSuccess(w, nil, "Invitation revoked")
+}
+
+// ── Access requests ──────────────────────────────────────────────────────────
+
+// ListAccessRequests handles GET /api/v1/projects/{id}/access-requests.
+func (h *CatalogHandler) ListAccessRequests(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		sendError(w, "InvalidParameter", "Invalid project ID", http.StatusBadRequest, nil)
+		return
+	}
+	requests, err := h.coreService.ListAccessRequests(r.Context(), uint(id))
+	if err != nil {
+		sendError(w, "Error", err.Error(), http.StatusInternalServerError, nil)
+		return
+	}
+	sendSuccess(w, map[string]interface{}{"access_requests": requests}, "")
+}
+
+// CreateAccessRequest handles POST /api/v1/projects/{id}/access-requests (self-service).
+func (h *CatalogHandler) CreateAccessRequest(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		sendError(w, "InvalidParameter", "Invalid project ID", http.StatusBadRequest, nil)
+		return
+	}
+	actor := middleware.GetUserFromContext(r.Context())
+	if actor == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	var body struct {
+		SuggestedRole string `json:"suggested_role"`
+		Reason        string `json:"reason"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		sendError(w, "InvalidJSON", "Invalid request body", http.StatusBadRequest, nil)
+		return
+	}
+	req, err := h.coreService.RequestProjectAccess(r.Context(), uint(id), actor.UserID, body.SuggestedRole, body.Reason)
+	if err != nil {
+		status := http.StatusInternalServerError
+		if strings.Contains(err.Error(), "unknown role") || strings.Contains(err.Error(), "required") {
+			status = http.StatusBadRequest
+		}
+		sendError(w, "Error", err.Error(), status, nil)
+		return
+	}
+	w.WriteHeader(http.StatusCreated)
+	sendSuccess(w, map[string]interface{}{"access_request": req}, "Access requested")
+}
+
+// ResolveAccessRequest handles PUT /api/v1/projects/{id}/access-requests/{requestId}
+// for an admin: body {"action":"approve"|"reject", "granted_role":..., "reason":...}.
+func (h *CatalogHandler) ResolveAccessRequest(w http.ResponseWriter, r *http.Request) {
+	reqID, err := strconv.ParseUint(chi.URLParam(r, "requestId"), 10, 32)
+	if err != nil {
+		sendError(w, "InvalidParameter", "Invalid request ID", http.StatusBadRequest, nil)
+		return
+	}
+	actor := middleware.GetUserFromContext(r.Context())
+	if actor == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	var body struct {
+		Action      string `json:"action"`
+		GrantedRole string `json:"granted_role"`
+		Reason      string `json:"reason"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		sendError(w, "InvalidJSON", "Invalid request body", http.StatusBadRequest, nil)
+		return
+	}
+	var resolveErr error
+	switch body.Action {
+	case "approve":
+		_, resolveErr = h.coreService.ApproveAccessRequest(r.Context(), uint(reqID), actor.UserID, body.GrantedRole)
+	case "reject":
+		_, resolveErr = h.coreService.RejectAccessRequest(r.Context(), uint(reqID), actor.UserID, body.Reason)
+	default:
+		sendError(w, "ValidationError", "action must be approve or reject", http.StatusBadRequest, nil)
+		return
+	}
+	if resolveErr != nil {
+		status := http.StatusInternalServerError
+		switch {
+		case strings.Contains(resolveErr.Error(), "not found"):
+			status = http.StatusNotFound
+		case strings.Contains(resolveErr.Error(), "only a pending"), strings.Contains(resolveErr.Error(), "unknown role"), strings.Contains(resolveErr.Error(), "required"):
+			status = http.StatusConflict
+		}
+		sendError(w, "Error", resolveErr.Error(), status, nil)
+		return
+	}
+	sendSuccess(w, nil, "Access request "+body.Action+"d")
+}
+
+// WithdrawAccessRequest handles POST /api/v1/projects/{id}/access-requests/{requestId}/withdraw (self-service).
+func (h *CatalogHandler) WithdrawAccessRequest(w http.ResponseWriter, r *http.Request) {
+	reqID, err := strconv.ParseUint(chi.URLParam(r, "requestId"), 10, 32)
+	if err != nil {
+		sendError(w, "InvalidParameter", "Invalid request ID", http.StatusBadRequest, nil)
+		return
+	}
+	actor := middleware.GetUserFromContext(r.Context())
+	if actor == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	if err := h.coreService.WithdrawAccessRequest(r.Context(), uint(reqID), actor.UserID); err != nil {
+		status := http.StatusInternalServerError
+		switch {
+		case strings.Contains(err.Error(), "not found"):
+			status = http.StatusNotFound
+		case strings.Contains(err.Error(), "not your"):
+			status = http.StatusForbidden
+		case strings.Contains(err.Error(), "only a pending"):
+			status = http.StatusConflict
+		}
+		sendError(w, "Error", err.Error(), status, nil)
+		return
+	}
+	sendSuccess(w, nil, "Access request withdrawn")
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -151,6 +151,17 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		r.With(customMiddleware.RequireScopedPermission("roles.assign", projectScope)).Post("/projects/{id}/members", catalogHandler.AddProjectMember)
 		r.With(customMiddleware.RequireScopedPermission("roles.assign", projectScope)).Put("/projects/{id}/members/{userId}", catalogHandler.UpdateProjectMember)
 		r.With(customMiddleware.RequireScopedPermission("roles.assign", projectScope)).Delete("/projects/{id}/members/{userId}", catalogHandler.RemoveProjectMember)
+		// Invitations (ADR-024): admin-driven (roles.assign at the project scope).
+		r.With(customMiddleware.RequireScopedPermission("users.read", projectScope)).Get("/projects/{id}/invitations", catalogHandler.ListInvitations)
+		r.With(customMiddleware.RequireScopedPermission("roles.assign", projectScope)).Post("/projects/{id}/invitations", catalogHandler.CreateInvitation)
+		r.With(customMiddleware.RequireScopedPermission("roles.assign", projectScope)).Delete("/projects/{id}/invitations/{invitationId}", catalogHandler.RevokeInvitation)
+		// Access requests (ADR-024): requesting + withdrawing are self-service (any
+		// authenticated user — they don't have project access yet); listing and
+		// approving/rejecting require roles.assign at the project scope.
+		r.With(customMiddleware.RequireScopedPermission("roles.assign", projectScope)).Get("/projects/{id}/access-requests", catalogHandler.ListAccessRequests)
+		r.Post("/projects/{id}/access-requests", catalogHandler.CreateAccessRequest)
+		r.With(customMiddleware.RequireScopedPermission("roles.assign", projectScope)).Put("/projects/{id}/access-requests/{requestId}", catalogHandler.ResolveAccessRequest)
+		r.Post("/projects/{id}/access-requests/{requestId}/withdraw", catalogHandler.WithdrawAccessRequest)
 		r.With(customMiddleware.RequireScopedPermission("secrets.read", projectScope)).Get("/projects/{id}/environments", catalogHandler.ListProjectEnvironments)
 		r.With(customMiddleware.RequireScopedPermission("secrets.write", projectScope)).Post("/projects/{id}/environments", catalogHandler.CreateProjectEnvironment)
 		// Environment restore is nested under the project so the scope resolves


### PR DESCRIPTION
Two related onboarding flows, project-scoped, each a state machine audited on every transition.

**Access requests (full)** — `pending → approved / rejected / withdrawn / expired` (7-day TTL). A user requests a role; an admin approves (granting the suggested or an adjusted role at the project scope via `AssignRole` — no auto-approval), rejects with a reason, or the requester withdraws. Requesting + withdrawing are self-service (any authenticated user — they don't have project access yet); listing + approve/reject need `roles.assign`.

**Invitations (foundation)** — `pending → accepted / revoked / expired` (14-day TTL). Admin invites an email with an intended role; listable, revocable, lazily aged out; `StaleInvitations` surfaces overdue ones. The email/setup-link **consumption (accept)** is a deliberate follow-up — needs SMTP/credential-delivery infra.

Storage: 8 interface methods, local GORM impl, remote stubs, mock. Two additive pgx-safe table creates. HTTP under `/projects/{id}/{invitations,access-requests}` (self-service POST/withdraw ungated by design; admin list/resolve gated).

Tests: invite create+audit, revoke/approve/withdraw guards, approve-grants-role + fallback-to-suggested, ownership, lazy-expire (mock); store round-trips (SQLite). Full gate green.

**Deferred (ADR-024):** invitation email + single-use setup-link consumption (SMTP), the invitation/access-request dialogs (frontend), in-app notifications, and the `keyorix invite` / `keyorix request` CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)