### PR TITLE
ci(release): add release workflow + align make release asset names

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+# Publishes the Keyorix CLI + server release binaries when a vX.Y.Z tag is pushed.
+#
+# Cross-compiles via `make release` (linux/darwin × amd64/arm64) and uploads the
+# binaries + checksums.txt to the GitHub Release for the tag. The asset names
+# (keyorix_<os>_<arch>, keyorix-server_<os>_<arch>) are exactly what install.sh
+# downloads — they are produced by the Makefile `release` target; keep the three
+# in sync. Before this workflow, release assets were built out-of-band, which is
+# how install.sh drifted from the published names.
+name: release
+
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: write # create the release and upload assets
+
+jobs:
+  build-and-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.26'
+
+      - name: Cross-compile release binaries
+        run: make release VERSION=${{ github.ref_name }}
+
+      - name: Publish to the GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh release view "${{ github.ref_name }}" >/dev/null 2>&1; then
+            gh release upload "${{ github.ref_name }}" dist/* --clobber
+          else
+            gh release create "${{ github.ref_name }}" dist/* \
+              --title "Keyorix ${{ github.ref_name }}" \
+              --generate-notes
+          fi

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ BUILD_DIR=./bin
 VERSION?=dev
 LDFLAGS=-ldflags "-X github.com/keyorixhq/keyorix/internal/cli.version=$(VERSION)"
 
-.PHONY: build build-cli build-server build-ui install install-cli install-server clean run db-up dev docker-build docker-up docker-down docker-logs proto proto-deps proto-lint
+.PHONY: build build-cli build-server build-ui install install-cli install-server clean run db-up dev docker-build docker-up docker-down docker-logs proto proto-deps proto-lint release
 
 # Pinned protoc-gen plugin versions (match google.golang.org/{protobuf,grpc} in go.mod).
 PROTOC_GEN_GO_VERSION=v1.36.11
@@ -73,18 +73,22 @@ dev: install-cli
 	@echo "✓ keyorix CLI installed to /usr/local/bin"
 	@echo "✓ Start server with: make run"
 
+# Cross-compile the published release artifacts. Asset names use the
+# {binary}_{os}_{arch} convention that install.sh downloads and that the GitHub
+# releases already use — keep these three in sync. Consumed by
+# .github/workflows/release.yml on a vX.Y.Z tag.
 release:
 	@echo "→ Cross-compiling $(VERSION)"
 	@mkdir -p dist
-	GOOS=linux  GOARCH=amd64  CGO_ENABLED=0 go build $(LDFLAGS) -trimpath -o dist/$(BINARY_CLI)-linux-amd64   .
-	GOOS=linux  GOARCH=arm64  CGO_ENABLED=0 go build $(LDFLAGS) -trimpath -o dist/$(BINARY_CLI)-linux-arm64   .
-	GOOS=darwin GOARCH=amd64  CGO_ENABLED=0 go build $(LDFLAGS) -trimpath -o dist/$(BINARY_CLI)-darwin-amd64  .
-	GOOS=darwin GOARCH=arm64  CGO_ENABLED=0 go build $(LDFLAGS) -trimpath -o dist/$(BINARY_CLI)-darwin-arm64  .
-	GOOS=linux  GOARCH=amd64  CGO_ENABLED=0 go build $(LDFLAGS) -trimpath -o dist/$(BINARY_SERVER)-linux-amd64  ./server/main.go
-	GOOS=linux  GOARCH=arm64  CGO_ENABLED=0 go build $(LDFLAGS) -trimpath -o dist/$(BINARY_SERVER)-linux-arm64  ./server/main.go
-	GOOS=darwin GOARCH=amd64  CGO_ENABLED=0 go build $(LDFLAGS) -trimpath -o dist/$(BINARY_SERVER)-darwin-amd64 ./server/main.go
-	GOOS=darwin GOARCH=arm64  CGO_ENABLED=0 go build $(LDFLAGS) -trimpath -o dist/$(BINARY_SERVER)-darwin-arm64 ./server/main.go
-	@cd dist && sha256sum * > checksums.txt
+	GOOS=linux  GOARCH=amd64  CGO_ENABLED=0 go build $(LDFLAGS) -trimpath -o dist/$(BINARY_CLI)_linux_amd64    .
+	GOOS=linux  GOARCH=arm64  CGO_ENABLED=0 go build $(LDFLAGS) -trimpath -o dist/$(BINARY_CLI)_linux_arm64    .
+	GOOS=darwin GOARCH=amd64  CGO_ENABLED=0 go build $(LDFLAGS) -trimpath -o dist/$(BINARY_CLI)_darwin_amd64   .
+	GOOS=darwin GOARCH=arm64  CGO_ENABLED=0 go build $(LDFLAGS) -trimpath -o dist/$(BINARY_CLI)_darwin_arm64   .
+	GOOS=linux  GOARCH=amd64  CGO_ENABLED=0 go build $(LDFLAGS) -trimpath -o dist/$(BINARY_SERVER)_linux_amd64  ./server/main.go
+	GOOS=linux  GOARCH=arm64  CGO_ENABLED=0 go build $(LDFLAGS) -trimpath -o dist/$(BINARY_SERVER)_linux_arm64  ./server/main.go
+	GOOS=darwin GOARCH=amd64  CGO_ENABLED=0 go build $(LDFLAGS) -trimpath -o dist/$(BINARY_SERVER)_darwin_amd64 ./server/main.go
+	GOOS=darwin GOARCH=arm64  CGO_ENABLED=0 go build $(LDFLAGS) -trimpath -o dist/$(BINARY_SERVER)_darwin_arm64 ./server/main.go
+	@cd dist && (sha256sum * > checksums.txt 2>/dev/null || shasum -a 256 * > checksums.txt)
 	@echo "✅ Release binaries in dist/"
 
 clean:


### PR DESCRIPTION
## Why

Follow-up to #80. While verifying `install.sh` I found release binaries were built **out-of-band** — there was no committed release config (only `ci.yml` + `docker-publish.yml`), and the `make release` target produced **hyphenated** names (`keyorix-linux-amd64`) while the actually-published assets use **underscores** (`keyorix_linux_amd64`). That mismatch is exactly how `install.sh` drifted and shipped broken.

This adds a real, source-controlled release pipeline so the artifacts `install.sh` depends on are always produced consistently.

## Changes

- **`.github/workflows/release.yml`** — on a `vX.Y.Z` tag: cross-compile via `make release` and upload binaries + `checksums.txt` to the GitHub Release (creates it with generated notes, or updates an existing one). Uses the preinstalled `gh` CLI — no third-party action.
- **`Makefile` `release`** — assets named `{binary}_{os}_{arch}`, matching the published v0.2.0/v0.1.0 releases **and** `install.sh` exactly. Added `release` to `.PHONY`; made the checksum step portable (`sha256sum` → `shasum -a 256` fallback for macOS).

Now **producer (Makefile), publisher (workflow), and consumer (install.sh) share one naming convention** — the install path can't silently drift again.

## Verification

- Ran `make release VERSION=v0.0.0-test` locally: all 8 binaries (CLI + server × linux/darwin × amd64/arm64) cross-compile; `checksums.txt` generated.
- Diffed the produced asset names against the live v0.2.0 release assets — **byte-identical set** (empty diff both directions).
- `release.yml` is valid YAML.

> Note: the tag-triggered publish step can only be fully exercised by pushing a real `v*` tag (cutting a release), which is intentionally left to a maintainer. The build half is validated above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)