### PR TITLE
release: prep v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,25 @@
 All notable changes to Keyorix are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## v0.8.0 — 2026-06-12
+
+### Added
+- **Cluster-wide login rate limiting** — brute-force protection now counts failed
+  attempts in the database rather than per-process memory, so the 10-attempts /
+  15-minutes-per-IP limit holds across HA replicas (the old in-memory limiter
+  enforced it independently on each replica). Covers every login surface —
+  password, TOTP, WebAuthn second-factor, and passwordless. ([#114], ADR-040)
+
+### Changed
+- CI hygiene: the `lint` (golangci-lint) and `gitleaks` jobs are green and
+  meaningful again — a `.gitleaks.toml` allowlist scopes the scanner to real
+  source/config (away from sample-credential fixtures in demos/docs/tests), and
+  the linter config keeps the bug-catching checks while dropping pure-style noise.
+  Several genuine issues those linters surfaced were fixed. ([#115])
+
+[#114]: https://github.com/keyorixhq/keyorix/pull/114
+[#115]: https://github.com/keyorixhq/keyorix/pull/115
+
 ## v0.7.0 — 2026-06-12
 
 Passwordless authentication and high-availability deployment.

--- a/deploy/helm/keyorix/Chart.yaml
+++ b/deploy/helm/keyorix/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix
 description: Self-hosted Keyorix secrets manager (API server + web UI + PostgreSQL)
 type: application
 # Chart version — bump on chart changes.
-version: 0.7.0
+version: 0.8.0
 # The Keyorix app version this chart deploys by default (the image tag).
-appVersion: "0.7.0"
+appVersion: "0.8.0"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix


### PR DESCRIPTION
## Summary

Prepares **v0.8.0**. Since v0.7.0:

- **Cluster-wide login rate limiting** — DB-backed brute-force protection that holds across HA replicas ([#114], ADR-040)
- **CI hygiene** — `lint` + `gitleaks` restored as meaningful green gates ([#115])

## Changes

- `CHANGELOG.md` — new v0.8.0 section
- `deploy/helm/keyorix/Chart.yaml` — `version` + `appVersion` → `0.8.0`

Merging this, then pushing the `v0.8.0` tag, triggers the release pipeline (binaries + checksums → GitHub Release; chart → `oci://ghcr.io/keyorixhq/charts`; server image `ghcr.io/keyorixhq/keyorix-server:0.8.0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)