### PR TITLE
feat(audit): tamper-evidence hash chain over audit events (ADR-029)

### DIFF
--- a/docs/adr-029-audit-log-tamper-evidence.md
+++ b/docs/adr-029-audit-log-tamper-evidence.md
@@ -1,0 +1,96 @@
+# ADR-029: Audit-log tamper-evidence (hash-chained audit events)
+
+**Status:** Accepted
+**Date:** 2026-06-10
+**Context:** NIS2 / DORA audit-log provisions; the honest "tamper resistance"
+gap flagged in `docs/compliance/AUDIT-LOG-PROVISIONS.md` (checklist row 11).
+
+## Context
+
+Keyorix audit events are stored in the operator's PostgreSQL with no purge and
+no cap (retention is unbounded — see the audit-retention coverage API). The
+remaining integrity gap is **tamper-evidence**: nothing detects after-the-fact
+modification, deletion, or reordering of audit rows by anyone with database
+access. Auditors (DORA Art. 9-style record integrity) want evidence that the
+trail has not been altered, not just that it exists.
+
+Full WORM (write-once-read-many) immutability needs infrastructure outside the
+application's control (append-only storage, an external notary/timestamp
+authority, or a managed immutable ledger). What the application *can* provide,
+self-contained, is **tamper-evidence**: a cryptographic hash chain over the
+audit rows so that any modification/deletion/insertion is detectable.
+
+## Decision
+
+Maintain a SHA-256 **hash chain** over `audit_events`. Each event stores:
+
+- `prev_hash` — the `entry_hash` of the immediately preceding chained event
+  (or a fixed genesis constant for the first chained event).
+- `entry_hash` — `SHA256( canonical(event fields) ‖ prev_hash )`.
+
+Because each entry's hash binds the previous entry's hash, altering any field of
+any row, deleting a row, inserting a row, or reordering rows breaks the chain at
+that point and is detectable by re-walking it.
+
+### Canonical encoding
+
+`entry_hash` is computed over a **fixed-order, null-separated** encoding of the
+semantically meaningful fields: `prev_hash`, `event_type`, `user_id`,
+`secret_node_id`, `project_id`, `ip_address`, `description`, `success`,
+`event_time`, `diff`, `impersonated_by`, `acting_as`, `impersonation`,
+`actor_type`. The DB-assigned `id` is **deliberately excluded** — it is not
+known before insert, and chain linkage already pins each row's position.
+
+`event_time` is encoded as **Unix microseconds** (`UnixMicro`), and the stored
+`event_time` is truncated to microseconds before both hashing and insert. This
+is required for correctness: PostgreSQL `timestamptz` has microsecond precision,
+so a nanosecond-precision `time.Now()` would not round-trip and verification
+would fail for every row. Truncating up front makes the stored value exactly
+equal to the hashed value on both Postgres and SQLite.
+
+### Serialization (correctness under concurrent writers)
+
+Audit events are emitted from detached goroutines, so appends are concurrent. A
+hash chain requires the read-previous-hash + insert to be atomic. The write is
+therefore serialized:
+
+1. A process-level mutex on the storage handle (covers the common single-writer
+   self-host topology and SQLite, which serializes writes anyway).
+2. Inside a DB transaction, a PostgreSQL **transaction-scoped advisory lock**
+   (`pg_advisory_xact_lock`) guards the critical section across processes for
+   multi-instance Postgres deployments (no-op on SQLite).
+
+The transaction reads the current chain head (`entry_hash` of the highest-`id`
+row), computes the new `entry_hash`, and inserts — all under the lock.
+
+### Verification
+
+`VerifyAuditChain` walks events by ascending `id` in bounded batches and, for
+each chained row, (a) checks `prev_hash` equals the running previous
+`entry_hash` (genesis for the first), and (b) recomputes `entry_hash` from the
+row's stored fields and checks it matches. The first divergence is reported with
+the offending `id` and reason. Exposed as `GET /api/v1/audit/verify`.
+
+### Legacy rows
+
+Events written before this ADR have empty `prev_hash`/`entry_hash`. Verification
+treats a leading run of empty-hash rows as an **unchained legacy prefix** (counted,
+not failed); the chain begins at the first row written after the columns exist.
+New columns are added via additive `ALTER TABLE` guarded by `columnExists`
+(never via a full `AutoMigrate` on an existing table — avoids the pgx
+double-migration hazard).
+
+## Consequences
+
+- **Detectable**, not **prevented**: an attacker with DB write access can still
+  modify rows, but cannot do so *undetectably* without recomputing the entire
+  forward chain — and cannot at all if a verified `entry_hash` has been exported
+  off-box (SIEM push already forwards every event). Re-anchoring the head to an
+  external notary/SIEM is a future enhancement.
+- Audit writes now take a lock + transaction. Audit emission is already
+  asynchronous/best-effort and off the request hot path, so the added latency is
+  not user-visible.
+- WORM/immutability (append-only physical storage) remains out of scope and
+  operator-owned; this ADR delivers tamper-*evidence*, moving compliance
+  checklist row 11 from "⚠️ Roadmap" to "✅ hash-chained (verification API);
+  physical immutability operator-owned".

