### PR TITLE
feat(auth): send password-reset links (RequestPasswordReset was a no-op)

### DIFF
--- a/internal/core/auth.go
+++ b/internal/core/auth.go
@@ -184,14 +184,34 @@ func (c *KeyorixCore) ValidateSessionToken(ctx context.Context, token string) (*
 	return user, roleNames, nil
 }
 
-// RequestPasswordReset initiates a password reset for the given email.
-// Best-effort: returns nil for unknown emails to avoid email enumeration.
+// RequestPasswordReset issues a password-reset link for the given email and
+// delivers it via the configured credential-delivery channel (ADR-028). The
+// recipient consumes it at /auth/setup/{token} to set a new password
+// (completePasswordSetup handles the password_reset_link purpose).
+//
+// Always returns nil: the outcome must not reveal whether the email maps to an
+// account (enumeration-safe), so unknown addresses, suspended accounts, throttled
+// repeats, and delivery/config failures are all swallowed. The attempt itself is
+// audited inside provisionSetupLink.
 func (c *KeyorixCore) RequestPasswordReset(ctx context.Context, email string) error {
-	_, err := c.storage.GetUserByEmail(ctx, email)
+	user, err := c.storage.GetUserByEmail(ctx, email)
 	if err != nil {
 		return nil // Don't reveal whether the email exists.
 	}
-	// TODO: send reset email
+	// Never send a reset to a login-blocked (e.g. suspended) account.
+	if AccountLoginBlocked(user.AccountState) {
+		return nil
+	}
+	// Throttle abusive repeats to a victim address (same control as resend).
+	if err := c.checkResendThrottle(ctx, SetupPurposePasswordResetLink, user.Email); err != nil {
+		return nil
+	}
+	_, _ = c.provisionSetupLink(ctx, IssueSetupTokenRequest{
+		Purpose:       SetupPurposePasswordResetLink,
+		SubjectEmail:  user.Email,
+		SubjectUserID: &user.ID,
+		CreatedBy:     0, // self-service (no issuing admin)
+	}, user.DisplayName, "")
 	return nil
 }
 

--- a/internal/core/password_reset_test.go
+++ b/internal/core/password_reset_test.go
@@ -1,0 +1,79 @@
+package core
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/delivery"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRequestPasswordReset(t *testing.T) {
+	ctx := context.Background()
+	const email = "reset@acme.io"
+	fixed := time.Date(2026, 6, 6, 12, 0, 0, 0, time.UTC)
+
+	newCore := func(d delivery.CredentialDelivery) (*KeyorixCore, *MockStorage) {
+		ms := new(MockStorage)
+		c := NewKeyorixCore(ms)
+		c.now = func() time.Time { return fixed }
+		c.SetCredentialDelivery(d, testBaseURL)
+		anyAudit(ms)
+		return c, ms
+	}
+	activeUser := &models.User{ID: 9, Email: email, DisplayName: "Rhea", AccountState: AccountActive}
+
+	t.Run("active account: issues a password_reset_link and delivers it", func(t *testing.T) {
+		fake := &fakeDeliverer{echoLink: true, result: delivery.DeliveryResult{Channel: delivery.ChannelSMTP, Delivered: true}}
+		c, ms := newCore(fake)
+		ms.On("GetUserByEmail", ctx, email).Return(activeUser, nil)
+		ms.On("CountSetupTokensSince", ctx, SetupPurposePasswordResetLink, email, fixed.Add(-24*time.Hour)).Return(int64(0), nil)
+		ms.On("CountSetupTokensSince", ctx, SetupPurposePasswordResetLink, email, fixed.Add(-resendMinInterval)).Return(int64(0), nil)
+		ms.On("SupersedeActiveSetupTokens", ctx, SetupPurposePasswordResetLink, email).Return(nil)
+		ms.On("CreateSetupToken", ctx, mock.AnythingOfType("*models.SetupToken")).Return(&models.SetupToken{ID: 1}, nil)
+
+		require.NoError(t, c.RequestPasswordReset(ctx, email))
+		assert.True(t, fake.called, "the reset link should be delivered")
+		assert.Equal(t, SetupPurposePasswordResetLink, fake.lastReq.Purpose)
+		assert.Equal(t, email, fake.lastReq.RecipientEmail)
+		ms.AssertCalled(t, "CreateSetupToken", ctx, mock.AnythingOfType("*models.SetupToken"))
+	})
+
+	t.Run("unknown email: no token, no delivery, no leak", func(t *testing.T) {
+		fake := &fakeDeliverer{}
+		c, ms := newCore(fake)
+		ms.On("GetUserByEmail", ctx, "nobody@acme.io").Return(nil, fmt.Errorf("not found"))
+
+		require.NoError(t, c.RequestPasswordReset(ctx, "nobody@acme.io"))
+		assert.False(t, fake.called)
+		ms.AssertNotCalled(t, "CreateSetupToken", mock.Anything, mock.Anything)
+	})
+
+	t.Run("suspended account: no reset link issued", func(t *testing.T) {
+		fake := &fakeDeliverer{}
+		c, ms := newCore(fake)
+		ms.On("GetUserByEmail", ctx, email).Return(
+			&models.User{ID: 9, Email: email, AccountState: AccountSuspended}, nil)
+
+		require.NoError(t, c.RequestPasswordReset(ctx, email))
+		assert.False(t, fake.called)
+		ms.AssertNotCalled(t, "CreateSetupToken", mock.Anything, mock.Anything)
+	})
+
+	t.Run("throttled: swallowed, no token issued", func(t *testing.T) {
+		fake := &fakeDeliverer{}
+		c, ms := newCore(fake)
+		ms.On("GetUserByEmail", ctx, email).Return(activeUser, nil)
+		// Over the daily cap → checkResendThrottle returns an error, swallowed.
+		ms.On("CountSetupTokensSince", ctx, SetupPurposePasswordResetLink, email, fixed.Add(-24*time.Hour)).Return(int64(resendDailyCap), nil)
+
+		require.NoError(t, c.RequestPasswordReset(ctx, email))
+		assert.False(t, fake.called)
+		ms.AssertNotCalled(t, "CreateSetupToken", mock.Anything, mock.Anything)
+	})
+}


### PR DESCRIPTION
**Item 1 of the core-gaps cleanup.** `RequestPasswordReset` validated the email but never sent anything (`// TODO: send reset email`), so `POST /auth/password-reset` silently did nothing.

The ADR-028 credential-delivery infrastructure already supported this end — there's a `password_reset_link` setup-token purpose and `completePasswordSetup` handles it on consume. Only the issue+deliver step was missing.

## Change
Wire `RequestPasswordReset` to issue + deliver a `password_reset_link`, mirroring `ResendAccountSetupLink` but self-service:
- Issue the token via `provisionSetupLink` and deliver over the configured channel; the recipient sets a new password at `/auth/setup/{token}`.
- **Enumeration-safe:** always returns `nil` — unknown emails, suspended accounts, throttled repeats, and delivery/config failures are all swallowed. Reuses the per-subject resend throttle; skips login-blocked accounts.

## Tests
active (issues + delivers), unknown email (no token/no delivery), suspended (skipped), throttled (swallowed).

`go build`/`vet`/`gofmt` clean; full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)