### PR TITLE
feat(notifications): in-app notifications + emit on membership/access events (ADR-024)

### DIFF
--- a/internal/core/invitations.go
+++ b/internal/core/invitations.go
@@ -210,6 +210,7 @@ func (c *KeyorixCore) RequestProjectAccess(ctx context.Context, projectID, userI
 	}
 	c.auditProjectScoped(ctx, "access_request.created", userID, projectID,
 		fmt.Sprintf("user %d requested %s access to project %d", userID, suggestedRole, projectID))
+	c.notifyAccessRequested(ctx, created)
 	return created, nil
 }
 
@@ -266,6 +267,7 @@ func (c *KeyorixCore) ApproveAccessRequest(ctx context.Context, requestID, appro
 	}
 	c.auditProjectScoped(ctx, "access_request.approved", approverID, req.ProjectID,
 		fmt.Sprintf("approved access request %d for user %d as %s", req.ID, req.UserID, role))
+	c.notifyAccessResolved(ctx, req, true)
 	return req, nil
 }
 
@@ -288,6 +290,7 @@ func (c *KeyorixCore) RejectAccessRequest(ctx context.Context, requestID, approv
 	}
 	c.auditProjectScoped(ctx, "access_request.rejected", approverID, req.ProjectID,
 		fmt.Sprintf("rejected access request %d for user %d", req.ID, req.UserID))
+	c.notifyAccessResolved(ctx, req, false)
 	return req, nil
 }
 

--- a/internal/core/invitations_test.go
+++ b/internal/core/invitations_test.go
@@ -64,6 +64,7 @@ func TestApproveAccessRequest_GrantsRole(t *testing.T) {
 		return e.EventType == "access_request.approved"
 	})).Return(nil)
 
+	allowNotifications(store) // best-effort outcome notification to the requester
 	out, err := c.ApproveAccessRequest(ctx, 3, 9, "project_developer")
 	require.NoError(t, err)
 	assert.Equal(t, AccessRequestApproved, out.State)
@@ -82,6 +83,7 @@ func TestApproveAccessRequest_FallsBackToSuggestedRole(t *testing.T) {
 	store.On("UpdateAccessRequest", ctx, mock.Anything).Return(nil)
 	store.On("LogAuditEvent", ctx, mock.Anything).Return(nil)
 
+	allowNotifications(store) // best-effort outcome notification to the requester
 	// Empty grantedRole → uses the suggested role.
 	out, err := c.ApproveAccessRequest(ctx, 3, 9, "")
 	require.NoError(t, err)

--- a/internal/core/membership_lifecycle.go
+++ b/internal/core/membership_lifecycle.go
@@ -194,6 +194,9 @@ func (c *KeyorixCore) TransitionMembership(ctx context.Context, membershipID uin
 	}
 
 	c.logMembershipEvent(ctx, "membership."+transitionVerb(to), m, actorID)
+	if to == MembershipActive {
+		c.notifyMembershipActivated(ctx, m)
+	}
 	return m, nil
 }
 

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -980,3 +980,32 @@ func (m *MockStorage) CountProjectMembershipsByUsers(ctx context.Context, userID
 	}
 	return args.Get(0).(map[uint]storage.MembershipCounts), args.Error(1)
 }
+
+func (m *MockStorage) CreateNotification(ctx context.Context, n *models.Notification) (*models.Notification, error) {
+	args := m.Called(ctx, n)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.Notification), args.Error(1)
+}
+
+func (m *MockStorage) ListNotifications(ctx context.Context, userID uint, unreadOnly bool, limit int) ([]*models.Notification, error) {
+	args := m.Called(ctx, userID, unreadOnly, limit)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*models.Notification), args.Error(1)
+}
+
+func (m *MockStorage) CountUnreadNotifications(ctx context.Context, userID uint) (int64, error) {
+	args := m.Called(ctx, userID)
+	return args.Get(0).(int64), args.Error(1)
+}
+
+func (m *MockStorage) MarkNotificationRead(ctx context.Context, id, userID uint) error {
+	return m.Called(ctx, id, userID).Error(0)
+}
+
+func (m *MockStorage) MarkAllNotificationsRead(ctx context.Context, userID uint) error {
+	return m.Called(ctx, userID).Error(0)
+}

