### PR TITLE
feat(secrets): soft-delete + restore for secrets (ADR-033)

### DIFF
--- a/docs/adr-033-secrets-soft-delete.md
+++ b/docs/adr-033-secrets-soft-delete.md
@@ -1,0 +1,59 @@
+# ADR-033: Secrets soft-delete + restore
+
+**Status:** Accepted
+**Date:** 2026-06-10
+**Context:** Users, projects, and environments soft-delete via GORM `DeletedAt`
+with restore endpoints and are covered by the ADR-032 purge scheduler. Secrets
+were the exception: `SecretNode` had no `DeletedAt`, so `DeleteSecret`
+**hard-deleted** the row immediately — no recycle bin, no restore, and nothing
+for the purge scheduler to govern.
+
+## Context
+
+A secret is the highest-value object in the system; an accidental delete with no
+undo is the worst footgun. Giving `SecretNode` a `DeletedAt` brings it in line
+with every other entity: a delete becomes reversible within the retention
+window, then the purge scheduler erases it permanently.
+
+The catch is GORM's soft-delete scoping. Once `SecretNode` has `DeletedAt`,
+GORM auto-adds `deleted_at IS NULL` to **model-based** queries
+(`db.Model(&SecretNode{})`, `Find`, `First`, `Delete`), but **not** to raw /
+`Table` / `Joins` SQL. An audit found six raw queries that touch `secret_nodes`
+and would otherwise leak soft-deleted secrets into results.
+
+## Decision
+
+Add `DeletedAt gorm.DeletedAt` to `SecretNode` (additive, `columnExists`-guarded
+migration). Consequences, all handled:
+
+- **`DeleteSecret` and the `DeleteProject` cascade become soft automatically** —
+  both already call `db.Delete(&SecretNode{})`, which GORM turns into a
+  `deleted_at` stamp once the field exists. The `DeleteProject` restore path now
+  also clears secrets' `deleted_at` (it previously, incorrectly, assumed secrets
+  were hard-deleted).
+- **`RestoreSecret`** (`Unscoped().Where("id = ? AND deleted_at IS NOT NULL").
+  Update("deleted_at", nil)`) + `POST /api/v1/secrets/{id}/restore`, mirroring
+  the user/project restore endpoints.
+- **List with `?include_deleted=true`** (`SecretFilter.IncludeDeleted` →
+  `Unscoped()`), so a restore UI can surface deleted secrets; the response
+  carries `deleted_at`.
+- **The six raw queries get an explicit `s.deleted_at IS NULL`**:
+  `ListProjectsWithCounts` (count/last-activity), `MostAccessedSecrets`,
+  `UnusedSecrets`, `ListProjectSecretsForDrift`, and the two `ListSharedSecrets`
+  joins. Without these, deleted secrets would inflate counts and appear in
+  usage/drift/shared views.
+- **Purge coverage**: `PurgeDeletedSecretsBefore` joins the ADR-032 scheduler, so
+  a soft-deleted secret older than the retention window is permanently removed
+  alongside users/projects/environments.
+
+The pre-existing `Status` field (active/expired business state) is orthogonal to
+`DeletedAt` (existence) and is left as-is.
+
+## Consequences
+
+- Deleting a secret is now reversible within the retention window — a real
+  safety net for the most dangerous operation in the product.
+- The blast radius of GORM auto-scoping is contained to the six audited raw
+  queries; all other secret access is model-based and filters automatically.
+- Soft-deleted secrets never appear in lists, counts, usage analytics, drift,
+  or shared-with-me views, and are erased by the purge scheduler on schedule.

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -195,6 +195,24 @@ func (m *MockStorage) DeleteSecret(ctx context.Context, id uint) error {
 	return args.Error(0)
 }
 
