### PR TITLE
feat(drift): cross-environment secret drift detection + API

### DIFF
--- a/internal/core/drift.go
+++ b/internal/core/drift.go
@@ -1,0 +1,183 @@
+package core
+
+import (
+	"context"
+	"fmt"
+	"sort"
+)
+
+// Drift status values for a single key across a project's environments.
+const (
+	DriftStatusConsistent   = "consistent"      // present in every environment, settings agree
+	DriftStatusMissingSome  = "missing_in_some" // present in some environments, absent in others
+	DriftStatusMetadataOnly = "metadata_drift"  // present everywhere, but settings differ
+)
+
+// DriftEnvironment is one environment column in the drift report.
+type DriftEnvironment struct {
+	ID   uint   `json:"id"`
+	Name string `json:"name"`
+}
+
+// DriftKey is one secret key's posture across the project's environments.
+type DriftKey struct {
+	Name string `json:"name"`
+	// PresentIn / MissingFrom are environment ids (subsets of the report's
+	// Environments). MissingFrom is empty when the key exists everywhere.
+	PresentIn   []uint `json:"present_in"`
+	MissingFrom []uint `json:"missing_from"`
+	// Status is one of the DriftStatus* values.
+	Status string `json:"status"`
+	// DriftFields names the settings that differ across the environments that DO
+	// have this key (subset of "type", "expiration", "max_reads"). Empty unless
+	// the settings diverge.
+	DriftFields []string `json:"drift_fields,omitempty"`
+}
+
+// DriftSummary is the headline tally for the drift report.
+type DriftSummary struct {
+	EnvironmentCount int `json:"environment_count"`
+	TotalKeys        int `json:"total_keys"`
+	ConsistentKeys   int `json:"consistent_keys"`
+	MissingInSome    int `json:"missing_in_some"`
+	MetadataDrift    int `json:"metadata_drift"`
+}
+
+// ProjectDrift is the cross-environment drift report for a project: the
+// environment columns, the keys that drift (consistent keys are summarised, not
+// listed), and a summary tally.
+type ProjectDrift struct {
+	ProjectID    uint               `json:"project_id"`
+	Environments []DriftEnvironment `json:"environments"`
+	// DriftedKeys lists only keys that are NOT fully consistent (missing in some
+	// environment, or present everywhere but with diverging settings), name-sorted.
+	DriftedKeys []DriftKey   `json:"drifted_keys"`
+	Summary     DriftSummary `json:"summary"`
+}
+
+// DetectProjectDrift compares secret keys across all of a project's
+// environments and reports the keys that drift — present in some environments
+// but not others, or present everywhere with diverging settings (type /
+// expiration / max-reads). No secret values are read. With fewer than two
+// environments no drift is possible, so the report is empty. Backs
+// GET /api/v1/projects/{id}/drift.
+func (c *KeyorixCore) DetectProjectDrift(ctx context.Context, projectID uint) (*ProjectDrift, error) {
+	envs, err := c.storage.ListEnvironmentsByProject(ctx, projectID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list environments for drift: %w", err)
+	}
+
+	report := &ProjectDrift{ProjectID: projectID}
+	envIDs := make([]uint, 0, len(envs))
+	for _, e := range envs {
+		report.Environments = append(report.Environments, DriftEnvironment{ID: e.ID, Name: e.Name})
+		envIDs = append(envIDs, e.ID)
+	}
+	report.Summary.EnvironmentCount = len(envs)
+
+	rows, err := c.storage.ListProjectSecretsForDrift(ctx, projectID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list secrets for drift: %w", err)
+	}
+
+	// Pivot rows into name -> (envID -> cell). A name may legitimately appear once
+	// per environment; duplicates within one environment collapse to the last.
+	byName := map[string]map[uint]driftCell{}
+	names := make([]string, 0)
+	for _, r := range rows {
+		if _, ok := byName[r.Name]; !ok {
+			byName[r.Name] = map[uint]driftCell{}
+			names = append(names, r.Name)
+		}
+		byName[r.Name][r.EnvironmentID] = driftCell{typ: r.Type, hasExpiration: r.HasExpiration, hasMaxReads: r.HasMaxReads}
+	}
+	sort.Strings(names)
+
+	report.Summary.TotalKeys = len(names)
+
+	for _, name := range names {
+		cells := byName[name]
+
+		presentIn := make([]uint, 0, len(cells))
+		missingFrom := make([]uint, 0)
+		for _, id := range envIDs { // iterate in environment order for stable output
+			if _, ok := cells[id]; ok {
+				presentIn = append(presentIn, id)
+			} else {
+				missingFrom = append(missingFrom, id)
+			}
+		}
+
+		driftFields := metadataDriftFields(cells)
+
+		// Fully consistent: present in every environment AND no setting diverges.
+		if len(missingFrom) == 0 && len(driftFields) == 0 {
+			report.Summary.ConsistentKeys++
+			continue
+		}
+
+		key := DriftKey{
+			Name:        name,
+			PresentIn:   presentIn,
+			MissingFrom: missingFrom,
+			DriftFields: driftFields,
+		}
+		if len(missingFrom) > 0 {
+			key.Status = DriftStatusMissingSome
+			report.Summary.MissingInSome++
+		} else {
+			key.Status = DriftStatusMetadataOnly
+			report.Summary.MetadataDrift++
+		}
+		report.DriftedKeys = append(report.DriftedKeys, key)
+	}
+
+	return report, nil
+}
+
+// driftCell is one secret's drift-relevant settings within a single environment.
+type driftCell struct {
+	typ           string
+	hasExpiration bool
+	hasMaxReads   bool
+}
+
+// metadataDriftFields reports which settings differ across the environments that
+// have a given key. Only the environments that actually hold the key are
+// compared, so a key missing from an environment is a presence issue, not a
+// metadata one. Returns a sorted subset of {"type","expiration","max_reads"}.
+func metadataDriftFields(cells map[uint]driftCell) []string {
+	if len(cells) < 2 {
+		return nil
+	}
+	var first driftCell
+	var typeDrift, expDrift, maxDrift bool
+	seen := false
+	for _, c := range cells {
+		if !seen {
+			first = c
+			seen = true
+			continue
+		}
+		if c.typ != first.typ {
+			typeDrift = true
+		}
+		if c.hasExpiration != first.hasExpiration {
+			expDrift = true
+		}
+		if c.hasMaxReads != first.hasMaxReads {
+			maxDrift = true
+		}
+	}
+	fields := make([]string, 0, 3)
+	if typeDrift {
+		fields = append(fields, "type")
+	}
+	if expDrift {
+		fields = append(fields, "expiration")
+	}
+	if maxDrift {
+		fields = append(fields, "max_reads")
+	}
+	return fields
+}

