### PR TITLE
refactor(grpc): extract shared service helpers into conversions.go

### DIFF
--- a/server/grpc/services/conversions.go
+++ b/server/grpc/services/conversions.go
@@ -1,0 +1,172 @@
+// conversions.go — helpers shared across the gRPC service implementations
+// (ADR Phase-2 split): caller identity, permission checks, proto<->model
+// conversion, and the pagination defaults the paginated list RPCs share. These
+// were previously scattered through secret_service.go / share_service.go; they
+// live here so each service file holds only its own RPC methods.
+package services
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/utils/safeconv"
+	"github.com/keyorixhq/keyorix/server/grpc/interceptors"
+	pb "github.com/keyorixhq/keyorix/server/proto/pb"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// --- Identity & authorization ---
+
+func requireUser(ctx context.Context) (*interceptors.UserContext, error) {
+	user := interceptors.GetUserFromGRPCContext(ctx)
+	if user == nil {
+		return nil, status.Error(codes.Unauthenticated, "user not authenticated")
+	}
+	return user, nil
+}
+
+func hasPermission(permissions []string, required string) bool {
+	for _, p := range permissions {
+		if p == required {
+			return true
+		}
+	}
+	return false
+}
+
+// --- Pagination ---
+
+// normalizePage applies the standard page (>=1) / page_size (1..100, default 20)
+// defaults shared by the paginated list RPCs.
+func normalizePage(page, pageSize uint32) (int, int) {
+	p := int(page)
+	if p < 1 {
+		p = 1
+	}
+	ps := int(pageSize)
+	if ps < 1 || ps > 100 {
+		ps = 20
+	}
+	return p, ps
+}
+
+func totalPages(total, pageSize int) int {
+	if pageSize <= 0 {
+		return 0
+	}
+	return (total + pageSize - 1) / pageSize
+}
+
+// --- Proto <-> model conversion ---
+
+func secretNodeToProto(n *models.SecretNode) *pb.Secret {
+	return &pb.Secret{
+		Id:            intToU32(int(n.ID)),
+		Name:          n.Name,
+		ProjectId:     intToU32(int(n.ProjectID)),
+		EnvironmentId: intToU32(int(n.EnvironmentID)),
+		Type:          n.Type,
+		MaxReads:      intPtrToInt32Ptr(n.MaxReads),
+		Expiration:    timePtrToTs(n.Expiration),
+		Metadata:      metadataToMap(n.Metadata),
+		Tags:          []string{}, // tags are not stored on the secret node
+		Status:        n.Status,
+		CreatedBy:     n.CreatedBy,
+		OwnerId:       intToU32(int(n.OwnerID)),
+		CreatedAt:     timestamppb.New(n.CreatedAt),
+		UpdatedAt:     timestamppb.New(n.UpdatedAt),
+		IsShared:      n.IsShared,
+	}
+}
+
+func sharingInfoToProto(s *models.SecretWithSharingInfo) *pb.Secret {
+	out := secretNodeToProto(s.SecretNode)
+	out.ProjectName = s.ProjectName
+	out.EnvironmentName = s.EnvironmentName
+	out.IsShared = s.IsShared
+	out.IsOwnedByUser = s.IsOwnedByUser
+	out.UserPermission = s.UserPermission
+	out.ShareCount = intToU32(s.ShareCount)
+	return out
+}
+
+func metadataToMap(raw models.JSON) map[string]string {
+	if len(raw) == 0 {
+		return map[string]string{}
+	}
+	m := map[string]string{}
+	_ = json.Unmarshal(raw, &m) // best-effort; non-string maps yield empty
+	return m
+}
+
+// --- Numeric / time / optional conversions ---
+// Overflow is unrealistic for IDs/counts; clamp on the off chance rather than
+// failing the RPC.
+
+func intToU32(v int) uint32 {
+	x, err := safeconv.UintToUint32(uint(v))
+	if err != nil || v < 0 {
+		return 0
+	}
+	return x
+}
+
+func i64ToU32(v int64) uint32 {
+	if v < 0 {
+		return 0
+	}
+	return intToU32(int(v))
+}
+
+func intPtrToInt32Ptr(p *int) *int32 {
+	if p == nil {
+		return nil
+	}
+	v, err := safeconv.IntToInt32(*p)
+	if err != nil {
+		v = 0
+	}
+	return &v
+}
+
+func int32PtrToIntPtr(p *int32) *int {
+	if p == nil {
+		return nil
+	}
+	v := int(*p)
+	return &v
+}
+
+func tsToTimePtr(ts *timestamppb.Timestamp) *time.Time {
+	if ts == nil {
+		return nil
+	}
+	t := ts.AsTime()
+	return &t
+}
+
+func timePtrToTs(t *time.Time) *timestamppb.Timestamp {
+	if t == nil {
+		return nil
+	}
+	return timestamppb.New(*t)
+}
+
+func optString(p *string) *string {
+	if p == nil || *p == "" {
+		return nil
+	}
+	return p
+}
+
+func optUint(p *uint32) *uint {
+	if p == nil || *p == 0 {
+		return nil
+	}
+	v := uint(*p)
+	return &v
+}

