### PR TITLE
fix(auth): close ADR-028 provisioning privesc + evict sessions on password reset

### DIFF
--- a/docs/adr-028-credential-delivery.md
+++ b/docs/adr-028-credential-delivery.md
@@ -187,6 +187,27 @@ In out-of-band mode every one of these returns the link as CLI/JSON output for t
 - **Inbound email (reply-to-approve).** Out of scope. Revisit only with a concrete customer workflow.
 - **Per-user email notification preferences.** This ADR delivers *credentials* (always sent — you cannot opt out of getting your own setup link). General *notifications* (ADR-024's inviter/access-request notifications) carry their own opt-out and are a separate track.
 
+## Security hardening (audit follow-up, 2026-06-13)
+
+Two fixes from an internal audit of this subsystem:
+
+- **`POST /users` privilege escalation closed.** The atomic-provisioning route
+  (which can grant a system role + project assignments) was gated only by the
+  group-level `users.read`, so a global read-only persona (`system_auditor` holds
+  `users.read`) could create a user with `role: "system_admin"` and escalate to
+  global admin. It is now gated by `users.write` (matching the sibling
+  `POST /invitations`), and the handler additionally authorizes the caller for
+  `roles.assign` at each grant's scope (global for a system role, per-project for a
+  project assignment) so atomic provisioning can never hand out more access than
+  the caller could assign directly — closing the cross-project/privesc class on
+  this newer route.
+- **Password-set consume now evicts other sessions.** `completePasswordSetup`
+  (account_setup / password_reset_link) minted a new session but left the subject's
+  existing sessions untouched, so a self-service password reset failed to lock out
+  an attacker holding a stolen session. It now drops all of the subject's other
+  sessions (keeping the freshly minted one), matching `ChangePassword`'s
+  invalidate-other-devices invariant.
+
 ## Related ADRs
 
 - **ADR-024** — Invitation and access-request flows (the invitation producer; this ADR provides the link/consume mechanism 024 deferred).

--- a/internal/core/setup_consume.go
+++ b/internal/core/setup_consume.go
@@ -117,6 +117,11 @@ func (c *KeyorixCore) completePasswordSetup(ctx context.Context, tok *models.Set
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}
+	// Evict every other session for this account, keeping only the one just minted.
+	// A self-service password reset must lock out anyone holding a stolen session
+	// (and a re-provision must drop stale ones) — matching ChangePassword's
+	// invalidate-other-devices invariant, which this path previously skipped.
+	_ = c.storage.DeleteSessionsForUserExcept(ctx, user.ID, session.ID)
 
 	c.writeAuditEventFull(ctx, "account.setup_completed", &user.ID, nil, nil, ip,
 		fmt.Sprintf("account setup completed via %s", tok.Purpose))

--- a/internal/core/setup_consume_test.go
+++ b/internal/core/setup_consume_test.go
@@ -87,6 +87,9 @@ func TestCompleteSetup(t *testing.T) {
 		ms.On("PrunePasswordHistory", ctx, uid, 5).Return(nil)
 		ms.On("CreateSession", ctx, mock.AnythingOfType("*models.Session")).
 			Return(&models.Session{ID: 1, UserID: uid, SessionToken: "sess-abc"}, nil)
+		// Completing setup must evict the subject's other sessions (keeping the new
+		// one) so a stolen session can't survive a self-service password reset.
+		ms.On("DeleteSessionsForUserExcept", ctx, uid, uint(1)).Return(nil)
 
 		res, err := c.CompleteSetup(ctx, raw, strongPw, "ua", "1.2.3.4")
 		require.NoError(t, err)
@@ -95,6 +98,7 @@ func TestCompleteSetup(t *testing.T) {
 		assert.NoError(t, bcrypt.CompareHashAndPassword([]byte(user.PasswordHash), []byte(strongPw)))
 		ms.AssertCalled(t, "MarkSetupTokenConsumed", ctx, uint(2), mock.AnythingOfType("time.Time"))
 		ms.AssertCalled(t, "CreateSession", ctx, mock.AnythingOfType("*models.Session"))
+		ms.AssertCalled(t, "DeleteSessionsForUserExcept", ctx, uid, uint(1))
 	})
 
 	t.Run("a weak password is rejected WITHOUT consuming the token", func(t *testing.T) {

--- a/server/http/handlers/create_user_assignments_test.go
+++ b/server/http/handlers/create_user_assignments_test.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"bytes"
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -11,6 +12,7 @@ import (
 	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/keyorixhq/keyorix/internal/storage/store"
+	customMiddleware "github.com/keyorixhq/keyorix/server/middleware"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gorm.io/driver/sqlite"
@@ -24,14 +26,36 @@ func setupCreateUserAssignmentsTest(t *testing.T) (*UserHandler, *gorm.DB) {
 	}))
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
-	require.NoError(t, db.AutoMigrate(&models.User{}, &models.UserRole{}, &models.Role{}, &models.Project{}))
+	require.NoError(t, db.AutoMigrate(&models.User{}, &models.UserRole{}, &models.Role{}, &models.Project{},
+		&models.Group{}, &models.UserGroup{}, &models.GroupRole{}))
 	require.NoError(t, db.Create(&models.Role{Name: "system_viewer"}).Error)
 	require.NoError(t, db.Create(&models.Role{Name: "project_developer"}).Error)
 	require.NoError(t, db.Create(&models.Project{Name: "default"}).Error)
+	// withUserCtx authenticates as user 1; create that user as a real row (so it
+	// takes id 1 and provisioned users get id 2+, no collision) and make them a
+	// global admin so they pass the ADR-028 provisioning authz (a system-role
+	// override + project assignments require roles.assign, here via admin-bypass).
+	require.NoError(t, db.Create(&models.User{Username: "admin1", Email: "admin1@x.io", IsActive: true}).Error)
+	var adminRole models.Role
+	require.NoError(t, db.Create(&models.Role{Name: "admin"}).Error)
+	require.NoError(t, db.Where("name = ?", "admin").First(&adminRole).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: adminRole.ID, ProjectID: 0}).Error)
 	coreService := core.NewKeyorixCore(store.NewLocalStorage(db))
 	uh, err := NewUserHandler(coreService)
 	require.NoError(t, err)
 	return uh, db