--- a/internal/core/notifications.go
+++ b/internal/core/notifications.go
@@ -1,0 +1,135 @@
+// notifications.go — in-app notifications (ADR-024).
+//
+// Notifications are addressed to a single user and surfaced via the header bell.
+// Emission is best-effort: a delivery failure never blocks the action that
+// triggered it (same contract as audit emission). Delivery is in-app only;
+// email/Slack/Teams fan-out is an M3+ follow-up.
+package core
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// Notification types.
+const (
+	NotificationMembershipActivated = "membership.activated"
+	NotificationAccessRequested     = "access_request.created"
+	NotificationAccessApproved      = "access_request.approved"
+	NotificationAccessRejected      = "access_request.rejected"
+)
+
+// approverRoleNames are the project/system roles whose holders can approve access
+// requests — the recipients of a "new request" notification.
+var approverRoleNames = map[string]struct{}{
+	"project_admin": {}, "system_admin": {}, "admin": {}, "super_admin": {},
+}
+
+// isApproverRole reports whether holders of roleName can approve access requests.
+func isApproverRole(roleName string) bool {
+	_, ok := approverRoleNames[roleName]
+	return ok
+}
+
+// notify creates one in-app notification, best-effort (errors are swallowed so a
+// failed insert can't roll back the triggering action).
+func (c *KeyorixCore) notify(ctx context.Context, userID uint, nType, title, message string, projectID *uint, link string) {
+	if userID == 0 {
+		return
+	}
+	_, _ = c.storage.CreateNotification(ctx, &models.Notification{
+		UserID:    userID,
+		ProjectID: projectID,
+		Type:      nType,
+		Title:     title,
+		Message:   message,
+		Link:      link,
+		CreatedAt: c.now(),
+	})
+}
+
+// projectLabel returns a human label for a project ("Payments" or "#3").
+func (c *KeyorixCore) projectLabel(ctx context.Context, projectID uint) string {
+	if p, err := c.storage.GetProject(ctx, projectID); err == nil && p.Name != "" {
+		return p.Name
+	}
+	return fmt.Sprintf("#%d", projectID)
+}
+
+// notifyMembershipActivated tells the inviter their invitee is now active.
+func (c *KeyorixCore) notifyMembershipActivated(ctx context.Context, m *models.ProjectMembership) {
+	if m.InvitedBy == 0 || m.InvitedBy == m.UserID {
+		return // self-serve activation: nobody distinct to notify.
+	}
+	pid := m.ProjectID
+	link := fmt.Sprintf("/projects/%d", m.ProjectID)
+	c.notify(ctx, m.InvitedBy, NotificationMembershipActivated,
+		"Member activated",
+		fmt.Sprintf("User %d is now an active member of %s.", m.UserID, c.projectLabel(ctx, m.ProjectID)),
+		&pid, link)
+}
+
+// notifyAccessRequested fans a new-request notification out to project approvers.
+func (c *KeyorixCore) notifyAccessRequested(ctx context.Context, req *models.AccessRequest) {
+	members, err := c.storage.ListProjectMembers(ctx, req.ProjectID)
+	if err != nil {
+		return
+	}
+	pid := req.ProjectID
+	label := c.projectLabel(ctx, req.ProjectID)
+	link := fmt.Sprintf("/projects/%d", req.ProjectID)
+	for _, mbr := range members {
+		if mbr.UserID == req.UserID {
+			continue // don't notify the requester of their own request.
+		}
+		if !isApproverRole(mbr.RoleName) {
+			continue
+		}
+		c.notify(ctx, mbr.UserID, NotificationAccessRequested,
+			"New access request",
+			fmt.Sprintf("User %d requested %s access to %s.", req.UserID, req.SuggestedRole, label),
+			&pid, link)
+	}
+}
+
+// notifyAccessResolved tells the requester their request was approved/rejected.
+func (c *KeyorixCore) notifyAccessResolved(ctx context.Context, req *models.AccessRequest, approved bool) {
+	pid := req.ProjectID
+	label := c.projectLabel(ctx, req.ProjectID)
+	link := fmt.Sprintf("/projects/%d", req.ProjectID)
+	if approved {
+		c.notify(ctx, req.UserID, NotificationAccessApproved,
+			"Access request approved",
+			fmt.Sprintf("Your request for access to %s was approved as %s.", label, req.GrantedRole),
+			&pid, link)
+		return
+	}
+	c.notify(ctx, req.UserID, NotificationAccessRejected,
+		"Access request rejected",
+		fmt.Sprintf("Your request for access to %s was rejected.", label),
+		&pid, link)
+}
+
+// ── Self-scoped reads/writes (the authenticated user) ───────────────────────
+
+// ListNotifications returns the user's notifications, newest first.
+func (c *KeyorixCore) ListNotifications(ctx context.Context, userID uint, unreadOnly bool, limit int) ([]*models.Notification, error) {
+	return c.storage.ListNotifications(ctx, userID, unreadOnly, limit)
+}
+
+// UnreadNotificationCount returns how many unread notifications the user has.
+func (c *KeyorixCore) UnreadNotificationCount(ctx context.Context, userID uint) (int64, error) {
+	return c.storage.CountUnreadNotifications(ctx, userID)
+}
+
+// MarkNotificationRead marks one of the user's notifications read (ownership-checked).
+func (c *KeyorixCore) MarkNotificationRead(ctx context.Context, id, userID uint) error {
+	return c.storage.MarkNotificationRead(ctx, id, userID)
+}
+
+// MarkAllNotificationsRead marks all of the user's notifications read.
+func (c *KeyorixCore) MarkAllNotificationsRead(ctx context.Context, userID uint) error {
+	return c.storage.MarkAllNotificationsRead(ctx, userID)
+}

