### PR TITLE
feat(risk): per-secret risk score + API (M2)

### DIFF
--- a/internal/core/secret_risk.go
+++ b/internal/core/secret_risk.go
@@ -1,0 +1,193 @@
+package core
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// Risk bands returned by ComputeSecretRiskScore.
+const (
+	RiskBandLow    = "low"
+	RiskBandMedium = "medium"
+	RiskBandHigh   = "high"
+)
+
+// SecretRiskFactor is one weighted contributor to a secret's risk score. Score
+// is 0-100 (higher = riskier); the composite is the weight-weighted sum.
+type SecretRiskFactor struct {
+	Key    string  `json:"key"`
+	Label  string  `json:"label"`
+	Score  int     `json:"score"`
+	Weight float64 `json:"weight"`
+	Detail string  `json:"detail"`
+}
+
+// SecretRiskScore is a per-secret risk assessment combining expiry, rotation
+// age, usage (read activity), and exposure (how many principals can read it).
+type SecretRiskScore struct {
+	SecretID   uint               `json:"secret_id"`
+	SecretName string             `json:"secret_name"`
+	Score      int                `json:"score"` // 0-100 weighted composite (higher = riskier)
+	Band       string             `json:"band"`  // low | medium | high
+	Factors    []SecretRiskFactor `json:"factors"`
+}
+
+func riskBand(score int) string {
+	switch {
+	case score >= 67:
+		return RiskBandHigh
+	case score >= 34:
+		return RiskBandMedium
+	default:
+		return RiskBandLow
+	}
+}
+
+// ComputeSecretRiskScore builds a per-secret risk score. Factor weights:
+// expiry 30%, rotation age 30%, usage 20%, exposure 20%.
+func (c *KeyorixCore) ComputeSecretRiskScore(ctx context.Context, secretID uint) (*SecretRiskScore, error) {
+	secret, err := c.storage.GetSecret(ctx, secretID)
+	if err != nil {
+		return nil, fmt.Errorf("secret not found: %w", err)
+	}
+	now := c.now()
+
+	expScore, expDetail := expiryRisk(secret.Expiration, now)
+	rotScore, rotDetail := rotationRisk(secret.LastRotatedAt, secret.CreatedAt, now)
+	usageScore, usageDetail := usageRisk(c.countReads(ctx, secretID, now.AddDate(0, 0, -30)))
+	expoScore, expoDetail := exposureRisk(c.countPrincipals(ctx, secret))
+
+	factors := []SecretRiskFactor{
+		{Key: "expiry", Label: "Expiry", Score: expScore, Weight: 0.30, Detail: expDetail},
+		{Key: "rotation", Label: "Rotation age", Score: rotScore, Weight: 0.30, Detail: rotDetail},
+		{Key: "usage", Label: "Usage", Score: usageScore, Weight: 0.20, Detail: usageDetail},
+		{Key: "exposure", Label: "Exposure", Score: expoScore, Weight: 0.20, Detail: expoDetail},
+	}
+
+	var composite float64
+	for _, f := range factors {
+		composite += float64(f.Score) * f.Weight
+	}
+	score := int(composite + 0.5)
+
+	return &SecretRiskScore{
+		SecretID:   secret.ID,
+		SecretName: secret.Name,
+		Score:      score,
+		Band:       riskBand(score),
+		Factors:    factors,
+	}, nil
+}
+
+func expiryRisk(exp *time.Time, now time.Time) (int, string) {
+	if exp == nil {
+		return 40, "No expiration set"
+	}
+	days := int(exp.Sub(now).Hours() / 24)
+	switch {
+	case days < 0:
+		return 100, fmt.Sprintf("Expired %d day(s) ago", -days)
+	case days <= 7:
+		return 80, fmt.Sprintf("Expires in %d day(s)", days)
+	case days <= 30:
+		return 50, fmt.Sprintf("Expires in %d day(s)", days)
+	default:
+		return 10, fmt.Sprintf("Expires in %d day(s)", days)
+	}
+}
+
+func rotationRisk(lastRotated *time.Time, created, now time.Time) (int, string) {
+	basis, verb := created, "created"
+	if lastRotated != nil {
+		basis, verb = *lastRotated, "rotated"
+	}
+	days := int(now.Sub(basis).Hours() / 24)
+
+	var score int
+	switch {
+	case days < 30:
+		score = 10
+	case days < 90:
+		score = 30
+	case days < 180:
+		score = 60
+	case days < 365:
+		score = 80
+	default:
+		score = 100
+	}
+
+	never := ""
+	if lastRotated == nil {
+		never = " (never rotated)"
+		if days >= 90 && score < 100 {
+			score += 10
+		}
+	}
+	return score, fmt.Sprintf("Last %s %d day(s) ago%s", verb, days, never)
+}
+
+func usageRisk(reads int) (int, string) {
+	switch {
+	case reads == 0:
+		return 80, "No reads in the last 30 days"
+	case reads <= 5:
+		return 40, fmt.Sprintf("%d read(s) in the last 30 days", reads)
+	default:
+		return 10, fmt.Sprintf("%d reads in the last 30 days", reads)
+	}
+}
+
+func exposureRisk(principals int) (int, string) {
+	switch {
+	case principals <= 1:
+		return 10, "Only the owner has access"
+	case principals <= 5:
+		return 30, fmt.Sprintf("%d principals have access", principals)
+	case principals <= 15:
+		return 60, fmt.Sprintf("%d principals have access", principals)
+	default:
+		return 90, fmt.Sprintf("%d principals have access", principals)
+	}
+}
+
+func (c *KeyorixCore) countReads(ctx context.Context, secretID uint, since time.Time) int {
+	logs, err := c.storage.ListSecretAccessLogs(ctx, secretID, since)
+	if err != nil {
+		return 0
+	}
+	n := 0
+	for _, l := range logs {
+		if l.Action == "read" {
+			n++
+		}
+	}
+	return n
+}
+
+// countPrincipals counts the distinct users that can read a secret: the owner
+// plus direct share recipients plus the members of any group it is shared with.
+func (c *KeyorixCore) countPrincipals(ctx context.Context, secret *models.SecretNode) int {
+	principals := map[uint]struct{}{secret.OwnerID: {}}
+	shares, err := c.storage.ListSharesBySecret(ctx, secret.ID)
+	if err != nil {
+		return len(principals)
+	}
+	for _, sh := range shares {
+		if sh.IsGroup {
+			members, err := c.storage.ListGroupMembers(ctx, sh.RecipientID)
+			if err != nil {
+				continue
+			}
+			for _, m := range members {
+				principals[m.ID] = struct{}{}
+			}
+		} else {
+			principals[sh.RecipientID] = struct{}{}
+		}
+	}
+	return len(principals)
+}

