### PR TITLE
fix(authz): cross-project guard on machine/membership/access-request transitions

### DIFF
--- a/internal/cli/machine/lifecycle.go
+++ b/internal/cli/machine/lifecycle.go
@@ -65,7 +65,7 @@ func lifecycleRunE(action, targetState string) func(*cobra.Command, []string) er
 		if err != nil {
 			return fmt.Errorf("failed to initialize service: %w", err)
 		}
-		if _, err := svc.TransitionMachineIdentity(ctx, m.ID, targetState, 0); err != nil {
+		if _, err := svc.TransitionMachineIdentity(ctx, m.ProjectID, m.ID, targetState, 0); err != nil {
 			return fmt.Errorf("failed to %s machine identity: %w", action, err)
 		}
 		fmt.Printf("Machine identity %q → %s\n", m.Name, targetState)

--- a/internal/cli/request/review.go
+++ b/internal/cli/request/review.go
@@ -54,16 +54,24 @@ func runReview(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// The approve/reject core methods are project-scoped (cross-project guard);
+	// the embedded CLI admin operates on the request's own project.
+	existing, err := service.Storage().GetAccessRequest(ctx, reviewID)
+	if err != nil {
+		return fmt.Errorf("access request %d not found", reviewID)
+	}
+	projectID := existing.ProjectID
+
 	switch reviewAction {
 	case "approve":
-		req, err := service.ApproveAccessRequest(ctx, reviewID, approverID, reviewRole)
+		req, err := service.ApproveAccessRequest(ctx, projectID, reviewID, approverID, reviewRole)
 		if err != nil {
 			return fmt.Errorf("failed to approve access request: %w", err)
 		}
 		fmt.Printf("Access request %d approved: granted role %q to %s.\n",
 			req.ID, req.GrantedRole, userLabel(ctx, service, req.UserID))
 	case "reject":
-		req, err := service.RejectAccessRequest(ctx, reviewID, approverID, reviewReason)
+		req, err := service.RejectAccessRequest(ctx, projectID, reviewID, approverID, reviewReason)
 		if err != nil {
 			return fmt.Errorf("failed to reject access request: %w", err)
 		}

--- a/internal/core/invitations.go
+++ b/internal/core/invitations.go
@@ -360,9 +360,15 @@ func (c *KeyorixCore) ListAccessRequests(ctx context.Context, projectID uint) ([
 // ApproveAccessRequest approves a pending request, granting grantedRole (falling
 // back to the suggested role) at the project scope. No auto-approval — an admin
 // performs this explicitly.
-func (c *KeyorixCore) ApproveAccessRequest(ctx context.Context, requestID, approverID uint, grantedRole string) (*models.AccessRequest, error) {
+func (c *KeyorixCore) ApproveAccessRequest(ctx context.Context, projectID, requestID, approverID uint, grantedRole string) (*models.AccessRequest, error) {
 	req, err := c.storage.GetAccessRequest(ctx, requestID)
 	if err != nil {
+		return nil, fmt.Errorf("access request not found")
+	}
+	// The approver is authorized within projectID; a request belonging to another
+	// project must not be approvable through it, or the role grant would land in a
+	// project the caller has no rights over (cross-project privilege escalation).
+	if req.ProjectID != projectID {
 		return nil, fmt.Errorf("access request not found")
 	}
 	if req.State != AccessRequestPending {
@@ -398,9 +404,12 @@ func (c *KeyorixCore) ApproveAccessRequest(ctx context.Context, requestID, appro
 }
 
 // RejectAccessRequest rejects a pending request with a reason.
-func (c *KeyorixCore) RejectAccessRequest(ctx context.Context, requestID, approverID uint, reason string) (*models.AccessRequest, error) {
+func (c *KeyorixCore) RejectAccessRequest(ctx context.Context, projectID, requestID, approverID uint, reason string) (*models.AccessRequest, error) {
 	req, err := c.storage.GetAccessRequest(ctx, requestID)
 	if err != nil {
+		return nil, fmt.Errorf("access request not found")
+	}
+	if req.ProjectID != projectID {
 		return nil, fmt.Errorf("access request not found")
 	}
 	if req.State != AccessRequestPending {

--- a/internal/core/invitations_test.go
+++ b/internal/core/invitations_test.go
@@ -65,7 +65,7 @@ func TestApproveAccessRequest_GrantsRole(t *testing.T) {
 	})).Return(nil)
 
 	allowNotifications(store) // best-effort outcome notification to the requester
-	out, err := c.ApproveAccessRequest(ctx, 3, 9, "project_developer")
+	out, err := c.ApproveAccessRequest(ctx, 1, 3, 9, "project_developer")
 	require.NoError(t, err)
 	assert.Equal(t, AccessRequestApproved, out.State)
 	store.AssertCalled(t, "AssignRole", ctx, uint(2), uint(5), storage.Scope{ProjectID: 1})
@@ -85,7 +85,7 @@ func TestApproveAccessRequest_FallsBackToSuggestedRole(t *testing.T) {
 
 	allowNotifications(store) // best-effort outcome notification to the requester
 	// Empty grantedRole → uses the suggested role.
-	out, err := c.ApproveAccessRequest(ctx, 3, 9, "")
+	out, err := c.ApproveAccessRequest(ctx, 1, 3, 9, "")
 	require.NoError(t, err)
 	assert.Equal(t, "project_viewer", out.GrantedRole)
 }
@@ -94,11 +94,28 @@ func TestApproveAccessRequest_RejectsNonPending(t *testing.T) {
 	store := new(MockStorage)
 	c := newInviteCore(store)
 	ctx := context.Background()
-	store.On("GetAccessRequest", ctx, uint(3)).Return(&models.AccessRequest{ID: 3, State: AccessRequestApproved}, nil)
+	store.On("GetAccessRequest", ctx, uint(3)).Return(&models.AccessRequest{ID: 3, ProjectID: 1, State: AccessRequestApproved}, nil)
 
-	_, err := c.ApproveAccessRequest(ctx, 3, 9, "project_viewer")
+	_, err := c.ApproveAccessRequest(ctx, 1, 3, 9, "project_viewer")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "only a pending")
+	store.AssertNotCalled(t, "AssignRole", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+}
+
+// Cross-project guard: approving a request that belongs to project 2 while the
+// caller is authorized for project 1 must be rejected — otherwise the role grant
+// lands in a project the caller has no rights over (privilege escalation).
+func TestApproveAccessRequest_RejectsOtherProject(t *testing.T) {
+	store := new(MockStorage)
+	c := newInviteCore(store)
+	ctx := context.Background()
+	store.On("GetAccessRequest", ctx, uint(3)).Return(&models.AccessRequest{
+		ID: 3, ProjectID: 2, UserID: 2, SuggestedRole: "project_admin", State: AccessRequestPending,
+	}, nil)
+
+	_, err := c.ApproveAccessRequest(ctx, 1, 3, 9, "project_admin")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
 	store.AssertNotCalled(t, "AssignRole", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 }
 

--- a/internal/core/machine_identities.go
+++ b/internal/core/machine_identities.go
@@ -94,11 +94,13 @@ func (c *KeyorixCore) ListMachineIdentities(ctx context.Context, projectID uint)
 }
 
 // TransitionMachineIdentity advances a machine identity to a new state,
-// enforcing the state machine, and audits the change.
-func (c *KeyorixCore) TransitionMachineIdentity(ctx context.Context, id uint, to string, actorID uint) (*models.MachineIdentity, error) {
-	m, err := c.storage.GetMachineIdentity(ctx, id)
+// enforcing the state machine, and audits the change. The machine must belong to
+// projectID — the caller's authorization is scoped to that project, so a machine
+// in another project must not be reachable through it (cross-project guard).
+func (c *KeyorixCore) TransitionMachineIdentity(ctx context.Context, projectID, id uint, to string, actorID uint) (*models.MachineIdentity, error) {
+	m, err := c.machineInProject(ctx, projectID, id)
 	if err != nil {
-		return nil, fmt.Errorf("machine identity not found")
+		return nil, err
 	}
 	if !canTransitionMachine(m.State, to) {
 		return nil, fmt.Errorf("cannot transition machine identity from %s to %s", m.State, to)

--- a/internal/core/machine_identities_test.go
+++ b/internal/core/machine_identities_test.go
@@ -90,7 +90,7 @@ func TestTransitionMachineIdentity(t *testing.T) {
 		})).Return(nil)
 		store.On("LogAuditEvent", ctx, mock.Anything).Return(nil)
 
-		m, err := c.TransitionMachineIdentity(ctx, 10, MachineSuspended, 9)
+		m, err := c.TransitionMachineIdentity(ctx, 1, 10, MachineSuspended, 9)
 		require.NoError(t, err)
 		assert.Equal(t, MachineSuspended, m.State)
 	})
@@ -105,7 +105,7 @@ func TestTransitionMachineIdentity(t *testing.T) {
 		})).Return(nil)
 		store.On("LogAuditEvent", ctx, mock.Anything).Return(nil)
 
-		_, err := c.TransitionMachineIdentity(ctx, 10, MachineRevoked, 9)
+		_, err := c.TransitionMachineIdentity(ctx, 1, 10, MachineRevoked, 9)
 		require.NoError(t, err)
 	})
 
@@ -113,11 +113,25 @@ func TestTransitionMachineIdentity(t *testing.T) {
 		store := new(MockStorage)
 		c := newMachineCore(store)
 		ctx := context.Background()
-		store.On("GetMachineIdentity", ctx, uint(10)).Return(&models.MachineIdentity{ID: 10, State: MachineRevoked}, nil)
+		store.On("GetMachineIdentity", ctx, uint(10)).Return(&models.MachineIdentity{ID: 10, ProjectID: 1, State: MachineRevoked}, nil)
 
-		_, err := c.TransitionMachineIdentity(ctx, 10, MachineActive, 9)
+		_, err := c.TransitionMachineIdentity(ctx, 1, 10, MachineActive, 9)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "cannot transition")
+		store.AssertNotCalled(t, "UpdateMachineIdentity", mock.Anything, mock.Anything)
+	})
+
+	// Cross-project guard: a machine in project 2 must not be reachable when the
+	// caller is authorized for project 1.
+	t.Run("rejects a machine in another project", func(t *testing.T) {
+		store := new(MockStorage)
+		c := newMachineCore(store)
+		ctx := context.Background()
+		store.On("GetMachineIdentity", ctx, uint(10)).Return(&models.MachineIdentity{ID: 10, ProjectID: 2, State: MachineActive}, nil)
+
+		_, err := c.TransitionMachineIdentity(ctx, 1, 10, MachineSuspended, 9)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
 		store.AssertNotCalled(t, "UpdateMachineIdentity", mock.Anything, mock.Anything)
 	})
 }

--- a/internal/core/membership_lifecycle.go
+++ b/internal/core/membership_lifecycle.go
@@ -160,9 +160,14 @@ func initialMembershipStateForMode(mode string, idpResolved bool) string {
 // TransitionMembership advances a membership to the next state, enforcing the
 // state machine. Reaching `active` grants the project role; `revoked` removes it.
 // actorID is the user performing the transition (for the audit trail).
-func (c *KeyorixCore) TransitionMembership(ctx context.Context, membershipID uint, to string, actorID uint) (*models.ProjectMembership, error) {
+func (c *KeyorixCore) TransitionMembership(ctx context.Context, projectID, membershipID uint, to string, actorID uint) (*models.ProjectMembership, error) {
 	m, err := c.storage.GetProjectMembership(ctx, membershipID)
 	if err != nil {
+		return nil, fmt.Errorf("membership not found")
+	}
+	// The caller is authorized within projectID; a membership in another project
+	// must not be reachable through it (cross-project guard).
+	if m.ProjectID != projectID {
 		return nil, fmt.Errorf("membership not found")
 	}
 	if !canTransition(m.State, to) {

--- a/internal/core/membership_lifecycle_test.go
+++ b/internal/core/membership_lifecycle_test.go
@@ -110,12 +110,28 @@ func TestTransitionMembership_RejectsIllegalJump(t *testing.T) {
 	c := newMembershipCore(store)
 	ctx := context.Background()
 	store.On("GetProjectMembership", ctx, uint(50)).
-		Return(&models.ProjectMembership{ID: 50, State: MembershipInvited}, nil)
+		Return(&models.ProjectMembership{ID: 50, ProjectID: 1, State: MembershipInvited}, nil)
 
-	_, err := c.TransitionMembership(ctx, 50, MembershipActive, 9)
+	_, err := c.TransitionMembership(ctx, 1, 50, MembershipActive, 9)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cannot transition")
 	store.AssertNotCalled(t, "UpdateProjectMembership", mock.Anything, mock.Anything)
+}
+
+// Cross-project guard: a membership in project 2 must not be transitionable when
+// the caller is authorized for project 1 (would otherwise grant a role in 2).
+func TestTransitionMembership_RejectsOtherProject(t *testing.T) {
+	store := new(MockStorage)
+	c := newMembershipCore(store)
+	ctx := context.Background()
+	store.On("GetProjectMembership", ctx, uint(50)).
+		Return(&models.ProjectMembership{ID: 50, ProjectID: 2, UserID: 2, Role: "project_admin", State: MembershipProvisioned}, nil)
+
+	_, err := c.TransitionMembership(ctx, 1, 50, MembershipActive, 9)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+	store.AssertNotCalled(t, "UpdateProjectMembership", mock.Anything, mock.Anything)
+	store.AssertNotCalled(t, "AssignRole", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 }
 
 func TestTransitionMembership_ActivateGrantsRole(t *testing.T) {
@@ -131,7 +147,7 @@ func TestTransitionMembership_ActivateGrantsRole(t *testing.T) {
 	store.On("AssignRole", ctx, uint(2), uint(5), storage.Scope{ProjectID: 1}).Return(nil)
 	store.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
 
-	out, err := c.TransitionMembership(ctx, 50, MembershipActive, 9)
+	out, err := c.TransitionMembership(ctx, 1, 50, MembershipActive, 9)
 	require.NoError(t, err)
 	assert.Equal(t, MembershipActive, out.State)
 	store.AssertCalled(t, "AssignRole", ctx, uint(2), uint(5), storage.Scope{ProjectID: 1})
@@ -151,7 +167,7 @@ func TestTransitionMembership_RevokeRemovesRole(t *testing.T) {
 	store.On("RemoveRole", ctx, uint(2), uint(5), storage.Scope{ProjectID: 1}).Return(nil)
 	store.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
 
-	out, err := c.TransitionMembership(ctx, 50, MembershipRevoked, 9)
+	out, err := c.TransitionMembership(ctx, 1, 50, MembershipRevoked, 9)
 	require.NoError(t, err)
 	assert.Equal(t, MembershipRevoked, out.State)
 	store.AssertCalled(t, "RemoveRole", ctx, uint(2), uint(5), storage.Scope{ProjectID: 1})

--- a/server/http/handlers/invitations.go
+++ b/server/http/handlers/invitations.go
@@ -244,6 +244,11 @@ func (h *CatalogHandler) CreateAccessRequest(w http.ResponseWriter, r *http.Requ
 // ResolveAccessRequest handles PUT /api/v1/projects/{id}/access-requests/{requestId}
 // for an admin: body {"action":"approve"|"reject", "granted_role":..., "reason":...}.
 func (h *CatalogHandler) ResolveAccessRequest(w http.ResponseWriter, r *http.Request) {
+	projectID, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		sendError(w, "InvalidParameter", "Invalid project ID", http.StatusBadRequest, nil)
+		return
+	}
 	reqID, err := strconv.ParseUint(chi.URLParam(r, "requestId"), 10, 32)
 	if err != nil {
 		sendError(w, "InvalidParameter", "Invalid request ID", http.StatusBadRequest, nil)
@@ -266,9 +271,9 @@ func (h *CatalogHandler) ResolveAccessRequest(w http.ResponseWriter, r *http.Req
 	var resolveErr error
 	switch body.Action {
 	case "approve":
-		_, resolveErr = h.coreService.ApproveAccessRequest(r.Context(), uint(reqID), actor.UserID, body.GrantedRole)
+		_, resolveErr = h.coreService.ApproveAccessRequest(r.Context(), uint(projectID), uint(reqID), actor.UserID, body.GrantedRole)
 	case "reject":
-		_, resolveErr = h.coreService.RejectAccessRequest(r.Context(), uint(reqID), actor.UserID, body.Reason)
+		_, resolveErr = h.coreService.RejectAccessRequest(r.Context(), uint(projectID), uint(reqID), actor.UserID, body.Reason)
 	default:
 		sendError(w, "ValidationError", "action must be approve or reject", http.StatusBadRequest, nil)
 		return

--- a/server/http/handlers/machine_identities.go
+++ b/server/http/handlers/machine_identities.go
@@ -72,6 +72,11 @@ func (h *CatalogHandler) CreateMachineIdentity(w http.ResponseWriter, r *http.Re
 // TransitionMachineIdentity handles PUT /api/v1/projects/{id}/machine-identities/{machineId}.
 // Body: {"action": "activate" | "suspend" | "revoke"}.
 func (h *CatalogHandler) TransitionMachineIdentity(w http.ResponseWriter, r *http.Request) {
+	projectID, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		sendError(w, "InvalidParameter", "Invalid project ID", http.StatusBadRequest, nil)
+		return
+	}
 	machineID, err := strconv.ParseUint(chi.URLParam(r, "machineId"), 10, 32)
 	if err != nil {
 		sendError(w, "InvalidParameter", "Invalid machine identity ID", http.StatusBadRequest, nil)
@@ -94,7 +99,7 @@ func (h *CatalogHandler) TransitionMachineIdentity(w http.ResponseWriter, r *htt
 		sendError(w, "ValidationError", "action must be activate, suspend, or revoke", http.StatusBadRequest, nil)
 		return
 	}
-	m, err := h.coreService.TransitionMachineIdentity(r.Context(), uint(machineID), to, actor.UserID)
+	m, err := h.coreService.TransitionMachineIdentity(r.Context(), uint(projectID), uint(machineID), to, actor.UserID)
 	if err != nil {
 		status := http.StatusInternalServerError
 		switch {

--- a/server/http/handlers/project_memberships.go
+++ b/server/http/handlers/project_memberships.go
@@ -97,6 +97,11 @@ func (h *CatalogHandler) InviteMember(w http.ResponseWriter, r *http.Request) {
 // TransitionMembership handles PUT /api/v1/projects/{id}/memberships/{membershipId}.
 // Body: {"action": "verify" | "provision" | "activate" | "revoke"}.
 func (h *CatalogHandler) TransitionMembership(w http.ResponseWriter, r *http.Request) {
+	projectID, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		sendError(w, "InvalidParameter", "Invalid project ID", http.StatusBadRequest, nil)
+		return
+	}
 	membershipID, err := strconv.ParseUint(chi.URLParam(r, "membershipId"), 10, 32)
 	if err != nil {
 		sendError(w, "InvalidParameter", "Invalid membership ID", http.StatusBadRequest, nil)
@@ -119,7 +124,7 @@ func (h *CatalogHandler) TransitionMembership(w http.ResponseWriter, r *http.Req
 		sendError(w, "ValidationError", "action must be verify, provision, activate, or revoke", http.StatusBadRequest, nil)
 		return
 	}
-	m, err := h.coreService.TransitionMembership(r.Context(), uint(membershipID), to, actor.UserID)
+	m, err := h.coreService.TransitionMembership(r.Context(), uint(projectID), uint(membershipID), to, actor.UserID)
 	if err != nil {
 		status := http.StatusInternalServerError
 		switch {


### PR DESCRIPTION
## The bug (HIGH — cross-project privilege escalation, from the HTTP audit)

Three project-nested lifecycle routes authorize the caller against the **path** project but the handler passed only the *child* ID to core, which re-derived the child's **own** project and acted there — never reconciling the two. The scope-resolver checks `roles.assign` in `{id}`, while the grant lands in the child's project.

A **project-A admin** (with `roles.assign` scoped only to A) could:
- `PUT /projects/A/access-requests/{req-in-B}` `{approve, granted_role: project_admin}` → make an arbitrary user **project_admin in project B**;
- `PUT /projects/A/memberships/{membership-in-B}` `{activate}` → grant that role **in B**;
- `PUT /projects/A/machine-identities/{machine-in-B}` `{revoke}` → cross-tenant **DoS** on B's automation.

The token/role machine endpoints already guarded this via `machineInProject`; these four methods were missed.

## Fix

Thread the path `projectID` into each core method and reject when `child.ProjectID != projectID` (404-style, no existence leak), mirroring `machineInProject`:
- **core**: `TransitionMachineIdentity` (now via `machineInProject`), `TransitionMembership`, `ApproveAccessRequest`, `RejectAccessRequest` take `projectID` + verify.
- **handlers**: parse the path `{id}` and pass it.
- **CLI** callers (host-local admin) pass the child's own project.

## Tests

Each core method gets a cross-project rejection test (child in project 2, caller scoped to project 1 → `not found`, **no** role grant / state change). Existing mock fixtures updated to set `ProjectID` so the guard passes before the state checks. Full `internal/core` + `server/http` suites green; CLI tests green; `go vet` clean.

## Follow-up (MEDIUM, audit findings #4/#5 — separate PR)

Cross-project **environment restore** (`RestoreEnvironment`) and **invitation revoke/resend** share the same root cause and will get the same treatment next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)