--- a/internal/core/notifications_test.go
+++ b/internal/core/notifications_test.go
@@ -1,0 +1,120 @@
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// allowNotifications registers a permissive expectation for the best-effort
+// CreateNotification side effect, so tests exercising an action that now emits a
+// notification don't fail on the extra storage call. (GetProject /
+// ListProjectMembers are hard-coded stubs in MockStorage, so they need no
+// expectation.) Shared across core tests.
+func allowNotifications(store *MockStorage) {
+	store.On("CreateNotification", mock.Anything, mock.Anything).
+		Return(&models.Notification{ID: 1}, nil).Maybe()
+}
+
+func TestIsApproverRole(t *testing.T) {
+	for _, r := range []string{"project_admin", "system_admin", "admin", "super_admin"} {
+		assert.True(t, isApproverRole(r), r)
+	}
+	for _, r := range []string{"project_viewer", "project_developer", "system_viewer", ""} {
+		assert.False(t, isApproverRole(r), r)
+	}
+}
+
+func TestNotifyMembershipActivated(t *testing.T) {
+	t.Run("notifies a distinct inviter with a project link", func(t *testing.T) {
+		store := new(MockStorage)
+		c := newMembershipCore(store)
+		ctx := context.Background()
+		var got *models.Notification
+		store.On("CreateNotification", ctx, mock.MatchedBy(func(n *models.Notification) bool {
+			got = n
+			return n.UserID == 9 && n.Type == NotificationMembershipActivated
+		})).Return(&models.Notification{ID: 1}, nil)
+
+		c.notifyMembershipActivated(ctx, &models.ProjectMembership{ProjectID: 1, UserID: 2, InvitedBy: 9})
+		store.AssertExpectations(t)
+		require.NotNil(t, got)
+		assert.Contains(t, got.Message, "active member")
+		assert.Equal(t, "/projects/1", got.Link)
+		require.NotNil(t, got.ProjectID)
+		assert.Equal(t, uint(1), *got.ProjectID)
+	})
+
+	t.Run("skips a self-invite (inviter == member)", func(t *testing.T) {
+		store := new(MockStorage)
+		c := newMembershipCore(store)
+		c.notifyMembershipActivated(context.Background(), &models.ProjectMembership{ProjectID: 1, UserID: 9, InvitedBy: 9})
+		store.AssertNotCalled(t, "CreateNotification", mock.Anything, mock.Anything)
+	})
+
+	t.Run("skips when there is no inviter", func(t *testing.T) {
+		store := new(MockStorage)
+		c := newMembershipCore(store)
+		c.notifyMembershipActivated(context.Background(), &models.ProjectMembership{ProjectID: 1, UserID: 2, InvitedBy: 0})
+		store.AssertNotCalled(t, "CreateNotification", mock.Anything, mock.Anything)
+	})
+}
+
+func TestNotifyAccessResolved_NotifiesRequester(t *testing.T) {
+	t.Run("approved", func(t *testing.T) {
+		store := new(MockStorage)
+		c := newMembershipCore(store)
+		ctx := context.Background()
+		var got *models.Notification
+		store.On("CreateNotification", ctx, mock.MatchedBy(func(n *models.Notification) bool {
+			got = n
+			return true
+		})).Return(&models.Notification{ID: 1}, nil)
+
+		c.notifyAccessResolved(ctx, &models.AccessRequest{ProjectID: 1, UserID: 2, GrantedRole: "project_developer"}, true)
+		require.NotNil(t, got)
+		assert.Equal(t, uint(2), got.UserID)
+		assert.Equal(t, NotificationAccessApproved, got.Type)
+		assert.Contains(t, got.Message, "project_developer")
+	})
+
+	t.Run("rejected", func(t *testing.T) {
+		store := new(MockStorage)
+		c := newMembershipCore(store)
+		ctx := context.Background()
+		var got *models.Notification
+		store.On("CreateNotification", ctx, mock.MatchedBy(func(n *models.Notification) bool {
+			got = n
+			return true
+		})).Return(&models.Notification{ID: 1}, nil)
+
+		c.notifyAccessResolved(ctx, &models.AccessRequest{ProjectID: 1, UserID: 2}, false)
+		require.NotNil(t, got)
+		assert.Equal(t, uint(2), got.UserID)
+		assert.Equal(t, NotificationAccessRejected, got.Type)
+	})
+}
+
+func TestNotificationSelfScopedDelegations(t *testing.T) {
+	store := new(MockStorage)
+	c := newMembershipCore(store)
+	ctx := context.Background()
+	store.On("ListNotifications", ctx, uint(2), true, 10).Return([]*models.Notification{{ID: 1}}, nil)
+	store.On("CountUnreadNotifications", ctx, uint(2)).Return(int64(3), nil)
+	store.On("MarkNotificationRead", ctx, uint(5), uint(2)).Return(nil)
+	store.On("MarkAllNotificationsRead", ctx, uint(2)).Return(nil)
+
+	items, err := c.ListNotifications(ctx, 2, true, 10)
+	require.NoError(t, err)
+	assert.Len(t, items, 1)
+	n, err := c.UnreadNotificationCount(ctx, 2)
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), n)
+	require.NoError(t, c.MarkNotificationRead(ctx, 5, 2))
+	require.NoError(t, c.MarkAllNotificationsRead(ctx, 2))
+	store.AssertExpectations(t)
+}

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -56,6 +56,16 @@ type Storage interface {
 	// ListStaleInvitedMemberships returns memberships still in `invited` state
 	// that were invited before the cutoff.
 	ListStaleInvitedMemberships(ctx context.Context, before time.Time) ([]*models.ProjectMembership, error)
+
+	// In-app notifications (ADR-024).
+	CreateNotification(ctx context.Context, n *models.Notification) (*models.Notification, error)
+	// ListNotifications returns a user's notifications newest-first; when
+	// unreadOnly is set, only unread ones. limit caps the result (0 = default).
+	ListNotifications(ctx context.Context, userID uint, unreadOnly bool, limit int) ([]*models.Notification, error)
+	CountUnreadNotifications(ctx context.Context, userID uint) (int64, error)
+	// MarkNotificationRead marks one notification read, scoped to its owner.
+	MarkNotificationRead(ctx context.Context, id, userID uint) error
+	MarkAllNotificationsRead(ctx context.Context, userID uint) error
 	// ListUserProjectMemberships returns all membership rows for a single user,
 	// newest first (powers the per-user assignments view).
 	ListUserProjectMemberships(ctx context.Context, userID uint) ([]*models.ProjectMembership, error)

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -234,6 +234,7 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 	machineExists := tableExists(db, "machine_identities")
 	membershipExists := tableExists(db, "project_memberships")
 	setupTokenExists := tableExists(db, "setup_tokens")
+	notificationsExists := tableExists(db, "notifications")
 
 	// Create rotation_policies if missing (additive, safe on existing DBs).
 	if !rotationExists {
@@ -286,6 +287,26 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 	if !setupTokenExists {
 		if err := db.AutoMigrate(&models.SetupToken{}); err != nil {
 			return fmt.Errorf("failed to migrate setup_tokens table: %w", err)
+		}
+	}
+
+	// Notifications (ADR-024). Create the table if absent; otherwise add only the
+	// newer ProjectID/Title/Link columns via the Migrator. We must NOT run a full
+	// AutoMigrate on an already-existing table here — on Postgres that re-inspect
+	// trips the pgx "insufficient arguments" prepared-statement bug mid-boot (the
+	// same hazard handled for the other additive tables above).
+	if !notificationsExists {
+		if err := db.AutoMigrate(&models.Notification{}); err != nil {
+			return fmt.Errorf("failed to migrate notifications table: %w", err)
+		}
+	} else {
+		m := db.Migrator()
+		for _, col := range []string{"ProjectID", "Title", "Link"} {
+			if !m.HasColumn(&models.Notification{}, col) {
+				if err := m.AddColumn(&models.Notification{}, col); err != nil {
+					return fmt.Errorf("failed to add notifications.%s column: %w", col, err)
+				}
+			}
 		}
 	}
 

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -286,13 +286,18 @@ type SecretTag struct {
 	TagID        uint `gorm:"primaryKey"`
 }
 
+// Notification is an in-app notification addressed to a single user (ADR-024).
+// Surfaced via the header bell; delivery is in-app only (email/Slack is M3+).
 type Notification struct {
 	ID           uint `gorm:"primaryKey"`
-	UserID       uint
+	UserID       uint `gorm:"index"`
 	SecretNodeID *uint
+	ProjectID    *uint // optional project context for the event
 	Type         string
+	Title        string
 	Message      string
-	IsRead       bool
+	Link         string // optional in-app target, e.g. /projects/{id}
+	IsRead       bool   `gorm:"index"`
 	CreatedAt    time.Time
 }
 

--- a/internal/storage/store/local_notifications.go
+++ b/internal/storage/store/local_notifications.go
@@ -1,0 +1,70 @@
+// local_notifications.go — in-app notification persistence (ADR-024).
+//
+// Notifications are addressed to a single user and surfaced via the header bell.
+// For the remote (HTTP) equivalent see remote_notifications.go.
+package store
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+const defaultNotificationLimit = 50
+
+func (ls *LocalStorage) CreateNotification(ctx context.Context, n *models.Notification) (*models.Notification, error) {
+	if err := ls.db.WithContext(ctx).Create(n).Error; err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	return n, nil
+}
+
+func (ls *LocalStorage) ListNotifications(ctx context.Context, userID uint, unreadOnly bool, limit int) ([]*models.Notification, error) {
+	if limit <= 0 || limit > 200 {
+		limit = defaultNotificationLimit
+	}
+	q := ls.db.WithContext(ctx).Where("user_id = ?", userID)
+	if unreadOnly {
+		q = q.Where("is_read = ?", false)
+	}
+	var rows []*models.Notification
+	if err := q.Order("created_at DESC").Limit(limit).Find(&rows).Error; err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	return rows, nil
+}
+
+func (ls *LocalStorage) CountUnreadNotifications(ctx context.Context, userID uint) (int64, error) {
+	var n int64
+	if err := ls.db.WithContext(ctx).Model(&models.Notification{}).
+		Where("user_id = ? AND is_read = ?", userID, false).
+		Count(&n).Error; err != nil {
+		return 0, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	return n, nil
+}
+
+func (ls *LocalStorage) MarkNotificationRead(ctx context.Context, id, userID uint) error {
+	res := ls.db.WithContext(ctx).Model(&models.Notification{}).
+		Where("id = ? AND user_id = ?", id, userID).
+		Update("is_read", true)
+	if res.Error != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), res.Error)
+	}
+	if res.RowsAffected == 0 {
+		// No row for this (id, user) — not found or not the caller's.
+		return fmt.Errorf("%s", i18n.T("ErrorNotFound", nil))
+	}
+	return nil
+}
+
+func (ls *LocalStorage) MarkAllNotificationsRead(ctx context.Context, userID uint) error {
+	if err := ls.db.WithContext(ctx).Model(&models.Notification{}).
+		Where("user_id = ? AND is_read = ?", userID, false).
+		Update("is_read", true).Error; err != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	return nil
+}

