### PR TITLE
fix(demo): seed the secrets + demo user the demo script expects

### DIFF
--- a/scripts/demo-keyorix.sh
+++ b/scripts/demo-keyorix.sh
@@ -1,12 +1,18 @@
 #!/bin/bash
 
-# Keyorix Demo Script
-# Shows off the key features of your secret management system
+# Keyorix Demo Seed + Walkthrough
+# Seeds the exact data the demo script (keyorix-gtm.md) expects, then shows the
+# headline features. Run AFTER `keyorix system init --server ...` and after the
+# CLI is pointed at the server.
+#
+# Server mode is required: export KEYORIX_SERVER + KEYORIX_TOKEN (or run
+# `keyorix connect`) so `keyorix secret create` and the user-seed curl below hit
+# the running server, not a local SQLite file.
 
 set -e
 
-echo "🚀 Keyorix Secret Management Demo"
-echo "================================="
+echo "🚀 Keyorix Demo Seed + Walkthrough"
+echo "=================================="
 
 # Colors
 GREEN='\033[0;32m'
@@ -18,61 +24,71 @@ NC='\033[0m'
 demo_step() { echo -e "${CYAN}➤${NC} $1"; }
 demo_success() { echo -e "${GREEN}✅${NC} $1"; }
 demo_info() { echo -e "${BLUE}ℹ️${NC}  $1"; }
+demo_warn() { echo -e "${YELLOW}⚠️${NC}  $1"; }
 
-echo ""
-demo_step "1. Creating API Keys for Different Services"
-./keyorix secret create --name "github-api-token" --value "ghp_demo_token_123456" --type "token"
-./keyorix secret create --name "aws-access-key" --value "AKIA_DEMO_KEY_789" --type "api_key"
-./keyorix secret create --name "database-password" --value "super_secure_db_pass_2024" --type "password"
+SERVER="${KEYORIX_SERVER:-http://localhost:8080}"
 
-echo ""
-demo_step "2. Listing All Your Secrets"
-./keyorix secret list
-
-echo ""
-demo_step "3. Getting Specific Secret Details"
-SECRET_ID=$(./keyorix secret list | grep "github-api-token" | awk '{print $1}' | head -1)
-if [ ! -z "$SECRET_ID" ]; then
-    ./keyorix secret get --id "$SECRET_ID"
-    echo ""
-    demo_info "To see the actual secret value, use: ./keyorix secret get --id $SECRET_ID --show-value"
+if [ -z "$KEYORIX_TOKEN" ]; then
+    demo_warn "KEYORIX_TOKEN is not set. Secrets are created via the CLI's own"
+    demo_warn "remote config (cli.yaml from 'keyorix connect'); the demo-user step"
+    demo_warn "below needs KEYORIX_TOKEN to call the API. Run 'keyorix connect' and"
+    demo_warn "export KEYORIX_TOKEN to seed the demo user automatically."
 fi
 
 echo ""
-demo_step "4. System Health Check"
-./keyorix status
+demo_step "1. Creating the three demo secrets (names match the demo script)"
+./keyorix secret create --name "prod-db-password" --value "super_secure_db_pass_2024" --type "password"
+./keyorix secret create --name "stripe-api-key" --value "sk_live_demo_51abc123def456" --type "api_key"
+./keyorix secret create --name "jwt-signing-key" --value "$(head -c 32 /dev/urandom | base64)" --type "password"
 
 echo ""
