### PR TITLE
feat(crypto): Azure Key Vault KEK provider — third KMS backend (ADR-041)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -124,7 +124,7 @@ storage:
 
     # key_provider — default is "password" when omitted.
     key_provider:
-      type: password              # password | file | env | aws-kms | gcp-kms
+      type: password              # password | file | env | aws-kms | gcp-kms | azure-kms
 
       # type: file — read raw key material from a path (mounted CSI/sealed
       # secret, KMS sidecar output). Accepts 32 raw bytes, hex, or base64.
@@ -133,11 +133,13 @@ storage:
       # type: env — read the KEK (hex or base64) from the named env var's value.
       # env_var: KEYORIX_KEK
 
-      # type: aws-kms / gcp-kms — envelope-wrap the KEK with a cloud KMS key
-      # (ADR-041); the wrapping key stays in the KMS/HSM. Credentials come from the
-      # standard cloud environment (AWS: env/instance-profile/IRSA; GCP: ADC).
-      # kms_key_id: arn:aws:kms:eu-west-1:123456789012:key/abcd-…              # aws-kms
-      # kms_key_id: projects/p/locations/eu/keyRings/r/cryptoKeys/keyorix-kek  # gcp-kms
+      # type: aws-kms / gcp-kms / azure-kms — envelope-wrap the KEK with a cloud
+      # KMS/HSM key (ADR-041); the wrapping key stays in the KMS/HSM. Credentials
+      # come from the standard cloud environment (AWS: env/instance-profile/IRSA;
+      # GCP: ADC; Azure: DefaultAzureCredential / managed identity).
+      # kms_key_id: arn:aws:kms:eu-west-1:123456789012:key/abcd-…                  # aws-kms
+      # kms_key_id: projects/p/locations/eu/keyRings/r/cryptoKeys/keyorix-kek      # gcp-kms
+      # kms_key_id: https://myvault.vault.azure.net/keys/keyorix-kek               # azure-kms
       # wrapped_key_path: keys/kek.kms
 ```
 
@@ -146,10 +148,12 @@ storage:
   prior releases — existing `dek.key` files keep working.
 - **`file`** / **`env`**: the KEK is externally managed (e.g. injected by a KMS,
   CSI driver, or sealed/SOPS secret). `KEYORIX_MASTER_PASSWORD` is **not** required.
-- **`aws-kms`** / **`gcp-kms`** (ADR-041): the KEK is a random key **wrapped by a
-  cloud KMS key**; only the wrapped blob is on disk (`wrapped_key_path`), unwrapped
-  via KMS at startup. The wrapping key never leaves the KMS/HSM.
-  `KEYORIX_MASTER_PASSWORD` is **not** required. Startup needs KMS reachable
+- **`aws-kms`** / **`gcp-kms`** / **`azure-kms`** (ADR-041): the KEK is a random key
+  **wrapped by a cloud KMS/HSM key**; only the wrapped blob is on disk
+  (`wrapped_key_path`), unwrapped via the KMS at startup. The wrapping key never
+  leaves the KMS/HSM. `kms_key_id` is an AWS key ID/ARN/alias, a GCP crypto-key
+  resource name, or an Azure Key Vault key identifier URL.
+  `KEYORIX_MASTER_PASSWORD` is **not** required. Startup needs the KMS reachable
   (fail-closed).
 
 > Rotating the **DEK** (`keyorix encryption rotate`) re-encrypts all rows under a

--- a/docs/adr-041-kms-key-provider.md
+++ b/docs/adr-041-kms-key-provider.md
@@ -91,8 +91,23 @@ is inherently pinned (the ciphertext cannot select a different key — the same
 property AWS gets via explicit `KeyId` pinning). Keyorix now offers AWS **or** GCP
 KMS for the wrapping key.
 
+## Addendum (2026-06-12): Azure Key Vault backend
+
+A third backend, **`azure-kms`**, ships behind the same `KMSClient` interface
+(`internal/crypto/azurekms`, the only place the Azure Key Vault SDK is imported).
+It uses the identical envelope flow and the generic `KMSKeyProvider` — no change to
+the provider logic or the data path. The KEK is wrapped/unwrapped with the vault
+key's `wrapKey`/`unwrapKey` operations (RSA-OAEP-256) rather than encrypt/decrypt,
+but the `Encrypt`/`Decrypt` interface is unchanged. `kms_key_id` holds the Key
+Vault **key identifier URL**
+(`https://{vault}.vault.azure.net/keys/{name}[/{version}]`; an omitted version uses
+the key's current version); credentials come from `DefaultAzureCredential` (env,
+managed identity, workload identity). Like GCP, the operation names the key, so the
+key is inherently pinned — the ciphertext cannot select a different key. Keyorix now
+offers AWS, GCP, **or** Azure for the wrapping key.
+
 ## Deferred
 