--- a/internal/storage/store/notifications_test.go
+++ b/internal/storage/store/notifications_test.go
@@ -1,0 +1,66 @@
+package store
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func newNotificationStore(t *testing.T) *LocalStorage {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.Notification{}))
+	return NewLocalStorage(db)
+}
+
+func TestNotifications_CRUD(t *testing.T) {
+	ctx := context.Background()
+	ls := newNotificationStore(t)
+
+	// User 2: two unread + one already read. User 3: one unread.
+	for _, n := range []*models.Notification{
+		{UserID: 2, Type: "a", Title: "A", Message: "m1"},
+		{UserID: 2, Type: "b", Title: "B", Message: "m2"},
+		{UserID: 2, Type: "c", Title: "C", Message: "m3", IsRead: true},
+		{UserID: 3, Type: "d", Title: "D", Message: "m4"},
+	} {
+		_, err := ls.CreateNotification(ctx, n)
+		require.NoError(t, err)
+	}
+
+	all, err := ls.ListNotifications(ctx, 2, false, 0)
+	require.NoError(t, err)
+	assert.Len(t, all, 3, "all of user 2's notifications")
+
+	unread, err := ls.ListNotifications(ctx, 2, true, 0)
+	require.NoError(t, err)
+	assert.Len(t, unread, 2, "only unread")
+
+	count, err := ls.CountUnreadNotifications(ctx, 2)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), count)
+
+	// Mark one (known-unread) read; the unread count drops.
+	require.NoError(t, ls.MarkNotificationRead(ctx, unread[0].ID, 2))
+	count, err = ls.CountUnreadNotifications(ctx, 2)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), count)
+
+	// Ownership: user 3 can't mark user 2's notification.
+	require.Error(t, ls.MarkNotificationRead(ctx, unread[1].ID, 3))
+
+	// Mark all read for user 2 → zero unread; user 3 untouched.
+	require.NoError(t, ls.MarkAllNotificationsRead(ctx, 2))
+	count, err = ls.CountUnreadNotifications(ctx, 2)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), count)
+	other, err := ls.CountUnreadNotifications(ctx, 3)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), other)
+}

