### PR TITLE
feat(auth): per-token least-privilege scoping for PATs (ADR-042)

### DIFF
--- a/docs/adr-027-personal-access-tokens.md
+++ b/docs/adr-027-personal-access-tokens.md
@@ -79,9 +79,12 @@ throttling applies to session `last_seen_at`.
   shared result shape — low complexity.
 - The full-permission-inheritance limitation must be communicated clearly until scoping
   lands; a leaked PAT is as powerful as the owner's session.
+  **Update (ADR-042):** optional per-token least-privilege scoping has now landed — a
+  PAT may carry a permission allowlist and/or a single-project confinement that narrows
+  it below its owner. Full inheritance remains the default for back-compat.
 
 ## What this is not
 
 - Not service accounts (those remain admin-managed, see `service_accounts_handler.go`).
-- Not scoped/least-privilege tokens (deferred).
+- ~~Not scoped/least-privilege tokens (deferred).~~ **Scoped tokens shipped in ADR-042.**
 - Not OAuth/OIDC tokens (separate M2 work).

--- a/docs/adr-042-pat-permission-scoping.md
+++ b/docs/adr-042-pat-permission-scoping.md
@@ -1,0 +1,107 @@
+# ADR-042: Personal access token permission scoping (least privilege)
+
+**Status:** Accepted
+**Date:** 2026-06-12
+
+## Context
+
+A personal access token (PAT, ADR-027) authenticates an API request **as its
+owning user**, inheriting that user's *full* permission set — there is no way to
+mint a token that does less than its owner. In practice a PAT is most often handed
+to automation: a CI job that only needs to **read** one project's secrets, a
+backup script, a third-party integration. Giving each of those the owner's entire
+authority — frequently a project- or system-admin's authority — is a textbook
+least-privilege violation. If such a token leaks, the blast radius is the whole
+account, not the one capability the job actually used.
+
+Least privilege for non-interactive credentials is a core control in the
+certification frames Keyorix targets — NIS2 Art. 21(2) (access control,
+least-functionality), ISO 27001:2022 A.5.15 / A.5.18 / A.8.2 (access rights and
+privileged access), ENS `op.acc.4` (least privilege). Machine identities (ADR-030)
+already get bounded, explicitly-granted permissions with **no admin bypass**; PATs
+were the remaining over-privileged credential.
+
+## Decision
+
+A PAT may carry an optional **least-privilege restriction** fixed at creation: a
+**permission allowlist** and/or a **single-project confinement**. The restriction
+is a **filter that only ever narrows** the token below its owner — it can never
+grant a permission the owner does not hold, because the owner's live RBAC still
+runs. An existing token, or one created without a restriction, is unaffected
+(full inheritance — the back-compatible default).
+
+- **Model** (`PersonalAccessToken`, additive columns, ADR-042):
+  - `Scopes` — JSON-encoded `[]string` permission allowlist. Empty/null = inherit
+    the owner's full set. An entry is an exact permission (`secrets.read`), the
+    catch-all `*`, or a prefix wildcard (`secrets.*`).
+  - `ProjectScope uint` — when non-zero, the token may act **only** within that
+    project's scope; `0` = any scope the owner can reach (mirrors the `0 = global`
+    sentinel used throughout RBAC). A project-scoped token is therefore denied at
+    global/system scope — it is not a system-wide credential.
+  - Defaults leave existing rows unrestricted. On an existing DB the columns are
+    added via the GORM `Migrator` (never a full `AutoMigrate` on the live table —
+    the same pgx prepared-statement hazard the invitations/notifications blocks
+    avoid).
+
+- **Enforcement is at the single authorization chokepoint, not the HTTP layer.**
+  The restriction is carried on the request `context.Context`
+  (`core.WithPATRestriction`, tagged in the auth middleware's
+  `buildRequestContext` for PAT requests only) and read back inside
+  **`core.Authorize` and `core.AuthorizePrincipal`** — the two functions every
+  authorization decision funnels through (HTTP middleware `RequireScopedPermission`
+  / `RequirePermission`, the in-handler authorizers for secret-create /
+  dynamic-secrets / rotation-create, and gRPC). The filter is applied **first,
+  before role resolution and before the admin bypass**, so it bounds even a
+  global admin's own token. Because it sits at the chokepoint rather than at N
+  call sites, every present and future authorization path is constrained
+  automatically — there is no route to forget to wire (the failure mode ADR-037's
+  pre-merge review caught for per-project MFA).
+
+- **It is a filter, never an escalation.** `Authorize` still resolves the owner's
+  live roles after the restriction passes. A token listing `secrets.write` whose
+  owner has since lost that permission grants nothing. This is why creation does
+  **not** need to validate that the requested scopes are a subset of the owner's
+  permissions: the runtime intersection makes over-broad scopes harmless, and the
+  owner's permission set is scope-dependent and changes over time anyway.
+
+- **API.** `POST /api/v1/auth/tokens` accepts optional `scopes` (`[]string`) and
+  `project_scope` (`uint`). The list/create DTO surfaces both read-only — a
+  token's scope is immutable after creation (to change it, revoke and re-mint).
+  The raw token is still returned exactly once.
+
+## Consequences
+
+- A user — including an admin — can mint a token that is strictly weaker than
+  themselves: a CI read-only token for one project, a rotation-only token, etc.
+  Leak blast radius shrinks to the granted capability.
+- Enforcement is uniform and centrally provable: the four-case core test plus the
+  real-RBAC end-to-end test show a `secrets.read`-scoped token on a **global
+  admin** is denied `secrets.write`, and a project-3 token is denied in project 4
+  and at global scope — surviving the real admin bypass.
+- No behavioural change for existing tokens or unrestricted new ones.
+
+## Alternatives considered
+
+- **Enforce in HTTP middleware (like ADR-037 per-project MFA).** Rejected: PAT
+  authority must hold for *every* authorization path including gRPC and in-handler
+  authorizers; the ctx-at-the-chokepoint approach covers them all without
+  per-site wiring. (Per-project MFA had to be at the HTTP layer because it keys on
+  request interactivity, which `Authorize` cannot see; a PAT restriction is pure
+  authorization data and belongs at the authorization function.)
+- **Validate scopes ⊆ owner at creation.** Rejected as unnecessary: the runtime
+  intersection already prevents escalation, and owner permissions are
+  scope-dependent and mutable, so a creation-time check would be both
+  redundant and frequently wrong later.
+- **Separate scoped-credential type.** Rejected: machine identities (ADR-030)
+  already serve the "first-class non-human principal" need; this is the lighter
+  "narrow a token I already trust myself to hold" case.
+
+## Deferred
+
+- **Per-environment confinement** (a token bound to `prod` only) — `Scope` already
+  carries an environment axis; the model/filter can extend to it when needed.
+- **Frontend (My Account) UI** to pick scopes/project when creating a token — the
+  API and storage are complete; the keyorix-web token-creation dialog is the
+  remaining surface.
+- **Scope presets** (e.g. a "read-only" macro expanding to the read permissions).
+- **CLI `--scope` / `--project` flags** on token creation.

