### PR TITLE
fix(grpc): scope-check secret reads/writes/deletes (flat-vs-scoped parity)

### DIFF
--- a/server/grpc/services/secret_service.go
+++ b/server/grpc/services/secret_service.go
@@ -71,8 +71,8 @@ func (s *SecretGRPCService) GetSecret(ctx context.Context, req *pb.GetSecretRequ
 	if err != nil {
 		return nil, err
 	}
-	if !hasPermission(user.Permissions, "secrets.read") {
-		return nil, status.Error(codes.PermissionDenied, "insufficient permissions to read secrets")
+	if err := s.authorizeSecretScoped(ctx, user.UserID, uint(req.GetId()), "secrets.read"); err != nil {
+		return nil, err
 	}
 	secret, err := s.core.GetSecretWithPermissionCheck(ctx, uint(req.GetId()), user.UserID)
 	if err != nil {
@@ -89,8 +89,8 @@ func (s *SecretGRPCService) GetSecretValue(ctx context.Context, req *pb.GetSecre
 	if err != nil {
 		return nil, err
 	}
-	if !hasPermission(user.Permissions, "secrets.read") {
-		return nil, status.Error(codes.PermissionDenied, "insufficient permissions to read secrets")
+	if err := s.authorizeSecretScoped(ctx, user.UserID, uint(req.GetId()), "secrets.read"); err != nil {
+		return nil, err
 	}
 	// Resolve the name first (metadata read, no read-count side effect).
 	secret, err := s.core.GetSecretWithPermissionCheck(ctx, uint(req.GetId()), user.UserID)
@@ -114,11 +114,11 @@ func (s *SecretGRPCService) UpdateSecret(ctx context.Context, req *pb.UpdateSecr
 	if err != nil {
 		return nil, err
 	}
-	if !hasPermission(user.Permissions, "secrets.write") {
-		return nil, status.Error(codes.PermissionDenied, "insufficient permissions to update secrets")
-	}
 	if req.GetId() == 0 {
 		return nil, status.Error(codes.InvalidArgument, "id is required")
+	}
+	if err := s.authorizeSecretScoped(ctx, user.UserID, uint(req.GetId()), "secrets.write"); err != nil {
+		return nil, err
 	}
 
 	updateReq := &core.UpdateSecretRequest{
@@ -147,11 +147,11 @@ func (s *SecretGRPCService) DeleteSecret(ctx context.Context, req *pb.DeleteSecr
 	if err != nil {
 		return nil, err
 	}
-	if !hasPermission(user.Permissions, "secrets.delete") {
-		return nil, status.Error(codes.PermissionDenied, "insufficient permissions to delete secrets")
-	}
 	if req.GetId() == 0 {
 		return nil, status.Error(codes.InvalidArgument, "id is required")
+	}
+	if err := s.authorizeSecretScoped(ctx, user.UserID, uint(req.GetId()), "secrets.delete"); err != nil {
+		return nil, err
 	}
 	if err := s.core.DeleteSecretWithPermissionCheck(ctx, uint(req.GetId()), user.UserID); err != nil {
 		return nil, mapSecretError(err)
@@ -165,7 +165,11 @@ func (s *SecretGRPCService) ListSecrets(ctx context.Context, req *pb.ListSecrets
 	if err != nil {
 		return nil, err
 	}
-	if !hasPermission(user.Permissions, "secrets.read") {
+	// Authorize at the requested project/environment scope (mirrors the HTTP list
+	// route's ScopeFromQuery); 0/0 means global. ListSecretsWithSharingInfo then
+	// filters the results to what the caller may actually see.
+	listScope := core.Scope{ProjectID: uint(req.GetProjectId()), EnvironmentID: uint(req.GetEnvironmentId())}
+	if allowed, err := s.core.Authorize(ctx, user.UserID, "secrets.read", listScope); err != nil || !allowed {
 		return nil, status.Error(codes.PermissionDenied, "insufficient permissions to list secrets")
 	}
 
@@ -216,8 +220,8 @@ func (s *SecretGRPCService) GetSecretVersions(ctx context.Context, req *pb.GetSe
 	if err != nil {
 		return nil, err
 	}
-	if !hasPermission(user.Permissions, "secrets.read") {
-		return nil, status.Error(codes.PermissionDenied, "insufficient permissions to read secrets")
+	if err := s.authorizeSecretScoped(ctx, user.UserID, uint(req.GetId()), "secrets.read"); err != nil {
+		return nil, err
 	}
 	versions, err := s.core.GetSecretVersionsWithPermissionCheck(ctx, uint(req.GetId()), user.UserID)
 	if err != nil {
@@ -241,6 +245,24 @@ func (s *SecretGRPCService) GetSecretVersions(ctx context.Context, req *pb.GetSe
 // requireUser returns the authenticated user from the context or an
 // Unauthenticated error. The auth interceptor populates this on every
 // non-public RPC.
+// authorizeSecretScoped resolves a secret's project/environment and checks the
+// permission AT that scope — mirroring the HTTP RequireScopedPermission gate, so
+// gRPC enforces the same scoped-RBAC model as HTTP rather than the flat, global
+// permission set. A missing secret yields NotFound (not PermissionDenied) to
+// avoid leaking existence; the downstream *WithPermissionCheck core calls still
+// enforce ownership/share on top of this.
+func (s *SecretGRPCService) authorizeSecretScoped(ctx context.Context, userID, secretID uint, perm string) error {
+	secret, err := s.core.Storage().GetSecret(ctx, secretID)
+	if err != nil {
+		return status.Error(codes.NotFound, "secret not found")
+	}
+	scope := core.Scope{ProjectID: secret.ProjectID, EnvironmentID: secret.EnvironmentID}
+	if allowed, err := s.core.Authorize(ctx, userID, perm, scope); err != nil || !allowed {
+		return status.Error(codes.PermissionDenied, "insufficient permissions for this secret")
+	}
+	return nil
+}
+
 // mapSecretError translates core errors into gRPC status codes.
 func mapSecretError(err error) error {
 	msg := err.Error()

--- a/server/grpc/services/secret_service_test.go
+++ b/server/grpc/services/secret_service_test.go
@@ -148,6 +148,62 @@ func TestSecretService_CreateSecret_ScopedToOtherProjectDenied(t *testing.T) {
 	assert.Equal(t, codes.PermissionDenied, status.Code(err))
 }
 
+// Regression (gRPC scoped-authz hardening): per-secret reads/writes/deletes must
+// authorize at the SECRET'S project/environment, not the flat global permission
+// set. A user who even OWNS a secret in a project where they hold no RBAC grant
+// must still be denied over gRPC — matching the HTTP scoped gate. Previously the
+// flat secrets.* check passed and the downstream owner check let them through, so
+// a project-1 writer could read/update/delete their secret sitting in project 2.
+func TestSecretService_PerSecretOps_ScopedToOtherProjectDenied(t *testing.T) {
+	r := newSecretTestRig(t)
+	require.NoError(t, r.db.Create(&models.Project{ID: 2, Name: "other"}).Error)
+	require.NoError(t, r.db.Create(&models.Environment{ID: 2, ProjectID: 2, Name: "development"}).Error)
+	// User 3: writer scoped to project 1 only — no grant in project 2.
+	require.NoError(t, r.db.Create(&models.User{ID: 3, Username: "scoped", Email: "scoped@example.com"}).Error)
+	require.NoError(t, r.db.Create(&models.UserRole{UserID: 3, RoleID: writerRoleID, ProjectID: 1}).Error)
+	// A secret in project 2 that user 3 OWNS (so the owner check alone would pass).
+	require.NoError(t, r.db.Create(&models.SecretNode{
+		ID: 50, Name: "p2-secret", ProjectID: 2, EnvironmentID: 2, OwnerID: 3, Status: "active", Type: "password",
+	}).Error)
+
+	// Flat list advertises every permission — the bug would have honoured it.
+	ctx := authCtx(3, "scoped", "secrets.read", "secrets.write", "secrets.delete")
+
+	_, err := r.svc.GetSecret(ctx, &pb.GetSecretRequest{Id: 50})
+	require.Error(t, err)
+	assert.Equal(t, codes.PermissionDenied, status.Code(err), "GetSecret cross-project")
+
+	_, err = r.svc.GetSecretValue(ctx, &pb.GetSecretRequest{Id: 50})
+	require.Error(t, err)
+	assert.Equal(t, codes.PermissionDenied, status.Code(err), "GetSecretValue cross-project")
+
+	_, err = r.svc.UpdateSecret(ctx, &pb.UpdateSecretRequest{Id: 50})
+	require.Error(t, err)
+	assert.Equal(t, codes.PermissionDenied, status.Code(err), "UpdateSecret cross-project")
+
+	_, err = r.svc.DeleteSecret(ctx, &pb.DeleteSecretRequest{Id: 50})
+	require.Error(t, err)
+	assert.Equal(t, codes.PermissionDenied, status.Code(err), "DeleteSecret cross-project")
+
+	_, err = r.svc.GetSecretVersions(ctx, &pb.GetSecretVersionsRequest{Id: 50})
+	require.Error(t, err)
+	assert.Equal(t, codes.PermissionDenied, status.Code(err), "GetSecretVersions cross-project")
+}
+
+// A scoped user CAN operate on a secret within a project where they hold the
+// grant — confirming the scoped check didn't over-restrict legitimate access.
+func TestSecretService_PerSecretOps_InScopeAllowed(t *testing.T) {
+	r := newSecretTestRig(t)
+	require.NoError(t, r.db.Create(&models.User{ID: 3, Username: "scoped", Email: "scoped@example.com"}).Error)
+	require.NoError(t, r.db.Create(&models.UserRole{UserID: 3, RoleID: writerRoleID, ProjectID: 1}).Error)
+	ctx := authCtx(3, "scoped", "secrets.read", "secrets.write")
+
+	created := r.createSecret(t, ctx, "in-scope", "v") // project 1, where user 3 has the grant
+	got, err := r.svc.GetSecret(ctx, &pb.GetSecretRequest{Id: created.GetId()})
+	require.NoError(t, err)
+	assert.Equal(t, "in-scope", got.GetName())
+}
+
 func TestSecretService_CreateSecret_Validation(t *testing.T) {
 	r := newSecretTestRig(t)
 	ctx := authCtx(1, "writer", "secrets.write")


### PR DESCRIPTION
## The bug (MEDIUM, from the auth-core security audit)

The gRPC `SecretService` gated `GetSecret`, `GetSecretValue`, `UpdateSecret`, `DeleteSecret`, `ListSecrets`, and `GetSecretVersions` on the **flat global** permission set (`hasPermission(user.Permissions, …)`), while the HTTP routes enforce `RequireScopedPermission(perm, secretScope)` — the permission must be held **in the target secret's own project**. `CreateSecret` was already fixed (#54); these six were the remaining flat-vs-scoped divergence.

**Net effect:** a user with `secrets.*` in project A who owns (or is shared) a secret in project B could read/update/delete it over gRPC, where HTTP denies. Two transports enforcing different authorization models for the same operations — a real correctness gap (and a certification concern in itself).

## Fix

- New `authorizeSecretScoped`: resolves the secret's project/environment (via `Storage().GetSecret`, exactly like HTTP's `ScopeFromSecretParam`) and `Authorize`s at that scope. A missing secret returns `NotFound` (no existence leak). The downstream `*WithPermissionCheck` core calls still enforce ownership/share on top.
- The five per-secret ops use it; `ListSecrets` authorizes at the request's project/environment scope (mirrors `ScopeFromQuery`), then the existing per-user result filtering applies.

## Tests

- `TestSecretService_PerSecretOps_ScopedToOtherProjectDenied`: a project-1-scoped user who **owns** a secret in project 2 is now denied Get/GetValue/Update/Delete/Versions over gRPC (the closed bypass).
- `TestSecretService_PerSecretOps_InScopeAllowed`: an in-scope user is still allowed (no over-restriction).
- Full `server/grpc` suite green (incl. the bufconn end-to-end + interceptor tests); `go vet` clean.

> Note: the gRPC `ShareService` uses the same flat pattern for some methods (with downstream owner checks). It's a candidate for the same treatment in a follow-up; this PR is scoped to the audited `SecretService`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)