### PR TITLE
feat(invitations): atomic global invitation — system role + project assignments (ADR-024)

### DIFF
--- a/internal/core/invitation_global_test.go
+++ b/internal/core/invitation_global_test.go
@@ -1,0 +1,139 @@
+package core
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInviteGlobal_ValidatesAndSnapshotsAssignments(t *testing.T) {
+	store := new(MockStorage)
+	c := newInviteCore(store)
+	ctx := context.Background()
+
+	// GetProject is a fixed stub in the mock (always resolves), so only roles are
+	// asserted here.
+	store.On("GetRoleByName", ctx, "system_auditor").Return(&models.Role{ID: 3, Name: "system_auditor"}, nil)
+	store.On("GetRoleByName", ctx, "project_developer").Return(&models.Role{ID: 5}, nil)
+	store.On("GetRoleByName", ctx, "project_viewer").Return(&models.Role{ID: 6}, nil)
+	store.On("CreateProjectInvitation", ctx, mock.MatchedBy(func(inv *models.ProjectInvitation) bool {
+		// Global invite: no project scope, system role set, assignments snapshotted.
+		if inv.ProjectID != 0 || inv.Role != "" || inv.SystemRole != "system_auditor" || inv.State != InvitationPending {
+			return false
+		}
+		var got []ProjectAssignment
+		if err := json.Unmarshal([]byte(inv.AssignmentsJSON), &got); err != nil {
+			return false
+		}
+		return len(got) == 2 // 3 in → one deduped
+	})).Return(&models.ProjectInvitation{ID: 12, State: InvitationPending}, nil)
+	store.On("LogAuditEvent", ctx, mock.MatchedBy(func(e *models.AuditEvent) bool {
+		return e.EventType == "invitation.created"
+	})).Return(nil)
+
+	inv, err := c.InviteGlobal(ctx, "carol@acme.io", "system_auditor", []ProjectAssignment{
+		{ProjectID: 1, Role: "project_developer"},
+		{ProjectID: 2, Role: "project_viewer"},
+		{ProjectID: 1, Role: "project_viewer"}, // duplicate project — deduped
+	}, 9)
+
+	require.NoError(t, err)
+	assert.Equal(t, InvitationPending, inv.State)
+	store.AssertExpectations(t)
+}
+
+func TestInviteGlobal_RejectsUnknownRole(t *testing.T) {
+	store := new(MockStorage)
+	c := newInviteCore(store)
+	ctx := context.Background()
+
+	store.On("GetRoleByName", ctx, "system_viewer").Return(&models.Role{ID: 1}, nil)
+	store.On("GetRoleByName", ctx, "bogus_role").Return(nil, assertNotFoundErr())
+
+	_, err := c.InviteGlobal(ctx, "carol@acme.io", "", []ProjectAssignment{
+		{ProjectID: 1, Role: "bogus_role"},
+	}, 9)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown role")
+	// Nothing persisted on a validation failure.
+	store.AssertNotCalled(t, "CreateProjectInvitation", mock.Anything, mock.Anything)
+}
+
+func TestInviteGlobal_RejectsAssignmentMissingRole(t *testing.T) {
+	store := new(MockStorage)
+	c := newInviteCore(store)
+	ctx := context.Background()
+
+	store.On("GetRoleByName", ctx, "system_viewer").Return(&models.Role{ID: 1}, nil)
+
+	_, err := c.InviteGlobal(ctx, "carol@acme.io", "", []ProjectAssignment{
+		{ProjectID: 1, Role: ""},
+	}, 9)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "needs a project_id and a role")
+	store.AssertNotCalled(t, "CreateProjectInvitation", mock.Anything, mock.Anything)
+}
+
+func TestInviteGlobal_DefaultsSystemViewer(t *testing.T) {
+	store := new(MockStorage)
+	c := newInviteCore(store)
+	ctx := context.Background()
+
+	store.On("GetRoleByName", ctx, "system_viewer").Return(&models.Role{ID: 1, Name: "system_viewer"}, nil)
+	store.On("CreateProjectInvitation", ctx, mock.MatchedBy(func(inv *models.ProjectInvitation) bool {
+		return inv.SystemRole == "system_viewer" && inv.AssignmentsJSON == ""
+	})).Return(&models.ProjectInvitation{ID: 13, State: InvitationPending}, nil)
+	store.On("LogAuditEvent", ctx, mock.Anything).Return(nil)
+
+	_, err := c.InviteGlobal(ctx, "dave@acme.io", "", nil, 9)
+	require.NoError(t, err)
+	store.AssertExpectations(t)
+}
+
+// applyInvitationGrants on a global invite must grant the system role at scope 0
+// plus one membership per assignment.
+func TestApplyInvitationGrants_GlobalInvite(t *testing.T) {
+	store := new(MockStorage)
+	c := newInviteCore(store)
+	anyAudit(store)
+	ctx := context.Background()
+
+	assignments, _ := json.Marshal([]ProjectAssignment{
+		{ProjectID: 1, Role: "project_developer"},
+		{ProjectID: 2, Role: "project_viewer"},
+	})
+	inv := &models.ProjectInvitation{
+		ID: 12, ProjectID: 0, Email: "carol@acme.io", InvitedBy: 9,
+		SystemRole: "system_auditor", AssignmentsJSON: string(assignments),
+		ValidationModeAtInvite: ValidationModeOpen,
+	}
+
+	// System role grant at scope 0.
+	store.On("GetRoleByName", ctx, "system_auditor").Return(&models.Role{ID: 3}, nil)
+	store.On("AssignRole", ctx, uint(20), uint(3), storage.Scope{ProjectID: 0}).Return(nil)
+	// One membership per assignment (open mode → active → role granted).
+	for _, a := range []struct {
+		pid    uint
+		role   string
+		roleID uint
+	}{{1, "project_developer", 5}, {2, "project_viewer", 6}} {
+		store.On("GetRoleByName", ctx, a.role).Return(&models.Role{ID: a.roleID, Name: a.role}, nil)
+		store.On("GetActiveProjectMembership", ctx, a.pid, uint(20)).Return(nil, assertNotFoundErr())
+		store.On("CreateProjectMembership", ctx, mock.MatchedBy(func(m *models.ProjectMembership) bool {
+			return m.ProjectID == a.pid && m.UserID == 20
+		})).Return(&models.ProjectMembership{ProjectID: a.pid, UserID: 20, Role: a.role, State: MembershipActive}, nil)
+		store.On("AssignRole", ctx, uint(20), a.roleID, storage.Scope{ProjectID: a.pid}).Return(nil)
+	}
+
+	err := c.applyInvitationGrants(ctx, inv, 20)
+	require.NoError(t, err)
+	store.AssertExpectations(t)
+}