--- a/internal/core/authz.go
+++ b/internal/core/authz.go
@@ -11,9 +11,72 @@ package core
 
 import (
 	"context"
+	"strings"
 
 	"github.com/keyorixhq/keyorix/internal/core/storage"
 )
+
+// PATRestriction bounds what a request authenticated by a personal access token
+// (ADR-042) may do, independent of — and intersected with — the owning user's own
+// permissions. It is a least-privilege FILTER: it can only narrow a token below
+// its owner, never grant the owner anything extra. The owner's live role
+// resolution still runs after this check, so a restriction listing a permission
+// the owner has since lost grants nothing.
+type PATRestriction struct {
+	// Permissions, when non-empty, is the exhaustive allowlist of permission
+	// strings the token may exercise. Empty = inherit the owner's full set. An
+	// entry may be an exact permission ("secrets.read"), the catch-all "*", or a
+	// prefix wildcard ("secrets.*").
+	Permissions []string
+	// ProjectID, when non-zero, restricts the token to that project's scope;
+	// any check at a different project — or at global/system scope (project 0) —
+	// is denied. Zero = any scope the owner can reach.
+	ProjectID uint
+}
+
+// Allows reports whether this restriction permits exercising permission at scope.
+// A nil restriction (no PAT, or an unrestricted PAT) is handled by the caller.
+func (r *PATRestriction) Allows(permission string, scope Scope) bool {
+	if r == nil {
+		return true
+	}
+	// A project-scoped token may act ONLY within its project. A check at global
+	// scope (ProjectID 0 — system-wide actions like users.read) is therefore
+	// denied for a project-scoped token: it is not a system credential.
+	if r.ProjectID != 0 && scope.ProjectID != r.ProjectID {
+		return false
+	}
+	if len(r.Permissions) == 0 {
+		return true
+	}
+	for _, p := range r.Permissions {
+		if p == "*" || p == permission {
+			return true
+		}
+		if strings.HasSuffix(p, ".*") && strings.HasPrefix(permission, strings.TrimSuffix(p, "*")) {
+			return true
+		}
+	}
+	return false
+}
+
+// patRestrictionCtxKey is the unexported context key carrying a *PATRestriction.
+type patRestrictionCtxKey struct{}
+
+// WithPATRestriction tags ctx with the restriction a personal access token
+// imposes on the request. The auth middleware sets it for PAT-authenticated
+// requests only; session, machine and OIDC requests never carry one. Authorize
+// and AuthorizePrincipal read it back so the restriction is enforced uniformly at
+// the single authorization chokepoint — every present and future authz path.
+func WithPATRestriction(ctx context.Context, r *PATRestriction) context.Context {
+	return context.WithValue(ctx, patRestrictionCtxKey{}, r)
+}
+
+// patRestrictionFromContext returns the PAT restriction on ctx, or nil if none.
+func patRestrictionFromContext(ctx context.Context) *PATRestriction {
+	r, _ := ctx.Value(patRestrictionCtxKey{}).(*PATRestriction)
+	return r
+}
 
 // Scope identifies the project/environment an authorization check or a role
 // assignment applies to. It aliases storage.Scope so the same 0 = global
