### PR TITLE
release: prep v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,39 @@
 All notable changes to Keyorix are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## v0.6.0 — 2026-06-12
+
+Key-management flexibility and a more complete dynamic-secrets engine: bring your
+own KEK source (file/KMS/env), mint on-demand MySQL credentials, and cap or renew
+leases — plus a full configuration reference.
+
+### Added
+- **Pluggable KEK providers** — the key-encryption key can now be sourced from a
+  passphrase (default, unchanged), a **file** (a mounted CSI/sealed secret or KMS
+  sidecar output), or an **environment variable** (KMS/secret-manager injection),
+  via `storage.encryption.key_provider`. The default `password` provider is
+  byte-identical to prior releases, so existing keys keep working with no
+  migration. ([#106], ADR-038)
+- **Dynamic secrets for MySQL** — on-demand MySQL accounts alongside the existing
+  PostgreSQL engine, behind the same API (`backend_type: mysql`). ([#107], ADR-035)
+- **Dynamic-secret lease lifecycle** — a per-config **max-TTL ceiling** that caps
+  a credential's lifetime regardless of the TTL a caller requests, and **lease
+  renewal** (`POST /dynamic-secrets/leases/{id}/renew`) to extend an active lease
+  up to that ceiling instead of re-issuing. ([#109], ADR-035)
+- **Configuration reference** — `docs/CONFIGURATION.md` documents every
+  `keyorix.yaml` block (encryption/KEK providers, MFA, WebAuthn, dynamic secrets,
+  OIDC, sessions, …) with examples, defaults, and environment variables. ([#108])
+
+### Fixed
+- The shipped `production.yaml` example used cron syntax for `purge.schedule`,
+  which is parsed as a Go duration and silently fell back to the 24h default;
+  corrected to a duration with a clarifying comment. ([#108])
+
+[#106]: https://github.com/keyorixhq/keyorix/pull/106
+[#107]: https://github.com/keyorixhq/keyorix/pull/107
+[#108]: https://github.com/keyorixhq/keyorix/pull/108
+[#109]: https://github.com/keyorixhq/keyorix/pull/109
+
 ## v0.5.0 — 2026-06-12
 
 The authentication & dynamic-secrets release: phishing-resistant passkeys, MFA

--- a/deploy/helm/keyorix/Chart.yaml
+++ b/deploy/helm/keyorix/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix
 description: Self-hosted Keyorix secrets manager (API server + web UI + PostgreSQL)
 type: application
 # Chart version — bump on chart changes.
-version: 0.5.0
+version: 0.6.0
 # The Keyorix app version this chart deploys by default (the image tag).
-appVersion: "0.5.0"
+appVersion: "0.6.0"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix


### PR DESCRIPTION
## Summary

Prepares **v0.6.0** — the key-management & dynamic-secrets release. Four PRs since v0.5.0:

- **Pluggable KEK providers** — file/env/password KEK sources ([#106], ADR-038)
- **MySQL dynamic secrets** — second backend engine ([#107], ADR-035)
- **Lease lifecycle** — per-config max-TTL ceiling + renewable leases ([#109], ADR-035)
- **Configuration reference** — `docs/CONFIGURATION.md` + `production.yaml` purge-schedule fix ([#108])

## Changes

- `CHANGELOG.md` — new v0.6.0 section (Added + Fixed)
- `deploy/helm/keyorix/Chart.yaml` — `version` + `appVersion` → `0.6.0`

Merging this, then pushing the `v0.6.0` tag, triggers the release pipeline (binaries + checksums → GitHub Release; chart → `oci://ghcr.io/keyorixhq/charts`; server image `ghcr.io/keyorixhq/keyorix-server:0.6.0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)