### PR TITLE
refactor(credential-delivery): ADR-028 cleanup — collapse dup logic + sentinel error

### DIFF
--- a/internal/cli/common/common.go
+++ b/internal/cli/common/common.go
@@ -51,21 +51,25 @@ func InitializeCoreService() (*core.KeyorixCore, error) {
 	svc := core.NewKeyorixCore(storageImpl)
 	svc.SetSetupTokenTTL(cfg.CredentialDelivery.GetSetupTokenTTL())
 	cd := cfg.CredentialDelivery
-	if deliverer, derr := delivery.New(delivery.Config{
-		Mode:    cd.Mode,
-		BaseURL: cd.BaseURL,
-		SMTP: delivery.SMTPSettings{
-			Host:     cd.SMTP.Host,
-			Port:     cd.SMTP.Port,
-			Username: cd.SMTP.Username,
-			Password: cd.SMTP.GetPassword(),
-			From:     cd.SMTP.From,
-			TLS:      cd.SMTP.TLS,
-		},
-	}); derr == nil {
+	if deliverer, derr := delivery.New(cd.DeliveryConfig()); derr == nil {
 		svc.SetCredentialDelivery(deliverer, cd.BaseURL)
 	} else {
 		svc.SetCredentialDelivery(nil, cd.BaseURL)
 	}
 	return svc, nil
+}
+
+// PrintProvisionResult prints how a setup link was delivered (ADR-028). In out-of-band
+// mode it prints the link for the admin to relay; in SMTP mode it confirms the send.
+// Shared by `user create --setup-link`, `user resend-setup-link`, `invite send`, and
+// `invite resend`.
+func PrintProvisionResult(prov *core.ProvisionSetupResult) {
+	if prov == nil {
+		return
+	}
+	if prov.Delivered {
+		fmt.Printf("Setup link delivered to %s via %s.\n", prov.Email, prov.Channel)
+		return
+	}
+	fmt.Printf("Setup link (relay this to %s securely — it is single-use and expires):\n  %s\n", prov.Email, prov.LinkForAdmin)
 }

--- a/internal/cli/invite/resend.go
+++ b/internal/cli/invite/resend.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 
 	"github.com/keyorixhq/keyorix/internal/cli/common"
-	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/spf13/cobra"
 )
 
@@ -42,7 +41,7 @@ var resendCmd = &cobra.Command{
 			return fmt.Errorf("failed to resend invitation link: %w", err)
 		}
 		fmt.Printf("Invitation link reissued for invitation %d.\n", resendID)
-		printProvisionResult(prov)
+		common.PrintProvisionResult(prov)
 		return nil
 	},
 }
@@ -52,18 +51,4 @@ func init() {
 	resendCmd.Flags().StringVar(&resendBy, "by", "", "Acting admin email (required, for audit)")
 	_ = resendCmd.MarkFlagRequired("id")
 	_ = resendCmd.MarkFlagRequired("by")
-}
-
-// printProvisionResult prints how an invitation's setup link was delivered. In
-// out-of-band mode it prints the link for the admin to relay; in SMTP mode it
-// confirms the send. Shared by `invite send` and `invite resend`.
-func printProvisionResult(prov *core.ProvisionSetupResult) {
-	if prov == nil {
-		return
-	}
-	if prov.Delivered {
-		fmt.Printf("Setup link delivered to %s via %s.\n", prov.Email, prov.Channel)
-		return
-	}
-	fmt.Printf("Setup link (relay this to %s securely — it is single-use and expires):\n  %s\n", prov.Email, prov.LinkForAdmin)
 }

--- a/internal/cli/invite/send.go
+++ b/internal/cli/invite/send.go
@@ -69,6 +69,6 @@ func runSend(cmd *cobra.Command, args []string) error {
 	}
 	fmt.Printf("Invitation sent: id=%d email=%s role=%s project=%s expires=%s\n",
 		inv.ID, inv.Email, inv.Role, projectName, fmtTime(inv.ExpiresAt))
-	printProvisionResult(prov)
+	common.PrintProvisionResult(prov)
 	return nil
 }

