### PR TITLE
feat(crypto): KMS-backed KEK provider — KeyProvider Tier 2 (ADR-041)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -124,7 +124,7 @@ storage:
 
     # key_provider — default is "password" when omitted.
     key_provider:
-      type: password              # password | file | env
+      type: password              # password | file | env | aws-kms
 
       # type: file — read raw key material from a path (mounted CSI/sealed
       # secret, KMS sidecar output). Accepts 32 raw bytes, hex, or base64.
@@ -132,14 +132,23 @@ storage:
 
       # type: env — read the KEK (hex or base64) from the named env var's value.
       # env_var: KEYORIX_KEK
+
+      # type: aws-kms — envelope-wrap the KEK with an AWS KMS key (ADR-041); the
+      # wrapping key (CMK) stays in the KMS/HSM. Region + credentials come from the
+      # standard AWS environment (env / instance profile / IRSA), not from here.
+      # kms_key_id: arn:aws:kms:eu-west-1:123456789012:key/abcd-…
+      # wrapped_key_path: keys/kek.kms
 ```
 
 - **`password`** (default): KEK = PBKDF2-SHA256(`KEYORIX_MASTER_PASSWORD`, salt,
   600 000). Requires `KEYORIX_MASTER_PASSWORD`. This is byte-identical to all
   prior releases — existing `dek.key` files keep working.
 - **`file`** / **`env`**: the KEK is externally managed (e.g. injected by a KMS,
-  CSI driver, or sealed/SOPS secret). `KEYORIX_MASTER_PASSWORD` is **not** required
-  in these modes.
+  CSI driver, or sealed/SOPS secret). `KEYORIX_MASTER_PASSWORD` is **not** required.
+- **`aws-kms`** (ADR-041): the KEK is a random key **wrapped by an AWS KMS key**;
+  only the wrapped blob is on disk (`wrapped_key_path`), unwrapped via KMS at
+  startup. The CMK never leaves the KMS. `KEYORIX_MASTER_PASSWORD` is **not**
+  required. Startup needs KMS reachable (fail-closed).
 
 > Rotating the **DEK** (`keyorix encryption rotate`) re-encrypts all rows under a
 > new DEK and is independent of the provider. Rotating the **KEK** itself for

--- a/docs/adr-041-kms-key-provider.md
+++ b/docs/adr-041-kms-key-provider.md
@@ -1,0 +1,87 @@
+# ADR-041: KMS-backed KEK provider (KeyProvider Tier 2)
+
+**Status:** Accepted
+**Date:** 2026-06-12
+
+## Context
+
+ADR-038 made the KEK source pluggable (`crypto.KeyProvider`: password / file /
+env). The Tier-2 follow-on, and a hard requirement for many enterprise / ENS /
+CRA deployments, is to keep the **wrapping key in a cloud KMS / HSM** so the key
+that protects everything at rest never exists in plaintext on the Keyorix host.
+This was deferred because it adds a cloud SDK to the **server** binary (Keyorix
+had deliberately kept cloud SDKs in the CLI only); that trade-off is now
+explicitly accepted for this provider.
+
+## Decision
+
+Add an **`aws-kms`** key provider using **KMS envelope encryption**.
+
+- The KEK is a random 32-byte key, **wrapped by a KMS key (CMK)**; only the
+  *wrapped* blob is stored on disk (`wrapped_key_path`). At startup the provider
+  calls **KMS Decrypt** to unwrap it into memory. The CMK never leaves the KMS,
+  and a host-disk read yields only ciphertext.
+- **First run** generates the KEK, calls **KMS Encrypt**, and persists the wrapped
+  blob (0600); **subsequent runs** decrypt the stored blob. This mirrors the
+  password provider's ensure-salt-then-derive, with KMS encrypt/decrypt instead of
+  PBKDF2.
+- Everything below the KEK is unchanged — the KEK still unwraps the on-disk DEK,
+  which still encrypts the data. Only the *KEK source* is the KMS.
+
+### Cloud-SDK isolation
+
+`internal/crypto` stays **SDK-free**: it defines a small `KMSClient` interface
+(`Encrypt` / `Decrypt`) and the generic `KMSKeyProvider` (the envelope logic). The
+AWS KMS SDK is imported only in `internal/crypto/awskms`. GCP KMS / Azure Key Vault
+are future backends implementing the same `KMSClient` — no change to the provider
+or the data path. Region and credentials come from the standard AWS chain (env,
+instance profile, IRSA), never from Keyorix config; `Decrypt` pins the `KeyId` so
+the blob is only decryptable by the expected CMK.
+
+### Config
+
+```yaml
+storage:
+  encryption:
+    enabled: true
+    dek_path: keys/dek.key
+    key_provider:
+      type: aws-kms
+      kms_key_id: arn:aws:kms:eu-west-1:123456789012:key/abcd-…   # ID, ARN, or alias
+      wrapped_key_path: keys/kek.kms                               # the KMS-wrapped KEK
+```
+
+`KEYORIX_MASTER_PASSWORD` is **not** required with `aws-kms` (as with file/env);
+the server and the `keyorix encryption` CLI start without it.
+
+## Consequences
+
+- **Wrapping key in the HSM.** A compromised Keyorix host disk reveals only the
+  KMS-wrapped KEK and the wrapped DEK — neither is usable without the CMK, and the
+  CMK is gated by KMS IAM (and KMS audit/CloudTrail).
+- **The server binary now links the AWS KMS SDK** (accepted). `internal/crypto` is
+  unaffected; non-KMS deployments pay only binary size.
+- **Switching providers is a migration**, not automatic: an existing DEK wrapped by
+  a password/file KEK is not unwrappable by a fresh KMS KEK. `aws-kms` is for new
+  installs (or a deliberate re-wrap). Same caveat as file/env (ADR-038).
+- **Startup depends on KMS reachability** — a 30 s timeout bounds the call; if KMS
+  or IAM is down, the server fails to start (fail-closed, correct for an
+  encryption root of trust).
+
+## Verification
+
+Provider logic is proven against a fake `KMSClient`: first-run generate-and-wrap
+persists a *ciphertext* blob (not the raw KEK); a restart unwraps the identical
+KEK; a different CMK cannot unwrap; nil-client / empty-path / KMS-encrypt-failure
+(no blob persisted) / KMS-decrypt-failure / wrong-size-KEK are all rejected. An
+encryption-level round-trip shows a KMS-provider `KeyManager` wraps and unwraps the
+DEK end-to-end. The AWS glue (`awskms.New`) is thin and exercised against real KMS
+only in a live environment. `make build` + full suite + `go vet` + golangci-lint +
+gitleaks green.
+
+## Deferred
+
+GCP KMS and Azure Key Vault backends (same `KMSClient` interface); AWS
+`GenerateDataKey` as an optimisation; KMS-key rotation runbook; a re-wrap
+("migrate KEK provider") tool so an existing install can move to KMS without a
+manual DEK re-encryption.

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets v1.5.0
 	github.com/aws/aws-sdk-go-v2 v1.42.0
 	github.com/aws/aws-sdk-go-v2/config v1.32.24
+	github.com/aws/aws-sdk-go-v2/service/kms v1.53.4
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.42.3
 	github.com/go-chi/chi/v5 v5.2.2
 	github.com/go-chi/cors v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,8 @@ github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.12 h1:ZD2+BS
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.12/go.mod h1:Ms4zlcVBbXbiP7EVLhl+lgjvA/a7YphqQ3Ih3174EmI=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.29 h1:DRebniUGZ2MqiiIVmQJ04vIXr918hubdHMnarSLEWyU=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.29/go.mod h1:LfRkPCD8YHDM2E5eTkos2UpwYeZnBcVarTa8L59bJHA=
+github.com/aws/aws-sdk-go-v2/service/kms v1.53.4 h1:PEgVSsWtR8NNxsDxFL2Ywisi7R+1EFQARGsT4q3mWwI=
+github.com/aws/aws-sdk-go-v2/service/kms v1.53.4/go.mod h1:3EeKyDGPGSCEphG2OolwNGNF45RvQIfm27AYYpfEWrw=
 github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.42.3 h1:L9gPLf3sFH1/ao3oB2QZcaX1xGYi8hj+WJlsf3/dN+M=
 github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.42.3/go.mod h1:9DKRlwDCw2OUDlyCIFcQCroL5M0mQTUU9qW8JEDcXmI=
 github.com/aws/aws-sdk-go-v2/service/signin v1.1.5 h1:6Xt6Ztjkwdia/7EtEaG7ki/qZUYlCcd7tGUotQed1QE=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -238,12 +238,19 @@ type EncryptionConfig struct {
 
 // KeyProviderConfig selects the KEK source. type: "password" (default) derives the
 // KEK from KEYORIX_MASTER_PASSWORD; "file" reads raw key material from FilePath;
-// "env" reads it from the EnvVar's value (hex or base64). file/env suit a KEK
-// injected by a KMS, sealed/SOPS secret, or CSI driver.
+// "env" reads it from the EnvVar's value (hex or base64); "aws-kms" envelope-wraps
+// the KEK with an AWS KMS key (ADR-041) and stores the wrapped blob at
+// WrappedKeyPath. file/env suit a KEK injected by a sealed/SOPS secret or CSI
+// driver; aws-kms keeps the wrapping key in the cloud HSM.
 type KeyProviderConfig struct {
 	Type     string `yaml:"type"`
 	FilePath string `yaml:"file_path"`
 	EnvVar   string `yaml:"env_var"`
+	// KMSKeyID is the AWS KMS key (ID, ARN, or alias) for type "aws-kms". Region and
+	// credentials come from the standard AWS environment, not from here.
+	KMSKeyID string `yaml:"kms_key_id"`
+	// WrappedKeyPath is where the KMS-wrapped KEK blob lives (type "aws-kms").
+	WrappedKeyPath string `yaml:"wrapped_key_path"`
 }
 
 type SecretsConfig struct {

--- a/internal/crypto/awskms/awskms.go
+++ b/internal/crypto/awskms/awskms.go
@@ -1,0 +1,50 @@
+// Package awskms implements crypto.KMSClient against AWS KMS (ADR-041). It is the
+// only place the AWS KMS SDK is imported, keeping internal/crypto cloud-SDK-free.
+// Region and credentials come from the standard AWS chain (env, instance profile,
+// IRSA, …) — never from Keyorix config.
+package awskms
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/kms"
+	keyorixcrypto "github.com/keyorixhq/keyorix/internal/crypto"
+)
+
+type client struct {
+	kms   *kms.Client
+	keyID string
+}
+
+// New builds an AWS-KMS-backed crypto.KMSClient for the given key (ID, ARN, or
+// alias). It loads the default AWS config; the caller's environment supplies the
+// region and credentials.
+func New(ctx context.Context, keyID string) (keyorixcrypto.KMSClient, error) {
+	if keyID == "" {
+		return nil, fmt.Errorf("aws-kms: kms_key_id is required")
+	}
+	cfg, err := config.LoadDefaultConfig(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("aws-kms: load AWS config: %w", err)
+	}
+	return &client{kms: kms.NewFromConfig(cfg), keyID: keyID}, nil
+}
+
+func (c *client) Encrypt(ctx context.Context, plaintext []byte) ([]byte, error) {
+	out, err := c.kms.Encrypt(ctx, &kms.EncryptInput{KeyId: &c.keyID, Plaintext: plaintext})
+	if err != nil {
+		return nil, err
+	}
+	return out.CiphertextBlob, nil
+}
+
+func (c *client) Decrypt(ctx context.Context, ciphertext []byte) ([]byte, error) {
+	// Pin KeyId so the blob is only decryptable by the expected CMK.
+	out, err := c.kms.Decrypt(ctx, &kms.DecryptInput{CiphertextBlob: ciphertext, KeyId: &c.keyID})
+	if err != nil {
+		return nil, err
+	}
+	return out.Plaintext, nil
+}

--- a/internal/crypto/kms_provider.go
+++ b/internal/crypto/kms_provider.go
@@ -1,0 +1,88 @@
+package crypto
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/securefiles"
+)
+
+// KMSClient is the minimal envelope-encryption surface a cloud KMS exposes: wrap
+// (Encrypt) and unwrap (Decrypt) a small blob with a key that never leaves the
+// KMS/HSM. Keeping it an interface keeps this package free of any cloud SDK — the
+// AWS (and future GCP/Azure) implementations live in subpackages, and tests use a
+// fake. ciphertext is opaque, provider-specific KMS output.
+type KMSClient interface {
+	Encrypt(ctx context.Context, plaintext []byte) (ciphertext []byte, err error)
+	Decrypt(ctx context.Context, ciphertext []byte) (plaintext []byte, err error)
+}
+
+// kmsCallTimeout bounds a single KMS round-trip at startup.
+const kmsCallTimeout = 30 * time.Second
+
+// KMSKeyProvider sources the KEK via cloud-KMS envelope encryption (ADR-041): a
+// random 32-byte KEK is wrapped by the KMS key and the *wrapped* blob is stored on
+// disk; at startup the KMS unwraps it into memory. The KMS key (CMK) never leaves
+// the KMS, and the on-disk blob is ciphertext. First run generates and wraps the
+// KEK; subsequent runs decrypt the stored blob.
+type KMSKeyProvider struct {
+	client         KMSClient
+	baseDir        string
+	wrappedKeyPath string
+	name           string
+}
+
+// NewKMSKeyProvider builds a KMS-backed provider. name identifies the backend
+// (e.g. "aws-kms") for logging/metadata; wrappedKeyPath is resolved under baseDir.
+func NewKMSKeyProvider(client KMSClient, name, baseDir, wrappedKeyPath string) *KMSKeyProvider {
+	return &KMSKeyProvider{client: client, name: name, baseDir: baseDir, wrappedKeyPath: wrappedKeyPath}
+}
+
+func (p *KMSKeyProvider) Name() string { return p.name }
+
+func (p *KMSKeyProvider) KEK() ([]byte, error) {
+	if p.client == nil {
+		return nil, fmt.Errorf("%s key provider: no KMS client configured", p.name)
+	}
+	if p.wrappedKeyPath == "" {
+		return nil, fmt.Errorf("%s key provider: wrapped_key_path is required", p.name)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), kmsCallTimeout)
+	defer cancel()
+
+	full := filepath.Join(p.baseDir, p.wrappedKeyPath)
+	if _, err := os.Stat(full); os.IsNotExist(err) {
+		return p.generateAndWrap(ctx)
+	}
+	wrapped, err := securefiles.SafeReadFile(p.baseDir, p.wrappedKeyPath)
+	if err != nil {
+		return nil, fmt.Errorf("%s key provider: read wrapped KEK: %w", p.name, err)
+	}
+	kek, err := p.client.Decrypt(ctx, wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("%s key provider: KMS decrypt failed: %w", p.name, err)
+	}
+	return validateKEK(kek, p.name)
+}
+
+// generateAndWrap creates a fresh KEK, wraps it with the KMS key, persists the
+// wrapped blob (0600), and returns the plaintext KEK. First-run only.
+func (p *KMSKeyProvider) generateAndWrap(ctx context.Context) ([]byte, error) {
+	kek := make([]byte, KEKSize)
+	if _, err := io.ReadFull(rand.Reader, kek); err != nil {
+		return nil, fmt.Errorf("%s key provider: generate KEK: %w", p.name, err)
+	}
+	wrapped, err := p.client.Encrypt(ctx, kek)
+	if err != nil {
+		return nil, fmt.Errorf("%s key provider: KMS encrypt failed: %w", p.name, err)
+	}
+	if err := securefiles.SecureWriteFile(p.baseDir, p.wrappedKeyPath, wrapped, 0600); err != nil {
+		return nil, fmt.Errorf("%s key provider: persist wrapped KEK: %w", p.name, err)
+	}
+	return kek, nil
+}

--- a/internal/crypto/kms_provider_test.go
+++ b/internal/crypto/kms_provider_test.go
@@ -1,0 +1,113 @@
+package crypto
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeKMS is an in-memory envelope cipher: it "wraps" by prefixing a tag, so
+// Decrypt(Encrypt(x)) == x, and a different key (tag) fails to decrypt.
+type fakeKMS struct {
+	tag      string
+	encrypts int
+	decrypts int
+	failEncr bool
+	failDecr bool
+}
+
+func (f *fakeKMS) Encrypt(_ context.Context, pt []byte) ([]byte, error) {
+	f.encrypts++
+	if f.failEncr {
+		return nil, errors.New("kms encrypt boom")
+	}
+	return append([]byte(f.tag+"|"), pt...), nil
+}
+func (f *fakeKMS) Decrypt(_ context.Context, ct []byte) ([]byte, error) {
+	f.decrypts++
+	if f.failDecr {
+		return nil, errors.New("kms decrypt boom")
+	}
+	prefix := []byte(f.tag + "|")
+	if len(ct) < len(prefix) || string(ct[:len(prefix)]) != f.tag+"|" {
+		return nil, errors.New("kms: ciphertext was not wrapped by this key")
+	}
+	return ct[len(prefix):], nil
+}
+
+func TestKMSKeyProvider_WrapsThenUnwrapsStably(t *testing.T) {
+	dir := t.TempDir()
+	kms := &fakeKMS{tag: "cmk-A"}
+	p := NewKMSKeyProvider(kms, "aws-kms", dir, "kek.kms")
+
+	// First run: generates a KEK, wraps it, persists the wrapped blob.
+	kek1, err := p.KEK()
+	require.NoError(t, err)
+	require.Len(t, kek1, KEKSize)
+	assert.Equal(t, 1, kms.encrypts)
+	assert.Equal(t, 0, kms.decrypts)
+
+	wrapped, err := os.ReadFile(filepath.Join(dir, "kek.kms"))
+	require.NoError(t, err)
+	assert.NotEqual(t, kek1, wrapped, "the on-disk blob is the wrapped (ciphertext) KEK, not the raw key")
+
+	// Restart: a fresh provider over the same dir + same KMS unwraps the SAME KEK.
+	p2 := NewKMSKeyProvider(&fakeKMS{tag: "cmk-A"}, "aws-kms", dir, "kek.kms")
+	kek2, err := p2.KEK()
+	require.NoError(t, err)
+	assert.Equal(t, kek1, kek2, "the KEK must be stable across restarts")
+}
+
+func TestKMSKeyProvider_WrongKMSKeyCannotUnwrap(t *testing.T) {
+	dir := t.TempDir()
+	_, err := NewKMSKeyProvider(&fakeKMS{tag: "cmk-A"}, "aws-kms", dir, "kek.kms").KEK()
+	require.NoError(t, err)
+
+	// A different KMS key (tag) cannot decrypt the wrapped blob — like rotating the
+	// CMK out from under the data.
+	_, err = NewKMSKeyProvider(&fakeKMS{tag: "cmk-B"}, "aws-kms", dir, "kek.kms").KEK()
+	require.Error(t, err)
+}
+
+func TestKMSKeyProvider_Errors(t *testing.T) {
+	dir := t.TempDir()
+	t.Run("nil client", func(t *testing.T) {
+		_, err := NewKMSKeyProvider(nil, "aws-kms", dir, "kek.kms").KEK()
+		require.Error(t, err)
+	})
+	t.Run("empty wrapped_key_path", func(t *testing.T) {
+		_, err := NewKMSKeyProvider(&fakeKMS{tag: "x"}, "aws-kms", dir, "").KEK()
+		require.Error(t, err)
+	})
+	t.Run("KMS encrypt failure on first run", func(t *testing.T) {
+		_, err := NewKMSKeyProvider(&fakeKMS{tag: "x", failEncr: true}, "aws-kms", dir, "fail.kms").KEK()
+		require.Error(t, err)
+		assert.NoFileExists(t, filepath.Join(dir, "fail.kms"), "no wrapped blob persisted on encrypt failure")
+	})
+	t.Run("KMS decrypt failure on restart", func(t *testing.T) {
+		d2 := t.TempDir()
+		_, err := NewKMSKeyProvider(&fakeKMS{tag: "x"}, "aws-kms", d2, "k.kms").KEK()
+		require.NoError(t, err)
+		_, err = NewKMSKeyProvider(&fakeKMS{tag: "x", failDecr: true}, "aws-kms", d2, "k.kms").KEK()
+		require.Error(t, err)
+	})
+}
+
+func TestKMSKeyProvider_RejectsWrongSizeKEK(t *testing.T) {
+	dir := t.TempDir()
+	// A KMS that returns a non-32-byte "KEK" on decrypt must be rejected.
+	bad := &shortKMS{}
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "k.kms"), []byte("anything"), 0600))
+	_, err := NewKMSKeyProvider(bad, "aws-kms", dir, "k.kms").KEK()
+	require.Error(t, err)
+}
+
+type shortKMS struct{}
+
+func (shortKMS) Encrypt(_ context.Context, pt []byte) ([]byte, error) { return pt, nil }
+func (shortKMS) Decrypt(_ context.Context, _ []byte) ([]byte, error)  { return []byte("too-short"), nil }

--- a/internal/encryption/keyprovider_compat_test.go
+++ b/internal/encryption/keyprovider_compat_test.go
@@ -2,6 +2,7 @@ package encryption
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"os"
 	"path/filepath"
@@ -14,6 +15,16 @@ import (
 )
 
 const compatPass = "correct horse battery staple"
+
+// fakeKMS is an in-memory envelope cipher for the KMS-provider round-trip test.
+type fakeKMS struct{}
+
+func (fakeKMS) Encrypt(_ context.Context, pt []byte) ([]byte, error) {
+	return append([]byte("wrapped|"), pt...), nil
+}
+func (fakeKMS) Decrypt(_ context.Context, ct []byte) ([]byte, error) {
+	return ct[len("wrapped|"):], nil
+}
 
 // TestKeyProvider_PasswordIsBackwardCompatible is the load-bearing guarantee of
 // ADR-038: a KeyManager using the new PasswordKeyProvider must unwrap a DEK that
@@ -73,6 +84,16 @@ func TestKeyProvider_EnvRoundTrip(t *testing.T) {
 	raw := bytes.Repeat([]byte{0x5C}, 32)
 	t.Setenv("KX_COMPAT_KEK", base64.StdEncoding.EncodeToString(raw))
 	roundTrip(t, dir, func() crypto.KeyProvider { return crypto.NewEnvKeyProvider("KX_COMPAT_KEK") })
+}
+
+// TestKeyProvider_KMSRoundTrip proves a KMS-envelope KEK wraps/unwraps the DEK
+// end-to-end: the KEK is generated and KMS-wrapped on first init, and a fresh
+// KeyManager over the same wrapped-blob + KMS unwraps the identical DEK.
+func TestKeyProvider_KMSRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	roundTrip(t, dir, func() crypto.KeyProvider {
+		return crypto.NewKMSKeyProvider(fakeKMS{}, "aws-kms", dir, "kek.kms")
+	})
 }
 
 // TestKeyProvider_DEKRotationUnderProvider verifies that rotating the DEK while a

--- a/internal/encryption/service.go
+++ b/internal/encryption/service.go
@@ -4,6 +4,7 @@
 package encryption
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/keyorixhq/keyorix/internal/config"
 	"github.com/keyorixhq/keyorix/internal/crypto"
+	"github.com/keyorixhq/keyorix/internal/crypto/awskms"
 )
 
 // Service provides high-level encryption operations for the application.
@@ -80,8 +82,14 @@ func (s *Service) buildKeyProvider(passphrase string) (crypto.KeyProvider, error
 		return crypto.NewFileKeyProvider(kp.FilePath), nil
 	case "env":
 		return crypto.NewEnvKeyProvider(kp.EnvVar), nil
+	case "aws-kms":
+		kmsClient, err := awskms.New(context.Background(), kp.KMSKeyID)
+		if err != nil {
+			return nil, err
+		}
+		return crypto.NewKMSKeyProvider(kmsClient, "aws-kms", s.keyManager.baseDir, kp.WrappedKeyPath), nil
 	default:
-		return nil, fmt.Errorf("unknown encryption key_provider type %q (supported: password, file, env)", kp.Type)
+		return nil, fmt.Errorf("unknown encryption key_provider type %q (supported: password, file, env, aws-kms)", kp.Type)
 	}
 }
 

--- a/server/main.go
+++ b/server/main.go
@@ -155,7 +155,7 @@ func initializeEncryption(cfg *config.Config) (*encryption.Service, error) {
 	if (providerType == "" || providerType == "password") && passphrase == "" {
 		return nil, fmt.Errorf(
 			"encryption is enabled with the password key provider but KEYORIX_MASTER_PASSWORD " +
-				"is not set; set it, or configure storage.encryption.key_provider (file/env)")
+				"is not set; set it, or configure storage.encryption.key_provider (file/env/aws-kms)")
 	}
 
 	baseDir := ""


### PR DESCRIPTION
## Summary

Adds an **`aws-kms`** key provider (KeyProvider Tier 2, ADR-041) so the KEK's *wrapping* key stays in a cloud **KMS/HSM** — the enterprise / ENS / CRA requirement that the root key protecting everything at rest never exists in plaintext on the Keyorix host.

**KMS envelope encryption:** a random 32-byte KEK is wrapped by an AWS KMS key (CMK); only the *wrapped* blob is stored on disk (`wrapped_key_path`), unwrapped via **KMS Decrypt** at startup. First run generates + wraps the KEK; restarts decrypt the stored blob. Everything below the KEK (the on-disk DEK, the data) is unchanged.

## Cloud-SDK isolation

`internal/crypto` stays **SDK-free** — it defines a small `KMSClient` interface (`Encrypt`/`Decrypt`) and the generic `KMSKeyProvider` (the envelope logic). The AWS KMS SDK is imported only in `internal/crypto/awskms`. GCP KMS / Azure Key Vault are future backends behind the same interface, no change to the provider or data path. `Decrypt` pins `KeyId`; region/credentials come from the standard AWS chain (env / instance profile / IRSA), never from config.

The **server binary now links the AWS KMS SDK** — the explicitly-accepted trade-off for this provider (per your green-light). `internal/crypto` is unaffected; non-KMS installs pay only binary size.

## Config

```yaml
storage:
  encryption:
    key_provider:
      type: aws-kms
      kms_key_id: arn:aws:kms:eu-west-1:123456789012:key/abcd-…   # ID, ARN, or alias
      wrapped_key_path: keys/kek.kms
```

`KEYORIX_MASTER_PASSWORD` is not required with `aws-kms` (like file/env). Switching providers on an existing install is a migration (same caveat as file/env). Startup is **fail-closed** if KMS is unreachable (30 s timeout) — correct for an encryption root of trust.

## Testing

Provider logic against a fake `KMSClient`: generate-and-wrap persists *ciphertext* (not the raw KEK); a restart unwraps the **identical** KEK; a different CMK can't unwrap; nil-client / empty-path / encrypt-failure (no blob written) / decrypt-failure / wrong-size-KEK all rejected. Plus an encryption-level `KeyManager` DEK wrap/unwrap round-trip via a KMS provider. The thin `awskms.New` glue is exercised against real KMS only in a live environment.

`make build` + full suite + `go vet` + `golangci-lint` (0 issues) + `gitleaks` (no leaks) green. ADR-041; CONFIGURATION.md updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)