--- a/internal/storage/store/remote_notifications.go
+++ b/internal/storage/store/remote_notifications.go
@@ -1,0 +1,32 @@
+// remote_notifications.go — in-app notifications for RemoteStorage.
+//
+// Notifications are processed server-side in remote mode; these are stubs. For
+// the local (GORM) equivalent see local_notifications.go.
+package store
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+func (rs *RemoteStorage) CreateNotification(_ context.Context, _ *models.Notification) (*models.Notification, error) {
+	return nil, fmt.Errorf("CreateNotification not implemented for remote storage")
+}
+
+func (rs *RemoteStorage) ListNotifications(_ context.Context, _ uint, _ bool, _ int) ([]*models.Notification, error) {
+	return nil, fmt.Errorf("ListNotifications not implemented for remote storage")
+}
+
+func (rs *RemoteStorage) CountUnreadNotifications(_ context.Context, _ uint) (int64, error) {
+	return 0, fmt.Errorf("CountUnreadNotifications not implemented for remote storage")
+}
+
+func (rs *RemoteStorage) MarkNotificationRead(_ context.Context, _, _ uint) error {
+	return fmt.Errorf("MarkNotificationRead not implemented for remote storage")
+}
+
+func (rs *RemoteStorage) MarkAllNotificationsRead(_ context.Context, _ uint) error {
+	return fmt.Errorf("MarkAllNotificationsRead not implemented for remote storage")
+}

