### PR TITLE
feat(auth): TOTP multi-factor authentication (ADR-034)

### DIFF
--- a/docs/adr-034-mfa-totp.md
+++ b/docs/adr-034-mfa-totp.md
@@ -1,0 +1,57 @@
+# ADR-034: Multi-factor authentication (TOTP)
+
+**Status:** Accepted
+**Date:** 2026-06-12
+
+## Context
+
+Interactive human login used a password only. MFA was the one outstanding gap in
+the authentication controls (the in-product 2FA panel was a placeholder), and
+strong/multi-factor authentication is expected by NIS2 Art. 21(2)(j) and ENS
+`op.acc.5/6` — directly relevant to the certification posture. We needed
+per-user, opt-in second-factor authentication without disrupting the existing
+session/RBAC machinery.
+
+## Decision
+
+Add **TOTP** (RFC 6238, `github.com/pquerna/otp`) as an opt-in second factor.
+
+- **Enrolment is self-service.** `POST /auth/mfa/enroll` generates a secret and
+  returns the `otpauth://` URI + base32 secret; `POST /auth/mfa/activate` confirms
+  it with a code, enables MFA, and returns 10 single-use **recovery codes** (shown
+  once). `POST /auth/mfa/disable` requires a current code or the password.
+- **Two-step login via a short-lived pre-auth challenge.** When an MFA-enabled
+  user passes the password step, `/auth/login` returns **no session** —
+  `{mfa_required: true, mfa_challenge}`. `POST /auth/mfa/verify` consumes the
+  single-use, 5-minute, hashed challenge, verifies the TOTP (or a recovery) code,
+  and only then mints the session. Chosen over a "pending MFA" session flag so a
+  `models.Session` always means *fully authenticated* — no half-authenticated
+  session can ever reach secrets, and the auth middleware is untouched.
+- **TOTP secret encrypted at rest.** The shared secret cannot be hashed (it is
+  needed to compute the expected code), so it is stored **reversibly encrypted**
+  via the server's initialised `encryption.Service` (KEK from
+  `KEYORIX_MASTER_PASSWORD`), wired onto the core at startup
+  (`SetAuthEncryptor`); passthrough when encryption is disabled, consistent with
+  the rest of the product. Recovery and challenge tokens are SHA-256 hashed,
+  single-use.
+- **Auditable.** `mfa.enrolled/activated/disabled/login_verified/recovery_used/
+  failed` flow through the existing audit pipeline.
+- **±1 time-step skew** for clock drift; the `/auth/mfa/verify` endpoint is rate
+  limited.
+
+## Consequences
+
+- Human logins can require a second factor; the access-control story now satisfies
+  the MFA expectation for the certification track (controls docs updated to
+  Shipped).
+- One TOTP code attempt per challenge: a wrong code burns the challenge and the
+  user re-authenticates. This is the simplest secure behaviour for v1; allowing a
+  few attempts per challenge (verify-without-consume + rate limit) is a tracked
+  UX follow-up.
+- TOTP applies to interactive human login only — PAT/machine-token/OIDC paths are
+  unchanged (those are non-interactive credentials with their own lifecycle).
+
+## Deferred
+
+Admin-enforced "MFA required" org/project policy; WebAuthn / passkeys;
+trusted-device "remember this device"; multi-attempt-per-challenge UX.

--- a/docs/compliance/ENS-CONTROLS.md
+++ b/docs/compliance/ENS-CONTROLS.md
@@ -51,9 +51,9 @@ for the secrets it manages:
   tokens with a hard absolute-lifetime ceiling; a configurable password policy
   (length, complexity, common-password denylist, history, max-age); federated
   authentication for machine identities via **OIDC / Kubernetes-JWT** (signed,
-  audience- and issuer-validated). **MFA/TOTP is Roadmap.**
+  audience- and issuer-validated). **TOTP MFA (ADR-034) is shipped** — per-user opt-in second factor with two-step login + recovery codes; WebAuthn/passkeys remain Roadmap.
 
-**Status:** Shipped (MFA Roadmap).
+**Status:** Shipped.
 
 ### Marco operacional — Registro de la actividad (`op.exp.8`)
 
@@ -126,7 +126,7 @@ audit trail that evidences that the operator's procedures are followed.
 
 | ENS measure family | Dimension(s) | Keyorix capability | Status |
 |--------------------|--------------|--------------------|--------|
-| `op.acc` — Control de acceso | C, A | Scoped RBAC, machine identities, membership lifecycle, password policy, OIDC | Shipped (MFA roadmap) |
+| `op.acc` — Control de acceso | C, A | Scoped RBAC, machine identities, membership lifecycle, password policy, OIDC, TOTP MFA | Shipped |
 | `op.exp.8` — Registro de actividad | T, I | Full audit trail + tamper-evident hash chain + SIEM | Shipped |
 | Protección de claves criptográficas | C, I | Envelope encryption, KEK/DEK, rotation sweep, key backup | Shipped |
 | `op.mon` — Monitorización | T | Anomaly detection | Shipped |

--- a/docs/compliance/NIS2-DORA-ISO-CONTROLS.md
+++ b/docs/compliance/NIS2-DORA-ISO-CONTROLS.md
@@ -127,10 +127,12 @@ authentication).
 - **Credential delivery** — single-use, hashed-at-rest setup links (24h TTL) or a
   one-time generated password for out-of-band relay; no reusable credential is
   ever emailed.
-- **MFA / TOTP** — **Roadmap** (positioned honestly as "coming soon" in-product;
-  not yet built).
+- **MFA / TOTP** — **Shipped** (ADR-034): per-user opt-in TOTP second factor with
+  a two-step login (a short-lived single-use challenge gates session issuance),
+  single-use recovery codes, and the TOTP secret encrypted at rest. WebAuthn /
+  passkeys and admin-enforced MFA policy remain Roadmap.
 
-**Status:** Shipped, except MFA/TOTP (Roadmap).
+**Status:** Shipped.
 
 ---
 
@@ -180,7 +182,7 @@ config-present but not yet wired — Roadmap.)
 | Access control & authorisation | 21(2)(i) | ICT protection | A.5.15–5.18 | Shipped |
 | Cryptography | 21(2)(h) | data protection | A.8.24 | Shipped |
 | Logging & audit | 21(2) | detection/records | A.8.15–8.16 | Shipped |
-| Authentication & sessions | 21(2)(j) | — | A.5.17, 8.5 | Shipped (MFA roadmap) |
+| Authentication & sessions | 21(2)(j) | — | A.5.17, 8.5 | Shipped (incl. TOTP MFA) |
 | ICT third-party / continuity | 21(2)(d) | third-party risk | A.5.19–5.23 | Shipped |
 | Retention & disposal | 21(2) | record-keeping | A.8.10, 5.33 | Shipped (purge roadmap) |
 

