### PR TITLE
feat(cli): keyorix user suspend/reactivate/force-password-reset (ADR-025)

### DIFF
--- a/internal/audit/siem/forwarder.go
+++ b/internal/audit/siem/forwarder.go
@@ -147,6 +147,7 @@ type eventPayload struct {
 	SecretID       *uint           `json:"secret_id,omitempty"`
 	Description    string          `json:"description"`
 	IPAddress      string          `json:"ip_address,omitempty"`
+	ActorType      string          `json:"actor_type,omitempty"`
 	Success        bool            `json:"success"`
 	Diff           json.RawMessage `json:"diff,omitempty"`
 	Impersonation  bool            `json:"impersonation,omitempty"`
@@ -168,6 +169,7 @@ func toPayload(e *models.AuditEvent) eventPayload {
 		SecretID:       e.SecretNodeID,
 		Description:    e.Description,
 		IPAddress:      e.IPAddress,
+		ActorType:      e.ActorType,
 		Success:        success,
 		Impersonation:  e.Impersonation,
 		ImpersonatedBy: e.ImpersonatedBy,

--- a/internal/cli/user/lifecycle.go
+++ b/internal/cli/user/lifecycle.go
@@ -1,0 +1,110 @@
+// lifecycle.go — account-state transitions for the user CLI (ADR-025).
+//
+// suspend / reactivate / force-password-reset wire the account-state machine
+// (internal/core/account_state.go) for operators who manage users from the
+// command line. Each takes the target user via --id and the acting admin's
+// email via --by (the local CLI has no session, so --by supplies the audited
+// actor). Mirrors the keyorix machine and request CLI groups.
+package user
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/spf13/cobra"
+)
+
+var (
+	suspendUserID            uint
+	suspendBy                string
+	reactivateUserID         uint
+	reactivateBy             string
+	forcePasswordResetUserID uint
+	forcePasswordResetBy     string
+)
+
+var suspendCmd = &cobra.Command{
+	Use:   "suspend",
+	Short: "Suspend a user (blocks login)",
+	Long:  "Suspend a user account. A suspended user is refused login entirely until reactivated.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runLifecycle(suspendUserID, suspendBy, "suspended",
+			func(s *core.KeyorixCore, ctx context.Context, adminID, userID uint) error {
+				return s.SuspendUser(ctx, adminID, userID)
+			})
+	},
+}
+
+var reactivateCmd = &cobra.Command{
+	Use:   "reactivate",
+	Short: "Reactivate a user (restores login)",
+	Long:  "Return a suspended (or otherwise non-active) user to the active state.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runLifecycle(reactivateUserID, reactivateBy, "reactivated",
+			func(s *core.KeyorixCore, ctx context.Context, adminID, userID uint) error {
+				return s.ReactivateUser(ctx, adminID, userID)
+			})
+	},
+}
+
+var forcePasswordResetCmd = &cobra.Command{
+	Use:   "force-password-reset",
+	Short: "Require a user to change their password at next login",
+	Long: "Force a user into a restricted session until they change their password.\n" +
+		"They can authenticate but every endpoint except change-password is blocked until then.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runLifecycle(forcePasswordResetUserID, forcePasswordResetBy, "required to reset their password",
+			func(s *core.KeyorixCore, ctx context.Context, adminID, userID uint) error {
+				return s.RequirePasswordReset(ctx, adminID, userID)
+			})
+	},
+}
+
+func init() {
+	suspendCmd.Flags().UintVar(&suspendUserID, "id", 0, "Target user ID (required)")
+	suspendCmd.Flags().StringVar(&suspendBy, "by", "", "Acting admin email (required, for audit)")
+	_ = suspendCmd.MarkFlagRequired("id")
+	_ = suspendCmd.MarkFlagRequired("by")
+
+	reactivateCmd.Flags().UintVar(&reactivateUserID, "id", 0, "Target user ID (required)")
+	reactivateCmd.Flags().StringVar(&reactivateBy, "by", "", "Acting admin email (required, for audit)")
+	_ = reactivateCmd.MarkFlagRequired("id")
+	_ = reactivateCmd.MarkFlagRequired("by")
+
+	forcePasswordResetCmd.Flags().UintVar(&forcePasswordResetUserID, "id", 0, "Target user ID (required)")
+	forcePasswordResetCmd.Flags().StringVar(&forcePasswordResetBy, "by", "", "Acting admin email (required, for audit)")
+	_ = forcePasswordResetCmd.MarkFlagRequired("id")
+	_ = forcePasswordResetCmd.MarkFlagRequired("by")
+}
+
+// runLifecycle is the shared body for the three account-state commands: it
+// validates flags, resolves the admin actor, applies the transition, and prints
+// a confirmation. pastTense fills the "User N has been <pastTense>." message.
+func runLifecycle(userID uint, by, pastTense string, apply func(*core.KeyorixCore, context.Context, uint, uint) error) error {
+	if userID == 0 {
+		return errors.New("user id is required (use --id)")
+	}
+	if by == "" {
+		return errors.New("acting admin email is required (use --by)")
+	}
+
+	service, err := common.InitializeCoreService()
+	if err != nil {
+		return fmt.Errorf("failed to initialize service: %w", err)
+	}
+	ctx := context.Background()
+
+	adminID, err := resolveAdminID(ctx, service, by)
+	if err != nil {
+		return err
+	}
+
+	if err := apply(service, ctx, adminID, userID); err != nil {
+		return fmt.Errorf("failed: %w", err)
+	}
+	fmt.Printf("User %d has been %s.\n", userID, pastTense)
+	return nil
+}

