### PR TITLE
feat(dynamic): incident kill switch — revoke all leases for a config (ADR-035)

### DIFF
--- a/docs/adr-035-dynamic-secrets.md
+++ b/docs/adr-035-dynamic-secrets.md
@@ -116,3 +116,8 @@ Two of the originally-deferred items shipped together:
   max-TTL — a renewal that wouldn't extend (cap reached) is rejected. Audited as
   `dynamic_lease.renewed`. Renewal reduces credential churn vs. re-issuing while
   the max-TTL keeps the hard bound on exposure.
+- **Incident kill switch** — `POST …/configs/{id}/revoke-all` (and
+  `keyorix dynamic-secret revoke-all <config-id>`) revokes **every** active lease
+  from a config at once, for when a target DB or config is compromised. Same
+  `secrets.write` + per-project-MFA authorization as a single revoke; best-effort
+  per lease; audited `dynamic_secret.bulk_revoke` with revoked/failed counts.

--- a/internal/cli/dynamic/dynamic.go
+++ b/internal/cli/dynamic/dynamic.go
@@ -25,6 +25,7 @@ var (
 	flagProjectID int
 	flagEnvID     int
 	flagTTL       int
+	flagYes       bool
 )
 
 func init() {
@@ -32,8 +33,9 @@ func init() {
 	listCmd.Flags().IntVar(&flagEnvID, "environment-id", 0, "Filter by environment ID")
 	issueCmd.Flags().IntVar(&flagTTL, "ttl", 0, "Lease TTL in seconds (0 = the config default)")
 	renewCmd.Flags().IntVar(&flagTTL, "ttl", 0, "Renewal TTL in seconds (0 = the config default)")
+	revokeAllCmd.Flags().BoolVar(&flagYes, "yes", false, "Skip the confirmation prompt")
 
-	DynamicSecretCmd.AddCommand(listCmd, issueCmd, leasesCmd, renewCmd, revokeCmd)
+	DynamicSecretCmd.AddCommand(listCmd, issueCmd, leasesCmd, renewCmd, revokeCmd, revokeAllCmd)
 }
 
 func client() (*common.RemoteClient, error) {
@@ -197,6 +199,41 @@ var revokeCmd = &cobra.Command{
 			return err
 		}
 		fmt.Printf("Lease %s %s.\n", out.LeaseID, out.Status)
+		return nil
+	},
+}
+
+var revokeAllCmd = &cobra.Command{
+	Use:   "revoke-all <config-id>",
+	Short: "Revoke ALL active leases from a config (incident kill switch)",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		id, err := strconv.Atoi(args[0])
+		if err != nil {
+			return fmt.Errorf("invalid config id: %s", args[0])
+		}
+		if !flagYes {
+			fmt.Printf("Revoke ALL active leases from config %d? This invalidates every outstanding\ncredential it issued. Type 'yes' to confirm: ", id)
+			var answer string
+			_, _ = fmt.Fscanln(cmd.InOrStdin(), &answer)
+			if answer != "yes" {
+				fmt.Println("Aborted.")
+				return nil
+			}
+		}
+		c, err := client()
+		if err != nil {
+			return err
+		}
+		var out struct {
+			ConfigID uint `json:"config_id"`
+			Revoked  int  `json:"revoked"`
+			Failed   int  `json:"failed"`
+		}
+		if err := c.Post(context.Background(), fmt.Sprintf("/api/v1/dynamic-secrets/configs/%d/revoke-all", id), map[string]any{}, &out); err != nil {
+			return err
+		}
+		fmt.Printf("Config %d: revoked %d lease(s), %d failed.\n", out.ConfigID, out.Revoked, out.Failed)
 		return nil
 	},
 }