--- a/docs/compliance/AUDIT-LOG-PROVISIONS.md
+++ b/docs/compliance/AUDIT-LOG-PROVISIONS.md
@@ -115,9 +115,14 @@ row states the expectation and the Keyorix capability that addresses it.
 | 8 | Records can be forwarded to monitoring/SIEM | Splunk HEC / Datadog / webhook push connectors | ✅ (operator-configured) |
 | 9 | Records are retained for the required period | Operator-owned PostgreSQL, no cap; coverage is demonstrable via `GET /api/v1/audit/retention` (oldest event + `meets_nis2_12_month`) | ✅ (operator-controlled) |
 | 10 | Records support incident detection | Built-in anomaly alerts + filterable/streamable audit query | ✅ |
-| 11 | Tamper resistance of records | Append-style writes in operator-controlled DB; **WORM/cryptographic chaining is Roadmap** | ⚠️ Roadmap |
+| 11 | Tamper resistance of records | **SHA-256 hash chain** over every audit event (ADR-029); any modification/deletion/insertion is detectable via `GET /api/v1/audit/verify`. Physical WORM/immutable storage remains operator-owned. | ✅ tamper-*evident* (physical immutability operator-owned) |
 
-> **Honest gap:** Keyorix does not yet provide cryptographic chaining /
-> write-once-read-many tamper-evidence on the audit table itself; integrity today
-> relies on operator-controlled PostgreSQL and standard DB controls. This is a
-> tracked roadmap item — do not represent it as shipped.
+> **Scope note (tamper-evidence vs. tamper-proofing):** Keyorix hash-chains the
+> audit table (each event binds the previous event's hash — ADR-029), so any
+> after-the-fact alteration, deletion, or reordering is **detectable** by
+> re-walking the chain (`GET /api/v1/audit/verify`). This is tamper-*evidence*,
+> not prevention: an actor with database access can still alter rows, but cannot
+> do so undetectably — and cannot at all once an `entry_hash` has been exported
+> off-box (the SIEM push connectors forward every event). Physical
+> write-once-read-many storage and an external timestamp/notary anchor remain
+> operator-owned infrastructure choices, outside the application.

--- a/internal/core/audit_retention.go
+++ b/internal/core/audit_retention.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
 )
 
 // nis2RetentionDays is the audit-log retention window NIS2 (and DORA) expect an
@@ -62,4 +64,15 @@ func (c *KeyorixCore) AuditRetentionCoverage(ctx context.Context) (*AuditRetenti
 		cov.MeetsNIS2TwelveMonth = days >= nis2RetentionDays
 	}
 	return cov, nil
+}
+
+// VerifyAuditChain re-walks the tamper-evidence hash chain (ADR-029) and reports
+// whether the audit trail is intact. Backs GET /api/v1/audit/verify — see
+// docs/adr-029-audit-log-tamper-evidence.md.
+func (c *KeyorixCore) VerifyAuditChain(ctx context.Context) (*storage.AuditChainVerification, error) {
+	v, err := c.storage.VerifyAuditChain(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to verify audit chain: %w", err)
+	}
+	return v, nil
 }

--- a/internal/core/audit_retention_test.go
+++ b/internal/core/audit_retention_test.go
@@ -53,6 +53,21 @@ func TestAuditRetentionCoverage_YoungDeployment(t *testing.T) {
 	require.Equal(t, RetentionPolicyUnlimited, cov.RetentionPolicy)
 }
 
