### PR TITLE
feat(crypto): migrate-provider — re-wrap DEK to a new KEK provider (ADR-041)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -157,8 +157,16 @@ storage:
   (fail-closed).
 
 > Rotating the **DEK** (`keyorix encryption rotate`) re-encrypts all rows under a
-> new DEK and is independent of the provider. Rotating the **KEK** itself for
-> file/env is an external operation (replace the key material, re-wrap the DEK).
+> new DEK and is independent of the provider.
+>
+> **Switching providers** (e.g. password → a cloud KMS) is
+> `keyorix encryption migrate-provider --to-type <type> … --confirm` (ADR-041): it
+> re-wraps the DEK under the target provider's KEK **without re-encrypting any
+> data** (fast, no DB lock), verifies the target unwraps it, and keeps a backup of
+> the previous wrapped DEK. Migrating `--to-type password` reads the new passphrase
+> from `KEYORIX_NEW_MASTER_PASSWORD` and doubles as a master-passphrase rotation.
+> After it succeeds, update `key_provider` in this config to the target before the
+> next restart (the command prints the exact block).
 
 If `encryption.enabled` is false, secrets and tokens are stored in **plaintext** —
 acceptable only for local development.

--- a/docs/adr-041-kms-key-provider.md
+++ b/docs/adr-041-kms-key-provider.md
@@ -106,8 +106,36 @@ managed identity, workload identity). Like GCP, the operation names the key, so 
 key is inherently pinned — the ciphertext cannot select a different key. Keyorix now
 offers AWS, GCP, **or** Azure for the wrapping key.
 
+## Addendum (2026-06-12): KEK-provider migration tool
+
+Switching providers used to be a manual DEK re-encryption (see Consequences). It is
+now a single command: **`keyorix encryption migrate-provider --to-type … --confirm`**
+**re-wraps the DEK under a KEK from the target provider without re-encrypting any
+data.** Because the DEK is unchanged — only the key that *wraps* it on disk changes —
+the operation is fast and takes no database lock, unlike `encryption rotate`
+(ADR-010), which generates a new DEK and re-encrypts every row.
+
+Flow: open the on-disk DEK with the **current** provider (from config); build the
+**target** provider from the `--to-*` flags; back up the current wrapped DEK; re-wrap
+the DEK under the target KEK and atomically replace it (write-pending-then-rename);
+then **verify** a fresh service on the target config round-trips a probe value and, on
+any mismatch, **restore the backup** and abort. The target provider's own key
+material (a fresh salt for `password`, the KMS-wrapped KEK blob for the `*-kms`
+providers) is persisted before the DEK file is touched, so a failure leaves the
+active DEK intact. After success the operator updates
+`storage.encryption.key_provider` to the target before the next restart (the command
+prints the exact block). Migrating *to* `password` reads the new passphrase from
+`KEYORIX_NEW_MASTER_PASSWORD`; this also doubles as a master-passphrase rotation
+(same salt, new passphrase) with no data re-encryption.
+
+The re-wrap core (`KeyManager.RewrapDEK`) and the provider builder
+(`encryption.NewKeyProviderFromConfig`, shared with service startup) carry no cloud
+dependency. Verified by unit tests (DEK preserved across re-wrap; the new provider
+unwraps it; the old provider no longer does; a failing provider leaves the active DEK
+intact) and an end-to-end CLI test (password → env migration round-trips a secret and
+keeps a backup).
+
 ## Deferred
 
-AWS `GenerateDataKey` as an optimisation; KMS-key rotation runbook; a re-wrap
-("migrate KEK provider") tool so an existing install can move to KMS without a
-manual DEK re-encryption.
+AWS `GenerateDataKey` as an optimisation; KMS-key rotation runbook (rotating the CMK
+itself within the cloud KMS).

