### PR TITLE
fix(crypto): fsync key-material writes to prevent data loss on crash

### DIFF
--- a/docs/adr-041-kms-key-provider.md
+++ b/docs/adr-041-kms-key-provider.md
@@ -135,6 +135,21 @@ unwraps it; the old provider no longer does; a failing provider leaves the activ
 intact) and an end-to-end CLI test (password → env migration round-trips a secret and
 keeps a backup).
 
+### Crash-durable key writes (hardening, 2026-06-12)
+
+Every write of unrecoverable key material — the wrapped DEK (first run, rotation,
+migration), the KMS-wrapped KEK blob, and the KEK salt — goes through
+`securefiles.SecureWriteFileSync`, which `fsync`s the file before returning, and any
+subsequent `rename` is followed by `securefiles.SyncDir` to flush the directory
+entry. This closes a durability gap surfaced by an internal audit: `os.WriteFile`
+leaves bytes in the page cache, so a power failure after the call returned (and
+after the operator retired the old KEK, which `migrate-provider` explicitly invites)
+could lose the new wrapped DEK while the old wrapping key is gone — orphaning all
+ciphertext irreversibly. The migration backup copy is fsync'd for the same reason
+(it is the rollback target). The standard write-temp → `fsync(file)` → `rename` →
+`fsync(dir)` pattern now holds on every key-material path; the data path is
+unchanged.
+
 ## Deferred
 
 AWS `GenerateDataKey` as an optimisation; KMS-key rotation runbook (rotating the CMK

--- a/internal/cli/encryption/migrate_provider.go
+++ b/internal/cli/encryption/migrate_provider.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/keyorixhq/keyorix/internal/config"
 	"github.com/keyorixhq/keyorix/internal/encryption"
+	"github.com/keyorixhq/keyorix/internal/securefiles"
 	"github.com/spf13/cobra"
 )
 
@@ -238,13 +239,31 @@ func migrateProviderWithConfig(cfg *config.Config, opts migrateOpts, confirm boo
 	return nil
 }
 
-// copyFile copies src to dst with 0600 permissions.
+// copyFile copies src to dst with 0600 permissions, fsyncing the destination file
+// and its directory so the copy is durable. The backup this produces is the
+// rollback target if migration verification fails — a non-durable backup lost to a
+// crash could leave neither a valid old nor new wrapped DEK on disk.
 func copyFile(src, dst string) error {
 	data, err := os.ReadFile(src) // #nosec G304 -- operator-configured key path under baseDir
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(dst, data, 0600) // #nosec G703 -- operator-configured key path under baseDir (local CLI tool, not network input)
+	f, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600) // #nosec G304 -- operator-configured key path under baseDir (local CLI tool, not network input)
+	if err != nil {
+		return err
+	}
+	if _, werr := f.Write(data); werr != nil {
+		_ = f.Close()
+		return werr
+	}
+	if serr := f.Sync(); serr != nil {
+		_ = f.Close()
+		return serr
+	}
+	if cerr := f.Close(); cerr != nil {
+		return cerr
+	}
+	return securefiles.SyncDir(filepath.Dir(dst))
 }
 
 // restoreBackup copies the backup back over the active DEK path. Best-effort: logs

--- a/internal/crypto/kms_provider.go
+++ b/internal/crypto/kms_provider.go
@@ -81,7 +81,10 @@ func (p *KMSKeyProvider) generateAndWrap(ctx context.Context) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("%s key provider: KMS encrypt failed: %w", p.name, err)
 	}
