### PR TITLE
feat(grpc): wire SystemService.GetMetrics to real request + runtime metrics

### DIFF
--- a/server/grpc/services/system_service.go
+++ b/server/grpc/services/system_service.go
@@ -8,6 +8,7 @@ import (
 	"github.com/keyorixhq/keyorix/internal/config"
 	"github.com/keyorixhq/keyorix/internal/core"
 	corestorage "github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/server/grpc/interceptors"
 	pb "github.com/keyorixhq/keyorix/server/proto/pb"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -82,9 +83,10 @@ func (s *SystemGRPCService) GetSystemInfo(ctx context.Context, _ *emptypb.Empty)
 	return info, nil
 }
 
-// GetMetrics returns an operational snapshot. Only the cheaply available counts
-// (active secrets, total users) are populated; request/performance/system
-// runtime metrics are not collected yet and report zero.
+// GetMetrics returns an operational snapshot: gRPC request counters (collected
+// by the metrics interceptor), Go runtime stats, and cheap domain counts
+// (active secrets, total users). CPU/disk usage and DB latency are not measured
+// yet and report zero.
 func (s *SystemGRPCService) GetMetrics(ctx context.Context, _ *emptypb.Empty) (*pb.Metrics, error) {
 	actor, err := requireUser(ctx)
 	if err != nil {
@@ -94,6 +96,32 @@ func (s *SystemGRPCService) GetMetrics(ctx context.Context, _ *emptypb.Empty) (*
 		return nil, status.Error(codes.PermissionDenied, "insufficient permissions to read metrics")
 	}
 
+	// Request/performance metrics from the gRPC metrics interceptor.
+	rm := interceptors.GetGRPCMetrics()
+	requests := &pb.RequestMetrics{
+		Total:         nonNegU64(rm.TotalRequests),
+		Success:       nonNegU64(rm.SuccessRequests),
+		Errors:        nonNegU64(rm.ErrorRequests),
+		AvgDurationMs: rm.GetAverageResponseTime(),
+	}
+	performance := &pb.PerformanceMetrics{
+		AvgResponseTimeMs: rm.GetAverageResponseTime(),
+		ErrorRatePercent:  rm.GetErrorRate(),
+	}
+
+	// Go runtime stats.
+	var mem runtime.MemStats
+	runtime.ReadMemStats(&mem)
+	var memPercent float64
+	if mem.Sys > 0 {
+		memPercent = float64(mem.HeapInuse) / float64(mem.Sys) * 100
+	}
+	system := &pb.SystemMetrics{
+		Goroutines:         uint32(runtime.NumGoroutine()), // #nosec G115 — goroutine count fits uint32
+		MemoryUsagePercent: memPercent,
+	}
+
+	// Domain counts.
 	activeSecrets := uint64(len(s.core.ListActiveSecrets(ctx)))
 	var totalUsers uint64
 	if _, total, err := s.core.ListUsers(ctx, &corestorage.UserFilter{Page: 1, PageSize: 1}); err == nil && total >= 0 {
@@ -101,9 +129,20 @@ func (s *SystemGRPCService) GetMetrics(ctx context.Context, _ *emptypb.Empty) (*
 	}
 
 	return &pb.Metrics{
-		Secrets: &pb.SecretMetrics{Active: activeSecrets, Total: activeSecrets},
-		Users:   &pb.UserMetrics{Total: totalUsers},
+		Requests:    requests,
+		Performance: performance,
+		System:      system,
+		Secrets:     &pb.SecretMetrics{Active: activeSecrets, Total: activeSecrets},
+		Users:       &pb.UserMetrics{Total: totalUsers},
 	}, nil
+}
+
+// nonNegU64 converts a counter to uint64, flooring negatives at 0.
+func nonNegU64(v int64) uint64 {
+	if v < 0 {
+		return 0
+	}
+	return uint64(v)
 }
 
 func encStatus(enabled bool) string {

--- a/server/grpc/services/system_service_test.go
+++ b/server/grpc/services/system_service_test.go
@@ -67,4 +67,9 @@ func TestSystemService_GetMetrics(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, m.GetSecrets())
 	require.NotNil(t, m.GetUsers())
+	require.NotNil(t, m.GetRequests())
+	require.NotNil(t, m.GetPerformance())
+	require.NotNil(t, m.GetSystem())
+	// Goroutine count is always positive in a running test binary.
+	assert.Greater(t, m.GetSystem().GetGoroutines(), uint32(0))
 }


### PR DESCRIPTION
Deferred Phase 3b follow-up. The `MetricsInterceptor` already collected gRPC request counters (total/success/errors/duration), but `SystemService.GetMetrics` ignored them and reported zeros. This connects the two and adds Go runtime stats.

## Changes
- **RequestMetrics + PerformanceMetrics** from `interceptors.GetGRPCMetrics()` — totals, average duration (ms), error rate (%).
- **SystemMetrics** — goroutine count and a heap-in-use/Sys memory percentage from `runtime.ReadMemStats`.
- Domain counts (active secrets, total users) unchanged.
- CPU/disk usage and DB latency remain zero (not measured yet).

Test asserts the request/performance/system sub-messages are populated and the goroutine count is positive.

## Verification
`go build`/`vet`/`gofmt` clean; full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)