### PR TITLE
fix(cli): remote-mode for `user create` + implement `rbac audit-logs`

### DIFF
--- a/internal/cli/rbac/audit_logs.go
+++ b/internal/cli/rbac/audit_logs.go
@@ -1,15 +1,18 @@
 package rbac
 
 import (
+	"context"
 	"fmt"
+	"time"
 
+	"github.com/keyorixhq/keyorix/internal/cli/common"
 	"github.com/spf13/cobra"
 )
 
 var auditLogsCmd = &cobra.Command{
 	Use:   "audit-logs",
 	Short: "View RBAC audit logs",
-	Long:  "View audit logs for RBAC operations (role assignments, removals, etc.)",
+	Long:  "View audit logs for RBAC operations (role assignments, removals, permission grants).",
 	RunE:  runAuditLogs,
 }
 
@@ -24,9 +27,99 @@ func init() {
 }
 
 func runAuditLogs(cmd *cobra.Command, args []string) error {
-	// TODO: Implement RBAC audit logs functionality using the new core architecture
-	// This functionality needs to be implemented in the core service first
-	fmt.Println("⚠️  RBAC audit logs functionality is not yet implemented in the new architecture")
-	fmt.Println("This feature will be available in a future update.")
+	if auditLimit < 1 {
+		auditLimit = 50
+	}
+	page := (auditOffset / auditLimit) + 1
+
+	ctx := context.Background()
+	if rc, ok := common.NewRemoteClient(); ok {
+		return runAuditLogsRemote(ctx, rc, page, auditLimit)
+	}
+	return runAuditLogsEmbedded(ctx, page, auditLimit)
+}
+
+// ── Remote mode ─────────────────────────────────────────────────────────────
+
+type remoteAuditLog struct {
+	ID           uint   `json:"id"`
+	Action       string `json:"action"`
+	ActorUserID  *uint  `json:"actor_user_id"`
+	TargetUserID *uint  `json:"target_user_id"`
+	GroupID      *uint  `json:"group_id"`
+	RoleID       *uint  `json:"role_id"`
+	PermissionID *uint  `json:"permission_id"`
+	ProjectID    *uint  `json:"project_id"`
+	Details      string `json:"details"`
+	CreatedAt    string `json:"created_at"`
+}
+
+func runAuditLogsRemote(ctx context.Context, rc *common.RemoteClient, page, pageSize int) error {
+	var resp struct {
+		Logs  []remoteAuditLog `json:"logs"`
+		Total int64            `json:"total"`
+	}
+	path := fmt.Sprintf("/api/v1/audit/rbac-logs?page=%d&page_size=%d", page, pageSize)
+	if err := rc.Get(ctx, path, &resp); err != nil {
+		return fmt.Errorf("failed to retrieve RBAC audit logs: %w", err)
+	}
+	if len(resp.Logs) == 0 {
+		fmt.Println("No RBAC audit logs found")
+		return nil
+	}
+	fmt.Printf("RBAC audit logs (showing %d of %d):\n", len(resp.Logs), resp.Total)
+	for _, e := range resp.Logs {
+		printAuditEntry(e.CreatedAt, e.Action, e.ActorUserID, e.TargetUserID, e.GroupID, e.RoleID, e.PermissionID, e.ProjectID, e.Details)
+	}
 	return nil
+}
+
+// ── Embedded mode ───────────────────────────────────────────────────────────
+
+func runAuditLogsEmbedded(ctx context.Context, page, pageSize int) error {
+	service, err := common.InitializeCoreService()
+	if err != nil {
+		return fmt.Errorf("failed to initialize service: %w", err)
+	}
+	entries, total, err := service.ListRBACAuditLogs(ctx, page, pageSize)
+	if err != nil {
+		return fmt.Errorf("failed to retrieve RBAC audit logs: %w", err)
+	}
+	if len(entries) == 0 {
+		fmt.Println("No RBAC audit logs found")
+		return nil
+	}
+	fmt.Printf("RBAC audit logs (showing %d of %d):\n", len(entries), total)
+	for _, e := range entries {
+		printAuditEntry(e.CreatedAt.UTC().Format(time.RFC3339), e.Action, e.ActorUserID, e.TargetUserID, e.GroupID, e.RoleID, e.PermissionID, e.ProjectID, e.Details)
+	}
+	return nil
+}
+
+// ── Shared formatting ───────────────────────────────────────────────────────
+
+func printAuditEntry(when, action string, actor, target, group, role, perm, project *uint, details string) {
+	fmt.Printf("  [%s] %s", when, action)
+	if actor != nil {
+		fmt.Printf(" by user %d", *actor)
+	}
+	if target != nil {
+		fmt.Printf(" → user %d", *target)
+	}
+	if group != nil {
+		fmt.Printf(" → group %d", *group)
+	}
+	if role != nil {
+		fmt.Printf(" role %d", *role)
+	}
+	if perm != nil {
+		fmt.Printf(" permission %d", *perm)
+	}
+	if project != nil && *project != 0 {
+		fmt.Printf(" @ project %d", *project)
+	}
+	if details != "" {
+		fmt.Printf(" (%s)", details)
+	}
+	fmt.Println()
 }

--- a/internal/cli/rbac/remote_test.go
+++ b/internal/cli/rbac/remote_test.go
@@ -32,6 +32,12 @@ func fakeRBACServer(t *testing.T) *httptest.Server {
 	mux.HandleFunc("/api/v1/roles/2/permissions", func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte(`{"data":{"permissions":[{"name":"secrets.read"},{"name":"users.read"}]}}`))
 	})
