### PR TITLE
feat(credential-delivery): account-setup producer + resend (ADR-028)

### DIFF
--- a/internal/cli/common/common.go
+++ b/internal/cli/common/common.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/keyorixhq/keyorix/internal/config"
 	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/delivery"
 	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/storage"
 )
@@ -42,6 +43,29 @@ func InitializeCoreService() (*core.KeyorixCore, error) {
 		return nil, fmt.Errorf("failed to create storage: %w", err)
 	}
 
-	// Create and return core service
-	return core.NewKeyorixCore(storageImpl), nil
+	// Create core service and wire credential delivery (ADR-028) so a CLI admin can
+	// provision / resend setup links. Best-effort: a delivery misconfig (e.g.
+	// mode=smtp with no host) must not break unrelated CLI commands, so on a New
+	// error we leave delivery unset — core then falls back to out-of-band (returns
+	// the link), which is exactly what a CLI admin wants anyway.
+	svc := core.NewKeyorixCore(storageImpl)
+	svc.SetSetupTokenTTL(cfg.CredentialDelivery.GetSetupTokenTTL())
+	cd := cfg.CredentialDelivery
+	if deliverer, derr := delivery.New(delivery.Config{
+		Mode:    cd.Mode,
+		BaseURL: cd.BaseURL,
+		SMTP: delivery.SMTPSettings{
+			Host:     cd.SMTP.Host,
+			Port:     cd.SMTP.Port,
+			Username: cd.SMTP.Username,
+			Password: cd.SMTP.GetPassword(),
+			From:     cd.SMTP.From,
+			TLS:      cd.SMTP.TLS,
+		},
+	}); derr == nil {
+		svc.SetCredentialDelivery(deliverer, cd.BaseURL)
+	} else {
+		svc.SetCredentialDelivery(nil, cd.BaseURL)
+	}
+	return svc, nil
 }

--- a/internal/cli/user/create.go
+++ b/internal/cli/user/create.go
@@ -15,19 +15,27 @@ var (
 	createEmail       string
 	createPassword    string
 	createDisplayName string
+	createSetupLink   bool
+	createBy          string
 )
 
 var createCmd = &cobra.Command{
 	Use:   "create",
 	Short: "Create a new user",
-	RunE:  runCreate,
+	Long: "Create a new user. Supply --password to set an initial password, or use\n" +
+		"--setup-link to provision an ADR-028 setup link instead: the account is created\n" +
+		"in pending_first_login state and the user sets their own password via the link.\n" +
+		"In out-of-band mode the link is printed for you to relay.",
+	RunE: runCreate,
 }
 
 func init() {
 	createCmd.Flags().StringVar(&createUsername, "username", "", "Username (required)")
 	createCmd.Flags().StringVar(&createEmail, "email", "", "Email (required)")
-	createCmd.Flags().StringVar(&createPassword, "password", "", "Password (required)")
+	createCmd.Flags().StringVar(&createPassword, "password", "", "Initial password (required unless --setup-link)")
 	createCmd.Flags().StringVar(&createDisplayName, "display-name", "", "Display name (defaults to username)")
+	createCmd.Flags().BoolVar(&createSetupLink, "setup-link", false, "Provision a setup link instead of an admin-set password (ADR-028)")
+	createCmd.Flags().StringVar(&createBy, "by", "", "Acting admin email (for audit; used with --setup-link)")
 }
 
 func runCreate(cmd *cobra.Command, args []string) error {
@@ -37,8 +45,8 @@ func runCreate(cmd *cobra.Command, args []string) error {
 	if createEmail == "" {
 		return errors.New("email is required (use --email)")
 	}
-	if createPassword == "" {
-		return errors.New("password is required (use --password)")
+	if !createSetupLink && createPassword == "" {
+		return errors.New("password is required (use --password), or use --setup-link")
 	}
 
 	service, err := common.InitializeCoreService()
@@ -52,16 +60,33 @@ func runCreate(cmd *cobra.Command, args []string) error {
 	}
 
 	ctx := context.Background()
-	u, err := service.CreateUser(ctx, &core.CreateUserRequest{
+	req := &core.CreateUserRequest{
 		Username:    createUsername,
 		Email:       createEmail,
 		DisplayName: display,
 		Password:    createPassword,
-	})
+	}
+
+	if createSetupLink {
+		var createdBy uint
+		if createBy != "" {
+			if createdBy, err = resolveAdminID(ctx, service, createBy); err != nil {
+				return err
+			}
+		}
+		u, prov, err := service.CreateUserWithSetupLink(ctx, req, createdBy)
+		if err != nil {
+			return fmt.Errorf("failed to create user with setup link: %w", err)
+		}
+		fmt.Printf("User created: id=%d username=%s email=%s\n", u.ID, u.Username, u.Email)
+		printProvisionResult(prov)
+		return nil
+	}
+
+	u, err := service.CreateUser(ctx, req)
 	if err != nil {
 		return fmt.Errorf("failed to create user: %w", err)
 	}
-
 	fmt.Printf("User created: id=%d username=%s email=%s\n", u.ID, u.Username, u.Email)
 	return nil
 }

--- a/internal/cli/user/setup_link.go
+++ b/internal/cli/user/setup_link.go
@@ -1,0 +1,74 @@
+// setup_link.go — credential-delivery setup-link commands for the user CLI (ADR-028).
+//
+// resend-setup-link reissues a user's account_setup link (superseding the prior one)
+// and re-delivers it. Like the lifecycle commands, the local CLI has no session, so
+// --by supplies the audited acting admin. printProvisionResult is shared with the
+// `user create --setup-link` path.
+package user
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/spf13/cobra"
+)
+
+var (
+	resendSetupLinkUserID uint
+	resendSetupLinkBy     string
+)
+
+var resendSetupLinkCmd = &cobra.Command{
+	Use:   "resend-setup-link",
+	Short: "Reissue and redeliver a user's setup link (ADR-028)",
+	Long: "Reissue an account's setup link, invalidating any prior link, and deliver it\n" +
+		"again. In out-of-band mode the link is printed for you to relay. Throttled per\n" +
+		"the ADR-028 resend limits.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if resendSetupLinkUserID == 0 {
+			return errors.New("user id is required (use --id)")
+		}
+		if resendSetupLinkBy == "" {
+			return errors.New("acting admin email is required (use --by)")
+		}
+		service, err := common.InitializeCoreService()
+		if err != nil {
+			return fmt.Errorf("failed to initialize service: %w", err)
+		}
+		ctx := context.Background()
+		adminID, err := resolveAdminID(ctx, service, resendSetupLinkBy)
+		if err != nil {
+			return err
+		}
+		prov, err := service.ResendAccountSetupLink(ctx, resendSetupLinkUserID, adminID)
+		if err != nil {
+			return fmt.Errorf("failed to resend setup link: %w", err)
+		}
+		fmt.Printf("Setup link reissued for user %d.\n", resendSetupLinkUserID)
+		printProvisionResult(prov)
+		return nil
+	},
+}
+
+func init() {
+	resendSetupLinkCmd.Flags().UintVar(&resendSetupLinkUserID, "id", 0, "Target user ID (required)")
+	resendSetupLinkCmd.Flags().StringVar(&resendSetupLinkBy, "by", "", "Acting admin email (required, for audit)")
+	_ = resendSetupLinkCmd.MarkFlagRequired("id")
+	_ = resendSetupLinkCmd.MarkFlagRequired("by")
+}
+
+// printProvisionResult prints how a setup link was delivered. In out-of-band mode it
+// prints the link itself for the admin to relay; in SMTP mode it confirms the send.
+func printProvisionResult(prov *core.ProvisionSetupResult) {
+	if prov == nil {
+		return
+	}
+	if prov.Delivered {
+		fmt.Printf("Setup link delivered to %s via %s.\n", prov.Email, prov.Channel)
+		return
+	}
+	fmt.Printf("Setup link (relay this to %s securely — it is single-use and expires):\n  %s\n", prov.Email, prov.LinkForAdmin)
+}

