### PR TITLE
feat(auth): deployment-mandated MFA (security.require_mfa)

### DIFF
--- a/docs/adr-034-mfa-totp.md
+++ b/docs/adr-034-mfa-totp.md
@@ -53,5 +53,5 @@ Add **TOTP** (RFC 6238, `github.com/pquerna/otp`) as an opt-in second factor.
 
 ## Deferred
 
-Admin-enforced "MFA required" org/project policy; WebAuthn / passkeys;
+WebAuthn / passkeys; per-project (vs deployment-wide) MFA policy;
 trusted-device "remember this device"; multi-attempt-per-challenge UX.

--- a/docs/compliance/NIS2-DORA-ISO-CONTROLS.md
+++ b/docs/compliance/NIS2-DORA-ISO-CONTROLS.md
@@ -130,7 +130,7 @@ authentication).
 - **MFA / TOTP** — **Shipped** (ADR-034): per-user opt-in TOTP second factor with
   a two-step login (a short-lived single-use challenge gates session issuance),
   single-use recovery codes, and the TOTP secret encrypted at rest. WebAuthn /
-  passkeys and admin-enforced MFA policy remain Roadmap.
+  passkeys remain Roadmap; a deployment can mandate MFA via `security.require_mfa` (interactive sessions without MFA are confined to enrolment).
 
 **Status:** Shipped.
 

--- a/docs/compliance/SECURITY-FAQ.md
+++ b/docs/compliance/SECURITY-FAQ.md
@@ -68,7 +68,7 @@ e.g. Kubernetes projected tokens — is a roadmap item.)
 **Do you support MFA?**
 Yes — per-user opt-in **TOTP** (RFC 6238) second factor with a two-step login,
 single-use recovery codes, and the TOTP secret encrypted at rest (ADR-034).
-WebAuthn/passkeys and admin-enforced MFA policy are on the roadmap. Password
+A deployment can mandate MFA for interactive login (`security.require_mfa`); WebAuthn/passkeys are on the roadmap. Password
 policy, short-lived sessions with an absolute lifetime ceiling, and first-login
 password-change enforcement are also shipped.
 
@@ -133,7 +133,7 @@ issues. See [`../SECURITY.md`](../SECURITY.md) for details.
 
 We would rather tell you these up front than have you find them:
 
-- **WebAuthn / passkeys** and admin-enforced MFA policy — roadmap (TOTP MFA itself is shipped, ADR-034).
+- **WebAuthn / passkeys** — roadmap. (TOTP MFA is shipped and can be mandated deployment-wide via `security.require_mfa`, ADR-034.)
 - **Audit-log tamper-evidence** (cryptographic chaining / WORM) — roadmap;
   integrity today relies on operator-controlled PostgreSQL.
 - **Automated purge schedulers** for soft-deleted records — config-present, not

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -243,6 +243,10 @@ type SecurityConfig struct {
 	EnableFilePermissionCheck  bool `yaml:"enable_file_permission_check"`
 	AutoFixFilePermissions     bool `yaml:"auto_fix_file_permissions"`
 	AllowUnsafeFilePermissions bool `yaml:"allow_unsafe_file_permissions"`
+	// RequireMFA mandates TOTP MFA for interactive login: a session-authenticated
+	// user without MFA enabled is confined to the MFA-enrolment endpoints until
+	// they enrol. Non-interactive credentials (PAT/machine/OIDC) are exempt.
+	RequireMFA bool `yaml:"require_mfa"`
 }
 
 type SoftDeleteConfig struct {

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -136,6 +136,9 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		// Confine restricted (must-change-password) sessions to the password-change
 		// allowlist (ADR-025).
 		r.Use(customMiddleware.EnforceAccountRestriction)
+		// When the deployment mandates MFA, confine interactive sessions without
+		// MFA to the enrolment endpoints (security.require_mfa). No-op when off.
+		r.Use(customMiddleware.EnforceMFAEnrollment(cfg.Security.RequireMFA))
 
 		// Self-service account endpoints (My Account). Authenticated but not
 		// permission-gated — every user manages their own profile, password,

--- a/server/middleware/auth.go
+++ b/server/middleware/auth.go
@@ -58,6 +58,11 @@ type UserContext struct {
 	// requests and "user" otherwise.
 	MachineIdentityID *uint  `json:"machine_identity_id,omitempty"`
 	ActorType         string `json:"actor_type,omitempty"`
+	// MFAEnabled mirrors the user's TOTP-MFA flag; SessionAuth is true only for an
+	// interactive session token (false for PAT / machine / OIDC). Together they
+	// drive EnforceMFAEnrollment, which must not confine non-interactive automation.
+	MFAEnabled  bool `json:"-"`
+	SessionAuth bool `json:"-"`
 }
 
 // ActorKind returns the principal's actor type ("user" or "machine_identity"),
@@ -307,6 +312,45 @@ func EnforceAccountRestriction(next http.Handler) http.Handler {
 	})
 }
 
