### PR TITLE
feat(dynamic): MySQL target engine for dynamic secrets (ADR-035)

### DIFF
--- a/docs/adr-035-dynamic-secrets.md
+++ b/docs/adr-035-dynamic-secrets.md
@@ -78,5 +78,24 @@ full suite + `go vet` green.
 
 ## Deferred
 
-MySQL/other backends; renewable leases (extend TTL in place); per-config max-TTL
-ceilings; a CLI surface; returning leases a caller can enumerate across configs.
+Other backends (Mongo, cloud IAM); renewable leases (extend TTL in place);
+per-config max-TTL ceilings; a CLI surface; returning leases a caller can
+enumerate across configs.
+
+## Addendum (2026-06-12): MySQL target engine
+
+A `mysql` backend now implements the same `CredentialEngine` interface
+(`internal/dynamic/mysql.go`); `key_provider`-style selection is via the config's
+`backend_type`. It mints `kx_dyn_<random>'@'%` accounts (`CREATE USER … IDENTIFIED
+BY …`), runs the creation template with `{{name}}` → the quoted account reference,
+and on revoke kills the account's live sessions then `DROP USER`. Username and
+password come from the same quote-free `crypto/rand` alphabet, so the documented
+SQL-injection trust boundary is unchanged.
+
+**One difference from PostgreSQL:** MySQL accounts have no `VALID UNTIL`
+equivalent that disables them at a timestamp, so a MySQL lease's TTL is enforced
+**only** by the auto-revoke sweeper (`dynamic_secrets.sweep_enabled`) — the
+sweeper should be enabled when using MySQL targets, otherwise a credential lives
+until an explicit revoke. The Postgres engine remains belt-and-suspenders (role
+expiry **and** sweep). The MySQL driver (`go-sql-driver/mysql`, pure Go) links
+into the server; no cloud SDK is added.

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.42.3
 	github.com/go-chi/chi/v5 v5.2.2
 	github.com/go-chi/cors v1.2.1
+	github.com/go-sql-driver/mysql v1.10.0
 	github.com/go-webauthn/webauthn v0.17.4
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/jackc/pgx/v5 v5.10.0
@@ -32,6 +33,7 @@ require (
 )
 
 require (
+	filippo.io/edwards25519 v1.2.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/internal v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+filippo.io/edwards25519 v1.2.0 h1:crnVqOiS4jqYleHd9vaKZ+HKtHfllngJIiOpNpoJsjo=
+filippo.io/edwards25519 v1.2.0/go.mod h1:xzAOLCNug/yB62zG1bQ8uziwrIqIuxhctzJT18Q77mc=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.0 h1:fou+2+WFTib47nS+nz/ozhEBnvU96bKHy6LjRsY4E28=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.0/go.mod h1:t76Ruy8AHvUAC8GfMWJMa0ElSbuIcO03NLpynfbgsPA=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1 h1:Hk5QBxZQC1jb2Fwj6mpzme37xbCDdNTxU7O9eb5+LB4=
@@ -71,6 +73,8 @@ github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
 github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
 github.com/go-ole/go-ole v1.2.6 h1:/Fpf6oFPoeFik9ty7siob0G6Ke8QvQEuVcuChpwXzpY=
 github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
+github.com/go-sql-driver/mysql v1.10.0 h1:Q+1LV8DkHJvSYAdR83XzuhDaTykuDx0l6fkXxoWCWfw=
+github.com/go-sql-driver/mysql v1.10.0/go.mod h1:M+cqaI7+xxXGG9swrdeUIoPG3Y3KCkF0pZej+SK+nWk=
 github.com/go-viper/mapstructure/v2 v2.5.0 h1:vM5IJoUAy3d7zRSVtIwQgBj7BiWtMPfmPEgAXnvj1Ro=
 github.com/go-viper/mapstructure/v2 v2.5.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/go-webauthn/webauthn v0.17.4 h1:KFTSz3R2RYDiUn/0cDi3XTJgFenSG74eKTTHlqWhlxk=

--- a/internal/core/dynamic_secrets_test.go
+++ b/internal/core/dynamic_secrets_test.go
@@ -149,3 +149,25 @@ func TestDynamicSecrets_IssueRejectsUnknownConfig(t *testing.T) {
 	_, err := c.IssueLease(ctx, 999, 0, 7)
 	require.Error(t, err)
 }
+
+// TestDynamicSecrets_RealFactoryValidatesBackend checks the real engine factory
+// (no fake): config creation accepts the supported backends and rejects others.
+func TestDynamicSecrets_RealFactoryValidatesBackend(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.DynamicSecretConfig{}, &models.AuditEvent{}))
+	fixed := time.Date(2026, 6, 12, 10, 0, 0, 0, time.UTC)
+	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: func() time.Time { return fixed }, passwordPolicy: DefaultPasswordPolicy()}
+
+	for _, backend := range []string{"postgres", "mysql"} {
+		_, err := c.CreateDynamicSecretConfig(context.Background(), &CreateDynamicSecretConfigRequest{
+			Name: backend + "-cfg", ProjectID: 1, BackendType: backend, AdminDSN: "admin:p@tcp(h:3306)/",
+		})
+		require.NoError(t, err, "backend %s must be accepted", backend)
+	}
+
+	_, err = c.CreateDynamicSecretConfig(context.Background(), &CreateDynamicSecretConfigRequest{
+		Name: "bad", ProjectID: 1, BackendType: "redis", AdminDSN: "x",
+	})
+	require.Error(t, err, "an unsupported backend must be rejected at config creation")
+}

