### PR TITLE
feat(dynamic): lease max-TTL ceiling + renewable leases (ADR-035)

### DIFF
--- a/docs/adr-035-dynamic-secrets.md
+++ b/docs/adr-035-dynamic-secrets.md
@@ -99,3 +99,20 @@ sweeper should be enabled when using MySQL targets, otherwise a credential lives
 until an explicit revoke. The Postgres engine remains belt-and-suspenders (role
 expiry **and** sweep). The MySQL driver (`go-sql-driver/mysql`, pure Go) links
 into the server; no cloud SDK is added.
+
+## Addendum (2026-06-12): lease lifecycle — max-TTL ceiling + renewal
+
+Two of the originally-deferred items shipped together:
+
+- **Per-config max-TTL ceiling** (`DynamicSecretConfig.MaxTTLSeconds`, 0 = none).
+  Caps the lifetime of any lease from the config regardless of the TTL a caller
+  requests: the issue TTL is clamped to it, and config creation rejects a
+  `default_ttl_seconds` greater than `max_ttl_seconds`. A real safety control —
+  it bounds credential exposure even if a caller asks for a long TTL.
+- **Renewable leases** — `POST …/leases/{leaseID}/renew {ttl_seconds}` extends an
+  **active** lease's expiry (a new `CredentialEngine.Renew` pushes PostgreSQL's
+  `VALID UNTIL` forward; MySQL is a no-op enforced by the sweep). Renewal is
+  **capped** so a lease's total lifetime from issue can never exceed the config's
+  max-TTL — a renewal that wouldn't extend (cap reached) is rejected. Audited as
+  `dynamic_lease.renewed`. Renewal reduces credential churn vs. re-issuing while
+  the max-TTL keeps the hard bound on exposure.

--- a/internal/core/dynamic_secrets.go
+++ b/internal/core/dynamic_secrets.go
@@ -24,6 +24,7 @@ type CreateDynamicSecretConfigRequest struct {
 	AdminDSN          string
 	CreationTemplate  string
 	DefaultTTLSeconds int
+	MaxTTLSeconds     int
 	CreatedBy         string
 }
 