-Azure Key Vault backend (same `KMSClient` interface); AWS `GenerateDataKey` as an
-optimisation; KMS-key rotation runbook; a re-wrap ("migrate KEK provider") tool so
-an existing install can move to KMS without a manual DEK re-encryption.
+AWS `GenerateDataKey` as an optimisation; KMS-key rotation runbook; a re-wrap
+("migrate KEK provider") tool so an existing install can move to KMS without a
+manual DEK re-encryption.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,9 @@ go 1.26.3
 
 require (
 	cloud.google.com/go/kms v1.31.0
+	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1
+	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azkeys v1.4.0
 	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets v1.5.0
 	github.com/aws/aws-sdk-go-v2 v1.42.0
 	github.com/aws/aws-sdk-go-v2/config v1.32.24
@@ -42,7 +44,6 @@ require (
 	cloud.google.com/go/iam v1.7.0 // indirect
 	cloud.google.com/go/longrunning v0.9.0 // indirect
 	filippo.io/edwards25519 v1.2.0 // indirect
-	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/internal v1.2.0 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,8 @@ github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache v0.3.2 h1:yz1bePFlP5Vws5+
 github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache v0.3.2/go.mod h1:Pa9ZNPuoNu/GztvBSKk9J1cDJW6vk/n0zLtV4mgd8N8=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2 h1:9iefClla7iYpfYWdzPCRDozdmndjTm8DXdpCzPajMgA=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2/go.mod h1:XtLgD3ZD34DAaVIIAyG3objl5DynM3CQ/vMcbBNJZGI=
+github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azkeys v1.4.0 h1:E4MgwLBGeVB5f2MdcIVD3ELVAWpr+WD6MUe1i+tM/PA=
+github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azkeys v1.4.0/go.mod h1:Y2b/1clN4zsAoUd/pgNAQHjLDnTis/6ROkUfyob6psM=
 github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets v1.5.0 h1:aMFOzch6ZJo4Ct9hI4A9Y2fPen5YNRTPmkSBhe5m0ZQ=
 github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets v1.5.0/go.mod h1:Oct8bx+g+DXKngU7i/LzFzYt44rmLdMu4uoofIpooVo=
 github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/internal v1.2.0 h1:nCYfgcSyHZXJI8J0IWE5MsCGlb2xp9fJiXyxWgmOFg4=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -238,20 +238,22 @@ type EncryptionConfig struct {
 
 // KeyProviderConfig selects the KEK source. type: "password" (default) derives the
 // KEK from KEYORIX_MASTER_PASSWORD; "file" reads raw key material from FilePath;
-// "env" reads it from the EnvVar's value (hex or base64); "aws-kms" / "gcp-kms"
-// envelope-wrap the KEK with a cloud KMS key (ADR-041) and store the wrapped blob
-// at WrappedKeyPath. file/env suit a KEK injected by a sealed/SOPS secret or CSI
-// driver; the KMS providers keep the wrapping key in the cloud HSM.
+// "env" reads it from the EnvVar's value (hex or base64); "aws-kms" / "gcp-kms" /
+// "azure-kms" envelope-wrap the KEK with a cloud KMS/HSM key (ADR-041) and store
+// the wrapped blob at WrappedKeyPath. file/env suit a KEK injected by a sealed/SOPS
+// secret or CSI driver; the KMS providers keep the wrapping key in the cloud HSM.
 type KeyProviderConfig struct {
 	Type     string `yaml:"type"`
 	FilePath string `yaml:"file_path"`
 	EnvVar   string `yaml:"env_var"`
-	// KMSKeyID is the cloud KMS key for type aws-kms / gcp-kms: an AWS key ID, ARN,
-	// or alias; or a GCP crypto-key resource name
-	// (projects/P/locations/L/keyRings/R/cryptoKeys/K). Region/credentials come from
-	// the standard cloud environment, not from here.
+	// KMSKeyID is the cloud KMS key for type aws-kms / gcp-kms / azure-kms: an AWS
+	// key ID, ARN, or alias; a GCP crypto-key resource name
+	// (projects/P/locations/L/keyRings/R/cryptoKeys/K); or an Azure Key Vault key
+	// identifier URL (https://{vault}.vault.azure.net/keys/{name}[/{version}]).
+	// Region/credentials come from the standard cloud environment, not from here.
 	KMSKeyID string `yaml:"kms_key_id"`
-	// WrappedKeyPath is where the KMS-wrapped KEK blob lives (aws-kms / gcp-kms).
+	// WrappedKeyPath is where the KMS-wrapped KEK blob lives (aws-kms / gcp-kms /
+	// azure-kms).
 	WrappedKeyPath string `yaml:"wrapped_key_path"`
 }
 

--- a/internal/crypto/azurekms/azurekms.go
+++ b/internal/crypto/azurekms/azurekms.go
@@ -1,0 +1,100 @@
+// Package azurekms implements crypto.KMSClient against Azure Key Vault (ADR-041).
+// Like the awskms and gcpkms packages, it is the only place the Azure Key Vault
+// SDK is imported, so internal/crypto stays cloud-SDK-free. Credentials come from
+// DefaultAzureCredential (env vars, managed identity, workload identity), never
+// from Keyorix config.
+//
+// Envelope encryption uses the vault key's wrapKey/unwrapKey operations
+// (RSA-OAEP-256): the 32-byte KEK is wrapped by the vault key and only the wrapped
+// blob is stored on disk. Like GCP KMS, the operation names the key (vault URL +
+// key name + version), so the key is inherently pinned — the ciphertext cannot
+// select a different key.
+package azurekms
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azkeys"
+	keyorixcrypto "github.com/keyorixhq/keyorix/internal/crypto"
+)
+
+// wrapAlgorithm is the asymmetric wrap algorithm used to envelope the KEK. RSA
+// keys are the common Key Vault case; the same algorithm is used for unwrap.
+var wrapAlgorithm = azkeys.EncryptionAlgorithmRSAOAEP256
+
+type client struct {
+	keys       *azkeys.Client
+	keyName    string
+	keyVersion string // "" = latest version
+}
+
+// New builds an Azure-Key-Vault-backed crypto.KMSClient. keyID is the full key
+// identifier URL (https://{vault}.vault.azure.net/keys/{name}[/{version}]); an
+// omitted version uses the key's current version.
+func New(_ context.Context, keyID string) (keyorixcrypto.KMSClient, error) {
+	if keyID == "" {
+		return nil, fmt.Errorf("azure-kms: kms_key_id (key identifier URL) is required")
+	}
+	vaultURL, name, version, err := parseKeyID(keyID)
+	if err != nil {
+		return nil, err
+	}
+	cred, err := azidentity.NewDefaultAzureCredential(nil)
+	if err != nil {
+		return nil, fmt.Errorf("azure-kms: default credential: %w", err)
+	}
+	c, err := azkeys.NewClient(vaultURL, cred, nil)
+	if err != nil {
+		return nil, fmt.Errorf("azure-kms: create client: %w", err)
+	}
+	return &client{keys: c, keyName: name, keyVersion: version}, nil
+}
+
+// parseKeyID splits an Azure Key Vault key identifier URL into the vault URL, key
+// name, and (optional) key version. Accepts both versioned and unversioned forms.
+func parseKeyID(keyID string) (vaultURL, name, version string, err error) {
+	u, err := url.Parse(keyID)
+	if err != nil {
+		return "", "", "", fmt.Errorf("azure-kms: invalid kms_key_id %q: %w", keyID, err)
+	}
+	if u.Scheme == "" || u.Host == "" {
+		return "", "", "", fmt.Errorf("azure-kms: kms_key_id must be a key identifier URL (https://{vault}.vault.azure.net/keys/{name}[/{version}]), got %q", keyID)
+	}
+	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
+	if len(parts) < 2 || parts[0] != "keys" || parts[1] == "" {
+		return "", "", "", fmt.Errorf("azure-kms: kms_key_id path must be /keys/{name}[/{version}], got %q", u.Path)
+	}
+	vaultURL = u.Scheme + "://" + u.Host
+	name = parts[1]
+	if len(parts) >= 3 {
+		version = parts[2]
+	}
+	return vaultURL, name, version, nil
+}
+
+func (c *client) Encrypt(ctx context.Context, plaintext []byte) ([]byte, error) {
+	res, err := c.keys.WrapKey(ctx, c.keyName, c.keyVersion, azkeys.KeyOperationParameters{
+		Algorithm: to.Ptr(wrapAlgorithm),
+		Value:     plaintext,
+	}, nil)
+	if err != nil {
+		return nil, err
+	}
+	return res.Result, nil
+}
+
+func (c *client) Decrypt(ctx context.Context, ciphertext []byte) ([]byte, error) {
+	res, err := c.keys.UnwrapKey(ctx, c.keyName, c.keyVersion, azkeys.KeyOperationParameters{
+		Algorithm: to.Ptr(wrapAlgorithm),
+		Value:     ciphertext,
+	}, nil)
+	if err != nil {
+		return nil, err
+	}
+	return res.Result, nil
+}

--- a/internal/crypto/azurekms/azurekms_test.go
+++ b/internal/crypto/azurekms/azurekms_test.go
@@ -1,0 +1,52 @@
+package azurekms
+
+import "testing"
+
+func TestParseKeyID(t *testing.T) {
+	tests := []struct {
+		name                             string
+		keyID                            string
+		wantVault, wantName, wantVersion string
+		wantErr                          bool
+	}{
+		{
+			name:        "versioned",
+			keyID:       "https://myvault.vault.azure.net/keys/kek/abc123",
+			wantVault:   "https://myvault.vault.azure.net",
+			wantName:    "kek",
+			wantVersion: "abc123",
+		},
+		{
+			name:      "unversioned uses latest",
+			keyID:     "https://myvault.vault.azure.net/keys/kek",
+			wantVault: "https://myvault.vault.azure.net",
+			wantName:  "kek",
+		},
+		{
+			name:      "trailing slash",
+			keyID:     "https://myvault.vault.azure.net/keys/kek/",
+			wantVault: "https://myvault.vault.azure.net",
+			wantName:  "kek",
+		},
+		{name: "missing scheme/host", keyID: "/keys/kek/v1", wantErr: true},
+		{name: "not a keys path", keyID: "https://myvault.vault.azure.net/secrets/foo", wantErr: true},
+		{name: "missing key name", keyID: "https://myvault.vault.azure.net/keys", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vault, name, version, err := parseKeyID(tt.keyID)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got vault=%q name=%q version=%q", vault, name, version)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if vault != tt.wantVault || name != tt.wantName || version != tt.wantVersion {
+				t.Fatalf("got (%q,%q,%q), want (%q,%q,%q)", vault, name, version, tt.wantVault, tt.wantName, tt.wantVersion)
+			}
+		})
+	}
+}

