### PR TITLE
feat(rbac): audit permission-to-role changes (completes the RBAC audit trail)

### DIFF
--- a/internal/core/audit.go
+++ b/internal/core/audit.go
@@ -16,12 +16,15 @@ const (
 	EventRoleRemoved       = "role.removed"
 	EventRoleGroupAssigned = "role.group_assigned" // #nosec G101 -- audit event type, not a credential
 	EventRoleGroupRemoved  = "role.group_removed"  // #nosec G101 -- audit event type, not a credential
+	EventPermissionAdded   = "permission.assigned" // #nosec G101 -- audit event type, not a credential
+	EventPermissionRemoved = "permission.removed"  // #nosec G101 -- audit event type, not a credential
 )
 
 // rbacAuditEventTypes is the set of event types that make up the RBAC audit log.
 var rbacAuditEventTypes = []string{
 	EventRoleAssigned, EventRoleRemoved,
 	EventRoleGroupAssigned, EventRoleGroupRemoved,
+	EventPermissionAdded, EventPermissionRemoved,
 }
 
 // rbacAuditDetail is the structured payload stored in an RBAC event's Diff field,
@@ -30,6 +33,7 @@ type rbacAuditDetail struct {
 	TargetUserID  uint `json:"target_user_id,omitempty"`
 	GroupID       uint `json:"group_id,omitempty"`
 	RoleID        uint `json:"role_id"`
+	PermissionID  uint `json:"permission_id,omitempty"`
 	ProjectID     uint `json:"project_id,omitempty"`
 	EnvironmentID uint `json:"environment_id,omitempty"`
 }
@@ -72,6 +76,24 @@ func (c *KeyorixCore) logGroupRoleChange(ctx context.Context, eventType, verb st
 		RoleID:        roleID,
 		ProjectID:     scope.ProjectID,
 		EnvironmentID: scope.EnvironmentID,
+	})
+}
+
+// LogPermissionAssigned / LogPermissionRemoved record a permission granted to /
+// removed from a role. See LogRoleAssigned for actorID semantics.
+func (c *KeyorixCore) LogPermissionAssigned(ctx context.Context, actorID, roleID, permissionID uint) {
+	c.logPermissionChange(ctx, EventPermissionAdded, "granted to role", actorID, roleID, permissionID)
+}
+
+func (c *KeyorixCore) LogPermissionRemoved(ctx context.Context, actorID, roleID, permissionID uint) {
+	c.logPermissionChange(ctx, EventPermissionRemoved, "removed from role", actorID, roleID, permissionID)
+}
+
+func (c *KeyorixCore) logPermissionChange(ctx context.Context, eventType, verb string, actorID, roleID, permissionID uint) {
+	desc := fmt.Sprintf("permission %d %s %d", permissionID, verb, roleID)
+	c.writeRBACAudit(ctx, eventType, desc, actorID, Scope{}, rbacAuditDetail{
+		RoleID:       roleID,
+		PermissionID: permissionID,
 	})
 }
 

