### PR TITLE
feat(deploy): Helm chart for Kubernetes (server + web + PostgreSQL)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,10 @@
 # =============================================================================
 
 # --- Binary Executables ---
-keyorix
-keyorix-*
+# Anchored to the repo root so they match the built binaries, not any nested
+# directory named `keyorix` (e.g. deploy/helm/keyorix/).
+/keyorix
+/keyorix-server
 server/keyorix-server
 cmd/keyorix
 cmd/keyorix-server

--- a/deploy/helm/keyorix/.helmignore
+++ b/deploy/helm/keyorix/.helmignore
@@ -1,0 +1,6 @@
+.git
+*.tmp
+*.bak
+rendered.yaml
+r2.yaml
+ci/

--- a/deploy/helm/keyorix/Chart.yaml
+++ b/deploy/helm/keyorix/Chart.yaml
@@ -1,0 +1,18 @@
+apiVersion: v2
+name: keyorix
+description: Self-hosted Keyorix secrets manager (API server + web UI + PostgreSQL)
+type: application
+# Chart version — bump on chart changes.
+version: 0.1.0
+# The Keyorix app version this chart deploys by default (the image tag).
+appVersion: "0.2.0"
+home: https://github.com/keyorixhq/keyorix
+sources:
+  - https://github.com/keyorixhq/keyorix
+keywords:
+  - secrets
+  - secrets-manager
+  - security
+  - vault
+maintainers:
+  - name: Keyorix

--- a/deploy/helm/keyorix/README.md
+++ b/deploy/helm/keyorix/README.md
@@ -1,0 +1,48 @@
+# Keyorix Helm chart
+
+Deploy the self-hosted [Keyorix](https://github.com/keyorixhq/keyorix) secrets
+manager — API server + web UI + PostgreSQL — to Kubernetes. It mirrors the
+docker-compose stack: a single-instance server holding the encryption keys on a
+persistent volume, the web UI proxying to it, and a bundled (or external) Postgres.
+
+## Quick start
+
+```sh
+helm install keyorix ./deploy/helm/keyorix \
+  --set auth.masterPassword='change-me-and-keep-it' \
+  --set postgresql.auth.password='a-strong-db-password' \
+  --set auth.adminPassword='Admin123!'
+```
+
+Then follow the printed NOTES (port-forward the web service and log in).
+
+> ⚠️ **`auth.masterPassword` derives the encryption KEK.** Set it once and keep it
+> — changing it, or losing the server's keys PVC, makes every stored secret
+> undecryptable. For production, supply it via `auth.existingSecret` and back up
+> the `*-server-keys` PVC.
+
+## Key values
+
+| Value | Default | Notes |
+|-------|---------|-------|
+| `auth.masterPassword` | — | **Required** (or `auth.existingSecret`). KEK passphrase. |
+| `auth.existingSecret` | — | Bring your own Secret (`KEYORIX_MASTER_PASSWORD`, `KEYORIX_DB_PASSWORD`, opt. `KEYORIX_ADMIN_PASSWORD`). |
+| `auth.adminPassword` | — | Optional first-boot admin bootstrap (idempotent). |
+| `server.image.tag` | chart `appVersion` | Server image tag. |
+| `server.keysPersistence.*` | 1Gi RWO | The encryption-keys PVC (`resource-policy: keep`). |
+| `web.enabled` | `true` | Deploy the UI (with a k8s-adapted nginx that proxies to the server Service). |
+| `ingress.*` | disabled | Ingress for the web UI. |
+| `postgresql.enabled` | `true` | Bundled Postgres for evaluation. |
+| `postgresql.auth.password` | — | Required when bundled DB is enabled. |
+| `externalDatabase.*` | — | Used when `postgresql.enabled=false` (managed/HA Postgres). |
+
+## Production notes
+
+- **External database:** set `postgresql.enabled=false` and `externalDatabase.host`
+  (+ `externalDatabase.password` via `auth.existingSecret`), pointing at a managed
+  or HA PostgreSQL. The bundled Postgres is single-instance, for evaluation.
+- **Single server instance:** the server is pinned to 1 replica — it owns the
+  ReadWriteOnce keys volume and a per-instance KEK; it is not horizontally scalable.
+- **Backups:** back up both the database and the `*-server-keys` PVC. You need
+  both (plus the master password) to recover.
+- **TLS:** terminate at the ingress (`ingress.tls` + cert-manager annotations).

--- a/deploy/helm/keyorix/templates/NOTES.txt
+++ b/deploy/helm/keyorix/templates/NOTES.txt
@@ -1,0 +1,33 @@
+Keyorix has been deployed as release "{{ .Release.Name }}".
+
+1. Wait for the pods to be ready:
+
+   kubectl -n {{ .Release.Namespace }} get pods -l app.kubernetes.io/instance={{ .Release.Name }} -w
+
+2. Reach the UI:
+{{- if .Values.ingress.enabled }}
+
+   http{{ if .Values.ingress.tls }}s{{ end }}://{{ .Values.ingress.host }}
+{{- else if .Values.web.enabled }}
+
+   kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "keyorix.web.fullname" . }} 8080:{{ .Values.web.service.port }}
+   open http://localhost:8080
+{{- else }}
+
+   kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "keyorix.server.fullname" . }} 8080:{{ .Values.server.service.port }}
+{{- end }}
+
+{{- if .Values.auth.adminPassword }}
+
+3. Log in with the admin you configured (auth.adminUsername="{{ .Values.auth.adminUsername }}").
+{{- else }}
+
+3. No admin password was set. Initialise the first admin manually:
+
+   kubectl -n {{ .Release.Namespace }} exec deploy/{{ include "keyorix.server.fullname" . }} -- ./keyorix-server  # then `keyorix system init`
+{{- end }}
+
+⚠️  CRITICAL — back up the encryption keys volume
+    The PVC "{{ include "keyorix.server.fullname" . }}-keys" holds the wrapped DEK
+    and KEK salt. It is annotated helm.sh/resource-policy: keep, but if you lose it
+    OR change auth.masterPassword, every stored secret becomes undecryptable.