--- a/server/grpc/services/secret_service.go
+++ b/server/grpc/services/secret_service.go
@@ -2,14 +2,10 @@ package services
 
 import (
 	"context"
-	"encoding/json"
 	"strings"
-	"time"
 
 	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
-	"github.com/keyorixhq/keyorix/internal/utils/safeconv"
-	"github.com/keyorixhq/keyorix/server/grpc/interceptors"
 	pb "github.com/keyorixhq/keyorix/server/proto/pb"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -245,23 +241,6 @@ func (s *SecretGRPCService) GetSecretVersions(ctx context.Context, req *pb.GetSe
 // requireUser returns the authenticated user from the context or an
 // Unauthenticated error. The auth interceptor populates this on every
 // non-public RPC.
-func requireUser(ctx context.Context) (*interceptors.UserContext, error) {
-	user := interceptors.GetUserFromGRPCContext(ctx)
-	if user == nil {
-		return nil, status.Error(codes.Unauthenticated, "user not authenticated")
-	}
-	return user, nil
-}
-
-func hasPermission(permissions []string, required string) bool {
-	for _, p := range permissions {
-		if p == required {
-			return true
-		}
-	}
-	return false
-}
-
 // mapSecretError translates core errors into gRPC status codes.
 func mapSecretError(err error) error {
 	msg := err.Error()
@@ -277,108 +256,4 @@ func mapSecretError(err error) error {
 	}
 }
 
-func secretNodeToProto(n *models.SecretNode) *pb.Secret {
-	return &pb.Secret{
-		Id:            intToU32(int(n.ID)),
-		Name:          n.Name,
-		ProjectId:     intToU32(int(n.ProjectID)),
-		EnvironmentId: intToU32(int(n.EnvironmentID)),
-		Type:          n.Type,
-		MaxReads:      intPtrToInt32Ptr(n.MaxReads),
-		Expiration:    timePtrToTs(n.Expiration),
-		Metadata:      metadataToMap(n.Metadata),
-		Tags:          []string{}, // tags are not stored on the secret node
-		Status:        n.Status,
-		CreatedBy:     n.CreatedBy,
-		OwnerId:       intToU32(int(n.OwnerID)),
-		CreatedAt:     timestamppb.New(n.CreatedAt),
-		UpdatedAt:     timestamppb.New(n.UpdatedAt),
-		IsShared:      n.IsShared,
-	}
-}
-
-func sharingInfoToProto(s *models.SecretWithSharingInfo) *pb.Secret {
-	out := secretNodeToProto(s.SecretNode)
-	out.ProjectName = s.ProjectName
-	out.EnvironmentName = s.EnvironmentName
-	out.IsShared = s.IsShared
-	out.IsOwnedByUser = s.IsOwnedByUser
-	out.UserPermission = s.UserPermission
-	out.ShareCount = intToU32(s.ShareCount)
-	return out
-}
-
-func metadataToMap(raw models.JSON) map[string]string {
-	if len(raw) == 0 {
-		return map[string]string{}
-	}
-	m := map[string]string{}
-	_ = json.Unmarshal(raw, &m) // best-effort; non-string maps yield empty
-	return m
-}
-
-// numeric conversions — overflow is unrealistic for IDs/counts; clamp on the
-// off chance rather than failing the RPC.
-func intToU32(v int) uint32 {
-	x, err := safeconv.UintToUint32(uint(v))
-	if err != nil || v < 0 {
-		return 0
-	}
-	return x
-}
-
-func i64ToU32(v int64) uint32 {
-	if v < 0 {
-		return 0
-	}
-	return intToU32(int(v))
-}
-
-func intPtrToInt32Ptr(p *int) *int32 {
-	if p == nil {
-		return nil
-	}
-	v, err := safeconv.IntToInt32(*p)
-	if err != nil {
-		v = 0
-	}
-	return &v
-}
-
-func int32PtrToIntPtr(p *int32) *int {
-	if p == nil {
-		return nil
-	}
-	v := int(*p)
-	return &v
-}
-
-func tsToTimePtr(ts *timestamppb.Timestamp) *time.Time {
-	if ts == nil {
-		return nil
-	}
-	t := ts.AsTime()
-	return &t
-}
-
-func timePtrToTs(t *time.Time) *timestamppb.Timestamp {
-	if t == nil {
-		return nil
-	}
-	return timestamppb.New(*t)
-}
-
-func optString(p *string) *string {
-	if p == nil || *p == "" {
-		return nil
-	}
-	return p
-}
-
-func optUint(p *uint32) *uint {
-	if p == nil || *p == 0 {
-		return nil
-	}
-	v := uint(*p)
-	return &v
-}
+// Shared proto-conversion, pagination, and identity helpers live in conversions.go.

--- a/server/grpc/services/share_service.go
+++ b/server/grpc/services/share_service.go
@@ -224,23 +224,4 @@ func sharesToResponse(shares []*models.ShareRecord, page, pageSize int) *pb.List
 	}
 }
 
