### PR TITLE
feat(rbac): RBAC audit trail — emit role.assigned/removed and serve them

### DIFF
--- a/internal/core/audit.go
+++ b/internal/core/audit.go
@@ -2,11 +2,60 @@ package core
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
+
+// RBAC audit event types. Role assignments/removals are written to the shared
+// audit_events table and surfaced together by ListRBACAuditLogs.
+const (
+	EventRoleAssigned = "role.assigned"
+	EventRoleRemoved  = "role.removed"
+)
+
+// rbacAuditDetail is the structured payload stored in an RBAC event's Diff field,
+// carrying the target/role/scope that the generic AuditEvent row cannot.
+type rbacAuditDetail struct {
+	TargetUserID  uint `json:"target_user_id"`
+	RoleID        uint `json:"role_id"`
+	ProjectID     uint `json:"project_id,omitempty"`
+	EnvironmentID uint `json:"environment_id,omitempty"`
+}
+
+// LogRoleAssigned / LogRoleRemoved record an RBAC change. actorID is the user who
+// made the change (0 = no authenticated principal, e.g. a local CLI invocation);
+// the target/role/scope are captured in the event's structured diff.
+func (c *KeyorixCore) LogRoleAssigned(ctx context.Context, actorID, targetUserID, roleID uint, scope Scope) {
+	c.logRoleChange(ctx, EventRoleAssigned, "assigned to", actorID, targetUserID, roleID, scope)
+}
+
+func (c *KeyorixCore) LogRoleRemoved(ctx context.Context, actorID, targetUserID, roleID uint, scope Scope) {
+	c.logRoleChange(ctx, EventRoleRemoved, "removed from", actorID, targetUserID, roleID, scope)
+}
+
+func (c *KeyorixCore) logRoleChange(ctx context.Context, eventType, verb string, actorID, targetUserID, roleID uint, scope Scope) {
+	detail, _ := json.Marshal(rbacAuditDetail{
+		TargetUserID:  targetUserID,
+		RoleID:        roleID,
+		ProjectID:     scope.ProjectID,
+		EnvironmentID: scope.EnvironmentID,
+	})
+	var actor *uint
+	if actorID != 0 {
+		a := actorID
+		actor = &a
+	}
+	var projectID *uint
+	if scope.ProjectID != 0 {
+		p := scope.ProjectID
+		projectID = &p
+	}
+	desc := fmt.Sprintf("role %d %s user %d", roleID, verb, targetUserID)
+	c.writeAuditEventDiff(ctx, eventType, actor, nil, projectID, "", desc, string(detail))
+}
 
 // writeAuditEvent persists an audit_events row (basic — no project/IP context).
 func (c *KeyorixCore) writeAuditEvent(ctx context.Context, eventType string, userID *uint, secretID *uint, description string) {

--- a/internal/core/rbac.go
+++ b/internal/core/rbac.go
@@ -19,8 +19,9 @@ func (c *KeyorixCore) AssignRoleToUser(ctx context.Context, userEmail, roleName 
 	if err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorRoleNotFound", nil), err)
 	}
-	if err := c.storage.AssignRole(ctx, user.ID, role.ID, Scope{}); err != nil {
-		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	// actorID 0: invoked without an authenticated session (local CLI/system).
+	if err := c.AssignUserRole(ctx, 0, user.ID, role.ID, Scope{}); err != nil {
+		return err
 	}
 	return nil
 }
@@ -35,8 +36,9 @@ func (c *KeyorixCore) RemoveRoleFromUser(ctx context.Context, userEmail, roleNam
 	if err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorRoleNotFound", nil), err)
 	}
-	if err := c.storage.RemoveRole(ctx, user.ID, role.ID, Scope{}); err != nil {
-		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	// actorID 0: invoked without an authenticated session (local CLI/system).
+	if err := c.RemoveUserRole(ctx, 0, user.ID, role.ID, Scope{}); err != nil {
+		return err
 	}
 	return nil
 }

--- a/internal/core/rbac_audit.go
+++ b/internal/core/rbac_audit.go
@@ -1,0 +1,78 @@
+// rbac_audit.go — read side of the RBAC audit trail.
+//
+// Role assignments/removals are written to the shared audit_events table (see
+// audit.go LogRoleAssigned/LogRoleRemoved), with the target/role/scope carried in
+// the event's structured Diff. ListRBACAuditLogs pulls those event types back out
+// and reconstructs the per-change attribution.
+package core
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+)
+
+// RBACAuditEntry is a reconstructed RBAC audit record: who changed which role for
+// whom, at what scope, and when.
+type RBACAuditEntry struct {
+	ID           uint
+	Action       string // role.assigned | role.removed
+	ActorUserID  *uint  // the principal who made the change (nil for system/CLI)
+	TargetUserID *uint
+	RoleID       *uint
+	ProjectID    *uint
+	Details      string
+	CreatedAt    time.Time
+}
+
+// ListRBACAuditLogs returns the RBAC audit trail (role assignments/removals),
+// most-recent first, with pagination.
+func (c *KeyorixCore) ListRBACAuditLogs(ctx context.Context, page, pageSize int) ([]*RBACAuditEntry, int64, error) {
+	if page < 1 {
+		page = 1
+	}
+	if pageSize < 1 || pageSize > 100 {
+		pageSize = 50
+	}
+
+	events, total, err := c.storage.GetAuditLogs(ctx, &storage.AuditFilter{
+		Actions:  []string{EventRoleAssigned, EventRoleRemoved},
+		Page:     page,
+		PageSize: pageSize,
+	})
+	if err != nil {
+		return nil, 0, fmt.Errorf("%s: %w", "failed to read RBAC audit logs", err)
+	}
+
+	entries := make([]*RBACAuditEntry, 0, len(events))
+	for _, e := range events {
+		entry := &RBACAuditEntry{
+			ID:          e.ID,
+			Action:      e.EventType,
+			ActorUserID: e.UserID,
+			Details:     e.Description,
+			CreatedAt:   e.EventTime,
+		}
+		// Reconstruct target/role/scope from the structured diff.
+		var d rbacAuditDetail
+		if e.Diff != "" && json.Unmarshal([]byte(e.Diff), &d) == nil {
+			if d.TargetUserID != 0 {
+				t := d.TargetUserID
+				entry.TargetUserID = &t
+			}
+			if d.RoleID != 0 {
+				r := d.RoleID
+				entry.RoleID = &r
+			}
+			if d.ProjectID != 0 {
+				p := d.ProjectID
+				entry.ProjectID = &p
+			}
+		}
+		entries = append(entries, entry)
+	}
+	return entries, total, nil
+}

