### PR TITLE
feat(credential-delivery): public /auth/setup endpoints + consume (ADR-028)

### DIFF
--- a/internal/core/account.go
+++ b/internal/core/account.go
@@ -47,37 +47,13 @@ func (c *KeyorixCore) ChangePassword(ctx context.Context, userID uint, current, 
 	if err := bcrypt.CompareHashAndPassword([]byte(user.PasswordHash), []byte(current)); err != nil {
 		return fmt.Errorf("%s: current password is incorrect", i18n.T("ErrorValidation", nil))
 	}
-	// Enforce the configured password policy (ADR-025). Done after the
-	// current-password check so an attacker can't probe the policy without
-	// already holding valid credentials.
-	if err := c.passwordPolicy.Validate(newPassword, user); err != nil {
-		return fmt.Errorf("%s: %w", i18n.T("ErrorValidation", nil), err)
+	// Enforce policy + history after the current-password check so an attacker can't
+	// probe the policy without already holding valid credentials (ADR-025).
+	if err := c.validateNewPassword(ctx, user, newPassword); err != nil {
+		return err
 	}
-	// Stateful history rule: forbid reuse of the last N passwords (ADR-025).
-	if c.passwordReused(ctx, user, newPassword) {
-		return fmt.Errorf("%s: password must not reuse a recent password", i18n.T("ErrorValidation", nil))
-	}
-
-	hash, err := bcrypt.GenerateFromPassword([]byte(newPassword), bcrypt.DefaultCost)
-	if err != nil {
-		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
-	}
-	now := c.now()
-	user.PasswordHash = string(hash)
-	user.PasswordChangedAt = &now
-	// A successful password change clears a restricted account back to active
-	// (ADR-025): pending_first_login / password_reset_required are satisfied.
-	user.AccountState = clearRestrictionOnPasswordChange(user.AccountState)
-	user.UpdatedAt = now
-	if _, err := c.storage.UpdateUser(ctx, user); err != nil {
-		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
-	}
-
-	// Record the new hash in history and prune to the configured depth.
-	// Best-effort: the password change itself has already succeeded.
-	if c.passwordPolicy.HistoryCount > 0 {
-		_ = c.storage.AddPasswordHistory(ctx, userID, string(hash), now)
-		_ = c.storage.PrunePasswordHistory(ctx, userID, c.passwordPolicy.HistoryCount)
+	if err := c.applyNewPassword(ctx, user, newPassword); err != nil {
+		return err
 	}
 
 	// Drop other sessions. Best-effort: the password change itself has succeeded.
@@ -88,6 +64,48 @@ func (c *KeyorixCore) ChangePassword(ctx context.Context, userID uint, current, 
 		}
 	}
 	_ = c.storage.DeleteSessionsForUserExcept(ctx, userID, keepID)
+	return nil
+}
+
+// validateNewPassword checks a candidate password against the configured policy and
+// the password-history rule, without mutating anything. Split from applyNewPassword
+// so callers (e.g. the setup-token consume flow) can reject a weak password BEFORE
+// spending a single-use token, rather than burning the link on a policy failure.
+func (c *KeyorixCore) validateNewPassword(ctx context.Context, user *models.User, newPassword string) error {
+	if err := c.passwordPolicy.Validate(newPassword, user); err != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorValidation", nil), err)
+	}
+	// Stateful history rule: forbid reuse of the last N passwords (ADR-025).
+	if c.passwordReused(ctx, user, newPassword) {
+		return fmt.Errorf("%s: password must not reuse a recent password", i18n.T("ErrorValidation", nil))
+	}
+	return nil
+}
+
+// applyNewPassword hashes newPassword, stamps it on the user (clearing a restricted
+// account state back to active per ADR-025), persists the user, and records the hash
+// in history. It assumes the password has already passed validateNewPassword. Shared
+// by ChangePassword and the setup-token consume flow so password handling is uniform.
+func (c *KeyorixCore) applyNewPassword(ctx context.Context, user *models.User, newPassword string) error {
+	hash, err := bcrypt.GenerateFromPassword([]byte(newPassword), bcrypt.DefaultCost)
+	if err != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	now := c.now()
+	user.PasswordHash = string(hash)
+	user.PasswordChangedAt = &now
+	user.AccountState = clearRestrictionOnPasswordChange(user.AccountState)
+	user.UpdatedAt = now
+	if _, err := c.storage.UpdateUser(ctx, user); err != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+
+	// Record the new hash in history and prune to the configured depth.
+	// Best-effort: the password change itself has already succeeded.
+	if c.passwordPolicy.HistoryCount > 0 {
+		_ = c.storage.AddPasswordHistory(ctx, user.ID, string(hash), now)
+		_ = c.storage.PrunePasswordHistory(ctx, user.ID, c.passwordPolicy.HistoryCount)
+	}
 	return nil
 }
 