-	if err := securefiles.SecureWriteFile(p.baseDir, p.wrappedKeyPath, wrapped, 0600); err != nil {
+	// Durably persist the wrapped KEK before returning it: the caller will wrap
+	// the DEK under this KEK, and the wrapped-KEK blob is the only way to recover
+	// it on restart. A non-durable write lost to a crash would orphan the DEK.
+	if err := securefiles.SecureWriteFileSync(p.baseDir, p.wrappedKeyPath, wrapped, 0600); err != nil {
 		return nil, fmt.Errorf("%s key provider: persist wrapped KEK: %w", p.name, err)
 	}
 	return kek, nil

--- a/internal/crypto/password_provider.go
+++ b/internal/crypto/password_provider.go
@@ -60,7 +60,7 @@ func (p *PasswordKeyProvider) ensureSalt() ([]byte, error) {
 		if _, err := io.ReadFull(rand.Reader, salt); err != nil {
 			return nil, fmt.Errorf("failed to generate salt: %w", err)
 		}
-		if err := securefiles.SecureWriteFile(p.baseDir, p.saltPath, salt, 0600); err != nil {
+		if err := securefiles.SecureWriteFileSync(p.baseDir, p.saltPath, salt, 0600); err != nil {
 			return nil, fmt.Errorf("failed to write salt: %w", err)
 		}
 		return salt, nil

--- a/internal/encryption/keymanager_lifecycle.go
+++ b/internal/encryption/keymanager_lifecycle.go
@@ -126,7 +126,7 @@ func (km *KeyManager) ensureSaltExists() ([]byte, error) {
 		if _, err := io.ReadFull(rand.Reader, salt); err != nil {
 			return nil, fmt.Errorf("failed to generate salt: %w", err)
 		}
-		if err := securefiles.SecureWriteFile(km.baseDir, km.saltPath, salt, 0600); err != nil {
+		if err := securefiles.SecureWriteFileSync(km.baseDir, km.saltPath, salt, 0600); err != nil {
 			return nil, fmt.Errorf("failed to write salt: %w", err)
 		}
 		fmt.Printf("✅ Generated new KEK salt at %s\n", saltFullPath)
@@ -158,7 +158,7 @@ func (km *KeyManager) ensureWrappedDEKExists(kek []byte) error {
 		if err != nil {
 			return fmt.Errorf("failed to wrap DEK: %w", err)
 		}
-		if err := securefiles.SecureWriteFile(km.baseDir, km.dekPath, wrapped, 0600); err != nil {
+		if err := securefiles.SecureWriteFileSync(km.baseDir, km.dekPath, wrapped, 0600); err != nil {
 			return fmt.Errorf("failed to write wrapped DEK: %w", err)
 		}
 		fmt.Printf("✅ Generated and wrapped new DEK at %s\n", dekFullPath)

--- a/internal/encryption/keymanager_rewrap.go
+++ b/internal/encryption/keymanager_rewrap.go
@@ -51,8 +51,13 @@ func (km *KeyManager) RewrapDEK(newProvider crypto.KeyProvider) error {
 		return fmt.Errorf("re-wrap DEK: wrap DEK with new KEK: %w", err)
 	}
 
+	// Durability is load-bearing here: this is the one operation where the OLD
+	// wrapping key is about to be retired, so the new wrapped DEK must be on disk
+	// (not just in the page cache) before — and the rename durable after — we
+	// declare success. A non-durable write that is lost to a power failure after
+	// the operator retires the old KEK would orphan all ciphertext irreversibly.
 	pendingDEKPath := km.dekPath + ".pending"
-	if err := securefiles.SecureWriteFile(km.baseDir, pendingDEKPath, wrapped, 0600); err != nil {
+	if err := securefiles.SecureWriteFileSync(km.baseDir, pendingDEKPath, wrapped, 0600); err != nil {
 		return fmt.Errorf("re-wrap DEK: write pending DEK: %w", err)
 	}
 	pendingPath := filepath.Join(km.baseDir, pendingDEKPath)
@@ -60,6 +65,9 @@ func (km *KeyManager) RewrapDEK(newProvider crypto.KeyProvider) error {
 	if err := os.Rename(pendingPath, activePath); err != nil {
 		_ = os.Remove(pendingPath)
 		return fmt.Errorf("re-wrap DEK: promote pending DEK to active: %w", err)
+	}
+	if err := securefiles.SyncDir(filepath.Dir(activePath)); err != nil {
+		return fmt.Errorf("re-wrap DEK: fsync key directory after promote: %w", err)
 	}
 	return nil
 }

--- a/internal/encryption/keymanager_rotation.go
+++ b/internal/encryption/keymanager_rotation.go
@@ -50,7 +50,7 @@ func (km *KeyManager) RotateDEKWithSweep(passphrase string, sweepFn func(oldSvc,
 		wipeBytes(newDEK)
 		return fmt.Errorf("failed to wrap new DEK: %w", err)
 	}
-	if err := securefiles.SecureWriteFile(km.baseDir, pendingDEKPath, wrapped, 0600); err != nil {
+	if err := securefiles.SecureWriteFileSync(km.baseDir, pendingDEKPath, wrapped, 0600); err != nil {
 		wipeBytes(newDEK)
 		return fmt.Errorf("failed to write pending DEK: %w", err)
 	}
@@ -81,6 +81,12 @@ func (km *KeyManager) RotateDEKWithSweep(passphrase string, sweepFn func(oldSvc,
 		wipeBytes(newDEK)
 		_ = os.Remove(pendingPath)
 		return fmt.Errorf("failed to promote pending DEK to active: %w", err)
+	}
+	// Make the rename durable before deleting the old-DEK backups below — else a
+	// crash could lose the new DEK while the backups are already gone.
+	if err := securefiles.SyncDir(filepath.Dir(activePath)); err != nil {
+		wipeBytes(newDEK)
+		return fmt.Errorf("failed to fsync key directory after promote: %w", err)
 	}
 
 	wipeBytes(km.currentDEK)
@@ -144,7 +150,9 @@ func (km *KeyManager) RotateDEK(passphrase string) error {
 	if err != nil {
 		return fmt.Errorf("failed to read old DEK for backup: %w", err)
 	}
-	if err := securefiles.SecureWriteFile(km.baseDir, oldDEKPath, oldWrapped, 0600); err != nil {
+	// Durable backup BEFORE overwriting the active DEK below, so a crash always
+	// leaves at least one recoverable wrapped DEK on disk.
+	if err := securefiles.SecureWriteFileSync(km.baseDir, oldDEKPath, oldWrapped, 0600); err != nil {
 		return fmt.Errorf("failed to backup old DEK: %w", err)
 	}
 
@@ -152,7 +160,7 @@ func (km *KeyManager) RotateDEK(passphrase string) error {
 	if err != nil {
 		return fmt.Errorf("failed to wrap new DEK: %w", err)
 	}
-	if err := securefiles.SecureWriteFile(km.baseDir, km.dekPath, wrapped, 0600); err != nil {
+	if err := securefiles.SecureWriteFileSync(km.baseDir, km.dekPath, wrapped, 0600); err != nil {
 		return fmt.Errorf("failed to write new wrapped DEK: %w", err)
 	}
 

--- a/internal/securefiles/securefiles.go
+++ b/internal/securefiles/securefiles.go
@@ -55,21 +55,77 @@ func SafeReadFile(baseDir, filePath string) ([]byte, error) {
 	return os.ReadFile(cleanPath)
 }
 
+// resolveInside joins and cleans baseDir/path and verifies the result stays
+// inside baseDir, returning the validated absolute-ish clean path.
+func resolveInside(baseDir, path string) (string, error) {
+	cleanPath := filepath.Clean(filepath.Join(baseDir, path))
+	ok, err := isPathInsideBase(baseDir, cleanPath)
+	if err != nil {
+		return "", fmt.Errorf("path validation error: %w", err)
+	}
+	if !ok {
+		return "", fmt.Errorf("access denied: file %q is outside of %q", cleanPath, baseDir)
+	}
+	return cleanPath, nil
+}
+
 // SecureWriteFile writes data to filepath.Join(baseDir, path), validating
 // that the resolved path remains inside baseDir.
 func SecureWriteFile(baseDir, path string, data []byte, perm os.FileMode) error {
-	fullPath := filepath.Join(baseDir, path)
-	cleanPath := filepath.Clean(fullPath)
-
-	ok, err := isPathInsideBase(baseDir, cleanPath)
+	cleanPath, err := resolveInside(baseDir, path)
 	if err != nil {
-		return fmt.Errorf("path validation error: %w", err)
+		return err
 	}
-	if !ok {
-		return fmt.Errorf("access denied: file %q is outside of %q", cleanPath, baseDir)
-	}
-
 	return os.WriteFile(cleanPath, data, perm)
+}
+
+// SecureWriteFileSync writes data like SecureWriteFile but fsyncs the file before
+// returning, so the bytes are durable on disk rather than merely in the page
+// cache. Use it for key material (DEK/KEK/salt) whose loss is unrecoverable: a
+// non-durable write can be lost on power failure even after the call returns,
+// which — combined with overwriting the previous key — risks orphaning all
+// ciphertext. Pair it with SyncDir after any rename to make the rename durable
+// too. The file mode is enforced even if the file pre-existed with a looser mode.
+func SecureWriteFileSync(baseDir, path string, data []byte, perm os.FileMode) error {
+	cleanPath, err := resolveInside(baseDir, path)
+	if err != nil {
+		return err
+	}
+	f, err := os.OpenFile(cleanPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, perm)
+	if err != nil {
+		return err
+	}
+	// O_TRUNC keeps a pre-existing file's mode; force the intended perms.
+	if cerr := f.Chmod(perm); cerr != nil {
+		_ = f.Close()
+		return cerr
+	}
+	if _, werr := f.Write(data); werr != nil {
+		_ = f.Close()
+		return werr
+	}
+	if serr := f.Sync(); serr != nil {
+		_ = f.Close()
+		return serr
+	}
+	return f.Close()
+}
+
+// SyncDir fsyncs the directory dirPath so a preceding file create or rename
+// within it is durable (the directory entry is flushed). On platforms where
+// opening a directory for sync is unsupported the error is returned to the
+// caller to decide; on Linux/macOS this is the standard create→fsync(file)→
+// rename→fsync(dir) durability pattern.
+func SyncDir(dirPath string) error {
+	d, err := os.Open(dirPath) // #nosec G304 -- caller-controlled key directory, not network input
+	if err != nil {
+		return err
+	}
+	if serr := d.Sync(); serr != nil {
+		_ = d.Close()
+		return serr
+	}
+	return d.Close()
 }
 
 // FixFilePerms verifies file permissions and ownership.

--- a/internal/securefiles/securefiles.go
+++ b/internal/securefiles/securefiles.go
@@ -91,7 +91,7 @@ func SecureWriteFileSync(baseDir, path string, data []byte, perm os.FileMode) er
 	if err != nil {
 		return err
 	}
-	f, err := os.OpenFile(cleanPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, perm)
+	f, err := os.OpenFile(cleanPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, perm) // #nosec G304 -- cleanPath validated inside baseDir by resolveInside
 	if err != nil {
 		return err
 	}

--- a/internal/securefiles/securefiles_test.go
+++ b/internal/securefiles/securefiles_test.go
@@ -47,6 +47,52 @@ func TestSecureWriteAndReadRoundTrip(t *testing.T) {
 	assert.Equal(t, want, got)
 }
 
+func TestSecureWriteFileSyncRoundTripAndPerms(t *testing.T) {
+	base := t.TempDir()
+	want := []byte("durable-key-bytes")
+	require.NoError(t, SecureWriteFileSync(base, "dek.key", want, 0600))
+
+	info, err := os.Stat(filepath.Join(base, "dek.key"))
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0600), info.Mode().Perm())
+
+	got, err := SafeReadFile(base, "dek.key")
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
+}
+
+func TestSecureWriteFileSyncEnforcesPermsOnExistingFile(t *testing.T) {
+	base := t.TempDir()
+	// A pre-existing file with looser perms must be tightened to the requested mode
+	// (O_TRUNC alone keeps the old mode; the explicit Chmod fixes it).
+	require.NoError(t, os.WriteFile(filepath.Join(base, "dek.key"), []byte("old"), 0644))
+	require.NoError(t, SecureWriteFileSync(base, "dek.key", []byte("new"), 0600))
+
+	info, err := os.Stat(filepath.Join(base, "dek.key"))
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0600), info.Mode().Perm())
+	got, err := SafeReadFile(base, "dek.key")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("new"), got)
+}
+
+func TestSecureWriteFileSyncRejectsTraversal(t *testing.T) {
+	base := t.TempDir()
+	err := SecureWriteFileSync(base, "../escape.key", []byte("x"), 0600)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "access denied")
+	_, statErr := os.Stat(filepath.Join(filepath.Dir(base), "escape.key"))
+	assert.True(t, os.IsNotExist(statErr))
+}
+
+func TestSyncDir(t *testing.T) {
+	base := t.TempDir()
+	// A real directory syncs without error.
+	require.NoError(t, SyncDir(base))
+	// A missing directory surfaces the open error rather than silently passing.
+	require.Error(t, SyncDir(filepath.Join(base, "does-not-exist")))
+}
+
 func TestSafeReadFileRejectsTraversal(t *testing.T) {
 	base := t.TempDir()
 	// Plant a file outside the base to make the test meaningful.


### PR DESCRIPTION
## What & why

An internal adversarial audit of the newer crypto subsystems found a **HIGH data-loss gap** in key-material persistence. Every wrapped-DEK / KEK-blob / salt write went through `os.WriteFile`, which leaves bytes in the **page cache** — not durable when the call returns. A power failure can lose them.

For most key writes this is benign (they fail closed: no data yet, or a backup survives). But **`migrate-provider`** explicitly invites the operator to retire the **old KEK** afterward. If the new wrapped DEK is lost to a crash *after* the old wrapping key is gone, **all ciphertext is orphaned irreversibly** — and the CLI had already printed *"✅ re-wrapped and verified"* because the verify step read back through the same page cache.

## Fix

Add two `securefiles` primitives and route every unrecoverable key-material write through them:
- **`SecureWriteFileSync`** — open → write → **fsync** → close, keeping the existing path-traversal guard and enforcing `0600` even on a pre-existing looser file.
- **`SyncDir`** — fsync a directory so a preceding `rename` is durable.

Applied to:
- **migration** — `RewrapDEK` pending write + post-rename dir fsync; the `migrate-provider` backup copy is fsync'd (it's the rollback target).
- **rotation** — `RotateDEKWithSweep` pending write + post-rename dir fsync *before* deleting old-DEK backups; legacy `RotateDEK` durable backup + active write.
- **first run** — wrapped DEK + KEK salt; KMS wrapped-KEK blob; password-provider salt.

The standard **write → fsync(file) → rename → fsync(dir)** pattern now holds on every key path. The data path and on-disk formats are unchanged.

## Tests

Existing rewrap/rotation **e2e tests (which round-trip the DEK) still pass** — proving the data path is intact. New `securefiles` tests cover the sync write (round-trip, perms enforced on a pre-existing looser file, traversal rejected) and `SyncDir`. golangci-lint 0 issues · gitleaks clean · full suite green.

The same audit surfaced two MEDIUM dynamic-secrets findings (orphaned role on failed cleanup-revoke; MySQL/MongoDB TTL unenforced when the default-off sweeper is disabled) — recorded separately in the backlog, not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)