### PR TITLE
fix(auth): revoke access on suspend/deactivate — sessions no longer outlive it

### DIFF
--- a/internal/core/account_state.go
+++ b/internal/core/account_state.go
@@ -98,6 +98,12 @@ func (c *KeyorixCore) setAccountState(ctx context.Context, adminID, userID uint,
 	if _, err := c.storage.UpdateUser(ctx, user); err != nil {
 		return fmt.Errorf("failed to update account state: %w", err)
 	}
+	// A state that blocks login must also terminate the user's existing sessions,
+	// so suspension is effective immediately instead of lingering until the token
+	// expires. ValidateSessionToken also rejects blocked accounts as a backstop.
+	if AccountLoginBlocked(state) {
+		_ = c.storage.DeleteSessionsForUserExcept(ctx, userID, 0)
+	}
 	aid := adminID
 	c.writeAuditEventFull(ctx, eventType, &aid, nil, nil, "",
 		fmt.Sprintf("user %d account state set to %s", userID, state))

--- a/internal/core/account_state_test.go
+++ b/internal/core/account_state_test.go
@@ -59,9 +59,16 @@ func TestAdminAccountTransitions(t *testing.T) {
 			store.On("LogAuditEvent", ctx, mock.MatchedBy(func(e *models.AuditEvent) bool {
 				return e.EventType == tc.event
 			})).Return(nil)
+			// A login-blocking transition (suspend) must purge the user's sessions.
+			if AccountLoginBlocked(tc.wantState) {
+				store.On("DeleteSessionsForUserExcept", ctx, uint(2), uint(0)).Return(nil)
+			}
 
 			require.NoError(t, tc.call(c, ctx))
 			store.AssertExpectations(t)
+			if !AccountLoginBlocked(tc.wantState) {
+				store.AssertNotCalled(t, "DeleteSessionsForUserExcept", mock.Anything, mock.Anything, mock.Anything)
+			}
 		})
 	}
 }
@@ -78,6 +85,50 @@ func TestLogin_BlocksSuspended(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "suspended")
 	store.AssertNotCalled(t, "CreateSession", mock.Anything, mock.Anything)
