### PR TITLE
feat(cli): keyorix migrate user-to-machine (ADR-023)

### DIFF
--- a/internal/cli/main.go
+++ b/internal/cli/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/keyorixhq/keyorix/internal/cli/group"
 	"github.com/keyorixhq/keyorix/internal/cli/invite"
 	"github.com/keyorixhq/keyorix/internal/cli/machine"
+	"github.com/keyorixhq/keyorix/internal/cli/migrate"
 	"github.com/keyorixhq/keyorix/internal/cli/project"
 	"github.com/keyorixhq/keyorix/internal/cli/rbac"
 	"github.com/keyorixhq/keyorix/internal/cli/request"
@@ -40,6 +41,7 @@ func init() {
 	rootCmd.AddCommand(secret.SecretCmd)
 	rootCmd.AddCommand(project.ProjectCmd)
 	rootCmd.AddCommand(machine.MachineCmd)
+	rootCmd.AddCommand(migrate.MigrateCmd)
 	rootCmd.AddCommand(user.UserCmd)
 	rootCmd.AddCommand(group.GroupCmd)
 	rootCmd.AddCommand(invite.InviteCmd)

--- a/internal/cli/migrate/migrate.go
+++ b/internal/cli/migrate/migrate.go
@@ -1,0 +1,22 @@
+// migrate.go — one-off operator migration helpers.
+//
+// These commands run against the local database (direct core service, no remote
+// API), mirroring the user account-lifecycle CLI: they have no session, so the
+// acting admin is supplied by email via --by for audit attribution. Today the
+// group hosts `migrate user-to-machine` (ADR-023).
+package migrate
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// MigrateCmd is the root command for operator migrations.
+var MigrateCmd = &cobra.Command{
+	Use:   "migrate",
+	Short: "Operator migration helpers",
+	Long:  "One-off migrations an operator runs against the local database, such as converting service-account-shaped users into machine identities.",
+}
+
+func init() {
+	MigrateCmd.AddCommand(userToMachineCmd)
+}

--- a/internal/cli/migrate/migrate_test.go
+++ b/internal/cli/migrate/migrate_test.go
@@ -1,0 +1,34 @@
+package migrate
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMigrateCmd_Subcommands(t *testing.T) {
+	want := map[string]bool{"user-to-machine": false}
+	for _, c := range MigrateCmd.Commands() {
+		want[c.Name()] = true
+	}
+	for name, found := range want {
+		assert.True(t, found, "expected migrate subcommand %q to be registered", name)
+	}
+}
+
+func TestUserToMachineCmd_Args(t *testing.T) {
+	cmd, _, err := MigrateCmd.Find([]string{"user-to-machine"})
+	require.NoError(t, err)
+	// ExactArgs(1): zero args rejected, one accepted.
+	assert.Error(t, cmd.Args(cmd, []string{}), "should require a username")
+	assert.NoError(t, cmd.Args(cmd, []string{"ci-bot"}), "should accept one username")
+}
+
+func TestUserToMachineCmd_Flags(t *testing.T) {
+	cmd, _, err := MigrateCmd.Find([]string{"user-to-machine"})
+	require.NoError(t, err)
+	for _, f := range []string{"project", "type", "name", "by", "keep-user"} {
+		assert.NotNil(t, cmd.Flags().Lookup(f), "user-to-machine should have a --%s flag", f)
+	}
+}

--- a/internal/cli/migrate/user_to_machine.go
+++ b/internal/cli/migrate/user_to_machine.go
@@ -1,0 +1,99 @@
+// user_to_machine.go — `keyorix migrate user-to-machine <username>` (ADR-023).
+//
+// Converts a service-account-shaped human user into a project machine identity.
+// Local mode only (operator tool): resolves the acting admin via --by, the
+// project via --project / KEYORIX_PROJECT / the active project, then delegates to
+// core.MigrateUserToMachine. By default the source user is suspended so it can no
+// longer log in; --keep-user leaves it active.
+package migrate
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/spf13/cobra"
+)
+
+var (
+	u2mProject  string
+	u2mType     string
+	u2mName     string
+	u2mBy       string
+	u2mKeepUser bool
+)
+
+var userToMachineCmd = &cobra.Command{
+	Use:   "user-to-machine <username>",
+	Short: "Convert a service-account-shaped user into a machine identity",
+	Long: "Materialise a project machine identity (ADR-023) for an existing user and,\n" +
+		"unless --keep-user is set, suspend the source user so it can no longer log in.\n" +
+		"The user is never deleted; suspension is reversible via `keyorix user reactivate`.",
+	Args: cobra.ExactArgs(1),
+	RunE: runUserToMachine,
+}
+
+func init() {
+	userToMachineCmd.Flags().StringVar(&u2mProject, "project", "", "Project for the new machine identity (defaults to the active project)")
+	userToMachineCmd.Flags().StringVar(&u2mType, "type", "service", "Identity type: ci | k8s | service | automation | other")
+	userToMachineCmd.Flags().StringVar(&u2mName, "name", "", "Machine identity name (defaults to the username)")
+	userToMachineCmd.Flags().StringVar(&u2mBy, "by", "", "Acting admin email (required, for audit)")
+	userToMachineCmd.Flags().BoolVar(&u2mKeepUser, "keep-user", false, "Leave the source user active (default: suspend it)")
+	_ = userToMachineCmd.MarkFlagRequired("by")
+}
+
+func runUserToMachine(cmd *cobra.Command, args []string) error {
+	username := args[0]
+	if u2mBy == "" {
+		return errors.New("acting admin email is required (use --by)")
+	}
+
+	ctx := context.Background()
+	svc, err := common.InitializeCoreService()
+	if err != nil {
+		return fmt.Errorf("failed to initialize service: %w", err)
+	}
+
+	admin, err := svc.GetUserByEmail(ctx, u2mBy)
+	if err != nil {
+		return fmt.Errorf("no user found for --by %q: %w", u2mBy, err)
+	}
+
+	projectID, err := resolveProjectID(ctx, svc, u2mProject)
+	if err != nil {
+		return err
+	}
+
+	m, err := svc.MigrateUserToMachine(ctx, username, projectID, u2mType, u2mName, admin.ID, !u2mKeepUser)
+	if err != nil {
+		return fmt.Errorf("migration failed: %w", err)
+	}
+
+	fmt.Printf("Migrated user %q to machine identity: id=%d name=%q type=%s state=%s\n",
+		username, m.ID, m.Name, m.IdentityType, m.State)
+	if !u2mKeepUser {
+		fmt.Println("Source user suspended (login blocked). Use `keyorix user reactivate` to restore.")
+	}
+	return nil
+}
+
+// resolveProjectID resolves a project name (flag / env / active) to its numeric
+// ID against the local core service.
+func resolveProjectID(ctx context.Context, svc *core.KeyorixCore, flagValue string) (uint, error) {
+	name, err := common.ResolveProject(flagValue)
+	if err != nil {
+		return 0, err
+	}
+	projects, err := svc.ListProjects(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("failed to list projects: %w", err)
+	}
+	for _, p := range projects {
+		if p.Name == name {
+			return p.ID, nil
+		}
+	}
+	return 0, fmt.Errorf("project %q not found", name)
+}

