### PR TITLE
feat(deploy): single-binary serves the embedded web UI (air-gap one-file deploy)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,3 +181,8 @@ temp/
 
 data_key
 certs/
+
+# Embedded web UI: commit only the placeholder; release builds (`make build-ui`)
+# copy the real keyorix-web bundle in, which must not be committed.
+/server/webui/dist/*
+!/server/webui/dist/index.html

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ BUILD_DIR=./bin
 VERSION?=dev
 LDFLAGS=-ldflags "-X github.com/keyorixhq/keyorix/internal/cli.version=$(VERSION)"
 
-.PHONY: build build-cli build-server install install-cli install-server clean run db-up dev docker-build docker-up docker-down docker-logs proto proto-deps proto-lint
+.PHONY: build build-cli build-server build-ui install install-cli install-server clean run db-up dev docker-build docker-up docker-down docker-logs proto proto-deps proto-lint
 
 # Pinned protoc-gen plugin versions (match google.golang.org/{protobuf,grpc} in go.mod).
 PROTOC_GEN_GO_VERSION=v1.36.11
@@ -31,6 +31,25 @@ build-cli:
 
 build-server:
 	go build $(LDFLAGS) -o $(BUILD_DIR)/$(BINARY_SERVER) ./server/main.go
+
+# Path to the keyorix-web checkout (override: make build-ui KEYORIX_WEB_DIR=/path).
+KEYORIX_WEB_DIR ?= ../keyorix-web
+
+# build-ui: build the web dashboard and embed it into the server binary, so a
+# single keyorix-server serves both API and UI (air-gap "one file" deploy).
+# Requires pnpm + a keyorix-web checkout at KEYORIX_WEB_DIR. The committed
+# placeholder is restored afterward so the working tree stays clean — the binary
+# already has the real UI embedded.
+build-ui:
+	@command -v pnpm >/dev/null 2>&1 || { echo "pnpm is required to build the web UI"; exit 1; }
+	@test -d "$(KEYORIX_WEB_DIR)" || { echo "keyorix-web not found at $(KEYORIX_WEB_DIR); set KEYORIX_WEB_DIR=<path>"; exit 1; }
+	cd "$(KEYORIX_WEB_DIR)" && pnpm install --frozen-lockfile && pnpm build
+	rm -rf server/webui/dist
+	mkdir -p server/webui/dist
+	cp -R "$(KEYORIX_WEB_DIR)"/dist/. server/webui/dist/
+	go build $(LDFLAGS) -o $(BUILD_DIR)/$(BINARY_SERVER) ./server/main.go
+	@git checkout -- server/webui/dist/index.html 2>/dev/null || true
+	@echo "Built $(BUILD_DIR)/$(BINARY_SERVER) with the web UI embedded."
 
 install-cli: build-cli
 	sudo mv $(BUILD_DIR)/$(BINARY_CLI) /usr/local/bin/$(BINARY_CLI)

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -158,6 +158,21 @@ your own Prometheus at `backend:8080/metrics`.
 ## 10. Single-binary / air-gapped deployment
 
 For environments where Docker isn't available, `keyorix-server` is a single Go
-binary (`make build` → `keyorix-server`) that runs against any PostgreSQL with
-`KEYORIX_MASTER_PASSWORD` + `KEYORIX_DB_PASSWORD` set. Serving the bundled web UI
-from the binary is on the roadmap; today the web UI ships as the `web` container.
+binary that runs against any PostgreSQL with `KEYORIX_MASTER_PASSWORD` +
+`KEYORIX_DB_PASSWORD` set — and it can serve the **web dashboard from the binary
+itself**, so the whole product is one file plus a database. No web container, no
+nginx.
+
+```sh
+make build-ui      # builds keyorix-web and embeds it into bin/keyorix-server
+                   # (override the web checkout: make build-ui KEYORIX_WEB_DIR=/path)
+KEYORIX_MASTER_PASSWORD=… KEYORIX_DB_PASSWORD=… ./bin/keyorix-server
+```
+
+Copy `keyorix-server` to the target host, point it at PostgreSQL, and the API +
+UI are served on one port (default 8080). Set TLS directly via `server.http.tls`
+in the config for HTTPS without a proxy.
+
+`make build` (without the UI) produces an API-only binary that serves a small
+placeholder page in place of the dashboard — use `make build-ui` for the full
+single-file deployment.

--- a/server/http/embedded_webui_test.go
+++ b/server/http/embedded_webui_test.go
@@ -1,0 +1,54 @@
+package http
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// With no on-disk web assets configured, the server serves the web UI from the
+// embedded build (the placeholder in test builds, the real SPA in release
+// builds), and the SPA fallback must not shadow API routes.
+func TestEmbeddedWebUI(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	router, err := NewRouter(&config.Config{}, core.NewKeyorixCore(store.NewLocalStorage(db)))
+	require.NoError(t, err)
+	srv := httptest.NewServer(router)
+	defer srv.Close()
+	client := &http.Client{}
+
+	// Root serves the embedded index.html.
+	resp, err := client.Get(srv.URL + "/")
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	body := readAll(t, resp.Body)
+	_ = resp.Body.Close()
+	assert.Contains(t, body, "Keyorix", "embedded index.html should be served at /")
+	assert.Contains(t, resp.Header.Get("Content-Type"), "text/html")
+
+	// A client-side route also resolves to index.html (SPA fallback).
+	resp, err = client.Get(srv.URL + "/admin/users")
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	_ = resp.Body.Close()
+
+	// API routes are NOT shadowed by the SPA fallback — an unauthenticated API
+	// call returns 401, not the HTML page.
+	resp, err = client.Get(srv.URL + "/api/v1/secrets")
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode, "API routes must not fall through to the SPA")
+	_ = resp.Body.Close()
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"fmt"
+	"log"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -15,6 +16,7 @@ import (
 	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/keyorixhq/keyorix/server/http/handlers"
 	customMiddleware "github.com/keyorixhq/keyorix/server/middleware"
+	"github.com/keyorixhq/keyorix/server/webui"
 )
 
 // NewRouter creates and configures the HTTP router
@@ -370,56 +372,58 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 	// OpenAPI spec endpoint
 	r.Get("/openapi.yaml", handlers.OpenAPISpec)
 
-	// Serve web dashboard static files
-	webDir := getWebAssetsPath(cfg)
-	if webDir != "" {
-		// Serve static assets with cache headers
-		r.Route("/static", func(r chi.Router) {
-			r.Use(setCacheHeaders)
-			fileServer := http.FileServer(http.Dir(filepath.Join(webDir, "static")))
-			r.Handle("/*", http.StripPrefix("/static", fileServer))
-		})
-
-		// Serve other assets (favicon, manifest, etc.)
-		r.Route("/assets", func(r chi.Router) {
-			r.Use(setCacheHeaders)
-			fileServer := http.FileServer(http.Dir(filepath.Join(webDir, "assets")))
-			r.Handle("/*", http.StripPrefix("/assets", fileServer))
-		})
-
-		// Serve service worker
-		r.Get("/sw.js", func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/javascript")
-			w.Header().Set("Cache-Control", "no-cache")
-			http.ServeFile(w, r, filepath.Join(webDir, "sw.js"))
-		})
-
-		// Serve manifest and other root files
-		r.Get("/manifest.json", func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			http.ServeFile(w, r, filepath.Join(webDir, "manifest.json"))
-		})
-
-		r.Get("/favicon.ico", func(w http.ResponseWriter, r *http.Request) {
-			http.ServeFile(w, r, filepath.Join(webDir, "favicon.ico"))
-		})
-
-		// SPA fallback - serve index.html for all non-API routes
-		r.NotFound(func(w http.ResponseWriter, r *http.Request) {
-			// Don't serve SPA for API routes
-			if strings.HasPrefix(r.URL.Path, "/api/") {
-				http.NotFound(w, r)
-				return
-			}
-
-			// Serve index.html for SPA routing
-			w.Header().Set("Content-Type", "text/html")
-			w.Header().Set("Cache-Control", "no-cache")
-			http.ServeFile(w, r, filepath.Join(webDir, "index.html"))
-		})
+	// Serve the web dashboard. Prefer an on-disk build (mounted in the Docker
+	// stack, or present in dev); otherwise fall back to the build embedded in the
+	// binary, so a single keyorix-server can serve the UI with no web container
+	// (the air-gap "one file" deployment).
+	if webDir := getWebAssetsPath(cfg); webDir != "" {
+		log.Printf("Serving web UI from %s", webDir)
+		registerWebUI(r, http.Dir(webDir))
+	} else if webui.HasRealBuild() {
+		log.Printf("Serving embedded web UI (single-binary mode)")
+		registerWebUI(r, webui.HTTPFS())
+	} else {
+		log.Printf("Web UI not bundled in this build; serving API only (placeholder page at /)")
+		registerWebUI(r, webui.HTTPFS())
 	}
 
 	return r, nil
+}
+
+// registerWebUI wires the SPA's static assets and the client-side-routing
+// fallback against fsys, which is rooted at the dist directory (so request paths
+// map directly: /assets/x -> dist/assets/x). fsys is either an on-disk build
+// (http.Dir) or the embedded build (webui.HTTPFS()).
+func registerWebUI(r chi.Router, fsys http.FileSystem) {
+	fileServer := http.FileServer(fsys)
+
+	r.With(setCacheHeaders).Handle("/assets/*", fileServer)
+	r.With(setCacheHeaders).Handle("/static/*", fileServer)
+	r.Handle("/sw.js", fileServer)
+	r.Handle("/manifest.json", fileServer)
+	r.Handle("/favicon.ico", fileServer)
+
+	// SPA fallback: serve index.html for any non-API route that didn't match a
+	// registered handler, so client-side routes (e.g. /admin/users) resolve.
+	r.NotFound(func(w http.ResponseWriter, req *http.Request) {
+		if strings.HasPrefix(req.URL.Path, "/api/") {
+			http.NotFound(w, req)
+			return
+		}
+		f, err := fsys.Open("index.html")
+		if err != nil {
+			http.NotFound(w, req)
+			return
+		}
+		defer func() { _ = f.Close() }()
+		fi, err := f.Stat()
+		if err != nil {
+			http.NotFound(w, req)
+			return
+		}
+		w.Header().Set("Cache-Control", "no-cache")
+		http.ServeContent(w, req, "index.html", fi.ModTime(), f)
+	})
 }
 
 // getAllowedOrigins returns the allowed origins for CORS based on configuration

--- a/server/webui/dist/index.html
+++ b/server/webui/dist/index.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<!--
+  Placeholder served by dev/test builds of keyorix-server. A release build
+  (`make build-ui`) replaces this dist/ with the real keyorix-web bundle, so the
+  single binary serves the full dashboard. If you are seeing this page in
+  production, the web UI was not bundled into this build.
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Keyorix</title>
+  </head>
+  <body>
+    <main style="font-family: system-ui, sans-serif; max-width: 40rem; margin: 4rem auto; padding: 0 1rem;">
+      <h1>Keyorix API server</h1>
+      <p>
+        This build does not bundle the web dashboard. The API is running and
+        healthy at <code>/health</code>. To get the dashboard, use the Docker
+        stack (web container) or a release binary built with
+        <code>make build-ui</code>.
+      </p>
+    </main>
+  </body>
+</html>

--- a/server/webui/embed.go
+++ b/server/webui/embed.go
@@ -1,0 +1,37 @@
+// Package webui embeds the built web dashboard so a single keyorix-server binary
+// can serve the UI with no separate web container — the air-gap "one file" deploy.
+//
+// dist/ holds a committed placeholder index.html so the repository always
+// compiles. A release build replaces dist/ with the real keyorix-web output
+// before compiling (see `make build-ui`), embedding the full SPA. Everything
+// under dist/ except the placeholder is gitignored, so build artifacts are never
+// committed.
+package webui
+
+import (
+	"embed"
+	"io/fs"
+	"net/http"
+)
+
+//go:embed all:dist
+var distFS embed.FS
+
+// FS returns the embedded web build rooted at dist/.
+func FS() fs.FS {
+	sub, err := fs.Sub(distFS, "dist")
+	if err != nil {
+		return distFS // dist is always present (committed placeholder); stay non-nil
+	}
+	return sub
+}
+
+// HTTPFS returns the embedded build as an http.FileSystem.
+func HTTPFS() http.FileSystem { return http.FS(FS()) }
+
+// HasRealBuild reports whether a real web build (not just the placeholder) is
+// embedded — detected by the Vite assets directory. Used only for a startup log.
+func HasRealBuild() bool {
+	_, err := fs.Stat(FS(), "assets")
+	return err == nil
+}


### PR DESCRIPTION
## Summary

`keyorix-server` can now serve the web dashboard **from the binary itself** — no web container, no nginx. Copy one file, point it at PostgreSQL, and the API + UI are on one port. This is the air-gap "one binary" story the ENISA positioning implies (the deferred Bar-2 item).

## How

- **`server/webui`** — `//go:embed` of `dist/`, with a committed **placeholder** `index.html` so the repo always compiles; real build artifacts under `dist/` are gitignored and never committed.
- **router** — serve the SPA from an on-disk build when present (the Docker stack's mounted assets), else fall back to the **embedded** build. Unified static-asset + SPA-fallback handling for both sources; `/api/` is never shadowed by the SPA.
- **Makefile `build-ui`** — builds keyorix-web (`KEYORIX_WEB_DIR`, default `../keyorix-web`) and embeds its `dist` into `bin/keyorix-server`, then restores the placeholder so the working tree stays clean. Plain `make build` stays UI-less (placeholder).
- **docs/SELF_HOSTING.md §10** rewritten: single-file deploy is real, not roadmap.

## Verification

Ran `make build-ui` and then the binary directly:
- `/` → real **"Keyorix Dashboard"** SPA
- embedded `/assets/index-*.js` → 200
- `/health` → 200
- logs `Serving embedded web UI (single-binary mode)`

Committed test (`embedded_webui_test.go`) covers the embedded fallback against a fresh build: root + SPA client-routes serve `index.html`, while unauthenticated `/api/` returns 401 (not shadowed).

Full suite green; gofmt + `gosec -severity medium` clean.

## Follow-up

A release workflow that runs `build-ui` and publishes the UI-embedded binaries (and consumes a published web-dist artifact rather than the sibling checkout) is a natural next step; this PR delivers the capability + local build path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)