### PR TITLE
feat(ha): single-replica background schedulers via advisory lock (ADR-039)

### DIFF
--- a/docs/adr-039-ha-deployment.md
+++ b/docs/adr-039-ha-deployment.md
@@ -1,0 +1,91 @@
+# ADR-039: High-availability deployment (multiple API replicas)
+
+**Status:** Accepted
+**Date:** 2026-06-12
+
+## Context
+
+Enterprise and on-prem buyers (the ENS/ENISA track) expect to run Keyorix
+highly-available: several stateless API replicas behind a load balancer, backed by
+an HA PostgreSQL. Most of the server is already replica-safe — sessions and tokens
+are DB-backed, the per-replica token/session caches are short-TTL and
+stale-tolerant, and the audit hash chain already serializes appends with a
+PostgreSQL advisory lock (ADR-029). Two gaps remained:
+
+1. **Encryption keys** were derived from a local passphrase + on-disk salt, which
+   each replica would have to reproduce. (Solved by ADR-038: a `file` or `env` KEK
+   provider lets every replica read the same externally-managed KEK.)
+2. **Background schedulers** (anomaly detection, retention purge, dynamic-secrets
+   auto-revoke) ran unconditionally on *every* replica — so N replicas duplicated
+   the work: N copies of each anomaly alert, concurrent purge DELETEs, and N
+   replicas connecting to the same target databases to revoke the same expired
+   leases. None corrupts data (the operations are idempotent), but it is wasteful
+   and operationally noisy, and the lease sweep could storm target DBs.
+
+## Decision
+
+Run each background scheduler on **one replica at a time**, gated by a PostgreSQL
+**advisory lock**, and document the supported HA topology.
+
+- **Scheduler singleton lock.** `Storage.WithSchedulerLock(ctx, key, fn)` runs `fn`
+  only if this process can take the advisory lock `key`. On PostgreSQL it uses a
+  session `pg_try_advisory_lock` on a dedicated pooled connection (released with
+  `pg_advisory_unlock` before the connection returns to the pool); if another
+  replica holds it, the call returns `ran=false` and the tick is skipped. On
+  SQLite (inherently single-instance) `fn` always runs. Each of the three
+  schedulers uses a distinct, namespaced key, separate from the audit-chain key.
+  This is **per-tick** gating — no long-lived leader, no leader-death handling: if
+  the running replica dies, the next replica simply wins the next tick.
+- **Shared KEK.** For multiple replicas, configure
+  `storage.encryption.key_provider` as `file` or `env` (ADR-038) so every replica
+  unwraps the same DEK. The default `password` provider also works if every
+  replica is given the same `KEYORIX_MASTER_PASSWORD` *and* shares the `kek.salt`
+  file — but file/env is the recommended HA path (no shared filesystem needed).
+- **PostgreSQL is required for HA.** SQLite is a single-file, single-process store;
+  it is supported only for single-instance / development. HA = PostgreSQL (itself
+  made HA by the operator: managed Postgres, Patroni, or similar).
+
+## Topology
+
+```
+        ┌─ load balancer ─┐
+        │        │        │
+     replica  replica  replica     (stateless API; identical config)
+        └────────┼────────┘
+            HA PostgreSQL           (sessions, secrets, audit chain, lock)
+                 │
+         external KEK source        (KMS / CSI / sealed secret → file or env provider)
+```
+
+All replicas are interchangeable. One holds each scheduler's advisory lock at any
+moment and does the periodic work; the rest serve API traffic and skip the job.
+
+## Consequences & caveats
+
+- **Per-replica state that is acceptable**: the 30-second token/session caches and
+  the negative-auth cache are process-local but short-lived and stale-tolerant —
+  eventual consistency within the TTL is fine for session tokens (which are
+  revocable and DB-authoritative).
+- **Login rate limiting is per-replica** (an in-memory sliding window). Across N
+  replicas an attacker could get up to N× the per-replica budget by spreading
+  attempts. For HA, enforce login/auth rate limits at the **load balancer / API
+  gateway / WAF**, or treat the per-replica limit as a backstop. Documented, not
+  yet centralized.
+- **No data-loss risk from the schedulers either way**: the gating is an
+  efficiency/cleanliness improvement; the underlying operations were already
+  idempotent (status checks on revoke, soft-delete cutoffs on purge).
+
+## Verification
+
+`WithSchedulerLock` runs the job and propagates its result on SQLite (the
+single-instance path), and is re-entrant there. The PostgreSQL advisory-lock
+semantics (`pg_try_advisory_lock` / `pg_advisory_unlock`) are the same primitive
+already relied on by the audit chain (ADR-029). `make build` + full suite + `go
+vet` green.
+
+## Deferred
+
+Centralized (Redis/DB-backed) login rate limiting across replicas; making anomaly
+detection opt-in; a config-time warning when the `password` KEK provider is used
+without a shared salt; automated multi-replica integration tests against a live
+PostgreSQL.

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -14,6 +14,11 @@ type MockStorage struct {
 	mock.Mock
 }
 
