### PR TITLE
feat(secret-update): remote-mode CLI + expiration set/clear support

### DIFF
--- a/internal/cli/secret/update.go
+++ b/internal/cli/secret/update.go
@@ -12,6 +12,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/keyorixhq/keyorix/internal/cli/common"
 	"github.com/keyorixhq/keyorix/internal/config"
 	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
@@ -60,6 +61,10 @@ func init() {
 func runUpdate(cmd *cobra.Command, args []string) error {
 	if updateID == 0 {
 		return errors.New("secret ID is required (use --id)")
+	}
+
+	if rc, ok := common.NewRemoteClient(); ok {
+		return runUpdateRemote(rc)
 	}
 
 	cfg, err := config.LoadConfig()
@@ -131,6 +136,70 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+// runUpdateRemote updates the secret through the server (PUT /api/v1/secrets/{id})
+// so it operates on the same store the dashboard/API use. Supports value,
+// max-reads, and expiration (set or clear); --type is not supported by the
+// endpoint (and is ignored in embedded mode too).
+func runUpdateRemote(rc *common.RemoteClient) error {
+	ctx := context.Background()
+
+	// Fetch current state for the display + interactive defaults. The GET response
+	// (without include_value) is the secret node itself, with PascalCase keys that
+	// unmarshal straight into models.SecretNode.
+	var current models.SecretNode
+	if err := rc.Get(ctx, fmt.Sprintf("/api/v1/secrets/%d", updateID), &current); err != nil {
+		return fmt.Errorf("failed to get current secret: %w", err)
+	}
+
+	fmt.Printf("🔄 Updating Secret: %s (ID: %d)\n", current.Name, current.ID)
+	fmt.Printf("Current Type: %s\n", current.Type)
+	if current.MaxReads != nil {
+		fmt.Printf("Current Max Reads: %d\n", *current.MaxReads)
+	}
+	if current.Expiration != nil {
+		fmt.Printf("Current Expiration: %s\n", current.Expiration.Format(time.RFC3339))
+	}
+	fmt.Println()
+
+	var req *core.UpdateSecretRequest
+	var err error
+	if updateInteractive {
+		req, err = interactiveUpdate(&current)
+	} else {
+		req, err = buildUpdateRequest()
+	}
+	if err != nil {
+		return fmt.Errorf("failed to build request: %w", err)
+	}
+
+	body := map[string]interface{}{}
+	if len(req.Value) > 0 {
+		body["value"] = string(req.Value)
+	}
+	if req.MaxReads != nil {
+		body["max_reads"] = *req.MaxReads
+	}
+	if req.ClearExpiration {
+		body["clear_expiration"] = true
+	} else if req.Expiration != nil {
+		body["expiration"] = req.Expiration.Format(time.RFC3339)
+	}
+
+	var updated models.SecretNode
+	if err := rc.Put(ctx, fmt.Sprintf("/api/v1/secrets/%d", updateID), body, &updated); err != nil {
+		return fmt.Errorf("failed to update secret: %w", err)
+	}
+
+	fmt.Printf("✅ Secret updated successfully!\n")
+	fmt.Printf("ID: %d\n", updated.ID)
+	fmt.Printf("Name: %s\n", updated.Name)
+	fmt.Printf("Type: %s\n", updated.Type)
+	if len(req.Value) > 0 {
+		fmt.Printf("🔐 New encrypted version created\n")
+	}
+	return nil
+}
+
 func buildUpdateRequest() (*core.UpdateSecretRequest, error) {
 	req := &core.UpdateSecretRequest{
 		ID:        updateID,
@@ -168,7 +237,7 @@ func buildUpdateRequest() (*core.UpdateSecretRequest, error) {
 	}
 
 	if updateClearExp {
-		req.Expiration = nil
+		req.ClearExpiration = true
 	} else if updateExpiration != "" {
 		exp, err := time.Parse(time.RFC3339, updateExpiration)
 		if err != nil {
@@ -253,7 +322,7 @@ func interactiveUpdate(current *models.SecretNode) (*core.UpdateSecretRequest, e
 
 	if askBool("Update expiration?") {
 		if askBool("Clear expiration?") {
-			req.Expiration = nil
+			req.ClearExpiration = true
 		} else {
 			expirationStr := ask("Expiration (RFC3339 format)", currentExp)
 			if expirationStr != "" && expirationStr != currentExp {

--- a/internal/cli/secret/update_remote_test.go
+++ b/internal/cli/secret/update_remote_test.go
@@ -1,0 +1,58 @@
+package secret
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// runUpdateRemote should GET current state then PUT only the changed fields,
+// against the server rather than a local SQLite file.
+func TestRunUpdateRemote(t *testing.T) {
+	var putBody map[string]interface{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			_, _ = w.Write([]byte(`{"data":{"ID":42,"Name":"db-pass","Type":"password"}}`))
+		case http.MethodPut:
+			b, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(b, &putBody)
+			_, _ = w.Write([]byte(`{"data":{"ID":42,"Name":"db-pass","Type":"password"}}`))
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	defer srv.Close()
+
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+	rc, ok := common.NewRemoteClient()
+	require.True(t, ok)
+	updateMaxReads = -1 // sentinel: "no change" (flag default isn't applied in tests)
+	updateFromFile = ""
+
+	t.Run("value + clear expiration", func(t *testing.T) {
+		putBody = nil
+		updateID, updateValue, updateClearExp, updateExpiration, updateInteractive = 42, "new-value", true, "", false
+		require.NoError(t, runUpdateRemote(rc))
+		assert.Equal(t, "new-value", putBody["value"])
+		assert.Equal(t, true, putBody["clear_expiration"])
+		_, hasExp := putBody["expiration"]
+		assert.False(t, hasExp, "clear and set are mutually exclusive")
+	})
+
+	t.Run("set expiration", func(t *testing.T) {
+		putBody = nil
+		updateID, updateValue, updateClearExp, updateExpiration, updateInteractive = 42, "", false, "2030-01-02T03:04:05Z", false
+		require.NoError(t, runUpdateRemote(rc))
+		assert.Equal(t, "2030-01-02T03:04:05Z", putBody["expiration"])
+		_, hasClear := putBody["clear_expiration"]
+		assert.False(t, hasClear)
+	})
+}

--- a/internal/core/secret_update_expiration_test.go
+++ b/internal/core/secret_update_expiration_test.go
@@ -1,0 +1,61 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// captureUpdatedSecret records the secret handed to UpdateSecret so the test can
+// assert on the persisted Expiration field.
+func captureUpdatedSecret(store *MockStorage, existing *models.SecretNode) *models.SecretNode {
+	saved := &models.SecretNode{}
+	store.On("GetSecret", mock.Anything, existing.ID).Return(existing, nil)
+	store.On("UpdateSecret", mock.Anything, mock.AnythingOfType("*models.SecretNode")).
+		Run(func(args mock.Arguments) { *saved = *args.Get(1).(*models.SecretNode) }).
+		Return(saved, nil)
+	return saved
+}
+
+// ClearExpiration removes an existing expiry; a nil Expiration with no clear flag
+// leaves it untouched (the distinction that was previously impossible to express).
+func TestUpdateSecret_ClearExpiration(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+	exp := time.Date(2030, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	t.Run("clear removes the expiration", func(t *testing.T) {
+		store := new(MockStorage)
+		saved := captureUpdatedSecret(store, &models.SecretNode{ID: 1, Name: "x", Expiration: &exp})
+		c := NewKeyorixCore(store)
+		_, err := c.UpdateSecret(context.Background(), &UpdateSecretRequest{ID: 1, ClearExpiration: true, UpdatedBy: "t"})
+		require.NoError(t, err)
+		require.Nil(t, saved.Expiration, "expiration should be cleared")
+	})
+
+	t.Run("nil expiration without clear leaves it unchanged", func(t *testing.T) {
+		store := new(MockStorage)
+		saved := captureUpdatedSecret(store, &models.SecretNode{ID: 1, Name: "x", Expiration: &exp})
+		c := NewKeyorixCore(store)
+		_, err := c.UpdateSecret(context.Background(), &UpdateSecretRequest{ID: 1, UpdatedBy: "t"})
+		require.NoError(t, err)
+		require.NotNil(t, saved.Expiration, "expiration should be untouched")
+		require.Equal(t, exp, *saved.Expiration)
+	})
+
+	t.Run("setting a new expiration overrides", func(t *testing.T) {
+		store := new(MockStorage)
+		saved := captureUpdatedSecret(store, &models.SecretNode{ID: 1, Name: "x"})
+		c := NewKeyorixCore(store)
+		newExp := exp.Add(24 * time.Hour)
+		_, err := c.UpdateSecret(context.Background(), &UpdateSecretRequest{ID: 1, Expiration: &newExp, UpdatedBy: "t"})
+		require.NoError(t, err)
+		require.NotNil(t, saved.Expiration)
+		require.Equal(t, newExp, *saved.Expiration)
+	})
+}

--- a/internal/core/secrets.go
+++ b/internal/core/secrets.go
@@ -33,14 +33,18 @@ type CreateSecretRequest struct {
 
 // UpdateSecretRequest represents a request to update an existing secret.
 type UpdateSecretRequest struct {
-	ID         uint              `json:"id" validate:"required"`
-	Value      []byte            `json:"value,omitempty"`
-	MaxReads   *int              `json:"max_reads,omitempty" validate:"omitempty,min=1"`
-	Expiration *time.Time        `json:"expiration,omitempty"`
-	Metadata   map[string]string `json:"metadata,omitempty"`
-	Tags       []string          `json:"tags,omitempty"`
-	UpdatedBy  string            `json:"updated_by" validate:"required"`
-	UserID     uint              `json:"user_id,omitempty"`
+	ID         uint       `json:"id" validate:"required"`
+	Value      []byte     `json:"value,omitempty"`
+	MaxReads   *int       `json:"max_reads,omitempty" validate:"omitempty,min=1"`
+	Expiration *time.Time `json:"expiration,omitempty"`
+	// ClearExpiration removes an existing expiration. It is distinct from leaving
+	// Expiration nil (which means "leave unchanged"): without this flag there is no
+	// way to make an expiring secret non-expiring.
+	ClearExpiration bool              `json:"clear_expiration,omitempty"`
+	Metadata        map[string]string `json:"metadata,omitempty"`
+	Tags            []string          `json:"tags,omitempty"`
+	UpdatedBy       string            `json:"updated_by" validate:"required"`
+	UserID          uint              `json:"user_id,omitempty"`
 }
 
 // CreateSecret creates a new secret with business logic validation.
@@ -128,7 +132,9 @@ func (c *KeyorixCore) UpdateSecret(ctx context.Context, req *UpdateSecretRequest
 	if req.MaxReads != nil {
 		secret.MaxReads = req.MaxReads
 	}
-	if req.Expiration != nil {
+	if req.ClearExpiration {
+		secret.Expiration = nil
+	} else if req.Expiration != nil {
 		secret.Expiration = req.Expiration
 	}
 	if req.Metadata != nil {

--- a/server/http/handlers/secrets_crud.go
+++ b/server/http/handlers/secrets_crud.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/keyorixhq/keyorix/internal/core"
@@ -156,6 +157,10 @@ func (h *SecretHandler) UpdateSecret(w http.ResponseWriter, r *http.Request) {
 	var reqBody struct {
 		Value    string `json:"value,omitempty"`
 		MaxReads *int   `json:"max_reads,omitempty" validate:"omitempty,min=1"`
+		// Expiration sets a new expiry (RFC3339); ClearExpiration removes an existing
+		// one. They are mutually exclusive.
+		Expiration      string `json:"expiration,omitempty"`
+		ClearExpiration bool   `json:"clear_expiration,omitempty"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
 		h.sendError(w, "InvalidJSON", "Invalid JSON in request body", http.StatusBadRequest, nil)
@@ -165,15 +170,28 @@ func (h *SecretHandler) UpdateSecret(w http.ResponseWriter, r *http.Request) {
 		h.sendError(w, "ValidationError", "Invalid request data", http.StatusBadRequest, err)
 		return
 	}
+	if reqBody.Expiration != "" && reqBody.ClearExpiration {
+		h.sendError(w, "ValidationError", "expiration and clear_expiration are mutually exclusive", http.StatusBadRequest, nil)
+		return
+	}
 
 	req := &core.UpdateSecretRequest{
-		ID:        uint(id),
-		MaxReads:  reqBody.MaxReads,
-		UpdatedBy: userCtx.Username,
-		UserID:    userCtx.UserID,
+		ID:              uint(id),
+		MaxReads:        reqBody.MaxReads,
+		ClearExpiration: reqBody.ClearExpiration,
+		UpdatedBy:       userCtx.Username,
+		UserID:          userCtx.UserID,
 	}
 	if reqBody.Value != "" {
 		req.Value = []byte(reqBody.Value)
+	}
+	if reqBody.Expiration != "" {
+		exp, perr := time.Parse(time.RFC3339, reqBody.Expiration)
+		if perr != nil {
+			h.sendError(w, "ValidationError", "invalid expiration (use RFC3339)", http.StatusBadRequest, nil)
+			return
+		}
+		req.Expiration = &exp
 	}
 
 	// Capture pre-update metadata for the audit diff (raw fetch, no read-count


### PR DESCRIPTION
## Summary

Closes the **last CLI remote-mode gap**: `keyorix secret update` was embedded-only (wrote local SQLite, ignored the configured server). Now dual-mode like the rest of the CLI.

Along the way it fixes a **latent correctness bug**: there was no way to *clear* a secret's expiration. Core `UpdateSecret` treated `Expiration == nil` as "leave unchanged", so `--clear-expiration` silently did nothing in embedded mode, and the HTTP `PUT` endpoint didn't accept expiration at all.

## Changes

- **core**: `UpdateSecretRequest` gains `ClearExpiration`; `UpdateSecret` now distinguishes **clear** (set nil) vs **unchanged** (nil + no flag) vs **set**.
- **HTTP**: `PUT /api/v1/secrets/{id}` accepts `expiration` (RFC3339) and `clear_expiration` (mutually exclusive, validated), alongside the existing `value`/`max_reads`.
- **CLI**: `runUpdateRemote` GETs current state (display + interactive defaults) then PUTs only the changed fields; `buildUpdateRequest`/`interactiveUpdate` now set `ClearExpiration` instead of the old no-op nil assignment — so clear works in **both** embedded and remote mode.

## Tests

- core: clear / unchanged / set semantics
- CLI: remote update body shaping (value + clear; set-expiration)

Full suite green; `gosec -severity medium` clean. (The remaining LOW G706 warnings are pre-existing in `users_roles.go`, untouched here.)

## Context

This completes the CLI server-awareness arc: `rbac` group (#55), `user create` + `rbac audit-logs` (#58), and now `secret update`. The whole CLI now operates on the server's store in remote mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)