+	mux.HandleFunc("/api/v1/audit/rbac-logs", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"logs":[
+			{"id":2,"action":"role.assigned","actor_user_id":1,"target_user_id":5,"role_id":1,"project_id":0,"details":"","created_at":"2026-06-07T10:00:00Z"},
+			{"id":1,"action":"role.removed","actor_user_id":1,"target_user_id":5,"role_id":2,"created_at":"2026-06-07T09:00:00Z"}
+		],"total":2,"page":1,"page_size":50,"total_pages":1}}`))
+	})
 	mux.HandleFunc("/api/v1/user-roles", func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
 		case http.MethodPost:
@@ -105,4 +111,10 @@ func TestRemoteCommandWrappers(t *testing.T) {
 
 	// A malformed permission name is rejected before any request.
 	require.Error(t, runCheckPermissionRemote(ctx, rc, "alice@test.com", "notvalid"))
+}
+
+func TestRunAuditLogsRemote(t *testing.T) {
+	rc := remoteClientFor(t, fakeRBACServer(t))
+	// Exercises the full request + decode path against the fake /audit/rbac-logs.
+	require.NoError(t, runAuditLogsRemote(context.Background(), rc, 1, 50))
 }

--- a/internal/cli/user/create.go
+++ b/internal/cli/user/create.go
@@ -58,6 +58,17 @@ func runCreate(cmd *cobra.Command, args []string) error {
 		return errors.New("password is required (use --password), or use --setup-link or --one-time-password")
 	}
 
+	// Remote mode: go through the server so the user lands in the SAME store the
+	// dashboard/API use, instead of a local SQLite file. Currently the password
+	// mode is supported remotely; the setup-link / one-time-password provisioning
+	// flows are embedded-only for now.
+	if rc, ok := common.NewRemoteClient(); ok {
+		if createSetupLink || createOneTimePassword {
+			return errors.New("--setup-link / --one-time-password are not yet supported in remote mode; use --password, or run this command on the server host")
+		}
+		return runCreateRemote(rc)
+	}
+
 	service, err := common.InitializeCoreService()
 	if err != nil {
 		return fmt.Errorf("failed to initialize service: %w", err)
@@ -110,6 +121,31 @@ func runCreate(cmd *cobra.Command, args []string) error {
 
 	u, err := service.CreateUser(ctx, req)
 	if err != nil {
+		return fmt.Errorf("failed to create user: %w", err)
+	}
+	fmt.Printf("User created: id=%d username=%s email=%s\n", u.ID, u.Username, u.Email)
+	return nil
+}
+
+// runCreateRemote creates the user via POST /api/v1/users (password mode), so it
+// lands in the server's store rather than a local SQLite file.
+func runCreateRemote(rc *common.RemoteClient) error {
+	display := createDisplayName
+	if display == "" {
+		display = createUsername
+	}
+	body := map[string]string{
+		"username":     createUsername,
+		"email":        createEmail,
+		"display_name": display,
+		"password":     createPassword,
+	}
+	var u struct {
+		ID       uint   `json:"id"`
+		Username string `json:"username"`
+		Email    string `json:"email"`
+	}
+	if err := rc.Post(context.Background(), "/api/v1/users", body, &u); err != nil {
 		return fmt.Errorf("failed to create user: %w", err)
 	}
 	fmt.Printf("User created: id=%d username=%s email=%s\n", u.ID, u.Username, u.Email)

--- a/internal/cli/user/create_remote_test.go
+++ b/internal/cli/user/create_remote_test.go
@@ -1,0 +1,41 @@
+package user
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// runCreateRemote should POST the password-mode payload to /api/v1/users and
+// print the created user, rather than touching a local SQLite file.
+func TestRunCreateRemote(t *testing.T) {
+	var gotBody map[string]string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "POST", r.Method)
+		require.Equal(t, "/api/v1/users", r.URL.Path)
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &gotBody)
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"data":{"id":7,"username":"bob","email":"bob@test.com"}}`))
+	}))
+	defer srv.Close()
+
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+	rc, ok := common.NewRemoteClient()
+	require.True(t, ok)
+
+	createUsername, createEmail, createPassword, createDisplayName = "bob", "bob@test.com", "s3cret-pass", ""
+	require.NoError(t, runCreateRemote(rc))
+
+	assert.Equal(t, "bob", gotBody["username"])
+	assert.Equal(t, "bob@test.com", gotBody["email"])
+	assert.Equal(t, "s3cret-pass", gotBody["password"])
+	assert.Equal(t, "bob", gotBody["display_name"], "display_name defaults to username when empty")
+}


### PR DESCRIPTION
## Summary

Two more CLI commands that ignored the configured server (same class as the merged `keyorix rbac` remote-mode fix, #55):

- **`keyorix rbac audit-logs`** was a pure stub ("not yet implemented"). Now dual-mode: remote via `GET /api/v1/audit/rbac-logs`, embedded via `core.ListRBACAuditLogs`. Prints the RBAC trail (role/permission grants + removals) with actor/target/scope and pagination from `--limit`/`--offset`.
- **`keyorix user create`** used `InitializeCoreService()` (local SQLite), so creating a user against a server wrote to the wrong store — this is exactly what forced the demo seed script (#56) to create its demo user via a raw `curl`. Now goes through `POST /api/v1/users` in remote mode (password mode). `--setup-link` / `--one-time-password` remain embedded-only and return a clear message in remote mode rather than silently misfiring.

## Tests

httptest-backed remote paths for both (audit-logs decode; create posts the right password-mode body and defaults `display_name` to username). Embedded paths unchanged.

## Remaining gap

`keyorix secret update` is still embedded-only — but the `PUT /secrets/{id}` endpoint supports only `value` + `max_reads`, not expiration, so wiring it cleanly needs a small backend change first. Left as a follow-up.

Green: `go build/vet/test ./...`, `gofmt`, `gosec` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)