--- a/internal/core/invitations.go
+++ b/internal/core/invitations.go
@@ -15,6 +15,7 @@ package core
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -100,6 +101,131 @@ func (c *KeyorixCore) InviteToProjectWithLink(ctx context.Context, projectID uin
 		return inv, nil, err
 	}
 	return inv, prov, nil
+}
+
+// InviteGlobal creates a non-project-scoped invitation (ProjectID 0) that, on
+// accept, grants a system role plus a set of project assignments in one go — the
+// invitation analogue of CreateUserWithAssignments (ADR-024/028). The system role
+// and every assignment (project + role) are validated and deduped up front, so
+// acceptance can't later fail on an unknown role or project. The per-project
+// grants are snapshotted as JSON on the invitation.
+func (c *KeyorixCore) InviteGlobal(ctx context.Context, email, systemRole string, assignments []ProjectAssignment, invitedBy uint) (*models.ProjectInvitation, error) {
+	if email == "" {
+		return nil, fmt.Errorf("email is required")
+	}
+	sysRole := systemRole
+	if sysRole == "" {
+		sysRole = "system_viewer"
+	}
+	if _, err := c.storage.GetRoleByName(ctx, sysRole); err != nil {
+		return nil, fmt.Errorf("unknown role %q (system): %w", sysRole, err)
+	}
+
+	// Validate + dedup assignments before persisting anything.
+	seen := map[uint]bool{}
+	clean := make([]ProjectAssignment, 0, len(assignments))
+	for _, a := range assignments {
+		if a.ProjectID == 0 || a.Role == "" {
+			return nil, fmt.Errorf("each project assignment needs a project_id and a role")
+		}
+		if seen[a.ProjectID] {
+			continue
+		}
+		seen[a.ProjectID] = true
+		if _, err := c.storage.GetProject(ctx, a.ProjectID); err != nil {
+			return nil, fmt.Errorf("unknown project %d: %w", a.ProjectID, err)
+		}
+		if _, err := c.storage.GetRoleByName(ctx, a.Role); err != nil {
+			return nil, fmt.Errorf("unknown role %q: %w", a.Role, err)
+		}
+		clean = append(clean, ProjectAssignment{ProjectID: a.ProjectID, Role: a.Role})
+	}
+	assignJSON := ""
+	if len(clean) > 0 {
+		b, err := json.Marshal(clean)
+		if err != nil {
+			return nil, fmt.Errorf("failed to encode assignments: %w", err)
+		}
+		assignJSON = string(b)
+	}
+
+	now := c.now()
+	expires := now.Add(invitationTTL)
+	inv := &models.ProjectInvitation{
+		ProjectID:              0, // global
+		Email:                  email,
+		Role:                   "",
+		State:                  InvitationPending,
+		InvitedBy:              invitedBy,
+		SystemRole:             sysRole,
+		AssignmentsJSON:        assignJSON,
+		ValidationModeAtInvite: c.validationMode(),
+		ExpiresAt:              &expires,
+		CreatedAt:              now,
+	}
+	created, err := c.storage.CreateProjectInvitation(ctx, inv)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create invitation: %w", err)
+	}
+	c.auditProjectScoped(ctx, "invitation.created", invitedBy, 0,
+		fmt.Sprintf("invited %s globally as %s with %d project assignment(s)", email, sysRole, len(clean)))
+	return created, nil
+}
+
+// InviteGlobalWithLink creates a global invitation and provisions its accept link
+// (ADR-028), mirroring InviteToProjectWithLink. A nil result with a non-nil error
+// and a non-nil invitation means the invite exists but the link couldn't be
+// delivered (e.g. base_url unset) — the caller can resend.
+func (c *KeyorixCore) InviteGlobalWithLink(ctx context.Context, email, systemRole string, assignments []ProjectAssignment, invitedBy uint) (*models.ProjectInvitation, *ProvisionSetupResult, error) {
+	inv, err := c.InviteGlobal(ctx, email, systemRole, assignments, invitedBy)
+	if err != nil {
+		return nil, nil, err
+	}
+	prov, err := c.provisionSetupLink(ctx, IssueSetupTokenRequest{
+		Purpose:      SetupPurposeInvitationAccept,
+		SubjectEmail: email,
+		InvitationID: &inv.ID,
+		CreatedBy:    invitedBy,
+	}, "", fmt.Sprintf("%s + %d project assignment(s)", inv.SystemRole, len(assignments)))
+	if err != nil {
+		return inv, nil, err
+	}
+	return inv, prov, nil
+}
+
+// applyInvitationGrants materializes an invitation's role grants onto a freshly
+// created (accepting) user. A global invite (ADR-024) grants its system role plus
+// each project assignment from AssignmentsJSON; a project-scoped invite grants the
+// single project role. Everything was validated at invite time, so a failure here
+// is a storage error (leaving the invitation pending/resendable), not bad input.
+func (c *KeyorixCore) applyInvitationGrants(ctx context.Context, inv *models.ProjectInvitation, userID uint) error {
+	// Global invite: system role + multi-project assignments.
+	if inv.SystemRole != "" || inv.AssignmentsJSON != "" {
+		if inv.SystemRole != "" {
+			role, err := c.storage.GetRoleByName(ctx, inv.SystemRole)
+			if err != nil {
+				return fmt.Errorf("unknown system role %q: %w", inv.SystemRole, err)
+			}
+			if err := c.storage.AssignRole(ctx, userID, role.ID, storage.Scope{ProjectID: 0}); err != nil {
+				return fmt.Errorf("failed to grant system role: %w", err)
+			}
+		}
+		if inv.AssignmentsJSON != "" {
+			var assignments []ProjectAssignment
+			if err := json.Unmarshal([]byte(inv.AssignmentsJSON), &assignments); err != nil {
+				return fmt.Errorf("failed to decode assignments: %w", err)
+			}
+			for _, a := range assignments {
+				if _, err := c.inviteMemberWithMode(ctx, a.ProjectID, userID, a.Role, inv.InvitedBy, inv.ValidationModeAtInvite, false); err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	}
+	// Project-scoped invite: single project membership.
+	_, err := c.inviteMemberWithMode(ctx, inv.ProjectID, userID, inv.Role, inv.InvitedBy, inv.ValidationModeAtInvite, false)
+	return err
 }
 
 // ResendInvitationLink reissues the accept link for a still-pending invitation

--- a/internal/core/setup_consume.go
+++ b/internal/core/setup_consume.go
@@ -188,13 +188,15 @@ func (c *KeyorixCore) completeInvitationAccept(ctx context.Context, tok *models.
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}
 
-	// Create the membership under the invite-time validation mode. This grants the
-	// project role immediately when the mode (e.g. open) lands it active; under
-	// allowlist it starts in `invited` for an admin to advance. Done BEFORE flipping
-	// the invitation to accepted: if membership creation fails, the invitation stays
-	// pending (resendable / revocable) rather than being falsely marked accepted with
-	// no membership behind it.
-	if _, err := c.inviteMemberWithMode(ctx, inv.ProjectID, user.ID, inv.Role, inv.InvitedBy, inv.ValidationModeAtInvite, false); err != nil {
+	// Materialize the invitation's grants under the invite-time validation mode. For a
+	// project-scoped invite that's the single project role; for a global invite it's
+	// the system role plus every project assignment (ADR-024). This grants project
+	// roles immediately when the mode (e.g. open) lands them active; under allowlist a
+	// membership starts in `invited` for an admin to advance. Done BEFORE flipping the
+	// invitation to accepted: if any grant fails, the invitation stays pending
+	// (resendable / revocable) rather than being falsely marked accepted with no
+	// grants behind it.
+	if err := c.applyInvitationGrants(ctx, inv, user.ID); err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}
 

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -250,10 +250,21 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 		}
 	}
 