+// WithSchedulerLock runs fn directly in tests (single instance, no DB lock).
+func (m *MockStorage) WithSchedulerLock(_ context.Context, _ int64, fn func() error) (bool, error) {
+	return true, fn()
+}
+
 // Permission Management
 
 func (m *MockStorage) CreatePermission(_ context.Context, permission *models.Permission) (*models.Permission, error) {

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -11,6 +11,13 @@ import (
 // This interface abstracts away the underlying storage implementation,
 // allowing for both local database access and remote API calls
 type Storage interface {
+	// WithSchedulerLock runs fn only if this process can take the named scheduler
+	// lock, so a background job runs on a single replica at a time (HA, ADR-039).
+	// On PostgreSQL it uses a session advisory lock (pg_try_advisory_lock); on
+	// SQLite (single instance) fn always runs. Returns ran=false (and nil error)
+	// when another replica holds the lock — the caller should simply skip this tick.
+	WithSchedulerLock(ctx context.Context, key int64, fn func() error) (ran bool, err error)
+
 	// Project / Environment management
 	CreateProject(ctx context.Context, project *models.Project) (*models.Project, error)
 	GetProject(ctx context.Context, id uint) (*models.Project, error)

--- a/internal/storage/store/local_scheduler_lock.go
+++ b/internal/storage/store/local_scheduler_lock.go
@@ -1,0 +1,42 @@
+// local_scheduler_lock.go — single-replica gating for background schedulers
+// (ADR-039 HA). On PostgreSQL a session-scoped advisory lock ensures only one
+// replica runs a given periodic job (purge, dynamic-secrets sweep, anomaly
+// detection) per tick; on SQLite (inherently single-instance) the job always runs.
+package store
+
+import "context"
+
+// WithSchedulerLock runs fn iff this process can acquire the advisory lock `key`.
+//
+// PostgreSQL: takes a session advisory lock on a dedicated pooled connection via
+// pg_try_advisory_lock. If another replica holds it, returns (false, nil) so the
+// caller skips this tick. The lock is always released (pg_advisory_unlock) before
+// the connection returns to the pool — a session lock would otherwise outlive the
+// tick on the pooled connection.
+//
+// SQLite / non-Postgres: there is only one instance, so fn always runs.
+func (ls *LocalStorage) WithSchedulerLock(ctx context.Context, key int64, fn func() error) (bool, error) {
+	if ls.db.Dialector.Name() != "postgres" {
+		return true, fn()
+	}
+	sqlDB, err := ls.db.DB()
+	if err != nil {
+		return false, err
+	}
+	conn, err := sqlDB.Conn(ctx)
+	if err != nil {
+		return false, err
+	}
+	defer conn.Close() // returns the conn to the pool (after the unlock below)
+
+	var locked bool
+	if err := conn.QueryRowContext(ctx, "SELECT pg_try_advisory_lock($1)", key).Scan(&locked); err != nil {
+		return false, err
+	}
+	if !locked {
+		return false, nil // another replica is running this job — skip
+	}
+	// Release before the deferred Close so the pooled connection carries no lock.
+	defer func() { _, _ = conn.ExecContext(ctx, "SELECT pg_advisory_unlock($1)", key) }()
+	return true, fn()
+}

--- a/internal/storage/store/local_scheduler_lock.go
+++ b/internal/storage/store/local_scheduler_lock.go
@@ -4,7 +4,23 @@
 // detection) per tick; on SQLite (inherently single-instance) the job always runs.
 package store
 
-import "context"
+import (
+	"context"
+	"fmt"
+)
+
+// runProtected runs a scheduler job, converting a panic into an error so a single
+// bad tick can't kill the scheduler goroutine (and so the advisory lock is still
+// released by the caller's defers). Mirrors that the pre-ADR-039 schedulers had no
+// panic guard either, but this is now the natural choke point to add one.
+func runProtected(fn func() error) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("scheduler job panicked: %v", r)
+		}
+	}()
+	return fn()
+}
 
 // WithSchedulerLock runs fn iff this process can acquire the advisory lock `key`.
 //