--- a/docs/compliance/SECURITY-FAQ.md
+++ b/docs/compliance/SECURITY-FAQ.md
@@ -66,9 +66,11 @@ separate from human users, with their own lifecycle. (OIDC service-account auth 
 e.g. Kubernetes projected tokens — is a roadmap item.)
 
 **Do you support MFA?**
-TOTP/MFA is on the roadmap and is positioned in-product as "coming soon"; it is
-not yet shipped. Password policy, short-lived sessions with an absolute lifetime
-ceiling, and first-login password-change enforcement are shipped today.
+Yes — per-user opt-in **TOTP** (RFC 6238) second factor with a two-step login,
+single-use recovery codes, and the TOTP secret encrypted at rest (ADR-034).
+WebAuthn/passkeys and admin-enforced MFA policy are on the roadmap. Password
+policy, short-lived sessions with an absolute lifetime ceiling, and first-login
+password-change enforcement are also shipped.
 
 **Can an admin act as another user, and is that visible?**
 Yes — impersonation issues a separate short-lived session (the admin's own session
@@ -131,8 +133,7 @@ issues. See [`../SECURITY.md`](../SECURITY.md) for details.
 
 We would rather tell you these up front than have you find them:
 
-- **MFA/TOTP** — roadmap, not shipped.
-- **OIDC service-account auth** (e.g. Kubernetes) — roadmap.
+- **WebAuthn / passkeys** and admin-enforced MFA policy — roadmap (TOTP MFA itself is shipped, ADR-034).
 - **Audit-log tamper-evidence** (cryptographic chaining / WORM) — roadmap;
   integrity today relies on operator-controlled PostgreSQL.
 - **Automated purge schedulers** for soft-deleted records — config-present, not

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/go-chi/cors v1.2.1
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/nicksnyder/go-i18n/v2 v2.6.0
+	github.com/pquerna/otp v1.5.0
 	github.com/prometheus/client_golang v1.23.2
 	github.com/shirou/gopsutil/v4 v4.26.5
 	github.com/spf13/cobra v1.9.1
@@ -46,6 +47,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sts v1.43.3 // indirect
 	github.com/aws/smithy-go v1.27.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/ebitengine/purego v0.10.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -48,6 +48,8 @@ github.com/aws/smithy-go v1.27.1 h1:4T340VFndXtADGF52gYa1POyL7s9E4Z1OeZ1hCscIw8=
 github.com/aws/smithy-go v1.27.1/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc h1:biVzkmvwrH8WK8raXaxBx6fRVTlJILwEwQGL1I/ByEI=
+github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
@@ -122,6 +124,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 h1:o4JXh1EVt9k/+g42oCprj/FisM4qX9L3sZB3upGN2ZU=
 github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
+github.com/pquerna/otp v1.5.0 h1:NMMR+WrmaqXU4EzdGJEE1aUUI0AMRzsp96fFFWNPwxs=
+github.com/pquerna/otp v1.5.0/go.mod h1:dkJfzwRKNiegxyNb54X/3fLwhCynbMspSyWKnvi1AEg=
 github.com/prometheus/client_golang v1.23.2 h1:Je96obch5RDVy3FDMndoUsjAhG5Edi49h0RJWRi/o0o=
 github.com/prometheus/client_golang v1.23.2/go.mod h1:Tb1a6LWHB3/SPIzCoaDXI4I8UHKeFTEQ1YCr+0Gyqmg=
 github.com/prometheus/client_model v0.6.2 h1:oBsgwpGs7iVziMvrGhE53c/GrLUsZdHnqNwqPLxwZyk=

--- a/internal/core/auth.go
+++ b/internal/core/auth.go
@@ -53,6 +53,11 @@ func (c *KeyorixCore) Login(ctx context.Context, req *LoginRequest) (*models.Ses
 	if AccountLoginBlocked(user.AccountState) {
 		return nil, nil, fmt.Errorf("account suspended")
 	}
+	// MFA-enabled accounts get no session from the password step — the caller must
+	// complete the second factor (CreateMFAChallenge → VerifyMFALogin).
+	if user.MFAEnabled {
+		return nil, user, ErrMFARequired
+	}
 	created, err := c.mintSession(ctx, user.ID, req.UserAgent, req.IPAddress)
 	if err != nil {
 		return nil, nil, err

--- a/internal/core/mfa.go
+++ b/internal/core/mfa.go
@@ -1,0 +1,227 @@
+// mfa.go — TOTP multi-factor authentication (RFC 6238): per-user opt-in
+// enrolment, two-step login via a short-lived challenge, and single-use recovery
+// codes. The TOTP shared secret is stored reversibly encrypted (it cannot be
+// hashed); recovery and challenge tokens are SHA-256 hashed at rest.
+package core
+
+import (
+	"context"
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/pquerna/otp"
+	"github.com/pquerna/otp/totp"
+	"golang.org/x/crypto/bcrypt"
+)
+
+// ErrMFARequired is returned by Login when the password is correct but the
+// account has MFA enabled: the caller must issue a challenge (CreateMFAChallenge)
+// and complete VerifyMFALogin with a one-time code.
+var ErrMFARequired = errors.New("mfa required")
+
+const (
+	mfaIssuer            = "Keyorix"
+	mfaRecoveryCodeCount = 10
+	mfaChallengeTTL      = 5 * time.Minute
+)
+
+// BeginMFAEnrollment generates a fresh TOTP secret, stores it encrypted in a
+// pending (not-activated) state, and returns the otpauth:// URI (QR) plus the
+// base32 secret (manual entry). Supersedes any prior pending enrolment. Refused
+// if MFA is already enabled (disable first).
+func (c *KeyorixCore) BeginMFAEnrollment(ctx context.Context, userID uint) (otpauthURI, base32Secret string, err error) {
+	user, err := c.storage.GetUser(ctx, userID)
+	if err != nil {
+		return "", "", fmt.Errorf("user not found")
+	}
+	if user.MFAEnabled {
+		return "", "", fmt.Errorf("MFA is already enabled; disable it first to re-enrol")
+	}
+	key, err := totp.Generate(totp.GenerateOpts{Issuer: mfaIssuer, AccountName: user.Username})
+	if err != nil {
+		return "", "", fmt.Errorf("failed to generate TOTP secret: %w", err)
+	}
+	ct, meta, err := c.encryptAuthSecret(key.Secret())
+	if err != nil {
+		return "", "", fmt.Errorf("failed to encrypt TOTP secret: %w", err)
+	}
+	if err := c.storage.UpsertMFASecret(ctx, &models.MFASecret{
+		UserID: userID, SecretEnc: ct, SecretMeta: meta, Activated: false, CreatedAt: c.now(),
+	}); err != nil {
+		return "", "", fmt.Errorf("failed to store TOTP secret: %w", err)
+	}
+	uid := userID
+	c.writeAuditEventFull(ctx, "mfa.enrolled", &uid, nil, nil, "", fmt.Sprintf("user %s began MFA enrolment", user.Username))
+	return key.URL(), key.Secret(), nil
+}
+
+// ActivateMFA verifies a TOTP code against the pending secret, enables MFA, and
+// returns N single-use recovery codes (shown once).
+func (c *KeyorixCore) ActivateMFA(ctx context.Context, userID uint, code string) ([]string, error) {
+	user, err := c.storage.GetUser(ctx, userID)
+	if err != nil {
+		return nil, fmt.Errorf("user not found")
+	}
+	secret, err := c.loadTOTPSecret(ctx, userID)
+	if err != nil {
+		return nil, fmt.Errorf("no pending MFA enrolment; begin enrolment first")
+	}
+	if !c.validateTOTP(secret, code) {
+		c.auditMFAFailed(ctx, userID, "activate")
+		return nil, fmt.Errorf("invalid code")
+	}
+	if err := c.storage.ActivateMFASecret(ctx, userID); err != nil {
+		return nil, fmt.Errorf("failed to activate MFA: %w", err)
+	}
+	if err := c.storage.SetUserMFAEnabled(ctx, userID, true); err != nil {
+		return nil, fmt.Errorf("failed to enable MFA: %w", err)
+	}
+	codes, hashes, err := generateRecoveryCodes(mfaRecoveryCodeCount)
+	if err != nil {
+		return nil, err
+	}
+	if err := c.storage.CreateMFARecoveryCodes(ctx, userID, hashes); err != nil {
+		return nil, fmt.Errorf("failed to store recovery codes: %w", err)
+	}
+	uid := userID
+	c.writeAuditEventFull(ctx, "mfa.activated", &uid, nil, nil, "", fmt.Sprintf("user %s activated MFA", user.Username))
+	return codes, nil
+}
+
+// DisableMFA turns MFA off after verifying a current TOTP code OR the account
+// password, then clears the secret and all recovery codes.
+func (c *KeyorixCore) DisableMFA(ctx context.Context, userID uint, codeOrPassword string) error {
+	user, err := c.storage.GetUser(ctx, userID)
+	if err != nil {
+		return fmt.Errorf("user not found")
+	}
+	if !user.MFAEnabled {
+		return fmt.Errorf("MFA is not enabled")
+	}
+	ok := false
+	if secret, err := c.loadTOTPSecret(ctx, userID); err == nil && c.validateTOTP(secret, codeOrPassword) {
+		ok = true
+	}
+	if !ok && bcrypt.CompareHashAndPassword([]byte(user.PasswordHash), []byte(codeOrPassword)) == nil {
+		ok = true
+	}
+	if !ok {
+		c.auditMFAFailed(ctx, userID, "disable")
+		return fmt.Errorf("invalid code or password")
+	}
+	if err := c.storage.SetUserMFAEnabled(ctx, userID, false); err != nil {
+		return err
+	}
+	if err := c.storage.DeleteMFAForUser(ctx, userID); err != nil {
+		return err
+	}
+	uid := userID
+	c.writeAuditEventFull(ctx, "mfa.disabled", &uid, nil, nil, "", fmt.Sprintf("user %s disabled MFA", user.Username))
+	return nil
+}
+
+// CreateMFAChallenge issues a short-lived single-use challenge for an MFA-enabled
+// user that has passed the password step. Only the token hash is stored.
+func (c *KeyorixCore) CreateMFAChallenge(ctx context.Context, userID uint) (string, error) {
+	token, err := generateSecureToken()
+	if err != nil {
+		return "", err
+	}
+	if err := c.storage.CreateMFAChallenge(ctx, &models.MFAChallenge{
+		UserID: userID, TokenHash: sha256Hex(token), ExpiresAt: c.now().Add(mfaChallengeTTL), CreatedAt: c.now(),
+	}); err != nil {
+		return "", err
+	}
+	return token, nil
+}
+
+// VerifyMFALogin consumes a challenge, verifies a TOTP code or a recovery code,
+// and on success mints and returns the session (the second login step).
+func (c *KeyorixCore) VerifyMFALogin(ctx context.Context, challenge, code, userAgent, ip string) (*models.Session, *models.User, error) {
+	ch, err := c.storage.ConsumeMFAChallenge(ctx, sha256Hex(challenge), c.now())
+	if err != nil {
+		return nil, nil, fmt.Errorf("invalid or expired challenge")
+	}
+	user, err := c.storage.GetUser(ctx, ch.UserID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("user not found")
+	}
+	verified, usedRecovery := false, false
+	if secret, err := c.loadTOTPSecret(ctx, ch.UserID); err == nil && c.validateTOTP(secret, code) {
+		verified = true
+	} else if consumed, err := c.storage.ConsumeMFARecoveryCode(ctx, ch.UserID, sha256Hex(normalizeRecoveryCode(code)), c.now()); err == nil && consumed {
+		verified, usedRecovery = true, true
+	}
+	if !verified {
+		c.auditMFAFailed(ctx, ch.UserID, "login")
+		return nil, nil, fmt.Errorf("invalid code")
+	}
+	session, err := c.mintSession(ctx, ch.UserID, userAgent, ip)
+	if err != nil {
+		return nil, nil, err
+	}
+	uid := ch.UserID
+	if usedRecovery {
+		c.writeAuditEventFull(ctx, "mfa.recovery_used", &uid, nil, nil, ip, fmt.Sprintf("user %s used a recovery code", user.Username))
+	}
+	c.writeAuditEventFull(ctx, "mfa.login_verified", &uid, nil, nil, ip, fmt.Sprintf("user %s passed MFA", user.Username))
+	return session, user, nil
+}
+
+// ── helpers ─────────────────────────────────────────────────────────────────
+
+func (c *KeyorixCore) loadTOTPSecret(ctx context.Context, userID uint) (string, error) {
+	row, err := c.storage.GetMFASecret(ctx, userID)
+	if err != nil {
+		return "", err
+	}
+	return c.decryptAuthSecret(row.SecretEnc, row.SecretMeta)
+}
+
+func (c *KeyorixCore) validateTOTP(secret, code string) bool {
+	code = strings.TrimSpace(code)
+	if code == "" {
+		return false
+	}
+	// ±1 time-step skew (clock drift); standard 30s SHA-1 6-digit TOTP.
+	valid, _ := totp.ValidateCustom(code, secret, c.now().UTC(), totp.ValidateOpts{
+		Period: 30, Skew: 1, Digits: otp.DigitsSix, Algorithm: otp.AlgorithmSHA1,
+	})
+	return valid
+}
+
+func (c *KeyorixCore) auditMFAFailed(ctx context.Context, userID uint, phase string) {
+	uid := userID
+	c.writeAuditEventFull(ctx, "mfa.failed", &uid, nil, nil, "", fmt.Sprintf("failed MFA %s for user %d", phase, userID))
+}
+
+// generateRecoveryCodes returns n human-friendly codes and their SHA-256 hashes.
+func generateRecoveryCodes(n int) (codes, hashes []string, err error) {
+	const alphabet = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789" // no ambiguous 0/O/1/I
+	for i := 0; i < n; i++ {
+		b := make([]byte, 10)
+		if _, err := rand.Read(b); err != nil {
+			return nil, nil, err
+		}
+		var sb strings.Builder
+		for j, x := range b {
+			if j == 5 {
+				sb.WriteByte('-')
+			}
+			sb.WriteByte(alphabet[int(x)%len(alphabet)])
+		}
+		code := sb.String()
+		codes = append(codes, code)
+		hashes = append(hashes, sha256Hex(normalizeRecoveryCode(code)))
+	}
+	return codes, hashes, nil
+}
+
+// normalizeRecoveryCode makes entry forgiving: upper-cased, dash/space-stripped.
+func normalizeRecoveryCode(code string) string {
+	return strings.ToUpper(strings.NewReplacer("-", "", " ", "").Replace(strings.TrimSpace(code)))
+}

--- a/internal/core/mfa.go
+++ b/internal/core/mfa.go
@@ -80,6 +80,10 @@ func (c *KeyorixCore) ActivateMFA(ctx context.Context, userID uint, code string)
 	if err := c.storage.SetUserMFAEnabled(ctx, userID, true); err != nil {
 		return nil, fmt.Errorf("failed to enable MFA: %w", err)
 	}
+	// Invalidate any sessions minted before MFA was enabled, so a pre-enrolment
+	// session cannot outlive the security upgrade (same hygiene as password change
+	// / suspend). Best-effort: enrolment must not fail on a session-cleanup error.
+	_ = c.storage.DeleteSessionsForUserExcept(ctx, userID, 0)
 	codes, hashes, err := generateRecoveryCodes(mfaRecoveryCodeCount)
 	if err != nil {
 		return nil, err

--- a/internal/core/mfa_test.go
+++ b/internal/core/mfa_test.go
@@ -1,0 +1,124 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/encryption"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/pquerna/otp/totp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/bcrypt"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+const mfaTestPassword = "Secret#Passw0rd!"
+
+// newMFATestCore builds a core over real SQLite with an enabled encryptor (so the
+// at-rest encryption of the TOTP secret is exercised) and a fixed clock (so TOTP
+// codes are deterministic). Seeds user id 1 = "alice".
+func newMFATestCore(t *testing.T) (*KeyorixCore, *gorm.DB, time.Time) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.User{}, &models.MFASecret{},
+		&models.MFARecoveryCode{}, &models.MFAChallenge{}, &models.Session{}, &models.AuditEvent{}))
+	hash, _ := bcrypt.GenerateFromPassword([]byte(mfaTestPassword), bcrypt.DefaultCost)
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "alice", Email: "a@b.com",
+		PasswordHash: string(hash), AccountState: "active"}).Error)
+
+	enc := encryption.NewService(&config.EncryptionConfig{Enabled: true, DEKPath: "dek.key", SaltPath: "kek.salt"}, t.TempDir())
+	require.NoError(t, enc.Initialize("test-passphrase"))
+
+	fixed := time.Date(2026, 6, 12, 10, 0, 0, 0, time.UTC)
+	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: func() time.Time { return fixed }, passwordPolicy: DefaultPasswordPolicy()}
+	c.SetAuthEncryptor(enc)
+	return c, db, fixed
+}
+
+func TestMFA_FullFlow(t *testing.T) {
+	c, db, fixed := newMFATestCore(t)
+	ctx := context.Background()
+
+	// ── Enrol ──
+	uri, secret, err := c.BeginMFAEnrollment(ctx, 1)
+	require.NoError(t, err)
+	assert.Contains(t, uri, "otpauth://totp/")
+	require.NotEmpty(t, secret)
+
+	// The secret is encrypted at rest — the stored bytes are not the base32 secret.
+	row, err := c.storage.GetMFASecret(ctx, 1)
+	require.NoError(t, err)
+	assert.NotEqual(t, secret, string(row.SecretEnc), "TOTP secret must be encrypted at rest")
+	assert.False(t, row.Activated)
+
+	// ── Activate ──
+	code, err := totp.GenerateCode(secret, fixed)
+	require.NoError(t, err)
+	codes, err := c.ActivateMFA(ctx, 1, code)
+	require.NoError(t, err)
+	assert.Len(t, codes, 10)
+
+	var user models.User
+	require.NoError(t, db.First(&user, 1).Error)
+	assert.True(t, user.MFAEnabled)
+
+	// Activating with a wrong code earlier would have failed.
+	// ── Login now demands MFA ──
+	session, u, err := c.Login(ctx, &LoginRequest{Username: "alice", Password: mfaTestPassword})
+	require.ErrorIs(t, err, ErrMFARequired)
+	assert.Nil(t, session)
+	require.NotNil(t, u)
+
+	// ── Verify: wrong code rejected (burns that challenge) ──
+	ch1, err := c.CreateMFAChallenge(ctx, 1)
+	require.NoError(t, err)
+	_, _, err = c.VerifyMFALogin(ctx, ch1, "000000", "ua", "1.2.3.4")
+	require.Error(t, err)
+
+	// ── Verify: correct code → session ──
+	ch2, err := c.CreateMFAChallenge(ctx, 1)
+	require.NoError(t, err)
+	code2, _ := totp.GenerateCode(secret, fixed)
+	sess, _, err := c.VerifyMFALogin(ctx, ch2, code2, "ua", "1.2.3.4")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+
+	// A consumed challenge can't be reused.
+	_, _, err = c.VerifyMFALogin(ctx, ch2, code2, "ua", "1.2.3.4")
+	require.Error(t, err, "challenge is single-use")
+
+	// ── Recovery code: works once, then fails ──
+	ch3, _ := c.CreateMFAChallenge(ctx, 1)
+	sess3, _, err := c.VerifyMFALogin(ctx, ch3, codes[0], "ua", "1.2.3.4")
+	require.NoError(t, err)
+	require.NotNil(t, sess3)
+
+	ch4, _ := c.CreateMFAChallenge(ctx, 1)
+	_, _, err = c.VerifyMFALogin(ctx, ch4, codes[0], "ua", "1.2.3.4")
+	require.Error(t, err, "recovery code is single-use")
+
+	// ── Disable via password → MFA off, secret cleared ──
+	require.NoError(t, c.DisableMFA(ctx, 1, mfaTestPassword))
+	require.NoError(t, db.First(&user, 1).Error)
+	assert.False(t, user.MFAEnabled)
+	_, err = c.storage.GetMFASecret(ctx, 1)
+	require.Error(t, err, "secret removed on disable")
+}
+
+func TestMFA_ActivateRejectsWrongCode(t *testing.T) {
+	c, _, _ := newMFATestCore(t)
+	ctx := context.Background()
+	_, _, err := c.BeginMFAEnrollment(ctx, 1)
+	require.NoError(t, err)
+	_, err = c.ActivateMFA(ctx, 1, "000000")
+	require.Error(t, err)
+	u, err := c.storage.GetUser(ctx, 1)
+	require.NoError(t, err)
+	assert.False(t, u.MFAEnabled, "a failed activation must not enable MFA")
+}

