### PR TITLE
ci(chart): validate the Helm chart in CI + publish to GHCR (OCI) on release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,3 +45,31 @@ jobs:
           # (generated protobuf code), whose *_FullMethodName string constants
           # otherwise trip G101 (hardcoded-credential) false positives.
           gosec -severity medium -exclude-generated ./...
+
+  helm-chart:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
+      - name: helm lint
+        run: |
+          helm lint deploy/helm/keyorix \
+            --set auth.masterPassword=ci --set postgresql.auth.password=ci
+
+      - name: Render + schema-validate (kubeconform)
+        run: |
+          curl -fsSL https://github.com/yannh/kubeconform/releases/latest/download/kubeconform-linux-amd64.tar.gz \
+            | tar -xz kubeconform
+          # Render both the bundled-DB and external-DB paths and validate against
+          # the Kubernetes schema.
+          helm template kx deploy/helm/keyorix \
+            --set auth.masterPassword=ci --set postgresql.auth.password=ci \
+            --set auth.adminPassword=ci --set ingress.enabled=true \
+            | ./kubeconform -strict -summary -kubernetes-version 1.29.0
+          helm template kx deploy/helm/keyorix \
+            --set auth.masterPassword=ci --set postgresql.enabled=false \
+            --set externalDatabase.host=db.example.com --set externalDatabase.password=ci \
+            | ./kubeconform -strict -summary -kubernetes-version 1.29.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ on:
 
 permissions:
   contents: write # create the release and upload assets
+  packages: write # push the Helm chart to GHCR (OCI)
 
 jobs:
   build-and-release:
@@ -40,3 +41,22 @@ jobs:
               --title "Keyorix ${{ github.ref_name }}" \
               --generate-notes
           fi
+
+  publish-chart:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
+      - name: Package + push chart to GHCR (OCI)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Chart version = the tag without the leading 'v' (semver); app version
+          # = the full tag, so the chart pins the matching image by default.
+          version="${GITHUB_REF_NAME#v}"
+          helm package deploy/helm/keyorix --version "$version" --app-version "${GITHUB_REF_NAME}"
+          echo "$GH_TOKEN" | helm registry login ghcr.io -u "${{ github.actor }}" --password-stdin
+          helm push "keyorix-${version}.tgz" oci://ghcr.io/keyorixhq/charts

--- a/deploy/helm/keyorix/README.md
+++ b/deploy/helm/keyorix/README.md
@@ -7,14 +7,24 @@ persistent volume, the web UI proxying to it, and a bundled (or external) Postgr
 
 ## Quick start
 
+From a published release (the chart is pushed to GHCR as an OCI artifact on each
+`vX.Y.Z` tag):
+
 ```sh
-helm install keyorix ./deploy/helm/keyorix \
+helm install keyorix oci://ghcr.io/keyorixhq/charts/keyorix \
   --set auth.masterPassword='change-me-and-keep-it' \
   --set postgresql.auth.password='a-strong-db-password' \
   --set auth.adminPassword='Admin123!'
 ```
 
-Then follow the printed NOTES (port-forward the web service and log in).
+Or from a source checkout, swap the chart reference for `./deploy/helm/keyorix`.
+
+Then follow the printed NOTES (port-forward the web service and log in). After
+install you can smoke-test the deployment:
+
+```sh
+helm test keyorix
+```
 
 > ⚠️ **`auth.masterPassword` derives the encryption KEK.** Set it once and keep it
 > — changing it, or losing the server's keys PVC, makes every stored secret

--- a/deploy/helm/keyorix/templates/tests/test-connection.yaml
+++ b/deploy/helm/keyorix/templates/tests/test-connection.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ include "keyorix.fullname" . }}-test
+  labels:
+    {{- include "keyorix.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: test
+    helm.sh/hook-delete-policy: hook-succeeded,before-hook-creation
+spec:
+  restartPolicy: Never
+  containers:
+    - name: health
+      image: busybox:1.36
+      command: ["wget"]
+      args:
+        - "--spider"
+        - "-S"
+        - "http://{{ include "keyorix.server.fullname" . }}:{{ .Values.server.service.port }}/health"


### PR DESCRIPTION
## Summary

Follow-up to #83 — makes the Helm chart a first-class, regression-proof, published artifact.

- **CI validation** (`ci.yml` → new `helm-chart` job): `helm lint` + render the **bundled-DB and external-DB** paths and schema-validate with `kubeconform -strict` on every PR/push. The chart can't silently break now.
- **OCI publish** (`release.yml` → new `publish-chart` job): on each `vX.Y.Z` tag, `helm package` the chart and `helm push` it to `oci://ghcr.io/keyorixhq/charts` (chart version = tag without the `v`; appVersion = the tag). Adds `packages: write`.
- **`helm test` hook**: a Pod that smoke-tests the server `/health` after install (`helm test keyorix`).
- **README**: `helm install oci://ghcr.io/keyorixhq/charts/keyorix …` + `helm test` usage.

## Verification

- `helm lint` clean; `helm template` (incl. the test hook) → `kubeconform -strict` **12/12 valid** for both DB paths.
- `helm package` produces a valid tarball (the publish step's packaging).
- Both workflow YAMLs parse.

> The `helm push` to GHCR runs only on a real `vX.Y.Z` tag (needs the registry + `GITHUB_TOKEN`), so it's exercised when a release is cut — same as the binary-publish step added in #81.

🤖 Generated with [Claude Code](https://claude.com/claude-code)