### PR TITLE
feat(audit): retention-coverage inspector API — makes NIS2 12-month retention demonstrable

### DIFF
--- a/docs/compliance/AUDIT-LOG-PROVISIONS.md
+++ b/docs/compliance/AUDIT-LOG-PROVISIONS.md
@@ -82,7 +82,16 @@ exposing the secrets they describe.
 - Audit history is stored in **your** PostgreSQL. Keyorix imposes **no retention
   cap and no retention paywall** — retain logs for as long as your policy
   requires (NIS2-grade durable record-keeping is a configuration of *your*
-  database lifecycle, not a Keyorix limit).
+  database lifecycle, not a Keyorix limit). There is no purge job, no TTL, and
+  no time-window on the audit query path — events are kept indefinitely.
+- **Demonstrate coverage** — `GET /api/v1/audit/retention` reports the total
+  event count, the **oldest** and **newest** event, how many days back the trail
+  reaches (`coverage_days`), and a `meets_nis2_12_month` flag that is `true` once
+  the earliest retained event is at least 12 months old. This turns the
+  "we retain everything" statement into a figure an auditor can read directly.
+  `retention_policy` is always `"unlimited"`. (A young deployment reads
+  `meets_nis2_12_month: false` with no retention deficiency — there is simply not
+  yet 12 months of history; the policy is unlimited regardless.)
 - Standard PostgreSQL backup/restore applies; the [self-hosting
   runbook](../SELF_HOSTING.md) documents it.
 
@@ -104,7 +113,7 @@ row states the expectation and the Keyorix capability that addresses it.
 | 6 | Records do not expose the protected data | No plaintext/keys/tokens in logs (regression-tested) | ✅ |
 | 7 | Records are exportable for examination | Cursor-paginated pull export | ✅ |
 | 8 | Records can be forwarded to monitoring/SIEM | Splunk HEC / Datadog / webhook push connectors | ✅ (operator-configured) |
-| 9 | Records are retained for the required period | Operator-owned PostgreSQL, no cap | ✅ (operator-controlled) |
+| 9 | Records are retained for the required period | Operator-owned PostgreSQL, no cap; coverage is demonstrable via `GET /api/v1/audit/retention` (oldest event + `meets_nis2_12_month`) | ✅ (operator-controlled) |
 | 10 | Records support incident detection | Built-in anomaly alerts + filterable/streamable audit query | ✅ |
 | 11 | Tamper resistance of records | Append-style writes in operator-controlled DB; **WORM/cryptographic chaining is Roadmap** | ⚠️ Roadmap |
 

--- a/internal/core/audit_retention.go
+++ b/internal/core/audit_retention.go
@@ -1,0 +1,65 @@
+package core
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// nis2RetentionDays is the audit-log retention window NIS2 (and DORA) expect an
+// operator to be able to demonstrate: 12 months.
+const nis2RetentionDays = 365
+
+// RetentionPolicyUnlimited is reported on every coverage response: Keyorix
+// never purges, caps, or time-limits audit events — retention is bounded only
+// by the operator's PostgreSQL.
+const RetentionPolicyUnlimited = "unlimited"
+
+// AuditRetentionCoverage describes how far back the audit trail demonstrably
+// reaches. It turns the "we retain everything" claim into an auditable figure:
+// an operator or buyer-security-review can read the oldest event and confirm
+// the trail spans the NIS2-mandated 12 months.
+type AuditRetentionCoverage struct {
+	// RetentionPolicy is always "unlimited" — Keyorix applies no audit cap.
+	RetentionPolicy string `json:"retention_policy"`
+	// TotalEvents is the number of audit events currently stored.
+	TotalEvents int64 `json:"total_events"`
+	// OldestEvent / NewestEvent bound the trail. Nil when no events exist yet.
+	OldestEvent *time.Time `json:"oldest_event"`
+	NewestEvent *time.Time `json:"newest_event"`
+	// CoverageDays is how far back the trail reaches from now (now − oldest),
+	// i.e. the age of the earliest retained event. 0 when there are no events.
+	CoverageDays int `json:"coverage_days"`
+	// MeetsNIS2TwelveMonth is true once the trail's earliest event is at least
+	// 12 months old, i.e. there is genuine 12-month history to inspect today.
+	// A young deployment reads false without any retention deficiency — the
+	// policy is still unlimited; there simply is not yet 12 months of history.
+	MeetsNIS2TwelveMonth bool `json:"meets_nis2_12_month"`
+}
+
+// AuditRetentionCoverage reports the audit trail's retention coverage: total
+// event count, the oldest/newest event, how many days back the trail reaches,
+// and whether that demonstrably covers the NIS2 12-month window. Backs the
+// compliance/retention inspector — see docs/compliance/AUDIT-LOG-PROVISIONS.md.
+func (c *KeyorixCore) AuditRetentionCoverage(ctx context.Context) (*AuditRetentionCoverage, error) {
+	stats, err := c.storage.AuditRetentionStats(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to compute audit retention coverage: %w", err)
+	}
+
+	cov := &AuditRetentionCoverage{
+		RetentionPolicy: RetentionPolicyUnlimited,
+		TotalEvents:     stats.TotalEvents,
+		OldestEvent:     stats.Oldest,
+		NewestEvent:     stats.Newest,
+	}
+	if stats.Oldest != nil {
+		days := int(c.now().Sub(*stats.Oldest).Hours() / 24)
+		if days < 0 {
+			days = 0
+		}
+		cov.CoverageDays = days
+		cov.MeetsNIS2TwelveMonth = days >= nis2RetentionDays
+	}
+	return cov, nil
+}

