### PR TITLE
feat(machine-auth): machine-token authentication + machine RBAC (ADR-030)

### DIFF
--- a/docs/adr-030-machine-token-authentication.md
+++ b/docs/adr-030-machine-token-authentication.md
@@ -1,0 +1,108 @@
+# ADR-030: Machine-token authentication + machine RBAC
+
+**Status:** Accepted
+**Date:** 2026-06-10
+**Context:** ADR-023 introduced machine identities (a `machine_identities` table,
+a lifecycle state machine, CLI, audit `actor_type`) but deferred the actual
+**authentication** path every time: a machine identity exists as a record but
+cannot sign in or call the API. This ADR closes that gap.
+
+## Context
+
+Human principals authenticate with session tokens or personal access tokens
+(ADR-027); a bearer token is hashed, looked up, and resolved to a `UserContext`
+carrying the user's roles, and `core.Authorize(userID, permission, scope)`
+gates every protected operation. Machine identities have none of this — no
+credential, no validation path, no way to be authorized.
+
+Two machine-auth modes are worth supporting:
+
+1. **Opaque bearer tokens** — issued by Keyorix, presented as `Authorization:
+   Bearer kx_machine_…`, validated by hash lookup. Mirrors the PAT path. Works
+   anywhere, no external dependency.
+2. **OIDC / Kubernetes projected service-account tokens** — a workload presents
+   a cluster-issued JWT, verified against the issuer's JWKS and mapped to a
+   machine identity by `(issuer, subject)`. No long-lived secret to distribute.
+
+**This ADR delivers mode 1 (opaque tokens) plus the machine-RBAC foundation
+both modes need.** Mode 2 (OIDC federation) is a follow-up (ADR-031) that reuses
+this foundation — it only adds a different way to *resolve a request to a
+machine principal*; issuance/authorization/audit are identical.
+
+## Decision
+
+### Credentials — `machine_identity_credentials`
+
+A new table holds hashed machine tokens (never plaintext), mirroring
+`personal_access_tokens`: `machine_identity_id`, `token_hash` (SHA-256 hex,
+unique), `token_prefix` (display, e.g. `kx_machine_ab12cd`), `expires_at`
+(nullable = non-expiring), `revoked`, `last_used_at`, `created_at`. Raw tokens
+are `kx_machine_` + base64url(32 random bytes), shown once at issuance. A machine
+may hold several active credentials (rotation).
+
+Issuance requires the machine to be in state `active`. Validation requires the
+credential to be un-revoked + unexpired **and** the machine still `active`, so
+suspending/revoking the identity instantly disables all its tokens.
+
+### Authorization — `machine_identity_roles` + actor-aware authorize
+
+Roles cannot be keyed to `user_id` for machines (id spaces overlap). A parallel
+grant table `machine_identity_roles` mirrors `user_roles`:
+`(machine_identity_id, role_id, project_id, environment_id)` composite PK, same
+0-sentinel global scope.
+
+Authorization is generalized to a **principal**: `AuthorizePrincipal(ctx,
+actorType, principalID, permission, scope)`. For `user` it is the existing
+logic; for `machine_identity` it resolves `machine_identity_roles` at scope
+(admin-role bypass deliberately does **not** apply to machines — a machine is
+never a global admin). `Authorize(userID, …)` is kept as a thin wrapper
+(`AuthorizePrincipal(ActorTypeUser, …)`) so every existing user call site is
+unchanged. The ~7 call sites that gate operations (the two permission
+middlewares + a handful of in-handler checks) switch to the principal form,
+reading actor type + principal id from the request context.
+
+### Request principal
+
+`UserContext` gains `ActorType` and `MachineIdentityID *uint`. For a machine
+request `UserID` is 0, `MachineIdentityID` is set, `Roles` carries the machine's
+granted roles, and the middleware tags the context `WithActorType(machine_identity)`
+so every audit event the request produces is correctly actored (ADR-023 plumbing,
+now finally exercised).
+
+### Middleware hook
+
+`validateToken` routes by prefix: `kx_machine_` → `ValidateMachineToken`
+(the new path), `kx_pat_` → PAT, else session. The machine path builds a
+machine `UserContext`. The token cache keys on the SHA-256 of the bearer, same
+as the others.
+
+### HTTP surface (under the existing project-scoped machine-identity group)
+
+- `POST   /projects/{id}/machine-identities/{machineId}/tokens` — issue (returns the raw token once)
+- `GET    /projects/{id}/machine-identities/{machineId}/tokens` — list (metadata only; never the token)
+- `DELETE /projects/{id}/machine-identities/{machineId}/tokens/{tokenId}` — revoke
+- `POST   /projects/{id}/machine-identities/{machineId}/roles` — grant a role at the project scope
+- `DELETE /projects/{id}/machine-identities/{machineId}/roles/{roleId}` — remove
+
+Issuance/role-management require `roles.assign` at the project scope (the same
+gate as human role assignment). Every mutation is audited
+(`machine_identity.token_issued` / `…token_revoked` / `…role_granted` /
+`…role_removed`).
+
+## Consequences
+
+- A CI/automation/K8s workload can now hold a Keyorix identity, be granted a
+  least-privilege project role (e.g. `project_viewer` to read deploy secrets),
+  and authenticate — the core ADR-023 promise, finally usable.
+- Machines get **no admin bypass** and are project-scoped by construction, so a
+  leaked machine token is bounded to its grants.
+- Suspending/revoking a machine identity disables all its tokens immediately
+  (validation re-checks machine state every request; the token cache TTL bounds
+  the window).
+- Blast radius is contained: `Authorize` stays source-compatible; only the gate
+  call sites become principal-aware.
+- **Out of scope (follow-up ADR-031):** OIDC/Kubernetes-JWT federation —
+  verifying an external cluster token against JWKS and mapping `(iss, sub)` to a
+  machine identity. It builds directly on this foundation (same credentials are
+  unnecessary; same `machine_identity_roles` + `AuthorizePrincipal` authorize
+  it; same audit actoring), so it is additive, not a rework.

--- a/internal/core/authz.go
+++ b/internal/core/authz.go
@@ -30,6 +30,27 @@ type Scope = storage.Scope
 // expected to be assigned at a project scope (bypasses within that project).
 var adminRoleNames = []string{"super_admin", "admin", "system_admin", "project_admin"}
 
+// AuthorizePrincipal reports whether a principal — a human user or a machine
+// identity (ADR-030) — may exercise permission against the target scope. It is
+// the actor-aware entrypoint the auth gates use; Authorize is the user-only
+// wrapper kept for source compatibility. Machine principals resolve their
+// permissions from machine_identity_roles and receive NO admin-role bypass: a
+// machine is never a global super-user, so a leaked machine token is bounded to
+// the permissions of its explicit grants. Fails closed.
+func (c *KeyorixCore) AuthorizePrincipal(ctx context.Context, actorType string, principalID uint, permission string, scope Scope) (bool, error) {
+	if actorType == ActorTypeMachine {
+		roleIDs, err := c.storage.GetMachineRoleIDsAt(ctx, principalID, scope)
+		if err != nil {
+			return false, err
+		}
+		if len(roleIDs) == 0 {
+			return false, nil
+		}
+		return c.storage.RoleSetHasPermission(ctx, roleIDs, permission)
+	}
+	return c.Authorize(ctx, principalID, permission, scope)
+}
+
 // Authorize reports whether userID may exercise permission (e.g. "secrets.read")
 // against the target scope. Fails closed: any resolution error returns
 // (false, err).

