### PR TITLE
feat(cli): keyorix dynamic-secret — issue/manage dynamic secrets from the CLI

### DIFF
--- a/docs/adr-035-dynamic-secrets.md
+++ b/docs/adr-035-dynamic-secrets.md
@@ -78,9 +78,9 @@ full suite + `go vet` green.
 
 ## Deferred
 
-Other backends (Mongo, cloud IAM); renewable leases (extend TTL in place);
-per-config max-TTL ceilings; a CLI surface; returning leases a caller can
-enumerate across configs.
+Other backends (Mongo, cloud IAM); returning leases a caller can enumerate across
+configs; a gRPC surface. (Renewable leases, per-config max-TTL ceilings, and a
+`keyorix dynamic-secret` CLI have since shipped — see the addenda.)
 
 ## Addendum (2026-06-12): MySQL target engine
 

--- a/internal/cli/dynamic/dynamic.go
+++ b/internal/cli/dynamic/dynamic.go
@@ -1,0 +1,202 @@
+// Package dynamic provides the `keyorix dynamic-secret` CLI — on-demand database
+// credentials (ADR-035) from the terminal: list registered targets, issue a
+// short-lived lease, and renew/revoke/list leases. All commands talk to the
+// server's REST API (the credentials are minted server-side); the issued
+// username/password is shown once, on issue.
+package dynamic
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/spf13/cobra"
+)
+
+// DynamicSecretCmd is the root `keyorix dynamic-secret` command.
+var DynamicSecretCmd = &cobra.Command{
+	Use:     "dynamic-secret",
+	Aliases: []string{"dynamic-secrets", "dyn"},
+	Short:   "Issue and manage on-demand database credentials (dynamic secrets)",
+}
+
+var (
+	flagProjectID int
+	flagEnvID     int
+	flagTTL       int
+)
+
+func init() {
+	listCmd.Flags().IntVar(&flagProjectID, "project-id", 0, "Filter by project ID")
+	listCmd.Flags().IntVar(&flagEnvID, "environment-id", 0, "Filter by environment ID")
+	issueCmd.Flags().IntVar(&flagTTL, "ttl", 0, "Lease TTL in seconds (0 = the config default)")
+	renewCmd.Flags().IntVar(&flagTTL, "ttl", 0, "Renewal TTL in seconds (0 = the config default)")
+
+	DynamicSecretCmd.AddCommand(listCmd, issueCmd, leasesCmd, renewCmd, revokeCmd)
+}
+
+func client() (*common.RemoteClient, error) {
+	c, ok := common.NewRemoteClient()
+	if !ok {
+		return nil, fmt.Errorf("not connected to a server — run: keyorix connect <server>")
+	}
+	return c, nil
+}
+
+type configView struct {
+	ID                uint   `json:"id"`
+	Name              string `json:"name"`
+	ProjectID         uint   `json:"project_id"`
+	EnvironmentID     uint   `json:"environment_id"`
+	BackendType       string `json:"backend_type"`
+	DefaultTTLSeconds int    `json:"default_ttl_seconds"`
+	MaxTTLSeconds     int    `json:"max_ttl_seconds"`
+}
+
+type issuedLease struct {
+	LeaseID   string `json:"lease_id"`
+	Username  string `json:"username"`
+	Password  string `json:"password"`
+	ExpiresAt string `json:"expires_at"`
+}
+
+type leaseView struct {
+	LeaseID   string `json:"lease_id"`
+	RoleName  string `json:"role_name"`
+	Status    string `json:"status"`
+	IssuedAt  string `json:"issued_at"`
+	ExpiresAt string `json:"expires_at"`
+}
+
+var listCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List dynamic-secret target configs",
+	RunE: func(_ *cobra.Command, _ []string) error {
+		c, err := client()
+		if err != nil {
+			return err
+		}
+		path := "/api/v1/dynamic-secrets/configs"
+		sep := "?"
+		if flagProjectID > 0 {
+			path += sep + "project_id=" + strconv.Itoa(flagProjectID)
+			sep = "&"
+		}
+		if flagEnvID > 0 {
+			path += sep + "environment_id=" + strconv.Itoa(flagEnvID)
+		}
+		var configs []configView
+		if err := c.Get(context.Background(), path, &configs); err != nil {
+			return err
+		}
+		if len(configs) == 0 {
+			fmt.Println("No dynamic-secret configs found.")
+			return nil
+		}
+		fmt.Printf("%-5s %-24s %-10s %-8s %-8s\n", "ID", "NAME", "BACKEND", "TTL", "MAXTTL")
+		for _, cfg := range configs {
+			fmt.Printf("%-5d %-24s %-10s %-8d %-8d\n", cfg.ID, cfg.Name, cfg.BackendType, cfg.DefaultTTLSeconds, cfg.MaxTTLSeconds)
+		}
+		return nil
+	},
+}
+
+var issueCmd = &cobra.Command{
+	Use:   "issue <config-id>",
+	Short: "Issue a short-lived credential from a config (shown once)",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(_ *cobra.Command, args []string) error {
+		c, err := client()
+		if err != nil {
+			return err
+		}
+		id, err := strconv.Atoi(args[0])
+		if err != nil {
+			return fmt.Errorf("invalid config id: %s", args[0])
+		}
+		var lease issuedLease
+		body := map[string]int{"ttl_seconds": flagTTL}
+		if err := c.Post(context.Background(), fmt.Sprintf("/api/v1/dynamic-secrets/configs/%d/issue", id), body, &lease); err != nil {
+			return err
+		}
+		fmt.Println("Credential issued — shown once, auto-revokes at expiry.")
+		fmt.Printf("  lease:    %s\n", lease.LeaseID)
+		fmt.Printf("  username: %s\n", lease.Username)
+		fmt.Printf("  password: %s\n", lease.Password)
+		fmt.Printf("  expires:  %s\n", lease.ExpiresAt)
+		return nil
+	},
+}
+
+var leasesCmd = &cobra.Command{
+	Use:   "leases <config-id>",
+	Short: "List leases issued from a config",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(_ *cobra.Command, args []string) error {
+		c, err := client()
+		if err != nil {
+			return err
+		}
+		id, err := strconv.Atoi(args[0])
+		if err != nil {
+			return fmt.Errorf("invalid config id: %s", args[0])
+		}
+		var leases []leaseView
+		if err := c.Get(context.Background(), fmt.Sprintf("/api/v1/dynamic-secrets/configs/%d/leases", id), &leases); err != nil {
+			return err
+		}
+		if len(leases) == 0 {
+			fmt.Println("No leases for this config.")
+			return nil
+		}
+		fmt.Printf("%-34s %-16s %-14s %s\n", "LEASE", "ROLE", "STATUS", "EXPIRES")
+		for _, l := range leases {
+			fmt.Printf("%-34s %-16s %-14s %s\n", l.LeaseID, l.RoleName, l.Status, l.ExpiresAt)
+		}
+		return nil
+	},
+}
+
+var renewCmd = &cobra.Command{
+	Use:   "renew <lease-id>",
+	Short: "Extend an active lease (up to the config's max TTL)",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(_ *cobra.Command, args []string) error {
+		c, err := client()
+		if err != nil {
+			return err
+		}
+		var out struct {
+			LeaseID   string `json:"lease_id"`
+			ExpiresAt string `json:"expires_at"`
+		}
+		body := map[string]int{"ttl_seconds": flagTTL}
+		if err := c.Post(context.Background(), fmt.Sprintf("/api/v1/dynamic-secrets/leases/%s/renew", args[0]), body, &out); err != nil {
+			return err
+		}
+		fmt.Printf("Lease %s renewed — new expiry %s\n", out.LeaseID, out.ExpiresAt)
+		return nil
+	},
+}
+
+var revokeCmd = &cobra.Command{
+	Use:   "revoke <lease-id>",
+	Short: "Revoke an active lease now",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(_ *cobra.Command, args []string) error {
+		c, err := client()
+		if err != nil {
+			return err
+		}
+		var out struct {
+			LeaseID string `json:"lease_id"`
+			Status  string `json:"status"`
+		}
+		if err := c.Post(context.Background(), fmt.Sprintf("/api/v1/dynamic-secrets/leases/%s/revoke", args[0]), map[string]any{}, &out); err != nil {
+			return err
+		}
+		fmt.Printf("Lease %s %s.\n", out.LeaseID, out.Status)
+		return nil
+	},
+}

