### PR TITLE
fix(remote): TLS verification secure-by-default for the remote client

### DIFF
--- a/internal/cli/auth/auth.go
+++ b/internal/cli/auth/auth.go
@@ -102,7 +102,7 @@ func runLogin(cmd *cobra.Command, args []string) error {
 	}
 	cfg.Storage.Remote.BaseURL = server
 	cfg.Storage.Remote.APIKey = apiKey
-	cfg.Storage.Remote.TLSVerify = true
+	cfg.Storage.Remote.TLSVerify = config.BoolPtr(true)
 	cfg.Storage.Remote.TimeoutSeconds = 30
 	cfg.Storage.Remote.RetryAttempts = 3
 

--- a/internal/cli/config/config.go
+++ b/internal/cli/config/config.go
@@ -109,7 +109,7 @@ func runSetRemote(cmd *cobra.Command, args []string) error {
 	cfg.Storage.Remote.BaseURL = url
 	cfg.Storage.Remote.APIKey = apiKey
 	cfg.Storage.Remote.TimeoutSeconds = timeout
-	cfg.Storage.Remote.TLSVerify = true
+	cfg.Storage.Remote.TLSVerify = config.BoolPtr(true)
 
 	if err := config.Save("keyorix.yaml", cfg); err != nil {
 		return fmt.Errorf("failed to save configuration: %w", err)
@@ -180,7 +180,7 @@ func testRemoteConnection(cfg *config.Config) error {
 	client := &http.Client{
 		Timeout: timeout,
 		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: !cfg.Storage.Remote.TLSVerify}, // #nosec G402 — honors the configured tls_verify
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: !cfg.Storage.Remote.VerifyTLS()}, // #nosec G402 — honors tls_verify (secure by default)
 		},
 	}
 

--- a/internal/cli/config/conn_test.go
+++ b/internal/cli/config/conn_test.go
@@ -10,7 +10,7 @@ import (
 
 func cfgFor(url string) *appconfig.Config {
 	c := &appconfig.Config{}
-	c.Storage.Remote = &appconfig.RemoteConfig{BaseURL: url, TLSVerify: false}
+	c.Storage.Remote = &appconfig.RemoteConfig{BaseURL: url, TLSVerify: appconfig.BoolPtr(false)}
 	return c
 }
 

--- a/internal/cli/integration_test.go
+++ b/internal/cli/integration_test.go
@@ -89,7 +89,7 @@ func TestRemoteCLIIntegration(t *testing.T) {
 				APIKey:         "test-api-key",
 				TimeoutSeconds: 30,
 				RetryAttempts:  3,
-				TLSVerify:      false,
+				TLSVerify:      config.BoolPtr(false),
 			},
 		},
 	}
@@ -159,7 +159,7 @@ func TestLocalToRemoteSwitching(t *testing.T) {
 				APIKey:         "test-api-key",
 				TimeoutSeconds: 30,
 				RetryAttempts:  3,
-				TLSVerify:      false,
+				TLSVerify:      config.BoolPtr(false),
 			},
 		},
 	}
@@ -200,7 +200,7 @@ func TestConfigurationPersistence(t *testing.T) {
 				APIKey:         "test-key-123",
 				TimeoutSeconds: 45,
 				RetryAttempts:  5,
-				TLSVerify:      true,
+				TLSVerify:      config.BoolPtr(true),
 			},
 		},
 	}
@@ -223,7 +223,7 @@ func TestConfigurationPersistence(t *testing.T) {
 	assert.Equal(t, "test-key-123", loadedCfg.Storage.Remote.APIKey)
 	assert.Equal(t, 45, loadedCfg.Storage.Remote.TimeoutSeconds)
 	assert.Equal(t, 5, loadedCfg.Storage.Remote.RetryAttempts)
-	assert.True(t, loadedCfg.Storage.Remote.TLSVerify)
+	assert.True(t, loadedCfg.Storage.Remote.VerifyTLS())
 }
 
 func TestErrorHandling(t *testing.T) {
@@ -280,7 +280,7 @@ func TestEnvironmentVariableSupport(t *testing.T) {
 				APIKey:         "${TEST_API_KEY}",
 				TimeoutSeconds: 30,
 				RetryAttempts:  3,
-				TLSVerify:      true,
+				TLSVerify:      config.BoolPtr(true),
 			},
 		},
 	}
@@ -301,7 +301,7 @@ func TestEnvironmentVariableSupport(t *testing.T) {
 		APIKey:         loadedCfg.Storage.Remote.APIKey,
 		TimeoutSeconds: loadedCfg.Storage.Remote.TimeoutSeconds,
 		RetryAttempts:  loadedCfg.Storage.Remote.RetryAttempts,
-		TLSVerify:      loadedCfg.Storage.Remote.TLSVerify,
+		TLSVerify:      loadedCfg.Storage.Remote.VerifyTLS(),
 	}
 
 	err = remoteConfig.Validate()

--- a/internal/cli/modes.go
+++ b/internal/cli/modes.go
@@ -127,7 +127,7 @@ func (c *CLI) initClientMode() error {
 				APIKey:         c.config.Client.Auth.GetAPIKey(),
 				TimeoutSeconds: int(c.config.GetTimeout().Seconds()),
 				RetryAttempts:  3,
-				TLSVerify:      true,
+				TLSVerify:      config.BoolPtr(true),
 			},
 		},
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -164,13 +164,26 @@ type RemoteConfig struct {
 	APIKey         string `yaml:"api_key"` // use KEYORIX_REMOTE_API_KEY env var instead
 	TimeoutSeconds int    `yaml:"timeout_seconds"`
 	RetryAttempts  int    `yaml:"retry_attempts"`
-	TLSVerify      bool   `yaml:"tls_verify"`
+	// TLSVerify is a pointer so "unset" is distinguishable from an explicit
+	// false: omitting tls_verify must NOT disable certificate verification on
+	// the (highly sensitive) secrets-manager API channel. Resolve via VerifyTLS.
+	TLSVerify *bool `yaml:"tls_verify"`
 }
 
 // GetAPIKey returns the resolved API key, preferring the environment variable.
 func (r *RemoteConfig) GetAPIKey() string {
 	return resolveSecret("KEYORIX_REMOTE_API_KEY", r.APIKey)
 }