+}
+
+// postCreateUserAsUser posts a create-user request authenticated as an arbitrary
+// (non-admin) user id, for exercising the provisioning authorization checks.
+func postCreateUserAsUser(t *testing.T, h *UserHandler, jsonBody string, userID uint) *httptest.ResponseRecorder {
+	t.Helper()
+	uc := &customMiddleware.UserContext{UserID: userID, Username: "caller", Email: "c@x.io"}
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/users", bytes.NewReader([]byte(jsonBody)))
+	req = req.WithContext(context.WithValue(req.Context(), customMiddleware.GetUserContextKey(), uc))
+	w := httptest.NewRecorder()
+	h.CreateUser(w, req)
+	return w
 }
 
 func postCreateUser(t *testing.T, h *UserHandler, jsonBody string) *httptest.ResponseRecorder {
@@ -95,5 +119,35 @@ func TestCreateUser_AtomicAssignments(t *testing.T) {
 		body := `{"username":"mix","email":"mix@x.io","display_name":"Mix","role":"system_viewer","deliver_setup_link":true}`
 		w := postCreateUser(t, h, body)
 		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+}
+
+// A caller who lacks roles.assign at the grant's scope cannot use atomic
+// provisioning to hand out a system role or a project role they couldn't assign
+// directly (ADR-028 privilege-escalation guard). User 9 has no roles.
+func TestCreateUser_AssignmentAuthorization(t *testing.T) {
+	h, db := setupCreateUserAssignmentsTest(t)
+	var proj models.Project
+	require.NoError(t, db.Where("name = ?", "default").First(&proj).Error)
+
+	t.Run("non-privileged caller cannot grant a system role", func(t *testing.T) {
+		body := `{"username":"esc1","email":"esc1@x.io","display_name":"E","password":"Str0ng#Pass!word","role":"system_viewer"}`
+		w := postCreateUserAsUser(t, h, body, 9)
+		assert.Equal(t, http.StatusForbidden, w.Code)
+		var n int64
+		require.NoError(t, db.Model(&models.User{}).Where("username = ?", "esc1").Count(&n).Error)
+		assert.Equal(t, int64(0), n, "no account is created when the grant is refused")
+	})
+
+	t.Run("non-privileged caller cannot grant a project role", func(t *testing.T) {
+		body := `{"username":"esc2","email":"esc2@x.io","display_name":"E","password":"Str0ng#Pass!word","project_assignments":[{"project_id":` + itoa(proj.ID) + `,"role":"project_developer"}]}`
+		w := postCreateUserAsUser(t, h, body, 9)
+		assert.Equal(t, http.StatusForbidden, w.Code)
+	})
+
+	t.Run("global admin (user 1) may grant both", func(t *testing.T) {
+		body := `{"username":"okuser","email":"ok@x.io","display_name":"OK","password":"Str0ng#Pass!word","role":"system_viewer","project_assignments":[{"project_id":` + itoa(proj.ID) + `,"role":"project_developer"}]}`
+		w := postCreateUser(t, h, body) // user 1 = admin
+		assert.Equal(t, http.StatusCreated, w.Code)
 	})
 }

--- a/server/http/handlers/users_crud.go
+++ b/server/http/handlers/users_crud.go
@@ -138,6 +138,26 @@ func (h *UserHandler) CreateUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Atomic provisioning must not let the caller hand out access they could not
+	// assign directly (defense-in-depth beyond the users.write route gate, and the
+	// principled fix for the cross-project privesc class): a system-role override
+	// requires roles.assign at global scope; each project assignment requires
+	// roles.assign at that project. A global admin passes both via admin-bypass.
+	if hasAssignments {
+		if body.Role != "" {
+			if ok, aerr := h.coreService.AuthorizePrincipal(r.Context(), userCtx.ActorKind(), userCtx.PrincipalID(), "roles.assign", core.Scope{}); aerr != nil || !ok {
+				sendError(w, "Forbidden", "You may not assign a system role", http.StatusForbidden, nil)
+				return
+			}
+		}
+		for _, a := range body.ProjectAssignments {
+			if ok, aerr := h.coreService.AuthorizePrincipal(r.Context(), userCtx.ActorKind(), userCtx.PrincipalID(), "roles.assign", core.Scope{ProjectID: a.ProjectID}); aerr != nil || !ok {
+				sendError(w, "Forbidden", "You may not assign roles in the target project", http.StatusForbidden, nil)
+				return
+			}
+		}
+	}
+
 	var created *models.User
 	var err error
 	if hasAssignments {

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -314,7 +314,11 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		r.Route("/users", func(r chi.Router) {
 			r.Use(customMiddleware.RequirePermission("users.read"))
 			r.Get("/", handlers.ListUsers)
-			r.Post("/", handlers.CreateUser)
+			// CreateUser mutates (and can grant roles via ADR-028 atomic provisioning),
+			// so it needs users.write — not just the group-level users.read. Without
+			// this gate a global read-only persona (system_auditor holds users.read)
+			// could POST a user with role:"system_admin" and escalate to global admin.
+			r.With(customMiddleware.RequirePermission("users.write")).Post("/", handlers.CreateUser)
 			r.Get("/search", handlers.SearchUsers)
 			// Stale-account warnings (ADR-025): static path before /{id}.
 			r.Get("/stale", handlers.StaleAccounts)


### PR DESCRIPTION
Two findings from an adversarial audit of the credential-delivery / account-provisioning subsystem.

## HIGH — `POST /api/v1/users` privilege escalation

The atomic-provisioning route (ADR-028) can grant a **system role + arbitrary project assignments**, but it was gated only by the group-level `users.read`. A **global read-only persona** — `system_auditor` holds `users.read` — could:

```
POST /api/v1/users
{ "username":"x", "email":"x@e.test", "display_name":"x", "password":"<valid>",
  "role":"system_admin", "project_assignments":[{"project_id":7,"role":"project_admin"}] }
```

…minting a `system_admin` (granted at **global scope**) and escalating to full global admin, plus arbitrary cross-project grants. The sibling `POST /invitations` (same grant set) is correctly gated `users.write` — the synchronous create path was the weaker-gated twin (the #92/#93 cross-project privesc class recurring on a newer route).

**Fix:** gate `POST /users` on `users.write`, **and** authorize the caller for `roles.assign` at each grant's scope in the handler (global for a system role, per-project for each assignment), so atomic provisioning can never hand out more access than the caller could assign directly. A global admin passes via admin-bypass.

## MEDIUM — password-reset consume didn't evict existing sessions

`completePasswordSetup` (account_setup / password_reset_link) minted a new session but never dropped the subject's **other** sessions — so a self-service password reset failed to lock out an attacker holding a stolen session, diverging from `ChangePassword`'s invalidate-other-devices invariant. **Fix:** `DeleteSessionsForUserExcept(keep=new)` after minting (a no-op for a brand-new `pending_first_login` account).

## Tests

A non-privileged caller is refused both a system-role and a project-role grant (no account created); a global admin may grant both; the password-set consume evicts other sessions. golangci-lint 0 · gitleaks clean · full suite green. ADR-028 updated.

The audit verified the rest of the subsystem clean (atomic single-use token consume, purpose/subject binding, no accept-time assignment injection, email-binding takeover guard, revoke/resend scoping).

🤖 Generated with [Claude Code](https://claude.com/claude-code)