--- a/internal/dynamic/engine.go
+++ b/internal/dynamic/engine.go
@@ -35,8 +35,10 @@ func New(backendType string) (CredentialEngine, error) {
 	switch backendType {
 	case "postgres":
 		return &PostgresEngine{}, nil
+	case "mysql":
+		return &MySQLEngine{}, nil
 	default:
-		return nil, fmt.Errorf("unsupported dynamic-secret backend %q (supported: postgres)", backendType)
+		return nil, fmt.Errorf("unsupported dynamic-secret backend %q (supported: postgres, mysql)", backendType)
 	}
 }
 

--- a/internal/dynamic/engine_test.go
+++ b/internal/dynamic/engine_test.go
@@ -1,0 +1,54 @@
+package dynamic
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNew_Backends(t *testing.T) {
+	pg, err := New("postgres")
+	require.NoError(t, err)
+	assert.Equal(t, "postgres", pg.BackendType())
+
+	my, err := New("mysql")
+	require.NoError(t, err)
+	assert.Equal(t, "mysql", my.BackendType())
+
+	_, err = New("redis")
+	require.Error(t, err, "an unsupported backend is rejected")
+}
+
+func TestMySQLAccountRef(t *testing.T) {
+	// The {{name}} substitution renders a properly-quoted account reference, and a
+	// quote-free username (as randString produces) cannot escape the quotes.
+	ref := mysqlAccountRef("kx_dyn_abc123")
+	assert.Equal(t, "'kx_dyn_abc123'@'%'", ref)
+
+	grant := strings.ReplaceAll("GRANT SELECT ON app.* TO {{name}};", "{{name}}", ref)
+	assert.Equal(t, "GRANT SELECT ON app.* TO 'kx_dyn_abc123'@'%';", grant)
+}
+
+func TestMySQLEngine_InvalidDSNRejected(t *testing.T) {
+	e := &MySQLEngine{}
+	// A malformed DSN is rejected by ParseDSN before any connection attempt.
+	_, _, err := e.Issue(context.Background(), "not a valid dsn at all", "", 0)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mysql admin DSN")
+}
+
+func TestRandString_QuoteFreeAlphabet(t *testing.T) {
+	// The credential alphabet must never contain a quote/backslash, which is what
+	// makes the fmt.Sprintf'd SQL safe in both engines.
+	s, err := randString(256)
+	require.NoError(t, err)
+	require.Len(t, s, 256)
+	for _, r := range s {
+		if !((r >= 'a' && r <= 'z') || (r >= '0' && r <= '9')) {
+			t.Fatalf("unexpected character %q in randString output", r)
+		}
+	}
+}

