### PR TITLE
feat(retention): soft-delete purge scheduler (ADR-032)

### DIFF
--- a/configs/keyorix.yaml.tpl
+++ b/configs/keyorix.yaml.tpl
@@ -113,14 +113,20 @@ password_policy:
   max_age_days: 0                # expire a password after N days (0 = never; login flags it)
 
 soft_delete:
-  # Enable soft-deletion for all database entities
+  # Soft-deletion is built in for users/projects/environments (DELETE sets
+  # deleted_at; restore endpoints clear it). retention_days is the grace period
+  # the purge scheduler below honours before a soft-deleted row is permanently
+  # removed (default 30).
   enabled: true
   retention_days: 30
 
 purge:
-  # Enable periodic purge of expired/deleted database entities
-  enabled: true
-  schedule: "0 0 * * *"
+  # ADR-032 retention purge. When enabled, a background job permanently deletes
+  # soft-deleted users/projects/environments whose deleted_at is older than
+  # soft_delete.retention_days. This is IRREVERSIBLE — opt-in (default off).
+  enabled: false
+  # Run interval as a Go duration (e.g. "24h", "6h"). Default 24h.
+  schedule: "24h"
 
 audit:
   # Native SIEM push: forward every audit event to an external SIEM.

--- a/docs/adr-032-soft-delete-purge-scheduler.md
+++ b/docs/adr-032-soft-delete-purge-scheduler.md
@@ -1,0 +1,58 @@
+# ADR-032: Soft-delete retention + purge scheduler
+
+**Status:** Accepted
+**Date:** 2026-06-10
+**Context:** The config has carried dormant `SoftDeleteConfig{Enabled,
+RetentionDays}` and `PurgeConfig{Enabled, Schedule}` blocks that nothing reads.
+Users, projects, and environments already soft-delete (GORM `DeletedAt`) with
+restore endpoints, so soft-deleted rows accumulate forever with no lifecycle.
+
+## Context
+
+Soft delete is a safety net (a restore window after an accidental delete), but
+without a purge step the rows live indefinitely. That is both a storage-hygiene
+problem and a compliance one: GDPR/NIS2 erasure expects that a deleted record is
+*actually* removed after a bounded grace period, not retained forever. Three
+entities already soft-delete via `DeletedAt`: `users`, `projects`,
+`environments`. (Secrets currently hard-delete and use a `Status` field, not
+`DeletedAt` — giving secrets a `DeletedAt` soft-delete is a separate, larger
+change that touches every secret query; it is a tracked follow-up, and the purge
+scheduler will cover it for free once it lands.)
+
+## Decision
+
+Wire the dormant config into a **purge scheduler**: a background job that
+hard-deletes soft-deleted rows whose `deleted_at` is older than the retention
+window.
+
+- **`SoftDeleteConfig.RetentionDays`** — the grace period; soft-deleted rows are
+  purged once `deleted_at < now − RetentionDays`. Defaults to 30 days when unset.
+- **`PurgeConfig.Enabled`** — opt-in. **Default off**: a hard delete is
+  irreversible, so an operator must explicitly enable it. With it off the
+  scheduler never runs and behaviour is unchanged (soft-deleted rows persist).
+- **`PurgeConfig.Schedule`** — the run interval, parsed as a Go duration
+  (e.g. `24h`, `6h`). Defaults to 24h.
+
+A `KeyorixCore.PurgeExpiredSoftDeletes(ctx, before)` orchestrates per-entity
+hard deletes (`PurgeDeletedUsersBefore` / `…ProjectsBefore` /
+`…EnvironmentsBefore`, each `Unscoped().Where("deleted_at < ?").Delete`,
+returning a count) and emits one **system-actored** `data.purged` audit event
+with the counts. The scheduler goroutine in `main.go` mirrors the existing
+anomaly-detection ticker (run-once-on-start + ticker + `ctx.Done()` shutdown),
+guarded by `PurgeConfig.Enabled`.
+
+Each entity is purged independently on its own `deleted_at` — no cascade logic
+in the purge (a soft-deleted project's environments carry their own
+`deleted_at` and are purged by their own query). This keeps the job simple and
+idempotent.
+
+## Consequences
+
+- Operators get a real retention lifecycle: a configurable grace period, then
+  permanent removal — the GDPR/NIS2 "erasure after grace" story, opt-in.
+- Default-off means no behaviour change for anyone who doesn't enable it, and no
+  surprise data loss.
+- The purge is irreversible by design; the retention window is the only safety
+  net, so the default (30 days, off) is conservative.
+- Secrets soft-delete + restore (replacing the hard delete) is a follow-up; when
+  it lands, adding `secret_nodes` to the purge is a one-line extension.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -219,6 +219,15 @@ type SoftDeleteConfig struct {
 	RetentionDays int  `yaml:"retention_days"`
 }
 