--- a/deploy/helm/keyorix/templates/_helpers.tpl
+++ b/deploy/helm/keyorix/templates/_helpers.tpl
@@ -1,0 +1,38 @@
+{{/* Base name, overridable, truncated to the 63-char DNS limit. */}}
+{{- define "keyorix.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "keyorix.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name (include "keyorix.name" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "keyorix.server.fullname" -}}{{ printf "%s-server" (include "keyorix.fullname" .) | trunc 63 | trimSuffix "-" }}{{- end -}}
+{{- define "keyorix.web.fullname" -}}{{ printf "%s-web" (include "keyorix.fullname" .) | trunc 63 | trimSuffix "-" }}{{- end -}}
+{{- define "keyorix.postgresql.fullname" -}}{{ printf "%s-postgresql" (include "keyorix.fullname" .) | trunc 63 | trimSuffix "-" }}{{- end -}}
+
+{{/* The Secret holding KEYORIX_MASTER_PASSWORD / KEYORIX_DB_PASSWORD / admin. */}}
+{{- define "keyorix.secretName" -}}
+{{- if .Values.auth.existingSecret -}}{{ .Values.auth.existingSecret }}{{- else -}}{{ include "keyorix.fullname" . }}{{- end -}}
+{{- end -}}
+
+{{/* Database host: the bundled Postgres service, or the external host. */}}
+{{- define "keyorix.dbHost" -}}
+{{- if .Values.postgresql.enabled -}}{{ include "keyorix.postgresql.fullname" . }}{{- else -}}{{ required "externalDatabase.host is required when postgresql.enabled is false" .Values.externalDatabase.host }}{{- end -}}
+{{- end -}}
+
+{{- define "keyorix.labels" -}}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" }}
+app.kubernetes.io/name: {{ include "keyorix.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "keyorix.server.image" -}}
+{{- printf "%s:%s" .Values.server.image.repository (default .Chart.AppVersion .Values.server.image.tag) -}}
+{{- end -}}

--- a/deploy/helm/keyorix/templates/ingress.yaml
+++ b/deploy/helm/keyorix/templates/ingress.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.ingress.enabled -}}
+{{- if not .Values.web.enabled -}}
+{{- fail "ingress.enabled requires web.enabled (the ingress routes to the web UI)." -}}
+{{- end -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "keyorix.fullname" . }}
+  labels:
+    {{- include "keyorix.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.host | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "keyorix.web.fullname" . }}
+                port:
+                  number: {{ .Values.web.service.port }}
+{{- end -}}

--- a/deploy/helm/keyorix/templates/postgresql.yaml
+++ b/deploy/helm/keyorix/templates/postgresql.yaml
@@ -1,0 +1,106 @@
+{{- if .Values.postgresql.enabled -}}
+{{- if .Values.postgresql.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "keyorix.postgresql.fullname" . }}
+  labels:
+    {{- include "keyorix.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgresql
+spec:
+  accessModes: [ReadWriteOnce]
+  resources:
+    requests:
+      storage: {{ .Values.postgresql.persistence.size }}
+  {{- with .Values.postgresql.persistence.storageClass }}
+  storageClassName: {{ . }}
+  {{- end }}
+---
+{{- end }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "keyorix.postgresql.fullname" . }}
+  labels:
+    {{- include "keyorix.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgresql
+spec:
+  type: ClusterIP
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: postgres
+  selector:
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: postgresql
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "keyorix.postgresql.fullname" . }}
+  labels:
+    {{- include "keyorix.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgresql
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: postgresql
+  template:
+    metadata:
+      labels:
+        {{- include "keyorix.labels" . | nindent 8 }}
+        app.kubernetes.io/component: postgresql
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: postgresql
+          image: "{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}"
+          imagePullPolicy: {{ .Values.postgresql.image.pullPolicy }}
+          ports:
+            - name: postgres
+              containerPort: 5432
+          env:
+            - name: POSTGRES_DB
+              value: {{ .Values.postgresql.auth.database | quote }}
+            - name: POSTGRES_USER
+              value: {{ .Values.postgresql.auth.username | quote }}
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "keyorix.secretName" . }}
+                  key: KEYORIX_DB_PASSWORD
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          readinessProbe:
+            exec:
+              command: ["pg_isready", "-U", {{ .Values.postgresql.auth.username | quote }}]
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            exec:
+              command: ["pg_isready", "-U", {{ .Values.postgresql.auth.username | quote }}]
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+          {{- with .Values.postgresql.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      volumes:
+        - name: data
+          {{- if .Values.postgresql.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "keyorix.postgresql.fullname" . }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+{{- end -}}

--- a/deploy/helm/keyorix/templates/secret.yaml
+++ b/deploy/helm/keyorix/templates/secret.yaml
@@ -1,0 +1,22 @@
+{{- if not .Values.auth.existingSecret -}}
+{{- if not .Values.auth.masterPassword -}}
+{{- fail "auth.masterPassword is required (or set auth.existingSecret). It derives the encryption KEK and must be stable for the life of the install." -}}
+{{- end -}}
+{{- $dbPass := .Values.postgresql.enabled | ternary .Values.postgresql.auth.password .Values.externalDatabase.password -}}
+{{- if not $dbPass -}}
+{{- fail "A database password is required: set postgresql.auth.password (bundled DB) or externalDatabase.password (external DB), or use auth.existingSecret." -}}
+{{- end -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "keyorix.fullname" . }}
+  labels:
+    {{- include "keyorix.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  KEYORIX_MASTER_PASSWORD: {{ .Values.auth.masterPassword | quote }}
+  KEYORIX_DB_PASSWORD: {{ $dbPass | quote }}
+  {{- if .Values.auth.adminPassword }}
+  KEYORIX_ADMIN_PASSWORD: {{ .Values.auth.adminPassword | quote }}
+  {{- end }}
+{{- end -}}

--- a/deploy/helm/keyorix/templates/server-config.yaml
+++ b/deploy/helm/keyorix/templates/server-config.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "keyorix.server.fullname" . }}-config
+  labels:
+    {{- include "keyorix.labels" . | nindent 4 }}
+data:
+  keyorix.yaml: |
+    environment: production
+    server:
+      http:
+        enabled: true
+        port: "{{ .Values.server.service.port }}"
+    storage:
+      type: postgres
+      database:
+        host: {{ include "keyorix.dbHost" . }}
+        port: "{{ .Values.postgresql.enabled | ternary 5432 .Values.externalDatabase.port }}"
+        name: {{ .Values.postgresql.enabled | ternary .Values.postgresql.auth.database .Values.externalDatabase.database }}
+        user: {{ .Values.postgresql.enabled | ternary .Values.postgresql.auth.username .Values.externalDatabase.user }}
+        ssl_mode: {{ .Values.postgresql.enabled | ternary "disable" .Values.externalDatabase.sslMode }}
+      encryption:
+        enabled: true
+        # The wrapped DEK + KEK salt live on the persisted keys volume. These MUST
+        # survive restarts — losing them, or changing KEYORIX_MASTER_PASSWORD,
+        # makes every stored secret undecryptable.
+        dek_path: "/app/keys/data.key"
+        salt_path: "/app/keys/kek.salt"

--- a/deploy/helm/keyorix/templates/server-deployment.yaml
+++ b/deploy/helm/keyorix/templates/server-deployment.yaml
@@ -1,0 +1,104 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "keyorix.server.fullname" . }}
+  labels:
+    {{- include "keyorix.labels" . | nindent 4 }}
+    app.kubernetes.io/component: server
+spec:
+  # Single instance: the keys volume is ReadWriteOnce and the KEK is per-instance.
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: server
+  template:
+    metadata:
+      labels:
+        {{- include "keyorix.labels" . | nindent 8 }}
+        app.kubernetes.io/component: server
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/server-config.yaml") . | sha256sum }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: server
+          image: {{ include "keyorix.server.image" . }}
+          imagePullPolicy: {{ .Values.server.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.server.service.port }}
+          env:
+            - name: KEYORIX_MASTER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "keyorix.secretName" . }}
+                  key: KEYORIX_MASTER_PASSWORD
+            - name: KEYORIX_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "keyorix.secretName" . }}
+                  key: KEYORIX_DB_PASSWORD
+            - name: KEYORIX_ADMIN_USERNAME
+              value: {{ .Values.auth.adminUsername | quote }}
+            - name: KEYORIX_ADMIN_EMAIL
+              value: {{ .Values.auth.adminEmail | quote }}
+            {{- if or .Values.auth.adminPassword .Values.auth.existingSecret }}
+            - name: KEYORIX_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "keyorix.secretName" . }}
+                  key: KEYORIX_ADMIN_PASSWORD
+                  optional: true
+            {{- end }}
+          volumeMounts:
+            - name: config
+              mountPath: /app/keyorix.yaml
+              subPath: keyorix.yaml
+              readOnly: true
+            - name: keys
+              mountPath: /app/keys
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          {{- with .Values.server.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "keyorix.server.fullname" . }}-config
+        - name: keys
+          {{- if .Values.server.keysPersistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "keyorix.server.fullname" . }}-keys
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+      {{- with .Values.server.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.server.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.server.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/helm/keyorix/templates/server-pvc.yaml
+++ b/deploy/helm/keyorix/templates/server-pvc.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.server.keysPersistence.enabled -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "keyorix.server.fullname" . }}-keys
+  labels:
+    {{- include "keyorix.labels" . | nindent 4 }}
+  annotations:
+    # Keep the encryption keys even if the release is uninstalled — deleting this
+    # PVC makes every stored secret undecryptable.
+    helm.sh/resource-policy: keep
+spec:
+  accessModes:
+    - {{ .Values.server.keysPersistence.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.server.keysPersistence.size }}
+  {{- with .Values.server.keysPersistence.storageClass }}
+  storageClassName: {{ . }}
+  {{- end }}
+{{- end -}}

