### PR TITLE
feat(grpc): real session-token auth + shared core wiring (gRPC Phase 2)

### DIFF
--- a/server/grpc/interceptors/auth.go
+++ b/server/grpc/interceptors/auth.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 
+	"github.com/keyorixhq/keyorix/internal/core"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
@@ -26,8 +27,9 @@ const (
 	userContextKey contextKey = "grpc_user"
 )
 
-// AuthInterceptor returns a unary server interceptor for authentication
-func AuthInterceptor() grpc.UnaryServerInterceptor {
+// AuthInterceptor returns a unary server interceptor that authenticates each
+// request against a real session token via the core service.
+func AuthInterceptor(coreService *core.KeyorixCore) grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 		// Skip authentication for certain methods
 		if isPublicMethod(info.FullMethod) {
@@ -35,7 +37,7 @@ func AuthInterceptor() grpc.UnaryServerInterceptor {
 		}
 
 		// Extract and validate token
-		userCtx, err := authenticateRequest(ctx)
+		userCtx, err := authenticateRequest(ctx, coreService)
 		if err != nil {
 			return nil, err
 		}
@@ -46,8 +48,9 @@ func AuthInterceptor() grpc.UnaryServerInterceptor {
 	}
 }
 
-// StreamAuthInterceptor returns a stream server interceptor for authentication
-func StreamAuthInterceptor() grpc.StreamServerInterceptor {
+// StreamAuthInterceptor returns a stream server interceptor that authenticates
+// each stream against a real session token via the core service.
+func StreamAuthInterceptor(coreService *core.KeyorixCore) grpc.StreamServerInterceptor {
 	return func(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 		// Skip authentication for certain methods
 		if isPublicMethod(info.FullMethod) {
@@ -55,7 +58,7 @@ func StreamAuthInterceptor() grpc.StreamServerInterceptor {
 		}
 
 		// Extract and validate token
-		userCtx, err := authenticateRequest(stream.Context())
+		userCtx, err := authenticateRequest(stream.Context(), coreService)
 		if err != nil {
 			return err
 		}
@@ -80,8 +83,16 @@ func (w *wrappedServerStream) Context() context.Context {
 	return w.ctx
 }
 
-// authenticateRequest extracts and validates the authentication token
-func authenticateRequest(ctx context.Context) (*UserContext, error) {
+// authenticateRequest extracts the bearer session token from the request
+// metadata and validates it against the core service — the same session-token
+// path the HTTP API uses. On success it returns the authenticated user's
+// context (id, identity, roles, permissions) for downstream authorization.
+func authenticateRequest(ctx context.Context, coreService *core.KeyorixCore) (*UserContext, error) {
+	if coreService == nil {
+		// Fail closed: a server wired without a core service must not authenticate.
+		return nil, status.Errorf(codes.Internal, "authentication unavailable")
+	}
+
 	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
 		return nil, status.Errorf(codes.Unauthenticated, "Missing metadata")
@@ -103,49 +114,25 @@ func authenticateRequest(ctx context.Context) (*UserContext, error) {
 		return nil, status.Errorf(codes.Unauthenticated, "Missing token")
 	}
 
-	// TODO: Validate JWT token and extract user information
-	// For now, we'll use a mock implementation
-	userCtx, err := validateGRPCToken(token)
+	// Validate the session token (existence + expiry) and resolve the user.
+	user, _, err := coreService.ValidateSessionToken(ctx, token)
 	if err != nil {
 		return nil, status.Errorf(codes.Unauthenticated, "Invalid or expired token")
 	}
 
-	return userCtx, nil
-}
-
-// validateGRPCToken validates a JWT token and returns user context
-// TODO: Implement actual JWT validation
-func validateGRPCToken(token string) (*UserContext, error) {
-	// Mock implementation - replace with actual JWT validation
-	if token == "valid-token" {
-		return &UserContext{
-			UserID:   1,
-			Username: "admin",
-			Email:    "admin@example.com",
-			Roles:    []string{"admin", "user"},
-			Permissions: []string{
-				"secrets.read", "secrets.write", "secrets.delete",
-				"users.read", "users.write", "users.delete",
-				"roles.read", "roles.write", "roles.assign",
-				"audit.read", "system.read",
-			},
-		}, nil
+	// Resolve roles + permissions for downstream per-method authorization.
+	identity, err := coreService.GetUserIdentity(ctx, user.ID)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to resolve user identity")
 	}
 
-	if token == "test-token" {
-		return &UserContext{
-			UserID:   2,
-			Username: "testuser",
-			Email:    "test@example.com",
-			Roles:    []string{"viewer"},
-			Permissions: []string{
-				"secrets.read",
-				"users.read",
-			},
-		}, nil
-	}
-
-	return nil, status.Errorf(codes.Unauthenticated, "Invalid token")
+	return &UserContext{
+		UserID:      user.ID,
+		Username:    user.Username,
+		Email:       user.Email,
+		Roles:       identity.Roles,
+		Permissions: identity.Permissions,
+	}, nil
 }
 
 // isPublicMethod checks if a gRPC method is public (doesn't require authentication)

--- a/server/grpc/interceptors/auth_test.go
+++ b/server/grpc/interceptors/auth_test.go
@@ -1,0 +1,146 @@
+package interceptors
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/testhelper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+// secretMethod is a representative non-public RPC method that requires auth.
+const secretMethod = "/keyorix.v1.SecretService/GetSecret"
+
+// okHandler records the context it was invoked with and returns a sentinel.
+func okHandler(captured *context.Context) grpc.UnaryHandler {
+	return func(ctx context.Context, req interface{}) (interface{}, error) {
+		if captured != nil {
+			*captured = ctx
+		}
+		return "ok", nil
+	}
+}
+
+func bearerCtx(token string) context.Context {
+	md := metadata.Pairs("authorization", "Bearer "+token)
+	return metadata.NewIncomingContext(context.Background(), md)
+}
+
+// setupAuthHelper builds an RBAC test helper and migrates the sessions table,
+// which the base helper does not include but the auth path requires.
+func setupAuthHelper(t *testing.T) *testhelper.RBACTestHelper {
+	t.Helper()
+	h := testhelper.NewRBACTestHelper(t)
+	require.NoError(t, h.DB.AutoMigrate(&models.Session{}))
+	return h
+}
+
+// mintSessionForTest inserts a user and a session token directly via storage and
+// returns the token. expiresAt controls whether the session is live or expired.
+func mintSessionForTest(t *testing.T, h *testhelper.RBACTestHelper, userID uint, username, token string, expiresAt time.Time) {
+	t.Helper()
+	h.CreateTestUser(t, username, userID)
+	_, err := h.Storage.CreateSession(context.Background(), &models.Session{
+		UserID:       userID,
+		SessionToken: token,
+		ExpiresAt:    &expiresAt,
+	})
+	require.NoError(t, err)
+}
+
+func TestAuthInterceptor_ValidSessionPopulatesUserContext(t *testing.T) {
+	h := setupAuthHelper(t)
+	defer h.Cleanup()
+	mintSessionForTest(t, h, 9001, "grpc-alice", "live-token", time.Now().Add(time.Hour))
+
+	var captured context.Context
+	interceptor := AuthInterceptor(h.CoreService)
+	resp, err := interceptor(bearerCtx("live-token"), nil,
+		&grpc.UnaryServerInfo{FullMethod: secretMethod}, okHandler(&captured))
+
+	require.NoError(t, err)
+	assert.Equal(t, "ok", resp)
+
+	user := GetUserFromGRPCContext(captured)
+	require.NotNil(t, user, "handler context must carry the authenticated user")
+	assert.Equal(t, uint(9001), user.UserID)
+	assert.Equal(t, "grpc-alice", user.Username)
+}
+
+// Regression guard: the removed mock validator granted full admin to the literal
+// token "valid-token". It must now be rejected like any other unknown token.
+func TestAuthInterceptor_LegacyBackdoorTokenRejected(t *testing.T) {
+	h := setupAuthHelper(t)
+	defer h.Cleanup()
+
+	interceptor := AuthInterceptor(h.CoreService)
+	for _, tok := range []string{"valid-token", "test-token"} {
+		_, err := interceptor(bearerCtx(tok), nil,
+			&grpc.UnaryServerInfo{FullMethod: secretMethod}, okHandler(nil))
+		require.Error(t, err, "legacy mock token %q must not authenticate", tok)
+		assert.Equal(t, codes.Unauthenticated, status.Code(err))
+	}
+}
+
+func TestAuthInterceptor_ExpiredSessionRejected(t *testing.T) {
+	h := setupAuthHelper(t)
+	defer h.Cleanup()
+	mintSessionForTest(t, h, 9002, "grpc-bob", "stale-token", time.Now().Add(-time.Minute))
+
+	interceptor := AuthInterceptor(h.CoreService)
+	_, err := interceptor(bearerCtx("stale-token"), nil,
+		&grpc.UnaryServerInfo{FullMethod: secretMethod}, okHandler(nil))
+	require.Error(t, err)
+	assert.Equal(t, codes.Unauthenticated, status.Code(err))
+}
+
+func TestAuthInterceptor_MissingAndMalformedCredentials(t *testing.T) {
+	h := setupAuthHelper(t)
+	defer h.Cleanup()
+	interceptor := AuthInterceptor(h.CoreService)
+	info := &grpc.UnaryServerInfo{FullMethod: secretMethod}
+
+	cases := map[string]context.Context{
+		"no metadata":    context.Background(),
+		"no auth header": metadata.NewIncomingContext(context.Background(), metadata.MD{}),
+		"not bearer":     metadata.NewIncomingContext(context.Background(), metadata.Pairs("authorization", "Basic abc")),
+		"empty bearer":   bearerCtx(""),
+		"unknown token":  bearerCtx("nope"),
+	}
+	for name, ctx := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, err := interceptor(ctx, nil, info, okHandler(nil))
+			require.Error(t, err)
+			assert.Equal(t, codes.Unauthenticated, status.Code(err))
+		})
+	}
+}
+
+// A nil core service must fail closed (never authenticate) rather than panic.
+func TestAuthInterceptor_NilCoreFailsClosed(t *testing.T) {
+	interceptor := AuthInterceptor(nil)
+	_, err := interceptor(bearerCtx("whatever"), nil,
+		&grpc.UnaryServerInfo{FullMethod: secretMethod}, okHandler(nil))
+	require.Error(t, err)
+	assert.Equal(t, codes.Internal, status.Code(err))
+}
+
+// Public methods (health, reflection) bypass authentication entirely.
+func TestAuthInterceptor_PublicMethodBypassesAuth(t *testing.T) {
+	interceptor := AuthInterceptor(nil) // never consulted for public methods
+	var captured context.Context
+	resp, err := interceptor(context.Background(), nil,
+		&grpc.UnaryServerInfo{FullMethod: "/grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo"},
+		okHandler(&captured))
+
+	require.NoError(t, err)
+	assert.Equal(t, "ok", resp)
+	assert.Nil(t, GetUserFromGRPCContext(captured), "public method must not set a user context")
+}

--- a/server/grpc/server.go
+++ b/server/grpc/server.go
@@ -6,26 +6,29 @@ import (
 	"log"
 
 	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/keyorixhq/keyorix/server/grpc/interceptors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/reflection"
 )
 
-// NewServer creates a new gRPC server with all services registered
-func NewServer(cfg *config.Config) (*grpc.Server, error) {
+// NewServer creates a new gRPC server. The auth interceptor validates session
+// tokens against the shared core service. Service registration is wired in a
+// later phase; until then the server runs with interceptors only.
+func NewServer(cfg *config.Config, coreService *core.KeyorixCore) (*grpc.Server, error) {
 	// Create server options
 	opts := []grpc.ServerOption{
 		grpc.ChainUnaryInterceptor(
 			interceptors.LoggingInterceptor(),
 			interceptors.RecoveryInterceptor(),
-			interceptors.AuthInterceptor(),
+			interceptors.AuthInterceptor(coreService),
 			interceptors.MetricsInterceptor(),
 		),
 		grpc.ChainStreamInterceptor(
 			interceptors.StreamLoggingInterceptor(),
 			interceptors.StreamRecoveryInterceptor(),
-			interceptors.StreamAuthInterceptor(),
+			interceptors.StreamAuthInterceptor(coreService),
 		),
 	}
 
@@ -42,10 +45,9 @@ func NewServer(cfg *config.Config) (*grpc.Server, error) {
 	// Create server
 	server := grpc.NewServer(opts...)
 
-	// TODO: Initialize services when protobuf definitions are ready
-	// For now, the gRPC server runs without registered services
-
-	// TODO: Register protobuf services when proto files are generated
+	// Service registration is wired in a later phase. The generated pb package
+	// exists (server/proto/pb); the services still need to implement the
+	// generated pb.*ServiceServer interfaces before they can be registered here:
 	// pb.RegisterSecretServiceServer(server, secretService)
 	// pb.RegisterUserServiceServer(server, userService)
 	// pb.RegisterRoleServiceServer(server, roleService)
@@ -59,7 +61,7 @@ func NewServer(cfg *config.Config) (*grpc.Server, error) {
 		log.Println("gRPC reflection enabled")
 	}
 
-	log.Printf("gRPC server configured with %d services", 6)
+	log.Println("gRPC server configured (no services registered yet)")
 	return server, nil
 }
 

--- a/server/grpc/sharing_integration_test.go
+++ b/server/grpc/sharing_integration_test.go
@@ -21,8 +21,10 @@ func newTestServer(t *testing.T) (*grpc.Server, *services.ShareGRPCService) {
 	shareService, err := services.NewShareService(nil)
 	require.NoError(t, err)
 
+	// These tests invoke service methods directly (no RPC routes through the
+	// interceptor), so a nil core service here is never exercised.
 	server := grpc.NewServer(
-		grpc.UnaryInterceptor(interceptors.AuthInterceptor()),
+		grpc.UnaryInterceptor(interceptors.AuthInterceptor(nil)),
 	)
 	return server, shareService
 }

--- a/server/main.go
+++ b/server/main.go
@@ -340,8 +340,15 @@ func startHTTPServer(ctx context.Context, cfg *config.Config) error {
 }
 
 func startGRPCServer(ctx context.Context, cfg *config.Config) error {
+	// Initialize the core service so the gRPC auth interceptor can validate
+	// session tokens (mirrors the HTTP server's own core initialization).
+	coreService, _, err := initializeCoreService(cfg)
+	if err != nil {
+		return fmt.Errorf("failed to initialize core service: %w", err)
+	}
+
 	// Create gRPC server
-	grpcServer, err := grpc.NewServer(cfg)
+	grpcServer, err := grpc.NewServer(cfg, coreService)
 	if err != nil {
 		return fmt.Errorf("failed to create gRPC server: %w", err)
 	}


### PR DESCRIPTION
**Stacked on #34 (Phase 1).** Review/merge #34 first.

## What

Replaces the gRPC auth interceptor's **mock validator** with real session-token validation against the shared core service, and threads that core through server construction. **Removes a latent admin backdoor.**

### The backdoor (removed)
`validateGRPCToken` hardcoded `"valid-token"` → **full admin** (all secrets/users/roles/audit/system permissions) and `"test-token"` → viewer. Not exploitable today (no services are registered, so the interceptor never runs on a live RPC), but it was a trap: the moment any service is registered, `valid-token` → admin would ship.

## Changes
- **`interceptors/auth.go`** — `AuthInterceptor`/`StreamAuthInterceptor` take a `*core.KeyorixCore`. `authenticateRequest` validates the bearer token via `ValidateSessionToken` (existence + expiry) and resolves roles/permissions via `GetUserIdentity` — the same path the HTTP API uses. Deletes the mock. **Fails closed** when the core service is nil.
- **`server.go`** — `NewServer(cfg, coreService)` passes the core to the interceptors; corrects the false `"configured with 6 services"` log (zero are registered yet).
- **`main.go`** — `startGRPCServer` initializes the core (mirroring HTTP) and passes it in.
- **Interceptor tests (package had none):** valid-session happy path, expired-session rejection, missing/malformed credentials, nil-core fail-closed, public-method bypass, and a **regression guard** asserting `valid-token`/`test-token` no longer authenticate.

## Scope note
No services are registered yet, so the interceptor isn't on a live RPC path — this makes the auth correct and backdoor-free *ahead of* registration (Phase 3+). This is a deliberate adaptation of the original plan: "pure DI" isn't a compilable unit on its own (injected services can't be used until registered), so DI threading is paired with the security-critical auth fix.

## Verification
`go build ./...`, `go vet ./...`, `gofmt` clean; **full suite green**.

## Remaining phases
3. Implement generated `pb.*ServiceServer` in the 6 services (against generated types; inject shared core; drop per-service DB)
4. Register services + rewrite service tests through generated types / in-process gRPC client

🤖 Generated with [Claude Code](https://claude.com/claude-code)