### PR TITLE
feat(auth): per-project MFA policy (ADR-037)

### DIFF
--- a/docs/adr-037-per-project-mfa-policy.md
+++ b/docs/adr-037-per-project-mfa-policy.md
@@ -1,0 +1,74 @@
+# ADR-037: Per-project MFA policy
+
+**Status:** Accepted
+**Date:** 2026-06-12
+
+## Context
+
+ADR-034 added a deployment-wide MFA mandate (`security.require_mfa`): when on, any
+interactive session without a second factor is confined to the enrolment endpoints
+until the user enrols. That is all-or-nothing — it cannot express "the
+**production** project requires MFA, but the sandbox doesn't." Teams running a
+single Keyorix install across projects of differing sensitivity need step-up
+assurance scoped to the sensitive projects, without forcing MFA on everyone.
+
+## Decision
+
+Add a **per-project MFA requirement** (`Project.RequireMFA`). When set, an
+interactive session **without a second factor** is denied access to that project's
+scoped resources, even when the deployment-wide policy is off.
+
+- **Model:** `Project.RequireMFA bool` (additive column, default false). Toggled
+  via `PUT /api/v1/projects/{id}` with `{"require_mfa": true|false}` (gated by the
+  same `secrets.write`-on-project authorization as other project edits); a nil
+  field leaves it unchanged. The toggle is audited
+  (`project.mfa_requirement_enabled|disabled`).
+- **Enforcement** lives at the HTTP authorization layer, where the request's
+  interactivity is known. `ProjectMFABlocked` denies (403 `ProjectMFARequired`)
+  iff the caller is an **interactive session** (`SessionAuth`) **without** a second
+  factor **and** the resolved scope's project requires MFA. It is applied:
+  - in `RequireScopedPermission` (covers all secret read/write/version/list and
+    other project-scoped middleware routes), and
+  - in the handful of endpoints that authorize in-handler rather than via that
+    middleware — dynamic-secrets issue/list/revoke (ADR-035) and rotation-policy
+    create — so the policy is uniform across every project-scoped path.
+- **Exemptions mirror the deployment-wide policy:** non-interactive credentials
+  (PAT / machine token / OIDC) are **exempt** — they cannot carry a second factor
+  and blocking them would break automation. A session whose user already has TOTP
+  or a passkey passes (their session is inherently second-factor-backed). The
+  project lookup is skipped entirely unless the caller is interactive-without-MFA,
+  so MFA-backed and automated callers pay no cost.
+
+## Why the HTTP layer, not core `Authorize`
+
+`AuthorizePrincipal` cannot distinguish an interactive session from a PAT — both
+resolve to actor type "user" — and it has no `SessionAuth` signal. The
+interactivity marker lives only on the request's `UserContext`. So the policy is
+enforced where that context exists (the authorization middleware and in-handler
+authorizers), consistent with where `EnforceMFAEnrollment` already runs.
+
+## Relationship to the deployment-wide policy
+
+The two compose: `security.require_mfa` is a floor applied to every endpoint via
+`EnforceMFAEnrollment`; the per-project flag is an additional gate on a specific
+project's resources. When the global policy is on, an un-enrolled user never
+reaches a scoped route anyway; when it is off, the per-project flag still protects
+the projects that opt in. A passkey (ADR-036) satisfies either requirement.
+
+## Verification
+
+Core tests: `UpdateProject` toggles `RequireMFA` (and a nil leaves it unchanged),
+`ProjectRequiresMFA` reflects it, the toggle audits exactly once (no re-audit on a
+no-op), and a missing project errors. Middleware tests over a real store:
+interactive-without-MFA is blocked on an MFA-required project but not on an open
+one; an MFA-backed session passes; PAT and machine identities are exempt; global
+scope (projectID 0) is never subject to a project policy. `make build` + full
+suite + `go vet` green.
+
+## Deferred
+
+Per-environment MFA granularity; requiring a *fresh* re-authentication / step-up
+within an active session (today "has a second factor" suffices, since every
+MFA-enabled login is second-factor-verified); a project-level minimum factor
+strength (e.g. require a phishing-resistant passkey, not just TOTP); surfacing the
+flag in the CLI/gRPC project commands.