--- a/internal/crypto/kms_provider.go
+++ b/internal/crypto/kms_provider.go
@@ -15,8 +15,8 @@ import (
 // KMSClient is the minimal envelope-encryption surface a cloud KMS exposes: wrap
 // (Encrypt) and unwrap (Decrypt) a small blob with a key that never leaves the
 // KMS/HSM. Keeping it an interface keeps this package free of any cloud SDK — the
-// AWS (and future GCP/Azure) implementations live in subpackages, and tests use a
-// fake. ciphertext is opaque, provider-specific KMS output.
+// AWS / GCP / Azure implementations live in subpackages, and tests use a fake.
+// ciphertext is opaque, provider-specific KMS output.
 type KMSClient interface {
 	Encrypt(ctx context.Context, plaintext []byte) (ciphertext []byte, err error)
 	Decrypt(ctx context.Context, ciphertext []byte) (plaintext []byte, err error)

--- a/internal/encryption/service.go
+++ b/internal/encryption/service.go
@@ -14,6 +14,7 @@ import (
 	"github.com/keyorixhq/keyorix/internal/config"
 	"github.com/keyorixhq/keyorix/internal/crypto"
 	"github.com/keyorixhq/keyorix/internal/crypto/awskms"
+	"github.com/keyorixhq/keyorix/internal/crypto/azurekms"
 	"github.com/keyorixhq/keyorix/internal/crypto/gcpkms"
 )
 
@@ -95,8 +96,14 @@ func (s *Service) buildKeyProvider(passphrase string) (crypto.KeyProvider, error
 			return nil, err
 		}
 		return crypto.NewKMSKeyProvider(kmsClient, "gcp-kms", s.keyManager.baseDir, kp.WrappedKeyPath), nil
+	case "azure-kms":
+		kmsClient, err := azurekms.New(context.Background(), kp.KMSKeyID)
+		if err != nil {
+			return nil, err
+		}
+		return crypto.NewKMSKeyProvider(kmsClient, "azure-kms", s.keyManager.baseDir, kp.WrappedKeyPath), nil
 	default:
-		return nil, fmt.Errorf("unknown encryption key_provider type %q (supported: password, file, env, aws-kms, gcp-kms)", kp.Type)
+		return nil, fmt.Errorf("unknown encryption key_provider type %q (supported: password, file, env, aws-kms, gcp-kms, azure-kms)", kp.Type)
 	}
 }
 


### PR DESCRIPTION
Adds an `azure-kms` key provider — the third KMS backend behind the existing
`crypto.KMSClient` interface, after AWS (#120) and GCP (#121). No change to the
provider logic or the data path; only a new `KMSClient` implementation. ADR-041.

## What
- **`internal/crypto/azurekms`** — the only place the Azure Key Vault SDK is
  imported, keeping `internal/crypto` cloud-SDK-free. Envelopes the KEK with the
  vault key's `wrapKey`/`unwrapKey` ops (RSA-OAEP-256). Credentials via
  `DefaultAzureCredential` (env / managed identity / workload identity), never from
  config. `kms_key_id` is the key-identifier URL
  (`https://{vault}.vault.azure.net/keys/{name}[/{version}]`); like GCP the op
  names the key, so it is inherently pinned.
- Wired into `encryption.buildKeyProvider` (`case "azure-kms"`) + the
  supported-types error string.
- `config.go` doc comments, ADR-041 Azure addendum, `CONFIGURATION.md`.
- Unit test for the key-id URL parser (the only Azure-specific logic).

## Verification
`make build`, full test suite, `go vet`, `golangci-lint` (0 issues), `gofmt`,
`gitleaks` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
