### PR TITLE
fix(dynamic): close two lease-lifecycle fail-opens (audit follow-up)

### DIFF
--- a/docs/adr-035-dynamic-secrets.md
+++ b/docs/adr-035-dynamic-secrets.md
@@ -143,6 +143,23 @@ expiry). The MongoDB driver (`go.mongodb.org/mongo-driver`, pure Go) links into 
 server; no cloud SDK is added. Keyorix now mints dynamic credentials for
 PostgreSQL, MySQL, **or** MongoDB.
 
+### Lease-lifecycle fail-open fixes (hardening, 2026-06-12)
+
+An internal audit surfaced two fail-opens, both fixed:
+
+- **TTL enforced or refuse to issue.** Backends without a DB-level expiry
+  (`SupportsNativeExpiry() == false`: MySQL, MongoDB) rely entirely on the
+  auto-revoke sweeper. `IssueLease` now refuses to mint from such a backend when
+  `dynamic_secrets.sweep_enabled` is off — otherwise the credential's advertised
+  TTL would never be enforced (it would live forever on the target). PostgreSQL
+  (`VALID UNTIL`) is unaffected and issues regardless.
+- **No invisible orphans.** If a post-mint step fails (encryption / token-gen /
+  lease persistence), the just-minted role is dropped; if that drop *also* fails,
+  a `revoke_failed` lease row is now recorded (capturing the role name) and
+  audited, so the orphaned live credential is visible to an operator instead of
+  being permanent and untrackable (every list/sweep/revoke path keys off the lease
+  table).
+
 ## Deferred (updated)
 
 Cloud-IAM backends (AWS STS / GCP / Azure), which need a non-DSN credential shape

