### PR TITLE
fix(auth): require write/assign perms on /users + /groups mutations (privesc)

### DIFF
--- a/server/http/integration_test.go
+++ b/server/http/integration_test.go
@@ -721,3 +721,57 @@ func TestHTTPServerPerformance(t *testing.T) {
 		assert.Less(t, duration, 100*time.Millisecond) // Should respond within 100ms
 	})
 }
+
+// TestPrivescRoutesRequireWrite is a regression test for the route-authorization
+// audit: mutating /users and /groups routes must NOT be reachable with only the
+// group-level users.read (held by the read-only system_auditor / system_viewer
+// personas). Before the fix these inherited users.read and let a read-only caller
+// edit/delete users and manage group membership (which confers the group's roles).
+// The middleware gate runs before the handler, so a non-existent target still 403s.
+func TestPrivescRoutesRequireWrite(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	cfg := &config.Config{Server: config.ServerConfig{HTTP: config.ServerInstanceConfig{Enabled: true, Port: "8080"}}}
+	testCore := newTestCore(t)
+	router, err := NewRouter(cfg, testCore)
+	require.NoError(t, err)
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	createTestToken(t, testCore) // bootstrap admin + seed roles
+	// Create a uniquely-named read-only user (the shared-cache in-memory DB means a
+	// fixed username from createLimitedToken can collide with other tests). New
+	// users get system_viewer, which holds users.read but not users.write.
+	ctx := context.Background()
+	_, err = testCore.CreateUser(ctx, &core.CreateUserRequest{
+		Username: "privesc_ro", Email: "privesc_ro@example.com", Password: "LimitedPass123!",
+	})
+	require.NoError(t, err)
+	sess, _, err := testCore.Login(ctx, &core.LoginRequest{Username: "privesc_ro", Password: "LimitedPass123!"})
+	require.NoError(t, err)
+	limited := sess.SessionToken
+
+	cases := []struct{ method, path string }{
+		{http.MethodPut, "/api/v1/users/1"},
+		{http.MethodDelete, "/api/v1/users/1"},
+		{http.MethodPost, "/api/v1/users/1/restore"},
+		{http.MethodPost, "/api/v1/groups"},
+		{http.MethodPut, "/api/v1/groups/1"},
+		{http.MethodDelete, "/api/v1/groups/1"},
+		{http.MethodPost, "/api/v1/groups/1/members"},
+		{http.MethodDelete, "/api/v1/groups/1/members/2"},
+	}
+	client := &http.Client{Timeout: 10 * time.Second}
+	for _, tc := range cases {
+		req, err := http.NewRequest(tc.method, server.URL+tc.path, bytes.NewReader([]byte("{}")))
+		require.NoError(t, err)
+		req.Header.Set("Authorization", "Bearer "+limited)
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		_ = resp.Body.Close()
+		assert.Equalf(t, http.StatusForbidden, resp.StatusCode,
+			"%s %s must be 403 for a users.read-only caller (privesc gate)", tc.method, tc.path)
+	}
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -323,9 +323,12 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			// Stale-account warnings (ADR-025): static path before /{id}.
 			r.Get("/stale", handlers.StaleAccounts)
 			r.Get("/{id}", handlers.GetUser)
-			r.Put("/{id}", handlers.UpdateUser)
-			r.Delete("/{id}", handlers.DeleteUser)
-			r.Post("/{id}/restore", handlers.RestoreUser)
+			// Mutations need users.write, not the group-wide users.read (which the
+			// read-only system_auditor persona holds) — these were the missed
+			// siblings of the suspend/reactivate transitions gated below.
+			r.With(customMiddleware.RequirePermission("users.write")).Put("/{id}", handlers.UpdateUser)
+			r.With(customMiddleware.RequirePermission("users.write")).Delete("/{id}", handlers.DeleteUser)
+			r.With(customMiddleware.RequirePermission("users.write")).Post("/{id}/restore", handlers.RestoreUser)
 			// Account state transitions (ADR-025).
 			r.With(customMiddleware.RequirePermission("users.write")).Post("/{id}/suspend", handlers.SuspendUser)
 			r.With(customMiddleware.RequirePermission("users.write")).Post("/{id}/reactivate", handlers.ReactivateUser)
@@ -349,13 +352,18 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		r.Route("/groups", func(r chi.Router) {
 			r.Use(customMiddleware.RequirePermission("users.read"))
 			r.Get("/", groupHandler.ListGroups)
-			r.Post("/", groupHandler.CreateGroup)
+			// Group CRUD mutates identity/membership state — gate on users.write,
+			// not the group-wide users.read (held by the read-only system_auditor).
+			r.With(customMiddleware.RequirePermission("users.write")).Post("/", groupHandler.CreateGroup)
 			r.Get("/{id}", groupHandler.GetGroup)
-			r.Put("/{id}", groupHandler.UpdateGroup)
-			r.Delete("/{id}", groupHandler.DeleteGroup)
+			r.With(customMiddleware.RequirePermission("users.write")).Put("/{id}", groupHandler.UpdateGroup)
+			r.With(customMiddleware.RequirePermission("users.write")).Delete("/{id}", groupHandler.DeleteGroup)
 			r.Get("/{id}/members", groupHandler.GetGroupMembers)
-			r.Post("/{id}/members", groupHandler.AddGroupMember)
-			r.Delete("/{id}/members/{userId}", groupHandler.RemoveGroupMember)
+			// Adding/removing a group member confers (or revokes) every role the group
+			// holds — the same blast radius as a role grant, so gate on roles.assign
+			// (matching the group's role-grant routes below), not users.read.
+			r.With(customMiddleware.RequirePermission("roles.assign")).Post("/{id}/members", groupHandler.AddGroupMember)
+			r.With(customMiddleware.RequirePermission("roles.assign")).Delete("/{id}/members/{userId}", groupHandler.RemoveGroupMember)
 			r.Get("/{id}/roles", rbacHandler.GetGroupRoles)
 			r.With(customMiddleware.RequirePermission("roles.assign")).Post("/{id}/roles", rbacHandler.AssignRoleToGroup)
 			r.With(customMiddleware.RequirePermission("roles.assign")).Delete("/{id}/roles/{roleId}", rbacHandler.RemoveRoleFromGroup)


### PR DESCRIPTION
A systematic route-authorization sweep (triggered by the #134 `POST /users` finding) showed the same class **recurs**: mutating routes inheriting the group-level `RequirePermission("users.read")` without a per-route write/assign override, and handlers that don't compensate in-handler. The read-only **`system_auditor`** persona holds `users.read`, so it could reach them.

## HIGH — group mutations gated only by `users.read`

`CreateGroup` / `UpdateGroup` / `DeleteGroup` / `AddGroupMember` / `RemoveGroupMember` have no in-handler authz. A read-only caller could create/edit/delete groups and change membership. Because a group carries role grants (`POST /groups/{id}/roles`), **adding yourself to a group that holds `system_admin` inherits admin** — a direct escalation.

**Fix:** group CRUD → `users.write`; membership add/remove → `roles.assign` (same blast radius as a role grant, matching the group's own role-grant routes).

## HIGH — `PUT`/`DELETE`/`restore` on `/users/{id}` gated only by `users.read`

The missed siblings of `suspend`/`reactivate`/`require-password-reset` (already on `users.write`). A read-only caller could edit any user (incl. `is_active`), delete, or restore.

**Fix:** all three now require `users.write`.

## Verified clean (ruled out)

secrets / dynamic-secrets / rotation create authorize in-handler at body scope; every `/projects/{id}/*` scoped mutation uses `RequireScopedPermission(..., projectScope)`; `POST /invitations` and impersonation correctly gated; reads use `*.read`. One **LOW** (`POST /audit/anomalies/{id}/acknowledge` on `audit.read`) left as-is — an auditor acknowledging alerts is arguably intended.

## Test

Regression: a `users.read`-only token gets **403 on all eight** mutating routes (the gate runs before the handler, so a non-existent target still 403s). golangci-lint 0 · gitleaks clean · full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)