+// mfaEnrollAllowedSuffixes are the only endpoints an interactive user who must
+// still enrol MFA (the security.require_mfa policy is on) may reach, beyond logout.
+var mfaEnrollAllowedSuffixes = []string{
+	"/auth/mfa/enroll",
+	"/auth/mfa/activate",
+	"/auth/profile",
+}
+
+// EnforceMFAEnrollment confines an interactive (session-authenticated) human user
+// who has not enabled MFA to the MFA-enrolment endpoints when the deployment
+// requires MFA (security.require_mfa). Non-interactive credentials — personal
+// access tokens, machine tokens, OIDC — are deliberately exempt so automation is
+// not broken; password-restricted sessions are handled first by
+// EnforceAccountRestriction. Applied after Authentication in the authed group.
+func EnforceMFAEnrollment(requireMFA bool) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			userCtx := GetUserFromContext(r.Context())
+			if !requireMFA || userCtx == nil || !userCtx.SessionAuth || userCtx.MFAEnabled {
+				next.ServeHTTP(w, r)
+				return
+			}
+			for _, suffix := range mfaEnrollAllowedSuffixes {
+				if strings.HasSuffix(r.URL.Path, suffix) {
+					next.ServeHTTP(w, r)
+					return
+				}
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusForbidden)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"error":   "MFAEnrollmentRequired",
+				"message": "This deployment requires multi-factor authentication. Enrol MFA to continue.",
+				"code":    http.StatusForbidden,
+			})
+		})
+	}
+}
+
 // ScopeGlobal always resolves to the global scope.
 func ScopeGlobal(_ *http.Request, _ *core.KeyorixCore) (core.Scope, error) {
 	return core.Scope{}, nil
@@ -543,14 +587,16 @@ func validateToken(ctx context.Context, validator sessionValidator, token string
 	// Route by prefix: PATs authenticate AS their owning user, resolving to the same
 	// UserContext shape as a session — so authorization downstream is identical.
 	var (
-		user      *models.User
-		roleNames []string
-		err       error
+		user       *models.User
+		roleNames  []string
+		err        error
+		viaSession bool
 	)
 	if strings.HasPrefix(token, patTokenPrefix) {
 		user, roleNames, err = validator.ValidatePATToken(ctx, token)
 	} else {
 		user, roleNames, err = validator.ValidateSessionToken(ctx, token)
+		viaSession = true
 	}
 	if err != nil {
 		return nil, err
@@ -563,6 +609,8 @@ func validateToken(ctx context.Context, validator sessionValidator, token string
 		ActorType:    core.ActorTypeUser,
 		AccountState: core.NormalizeAccountState(user.AccountState),
 		Restricted:   core.AccountRestricted(user.AccountState),
+		MFAEnabled:   user.MFAEnabled,
+		SessionAuth:  viaSession,
 	}, nil
 }
 

--- a/server/middleware/mfa_enforcement_test.go
+++ b/server/middleware/mfa_enforcement_test.go
@@ -1,0 +1,70 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEnforceMFAEnrollment(t *testing.T) {
+	nextCalled := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	run := func(requireMFA bool, userCtx *UserContext, path string) *httptest.ResponseRecorder {
+		nextCalled = false
+		h := EnforceMFAEnrollment(requireMFA)(next)
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		if userCtx != nil {
+			req = req.WithContext(context.WithValue(req.Context(), userContextKey, userCtx))
+		}
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, req)
+		return rr
+	}
+
+	sessionNoMFA := &UserContext{UserID: 1, ActorType: core.ActorTypeUser, SessionAuth: true, MFAEnabled: false}
+
+	t.Run("policy off: passes through", func(t *testing.T) {
+		assert.Equal(t, http.StatusOK, run(false, sessionNoMFA, "/api/v1/secrets").Code)
+		assert.True(t, nextCalled)
+	})
+
+	t.Run("policy on, session without MFA: blocked on a normal endpoint", func(t *testing.T) {
+		rr := run(true, sessionNoMFA, "/api/v1/secrets")
+		assert.Equal(t, http.StatusForbidden, rr.Code)
+		assert.False(t, nextCalled)
+		assert.Contains(t, rr.Body.String(), "MFAEnrollmentRequired")
+	})
+
+	t.Run("policy on, session without MFA: may reach enrolment", func(t *testing.T) {
+		assert.Equal(t, http.StatusOK, run(true, sessionNoMFA, "/api/v1/auth/mfa/enroll").Code)
+		assert.True(t, nextCalled)
+		assert.Equal(t, http.StatusOK, run(true, sessionNoMFA, "/api/v1/auth/mfa/activate").Code)
+	})
+
+	t.Run("policy on, session WITH MFA: passes through", func(t *testing.T) {
+		ctx := &UserContext{UserID: 1, ActorType: core.ActorTypeUser, SessionAuth: true, MFAEnabled: true}
+		assert.Equal(t, http.StatusOK, run(true, ctx, "/api/v1/secrets").Code)
+		assert.True(t, nextCalled)
+	})
+
+	t.Run("policy on, PAT (non-interactive) without MFA: EXEMPT", func(t *testing.T) {
+		pat := &UserContext{UserID: 1, ActorType: core.ActorTypeUser, SessionAuth: false, MFAEnabled: false}
+		assert.Equal(t, http.StatusOK, run(true, pat, "/api/v1/secrets").Code)
+		assert.True(t, nextCalled, "PAT/automation must not be confined by the MFA policy")
+	})
+
+	t.Run("policy on, machine identity: EXEMPT", func(t *testing.T) {
+		mid := uint(5)
+		machine := &UserContext{MachineIdentityID: &mid, ActorType: core.ActorTypeMachine, SessionAuth: false}
+		assert.Equal(t, http.StatusOK, run(true, machine, "/api/v1/secrets").Code)
+		assert.True(t, nextCalled)
+	})
+}


### PR DESCRIPTION
## Summary

Turns the opt-in TOTP MFA (ADR-034, #99) into something a **deployment can mandate** — the natural next step in the MFA story and the NIS2 Art. 21(2)(j) / ENS `op.acc.6` "MFA where appropriate" *enforcement*.

With `security.require_mfa: true`, an **interactive (session-authenticated)** human user who hasn't enabled MFA is confined to the MFA-enrolment endpoints (+ logout) until they enrol — mirroring the existing ADR-025 password-change confinement.

## Design

- New `EnforceMFAEnrollment(requireMFA)` middleware in the authed group, right after `EnforceAccountRestriction` (so password-change is handled first, then MFA-enrolment). Allowlist: `/auth/mfa/enroll`, `/auth/mfa/activate`, `/auth/profile`.
- `UserContext` gains `MFAEnabled` (from the user row) and `SessionAuth` (true only for a session token, false for PAT/machine/OIDC).
- **The key safety property:** the policy applies **only to interactive sessions**. Personal access tokens, machine tokens, and OIDC federation are **EXEMPT** — so CI/automation is never broken by a require-MFA deployment. (The auth router resolves PATs and sessions to the same `UserContext` shape with no distinguisher; this PR adds the `SessionAuth` marker precisely to make that distinction.)
- `security.require_mfa` config flag, **default off** → zero behaviour change for existing deployments.

## Tests

`TestEnforceMFAEnrollment`: policy off → pass; on + session-without-MFA → `403 MFAEnrollmentRequired` (enrolment endpoints still reachable); on + session-with-MFA → pass; **on + PAT → EXEMPT**; **on + machine → EXEMPT**. Full middleware/http/config suites + `go vet` green.

## Docs

NIS2/ISO controls, Security FAQ, and ADR-034 updated: deployment-wide MFA mandate is now available (WebAuthn/passkeys + per-project policy remain Roadmap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)