--- a/internal/cli/user/user.go
+++ b/internal/cli/user/user.go
@@ -24,6 +24,7 @@ func init() {
 	UserCmd.AddCommand(suspendCmd)
 	UserCmd.AddCommand(reactivateCmd)
 	UserCmd.AddCommand(forcePasswordResetCmd)
+	UserCmd.AddCommand(resendSetupLinkCmd)
 }
 
 // resolveAdminID resolves an admin email to a user ID for audit attribution.

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/delivery"
 	"github.com/keyorixhq/keyorix/internal/encryption"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
@@ -33,6 +34,12 @@ type KeyorixCore struct {
 	// setupTokenTTL is the lifetime of a credential-delivery setup token (ADR-028);
 	// 0 = DefaultSetupTokenTTL. Set from config via SetSetupTokenTTL.
 	setupTokenTTL time.Duration
+	// credentialDelivery transports setup links (ADR-028). nil = out-of-band: the
+	// link is returned to the caller. Set from config via SetCredentialDelivery.
+	credentialDelivery delivery.CredentialDelivery
+	// setupBaseURL is the absolute base (e.g. https://keyorix.acme.internal) used to
+	// build setup links. Required to mint a link; a relative link is a misconfig.
+	setupBaseURL string
 }
 
 // AuditForwarder ships persisted audit events to an external sink (e.g. a SIEM).

--- a/internal/core/setup_delivery.go
+++ b/internal/core/setup_delivery.go
@@ -104,24 +104,20 @@ func (c *KeyorixCore) CreateUserWithSetupLink(ctx context.Context, req *CreateUs
 		return nil, nil, fmt.Errorf("%s: credential_delivery.base_url is required to issue a setup link", i18n.T("ErrorValidation", nil))
 	}
 
-	// Create the account with a random, unusable password; the real one is set when
-	// the user consumes the setup link.
+	// Create the account with a random, unusable password and confined directly to
+	// pending_first_login in the SAME write — no second UpdateUser that, on failure,
+	// could strand an active account with a password nobody knows. The real password
+	// is set when the user consumes the setup link.
 	reqCopy := *req
 	unusable, err := randomUnusablePassword()
 	if err != nil {
 		return nil, nil, err
 	}
 	reqCopy.Password = unusable