--- a/internal/core/auth.go
+++ b/internal/core/auth.go
@@ -40,25 +40,36 @@ func (c *KeyorixCore) Login(ctx context.Context, req *LoginRequest) (*models.Ses
 	if AccountLoginBlocked(user.AccountState) {
 		return nil, nil, fmt.Errorf("account suspended")
 	}
+	created, err := c.mintSession(ctx, user.ID, req.UserAgent, req.IPAddress)
+	if err != nil {
+		return nil, nil, err
+	}
+	return created, user, nil
+}
+
+// mintSession creates and persists a new 24h session token for a user. Shared by
+// Login and the setup-token consume flow (auto-login) so session issuance — token
+// generation, expiry, and the captured device fields — stays uniform.
+func (c *KeyorixCore) mintSession(ctx context.Context, userID uint, userAgent, ip string) (*models.Session, error) {
 	token, err := generateSecureToken()
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to generate session token: %w", err)
+		return nil, fmt.Errorf("failed to generate session token: %w", err)
 	}
-	expiresAt := c.now().Add(24 * time.Hour)
 	now := c.now()
+	expiresAt := now.Add(24 * time.Hour)
 	session := &models.Session{
-		UserID:       user.ID,
+		UserID:       userID,
 		SessionToken: token,
-		UserAgent:    req.UserAgent,
-		IPAddress:    req.IPAddress,
+		UserAgent:    userAgent,
+		IPAddress:    ip,
 		LastSeenAt:   &now,
 		ExpiresAt:    &expiresAt,
 	}
 	created, err := c.storage.CreateSession(ctx, session)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create session: %w", err)
+		return nil, fmt.Errorf("failed to create session: %w", err)
 	}
-	return created, user, nil
+	return created, nil
 }
 
 // RecordLogin stamps the user's last_login_at to the current time. Best-effort:

--- a/internal/core/setup_consume.go
+++ b/internal/core/setup_consume.go
@@ -12,11 +12,20 @@ package core
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
+
+// ErrInvalidSetupPassword wraps a password-policy rejection during setup-token
+// consume. It is the ONLY consume failure whose reason is safe (and useful) to
+// surface to the unauthenticated caller — the link stays live so they can retry.
+// Every other failure (dead token, missing/duplicate account, internal error) is
+// reported generically by the HTTP layer so the public endpoint is not an
+// account-existence / error-string oracle.
+var ErrInvalidSetupPassword = errors.New("invalid password")
 
 // SetupTokenInfo is the non-sensitive description of a setup token returned to the
 // landing page. It deliberately carries no token, no hash, and no secret material.
@@ -86,7 +95,7 @@ func (c *KeyorixCore) CompleteSetup(ctx context.Context, raw, newPassword, userA
 	// Validate the password BEFORE consuming the token, so a policy rejection lets
 	// the user retry with the same link instead of dead-ending on a spent token.
 	if err := c.validateNewPassword(ctx, user, newPassword); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: %v", ErrInvalidSetupPassword, err)
 	}
 
 	// Consume is single-use and atomic; from here the token is spent (fail-closed).

