### PR TITLE
docs(compliance): NIS2 / DORA / ISO 27001 control mappings + security FAQ (M1)

### DIFF
--- a/docs/compliance/AUDIT-LOG-PROVISIONS.md
+++ b/docs/compliance/AUDIT-LOG-PROVISIONS.md
@@ -1,0 +1,114 @@
+# Keyorix Audit-Log & Record-Keeping Provisions
+
+This document describes exactly **what Keyorix logs, how, and how it maps onto
+the audit-log / record-keeping expectations** of NIS2 and DORA. It is the
+companion to the broader [controls statement](./NIS2-DORA-ISO-CONTROLS.md).
+
+> See [`README.md`](./README.md) for the positioning disclaimer. This is an
+> informational mapping of shipped capabilities, not a certification or legal
+> advice. Article numbers are for orientation; confirm applicability with counsel.
+
+## Why this matters
+
+Both NIS2 (Art. 21(2), in support of incident detection and handling) and DORA
+(ICT-activity detection and record-keeping) expect regulated entities to keep
+durable, attributable records of who did what to sensitive systems, and to be
+able to surface those records during an incident or an audit. Because Keyorix is
+self-hosted, **you** own and retain those records — Keyorix's job is to produce
+them completely, attributably, and without leaking the secrets they describe.
+
+---
+
+## 1. What is logged
+
+Every security-relevant event is written to the audit trail:
+
+| Category | Events |
+|---|---|
+| Secret lifecycle | create, read, update (with metadata diff), delete |
+| Sharing | share create, modify, revoke (incl. group shares) |
+| Authentication | login success, login failure, logout, session refresh |
+| Authorisation / RBAC | role assigned/removed (user & group), permission assigned/removed to role |
+| Membership | each membership state transition (invited → … → active, revoked) |
+| Invitations & access requests | invitation sent/accepted/revoked/expired; access request created/approved/rejected/withdrawn |
+| Account lifecycle | suspend, reactivate, force-password-reset, credential displayed out-of-band |
+| Machine identities | create, activate, suspend, revoke, migrated-from-user |
+| Impersonation | `impersonation.start` / `impersonation.end` (with duration + action count) |
+
+## 2. What each record contains
+
+Each audit event carries, at minimum:
+
+- **Actor identity** — the acting user or principal.
+- **`actor_type`** — `user`, `machine_identity`, or `system`, so machine and
+  human activity are distinguishable.
+- **Timestamp** — server-side, on every row.
+- **Action / event type** and **target** (e.g. secret by id/name, role, project).
+- **Outcome** — success/failure (failed authentications are recorded).
+- **Delegation attribution** — `impersonated_by` / `acting_as` (resolved to
+  human-readable usernames) whenever the action occurred under an impersonation
+  session; the `impersonation` flag is set on **every** action in that session.
+- **Change diff** — for `secret.updated`, a before/after diff of non-sensitive
+  metadata (max_reads, expiration) plus a `{"value":{"changed":true}}` marker.
+
+## 3. The no-leakage guarantee
+
+Audit records reference secrets **by id/name only**. They never contain:
+
+- plaintext secret values,
+- passphrases or DEK/KEK key bytes,
+- raw authentication tokens (tokens are SHA-256 hashed before use; API keys are
+  masked).
+
+This is enforced and regression-tested (leak-assertion tests on the diff path),
+so audit logs can be forwarded to a SIEM or shared with auditors without
+exposing the secrets they describe.
+
+## 4. How records are accessed, exported, and forwarded
+
+- **Query / filter** — the audit API supports filtering by event type(s), actor,
+  project, `actor_type`, time window, and success/failure.
+- **Pull export** — cursor-paginated `GET /api/v1/audit/export` for bulk
+  retrieval into your own systems.
+- **Push (SIEM)** — async, best-effort, bounded-queue connectors for **Splunk
+  HEC**, **Datadog**, and a **generic webhook**, wired through a single emission
+  funnel so all event families are forwarded consistently. No plaintext is ever
+  forwarded (the value diff is a marker only).
+- **Live tail** — a server-streaming gRPC `StreamAuditLogs` (when the gRPC
+  surface is enabled) tails events after stream open, honouring the same filters.
+
+## 5. Retention
+
+- Audit history is stored in **your** PostgreSQL. Keyorix imposes **no retention
+  cap and no retention paywall** — retain logs for as long as your policy
+  requires (NIS2-grade durable record-keeping is a configuration of *your*
+  database lifecycle, not a Keyorix limit).
+- Standard PostgreSQL backup/restore applies; the [self-hosting
+  runbook](../SELF_HOSTING.md) documents it.
+
+---
+
+## DORA-oriented audit-log checklist
+
+A practical checklist a financial entity can walk through with its auditor. Each
+row states the expectation and the Keyorix capability that addresses it.
+(Article references are for orientation; confirm exact applicability with counsel.)
+
+| # | Expectation | Keyorix capability | Status |
+|---|---|---|---|
+| 1 | Access to ICT assets is logged with attributable identity | Every event carries actor identity + `actor_type` | ✅ |
+| 2 | Privileged / delegated actions are distinguishable | `impersonated_by` / `acting_as` + per-session impersonation flag | ✅ |
+| 3 | Authentication events (incl. failures) are recorded | login success/failure, logout, refresh logged | ✅ |
+| 4 | Changes to authorisation are recorded | RBAC role/permission/group changes audited (HTTP + gRPC routed through the audited choke point) | ✅ |
+| 5 | Cryptographic key operations are recorded | DEK rotation audited; key files in perm checks/audit | ✅ |
+| 6 | Records do not expose the protected data | No plaintext/keys/tokens in logs (regression-tested) | ✅ |
+| 7 | Records are exportable for examination | Cursor-paginated pull export | ✅ |
+| 8 | Records can be forwarded to monitoring/SIEM | Splunk HEC / Datadog / webhook push connectors | ✅ (operator-configured) |
+| 9 | Records are retained for the required period | Operator-owned PostgreSQL, no cap | ✅ (operator-controlled) |
+| 10 | Records support incident detection | Built-in anomaly alerts + filterable/streamable audit query | ✅ |
+| 11 | Tamper resistance of records | Append-style writes in operator-controlled DB; **WORM/cryptographic chaining is Roadmap** | ⚠️ Roadmap |
+
+> **Honest gap:** Keyorix does not yet provide cryptographic chaining /
+> write-once-read-many tamper-evidence on the audit table itself; integrity today
+> relies on operator-controlled PostgreSQL and standard DB controls. This is a
+> tracked roadmap item — do not represent it as shipped.

