### PR TITLE
feat(core): include group-shared secrets in ListUserPermissions

### DIFF
--- a/internal/core/list_user_permissions_test.go
+++ b/internal/core/list_user_permissions_test.go
@@ -1,0 +1,67 @@
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListUserPermissions_IncludesGroupShares(t *testing.T) {
+	ctx := context.Background()
+	const userID = uint(7)
+	ms := new(MockStorage)
+	c := NewKeyorixCore(ms)
+
+	// Owned secret #1.
+	ms.On("ListSecrets", ctx, mock.AnythingOfType("*storage.SecretFilter")).
+		Return([]*models.SecretNode{{ID: 1}}, int64(1), nil)
+	// Direct share of secret #2.
+	ms.On("ListSharesByUser", ctx, userID).
+		Return([]*models.ShareRecord{{ID: 20, SecretID: 2, Permission: "read"}}, nil)
+	// User belongs to group #5, which has secret #3 shared with write.
+	ms.On("GetUserGroups", ctx, userID).
+		Return([]*models.Group{{ID: 5, Name: "team"}}, nil)
+	ms.On("ListSharesByGroup", ctx, uint(5)).
+		Return([]*models.ShareRecord{{ID: 30, SecretID: 3, Permission: "write", IsGroup: true, RecipientID: 5}}, nil)
+
+	perms, err := c.ListUserPermissions(ctx, userID)
+	require.NoError(t, err)
+
+	bySource := map[string]*models.UserSecretPermission{}
+	for _, p := range perms {
+		bySource[p.Source] = p
+	}
+
+	require.Contains(t, bySource, "owner")
+	require.Contains(t, bySource, "direct_share")
+	require.Contains(t, bySource, "group_share")
+
+	g := bySource["group_share"]
+	assert.Equal(t, uint(3), g.SecretID)
+	assert.Equal(t, "write", g.Permission)
+	require.NotNil(t, g.GroupID)
+	assert.Equal(t, uint(5), *g.GroupID)
+	require.NotNil(t, g.ShareID)
+	assert.Equal(t, uint(30), *g.ShareID)
+}
+
+func TestListUserPermissions_NoGroups(t *testing.T) {
+	ctx := context.Background()
+	const userID = uint(8)
+	ms := new(MockStorage)
+	c := NewKeyorixCore(ms)
+
+	ms.On("ListSecrets", ctx, mock.AnythingOfType("*storage.SecretFilter")).
+		Return([]*models.SecretNode{}, int64(0), nil)
+	ms.On("ListSharesByUser", ctx, userID).Return([]*models.ShareRecord{}, nil)
+	ms.On("GetUserGroups", ctx, userID).Return([]*models.Group{}, nil)
+
+	perms, err := c.ListUserPermissions(ctx, userID)
+	require.NoError(t, err)
+	assert.Empty(t, perms)
+	ms.AssertNotCalled(t, "ListSharesByGroup", mock.Anything, mock.Anything)
+}

--- a/internal/core/permissions.go
+++ b/internal/core/permissions.go
@@ -220,7 +220,28 @@ func (c *KeyorixCore) ListUserPermissions(ctx context.Context, userID uint) ([]*
 		})
 	}
 
-	// TODO: include group-shared secrets when group functionality is fully wired.
+	// Secrets shared with any group the user belongs to.
+	groups, err := c.storage.GetUserGroups(ctx, userID)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	for _, group := range groups {
+		groupShares, err := c.storage.ListSharesByGroup(ctx, group.ID)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+		}
+		for _, share := range groupShares {
+			groupID := group.ID
+			permissions = append(permissions, &models.UserSecretPermission{
+				SecretID:   share.SecretID,
+				UserID:     userID,
+				Permission: share.Permission,
+				Source:     "group_share",
+				ShareID:    &share.ID,
+				GroupID:    &groupID,
+			})
+		}
+	}
 
 	return permissions, nil
 }


### PR DESCRIPTION
**Item 2 of the core-gaps cleanup.** `ListUserPermissions` enumerated owned + directly-shared secrets but skipped secrets shared with the user's *groups* (`// TODO: include group-shared secrets when group functionality is fully wired`) — so a user's effective access via group membership was missing from the listing.

Group sharing is fully wired (`ShareSecretWithGroup`, `ListSharesByGroup`, `GetUserGroups`), so resolve it: for each group the user belongs to, append a `group_share` `UserSecretPermission` (`Source="group_share"`, `ShareID` + `GroupID` populated) for every secret shared with that group. The model already carried the `group_share` source and `GroupID` field — this just fills them.

## Tests
owner + direct + group sources all present with correct attribution; no-groups case issues no group-share lookups.

`go build`/`vet`/`gofmt` clean; full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)