@@ -17,7 +33,7 @@ import "context"
 // SQLite / non-Postgres: there is only one instance, so fn always runs.
 func (ls *LocalStorage) WithSchedulerLock(ctx context.Context, key int64, fn func() error) (bool, error) {
 	if ls.db.Dialector.Name() != "postgres" {
-		return true, fn()
+		return true, runProtected(fn)
 	}
 	sqlDB, err := ls.db.DB()
 	if err != nil {
@@ -38,5 +54,5 @@ func (ls *LocalStorage) WithSchedulerLock(ctx context.Context, key int64, fn fun
 	}
 	// Release before the deferred Close so the pooled connection carries no lock.
 	defer func() { _, _ = conn.ExecContext(ctx, "SELECT pg_advisory_unlock($1)", key) }()
-	return true, fn()
+	return true, runProtected(fn)
 }

--- a/internal/storage/store/local_scheduler_lock_test.go
+++ b/internal/storage/store/local_scheduler_lock_test.go
@@ -1,0 +1,45 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func newSchedLockStore(t *testing.T) *LocalStorage {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	return NewLocalStorage(db)
+}
+
+// On SQLite (single instance) the job always runs and fn's result propagates.
+func TestWithSchedulerLock_SQLiteAlwaysRuns(t *testing.T) {
+	ls := newSchedLockStore(t)
+	ctx := context.Background()
+
+	ran := false
+	got, err := ls.WithSchedulerLock(ctx, 123, func() error {
+		ran = true
+		return nil
+	})
+	require.NoError(t, err)
+	assert.True(t, got, "ran=true on SQLite")
+	assert.True(t, ran, "fn executed")
+
+	// fn's error propagates, still ran=true.
+	sentinel := errors.New("boom")
+	got, err = ls.WithSchedulerLock(ctx, 123, func() error { return sentinel })
+	assert.True(t, got)
+	require.ErrorIs(t, err, sentinel)
+
+	// Re-entrant: a second call still runs (no held lock on SQLite).
+	got, err = ls.WithSchedulerLock(ctx, 123, func() error { return nil })
+	require.NoError(t, err)
+	assert.True(t, got)
+}

--- a/internal/storage/store/local_scheduler_lock_test.go
+++ b/internal/storage/store/local_scheduler_lock_test.go
@@ -43,3 +43,15 @@ func TestWithSchedulerLock_SQLiteAlwaysRuns(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, got)
 }
+
+// A panic in the job is converted to an error rather than killing the caller's
+// scheduler goroutine.
+func TestWithSchedulerLock_RecoversPanic(t *testing.T) {
+	ls := newSchedLockStore(t)
+	got, err := ls.WithSchedulerLock(context.Background(), 7, func() error {
+		panic("kaboom")
+	})
+	assert.True(t, got)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "panicked")
+}

--- a/internal/storage/store/remote_scheduler_lock.go
+++ b/internal/storage/store/remote_scheduler_lock.go
@@ -1,0 +1,10 @@
+package store
+
+import "context"
+
+// WithSchedulerLock is server-side only — background schedulers run on the server
+// (LocalStorage), never the remote client. A remote caller never reaches this, so
+// it conservatively reports "not acquired" and runs nothing.
+func (rs *RemoteStorage) WithSchedulerLock(_ context.Context, _ int64, _ func() error) (bool, error) {
+	return false, remoteUnsupported("WithSchedulerLock")
+}

--- a/server/main.go
+++ b/server/main.go
@@ -130,6 +130,15 @@ func main() {
 	}
 }
 
+// Scheduler advisory-lock keys (ADR-039) — arbitrary distinct constants,
+// namespaced to each background job, so on PostgreSQL only one replica runs a
+// given scheduler per tick. Distinct from the audit-chain key (0x4B455941_55444954).
+const (
+	schedLockAnomaly      int64 = 0x4B455953_414E4F4D // "KEYSANOM"
+	schedLockPurge        int64 = 0x4B455953_50555247 // "KEYSPURG"
+	schedLockDynamicSweep int64 = 0x4B455953_44594E53 // "KEYSDYNS"
+)
+
 // initializeEncryption sources the KEK per the configured key provider (ADR-038)
 // and returns an initialized encryption.Service. If encryption is disabled in
 // config, it returns nil without error. For the default "password" provider it