--- a/internal/core/audit_retention_test.go
+++ b/internal/core/audit_retention_test.go
@@ -1,0 +1,71 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAuditRetentionCoverage_MeetsNIS2(t *testing.T) {
+	fixed := time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)
+	oldest := fixed.AddDate(0, 0, -400) // 400d back → > 365
+	newest := fixed.AddDate(0, 0, -1)
+
+	store := new(MockStorage)
+	store.On("AuditRetentionStats", mock.Anything).Return(&storage.AuditRetentionStats{
+		TotalEvents: 12345, Oldest: &oldest, Newest: &newest,
+	}, nil)
+
+	c := NewKeyorixCore(store)
+	c.now = func() time.Time { return fixed }
+
+	cov, err := c.AuditRetentionCoverage(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, RetentionPolicyUnlimited, cov.RetentionPolicy)
+	require.Equal(t, int64(12345), cov.TotalEvents)
+	require.Equal(t, 400, cov.CoverageDays)
+	require.True(t, cov.MeetsNIS2TwelveMonth, "400 days of history covers the 12-month window")
+	require.Equal(t, &oldest, cov.OldestEvent)
+	require.Equal(t, &newest, cov.NewestEvent)
+}
+
+func TestAuditRetentionCoverage_YoungDeployment(t *testing.T) {
+	fixed := time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)
+	oldest := fixed.AddDate(0, 0, -100) // only 100d of history
+
+	store := new(MockStorage)
+	store.On("AuditRetentionStats", mock.Anything).Return(&storage.AuditRetentionStats{
+		TotalEvents: 50, Oldest: &oldest, Newest: &fixed,
+	}, nil)
+
+	c := NewKeyorixCore(store)
+	c.now = func() time.Time { return fixed }
+
+	cov, err := c.AuditRetentionCoverage(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 100, cov.CoverageDays)
+	require.False(t, cov.MeetsNIS2TwelveMonth, "< 365 days of history yet")
+	// Policy is still unlimited regardless of how young the deployment is.
+	require.Equal(t, RetentionPolicyUnlimited, cov.RetentionPolicy)
+}
+
+func TestAuditRetentionCoverage_Empty(t *testing.T) {
+	store := new(MockStorage)
+	store.On("AuditRetentionStats", mock.Anything).Return(&storage.AuditRetentionStats{
+		TotalEvents: 0, Oldest: nil, Newest: nil,
+	}, nil)
+
+	c := NewKeyorixCore(store)
+
+	cov, err := c.AuditRetentionCoverage(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, int64(0), cov.TotalEvents)
+	require.Equal(t, 0, cov.CoverageDays)
+	require.False(t, cov.MeetsNIS2TwelveMonth)
+	require.Nil(t, cov.OldestEvent)
+	require.Equal(t, RetentionPolicyUnlimited, cov.RetentionPolicy)
+}

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -595,6 +595,14 @@ func (m *MockStorage) MostAccessedSecrets(ctx context.Context, projectID *uint, 
 	return args.Get(0).([]storage.SecretUsageStat), args.Error(1)
 }
 
