### PR TITLE
feat(credential-delivery): setup-token primitive + delivery interface (ADR-028)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/keyorixhq/keyorix/internal/securefiles"
 	"gopkg.in/yaml.v3"
@@ -21,6 +22,10 @@ type Config struct {
 	Purge       PurgeConfig      `yaml:"purge"`
 	Audit       AuditConfig      `yaml:"audit"`
 	Membership  MembershipConfig `yaml:"membership"`
+
+	// CredentialDelivery configures how a new principal receives their first-credential
+	// setup link (ADR-028). Absent (zero value) = auto mode, out-of-band when no SMTP.
+	CredentialDelivery CredentialDeliveryConfig `yaml:"credential_delivery"`
 
 	// PasswordPolicy is optional. When the block is absent (zero value), the
 	// server keeps its conservative built-in defaults (see core.DefaultPasswordPolicy);
@@ -239,6 +244,54 @@ type SIEMConfig struct {
 // GetToken returns the resolved SIEM token, preferring the environment variable.
 func (s *SIEMConfig) GetToken() string {
 	return resolveSecret("KEYORIX_SIEM_TOKEN", s.Token)
+}
+
+// CredentialDeliveryConfig configures the ADR-028 credential-delivery subsystem:
+// how a brand-new principal receives their first-credential setup link.
+type CredentialDeliveryConfig struct {
+	// Mode selects the channel: auto | smtp | out_of_band | log ("" = auto).
+	Mode string `yaml:"mode"`
+	// SetupTokenTTL is the single-use setup/invite link lifetime (e.g. "24h").
+	// Empty = DefaultSetupTokenTTLString.
+	SetupTokenTTL string `yaml:"setup_token_ttl"`
+	// BaseURL is required for any link-producing mode; used to build absolute setup
+	// links (e.g. "https://keyorix.acme.internal"). A relative link is a
+	// misconfiguration, not a fallback, so link minting refuses an empty BaseURL.
+	BaseURL string               `yaml:"base_url"`
+	SMTP    CredentialSMTPConfig `yaml:"smtp"`
+}
+
+// CredentialSMTPConfig is the operator's own mail relay. The password is resolved
+// from KEYORIX_SMTP_PASSWORD when set, so it need not be written into the file
+// (same convention as the DB password).
+type CredentialSMTPConfig struct {
+	Host     string `yaml:"host"`
+	Port     int    `yaml:"port"`
+	Username string `yaml:"username"`
+	Password string `yaml:"password"` // use KEYORIX_SMTP_PASSWORD env var instead
+	From     string `yaml:"from"`
+	TLS      string `yaml:"tls"` // starttls | implicit | none(dev-only)
+}
+
+// DefaultSetupTokenTTLString is the fallback link lifetime when none is configured.
+const DefaultSetupTokenTTLString = "24h"
+
+// GetSetupTokenTTL parses SetupTokenTTL, falling back to 24h when empty or invalid.
+func (c *CredentialDeliveryConfig) GetSetupTokenTTL() time.Duration {
+	raw := c.SetupTokenTTL
+	if raw == "" {
+		raw = DefaultSetupTokenTTLString
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil || d <= 0 {
+		d, _ = time.ParseDuration(DefaultSetupTokenTTLString)
+	}
+	return d
+}
+
+// GetPassword returns the resolved SMTP password, preferring the environment variable.
+func (s *CredentialSMTPConfig) GetPassword() string {
+	return resolveSecret("KEYORIX_SMTP_PASSWORD", s.Password)
 }
 
 type PurgeConfig struct {

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -703,6 +703,44 @@ func (m *MockStorage) TouchPersonalAccessToken(ctx context.Context, id uint, use
 	return args.Error(0)
 }
 
+// Setup Token Management (ADR-028)
+
+func (m *MockStorage) CreateSetupToken(ctx context.Context, t *models.SetupToken) (*models.SetupToken, error) {
+	args := m.Called(ctx, t)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.SetupToken), args.Error(1)
+}
+
+func (m *MockStorage) GetSetupTokenByHash(ctx context.Context, hash string) (*models.SetupToken, error) {
+	args := m.Called(ctx, hash)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.SetupToken), args.Error(1)
+}
+
+func (m *MockStorage) SupersedeActiveSetupTokens(ctx context.Context, purpose, email string) error {
+	args := m.Called(ctx, purpose, email)
+	return args.Error(0)
+}
+
+func (m *MockStorage) MarkSetupTokenConsumed(ctx context.Context, id uint, consumedAt time.Time) (bool, error) {
+	args := m.Called(ctx, id, consumedAt)
+	return args.Bool(0), args.Error(1)
+}
+
+func (m *MockStorage) MarkSetupTokenExpired(ctx context.Context, id uint) error {
+	args := m.Called(ctx, id)
+	return args.Error(0)
+}
+
+func (m *MockStorage) CountSetupTokensSince(ctx context.Context, purpose, email string, since time.Time) (int64, error) {
+	args := m.Called(ctx, purpose, email, since)
+	return args.Get(0).(int64), args.Error(1)
+}
+
 // API Client Management
 
 func (m *MockStorage) CreateAPIClient(ctx context.Context, client *models.APIClient) (*models.APIClient, error) {

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -30,6 +30,9 @@ type KeyorixCore struct {
 	// membershipValidationMode is the ADR-022 install-level onboarding mode;
 	// "" = allowlist default. Set via SetMembershipValidationMode.
 	membershipValidationMode string
+	// setupTokenTTL is the lifetime of a credential-delivery setup token (ADR-028);
+	// 0 = DefaultSetupTokenTTL. Set from config via SetSetupTokenTTL.
+	setupTokenTTL time.Duration
 }
 
 // AuditForwarder ships persisted audit events to an external sink (e.g. a SIEM).
@@ -80,6 +83,13 @@ func NewKeyorixCoreWithEncryption(storage storage.Storage, enc *encryption.Secre
 // configures a password_policy block.
 func (c *KeyorixCore) SetPasswordPolicy(p PasswordPolicy) {
 	c.passwordPolicy = p
+}
+
+// SetSetupTokenTTL overrides the setup-token lifetime (ADR-028). The server calls
+// this at startup from credential_delivery.setup_token_ttl. A non-positive value
+// falls back to DefaultSetupTokenTTL.
+func (c *KeyorixCore) SetSetupTokenTTL(ttl time.Duration) {
+	c.setupTokenTTL = ttl
 }
 
 // Storage returns the underlying storage interface (used by ancillary services such as AnomalyDetector).

--- a/internal/core/setup_token.go
+++ b/internal/core/setup_token.go
@@ -1,0 +1,204 @@
+// setup_token.go — credential-delivery setup tokens (ADR-028).
+//
+// A setup token is the single-use bearer string that lets a brand-new principal
+// establish their first credential. It backs three producers — invitation
+// acceptance (ADR-024), admin-direct account setup (ADR-025), and the reset-link
+// path — selected by Purpose. The raw token is returned once on issuance (to embed
+// in an https link or display out of band) and never persisted; only its SHA-256
+// hash is stored, and lookup is by hash. This mirrors the PAT handling in pat.go.
+//
+// Lifecycle invariants:
+//   - Single-use: consuming flips active → consumed via a state-guarded UPDATE, so a
+//     replay matches zero rows and is rejected.
+//   - Short TTL: default 24h (configurable). A lazy-expire check flips an overdue
+//     active token to expired on read.
+//   - Superseded on reissue: minting a new token for the same (purpose, email)
+//     supersedes any prior active one, so "resend" kills the old link instantly.
+//   - Purpose-scoped: a token minted for one purpose can never drive another.
+package core
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// Setup-token purposes. A token is bound to exactly one at issuance.
+const (
+	SetupPurposeInvitationAccept  = "invitation_accept"
+	SetupPurposeAccountSetup      = "account_setup"
+	SetupPurposePasswordResetLink = "password_reset_link"
+)
+
+// Setup-token states.
+const (
+	SetupTokenActive     = "active"
+	SetupTokenConsumed   = "consumed"
+	SetupTokenExpired    = "expired"
+	SetupTokenSuperseded = "superseded"
+)
+
+const (
+	// setupPrefix marks a raw setup token. Load-bearing for secret-scanning leak
+	// detection; the token travels in an https link, not the auth bearer path.
+	setupPrefix = "kx_setup_"
+	// DefaultSetupTokenTTL is the fallback link lifetime when none is configured.
+	DefaultSetupTokenTTL = 24 * time.Hour
+)
+
+// validSetupPurpose reports whether p is a recognised purpose.
+func validSetupPurpose(p string) bool {
+	switch p {
+	case SetupPurposeInvitationAccept, SetupPurposeAccountSetup, SetupPurposePasswordResetLink:
+		return true
+	default:
+		return false
+	}
+}
+
+// hashSetupToken returns the SHA-256 hex of a raw token — the stored, indexed form.
+func hashSetupToken(raw string) string {
+	sum := sha256.Sum256([]byte(raw))
+	return hex.EncodeToString(sum[:])
+}
+
+// IssueSetupTokenRequest describes a token to mint.
+type IssueSetupTokenRequest struct {
+	Purpose       string
+	SubjectEmail  string // the address the token is bound to (required)
+	SubjectUserID *uint  // nil until an account exists (e.g. invitation by email)
+	InvitationID  *uint  // set for purpose = invitation_accept
+	CreatedBy     uint   // issuing admin/inviter; 0 for self-service reset
+}
+
+// IssueSetupTokenResult carries the freshly minted token plus its one-time plaintext.
+// PlainToken is never persisted and never returned again.
+type IssueSetupTokenResult struct {
+	Token      *models.SetupToken
+	PlainToken string
+}
+
+// IssueSetupToken mints a single-use setup token, superseding any prior active token
+// for the same (purpose, email) so a reissue invalidates the old link. The raw token
+// is returned once; only its hash is stored.
+func (c *KeyorixCore) IssueSetupToken(ctx context.Context, req IssueSetupTokenRequest) (*IssueSetupTokenResult, error) {
+	if !validSetupPurpose(req.Purpose) {
+		return nil, fmt.Errorf("%s: unknown setup-token purpose %q", i18n.T("ErrorValidation", nil), req.Purpose)
+	}
+	email := strings.TrimSpace(strings.ToLower(req.SubjectEmail))
+	if email == "" {
+		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "subject email is required")
+	}
+
+	// Supersede any prior active token for this subject+purpose first, so the old
+	// link dies the instant the new one is issued (safe "resend").
+	if err := c.storage.SupersedeActiveSetupTokens(ctx, req.Purpose, email); err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	raw := setupPrefix + base64.RawURLEncoding.EncodeToString(b)
+
+	ttl := c.setupTokenTTL
+	if ttl <= 0 {
+		ttl = DefaultSetupTokenTTL
+	}
+	now := c.now()
+
+	tok := &models.SetupToken{
+		TokenHash:     hashSetupToken(raw),
+		Purpose:       req.Purpose,
+		SubjectUserID: req.SubjectUserID,
+		SubjectEmail:  email,
+		InvitationID:  req.InvitationID,
+		State:         SetupTokenActive,
+		ExpiresAt:     now.Add(ttl),
+		CreatedBy:     req.CreatedBy,
+		CreatedAt:     now,
+	}
+	created, err := c.storage.CreateSetupToken(ctx, tok)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+
+	// Issuer is the actor; for self-service reset (CreatedBy == 0) attribute to the
+	// subject. No token (not even the hash) is recorded on the audit row.
+	actor := actorOrSubject(req.CreatedBy, req.SubjectUserID)
+	c.writeAuditEventFull(ctx, "setup_token.issued", actor, nil, nil, "",
+		fmt.Sprintf("setup token issued (purpose=%s, subject=%s, expires=%s)",
+			req.Purpose, email, created.ExpiresAt.Format(time.RFC3339)))
+
+	return &IssueSetupTokenResult{Token: created, PlainToken: raw}, nil
+}
+
+// ValidateSetupToken resolves a raw token to its record for the expected purpose,
+// without consuming it (the landing page calls this to show the assignment summary).
+// It rejects unknown, non-active, wrong-purpose, and expired tokens, lazily flipping
+// an overdue active token to expired as a side effect.
+func (c *KeyorixCore) ValidateSetupToken(ctx context.Context, raw, expectedPurpose string) (*models.SetupToken, error) {
+	tok, err := c.storage.GetSetupTokenByHash(ctx, hashSetupToken(raw))
+	if err != nil {
+		return nil, fmt.Errorf("%s: invalid setup token", i18n.T("ErrorNotFound", nil))
+	}
+
+	// Lazy expiry: an active token past its TTL is flipped to expired on read.
+	if tok.State == SetupTokenActive && c.now().After(tok.ExpiresAt) {
+		_ = c.storage.MarkSetupTokenExpired(ctx, tok.ID)
+		c.writeAuditEventFull(ctx, "setup_token.expired", tok.SubjectUserID, nil, nil, "",
+			fmt.Sprintf("setup token expired (purpose=%s, subject=%s)", tok.Purpose, tok.SubjectEmail))
+		return nil, fmt.Errorf("%s: setup token expired", i18n.T("ErrorNotFound", nil))
+	}
+	if tok.State != SetupTokenActive {
+		return nil, fmt.Errorf("%s: setup token is %s", i18n.T("ErrorNotFound", nil), tok.State)
+	}
+	// Purpose-scoping: the token may only drive the flow it was minted for.
+	if tok.Purpose != expectedPurpose {
+		return nil, fmt.Errorf("%s: setup token purpose mismatch", i18n.T("ErrorValidation", nil))
+	}
+	return tok, nil
+}
+
+// ConsumeSetupToken validates a token for the expected purpose and atomically marks
+// it consumed (single-use). The returned record lets the caller materialize the
+// token's effect (accept the invitation / set the password). Consumption is burned
+// up front: if the caller's subsequent materialization fails, the token is already
+// spent — a deliberate fail-closed choice, since a setup token is a credential.
+func (c *KeyorixCore) ConsumeSetupToken(ctx context.Context, raw, expectedPurpose string) (*models.SetupToken, error) {
+	tok, err := c.ValidateSetupToken(ctx, raw, expectedPurpose)
+	if err != nil {
+		return nil, err
+	}
+	ok, err := c.storage.MarkSetupTokenConsumed(ctx, tok.ID, c.now())
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	if !ok {
+		// Lost a race to a concurrent consumer (or already spent between validate
+		// and mark). Single-use holds: reject.
+		return nil, fmt.Errorf("%s: setup token already used", i18n.T("ErrorNotFound", nil))
+	}
+	c.writeAuditEventFull(ctx, "setup_token.consumed", tok.SubjectUserID, nil, nil, "",
+		fmt.Sprintf("setup token consumed (purpose=%s, subject=%s)", tok.Purpose, tok.SubjectEmail))
+	return tok, nil
+}
+
+// actorOrSubject returns the issuing admin as the audit actor, falling back to the
+// subject for self-service issuance (createdBy == 0).
+func actorOrSubject(createdBy uint, subjectUserID *uint) *uint {
+	if createdBy != 0 {
+		a := createdBy
+		return &a
+	}
+	return subjectUserID
+}

--- a/internal/core/setup_token_test.go
+++ b/internal/core/setup_token_test.go
@@ -1,0 +1,206 @@
+package core
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// anyAudit stubs the audit write path (every issue/consume/expire writes one).
+func anyAudit(ms *MockStorage) {
+	ms.On("LogAuditEvent", mock.Anything, mock.AnythingOfType("*models.AuditEvent")).Return(nil)
+}
+
+func TestIssueSetupToken(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("returns plaintext once, stores only the hash, supersedes prior tokens", func(t *testing.T) {
+		ms := new(MockStorage)
+		c := NewKeyorixCore(ms)
+		anyAudit(ms)
+
+		var captured *models.SetupToken
+		ms.On("SupersedeActiveSetupTokens", ctx, SetupPurposeInvitationAccept, "new@acme.io").Return(nil)
+		ms.On("CreateSetupToken", ctx, mock.AnythingOfType("*models.SetupToken")).
+			Run(func(args mock.Arguments) { captured = args.Get(1).(*models.SetupToken) }).
+			Return(&models.SetupToken{ID: 1}, nil)
+
+		res, err := c.IssueSetupToken(ctx, IssueSetupTokenRequest{
+			Purpose:      SetupPurposeInvitationAccept,
+			SubjectEmail: "New@Acme.io", // normalised to lower-case
+			CreatedBy:    7,
+		})
+		require.NoError(t, err)
+		assert.True(t, strings.HasPrefix(res.PlainToken, setupPrefix), "raw token carries the kx_setup_ prefix")
+		require.NotNil(t, captured)
+		assert.Equal(t, hashSetupToken(res.PlainToken), captured.TokenHash, "stored value is the hash of the plaintext")
+		assert.NotEqual(t, res.PlainToken, captured.TokenHash, "plaintext is never stored")
+		assert.Equal(t, "new@acme.io", captured.SubjectEmail)
+		assert.Equal(t, SetupTokenActive, captured.State)
+		ms.AssertCalled(t, "SupersedeActiveSetupTokens", ctx, SetupPurposeInvitationAccept, "new@acme.io")
+	})
+
+	t.Run("applies the default TTL when none is configured", func(t *testing.T) {
+		ms := new(MockStorage)
+		fixed := time.Date(2026, 6, 5, 12, 0, 0, 0, time.UTC)
+		c := NewKeyorixCore(ms)
+		c.now = func() time.Time { return fixed }
+		anyAudit(ms)
+		var captured *models.SetupToken
+		ms.On("SupersedeActiveSetupTokens", ctx, SetupPurposeAccountSetup, "a@b.io").Return(nil)
+		ms.On("CreateSetupToken", ctx, mock.AnythingOfType("*models.SetupToken")).
+			Run(func(args mock.Arguments) { captured = args.Get(1).(*models.SetupToken) }).
+			Return(&models.SetupToken{ID: 2}, nil)
+
+		_, err := c.IssueSetupToken(ctx, IssueSetupTokenRequest{Purpose: SetupPurposeAccountSetup, SubjectEmail: "a@b.io"})
+		require.NoError(t, err)
+		assert.Equal(t, fixed.Add(DefaultSetupTokenTTL), captured.ExpiresAt)
+	})
+
+	t.Run("honours a configured TTL", func(t *testing.T) {
+		ms := new(MockStorage)
+		fixed := time.Date(2026, 6, 5, 12, 0, 0, 0, time.UTC)
+		c := NewKeyorixCore(ms)
+		c.now = func() time.Time { return fixed }
+		c.SetSetupTokenTTL(2 * time.Hour)
+		anyAudit(ms)
+		var captured *models.SetupToken
+		ms.On("SupersedeActiveSetupTokens", ctx, SetupPurposeAccountSetup, "a@b.io").Return(nil)
+		ms.On("CreateSetupToken", ctx, mock.AnythingOfType("*models.SetupToken")).
+			Run(func(args mock.Arguments) { captured = args.Get(1).(*models.SetupToken) }).
+			Return(&models.SetupToken{ID: 2}, nil)
+
+		_, err := c.IssueSetupToken(ctx, IssueSetupTokenRequest{Purpose: SetupPurposeAccountSetup, SubjectEmail: "a@b.io"})
+		require.NoError(t, err)
+		assert.Equal(t, fixed.Add(2*time.Hour), captured.ExpiresAt)
+	})
+
+	t.Run("rejects an unknown purpose before any storage call", func(t *testing.T) {
+		ms := new(MockStorage)
+		c := NewKeyorixCore(ms)
+		_, err := c.IssueSetupToken(ctx, IssueSetupTokenRequest{Purpose: "wat", SubjectEmail: "a@b.io"})
+		require.Error(t, err)
+		ms.AssertNotCalled(t, "CreateSetupToken", mock.Anything, mock.Anything)
+	})
+
+	t.Run("rejects an empty email", func(t *testing.T) {
+		ms := new(MockStorage)
+		c := NewKeyorixCore(ms)
+		_, err := c.IssueSetupToken(ctx, IssueSetupTokenRequest{Purpose: SetupPurposeAccountSetup, SubjectEmail: "  "})
+		require.Error(t, err)
+		ms.AssertNotCalled(t, "CreateSetupToken", mock.Anything, mock.Anything)
+	})
+}
+
+func TestValidateSetupToken(t *testing.T) {
+	ctx := context.Background()
+	raw := setupPrefix + "abc123"
+	hash := hashSetupToken(raw)
+
+	t.Run("resolves an active token for the matching purpose", func(t *testing.T) {
+		ms := new(MockStorage)
+		c := NewKeyorixCore(ms)
+		future := c.now().Add(time.Hour)
+		ms.On("GetSetupTokenByHash", ctx, hash).Return(&models.SetupToken{
+			ID: 5, State: SetupTokenActive, Purpose: SetupPurposeInvitationAccept, ExpiresAt: future,
+		}, nil)
+		tok, err := c.ValidateSetupToken(ctx, raw, SetupPurposeInvitationAccept)
+		require.NoError(t, err)
+		assert.Equal(t, uint(5), tok.ID)
+	})
+
+	t.Run("rejects (and lazily expires) an overdue token", func(t *testing.T) {
+		ms := new(MockStorage)
+		c := NewKeyorixCore(ms)
+		anyAudit(ms)
+		past := c.now().Add(-time.Hour)
+		ms.On("GetSetupTokenByHash", ctx, hash).Return(&models.SetupToken{
+			ID: 5, State: SetupTokenActive, Purpose: SetupPurposeInvitationAccept, ExpiresAt: past,
+		}, nil)
+		ms.On("MarkSetupTokenExpired", ctx, uint(5)).Return(nil)
+		_, err := c.ValidateSetupToken(ctx, raw, SetupPurposeInvitationAccept)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "expired")
+		ms.AssertCalled(t, "MarkSetupTokenExpired", ctx, uint(5))
+	})
+
+	t.Run("rejects a wrong-purpose token (purpose-scoping)", func(t *testing.T) {
+		ms := new(MockStorage)
+		c := NewKeyorixCore(ms)
+		future := c.now().Add(time.Hour)
+		ms.On("GetSetupTokenByHash", ctx, hash).Return(&models.SetupToken{
+			ID: 5, State: SetupTokenActive, Purpose: SetupPurposeInvitationAccept, ExpiresAt: future,
+		}, nil)
+		_, err := c.ValidateSetupToken(ctx, raw, SetupPurposePasswordResetLink)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "purpose")
+	})
+
+	t.Run("rejects an already-consumed token", func(t *testing.T) {
+		ms := new(MockStorage)
+		c := NewKeyorixCore(ms)
+		future := c.now().Add(time.Hour)
+		ms.On("GetSetupTokenByHash", ctx, hash).Return(&models.SetupToken{
+			ID: 5, State: SetupTokenConsumed, Purpose: SetupPurposeInvitationAccept, ExpiresAt: future,
+		}, nil)
+		_, err := c.ValidateSetupToken(ctx, raw, SetupPurposeInvitationAccept)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), SetupTokenConsumed)
+	})
+
+	t.Run("rejects an unknown token", func(t *testing.T) {
+		ms := new(MockStorage)
+		c := NewKeyorixCore(ms)
+		ms.On("GetSetupTokenByHash", ctx, hash).Return(nil, assert.AnError)
+		_, err := c.ValidateSetupToken(ctx, raw, SetupPurposeInvitationAccept)
+		require.Error(t, err)
+	})
+}
+
+func TestConsumeSetupToken(t *testing.T) {
+	ctx := context.Background()
+	raw := setupPrefix + "xyz789"
+	hash := hashSetupToken(raw)
+
+	activeTok := func(c *KeyorixCore) *models.SetupToken {
+		return &models.SetupToken{ID: 9, State: SetupTokenActive, Purpose: SetupPurposeAccountSetup, ExpiresAt: c.now().Add(time.Hour)}
+	}
+
+	t.Run("consumes an active token exactly once", func(t *testing.T) {
+		ms := new(MockStorage)
+		c := NewKeyorixCore(ms)
+		anyAudit(ms)
+		ms.On("GetSetupTokenByHash", ctx, hash).Return(activeTok(c), nil)
+		ms.On("MarkSetupTokenConsumed", ctx, uint(9), mock.AnythingOfType("time.Time")).Return(true, nil)
+		tok, err := c.ConsumeSetupToken(ctx, raw, SetupPurposeAccountSetup)
+		require.NoError(t, err)
+		assert.Equal(t, uint(9), tok.ID)
+		ms.AssertCalled(t, "MarkSetupTokenConsumed", ctx, uint(9), mock.AnythingOfType("time.Time"))
+	})
+
+	t.Run("rejects a replay that loses the consume race", func(t *testing.T) {
+		ms := new(MockStorage)
+		c := NewKeyorixCore(ms)
+		ms.On("GetSetupTokenByHash", ctx, hash).Return(activeTok(c), nil)
+		// The state-guarded UPDATE matched zero rows: someone else already consumed it.
+		ms.On("MarkSetupTokenConsumed", ctx, uint(9), mock.AnythingOfType("time.Time")).Return(false, nil)
+		_, err := c.ConsumeSetupToken(ctx, raw, SetupPurposeAccountSetup)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "already used")
+	})
+
+	t.Run("does not consume a wrong-purpose token", func(t *testing.T) {
+		ms := new(MockStorage)
+		c := NewKeyorixCore(ms)
+		ms.On("GetSetupTokenByHash", ctx, hash).Return(activeTok(c), nil)
+		_, err := c.ConsumeSetupToken(ctx, raw, SetupPurposeInvitationAccept)
+		require.Error(t, err)
+		ms.AssertNotCalled(t, "MarkSetupTokenConsumed", mock.Anything, mock.Anything, mock.Anything)
+	})
+}

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -194,6 +194,23 @@ type Storage interface {
 	RevokePersonalAccessToken(ctx context.Context, id uint) error
 	TouchPersonalAccessToken(ctx context.Context, id uint, usedAt time.Time, staleness time.Duration) error
 
+	// Setup Token Management (ADR-028) — single-use, hashed-at-rest credential-delivery tokens.
+	CreateSetupToken(ctx context.Context, t *models.SetupToken) (*models.SetupToken, error)
+	// GetSetupTokenByHash is the consumption lookup (indexed equality on token_hash).
+	GetSetupTokenByHash(ctx context.Context, hash string) (*models.SetupToken, error)
+	// SupersedeActiveSetupTokens flips every active token for (purpose, email) to
+	// superseded, so reissuing ("resend") atomically kills the prior link.
+	SupersedeActiveSetupTokens(ctx context.Context, purpose, email string) error
+	// MarkSetupTokenConsumed transitions active → consumed only if the token is still
+	// active, stamping consumedAt. It reports whether the transition happened, so a
+	// concurrent replay (state already consumed/expired/superseded) is rejected.
+	MarkSetupTokenConsumed(ctx context.Context, id uint, consumedAt time.Time) (bool, error)
+	// MarkSetupTokenExpired transitions active → expired (lazy expiry on read).
+	MarkSetupTokenExpired(ctx context.Context, id uint) error
+	// CountSetupTokensSince counts tokens minted for (purpose, email) since a cutoff,
+	// backing resend throttling / daily caps.
+	CountSetupTokensSince(ctx context.Context, purpose, email string, since time.Time) (int64, error)
+
 	// API Client Management
 	CreateAPIClient(ctx context.Context, client *models.APIClient) (*models.APIClient, error)
 	GetAPIClient(ctx context.Context, clientID string) (*models.APIClient, error)

--- a/internal/delivery/delivery.go
+++ b/internal/delivery/delivery.go
@@ -1,0 +1,153 @@
+// Package delivery transports a new principal's first-credential setup link to
+// them (ADR-028). It sits behind one CredentialDelivery interface with two
+// interchangeable channels — operator-configured SMTP email and admin out-of-band
+// display (the link is returned to the admin to relay manually) — selected by
+// config, mirroring the SIEM-connector pattern in internal/audit/siem.
+//
+// SECURITY: an implementation never sees a password or any reusable credential. It
+// transports only the single-use, short-TTL, hashed-at-rest setup link (or, for the
+// out-of-band one-time-password path, a value the caller forces to be reset on first
+// login). No email carries a password or a reusable token.
+package delivery
+
+import (
+	"context"
+	"fmt"
+	"log"
+)
+
+// Delivery modes (credential_delivery.mode).
+const (
+	// ModeAuto uses SMTP when configured, else out-of-band. Safe zero-config default.
+	ModeAuto = "auto"
+	// ModeSMTP always sends via SMTP, degrading to a returned link if sending fails.
+	ModeSMTP = "smtp"
+	// ModeOutOfBand never attempts SMTP; always returns the link to the admin.
+	// Correct default for air-gapped installs.
+	ModeOutOfBand = "out_of_band"
+	// ModeLog writes the link to the server log with a loud warning (dev/test only).
+	ModeLog = "log"
+)
+
+// Channel identifiers reported on a DeliveryResult.
+const (
+	ChannelSMTP      = "smtp"
+	ChannelOutOfBand = "out_of_band"
+	ChannelLog       = "log"
+)
+
+// SetupLinkRequest is the transport-agnostic payload for delivering a setup link.
+type SetupLinkRequest struct {
+	RecipientEmail    string
+	DisplayName       string
+	Link              string // fully-formed https URL containing the single-use token
+	Purpose           string
+	InstallName       string // e.g. "Acme Corporation Keyorix"
+	Message           string // optional inviter note
+	AssignmentSummary string // e.g. "developer on mobile-app, viewer on payment-svc"
+}
+
+// DeliveryResult reports how a setup link was delivered.
+type DeliveryResult struct {
+	Channel      string // ChannelSMTP | ChannelOutOfBand | ChannelLog
+	Delivered    bool   // true if actually sent; false if returned for manual relay
+	LinkForAdmin string // populated for out-of-band — the link to show the admin once
+}
+
+// CredentialDelivery delivers a setup link (or one-time secret) to a new principal.
+// Implementations never see the password; they transport the single-use link only.
+type CredentialDelivery interface {
+	// DeliverSetupLink delivers the link to the recipient. For out-of-band mode it
+	// returns the link to the caller (for the admin to relay) instead of sending.
+	DeliverSetupLink(ctx context.Context, req SetupLinkRequest) (DeliveryResult, error)
+	// Name identifies the channel for logging/audit.
+	Name() string
+}
+
+// SMTPSettings configures the operator's own mail relay. The password is resolved
+// from KEYORIX_SMTP_PASSWORD by the config layer and passed in here; it is never
+// written to the config file. SMTP transport itself lands in a follow-up — see New.
+type SMTPSettings struct {
+	Host     string
+	Port     int
+	Username string
+	Password string
+	From     string
+	TLS      string // starttls | implicit | none(dev-only)
+}
+
+// Configured reports whether an SMTP relay has been set up.
+func (s SMTPSettings) Configured() bool {
+	return s.Host != ""
+}
+
+// Config selects and parameterizes the delivery channel.
+type Config struct {
+	Mode    string // ModeAuto | ModeSMTP | ModeOutOfBand | ModeLog ("" = ModeAuto)
+	BaseURL string // used by the caller to build absolute setup links
+	SMTP    SMTPSettings
+}
+
+// New selects a CredentialDelivery implementation from cfg, mirroring siem.New.
+//
+// SMTP transport is not yet implemented in this package; it lands as SMTPDelivery in
+// a follow-up. Until then ModeSMTP (and ModeAuto with SMTP configured) is rejected at
+// construction so an install fails loudly at startup rather than silently dropping
+// invites. ModeAuto with no SMTP, ModeOutOfBand, and ModeLog all work today and cover
+// the air-gapped and zero-config cases that are the priority for the ICP.
+func New(cfg Config) (CredentialDelivery, error) {
+	mode := cfg.Mode
+	if mode == "" {
+		mode = ModeAuto
+	}
+	switch mode {
+	case ModeOutOfBand:
+		return &OutOfBandDelivery{}, nil
+	case ModeLog:
+		return &LogDelivery{}, nil
+	case ModeAuto:
+		if cfg.SMTP.Configured() {
+			return nil, fmt.Errorf("delivery: mode=auto resolved to SMTP but SMTP transport is not yet implemented; set credential_delivery.mode=out_of_band or remove the smtp block")
+		}
+		return &OutOfBandDelivery{}, nil
+	case ModeSMTP:
+		return nil, fmt.Errorf("delivery: mode=smtp is not yet implemented; use credential_delivery.mode=out_of_band")
+	default:
+		return nil, fmt.Errorf("delivery: unknown mode %q (want auto|smtp|out_of_band|log)", cfg.Mode)
+	}
+}
+
+// OutOfBandDelivery sends nothing; it returns the link in DeliveryResult.LinkForAdmin
+// so the create-user / invite response carries it back to the admin UI/CLI, which
+// displays it once for the admin to relay over their own secure channel. This is the
+// only path that works on an air-gapped install.
+type OutOfBandDelivery struct{}
+
+func (d *OutOfBandDelivery) DeliverSetupLink(_ context.Context, req SetupLinkRequest) (DeliveryResult, error) {
+	if req.Link == "" {
+		return DeliveryResult{}, fmt.Errorf("delivery: setup link is empty")
+	}
+	return DeliveryResult{
+		Channel:      ChannelOutOfBand,
+		Delivered:    false,
+		LinkForAdmin: req.Link,
+	}, nil
+}
+
+func (d *OutOfBandDelivery) Name() string { return ChannelOutOfBand }
+
+// LogDelivery writes the setup link to the server log with a loud warning. Dev/test
+// only — it puts a credential-bearing link in the logs, so it is never selected
+// unless the operator explicitly sets mode=log.
+type LogDelivery struct{}
+
+func (d *LogDelivery) DeliverSetupLink(_ context.Context, req SetupLinkRequest) (DeliveryResult, error) {
+	if req.Link == "" {
+		return DeliveryResult{}, fmt.Errorf("delivery: setup link is empty")
+	}
+	log.Printf("delivery: [DEV LOG MODE] setup link for %s (purpose=%s): %s",
+		req.RecipientEmail, req.Purpose, req.Link)
+	return DeliveryResult{Channel: ChannelLog, Delivered: true}, nil
+}
+
+func (d *LogDelivery) Name() string { return ChannelLog }

--- a/internal/delivery/delivery_test.go
+++ b/internal/delivery/delivery_test.go
@@ -1,0 +1,76 @@
+package delivery
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNew(t *testing.T) {
+	t.Run("empty mode defaults to auto → out-of-band when no SMTP", func(t *testing.T) {
+		d, err := New(Config{})
+		require.NoError(t, err)
+		assert.Equal(t, ChannelOutOfBand, d.Name())
+	})
+
+	t.Run("out_of_band selects OutOfBandDelivery", func(t *testing.T) {
+		d, err := New(Config{Mode: ModeOutOfBand})
+		require.NoError(t, err)
+		assert.IsType(t, &OutOfBandDelivery{}, d)
+	})
+
+	t.Run("log selects LogDelivery", func(t *testing.T) {
+		d, err := New(Config{Mode: ModeLog})
+		require.NoError(t, err)
+		assert.IsType(t, &LogDelivery{}, d)
+	})
+
+	t.Run("smtp is rejected until SMTP transport lands", func(t *testing.T) {
+		_, err := New(Config{Mode: ModeSMTP})
+		require.Error(t, err)
+	})
+
+	t.Run("auto with SMTP configured is rejected until SMTP transport lands", func(t *testing.T) {
+		_, err := New(Config{Mode: ModeAuto, SMTP: SMTPSettings{Host: "smtp.acme.io"}})
+		require.Error(t, err)
+	})
+
+	t.Run("unknown mode errors", func(t *testing.T) {
+		_, err := New(Config{Mode: "carrier-pigeon"})
+		require.Error(t, err)
+	})
+}
+
+func TestOutOfBandDelivery(t *testing.T) {
+	d := &OutOfBandDelivery{}
+	ctx := context.Background()
+
+	t.Run("returns the link for the admin to relay, sends nothing", func(t *testing.T) {
+		res, err := d.DeliverSetupLink(ctx, SetupLinkRequest{
+			RecipientEmail: "new@acme.io",
+			Link:           "https://keyorix.acme.internal/auth/setup/kx_setup_abc",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, ChannelOutOfBand, res.Channel)
+		assert.False(t, res.Delivered)
+		assert.Equal(t, "https://keyorix.acme.internal/auth/setup/kx_setup_abc", res.LinkForAdmin)
+	})
+
+	t.Run("errors on an empty link", func(t *testing.T) {
+		_, err := d.DeliverSetupLink(ctx, SetupLinkRequest{RecipientEmail: "new@acme.io"})
+		require.Error(t, err)
+	})
+}
+
+func TestLogDelivery(t *testing.T) {
+	d := &LogDelivery{}
+	res, err := d.DeliverSetupLink(context.Background(), SetupLinkRequest{
+		RecipientEmail: "new@acme.io",
+		Link:           "https://keyorix.acme.internal/auth/setup/kx_setup_abc",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ChannelLog, res.Channel)
+	assert.True(t, res.Delivered)
+}

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -233,6 +233,7 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 	pwHistExists := tableExists(db, "password_histories")
 	machineExists := tableExists(db, "machine_identities")
 	membershipExists := tableExists(db, "project_memberships")
+	setupTokenExists := tableExists(db, "setup_tokens")
 
 	// Create rotation_policies if missing (additive, safe on existing DBs).
 	if !rotationExists {
@@ -278,6 +279,13 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 	if !membershipExists {
 		if err := db.AutoMigrate(&models.ProjectMembership{}); err != nil {
 			return fmt.Errorf("failed to migrate project_memberships table: %w", err)
+		}
+	}
+
+	// Create setup_tokens if missing (ADR-028 credential delivery, additive).
+	if !setupTokenExists {
+		if err := db.AutoMigrate(&models.SetupToken{}); err != nil {
+			return fmt.Errorf("failed to migrate setup_tokens table: %w", err)
 		}
 	}
 

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -230,6 +230,42 @@ type PersonalAccessToken struct {
 	CreatedAt   time.Time
 }
 
+// SetupToken is the single-use, hashed-at-rest bearer string that lets a brand-new
+// principal establish their first credential (ADR-028). It backs three producers —
+// invitation acceptance (ADR-024), admin-direct account setup (ADR-025), and the
+// reset-link path — selected by Purpose. The plaintext is shown exactly once (in a
+// link or out-of-band display) and never persisted; only TokenHash (SHA-256 hex) is
+// stored, and lookup is by hash, mirroring PersonalAccessToken.
+type SetupToken struct {
+	ID        uint   `gorm:"primaryKey"`
+	TokenHash string `gorm:"uniqueIndex;not null"` // SHA-256 hex of the raw token (never the plaintext)
+
+	// Purpose scopes the token: invitation_accept | account_setup | password_reset_link.
+	// A token minted for one purpose can never drive another, even if the raw string
+	// leaked into the wrong endpoint.
+	Purpose string `gorm:"index;not null"`
+
+	// SubjectUserID is the account the token establishes a credential for. Nullable:
+	// an invitation issued to an email has no user row until acceptance materializes one.
+	SubjectUserID *uint `gorm:"index"`
+	// SubjectEmail binds the token to the address it was minted for (acceptance checks it).
+	SubjectEmail string `gorm:"index"`
+	// InvitationID links back to the project_invitations row for purpose=invitation_accept.
+	InvitationID *uint `gorm:"index"`
+
+	// State: active | consumed | expired | superseded. Consuming is single-use
+	// (active → consumed in the same txn that materializes the effect); reissuing for
+	// the same (purpose, subject) supersedes the prior active token (active → superseded);
+	// a lazy-expire check flips overdue active tokens to expired on read.
+	State string `gorm:"index;not null;default:active"`
+
+	ExpiresAt time.Time
+	// CreatedBy is the admin/inviter who minted the token; 0 for self-service reset.
+	CreatedBy  uint
+	CreatedAt  time.Time
+	ConsumedAt *time.Time // nil until consumed
+}
+
 type PasswordReset struct {
 	ID             uint `gorm:"primaryKey"`
 	UserID         uint

--- a/internal/storage/store/local_auth.go
+++ b/internal/storage/store/local_auth.go
@@ -240,3 +240,61 @@ func (ls *LocalStorage) TouchPersonalAccessToken(ctx context.Context, id uint, u
 		Where("id = ? AND (last_used_at IS NULL OR last_used_at < ?)", id, cutoff).
 		UpdateColumn("last_used_at", usedAt).Error
 }
+
+// --- Setup Tokens (ADR-028) ---
+
+func (ls *LocalStorage) CreateSetupToken(ctx context.Context, t *models.SetupToken) (*models.SetupToken, error) {
+	if err := ls.db.WithContext(ctx).Create(t).Error; err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	return t, nil
+}
+
+// GetSetupTokenByHash is the consumption lookup (indexed equality on token_hash).
+func (ls *LocalStorage) GetSetupTokenByHash(ctx context.Context, hash string) (*models.SetupToken, error) {
+	var t models.SetupToken
+	if err := ls.db.WithContext(ctx).Where("token_hash = ?", hash).First(&t).Error; err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorNotFound", nil), err)
+	}
+	return &t, nil
+}
+
+// SupersedeActiveSetupTokens flips every active token for (purpose, email) to
+// superseded so a reissue kills the prior link atomically.
+func (ls *LocalStorage) SupersedeActiveSetupTokens(ctx context.Context, purpose, email string) error {
+	return ls.db.WithContext(ctx).Model(&models.SetupToken{}).
+		Where("purpose = ? AND subject_email = ? AND state = ?", purpose, email, "active").
+		Update("state", "superseded").Error
+}
+
+// MarkSetupTokenConsumed transitions active → consumed only if still active. The
+// state guard in the WHERE clause makes consumption single-use even under a
+// concurrent replay: the second caller matches zero rows and gets false.
+func (ls *LocalStorage) MarkSetupTokenConsumed(ctx context.Context, id uint, consumedAt time.Time) (bool, error) {
+	result := ls.db.WithContext(ctx).Model(&models.SetupToken{}).
+		Where("id = ? AND state = ?", id, "active").
+		Updates(map[string]interface{}{"state": "consumed", "consumed_at": consumedAt})
+	if result.Error != nil {
+		return false, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), result.Error)
+	}
+	return result.RowsAffected == 1, nil
+}
+
+// MarkSetupTokenExpired transitions active → expired (lazy expiry on read).
+func (ls *LocalStorage) MarkSetupTokenExpired(ctx context.Context, id uint) error {
+	return ls.db.WithContext(ctx).Model(&models.SetupToken{}).
+		Where("id = ? AND state = ?", id, "active").
+		Update("state", "expired").Error
+}
+
+// CountSetupTokensSince counts tokens minted for (purpose, email) since a cutoff,
+// backing resend throttling and the daily cap.
+func (ls *LocalStorage) CountSetupTokensSince(ctx context.Context, purpose, email string, since time.Time) (int64, error) {
+	var n int64
+	if err := ls.db.WithContext(ctx).Model(&models.SetupToken{}).
+		Where("purpose = ? AND subject_email = ? AND created_at >= ?", purpose, email, since).
+		Count(&n).Error; err != nil {
+		return 0, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	return n, nil
+}

--- a/internal/storage/store/remote_auth.go
+++ b/internal/storage/store/remote_auth.go
@@ -275,3 +275,30 @@ func (rs *RemoteStorage) RevokePersonalAccessToken(_ context.Context, _ uint) er
 func (rs *RemoteStorage) TouchPersonalAccessToken(_ context.Context, _ uint, _ time.Time, _ time.Duration) error {
 	return nil // best-effort; no-op on remote storage
 }
+
+// Setup Token Management (ADR-028) — credential delivery is a server-side concern;
+// a remote CLI client does not mint or consume setup tokens.
+
+func (rs *RemoteStorage) CreateSetupToken(_ context.Context, _ *models.SetupToken) (*models.SetupToken, error) {
+	return nil, errUnsupportedRemote
+}
+
+func (rs *RemoteStorage) GetSetupTokenByHash(_ context.Context, _ string) (*models.SetupToken, error) {
+	return nil, errUnsupportedRemote
+}
+
+func (rs *RemoteStorage) SupersedeActiveSetupTokens(_ context.Context, _, _ string) error {
+	return errUnsupportedRemote
+}
+
+func (rs *RemoteStorage) MarkSetupTokenConsumed(_ context.Context, _ uint, _ time.Time) (bool, error) {
+	return false, errUnsupportedRemote
+}
+
+func (rs *RemoteStorage) MarkSetupTokenExpired(_ context.Context, _ uint) error {
+	return errUnsupportedRemote
+}
+
+func (rs *RemoteStorage) CountSetupTokensSince(_ context.Context, _, _ string, _ time.Time) (int64, error) {
+	return 0, errUnsupportedRemote
+}

--- a/server/main.go
+++ b/server/main.go
@@ -215,6 +215,11 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 	if vm := cfg.Membership.ValidationMode; vm != "" {
 		coreService.SetMembershipValidationMode(vm)
 	}
+
+	// Apply the credential-delivery setup-token TTL (ADR-028). GetSetupTokenTTL
+	// falls back to 24h when the block is absent or invalid.
+	coreService.SetSetupTokenTTL(cfg.CredentialDelivery.GetSetupTokenTTL())
+
 	return coreService, encSvc, nil
 }
 


### PR DESCRIPTION
## Summary

First implementation PR for **ADR-028 — Credential Delivery** (#19). Lands the foundational primitive that the invitation-accept (ADR-024), admin-direct-creation (ADR-025), and resend flows will sit on top of, plus the delivery interface — **without** the SMTP dependency yet (that's the next PR).

## What's in this PR

- **`setup_tokens` table + model** — single-use, SHA-256 hashed-at-rest, 256-bit (`crypto/rand`) token. Purpose-scoped (`invitation_accept | account_setup | password_reset_link`), short-TTL, `active | consumed | expired | superseded`. Conditional `AutoMigrate` via the early table-existence snapshot (avoids the documented pgx prepared-statement cache trip).
- **Storage layer** — interface methods + local impl + mock + remote stubs: create, hash-lookup, `SupersedeActiveSetupTokens`, state-guarded single-use `MarkSetupTokenConsumed`, `MarkSetupTokenExpired`, `CountSetupTokensSince` (resend throttle).
- **`core/setup_token.go`** — `IssueSetupToken` / `ValidateSetupToken` / `ConsumeSetupToken`. Plaintext returned once and never stored, supersede-on-reissue, lazy expiry, purpose-scoping, single-use consume (state-guarded UPDATE → replay matches zero rows). Mirrors the PAT handling from ADR-027.
- **`internal/delivery`** — `CredentialDelivery` interface with `OutOfBand` + `Log` channels, config-selected like `internal/audit/siem`. `auto` mode degrades safely to out-of-band; `smtp` is rejected at construction until the next PR (fails loud, never silently drops invites).
- **`credential_delivery` config block** — `mode`, `setup_token_ttl`, `base_url`, `smtp` with `KEYORIX_SMTP_PASSWORD` env convention. TTL wired into core at startup.
- **Audit events** — `setup_token.issued` / `consumed` / `expired` (no token, not even the hash, on the row).

## Security invariants enforced here

- Plaintext token returned exactly once; only `sha256(token)` persisted; lookup by hash.
- Single-use is structural: the consume is a state-guarded conditional UPDATE, so a concurrent replay is rejected.
- Purpose-scoped: an `invitation_accept` token cannot drive a password reset even if the raw string reaches the wrong endpoint.
- Reissue supersedes the prior active token, so "resend" kills the old link instantly.

## Not in this PR (follow-ups)

- **SMTP delivery** — `wneessen/go-mail`, `SMTPDelivery`, email content (Part D). Next PR.
- **Endpoints + producers** — `/auth/setup/{token}` + `/auth/setup/consume`, wiring ADR-025 user creation / ADR-024 invitation resend, CLI commands, `credential.displayed_out_of_band`, rate limiting (Parts E/G).
- **Frontend** setup/landing page (keyorix-web).

## Testing

`go build/vet/test ./...` all green. New unit tests cover token mint/validate/consume/replay/expire/supersede/purpose-scope and delivery channel selection.

Depends on ADR doc #19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)