### PR TITLE
feat(usage): secrets usage analytics — most-accessed + unused API (M2)

### DIFF
--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -587,6 +587,22 @@ func (m *MockStorage) ListSecretAccessLogs(ctx context.Context, secretID uint, s
 	return args.Get(0).([]models.SecretAccessLog), args.Error(1)
 }
 
+func (m *MockStorage) MostAccessedSecrets(ctx context.Context, projectID *uint, since time.Time, limit int) ([]storage.SecretUsageStat, error) {
+	args := m.Called(ctx, projectID, since, limit)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]storage.SecretUsageStat), args.Error(1)
+}
+
+func (m *MockStorage) UnusedSecrets(ctx context.Context, projectID *uint, notReadSince time.Time) ([]storage.UnusedSecretStat, error) {
+	args := m.Called(ctx, projectID, notReadSince)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]storage.UnusedSecretStat), args.Error(1)
+}
+
 func (m *MockStorage) CreateAnomalyAlert(ctx context.Context, alert *models.AnomalyAlert) error {
 	args := m.Called(ctx, alert)
 	return args.Error(0)

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -183,6 +183,14 @@ type Storage interface {
 	LogAuditEvent(ctx context.Context, event *models.AuditEvent) error
 	CreateSecretAccessLog(ctx context.Context, log *models.SecretAccessLog) error
 	ListSecretAccessLogs(ctx context.Context, secretID uint, since time.Time) ([]models.SecretAccessLog, error)
+	// MostAccessedSecrets returns the most-read secrets (optionally scoped to a
+	// project) in the window since `since`, ordered by read count descending,
+	// capped at `limit`. Backs the usage-analytics dashboard.
+	MostAccessedSecrets(ctx context.Context, projectID *uint, since time.Time, limit int) ([]SecretUsageStat, error)
+	// UnusedSecrets returns secrets (optionally scoped to a project) with no read
+	// access since `notReadSince` — including never-read secrets — ordered
+	// never-read first, then oldest last read.
+	UnusedSecrets(ctx context.Context, projectID *uint, notReadSince time.Time) ([]UnusedSecretStat, error)
 	CreateAnomalyAlert(ctx context.Context, alert *models.AnomalyAlert) error
 	ListAnomalyAlerts(ctx context.Context, acknowledged *bool) ([]models.AnomalyAlert, error)
 	AcknowledgeAnomalyAlert(ctx context.Context, id uint) error
@@ -399,6 +407,24 @@ type ProjectWithCounts struct {
 	LastActivity     string `json:"last_activity,omitempty"` // most recent of project update or any secret change
 	Deleted          bool   `json:"deleted"`                 // true when soft-deleted (only returned when includeDeleted)
 	DeletedAt        string `json:"deleted_at,omitempty"`    // RFC3339 timestamp when soft-deleted
+}
+
+// SecretUsageStat is one row of the most-accessed-secrets report.
+type SecretUsageStat struct {
+	SecretID      uint       `json:"secret_id"`
+	SecretName    string     `json:"secret_name"`
+	EnvironmentID uint       `json:"environment_id"`
+	ReadCount     int64      `json:"read_count"`
+	LastRead      *time.Time `json:"last_read"`
+}
+
+// UnusedSecretStat is one row of the unused-secrets report. LastRead is nil when
+// the secret has never been read.
+type UnusedSecretStat struct {
+	SecretID      uint       `json:"secret_id"`
+	SecretName    string     `json:"secret_name"`
+	EnvironmentID uint       `json:"environment_id"`
+	LastRead      *time.Time `json:"last_read"`
 }
 
 // ProjectMember is a user who holds a role at a project's scope (ADR-021).

--- a/internal/core/usage_analytics.go
+++ b/internal/core/usage_analytics.go
@@ -1,0 +1,50 @@
+package core
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+)
+
+const (
+	defaultUsageWindowDays   = 30
+	defaultMostAccessedLimit = 10
+	maxMostAccessedLimit     = 100
+)
+
+// MostAccessedSecrets returns the most-read secrets (optionally scoped to a
+// project) over the last `days` (default 30), capped at `limit` (default 10,
+// max 100). Backs the usage-analytics dashboard's "most accessed" ranking.
+func (c *KeyorixCore) MostAccessedSecrets(ctx context.Context, projectID *uint, days, limit int) ([]storage.SecretUsageStat, error) {
+	if days <= 0 {
+		days = defaultUsageWindowDays
+	}
+	if limit <= 0 {
+		limit = defaultMostAccessedLimit
+	}
+	if limit > maxMostAccessedLimit {
+		limit = maxMostAccessedLimit
+	}
+	since := c.now().AddDate(0, 0, -days)
+	stats, err := c.storage.MostAccessedSecrets(ctx, projectID, since, limit)
+	if err != nil {
+		return nil, fmt.Errorf("failed to compute most-accessed secrets: %w", err)
+	}
+	return stats, nil
+}
+
+// UnusedSecrets returns secrets (optionally scoped to a project) with no read
+// in the last `days` (default 30), including never-read secrets. Powers the
+// "find & retire dead secrets" view.
+func (c *KeyorixCore) UnusedSecrets(ctx context.Context, projectID *uint, days int) ([]storage.UnusedSecretStat, error) {
+	if days <= 0 {
+		days = defaultUsageWindowDays
+	}
+	cutoff := c.now().AddDate(0, 0, -days)
+	stats, err := c.storage.UnusedSecrets(ctx, projectID, cutoff)
+	if err != nil {
+		return nil, fmt.Errorf("failed to compute unused secrets: %w", err)
+	}
+	return stats, nil
+}

--- a/internal/storage/store/local_audit.go
+++ b/internal/storage/store/local_audit.go
@@ -11,6 +11,7 @@ package store
 
 import (
 	"context"
+	"database/sql/driver"
 	"fmt"
 	"time"
 
@@ -32,6 +33,133 @@ func (ls *LocalStorage) ListSecretAccessLogs(ctx context.Context, secretID uint,
 		Where("secret_node_id = ? AND access_time >= ?", secretID, since).
 		Find(&logs)
 	return logs, result.Error
+}
+
+// scanTime portably scans a SQL timestamp that some drivers return as time.Time
+// (Postgres) and others as a string from an aggregate like MAX() (SQLite).
+type scanTime struct{ t *time.Time }
+
+// Value satisfies driver.Valuer so GORM treats scanTime as a scalar field
+// (not a relation); the queries are read-only so it is never actually written.
+func (s scanTime) Value() (driver.Value, error) {
+	if s.t == nil {
+		return nil, nil
+	}
+	return *s.t, nil
+}
+
+func (s *scanTime) Scan(value interface{}) error {
+	if value == nil {
+		return nil
+	}
+	switch v := value.(type) {
+	case time.Time:
+		t := v
+		s.t = &t
+		return nil
+	case []byte:
+		return s.parse(string(v))
+	case string:
+		return s.parse(v)
+	default:
+		return fmt.Errorf("scanTime: unsupported type %T", value)
+	}
+}
+
+func (s *scanTime) parse(str string) error {
+	for _, layout := range []string{
+		"2006-01-02 15:04:05.999999999-07:00",
+		"2006-01-02 15:04:05-07:00",
+		time.RFC3339Nano,
+		"2006-01-02 15:04:05.999999999",
+		"2006-01-02 15:04:05",
+	} {
+		if t, err := time.Parse(layout, str); err == nil {
+			s.t = &t
+			return nil
+		}
+	}
+	return fmt.Errorf("scanTime: cannot parse %q", str)
+}
+
+// MostAccessedSecrets ranks secrets by read count in the window, joining
+// secret_nodes for the name/environment. Reads are the usage signal, so only
+// access logs with action="read" are counted.
+func (ls *LocalStorage) MostAccessedSecrets(ctx context.Context, projectID *uint, since time.Time, limit int) ([]storage.SecretUsageStat, error) {
+	if limit <= 0 {
+		limit = 10
+	}
+	q := ls.db.WithContext(ctx).
+		Table("secret_access_logs AS l").
+		Select("l.secret_node_id AS secret_id, s.name AS secret_name, s.environment_id AS environment_id, COUNT(*) AS read_count, MAX(l.access_time) AS last_read").
+		Joins("JOIN secret_nodes s ON s.id = l.secret_node_id").
+		Where("s.is_secret = ?", true).
+		Where("l.action = ?", "read").
+		Where("l.access_time >= ?", since).
+		Group("l.secret_node_id, s.name, s.environment_id").
+		Order("read_count DESC, last_read DESC").
+		Limit(limit)
+	if projectID != nil {
+		q = q.Where("s.project_id = ?", *projectID)
+	}
+
+	type row struct {
+		SecretID      uint
+		SecretName    string
+		EnvironmentID uint
+		ReadCount     int64
+		LastRead      scanTime
+	}
+	var rows []row
+	if err := q.Scan(&rows).Error; err != nil {
+		return nil, err
+	}
+
+	stats := make([]storage.SecretUsageStat, 0, len(rows))
+	for _, r := range rows {
+		stats = append(stats, storage.SecretUsageStat{
+			SecretID: r.SecretID, SecretName: r.SecretName, EnvironmentID: r.EnvironmentID,
+			ReadCount: r.ReadCount, LastRead: r.LastRead.t,
+		})
+	}
+	return stats, nil
+}
+
+// UnusedSecrets returns secrets whose most recent read is older than
+// notReadSince (or that have never been read), ordered never-read first. Only
+// real secrets (is_secret) are considered, not folder nodes.
+func (ls *LocalStorage) UnusedSecrets(ctx context.Context, projectID *uint, notReadSince time.Time) ([]storage.UnusedSecretStat, error) {
+	q := ls.db.WithContext(ctx).
+		Table("secret_nodes AS s").
+		Select("s.id AS secret_id, s.name AS secret_name, s.environment_id AS environment_id, MAX(l.access_time) AS last_read").
+		Joins("LEFT JOIN secret_access_logs l ON l.secret_node_id = s.id AND l.action = ?", "read").
+		Where("s.is_secret = ?", true).
+		Group("s.id, s.name, s.environment_id").
+		Having("MAX(l.access_time) IS NULL OR MAX(l.access_time) < ?", notReadSince).
+		Order("(MAX(l.access_time) IS NULL) DESC, last_read ASC")
+	if projectID != nil {
+		q = q.Where("s.project_id = ?", *projectID)
+	}
+
+	type row struct {
+		SecretID      uint
+		SecretName    string
+		EnvironmentID uint
+		LastRead      scanTime
+	}
+	var rows []row
+	if err := q.Scan(&rows).Error; err != nil {
+		return nil, err
+	}
+
+	stats := make([]storage.UnusedSecretStat, 0, len(rows))
+	for _, r := range rows {
+		stats = append(stats, storage.UnusedSecretStat{
+			SecretID: r.SecretID, SecretName: r.SecretName, EnvironmentID: r.EnvironmentID,
+			LastRead: r.LastRead.t,
+		})
+	}
+	return stats, nil
 }
 
 // GetAuditLogs retrieves audit events with optional filtering and pagination.

--- a/internal/storage/store/remote_audit.go
+++ b/internal/storage/store/remote_audit.go
@@ -123,6 +123,16 @@ func (rs *RemoteStorage) ListSecretAccessLogs(_ context.Context, _ uint, _ time.
 	return nil, fmt.Errorf("ListSecretAccessLogs not available in remote mode")
 }
 
+// MostAccessedSecrets is not available in remote mode; usage analytics aggregate server-side.
+func (rs *RemoteStorage) MostAccessedSecrets(_ context.Context, _ *uint, _ time.Time, _ int) ([]storage.SecretUsageStat, error) {
+	return nil, fmt.Errorf("MostAccessedSecrets not available in remote mode")
+}
+
+// UnusedSecrets is not available in remote mode; usage analytics aggregate server-side.
+func (rs *RemoteStorage) UnusedSecrets(_ context.Context, _ *uint, _ time.Time) ([]storage.UnusedSecretStat, error) {
+	return nil, fmt.Errorf("UnusedSecrets not available in remote mode")
+}
+
 // CreateAnomalyAlert is not available in remote mode; anomaly detection is server-side.
 func (rs *RemoteStorage) CreateAnomalyAlert(_ context.Context, _ *models.AnomalyAlert) error {
 	return fmt.Errorf("CreateAnomalyAlert not available in remote mode")

--- a/internal/storage/store/usage_analytics_test.go
+++ b/internal/storage/store/usage_analytics_test.go
@@ -1,0 +1,97 @@
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func newUsageTestStore(t *testing.T) *LocalStorage {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretAccessLog{}))
+	return NewLocalStorage(db)
+}
+
+func seedUsageFixtures(t *testing.T, ls *LocalStorage, now time.Time) {
+	t.Helper()
+	ctx := context.Background()
+	secrets := []*models.SecretNode{
+		{ID: 1, Name: "hot-key", EnvironmentID: 1, IsSecret: true},
+		{ID: 2, Name: "warm-key", EnvironmentID: 1, IsSecret: true},
+		{ID: 3, Name: "never-read", EnvironmentID: 1, IsSecret: true},
+		{ID: 4, Name: "stale-key", EnvironmentID: 1, IsSecret: true},
+		{ID: 5, Name: "a-folder", EnvironmentID: 1, IsSecret: false},
+	}
+	for _, s := range secrets {
+		require.NoError(t, ls.db.WithContext(ctx).Create(s).Error)
+	}
+
+	read := func(secretID uint, at time.Time, action string) {
+		require.NoError(t, ls.db.WithContext(ctx).Create(&models.SecretAccessLog{
+			SecretNodeID: secretID, AccessedBy: "u", AccessTime: at, Action: action,
+		}).Error)
+	}
+	// hot-key: 3 recent reads. warm-key: 1 recent read.
+	read(1, now.AddDate(0, 0, -1), "read")
+	read(1, now.AddDate(0, 0, -2), "read")
+	read(1, now.AddDate(0, 0, -3), "read")
+	read(2, now.AddDate(0, 0, -5), "read")
+	// stale-key: only an old read (60d ago).
+	read(4, now.AddDate(0, 0, -60), "read")
+	// folder gets a recent read (must be excluded from both reports).
+	read(5, now.AddDate(0, 0, -1), "read")
+	// a non-read action on hot-key must not inflate the read count.
+	read(1, now.AddDate(0, 0, -1), "update")
+}
+
+func TestMostAccessedSecrets(t *testing.T) {
+	ls := newUsageTestStore(t)
+	now := time.Now()
+	seedUsageFixtures(t, ls, now)
+
+	stats, err := ls.MostAccessedSecrets(context.Background(), nil, now.AddDate(0, 0, -30), 10)
+	require.NoError(t, err)
+	require.Len(t, stats, 2, "only secrets read within the window, folders excluded")
+
+	assert.Equal(t, uint(1), stats[0].SecretID)
+	assert.Equal(t, "hot-key", stats[0].SecretName)
+	assert.Equal(t, int64(3), stats[0].ReadCount, "non-read actions are not counted")
+	assert.Equal(t, uint(2), stats[1].SecretID)
+	assert.Equal(t, int64(1), stats[1].ReadCount)
+	require.NotNil(t, stats[0].LastRead)
+}
+
+func TestMostAccessedSecrets_RespectsLimit(t *testing.T) {
+	ls := newUsageTestStore(t)
+	now := time.Now()
+	seedUsageFixtures(t, ls, now)
+
+	stats, err := ls.MostAccessedSecrets(context.Background(), nil, now.AddDate(0, 0, -30), 1)
+	require.NoError(t, err)
+	require.Len(t, stats, 1)
+	assert.Equal(t, "hot-key", stats[0].SecretName)
+}
+
+func TestUnusedSecrets(t *testing.T) {
+	ls := newUsageTestStore(t)
+	now := time.Now()
+	seedUsageFixtures(t, ls, now)
+
+	stats, err := ls.UnusedSecrets(context.Background(), nil, now.AddDate(0, 0, -30))
+	require.NoError(t, err)
+	require.Len(t, stats, 2, "never-read + stale, excluding recently-read and folders")
+
+	// Never-read is ordered first; its LastRead is nil.
+	assert.Equal(t, "never-read", stats[0].SecretName)
+	assert.Nil(t, stats[0].LastRead)
+	assert.Equal(t, "stale-key", stats[1].SecretName)
+	require.NotNil(t, stats[1].LastRead)
+}

--- a/server/http/handlers/secrets_usage.go
+++ b/server/http/handlers/secrets_usage.go
@@ -1,0 +1,89 @@
+// secrets_usage.go — usage-analytics handlers (most-accessed / unused secrets).
+//
+// Routes (under /api/v1/secrets):
+//
+//	GET /usage/most-accessed — top secrets by read count (params: project_id, days, limit)
+//	GET /usage/unused        — secrets not read in N days, never-read first (params: project_id, days)
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/keyorixhq/keyorix/server/middleware"
+)
+
+// parseProjectIDQuery reads an optional project_id query param. Returns
+// (nil, true) when absent, (ptr, true) when valid, (nil, false) when malformed.
+func parseProjectIDQuery(r *http.Request) (*uint, bool) {
+	v := r.URL.Query().Get("project_id")
+	if v == "" {
+		return nil, true
+	}
+	id, err := strconv.ParseUint(v, 10, 32)
+	if err != nil {
+		return nil, false
+	}
+	uid := uint(id)
+	return &uid, true
+}
+
+// parseIntQuery reads an optional positive int query param, falling back to def.
+func parseIntQuery(r *http.Request, key string, def int) int {
+	v := r.URL.Query().Get(key)
+	if v == "" {
+		return def
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n <= 0 {
+		return def
+	}
+	return n
+}
+
+// UsageMostAccessed handles GET /api/v1/secrets/usage/most-accessed
+func (h *SecretHandler) UsageMostAccessed(w http.ResponseWriter, r *http.Request) {
+	if middleware.GetUserFromContext(r.Context()) == nil {
+		h.sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+
+	projectID, ok := parseProjectIDQuery(r)
+	if !ok {
+		h.sendError(w, "InvalidParameter", "Invalid project_id", http.StatusBadRequest, nil)
+		return
+	}
+	days := parseIntQuery(r, "days", 30)
+	limit := parseIntQuery(r, "limit", 10)
+
+	stats, err := h.coreService.MostAccessedSecrets(r.Context(), projectID, days, limit)
+	if err != nil {
+		h.sendError(w, "InternalError", "Failed to compute most-accessed secrets", http.StatusInternalServerError, nil)
+		return
+	}
+
+	h.sendSuccess(w, map[string]interface{}{"secrets": stats, "days": days}, "")
+}
+
+// UsageUnused handles GET /api/v1/secrets/usage/unused
+func (h *SecretHandler) UsageUnused(w http.ResponseWriter, r *http.Request) {
+	if middleware.GetUserFromContext(r.Context()) == nil {
+		h.sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+
+	projectID, ok := parseProjectIDQuery(r)
+	if !ok {
+		h.sendError(w, "InvalidParameter", "Invalid project_id", http.StatusBadRequest, nil)
+		return
+	}
+	days := parseIntQuery(r, "days", 30)
+
+	stats, err := h.coreService.UnusedSecrets(r.Context(), projectID, days)
+	if err != nil {
+		h.sendError(w, "InternalError", "Failed to compute unused secrets", http.StatusInternalServerError, nil)
+		return
+	}
+
+	h.sendSuccess(w, map[string]interface{}{"secrets": stats, "days": days}, "")
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -216,6 +216,9 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		secretScope := customMiddleware.ScopeFromSecretParam("id")
 		r.Route("/secrets", func(r chi.Router) {
 			r.With(customMiddleware.RequireScopedPermission("secrets.read", customMiddleware.ScopeFromQuery)).Get("/", secretHandler.ListSecrets)
+			// Usage analytics (static paths, before /{id}).
+			r.With(customMiddleware.RequireScopedPermission("secrets.read", customMiddleware.ScopeFromQuery)).Get("/usage/most-accessed", secretHandler.UsageMostAccessed)
+			r.With(customMiddleware.RequireScopedPermission("secrets.read", customMiddleware.ScopeFromQuery)).Get("/usage/unused", secretHandler.UsageUnused)
 			r.With(customMiddleware.RequireScopedPermission("secrets.read", secretScope)).Get("/{id}", secretHandler.GetSecret)
 			r.With(customMiddleware.RequireScopedPermission("secrets.read", secretScope)).Get("/{id}/versions", secretHandler.GetSecretVersions)
 			r.With(customMiddleware.RequireScopedPermission("secrets.read", secretScope)).Get("/{id}/shares", shareHandler.ListSecretShares)


### PR DESCRIPTION
## What

M2 **secrets usage analytics**. The `secret_access_logs` table was populated on every read but never surfaced; this exposes it. (Rebased onto `main` after the rotation PR #64 merged — supersedes the auto-closed #65.)

- **`MostAccessedSecrets`** — top-N by read count in a window (default 30d, limit 10/max 100), joined to `secret_nodes`, folders + non-read actions excluded.
- **`UnusedSecrets`** — no read in N days incl. never-read, never-read ordered first.
- Storage interface methods + `SecretUsageStat`/`UnusedSecretStat` structs; local GORM impl; remote stubs; mock. Portable `scanTime` for the SQLite (string) vs Postgres (time.Time) `MAX()` quirk, with a `Valuer` so GORM treats it as a scalar.
- HTTP: `GET /api/v1/secrets/usage/{most-accessed,unused}` (scoped `secrets.read`, static paths before `/{id}`).

## Tests
SQLite store-layer tests: ranking + limit + read-only counting + folder exclusion; unused classification + never-read-first ordering. `go vet` + `go test ./...` green.

Paired frontend: keyorix-web usage PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)