### PR TITLE
fix(grpc): scope-check share mutations (flat-vs-scoped parity, cont.)

### DIFF
--- a/server/grpc/services/secret_service.go
+++ b/server/grpc/services/secret_service.go
@@ -71,7 +71,7 @@ func (s *SecretGRPCService) GetSecret(ctx context.Context, req *pb.GetSecretRequ
 	if err != nil {
 		return nil, err
 	}
-	if err := s.authorizeSecretScoped(ctx, user.UserID, uint(req.GetId()), "secrets.read"); err != nil {
+	if err := authorizeSecretScoped(ctx, s.core, user.UserID, uint(req.GetId()), "secrets.read"); err != nil {
 		return nil, err
 	}
 	secret, err := s.core.GetSecretWithPermissionCheck(ctx, uint(req.GetId()), user.UserID)
@@ -89,7 +89,7 @@ func (s *SecretGRPCService) GetSecretValue(ctx context.Context, req *pb.GetSecre
 	if err != nil {
 		return nil, err
 	}
-	if err := s.authorizeSecretScoped(ctx, user.UserID, uint(req.GetId()), "secrets.read"); err != nil {
+	if err := authorizeSecretScoped(ctx, s.core, user.UserID, uint(req.GetId()), "secrets.read"); err != nil {
 		return nil, err
 	}
 	// Resolve the name first (metadata read, no read-count side effect).
@@ -117,7 +117,7 @@ func (s *SecretGRPCService) UpdateSecret(ctx context.Context, req *pb.UpdateSecr
 	if req.GetId() == 0 {
 		return nil, status.Error(codes.InvalidArgument, "id is required")
 	}
-	if err := s.authorizeSecretScoped(ctx, user.UserID, uint(req.GetId()), "secrets.write"); err != nil {
+	if err := authorizeSecretScoped(ctx, s.core, user.UserID, uint(req.GetId()), "secrets.write"); err != nil {
 		return nil, err
 	}
 
@@ -150,7 +150,7 @@ func (s *SecretGRPCService) DeleteSecret(ctx context.Context, req *pb.DeleteSecr
 	if req.GetId() == 0 {
 		return nil, status.Error(codes.InvalidArgument, "id is required")
 	}
-	if err := s.authorizeSecretScoped(ctx, user.UserID, uint(req.GetId()), "secrets.delete"); err != nil {
+	if err := authorizeSecretScoped(ctx, s.core, user.UserID, uint(req.GetId()), "secrets.delete"); err != nil {
 		return nil, err
 	}
 	if err := s.core.DeleteSecretWithPermissionCheck(ctx, uint(req.GetId()), user.UserID); err != nil {
@@ -220,7 +220,7 @@ func (s *SecretGRPCService) GetSecretVersions(ctx context.Context, req *pb.GetSe
 	if err != nil {
 		return nil, err
 	}
-	if err := s.authorizeSecretScoped(ctx, user.UserID, uint(req.GetId()), "secrets.read"); err != nil {
+	if err := authorizeSecretScoped(ctx, s.core, user.UserID, uint(req.GetId()), "secrets.read"); err != nil {
 		return nil, err
 	}
 	versions, err := s.core.GetSecretVersionsWithPermissionCheck(ctx, uint(req.GetId()), user.UserID)
@@ -251,13 +251,13 @@ func (s *SecretGRPCService) GetSecretVersions(ctx context.Context, req *pb.GetSe
 // permission set. A missing secret yields NotFound (not PermissionDenied) to
 // avoid leaking existence; the downstream *WithPermissionCheck core calls still
 // enforce ownership/share on top of this.
-func (s *SecretGRPCService) authorizeSecretScoped(ctx context.Context, userID, secretID uint, perm string) error {
-	secret, err := s.core.Storage().GetSecret(ctx, secretID)
+func authorizeSecretScoped(ctx context.Context, cs *core.KeyorixCore, userID, secretID uint, perm string) error {
+	secret, err := cs.Storage().GetSecret(ctx, secretID)
 	if err != nil {
 		return status.Error(codes.NotFound, "secret not found")
 	}
 	scope := core.Scope{ProjectID: secret.ProjectID, EnvironmentID: secret.EnvironmentID}
-	if allowed, err := s.core.Authorize(ctx, userID, perm, scope); err != nil || !allowed {
+	if allowed, err := cs.Authorize(ctx, userID, perm, scope); err != nil || !allowed {
 		return status.Error(codes.PermissionDenied, "insufficient permissions for this secret")
 	}
 	return nil

--- a/server/grpc/services/share_service.go
+++ b/server/grpc/services/share_service.go
@@ -35,14 +35,16 @@ func (s *ShareGRPCService) ShareSecret(ctx context.Context, req *pb.ShareSecretR
 	if err != nil {
 		return nil, err
 	}
-	if !hasPermission(user.Permissions, "secrets.write") {
-		return nil, status.Error(codes.PermissionDenied, "insufficient permissions to share secrets")
-	}
 	if req.GetSecretId() == 0 || req.GetRecipientId() == 0 {
 		return nil, status.Error(codes.InvalidArgument, "secret_id and recipient_id are required")
 	}
 	if req.GetPermission() != "read" && req.GetPermission() != "write" {
 		return nil, status.Error(codes.InvalidArgument, "permission must be 'read' or 'write'")
+	}
+	// Scope secrets.write to the shared secret's project (mirrors the HTTP
+	// /secrets/{id}/share route), not the flat global permission set.
+	if err := authorizeSecretScoped(ctx, s.core, user.UserID, uint(req.GetSecretId()), "secrets.write"); err != nil {
+		return nil, err
 	}
 
 	var record *models.ShareRecord
@@ -74,11 +76,11 @@ func (s *ShareGRPCService) ListSecretShares(ctx context.Context, req *pb.ListSec
 	if err != nil {
 		return nil, err
 	}
-	if !hasPermission(user.Permissions, "secrets.read") {
-		return nil, status.Error(codes.PermissionDenied, "insufficient permissions to view shares")
-	}
 	if req.GetSecretId() == 0 {
 		return nil, status.Error(codes.InvalidArgument, "secret_id is required")
+	}
+	if err := authorizeSecretScoped(ctx, s.core, user.UserID, uint(req.GetSecretId()), "secrets.read"); err != nil {
+		return nil, err
 	}
 
 	shares, err := s.core.ListSecretSharesWithPermissionCheck(ctx, uint(req.GetSecretId()), user.UserID)
@@ -141,14 +143,14 @@ func (s *ShareGRPCService) UpdateSharePermission(ctx context.Context, req *pb.Up
 	if err != nil {
 		return nil, err
 	}
-	if !hasPermission(user.Permissions, "secrets.write") {
-		return nil, status.Error(codes.PermissionDenied, "insufficient permissions to update shares")
-	}
 	if req.GetShareId() == 0 {
 		return nil, status.Error(codes.InvalidArgument, "share_id is required")
 	}
 	if req.GetPermission() != "read" && req.GetPermission() != "write" {
 		return nil, status.Error(codes.InvalidArgument, "permission must be 'read' or 'write'")
+	}
+	if err := s.authorizeShareScoped(ctx, user.UserID, uint(req.GetShareId()), "secrets.write"); err != nil {
+		return nil, err
 	}
 
 	record, err := s.core.UpdateSharePermission(ctx, &core.UpdateShareRequest{
@@ -168,11 +170,11 @@ func (s *ShareGRPCService) RevokeShare(ctx context.Context, req *pb.RevokeShareR
 	if err != nil {
 		return nil, err
 	}
-	if !hasPermission(user.Permissions, "secrets.write") {
-		return nil, status.Error(codes.PermissionDenied, "insufficient permissions to revoke shares")
-	}
 	if req.GetShareId() == 0 {
 		return nil, status.Error(codes.InvalidArgument, "share_id is required")
+	}
+	if err := s.authorizeShareScoped(ctx, user.UserID, uint(req.GetShareId()), "secrets.write"); err != nil {
+		return nil, err
 	}
 	if err := s.core.RevokeShare(ctx, uint(req.GetShareId()), user.UserID); err != nil {
 		return nil, mapShareError(err)
@@ -183,6 +185,27 @@ func (s *ShareGRPCService) RevokeShare(ctx context.Context, req *pb.RevokeShareR
 // ---------------------------------------------------------------------------
 // helpers
 // ---------------------------------------------------------------------------
+
+// authorizeShareScoped resolves a share's underlying secret and checks the
+// permission at that secret's project/environment — mirroring HTTP's
+// ScopeFromShareParam, so mutating a specific share enforces the same scoped
+// RBAC as HTTP rather than the flat global set. A missing share/secret yields
+// NotFound; the downstream core call still enforces ownership.
+func (s *ShareGRPCService) authorizeShareScoped(ctx context.Context, userID, shareID uint, perm string) error {
+	share, err := s.core.Storage().GetShareRecord(ctx, shareID)
+	if err != nil {
+		return status.Error(codes.NotFound, "share not found")
+	}
+	secret, err := s.core.Storage().GetSecret(ctx, share.SecretID)
+	if err != nil {
+		return status.Error(codes.NotFound, "share not found")
+	}
+	scope := core.Scope{ProjectID: secret.ProjectID, EnvironmentID: secret.EnvironmentID}
+	if allowed, err := s.core.Authorize(ctx, userID, perm, scope); err != nil || !allowed {
+		return status.Error(codes.PermissionDenied, "insufficient permissions for this share")
+	}
+	return nil
+}
 
 // mapShareError translates core sharing errors into gRPC status codes.
 func mapShareError(err error) error {

--- a/server/grpc/services/share_service_test.go
+++ b/server/grpc/services/share_service_test.go
@@ -21,6 +21,7 @@ import (
 type shareTestRig struct {
 	svc      *ShareGRPCService
 	core     *core.KeyorixCore
+	db       *gorm.DB
 	secretID uint32
 }
 
@@ -37,12 +38,25 @@ func newShareTestRig(t *testing.T) *shareTestRig {
 	require.NoError(t, db.AutoMigrate(
 		&models.Project{}, &models.Environment{}, &models.SecretNode{},
 		&models.SecretVersion{}, &models.User{}, &models.Role{}, &models.ShareRecord{},
-		&models.Group{}, &models.UserGroup{}, // ListSharedSecrets joins user_groups
+		&models.Permission{}, &models.RolePermission{}, &models.UserRole{},
+		&models.Group{}, &models.UserGroup{}, &models.GroupRole{}, &models.ProjectMembership{},
 	))
 	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "default"}).Error)
 	require.NoError(t, db.Create(&models.Environment{ID: 1, ProjectID: 1, Name: "development"}).Error)
 	require.NoError(t, db.Create(&models.User{ID: 1, Username: "owner", Email: "owner@example.com"}).Error)
 	require.NoError(t, db.Create(&models.User{ID: 2, Username: "recipient", Email: "rcpt@example.com"}).Error)
+
+	// Share ops now scope-check via the RBAC graph (like HTTP), so seed real
+	// grants: a writer role (secrets.read/write/delete) assigned to the owner
+	// globally. Mirrors newSecretTestRig.
+	require.NoError(t, db.Create(&models.Role{ID: writerRoleID, Name: "writer"}).Error)
+	require.NoError(t, db.Create(&models.Permission{ID: 1, Name: "secrets.read", Resource: "secrets", Action: "read"}).Error)
+	require.NoError(t, db.Create(&models.Permission{ID: 2, Name: "secrets.write", Resource: "secrets", Action: "write"}).Error)
+	require.NoError(t, db.Create(&models.Permission{ID: 3, Name: "secrets.delete", Resource: "secrets", Action: "delete"}).Error)
+	require.NoError(t, db.Create(&models.RolePermission{RoleID: writerRoleID, PermissionID: 1}).Error)
+	require.NoError(t, db.Create(&models.RolePermission{RoleID: writerRoleID, PermissionID: 2}).Error)
+	require.NoError(t, db.Create(&models.RolePermission{RoleID: writerRoleID, PermissionID: 3}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: writerRoleID}).Error) // global
 
 	coreService := core.NewKeyorixCore(store.NewLocalStorage(db))
 	secret, err := coreService.CreateSecret(context.Background(), &core.CreateSecretRequest{
@@ -54,8 +68,35 @@ func newShareTestRig(t *testing.T) *shareTestRig {
 	return &shareTestRig{
 		svc:      NewShareService(coreService),
 		core:     coreService,
+		db:       db,
 		secretID: intToU32(int(secret.ID)),
 	}
+}
+
+// Regression (gRPC scoped-authz hardening): share ops must authorize at the
+// SECRET'S project, not the flat global permission set. A user scoped to project
+// 1 who even OWNS a secret in project 2 is denied sharing it / listing its shares
+// over gRPC — matching the HTTP scoped gate.
+func TestShareService_ShareSecret_ScopedToOtherProjectDenied(t *testing.T) {
+	r := newShareTestRig(t)
+	require.NoError(t, r.db.Create(&models.Project{ID: 2, Name: "other"}).Error)
+	require.NoError(t, r.db.Create(&models.Environment{ID: 2, ProjectID: 2, Name: "development"}).Error)
+	require.NoError(t, r.db.Create(&models.User{ID: 3, Username: "scoped", Email: "scoped@example.com"}).Error)
+	require.NoError(t, r.db.Create(&models.UserRole{UserID: 3, RoleID: writerRoleID, ProjectID: 1}).Error) // project 1 only
+	// A secret in project 2 owned by user 3 (owner check alone would pass).
+	require.NoError(t, r.db.Create(&models.SecretNode{
+		ID: 90, Name: "p2", ProjectID: 2, EnvironmentID: 2, OwnerID: 3, Status: "active", Type: "password",
+	}).Error)
+
+	ctx := authCtx(3, "scoped", "secrets.read", "secrets.write")
+
+	_, err := r.svc.ShareSecret(ctx, &pb.ShareSecretRequest{SecretId: 90, RecipientId: 2, Permission: "read"})
+	require.Error(t, err)
+	assert.Equal(t, codes.PermissionDenied, status.Code(err), "ShareSecret cross-project")
+
+	_, err = r.svc.ListSecretShares(ctx, &pb.ListSecretSharesRequest{SecretId: 90})
+	require.Error(t, err)
+	assert.Equal(t, codes.PermissionDenied, status.Code(err), "ListSecretShares cross-project")
 }
 
 func ownerCtx() context.Context {
@@ -91,9 +132,11 @@ func TestShareService_ShareSecret_Unauthenticated(t *testing.T) {
 
 func TestShareService_ShareSecret_PermissionDenied(t *testing.T) {
 	r := newShareTestRig(t)
-	ctx := authCtx(1, "owner", "secrets.read") // no write
+	// User 2 holds no RBAC role in the secret's scope, so the scoped check denies
+	// regardless of any flat permission advertised in the context.
+	ctx := authCtx(2, "recipient", "secrets.write", "secrets.read")
 	_, err := r.svc.ShareSecret(ctx, &pb.ShareSecretRequest{
-		SecretId: r.secretID, RecipientId: 2, Permission: "read",
+		SecretId: r.secretID, RecipientId: 3, Permission: "read",
 	})
 	require.Error(t, err)
 	assert.Equal(t, codes.PermissionDenied, status.Code(err))


### PR DESCRIPTION
## Summary

Follow-up to #88. The gRPC `ShareService` gated `ShareSecret`, `ListSecretShares`, `UpdateSharePermission`, and `RevokeShare` on the **flat global** permission set, while the HTTP routes scope them to the shared secret's project (`RequireScopedPermission` with `secretScope` / `ScopeFromShareParam`). Same flat-vs-scoped divergence as #88 — a project-A-scoped user could share/list-shares/update/revoke on a secret in project B over gRPC where HTTP denies.

## Fix

- **`ShareSecret` / `ListSecretShares`** (take a secret_id): authorize at the target secret's scope — reusing `authorizeSecretScoped`, now a package-level helper shared by both gRPC services.
- **`UpdateSharePermission` / `RevokeShare`** (take a share_id): new `authorizeShareScoped` resolves the share's secret (`GetShareRecord` → `GetSecret`) and authorizes at that scope, mirroring HTTP's `ScopeFromShareParam`.
- **`ListUserShares` / `ListSharedSecrets`** stay flat — they list the caller's **own** shares / received secrets, which HTTP also gates with a global `RequirePermission` (by design, "the user's own share list stays a global-read op").

## Tests

- New `TestShareService_ShareSecret_ScopedToOtherProjectDenied`: a project-1-scoped user who **owns** a secret in project 2 is denied `ShareSecret` + `ListSecretShares` over gRPC.
- `ShareSecret_PermissionDenied` now denies via a user with **no RBAC grant** (the scoped model ignores flat ctx perms, so the old "owner ctx minus a perm" premise no longer applies).
- The share test rig now seeds RBAC grants + the `project_memberships` table (the scoped `Authorize` path needs them).
- Full `server/grpc` suite green; `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)