### PR TITLE
feat(rotation): secret.rotated audit + rotation status inspector API (M2)

### DIFF
--- a/internal/core/audit.go
+++ b/internal/core/audit.go
@@ -237,6 +237,22 @@ func (c *KeyorixCore) LogSecretUpdatedWithDiff(ctx context.Context, userID uint,
 	c.writeAccessLog(ctx, secretID, username, "update", ip, ua)
 }
 
+// LogSecretRotated writes audit_events + secret_access_logs for a secret rotation.
+func (c *KeyorixCore) LogSecretRotated(ctx context.Context, userID uint, secretID uint, username, secretName, ip, ua string) {
+	uid, sid := userID, secretID
+	c.writeAuditEvent(ctx, "secret.rotated", &uid, &sid,
+		fmt.Sprintf("User %s rotated secret %s", username, secretName))
+	c.writeAccessLog(ctx, secretID, username, "rotate", ip, ua)
+}
+
+// LogSecretRotatedWithProject writes audit_events + secret_access_logs including project context.
+func (c *KeyorixCore) LogSecretRotatedWithProject(ctx context.Context, userID uint, secretID uint, projectID uint, username, secretName, ip, ua string) {
+	uid, sid, pid := userID, secretID, projectID
+	c.writeAuditEventFull(ctx, "secret.rotated", &uid, &sid, &pid, ip,
+		fmt.Sprintf("User %s rotated secret %s", username, secretName))
+	c.writeAccessLog(ctx, secretID, username, "rotate", ip, ua)
+}
+
 // LogSecretDeleted writes audit_events + secret_access_logs for a secret deletion.
 func (c *KeyorixCore) LogSecretDeleted(ctx context.Context, userID uint, secretID uint, username, secretName, ip, ua string) {
 	uid, sid := userID, secretID

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -885,8 +885,12 @@ func (m *MockStorage) GetRotationPolicy(_ context.Context, id uint) (*models.Rot
 	return &models.RotationPolicy{ID: id}, nil
 }
 
-func (m *MockStorage) ListRotationPolicies(_ context.Context, _ *uint, _ *uint) ([]*models.RotationPolicy, error) {
-	return nil, nil
+func (m *MockStorage) ListRotationPolicies(ctx context.Context, projectID *uint, environmentID *uint) ([]*models.RotationPolicy, error) {
+	args := m.Called(ctx, projectID, environmentID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*models.RotationPolicy), args.Error(1)
 }
 
 func (m *MockStorage) UpdateRotationPolicy(_ context.Context, _ *models.RotationPolicy) error {

--- a/internal/core/rotation_policies.go
+++ b/internal/core/rotation_policies.go
@@ -121,6 +121,96 @@ func (c *KeyorixCore) DeleteRotationPolicy(ctx context.Context, id uint) error {
 	return nil
 }
 
+// Rotation status values returned by GetRotationStatus.
+const (
+	RotationStatusOverdue = "overdue"
+	RotationStatusDueSoon = "due_soon"
+	RotationStatusOK      = "ok"
+)
+
+// RotationStatusEntry is the per-secret rotation posture under a policy. Unlike
+// RotationPolicyEvaluation (which only surfaces overdue/approaching secrets),
+// GetRotationStatus returns every policy-covered secret with an explicit status,
+// so the dashboard can render a full inspector and a rotation health score.
+type RotationStatusEntry struct {
+	PolicyID          uint       `json:"policy_id"`
+	PolicyName        string     `json:"policy_name"`
+	IntervalDays      int        `json:"interval_days"`
+	AlertDaysBefore   int        `json:"alert_days_before"`
+	SecretID          uint       `json:"secret_id"`
+	SecretName        string     `json:"secret_name"`
+	EnvironmentID     uint       `json:"environment_id"`
+	LastRotatedAt     *time.Time `json:"last_rotated_at"`
+	DaysSinceRotation int        `json:"days_since_rotation"`
+	DaysOverdue       int        `json:"days_overdue"` // positive = overdue, negative = days remaining
+	Status            string     `json:"status"`       // overdue | due_soon | ok
+}
+
+// GetRotationStatus returns the rotation posture of every secret covered by an
+// active rotation policy (optionally scoped to a project), classified as
+// overdue / due_soon / ok. Secrets never rotated fall back to their creation
+// time, mirroring EvaluateRotationPolicies.
+func (c *KeyorixCore) GetRotationStatus(ctx context.Context, projectID *uint) ([]*RotationStatusEntry, error) {
+	policies, err := c.storage.ListRotationPolicies(ctx, projectID, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list rotation policies: %w", err)
+	}
+
+	var entries []*RotationStatusEntry
+	now := c.now()
+
+	for _, policy := range policies {
+		if !policy.IsActive {
+			continue
+		}
+
+		filter := &storage.SecretFilter{Page: 1, PageSize: 1000}
+		if policy.Scope == "project" {
+			filter.ProjectID = policy.ProjectID
+		} else {
+			filter.EnvironmentID = policy.EnvironmentID
+		}
+
+		secrets, _, err := c.storage.ListSecrets(ctx, filter)
+		if err != nil {
+			continue
+		}
+
+		for _, secret := range secrets {
+			lastRotated := secret.CreatedAt
+			if secret.LastRotatedAt != nil {
+				lastRotated = *secret.LastRotatedAt
+			}
+
+			daysSince := int(now.Sub(lastRotated).Hours() / 24)
+			daysOverdue := daysSince - policy.IntervalDays
+
+			status := RotationStatusOK
+			if daysOverdue > 0 {
+				status = RotationStatusOverdue
+			} else if (policy.IntervalDays - daysSince) <= policy.AlertDaysBefore {
+				status = RotationStatusDueSoon
+			}
+
+			entries = append(entries, &RotationStatusEntry{
+				PolicyID:          policy.ID,
+				PolicyName:        policy.Name,
+				IntervalDays:      policy.IntervalDays,
+				AlertDaysBefore:   policy.AlertDaysBefore,
+				SecretID:          secret.ID,
+				SecretName:        secret.Name,
+				EnvironmentID:     secret.EnvironmentID,
+				LastRotatedAt:     secret.LastRotatedAt,
+				DaysSinceRotation: daysSince,
+				DaysOverdue:       daysOverdue,
+				Status:            status,
+			})
+		}
+	}
+
+	return entries, nil
+}
+
 func (c *KeyorixCore) EvaluateRotationPolicies(ctx context.Context, projectID *uint) ([]*RotationPolicyEvaluation, error) {
 	policies, err := c.storage.ListRotationPolicies(ctx, projectID, nil)
 	if err != nil {

--- a/internal/core/rotation_status_test.go
+++ b/internal/core/rotation_status_test.go
@@ -1,0 +1,67 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// GetRotationStatus classifies every policy-covered secret as overdue / due_soon
+// / ok against the policy interval + alert window, including healthy secrets
+// (which EvaluateRotationPolicies omits).
+func TestGetRotationStatus_Classification(t *testing.T) {
+	fixed := time.Date(2026, 6, 8, 12, 0, 0, 0, time.UTC)
+	daysAgo := func(d int) *time.Time {
+		t := fixed.Add(-time.Duration(d) * 24 * time.Hour)
+		return &t
+	}
+
+	store := new(MockStorage)
+	projectID := uint(1)
+
+	policy := &models.RotationPolicy{
+		ID:              7,
+		Name:            "90-day prod",
+		Scope:           "project",
+		ProjectID:       &projectID,
+		IntervalDays:    90,
+		AlertDaysBefore: 14,
+		IsActive:        true,
+	}
+	// An inactive policy must be ignored entirely.
+	inactive := &models.RotationPolicy{ID: 8, Name: "off", Scope: "project", ProjectID: &projectID, IntervalDays: 30, IsActive: false}
+
+	secrets := []*models.SecretNode{
+		{ID: 1, Name: "overdue-key", EnvironmentID: 2, LastRotatedAt: daysAgo(120)}, // 120 > 90 → overdue
+		{ID: 2, Name: "due-soon-key", EnvironmentID: 2, LastRotatedAt: daysAgo(80)}, // 90-80=10 <= 14 → due_soon
+		{ID: 3, Name: "healthy-key", EnvironmentID: 2, LastRotatedAt: daysAgo(10)},  // 90-10=80 > 14 → ok
+		{ID: 4, Name: "never-rotated", EnvironmentID: 2, CreatedAt: *daysAgo(200)},  // falls back to CreatedAt → overdue
+	}
+
+	store.On("ListRotationPolicies", mock.Anything, &projectID, (*uint)(nil)).Return([]*models.RotationPolicy{policy, inactive}, nil)
+	store.On("ListSecrets", mock.Anything, mock.AnythingOfType("*storage.SecretFilter")).Return(secrets, int64(len(secrets)), nil)
+
+	c := NewKeyorixCore(store)
+	c.now = func() time.Time { return fixed }
+
+	entries, err := c.GetRotationStatus(context.Background(), &projectID)
+	require.NoError(t, err)
+	require.Len(t, entries, 4, "all covered secrets returned, inactive policy skipped")
+
+	byID := map[uint]*RotationStatusEntry{}
+	for _, e := range entries {
+		byID[e.SecretID] = e
+	}
+
+	require.Equal(t, RotationStatusOverdue, byID[1].Status)
+	require.Equal(t, 30, byID[1].DaysOverdue) // 120 - 90
+	require.Equal(t, RotationStatusDueSoon, byID[2].Status)
+	require.Equal(t, RotationStatusOK, byID[3].Status)
+	require.Equal(t, RotationStatusOverdue, byID[4].Status, "never-rotated falls back to CreatedAt")
+	require.Equal(t, uint(7), byID[1].PolicyID)
+	require.Equal(t, 90, byID[1].IntervalDays)
+}

--- a/server/http/handlers/rotation_policies_handler.go
+++ b/server/http/handlers/rotation_policies_handler.go
@@ -313,3 +313,35 @@ func (h *RotationPolicyHandler) Evaluate(w http.ResponseWriter, r *http.Request)
 
 	h.sendSuccess(w, evaluations, "")
 }
+
+// Status handles GET /api/v1/rotation-policies/status — the rotation posture of
+// every policy-covered secret (overdue / due_soon / ok), powering the dashboard
+// rotation inspector and health score. Unlike Evaluate it does not filter to
+// only overdue/approaching secrets.
+func (h *RotationPolicyHandler) Status(w http.ResponseWriter, r *http.Request) {
+	userCtx := middleware.GetUserFromContext(r.Context())
+	if userCtx == nil {
+		h.sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+
+	var projectID *uint
+	if v := r.URL.Query().Get("project_id"); v != "" {
+		id, err := strconv.ParseUint(v, 10, 32)
+		if err != nil {
+			h.sendError(w, "InvalidParameter", "Invalid project_id", http.StatusBadRequest, nil)
+			return
+		}
+		uid := uint(id)
+		projectID = &uid
+	}
+
+	entries, err := h.coreService.GetRotationStatus(r.Context(), projectID)
+	if err != nil {
+		log.Printf("Error getting rotation status: %v", err)
+		h.sendError(w, "InternalError", "Failed to get rotation status", http.StatusInternalServerError, nil)
+		return
+	}
+
+	h.sendSuccess(w, entries, "")
+}

--- a/server/http/handlers/secrets_versions.go
+++ b/server/http/handlers/secrets_versions.go
@@ -91,5 +91,10 @@ func (h *SecretHandler) RotateSecret(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Audit the rotation (async, detached) so the rotation inspector and the
+	// activity feed have an attributable secret.rotated event.
+	ip, ua := r.RemoteAddr, r.Header.Get("User-Agent")
+	go h.coreService.LogSecretRotatedWithProject(core.DetachedAuditContext(r.Context()), userCtx.UserID, uint(id), secret.ProjectID, userCtx.Username, secret.Name, ip, ua) // #nosec G118
+
 	h.sendSuccess(w, secret, "Secret rotated successfully")
 }

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -248,6 +248,7 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		r.Route("/rotation-policies", func(r chi.Router) {
 			r.With(customMiddleware.RequireScopedPermission("secrets.read", customMiddleware.ScopeFromQuery)).Get("/", rotationPolicyHandler.List)
 			r.With(customMiddleware.RequireScopedPermission("secrets.read", customMiddleware.ScopeFromQuery)).Get("/evaluate", rotationPolicyHandler.Evaluate)
+			r.With(customMiddleware.RequireScopedPermission("secrets.read", customMiddleware.ScopeFromQuery)).Get("/status", rotationPolicyHandler.Status)
 			r.With(customMiddleware.RequireScopedPermission("secrets.read", policyScope)).Get("/{id}", rotationPolicyHandler.Get)
 			r.Post("/", rotationPolicyHandler.Create)
 			r.With(customMiddleware.RequireScopedPermission("secrets.write", policyScope)).Put("/{id}", rotationPolicyHandler.Update)


### PR DESCRIPTION
## What

M2 backend for **manual rotation trigger + rotation state inspector**. The `POST /api/v1/secrets/{id}/rotate` endpoint already existed (stores a new version + stamps `LastRotatedAt`) but had two gaps this PR closes.

### 1. `secret.rotated` audit event
`RotateSecret` emitted no audit event, even though the activity-feed action mapping for `secret.rotated` already existed (`dashboard.go`). Added `LogSecretRotated` / `LogSecretRotatedWithProject` (event `secret.rotated`, access-log action `rotate`) and emit it async (detached) from the rotate handler with project/ip/ua, mirroring the read path. This gives the inspector and activity feed an attributable rotation record.

### 2. Rotation status endpoint
New `core.GetRotationStatus(projectID)` + `GET /api/v1/rotation-policies/status` returns **every policy-covered secret** classified `overdue` / `due_soon` / `ok`. The existing `EvaluateRotationPolicies` only surfaces overdue/approaching secrets, so it can't back a full inspector table or a rotation health score. Scoped under `secrets.read` (same as `/evaluate`).

## Tests
- `rotation_status_test.go` — classification (overdue / due_soon / ok), never-rotated fallback to `CreatedAt`, inactive-policy skip.
- Wired the previously hardcoded `ListRotationPolicies` mock to `m.Called` (nothing else exercised it).
- `go vet ./...` + `go test ./...` green.

## Paired frontend
keyorix-web PR adds the "Rotate now" button/modal and the real Rotation Health card that consumes `/status`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)