--- a/internal/core/migrate_user_to_machine.go
+++ b/internal/core/migrate_user_to_machine.go
@@ -1,0 +1,66 @@
+// migrate_user_to_machine.go — operator helper to convert a service-account-shaped
+// human user into a project machine identity (ADR-023).
+//
+// Early deployments often model CI runners, automation, and service accounts as
+// ordinary user records. ADR-023 keeps machine identities separate from humans so
+// the Members view can segment the two and a future machine-token auth path can
+// target them. This helper performs the one-way conversion: it materialises a
+// machine identity for the user and (by default) suspends the source account so
+// the human-login path is closed. The user is never deleted — suspension is
+// reversible and preserves audit/ownership history that may still reference it.
+package core
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// MigrateUserToMachine converts the user identified by username into an active
+// machine identity in projectID. identityType defaults to "service" and name
+// defaults to the user's username. When suspendSource is true the source user is
+// suspended (login blocked) so it can no longer authenticate as a human. actorID
+// is the acting admin, recorded on every audit event. The created machine
+// identity is returned.
+func (c *KeyorixCore) MigrateUserToMachine(ctx context.Context, username string, projectID uint, identityType, name string, actorID uint, suspendSource bool) (*models.MachineIdentity, error) {
+	if username == "" {
+		return nil, fmt.Errorf("username is required")
+	}
+	if projectID == 0 {
+		return nil, fmt.Errorf("project ID is required")
+	}
+
+	user, err := c.storage.GetUserByUsername(ctx, username)
+	if err != nil {
+		return nil, fmt.Errorf("user %q not found: %w", username, err)
+	}
+
+	if identityType == "" {
+		identityType = MachineTypeService
+	}
+	if name == "" {
+		name = user.Username
+	}
+	desc := fmt.Sprintf("Migrated from user %q (id %d, %s)", user.Username, user.ID, user.Email)
+
+	m, err := c.CreateMachineIdentity(ctx, projectID, name, identityType, desc, actorID)
+	if err != nil {
+		return nil, err
+	}
+
+	if suspendSource {
+		if err := c.SuspendUser(ctx, actorID, user.ID); err != nil {
+			// The identity exists; report the partial state so the operator can
+			// suspend the source user manually rather than silently leaving an
+			// active human login alongside the new machine identity.
+			return m, fmt.Errorf("machine identity %d created but failed to suspend source user %d: %w", m.ID, user.ID, err)
+		}
+	}
+
+	aid, pid := actorID, projectID
+	c.writeAuditEventFull(ctx, "machine_identity.migrated_from_user", &aid, nil, &pid, "",
+		fmt.Sprintf("user %q (id %d) migrated to machine identity %q (id %d) in project %d", user.Username, user.ID, m.Name, m.ID, projectID))
+
+	return m, nil
+}

