### PR TITLE
feat(audit): actor_type (user vs machine_identity) on every audit event (ADR-023)

### DIFF
--- a/internal/audit/siem/forwarder.go
+++ b/internal/audit/siem/forwarder.go
@@ -147,6 +147,7 @@ type eventPayload struct {
 	SecretID       *uint           `json:"secret_id,omitempty"`
 	Description    string          `json:"description"`
 	IPAddress      string          `json:"ip_address,omitempty"`
+	ActorType      string          `json:"actor_type,omitempty"`
 	Success        bool            `json:"success"`
 	Diff           json.RawMessage `json:"diff,omitempty"`
 	Impersonation  bool            `json:"impersonation,omitempty"`
@@ -168,6 +169,7 @@ func toPayload(e *models.AuditEvent) eventPayload {
 		SecretID:       e.SecretNodeID,
 		Description:    e.Description,
 		IPAddress:      e.IPAddress,
+		ActorType:      e.ActorType,
 		Success:        success,
 		Impersonation:  e.Impersonation,
 		ImpersonatedBy: e.ImpersonatedBy,

--- a/internal/core/audit.go
+++ b/internal/core/audit.go
@@ -34,6 +34,7 @@ func (c *KeyorixCore) writeAuditEventDiff(ctx context.Context, eventType string,
 		Success:      &t,
 		EventTime:    time.Now(),
 		Diff:         diff,
+		ActorType:    actorTypeFromContext(ctx),
 	}
 	if adminID, ok := impersonatorFromContext(ctx); ok {
 		a := adminID
@@ -54,6 +55,7 @@ func (c *KeyorixCore) writeAuditEventFailed(ctx context.Context, eventType strin
 		Description: description,
 		Success:     &f,
 		EventTime:   time.Now(),
+		ActorType:   actorTypeFromContext(ctx),
 	}
 	c.emitAudit(ctx, event)
 }

--- a/internal/core/audit_actor_type_test.go
+++ b/internal/core/audit_actor_type_test.go
@@ -1,0 +1,98 @@
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/mock"
+)
+
+// captureActorType writes one audit event and returns the ActorType stamped on
+// the row handed to storage.
+func captureActorType(t *testing.T, write func(c *KeyorixCore, ctx context.Context)) string {
+	t.Helper()
+	store := new(MockStorage)
+	c := NewKeyorixCore(store)
+	var got string
+	store.On("LogAuditEvent", mock.Anything, mock.MatchedBy(func(e *models.AuditEvent) bool {
+		got = e.ActorType
+		return true
+	})).Return(nil)
+	write(c, context.Background())
+	store.AssertExpectations(t)
+	return got
+}
+
+func TestWriteAuditEvent_DefaultsToUserActorType(t *testing.T) {
+	got := captureActorType(t, func(c *KeyorixCore, ctx context.Context) {
+		c.writeAuditEventFull(ctx, "secret.read", nil, nil, nil, "", "x")
+	})
+	if got != ActorTypeUser {
+		t.Errorf("ActorType = %q, want %q", got, ActorTypeUser)
+	}
+}
+
+func TestWriteAuditEvent_StampsMachineActorTypeFromContext(t *testing.T) {
+	store := new(MockStorage)
+	c := NewKeyorixCore(store)
+	var got string
+	store.On("LogAuditEvent", mock.Anything, mock.MatchedBy(func(e *models.AuditEvent) bool {
+		got = e.ActorType
+		return true
+	})).Return(nil)
+
+	ctx := WithActorType(context.Background(), ActorTypeMachine)
+	c.writeAuditEventFull(ctx, "secret.read", nil, nil, nil, "", "x")
+
+	store.AssertExpectations(t)
+	if got != ActorTypeMachine {
+		t.Errorf("ActorType = %q, want %q", got, ActorTypeMachine)
+	}
+}
+
+func TestWriteAuditEventFailed_StampsActorTypeFromContext(t *testing.T) {
+	store := new(MockStorage)
+	c := NewKeyorixCore(store)
+	var got string
+	store.On("LogAuditEvent", mock.Anything, mock.MatchedBy(func(e *models.AuditEvent) bool {
+		got = e.ActorType
+		return true
+	})).Return(nil)
+
+	ctx := WithActorType(context.Background(), ActorTypeSystem)
+	c.writeAuditEventFailed(ctx, "auth.login_failed", nil, "1.2.3.4", "x")
+
+	store.AssertExpectations(t)
+	if got != ActorTypeSystem {
+		t.Errorf("ActorType = %q, want %q", got, ActorTypeSystem)
+	}
+}
+
+func TestActorTypeFromContext_DefaultAndTagged(t *testing.T) {
+	if at := actorTypeFromContext(context.Background()); at != ActorTypeUser {
+		t.Errorf("untagged context actor type = %q, want %q", at, ActorTypeUser)
+	}
+	// An empty tag is treated as no tag (default user).
+	if ctx := WithActorType(context.Background(), ""); actorTypeFromContext(ctx) != ActorTypeUser {
+		t.Errorf("empty tag should default to %q", ActorTypeUser)
+	}
+	ctx := WithActorType(context.Background(), ActorTypeMachine)
+	if at := actorTypeFromContext(ctx); at != ActorTypeMachine {
+		t.Errorf("tagged context actor type = %q, want %q", at, ActorTypeMachine)
+	}
+}
+
+// DetachedAuditContext must carry the actor-type tag (and impersonation) past
+// request cancellation into the detached audit goroutine.
+func TestDetachedAuditContext_PreservesActorTypeAndImpersonation(t *testing.T) {
+	parent := WithActorType(WithImpersonation(context.Background(), 7), ActorTypeMachine)
+	detached := DetachedAuditContext(parent)
+
+	if at := actorTypeFromContext(detached); at != ActorTypeMachine {
+		t.Errorf("detached actor type = %q, want %q", at, ActorTypeMachine)
+	}
+	if adminID, ok := impersonatorFromContext(detached); !ok || adminID != 7 {
+		t.Errorf("detached impersonator = (%d,%v), want (7,true)", adminID, ok)
+	}
+}

--- a/internal/core/audit_context.go
+++ b/internal/core/audit_context.go
@@ -10,7 +10,38 @@ package core
 
 import "context"
 
+// Actor types stamped on every audit event (ADR-023). They distinguish a human
+// user from a non-human machine identity so the audit view can segment and
+// filter the two.
+const (
+	ActorTypeUser    = "user"
+	ActorTypeMachine = "machine_identity"
+	ActorTypeSystem  = "system"
+)
+
 type impersonationKey struct{}
+
+type actorTypeKey struct{}
+
+// WithActorType tags ctx with the principal kind for the current request
+// (ActorTypeUser/ActorTypeMachine/ActorTypeSystem). The auth middleware sets it
+// per request; writeAuditEvent* reads it and stamps ActorType on the row. An
+// empty actorType is treated as "no tag" (the writer defaults to user).
+func WithActorType(ctx context.Context, actorType string) context.Context {
+	if actorType == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, actorTypeKey{}, actorType)
+}
+
+// actorTypeFromContext returns the tagged actor type, defaulting to
+// ActorTypeUser when the context carries no tag.
+func actorTypeFromContext(ctx context.Context) string {
+	if t, ok := ctx.Value(actorTypeKey{}).(string); ok && t != "" {
+		return t
+	}
+	return ActorTypeUser
+}
 
 // WithImpersonation tags ctx with the admin user ID that initiated the current
 // impersonation session. A zero adminID is treated as "no impersonation".
