### PR TITLE
feat(ci): GitHub Action to fetch Keyorix secrets in pipelines (+ GitLab/CircleCI docs)

### DIFF
--- a/docs/CI_CD.md
+++ b/docs/CI_CD.md
@@ -1,0 +1,104 @@
+# Using Keyorix secrets in CI/CD
+
+Fetch secrets from a Keyorix server into a pipeline at build/deploy time, instead
+of duplicating them into each CI system. All three examples below authenticate
+with a **Keyorix API token** (a machine token or personal access token that has
+`secrets.read`), stored as a CI secret — never commit it.
+
+Set two values as CI secrets/variables in every system:
+
+| Variable | Value |
+|----------|-------|
+| `KEYORIX_SERVER` | Your server URL, e.g. `https://keyorix.your-company.internal` |
+| `KEYORIX_TOKEN` | A machine/PAT token with `secrets.read` on the target project |
+
+## GitHub Actions
+
+Use the bundled action. It installs the Keyorix CLI, fetches the chosen
+project/environment, and injects each secret as a **masked** environment
+variable for the following steps.
+
+```yaml
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Load Keyorix secrets
+        uses: keyorixhq/keyorix/integrations/github-action@v1
+        with:
+          server: ${{ secrets.KEYORIX_SERVER }}
+          token: ${{ secrets.KEYORIX_TOKEN }}
+          project: payments
+          environment: production
+          # version: v0.2.0      # pin the CLI (default: latest release)
+          # export-to-env: true  # inject as env vars (default)
+          # output-file: .env    # also write a dotenv file
+
+      - name: Deploy
+        run: ./deploy.sh   # secrets are now in the environment, e.g. $STRIPE_KEY
+```
+
+**Inputs:** `server`, `token` (required); `project` (default `default`),
+`environment` (default `development`), `version` (default latest),
+`export-to-env` (default `true`), `output-file` (default none).
+
+Values are masked with `::add-mask::` so they won't print in logs. Secret names
+are injected verbatim, so name your secrets as valid environment identifiers
+(e.g. `STRIPE_KEY`) for the smoothest consumption.
+
+## GitLab CI
+
+GitLab has no Keyorix action, so install the CLI and export directly. Store
+`KEYORIX_SERVER` / `KEYORIX_TOKEN` as **masked** CI/CD variables.
+
+```yaml
+deploy:
+  image: debian:stable-slim
+  before_script:
+    - apt-get update -qq && apt-get install -y -qq curl ca-certificates
+    - curl -fsSL https://raw.githubusercontent.com/keyorixhq/keyorix/main/install.sh | sh
+  script:
+    # Export to a dotenv file, then load it into the environment.
+    - keyorix secret export --project payments --env production --format dotenv > keyorix.env
+    - set -a && . ./keyorix.env && set +a
+    - ./deploy.sh
+  after_script:
+    - rm -f keyorix.env
+```
+
+> Note: GitLab only auto-masks variables you declare as masked. Values fetched
+> at runtime are not masked — don't `echo` them.
+
+## CircleCI
+
+Set `KEYORIX_SERVER` / `KEYORIX_TOKEN` as project environment variables (or a
+context). Install the CLI and export within the job.
+
+```yaml
+version: 2.1
+jobs:
+  deploy:
+    docker:
+      - image: cimg/base:current
+    steps:
+      - checkout
+      - run:
+          name: Load Keyorix secrets
+          command: |
+            curl -fsSL https://raw.githubusercontent.com/keyorixhq/keyorix/main/install.sh | sh
+            keyorix secret export --project payments --env production --format dotenv > keyorix.env
+            set -a && . ./keyorix.env && set +a
+            ./deploy.sh
+workflows:
+  deploy:
+    jobs:
+      - deploy
+```
+
+## Token scope
+
+Issue a dedicated **machine identity** token (ADR-030) scoped to just the
+project/environment the pipeline needs, with `secrets.read` only — not an admin
+token. Rotate it like any other CI credential.

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ Complete documentation for the production-ready Keyorix secret management system
 | [Performance Guide](./PERFORMANCE.md) | Performance metrics and optimization | ✅ New |
 | [Deployment Guide](../DEPLOYMENT_GUIDE.md) | Production deployment instructions | ✅ Updated |
 | [Migration Guide](./MIGRATION.md) | Import secrets from Vault / AWS / Azure / files | ✅ New |
+| [CI/CD Guide](./CI_CD.md) | Fetch secrets in GitHub Actions / GitLab CI / CircleCI | ✅ New |
 
 ## 📖 **Core Documentation**
 