--- a/internal/cli/dynamic/dynamic_test.go
+++ b/internal/cli/dynamic/dynamic_test.go
@@ -17,7 +17,7 @@ func TestCommandWiring(t *testing.T) {
 	for _, sub := range DynamicSecretCmd.Commands() {
 		names[sub.Name()] = true
 	}
-	for _, want := range []string{"list", "issue", "leases", "renew", "revoke"} {
+	for _, want := range []string{"list", "issue", "leases", "renew", "revoke", "revoke-all"} {
 		assert.True(t, names[want], "missing subcommand %q", want)
 	}
 	assert.Contains(t, DynamicSecretCmd.Aliases, "dyn")
@@ -62,6 +62,27 @@ func TestIssueAgainstMockServer(t *testing.T) {
 	assert.Contains(t, out, "lease-abc")
 	assert.Contains(t, out, "kx_dyn_x9")
 	assert.Contains(t, out, "s3cr3t-pw")
+}
+
+func TestRevokeAllAgainstMockServer(t *testing.T) {
+	var gotMethod, gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod, gotPath = r.Method, r.URL.Path
+		_, _ = w.Write([]byte(`{"data":{"config_id":7,"revoked":3,"failed":0}}`))
+	}))
+	defer srv.Close()
+
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+	flagYes = true // skip the interactive confirmation
+	t.Cleanup(func() { flagYes = false })
+
+	out := captureStdout(t, func() {
+		require.NoError(t, revokeAllCmd.RunE(revokeAllCmd, []string{"7"}))
+	})
+	assert.Equal(t, http.MethodPost, gotMethod)
+	assert.Equal(t, "/api/v1/dynamic-secrets/configs/7/revoke-all", gotPath)
+	assert.Contains(t, out, "revoked 3")
 }
 
 func TestIssueRejectsBadConfigID(t *testing.T) {

--- a/internal/core/dynamic_secrets.go
+++ b/internal/core/dynamic_secrets.go
@@ -214,6 +214,43 @@ func (c *KeyorixCore) RevokeExpiredLeases(ctx context.Context, before time.Time)
 	return revoked, nil
 }
 
+// RevokeLeasesForConfig revokes every active lease issued from a config — an
+// incident-response kill switch for a config's outstanding dynamic credentials
+// (e.g. a compromised target DB or config). Returns the counts revoked and failed
+// (each revoke is audited per-lease as well). Best-effort: one lease's revoke
+// failure does not stop the others.
+func (c *KeyorixCore) RevokeLeasesForConfig(ctx context.Context, configID, userID uint, reason string) (revoked, failed int, err error) {
+	leases, err := c.storage.ListDynamicSecretLeases(ctx, configID)
+	if err != nil {
+		return 0, 0, err
+	}
+	for _, l := range leases {
+		if l.Status != "active" {
+			continue
+		}
+		if rerr := c.RevokeLease(ctx, l.LeaseID, userID, reason); rerr != nil {
+			failed++
+		} else {
+			revoked++
+		}
+	}
+	var uidPtr *uint
+	if userID != 0 {
+		uidPtr = &userID
+	}
+	pid := uint(0)
+	if cfg, gerr := c.storage.GetDynamicSecretConfig(ctx, configID); gerr == nil {
+		pid = cfg.ProjectID
+	}
+	var pidPtr *uint
+	if pid != 0 {
+		pidPtr = &pid
+	}
+	c.writeAuditEventFull(ctx, "dynamic_secret.bulk_revoke", uidPtr, nil, pidPtr, "",
+		fmt.Sprintf("bulk-revoked dynamic leases for config %d (revoked=%d, failed=%d, reason=%s)", configID, revoked, failed, reason))
+	return revoked, failed, nil
+}
+
 // dynamicTTL resolves the requested TTL (override, else config default, else 1h)
 // and clamps it to the config's MaxTTLSeconds ceiling when one is set.
 func (c *KeyorixCore) dynamicTTL(cfg *models.DynamicSecretConfig, override int) time.Duration {

--- a/internal/core/dynamic_secrets_test.go
+++ b/internal/core/dynamic_secrets_test.go
@@ -199,6 +199,32 @@ func TestDynamicSecrets_RenewExtendsAndRespectsMaxTTL(t *testing.T) {
 	require.Error(t, err, "renewal beyond the max-TTL ceiling is rejected")
 }
 
+func TestDynamicSecrets_RevokeLeasesForConfig(t *testing.T) {
+	c, _, fake, _ := newDynamicTestCore(t)
+	ctx := context.Background()
+	cfg := mkConfig(t, c, ctx)
+
+	i1, err := c.IssueLease(ctx, cfg.ID, 0, 7)
+	require.NoError(t, err)
+	i2, err := c.IssueLease(ctx, cfg.ID, 0, 7)
+	require.NoError(t, err)
+
+	revoked, failed, err := c.RevokeLeasesForConfig(ctx, cfg.ID, 7, "incident")
+	require.NoError(t, err)
+	assert.Equal(t, 2, revoked)
+	assert.Equal(t, 0, failed)
+	assert.ElementsMatch(t, []string{i1.Username, i2.Username}, fake.Revoked)
+
+	// Both leases are now revoked; a second bulk-revoke finds nothing active.
+	for _, lid := range []string{i1.LeaseID, i2.LeaseID} {
+		l, _ := c.storage.GetDynamicSecretLease(ctx, lid)
+		assert.Equal(t, "revoked", l.Status)
+	}
+	revoked2, _, err := c.RevokeLeasesForConfig(ctx, cfg.ID, 7, "incident")
+	require.NoError(t, err)
+	assert.Equal(t, 0, revoked2)
+}
+
 func TestDynamicSecrets_RenewRejectsInactiveLease(t *testing.T) {
 	c, _, _, _ := newDynamicTestCore(t)
 	ctx := context.Background()

--- a/server/http/handlers/dynamic_secrets.go
+++ b/server/http/handlers/dynamic_secrets.go
@@ -6,6 +6,7 @@ package handlers
 
 import (
 	"encoding/json"
+	"fmt"
 	"log"
 	"net/http"
 	"strconv"
@@ -221,6 +222,24 @@ func (h *DynamicSecretHandler) RenewLease(w http.ResponseWriter, r *http.Request
 		return
 	}
 	sendSuccess(w, map[string]interface{}{"lease_id": leaseID, "expires_at": newExpiry}, "Lease renewed.")
+}
+
+// RevokeAllLeases handles POST /api/v1/dynamic-secrets/configs/{id}/revoke-all —
+// the incident kill switch: revoke every active lease from a config at once.
+func (h *DynamicSecretHandler) RevokeAllLeases(w http.ResponseWriter, r *http.Request) {
+	userCtx := middleware.GetUserFromContext(r.Context())
+	cfg, ok := h.loadAuthorizedConfig(w, r, "secrets.write")
+	if !ok {
+		return
+	}
+	revoked, failed, err := h.coreService.RevokeLeasesForConfig(r.Context(), cfg.ID, userCtx.UserID, "bulk")
+	if err != nil {
+		sendError(w, "Error", err.Error(), http.StatusBadGateway, nil)
+		return
+	}
+	sendSuccess(w, map[string]interface{}{
+		"config_id": cfg.ID, "revoked": revoked, "failed": failed,
+	}, fmt.Sprintf("Revoked %d active lease(s); %d failed.", revoked, failed))
 }
 
 // loadAuthorizedConfig loads the {id} config and authorizes the caller against

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -305,6 +305,7 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.Get("/configs/{id}", dynamicSecretHandler.GetConfig)
 			r.Post("/configs/{id}/issue", dynamicSecretHandler.IssueLease)
 			r.Get("/configs/{id}/leases", dynamicSecretHandler.ListLeases)
+			r.Post("/configs/{id}/revoke-all", dynamicSecretHandler.RevokeAllLeases)
 			r.Post("/leases/{leaseID}/renew", dynamicSecretHandler.RenewLease)
 			r.Post("/leases/{leaseID}/revoke", dynamicSecretHandler.RevokeLease)
 		})


