### PR TITLE
chore(release): prep v0.3.0 (changelog, releasing guide, chart version)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,6 @@ jobs:
           # Chart version = the tag without the leading 'v' (semver); app version
           # = the full tag, so the chart pins the matching image by default.
           version="${GITHUB_REF_NAME#v}"
-          helm package deploy/helm/keyorix --version "$version" --app-version "${GITHUB_REF_NAME}"
+          helm package deploy/helm/keyorix --version "$version" --app-version "$version"
           echo "$GH_TOKEN" | helm registry login ghcr.io -u "${{ github.actor }}" --password-stdin
           helm push "keyorix-${version}.tgz" oci://ghcr.io/keyorixhq/charts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,48 @@
+# Changelog
+
+All notable changes to Keyorix are documented here. This project follows
+[Semantic Versioning](https://semver.org/).
+
+## v0.3.0 — 2026-06-11
+
+The "adopt Keyorix" release: a complete path to bring your secrets in, install
+the CLI, run it in CI, and deploy to Kubernetes.
+
+### Added
+- **Live secret migration** — `keyorix secret import --source {vault|aws|azure}`
+  pulls secrets directly from a running HashiCorp Vault, AWS Secrets Manager, or
+  Azure Key Vault (in addition to the existing file imports). Credentials stay
+  client-side; the source is read-only. ([#79])
+- **CI/CD integration** — a reusable GitHub Action
+  (`keyorixhq/keyorix/integrations/github-action`) that injects secrets into a
+  workflow as masked environment variables, plus GitLab CI and CircleCI
+  examples. ([#82])
+- **Kubernetes Helm chart** (`deploy/helm/keyorix`) — deploy the server + web UI
+  + PostgreSQL to a cluster; bundled or external database; optional ingress;
+  `helm test` hook. Published to `oci://ghcr.io/keyorixhq/charts` on release.
+  ([#83], [#84])
+- **Release pipeline** — a tagged workflow that cross-compiles and publishes the
+  CLI + server binaries (with checksums) and the Helm chart on every `vX.Y.Z`
+  tag. ([#81], [#84])
+
+### Fixed
+- **`install.sh`** downloaded assets under the wrong names (hyphens vs the
+  published underscores), so it never worked against a real release. Corrected
+  the names and added SHA-256 checksum verification. ([#80])
+- A `.gitignore` pattern (`keyorix`) matched any nested directory of that name,
+  silently hiding the new Helm chart from git. ([#83])
+
+[#79]: https://github.com/keyorixhq/keyorix/pull/79
+[#80]: https://github.com/keyorixhq/keyorix/pull/80
+[#81]: https://github.com/keyorixhq/keyorix/pull/81
+[#82]: https://github.com/keyorixhq/keyorix/pull/82
+[#83]: https://github.com/keyorixhq/keyorix/pull/83
+[#84]: https://github.com/keyorixhq/keyorix/pull/84
+
+## v0.2.0 — 2026-04-27
+
+Earlier release (binaries published out-of-band, before the automated pipeline).
+
+## v0.1.0 — 2026-04-20
+
+Initial tagged release.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,50 @@
+# Releasing Keyorix
+
+Releases are automated: pushing a `vX.Y.Z` git tag is the only manual step. The
+tag fires three workflows that publish everything a user consumes.
+
+## Cut a release
+
+1. Make sure `main` is green and `CHANGELOG.md` has an entry for the new version.
+2. (If the chart changed) bump `version`/`appVersion` in
+   `deploy/helm/keyorix/Chart.yaml`.
+3. Tag and push:
+
+   ```sh
+   git checkout main && git pull
+   git tag v0.3.0
+   git push origin v0.3.0
+   ```
+
+That's it. Watch the runs under the repo's **Actions** tab.
+
+## What the tag publishes
+
+| Workflow | Trigger | Output |
+|----------|---------|--------|
+| `release.yml` → `build-and-release` | `v*` tag | CLI + server binaries for linux/darwin × amd64/arm64 (`keyorix_<os>_<arch>`, `keyorix-server_<os>_<arch>`) + `checksums.txt`, attached to the GitHub Release. |
+| `release.yml` → `publish-chart` | `v*` tag | Helm chart pushed to `oci://ghcr.io/keyorixhq/charts` (chart + app version = the tag without the `v`). |
+| `docker-publish.yml` | `v*` tag (and `main`) | `ghcr.io/keyorixhq/keyorix-server` image tagged with the semver version. |
+
+The asset names produced by `make release` are exactly what `install.sh`
+downloads — keep `make release`, `install.sh`, and any image references in sync.
+
+> The **web** image (`ghcr.io/keyorixhq/keyorix-web`) is published from the
+> separate `keyorix-web` repository; tag it there too for a matching version.
+
+## After the release — verify it's consumable
+
+```sh
+# CLI installer (latest)
+curl -fsSL https://raw.githubusercontent.com/keyorixhq/keyorix/main/install.sh | sh
+keyorix --version          # → the new version
+
+# Helm chart from the OCI registry
+helm show chart oci://ghcr.io/keyorixhq/charts/keyorix --version 0.3.0
+```
+
+## Versioning
+
+Semantic Versioning. New user-facing features → minor; fixes → patch; breaking
+changes → major. The CLI/server embed the version via `-ldflags` at build time
+(`make release VERSION=<tag>`), so `keyorix --version` reports the tag.

--- a/deploy/helm/keyorix/Chart.yaml
+++ b/deploy/helm/keyorix/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix
 description: Self-hosted Keyorix secrets manager (API server + web UI + PostgreSQL)
 type: application
 # Chart version — bump on chart changes.
-version: 0.1.0
+version: 0.3.0
 # The Keyorix app version this chart deploys by default (the image tag).
-appVersion: "0.2.0"
+appVersion: "0.3.0"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix


### PR DESCRIPTION
## Summary

Makes the repo **tag-ready** so cutting `v0.3.0` fires the automated pipeline (binaries + Helm chart + server image) for the first time — turning this session's merged work into something a user can actually install/deploy at a pinned version.

- **`CHANGELOG.md`** — v0.3.0 entry: live migration (#79), install.sh fix (#80), release pipeline (#81), CI/CD action (#82), Helm chart (#83), chart CI/publish (#84).
- **`RELEASING.md`** — maintainer guide: push a `vX.Y.Z` tag; documents exactly what each workflow publishes (`release.yml` binaries + chart, `docker-publish.yml` image) and how to verify the release is consumable.
- **`Chart.yaml`** — version/appVersion → `0.3.0`.
- **`release.yml`** — chart appVersion = version without the leading `v` (matches the GHCR semver image-tag convention).

## After this merges — the one maintainer action

```sh
git checkout main && git pull
git tag v0.3.0 && git push origin v0.3.0
```

That single push publishes: versioned CLI + server binaries + checksums (so `install.sh` works against a real release), the Helm chart to `oci://ghcr.io/keyorixhq/charts`, and a semver-tagged server image.

## Verification

`helm lint` clean; `helm package --version 0.3.0` succeeds; the server image still resolves to `latest` (no accidental pin to an as-yet-unpublished tag); `release.yml` valid YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)