--- a/internal/cli/user/create.go
+++ b/internal/cli/user/create.go
@@ -79,7 +79,7 @@ func runCreate(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("failed to create user with setup link: %w", err)
 		}
 		fmt.Printf("User created: id=%d username=%s email=%s\n", u.ID, u.Username, u.Email)
-		printProvisionResult(prov)
+		common.PrintProvisionResult(prov)
 		return nil
 	}
 

--- a/internal/cli/user/setup_link.go
+++ b/internal/cli/user/setup_link.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 
 	"github.com/keyorixhq/keyorix/internal/cli/common"
-	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/spf13/cobra"
 )
 
@@ -48,7 +47,7 @@ var resendSetupLinkCmd = &cobra.Command{
 			return fmt.Errorf("failed to resend setup link: %w", err)
 		}
 		fmt.Printf("Setup link reissued for user %d.\n", resendSetupLinkUserID)
-		printProvisionResult(prov)
+		common.PrintProvisionResult(prov)
 		return nil
 	},
 }
@@ -58,17 +57,4 @@ func init() {
 	resendSetupLinkCmd.Flags().StringVar(&resendSetupLinkBy, "by", "", "Acting admin email (required, for audit)")
 	_ = resendSetupLinkCmd.MarkFlagRequired("id")
 	_ = resendSetupLinkCmd.MarkFlagRequired("by")
-}
-
-// printProvisionResult prints how a setup link was delivered. In out-of-band mode it
-// prints the link itself for the admin to relay; in SMTP mode it confirms the send.
-func printProvisionResult(prov *core.ProvisionSetupResult) {
-	if prov == nil {
-		return
-	}
-	if prov.Delivered {
-		fmt.Printf("Setup link delivered to %s via %s.\n", prov.Email, prov.Channel)
-		return
-	}
-	fmt.Printf("Setup link (relay this to %s securely — it is single-use and expires):\n  %s\n", prov.Email, prov.LinkForAdmin)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/keyorixhq/keyorix/internal/delivery"
 	"github.com/keyorixhq/keyorix/internal/securefiles"
 	"gopkg.in/yaml.v3"
 )