--- a/internal/core/setup_consume.go
+++ b/internal/core/setup_consume.go
@@ -1,0 +1,109 @@
+// setup_consume.go — public consumption of credential-delivery setup tokens (ADR-028).
+//
+// These power the unauthenticated landing page a new principal reaches via their
+// setup link: a GET that describes the token (no secrets) so the page can render the
+// right form, and the consume that sets the password and lands the user logged in.
+//
+// Only the password-setting purposes (account_setup, password_reset_link) are
+// completed here — both act on an existing account. The invitation_accept purpose,
+// which must also materialize project membership, is completed by the invitation
+// producer (ADR-024) and is rejected here.
+package core
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// SetupTokenInfo is the non-sensitive description of a setup token returned to the
+// landing page. It deliberately carries no token, no hash, and no secret material.
+type SetupTokenInfo struct {
+	Purpose     string `json:"purpose"`
+	Email       string `json:"email"`
+	DisplayName string `json:"display_name,omitempty"`
+}
+
+// SetupConsumeResult is returned after a setup token is consumed: the freshly minted
+// session (auto-login) plus the user it belongs to, so the HTTP layer can build a
+// login-shaped response.
+type SetupConsumeResult struct {
+	Session *models.Session
+	User    *models.User
+}
+
+// DescribeSetupToken validates a raw setup token (without consuming it) and returns
+// a non-sensitive description for the landing page, or an error if the token is
+// unknown, expired, or otherwise not active. It is the GET /auth/setup/{token} path.
+func (c *KeyorixCore) DescribeSetupToken(ctx context.Context, raw string) (*SetupTokenInfo, error) {
+	tok, err := c.inspectActiveSetupToken(ctx, raw)
+	if err != nil {
+		return nil, err
+	}
+	info := &SetupTokenInfo{Purpose: tok.Purpose, Email: tok.SubjectEmail}
+	// Resolve a friendly name when the account already exists (best-effort; never
+	// leaks more than the display name the user set).
+	if tok.SubjectUserID != nil {
+		if u, uerr := c.storage.GetUser(ctx, *tok.SubjectUserID); uerr == nil {
+			info.DisplayName = u.DisplayName
+		}
+	}
+	return info, nil
+}
+
+// CompleteSetup consumes a setup token and materializes its effect. For the
+// account_setup and password_reset_link purposes it: validates the new password
+// BEFORE spending the token (a weak password must not burn the link), atomically
+// consumes the token, sets the password (clearing the account back to active), and
+// mints a login session so the user lands authenticated. The invitation_accept
+// purpose is completed by the invitation producer, not here.
+func (c *KeyorixCore) CompleteSetup(ctx context.Context, raw, newPassword, userAgent, ip string) (*SetupConsumeResult, error) {
+	tok, err := c.inspectActiveSetupToken(ctx, raw)
+	if err != nil {
+		return nil, err
+	}
+	switch tok.Purpose {
+	case SetupPurposeAccountSetup, SetupPurposePasswordResetLink:
+		// handled below
+	default:
+		return nil, fmt.Errorf("%s: setup token purpose %q is not completed at this endpoint", i18n.T("ErrorValidation", nil), tok.Purpose)
+	}
+	if tok.SubjectUserID == nil {
+		return nil, fmt.Errorf("%s: setup token has no subject account", i18n.T("ErrorValidation", nil))
+	}
+
+	user, err := c.storage.GetUser(ctx, *tok.SubjectUserID)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorUserNotFound", nil), err)
+	}
+	// A suspended account cannot be activated via a setup link.
+	if AccountLoginBlocked(user.AccountState) {
+		return nil, fmt.Errorf("account suspended")
+	}
+
+	// Validate the password BEFORE consuming the token, so a policy rejection lets
+	// the user retry with the same link instead of dead-ending on a spent token.
+	if err := c.validateNewPassword(ctx, user, newPassword); err != nil {
+		return nil, err
+	}
+
+	// Consume is single-use and atomic; from here the token is spent (fail-closed).
+	if _, err := c.ConsumeSetupToken(ctx, raw, tok.Purpose); err != nil {
+		return nil, err
+	}
+	if err := c.applyNewPassword(ctx, user, newPassword); err != nil {
+		return nil, err
+	}
+
+	session, err := c.mintSession(ctx, user.ID, userAgent, ip)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+
+	c.writeAuditEventFull(ctx, "account.setup_completed", &user.ID, nil, nil, ip,
+		fmt.Sprintf("account setup completed via %s", tok.Purpose))
+
+	return &SetupConsumeResult{Session: session, User: user}, nil
+}