--- a/server/http/handlers/notifications_handler.go
+++ b/server/http/handlers/notifications_handler.go
@@ -1,0 +1,117 @@
+// notifications_handler.go — self-scoped in-app notification endpoints (ADR-024).
+//
+// Every endpoint operates on the authenticated user's own notifications; there is
+// no permission gate (mirrors the My Account endpoints). Surfaced by the header
+// bell in the web client.
+package handlers
+
+import (
+	"log"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/server/middleware"
+)
+
+// NotificationHandler serves the authenticated user's notifications.
+type NotificationHandler struct {
+	coreService *core.KeyorixCore
+}
+
+// NewNotificationHandler constructs a NotificationHandler.
+func NewNotificationHandler(coreService *core.KeyorixCore) *NotificationHandler {
+	return &NotificationHandler{coreService: coreService}
+}
+
+func notificationToAPI(n *models.Notification) map[string]interface{} {
+	out := map[string]interface{}{
+		"id":         n.ID,
+		"type":       n.Type,
+		"title":      n.Title,
+		"message":    n.Message,
+		"link":       n.Link,
+		"is_read":    n.IsRead,
+		"created_at": n.CreatedAt.UTC().Format(time.RFC3339),
+	}
+	if n.ProjectID != nil {
+		out["project_id"] = *n.ProjectID
+	}
+	return out
+}
+
+// List handles GET /api/v1/notifications?unread=true&limit=20 — the user's
+// notifications (newest first) plus the unread count for the bell badge.
+func (h *NotificationHandler) List(w http.ResponseWriter, r *http.Request) {
+	u := middleware.GetUserFromContext(r.Context())
+	if u == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	unreadOnly := r.URL.Query().Get("unread") == "true"
+	limit := 0
+	if l := r.URL.Query().Get("limit"); l != "" {
+		if n, err := strconv.Atoi(l); err == nil && n > 0 {
+			limit = n
+		}
+	}
+
+	items, err := h.coreService.ListNotifications(r.Context(), u.UserID, unreadOnly, limit)
+	if err != nil {
+		log.Printf("Error listing notifications: %v", err)
+		sendError(w, "InternalError", "Failed to list notifications", http.StatusInternalServerError, nil)
+		return
+	}
+	count, err := h.coreService.UnreadNotificationCount(r.Context(), u.UserID)
+	if err != nil {
+		log.Printf("Error counting notifications: %v", err)
+		count = 0
+	}
+
+	out := make([]map[string]interface{}, 0, len(items))
+	for _, n := range items {
+		out = append(out, notificationToAPI(n))
+	}
+	sendSuccess(w, map[string]interface{}{"notifications": out, "unread_count": count}, "")
+}
+
+// MarkRead handles POST /api/v1/notifications/{id}/read.
+func (h *NotificationHandler) MarkRead(w http.ResponseWriter, r *http.Request) {
+	u := middleware.GetUserFromContext(r.Context())
+	if u == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	id, ok := parseUintParam(w, r, "id")
+	if !ok {
+		return
+	}
+	if err := h.coreService.MarkNotificationRead(r.Context(), id, u.UserID); err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			sendError(w, "NotFound", "Notification not found", http.StatusNotFound, nil)
+			return
+		}
+		log.Printf("Error marking notification read: %v", err)
+		sendError(w, "InternalError", "Failed to mark notification read", http.StatusInternalServerError, nil)
+		return
+	}
+	sendSuccess(w, map[string]interface{}{"id": id, "is_read": true}, "")
+}
+
+// MarkAllRead handles POST /api/v1/notifications/read-all.
+func (h *NotificationHandler) MarkAllRead(w http.ResponseWriter, r *http.Request) {
+	u := middleware.GetUserFromContext(r.Context())
+	if u == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	if err := h.coreService.MarkAllNotificationsRead(r.Context(), u.UserID); err != nil {
+		log.Printf("Error marking all notifications read: %v", err)
+		sendError(w, "InternalError", "Failed to mark notifications read", http.StatusInternalServerError, nil)
+		return
+	}
+	sendSuccess(w, map[string]interface{}{"all_read": true}, "")
+}