--- a/deploy/helm/keyorix/templates/server-service.yaml
+++ b/deploy/helm/keyorix/templates/server-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "keyorix.server.fullname" . }}
+  labels:
+    {{- include "keyorix.labels" . | nindent 4 }}
+    app.kubernetes.io/component: server
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: {{ .Values.server.service.port }}
+      targetPort: http
+  selector:
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: server

--- a/deploy/helm/keyorix/templates/web-config.yaml
+++ b/deploy/helm/keyorix/templates/web-config.yaml
@@ -1,0 +1,75 @@
+{{- if .Values.web.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "keyorix.web.fullname" . }}-config
+  labels:
+    {{- include "keyorix.labels" . | nindent 4 }}
+    app.kubernetes.io/component: web
+data:
+  # Kubernetes-adapted nginx.conf. Unlike the Docker image's config (which uses
+  # Docker's embedded DNS resolver 127.0.0.11 + a variable upstream), this proxies
+  # to the server Service by name with a literal proxy_pass: a Service ClusterIP
+  # is stable, so nginx resolves it once at startup via the pod's cluster DNS and
+  # never caches a stale pod IP.
+  nginx.conf: |
+    events { worker_connections 1024; }
+    http {
+      include       /etc/nginx/mime.types;
+      default_type  application/octet-stream;
+      sendfile on;
+      tcp_nopush on;
+      tcp_nodelay on;
+      keepalive_timeout 65;
+      gzip on;
+      gzip_vary on;
+      gzip_min_length 1024;
+      gzip_proxied any;
+      gzip_comp_level 6;
+      gzip_types application/javascript application/json application/xml image/svg+xml text/css text/javascript text/plain text/xml font/ttf font/otf;
+
+      add_header X-Frame-Options "SAMEORIGIN" always;
+      add_header X-Content-Type-Options "nosniff" always;
+      add_header X-XSS-Protection "1; mode=block" always;
+      add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+      add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' ws: wss:;" always;
+
+      server {
+        listen 80;
+        server_name _;
+        root /usr/share/nginx/html;
+        index index.html;
+
+        location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
+          expires 1y;
+          add_header Cache-Control "public, immutable";
+          try_files $uri =404;
+        }
+
+        # /api/ = authenticated API, /auth/ = public auth (login/refresh/logout,
+        # served at the root), /system/ = first-boot init. Proxy all to the server.
+        location ~ ^/(api|auth|system)/ {
+          proxy_pass http://{{ include "keyorix.server.fullname" . }}:{{ .Values.server.service.port }};
+          proxy_set_header Host $host;
+          proxy_set_header X-Real-IP $remote_addr;
+          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+          proxy_set_header X-Forwarded-Proto $scheme;
+          add_header Access-Control-Allow-Origin $http_origin always;
+          add_header Access-Control-Allow-Methods "GET, POST, PUT, DELETE, OPTIONS" always;
+          add_header Access-Control-Allow-Headers "Authorization, Content-Type, Accept" always;
+          add_header Access-Control-Allow-Credentials true always;
+          if ($request_method = 'OPTIONS') { return 204; }
+        }
+
+        location / { try_files $uri $uri/ /index.html; }
+
+        location /health {
+          access_log off;
+          return 200 "healthy\n";
+          add_header Content-Type text/plain;
+        }
+
+        location ~ /\. { deny all; access_log off; log_not_found off; }
+      }
+    }
+{{- end -}}