--- a/internal/core/dynamic_secrets.go
+++ b/internal/core/dynamic_secrets.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/keyorixhq/keyorix/internal/dynamic"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
@@ -103,6 +104,13 @@ func (c *KeyorixCore) IssueLease(ctx context.Context, configID uint, ttlSeconds 
 	if err != nil {
 		return nil, err
 	}
+	// A backend with no DB-level expiry (MySQL/MongoDB) relies entirely on the
+	// auto-revoke sweeper to enforce the lease TTL. Issuing from it while the
+	// sweeper is disabled would mint a credential whose advertised expiry is never
+	// enforced — a false promise — so refuse and point the operator at the fix.
+	if !engine.SupportsNativeExpiry() && !c.dynamicSweepEnabled {
+		return nil, fmt.Errorf("cannot issue from the %s backend while the auto-revoke sweeper is disabled: its lease TTL is enforced only by the sweeper, so the credential would never expire — enable dynamic_secrets.sweep_enabled", cfg.BackendType)
+	}
 	adminDSN, err := c.decryptAuthSecret(cfg.AdminDSNEnc, cfg.AdminDSNMeta)
 	if err != nil {
 		return nil, fmt.Errorf("failed to decrypt admin DSN: %w", err)
@@ -117,13 +125,13 @@ func (c *KeyorixCore) IssueLease(ctx context.Context, configID uint, ttlSeconds 
 	credEnc, credMeta, err := c.encryptAuthSecret(string(credJSON))
 	if err != nil {
 		// The role exists on the target — revoke it so we don't leak it.
-		_ = engine.Revoke(ctx, adminDSN, roleName)
+		c.cleanupOrphanedRole(ctx, cfg, engine, adminDSN, roleName, userID)
 		return nil, fmt.Errorf("failed to encrypt credential: %w", err)
 	}
 
 	leaseID, err := generateSecureToken()
 	if err != nil {
-		_ = engine.Revoke(ctx, adminDSN, roleName)
+		c.cleanupOrphanedRole(ctx, cfg, engine, adminDSN, roleName, userID)
 		return nil, err
 	}
 	expiresAt := c.now().Add(ttl)
@@ -140,7 +148,7 @@ func (c *KeyorixCore) IssueLease(ctx context.Context, configID uint, ttlSeconds 
 		ExpiresAt:      expiresAt,
 	})
 	if err != nil {
-		_ = engine.Revoke(ctx, adminDSN, roleName)
+		c.cleanupOrphanedRole(ctx, cfg, engine, adminDSN, roleName, userID)
 		return nil, fmt.Errorf("failed to persist lease: %w", err)
 	}
 	uid := userID
@@ -148,6 +156,49 @@ func (c *KeyorixCore) IssueLease(ctx context.Context, configID uint, ttlSeconds 
 	c.writeAuditEventFull(ctx, "dynamic_lease.issued", &uid, nil, &pid, "",
 		fmt.Sprintf("issued dynamic credential (lease=%s, config=%q, ttl=%s)", lease.LeaseID, cfg.Name, ttl))
 	return &IssuedLease{LeaseID: lease.LeaseID, Username: cred.Username, Password: cred.Password, ExpiresAt: expiresAt}, nil
+}
+
+// cleanupOrphanedRole drops a just-minted role after a post-mint failure aborts the
+// issue (encryption / token-gen / lease-persist failed). If the drop itself fails,
+// the role would otherwise be a LIVE credential with no lease row — invisible to
+// every list/sweep/revoke path (all keyed off the lease table) and therefore
+// permanent and undrop-able. To keep it visible, we record a revoke_failed lease
+// capturing the role name and audit it, mirroring RevokeLease's failure handling.
+func (c *KeyorixCore) cleanupOrphanedRole(ctx context.Context, cfg *models.DynamicSecretConfig, engine dynamic.CredentialEngine, adminDSN, roleName string, userID uint) {
+	if err := engine.Revoke(ctx, adminDSN, roleName); err == nil {
+		return // role dropped cleanly — nothing to track
+	} else {
+		now := c.now()
+		leaseID, gerr := generateSecureToken()
+		if gerr != nil {
+			leaseID = "orphan-" + roleName // last-resort id so the row still persists
+		}
+		// No credential is stored — the issue was aborted; only the role name
+		// matters so an operator can drop it. CredentialEnc is intentionally empty.
+		_, _ = c.storage.CreateDynamicSecretLease(ctx, &models.DynamicSecretLease{
+			ConfigID:      cfg.ID,
+			LeaseID:       leaseID,
+			ProjectID:     cfg.ProjectID,
+			EnvironmentID: cfg.EnvironmentID,
+			RoleName:      roleName,
+			Status:        "revoke_failed",
+			RevokeError:   "orphaned on aborted issue: " + err.Error(),
+			IssuedAt:      now,
+			ExpiresAt:     now,
+			RevokedAt:     &now,
+		})
+		var uidPtr *uint
+		if userID != 0 {
+			uidPtr = &userID
+		}
+		var pidPtr *uint
+		if cfg.ProjectID != 0 {
+			pid := cfg.ProjectID
+			pidPtr = &pid
+		}
+		c.writeAuditEventFull(ctx, "dynamic_lease.revoke_failed", uidPtr, nil, pidPtr, "",
+			fmt.Sprintf("FAILED to clean up orphaned dynamic role %s after an aborted issue (config=%q): %v — drop it manually", roleName, cfg.Name, err))
+	}
 }
 
 // RevokeLease revokes a lease on the target and marks it revoked (or

--- a/internal/core/dynamic_secrets_test.go
+++ b/internal/core/dynamic_secrets_test.go
@@ -30,7 +30,10 @@ func newDynamicTestCore(t *testing.T) (*KeyorixCore, *gorm.DB, *dynamic.FakeEngi
 	enc := encryption.NewService(&config.EncryptionConfig{Enabled: true, DEKPath: "dek.key", SaltPath: "kek.salt"}, t.TempDir())
 	require.NoError(t, enc.Initialize("test-passphrase"))
 
-	fake := &dynamic.FakeEngine{}
+	// The default config in these tests is a "postgres" target, so the fake mimics a
+	// backend with DB-level expiry (VALID UNTIL) — issuing does not require the
+	// sweeper. Tests that exercise the no-native-expiry gate flip NativeExpiry off.
+	fake := &dynamic.FakeEngine{NativeExpiry: true}
 	fixed := time.Date(2026, 6, 12, 10, 0, 0, 0, time.UTC)
 	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: func() time.Time { return fixed }, passwordPolicy: DefaultPasswordPolicy()}
 	c.SetAuthEncryptor(enc)
@@ -256,4 +259,54 @@ func TestDynamicSecrets_RealFactoryValidatesBackend(t *testing.T) {
 		Name: "bad", ProjectID: 1, BackendType: "redis", AdminDSN: "x",
 	})
 	require.Error(t, err, "an unsupported backend must be rejected at config creation")
+}
+
+// A backend without DB-level expiry (MySQL/MongoDB) must not issue while the
+// auto-revoke sweeper is disabled — otherwise the lease TTL is never enforced.
+func TestDynamicSecrets_IssueRequiresSweeperForNoExpiryBackend(t *testing.T) {
+	c, _, fake, _ := newDynamicTestCore(t)
+	ctx := context.Background()
+	cfg := mkConfig(t, c, ctx)
+	fake.NativeExpiry = false // mimic MySQL/MongoDB
+
+	// Sweeper disabled (the default): refuse, and mint nothing.
+	_, err := c.IssueLease(ctx, cfg.ID, 0, 7)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "sweep_enabled")
+	assert.Empty(t, fake.Issued, "no role is minted when the issue is refused")
+
+	// Enable the sweeper → issuing proceeds.
+	c.SetDynamicSweepEnabled(true)
+	issued, err := c.IssueLease(ctx, cfg.ID, 0, 7)
+	require.NoError(t, err)
+	assert.NotEmpty(t, issued.LeaseID)
+	assert.Len(t, fake.Issued, 1)
+}
+
+// A failed cleanup-revoke after an aborted issue must leave a visible
+// revoke_failed lease (so the orphaned target role is not silently permanent),
+// while a clean drop records nothing.
+func TestDynamicSecrets_CleanupOrphanedRole(t *testing.T) {
+	c, _, fake, _ := newDynamicTestCore(t)
+	ctx := context.Background()
+	cfg := mkConfig(t, c, ctx)
+
+	t.Run("clean drop leaves no trace", func(t *testing.T) {
+		c.cleanupOrphanedRole(ctx, cfg, fake, adminDSNPlain, "kx_orphan_ok", 7)
+		assert.Contains(t, fake.Revoked, "kx_orphan_ok")
+		leases, err := c.ListDynamicSecretLeases(ctx, cfg.ID)
+		require.NoError(t, err)
+		assert.Empty(t, leases, "a clean drop records no lease")
+	})
+
+	t.Run("failed drop records a revoke_failed lease", func(t *testing.T) {
+		fake.FailRevoke = true
+		c.cleanupOrphanedRole(ctx, cfg, fake, adminDSNPlain, "kx_orphan_stuck", 7)
+		leases, err := c.ListDynamicSecretLeases(ctx, cfg.ID)
+		require.NoError(t, err)
+		require.Len(t, leases, 1)
+		assert.Equal(t, "revoke_failed", leases[0].Status)
+		assert.Equal(t, "kx_orphan_stuck", leases[0].RoleName)
+		assert.Contains(t, leases[0].RevokeError, "orphaned")
+	})
 }

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -25,20 +25,25 @@ import (
 //   - dashboard.go     — Dashboard stats and activity feed
 //   - catalog.go       — Project / environment passthrough
 type KeyorixCore struct {
-	storage        storage.Storage
-	encryption     *encryption.SecretEncryption
+	storage    storage.Storage
+	encryption *encryption.SecretEncryption
 	// authEncryptor reversibly encrypts auth secrets that cannot be hashed (the
 	// TOTP MFA shared secret). nil or disabled = passthrough (store plaintext),
 	// consistent with the rest of the product when encryption is off. Wired from
 	// the initialised encryption.Service at server startup via SetAuthEncryptor.
-	authEncryptor  *encryption.Service
+	authEncryptor *encryption.Service
 	// dynamicEngineFactory resolves a dynamic-secrets credential engine by backend
 	// type (ADR-035). nil = the real dynamic.New; overridable in tests with a fake.
 	dynamicEngineFactory func(string) (dynamic.CredentialEngine, error)
+	// dynamicSweepEnabled mirrors config dynamic_secrets.sweep_enabled. Backends
+	// without DB-level expiry (MySQL/MongoDB) rely entirely on the sweeper to
+	// enforce a lease's TTL, so IssueLease refuses to mint from them when it is off
+	// (the credential would otherwise never expire). Set via SetDynamicSweepEnabled.
+	dynamicSweepEnabled bool
 	// webauthnRP is the WebAuthn relying party (ADR-036); nil = WebAuthn disabled.
 	// Set from config at startup via SetWebAuthn.
-	webauthnRP *webauthn.WebAuthn
-	now                  func() time.Time // For testability
+	webauthnRP     *webauthn.WebAuthn
+	now            func() time.Time // For testability
 	passwordPolicy PasswordPolicy
 	auditForwarder AuditForwarder
 	// oidcVerifier verifies federated machine-identity JWTs (ADR-031); nil = OIDC
@@ -138,6 +143,13 @@ func (c *KeyorixCore) decryptAuthSecret(ct, _ []byte) (string, error) {
 // inject a fake engine).
 func (c *KeyorixCore) SetDynamicEngineFactory(f func(string) (dynamic.CredentialEngine, error)) {
 	c.dynamicEngineFactory = f
+}
+
+// SetDynamicSweepEnabled records whether the auto-revoke sweeper is running
+// (config dynamic_secrets.sweep_enabled). Wired at startup so IssueLease can refuse
+// to mint a credential from a backend whose TTL only the sweeper would enforce.
+func (c *KeyorixCore) SetDynamicSweepEnabled(enabled bool) {
+	c.dynamicSweepEnabled = enabled
 }
 
 // dynamicEngine resolves an engine for a backend type via the factory (or the

--- a/internal/dynamic/engine.go
+++ b/internal/dynamic/engine.go
@@ -31,6 +31,11 @@ type CredentialEngine interface {
 	// DB-level expiry (PostgreSQL VALID UNTIL). Backends without one (MySQL) make it
 	// a no-op — the lease's new expiry is enforced by the auto-revoke sweep.
 	Renew(ctx context.Context, adminDSN, roleName string, expiresAt time.Time) error
+	// SupportsNativeExpiry reports whether the backend enforces the lease TTL at the
+	// database level (PostgreSQL VALID UNTIL). A backend that returns false relies
+	// ENTIRELY on the auto-revoke sweeper to enforce expiry, so issuing from it with
+	// the sweeper disabled would mint a credential whose TTL is never enforced.
+	SupportsNativeExpiry() bool
 	BackendType() string
 }
 
@@ -70,16 +75,18 @@ func randString(n int) (string, error) {
 // FakeEngine is an in-memory engine for tests: it records issued and revoked
 // roles without touching any real database.
 type FakeEngine struct {
-	mu         sync.Mutex
-	Issued     []string
-	Revoked    []string
-	Renewed    []string
-	FailIssue  bool
-	FailRevoke bool
-	FailRenew  bool
+	mu           sync.Mutex
+	Issued       []string
+	Revoked      []string
+	Renewed      []string
+	FailIssue    bool
+	FailRevoke   bool
+	FailRenew    bool
+	NativeExpiry bool // when true, mimics a backend with DB-level TTL (e.g. Postgres)
 }
 
-func (f *FakeEngine) BackendType() string { return "fake" }
+func (f *FakeEngine) BackendType() string        { return "fake" }
+func (f *FakeEngine) SupportsNativeExpiry() bool { return f.NativeExpiry }
 
 func (f *FakeEngine) Issue(_ context.Context, _, _ string, _ time.Duration) (Credential, string, error) {
 	f.mu.Lock()

--- a/internal/dynamic/mongodb.go
+++ b/internal/dynamic/mongodb.go
@@ -34,6 +34,10 @@ type MongoEngine struct{}
 
 func (e *MongoEngine) BackendType() string { return "mongodb" }
 
+// SupportsNativeExpiry is false: MongoDB users have no native expiry, so lease
+// expiry is enforced only by the auto-revoke sweeper (which must be enabled).
+func (e *MongoEngine) SupportsNativeExpiry() bool { return false }
+
 // mongoAuthDB is the database new users are created in (their authentication db).
 // Roles within the template may still target any database.
 const mongoAuthDB = "admin"

--- a/internal/dynamic/mysql.go
+++ b/internal/dynamic/mysql.go
@@ -26,6 +26,10 @@ type MySQLEngine struct{}
 
 func (e *MySQLEngine) BackendType() string { return "mysql" }
 
+// SupportsNativeExpiry is false: MySQL users have no VALID UNTIL, so lease expiry
+// is enforced only by the auto-revoke sweeper (which must be enabled).
+func (e *MySQLEngine) SupportsNativeExpiry() bool { return false }
+
 // mysqlHost is the host part of the created account ('user'@'%'). Restricting it
 // further is a deployment concern best expressed via the creation template/grants.
 const mysqlHost = "%"

--- a/internal/dynamic/postgres.go
+++ b/internal/dynamic/postgres.go
@@ -15,6 +15,10 @@ type PostgresEngine struct{}
 
 func (e *PostgresEngine) BackendType() string { return "postgres" }
 
+// SupportsNativeExpiry is true: PostgreSQL roles carry a VALID UNTIL, so the
+// credential disables itself at expiry even without the auto-revoke sweeper.
+func (e *PostgresEngine) SupportsNativeExpiry() bool { return true }
+
 // Issue creates a `kx_dyn_<random>` LOGIN role with a random password and a
 // VALID UNTIL of now+ttl, then runs the operator's creation template ({{name}} →
 // the role). Role name and password are crypto/rand from an identifier/quote-safe

--- a/server/main.go
+++ b/server/main.go
@@ -243,6 +243,11 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 	// an install without a session block behaves exactly as before.
 	coreService.SetSessionTTLs(cfg.Session.GetAccessTTL(), cfg.Session.GetAbsoluteTTL())
 
+	// Tell core whether the auto-revoke sweeper runs (started below), so IssueLease
+	// refuses to mint from backends whose lease TTL only the sweeper enforces
+	// (MySQL/MongoDB) when it is disabled — otherwise the credential never expires.
+	coreService.SetDynamicSweepEnabled(cfg.DynamicSecrets.SweepEnabled)
+
 	// Wire the credential-delivery channel (ADR-028). New selects out-of-band/SMTP/
 	// log from the configured mode and fails loud on a bad mode (e.g. smtp with no
 	// host), so a misconfigured install does not silently drop setup links.


### PR DESCRIPTION
Follow-up to the internal dynamic-secrets audit (the engines were clean on injection/crypto/authz/at-rest; these are the two **MEDIUM lease-lifecycle fail-opens** it found).

## 1. TTL enforced, or refuse to issue

MySQL and MongoDB have **no DB-level expiry** — a lease's TTL is enforced **only** by the opt-in, default-off auto-revoke sweeper. A default deployment could register a MySQL/Mongo target and issue a credential whose advertised `expires_at` is **never enforced** — it lives forever on the target (a false TTL promise).

- Add `CredentialEngine.SupportsNativeExpiry()` — `postgres` true, `mysql`/`mongodb` false.
- Add a core `dynamicSweepEnabled` flag wired from `dynamic_secrets.sweep_enabled` at startup.
- `IssueLease` now **refuses to mint** from a no-native-expiry backend while the sweeper is disabled, with a clear error pointing at the config. PostgreSQL (`VALID UNTIL`) issues regardless.

## 2. No invisible orphaned roles

When a post-mint step (encryption / token-gen / lease persistence) aborts an issue, the just-minted role was dropped via `_ = engine.Revoke(...)`, **discarding the error**. If that drop *also* failed, a **live credential existed on the target with no lease row** — invisible to every list/sweep/revoke path (all keyed off the lease table), so permanent and undrop-able.

- New `core.cleanupOrphanedRole` records a `revoke_failed` lease (capturing the role name) and audits it on cleanup failure, so an operator can see and drop the orphan; a clean drop records nothing.

## Tests

`IssueLease` refused for a no-native-expiry backend with the sweeper off / allowed once enabled / no role minted on refusal; `cleanupOrphanedRole` records a `revoke_failed` lease on a failed drop and nothing on a clean drop. Existing suite (postgres-shaped fake → `NativeExpiry` true) unchanged. golangci-lint 0 · gitleaks clean · gofmt clean · full suite green. ADR-035 updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)