--- a/internal/core/machine_token.go
+++ b/internal/core/machine_token.go
@@ -1,0 +1,157 @@
+// machine_token.go — machine-identity authentication + RBAC (ADR-030).
+//
+// Machine identities (ADR-023) can now hold opaque bearer tokens and be granted
+// project-scoped roles, so a CI/automation/Kubernetes workload can authenticate
+// to the API as a least-privilege principal. Tokens mirror personal access
+// tokens (hashed at rest, kx_machine_ prefix); role grants mirror user_roles.
+package core
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+const (
+	machineTokenPrefix = "kx_machine_"
+	// machineTouchInterval throttles last_used_at writes on the auth hot path.
+	machineTouchInterval = 30 * time.Second
+)
+
+// IssueMachineTokenResult carries the freshly minted token. PlainToken is shown
+// once and never persisted (only its hash is stored).
+type IssueMachineTokenResult struct {
+	Credential *models.MachineIdentityCredential
+	PlainToken string
+}
+
+// IssueMachineToken mints an opaque bearer token for an active machine identity.
+// The raw token is returned once for out-of-band delivery; only its SHA-256 hash
+// is stored. Issuing requires the machine to be active.
+func (c *KeyorixCore) IssueMachineToken(ctx context.Context, machineID uint, name string, expiresAt *time.Time, actorID uint) (*IssueMachineTokenResult, error) {
+	m, err := c.storage.GetMachineIdentity(ctx, machineID)
+	if err != nil {
+		return nil, fmt.Errorf("machine identity not found")
+	}
+	if m.State != MachineActive {
+		return nil, fmt.Errorf("cannot issue a token for a %s machine identity (must be active)", m.State)
+	}
+
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return nil, fmt.Errorf("failed to generate token: %w", err)
+	}
+	raw := machineTokenPrefix + base64.RawURLEncoding.EncodeToString(b)
+
+	cred := &models.MachineIdentityCredential{
+		MachineIdentityID: machineID,
+		Name:              strings.TrimSpace(name),
+		TokenHash:         sha256Hex(raw),
+		TokenPrefix:       raw[:len(machineTokenPrefix)+6], // "kx_machine_ab12cd"
+		ExpiresAt:         expiresAt,
+		CreatedAt:         c.now(),
+	}
+	created, err := c.storage.CreateMachineIdentityCredential(ctx, cred)
+	if err != nil {
+		return nil, fmt.Errorf("failed to store machine token: %w", err)
+	}
+	c.logMachineEvent(ctx, "machine_identity.token_issued", m, actorID)
+	return &IssueMachineTokenResult{Credential: created, PlainToken: raw}, nil
+}
+
+// ListMachineTokens returns a machine's credentials (hashes are never exposed by the DTO).
+func (c *KeyorixCore) ListMachineTokens(ctx context.Context, machineID uint) ([]*models.MachineIdentityCredential, error) {
+	return c.storage.ListMachineIdentityCredentials(ctx, machineID)
+}
+
+// RevokeMachineToken revokes one credential after verifying it belongs to the machine.
+func (c *KeyorixCore) RevokeMachineToken(ctx context.Context, machineID, credentialID, actorID uint) error {
+	cred, err := c.storage.GetMachineIdentityCredentialByID(ctx, credentialID)
+	if err != nil || cred.MachineIdentityID != machineID {
+		return fmt.Errorf("token not found")
+	}
+	if err := c.storage.RevokeMachineIdentityCredential(ctx, credentialID); err != nil {
+		return err
+	}
+	if m, err := c.storage.GetMachineIdentity(ctx, machineID); err == nil {
+		c.logMachineEvent(ctx, "machine_identity.token_revoked", m, actorID)
+	}
+	return nil
+}
+
+// ValidateMachineToken resolves a raw machine token to its identity and granted
+// role names. It rejects revoked/expired credentials and any machine not in the
+// active state, and best-effort throttled-updates last_used_at. The middleware
+// gates on the machineTokenPrefix before calling this.
+func (c *KeyorixCore) ValidateMachineToken(ctx context.Context, raw string) (*models.MachineIdentity, []string, error) {
+	if !strings.HasPrefix(raw, machineTokenPrefix) {
+		return nil, nil, fmt.Errorf("not a machine token")
+	}
+	cred, err := c.storage.GetMachineIdentityCredentialByHash(ctx, sha256Hex(raw))
+	if err != nil {
+		return nil, nil, fmt.Errorf("invalid token")
+	}
+	if cred.Revoked {
+		return nil, nil, fmt.Errorf("token revoked")
+	}
+	if cred.ExpiresAt != nil && c.now().After(*cred.ExpiresAt) {
+		return nil, nil, fmt.Errorf("token expired")
+	}
+	m, err := c.storage.GetMachineIdentity(ctx, cred.MachineIdentityID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("machine identity not found")
+	}
+	if m.State != MachineActive {
+		return nil, nil, fmt.Errorf("machine identity is %s", m.State)
+	}
+
+	// Best-effort, throttled last-used stamp — never fails the request.
+	_ = c.storage.TouchMachineIdentityCredential(ctx, cred.ID, c.now(), machineTouchInterval)
+
+	roles, err := c.storage.GetMachineRoles(ctx, m.ID)
+	if err != nil {
+		return m, []string{}, nil
+	}
+	roleNames := make([]string, len(roles))
+	for i, r := range roles {
+		roleNames[i] = r.Name
+	}
+	return m, roleNames, nil
+}
+
+// AssignMachineRole grants a role to a machine identity at the given scope and
+// audits it. The caller (handler) gates on roles.assign at the project scope.
+func (c *KeyorixCore) AssignMachineRole(ctx context.Context, machineID, roleID uint, scope Scope, actorID uint) error {
+	m, err := c.storage.GetMachineIdentity(ctx, machineID)
+	if err != nil {
+		return fmt.Errorf("machine identity not found")
+	}
+	if err := c.storage.AssignMachineRole(ctx, machineID, roleID, scope); err != nil {
+		return err
+	}
+	c.logMachineEvent(ctx, "machine_identity.role_granted", m, actorID)
+	return nil
+}
+
+// RemoveMachineRole revokes a machine identity's role grant at the given scope.
+func (c *KeyorixCore) RemoveMachineRole(ctx context.Context, machineID, roleID uint, scope Scope, actorID uint) error {
+	m, err := c.storage.GetMachineIdentity(ctx, machineID)
+	if err != nil {
+		return fmt.Errorf("machine identity not found")
+	}
+	if err := c.storage.RemoveMachineRole(ctx, machineID, roleID, scope); err != nil {
+		return err
+	}
+	c.logMachineEvent(ctx, "machine_identity.role_removed", m, actorID)
+	return nil
+}
+
+// ListMachineRoles returns every role granted to a machine identity (for display).
+func (c *KeyorixCore) ListMachineRoles(ctx context.Context, machineID uint) ([]*models.Role, error) {
+	return c.storage.GetMachineRoles(ctx, machineID)
+}

--- a/internal/core/machine_token.go
+++ b/internal/core/machine_token.go
@@ -30,13 +30,27 @@ type IssueMachineTokenResult struct {
 	PlainToken string
 }
 
+// machineInProject fetches a machine identity and verifies it belongs to the
+// given project. Every project-scoped machine operation goes through here so a
+// caller authorized at project A cannot act on a machine in project B by passing
+// its id in the path (the route gate only proves rights at the path's project).
+// A project mismatch is reported as "not found" to avoid cross-project id
+// enumeration.
+func (c *KeyorixCore) machineInProject(ctx context.Context, projectID, machineID uint) (*models.MachineIdentity, error) {
+	m, err := c.storage.GetMachineIdentity(ctx, machineID)
+	if err != nil || m.ProjectID != projectID {
+		return nil, fmt.Errorf("machine identity not found")
+	}
+	return m, nil
+}
+
 // IssueMachineToken mints an opaque bearer token for an active machine identity.
 // The raw token is returned once for out-of-band delivery; only its SHA-256 hash
