### PR TITLE
feat(grpc): implement StreamAuditLogs (live audit tail)

### DIFF
--- a/server/grpc/services/audit_service.go
+++ b/server/grpc/services/audit_service.go
@@ -2,18 +2,25 @@ package services
 
 import (
 	"context"
+	"time"
 
 	"github.com/keyorixhq/keyorix/internal/core"
 	corestorage "github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/server/grpc/interceptors"
 	pb "github.com/keyorixhq/keyorix/server/proto/pb"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-// AuditGRPCService implements pb.AuditServiceServer. StreamAuditLogs has no
-// backing yet, so it is left as the embedded Unimplemented default.
+// Audit-stream tail tuning: how often to poll for new events, and the max events
+// drained per poll. The interval is a var so tests can shorten it.
+var auditStreamPollInterval = 2 * time.Second
+
+const auditStreamBatch = 100
+
+// AuditGRPCService implements pb.AuditServiceServer.
 type AuditGRPCService struct {
 	pb.UnimplementedAuditServiceServer
 	core *core.KeyorixCore
@@ -123,6 +130,76 @@ func rbacEntryToProto(e *core.RBACAuditEntry) *pb.RBACAuditLog {
 		out.ProjectId = ptrU32(*e.ProjectID)
 	}
 	return out
+}
+
+// StreamAuditLogs tails the audit log: it streams audit events as they occur
+// (events created after the stream opens — use GetAuditLogs for history),
+// applying the same event_type/user/project filters. Implemented by polling the
+// forward id cursor (AuditFilter.AfterID/Ascending) every auditStreamPollInterval,
+// which avoids a separate pub/sub broker and reuses the existing query path. The
+// stream ends when the client disconnects (context cancellation).
+func (s *AuditGRPCService) StreamAuditLogs(req *pb.StreamAuditLogsRequest, stream pb.AuditService_StreamAuditLogsServer) error {
+	ctx := stream.Context()
+	actor := interceptors.GetUserFromGRPCContext(ctx)
+	if actor == nil {
+		return status.Error(codes.Unauthenticated, "user not authenticated")
+	}
+	if !hasPermission(actor.Permissions, "audit.read") {
+		return status.Error(codes.PermissionDenied, "insufficient permissions to read audit logs")
+	}
+
+	// Start at the current head so we tail new events, not the backlog.
+	cursor, err := s.latestAuditID(ctx)
+	if err != nil {
+		return status.Error(codes.Internal, "failed to start audit stream")
+	}
+
+	ticker := time.NewTicker(auditStreamPollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			after := cursor
+			events, _, err := s.core.Storage().GetAuditLogs(ctx, &corestorage.AuditFilter{
+				AfterID:   &after,
+				Ascending: true,
+				PageSize:  auditStreamBatch,
+				Action:    optString(req.EventType),
+				UserID:    optUint(req.UserId),
+				ProjectID: optUint(req.ProjectId),
+			})
+			if err != nil {
+				return status.Error(codes.Internal, "failed to read audit logs")
+			}
+			if len(events) == 0 {
+				continue
+			}
+			names := s.core.ResolveUsernames(ctx, events)
+			for _, e := range events {
+				if err := stream.Send(auditEventToProto(e, names)); err != nil {
+					return err // client gone / send failed
+				}
+				cursor = e.ID
+			}
+		}
+	}
+}
+
+// latestAuditID returns the most recent audit event id (the tail starting point),
+// or 0 when the log is empty. The default GetAuditLogs order is newest-first and
+// ids autoincrement with insertion, so the first row carries the head id.
+func (s *AuditGRPCService) latestAuditID(ctx context.Context) (uint, error) {
+	events, _, err := s.core.Storage().GetAuditLogs(ctx, &corestorage.AuditFilter{Page: 1, PageSize: 1})
+	if err != nil {
+		return 0, err
+	}
+	if len(events) == 0 {
+		return 0, nil
+	}
+	return events[0].ID, nil
 }
 
 // ---------------------------------------------------------------------------