@@ -309,17 +318,22 @@ func startHTTPServer(ctx context.Context, cfg *config.Config) error {
 		return fmt.Errorf("failed to create HTTP router: %w", err)
 	}
 
-	// Start anomaly detection scheduler (runs every hour)
+	// Start anomaly detection scheduler (runs every hour). Single-replica-gated
+	// (ADR-039) so N replicas don't emit N copies of each alert.
 	go func() {
 		detector := core.NewAnomalyDetector(coreService.Storage())
 		ticker := time.NewTicker(1 * time.Hour)
 		defer ticker.Stop()
-		// Run once immediately on startup
-		_ = detector.RunDetection(ctx, coreService.ListActiveSecrets(ctx))
+		runDetect := func() {
+			_, _ = coreService.Storage().WithSchedulerLock(ctx, schedLockAnomaly, func() error {
+				return detector.RunDetection(ctx, coreService.ListActiveSecrets(ctx))
+			})
+		}
+		runDetect() // run once immediately on startup
 		for {
 			select {
 			case <-ticker.C:
-				_ = detector.RunDetection(ctx, coreService.ListActiveSecrets(ctx))
+				runDetect()
 			case <-ctx.Done():
 				return
 			}
@@ -336,13 +350,20 @@ func startHTTPServer(ctx context.Context, cfg *config.Config) error {
 			ticker := time.NewTicker(interval)
 			defer ticker.Stop()
 			runPurge := func() {
-				cutoff := time.Now().AddDate(0, 0, -retentionDays)
-				if res, err := coreService.PurgeExpiredSoftDeletes(ctx, cutoff); err != nil {
-					log.Printf("Retention purge error: %v", err)
-				} else if res.Total() > 0 {
-					log.Printf("Retention purge removed %d soft-deleted records (users=%d, projects=%d, environments=%d, secrets=%d)",
-						res.Total(), res.Users, res.Projects, res.Environments, res.Secrets)
-				}
+				// Single-replica-gated (ADR-039): only one replica runs the purge.
+				_, _ = coreService.Storage().WithSchedulerLock(ctx, schedLockPurge, func() error {
+					cutoff := time.Now().AddDate(0, 0, -retentionDays)
+					res, err := coreService.PurgeExpiredSoftDeletes(ctx, cutoff)
+					if err != nil {
+						log.Printf("Retention purge error: %v", err)
+						return err
+					}
+					if res.Total() > 0 {
+						log.Printf("Retention purge removed %d soft-deleted records (users=%d, projects=%d, environments=%d, secrets=%d)",
+							res.Total(), res.Users, res.Projects, res.Environments, res.Secrets)
+					}
+					return nil
+				})
 			}
 			runPurge() // run once on startup
 			for {
@@ -365,11 +386,19 @@ func startHTTPServer(ctx context.Context, cfg *config.Config) error {
 			ticker := time.NewTicker(interval)
 			defer ticker.Stop()
 			runSweep := func() {
-				if n, err := coreService.RevokeExpiredLeases(ctx, time.Now()); err != nil {
-					log.Printf("Dynamic-secrets sweep error: %v", err)
-				} else if n > 0 {
-					log.Printf("Dynamic-secrets sweep revoked %d expired lease(s)", n)
-				}
+				// Single-replica-gated (ADR-039): one replica revokes per tick, so
+				// replicas don't storm the target DBs revoking the same leases.
+				_, _ = coreService.Storage().WithSchedulerLock(ctx, schedLockDynamicSweep, func() error {
+					n, err := coreService.RevokeExpiredLeases(ctx, time.Now())
+					if err != nil {
+						log.Printf("Dynamic-secrets sweep error: %v", err)
+						return err
+					}
+					if n > 0 {
+						log.Printf("Dynamic-secrets sweep revoked %d expired lease(s)", n)
+					}
+					return nil
+				})
 			}
 			runSweep() // run once on startup
 			for {

--- a/server/main.go
+++ b/server/main.go
@@ -325,9 +325,11 @@ func startHTTPServer(ctx context.Context, cfg *config.Config) error {
 		ticker := time.NewTicker(1 * time.Hour)
 		defer ticker.Stop()
 		runDetect := func() {
-			_, _ = coreService.Storage().WithSchedulerLock(ctx, schedLockAnomaly, func() error {
+			if _, err := coreService.Storage().WithSchedulerLock(ctx, schedLockAnomaly, func() error {
 				return detector.RunDetection(ctx, coreService.ListActiveSecrets(ctx))
-			})
+			}); err != nil {
+				log.Printf("Anomaly detection scheduler error: %v", err)
+			}
 		}
 		runDetect() // run once immediately on startup
 		for {
@@ -351,7 +353,7 @@ func startHTTPServer(ctx context.Context, cfg *config.Config) error {
 			defer ticker.Stop()
 			runPurge := func() {
 				// Single-replica-gated (ADR-039): only one replica runs the purge.
-				_, _ = coreService.Storage().WithSchedulerLock(ctx, schedLockPurge, func() error {
+				if _, err := coreService.Storage().WithSchedulerLock(ctx, schedLockPurge, func() error {
 					cutoff := time.Now().AddDate(0, 0, -retentionDays)
 					res, err := coreService.PurgeExpiredSoftDeletes(ctx, cutoff)
 					if err != nil {
@@ -363,7 +365,9 @@ func startHTTPServer(ctx context.Context, cfg *config.Config) error {
 							res.Total(), res.Users, res.Projects, res.Environments, res.Secrets)
 					}
 					return nil
-				})
+				}); err != nil {
+					log.Printf("Retention purge scheduler error: %v", err)
+				}
 			}
 			runPurge() // run once on startup
 			for {
@@ -388,17 +392,19 @@ func startHTTPServer(ctx context.Context, cfg *config.Config) error {
 			runSweep := func() {
 				// Single-replica-gated (ADR-039): one replica revokes per tick, so
 				// replicas don't storm the target DBs revoking the same leases.
-				_, _ = coreService.Storage().WithSchedulerLock(ctx, schedLockDynamicSweep, func() error {
-					n, err := coreService.RevokeExpiredLeases(ctx, time.Now())
-					if err != nil {
-						log.Printf("Dynamic-secrets sweep error: %v", err)
-						return err
+				if _, err := coreService.Storage().WithSchedulerLock(ctx, schedLockDynamicSweep, func() error {
+					n, rerr := coreService.RevokeExpiredLeases(ctx, time.Now())
+					if rerr != nil {
+						log.Printf("Dynamic-secrets sweep error: %v", rerr)
+						return rerr
 					}
 					if n > 0 {
 						log.Printf("Dynamic-secrets sweep revoked %d expired lease(s)", n)
 					}
 					return nil
-				})
+				}); err != nil {
+					log.Printf("Dynamic-secrets sweep scheduler error: %v", err)
+				}
 			}
 			runSweep() // run once on startup
 			for {


### PR DESCRIPTION
## Summary

Makes Keyorix safely **HA-deployable** — multiple stateless API replicas behind a load balancer, backed by HA PostgreSQL. The auth path was already replica-safe (DB-backed sessions; short-TTL, stale-tolerant token/session caches), and ADR-038's file/env KEK providers let every replica share the KEK. The remaining gap: the three background schedulers (anomaly detection, retention purge, dynamic-secrets auto-revoke) ran on **every** replica — duplicating alerts, issuing concurrent purge DELETEs, and having N replicas storm the target databases to revoke the same expired leases (idempotent, but wasteful and noisy).

## What's in it

- **`Storage.WithSchedulerLock(ctx, key, fn)`** — runs `fn` only if this process can take the advisory lock `key`:
  - **PostgreSQL**: a session `pg_try_advisory_lock` on a dedicated pooled connection, released with `pg_advisory_unlock` *before* the connection returns to the pool. Another replica holding it → `ran=false`, the tick is skipped.
  - **SQLite** (single instance): `fn` always runs.
  - **Per-tick** gating: no long-lived leader, no leader-death handling — if the running replica dies, the next one wins the next tick. Reuses the same advisory-lock primitive the audit chain already relies on (ADR-029).
- **`main.go`** wraps all three schedulers, each with a distinct namespaced key.
- **ADR-039** documents the supported HA topology (stateless replicas + HA Postgres + shared KEK via file/env provider) and the known caveats.

## Documented caveats (in the ADR)

- **Login rate limiting is per-replica** (in-memory sliding window) — across N replicas an attacker gets up to N× the budget. For HA, enforce auth rate limits at the gateway/WAF; the per-replica limit is a backstop. (Deferred: centralized rate limiting.)
- **SQLite is single-instance only**; HA requires PostgreSQL.

## Testing

`WithSchedulerLock` runs the job and propagates its result on the SQLite (single-instance) path and is re-entrant there. The PostgreSQL advisory-lock semantics are the same primitive the audit chain already uses in production. Remote + mock stubs added. `make build` + full suite + `go vet` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)