+func (m *MockStorage) AuditRetentionStats(ctx context.Context) (*storage.AuditRetentionStats, error) {
+	args := m.Called(ctx)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*storage.AuditRetentionStats), args.Error(1)
+}
+
 func (m *MockStorage) UnusedSecrets(ctx context.Context, projectID *uint, notReadSince time.Time) ([]storage.UnusedSecretStat, error) {
 	args := m.Called(ctx, projectID, notReadSince)
 	if args.Get(0) == nil {

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -196,6 +196,12 @@ type Storage interface {
 	AcknowledgeAnomalyAlert(ctx context.Context, id uint) error
 	GetAuditLogs(ctx context.Context, filter *AuditFilter) ([]*models.AuditEvent, int64, error)
 	GetRBACAuditLogs(ctx context.Context, filter *RBACAuditFilter) ([]*RBACAuditLog, int64, error)
+	// AuditRetentionStats returns the total audit event count and the oldest /
+	// newest event timestamps. Keyorix never purges audit events, so these raw
+	// aggregates let an operator demonstrate how far back the trail reaches
+	// (NIS2 mandates 12 months of retention). Oldest/Newest are nil on an empty
+	// table.
+	AuditRetentionStats(ctx context.Context) (*AuditRetentionStats, error)
 	GetDistinctActiveUserIDs(ctx context.Context, since time.Time) ([]uint, error)
 	// CountImpersonatedActions returns the number of impersonated audit events
 	// recorded for actingAs by impersonator since `since`, excluding the
@@ -416,6 +422,15 @@ type SecretUsageStat struct {
 	EnvironmentID uint       `json:"environment_id"`
 	ReadCount     int64      `json:"read_count"`
 	LastRead      *time.Time `json:"last_read"`
+}
+
+// AuditRetentionStats holds the raw aggregates backing the audit-retention
+// coverage report: how many audit events exist and the timestamps of the
+// oldest and newest. Oldest/Newest are nil when the audit table is empty.
+type AuditRetentionStats struct {
+	TotalEvents int64
+	Oldest      *time.Time
+	Newest      *time.Time
 }
 
 // UnusedSecretStat is one row of the unused-secrets report. LastRead is nil when

--- a/internal/storage/store/audit_retention_test.go
+++ b/internal/storage/store/audit_retention_test.go
@@ -1,0 +1,55 @@
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func newAuditRetentionTestStore(t *testing.T) *LocalStorage {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.AuditEvent{}))
+	return NewLocalStorage(db)
+}
+
+func TestAuditRetentionStats_Empty(t *testing.T) {
+	ls := newAuditRetentionTestStore(t)
+
+	stats, err := ls.AuditRetentionStats(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), stats.TotalEvents)
+	assert.Nil(t, stats.Oldest, "no oldest on an empty table")
+	assert.Nil(t, stats.Newest, "no newest on an empty table")
+}
+
+func TestAuditRetentionStats_OldestNewestAndCount(t *testing.T) {
+	ls := newAuditRetentionTestStore(t)
+	ctx := context.Background()
+
+	now := time.Now().UTC().Truncate(time.Second)
+	oldest := now.AddDate(0, 0, -400) // > 12 months back
+	mid := now.AddDate(0, 0, -30)
+	newest := now.AddDate(0, 0, -1)
+
+	for _, at := range []time.Time{mid, oldest, newest} {
+		require.NoError(t, ls.db.WithContext(ctx).Create(&models.AuditEvent{
+			EventType: "secret.read", EventTime: at,
+		}).Error)
+	}
+
+	stats, err := ls.AuditRetentionStats(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), stats.TotalEvents)
+	require.NotNil(t, stats.Oldest)
+	require.NotNil(t, stats.Newest)
+	assert.WithinDuration(t, oldest, *stats.Oldest, time.Second)
+	assert.WithinDuration(t, newest, *stats.Newest, time.Second)
+}

--- a/internal/storage/store/local_audit.go
+++ b/internal/storage/store/local_audit.go
@@ -162,6 +162,30 @@ func (ls *LocalStorage) UnusedSecrets(ctx context.Context, projectID *uint, notR
 	return stats, nil
 }
 
+// AuditRetentionStats returns the total audit event count plus the oldest and
+// newest event_time in a single aggregate query. Keyorix applies no retention
+// cap, so MIN(event_time) is the true start of the trail — the basis for the
+// retention-coverage report. Oldest/Newest stay nil on an empty table.
+func (ls *LocalStorage) AuditRetentionStats(ctx context.Context) (*storage.AuditRetentionStats, error) {
+	type row struct {
+		Total  int64
+		Oldest scanTime
+		Newest scanTime
+	}
+	var r row
+	if err := ls.db.WithContext(ctx).
+		Model(&models.AuditEvent{}).
+		Select("COUNT(*) AS total, MIN(event_time) AS oldest, MAX(event_time) AS newest").
+		Scan(&r).Error; err != nil {
+		return nil, err
+	}
+	return &storage.AuditRetentionStats{
+		TotalEvents: r.Total,
+		Oldest:      r.Oldest.t,
+		Newest:      r.Newest.t,
+	}, nil
+}
+
 // GetAuditLogs retrieves audit events with optional filtering and pagination.
 func (ls *LocalStorage) GetAuditLogs(ctx context.Context, filter *storage.AuditFilter) ([]*models.AuditEvent, int64, error) {
 	query := ls.db.WithContext(ctx).Model(&models.AuditEvent{})

--- a/internal/storage/store/remote_audit.go
+++ b/internal/storage/store/remote_audit.go
@@ -133,6 +133,11 @@ func (rs *RemoteStorage) UnusedSecrets(_ context.Context, _ *uint, _ time.Time) 
 	return nil, fmt.Errorf("UnusedSecrets not available in remote mode")
 }
 