### PR DESCRIPTION
## Summary

When a target database or a dynamic-secret config is compromised, an operator needs to invalidate **every** credential it issued *at once* — not click through leases one at a time. This adds an incident kill switch.

- **`core.RevokeLeasesForConfig`** — revokes every active lease from a config (best-effort per lease; reuses `RevokeLease` so each is dropped on the target DB and audited individually), returns `revoked`/`failed` counts, and audits a `dynamic_secret.bulk_revoke` summary.
- **`POST /api/v1/dynamic-secrets/configs/{id}/revoke-all`** — same `secrets.write` + per-project-MFA authorization as a single revoke (goes through `loadAuthorizedConfig`).
- **`keyorix dynamic-secret revoke-all <config-id>`** — destructive, so it prompts for a typed `yes` confirmation unless `--yes` is passed.

## Safety / authorization

Revoking is the *safe* direction (it removes access). It's gated by exactly the same scope check as a single-lease revoke (`secrets.write` on the config's project/environment, plus the per-project MFA policy). Each lease's revoke is still audited individually, with a summary event on top.

## Testing

- Core: bulk-revoke marks both leases revoked (and dropped on the engine); a second call finds nothing active.
- CLI: `revoke-all` against an `httptest` stub asserts the `POST …/configs/7/revoke-all` path + summary output; the `--yes` flag skips the prompt.

`golangci-lint run` → 0 issues; `gitleaks` → no leaks; `make build` + full suite + `go vet` green. ADR-035 addendum updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)