+// GetRetentionDays returns the soft-delete grace period in days, defaulting to
+// 30 when unset (ADR-032).
+func (c SoftDeleteConfig) GetRetentionDays() int {
+	if c.RetentionDays <= 0 {
+		return 30
+	}
+	return c.RetentionDays
+}
+
 // AuditConfig groups audit-log delivery integrations.
 type AuditConfig struct {
 	SIEM SIEMConfig `yaml:"siem"`
@@ -363,6 +372,17 @@ func (c *CredentialDeliveryConfig) DeliveryConfig() delivery.Config {
 type PurgeConfig struct {
 	Enabled  bool   `yaml:"enabled"`
 	Schedule string `yaml:"schedule"`
+}
+
+// GetInterval returns the purge run interval, parsing Schedule as a Go duration
+// (e.g. "24h", "6h"); defaults to 24h when unset or unparseable (ADR-032).
+func (c PurgeConfig) GetInterval() time.Duration {
+	if c.Schedule != "" {
+		if d, err := time.ParseDuration(c.Schedule); err == nil && d > 0 {
+			return d
+		}
+	}
+	return 24 * time.Hour
 }
 
 // resolveSecret returns the value of envVar if set and non-empty, otherwise fallback.

--- a/internal/config/purge_config_test.go
+++ b/internal/config/purge_config_test.go
@@ -1,0 +1,22 @@
+package config
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSoftDeleteConfig_GetRetentionDays(t *testing.T) {
+	assert.Equal(t, 30, SoftDeleteConfig{}.GetRetentionDays(), "default when unset")
+	assert.Equal(t, 30, SoftDeleteConfig{RetentionDays: 0}.GetRetentionDays())
+	assert.Equal(t, 30, SoftDeleteConfig{RetentionDays: -5}.GetRetentionDays(), "negative falls back to default")
+	assert.Equal(t, 7, SoftDeleteConfig{RetentionDays: 7}.GetRetentionDays())
+}
+
+func TestPurgeConfig_GetInterval(t *testing.T) {
+	assert.Equal(t, 24*time.Hour, PurgeConfig{}.GetInterval(), "default when unset")
+	assert.Equal(t, 24*time.Hour, PurgeConfig{Schedule: "garbage"}.GetInterval(), "unparseable falls back")
+	assert.Equal(t, 6*time.Hour, PurgeConfig{Schedule: "6h"}.GetInterval())
+	assert.Equal(t, 90*time.Minute, PurgeConfig{Schedule: "90m"}.GetInterval())
+}

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -365,6 +365,21 @@ func (m *MockStorage) RestoreUser(ctx context.Context, id uint) error {
 	return args.Error(0)
 }
 
+func (m *MockStorage) PurgeDeletedUsersBefore(ctx context.Context, before time.Time) (int64, error) {
+	args := m.Called(ctx, before)
+	return args.Get(0).(int64), args.Error(1)
+}
+
+func (m *MockStorage) PurgeDeletedProjectsBefore(ctx context.Context, before time.Time) (int64, error) {
+	args := m.Called(ctx, before)
+	return args.Get(0).(int64), args.Error(1)
+}
+
+func (m *MockStorage) PurgeDeletedEnvironmentsBefore(ctx context.Context, before time.Time) (int64, error) {
+	args := m.Called(ctx, before)
+	return args.Get(0).(int64), args.Error(1)
+}
+
 func (m *MockStorage) ListUsers(ctx context.Context, filter *storage.UserFilter) ([]*models.User, int64, error) {
 	args := m.Called(ctx, filter)
 	if args.Get(0) == nil {

--- a/internal/core/purge.go
+++ b/internal/core/purge.go
@@ -1,0 +1,47 @@
+// purge.go — retention purge of soft-deleted records (ADR-032).
+package core
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// PurgeResult reports how many soft-deleted rows each entity purge removed.
+type PurgeResult struct {
+	Users        int64 `json:"users"`
+	Projects     int64 `json:"projects"`
+	Environments int64 `json:"environments"`
+}
+
+// Total is the combined count of purged rows.
+func (r PurgeResult) Total() int64 { return r.Users + r.Projects + r.Environments }
+
+// PurgeExpiredSoftDeletes hard-deletes every soft-deleted user, project, and
+// environment whose deleted_at predates `before`. Each entity is purged
+// independently on its own deleted_at (no cascade). When anything was removed it
+// emits one system-actored `data.purged` audit event with the counts. Errors on
+// individual entities are collected but do not abort the others.
+func (c *KeyorixCore) PurgeExpiredSoftDeletes(ctx context.Context, before time.Time) (*PurgeResult, error) {
+	res := &PurgeResult{}
+	var firstErr error
+	record := func(n int64, err error) int64 {
+		if err != nil && firstErr == nil {
+			firstErr = err
+		}
+		return n
+	}
+
+	res.Users = record(c.storage.PurgeDeletedUsersBefore(ctx, before))
+	res.Projects = record(c.storage.PurgeDeletedProjectsBefore(ctx, before))
+	res.Environments = record(c.storage.PurgeDeletedEnvironmentsBefore(ctx, before))
+
+	if res.Total() > 0 {
+		sysCtx := WithActorType(ctx, ActorTypeSystem)
+		c.writeAuditEvent(sysCtx, "data.purged", nil, nil,
+			fmt.Sprintf("retention purge removed %d soft-deleted records (users=%d, projects=%d, environments=%d) older than %s",
+				res.Total(), res.Users, res.Projects, res.Environments, before.UTC().Format(time.RFC3339)))
+	}
+
+	return res, firstErr
+}

--- a/internal/core/purge_test.go
+++ b/internal/core/purge_test.go
@@ -1,0 +1,53 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPurgeExpiredSoftDeletes_CountsAndAudits(t *testing.T) {
+	before := time.Date(2026, 6, 10, 0, 0, 0, 0, time.UTC)
+	store := new(MockStorage)
+	store.On("PurgeDeletedUsersBefore", mock.Anything, before).Return(int64(2), nil)
+	store.On("PurgeDeletedProjectsBefore", mock.Anything, before).Return(int64(1), nil)
+	store.On("PurgeDeletedEnvironmentsBefore", mock.Anything, before).Return(int64(3), nil)
+
+	// Something was purged → a single system-actored data.purged event is written.
+	var auditedActorType string
+	store.On("LogAuditEvent", mock.Anything, mock.MatchedBy(func(e *models.AuditEvent) bool {
+		if e.EventType == "data.purged" {
+			auditedActorType = e.ActorType
+			return true
+		}
+		return false
+	})).Return(nil)
+
+	c := NewKeyorixCore(store)
+	res, err := c.PurgeExpiredSoftDeletes(context.Background(), before)
+	require.NoError(t, err)
+	require.Equal(t, int64(2), res.Users)
+	require.Equal(t, int64(1), res.Projects)
+	require.Equal(t, int64(3), res.Environments)
+	require.Equal(t, int64(6), res.Total())
+	require.Equal(t, ActorTypeSystem, auditedActorType, "purge is actored as system")
+}
+
+func TestPurgeExpiredSoftDeletes_NoAuditWhenNothingPurged(t *testing.T) {
+	before := time.Now()
+	store := new(MockStorage)
+	store.On("PurgeDeletedUsersBefore", mock.Anything, before).Return(int64(0), nil)
+	store.On("PurgeDeletedProjectsBefore", mock.Anything, before).Return(int64(0), nil)
+	store.On("PurgeDeletedEnvironmentsBefore", mock.Anything, before).Return(int64(0), nil)
+	// No LogAuditEvent expectation: a zero-purge run must not emit an event.
+
+	c := NewKeyorixCore(store)
+	res, err := c.PurgeExpiredSoftDeletes(context.Background(), before)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), res.Total())
+	store.AssertNotCalled(t, "LogAuditEvent", mock.Anything, mock.Anything)
+}

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -131,6 +131,11 @@ type Storage interface {
 	UpdateLastLogin(ctx context.Context, userID uint, loginAt time.Time) error
 	DeleteUser(ctx context.Context, id uint) error
 	RestoreUser(ctx context.Context, id uint) error
+	// PurgeDeleted*Before hard-delete soft-deleted rows whose deleted_at is
+	// older than `before`, returning the number purged (ADR-032). Irreversible.
+	PurgeDeletedUsersBefore(ctx context.Context, before time.Time) (int64, error)
+	PurgeDeletedProjectsBefore(ctx context.Context, before time.Time) (int64, error)
+	PurgeDeletedEnvironmentsBefore(ctx context.Context, before time.Time) (int64, error)
 	ListUsers(ctx context.Context, filter *UserFilter) ([]*models.User, int64, error)
 	// ListUsersInStateBefore returns users whose account_state equals state and
 	// who were created before the cutoff (ADR-025 stale-account warnings).

--- a/internal/storage/store/local_purge.go
+++ b/internal/storage/store/local_purge.go
@@ -1,0 +1,38 @@
+// local_purge.go — retention purge of soft-deleted rows (ADR-032).
+//
+// Each method hard-deletes (Unscoped) rows whose deleted_at predates the cutoff,
+// returning the count removed. The purge scheduler (main.go) drives these on an
+// interval when enabled. Irreversible by design — the retention window is the
+// only safety net.
+package store
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+func (ls *LocalStorage) purgeDeletedBefore(ctx context.Context, model interface{}, before time.Time) (int64, error) {
+	result := ls.db.WithContext(ctx).Unscoped().
+		Where("deleted_at IS NOT NULL AND deleted_at < ?", before).
+		Delete(model)
+	if result.Error != nil {
+		return 0, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), result.Error)
+	}
+	return result.RowsAffected, nil
+}
+
+func (ls *LocalStorage) PurgeDeletedUsersBefore(ctx context.Context, before time.Time) (int64, error) {
+	return ls.purgeDeletedBefore(ctx, &models.User{}, before)
+}
+
+func (ls *LocalStorage) PurgeDeletedProjectsBefore(ctx context.Context, before time.Time) (int64, error) {
+	return ls.purgeDeletedBefore(ctx, &models.Project{}, before)
+}
+
+func (ls *LocalStorage) PurgeDeletedEnvironmentsBefore(ctx context.Context, before time.Time) (int64, error) {
+	return ls.purgeDeletedBefore(ctx, &models.Environment{}, before)
+}

--- a/internal/storage/store/local_purge_test.go
+++ b/internal/storage/store/local_purge_test.go
@@ -1,0 +1,77 @@
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func newPurgeTestStore(t *testing.T) *LocalStorage {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.User{}, &models.Project{}, &models.Environment{}))
+	return NewLocalStorage(db)
+}
+
+func TestPurgeDeletedUsersBefore(t *testing.T) {
+	ls := newPurgeTestStore(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	// Three users: live, soft-deleted long ago, soft-deleted recently.
+	require.NoError(t, ls.db.Create(&models.User{ID: 1, Username: "live", Email: "l@x"}).Error)
+	require.NoError(t, ls.db.Create(&models.User{ID: 2, Username: "old", Email: "o@x"}).Error)
+	require.NoError(t, ls.db.Create(&models.User{ID: 3, Username: "recent", Email: "r@x"}).Error)
+	// Soft-delete 2 (40 days ago) and 3 (1 day ago) by stamping deleted_at directly.
+	require.NoError(t, ls.db.Unscoped().Model(&models.User{}).Where("id = ?", 2).Update("deleted_at", now.AddDate(0, 0, -40)).Error)
+	require.NoError(t, ls.db.Unscoped().Model(&models.User{}).Where("id = ?", 3).Update("deleted_at", now.AddDate(0, 0, -1)).Error)
+
+	cutoff := now.AddDate(0, 0, -30) // 30-day retention
+	n, err := ls.PurgeDeletedUsersBefore(ctx, cutoff)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), n, "only the 40-day-old soft-deleted user is purged")
+
+	// The purged user is gone even with Unscoped; live + recent remain.
+	var count int64
+	require.NoError(t, ls.db.Unscoped().Model(&models.User{}).Count(&count).Error)
+	assert.Equal(t, int64(2), count)
+
+	var purged int64
+	require.NoError(t, ls.db.Unscoped().Model(&models.User{}).Where("id = ?", 2).Count(&purged).Error)
+	assert.Equal(t, int64(0), purged, "row hard-deleted")
+}
+
+func TestPurgeDeletedProjectsAndEnvironments(t *testing.T) {
+	ls := newPurgeTestStore(t)
+	ctx := context.Background()
+	old := time.Now().AddDate(0, 0, -40)
+	cutoff := time.Now().AddDate(0, 0, -30)
+
+	require.NoError(t, ls.db.Create(&models.Project{ID: 1, Name: "p"}).Error)
+	require.NoError(t, ls.db.Unscoped().Model(&models.Project{}).Where("id = ?", 1).Update("deleted_at", old).Error)
+	require.NoError(t, ls.db.Create(&models.Environment{ID: 1, ProjectID: 1, Name: "dev"}).Error)
+	require.NoError(t, ls.db.Unscoped().Model(&models.Environment{}).Where("id = ?", 1).Update("deleted_at", old).Error)
+
+	np, err := ls.PurgeDeletedProjectsBefore(ctx, cutoff)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), np)
+
+	ne, err := ls.PurgeDeletedEnvironmentsBefore(ctx, cutoff)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), ne)
+}
+
+func TestPurgeDeletedUsersBefore_NothingToPurge(t *testing.T) {
+	ls := newPurgeTestStore(t)
+	require.NoError(t, ls.db.Create(&models.User{ID: 1, Username: "live", Email: "l@x"}).Error)
+	n, err := ls.PurgeDeletedUsersBefore(context.Background(), time.Now())
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), n, "a live (non-deleted) user is never purged")
+}

