### PR TITLE
release: prep v0.13.1 (CHANGELOG + Helm chart 0.13.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,31 @@
 All notable changes to Keyorix are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## v0.13.1 — 2026-06-12
+
+Security/correctness fixes from an internal audit of the credential & crypto
+subsystems. No new features; no config or schema changes.
+
+### Fixed
+- **Crash-durable key-material writes** (ADR-041) — every write of unrecoverable
+  key material (the wrapped DEK on first run / rotation / KEK-provider migration,
+  the KMS-wrapped KEK blob, and the KEK salt) is now `fsync`'d before returning,
+  and each promote-`rename` is followed by a directory `fsync`. Previously these
+  used `os.WriteFile`, leaving the bytes in the page cache; a power failure after
+  `migrate-provider` reported success — and after the operator retired the old KEK
+  — could lose the new wrapped DEK and orphan all ciphertext irreversibly. The
+  data path and on-disk formats are unchanged. ([#131])
+- **Dynamic-secrets lease fail-opens** (ADR-035) — (1) issuing from a backend with
+  no database-level expiry (MySQL, MongoDB) is now refused while the auto-revoke
+  sweeper is disabled, so a lease's advertised TTL is always enforced rather than
+  silently never expiring; (2) if cleaning up a just-minted role after an aborted
+  issue fails, a `revoke_failed` lease is recorded and audited so the orphaned
+  credential is visible to an operator instead of being permanent and
+  untrackable. ([#132])
+
+[#131]: https://github.com/keyorixhq/keyorix/pull/131
+[#132]: https://github.com/keyorixhq/keyorix/pull/132
+
 ## v0.13.0 — 2026-06-12
 
 ### Added

--- a/deploy/helm/keyorix/Chart.yaml
+++ b/deploy/helm/keyorix/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix
 description: Self-hosted Keyorix secrets manager (API server + web UI + PostgreSQL)
 type: application
 # Chart version — bump on chart changes.
-version: 0.13.0
+version: 0.13.1
 # The Keyorix app version this chart deploys by default (the image tag).
-appVersion: "0.13.0"
+appVersion: "0.13.1"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix


### PR DESCRIPTION
Patch release **v0.13.1** — security/correctness fixes from the internal credential & crypto subsystem audit. No new features; no config or schema changes.

- **Crash-durable key-material writes** ([#131]) — fsync the wrapped DEK / KMS KEK blob / salt and the parent dir after rename, so a crash during `migrate-provider` (after the old KEK is retired) can't orphan all ciphertext.
- **Dynamic-secrets lease fail-opens** ([#132]) — refuse to issue from a no-native-expiry backend (MySQL/Mongo) while the sweeper is off; record a `revoke_failed` lease when an orphan cleanup-drop fails.

CHANGELOG entry + Helm chart `version`/`appVersion` → 0.13.1. Tag `v0.13.1` after merge fires the release + chart + image pipelines.

[#131]: https://github.com/keyorixhq/keyorix/pull/131
[#132]: https://github.com/keyorixhq/keyorix/pull/132

🤖 Generated with [Claude Code](https://claude.com/claude-code)