--- a/internal/core/rbac_audit_test.go
+++ b/internal/core/rbac_audit_test.go
@@ -1,0 +1,101 @@
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func newRBACAuditCore(t *testing.T) *KeyorixCore {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.AuditEvent{}, &models.UserRole{}))
+	return NewKeyorixCore(store.NewLocalStorage(db))
+}
+
+func TestRBACAuditTrail_AssignAndRemove(t *testing.T) {
+	c := newRBACAuditCore(t)
+	ctx := context.Background()
+
+	require.NoError(t, c.AssignUserRole(ctx, 5, 10, 2, Scope{ProjectID: 3}))
+	require.NoError(t, c.RemoveUserRole(ctx, 5, 10, 2, Scope{ProjectID: 3}))
+
+	entries, total, err := c.ListRBACAuditLogs(ctx, 1, 50)
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, total, int64(2))
+
+	var assigned, removed *RBACAuditEntry
+	for _, e := range entries {
+		switch e.Action {
+		case EventRoleAssigned:
+			assigned = e
+		case EventRoleRemoved:
+			removed = e
+		}
+	}
+
+	require.NotNil(t, assigned, "expected a role.assigned entry")
+	require.NotNil(t, assigned.ActorUserID)
+	assert.Equal(t, uint(5), *assigned.ActorUserID)
+	require.NotNil(t, assigned.TargetUserID)
+	assert.Equal(t, uint(10), *assigned.TargetUserID)
+	require.NotNil(t, assigned.RoleID)
+	assert.Equal(t, uint(2), *assigned.RoleID)
+	require.NotNil(t, assigned.ProjectID)
+	assert.Equal(t, uint(3), *assigned.ProjectID)
+
+	require.NotNil(t, removed, "expected a role.removed entry")
+	require.NotNil(t, removed.TargetUserID)
+	assert.Equal(t, uint(10), *removed.TargetUserID)
+}
+
+// A change made without an authenticated principal (actorID 0, e.g. local CLI)
+// records no actor.
+func TestRBACAuditTrail_SystemActor(t *testing.T) {
+	c := newRBACAuditCore(t)
+	ctx := context.Background()
+
+	require.NoError(t, c.AssignUserRole(ctx, 0, 11, 4, Scope{}))
+
+	entries, _, err := c.ListRBACAuditLogs(ctx, 1, 50)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Nil(t, entries[0].ActorUserID, "system/CLI actor should be unset")
+	require.NotNil(t, entries[0].RoleID)
+	assert.Equal(t, uint(4), *entries[0].RoleID)
+}
+
+// SetUserRoles diffs the current vs desired set and audits each resulting change.
+func TestRBACAuditTrail_SetUserRolesEmitsPerChange(t *testing.T) {
+	c := newRBACAuditCore(t)
+	ctx := context.Background()
+
+	// From {} to {1,2}: two assignments.
+	require.NoError(t, c.SetUserRoles(ctx, 9, 20, []uint{1, 2}, Scope{}))
+	// From {1,2} to {2,3}: remove 1, add 3.
+	require.NoError(t, c.SetUserRoles(ctx, 9, 20, []uint{2, 3}, Scope{}))
+
+	entries, _, err := c.ListRBACAuditLogs(ctx, 1, 50)
+	require.NoError(t, err)
+
+	var assigns, removes int
+	for _, e := range entries {
+		switch e.Action {
+		case EventRoleAssigned:
+			assigns++
+		case EventRoleRemoved:
+			removes++
+		}
+		require.NotNil(t, e.ActorUserID)
+		assert.Equal(t, uint(9), *e.ActorUserID)
+	}
+	assert.Equal(t, 3, assigns, "assigned roles 1,2 then 3")
+	assert.Equal(t, 1, removes, "removed role 1")
+}