--- a/internal/cli/user/user.go
+++ b/internal/cli/user/user.go
@@ -1,6 +1,10 @@
 package user
 
 import (
+	"context"
+	"fmt"
+
+	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/spf13/cobra"
 )
 
@@ -8,7 +12,7 @@ import (
 var UserCmd = &cobra.Command{
 	Use:   "user",
 	Short: "Manage users",
-	Long:  "Create, read, update, delete, and list users in the local database.",
+	Long:  "Create, read, update, delete, list, and manage the account lifecycle of users in the local database.",
 }
 
 func init() {
@@ -17,4 +21,18 @@ func init() {
 	UserCmd.AddCommand(updateCmd)
 	UserCmd.AddCommand(deleteCmd)
 	UserCmd.AddCommand(listCmd)
+	UserCmd.AddCommand(suspendCmd)
+	UserCmd.AddCommand(reactivateCmd)
+	UserCmd.AddCommand(forcePasswordResetCmd)
+}
+
+// resolveAdminID resolves an admin email to a user ID for audit attribution.
+// The local CLI has no session, so account-lifecycle commands take the acting
+// admin's email via --by (mirrors the invite/request CLI).
+func resolveAdminID(ctx context.Context, service *core.KeyorixCore, email string) (uint, error) {
+	u, err := service.GetUserByEmail(ctx, email)
+	if err != nil {
+		return 0, fmt.Errorf("no user found for --by %q: %w", email, err)
+	}
+	return u.ID, nil
 }

--- a/internal/cli/user/user_test.go
+++ b/internal/cli/user/user_test.go
@@ -1,0 +1,43 @@
+package user
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+// cobraRequired is the annotation key cobra uses to mark required flags.
+const cobraRequired = "cobra_annotation_bash_completion_one_required_flag"
+
+func TestUserCommandStructure(t *testing.T) {
+	assert.Equal(t, "user", UserCmd.Use)
+
+	names := make([]string, 0)
+	for _, c := range UserCmd.Commands() {
+		names = append(names, c.Use)
+	}
+	for _, expected := range []string{
+		"create", "get", "update", "delete", "list",
+		"suspend", "reactivate", "force-password-reset",
+	} {
+		assert.Contains(t, names, expected, "expected subcommand %q", expected)
+	}
+}
+
+func TestLifecycleRequiredFlags(t *testing.T) {
+	cmds := map[string]*cobra.Command{
+		"suspend":              suspendCmd,
+		"reactivate":           reactivateCmd,
+		"force-password-reset": forcePasswordResetCmd,
+	}
+	for label, c := range cmds {
+		for _, name := range []string{"id", "by"} {
+			f := c.Flags().Lookup(name)
+			assert.NotNil(t, f, "%s should have --%s", label, name)
+			if f != nil {
+				assert.NotEmpty(t, f.Annotations[cobraRequired], "%s --%s should be required", label, name)
+			}
+		}
+	}
+}

--- a/internal/core/audit.go
+++ b/internal/core/audit.go
@@ -34,6 +34,7 @@ func (c *KeyorixCore) writeAuditEventDiff(ctx context.Context, eventType string,
 		Success:      &t,
 		EventTime:    time.Now(),
 		Diff:         diff,
+		ActorType:    actorTypeFromContext(ctx),
 	}
 	if adminID, ok := impersonatorFromContext(ctx); ok {
 		a := adminID
@@ -54,6 +55,7 @@ func (c *KeyorixCore) writeAuditEventFailed(ctx context.Context, eventType strin
 		Description: description,
 		Success:     &f,
 		EventTime:   time.Now(),
+		ActorType:   actorTypeFromContext(ctx),
 	}
 	c.emitAudit(ctx, event)
 }

--- a/internal/core/audit_actor_type_test.go
+++ b/internal/core/audit_actor_type_test.go
@@ -1,0 +1,98 @@
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/mock"
+)
+
+// captureActorType writes one audit event and returns the ActorType stamped on
+// the row handed to storage.
+func captureActorType(t *testing.T, write func(c *KeyorixCore, ctx context.Context)) string {
+	t.Helper()
+	store := new(MockStorage)
+	c := NewKeyorixCore(store)
+	var got string
+	store.On("LogAuditEvent", mock.Anything, mock.MatchedBy(func(e *models.AuditEvent) bool {
+		got = e.ActorType
+		return true
+	})).Return(nil)
+	write(c, context.Background())
+	store.AssertExpectations(t)
+	return got
+}
+
+func TestWriteAuditEvent_DefaultsToUserActorType(t *testing.T) {
+	got := captureActorType(t, func(c *KeyorixCore, ctx context.Context) {
+		c.writeAuditEventFull(ctx, "secret.read", nil, nil, nil, "", "x")
+	})
+	if got != ActorTypeUser {
+		t.Errorf("ActorType = %q, want %q", got, ActorTypeUser)
+	}
+}
+
+func TestWriteAuditEvent_StampsMachineActorTypeFromContext(t *testing.T) {
+	store := new(MockStorage)
+	c := NewKeyorixCore(store)
+	var got string
+	store.On("LogAuditEvent", mock.Anything, mock.MatchedBy(func(e *models.AuditEvent) bool {
+		got = e.ActorType
+		return true
+	})).Return(nil)
+
+	ctx := WithActorType(context.Background(), ActorTypeMachine)
+	c.writeAuditEventFull(ctx, "secret.read", nil, nil, nil, "", "x")
+
+	store.AssertExpectations(t)
+	if got != ActorTypeMachine {
+		t.Errorf("ActorType = %q, want %q", got, ActorTypeMachine)
+	}
+}
+
+func TestWriteAuditEventFailed_StampsActorTypeFromContext(t *testing.T) {
+	store := new(MockStorage)
+	c := NewKeyorixCore(store)
+	var got string
+	store.On("LogAuditEvent", mock.Anything, mock.MatchedBy(func(e *models.AuditEvent) bool {
+		got = e.ActorType
+		return true
+	})).Return(nil)
+
+	ctx := WithActorType(context.Background(), ActorTypeSystem)
+	c.writeAuditEventFailed(ctx, "auth.login_failed", nil, "1.2.3.4", "x")
+
+	store.AssertExpectations(t)
+	if got != ActorTypeSystem {
+		t.Errorf("ActorType = %q, want %q", got, ActorTypeSystem)
+	}
+}
+
+func TestActorTypeFromContext_DefaultAndTagged(t *testing.T) {
+	if at := actorTypeFromContext(context.Background()); at != ActorTypeUser {
+		t.Errorf("untagged context actor type = %q, want %q", at, ActorTypeUser)
+	}
+	// An empty tag is treated as no tag (default user).
+	if ctx := WithActorType(context.Background(), ""); actorTypeFromContext(ctx) != ActorTypeUser {
+		t.Errorf("empty tag should default to %q", ActorTypeUser)
+	}
+	ctx := WithActorType(context.Background(), ActorTypeMachine)
+	if at := actorTypeFromContext(ctx); at != ActorTypeMachine {
+		t.Errorf("tagged context actor type = %q, want %q", at, ActorTypeMachine)
+	}
+}
+
+// DetachedAuditContext must carry the actor-type tag (and impersonation) past
+// request cancellation into the detached audit goroutine.
+func TestDetachedAuditContext_PreservesActorTypeAndImpersonation(t *testing.T) {
+	parent := WithActorType(WithImpersonation(context.Background(), 7), ActorTypeMachine)
+	detached := DetachedAuditContext(parent)
+
+	if at := actorTypeFromContext(detached); at != ActorTypeMachine {
+		t.Errorf("detached actor type = %q, want %q", at, ActorTypeMachine)
+	}
+	if adminID, ok := impersonatorFromContext(detached); !ok || adminID != 7 {
+		t.Errorf("detached impersonator = (%d,%v), want (7,true)", adminID, ok)
+	}
+}

--- a/internal/core/audit_context.go
+++ b/internal/core/audit_context.go
@@ -10,7 +10,38 @@ package core
 
 import "context"
 
+// Actor types stamped on every audit event (ADR-023). They distinguish a human
+// user from a non-human machine identity so the audit view can segment and
+// filter the two.
+const (
+	ActorTypeUser    = "user"
+	ActorTypeMachine = "machine_identity"
+	ActorTypeSystem  = "system"
+)
+
 type impersonationKey struct{}
+
+type actorTypeKey struct{}
+
+// WithActorType tags ctx with the principal kind for the current request
+// (ActorTypeUser/ActorTypeMachine/ActorTypeSystem). The auth middleware sets it
+// per request; writeAuditEvent* reads it and stamps ActorType on the row. An
+// empty actorType is treated as "no tag" (the writer defaults to user).
+func WithActorType(ctx context.Context, actorType string) context.Context {
+	if actorType == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, actorTypeKey{}, actorType)
+}
+
+// actorTypeFromContext returns the tagged actor type, defaulting to
+// ActorTypeUser when the context carries no tag.
+func actorTypeFromContext(ctx context.Context) string {
+	if t, ok := ctx.Value(actorTypeKey{}).(string); ok && t != "" {
+		return t
+	}
+	return ActorTypeUser
+}
 
 // WithImpersonation tags ctx with the admin user ID that initiated the current
 // impersonation session. A zero adminID is treated as "no impersonation".
