### PR TITLE
fix(encryption): stable ordering in the DEK-rotation sweep

### DIFF
--- a/internal/encryption/sweep.go
+++ b/internal/encryption/sweep.go
@@ -20,7 +20,9 @@ import (
 	"gorm.io/gorm"
 )
 
-const sweepBatchSize = 500
+// sweepBatchSize is how many secret_versions rows are re-encrypted per batch.
+// A var (not const) so tests can shrink it to exercise multi-batch pagination.
+var sweepBatchSize = 500
 
 // SweepResult holds statistics from a completed sweep.
 type SweepResult struct {
@@ -96,7 +98,11 @@ func sweepSecretVersions(tx *gorm.DB, oldSvc *EncryptionService, newSvc *Encrypt
 
 	for {
 		var batch []models.SecretVersion
-		if err := tx.Offset(offset).Limit(sweepBatchSize).Find(&batch).Error; err != nil {
+		// Order by the immutable primary key: this batch loop re-encrypts (updates)
+		// rows in place, and without a stable ORDER BY, offset pagination could skip
+		// or double-visit rows as the engine re-orders the unupdated result set —
+		// silently leaving some versions under the old DEK. id is never updated.
+		if err := tx.Order("id").Offset(offset).Limit(sweepBatchSize).Find(&batch).Error; err != nil {
 			return totalSwept, totalLegacyUpgraded, fmt.Errorf("failed to fetch secret_versions batch at offset %d: %w", offset, err)
 		}
 		if len(batch) == 0 {

--- a/internal/encryption/sweep_test.go
+++ b/internal/encryption/sweep_test.go
@@ -189,6 +189,55 @@ func TestRotateDEKWithSweep_ReEncryptsAllRows(t *testing.T) {
 	}
 }
 
+// TestRotateDEKWithSweep_MultipleBatches verifies that a rotation spanning more
+// than one pagination batch re-encrypts EVERY row. A row skipped by unstable
+// offset pagination would remain under the old DEK and fail to decrypt below.
+func TestRotateDEKWithSweep_MultipleBatches(t *testing.T) {
+	db := newTestDB(t)
+	svc, _ := newTestService(t, "test-passphrase")
+
+	// Shrink the batch so a handful of rows spans several batches.
+	orig := sweepBatchSize
+	sweepBatchSize = 2
+	defer func() { sweepBatchSize = orig }()
+
+	const projectID = uint(1)
+	nodeID := seedSecretNode(t, db, projectID)
+	const n = 5
+	values := make(map[int]string, n)
+	for i := 1; i <= n; i++ {
+		val := fmt.Sprintf("secret-value-%d", i)
+		seedSecretVersion(t, db, svc, nodeID, projectID, i, val)
+		values[i] = val
+	}
+
+	oldDEK := captureCurrentDEK(t, svc)
+	if err := svc.RotateDEKWithSweep("test-passphrase", db); err != nil {
+		t.Fatalf("RotateDEKWithSweep failed: %v", err)
+	}
+	if string(oldDEK) == string(captureCurrentDEK(t, svc)) {
+		t.Fatal("DEK did not change after rotation")
+	}
+
+	var versions []models.SecretVersion
+	if err := db.Where("secret_node_id = ?", nodeID).Find(&versions).Error; err != nil {
+		t.Fatalf("failed to fetch versions: %v", err)
+	}
+	if len(versions) != n {
+		t.Fatalf("expected %d versions, got %d", n, len(versions))
+	}
+	for _, v := range versions {
+		aad := SecretAAD(nodeID, projectID, v.VersionNumber)
+		plaintext, err := svc.DecryptSecretWithAAD(v.EncryptedValue, aad)
+		if err != nil {
+			t.Fatalf("version %d not re-encrypted under the new DEK (sweep skipped it): %v", v.VersionNumber, err)
+		}
+		if string(plaintext) != values[v.VersionNumber] {
+			t.Errorf("version %d: got %q, want %q", v.VersionNumber, plaintext, values[v.VersionNumber])
+		}
+	}
+}
+
 // TestRotateDEKWithSweep_UpgradesLegacyAAD verifies that legacy rows (no AAD)
 // are decrypted without AAD and re-encrypted with AAD after the sweep.
 func TestRotateDEKWithSweep_UpgradesLegacyAAD(t *testing.T) {


### PR DESCRIPTION
## The bug (from the encryption-core audit)

`sweepSecretVersions` (the re-encryption sweep behind `RotateDEKWithSweep`, ADR-010) paginated with `Offset(offset).Limit(sweepBatchSize).Find(&batch)` and **no `ORDER BY`**, while updating (re-encrypting) each row in place. Row order for `LIMIT/OFFSET` without `ORDER BY` is engine-defined and can shift as the result set is mutated, so a batch boundary could **skip or double-visit rows** — silently leaving some `secret_versions` encrypted under the **old DEK** after a rotation the sweep reported as fully successful.

For a secrets manager, "key rotation completed, but some secrets are still under the old key" is a serious correctness/compliance failure (and exactly the kind of invariant a certification cares about).

## Fix

- Order the batch query by the immutable primary key (`Order("id")`), so offset pagination visits every row exactly once. `id` is never updated, so the order is stable across the in-transaction re-encryption.
- Make `sweepBatchSize` a `var` so tests can shrink it; add `TestRotateDEKWithSweep_MultipleBatches`: 5 versions spanning several batches must **all** decrypt under the new DEK after rotation (a skipped row would still be under the old key and fail the test).

## Verification

Full `internal/encryption` suite green (incl. the existing all-rows / legacy-AAD / rollback / pending-file tests); `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)