### PR TITLE
feat(auth): WebAuthn passwordless (usernameless) login (ADR-036)

### DIFF
--- a/docs/adr-036-webauthn-passkeys.md
+++ b/docs/adr-036-webauthn-passkeys.md
@@ -82,7 +82,32 @@ itself is covered by the go-webauthn library's own test suite.)
 
 ## Deferred
 
-Discoverable-credential / usernameless passkey login (passwordless first factor);
-"remember this device" trusted-device skip; per-credential UV policy and
-attestation-format allowlists; WebAuthn for the CLI. WebAuthn here is a second
-factor for interactive human login, not for PAT/machine/OIDC paths.
+"Remember this device" trusted-device skip; per-credential UV policy and
+attestation-format allowlists; WebAuthn for the CLI. WebAuthn (second factor or
+passwordless) is for interactive human login, not PAT/machine/OIDC paths.
+
+## Addendum (2026-06-12): passwordless (usernameless) login
+
+The originally-deferred discoverable-credential flow shipped: a registered passkey
+alone can mint a session, no password.
+
+- **Registration** now requests a **discoverable (resident) credential**
+  (`ResidentKeyRequirement: preferred` — backward-compatible; authenticators that
+  can't store a resident key still register for the second-factor flow), so the
+  passkey can later be found usernamelessly.
+- **`POST /auth/webauthn/passwordless/begin`** (public, no body) →
+  `BeginDiscoverableLogin` with **user verification REQUIRED**, so the single
+  passkey gesture proves *possession + user* (MFA-grade) — a complete login, not
+  just a possession check. Returns assertion options + an opaque ceremony session.
+- **`POST /auth/webauthn/passwordless/finish`** `{webauthn_session, credential}` →
+  consumes the single-use session, and a `DiscoverableUserHandler` resolves the
+  user from the assertion's **user handle** (our 8-byte `WebAuthnID`).
+  `ValidatePasskeyLogin` then verifies the assertion **against that user's own
+  stored credentials** — so a forged user handle can't be paired with someone
+  else's credential. The account-state gate (`AccountLoginBlocked`) is enforced
+  here, since there is no password step to gate a suspended account. Audited
+  `webauthn.passwordless_login`.
+
+Because the resulting session belongs to a `WebAuthnEnabled` user, it satisfies
+the `require_mfa` mandate inherently. Still deferred: trusted-device skip,
+per-credential UV/attestation policy, CLI WebAuthn.

--- a/internal/core/webauthn.go
+++ b/internal/core/webauthn.go
@@ -102,7 +102,14 @@ func (c *KeyorixCore) BeginWebAuthnRegistration(ctx context.Context, userID uint
 	for i := range wu.creds {
 		exclusions = append(exclusions, wu.creds[i].Descriptor())
 	}
-	creation, sd, err := c.webauthnRP.BeginRegistration(wu, webauthn.WithExclusions(exclusions))
+	// Request a discoverable (resident) credential so the passkey can also be used
+	// for passwordless login (ADR-036 addendum). "preferred" is backward-compatible:
+	// authenticators that can't store a resident key still register for the
+	// second-factor flow.
+	creation, sd, err := c.webauthnRP.BeginRegistration(wu,
+		webauthn.WithExclusions(exclusions),
+		webauthn.WithResidentKeyRequirement(protocol.ResidentKeyRequirementPreferred),
+	)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to begin registration: %w", err)
 	}
@@ -271,6 +278,90 @@ func (c *KeyorixCore) FinishWebAuthnLogin(ctx context.Context, challenge, sessio
 	c.writeAuditEventFull(ctx, "webauthn.login_verified", &uid, nil, nil, ip,
 		fmt.Sprintf("user %s passed WebAuthn", wu.user.Username))
 	return session, wu.user, nil
+}
+
+// BeginWebAuthnPasswordlessLogin starts a discoverable (usernameless) login. No
+// user is identified yet — the authenticator reveals which resident passkey (and
+// thus which user) to use. User verification is REQUIRED, so the single passkey
+// gesture proves both possession and the user (MFA-grade), making this a complete
+// passwordless login. Returns the assertion options + an opaque session token.
+func (c *KeyorixCore) BeginWebAuthnPasswordlessLogin(ctx context.Context) (*protocol.CredentialAssertion, string, error) {
+	if c.webauthnRP == nil {
+		return nil, "", ErrWebAuthnDisabled
+	}
+	assertion, sd, err := c.webauthnRP.BeginDiscoverableLogin(
+		webauthn.WithUserVerification(protocol.VerificationRequired),
+	)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to begin passwordless login: %w", err)
+	}
+	// userID is unknown until finish resolves it from the credential's user handle.
+	token, err := c.storeWebAuthnSession(ctx, 0, "passwordless", sd)
+	if err != nil {
+		return nil, "", err
+	}
+	return assertion, token, nil
+}
+
+// FinishWebAuthnPasswordlessLogin verifies a discoverable assertion, resolves the
+// user from the credential's user handle, enforces account state, and mints a
+// session — a full login from a single passkey, no password.
+func (c *KeyorixCore) FinishWebAuthnPasswordlessLogin(ctx context.Context, sessionToken, userAgent, ip string, parsed *protocol.ParsedCredentialAssertionData) (*models.Session, *models.User, error) {
+	if c.webauthnRP == nil {
+		return nil, nil, ErrWebAuthnDisabled
+	}
+	sess, err := c.storage.ConsumeWebAuthnSession(ctx, sha256Hex(sessionToken), c.now())
+	if err != nil {
+		return nil, nil, fmt.Errorf("invalid or expired webauthn session")
+	}
+	if sess.Purpose != "passwordless" {
+		return nil, nil, fmt.Errorf("webauthn session mismatch")
+	}
+	var sd webauthn.SessionData
+	if err := json.Unmarshal(sess.Data, &sd); err != nil {
+		return nil, nil, err
+	}
+
+	// The discoverable handler resolves the user from the 8-byte user handle that
+	// the authenticator returns (our WebAuthnID encoding). ValidatePasskeyLogin then
+	// verifies the assertion against that user's stored credentials.
+	var resolved *models.User
+	handler := func(_, userHandle []byte) (webauthn.User, error) {
+		if len(userHandle) != 8 {
+			return nil, fmt.Errorf("unexpected user handle")
+		}
+		uid := uint(binary.BigEndian.Uint64(userHandle))
+		wu, err := c.loadWebAuthnUser(ctx, uid)
+		if err != nil {
+			return nil, err
+		}
+		resolved = wu.user
+		return wu, nil
+	}
+	_, cred, err := c.webauthnRP.ValidatePasskeyLogin(handler, sd, parsed)
+	if err != nil || resolved == nil {
+		c.writeAuditEventFull(ctx, "webauthn.failed", nil, nil, nil, ip, "failed passwordless WebAuthn login")
+		return nil, nil, fmt.Errorf("assertion verification failed: %w", err)
+	}
+	// A passwordless login is still a login: a suspended/blocked account is refused
+	// (the password path's AccountLoginBlocked gate has no equivalent here).
+	if AccountLoginBlocked(resolved.AccountState) {
+		return nil, nil, fmt.Errorf("account suspended")
+	}
+	c.persistUpdatedCredential(ctx, resolved.ID, cred)
+
+	session, err := c.mintSession(ctx, resolved.ID, userAgent, ip)
+	if err != nil {
+		return nil, nil, err
+	}
+	uid := resolved.ID
+	if cred.Authenticator.CloneWarning {
+		c.writeAuditEventFull(ctx, "webauthn.clone_warning", &uid, nil, nil, ip,
+			fmt.Sprintf("possible cloned authenticator for user %s (signature counter did not advance)", resolved.Username))
+	}
+	c.writeAuditEventFull(ctx, "webauthn.passwordless_login", &uid, nil, nil, ip,
+		fmt.Sprintf("user %s logged in passwordlessly via WebAuthn", resolved.Username))
+	return session, resolved, nil
 }
 
 // persistUpdatedCredential writes back the credential's advanced signature counter

