### PR TITLE
feat(deploy): optional Caddy auto-HTTPS profile for the self-host stack

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,3 +17,9 @@ KEYORIX_MASTER_PASSWORD=
 KEYORIX_ADMIN_USERNAME=admin
 KEYORIX_ADMIN_EMAIL=admin@keyorix.local
 KEYORIX_ADMIN_PASSWORD=
+
+# TLS (only used by the `tls` compose profile: docker compose --profile tls up).
+# Set to your real domain (with ports 80/443 reachable + DNS pointing here) for an
+# automatic, publicly-trusted certificate. Leave as localhost for Caddy's internal
+# CA (browser trust warning).
+KEYORIX_DOMAIN=localhost

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,15 @@
+# Keyorix TLS front-end — used only by the optional `tls` compose profile
+# (`docker compose --profile tls up -d`).
+#
+# Caddy terminates HTTPS and reverse-proxies to the web container (which serves
+# the SPA and proxies the API to the backend). With a real domain set in
+# KEYORIX_DOMAIN, Caddy automatically provisions and renews a publicly-trusted
+# certificate (Let's Encrypt / ZeroSSL) — ports 80 and 443 must be reachable from
+# the internet and DNS must point at this host. For the default `localhost` it
+# uses Caddy's internal CA (browsers warn unless you trust Caddy's root).
+#
+# Add `email you@example.com` below for ACME expiry notifications if you like.
+
+{$KEYORIX_DOMAIN:localhost} {
+	reverse_proxy web:80
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,6 +56,31 @@ services:
     depends_on:
       - backend
 
+  # Optional HTTPS front-end. Enable with `docker compose --profile tls up -d`.
+  # Caddy terminates TLS and proxies to web. Set KEYORIX_DOMAIN to a real domain
+  # (with 80/443 reachable + DNS pointing here) for an automatic, publicly-trusted
+  # certificate; the default `localhost` uses Caddy's internal CA. See
+  # docs/SELF_HOSTING.md §7. When using this, don't also expose web's 8088 publicly.
+  caddy:
+    image: caddy:2-alpine
+    profiles: ["tls"]
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    environment:
+      KEYORIX_DOMAIN: ${KEYORIX_DOMAIN:-localhost}
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      # Persist issued certificates so restarts don't re-request them (ACME has
+      # rate limits).
+      - caddy_data:/data
+      - caddy_config:/config
+    depends_on:
+      - web
+
 volumes:
   postgres_data:
   keyorix_keys:
+  caddy_data:
+  caddy_config:

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -112,10 +112,31 @@ Schema migrations run automatically on boot and are additive. **Back up first**
 
 ## 7. TLS
 
-The stack serves plain HTTP on `8088` by design — terminate TLS at a reverse
-proxy in front of the `web` container (Caddy, Traefik, nginx, or your cloud load
-balancer). Point it at `web:80` and forward `X-Forwarded-Proto: https`. Do not
-expose `8088` directly to the internet.
+The default stack serves plain HTTP on `8088`. Two ways to get HTTPS:
+
+**Bundled (recommended) — the `tls` profile.** An optional Caddy front-end that
+terminates TLS and proxies to the web container:
+
+```sh
+# In .env, set KEYORIX_DOMAIN to your real domain (DNS must point here, and
+# ports 80 + 443 must be reachable from the internet for the ACME challenge):
+#   KEYORIX_DOMAIN=keyorix.example.com
+docker compose --profile tls up -d
+```
+
+Caddy automatically provisions and renews a publicly-trusted certificate
+(Let's Encrypt / ZeroSSL). Issued certs persist on the `caddy_data` volume so
+restarts don't re-request them. For a `localhost` value Caddy uses its internal
+CA (browsers warn unless you trust Caddy's root). When running the `tls` profile,
+don't also expose web's `8088` publicly — front everything through Caddy on
+80/443.
+
+**Your own proxy.** Or terminate TLS at an existing Caddy/Traefik/nginx/LB in
+front of the `web` container: point it at `web:80` and forward
+`X-Forwarded-Proto: https`.
+
+The single-binary `keyorix-server` also supports TLS directly
+(`server.http.tls` in the config) for non-Docker deployments.
 
 ## 8. Metrics (Prometheus)
 


### PR DESCRIPTION
## Summary

Bundled TLS for the Docker self-host stack (Bar-2 hardening). Previously the only guidance was "terminate TLS at your own reverse proxy"; now there's a one-command HTTPS option.

```sh
# set KEYORIX_DOMAIN=your.domain in .env (DNS + 80/443 reachable), then:
docker compose --profile tls up -d
```

A Caddy front-end terminates TLS and proxies to the web container. With a real `KEYORIX_DOMAIN`, Caddy auto-provisions and renews a **publicly-trusted** cert (Let's Encrypt / ZeroSSL); `localhost` uses Caddy's internal CA. Issued certs persist on the `caddy_data` volume (avoids ACME rate limits). The profile is **opt-in** — the default stack is unchanged.

## Changes

- **`Caddyfile`** — minimal `reverse_proxy web:80`, domain from `KEYORIX_DOMAIN`.
- **`docker-compose.yml`** — `caddy` service under `profiles: ["tls"]` (ports 80/443, `caddy_data`/`caddy_config` volumes).
- **`.env.example`** — `KEYORIX_DOMAIN`.
- **`docs/SELF_HOSTING.md §7`** — documents the bundled profile, the own-proxy alternative, and the single-binary TLS config.

## Verification

Ran `docker compose --profile tls up` locally and confirmed over HTTPS (Caddy internal CA on localhost): `/health` → 200, login through the `/auth/` proxy → token, and the SPA all served through Caddy.

## Bar-2 status

- ✅ Prometheus `/metrics` (#60)
- ✅ Bundled TLS (this PR)
- ⏸️ Single-binary-serves-bundled-UI — deferred (cross-repo release effort)

🤖 Generated with [Claude Code](https://claude.com/claude-code)