### PR TITLE
fix(cli): route `keyorix rbac` through the server in remote mode

### DIFF
--- a/internal/cli/common/remote_client.go
+++ b/internal/cli/common/remote_client.go
@@ -166,6 +166,33 @@ func (c *RemoteClient) Put(ctx context.Context, path string, body interface{}, o
 	return nil
 }
 
+// DeleteWithBody sends a DELETE to path carrying a JSON body (some endpoints —
+// e.g. DELETE /user-roles — identify the target in the body rather than the URL).
+// No response body is expected.
+func (c *RemoteClient) DeleteWithBody(ctx context.Context, path string, body interface{}) error {
+	data, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("marshal request body: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, c.Endpoint+path, bytes.NewReader(data))
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.Token)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.hc.Do(req)
+	if err != nil {
+		return fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("server returned HTTP %d for %s", resp.StatusCode, path)
+	}
+	return nil
+}
+
 // Delete sends a DELETE to path. No response body is expected.
 func (c *RemoteClient) Delete(ctx context.Context, path string) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, c.Endpoint+path, nil)

--- a/internal/cli/rbac/assign_role.go
+++ b/internal/cli/rbac/assign_role.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/keyorixhq/keyorix/internal/cli/common"
 	"github.com/keyorixhq/keyorix/internal/config"
 	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/keyorixhq/keyorix/internal/storage/store"