--- a/internal/dynamic/engine_test.go
+++ b/internal/dynamic/engine_test.go
@@ -32,6 +32,21 @@ func TestMySQLAccountRef(t *testing.T) {
 	assert.Equal(t, "GRANT SELECT ON app.* TO 'kx_dyn_abc123'@'%';", grant)
 }
 
+func TestAssertSafeUsername(t *testing.T) {
+	require.NoError(t, assertSafeUsername("kx_dyn_abc123"))
+	for _, bad := range []string{"", "kx'dyn", "kx`dyn", "kx dyn", "kx-dyn", "KXDYN", "kx\\dyn"} {
+		assert.Error(t, assertSafeUsername(bad), "must reject %q", bad)
+	}
+}
+
+func TestMySQLEngine_RevokeRejectsUnsafeRole(t *testing.T) {
+	// Defense-in-depth: a tampered/unsafe role name from storage is rejected before
+	// any SQL is constructed or any connection is opened.
+	err := (&MySQLEngine{}).Revoke(context.Background(), "admin:p@tcp(h:3306)/", "evil'; DROP")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsafe mysql username")
+}
+
 func TestMySQLEngine_InvalidDSNRejected(t *testing.T) {
 	e := &MySQLEngine{}
 	// A malformed DSN is rejected by ParseDSN before any connection attempt.

--- a/internal/dynamic/mysql.go
+++ b/internal/dynamic/mysql.go
@@ -1,0 +1,126 @@
+package dynamic
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/go-sql-driver/mysql"
+)
+
+// MySQLEngine mints short-lived MySQL accounts using the admin DSN and drops them
+// on revoke. Unlike PostgreSQL (whose roles carry a VALID UNTIL that disables them
+// at expiry), MySQL has no per-account expiry timestamp, so a lease's TTL is
+// enforced solely by the dynamic-secrets auto-revoke sweeper (ADR-035) — the
+// sweeper must be enabled for MySQL credentials to expire. The DROP at revoke is
+// the authoritative teardown either way.
+//
+// The admin DSN is in go-sql-driver/mysql format, e.g.
+// "admin:pass@tcp(db.internal:3306)/". Username and password are crypto/rand from
+// an identifier/quote-safe alphabet (lowercase+digits), so neither can break out
+// of the surrounding quotes; the creation template is operator-authored (trusted)
+// and is the documented SQL-injection trust boundary.
+type MySQLEngine struct{}
+
+func (e *MySQLEngine) BackendType() string { return "mysql" }
+
+// mysqlHost is the host part of the created account ('user'@'%'). Restricting it
+// further is a deployment concern best expressed via the creation template/grants.
+const mysqlHost = "%"
+
+// mysqlAccountRef renders the quoted account reference 'user'@'%' used in CREATE
+// USER / GRANT / DROP USER. user is crypto/rand from a quote-free alphabet, so it
+// cannot break out of the quotes.
+func mysqlAccountRef(user string) string {
+	return fmt.Sprintf("'%s'@'%s'", user, mysqlHost)
+}
+
+func (e *MySQLEngine) Issue(ctx context.Context, adminDSN, creationTemplate string, ttl time.Duration) (Credential, string, error) {
+	db, err := openMySQL(ctx, adminDSN)
+	if err != nil {
+		return Credential{}, "", err
+	}
+	defer db.Close()
+
+	suffix, err := randString(16)
+	if err != nil {
+		return Credential{}, "", err
+	}
+	user := "kx_dyn_" + suffix // 7+16 = 23 chars, within MySQL's 32-char limit
+	password, err := randString(32)
+	if err != nil {
+		return Credential{}, "", err
+	}
+
+	ref := mysqlAccountRef(user)
+	if _, err := db.ExecContext(ctx, fmt.Sprintf("CREATE USER %s IDENTIFIED BY '%s'", ref, password)); err != nil {
+		return Credential{}, "", fmt.Errorf("create user: %w", err)
+	}
+
+	if tmpl := strings.TrimSpace(creationTemplate); tmpl != "" {
+		// {{name}} → the full account reference, e.g. 'kx_dyn_xxx'@'%', so templates
+		// read naturally: GRANT SELECT ON app.* TO {{name}};
+		grant := strings.ReplaceAll(tmpl, "{{name}}", ref)
+		if _, err := db.ExecContext(ctx, grant); err != nil {
+			// Don't leak a half-provisioned account if the template fails.
+			_, _ = db.ExecContext(ctx, fmt.Sprintf("DROP USER IF EXISTS %s", ref))
+			return Credential{}, "", fmt.Errorf("run creation template: %w", err)
+		}
+	}
+	return Credential{Username: user, Password: password}, user, nil
+}
+
+// Revoke kills the account's live sessions (best-effort), then drops it. DROP USER
+// removes the account and all its privileges. roleName is the bare username.
+func (e *MySQLEngine) Revoke(ctx context.Context, adminDSN, roleName string) error {
+	db, err := openMySQL(ctx, adminDSN)
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+
+	killUserConnections(ctx, db, roleName)
+	if _, err := db.ExecContext(ctx, fmt.Sprintf("DROP USER IF EXISTS %s", mysqlAccountRef(roleName))); err != nil {
+		return fmt.Errorf("drop user %s: %w", roleName, err)
+	}
+	return nil
+}
+
+// openMySQL opens and verifies a connection to the target using the admin DSN.
+func openMySQL(ctx context.Context, adminDSN string) (*sql.DB, error) {
+	if _, err := mysql.ParseDSN(adminDSN); err != nil {
+		return nil, fmt.Errorf("invalid mysql admin DSN: %w", err)
+	}
+	db, err := sql.Open("mysql", adminDSN)
+	if err != nil {
+		return nil, fmt.Errorf("connect to target: %w", err)
+	}
+	if err := db.PingContext(ctx); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("connect to target: %w", err)
+	}
+	return db, nil
+}
+
+// killUserConnections terminates the account's active sessions so a revoke takes
+// effect immediately. Best-effort: errors are ignored (the authoritative teardown
+// is DROP USER). The user filter is parameterized.
+func killUserConnections(ctx context.Context, db *sql.DB, user string) {
+	rows, err := db.QueryContext(ctx, "SELECT id FROM information_schema.processlist WHERE user = ?", user)
+	if err != nil {
+		return
+	}
+	defer rows.Close()
+	var ids []int64
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err == nil {
+			ids = append(ids, id)
+		}
+	}
+	for _, id := range ids {
+		_, _ = db.ExecContext(ctx, fmt.Sprintf("KILL %d", id))
+	}
+}

