### PR TITLE
release: prep v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,29 @@
 All notable changes to Keyorix are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## v0.11.0 — 2026-06-12
+
+KMS follow-ups: a third cloud backend for the wrapping key, plus zero-downtime
+provider migration.
+
+### Added
+- **Azure Key Vault KEK provider** (`type: azure-kms`) — the third KMS backend for
+  the KEK wrapping key, after AWS and GCP, behind the same `KMSClient` interface. It
+  envelopes the KEK with the vault key's `wrapKey`/`unwrapKey` operations
+  (RSA-OAEP-256); credentials come from `DefaultAzureCredential` (env / managed
+  identity / workload identity) and the key is inherently pinned by name.
+  ([#123], ADR-041)
+- **`keyorix encryption migrate-provider`** — move an existing install between KEK
+  providers (e.g. password → a cloud KMS) by **re-wrapping the DEK under the target
+  provider's KEK without re-encrypting any data** — fast and with no database lock,
+  unlike a DEK rotation. It backs up the previous wrapped DEK, verifies the target
+  provider round-trips a probe before keeping the change, and prints the config block
+  to apply. Migrating `--to-type password` also rotates the master passphrase.
+  ([#125], ADR-041)
+
+[#123]: https://github.com/keyorixhq/keyorix/pull/123
+[#125]: https://github.com/keyorixhq/keyorix/pull/125
+
 ## v0.10.0 — 2026-06-12
 
 The bring-your-own-KMS release.

--- a/deploy/helm/keyorix/Chart.yaml
+++ b/deploy/helm/keyorix/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix
 description: Self-hosted Keyorix secrets manager (API server + web UI + PostgreSQL)
 type: application
 # Chart version — bump on chart changes.
-version: 0.10.0
+version: 0.11.0
 # The Keyorix app version this chart deploys by default (the image tag).
-appVersion: "0.10.0"
+appVersion: "0.11.0"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix


### PR DESCRIPTION
Prep v0.11.0: CHANGELOG entry + Helm chart bump to 0.11.0.

Ships **Azure Key Vault KEK provider** (#123) and **`keyorix encryption migrate-provider`** (#125), both ADR-041 — KMS follow-ups (third cloud backend + zero-downtime provider migration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)