@@ -32,8 +63,12 @@ func impersonatorFromContext(ctx context.Context) (uint, bool) {
 // impersonation tag from parent. Audit writes run in goroutines that must
 // outlive the request, but still need to record the impersonating admin.
 func DetachedAuditContext(parent context.Context) context.Context {
+	ctx := context.Background()
 	if adminID, ok := impersonatorFromContext(parent); ok {
-		return WithImpersonation(context.Background(), adminID)
+		ctx = WithImpersonation(ctx, adminID)
 	}
-	return context.Background()
+	if t, ok := parent.Value(actorTypeKey{}).(string); ok && t != "" {
+		ctx = WithActorType(ctx, t)
+	}
+	return ctx
 }

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -254,6 +254,9 @@ type AuditFilter struct {
 	Action    *string
 	Resource  *string
 	Success   *bool
+	// ActorType filters by acting-principal kind: "user" or "machine_identity"
+	// (also "system"). Nil = all actor types. (ADR-023)
+	ActorType *string
 	StartTime *time.Time
 	EndTime   *time.Time
 	Page      int

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -186,6 +186,10 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 		if !columnExists(db, "audit_events", "impersonation") {
 			db.Exec("ALTER TABLE audit_events ADD COLUMN impersonation BOOLEAN NOT NULL DEFAULT false")
 		}
+		// ADR-023: actor kind (user vs machine_identity) on every event.
+		if !columnExists(db, "audit_events", "actor_type") {
+			db.Exec("ALTER TABLE audit_events ADD COLUMN actor_type TEXT NOT NULL DEFAULT 'user'")
+		}
 	}
 
 	// Impersonation sessions carry the initiating admin + start time.

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -286,6 +286,14 @@ type AuditEvent struct {
 	ImpersonatedBy *uint
 	ActingAs       *uint
 	Impersonation  bool `gorm:"default:false"`
+
+	// ActorType records whether the acting principal is a human user or a
+	// non-human machine identity (ADR-023). It is "user" on every ordinary
+	// event; the (future) machine-token auth path tags the request context so
+	// every event under a machine session is stamped "machine_identity".
+	// "system" marks events with no authenticated principal. Defaults to "user"
+	// so legacy rows and back-compat writers read as human-actored.
+	ActorType string `gorm:"default:user"`
 }
 
 type Setting struct {

--- a/internal/storage/store/audit_actor_type_test.go
+++ b/internal/storage/store/audit_actor_type_test.go
@@ -1,0 +1,43 @@
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// GetAuditLogs filters by actor_type; a nil filter returns every actor kind.
+func TestGetAuditLogs_FilterByActorType(t *testing.T) {
+	ctx := context.Background()
+	ls := newAuditTestStore(t)
+	now := time.Now().UTC()
+
+	ev := func(eventType, actorType string, at time.Time) *models.AuditEvent {
+		return &models.AuditEvent{EventType: eventType, ActorType: actorType, EventTime: at}
+	}
+	require.NoError(t, ls.LogAuditEvent(ctx, ev("secret.read", "user", now.Add(1*time.Second))))
+	require.NoError(t, ls.LogAuditEvent(ctx, ev("secret.read", "user", now.Add(2*time.Second))))
+	require.NoError(t, ls.LogAuditEvent(ctx, ev("secret.read", "machine_identity", now.Add(3*time.Second))))
+	require.NoError(t, ls.LogAuditEvent(ctx, ev("anomaly.detected", "system", now.Add(4*time.Second))))
+
+	machine := "machine_identity"
+	events, total, err := ls.GetAuditLogs(ctx, &storage.AuditFilter{ActorType: &machine})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), total, "only the machine-actored event matches")
+	require.Len(t, events, 1)
+	assert.Equal(t, "machine_identity", events[0].ActorType)
+
+	user := "user"
+	_, userTotal, err := ls.GetAuditLogs(ctx, &storage.AuditFilter{ActorType: &user})
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), userTotal, "two user-actored events match")
+
+	_, allTotal, err := ls.GetAuditLogs(ctx, &storage.AuditFilter{})
+	require.NoError(t, err)
+	assert.Equal(t, int64(4), allTotal, "no actor_type filter returns every event")
+}