-// is stored. Issuing requires the machine to be active.
-func (c *KeyorixCore) IssueMachineToken(ctx context.Context, machineID uint, name string, expiresAt *time.Time, actorID uint) (*IssueMachineTokenResult, error) {
-	m, err := c.storage.GetMachineIdentity(ctx, machineID)
+// is stored. Issuing requires the machine to be active and in the given project.
+func (c *KeyorixCore) IssueMachineToken(ctx context.Context, projectID, machineID uint, name string, expiresAt *time.Time, actorID uint) (*IssueMachineTokenResult, error) {
+	m, err := c.machineInProject(ctx, projectID, machineID)
 	if err != nil {
-		return nil, fmt.Errorf("machine identity not found")
+		return nil, err
 	}
 	if m.State != MachineActive {
 		return nil, fmt.Errorf("cannot issue a token for a %s machine identity (must be active)", m.State)
@@ -64,13 +78,22 @@ func (c *KeyorixCore) IssueMachineToken(ctx context.Context, machineID uint, nam
 	return &IssueMachineTokenResult{Credential: created, PlainToken: raw}, nil
 }
 
-// ListMachineTokens returns a machine's credentials (hashes are never exposed by the DTO).
-func (c *KeyorixCore) ListMachineTokens(ctx context.Context, machineID uint) ([]*models.MachineIdentityCredential, error) {
+// ListMachineTokens returns a machine's credentials (hashes are never exposed by
+// the DTO), after verifying the machine belongs to the project.
+func (c *KeyorixCore) ListMachineTokens(ctx context.Context, projectID, machineID uint) ([]*models.MachineIdentityCredential, error) {
+	if _, err := c.machineInProject(ctx, projectID, machineID); err != nil {
+		return nil, err
+	}
 	return c.storage.ListMachineIdentityCredentials(ctx, machineID)
 }
 
-// RevokeMachineToken revokes one credential after verifying it belongs to the machine.
-func (c *KeyorixCore) RevokeMachineToken(ctx context.Context, machineID, credentialID, actorID uint) error {
+// RevokeMachineToken revokes one credential after verifying the machine belongs
+// to the project and the credential belongs to the machine.
+func (c *KeyorixCore) RevokeMachineToken(ctx context.Context, projectID, machineID, credentialID, actorID uint) error {
+	m, err := c.machineInProject(ctx, projectID, machineID)
+	if err != nil {
+		return err
+	}
 	cred, err := c.storage.GetMachineIdentityCredentialByID(ctx, credentialID)
 	if err != nil || cred.MachineIdentityID != machineID {
 		return fmt.Errorf("token not found")
@@ -78,9 +101,7 @@ func (c *KeyorixCore) RevokeMachineToken(ctx context.Context, machineID, credent
 	if err := c.storage.RevokeMachineIdentityCredential(ctx, credentialID); err != nil {
 		return err
 	}
-	if m, err := c.storage.GetMachineIdentity(ctx, machineID); err == nil {
-		c.logMachineEvent(ctx, "machine_identity.token_revoked", m, actorID)
-	}
+	c.logMachineEvent(ctx, "machine_identity.token_revoked", m, actorID)
 	return nil
 }
 
@@ -125,11 +146,13 @@ func (c *KeyorixCore) ValidateMachineToken(ctx context.Context, raw string) (*mo
 }
 
 // AssignMachineRole grants a role to a machine identity at the given scope and
-// audits it. The caller (handler) gates on roles.assign at the project scope.
+// audits it. The machine must belong to scope.ProjectID — the caller is only
+// proven to hold roles.assign at that project, so a machine in another project
+// must not be reachable through this path.
 func (c *KeyorixCore) AssignMachineRole(ctx context.Context, machineID, roleID uint, scope Scope, actorID uint) error {
-	m, err := c.storage.GetMachineIdentity(ctx, machineID)
+	m, err := c.machineInProject(ctx, scope.ProjectID, machineID)
 	if err != nil {
-		return fmt.Errorf("machine identity not found")
+		return err
 	}
 	if err := c.storage.AssignMachineRole(ctx, machineID, roleID, scope); err != nil {
 		return err
@@ -140,9 +163,9 @@ func (c *KeyorixCore) AssignMachineRole(ctx context.Context, machineID, roleID u
 
 // RemoveMachineRole revokes a machine identity's role grant at the given scope.
 func (c *KeyorixCore) RemoveMachineRole(ctx context.Context, machineID, roleID uint, scope Scope, actorID uint) error {
-	m, err := c.storage.GetMachineIdentity(ctx, machineID)
+	m, err := c.machineInProject(ctx, scope.ProjectID, machineID)
 	if err != nil {
-		return fmt.Errorf("machine identity not found")
+		return err
 	}
 	if err := c.storage.RemoveMachineRole(ctx, machineID, roleID, scope); err != nil {
 		return err
@@ -151,7 +174,11 @@ func (c *KeyorixCore) RemoveMachineRole(ctx context.Context, machineID, roleID u
 	return nil
 }
 
-// ListMachineRoles returns every role granted to a machine identity (for display).
-func (c *KeyorixCore) ListMachineRoles(ctx context.Context, machineID uint) ([]*models.Role, error) {
+// ListMachineRoles returns every role granted to a machine identity in the
+// given project (for display), after verifying the machine belongs to it.
+func (c *KeyorixCore) ListMachineRoles(ctx context.Context, projectID, machineID uint) ([]*models.Role, error) {
+	if _, err := c.machineInProject(ctx, projectID, machineID); err != nil {
+		return nil, err
+	}
 	return c.storage.GetMachineRoles(ctx, machineID)
 }

--- a/internal/core/machine_token_test.go
+++ b/internal/core/machine_token_test.go
@@ -1,0 +1,132 @@
+package core
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIssueMachineToken_ActiveOnly(t *testing.T) {
+	store := new(MockStorage)
+	fixed := time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)
+
+	// Suspended machine → refused.
+	store.On("GetMachineIdentity", mock.Anything, uint(1)).Return(&models.MachineIdentity{ID: 1, ProjectID: 2, State: MachineSuspended}, nil).Once()
+	c := NewKeyorixCore(store)
+	c.now = func() time.Time { return fixed }
+	_, err := c.IssueMachineToken(context.Background(), 1, "ci", nil, 7)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "must be active")
+
+	// Active machine → token minted with the kx_machine_ prefix, hash stored.
+	store.On("GetMachineIdentity", mock.Anything, uint(1)).Return(&models.MachineIdentity{ID: 1, ProjectID: 2, State: MachineActive}, nil)
+	store.On("CreateMachineIdentityCredential", mock.Anything, mock.AnythingOfType("*models.MachineIdentityCredential")).
+		Return(&models.MachineIdentityCredential{ID: 5}, nil)
+	store.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
+
+	res, err := c.IssueMachineToken(context.Background(), 1, "ci", nil, 7)
+	require.NoError(t, err)
+	require.True(t, strings.HasPrefix(res.PlainToken, "kx_machine_"))
+
+	// The stored credential carries only the hash, never the raw token.
+	var created *models.MachineIdentityCredential
+	for _, call := range store.Calls {
+		if call.Method == "CreateMachineIdentityCredential" {
+			created = call.Arguments.Get(1).(*models.MachineIdentityCredential)
+		}
+	}
+	require.NotNil(t, created)
+	require.NotEmpty(t, created.TokenHash)
+	require.NotEqual(t, res.PlainToken, created.TokenHash)
+	require.Equal(t, sha256Hex(res.PlainToken), created.TokenHash)
+}
+
+func TestValidateMachineToken(t *testing.T) {
+	fixed := time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)
+	raw := "kx_machine_abc"
+	hash := sha256Hex(raw)
+
+	t.Run("valid active machine resolves roles", func(t *testing.T) {
+		store := new(MockStorage)
+		store.On("GetMachineIdentityCredentialByHash", mock.Anything, hash).Return(&models.MachineIdentityCredential{ID: 5, MachineIdentityID: 1}, nil)
+		store.On("GetMachineIdentity", mock.Anything, uint(1)).Return(&models.MachineIdentity{ID: 1, Name: "ci", State: MachineActive}, nil)
+		store.On("GetMachineRoles", mock.Anything, uint(1)).Return([]*models.Role{{Name: "project_viewer"}}, nil)
+		c := NewKeyorixCore(store)
+		c.now = func() time.Time { return fixed }
+
+		m, roles, err := c.ValidateMachineToken(context.Background(), raw)
+		require.NoError(t, err)
+		require.Equal(t, uint(1), m.ID)
+		require.Equal(t, []string{"project_viewer"}, roles)
+	})
+
+	t.Run("revoked credential rejected", func(t *testing.T) {
+		store := new(MockStorage)
+		store.On("GetMachineIdentityCredentialByHash", mock.Anything, hash).Return(&models.MachineIdentityCredential{ID: 5, MachineIdentityID: 1, Revoked: true}, nil)
+		c := NewKeyorixCore(store)
+		c.now = func() time.Time { return fixed }
+		_, _, err := c.ValidateMachineToken(context.Background(), raw)
+		require.ErrorContains(t, err, "revoked")
+	})
+
+	t.Run("expired credential rejected", func(t *testing.T) {
+		past := fixed.Add(-time.Hour)
+		store := new(MockStorage)
+		store.On("GetMachineIdentityCredentialByHash", mock.Anything, hash).Return(&models.MachineIdentityCredential{ID: 5, MachineIdentityID: 1, ExpiresAt: &past}, nil)
+		c := NewKeyorixCore(store)
+		c.now = func() time.Time { return fixed }
+		_, _, err := c.ValidateMachineToken(context.Background(), raw)
+		require.ErrorContains(t, err, "expired")
+	})
+
+	t.Run("suspended machine disables its tokens", func(t *testing.T) {
+		store := new(MockStorage)
+		store.On("GetMachineIdentityCredentialByHash", mock.Anything, hash).Return(&models.MachineIdentityCredential{ID: 5, MachineIdentityID: 1}, nil)
+		store.On("GetMachineIdentity", mock.Anything, uint(1)).Return(&models.MachineIdentity{ID: 1, State: MachineSuspended}, nil)
+		c := NewKeyorixCore(store)
+		c.now = func() time.Time { return fixed }
+		_, _, err := c.ValidateMachineToken(context.Background(), raw)
+		require.ErrorContains(t, err, "suspended")
+	})
+}
+
+func TestAuthorizePrincipal_Machine(t *testing.T) {
+	scope := Scope{ProjectID: 2}
+
+	t.Run("granted role permits", func(t *testing.T) {
+		store := new(MockStorage)
+		store.On("GetMachineRoleIDsAt", mock.Anything, uint(1), scope).Return([]uint{7}, nil)
+		store.On("RoleSetHasPermission", mock.Anything, []uint{7}, "secrets.read").Return(true, nil)
+		c := NewKeyorixCore(store)
+		ok, err := c.AuthorizePrincipal(context.Background(), ActorTypeMachine, 1, "secrets.read", scope)
+		require.NoError(t, err)
+		require.True(t, ok)
+	})
+
+	t.Run("no grant denies", func(t *testing.T) {
+		store := new(MockStorage)
+		store.On("GetMachineRoleIDsAt", mock.Anything, uint(1), scope).Return([]uint{}, nil)
+		c := NewKeyorixCore(store)
+		ok, err := c.AuthorizePrincipal(context.Background(), ActorTypeMachine, 1, "secrets.read", scope)
+		require.NoError(t, err)
+		require.False(t, ok)
+	})
+
+	t.Run("no admin bypass for machines", func(t *testing.T) {
+		// Even if a machine somehow holds an admin-named role, AuthorizePrincipal
+		// goes straight to the permission check (never the admin short-circuit),
+		// so a permission the role lacks is denied.
+		store := new(MockStorage)
+		store.On("GetMachineRoleIDsAt", mock.Anything, uint(1), scope).Return([]uint{99}, nil)
+		store.On("RoleSetHasPermission", mock.Anything, []uint{99}, "users.write").Return(false, nil)
+		c := NewKeyorixCore(store)
+		ok, err := c.AuthorizePrincipal(context.Background(), ActorTypeMachine, 1, "users.write", scope)
+		require.NoError(t, err)
+		require.False(t, ok, "machines never get the admin-role bypass")
+	})
+}

--- a/internal/core/machine_token_test.go
+++ b/internal/core/machine_token_test.go
@@ -19,9 +19,14 @@ func TestIssueMachineToken_ActiveOnly(t *testing.T) {
 	store.On("GetMachineIdentity", mock.Anything, uint(1)).Return(&models.MachineIdentity{ID: 1, ProjectID: 2, State: MachineSuspended}, nil).Once()
 	c := NewKeyorixCore(store)
 	c.now = func() time.Time { return fixed }
-	_, err := c.IssueMachineToken(context.Background(), 1, "ci", nil, 7)
+	_, err := c.IssueMachineToken(context.Background(), 2, 1, "ci", nil, 7)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "must be active")
+
+	// Wrong project → not found (cross-project IDOR guard).
+	store.On("GetMachineIdentity", mock.Anything, uint(1)).Return(&models.MachineIdentity{ID: 1, ProjectID: 2, State: MachineActive}, nil)
+	_, err = c.IssueMachineToken(context.Background(), 999, 1, "ci", nil, 7)
+	require.ErrorContains(t, err, "not found")
 
 	// Active machine → token minted with the kx_machine_ prefix, hash stored.
 	store.On("GetMachineIdentity", mock.Anything, uint(1)).Return(&models.MachineIdentity{ID: 1, ProjectID: 2, State: MachineActive}, nil)
@@ -29,7 +34,7 @@ func TestIssueMachineToken_ActiveOnly(t *testing.T) {
 		Return(&models.MachineIdentityCredential{ID: 5}, nil)
 	store.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
 
-	res, err := c.IssueMachineToken(context.Background(), 1, "ci", nil, 7)
+	res, err := c.IssueMachineToken(context.Background(), 2, 1, "ci", nil, 7)
 	require.NoError(t, err)
 	require.True(t, strings.HasPrefix(res.PlainToken, "kx_machine_"))
 

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -983,6 +983,79 @@ func (m *MockStorage) ListMachineIdentities(ctx context.Context, projectID uint)
 	return args.Get(0).([]*models.MachineIdentity), args.Error(1)
 }
 
+func (m *MockStorage) CreateMachineIdentityCredential(ctx context.Context, c *models.MachineIdentityCredential) (*models.MachineIdentityCredential, error) {
+	args := m.Called(ctx, c)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.MachineIdentityCredential), args.Error(1)
+}
+
+func (m *MockStorage) GetMachineIdentityCredentialByHash(ctx context.Context, hash string) (*models.MachineIdentityCredential, error) {
+	args := m.Called(ctx, hash)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.MachineIdentityCredential), args.Error(1)
+}
+
+func (m *MockStorage) GetMachineIdentityCredentialByID(ctx context.Context, id uint) (*models.MachineIdentityCredential, error) {
+	args := m.Called(ctx, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.MachineIdentityCredential), args.Error(1)
+}
+
+func (m *MockStorage) ListMachineIdentityCredentials(ctx context.Context, machineID uint) ([]*models.MachineIdentityCredential, error) {
+	args := m.Called(ctx, machineID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*models.MachineIdentityCredential), args.Error(1)
+}
+
+func (m *MockStorage) RevokeMachineIdentityCredential(ctx context.Context, id uint) error {
+	args := m.Called(ctx, id)
+	return args.Error(0)
+}
+
+func (m *MockStorage) TouchMachineIdentityCredential(ctx context.Context, id uint, usedAt time.Time, staleness time.Duration) error {
+	// Best-effort on the auth hot path — tolerate tests that don't set an expectation.
+	for _, c := range m.ExpectedCalls {
+		if c.Method == "TouchMachineIdentityCredential" {
+			return m.Called(ctx, id, usedAt, staleness).Error(0)
+		}
+	}
+	return nil
+}
+
+func (m *MockStorage) AssignMachineRole(ctx context.Context, machineID, roleID uint, scope storage.Scope) error {
+	args := m.Called(ctx, machineID, roleID, scope)
+	return args.Error(0)
+}
+
+func (m *MockStorage) RemoveMachineRole(ctx context.Context, machineID, roleID uint, scope storage.Scope) error {
+	args := m.Called(ctx, machineID, roleID, scope)
+	return args.Error(0)
+}
+
+func (m *MockStorage) GetMachineRoleIDsAt(ctx context.Context, machineID uint, scope storage.Scope) ([]uint, error) {
+	args := m.Called(ctx, machineID, scope)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]uint), args.Error(1)
+}
+
+func (m *MockStorage) GetMachineRoles(ctx context.Context, machineID uint) ([]*models.Role, error) {
+	args := m.Called(ctx, machineID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*models.Role), args.Error(1)
+}
+
 // Project membership lifecycle (ADR-022).
 func (m *MockStorage) CreateProjectMembership(ctx context.Context, pm *models.ProjectMembership) (*models.ProjectMembership, error) {
 	args := m.Called(ctx, pm)

--- a/internal/core/secret_listing_query.go
+++ b/internal/core/secret_listing_query.go
@@ -14,6 +14,61 @@ import (
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
+// ListSecretsInScope lists every secret in the filter's project/environment
+// scope, with no per-user ownership or sharing resolution. It backs machine
+// principals (ADR-030), which have no user identity and whose authorization to
+// the scope is already enforced by the route's scoped-permission gate. The
+// response shape matches ListSecretsWithSharingInfo so the handler is uniform;
+// the sharing fields are owner-agnostic (a machine does not "own" or have
+// secrets "shared with" it).
+func (c *KeyorixCore) ListSecretsInScope(ctx context.Context, filter *models.SecretListFilter) (*models.SecretListResponse, error) {
+	if filter == nil {
+		filter = &models.SecretListFilter{}
+	}
+	storageFilter := c.convertToStorageFilter(filter)
+	secrets, _, err := c.storage.ListSecrets(ctx, storageFilter)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+
+	all := make([]*models.SecretWithSharingInfo, 0, len(secrets))
+	for _, secret := range secrets {
+		all = append(all, &models.SecretWithSharingInfo{SecretNode: secret})
+	}
+	all = c.applySecretFilters(all, filter)
+	c.sortSecrets(all, filter.SortBy, filter.SortOrder)
+
+	total := int64(len(all))
+	page := filter.Page
+	if page < 1 {
+		page = 1
+	}
+	pageSize := filter.PageSize
+	if pageSize < 1 {
+		pageSize = 20
+	}
+	start := (page - 1) * pageSize
+	end := start + pageSize
+	totalInt := int(total)
+	if start > totalInt {
+		start = totalInt
+	}
+	if end > totalInt {
+		end = totalInt
+	}
+	totalPages := (totalInt + pageSize - 1) / pageSize
+	if totalPages == 0 {
+		totalPages = 1
+	}
+	return &models.SecretListResponse{
+		Secrets:    all[start:end],
+		Total:      total,
+		Page:       page,
+		PageSize:   pageSize,
+		TotalPages: totalPages,
+	}, nil
+}
+
 // ListSecretsWithSharingInfo lists secrets with sharing information for a specific user.
 func (c *KeyorixCore) ListSecretsWithSharingInfo(ctx context.Context, userID uint, filter *models.SecretListFilter) (*models.SecretListResponse, error) {
 	if filter == nil {

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -45,6 +45,20 @@ type Storage interface {
 	UpdateMachineIdentity(ctx context.Context, m *models.MachineIdentity) error
 	ListMachineIdentities(ctx context.Context, projectID uint) ([]*models.MachineIdentity, error)
 
+	// Machine-token credentials (ADR-030) — opaque bearer tokens, hashed at rest.
+	CreateMachineIdentityCredential(ctx context.Context, c *models.MachineIdentityCredential) (*models.MachineIdentityCredential, error)
+	GetMachineIdentityCredentialByHash(ctx context.Context, hash string) (*models.MachineIdentityCredential, error)
+	GetMachineIdentityCredentialByID(ctx context.Context, id uint) (*models.MachineIdentityCredential, error)
+	ListMachineIdentityCredentials(ctx context.Context, machineID uint) ([]*models.MachineIdentityCredential, error)
+	RevokeMachineIdentityCredential(ctx context.Context, id uint) error
+	TouchMachineIdentityCredential(ctx context.Context, id uint, usedAt time.Time, staleness time.Duration) error
+
+	// Machine-identity role grants (ADR-030) — mirror the user_roles surface.
+	AssignMachineRole(ctx context.Context, machineID, roleID uint, scope Scope) error
+	RemoveMachineRole(ctx context.Context, machineID, roleID uint, scope Scope) error
+	GetMachineRoleIDsAt(ctx context.Context, machineID uint, scope Scope) ([]uint, error)
+	GetMachineRoles(ctx context.Context, machineID uint) ([]*models.Role, error)
+
 	// Project membership lifecycle (ADR-022). Separate from the role grant.
 	CreateProjectMembership(ctx context.Context, m *models.ProjectMembership) (*models.ProjectMembership, error)
 	GetProjectMembership(ctx context.Context, id uint) (*models.ProjectMembership, error)

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -245,6 +245,8 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 	accessReqExists := tableExists(db, "access_requests")
 	pwHistExists := tableExists(db, "password_histories")
 	machineExists := tableExists(db, "machine_identities")
+	machineCredExists := tableExists(db, "machine_identity_credentials")
+	machineRoleExists := tableExists(db, "machine_identity_roles")
 	membershipExists := tableExists(db, "project_memberships")
 	setupTokenExists := tableExists(db, "setup_tokens")
 	notificationsExists := tableExists(db, "notifications")
@@ -297,6 +299,18 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 	if !machineExists {
 		if err := db.AutoMigrate(&models.MachineIdentity{}); err != nil {
 			return fmt.Errorf("failed to migrate machine_identities table: %w", err)
+		}
+	}
+
+	// Create machine-token tables if missing (ADR-030, additive, safe on existing DBs).
+	if !machineCredExists {
+		if err := db.AutoMigrate(&models.MachineIdentityCredential{}); err != nil {
+			return fmt.Errorf("failed to migrate machine_identity_credentials table: %w", err)
+		}
+	}
+	if !machineRoleExists {
+		if err := db.AutoMigrate(&models.MachineIdentityRole{}); err != nil {
+			return fmt.Errorf("failed to migrate machine_identity_roles table: %w", err)
 		}
 	}
 

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -517,6 +517,34 @@ type MachineIdentity struct {
 	RevokedAt    *time.Time
 }
 
+// MachineIdentityCredential is an opaque bearer token a machine identity uses to
+// authenticate (ADR-030), mirroring PersonalAccessToken. Only the SHA-256 hash
+// is stored — the raw `kx_machine_…` token is shown once at issuance. A machine
+// may hold several active credentials (rotation). A credential is usable only
+// while un-revoked, unexpired, AND its machine identity is still `active`.
+type MachineIdentityCredential struct {
+	ID                uint   `gorm:"primaryKey"`
+	MachineIdentityID uint   `gorm:"index;not null"`
+	Name              string // operator-facing label
+	TokenHash         string `gorm:"uniqueIndex;not null"` // SHA-256 hex (never the plaintext)
+	TokenPrefix       string `gorm:"index"`                // leading chars for display ("kx_machine_ab12cd")
+	LastUsedAt        *time.Time
+	ExpiresAt         *time.Time // nil = never expires
+	Revoked           bool       `gorm:"default:false"`
+	CreatedAt         time.Time
+}
+
+// MachineIdentityRole grants a role to a machine identity at a project/
+// environment scope (ADR-030), mirroring UserRole. 0 = global scope. Machine
+// principals never receive an admin-role bypass, so a leaked machine token is
+// bounded to the permissions of its granted roles.
+type MachineIdentityRole struct {
+	MachineIdentityID uint `gorm:"primaryKey"`
+	RoleID            uint `gorm:"primaryKey"`
+	ProjectID         uint `gorm:"primaryKey;not null;default:0"`
+	EnvironmentID     uint `gorm:"primaryKey;not null;default:0"`
+}
+
 // ProjectMembership tracks the onboarding lifecycle of a user into a project
 // (ADR-022), separate from the actual role grant (user_roles). It carries a
 // 5-state machine: invited → identity_verified → provisioned → active, with

--- a/internal/storage/store/local_machine_credentials.go
+++ b/internal/storage/store/local_machine_credentials.go
@@ -1,0 +1,138 @@
+// local_machine_credentials.go — machine-token credentials + machine role grants
+// (ADR-030). Credentials mirror personal_access_tokens; role grants mirror
+// user_roles. For the remote (HTTP) equivalent see remote_machine_identities.go.
+package store
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"gorm.io/gorm"
+)
+
+// --- Machine-token credentials ---
+
+func (ls *LocalStorage) CreateMachineIdentityCredential(ctx context.Context, c *models.MachineIdentityCredential) (*models.MachineIdentityCredential, error) {
+	if err := ls.db.WithContext(ctx).Create(c).Error; err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	return c, nil
+}
+
+func (ls *LocalStorage) GetMachineIdentityCredentialByHash(ctx context.Context, hash string) (*models.MachineIdentityCredential, error) {
+	var c models.MachineIdentityCredential
+	if err := ls.db.WithContext(ctx).Where("token_hash = ?", hash).First(&c).Error; err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorNotFound", nil), err)
+	}
+	return &c, nil
+}
+
+func (ls *LocalStorage) GetMachineIdentityCredentialByID(ctx context.Context, id uint) (*models.MachineIdentityCredential, error) {
+	var c models.MachineIdentityCredential
+	if err := ls.db.WithContext(ctx).First(&c, id).Error; err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorNotFound", nil), err)
+	}
+	return &c, nil
+}
+
+func (ls *LocalStorage) ListMachineIdentityCredentials(ctx context.Context, machineID uint) ([]*models.MachineIdentityCredential, error) {
+	var rows []*models.MachineIdentityCredential
+	err := ls.db.WithContext(ctx).
+		Where("machine_identity_id = ?", machineID).
+		Order("created_at DESC").
+		Find(&rows).Error
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	return rows, nil
+}
+
+func (ls *LocalStorage) RevokeMachineIdentityCredential(ctx context.Context, id uint) error {
+	result := ls.db.WithContext(ctx).Model(&models.MachineIdentityCredential{}).
+		Where("id = ?", id).UpdateColumn("revoked", true)
+	if result.Error != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), result.Error)
+	}
+	if result.RowsAffected == 0 {
+		return fmt.Errorf("%s", i18n.T("ErrorNotFound", nil))
+	}
+	return nil
+}
+
+func (ls *LocalStorage) TouchMachineIdentityCredential(ctx context.Context, id uint, usedAt time.Time, staleness time.Duration) error {
+	cutoff := usedAt.Add(-staleness)
+	return ls.db.WithContext(ctx).Model(&models.MachineIdentityCredential{}).
+		Where("id = ? AND (last_used_at IS NULL OR last_used_at < ?)", id, cutoff).
+		UpdateColumn("last_used_at", usedAt).Error
+}
+
+// --- Machine role grants ---
+
+func (ls *LocalStorage) AssignMachineRole(ctx context.Context, machineID, roleID uint, scope storage.Scope) error {
+	var existing models.MachineIdentityRole
+	err := ls.db.WithContext(ctx).
+		Where("machine_identity_id = ? AND role_id = ? AND project_id = ? AND environment_id = ?",
+			machineID, roleID, scope.ProjectID, scope.EnvironmentID).First(&existing).Error
+	if err == nil {
+		return fmt.Errorf("%s", i18n.T("ErrorRoleAlreadyAssigned", nil))
+	}
+	if err != gorm.ErrRecordNotFound {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorInternalServer", nil), err)
+	}
+	grant := models.MachineIdentityRole{
+		MachineIdentityID: machineID,
+		RoleID:            roleID,
+		ProjectID:         scope.ProjectID,
+		EnvironmentID:     scope.EnvironmentID,
+	}
+	if err := ls.db.WithContext(ctx).Create(&grant).Error; err != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	return nil
+}
+
+func (ls *LocalStorage) RemoveMachineRole(ctx context.Context, machineID, roleID uint, scope storage.Scope) error {
+	result := ls.db.WithContext(ctx).
+		Where("machine_identity_id = ? AND role_id = ? AND project_id = ? AND environment_id = ?",
+			machineID, roleID, scope.ProjectID, scope.EnvironmentID).Delete(&models.MachineIdentityRole{})
+	if result.Error != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), result.Error)
+	}
+	if result.RowsAffected == 0 {
+		return fmt.Errorf("%s", i18n.T("ErrorRoleNotAssigned", nil))
+	}
+	return nil
+}
+
+// GetMachineRoleIDsAt returns the role IDs granted to the machine that apply at
+// the target scope — a grant applies when its project is global or equal AND its
+// environment is global or equal (mirrors GetUserRoleIDsAt).
+func (ls *LocalStorage) GetMachineRoleIDsAt(ctx context.Context, machineID uint, scope storage.Scope) ([]uint, error) {
+	var ids []uint
+	err := ls.db.WithContext(ctx).Model(&models.MachineIdentityRole{}).
+		Where("machine_identity_id = ?", machineID).
+		Where("project_id = 0 OR project_id = ?", scope.ProjectID).
+		Where("environment_id = 0 OR environment_id = ?", scope.EnvironmentID).
+		Distinct().Pluck("role_id", &ids).Error
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	return ids, nil
+}
+
+// GetMachineRoles returns every role granted to the machine (any scope), for display.
+func (ls *LocalStorage) GetMachineRoles(ctx context.Context, machineID uint) ([]*models.Role, error) {
+	var roles []*models.Role
+	err := ls.db.WithContext(ctx).Table("roles").
+		Joins("JOIN machine_identity_roles ON roles.id = machine_identity_roles.role_id").
+		Where("machine_identity_roles.machine_identity_id = ?", machineID).
+		Find(&roles).Error
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	return roles, nil
+}

--- a/internal/storage/store/local_machine_credentials_test.go
+++ b/internal/storage/store/local_machine_credentials_test.go
@@ -1,0 +1,78 @@
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func newMachineCredTestStore(t *testing.T) *LocalStorage {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.MachineIdentityCredential{}, &models.MachineIdentityRole{}, &models.Role{},
+	))
+	return NewLocalStorage(db)
+}
+
+func TestMachineCredentialLifecycle(t *testing.T) {
+	ls := newMachineCredTestStore(t)
+	ctx := context.Background()
+
+	cred, err := ls.CreateMachineIdentityCredential(ctx, &models.MachineIdentityCredential{
+		MachineIdentityID: 1, Name: "ci", TokenHash: "hash-abc", TokenPrefix: "kx_machine_ab12cd", CreatedAt: time.Now(),
+	})
+	require.NoError(t, err)
+	require.NotZero(t, cred.ID)
+
+	got, err := ls.GetMachineIdentityCredentialByHash(ctx, "hash-abc")
+	require.NoError(t, err)
+	assert.Equal(t, cred.ID, got.ID)
+	assert.False(t, got.Revoked)
+
+	list, err := ls.ListMachineIdentityCredentials(ctx, 1)
+	require.NoError(t, err)
+	require.Len(t, list, 1)
+
+	require.NoError(t, ls.RevokeMachineIdentityCredential(ctx, cred.ID))
+	got, err = ls.GetMachineIdentityCredentialByHash(ctx, "hash-abc")
+	require.NoError(t, err)
+	assert.True(t, got.Revoked, "revoke flips the flag, row preserved for audit")
+}
+
+func TestMachineRoleGrantScopeResolution(t *testing.T) {
+	ls := newMachineCredTestStore(t)
+	ctx := context.Background()
+	const machineID = uint(1)
+
+	// A global grant (project 0) and a project-2 grant.
+	require.NoError(t, ls.AssignMachineRole(ctx, machineID, 100, storage.Scope{}))
+	require.NoError(t, ls.AssignMachineRole(ctx, machineID, 200, storage.Scope{ProjectID: 2}))
+
+	// Duplicate grant is rejected.
+	require.Error(t, ls.AssignMachineRole(ctx, machineID, 100, storage.Scope{}))
+
+	// At project 2: both the global and the project-2 grant apply.
+	ids, err := ls.GetMachineRoleIDsAt(ctx, machineID, storage.Scope{ProjectID: 2})
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []uint{100, 200}, ids)
+
+	// At project 3: only the global grant applies (project-2 grant excluded).
+	ids, err = ls.GetMachineRoleIDsAt(ctx, machineID, storage.Scope{ProjectID: 3})
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []uint{100}, ids)
+
+	// Remove the project-2 grant.
+	require.NoError(t, ls.RemoveMachineRole(ctx, machineID, 200, storage.Scope{ProjectID: 2}))
+	ids, err = ls.GetMachineRoleIDsAt(ctx, machineID, storage.Scope{ProjectID: 2})
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []uint{100}, ids)
+}