-// normalizePage applies the standard page (>=1) / page_size (1..100, default 20)
-// defaults shared by the paginated list RPCs.
-func normalizePage(page, pageSize uint32) (int, int) {
-	p := int(page)
-	if p < 1 {
-		p = 1
-	}
-	ps := int(pageSize)
-	if ps < 1 || ps > 100 {
-		ps = 20
-	}
-	return p, ps
-}
-
-func totalPages(total, pageSize int) int {
-	if pageSize <= 0 {
-		return 0
-	}
-	return (total + pageSize - 1) / pageSize
-}
+// Shared pagination helpers (normalizePage / totalPages) live in conversions.go.


### PR DESCRIPTION
Phase-2 gRPC cleanup (the last M2 engineering item). The proto↔model converters, pagination defaults, and caller-identity helpers used by **all six** gRPC services were scattered through `secret_service.go` and `share_service.go`, so those files mixed RPC handlers with package-wide plumbing.

## What

Moved the shared helpers into a dedicated **`conversions.go`**:
- identity/authz: `requireUser`, `hasPermission`
- pagination: `normalizePage`, `totalPages`
- proto conversion: `secretNodeToProto`, `sharingInfoToProto`, `metadataToMap`
- numeric/time/optional: `intToU32`, `i64ToU32`, `intPtrToInt32Ptr`, `int32PtrToIntPtr`, `tsToTimePtr`, `timePtrToTs`, `optString`, `optUint`

Each service file now holds only its own RPC methods plus its service-specific error mapper (`mapSecretError` / `mapShareError`).

## Pure move — no behavior change

The gRPC service tests are unchanged and green, confirming behavior is preserved.

`secret_service.go` 384→259, `share_service.go` 246→227, + `conversions.go` (172). `gofmt`/`go vet` clean; `go test ./...` green.

## Note on scope

The backlog suggested a finer CRUD/versions/listing split. But the original "15.1k/17.8k" was bytes, not lines — after extracting the shared plumbing both files are ~230–260 lines, so further sub-splitting would be over-engineering. The real smell (package-wide helpers arbitrarily parked in two service files) is what this fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)