### PR TITLE
release: prep v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to Keyorix are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## v0.9.0 — 2026-06-12
+
+### Added
+- **`keyorix dynamic-secret` CLI** — issue and manage on-demand database
+  credentials (ADR-035) from the terminal: `list`, `issue <config-id>`,
+  `leases <config-id>`, `renew <lease-id>`, `revoke <lease-id>` (aliases:
+  `dynamic-secrets`, `dyn`). The issued username/password is shown once on
+  `issue`. Config creation stays API/UI-only (it takes the privileged admin DSN).
+  ([#117], ADR-035)
+
+[#117]: https://github.com/keyorixhq/keyorix/pull/117
+
 ## v0.8.0 — 2026-06-12
 
 ### Added

--- a/deploy/helm/keyorix/Chart.yaml
+++ b/deploy/helm/keyorix/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix
 description: Self-hosted Keyorix secrets manager (API server + web UI + PostgreSQL)
 type: application
 # Chart version — bump on chart changes.
-version: 0.8.0
+version: 0.9.0
 # The Keyorix app version this chart deploys by default (the image tag).
-appVersion: "0.8.0"
+appVersion: "0.9.0"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix


### PR DESCRIPTION
## Summary

Prepares **v0.9.0**. Since v0.8.0:

- **`keyorix dynamic-secret` CLI** — issue/manage on-demand database credentials from the terminal ([#117], ADR-035)

## Changes

- `CHANGELOG.md` — new v0.9.0 section
- `deploy/helm/keyorix/Chart.yaml` — `version` + `appVersion` → `0.9.0`

Merging this, then pushing the `v0.9.0` tag, triggers the release pipeline (binaries + checksums → GitHub Release; chart → `oci://ghcr.io/keyorixhq/charts`; server image `ghcr.io/keyorixhq/keyorix-server:0.9.0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)