--- a/internal/storage/store/remote_machine_identities.go
+++ b/internal/storage/store/remote_machine_identities.go
@@ -6,7 +6,9 @@ package store
 
 import (
 	"context"
+	"time"
 
+	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
@@ -24,4 +26,44 @@ func (rs *RemoteStorage) UpdateMachineIdentity(_ context.Context, _ *models.Mach
 
 func (rs *RemoteStorage) ListMachineIdentities(_ context.Context, _ uint) ([]*models.MachineIdentity, error) {
 	return nil, remoteUnsupported("ListMachineIdentities")
+}
+
+func (rs *RemoteStorage) CreateMachineIdentityCredential(_ context.Context, _ *models.MachineIdentityCredential) (*models.MachineIdentityCredential, error) {
+	return nil, remoteUnsupported("CreateMachineIdentityCredential")
+}
+
+func (rs *RemoteStorage) GetMachineIdentityCredentialByHash(_ context.Context, _ string) (*models.MachineIdentityCredential, error) {
+	return nil, remoteUnsupported("GetMachineIdentityCredentialByHash")
+}
+
+func (rs *RemoteStorage) GetMachineIdentityCredentialByID(_ context.Context, _ uint) (*models.MachineIdentityCredential, error) {
+	return nil, remoteUnsupported("GetMachineIdentityCredentialByID")
+}
+
+func (rs *RemoteStorage) ListMachineIdentityCredentials(_ context.Context, _ uint) ([]*models.MachineIdentityCredential, error) {
+	return nil, remoteUnsupported("ListMachineIdentityCredentials")
+}
+
+func (rs *RemoteStorage) RevokeMachineIdentityCredential(_ context.Context, _ uint) error {
+	return remoteUnsupported("RevokeMachineIdentityCredential")
+}
+
+func (rs *RemoteStorage) TouchMachineIdentityCredential(_ context.Context, _ uint, _ time.Time, _ time.Duration) error {
+	return remoteUnsupported("TouchMachineIdentityCredential")
+}
+
+func (rs *RemoteStorage) AssignMachineRole(_ context.Context, _, _ uint, _ storage.Scope) error {
+	return remoteUnsupported("AssignMachineRole")
+}
+
+func (rs *RemoteStorage) RemoveMachineRole(_ context.Context, _, _ uint, _ storage.Scope) error {
+	return remoteUnsupported("RemoveMachineRole")
+}
+
+func (rs *RemoteStorage) GetMachineRoleIDsAt(_ context.Context, _ uint, _ storage.Scope) ([]uint, error) {
+	return nil, remoteUnsupported("GetMachineRoleIDsAt")
+}
+
+func (rs *RemoteStorage) GetMachineRoles(_ context.Context, _ uint) ([]*models.Role, error) {
+	return nil, remoteUnsupported("GetMachineRoles")
 }

--- a/server/http/handlers/machine_identities.go
+++ b/server/http/handlers/machine_identities.go
@@ -112,6 +112,11 @@ func (h *CatalogHandler) TransitionMachineIdentity(w http.ResponseWriter, r *htt
 // IssueMachineToken handles POST /api/v1/projects/{id}/machine-identities/{machineId}/tokens.
 // Returns the raw token ONCE. Body: {"name": "...", "expires_in_days": 90}.
 func (h *CatalogHandler) IssueMachineToken(w http.ResponseWriter, r *http.Request) {
+	projectID, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		sendError(w, "InvalidParameter", "Invalid project ID", http.StatusBadRequest, nil)
+		return
+	}
 	machineID, err := strconv.ParseUint(chi.URLParam(r, "machineId"), 10, 32)
 	if err != nil {
 		sendError(w, "InvalidParameter", "Invalid machine identity ID", http.StatusBadRequest, nil)
@@ -135,7 +140,7 @@ func (h *CatalogHandler) IssueMachineToken(w http.ResponseWriter, r *http.Reques
 		t := time.Now().AddDate(0, 0, body.ExpiresInDays)
 		expiresAt = &t
 	}
-	result, err := h.coreService.IssueMachineToken(r.Context(), uint(machineID), body.Name, expiresAt, actor.UserID)
+	result, err := h.coreService.IssueMachineToken(r.Context(), uint(projectID), uint(machineID), body.Name, expiresAt, actor.UserID)
 	if err != nil {
 		status := http.StatusInternalServerError
 		switch {
@@ -159,12 +164,17 @@ func (h *CatalogHandler) IssueMachineToken(w http.ResponseWriter, r *http.Reques
 // ListMachineTokens handles GET /api/v1/projects/{id}/machine-identities/{machineId}/tokens.
 // Returns credential metadata only — never the token.
 func (h *CatalogHandler) ListMachineTokens(w http.ResponseWriter, r *http.Request) {
+	projectID, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		sendError(w, "InvalidParameter", "Invalid project ID", http.StatusBadRequest, nil)
+		return
+	}
 	machineID, err := strconv.ParseUint(chi.URLParam(r, "machineId"), 10, 32)
 	if err != nil {
 		sendError(w, "InvalidParameter", "Invalid machine identity ID", http.StatusBadRequest, nil)
 		return
 	}
-	creds, err := h.coreService.ListMachineTokens(r.Context(), uint(machineID))
+	creds, err := h.coreService.ListMachineTokens(r.Context(), uint(projectID), uint(machineID))
 	if err != nil {
 		sendError(w, "Error", err.Error(), http.StatusInternalServerError, nil)
 		return
@@ -186,6 +196,11 @@ func (h *CatalogHandler) ListMachineTokens(w http.ResponseWriter, r *http.Reques
 
 // RevokeMachineToken handles DELETE /api/v1/projects/{id}/machine-identities/{machineId}/tokens/{tokenId}.
 func (h *CatalogHandler) RevokeMachineToken(w http.ResponseWriter, r *http.Request) {
+	projectID, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		sendError(w, "InvalidParameter", "Invalid project ID", http.StatusBadRequest, nil)
+		return
+	}
 	machineID, err := strconv.ParseUint(chi.URLParam(r, "machineId"), 10, 32)
 	if err != nil {
 		sendError(w, "InvalidParameter", "Invalid machine identity ID", http.StatusBadRequest, nil)
@@ -201,7 +216,7 @@ func (h *CatalogHandler) RevokeMachineToken(w http.ResponseWriter, r *http.Reque
 		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
 		return
 	}
-	if err := h.coreService.RevokeMachineToken(r.Context(), uint(machineID), uint(tokenID), actor.UserID); err != nil {
+	if err := h.coreService.RevokeMachineToken(r.Context(), uint(projectID), uint(machineID), uint(tokenID), actor.UserID); err != nil {
 		status := http.StatusInternalServerError
 		if strings.Contains(err.Error(), "not found") {
 			status = http.StatusNotFound

--- a/server/http/handlers/machine_identities.go
+++ b/server/http/handlers/machine_identities.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/keyorixhq/keyorix/internal/core"
@@ -106,6 +107,180 @@ func (h *CatalogHandler) TransitionMachineIdentity(w http.ResponseWriter, r *htt
 		return
 	}
 	sendSuccess(w, map[string]interface{}{"machine_identity": m}, "Machine identity updated")
+}
+
+// IssueMachineToken handles POST /api/v1/projects/{id}/machine-identities/{machineId}/tokens.
+// Returns the raw token ONCE. Body: {"name": "...", "expires_in_days": 90}.
+func (h *CatalogHandler) IssueMachineToken(w http.ResponseWriter, r *http.Request) {
+	machineID, err := strconv.ParseUint(chi.URLParam(r, "machineId"), 10, 32)
+	if err != nil {
+		sendError(w, "InvalidParameter", "Invalid machine identity ID", http.StatusBadRequest, nil)
+		return
+	}
+	actor := middleware.GetUserFromContext(r.Context())
+	if actor == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	var body struct {
+		Name          string `json:"name"`
+		ExpiresInDays int    `json:"expires_in_days"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		sendError(w, "InvalidJSON", "Invalid request body", http.StatusBadRequest, nil)
+		return
+	}
+	var expiresAt *time.Time
+	if body.ExpiresInDays > 0 {
+		t := time.Now().AddDate(0, 0, body.ExpiresInDays)
+		expiresAt = &t
+	}
+	result, err := h.coreService.IssueMachineToken(r.Context(), uint(machineID), body.Name, expiresAt, actor.UserID)
+	if err != nil {
+		status := http.StatusInternalServerError
+		switch {
+		case strings.Contains(err.Error(), "not found"):
+			status = http.StatusNotFound
+		case strings.Contains(err.Error(), "must be active"):
+			status = http.StatusConflict
+		}
+		sendError(w, "Error", err.Error(), status, nil)
+		return
+	}
+	w.WriteHeader(http.StatusCreated)
+	sendSuccess(w, map[string]interface{}{
+		"token":      result.PlainToken, // shown once
+		"id":         result.Credential.ID,
+		"prefix":     result.Credential.TokenPrefix,
+		"expires_at": result.Credential.ExpiresAt,
+	}, "Machine token issued — copy it now; it will not be shown again")
+}
+
+// ListMachineTokens handles GET /api/v1/projects/{id}/machine-identities/{machineId}/tokens.
+// Returns credential metadata only — never the token.
+func (h *CatalogHandler) ListMachineTokens(w http.ResponseWriter, r *http.Request) {
+	machineID, err := strconv.ParseUint(chi.URLParam(r, "machineId"), 10, 32)
+	if err != nil {
+		sendError(w, "InvalidParameter", "Invalid machine identity ID", http.StatusBadRequest, nil)
+		return
+	}
+	creds, err := h.coreService.ListMachineTokens(r.Context(), uint(machineID))
+	if err != nil {
+		sendError(w, "Error", err.Error(), http.StatusInternalServerError, nil)
+		return
+	}
+	out := make([]map[string]interface{}, 0, len(creds))
+	for _, c := range creds {
+		out = append(out, map[string]interface{}{
+			"id":           c.ID,
+			"name":         c.Name,
+			"prefix":       c.TokenPrefix,
+			"last_used_at": c.LastUsedAt,
+			"expires_at":   c.ExpiresAt,
+			"revoked":      c.Revoked,
+			"created_at":   c.CreatedAt,
+		})
+	}
+	sendSuccess(w, map[string]interface{}{"tokens": out}, "")
+}
+
+// RevokeMachineToken handles DELETE /api/v1/projects/{id}/machine-identities/{machineId}/tokens/{tokenId}.
+func (h *CatalogHandler) RevokeMachineToken(w http.ResponseWriter, r *http.Request) {
+	machineID, err := strconv.ParseUint(chi.URLParam(r, "machineId"), 10, 32)
+	if err != nil {
+		sendError(w, "InvalidParameter", "Invalid machine identity ID", http.StatusBadRequest, nil)
+		return
+	}
+	tokenID, err := strconv.ParseUint(chi.URLParam(r, "tokenId"), 10, 32)
+	if err != nil {
+		sendError(w, "InvalidParameter", "Invalid token ID", http.StatusBadRequest, nil)
+		return
+	}
+	actor := middleware.GetUserFromContext(r.Context())
+	if actor == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	if err := h.coreService.RevokeMachineToken(r.Context(), uint(machineID), uint(tokenID), actor.UserID); err != nil {
+		status := http.StatusInternalServerError
+		if strings.Contains(err.Error(), "not found") {
+			status = http.StatusNotFound
+		}
+		sendError(w, "Error", err.Error(), status, nil)
+		return
+	}
+	sendSuccess(w, nil, "Machine token revoked")
+}
+
+// GrantMachineRole handles POST /api/v1/projects/{id}/machine-identities/{machineId}/roles.
+// Body: {"role_id": 5}. The role is granted at the project scope.
+func (h *CatalogHandler) GrantMachineRole(w http.ResponseWriter, r *http.Request) {
+	h.changeMachineRole(w, r, true)
+}
+
+// RemoveMachineRole handles DELETE /api/v1/projects/{id}/machine-identities/{machineId}/roles/{roleId}.
+func (h *CatalogHandler) RemoveMachineRole(w http.ResponseWriter, r *http.Request) {
+	h.changeMachineRole(w, r, false)
+}
+
+func (h *CatalogHandler) changeMachineRole(w http.ResponseWriter, r *http.Request, grant bool) {
+	projectID, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		sendError(w, "InvalidParameter", "Invalid project ID", http.StatusBadRequest, nil)
+		return
+	}
+	machineID, err := strconv.ParseUint(chi.URLParam(r, "machineId"), 10, 32)
+	if err != nil {
+		sendError(w, "InvalidParameter", "Invalid machine identity ID", http.StatusBadRequest, nil)
+		return
+	}
+	actor := middleware.GetUserFromContext(r.Context())
+	if actor == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+
+	var roleID uint
+	if grant {
+		var body struct {
+			RoleID uint `json:"role_id"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.RoleID == 0 {
+			sendError(w, "ValidationError", "role_id is required", http.StatusBadRequest, nil)
+			return
+		}
+		roleID = body.RoleID
+	} else {
+		rid, err := strconv.ParseUint(chi.URLParam(r, "roleId"), 10, 32)
+		if err != nil {
+			sendError(w, "InvalidParameter", "Invalid role ID", http.StatusBadRequest, nil)
+			return
+		}
+		roleID = uint(rid)
+	}
+
+	scope := core.Scope{ProjectID: uint(projectID)}
+	if grant {
+		err = h.coreService.AssignMachineRole(r.Context(), uint(machineID), roleID, scope, actor.UserID)
+	} else {
+		err = h.coreService.RemoveMachineRole(r.Context(), uint(machineID), roleID, scope, actor.UserID)
+	}
+	if err != nil {
+		status := http.StatusInternalServerError
+		switch {
+		case strings.Contains(err.Error(), "not found"):
+			status = http.StatusNotFound
+		case strings.Contains(err.Error(), "already") || strings.Contains(err.Error(), "not assigned"):
+			status = http.StatusConflict
+		}
+		sendError(w, "Error", err.Error(), status, nil)
+		return
+	}
+	verb := "granted"
+	if !grant {
+		verb = "removed"
+	}
+	sendSuccess(w, nil, "Machine role "+verb)
 }
 
 func machineActionState(action string) (string, bool) {

--- a/server/http/handlers/rotation_policies_handler.go
+++ b/server/http/handlers/rotation_policies_handler.go
@@ -137,7 +137,7 @@ func (h *RotationPolicyHandler) Create(w http.ResponseWriter, r *http.Request) {
 		eid = *reqBody.EnvironmentID
 	}
 	scope := core.Scope{ProjectID: pid, EnvironmentID: eid}
-	if allowed, err := h.coreService.Authorize(r.Context(), userCtx.UserID, "secrets.write", scope); err != nil || !allowed {
+	if allowed, err := h.coreService.AuthorizePrincipal(r.Context(), userCtx.ActorKind(), userCtx.PrincipalID(), "secrets.write", scope); err != nil || !allowed {
 		h.sendError(w, "Forbidden", "Insufficient permissions", http.StatusForbidden, nil)
 		return
 	}

--- a/server/http/handlers/secrets_crud.go
+++ b/server/http/handlers/secrets_crud.go
@@ -16,6 +16,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/keyorixhq/keyorix/server/middleware"
 )
 
@@ -50,7 +51,7 @@ func (h *SecretHandler) CreateSecret(w http.ResponseWriter, r *http.Request) {
 	// Authorize against the target project/environment from the body — the
 	// create route carries no path scope for the middleware to resolve.
 	scope := core.Scope{ProjectID: reqBody.ProjectID, EnvironmentID: reqBody.EnvironmentID}
-	if allowed, err := h.coreService.Authorize(r.Context(), userCtx.UserID, "secrets.write", scope); err != nil || !allowed {
+	if allowed, err := h.coreService.AuthorizePrincipal(r.Context(), userCtx.ActorKind(), userCtx.PrincipalID(), "secrets.write", scope); err != nil || !allowed {
 		h.sendError(w, "Forbidden", "Insufficient permissions", http.StatusForbidden, nil)
 		return
 	}
@@ -104,7 +105,17 @@ func (h *SecretHandler) GetSecret(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	secret, err := h.coreService.GetSecretWithPermissionCheck(r.Context(), uint(id), userCtx.UserID)
+	// Machine principals (ADR-030) are already authorized at the secret's scope
+	// by the route's scoped-permission gate; the per-user owner/sharing check
+	// (and its user-id requirement) does not apply to them, so fetch directly.
+	isMachine := userCtx.MachineIdentityID != nil
+
+	var secret *models.SecretNode
+	if isMachine {
+		secret, err = h.coreService.GetSecret(r.Context(), uint(id))
+	} else {
+		secret, err = h.coreService.GetSecretWithPermissionCheck(r.Context(), uint(id), userCtx.UserID)
+	}
 	if err != nil {
 		log.Printf("Error getting secret: %v", err)
 		if strings.Contains(err.Error(), "not found") {
@@ -119,7 +130,12 @@ func (h *SecretHandler) GetSecret(w http.ResponseWriter, r *http.Request) {
 
 	var response interface{} = secret
 	if r.URL.Query().Get("include_value") == "true" { //nolint:goconst
-		value, err := h.coreService.GetSecretValueWithPermissionCheck(r.Context(), uint(id), userCtx.UserID)
+		var value []byte
+		if isMachine {
+			value, err = h.coreService.GetSecretValue(r.Context(), uint(id))
+		} else {
+			value, err = h.coreService.GetSecretValueWithPermissionCheck(r.Context(), uint(id), userCtx.UserID)
+		}
 		if err != nil {
 			log.Printf("Error getting secret value: %v", err)
 			if strings.Contains(err.Error(), "permission denied") {

--- a/server/http/handlers/secrets_list.go
+++ b/server/http/handlers/secrets_list.go
@@ -82,7 +82,15 @@ func (h *SecretHandler) ListSecrets(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	response, err := h.coreService.ListSecretsWithSharingInfo(r.Context(), userCtx.UserID, filter)
+	// Machine principals (ADR-030) have no user identity for the owned/shared
+	// model; they list by their authorized scope (already gated by the route).
+	var response *models.SecretListResponse
+	var err error
+	if userCtx.MachineIdentityID != nil {
+		response, err = h.coreService.ListSecretsInScope(r.Context(), filter)
+	} else {
+		response, err = h.coreService.ListSecretsWithSharingInfo(r.Context(), userCtx.UserID, filter)
+	}
 	if err != nil {
 		log.Printf("Error listing secrets: %v", err)
 		h.sendError(w, "InternalError", "Failed to list secrets", http.StatusInternalServerError, nil)

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -201,6 +201,12 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		r.With(customMiddleware.RequireScopedPermission("users.read", projectScope)).Get("/projects/{id}/machine-identities", catalogHandler.ListMachineIdentities)
 		r.With(customMiddleware.RequireScopedPermission("roles.assign", projectScope)).Post("/projects/{id}/machine-identities", catalogHandler.CreateMachineIdentity)
 		r.With(customMiddleware.RequireScopedPermission("roles.assign", projectScope)).Put("/projects/{id}/machine-identities/{machineId}", catalogHandler.TransitionMachineIdentity)
+		// Machine-token credentials + role grants (ADR-030).
+		r.With(customMiddleware.RequireScopedPermission("roles.assign", projectScope)).Post("/projects/{id}/machine-identities/{machineId}/tokens", catalogHandler.IssueMachineToken)
+		r.With(customMiddleware.RequireScopedPermission("users.read", projectScope)).Get("/projects/{id}/machine-identities/{machineId}/tokens", catalogHandler.ListMachineTokens)
+		r.With(customMiddleware.RequireScopedPermission("roles.assign", projectScope)).Delete("/projects/{id}/machine-identities/{machineId}/tokens/{tokenId}", catalogHandler.RevokeMachineToken)
+		r.With(customMiddleware.RequireScopedPermission("roles.assign", projectScope)).Post("/projects/{id}/machine-identities/{machineId}/roles", catalogHandler.GrantMachineRole)
+		r.With(customMiddleware.RequireScopedPermission("roles.assign", projectScope)).Delete("/projects/{id}/machine-identities/{machineId}/roles/{roleId}", catalogHandler.RemoveMachineRole)
 		r.With(customMiddleware.RequireScopedPermission("secrets.read", projectScope)).Get("/projects/{id}/environments", catalogHandler.ListProjectEnvironments)
 		r.With(customMiddleware.RequireScopedPermission("secrets.write", projectScope)).Post("/projects/{id}/environments", catalogHandler.CreateProjectEnvironment)
 		// Environment restore is nested under the project so the scope resolves

--- a/server/middleware/auth.go
+++ b/server/middleware/auth.go
@@ -28,10 +28,12 @@ import (
 type sessionValidator interface {
 	ValidateSessionToken(ctx context.Context, token string) (*models.User, []string, error)
 	ValidatePATToken(ctx context.Context, token string) (*models.User, []string, error)
+	ValidateMachineToken(ctx context.Context, token string) (*models.MachineIdentity, []string, error)
 }
 
 // patTokenPrefix marks a personal access token (kept in sync with core.patPrefix).
 const patTokenPrefix = "kx_pat_"
+const machineTokenPrefix = "kx_machine_"
 
 // UserContext represents the authenticated user context. It carries identity
 // only — authorization is resolved per-request against the target scope by
@@ -49,6 +51,29 @@ type UserContext struct {
 	// account must change its password before using non-allowlisted endpoints.
 	AccountState string `json:"account_state,omitempty"`
 	Restricted   bool   `json:"-"`
+	// MachineIdentityID is set (and UserID is 0) when the request authenticated
+	// with a machine token (ADR-030). ActorType is "machine_identity" for such
+	// requests and "user" otherwise.
+	MachineIdentityID *uint  `json:"machine_identity_id,omitempty"`
+	ActorType         string `json:"actor_type,omitempty"`
+}
+
+// ActorKind returns the principal's actor type ("user" or "machine_identity"),
+// defaulting to user for legacy/empty contexts.
+func (u *UserContext) ActorKind() string {
+	if u.ActorType == core.ActorTypeMachine {
+		return core.ActorTypeMachine
+	}
+	return core.ActorTypeUser
+}
+
+// PrincipalID returns the id to authorize against: the machine identity id for a
+// machine request, otherwise the user id.
+func (u *UserContext) PrincipalID() uint {
+	if u.MachineIdentityID != nil {
+		return *u.MachineIdentityID
+	}
+	return u.UserID
 }
 
 // contextKey is used for context keys to avoid collisions
@@ -170,8 +195,9 @@ func authenticationWithValidator(validator sessionValidator, coreService *core.K
 			}
 
 			// Resolve impersonation once, on the slow path, so it is cached with
-			// the identity. PATs are never impersonation sessions (prefix check).
-			if coreService != nil && !strings.HasPrefix(token, patTokenPrefix) {
+			// the identity. PATs and machine tokens are never impersonation
+			// sessions (prefix check).
+			if coreService != nil && !strings.HasPrefix(token, patTokenPrefix) && !strings.HasPrefix(token, machineTokenPrefix) {
 				userCtx.ImpersonatedBy = coreService.SessionImpersonator(r.Context(), token)
 			}
 
@@ -217,7 +243,7 @@ func RequireScopedPermission(permission string, resolve ScopeResolver) func(http
 					// Reveal "not found" only to callers who hold the permission
 					// globally; otherwise deny without confirming the resource
 					// exists (avoids existence enumeration by unprivileged users).
-					if ok, aerr := cs.Authorize(r.Context(), userCtx.UserID, permission, core.Scope{}); aerr == nil && ok {
+					if ok, aerr := cs.AuthorizePrincipal(r.Context(), userCtx.ActorKind(), userCtx.PrincipalID(), permission, core.Scope{}); aerr == nil && ok {
 						notFoundResponse(w, "Resource not found")
 					} else {
 						forbiddenResponse(w, "Insufficient permissions")
@@ -227,7 +253,7 @@ func RequireScopedPermission(permission string, resolve ScopeResolver) func(http
 				badRequestResponse(w, "Invalid target")
 				return
 			}
-			allowed, err := cs.Authorize(r.Context(), userCtx.UserID, permission, scope)
+			allowed, err := cs.AuthorizePrincipal(r.Context(), userCtx.ActorKind(), userCtx.PrincipalID(), permission, scope)
 			if err != nil || !allowed {
 				forbiddenResponse(w, "Insufficient permissions")
 				return
@@ -428,6 +454,11 @@ func buildRequestContext(parent context.Context, userCtx *UserContext, coreServi
 	if userCtx != nil && userCtx.ImpersonatedBy != nil {
 		ctx = core.WithImpersonation(ctx, *userCtx.ImpersonatedBy)
 	}
+	// Tag machine requests so every audit event they produce is actored as a
+	// machine identity (ADR-023/030 plumbing).
+	if userCtx != nil && userCtx.MachineIdentityID != nil {
+		ctx = core.WithActorType(ctx, core.ActorTypeMachine)
+	}
 	return ctx
 }
 
@@ -446,6 +477,23 @@ func validateToken(ctx context.Context, validator sessionValidator, token string
 	if validator == nil {
 		return nil, http.ErrNotSupported
 	}
+	// Machine tokens (ADR-030) authenticate AS a machine identity, not a user.
+	if strings.HasPrefix(token, machineTokenPrefix) {
+		m, roleNames, err := validator.ValidateMachineToken(ctx, token)
+		if err != nil {
+			return nil, err
+		}
+		mid := m.ID
+		return &UserContext{
+			UserID:            0,
+			MachineIdentityID: &mid,
+			ActorType:         core.ActorTypeMachine,
+			Username:          m.Name,
+			Roles:             roleNames,
+			AccountState:      core.AccountActive,
+		}, nil
+	}
+
 	// Route by prefix: PATs authenticate AS their owning user, resolving to the same
 	// UserContext shape as a session — so authorization downstream is identical.
 	var (
@@ -466,6 +514,7 @@ func validateToken(ctx context.Context, validator sessionValidator, token string
 		Username:     user.Username,
 		Email:        user.Email,
 		Roles:        roleNames,
+		ActorType:    core.ActorTypeUser,
 		AccountState: core.NormalizeAccountState(user.AccountState),
 		Restricted:   core.AccountRestricted(user.AccountState),
 	}, nil

--- a/server/middleware/auth_test.go
+++ b/server/middleware/auth_test.go
@@ -57,6 +57,17 @@ func (fakeValidator) ValidatePATToken(_ context.Context, token string) (*models.
 	return nil, nil, fmt.Errorf("invalid token")
 }
 
+func (fakeValidator) ValidateMachineToken(_ context.Context, token string) (*models.MachineIdentity, []string, error) {
+	if token == "kx_machine_validtoken" {
+		return &models.MachineIdentity{
+			ID:    9,
+			Name:  "ci-bot",
+			State: "active",
+		}, []string{"project_viewer"}, nil
+	}
+	return nil, nil, fmt.Errorf("invalid token")
+}
+
 // newTestAuthMiddleware builds the Authentication middleware with the fake
 // validator. The coreService passed to authenticationWithValidator is nil here
 // because none of these tests exercise downstream handlers that pull the core


### PR DESCRIPTION
Closes the long-deferred machine-auth gap: **machine identities (ADR-023) existed as records but could not authenticate.** Now a CI/automation/Kubernetes workload can hold a Keyorix identity, be granted a least-privilege project role, and call the API with a bearer token. Design in **ADR-030**.

## The vertical

1. **Opaque bearer tokens** — `machine_identity_credentials` (hashed at rest, `kx_machine_` prefix, mirrors PATs). Issuing requires the machine `active`; validation re-checks revoked/expired **and** machine state every request, so suspending/revoking the identity disables all its tokens (bounded by the 30s token cache).
2. **Machine RBAC** — `machine_identity_roles` (mirrors `user_roles`, scoped). Authorization is generalized to `AuthorizePrincipal(actorType, principalID, perm, scope)`; `Authorize` stays a user-only wrapper so **every existing call site is unchanged**. Machines get **no admin-role bypass** — a leaked token is bounded to its explicit grants.
3. **Middleware** — `kx_machine_` routes to `ValidateMachineToken`; the request principal gains `ActorType` + `MachineIdentityID` and is tagged `WithActorType(machine_identity)`, so every audit event the request produces is actored as a machine — the ADR-023 `actor_type` plumbing, **finally exercised**.

## HTTP surface (project-scoped, `roles.assign`-gated)

```
POST   /projects/{id}/machine-identities/{mid}/tokens          # issue (raw token shown once)
GET    /projects/{id}/machine-identities/{mid}/tokens          # list metadata
DELETE /projects/{id}/machine-identities/{mid}/tokens/{tid}    # revoke
POST   /projects/{id}/machine-identities/{mid}/roles           # grant a role
DELETE /projects/{id}/machine-identities/{mid}/roles/{rid}     # remove
```

Machine principals list secrets by authorized scope (`ListSecretsInScope`) and read individual secrets/values directly — the route's scoped gate already authorized them, and the per-user owner/sharing model doesn't apply to a machine.

## Blast radius (contained)

`Authorize(userID,…)` is source-compatible; only the ~7 gate call sites (2 middleware + 5 handler) became principal-aware. Two additive, guarded migrations.

## Tests

- core: issue (active-only), validate (revoked / expired / suspended-machine), authorize-machine + **no-admin-bypass**
- storage: credential lifecycle, scoped role resolution (global + project grants)
- middleware validator extended
- Full `go test ./...` green; `gofmt`/`go vet` clean.

## Verified end-to-end

Created a machine → issued a token → **read denied before any grant (403)** → granted `project_viewer` → **read allowed (200), including the decrypted value** (`s3cr3t-val` — the CI use case) → **write denied (403, viewer can't write)** → audit events recorded as `secret.read | machine_identity`.

## Follow-up

**OIDC / Kubernetes projected-SA-token federation (ADR-031)** — verifying an external cluster JWT against JWKS and mapping `(iss, sub)` to a machine identity. It builds directly on this foundation (same `machine_identity_roles` + `AuthorizePrincipal` + audit actoring); additive, not a rework.

🤖 Generated with [Claude Code](https://claude.com/claude-code)