### PR TITLE
fix(install): correct release asset names + verify checksums

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -53,8 +53,8 @@ fi
 
 info "Latest version: ${LATEST}"
 
-# Download URL
-BINARY_NAME="${BINARY}-${OS}-${ARCH}"
+# Download URL — release assets are named with underscores (keyorix_linux_amd64).
+BINARY_NAME="${BINARY}_${OS}_${ARCH}"
 DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${LATEST}/${BINARY_NAME}"
 
 # Download binary
@@ -66,6 +66,35 @@ if command -v curl >/dev/null 2>&1; then
     curl -fsSL "$DOWNLOAD_URL" -o "$TMP_BIN" || error "Download failed. Check https://github.com/${REPO}/releases/${LATEST}"
 else
     wget -qO "$TMP_BIN" "$DOWNLOAD_URL" || error "Download failed. Check https://github.com/${REPO}/releases/${LATEST}"
+fi
+
+# Verify SHA-256 checksum against the release's published checksums.txt.
+info "Verifying checksum..."
+CHECKSUMS_URL="https://github.com/${REPO}/releases/download/${LATEST}/checksums.txt"
+if command -v curl >/dev/null 2>&1; then
+    EXPECTED=$(curl -fsSL "$CHECKSUMS_URL" | awk -v n="$BINARY_NAME" '$2==n {print $1}')
+else
+    EXPECTED=$(wget -qO- "$CHECKSUMS_URL" | awk -v n="$BINARY_NAME" '$2==n {print $1}')
+fi
+
+if [ -n "$EXPECTED" ]; then
+    if command -v sha256sum >/dev/null 2>&1; then
+        ACTUAL=$(sha256sum "$TMP_BIN" | awk '{print $1}')
+    elif command -v shasum >/dev/null 2>&1; then
+        ACTUAL=$(shasum -a 256 "$TMP_BIN" | awk '{print $1}')
+    else
+        ACTUAL=""
+    fi
+    if [ -n "$ACTUAL" ] && [ "$ACTUAL" != "$EXPECTED" ]; then
+        error "Checksum mismatch for ${BINARY_NAME}: expected ${EXPECTED}, got ${ACTUAL}. Aborting."
+    fi
+    if [ -n "$ACTUAL" ]; then
+        success "Checksum verified"
+    else
+        info "No sha256 tool found; skipping checksum verification"
+    fi
+else
+    info "No checksum published for ${BINARY_NAME}; skipping verification"
 fi
 
 # Make executable


### PR DESCRIPTION
## Problem

`install.sh` is the documented `curl … | sh` install path. It built download URLs with **hyphens** (`keyorix-linux-amd64`), but the GoReleaser assets on every release are named with **underscores** (`keyorix_linux_amd64`). So every download 404'd — **the installer has never worked against a real release.** Confirmed: the hyphen URL returns 404, the underscore URL returns 200.

## Fix

- `BINARY_NAME` → `keyorix_${OS}_${ARCH}`, matching the published assets.
- Add **SHA-256 checksum verification** against the release's `checksums.txt` (`sha256sum` or `shasum -a 256`), aborting on mismatch. The release already ships `checksums.txt`; verifying it matters for a `curl|sh` installer of a secrets product. Degrades gracefully if no checksum/tool is present.

## Verification (end-to-end, clean containers)

| Image | Downloader | Result |
|-------|-----------|--------|
| `debian:stable-slim` | curl | ✅ downloads `keyorix_linux_arm64`, checksum verified, `keyorix version v0.2.0` |
| `alpine:latest` | busybox wget | ✅ same |

`shellcheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)