+func (m *MockStorage) RestoreSecret(ctx context.Context, id uint) error {
+	args := m.Called(ctx, id)
+	return args.Error(0)
+}
+
+func (m *MockStorage) GetSecretIncludingDeleted(ctx context.Context, id uint) (*models.SecretNode, error) {
+	args := m.Called(ctx, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.SecretNode), args.Error(1)
+}
+
+func (m *MockStorage) PurgeDeletedSecretsBefore(ctx context.Context, before time.Time) (int64, error) {
+	args := m.Called(ctx, before)
+	return args.Get(0).(int64), args.Error(1)
+}
+
 func (m *MockStorage) ListSecrets(ctx context.Context, filter *storage.SecretFilter) ([]*models.SecretNode, int64, error) {
 	args := m.Called(ctx, filter)
 	if args.Get(0) == nil {

--- a/internal/core/purge.go
+++ b/internal/core/purge.go
@@ -12,10 +12,13 @@ type PurgeResult struct {
 	Users        int64 `json:"users"`
 	Projects     int64 `json:"projects"`
 	Environments int64 `json:"environments"`
+	Secrets      int64 `json:"secrets"`
 }
 
 // Total is the combined count of purged rows.
-func (r PurgeResult) Total() int64 { return r.Users + r.Projects + r.Environments }
+func (r PurgeResult) Total() int64 {
+	return r.Users + r.Projects + r.Environments + r.Secrets
+}
 
 // PurgeExpiredSoftDeletes hard-deletes every soft-deleted user, project, and
 // environment whose deleted_at predates `before`. Each entity is purged
@@ -35,12 +38,13 @@ func (c *KeyorixCore) PurgeExpiredSoftDeletes(ctx context.Context, before time.T
 	res.Users = record(c.storage.PurgeDeletedUsersBefore(ctx, before))
 	res.Projects = record(c.storage.PurgeDeletedProjectsBefore(ctx, before))
 	res.Environments = record(c.storage.PurgeDeletedEnvironmentsBefore(ctx, before))
+	res.Secrets = record(c.storage.PurgeDeletedSecretsBefore(ctx, before))
 
 	if res.Total() > 0 {
 		sysCtx := WithActorType(ctx, ActorTypeSystem)
 		c.writeAuditEvent(sysCtx, "data.purged", nil, nil,
-			fmt.Sprintf("retention purge removed %d soft-deleted records (users=%d, projects=%d, environments=%d) older than %s",
-				res.Total(), res.Users, res.Projects, res.Environments, before.UTC().Format(time.RFC3339)))
+			fmt.Sprintf("retention purge removed %d soft-deleted records (users=%d, projects=%d, environments=%d, secrets=%d) older than %s",
+				res.Total(), res.Users, res.Projects, res.Environments, res.Secrets, before.UTC().Format(time.RFC3339)))
 	}
 
 	return res, firstErr

--- a/internal/core/purge_test.go
+++ b/internal/core/purge_test.go
@@ -16,6 +16,7 @@ func TestPurgeExpiredSoftDeletes_CountsAndAudits(t *testing.T) {
 	store.On("PurgeDeletedUsersBefore", mock.Anything, before).Return(int64(2), nil)
 	store.On("PurgeDeletedProjectsBefore", mock.Anything, before).Return(int64(1), nil)
 	store.On("PurgeDeletedEnvironmentsBefore", mock.Anything, before).Return(int64(3), nil)
+	store.On("PurgeDeletedSecretsBefore", mock.Anything, before).Return(int64(4), nil)
 
 	// Something was purged → a single system-actored data.purged event is written.
 	var auditedActorType string
@@ -33,7 +34,8 @@ func TestPurgeExpiredSoftDeletes_CountsAndAudits(t *testing.T) {
 	require.Equal(t, int64(2), res.Users)
 	require.Equal(t, int64(1), res.Projects)
 	require.Equal(t, int64(3), res.Environments)
-	require.Equal(t, int64(6), res.Total())
+	require.Equal(t, int64(4), res.Secrets)
+	require.Equal(t, int64(10), res.Total())
 	require.Equal(t, ActorTypeSystem, auditedActorType, "purge is actored as system")
 }
 
@@ -43,6 +45,7 @@ func TestPurgeExpiredSoftDeletes_NoAuditWhenNothingPurged(t *testing.T) {
 	store.On("PurgeDeletedUsersBefore", mock.Anything, before).Return(int64(0), nil)
 	store.On("PurgeDeletedProjectsBefore", mock.Anything, before).Return(int64(0), nil)
 	store.On("PurgeDeletedEnvironmentsBefore", mock.Anything, before).Return(int64(0), nil)
+	store.On("PurgeDeletedSecretsBefore", mock.Anything, before).Return(int64(0), nil)
 	// No LogAuditEvent expectation: a zero-purge run must not emit an event.
 
 	c := NewKeyorixCore(store)

--- a/internal/core/secret_listing_query.go
+++ b/internal/core/secret_listing_query.go
@@ -281,12 +281,13 @@ func (c *KeyorixCore) sortSecrets(secrets []*models.SecretWithSharingInfo, sortB
 // convertToStorageFilter converts SecretListFilter to storage.SecretFilter.
 func (c *KeyorixCore) convertToStorageFilter(filter *models.SecretListFilter) *storage.SecretFilter {
 	f := &storage.SecretFilter{
-		Page:          filter.Page,
-		PageSize:      filter.PageSize,
-		Type:          filter.Type,
-		CreatedBy:     filter.CreatedBy,
-		ProjectID:     filter.ProjectID,
-		EnvironmentID: filter.EnvironmentID,
+		Page:           filter.Page,
+		PageSize:       filter.PageSize,
+		Type:           filter.Type,
+		CreatedBy:      filter.CreatedBy,
+		ProjectID:      filter.ProjectID,
+		EnvironmentID:  filter.EnvironmentID,
+		IncludeDeleted: filter.IncludeDeleted,
 	}
 	if f.Page < 1 {
 		f.Page = 1

--- a/internal/core/secrets.go
+++ b/internal/core/secrets.go
@@ -224,6 +224,18 @@ func (c *KeyorixCore) DeleteSecretWithPermissionCheck(ctx context.Context, id, u
 	return c.DeleteSecret(ctx, id)
 }
 
+// RestoreSecret clears a soft-deleted secret's deleted_at (ADR-033), bringing it
+// back within the retention window.
+func (c *KeyorixCore) RestoreSecret(ctx context.Context, id uint) error {
+	if id == 0 {
+		return fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "secret ID is required")
+	}
+	if err := c.storage.RestoreSecret(ctx, id); err != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	return nil
+}
+
 // ListSecrets lists secrets with filtering and pagination.
 func (c *KeyorixCore) ListSecrets(ctx context.Context, filter *storage.SecretFilter) ([]*models.SecretNode, int64, error) {
 	if filter == nil {

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -93,6 +93,11 @@ type Storage interface {
 	GetSecretByName(ctx context.Context, name string, projectID, environmentID uint) (*models.SecretNode, error)
 	UpdateSecret(ctx context.Context, secret *models.SecretNode) (*models.SecretNode, error)
 	DeleteSecret(ctx context.Context, id uint) error
+	// RestoreSecret clears a soft-deleted secret's deleted_at (ADR-033).
+	RestoreSecret(ctx context.Context, id uint) error
+	// GetSecretIncludingDeleted loads a secret even if soft-deleted (Unscoped),
+	// so the restore route can resolve a deleted secret's scope (ADR-033).
+	GetSecretIncludingDeleted(ctx context.Context, id uint) (*models.SecretNode, error)
 	ListSecrets(ctx context.Context, filter *SecretFilter) ([]*models.SecretNode, int64, error)
 	// ListProjectSecretsForDrift returns one lightweight row per secret in the
 	// project (folders excluded, secrets in soft-deleted environments excluded),
@@ -136,6 +141,7 @@ type Storage interface {
 	PurgeDeletedUsersBefore(ctx context.Context, before time.Time) (int64, error)
 	PurgeDeletedProjectsBefore(ctx context.Context, before time.Time) (int64, error)
 	PurgeDeletedEnvironmentsBefore(ctx context.Context, before time.Time) (int64, error)
+	PurgeDeletedSecretsBefore(ctx context.Context, before time.Time) (int64, error)
 	ListUsers(ctx context.Context, filter *UserFilter) ([]*models.User, int64, error)
 	// ListUsersInStateBefore returns users whose account_state equals state and
 	// who were created before the cutoff (ADR-025 stale-account warnings).
@@ -315,6 +321,9 @@ type SecretFilter struct {
 	CreatedBefore *time.Time
 	Page          int
 	PageSize      int
+	// IncludeDeleted, when true, also returns soft-deleted secrets (ADR-033) —
+	// for a restore UI. Default false: GORM auto-scopes deleted_at IS NULL.
+	IncludeDeleted bool
 }
 
 // DriftSecretRow is one secret's drift-relevant projection: which environment it

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -143,6 +143,10 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 	if tableExists(db, "secret_nodes") && !columnExists(db, "secret_nodes", "last_rotated_at") {
 		db.Exec("ALTER TABLE secret_nodes ADD COLUMN last_rotated_at TIMESTAMP WITH TIME ZONE")
 	}
+	// ADR-033: secrets soft-delete. Additive deleted_at (nil = live).
+	if tableExists(db, "secret_nodes") && !columnExists(db, "secret_nodes", "deleted_at") {
+		db.Exec("ALTER TABLE secret_nodes ADD COLUMN deleted_at TIMESTAMP WITH TIME ZONE")
+	}
 
 	// Track last successful login per user (nil = never logged in).
 	if tableExists(db, "users") && !columnExists(db, "users", "last_login_at") {

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -165,6 +165,11 @@ type SecretNode struct {
 	CreatedAt     time.Time
 	UpdatedAt     time.Time
 	LastRotatedAt *time.Time
+	// DeletedAt enables soft delete (ADR-033). DELETE stamps it; restore clears
+	// it; the purge scheduler hard-deletes rows past the retention window. GORM
+	// auto-scopes `deleted_at IS NULL` on model-based queries — raw/Table/Joins
+	// queries on secret_nodes must filter it explicitly.
+	DeletedAt gorm.DeletedAt `gorm:"index"`
 }
 
 type SecretVersion struct {

--- a/internal/storage/models/secret_with_sharing.go
+++ b/internal/storage/models/secret_with_sharing.go
@@ -52,6 +52,9 @@ type SecretListFilter struct {
 	// Sorting
 	SortBy    string // "name", "created_at", "shared_at", "owner"
 	SortOrder string // "asc", "desc"
+
+	// IncludeDeleted also returns soft-deleted secrets (ADR-033) for a restore UI.
+	IncludeDeleted bool
 }
 
 // SecretListResponse represents the response for listing secrets with sharing information

--- a/internal/storage/store/local_audit.go
+++ b/internal/storage/store/local_audit.go
@@ -88,7 +88,7 @@ func (ls *LocalStorage) MostAccessedSecrets(ctx context.Context, projectID *uint
 	q := ls.db.WithContext(ctx).
 		Table("secret_access_logs AS l").
 		Select("l.secret_node_id AS secret_id, s.name AS secret_name, s.environment_id AS environment_id, COUNT(*) AS read_count, MAX(l.access_time) AS last_read").
-		Joins("JOIN secret_nodes s ON s.id = l.secret_node_id").
+		Joins("JOIN secret_nodes s ON s.id = l.secret_node_id AND s.deleted_at IS NULL").
 		Where("s.is_secret = ?", true).
 		Where("l.action = ?", "read").
 		Where("l.access_time >= ?", since).
@@ -130,6 +130,7 @@ func (ls *LocalStorage) UnusedSecrets(ctx context.Context, projectID *uint, notR
 		Select("s.id AS secret_id, s.name AS secret_name, s.environment_id AS environment_id, MAX(l.access_time) AS last_read").
 		Joins("LEFT JOIN secret_access_logs l ON l.secret_node_id = s.id AND l.action = ?", "read").
 		Where("s.is_secret = ?", true).
+		Where("s.deleted_at IS NULL").
 		Group("s.id, s.name, s.environment_id").
 		Having("MAX(l.access_time) IS NULL OR MAX(l.access_time) < ?", notReadSince).
 		Order("(MAX(l.access_time) IS NULL) DESC, last_read ASC")

--- a/internal/storage/store/local_drift.go
+++ b/internal/storage/store/local_drift.go
@@ -33,6 +33,7 @@ func (ls *LocalStorage) ListProjectSecretsForDrift(ctx context.Context, projectI
 		Where("s.project_id = ?", projectID).
 		Where("e.project_id = ?", projectID).
 		Where("e.deleted_at IS NULL").
+		Where("s.deleted_at IS NULL").
 		Where("s.is_secret = ?", true).
 		Order("s.name ASC, s.environment_id ASC").
 		Scan(&rows).Error; err != nil {

--- a/internal/storage/store/local_purge.go
+++ b/internal/storage/store/local_purge.go
@@ -36,3 +36,7 @@ func (ls *LocalStorage) PurgeDeletedProjectsBefore(ctx context.Context, before t
 func (ls *LocalStorage) PurgeDeletedEnvironmentsBefore(ctx context.Context, before time.Time) (int64, error) {
 	return ls.purgeDeletedBefore(ctx, &models.Environment{}, before)
 }
+
+func (ls *LocalStorage) PurgeDeletedSecretsBefore(ctx context.Context, before time.Time) (int64, error) {
+	return ls.purgeDeletedBefore(ctx, &models.SecretNode{}, before)
+}

--- a/internal/storage/store/local_secrets.go
+++ b/internal/storage/store/local_secrets.go
@@ -62,7 +62,7 @@ func (ls *LocalStorage) ListProjectsWithCounts(ctx context.Context, includeDelet
 		       COUNT(DISTINCT e.id) AS environment_count,
 		       MAX(s.updated_at) AS last_secret_activity
 		FROM projects p
-		LEFT JOIN secret_nodes s ON s.project_id = p.id
+		LEFT JOIN secret_nodes s ON s.project_id = p.id AND s.deleted_at IS NULL
 		LEFT JOIN environments e ON e.project_id = p.id AND e.deleted_at IS NULL
 		` + where + `
 		GROUP BY p.id
@@ -155,6 +155,12 @@ func (ls *LocalStorage) RestoreProject(ctx context.Context, id uint) error {
 		if err := tx.Unscoped().Model(&models.Environment{}).
 			Where("project_id = ?", id).Update("deleted_at", nil).Error; err != nil {
 			return fmt.Errorf("failed to restore project environments: %w", err)
+		}
+		// Secrets cascade-restore too (ADR-033 made them soft-deletable; the
+		// DeleteProject cascade soft-deletes them, so a restore must bring them back).
+		if err := tx.Unscoped().Model(&models.SecretNode{}).
+			Where("project_id = ?", id).Update("deleted_at", nil).Error; err != nil {
+			return fmt.Errorf("failed to restore project secrets: %w", err)
 		}
 		return nil
 	})
@@ -281,12 +287,39 @@ func (ls *LocalStorage) DeleteSecret(ctx context.Context, id uint) error {
 	return nil
 }
 
+// GetSecretIncludingDeleted loads a secret even when soft-deleted (Unscoped).
+func (ls *LocalStorage) GetSecretIncludingDeleted(ctx context.Context, id uint) (*models.SecretNode, error) {
+	var secret models.SecretNode
+	if err := ls.db.WithContext(ctx).Unscoped().First(&secret, id).Error; err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorSecretNotFound", nil), err)
+	}
+	return &secret, nil
+}
+
+// RestoreSecret clears a soft-deleted secret's deleted_at (ADR-033). Uses
+// Unscoped to reach the soft-deleted row, which GORM hides by default.
+func (ls *LocalStorage) RestoreSecret(ctx context.Context, id uint) error {
+	result := ls.db.WithContext(ctx).Unscoped().Model(&models.SecretNode{}).
+		Where("id = ? AND deleted_at IS NOT NULL", id).Update("deleted_at", nil)
+	if result.Error != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), result.Error)
+	}
+	if result.RowsAffected == 0 {
+		return fmt.Errorf("%s", i18n.T("ErrorSecretNotFound", nil))
+	}
+	return nil
+}
+
 // ListSecrets lists secrets with filtering and pagination.
 // When project_id is provided, results are always scoped to that project via
 // a JOIN through environments — prevents cross-project leakage if a caller
 // passes a mismatched environment_id.
 func (ls *LocalStorage) ListSecrets(ctx context.Context, filter *storage.SecretFilter) ([]*models.SecretNode, int64, error) {
 	query := ls.db.WithContext(ctx).Model(&models.SecretNode{})
+	if filter.IncludeDeleted {
+		// Reach soft-deleted rows too (restore UI); GORM hides them by default.
+		query = query.Unscoped()
+	}
 
 	if filter.ProjectID != nil {
 		// JOIN ensures environment_id is always verified against the project,

--- a/internal/storage/store/local_sharing.go
+++ b/internal/storage/store/local_sharing.go
@@ -158,7 +158,7 @@ func (ls *LocalStorage) ListSharedSecrets(ctx context.Context, userID uint) ([]*
 	directQuery := `
 		SELECT s.* FROM secret_nodes s
 		JOIN share_records sr ON s.id = sr.secret_id
-		WHERE sr.recipient_id = ? AND sr.is_group = ? AND sr.deleted_at IS NULL
+		WHERE sr.recipient_id = ? AND sr.is_group = ? AND sr.deleted_at IS NULL AND s.deleted_at IS NULL
 	`
 	if err := ls.db.Raw(directQuery, userID, false).Scan(&secrets).Error; err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorDatabaseOperation", nil), err)
@@ -168,7 +168,7 @@ func (ls *LocalStorage) ListSharedSecrets(ctx context.Context, userID uint) ([]*
 		SELECT s.* FROM secret_nodes s
 		JOIN share_records sr ON s.id = sr.secret_id
 		JOIN user_groups ug ON sr.recipient_id = ug.group_id
-		WHERE ug.user_id = ? AND sr.is_group = ? AND sr.deleted_at IS NULL
+		WHERE ug.user_id = ? AND sr.is_group = ? AND sr.deleted_at IS NULL AND s.deleted_at IS NULL
 	`
 	var groupSecrets []*models.SecretNode
 	if err := ls.db.Raw(groupQuery, userID, true).Scan(&groupSecrets).Error; err != nil {

--- a/internal/storage/store/remote_secrets.go
+++ b/internal/storage/store/remote_secrets.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
@@ -97,6 +98,28 @@ func (rs *RemoteStorage) DeleteSecret(ctx context.Context, id uint) error {
 		return fmt.Errorf("delete secret failed: %s", resp.Error.Error())
 	}
 	return nil
+}
+
+// GetSecretIncludingDeleted is not available in remote mode; restore resolves server-side.
+func (rs *RemoteStorage) GetSecretIncludingDeleted(_ context.Context, _ uint) (*models.SecretNode, error) {
+	return nil, remoteUnsupported("GetSecretIncludingDeleted")
+}
+
+func (rs *RemoteStorage) RestoreSecret(ctx context.Context, id uint) error {
+	path := fmt.Sprintf("/api/v1/secrets/%d/restore", id)
+	resp, err := rs.client.Post(ctx, path, nil)
+	if err != nil {
+		return fmt.Errorf("failed to restore secret: %w", err)
+	}
+	if !resp.Success {
+		return fmt.Errorf("restore secret failed: %s", resp.Error.Error())
+	}
+	return nil
+}
+
+// Retention purge runs server-side (ADR-032/033); not available in remote mode.
+func (rs *RemoteStorage) PurgeDeletedSecretsBefore(_ context.Context, _ time.Time) (int64, error) {
+	return 0, remoteUnsupported("PurgeDeletedSecretsBefore")
 }
 
 // ListSecrets lists secrets with optional filtering via remote API.

--- a/internal/storage/store/restore_test.go
+++ b/internal/storage/store/restore_test.go
@@ -46,15 +46,15 @@ func TestRestoreProjectCascade(t *testing.T) {
 	assert.True(t, all[0].Deleted)
 	assert.NotEmpty(t, all[0].DeletedAt)
 
-	// Restore brings back the project and its environments. Secrets are NOT
-	// restored — DeleteProject hard-deletes them (no soft-delete on SecretNode).
+	// Restore brings back the project, its environments, AND its secrets —
+	// secrets now soft-delete with the project and restore with it (ADR-033).
 	require.NoError(t, ls.RestoreProject(ctx, proj.ID))
 
 	restored, err := ls.ListProjectsWithCounts(ctx, false)
 	require.NoError(t, err)
 	require.Len(t, restored, 1)
 	assert.False(t, restored[0].Deleted)
-	assert.Equal(t, int64(0), restored[0].SecretCount, "secrets are hard-deleted, not restored")
+	assert.Equal(t, int64(1), restored[0].SecretCount, "secrets are soft-deleted with the project and restored (ADR-033)")
 	assert.Equal(t, int64(1), restored[0].EnvironmentCount, "environment should be restored")
 
 	envs, err := ls.ListEnvironmentsByProject(ctx, proj.ID)

--- a/internal/storage/store/secret_soft_delete_test.go
+++ b/internal/storage/store/secret_soft_delete_test.go
@@ -1,0 +1,83 @@
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func newSoftDeleteTestStore(t *testing.T) *LocalStorage {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.Environment{}))
+	return NewLocalStorage(db)
+}
+
+func TestSecretSoftDeleteLifecycle(t *testing.T) {
+	ls := newSoftDeleteTestStore(t)
+	ctx := context.Background()
+	const projectID = uint(1)
+
+	require.NoError(t, ls.db.Create(&models.Environment{ID: 10, ProjectID: projectID, Name: "dev"}).Error)
+	s, err := ls.CreateSecret(ctx, &models.SecretNode{ProjectID: projectID, EnvironmentID: 10, Name: "API_KEY", IsSecret: true, Type: "api_key", Status: "active"})
+	require.NoError(t, err)
+
+	// Soft-delete via the model-aware Delete (now a deleted_at stamp, not a row removal).
+	require.NoError(t, ls.DeleteSecret(ctx, s.ID))
+
+	// Scoped reads hide it; Unscoped read still finds it.
+	_, err = ls.GetSecret(ctx, s.ID)
+	require.Error(t, err, "GetSecret hides soft-deleted secrets")
+	got, err := ls.GetSecretIncludingDeleted(ctx, s.ID)
+	require.NoError(t, err)
+	assert.True(t, got.DeletedAt.Valid, "row retained with deleted_at set")
+
+	// ListSecrets excludes by default, includes with IncludeDeleted.
+	live, _, err := ls.ListSecrets(ctx, &storage.SecretFilter{ProjectID: ptr(projectID), Page: 1, PageSize: 50})
+	require.NoError(t, err)
+	assert.Len(t, live, 0, "soft-deleted secret excluded from default listing")
+	all, _, err := ls.ListSecrets(ctx, &storage.SecretFilter{ProjectID: ptr(projectID), Page: 1, PageSize: 50, IncludeDeleted: true})
+	require.NoError(t, err)
+	assert.Len(t, all, 1, "IncludeDeleted surfaces it for the restore UI")
+
+	// The drift raw query (Table/Joins) must also exclude it.
+	drift, err := ls.ListProjectSecretsForDrift(ctx, projectID)
+	require.NoError(t, err)
+	assert.Len(t, drift, 0, "raw drift query filters s.deleted_at IS NULL")
+
+	// Restore brings it back.
+	require.NoError(t, ls.RestoreSecret(ctx, s.ID))
+	restored, err := ls.GetSecret(ctx, s.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "API_KEY", restored.Name)
+}
+
+func TestPurgeDeletedSecretsBefore(t *testing.T) {
+	ls := newSoftDeleteTestStore(t)
+	ctx := context.Background()
+
+	// Two soft-deleted secrets, one 40d old, one 5d old (stamp deleted_at directly).
+	for i, name := range []string{"old", "recent"} {
+		require.NoError(t, ls.db.Create(&models.SecretNode{ID: uint(i + 1), ProjectID: 1, EnvironmentID: 10, Name: name, IsSecret: true}).Error)
+	}
+	require.NoError(t, ls.db.Unscoped().Model(&models.SecretNode{}).Where("name = ?", "old").Update("deleted_at", time.Now().AddDate(0, 0, -40)).Error)
+	require.NoError(t, ls.db.Unscoped().Model(&models.SecretNode{}).Where("name = ?", "recent").Update("deleted_at", time.Now().AddDate(0, 0, -5)).Error)
+
+	n, err := ls.PurgeDeletedSecretsBefore(ctx, time.Now().AddDate(0, 0, -30))
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), n, "only the 40-day-old soft-deleted secret is purged")
+
+	var remaining int64
+	require.NoError(t, ls.db.Unscoped().Model(&models.SecretNode{}).Where("name = ?", "old").Count(&remaining).Error)
+	assert.Equal(t, int64(0), remaining, "purged row hard-deleted")
+}
+
+func ptr[T any](v T) *T { return &v }

--- a/server/http/handlers/secrets_crud.go
+++ b/server/http/handlers/secrets_crud.go
@@ -155,6 +155,30 @@ func (h *SecretHandler) GetSecret(w http.ResponseWriter, r *http.Request) {
 	h.sendSuccess(w, response, "")
 }
 
+// RestoreSecret handles POST /api/v1/secrets/{id}/restore — clears a
+// soft-deleted secret's deleted_at (ADR-033). Authorized by the route's scoped
+// secrets.write gate at the secret's own project/environment.
+func (h *SecretHandler) RestoreSecret(w http.ResponseWriter, r *http.Request) {
+	if middleware.GetUserFromContext(r.Context()) == nil {
+		h.sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		h.sendError(w, "InvalidParameter", "Invalid secret ID", http.StatusBadRequest, nil)
+		return
+	}
+	if err := h.coreService.RestoreSecret(r.Context(), uint(id)); err != nil {
+		status := http.StatusInternalServerError
+		if strings.Contains(err.Error(), "not found") {
+			status = http.StatusNotFound
+		}
+		h.sendError(w, "Error", err.Error(), status, nil)
+		return
+	}
+	h.sendSuccess(w, nil, "Secret restored")
+}
+
 // UpdateSecret handles PUT /api/v1/secrets/{id}
 func (h *SecretHandler) UpdateSecret(w http.ResponseWriter, r *http.Request) {
 	userCtx := middleware.GetUserFromContext(r.Context())

--- a/server/http/handlers/secrets_list.go
+++ b/server/http/handlers/secrets_list.go
@@ -57,6 +57,9 @@ func (h *SecretHandler) ListSecrets(w http.ResponseWriter, r *http.Request) {
 		filter.Search = &search
 	}
 
+	if r.URL.Query().Get("include_deleted") == "true" {
+		filter.IncludeDeleted = true
+	}
 	if r.URL.Query().Get("show_owned_only") == "true" {
 		filter.ShowOwnedOnly = true
 	}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -238,6 +238,8 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.With(customMiddleware.RequireScopedPermission("secrets.write", secretScope)).Post("/{id}/share", shareHandler.ShareSecret)
 
 			r.With(customMiddleware.RequireScopedPermission("secrets.delete", secretScope)).Delete("/{id}", secretHandler.DeleteSecret)
+			// Restore resolves scope from the (soft-deleted) secret via the unscoped resolver.
+			r.With(customMiddleware.RequireScopedPermission("secrets.write", customMiddleware.ScopeFromDeletedSecretParam("id"))).Post("/{id}/restore", secretHandler.RestoreSecret)
 		})
 
 		// Shares endpoints. The user's own share list stays a global-read op;

--- a/server/main.go
+++ b/server/main.go
@@ -288,8 +288,8 @@ func startHTTPServer(ctx context.Context, cfg *config.Config) error {
 				if res, err := coreService.PurgeExpiredSoftDeletes(ctx, cutoff); err != nil {
 					log.Printf("Retention purge error: %v", err)
 				} else if res.Total() > 0 {
-					log.Printf("Retention purge removed %d soft-deleted records (users=%d, projects=%d, environments=%d)",
-						res.Total(), res.Users, res.Projects, res.Environments)
+					log.Printf("Retention purge removed %d soft-deleted records (users=%d, projects=%d, environments=%d, secrets=%d)",
+						res.Total(), res.Users, res.Projects, res.Environments, res.Secrets)
 				}
 			}
 			runPurge() // run once on startup

--- a/server/middleware/auth.go
+++ b/server/middleware/auth.go
@@ -363,6 +363,23 @@ func ScopeFromSecretParam(param string) ScopeResolver {
 	}
 }
 
+// ScopeFromDeletedSecretParam resolves the scope of a secret that may be
+// soft-deleted (loads it Unscoped). Used by the restore route, where the target
+// secret is by definition soft-deleted and unloadable via the normal path.
+func ScopeFromDeletedSecretParam(param string) ScopeResolver {
+	return func(r *http.Request, cs *core.KeyorixCore) (core.Scope, error) {
+		id, err := scopePathUint(r, param)
+		if err != nil {
+			return core.Scope{}, errInvalidTarget
+		}
+		secret, err := cs.Storage().GetSecretIncludingDeleted(r.Context(), id)
+		if err != nil {
+			return core.Scope{}, errTargetNotFound
+		}
+		return core.Scope{ProjectID: secret.ProjectID, EnvironmentID: secret.EnvironmentID}, nil
+	}
+}
+
 // ScopeFromShareParam treats the named path param as a share ID and resolves the
 // scope of the shared secret.
 func ScopeFromShareParam(param string) ScopeResolver {


### PR DESCRIPTION
Secrets were the one entity that **hard-deleted** — `DeleteSecret` removed the row immediately, no undo, nothing for the purge scheduler to govern. This gives `SecretNode` a `gorm.DeletedAt` so a delete is reversible within the retention window, then permanently erased by the ADR-032 purge scheduler. **ADR-033.** (The first of the two deferred follow-ups.)

## The careful part: GORM auto-scoping

GORM auto-scopes `deleted_at IS NULL` on **model-based** queries, so `DeleteSecret` and the `DeleteProject` cascade became soft-delete automatically. The audited risk was the **6 raw/`Table`/`Joins` queries** that don't auto-scope — each now filters `s.deleted_at IS NULL` so soft-deleted secrets never leak into:
- `ListProjectsWithCounts` (project counts + last-activity)
- `MostAccessedSecrets`, `UnusedSecrets` (usage analytics)
- `ListProjectSecretsForDrift` (cross-environment drift)
- both `ListSharedSecrets` joins (shared-with-me)

## Added

- **`RestoreSecret`** + `POST /api/v1/secrets/{id}/restore`, gated by `secrets.write` at the **soft-deleted** secret's own scope via a new `ScopeFromDeletedSecretParam` resolver (`GetSecretIncludingDeleted` loads it `Unscoped`).
- **`?include_deleted=true`** on the list endpoint (`SecretFilter.IncludeDeleted` → `Unscoped`) for a restore UI; threaded through `SecretListFilter`.
- `DeleteProject`'s restore cascade now **also restores secrets** (it previously, wrongly, assumed secrets were hard-deleted — fixed that test too).
- **`PurgeDeletedSecretsBefore`** joins the purge scheduler; the `data.purged` audit event + log now report `secrets=N`.
- Additive `deleted_at` migration, `columnExists`-guarded.

## Tests

Soft-delete lifecycle (hidden / Unscoped / include-deleted / restore), raw-query exclusion (drift), purge boundary (40-day purged, 5-day kept); updated `RestoreProjectCascade` + purge-orchestration tests for the new secrets coverage. Full `go test ./...` green; `gofmt`/`go vet` clean.

## Verified end-to-end

delete → **204**, DB row retained with `deleted_at` set; list **hides** it, `include_deleted=true` **surfaces** it, GET → **404**; restore → **200**, GET → **200**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)