--- a/internal/cli/dynamic/dynamic_test.go
+++ b/internal/cli/dynamic/dynamic_test.go
@@ -1,0 +1,73 @@
+package dynamic
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCommandWiring guards the cobra wiring: subcommands, aliases, and flags.
+func TestCommandWiring(t *testing.T) {
+	names := map[string]bool{}
+	for _, sub := range DynamicSecretCmd.Commands() {
+		names[sub.Name()] = true
+	}
+	for _, want := range []string{"list", "issue", "leases", "renew", "revoke"} {
+		assert.True(t, names[want], "missing subcommand %q", want)
+	}
+	assert.Contains(t, DynamicSecretCmd.Aliases, "dyn")
+	assert.NotNil(t, issueCmd.Flags().Lookup("ttl"))
+	assert.NotNil(t, listCmd.Flags().Lookup("project-id"))
+}
+
+// captureStdout runs fn with os.Stdout redirected and returns what it printed.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+	fn()
+	_ = w.Close()
+	os.Stdout = old
+	out, _ := io.ReadAll(r)
+	return string(out)
+}
+
+// TestIssueAgainstMockServer drives `issue` against a stub API and checks it posts
+// to the right path and prints the once-shown credential.
+func TestIssueAgainstMockServer(t *testing.T) {
+	var gotMethod, gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod, gotPath = r.Method, r.URL.Path
+		_, _ = w.Write([]byte(`{"data":{"lease_id":"lease-abc","username":"kx_dyn_x9","password":"s3cr3t-pw","expires_at":"2026-06-12T11:00:00Z"}}`))
+	}))
+	defer srv.Close()
+
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+	flagTTL = 0
+
+	out := captureStdout(t, func() {
+		require.NoError(t, issueCmd.RunE(issueCmd, []string{"7"}))
+	})
+
+	assert.Equal(t, http.MethodPost, gotMethod)
+	assert.Equal(t, "/api/v1/dynamic-secrets/configs/7/issue", gotPath)
+	assert.Contains(t, out, "lease-abc")
+	assert.Contains(t, out, "kx_dyn_x9")
+	assert.Contains(t, out, "s3cr3t-pw")
+}
+
+func TestIssueRejectsBadConfigID(t *testing.T) {
+	t.Setenv("KEYORIX_SERVER", "http://127.0.0.1:0")
+	t.Setenv("KEYORIX_TOKEN", "t")
+	err := issueCmd.RunE(issueCmd, []string{"not-a-number"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid config id")
+}

--- a/internal/cli/main.go
+++ b/internal/cli/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/keyorixhq/keyorix/internal/cli/auth"
 	"github.com/keyorixhq/keyorix/internal/cli/config"
 	"github.com/keyorixhq/keyorix/internal/cli/connect"
+	"github.com/keyorixhq/keyorix/internal/cli/dynamic"
 	"github.com/keyorixhq/keyorix/internal/cli/encryption"
 	"github.com/keyorixhq/keyorix/internal/cli/group"
 	"github.com/keyorixhq/keyorix/internal/cli/invite"
@@ -55,6 +56,7 @@ func init() {
 	rootCmd.AddCommand(status.StatusCmd)
 	rootCmd.AddCommand(system.SystemCmd)
 	rootCmd.AddCommand(anomalies.AnomaliesCmd)
+	rootCmd.AddCommand(dynamic.DynamicSecretCmd)
 }
 
 // Execute runs the root command


### PR DESCRIPTION
## Summary

Dynamic secrets (ADR-035) were **API-only** — a developer couldn't get an on-demand database credential without hitting the REST API directly. This adds a `keyorix dynamic-secret` command so the feature is usable from the terminal:

```
keyorix dynamic-secret list [--project-id N] [--environment-id N]
keyorix dynamic-secret issue  <config-id> [--ttl SECONDS]   # credential shown once
keyorix dynamic-secret leases <config-id>
keyorix dynamic-secret renew  <lease-id> [--ttl SECONDS]
keyorix dynamic-secret revoke <lease-id>
```

(aliases: `dynamic-secrets`, `dyn`). It talks to the server REST API via the shared `common.RemoteClient` (auth + `{"data":…}` envelope decoding) — the credentials are minted server-side; the issued username/password is printed once, on `issue`.

**Config creation stays API/UI-only** — it takes the privileged admin DSN, which doesn't belong on a command line / in shell history.

## Testing

- Command wiring (subcommands, aliases, flags).
- `issue` against an `httptest` stub: asserts the `POST /api/v1/dynamic-secrets/configs/7/issue` path and that the once-shown credential is printed.
- Bad-config-id rejection.

`golangci-lint run` → 0 issues; `gitleaks` → no leaks; `make build` + full suite + `go vet` green. ADR-035 deferred list updated. Additive (new package + one registration line) — no behavior change to existing commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)