--- a/internal/core/webauthn_test.go
+++ b/internal/core/webauthn_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-webauthn/webauthn/protocol"
 	"github.com/go-webauthn/webauthn/webauthn"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/keyorixhq/keyorix/internal/storage/store"
@@ -137,6 +138,50 @@ func TestWebAuthn_DeleteClearsFlagOnLastAndIsUserScoped(t *testing.T) {
 	var user models.User
 	require.NoError(t, db.First(&user, 1).Error)
 	assert.False(t, user.WebAuthnEnabled, "removing the last passkey disables WebAuthn")
+}
+
+func TestWebAuthn_PasswordlessBeginIssuesSession(t *testing.T) {
+	c, _ := newWebAuthnTestCore(t, true)
+	ctx := context.Background()
+
+	assertion, token, err := c.BeginWebAuthnPasswordlessLogin(ctx)
+	require.NoError(t, err)
+	require.NotEmpty(t, token)
+	require.NotEmpty(t, assertion.Response.Challenge)
+	// Usernameless: no specific credential is pre-listed (the authenticator picks).
+	assert.Empty(t, assertion.Response.AllowedCredentials)
+	// User verification is required so the single gesture is MFA-grade.
+	assert.Equal(t, protocol.VerificationRequired, assertion.Response.UserVerification)
+
+	// The ceremony session is stored single-use with the passwordless purpose.
+	sess, err := c.storage.ConsumeWebAuthnSession(ctx, sha256Hex(token), c.now())
+	require.NoError(t, err)
+	assert.Equal(t, "passwordless", sess.Purpose)
+}
+
+func TestWebAuthn_PasswordlessDisabledServerRejects(t *testing.T) {
+	c, _ := newWebAuthnTestCore(t, false)
+	ctx := context.Background()
+	_, _, err := c.BeginWebAuthnPasswordlessLogin(ctx)
+	require.ErrorIs(t, err, ErrWebAuthnDisabled)
+	_, _, err = c.FinishWebAuthnPasswordlessLogin(ctx, "tok", "ua", "1.2.3.4", nil)
+	require.ErrorIs(t, err, ErrWebAuthnDisabled)
+}
+
+func TestWebAuthn_PasswordlessFinishRejectsWrongPurposeSession(t *testing.T) {
+	c, _ := newWebAuthnTestCore(t, true)
+	ctx := context.Background()
+	// A session minted for the second-factor flow must not complete a passwordless
+	// login (purpose check runs before any assertion validation).
+	sd := &webauthn.SessionData{Challenge: "x"}
+	tok, err := c.storeWebAuthnSession(ctx, 1, "login", sd)
+	require.NoError(t, err)
+	_, _, err = c.FinishWebAuthnPasswordlessLogin(ctx, tok, "ua", "1.2.3.4", nil)
+	require.Error(t, err)
+
+	// An unknown/expired session token is rejected too.
+	_, _, err = c.FinishWebAuthnPasswordlessLogin(ctx, "nope", "ua", "1.2.3.4", nil)
+	require.Error(t, err)
 }
 
 func TestWebAuthn_FinishLoginRejectsMismatchedSession(t *testing.T) {

--- a/server/http/handlers/webauthn.go
+++ b/server/http/handlers/webauthn.go
@@ -179,6 +179,58 @@ func (h *AuthHandler) FinishWebAuthnLogin(w http.ResponseWriter, r *http.Request
 	sendSuccess(w, resp, "Login successful")
 }
 
+// BeginWebAuthnPasswordlessLogin starts a usernameless passkey login. Public, no
+// body — the authenticator reveals which resident passkey/user to use.
+func (h *AuthHandler) BeginWebAuthnPasswordlessLogin(w http.ResponseWriter, r *http.Request) {
+	ip := clientIP(r)
+	if checkLoginRateLimit(ip) {
+		sendError(w, "TooManyRequests", "Too many attempts. Try again later.", http.StatusTooManyRequests, nil)
+		return
+	}
+	assertion, sessionToken, err := h.coreService.BeginWebAuthnPasswordlessLogin(r.Context())
+	if err != nil {
+		h.writeWebAuthnErr(w, err)
+		return
+	}
+	sendSuccess(w, map[string]interface{}{
+		"publicKey":        assertion.Response,
+		"webauthn_session": sessionToken,
+	}, "Complete the passkey assertion to sign in.")
+}
+
+// FinishWebAuthnPasswordlessLogin verifies a discoverable assertion and returns a
+// session. Body: { webauthn_session, credential: <PublicKeyCredential> }.
+func (h *AuthHandler) FinishWebAuthnPasswordlessLogin(w http.ResponseWriter, r *http.Request) {
+	ip := clientIP(r)
+	if checkLoginRateLimit(ip) {
+		sendError(w, "TooManyRequests", "Too many attempts. Try again later.", http.StatusTooManyRequests, nil)
+		return
+	}
+	var body struct {
+		WebAuthnSession string          `json:"webauthn_session"`
+		Credential      json.RawMessage `json:"credential"`
+	}
+	if err := decodeJSON(r, &body); err != nil || len(body.Credential) == 0 {
+		sendError(w, "BadRequest", "Invalid request body", http.StatusBadRequest, nil)
+		return
+	}
+	parsed, err := protocol.ParseCredentialRequestResponseBytes(body.Credential)
+	if err != nil {
+		sendError(w, "BadRequest", "Invalid assertion", http.StatusBadRequest, nil)
+		return
+	}
+	session, user, err := h.coreService.FinishWebAuthnPasswordlessLogin(r.Context(), body.WebAuthnSession, r.Header.Get("User-Agent"), ip, parsed)
+	if err != nil {
+		recordLoginAttempt(ip)
+		sendError(w, "Unauthorized", "Passwordless login failed", http.StatusUnauthorized, nil)
+		return
+	}
+	resp := h.buildLoginResponse(r.Context(), session, user)
+	go h.coreService.LogAuthLogin(context.Background(), user.ID, user.Username, ip, r.Header.Get("User-Agent")) // #nosec G118
+	go func() { _ = h.coreService.RecordLogin(context.Background(), user.ID) }()                                // #nosec G118
+	sendSuccess(w, resp, "Login successful")
+}
+
 // writeWebAuthnErr maps a core error to an HTTP status: disabled → 501, else 400.
 func (h *AuthHandler) writeWebAuthnErr(w http.ResponseWriter, err error) {
 	if errors.Is(err, core.ErrWebAuthnDisabled) {

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -82,6 +82,10 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 	// single-use challenge from /auth/login plus the ceremony's webauthn_session.
 	r.Post("/auth/webauthn/login/begin", authHandler.BeginWebAuthnLogin)
 	r.Post("/auth/webauthn/login/finish", authHandler.FinishWebAuthnLogin)
+	// Passwordless (usernameless) passkey login — public; a single resident-passkey
+	// gesture with user verification mints a session, no password (ADR-036 addendum).
+	r.Post("/auth/webauthn/passwordless/begin", authHandler.BeginWebAuthnPasswordlessLogin)
+	r.Post("/auth/webauthn/passwordless/finish", authHandler.FinishWebAuthnPasswordlessLogin)
 	r.Post("/system/init", authHandler.InitSystem)
 
 	// Credential-delivery setup links (ADR-028) — unauthenticated: the bearer is the


### PR DESCRIPTION
## Summary

A registered passkey alone can now mint a session — **no password**. This extends the WebAuthn second-factor infrastructure (ADR-036) with the discoverable-credential (usernameless) flow: phishing-resistant passwordless login, a strong auth story for the certification track.

## Flow

- **Registration** now requests a **discoverable (resident) credential** (`ResidentKeyRequirement: preferred` — backward-compatible; authenticators that can't store a resident key still register for the second-factor flow), so the passkey can later be found usernamelessly.
- **`POST /auth/webauthn/passwordless/begin`** (public, no body) → `BeginDiscoverableLogin` with **user verification REQUIRED**, so the single passkey gesture proves *possession + user* (MFA-grade) — a complete login, not just possession. Returns assertion options + an opaque ceremony session token.
- **`POST /auth/webauthn/passwordless/finish`** `{webauthn_session, credential}` → consumes the single-use session; a `DiscoverableUserHandler` resolves the user from the assertion's **user handle** (our 8-byte `WebAuthnID`), and `ValidatePasskeyLogin` verifies the assertion **against that user's own stored credentials**.

## Security properties

- **No user-handle confusion**: `ValidatePasskeyLogin` checks the asserted credential belongs to the user the handle resolves to — a forged/attacker-supplied user handle can't be paired with someone else's credential.
- **Account-state gate enforced here** (`AccountLoginBlocked`) — there's no password step to gate a suspended/blocked account, so the check moves into the passwordless finish.
- **MFA-grade by construction**: UV is required (PIN/biometric), so one gesture = possession + user verification. The resulting session belongs to a `WebAuthnEnabled` user, so it satisfies a `require_mfa` mandate inherently.
- Single-use, hashed ceremony session; rate-limited like the other login paths. No half-authenticated state.

## Testing

Begin issues a single-use `passwordless` session with `UV=required` and no pre-listed credentials; disabled-server rejection (begin + finish); finish rejects a wrong-purpose or unknown/expired session **before any crypto**. The assertion crypto + user-handle binding is covered by go-webauthn's own suite. `make build` + full suite + `go vet` green. ADR-036 addendum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)