@@ -38,6 +101,14 @@ var adminRoleNames = []string{"super_admin", "admin", "system_admin", "project_a
 // machine is never a global super-user, so a leaked machine token is bounded to
 // the permissions of its explicit grants. Fails closed.
 func (c *KeyorixCore) AuthorizePrincipal(ctx context.Context, actorType string, principalID uint, permission string, scope Scope) (bool, error) {
+	// A personal access token may carry a least-privilege restriction (ADR-042)
+	// that narrows it below its owner. Enforce it first, before any role
+	// resolution or admin bypass, so even a global-admin's token is bounded. Only
+	// PAT-authenticated (user-actored) requests ever carry one, but the check is
+	// safe on every path. Fails closed (deny) when the restriction disallows.
+	if !patRestrictionFromContext(ctx).Allows(permission, scope) {
+		return false, nil
+	}
 	if actorType == ActorTypeMachine {
 		roleIDs, err := c.storage.GetMachineRoleIDsAt(ctx, principalID, scope)
 		if err != nil {
@@ -55,6 +126,13 @@ func (c *KeyorixCore) AuthorizePrincipal(ctx context.Context, actorType string, 
 // against the target scope. Fails closed: any resolution error returns
 // (false, err).
 func (c *KeyorixCore) Authorize(ctx context.Context, userID uint, permission string, scope Scope) (bool, error) {
+	// PAT least-privilege filter (ADR-042) — narrows even an admin owner. Applied
+	// here too (not only in AuthorizePrincipal) so direct Authorize callers and the
+	// admin bypass below are equally bounded. Idempotent on the AuthorizePrincipal
+	// path, which already checked it.
+	if !patRestrictionFromContext(ctx).Allows(permission, scope) {
+		return false, nil
+	}
 	roleIDs, err := c.scopedRoleIDs(ctx, userID, scope)
 	if err != nil {
 		return false, err

--- a/internal/core/authz_pat_test.go
+++ b/internal/core/authz_pat_test.go
@@ -1,0 +1,115 @@
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPATRestriction_Allows covers the pure least-privilege filter (ADR-042):
+// what a personal-access-token restriction permits, independent of any RBAC.
+func TestPATRestriction_Allows(t *testing.T) {
+	proj5 := Scope{ProjectID: 5}
+	global := Scope{} // project 0 — system-wide actions
+
+	cases := []struct {
+		name string
+		r    *PATRestriction
+		perm string
+		sc   Scope
+		want bool
+	}{
+		{"nil restriction allows anything", nil, "secrets.write", global, true},
+		{"empty allowlist inherits owner", &PATRestriction{}, "secrets.write", proj5, true},
+		{"exact permission match", &PATRestriction{Permissions: []string{"secrets.read"}}, "secrets.read", proj5, true},
+		{"permission not in allowlist denied", &PATRestriction{Permissions: []string{"secrets.read"}}, "secrets.write", proj5, false},
+		{"catch-all wildcard allows", &PATRestriction{Permissions: []string{"*"}}, "users.delete", global, true},
+		{"prefix wildcard matches family", &PATRestriction{Permissions: []string{"secrets.*"}}, "secrets.delete", proj5, true},
+		{"prefix wildcard does not cross family", &PATRestriction{Permissions: []string{"secrets.*"}}, "users.read", proj5, false},
+		{"project-scoped token allowed within its project", &PATRestriction{ProjectID: 5}, "secrets.read", proj5, true},
+		{"project-scoped token denied in other project", &PATRestriction{ProjectID: 5}, "secrets.read", Scope{ProjectID: 6}, false},
+		{"project-scoped token denied at global scope", &PATRestriction{ProjectID: 5}, "users.read", global, false},
+		{"both axes must pass — wrong project", &PATRestriction{Permissions: []string{"secrets.read"}, ProjectID: 5}, "secrets.read", Scope{ProjectID: 6}, false},
+		{"both axes must pass — wrong perm", &PATRestriction{Permissions: []string{"secrets.read"}, ProjectID: 5}, "secrets.write", proj5, false},
+		{"both axes pass", &PATRestriction{Permissions: []string{"secrets.read"}, ProjectID: 5}, "secrets.read", proj5, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, tc.r.Allows(tc.perm, tc.sc))
+		})
+	}
+}
+
+// TestAuthorize_PATRestriction proves the restriction is enforced inside Authorize
+// as a hard pre-gate: a disallowed permission is denied BEFORE any role resolution
+// (so even a global admin's token is bounded), and an allowed permission still
+// flows through to the owner's normal RBAC.
+func TestAuthorize_PATRestriction(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("disallowed permission denied without touching storage — even for an admin owner", func(t *testing.T) {
+		ms := new(MockStorage)
+		c := NewKeyorixCore(ms)
+		// Token may only read secrets; the owner could be a full admin, but the
+		// filter denies a write before any role/admin-bypass lookup runs.
+		rctx := WithPATRestriction(ctx, &PATRestriction{Permissions: []string{"secrets.read"}})
+
+		allowed, err := c.Authorize(rctx, 1, "secrets.write", Scope{ProjectID: 5})
+		require.NoError(t, err)
+		assert.False(t, allowed)
+		ms.AssertNotCalled(t, "GetUserRoleIDsAt")
+		ms.AssertNotCalled(t, "RoleSetHasPermission")
+	})
+
+	t.Run("project-scoped token denied outside its project before storage", func(t *testing.T) {
+		ms := new(MockStorage)
+		c := NewKeyorixCore(ms)
+		rctx := WithPATRestriction(ctx, &PATRestriction{ProjectID: 5})
+
+		allowed, err := c.Authorize(rctx, 1, "secrets.read", Scope{ProjectID: 9})
+		require.NoError(t, err)
+		assert.False(t, allowed)
+		ms.AssertNotCalled(t, "GetUserRoleIDsAt")
+	})
+
+	t.Run("allowed permission still requires the owner to hold it", func(t *testing.T) {
+		ms := new(MockStorage)
+		c := NewKeyorixCore(ms)
+		scope := storage.Scope{ProjectID: 5}
+		// Context carries the restriction, so match on Anything for ctx.
+		ms.On("GetUserRoleIDsAt", mock.Anything, uint(1), scope).Return([]uint{10}, nil)
+		ms.On("GetUserGroupRoleIDsAt", mock.Anything, uint(1), scope).Return([]uint{}, nil)
+		// Not an admin role set — every admin-name lookup misses.
+		ms.On("GetRoleByName", mock.Anything, "super_admin").Return(nil, assert.AnError)
+		ms.On("GetRoleByName", mock.Anything, "admin").Return(nil, assert.AnError)
+		ms.On("GetRoleByName", mock.Anything, "system_admin").Return(nil, assert.AnError)
+		ms.On("GetRoleByName", mock.Anything, "project_admin").Return(nil, assert.AnError)
+		ms.On("RoleSetHasPermission", mock.Anything, []uint{10}, "secrets.read").Return(true, nil)
+
+		rctx := WithPATRestriction(ctx, &PATRestriction{Permissions: []string{"secrets.read"}, ProjectID: 5})
+		allowed, err := c.Authorize(rctx, 1, "secrets.read", Scope{ProjectID: 5})
+		require.NoError(t, err)
+		assert.True(t, allowed, "the restriction permits it AND the owner's role grants it")
+	})
+
+	t.Run("no restriction on context is a no-op", func(t *testing.T) {
+		ms := new(MockStorage)
+		c := NewKeyorixCore(ms)
+		scope := storage.Scope{ProjectID: 5}
+		ms.On("GetUserRoleIDsAt", ctx, uint(1), scope).Return([]uint{10}, nil)
+		ms.On("GetUserGroupRoleIDsAt", ctx, uint(1), scope).Return([]uint{}, nil)
+		ms.On("GetRoleByName", ctx, "super_admin").Return(nil, assert.AnError)
+		ms.On("GetRoleByName", ctx, "admin").Return(nil, assert.AnError)
+		ms.On("GetRoleByName", ctx, "system_admin").Return(nil, assert.AnError)
+		ms.On("GetRoleByName", ctx, "project_admin").Return(nil, assert.AnError)
+		ms.On("RoleSetHasPermission", ctx, []uint{10}, "secrets.write").Return(true, nil)
+
+		allowed, err := c.Authorize(ctx, 1, "secrets.write", Scope{ProjectID: 5})
+		require.NoError(t, err)
+		assert.True(t, allowed)
+	})
+}

--- a/internal/core/pat.go
+++ b/internal/core/pat.go
@@ -1,16 +1,20 @@
-// pat.go — Personal Access Tokens (ADR-027).
+// pat.go — Personal Access Tokens (ADR-027, ADR-042).
 //
 // A PAT is a long-lived bearer credential a user creates from the My Account page.
-// It authenticates API requests AS that user, inheriting their full permission set
-// (no per-token scoping in v1). The raw token is returned once on creation; only its
-// SHA-256 hash is stored. Raw tokens carry the patPrefix so the auth middleware can
-// route them to ValidatePATToken and secret scanners can detect leaks.
+// It authenticates API requests AS that user. By default it inherits the owner's
+// full permission set; optionally (ADR-042) it carries a least-privilege
+// restriction — a permission allowlist and/or a single-project scope — that
+// narrows it below the owner (never above). The raw token is returned once on
+// creation; only its SHA-256 hash is stored. Raw tokens carry the patPrefix so the
+// auth middleware can route them to ValidatePATToken and secret scanners can detect
+// leaks.
 package core
 
 import (
 	"context"
 	"crypto/rand"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -34,13 +38,22 @@ type CreatePATResult struct {
 }
 
 // CreateOwnPAT generates a new personal access token for the caller. expiresAt may
-// be nil for a non-expiring token.
-func (c *KeyorixCore) CreateOwnPAT(ctx context.Context, userID uint, name string, expiresAt *time.Time) (*CreatePATResult, error) {
+// be nil for a non-expiring token. scopes, when non-empty, is a least-privilege
+// permission allowlist (ADR-042); projectScope, when non-zero, confines the token
+// to a single project. Both only ever NARROW the token below its owner — they are
+// enforced at request time as a filter intersected with the owner's live
+// permissions, so a token can never grant more than its owner currently holds.
+func (c *KeyorixCore) CreateOwnPAT(ctx context.Context, userID uint, name string, expiresAt *time.Time, scopes []string, projectScope uint) (*CreatePATResult, error) {
 	if userID == 0 {
 		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "user ID is required")
 	}
 	if strings.TrimSpace(name) == "" {
 		return nil, fmt.Errorf("%s: token name is required", i18n.T("ErrorValidation", nil))
+	}
+
+	scopesJSON, err := encodePATScopes(scopes)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorValidation", nil), err)
 	}
 
 	b := make([]byte, 32)
@@ -50,12 +63,14 @@ func (c *KeyorixCore) CreateOwnPAT(ctx context.Context, userID uint, name string
 	raw := patPrefix + base64.RawURLEncoding.EncodeToString(b)
 
 	pat := &models.PersonalAccessToken{
-		UserID:      userID,
-		Name:        strings.TrimSpace(name),
-		TokenHash:   sha256Hex(raw),
-		TokenPrefix: raw[:len(patPrefix)+6], // e.g. "kx_pat_ab12cd" for display
-		ExpiresAt:   expiresAt,
-		CreatedAt:   c.now(),
+		UserID:       userID,
+		Name:         strings.TrimSpace(name),
+		TokenHash:    sha256Hex(raw),
+		TokenPrefix:  raw[:len(patPrefix)+6], // e.g. "kx_pat_ab12cd" for display
+		Scopes:       scopesJSON,
+		ProjectScope: projectScope,
+		ExpiresAt:    expiresAt,
+		CreatedAt:    c.now(),
 	}
 	created, err := c.storage.CreatePersonalAccessToken(ctx, pat)
 	if err != nil {
@@ -85,42 +100,99 @@ func (c *KeyorixCore) RevokeOwnPAT(ctx context.Context, userID, tokenID uint) er
 	return c.storage.RevokePersonalAccessToken(ctx, tokenID)
 }
 
-// ValidatePATToken resolves a raw PAT to its owning user and role names, mirroring
-// the shape of ValidateSessionToken so the auth middleware can use either. It rejects
-// revoked/expired tokens and inactive users, and best-effort throttled-updates
-// last_used_at. The caller (middleware) is expected to gate on the patPrefix.
-func (c *KeyorixCore) ValidatePATToken(ctx context.Context, raw string) (*models.User, []string, error) {
+// ValidatePATToken resolves a raw PAT to its owning user, role names, and any
+// least-privilege restriction (ADR-042; nil when the token is unrestricted),
+// mirroring the shape of ValidateSessionToken so the auth middleware can use
+// either. It rejects revoked/expired tokens and inactive users, and best-effort
+// throttled-updates last_used_at. The caller (middleware) is expected to gate on
+// the patPrefix.
+func (c *KeyorixCore) ValidatePATToken(ctx context.Context, raw string) (*models.User, []string, *PATRestriction, error) {
 	if !strings.HasPrefix(raw, patPrefix) {
-		return nil, nil, fmt.Errorf("not a personal access token")
+		return nil, nil, nil, fmt.Errorf("not a personal access token")
 	}
 	pat, err := c.storage.GetPersonalAccessTokenByHash(ctx, sha256Hex(raw))
 	if err != nil {
-		return nil, nil, fmt.Errorf("invalid token")
+		return nil, nil, nil, fmt.Errorf("invalid token")
 	}
 	if pat.Revoked {
-		return nil, nil, fmt.Errorf("token revoked")
+		return nil, nil, nil, fmt.Errorf("token revoked")
 	}
 	if pat.ExpiresAt != nil && c.now().After(*pat.ExpiresAt) {
-		return nil, nil, fmt.Errorf("token expired")
+		return nil, nil, nil, fmt.Errorf("token expired")
 	}
 	user, err := c.storage.GetUser(ctx, pat.UserID)
 	if err != nil {
-		return nil, nil, fmt.Errorf("user not found")
+		return nil, nil, nil, fmt.Errorf("user not found")
 	}
 	if !user.IsActive {
-		return nil, nil, fmt.Errorf("user inactive")
+		return nil, nil, nil, fmt.Errorf("user inactive")
 	}
 
 	// Best-effort, throttled last-used stamp — never fails the request.
 	_ = c.storage.TouchPersonalAccessToken(ctx, pat.ID, c.now(), patTouchInterval)
 
+	restriction := patRestrictionFrom(pat)
+
 	roles, err := c.storage.GetUserRoles(ctx, user.ID)
 	if err != nil {
-		return user, []string{}, nil
+		return user, []string{}, restriction, nil
 	}
 	roleNames := make([]string, len(roles))
 	for i, r := range roles {
 		roleNames[i] = r.Name
 	}
-	return user, roleNames, nil
+	return user, roleNames, restriction, nil
+}
+
+// encodePATScopes normalises and JSON-encodes a permission allowlist for storage.
+// Blank entries are dropped and duplicates removed; an all-blank/empty list
+// encodes to "" so the token stays unrestricted (the back-compat default).
+func encodePATScopes(scopes []string) (string, error) {
+	cleaned := make([]string, 0, len(scopes))
+	seen := make(map[string]struct{}, len(scopes))
+	for _, s := range scopes {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			continue
+		}
+		if _, dup := seen[s]; dup {
+			continue
+		}
+		seen[s] = struct{}{}
+		cleaned = append(cleaned, s)
+	}
+	if len(cleaned) == 0 {
+		return "", nil
+	}
+	b, err := json.Marshal(cleaned)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+// DecodePATScopes parses a stored scopes column back into a permission list.
+// An empty/invalid column yields nil (unrestricted) — fail-open here is correct
+// because an empty allowlist already means "inherit the owner", and the owner's
+// own RBAC still gates every action.
+func DecodePATScopes(raw string) []string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
+	}
+	var out []string
+	if err := json.Unmarshal([]byte(raw), &out); err != nil {
+		return nil
+	}
+	return out
+}
+
+// patRestrictionFrom builds the request-time restriction for a token, or nil when
+// the token is unrestricted (no scopes and no project confinement).
+func patRestrictionFrom(pat *models.PersonalAccessToken) *PATRestriction {
+	scopes := DecodePATScopes(pat.Scopes)
+	if len(scopes) == 0 && pat.ProjectScope == 0 {
+		return nil
+	}
+	return &PATRestriction{Permissions: scopes, ProjectID: pat.ProjectScope}
 }

--- a/internal/core/pat_scoping_e2e_test.go
+++ b/internal/core/pat_scoping_e2e_test.go
@@ -1,0 +1,104 @@
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// newPATScopingCore bootstraps a real core (admin = global admin) with the PAT
+// table migrated, for end-to-end ADR-042 assertions against real RBAC.
+func newPATScopingCore(t *testing.T) (*KeyorixCore, *store.LocalStorage) {
+	t.Helper()
+	require.NoError(t, i18n.Initialize(&config.Config{
+		Locale: config.LocaleConfig{Language: "en", FallbackLanguage: "en"},
+	}))
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.User{}, &models.Role{}, &models.Permission{}, &models.RolePermission{},
+		&models.UserRole{}, &models.Group{}, &models.UserGroup{}, &models.GroupRole{},
+		&models.Project{}, &models.Environment{}, &models.PersonalAccessToken{},
+	))
+	st := store.NewLocalStorage(db)
+	c := NewKeyorixCore(st)
+	_, err = c.BootstrapSystem(context.Background(), &BootstrapRequest{
+		Username: "admin", Email: "admin@example.com", Password: "password12345", DisplayName: "Admin",
+	})
+	require.NoError(t, err)
+	return c, st
+}
+
+// TestPATScoping_EndToEnd_RealRBAC drives the whole ADR-042 vertical against real
+// RBAC: create a scoped PAT, resolve it back through ValidatePATToken, then prove
+// the restriction bounds even a GLOBAL ADMIN's authorization — the property mocks
+// alone can't fully establish because it must survive the real admin bypass.
+func TestPATScoping_EndToEnd_RealRBAC(t *testing.T) {
+	ctx := context.Background()
+	c, st := newPATScopingCore(t)
+	admin, err := st.GetUserByUsername(ctx, "admin")
+	require.NoError(t, err)
+	proj := Scope{ProjectID: 3}
+
+	t.Run("sanity: an unrestricted admin token may write (admin bypass)", func(t *testing.T) {
+		ok, err := c.AuthorizePrincipal(ctx, ActorTypeUser, admin.ID, "secrets.write", proj)
+		require.NoError(t, err)
+		assert.True(t, ok, "the global admin can write everywhere by default")
+	})
+
+	t.Run("permission-scoped PAT bounds the admin to read-only", func(t *testing.T) {
+		res, err := c.CreateOwnPAT(ctx, admin.ID, "ci-read", nil, []string{"secrets.read"}, 0)
+		require.NoError(t, err)
+
+		user, _, restriction, err := c.ValidatePATToken(ctx, res.PlainToken)
+		require.NoError(t, err)
+		require.Equal(t, admin.ID, user.ID)
+		require.NotNil(t, restriction)
+
+		rctx := WithPATRestriction(ctx, restriction)
+		readOK, err := c.AuthorizePrincipal(rctx, ActorTypeUser, admin.ID, "secrets.read", proj)
+		require.NoError(t, err)
+		assert.True(t, readOK, "the listed permission passes")
+
+		writeOK, err := c.AuthorizePrincipal(rctx, ActorTypeUser, admin.ID, "secrets.write", proj)
+		require.NoError(t, err)
+		assert.False(t, writeOK, "the admin's own token cannot write — the restriction wins over the admin bypass")
+	})
+
+	t.Run("project-scoped PAT is confined to its project", func(t *testing.T) {
+		res, err := c.CreateOwnPAT(ctx, admin.ID, "ci-proj3", nil, nil, 3)
+		require.NoError(t, err)
+		_, _, restriction, err := c.ValidatePATToken(ctx, res.PlainToken)
+		require.NoError(t, err)
+		require.NotNil(t, restriction)
+		rctx := WithPATRestriction(ctx, restriction)
+
+		inProject, err := c.AuthorizePrincipal(rctx, ActorTypeUser, admin.ID, "secrets.write", Scope{ProjectID: 3})
+		require.NoError(t, err)
+		assert.True(t, inProject, "writes within the token's project still flow through the admin bypass")
+
+		otherProject, err := c.AuthorizePrincipal(rctx, ActorTypeUser, admin.ID, "secrets.write", Scope{ProjectID: 4})
+		require.NoError(t, err)
+		assert.False(t, otherProject, "a project-3 token cannot touch project 4")
+
+		globalScope, err := c.AuthorizePrincipal(rctx, ActorTypeUser, admin.ID, "users.read", Scope{})
+		require.NoError(t, err)
+		assert.False(t, globalScope, "a project-scoped token is not a system-wide credential")
+	})
+
+	t.Run("unrestricted PAT resolves to no restriction and keeps full inheritance", func(t *testing.T) {
+		res, err := c.CreateOwnPAT(ctx, admin.ID, "ci-full", nil, nil, 0)
+		require.NoError(t, err)
+		_, _, restriction, err := c.ValidatePATToken(ctx, res.PlainToken)
+		require.NoError(t, err)
+		assert.Nil(t, restriction, "no scopes + no project = unrestricted (back-compat)")
+	})
+}

--- a/internal/core/pat_test.go
+++ b/internal/core/pat_test.go
@@ -23,19 +23,42 @@ func TestCreateOwnPAT(t *testing.T) {
 			Run(func(args mock.Arguments) { captured = args.Get(1).(*models.PersonalAccessToken) }).
 			Return(&models.PersonalAccessToken{ID: 1}, nil)
 
-		res, err := c.CreateOwnPAT(ctx, 1, "ci-token", nil)
+		res, err := c.CreateOwnPAT(ctx, 1, "ci-token", nil, nil, 0)
 		require.NoError(t, err)
 		assert.True(t, strings.HasPrefix(res.PlainToken, patPrefix), "raw token carries the kx_pat_ prefix")
 		require.NotNil(t, captured)
 		assert.Equal(t, sha256Hex(res.PlainToken), captured.TokenHash, "stored value is the hash of the plaintext")
 		assert.NotEqual(t, res.PlainToken, captured.TokenHash, "plaintext is never stored")
 		assert.True(t, strings.HasPrefix(captured.TokenPrefix, patPrefix))
+		assert.Empty(t, captured.Scopes, "an unscoped token stores no allowlist (inherits owner)")
+		assert.Zero(t, captured.ProjectScope)
+	})
+
+	t.Run("persists a least-privilege scope restriction (ADR-042)", func(t *testing.T) {
+		ms := new(MockStorage)
+		c := NewKeyorixCore(ms)
+		var captured *models.PersonalAccessToken
+		ms.On("CreatePersonalAccessToken", ctx, mock.AnythingOfType("*models.PersonalAccessToken")).
+			Run(func(args mock.Arguments) { captured = args.Get(1).(*models.PersonalAccessToken) }).
+			Return(&models.PersonalAccessToken{ID: 1}, nil)
+
+		_, err := c.CreateOwnPAT(ctx, 1, "ci-read-only", nil, []string{"secrets.read", "  ", "secrets.read"}, 7)
+		require.NoError(t, err)
+		require.NotNil(t, captured)
+		// Blanks dropped, duplicates removed, encoded as JSON.
+		assert.Equal(t, `["secrets.read"]`, captured.Scopes)
+		assert.Equal(t, uint(7), captured.ProjectScope)
+		// Round-trips back into a restriction.
+		r := patRestrictionFrom(captured)
+		require.NotNil(t, r)
+		assert.Equal(t, []string{"secrets.read"}, r.Permissions)
+		assert.Equal(t, uint(7), r.ProjectID)
 	})
 
 	t.Run("rejects an empty name", func(t *testing.T) {
 		ms := new(MockStorage)
 		c := NewKeyorixCore(ms)
-		_, err := c.CreateOwnPAT(ctx, 1, "   ", nil)
+		_, err := c.CreateOwnPAT(ctx, 1, "   ", nil, nil, 0)
 		require.Error(t, err)
 		ms.AssertNotCalled(t, "CreatePersonalAccessToken", mock.Anything, mock.Anything)
 	})
@@ -55,17 +78,35 @@ func TestValidatePATToken(t *testing.T) {
 		role := "system_viewer"
 		ms.On("GetUserRoles", ctx, uint(1)).Return([]*models.Role{{Name: role}}, nil)
 
-		user, roles, err := c.ValidatePATToken(ctx, raw)
+		user, roles, restriction, err := c.ValidatePATToken(ctx, raw)
 		require.NoError(t, err)
 		assert.Equal(t, uint(1), user.ID)
 		assert.Equal(t, []string{role}, roles)
+		assert.Nil(t, restriction, "an unscoped token resolves to no restriction (full inheritance)")
+	})
+
+	t.Run("surfaces the least-privilege restriction for a scoped token (ADR-042)", func(t *testing.T) {
+		ms := new(MockStorage)
+		c := NewKeyorixCore(ms)
+		ms.On("GetPersonalAccessTokenByHash", ctx, hash).Return(&models.PersonalAccessToken{
+			ID: 9, UserID: 1, Scopes: `["secrets.read"]`, ProjectScope: 4,
+		}, nil)
+		ms.On("GetUser", ctx, uint(1)).Return(&models.User{ID: 1, Username: acctTestUser, IsActive: true}, nil)
+		ms.On("TouchPersonalAccessToken", ctx, uint(9), mock.AnythingOfType("time.Time"), patTouchInterval).Return(nil)
+		ms.On("GetUserRoles", ctx, uint(1)).Return([]*models.Role{{Name: "system_viewer"}}, nil)
+
+		_, _, restriction, err := c.ValidatePATToken(ctx, raw)
+		require.NoError(t, err)
+		require.NotNil(t, restriction)
+		assert.Equal(t, []string{"secrets.read"}, restriction.Permissions)
+		assert.Equal(t, uint(4), restriction.ProjectID)
 	})
 
 	t.Run("rejects a revoked token", func(t *testing.T) {
 		ms := new(MockStorage)
 		c := NewKeyorixCore(ms)
 		ms.On("GetPersonalAccessTokenByHash", ctx, hash).Return(&models.PersonalAccessToken{ID: 9, UserID: 1, Revoked: true}, nil)
-		_, _, err := c.ValidatePATToken(ctx, raw)
+		_, _, _, err := c.ValidatePATToken(ctx, raw)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "revoked")
 	})
@@ -75,7 +116,7 @@ func TestValidatePATToken(t *testing.T) {
 		c := NewKeyorixCore(ms)
 		past := time.Now().Add(-time.Hour)
 		ms.On("GetPersonalAccessTokenByHash", ctx, hash).Return(&models.PersonalAccessToken{ID: 9, UserID: 1, ExpiresAt: &past}, nil)
-		_, _, err := c.ValidatePATToken(ctx, raw)
+		_, _, _, err := c.ValidatePATToken(ctx, raw)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "expired")
 	})
