### PR TITLE
feat(credential-delivery): one-time-password out-of-band artifact (ADR-028 Part E)

### DIFF
--- a/internal/cli/common/common.go
+++ b/internal/cli/common/common.go
@@ -73,3 +73,13 @@ func PrintProvisionResult(prov *core.ProvisionSetupResult) {
 	}
 	fmt.Printf("Setup link (relay this to %s securely — it is single-use and expires):\n  %s\n", prov.Email, prov.LinkForAdmin)
 }
+
+// PrintOneTimePasswordResult prints the out-of-band one-time password for the admin to
+// relay (ADR-028 Part E). It is shown once and the account must change it on first login.
+// Shared by `user create --one-time-password`.
+func PrintOneTimePasswordResult(otp *core.OneTimePasswordResult) {
+	if otp == nil {
+		return
+	}
+	fmt.Printf("One-time password for %s (relay securely — it must be changed on first login):\n  %s\n", otp.Email, otp.OneTimePassword)
+}

--- a/internal/cli/user/create.go
+++ b/internal/cli/user/create.go
@@ -11,12 +11,13 @@ import (
 )
 
 var (
-	createUsername    string
-	createEmail       string
-	createPassword    string
-	createDisplayName string
-	createSetupLink   bool
-	createBy          string
+	createUsername        string
+	createEmail           string
+	createPassword        string
+	createDisplayName     string
+	createSetupLink       bool
+	createOneTimePassword bool
+	createBy              string
 )
 
 var createCmd = &cobra.Command{
@@ -25,17 +26,22 @@ var createCmd = &cobra.Command{
 	Long: "Create a new user. Supply --password to set an initial password, or use\n" +
 		"--setup-link to provision an ADR-028 setup link instead: the account is created\n" +
 		"in pending_first_login state and the user sets their own password via the link.\n" +
-		"In out-of-band mode the link is printed for you to relay.",
+		"In out-of-band mode the link is printed for you to relay.\n\n" +
+		"Or use --one-time-password to have the server generate an initial password\n" +
+		"(ADR-028 Part E): the account is created in password_reset_required state, the\n" +
+		"password is printed once for you to relay, and the user must change it on first\n" +
+		"login.",
 	RunE: runCreate,
 }
 
 func init() {
 	createCmd.Flags().StringVar(&createUsername, "username", "", "Username (required)")
 	createCmd.Flags().StringVar(&createEmail, "email", "", "Email (required)")
-	createCmd.Flags().StringVar(&createPassword, "password", "", "Initial password (required unless --setup-link)")
+	createCmd.Flags().StringVar(&createPassword, "password", "", "Initial password (required unless --setup-link or --one-time-password)")
 	createCmd.Flags().StringVar(&createDisplayName, "display-name", "", "Display name (defaults to username)")
 	createCmd.Flags().BoolVar(&createSetupLink, "setup-link", false, "Provision a setup link instead of an admin-set password (ADR-028)")
-	createCmd.Flags().StringVar(&createBy, "by", "", "Acting admin email (for audit; used with --setup-link)")
+	createCmd.Flags().BoolVar(&createOneTimePassword, "one-time-password", false, "Generate a one-time password instead of an admin-set password (ADR-028 Part E); must be changed on first login")
+	createCmd.Flags().StringVar(&createBy, "by", "", "Acting admin email (for audit; used with --setup-link / --one-time-password)")
 }
 
 func runCreate(cmd *cobra.Command, args []string) error {
@@ -45,8 +51,11 @@ func runCreate(cmd *cobra.Command, args []string) error {
 	if createEmail == "" {
 		return errors.New("email is required (use --email)")
 	}
-	if !createSetupLink && createPassword == "" {
-		return errors.New("password is required (use --password), or use --setup-link")
+	if createSetupLink && createOneTimePassword {
+		return errors.New("use either --setup-link or --one-time-password, not both")
+	}
+	if !createSetupLink && !createOneTimePassword && createPassword == "" {
+		return errors.New("password is required (use --password), or use --setup-link or --one-time-password")
 	}
 
 	service, err := common.InitializeCoreService()
@@ -80,6 +89,22 @@ func runCreate(cmd *cobra.Command, args []string) error {
 		}
 		fmt.Printf("User created: id=%d username=%s email=%s\n", u.ID, u.Username, u.Email)
 		common.PrintProvisionResult(prov)
+		return nil
+	}
+
+	if createOneTimePassword {
+		var createdBy uint
+		if createBy != "" {
+			if createdBy, err = resolveAdminID(ctx, service, createBy); err != nil {
+				return err
+			}
+		}
+		u, otp, err := service.CreateUserWithOneTimePassword(ctx, req, createdBy)
+		if err != nil {
+			return fmt.Errorf("failed to create user with one-time password: %w", err)
+		}
+		fmt.Printf("User created: id=%d username=%s email=%s\n", u.ID, u.Username, u.Email)
+		common.PrintOneTimePasswordResult(otp)
 		return nil
 	}
 

--- a/internal/core/setup_delivery.go
+++ b/internal/core/setup_delivery.go
@@ -14,6 +14,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"math/big"
 	"strings"
 	"time"
 
@@ -141,6 +142,48 @@ func (c *KeyorixCore) CreateUserWithSetupLink(ctx context.Context, req *CreateUs
 	return user, res, nil
 }
 
+// OneTimePasswordResult carries the out-of-band one-time password for the admin to
+// relay (ADR-028 Part E). It is returned once, at creation, and never stored in clear:
+// only the bcrypt hash is persisted, and the account is forced into
+// password_reset_required so the user must replace it on first login.
+type OneTimePasswordResult struct {
+	Email           string `json:"email"`
+	OneTimePassword string `json:"one_time_password"`
+}
+
+// CreateUserWithOneTimePassword creates a user with a server-generated initial password
+// and forces it into password_reset_required (ADR-025), returning the password once for
+// the admin to relay out-of-band (ADR-028 Part E). It is the alternative to the
+// setup-link path for when an admin wants to set an initial credential rather than have
+// the end user choose one: the admin holds the first credential, so the account must
+// change it on first login. The password is never emailed and never persisted in clear
+// (only its bcrypt hash). No base URL is required — there is no link.
+func (c *KeyorixCore) CreateUserWithOneTimePassword(ctx context.Context, req *CreateUserRequest, createdBy uint) (*models.User, *OneTimePasswordResult, error) {
+	otp, err := generateOneTimePassword()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Create the account directly in password_reset_required with the generated
+	// password, in the SAME write — no second UpdateUser that, on failure, could
+	// strand an active account whose credential the admin already saw.
+	reqCopy := *req
+	reqCopy.Password = otp
+	reqCopy.AccountState = AccountPasswordResetRequired
+	user, err := c.CreateUser(ctx, &reqCopy)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Record that a human saw a credential — the one path the ADR singles out for
+	// compliance (artifact=one_time_password, vs the setup-link artifact).
+	actor := actorOrSubject(createdBy, &user.ID)
+	c.writeAuditEventFull(ctx, "credential.displayed_out_of_band", actor, nil, nil, "",
+		fmt.Sprintf("one-time password shown out-of-band to admin (subject=%s, artifact=one_time_password)", user.Email))
+
+	return user, &OneTimePasswordResult{Email: user.Email, OneTimePassword: otp}, nil
+}
+
 // ResendAccountSetupLink reissues an account_setup link for an existing user,
 // superseding the prior active token, and re-delivers it. Throttled per ADR-028.
 func (c *KeyorixCore) ResendAccountSetupLink(ctx context.Context, userID, createdBy uint) (*ProvisionSetupResult, error) {
@@ -201,4 +244,68 @@ func randomUnusablePassword() (string, error) {
 		return "", fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}
 	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+// One-time-password character classes (ADR-028 Part E). Visually ambiguous characters
+// (0/O, 1/l/I) are excluded so the password survives being read aloud or copied by hand
+// when the admin relays it out of band.
+const (
+	otpLower   = "abcdefghijkmnpqrstuvwxyz" // no l, o
+	otpUpper   = "ABCDEFGHJKLMNPQRSTUVWXYZ" // no I, O
+	otpDigits  = "23456789"                 // no 0, 1
+	otpSpecial = "!@#$%^&*-_=+"
+	otpLength  = 20
+)
+
+// generateOneTimePassword returns a high-entropy password that satisfies the default
+// ADR-025 password policy (length + all four character classes). It seeds one character
+// from each required class so the policy always holds regardless of the random draw,
+// fills the rest from the union, then shuffles so the seeded characters aren't in fixed
+// positions. All randomness is from crypto/rand.
+func generateOneTimePassword() (string, error) {
+	classes := []string{otpLower, otpUpper, otpDigits, otpSpecial}
+	all := otpLower + otpUpper + otpDigits + otpSpecial
+
+	out := make([]byte, otpLength)
+	for i, class := range classes {
+		ch, err := randChar(class)
+		if err != nil {
+			return "", err
+		}
+		out[i] = ch
+	}
+	for i := len(classes); i < otpLength; i++ {
+		ch, err := randChar(all)
+		if err != nil {
+			return "", err
+		}
+		out[i] = ch
+	}
+	if err := shuffleBytes(out); err != nil {
+		return "", err
+	}
+	return string(out), nil
+}
+
+// randChar returns a uniformly random byte from set using crypto/rand.
+func randChar(set string) (byte, error) {
+	n, err := rand.Int(rand.Reader, big.NewInt(int64(len(set))))
+	if err != nil {
+		return 0, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	return set[n.Int64()], nil
+}
+
+// shuffleBytes performs an in-place Fisher–Yates shuffle using crypto/rand, so the
+// class-seeded characters do not stay in their initial positions.
+func shuffleBytes(b []byte) error {
+	for i := len(b) - 1; i > 0; i-- {
+		j, err := rand.Int(rand.Reader, big.NewInt(int64(i+1)))
+		if err != nil {
+			return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+		}
+		jj := int(j.Int64())
+		b[i], b[jj] = b[jj], b[i]
+	}
+	return nil
 }

--- a/internal/core/setup_delivery_test.go
+++ b/internal/core/setup_delivery_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/bcrypt"
 )
 
 // fakeDeliverer is a controllable CredentialDelivery for tests. When echoLink is set
@@ -172,6 +173,60 @@ func TestCreateUserWithSetupLink(t *testing.T) {
 	ms.AssertNotCalled(t, "UpdateUser", mock.Anything, mock.Anything)
 	require.NotNil(t, prov)
 	assert.True(t, strings.HasPrefix(prov.LinkForAdmin, testBaseURL+"/auth/setup/"+setupPrefix))
+}
+
+func TestCreateUserWithOneTimePassword(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	ctx := context.Background()
+	ms := new(MockStorage)
+	c := NewKeyorixCore(ms)
+	anyAudit(ms)
+
+	notFound := func() error { return assertNotFoundErr() }
+	created := &models.User{ID: 11, Username: "dana", Email: "dana@acme.io", DisplayName: "Dana", AccountState: AccountPasswordResetRequired}
+
+	ms.On("GetUserByUsername", ctx, "dana").Return(nil, notFound())
+	ms.On("GetUserByEmail", ctx, "dana@acme.io").Return(nil, notFound())
+	// The account is created directly in password_reset_required — the admin holds the
+	// first credential, so the user must change it on first login.
+	var captured *models.User
+	ms.On("CreateUser", ctx, mock.MatchedBy(func(u *models.User) bool {
+		return u.AccountState == AccountPasswordResetRequired
+	})).Run(func(args mock.Arguments) { captured = args.Get(1).(*models.User) }).Return(created, nil)
+	ms.On("AddPasswordHistory", ctx, uint(11), mock.AnythingOfType("string"), mock.Anything).Return(nil)
+	ms.On("GetRoleByName", ctx, "system_viewer").Return(nil, notFound())
+
+	user, otp, err := c.CreateUserWithOneTimePassword(ctx, &CreateUserRequest{
+		Username: "dana", Email: "dana@acme.io", DisplayName: "Dana",
+	}, 7)
+	require.NoError(t, err)
+	assert.Equal(t, AccountPasswordResetRequired, user.AccountState, "account must change the credential on first login")
+	ms.AssertNotCalled(t, "UpdateUser", mock.Anything, mock.Anything)
+	require.NotNil(t, otp)
+	assert.Equal(t, "dana@acme.io", otp.Email)
+	// The returned OTP satisfies the default policy and is exactly what was hashed and
+	// stored — so it actually authenticates (then hits the password-change gate).
+	require.NoError(t, DefaultPasswordPolicy().Validate(otp.OneTimePassword, nil))
+	require.NotNil(t, captured)
+	assert.NoError(t, bcrypt.CompareHashAndPassword([]byte(captured.PasswordHash), []byte(otp.OneTimePassword)),
+		"the displayed OTP must be the one persisted")
+	// The out-of-band display is recorded as a human seeing a credential.
+	ms.AssertCalled(t, "LogAuditEvent", mock.Anything, mock.MatchedBy(func(e *models.AuditEvent) bool {
+		return e.EventType == "credential.displayed_out_of_band" && strings.Contains(e.Description, "one_time_password")
+	}))
+}
+
+func TestGenerateOneTimePassword(t *testing.T) {
+	policy := DefaultPasswordPolicy()
+	seen := map[string]bool{}
+	for i := 0; i < 50; i++ {
+		pw, err := generateOneTimePassword()
+		require.NoError(t, err)
+		assert.Len(t, pw, otpLength)
+		require.NoError(t, policy.Validate(pw, nil), "every generated OTP must satisfy the default password policy")
+		assert.False(t, seen[pw], "OTPs must be unique")
+		seen[pw] = true
+	}
 }
 
 // helpers ---------------------------------------------------------------------

--- a/server/http/handlers/users_crud.go
+++ b/server/http/handlers/users_crud.go
@@ -39,6 +39,11 @@ func (h *UserHandler) CreateUser(w http.ResponseWriter, r *http.Request) {
 		// password: the account is created in pending_first_login state and a setup
 		// link is delivered (or returned for out-of-band relay).
 		DeliverSetupLink bool `json:"deliver_setup_link,omitempty"`
+		// GenerateOneTimePassword provisions a server-generated initial password instead
+		// of an admin-set one or a setup link: the account is created in
+		// password_reset_required state and the password is returned once for the admin
+		// to relay out-of-band (ADR-028 Part E). The user must change it on first login.
+		GenerateOneTimePassword bool `json:"generate_one_time_password,omitempty"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		sendError(w, "InvalidJSON", "Invalid JSON in request body", http.StatusBadRequest, nil)
@@ -55,6 +60,34 @@ func (h *UserHandler) CreateUser(w http.ResponseWriter, r *http.Request) {
 		DisplayName: body.DisplayName,
 		Password:    body.Password,
 		IsActive:    body.IsActive,
+	}
+
+	// The three credential modes are mutually exclusive: admin-set password, setup
+	// link, or generated one-time password.
+	if body.DeliverSetupLink && body.GenerateOneTimePassword {
+		sendError(w, "ValidationError", "Choose either deliver_setup_link or generate_one_time_password, not both", http.StatusBadRequest, nil)
+		return
+	}
+
+	// One-time-password path (ADR-028 Part E): server generates the initial password,
+	// returns it once for out-of-band relay, and forces a change on first login.
+	if body.GenerateOneTimePassword {
+		created, otp, err := h.coreService.CreateUserWithOneTimePassword(r.Context(), req, userCtx.UserID)
+		if err != nil {
+			log.Printf("Error creating user with one-time password: %v", err)
+			if strings.Contains(err.Error(), "already exists") {
+				sendError(w, "ConflictError", "User already exists", http.StatusConflict, nil)
+				return
+			}
+			sendError(w, "InternalError", "Failed to create user", http.StatusInternalServerError, nil)
+			return
+		}
+		w.WriteHeader(http.StatusCreated)
+		sendSuccess(w, map[string]interface{}{
+			"user":              userToAPIResponse(created),
+			"one_time_password": otp,
+		}, i18n.T("SuccessUserCreated", nil))
+		return
 	}
 
 	// Setup-link provisioning path (ADR-028): no admin password; deliver a link.
@@ -83,7 +116,7 @@ func (h *UserHandler) CreateUser(w http.ResponseWriter, r *http.Request) {
 
 	// Classic path: the admin supplies the initial password.
 	if body.Password == "" {
-		sendError(w, "ValidationError", "Password is required unless deliver_setup_link is set", http.StatusBadRequest, nil)
+		sendError(w, "ValidationError", "Password is required unless deliver_setup_link or generate_one_time_password is set", http.StatusBadRequest, nil)
 		return
 	}
 	created, err := h.coreService.CreateUser(r.Context(), req)


### PR DESCRIPTION
## What

Implements **ADR-028 Part E** — the one-time-password out-of-band artifact, the last open item from the credential-delivery ship. It's the third credential mode for admin-direct user creation, alongside an admin-set password and the setup link.

When an admin opts to set an initial credential themselves (rather than have the end user choose one via a setup link), the server **generates** a strong password, **shows it once** for the admin to relay out-of-band, and forces the account into `password_reset_required` (ADR-025) so the user must replace it on first login.

## Changes

- **core** — `CreateUserWithOneTimePassword`: creates the account directly in `password_reset_required` with the generated password in a single write (no second `UpdateUser` that, on failure, could strand an active account whose credential the admin already saw — same invariant as the setup-link path). Fires `credential.displayed_out_of_band` with `artifact=one_time_password` (Part F audit).
- **core** — `generateOneTimePassword`: `crypto/rand`, 20 chars, seeds one char of each required class then Fisher–Yates shuffles, so it always satisfies the default ADR-025 policy. Visually ambiguous chars (`0/O`, `1/l/I`) excluded so it survives hand-relay.
- **http** — `POST /api/v1/users` gains `generate_one_time_password`, mutually exclusive with `deliver_setup_link`/`password`; returns `{user, one_time_password}`.
- **cli** — `keyorix user create --one-time-password` + `common.PrintOneTimePasswordResult`.
- **tests** — producer (account state, audit event, OTP authenticates against the persisted bcrypt hash) and generator (policy-compliant + unique across 50 draws).

## Security notes

- The password is **never emailed** and **never persisted in clear** — only its bcrypt hash. It's returned to the admin exactly once, in the API/CLI response.
- The out-of-band display is audited (`credential.displayed_out_of_band`), the one path ADR-028 singles out for compliance because a human briefly sees a credential.
- `password_reset_required` means the ADR-025 restricted-session gate 403s every endpoint until the user changes it — the OTP is good for first login only.

## Scope

Backend only (keyorix repo), mirroring how setup-link backend (#23) and frontend (#11) were split. A frontend toggle for the OTP mode is a separate keyorix-web follow-up. Resend stays link-only (OTP is a create-time artifact).

`go build/vet/gofmt/test ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)