--- a/docs/compliance/NIS2-DORA-ISO-CONTROLS.md
+++ b/docs/compliance/NIS2-DORA-ISO-CONTROLS.md
@@ -1,0 +1,188 @@
+# Keyorix Controls Statement — NIS2 · DORA · ISO/IEC 27001
+
+This document maps Keyorix's **implemented** technical controls onto the control
+themes of the EU NIS2 Directive (Directive (EU) 2022/2555), the Digital
+Operational Resilience Act (DORA, Regulation (EU) 2022/2554), and ISO/IEC
+27001:2022 Annex A.
+
+> See [`README.md`](./README.md) for the positioning disclaimer. Keyorix is not
+> certified against these frameworks; this is an informational mapping of shipped
+> capabilities. Article numbers are provided for orientation — confirm exact
+> applicability with your legal counsel.
+
+## How to read the mapping
+
+Each control theme below lists:
+- **What the regulation expects** (paraphrased, for orientation).
+- **What Keyorix provides** — the concrete, shipping capability.
+- **Status** — `Shipped` (in product today), `Operator-configured` (a shipped
+  capability the operator must enable/configure), or `Roadmap`.
+
+---
+
+## 1. Access control & authorisation
+
+**Expected** — NIS2 Art. 21(2)(i) access-control policies; DORA ICT protection &
+prevention (access management); ISO 27001 Annex A 5.15–5.18 (access control,
+identity, authentication, access rights).
+
+**Keyorix provides:**
+- **Role-based access control (RBAC)** with a two-tier scoped model: roles are
+  granted at **system**, **project**, or **environment** scope (sentinel model —
+  `project_id = 0` = system scope). Built-in roles: `system_admin` /
+  `system_auditor` / `system_viewer` and `project_admin` / `project_developer` /
+  `project_viewer` / `project_auditor`. Authorisation is enforced server-side on
+  every API path (`core.Authorize(user, permission, scope)`), with the same
+  enforcement on both the HTTP and gRPC surfaces.
+- **Least-privilege defaults** — new users default to `system_viewer`; users
+  cannot grant permissions they do not themselves hold.
+- **Project membership lifecycle** — a 5-state membership machine
+  (`invited → identity_verified → provisioned → active`, `revoked` terminal);
+  access is granted only on `active` and removed on `revoke`.
+- **Machine identities** — service/CI/Kubernetes principals modelled separately
+  from human users, with their own lifecycle (`pending → active → suspended ⇄
+  active`, `revoked` terminal).
+
+**Status:** Shipped.
+
+---
+
+## 2. Cryptography & protection of data
+
+**Expected** — NIS2 Art. 21(2)(h) cryptography and encryption policies; DORA
+protection of data at rest/in transit; ISO 27001 Annex A 8.24 (use of
+cryptography).
+
+**Keyorix provides:**
+- **Encryption at rest** — every secret value is encrypted with **AES-256-GCM**
+  using **envelope encryption**: a Data Encryption Key (DEK) wrapped by a
+  passphrase-derived Key Encryption Key (KEK). Additional Authenticated Data
+  (AAD) binds each ciphertext to its project context, preventing
+  cross-context ciphertext substitution.
+- **Key rotation** — operator-driven DEK rotation with a full re-encryption sweep
+  (`keyorix encryption rotate`), covering all DEK-encrypted tables, with
+  promote-to-disk and restart-survival verified by an end-to-end integration
+  test (ADR-010).
+- **Encryption in transit** — TLS terminated either by the bundled, opt-in Caddy
+  auto-HTTPS profile (`docker compose --profile tls up`, which auto-provisions a
+  publicly-trusted certificate for a real domain) or at the server itself for the
+  single-binary deployment. HSTS and a strict Content-Security-Policy
+  (`script-src 'self'`) are shipped.
+- **No plaintext in logs** — audited across every sink: no secret values,
+  passphrases, key bytes, or raw tokens are ever logged. Tokens are SHA-256
+  hashed before use; API keys are masked.
+
+**Status:** Shipped (in-transit TLS is Operator-configured — enable the profile
+or provide certs).
+
+---
+
+## 3. Logging, monitoring & audit trail
+
+**Expected** — NIS2 Art. 21(2) logging in support of incident detection &
+handling; DORA detection and record-keeping of ICT activity; ISO 27001 Annex A
+8.15 (logging), 8.16 (monitoring activities).
+
+**Keyorix provides** (see [`AUDIT-LOG-PROVISIONS.md`](./AUDIT-LOG-PROVISIONS.md)
+for the full treatment):
+- A complete, append-style **audit trail** of every security-relevant event —
+  secret create/read/update/delete, sharing changes, authentication
+  success/failure, RBAC role/permission/group changes, membership transitions,
+  and impersonation start/end — each carrying actor identity, timestamp, and
+  outcome.
+- **Actor attribution** — `actor_type` (user / machine_identity / system) and,
+  for delegated actions, `impersonated_by` / `acting_as` resolved to
+  human-readable identities; every action under an impersonation session is
+  tagged.
+- **Change diffs without leakage** — `secret.updated` records a metadata
+  before/after diff (max_reads, expiration) and a `{"value":{"changed":true}}`
+  marker — **never the plaintext value**.
+- **SIEM integration** — async push connectors for Splunk HEC, Datadog, and a
+  generic webhook, plus a cursor-paginated pull export
+  (`GET /api/v1/audit/export`).
+- **Anomaly detection** — built-in alerts (e.g. brute-force / unusual access),
+  deduplicated within a detection window.
+
+**Status:** Shipped (SIEM forwarding is Operator-configured).
+
+---
+
+## 4. Authentication & session security
+
+**Expected** — NIS2 Art. 21(2)(j) use of MFA/strong authentication where
+appropriate; ISO 27001 Annex A 5.17 (authentication information), 8.5 (secure
+authentication).
+
+**Keyorix provides:**
+- **Short-lived session tokens** with a configurable access TTL and a hard
+  **absolute lifetime ceiling** that refresh cannot extend; `/auth/refresh`
+  rotates the token and refuses past the ceiling. Active sessions are listable
+  and individually revocable.
+- **Password policy** — configurable minimum length, character-class complexity,
+  reject-personal-info, reject-common-passwords (offline denylist), password
+  history (no-reuse), and max-age expiry.
+- **Account state machine** — `active` / `pending_first_login` /
+  `password_reset_required` / `suspended`; a first-login gate forces a password
+  change before any other action; suspended accounts cannot authenticate.
+- **Credential delivery** — single-use, hashed-at-rest setup links (24h TTL) or a
+  one-time generated password for out-of-band relay; no reusable credential is
+  ever emailed.
+- **MFA / TOTP** — **Roadmap** (positioned honestly as "coming soon" in-product;
+  not yet built).
+
+**Status:** Shipped, except MFA/TOTP (Roadmap).
+
+---
+
+## 5. ICT third-party risk & operational continuity
+
+**Expected** — DORA ICT third-party-risk management and continuity of critical
+functions; NIS2 supply-chain security (Art. 21(2)(d)); ISO 27001 Annex A 5.19–5.23
+(supplier relationships, cloud services).
+
+**Keyorix provides:**
+- **On-premise / air-gapped deployment** — no Keyorix-operated cloud in the
+  secret-resolution path; the single static binary can serve the API and the web
+  UI with no external dependency. This materially reduces the ICT-third-party
+  surface for the secret-management function.
+- **PostgreSQL-backed durability** — the operator owns the database; standard
+  PostgreSQL backup/restore applies. The self-hosting runbook documents backup &
+  restore of **both** the database and the key material (wrapped DEK + KEK salt).
+- **No hidden defaults** — the deployment refuses to start without
+  operator-supplied secrets (`${VAR:?}`), so there are no baked-in default
+  passwords.
+
+**Status:** Shipped.
+
+---
+
+## 6. Data retention & disposal
+
+**Expected** — NIS2 durable record-keeping in support of incident handling; ISO
+27001 Annex A 8.10 (information deletion), 5.33 (protection of records).
+
+**Keyorix provides:**
+- **Operator-controlled, uncapped retention** — audit history lives in your
+  PostgreSQL; Keyorix imposes no retention limit and no retention paywall.
+- **Soft delete + restore** — users (and projects/environments) are soft-deleted
+  and restorable, preserving audit and ownership history rather than hard-erasing
+  it.
+
+**Status:** Shipped. (Automated purge schedulers for soft-deleted records are
+config-present but not yet wired — Roadmap.)
+
+---
+
+## Summary matrix
+
+| Control theme | NIS2 (Art. 21) | DORA | ISO 27001:2022 | Keyorix status |
+|---|---|---|---|---|
+| Access control & authorisation | 21(2)(i) | ICT protection | A.5.15–5.18 | Shipped |
+| Cryptography | 21(2)(h) | data protection | A.8.24 | Shipped |
+| Logging & audit | 21(2) | detection/records | A.8.15–8.16 | Shipped |
+| Authentication & sessions | 21(2)(j) | — | A.5.17, 8.5 | Shipped (MFA roadmap) |
+| ICT third-party / continuity | 21(2)(d) | third-party risk | A.5.19–5.23 | Shipped |
+| Retention & disposal | 21(2) | record-keeping | A.8.10, 5.33 | Shipped (purge roadmap) |
+
+*This matrix is an informational mapping, not a certification. See the disclaimer
+in [`README.md`](./README.md).*

