### PR TITLE
feat(credential-delivery): invitation accept vertical (ADR-024 + ADR-028)

### DIFF
--- a/internal/cli/invite/invite.go
+++ b/internal/cli/invite/invite.go
@@ -24,6 +24,7 @@ func init() {
 	InviteCmd.AddCommand(sendCmd)
 	InviteCmd.AddCommand(listCmd)
 	InviteCmd.AddCommand(revokeCmd)
+	InviteCmd.AddCommand(resendCmd)
 }
 
 // resolveUserID resolves an email address to a user ID via the core service.

--- a/internal/cli/invite/resend.go
+++ b/internal/cli/invite/resend.go
@@ -1,0 +1,69 @@
+package invite
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/spf13/cobra"
+)
+
+var (
+	resendID uint
+	resendBy string
+)
+
+var resendCmd = &cobra.Command{
+	Use:   "resend",
+	Short: "Reissue and redeliver an invitation's setup link (ADR-028)",
+	Long: "Reissue a pending invitation's accept link, invalidating any prior link, and\n" +
+		"deliver it again. In out-of-band mode the link is printed for you to relay.\n" +
+		"Throttled per the ADR-028 resend limits.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if resendID == 0 {
+			return errors.New("invitation id is required (use --id)")
+		}
+		if resendBy == "" {
+			return errors.New("acting admin email is required (use --by)")
+		}
+		service, err := common.InitializeCoreService()
+		if err != nil {
+			return fmt.Errorf("failed to initialize service: %w", err)
+		}
+		ctx := context.Background()
+		actorID, err := resolveUserID(ctx, service, resendBy)
+		if err != nil {
+			return err
+		}
+		prov, err := service.ResendInvitationLink(ctx, resendID, actorID)
+		if err != nil {
+			return fmt.Errorf("failed to resend invitation link: %w", err)
+		}
+		fmt.Printf("Invitation link reissued for invitation %d.\n", resendID)
+		printProvisionResult(prov)
+		return nil
+	},
+}
+
+func init() {
+	resendCmd.Flags().UintVar(&resendID, "id", 0, "Invitation ID (required)")
+	resendCmd.Flags().StringVar(&resendBy, "by", "", "Acting admin email (required, for audit)")
+	_ = resendCmd.MarkFlagRequired("id")
+	_ = resendCmd.MarkFlagRequired("by")
+}
+
+// printProvisionResult prints how an invitation's setup link was delivered. In
+// out-of-band mode it prints the link for the admin to relay; in SMTP mode it
+// confirms the send. Shared by `invite send` and `invite resend`.
+func printProvisionResult(prov *core.ProvisionSetupResult) {
+	if prov == nil {
+		return
+	}
+	if prov.Delivered {
+		fmt.Printf("Setup link delivered to %s via %s.\n", prov.Email, prov.Channel)
+		return
+	}
+	fmt.Printf("Setup link (relay this to %s securely — it is single-use and expires):\n  %s\n", prov.Email, prov.LinkForAdmin)
+}

--- a/internal/cli/invite/send.go
+++ b/internal/cli/invite/send.go
@@ -56,11 +56,19 @@ func runSend(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	inv, err := service.InviteToProject(ctx, projectID, sendEmail, sendRole, invitedBy)
+	inv, prov, err := service.InviteToProjectWithLink(ctx, projectID, sendEmail, sendRole, invitedBy)
 	if err != nil {
-		return fmt.Errorf("failed to send invitation: %w", err)
+		if inv == nil {
+			return fmt.Errorf("failed to send invitation: %w", err)
+		}
+		// The invitation exists but the link could not be delivered (e.g. base_url
+		// unset). Report it so the operator can fix config and `invite resend`.
+		fmt.Printf("Invitation created: id=%d email=%s role=%s project=%s expires=%s\n",
+			inv.ID, inv.Email, inv.Role, projectName, fmtTime(inv.ExpiresAt))
+		return fmt.Errorf("but the setup link could not be delivered: %w", err)
 	}
 	fmt.Printf("Invitation sent: id=%d email=%s role=%s project=%s expires=%s\n",
 		inv.ID, inv.Email, inv.Role, projectName, fmtTime(inv.ExpiresAt))
+	printProvisionResult(prov)
 	return nil
 }