@@ -44,6 +45,9 @@ func (c *KeyorixCore) CreateDynamicSecretConfig(ctx context.Context, req *Create
 	if _, err := c.dynamicEngine(req.BackendType); err != nil {
 		return nil, err
 	}
+	if req.MaxTTLSeconds > 0 && req.DefaultTTLSeconds > req.MaxTTLSeconds {
+		return nil, fmt.Errorf("default_ttl_seconds (%d) cannot exceed max_ttl_seconds (%d)", req.DefaultTTLSeconds, req.MaxTTLSeconds)
+	}
 	dsnEnc, dsnMeta, err := c.encryptAuthSecret(req.AdminDSN)
 	if err != nil {
 		return nil, fmt.Errorf("failed to encrypt admin DSN: %w", err)
@@ -57,6 +61,7 @@ func (c *KeyorixCore) CreateDynamicSecretConfig(ctx context.Context, req *Create
 		AdminDSNMeta:      dsnMeta,
 		CreationTemplate:  req.CreationTemplate,
 		DefaultTTLSeconds: req.DefaultTTLSeconds,
+		MaxTTLSeconds:     req.MaxTTLSeconds,
 		CreatedBy:         req.CreatedBy,
 		CreatedAt:         c.now(),
 		UpdatedAt:         c.now(),
@@ -209,12 +214,72 @@ func (c *KeyorixCore) RevokeExpiredLeases(ctx context.Context, before time.Time)
 	return revoked, nil
 }
 
+// dynamicTTL resolves the requested TTL (override, else config default, else 1h)
+// and clamps it to the config's MaxTTLSeconds ceiling when one is set.
 func (c *KeyorixCore) dynamicTTL(cfg *models.DynamicSecretConfig, override int) time.Duration {
-	if override > 0 {
-		return time.Duration(override) * time.Second
+	ttl := defaultDynamicTTL
+	switch {
+	case override > 0:
+		ttl = time.Duration(override) * time.Second
+	case cfg.DefaultTTLSeconds > 0:
+		ttl = time.Duration(cfg.DefaultTTLSeconds) * time.Second
 	}
-	if cfg.DefaultTTLSeconds > 0 {
-		return time.Duration(cfg.DefaultTTLSeconds) * time.Second
+	if cfg.MaxTTLSeconds > 0 {
+		if max := time.Duration(cfg.MaxTTLSeconds) * time.Second; ttl > max {
+			ttl = max
+		}
 	}
-	return defaultDynamicTTL
+	return ttl
+}
+
+// RenewLease extends an active lease's expiry by ttlSeconds (or the config
+// default), capped so the lease's total lifetime from issue never exceeds the
+// config's MaxTTLSeconds. On backends with a DB-level expiry (PostgreSQL) it also
+// pushes the role's VALID UNTIL forward. Returns the new expiry.
+func (c *KeyorixCore) RenewLease(ctx context.Context, leaseID string, ttlSeconds int, userID uint) (time.Time, error) {
+	lease, err := c.storage.GetDynamicSecretLease(ctx, leaseID)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("lease not found")
+	}
+	if lease.Status != "active" {
+		return time.Time{}, fmt.Errorf("lease is not active (status %s)", lease.Status)
+	}
+	cfg, err := c.storage.GetDynamicSecretConfig(ctx, lease.ConfigID)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("config not found")
+	}
+	newExpiry := c.now().Add(c.dynamicTTL(cfg, ttlSeconds))
+	// Never let renewal push total lifetime past the config's max-TTL ceiling.
+	if cfg.MaxTTLSeconds > 0 {
+		if hardCap := lease.IssuedAt.Add(time.Duration(cfg.MaxTTLSeconds) * time.Second); newExpiry.After(hardCap) {
+			newExpiry = hardCap
+		}
+	}
+	if !newExpiry.After(lease.ExpiresAt) {
+		return time.Time{}, fmt.Errorf("renewal would not extend the lease (max-TTL ceiling reached)")
+	}
+	engine, err := c.dynamicEngine(cfg.BackendType)
+	if err != nil {
+		return time.Time{}, err
+	}
+	adminDSN, err := c.decryptAuthSecret(cfg.AdminDSNEnc, cfg.AdminDSNMeta)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("failed to decrypt admin DSN: %w", err)
+	}
+	if err := engine.Renew(ctx, adminDSN, lease.RoleName, newExpiry); err != nil {
+		return time.Time{}, fmt.Errorf("failed to renew on target: %w", err)
+	}
+	lease.ExpiresAt = newExpiry
+	if err := c.storage.UpdateDynamicSecretLease(ctx, lease); err != nil {
+		return time.Time{}, err
+	}
+	uid := userID
+	var uidPtr *uint
+	if userID != 0 {
+		uidPtr = &uid
+	}
+	pid := lease.ProjectID
+	c.writeAuditEventFull(ctx, "dynamic_lease.renewed", uidPtr, nil, &pid, "",
+		fmt.Sprintf("renewed dynamic lease %s (new expiry %s)", lease.LeaseID, newExpiry.UTC().Format(time.RFC3339)))
+	return newExpiry, nil
 }

--- a/internal/core/dynamic_secrets_test.go
+++ b/internal/core/dynamic_secrets_test.go
@@ -150,6 +150,66 @@ func TestDynamicSecrets_IssueRejectsUnknownConfig(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestDynamicSecrets_MaxTTLClampsIssue(t *testing.T) {
+	c, _, _, fixed := newDynamicTestCore(t)
+	ctx := context.Background()
+	cfg, err := c.CreateDynamicSecretConfig(ctx, &CreateDynamicSecretConfigRequest{
+		Name: "capped", ProjectID: 1, BackendType: "postgres", AdminDSN: adminDSNPlain,
+		DefaultTTLSeconds: 600, MaxTTLSeconds: 1800,
+	})
+	require.NoError(t, err)
+
+	// Request 1h but the config caps at 30m → expiry is now+30m.
+	issued, err := c.IssueLease(ctx, cfg.ID, 3600, 7)
+	require.NoError(t, err)
+	assert.Equal(t, fixed.Add(30*time.Minute), issued.ExpiresAt, "issue TTL must be clamped to max_ttl_seconds")
+}
+
+func TestDynamicSecrets_CreateRejectsDefaultOverMax(t *testing.T) {
+	c, _, _, _ := newDynamicTestCore(t)
+	_, err := c.CreateDynamicSecretConfig(context.Background(), &CreateDynamicSecretConfigRequest{
+		Name: "bad", ProjectID: 1, BackendType: "postgres", AdminDSN: adminDSNPlain,
+		DefaultTTLSeconds: 3600, MaxTTLSeconds: 600,
+	})
+	require.Error(t, err)
+}
+
+func TestDynamicSecrets_RenewExtendsAndRespectsMaxTTL(t *testing.T) {
+	c, _, fake, fixed := newDynamicTestCore(t)
+	ctx := context.Background()
+	cfg, err := c.CreateDynamicSecretConfig(ctx, &CreateDynamicSecretConfigRequest{
+		Name: "renewable", ProjectID: 1, BackendType: "postgres", AdminDSN: adminDSNPlain,
+		DefaultTTLSeconds: 600, MaxTTLSeconds: 1200, // 10m default, 20m hard cap
+	})
+	require.NoError(t, err)
+
+	issued, err := c.IssueLease(ctx, cfg.ID, 0, 7) // expiry = fixed+10m
+	require.NoError(t, err)
+	require.Equal(t, fixed.Add(10*time.Minute), issued.ExpiresAt)
+
+	// Renew for 20m from now; the fixed clock means now=issue time, so the new
+	// expiry is fixed+20m — exactly the IssuedAt+max ceiling, extending from +10m.
+	exp, err := c.RenewLease(ctx, issued.LeaseID, 1200, 7)
+	require.NoError(t, err)
+	assert.Equal(t, fixed.Add(20*time.Minute), exp)
+	assert.Contains(t, fake.Renewed, issued.Username, "the engine renewed the role")
+
+	// A further renewal can't extend past IssuedAt+max (20m) → rejected.
+	_, err = c.RenewLease(ctx, issued.LeaseID, 1200, 7)
+	require.Error(t, err, "renewal beyond the max-TTL ceiling is rejected")
+}
+
+func TestDynamicSecrets_RenewRejectsInactiveLease(t *testing.T) {
+	c, _, _, _ := newDynamicTestCore(t)
+	ctx := context.Background()
+	cfg := mkConfig(t, c, ctx)
+	issued, err := c.IssueLease(ctx, cfg.ID, 0, 7)
+	require.NoError(t, err)
+	require.NoError(t, c.RevokeLease(ctx, issued.LeaseID, 7, "manual"))
+	_, err = c.RenewLease(ctx, issued.LeaseID, 0, 7)
+	require.Error(t, err, "a revoked lease cannot be renewed")
+}
+
 // TestDynamicSecrets_RealFactoryValidatesBackend checks the real engine factory
 // (no fake): config creation accepts the supported backends and rejects others.
 func TestDynamicSecrets_RealFactoryValidatesBackend(t *testing.T) {

--- a/internal/dynamic/engine.go
+++ b/internal/dynamic/engine.go
@@ -27,6 +27,10 @@ type CredentialEngine interface {
 	Issue(ctx context.Context, adminDSN, creationTemplate string, ttl time.Duration) (cred Credential, roleName string, err error)
 	// Revoke removes the role/credential from the target.
 	Revoke(ctx context.Context, adminDSN, roleName string) error
+	// Renew extends the credential's validity to expiresAt on backends that carry a
+	// DB-level expiry (PostgreSQL VALID UNTIL). Backends without one (MySQL) make it
+	// a no-op — the lease's new expiry is enforced by the auto-revoke sweep.
+	Renew(ctx context.Context, adminDSN, roleName string, expiresAt time.Time) error
 	BackendType() string
 }
 
@@ -64,11 +68,13 @@ func randString(n int) (string, error) {
 // FakeEngine is an in-memory engine for tests: it records issued and revoked
 // roles without touching any real database.
 type FakeEngine struct {
-	mu        sync.Mutex
-	Issued    []string
-	Revoked   []string
-	FailIssue bool
+	mu         sync.Mutex
+	Issued     []string
+	Revoked    []string
+	Renewed    []string
+	FailIssue  bool
 	FailRevoke bool
+	FailRenew  bool
 }
 
 func (f *FakeEngine) BackendType() string { return "fake" }
@@ -96,5 +102,15 @@ func (f *FakeEngine) Revoke(_ context.Context, _, roleName string) error {
 		return fmt.Errorf("fake revoke failure")
 	}
 	f.Revoked = append(f.Revoked, roleName)
+	return nil
+}
+
+func (f *FakeEngine) Renew(_ context.Context, _, roleName string, _ time.Time) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.FailRenew {
+		return fmt.Errorf("fake renew failure")
+	}
+	f.Renewed = append(f.Renewed, roleName)
 	return nil
 }

--- a/internal/dynamic/mysql.go
+++ b/internal/dynamic/mysql.go
@@ -111,6 +111,12 @@ func (e *MySQLEngine) Revoke(ctx context.Context, adminDSN, roleName string) err
 	return nil
 }
 
+// Renew is a no-op for MySQL: accounts carry no VALID UNTIL, so the renewed expiry
+// is enforced entirely by the lease's updated ExpiresAt + the auto-revoke sweep.
+func (e *MySQLEngine) Renew(_ context.Context, _, _ string, _ time.Time) error {
+	return nil
+}
+
 // openMySQL opens and verifies a connection to the target using the admin DSN.
 func openMySQL(ctx context.Context, adminDSN string) (*sql.DB, error) {
 	if _, err := mysql.ParseDSN(adminDSN); err != nil {

--- a/internal/dynamic/postgres.go
+++ b/internal/dynamic/postgres.go
@@ -76,3 +76,20 @@ func (e *PostgresEngine) Revoke(ctx context.Context, adminDSN, roleName string) 
 	}
 	return nil
 }
+
+// Renew extends the role's VALID UNTIL to expiresAt, so the credential stays
+// usable for the renewed window without re-issuing.
+func (e *PostgresEngine) Renew(ctx context.Context, adminDSN, roleName string, expiresAt time.Time) error {
+	conn, err := pgx.Connect(ctx, adminDSN)
+	if err != nil {
+		return fmt.Errorf("connect to target: %w", err)
+	}
+	defer conn.Close(ctx)
+
+	ident := pgx.Identifier{roleName}.Sanitize()
+	validUntil := expiresAt.UTC().Format(time.RFC3339)
+	if _, err := conn.Exec(ctx, fmt.Sprintf("ALTER ROLE %s VALID UNTIL '%s'", ident, validUntil)); err != nil {
+		return fmt.Errorf("renew role %s: %w", roleName, err)
+	}
+	return nil
+}

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -299,10 +299,19 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 		}
 	}
 