--- a/server/grpc/services/audit_stream_test.go
+++ b/server/grpc/services/audit_stream_test.go
@@ -1,0 +1,115 @@
+package services
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	pb "github.com/keyorixhq/keyorix/server/proto/pb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// fakeAuditStream implements pb.AuditService_StreamAuditLogsServer, capturing
+// sent events. The embedded grpc.ServerStream is nil — only Context()/Send() are
+// exercised by StreamAuditLogs.
+type fakeAuditStream struct {
+	grpc.ServerStream
+	ctx  context.Context
+	mu   sync.Mutex
+	sent []*pb.AuditLog
+}
+
+func (f *fakeAuditStream) Context() context.Context { return f.ctx }
+func (f *fakeAuditStream) Send(m *pb.AuditLog) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.sent = append(f.sent, m)
+	return nil
+}
+func (f *fakeAuditStream) count() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.sent)
+}
+func (f *fakeAuditStream) first() *pb.AuditLog {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.sent[0]
+}
+
+func newStreamCore(t *testing.T) (*AuditGRPCService, *gorm.DB) {
+	t.Helper()
+	require.NoError(t, i18n.Initialize(&config.Config{
+		Locale: config.LocaleConfig{Language: "en", FallbackLanguage: "en"},
+	}))
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	// Pin to one connection: a shared :memory: db so the stream goroutine and the
+	// test see the same schema (each new pool connection is a fresh :memory: db).
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	sqlDB.SetMaxOpenConns(1)
+	require.NoError(t, db.AutoMigrate(&models.AuditEvent{}, &models.User{}))
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "admin"}).Error)
+	return NewAuditService(core.NewKeyorixCore(store.NewLocalStorage(db))), db
+}
+
+func TestAuditService_StreamAuditLogs_PermissionDenied(t *testing.T) {
+	svc, _ := newStreamCore(t)
+	stream := &fakeAuditStream{ctx: authCtx(1, "nobody")} // no audit.read
+	err := svc.StreamAuditLogs(&pb.StreamAuditLogsRequest{}, stream)
+	require.Error(t, err)
+	assert.Equal(t, codes.PermissionDenied, status.Code(err))
+}
+
+func TestAuditService_StreamAuditLogs_TailsNewEvents(t *testing.T) {
+	// Fast poll for the test.
+	old := auditStreamPollInterval
+	auditStreamPollInterval = 15 * time.Millisecond
+	defer func() { auditStreamPollInterval = old }()
+
+	svc, db := newStreamCore(t)
+
+	// A pre-existing event: it's the head, so it should NOT be streamed.
+	uid := uint(1)
+	require.NoError(t, db.Create(&models.AuditEvent{
+		EventType: "role.assigned", UserID: &uid, EventTime: time.Now(),
+	}).Error)
+
+	ctx, cancel := context.WithCancel(authCtx(1, "admin", "audit.read"))
+	defer cancel()
+	stream := &fakeAuditStream{ctx: ctx}
+
+	done := make(chan error, 1)
+	go func() { done <- svc.StreamAuditLogs(&pb.StreamAuditLogsRequest{}, stream) }()
+
+	// Let the stream start and capture the head cursor, then create a new event.
+	time.Sleep(60 * time.Millisecond)
+	require.NoError(t, db.Create(&models.AuditEvent{
+		EventType: "role.removed", UserID: &uid, EventTime: time.Now(),
+	}).Error)
+
+	// The new event should arrive on the stream.
+	require.Eventually(t, func() bool { return stream.count() >= 1 }, time.Second, 10*time.Millisecond)
+	assert.Equal(t, "role.removed", stream.first().GetEventType())
+
+	cancel()
+	select {
+	case err := <-done:
+		assert.ErrorIs(t, err, context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("stream did not return after cancel")
+	}
+}


### PR DESCRIPTION
`StreamAuditLogs` was the embedded `Unimplemented` default. This implements it as a server-streaming **live tail** of the audit log.

## Design
- Tails events created **after** the stream opens (use `GetAuditLogs` for history), honoring the same `event_type`/`user`/`project` filters.
- **Polls the forward id cursor** (`AuditFilter.AfterID`/`Ascending` — already built for incremental SIEM export) every `auditStreamPollInterval`, `Send`s each new event mapped to `pb.AuditLog`, resolves actor usernames per batch.
- **No pub/sub broker** — reuses the existing query path, so there's no event-bus lifecycle or backpressure to manage. Ends cleanly on client disconnect (ctx cancel).
- `audit.read` permission enforced from the stream context.

This is the pragmatic choice over a push-based broker: robust, no new subsystem, leverages the cursor infra that already exists.

## Tests (incl. `-race`)
permission-denied; tails a newly-created event without replaying the pre-existing backlog; returns `context.Canceled` on cancel.

`go build`/`vet`/`gofmt`/`gosec` clean; full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)