### PR TITLE
fix(cli): remote-mode for `share list` + `share shared-secrets` (read path)

### DIFF
--- a/internal/cli/share/list.go
+++ b/internal/cli/share/list.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"text/tabwriter"
 
+	"github.com/keyorixhq/keyorix/internal/cli/common"
 	"github.com/keyorixhq/keyorix/internal/config"
 	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
@@ -31,6 +32,10 @@ func init() {
 }
 
 func runList(cmd *cobra.Command, args []string) error {
+	if rc, ok := common.NewRemoteClient(); ok {
+		return runListRemote(rc, listSecretID)
+	}
+
 	// Load config and connect to database
 	cfg, err := config.Load("keyorix.yaml")
 	if err != nil {

--- a/internal/cli/share/remote.go
+++ b/internal/cli/share/remote.go
@@ -1,0 +1,64 @@
+// remote.go — server-backed (remote mode) implementations of the read-path share
+// commands. Like the rest of the CLI, `keyorix share` is dual-mode: when remote
+// config is present (env or ~/.keyorix/cli.yaml from `keyorix connect`) these go
+// through the HTTP API so they operate on the same store the dashboard uses;
+// otherwise the embedded direct-DB path runs.
+//
+// Remote mode is also more correct for sharing: the embedded path has no
+// authenticated-user concept, whereas the server resolves the caller from the
+// session token.
+package share
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+func runListRemote(rc *common.RemoteClient, secretID uint) error {
+	var resp struct {
+		Shares []models.ShareRecord `json:"shares"`
+	}
+	if err := rc.Get(context.Background(), fmt.Sprintf("/api/v1/secrets/%d/shares", secretID), &resp); err != nil {
+		return fmt.Errorf("failed to list shares: %w", err)
+	}
+	if len(resp.Shares) == 0 {
+		fmt.Println("No shares found for this secret.")
+		return nil
+	}
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "ID\tSECRET ID\tOWNER ID\tRECIPIENT ID\tIS GROUP\tPERMISSION\tCREATED AT") //nolint:errcheck
+	for _, share := range resp.Shares {
+		fmt.Fprintf(w, "%d\t%d\t%d\t%d\t%t\t%s\t%s\n", //nolint:errcheck
+			share.ID, share.SecretID, share.OwnerID, share.RecipientID, share.IsGroup,
+			share.Permission, share.CreatedAt.Format("2006-01-02 15:04:05"))
+	}
+	_ = w.Flush() // #nosec G104
+	return nil
+}
+
+func runSharedSecretsRemote(rc *common.RemoteClient) error {
+	var resp struct {
+		Secrets []models.SecretNode `json:"secrets"`
+	}
+	if err := rc.Get(context.Background(), "/api/v1/shared-secrets", &resp); err != nil {
+		return fmt.Errorf("failed to list shared secrets: %w", err)
+	}
+	if len(resp.Secrets) == 0 {
+		fmt.Println("No shared secrets found.")
+		return nil
+	}
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "ID\tNAME\tTYPE\tPROJECT\tENVIRONMENT\tCREATED BY\tCREATED AT") //nolint:errcheck
+	for _, secret := range resp.Secrets {
+		fmt.Fprintf(w, "%d\t%s\t%s\t%d\t%d\t%s\t%s\n", //nolint:errcheck
+			secret.ID, secret.Name, secret.Type, secret.ProjectID, secret.EnvironmentID,
+			secret.CreatedBy, secret.CreatedAt.Format("2006-01-02 15:04:05"))
+	}
+	_ = w.Flush() // #nosec G104
+	return nil
+}

--- a/internal/cli/share/remote_test.go
+++ b/internal/cli/share/remote_test.go
@@ -1,0 +1,36 @@
+package share
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestShareReadRemote(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/secrets/7/shares", func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "GET", r.Method)
+		_, _ = w.Write([]byte(`{"data":{"shares":[
+			{"ID":1,"SecretID":7,"OwnerID":1,"RecipientID":5,"IsGroup":false,"Permission":"read","CreatedAt":"2026-06-08T10:00:00Z"}
+		]}}`))
+	})
+	mux.HandleFunc("/api/v1/shared-secrets", func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "GET", r.Method)
+		_, _ = w.Write([]byte(`{"data":{"secrets":[
+			{"ID":7,"Name":"db-pass","Type":"password","ProjectID":1,"EnvironmentID":1,"CreatedBy":"admin","CreatedAt":"2026-06-08T10:00:00Z"}
+		]}}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+	rc, ok := common.NewRemoteClient()
+	require.True(t, ok)
+
+	require.NoError(t, runListRemote(rc, 7))
+	require.NoError(t, runSharedSecretsRemote(rc))
+}

--- a/internal/cli/share/shared_secrets.go
+++ b/internal/cli/share/shared_secrets.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"text/tabwriter"
 
+	"github.com/keyorixhq/keyorix/internal/cli/common"
 	"github.com/keyorixhq/keyorix/internal/config"
 	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
@@ -31,6 +32,13 @@ func init() {
 }
 
 func runSharedSecrets(cmd *cobra.Command, args []string) error {
+	if rc, ok := common.NewRemoteClient(); ok {
+		// The server scopes this to the authenticated caller, so --user-id is
+		// ignored in remote mode (an embedded admin can query any user; over the
+		// API you see your own shared secrets).
+		return runSharedSecretsRemote(rc)
+	}
+
 	// Load config and connect to database
 	cfg, err := config.Load("keyorix.yaml")
 	if err != nil {


### PR DESCRIPTION
## Summary

Continues closing the embedded-only CLI gaps (after `secret`, `rbac`, `user`). The `share` command group ignored the configured server (read/wrote local SQLite). This makes the two **read** commands server-aware:

- `share list --secret-id N` → `GET /api/v1/secrets/{id}/shares`
- `share shared-secrets` → `GET /api/v1/shared-secrets`

Remote mode is also **more correct** here: the embedded path has no authenticated-user concept, while the server resolves the caller from the session token (so `shared-secrets` returns *your* shares; `--user-id` is ignored over the API).

## Tests

httptest-backed test covering both read paths. Embedded paths unchanged.

## Scope

The write-path share commands (`create`/`revoke`/`update`/`self-remove`/`group-shares`) remain embedded-only — a follow-up. `self-remove` in particular needs the remote path to drop its hardcoded `getCurrentUserID()=1`.

Full suite green; gofmt + `gosec -severity medium` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)