--- a/server/http/handlers/notifications_handler_test.go
+++ b/server/http/handlers/notifications_handler_test.go
@@ -1,0 +1,83 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func setupNotificationTest(t *testing.T) (*NotificationHandler, *gorm.DB) {
+	t.Helper()
+	require.NoError(t, i18n.Initialize(&config.Config{
+		Locale: config.LocaleConfig{Language: "en", FallbackLanguage: "en"},
+	}))
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.Notification{}))
+	coreService := core.NewKeyorixCore(store.NewLocalStorage(db))
+	return NewNotificationHandler(coreService), db
+}
+
+func TestNotificationHandler_ListMarkReadMarkAll(t *testing.T) {
+	h, db := setupNotificationTest(t)
+
+	// withUserCtx authenticates as user 1. Seed 2 for user 1 (one read) + 1 for user 2.
+	require.NoError(t, db.Create(&models.Notification{UserID: 1, Type: "a", Title: "A", Message: "m1"}).Error)
+	require.NoError(t, db.Create(&models.Notification{UserID: 1, Type: "b", Title: "B", Message: "m2", IsRead: true}).Error)
+	require.NoError(t, db.Create(&models.Notification{UserID: 2, Type: "c", Title: "C", Message: "m3"}).Error)
+
+	// List all for user 1 → 2 items, unread_count 1.
+	req := withUserCtx(httptest.NewRequest(http.MethodGet, "/api/v1/notifications", nil))
+	w := httptest.NewRecorder()
+	h.List(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+	data := decodeData(t, w)
+	assert.Len(t, data["notifications"].([]interface{}), 2)
+	assert.Equal(t, float64(1), data["unread_count"])
+
+	// List unread only → 1 item.
+	reqU := withUserCtx(httptest.NewRequest(http.MethodGet, "/api/v1/notifications?unread=true", nil))
+	wu := httptest.NewRecorder()
+	h.List(wu, reqU)
+	require.Equal(t, http.StatusOK, wu.Code)
+	assert.Len(t, decodeData(t, wu)["notifications"].([]interface{}), 1)
+
+	// Mark the unread one read → unread_count drops to 0.
+	var unread models.Notification
+	require.NoError(t, db.Where("user_id = ? AND is_read = ?", 1, false).First(&unread).Error)
+	mr := withChiParam(withUserCtx(httptest.NewRequest(http.MethodPost, "/x", nil)), "id", itoa(unread.ID))
+	wmr := httptest.NewRecorder()
+	h.MarkRead(wmr, mr)
+	require.Equal(t, http.StatusOK, wmr.Code)
+
+	wc := httptest.NewRecorder()
+	h.List(wc, withUserCtx(httptest.NewRequest(http.MethodGet, "/api/v1/notifications", nil)))
+	assert.Equal(t, float64(0), decodeData(t, wc)["unread_count"])
+
+	// Marking another user's notification → 404 (ownership).
+	var others models.Notification
+	require.NoError(t, db.Where("user_id = ?", 2).First(&others).Error)
+	w404 := httptest.NewRecorder()
+	h.MarkRead(w404, withChiParam(withUserCtx(httptest.NewRequest(http.MethodPost, "/x", nil)), "id", itoa(others.ID)))
+	assert.Equal(t, http.StatusNotFound, w404.Code)
+
+	// Mark-all-read is a clean 200.
+	wall := httptest.NewRecorder()
+	h.MarkAllRead(wall, withUserCtx(httptest.NewRequest(http.MethodPost, "/x", nil)))
+	assert.Equal(t, http.StatusOK, wall.Code)
+}
+
+func itoa(u uint) string {
+	return strconv.FormatUint(uint64(u), 10)
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -64,6 +64,7 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 	rotationPolicyHandler := handlers.NewRotationPolicyHandler(coreService)
 	rbacHandler := handlers.NewRBACHandler(coreService)
 	usersRolesHandler := handlers.NewUsersRolesHandler(coreService)
+	notificationHandler := handlers.NewNotificationHandler(coreService)
 
 	// Auth endpoints (no authentication middleware)
 	r.Post("/auth/login", authHandler.Login)
@@ -139,6 +140,11 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		r.Delete("/auth/tokens/{id}", patHandler.RevokePAT)
 		// Self-scoped: end the current impersonation session (no permission gate).
 		r.Post("/auth/end-impersonation", impersonationHandler.End)
+
+		// In-app notifications (ADR-024) — self-scoped, no permission gate.
+		r.Get("/notifications", notificationHandler.List)
+		r.Post("/notifications/read-all", notificationHandler.MarkAllRead)
+		r.Post("/notifications/{id}/read", notificationHandler.MarkRead)
 
 		// Dashboard endpoints
 		r.Get("/dashboard/stats", dashboardHandler.GetStats)


### PR DESCRIPTION
## What

Backend for the **in-app notifications** subsystem — the data + emit + API half of making the (currently inert) header bell real. Delivery is **in-app only**; email/Slack/Teams is M3+.

## Changes

- **Model** — extended the dormant `Notification` model with `ProjectID`/`Title`/`Link` (additive). Migration creates the table if absent, else adds only the new columns via the Migrator — **never a full AutoMigrate on an existing table**, which trips the pgx "insufficient arguments" bug mid-boot (the same hazard handled for the other additive tables).
- **Storage** — `CreateNotification` / `ListNotifications(unreadOnly, limit)` / `CountUnreadNotifications` / `MarkNotificationRead` (ownership-scoped) / `MarkAllNotificationsRead`, on the interface + local (GORM) + remote stub + mock.
- **Core** — best-effort emission (a failed insert never rolls back the triggering action, mirroring audit). Three triggers:
  - membership reaches `active` → notify the **inviter** (skipped for self-serve);
  - access request **created** → fan out to project **approvers** (`project_admin` / `system_admin` / `admin` / `super_admin`), skipping the requester;
  - access request **approved/rejected** → notify the **requester**.
- **HTTP** (self-scoped, no permission gate — like the My Account endpoints): `GET /api/v1/notifications?unread=&limit=`, `POST /notifications/{id}/read`, `POST /notifications/read-all`.

## Tests / verification

- Store tests (SQLite), core tests (emit logic, approver filter, self-scoped delegations), handler integration tests (real core over SQLite).
- **Verified end-to-end against Postgres**: approving an access request emits the notification (project name resolved to "default"), and `list` / `unread-count` / `mark-read` / `404-on-non-owned` / `mark-all-read` all behave. Caught + fixed a migration bug (unconditional AutoMigrate tripped pgx on the existing dev DB) during this step.
- `go build` / `vet` / `gofmt` / `go test ./...` green.

Frontend (header bell dropdown) follows in keyorix-web.

ADR-024.

🤖 Generated with [Claude Code](https://claude.com/claude-code)