--- a/internal/core/setup_consume_test.go
+++ b/internal/core/setup_consume_test.go
@@ -1,0 +1,151 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/bcrypt"
+)
+
+// strongPw passes DefaultPasswordPolicy (>=16 chars, upper/lower/digit/special).
+const strongPw = "Str0ng!Passw0rd-2026"
+
+func TestDescribeSetupToken(t *testing.T) {
+	ctx := context.Background()
+	raw := setupPrefix + "describe1"
+	hash := hashSetupToken(raw)
+
+	t.Run("returns purpose, email, and display name for an active token", func(t *testing.T) {
+		ms := new(MockStorage)
+		c := NewKeyorixCore(ms)
+		uid := uint(3)
+		ms.On("GetSetupTokenByHash", ctx, hash).Return(&models.SetupToken{
+			ID: 1, State: SetupTokenActive, Purpose: SetupPurposeAccountSetup,
+			SubjectEmail: "new@acme.io", SubjectUserID: &uid, ExpiresAt: c.now().Add(time.Hour),
+		}, nil)
+		ms.On("GetUser", ctx, uid).Return(&models.User{ID: uid, DisplayName: "Dana"}, nil)
+
+		info, err := c.DescribeSetupToken(ctx, raw)
+		require.NoError(t, err)
+		assert.Equal(t, SetupPurposeAccountSetup, info.Purpose)
+		assert.Equal(t, "new@acme.io", info.Email)
+		assert.Equal(t, "Dana", info.DisplayName)
+	})
+
+	t.Run("does not consume the token", func(t *testing.T) {
+		ms := new(MockStorage)
+		c := NewKeyorixCore(ms)
+		ms.On("GetSetupTokenByHash", ctx, hash).Return(&models.SetupToken{
+			ID: 1, State: SetupTokenActive, Purpose: SetupPurposePasswordResetLink,
+			SubjectEmail: "x@y.io", ExpiresAt: c.now().Add(time.Hour),
+		}, nil)
+		_, err := c.DescribeSetupToken(ctx, raw)
+		require.NoError(t, err)
+		ms.AssertNotCalled(t, "MarkSetupTokenConsumed", mock.Anything, mock.Anything, mock.Anything)
+	})
+
+	t.Run("rejects a dead token", func(t *testing.T) {
+		ms := new(MockStorage)
+		c := NewKeyorixCore(ms)
+		ms.On("GetSetupTokenByHash", ctx, hash).Return(&models.SetupToken{
+			ID: 1, State: SetupTokenConsumed, Purpose: SetupPurposeAccountSetup, ExpiresAt: c.now().Add(time.Hour),
+		}, nil)
+		_, err := c.DescribeSetupToken(ctx, raw)
+		require.Error(t, err)
+	})
+}
+
+func TestCompleteSetup(t *testing.T) {
+	ctx := context.Background()
+	raw := setupPrefix + "consume1"
+	hash := hashSetupToken(raw)
+	uid := uint(4)
+
+	activeAccountSetup := func(c *KeyorixCore) *models.SetupToken {
+		return &models.SetupToken{
+			ID: 2, State: SetupTokenActive, Purpose: SetupPurposeAccountSetup,
+			SubjectEmail: "new@acme.io", SubjectUserID: &uid, ExpiresAt: c.now().Add(time.Hour),
+		}
+	}
+
+	t.Run("sets the password, activates the account, and mints a session (auto-login)", func(t *testing.T) {
+		ms := new(MockStorage)
+		c := NewKeyorixCore(ms)
+		anyAudit(ms)
+		user := &models.User{ID: uid, Username: "dana", AccountState: AccountPendingFirstLogin}
+		ms.On("GetSetupTokenByHash", ctx, hash).Return(activeAccountSetup(c), nil)
+		ms.On("GetUser", ctx, uid).Return(user, nil)
+		ms.On("RecentPasswordHashes", ctx, uid, 5).Return([]string{}, nil)
+		ms.On("MarkSetupTokenConsumed", ctx, uint(2), mock.AnythingOfType("time.Time")).Return(true, nil)
+		ms.On("UpdateUser", ctx, mock.AnythingOfType("*models.User")).Return(user, nil)
+		ms.On("AddPasswordHistory", ctx, uid, mock.AnythingOfType("string"), mock.Anything).Return(nil)
+		ms.On("PrunePasswordHistory", ctx, uid, 5).Return(nil)
+		ms.On("CreateSession", ctx, mock.AnythingOfType("*models.Session")).
+			Return(&models.Session{ID: 1, UserID: uid, SessionToken: "sess-abc"}, nil)
+
+		res, err := c.CompleteSetup(ctx, raw, strongPw, "ua", "1.2.3.4")
+		require.NoError(t, err)
+		assert.Equal(t, "sess-abc", res.Session.SessionToken)
+		assert.Equal(t, AccountActive, user.AccountState, "restricted account cleared to active")
+		assert.NoError(t, bcrypt.CompareHashAndPassword([]byte(user.PasswordHash), []byte(strongPw)))
+		ms.AssertCalled(t, "MarkSetupTokenConsumed", ctx, uint(2), mock.AnythingOfType("time.Time"))
+		ms.AssertCalled(t, "CreateSession", ctx, mock.AnythingOfType("*models.Session"))
+	})
+
+	t.Run("a weak password is rejected WITHOUT consuming the token", func(t *testing.T) {
+		ms := new(MockStorage)
+		c := NewKeyorixCore(ms)
+		user := &models.User{ID: uid, Username: "dana", AccountState: AccountPendingFirstLogin}
+		ms.On("GetSetupTokenByHash", ctx, hash).Return(activeAccountSetup(c), nil)
+		ms.On("GetUser", ctx, uid).Return(user, nil)
+		ms.On("RecentPasswordHashes", ctx, uid, 5).Return([]string{}, nil)
+
+		_, err := c.CompleteSetup(ctx, raw, "short", "ua", "1.2.3.4")
+		require.Error(t, err)
+		// The link must remain usable: the token was never consumed, no session minted.
+		ms.AssertNotCalled(t, "MarkSetupTokenConsumed", mock.Anything, mock.Anything, mock.Anything)
+		ms.AssertNotCalled(t, "CreateSession", mock.Anything, mock.Anything)
+		ms.AssertNotCalled(t, "UpdateUser", mock.Anything, mock.Anything)
+	})
+
+	t.Run("rejects an invitation_accept token (handled by the invitation producer)", func(t *testing.T) {
+		ms := new(MockStorage)
+		c := NewKeyorixCore(ms)
+		ms.On("GetSetupTokenByHash", ctx, hash).Return(&models.SetupToken{
+			ID: 2, State: SetupTokenActive, Purpose: SetupPurposeInvitationAccept,
+			SubjectEmail: "new@acme.io", ExpiresAt: c.now().Add(time.Hour),
+		}, nil)
+		_, err := c.CompleteSetup(ctx, raw, strongPw, "ua", "1.2.3.4")
+		require.Error(t, err)
+		ms.AssertNotCalled(t, "MarkSetupTokenConsumed", mock.Anything, mock.Anything, mock.Anything)
+	})
+
+	t.Run("rejects a suspended account", func(t *testing.T) {
+		ms := new(MockStorage)
+		c := NewKeyorixCore(ms)
+		ms.On("GetSetupTokenByHash", ctx, hash).Return(activeAccountSetup(c), nil)
+		ms.On("GetUser", ctx, uid).Return(&models.User{ID: uid, AccountState: AccountSuspended}, nil)
+		_, err := c.CompleteSetup(ctx, raw, strongPw, "ua", "1.2.3.4")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "suspended")
+		ms.AssertNotCalled(t, "MarkSetupTokenConsumed", mock.Anything, mock.Anything, mock.Anything)
+	})
+
+	t.Run("rejects an expired token", func(t *testing.T) {
+		ms := new(MockStorage)
+		c := NewKeyorixCore(ms)
+		anyAudit(ms)
+		ms.On("GetSetupTokenByHash", ctx, hash).Return(&models.SetupToken{
+			ID: 2, State: SetupTokenActive, Purpose: SetupPurposeAccountSetup,
+			SubjectEmail: "new@acme.io", SubjectUserID: &uid, ExpiresAt: c.now().Add(-time.Hour),
+		}, nil)
+		ms.On("MarkSetupTokenExpired", ctx, uint(2)).Return(nil)
+		_, err := c.CompleteSetup(ctx, raw, strongPw, "ua", "1.2.3.4")
+		require.Error(t, err)
+	})
+}