@@ -85,7 +126,7 @@ func TestValidatePATToken(t *testing.T) {
 		c := NewKeyorixCore(ms)
 		ms.On("GetPersonalAccessTokenByHash", ctx, hash).Return(&models.PersonalAccessToken{ID: 9, UserID: 1}, nil)
 		ms.On("GetUser", ctx, uint(1)).Return(&models.User{ID: 1, IsActive: false}, nil)
-		_, _, err := c.ValidatePATToken(ctx, raw)
+		_, _, _, err := c.ValidatePATToken(ctx, raw)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "inactive")
 	})
@@ -94,14 +135,14 @@ func TestValidatePATToken(t *testing.T) {
 		ms := new(MockStorage)
 		c := NewKeyorixCore(ms)
 		ms.On("GetPersonalAccessTokenByHash", ctx, hash).Return(nil, assert.AnError)
-		_, _, err := c.ValidatePATToken(ctx, raw)
+		_, _, _, err := c.ValidatePATToken(ctx, raw)
 		require.Error(t, err)
 	})
 
 	t.Run("rejects a non-PAT token before any storage lookup", func(t *testing.T) {
 		ms := new(MockStorage)
 		c := NewKeyorixCore(ms)
-		_, _, err := c.ValidatePATToken(ctx, "some-session-token")
+		_, _, _, err := c.ValidatePATToken(ctx, "some-session-token")
 		require.Error(t, err)
 		ms.AssertNotCalled(t, "GetPersonalAccessTokenByHash", mock.Anything, mock.Anything)
 	})

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -276,10 +276,22 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 		}
 	}
 