@@ -32,8 +63,12 @@ func impersonatorFromContext(ctx context.Context) (uint, bool) {
 // impersonation tag from parent. Audit writes run in goroutines that must
 // outlive the request, but still need to record the impersonating admin.
 func DetachedAuditContext(parent context.Context) context.Context {
+	ctx := context.Background()
 	if adminID, ok := impersonatorFromContext(parent); ok {
-		return WithImpersonation(context.Background(), adminID)
+		ctx = WithImpersonation(ctx, adminID)
 	}
-	return context.Background()
+	if t, ok := parent.Value(actorTypeKey{}).(string); ok && t != "" {
+		ctx = WithActorType(ctx, t)
+	}
+	return ctx
 }

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -254,6 +254,9 @@ type AuditFilter struct {
 	Action    *string
 	Resource  *string
 	Success   *bool
+	// ActorType filters by acting-principal kind: "user" or "machine_identity"
+	// (also "system"). Nil = all actor types. (ADR-023)
+	ActorType *string
 	StartTime *time.Time
 	EndTime   *time.Time
 	Page      int

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -186,6 +186,10 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 		if !columnExists(db, "audit_events", "impersonation") {
 			db.Exec("ALTER TABLE audit_events ADD COLUMN impersonation BOOLEAN NOT NULL DEFAULT false")
 		}
+		// ADR-023: actor kind (user vs machine_identity) on every event.
+		if !columnExists(db, "audit_events", "actor_type") {
+			db.Exec("ALTER TABLE audit_events ADD COLUMN actor_type TEXT NOT NULL DEFAULT 'user'")
+		}
 	}
 
 	// Impersonation sessions carry the initiating admin + start time.

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -286,6 +286,14 @@ type AuditEvent struct {
 	ImpersonatedBy *uint
 	ActingAs       *uint
 	Impersonation  bool `gorm:"default:false"`
+
+	// ActorType records whether the acting principal is a human user or a
+	// non-human machine identity (ADR-023). It is "user" on every ordinary
+	// event; the (future) machine-token auth path tags the request context so
+	// every event under a machine session is stamped "machine_identity".
+	// "system" marks events with no authenticated principal. Defaults to "user"
+	// so legacy rows and back-compat writers read as human-actored.
+	ActorType string `gorm:"default:user"`
 }
 
 type Setting struct {

--- a/internal/storage/store/audit_actor_type_test.go
+++ b/internal/storage/store/audit_actor_type_test.go
@@ -1,0 +1,43 @@
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// GetAuditLogs filters by actor_type; a nil filter returns every actor kind.
+func TestGetAuditLogs_FilterByActorType(t *testing.T) {
+	ctx := context.Background()
+	ls := newAuditTestStore(t)
+	now := time.Now().UTC()
+
+	ev := func(eventType, actorType string, at time.Time) *models.AuditEvent {
+		return &models.AuditEvent{EventType: eventType, ActorType: actorType, EventTime: at}
+	}
+	require.NoError(t, ls.LogAuditEvent(ctx, ev("secret.read", "user", now.Add(1*time.Second))))
+	require.NoError(t, ls.LogAuditEvent(ctx, ev("secret.read", "user", now.Add(2*time.Second))))
+	require.NoError(t, ls.LogAuditEvent(ctx, ev("secret.read", "machine_identity", now.Add(3*time.Second))))
+	require.NoError(t, ls.LogAuditEvent(ctx, ev("anomaly.detected", "system", now.Add(4*time.Second))))
+
+	machine := "machine_identity"
+	events, total, err := ls.GetAuditLogs(ctx, &storage.AuditFilter{ActorType: &machine})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), total, "only the machine-actored event matches")
+	require.Len(t, events, 1)
+	assert.Equal(t, "machine_identity", events[0].ActorType)
+
+	user := "user"
+	_, userTotal, err := ls.GetAuditLogs(ctx, &storage.AuditFilter{ActorType: &user})
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), userTotal, "two user-actored events match")
+
+	_, allTotal, err := ls.GetAuditLogs(ctx, &storage.AuditFilter{})
+	require.NoError(t, err)
+	assert.Equal(t, int64(4), allTotal, "no actor_type filter returns every event")
+}