--- a/internal/storage/store/remote_users.go
+++ b/internal/storage/store/remote_users.go
@@ -126,6 +126,19 @@ func (rs *RemoteStorage) RestoreUser(ctx context.Context, id uint) error {
 	return nil
 }
 
+// Retention purge runs server-side (ADR-032); not available in remote mode.
+func (rs *RemoteStorage) PurgeDeletedUsersBefore(_ context.Context, _ time.Time) (int64, error) {
+	return 0, remoteUnsupported("PurgeDeletedUsersBefore")
+}
+
+func (rs *RemoteStorage) PurgeDeletedProjectsBefore(_ context.Context, _ time.Time) (int64, error) {
+	return 0, remoteUnsupported("PurgeDeletedProjectsBefore")
+}
+
+func (rs *RemoteStorage) PurgeDeletedEnvironmentsBefore(_ context.Context, _ time.Time) (int64, error) {
+	return 0, remoteUnsupported("PurgeDeletedEnvironmentsBefore")
+}
+
 // ListUsers lists users with optional filtering via remote API.
 func (rs *RemoteStorage) ListUsers(ctx context.Context, filter *storage.UserFilter) ([]*models.User, int64, error) {
 	path := buildUserFilterPath(filter)

--- a/server/main.go
+++ b/server/main.go
@@ -274,6 +274,36 @@ func startHTTPServer(ctx context.Context, cfg *config.Config) error {
 		}
 	}()
 
