### PR TITLE
fix(authz): cross-project guard on env-restore + invitation revoke/resend

### DIFF
--- a/internal/cli/invite/resend.go
+++ b/internal/cli/invite/resend.go
@@ -36,7 +36,13 @@ var resendCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		prov, err := service.ResendInvitationLink(ctx, resendID, actorID)
+		// Project-scoped core method (cross-project guard); the embedded CLI admin
+		// operates on the invitation's own project.
+		inv, err := service.Storage().GetProjectInvitation(ctx, resendID)
+		if err != nil {
+			return fmt.Errorf("invitation %d not found", resendID)
+		}
+		prov, err := service.ResendInvitationLink(ctx, inv.ProjectID, resendID, actorID)
 		if err != nil {
 			return fmt.Errorf("failed to resend invitation link: %w", err)
 		}

--- a/internal/cli/invite/revoke.go
+++ b/internal/cli/invite/revoke.go
@@ -41,7 +41,13 @@ func runRevoke(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	if err := service.RevokeInvitation(ctx, revokeID, actorID); err != nil {
+	// The core method is project-scoped (cross-project guard); the embedded CLI
+	// admin operates on the invitation's own project.
+	inv, err := service.Storage().GetProjectInvitation(ctx, revokeID)
+	if err != nil {
+		return fmt.Errorf("invitation %d not found", revokeID)
+	}
+	if err := service.RevokeInvitation(ctx, inv.ProjectID, revokeID, actorID); err != nil {
 		return fmt.Errorf("failed to revoke invitation: %w", err)
 	}
 	fmt.Printf("Invitation %d revoked.\n", revokeID)

--- a/internal/core/catalog.go
+++ b/internal/core/catalog.go
@@ -71,9 +71,10 @@ func (c *KeyorixCore) DeleteEnvironment(ctx context.Context, id uint) error {
 	return c.storage.DeleteEnvironment(ctx, id)
 }
 
-// RestoreEnvironment clears the soft-delete on an environment.
-func (c *KeyorixCore) RestoreEnvironment(ctx context.Context, id uint) error {
-	return c.storage.RestoreEnvironment(ctx, id)
+// RestoreEnvironment clears the soft-delete on an environment, scoped to
+// projectID so a caller authorized for one project cannot restore another's.
+func (c *KeyorixCore) RestoreEnvironment(ctx context.Context, projectID, id uint) error {
+	return c.storage.RestoreEnvironment(ctx, projectID, id)
 }
 
 // CreateProject creates a new project and seeds it with default environments.

--- a/internal/core/invitations.go
+++ b/internal/core/invitations.go
@@ -230,9 +230,14 @@ func (c *KeyorixCore) applyInvitationGrants(ctx context.Context, inv *models.Pro
 
 // ResendInvitationLink reissues the accept link for a still-pending invitation
 // (superseding the prior token) and re-delivers it. Throttled per ADR-028.
-func (c *KeyorixCore) ResendInvitationLink(ctx context.Context, invitationID, actorID uint) (*ProvisionSetupResult, error) {
+func (c *KeyorixCore) ResendInvitationLink(ctx context.Context, projectID, invitationID, actorID uint) (*ProvisionSetupResult, error) {
 	inv, err := c.storage.GetProjectInvitation(ctx, invitationID)
 	if err != nil {
+		return nil, fmt.Errorf("invitation not found")
+	}
+	// The caller is authorized within projectID; an invitation in another project
+	// must not be resendable through it (cross-project guard).
+	if inv.ProjectID != projectID {
 		return nil, fmt.Errorf("invitation not found")
 	}
 	// Lazy-expire an overdue invite so a resend can't revive a dead one.
@@ -272,9 +277,12 @@ func (c *KeyorixCore) ListProjectInvitations(ctx context.Context, projectID uint
 }
 
 // RevokeInvitation cancels a pending invitation.
-func (c *KeyorixCore) RevokeInvitation(ctx context.Context, invitationID, actorID uint) error {
+func (c *KeyorixCore) RevokeInvitation(ctx context.Context, projectID, invitationID, actorID uint) error {
 	inv, err := c.storage.GetProjectInvitation(ctx, invitationID)
 	if err != nil {
+		return fmt.Errorf("invitation not found")
+	}
+	if inv.ProjectID != projectID {
 		return fmt.Errorf("invitation not found")
 	}
 	if inv.State != InvitationPending {

--- a/internal/core/invitations_test.go
+++ b/internal/core/invitations_test.go
@@ -39,11 +39,25 @@ func TestRevokeInvitation_RejectsNonPending(t *testing.T) {
 	store := new(MockStorage)
 	c := newInviteCore(store)
 	ctx := context.Background()
-	store.On("GetProjectInvitation", ctx, uint(7)).Return(&models.ProjectInvitation{ID: 7, State: InvitationAccepted}, nil)
+	store.On("GetProjectInvitation", ctx, uint(7)).Return(&models.ProjectInvitation{ID: 7, ProjectID: 1, State: InvitationAccepted}, nil)
 
-	err := c.RevokeInvitation(ctx, 7, 9)
+	err := c.RevokeInvitation(ctx, 1, 7, 9)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "only a pending")
+	store.AssertNotCalled(t, "UpdateProjectInvitation", mock.Anything, mock.Anything)
+}
+
+// Cross-project guard: revoking an invitation in project 2 while authorized for
+// project 1 must be rejected.
+func TestRevokeInvitation_RejectsOtherProject(t *testing.T) {
+	store := new(MockStorage)
+	c := newInviteCore(store)
+	ctx := context.Background()
+	store.On("GetProjectInvitation", ctx, uint(7)).Return(&models.ProjectInvitation{ID: 7, ProjectID: 2, State: InvitationPending}, nil)
+
+	err := c.RevokeInvitation(ctx, 1, 7, 9)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
 	store.AssertNotCalled(t, "UpdateProjectInvitation", mock.Anything, mock.Anything)
 }
 

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -152,7 +152,7 @@ func (m *MockStorage) DeleteEnvironment(_ context.Context, _ uint) error {
 	return nil
 }
 
-func (m *MockStorage) RestoreEnvironment(_ context.Context, _ uint) error {
+func (m *MockStorage) RestoreEnvironment(_ context.Context, _, _ uint) error {
 	return nil
 }
 

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -22,7 +22,9 @@ type Storage interface {
 	CreateEnvironment(ctx context.Context, env *models.Environment) (*models.Environment, error)
 	GetEnvironment(ctx context.Context, id uint) (*models.Environment, error)
 	DeleteEnvironment(ctx context.Context, id uint) error
-	RestoreEnvironment(ctx context.Context, id uint) error
+	// RestoreEnvironment restores a soft-deleted environment, scoped to projectID
+	// so a caller authorized for one project cannot restore another's environment.
+	RestoreEnvironment(ctx context.Context, projectID, id uint) error
 	ListEnvironments(ctx context.Context) ([]*models.Environment, error)
 	ListEnvironmentsByProject(ctx context.Context, projectID uint) ([]*models.Environment, error)
 	ListEnvironmentsByProjectIncludingDeleted(ctx context.Context, projectID uint) ([]*models.Environment, error)

--- a/internal/storage/store/local_secrets.go
+++ b/internal/storage/store/local_secrets.go
@@ -217,9 +217,9 @@ func (ls *LocalStorage) DeleteEnvironment(ctx context.Context, id uint) error {
 }
 
 // RestoreEnvironment clears deleted_at on a soft-deleted environment.
-func (ls *LocalStorage) RestoreEnvironment(ctx context.Context, id uint) error {
+func (ls *LocalStorage) RestoreEnvironment(ctx context.Context, projectID, id uint) error {
 	result := ls.db.WithContext(ctx).Unscoped().Model(&models.Environment{}).
-		Where("id = ? AND deleted_at IS NOT NULL", id).Update("deleted_at", nil)
+		Where("id = ? AND project_id = ? AND deleted_at IS NOT NULL", id, projectID).Update("deleted_at", nil)
 	if result.Error != nil {
 		return fmt.Errorf("failed to restore environment: %w", result.Error)
 	}

--- a/internal/storage/store/remote_rbac.go
+++ b/internal/storage/store/remote_rbac.go
@@ -373,6 +373,6 @@ func (rs *RemoteStorage) DeleteEnvironment(_ context.Context, _ uint) error {
 	return remoteUnsupported("DeleteEnvironment")
 }
 
-func (rs *RemoteStorage) RestoreEnvironment(_ context.Context, _ uint) error {
+func (rs *RemoteStorage) RestoreEnvironment(_ context.Context, _, _ uint) error {
 	return remoteUnsupported("RestoreEnvironment")
 }

--- a/internal/storage/store/restore_test.go
+++ b/internal/storage/store/restore_test.go
@@ -93,12 +93,19 @@ func TestRestoreEnvironment(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, withDeleted, 1)
 
-	require.NoError(t, ls.RestoreEnvironment(ctx, env.ID))
+	// Restoring under the wrong project is a no-op → not found (cross-project guard).
+	err = ls.RestoreEnvironment(ctx, proj.ID+999, env.ID)
+	require.Error(t, err)
+	stillDeleted, err := ls.ListEnvironmentsByProject(ctx, proj.ID)
+	require.NoError(t, err)
+	assert.Empty(t, stillDeleted)
+
+	require.NoError(t, ls.RestoreEnvironment(ctx, proj.ID, env.ID))
 	live, err = ls.ListEnvironmentsByProject(ctx, proj.ID)
 	require.NoError(t, err)
 	assert.Len(t, live, 1)
 
 	// Restoring a live environment errors.
-	err = ls.RestoreEnvironment(ctx, env.ID)
+	err = ls.RestoreEnvironment(ctx, proj.ID, env.ID)
 	require.Error(t, err)
 }

--- a/server/http/handlers/catalog.go
+++ b/server/http/handlers/catalog.go
@@ -240,13 +240,17 @@ func (h *CatalogHandler) ListProjectEnvironments(w http.ResponseWriter, r *http.
 // Nested under the project so the permission scope resolves from the project ID
 // (the environment row itself is soft-deleted and not loadable by the scope check).
 func (h *CatalogHandler) RestoreEnvironment(w http.ResponseWriter, r *http.Request) {
-	idStr := chi.URLParam(r, "id")
-	id, err := strconv.ParseUint(idStr, 10, 32)
+	projectID, err := strconv.ParseUint(chi.URLParam(r, "projectId"), 10, 32)
+	if err != nil {
+		sendError(w, "InvalidParameter", "Invalid project ID", http.StatusBadRequest, nil)
+		return
+	}
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
 	if err != nil {
 		sendError(w, "InvalidParameter", "Invalid environment ID", http.StatusBadRequest, nil)
 		return
 	}
-	if err := h.coreService.RestoreEnvironment(r.Context(), uint(id)); err != nil {
+	if err := h.coreService.RestoreEnvironment(r.Context(), uint(projectID), uint(id)); err != nil {
 		status := http.StatusInternalServerError
 		if strings.Contains(err.Error(), "not found") {
 			status = http.StatusNotFound

--- a/server/http/handlers/invitations.go
+++ b/server/http/handlers/invitations.go
@@ -135,6 +135,11 @@ func (h *CatalogHandler) CreateGlobalInvitation(w http.ResponseWriter, r *http.R
 // ResendInvitation handles POST /api/v1/projects/{id}/invitations/{invitationId}/resend
 // (ADR-028): it reissues the invitation's accept link and re-delivers it.
 func (h *CatalogHandler) ResendInvitation(w http.ResponseWriter, r *http.Request) {
+	projectID, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		sendError(w, "InvalidParameter", "Invalid project ID", http.StatusBadRequest, nil)
+		return
+	}
 	invID, err := strconv.ParseUint(chi.URLParam(r, "invitationId"), 10, 32)
 	if err != nil {
 		sendError(w, "InvalidParameter", "Invalid invitation ID", http.StatusBadRequest, nil)
@@ -145,7 +150,7 @@ func (h *CatalogHandler) ResendInvitation(w http.ResponseWriter, r *http.Request
 		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
 		return
 	}
-	prov, err := h.coreService.ResendInvitationLink(r.Context(), uint(invID), actor.UserID)
+	prov, err := h.coreService.ResendInvitationLink(r.Context(), uint(projectID), uint(invID), actor.UserID)
 	if err != nil {
 		msg := err.Error()
 		status := http.StatusInternalServerError
@@ -167,6 +172,11 @@ func (h *CatalogHandler) ResendInvitation(w http.ResponseWriter, r *http.Request
 
 // RevokeInvitation handles DELETE /api/v1/projects/{id}/invitations/{invitationId}.
 func (h *CatalogHandler) RevokeInvitation(w http.ResponseWriter, r *http.Request) {
+	projectID, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		sendError(w, "InvalidParameter", "Invalid project ID", http.StatusBadRequest, nil)
+		return
+	}
 	invID, err := strconv.ParseUint(chi.URLParam(r, "invitationId"), 10, 32)
 	if err != nil {
 		sendError(w, "InvalidParameter", "Invalid invitation ID", http.StatusBadRequest, nil)
@@ -177,7 +187,7 @@ func (h *CatalogHandler) RevokeInvitation(w http.ResponseWriter, r *http.Request
 		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
 		return
 	}
-	if err := h.coreService.RevokeInvitation(r.Context(), uint(invID), actor.UserID); err != nil {
+	if err := h.coreService.RevokeInvitation(r.Context(), uint(projectID), uint(invID), actor.UserID); err != nil {
 		status := http.StatusInternalServerError
 		switch {
 		case strings.Contains(err.Error(), "not found"):


### PR DESCRIPTION
## Summary

The MEDIUM half of the HTTP-audit cross-project IDOR class (companion to #92's HIGH transitions fix). Three more project-nested routes authorized the **path** project but acted on a child re-derived from its **own** project:

- `POST /projects/{projectId}/environments/{id}/restore` — `RestoreEnvironment` restored by env id only → a user with `secrets.write` in their project could un-delete **another project's** environment.
- `DELETE /projects/{id}/invitations/{invitationId}` (+ `/resend`) — Revoke/Resend operated on the invitation's own project → a project-A admin could revoke or **re-deliver project B's** pending invitations.

## Fix (same pattern as #92)

- **`RestoreEnvironment`**: the storage query now filters `project_id = ?` (interface + local + remote signatures updated); core + handler pass the path `projectId`. A wrong-project restore matches no rows → not found.
- **`RevokeInvitation` / `ResendInvitationLink`**: core verifies `inv.ProjectID == projectID`; handlers pass the path `id`; CLI callers (host-local admin) pass the invite's own project.

## Tests

- Storage restore test rejects a wrong-project restore (env stays soft-deleted).
- `RevokeInvitation` cross-project rejection test.
- Existing mock fixtures updated to set `ProjectID` so the guard passes before the state checks.
- Full core / storage / http / cli suites green; `go vet` clean.

With this, the entire cross-project IDOR class the HTTP audit surfaced (#92 HIGH + this MEDIUM) is closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)