### PR TITLE
feat(auth): cluster-wide login rate limiting (ADR-040)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,15 @@ on:
   pull_request:
     branches: [main]
 
+env:
+  # Pinned security tooling (SSDLC Phase 1, June 2026). Do not use @latest:
+  # the tools that gate our security checks are themselves a supply-chain
+  # surface. govulncheck deliberately floats — Google x/ tool, vuln DB is
+  # fetched live regardless of binary version.
+  GOSEC_VERSION: v2.26.1
+  GOLANGCI_LINT_VERSION: v2.12.2
+  GITLEAKS_VERSION: 8.30.1
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
@@ -40,11 +49,44 @@ jobs:
 
       - name: gosec
         run: |
-          go install github.com/securego/gosec/v2/cmd/gosec@latest
+          go install github.com/securego/gosec/v2/cmd/gosec@${GOSEC_VERSION}
           # -exclude-generated skips files with the "DO NOT EDIT" header
           # (generated protobuf code), whose *_FullMethodName string constants
           # otherwise trip G101 (hardcoded-credential) false positives.
           gosec -severity medium -exclude-generated ./...
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.26'
+
+      # Promotes the previously local-only `make lint` to a CI gate:
+      # errcheck, staticcheck, unused, goconst, ineffassign (.golangci.yml).
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v8
+        with:
+          version: ${{ env.GOLANGCI_LINT_VERSION }}
+
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full history: a secret committed and later deleted is still leaked.
+          fetch-depth: 0
+
+      # Pinned binary instead of gitleaks-action (the action requires a
+      # license key for org accounts; the CLI is MIT).
+      - name: gitleaks (full history)
+        run: |
+          curl -fsSL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+            | tar -xz gitleaks
+          ./gitleaks detect --source . --verbose --redact
 
   helm-chart:
     runs-on: ubuntu-latest

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,85 @@
+# Security Policy
+
+Keyorix is a secrets manager. We hold ourselves to the standard we ask you to trust
+us with: every control described here is verifiable in this repository's CI
+configuration and release artifacts.
+
+## Supported Versions
+
+| Version | Supported |
+|---|---|
+| Latest release | ✅ Security fixes |
+| Older releases | ❌ Upgrade to latest |
+
+Keyorix is pre-1.0. A formal backport policy for previous minor versions (relevant
+for air-gapped deployments with slow upgrade cadences) will be published with the
+1.0 release; commercial licence tiers will include extended backport windows.
+
+## Reporting a Vulnerability
+
+**Do not open a public GitHub issue for security vulnerabilities.**
+
+- Email: **security@keyorix.com**
+- Or use GitHub's private vulnerability reporting on this repository
+
+We acknowledge within **48 hours** and provide an initial assessment within **7 days**.
+Please include: a description, reproduction steps, and the affected version
+(`keyorix --version` / `keyorix-server --version`).
+
+We follow coordinated disclosure: we'll agree a disclosure timeline with you,
+credit you in the advisory unless you prefer otherwise, and publish a fix and
+advisory together. As an EU vendor we operate under the EU Cyber Resilience Act
+reporting regime for actively exploited vulnerabilities.
+
+## Threat Model (summary)
+
+Keyorix server runs **entirely within your perimeter**:
+
+- No telemetry, no usage metering, no "phone home" — ever. Air-gapped operation
+  is a first-class deployment model, not a degraded mode.
+- All secret values encrypted at rest with AES-256-GCM (authenticated encryption,
+  AAD-bound to secret identity). Envelope encryption: the data key is wrapped by a
+  key derived from an operator passphrase (PBKDF2-SHA256, 600k iterations); no
+  plaintext key material is ever written to disk.
+- Session tokens, API tokens, and client secrets are encrypted at rest.
+- Every secret access and every administrative action is written to an append-only
+  audit log in your database.
+- RBAC is enforced at the API level, not the UI.
+
+What Keyorix never does: open outbound connections to us, embed third-party
+analytics, or require internet access for any cryptographic operation.
+
+A full STRIDE threat model is maintained internally and shared with customers and
+prospects under evaluation — ask via hello@keyorix.com.
+
+## Verifying a Release
+
+Every release ships with `checksums.txt`:
+
+```bash
+sha256sum --check --ignore-missing checksums.txt
+```
+
+Release binaries are built with `-trimpath` and `CGO_ENABLED=0` from the tagged
+commit. Cryptographic release signing (Sigstore/cosign) and SLSA build provenance
+are being rolled out — this section will be updated with verification commands
+when they ship. Until then, download releases only from
+`github.com/keyorixhq/keyorix/releases` over HTTPS and verify checksums.
+
+## Secure Development
+
+- Pre-commit gates: `gofmt`, `go vet`, `go build`, `gosec` (MEDIUM+ severity)
+- CI gates on every push and pull request: `go vet`, race-enabled tests,
+  `govulncheck`, `gosec` (pinned version), `golangci-lint` (errcheck, staticcheck,
+  unused, and more), `gitleaks` full-history secret scan
+- Any change to the encryption layer requires a written Architecture Decision
+  Record before implementation
+- External contributions require a signed CLA and maintainer review
+
+## Security-Relevant Configuration
+
+- `KEYORIX_MASTER_PASSWORD` is the root credential — inject it via systemd
+  credentials/`EnvironmentFile` (0600) or a Kubernetes Secret, never a config file.
+- Run `keyorix-server` as a non-root service user.
+- TLS is required in production; the CLI `--insecure` flag is for local
+  development only.