--- a/internal/storage/store/local_audit.go
+++ b/internal/storage/store/local_audit.go
@@ -58,6 +58,9 @@ func (ls *LocalStorage) GetAuditLogs(ctx context.Context, filter *storage.AuditF
 		if filter.Success != nil {
 			query = query.Where("success = ?", *filter.Success)
 		}
+		if filter.ActorType != nil {
+			query = query.Where("actor_type = ?", *filter.ActorType)
+		}
 		if filter.AfterID != nil {
 			query = query.Where("id > ?", *filter.AfterID)
 		}

--- a/internal/storage/store/remote_audit.go
+++ b/internal/storage/store/remote_audit.go
@@ -73,6 +73,7 @@ func buildAuditFilterPath(filter *storage.AuditFilter) string {
 	params.addUint("user_id", filter.UserID)
 	params.addString("action", filter.Action)
 	params.addString("resource", filter.Resource)
+	params.addString("actor_type", filter.ActorType)
 	params.addBool("success", filter.Success)
 	params.addTime("start_time", filter.StartTime)
 	params.addTime("end_time", filter.EndTime)

--- a/server/http/handlers/audit.go
+++ b/server/http/handlers/audit.go
@@ -26,9 +26,13 @@ func NewAuditHandler(coreService *core.KeyorixCore) *AuditHandler {
 
 // AuditLogEntry is the wire format returned to the frontend.
 type AuditLogEntry struct {
-	ID          uint      `json:"id"`
-	EventType   string    `json:"event_type"`
-	Actor       string    `json:"actor"`
+	ID        uint   `json:"id"`
+	EventType string `json:"event_type"`
+	Actor     string `json:"actor"`
+	// ActorType is the acting-principal kind: "user" or "machine_identity"
+	// (also "system"). Lets the audit view segment/filter human vs machine
+	// activity (ADR-023).
+	ActorType   string    `json:"actor_type"`
 	Description string    `json:"description"`
 	Timestamp   time.Time `json:"timestamp"`
 	// Diff is the structured before/after payload for mutation events (parsed
@@ -84,6 +88,9 @@ func (h *AuditHandler) GetAuditLogs(w http.ResponseWriter, r *http.Request) {
 			filter.EndTime = &t
 		}
 	}
+	if at := r.URL.Query().Get("actor_type"); validActorType(at) {
+		filter.ActorType = &at
+	}
 
 	events, total, err := h.coreService.Storage().GetAuditLogs(r.Context(), filter)
 	if err != nil {
@@ -105,6 +112,7 @@ func (h *AuditHandler) GetAuditLogs(w http.ResponseWriter, r *http.Request) {
 			ID:          e.ID,
 			EventType:   e.EventType,
 			Actor:       actor,
+			ActorType:   actorTypeOrDefault(e.ActorType),
 			Description: e.Description,
 			Timestamp:   e.EventTime,
 		}
@@ -150,6 +158,7 @@ type AuditExportEntry struct {
 	SecretID       *uint           `json:"secret_id,omitempty"`
 	Description    string          `json:"description"`
 	IPAddress      string          `json:"ip_address,omitempty"`
+	ActorType      string          `json:"actor_type"`
 	Success        bool            `json:"success"`
 	Diff           json.RawMessage `json:"diff,omitempty"`
 	Impersonation  bool            `json:"impersonation,omitempty"`
@@ -216,6 +225,7 @@ func (h *AuditHandler) ExportAuditLogs(w http.ResponseWriter, r *http.Request) {
 			SecretID:    e.SecretNodeID,
 			Description: e.Description,
 			IPAddress:   e.IPAddress,
+			ActorType:   actorTypeOrDefault(e.ActorType),
 			Success:     success,
 		}
 		if e.Diff != "" {
@@ -236,6 +246,25 @@ func (h *AuditHandler) ExportAuditLogs(w http.ResponseWriter, r *http.Request) {
 		"count":       len(entries),
 		"next_cursor": nextCursor,
 	}, "")
+}
+
+// validActorType reports whether s is an audit actor-type filter value.
+func validActorType(s string) bool {
+	switch s {
+	case core.ActorTypeUser, core.ActorTypeMachine, core.ActorTypeSystem:
+		return true
+	default:
+		return false
+	}
+}
+
+// actorTypeOrDefault normalizes a stored actor_type, treating an empty value
+// (legacy rows written before the column existed) as a human user.
+func actorTypeOrDefault(s string) string {
+	if s == "" {
+		return core.ActorTypeUser
+	}
+	return s
 }
 
 // GetRBACAuditLogs handles GET /api/v1/audit/rbac-logs (stub — returns empty).

--- a/server/http/handlers/audit_actor_type_test.go
+++ b/server/http/handlers/audit_actor_type_test.go
@@ -1,0 +1,30 @@
+package handlers
+
+import (
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+)
+
+func TestValidActorType(t *testing.T) {
+	valid := []string{core.ActorTypeUser, core.ActorTypeMachine, core.ActorTypeSystem}
+	for _, v := range valid {
+		if !validActorType(v) {
+			t.Errorf("validActorType(%q) = false, want true", v)
+		}
+	}
+	for _, v := range []string{"", "User", "robot", "machine"} {
+		if validActorType(v) {
+			t.Errorf("validActorType(%q) = true, want false", v)
+		}
+	}
+}
+
+func TestActorTypeOrDefault(t *testing.T) {
+	if got := actorTypeOrDefault(""); got != core.ActorTypeUser {
+		t.Errorf("actorTypeOrDefault(\"\") = %q, want %q", got, core.ActorTypeUser)
+	}
+	if got := actorTypeOrDefault(core.ActorTypeMachine); got != core.ActorTypeMachine {
+		t.Errorf("actorTypeOrDefault(machine) = %q, want %q", got, core.ActorTypeMachine)
+	}
+}


### PR DESCRIPTION
## What

Wires the account-state machine (keyorix#12) into the `keyorix user` CLI so operators can manage the account lifecycle from the command line — mirroring the existing `invite` / `request` / `machine` CLI groups.

This is the suspend/reactivate/force-password-reset slice of the ADR-025 "CLI: keyorix user …" backlog item. The existing `user` group already had create/get/update/delete/list; this adds the lifecycle transitions.

## Commands

- `keyorix user suspend --id N --by <admin-email>` — blocks login entirely.
- `keyorix user reactivate --id N --by <admin-email>` — returns to `active`.
- `keyorix user force-password-reset --id N --by <admin-email>` — restricted session until the user changes their password.

The local CLI has no session, so `--by` supplies the **audited admin actor** (resolved via `GetUserByEmail`), exactly as the invite/request groups do. A shared `runLifecycle` body backs the three cohesive transitions.

## Verification

Verified end-to-end against a temp local DB:

```
active → suspended → password_reset_required → active
```

…each writing the matching `account.*` audit event attributed to the `--by` admin (user_id=1), plus both error paths (`--by` resolving to no user; `--by` omitted → cobra required-flag error). Structural test covers subcommand registration + required flags. Gate green: `gofmt`, `go vet`, `go test ./internal/cli/...`.

## Deferred

`resend-setup-link` is intentionally left out — it needs the SMTP/setup-link infra (separate ADR-025 credential-delivery item).

🤖 Generated with [Claude Code](https://claude.com/claude-code)