--- a/internal/core/drift_test.go
+++ b/internal/core/drift_test.go
@@ -1,0 +1,103 @@
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDetectProjectDrift_Classification(t *testing.T) {
+	const projectID = uint(1)
+	store := new(MockStorage)
+
+	store.On("ListEnvironmentsByProject", mock.Anything, projectID).Return([]*models.Environment{
+		{ID: 10, ProjectID: projectID, Name: "dev"},
+		{ID: 20, ProjectID: projectID, Name: "staging"},
+		{ID: 30, ProjectID: projectID, Name: "prod"},
+	}, nil)
+
+	// CONSISTENT: present in all three, identical settings.
+	// MISSING:    present in dev+staging, absent in prod.
+	// META:       present in all three, but type differs in prod.
+	store.On("ListProjectSecretsForDrift", mock.Anything, projectID).Return([]storage.DriftSecretRow{
+		{EnvironmentID: 10, Name: "CONSISTENT", Type: "password"},
+		{EnvironmentID: 20, Name: "CONSISTENT", Type: "password"},
+		{EnvironmentID: 30, Name: "CONSISTENT", Type: "password"},
+
+		{EnvironmentID: 10, Name: "MISSING", Type: "api_key"},
+		{EnvironmentID: 20, Name: "MISSING", Type: "api_key"},
+
+		{EnvironmentID: 10, Name: "META", Type: "password"},
+		{EnvironmentID: 20, Name: "META", Type: "password"},
+		{EnvironmentID: 30, Name: "META", Type: "api_key"},
+	}, nil)
+
+	c := NewKeyorixCore(store)
+	rep, err := c.DetectProjectDrift(context.Background(), projectID)
+	require.NoError(t, err)
+
+	require.Equal(t, 3, rep.Summary.EnvironmentCount)
+	require.Equal(t, 3, rep.Summary.TotalKeys)
+	require.Equal(t, 1, rep.Summary.ConsistentKeys)
+	require.Equal(t, 1, rep.Summary.MissingInSome)
+	require.Equal(t, 1, rep.Summary.MetadataDrift)
+
+	// Only the two non-consistent keys are listed, name-sorted (META < MISSING).
+	require.Len(t, rep.DriftedKeys, 2)
+
+	meta := rep.DriftedKeys[0]
+	require.Equal(t, "META", meta.Name)
+	require.Equal(t, DriftStatusMetadataOnly, meta.Status)
+	require.Empty(t, meta.MissingFrom)
+	require.Equal(t, []string{"type"}, meta.DriftFields)
+
+	missing := rep.DriftedKeys[1]
+	require.Equal(t, "MISSING", missing.Name)
+	require.Equal(t, DriftStatusMissingSome, missing.Status)
+	require.Equal(t, []uint{10, 20}, missing.PresentIn)
+	require.Equal(t, []uint{30}, missing.MissingFrom)
+}
+
+func TestDetectProjectDrift_SingleEnvironmentNoDrift(t *testing.T) {
+	const projectID = uint(2)
+	store := new(MockStorage)
+	store.On("ListEnvironmentsByProject", mock.Anything, projectID).Return([]*models.Environment{
+		{ID: 10, ProjectID: projectID, Name: "dev"},
+	}, nil)
+	store.On("ListProjectSecretsForDrift", mock.Anything, projectID).Return([]storage.DriftSecretRow{
+		{EnvironmentID: 10, Name: "A", Type: "password"},
+		{EnvironmentID: 10, Name: "B", Type: "password"},
+	}, nil)
+
+	c := NewKeyorixCore(store)
+	rep, err := c.DetectProjectDrift(context.Background(), projectID)
+	require.NoError(t, err)
+	require.Equal(t, 2, rep.Summary.TotalKeys)
+	require.Equal(t, 2, rep.Summary.ConsistentKeys, "with one environment every key is trivially consistent")
+	require.Empty(t, rep.DriftedKeys)
+}
+
+func TestDetectProjectDrift_ExpirationAndMaxReadsDrift(t *testing.T) {
+	const projectID = uint(3)
+	store := new(MockStorage)
+	store.On("ListEnvironmentsByProject", mock.Anything, projectID).Return([]*models.Environment{
+		{ID: 10, ProjectID: projectID, Name: "dev"},
+		{ID: 20, ProjectID: projectID, Name: "prod"},
+	}, nil)
+	store.On("ListProjectSecretsForDrift", mock.Anything, projectID).Return([]storage.DriftSecretRow{
+		// Same type, but prod adds expiration + max_reads → metadata drift on both.
+		{EnvironmentID: 10, Name: "TOKEN", Type: "api_key", HasExpiration: false, HasMaxReads: false},
+		{EnvironmentID: 20, Name: "TOKEN", Type: "api_key", HasExpiration: true, HasMaxReads: true},
+	}, nil)
+
+	c := NewKeyorixCore(store)
+	rep, err := c.DetectProjectDrift(context.Background(), projectID)
+	require.NoError(t, err)
+	require.Len(t, rep.DriftedKeys, 1)
+	require.Equal(t, DriftStatusMetadataOnly, rep.DriftedKeys[0].Status)
+	require.Equal(t, []string{"expiration", "max_reads"}, rep.DriftedKeys[0].DriftFields)
+}

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -62,7 +62,19 @@ func (m *MockStorage) ListEnvironments(_ context.Context) ([]*models.Environment
 	return nil, nil
 }
 