--- a/internal/core/rbac_audit.go
+++ b/internal/core/rbac_audit.go
@@ -24,6 +24,7 @@ type RBACAuditEntry struct {
 	TargetUserID *uint  // set for user-role events
 	GroupID      *uint  // set for group-role events
 	RoleID       *uint
+	PermissionID *uint // set for permission-to-role events
 	ProjectID    *uint
 	Details      string
 	CreatedAt    time.Time
@@ -71,6 +72,10 @@ func (c *KeyorixCore) ListRBACAuditLogs(ctx context.Context, page, pageSize int)
 			if d.RoleID != 0 {
 				r := d.RoleID
 				entry.RoleID = &r
+			}
+			if d.PermissionID != 0 {
+				pid := d.PermissionID
+				entry.PermissionID = &pid
 			}
 			if d.ProjectID != 0 {
 				p := d.ProjectID

--- a/internal/core/rbac_audit_test.go
+++ b/internal/core/rbac_audit_test.go
@@ -100,6 +100,39 @@ func TestRBACAuditTrail_GroupRole(t *testing.T) {
 	assert.Nil(t, e.TargetUserID, "group event has no target user")
 }
 
+func TestRBACAuditTrail_PermissionToRole(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.AuditEvent{}, &models.Role{}, &models.Permission{}, &models.RolePermission{},
+	))
+	require.NoError(t, db.Create(&models.Role{ID: 2, Name: "editor"}).Error)
+	require.NoError(t, db.Create(&models.Permission{ID: 8, Name: "secrets.write", Resource: "secrets", Action: "write"}).Error)
+	c := NewKeyorixCore(store.NewLocalStorage(db))
+	ctx := context.Background()
+
+	require.NoError(t, c.AssignPermissionToRole(ctx, 5, 2, 8))
+	require.NoError(t, c.RemovePermissionFromRole(ctx, 5, 2, 8))
+
+	entries, _, err := c.ListRBACAuditLogs(ctx, 1, 50)
+	require.NoError(t, err)
+	require.Len(t, entries, 2)
+
+	var added *RBACAuditEntry
+	for _, e := range entries {
+		if e.Action == EventPermissionAdded {
+			added = e
+		}
+	}
+	require.NotNil(t, added, "expected a permission.assigned entry")
+	require.NotNil(t, added.ActorUserID)
+	assert.Equal(t, uint(5), *added.ActorUserID)
+	require.NotNil(t, added.RoleID)
+	assert.Equal(t, uint(2), *added.RoleID)
+	require.NotNil(t, added.PermissionID)
+	assert.Equal(t, uint(8), *added.PermissionID)
+}
+
 // SetUserRoles diffs the current vs desired set and audits each resulting change.
 func TestRBACAuditTrail_SetUserRolesEmitsPerChange(t *testing.T) {
 	c := newRBACAuditCore(t)

--- a/internal/core/rbac_management.go
+++ b/internal/core/rbac_management.go
@@ -44,8 +44,9 @@ func (c *KeyorixCore) GetRoleWithPermissions(ctx context.Context, roleID uint) (
 	return role, perms, nil
 }
 
-// AssignPermissionToRole verifies both exist and assigns the permission.
-func (c *KeyorixCore) AssignPermissionToRole(ctx context.Context, roleID, permissionID uint) error {
+// AssignPermissionToRole verifies both exist, assigns the permission, and records
+// an RBAC audit event. actorID is the acting principal (0 = none).
+func (c *KeyorixCore) AssignPermissionToRole(ctx context.Context, actorID, roleID, permissionID uint) error {
 	if _, err := c.storage.GetRole(ctx, roleID); err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorRoleNotFound", nil), err)
 	}
@@ -55,17 +56,20 @@ func (c *KeyorixCore) AssignPermissionToRole(ctx context.Context, roleID, permis
 	if err := c.storage.AssignPermissionToRole(ctx, roleID, permissionID); err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}
+	c.LogPermissionAssigned(ctx, actorID, roleID, permissionID)
 	return nil
 }
 
-// RemovePermissionFromRole verifies the role exists then removes the permission.
-func (c *KeyorixCore) RemovePermissionFromRole(ctx context.Context, roleID, permissionID uint) error {
+// RemovePermissionFromRole verifies the role exists, removes the permission, and
+// records an RBAC audit event. actorID is the acting principal (0 = none).
+func (c *KeyorixCore) RemovePermissionFromRole(ctx context.Context, actorID, roleID, permissionID uint) error {
 	if _, err := c.storage.GetRole(ctx, roleID); err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorRoleNotFound", nil), err)
 	}
 	if err := c.storage.RemovePermissionFromRole(ctx, roleID, permissionID); err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}
+	c.LogPermissionRemoved(ctx, actorID, roleID, permissionID)
 	return nil
 }
 

