### PR TITLE
fix(cli): correct rbac check-permission parsing; real remote connection test

### DIFF
--- a/internal/cli/config/config.go
+++ b/internal/cli/config/config.go
@@ -1,8 +1,11 @@
 package config
 
 import (
+	"crypto/tls"
 	"fmt"
+	"net/http"
 	"os"
+	"time"
 
 	"github.com/keyorixhq/keyorix/internal/config"
 	"github.com/spf13/cobra"
@@ -165,16 +168,34 @@ func testRemoteConnection(cfg *config.Config) error {
 		return fmt.Errorf("remote configuration not found")
 	}
 
-	// TODO: Implement actual connection test
-	// For now, just validate configuration
 	if cfg.Storage.Remote.BaseURL == "" {
 		return fmt.Errorf("remote server URL not configured")
 	}
-
 	fmt.Printf("🌐 Remote server: %s\n", cfg.Storage.Remote.BaseURL)
-	fmt.Printf("✅ Configuration appears valid\n")
-	fmt.Printf("💡 Note: Actual connection test will be implemented in next phase\n")
 
+	timeout := time.Duration(cfg.Storage.Remote.TimeoutSeconds) * time.Second
+	if timeout <= 0 {
+		timeout = 10 * time.Second
+	}
+	client := &http.Client{
+		Timeout: timeout,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: !cfg.Storage.Remote.TLSVerify}, // #nosec G402 — honors the configured tls_verify
+		},
+	}
+
+	// Any HTTP response (even 401) proves the server is reachable; only a
+	// transport error means we couldn't connect. We probe a real API path.
+	resp, err := client.Get(cfg.Storage.Remote.BaseURL + "/api/v1/system/info")
+	if err != nil {
+		return fmt.Errorf("could not reach remote server: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	fmt.Printf("✅ Reachable (HTTP %d)\n", resp.StatusCode)
+	if resp.StatusCode == http.StatusUnauthorized {
+		fmt.Printf("💡 Server is up; this probe is unauthenticated, so credentials were not verified\n")
+	}
 	return nil
 }
 

--- a/internal/cli/config/conn_test.go
+++ b/internal/cli/config/conn_test.go
@@ -1,0 +1,43 @@
+package config
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	appconfig "github.com/keyorixhq/keyorix/internal/config"
+)
+
+func cfgFor(url string) *appconfig.Config {
+	c := &appconfig.Config{}
+	c.Storage.Remote = &appconfig.RemoteConfig{BaseURL: url, TLSVerify: false}
+	return c
+}
+
+func TestTestRemoteConnection_Reachable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized) // unauthenticated probe still proves reachability
+	}))
+	defer srv.Close()
+
+	if err := testRemoteConnection(cfgFor(srv.URL)); err != nil {
+		t.Fatalf("expected reachable server to pass, got %v", err)
+	}
+}
+
+func TestTestRemoteConnection_Unreachable(t *testing.T) {
+	// Closed server → connection refused.
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	url := srv.URL
+	srv.Close()
+
+	if err := testRemoteConnection(cfgFor(url)); err == nil {
+		t.Fatal("expected an error reaching a closed server, got nil")
+	}
+}
+
+func TestTestRemoteConnection_NoURL(t *testing.T) {
+	if err := testRemoteConnection(cfgFor("")); err == nil {
+		t.Fatal("expected an error when base URL is unset, got nil")
+	}
+}

--- a/internal/cli/rbac/check_permission.go
+++ b/internal/cli/rbac/check_permission.go
@@ -3,6 +3,7 @@ package rbac
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/keyorixhq/keyorix/internal/config"
 	"github.com/keyorixhq/keyorix/internal/core"
@@ -58,11 +59,11 @@ func runCheckPermission(cmd *cobra.Command, args []string) error {
 	// Create context
 	ctx := context.Background()
 
-	// Parse permission into resource and action
-	// For now, assume format like "secrets.read" or "system.admin"
-	// TODO: Implement proper permission parsing
-	resource := "secrets"
-	action := checkPermissionName
+	// Permissions are named "resource.action" (e.g. secrets.read, system.admin).
+	resource, action, perr := splitPermissionName(checkPermissionName)
+	if perr != nil {
+		return perr
+	}
 
 	hasPermission, err := service.HasPermissionByEmail(ctx, checkUserEmail, resource, action)
 	if err != nil {
@@ -76,4 +77,13 @@ func runCheckPermission(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+// splitPermissionName parses a "resource.action" permission name into its parts.
+func splitPermissionName(name string) (resource, action string, err error) {
+	parts := strings.SplitN(name, ".", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf("permission must be in 'resource.action' form (e.g. secrets.read), got %q", name)
+	}
+	return parts[0], parts[1], nil
 }

--- a/internal/cli/rbac/check_permission_test.go
+++ b/internal/cli/rbac/check_permission_test.go
@@ -1,0 +1,26 @@
+package rbac
+
+import "testing"
+
+func TestSplitPermissionName(t *testing.T) {
+	ok := map[string][2]string{
+		"secrets.read": {"secrets", "read"},
+		"system.admin": {"system", "admin"},
+		"roles.assign": {"roles", "assign"},
+	}
+	for name, want := range ok {
+		res, act, err := splitPermissionName(name)
+		if err != nil {
+			t.Fatalf("%q: unexpected error %v", name, err)
+		}
+		if res != want[0] || act != want[1] {
+			t.Errorf("%q: got (%q,%q), want (%q,%q)", name, res, act, want[0], want[1])
+		}
+	}
+
+	for _, bad := range []string{"", "noaction", ".read", "secrets.", "secrets"} {
+		if _, _, err := splitPermissionName(bad); err == nil {
+			t.Errorf("%q: expected an error, got nil", bad)
+		}
+	}
+}


### PR DESCRIPTION
**Item from the CLI-stubs cleanup.** Two fixes:

- **`rbac check-permission`** hardcoded `resource="secrets"` and used the whole permission string as the action — so `--permission system.admin` checked `secrets`/`"system.admin"` (wrong resource). Now parses the `resource.action` name and rejects malformed input instead of silently mis-checking.
- **`config test` (remote)** only validated config and printed "will be implemented in next phase". It now does a real reachability probe: `GET {base_url}/api/v1/system/info` with the configured timeout + `tls_verify`. Any HTTP response proves the server is up; a transport error fails. Notes that the unauthenticated probe doesn't verify credentials.

**Left as-is:** share self-remove's `getCurrentUserID()` placeholder — the local CLI has no authenticated-user concept to resolve it from (architectural, not a quick fix).

## Tests
`splitPermissionName` (valid/invalid forms); `testRemoteConnection` (reachable-401 / unreachable / no-URL) via `httptest`.

`go build`/`vet`/`gofmt` clean; full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)