-func (m *MockStorage) ListEnvironmentsByProject(_ context.Context, _ uint) ([]*models.Environment, error) {
+func (m *MockStorage) ListEnvironmentsByProject(ctx context.Context, projectID uint) ([]*models.Environment, error) {
+	if len(m.ExpectedCalls) == 0 {
+		return nil, nil
+	}
+	for _, c := range m.ExpectedCalls {
+		if c.Method == "ListEnvironmentsByProject" {
+			args := m.Called(ctx, projectID)
+			if args.Get(0) == nil {
+				return nil, args.Error(1)
+			}
+			return args.Get(0).([]*models.Environment), args.Error(1)
+		}
+	}
 	return nil, nil
 }
 
@@ -189,6 +201,14 @@ func (m *MockStorage) ListSecrets(ctx context.Context, filter *storage.SecretFil
 		return nil, args.Get(1).(int64), args.Error(2)
 	}
 	return args.Get(0).([]*models.SecretNode), args.Get(1).(int64), args.Error(2)
+}
+
+func (m *MockStorage) ListProjectSecretsForDrift(ctx context.Context, projectID uint) ([]storage.DriftSecretRow, error) {
+	args := m.Called(ctx, projectID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]storage.DriftSecretRow), args.Error(1)
 }
 
 func (m *MockStorage) GetSecretVersions(ctx context.Context, secretID uint) ([]*models.SecretVersion, error) {

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -80,6 +80,12 @@ type Storage interface {
 	UpdateSecret(ctx context.Context, secret *models.SecretNode) (*models.SecretNode, error)
 	DeleteSecret(ctx context.Context, id uint) error
 	ListSecrets(ctx context.Context, filter *SecretFilter) ([]*models.SecretNode, int64, error)
+	// ListProjectSecretsForDrift returns one lightweight row per secret in the
+	// project (folders excluded, secrets in soft-deleted environments excluded),
+	// carrying just the fields cross-environment drift detection pivots on:
+	// environment id, name, type, and whether expiration / max_reads are set. No
+	// secret values are read.
+	ListProjectSecretsForDrift(ctx context.Context, projectID uint) ([]DriftSecretRow, error)
 	GetSecretVersions(ctx context.Context, secretID uint) ([]*models.SecretVersion, error)
 	CreateSecretVersion(ctx context.Context, version *models.SecretVersion) (*models.SecretVersion, error)
 	GetLatestSecretVersion(ctx context.Context, secretID uint) (*models.SecretVersion, error)
@@ -290,6 +296,18 @@ type SecretFilter struct {
 	CreatedBefore *time.Time
 	Page          int
 	PageSize      int
+}
+
+// DriftSecretRow is one secret's drift-relevant projection: which environment it
+// lives in, its name (the cross-environment key), its type, and whether it has
+// an expiration / max-reads cap set. Used to build the per-key × per-environment
+// presence matrix for cross-environment drift detection.
+type DriftSecretRow struct {
+	EnvironmentID uint
+	Name          string
+	Type          string
+	HasExpiration bool
+	HasMaxReads   bool
 }
 
 // UserFilter defines filtering options for user queries

--- a/internal/storage/store/local_drift.go
+++ b/internal/storage/store/local_drift.go
@@ -1,0 +1,53 @@
+// local_drift.go — cross-environment drift projection for LocalStorage.
+//
+// Drift detection compares the set of secret keys (by name) across a project's
+// environments. This query supplies the raw rows — one per secret, carrying only
+// the fields the pivot needs — without reading any secret value.
+package store
+
+import (
+	"context"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+)
+
+// ListProjectSecretsForDrift returns the drift projection for every real secret
+// in the project. Folders (is_secret = false) are excluded, as are secrets whose
+// environment has been soft-deleted (so a deleted environment never shows up as
+// a phantom column). The JOIN also pins environment_id to the project, mirroring
+// ListSecrets' cross-project-leakage guard.
+func (ls *LocalStorage) ListProjectSecretsForDrift(ctx context.Context, projectID uint) ([]storage.DriftSecretRow, error) {
+	type row struct {
+		EnvironmentID uint
+		Name          string
+		Type          string
+		HasExpiration bool
+		HasMaxReads   bool
+	}
+	var rows []row
+	if err := ls.db.WithContext(ctx).
+		Table("secret_nodes AS s").
+		Select("s.environment_id AS environment_id, s.name AS name, s.type AS type, "+
+			"(s.expiration IS NOT NULL) AS has_expiration, (s.max_reads IS NOT NULL) AS has_max_reads").
+		Joins("JOIN environments e ON e.id = s.environment_id").
+		Where("s.project_id = ?", projectID).
+		Where("e.project_id = ?", projectID).
+		Where("e.deleted_at IS NULL").
+		Where("s.is_secret = ?", true).
+		Order("s.name ASC, s.environment_id ASC").
+		Scan(&rows).Error; err != nil {
+		return nil, err
+	}
+
+	out := make([]storage.DriftSecretRow, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, storage.DriftSecretRow{
+			EnvironmentID: r.EnvironmentID,
+			Name:          r.Name,
+			Type:          r.Type,
+			HasExpiration: r.HasExpiration,
+			HasMaxReads:   r.HasMaxReads,
+		})
+	}
+	return out, nil
+}

--- a/internal/storage/store/local_drift_test.go
+++ b/internal/storage/store/local_drift_test.go
@@ -1,0 +1,64 @@
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func newDriftTestStore(t *testing.T) *LocalStorage {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.Environment{}, &models.SecretNode{}))
+	return NewLocalStorage(db)
+}
+
+func TestListProjectSecretsForDrift(t *testing.T) {
+	ls := newDriftTestStore(t)
+	ctx := context.Background()
+	const projectID = uint(1)
+
+	// Two live environments + one soft-deleted environment in the project.
+	envs := []*models.Environment{
+		{ID: 10, ProjectID: projectID, Name: "dev"},
+		{ID: 20, ProjectID: projectID, Name: "prod"},
+		{ID: 30, ProjectID: projectID, Name: "old"},
+	}
+	for _, e := range envs {
+		require.NoError(t, ls.db.Create(e).Error)
+	}
+	require.NoError(t, ls.db.Delete(&models.Environment{}, 30).Error) // soft-delete "old"
+
+	maxR := 5
+	exp := time.Now().Add(24 * time.Hour)
+	nodes := []*models.SecretNode{
+		{ProjectID: projectID, EnvironmentID: 10, Name: "DB_PASSWORD", IsSecret: true, Type: "password"},
+		{ProjectID: projectID, EnvironmentID: 20, Name: "DB_PASSWORD", IsSecret: true, Type: "password", MaxReads: &maxR, Expiration: &exp},
+		{ProjectID: projectID, EnvironmentID: 10, Name: "a-folder", IsSecret: false}, // folder excluded
+		{ProjectID: projectID, EnvironmentID: 30, Name: "GHOST", IsSecret: true},     // in deleted env, excluded
+	}
+	for _, n := range nodes {
+		require.NoError(t, ls.db.Create(n).Error)
+	}
+
+	rows, err := ls.ListProjectSecretsForDrift(ctx, projectID)
+	require.NoError(t, err)
+	require.Len(t, rows, 2, "folders and secrets in soft-deleted environments are excluded")
+
+	// Ordered by name then environment id.
+	assert.Equal(t, "DB_PASSWORD", rows[0].Name)
+	assert.Equal(t, uint(10), rows[0].EnvironmentID)
+	assert.False(t, rows[0].HasExpiration)
+	assert.False(t, rows[0].HasMaxReads)
+
+	assert.Equal(t, uint(20), rows[1].EnvironmentID)
+	assert.True(t, rows[1].HasExpiration, "prod secret has expiration set")
+	assert.True(t, rows[1].HasMaxReads, "prod secret has max_reads set")
+}