+}
+
+// A suspended or deactivated account must not authenticate via an existing,
+// not-yet-expired session token (the suspend/deactivate revocation gap).
+func TestValidateSessionToken_RejectsBlockedOrInactive(t *testing.T) {
+	future := time.Date(2026, 6, 6, 12, 0, 0, 0, time.UTC) // after newAccountCore's fixed now
+	cases := []struct {
+		name string
+		user *models.User
+	}{
+		{"suspended", &models.User{ID: 2, IsActive: true, AccountState: AccountSuspended}},
+		{"inactive", &models.User{ID: 2, IsActive: false, AccountState: AccountActive}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := new(MockStorage)
+			c := newAccountCore(store)
+			ctx := context.Background()
+			store.On("GetSession", ctx, "tok").Return(&models.Session{ID: 7, UserID: 2, ExpiresAt: &future}, nil)
+			store.On("TouchSession", ctx, uint(7), mock.Anything, mock.Anything).Return(nil)
+			store.On("GetUser", ctx, uint(2)).Return(tc.user, nil)
+
+			_, _, err := c.ValidateSessionToken(ctx, "tok")
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "not active")
+			store.AssertNotCalled(t, "GetUserRoles", mock.Anything, mock.Anything)
+		})
+	}
+}
+
+func TestValidateSessionToken_AllowsActive(t *testing.T) {
+	future := time.Date(2026, 6, 6, 12, 0, 0, 0, time.UTC)
+	store := new(MockStorage)
+	c := newAccountCore(store)
+	ctx := context.Background()
+	store.On("GetSession", ctx, "tok").Return(&models.Session{ID: 7, UserID: 2, ExpiresAt: &future}, nil)
+	store.On("TouchSession", ctx, uint(7), mock.Anything, mock.Anything).Return(nil)
+	store.On("GetUser", ctx, uint(2)).Return(&models.User{ID: 2, IsActive: true, AccountState: AccountActive}, nil)
+	store.On("GetUserRoles", ctx, uint(2)).Return([]*models.Role{{Name: "viewer"}}, nil)
+
+	user, roles, err := c.ValidateSessionToken(ctx, "tok")
+	require.NoError(t, err)
+	assert.Equal(t, uint(2), user.ID)
+	assert.Equal(t, []string{"viewer"}, roles)
 }
 
 func TestChangePassword_ClearsRestriction(t *testing.T) {

--- a/internal/core/auth.go
+++ b/internal/core/auth.go
@@ -173,6 +173,12 @@ func (c *KeyorixCore) ValidateSessionToken(ctx context.Context, token string) (*
 	if err != nil {
 		return nil, nil, fmt.Errorf("user not found")
 	}
+	// Reject sessions whose account has since been deactivated or suspended, so an
+	// admin's suspend/deactivate takes effect on already-issued tokens rather than
+	// lingering until expiry. Mirrors the active-state check in ValidatePATToken.
+	if !user.IsActive || AccountLoginBlocked(user.AccountState) {
+		return nil, nil, fmt.Errorf("account is not active")
+	}
 	roles, err := c.storage.GetUserRoles(ctx, user.ID)
 	if err != nil {
 		return user, []string{}, nil

--- a/internal/core/migrate_user_to_machine_test.go
+++ b/internal/core/migrate_user_to_machine_test.go
@@ -22,12 +22,14 @@ func TestMigrateUserToMachine(t *testing.T) {
 		store.On("CreateMachineIdentity", ctx, mock.MatchedBy(func(m *models.MachineIdentity) bool {
 			return m.ProjectID == 3 && m.Name == "ci-bot" && m.IdentityType == MachineTypeService && m.State == MachineActive
 		})).Return(&models.MachineIdentity{ID: 20, ProjectID: 3, Name: "ci-bot", IdentityType: MachineTypeService, State: MachineActive}, nil)
-		// SuspendUser path: GetUser → UpdateUser(account_state=suspended).
+		// SuspendUser path: GetUser → UpdateUser(account_state=suspended) →
+		// purge the migrated user's sessions (suspension revokes existing tokens).
 		store.On("GetUser", ctx, uint(7)).
 			Return(&models.User{ID: 7, Username: "ci-bot", AccountState: "active"}, nil)
 		store.On("UpdateUser", ctx, mock.MatchedBy(func(u *models.User) bool {
 			return u.ID == 7 && u.AccountState == AccountSuspended
 		})).Return(&models.User{ID: 7, AccountState: AccountSuspended}, nil)
+		store.On("DeleteSessionsForUserExcept", ctx, uint(7), uint(0)).Return(nil)
 
 		seen := map[string]bool{}
 		store.On("LogAuditEvent", ctx, mock.MatchedBy(func(e *models.AuditEvent) bool {


### PR DESCRIPTION
## The bug (HIGH, found in a security audit of the auth core)

`ValidateSessionToken` checked **only session expiry** — never the account's state. So when an admin **suspends** (or deactivates) a user, that user's already-issued session token keeps **full API access** until it naturally expires (default 24h, and `RefreshSession` can extend it up to the absolute ceiling). `ValidatePATToken` already rejected `!IsActive` users; the session path didn't — so account suspension was effectively a no-op against live sessions.

This is an access-lifecycle gap: an admin's "cut off this user now" action didn't actually cut them off. Exactly the kind of finding a security certification flags.

## Fix (two layers)

1. **`ValidateSessionToken`** now rejects a session when the account is `!IsActive` or login-blocked (`AccountLoginBlocked`, i.e. suspended) — mirroring `ValidatePATToken`. Effective on the next request after the middleware token-cache window.
2. **`setAccountState`** now purges the user's sessions (`DeleteSessionsForUserExcept(userID, 0)`) on any login-blocking transition, so suspension is effective **immediately**, not just at token expiry. (`MigrateUserToMachine` suspends the migrated human user, so its sessions are correctly purged now too.)

## Tests

- `ValidateSessionToken` rejects suspended **and** inactive accounts (with a valid, non-expired session) and still allows active ones.
- The admin suspend transition asserts the session purge fires (and that non-blocking transitions don't).
- Full `internal/core` suite green; `go vet` clean.

> Residual (documented, minor): the auth middleware caches a validated token for ~30s, so a suspension can take up to that long to propagate to in-flight cached tokens even though the DB sessions are deleted immediately. Tightening/invalidating that cache is a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)