--- a/docs/compliance/NIS2-DORA-ISO-CONTROLS.md
+++ b/docs/compliance/NIS2-DORA-ISO-CONTROLS.md
@@ -133,7 +133,10 @@ authentication).
   rest), and **phishing-resistant WebAuthn / passkeys** (origin-bound public-key
   assertions, no exportable shared secret, FIDO clone detection). Either factor
   satisfies a `security.require_mfa` mandate (interactive sessions without a second
-  factor are confined to enrolment; PAT / machine / OIDC are exempt).
+  factor are confined to enrolment; PAT / machine / OIDC are exempt). The mandate
+  is enforceable **deployment-wide or per-project** (ADR-037: a sensitive project
+  can require MFA even when the global policy is off), giving risk-proportionate
+  step-up.
 
 **Status:** Shipped.
 

--- a/internal/core/catalog.go
+++ b/internal/core/catalog.go
@@ -25,8 +25,10 @@ func (c *KeyorixCore) GetProject(ctx context.Context, id uint) (*models.Project,
 	return c.storage.GetProject(ctx, id)
 }
 
-// UpdateProject updates an existing project's name and description.
-func (c *KeyorixCore) UpdateProject(ctx context.Context, id uint, name, description string) (*models.Project, error) {
+// UpdateProject updates an existing project's name and description, and — when
+// requireMFA is non-nil — its per-project MFA requirement (ADR-037). A nil
+// requireMFA leaves the flag unchanged (backward-compatible).
+func (c *KeyorixCore) UpdateProject(ctx context.Context, id uint, name, description string, requireMFA *bool) (*models.Project, error) {
 	if name == "" {
 		return nil, fmt.Errorf("project name is required")
 	}
@@ -34,9 +36,36 @@ func (c *KeyorixCore) UpdateProject(ctx context.Context, id uint, name, descript
 	if err != nil {
 		return nil, err
 	}
+	mfaChanged := requireMFA != nil && *requireMFA != project.RequireMFA
 	project.Name = name
 	project.Description = description
-	return c.storage.UpdateProject(ctx, project)
+	if requireMFA != nil {
+		project.RequireMFA = *requireMFA
+	}
+	updated, err := c.storage.UpdateProject(ctx, project)
+	if err != nil {
+		return nil, err
+	}
+	if mfaChanged {
+		pid := id
+		state := "disabled"
+		if *requireMFA {
+			state = "enabled"
+		}
+		c.writeAuditEventFull(ctx, "project.mfa_requirement_"+state, nil, nil, &pid, "",
+			fmt.Sprintf("per-project MFA requirement %s for project %q", state, updated.Name))
+	}
+	return updated, nil
+}
+
+// ProjectRequiresMFA reports whether the project enforces a per-project MFA
+// requirement (ADR-037). A missing project is treated as not requiring MFA.
+func (c *KeyorixCore) ProjectRequiresMFA(ctx context.Context, projectID uint) (bool, error) {
+	project, err := c.storage.GetProject(ctx, projectID)
+	if err != nil {
+		return false, err
+	}
+	return project.RequireMFA, nil
 }
 
 // DeleteProject deletes a project by ID.

--- a/internal/core/project_mfa_test.go
+++ b/internal/core/project_mfa_test.go
@@ -1,0 +1,78 @@
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func newProjectMFATestCore(t *testing.T) (*KeyorixCore, *gorm.DB) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.Project{}, &models.AuditEvent{}))
+	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "alpha"}).Error)
+	return NewKeyorixCore(store.NewLocalStorage(db)), db
+}
+
+func boolPtr(b bool) *bool { return &b }
+
+func TestProjectMFA_ToggleAndQuery(t *testing.T) {
+	c, _ := newProjectMFATestCore(t)
+	ctx := context.Background()
+
+	// Default: a project does not require MFA.
+	req, err := c.ProjectRequiresMFA(ctx, 1)
+	require.NoError(t, err)
+	assert.False(t, req)
+
+	// Enable per-project MFA via UpdateProject.
+	p, err := c.UpdateProject(ctx, 1, "alpha", "", boolPtr(true))
+	require.NoError(t, err)
+	assert.True(t, p.RequireMFA)
+	req, _ = c.ProjectRequiresMFA(ctx, 1)
+	assert.True(t, req)
+
+	// A nil requireMFA leaves the flag unchanged (backward-compatible update).
+	p, err = c.UpdateProject(ctx, 1, "alpha-renamed", "desc", nil)
+	require.NoError(t, err)
+	assert.True(t, p.RequireMFA, "nil must not clear the flag")
+	assert.Equal(t, "alpha-renamed", p.Name)
+
+	// Disable it again.
+	p, err = c.UpdateProject(ctx, 1, "alpha-renamed", "desc", boolPtr(false))
+	require.NoError(t, err)
+	assert.False(t, p.RequireMFA)
+}
+
+func TestProjectMFA_ToggleIsAudited(t *testing.T) {
+	c, db := newProjectMFATestCore(t)
+	ctx := context.Background()
+
+	_, err := c.UpdateProject(ctx, 1, "alpha", "", boolPtr(true))
+	require.NoError(t, err)
+
+	var count int64
+	require.NoError(t, db.Model(&models.AuditEvent{}).
+		Where("event_type = ?", "project.mfa_requirement_enabled").Count(&count).Error)
+	assert.Equal(t, int64(1), count)
+
+	// A no-op (already-enabled) update writes no new audit row.
+	_, err = c.UpdateProject(ctx, 1, "alpha", "", boolPtr(true))
+	require.NoError(t, err)
+	require.NoError(t, db.Model(&models.AuditEvent{}).
+		Where("event_type = ?", "project.mfa_requirement_enabled").Count(&count).Error)
+	assert.Equal(t, int64(1), count, "an unchanged flag must not re-audit")
+}
+
+func TestProjectMFA_MissingProject(t *testing.T) {
+	c, _ := newProjectMFATestCore(t)
+	_, err := c.ProjectRequiresMFA(context.Background(), 999)
+	require.Error(t, err)
+}

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -10,9 +10,14 @@ type Project struct {
 	ID          uint   `gorm:"primaryKey"`
 	Name        string `gorm:"uniqueIndex;not null"`
 	Description string
-	CreatedAt   time.Time
-	UpdatedAt   time.Time
-	DeletedAt   gorm.DeletedAt `gorm:"index"` // soft delete
+	// RequireMFA, when true, denies interactive (session-authenticated) callers
+	// without a second factor access to this project's scoped resources, even when
+	// the deployment-wide security.require_mfa policy is off (ADR-037). Non-
+	// interactive credentials (PAT / machine / OIDC) are exempt, like the global policy.
+	RequireMFA bool `gorm:"default:false"`
+	CreatedAt  time.Time
+	UpdatedAt  time.Time
+	DeletedAt  gorm.DeletedAt `gorm:"index"` // soft delete
 }
 
 type Environment struct {

--- a/server/http/handlers/catalog.go
+++ b/server/http/handlers/catalog.go
@@ -127,12 +127,13 @@ func (h *CatalogHandler) UpdateProject(w http.ResponseWriter, r *http.Request) {
 	var body struct {
 		Name        string `json:"name"`
 		Description string `json:"description"`
+		RequireMFA  *bool  `json:"require_mfa"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		sendError(w, "InvalidJSON", "Invalid request body", http.StatusBadRequest, nil)
 		return
 	}
-	project, err := h.coreService.UpdateProject(r.Context(), uint(id), body.Name, body.Description)
+	project, err := h.coreService.UpdateProject(r.Context(), uint(id), body.Name, body.Description, body.RequireMFA)
 	if err != nil {
 		sendError(w, "Error", err.Error(), http.StatusInternalServerError, nil)
 		return

--- a/server/http/handlers/dynamic_secrets.go
+++ b/server/http/handlers/dynamic_secrets.go
@@ -26,13 +26,31 @@ func NewDynamicSecretHandler(coreService *core.KeyorixCore) *DynamicSecretHandle
 	return &DynamicSecretHandler{coreService: coreService}
 }
 
-func (h *DynamicSecretHandler) authorize(r *http.Request, perm string, scope core.Scope) bool {
+// authorize checks both RBAC and the per-project MFA policy (ADR-037). It returns
+// the failure mode so the caller can send the right response: permission denied
+// vs. MFA required.
+func (h *DynamicSecretHandler) authorize(r *http.Request, perm string, scope core.Scope) (ok bool, mfaBlocked bool) {
 	userCtx := middleware.GetUserFromContext(r.Context())
 	if userCtx == nil {
-		return false
+		return false, false
 	}
 	allowed, err := h.coreService.AuthorizePrincipal(r.Context(), userCtx.ActorKind(), userCtx.PrincipalID(), perm, scope)
-	return err == nil && allowed
+	if err != nil || !allowed {
+		return false, false
+	}
+	if middleware.ProjectMFABlocked(r, h.coreService, scope.ProjectID) {
+		return false, true
+	}
+	return true, false
+}
+
+// denyAuthz writes the appropriate response for a failed authorize().
+func (h *DynamicSecretHandler) denyAuthz(w http.ResponseWriter, mfaBlocked bool) {
+	if mfaBlocked {
+		middleware.WriteProjectMFARequired(w)
+		return
+	}
+	sendError(w, "Forbidden", "Insufficient permissions", http.StatusForbidden, nil)
 }
 
 // CreateConfig handles POST /api/v1/dynamic-secrets/configs
@@ -56,8 +74,8 @@ func (h *DynamicSecretHandler) CreateConfig(w http.ResponseWriter, r *http.Reque
 		return
 	}
 	scope := core.Scope{ProjectID: body.ProjectID, EnvironmentID: body.EnvironmentID}
-	if !h.authorize(r, "secrets.write", scope) {
-		sendError(w, "Forbidden", "Insufficient permissions", http.StatusForbidden, nil)
+	if ok, mfaBlocked := h.authorize(r, "secrets.write", scope); !ok {
+		h.denyAuthz(w, mfaBlocked)
 		return
 	}
 	cfg, err := h.coreService.CreateDynamicSecretConfig(r.Context(), &core.CreateDynamicSecretConfigRequest{
@@ -84,8 +102,8 @@ func (h *DynamicSecretHandler) ListConfigs(w http.ResponseWriter, r *http.Reques
 	if !ok {
 		return
 	}
-	if !h.authorize(r, "secrets.read", core.Scope{ProjectID: projectID, EnvironmentID: environmentID}) {
-		sendError(w, "Forbidden", "Insufficient permissions", http.StatusForbidden, nil)
+	if ok, mfaBlocked := h.authorize(r, "secrets.read", core.Scope{ProjectID: projectID, EnvironmentID: environmentID}); !ok {
+		h.denyAuthz(w, mfaBlocked)
 		return
 	}
 	cfgs, err := h.coreService.ListDynamicSecretConfigs(r.Context(), projectID, environmentID)
@@ -163,8 +181,8 @@ func (h *DynamicSecretHandler) RevokeLease(w http.ResponseWriter, r *http.Reques
 		sendError(w, "NotFound", "Lease not found", http.StatusNotFound, nil)
 		return
 	}
-	if !h.authorize(r, "secrets.write", core.Scope{ProjectID: lease.ProjectID, EnvironmentID: lease.EnvironmentID}) {
-		sendError(w, "Forbidden", "Insufficient permissions", http.StatusForbidden, nil)
+	if ok, mfaBlocked := h.authorize(r, "secrets.write", core.Scope{ProjectID: lease.ProjectID, EnvironmentID: lease.EnvironmentID}); !ok {
+		h.denyAuthz(w, mfaBlocked)
 		return
 	}
 	if err := h.coreService.RevokeLease(r.Context(), leaseID, userCtx.UserID, "manual"); err != nil {
@@ -188,8 +206,8 @@ func (h *DynamicSecretHandler) loadAuthorizedConfig(w http.ResponseWriter, r *ht
 		sendError(w, "NotFound", "Config not found", http.StatusNotFound, nil)
 		return nil, false
 	}
-	if !h.authorize(r, perm, core.Scope{ProjectID: cfg.ProjectID, EnvironmentID: cfg.EnvironmentID}) {
-		sendError(w, "Forbidden", "Insufficient permissions", http.StatusForbidden, nil)
+	if ok, mfaBlocked := h.authorize(r, perm, core.Scope{ProjectID: cfg.ProjectID, EnvironmentID: cfg.EnvironmentID}); !ok {
+		h.denyAuthz(w, mfaBlocked)
 		return nil, false
 	}
 	return cfg, true

--- a/server/http/handlers/project_mfa_createsecret_test.go
+++ b/server/http/handlers/project_mfa_createsecret_test.go
@@ -1,0 +1,77 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/keyorixhq/keyorix/server/middleware"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// TestCreateSecret_PerProjectMFAGate is a regression guard for ADR-037: the
+// in-handler-authorized POST /secrets must enforce the per-project MFA policy,
+// exactly like the scoped-permission middleware. (A security review found this
+// call site originally missed the gate.)
+func TestCreateSecret_PerProjectMFAGate(t *testing.T) {
+	require.NoError(t, i18n.Initialize(&config.Config{Locale: config.LocaleConfig{Language: "en", FallbackLanguage: "en"}}))
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.User{}, &models.Role{}, &models.UserRole{},
+		&models.Permission{}, &models.RolePermission{}, &models.Group{}, &models.GroupRole{},
+		&models.UserGroup{}, &models.Project{}, &models.Environment{}, &models.AuditEvent{}))
+
+	// A global admin user (bypasses the RBAC check, so we reach the MFA gate).
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "alice", AccountState: "active"}).Error)
+	adminRole := &models.Role{Name: "admin"}
+	require.NoError(t, db.Create(adminRole).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: adminRole.ID}).Error)
+
+	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "needs-mfa", RequireMFA: true}).Error)
+	require.NoError(t, db.Create(&models.Project{ID: 2, Name: "open"}).Error)
+	require.NoError(t, db.Create(&models.Environment{ID: 10, ProjectID: 1, Name: "prod"}).Error)
+	require.NoError(t, db.Create(&models.Environment{ID: 20, ProjectID: 2, Name: "prod"}).Error)
+
+	coreService := core.NewKeyorixCore(store.NewLocalStorage(db))
+	handler, err := NewSecretHandler(coreService)
+	require.NoError(t, err)
+
+	// Interactive session, no second factor.
+	userCtx := &middleware.UserContext{UserID: 1, ActorType: core.ActorTypeUser, SessionAuth: true, MFAEnabled: false}
+
+	post := func(projectID, environmentID uint) *httptest.ResponseRecorder {
+		body, _ := json.Marshal(map[string]interface{}{
+			"name": "API_KEY", "value": "v", "project_id": projectID,
+			"environment_id": environmentID, "type": "static",
+		})
+		r := httptest.NewRequest(http.MethodPost, "/api/v1/secrets", bytes.NewReader(body))
+		r = r.WithContext(context.WithValue(r.Context(), middleware.GetUserContextKey(), userCtx))
+		rr := httptest.NewRecorder()
+		handler.CreateSecret(rr, r)
+		return rr
+	}
+
+	t.Run("MFA-required project blocks an interactive no-MFA user", func(t *testing.T) {
+		rr := post(1, 10)
+		assert.Equal(t, http.StatusForbidden, rr.Code)
+		assert.Contains(t, rr.Body.String(), "ProjectMFARequired")
+	})
+
+	t.Run("open project does not trip the MFA gate", func(t *testing.T) {
+		rr := post(2, 20)
+		assert.NotContains(t, rr.Body.String(), "ProjectMFARequired",
+			"a project without require_mfa must not be blocked by the policy")
+	})
+}

--- a/server/http/handlers/rotation_policies_handler.go
+++ b/server/http/handlers/rotation_policies_handler.go
@@ -141,6 +141,11 @@ func (h *RotationPolicyHandler) Create(w http.ResponseWriter, r *http.Request) {
 		h.sendError(w, "Forbidden", "Insufficient permissions", http.StatusForbidden, nil)
 		return
 	}
+	// Per-project MFA policy (ADR-037), same as the scoped-permission middleware.
+	if middleware.ProjectMFABlocked(r, h.coreService, scope.ProjectID) {
+		middleware.WriteProjectMFARequired(w)
+		return
+	}
 
 	req := &core.CreateRotationPolicyRequest{
 		Name:            reqBody.Name,

--- a/server/http/handlers/secrets_crud.go
+++ b/server/http/handlers/secrets_crud.go
@@ -55,6 +55,13 @@ func (h *SecretHandler) CreateSecret(w http.ResponseWriter, r *http.Request) {
 		h.sendError(w, "Forbidden", "Insufficient permissions", http.StatusForbidden, nil)
 		return
 	}
+	// Per-project MFA policy (ADR-037): create carries no path scope for the
+	// scoped-permission middleware, so enforce it here too (same as the other
+	// in-handler-authorized mutations).
+	if middleware.ProjectMFABlocked(r, h.coreService, scope.ProjectID) {
+		middleware.WriteProjectMFARequired(w)
+		return
+	}
 
 	req := &core.CreateSecretRequest{
 		Name:          reqBody.Name,

--- a/server/middleware/auth.go
+++ b/server/middleware/auth.go
@@ -266,6 +266,12 @@ func RequireScopedPermission(permission string, resolve ScopeResolver) func(http
 				forbiddenResponse(w, "Insufficient permissions")
 				return
 			}
+			// Per-project MFA policy (ADR-037): deny an interactive session without a
+			// second factor access to a project that requires MFA.
+			if ProjectMFABlocked(r, cs, scope.ProjectID) {
+				projectMFARequiredResponse(w)
+				return
+			}
 			next.ServeHTTP(w, r)
 		})
 	}
@@ -633,6 +639,42 @@ func forbiddenResponse(w http.ResponseWriter, message string) {
 	w.WriteHeader(http.StatusForbidden)
 	_ = json.NewEncoder(w).Encode(map[string]interface{}{
 		"error": "Forbidden", "message": message, "code": http.StatusForbidden,
+	})
+}
+
+// ProjectMFABlocked reports whether the request must be denied by a project's
+// per-project MFA policy (ADR-037): true only when the caller is an interactive
+// session WITHOUT a second factor and the scoped project requires MFA. The
+// project lookup is skipped unless the caller could actually be subject to the
+// policy, so MFA-backed and non-interactive (PAT / machine / OIDC) callers pay no
+// cost and stay exempt — consistent with EnforceMFAEnrollment. Handlers that
+// authorize in-handler (not via RequireScopedPermission) call this too, so the
+// policy is enforced uniformly across every project-scoped path.
+func ProjectMFABlocked(r *http.Request, cs *core.KeyorixCore, projectID uint) bool {
+	if projectID == 0 || cs == nil {
+		return false
+	}
+	userCtx := GetUserFromContext(r.Context())
+	if userCtx == nil || !userCtx.SessionAuth || userCtx.MFAEnabled {
+		return false
+	}
+	req, err := cs.ProjectRequiresMFA(r.Context(), projectID)
+	return err == nil && req
+}
+
+// WriteProjectMFARequired writes the 403 ProjectMFARequired response (exported so
+// in-handler authorizers can emit the same body as the scoped-permission path).
+func WriteProjectMFARequired(w http.ResponseWriter) { projectMFARequiredResponse(w) }
+
+// projectMFARequiredResponse sends a 403 with a distinct code so the client can
+// prompt the user to enrol a second factor (ADR-037 per-project MFA policy).
+func projectMFARequiredResponse(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusForbidden)
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"error":   "ProjectMFARequired",
+		"message": "This project requires multi-factor authentication. Enrol a second factor to access it.",
+		"code":    http.StatusForbidden,
 	})
 }
 

--- a/server/middleware/project_mfa_test.go
+++ b/server/middleware/project_mfa_test.go
@@ -1,0 +1,67 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func newProjectMFACore(t *testing.T) *core.KeyorixCore {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.Project{}, &models.AuditEvent{}))
+	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "needs-mfa", RequireMFA: true}).Error)
+	require.NoError(t, db.Create(&models.Project{ID: 2, Name: "open"}).Error)
+	return core.NewKeyorixCore(store.NewLocalStorage(db))
+}
+
+func reqWithUser(u *UserContext) *http.Request {
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/secrets", nil)
+	if u != nil {
+		r = r.WithContext(context.WithValue(r.Context(), userContextKey, u))
+	}
+	return r
+}
+
+func TestProjectMFABlocked(t *testing.T) {
+	cs := newProjectMFACore(t)
+	sessionNoMFA := &UserContext{UserID: 1, ActorType: core.ActorTypeUser, SessionAuth: true, MFAEnabled: false}
+
+	t.Run("interactive, no MFA, project requires MFA: BLOCKED", func(t *testing.T) {
+		assert.True(t, ProjectMFABlocked(reqWithUser(sessionNoMFA), cs, 1))
+	})
+
+	t.Run("interactive, no MFA, project does NOT require MFA: allowed", func(t *testing.T) {
+		assert.False(t, ProjectMFABlocked(reqWithUser(sessionNoMFA), cs, 2))
+	})
+
+	t.Run("interactive WITH MFA: allowed even on MFA-required project", func(t *testing.T) {
+		withMFA := &UserContext{UserID: 1, ActorType: core.ActorTypeUser, SessionAuth: true, MFAEnabled: true}
+		assert.False(t, ProjectMFABlocked(reqWithUser(withMFA), cs, 1))
+	})
+
+	t.Run("PAT (non-interactive) without MFA: EXEMPT", func(t *testing.T) {
+		pat := &UserContext{UserID: 1, ActorType: core.ActorTypeUser, SessionAuth: false, MFAEnabled: false}
+		assert.False(t, ProjectMFABlocked(reqWithUser(pat), cs, 1), "automation must not be blocked by per-project MFA")
+	})
+
+	t.Run("machine identity: EXEMPT", func(t *testing.T) {
+		mid := uint(5)
+		machine := &UserContext{MachineIdentityID: &mid, ActorType: core.ActorTypeMachine, SessionAuth: false}
+		assert.False(t, ProjectMFABlocked(reqWithUser(machine), cs, 1))
+	})
+
+	t.Run("global scope (projectID 0): not subject to any project policy", func(t *testing.T) {
+		assert.False(t, ProjectMFABlocked(reqWithUser(sessionNoMFA), cs, 0))
+	})
+}


### PR DESCRIPTION
## Summary

Extends the deployment-wide `security.require_mfa` mandate (ADR-034) to **per-project granularity**: a sensitive project (e.g. `production`) can require a second factor even when the global policy is off — risk-proportionate step-up across a single install. Completes the MFA-policy line of work (the "2" in the founder's "3 1 2" queue).

## What's in it

- **Model:** `Project.RequireMFA` (additive column, default false), toggled via `PUT /api/v1/projects/{id}` with `{"require_mfa": true|false}` (gated by the same `secrets.write`-on-project authz as other project edits); a nil field leaves it unchanged. The toggle is audited (`project.mfa_requirement_enabled|disabled`), exactly once, with no re-audit on a no-op.
- **Enforcement** (`middleware.ProjectMFABlocked`): denies **403 `ProjectMFARequired`** iff the caller is an **interactive session** (`SessionAuth`) **without** a second factor **and** the resolved scope's project requires MFA. Applied in `RequireScopedPermission` (all secret read/write/version/list + project-scoped routes) **and** in the in-handler authorizers — dynamic-secrets issue/list/revoke (ADR-035) and rotation-policy create — so the policy is uniform across every project-scoped path.
- **Exemptions mirror the global policy:** PAT / machine / OIDC are exempt (they can't carry a second factor; blocking them breaks automation); an MFA-backed session passes (it's inherently second-factor-verified). The project lookup is **skipped unless the caller is interactive-without-MFA**, so MFA-backed and automated callers pay no cost.

## Design note: why the HTTP layer, not core `Authorize`

`AuthorizePrincipal` can't distinguish an interactive session from a PAT — both resolve to actor type `"user"` — and has no `SessionAuth` signal. That marker lives only on the request `UserContext`, so enforcement sits where that context exists (the authz middleware + in-handler authorizers), consistent with where `EnforceMFAEnrollment` already runs. A passkey (ADR-036) or TOTP both satisfy the requirement.

## Testing

Core tests: `UpdateProject` toggles `RequireMFA` (nil leaves it unchanged), `ProjectRequiresMFA` reflects it, the toggle audits once (no re-audit on no-op), missing project errors. Middleware tests over a real store: interactive-without-MFA blocked on an MFA-required project but not an open one; MFA-backed session passes; PAT + machine exempt; global scope (projectID 0) never subject. `make build` + full suite + `go vet` green.

See `docs/adr-037-per-project-mfa-policy.md`; NIS2 controls doc notes the per-project granularity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)