--- a/internal/core/migrate_user_to_machine_test.go
+++ b/internal/core/migrate_user_to_machine_test.go
@@ -1,0 +1,85 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMigrateUserToMachine(t *testing.T) {
+	t.Run("creates a service identity, suspends the source user, and audits", func(t *testing.T) {
+		store := new(MockStorage)
+		c := newMachineCore(store)
+		ctx := context.Background()
+
+		store.On("GetUserByUsername", ctx, "ci-bot").
+			Return(&models.User{ID: 7, Username: "ci-bot", Email: "ci-bot@example.com", AccountState: "active"}, nil)
+		store.On("CreateMachineIdentity", ctx, mock.MatchedBy(func(m *models.MachineIdentity) bool {
+			return m.ProjectID == 3 && m.Name == "ci-bot" && m.IdentityType == MachineTypeService && m.State == MachineActive
+		})).Return(&models.MachineIdentity{ID: 20, ProjectID: 3, Name: "ci-bot", IdentityType: MachineTypeService, State: MachineActive}, nil)
+		// SuspendUser path: GetUser → UpdateUser(account_state=suspended).
+		store.On("GetUser", ctx, uint(7)).
+			Return(&models.User{ID: 7, Username: "ci-bot", AccountState: "active"}, nil)
+		store.On("UpdateUser", ctx, mock.MatchedBy(func(u *models.User) bool {
+			return u.ID == 7 && u.AccountState == AccountSuspended
+		})).Return(&models.User{ID: 7, AccountState: AccountSuspended}, nil)
+
+		seen := map[string]bool{}
+		store.On("LogAuditEvent", ctx, mock.MatchedBy(func(e *models.AuditEvent) bool {
+			seen[e.EventType] = true
+			return true
+		})).Return(nil)
+
+		m, err := c.MigrateUserToMachine(ctx, "ci-bot", 3, "", "", 9, true)
+		require.NoError(t, err)
+		assert.Equal(t, uint(20), m.ID)
+		assert.Equal(t, MachineTypeService, m.IdentityType)
+		assert.True(t, seen["machine_identity.created"], "create event")
+		assert.True(t, seen["account.suspended"], "suspend event")
+		assert.True(t, seen["machine_identity.migrated_from_user"], "migration event")
+		store.AssertExpectations(t)
+	})
+
+	t.Run("keep-user leaves the source account untouched", func(t *testing.T) {
+		store := new(MockStorage)
+		c := newMachineCore(store)
+		ctx := context.Background()
+
+		store.On("GetUserByUsername", ctx, "svc").
+			Return(&models.User{ID: 5, Username: "svc", Email: "svc@example.com"}, nil)
+		store.On("CreateMachineIdentity", ctx, mock.MatchedBy(func(m *models.MachineIdentity) bool {
+			return m.Name == "renamed" && m.IdentityType == MachineTypeAutomation
+		})).Return(&models.MachineIdentity{ID: 21, Name: "renamed", IdentityType: MachineTypeAutomation, State: MachineActive}, nil)
+		store.On("LogAuditEvent", ctx, mock.Anything).Return(nil)
+
+		_, err := c.MigrateUserToMachine(ctx, "svc", 1, MachineTypeAutomation, "renamed", 9, false)
+		require.NoError(t, err)
+		store.AssertNotCalled(t, "UpdateUser", mock.Anything, mock.Anything)
+		store.AssertExpectations(t)
+	})
+
+	t.Run("rejects an unknown user without creating anything", func(t *testing.T) {
+		store := new(MockStorage)
+		c := newMachineCore(store)
+		ctx := context.Background()
+		store.On("GetUserByUsername", ctx, "ghost").Return((*models.User)(nil), errors.New("not found"))
+
+		_, err := c.MigrateUserToMachine(ctx, "ghost", 1, "", "", 9, true)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "ghost")
+		store.AssertNotCalled(t, "CreateMachineIdentity", mock.Anything, mock.Anything)
+	})
+
+	t.Run("validates required inputs", func(t *testing.T) {
+		c := newMachineCore(new(MockStorage))
+		_, err := c.MigrateUserToMachine(context.Background(), "", 1, "", "", 9, true)
+		require.Error(t, err)
+		_, err = c.MigrateUserToMachine(context.Background(), "x", 0, "", "", 9, true)
+		require.Error(t, err)
+	})
+}


