### PR TITLE
fix(oidc): require https for federation jwks_uri (key-MITM hardening)

### DIFF
--- a/internal/core/oidc_jwks.go
+++ b/internal/core/oidc_jwks.go
@@ -15,7 +15,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/big"
+	"net"
 	"net/http"
+	"net/url"
 	"sync"
 	"time"
 )
@@ -37,13 +39,50 @@ type jwksEntry struct {
 	fetchedAt time.Time
 }
 
-// NewHTTPJWKSResolver builds a resolver over the issuer->jwks_uri map.
-func NewHTTPJWKSResolver(jwksURIs map[string]string) *HTTPJWKSResolver {
+// NewHTTPJWKSResolver builds a resolver over the issuer->jwks_uri map. Each
+// jwks_uri must use https so the issuer's signing keys are never fetched over
+// plaintext — a MITM on an http jwks_uri could swap the keys and forge federation
+// tokens. http is permitted only for loopback hosts (local development/testing).
+func NewHTTPJWKSResolver(jwksURIs map[string]string) (*HTTPJWKSResolver, error) {
+	for issuer, uri := range jwksURIs {
+		if err := validateJWKSScheme(uri); err != nil {
+			return nil, fmt.Errorf("issuer %q: %w", issuer, err)
+		}
+	}
 	return &HTTPJWKSResolver{
 		jwksURIs: jwksURIs,
 		client:   &http.Client{Timeout: 10 * time.Second},
 		cache:    map[string]*jwksEntry{},
+	}, nil
+}
+
+// validateJWKSScheme requires https for a jwks_uri (http only for loopback).
+func validateJWKSScheme(raw string) error {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("invalid jwks_uri %q: %w", raw, err)
 	}
+	switch u.Scheme {
+	case "https":
+		return nil
+	case "http":
+		if isLoopbackHost(u.Hostname()) {
+			return nil
+		}
+		return fmt.Errorf("jwks_uri %q must use https (http is allowed only for localhost)", raw)
+	default:
+		return fmt.Errorf("jwks_uri %q must use https", raw)
+	}
+}
+
+func isLoopbackHost(host string) bool {
+	if host == "localhost" {
+		return true
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return ip.IsLoopback()
+	}
+	return false
 }
 
 // Key returns the public key for (issuer, kid), fetching/refreshing the issuer's

--- a/internal/core/oidc_jwks_test.go
+++ b/internal/core/oidc_jwks_test.go
@@ -34,7 +34,9 @@ func TestHTTPJWKSResolver_FetchAndCache(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	r := NewHTTPJWKSResolver(map[string]string{"https://iss": srv.URL})
+	// srv.URL is http://127.0.0.1:… (loopback) — allowed for tests.
+	r, err := NewHTTPJWKSResolver(map[string]string{"https://iss": srv.URL})
+	require.NoError(t, err)
 
 	got, err := r.Key(context.Background(), "https://iss", "k1")
 	require.NoError(t, err)
@@ -51,4 +53,20 @@ func TestHTTPJWKSResolver_FetchAndCache(t *testing.T) {
 	// Unknown issuer fails.
 	_, err = r.Key(context.Background(), "https://other", "k1")
 	require.ErrorContains(t, err, "no jwks_uri")
+}
+
+func TestNewHTTPJWKSResolver_RejectsInsecureScheme(t *testing.T) {
+	// Plaintext http to a non-loopback host is refused (signing-key MITM).
+	_, err := NewHTTPJWKSResolver(map[string]string{"https://iss": "http://idp.example.com/jwks"})
+	require.ErrorContains(t, err, "must use https")
+
+	// https is accepted.
+	_, err = NewHTTPJWKSResolver(map[string]string{"https://iss": "https://idp.example.com/jwks"})
+	require.NoError(t, err)
+
+	// http to loopback is allowed (dev/test).
+	for _, uri := range []string{"http://localhost:8200/jwks", "http://127.0.0.1:8200/jwks", "http://[::1]:8200/jwks"} {
+		_, err = NewHTTPJWKSResolver(map[string]string{"https://iss": uri})
+		require.NoErrorf(t, err, "loopback %s should be allowed", uri)
+	}
 }

--- a/server/main.go
+++ b/server/main.go
@@ -246,7 +246,11 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 			trusted = append(trusted, core.OIDCTrustedIssuer{Issuer: iss.Issuer, Audiences: iss.Audiences})
 			jwksURIs[iss.Issuer] = iss.JWKSURI
 		}
-		verifier, verr := core.NewOIDCVerifier(trusted, core.NewHTTPJWKSResolver(jwksURIs))
+		resolver, rerr := core.NewHTTPJWKSResolver(jwksURIs)
+		if rerr != nil {
+			return nil, nil, fmt.Errorf("invalid OIDC jwks_uri: %w", rerr)
+		}
+		verifier, verr := core.NewOIDCVerifier(trusted, resolver)
 		if verr != nil {
 			return nil, nil, fmt.Errorf("failed to init OIDC federation: %w", verr)
 		}


### PR DESCRIPTION
## Summary

The OIDC / Kubernetes-JWT federation resolver (ADR-031) fetched each issuer's signing keys from its configured `jwks_uri` with **no scheme check**. An `http://` jwks_uri pulls the JWKS over plaintext — a network MITM could swap the signing keys and **forge federation tokens** that authenticate as a trusted machine identity.

`NewHTTPJWKSResolver` now validates every `jwks_uri` at construction: **https required**; `http` permitted only for loopback hosts (`localhost` / `127.0.0.1` / `::1`) for local dev/tests. A misconfigured https-less issuer now fails the server's startup wiring loudly instead of silently fetching keys insecurely.

The URI is operator-supplied (not attacker-controlled), so this is **secure-by-default hardening** of the federation trust boundary, not an exploitable flaw — but plaintext retrieval of signing-key material is exactly the kind of control a certification expects enforced.

## Context

Surfaced by a focused audit of the token-issuance / credential-delivery / OIDC paths, which **otherwise came back clean** (all tokens `crypto/rand` + SHA-256/hash-lookup; the JWT verifier enforces alg-allowlist + aud + iss + exp; machine tokens get no admin bypass; PATs honor the inactive-user check).

## Tests

`TestNewHTTPJWKSResolver_RejectsInsecureScheme`: rejects `http` to a remote host, accepts `https`, accepts `http` to loopback. Full `internal/core` suite green; `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)