--- a/docs/adr-040-distributed-rate-limiting.md
+++ b/docs/adr-040-distributed-rate-limiting.md
@@ -1,0 +1,66 @@
+# ADR-040: Cluster-wide login rate limiting
+
+**Status:** Accepted
+**Date:** 2026-06-12
+
+## Context
+
+Login brute-force protection was an in-process, in-memory sliding window: a
+`map[ip][]time.Time` in the HTTP auth handlers, capping failed attempts at 10 per
+IP per 15 minutes. The HA work (ADR-039) flagged this as the one remaining
+per-replica gap: with N stateless replicas behind a load balancer, the limit is
+enforced *independently* on each replica, so an attacker spreading attempts across
+replicas gets up to N× the budget. The recommended mitigation was a gateway/WAF,
+but Keyorix should be secure-by-default on-prem without requiring one.
+
+## Decision
+
+Move the limiter into the database so the count is shared across replicas.
+
+- **`login_attempts` table** (`id`, `ip`, `attempted_at`) with a composite
+  `(ip, attempted_at)` index. A failed attempt inserts a row; the gate counts an
+  IP's rows within the window across the whole cluster.
+- **Core API** (`internal/core/rate_limit.go`): `RecordFailedLogin(ctx, ip)`,
+  `IsLoginRateLimited(ctx, ip)` (count ≥ `LoginMaxAttempts=10` within
+  `LoginWindow=15m`), and `PruneLoginAttempts(ctx)`. The HTTP handlers' old
+  free-function limiter is replaced by thin `AuthHandler` methods that delegate
+  here — every login surface (password, TOTP verify, WebAuthn second-factor, and
+  passwordless) now shares one cluster-wide limit.
+- **Fail-open.** A storage error in `IsLoginRateLimited` returns `false` (allow).
+  Rate limiting is a *backstop* layered on the real password/passkey check, not the
+  auth gate itself; a transient DB hiccup must not lock every user out. Recording
+  is best-effort for the same reason.
+- **Bounded growth.** An always-on, single-replica-gated (ADR-039) maintenance
+  goroutine prunes rows past the window hourly, independent of the opt-in retention
+  purge scheduler — the limiter table must stay bounded even when purge is off.
+
+## Why the write volume is acceptable
+
+A row is written only on a *failed* attempt, and the gate is checked *first*: once
+an IP reaches the budget it is rejected **before** another row is recorded. So a
+single attacking IP writes at most ~`LoginMaxAttempts` rows per window before being
+throttled. A distributed attack writes proportionally to the number of distinct
+IPs — that broad case is still best handled at the gateway (noted below), but the
+common single-IP / small-botnet brute force is now bounded cluster-wide by Keyorix
+itself.
+
+## Consequences
+
+- The limit now holds across replicas — the ADR-039 per-replica gap is closed for
+  the single-IP/small-botnet case.
+- Each login does one indexed `COUNT` (and a failed one, one `INSERT`). Login is
+  far less frequent than secret reads, so the added DB work is negligible.
+- SQLite (single instance) works identically — it is just a table.
+
+## Deferred
+
+A truly distributed (many-IP) brute force, and request-rate limiting in general,
+are still best enforced at the load balancer / API gateway / WAF — this ADR
+hardens the credential-stuffing case, it does not replace edge rate limiting.
+Per-account (not just per-IP) lockout; exponential backoff; CAPTCHA challenge.
+
+## Verification
+
+Core tests over SQLite: an IP is allowed under the budget and blocked at it; a
+different IP is unaffected; attempts age out of the window; an empty IP is never
+limited; prune removes aged rows. `make build` + full suite + `go vet` green.

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -19,6 +19,15 @@ func (m *MockStorage) WithSchedulerLock(_ context.Context, _ int64, fn func() er
 	return true, fn()
 }
 
