### PR TITLE
release: prep v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to Keyorix are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## v0.12.0 — 2026-06-12
+
+### Added
+- **MongoDB dynamic-secrets engine** (`backend_type: mongodb`) — the third dynamic-
+  secrets target after PostgreSQL and MySQL, behind the same `CredentialEngine`
+  interface. It mints `kx_dyn_<random>` users in the target's `admin` database
+  (`createUser`) and drops them on revoke (`dropUser`, idempotent). The admin DSN is
+  a MongoDB connection URI and the creation template is a JSON role spec
+  (`{"roles": [{"role": "readWrite", "db": "app"}]}`); the username/password are
+  passed as typed BSON values, so credential injection is structurally impossible.
+  Like MySQL, MongoDB users carry no native expiry, so enable the auto-revoke
+  sweeper for MongoDB targets. ([#127], ADR-035)
+
+[#127]: https://github.com/keyorixhq/keyorix/pull/127
+
 ## v0.11.0 — 2026-06-12
 
 KMS follow-ups: a third cloud backend for the wrapping key, plus zero-downtime

--- a/deploy/helm/keyorix/Chart.yaml
+++ b/deploy/helm/keyorix/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix
 description: Self-hosted Keyorix secrets manager (API server + web UI + PostgreSQL)
 type: application
 # Chart version — bump on chart changes.
-version: 0.11.0
+version: 0.12.0
 # The Keyorix app version this chart deploys by default (the image tag).
-appVersion: "0.11.0"
+appVersion: "0.12.0"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix


### PR DESCRIPTION
Prep v0.12.0: CHANGELOG entry + Helm chart bump to 0.12.0.

Ships the **MongoDB dynamic-secrets engine** (#127, ADR-035) — the third dynamic-secrets target after PostgreSQL and MySQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)