--- a/integrations/github-action/README.md
+++ b/integrations/github-action/README.md
@@ -1,0 +1,35 @@
+# Keyorix Secrets — GitHub Action
+
+Fetch secrets from a [Keyorix](https://github.com/keyorixhq/keyorix) server into
+your workflow as **masked environment variables**.
+
+```yaml
+- name: Load Keyorix secrets
+  uses: keyorixhq/keyorix/integrations/github-action@v1
+  with:
+    server: ${{ secrets.KEYORIX_SERVER }}
+    token: ${{ secrets.KEYORIX_TOKEN }}
+    project: payments
+    environment: production
+
+- run: ./deploy.sh   # secrets available as env vars, e.g. $STRIPE_KEY
+```
+
+## Inputs
+
+| Input | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `server` | yes | — | Keyorix server URL |
+| `token` | yes | — | API token (machine/PAT) with `secrets.read` |
+| `project` | no | `default` | Project name |
+| `environment` | no | `development` | Environment name |
+| `version` | no | latest | Keyorix CLI version to install (e.g. `v0.2.0`) |
+| `export-to-env` | no | `true` | Inject secrets as masked env vars |
+| `output-file` | no | — | Also write secrets to this dotenv file |
+
+How it works: installs the Keyorix CLI (via the official installer, or a pinned
+`version`), runs `keyorix secret export --format json`, masks each value with
+`::add-mask::`, and writes them to `$GITHUB_ENV`. Secret names are injected
+verbatim — name them as valid env identifiers (e.g. `STRIPE_KEY`).
+
+See [docs/CI_CD.md](../../docs/CI_CD.md) for GitLab CI and CircleCI examples.

--- a/integrations/github-action/action.yml
+++ b/integrations/github-action/action.yml
@@ -1,0 +1,49 @@
+name: 'Keyorix Secrets'
+description: 'Fetch secrets from a Keyorix server into your workflow as masked environment variables.'
+author: 'Keyorix'
+branding:
+  icon: 'lock'
+  color: 'blue'
+
+inputs:
+  server:
+    description: 'Keyorix server URL (e.g. https://keyorix.your-company.internal).'
+    required: true
+  token:
+    description: 'Keyorix API token (machine token or personal access token) with secrets.read.'
+    required: true
+  project:
+    description: 'Project name to read secrets from.'
+    required: false
+    default: 'default'
+  environment:
+    description: 'Environment name (e.g. production).'
+    required: false
+    default: 'development'
+  version:
+    description: 'Keyorix CLI version to install (e.g. v0.2.0). Defaults to the latest release.'
+    required: false
+    default: ''
+  export-to-env:
+    description: 'Inject the secrets as masked environment variables for subsequent steps.'
+    required: false
+    default: 'true'
+  output-file:
+    description: 'Optional path to also write the secrets as a dotenv (.env) file.'
+    required: false
+    default: ''
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Fetch Keyorix secrets
+      shell: bash
+      env:
+        KEYORIX_SERVER: ${{ inputs.server }}
+        KEYORIX_TOKEN: ${{ inputs.token }}
+        INPUT_PROJECT: ${{ inputs.project }}
+        INPUT_ENVIRONMENT: ${{ inputs.environment }}
+        INPUT_VERSION: ${{ inputs.version }}
+        INPUT_EXPORT_TO_ENV: ${{ inputs.export-to-env }}
+        INPUT_OUTPUT_FILE: ${{ inputs.output-file }}
+      run: ${{ github.action_path }}/entrypoint.sh

--- a/integrations/github-action/entrypoint.sh
+++ b/integrations/github-action/entrypoint.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# entrypoint.sh — install the Keyorix CLI (if needed), then export the requested
+# project/environment's secrets and inject them into the GitHub Actions
+# environment as MASKED variables (and optionally to a dotenv file).
+#
+# Reads its config from the INPUT_* / KEYORIX_* env the action.yml sets. Uses
+# `keyorix secret export --format json` (pure JSON on stdout; warnings go to
+# stderr) so values are parsed unambiguously with jq.
+set -euo pipefail
+
+: "${KEYORIX_SERVER:?server input is required}"
+: "${KEYORIX_TOKEN:?token input is required}"
+export KEYORIX_SERVER KEYORIX_TOKEN
+
+PROJECT="${INPUT_PROJECT:-default}"
+ENVIRONMENT="${INPUT_ENVIRONMENT:-development}"
+VERSION="${INPUT_VERSION:-}"
+EXPORT_TO_ENV="${INPUT_EXPORT_TO_ENV:-true}"
+OUTPUT_FILE="${INPUT_OUTPUT_FILE:-}"
+
+install_dir="/usr/local/bin"
+
+install_cli() {
+  if command -v keyorix >/dev/null 2>&1; then
+    echo "Using existing keyorix: $(keyorix --version)"
+    return
+  fi
+  if [ -n "$VERSION" ]; then
+    os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+    arch="$(uname -m)"
+    case "$arch" in
+      x86_64) arch="amd64" ;;
+      aarch64 | arm64) arch="arm64" ;;
+    esac
+    url="https://github.com/keyorixhq/keyorix/releases/download/${VERSION}/keyorix_${os}_${arch}"
+    echo "Downloading keyorix ${VERSION} (${os}/${arch})..."
+    curl -fsSL "$url" -o /tmp/keyorix
+    chmod +x /tmp/keyorix
+    if [ -w "$install_dir" ]; then
+      mv /tmp/keyorix "${install_dir}/keyorix"
+    else
+      sudo mv /tmp/keyorix "${install_dir}/keyorix"
+    fi
+  else
+    # Latest release via the official installer (verifies the checksum).
+    curl -fsSL https://raw.githubusercontent.com/keyorixhq/keyorix/main/install.sh | sh
+  fi
+  keyorix --version
+}
+
+inject_env() {
+  local json key val delim count
+  json="$(keyorix secret export --project "$PROJECT" --env "$ENVIRONMENT" --format json)"
+  if ! printf '%s' "$json" | jq empty 2>/dev/null; then
+    echo "error: 'keyorix secret export' did not return valid JSON" >&2
+    exit 1
+  fi
+
+  # `keys[]` is newline-delimited; read line-by-line so the loop is whitespace-safe.
+  count=0
+  while IFS= read -r key; do
+    [ -n "$key" ] || continue
+    val="$(printf '%s' "$json" | jq -r --arg k "$key" '.[$k]')"
+    # Mask the value everywhere it might appear in the logs.
+    echo "::add-mask::$val"
+    if [ "$EXPORT_TO_ENV" = "true" ]; then
+      # Heredoc form so multi-line values survive the GITHUB_ENV file format.
+      delim="KEYORIX_EOF_${RANDOM}${RANDOM}"
+      {
+        printf '%s<<%s\n' "$key" "$delim"
+        printf '%s\n' "$val"
+        printf '%s\n' "$delim"
+      } >>"$GITHUB_ENV"
+    fi
+    count=$((count + 1))
+  done < <(printf '%s' "$json" | jq -r 'keys[]')
+
+  echo "Loaded ${count} secret(s) from project '${PROJECT}' environment '${ENVIRONMENT}'."
+}
+
+install_cli
+
+if [ "$EXPORT_TO_ENV" = "true" ]; then
+  inject_env
+fi
+
+if [ -n "$OUTPUT_FILE" ]; then
+  # Reuse the CLI's dotenv writer (handles quoting) for the file form.
+  keyorix secret export --project "$PROJECT" --env "$ENVIRONMENT" --format dotenv --output "$OUTPUT_FILE"
+  echo "Wrote secrets to ${OUTPUT_FILE}"
+fi


