### PR TITLE
feat(crypto): pluggable KEK providers — password / file / env (ADR-038)

### DIFF
--- a/docs/adr-038-pluggable-key-providers.md
+++ b/docs/adr-038-pluggable-key-providers.md
@@ -1,0 +1,120 @@
+# ADR-038: Pluggable KEK providers
+
+**Status:** Accepted
+**Date:** 2026-06-12
+
+## Context
+
+Keyorix uses envelope encryption (ADR-004): a per-process **DEK** (data-encryption
+key) encrypts secrets/tokens, and the DEK is stored on disk wrapped by a **KEK**
+(key-encryption key). Until now the KEK was *always* derived from
+`KEYORIX_MASTER_PASSWORD` via PBKDF2-SHA256 (600 000 iterations) over an on-disk
+salt. That single, hard-coded source is a friction point for the deployments the
+certification track targets:
+
+- **Managed/HSM-backed keys.** ENS/ENISA and enterprise on-prem buyers frequently
+  require the KEK to come from a KMS or hardware module, not a passphrase a human
+  types or stores in an env var.
+- **Kubernetes-native delivery.** Operators want to mount the KEK from a CSI
+  secrets driver, a sealed/SOPS secret, or a KMS sidecar — i.e. supply raw key
+  material, not a password.
+
+We need to abstract *where the KEK comes from* without touching the proven DEK
+wrapping/data path, and without changing anything for existing deployments.
+
+## Decision
+
+Introduce a `crypto.KeyProvider` interface that sources the 32-byte KEK, selected
+by config. Wrapping/unwrapping the DEK with that KEK is unchanged.
+
+```go
+type KeyProvider interface {
+    KEK() ([]byte, error) // exactly 32 bytes; caller wipes it
+    Name() string
+}
+```
+
+Three providers ship (`internal/crypto`):
+
+- **`password`** (default) — `PasswordKeyProvider`: PBKDF2-SHA256, 600 000
+  iterations, over the same on-disk salt. **Byte-for-byte identical** to the
+  historical derivation, proven by a test that a fresh password-provider
+  `KeyManager` unwraps a DEK created by the legacy code path.
+- **`file`** — `FileKeyProvider`: reads raw key material from an operator-set path
+  (a mounted CSI/sealed secret, KMS sidecar output). Accepts 32 raw bytes, hex, or
+  base64.
+- **`env`** — `EnvKeyProvider`: reads the KEK (hex/base64) from a named env var's
+  value, for KMS/secret-manager injection.
+
+KMS- and TPM-backed providers are a **Tier-2 follow-up** implementing the same
+interface.
+
+### Config
+
+```yaml
+storage:
+  encryption:
+    enabled: true
+    dek_path: keys/dek.key
+    salt_path: keys/kek.salt
+    key_provider:
+      type: file            # password (default) | file | env
+      file_path: /etc/keyorix/kek.key   # type=file
+      env_var: KEYORIX_KEK              # type=env (value is hex/base64)
+```
+
+Absent / zero value = `password`. `KEYORIX_MASTER_PASSWORD` is required only for
+the password provider; with file/env the server and the `keyorix encryption`
+CLI start without it.
+
+### Where it plugs in
+
+The `KeyProvider` only *sources* the KEK; it carries no dependency on the cipher
+code, avoiding any import cycle. `encryption.Service.Initialize` builds the
+provider from config and sets it on the `KeyManager`; `KeyManager.deriveKEK`
+returns the provider's KEK (or, when no provider is set — e.g. a direct unit-test
+caller — the legacy passphrase+salt derivation). Both `Initialize` and the DEK
+rotation paths (`RotateDEKWithSweep`, `RotateDEK`) route through `deriveKEK`, so
+the same KEK source is used to wrap a rotated DEK.
+
+## Consequences
+
+- **Zero change for existing deployments.** The default path derives the identical
+  KEK and unwraps the existing `dek.key`. No re-encryption, no migration.
+- **DEK rotation is unchanged in meaning.** `keyorix encryption rotate` still
+  rotates the *DEK* and re-encrypts rows; under file/env it re-wraps the new DEK
+  with the externally-managed KEK. Rotating the **KEK itself** for file/env (swap
+  the key material, re-wrap the DEK) is an external/operator action and a Tier-2
+  concern.
+- **Trust model.** `file`/`env` providers consume operator-supplied key material;
+  the file path and env var are trusted configuration. The KEK is validated to be
+  exactly 32 bytes and wiped after the DEK is unwrapped, as before.
+
+### Note on package location
+
+The backlog placed this in `internal/crypto/`, and that is where the interface and
+providers live. The KEK-wrapping machinery remains in `internal/encryption/`
+(which now imports `internal/crypto`), keeping providers cipher-independent.
+
+## Verification
+
+- **Backward-compat (load-bearing):** a `PasswordKeyProvider` `KeyManager` unwraps
+  a DEK created by the legacy derivation; a wrong passphrase fails the GCM check.
+- **Byte-identity:** the provider's KEK equals `PBKDF2(passphrase, salt, 600000,
+  32, SHA-256)` for the same salt.
+- **File/env round-trips:** init → restart → same DEK; raw/hex/base64 accepted;
+  wrong-size and missing material rejected.
+- **Rotation under a provider:** rotating the DEK re-wraps with the provider KEK;
+  a fresh manager reads the rotated DEK.
+- **Service end-to-end:** a file-provider Service encrypts a value that a fresh
+  Service over the same files decrypts.
+
+`make build` + full suite + `go vet` green; the existing encryption suite is
+unchanged.
+
+## Deferred
+
+KMS providers (AWS KMS / GCP KMS / Azure Key Vault), TPM / OS-keychain, and
+Shamir-split KEK (the original ADR-010 "KeyProvider Tier 2" note); a `resolver`
+that fronts multiple providers; in-process KEK rotation for file/env; CLI
+subcommands to inspect/validate the configured provider.

--- a/internal/cli/encryption/auth_encryption.go
+++ b/internal/cli/encryption/auth_encryption.go
@@ -84,7 +84,7 @@ func runAuthEncryptionStatus(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to open database: %w", err)
 	}
 	authEnc := encryption.NewAuthEncryption(&cfg.Storage.Encryption, ".", db)
-	passphrase, _ := masterPassphrase()
+	passphrase, _ := masterPassphrase(cfg)
 	if err := authEnc.Initialize(passphrase); err != nil {
 		return fmt.Errorf("failed to initialize auth encryption: %w", err)
 	}
@@ -130,7 +130,7 @@ func runEnableAuthEncryption(cmd *cobra.Command, args []string) error {
 		fmt.Println("✅ Authentication encryption is already enabled")
 		return nil
 	}
-	passphrase, _ := masterPassphrase()
+	passphrase, _ := masterPassphrase(cfg)
 	if err := authEnc.Initialize(passphrase); err != nil {
 		return fmt.Errorf("failed to initialize auth encryption: %w", err)
 	}
@@ -154,7 +154,7 @@ func runRotateAuthEncryption(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to open database: %w", err)
 	}
 	authEnc := encryption.NewAuthEncryption(&cfg.Storage.Encryption, ".", db)
-	passphrase, _ := masterPassphrase()
+	passphrase, _ := masterPassphrase(cfg)
 	if err := authEnc.Initialize(passphrase); err != nil {
 		return fmt.Errorf("failed to initialize auth encryption: %w", err)
 	}

--- a/internal/cli/encryption/auth_encryption_migrate.go
+++ b/internal/cli/encryption/auth_encryption_migrate.go
@@ -25,7 +25,7 @@ func runMigrateAuthData(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to open database: %w", err)
 	}
 	authEnc := encryption.NewAuthEncryption(&cfg.Storage.Encryption, ".", db)
-	passphrase, _ := masterPassphrase()
+	passphrase, _ := masterPassphrase(cfg)
 	if err := authEnc.Initialize(passphrase); err != nil {
 		return fmt.Errorf("failed to initialize auth encryption: %w", err)
 	}

--- a/internal/cli/encryption/auth_encryption_validate.go
+++ b/internal/cli/encryption/auth_encryption_validate.go
@@ -25,7 +25,7 @@ func runValidateAuthEncryption(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to open database: %w", err)
 	}
 	authEnc := encryption.NewAuthEncryption(&cfg.Storage.Encryption, ".", db)
-	passphrase, _ := masterPassphrase()
+	passphrase, _ := masterPassphrase(cfg)
 	if err := authEnc.Initialize(passphrase); err != nil {
 		return fmt.Errorf("failed to initialize auth encryption: %w", err)
 	}

--- a/internal/cli/encryption/encryption.go
+++ b/internal/cli/encryption/encryption.go
@@ -13,9 +13,14 @@ import (
 	"gorm.io/gorm"
 )
 
-// masterPassphrase reads the master passphrase from KEYORIX_MASTER_PASSWORD.
-// Returns an error if the variable is unset or empty.
-func masterPassphrase() (string, error) {
+// masterPassphrase reads the master passphrase from KEYORIX_MASTER_PASSWORD. It is
+// required only for the default "password" key provider; with the file/env
+// providers (ADR-038) the KEK comes from key material elsewhere, so it returns ""
+// without error and Service.Initialize sources the KEK from the provider.
+func masterPassphrase(cfg *config.Config) (string, error) {
+	if t := cfg.Storage.Encryption.KeyProvider.Type; t != "" && t != "password" {
+		return "", nil
+	}
 	p := os.Getenv("KEYORIX_MASTER_PASSWORD")
 	if p == "" {
 		return "", fmt.Errorf("KEYORIX_MASTER_PASSWORD environment variable is not set")
@@ -104,7 +109,7 @@ func runInit(cmd *cobra.Command, args []string) error {
 	baseDir, _ := os.Getwd()
 	service := encryption.NewService(&cfg.Storage.Encryption, baseDir)
 
-	passphrase, err := masterPassphrase()
+	passphrase, err := masterPassphrase(cfg)
 	if err != nil {
 		return err
 	}
@@ -138,7 +143,7 @@ func runStatus(cmd *cobra.Command, args []string) error {
 	baseDir, _ := os.Getwd()
 	service := encryption.NewService(&cfg.Storage.Encryption, baseDir)
 
-	passphrase, err := masterPassphrase()
+	passphrase, err := masterPassphrase(cfg)
 	if err != nil {
 		fmt.Printf("⚠️  %v\n", err)
 		return nil
@@ -184,7 +189,7 @@ func rotateWithConfig(cfg *config.Config, confirm bool) error {
 	baseDir, _ := os.Getwd()
 	service := encryption.NewService(&cfg.Storage.Encryption, baseDir)
 
-	passphrase, err := masterPassphrase()
+	passphrase, err := masterPassphrase(cfg)
 	if err != nil {
 		return err
 	}
@@ -282,7 +287,7 @@ func runValidate(cmd *cobra.Command, args []string) error {
 
 	fmt.Println("🔍 Validating encryption setup...")
 
-	passphrase, err := masterPassphrase()
+	passphrase, err := masterPassphrase(cfg)
 	if err != nil {
 		return err
 	}
@@ -314,7 +319,7 @@ func runFixPerms(cmd *cobra.Command, args []string) error {
 	baseDir, _ := os.Getwd()
 	service := encryption.NewService(&cfg.Storage.Encryption, baseDir)
 
-	passphrase, err := masterPassphrase()
+	passphrase, err := masterPassphrase(cfg)
 	if err != nil {
 		return err
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -230,6 +230,20 @@ type EncryptionConfig struct {
 	Enabled  bool   `yaml:"enabled"`
 	DEKPath  string `yaml:"dek_path"`
 	SaltPath string `yaml:"salt_path"`
+	// KeyProvider selects where the KEK comes from (ADR-038). Absent/zero value =
+	// the default passphrase derivation (KEYORIX_MASTER_PASSWORD + on-disk salt),
+	// byte-identical to the historical behaviour.
+	KeyProvider KeyProviderConfig `yaml:"key_provider"`
+}
+
+// KeyProviderConfig selects the KEK source. type: "password" (default) derives the
+// KEK from KEYORIX_MASTER_PASSWORD; "file" reads raw key material from FilePath;
+// "env" reads it from the EnvVar's value (hex or base64). file/env suit a KEK
+// injected by a KMS, sealed/SOPS secret, or CSI driver.
+type KeyProviderConfig struct {
+	Type     string `yaml:"type"`
+	FilePath string `yaml:"file_path"`
+	EnvVar   string `yaml:"env_var"`
 }
 
 type SecretsConfig struct {

--- a/internal/crypto/keyprovider.go
+++ b/internal/crypto/keyprovider.go
@@ -1,0 +1,36 @@
+// Package crypto defines KeyProvider — the pluggable source of the 32-byte
+// key-encryption key (KEK) that the encryption subsystem uses to wrap/unwrap the
+// data-encryption key (DEK). Abstracting the KEK source lets a deployment choose
+// how the KEK is obtained: derived from a passphrase (the default, unchanged), or
+// supplied as raw key material from a file or environment variable (e.g. injected
+// by a KMS, a sealed/SOPS secret, or a CSI driver). KMS/TPM-backed providers are a
+// future Tier-2 follow-up that implement this same interface.
+//
+// A KeyProvider only SOURCES the KEK; wrapping/unwrapping the DEK with it stays in
+// the encryption package, so providers carry no dependency on the cipher code.
+package crypto
+
+import "fmt"
+
+// KEKSize is the required key-encryption-key length in bytes (AES-256).
+const KEKSize = 32
+
+// KeyProvider sources the 32-byte KEK. Implementations must return exactly
+// KEKSize bytes. The caller owns the returned slice and wipes it after use.
+type KeyProvider interface {
+	// KEK returns the key-encryption key. It may have side effects on first use
+	// (e.g. the password provider generates and persists a salt) but must be
+	// deterministic thereafter for a given configuration.
+	KEK() ([]byte, error)
+	// Name identifies the provider kind for logging and key-version metadata.
+	Name() string
+}
+
+// validateKEK ensures key material is exactly KEKSize bytes — a shared guard so
+// every provider rejects a mis-sized key with the same clear error.
+func validateKEK(key []byte, providerName string) ([]byte, error) {
+	if len(key) != KEKSize {
+		return nil, fmt.Errorf("%s key provider: KEK must be %d bytes, got %d", providerName, KEKSize, len(key))
+	}
+	return key, nil
+}

--- a/internal/crypto/keyprovider_test.go
+++ b/internal/crypto/keyprovider_test.go
@@ -1,0 +1,116 @@
+package crypto
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/pbkdf2"
+)
+
+func TestPasswordKeyProvider_DeterministicAndMatchesLegacyKDF(t *testing.T) {
+	dir := t.TempDir()
+	p := NewPasswordKeyProvider("correct horse battery staple", dir, "kek.salt")
+
+	kek1, err := p.KEK()
+	require.NoError(t, err)
+	require.Len(t, kek1, KEKSize)
+
+	// Salt was persisted; a second call (and a fresh provider over the same dir)
+	// derives the identical KEK.
+	kek2, err := p.KEK()
+	require.NoError(t, err)
+	assert.Equal(t, kek1, kek2, "KEK must be stable for a fixed passphrase + salt")
+
+	salt, err := os.ReadFile(filepath.Join(dir, "kek.salt"))
+	require.NoError(t, err)
+	require.Len(t, salt, saltSize)
+
+	// Byte-identity with the historical derivation (PBKDF2-SHA256, 600000, 32).
+	want := pbkdf2.Key([]byte("correct horse battery staple"), salt, 600000, KEKSize, sha256.New)
+	assert.Equal(t, want, kek1, "password provider must reproduce the legacy KEK derivation exactly")
+
+	p2 := NewPasswordKeyProvider("correct horse battery staple", dir, "kek.salt")
+	kek3, err := p2.KEK()
+	require.NoError(t, err)
+	assert.Equal(t, kek1, kek3, "a fresh provider over the same salt derives the same KEK")
+}
+
+func TestPasswordKeyProvider_EmptyPassphraseRejected(t *testing.T) {
+	_, err := NewPasswordKeyProvider("", t.TempDir(), "kek.salt").KEK()
+	require.Error(t, err)
+}
+
+func TestFileKeyProvider_AcceptsRawHexBase64(t *testing.T) {
+	dir := t.TempDir()
+	raw := make([]byte, KEKSize)
+	for i := range raw {
+		raw[i] = byte(i + 1)
+	}
+
+	cases := map[string][]byte{
+		"raw":        raw,
+		"hex":        []byte(hex.EncodeToString(raw)),
+		"base64":     []byte(base64.StdEncoding.EncodeToString(raw)),
+		"hex+nl":     []byte(hex.EncodeToString(raw) + "\n"),
+		"base64+nl":  []byte(base64.StdEncoding.EncodeToString(raw) + "\n"),
+		"base64-raw": []byte(base64.RawStdEncoding.EncodeToString(raw)),
+	}
+	for name, content := range cases {
+		t.Run(name, func(t *testing.T) {
+			path := filepath.Join(dir, name+".key")
+			require.NoError(t, os.WriteFile(path, content, 0600))
+			kek, err := NewFileKeyProvider(path).KEK()
+			require.NoError(t, err)
+			assert.Equal(t, raw, kek)
+		})
+	}
+}
+
+func TestFileKeyProvider_Errors(t *testing.T) {
+	dir := t.TempDir()
+	t.Run("missing path", func(t *testing.T) {
+		_, err := NewFileKeyProvider("").KEK()
+		require.Error(t, err)
+	})
+	t.Run("nonexistent file", func(t *testing.T) {
+		_, err := NewFileKeyProvider(filepath.Join(dir, "nope.key")).KEK()
+		require.Error(t, err)
+	})
+	t.Run("wrong-size key rejected", func(t *testing.T) {
+		path := filepath.Join(dir, "short.key")
+		require.NoError(t, os.WriteFile(path, []byte("tooshort"), 0600))
+		_, err := NewFileKeyProvider(path).KEK()
+		require.Error(t, err, "a key that doesn't decode to 32 bytes must be rejected")
+	})
+}
+
+func TestEnvKeyProvider(t *testing.T) {
+	raw := make([]byte, KEKSize)
+	for i := range raw {
+		raw[i] = byte(255 - i)
+	}
+	t.Setenv("KX_TEST_KEK", base64.StdEncoding.EncodeToString(raw))
+	kek, err := NewEnvKeyProvider("KX_TEST_KEK").KEK()
+	require.NoError(t, err)
+	assert.Equal(t, raw, kek)
+
+	t.Run("unset env rejected", func(t *testing.T) {
+		_, err := NewEnvKeyProvider("KX_DOES_NOT_EXIST").KEK()
+		require.Error(t, err)
+	})
+	t.Run("empty env_var rejected", func(t *testing.T) {
+		_, err := NewEnvKeyProvider("").KEK()
+		require.Error(t, err)
+	})
+	t.Run("garbage value rejected", func(t *testing.T) {
+		t.Setenv("KX_TEST_BAD", "not-a-valid-key")
+		_, err := NewEnvKeyProvider("KX_TEST_BAD").KEK()
+		require.Error(t, err)
+	})
+}

--- a/internal/crypto/password_provider.go
+++ b/internal/crypto/password_provider.go
@@ -1,0 +1,76 @@
+package crypto
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/keyorixhq/keyorix/internal/securefiles"
+	"golang.org/x/crypto/pbkdf2"
+)
+
+// pbkdf2Iterations is the PBKDF2-SHA256 work factor. This value MUST match the
+// historical KEK derivation (encryption.GenerateKEK used 600000) so an existing
+// wrapped DEK still unwraps — changing it would orphan all encrypted data.
+const pbkdf2Iterations = 600000
+
+// saltSize is the KEK-salt length in bytes (must match the historical 32).
+const saltSize = 32
+
+// PasswordKeyProvider derives the KEK from a passphrase via PBKDF2-SHA256 over a
+// random, on-disk salt — the original (ADR-004) behaviour, now behind the
+// KeyProvider interface. Byte-for-byte compatible with the legacy derivation:
+// same salt file, same iteration count, same KDF, so existing deployments are
+// unaffected.
+type PasswordKeyProvider struct {
+	passphrase string
+	baseDir    string
+	saltPath   string
+}
+
+// NewPasswordKeyProvider builds the default passphrase-derived provider. saltPath
+// is resolved under baseDir via the same securefiles guard as before.
+func NewPasswordKeyProvider(passphrase, baseDir, saltPath string) *PasswordKeyProvider {
+	return &PasswordKeyProvider{passphrase: passphrase, baseDir: baseDir, saltPath: saltPath}
+}
+
+func (p *PasswordKeyProvider) Name() string { return "password" }
+
+// KEK ensures the salt exists (generating it on first run) and derives the KEK.
+func (p *PasswordKeyProvider) KEK() ([]byte, error) {
+	if p.passphrase == "" {
+		return nil, fmt.Errorf("password key provider: master passphrase must not be empty")
+	}
+	salt, err := p.ensureSalt()
+	if err != nil {
+		return nil, err
+	}
+	return pbkdf2.Key([]byte(p.passphrase), salt, pbkdf2Iterations, KEKSize, sha256.New), nil
+}
+
+// ensureSalt mirrors the historical KeyManager.ensureSaltExists exactly: read the
+// 32-byte salt if present, otherwise generate one and persist it 0600.
+func (p *PasswordKeyProvider) ensureSalt() ([]byte, error) {
+	full := filepath.Join(p.baseDir, p.saltPath)
+	if _, err := os.Stat(full); os.IsNotExist(err) {
+		salt := make([]byte, saltSize)
+		if _, err := io.ReadFull(rand.Reader, salt); err != nil {
+			return nil, fmt.Errorf("failed to generate salt: %w", err)
+		}
+		if err := securefiles.SecureWriteFile(p.baseDir, p.saltPath, salt, 0600); err != nil {
+			return nil, fmt.Errorf("failed to write salt: %w", err)
+		}
+		return salt, nil
+	}
+	salt, err := securefiles.SafeReadFile(p.baseDir, p.saltPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read salt: %w", err)
+	}
+	if len(salt) != saltSize {
+		return nil, fmt.Errorf("invalid salt size: expected %d bytes, got %d", saltSize, len(salt))
+	}
+	return salt, nil
+}

--- a/internal/crypto/raw_providers.go
+++ b/internal/crypto/raw_providers.go
@@ -1,0 +1,82 @@
+package crypto
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// decodeKeyMaterial accepts a 32-byte KEK supplied as raw bytes, hex, or base64
+// (standard or raw, with or without padding) and returns the 32 raw bytes. This
+// lets operators provide a KEK however their secret store emits it.
+func decodeKeyMaterial(material []byte, providerName string) ([]byte, error) {
+	// Already raw 32 bytes.
+	if len(material) == KEKSize {
+		return validateKEK(material, providerName)
+	}
+	s := strings.TrimSpace(string(material))
+	// Hex (64 chars for 32 bytes).
+	if b, err := hex.DecodeString(s); err == nil && len(b) == KEKSize {
+		return b, nil
+	}
+	// Base64 — try standard then raw (unpadded), both URL-safe-tolerant.
+	for _, enc := range []*base64.Encoding{base64.StdEncoding, base64.RawStdEncoding, base64.URLEncoding, base64.RawURLEncoding} {
+		if b, err := enc.DecodeString(s); err == nil && len(b) == KEKSize {
+			return b, nil
+		}
+	}
+	return nil, fmt.Errorf("%s key provider: key material must be 32 raw bytes, or hex/base64 encoding thereof (got %d bytes that did not decode to %d)", providerName, len(material), KEKSize)
+}
+
+// FileKeyProvider reads the KEK from a file — typically a path backed by a mounted
+// Kubernetes/CSI secret, a sealed/SOPS-decrypted file, or a KMS sidecar. The path
+// is operator-configured and trusted (read directly, not through the baseDir
+// traversal guard, so absolute paths like /etc/keyorix/kek.key work).
+type FileKeyProvider struct {
+	path string
+}
+
+func NewFileKeyProvider(path string) *FileKeyProvider { return &FileKeyProvider{path: path} }
+
+func (p *FileKeyProvider) Name() string { return "file" }
+
+func (p *FileKeyProvider) KEK() ([]byte, error) {
+	if p.path == "" {
+		return nil, fmt.Errorf("file key provider: file_path is required")
+	}
+	data, err := os.ReadFile(p.path) // #nosec G304 -- operator-configured trusted KEK path
+	if err != nil {
+		return nil, fmt.Errorf("file key provider: failed to read %s: %w", p.path, err)
+	}
+	// Trim a single trailing newline (common when a key file is `echo`-written),
+	// but only for encoded forms — never mangle exactly-32 raw bytes.
+	if len(data) != KEKSize {
+		data = bytes.TrimRight(data, "\r\n")
+	}
+	return decodeKeyMaterial(data, "file")
+}
+
+// EnvKeyProvider reads the KEK directly from an environment variable's value
+// (hex or base64). Suited to KMS/secret-manager injection that lands the key in
+// the process environment.
+type EnvKeyProvider struct {
+	envVar string
+}
+
+func NewEnvKeyProvider(envVar string) *EnvKeyProvider { return &EnvKeyProvider{envVar: envVar} }
+
+func (p *EnvKeyProvider) Name() string { return "env" }
+
+func (p *EnvKeyProvider) KEK() ([]byte, error) {
+	if p.envVar == "" {
+		return nil, fmt.Errorf("env key provider: env_var is required")
+	}
+	val := os.Getenv(p.envVar)
+	if val == "" {
+		return nil, fmt.Errorf("env key provider: %s is not set or empty", p.envVar)
+	}
+	return decodeKeyMaterial([]byte(val), "env")
+}

--- a/internal/encryption/keymanager_lifecycle.go
+++ b/internal/encryption/keymanager_lifecycle.go
@@ -29,6 +29,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/keyorixhq/keyorix/internal/crypto"
 	"github.com/keyorixhq/keyorix/internal/securefiles"
 )
 
@@ -39,7 +40,37 @@ type KeyManager struct {
 	baseDir    string
 	currentDEK []byte
 	keyVersion string
-	mu         sync.RWMutex
+	// keyProvider sources the KEK (ADR-038). nil = the legacy passphrase+salt
+	// derivation below; set to a crypto.KeyProvider (password/file/env) by the
+	// Service to obtain the KEK from elsewhere. Either way the KEK still wraps the
+	// same on-disk DEK, so the data path is unchanged.
+	keyProvider crypto.KeyProvider
+	mu          sync.RWMutex
+}
+
+// SetKeyProvider configures where the KEK comes from. Must be called before
+// Initialize / rotation. nil restores the legacy passphrase+salt derivation.
+func (km *KeyManager) SetKeyProvider(p crypto.KeyProvider) {
+	km.mu.Lock()
+	defer km.mu.Unlock()
+	km.keyProvider = p
+}
+
+// deriveKEK returns the KEK from the configured provider, or — when none is set —
+// the legacy passphrase + on-disk salt PBKDF2 derivation (byte-identical to the
+// pre-ADR-038 behaviour). The caller wipes the returned key.
+func (km *KeyManager) deriveKEK(passphrase string) ([]byte, error) {
+	if km.keyProvider != nil {
+		return km.keyProvider.KEK()
+	}
+	if passphrase == "" {
+		return nil, fmt.Errorf("master passphrase must not be empty")
+	}
+	salt, err := km.ensureSaltExists()
+	if err != nil {
+		return nil, fmt.Errorf("failed to ensure salt exists: %w", err)
+	}
+	return GenerateKEK(passphrase, salt, 600000), nil
 }
 
 // KeyInfo contains metadata about encryption keys.
@@ -67,16 +98,10 @@ func (km *KeyManager) Initialize(passphrase string) error {
 	km.mu.Lock()
 	defer km.mu.Unlock()
 
-	if passphrase == "" {
-		return fmt.Errorf("master passphrase must not be empty")
-	}
-
-	salt, err := km.ensureSaltExists()
+	kek, err := km.deriveKEK(passphrase)
 	if err != nil {
-		return fmt.Errorf("failed to ensure salt exists: %w", err)
+		return err
 	}
-
-	kek := GenerateKEK(passphrase, salt, 600000)
 	defer wipeBytes(kek)
 
 	if err := km.ensureWrappedDEKExists(kek); err != nil {

--- a/internal/encryption/keymanager_rotation.go
+++ b/internal/encryption/keymanager_rotation.go
@@ -29,18 +29,14 @@ func (km *KeyManager) RotateDEKWithSweep(passphrase string, sweepFn func(oldSvc,
 	km.mu.Lock()
 	defer km.mu.Unlock()
 
-	if passphrase == "" {
-		return fmt.Errorf("master passphrase must not be empty")
-	}
 	if km.currentDEK == nil {
 		return fmt.Errorf("key manager not initialized — cannot rotate")
 	}
 
-	salt, err := securefiles.SafeReadFile(km.baseDir, km.saltPath)
+	kek, err := km.deriveKEK(passphrase)
 	if err != nil {
-		return fmt.Errorf("failed to read salt for DEK rotation: %w", err)
+		return fmt.Errorf("failed to derive KEK for DEK rotation: %w", err)
 	}
-	kek := GenerateKEK(passphrase, salt, 600000)
 	defer wipeBytes(kek)
 
 	newDEK, err := GenerateRandomKey(32)
@@ -132,15 +128,10 @@ func (km *KeyManager) RotateDEK(passphrase string) error {
 	km.mu.Lock()
 	defer km.mu.Unlock()
 
-	if passphrase == "" {
-		return fmt.Errorf("master passphrase must not be empty")
-	}
-
-	salt, err := securefiles.SafeReadFile(km.baseDir, km.saltPath)
+	kek, err := km.deriveKEK(passphrase)
 	if err != nil {
-		return fmt.Errorf("failed to read salt for DEK rotation: %w", err)
+		return fmt.Errorf("failed to derive KEK for DEK rotation: %w", err)
 	}
-	kek := GenerateKEK(passphrase, salt, 600000)
 	defer wipeBytes(kek)
 
 	newDEK, err := GenerateRandomKey(32)

--- a/internal/encryption/keyprovider_compat_test.go
+++ b/internal/encryption/keyprovider_compat_test.go
@@ -1,0 +1,123 @@
+package encryption
+
+import (
+	"bytes"
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/crypto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const compatPass = "correct horse battery staple"
+
+// TestKeyProvider_PasswordIsBackwardCompatible is the load-bearing guarantee of
+// ADR-038: a KeyManager using the new PasswordKeyProvider must unwrap a DEK that
+// was created by the LEGACY passphrase+salt path — i.e. the KEK derivation is
+// byte-identical, so existing encrypted deployments are unaffected.
+func TestKeyProvider_PasswordIsBackwardCompatible(t *testing.T) {
+	dir := t.TempDir()
+
+	// Legacy path: no provider set → ensureSaltExists + GenerateKEK(600000).
+	legacy := NewKeyManager(dir, "dek.key", "kek.salt")
+	require.NoError(t, legacy.Initialize(compatPass))
+	legacyDEK := append([]byte(nil), legacy.GetDEK()...)
+	require.Len(t, legacyDEK, 32)
+
+	// New path over the SAME files: PasswordKeyProvider derives the KEK and must
+	// unwrap the identical DEK (passphrase arg ignored by the provider branch).
+	viaProvider := NewKeyManager(dir, "dek.key", "kek.salt")
+	viaProvider.SetKeyProvider(crypto.NewPasswordKeyProvider(compatPass, dir, "kek.salt"))
+	require.NoError(t, viaProvider.Initialize(""))
+	assert.Equal(t, legacyDEK, viaProvider.GetDEK(),
+		"the password provider must unwrap a DEK created by the legacy derivation")
+
+	// A wrong passphrase must fail to unwrap (the GCM auth check).
+	wrong := NewKeyManager(dir, "dek.key", "kek.salt")
+	wrong.SetKeyProvider(crypto.NewPasswordKeyProvider("not-the-passphrase", dir, "kek.salt"))
+	require.Error(t, wrong.Initialize(""))
+}
+
+// roundTrip initialises a KeyManager with the given provider, captures its DEK,
+// then re-initialises a fresh KeyManager over the same files and asserts the DEK
+// unwraps identically — i.e. the provider's KEK is stable and the wrapped DEK
+// persists correctly.
+func roundTrip(t *testing.T, dir string, mk func() crypto.KeyProvider) {
+	t.Helper()
+	km1 := NewKeyManager(dir, "dek.key", "kek.salt")
+	km1.SetKeyProvider(mk())
+	require.NoError(t, km1.Initialize(""))
+	dek1 := append([]byte(nil), km1.GetDEK()...)
+	require.Len(t, dek1, 32)
+
+	km2 := NewKeyManager(dir, "dek.key", "kek.salt")
+	km2.SetKeyProvider(mk())
+	require.NoError(t, km2.Initialize(""))
+	assert.Equal(t, dek1, km2.GetDEK(), "the same provider must unwrap the same DEK across restarts")
+}
+
+func TestKeyProvider_FileRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "kek.bin")
+	raw := bytes.Repeat([]byte{0xAB}, 32)
+	require.NoError(t, os.WriteFile(keyPath, raw, 0600))
+	roundTrip(t, dir, func() crypto.KeyProvider { return crypto.NewFileKeyProvider(keyPath) })
+}
+
+func TestKeyProvider_EnvRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	raw := bytes.Repeat([]byte{0x5C}, 32)
+	t.Setenv("KX_COMPAT_KEK", base64.StdEncoding.EncodeToString(raw))
+	roundTrip(t, dir, func() crypto.KeyProvider { return crypto.NewEnvKeyProvider("KX_COMPAT_KEK") })
+}
+
+// TestKeyProvider_DEKRotationUnderProvider verifies that rotating the DEK while a
+// file provider sources the KEK re-wraps the NEW DEK with that same KEK, so a
+// fresh KeyManager reads the rotated DEK back.
+func TestKeyProvider_DEKRotationUnderProvider(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "kek.bin")
+	require.NoError(t, os.WriteFile(keyPath, bytes.Repeat([]byte{0x11}, 32), 0600))
+
+	km := NewKeyManager(dir, "dek.key", "kek.salt")
+	km.SetKeyProvider(crypto.NewFileKeyProvider(keyPath))
+	require.NoError(t, km.Initialize(""))
+	before := append([]byte(nil), km.GetDEK()...)
+
+	require.NoError(t, km.RotateDEK("")) // deprecated path, but exercises re-wrap under a provider
+	after := km.GetDEK()
+	assert.NotEqual(t, before, after, "rotation must produce a new DEK")
+
+	// A fresh manager with the same KEK source unwraps the rotated DEK.
+	km2 := NewKeyManager(dir, "dek.key", "kek.salt")
+	km2.SetKeyProvider(crypto.NewFileKeyProvider(keyPath))
+	require.NoError(t, km2.Initialize(""))
+	assert.Equal(t, after, km2.GetDEK(), "the rotated DEK must unwrap with the provider KEK")
+}
+
+// TestService_FileProviderEndToEnd exercises the full Service path: a file-provider
+// KEK encrypts a secret, and a fresh Service over the same files decrypts it.
+func TestService_FileProviderEndToEnd(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "kek.bin")
+	require.NoError(t, os.WriteFile(keyPath, bytes.Repeat([]byte{0x42}, 32), 0600))
+	cfg := &config.EncryptionConfig{
+		Enabled: true, DEKPath: "dek.key", SaltPath: "kek.salt",
+		KeyProvider: config.KeyProviderConfig{Type: "file", FilePath: keyPath},
+	}
+
+	s1 := NewService(cfg, dir)
+	require.NoError(t, s1.Initialize("")) // no passphrase needed for the file provider
+	ct, _, err := s1.EncryptSecret([]byte("super-secret-value"))
+	require.NoError(t, err)
+
+	s2 := NewService(cfg, dir)
+	require.NoError(t, s2.Initialize(""))
+	pt, err := s2.DecryptSecret(ct)
+	require.NoError(t, err)
+	assert.Equal(t, "super-secret-value", string(pt))
+}

--- a/internal/encryption/service.go
+++ b/internal/encryption/service.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 
 	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/crypto"
 )
 
 // Service provides high-level encryption operations for the application.
@@ -49,6 +50,11 @@ func (s *Service) Initialize(passphrase string) error {
 	if !s.config.Enabled {
 		return fmt.Errorf("encryption is disabled in configuration")
 	}
+	provider, err := s.buildKeyProvider(passphrase)
+	if err != nil {
+		return err
+	}
+	s.keyManager.SetKeyProvider(provider)
 	if err := s.keyManager.Initialize(passphrase); err != nil {
 		return fmt.Errorf("failed to initialize key manager: %w", err)
 	}
@@ -60,6 +66,23 @@ func (s *Service) Initialize(passphrase string) error {
 	s.encryptionService = encSvc
 	s.initialized = true
 	return nil
+}
+
+// buildKeyProvider selects the KEK source from config (ADR-038). The default and
+// the absent/zero value is the passphrase provider, byte-identical to the
+// historical derivation; file/env supply externally-managed raw key material.
+func (s *Service) buildKeyProvider(passphrase string) (crypto.KeyProvider, error) {
+	kp := s.config.KeyProvider
+	switch kp.Type {
+	case "", "password":
+		return crypto.NewPasswordKeyProvider(passphrase, s.keyManager.baseDir, s.config.SaltPath), nil
+	case "file":
+		return crypto.NewFileKeyProvider(kp.FilePath), nil
+	case "env":
+		return crypto.NewEnvKeyProvider(kp.EnvVar), nil
+	default:
+		return nil, fmt.Errorf("unknown encryption key_provider type %q (supported: password, file, env)", kp.Type)
+	}
 }
 
 // IsEnabled returns whether encryption is enabled in config.

--- a/server/main.go
+++ b/server/main.go
@@ -130,19 +130,22 @@ func main() {
 	}
 }
 
-// initializeEncryption derives the KEK from KEYORIX_MASTER_PASSWORD and returns
-// an initialized encryption.Service. If encryption is disabled in config, it returns
-// nil without error. Exits loudly if encryption is enabled but no passphrase is set.
+// initializeEncryption sources the KEK per the configured key provider (ADR-038)
+// and returns an initialized encryption.Service. If encryption is disabled in
+// config, it returns nil without error. For the default "password" provider it
+// requires KEYORIX_MASTER_PASSWORD; for the "file"/"env" providers the KEK comes
+// from key material elsewhere, so no passphrase is needed.
 func initializeEncryption(cfg *config.Config) (*encryption.Service, error) {
 	if !cfg.Storage.Encryption.Enabled {
 		return nil, nil
 	}
 
+	providerType := cfg.Storage.Encryption.KeyProvider.Type
 	passphrase := strings.TrimSpace(os.Getenv("KEYORIX_MASTER_PASSWORD"))
-	if passphrase == "" {
+	if (providerType == "" || providerType == "password") && passphrase == "" {
 		return nil, fmt.Errorf(
-			"encryption is enabled but KEYORIX_MASTER_PASSWORD is not set; " +
-				"set this environment variable before starting the server")
+			"encryption is enabled with the password key provider but KEYORIX_MASTER_PASSWORD " +
+				"is not set; set it, or configure storage.encryption.key_provider (file/env)")
 	}
 
 	baseDir := ""
@@ -155,7 +158,11 @@ func initializeEncryption(cfg *config.Config) (*encryption.Service, error) {
 		return nil, fmt.Errorf("failed to initialize encryption (KEK derivation): %w", err)
 	}
 
-	log.Printf("Encryption initialised — KEK derived from passphrase, key version: %s", svc.GetKeyVersion())
+	kekSource := providerType
+	if kekSource == "" {
+		kekSource = "password"
+	}
+	log.Printf("Encryption initialised — KEK source: %s, key version: %s", kekSource, svc.GetKeyVersion())
 	return svc, nil
 }
 


### PR DESCRIPTION
## Summary

Abstracts **where the KEK (key-encryption key) comes from** behind a `crypto.KeyProvider` interface, so a deployment can source it from a passphrase (default, unchanged), a **file** (mounted CSI/sealed secret, KMS sidecar), or an **env var** (KMS/secret-manager injection). This is the on-prem / HSM-backed key delivery that the ENS/ENISA + enterprise track needs. KMS/TPM-backed providers are a future Tier-2 implementation of the same interface.

Envelope encryption is unchanged: a per-process DEK encrypts data, and the DEK is stored wrapped by the KEK. This PR only changes how the **KEK** is obtained — never the DEK/data path.

## What's in it

- **`internal/crypto`** — `KeyProvider` interface + three providers:
  - `PasswordKeyProvider` (default): PBKDF2-SHA256, 600 000 iterations, on-disk salt — **byte-identical** to the historical derivation.
  - `FileKeyProvider` / `EnvKeyProvider`: accept 32 raw bytes, hex, or base64, validated to 32 bytes.
  - Providers only *source* the KEK — no dependency on the cipher code, so no import cycle.
- **`KeyManager`** routes `Initialize` + `RotateDEKWithSweep` + `RotateDEK` through a new `deriveKEK()`: the configured provider, or — when none is set (direct callers / existing unit tests) — the **legacy passphrase+salt path, unchanged**. `Service.Initialize` builds the provider from config and sets it; rotation reuses it (re-wraps the new DEK with the same KEK source).
- **Config**: `storage.encryption.key_provider {type, file_path, env_var}`; absent = `password`. `KEYORIX_MASTER_PASSWORD` is required **only** for the password provider — server startup and the `keyorix encryption` CLI start without it for file/env.

## Backward compatibility (load-bearing)

The default path derives the **identical** KEK and unwraps the existing `dek.key` — no re-encryption, no migration, zero change for current deployments. Proven by a test that a fresh password-provider `KeyManager` unwraps a DEK created by the **legacy code path**, plus a byte-identity check against `PBKDF2(passphrase, salt, 600000, 32, SHA-256)`.

## Testing

`internal/crypto`: password determinism + legacy-KDF byte-identity, file/env raw/hex/base64 decode + error cases. `internal/encryption`: backward-compat (legacy→provider unwrap, wrong-passphrase GCM failure), file/env round-trips (init→restart→same DEK), DEK rotation under a provider, and a Service file-provider encrypt→restart→decrypt. The existing encryption suite is unchanged. `make build` + full suite + `go vet` green.

See `docs/adr-038-pluggable-key-providers.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)