--- a/internal/core/secret_risk_test.go
+++ b/internal/core/secret_risk_test.go
@@ -1,0 +1,81 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func factorByKey(s *SecretRiskScore, key string) SecretRiskFactor {
+	for _, f := range s.Factors {
+		if f.Key == key {
+			return f
+		}
+	}
+	return SecretRiskFactor{}
+}
+
+func TestComputeSecretRiskScore_HighRisk(t *testing.T) {
+	now := time.Date(2026, 6, 8, 12, 0, 0, 0, time.UTC)
+	expired := now.AddDate(0, 0, -3)
+	store := new(MockStorage)
+
+	// Expired, never rotated + 400 days old, shared with a 20-member group → high on every axis.
+	store.On("GetSecret", mock.Anything, uint(1)).Return(&models.SecretNode{
+		ID: 1, Name: "stripe-key", OwnerID: 9, Expiration: &expired, CreatedAt: now.AddDate(0, 0, -400),
+	}, nil)
+	store.On("ListSecretAccessLogs", mock.Anything, uint(1), mock.Anything).Return([]models.SecretAccessLog{}, nil)
+	store.On("ListSharesBySecret", mock.Anything, uint(1)).Return([]*models.ShareRecord{{IsGroup: true, RecipientID: 5}}, nil)
+	members := make([]*models.User, 20)
+	for i := range members {
+		members[i] = &models.User{ID: uint(100 + i)}
+	}
+	store.On("ListGroupMembers", mock.Anything, uint(5)).Return(members, nil)
+
+	c := NewKeyorixCore(store)
+	c.now = func() time.Time { return now }
+
+	got, err := c.ComputeSecretRiskScore(context.Background(), 1)
+	require.NoError(t, err)
+	require.Equal(t, RiskBandHigh, got.Band)
+	require.Equal(t, 100, factorByKey(got, "expiry").Score, "expired")
+	require.Equal(t, 100, factorByKey(got, "rotation").Score, "never rotated + 400d")
+	require.Equal(t, 80, factorByKey(got, "usage").Score, "no reads")
+	require.Equal(t, 90, factorByKey(got, "exposure").Score, "21 principals")
+	require.GreaterOrEqual(t, got.Score, 90)
+}
+
+func TestComputeSecretRiskScore_LowRisk(t *testing.T) {
+	now := time.Date(2026, 6, 8, 12, 0, 0, 0, time.UTC)
+	future := now.AddDate(0, 0, 200)
+	rotated := now.AddDate(0, 0, -5)
+	store := new(MockStorage)
+
+	// Future expiry, freshly rotated, actively read, owner-only → low on every axis.
+	store.On("GetSecret", mock.Anything, uint(2)).Return(&models.SecretNode{
+		ID: 2, Name: "jwt-key", OwnerID: 9, Expiration: &future, LastRotatedAt: &rotated, CreatedAt: now.AddDate(0, 0, -10),
+	}, nil)
+	reads := make([]models.SecretAccessLog, 12)
+	for i := range reads {
+		reads[i] = models.SecretAccessLog{Action: "read"}
+	}
+	// An update action must not count toward usage.
+	reads = append(reads, models.SecretAccessLog{Action: "update"})
+	store.On("ListSecretAccessLogs", mock.Anything, uint(2), mock.Anything).Return(reads, nil)
+	store.On("ListSharesBySecret", mock.Anything, uint(2)).Return([]*models.ShareRecord{}, nil)
+
+	c := NewKeyorixCore(store)
+	c.now = func() time.Time { return now }
+
+	got, err := c.ComputeSecretRiskScore(context.Background(), 2)
+	require.NoError(t, err)
+	require.Equal(t, RiskBandLow, got.Band)
+	require.Equal(t, 10, factorByKey(got, "expiry").Score)
+	require.Equal(t, 10, factorByKey(got, "rotation").Score)
+	require.Equal(t, 10, factorByKey(got, "usage").Score, "12 reads, update excluded")
+	require.Equal(t, 10, factorByKey(got, "exposure").Score, "owner only")
+}

