### PR TITLE
refactor(storage): clean sentinel for unsupported remote ops + wire 3 endpoints

### DIFF
--- a/internal/storage/store/remote_invitations.go
+++ b/internal/storage/store/remote_invitations.go
@@ -6,39 +6,38 @@ package store
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
 func (rs *RemoteStorage) CreateProjectInvitation(_ context.Context, _ *models.ProjectInvitation) (*models.ProjectInvitation, error) {
-	return nil, fmt.Errorf("CreateProjectInvitation not implemented for remote storage")
+	return nil, remoteUnsupported("CreateProjectInvitation")
 }
 
 func (rs *RemoteStorage) GetProjectInvitation(_ context.Context, _ uint) (*models.ProjectInvitation, error) {
-	return nil, fmt.Errorf("GetProjectInvitation not implemented for remote storage")
+	return nil, remoteUnsupported("GetProjectInvitation")
 }
 
 func (rs *RemoteStorage) UpdateProjectInvitation(_ context.Context, _ *models.ProjectInvitation) error {
-	return fmt.Errorf("UpdateProjectInvitation not implemented for remote storage")
+	return remoteUnsupported("UpdateProjectInvitation")
 }
 
 func (rs *RemoteStorage) ListProjectInvitations(_ context.Context, _ uint) ([]*models.ProjectInvitation, error) {
-	return nil, fmt.Errorf("ListProjectInvitations not implemented for remote storage")
+	return nil, remoteUnsupported("ListProjectInvitations")
 }
 
 func (rs *RemoteStorage) CreateAccessRequest(_ context.Context, _ *models.AccessRequest) (*models.AccessRequest, error) {
-	return nil, fmt.Errorf("CreateAccessRequest not implemented for remote storage")
+	return nil, remoteUnsupported("CreateAccessRequest")
 }
 
 func (rs *RemoteStorage) GetAccessRequest(_ context.Context, _ uint) (*models.AccessRequest, error) {
-	return nil, fmt.Errorf("GetAccessRequest not implemented for remote storage")
+	return nil, remoteUnsupported("GetAccessRequest")
 }
 
 func (rs *RemoteStorage) UpdateAccessRequest(_ context.Context, _ *models.AccessRequest) error {
-	return fmt.Errorf("UpdateAccessRequest not implemented for remote storage")
+	return remoteUnsupported("UpdateAccessRequest")
 }
 
 func (rs *RemoteStorage) ListAccessRequests(_ context.Context, _ uint) ([]*models.AccessRequest, error) {
-	return nil, fmt.Errorf("ListAccessRequests not implemented for remote storage")
+	return nil, remoteUnsupported("ListAccessRequests")
 }

--- a/internal/storage/store/remote_machine_identities.go
+++ b/internal/storage/store/remote_machine_identities.go
@@ -6,23 +6,22 @@ package store
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
 func (rs *RemoteStorage) CreateMachineIdentity(_ context.Context, _ *models.MachineIdentity) (*models.MachineIdentity, error) {
-	return nil, fmt.Errorf("CreateMachineIdentity not implemented for remote storage")
+	return nil, remoteUnsupported("CreateMachineIdentity")
 }
 
 func (rs *RemoteStorage) GetMachineIdentity(_ context.Context, _ uint) (*models.MachineIdentity, error) {
-	return nil, fmt.Errorf("GetMachineIdentity not implemented for remote storage")
+	return nil, remoteUnsupported("GetMachineIdentity")
 }
 
 func (rs *RemoteStorage) UpdateMachineIdentity(_ context.Context, _ *models.MachineIdentity) error {
-	return fmt.Errorf("UpdateMachineIdentity not implemented for remote storage")
+	return remoteUnsupported("UpdateMachineIdentity")
 }
 
 func (rs *RemoteStorage) ListMachineIdentities(_ context.Context, _ uint) ([]*models.MachineIdentity, error) {
-	return nil, fmt.Errorf("ListMachineIdentities not implemented for remote storage")
+	return nil, remoteUnsupported("ListMachineIdentities")
 }

