### PR TITLE
feat(rbac): audit group-role assignments (extends the RBAC audit trail)

### DIFF
--- a/internal/core/audit.go
+++ b/internal/core/audit.go
@@ -14,8 +14,8 @@ import (
 const (
 	EventRoleAssigned      = "role.assigned"
 	EventRoleRemoved       = "role.removed"
-	EventRoleGroupAssigned = "role.group_assigned"
-	EventRoleGroupRemoved  = "role.group_removed"
+	EventRoleGroupAssigned = "role.group_assigned" // #nosec G101 -- audit event type, not a credential
+	EventRoleGroupRemoved  = "role.group_removed"  // #nosec G101 -- audit event type, not a credential
 )
 
 // rbacAuditEventTypes is the set of event types that make up the RBAC audit log.

--- a/internal/core/audit.go
+++ b/internal/core/audit.go
@@ -12,14 +12,23 @@ import (
 // RBAC audit event types. Role assignments/removals are written to the shared
 // audit_events table and surfaced together by ListRBACAuditLogs.
 const (
-	EventRoleAssigned = "role.assigned"
-	EventRoleRemoved  = "role.removed"
+	EventRoleAssigned      = "role.assigned"
+	EventRoleRemoved       = "role.removed"
+	EventRoleGroupAssigned = "role.group_assigned"
+	EventRoleGroupRemoved  = "role.group_removed"
 )
+
+// rbacAuditEventTypes is the set of event types that make up the RBAC audit log.
+var rbacAuditEventTypes = []string{
+	EventRoleAssigned, EventRoleRemoved,
+	EventRoleGroupAssigned, EventRoleGroupRemoved,
+}
 
 // rbacAuditDetail is the structured payload stored in an RBAC event's Diff field,
 // carrying the target/role/scope that the generic AuditEvent row cannot.
 type rbacAuditDetail struct {
-	TargetUserID  uint `json:"target_user_id"`
+	TargetUserID  uint `json:"target_user_id,omitempty"`
+	GroupID       uint `json:"group_id,omitempty"`
 	RoleID        uint `json:"role_id"`
 	ProjectID     uint `json:"project_id,omitempty"`
 	EnvironmentID uint `json:"environment_id,omitempty"`
@@ -37,12 +46,39 @@ func (c *KeyorixCore) LogRoleRemoved(ctx context.Context, actorID, targetUserID,
 }
 
 func (c *KeyorixCore) logRoleChange(ctx context.Context, eventType, verb string, actorID, targetUserID, roleID uint, scope Scope) {
-	detail, _ := json.Marshal(rbacAuditDetail{
+	desc := fmt.Sprintf("role %d %s user %d", roleID, verb, targetUserID)
+	c.writeRBACAudit(ctx, eventType, desc, actorID, scope, rbacAuditDetail{
 		TargetUserID:  targetUserID,
 		RoleID:        roleID,
 		ProjectID:     scope.ProjectID,
 		EnvironmentID: scope.EnvironmentID,
 	})
+}
+
+// LogGroupRoleAssigned / LogGroupRoleRemoved record a role granted to / removed
+// from a group. See LogRoleAssigned for actorID semantics.
+func (c *KeyorixCore) LogGroupRoleAssigned(ctx context.Context, actorID, groupID, roleID uint, scope Scope) {
+	c.logGroupRoleChange(ctx, EventRoleGroupAssigned, "assigned to group", actorID, groupID, roleID, scope)
+}
+
+func (c *KeyorixCore) LogGroupRoleRemoved(ctx context.Context, actorID, groupID, roleID uint, scope Scope) {
+	c.logGroupRoleChange(ctx, EventRoleGroupRemoved, "removed from group", actorID, groupID, roleID, scope)
+}
+
+func (c *KeyorixCore) logGroupRoleChange(ctx context.Context, eventType, verb string, actorID, groupID, roleID uint, scope Scope) {
+	desc := fmt.Sprintf("role %d %s %d", roleID, verb, groupID)
+	c.writeRBACAudit(ctx, eventType, desc, actorID, scope, rbacAuditDetail{
+		GroupID:       groupID,
+		RoleID:        roleID,
+		ProjectID:     scope.ProjectID,
+		EnvironmentID: scope.EnvironmentID,
+	})
+}
+
+// writeRBACAudit is the shared writer for RBAC audit events: actor as UserID,
+// scope's project as ProjectID, and the structured detail in the diff.
+func (c *KeyorixCore) writeRBACAudit(ctx context.Context, eventType, desc string, actorID uint, scope Scope, detail rbacAuditDetail) {
+	encoded, _ := json.Marshal(detail)
 	var actor *uint
 	if actorID != 0 {
 		a := actorID
@@ -53,8 +89,7 @@ func (c *KeyorixCore) logRoleChange(ctx context.Context, eventType, verb string,
 		p := scope.ProjectID
 		projectID = &p
 	}
-	desc := fmt.Sprintf("role %d %s user %d", roleID, verb, targetUserID)
-	c.writeAuditEventDiff(ctx, eventType, actor, nil, projectID, "", desc, string(detail))
+	c.writeAuditEventDiff(ctx, eventType, actor, nil, projectID, "", desc, string(encoded))
 }
 
 // writeAuditEvent persists an audit_events row (basic — no project/IP context).

--- a/internal/core/rbac_audit.go
+++ b/internal/core/rbac_audit.go
@@ -19,9 +19,10 @@ import (
 // whom, at what scope, and when.
 type RBACAuditEntry struct {
 	ID           uint
-	Action       string // role.assigned | role.removed
+	Action       string // role.assigned | role.removed | role.group_assigned | role.group_removed
 	ActorUserID  *uint  // the principal who made the change (nil for system/CLI)
-	TargetUserID *uint
+	TargetUserID *uint  // set for user-role events
+	GroupID      *uint  // set for group-role events
 	RoleID       *uint
 	ProjectID    *uint
 	Details      string
@@ -39,7 +40,7 @@ func (c *KeyorixCore) ListRBACAuditLogs(ctx context.Context, page, pageSize int)
 	}
 
 	events, total, err := c.storage.GetAuditLogs(ctx, &storage.AuditFilter{
-		Actions:  []string{EventRoleAssigned, EventRoleRemoved},
+		Actions:  rbacAuditEventTypes,
 		Page:     page,
 		PageSize: pageSize,
 	})
@@ -62,6 +63,10 @@ func (c *KeyorixCore) ListRBACAuditLogs(ctx context.Context, page, pageSize int)
 			if d.TargetUserID != 0 {
 				t := d.TargetUserID
 				entry.TargetUserID = &t
+			}
+			if d.GroupID != 0 {
+				g := d.GroupID
+				entry.GroupID = &g
 			}
 			if d.RoleID != 0 {
 				r := d.RoleID

--- a/internal/core/rbac_audit_test.go
+++ b/internal/core/rbac_audit_test.go
@@ -72,6 +72,34 @@ func TestRBACAuditTrail_SystemActor(t *testing.T) {
 	assert.Equal(t, uint(4), *entries[0].RoleID)
 }
 
+func TestRBACAuditTrail_GroupRole(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.AuditEvent{}, &models.Group{}, &models.Role{}, &models.GroupRole{},
+	))
+	require.NoError(t, db.Create(&models.Group{ID: 7, Name: "platform"}).Error)
+	require.NoError(t, db.Create(&models.Role{ID: 2, Name: "editor"}).Error)
+	c := NewKeyorixCore(store.NewLocalStorage(db))
+	ctx := context.Background()
+
+	require.NoError(t, c.AssignRoleToGroup(ctx, 5, 7, 2, Scope{ProjectID: 3}))
+
+	entries, _, err := c.ListRBACAuditLogs(ctx, 1, 50)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+
+	e := entries[0]
+	assert.Equal(t, EventRoleGroupAssigned, e.Action)
+	require.NotNil(t, e.ActorUserID)
+	assert.Equal(t, uint(5), *e.ActorUserID)
+	require.NotNil(t, e.GroupID)
+	assert.Equal(t, uint(7), *e.GroupID)
+	require.NotNil(t, e.RoleID)
+	assert.Equal(t, uint(2), *e.RoleID)
+	assert.Nil(t, e.TargetUserID, "group event has no target user")
+}
+
 // SetUserRoles diffs the current vs desired set and audits each resulting change.
 func TestRBACAuditTrail_SetUserRolesEmitsPerChange(t *testing.T) {
 	c := newRBACAuditCore(t)

--- a/internal/core/rbac_management.go
+++ b/internal/core/rbac_management.go
@@ -78,8 +78,9 @@ func (c *KeyorixCore) GetGroupRoles(ctx context.Context, groupID uint) ([]*model
 	return roles, nil
 }
 
-// AssignRoleToGroup verifies both exist then assigns the role at scope.
-func (c *KeyorixCore) AssignRoleToGroup(ctx context.Context, groupID, roleID uint, scope Scope) error {
+// AssignRoleToGroup verifies both exist then assigns the role at scope and
+// records an RBAC audit event. actorID is the acting principal (0 = none).
+func (c *KeyorixCore) AssignRoleToGroup(ctx context.Context, actorID, groupID, roleID uint, scope Scope) error {
 	if _, err := c.storage.GetGroup(ctx, groupID); err != nil {
 		return fmt.Errorf("group not found: %w", err)
 	}
@@ -89,17 +90,20 @@ func (c *KeyorixCore) AssignRoleToGroup(ctx context.Context, groupID, roleID uin
 	if err := c.storage.AssignRoleToGroup(ctx, groupID, roleID, scope); err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}
+	c.LogGroupRoleAssigned(ctx, actorID, groupID, roleID, scope)
 	return nil
 }
 
-// RemoveRoleFromGroup verifies the group exists then removes the role at scope.
-func (c *KeyorixCore) RemoveRoleFromGroup(ctx context.Context, groupID, roleID uint, scope Scope) error {
+// RemoveRoleFromGroup verifies the group exists then removes the role at scope
+// and records an RBAC audit event. actorID is the acting principal (0 = none).
+func (c *KeyorixCore) RemoveRoleFromGroup(ctx context.Context, actorID, groupID, roleID uint, scope Scope) error {
 	if _, err := c.storage.GetGroup(ctx, groupID); err != nil {
 		return fmt.Errorf("group not found: %w", err)
 	}
 	if err := c.storage.RemoveRoleFromGroup(ctx, groupID, roleID, scope); err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}
+	c.LogGroupRoleRemoved(ctx, actorID, groupID, roleID, scope)
 	return nil
 }
 

--- a/server/grpc/services/audit_service.go
+++ b/server/grpc/services/audit_service.go
@@ -110,6 +110,9 @@ func rbacEntryToProto(e *core.RBACAuditEntry) *pb.RBACAuditLog {
 	if e.TargetUserID != nil {
 		out.TargetUserId = ptrU32(*e.TargetUserID)
 	}
+	if e.GroupID != nil {
+		out.GroupId = ptrU32(*e.GroupID)
+	}
 	if e.RoleID != nil {
 		out.RoleId = ptrU32(*e.RoleID)
 	}

--- a/server/http/handlers/audit.go
+++ b/server/http/handlers/audit.go
@@ -297,6 +297,7 @@ func (h *AuditHandler) GetRBACAuditLogs(w http.ResponseWriter, r *http.Request) 
 			"action":         e.Action,
 			"actor_user_id":  e.ActorUserID,
 			"target_user_id": e.TargetUserID,
+			"group_id":       e.GroupID,
 			"role_id":        e.RoleID,
 			"project_id":     e.ProjectID,
 			"details":        e.Details,

--- a/server/http/handlers/rbac.go
+++ b/server/http/handlers/rbac.go
@@ -580,7 +580,7 @@ func (h *RBACHandler) AssignRoleToGroup(w http.ResponseWriter, r *http.Request) 
 	}
 
 	scope := core.Scope{ProjectID: body.ProjectID, EnvironmentID: body.EnvironmentID}
-	if err := h.coreService.AssignRoleToGroup(r.Context(), groupID, body.RoleID, scope); err != nil {
+	if err := h.coreService.AssignRoleToGroup(r.Context(), userCtx.UserID, groupID, body.RoleID, scope); err != nil {
 		log.Printf("Error assigning role to group: %v", err)
 		if strings.Contains(err.Error(), "not found") {
 			sendError(w, "NotFound", err.Error(), http.StatusNotFound, nil)
@@ -617,7 +617,7 @@ func (h *RBACHandler) RemoveRoleFromGroup(w http.ResponseWriter, r *http.Request
 		EnvironmentID: queryUint(r, "environment_id"),
 	}
 
-	if err := h.coreService.RemoveRoleFromGroup(r.Context(), groupID, roleID, scope); err != nil {
+	if err := h.coreService.RemoveRoleFromGroup(r.Context(), userCtx.UserID, groupID, roleID, scope); err != nil {
 		log.Printf("Error removing role from group: %v", err)
 		if strings.Contains(err.Error(), "not found") {
 			sendError(w, "NotFound", err.Error(), http.StatusNotFound, nil)

--- a/server/proto/keyorix.proto
+++ b/server/proto/keyorix.proto
@@ -449,6 +449,9 @@ message RBACAuditLog {
   optional uint32 project_id = 6;
   string details = 7;
   google.protobuf.Timestamp created_at = 8;
+  // Set for group-role events (role.group_assigned / role.group_removed): the
+  // group the role was granted to / removed from.
+  optional uint32 group_id = 9;
 }
 
 message GetRBACAuditLogsRequest {

--- a/server/proto/pb/keyorix.pb.go
+++ b/server/proto/pb/keyorix.pb.go
@@ -2768,15 +2768,18 @@ func (x *GetAuditLogsResponse) GetTotalPages() uint32 {
 }
 
 type RBACAuditLog struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Id            uint32                 `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
-	Action        string                 `protobuf:"bytes,2,opt,name=action,proto3" json:"action,omitempty"`
-	ActorUserId   *uint32                `protobuf:"varint,3,opt,name=actor_user_id,json=actorUserId,proto3,oneof" json:"actor_user_id,omitempty"`
-	TargetUserId  *uint32                `protobuf:"varint,4,opt,name=target_user_id,json=targetUserId,proto3,oneof" json:"target_user_id,omitempty"`
-	RoleId        *uint32                `protobuf:"varint,5,opt,name=role_id,json=roleId,proto3,oneof" json:"role_id,omitempty"`
-	ProjectId     *uint32                `protobuf:"varint,6,opt,name=project_id,json=projectId,proto3,oneof" json:"project_id,omitempty"`
-	Details       string                 `protobuf:"bytes,7,opt,name=details,proto3" json:"details,omitempty"`
-	CreatedAt     *timestamppb.Timestamp `protobuf:"bytes,8,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
+	state        protoimpl.MessageState `protogen:"open.v1"`
+	Id           uint32                 `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
+	Action       string                 `protobuf:"bytes,2,opt,name=action,proto3" json:"action,omitempty"`
+	ActorUserId  *uint32                `protobuf:"varint,3,opt,name=actor_user_id,json=actorUserId,proto3,oneof" json:"actor_user_id,omitempty"`
+	TargetUserId *uint32                `protobuf:"varint,4,opt,name=target_user_id,json=targetUserId,proto3,oneof" json:"target_user_id,omitempty"`
+	RoleId       *uint32                `protobuf:"varint,5,opt,name=role_id,json=roleId,proto3,oneof" json:"role_id,omitempty"`
+	ProjectId    *uint32                `protobuf:"varint,6,opt,name=project_id,json=projectId,proto3,oneof" json:"project_id,omitempty"`
+	Details      string                 `protobuf:"bytes,7,opt,name=details,proto3" json:"details,omitempty"`
+	CreatedAt    *timestamppb.Timestamp `protobuf:"bytes,8,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
+	// Set for group-role events (role.group_assigned / role.group_removed): the
+	// group the role was granted to / removed from.
+	GroupId       *uint32 `protobuf:"varint,9,opt,name=group_id,json=groupId,proto3,oneof" json:"group_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2865,6 +2868,13 @@ func (x *RBACAuditLog) GetCreatedAt() *timestamppb.Timestamp {
 		return x.CreatedAt
 	}
 	return nil
+}
+
+func (x *RBACAuditLog) GetGroupId() uint32 {
+	if x != nil && x.GroupId != nil {
+		return *x.GroupId
+	}
+	return 0
 }
 
 type GetRBACAuditLogsRequest struct {
@@ -4607,7 +4617,7 @@ const file_keyorix_proto_rawDesc = "" +
 	"\x04page\x18\x03 \x01(\rR\x04page\x12\x1b\n" +
 	"\tpage_size\x18\x04 \x01(\rR\bpageSize\x12\x1f\n" +
 	"\vtotal_pages\x18\x05 \x01(\rR\n" +
-	"totalPages\"\xe1\x02\n" +
+	"totalPages\"\x8e\x03\n" +
 	"\fRBACAuditLog\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\rR\x02id\x12\x16\n" +
 	"\x06action\x18\x02 \x01(\tR\x06action\x12'\n" +
@@ -4618,12 +4628,14 @@ const file_keyorix_proto_rawDesc = "" +
 	"project_id\x18\x06 \x01(\rH\x03R\tprojectId\x88\x01\x01\x12\x18\n" +
 	"\adetails\x18\a \x01(\tR\adetails\x129\n" +
 	"\n" +
-	"created_at\x18\b \x01(\v2\x1a.google.protobuf.TimestampR\tcreatedAtB\x10\n" +
+	"created_at\x18\b \x01(\v2\x1a.google.protobuf.TimestampR\tcreatedAt\x12\x1e\n" +
+	"\bgroup_id\x18\t \x01(\rH\x04R\agroupId\x88\x01\x01B\x10\n" +
 	"\x0e_actor_user_idB\x11\n" +
 	"\x0f_target_user_idB\n" +
 	"\n" +
 	"\b_role_idB\r\n" +
-	"\v_project_id\"\xeb\x01\n" +
+	"\v_project_idB\v\n" +
+	"\t_group_id\"\xeb\x01\n" +
 	"\x17GetRBACAuditLogsRequest\x12\x1b\n" +
 	"\x06action\x18\x01 \x01(\tH\x00R\x06action\x88\x01\x01\x12'\n" +
 	"\ractor_user_id\x18\x02 \x01(\rH\x01R\vactorUserId\x88\x01\x01\x12)\n" +


### PR DESCRIPTION
Follow-up to #47. Role grants to **groups** were still unaudited.

## Changes
- `AssignRoleToGroup`/`RemoveRoleFromGroup` take an `actorID` and emit `role.group_assigned` / `role.group_removed`, carrying `group_id` (+ role/scope) in the structured diff. The two HTTP handlers pass the authed admin.
- `ListRBACAuditLogs` includes the group event types and reconstructs `GroupID`, surfaced via a new `RBACAuditLog.group_id` proto field (HTTP + gRPC).
- Clean call sites (HTTP-only via the core methods) — no bypass rerouting needed.

## Deferred (noted)
**Permission-to-role** change auditing: assigned via direct `storage` calls inside role create/update across gRPC, HTTP, and bootstrap, so it needs those flows rerouted through an audited path first — a larger change than this clean slice.

## Tests
group-role emit+query round trip (action, actor, group_id, role_id, no target user). `buf lint` clean; `go build`/`vet`/`gofmt` clean; full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)