--- a/docs/compliance/README.md
+++ b/docs/compliance/README.md
@@ -1,0 +1,41 @@
+# Keyorix Compliance Documentation
+
+How Keyorix is **designed to support** your regulatory obligations under EU
+cybersecurity and operational-resilience law. Keyorix runs **on your own
+infrastructure**, so your organisation remains the data controller and the
+operator of record — these documents describe the technical controls Keyorix
+ships so you can map them onto your own compliance programme.
+
+> **Positioning — read this first.** Keyorix is **not** itself certified or
+> audited against NIS2, DORA, or ISO/IEC 27001. These documents are
+> *informational control mappings*, not certifications or legal advice. They
+> describe capabilities that are implemented and shipping today (see
+> [`../SECURITY.md`](../SECURITY.md) and the cited code/ADRs). Detailed,
+> independently-reviewed compliance mapping reports are targeted for **Q3 2026**;
+> contact `hello@keyorix.com` for pre-release access. Verify the exact regulatory
+> article applicability with your own legal counsel before relying on these
+> mappings in an audit.
+
+## Contents
+
+| Document | Purpose |
+|---|---|
+| [`NIS2-DORA-ISO-CONTROLS.md`](./NIS2-DORA-ISO-CONTROLS.md) | Controls statement — Keyorix technical controls mapped to NIS2, DORA, and ISO/IEC 27001:2022 Annex A control themes. |
+| [`AUDIT-LOG-PROVISIONS.md`](./AUDIT-LOG-PROVISIONS.md) | Audit-log & record-keeping provisions mapping — what Keyorix logs, how, and how it satisfies logging/record-keeping requirements (incl. a DORA-oriented checklist). |
+| [`SECURITY-FAQ.md`](./SECURITY-FAQ.md) | Buyer/security-team FAQ — the questions that come up in a vendor security review. |
+
+## Why on-premise matters for compliance
+
+Keyorix is deployed inside your own boundary (Docker Compose or a single static
+binary — see [`../SELF_HOSTING.md`](../SELF_HOSTING.md)). That has direct
+compliance consequences:
+
+- **Data residency** — secrets, audit logs, and keys never leave your
+  infrastructure. There is no Keyorix-operated cloud in the secret-resolution
+  path; air-gapped deployment is supported.
+- **Retention is yours** — audit history lives in *your* PostgreSQL. Keyorix
+  imposes no retention cap and no retention paywall; you keep logs for as long as
+  your policy (e.g. NIS2's expectation of durable records) requires.
+- **No third-party ICT dependency** for core operation — relevant to DORA's
+  ICT third-party-risk provisions, since secret resolution has no external SaaS
+  dependency.

--- a/docs/compliance/SECURITY-FAQ.md
+++ b/docs/compliance/SECURITY-FAQ.md
@@ -1,0 +1,144 @@
+# Keyorix Security FAQ
+
+The questions a customer's security team typically asks during a vendor review.
+Answers describe **shipped** behaviour; see [`../SECURITY.md`](../SECURITY.md) for
+the full security guide and [`NIS2-DORA-ISO-CONTROLS.md`](./NIS2-DORA-ISO-CONTROLS.md)
+for the regulatory mapping.
+
+> See [`README.md`](./README.md) for the positioning disclaimer. Keyorix is not
+> independently certified; this FAQ describes implemented capabilities.
+
+## Deployment & data residency
+
+**Where does our data live?**
+Entirely on infrastructure you control. Keyorix deploys as a Docker Compose stack
+(server + web + PostgreSQL) or as a single static binary that serves both the API
+and the web UI. There is no Keyorix-operated cloud in the secret-resolution path.
+Air-gapped deployment is supported.
+
+**Do you (the vendor) ever see our secrets?**
+No. We operate nothing in your secret path. We have no telemetry that exfiltrates
+secret material, and the product runs without any outbound dependency for core
+operation.
+
+**Is there a SaaS option?**
+Not currently — Keyorix is on-premise / self-hosted by design. (A SaaS offering is
+gated behind on-prem traction and is not on the near-term roadmap.)
+
+## Encryption
+
+**How are secrets encrypted at rest?**
+AES-256-GCM with envelope encryption: each secret is encrypted under a Data
+Encryption Key (DEK), and the DEK is wrapped by a passphrase-derived Key
+Encryption Key (KEK). Ciphertexts are bound to their project context via AEAD
+Additional Authenticated Data (AAD).
+
+**How is data protected in transit?**
+TLS — either via the bundled opt-in Caddy auto-HTTPS profile (auto-provisions a
+publicly-trusted certificate for a real domain; internal CA for localhost) or
+terminated at the server for the single-binary deployment. HSTS and a strict CSP
+(`script-src 'self'`) ship by default.
+
+**Can we rotate encryption keys?**
+Yes. `keyorix encryption rotate` performs a full re-encryption sweep across all
+DEK-encrypted tables, promotes the new key to disk, and survives restart — covered
+by an end-to-end integration test (ADR-010).
+
+**What happens if we lose the master password or key material?**
+Secrets become unrecoverable by design — there is no vendor backdoor. The
+self-hosting runbook documents backing up **both** the database and the key
+material (wrapped DEK + KEK salt); losing the key volume or changing the master
+password without the original makes every secret unreadable.
+
+## Access control
+
+**What authorisation model do you use?**
+Role-based access control with scoping at system, project, and environment level.
+Built-in system roles (`system_admin` / `system_auditor` / `system_viewer`) and
+project roles (`project_admin` / `project_developer` / `project_viewer` /
+`project_auditor`). Authorisation is enforced server-side on every request, on
+both the HTTP and gRPC surfaces; new users default to least privilege
+(`system_viewer`).
+
+**How do machine/service workloads authenticate?**
+Service, CI, and Kubernetes principals are modelled as **machine identities**,
+separate from human users, with their own lifecycle. (OIDC service-account auth —
+e.g. Kubernetes projected tokens — is a roadmap item.)
+
+**Do you support MFA?**
+TOTP/MFA is on the roadmap and is positioned in-product as "coming soon"; it is
+not yet shipped. Password policy, short-lived sessions with an absolute lifetime
+ceiling, and first-login password-change enforcement are shipped today.
+
+**Can an admin act as another user, and is that visible?**
+Yes — impersonation issues a separate short-lived session (the admin's own session
+is untouched), and **every** action under it is tagged in the audit log with
+`impersonated_by` / `acting_as`, plus discrete `impersonation.start` /
+`impersonation.end` events with duration and action count.
+
+## Authentication & sessions
+
+**How long do sessions last?**
+Configurable. Access tokens have a short TTL and a hard **absolute lifetime
+ceiling** that token refresh cannot extend; the default is a 24h access window with
+an uncapped ceiling (short-lived is opt-in). Active sessions are listable and
+individually revocable.
+
+**What is your password policy?**
+Configurable: minimum length, character-class complexity, reject-personal-info,
+reject-common-passwords (offline denylist), no-reuse password history, and max-age
+expiry. Conservative defaults (16-char minimum + full complexity) ship out of the
+box.
+
+**How are credentials delivered to new users?**
+Via single-use, hashed-at-rest setup links (24h TTL) or a one-time generated
+password for out-of-band relay. No reusable credential is ever emailed; accounts
+are created in a restricted state that forces a password change at first login.
+
+## Audit & monitoring
+
+**What is logged?**
+Every security-relevant event — secret access/changes, sharing, authentication
+(incl. failures), RBAC changes, membership transitions, account lifecycle, machine
+identities, and impersonation — each with actor identity, `actor_type`, timestamp,
+and outcome. See [`AUDIT-LOG-PROVISIONS.md`](./AUDIT-LOG-PROVISIONS.md).
+
+**Are secret values ever written to logs?**
+No. Records reference secrets by id/name only; no plaintext values, key bytes, or
+raw tokens are logged (regression-tested). Secret-update diffs record changed
+metadata plus a `value changed` marker, never the value.
+
+**Can we forward audit logs to our SIEM?**
+Yes — async push connectors for Splunk HEC, Datadog, and a generic webhook, plus a
+cursor-paginated pull export and (when gRPC is enabled) a live stream.
+
+**How long are logs retained?**
+As long as you choose — audit history lives in your PostgreSQL with no Keyorix
+retention cap or paywall.
+
+## Vulnerability management & reporting
+
+**How do you handle security scanning?**
+The codebase is gated in CI with `gosec`, `golangci-lint`, and `govulncheck`
+(reported at zero issues/vulnerabilities at last sweep). The frontend ships a
+strict CSP and passes `pnpm audit`.
+
+**How do we report a vulnerability?**
+Email `security@keyorix.com`. Target response time is 24 hours for critical
+issues. See [`../SECURITY.md`](../SECURITY.md) for details.
+
+## Known gaps (stated honestly)
+
+We would rather tell you these up front than have you find them:
+
+- **MFA/TOTP** — roadmap, not shipped.
+- **OIDC service-account auth** (e.g. Kubernetes) — roadmap.
+- **Audit-log tamper-evidence** (cryptographic chaining / WORM) — roadmap;
+  integrity today relies on operator-controlled PostgreSQL.
+- **Automated purge schedulers** for soft-deleted records — config-present, not
+  yet wired.
+- **PAT per-token permission scoping** — a personal access token currently
+  inherits the owner's full permission set; least-privilege scoping is a roadmap
+  item.
+- **No independent certification yet** — NIS2/DORA/ISO mappings are informational;
+  detailed reviewed reports are targeted for Q3 2026.


### PR DESCRIPTION
## What

Adds `docs/compliance/` — buyer-facing compliance material grounded **only in shipped features**. Closes the M1 items "`security/compliance/` (NIS2/DORA controls statement + security FAQ)" and "NIS2/DORA audit-log provisions mapping".

- **README.md** — index + a non-certification positioning disclaimer (mirrors the web Compliance page's "designed to support" language).
- **NIS2-DORA-ISO-CONTROLS.md** — controls statement mapping Keyorix controls → NIS2 Art. 21 / DORA / ISO 27001:2022 Annex A across six themes + a summary matrix.
- **AUDIT-LOG-PROVISIONS.md** — what is logged, the no-plaintext guarantee, export/SIEM/retention, and an 11-row DORA auditor checklist.
- **SECURITY-FAQ.md** — vendor-security-review FAQ with an honest "known gaps" section (MFA, OIDC, audit tamper-evidence — all roadmap, not claimed as shipped).

## ⚠️ Review before publishing
These are **drafts**. Every claim is tied to a shipped feature and the framing is deliberately non-certification, but **the exact regulatory article citations should be confirmed with legal counsel / the gestoría** before this is linked from the site. Detailed independently-reviewed mapping reports remain targeted for Q3 2026.

Docs-only; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)