--- a/server/http/handlers/secrets_risk.go
+++ b/server/http/handlers/secrets_risk.go
@@ -1,0 +1,42 @@
+// secrets_risk.go — per-secret risk-score handler.
+//
+// Route (under /api/v1/secrets):
+//
+//	GET /{id}/risk — composite risk score (expiry / rotation / usage / exposure)
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/keyorixhq/keyorix/server/middleware"
+)
+
+// GetSecretRisk handles GET /api/v1/secrets/{id}/risk
+func (h *SecretHandler) GetSecretRisk(w http.ResponseWriter, r *http.Request) {
+	if middleware.GetUserFromContext(r.Context()) == nil {
+		h.sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+
+	idStr := chi.URLParam(r, "id")
+	id, err := strconv.ParseUint(idStr, 10, 32)
+	if err != nil {
+		h.sendError(w, "InvalidParameter", "Invalid secret ID", http.StatusBadRequest, nil)
+		return
+	}
+
+	risk, err := h.coreService.ComputeSecretRiskScore(r.Context(), uint(id))
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			h.sendError(w, "NotFound", "Secret not found", http.StatusNotFound, nil)
+		} else {
+			h.sendError(w, "InternalError", "Failed to compute secret risk", http.StatusInternalServerError, nil)
+		}
+		return
+	}
+
+	h.sendSuccess(w, risk, "")
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -221,6 +221,7 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.With(customMiddleware.RequireScopedPermission("secrets.read", customMiddleware.ScopeFromQuery)).Get("/usage/unused", secretHandler.UsageUnused)
 			r.With(customMiddleware.RequireScopedPermission("secrets.read", secretScope)).Get("/{id}", secretHandler.GetSecret)
 			r.With(customMiddleware.RequireScopedPermission("secrets.read", secretScope)).Get("/{id}/versions", secretHandler.GetSecretVersions)
+			r.With(customMiddleware.RequireScopedPermission("secrets.read", secretScope)).Get("/{id}/risk", secretHandler.GetSecretRisk)
 			r.With(customMiddleware.RequireScopedPermission("secrets.read", secretScope)).Get("/{id}/shares", shareHandler.ListSecretShares)
 
 			// Create: authorized inside the handler (scope comes from the body).


### PR DESCRIPTION
## What

M2 **per-secret risk score**. Combines four weighted factors into a 0-100 composite with a low/medium/high band:

| Factor | Weight | Signal |
|---|---|---|
| Expiry | 30% | expired / expiring-soon / no-expiry-set / future |
| Rotation age | 30% | days since last rotation (falls back to creation; bump when never-rotated & old) |
| Usage | 20% | reads in the last 30 days — **zero reads = stale/forgotten risk** |
| Exposure | 20% | distinct principals with access (owner + direct shares + resolved group members) |

`core.ComputeSecretRiskScore` returns the composite + a per-factor breakdown with human-readable detail strings (e.g. "Expired 3 days ago", "Only the owner has access"). Reuses the access-log + sharing data already in the system; no new storage methods.

`GET /api/v1/secrets/{id}/risk` (scoped `secrets.read`).

## Tests
Core tests cover a high-risk and a low-risk scenario, including non-read actions excluded from usage and group-member exposure resolution. `go vet` + `go test ./...` green.

Paired frontend: keyorix-web (Risk Score panel on the secret detail view).

🤖 Generated with [Claude Code](https://claude.com/claude-code)