--- a/internal/cli/encryption/migrate_provider.go
+++ b/internal/cli/encryption/migrate_provider.go
@@ -1,0 +1,286 @@
+// migrate_provider.go — `keyorix encryption migrate-provider`.
+//
+// Re-wraps the DEK under a KEK from a different provider (ADR-041) so an existing
+// install can move between KEK providers — most importantly password/file/env → a
+// cloud KMS — without re-encrypting any data. Only the DEK's wrapping changes; the
+// operation is fast and takes no database lock. After re-wrapping it verifies the
+// target provider unwraps the DEK (round-tripping a probe value through a fresh
+// service) and keeps a timestamped backup of the previous wrapped DEK, restoring it
+// if verification fails.
+package encryption
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/encryption"
+	"github.com/spf13/cobra"
+)
+
+// newMasterPasswordEnv holds the new master passphrase when migrating TO the
+// password provider (kept distinct from KEYORIX_MASTER_PASSWORD, which is the
+// current one).
+const newMasterPasswordEnv = "KEYORIX_NEW_MASTER_PASSWORD"
+
+var (
+	mpToType           string
+	mpToKMSKeyID       string
+	mpToWrappedKeyPath string
+	mpToFilePath       string
+	mpToEnvVar         string
+	mpToSaltPath       string
+	mpConfirm          bool
+)
+
+var migrateProviderCmd = &cobra.Command{
+	Use:   "migrate-provider",
+	Short: "Migrate the KEK to a different key provider without re-encrypting data",
+	Long: `Re-wrap the data-encryption key (DEK) with a key-encryption key (KEK) from a
+different provider — for example, move an existing install from a password-derived
+KEK to a cloud KMS (ADR-041). Only the DEK's wrapping changes; secret values are
+never re-encrypted, so this is fast and does not lock the database.
+
+The CURRENT provider comes from the loaded config (storage.encryption.key_provider).
+The TARGET provider is described by the --to-* flags. After re-wrapping, the tool
+verifies the target provider unwraps the DEK before keeping the change and writes a
+timestamped backup of the previous wrapped DEK (restoring it if verification fails).
+
+When migrating TO the password provider, set ` + newMasterPasswordEnv + ` to the new
+master passphrase.
+
+Run on the server host (local storage). Requires --confirm. After it succeeds,
+update storage.encryption.key_provider in your config to the target before the next
+restart — the printed summary shows the exact block.`,
+	RunE: runMigrateProvider,
+}
+
+func init() {
+	EncryptionCmd.AddCommand(migrateProviderCmd)
+	f := migrateProviderCmd.Flags()
+	f.StringVar(&mpToType, "to-type", "", "target provider: password|file|env|aws-kms|gcp-kms|azure-kms (required)")
+	f.StringVar(&mpToKMSKeyID, "to-kms-key-id", "", "target KMS key id/ARN/resource-name/URL (kms types)")
+	f.StringVar(&mpToWrappedKeyPath, "to-wrapped-key-path", "", "where to store the KMS-wrapped KEK blob (kms types)")
+	f.StringVar(&mpToFilePath, "to-file-path", "", "path to the raw KEK material (file type)")
+	f.StringVar(&mpToEnvVar, "to-env-var", "", "env var holding the raw KEK (env type)")
+	f.StringVar(&mpToSaltPath, "to-salt-path", "", "salt path for the target password provider (default: current salt_path)")
+	f.BoolVar(&mpConfirm, "confirm", false, "required acknowledgement before re-wrapping the DEK")
+}
+
+// migrateOpts is the target-provider description, mirroring the --to-* flags so the
+// core can be unit-tested without cobra.
+type migrateOpts struct {
+	toType           string
+	toKMSKeyID       string
+	toWrappedKeyPath string
+	toFilePath       string
+	toEnvVar         string
+	toSaltPath       string
+}
+
+func runMigrateProvider(cmd *cobra.Command, args []string) error {
+	cfg, err := loadConfig()
+	if err != nil {
+		return err
+	}
+	opts := migrateOpts{
+		toType:           mpToType,
+		toKMSKeyID:       mpToKMSKeyID,
+		toWrappedKeyPath: mpToWrappedKeyPath,
+		toFilePath:       mpToFilePath,
+		toEnvVar:         mpToEnvVar,
+		toSaltPath:       mpToSaltPath,
+	}
+	return migrateProviderWithConfig(cfg, opts, mpConfirm)
+}
+
+// targetEncryptionConfig derives the target EncryptionConfig from the current one
+// plus the --to-* options. The DEK path is preserved (the same dek.key is re-wrapped
+// in place); only the key_provider (and, for password, optionally the salt path)
+// changes.
+func targetEncryptionConfig(cur *config.EncryptionConfig, opts migrateOpts) (config.EncryptionConfig, error) {
+	tgt := *cur
+	kp := config.KeyProviderConfig{Type: opts.toType}
+	switch opts.toType {
+	case "password":
+		if opts.toSaltPath != "" {
+			tgt.SaltPath = opts.toSaltPath
+		}
+	case "file":
+		if opts.toFilePath == "" {
+			return tgt, fmt.Errorf("--to-file-path is required for --to-type file")
+		}
+		kp.FilePath = opts.toFilePath
+	case "env":
+		if opts.toEnvVar == "" {
+			return tgt, fmt.Errorf("--to-env-var is required for --to-type env")
+		}
+		kp.EnvVar = opts.toEnvVar
+	case "aws-kms", "gcp-kms", "azure-kms":
+		if opts.toKMSKeyID == "" {
+			return tgt, fmt.Errorf("--to-kms-key-id is required for --to-type %s", opts.toType)
+		}
+		if opts.toWrappedKeyPath == "" {
+			return tgt, fmt.Errorf("--to-wrapped-key-path is required for --to-type %s", opts.toType)
+		}
+		if opts.toWrappedKeyPath == tgt.DEKPath {
+			return tgt, fmt.Errorf("--to-wrapped-key-path must differ from the DEK path (%s)", tgt.DEKPath)
+		}
+		kp.KMSKeyID = opts.toKMSKeyID
+		kp.WrappedKeyPath = opts.toWrappedKeyPath
+	default:
+		return tgt, fmt.Errorf("unknown --to-type %q (supported: password, file, env, aws-kms, gcp-kms, azure-kms)", opts.toType)
+	}
+	tgt.KeyProvider = kp
+	return tgt, nil
+}
+
+// targetPassphrase resolves the passphrase for the TARGET provider. Only the
+// password provider needs one (from KEYORIX_NEW_MASTER_PASSWORD); the others source
+// the KEK from key material / KMS and return "".
+func targetPassphrase(providerType string) (string, error) {
+	if providerType != "" && providerType != "password" {
+		return "", nil
+	}
+	p := os.Getenv(newMasterPasswordEnv)
+	if p == "" {
+		return "", fmt.Errorf("target provider is password — set %s to the new master passphrase", newMasterPasswordEnv)
+	}
+	return p, nil
+}
+
+// migrateProviderWithConfig is the testable core: it does no flag parsing and takes
+// an explicit confirm. The validation gates (encryption enabled, local storage,
+// target-config sanity, --confirm) all return before any key/DB work, so structural
+// tests can exercise them without key files.
+func migrateProviderWithConfig(cfg *config.Config, opts migrateOpts, confirm bool) error {
+	enc := &cfg.Storage.Encryption
+	if !enc.Enabled {
+		return fmt.Errorf("encryption is disabled in configuration")
+	}
+	if cfg.Storage.Type == "remote" {
+		return fmt.Errorf("KEK-provider migration must run on the server host. Current storage type is 'remote' — connect to the server and run this command there")
+	}
+	if opts.toType == "" {
+		return fmt.Errorf("--to-type is required (password|file|env|aws-kms|gcp-kms|azure-kms)")
+	}
+	tgtEnc, err := targetEncryptionConfig(enc, opts)
+	if err != nil {
+		return err
+	}
+	if !confirm {
+		return fmt.Errorf("this re-wraps the DEK and changes the KEK provider. Re-run with --confirm")
+	}
+
+	baseDir, _ := os.Getwd()
+
+	oldPass, err := masterPassphrase(cfg)
+	if err != nil {
+		return err
+	}
+	newPass, err := targetPassphrase(tgtEnc.KeyProvider.Type)
+	if err != nil {
+		return err
+	}
+
+	// 1. Open with the CURRENT provider — unwraps the DEK into memory.
+	oldSvc := encryption.NewService(enc, baseDir)
+	if err := oldSvc.Initialize(oldPass); err != nil {
+		return fmt.Errorf("failed to open encryption with the current provider: %w", err)
+	}
+	defer oldSvc.Shutdown()
+
+	// 2. Encrypt a probe value under the current DEK — used after re-wrapping to
+	//    verify the target provider yields the *same* DEK (data still decryptable).
+	probe := []byte("keyorix-kek-provider-migration-probe")
+	probeCT, _, err := oldSvc.EncryptSecret(probe)
+	if err != nil {
+		return fmt.Errorf("failed to encrypt verification probe: %w", err)
+	}
+
+	// 3. Back up the current wrapped DEK before overwriting it.
+	backupRel := fmt.Sprintf("%s.migrate-backup.%d", enc.DEKPath, time.Now().Unix())
+	if err := copyFile(filepath.Join(baseDir, enc.DEKPath), filepath.Join(baseDir, backupRel)); err != nil {
+		return fmt.Errorf("failed to back up current wrapped DEK: %w", err)
+	}
+
+	// 4. Build the TARGET provider and re-wrap the DEK under it.
+	newProvider, err := encryption.NewKeyProviderFromConfig(&tgtEnc, baseDir, newPass)
+	if err != nil {
+		_ = os.Remove(filepath.Join(baseDir, backupRel))
+		return fmt.Errorf("failed to build target provider: %w", err)
+	}
+	fmt.Printf("🔄 Re-wrapping DEK: %s → %s provider...\n", providerLabel(enc.KeyProvider.Type), opts.toType)
+	if err := oldSvc.RewrapDEKWithProvider(newProvider); err != nil {
+		// RewrapDEK leaves the active DEK untouched on failure — drop the backup.
+		_ = os.Remove(filepath.Join(baseDir, backupRel))
+		return fmt.Errorf("re-wrap failed — no changes made to the active DEK: %w", err)
+	}
+
+	// 5. Verify a fresh service on the TARGET config unwraps the DEK and decrypts
+	//    the probe. On any mismatch, restore the previous wrapped DEK and abort.
+	verifySvc := encryption.NewService(&tgtEnc, baseDir)
+	if err := verifySvc.Initialize(newPass); err != nil {
+		restoreBackup(baseDir, backupRel, enc.DEKPath)
+		return fmt.Errorf("verification failed (target provider could not open) — restored previous DEK: %w", err)
+	}
+	defer verifySvc.Shutdown()
+	got, err := verifySvc.DecryptSecret(probeCT)
+	if err != nil || !bytes.Equal(got, probe) {
+		restoreBackup(baseDir, backupRel, enc.DEKPath)
+		return fmt.Errorf("verification failed (probe did not round-trip under the target provider) — restored previous DEK")
+	}
+
+	printMigrateSummary(tgtEnc, backupRel)
+	return nil
+}
+
+// copyFile copies src to dst with 0600 permissions.
+func copyFile(src, dst string) error {
+	data, err := os.ReadFile(src) // #nosec G304 -- operator-configured key path under baseDir
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(dst, data, 0600)
+}
+
+// restoreBackup copies the backup back over the active DEK path. Best-effort: logs
+// to stderr if the restore itself fails so the operator can recover manually.
+func restoreBackup(baseDir, backupRel, dekPath string) {
+	if err := copyFile(filepath.Join(baseDir, backupRel), filepath.Join(baseDir, dekPath)); err != nil {
+		fmt.Fprintf(os.Stderr, "❌ CRITICAL: failed to restore DEK backup %s → %s: %v\n  Restore it manually before restarting.\n", backupRel, dekPath, err)
+	}
+}
+
+func providerLabel(t string) string {
+	if t == "" {
+		return "password"
+	}
+	return t
+}
+
+func printMigrateSummary(tgt config.EncryptionConfig, backupRel string) {
+	kp := tgt.KeyProvider
+	fmt.Println("✅ DEK re-wrapped and verified under the new provider.")
+	fmt.Printf("🗄️  Previous wrapped DEK backed up at %s (remove once confident).\n", backupRel)
+	fmt.Println()
+	fmt.Println("⚠️  Update storage.encryption.key_provider in your config to match BEFORE the next restart:")
+	fmt.Println()
+	fmt.Println("    key_provider:")
+	fmt.Printf("      type: %s\n", kp.Type)
+	switch kp.Type {
+	case "file":
+		fmt.Printf("      file_path: %s\n", kp.FilePath)
+	case "env":
+		fmt.Printf("      env_var: %s\n", kp.EnvVar)
+	case "aws-kms", "gcp-kms", "azure-kms":
+		fmt.Printf("      kms_key_id: %s\n", kp.KMSKeyID)
+		fmt.Printf("      wrapped_key_path: %s\n", kp.WrappedKeyPath)
+	case "password":
+		fmt.Printf("      # salt_path: %s (set storage.encryption.salt_path)\n", tgt.SaltPath)
+		fmt.Printf("      # the master passphrase is now %s — set KEYORIX_MASTER_PASSWORD to it\n", newMasterPasswordEnv)
+	}
+}