--- a/internal/dynamic/mysql.go
+++ b/internal/dynamic/mysql.go
@@ -32,9 +32,26 @@ const mysqlHost = "%"
 
 // mysqlAccountRef renders the quoted account reference 'user'@'%' used in CREATE
 // USER / GRANT / DROP USER. user is crypto/rand from a quote-free alphabet, so it
-// cannot break out of the quotes.
+// cannot break out of the quotes. assertSafeUsername is a fail-closed second layer
+// (MySQL has no pgx.Identifier.Sanitize equivalent): even if the alphabet were
+// ever widened, an unexpected character aborts before any SQL is built.
 func mysqlAccountRef(user string) string {
 	return fmt.Sprintf("'%s'@'%s'", user, mysqlHost)
+}
+
+// assertSafeUsername rejects any username containing a character outside the
+// generated alphabet ([a-z0-9_]), so the fmt.Sprintf'd account name can never be
+// an injection vector regardless of where the name came from.
+func assertSafeUsername(user string) error {
+	if user == "" {
+		return fmt.Errorf("empty mysql username")
+	}
+	for _, r := range user {
+		if !((r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '_') {
+			return fmt.Errorf("refusing unsafe mysql username %q", user)
+		}
+	}
+	return nil
 }
 
 func (e *MySQLEngine) Issue(ctx context.Context, adminDSN, creationTemplate string, ttl time.Duration) (Credential, string, error) {
@@ -49,6 +66,9 @@ func (e *MySQLEngine) Issue(ctx context.Context, adminDSN, creationTemplate stri
 		return Credential{}, "", err
 	}
 	user := "kx_dyn_" + suffix // 7+16 = 23 chars, within MySQL's 32-char limit
+	if err := assertSafeUsername(user); err != nil {
+		return Credential{}, "", err
+	}
 	password, err := randString(32)
 	if err != nil {
 		return Credential{}, "", err
@@ -75,6 +95,9 @@ func (e *MySQLEngine) Issue(ctx context.Context, adminDSN, creationTemplate stri
 // Revoke kills the account's live sessions (best-effort), then drops it. DROP USER
 // removes the account and all its privileges. roleName is the bare username.
 func (e *MySQLEngine) Revoke(ctx context.Context, adminDSN, roleName string) error {
+	if err := assertSafeUsername(roleName); err != nil {
+		return err
+	}
 	db, err := openMySQL(ctx, adminDSN)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary

Extends **dynamic secrets** (ADR-035) to **MySQL** targets — the second-most-common database, which the original ADR explicitly deferred. Built on the existing `CredentialEngine` interface + `New(backend)` factory, so the core/HTTP/storage layers are untouched; selection is via the config's `backend_type: mysql`.

## What's in it

- **`internal/dynamic/mysql.go`** — `MySQLEngine`: `Issue` mints a `kx_dyn_<random>'@'%'` account (`CREATE USER … IDENTIFIED BY …`), runs the operator's `creation_template` with `{{name}}` → the quoted account reference (`'kx_dyn_xxx'@'%'`), and drops the account if the template fails. `Revoke` kills the account's live sessions (best-effort, parameterized lookup) then `DROP USER IF EXISTS`. The admin DSN (go-sql-driver format) is validated via `mysql.ParseDSN` before any connection.
- Factory now supports `postgres` **and** `mysql`.
- **Driver**: `go-sql-driver/mysql` (pure Go, lightweight) — **no cloud SDK added to the server binary.**

## Safety

Username and password come from the same quote-free `crypto/rand` alphabet (lowercase+digits) as the Postgres engine, so neither can break out of the surrounding quotes — the documented SQL-injection trust boundary (the operator-authored `creation_template`) is unchanged.

## One documented difference from PostgreSQL

MySQL accounts have no `VALID UNTIL` equivalent, so a MySQL lease's TTL is enforced **only** by the auto-revoke sweeper (`dynamic_secrets.sweep_enabled`) — it should be enabled for MySQL targets. Postgres remains belt-and-suspenders (role expiry **and** sweep). Captured in the ADR-035 addendum.

## Testing

`internal/dynamic`: factory returns the mysql engine; the `{{name}}` account-ref substitution renders `'user'@'%'`; invalid-DSN rejection happens before any connection; `randString` output stays quote-free. `internal/core`: config creation accepts `postgres`+`mysql` via the **real** factory and rejects an unsupported backend. (The live SQL path is covered the same way the Postgres engine is — via the core FakeEngine lease lifecycle tests — since it needs a live server.) `make build` + full suite + `go vet` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)