+// AuditRetentionStats is not available in remote mode; retention coverage aggregates server-side.
+func (rs *RemoteStorage) AuditRetentionStats(_ context.Context) (*storage.AuditRetentionStats, error) {
+	return nil, fmt.Errorf("AuditRetentionStats not available in remote mode")
+}
+
 // CreateAnomalyAlert is not available in remote mode; anomaly detection is server-side.
 func (rs *RemoteStorage) CreateAnomalyAlert(_ context.Context, _ *models.AnomalyAlert) error {
 	return fmt.Errorf("CreateAnomalyAlert not available in remote mode")

--- a/server/http/handlers/audit.go
+++ b/server/http/handlers/audit.go
@@ -314,3 +314,23 @@ func (h *AuditHandler) GetRBACAuditLogs(w http.ResponseWriter, r *http.Request) 
 		"logs": logs, "page": page, "page_size": pageSize, "total": total, "total_pages": totalPages,
 	}, "")
 }
+
+// GetAuditRetention handles GET /api/v1/audit/retention — reports how far back
+// the audit trail demonstrably reaches (total events, oldest/newest event,
+// coverage days, and whether that covers the NIS2-mandated 12 months). Keyorix
+// never purges audit events, so this makes the unlimited-retention claim
+// auditable rather than merely asserted.
+func (h *AuditHandler) GetAuditRetention(w http.ResponseWriter, r *http.Request) {
+	if middleware.GetUserFromContext(r.Context()) == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+
+	cov, err := h.coreService.AuditRetentionCoverage(r.Context())
+	if err != nil {
+		sendError(w, "InternalError", "Failed to compute audit retention coverage", http.StatusInternalServerError, nil)
+		return
+	}
+
+	sendSuccess(w, cov, "")
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -357,6 +357,7 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.Get("/logs", auditHandler.GetAuditLogs)
 			r.Get("/export", auditHandler.ExportAuditLogs)
 			r.Get("/rbac-logs", auditHandler.GetRBACAuditLogs)
+			r.Get("/retention", auditHandler.GetAuditRetention)
 			r.Get("/anomalies", handlers.ListAnomalyAlerts)
 			r.Post("/anomalies/{id}/acknowledge", handlers.AcknowledgeAnomalyAlert)
 		})


### PR DESCRIPTION
## What & why

Keyorix already retains audit events **indefinitely** — no purge job, no TTL, no retention cap, no time-window on the query path (verified across storage/core/handlers/migrations). Bounded only by the operator's PostgreSQL. But that "we keep everything" stance was only *assertable*, not *demonstrable*: a buyer's security review or auditor had no way to ask "how far back does your audit trail actually reach?"

This adds the small inspector API that makes the **NIS2-mandated 12-month retention** an auditable figure rather than a claim. It's the last M1 engineering line item ("Unlimited audit log retention — NIS2 requires 12 months").

Mirrors the established read-only inspector-API pattern (rotation status #64, usage analytics #67, risk score #68).

## Endpoint

`GET /api/v1/audit/retention` (gated by the existing `audit.read` permission):

```json
{
  "retention_policy": "unlimited",
  "total_events": 12345,
  "oldest_event": "2025-05-01T09:14:00Z",
  "newest_event": "2026-06-10T10:32:30Z",
  "coverage_days": 405,
  "meets_nis2_12_month": true
}
```

- `retention_policy` is always `"unlimited"` — Keyorix applies no cap.
- `meets_nis2_12_month` is `true` once the earliest retained event is ≥365 days old. A young deployment reads `false` with **no retention deficiency** — there simply isn't 12 months of history yet; the policy is unlimited regardless.

## Layers

- **storage** — `AuditRetentionStats` (single `COUNT/MIN/MAX` aggregate over `audit_events`; remote-mode stub; nil oldest/newest on an empty table)
- **core** — `AuditRetentionCoverage` computes `coverage_days` + `meets_nis2_12_month` against `c.now()`
- **http** — `GET /audit/retention`
- **docs** — `AUDIT-LOG-PROVISIONS.md` Retention section + DORA checklist row 9 now point at the endpoint

## Tests

- core: meets-NIS2 / young-deployment / empty (3)
- store: empty / oldest-newest-count (2)
- full `go test ./...` green; `gofmt`/`go vet` clean

## Verified end-to-end

Ran the built server (SQLite), bootstrapped admin, logged in:
- `GET /audit/retention` → 200 with the shape above
- no token → **401** (correctly behind `audit.read`)
- `total_events` tracked 1 → 5 as logins generated events; `newest_event` advanced, `oldest_event` held

🤖 Generated with [Claude Code](https://claude.com/claude-code)