+	reqCopy.AccountState = AccountPendingFirstLogin
 	user, err := c.CreateUser(ctx, &reqCopy)
 	if err != nil {
 		return nil, nil, err
-	}
-
-	// Confine the account until the link is consumed (CreateUser leaves it active).
-	user.AccountState = AccountPendingFirstLogin
-	user.UpdatedAt = c.now()
-	if _, err := c.storage.UpdateUser(ctx, user); err != nil {
-		return nil, nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}
 
 	res, err := c.provisionSetupLink(ctx, IssueSetupTokenRequest{
@@ -168,10 +164,22 @@ func (c *KeyorixCore) ResendAccountSetupLink(ctx context.Context, userID, create
 func (c *KeyorixCore) checkResendThrottle(ctx context.Context, purpose, email string) error {
 	key := strings.TrimSpace(strings.ToLower(email))
 
-	if n, err := c.storage.CountSetupTokensSince(ctx, purpose, key, c.now().Add(-24*time.Hour)); err == nil && n >= resendDailyCap {
+	// Fail CLOSED on a count error: an abuse control that silently no-ops whenever
+	// the store hiccups isn't a control. A transient error briefly delays a
+	// legitimate resend (acceptable); it must never open the door to unthrottled
+	// setup-link mail to a victim address.
+	n, err := c.storage.CountSetupTokensSince(ctx, purpose, key, c.now().Add(-24*time.Hour))
+	if err != nil {
+		return fmt.Errorf("%s: could not verify resend limits, please try again", i18n.T("ErrorValidation", nil))
+	}
+	if n >= resendDailyCap {
 		return fmt.Errorf("%s: resend limit reached (max %d per day)", i18n.T("ErrorValidation", nil), resendDailyCap)
 	}
-	if m, err := c.storage.CountSetupTokensSince(ctx, purpose, key, c.now().Add(-resendMinInterval)); err == nil && m >= 1 {
+	m, err := c.storage.CountSetupTokensSince(ctx, purpose, key, c.now().Add(-resendMinInterval))
+	if err != nil {
+		return fmt.Errorf("%s: could not verify resend limits, please try again", i18n.T("ErrorValidation", nil))
+	}
+	if m >= 1 {
 		return fmt.Errorf("%s: please wait before requesting another setup link", i18n.T("ErrorValidation", nil))
 	}
 	return nil

--- a/internal/core/setup_delivery.go
+++ b/internal/core/setup_delivery.go
@@ -1,0 +1,189 @@
+// setup_delivery.go — credential-delivery producers (ADR-028).
+//
+// These turn the setup-token primitive + delivery channel into the admin-facing
+// flows: provisioning a brand-new account's first-credential link, and resending it.
+// A producer issues a token, builds the absolute setup link, delivers it via the
+// configured channel, and audits the delivery. In out-of-band mode the link is
+// returned to the admin to relay; that display is itself audited
+// (credential.displayed_out_of_band) because a human briefly sees a credential.
+package core
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/delivery"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// Resend throttling (ADR-028 abuse section): a minimum interval between issues for
+// the same subject, and a daily cap, both per (purpose, email).
+const (
+	resendMinInterval = 60 * time.Second
+	resendDailyCap    = 10
+)
+
+// SetCredentialDelivery wires the credential-delivery channel and the base URL used
+// to build absolute setup links (ADR-028). The server/CLI calls this at startup from
+// the credential_delivery config. A nil deliverer means out-of-band: the link is
+// returned to the caller rather than sent.
+func (c *KeyorixCore) SetCredentialDelivery(d delivery.CredentialDelivery, baseURL string) {
+	c.credentialDelivery = d
+	c.setupBaseURL = strings.TrimRight(strings.TrimSpace(baseURL), "/")
+}
+
+// ProvisionSetupResult reports how a setup link was provisioned and delivered.
+type ProvisionSetupResult struct {
+	Email        string `json:"email"`
+	Channel      string `json:"channel"`                  // smtp | out_of_band | log
+	Delivered    bool   `json:"delivered"`                // true if actually sent
+	LinkForAdmin string `json:"link_for_admin,omitempty"` // set in out-of-band mode
+}
+
+// provisionSetupLink issues a setup token for the request's subject and delivers it
+// via the configured channel, returning the outcome. Requires a configured base URL
+// (a relative link is a misconfiguration, not a fallback).
+func (c *KeyorixCore) provisionSetupLink(ctx context.Context, req IssueSetupTokenRequest, displayName, assignmentSummary string) (*ProvisionSetupResult, error) {
+	if c.setupBaseURL == "" {
+		return nil, fmt.Errorf("%s: credential_delivery.base_url is required to issue a setup link", i18n.T("ErrorValidation", nil))
+	}
+	issued, err := c.IssueSetupToken(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	link := c.setupBaseURL + "/auth/setup/" + issued.PlainToken
+
+	var result delivery.DeliveryResult
+	if c.credentialDelivery != nil {
+		result, err = c.credentialDelivery.DeliverSetupLink(ctx, delivery.SetupLinkRequest{
+			RecipientEmail:    req.SubjectEmail,
+			DisplayName:       displayName,
+			Link:              link,
+			Purpose:           req.Purpose,
+			AssignmentSummary: assignmentSummary,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+		}
+	} else {
+		// No channel configured → out-of-band: hand the link back to the caller.
+		result = delivery.DeliveryResult{Channel: delivery.ChannelOutOfBand, Delivered: false, LinkForAdmin: link}
+	}
+
+	// Audit the delivery (no token on the row).
+	actor := actorOrSubject(req.CreatedBy, req.SubjectUserID)
+	c.writeAuditEventFull(ctx, "setup_link.delivered", actor, nil, nil, "",
+		fmt.Sprintf("setup link delivered (purpose=%s, subject=%s, channel=%s, delivered=%t)",
+			req.Purpose, req.SubjectEmail, result.Channel, result.Delivered))
+	// When the link is shown to the admin out of band, record that a human saw a
+	// credential — the one path the ADR singles out for compliance.
+	if result.LinkForAdmin != "" {
+		c.writeAuditEventFull(ctx, "credential.displayed_out_of_band", actor, nil, nil, "",
+			fmt.Sprintf("setup link shown out-of-band to admin (subject=%s, artifact=link)", req.SubjectEmail))
+	}
+
+	return &ProvisionSetupResult{
+		Email:        req.SubjectEmail,
+		Channel:      result.Channel,
+		Delivered:    result.Delivered,
+		LinkForAdmin: result.LinkForAdmin,
+	}, nil
+}
+
+// CreateUserWithSetupLink creates a user in pending_first_login state with NO usable
+// password and provisions an account_setup link, so the user sets their own password
+// via the link instead of the admin choosing one (ADR-025 / ADR-028). Returns the
+// created user and the delivery outcome (the link to relay in out-of-band mode).
+func (c *KeyorixCore) CreateUserWithSetupLink(ctx context.Context, req *CreateUserRequest, createdBy uint) (*models.User, *ProvisionSetupResult, error) {
+	if c.setupBaseURL == "" {
+		return nil, nil, fmt.Errorf("%s: credential_delivery.base_url is required to issue a setup link", i18n.T("ErrorValidation", nil))
+	}
+
+	// Create the account with a random, unusable password; the real one is set when
+	// the user consumes the setup link.
+	reqCopy := *req
+	unusable, err := randomUnusablePassword()
+	if err != nil {
+		return nil, nil, err
+	}
+	reqCopy.Password = unusable
+	user, err := c.CreateUser(ctx, &reqCopy)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Confine the account until the link is consumed (CreateUser leaves it active).
+	user.AccountState = AccountPendingFirstLogin
+	user.UpdatedAt = c.now()
+	if _, err := c.storage.UpdateUser(ctx, user); err != nil {
+		return nil, nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+
+	res, err := c.provisionSetupLink(ctx, IssueSetupTokenRequest{
+		Purpose:       SetupPurposeAccountSetup,
+		SubjectEmail:  user.Email,
+		SubjectUserID: &user.ID,
+		CreatedBy:     createdBy,
+	}, user.DisplayName, "")
+	if err != nil {
+		// The account exists but the link could not be provisioned; surface the user
+		// so the caller can resend rather than orphaning a half-created account.
+		return user, nil, err
+	}
+	return user, res, nil
+}
+
+// ResendAccountSetupLink reissues an account_setup link for an existing user,
+// superseding the prior active token, and re-delivers it. Throttled per ADR-028.
+func (c *KeyorixCore) ResendAccountSetupLink(ctx context.Context, userID, createdBy uint) (*ProvisionSetupResult, error) {
+	if userID == 0 {
+		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "user ID is required")
+	}
+	user, err := c.storage.GetUser(ctx, userID)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorUserNotFound", nil), err)
+	}
+	if AccountLoginBlocked(user.AccountState) {
+		return nil, fmt.Errorf("account suspended")
+	}
+	if err := c.checkResendThrottle(ctx, SetupPurposeAccountSetup, user.Email); err != nil {
+		return nil, err
+	}
+	return c.provisionSetupLink(ctx, IssueSetupTokenRequest{
+		Purpose:       SetupPurposeAccountSetup,
+		SubjectEmail:  user.Email,
+		SubjectUserID: &user.ID,
+		CreatedBy:     createdBy,
+	}, user.DisplayName, "")
+}
+
+// checkResendThrottle enforces the per-subject resend limits: a minimum interval
+// between issues and a daily cap (ADR-028 abuse section). Counting failures fail
+// open — a throttle-store error must not block a legitimate resend.
+func (c *KeyorixCore) checkResendThrottle(ctx context.Context, purpose, email string) error {
+	key := strings.TrimSpace(strings.ToLower(email))
+
+	if n, err := c.storage.CountSetupTokensSince(ctx, purpose, key, c.now().Add(-24*time.Hour)); err == nil && n >= resendDailyCap {
+		return fmt.Errorf("%s: resend limit reached (max %d per day)", i18n.T("ErrorValidation", nil), resendDailyCap)
+	}
+	if m, err := c.storage.CountSetupTokensSince(ctx, purpose, key, c.now().Add(-resendMinInterval)); err == nil && m >= 1 {
+		return fmt.Errorf("%s: please wait before requesting another setup link", i18n.T("ErrorValidation", nil))
+	}
+	return nil
+}
+
+// randomUnusablePassword returns a high-entropy random string used as the initial
+// password of a setup-link account. It is never disclosed, so no one can log in
+// until the user sets a real password via the link.
+func randomUnusablePassword() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}

--- a/internal/core/setup_delivery_test.go
+++ b/internal/core/setup_delivery_test.go
@@ -148,14 +148,17 @@ func TestCreateUserWithSetupLink(t *testing.T) {
 	anyAudit(ms)
 
 	notFound := func() error { return assertNotFoundErr() }
-	created := &models.User{ID: 9, Username: "dana", Email: "dana@acme.io", DisplayName: "Dana"}
+	created := &models.User{ID: 9, Username: "dana", Email: "dana@acme.io", DisplayName: "Dana", AccountState: AccountPendingFirstLogin}
 
 	ms.On("GetUserByUsername", ctx, "dana").Return(nil, notFound())
 	ms.On("GetUserByEmail", ctx, "dana@acme.io").Return(nil, notFound())
-	ms.On("CreateUser", ctx, mock.AnythingOfType("*models.User")).Return(created, nil)
+	// The account is confined to pending_first_login in the SAME create — no separate
+	// UpdateUser that could strand an active, unknown-password account on failure.
+	ms.On("CreateUser", ctx, mock.MatchedBy(func(u *models.User) bool {
+		return u.AccountState == AccountPendingFirstLogin
+	})).Return(created, nil)
 	ms.On("AddPasswordHistory", ctx, uint(9), mock.AnythingOfType("string"), mock.Anything).Return(nil)
 	ms.On("GetRoleByName", ctx, "system_viewer").Return(nil, notFound())
-	ms.On("UpdateUser", ctx, mock.AnythingOfType("*models.User")).Return(created, nil)
 	ms.On("SupersedeActiveSetupTokens", ctx, SetupPurposeAccountSetup, "dana@acme.io").Return(nil)
 	ms.On("CreateSetupToken", ctx, mock.AnythingOfType("*models.SetupToken")).Return(&models.SetupToken{ID: 1}, nil)
 
@@ -164,6 +167,7 @@ func TestCreateUserWithSetupLink(t *testing.T) {
 	}, 7)
 	require.NoError(t, err)
 	assert.Equal(t, AccountPendingFirstLogin, user.AccountState, "account is confined until the link is consumed")
+	ms.AssertNotCalled(t, "UpdateUser", mock.Anything, mock.Anything)
 	require.NotNil(t, prov)
 	assert.True(t, strings.HasPrefix(prov.LinkForAdmin, testBaseURL+"/auth/setup/"+setupPrefix))
 }

--- a/internal/core/setup_delivery_test.go
+++ b/internal/core/setup_delivery_test.go
@@ -1,0 +1,181 @@
+package core
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/delivery"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeDeliverer is a controllable CredentialDelivery for tests. When echoLink is set
+// it copies the request link into LinkForAdmin (out-of-band behaviour); otherwise it
+// returns the configured result verbatim.
+type fakeDeliverer struct {
+	called   bool
+	lastReq  delivery.SetupLinkRequest
+	result   delivery.DeliveryResult
+	echoLink bool
+	err      error
+}
+
+func (f *fakeDeliverer) DeliverSetupLink(_ context.Context, req delivery.SetupLinkRequest) (delivery.DeliveryResult, error) {
+	f.called = true
+	f.lastReq = req
+	res := f.result
+	if f.echoLink {
+		res.LinkForAdmin = req.Link
+	}
+	return res, f.err
+}
+
+func (f *fakeDeliverer) Name() string { return "fake" }
+
+const testBaseURL = "https://keyorix.test"
+
+func TestResendAccountSetupLink(t *testing.T) {
+	ctx := context.Background()
+	uid := uint(4)
+	fixed := time.Date(2026, 6, 5, 12, 0, 0, 0, time.UTC)
+
+	newCore := func(d delivery.CredentialDelivery) (*KeyorixCore, *MockStorage) {
+		ms := new(MockStorage)
+		c := NewKeyorixCore(ms)
+		c.now = func() time.Time { return fixed }
+		c.SetCredentialDelivery(d, testBaseURL)
+		anyAudit(ms)
+		return c, ms
+	}
+	user := func() *models.User {
+		return &models.User{ID: uid, Email: "new@acme.io", DisplayName: "Dana", AccountState: AccountPendingFirstLogin}
+	}
+
+	t.Run("out-of-band returns the built link and audits the display", func(t *testing.T) {
+		fake := &fakeDeliverer{echoLink: true, result: delivery.DeliveryResult{Channel: delivery.ChannelOutOfBand}}
+		c, ms := newCore(fake)
+		ms.On("GetUser", ctx, uid).Return(user(), nil)
+		ms.On("CountSetupTokensSince", ctx, SetupPurposeAccountSetup, "new@acme.io", fixed.Add(-24*time.Hour)).Return(int64(0), nil)
+		ms.On("CountSetupTokensSince", ctx, SetupPurposeAccountSetup, "new@acme.io", fixed.Add(-resendMinInterval)).Return(int64(0), nil)
+		ms.On("SupersedeActiveSetupTokens", ctx, SetupPurposeAccountSetup, "new@acme.io").Return(nil)
+		ms.On("CreateSetupToken", ctx, mock.AnythingOfType("*models.SetupToken")).Return(&models.SetupToken{ID: 1}, nil)
+
+		res, err := c.ResendAccountSetupLink(ctx, uid, 7)
+		require.NoError(t, err)
+		assert.True(t, fake.called)
+		assert.Equal(t, delivery.ChannelOutOfBand, res.Channel)
+		assert.False(t, res.Delivered)
+		assert.True(t, strings.HasPrefix(res.LinkForAdmin, testBaseURL+"/auth/setup/"+setupPrefix),
+			"link is base_url + /auth/setup/ + a kx_setup_ token, got %q", res.LinkForAdmin)
+		// The out-of-band display is recorded as a human seeing a credential.
+		ms.AssertCalled(t, "LogAuditEvent", mock.Anything, mock.MatchedBy(func(e *models.AuditEvent) bool {
+			return e.EventType == "credential.displayed_out_of_band"
+		}))
+	})
+
+	t.Run("smtp delivery reports delivered with no admin link", func(t *testing.T) {
+		fake := &fakeDeliverer{result: delivery.DeliveryResult{Channel: delivery.ChannelSMTP, Delivered: true}}
+		c, ms := newCore(fake)
+		ms.On("GetUser", ctx, uid).Return(user(), nil)
+		ms.On("CountSetupTokensSince", ctx, SetupPurposeAccountSetup, "new@acme.io", mock.AnythingOfType("time.Time")).Return(int64(0), nil)
+		ms.On("SupersedeActiveSetupTokens", ctx, SetupPurposeAccountSetup, "new@acme.io").Return(nil)
+		ms.On("CreateSetupToken", ctx, mock.AnythingOfType("*models.SetupToken")).Return(&models.SetupToken{ID: 1}, nil)
+
+		res, err := c.ResendAccountSetupLink(ctx, uid, 7)
+		require.NoError(t, err)
+		assert.True(t, res.Delivered)
+		assert.Empty(t, res.LinkForAdmin)
+		// The recipient sees the right link in the email.
+		assert.True(t, strings.HasPrefix(fake.lastReq.Link, testBaseURL+"/auth/setup/"))
+	})
+
+	t.Run("min-interval throttle blocks a too-soon resend", func(t *testing.T) {
+		c, ms := newCore(&fakeDeliverer{})
+		ms.On("GetUser", ctx, uid).Return(user(), nil)
+		ms.On("CountSetupTokensSince", ctx, SetupPurposeAccountSetup, "new@acme.io", fixed.Add(-24*time.Hour)).Return(int64(1), nil)
+		ms.On("CountSetupTokensSince", ctx, SetupPurposeAccountSetup, "new@acme.io", fixed.Add(-resendMinInterval)).Return(int64(1), nil)
+
+		_, err := c.ResendAccountSetupLink(ctx, uid, 7)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "wait")
+		ms.AssertNotCalled(t, "CreateSetupToken", mock.Anything, mock.Anything)
+	})
+
+	t.Run("daily-cap throttle blocks once the cap is hit", func(t *testing.T) {
+		c, ms := newCore(&fakeDeliverer{})
+		ms.On("GetUser", ctx, uid).Return(user(), nil)
+		ms.On("CountSetupTokensSince", ctx, SetupPurposeAccountSetup, "new@acme.io", fixed.Add(-24*time.Hour)).Return(int64(resendDailyCap), nil)
+
+		_, err := c.ResendAccountSetupLink(ctx, uid, 7)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "limit")
+		ms.AssertNotCalled(t, "CreateSetupToken", mock.Anything, mock.Anything)
+	})
+
+	t.Run("rejects a suspended account", func(t *testing.T) {
+		c, ms := newCore(&fakeDeliverer{})
+		ms.On("GetUser", ctx, uid).Return(&models.User{ID: uid, AccountState: AccountSuspended}, nil)
+		_, err := c.ResendAccountSetupLink(ctx, uid, 7)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "suspended")
+	})
+}
+
+func TestProvisionRequiresBaseURL(t *testing.T) {
+	ctx := context.Background()
+	ms := new(MockStorage)
+	c := NewKeyorixCore(ms)
+	c.SetCredentialDelivery(&fakeDeliverer{}, "") // no base URL
+
+	req := CreateUserRequest{Username: "dana", Email: "dana@acme.io", DisplayName: "Dana"}
+	_, _, err := c.CreateUserWithSetupLink(ctx, &req, 0)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "base_url")
+	ms.AssertNotCalled(t, "CreateUser", mock.Anything, mock.Anything)
+}
+
+func TestCreateUserWithSetupLink(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	ctx := context.Background()
+	ms := new(MockStorage)
+	c := NewKeyorixCore(ms)
+	c.SetCredentialDelivery(&fakeDeliverer{echoLink: true, result: delivery.DeliveryResult{Channel: delivery.ChannelOutOfBand}}, testBaseURL)
+	anyAudit(ms)
+
+	notFound := func() error { return assertNotFoundErr() }
+	created := &models.User{ID: 9, Username: "dana", Email: "dana@acme.io", DisplayName: "Dana"}
+
+	ms.On("GetUserByUsername", ctx, "dana").Return(nil, notFound())
+	ms.On("GetUserByEmail", ctx, "dana@acme.io").Return(nil, notFound())
+	ms.On("CreateUser", ctx, mock.AnythingOfType("*models.User")).Return(created, nil)
+	ms.On("AddPasswordHistory", ctx, uint(9), mock.AnythingOfType("string"), mock.Anything).Return(nil)
+	ms.On("GetRoleByName", ctx, "system_viewer").Return(nil, notFound())
+	ms.On("UpdateUser", ctx, mock.AnythingOfType("*models.User")).Return(created, nil)
+	ms.On("SupersedeActiveSetupTokens", ctx, SetupPurposeAccountSetup, "dana@acme.io").Return(nil)
+	ms.On("CreateSetupToken", ctx, mock.AnythingOfType("*models.SetupToken")).Return(&models.SetupToken{ID: 1}, nil)
+
+	user, prov, err := c.CreateUserWithSetupLink(ctx, &CreateUserRequest{
+		Username: "dana", Email: "dana@acme.io", DisplayName: "Dana",
+	}, 7)
+	require.NoError(t, err)
+	assert.Equal(t, AccountPendingFirstLogin, user.AccountState, "account is confined until the link is consumed")
+	require.NotNil(t, prov)
+	assert.True(t, strings.HasPrefix(prov.LinkForAdmin, testBaseURL+"/auth/setup/"+setupPrefix))
+}
+
+// helpers ---------------------------------------------------------------------
+
+// assertNotFoundErr returns an error whose message contains the not-found marker
+// CreateUser checks for, so the "does this user already exist?" probes read as absent.
+func assertNotFoundErr() error {
+	return &notFoundError{msg: i18n.T("ErrorUserNotFound", nil)}
+}
+
+type notFoundError struct{ msg string }
+
+func (e *notFoundError) Error() string { return e.msg }

--- a/internal/core/users.go
+++ b/internal/core/users.go
@@ -56,7 +56,8 @@ func (c *KeyorixCore) CreateUser(ctx context.Context, req *CreateUserRequest) (*
 		DisplayName:       displayName,
 		PasswordHash:      string(hash),
 		IsActive:          active,
-		PasswordChangedAt: &now, // baseline for max-age expiry (ADR-025)
+		AccountState:      NormalizeAccountState(req.AccountState), // empty → active (ADR-025)
+		PasswordChangedAt: &now,                                    // baseline for max-age expiry (ADR-025)
 		CreatedAt:         now,
 		UpdatedAt:         now,
 	}

--- a/internal/core/users_types.go
+++ b/internal/core/users_types.go
@@ -8,6 +8,10 @@ type CreateUserRequest struct {
 	DisplayName string `json:"display_name" validate:"required,min=1,max=100"`
 	Password    string `json:"password" validate:"required,min=8"`
 	IsActive    *bool  `json:"is_active,omitempty"`
+	// AccountState optionally sets the initial lifecycle state (ADR-025). Empty
+	// normalizes to "active". Setup-link provisioning sets pending_first_login so the
+	// account is confined from creation — no separate write that could leave it active.
+	AccountState string `json:"-"`
 }
 
 // UpdateUserRequest represents a request to update an existing user.

--- a/server/http/handlers/users_crud.go
+++ b/server/http/handlers/users_crud.go
@@ -30,8 +30,14 @@ func (h *UserHandler) CreateUser(w http.ResponseWriter, r *http.Request) {
 		Username    string `json:"username" validate:"required,min=3,max=50"`
 		Email       string `json:"email" validate:"required,email"`
 		DisplayName string `json:"display_name" validate:"required,min=1,max=100"`
-		Password    string `json:"password" validate:"required,min=8"`
-		IsActive    *bool  `json:"is_active,omitempty"`
+		// Password is optional when DeliverSetupLink is set — the user sets their own
+		// password via the setup link (ADR-028) instead of the admin choosing one.
+		Password string `json:"password" validate:"omitempty,min=8"`
+		IsActive *bool  `json:"is_active,omitempty"`
+		// DeliverSetupLink provisions an account_setup link instead of an admin-set
+		// password: the account is created in pending_first_login state and a setup
+		// link is delivered (or returned for out-of-band relay).
+		DeliverSetupLink bool `json:"deliver_setup_link,omitempty"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		sendError(w, "InvalidJSON", "Invalid JSON in request body", http.StatusBadRequest, nil)
@@ -48,6 +54,36 @@ func (h *UserHandler) CreateUser(w http.ResponseWriter, r *http.Request) {
 		DisplayName: body.DisplayName,
 		Password:    body.Password,
 		IsActive:    body.IsActive,
+	}
+
+	// Setup-link provisioning path (ADR-028): no admin password; deliver a link.
+	if body.DeliverSetupLink {
+		created, prov, err := h.coreService.CreateUserWithSetupLink(r.Context(), req, userCtx.UserID)
+		if err != nil {
+			log.Printf("Error creating user with setup link: %v", err)
+			if strings.Contains(err.Error(), "already exists") {
+				sendError(w, "ConflictError", "User already exists", http.StatusConflict, nil)
+				return
+			}
+			if strings.Contains(err.Error(), "base_url") {
+				sendError(w, "ConfigError", err.Error(), http.StatusBadRequest, nil)
+				return
+			}
+			sendError(w, "InternalError", "Failed to create user", http.StatusInternalServerError, nil)
+			return
+		}
+		w.WriteHeader(http.StatusCreated)
+		sendSuccess(w, map[string]interface{}{
+			"user":       userToAPIResponse(created),
+			"setup_link": prov,
+		}, i18n.T("SuccessUserCreated", nil))
+		return
+	}
+
+	// Classic path: the admin supplies the initial password.
+	if body.Password == "" {
+		sendError(w, "ValidationError", "Password is required unless deliver_setup_link is set", http.StatusBadRequest, nil)
+		return
 	}
 	created, err := h.coreService.CreateUser(r.Context(), req)
 	if err != nil {
@@ -242,4 +278,36 @@ func (h *UserHandler) ReactivateUser(w http.ResponseWriter, r *http.Request) {
 // RequirePasswordReset handles POST /api/v1/users/{id}/require-password-reset.
 func (h *UserHandler) RequirePasswordReset(w http.ResponseWriter, r *http.Request) {
 	h.accountStateAction(w, r, "Password reset required", h.coreService.RequirePasswordReset)
+}
+
+// ResendSetupLink handles POST /api/v1/users/{id}/resend-setup-link (ADR-028). It
+// reissues the user's account_setup link (superseding any prior one) and re-delivers
+// it, returning the delivery outcome — including the link itself in out-of-band mode.
+func (h *UserHandler) ResendSetupLink(w http.ResponseWriter, r *http.Request) {
+	admin := middleware.GetUserFromContext(r.Context())
+	if admin == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		sendError(w, "InvalidParameter", "Invalid user ID", http.StatusBadRequest, nil)
+		return
+	}
+	res, err := h.coreService.ResendAccountSetupLink(r.Context(), uint(id), admin.UserID)
+	if err != nil {
+		msg := err.Error()
+		status := http.StatusInternalServerError
+		switch {
+		case strings.Contains(msg, "not found"):
+			status = http.StatusNotFound
+		case strings.Contains(msg, "limit") || strings.Contains(msg, "wait"):
+			status = http.StatusTooManyRequests
+		case strings.Contains(msg, "base_url") || strings.Contains(msg, "suspended"):
+			status = http.StatusBadRequest
+		}
+		sendError(w, "Error", msg, status, nil)
+		return
+	}
+	sendSuccess(w, res, "Setup link resent")
 }

--- a/server/http/handlers/users_handler.go
+++ b/server/http/handlers/users_handler.go
@@ -293,3 +293,12 @@ func RequirePasswordReset(w http.ResponseWriter, r *http.Request) {
 	}
 	defaultUserHandler.RequirePasswordReset(w, r)
 }
+
+// ResendSetupLink handles POST /api/v1/users/{id}/resend-setup-link (ADR-028).
+func ResendSetupLink(w http.ResponseWriter, r *http.Request) {
+	if defaultUserHandler == nil {
+		sendError(w, "ServiceUnavailable", "User handler not initialised", http.StatusServiceUnavailable, nil)
+		return
+	}
+	defaultUserHandler.ResendSetupLink(w, r)
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -250,6 +250,8 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.With(customMiddleware.RequirePermission("users.write")).Post("/{id}/suspend", handlers.SuspendUser)
 			r.With(customMiddleware.RequirePermission("users.write")).Post("/{id}/reactivate", handlers.ReactivateUser)
 			r.With(customMiddleware.RequirePermission("users.write")).Post("/{id}/require-password-reset", handlers.RequirePasswordReset)
+			// Credential-delivery resend (ADR-028): reissue + redeliver a setup link.
+			r.With(customMiddleware.RequirePermission("users.write")).Post("/{id}/resend-setup-link", handlers.ResendSetupLink)
 			r.Get("/{id}/roles", usersRolesHandler.GetUserRolesForUser)
 			r.Put("/{id}/roles", usersRolesHandler.UpdateUserRoles)
 		})

--- a/server/main.go
+++ b/server/main.go
@@ -36,6 +36,7 @@ import (
 	"github.com/keyorixhq/keyorix/internal/audit/siem"
 	"github.com/keyorixhq/keyorix/internal/config"
 	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/delivery"
 	"github.com/keyorixhq/keyorix/internal/encryption"
 	"github.com/keyorixhq/keyorix/internal/i18n"
 	appstorage "github.com/keyorixhq/keyorix/internal/storage"
@@ -219,6 +220,27 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 	// Apply the credential-delivery setup-token TTL (ADR-028). GetSetupTokenTTL
 	// falls back to 24h when the block is absent or invalid.
 	coreService.SetSetupTokenTTL(cfg.CredentialDelivery.GetSetupTokenTTL())
+
+	// Wire the credential-delivery channel (ADR-028). New selects out-of-band/SMTP/
+	// log from the configured mode and fails loud on a bad mode (e.g. smtp with no
+	// host), so a misconfigured install does not silently drop setup links.
+	cd := cfg.CredentialDelivery
+	deliverer, derr := delivery.New(delivery.Config{
+		Mode:    cd.Mode,
+		BaseURL: cd.BaseURL,
+		SMTP: delivery.SMTPSettings{
+			Host:     cd.SMTP.Host,
+			Port:     cd.SMTP.Port,
+			Username: cd.SMTP.Username,
+			Password: cd.SMTP.GetPassword(),
+			From:     cd.SMTP.From,
+			TLS:      cd.SMTP.TLS,
+		},
+	})
+	if derr != nil {
+		return nil, nil, fmt.Errorf("failed to init credential delivery: %w", derr)
+	}
+	coreService.SetCredentialDelivery(deliverer, cd.BaseURL)
 
 	return coreService, encSvc, nil
 }


### PR DESCRIPTION
## Summary

Fourth implementation PR for **ADR-028** (#19). Wires the delivery channel into core and adds the admin-facing **account_setup vertical** — making the setup-link flow reachable end-to-end with the consume endpoint from #22.

> **Stacked on #22** (`feat/adr-028-setup-endpoints`) → #21 → #20. Merge in order. Base is `feat/adr-028-setup-endpoints`, so the diff here is producer-only.

## What's in this PR

- **Delivery wired into core** — `KeyorixCore` holds a `CredentialDelivery` channel + base URL (`SetCredentialDelivery`), constructed at startup from `credential_delivery` config in **both** the server and the CLI. A nil channel ⇒ out-of-band (the link is returned to the caller).
- **`provisionSetupLink`** — issues a token, builds the absolute setup link from `base_url`, delivers it, and audits `setup_link.delivered` plus `credential.displayed_out_of_band` when an out-of-band link is shown to an admin. Refuses to mint a link without `base_url` (a relative link is a misconfig, per the ADR).
- **`CreateUserWithSetupLink`** — creates a user in `pending_first_login` with a random *unusable* password and provisions an `account_setup` link, so the user sets their own password via the link instead of the admin choosing one.
- **`ResendAccountSetupLink`** — reissue (supersedes prior token) + redeliver, with ADR-028 resend throttling: **60s min interval + 10/day cap** per subject (via `CountSetupTokensSince`).
- **HTTP** — `POST /api/v1/users` gains a `deliver_setup_link` mode (password optional); new `POST /api/v1/users/{id}/resend-setup-link` (`users.write`). Out-of-band responses carry `link_for_admin`.
- **CLI** — `keyorix user create --setup-link [--by]` and `keyorix user resend-setup-link --id --by`, printing the link in out-of-band mode.

## Scope decisions (ADR-grounded)

- **Additive**: the existing password-based create path is unchanged; setup-link is a new opt-in mode.
- **Link-only** here (the ADR's documented default artifact); the one-time-password out-of-band artifact is a documented follow-up.
- Emits `credential.displayed_out_of_band` (artifact=link) whenever an out-of-band link is surfaced to an admin.

## Testing

`go build/vet/test ./...` green. New core tests: provision outcomes (out-of-band link + audit / SMTP delivered), resend throttle (min-interval + daily cap), suspended-account + `base_url`-required guards, and `CreateUserWithSetupLink` pending-state.

## Next / remaining

The **invitation vertical** (ADR-024): issue+deliver `invitation_accept` tokens on invite, invitation resend, the `invitation_accept` consume branch (materialize membership), and `keyorix invite resend`. Then the keyorix-web setup/landing page. The one-time-password out-of-band artifact (ADR Part E) is also still open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)