### PR TITLE
feat(credential-delivery): SMTP setup-link transport (ADR-028)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/nicksnyder/go-i18n/v2 v2.6.0
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0
+	github.com/wneessen/go-mail v0.7.3
 	golang.org/x/crypto v0.51.0
 	golang.org/x/term v0.43.0
 	golang.org/x/text v0.37.0

--- a/go.sum
+++ b/go.sum
@@ -71,6 +71,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/wneessen/go-mail v0.7.3 h1:g3DravXC5SMlVdboFrQA8Jx95A8sOzoBeS5F+vzNRK0=
+github.com/wneessen/go-mail v0.7.3/go.mod h1:QGhBX0yNbc1J+Mkjcu7z2rpj4B4l+BmDY8gYznPC9sk=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=

--- a/internal/delivery/delivery.go
+++ b/internal/delivery/delivery.go
@@ -90,11 +90,12 @@ type Config struct {
 
 // New selects a CredentialDelivery implementation from cfg, mirroring siem.New.
 //
-// SMTP transport is not yet implemented in this package; it lands as SMTPDelivery in
-// a follow-up. Until then ModeSMTP (and ModeAuto with SMTP configured) is rejected at
-// construction so an install fails loudly at startup rather than silently dropping
-// invites. ModeAuto with no SMTP, ModeOutOfBand, and ModeLog all work today and cover
-// the air-gapped and zero-config cases that are the priority for the ICP.
+//   - out_of_band — always return the link to the admin (air-gapped installs).
+//   - log         — write the link to the server log (dev/test only).
+//   - smtp        — send via the operator's relay; send failures degrade to
+//     out-of-band rather than failing closed.
+//   - auto ("")   — smtp when an SMTP relay is configured, else out_of_band, so a
+//     zero-config install still works without any mail infrastructure.
 func New(cfg Config) (CredentialDelivery, error) {
 	mode := cfg.Mode
 	if mode == "" {
@@ -105,13 +106,13 @@ func New(cfg Config) (CredentialDelivery, error) {
 		return &OutOfBandDelivery{}, nil
 	case ModeLog:
 		return &LogDelivery{}, nil
+	case ModeSMTP:
+		return newSMTPDelivery(cfg.SMTP)
 	case ModeAuto:
 		if cfg.SMTP.Configured() {
-			return nil, fmt.Errorf("delivery: mode=auto resolved to SMTP but SMTP transport is not yet implemented; set credential_delivery.mode=out_of_band or remove the smtp block")
+			return newSMTPDelivery(cfg.SMTP)
 		}
 		return &OutOfBandDelivery{}, nil
-	case ModeSMTP:
-		return nil, fmt.Errorf("delivery: mode=smtp is not yet implemented; use credential_delivery.mode=out_of_band")
 	default:
 		return nil, fmt.Errorf("delivery: unknown mode %q (want auto|smtp|out_of_band|log)", cfg.Mode)
 	}

--- a/internal/delivery/delivery_test.go
+++ b/internal/delivery/delivery_test.go
@@ -27,14 +27,22 @@ func TestNew(t *testing.T) {
 		assert.IsType(t, &LogDelivery{}, d)
 	})
 
-	t.Run("smtp is rejected until SMTP transport lands", func(t *testing.T) {
+	t.Run("smtp with a configured relay selects SMTPDelivery", func(t *testing.T) {
+		d, err := New(Config{Mode: ModeSMTP, SMTP: SMTPSettings{Host: "smtp.acme.io", From: "k@acme.io"}})
+		require.NoError(t, err)
+		assert.IsType(t, &SMTPDelivery{}, d)
+		assert.Equal(t, ChannelSMTP, d.Name())
+	})
+
+	t.Run("smtp without a host errors at construction", func(t *testing.T) {
 		_, err := New(Config{Mode: ModeSMTP})
 		require.Error(t, err)
 	})
 
-	t.Run("auto with SMTP configured is rejected until SMTP transport lands", func(t *testing.T) {
-		_, err := New(Config{Mode: ModeAuto, SMTP: SMTPSettings{Host: "smtp.acme.io"}})
-		require.Error(t, err)
+	t.Run("auto with SMTP configured selects SMTPDelivery", func(t *testing.T) {
+		d, err := New(Config{Mode: ModeAuto, SMTP: SMTPSettings{Host: "smtp.acme.io", From: "k@acme.io"}})
+		require.NoError(t, err)
+		assert.IsType(t, &SMTPDelivery{}, d)
 	})
 
 	t.Run("unknown mode errors", func(t *testing.T) {

--- a/internal/delivery/smtp.go
+++ b/internal/delivery/smtp.go
@@ -1,0 +1,193 @@
+// smtp.go — SMTP credential delivery (ADR-028).
+//
+// SMTPDelivery sends a new principal's single-use setup link via the operator's own
+// mail relay. TLS correctness (implicit TLS on 465, STARTTLS on 587, auth
+// negotiation) is delegated to wneessen/go-mail rather than hand-rolled on top of
+// stdlib net/smtp — getting TLS wrong in a security product is not worth the saved
+// dependency.
+//
+// The email carries ONLY the single-use, short-TTL link plus context (inviter,
+// install name, optional note, assignment summary). It never contains a password, a
+// reusable token, or any remote resource (image/CSS/JS/tracking pixel): regulated
+// buyers' mail gateways flag those and they are a privacy/exfil surface.
+//
+// Send failures degrade gracefully to out-of-band: DeliverSetupLink returns a result
+// with Delivered=false and the link in LinkForAdmin (and logs the cause) rather than
+// failing closed, so the admin can always relay the link manually.
+package delivery
+
+import (
+	"context"
+	"fmt"
+	"html"
+	"log"
+	"strings"
+	"time"
+
+	mail "github.com/wneessen/go-mail"
+)
+
+// smtpDialTimeout bounds a single send so a wedged relay cannot stall the request.
+const smtpDialTimeout = 10 * time.Second
+
+// TLS modes (credential_delivery.smtp.tls).
+const (
+	smtpTLSStartTLS = "starttls"
+	smtpTLSImplicit = "implicit"
+	smtpTLSNone     = "none"
+)
+
+// SMTPDelivery sends setup links via the operator's configured SMTP relay.
+type SMTPDelivery struct {
+	cfg SMTPSettings
+}
+
+// newSMTPDelivery validates the SMTP settings and returns a ready sender. It does
+// not dial — connection is per-send so a relay outage never blocks startup.
+func newSMTPDelivery(cfg SMTPSettings) (*SMTPDelivery, error) {
+	if cfg.Host == "" {
+		return nil, fmt.Errorf("delivery: smtp host is required")
+	}
+	if cfg.From == "" {
+		return nil, fmt.Errorf("delivery: smtp from address is required")
+	}
+	switch strings.ToLower(cfg.TLS) {
+	case "", smtpTLSStartTLS, smtpTLSImplicit, smtpTLSNone:
+	default:
+		return nil, fmt.Errorf("delivery: unknown smtp tls mode %q (want starttls|implicit|none)", cfg.TLS)
+	}
+	return &SMTPDelivery{cfg: cfg}, nil
+}
+
+func (d *SMTPDelivery) Name() string { return ChannelSMTP }
+
+// DeliverSetupLink builds and sends the setup-link email. On any failure it returns
+// a non-delivered result carrying the link for manual relay (graceful degradation),
+// never an error — a setup link must always have a recourse path.
+func (d *SMTPDelivery) DeliverSetupLink(ctx context.Context, req SetupLinkRequest) (DeliveryResult, error) {
+	if req.Link == "" {
+		return DeliveryResult{}, fmt.Errorf("delivery: setup link is empty")
+	}
+	if req.RecipientEmail == "" {
+		return DeliveryResult{}, fmt.Errorf("delivery: recipient email is empty")
+	}
+
+	msg, err := d.buildMessage(req)
+	if err != nil {
+		// A malformed from/to is a config error, not a transient outage — still
+		// degrade to manual relay rather than dropping the principal's only link.
+		log.Printf("delivery: smtp message build failed for %s, degrading to manual relay: %v", req.RecipientEmail, err)
+		return DeliveryResult{Channel: ChannelSMTP, Delivered: false, LinkForAdmin: req.Link}, nil
+	}
+
+	client, err := d.newClient()
+	if err != nil {
+		log.Printf("delivery: smtp client init failed, degrading to manual relay: %v", err)
+		return DeliveryResult{Channel: ChannelSMTP, Delivered: false, LinkForAdmin: req.Link}, nil
+	}
+
+	if err := client.DialAndSendWithContext(ctx, msg); err != nil {
+		log.Printf("delivery: smtp send to %s failed, degrading to manual relay: %v", req.RecipientEmail, err)
+		return DeliveryResult{Channel: ChannelSMTP, Delivered: false, LinkForAdmin: req.Link}, nil
+	}
+	return DeliveryResult{Channel: ChannelSMTP, Delivered: true}, nil
+}
+
+// newClient builds a go-mail client from the SMTP settings, selecting the TLS policy
+// and auth mechanism. Auth is auto-discovered when credentials are present and
+// disabled otherwise (e.g. an internal relay that authenticates by network).
+func (d *SMTPDelivery) newClient() (*mail.Client, error) {
+	opts := []mail.Option{
+		mail.WithTimeout(smtpDialTimeout),
+	}
+	if d.cfg.Port > 0 {
+		opts = append(opts, mail.WithPort(d.cfg.Port))
+	}
+	switch strings.ToLower(d.cfg.TLS) {
+	case smtpTLSImplicit:
+		opts = append(opts, mail.WithSSL())
+	case smtpTLSNone:
+		opts = append(opts, mail.WithTLSPolicy(mail.NoTLS))
+	default: // "" or starttls — require STARTTLS.
+		opts = append(opts, mail.WithTLSPolicy(mail.TLSMandatory))
+	}
+	if d.cfg.Username != "" {
+		opts = append(opts,
+			mail.WithSMTPAuth(mail.SMTPAuthAutoDiscover),
+			mail.WithUsername(d.cfg.Username),
+			mail.WithPassword(d.cfg.Password),
+		)
+	}
+	return mail.NewClient(d.cfg.Host, opts...)
+}
+
+// buildMessage renders the setup-link email. Exposed-for-test via buildMessage; the
+// plaintext and HTML parts are produced by renderBody so their content can be
+// asserted (no remote resources, link present) without a live SMTP server.
+func (d *SMTPDelivery) buildMessage(req SetupLinkRequest) (*mail.Msg, error) {
+	msg := mail.NewMsg()
+	if err := msg.From(d.cfg.From); err != nil {
+		return nil, fmt.Errorf("invalid from address %q: %w", d.cfg.From, err)
+	}
+	if err := msg.To(req.RecipientEmail); err != nil {
+		return nil, fmt.Errorf("invalid recipient %q: %w", req.RecipientEmail, err)
+	}
+	plain, htmlBody := renderBody(req)
+	msg.Subject(subjectFor(req))
+	msg.SetBodyString(mail.TypeTextPlain, plain)
+	msg.AddAlternativeString(mail.TypeTextHTML, htmlBody)
+	return msg, nil
+}
+
+// subjectFor returns the email subject, scoped to the install name when present.
+func subjectFor(req SetupLinkRequest) string {
+	install := req.InstallName
+	if install == "" {
+		install = "Keyorix"
+	}
+	return fmt.Sprintf("Set up your %s access", install)
+}
+
+// renderBody produces the plaintext and minimal-inline-HTML bodies. No remote
+// resources, no tracking — text plus one anchor for the single call to action.
+func renderBody(req SetupLinkRequest) (plain, htmlBody string) {
+	install := req.InstallName
+	if install == "" {
+		install = "Keyorix"
+	}
+	greetName := req.DisplayName
+	if greetName == "" {
+		greetName = "there"
+	}
+
+	var p strings.Builder
+	fmt.Fprintf(&p, "Hi %s,\n\n", greetName)
+	fmt.Fprintf(&p, "You've been given access to %s.\n\n", install)
+	if req.AssignmentSummary != "" {
+		fmt.Fprintf(&p, "Your access: %s\n\n", req.AssignmentSummary)
+	}
+	if req.Message != "" {
+		fmt.Fprintf(&p, "Note from the sender:\n%s\n\n", req.Message)
+	}
+	p.WriteString("To set your password and finish setup, open this single-use link:\n")
+	fmt.Fprintf(&p, "%s\n\n", req.Link)
+	p.WriteString("The link can be used once and expires soon. If you weren't expecting this, you can ignore this email.\n")
+
+	var h strings.Builder
+	h.WriteString("<div style=\"font-family:sans-serif;font-size:14px;line-height:1.5;color:#1a1a1a\">")
+	fmt.Fprintf(&h, "<p>Hi %s,</p>", html.EscapeString(greetName))
+	fmt.Fprintf(&h, "<p>You've been given access to <strong>%s</strong>.</p>", html.EscapeString(install))
+	if req.AssignmentSummary != "" {
+		fmt.Fprintf(&h, "<p><strong>Your access:</strong> %s</p>", html.EscapeString(req.AssignmentSummary))
+	}
+	if req.Message != "" {
+		fmt.Fprintf(&h, "<p><strong>Note from the sender:</strong><br>%s</p>", html.EscapeString(req.Message))
+	}
+	h.WriteString("<p>To set your password and finish setup, use this single-use link:</p>")
+	// The href and visible text are the same trusted setup URL; no redirect, no tracking.
+	fmt.Fprintf(&h, "<p><a href=\"%s\">%s</a></p>", html.EscapeString(req.Link), html.EscapeString(req.Link))
+	h.WriteString("<p style=\"color:#666\">The link can be used once and expires soon. If you weren't expecting this, you can ignore this email.</p>")
+	h.WriteString("</div>")
+
+	return p.String(), h.String()
+}

--- a/internal/delivery/smtp_test.go
+++ b/internal/delivery/smtp_test.go
@@ -1,0 +1,111 @@
+package delivery
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewSMTPDelivery(t *testing.T) {
+	t.Run("requires host and from", func(t *testing.T) {
+		_, err := newSMTPDelivery(SMTPSettings{From: "k@acme.io"})
+		require.Error(t, err)
+		_, err = newSMTPDelivery(SMTPSettings{Host: "smtp.acme.io"})
+		require.Error(t, err)
+	})
+
+	t.Run("rejects an unknown tls mode", func(t *testing.T) {
+		_, err := newSMTPDelivery(SMTPSettings{Host: "smtp.acme.io", From: "k@acme.io", TLS: "ssl-maybe"})
+		require.Error(t, err)
+	})
+
+	t.Run("accepts the documented tls modes", func(t *testing.T) {
+		for _, m := range []string{"", "starttls", "implicit", "none", "STARTTLS"} {
+			_, err := newSMTPDelivery(SMTPSettings{Host: "smtp.acme.io", From: "k@acme.io", TLS: m})
+			require.NoError(t, err, "tls=%q", m)
+		}
+	})
+}
+
+func TestRenderBody(t *testing.T) {
+	req := SetupLinkRequest{
+		RecipientEmail:    "new@acme.io",
+		DisplayName:       "Dana",
+		Link:              "https://keyorix.acme.internal/auth/setup/kx_setup_abc123",
+		InstallName:       "Acme Keyorix",
+		Message:           "welcome aboard",
+		AssignmentSummary: "developer on mobile-app",
+	}
+	plain, htmlBody := renderBody(req)
+
+	t.Run("both parts carry the single-use link and context", func(t *testing.T) {
+		for _, body := range []string{plain, htmlBody} {
+			assert.Contains(t, body, req.Link)
+			assert.Contains(t, body, "Acme Keyorix")
+			assert.Contains(t, body, "Dana")
+			assert.Contains(t, body, "developer on mobile-app")
+			assert.Contains(t, body, "welcome aboard")
+		}
+	})
+
+	t.Run("html carries no remote resources or tracking", func(t *testing.T) {
+		lower := strings.ToLower(htmlBody)
+		assert.NotContains(t, lower, "<img", "no images / tracking pixels")
+		assert.NotContains(t, lower, "http://", "no plaintext-http resources")
+		assert.NotContains(t, lower, "<script", "no scripts")
+		assert.NotContains(t, lower, "background:url", "no remote CSS resources")
+		// Every https URL in the document is the trusted setup link (it appears twice:
+		// once as the anchor href, once as the visible text — both the same link).
+		assert.Equal(t, strings.Count(lower, strings.ToLower(req.Link)), strings.Count(lower, "https://"),
+			"the setup link is the only URL in the document")
+	})
+
+	t.Run("never leaks a password or reusable credential", func(t *testing.T) {
+		// Defensive: the request has no password field; assert the body has no such word
+		// so a future field addition cannot silently start emailing one.
+		assert.NotContains(t, strings.ToLower(plain), "password:")
+		assert.NotContains(t, strings.ToLower(htmlBody), "password:")
+	})
+}
+
+func TestRenderBodyDefaults(t *testing.T) {
+	// Minimal request: no display name, install name, message, or summary.
+	plain, htmlBody := renderBody(SetupLinkRequest{Link: "https://x/auth/setup/kx_setup_z"})
+	assert.Contains(t, plain, "Hi there,")
+	assert.Contains(t, plain, "Keyorix")
+	assert.Contains(t, htmlBody, "Keyorix")
+	assert.Contains(t, plain, "https://x/auth/setup/kx_setup_z")
+}
+
+func TestSubjectFor(t *testing.T) {
+	assert.Equal(t, "Set up your Acme Keyorix access", subjectFor(SetupLinkRequest{InstallName: "Acme Keyorix"}))
+	assert.Equal(t, "Set up your Keyorix access", subjectFor(SetupLinkRequest{}))
+}
+
+func TestSMTPDeliverDegradesOnSendFailure(t *testing.T) {
+	// Point at a closed port on localhost: the dial fails fast (connection refused),
+	// and delivery must degrade to manual relay rather than returning an error.
+	d, err := newSMTPDelivery(SMTPSettings{Host: "127.0.0.1", Port: 1, From: "k@acme.io", TLS: "none"})
+	require.NoError(t, err)
+
+	res, err := d.DeliverSetupLink(context.Background(), SetupLinkRequest{
+		RecipientEmail: "new@acme.io",
+		Link:           "https://keyorix.acme.internal/auth/setup/kx_setup_abc",
+	})
+	require.NoError(t, err, "send failure degrades gracefully, never errors")
+	assert.Equal(t, ChannelSMTP, res.Channel)
+	assert.False(t, res.Delivered)
+	assert.Equal(t, "https://keyorix.acme.internal/auth/setup/kx_setup_abc", res.LinkForAdmin)
+}
+
+func TestSMTPDeliverRejectsEmptyInput(t *testing.T) {
+	d, err := newSMTPDelivery(SMTPSettings{Host: "127.0.0.1", From: "k@acme.io"})
+	require.NoError(t, err)
+	_, err = d.DeliverSetupLink(context.Background(), SetupLinkRequest{RecipientEmail: "x@y.io"})
+	require.Error(t, err, "empty link is a programming error, not a transient outage")
+	_, err = d.DeliverSetupLink(context.Background(), SetupLinkRequest{Link: "https://x/y"})
+	require.Error(t, err, "empty recipient is a programming error")
+}


### PR DESCRIPTION
## Summary

Second implementation PR for **ADR-028** (#19). Adds the SMTP delivery channel — Parts B/D of the ADR — on top of the credential-delivery primitive.

> **Stacked on #20** (`feat/adr-028-setup-tokens`). Review/merge #20 first; this PR's base is that branch, so the diff shown is SMTP-only.

## What's in this PR

- **`SMTPDelivery`** — sends a new principal's single-use setup link via the operator's own relay using `wneessen/go-mail`. TLS correctness (implicit TLS on 465, STARTTLS on 587, auth negotiation) is delegated to the library rather than hand-rolled on stdlib `net/smtp`. Per-send dial (a relay outage never blocks startup), 10s timeout, auth auto-discovered when credentials are present.
- **`delivery.New` wiring** — `mode=smtp` and `mode=auto`-with-relay now build `SMTPDelivery`; `auto` with no relay still resolves to out-of-band (zero-config installs keep working).
- **Email content (Part D)** — plaintext + minimal inline HTML, single call to action. **No password, no reusable token, no remote image/CSS/JS, no tracking pixel.** The only URL in the document is the trusted single-use setup link (asserted in tests).
- **Graceful degradation** — a send failure returns `Delivered=false` with the link in `LinkForAdmin` (and logs the cause) instead of failing closed, so a setup link always has a manual-relay recourse — matching the ADR's `mode=smtp` behaviour.

## Why go-mail (the one new dependency)

Correct SMTP TLS/auth is exactly the kind of thing not to own in a security product. `net/smtp` is frozen and does not do implicit TLS on 465 or modern auth negotiation cleanly. ADR-028 calls this dependency out explicitly as justified.

## Testing

`go build/vet/test ./...` green. New tests cover:
- Body rendering: link + context present, **zero remote resources / tracking**, no password leak.
- TLS-mode validation (`starttls | implicit | none`), required host/from.
- Default greetings when optional fields are absent.
- Connection-refused → graceful degradation to manual relay (never errors).

## Next (final PR in the stack)

Endpoints + producers: `/auth/setup/{token}` + `/auth/setup/consume`, wire ADR-025 user-creation and ADR-024 invitation-resend, `resend-setup-link` CLI, `credential.displayed_out_of_band` audit, resend rate-limiting (Parts E/G). Then the keyorix-web setup/landing page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)