--- a/internal/core/invitation_accept_test.go
+++ b/internal/core/invitation_accept_test.go
@@ -1,0 +1,168 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompleteInvitationAccept(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	ctx := context.Background()
+	raw := setupPrefix + "invite1"
+	hash := hashSetupToken(raw)
+	iid := uint(11)
+
+	pendingInvite := func(c *KeyorixCore, mode string) *models.SetupToken {
+		return &models.SetupToken{
+			ID: 3, State: SetupTokenActive, Purpose: SetupPurposeInvitationAccept,
+			SubjectEmail: "bob@acme.io", InvitationID: &iid, ExpiresAt: c.now().Add(time.Hour),
+		}
+	}
+	invite := func(state, mode string) *models.ProjectInvitation {
+		exp := time.Now().Add(24 * time.Hour)
+		return &models.ProjectInvitation{
+			ID: iid, ProjectID: 5, Email: "bob@acme.io", Role: "developer", State: state,
+			InvitedBy: 7, ValidationModeAtInvite: mode, ExpiresAt: &exp,
+		}
+	}
+
+	t.Run("open mode: lazy-creates the account, activates membership, grants role, auto-logs in", func(t *testing.T) {
+		ms := new(MockStorage)
+		c := NewKeyorixCore(ms)
+		anyAudit(ms)
+		created := &models.User{ID: 20, Username: "bob", Email: "bob@acme.io"}
+
+		ms.On("GetSetupTokenByHash", ctx, hash).Return(pendingInvite(c, ValidationModeOpen), nil)
+		ms.On("GetProjectInvitation", ctx, iid).Return(invite(InvitationPending, ValidationModeOpen), nil)
+		ms.On("GetUserByEmail", ctx, "bob@acme.io").Return(nil, assertNotFoundErr())
+		ms.On("MarkSetupTokenConsumed", ctx, uint(3), mock.AnythingOfType("time.Time")).Return(true, nil)
+		ms.On("GetUserByUsername", ctx, mock.AnythingOfType("string")).Return(nil, assertNotFoundErr())
+		ms.On("CreateUser", ctx, mock.AnythingOfType("*models.User")).Return(created, nil)
+		ms.On("AddPasswordHistory", ctx, uint(20), mock.AnythingOfType("string"), mock.Anything).Return(nil)
+		// system_viewer auto-assign (CreateUser) + the invited "developer" grant on activation.
+		ms.On("GetRoleByName", ctx, "system_viewer").Return(nil, assertNotFoundErr())
+		ms.On("GetRoleByName", ctx, "developer").Return(&models.Role{ID: 9, Name: "developer"}, nil)
+		ms.On("GetActiveProjectMembership", ctx, uint(5), uint(20)).Return(nil, assertNotFoundErr())
+		ms.On("CreateProjectMembership", ctx, mock.AnythingOfType("*models.ProjectMembership")).
+			Return(&models.ProjectMembership{ID: 1, ProjectID: 5, UserID: 20, Role: "developer", State: MembershipActive}, nil)
+		ms.On("AssignRole", ctx, uint(20), uint(9), mock.Anything).Return(nil)
+		ms.On("UpdateProjectInvitation", ctx, mock.AnythingOfType("*models.ProjectInvitation")).Return(nil)
+		ms.On("CreateSession", ctx, mock.AnythingOfType("*models.Session")).
+			Return(&models.Session{ID: 1, UserID: 20, SessionToken: "sess-bob"}, nil)
+
+		res, err := c.CompleteSetup(ctx, raw, strongPw, "ua", "1.2.3.4")
+		require.NoError(t, err)
+		assert.Equal(t, "sess-bob", res.Session.SessionToken)
+		assert.Equal(t, uint(20), res.User.ID)
+		// Role was granted (open mode → active membership → AddProjectMember → AssignRole).
+		ms.AssertCalled(t, "AssignRole", ctx, uint(20), uint(9), mock.Anything)
+		// Invitation marked accepted.
+		ms.AssertCalled(t, "UpdateProjectInvitation", ctx, mock.MatchedBy(func(i *models.ProjectInvitation) bool {
+			return i.State == InvitationAccepted
+		}))
+	})
+
+	t.Run("allowlist mode: membership starts in invited, role is NOT granted yet", func(t *testing.T) {
+		ms := new(MockStorage)
+		c := NewKeyorixCore(ms)
+		anyAudit(ms)
+		created := &models.User{ID: 21, Username: "bob", Email: "bob@acme.io"}
+
+		ms.On("GetSetupTokenByHash", ctx, hash).Return(pendingInvite(c, ValidationModeAllowlist), nil)
+		ms.On("GetProjectInvitation", ctx, iid).Return(invite(InvitationPending, ValidationModeAllowlist), nil)
+		ms.On("GetUserByEmail", ctx, "bob@acme.io").Return(nil, assertNotFoundErr())
+		ms.On("MarkSetupTokenConsumed", ctx, uint(3), mock.AnythingOfType("time.Time")).Return(true, nil)
+		ms.On("GetUserByUsername", ctx, mock.AnythingOfType("string")).Return(nil, assertNotFoundErr())
+		ms.On("CreateUser", ctx, mock.AnythingOfType("*models.User")).Return(created, nil)
+		ms.On("AddPasswordHistory", ctx, uint(21), mock.AnythingOfType("string"), mock.Anything).Return(nil)
+		ms.On("GetRoleByName", ctx, "system_viewer").Return(nil, assertNotFoundErr())
+		ms.On("GetRoleByName", ctx, "developer").Return(&models.Role{ID: 9, Name: "developer"}, nil)
+		ms.On("GetActiveProjectMembership", ctx, uint(5), uint(21)).Return(nil, assertNotFoundErr())
+		ms.On("CreateProjectMembership", ctx, mock.AnythingOfType("*models.ProjectMembership")).
+			Return(&models.ProjectMembership{ID: 2, ProjectID: 5, UserID: 21, Role: "developer", State: MembershipInvited}, nil)
+		ms.On("UpdateProjectInvitation", ctx, mock.AnythingOfType("*models.ProjectInvitation")).Return(nil)
+		ms.On("CreateSession", ctx, mock.AnythingOfType("*models.Session")).
+			Return(&models.Session{ID: 2, UserID: 21, SessionToken: "sess-bob2"}, nil)
+
+		res, err := c.CompleteSetup(ctx, raw, strongPw, "ua", "1.2.3.4")
+		require.NoError(t, err)
+		assert.Equal(t, "sess-bob2", res.Session.SessionToken)
+		// The membership landed in `invited`, so no project-role grant happened.
+		ms.AssertNotCalled(t, "AssignRole", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+		// The membership was created in the invited state (not active).
+		ms.AssertCalled(t, "CreateProjectMembership", ctx, mock.MatchedBy(func(m *models.ProjectMembership) bool {
+			return m.State == MembershipInvited
+		}))
+	})
+
+	t.Run("rejects acceptance when an account already exists for the email (no auth bypass)", func(t *testing.T) {
+		ms := new(MockStorage)
+		c := NewKeyorixCore(ms)
+		ms.On("GetSetupTokenByHash", ctx, hash).Return(pendingInvite(c, ValidationModeOpen), nil)
+		ms.On("GetProjectInvitation", ctx, iid).Return(invite(InvitationPending, ValidationModeOpen), nil)
+		ms.On("GetUserByEmail", ctx, "bob@acme.io").Return(&models.User{ID: 99}, nil)
+
+		_, err := c.CompleteSetup(ctx, raw, strongPw, "ua", "1.2.3.4")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "already exists")
+		ms.AssertNotCalled(t, "MarkSetupTokenConsumed", mock.Anything, mock.Anything, mock.Anything)
+		ms.AssertNotCalled(t, "CreateUser", mock.Anything, mock.Anything)
+	})
+
+	t.Run("rejects a non-pending invitation", func(t *testing.T) {
+		ms := new(MockStorage)
+		c := NewKeyorixCore(ms)
+		ms.On("GetSetupTokenByHash", ctx, hash).Return(pendingInvite(c, ValidationModeOpen), nil)
+		ms.On("GetProjectInvitation", ctx, iid).Return(invite(InvitationRevoked, ValidationModeOpen), nil)
+
+		_, err := c.CompleteSetup(ctx, raw, strongPw, "ua", "1.2.3.4")
+		require.Error(t, err)
+		ms.AssertNotCalled(t, "MarkSetupTokenConsumed", mock.Anything, mock.Anything, mock.Anything)
+	})
+
+	t.Run("a weak password is rejected without consuming the token", func(t *testing.T) {
+		ms := new(MockStorage)
+		c := NewKeyorixCore(ms)
+		ms.On("GetSetupTokenByHash", ctx, hash).Return(pendingInvite(c, ValidationModeOpen), nil)
+		ms.On("GetProjectInvitation", ctx, iid).Return(invite(InvitationPending, ValidationModeOpen), nil)
+		ms.On("GetUserByEmail", ctx, "bob@acme.io").Return(nil, assertNotFoundErr())
+
+		_, err := c.CompleteSetup(ctx, raw, "short", "ua", "1.2.3.4")
+		require.Error(t, err)
+		ms.AssertNotCalled(t, "MarkSetupTokenConsumed", mock.Anything, mock.Anything, mock.Anything)
+		ms.AssertNotCalled(t, "CreateUser", mock.Anything, mock.Anything)
+	})
+}
+
+func TestDeriveUsername(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	ctx := context.Background()
+
+	t.Run("sanitizes the email local part and dedupes on collision", func(t *testing.T) {
+		ms := new(MockStorage)
+		c := NewKeyorixCore(ms)
+		// "bob.smith" sanitizes to "bobsmith"; first candidate is taken, suffix wins.
+		ms.On("GetUserByUsername", ctx, "bobsmith").Return(&models.User{ID: 1}, nil)
+		ms.On("GetUserByUsername", ctx, "bobsmith1").Return(nil, assertNotFoundErr())
+
+		got, err := c.deriveUsername(ctx, "Bob.Smith@acme.io")
+		require.NoError(t, err)
+		assert.Equal(t, "bobsmith1", got)
+	})
+
+	t.Run("pads a too-short local part", func(t *testing.T) {
+		ms := new(MockStorage)
+		c := NewKeyorixCore(ms)
+		ms.On("GetUserByUsername", ctx, "abuser").Return(nil, assertNotFoundErr())
+		got, err := c.deriveUsername(ctx, "ab@acme.io")
+		require.NoError(t, err)
+		assert.Equal(t, "abuser", got)
+	})
+}