-	// Create personal_access_tokens if missing (ADR-027, additive, safe on existing DBs).
+	// Create personal_access_tokens if missing (ADR-027, additive, safe on existing DBs);
+	// otherwise add only the ADR-042 per-token scoping columns via the Migrator (same
+	// pgx hazard as the notifications/invitations blocks — never full-AutoMigrate an
+	// existing table here). Defaults leave existing tokens unrestricted (back-compat).
 	if !patExists {
 		if err := db.AutoMigrate(&models.PersonalAccessToken{}); err != nil {
 			return fmt.Errorf("failed to migrate personal_access_tokens table: %w", err)
+		}
+	} else {
+		m := db.Migrator()
+		for _, col := range []string{"Scopes", "ProjectScope"} {
+			if !m.HasColumn(&models.PersonalAccessToken{}, col) {
+				if err := m.AddColumn(&models.PersonalAccessToken{}, col); err != nil {
+					return fmt.Errorf("failed to add personal_access_tokens.%s column: %w", col, err)
+				}
+			}
 		}
 	}
 

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -372,10 +372,20 @@ type PersonalAccessToken struct {
 	Name        string `gorm:"not null"`             // user-facing label
 	TokenHash   string `gorm:"uniqueIndex;not null"` // SHA-256 hex of the raw token (never the plaintext)
 	TokenPrefix string `gorm:"index"`                // leading chars of the raw token, for display ("kx_pat_ab12…")
-	LastUsedAt  *time.Time
-	ExpiresAt   *time.Time // nil = never expires
-	Revoked     bool       `gorm:"default:false"`
-	CreatedAt   time.Time
+	// Scopes is a JSON-encoded []string permission allowlist (ADR-042). Empty/null =
+	// the token inherits the owner's full permission set (legacy v1 behaviour, the
+	// default for existing rows). When non-empty, the token may exercise ONLY the
+	// listed permissions — and even then never more than the owner actually holds at
+	// request time (it is a filter that narrows, never an escalation).
+	Scopes string `gorm:"type:text"`
+	// ProjectScope, when non-zero, restricts the token to acting within that single
+	// project's scope (and denies global/system-wide actions). 0 = any scope the
+	// owner can reach. Mirrors the 0 = global sentinel used throughout RBAC.
+	ProjectScope uint `gorm:"default:0"`
+	LastUsedAt   *time.Time
+	ExpiresAt    *time.Time // nil = never expires
+	Revoked      bool       `gorm:"default:false"`
+	CreatedAt    time.Time
 }
 
 // SetupToken is the single-use, hashed-at-rest bearer string that lets a brand-new