-	// Create project_invitations / access_requests if missing (ADR-024, additive).
+	// Create project_invitations if missing (ADR-024, additive); otherwise add only
+	// the newer global-invite columns via the Migrator (same pgx hazard as the
+	// notifications block below — never full-AutoMigrate an existing table here).
 	if !invitationsExists {
 		if err := db.AutoMigrate(&models.ProjectInvitation{}); err != nil {
 			return fmt.Errorf("failed to migrate project_invitations table: %w", err)
+		}
+	} else {
+		m := db.Migrator()
+		for _, col := range []string{"SystemRole", "AssignmentsJSON"} {
+			if !m.HasColumn(&models.ProjectInvitation{}, col) {
+				if err := m.AddColumn(&models.ProjectInvitation{}, col); err != nil {
+					return fmt.Errorf("failed to add project_invitations.%s column: %w", col, err)
+				}
+			}
 		}
 	}
 	if !accessReqExists {

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -32,14 +32,19 @@ type ProjectInvitation struct {
 	ID                     uint   `gorm:"primaryKey"`
 	ProjectID              uint   `gorm:"index"`
 	Email                  string `gorm:"index"`
-	Role                   string // intended project role
+	Role                   string // intended project role (project-scoped invite)
 	State                  string // pending | accepted | revoked | expired
 	InvitedBy              uint
 	ValidationModeAtInvite string // snapshot of the install validation mode at invite time
-	ExpiresAt              *time.Time
-	CreatedAt              time.Time
-	AcceptedAt             *time.Time
-	RevokedAt              *time.Time
+	// Global invite (ADR-024): a non-project-scoped invitation (ProjectID 0) that, on
+	// accept, grants a system role plus the per-project assignments below. Both empty
+	// for a project-scoped invite.
+	SystemRole      string // optional system role granted on accept
+	AssignmentsJSON string `gorm:"type:text"` // optional JSON []{project_id, role} for multi-project grants
+	ExpiresAt       *time.Time
+	CreatedAt       time.Time
+	AcceptedAt      *time.Time
+	RevokedAt       *time.Time
 }
 
 // AccessRequest is a user's request for a role in a project (ADR-024). State

--- a/server/http/handlers/global_invitation_test.go
+++ b/server/http/handlers/global_invitation_test.go
@@ -1,0 +1,84 @@
+package handlers
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func setupGlobalInvitationTest(t *testing.T) (*CatalogHandler, *gorm.DB) {
+	t.Helper()
+	require.NoError(t, i18n.Initialize(&config.Config{
+		Locale: config.LocaleConfig{Language: "en", FallbackLanguage: "en"},
+	}))
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.User{}, &models.UserRole{}, &models.Role{}, &models.Project{},
+		&models.ProjectInvitation{}, &models.SetupToken{}, &models.AuditEvent{},
+	))
+	require.NoError(t, db.Create(&models.Role{Name: "system_viewer"}).Error)
+	require.NoError(t, db.Create(&models.Role{Name: "system_auditor"}).Error)
+	require.NoError(t, db.Create(&models.Role{Name: "project_developer"}).Error)
+	require.NoError(t, db.Create(&models.Project{Name: "default"}).Error)
+	return NewCatalogHandler(core.NewKeyorixCore(store.NewLocalStorage(db))), db
+}
+
+func postGlobalInvite(t *testing.T, h *CatalogHandler, jsonBody string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := withUserCtx(httptest.NewRequest(http.MethodPost, "/api/v1/invitations", bytes.NewReader([]byte(jsonBody))))
+	w := httptest.NewRecorder()
+	h.CreateGlobalInvitation(w, req)
+	return w
+}
+
+func TestCreateGlobalInvitation(t *testing.T) {
+	h, db := setupGlobalInvitationTest(t)
+	var proj models.Project
+	require.NoError(t, db.Where("name = ?", "default").First(&proj).Error)
+
+	t.Run("creates a global invitation with system role + project assignments", func(t *testing.T) {
+		body := `{"email":"carol@acme.io","role":"system_auditor","project_assignments":[{"project_id":` + itoa(proj.ID) + `,"role":"project_developer"}]}`
+		w := postGlobalInvite(t, h, body)
+		// 201 even though the setup link can't be delivered in test (no base_url) —
+		// the invitation is still persisted.
+		require.Equal(t, http.StatusCreated, w.Code)
+
+		var inv models.ProjectInvitation
+		require.NoError(t, db.Where("email = ?", "carol@acme.io").First(&inv).Error)
+		assert.Equal(t, uint(0), inv.ProjectID) // global
+		assert.Equal(t, "system_auditor", inv.SystemRole)
+		assert.Contains(t, inv.AssignmentsJSON, "project_developer")
+		assert.Equal(t, core.InvitationPending, inv.State)
+	})
+
+	t.Run("missing email rejects with 400", func(t *testing.T) {
+		w := postGlobalInvite(t, h, `{"role":"system_viewer"}`)
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("unknown system role rejects with 400 and creates no invitation", func(t *testing.T) {
+		w := postGlobalInvite(t, h, `{"email":"x@y.io","role":"nope_role"}`)
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		var n int64
+		require.NoError(t, db.Model(&models.ProjectInvitation{}).Where("email = ?", "x@y.io").Count(&n).Error)
+		assert.Equal(t, int64(0), n)
+	})
+
+	t.Run("unknown project role rejects with 400", func(t *testing.T) {
+		body := `{"email":"z@y.io","project_assignments":[{"project_id":` + itoa(proj.ID) + `,"role":"bogus"}]}`
+		w := postGlobalInvite(t, h, body)
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+}

--- a/server/http/handlers/invitations.go
+++ b/server/http/handlers/invitations.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/keyorixhq/keyorix/server/middleware"
 )
 
@@ -65,6 +66,58 @@ func (h *CatalogHandler) CreateInvitation(w http.ResponseWriter, r *http.Request
 		if inv == nil {
 			status := http.StatusInternalServerError
 			if strings.Contains(err.Error(), "unknown role") || strings.Contains(err.Error(), "required") {
+				status = http.StatusBadRequest
+			}
+			sendError(w, "Error", err.Error(), status, nil)
+			return
+		}
+		w.WriteHeader(http.StatusCreated)
+		sendSuccess(w, map[string]interface{}{"invitation": inv, "delivery_error": err.Error()},
+			"Invitation created but the setup link could not be delivered")
+		return
+	}
+	w.WriteHeader(http.StatusCreated)
+	sendSuccess(w, map[string]interface{}{"invitation": inv, "setup_link": prov}, "Invitation created")
+}
+
+// CreateGlobalInvitation is the Global-Admin counterpart to CreateInvitation: a
+// non-project-scoped invite (ADR-024) carrying an optional system role plus
+// per-project assignments, all applied atomically when the user accepts. Gated by
+// users.write (system scope) since it provisions an account-to-be with grants.
+func (h *CatalogHandler) CreateGlobalInvitation(w http.ResponseWriter, r *http.Request) {
+	actor := middleware.GetUserFromContext(r.Context())
+	if actor == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	var body struct {
+		Email              string `json:"email"`
+		Role               string `json:"role"` // system role (optional; defaults to system_viewer)
+		ProjectAssignments []struct {
+			ProjectID uint   `json:"project_id"`
+			Role      string `json:"role"`
+		} `json:"project_assignments"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		sendError(w, "InvalidJSON", "Invalid request body", http.StatusBadRequest, nil)
+		return
+	}
+	if body.Email == "" {
+		sendError(w, "ValidationError", "email is required", http.StatusBadRequest, nil)
+		return
+	}
+	assignments := make([]core.ProjectAssignment, 0, len(body.ProjectAssignments))
+	for _, a := range body.ProjectAssignments {
+		assignments = append(assignments, core.ProjectAssignment{ProjectID: a.ProjectID, Role: a.Role})
+	}
+	inv, prov, err := h.coreService.InviteGlobalWithLink(r.Context(), body.Email, body.Role, assignments, actor.UserID)
+	if err != nil {
+		// A nil inv means the invitation was not created at all (bad input); a non-nil
+		// inv with an error means it exists but the link couldn't be provisioned (e.g.
+		// base_url unset) — surface that so the admin can fix config and resend.
+		if inv == nil {
+			status := http.StatusInternalServerError
+			if strings.Contains(err.Error(), "unknown") || strings.Contains(err.Error(), "required") || strings.Contains(err.Error(), "needs a") {
 				status = http.StatusBadRequest
 			}
 			sendError(w, "Error", err.Error(), status, nil)

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -179,6 +179,9 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		r.With(customMiddleware.RequireScopedPermission("roles.assign", projectScope)).Delete("/projects/{id}/invitations/{invitationId}", catalogHandler.RevokeInvitation)
 		// Resend the invitation's setup link (ADR-028).
 		r.With(customMiddleware.RequireScopedPermission("roles.assign", projectScope)).Post("/projects/{id}/invitations/{invitationId}/resend", catalogHandler.ResendInvitation)
+		// Global (non-project-scoped) invitation (ADR-024): system role + multi-project
+		// assignments applied atomically on accept. A system-admin operation (users.write).
+		r.With(customMiddleware.RequirePermission("users.write")).Post("/invitations", catalogHandler.CreateGlobalInvitation)
 		// Access requests (ADR-024): requesting + withdrawing are self-service (any
 		// authenticated user — they don't have project access yet); listing and
 		// approving/rejecting require roles.assign at the project scope.


### PR DESCRIPTION
## What

The Global-Admin **invitation** primitive only carried one project + one project role. This adds the invitation analogue of the atomic `POST /users` (#30): a non-project-scoped invite (`ProjectID 0`) that, on accept, grants a **system role** plus a set of **per-project assignments** in one go.

This is the backend half of the **Invitation dialog (Global Admin)** backlog item (ADR-024). The frontend dialog is a follow-up PR in keyorix-web.

## Changes

- **model**: `SystemRole` + `AssignmentsJSON` on `ProjectInvitation`; additive Migrator columns for existing `project_invitations` tables (same pgx-safe pattern as the notifications block — **verified live on the dev Postgres**: both columns added, clean boot, no pgx crash).
- **core**: `InviteGlobal`/`InviteGlobalWithLink` validate the system role and every assignment (project + role) up front and dedup by project, so acceptance can't fail on unknown input; `applyInvitationGrants` materializes the system-role grant plus one membership per assignment under the invite-time validation mode. The accept flow (`setup_consume`) now routes through it — **project-scoped invites are unchanged**.
- **http**: `POST /invitations` (system-scoped, `users.write`) mirroring the project `CreateInvitation` handler's request/response and error shape (`{invitation, setup_link}`; 201-with-`delivery_error` when the link can't be delivered).

## Tests

- core: validate-up-front, dedup, default `system_viewer`, accept applies all grants
- handler: 201 with assignments persisted; 400 on missing email / unknown system role / unknown project role

`go build/vet/gofmt/test ./...` green; migration verified live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)