@@ -292,6 +293,24 @@ func (c *CredentialDeliveryConfig) GetSetupTokenTTL() time.Duration {
 // GetPassword returns the resolved SMTP password, preferring the environment variable.
 func (s *CredentialSMTPConfig) GetPassword() string {
 	return resolveSecret("KEYORIX_SMTP_PASSWORD", s.Password)
+}
+
+// DeliveryConfig maps the credential-delivery config block onto the delivery package's
+// channel selector, resolving the SMTP password from the environment. Shared by the
+// server and CLI wiring (ADR-028) so the mapping lives in exactly one place.
+func (c *CredentialDeliveryConfig) DeliveryConfig() delivery.Config {
+	return delivery.Config{
+		Mode:    c.Mode,
+		BaseURL: c.BaseURL,
+		SMTP: delivery.SMTPSettings{
+			Host:     c.SMTP.Host,
+			Port:     c.SMTP.Port,
+			Username: c.SMTP.Username,
+			Password: c.SMTP.GetPassword(),
+			From:     c.SMTP.From,
+			TLS:      c.SMTP.TLS,
+		},
+	}
 }
 
 type PurgeConfig struct {

--- a/internal/core/hash.go
+++ b/internal/core/hash.go
@@ -1,0 +1,15 @@
+// hash.go — shared token-hashing helper.
+package core
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+)
+
+// sha256Hex returns the SHA-256 hex digest of a raw token — the stored, indexed form
+// for both setup tokens (ADR-028) and personal access tokens (ADR-027). The plaintext
+// token is never persisted; lookups are by this hash.
+func sha256Hex(raw string) string {
+	sum := sha256.Sum256([]byte(raw))
+	return hex.EncodeToString(sum[:])
+}

--- a/internal/core/invitation_accept_test.go
+++ b/internal/core/invitation_accept_test.go
@@ -16,7 +16,7 @@ func TestCompleteInvitationAccept(t *testing.T) {
 	require.NoError(t, i18n.InitializeForTesting())
 	ctx := context.Background()
 	raw := setupPrefix + "invite1"
-	hash := hashSetupToken(raw)
+	hash := sha256Hex(raw)
 	iid := uint(11)
 
 	pendingInvite := func(c *KeyorixCore, mode string) *models.SetupToken {

--- a/internal/core/pat.go
+++ b/internal/core/pat.go
@@ -10,9 +10,7 @@ package core
 import (
 	"context"
 	"crypto/rand"
-	"crypto/sha256"
 	"encoding/base64"
-	"encoding/hex"
 	"fmt"
 	"strings"
 	"time"
@@ -35,12 +33,6 @@ type CreatePATResult struct {
 	PlainToken string
 }
 
-// hashPAT returns the SHA-256 hex of a raw token — the stored, indexed form.
-func hashPAT(raw string) string {
-	sum := sha256.Sum256([]byte(raw))
-	return hex.EncodeToString(sum[:])
-}
-
 // CreateOwnPAT generates a new personal access token for the caller. expiresAt may
 // be nil for a non-expiring token.
 func (c *KeyorixCore) CreateOwnPAT(ctx context.Context, userID uint, name string, expiresAt *time.Time) (*CreatePATResult, error) {
@@ -60,7 +52,7 @@ func (c *KeyorixCore) CreateOwnPAT(ctx context.Context, userID uint, name string
 	pat := &models.PersonalAccessToken{
 		UserID:      userID,
 		Name:        strings.TrimSpace(name),
-		TokenHash:   hashPAT(raw),
+		TokenHash:   sha256Hex(raw),
 		TokenPrefix: raw[:len(patPrefix)+6], // e.g. "kx_pat_ab12cd" for display
 		ExpiresAt:   expiresAt,
 		CreatedAt:   c.now(),
@@ -101,7 +93,7 @@ func (c *KeyorixCore) ValidatePATToken(ctx context.Context, raw string) (*models
 	if !strings.HasPrefix(raw, patPrefix) {
 		return nil, nil, fmt.Errorf("not a personal access token")
 	}
-	pat, err := c.storage.GetPersonalAccessTokenByHash(ctx, hashPAT(raw))
+	pat, err := c.storage.GetPersonalAccessTokenByHash(ctx, sha256Hex(raw))
 	if err != nil {
 		return nil, nil, fmt.Errorf("invalid token")
 	}

--- a/internal/core/pat_test.go
+++ b/internal/core/pat_test.go
@@ -27,7 +27,7 @@ func TestCreateOwnPAT(t *testing.T) {
 		require.NoError(t, err)
 		assert.True(t, strings.HasPrefix(res.PlainToken, patPrefix), "raw token carries the kx_pat_ prefix")
 		require.NotNil(t, captured)
-		assert.Equal(t, hashPAT(res.PlainToken), captured.TokenHash, "stored value is the hash of the plaintext")
+		assert.Equal(t, sha256Hex(res.PlainToken), captured.TokenHash, "stored value is the hash of the plaintext")
 		assert.NotEqual(t, res.PlainToken, captured.TokenHash, "plaintext is never stored")
 		assert.True(t, strings.HasPrefix(captured.TokenPrefix, patPrefix))
 	})
@@ -44,7 +44,7 @@ func TestCreateOwnPAT(t *testing.T) {
 func TestValidatePATToken(t *testing.T) {
 	ctx := context.Background()
 	raw := patPrefix + "abc123def456"
-	hash := hashPAT(raw)
+	hash := sha256Hex(raw)
 
 	t.Run("resolves a valid token to its user and roles", func(t *testing.T) {
 		ms := new(MockStorage)

--- a/internal/core/setup_consume.go
+++ b/internal/core/setup_consume.go
@@ -75,9 +75,9 @@ func (c *KeyorixCore) CompleteSetup(ctx context.Context, raw, newPassword, userA
 	}
 	switch tok.Purpose {
 	case SetupPurposeAccountSetup, SetupPurposePasswordResetLink:
-		return c.completePasswordSetup(ctx, raw, tok, newPassword, userAgent, ip)
+		return c.completePasswordSetup(ctx, tok, newPassword, userAgent, ip)
 	case SetupPurposeInvitationAccept:
-		return c.completeInvitationAccept(ctx, raw, tok, newPassword, userAgent, ip)
+		return c.completeInvitationAccept(ctx, tok, newPassword, userAgent, ip)
 	default:
 		return nil, fmt.Errorf("%s: setup token purpose %q is not completed at this endpoint", i18n.T("ErrorValidation", nil), tok.Purpose)
 	}
@@ -85,7 +85,7 @@ func (c *KeyorixCore) CompleteSetup(ctx context.Context, raw, newPassword, userA
 
 // completePasswordSetup handles account_setup / password_reset_link: set the existing
 // subject's password and auto-log them in.
-func (c *KeyorixCore) completePasswordSetup(ctx context.Context, raw string, tok *models.SetupToken, newPassword, userAgent, ip string) (*SetupConsumeResult, error) {
+func (c *KeyorixCore) completePasswordSetup(ctx context.Context, tok *models.SetupToken, newPassword, userAgent, ip string) (*SetupConsumeResult, error) {
 	if tok.SubjectUserID == nil {
 		return nil, fmt.Errorf("%s: setup token has no subject account", i18n.T("ErrorValidation", nil))
 	}
@@ -105,7 +105,8 @@ func (c *KeyorixCore) completePasswordSetup(ctx context.Context, raw string, tok
 	}
 
 	// Consume is single-use and atomic; from here the token is spent (fail-closed).
-	if _, err := c.ConsumeSetupToken(ctx, raw, tok.Purpose); err != nil {
+	// tok was already inspected by CompleteSetup, so consume it directly (no re-lookup).
+	if err := c.consumeInspectedToken(ctx, tok, tok.Purpose); err != nil {
 		return nil, err
 	}
 	if err := c.applyNewPassword(ctx, user, newPassword); err != nil {
@@ -127,7 +128,7 @@ func (c *KeyorixCore) completePasswordSetup(ctx context.Context, raw string, tok
 // account (ADR-024/ADR-028), accept the invitation, create a project membership
 // honouring the validation mode snapshotted at invite time (which grants the role
 // when the mode lands it active), and auto-log the user in.
-func (c *KeyorixCore) completeInvitationAccept(ctx context.Context, raw string, tok *models.SetupToken, newPassword, userAgent, ip string) (*SetupConsumeResult, error) {
+func (c *KeyorixCore) completeInvitationAccept(ctx context.Context, tok *models.SetupToken, newPassword, userAgent, ip string) (*SetupConsumeResult, error) {
 	if tok.InvitationID == nil {
 		return nil, fmt.Errorf("%s: invitation token has no invitation", i18n.T("ErrorValidation", nil))
 	}
@@ -166,8 +167,9 @@ func (c *KeyorixCore) completeInvitationAccept(ctx context.Context, raw string, 
 		return nil, fmt.Errorf("%w: %v", ErrInvalidSetupPassword, err)
 	}
 
-	// Consume the token (single-use, atomic) before materializing.
-	if _, err := c.ConsumeSetupToken(ctx, raw, SetupPurposeInvitationAccept); err != nil {
+	// Consume the token (single-use, atomic) before materializing. tok was already
+	// inspected by CompleteSetup, so consume it directly (no re-lookup).
+	if err := c.consumeInspectedToken(ctx, tok, SetupPurposeInvitationAccept); err != nil {
 		return nil, err
 	}
 

--- a/internal/core/setup_consume_test.go
+++ b/internal/core/setup_consume_test.go
@@ -18,7 +18,7 @@ const strongPw = "Str0ng!Passw0rd-2026"
 func TestDescribeSetupToken(t *testing.T) {
 	ctx := context.Background()
 	raw := setupPrefix + "describe1"
-	hash := hashSetupToken(raw)
+	hash := sha256Hex(raw)
 
 	t.Run("returns purpose, email, and display name for an active token", func(t *testing.T) {
 		ms := new(MockStorage)
@@ -63,7 +63,7 @@ func TestDescribeSetupToken(t *testing.T) {
 func TestCompleteSetup(t *testing.T) {
 	ctx := context.Background()
 	raw := setupPrefix + "consume1"
-	hash := hashSetupToken(raw)
+	hash := sha256Hex(raw)
 	uid := uint(4)
 
 	activeAccountSetup := func(c *KeyorixCore) *models.SetupToken {

--- a/internal/core/setup_delivery.go
+++ b/internal/core/setup_delivery.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -20,6 +21,12 @@ import (
 	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
+
+// ErrSetupBaseURLRequired is returned when a setup link is requested but
+// credential_delivery.base_url is unconfigured. It is a misconfiguration (a relative
+// link is never a fallback), so the HTTP layer maps it to a 400 with this reason
+// rather than a generic 500 — letting an admin fix the config.
+var ErrSetupBaseURLRequired = errors.New("credential_delivery.base_url is required to issue a setup link")
 
 // Resend throttling (ADR-028 abuse section): a minimum interval between issues for
 // the same subject, and a daily cap, both per (purpose, email).
@@ -50,7 +57,7 @@ type ProvisionSetupResult struct {
 // (a relative link is a misconfiguration, not a fallback).
 func (c *KeyorixCore) provisionSetupLink(ctx context.Context, req IssueSetupTokenRequest, displayName, assignmentSummary string) (*ProvisionSetupResult, error) {
 	if c.setupBaseURL == "" {
-		return nil, fmt.Errorf("%s: credential_delivery.base_url is required to issue a setup link", i18n.T("ErrorValidation", nil))
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorValidation", nil), ErrSetupBaseURLRequired)
 	}
 	issued, err := c.IssueSetupToken(ctx, req)
 	if err != nil {
@@ -101,7 +108,7 @@ func (c *KeyorixCore) provisionSetupLink(ctx context.Context, req IssueSetupToke
 // created user and the delivery outcome (the link to relay in out-of-band mode).
 func (c *KeyorixCore) CreateUserWithSetupLink(ctx context.Context, req *CreateUserRequest, createdBy uint) (*models.User, *ProvisionSetupResult, error) {
 	if c.setupBaseURL == "" {
-		return nil, nil, fmt.Errorf("%s: credential_delivery.base_url is required to issue a setup link", i18n.T("ErrorValidation", nil))
+		return nil, nil, fmt.Errorf("%s: %w", i18n.T("ErrorValidation", nil), ErrSetupBaseURLRequired)
 	}
 
 	// Create the account with a random, unusable password and confined directly to

--- a/internal/core/setup_delivery_test.go
+++ b/internal/core/setup_delivery_test.go
@@ -135,7 +135,9 @@ func TestProvisionRequiresBaseURL(t *testing.T) {
 	req := CreateUserRequest{Username: "dana", Email: "dana@acme.io", DisplayName: "Dana"}
 	_, _, err := c.CreateUserWithSetupLink(ctx, &req, 0)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "base_url")
+	// The HTTP layer maps this to a 400 ConfigError via errors.Is, so the sentinel
+	// must survive the i18n-prefixed wrap.
+	assert.ErrorIs(t, err, ErrSetupBaseURLRequired)
 	ms.AssertNotCalled(t, "CreateUser", mock.Anything, mock.Anything)
 }
 

--- a/internal/core/setup_token.go
+++ b/internal/core/setup_token.go
@@ -20,9 +20,7 @@ package core
 import (
 	"context"
 	"crypto/rand"
-	"crypto/sha256"
 	"encoding/base64"
-	"encoding/hex"
 	"fmt"
 	"strings"
 	"time"
@@ -62,12 +60,6 @@ func validSetupPurpose(p string) bool {
 	default:
 		return false
 	}
-}
-
-// hashSetupToken returns the SHA-256 hex of a raw token — the stored, indexed form.
-func hashSetupToken(raw string) string {
-	sum := sha256.Sum256([]byte(raw))
-	return hex.EncodeToString(sum[:])
 }
 
 // IssueSetupTokenRequest describes a token to mint.
@@ -117,7 +109,7 @@ func (c *KeyorixCore) IssueSetupToken(ctx context.Context, req IssueSetupTokenRe
 	now := c.now()
 
 	tok := &models.SetupToken{
-		TokenHash:     hashSetupToken(raw),
+		TokenHash:     sha256Hex(raw),
 		Purpose:       req.Purpose,
 		SubjectUserID: req.SubjectUserID,
 		SubjectEmail:  email,
@@ -163,7 +155,7 @@ func (c *KeyorixCore) ValidateSetupToken(ctx context.Context, raw, expectedPurpo
 // expected purpose use ValidateSetupToken; the GET-describe path (which must report
 // the purpose to the landing page) uses this directly.
 func (c *KeyorixCore) inspectActiveSetupToken(ctx context.Context, raw string) (*models.SetupToken, error) {
-	tok, err := c.storage.GetSetupTokenByHash(ctx, hashSetupToken(raw))
+	tok, err := c.storage.GetSetupTokenByHash(ctx, sha256Hex(raw))
 	if err != nil {
 		return nil, fmt.Errorf("%s: invalid setup token", i18n.T("ErrorNotFound", nil))
 	}
@@ -187,22 +179,37 @@ func (c *KeyorixCore) inspectActiveSetupToken(ctx context.Context, raw string) (
 // up front: if the caller's subsequent materialization fails, the token is already
 // spent — a deliberate fail-closed choice, since a setup token is a credential.
 func (c *KeyorixCore) ConsumeSetupToken(ctx context.Context, raw, expectedPurpose string) (*models.SetupToken, error) {
-	tok, err := c.ValidateSetupToken(ctx, raw, expectedPurpose)
+	tok, err := c.inspectActiveSetupToken(ctx, raw)
 	if err != nil {
 		return nil, err
 	}
+	if err := c.consumeInspectedToken(ctx, tok, expectedPurpose); err != nil {
+		return nil, err
+	}
+	return tok, nil
+}
+
+// consumeInspectedToken marks an already-inspected active token consumed (single-use),
+// after checking its purpose. CompleteSetup calls this with the token it already
+// resolved, so the consume flow performs ONE hash+lookup instead of two — closing the
+// lazy-expire race between a re-validate and the mark. Consumption is burned up front
+// (fail-closed): a setup token is a credential.
+func (c *KeyorixCore) consumeInspectedToken(ctx context.Context, tok *models.SetupToken, expectedPurpose string) error {
+	if tok.Purpose != expectedPurpose {
+		return fmt.Errorf("%s: setup token purpose mismatch", i18n.T("ErrorValidation", nil))
+	}
 	ok, err := c.storage.MarkSetupTokenConsumed(ctx, tok.ID, c.now())
 	if err != nil {
-		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}
 	if !ok {
-		// Lost a race to a concurrent consumer (or already spent between validate
-		// and mark). Single-use holds: reject.
-		return nil, fmt.Errorf("%s: setup token already used", i18n.T("ErrorNotFound", nil))
+		// Lost a race to a concurrent consumer (or already spent between inspect and
+		// mark). Single-use holds: reject.
+		return fmt.Errorf("%s: setup token already used", i18n.T("ErrorNotFound", nil))
 	}
 	c.writeAuditEventFull(ctx, "setup_token.consumed", tok.SubjectUserID, nil, nil, "",
 		fmt.Sprintf("setup token consumed (purpose=%s, subject=%s)", tok.Purpose, tok.SubjectEmail))
-	return tok, nil
+	return nil
 }
 
 // actorOrSubject returns the issuing admin as the audit actor, falling back to the

--- a/internal/core/setup_token_test.go
+++ b/internal/core/setup_token_test.go
@@ -39,7 +39,7 @@ func TestIssueSetupToken(t *testing.T) {
 		require.NoError(t, err)
 		assert.True(t, strings.HasPrefix(res.PlainToken, setupPrefix), "raw token carries the kx_setup_ prefix")
 		require.NotNil(t, captured)
-		assert.Equal(t, hashSetupToken(res.PlainToken), captured.TokenHash, "stored value is the hash of the plaintext")
+		assert.Equal(t, sha256Hex(res.PlainToken), captured.TokenHash, "stored value is the hash of the plaintext")
 		assert.NotEqual(t, res.PlainToken, captured.TokenHash, "plaintext is never stored")
 		assert.Equal(t, "new@acme.io", captured.SubjectEmail)
 		assert.Equal(t, SetupTokenActive, captured.State)
@@ -101,7 +101,7 @@ func TestIssueSetupToken(t *testing.T) {
 func TestValidateSetupToken(t *testing.T) {
 	ctx := context.Background()
 	raw := setupPrefix + "abc123"
-	hash := hashSetupToken(raw)
+	hash := sha256Hex(raw)
 
 	t.Run("resolves an active token for the matching purpose", func(t *testing.T) {
 		ms := new(MockStorage)
@@ -166,7 +166,7 @@ func TestValidateSetupToken(t *testing.T) {
 func TestConsumeSetupToken(t *testing.T) {
 	ctx := context.Background()
 	raw := setupPrefix + "xyz789"
-	hash := hashSetupToken(raw)
+	hash := sha256Hex(raw)
 
 	activeTok := func(c *KeyorixCore) *models.SetupToken {
 		return &models.SetupToken{ID: 9, State: SetupTokenActive, Purpose: SetupPurposeAccountSetup, ExpiresAt: c.now().Add(time.Hour)}

--- a/server/http/handlers/users_crud.go
+++ b/server/http/handlers/users_crud.go
@@ -7,6 +7,7 @@ package handlers
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"log"
 	"net/http"
 	"strconv"
@@ -65,7 +66,7 @@ func (h *UserHandler) CreateUser(w http.ResponseWriter, r *http.Request) {
 				sendError(w, "ConflictError", "User already exists", http.StatusConflict, nil)
 				return
 			}
-			if strings.Contains(err.Error(), "base_url") {
+			if errors.Is(err, core.ErrSetupBaseURLRequired) {
 				sendError(w, "ConfigError", err.Error(), http.StatusBadRequest, nil)
 				return
 			}

--- a/server/main.go
+++ b/server/main.go
@@ -225,18 +225,7 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 	// log from the configured mode and fails loud on a bad mode (e.g. smtp with no
 	// host), so a misconfigured install does not silently drop setup links.
 	cd := cfg.CredentialDelivery
-	deliverer, derr := delivery.New(delivery.Config{
-		Mode:    cd.Mode,
-		BaseURL: cd.BaseURL,
-		SMTP: delivery.SMTPSettings{
-			Host:     cd.SMTP.Host,
-			Port:     cd.SMTP.Port,
-			Username: cd.SMTP.Username,
-			Password: cd.SMTP.GetPassword(),
-			From:     cd.SMTP.From,
-			TLS:      cd.SMTP.TLS,
-		},
-	})
+	deliverer, derr := delivery.New(cd.DeliveryConfig())
 	if derr != nil {
 		return nil, nil, fmt.Errorf("failed to init credential delivery: %w", derr)
 	}


### PR DESCRIPTION
Tech-debt follow-ups deferred from the ADR-028 ship. **No behaviour change** — pure refactors, full gate green.

## Changes
1. **Single token lookup in setup consume** — `CompleteSetup` already inspects the token, so the consume branches now call a new `consumeInspectedToken(tok, …)` that marks-by-ID instead of re-hashing + re-fetching via `ConsumeSetupToken`. Closes the lazy-expire race between the two inspects. `ConsumeSetupToken` (public, used elsewhere) refactored to reuse the same helper.
2. **`base_url` misconfig → sentinel** — new `core.ErrSetupBaseURLRequired`; the `POST /users` setup-link handler maps it via `errors.Is` instead of `strings.Contains(err.Error(), "base_url")`.
3. **De-dup `hashSetupToken` == `hashPAT`** into one `sha256Hex` helper (`internal/core/hash.go`).
4. **De-dup `printProvisionResult`** (cli/user + cli/invite) into `common.PrintProvisionResult`.
5. **De-dup config→`delivery.Config` mapping** (server/main + cli/common) into a `CredentialDeliveryConfig.DeliveryConfig()` method.

Tightened `TestProvisionRequiresBaseURL` to assert the sentinel via `errors.Is`.

## Verification
`go build ./...`, `go vet ./...`, `gofmt -l`, `go test ./...` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)