-	// Create the dynamic-secrets tables if missing (ADR-035, additive).
+	// Create the dynamic-secrets tables if missing (ADR-035, additive); otherwise add
+	// only the newer max-TTL column via the Migrator (same pgx hazard — never
+	// full-AutoMigrate an existing table here).
 	if !dynConfigExists {
 		if err := db.AutoMigrate(&models.DynamicSecretConfig{}); err != nil {
 			return fmt.Errorf("failed to migrate dynamic_secret_configs table: %w", err)
+		}
+	} else {
+		m := db.Migrator()
+		if !m.HasColumn(&models.DynamicSecretConfig{}, "MaxTTLSeconds") {
+			if err := m.AddColumn(&models.DynamicSecretConfig{}, "MaxTTLSeconds"); err != nil {
+				return fmt.Errorf("failed to add dynamic_secret_configs.max_ttl_seconds column: %w", err)
+			}
 		}
 	}
 	if !dynLeaseExists {

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -275,9 +275,12 @@ type DynamicSecretConfig struct {
 	// "GRANT SELECT ON ALL TABLES IN SCHEMA public TO {{name}};"
 	CreationTemplate string
 	DefaultTTLSeconds int
-	CreatedBy         string
-	CreatedAt         time.Time
-	UpdatedAt         time.Time
+	// MaxTTLSeconds caps the lifetime of any lease from this config (issue + all
+	// renewals), regardless of the TTL a caller requests. 0 = no ceiling.
+	MaxTTLSeconds int
+	CreatedBy     string
+	CreatedAt     time.Time
+	UpdatedAt     time.Time
 }
 
 // DynamicSecretLease is one issued credential: a short-lived role on the target

--- a/server/http/handlers/dynamic_secrets.go
+++ b/server/http/handlers/dynamic_secrets.go
@@ -68,6 +68,7 @@ func (h *DynamicSecretHandler) CreateConfig(w http.ResponseWriter, r *http.Reque
 		AdminDSN          string `json:"admin_dsn"`
 		CreationTemplate  string `json:"creation_template"`
 		DefaultTTLSeconds int    `json:"default_ttl_seconds"`
+		MaxTTLSeconds     int    `json:"max_ttl_seconds"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		sendError(w, "BadRequest", "Invalid request body", http.StatusBadRequest, nil)
@@ -86,6 +87,7 @@ func (h *DynamicSecretHandler) CreateConfig(w http.ResponseWriter, r *http.Reque
 		AdminDSN:          body.AdminDSN,
 		CreationTemplate:  body.CreationTemplate,
 		DefaultTTLSeconds: body.DefaultTTLSeconds,
+		MaxTTLSeconds:     body.MaxTTLSeconds,
 		CreatedBy:         userCtx.Username,
 	})
 	if err != nil {
@@ -192,6 +194,35 @@ func (h *DynamicSecretHandler) RevokeLease(w http.ResponseWriter, r *http.Reques
 	sendSuccess(w, map[string]interface{}{"lease_id": leaseID, "status": "revoked"}, "Lease revoked.")
 }
 
+// RenewLease handles POST /api/v1/dynamic-secrets/leases/{leaseID}/renew
+func (h *DynamicSecretHandler) RenewLease(w http.ResponseWriter, r *http.Request) {
+	userCtx := middleware.GetUserFromContext(r.Context())
+	if userCtx == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	leaseID := chi.URLParam(r, "leaseID")
+	lease, err := h.coreService.GetDynamicSecretLease(r.Context(), leaseID)
+	if err != nil {
+		sendError(w, "NotFound", "Lease not found", http.StatusNotFound, nil)
+		return
+	}
+	if ok, mfaBlocked := h.authorize(r, "secrets.write", core.Scope{ProjectID: lease.ProjectID, EnvironmentID: lease.EnvironmentID}); !ok {
+		h.denyAuthz(w, mfaBlocked)
+		return
+	}
+	var body struct {
+		TTLSeconds int `json:"ttl_seconds"`
+	}
+	_ = json.NewDecoder(r.Body).Decode(&body) // body optional; default TTL on absence
+	newExpiry, err := h.coreService.RenewLease(r.Context(), leaseID, body.TTLSeconds, userCtx.UserID)
+	if err != nil {
+		sendError(w, "Error", err.Error(), http.StatusBadGateway, nil)
+		return
+	}
+	sendSuccess(w, map[string]interface{}{"lease_id": leaseID, "expires_at": newExpiry}, "Lease renewed.")
+}
+
 // loadAuthorizedConfig loads the {id} config and authorizes the caller against
 // its scope. It writes the error response and returns ok=false on failure.
 func (h *DynamicSecretHandler) loadAuthorizedConfig(w http.ResponseWriter, r *http.Request, perm string) (*models.DynamicSecretConfig, bool) {
@@ -224,6 +255,7 @@ func sanitizeConfig(c *models.DynamicSecretConfig) map[string]interface{} {
 		"backend_type":        c.BackendType,
 		"creation_template":   c.CreationTemplate,
 		"default_ttl_seconds": c.DefaultTTLSeconds,
+		"max_ttl_seconds":     c.MaxTTLSeconds,
 		"created_by":          c.CreatedBy,
 		"created_at":          c.CreatedAt,
 	}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -301,6 +301,7 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.Get("/configs/{id}", dynamicSecretHandler.GetConfig)
 			r.Post("/configs/{id}/issue", dynamicSecretHandler.IssueLease)
 			r.Get("/configs/{id}/leases", dynamicSecretHandler.ListLeases)
+			r.Post("/leases/{leaseID}/renew", dynamicSecretHandler.RenewLease)
 			r.Post("/leases/{leaseID}/revoke", dynamicSecretHandler.RevokeLease)
 		})
 


### PR DESCRIPTION
## Summary

Ships two deferred dynamic-secrets lease-lifecycle controls:

- **Per-config max-TTL ceiling** (`DynamicSecretConfig.MaxTTLSeconds`, 0 = none) — the issue TTL is **clamped** to it regardless of what a caller requests, and config creation rejects `default_ttl_seconds` > `max_ttl_seconds`. A real safety control: it bounds credential exposure even when a caller asks for a long TTL.
- **Renewable leases** — `POST /api/v1/dynamic-secrets/leases/{leaseID}/renew {ttl_seconds}` extends an **active** lease's expiry. A new `CredentialEngine.Renew` pushes PostgreSQL's `VALID UNTIL` forward; MySQL is a no-op (sweep-enforced); the fake records it. Renewal is **capped** so a lease's total lifetime from issue can never exceed the config's max-TTL — a renewal that wouldn't extend (cap reached) is rejected.

## Details

- **Migration**: `MaxTTLSeconds` is an additive column with an explicit `Migrator.AddColumn` for existing `dynamic_secret_configs` tables (the create-if-absent block skips already-present tables — the same pattern used for invitations/notifications).
- **Authorization**: renew is gated exactly like revoke — `secrets.write` on the lease's project/environment scope, plus the per-project MFA policy. Audited as `dynamic_lease.renewed`.
- **Engine interface**: `Renew(ctx, adminDSN, roleName, expiresAt)` added to `CredentialEngine`; Postgres `ALTER ROLE … VALID UNTIL` (sanitized identifier, same trust boundary as the rest of the engine), MySQL no-op, FakeEngine records.

## Testing

Core tests: max-TTL clamps the issue expiry; create rejects `default > max`; renew extends the expiry, respects the `IssuedAt + max` ceiling (a further renewal past it is rejected), and records the engine call; renewing an inactive (revoked) lease is rejected. `make build` + full suite + `go vet` green. ADR-035 addendum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)