### PR DESCRIPTION
## Summary

Backlog M3 "CI/CD integrations". Adds a reusable **composite GitHub Action** that pulls a project/environment's secrets from a Keyorix server into a workflow as **masked environment variables**, plus copy-paste **GitLab CI** and **CircleCI** examples.

**No server/CLI code changes** — it builds on the now-fixed `install.sh` and the existing `keyorix secret export`.

## Usage

```yaml
- uses: keyorixhq/keyorix/integrations/github-action@v1
  with:
    server: ${{ secrets.KEYORIX_SERVER }}
    token: ${{ secrets.KEYORIX_TOKEN }}
    project: payments
    environment: production
- run: ./deploy.sh   # secrets now in the env, e.g. $STRIPE_KEY
```

## How it works

`entrypoint.sh` installs the CLI (latest via `install.sh`, or a pinned `version` input), runs `keyorix secret export --format json` (**pure JSON on stdout**; warnings go to stderr — verified in `export.go`), masks each value with `::add-mask::`, and writes them to `$GITHUB_ENV` using the multi-line-safe heredoc form. Optional `output-file` writes a dotenv via the CLI's own writer. Fails loud if the export output isn't valid JSON.

## Security

- Auth uses a Keyorix **machine/PAT token** supplied from CI secrets; nothing committed. Docs recommend a machine-identity token scoped to `secrets.read` on just the needed project.
- Values are masked **before** any potential log exposure; the heredoc delimiter is randomized per value.

## Verification

- Exercised the action's parse/mask/inject/file logic end to end with a stub CLI, including a **multi-line value** → correct `::add-mask::` per value and correct `$GITHUB_ENV` heredoc blocks.
- `shellcheck` clean; `action.yml` valid YAML.
- The wrapped pieces are already verified: `install.sh` (e2e in Debian+Alpine containers, #80) and `keyorix secret export` (existing CLI; JSON output contract confirmed by reading `export.go`).

> Note: full live exercise (action → real server) and Marketplace publishing (which wants the action in its own repo) are follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)