--- a/server/grpc/services/audit_service.go
+++ b/server/grpc/services/audit_service.go
@@ -113,6 +113,9 @@ func rbacEntryToProto(e *core.RBACAuditEntry) *pb.RBACAuditLog {
 	if e.GroupID != nil {
 		out.GroupId = ptrU32(*e.GroupID)
 	}
+	if e.PermissionID != nil {
+		out.PermissionId = ptrU32(*e.PermissionID)
+	}
 	if e.RoleID != nil {
 		out.RoleId = ptrU32(*e.RoleID)
 	}

--- a/server/grpc/services/role_service.go
+++ b/server/grpc/services/role_service.go
@@ -51,7 +51,7 @@ func (s *RoleGRPCService) CreateRole(ctx context.Context, req *pb.CreateRoleRequ
 		return nil, mapRoleError(err)
 	}
 	for _, pid := range permIDs {
-		if err := s.core.Storage().AssignPermissionToRole(ctx, role.ID, pid); err != nil {
+		if err := s.core.AssignPermissionToRole(ctx, actor.UserID, role.ID, pid); err != nil {
 			return nil, status.Error(codes.Internal, "failed to assign permissions to role")
 		}
 	}
@@ -102,12 +102,12 @@ func (s *RoleGRPCService) UpdateRole(ctx context.Context, req *pb.UpdateRoleRequ
 			return nil, err
 		}
 		for _, p := range current {
-			if err := s.core.Storage().RemovePermissionFromRole(ctx, role.ID, p.ID); err != nil {
+			if err := s.core.RemovePermissionFromRole(ctx, actor.UserID, role.ID, p.ID); err != nil {
 				return nil, status.Error(codes.Internal, "failed to update role permissions")
 			}
 		}
 		for _, pid := range permIDs {
-			if err := s.core.Storage().AssignPermissionToRole(ctx, role.ID, pid); err != nil {
+			if err := s.core.AssignPermissionToRole(ctx, actor.UserID, role.ID, pid); err != nil {
 				return nil, status.Error(codes.Internal, "failed to update role permissions")
 			}
 		}

--- a/server/http/handlers/audit.go
+++ b/server/http/handlers/audit.go
@@ -299,6 +299,7 @@ func (h *AuditHandler) GetRBACAuditLogs(w http.ResponseWriter, r *http.Request) 
 			"target_user_id": e.TargetUserID,
 			"group_id":       e.GroupID,
 			"role_id":        e.RoleID,
+			"permission_id":  e.PermissionID,
 			"project_id":     e.ProjectID,
 			"details":        e.Details,
 			"created_at":     e.CreatedAt.UTC().Format(time.RFC3339),

--- a/server/http/handlers/rbac.go
+++ b/server/http/handlers/rbac.go
@@ -168,7 +168,7 @@ func (h *RBACHandler) CreateRole(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			continue // skip unknown permission names
 		}
-		if err := h.coreService.Storage().AssignPermissionToRole(r.Context(), role.ID, perm.ID); err != nil {
+		if err := h.coreService.AssignPermissionToRole(r.Context(), userCtx.UserID, role.ID, perm.ID); err != nil {
 			log.Printf("Warning: could not assign permission %q to role %d: %v", permName, role.ID, err)
 		} else {
 			assignedPerms = append(assignedPerms, perm)
@@ -253,14 +253,14 @@ func (h *RBACHandler) UpdateRole(w http.ResponseWriter, r *http.Request) {
 	if req.Permissions != nil {
 		existing, _ := h.coreService.Storage().GetRolePermissions(r.Context(), id)
 		for _, ep := range existing {
-			_ = h.coreService.Storage().RemovePermissionFromRole(r.Context(), id, ep.ID)
+			_ = h.coreService.RemovePermissionFromRole(r.Context(), userCtx.UserID, id, ep.ID)
 		}
 		for _, permName := range *req.Permissions {
 			perm, err := h.findPermissionByName(r.Context(), permName)
 			if err != nil {
 				continue
 			}
-			_ = h.coreService.Storage().AssignPermissionToRole(r.Context(), id, perm.ID)
+			_ = h.coreService.AssignPermissionToRole(r.Context(), userCtx.UserID, id, perm.ID)
 		}
 	}
 
@@ -481,7 +481,7 @@ func (h *RBACHandler) AssignPermissionToRole(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	if err := h.coreService.AssignPermissionToRole(r.Context(), roleID, body.PermissionID); err != nil {
+	if err := h.coreService.AssignPermissionToRole(r.Context(), userCtx.UserID, roleID, body.PermissionID); err != nil {
 		log.Printf("Error assigning permission to role: %v", err)
 		if strings.Contains(err.Error(), "not found") {
 			sendError(w, "NotFound", err.Error(), http.StatusNotFound, nil)
@@ -512,7 +512,7 @@ func (h *RBACHandler) RemovePermissionFromRole(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	if err := h.coreService.RemovePermissionFromRole(r.Context(), roleID, permID); err != nil {
+	if err := h.coreService.RemovePermissionFromRole(r.Context(), userCtx.UserID, roleID, permID); err != nil {
 		log.Printf("Error removing permission from role: %v", err)
 		if strings.Contains(err.Error(), "not found") {
 			sendError(w, "NotFound", err.Error(), http.StatusNotFound, nil)

--- a/server/proto/keyorix.proto
+++ b/server/proto/keyorix.proto
@@ -452,6 +452,9 @@ message RBACAuditLog {
   // Set for group-role events (role.group_assigned / role.group_removed): the
   // group the role was granted to / removed from.
   optional uint32 group_id = 9;
+  // Set for permission-to-role events (permission.assigned / permission.removed):
+  // the permission granted to / removed from the role.
+  optional uint32 permission_id = 10;
 }
 
 message GetRBACAuditLogsRequest {

--- a/server/proto/pb/keyorix.pb.go
+++ b/server/proto/pb/keyorix.pb.go
@@ -2779,7 +2779,10 @@ type RBACAuditLog struct {
 	CreatedAt    *timestamppb.Timestamp `protobuf:"bytes,8,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
 	// Set for group-role events (role.group_assigned / role.group_removed): the
 	// group the role was granted to / removed from.
-	GroupId       *uint32 `protobuf:"varint,9,opt,name=group_id,json=groupId,proto3,oneof" json:"group_id,omitempty"`
+	GroupId *uint32 `protobuf:"varint,9,opt,name=group_id,json=groupId,proto3,oneof" json:"group_id,omitempty"`
+	// Set for permission-to-role events (permission.assigned / permission.removed):
+	// the permission granted to / removed from the role.
+	PermissionId  *uint32 `protobuf:"varint,10,opt,name=permission_id,json=permissionId,proto3,oneof" json:"permission_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2873,6 +2876,13 @@ func (x *RBACAuditLog) GetCreatedAt() *timestamppb.Timestamp {
 func (x *RBACAuditLog) GetGroupId() uint32 {
 	if x != nil && x.GroupId != nil {
 		return *x.GroupId
+	}
+	return 0
+}
+
+func (x *RBACAuditLog) GetPermissionId() uint32 {
+	if x != nil && x.PermissionId != nil {
+		return *x.PermissionId
 	}
 	return 0
 }
@@ -4617,7 +4627,7 @@ const file_keyorix_proto_rawDesc = "" +
 	"\x04page\x18\x03 \x01(\rR\x04page\x12\x1b\n" +
 	"\tpage_size\x18\x04 \x01(\rR\bpageSize\x12\x1f\n" +
 	"\vtotal_pages\x18\x05 \x01(\rR\n" +
-	"totalPages\"\x8e\x03\n" +
+	"totalPages\"\xca\x03\n" +
 	"\fRBACAuditLog\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\rR\x02id\x12\x16\n" +
 	"\x06action\x18\x02 \x01(\tR\x06action\x12'\n" +
@@ -4629,13 +4639,16 @@ const file_keyorix_proto_rawDesc = "" +
 	"\adetails\x18\a \x01(\tR\adetails\x129\n" +
 	"\n" +
 	"created_at\x18\b \x01(\v2\x1a.google.protobuf.TimestampR\tcreatedAt\x12\x1e\n" +
-	"\bgroup_id\x18\t \x01(\rH\x04R\agroupId\x88\x01\x01B\x10\n" +
+	"\bgroup_id\x18\t \x01(\rH\x04R\agroupId\x88\x01\x01\x12(\n" +
+	"\rpermission_id\x18\n" +
+	" \x01(\rH\x05R\fpermissionId\x88\x01\x01B\x10\n" +
 	"\x0e_actor_user_idB\x11\n" +
 	"\x0f_target_user_idB\n" +
 	"\n" +
 	"\b_role_idB\r\n" +
 	"\v_project_idB\v\n" +
-	"\t_group_id\"\xeb\x01\n" +
+	"\t_group_idB\x10\n" +
+	"\x0e_permission_id\"\xeb\x01\n" +
 	"\x17GetRBACAuditLogsRequest\x12\x1b\n" +
 	"\x06action\x18\x01 \x01(\tH\x00R\x06action\x88\x01\x01\x12'\n" +
 	"\ractor_user_id\x18\x02 \x01(\rH\x01R\vactorUserId\x88\x01\x01\x12)\n" +


### PR DESCRIPTION
The final RBAC-audit piece, after #47 (user-role) and #48 (group-role). Granting/revoking a permission on a role is now audited — this was the deferred messy one, since permissions were assigned via direct `storage` calls inside role create/update across gRPC and HTTP, bypassing core (and thus audit).

## Changes
- `core.AssignPermissionToRole`/`RemovePermissionFromRole` take an `actorID` and emit `permission.assigned` / `permission.removed` (`role_id` + `permission_id` in the structured diff), surfaced via a new `RBACAuditLog.permission_id` proto field.
- **Rerouted every user-facing bypass site** through the audited core methods with the caller's identity: HTTP single add/remove + role create/update loops, and the gRPC `RoleService` create/update loops. **First-boot bootstrap stays on the storage layer directly** (no actor, intentionally unaudited).
- `ListRBACAuditLogs` now covers user-role, group-role, **and** permission-to-role events together — the RBAC audit trail is complete.

## Tests
permission emit+query round trip (action, actor, role_id, permission_id). `buf lint` clean; `gosec` clean; `go build`/`vet`/`gofmt` clean; full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)