+	// Start the retention purge scheduler (ADR-032) — opt-in. Hard-deletes
+	// soft-deleted users/projects/environments older than the retention window.
+	if cfg.Purge.Enabled {
+		retentionDays := cfg.SoftDelete.GetRetentionDays()
+		interval := cfg.Purge.GetInterval()
+		log.Printf("Retention purge scheduler enabled: every %s, %d-day retention", interval, retentionDays)
+		go func() {
+			ticker := time.NewTicker(interval)
+			defer ticker.Stop()
+			runPurge := func() {
+				cutoff := time.Now().AddDate(0, 0, -retentionDays)
+				if res, err := coreService.PurgeExpiredSoftDeletes(ctx, cutoff); err != nil {
+					log.Printf("Retention purge error: %v", err)
+				} else if res.Total() > 0 {
+					log.Printf("Retention purge removed %d soft-deleted records (users=%d, projects=%d, environments=%d)",
+						res.Total(), res.Users, res.Projects, res.Environments)
+				}
+			}
+			runPurge() // run once on startup
+			for {
+				select {
+				case <-ticker.C:
+					runPurge()
+				case <-ctx.Done():
+					return
+				}
+			}
+		}()
+	}
+
 	// Create HTTP server
 	server := &http.Server{
 		Addr:         fmt.Sprintf(":%s", cfg.Server.HTTP.Port),


### PR DESCRIPTION
Wires the long-dormant `SoftDeleteConfig`/`PurgeConfig` (nothing read them) into a real retention lifecycle. Users/projects/environments already soft-delete (GORM `DeletedAt`) with restore endpoints, but soft-deleted rows lived forever. This adds the purge step: permanent removal once `deleted_at` is older than the retention window — the GDPR/NIS2 "erasure after a grace period" story. **ADR-032.** Third M2 engineering item.

## Behaviour

- **`SoftDeleteConfig.RetentionDays`** — grace period before purge (default 30).
- **`PurgeConfig.Enabled`** — **opt-in, default off** (a hard delete is irreversible).
- **`PurgeConfig.Schedule`** — run interval as a Go duration (`24h`, `6h`; default 24h).

A `PurgeExpiredSoftDeletes` core method hard-deletes per entity (`Unscoped().Where("deleted_at < ?")`), and emits one **system-actored `data.purged`** audit event with counts (only when something was purged). The scheduler goroutine in `main.go` mirrors the existing anomaly-detection ticker (run-once-on-start + `ctx.Done()` shutdown), gated on `Purge.Enabled`.

Each entity is purged independently on its own `deleted_at` (no cascade) — simple and idempotent.

## Tests

- storage: older-than boundary (40-day-old purged, 5-day-old kept, live never purged)
- core: counts + system-actored audit; **no audit emitted on a zero-purge run**
- config: getter defaults (retention 30, interval 24h, unparseable falls back)
- Full `go test ./...` green; `gofmt`/`go vet` clean.

## Verified end-to-end

Two soft-deleted users (40 days + 5 days old), purge enabled → on startup the scheduler logged `removed 1 soft-deleted records (users=1, ...)`; the 40-day user was permanently gone, the 5-day user survived the 30-day window, audit `data.purged | system` written.

## Follow-up

Secrets currently **hard-delete** (they use a `Status` field, not `DeletedAt`). Giving `secret_nodes` a `DeletedAt` soft-delete + restore is a separate, larger change (it changes every secret query via GORM scoping) — a tracked follow-up. Once it lands, adding secrets to the purge is a one-line extension.

🤖 Generated with [Claude Code](https://claude.com/claude-code)