--- a/internal/storage/store/remote_secrets.go
+++ b/internal/storage/store/remote_secrets.go
@@ -120,6 +120,11 @@ func (rs *RemoteStorage) ListSecrets(ctx context.Context, filter *storage.Secret
 	return result.Secrets, result.Total, nil
 }
 
+// ListProjectSecretsForDrift is not available in remote mode; drift detection aggregates server-side.
+func (rs *RemoteStorage) ListProjectSecretsForDrift(_ context.Context, _ uint) ([]storage.DriftSecretRow, error) {
+	return nil, fmt.Errorf("ListProjectSecretsForDrift not available in remote mode")
+}
+
 // buildSecretFilterPath constructs the /api/v1/secrets query string from filter fields.
 func buildSecretFilterPath(filter *storage.SecretFilter) string {
 	if filter == nil {

--- a/server/http/handlers/catalog.go
+++ b/server/http/handlers/catalog.go
@@ -69,6 +69,24 @@ func (h *CatalogHandler) GetProject(w http.ResponseWriter, r *http.Request) {
 	sendSuccess(w, project, "")
 }
 
+// GetProjectDrift handles GET /api/v1/projects/{id}/drift — the
+// cross-environment drift report for the project (keys missing in some
+// environments, or present everywhere with diverging settings).
+func (h *CatalogHandler) GetProjectDrift(w http.ResponseWriter, r *http.Request) {
+	idStr := chi.URLParam(r, "id")
+	id, err := strconv.ParseUint(idStr, 10, 32)
+	if err != nil {
+		sendError(w, "InvalidParameter", "Invalid project ID", http.StatusBadRequest, nil)
+		return
+	}
+	report, err := h.coreService.DetectProjectDrift(r.Context(), uint(id))
+	if err != nil {
+		sendError(w, "InternalError", "Failed to compute drift", http.StatusInternalServerError, nil)
+		return
+	}
+	sendSuccess(w, report, "")
+}
+
 // CreateProject handles POST /api/v1/projects
 func (h *CatalogHandler) CreateProject(w http.ResponseWriter, r *http.Request) {
 	var body struct {

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -168,6 +168,7 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		r.With(customMiddleware.RequireScopedPermission("secrets.write", projectScope)).Put("/projects/{id}", catalogHandler.UpdateProject)
 		r.With(customMiddleware.RequireScopedPermission("secrets.delete", projectScope)).Delete("/projects/{id}", catalogHandler.DeleteProject)
 		r.With(customMiddleware.RequireScopedPermission("secrets.write", projectScope)).Post("/projects/{id}/restore", catalogHandler.RestoreProject)
+		r.With(customMiddleware.RequireScopedPermission("secrets.read", projectScope)).Get("/projects/{id}/drift", catalogHandler.GetProjectDrift)
 		// Project membership (ADR-021 two-tier model). Read = project members may
 		// view the roster; mutations require roles.assign at the project scope, so
 		// a project_admin can manage their own project's members.


### PR DESCRIPTION
## What & why

A cross-environment **drift detection** inspector: compares secret keys across a project's environments and surfaces the keys that drift. A secrets manager that tells an operator *"production is missing `STRIPE_KEY` that staging has"* or *"`JWT_SECRET` is a `password` in dev but an `api_key` in prod"* is a concrete config-safety / completeness signal — a common cause of failed deploys. **No secret values are read** — only presence and non-sensitive settings.

First of the M2 engineering items.

## Endpoint

`GET /api/v1/projects/{id}/drift` (scoped `secrets.read`):

```json
{
  "project_id": 1,
  "environments": [ {"id":1,"name":"development"}, {"id":2,"name":"staging"}, {"id":3,"name":"production"} ],
  "drifted_keys": [
    { "name":"JWT_SECRET", "present_in":[1,2,3], "missing_from":[], "status":"metadata_drift", "drift_fields":["type","max_reads"] },
    { "name":"STRIPE_KEY", "present_in":[1,2], "missing_from":[3], "status":"missing_in_some" }
  ],
  "summary": { "environment_count":3, "total_keys":3, "consistent_keys":1, "missing_in_some":1, "metadata_drift":1 }
}
```

Each key is classified **consistent** (present everywhere, settings agree — summarised, not listed), **missing_in_some** (present in some envs, absent in others), or **metadata_drift** (present everywhere but `type`/`expiration`/`max_reads` diverge). Fewer than two environments → no drift possible.

## Layers

- **storage** — `ListProjectSecretsForDrift`: one lightweight row per real secret (env id, name, type, has_expiration, has_max_reads) via a single aggregate query; folders and secrets in soft-deleted environments excluded; remote-mode stub.
- **core** — `DetectProjectDrift` pivots into a per-key × per-environment matrix and classifies; returns only drifted keys + a summary tally.
- **http** — the project-scoped route.

## Tests

- core: classification (consistent/missing/metadata), expiration+max_reads drift, single-environment (no drift); mock `ListEnvironmentsByProject` made expectation-driven.
- storage: projection excludes folders + secrets in soft-deleted envs, surfaces has_expiration/has_max_reads.
- Full `go test ./...` green; `gofmt`/`go vet` clean.

## Verified end-to-end

Ran the server (SQLite), seeded the default project's dev/staging/prod with: a key present+identical in all three (→ consistent), a key missing from prod (→ missing_in_some), and a key with type+max_reads divergence (→ metadata_drift). The endpoint classified all three correctly; 401 without auth.

## Follow-up

Frontend drift page in keyorix-web (paired PR, matching the usage/risk/rotation inspector pattern) — building next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)