### PR TITLE
release: prep v0.13.0 (CHANGELOG + Helm chart 0.13.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to Keyorix are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## v0.13.0 — 2026-06-12
+
+### Added
+- **Personal access token least-privilege scoping** (ADR-042) — a PAT can now be
+  minted **weaker than its owner**. At creation it may carry an optional permission
+  allowlist (exact like `secrets.read`, the catch-all `*`, or a prefix like
+  `secrets.*`) and/or a single-project confinement (`project_scope`). The
+  restriction is a **filter that only ever narrows** the token below its owner —
+  never an escalation, since the owner's live RBAC still runs after it. It is
+  enforced at the single authorization chokepoint (before role resolution and the
+  admin bypass), so it bounds even a global admin's own token across every
+  authorization path. `POST /api/v1/auth/tokens` accepts `scopes` and
+  `project_scope`; existing and unrestricted tokens are unaffected (full
+  inheritance remains the default). Closes the last over-privileged-credential gap
+  after machine identities (ADR-030). ([#129], ADR-042)
+
+[#129]: https://github.com/keyorixhq/keyorix/pull/129
+
 ## v0.12.0 — 2026-06-12
 
 ### Added

--- a/deploy/helm/keyorix/Chart.yaml
+++ b/deploy/helm/keyorix/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix
 description: Self-hosted Keyorix secrets manager (API server + web UI + PostgreSQL)
 type: application
 # Chart version — bump on chart changes.
-version: 0.12.0
+version: 0.13.0
 # The Keyorix app version this chart deploys by default (the image tag).
-appVersion: "0.12.0"
+appVersion: "0.13.0"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix


### PR DESCRIPTION
Release prep for **v0.13.0** — bundles the one unreleased change on top of v0.12.0:

- **PAT least-privilege scoping** ([#129], ADR-042) — personal access tokens can now be minted weaker than their owner (permission allowlist + single-project confinement), enforced at the authorization chokepoint before the admin bypass.

Changes: CHANGELOG entry + Helm chart `version`/`appVersion` → 0.13.0. Tag `v0.13.0` pushed after merge fires the release + chart + image pipelines.

[#129]: https://github.com/keyorixhq/keyorix/pull/129

🤖 Generated with [Claude Code](https://claude.com/claude-code)