--- a/internal/cli/encryption/migrate_provider_test.go
+++ b/internal/cli/encryption/migrate_provider_test.go
@@ -1,0 +1,175 @@
+package encryption
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"io"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/encryption"
+)
+
+func enabledLocalCfg() *config.Config {
+	return &config.Config{
+		Storage: config.StorageConfig{
+			Type: "local",
+			Encryption: config.EncryptionConfig{
+				Enabled: true,
+				DEKPath: "keys/dek.key",
+			},
+		},
+	}
+}
+
+func TestMigrateProvider_RequiresConfirm(t *testing.T) {
+	err := migrateProviderWithConfig(enabledLocalCfg(), migrateOpts{toType: "env", toEnvVar: "KEK"}, false)
+	if err == nil || !strings.Contains(err.Error(), "--confirm") {
+		t.Fatalf("expected --confirm gate, got: %v", err)
+	}
+}
+
+func TestMigrateProvider_RejectsRemoteStorage(t *testing.T) {
+	cfg := enabledLocalCfg()
+	cfg.Storage.Type = "remote"
+	err := migrateProviderWithConfig(cfg, migrateOpts{toType: "env", toEnvVar: "KEK"}, true)
+	if err == nil || !strings.Contains(err.Error(), "server host") {
+		t.Fatalf("expected remote-storage rejection, got: %v", err)
+	}
+}
+
+func TestMigrateProvider_RejectsDisabledEncryption(t *testing.T) {
+	cfg := enabledLocalCfg()
+	cfg.Storage.Encryption.Enabled = false
+	err := migrateProviderWithConfig(cfg, migrateOpts{toType: "env", toEnvVar: "KEK"}, true)
+	if err == nil || !strings.Contains(err.Error(), "disabled") {
+		t.Fatalf("expected disabled-encryption rejection, got: %v", err)
+	}
+}
+
+func TestMigrateProvider_RequiresToType(t *testing.T) {
+	err := migrateProviderWithConfig(enabledLocalCfg(), migrateOpts{}, true)
+	if err == nil || !strings.Contains(err.Error(), "--to-type") {
+		t.Fatalf("expected --to-type requirement, got: %v", err)
+	}
+}
+
+// TestMigrateProvider_EndToEnd_PasswordToEnv drives the full CLI core: it
+// bootstraps a password-derived install, migrates the KEK to the env provider, and
+// confirms the env provider unwraps the same DEK and a backup was kept — all
+// without a database (encrypt/decrypt are key-only operations).
+func TestMigrateProvider_EndToEnd_PasswordToEnv(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir) // migrateProviderWithConfig resolves key paths under cwd
+
+	t.Setenv("KEYORIX_MASTER_PASSWORD", "Sup3r-Secret-Passphrase!")
+	raw := make([]byte, 32)
+	if _, err := io.ReadFull(rand.Reader, raw); err != nil {
+		t.Fatalf("gen kek: %v", err)
+	}
+	t.Setenv("KEYORIX_TARGET_KEK", hex.EncodeToString(raw))
+
+	cfg := enabledLocalCfg()
+	cfg.Storage.Encryption.DEKPath = "dek.key"
+	cfg.Storage.Encryption.SaltPath = "kek.salt"
+
+	opts := migrateOpts{toType: "env", toEnvVar: "KEYORIX_TARGET_KEK"}
+	if err := migrateProviderWithConfig(cfg, opts, true); err != nil {
+		t.Fatalf("migrate password → env: %v", err)
+	}
+
+	// A fresh service on the TARGET (env) provider must open the re-wrapped DEK and
+	// round-trip a secret.
+	tgt := cfg.Storage.Encryption
+	tgt.KeyProvider = config.KeyProviderConfig{Type: "env", EnvVar: "KEYORIX_TARGET_KEK"}
+	svc := encryption.NewService(&tgt, dir)
+	if err := svc.Initialize(""); err != nil {
+		t.Fatalf("open with env provider after migration: %v", err)
+	}
+	defer svc.Shutdown()
+	ct, _, err := svc.EncryptSecret([]byte("hello"))
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+	pt, err := svc.DecryptSecret(ct)
+	if err != nil || string(pt) != "hello" {
+		t.Fatalf("round-trip under env provider failed: pt=%q err=%v", pt, err)
+	}
+
+	// The previous wrapped DEK was backed up.
+	matches, _ := filepath.Glob(filepath.Join(dir, "dek.key.migrate-backup.*"))
+	if len(matches) == 0 {
+		t.Fatalf("expected a dek.key.migrate-backup.* file")
+	}
+}
+
+func TestTargetEncryptionConfig(t *testing.T) {
+	cur := &config.EncryptionConfig{DEKPath: "keys/dek.key", SaltPath: "keys/kek.salt"}
+
+	t.Run("kms requires key id", func(t *testing.T) {
+		_, err := targetEncryptionConfig(cur, migrateOpts{toType: "aws-kms", toWrappedKeyPath: "keys/kek.kms"})
+		if err == nil || !strings.Contains(err.Error(), "--to-kms-key-id") {
+			t.Fatalf("expected kms key-id requirement, got: %v", err)
+		}
+	})
+
+	t.Run("kms requires wrapped key path", func(t *testing.T) {
+		_, err := targetEncryptionConfig(cur, migrateOpts{toType: "gcp-kms", toKMSKeyID: "k"})
+		if err == nil || !strings.Contains(err.Error(), "--to-wrapped-key-path") {
+			t.Fatalf("expected wrapped-key-path requirement, got: %v", err)
+		}
+	})
+
+	t.Run("kms wrapped path must differ from dek", func(t *testing.T) {
+		_, err := targetEncryptionConfig(cur, migrateOpts{toType: "azure-kms", toKMSKeyID: "k", toWrappedKeyPath: "keys/dek.key"})
+		if err == nil || !strings.Contains(err.Error(), "must differ") {
+			t.Fatalf("expected DEK-path collision rejection, got: %v", err)
+		}
+	})
+
+	t.Run("kms ok preserves dek path", func(t *testing.T) {
+		tgt, err := targetEncryptionConfig(cur, migrateOpts{toType: "azure-kms", toKMSKeyID: "https://v.vault.azure.net/keys/k", toWrappedKeyPath: "keys/kek.kms"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if tgt.DEKPath != cur.DEKPath {
+			t.Fatalf("DEK path should be preserved, got %q", tgt.DEKPath)
+		}
+		if tgt.KeyProvider.Type != "azure-kms" || tgt.KeyProvider.WrappedKeyPath != "keys/kek.kms" {
+			t.Fatalf("unexpected target provider: %+v", tgt.KeyProvider)
+		}
+	})
+
+	t.Run("file requires path", func(t *testing.T) {
+		_, err := targetEncryptionConfig(cur, migrateOpts{toType: "file"})
+		if err == nil || !strings.Contains(err.Error(), "--to-file-path") {
+			t.Fatalf("expected file-path requirement, got: %v", err)
+		}
+	})
+
+	t.Run("env requires var", func(t *testing.T) {
+		_, err := targetEncryptionConfig(cur, migrateOpts{toType: "env"})
+		if err == nil || !strings.Contains(err.Error(), "--to-env-var") {
+			t.Fatalf("expected env-var requirement, got: %v", err)
+		}
+	})
+
+	t.Run("password overrides salt path", func(t *testing.T) {
+		tgt, err := targetEncryptionConfig(cur, migrateOpts{toType: "password", toSaltPath: "keys/new.salt"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if tgt.SaltPath != "keys/new.salt" {
+			t.Fatalf("expected salt path override, got %q", tgt.SaltPath)
+		}
+	})
+
+	t.Run("unknown type", func(t *testing.T) {
+		_, err := targetEncryptionConfig(cur, migrateOpts{toType: "bogus"})
+		if err == nil || !strings.Contains(err.Error(), "unknown --to-type") {
+			t.Fatalf("expected unknown-type error, got: %v", err)
+		}
+	})
+}

--- a/internal/encryption/keymanager_rewrap.go
+++ b/internal/encryption/keymanager_rewrap.go
@@ -1,0 +1,65 @@
+// keymanager_rewrap.go — KEK-provider migration: re-wrap the DEK under a new KEK
+// without re-encrypting any data (ADR-041).
+//
+// Unlike RotateDEKWithSweep (which generates a NEW DEK and re-encrypts every row),
+// RewrapDEK keeps the SAME DEK and only changes the key that wraps it on disk. The
+// data path is untouched, so this is fast and holds no database lock — it is how an
+// existing install moves between KEK providers (e.g. password → cloud KMS).
+package encryption
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/keyorixhq/keyorix/internal/crypto"
+	"github.com/keyorixhq/keyorix/internal/securefiles"
+)
+
+// RewrapDEK re-wraps the in-memory DEK with a KEK sourced from newProvider and
+// atomically replaces the on-disk wrapped DEK (write-pending-then-rename). The DEK
+// value is unchanged, so all existing ciphertext stays valid — only the wrapping
+// key changes. The manager must already be Initialized (DEK in memory) with the
+// CURRENT provider.
+//
+// newProvider.KEK() persists the new provider's own key material as a side effect
+// (a fresh salt for password, a KMS-wrapped KEK blob for the kms providers); this
+// happens before the DEK file is touched, so a failure here leaves the active DEK
+// untouched and the old provider still working.
+func (km *KeyManager) RewrapDEK(newProvider crypto.KeyProvider) error {
+	km.mu.Lock()
+	defer km.mu.Unlock()
+
+	if km.currentDEK == nil {
+		return fmt.Errorf("key manager not initialized — cannot re-wrap DEK")
+	}
+	if newProvider == nil {
+		return fmt.Errorf("re-wrap DEK: new key provider must not be nil")
+	}
+
+	newKEK, err := newProvider.KEK()
+	if err != nil {
+		return fmt.Errorf("re-wrap DEK: derive KEK from %s provider: %w", newProvider.Name(), err)
+	}
+	defer wipeBytes(newKEK)
+	if len(newKEK) != crypto.KEKSize {
+		return fmt.Errorf("re-wrap DEK: %s provider returned a %d-byte KEK, expected %d", newProvider.Name(), len(newKEK), crypto.KEKSize)
+	}
+
+	wrapped, err := wrapKey(km.currentDEK, newKEK)
+	if err != nil {
+		return fmt.Errorf("re-wrap DEK: wrap DEK with new KEK: %w", err)
+	}
+
+	pendingDEKPath := km.dekPath + ".pending"
+	if err := securefiles.SecureWriteFile(km.baseDir, pendingDEKPath, wrapped, 0600); err != nil {
+		return fmt.Errorf("re-wrap DEK: write pending DEK: %w", err)
+	}
+	pendingPath := filepath.Join(km.baseDir, pendingDEKPath)
+	activePath := filepath.Join(km.baseDir, km.dekPath)
+	if err := os.Rename(pendingPath, activePath); err != nil {
+		_ = os.Remove(pendingPath)
+		return fmt.Errorf("re-wrap DEK: promote pending DEK to active: %w", err)
+	}
+	return nil
+}

--- a/internal/encryption/keymanager_rewrap_test.go
+++ b/internal/encryption/keymanager_rewrap_test.go
@@ -1,0 +1,107 @@
+package encryption
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/hex"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/crypto"
+)
+
+// writeHexKEK writes a fresh random 32-byte KEK to path as hex (the FileKeyProvider
+// accepts hex) and returns the path.
+func writeHexKEK(t *testing.T, path string) {
+	t.Helper()
+	raw := make([]byte, crypto.KEKSize)
+	if _, err := io.ReadFull(rand.Reader, raw); err != nil {
+		t.Fatalf("gen kek: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(hex.EncodeToString(raw)), 0600); err != nil {
+		t.Fatalf("write kek: %v", err)
+	}
+}
+
+func TestRewrapDEK_MigratesKEKWithoutChangingDEK(t *testing.T) {
+	dir := t.TempDir()
+	oldKEK := filepath.Join(dir, "old.kek")
+	newKEK := filepath.Join(dir, "new.kek")
+	writeHexKEK(t, oldKEK)
+	writeHexKEK(t, newKEK)
+
+	// Initialize under the OLD (file) provider — generates and wraps a DEK.
+	km := NewKeyManager(dir, "dek.key", "kek.salt")
+	km.SetKeyProvider(crypto.NewFileKeyProvider(oldKEK))
+	if err := km.Initialize(""); err != nil {
+		t.Fatalf("initialize old: %v", err)
+	}
+	dekBefore := km.GetDEK()
+
+	// Re-wrap under the NEW provider.
+	if err := km.RewrapDEK(crypto.NewFileKeyProvider(newKEK)); err != nil {
+		t.Fatalf("rewrap: %v", err)
+	}
+	if dekAfter := km.GetDEK(); !bytes.Equal(dekBefore, dekAfter) {
+		t.Fatalf("DEK changed across re-wrap: before=%x after=%x", dekBefore, dekAfter)
+	}
+
+	// A fresh manager using the NEW provider must unwrap the SAME DEK from disk.
+	kmNew := NewKeyManager(dir, "dek.key", "kek.salt")
+	kmNew.SetKeyProvider(crypto.NewFileKeyProvider(newKEK))
+	if err := kmNew.Initialize(""); err != nil {
+		t.Fatalf("initialize new: %v", err)
+	}
+	if !bytes.Equal(kmNew.GetDEK(), dekBefore) {
+		t.Fatalf("new provider unwrapped a different DEK")
+	}
+
+	// A fresh manager using the OLD provider must NO LONGER unwrap the DEK.
+	kmOld := NewKeyManager(dir, "dek.key", "kek.salt")
+	kmOld.SetKeyProvider(crypto.NewFileKeyProvider(oldKEK))
+	if err := kmOld.Initialize(""); err == nil {
+		t.Fatalf("old provider should fail to unwrap after migration, but succeeded")
+	}
+}
+
+func TestRewrapDEK_RequiresInitializedManager(t *testing.T) {
+	dir := t.TempDir()
+	newKEK := filepath.Join(dir, "new.kek")
+	writeHexKEK(t, newKEK)
+
+	km := NewKeyManager(dir, "dek.key", "kek.salt") // not Initialized — no DEK in memory
+	if err := km.RewrapDEK(crypto.NewFileKeyProvider(newKEK)); err == nil {
+		t.Fatalf("expected error re-wrapping an uninitialized manager")
+	}
+}
+
+func TestRewrapDEK_FailingProviderLeavesActiveDEKIntact(t *testing.T) {
+	dir := t.TempDir()
+	oldKEK := filepath.Join(dir, "old.kek")
+	writeHexKEK(t, oldKEK)
+
+	km := NewKeyManager(dir, "dek.key", "kek.salt")
+	km.SetKeyProvider(crypto.NewFileKeyProvider(oldKEK))
+	if err := km.Initialize(""); err != nil {
+		t.Fatalf("initialize: %v", err)
+	}
+	wrappedBefore, err := os.ReadFile(filepath.Join(dir, "dek.key"))
+	if err != nil {
+		t.Fatalf("read dek: %v", err)
+	}
+
+	// A file provider pointing at a missing path fails in KEK() — before any write.
+	bad := crypto.NewFileKeyProvider(filepath.Join(dir, "does-not-exist.kek"))
+	if err := km.RewrapDEK(bad); err == nil {
+		t.Fatalf("expected re-wrap to fail with a missing-key provider")
+	}
+	wrappedAfter, err := os.ReadFile(filepath.Join(dir, "dek.key"))
+	if err != nil {
+		t.Fatalf("read dek after: %v", err)
+	}
+	if !bytes.Equal(wrappedBefore, wrappedAfter) {
+		t.Fatalf("active wrapped DEK changed after a failed re-wrap")
+	}
+}

--- a/internal/encryption/service.go
+++ b/internal/encryption/service.go
@@ -72,14 +72,23 @@ func (s *Service) Initialize(passphrase string) error {
 	return nil
 }
 
-// buildKeyProvider selects the KEK source from config (ADR-038). The default and
-// the absent/zero value is the passphrase provider, byte-identical to the
-// historical derivation; file/env supply externally-managed raw key material.
+// buildKeyProvider selects the KEK source for this service from its own config.
 func (s *Service) buildKeyProvider(passphrase string) (crypto.KeyProvider, error) {
-	kp := s.config.KeyProvider
+	return NewKeyProviderFromConfig(s.config, s.keyManager.baseDir, passphrase)
+}
+
+// NewKeyProviderFromConfig builds the KEK source described by an EncryptionConfig
+// (ADR-038/ADR-041). The default and the absent/zero value is the passphrase
+// provider, byte-identical to the historical derivation; file/env supply
+// externally-managed raw key material; the *-kms providers envelope-wrap the KEK
+// with a cloud KMS key. baseDir resolves provider-relative paths (salt /
+// wrapped_key_path). Exported so the KEK-provider migration tool can build a
+// *target* provider from a different config than the running service's.
+func NewKeyProviderFromConfig(cfg *config.EncryptionConfig, baseDir, passphrase string) (crypto.KeyProvider, error) {
+	kp := cfg.KeyProvider
 	switch kp.Type {
 	case "", "password":
-		return crypto.NewPasswordKeyProvider(passphrase, s.keyManager.baseDir, s.config.SaltPath), nil
+		return crypto.NewPasswordKeyProvider(passphrase, baseDir, cfg.SaltPath), nil
 	case "file":
 		return crypto.NewFileKeyProvider(kp.FilePath), nil
 	case "env":
@@ -89,19 +98,19 @@ func (s *Service) buildKeyProvider(passphrase string) (crypto.KeyProvider, error
 		if err != nil {
 			return nil, err
 		}
-		return crypto.NewKMSKeyProvider(kmsClient, "aws-kms", s.keyManager.baseDir, kp.WrappedKeyPath), nil
+		return crypto.NewKMSKeyProvider(kmsClient, "aws-kms", baseDir, kp.WrappedKeyPath), nil
 	case "gcp-kms":
 		kmsClient, err := gcpkms.New(context.Background(), kp.KMSKeyID)
 		if err != nil {
 			return nil, err
 		}
-		return crypto.NewKMSKeyProvider(kmsClient, "gcp-kms", s.keyManager.baseDir, kp.WrappedKeyPath), nil
+		return crypto.NewKMSKeyProvider(kmsClient, "gcp-kms", baseDir, kp.WrappedKeyPath), nil
 	case "azure-kms":
 		kmsClient, err := azurekms.New(context.Background(), kp.KMSKeyID)
 		if err != nil {
 			return nil, err
 		}
-		return crypto.NewKMSKeyProvider(kmsClient, "azure-kms", s.keyManager.baseDir, kp.WrappedKeyPath), nil
+		return crypto.NewKMSKeyProvider(kmsClient, "azure-kms", baseDir, kp.WrappedKeyPath), nil
 	default:
 		return nil, fmt.Errorf("unknown encryption key_provider type %q (supported: password, file, env, aws-kms, gcp-kms, azure-kms)", kp.Type)
 	}

--- a/internal/encryption/service_rotation.go
+++ b/internal/encryption/service_rotation.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/keyorixhq/keyorix/internal/crypto"
 	"gorm.io/gorm"
 )
 
@@ -86,6 +87,22 @@ func (s *Service) RotateDEK(passphrase string) error {
 	}
 	s.encryptionService = encSvc
 	return nil
+}
+
+// RewrapDEKWithProvider re-wraps the in-memory DEK with a KEK from newProvider and
+// atomically replaces the on-disk wrapped DEK (ADR-041 KEK-provider migration). The
+// DEK value is unchanged, so every existing ciphertext stays valid — only the
+// wrapping key changes; no data is re-encrypted and no DB lock is taken. The
+// service must already be Initialized with the CURRENT provider. The caller should
+// then verify the new provider unwraps the DEK before discarding the previous
+// wrapped-DEK backup.
+func (s *Service) RewrapDEKWithProvider(newProvider crypto.KeyProvider) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.initialized {
+		return fmt.Errorf("encryption service not initialized")
+	}
+	return s.keyManager.RewrapDEK(newProvider)
 }
 
 // ValidateKeyFiles validates encryption key files exist with correct permissions.


### PR DESCRIPTION
Switching KEK providers was a manual DEK re-encryption. Adds
`keyorix encryption migrate-provider --to-type … --confirm`, which **re-wraps the
DEK under a KEK from the target provider without re-encrypting any data** (fast, no
DB lock) — e.g. move an existing install from a password-derived KEK to a cloud
KMS. ADR-041.

> Stacked on #123 (Azure backend) — this PR's base is `feat/azure-kms-key-provider`
> and will retarget to `main` once #123 merges. Review only the
> `migrate-provider` / re-wrap commit here.

## What
- **`KeyManager.RewrapDEK`** — derive the new KEK, re-wrap the in-memory DEK,
  atomically replace `dek.key` (write-pending → rename). DEK value unchanged, so all
  ciphertext stays valid. Target provider key material (salt / KMS-wrapped blob) is
  persisted before the DEK file is touched, so a failure leaves the active DEK
  intact.
- **`Service.RewrapDEKWithProvider`** — guarded wrapper.
- **`NewKeyProviderFromConfig`** — extracted the provider builder from the private
  `Service` method so a *target* provider can be built from a different config (the
  method now delegates; no behavior change).
- **CLI `migrate-provider`** — open with current provider → encrypt a probe → back
  up the wrapped DEK → re-wrap under the target → verify a fresh service round-trips
  the probe → on mismatch restore the backup and abort. Prints the exact
  `key_provider` block to apply before restart. Supports all six provider types;
  `--to-type password` reads `KEYORIX_NEW_MASTER_PASSWORD` and doubles as a
  master-passphrase rotation.
- ADR-041 migration addendum, `CONFIGURATION.md` switch-providers note.

## Verification
Unit tests (DEK preserved across re-wrap; new provider unwraps it; old no longer
does; failing provider leaves DEK intact), CLI gate + target-config tests, and a
password→env end-to-end round-trip. `make build`, full suite, `go vet`,
`golangci-lint` (0 issues), `gofmt`, `gitleaks` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