--- a/internal/storage/store/remote_memberships.go
+++ b/internal/storage/store/remote_memberships.go
@@ -6,7 +6,6 @@ package store
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/core/storage"
@@ -14,33 +13,33 @@ import (
 )
 
 func (rs *RemoteStorage) CreateProjectMembership(_ context.Context, _ *models.ProjectMembership) (*models.ProjectMembership, error) {
-	return nil, fmt.Errorf("CreateProjectMembership not implemented for remote storage")
+	return nil, remoteUnsupported("CreateProjectMembership")
 }
 
 func (rs *RemoteStorage) GetProjectMembership(_ context.Context, _ uint) (*models.ProjectMembership, error) {
-	return nil, fmt.Errorf("GetProjectMembership not implemented for remote storage")
+	return nil, remoteUnsupported("GetProjectMembership")
 }
 
 func (rs *RemoteStorage) UpdateProjectMembership(_ context.Context, _ *models.ProjectMembership) error {
-	return fmt.Errorf("UpdateProjectMembership not implemented for remote storage")
+	return remoteUnsupported("UpdateProjectMembership")
 }
 
 func (rs *RemoteStorage) ListProjectMemberships(_ context.Context, _ uint) ([]*models.ProjectMembership, error) {
-	return nil, fmt.Errorf("ListProjectMemberships not implemented for remote storage")
+	return nil, remoteUnsupported("ListProjectMemberships")
 }
 
 func (rs *RemoteStorage) GetActiveProjectMembership(_ context.Context, _, _ uint) (*models.ProjectMembership, error) {
-	return nil, fmt.Errorf("GetActiveProjectMembership not implemented for remote storage")
+	return nil, remoteUnsupported("GetActiveProjectMembership")
 }
 
 func (rs *RemoteStorage) ListStaleInvitedMemberships(_ context.Context, _ time.Time) ([]*models.ProjectMembership, error) {
-	return nil, fmt.Errorf("ListStaleInvitedMemberships not implemented for remote storage")
+	return nil, remoteUnsupported("ListStaleInvitedMemberships")
 }
 
 func (rs *RemoteStorage) ListUserProjectMemberships(_ context.Context, _ uint) ([]*models.ProjectMembership, error) {
-	return nil, fmt.Errorf("ListUserProjectMemberships not implemented for remote storage")
+	return nil, remoteUnsupported("ListUserProjectMemberships")
 }
 
 func (rs *RemoteStorage) CountProjectMembershipsByUsers(_ context.Context, _ []uint) (map[uint]storage.MembershipCounts, error) {
-	return nil, fmt.Errorf("CountProjectMembershipsByUsers not implemented for remote storage")
+	return nil, remoteUnsupported("CountProjectMembershipsByUsers")
 }

--- a/internal/storage/store/remote_notifications.go
+++ b/internal/storage/store/remote_notifications.go
@@ -12,21 +12,37 @@ import (
 )
 
 func (rs *RemoteStorage) CreateNotification(_ context.Context, _ *models.Notification) (*models.Notification, error) {
-	return nil, fmt.Errorf("CreateNotification not implemented for remote storage")
+	return nil, remoteUnsupported("CreateNotification")
 }
 
 func (rs *RemoteStorage) ListNotifications(_ context.Context, _ uint, _ bool, _ int) ([]*models.Notification, error) {
-	return nil, fmt.Errorf("ListNotifications not implemented for remote storage")
+	return nil, remoteUnsupported("ListNotifications")
 }
 
 func (rs *RemoteStorage) CountUnreadNotifications(_ context.Context, _ uint) (int64, error) {
-	return 0, fmt.Errorf("CountUnreadNotifications not implemented for remote storage")
+	return 0, remoteUnsupported("CountUnreadNotifications")
 }
 