--- a/internal/storage/store/local_audit.go
+++ b/internal/storage/store/local_audit.go
@@ -58,6 +58,9 @@ func (ls *LocalStorage) GetAuditLogs(ctx context.Context, filter *storage.AuditF
 		if filter.Success != nil {
 			query = query.Where("success = ?", *filter.Success)
 		}
+		if filter.ActorType != nil {
+			query = query.Where("actor_type = ?", *filter.ActorType)
+		}
 		if filter.AfterID != nil {
 			query = query.Where("id > ?", *filter.AfterID)
 		}

--- a/internal/storage/store/remote_audit.go
+++ b/internal/storage/store/remote_audit.go
@@ -73,6 +73,7 @@ func buildAuditFilterPath(filter *storage.AuditFilter) string {
 	params.addUint("user_id", filter.UserID)
 	params.addString("action", filter.Action)
 	params.addString("resource", filter.Resource)
+	params.addString("actor_type", filter.ActorType)
 	params.addBool("success", filter.Success)
 	params.addTime("start_time", filter.StartTime)
 	params.addTime("end_time", filter.EndTime)

--- a/server/http/handlers/audit.go
+++ b/server/http/handlers/audit.go
@@ -26,9 +26,13 @@ func NewAuditHandler(coreService *core.KeyorixCore) *AuditHandler {
 
 // AuditLogEntry is the wire format returned to the frontend.
 type AuditLogEntry struct {
-	ID          uint      `json:"id"`
-	EventType   string    `json:"event_type"`
-	Actor       string    `json:"actor"`
+	ID        uint   `json:"id"`
+	EventType string `json:"event_type"`
+	Actor     string `json:"actor"`
+	// ActorType is the acting-principal kind: "user" or "machine_identity"
+	// (also "system"). Lets the audit view segment/filter human vs machine
+	// activity (ADR-023).
+	ActorType   string    `json:"actor_type"`
 	Description string    `json:"description"`
 	Timestamp   time.Time `json:"timestamp"`
 	// Diff is the structured before/after payload for mutation events (parsed
@@ -84,6 +88,9 @@ func (h *AuditHandler) GetAuditLogs(w http.ResponseWriter, r *http.Request) {
 			filter.EndTime = &t
 		}
 	}
+	if at := r.URL.Query().Get("actor_type"); validActorType(at) {
+		filter.ActorType = &at
+	}
 
 	events, total, err := h.coreService.Storage().GetAuditLogs(r.Context(), filter)
 	if err != nil {
@@ -105,6 +112,7 @@ func (h *AuditHandler) GetAuditLogs(w http.ResponseWriter, r *http.Request) {
 			ID:          e.ID,
 			EventType:   e.EventType,
 			Actor:       actor,
+			ActorType:   actorTypeOrDefault(e.ActorType),
 			Description: e.Description,
 			Timestamp:   e.EventTime,
 		}
@@ -150,6 +158,7 @@ type AuditExportEntry struct {
 	SecretID       *uint           `json:"secret_id,omitempty"`
 	Description    string          `json:"description"`
 	IPAddress      string          `json:"ip_address,omitempty"`
+	ActorType      string          `json:"actor_type"`
 	Success        bool            `json:"success"`
 	Diff           json.RawMessage `json:"diff,omitempty"`
 	Impersonation  bool            `json:"impersonation,omitempty"`
@@ -216,6 +225,7 @@ func (h *AuditHandler) ExportAuditLogs(w http.ResponseWriter, r *http.Request) {
 			SecretID:    e.SecretNodeID,
 			Description: e.Description,
 			IPAddress:   e.IPAddress,
+			ActorType:   actorTypeOrDefault(e.ActorType),
 			Success:     success,
 		}
 		if e.Diff != "" {
@@ -236,6 +246,25 @@ func (h *AuditHandler) ExportAuditLogs(w http.ResponseWriter, r *http.Request) {
 		"count":       len(entries),
 		"next_cursor": nextCursor,
 	}, "")
+}
+
+// validActorType reports whether s is an audit actor-type filter value.
+func validActorType(s string) bool {
+	switch s {
+	case core.ActorTypeUser, core.ActorTypeMachine, core.ActorTypeSystem:
+		return true
+	default:
+		return false
+	}
+}
+
+// actorTypeOrDefault normalizes a stored actor_type, treating an empty value
+// (legacy rows written before the column existed) as a human user.
+func actorTypeOrDefault(s string) string {
+	if s == "" {
+		return core.ActorTypeUser
+	}
+	return s
 }
 
 // GetRBACAuditLogs handles GET /api/v1/audit/rbac-logs (stub — returns empty).

--- a/server/http/handlers/audit_actor_type_test.go
+++ b/server/http/handlers/audit_actor_type_test.go
@@ -1,0 +1,30 @@
+package handlers
+
+import (
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+)
+
+func TestValidActorType(t *testing.T) {
+	valid := []string{core.ActorTypeUser, core.ActorTypeMachine, core.ActorTypeSystem}
+	for _, v := range valid {
+		if !validActorType(v) {
+			t.Errorf("validActorType(%q) = false, want true", v)
+		}
+	}
+	for _, v := range []string{"", "User", "robot", "machine"} {
+		if validActorType(v) {
+			t.Errorf("validActorType(%q) = true, want false", v)
+		}
+	}
+}
+
+func TestActorTypeOrDefault(t *testing.T) {
+	if got := actorTypeOrDefault(""); got != core.ActorTypeUser {
+		t.Errorf("actorTypeOrDefault(\"\") = %q, want %q", got, core.ActorTypeUser)
+	}
+	if got := actorTypeOrDefault(core.ActorTypeMachine); got != core.ActorTypeMachine {
+		t.Errorf("actorTypeOrDefault(machine) = %q, want %q", got, core.ActorTypeMachine)
+	}
+}


### PR DESCRIPTION
## What

Every audit event now records whether the acting principal is a **human user** or a **non-human machine identity** (ADR-023), with a server-side filter and a SIEM field so human vs machine activity can be segmented in the audit view and downstream.

This is the audit `actor_type` item from the ADR-023 track — deliberately held back from keyorix#13 to avoid colliding with the `AuditEvent` changes in keyorix#8; both are now on `main`, so it lands cleanly here.

## Changes

- **Model + migration:** `AuditEvent.ActorType` (default `"user"`); additive, pgx-safe `ALTER TABLE audit_events ADD COLUMN actor_type` guarded by `columnExists`. Legacy rows read as `"user"`.
- **Context plumbing (mirrors impersonation):** `WithActorType` tags the request context, `writeAuditEvent*` stamps the row, `DetachedAuditContext` carries the tag into the detached audit goroutine. The (future) machine-token auth path sets the tag once and **every** event under that session is stamped `machine_identity` — same propagation pattern already used for impersonation. `ActorTypeUser` / `ActorTypeMachine` / `ActorTypeSystem` constants.
- **API:** `AuditFilter.ActorType` + `GET /api/v1/audit/logs?actor_type=` (validated against the allowed set). `actor_type` exposed on the UI log entry, the cursor `/audit/export` entry, and the SIEM push payload.

## Notes

- No event is machine-actored in practice yet (machine-token auth is a separate deferred item) — this ships the field, filter, and propagation so machine activity is correctly tagged the moment that auth path lands. Machine-lifecycle events (`machine_identity.*`) remain `user`-actored: the actor is the admin performing the transition.
- Frontend `actor_type` filter pill pairs with the keyorix-web Members/audit work.

## Tests

Core context stamping (default / machine / system) + `DetachedAuditContext` preservation; storage-layer `actor_type` filter; handler validation helpers. Full gate green: `gofmt`, `go vet`, `go test ./...`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)