+func TestVerifyAuditChain_PassesThrough(t *testing.T) {
+	brokenID := uint(42)
+	store := new(MockStorage)
+	store.On("VerifyAuditChain", mock.Anything).Return(&storage.AuditChainVerification{
+		Valid: false, ChainedEvents: 41, FirstBrokenID: &brokenID, Reason: "event modified",
+	}, nil)
+
+	c := NewKeyorixCore(store)
+	v, err := c.VerifyAuditChain(context.Background())
+	require.NoError(t, err)
+	require.False(t, v.Valid)
+	require.Equal(t, &brokenID, v.FirstBrokenID)
+	require.Equal(t, "event modified", v.Reason)
+}
+
 func TestAuditRetentionCoverage_Empty(t *testing.T) {
 	store := new(MockStorage)
 	store.On("AuditRetentionStats", mock.Anything).Return(&storage.AuditRetentionStats{

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -603,6 +603,14 @@ func (m *MockStorage) AuditRetentionStats(ctx context.Context) (*storage.AuditRe
 	return args.Get(0).(*storage.AuditRetentionStats), args.Error(1)
 }
 
+func (m *MockStorage) VerifyAuditChain(ctx context.Context) (*storage.AuditChainVerification, error) {
+	args := m.Called(ctx)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*storage.AuditChainVerification), args.Error(1)
+}
+
 func (m *MockStorage) UnusedSecrets(ctx context.Context, projectID *uint, notReadSince time.Time) ([]storage.UnusedSecretStat, error) {
 	args := m.Called(ctx, projectID, notReadSince)
 	if args.Get(0) == nil {

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -202,6 +202,12 @@ type Storage interface {
 	// (NIS2 mandates 12 months of retention). Oldest/Newest are nil on an empty
 	// table.
 	AuditRetentionStats(ctx context.Context) (*AuditRetentionStats, error)
+	// VerifyAuditChain re-walks the tamper-evidence hash chain (ADR-029) over
+	// audit_events and reports whether it is intact. The first divergence —
+	// modified field, deleted/inserted row, or broken linkage — is reported
+	// with the offending event id. A leading run of pre-ADR-029 rows with empty
+	// hashes is counted as an unchained legacy prefix, not a failure.
+	VerifyAuditChain(ctx context.Context) (*AuditChainVerification, error)
 	GetDistinctActiveUserIDs(ctx context.Context, since time.Time) ([]uint, error)
 	// CountImpersonatedActions returns the number of impersonated audit events
 	// recorded for actingAs by impersonator since `since`, excluding the
@@ -431,6 +437,25 @@ type AuditRetentionStats struct {
 	TotalEvents int64
 	Oldest      *time.Time
 	Newest      *time.Time
+}
+
+// AuditChainVerification is the verdict of re-walking the audit hash chain
+// (ADR-029). Valid is true when every chained event's hash and linkage check
+// out. On failure, FirstBrokenID and Reason identify the first divergence.
+type AuditChainVerification struct {
+	// Valid is true when the chained suffix is intact end to end.
+	Valid bool
+	// ChainedEvents is the number of hash-chained events verified.
+	ChainedEvents int64
+	// UnchainedEvents is the leading run of legacy rows (pre-ADR-029, empty
+	// hashes) skipped before the chain begins.
+	UnchainedEvents int64
+	// FirstBrokenID is the id of the first event that failed verification, nil
+	// when Valid.
+	FirstBrokenID *uint
+	// Reason is a human-readable description of the first failure, empty when
+	// Valid.
+	Reason string
 }
 
 // UnusedSecretStat is one row of the unused-secrets report. LastRead is nil when

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -195,6 +195,14 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 		if !columnExists(db, "audit_events", "actor_type") {
 			db.Exec("ALTER TABLE audit_events ADD COLUMN actor_type TEXT NOT NULL DEFAULT 'user'")
 		}
+		// ADR-029: tamper-evidence hash chain. Empty on legacy rows (the chain
+		// begins at the first event written after these columns exist).
+		if !columnExists(db, "audit_events", "prev_hash") {
+			db.Exec("ALTER TABLE audit_events ADD COLUMN prev_hash TEXT NOT NULL DEFAULT ''")
+		}
+		if !columnExists(db, "audit_events", "entry_hash") {
+			db.Exec("ALTER TABLE audit_events ADD COLUMN entry_hash TEXT NOT NULL DEFAULT ''")
+		}
 	}
 
 	// Impersonation sessions carry the initiating admin + start time.

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -346,6 +346,15 @@ type AuditEvent struct {
 	// "system" marks events with no authenticated principal. Defaults to "user"
 	// so legacy rows and back-compat writers read as human-actored.
 	ActorType string `gorm:"default:user"`
+
+	// Tamper-evidence hash chain (ADR-029). PrevHash is the EntryHash of the
+	// immediately preceding chained event (a fixed genesis constant for the
+	// first chained event); EntryHash is SHA256(canonical(fields) ‖ PrevHash).
+	// Each entry binds its predecessor, so any modification/deletion/insertion
+	// is detectable by re-walking the chain (see VerifyAuditChain). Both are
+	// empty on legacy rows written before ADR-029 (an unchained prefix).
+	PrevHash  string `gorm:"index"`
+	EntryHash string `gorm:"index"`
 }
 
 type Setting struct {

--- a/internal/storage/store/entry.go
+++ b/internal/storage/store/entry.go
@@ -50,6 +50,7 @@ package store
 
 import (
 	"fmt"
+	"sync"
 
 	"github.com/keyorixhq/keyorix/internal/storage/remote"
 	"gorm.io/gorm"
@@ -72,6 +73,10 @@ func NewRemoteStorage(config *remote.Config) (*RemoteStorage, error) {
 // LocalStorage implements storage.Storage via direct GORM database access.
 type LocalStorage struct {
 	db *gorm.DB
+	// auditChainMu serializes audit-event appends so the read-chain-head +
+	// insert critical section is atomic within this process (ADR-029). The
+	// PostgreSQL advisory lock in LogAuditEvent extends this across processes.
+	auditChainMu sync.Mutex
 }
 
 // NewLocalStorage creates a LocalStorage backed by the given *gorm.DB.

--- a/internal/storage/store/local_audit.go
+++ b/internal/storage/store/local_audit.go
@@ -19,10 +19,6 @@ import (
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
-func (ls *LocalStorage) LogAuditEvent(ctx context.Context, event *models.AuditEvent) error {
-	return ls.db.WithContext(ctx).Create(event).Error
-}
-
 func (ls *LocalStorage) CreateSecretAccessLog(ctx context.Context, log *models.SecretAccessLog) error {
 	return ls.db.WithContext(ctx).Create(log).Error
 }

--- a/internal/storage/store/local_audit_chain.go
+++ b/internal/storage/store/local_audit_chain.go
@@ -1,0 +1,182 @@
+// local_audit_chain.go — tamper-evidence hash chain over audit_events (ADR-029).
+//
+// Each audit event stores prev_hash (the prior chained event's entry_hash, or a
+// genesis constant for the first) and entry_hash = SHA256(canonical(fields) ‖
+// prev_hash). Any modification, deletion, insertion, or reordering of audit
+// rows breaks the chain and is detected by VerifyAuditChain.
+//
+// Appends are serialized (process mutex + a Postgres transaction-scoped advisory
+// lock) so the read-chain-head + insert critical section is atomic even though
+// audit events are emitted from concurrent goroutines.
+package store
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"strconv"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"gorm.io/gorm"
+)
+
+// auditGenesisHash is the prev_hash of the first chained event. A fixed, visibly
+// non-real 64-hex-char constant so the chain has a deterministic anchor.
+const auditGenesisHash = "0000000000000000000000000000000000000000000000000000000000000000"
+
+// auditAdvisoryLockKey is the Postgres advisory-lock key guarding audit appends
+// across processes (arbitrary constant, namespaced to this use).
+const auditAdvisoryLockKey = 0x4B455941_55444954 // "KEYAUDIT"
+
+// auditChainVerifyBatch bounds memory when re-walking the chain.
+const auditChainVerifyBatch = 1000
+
+// computeAuditEntryHash hashes an event's semantically meaningful fields plus
+// prevHash, in a fixed order with null separators (so field boundaries are
+// unambiguous). The DB-assigned id is excluded — it is unknown before insert and
+// chain linkage already pins position. event_time is encoded as Unix
+// microseconds to round-trip identically on Postgres (µs precision) and SQLite.
+func computeAuditEntryHash(e *models.AuditEvent, prevHash string) string {
+	h := sha256.New()
+	write := func(s string) {
+		h.Write([]byte(s))
+		h.Write([]byte{0})
+	}
+	uptr := func(p *uint) string {
+		if p == nil {
+			return ""
+		}
+		return strconv.FormatUint(uint64(*p), 10)
+	}
+	bptr := func(p *bool) string {
+		if p == nil {
+			return ""
+		}
+		return strconv.FormatBool(*p)
+	}
+
+	write(prevHash)
+	write(e.EventType)
+	write(uptr(e.UserID))
+	write(uptr(e.SecretNodeID))
+	write(uptr(e.ProjectID))
+	write(e.IPAddress)
+	write(e.Description)
+	write(bptr(e.Success))
+	write(strconv.FormatInt(e.EventTime.UnixMicro(), 10))
+	write(e.Diff)
+	write(uptr(e.ImpersonatedBy))
+	write(uptr(e.ActingAs))
+	write(strconv.FormatBool(e.Impersonation))
+	write(e.ActorType)
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// LogAuditEvent appends an audit event, linking it into the tamper-evidence
+// hash chain (ADR-029). The read-chain-head + insert is serialized so the chain
+// stays well-formed under concurrent writers.
+func (ls *LocalStorage) LogAuditEvent(ctx context.Context, event *models.AuditEvent) error {
+	// Truncate to microseconds before both hashing and storage so the stored
+	// timestamp equals the hashed one on every backend (Postgres timestamptz is
+	// µs-precision; an un-truncated nanosecond time would not round-trip).
+	event.EventTime = event.EventTime.Truncate(time.Microsecond)
+
+	ls.auditChainMu.Lock()
+	defer ls.auditChainMu.Unlock()
+
+	return ls.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		// Cross-process serialization for multi-instance Postgres; no-op on SQLite.
+		if tx.Dialector.Name() == "postgres" {
+			if err := tx.Exec("SELECT pg_advisory_xact_lock(?)", int64(auditAdvisoryLockKey)).Error; err != nil {
+				return err
+			}
+		}
+
+		var head struct{ EntryHash string }
+		if err := tx.Model(&models.AuditEvent{}).
+			Select("entry_hash").
+			Order("id DESC").
+			Limit(1).
+			Scan(&head).Error; err != nil {
+			return err
+		}
+		prev := head.EntryHash
+		if prev == "" {
+			prev = auditGenesisHash
+		}
+
+		event.PrevHash = prev
+		event.EntryHash = computeAuditEntryHash(event, prev)
+		return tx.Create(event).Error
+	})
+}
+
+// VerifyAuditChain re-walks the hash chain by ascending id in bounded batches.
+// A leading run of legacy rows (empty entry_hash, pre-ADR-029) is counted as an
+// unchained prefix. From the first chained row, each row's prev_hash must equal
+// the running previous entry_hash (genesis for the first) and its entry_hash
+// must recompute from its stored fields. The first divergence stops the walk.
+func (ls *LocalStorage) VerifyAuditChain(ctx context.Context) (*storage.AuditChainVerification, error) {
+	result := &storage.AuditChainVerification{Valid: true}
+
+	prevHash := auditGenesisHash
+	started := false
+	var lastID uint
+
+	for {
+		var batch []*models.AuditEvent
+		if err := ls.db.WithContext(ctx).
+			Where("id > ?", lastID).
+			Order("id ASC").
+			Limit(auditChainVerifyBatch).
+			Find(&batch).Error; err != nil {
+			return nil, err
+		}
+		if len(batch) == 0 {
+			break
+		}
+
+		for _, e := range batch {
+			lastID = e.ID
+
+			if !started {
+				if e.EntryHash == "" {
+					result.UnchainedEvents++
+					continue
+				}
+				started = true
+			}
+
+			// Once chained, an empty hash means chain data was stripped.
+			if e.EntryHash == "" {
+				return brokenChain(result, e.ID, "missing entry hash on a chained event (chain data removed)"), nil
+			}
+			if e.PrevHash != prevHash {
+				return brokenChain(result, e.ID, "prev_hash does not link to the preceding event (row inserted, deleted, or reordered)"), nil
+			}
+			if computeAuditEntryHash(e, e.PrevHash) != e.EntryHash {
+				return brokenChain(result, e.ID, "entry_hash does not match the event contents (event modified)"), nil
+			}
+
+			prevHash = e.EntryHash
+			result.ChainedEvents++
+		}
+
+		if len(batch) < auditChainVerifyBatch {
+			break
+		}
+	}
+
+	return result, nil
+}
+
+// brokenChain marks a verification result as failed at the given event.
+func brokenChain(r *storage.AuditChainVerification, id uint, reason string) *storage.AuditChainVerification {
+	r.Valid = false
+	idCopy := id
+	r.FirstBrokenID = &idCopy
+	r.Reason = reason
+	return r
+}

--- a/internal/storage/store/local_audit_chain_test.go
+++ b/internal/storage/store/local_audit_chain_test.go
@@ -1,0 +1,183 @@
+package store
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func newAuditChainTestStore(t *testing.T) *LocalStorage {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.AuditEvent{}))
+	return NewLocalStorage(db)
+}
+
+func appendEvent(t *testing.T, ls *LocalStorage, eventType, desc string, at time.Time) *models.AuditEvent {
+	t.Helper()
+	tr := true
+	e := &models.AuditEvent{
+		EventType: eventType, Description: desc, Success: &tr,
+		EventTime: at, ActorType: "user",
+	}
+	require.NoError(t, ls.LogAuditEvent(context.Background(), e))
+	return e
+}
+
+func TestLogAuditEvent_BuildsChain(t *testing.T) {
+	ls := newAuditChainTestStore(t)
+	base := time.Now().UTC()
+
+	e1 := appendEvent(t, ls, "auth.login", "first", base)
+	e2 := appendEvent(t, ls, "secret.read", "second", base.Add(time.Second))
+	e3 := appendEvent(t, ls, "secret.updated", "third", base.Add(2*time.Second))
+
+	// First event anchors to the genesis hash; each subsequent prev_hash is the
+	// previous entry_hash.
+	assert.Equal(t, auditGenesisHash, e1.PrevHash)
+	assert.NotEmpty(t, e1.EntryHash)
+	assert.Equal(t, e1.EntryHash, e2.PrevHash)
+	assert.Equal(t, e2.EntryHash, e3.PrevHash)
+	assert.NotEqual(t, e1.EntryHash, e2.EntryHash)
+
+	v, err := ls.VerifyAuditChain(context.Background())
+	require.NoError(t, err)
+	assert.True(t, v.Valid)
+	assert.Equal(t, int64(3), v.ChainedEvents)
+	assert.Equal(t, int64(0), v.UnchainedEvents)
+	assert.Nil(t, v.FirstBrokenID)
+}
+
+func TestVerifyAuditChain_DetectsModification(t *testing.T) {
+	ls := newAuditChainTestStore(t)
+	base := time.Now().UTC()
+	appendEvent(t, ls, "auth.login", "first", base)
+	e2 := appendEvent(t, ls, "secret.read", "second", base.Add(time.Second))
+	appendEvent(t, ls, "secret.updated", "third", base.Add(2*time.Second))
+
+	// Tamper: rewrite a field directly, leaving the stored hash stale.
+	require.NoError(t, ls.db.Model(&models.AuditEvent{}).
+		Where("id = ?", e2.ID).
+		Update("description", "TAMPERED").Error)
+
+	v, err := ls.VerifyAuditChain(context.Background())
+	require.NoError(t, err)
+	assert.False(t, v.Valid)
+	require.NotNil(t, v.FirstBrokenID)
+	assert.Equal(t, e2.ID, *v.FirstBrokenID)
+	assert.Contains(t, v.Reason, "modified")
+	// One clean event verified before the break.
+	assert.Equal(t, int64(1), v.ChainedEvents)
+}
+
+func TestVerifyAuditChain_DetectsDeletion(t *testing.T) {
+	ls := newAuditChainTestStore(t)
+	base := time.Now().UTC()
+	appendEvent(t, ls, "auth.login", "first", base)
+	e2 := appendEvent(t, ls, "secret.read", "second", base.Add(time.Second))
+	e3 := appendEvent(t, ls, "secret.updated", "third", base.Add(2*time.Second))
+
+	// Delete a middle event; e3's prev_hash now links to a vanished entry.
+	require.NoError(t, ls.db.Delete(&models.AuditEvent{}, e2.ID).Error)
+
+	v, err := ls.VerifyAuditChain(context.Background())
+	require.NoError(t, err)
+	assert.False(t, v.Valid)
+	require.NotNil(t, v.FirstBrokenID)
+	assert.Equal(t, e3.ID, *v.FirstBrokenID, "break surfaces at the row after the deleted one")
+	assert.Contains(t, v.Reason, "link")
+}
+
+func TestVerifyAuditChain_LegacyPrefix(t *testing.T) {
+	ls := newAuditChainTestStore(t)
+	base := time.Now().UTC()
+
+	// Two pre-ADR-029 rows: inserted raw with empty hashes.
+	tr := true
+	for i, d := range []string{"legacy-1", "legacy-2"} {
+		require.NoError(t, ls.db.Create(&models.AuditEvent{
+			EventType: "secret.read", Description: d, Success: &tr,
+			EventTime: base.Add(time.Duration(i) * time.Second), ActorType: "user",
+		}).Error)
+	}
+
+	// New chained events appended afterward.
+	appendEvent(t, ls, "auth.login", "chained-1", base.Add(10*time.Second))
+	appendEvent(t, ls, "secret.read", "chained-2", base.Add(11*time.Second))
+
+	v, err := ls.VerifyAuditChain(context.Background())
+	require.NoError(t, err)
+	assert.True(t, v.Valid)
+	assert.Equal(t, int64(2), v.UnchainedEvents, "legacy rows counted, not failed")
+	assert.Equal(t, int64(2), v.ChainedEvents)
+}
+
+func TestVerifyAuditChain_Empty(t *testing.T) {
+	ls := newAuditChainTestStore(t)
+	v, err := ls.VerifyAuditChain(context.Background())
+	require.NoError(t, err)
+	assert.True(t, v.Valid)
+	assert.Equal(t, int64(0), v.ChainedEvents)
+	assert.Equal(t, int64(0), v.UnchainedEvents)
+}
+
+func TestLogAuditEvent_ConcurrentAppendsStayChained(t *testing.T) {
+	ls := newAuditChainTestStore(t)
+	base := time.Now().UTC()
+
+	const writers = 8
+	const perWriter = 25
+	var wg sync.WaitGroup
+	wg.Add(writers)
+	for w := 0; w < writers; w++ {
+		go func(w int) {
+			defer wg.Done()
+			tr := true
+			for i := 0; i < perWriter; i++ {
+				e := &models.AuditEvent{
+					EventType: "secret.read", Description: "concurrent", Success: &tr,
+					EventTime: base.Add(time.Duration(w*perWriter+i) * time.Millisecond),
+					ActorType: "user",
+				}
+				// Serialized internally; concurrent callers must not corrupt the chain.
+				require.NoError(t, ls.LogAuditEvent(context.Background(), e))
+			}
+		}(w)
+	}
+	wg.Wait()
+
+	v, err := ls.VerifyAuditChain(context.Background())
+	require.NoError(t, err)
+	assert.True(t, v.Valid, "chain intact under concurrent writers: %s", v.Reason)
+	assert.Equal(t, int64(writers*perWriter), v.ChainedEvents)
+}
+
+func TestComputeAuditEntryHash_Deterministic(t *testing.T) {
+	at := time.Unix(1_700_000_000, 123000).UTC() // 123µs exactly
+	uid := uint(7)
+	tr := true
+	e := &models.AuditEvent{
+		EventType: "secret.read", UserID: &uid, Description: "d",
+		Success: &tr, EventTime: at, ActorType: "user",
+	}
+	// UnixMicro encoding means sub-microsecond differences do not change the hash.
+	e2 := *e
+	e2.EventTime = at.Add(500 * time.Nanosecond) // stays within the same µs
+
+	assert.Equal(t,
+		computeAuditEntryHash(e, auditGenesisHash),
+		computeAuditEntryHash(&e2, auditGenesisHash),
+		"hash is stable across sub-microsecond timestamp jitter (Postgres µs round-trip)")
+	assert.NotEqual(t,
+		computeAuditEntryHash(e, auditGenesisHash),
+		computeAuditEntryHash(e, "different-prev"),
+		"prev_hash is bound into the entry hash")
+}

--- a/internal/storage/store/remote_audit.go
+++ b/internal/storage/store/remote_audit.go
@@ -138,6 +138,11 @@ func (rs *RemoteStorage) AuditRetentionStats(_ context.Context) (*storage.AuditR
 	return nil, fmt.Errorf("AuditRetentionStats not available in remote mode")
 }
 
+// VerifyAuditChain is not available in remote mode; chain verification runs server-side.
+func (rs *RemoteStorage) VerifyAuditChain(_ context.Context) (*storage.AuditChainVerification, error) {
+	return nil, fmt.Errorf("VerifyAuditChain not available in remote mode")
+}
+
 // CreateAnomalyAlert is not available in remote mode; anomaly detection is server-side.
 func (rs *RemoteStorage) CreateAnomalyAlert(_ context.Context, _ *models.AnomalyAlert) error {
 	return fmt.Errorf("CreateAnomalyAlert not available in remote mode")

--- a/server/http/handlers/audit.go
+++ b/server/http/handlers/audit.go
@@ -334,3 +334,30 @@ func (h *AuditHandler) GetAuditRetention(w http.ResponseWriter, r *http.Request)
 
 	sendSuccess(w, cov, "")
 }
+
+// VerifyAuditChain handles GET /api/v1/audit/verify — re-walks the
+// tamper-evidence hash chain (ADR-029) and reports whether the audit trail is
+// intact, naming the first divergent event on failure.
+func (h *AuditHandler) VerifyAuditChain(w http.ResponseWriter, r *http.Request) {
+	if middleware.GetUserFromContext(r.Context()) == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+
+	v, err := h.coreService.VerifyAuditChain(r.Context())
+	if err != nil {
+		sendError(w, "InternalError", "Failed to verify audit chain", http.StatusInternalServerError, nil)
+		return
+	}
+
+	resp := map[string]interface{}{
+		"valid":            v.Valid,
+		"chained_events":   v.ChainedEvents,
+		"unchained_events": v.UnchainedEvents,
+	}
+	if !v.Valid {
+		resp["first_broken_id"] = v.FirstBrokenID
+		resp["reason"] = v.Reason
+	}
+	sendSuccess(w, resp, "")
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -358,6 +358,7 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.Get("/export", auditHandler.ExportAuditLogs)
 			r.Get("/rbac-logs", auditHandler.GetRBACAuditLogs)
 			r.Get("/retention", auditHandler.GetAuditRetention)
+			r.Get("/verify", auditHandler.VerifyAuditChain)
 			r.Get("/anomalies", handlers.ListAnomalyAlerts)
 			r.Post("/anomalies/{id}/acknowledge", handlers.AcknowledgeAnomalyAlert)
 		})


### PR DESCRIPTION
> **Stacked on #69** (base = `feat/audit-retention-coverage`). Review/merge #69 first; this branch will be rebased onto `main` and retargeted once #69 lands.

## What & why

Closes the last honest gap in `AUDIT-LOG-PROVISIONS.md` — checklist row 11, *tamper resistance* — which until now read "⚠️ Roadmap". Every audit event is linked into a **SHA-256 hash chain**:

- `prev_hash` = the prior chained event's `entry_hash` (a genesis constant for the first)
- `entry_hash` = `SHA256( canonical(fields) ‖ prev_hash )`

Each entry binds its predecessor, so any after-the-fact **modification, deletion, insertion, or reordering** of audit rows breaks the chain and is detectable by re-walking it. This is tamper-**evidence** (detection), not prevention — but once an `entry_hash` is exported off-box (the existing SIEM push forwards every event), undetectable tampering becomes impossible. Design rationale in **ADR-029**.

## Endpoint

`GET /api/v1/audit/verify` (behind `audit.read`):

```json
{ "valid": true, "chained_events": 41234, "unchained_events": 0 }
```
On a broken chain:
```json
{ "valid": false, "chained_events": 120, "unchained_events": 0,
  "first_broken_id": 121, "reason": "entry_hash does not match the event contents (event modified)" }
```

## Correctness highlights

- **Serialization** — audit events are emitted from detached goroutines, so the read-chain-head + insert is serialized: a process mutex (covers single-instance + SQLite) **plus** a Postgres transaction-scoped advisory lock (covers multi-instance). Concurrency test runs race-clean.
- **Timestamp round-trip** — `event_time` is hashed as Unix microseconds and truncated to µs before store, so the stored value equals the hashed value on both Postgres (µs `timestamptz`) and SQLite. Without this, verification would fail for every row on Postgres.
- **Migration** — additive `ALTER` guarded by `columnExists` (not `AutoMigrate` on an existing table — avoids the documented pgx double-migration hazard). Legacy pre-ADR-029 rows have empty hashes and are counted as an *unchained prefix*, not a failure.
- **Hash excludes the DB-assigned `id`** (unknown pre-insert); chain linkage already pins position.

## Tests

`internal/storage/store/local_audit_chain_test.go`:
- chain builds + links (genesis → e1 → e2 → e3)
- detects modification (stale hash) → names the row, reason "modified"
- detects deletion → break surfaces at the row after the gap, reason "link"
- legacy prefix counted not failed; empty table valid
- **concurrent writers** (8×25) stay chained — race-clean
- deterministic hash incl. sub-µs timestamp stability + prev_hash binding

Plus core passthrough test. Full `go test ./...` green; `gofmt`/`go vet` clean; `-race` clean on store + core.

## Verified end-to-end

Ran the built server (SQLite), bootstrapped admin, logged in:
- `GET /audit/verify` → `{valid: true, chained_events: 2}`
- modified an audit row's `description` directly in the DB → `/verify` flipped to `valid: false`, `first_broken_id: 1`, reason `"entry_hash does not match the event contents (event modified)"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)