--- a/internal/core/rbac_management.go
+++ b/internal/core/rbac_management.go
@@ -154,7 +154,7 @@ func (c *KeyorixCore) GetUserRolesByID(ctx context.Context, userID uint) ([]*mod
 // given scope. Only assignments at exactly that scope are considered: roles
 // present there but not in roleIDs are removed; roles in roleIDs not already
 // assigned there are added. Assignments at other scopes are left untouched.
-func (c *KeyorixCore) SetUserRoles(ctx context.Context, userID uint, roleIDs []uint, scope Scope) error {
+func (c *KeyorixCore) SetUserRoles(ctx context.Context, actorID, userID uint, roleIDs []uint, scope Scope) error {
 	current, err := c.storage.GetUserRoleIDsExact(ctx, userID, scope)
 	if err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
@@ -169,17 +169,39 @@ func (c *KeyorixCore) SetUserRoles(ctx context.Context, userID uint, roleIDs []u
 	}
 	for _, id := range current {
 		if !newSet[id] {
-			if err := c.storage.RemoveRole(ctx, userID, id, scope); err != nil {
-				return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+			if err := c.RemoveUserRole(ctx, actorID, userID, id, scope); err != nil {
+				return err
 			}
 		}
 	}
 	for _, id := range roleIDs {
 		if !currentSet[id] {
-			if err := c.storage.AssignRole(ctx, userID, id, scope); err != nil {
-				return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+			if err := c.AssignUserRole(ctx, actorID, userID, id, scope); err != nil {
+				return err
 			}
 		}
 	}
+	return nil
+}
+
+// AssignUserRole assigns a role to a user at the given scope and records an RBAC
+// audit event. actorID is the acting principal (0 when unauthenticated, e.g. a
+// local CLI invocation). This is the audited choke point all role-assignment
+// paths funnel through.
+func (c *KeyorixCore) AssignUserRole(ctx context.Context, actorID, userID, roleID uint, scope Scope) error {
+	if err := c.storage.AssignRole(ctx, userID, roleID, scope); err != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	c.LogRoleAssigned(ctx, actorID, userID, roleID, scope)
+	return nil
+}
+
+// RemoveUserRole removes a role from a user at the given scope and records an
+// RBAC audit event. See AssignUserRole for actorID semantics.
+func (c *KeyorixCore) RemoveUserRole(ctx context.Context, actorID, userID, roleID uint, scope Scope) error {
+	if err := c.storage.RemoveRole(ctx, userID, roleID, scope); err != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	c.LogRoleRemoved(ctx, actorID, userID, roleID, scope)
 	return nil
 }

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -299,8 +299,11 @@ type AuditFilter struct {
 	ProjectID *uint
 	UserID    *uint
 	Action    *string
-	Resource  *string
-	Success   *bool
+	// Actions matches any of several event types (event_type IN). Used to pull a
+	// related family of events together, e.g. the RBAC audit log (role.*).
+	Actions  []string
+	Resource *string
+	Success  *bool
 	// ActorType filters by acting-principal kind: "user" or "machine_identity"
 	// (also "system"). Nil = all actor types. (ADR-023)
 	ActorType *string

--- a/internal/storage/store/local_audit.go
+++ b/internal/storage/store/local_audit.go
@@ -49,6 +49,9 @@ func (ls *LocalStorage) GetAuditLogs(ctx context.Context, filter *storage.AuditF
 		if filter.Action != nil {
 			query = query.Where("event_type = ?", *filter.Action)
 		}
+		if len(filter.Actions) > 0 {
+			query = query.Where("event_type IN ?", filter.Actions)
+		}
 		if filter.StartTime != nil {
 			query = query.Where("event_time >= ?", *filter.StartTime)
 		}

--- a/server/grpc/services/audit_service.go
+++ b/server/grpc/services/audit_service.go
@@ -68,8 +68,7 @@ func (s *AuditGRPCService) GetAuditLogs(ctx context.Context, req *pb.GetAuditLog
 	}, nil
 }
 
-// GetRBACAuditLogs has no dedicated backing store yet; it returns an empty page
-// (mirroring the HTTP behaviour) rather than failing.
+// GetRBACAuditLogs returns the RBAC audit trail (role assignments/removals).
 func (s *AuditGRPCService) GetRBACAuditLogs(ctx context.Context, req *pb.GetRBACAuditLogsRequest) (*pb.GetRBACAuditLogsResponse, error) {
 	actor, err := requireUser(ctx)
 	if err != nil {
@@ -79,13 +78,45 @@ func (s *AuditGRPCService) GetRBACAuditLogs(ctx context.Context, req *pb.GetRBAC
 		return nil, status.Error(codes.PermissionDenied, "insufficient permissions to read audit logs")
 	}
 	page, pageSize := normalizePage(req.GetPage(), req.GetPageSize())
+
+	entries, total, err := s.core.ListRBACAuditLogs(ctx, page, pageSize)
+	if err != nil {
+		return nil, status.Error(codes.Internal, "failed to read RBAC audit logs")
+	}
+
+	logs := make([]*pb.RBACAuditLog, 0, len(entries))
+	for _, e := range entries {
+		logs = append(logs, rbacEntryToProto(e))
+	}
 	return &pb.GetRBACAuditLogsResponse{
-		Logs:       []*pb.RBACAuditLog{},
-		Total:      0,
+		Logs:       logs,
+		Total:      i64ToU32(total),
 		Page:       intToU32(page),
 		PageSize:   intToU32(pageSize),
-		TotalPages: 0,
+		TotalPages: intToU32(totalPages(int(total), pageSize)),
 	}, nil
+}
+
+func rbacEntryToProto(e *core.RBACAuditEntry) *pb.RBACAuditLog {
+	out := &pb.RBACAuditLog{
+		Id:        intToU32(int(e.ID)),
+		Action:    e.Action,
+		Details:   e.Details,
+		CreatedAt: timestamppb.New(e.CreatedAt),
+	}
+	if e.ActorUserID != nil {
+		out.ActorUserId = ptrU32(*e.ActorUserID)
+	}
+	if e.TargetUserID != nil {
+		out.TargetUserId = ptrU32(*e.TargetUserID)
+	}
+	if e.RoleID != nil {
+		out.RoleId = ptrU32(*e.RoleID)
+	}
+	if e.ProjectID != nil {
+		out.ProjectId = ptrU32(*e.ProjectID)
+	}
+	return out
 }
 
 // ---------------------------------------------------------------------------

--- a/server/grpc/services/audit_service_test.go
+++ b/server/grpc/services/audit_service_test.go
@@ -76,3 +76,27 @@ func TestAuditService_GetRBACAuditLogs_EmptyButOK(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, resp.GetLogs())
 }
+
+func TestAuditService_GetRBACAuditLogs_ReturnsRoleChanges(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.AuditEvent{}, &models.UserRole{}))
+	c := core.NewKeyorixCore(store.NewLocalStorage(db))
+	require.NoError(t, c.AssignUserRole(context.Background(), 5, 10, 2, core.Scope{ProjectID: 3}))
+
+	svc := NewAuditService(c)
+	resp, err := svc.GetRBACAuditLogs(auditCtx(), &pb.GetRBACAuditLogsRequest{})
+	require.NoError(t, err)
+	require.Len(t, resp.GetLogs(), 1)
+
+	log := resp.GetLogs()[0]
+	assert.Equal(t, core.EventRoleAssigned, log.GetAction())
+	require.NotNil(t, log.ActorUserId)
+	assert.Equal(t, uint32(5), log.GetActorUserId())
+	require.NotNil(t, log.TargetUserId)
+	assert.Equal(t, uint32(10), log.GetTargetUserId())
+	require.NotNil(t, log.RoleId)
+	assert.Equal(t, uint32(2), log.GetRoleId())
+	require.NotNil(t, log.ProjectId)
+	assert.Equal(t, uint32(3), log.GetProjectId())
+}

--- a/server/grpc/services/role_service.go
+++ b/server/grpc/services/role_service.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/keyorixhq/keyorix/internal/core"
-	corestorage "github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	pb "github.com/keyorixhq/keyorix/server/proto/pb"
 	"google.golang.org/grpc/codes"
@@ -186,8 +185,8 @@ func (s *RoleGRPCService) AssignRole(ctx context.Context, req *pb.AssignRoleRequ
 	if req.GetUserId() == 0 || req.GetRoleId() == 0 {
 		return nil, status.Error(codes.InvalidArgument, "user_id and role_id are required")
 	}
-	scope := corestorage.Scope{ProjectID: uint(req.GetProjectId()), EnvironmentID: uint(req.GetEnvironmentId())}
-	if err := s.core.Storage().AssignRole(ctx, uint(req.GetUserId()), uint(req.GetRoleId()), scope); err != nil {
+	scope := core.Scope{ProjectID: uint(req.GetProjectId()), EnvironmentID: uint(req.GetEnvironmentId())}
+	if err := s.core.AssignUserRole(ctx, actor.UserID, uint(req.GetUserId()), uint(req.GetRoleId()), scope); err != nil {
 		return nil, mapRoleError(err)
 	}
 	return &pb.RoleAssignment{
@@ -210,8 +209,8 @@ func (s *RoleGRPCService) RemoveRole(ctx context.Context, req *pb.RemoveRoleRequ
 	if req.GetUserId() == 0 || req.GetRoleId() == 0 {
 		return nil, status.Error(codes.InvalidArgument, "user_id and role_id are required")
 	}
-	scope := corestorage.Scope{ProjectID: uint(req.GetProjectId()), EnvironmentID: uint(req.GetEnvironmentId())}
-	if err := s.core.Storage().RemoveRole(ctx, uint(req.GetUserId()), uint(req.GetRoleId()), scope); err != nil {
+	scope := core.Scope{ProjectID: uint(req.GetProjectId()), EnvironmentID: uint(req.GetEnvironmentId())}
+	if err := s.core.RemoveUserRole(ctx, actor.UserID, uint(req.GetUserId()), uint(req.GetRoleId()), scope); err != nil {
 		return nil, mapRoleError(err)
 	}
 	return &emptypb.Empty{}, nil

--- a/server/http/handlers/audit.go
+++ b/server/http/handlers/audit.go
@@ -267,14 +267,48 @@ func actorTypeOrDefault(s string) string {
 	return s
 }
 
-// GetRBACAuditLogs handles GET /api/v1/audit/rbac-logs (stub — returns empty).
+// GetRBACAuditLogs handles GET /api/v1/audit/rbac-logs — the role-assignment
+// audit trail (role.assigned / role.removed).
 func (h *AuditHandler) GetRBACAuditLogs(w http.ResponseWriter, r *http.Request) {
 	userCtx := middleware.GetUserFromContext(r.Context())
 	if userCtx == nil {
 		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
 		return
 	}
+
+	page, pageSize := 1, 50
+	if p, err := strconv.Atoi(r.URL.Query().Get("page")); err == nil && p > 0 {
+		page = p
+	}
+	if ps, err := strconv.Atoi(r.URL.Query().Get("page_size")); err == nil && ps > 0 && ps <= 100 {
+		pageSize = ps
+	}
+
+	entries, total, err := h.coreService.ListRBACAuditLogs(r.Context(), page, pageSize)
+	if err != nil {
+		sendError(w, "InternalError", "Failed to retrieve RBAC audit logs", http.StatusInternalServerError, nil)
+		return
+	}
+
+	logs := make([]map[string]interface{}, 0, len(entries))
+	for _, e := range entries {
+		logs = append(logs, map[string]interface{}{
+			"id":             e.ID,
+			"action":         e.Action,
+			"actor_user_id":  e.ActorUserID,
+			"target_user_id": e.TargetUserID,
+			"role_id":        e.RoleID,
+			"project_id":     e.ProjectID,
+			"details":        e.Details,
+			"created_at":     e.CreatedAt.UTC().Format(time.RFC3339),
+		})
+	}
+
+	totalPages := 0
+	if pageSize > 0 {
+		totalPages = int((total + int64(pageSize) - 1) / int64(pageSize))
+	}
 	sendSuccess(w, map[string]interface{}{
-		"logs": []interface{}{}, "page": 1, "page_size": 50, "total": 0, "total_pages": 0,
+		"logs": logs, "page": page, "page_size": pageSize, "total": total, "total_pages": totalPages,
 	}, "")
 }

--- a/server/http/handlers/users_roles.go
+++ b/server/http/handlers/users_roles.go
@@ -122,7 +122,8 @@ func (h *UsersRolesHandler) GetUserMembershipsForUser(w http.ResponseWriter, r *
 
 // UpdateUserRoles handles PUT /api/v1/users/{id}/roles — full role replacement.
 func (h *UsersRolesHandler) UpdateUserRoles(w http.ResponseWriter, r *http.Request) {
-	if middleware.GetUserFromContext(r.Context()) == nil {
+	actor := middleware.GetUserFromContext(r.Context())
+	if actor == nil {
 		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
 		return
 	}
@@ -162,7 +163,7 @@ func (h *UsersRolesHandler) UpdateUserRoles(w http.ResponseWriter, r *http.Reque
 	}
 
 	scope := core.Scope{ProjectID: req.ProjectID, EnvironmentID: req.EnvironmentID}
-	if err := h.coreService.SetUserRoles(r.Context(), userID, req.RoleIDs, scope); err != nil {
+	if err := h.coreService.SetUserRoles(r.Context(), actor.UserID, userID, req.RoleIDs, scope); err != nil {
 		log.Printf("Error setting roles for user %d: %v", userID, err)
 		if strings.Contains(err.Error(), "not found") {
 			sendError(w, "NotFound", "User not found", http.StatusNotFound, nil)


### PR DESCRIPTION
**The feature-sized item you picked.** `GetRBACAuditLogs` was a stub returning empty because RBAC role changes emitted **no** audit events. This implements the full trail (v1: user-role assign/remove), reusing the existing `audit_events` pipeline — no new table, and it inherits SIEM forwarding + the existing query path.

## Emit
- New audited choke point **`AssignUserRole`/`RemoveUserRole`** writes the storage grant **plus** a `role.assigned`/`role.removed` event — actor as `UserID`, and `{target_user_id, role_id, project_id, environment_id}` in the structured `Diff` (the generic `AuditEvent` row has no target/role columns).
- `SetUserRoles`, `AssignRoleToUser`, `RemoveRoleFromUser` now funnel through it. `SetUserRoles` takes an `actorID` (the one HTTP caller passes the authed admin).
- **The gRPC `RoleService.AssignRole`/`RemoveRole` previously hit storage directly, bypassing audit** — now routed through the core choke point, recorded with the caller's identity. CLI/email paths pass `actorID 0` (local CLI has no authenticated principal).

## Query
- `AuditFilter` gains `Actions []string` (`event_type IN`); local query honors it.
- `core.ListRBACAuditLogs` filters `role.*` events and reconstructs actor/target/role/scope from the diff into `RBACAuditEntry`.
- Wired into **HTTP `GetRBACAuditLogs`** (was the stub) and **gRPC `GetRBACAuditLogs`**.

## Deferred (noted)
Group-role and permission-to-role change events.

## Tests
emit+query round trip (assign/remove, scope, system actor, SetUserRoles per-change diff) + gRPC mapping. `go build`/`vet`/`gofmt` clean; full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)