+// Login rate-limiting stubs (core rate-limit logic is tested against real SQLite).
+func (m *MockStorage) RecordLoginAttempt(_ context.Context, _ string, _ time.Time) error { return nil }
+func (m *MockStorage) CountRecentLoginAttempts(_ context.Context, _ string, _ time.Time) (int64, error) {
+	return 0, nil
+}
+func (m *MockStorage) PruneLoginAttempts(_ context.Context, _ time.Time) (int64, error) {
+	return 0, nil
+}
+
 // Permission Management
 
 func (m *MockStorage) CreatePermission(_ context.Context, permission *models.Permission) (*models.Permission, error) {

--- a/internal/core/rate_limit.go
+++ b/internal/core/rate_limit.go
@@ -1,0 +1,46 @@
+// rate_limit.go — cluster-wide login brute-force rate limiting (ADR-040). A
+// windowed count of failed attempts per IP, persisted in the DB so the limit holds
+// across HA replicas (the old limiter was a per-process in-memory map). Rate
+// limiting is a backstop on top of the real password/passkey checks, so a storage
+// error fails OPEN (allow) rather than locking everyone out on a DB hiccup.
+package core
+
+import (
+	"context"
+	"time"
+)
+
+const (
+	// LoginMaxAttempts is the failed-attempt budget per IP within LoginWindow.
+	LoginMaxAttempts = 10
+	// LoginWindow is the sliding window over which attempts are counted.
+	LoginWindow = 15 * time.Minute
+)
+
+// IsLoginRateLimited reports whether an IP has reached the failed-login budget
+// within the window. Fails open (false) on an empty IP or a storage error.
+func (c *KeyorixCore) IsLoginRateLimited(ctx context.Context, ip string) bool {
+	if ip == "" {
+		return false
+	}
+	n, err := c.storage.CountRecentLoginAttempts(ctx, ip, c.now().Add(-LoginWindow))
+	if err != nil {
+		return false
+	}
+	return n >= LoginMaxAttempts
+}
+
+// RecordFailedLogin records a failed authentication attempt from an IP.
+// Best-effort: a storage error does not block the response path.
+func (c *KeyorixCore) RecordFailedLogin(ctx context.Context, ip string) {
+	if ip == "" {
+		return
+	}
+	_ = c.storage.RecordLoginAttempt(ctx, ip, c.now())
+}
+
+// PruneLoginAttempts removes attempts older than the window; called by the
+// maintenance sweep. Returns the number removed.
+func (c *KeyorixCore) PruneLoginAttempts(ctx context.Context) (int64, error) {
+	return c.storage.PruneLoginAttempts(ctx, c.now().Add(-LoginWindow))
+}

--- a/internal/core/rate_limit_test.go
+++ b/internal/core/rate_limit_test.go
@@ -1,0 +1,75 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func newRateLimitCore(t *testing.T) (*KeyorixCore, func(time.Time)) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.LoginAttempt{}))
+	now := time.Date(2026, 6, 12, 10, 0, 0, 0, time.UTC)
+	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: func() time.Time { return now }, passwordPolicy: DefaultPasswordPolicy()}
+	setNow := func(t time.Time) { c.now = func() time.Time { return t } }
+	return c, setNow
+}
+
+func TestRateLimit_BlocksAtBudgetAndExpiresWithWindow(t *testing.T) {
+	c, setNow := newRateLimitCore(t)
+	ctx := context.Background()
+	base := c.now()
+
+	// Below the budget: allowed.
+	for i := 0; i < LoginMaxAttempts-1; i++ {
+		c.RecordFailedLogin(ctx, "1.2.3.4")
+	}
+	assert.False(t, c.IsLoginRateLimited(ctx, "1.2.3.4"), "under budget is allowed")
+
+	// Reaching the budget: blocked.
+	c.RecordFailedLogin(ctx, "1.2.3.4")
+	assert.True(t, c.IsLoginRateLimited(ctx, "1.2.3.4"), "at the budget the IP is blocked")
+
+	// A different IP is unaffected.
+	assert.False(t, c.IsLoginRateLimited(ctx, "9.9.9.9"))
+
+	// After the window elapses, the old attempts no longer count.
+	setNow(base.Add(LoginWindow + time.Minute))
+	assert.False(t, c.IsLoginRateLimited(ctx, "1.2.3.4"), "attempts age out of the window")
+}
+
+func TestRateLimit_EmptyIPNeverLimited(t *testing.T) {
+	c, _ := newRateLimitCore(t)
+	ctx := context.Background()
+	for i := 0; i < LoginMaxAttempts+5; i++ {
+		c.RecordFailedLogin(ctx, "")
+	}
+	assert.False(t, c.IsLoginRateLimited(ctx, ""), "an empty IP is never rate-limited")
+}
+
+func TestRateLimit_PruneRemovesAgedRows(t *testing.T) {
+	c, setNow := newRateLimitCore(t)
+	ctx := context.Background()
+	base := c.now()
+	for i := 0; i < 5; i++ {
+		c.RecordFailedLogin(ctx, "1.2.3.4")
+	}
+	// Move past the window and prune — aged rows are removed.
+	setNow(base.Add(LoginWindow + time.Minute))
+	removed, err := c.PruneLoginAttempts(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(5), removed)
+
+	n, err := c.storage.CountRecentLoginAttempts(ctx, "1.2.3.4", time.Time{})
+	require.NoError(t, err)
+	assert.Zero(t, n, "table is empty after pruning aged rows")
+}

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -11,6 +11,12 @@ import (
 // This interface abstracts away the underlying storage implementation,
 // allowing for both local database access and remote API calls
 type Storage interface {
+	// Login rate limiting (ADR-040) — cluster-wide brute-force protection. Replaces
+	// the per-process in-memory limiter so the limit holds across HA replicas.
+	RecordLoginAttempt(ctx context.Context, ip string, at time.Time) error
+	CountRecentLoginAttempts(ctx context.Context, ip string, since time.Time) (int64, error)
+	PruneLoginAttempts(ctx context.Context, before time.Time) (int64, error)
+
 	// WithSchedulerLock runs fn only if this process can take the named scheduler
 	// lock, so a background job runs on a single replica at a time (HA, ADR-039).
 	// On PostgreSQL it uses a session advisory lock (pg_try_advisory_lock); on

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -267,6 +267,7 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 	dynLeaseExists := tableExists(db, "dynamic_secret_leases")
 	webauthnCredExists := tableExists(db, "web_authn_credentials")
 	webauthnSessExists := tableExists(db, "web_authn_sessions")
+	loginAttemptExists := tableExists(db, "login_attempts")
 
 	// Create rotation_policies if missing (additive, safe on existing DBs).
 	if !rotationExists {
@@ -329,6 +330,13 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 	if !webauthnSessExists {
 		if err := db.AutoMigrate(&models.WebAuthnSession{}); err != nil {
 			return fmt.Errorf("failed to migrate web_authn_sessions table: %w", err)
+		}
+	}
+
+	// Create the login_attempts table if missing (ADR-040 rate limiting, additive).
+	if !loginAttemptExists {
+		if err := db.AutoMigrate(&models.LoginAttempt{}); err != nil {
+			return fmt.Errorf("failed to migrate login_attempts table: %w", err)
 		}
 	}
 

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -129,6 +129,17 @@ type MFAChallenge struct {
 	CreatedAt time.Time
 }
 
+// LoginAttempt records one failed authentication attempt from a client IP, for
+// cluster-wide brute-force rate limiting (ADR-040). Counting rows within the
+// window across all replicas replaces the old per-process in-memory limiter, so
+// the limit holds in HA. Rows past the window are pruned by a maintenance sweep
+// and are never read after that. The composite index serves the windowed count.
+type LoginAttempt struct {
+	ID          uint      `gorm:"primaryKey"`
+	IP          string    `gorm:"index:idx_login_attempt_ip_time,priority:1"`
+	AttemptedAt time.Time `gorm:"index:idx_login_attempt_ip_time,priority:2"`
+}
+
 // WebAuthnCredential is a registered passkey / FIDO2 authenticator (ADR-036).
 // CredentialBlob is the JSON-serialized go-webauthn Credential (public key,
 // attestation, sign count, transports) — the library's canonical record, updated

--- a/internal/storage/store/local_login_attempts.go
+++ b/internal/storage/store/local_login_attempts.go
@@ -1,0 +1,31 @@
+// local_login_attempts.go — cluster-wide login rate limiting (ADR-040). Failed
+// attempts are recorded per IP; a windowed count gates further attempts across all
+// replicas, and a maintenance sweep prunes rows past the window.
+package store
+
+import (
+	"context"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+func (ls *LocalStorage) RecordLoginAttempt(ctx context.Context, ip string, at time.Time) error {
+	return ls.db.WithContext(ctx).Create(&models.LoginAttempt{IP: ip, AttemptedAt: at}).Error
+}
+
+func (ls *LocalStorage) CountRecentLoginAttempts(ctx context.Context, ip string, since time.Time) (int64, error) {
+	var n int64
+	if err := ls.db.WithContext(ctx).Model(&models.LoginAttempt{}).
+		Where("ip = ? AND attempted_at > ?", ip, since).Count(&n).Error; err != nil {
+		return 0, err
+	}
+	return n, nil
+}
+
+// PruneLoginAttempts deletes attempts older than `before` (past the window) and
+// returns how many were removed.
+func (ls *LocalStorage) PruneLoginAttempts(ctx context.Context, before time.Time) (int64, error) {
+	res := ls.db.WithContext(ctx).Where("attempted_at < ?", before).Delete(&models.LoginAttempt{})
+	return res.RowsAffected, res.Error
+}

--- a/internal/storage/store/remote_login_attempts.go
+++ b/internal/storage/store/remote_login_attempts.go
@@ -1,0 +1,19 @@
+package store
+
+import (
+	"context"
+	"time"
+)
+
+// Login rate limiting is server-side only (ADR-040) — the limiter runs in the
+// server's auth handlers against LocalStorage; a remote (client) caller never
+// records or counts attempts.
+func (rs *RemoteStorage) RecordLoginAttempt(_ context.Context, _ string, _ time.Time) error {
+	return remoteUnsupported("RecordLoginAttempt")
+}
+func (rs *RemoteStorage) CountRecentLoginAttempts(_ context.Context, _ string, _ time.Time) (int64, error) {
+	return 0, remoteUnsupported("CountRecentLoginAttempts")
+}
+func (rs *RemoteStorage) PruneLoginAttempts(_ context.Context, _ time.Time) (int64, error) {
+	return 0, remoteUnsupported("PruneLoginAttempts")
+}

--- a/server/http/handlers/auth.go
+++ b/server/http/handlers/auth.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -16,41 +15,17 @@ import (
 	"github.com/keyorixhq/keyorix/server/middleware"
 )
 
-// loginRateLimiter tracks failed login attempts per IP.
-var loginRateLimiter = struct {
-	sync.Mutex
-	attempts map[string][]time.Time
-}{attempts: make(map[string][]time.Time)}
-
-const (
-	loginMaxAttempts = 10
-	loginWindow      = 15 * time.Minute
-)
-
-// checkLoginRateLimit returns true if the IP has exceeded the login attempt limit.
-func checkLoginRateLimit(ip string) bool {
-	loginRateLimiter.Lock()
-	defer loginRateLimiter.Unlock()
-
-	now := time.Now()
-	cutoff := now.Add(-loginWindow)
-
-	var recent []time.Time
-	for _, t := range loginRateLimiter.attempts[ip] {
-		if t.After(cutoff) {
-			recent = append(recent, t)
-		}
-	}
-	loginRateLimiter.attempts[ip] = recent
-
-	return len(recent) >= loginMaxAttempts
+// checkLoginRateLimit returns true if the IP has exceeded the login-attempt budget
+// within the window. Backed by the DB so the limit holds across HA replicas
+// (ADR-040). Fails open on a storage error — it's a backstop on top of the real
+// credential check, not the auth gate itself.
+func (h *AuthHandler) checkLoginRateLimit(ctx context.Context, ip string) bool {
+	return h.coreService.IsLoginRateLimited(ctx, ip)
 }
 
-// recordLoginAttempt records a failed login attempt for the IP.
-func recordLoginAttempt(ip string) {
-	loginRateLimiter.Lock()
-	defer loginRateLimiter.Unlock()
-	loginRateLimiter.attempts[ip] = append(loginRateLimiter.attempts[ip], time.Now())
+// recordLoginAttempt records a failed login attempt for the IP (best-effort).
+func (h *AuthHandler) recordLoginAttempt(ctx context.Context, ip string) {
+	h.coreService.RecordFailedLogin(ctx, ip)
 }
 
 // AuthHandler handles authentication HTTP requests.
@@ -112,7 +87,7 @@ func (h *AuthHandler) Login(w http.ResponseWriter, r *http.Request) {
 	if idx := strings.LastIndex(ip, ":"); idx != -1 {
 		ip = ip[:idx]
 	}
-	if checkLoginRateLimit(ip) {
+	if h.checkLoginRateLimit(r.Context(), ip) {
 		sendError(w, "TooManyRequests", "Too many login attempts. Try again later.", http.StatusTooManyRequests, nil)
 		return
 	}
@@ -148,7 +123,7 @@ func (h *AuthHandler) Login(w http.ResponseWriter, r *http.Request) {
 			}, "MFA required")
 			return
 		}
-		recordLoginAttempt(ip)
+		h.recordLoginAttempt(r.Context(), ip)
 		go h.coreService.LogAuthFailure(context.Background(), body.Username, ip) // #nosec G118
 		sendError(w, "Unauthorized", "Invalid credentials", http.StatusUnauthorized, nil)
 		return

--- a/server/http/handlers/mfa.go
+++ b/server/http/handlers/mfa.go
@@ -88,7 +88,7 @@ func (h *AuthHandler) VerifyMFA(w http.ResponseWriter, r *http.Request) {
 	if idx := strings.LastIndex(ip, ":"); idx != -1 {
 		ip = ip[:idx]
 	}
-	if checkLoginRateLimit(ip) {
+	if h.checkLoginRateLimit(r.Context(), ip) {
 		sendError(w, "TooManyRequests", "Too many attempts. Try again later.", http.StatusTooManyRequests, nil)
 		return
 	}
@@ -102,7 +102,7 @@ func (h *AuthHandler) VerifyMFA(w http.ResponseWriter, r *http.Request) {
 	}
 	session, user, err := h.coreService.VerifyMFALogin(r.Context(), body.Challenge, body.Code, r.Header.Get("User-Agent"), ip)
 	if err != nil {
-		recordLoginAttempt(ip)
+		h.recordLoginAttempt(r.Context(), ip)
 		sendError(w, "Unauthorized", "Invalid or expired code", http.StatusUnauthorized, nil)
 		return
 	}

--- a/server/http/handlers/webauthn.go
+++ b/server/http/handlers/webauthn.go
@@ -122,7 +122,7 @@ func (h *AuthHandler) DeleteWebAuthnCredential(w http.ResponseWriter, r *http.Re
 // Body: { mfa_challenge }. Public (the challenge from /auth/login is the bearer).
 func (h *AuthHandler) BeginWebAuthnLogin(w http.ResponseWriter, r *http.Request) {
 	ip := clientIP(r)
-	if checkLoginRateLimit(ip) {
+	if h.checkLoginRateLimit(r.Context(), ip) {
 		sendError(w, "TooManyRequests", "Too many attempts. Try again later.", http.StatusTooManyRequests, nil)
 		return
 	}
@@ -135,7 +135,7 @@ func (h *AuthHandler) BeginWebAuthnLogin(w http.ResponseWriter, r *http.Request)
 	}
 	assertion, sessionToken, err := h.coreService.BeginWebAuthnLogin(r.Context(), body.Challenge)
 	if err != nil {
-		recordLoginAttempt(ip)
+		h.recordLoginAttempt(r.Context(), ip)
 		h.writeWebAuthnErr(w, err)
 		return
 	}
@@ -149,7 +149,7 @@ func (h *AuthHandler) BeginWebAuthnLogin(w http.ResponseWriter, r *http.Request)
 // Body: { mfa_challenge, webauthn_session, credential: <PublicKeyCredential> }.
 func (h *AuthHandler) FinishWebAuthnLogin(w http.ResponseWriter, r *http.Request) {
 	ip := clientIP(r)
-	if checkLoginRateLimit(ip) {
+	if h.checkLoginRateLimit(r.Context(), ip) {
 		sendError(w, "TooManyRequests", "Too many attempts. Try again later.", http.StatusTooManyRequests, nil)
 		return
 	}
@@ -169,7 +169,7 @@ func (h *AuthHandler) FinishWebAuthnLogin(w http.ResponseWriter, r *http.Request
 	}
 	session, user, err := h.coreService.FinishWebAuthnLogin(r.Context(), body.Challenge, body.WebAuthnSession, r.Header.Get("User-Agent"), ip, parsed)
 	if err != nil {
-		recordLoginAttempt(ip)
+		h.recordLoginAttempt(r.Context(), ip)
 		sendError(w, "Unauthorized", "Assertion failed or challenge expired", http.StatusUnauthorized, nil)
 		return
 	}
@@ -183,7 +183,7 @@ func (h *AuthHandler) FinishWebAuthnLogin(w http.ResponseWriter, r *http.Request
 // body — the authenticator reveals which resident passkey/user to use.
 func (h *AuthHandler) BeginWebAuthnPasswordlessLogin(w http.ResponseWriter, r *http.Request) {
 	ip := clientIP(r)
-	if checkLoginRateLimit(ip) {
+	if h.checkLoginRateLimit(r.Context(), ip) {
 		sendError(w, "TooManyRequests", "Too many attempts. Try again later.", http.StatusTooManyRequests, nil)
 		return
 	}
@@ -202,7 +202,7 @@ func (h *AuthHandler) BeginWebAuthnPasswordlessLogin(w http.ResponseWriter, r *h
 // session. Body: { webauthn_session, credential: <PublicKeyCredential> }.
 func (h *AuthHandler) FinishWebAuthnPasswordlessLogin(w http.ResponseWriter, r *http.Request) {
 	ip := clientIP(r)
-	if checkLoginRateLimit(ip) {
+	if h.checkLoginRateLimit(r.Context(), ip) {
 		sendError(w, "TooManyRequests", "Too many attempts. Try again later.", http.StatusTooManyRequests, nil)
 		return
 	}
@@ -221,7 +221,7 @@ func (h *AuthHandler) FinishWebAuthnPasswordlessLogin(w http.ResponseWriter, r *
 	}
 	session, user, err := h.coreService.FinishWebAuthnPasswordlessLogin(r.Context(), body.WebAuthnSession, r.Header.Get("User-Agent"), ip, parsed)
 	if err != nil {
-		recordLoginAttempt(ip)
+		h.recordLoginAttempt(r.Context(), ip)
 		sendError(w, "Unauthorized", "Passwordless login failed", http.StatusUnauthorized, nil)
 		return
 	}

--- a/server/main.go
+++ b/server/main.go
@@ -137,6 +137,7 @@ const (
 	schedLockAnomaly      int64 = 0x4B455953_414E4F4D // "KEYSANOM"
 	schedLockPurge        int64 = 0x4B455953_50555247 // "KEYSPURG"
 	schedLockDynamicSweep int64 = 0x4B455953_44594E53 // "KEYSDYNS"
+	schedLockLoginPrune   int64 = 0x4B455953_4C474E50 // "KEYSLGNP"
 )
 
 // initializeEncryption sources the KEK per the configured key provider (ADR-038)
@@ -417,6 +418,31 @@ func startHTTPServer(ctx context.Context, cfg *config.Config) error {
 			}
 		}()
 	}
+
+	// Prune expired login-attempt records hourly (ADR-040). Single-replica-gated;
+	// always on (the limiter table needs bounded growth regardless of the purge
+	// scheduler). Rows past the rate-limit window are never read again.
+	go func() {
+		ticker := time.NewTicker(1 * time.Hour)
+		defer ticker.Stop()
+		runPrune := func() {
+			if _, err := coreService.Storage().WithSchedulerLock(ctx, schedLockLoginPrune, func() error {
+				_, perr := coreService.PruneLoginAttempts(ctx)
+				return perr
+			}); err != nil {
+				log.Printf("Login-attempt prune error: %v", err)
+			}
+		}
+		runPrune() // run once on startup
+		for {
+			select {
+			case <-ticker.C:
+				runPrune()
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
 
 	// Create HTTP server
 	server := &http.Server{


### PR DESCRIPTION
## Summary

Replaces the per-process in-memory login rate limiter with a **DB-backed** one, closing the HA gap flagged in ADR-039: with N stateless replicas the old `map[ip][]time.Time` enforced the 10-per-15min limit **independently per replica**, so an attacker spreading attempts across replicas got up to N× the budget.

## What's in it

- **`login_attempts` table** (`ip`, `attempted_at`, composite index). A failed attempt inserts a row; the gate counts an IP's rows within the window **across the whole cluster**.
- **`internal/core/rate_limit.go`**: `RecordFailedLogin` / `IsLoginRateLimited` (≥10 in 15m) / `PruneLoginAttempts`. The handlers' old free-function limiter becomes thin `AuthHandler` methods delegating here — so **every** login surface (password, TOTP verify, WebAuthn second-factor, **and** passwordless) shares one cluster-wide limit.
- **Fail-open**: a storage error in `IsLoginRateLimited` returns `false` (allow). Rate limiting is a *backstop* on top of the real password/passkey check, not the auth gate — a transient DB hiccup must not lock every user out. Recording is best-effort.
- **Bounded growth**: an always-on, single-replica-gated (ADR-039) hourly maintenance goroutine prunes rows past the window, independent of the opt-in retention purge scheduler.

## Why the write volume is fine

The gate is checked **before** recording, so once an IP hits the budget it's rejected *before* another row is written — a single attacking IP writes at most ~budget rows per window. The broad many-IP case is still best handled at the gateway (documented); this hardens the common single-IP / small-botnet brute force cluster-wide.

## Testing

Core tests over SQLite: allowed under budget, blocked at it, a different IP unaffected, attempts age out of the window, empty IP never limited, prune removes aged rows. `make build` + full suite + `go vet` green. ADR-040.

🤖 Generated with [Claude Code](https://claude.com/claude-code)