### PR TITLE
demo(migrate): one-command "leave Vault in 5 minutes" demo

### DIFF
--- a/demo/vault-migration/README.md
+++ b/demo/vault-migration/README.md
@@ -1,0 +1,61 @@
+# Demo: migrate off HashiCorp Vault in 5 minutes
+
+A self-contained, one-command demo of Keyorix's flagship "leave Vault" story: it
+stands up Keyorix **and** a throwaway HashiCorp Vault, seeds Vault with sample
+secrets, then migrates every one of them into Keyorix with a single command and
+shows them — then tears it all down.
+
+## Run it
+
+Prerequisites: `docker`, `curl`, `jq`, and the Keyorix CLI:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/keyorixhq/keyorix/main/install.sh | sh
+```
+
+Then, from the repo root:
+
+```sh
+./demo/vault-migration/run.sh
+```
+
+That's it. It runs five steps and cleans up on exit (Ctrl-C is safe):
+
+1. Start Keyorix (Postgres + API + web UI) via `docker compose`.
+2. Start a throwaway Vault and seed it with sample secrets.
+3. Show what's in Vault.
+4. **Migrate** — `keyorix secret import --source vault --vault-path demo/prod`.
+5. List the migrated secrets, now living in Keyorix.
+
+## What it demonstrates
+
+The seeded Vault holds three KV paths:
+
+```
+secret/demo/prod/database  → { username, password }
+secret/demo/prod/stripe    → { value }
+secret/demo/prod/redis     → { url }
+```
+
+One command imports all of them. Multi-field paths explode into one secret per
+field (`demo-prod-database-username`, `demo-prod-database-password`), a single
+`value` field keeps the path name (`demo-prod-stripe`), and credentials never
+touch the Keyorix server — the CLI reads Vault with your local token and POSTs
+only the resolved secrets.
+
+## Try it on your own Vault
+
+Skip step 2 and point the importer at a real Vault:
+
+```sh
+export KEYORIX_SERVER=https://keyorix.your-company.internal
+export KEYORIX_TOKEN=<machine token with secrets.write>
+export VAULT_ADDR=https://vault.your-company.internal:8200
+export VAULT_TOKEN=<a token with read+list on the path>
+
+keyorix secret import --source vault --vault-path prod \
+  --project payments --env production --dry-run   # preview first
+```
+
+See [docs/MIGRATION.md](../../docs/MIGRATION.md) for AWS Secrets Manager and
+Azure Key Vault, and the full flag reference.

--- a/demo/vault-migration/run.sh
+++ b/demo/vault-migration/run.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# "Migrate off Vault in 5 minutes" — a self-contained demo.
+#
+# Stands up Keyorix (docker compose) + a throwaway HashiCorp Vault, seeds Vault
+# with sample secrets, then migrates EVERY secret into Keyorix with one command
+# (`keyorix secret import --source vault`) and shows them. Tears everything down
+# on exit.
+#
+# Requires: docker, curl, jq, and the `keyorix` CLI on PATH
+#   (curl -fsSL https://raw.githubusercontent.com/keyorixhq/keyorix/main/install.sh | sh)
+# For testing against a locally-built CLI: KEYORIX_BIN=/path/to/keyorix ./run.sh
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+COMPOSE="docker compose -f ${ROOT}/docker-compose.yml -p keyorix-demo"
+KX="${KEYORIX_BIN:-keyorix}"
+KEYORIX_URL="http://localhost:8088"
+VAULT_PORT="8200"
+VAULT_ADDR="http://localhost:${VAULT_PORT}"
+VAULT_TOKEN="root"
+
+# Throwaway demo credentials (compose bootstraps the admin from these).
+export KEYORIX_DB_PASSWORD="demo-db-pass"
+export KEYORIX_MASTER_PASSWORD="demo-master-pass"
+export KEYORIX_ADMIN_USERNAME="admin"
+export KEYORIX_ADMIN_PASSWORD="Admin123!"
+export KEYORIX_ADMIN_EMAIL="admin@keyorix.local"
+
+c()  { printf '\n\033[1;34m▶ %s\033[0m\n' "$1"; }
+ok() { printf '\033[0;32m✓ %s\033[0m\n' "$1"; }
+
+cleanup() {
+  c "Cleaning up"
+  docker rm -f keyorix-demo-vault >/dev/null 2>&1 || true
+  $COMPOSE down -v >/dev/null 2>&1 || true
+  ok "Demo environment removed"
+}
+trap cleanup EXIT
+
+command -v "$KX" >/dev/null 2>&1 || { echo "keyorix CLI not found — install it first (see header)"; exit 1; }
+command -v jq >/dev/null 2>&1 || { echo "jq is required"; exit 1; }
+
+c "1/5  Starting Keyorix (Postgres + API + web UI)"
+$COMPOSE up -d postgres backend web
+printf 'Waiting for Keyorix to bootstrap'
+TOKEN=""
+set +e  # the early attempts fail while the backend boots — don't let that exit
+for _ in $(seq 1 60); do
+  TOKEN="$(curl -s -X POST "${KEYORIX_URL}/auth/login" -H 'Content-Type: application/json' \
+    -d "{\"username\":\"${KEYORIX_ADMIN_USERNAME}\",\"password\":\"${KEYORIX_ADMIN_PASSWORD}\"}" \
+    2>/dev/null | jq -r '.data.token // empty')"
+  [ -n "$TOKEN" ] && break
+  printf '.'; sleep 2
+done
+set -e
+echo
+[ -n "$TOKEN" ] || { echo "Keyorix did not come up in time"; $COMPOSE logs backend | tail -20; exit 1; }
+ok "Keyorix is up — logged in as ${KEYORIX_ADMIN_USERNAME}"
+
+c "2/5  Starting a throwaway HashiCorp Vault and seeding it"
+docker rm -f keyorix-demo-vault >/dev/null 2>&1 || true
+docker run -d --name keyorix-demo-vault -p "${VAULT_PORT}:8200" \
+  -e "VAULT_DEV_ROOT_TOKEN_ID=${VAULT_TOKEN}" -e "VAULT_DEV_LISTEN_ADDRESS=0.0.0.0:8200" \
+  hashicorp/vault:latest >/dev/null
+set +e
+for _ in $(seq 1 30); do curl -sf "${VAULT_ADDR}/v1/sys/health" >/dev/null 2>&1 && break; sleep 1; done
+set -e
+vault_put() { curl -s -H "X-Vault-Token: ${VAULT_TOKEN}" -X POST "${VAULT_ADDR}/v1/secret/data/$1" -d "$2" >/dev/null; }
+vault_put demo/prod/database '{"data":{"username":"app_user","password":"pg-prod-xK9mN2pQ"}}'
+vault_put demo/prod/stripe   '{"data":{"value":"sk_live_demo_51abcXYZ"}}'
+vault_put demo/prod/redis    '{"data":{"url":"redis://cache.prod.internal:6379"}}'
+ok "Seeded Vault with 3 paths under secret/demo/prod/ (4 secrets)"
+
+c "3/5  What's in Vault today"
+echo "  secret/demo/prod/database  → username, password"
+echo "  secret/demo/prod/stripe    → value"
+echo "  secret/demo/prod/redis     → url"
+
+c "4/5  Migrating EVERY secret into Keyorix — one command"
+echo "  \$ keyorix secret import --source vault --vault-path demo/prod --project default --env production"
+KEYORIX_SERVER="$KEYORIX_URL" KEYORIX_TOKEN="$TOKEN" \
+VAULT_ADDR="$VAULT_ADDR" VAULT_TOKEN="$VAULT_TOKEN" \
+  "$KX" secret import --source vault --vault-path demo/prod --project default --env production
+
+c "5/5  The secrets now live in Keyorix"
+KEYORIX_SERVER="$KEYORIX_URL" KEYORIX_TOKEN="$TOKEN" "$KX" secret list
+
+ok "Migration complete. Open ${KEYORIX_URL} (admin / ${KEYORIX_ADMIN_PASSWORD}) to browse them in the UI."
+echo
+echo "That's the whole 'leave Vault' story: point Keyorix at your live Vault, run one"
+echo "command, and every secret is imported — names, values, multi-field paths and all."

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -1,5 +1,10 @@
 # Migrating secrets into Keyorix
 
+> **Want to see it first?** [`demo/vault-migration/`](../demo/vault-migration/README.md)
+> is a one-command demo that stands up Keyorix + a throwaway Vault and migrates
+> live secrets end to end.
+
+
 `keyorix secret import` pulls existing secrets into Keyorix — either from a file
 or **directly from a running secrets manager** (HashiCorp Vault, AWS Secrets
 Manager, Azure Key Vault). It runs in remote mode against your Keyorix server, so


### PR DESCRIPTION
## Summary

A self-contained, sales-ready demo of the flagship live-Vault migration (#79) — the strongest "switch off Vault" wedge. One command stands up Keyorix **and** a throwaway HashiCorp Vault, seeds Vault, migrates every secret into Keyorix, shows them, and cleans up.

```sh
./demo/vault-migration/run.sh
```

Steps: start Keyorix (compose) → start + seed Vault → show Vault contents → `keyorix secret import --source vault` → list the migrated secrets. Tears everything down on exit (Ctrl-C safe).

## Why

The binding constraint is landing the first customer, and "leave Vault in an afternoon" is the headline pitch. This turns the merged migration feature into a concrete, runnable story a founder can demo live or a prospect can try themselves — leveraging the now-released, install-verified CLI.

## Verification

Ran end to end locally: 4 secrets across 3 KV paths → **all 4 imported** (multi-field `database` explodes into `-username`/`-password`; single-`value` `stripe` keeps the path name) → listed in Keyorix → environment removed. `shellcheck` clean. `docs/MIGRATION.md` links to it.

## Files

- `demo/vault-migration/run.sh` — orchestrator (`KEYORIX_BIN` overridable for local CLI builds)
- `demo/vault-migration/README.md` — run instructions + how to point at a real Vault

🤖 Generated with [Claude Code](https://claude.com/claude-code)