--- a/internal/core/mfa_test.go
+++ b/internal/core/mfa_test.go
@@ -57,12 +57,19 @@ func TestMFA_FullFlow(t *testing.T) {
 	assert.NotEqual(t, secret, string(row.SecretEnc), "TOTP secret must be encrypted at rest")
 	assert.False(t, row.Activated)
 
+	// A session minted before MFA is enabled must be purged on activation.
+	require.NoError(t, db.Create(&models.Session{UserID: 1, SessionToken: "pre-mfa"}).Error)
+
 	// ── Activate ──
 	code, err := totp.GenerateCode(secret, fixed)
 	require.NoError(t, err)
 	codes, err := c.ActivateMFA(ctx, 1, code)
 	require.NoError(t, err)
 	assert.Len(t, codes, 10)
+
+	var preSessions int64
+	require.NoError(t, db.Model(&models.Session{}).Where("user_id = ?", 1).Count(&preSessions).Error)
+	assert.Zero(t, preSessions, "pre-enrolment sessions are invalidated on MFA activation")
 
 	var user models.User
 	require.NoError(t, db.First(&user, 1).Error)

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -1216,3 +1216,22 @@ func (m *MockStorage) MarkNotificationRead(ctx context.Context, id, userID uint)
 func (m *MockStorage) MarkAllNotificationsRead(ctx context.Context, userID uint) error {
 	return m.Called(ctx, userID).Error(0)
 }
+
+// MFA stubs (MFA core logic is tested against real SQLite, not this mock).
+func (m *MockStorage) UpsertMFASecret(_ context.Context, _ *models.MFASecret) error { return nil }
+func (m *MockStorage) GetMFASecret(_ context.Context, _ uint) (*models.MFASecret, error) {
+	return nil, nil
+}
+func (m *MockStorage) ActivateMFASecret(_ context.Context, _ uint) error          { return nil }
+func (m *MockStorage) DeleteMFAForUser(_ context.Context, _ uint) error            { return nil }
+func (m *MockStorage) SetUserMFAEnabled(_ context.Context, _ uint, _ bool) error   { return nil }
+func (m *MockStorage) CreateMFARecoveryCodes(_ context.Context, _ uint, _ []string) error {
+	return nil
+}
+func (m *MockStorage) ConsumeMFARecoveryCode(_ context.Context, _ uint, _ string, _ time.Time) (bool, error) {
+	return false, nil
+}
+func (m *MockStorage) CreateMFAChallenge(_ context.Context, _ *models.MFAChallenge) error { return nil }
+func (m *MockStorage) ConsumeMFAChallenge(_ context.Context, _ string, _ time.Time) (*models.MFAChallenge, error) {
+	return nil, nil
+}

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -25,6 +25,11 @@ import (
 type KeyorixCore struct {
 	storage        storage.Storage
 	encryption     *encryption.SecretEncryption
+	// authEncryptor reversibly encrypts auth secrets that cannot be hashed (the
+	// TOTP MFA shared secret). nil or disabled = passthrough (store plaintext),
+	// consistent with the rest of the product when encryption is off. Wired from
+	// the initialised encryption.Service at server startup via SetAuthEncryptor.
+	authEncryptor  *encryption.Service
 	now            func() time.Time // For testability
 	passwordPolicy PasswordPolicy
 	auditForwarder AuditForwarder
@@ -92,6 +97,33 @@ func NewKeyorixCoreWithEncryption(storage storage.Storage, enc *encryption.Secre
 		now:            time.Now,
 		passwordPolicy: DefaultPasswordPolicy(),
 	}
+}
+
+// SetAuthEncryptor wires the encryption service used to protect reversibly-
+// encrypted auth secrets (the TOTP MFA secret). The server calls this at startup
+// when encryption is enabled. nil/disabled = passthrough.
+func (c *KeyorixCore) SetAuthEncryptor(s *encryption.Service) {
+	c.authEncryptor = s
+}
+
+// encryptAuthSecret reversibly encrypts plain; passthrough when encryption is off.
+func (c *KeyorixCore) encryptAuthSecret(plain string) (ct, meta []byte, err error) {
+	if c.authEncryptor == nil || !c.authEncryptor.IsEnabled() {
+		return []byte(plain), nil, nil
+	}
+	return c.authEncryptor.EncryptSecret([]byte(plain))
+}
+
+// decryptAuthSecret reverses encryptAuthSecret; passthrough when encryption is off.
+func (c *KeyorixCore) decryptAuthSecret(ct, _ []byte) (string, error) {
+	if c.authEncryptor == nil || !c.authEncryptor.IsEnabled() {
+		return string(ct), nil
+	}
+	plain, err := c.authEncryptor.DecryptSecret(ct)
+	if err != nil {
+		return "", err
+	}
+	return string(plain), nil
 }
 
 // SetPasswordPolicy overrides the password policy (which defaults to

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -270,6 +270,20 @@ type Storage interface {
 	TouchSession(ctx context.Context, id uint, seenAt time.Time, staleness time.Duration) error
 	CleanupExpiredSessions(ctx context.Context) error
 
+	// MFA / TOTP (per-user two-factor authentication).
+	UpsertMFASecret(ctx context.Context, s *models.MFASecret) error
+	GetMFASecret(ctx context.Context, userID uint) (*models.MFASecret, error)
+	ActivateMFASecret(ctx context.Context, userID uint) error
+	DeleteMFAForUser(ctx context.Context, userID uint) error // clears secret + recovery codes
+	SetUserMFAEnabled(ctx context.Context, userID uint, enabled bool) error
+	CreateMFARecoveryCodes(ctx context.Context, userID uint, codeHashes []string) error
+	// ConsumeMFARecoveryCode marks a matching unused code used and reports whether one was consumed.
+	ConsumeMFARecoveryCode(ctx context.Context, userID uint, codeHash string, now time.Time) (bool, error)
+	CreateMFAChallenge(ctx context.Context, c *models.MFAChallenge) error
+	// ConsumeMFAChallenge atomically finds an unused, unexpired challenge by token
+	// hash, marks it used, and returns it (or an error if none).
+	ConsumeMFAChallenge(ctx context.Context, tokenHash string, now time.Time) (*models.MFAChallenge, error)
+
 	// Personal Access Token Management (ADR-027) — user-owned bearer credentials.
 	CreatePersonalAccessToken(ctx context.Context, t *models.PersonalAccessToken) (*models.PersonalAccessToken, error)
 	ListPersonalAccessTokensByUser(ctx context.Context, userID uint) ([]*models.PersonalAccessToken, error)

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -163,6 +163,11 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 		db.Exec("ALTER TABLE users ADD COLUMN account_state TEXT NOT NULL DEFAULT 'active'")
 	}
 
+	// MFA/TOTP opt-in flag. Existing rows default to false (MFA off).
+	if tableExists(db, "users") && !columnExists(db, "users", "mfa_enabled") {
+		db.Exec("ALTER TABLE users ADD COLUMN mfa_enabled BOOLEAN NOT NULL DEFAULT false")
+	}
+
 	// Enrich sessions for the My Account "active sessions" view (device/IP/last-active).
 	if tableExists(db, "sessions") {
 		if !columnExists(db, "sessions", "user_agent") {
@@ -255,6 +260,9 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 	membershipExists := tableExists(db, "project_memberships")
 	setupTokenExists := tableExists(db, "setup_tokens")
 	notificationsExists := tableExists(db, "notifications")
+	mfaSecretExists := tableExists(db, "mfa_secrets")
+	mfaRecoveryExists := tableExists(db, "mfa_recovery_codes")
+	mfaChallengeExists := tableExists(db, "mfa_challenges")
 
 	// Create rotation_policies if missing (additive, safe on existing DBs).
 	if !rotationExists {
@@ -267,6 +275,23 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 	if !patExists {
 		if err := db.AutoMigrate(&models.PersonalAccessToken{}); err != nil {
 			return fmt.Errorf("failed to migrate personal_access_tokens table: %w", err)
+		}
+	}
+
+	// Create the MFA tables if missing (TOTP MFA, additive, safe on existing DBs).
+	if !mfaSecretExists {
+		if err := db.AutoMigrate(&models.MFASecret{}); err != nil {
+			return fmt.Errorf("failed to migrate mfa_secrets table: %w", err)
+		}
+	}
+	if !mfaRecoveryExists {
+		if err := db.AutoMigrate(&models.MFARecoveryCode{}); err != nil {
+			return fmt.Errorf("failed to migrate mfa_recovery_codes table: %w", err)
+		}
+	}
+	if !mfaChallengeExists {
+		if err := db.AutoMigrate(&models.MFAChallenge{}); err != nil {
+			return fmt.Errorf("failed to migrate mfa_challenges table: %w", err)
 		}
 	}
 

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -79,9 +79,45 @@ type User struct {
 	// AccountState is the ADR-025 lifecycle state: active | pending_first_login |
 	// password_reset_required | suspended. Empty (legacy rows) is treated as active.
 	AccountState string `gorm:"default:'active'"`
-	CreatedAt    time.Time
-	UpdatedAt    time.Time
-	DeletedAt    gorm.DeletedAt `gorm:"index"` // soft delete — set by DELETE /users/{id}, cleared by restore
+	// MFAEnabled is true once the user has activated TOTP MFA; login then requires
+	// a one-time code (see MFASecret / MFAChallenge).
+	MFAEnabled bool `gorm:"default:false"`
+	CreatedAt  time.Time
+	UpdatedAt  time.Time
+	DeletedAt  gorm.DeletedAt `gorm:"index"` // soft delete — set by DELETE /users/{id}, cleared by restore
+}
+
+// MFASecret holds a user's TOTP shared secret, encrypted at rest. One row per
+// user (UserID unique). Activated flips true on the first valid code at
+// enrolment; a row with Activated=false is a pending enrolment not yet confirmed.
+type MFASecret struct {
+	ID         uint   `gorm:"primaryKey"`
+	UserID     uint   `gorm:"uniqueIndex"`
+	SecretEnc  []byte // encrypted TOTP secret (passthrough plaintext when encryption is disabled)
+	SecretMeta []byte // encryption metadata (key version etc.)
+	Activated  bool   `gorm:"default:false"`
+	CreatedAt  time.Time
+}
+
+// MFARecoveryCode is a single-use backup code (SHA-256 hashed). UsedAt is stamped
+// when consumed so a code cannot be replayed.
+type MFARecoveryCode struct {
+	ID       uint   `gorm:"primaryKey"`
+	UserID   uint   `gorm:"index"`
+	CodeHash string `gorm:"index"`
+	UsedAt   *time.Time
+}
+
+// MFAChallenge is a short-lived, single-use pre-auth token issued when an
+// MFA-enabled user passes the password step; the verify step consumes it. The
+// raw token is never stored — only its SHA-256 hash.
+type MFAChallenge struct {
+	ID        uint   `gorm:"primaryKey"`
+	UserID    uint   `gorm:"index"`
+	TokenHash string `gorm:"uniqueIndex"`
+	ExpiresAt time.Time
+	UsedAt    *time.Time
+	CreatedAt time.Time
 }
 
 // PasswordHistory records prior password hashes per user so the policy can

--- a/internal/storage/store/local_mfa.go
+++ b/internal/storage/store/local_mfa.go
@@ -1,0 +1,103 @@
+// local_mfa.go — TOTP MFA persistence: the encrypted secret, single-use recovery
+// codes, and short-lived login challenges.
+package store
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// UpsertMFASecret creates or replaces the user's TOTP secret row (one per user).
+func (ls *LocalStorage) UpsertMFASecret(ctx context.Context, s *models.MFASecret) error {
+	return ls.db.WithContext(ctx).Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "user_id"}},
+		UpdateAll: true,
+	}).Create(s).Error
+}
+
+func (ls *LocalStorage) GetMFASecret(ctx context.Context, userID uint) (*models.MFASecret, error) {
+	var s models.MFASecret
+	if err := ls.db.WithContext(ctx).Where("user_id = ?", userID).First(&s).Error; err != nil {
+		return nil, err
+	}
+	return &s, nil
+}
+
+func (ls *LocalStorage) ActivateMFASecret(ctx context.Context, userID uint) error {
+	return ls.db.WithContext(ctx).Model(&models.MFASecret{}).
+		Where("user_id = ?", userID).Update("activated", true).Error
+}
+
+// DeleteMFAForUser removes the secret and all recovery codes for a user.
+func (ls *LocalStorage) DeleteMFAForUser(ctx context.Context, userID uint) error {
+	return ls.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Where("user_id = ?", userID).Delete(&models.MFASecret{}).Error; err != nil {
+			return err
+		}
+		return tx.Where("user_id = ?", userID).Delete(&models.MFARecoveryCode{}).Error
+	})
+}
+
+func (ls *LocalStorage) SetUserMFAEnabled(ctx context.Context, userID uint, enabled bool) error {
+	return ls.db.WithContext(ctx).Model(&models.User{}).
+		Where("id = ?", userID).Update("mfa_enabled", enabled).Error
+}
+
+func (ls *LocalStorage) CreateMFARecoveryCodes(ctx context.Context, userID uint, codeHashes []string) error {
+	if len(codeHashes) == 0 {
+		return nil
+	}
+	rows := make([]models.MFARecoveryCode, 0, len(codeHashes))
+	for _, h := range codeHashes {
+		rows = append(rows, models.MFARecoveryCode{UserID: userID, CodeHash: h})
+	}
+	return ls.db.WithContext(ctx).Create(&rows).Error
+}
+
+// ConsumeMFARecoveryCode marks a matching unused code used; returns true if one
+// was consumed. The conditional UPDATE is atomic (no read-then-write race).
+func (ls *LocalStorage) ConsumeMFARecoveryCode(ctx context.Context, userID uint, codeHash string, now time.Time) (bool, error) {
+	res := ls.db.WithContext(ctx).Model(&models.MFARecoveryCode{}).
+		Where("user_id = ? AND code_hash = ? AND used_at IS NULL", userID, codeHash).
+		Update("used_at", now)
+	if res.Error != nil {
+		return false, res.Error
+	}
+	return res.RowsAffected > 0, nil
+}
+
+func (ls *LocalStorage) CreateMFAChallenge(ctx context.Context, c *models.MFAChallenge) error {
+	return ls.db.WithContext(ctx).Create(c).Error
+}
+
+// ConsumeMFAChallenge atomically marks a valid (unused, unexpired) challenge used
+// and returns it. Returns an error if none matched.
+func (ls *LocalStorage) ConsumeMFAChallenge(ctx context.Context, tokenHash string, now time.Time) (*models.MFAChallenge, error) {
+	var ch *models.MFAChallenge
+	err := ls.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		res := tx.Model(&models.MFAChallenge{}).
+			Where("token_hash = ? AND used_at IS NULL AND expires_at > ?", tokenHash, now).
+			Update("used_at", now)
+		if res.Error != nil {
+			return res.Error
+		}
+		if res.RowsAffected == 0 {
+			return fmt.Errorf("invalid or expired challenge")
+		}
+		var loaded models.MFAChallenge
+		if err := tx.Where("token_hash = ?", tokenHash).First(&loaded).Error; err != nil {
+			return err
+		}
+		ch = &loaded
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return ch, nil
+}

