### PR TITLE
fix(grpc): scope-check secrets.write on CreateSecret (was flat global)

### DIFF
--- a/server/grpc/services/secret_service.go
+++ b/server/grpc/services/secret_service.go
@@ -39,11 +39,15 @@ func (s *SecretGRPCService) CreateSecret(ctx context.Context, req *pb.CreateSecr
 	if err != nil {
 		return nil, err
 	}
-	if !hasPermission(user.Permissions, "secrets.write") {
-		return nil, status.Error(codes.PermissionDenied, "insufficient permissions to create secrets")
-	}
 	if req.GetName() == "" || req.GetValue() == "" || req.GetProjectId() == 0 || req.GetEnvironmentId() == 0 || req.GetType() == "" {
 		return nil, status.Error(codes.InvalidArgument, "name, value, project_id, environment_id and type are required")
+	}
+	// Authorize secrets.write AT THE TARGET project/environment, not the flat
+	// global permission set — a project-scoped writer must not create in another
+	// project. Mirrors the HTTP CreateSecret handler (scope from the body).
+	scope := core.Scope{ProjectID: uint(req.GetProjectId()), EnvironmentID: uint(req.GetEnvironmentId())}
+	if allowed, err := s.core.Authorize(ctx, user.UserID, "secrets.write", scope); err != nil || !allowed {
+		return nil, status.Error(codes.PermissionDenied, "insufficient permissions to create secrets in this project")
 	}
 
 	secret, err := s.core.CreateSecret(ctx, &core.CreateSecretRequest{

--- a/server/grpc/services/secret_service_test.go
+++ b/server/grpc/services/secret_service_test.go
@@ -37,15 +37,34 @@ func newSecretTestRig(t *testing.T) *secretTestRig {
 	require.NoError(t, db.AutoMigrate(
 		&models.Project{}, &models.Environment{}, &models.SecretNode{},
 		&models.SecretVersion{}, &models.User{}, &models.Role{}, &models.ShareRecord{},
+		&models.Permission{}, &models.RolePermission{}, &models.UserRole{},
+		&models.Group{}, &models.UserGroup{}, &models.GroupRole{},
 	))
 	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "default"}).Error)
 	require.NoError(t, db.Create(&models.Environment{ID: 1, ProjectID: 1, Name: "development"}).Error)
 	// The owner user (id 1) — ListSecretsWithSharingInfo resolves owner usernames.
 	require.NoError(t, db.Create(&models.User{ID: 1, Username: "owner", Email: "owner@example.com"}).Error)
 
+	// CreateSecret authorizes secrets.write at the target scope via the RBAC graph
+	// (mirroring the HTTP handler), so the test DB needs real grants — the flat
+	// UserContext.Permissions no longer gate creation. Seed a "writer" role that
+	// grants secrets.read/write/delete and assign user 1 globally so the owner can
+	// create/read/update/delete in every test below.
+	require.NoError(t, db.Create(&models.Role{ID: writerRoleID, Name: "writer"}).Error)
+	require.NoError(t, db.Create(&models.Permission{ID: 1, Name: "secrets.read", Resource: "secrets", Action: "read"}).Error)
+	require.NoError(t, db.Create(&models.Permission{ID: 2, Name: "secrets.write", Resource: "secrets", Action: "write"}).Error)
+	require.NoError(t, db.Create(&models.Permission{ID: 3, Name: "secrets.delete", Resource: "secrets", Action: "delete"}).Error)
+	require.NoError(t, db.Create(&models.RolePermission{RoleID: writerRoleID, PermissionID: 1}).Error)
+	require.NoError(t, db.Create(&models.RolePermission{RoleID: writerRoleID, PermissionID: 2}).Error)
+	require.NoError(t, db.Create(&models.RolePermission{RoleID: writerRoleID, PermissionID: 3}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: writerRoleID}).Error) // global (project 0, env 0)
+
 	coreService := core.NewKeyorixCore(store.NewLocalStorage(db))
 	return &secretTestRig{svc: NewSecretService(coreService), db: db}
 }
+
+// writerRoleID is the seeded role granting secrets.read/write/delete in the rig.
+const writerRoleID = 1
 
 // authCtx returns a context carrying a user with the given permissions, as the
 // auth interceptor would populate after validating a session.
