### PR TITLE
feat(users): atomic create-with-role-and-project-assignments (ADR-028)

### DIFF
--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -361,6 +361,14 @@ func (m *MockStorage) ListUsersInStateBefore(ctx context.Context, state string, 
 	return args.Get(0).([]*models.User), args.Error(1)
 }
 
+func (m *MockStorage) CreateUserWithRoleGrants(ctx context.Context, user *models.User, grants []storage.RoleGrant) (*models.User, error) {
+	args := m.Called(ctx, user, grants)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.User), args.Error(1)
+}
+
 func (m *MockStorage) GetUserByUsername(ctx context.Context, username string) (*models.User, error) {
 	args := m.Called(ctx, username)
 	if args.Get(0) == nil {

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -99,6 +99,10 @@ type Storage interface {
 
 	// User Management
 	CreateUser(ctx context.Context, user *models.User) (*models.User, error)
+	// CreateUserWithRoleGrants creates the user and applies all role grants in a
+	// single transaction (ADR-028 atomic provisioning); on any failure nothing is
+	// persisted.
+	CreateUserWithRoleGrants(ctx context.Context, user *models.User, grants []RoleGrant) (*models.User, error)
 	GetUser(ctx context.Context, id uint) (*models.User, error)
 	GetUserByEmail(ctx context.Context, email string) (*models.User, error)
 	UpdateUser(ctx context.Context, user *models.User) (*models.User, error)
@@ -337,6 +341,13 @@ type RBACAuditFilter struct {
 type Scope struct {
 	ProjectID     uint
 	EnvironmentID uint
+}
+
+// RoleGrant is a single role-to-scope grant applied atomically alongside a user
+// creation (ADR-028 atomic provisioning).
+type RoleGrant struct {
+	RoleID uint
+	Scope  Scope
 }
 
 // Permission represents a fine-grained permission

--- a/internal/core/users.go
+++ b/internal/core/users.go
@@ -15,10 +15,18 @@ import (
 	"golang.org/x/crypto/bcrypt"
 )
 
-// CreateUser creates a new user with business logic validation.
-func (c *KeyorixCore) CreateUser(ctx context.Context, req *CreateUserRequest) (*models.User, error) {
+// ProjectAssignment grants Role to the new user at a project's scope, applied
+// atomically with the user create (ADR-028).
+type ProjectAssignment struct {
+	ProjectID uint
+	Role      string
+}
+
+// buildUserForCreate validates the request and constructs the (unsaved) user
+// record plus its bcrypt hash. Shared by CreateUser and CreateUserWithAssignments.
+func (c *KeyorixCore) buildUserForCreate(ctx context.Context, req *CreateUserRequest) (*models.User, string, error) {
 	if err := c.validateCreateUserRequest(req); err != nil {
-		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorValidation", nil), err)
+		return nil, "", fmt.Errorf("%s: %w", i18n.T("ErrorValidation", nil), err)
 	}
 
 	displayName := req.DisplayName
@@ -28,21 +36,21 @@ func (c *KeyorixCore) CreateUser(ctx context.Context, req *CreateUserRequest) (*
 
 	hash, err := bcrypt.GenerateFromPassword([]byte(req.Password), bcrypt.DefaultCost)
 	if err != nil {
-		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+		return nil, "", fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}
 
 	if _, err := c.storage.GetUserByUsername(ctx, req.Username); err == nil {
-		return nil, fmt.Errorf("%s: username already exists", i18n.T("ErrorValidation", nil))
+		return nil, "", fmt.Errorf("%s: username already exists", i18n.T("ErrorValidation", nil))
 	} else if err != nil && !strings.Contains(err.Error(), i18n.T("ErrorUserNotFound", nil)) {
-		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+		return nil, "", fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
 	}
 
 	existing, err := c.storage.GetUserByEmail(ctx, req.Email)
 	if err == nil && existing != nil {
-		return nil, fmt.Errorf("%s: user with email already exists", i18n.T("ErrorValidation", nil))
+		return nil, "", fmt.Errorf("%s: user with email already exists", i18n.T("ErrorValidation", nil))
 	}
 	if err != nil && !strings.Contains(err.Error(), i18n.T("ErrorUserNotFound", nil)) {
-		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+		return nil, "", fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
 	}
 
 	now := c.now()
@@ -61,6 +69,17 @@ func (c *KeyorixCore) CreateUser(ctx context.Context, req *CreateUserRequest) (*
 		CreatedAt:         now,
 		UpdatedAt:         now,
 	}
+	return user, string(hash), nil
+}
+
+// CreateUser creates a new user with business logic validation. It auto-assigns
+// the system_viewer baseline role (best-effort). For atomic create-with-role and
+// project assignments see CreateUserWithAssignments.
+func (c *KeyorixCore) CreateUser(ctx context.Context, req *CreateUserRequest) (*models.User, error) {
+	user, hash, err := c.buildUserForCreate(ctx, req)
+	if err != nil {
+		return nil, err
+	}
 
 	createdUser, err := c.storage.CreateUser(ctx, user)
 	if err != nil {
@@ -70,17 +89,77 @@ func (c *KeyorixCore) CreateUser(ctx context.Context, req *CreateUserRequest) (*
 	// Seed password history with the initial password so the no-reuse rule
 	// (ADR-025) counts it. Best-effort — user creation has already succeeded.
 	if c.passwordPolicy.HistoryCount > 0 {
-		_ = c.storage.AddPasswordHistory(ctx, createdUser.ID, string(hash), now)
+		_ = c.storage.AddPasswordHistory(ctx, createdUser.ID, hash, c.now())
 	}
 
 	// Auto-assign the system_viewer role (ADR-021): a minimal install-wide
-	// baseline. Real access to a project comes from a project role granted via the
-	// Members tab. Failure is non-fatal — the user is created regardless.
+	// baseline. Failure is non-fatal — the user is created regardless.
 	if role, err := c.storage.GetRoleByName(ctx, "system_viewer"); err == nil {
 		_ = c.storage.AssignRole(ctx, createdUser.ID, role.ID, Scope{})
 	}
 
 	return createdUser, nil
+}
+
+// CreateUserWithAssignments creates a user and grants a system role plus a set of
+// project-scoped roles in one transaction (ADR-028 atomic provisioning). All role
+// names and project IDs are resolved and validated up front, so an invalid input
+// fails before anything is written; a storage failure mid-way rolls everything
+// back. systemRole defaults to system_viewer when empty.
+func (c *KeyorixCore) CreateUserWithAssignments(ctx context.Context, req *CreateUserRequest, systemRole string, assignments []ProjectAssignment) (*models.User, error) {
+	user, hash, err := c.buildUserForCreate(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	// Resolve every grant before touching the database. Dedup by role+project so a
+	// repeated assignment can't trip the unique constraint inside the transaction.
+	grants := make([]storage.RoleGrant, 0, len(assignments)+1)
+	seen := map[[2]uint]bool{}
+	addGrant := func(roleID, projectID uint) {
+		key := [2]uint{roleID, projectID}
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		grants = append(grants, storage.RoleGrant{RoleID: roleID, Scope: storage.Scope{ProjectID: projectID}})
+	}
+
+	sysRole := systemRole
+	if sysRole == "" {
+		sysRole = "system_viewer"
+	}
+	sr, err := c.storage.GetRoleByName(ctx, sysRole)
+	if err != nil {
+		return nil, fmt.Errorf("%s: unknown role %q (system)", i18n.T("ErrorValidation", nil), sysRole)
+	}
+	addGrant(sr.ID, 0)
+
+	for _, a := range assignments {
+		if a.ProjectID == 0 || a.Role == "" {
+			return nil, fmt.Errorf("%s: each project assignment needs a project_id and a role", i18n.T("ErrorValidation", nil))
+		}
+		if _, err := c.storage.GetProject(ctx, a.ProjectID); err != nil {
+			return nil, fmt.Errorf("%s: unknown project %d", i18n.T("ErrorValidation", nil), a.ProjectID)
+		}
+		r, err := c.storage.GetRoleByName(ctx, a.Role)
+		if err != nil {
+			return nil, fmt.Errorf("%s: unknown role %q", i18n.T("ErrorValidation", nil), a.Role)
+		}
+		addGrant(r.ID, a.ProjectID)
+	}
+
+	created, err := c.storage.CreateUserWithRoleGrants(ctx, user, grants)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+
+	// Best-effort password-history seed, after the atomic create (ADR-025).
+	if c.passwordPolicy.HistoryCount > 0 {
+		_ = c.storage.AddPasswordHistory(ctx, created.ID, hash, c.now())
+	}
+
+	return created, nil
 }
 
 // GetUser retrieves a user by ID.

--- a/internal/storage/store/create_user_grants_test.go
+++ b/internal/storage/store/create_user_grants_test.go
@@ -1,0 +1,61 @@
+package store
+
+import (
+	"context"
+	"testing"
+
+	stg "github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func newUserGrantStore(t *testing.T) (*LocalStorage, *gorm.DB) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.User{}, &models.UserRole{}))
+	return NewLocalStorage(db), db
+}
+
+func TestCreateUserWithRoleGrants_AtomicSuccess(t *testing.T) {
+	ctx := context.Background()
+	ls, db := newUserGrantStore(t)
+
+	user := &models.User{Username: "atomic", Email: "atomic@x.io"}
+	grants := []stg.RoleGrant{
+		{RoleID: 1, Scope: stg.Scope{}},             // system role
+		{RoleID: 5, Scope: stg.Scope{ProjectID: 3}}, // project role
+	}
+	created, err := ls.CreateUserWithRoleGrants(ctx, user, grants)
+	require.NoError(t, err)
+	require.NotZero(t, created.ID)
+
+	var roles []models.UserRole
+	require.NoError(t, db.Where("user_id = ?", created.ID).Find(&roles).Error)
+	assert.Len(t, roles, 2)
+}
+
+func TestCreateUserWithRoleGrants_RollsBackOnGrantFailure(t *testing.T) {
+	ctx := context.Background()
+	ls, db := newUserGrantStore(t)
+
+	// Two identical grants collide on the UserRole composite PK; the second insert
+	// fails, so the whole transaction — including the user — must roll back.
+	user := &models.User{Username: "rollback", Email: "rollback@x.io"}
+	grants := []stg.RoleGrant{
+		{RoleID: 1, Scope: stg.Scope{ProjectID: 3}},
+		{RoleID: 1, Scope: stg.Scope{ProjectID: 3}},
+	}
+	_, err := ls.CreateUserWithRoleGrants(ctx, user, grants)
+	require.Error(t, err)
+
+	var userCount int64
+	require.NoError(t, db.Model(&models.User{}).Where("username = ?", "rollback").Count(&userCount).Error)
+	assert.Equal(t, int64(0), userCount, "user must not persist when a grant fails")
+	var roleCount int64
+	require.NoError(t, db.Model(&models.UserRole{}).Count(&roleCount).Error)
+	assert.Equal(t, int64(0), roleCount, "no role grants persist either")
+}

--- a/internal/storage/store/local_users.go
+++ b/internal/storage/store/local_users.go
@@ -30,6 +30,33 @@ func (ls *LocalStorage) CreateUser(ctx context.Context, user *models.User) (*mod
 	return user, nil
 }
 
+// CreateUserWithRoleGrants creates the user and every role grant inside one
+// transaction (ADR-028). If any grant insert fails, the user is rolled back too,
+// so a create never leaves a half-provisioned account.
+func (ls *LocalStorage) CreateUserWithRoleGrants(ctx context.Context, user *models.User, grants []storage.RoleGrant) (*models.User, error) {
+	err := ls.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Create(user).Error; err != nil {
+			return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+		}
+		for _, g := range grants {
+			ur := models.UserRole{
+				UserID:        user.ID,
+				RoleID:        g.RoleID,
+				ProjectID:     g.Scope.ProjectID,
+				EnvironmentID: g.Scope.EnvironmentID,
+			}
+			if err := tx.Create(&ur).Error; err != nil {
+				return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return user, nil
+}
+
 func (ls *LocalStorage) GetUser(ctx context.Context, id uint) (*models.User, error) {
 	var user models.User
 	if err := ls.db.WithContext(ctx).First(&user, id).Error; err != nil {

--- a/internal/storage/store/remote_users.go
+++ b/internal/storage/store/remote_users.go
@@ -150,6 +150,10 @@ func (rs *RemoteStorage) ListUsersInStateBefore(_ context.Context, _ string, _ t
 	return nil, fmt.Errorf("ListUsersInStateBefore not implemented for remote storage")
 }
 
+func (rs *RemoteStorage) CreateUserWithRoleGrants(_ context.Context, _ *models.User, _ []storage.RoleGrant) (*models.User, error) {
+	return nil, fmt.Errorf("CreateUserWithRoleGrants not implemented for remote storage")
+}
+
 // buildUserFilterPath constructs the /api/v1/users query string.
 func buildUserFilterPath(filter *storage.UserFilter) string {
 	if filter == nil {

--- a/server/http/handlers/create_user_assignments_test.go
+++ b/server/http/handlers/create_user_assignments_test.go
@@ -1,0 +1,99 @@
+package handlers
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func setupCreateUserAssignmentsTest(t *testing.T) (*UserHandler, *gorm.DB) {
+	t.Helper()
+	require.NoError(t, i18n.Initialize(&config.Config{
+		Locale: config.LocaleConfig{Language: "en", FallbackLanguage: "en"},
+	}))
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.User{}, &models.UserRole{}, &models.Role{}, &models.Project{}))
+	require.NoError(t, db.Create(&models.Role{Name: "system_viewer"}).Error)
+	require.NoError(t, db.Create(&models.Role{Name: "project_developer"}).Error)
+	require.NoError(t, db.Create(&models.Project{Name: "default"}).Error)
+	coreService := core.NewKeyorixCore(store.NewLocalStorage(db))
+	uh, err := NewUserHandler(coreService)
+	require.NoError(t, err)
+	return uh, db
+}
+
+func postCreateUser(t *testing.T, h *UserHandler, jsonBody string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := withUserCtx(httptest.NewRequest(http.MethodPost, "/api/v1/users", bytes.NewReader([]byte(jsonBody))))
+	w := httptest.NewRecorder()
+	h.CreateUser(w, req)
+	return w
+}
+
+func TestCreateUser_AtomicAssignments(t *testing.T) {
+	h, db := setupCreateUserAssignmentsTest(t)
+	var proj models.Project
+	require.NoError(t, db.Where("name = ?", "default").First(&proj).Error)
+
+	t.Run("creates the user with system + project role grants", func(t *testing.T) {
+		body := `{"username":"provisioned","email":"prov@x.io","display_name":"Prov","password":"Str0ng#Pass!word","role":"system_viewer","project_assignments":[{"project_id":` + itoa(proj.ID) + `,"role":"project_developer"}]}`
+		w := postCreateUser(t, h, body)
+		require.Equal(t, http.StatusCreated, w.Code)
+
+		var u models.User
+		require.NoError(t, db.Where("username = ?", "provisioned").First(&u).Error)
+		var roles []models.UserRole
+		require.NoError(t, db.Where("user_id = ?", u.ID).Find(&roles).Error)
+		require.Len(t, roles, 2)
+		// One global (system_viewer) + one at the project scope.
+		var globals, scoped int
+		for _, r := range roles {
+			if r.ProjectID == 0 {
+				globals++
+			} else if r.ProjectID == proj.ID {
+				scoped++
+			}
+		}
+		assert.Equal(t, 1, globals)
+		assert.Equal(t, 1, scoped)
+	})
+
+	t.Run("an unknown project rejects with 400 and creates no user", func(t *testing.T) {
+		body := `{"username":"badproj","email":"badproj@x.io","display_name":"Bad","password":"Str0ng#Pass!word","project_assignments":[{"project_id":9999,"role":"project_developer"}]}`
+		w := postCreateUser(t, h, body)
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		var n int64
+		require.NoError(t, db.Model(&models.User{}).Where("username = ?", "badproj").Count(&n).Error)
+		assert.Equal(t, int64(0), n)
+	})
+
+	t.Run("an unknown project role rejects with 400", func(t *testing.T) {
+		body := `{"username":"badrole","email":"badrole@x.io","display_name":"Bad","password":"Str0ng#Pass!word","project_assignments":[{"project_id":` + itoa(proj.ID) + `,"role":"nope"}]}`
+		w := postCreateUser(t, h, body)
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("an unknown system role rejects with 400", func(t *testing.T) {
+		body := `{"username":"badsys","email":"badsys@x.io","display_name":"Bad","password":"Str0ng#Pass!word","role":"nonexistent_role"}`
+		w := postCreateUser(t, h, body)
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("assignments combined with a setup link are rejected", func(t *testing.T) {
+		body := `{"username":"mix","email":"mix@x.io","display_name":"Mix","role":"system_viewer","deliver_setup_link":true}`
+		w := postCreateUser(t, h, body)
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+}

--- a/server/http/handlers/users_crud.go
+++ b/server/http/handlers/users_crud.go
@@ -16,6 +16,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/keyorixhq/keyorix/server/middleware"
 )
 
@@ -44,6 +45,14 @@ func (h *UserHandler) CreateUser(w http.ResponseWriter, r *http.Request) {
 		// password_reset_required state and the password is returned once for the admin
 		// to relay out-of-band (ADR-028 Part E). The user must change it on first login.
 		GenerateOneTimePassword bool `json:"generate_one_time_password,omitempty"`
+		// Atomic provisioning (ADR-028): an optional system role override and a set
+		// of project-scoped role assignments, applied with the create in one
+		// transaction. Supported on the admin-set-password path only.
+		Role               string `json:"role,omitempty"`
+		ProjectAssignments []struct {
+			ProjectID uint   `json:"project_id"`
+			Role      string `json:"role"`
+		} `json:"project_assignments,omitempty"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		sendError(w, "InvalidJSON", "Invalid JSON in request body", http.StatusBadRequest, nil)
@@ -66,6 +75,15 @@ func (h *UserHandler) CreateUser(w http.ResponseWriter, r *http.Request) {
 	// link, or generated one-time password.
 	if body.DeliverSetupLink && body.GenerateOneTimePassword {
 		sendError(w, "ValidationError", "Choose either deliver_setup_link or generate_one_time_password, not both", http.StatusBadRequest, nil)
+		return
+	}
+
+	// Atomic role/project assignments are supported only on the admin-set-password
+	// path for now (the setup-link / one-time-password paths create the account in
+	// a restricted state before the user finishes setup).
+	hasAssignments := body.Role != "" || len(body.ProjectAssignments) > 0
+	if hasAssignments && (body.DeliverSetupLink || body.GenerateOneTimePassword) {
+		sendError(w, "ValidationError", "role/project_assignments are only supported with an admin-set password", http.StatusBadRequest, nil)
 		return
 	}
 
@@ -119,14 +137,29 @@ func (h *UserHandler) CreateUser(w http.ResponseWriter, r *http.Request) {
 		sendError(w, "ValidationError", "Password is required unless deliver_setup_link or generate_one_time_password is set", http.StatusBadRequest, nil)
 		return
 	}
-	created, err := h.coreService.CreateUser(r.Context(), req)
+
+	var created *models.User
+	var err error
+	if hasAssignments {
+		assignments := make([]core.ProjectAssignment, 0, len(body.ProjectAssignments))
+		for _, a := range body.ProjectAssignments {
+			assignments = append(assignments, core.ProjectAssignment{ProjectID: a.ProjectID, Role: a.Role})
+		}
+		created, err = h.coreService.CreateUserWithAssignments(r.Context(), req, body.Role, assignments)
+	} else {
+		created, err = h.coreService.CreateUser(r.Context(), req)
+	}
 	if err != nil {
 		log.Printf("Error creating user: %v", err)
-		if strings.Contains(err.Error(), "already exists") {
+		switch {
+		case strings.Contains(err.Error(), "already exists"):
 			sendError(w, "ConflictError", "User already exists", http.StatusConflict, nil)
-			return
+		case strings.Contains(err.Error(), "unknown role"), strings.Contains(err.Error(), "unknown project"),
+			strings.Contains(err.Error(), "each project assignment"):
+			sendError(w, "ValidationError", err.Error(), http.StatusBadRequest, nil)
+		default:
+			sendError(w, "InternalError", "Failed to create user", http.StatusInternalServerError, nil)
 		}
-		sendError(w, "InternalError", "Failed to create user", http.StatusInternalServerError, nil)
 		return
 	}
 


### PR DESCRIPTION
## What

`POST /api/v1/users` (admin-set-password path) now accepts an optional system `role` and a set of `project_assignments`, applied **with the user create in one transaction** — so the Global-Admin "create a fully-provisioned user in one go" dialog no longer risks partial-failure states.

## Changes

- **Storage** — new `RoleGrant` type + `CreateUserWithRoleGrants`: creates the user and every role grant inside a single GORM transaction; a grant failure rolls the user back too. Interface + local + remote stub + mock.
- **Core** — extracted `buildUserForCreate` (shared validation / hash / dup-check) and added `CreateUserWithAssignments`: resolves and validates the system role + every project assignment (role names + project IDs) **up front**, so invalid input fails before any write; dedups grants; then commits atomically. System role defaults to `system_viewer`. Existing `CreateUser` is unchanged (still best-effort baseline).
- **Handler** — the classic password path routes to the atomic method when `role`/`project_assignments` are present; unknown role/project → 400, dup → 409. Assignments combined with setup-link / one-time-password are rejected (those restricted-state modes are a follow-up).

## Tests / verification

- Store tests (atomic success + rollback on a grant PK collision) and handler integration tests (grants land, unknown project/role → 400, setup-link combo → 400).
- **Verified end-to-end against Postgres**: a user created with assignments holds both `system_viewer` and the project role; an unknown project/role rolls back with 400 and leaves no user. (Caught + fixed a 500-vs-400 mismatch on the unknown-system-role path during verify — also caught a stale-server gotcha mid-verification.)
- `go build` / `vet` / `gofmt` / `go test ./...` green.

Frontend (Global-Admin create dialog with a project-assignment selector) is the follow-on.

ADR-028.

🤖 Generated with [Claude Code](https://claude.com/claude-code)