--- a/internal/storage/store/remote_mfa.go
+++ b/internal/storage/store/remote_mfa.go
@@ -1,0 +1,46 @@
+// remote_mfa.go — MFA persistence is server-side only; the remote client never
+// manages MFA state directly (enrolment/verify go through the server's REST API).
+package store
+
+import (
+	"context"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+func (rs *RemoteStorage) UpsertMFASecret(_ context.Context, _ *models.MFASecret) error {
+	return remoteUnsupported("UpsertMFASecret")
+}
+
+func (rs *RemoteStorage) GetMFASecret(_ context.Context, _ uint) (*models.MFASecret, error) {
+	return nil, remoteUnsupported("GetMFASecret")
+}
+
+func (rs *RemoteStorage) ActivateMFASecret(_ context.Context, _ uint) error {
+	return remoteUnsupported("ActivateMFASecret")
+}
+
+func (rs *RemoteStorage) DeleteMFAForUser(_ context.Context, _ uint) error {
+	return remoteUnsupported("DeleteMFAForUser")
+}
+
+func (rs *RemoteStorage) SetUserMFAEnabled(_ context.Context, _ uint, _ bool) error {
+	return remoteUnsupported("SetUserMFAEnabled")
+}
+
+func (rs *RemoteStorage) CreateMFARecoveryCodes(_ context.Context, _ uint, _ []string) error {
+	return remoteUnsupported("CreateMFARecoveryCodes")
+}
+
+func (rs *RemoteStorage) ConsumeMFARecoveryCode(_ context.Context, _ uint, _ string, _ time.Time) (bool, error) {
+	return false, remoteUnsupported("ConsumeMFARecoveryCode")
+}
+
+func (rs *RemoteStorage) CreateMFAChallenge(_ context.Context, _ *models.MFAChallenge) error {
+	return remoteUnsupported("CreateMFAChallenge")
+}
+
+func (rs *RemoteStorage) ConsumeMFAChallenge(_ context.Context, _ string, _ time.Time) (*models.MFAChallenge, error) {
+	return nil, remoteUnsupported("ConsumeMFAChallenge")
+}

--- a/server/http/handlers/auth.go
+++ b/server/http/handlers/auth.go
@@ -130,6 +130,17 @@ func (h *AuthHandler) Login(w http.ResponseWriter, r *http.Request) {
 		IPAddress: ip,
 	})
 	if err != nil {
+		// MFA-enabled account: the password was correct but a second factor is
+		// required. Issue a short-lived challenge instead of a session.
+		if errors.Is(err, core.ErrMFARequired) {
+			challenge, cerr := h.coreService.CreateMFAChallenge(r.Context(), user.ID)
+			if cerr != nil {
+				sendError(w, "Internal", "failed to start MFA challenge", http.StatusInternalServerError, nil)
+				return
+			}
+			sendSuccess(w, map[string]interface{}{"mfa_required": true, "mfa_challenge": challenge}, "MFA required")
+			return
+		}
 		recordLoginAttempt(ip)
 		go h.coreService.LogAuthFailure(context.Background(), body.Username, ip) // #nosec G118
 		sendError(w, "Unauthorized", "Invalid credentials", http.StatusUnauthorized, nil)

--- a/server/http/handlers/mfa.go
+++ b/server/http/handlers/mfa.go
@@ -1,0 +1,113 @@
+// mfa.go — HTTP handlers for TOTP MFA: self-service enrol/activate/disable
+// (authenticated) and the public two-step login verify.
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/keyorixhq/keyorix/server/middleware"
+)
+
+// EnrollMFA begins TOTP enrolment for the authenticated caller and returns the
+// otpauth:// provisioning URI (for a QR code) plus the base32 secret.
+func (h *AuthHandler) EnrollMFA(w http.ResponseWriter, r *http.Request) {
+	userCtx := middleware.GetUserFromContext(r.Context())
+	if userCtx == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	uri, secret, err := h.coreService.BeginMFAEnrollment(r.Context(), userCtx.UserID)
+	if err != nil {
+		sendError(w, "Error", err.Error(), http.StatusBadRequest, nil)
+		return
+	}
+	sendSuccess(w, map[string]interface{}{
+		"otpauth_uri": uri,
+		"secret":      secret,
+	}, "Scan the QR code in your authenticator app, then activate with a code.")
+}
+
+// ActivateMFA confirms enrolment with a TOTP code and returns the one-time-shown
+// recovery codes.
+func (h *AuthHandler) ActivateMFA(w http.ResponseWriter, r *http.Request) {
+	userCtx := middleware.GetUserFromContext(r.Context())
+	if userCtx == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	var body struct {
+		Code string `json:"code"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		sendError(w, "BadRequest", "Invalid request body", http.StatusBadRequest, nil)
+		return
+	}
+	codes, err := h.coreService.ActivateMFA(r.Context(), userCtx.UserID, body.Code)
+	if err != nil {
+		sendError(w, "Error", err.Error(), http.StatusBadRequest, nil)
+		return
+	}
+	sendSuccess(w, map[string]interface{}{
+		"recovery_codes": codes,
+	}, "MFA enabled. Save these recovery codes now — they will not be shown again.")
+}
+
+// DisableMFA turns off MFA after verifying a current code or the password.
+func (h *AuthHandler) DisableMFA(w http.ResponseWriter, r *http.Request) {
+	userCtx := middleware.GetUserFromContext(r.Context())
+	if userCtx == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	var body struct {
+		Code     string `json:"code"`
+		Password string `json:"password"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		sendError(w, "BadRequest", "Invalid request body", http.StatusBadRequest, nil)
+		return
+	}
+	proof := body.Code
+	if proof == "" {
+		proof = body.Password
+	}
+	if err := h.coreService.DisableMFA(r.Context(), userCtx.UserID, proof); err != nil {
+		sendError(w, "Error", err.Error(), http.StatusBadRequest, nil)
+		return
+	}
+	sendSuccess(w, map[string]interface{}{"mfa_enabled": false}, "MFA disabled")
+}
+
+// VerifyMFA completes the two-step login: it consumes the challenge from
+// /auth/login, verifies the TOTP (or recovery) code, and returns a session.
+func (h *AuthHandler) VerifyMFA(w http.ResponseWriter, r *http.Request) {
+	ip := r.RemoteAddr
+	if idx := strings.LastIndex(ip, ":"); idx != -1 {
+		ip = ip[:idx]
+	}
+	if checkLoginRateLimit(ip) {
+		sendError(w, "TooManyRequests", "Too many attempts. Try again later.", http.StatusTooManyRequests, nil)
+		return
+	}
+	var body struct {
+		Challenge string `json:"mfa_challenge"`
+		Code      string `json:"code"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		sendError(w, "BadRequest", "Invalid request body", http.StatusBadRequest, nil)
+		return
+	}
+	session, user, err := h.coreService.VerifyMFALogin(r.Context(), body.Challenge, body.Code, r.Header.Get("User-Agent"), ip)
+	if err != nil {
+		recordLoginAttempt(ip)
+		sendError(w, "Unauthorized", "Invalid or expired code", http.StatusUnauthorized, nil)
+		return
+	}
+	resp := h.buildLoginResponse(r.Context(), session, user)
+	go h.coreService.LogAuthLogin(context.Background(), user.ID, user.Username, ip, r.Header.Get("User-Agent")) // #nosec G118
+	go func() { _ = h.coreService.RecordLogin(context.Background(), user.ID) }()                                // #nosec G118
+	sendSuccess(w, resp, "Login successful")
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -74,6 +74,9 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 	r.Post("/auth/logout", authHandler.Logout)
 	r.Post("/auth/refresh", authHandler.RefreshToken)
 	r.Post("/auth/password-reset", authHandler.PasswordReset)
+	// MFA second-step: unauthenticated — the bearer is the single-use challenge
+	// issued by /auth/login, not a session.
+	r.Post("/auth/mfa/verify", authHandler.VerifyMFA)
 	r.Post("/system/init", authHandler.InitSystem)
 
 	// Credential-delivery setup links (ADR-028) — unauthenticated: the bearer is the
@@ -140,6 +143,10 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		r.Get("/auth/profile", authHandler.Profile)
 		r.Put("/auth/profile", authHandler.UpdateProfile)
 		r.Post("/auth/change-password", authHandler.ChangePassword)
+		// MFA self-service (acts on the authenticated caller's own account).
+		r.Post("/auth/mfa/enroll", authHandler.EnrollMFA)
+		r.Post("/auth/mfa/activate", authHandler.ActivateMFA)
+		r.Post("/auth/mfa/disable", authHandler.DisableMFA)
 		r.Get("/auth/sessions", authHandler.ListSessions)
 		r.Delete("/auth/sessions/{id}", authHandler.RevokeSession)
 		r.Get("/auth/tokens", patHandler.ListPATs)

--- a/server/main.go
+++ b/server/main.go
@@ -171,12 +171,11 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 		return nil, nil, fmt.Errorf("failed to initialize encryption: %w", err)
 	}
 
-	var coreService *core.KeyorixCore
+	coreService := core.NewKeyorixCore(store)
 	if encSvc != nil {
-		// Encryption enabled: pass the service to core (used for future SecretEncryption wiring)
-		coreService = core.NewKeyorixCore(store)
-	} else {
-		coreService = core.NewKeyorixCore(store)
+		// Wire the initialised encryption service for reversibly-encrypted auth
+		// secrets (the TOTP MFA secret, which cannot be hashed).
+		coreService.SetAuthEncryptor(encSvc)
 	}
 
 	// Apply a configured password policy, if any. An absent block leaves the


### PR DESCRIPTION
## Summary

Adds per-user opt-in **TOTP MFA** (RFC 6238) — the last "Roadmap" gap in the authentication controls (NIS2 Art. 21(2)(j) strong authentication; ENS `op.acc.5/6`). A full vertical: enrol → activate → **two-step login** → recovery codes, with the TOTP secret **encrypted at rest**.

## How it works

- **Enrolment (self-service, authenticated):** `POST /auth/mfa/enroll` → `otpauth://` URI + base32 secret; `POST /auth/mfa/activate` confirms with a code, enables MFA, returns 10 single-use **recovery codes** (shown once); `POST /auth/mfa/disable` (current code or password).
- **Two-step login:** an MFA-enabled user's correct password returns **no session** — `{mfa_required: true, mfa_challenge}`. `POST /auth/mfa/verify` consumes the 5-min single-use, hashed challenge, verifies a TOTP (or recovery) code, then mints the session. Chosen over a "pending MFA" session flag so a `Session` **always means fully authenticated** — no half-authenticated state can reach secrets, and the auth middleware is untouched.
- **TOTP secret encrypted at rest:** it can't be hashed (needed to compute the code), so it's stored reversibly encrypted via the server's already-initialised `encryption.Service` (KEK from `KEYORIX_MASTER_PASSWORD`), wired onto the core at startup. Recovery + challenge tokens are `crypto/rand` + SHA-256 hashed, single-use. All actions audited (`mfa.*`).

## Key integration

- The encryption seam: `initializeCoreService` now calls `SetAuthEncryptor(encSvc)` — the encryptor that was built but unused is now wired for reversibly-encrypted auth secrets.
- Migration: three new tables via dedicated create-if-absent blocks (kept out of the big AutoMigrate list per the pgx double-migration hazard); `users.mfa_enabled` additive column.
- `pquerna/otp`; ±1 time-step skew; `/auth/mfa/verify` rate-limited.

## Verification

`TestMFA_FullFlow` runs the whole vertical against **real SQLite + an enabled encryptor**: enrol → assert the stored secret is **ciphertext, not the base32 secret** → activate (10 recovery codes) → `Login` returns `ErrMFARequired` (no session) → verify with a fresh code → session; consumed challenge can't be reused; a recovery code works **once** then fails; disable clears everything. Plus wrong-code rejection. `make build` + full core/storage/handler suites + `go vet` green.

## Docs

ADR-034; controls docs (NIS2/ISO, ENS, Security FAQ) flipped from "MFA Roadmap" to **Shipped**.

## Deferred

WebAuthn/passkeys; admin-enforced "MFA required" policy; multiple code attempts per challenge (today a wrong code burns the challenge — secure but a UX follow-up).

> Recommend a `/security-review` on this diff before merge (it changes the login path + adds credential-at-rest handling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)