-func (rs *RemoteStorage) MarkNotificationRead(_ context.Context, _, _ uint) error {
-	return fmt.Errorf("MarkNotificationRead not implemented for remote storage")
+func (rs *RemoteStorage) MarkNotificationRead(ctx context.Context, id, _ uint) error {
+	// The server scopes the mark to the authenticated user (the client's own
+	// session), so userID is implicit in the endpoint.
+	resp, err := rs.client.Post(ctx, fmt.Sprintf("/api/v1/notifications/%d/read", id), nil)
+	if err != nil {
+		return fmt.Errorf("failed to mark notification read: %w", err)
+	}
+	if !resp.Success {
+		return fmt.Errorf("mark notification read failed: %s", resp.Error.Error())
+	}
+	return nil
 }
 
-func (rs *RemoteStorage) MarkAllNotificationsRead(_ context.Context, _ uint) error {
-	return fmt.Errorf("MarkAllNotificationsRead not implemented for remote storage")
+func (rs *RemoteStorage) MarkAllNotificationsRead(ctx context.Context, _ uint) error {
+	resp, err := rs.client.Post(ctx, "/api/v1/notifications/read-all", nil)
+	if err != nil {
+		return fmt.Errorf("failed to mark all notifications read: %w", err)
+	}
+	if !resp.Success {
+		return fmt.Errorf("mark all notifications read failed: %s", resp.Error.Error())
+	}
+	return nil
 }

--- a/internal/storage/store/remote_rbac.go
+++ b/internal/storage/store/remote_rbac.go
@@ -221,22 +221,29 @@ func (rs *RemoteStorage) AssignPermissionToRole(_ context.Context, _, _ uint) er
 
 // ListPermissions is not implemented in remote storage.
 func (rs *RemoteStorage) ListPermissions(_ context.Context) ([]*models.Permission, error) {
-	return nil, fmt.Errorf("not implemented: ListPermissions")
+	return nil, remoteUnsupported("ListPermissions")
 }
 
 // GetPermission is not implemented in remote storage.
 func (rs *RemoteStorage) GetPermission(_ context.Context, _ uint) (*models.Permission, error) {
-	return nil, fmt.Errorf("not implemented: GetPermission")
+	return nil, remoteUnsupported("GetPermission")
 }
 
 // GetRolePermissions is not implemented in remote storage.
 func (rs *RemoteStorage) GetRolePermissions(_ context.Context, _ uint) ([]*models.Permission, error) {
-	return nil, fmt.Errorf("not implemented: GetRolePermissions")
+	return nil, remoteUnsupported("GetRolePermissions")
 }
 
-// RemovePermissionFromRole is not implemented in remote storage.
-func (rs *RemoteStorage) RemovePermissionFromRole(_ context.Context, _, _ uint) error {
-	return fmt.Errorf("not implemented: RemovePermissionFromRole")
+// RemovePermissionFromRole revokes a permission from a role via the REST API.
+func (rs *RemoteStorage) RemovePermissionFromRole(ctx context.Context, roleID, permissionID uint) error {
+	resp, err := rs.client.Delete(ctx, fmt.Sprintf("/api/v1/roles/%d/permissions/%d", roleID, permissionID))
+	if err != nil {
+		return fmt.Errorf("failed to remove permission from role: %w", err)
+	}
+	if !resp.Success {
+		return fmt.Errorf("remove permission from role failed: %s", resp.Error.Error())
+	}
+	return nil
 }
 
 // GetGroupRoles lists the roles assigned to a group via remote API.
@@ -319,53 +326,53 @@ func (rs *RemoteStorage) CreateEnvironment(_ context.Context, _ *models.Environm
 }
 
 func (rs *RemoteStorage) ListProjects(_ context.Context) ([]*models.Project, error) {
-	return nil, fmt.Errorf("not implemented in remote storage")
+	return nil, remoteUnsupported("ListProjects")
 }
 
 func (rs *RemoteStorage) ListProjectsWithCounts(_ context.Context, _ bool) ([]storage.ProjectWithCounts, error) {
-	return nil, fmt.Errorf("not implemented in remote storage")
+	return nil, remoteUnsupported("ListProjectsWithCounts")
 }
 
 func (rs *RemoteStorage) GetProject(_ context.Context, _ uint) (*models.Project, error) {
-	return nil, fmt.Errorf("not implemented in remote storage")
+	return nil, remoteUnsupported("GetProject")
 }
 
 func (rs *RemoteStorage) UpdateProject(_ context.Context, _ *models.Project) (*models.Project, error) {
-	return nil, fmt.Errorf("not implemented in remote storage")
+	return nil, remoteUnsupported("UpdateProject")
 }
 
 func (rs *RemoteStorage) DeleteProject(_ context.Context, _ uint) error {
-	return fmt.Errorf("not implemented in remote storage")
+	return remoteUnsupported("DeleteProject")
 }
 
 func (rs *RemoteStorage) RestoreProject(_ context.Context, _ uint) error {
-	return fmt.Errorf("not implemented in remote storage")
+	return remoteUnsupported("RestoreProject")
 }
 
 func (rs *RemoteStorage) ListEnvironments(_ context.Context) ([]*models.Environment, error) {
-	return nil, fmt.Errorf("not implemented in remote storage")
+	return nil, remoteUnsupported("ListEnvironments")
 }
 
 func (rs *RemoteStorage) ListEnvironmentsByProject(_ context.Context, _ uint) ([]*models.Environment, error) {
-	return nil, fmt.Errorf("not implemented in remote storage")
+	return nil, remoteUnsupported("ListEnvironmentsByProject")
 }
 
 func (rs *RemoteStorage) ListEnvironmentsByProjectIncludingDeleted(_ context.Context, _ uint) ([]*models.Environment, error) {
-	return nil, fmt.Errorf("not implemented in remote storage")
+	return nil, remoteUnsupported("ListEnvironmentsByProjectIncludingDeleted")
 }
 
 func (rs *RemoteStorage) ListProjectMembers(_ context.Context, _ uint) ([]storage.ProjectMember, error) {
-	return nil, fmt.Errorf("not implemented in remote storage")
+	return nil, remoteUnsupported("ListProjectMembers")
 }
 
 func (rs *RemoteStorage) GetEnvironment(_ context.Context, _ uint) (*models.Environment, error) {
-	return nil, fmt.Errorf("not implemented in remote storage")
+	return nil, remoteUnsupported("GetEnvironment")
 }
 
 func (rs *RemoteStorage) DeleteEnvironment(_ context.Context, _ uint) error {
-	return fmt.Errorf("not implemented in remote storage")
+	return remoteUnsupported("DeleteEnvironment")
 }
 
 func (rs *RemoteStorage) RestoreEnvironment(_ context.Context, _ uint) error {
-	return fmt.Errorf("not implemented in remote storage")
+	return remoteUnsupported("RestoreEnvironment")
 }

--- a/internal/storage/store/remote_unsupported.go
+++ b/internal/storage/store/remote_unsupported.go
@@ -1,0 +1,24 @@
+package store
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrRemoteUnsupported is returned by RemoteStorage methods whose operation has
+// no server REST endpoint to proxy to. These fall into two groups: server-internal
+// primitives that a remote (client-mode) caller never invokes directly — project
+// membership lifecycle, invitation/access-request primitives, notification
+// creation, group CRUD, low-level permission lookups — and a handful not yet
+// exposed for client mode. Callers can errors.Is against it to distinguish
+// "not supported in remote mode" from a genuine transport/API failure.
+//
+// The live data path for these features runs on the server (LocalStorage); the
+// remote client reaches them through higher-level REST endpoints, not raw storage
+// primitives, so faithful one-to-one proxying isn't possible.
+var ErrRemoteUnsupported = errors.New("operation not supported in remote (client) mode")
+
+// remoteUnsupported wraps ErrRemoteUnsupported with the calling operation's name.
+func remoteUnsupported(op string) error {
+	return fmt.Errorf("%s: %w", op, ErrRemoteUnsupported)
+}

--- a/internal/storage/store/remote_unsupported_test.go
+++ b/internal/storage/store/remote_unsupported_test.go
@@ -1,0 +1,76 @@
+package store_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Unwired RemoteStorage stubs return ErrRemoteUnsupported (errors.Is-able), so
+// client mode degrades cleanly instead of with ad-hoc "not implemented" strings.
+func TestRemoteStorage_UnsupportedSentinel(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("https://unused.example"))
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	calls := map[string]func() error{
+		"CreateGroup":             func() error { _, e := rs.CreateGroup(ctx, &models.Group{}); return e },
+		"CreateProjectMembership": func() error { _, e := rs.CreateProjectMembership(ctx, &models.ProjectMembership{}); return e },
+		"ListProjectInvitations":  func() error { _, e := rs.ListProjectInvitations(ctx, 1); return e },
+		"CreateNotification":      func() error { _, e := rs.CreateNotification(ctx, &models.Notification{}); return e },
+		"ListPermissions":         func() error { _, e := rs.ListPermissions(ctx); return e },
+		"CreateMachineIdentity":   func() error { _, e := rs.CreateMachineIdentity(ctx, &models.MachineIdentity{}); return e },
+	}
+	for name, call := range calls {
+		err := call()
+		require.Error(t, err, "%s should error", name)
+		assert.True(t, errors.Is(err, store.ErrRemoteUnsupported),
+			"%s should wrap ErrRemoteUnsupported, got %v", name, err)
+	}
+}
+
+func TestRemoteStorage_MarkAllNotificationsRead(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/api/v1/notifications/read-all", r.URL.Path)
+		_, _ = w.Write(apiOK(nil))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+	require.NoError(t, rs.MarkAllNotificationsRead(context.Background(), 1))
+}
+
+func TestRemoteStorage_MarkNotificationRead(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/api/v1/notifications/5/read", r.URL.Path)
+		_, _ = w.Write(apiOK(nil))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+	require.NoError(t, rs.MarkNotificationRead(context.Background(), 5, 0))
+}
+
+func TestRemoteStorage_RemovePermissionFromRole(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "DELETE", r.Method)
+		assert.Equal(t, "/api/v1/roles/2/permissions/8", r.URL.Path)
+		_, _ = w.Write(apiOK(nil))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+	require.NoError(t, rs.RemovePermissionFromRole(context.Background(), 2, 8))
+}

--- a/internal/storage/store/remote_users.go
+++ b/internal/storage/store/remote_users.go
@@ -74,7 +74,7 @@ func (rs *RemoteStorage) GetUserByEmail(ctx context.Context, email string) (*mod
 
 // GetUserByUsername is not implemented for remote storage.
 func (rs *RemoteStorage) GetUserByUsername(_ context.Context, _ string) (*models.User, error) {
-	return nil, fmt.Errorf("GetUserByUsername not implemented for remote storage")
+	return nil, remoteUnsupported("GetUserByUsername")
 }
 
 // UpdateUser updates an existing user via remote API.
@@ -147,11 +147,11 @@ func (rs *RemoteStorage) ListUsers(ctx context.Context, filter *storage.UserFilt
 }
 
 func (rs *RemoteStorage) ListUsersInStateBefore(_ context.Context, _ string, _ time.Time) ([]*models.User, error) {
-	return nil, fmt.Errorf("ListUsersInStateBefore not implemented for remote storage")
+	return nil, remoteUnsupported("ListUsersInStateBefore")
 }
 
 func (rs *RemoteStorage) CreateUserWithRoleGrants(_ context.Context, _ *models.User, _ []storage.RoleGrant) (*models.User, error) {
-	return nil, fmt.Errorf("CreateUserWithRoleGrants not implemented for remote storage")
+	return nil, remoteUnsupported("CreateUserWithRoleGrants")
 }
 
 // buildUserFilterPath constructs the /api/v1/users query string.
@@ -178,35 +178,35 @@ func (rs *RemoteStorage) GetUserGroups(_ context.Context, _ uint) ([]*models.Gro
 // --- Groups (stubs — not yet implemented on remote API) ---
 
 func (rs *RemoteStorage) CreateGroup(_ context.Context, _ *models.Group) (*models.Group, error) {
-	return nil, fmt.Errorf("CreateGroup not implemented for remote storage")
+	return nil, remoteUnsupported("CreateGroup")
 }
 
 func (rs *RemoteStorage) GetGroup(_ context.Context, _ uint) (*models.Group, error) {
-	return nil, fmt.Errorf("GetGroup not implemented for remote storage")
+	return nil, remoteUnsupported("GetGroup")
 }
 
 func (rs *RemoteStorage) UpdateGroup(_ context.Context, _ *models.Group) (*models.Group, error) {
-	return nil, fmt.Errorf("UpdateGroup not implemented for remote storage")
+	return nil, remoteUnsupported("UpdateGroup")
 }
 
 func (rs *RemoteStorage) DeleteGroup(_ context.Context, _ uint) error {
-	return fmt.Errorf("DeleteGroup not implemented for remote storage")
+	return remoteUnsupported("DeleteGroup")
 }
 
 func (rs *RemoteStorage) ListGroups(_ context.Context) ([]*models.Group, error) {
-	return nil, fmt.Errorf("ListGroups not implemented for remote storage")
+	return nil, remoteUnsupported("ListGroups")
 }
 
 func (rs *RemoteStorage) AddUserToGroup(_ context.Context, _, _ uint) error {
-	return fmt.Errorf("AddUserToGroup not implemented for remote storage")
+	return remoteUnsupported("AddUserToGroup")
 }
 
 func (rs *RemoteStorage) RemoveUserFromGroup(_ context.Context, _, _ uint) error {
-	return fmt.Errorf("RemoveUserFromGroup not implemented for remote storage")
+	return remoteUnsupported("RemoveUserFromGroup")
 }
 
 func (rs *RemoteStorage) ListGroupMembers(_ context.Context, _ uint) ([]*models.User, error) {
-	return nil, fmt.Errorf("ListGroupMembers not implemented for remote storage")
+	return nil, remoteUnsupported("ListGroupMembers")
 }
 
 // --- Password history (ADR-025) ---


### PR DESCRIPTION
Remote-storage **option A** (the bounded slice you picked earlier). Remote (client-mode) storage had ~58 methods returning ad-hoc `"X not implemented for remote storage"` strings. Most are **server-internal primitives** (membership lifecycle, invitations, notification creation, group CRUD, low-level permission lookups) with no matching REST endpoint — the remote client reaches those features through higher-level endpoints, not raw storage ops.

## Changes
- **`ErrRemoteUnsupported` + `remoteUnsupported(op)`** — every unwired stub now returns a single `errors.Is`-able sentinel, so client mode degrades cleanly and callers can tell "unsupported in remote mode" apart from a transport/API failure.
- **Wired the methods that map 1:1 to existing endpoints** (no response-body parsing → no shape risk): `MarkNotificationRead` (POST `/notifications/{id}/read`), `MarkAllNotificationsRead` (POST `/notifications/read-all`), `RemovePermissionFromRole` (DELETE `/roles/{id}/permissions/{id}`).

Methods needing response-body parsing or new server endpoints (list/get primitives, group CRUD, `CreateUserWithRoleGrants`) intentionally stay on the sentinel — wiring them faithfully would mean guessing/duplicating response shapes for a roadmap-only mode.

## Tests
Representative stubs wrap `ErrRemoteUnsupported`; the 3 wired methods hit the right method+path via `httptest`. `go build`/`vet`/`gofmt`/`gosec` clean; full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)