-demo_step "5. Testing API Endpoints"
-echo "Health Check:"
-curl -s http://localhost:8080/health | jq '.' 2>/dev/null || curl -s http://localhost:8080/health
+demo_step "2. Creating a limited-permission demo user (for the RBAC chapter)"
+# New users are auto-assigned the read-only 'viewer' role, so
+# 'keyorix rbac check-permission --user demo@keyorix.com --permission secrets.write'
+# returns ❌ — the contrast that makes the RBAC chapter land.
+if [ -n "$KEYORIX_TOKEN" ]; then
+    HTTP_CODE=$(curl -s -o /tmp/keyorix-demo-user.json -w "%{http_code}" \
+        -X POST "$SERVER/api/v1/users" \
+        -H "Authorization: Bearer $KEYORIX_TOKEN" \
+        -H "Content-Type: application/json" \
+        -d '{"username":"demo","email":"demo@keyorix.com","password":"Demo#Pass!2026","display_name":"Demo User"}')
+    if [ "$HTTP_CODE" = "200" ] || [ "$HTTP_CODE" = "201" ]; then
+        demo_success "Created demo user demo@keyorix.com (viewer role)"
+    elif [ "$HTTP_CODE" = "409" ]; then
+        demo_info "Demo user demo@keyorix.com already exists — skipping"
+    else
+        demo_warn "Demo user creation returned HTTP $HTTP_CODE (see /tmp/keyorix-demo-user.json)"
+    fi
+else
+    demo_warn "Skipped demo-user creation (no KEYORIX_TOKEN). Create it in the web"
+    demo_warn "Admin UI instead — new users get the viewer role automatically."
+fi
+
+echo ""
+demo_step "3. Listing all secrets"
+./keyorix secret list
+
+echo ""
+demo_step "4. RBAC: roles and a permission check"
+./keyorix rbac list-roles
+if [ -n "$KEYORIX_TOKEN" ]; then
+    echo ""
+    demo_info "Limited user does NOT have secrets.write:"
+    ./keyorix rbac check-permission --user "demo@keyorix.com" --permission "secrets.write" || true
+fi
+
+echo ""
+demo_step "5. System health"
+./keyorix status || true
+echo "API health:"
+curl -s "$SERVER/health" | jq '.' 2>/dev/null || curl -s "$SERVER/health"
 
 echo ""
 echo ""
-demo_step "6. Available Commands"
-echo "Try these commands:"
-echo "  • ./keyorix secret create --name 'my-secret' --value 'my-value' --type 'password'"
-echo "  • ./keyorix secret list"
-echo "  • ./keyorix secret get --id <ID> --show-value"
-echo "  • ./keyorix share list"
-echo "  • ./keyorix status"
-
+demo_success "Demo seed complete. Walkthrough script: keyorix-gtm.md → 'Demo Script'."
 echo ""
-demo_success "Demo Complete! Your Keyorix system is fully operational."
-echo ""
-echo "🌐 Web Access:"
-echo "  • API Health: http://localhost:8080/health"
-echo "  • API Docs: http://localhost:8080/openapi.yaml"
-echo ""
-echo "🔐 Security Features:"
-echo "  • AES-256-GCM encryption"
-echo "  • Role-based access control"
-echo "  • Audit logging"
-echo "  • Secret sharing with permissions"
-echo ""
-echo "🌍 Multi-language Support:"
-echo "  • English (default)"
-echo "  • Russian: KEYORIX_LANGUAGE=ru ./keyorix secret list"
-echo "  • Spanish: KEYORIX_LANGUAGE=es ./keyorix secret list"
-echo "  • French: KEYORIX_LANGUAGE=fr ./keyorix secret list"
-echo "  • German: KEYORIX_LANGUAGE=de ./keyorix secret list"
+echo "🔐 Highlights to show:"
+echo "  • Secrets list + reveal a value + version history (web UI)"
+echo "  • RBAC enforced at the API: keyorix rbac check-permission"
+echo "  • Audit trail: GET /api/v1/audit/logs (or the Audit Log UI page)"
+echo "  • Single binary deploy: keyorix-server + PostgreSQL"


### PR DESCRIPTION
## Summary

`scripts/demo-keyorix.sh` seeded secrets named `github-api-token` / `aws-access-key` / `database-password` and **no demo user**, while the demo walkthrough (`keyorix-gtm.md`) narrates `prod-db-password` / `stripe-api-key` / `jwt-signing-key` and a limited-permission user for the RBAC chapter. The on-screen data didn't match the script — a demo-readiness gap.

## Change

Rewrites the seed to produce exactly what the walkthrough expects:
- The three **named secrets** via the remote-aware `keyorix secret create` (so they land on the running server, not a local SQLite file).
- A `demo@keyorix.com` user via `POST /api/v1/users` (auto-assigned the read-only **viewer** role), so `keyorix rbac check-permission --permission secrets.write` returns ❌ — the contrast that makes the RBAC chapter land. Guarded on `KEYORIX_TOKEN`; tolerates an already-existing user (409); prints a web-UI fallback when no token.
- Server-mode preconditions documented up front; audit reference corrected to `/api/v1/audit/logs`; deploy line refers to `keyorix-server`.

## Note

`keyorix user create` is still embedded-only (writes local SQLite), so the demo user is seeded via the API rather than the CLI — noted as a follow-up alongside the other CLI remote-mode gaps (`secret update`, `rbac audit-logs`).

`bash -n` clean. Script-only change (no Go).

🤖 Generated with [Claude Code](https://claude.com/claude-code)