--- a/server/http/handlers/openapi.yaml
+++ b/server/http/handlers/openapi.yaml
@@ -328,6 +328,8 @@ paths:
               properties:
                 name: {type: string}
                 expires_at: {type: string, format: date-time, nullable: true, description: 'RFC3339; omit/null for non-expiring'}
+                scopes: {type: array, items: {type: string}, description: 'ADR-042 least-privilege allowlist (e.g. ["secrets.read"], supports "*" and "secrets.*"). Omit/empty = inherit the owner''s full permissions. Only ever narrows below the owner.'}
+                project_scope: {type: integer, description: 'ADR-042: confine the token to a single project id; 0/omit = any project the owner can reach.'}
       responses:
         '201': {description: 'Token created; plaintext token in data.token shown once'}
         '400': {$ref: '#/components/responses/Error'}

--- a/server/http/handlers/pat_handler.go
+++ b/server/http/handlers/pat_handler.go
@@ -30,23 +30,29 @@ func NewPATHandler(coreService *core.KeyorixCore) *PATHandler {
 }
 
 // patResponse is the safe DTO — omits TokenHash; carries only the display prefix.
+// scopes/project_scope surface the ADR-042 least-privilege restriction (read-only;
+// a token's scope is fixed at creation).
 type patResponse struct {
-	ID          uint    `json:"id"`
-	Name        string  `json:"name"`
-	TokenPrefix string  `json:"token_prefix"`
-	Revoked     bool    `json:"revoked"`
-	CreatedAt   string  `json:"created_at"`
-	ExpiresAt   *string `json:"expires_at"`
-	LastUsedAt  *string `json:"last_used_at"`
+	ID           uint     `json:"id"`
+	Name         string   `json:"name"`
+	TokenPrefix  string   `json:"token_prefix"`
+	Revoked      bool     `json:"revoked"`
+	CreatedAt    string   `json:"created_at"`
+	ExpiresAt    *string  `json:"expires_at"`
+	LastUsedAt   *string  `json:"last_used_at"`
+	Scopes       []string `json:"scopes"`        // empty = inherits the owner's full permissions
+	ProjectScope uint     `json:"project_scope"` // 0 = any project the owner can reach
 }
 
 func toPATResponse(t *models.PersonalAccessToken) patResponse {
 	resp := patResponse{
-		ID:          t.ID,
-		Name:        t.Name,
-		TokenPrefix: t.TokenPrefix,
-		Revoked:     t.Revoked,
-		CreatedAt:   t.CreatedAt.UTC().Format(time.RFC3339),
+		ID:           t.ID,
+		Name:         t.Name,
+		TokenPrefix:  t.TokenPrefix,
+		Revoked:      t.Revoked,
+		CreatedAt:    t.CreatedAt.UTC().Format(time.RFC3339),
+		Scopes:       core.DecodePATScopes(t.Scopes),
+		ProjectScope: t.ProjectScope,
 	}
 	if t.ExpiresAt != nil {
 		v := t.ExpiresAt.UTC().Format(time.RFC3339)
@@ -81,6 +87,11 @@ func (h *PATHandler) ListPATs(w http.ResponseWriter, r *http.Request) {
 type createPATRequestBody struct {
 	Name      string  `json:"name"`
 	ExpiresAt *string `json:"expires_at"` // RFC3339; omit/null for a non-expiring token
+	// Scopes is an optional least-privilege permission allowlist (ADR-042). Omit or
+	// leave empty to inherit the owner's full permission set (the default).
+	Scopes []string `json:"scopes"`
+	// ProjectScope optionally confines the token to a single project (0/omit = any).
+	ProjectScope uint `json:"project_scope"`
 }
 
 // CreatePAT handles POST /auth/tokens. The raw token is returned exactly once.
@@ -106,7 +117,7 @@ func (h *PATHandler) CreatePAT(w http.ResponseWriter, r *http.Request) {
 		expiresAt = &t
 	}
 
-	result, err := h.coreService.CreateOwnPAT(r.Context(), userCtx.UserID, body.Name, expiresAt)
+	result, err := h.coreService.CreateOwnPAT(r.Context(), userCtx.UserID, body.Name, expiresAt, body.Scopes, body.ProjectScope)
 	if err != nil {
 		sendError(w, "BadRequest", err.Error(), http.StatusBadRequest, nil)
 		return

--- a/server/middleware/auth.go
+++ b/server/middleware/auth.go
@@ -27,7 +27,7 @@ import (
 // downstream per-scope authorization work unchanged.
 type sessionValidator interface {
 	ValidateSessionToken(ctx context.Context, token string) (*models.User, []string, error)
-	ValidatePATToken(ctx context.Context, token string) (*models.User, []string, error)
+	ValidatePATToken(ctx context.Context, token string) (*models.User, []string, *core.PATRestriction, error)
 	ValidateMachineToken(ctx context.Context, token string) (*models.MachineIdentity, []string, error)
 	ValidateOIDCToken(ctx context.Context, token string) (*models.MachineIdentity, []string, error)
 	OIDCEnabled() bool
@@ -64,6 +64,11 @@ type UserContext struct {
 	// confine non-interactive automation.
 	MFAEnabled  bool `json:"-"`
 	SessionAuth bool `json:"-"`
+	// PATRestriction is the least-privilege filter a personal access token imposes
+	// (ADR-042), or nil for sessions / unrestricted PATs. Cached with the rest of
+	// the identity and tagged onto the request context by buildRequestContext so
+	// core.Authorize enforces it at the single authorization chokepoint.
+	PATRestriction *core.PATRestriction `json:"-"`
 }
 
 // ActorKind returns the principal's actor type ("user" or "machine_identity"),
@@ -532,6 +537,11 @@ func buildRequestContext(parent context.Context, userCtx *UserContext, coreServi
 	if userCtx != nil && userCtx.MachineIdentityID != nil {
 		ctx = core.WithActorType(ctx, core.ActorTypeMachine)
 	}
+	// Carry a PAT's least-privilege restriction (ADR-042) so core.Authorize
+	// enforces it on every authorization check this request makes.
+	if userCtx != nil && userCtx.PATRestriction != nil {
+		ctx = core.WithPATRestriction(ctx, userCtx.PATRestriction)
+	}
 	return ctx
 }
 
@@ -597,13 +607,14 @@ func validateToken(ctx context.Context, validator sessionValidator, token string
 	// Route by prefix: PATs authenticate AS their owning user, resolving to the same
 	// UserContext shape as a session — so authorization downstream is identical.
 	var (
-		user       *models.User
-		roleNames  []string
-		err        error
-		viaSession bool
+		user        *models.User
+		roleNames   []string
+		restriction *core.PATRestriction
+		err         error
+		viaSession  bool
 	)
 	if strings.HasPrefix(token, patTokenPrefix) {
-		user, roleNames, err = validator.ValidatePATToken(ctx, token)
+		user, roleNames, restriction, err = validator.ValidatePATToken(ctx, token)
 	} else {
 		user, roleNames, err = validator.ValidateSessionToken(ctx, token)
 		viaSession = true
@@ -612,15 +623,16 @@ func validateToken(ctx context.Context, validator sessionValidator, token string
 		return nil, err
 	}
 	return &UserContext{
-		UserID:       user.ID,
-		Username:     user.Username,
-		Email:        user.Email,
-		Roles:        roleNames,
-		ActorType:    core.ActorTypeUser,
-		AccountState: core.NormalizeAccountState(user.AccountState),
-		Restricted:   core.AccountRestricted(user.AccountState),
-		MFAEnabled:   user.MFAEnabled || user.WebAuthnEnabled,
-		SessionAuth:  viaSession,
+		UserID:         user.ID,
+		Username:       user.Username,
+		Email:          user.Email,
+		Roles:          roleNames,
+		ActorType:      core.ActorTypeUser,
+		AccountState:   core.NormalizeAccountState(user.AccountState),
+		Restricted:     core.AccountRestricted(user.AccountState),
+		MFAEnabled:     user.MFAEnabled || user.WebAuthnEnabled,
+		SessionAuth:    viaSession,
+		PATRestriction: restriction,
 	}, nil
 }
 

--- a/server/middleware/auth_test.go
+++ b/server/middleware/auth_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -46,15 +47,22 @@ func (fakeValidator) ValidateSessionToken(_ context.Context, token string) (*mod
 // ValidatePATToken accepts a single fixed PAT and resolves it to a user, mirroring
 // the shape of ValidateSessionToken so the prefix-routing in validateToken can be
 // exercised. Anything else is rejected.
-func (fakeValidator) ValidatePATToken(_ context.Context, token string) (*models.User, []string, error) {
+func (fakeValidator) ValidatePATToken(_ context.Context, token string) (*models.User, []string, *core.PATRestriction, error) {
 	if token == "kx_pat_validtoken" {
 		return &models.User{
 			ID:       3,
 			Username: "patuser",
 			Email:    "pat@example.com",
-		}, []string{"system_viewer"}, nil
+		}, []string{"system_viewer"}, nil, nil
 	}
-	return nil, nil, fmt.Errorf("invalid token")
+	if token == "kx_pat_scopedtoken" {
+		// A least-privilege token confined to secrets.read in project 5 (ADR-042).
+		return &models.User{ID: 3, Username: "patuser", Email: "pat@example.com"},
+			[]string{"system_viewer"},
+			&core.PATRestriction{Permissions: []string{"secrets.read"}, ProjectID: 5},
+			nil
+	}
+	return nil, nil, nil, fmt.Errorf("invalid token")
 }
 
 func (fakeValidator) ValidateMachineToken(_ context.Context, token string) (*models.MachineIdentity, []string, error) {
@@ -400,6 +408,46 @@ func TestValidateToken(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestValidateToken_PATRestriction asserts the ADR-042 least-privilege wiring:
+// a scoped PAT surfaces its restriction on the UserContext, an unrestricted PAT
+// and a session carry none, and buildRequestContext propagates the restriction so
+// core.Authorize can enforce it downstream.
+func TestValidateToken_PATRestriction(t *testing.T) {
+	t.Run("scoped PAT carries its restriction and propagates to context", func(t *testing.T) {
+		userCtx, err := validateToken(context.Background(), fakeValidator{}, "kx_pat_scopedtoken")
+		require.NoError(t, err)
+		require.NotNil(t, userCtx.PATRestriction)
+		assert.Equal(t, []string{"secrets.read"}, userCtx.PATRestriction.Permissions)
+		assert.Equal(t, uint(5), userCtx.PATRestriction.ProjectID)
+		assert.False(t, userCtx.SessionAuth, "a PAT is not an interactive session")
+
+		// The restriction filters as expected: the listed permission within the
+		// token's project passes; a different permission or project is denied.
+		assert.True(t, userCtx.PATRestriction.Allows("secrets.read", core.Scope{ProjectID: 5}))
+		assert.False(t, userCtx.PATRestriction.Allows("secrets.write", core.Scope{ProjectID: 5}))
+		assert.False(t, userCtx.PATRestriction.Allows("secrets.read", core.Scope{ProjectID: 6}))
+
+		// buildRequestContext must not panic and must return a context carrying the
+		// identity, so downstream core.Authorize reads the restriction off ctx.
+		ctx := buildRequestContext(context.Background(), userCtx, nil)
+		require.NotNil(t, ctx)
+		assert.Equal(t, userCtx, GetUserFromContext(ctx))
+	})
+
+	t.Run("unrestricted PAT carries no restriction", func(t *testing.T) {
+		userCtx, err := validateToken(context.Background(), fakeValidator{}, "kx_pat_validtoken")
+		require.NoError(t, err)
+		assert.Nil(t, userCtx.PATRestriction)
+	})
+
+	t.Run("session token carries no restriction", func(t *testing.T) {
+		userCtx, err := validateToken(context.Background(), fakeValidator{}, "valid-token")
+		require.NoError(t, err)
+		assert.Nil(t, userCtx.PATRestriction)
+		assert.True(t, userCtx.SessionAuth)
+	})
 }
 
 // Benchmark tests


### PR DESCRIPTION
## What

Adds optional **least-privilege scoping** to Personal Access Tokens (ADR-042). Until now a PAT authenticated AS its owner with the owner's **full** permission set — so a CI read-only token carried its (often admin) owner's entire authority, and a leak meant the whole account. A PAT may now carry, fixed at creation:

- a **permission allowlist** — exact (`secrets.read`), catch-all (`*`), or prefix (`secrets.*`)
- a **single-project confinement** (`project_scope`)

It is a **filter that only ever narrows** a token below its owner — never an escalation, because the owner's live RBAC still runs after it. Existing tokens and unrestricted new ones are unaffected (back-compat default).

## Why

Least privilege for non-interactive credentials is a core control in the certification frames Keyorix targets — NIS2 Art. 21(2), ISO 27001:2022 A.5.15/A.5.18/A.8.2, ENS `op.acc.4`. Machine identities (ADR-030) were already bounded; PATs were the remaining over-privileged credential.

## How

Enforcement is at the **single authorization chokepoint**, not the HTTP layer. The restriction rides the request `context.Context` (`core.WithPATRestriction`, tagged in the auth middleware's `buildRequestContext` for PAT requests only) and is read back inside **`core.Authorize` and `core.AuthorizePrincipal`** — the two functions every authorization decision funnels through (HTTP middleware, in-handler authorizers, gRPC). It is applied **before role resolution and the admin bypass**, so it bounds even a global admin's own token. Centralizing it at the chokepoint means no path can forget to wire it.

- **Model:** `PersonalAccessToken.{Scopes (JSON []string), ProjectScope uint}` — additive columns via the GORM `Migrator` on existing DBs (defaults leave existing rows unrestricted).
- **API:** `POST /auth/tokens` accepts optional `scopes` + `project_scope`; the list/create DTO surfaces both read-only (scope is immutable after creation — revoke & re-mint to change).
- **Filter, never escalation:** creation does not pre-validate `scopes ⊆ owner` — the runtime intersection makes over-broad scopes harmless, and owner permissions are scope-dependent and mutable anyway.

## Tests

- Pure `Allows()` table (wildcards, project axis, both-axes).
- `Authorize`-with-restriction: denies before touching storage, **admin owner narrowed**, unrestricted = no-op.
- `CreateOwnPAT`/`ValidatePATToken` round-trip (scopes persisted, normalized, decoded).
- Middleware wiring (restriction on `UserContext`, nil for sessions).
- **Real-RBAC end-to-end:** a `secrets.read`-scoped token on a **global admin** is denied `secrets.write`; a project-3 token is denied in project 4 and at global scope — surviving the real admin bypass.

golangci-lint 0 issues · gitleaks clean · full suite green. **Security-reviewed before commit — no findings.** Two non-blocking defense-in-depth follow-ups (currently-unused `IsGlobalAdmin`/`RequireRole` paths; gRPC PAT support) recorded in the private backlog.

## Deferred (in ADR)

Per-environment confinement · frontend (My Account) scope picker · scope presets · CLI `--scope`/`--project` flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)