--- a/internal/core/invitation_accept_test.go
+++ b/internal/core/invitation_accept_test.go
@@ -116,6 +116,20 @@ func TestCompleteInvitationAccept(t *testing.T) {
 		ms.AssertNotCalled(t, "CreateUser", mock.Anything, mock.Anything)
 	})
 
+	t.Run("fails closed when the existing-account lookup errors (no silent bypass)", func(t *testing.T) {
+		ms := new(MockStorage)
+		c := NewKeyorixCore(ms)
+		ms.On("GetSetupTokenByHash", ctx, hash).Return(pendingInvite(c, ValidationModeOpen), nil)
+		ms.On("GetProjectInvitation", ctx, iid).Return(invite(InvitationPending, ValidationModeOpen), nil)
+		// A non-"not found" storage error must abort, not be read as "no account".
+		ms.On("GetUserByEmail", ctx, "bob@acme.io").Return(nil, assert.AnError)
+
+		_, err := c.CompleteSetup(ctx, raw, strongPw, "ua", "1.2.3.4")
+		require.Error(t, err)
+		ms.AssertNotCalled(t, "MarkSetupTokenConsumed", mock.Anything, mock.Anything, mock.Anything)
+		ms.AssertNotCalled(t, "CreateUser", mock.Anything, mock.Anything)
+	})
+
 	t.Run("rejects a non-pending invitation", func(t *testing.T) {
 		ms := new(MockStorage)
 		c := NewKeyorixCore(ms)

--- a/internal/core/invitations.go
+++ b/internal/core/invitations.go
@@ -64,9 +64,9 @@ func (c *KeyorixCore) InviteToProject(ctx context.Context, projectID uint, email
 		Role:      role,
 		State:     InvitationPending,
 		InvitedBy: invitedBy,
-		// Snapshot left empty here; once the membership validation-mode config
-		// (ADR-022) lands, capture it so consumption honours the mode at invite time.
-		ValidationModeAtInvite: "",
+		// Snapshot the install validation mode (ADR-022) so acceptance honours the
+		// mode in force at invite time, not whatever it changes to later.
+		ValidationModeAtInvite: c.validationMode(),
 		ExpiresAt:              &expires,
 		CreatedAt:              now,
 	}
@@ -77,6 +77,55 @@ func (c *KeyorixCore) InviteToProject(ctx context.Context, projectID uint, email
 	c.auditProjectScoped(ctx, "invitation.created", invitedBy, projectID,
 		fmt.Sprintf("invited %s to project %d as %s", email, projectID, role))
 	return created, nil
+}
+
+// InviteToProjectWithLink creates an invitation and provisions its accept link
+// (ADR-028): an invitation_accept setup token bound to the invitation, delivered via
+// the configured channel. Returns the invitation and the delivery outcome. If
+// provisioning fails (e.g. base_url unset), the invitation still exists and is
+// returned with a nil result and the error, so the caller can resend rather than
+// losing the invite.
+func (c *KeyorixCore) InviteToProjectWithLink(ctx context.Context, projectID uint, email, role string, invitedBy uint) (*models.ProjectInvitation, *ProvisionSetupResult, error) {
+	inv, err := c.InviteToProject(ctx, projectID, email, role, invitedBy)
+	if err != nil {
+		return nil, nil, err
+	}
+	prov, err := c.provisionSetupLink(ctx, IssueSetupTokenRequest{
+		Purpose:      SetupPurposeInvitationAccept,
+		SubjectEmail: email,
+		InvitationID: &inv.ID,
+		CreatedBy:    invitedBy,
+	}, "", fmt.Sprintf("%s on project %d", role, projectID))
+	if err != nil {
+		return inv, nil, err
+	}
+	return inv, prov, nil
+}
+
+// ResendInvitationLink reissues the accept link for a still-pending invitation
+// (superseding the prior token) and re-delivers it. Throttled per ADR-028.
+func (c *KeyorixCore) ResendInvitationLink(ctx context.Context, invitationID, actorID uint) (*ProvisionSetupResult, error) {
+	inv, err := c.storage.GetProjectInvitation(ctx, invitationID)
+	if err != nil {
+		return nil, fmt.Errorf("invitation not found")
+	}
+	// Lazy-expire an overdue invite so a resend can't revive a dead one.
+	if inv.State == InvitationPending && inv.ExpiresAt != nil && c.now().After(*inv.ExpiresAt) {
+		inv.State = InvitationExpired
+		_ = c.storage.UpdateProjectInvitation(ctx, inv)
+	}
+	if inv.State != InvitationPending {
+		return nil, fmt.Errorf("only a pending invitation can be resent (state is %s)", inv.State)
+	}
+	if err := c.checkResendThrottle(ctx, SetupPurposeInvitationAccept, inv.Email); err != nil {
+		return nil, err
+	}
+	return c.provisionSetupLink(ctx, IssueSetupTokenRequest{
+		Purpose:      SetupPurposeInvitationAccept,
+		SubjectEmail: inv.Email,
+		InvitationID: &inv.ID,
+		CreatedBy:    actorID,
+	}, "", fmt.Sprintf("%s on project %d", inv.Role, inv.ProjectID))
 }
 
 // ListProjectInvitations returns a project's invitations, marking any pending

--- a/internal/core/membership_lifecycle.go
+++ b/internal/core/membership_lifecycle.go
@@ -86,6 +86,13 @@ func (c *KeyorixCore) validationMode() string {
 // membership. When the mode lands the membership directly in `active`, the role
 // grant is applied immediately.
 func (c *KeyorixCore) InviteMember(ctx context.Context, projectID, userID uint, role string, invitedBy uint, idpResolved bool) (*models.ProjectMembership, error) {
+	return c.inviteMemberWithMode(ctx, projectID, userID, role, invitedBy, c.validationMode(), idpResolved)
+}
+
+// inviteMemberWithMode is InviteMember with an explicit validation mode, so the
+// invitation-accept flow (ADR-024/ADR-028) can honour the mode snapshotted at invite
+// time rather than the install's current mode. InviteMember passes the current mode.
+func (c *KeyorixCore) inviteMemberWithMode(ctx context.Context, projectID, userID uint, role string, invitedBy uint, mode string, idpResolved bool) (*models.ProjectMembership, error) {
 	if projectID == 0 || userID == 0 {
 		return nil, fmt.Errorf("project and user IDs are required")
 	}
@@ -101,7 +108,7 @@ func (c *KeyorixCore) InviteMember(ctx context.Context, projectID, userID uint, 
 	}
 
 	now := c.now()
-	initial := c.initialMembershipState(idpResolved)
+	initial := initialMembershipStateForMode(mode, idpResolved)
 	m := &models.ProjectMembership{
 		ProjectID: projectID,
 		UserID:    userID,
@@ -133,9 +140,10 @@ func (c *KeyorixCore) InviteMember(ctx context.Context, projectID, userID uint, 
 	return created, nil
 }
 
-// initialMembershipState resolves the starting state for a new invite.
-func (c *KeyorixCore) initialMembershipState(idpResolved bool) string {
-	switch c.validationMode() {
+// initialMembershipStateForMode resolves the starting state for a new invite under
+// an explicit validation mode. An empty/unknown mode falls back to allowlist.
+func initialMembershipStateForMode(mode string, idpResolved bool) string {
+	switch mode {
 	case ValidationModeOpen:
 		return MembershipActive
 	case ValidationModeIDP:
@@ -143,7 +151,7 @@ func (c *KeyorixCore) initialMembershipState(idpResolved bool) string {
 			return MembershipProvisioned // skip invited/identity_verified
 		}
 		return MembershipInvited
-	default: // allowlist
+	default: // allowlist (and empty/unknown)
 		return MembershipInvited
 	}
 }

--- a/internal/core/membership_lifecycle_test.go
+++ b/internal/core/membership_lifecycle_test.go
@@ -42,20 +42,12 @@ func TestCanTransition(t *testing.T) {
 	}
 }
 
-func TestInitialMembershipState(t *testing.T) {
-	c := &KeyorixCore{}
-	c.membershipValidationMode = ValidationModeOpen
-	assert.Equal(t, MembershipActive, c.initialMembershipState(false))
-
-	c.membershipValidationMode = ValidationModeAllowlist
-	assert.Equal(t, MembershipInvited, c.initialMembershipState(true))
-
-	c.membershipValidationMode = ValidationModeIDP
-	assert.Equal(t, MembershipProvisioned, c.initialMembershipState(true), "idp-resolved skips early states")
-	assert.Equal(t, MembershipInvited, c.initialMembershipState(false), "non-idp starts invited")
-
-	c.membershipValidationMode = "" // default
-	assert.Equal(t, MembershipInvited, c.initialMembershipState(false))
+func TestInitialMembershipStateForMode(t *testing.T) {
+	assert.Equal(t, MembershipActive, initialMembershipStateForMode(ValidationModeOpen, false))
+	assert.Equal(t, MembershipInvited, initialMembershipStateForMode(ValidationModeAllowlist, true))
+	assert.Equal(t, MembershipProvisioned, initialMembershipStateForMode(ValidationModeIDP, true), "idp-resolved skips early states")
+	assert.Equal(t, MembershipInvited, initialMembershipStateForMode(ValidationModeIDP, false), "non-idp starts invited")
+	assert.Equal(t, MembershipInvited, initialMembershipStateForMode("", false), "empty/unknown falls back to allowlist")
 }
 
 func TestInviteMember_AllowlistStartsInvited(t *testing.T) {

--- a/internal/core/setup_consume.go
+++ b/internal/core/setup_consume.go
@@ -146,15 +146,24 @@ func (c *KeyorixCore) completeInvitationAccept(ctx context.Context, raw string, 
 
 	// SECURITY: if an account already exists for this email, the invite link must NOT
 	// log them in — that would bypass their real password. Reject and route them to
-	// the normal add-member flow instead of auto-authenticating.
-	if existing, eerr := c.storage.GetUserByEmail(ctx, inv.Email); eerr == nil && existing != nil {
-		return nil, fmt.Errorf("%s: an account already exists for %s; ask an admin to add you to the project directly", i18n.T("ErrorValidation", nil), inv.Email)
+	// the normal add-member flow. Fail CLOSED: a lookup error that is NOT a clean
+	// "not found" must abort rather than be read as "no account" (which would let a
+	// transient store error slip the guard and mint a duplicate identity). Email
+	// matching is case-insensitive (see GetUserByEmail) so "Bob@x" cannot evade a
+	// "bob@x" invite. The message is deliberately generic (the HTTP layer keeps this
+	// endpoint from being an account-existence oracle).
+	existing, eerr := c.storage.GetUserByEmail(ctx, inv.Email)
+	if eerr == nil && existing != nil {
+		return nil, fmt.Errorf("%s: an account already exists for this email; ask an admin to add you to the project directly", i18n.T("ErrorValidation", nil))
+	}
+	if eerr != nil && !isUserNotFound(eerr) {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), eerr)
 	}
 
 	// Validate the password before consuming (a weak password must not burn the link).
 	// No account exists yet, so this is policy-only (no history to check).
 	if err := c.passwordPolicy.Validate(newPassword, nil); err != nil {
-		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorValidation", nil), err)
+		return nil, fmt.Errorf("%w: %v", ErrInvalidSetupPassword, err)
 	}
 
 	// Consume the token (single-use, atomic) before materializing.
@@ -177,18 +186,21 @@ func (c *KeyorixCore) completeInvitationAccept(ctx context.Context, raw string, 
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}
 
-	// Mark the invitation accepted.
+	// Create the membership under the invite-time validation mode. This grants the
+	// project role immediately when the mode (e.g. open) lands it active; under
+	// allowlist it starts in `invited` for an admin to advance. Done BEFORE flipping
+	// the invitation to accepted: if membership creation fails, the invitation stays
+	// pending (resendable / revocable) rather than being falsely marked accepted with
+	// no membership behind it.
+	if _, err := c.inviteMemberWithMode(ctx, inv.ProjectID, user.ID, inv.Role, inv.InvitedBy, inv.ValidationModeAtInvite, false); err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+
+	// Mark the invitation accepted (only now that account + membership both exist).
 	now := c.now()
 	inv.State = InvitationAccepted
 	inv.AcceptedAt = &now
 	_ = c.storage.UpdateProjectInvitation(ctx, inv)
-
-	// Create the membership under the invite-time validation mode. This grants the
-	// project role immediately when the mode (e.g. open) lands it active; under
-	// allowlist it starts in `invited` for an admin to advance.
-	if _, err := c.inviteMemberWithMode(ctx, inv.ProjectID, user.ID, inv.Role, inv.InvitedBy, inv.ValidationModeAtInvite, false); err != nil {
-		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
-	}
 
 	c.auditProjectScoped(ctx, "invitation.accepted", user.ID, inv.ProjectID,
 		fmt.Sprintf("invitation %d accepted by %s (user %d)", inv.ID, inv.Email, user.ID))
@@ -243,4 +255,11 @@ func displayNameFromEmail(email string) string {
 		return lp
 	}
 	return email
+}
+
+// isUserNotFound reports whether err is the storage layer's "user not found"
+// sentinel (mirrors the check in CreateUser). Used to fail closed on a real lookup
+// error while treating a clean miss as "no existing account".
+func isUserNotFound(err error) bool {
+	return err != nil && strings.Contains(err.Error(), i18n.T("ErrorUserNotFound", nil))
 }

--- a/internal/core/setup_consume.go
+++ b/internal/core/setup_consume.go
@@ -4,16 +4,16 @@
 // setup link: a GET that describes the token (no secrets) so the page can render the
 // right form, and the consume that sets the password and lands the user logged in.
 //
-// Only the password-setting purposes (account_setup, password_reset_link) are
-// completed here — both act on an existing account. The invitation_accept purpose,
-// which must also materialize project membership, is completed by the invitation
-// producer (ADR-024) and is rejected here.
+// The password-setting purposes (account_setup, password_reset_link) act on an
+// existing account; invitation_accept lazily creates the invited account and
+// materializes its project membership (ADR-024). Each is dispatched by purpose.
 package core
 
 import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
@@ -75,14 +75,20 @@ func (c *KeyorixCore) CompleteSetup(ctx context.Context, raw, newPassword, userA
 	}
 	switch tok.Purpose {
 	case SetupPurposeAccountSetup, SetupPurposePasswordResetLink:
-		// handled below
+		return c.completePasswordSetup(ctx, raw, tok, newPassword, userAgent, ip)
+	case SetupPurposeInvitationAccept:
+		return c.completeInvitationAccept(ctx, raw, tok, newPassword, userAgent, ip)
 	default:
 		return nil, fmt.Errorf("%s: setup token purpose %q is not completed at this endpoint", i18n.T("ErrorValidation", nil), tok.Purpose)
 	}
+}
+
+// completePasswordSetup handles account_setup / password_reset_link: set the existing
+// subject's password and auto-log them in.
+func (c *KeyorixCore) completePasswordSetup(ctx context.Context, raw string, tok *models.SetupToken, newPassword, userAgent, ip string) (*SetupConsumeResult, error) {
 	if tok.SubjectUserID == nil {
 		return nil, fmt.Errorf("%s: setup token has no subject account", i18n.T("ErrorValidation", nil))
 	}
-
 	user, err := c.storage.GetUser(ctx, *tok.SubjectUserID)
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorUserNotFound", nil), err)
@@ -115,4 +121,126 @@ func (c *KeyorixCore) CompleteSetup(ctx context.Context, raw, newPassword, userA
 		fmt.Sprintf("account setup completed via %s", tok.Purpose))
 
 	return &SetupConsumeResult{Session: session, User: user}, nil
+}
+
+// completeInvitationAccept handles invitation_accept: lazily create the invited
+// account (ADR-024/ADR-028), accept the invitation, create a project membership
+// honouring the validation mode snapshotted at invite time (which grants the role
+// when the mode lands it active), and auto-log the user in.
+func (c *KeyorixCore) completeInvitationAccept(ctx context.Context, raw string, tok *models.SetupToken, newPassword, userAgent, ip string) (*SetupConsumeResult, error) {
+	if tok.InvitationID == nil {
+		return nil, fmt.Errorf("%s: invitation token has no invitation", i18n.T("ErrorValidation", nil))
+	}
+	inv, err := c.storage.GetProjectInvitation(ctx, *tok.InvitationID)
+	if err != nil {
+		return nil, fmt.Errorf("%s: invitation not found", i18n.T("ErrorNotFound", nil))
+	}
+	// Lazy-expire an overdue invite, then require it still be pending.
+	if inv.State == InvitationPending && inv.ExpiresAt != nil && c.now().After(*inv.ExpiresAt) {
+		inv.State = InvitationExpired
+		_ = c.storage.UpdateProjectInvitation(ctx, inv)
+	}
+	if inv.State != InvitationPending {
+		return nil, fmt.Errorf("%s: invitation is %s", i18n.T("ErrorValidation", nil), inv.State)
+	}
+
+	// SECURITY: if an account already exists for this email, the invite link must NOT
+	// log them in — that would bypass their real password. Reject and route them to
+	// the normal add-member flow instead of auto-authenticating.
+	if existing, eerr := c.storage.GetUserByEmail(ctx, inv.Email); eerr == nil && existing != nil {
+		return nil, fmt.Errorf("%s: an account already exists for %s; ask an admin to add you to the project directly", i18n.T("ErrorValidation", nil), inv.Email)
+	}
+
+	// Validate the password before consuming (a weak password must not burn the link).
+	// No account exists yet, so this is policy-only (no history to check).
+	if err := c.passwordPolicy.Validate(newPassword, nil); err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorValidation", nil), err)
+	}
+
+	// Consume the token (single-use, atomic) before materializing.
+	if _, err := c.ConsumeSetupToken(ctx, raw, SetupPurposeInvitationAccept); err != nil {
+		return nil, err
+	}
+
+	// Lazily create the account with the chosen password (active — they just set it).
+	username, err := c.deriveUsername(ctx, inv.Email)
+	if err != nil {
+		return nil, err
+	}
+	user, err := c.CreateUser(ctx, &CreateUserRequest{
+		Username:    username,
+		Email:       inv.Email,
+		DisplayName: displayNameFromEmail(inv.Email),
+		Password:    newPassword,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+
+	// Mark the invitation accepted.
+	now := c.now()
+	inv.State = InvitationAccepted
+	inv.AcceptedAt = &now
+	_ = c.storage.UpdateProjectInvitation(ctx, inv)
+
+	// Create the membership under the invite-time validation mode. This grants the
+	// project role immediately when the mode (e.g. open) lands it active; under
+	// allowlist it starts in `invited` for an admin to advance.
+	if _, err := c.inviteMemberWithMode(ctx, inv.ProjectID, user.ID, inv.Role, inv.InvitedBy, inv.ValidationModeAtInvite, false); err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+
+	c.auditProjectScoped(ctx, "invitation.accepted", user.ID, inv.ProjectID,
+		fmt.Sprintf("invitation %d accepted by %s (user %d)", inv.ID, inv.Email, user.ID))
+
+	session, err := c.mintSession(ctx, user.ID, userAgent, ip)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	return &SetupConsumeResult{Session: session, User: user}, nil
+}
+
+// deriveUsername builds a unique, alphanumeric username from an email's local part,
+// appending a numeric suffix on collision. Best-effort: CreateUser re-checks
+// uniqueness, so a racy lookup at worst surfaces there.
+func (c *KeyorixCore) deriveUsername(ctx context.Context, email string) (string, error) {
+	base := sanitizeUsername(localPart(email))
+	if len(base) < 3 {
+		base += "user"
+	}
+	candidate := base
+	for i := 1; i <= 1000; i++ {
+		if _, err := c.storage.GetUserByUsername(ctx, candidate); err != nil {
+			return candidate, nil // not found → available
+		}
+		candidate = fmt.Sprintf("%s%d", base, i)
+	}
+	return "", fmt.Errorf("%s: could not derive a unique username for %s", i18n.T("ErrorValidation", nil), email)
+}
+
+// localPart returns the part of an email before '@' (or the whole string if none).
+func localPart(email string) string {
+	if i := strings.IndexByte(email, '@'); i > 0 {
+		return email[:i]
+	}
+	return email
+}
+
+// sanitizeUsername lowercases and keeps only [a-z0-9].
+func sanitizeUsername(s string) string {
+	var b strings.Builder
+	for _, r := range strings.ToLower(s) {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+// displayNameFromEmail derives a human-facing default name from an email.
+func displayNameFromEmail(email string) string {
+	if lp := localPart(email); lp != "" {
+		return lp
+	}
+	return email
 }

--- a/internal/storage/store/local_users.go
+++ b/internal/storage/store/local_users.go
@@ -43,7 +43,11 @@ func (ls *LocalStorage) GetUser(ctx context.Context, id uint) (*models.User, err
 
 func (ls *LocalStorage) GetUserByEmail(ctx context.Context, email string) (*models.User, error) {
 	var user models.User
-	if err := ls.db.WithContext(ctx).Where("email = ?", email).First(&user).Error; err != nil {
+	// Case-insensitive: email addresses are not case-sensitive in practice, and an
+	// exact match let the ADR-028 invite-accept "account already exists" guard be
+	// evaded by case (Bob@x vs bob@x), minting a duplicate identity. LOWER() on both
+	// sides matches regardless of stored casing (covers legacy mixed-case rows).
+	if err := ls.db.WithContext(ctx).Where("LOWER(email) = LOWER(?)", email).First(&user).Error; err != nil {
 		if err == gorm.ErrRecordNotFound {
 			return nil, fmt.Errorf("%s", i18n.T("ErrorUserNotFound", nil))
 		}

--- a/server/http/handlers/invitations.go
+++ b/server/http/handlers/invitations.go
@@ -57,17 +57,59 @@ func (h *CatalogHandler) CreateInvitation(w http.ResponseWriter, r *http.Request
 		sendError(w, "ValidationError", "email and role are required", http.StatusBadRequest, nil)
 		return
 	}
-	inv, err := h.coreService.InviteToProject(r.Context(), uint(id), body.Email, body.Role, actor.UserID)
+	inv, prov, err := h.coreService.InviteToProjectWithLink(r.Context(), uint(id), body.Email, body.Role, actor.UserID)
 	if err != nil {
-		status := http.StatusInternalServerError
-		if strings.Contains(err.Error(), "unknown role") || strings.Contains(err.Error(), "required") {
-			status = http.StatusBadRequest
+		// A nil inv means the invitation was not created at all; a non-nil inv with an
+		// error means it was created but the link could not be provisioned (e.g.
+		// base_url unset) — surface that so the admin can fix config and resend.
+		if inv == nil {
+			status := http.StatusInternalServerError
+			if strings.Contains(err.Error(), "unknown role") || strings.Contains(err.Error(), "required") {
+				status = http.StatusBadRequest
+			}
+			sendError(w, "Error", err.Error(), status, nil)
+			return
 		}
-		sendError(w, "Error", err.Error(), status, nil)
+		w.WriteHeader(http.StatusCreated)
+		sendSuccess(w, map[string]interface{}{"invitation": inv, "delivery_error": err.Error()},
+			"Invitation created but the setup link could not be delivered")
 		return
 	}
 	w.WriteHeader(http.StatusCreated)
-	sendSuccess(w, map[string]interface{}{"invitation": inv}, "Invitation created")
+	sendSuccess(w, map[string]interface{}{"invitation": inv, "setup_link": prov}, "Invitation created")
+}
+
+// ResendInvitation handles POST /api/v1/projects/{id}/invitations/{invitationId}/resend
+// (ADR-028): it reissues the invitation's accept link and re-delivers it.
+func (h *CatalogHandler) ResendInvitation(w http.ResponseWriter, r *http.Request) {
+	invID, err := strconv.ParseUint(chi.URLParam(r, "invitationId"), 10, 32)
+	if err != nil {
+		sendError(w, "InvalidParameter", "Invalid invitation ID", http.StatusBadRequest, nil)
+		return
+	}
+	actor := middleware.GetUserFromContext(r.Context())
+	if actor == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	prov, err := h.coreService.ResendInvitationLink(r.Context(), uint(invID), actor.UserID)
+	if err != nil {
+		msg := err.Error()
+		status := http.StatusInternalServerError
+		switch {
+		case strings.Contains(msg, "not found"):
+			status = http.StatusNotFound
+		case strings.Contains(msg, "only a pending"):
+			status = http.StatusConflict
+		case strings.Contains(msg, "limit") || strings.Contains(msg, "wait"):
+			status = http.StatusTooManyRequests
+		case strings.Contains(msg, "base_url"):
+			status = http.StatusBadRequest
+		}
+		sendError(w, "Error", msg, status, nil)
+		return
+	}
+	sendSuccess(w, map[string]interface{}{"setup_link": prov}, "Invitation link resent")
 }
 
 // RevokeInvitation handles DELETE /api/v1/projects/{id}/invitations/{invitationId}.

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -171,6 +171,8 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		r.With(customMiddleware.RequireScopedPermission("users.read", projectScope)).Get("/projects/{id}/invitations", catalogHandler.ListInvitations)
 		r.With(customMiddleware.RequireScopedPermission("roles.assign", projectScope)).Post("/projects/{id}/invitations", catalogHandler.CreateInvitation)
 		r.With(customMiddleware.RequireScopedPermission("roles.assign", projectScope)).Delete("/projects/{id}/invitations/{invitationId}", catalogHandler.RevokeInvitation)
+		// Resend the invitation's setup link (ADR-028).
+		r.With(customMiddleware.RequireScopedPermission("roles.assign", projectScope)).Post("/projects/{id}/invitations/{invitationId}/resend", catalogHandler.ResendInvitation)
 		// Access requests (ADR-024): requesting + withdrawing are self-service (any
 		// authenticated user — they don't have project access yet); listing and
 		// approving/rejecting require roles.assign at the project scope.


### PR DESCRIPTION
## Summary

Fifth implementation PR for **ADR-028** (#19), completing the **invitation vertical** (ADR-024): an admin invites an email → the invitee opens the link, sets a password, and lands in the project.

> **Stacked on #23** → #22 → #21 → #20. Base is `feat/adr-028-account-provisioning`, so the diff here is invitation-only.

## Product decisions (confirmed)

- **Lazy account creation** — the `users` row is created on *accept*, not invite. No dormant accounts for un-accepted invites.
- **One-click, mode-aware accept** — accepting grants the invited role and creates a project membership whose **state follows the ADR-022 validation mode snapshotted at invite time**: `open` → active + role granted immediately; `allowlist` → `invited` for an admin to advance; `idp` → provisioned.

## What's in this PR

- **Consume — `invitation_accept` branch** in `CompleteSetup`: validate password before consume (weak password doesn't burn the link) → lazily create the account → mark invitation accepted → create membership via the invite-time mode → auto-login.
- **Security guard** — an invite for an email that **already has an account** is rejected: the link must not log them in (that would bypass their real password). They're routed to the normal add-member flow. Lazy creation derives a unique alphanumeric username from the email.
- **Membership refactor** — extracted `inviteMemberWithMode` / `initialMembershipStateForMode` so accept honours the *invite-time* mode, not the install's current mode. `InviteToProject` now snapshots `validation_mode` (closes the ADR-024 TODO).
- **Producers** — `InviteToProjectWithLink` (create + issue+deliver an `invitation_accept` link) and `ResendInvitationLink` (pending-guard + ADR-028 throttle + redeliver).
- **HTTP** — `POST /projects/{id}/invitations` now returns the setup link (or surfaces a delivery error while keeping the invite); new `POST .../invitations/{invitationId}/resend`.
- **CLI** — `keyorix invite send` prints the link; new `keyorix invite resend --id --by`.

## Testing

`go build/vet/test ./...` green. New core tests: accept under **open** (active membership + role granted) and **allowlist** (invited, no grant), existing-email rejection, non-pending rejection, weak-password no-consume, and `deriveUsername` sanitize/dedupe.

## Remaining (separate follow-ups)

- One-time-password out-of-band artifact (ADR Part E) — opt-in alternative to the link.
- keyorix-web setup/landing page (frontend; contract defined in #22).
- Inviter / access-request *notifications* (explicitly out of ADR-028 scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)