@@ -33,6 +34,11 @@ func init() {
 }
 
 func runAssignRole(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+	if rc, ok := common.NewRemoteClient(); ok {
+		return runAssignRoleRemote(ctx, rc, userEmail, roleName)
+	}
+
 	// Load configuration
 	cfg, err := config.LoadConfig()
 	if err != nil {
@@ -52,7 +58,6 @@ func runAssignRole(cmd *cobra.Command, args []string) error {
 	coreService := core.NewKeyorixCore(storage)
 
 	// Use core service to assign role
-	ctx := context.Background()
 	err = coreService.AssignRoleToUser(ctx, userEmail, roleName)
 	if err != nil {
 		return fmt.Errorf("failed to assign role: %w", err)

--- a/internal/cli/rbac/check_permission.go
+++ b/internal/cli/rbac/check_permission.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/keyorixhq/keyorix/internal/cli/common"
 	"github.com/keyorixhq/keyorix/internal/config"
 	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
@@ -35,6 +36,11 @@ func init() {
 }
 
 func runCheckPermission(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+	if rc, ok := common.NewRemoteClient(); ok {
+		return runCheckPermissionRemote(ctx, rc, checkUserEmail, checkPermissionName)
+	}
+
 	// Load configuration
 	cfg, err := config.LoadConfig()
 	if err != nil {
@@ -55,9 +61,6 @@ func runCheckPermission(cmd *cobra.Command, args []string) error {
 	// Initialize storage and core service
 	storage := store.NewLocalStorage(db)
 	service := core.NewKeyorixCore(storage)
-
-	// Create context
-	ctx := context.Background()
 
 	// Permissions are named "resource.action" (e.g. secrets.read, system.admin).
 	resource, action, perr := splitPermissionName(checkPermissionName)

--- a/internal/cli/rbac/list_permissions.go
+++ b/internal/cli/rbac/list_permissions.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/keyorixhq/keyorix/internal/cli/common"
 	"github.com/keyorixhq/keyorix/internal/config"
 	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
@@ -28,6 +29,11 @@ func init() {
 }
 
 func runListPermissions(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+	if rc, ok := common.NewRemoteClient(); ok {
+		return runListPermissionsRemote(ctx, rc, listPermissionsUserEmail)
+	}
+
 	// Load configuration
 	cfg, err := config.LoadConfig()
 	if err != nil {
@@ -48,9 +54,6 @@ func runListPermissions(cmd *cobra.Command, args []string) error {
 	// Initialize storage and core service
 	storage := store.NewLocalStorage(db)
 	service := core.NewKeyorixCore(storage)
-
-	// Create context
-	ctx := context.Background()
 
 	permissions, err := service.ListUserPermissionsByEmail(ctx, listPermissionsUserEmail)
 	if err != nil {

--- a/internal/cli/rbac/list_roles.go
+++ b/internal/cli/rbac/list_roles.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/keyorixhq/keyorix/internal/cli/common"
 	"github.com/keyorixhq/keyorix/internal/config"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/keyorixhq/keyorix/internal/storage/store"
@@ -20,6 +21,11 @@ var listRolesCmd = &cobra.Command{
 }
 
 func runListRoles(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+	if rc, ok := common.NewRemoteClient(); ok {
+		return runListRolesRemote(ctx, rc)
+	}
+
 	// Load configuration
 	cfg, err := config.LoadConfig()
 	if err != nil {
@@ -39,9 +45,6 @@ func runListRoles(cmd *cobra.Command, args []string) error {
 
 	// Initialize storage
 	storage := store.NewLocalStorage(db)
-
-	// Create context
-	ctx := context.Background()
 
 	// TODO: Implement ListRoles in core service
 	// For now, use storage directly

--- a/internal/cli/rbac/list_user_roles.go
+++ b/internal/cli/rbac/list_user_roles.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/keyorixhq/keyorix/internal/cli/common"
 	"github.com/keyorixhq/keyorix/internal/config"
 	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
@@ -28,6 +29,11 @@ func init() {
 }
 
 func runListUserRoles(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+	if rc, ok := common.NewRemoteClient(); ok {
+		return runListUserRolesRemote(ctx, rc, listUserEmail)
+	}
+
 	// Load configuration
 	cfg, err := config.LoadConfig()
 	if err != nil {
@@ -48,9 +54,6 @@ func runListUserRoles(cmd *cobra.Command, args []string) error {
 	// Initialize storage and core service
 	storage := store.NewLocalStorage(db)
 	service := core.NewKeyorixCore(storage)
-
-	// Create context
-	ctx := context.Background()
 
 	roles, err := service.ListUserRolesByEmail(ctx, listUserEmail)
 	if err != nil {

--- a/internal/cli/rbac/remote.go
+++ b/internal/cli/rbac/remote.go
@@ -1,0 +1,231 @@
+// remote.go — server-backed (remote mode) implementations of the rbac commands.
+//
+// Every rbac subcommand is dual-mode (mirroring `keyorix secret`): when the CLI
+// is configured to talk to a server (env vars or ~/.keyorix/cli.yaml written by
+// `keyorix connect` / `keyorix auth login --server`), the command goes through
+// the HTTP API so it operates on the SAME data the server and web UI show.
+// Without remote configuration it falls back to the embedded direct-DB path.
+//
+// Before this, every rbac command opened a local SQLite file directly, so against
+// a server-backed (e.g. Postgres) deployment `list-roles` reported "No roles
+// found" and `assign-role` wrote to the wrong store — silently diverging from the
+// dashboard. See fix/rbac-cli-remote-mode.
+package rbac
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+)
+
+// ── shared resolution helpers ───────────────────────────────────────────────
+
+// resolveUserIDByEmail finds a user's ID by email via GET /api/v1/users.
+func resolveUserIDByEmail(ctx context.Context, rc *common.RemoteClient, email string) (uint, error) {
+	var resp struct {
+		Users []struct {
+			ID    uint   `json:"id"`
+			Email string `json:"email"`
+		} `json:"users"`
+	}
+	if err := rc.Get(ctx, "/api/v1/users?page_size=1000", &resp); err != nil {
+		return 0, fmt.Errorf("failed to list users: %w", err)
+	}
+	for _, u := range resp.Users {
+		if strings.EqualFold(u.Email, email) {
+			return u.ID, nil
+		}
+	}
+	return 0, fmt.Errorf("user %q not found", email)
+}
+
+type remoteRole struct {
+	ID          uint   `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+// fetchRoles returns all roles via GET /api/v1/roles.
+func fetchRoles(ctx context.Context, rc *common.RemoteClient) ([]remoteRole, error) {
+	var resp struct {
+		Roles []remoteRole `json:"roles"`
+	}
+	if err := rc.Get(ctx, "/api/v1/roles", &resp); err != nil {
+		return nil, fmt.Errorf("failed to list roles: %w", err)
+	}
+	return resp.Roles, nil
+}
+
+// resolveRoleIDByName finds a role's ID by name via GET /api/v1/roles.
+func resolveRoleIDByName(ctx context.Context, rc *common.RemoteClient, name string) (uint, error) {
+	roles, err := fetchRoles(ctx, rc)
+	if err != nil {
+		return 0, err
+	}
+	for _, r := range roles {
+		if strings.EqualFold(r.Name, name) {
+			return r.ID, nil
+		}
+	}
+	return 0, fmt.Errorf("role %q not found — run 'keyorix rbac list-roles' to see available roles", name)
+}
+
+// fetchUserRoles returns the roles assigned to a user via GET /api/v1/users/{id}/roles.
+func fetchUserRoles(ctx context.Context, rc *common.RemoteClient, userID uint) ([]remoteRole, error) {
+	var resp struct {
+		Roles []remoteRole `json:"roles"`
+	}
+	if err := rc.Get(ctx, fmt.Sprintf("/api/v1/users/%d/roles", userID), &resp); err != nil {
+		return nil, fmt.Errorf("failed to get user roles: %w", err)
+	}
+	return resp.Roles, nil
+}
+
+// userEffectivePermissions returns the de-duplicated set of permission names a
+// user holds, composed from each assigned role's permissions
+// (GET /api/v1/roles/{id}/permissions). There is no single by-email permission
+// endpoint, so the union is assembled client-side.
+func userEffectivePermissions(ctx context.Context, rc *common.RemoteClient, userID uint) ([]string, error) {
+	roles, err := fetchUserRoles(ctx, rc, userID)
+	if err != nil {
+		return nil, err
+	}
+	seen := map[string]struct{}{}
+	var names []string
+	for _, role := range roles {
+		var resp struct {
+			Permissions []struct {
+				Name string `json:"name"`
+			} `json:"permissions"`
+		}
+		if err := rc.Get(ctx, fmt.Sprintf("/api/v1/roles/%d/permissions", role.ID), &resp); err != nil {
+			return nil, fmt.Errorf("failed to get permissions for role %q: %w", role.Name, err)
+		}
+		for _, p := range resp.Permissions {
+			if _, ok := seen[p.Name]; ok {
+				continue
+			}
+			seen[p.Name] = struct{}{}
+			names = append(names, p.Name)
+		}
+	}
+	return names, nil
+}
+
+// ── remote command implementations ──────────────────────────────────────────
+
+func runListRolesRemote(ctx context.Context, rc *common.RemoteClient) error {
+	roles, err := fetchRoles(ctx, rc)
+	if err != nil {
+		return err
+	}
+	if len(roles) == 0 {
+		fmt.Println("No roles found")
+		return nil
+	}
+	fmt.Println("Available roles:")
+	for _, role := range roles {
+		fmt.Printf("  - %s: %s\n", role.Name, role.Description)
+	}
+	return nil
+}
+
+func runListUserRolesRemote(ctx context.Context, rc *common.RemoteClient, email string) error {
+	userID, err := resolveUserIDByEmail(ctx, rc, email)
+	if err != nil {
+		return err
+	}
+	roles, err := fetchUserRoles(ctx, rc, userID)
+	if err != nil {
+		return err
+	}
+	if len(roles) == 0 {
+		fmt.Printf("No roles assigned to user '%s'\n", email)
+		return nil
+	}
+	fmt.Printf("Roles assigned to user '%s':\n", email)
+	for _, role := range roles {
+		fmt.Printf("  - %s: %s\n", role.Name, role.Description)
+	}
+	return nil
+}
+
+func runListPermissionsRemote(ctx context.Context, rc *common.RemoteClient, email string) error {
+	userID, err := resolveUserIDByEmail(ctx, rc, email)
+	if err != nil {
+		return err
+	}
+	perms, err := userEffectivePermissions(ctx, rc, userID)
+	if err != nil {
+		return err
+	}
+	if len(perms) == 0 {
+		fmt.Printf("No permissions found for user '%s'\n", email)
+		return nil
+	}
+	fmt.Printf("Permissions for user '%s':\n", email)
+	for _, p := range perms {
+		fmt.Printf("  - %s\n", p)
+	}
+	return nil
+}
+
+func runCheckPermissionRemote(ctx context.Context, rc *common.RemoteClient, email, permission string) error {
+	// Validate the name shape up front for a clear error (matches embedded mode).
+	if _, _, err := splitPermissionName(permission); err != nil {
+		return err
+	}
+	userID, err := resolveUserIDByEmail(ctx, rc, email)
+	if err != nil {
+		return err
+	}
+	perms, err := userEffectivePermissions(ctx, rc, userID)
+	if err != nil {
+		return err
+	}
+	for _, p := range perms {
+		if strings.EqualFold(p, permission) {
+			fmt.Printf("✅ User '%s' has permission '%s'\n", email, permission)
+			return nil
+		}
+	}
+	fmt.Printf("❌ User '%s' does NOT have permission '%s'\n", email, permission)
+	return nil
+}
+
+func runAssignRoleRemote(ctx context.Context, rc *common.RemoteClient, email, role string) error {
+	userID, err := resolveUserIDByEmail(ctx, rc, email)
+	if err != nil {
+		return err
+	}
+	roleID, err := resolveRoleIDByName(ctx, rc, role)
+	if err != nil {
+		return err
+	}
+	body := map[string]uint{"user_id": userID, "role_id": roleID}
+	var out map[string]interface{}
+	if err := rc.Post(ctx, "/api/v1/user-roles", body, &out); err != nil {
+		return fmt.Errorf("failed to assign role: %w", err)
+	}
+	fmt.Printf("✅ Successfully assigned role '%s' to user '%s'\n", role, email)
+	return nil
+}
+
+func runRemoveRoleRemote(ctx context.Context, rc *common.RemoteClient, email, role string) error {
+	userID, err := resolveUserIDByEmail(ctx, rc, email)
+	if err != nil {
+		return err
+	}
+	roleID, err := resolveRoleIDByName(ctx, rc, role)
+	if err != nil {
+		return err
+	}
+	body := map[string]uint{"user_id": userID, "role_id": roleID}
+	if err := rc.DeleteWithBody(ctx, "/api/v1/user-roles", body); err != nil {
+		return fmt.Errorf("failed to remove role: %w", err)
+	}
+	fmt.Printf("✅ Successfully removed role '%s' from user '%s'\n", role, email)
+	return nil
+}

--- a/internal/cli/rbac/remote_test.go
+++ b/internal/cli/rbac/remote_test.go
@@ -1,0 +1,108 @@
+package rbac
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeRBACServer mimics the subset of the Keyorix HTTP API the remote rbac
+// commands call, wrapping every payload in the server's {"data":…} envelope.
+func fakeRBACServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/api/v1/roles", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"roles":[
+			{"id":1,"name":"admin","description":"Administrator"},
+			{"id":2,"name":"viewer","description":"Read-only access"}
+		]}}`))
+	})
+	mux.HandleFunc("/api/v1/users", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"users":[{"id":5,"email":"alice@test.com"}]}}`))
+	})
+	mux.HandleFunc("/api/v1/users/5/roles", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"roles":[{"id":2,"name":"viewer","description":"Read-only access"}]}}`))
+	})
+	mux.HandleFunc("/api/v1/roles/2/permissions", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"permissions":[{"name":"secrets.read"},{"name":"users.read"}]}}`))
+	})
+	mux.HandleFunc("/api/v1/user-roles", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPost:
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"data":{"user_id":5,"role_id":1}}`))
+		case http.MethodDelete:
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// remoteClientFor points the CLI's remote-config resolver at the fake server via
+// env vars (highest priority in ResolveRemote), so NewRemoteClient picks it up.
+func remoteClientFor(t *testing.T, srv *httptest.Server) *common.RemoteClient {
+	t.Helper()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+	rc, ok := common.NewRemoteClient()
+	require.True(t, ok, "remote client should resolve from env")
+	return rc
+}
+
+func TestResolveUserIDByEmail(t *testing.T) {
+	rc := remoteClientFor(t, fakeRBACServer(t))
+	id, err := resolveUserIDByEmail(context.Background(), rc, "ALICE@test.com") // case-insensitive
+	require.NoError(t, err)
+	assert.Equal(t, uint(5), id)
+
+	_, err = resolveUserIDByEmail(context.Background(), rc, "nobody@test.com")
+	require.Error(t, err)
+}
+
+func TestResolveRoleIDByName(t *testing.T) {
+	rc := remoteClientFor(t, fakeRBACServer(t))
+	id, err := resolveRoleIDByName(context.Background(), rc, "admin")
+	require.NoError(t, err)
+	assert.Equal(t, uint(1), id)
+
+	_, err = resolveRoleIDByName(context.Background(), rc, "ghost")
+	require.Error(t, err)
+}
+
+func TestUserEffectivePermissions(t *testing.T) {
+	rc := remoteClientFor(t, fakeRBACServer(t))
+	perms, err := userEffectivePermissions(context.Background(), rc, 5)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"secrets.read", "users.read"}, perms)
+}
+
+// The remote command wrappers exercise the full request path against the fake
+// server and must not error (output is printed; correctness of the decision is
+// covered by TestUserEffectivePermissions).
+func TestRemoteCommandWrappers(t *testing.T) {
+	srv := fakeRBACServer(t)
+	rc := remoteClientFor(t, srv)
+	ctx := context.Background()
+
+	require.NoError(t, runListRolesRemote(ctx, rc))
+	require.NoError(t, runListUserRolesRemote(ctx, rc, "alice@test.com"))
+	require.NoError(t, runListPermissionsRemote(ctx, rc, "alice@test.com"))
+	require.NoError(t, runCheckPermissionRemote(ctx, rc, "alice@test.com", "secrets.read"))
+	require.NoError(t, runCheckPermissionRemote(ctx, rc, "alice@test.com", "secrets.write")) // not held → ❌, still nil err
+	require.NoError(t, runAssignRoleRemote(ctx, rc, "alice@test.com", "admin"))
+	require.NoError(t, runRemoveRoleRemote(ctx, rc, "alice@test.com", "admin"))
+
+	// A malformed permission name is rejected before any request.
+	require.Error(t, runCheckPermissionRemote(ctx, rc, "alice@test.com", "notvalid"))
+}

--- a/internal/cli/rbac/remove_role.go
+++ b/internal/cli/rbac/remove_role.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/keyorixhq/keyorix/internal/cli/common"
 	"github.com/keyorixhq/keyorix/internal/config"
 	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/keyorixhq/keyorix/internal/storage/store"
@@ -33,6 +34,11 @@ func init() {
 }
 
 func runRemoveRole(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+	if rc, ok := common.NewRemoteClient(); ok {
+		return runRemoveRoleRemote(ctx, rc, removeUserEmail, removeRoleName)
+	}
+
 	// Load configuration
 	cfg, err := config.LoadConfig()
 	if err != nil {
@@ -52,7 +58,6 @@ func runRemoveRole(cmd *cobra.Command, args []string) error {
 	coreService := core.NewKeyorixCore(storage)
 
 	// Use core service to remove role
-	ctx := context.Background()
 	err = coreService.RemoveRoleFromUser(ctx, removeUserEmail, removeRoleName)
 	if err != nil {
 		return fmt.Errorf("failed to remove role: %w", err)


### PR DESCRIPTION
## Summary

The `keyorix rbac` command group opened a **local SQLite file directly** and ignored the configured server. Against a server-backed deployment (the Postgres demo), `rbac list-roles` reported **"No roles found"** from an empty/absent local DB and `assign-role` wrote to the wrong store — silently diverging from what the dashboard and API show.

This is the **top demo-readiness blocker** found in the product assessment: Chapter 3 of the demo runs `keyorix rbac list-roles` / `check-permission` live.

## Change

Make the whole group **dual-mode**, mirroring `keyorix secret`: when remote config is present (env vars or `~/.keyorix/cli.yaml` from `keyorix connect` / `auth login --server`), each command goes through the HTTP API; otherwise it falls back to the existing embedded direct-DB path **unchanged**.

- **`internal/cli/rbac/remote.go`** — server-backed implementations of all six commands + shared resolution helpers (email→user ID via `/users`, role name→ID via `/roles`, user→roles via `/users/{id}/roles`). `check-permission` / `list-permissions` have no single by-email endpoint, so the effective-permission set is composed **client-side** as the union of each assigned role's `/roles/{id}/permissions`.
- **`common.RemoteClient.DeleteWithBody`** — `DELETE /user-roles` identifies the target in the body, which the body-less `Delete` couldn't send.
- Each command's `RunE` branches on `common.NewRemoteClient()` before the SQLite path.

## Tests

`internal/cli/rbac/remote_test.go` drives every remote path against an `httptest` server: resolution helpers (incl. case-insensitive email + not-found), the client-side permission union, all six command wrappers, and malformed-permission rejection. Embedded-mode tests unchanged and still pass.

Green: `go build/vet/test ./...`, `gofmt`, `gosec -exclude-generated` all clean.

## Scope note

This PR covers the `rbac` group (the demo blocker). Two sibling CLI gaps from the same assessment — `keyorix secret update` (also SQLite-only) and `keyorix rbac audit-logs` (a stub) — are left for a follow-up; neither is in the demo path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)