@@ -87,9 +106,43 @@ func TestSecretService_CreateSecret_Unauthenticated(t *testing.T) {
 
 func TestSecretService_CreateSecret_PermissionDenied(t *testing.T) {
 	r := newSecretTestRig(t)
-	ctx := authCtx(1, "reader", "secrets.read") // no write
+	// User 2 holds no RBAC role, so Authorize denies regardless of any flat
+	// permission claimed in the context.
+	ctx := authCtx(2, "reader", "secrets.read") // no write grant
 	_, err := r.svc.CreateSecret(ctx, &pb.CreateSecretRequest{
 		Name: "x", Value: "y", ProjectId: 1, EnvironmentId: 1, Type: "password",
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.PermissionDenied, status.Code(err))
+}
+
+// Regression (gRPC scoped-authz hardening): CreateSecret must authorize
+// secrets.write at the TARGET project/environment, not against the flat global
+// permission set. A user whose secrets.write is granted only in project 1 must
+// not be able to create a secret in project 2 — even though their flat
+// UserContext.Permissions advertise secrets.write. Previously the gRPC handler
+// checked only the flat list and let a project-scoped writer create anywhere.
+func TestSecretService_CreateSecret_ScopedToOtherProjectDenied(t *testing.T) {
+	r := newSecretTestRig(t)
+	// A second project/environment the scoped writer has no grant in.
+	require.NoError(t, r.db.Create(&models.Project{ID: 2, Name: "other"}).Error)
+	require.NoError(t, r.db.Create(&models.Environment{ID: 2, ProjectID: 2, Name: "development"}).Error)
+	// User 3: writer role scoped to project 1 only (env 0 = all envs in project 1).
+	require.NoError(t, r.db.Create(&models.User{ID: 3, Username: "scoped", Email: "scoped@example.com"}).Error)
+	require.NoError(t, r.db.Create(&models.UserRole{UserID: 3, RoleID: writerRoleID, ProjectID: 1}).Error)
+
+	// The flat list advertises write — the bug would have honoured it everywhere.
+	ctx := authCtx(3, "scoped", "secrets.write", "secrets.read")
+
+	// In-scope (project 1): allowed.
+	_, err := r.svc.CreateSecret(ctx, &pb.CreateSecretRequest{
+		Name: "in-scope", Value: "v", ProjectId: 1, EnvironmentId: 1, Type: "password",
+	})
+	require.NoError(t, err)
+
+	// Out-of-scope (project 2): denied.
+	_, err = r.svc.CreateSecret(ctx, &pb.CreateSecretRequest{
+		Name: "cross-project", Value: "v", ProjectId: 2, EnvironmentId: 2, Type: "password",
 	})
 	require.Error(t, err)
 	assert.Equal(t, codes.PermissionDenied, status.Code(err))


### PR DESCRIPTION
## Summary

The gRPC `CreateSecret` RPC gated creation on the **flat** `UserContext.Permissions` set (`hasPermission(user.Permissions, "secrets.write")`), which carries no scope. A user granted `secrets.write` only in project 1 therefore appeared to hold write in the flat list and could create secrets in **any** project over gRPC — a scope bypass relative to the HTTP handler, which authorizes `secrets.write` at the target project/environment via `coreService.Authorize`.

This was the one genuine scope bypass remaining on the gRPC surface from the post-#53 security audit. The audit confirmed the rest is safe:
- **reads/lists** go through per-user-scoped queries (`ListSecretsWithSharingInfo`, `*WithPermissionCheck`),
- **admin RPCs** use global permissions by design.

## Change

- `CreateSecret` now builds the scope from the request's `project_id` / `environment_id` and calls `core.Authorize(user, "secrets.write", scope)` — same model as the HTTP `CreateSecret` handler. A project-scoped writer can only create within their scope.
- Required-field validation runs **before** the authz check (cheap, and avoids leaking a permission verdict on a malformed request).

## Tests

- The secret test rig now seeds a real RBAC writer role + global assignment for the owner (the flat context permissions no longer gate creation), and migrates the role/group tables `Authorize` touches.
- New regression test `TestSecretService_CreateSecret_ScopedToOtherProjectDenied`: a project-1-scoped writer is **allowed** in project 1 but **denied** in project 2 — even though its flat `UserContext.Permissions` advertise `secrets.write`.
- `CreateSecret_PermissionDenied` switched to a role-less user (flat perms are now irrelevant to the verdict).

Green gate: `go build/vet/test ./...`, `gofmt`, `gosec -exclude-generated` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)