--- a/deploy/helm/keyorix/templates/web-deployment.yaml
+++ b/deploy/helm/keyorix/templates/web-deployment.yaml
@@ -1,0 +1,59 @@
+{{- if .Values.web.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "keyorix.web.fullname" . }}
+  labels:
+    {{- include "keyorix.labels" . | nindent 4 }}
+    app.kubernetes.io/component: web
+spec:
+  replicas: {{ .Values.web.replicas }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: web
+  template:
+    metadata:
+      labels:
+        {{- include "keyorix.labels" . | nindent 8 }}
+        app.kubernetes.io/component: web
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/web-config.yaml") . | sha256sum }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: web
+          image: "{{ .Values.web.image.repository }}:{{ .Values.web.image.tag }}"
+          imagePullPolicy: {{ .Values.web.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 80
+          volumeMounts:
+            - name: nginx-config
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
+              readOnly: true
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 3
+            periodSeconds: 10
+          {{- with .Values.web.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      volumes:
+        - name: nginx-config
+          configMap:
+            name: {{ include "keyorix.web.fullname" . }}-config
+{{- end -}}

--- a/deploy/helm/keyorix/templates/web-service.yaml
+++ b/deploy/helm/keyorix/templates/web-service.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.web.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "keyorix.web.fullname" . }}
+  labels:
+    {{- include "keyorix.labels" . | nindent 4 }}
+    app.kubernetes.io/component: web
+spec:
+  type: {{ .Values.web.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.web.service.port }}
+      targetPort: http
+  selector:
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: web
+{{- end -}}

--- a/deploy/helm/keyorix/values.yaml
+++ b/deploy/helm/keyorix/values.yaml
@@ -1,0 +1,95 @@
+# Default values for the Keyorix chart.
+
+# ── Required secrets ──────────────────────────────────────────────────────────
+# The KEK is derived from masterPassword. Changing it after first boot makes
+# every stored secret undecryptable — set it once and keep it. Provide it here,
+# or set auth.existingSecret to bring your own Secret (recommended for prod).
+auth:
+  # The encryption master passphrase. REQUIRED unless existingSecret is set.
+  masterPassword: ""
+  # Optional first-boot admin bootstrap (idempotent). Leave password empty to
+  # run `keyorix system init` manually instead.
+  adminUsername: "admin"
+  adminEmail: "admin@keyorix.local"
+  adminPassword: ""
+  # Bring your own Secret instead of the values above. It must contain keys:
+  #   KEYORIX_MASTER_PASSWORD, KEYORIX_DB_PASSWORD, and optionally
+  #   KEYORIX_ADMIN_PASSWORD.
+  existingSecret: ""
+
+# ── API server ────────────────────────────────────────────────────────────────
+server:
+  image:
+    repository: ghcr.io/keyorixhq/keyorix-server
+    # Published GHCR tags today are `latest` / `main` / `sha-<commit>` (no semver
+    # tags yet). Pin to a `sha-*` or a future `vX.Y.Z` tag for reproducibility.
+    tag: "latest"
+    pullPolicy: IfNotPresent
+  # The server holds the encryption keys on a single ReadWriteOnce volume and is
+  # a single logical instance — do not scale beyond 1 replica.
+  replicas: 1
+  service:
+    port: 8080
+  # Persistent volume for the wrapped DEK + KEK salt (/app/keys). MUST persist —
+  # losing it makes every stored secret undecryptable. Back it up.
+  keysPersistence:
+    enabled: true
+    size: 1Gi
+    storageClass: ""
+    accessMode: ReadWriteOnce
+  resources: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+# ── Web UI ────────────────────────────────────────────────────────────────────
+web:
+  enabled: true
+  image:
+    repository: ghcr.io/keyorixhq/keyorix-web
+    tag: latest
+    pullPolicy: IfNotPresent
+  replicas: 1
+  service:
+    type: ClusterIP
+    port: 80
+  resources: {}
+
+# ── Ingress (for the web UI) ──────────────────────────────────────────────────
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  host: keyorix.local
+  tls: []   # e.g. [{ secretName: keyorix-tls, hosts: [keyorix.example.com] }]
+
+# ── Bundled PostgreSQL ────────────────────────────────────────────────────────
+# A minimal in-chart Postgres for evaluation. For production, set enabled:false
+# and point externalDatabase at a managed/HA PostgreSQL.
+postgresql:
+  enabled: true
+  image:
+    repository: postgres
+    tag: "15-alpine"
+    pullPolicy: IfNotPresent
+  auth:
+    username: keyorix
+    database: keyorix
+    # Password for the bundled DB. REQUIRED when postgresql.enabled and no
+    # auth.existingSecret is set.
+    password: ""
+  persistence:
+    enabled: true
+    size: 8Gi
+    storageClass: ""
+  resources: {}
+
+# Used when postgresql.enabled is false.
+externalDatabase:
+  host: ""
+  port: 5432
+  database: keyorix
+  user: keyorix
+  sslMode: require
+
+imagePullSecrets: []

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ Complete documentation for the production-ready Keyorix secret management system
 | [Deployment Guide](../DEPLOYMENT_GUIDE.md) | Production deployment instructions | ✅ Updated |
 | [Migration Guide](./MIGRATION.md) | Import secrets from Vault / AWS / Azure / files | ✅ New |
 | [CI/CD Guide](./CI_CD.md) | Fetch secrets in GitHub Actions / GitLab CI / CircleCI | ✅ New |
+| [Helm chart](../deploy/helm/keyorix/README.md) | Deploy Keyorix on Kubernetes | ✅ New |
 
 ## 📖 **Core Documentation**
 


### PR DESCRIPTION
## Summary

Backlog M3 "Kubernetes operator / Helm chart". Deploy self-hosted Keyorix on Kubernetes, mirroring the docker-compose stack: a single-instance API server holding the encryption keys on a persistent volume, the web UI proxying to it, and a bundled (or external) PostgreSQL.

```sh
helm install keyorix ./deploy/helm/keyorix \
  --set auth.masterPassword='change-me-and-keep-it' \
  --set postgresql.auth.password='a-strong-db-password' \
  --set auth.adminPassword='Admin123!'
```

## What's in the chart

- **server**: Deployment (pinned to 1 replica — owns the RWO keys volume + per-instance KEK), Service, keys PVC (`resource-policy: keep`), config ConfigMap.
- **web**: Deployment, Service, and a **Kubernetes-adapted nginx ConfigMap**. The stock web image's nginx uses Docker's embedded DNS resolver (`127.0.0.11`), which doesn't exist in k8s — the chart ships a corrected `nginx.conf` that proxies to the server Service by name with a literal `proxy_pass` (stable ClusterIP, resolved once at startup via cluster DNS).
- **postgresql**: bundled single-instance Postgres for evaluation (gated; set `postgresql.enabled=false` + `externalDatabase.*` for managed/HA).
- **Secret** (master password / DB password / admin) and an optional **Ingress**.
- **Guard rails**: template fails fast if the master password or a DB password is missing.

## Two fixes surfaced while building

- **`.gitignore` footgun**: the bare `keyorix` / `keyorix-*` binary patterns matched *any* nested directory named `keyorix` — which silently hid this entire chart from git. Anchored them to the repo root (binaries stay covered by `/bin/` and `/dist/`).
- **Image tag**: defaulted the server image to `latest` because the only GHCR tags published today are `latest`/`main`/`sha-*` — there are no semver image tags yet (same release-pipeline gap as the install.sh fix).

## Verification — real cluster, not just lint

Deployed end to end on a **kind cluster (k8s v1.36)**:
1. `helm install` → all resources created; postgres + server + web pods **Ready**.
2. Server **migrates the DB and bootstraps the admin** (`POST /system/init → 200`).
3. **Login through the web→server nginx proxy returns a valid token** (`HTTP 200`) — proving the k8s nginx override + Service DNS + server + Postgres chain.

Also: `helm lint` clean; `helm template` → `kubeconform -strict` (k8s 1.29) **12/12 valid**; guard rails and the external-DB path verified.

> Follow-ups: package/publish the chart to an OCI/Helm repo; a `helm test` hook; optional HPA/PodMonitor; the server image isn't multi-replica (keys volume + KEK are single-instance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)