+
+// VerifyTLS reports whether TLS certificate verification is enabled for the
+// remote connection. Secure by default: verification is on unless the operator
+// EXPLICITLY sets `tls_verify: false`. An omitted key verifies.
+func (r *RemoteConfig) VerifyTLS() bool {
+	return r.TLSVerify == nil || *r.TLSVerify
+}
+
+// BoolPtr returns a pointer to b — for setting optional *bool config fields.
+func BoolPtr(b bool) *bool { return &b }
 
 type ClientConfig struct {
 	Endpoint string     `yaml:"endpoint"`

--- a/internal/config/config_load_test.go
+++ b/internal/config/config_load_test.go
@@ -66,3 +66,35 @@ func TestSessionConfigParsing(t *testing.T) {
 	zero := SessionConfig{AbsoluteTTL: "0"}
 	assert.Equal(t, time.Duration(0), zero.GetAbsoluteTTL(), `"0" → no ceiling`)
 }
+
+// TLS verification for the remote storage client is SECURE BY DEFAULT: an omitted
+// tls_verify must not disable certificate validation on the secrets-manager API.
+func TestRemoteConfig_VerifyTLS_SecureByDefault(t *testing.T) {
+	// Unset (the dangerous case before the fix) → verification ON.
+	unset := &RemoteConfig{BaseURL: "https://x"}
+	assert.True(t, unset.VerifyTLS(), "omitted tls_verify must verify")
+
+	// A config file that omits the key parses to nil → verify.
+	var loaded Config
+	require.NoError(t, yamlUnmarshalForTest(t, "storage:\n  type: remote\n  remote:\n    base_url: https://x\n", &loaded))
+	require.NotNil(t, loaded.Storage.Remote)
+	assert.True(t, loaded.Storage.Remote.VerifyTLS(), "parsed-without-key must verify")
+
+	// Explicit opt-out is honoured.
+	assert.False(t, (&RemoteConfig{TLSVerify: BoolPtr(false)}).VerifyTLS())
+	// Explicit true verifies.
+	assert.True(t, (&RemoteConfig{TLSVerify: BoolPtr(true)}).VerifyTLS())
+}
+
+func yamlUnmarshalForTest(t *testing.T, y string, c *Config) error {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "keyorix.yaml")
+	require.NoError(t, os.WriteFile(p, []byte(y), 0o600))
+	loaded, err := Load(p)
+	if err != nil {
+		return err
+	}
+	*c = *loaded
+	return nil
+}

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -114,7 +114,7 @@ func (f *DefaultStorageFactory) createRemoteStorage(cfg *config.Config) (storage
 		APIKey:         cfg.Storage.Remote.GetAPIKey(),
 		TimeoutSeconds: cfg.Storage.Remote.TimeoutSeconds,
 		RetryAttempts:  cfg.Storage.Remote.RetryAttempts,
-		TLSVerify:      cfg.Storage.Remote.TLSVerify,
+		TLSVerify:      cfg.Storage.Remote.VerifyTLS(), // secure-by-default resolution
 	}
 
 	return store.NewRemoteStorage(remoteConfig)


### PR DESCRIPTION
## The bug (HIGH — from the storage/remote-client audit)

The remote storage client's `tls_verify` is a plain `bool`: its zero value is `false`, and `config.Load()` is a bare `yaml.Unmarshal` with **no defaulting**. So a `keyorix.yaml` with `storage.type: remote` that **omits** `tls_verify` resolved to `TLSVerify=false` → `InsecureSkipVerify=true` — silently disabling certificate verification on the most security-sensitive channel there is: the secrets-manager API, carrying the bearer token and every retrieved secret.

The `keyorix connect` / `auth login` paths set it `true`, so the exposure is any **hand-authored or templated** config that leaves the key out. An on-path attacker could terminate TLS with any certificate; the client accepts it and leaks the token + secrets.

## Fix — make secure the default

- `RemoteConfig.TLSVerify` is now `*bool`, so "unset" (nil) is distinguishable from an explicit `false`. New `VerifyTLS()` resolves it: **verification is ON unless the operator explicitly sets `tls_verify: false`**.
- The two TLS-config readers (storage factory + the CLI connectivity probe) go through `VerifyTLS()`; the three config writers set it via `config.BoolPtr(true)`.

Operators who genuinely need to skip verification (dev / air-gapped self-signed) must now opt in explicitly with `tls_verify: false`.

## Context

Found by the **storage-layer / remote-client audit**, which otherwise came back **clean**: all SQL is GORM-parameterized (no string-built queries, `ORDER BY` clauses are literals), every `secret_nodes` query is soft-delete-scoped, `Unscoped()` uses are intentional restore/purge paths, migrations are strictly additive, and no code path persists a plaintext secret/token.

## Tests

An omitted / parsed-without-key config verifies (the previously-vulnerable case); explicit `false` opts out; explicit `true` verifies. Full config/cli/storage suites green; `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)