### PR TITLE
feat(users): per-user project counts, assignments + stale-account API (ADR-025)

### DIFF
--- a/internal/core/account_state.go
+++ b/internal/core/account_state.go
@@ -18,6 +18,9 @@ package core
 import (
 	"context"
 	"fmt"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
 // Account states.
@@ -50,6 +53,18 @@ func AccountRestricted(state string) bool {
 // AccountLoginBlocked reports whether a state refuses login outright.
 func AccountLoginBlocked(state string) bool {
 	return NormalizeAccountState(state) == AccountSuspended
+}
+
+// StaleAccounts returns users that have sat in the given account_state longer
+// than olderThan — by default pending_first_login accounts an admin provisioned
+// but the user never completed (ADR-025 stale-account warnings; surfaced at >7
+// days). Oldest first.
+func (c *KeyorixCore) StaleAccounts(ctx context.Context, state string, olderThan time.Duration) ([]*models.User, error) {
+	if state == "" {
+		state = AccountPendingFirstLogin
+	}
+	before := c.now().Add(-olderThan)
+	return c.storage.ListUsersInStateBefore(ctx, state, before)
 }
 
 // SuspendUser blocks a user's login. Admin action; audited. The bootstrap/admin

--- a/internal/core/account_state_stale_test.go
+++ b/internal/core/account_state_stale_test.go
@@ -1,0 +1,55 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	stg "github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStaleAccounts_PassesCutoffAndDefaultsState(t *testing.T) {
+	store := new(MockStorage)
+	c := newMembershipCore(store)
+	ctx := context.Background()
+	want := c.now().Add(-7 * 24 * time.Hour)
+
+	// Empty state defaults to pending_first_login.
+	store.On("ListUsersInStateBefore", ctx, AccountPendingFirstLogin, want).
+		Return([]*models.User{{ID: 1, AccountState: AccountPendingFirstLogin}}, nil)
+
+	out, err := c.StaleAccounts(ctx, "", 7*24*time.Hour)
+	require.NoError(t, err)
+	assert.Len(t, out, 1)
+	store.AssertCalled(t, "ListUsersInStateBefore", ctx, AccountPendingFirstLogin, want)
+}
+
+func TestProjectMembershipCounts_Delegates(t *testing.T) {
+	store := new(MockStorage)
+	c := newMembershipCore(store)
+	ctx := context.Background()
+	ids := []uint{2, 3}
+	store.On("CountProjectMembershipsByUsers", ctx, ids).
+		Return(map[uint]stg.MembershipCounts{2: {Active: 1, Total: 2}}, nil)
+
+	got, err := c.ProjectMembershipCounts(ctx, ids)
+	require.NoError(t, err)
+	assert.Equal(t, 1, got[2].Active)
+	assert.Equal(t, 2, got[2].Total)
+}
+
+func TestListUserProjectMemberships_Delegates(t *testing.T) {
+	store := new(MockStorage)
+	c := newMembershipCore(store)
+	ctx := context.Background()
+	store.On("ListUserProjectMemberships", ctx, uint(2)).
+		Return([]*models.ProjectMembership{{ID: 9, ProjectID: 1, UserID: 2, State: "active"}}, nil)
+
+	out, err := c.ListUserProjectMemberships(ctx, 2)
+	require.NoError(t, err)
+	require.Len(t, out, 1)
+	assert.Equal(t, uint(9), out[0].ID)
+}

--- a/internal/core/membership_lifecycle.go
+++ b/internal/core/membership_lifecycle.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
@@ -224,6 +225,18 @@ func (c *KeyorixCore) ListProjectMemberships(ctx context.Context, projectID uint
 func (c *KeyorixCore) StaleInvites(ctx context.Context, olderThan time.Duration) ([]*models.ProjectMembership, error) {
 	before := c.now().Add(-olderThan)
 	return c.storage.ListStaleInvitedMemberships(ctx, before)
+}
+
+// ListUserProjectMemberships returns all membership rows for a single user
+// (ADR-025 per-user assignments view).
+func (c *KeyorixCore) ListUserProjectMemberships(ctx context.Context, userID uint) ([]*models.ProjectMembership, error) {
+	return c.storage.ListUserProjectMemberships(ctx, userID)
+}
+
+// ProjectMembershipCounts returns per-user project-membership tallies (active and
+// non-revoked total) for the given user IDs in one query (ADR-025 user list).
+func (c *KeyorixCore) ProjectMembershipCounts(ctx context.Context, userIDs []uint) (map[uint]storage.MembershipCounts, error) {
+	return c.storage.CountProjectMembershipsByUsers(ctx, userIDs)
 }
 
 // logMembershipEvent writes an audit event for a membership transition.

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -353,6 +353,14 @@ func (m *MockStorage) ListUsers(ctx context.Context, filter *storage.UserFilter)
 	return args.Get(0).([]*models.User), args.Get(1).(int64), args.Error(2)
 }
 
+func (m *MockStorage) ListUsersInStateBefore(ctx context.Context, state string, before time.Time) ([]*models.User, error) {
+	args := m.Called(ctx, state, before)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*models.User), args.Error(1)
+}
+
 func (m *MockStorage) GetUserByUsername(ctx context.Context, username string) (*models.User, error) {
 	args := m.Called(ctx, username)
 	if args.Get(0) == nil {
@@ -955,4 +963,20 @@ func (m *MockStorage) ListStaleInvitedMemberships(ctx context.Context, before ti
 		return nil, args.Error(1)
 	}
 	return args.Get(0).([]*models.ProjectMembership), args.Error(1)
+}
+
+func (m *MockStorage) ListUserProjectMemberships(ctx context.Context, userID uint) ([]*models.ProjectMembership, error) {
+	args := m.Called(ctx, userID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*models.ProjectMembership), args.Error(1)
+}
+
+func (m *MockStorage) CountProjectMembershipsByUsers(ctx context.Context, userIDs []uint) (map[uint]storage.MembershipCounts, error) {
+	args := m.Called(ctx, userIDs)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(map[uint]storage.MembershipCounts), args.Error(1)
 }

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -56,6 +56,12 @@ type Storage interface {
 	// ListStaleInvitedMemberships returns memberships still in `invited` state
 	// that were invited before the cutoff.
 	ListStaleInvitedMemberships(ctx context.Context, before time.Time) ([]*models.ProjectMembership, error)
+	// ListUserProjectMemberships returns all membership rows for a single user,
+	// newest first (powers the per-user assignments view).
+	ListUserProjectMemberships(ctx context.Context, userID uint) ([]*models.ProjectMembership, error)
+	// CountProjectMembershipsByUsers returns per-user membership tallies (active
+	// and non-revoked total) for the given user IDs in one grouped query.
+	CountProjectMembershipsByUsers(ctx context.Context, userIDs []uint) (map[uint]MembershipCounts, error)
 
 	// Secret Management
 	CreateSecret(ctx context.Context, secret *models.SecretNode) (*models.SecretNode, error)
@@ -92,6 +98,9 @@ type Storage interface {
 	DeleteUser(ctx context.Context, id uint) error
 	RestoreUser(ctx context.Context, id uint) error
 	ListUsers(ctx context.Context, filter *UserFilter) ([]*models.User, int64, error)
+	// ListUsersInStateBefore returns users whose account_state equals state and
+	// who were created before the cutoff (ADR-025 stale-account warnings).
+	ListUsersInStateBefore(ctx context.Context, state string, before time.Time) ([]*models.User, error)
 	GetUserByUsername(ctx context.Context, username string) (*models.User, error)
 	GetUserGroups(ctx context.Context, userID uint) ([]*models.Group, error)
 
@@ -262,6 +271,13 @@ type UserFilter struct {
 	IncludeDeleted bool // when true, also return soft-deleted users
 	Page           int
 	PageSize       int
+}
+
+// MembershipCounts holds a user's project-membership tallies: Active counts
+// memberships in the `active` state; Total counts all non-revoked memberships.
+type MembershipCounts struct {
+	Active int
+	Total  int
 }
 
 // AuditFilter defines filtering options for audit log queries

--- a/internal/storage/store/local_memberships.go
+++ b/internal/storage/store/local_memberships.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
@@ -68,4 +69,45 @@ func (ls *LocalStorage) ListStaleInvitedMemberships(ctx context.Context, before 
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
 	}
 	return rows, nil
+}
+
+func (ls *LocalStorage) ListUserProjectMemberships(ctx context.Context, userID uint) ([]*models.ProjectMembership, error) {
+	var rows []*models.ProjectMembership
+	err := ls.db.WithContext(ctx).
+		Where("user_id = ?", userID).
+		Order("invited_at DESC").
+		Find(&rows).Error
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	return rows, nil
+}
+
+func (ls *LocalStorage) CountProjectMembershipsByUsers(ctx context.Context, userIDs []uint) (map[uint]storage.MembershipCounts, error) {
+	counts := make(map[uint]storage.MembershipCounts, len(userIDs))
+	if len(userIDs) == 0 {
+		return counts, nil
+	}
+	// One grouped query: per user, active = state 'active', total = non-revoked.
+	// CASE/SUM keeps this valid on both SQLite (store tests) and Postgres.
+	var rows []struct {
+		UserID uint
+		Active int
+		Total  int
+	}
+	err := ls.db.WithContext(ctx).
+		Model(&models.ProjectMembership{}).
+		Select("user_id, "+
+			"SUM(CASE WHEN state = 'active' THEN 1 ELSE 0 END) AS active, "+
+			"SUM(CASE WHEN state <> 'revoked' THEN 1 ELSE 0 END) AS total").
+		Where("user_id IN ?", userIDs).
+		Group("user_id").
+		Scan(&rows).Error
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	for _, r := range rows {
+		counts[r.UserID] = storage.MembershipCounts{Active: r.Active, Total: r.Total}
+	}
+	return counts, nil
 }

--- a/internal/storage/store/local_users.go
+++ b/internal/storage/store/local_users.go
@@ -85,6 +85,22 @@ func (ls *LocalStorage) UpdateLastLogin(ctx context.Context, userID uint, loginA
 	return nil
 }
 
+// ListUsersInStateBefore returns users whose account_state equals state and who
+// were created before the cutoff, oldest first (ADR-025 stale-account warnings).
+// Legacy rows with an empty account_state normalise to "active" at the read
+// boundary, so they never match a restricted state like pending_first_login.
+func (ls *LocalStorage) ListUsersInStateBefore(ctx context.Context, state string, before time.Time) ([]*models.User, error) {
+	var users []*models.User
+	err := ls.db.WithContext(ctx).
+		Where("account_state = ? AND created_at < ?", state, before).
+		Order("created_at ASC").
+		Find(&users).Error
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	return users, nil
+}
+
 func (ls *LocalStorage) DeleteUser(ctx context.Context, id uint) error {
 	result := ls.db.WithContext(ctx).Delete(&models.User{}, id)
 	if result.Error != nil {

--- a/internal/storage/store/memberships_test.go
+++ b/internal/storage/store/memberships_test.go
@@ -83,3 +83,54 @@ func TestListStaleInvitedMemberships(t *testing.T) {
 	require.Len(t, stale, 1, "only the old invited membership is stale")
 	assert.Equal(t, "invited", stale[0].State)
 }
+
+func TestListUserProjectMemberships(t *testing.T) {
+	ctx := context.Background()
+	ls := newMembershipStore(t)
+	now := time.Now().UTC()
+
+	// Two memberships for user 2, one for user 3.
+	_, err := ls.CreateProjectMembership(ctx, &models.ProjectMembership{ProjectID: 1, UserID: 2, State: "active", InvitedAt: now.Add(-2 * time.Hour), UpdatedAt: now})
+	require.NoError(t, err)
+	_, err = ls.CreateProjectMembership(ctx, &models.ProjectMembership{ProjectID: 5, UserID: 2, State: "invited", InvitedAt: now.Add(-1 * time.Hour), UpdatedAt: now})
+	require.NoError(t, err)
+	_, err = ls.CreateProjectMembership(ctx, &models.ProjectMembership{ProjectID: 1, UserID: 3, State: "active", InvitedAt: now, UpdatedAt: now})
+	require.NoError(t, err)
+
+	rows, err := ls.ListUserProjectMemberships(ctx, 2)
+	require.NoError(t, err)
+	require.Len(t, rows, 2, "only user 2's memberships")
+	// Newest first (invited_at DESC): project 5 (most recent) before project 1.
+	assert.Equal(t, uint(5), rows[0].ProjectID)
+	assert.Equal(t, uint(1), rows[1].ProjectID)
+}
+
+func TestCountProjectMembershipsByUsers(t *testing.T) {
+	ctx := context.Background()
+	ls := newMembershipStore(t)
+	now := time.Now().UTC()
+
+	// User 2: 2 active + 1 invited + 1 revoked → active 2, total 3 (revoked excluded).
+	for _, st := range []string{"active", "active", "invited", "revoked"} {
+		_, err := ls.CreateProjectMembership(ctx, &models.ProjectMembership{ProjectID: 1, UserID: 2, State: st, InvitedAt: now, UpdatedAt: now})
+		require.NoError(t, err)
+	}
+	// User 3: 1 active.
+	_, err := ls.CreateProjectMembership(ctx, &models.ProjectMembership{ProjectID: 1, UserID: 3, State: "active", InvitedAt: now, UpdatedAt: now})
+	require.NoError(t, err)
+
+	counts, err := ls.CountProjectMembershipsByUsers(ctx, []uint{2, 3, 99})
+	require.NoError(t, err)
+	assert.Equal(t, 2, counts[2].Active)
+	assert.Equal(t, 3, counts[2].Total)
+	assert.Equal(t, 1, counts[3].Active)
+	assert.Equal(t, 1, counts[3].Total)
+	_, present := counts[99]
+	assert.False(t, present, "a user with no memberships is absent from the map")
+
+	// Empty input returns an empty (non-nil) map without a query.
+	empty, err := ls.CountProjectMembershipsByUsers(ctx, nil)
+	require.NoError(t, err)
+	assert.NotNil(t, empty)
+	assert.Empty(t, empty)
+}

--- a/internal/storage/store/remote_memberships.go
+++ b/internal/storage/store/remote_memberships.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
@@ -34,4 +35,12 @@ func (rs *RemoteStorage) GetActiveProjectMembership(_ context.Context, _, _ uint
 
 func (rs *RemoteStorage) ListStaleInvitedMemberships(_ context.Context, _ time.Time) ([]*models.ProjectMembership, error) {
 	return nil, fmt.Errorf("ListStaleInvitedMemberships not implemented for remote storage")
+}
+
+func (rs *RemoteStorage) ListUserProjectMemberships(_ context.Context, _ uint) ([]*models.ProjectMembership, error) {
+	return nil, fmt.Errorf("ListUserProjectMemberships not implemented for remote storage")
+}
+
+func (rs *RemoteStorage) CountProjectMembershipsByUsers(_ context.Context, _ []uint) (map[uint]storage.MembershipCounts, error) {
+	return nil, fmt.Errorf("CountProjectMembershipsByUsers not implemented for remote storage")
 }

--- a/internal/storage/store/remote_users.go
+++ b/internal/storage/store/remote_users.go
@@ -146,6 +146,10 @@ func (rs *RemoteStorage) ListUsers(ctx context.Context, filter *storage.UserFilt
 	return result.Users, result.Total, nil
 }
 
+func (rs *RemoteStorage) ListUsersInStateBefore(_ context.Context, _ string, _ time.Time) ([]*models.User, error) {
+	return nil, fmt.Errorf("ListUsersInStateBefore not implemented for remote storage")
+}
+
 // buildUserFilterPath constructs the /api/v1/users query string.
 func buildUserFilterPath(filter *storage.UserFilter) string {
 	if filter == nil {

--- a/internal/storage/store/stale_accounts_test.go
+++ b/internal/storage/store/stale_accounts_test.go
@@ -1,0 +1,54 @@
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func newUserStore(t *testing.T) *LocalStorage {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.User{}))
+	return NewLocalStorage(db)
+}
+
+func TestListUsersInStateBefore(t *testing.T) {
+	ctx := context.Background()
+	ls := newUserStore(t)
+	now := time.Now().UTC()
+
+	mk := func(username, state string, createdAt time.Time) {
+		t.Helper()
+		u := &models.User{Username: username, Email: username + "@x.com", AccountState: state}
+		_, err := ls.CreateUser(ctx, u)
+		require.NoError(t, err)
+		// CreateUser stamps created_at; force it for the cutoff assertions.
+		require.NoError(t, ls.db.WithContext(ctx).Model(&models.User{}).
+			Where("username = ?", username).UpdateColumn("created_at", createdAt).Error)
+	}
+
+	mk("old-pending", "pending_first_login", now.Add(-10*24*time.Hour))   // stale
+	mk("new-pending", "pending_first_login", now.Add(-1*24*time.Hour))    // too recent
+	mk("old-active", "active", now.Add(-10*24*time.Hour))                 // wrong state
+	mk("old-reset", "password_reset_required", now.Add(-10*24*time.Hour)) // other state
+
+	cutoff := now.Add(-7 * 24 * time.Hour)
+
+	pending, err := ls.ListUsersInStateBefore(ctx, "pending_first_login", cutoff)
+	require.NoError(t, err)
+	require.Len(t, pending, 1, "only the >7d pending account is stale")
+	assert.Equal(t, "old-pending", pending[0].Username)
+
+	reset, err := ls.ListUsersInStateBefore(ctx, "password_reset_required", cutoff)
+	require.NoError(t, err)
+	require.Len(t, reset, 1)
+	assert.Equal(t, "old-reset", reset[0].Username)
+}

--- a/server/http/handlers/users_crud.go
+++ b/server/http/handlers/users_crud.go
@@ -157,7 +157,9 @@ func (h *UserHandler) GetUser(w http.ResponseWriter, r *http.Request) {
 		sendError(w, "InternalError", "Failed to get user", http.StatusInternalServerError, nil)
 		return
 	}
-	sendSuccess(w, userToAPIResponse(u), "")
+	resp := userToAPIResponse(u)
+	h.attachProjectCounts(r.Context(), []map[string]interface{}{resp}, []uint{u.ID})
+	sendSuccess(w, resp, "")
 }
 
 // UpdateUser handles PUT /api/v1/users/{id}

--- a/server/http/handlers/users_enhancement_test.go
+++ b/server/http/handlers/users_enhancement_test.go
@@ -1,0 +1,120 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func setupUserEnhancementTest(t *testing.T) (*UserHandler, *UsersRolesHandler, *gorm.DB) {
+	t.Helper()
+	require.NoError(t, i18n.Initialize(&config.Config{
+		Locale: config.LocaleConfig{Language: "en", FallbackLanguage: "en"},
+	}))
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.User{}, &models.ProjectMembership{}, &models.Project{}))
+	coreService := core.NewKeyorixCore(store.NewLocalStorage(db))
+	uh, err := NewUserHandler(coreService)
+	require.NoError(t, err)
+	return uh, NewUsersRolesHandler(coreService), db
+}
+
+func decodeData(t *testing.T, w *httptest.ResponseRecorder) map[string]interface{} {
+	t.Helper()
+	var resp map[string]interface{}
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	data, ok := resp["data"].(map[string]interface{})
+	require.True(t, ok, "response has a data object")
+	return data
+}
+
+func TestStaleAccountsHandler(t *testing.T) {
+	uh, _, db := setupUserEnhancementTest(t)
+
+	// One stale pending account (>7d), one recent pending, one active old.
+	mk := func(name, state string, age time.Duration) {
+		require.NoError(t, db.Create(&models.User{Username: name, Email: name + "@x.com", AccountState: state}).Error)
+		require.NoError(t, db.Model(&models.User{}).Where("username = ?", name).
+			UpdateColumn("created_at", time.Now().Add(-age)).Error)
+	}
+	mk("stale-bot", core.AccountPendingFirstLogin, 10*24*time.Hour)
+	mk("fresh-bot", core.AccountPendingFirstLogin, 1*24*time.Hour)
+	mk("old-active", core.AccountActive, 30*24*time.Hour)
+
+	req := withUserCtx(httptest.NewRequest(http.MethodGet, "/api/v1/users/stale?days=7", nil))
+	w := httptest.NewRecorder()
+	uh.StaleAccounts(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	data := decodeData(t, w)
+	users := data["users"].([]interface{})
+	require.Len(t, users, 1, "only the >7d pending account")
+	assert.Equal(t, "stale-bot", users[0].(map[string]interface{})["username"])
+	assert.Equal(t, core.AccountPendingFirstLogin, data["state"])
+
+	// Unsupported state is a 400.
+	bad := withUserCtx(httptest.NewRequest(http.MethodGet, "/api/v1/users/stale?state=active", nil))
+	bw := httptest.NewRecorder()
+	uh.StaleAccounts(bw, bad)
+	assert.Equal(t, http.StatusBadRequest, bw.Code)
+}
+
+func TestListUsers_MergesProjectCounts(t *testing.T) {
+	uh, _, db := setupUserEnhancementTest(t)
+
+	require.NoError(t, db.Create(&models.User{Username: "alice", Email: "alice@x.com", AccountState: core.AccountActive}).Error)
+	var alice models.User
+	require.NoError(t, db.Where("username = ?", "alice").First(&alice).Error)
+	// 2 active + 1 revoked → active 2, total 2 (revoked excluded).
+	for _, st := range []string{"active", "active", "revoked"} {
+		require.NoError(t, db.Create(&models.ProjectMembership{ProjectID: 1, UserID: alice.ID, State: st}).Error)
+	}
+
+	req := withUserCtx(httptest.NewRequest(http.MethodGet, "/api/v1/users", nil))
+	w := httptest.NewRecorder()
+	uh.ListUsers(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	data := decodeData(t, w)
+	users := data["users"].([]interface{})
+	require.Len(t, users, 1)
+	u := users[0].(map[string]interface{})
+	assert.Equal(t, float64(2), u["active_project_count"])
+	assert.Equal(t, float64(2), u["project_count"])
+}
+
+func TestGetUserMembershipsHandler(t *testing.T) {
+	_, rh, db := setupUserEnhancementTest(t)
+
+	require.NoError(t, db.Create(&models.Project{Name: "payments"}).Error)
+	var proj models.Project
+	require.NoError(t, db.Where("name = ?", "payments").First(&proj).Error)
+	require.NoError(t, db.Create(&models.ProjectMembership{ProjectID: proj.ID, UserID: 42, Role: "project_developer", State: "active"}).Error)
+
+	req := withChiParam(withUserCtx(httptest.NewRequest(http.MethodGet, "/api/v1/users/42/memberships", nil)), "id", "42")
+	w := httptest.NewRecorder()
+	rh.GetUserMembershipsForUser(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	data := decodeData(t, w)
+	memberships := data["memberships"].([]interface{})
+	require.Len(t, memberships, 1)
+	m := memberships[0].(map[string]interface{})
+	assert.Equal(t, "payments", m["project_name"])
+	assert.Equal(t, "project_developer", m["role"])
+	assert.Equal(t, "active", m["state"])
+	assert.Equal(t, float64(proj.ID), m["project_id"])
+}

--- a/server/http/handlers/users_handler.go
+++ b/server/http/handlers/users_handler.go
@@ -222,6 +222,15 @@ func ListUsers(w http.ResponseWriter, r *http.Request) {
 	defaultUserHandler.ListUsers(w, r)
 }
 
+// StaleAccounts handles GET /api/v1/users/stale (ADR-025).
+func StaleAccounts(w http.ResponseWriter, r *http.Request) {
+	if defaultUserHandler == nil {
+		sendError(w, "ServiceUnavailable", "User handler not initialised", http.StatusServiceUnavailable, nil)
+		return
+	}
+	defaultUserHandler.StaleAccounts(w, r)
+}
+
 // CreateUser handles POST /api/v1/users
 func CreateUser(w http.ResponseWriter, r *http.Request) {
 	if defaultUserHandler == nil {

--- a/server/http/handlers/users_list.go
+++ b/server/http/handlers/users_list.go
@@ -5,12 +5,14 @@
 package handlers
 
 import (
+	"context"
 	"log"
 	"net/http"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/server/middleware"
 )
@@ -71,9 +73,12 @@ func (h *UserHandler) ListUsers(w http.ResponseWriter, r *http.Request) {
 	}
 
 	out := make([]map[string]interface{}, 0, len(users))
+	ids := make([]uint, 0, len(users))
 	for _, u := range users {
 		out = append(out, userToAPIResponse(u))
+		ids = append(ids, u.ID)
 	}
+	h.attachProjectCounts(r.Context(), out, ids)
 	totalPages := int64(0)
 	if pageSize > 0 {
 		totalPages = (total + int64(pageSize) - 1) / int64(pageSize)
@@ -118,4 +123,70 @@ func (h *UserHandler) SearchUsers(w http.ResponseWriter, r *http.Request) {
 		results = append(results, userResult{ID: u.ID, Username: u.Username, Email: u.Email})
 	}
 	sendSuccess(w, map[string]interface{}{"users": results}, "")
+}
+
+// attachProjectCounts merges each user's project-membership tallies
+// (project_count = non-revoked total, active_project_count = active) into the
+// already-built response maps via one grouped query. Best-effort: on error the
+// counts default to zero so the fields are always present (ADR-025).
+func (h *UserHandler) attachProjectCounts(ctx context.Context, resp []map[string]interface{}, ids []uint) {
+	var counts map[uint]storage.MembershipCounts
+	if len(ids) > 0 {
+		var err error
+		counts, err = h.coreService.ProjectMembershipCounts(ctx, ids)
+		if err != nil {
+			log.Printf("Error counting project memberships: %v", err)
+		}
+	}
+	for _, m := range resp {
+		id, _ := m["id"].(uint)
+		c := counts[id]
+		m["project_count"] = c.Total
+		m["active_project_count"] = c.Active
+	}
+}
+
+// staleAccountStates are the account states it makes sense to surface as "stuck":
+// an admin provisioned the account but the user never finished (ADR-025).
+var staleAccountStates = map[string]bool{
+	core.AccountPendingFirstLogin:     true,
+	core.AccountPasswordResetRequired: true,
+}
+
+// StaleAccounts serves GET /api/v1/users/stale?state=pending_first_login&days=7 —
+// users that have sat in a restricted state longer than the window (ADR-025).
+func (h *UserHandler) StaleAccounts(w http.ResponseWriter, r *http.Request) {
+	if middleware.GetUserFromContext(r.Context()) == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+
+	state := strings.TrimSpace(r.URL.Query().Get("state"))
+	if state == "" {
+		state = core.AccountPendingFirstLogin
+	}
+	if !staleAccountStates[state] {
+		sendError(w, "InvalidParameter", "Unsupported state (want pending_first_login or password_reset_required)", http.StatusBadRequest, nil)
+		return
+	}
+
+	days := 7
+	if d := r.URL.Query().Get("days"); d != "" {
+		if n, err := strconv.Atoi(d); err == nil && n >= 0 {
+			days = n
+		}
+	}
+
+	users, err := h.coreService.StaleAccounts(r.Context(), state, time.Duration(days)*24*time.Hour)
+	if err != nil {
+		log.Printf("Error listing stale accounts: %v", err)
+		sendError(w, "InternalError", "Failed to list stale accounts", http.StatusInternalServerError, nil)
+		return
+	}
+
+	out := make([]map[string]interface{}, 0, len(users))
+	for _, u := range users {
+		out = append(out, userToAPIResponse(u))
+	}
+	sendSuccess(w, map[string]interface{}{"users": out, "state": state, "days": days}, "")
 }

--- a/server/http/handlers/users_roles.go
+++ b/server/http/handlers/users_roles.go
@@ -69,6 +69,57 @@ func (h *UsersRolesHandler) GetUserRolesForUser(w http.ResponseWriter, r *http.R
 	sendSuccess(w, map[string]interface{}{"roles": apiRoles}, "")
 }
 
+// apiUserMembership is one row of a user's project-assignments view (ADR-025).
+type apiUserMembership struct {
+	ProjectID   uint   `json:"project_id"`
+	ProjectName string `json:"project_name"`
+	Role        string `json:"role"`
+	State       string `json:"state"`
+}
+
+// GetUserMembershipsForUser handles GET /api/v1/users/{id}/memberships (ADR-025) —
+// the user's project memberships with project name, role, and lifecycle state,
+// powering the per-user assignments table on the detail page.
+func (h *UsersRolesHandler) GetUserMembershipsForUser(w http.ResponseWriter, r *http.Request) {
+	if middleware.GetUserFromContext(r.Context()) == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+
+	userID, ok := parseUintParam(w, r, "id")
+	if !ok {
+		return
+	}
+
+	memberships, err := h.coreService.ListUserProjectMemberships(r.Context(), userID)
+	if err != nil {
+		log.Printf("Error getting memberships for user %d: %v", userID, err)
+		sendError(w, "InternalError", "Failed to get user memberships", http.StatusInternalServerError, nil)
+		return
+	}
+
+	// Resolve project names once for the rows.
+	nameByID := map[uint]string{}
+	if projects, perr := h.coreService.ListProjects(r.Context()); perr == nil {
+		for _, p := range projects {
+			nameByID[p.ID] = p.Name
+		}
+	} else {
+		log.Printf("Error listing projects for membership names: %v", perr)
+	}
+
+	out := make([]apiUserMembership, 0, len(memberships))
+	for _, m := range memberships {
+		out = append(out, apiUserMembership{
+			ProjectID:   m.ProjectID,
+			ProjectName: nameByID[m.ProjectID],
+			Role:        m.Role,
+			State:       m.State,
+		})
+	}
+	sendSuccess(w, map[string]interface{}{"memberships": out}, "")
+}
+
 // UpdateUserRoles handles PUT /api/v1/users/{id}/roles — full role replacement.
 func (h *UsersRolesHandler) UpdateUserRoles(w http.ResponseWriter, r *http.Request) {
 	if middleware.GetUserFromContext(r.Context()) == nil {

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -244,6 +244,8 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.Get("/", handlers.ListUsers)
 			r.Post("/", handlers.CreateUser)
 			r.Get("/search", handlers.SearchUsers)
+			// Stale-account warnings (ADR-025): static path before /{id}.
+			r.Get("/stale", handlers.StaleAccounts)
 			r.Get("/{id}", handlers.GetUser)
 			r.Put("/{id}", handlers.UpdateUser)
 			r.Delete("/{id}", handlers.DeleteUser)
@@ -256,6 +258,8 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.With(customMiddleware.RequirePermission("users.write")).Post("/{id}/resend-setup-link", handlers.ResendSetupLink)
 			r.Get("/{id}/roles", usersRolesHandler.GetUserRolesForUser)
 			r.Put("/{id}/roles", usersRolesHandler.UpdateUserRoles)
+			// Per-user project assignments for the detail page (ADR-025).
+			r.Get("/{id}/memberships", usersRolesHandler.GetUserMembershipsForUser)
 		})
 
 		// Admin impersonation — gated by users.impersonate, which only global


### PR DESCRIPTION
## What

Backend for the **User Management page enhancement** + **stale-account warnings** (ADR-025), surfacing the account-lifecycle machinery (ADR-025/028) in the admin API. Frontend (table badge/columns, per-user detail page, stale-warnings UI) follows in keyorix-web.

## Changes

- **Per-user project counts** — new `storage.CountProjectMembershipsByUsers` (one grouped query: `active` = state `active`, `total` = non-revoked) + `core.ProjectMembershipCounts`. `GET /users` and `GET /users/{id}` now carry `project_count` + `active_project_count` (best-effort merge; the fields are always present even on a count error).
- **Per-user assignments** — new `storage.ListUserProjectMemberships` + `core.ListUserProjectMemberships`, exposed as **`GET /users/{id}/memberships`** (project name + role + lifecycle state) for the detail-page assignments table.
- **Stale accounts** — new `storage.ListUsersInStateBefore` + `core.StaleAccounts` (mirrors the proven `StaleInvites` pattern), exposed as **`GET /users/stale?state=pending_first_login&days=7`** — surfaces accounts an admin provisioned but the user never completed. Validated to the restricted states (`pending_first_login` / `password_reset_required`); default window 7 days. Static route registered before `/{id}` so it isn't shadowed.

All gated by the existing `users.read` on the `/users` group. `MembershipCounts` type added to the storage interface; remote-storage stubs + mock updated.

## Tests

- Store (SQLite): counts (active vs non-revoked, absent users, empty input), per-user membership list ordering, stale-state cutoff.
- Core: `StaleAccounts` cutoff + default-state, count/list delegation.
- Handler (real core over SQLite): `/users/stale` (match + 400 on unsupported state), counts merge on `ListUsers`, `/users/{id}/memberships` shape.
- `go build` / `vet` / `gofmt` / `go test ./...` green.

ADR-025.

🤖 Generated with [Claude Code](https://claude.com/claude-code)