### PR DESCRIPTION
## What

Operator helper that converts a service-account-shaped human user into a project **machine identity** (ADR-023), closing the remaining "Machine Identities — migration helper" backlog item.

## Changes

- **`core.MigrateUserToMachine`** — looks up the user by username, creates an active machine identity in the target project (type defaults to `service`, name to the username), and — unless `--keep-user` is passed — **suspends** the source user so the human-login path is closed. The user is never deleted (suspension is reversible and preserves audit/ownership history). Audits the conversion via a new `machine_identity.migrated_from_user` event linking the two records.
- **`keyorix migrate` CLI group** + **`migrate user-to-machine <username>`** subcommand. Local mode only (operator tool): resolves the acting admin via `--by` and the project via `--project` / `KEYORIX_PROJECT` / active project, mirroring the user account-lifecycle CLI. Flags: `--project`, `--type`, `--name`, `--by` (required), `--keep-user`.

## Tests

- Core tests: suspend path (+ all three audit events), `--keep-user` leaves the account untouched, unknown-user rejected before any write, input validation.
- CLI structural tests: subcommand registration, `ExactArgs(1)`, flag presence.
- `go build` / `vet` / `gofmt` / `go test ./...` green; `migrate --help` and `migrate user-to-machine --help` render correctly.

## Notes

- Machine-token **authentication** for the migrated identity remains the separate ADR-023 follow-up (needs the machine-principal/RBAC model). This helper produces the identity record + closes the source login.

ADR-023.

🤖 Generated with [Claude Code](https://claude.com/claude-code)