--- a/internal/core/setup_token.go
+++ b/internal/core/setup_token.go
@@ -147,6 +147,22 @@ func (c *KeyorixCore) IssueSetupToken(ctx context.Context, req IssueSetupTokenRe
 // It rejects unknown, non-active, wrong-purpose, and expired tokens, lazily flipping
 // an overdue active token to expired as a side effect.
 func (c *KeyorixCore) ValidateSetupToken(ctx context.Context, raw, expectedPurpose string) (*models.SetupToken, error) {
+	tok, err := c.inspectActiveSetupToken(ctx, raw)
+	if err != nil {
+		return nil, err
+	}
+	// Purpose-scoping: the token may only drive the flow it was minted for.
+	if tok.Purpose != expectedPurpose {
+		return nil, fmt.Errorf("%s: setup token purpose mismatch", i18n.T("ErrorValidation", nil))
+	}
+	return tok, nil
+}
+
+// inspectActiveSetupToken resolves a raw token, lazily expires it if overdue, and
+// returns it only if active. It does NOT check purpose — callers that know the
+// expected purpose use ValidateSetupToken; the GET-describe path (which must report
+// the purpose to the landing page) uses this directly.
+func (c *KeyorixCore) inspectActiveSetupToken(ctx context.Context, raw string) (*models.SetupToken, error) {
 	tok, err := c.storage.GetSetupTokenByHash(ctx, hashSetupToken(raw))
 	if err != nil {
 		return nil, fmt.Errorf("%s: invalid setup token", i18n.T("ErrorNotFound", nil))
@@ -161,10 +177,6 @@ func (c *KeyorixCore) ValidateSetupToken(ctx context.Context, raw, expectedPurpo
 	}
 	if tok.State != SetupTokenActive {
 		return nil, fmt.Errorf("%s: setup token is %s", i18n.T("ErrorNotFound", nil), tok.State)
-	}
-	// Purpose-scoping: the token may only drive the flow it was minted for.
-	if tok.Purpose != expectedPurpose {
-		return nil, fmt.Errorf("%s: setup token purpose mismatch", i18n.T("ErrorValidation", nil))
 	}
 	return tok, nil
 }

--- a/server/http/handlers/auth.go
+++ b/server/http/handlers/auth.go
@@ -131,6 +131,20 @@ func (h *AuthHandler) Login(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	resp := h.buildLoginResponse(r.Context(), session, user)
+
+	// Audit log + last-login stamp (both non-blocking)
+	ip, ua := r.RemoteAddr, r.Header.Get("User-Agent")
+	go h.coreService.LogAuthLogin(context.Background(), user.ID, user.Username, ip, ua) // #nosec G118
+	go func() { _ = h.coreService.RecordLogin(context.Background(), user.ID) }()        // #nosec G118
+
+	sendSuccess(w, resp, "Login successful")
+}
+
+// buildLoginResponse assembles the session-token + identity payload returned on a
+// successful login. Shared with the setup-token consume flow so that "landing the
+// user logged in" yields exactly the same shape a normal login does.
+func (h *AuthHandler) buildLoginResponse(ctx context.Context, session *models.Session, user *models.User) loginResponseBody {
 	resp := loginResponseBody{
 		Token:       session.SessionToken,
 		UserID:      user.ID,
@@ -145,19 +159,81 @@ func (h *AuthHandler) Login(w http.ResponseWriter, r *http.Request) {
 	}
 	// Surface roles + permissions so the UI can gate nav/routes. Best-effort:
 	// a failure here must not block an otherwise-successful login.
-	if id, ierr := h.coreService.GetUserIdentity(r.Context(), user.ID); ierr == nil {
+	if id, ierr := h.coreService.GetUserIdentity(ctx, user.ID); ierr == nil {
 		resp.Role, resp.Roles, resp.Permissions = id.Role, id.Roles, id.Permissions
 	}
-	// Flag an expired password so the UI can require a change (ADR-025).
+	// Flag an expired/required password change so the UI can route (ADR-025).
 	resp.AccountState = core.NormalizeAccountState(user.AccountState)
 	resp.PasswordChangeRequired = h.coreService.PasswordExpired(user) || core.AccountRestricted(user.AccountState)
+	return resp
+}
 
-	// Audit log + last-login stamp (both non-blocking)
-	ip, ua := r.RemoteAddr, r.Header.Get("User-Agent")
-	go h.coreService.LogAuthLogin(context.Background(), user.ID, user.Username, ip, ua) // #nosec G118
-	go func() { _ = h.coreService.RecordLogin(context.Background(), user.ID) }()        // #nosec G118
+// ── Setup-token endpoints (ADR-028) ─────────────────────────────────────────────
 
-	sendSuccess(w, resp, "Login successful")
+type setupTokenInfoResponse struct {
+	Purpose     string `json:"purpose"`
+	Email       string `json:"email"`
+	DisplayName string `json:"display_name,omitempty"`
+}
+
+type consumeSetupRequestBody struct {
+	Token    string `json:"token"`
+	Password string `json:"password"`
+}
+
+// GetSetupToken handles GET /auth/setup/{token}: it validates the single-use setup
+// token (without consuming it) and returns a non-sensitive description so the
+// landing page can render the right form. A dead token (unknown/expired/used)
+// returns 410 Gone.
+func (h *AuthHandler) GetSetupToken(w http.ResponseWriter, r *http.Request) {
+	token := chi.URLParam(r, "token")
+	if token == "" {
+		sendError(w, "BadRequest", "Missing setup token", http.StatusBadRequest, nil)
+		return
+	}
+	info, err := h.coreService.DescribeSetupToken(r.Context(), token)
+	if err != nil {
+		sendError(w, "Gone", "This setup link is no longer valid", http.StatusGone, nil)
+		return
+	}
+	sendSuccess(w, setupTokenInfoResponse{
+		Purpose:     info.Purpose,
+		Email:       info.Email,
+		DisplayName: info.DisplayName,
+	}, "")
+}
+
+// ConsumeSetup handles POST /auth/setup/consume: it consumes the single-use setup
+// token, sets the user's password, and lands them logged in with a fresh session —
+// the same response shape as a normal login.
+func (h *AuthHandler) ConsumeSetup(w http.ResponseWriter, r *http.Request) {
+	var body consumeSetupRequestBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		sendError(w, "BadRequest", "Invalid request body", http.StatusBadRequest, nil)
+		return
+	}
+	if body.Token == "" || body.Password == "" {
+		sendError(w, "BadRequest", "Token and password are required", http.StatusBadRequest, nil)
+		return
+	}
+
+	ip := r.RemoteAddr
+	if idx := strings.LastIndex(ip, ":"); idx != -1 {
+		ip = ip[:idx]
+	}
+	result, err := h.coreService.CompleteSetup(r.Context(), body.Token, body.Password, r.Header.Get("User-Agent"), ip)
+	if err != nil {
+		// A password-policy failure must surface its reason (the link is still live);
+		// a dead/wrong token is reported generically.
+		sendError(w, "BadRequest", err.Error(), http.StatusBadRequest, nil)
+		return
+	}
+
+	resp := h.buildLoginResponse(r.Context(), result.Session, result.User)
+	go h.coreService.LogAuthLogin(context.Background(), result.User.ID, result.User.Username, ip, r.Header.Get("User-Agent")) // #nosec G118
+	go func() { _ = h.coreService.RecordLogin(context.Background(), result.User.ID) }()                                       // #nosec G118
+
+	sendSuccess(w, resp, "Account setup complete")
 }
 
 // Logout handles POST /auth/logout.

--- a/server/http/handlers/auth.go
+++ b/server/http/handlers/auth.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"strconv"
 	"strings"
@@ -223,9 +224,16 @@ func (h *AuthHandler) ConsumeSetup(w http.ResponseWriter, r *http.Request) {
 	}
 	result, err := h.coreService.CompleteSetup(r.Context(), body.Token, body.Password, r.Header.Get("User-Agent"), ip)
 	if err != nil {
-		// A password-policy failure must surface its reason (the link is still live);
-		// a dead/wrong token is reported generically.
-		sendError(w, "BadRequest", err.Error(), http.StatusBadRequest, nil)
+		// Only a password-policy failure surfaces its reason (the link is still live,
+		// so the user can fix the password and retry). Every other failure — dead/used
+		// token, missing or already-existing account, internal error — is reported
+		// generically so this unauthenticated endpoint is not an account-existence or
+		// internal-error oracle.
+		if errors.Is(err, core.ErrInvalidSetupPassword) {
+			sendError(w, "BadRequest", err.Error(), http.StatusBadRequest, nil)
+			return
+		}
+		sendError(w, "BadRequest", "This setup link could not be completed. It may be invalid or expired — ask your administrator for a new one.", http.StatusBadRequest, nil)
 		return
 	}
 

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -72,6 +72,11 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 	r.Post("/auth/password-reset", authHandler.PasswordReset)
 	r.Post("/system/init", authHandler.InitSystem)
 
+	// Credential-delivery setup links (ADR-028) — unauthenticated: the bearer is the
+	// single-use setup token in the URL / request body, not a session.
+	r.Get("/auth/setup/{token}", authHandler.GetSetupToken)
+	r.Post("/auth/setup/consume", authHandler.ConsumeSetup)
+
 	// Health check endpoint
 	r.Get("/health", handlers.HealthCheck)
 


### PR DESCRIPTION
## Summary

Third implementation PR for **ADR-028** (#19). Adds the unauthenticated landing-page contract a new principal reaches via their setup link — the consumption half of the subsystem.

> **Stacked on #21** (`feat/adr-028-smtp-delivery`), which is stacked on #20. Merge in order #20 → #21 → this. Base is `feat/adr-028-smtp-delivery`, so the diff shown here is endpoints-only.

## What's in this PR

- **`GET /auth/setup/{token}`** — validates a setup token **without consuming it** and returns a non-sensitive description (purpose, email, display name) so the page can render the right form. A dead token (unknown/expired/used) returns **410 Gone**.
- **`POST /auth/setup/consume`** — validates the new password against the ADR-025 policy **before** spending the single-use token (a weak password must not burn the link), then atomically consumes it, sets the password (clearing a restricted account to `active`), and mints a login session. **Auto-login**: identical response shape to a normal login, minted through the same session path so account-state/future-2FA checks still apply. Only `account_setup` / `password_reset_link` are completed here; `invitation_accept` (which also materializes membership) is the invitation producer's job (next PR) and is rejected.
- **Behaviour-preserving refactors** so consume reuses, not reinvents, existing logic:
  - `account.go` → `validateNewPassword` / `applyNewPassword` (split from `ChangePassword`)
  - `auth.go` → `mintSession` (shared with `Login`)
  - `setup_token.go` → `inspectActiveSetupToken` (shared with `ValidateSetupToken`)
  - handler → `buildLoginResponse` (shared with `Login`)
- **Audit** — `account.setup_completed` on a successful consume.

## Design note (auto-login)

The consume returns a session because the user has demonstrated equivalent assurance to a login — single-use token possession **plus** setting a password. The session is minted via the same `mintSession` path as normal login, not a side door, so it's not a weaker entry point. Validate-before-consume means a policy rejection leaves the link live for a retry.

## Testing

`go build/vet/test ./...` green. New core tests: describe (no-consume, dead-token), consume (auto-login + state clear, **weak-password-does-not-consume**, invitation rejected, suspended rejected, expired). Auth is tested at the core level per the repo's existing convention.

## Next (final PR in the stack)

Producers: wire ADR-025 admin user-creation and ADR-024 invitation-resend to issue+deliver tokens, the `resend-setup-link` CLI, `credential.displayed_out_of_band` audit + the invitation_accept consume branch, and resend rate-limiting. Then the keyorix-web setup/landing page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)