### PR TITLE
fix(grpc): enforce scoped RBAC on Role/User/Audit/System services (privesc)

### DIFF
--- a/docs/compliance/SECURITY-VERIFICATION.md
+++ b/docs/compliance/SECURITY-VERIFICATION.md
@@ -64,10 +64,18 @@ each strengthens:
 ### Access control & authorisation (§1)
 
 - **Cross-transport authorization parity.** The gRPC surface authorized several
-  secret and share operations against the flat (global) permission set while HTTP
-  enforced project-scoped permissions. Both transports now enforce identical
-  **scoped** RBAC, so a permission held in one project can never act on an object
-  in another. *(Severity: medium; closed the full flat-vs-scoped class.)*
+  operations against the flat (global) permission set while HTTP enforced
+  project-scoped permissions. This was closed for the Secret and Share services
+  first, then — in a follow-up audit — for the remaining **Role, User, Audit and
+  System** services, which still checked the flat union: a `roles.assign`/
+  `users.write` grant held at one project could create global roles, mutate any
+  user, or grant roles into another project over gRPC (a cross-project privilege
+  escalation), and a project-scoped read permission could read install-wide audit
+  logs / user lists. Every gRPC RPC now authorizes through `core.Authorize` at the
+  correct scope (global for install-wide ops; the request's project/environment for
+  role assignment), identical to HTTP — so a permission held in one project can
+  never act on an object in another. *(Severity: medium→high; the full flat-vs-
+  scoped class is now closed across all six services.)*
 - **Cross-project (cross-tenant) isolation.** Five project-nested lifecycle
   routes authorized the caller against the URL's project but then acted on a
   child object belonging to a *different* project (access-request approval,

--- a/server/grpc/services/audit_service.go
+++ b/server/grpc/services/audit_service.go
@@ -40,8 +40,8 @@ func (s *AuditGRPCService) GetAuditLogs(ctx context.Context, req *pb.GetAuditLog
 	if err != nil {
 		return nil, err
 	}
-	if !hasPermission(actor.Permissions, "audit.read") {
-		return nil, status.Error(codes.PermissionDenied, "insufficient permissions to read audit logs")
+	if err := authorizeGlobal(ctx, s.core, actor.UserID, "audit.read"); err != nil {
+		return nil, err
 	}
 	page, pageSize := normalizePage(req.GetPage(), req.GetPageSize())
 
@@ -81,8 +81,8 @@ func (s *AuditGRPCService) GetRBACAuditLogs(ctx context.Context, req *pb.GetRBAC
 	if err != nil {
 		return nil, err
 	}
-	if !hasPermission(actor.Permissions, "audit.read") {
-		return nil, status.Error(codes.PermissionDenied, "insufficient permissions to read audit logs")
+	if err := authorizeGlobal(ctx, s.core, actor.UserID, "audit.read"); err != nil {
+		return nil, err
 	}
 	page, pageSize := normalizePage(req.GetPage(), req.GetPageSize())
 
@@ -144,8 +144,8 @@ func (s *AuditGRPCService) StreamAuditLogs(req *pb.StreamAuditLogsRequest, strea
 	if actor == nil {
 		return status.Error(codes.Unauthenticated, "user not authenticated")
 	}
-	if !hasPermission(actor.Permissions, "audit.read") {
-		return status.Error(codes.PermissionDenied, "insufficient permissions to read audit logs")
+	if err := authorizeGlobal(ctx, s.core, actor.UserID, "audit.read"); err != nil {
+		return err
 	}
 
 	// Start at the current head so we tail new events, not the backlog.

--- a/server/grpc/services/audit_service_test.go
+++ b/server/grpc/services/audit_service_test.go
@@ -28,8 +28,14 @@ func newAuditService(t *testing.T) *AuditGRPCService {
 	}))
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
-	require.NoError(t, db.AutoMigrate(&models.AuditEvent{}, &models.User{}))
+	require.NoError(t, db.AutoMigrate(&models.AuditEvent{}, &models.User{},
+		&models.Role{}, &models.Permission{}, &models.RolePermission{}, &models.UserRole{},
+		&models.Group{}, &models.UserGroup{}, &models.GroupRole{}))
 	require.NoError(t, db.Create(&models.User{ID: 1, Username: "alice", Email: "alice@example.com"}).Error)
+	// User 1 = super_admin (global) so core.Authorize admits the admin-context
+	// tests; the denied test uses an ungranted user id.
+	require.NoError(t, db.Create(&models.Role{ID: 1, Name: "super_admin"}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1, ProjectID: 0}).Error)
 	uid := uint(1)
 	require.NoError(t, db.Create(&models.AuditEvent{
 		EventType: "secret.read", UserID: &uid, Description: "read a secret",
@@ -64,7 +70,7 @@ func TestAuditService_GetAuditLogs_Unauthenticated(t *testing.T) {
 
 func TestAuditService_GetAuditLogs_PermissionDenied(t *testing.T) {
 	svc := newAuditService(t)
-	ctx := authCtx(1, "nobody") // no audit.read
+	ctx := authCtx(7, "nobody") // ungranted user → denied
 	_, err := svc.GetAuditLogs(ctx, &pb.GetAuditLogsRequest{})
 	require.Error(t, err)
 	assert.Equal(t, codes.PermissionDenied, status.Code(err))
@@ -78,9 +84,17 @@ func TestAuditService_GetRBACAuditLogs_EmptyButOK(t *testing.T) {
 }
 
 func TestAuditService_GetRBACAuditLogs_ReturnsRoleChanges(t *testing.T) {
+	require.NoError(t, i18n.Initialize(&config.Config{
+		Locale: config.LocaleConfig{Language: "en", FallbackLanguage: "en"},
+	}))
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
-	require.NoError(t, db.AutoMigrate(&models.AuditEvent{}, &models.UserRole{}))
+	require.NoError(t, db.AutoMigrate(&models.AuditEvent{}, &models.UserRole{},
+		&models.Role{}, &models.Permission{}, &models.RolePermission{},
+		&models.Group{}, &models.UserGroup{}, &models.GroupRole{}))
+	// auditCtx() is user 1 — grant it super_admin (global) so the audit.read check passes.
+	require.NoError(t, db.Create(&models.Role{ID: 1, Name: "super_admin"}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1, ProjectID: 0}).Error)
 	c := core.NewKeyorixCore(store.NewLocalStorage(db))
 	require.NoError(t, c.AssignUserRole(context.Background(), 5, 10, 2, core.Scope{ProjectID: 3}))
 

--- a/server/grpc/services/audit_stream_test.go
+++ b/server/grpc/services/audit_stream_test.go
@@ -61,14 +61,20 @@ func newStreamCore(t *testing.T) (*AuditGRPCService, *gorm.DB) {
 	sqlDB, err := db.DB()
 	require.NoError(t, err)
 	sqlDB.SetMaxOpenConns(1)
-	require.NoError(t, db.AutoMigrate(&models.AuditEvent{}, &models.User{}))
+	require.NoError(t, db.AutoMigrate(&models.AuditEvent{}, &models.User{},
+		&models.Role{}, &models.Permission{}, &models.RolePermission{}, &models.UserRole{},
+		&models.Group{}, &models.UserGroup{}, &models.GroupRole{}))
 	require.NoError(t, db.Create(&models.User{ID: 1, Username: "admin"}).Error)
+	// User 1 = super_admin (global) so the audit.read check passes (stream tests
+	// authenticate as user 1); the denied test uses an ungranted user id.
+	require.NoError(t, db.Create(&models.Role{ID: 1, Name: "super_admin"}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1, ProjectID: 0}).Error)
 	return NewAuditService(core.NewKeyorixCore(store.NewLocalStorage(db))), db
 }
 
 func TestAuditService_StreamAuditLogs_PermissionDenied(t *testing.T) {
 	svc, _ := newStreamCore(t)
-	stream := &fakeAuditStream{ctx: authCtx(1, "nobody")} // no audit.read
+	stream := &fakeAuditStream{ctx: authCtx(7, "nobody")} // ungranted user → denied
 	err := svc.StreamAuditLogs(&pb.StreamAuditLogsRequest{}, stream)
 	require.Error(t, err)
 	assert.Equal(t, codes.PermissionDenied, status.Code(err))

--- a/server/grpc/services/conversions.go
+++ b/server/grpc/services/conversions.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"time"
 
+	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/keyorixhq/keyorix/internal/utils/safeconv"
 	"github.com/keyorixhq/keyorix/server/grpc/interceptors"
@@ -29,6 +30,11 @@ func requireUser(ctx context.Context) (*interceptors.UserContext, error) {
 	return user, nil
 }
 
+// hasPermission reports flat membership in the caller's permission union. Use it
+// ONLY for self-scoped reads (a caller listing their OWN shares), where the result
+// set is already filtered to the caller and no cross-tenant access is possible. For
+// anything that reads or mutates another tenant's / global state, use
+// authorizeScoped / authorizeGlobal instead (see the bug-class note below).
 func hasPermission(permissions []string, required string) bool {
 	for _, p := range permissions {
 		if p == required {
@@ -36,6 +42,27 @@ func hasPermission(permissions []string, required string) bool {
 		}
 	}
 	return false
+}
+
+// authorizeScoped enforces perm at the given scope via core.Authorize — the same
+// scope-aware path HTTP uses. This is the ONLY authorization primitive the services
+// use: an earlier flat `hasPermission(user.Permissions, …)` check treated a
+// permission held only at one project's scope as if held everywhere, because
+// UserContext.Permissions is the FLAT union of the caller's grants across every
+// scope (the #53/#54/#88/#90 flat-vs-scoped bug class). Routing through
+// core.Authorize fixes that and future-proofs the PAT/machine paths.
+func authorizeScoped(ctx context.Context, cs *core.KeyorixCore, userID uint, perm string, scope core.Scope) error {
+	if allowed, err := cs.Authorize(ctx, userID, perm, scope); err != nil || !allowed {
+		return status.Error(codes.PermissionDenied, "insufficient permissions")
+	}
+	return nil
+}
+
+// authorizeGlobal enforces perm at global scope (project 0) — for install-wide
+// operations (user/role/system/audit management) that HTTP gates with
+// RequirePermission. A grant held only at a project scope does NOT satisfy it.
+func authorizeGlobal(ctx context.Context, cs *core.KeyorixCore, userID uint, perm string) error {
+	return authorizeScoped(ctx, cs, userID, perm, core.Scope{})
 }
 
 // --- Pagination ---

--- a/server/grpc/services/role_service.go
+++ b/server/grpc/services/role_service.go
@@ -34,8 +34,8 @@ func (s *RoleGRPCService) CreateRole(ctx context.Context, req *pb.CreateRoleRequ
 	if err != nil {
 		return nil, err
 	}
-	if !hasPermission(actor.Permissions, "roles.write") {
-		return nil, status.Error(codes.PermissionDenied, "insufficient permissions to create roles")
+	if err := authorizeGlobal(ctx, s.core, actor.UserID, "roles.write"); err != nil {
+		return nil, err
 	}
 	if req.GetName() == "" || req.GetDescription() == "" || len(req.GetPermissions()) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "name, description and at least one permission are required")
@@ -64,8 +64,8 @@ func (s *RoleGRPCService) GetRole(ctx context.Context, req *pb.GetRoleRequest) (
 	if err != nil {
 		return nil, err
 	}
-	if !hasPermission(actor.Permissions, "roles.read") {
-		return nil, status.Error(codes.PermissionDenied, "insufficient permissions to read roles")
+	if err := authorizeGlobal(ctx, s.core, actor.UserID, "roles.read"); err != nil {
+		return nil, err
 	}
 	return s.roleByID(ctx, uint(req.GetId()))
 }
@@ -76,8 +76,8 @@ func (s *RoleGRPCService) UpdateRole(ctx context.Context, req *pb.UpdateRoleRequ
 	if err != nil {
 		return nil, err
 	}
-	if !hasPermission(actor.Permissions, "roles.write") {
-		return nil, status.Error(codes.PermissionDenied, "insufficient permissions to update roles")
+	if err := authorizeGlobal(ctx, s.core, actor.UserID, "roles.write"); err != nil {
+		return nil, err
 	}
 	if req.GetId() == 0 {
 		return nil, status.Error(codes.InvalidArgument, "id is required")
@@ -122,8 +122,8 @@ func (s *RoleGRPCService) DeleteRole(ctx context.Context, req *pb.DeleteRoleRequ
 	if err != nil {
 		return nil, err
 	}
-	if !hasPermission(actor.Permissions, "roles.write") {
-		return nil, status.Error(codes.PermissionDenied, "insufficient permissions to delete roles")
+	if err := authorizeGlobal(ctx, s.core, actor.UserID, "roles.write"); err != nil {
+		return nil, err
 	}
 	if req.GetId() == 0 {
 		return nil, status.Error(codes.InvalidArgument, "id is required")
@@ -140,8 +140,8 @@ func (s *RoleGRPCService) ListRoles(ctx context.Context, req *pb.ListRolesReques
 	if err != nil {
 		return nil, err
 	}
-	if !hasPermission(actor.Permissions, "roles.read") {
-		return nil, status.Error(codes.PermissionDenied, "insufficient permissions to list roles")
+	if err := authorizeGlobal(ctx, s.core, actor.UserID, "roles.read"); err != nil {
+		return nil, err
 	}
 
 	all, err := s.core.ListRolesWithPermissions(ctx)
@@ -179,13 +179,15 @@ func (s *RoleGRPCService) AssignRole(ctx context.Context, req *pb.AssignRoleRequ
 	if err != nil {
 		return nil, err
 	}
-	if !hasPermission(actor.Permissions, "roles.assign") {
-		return nil, status.Error(codes.PermissionDenied, "insufficient permissions to assign roles")
-	}
 	if req.GetUserId() == 0 || req.GetRoleId() == 0 {
 		return nil, status.Error(codes.InvalidArgument, "user_id and role_id are required")
 	}
+	// Authorize roles.assign AT THE TARGET scope, not the flat global union — else a
+	// project-A admin could grant roles into any project B (cross-project privesc).
 	scope := core.Scope{ProjectID: uint(req.GetProjectId()), EnvironmentID: uint(req.GetEnvironmentId())}
+	if err := authorizeScoped(ctx, s.core, actor.UserID, "roles.assign", scope); err != nil {
+		return nil, err
+	}
 	if err := s.core.AssignUserRole(ctx, actor.UserID, uint(req.GetUserId()), uint(req.GetRoleId()), scope); err != nil {
 		return nil, mapRoleError(err)
 	}
@@ -203,13 +205,14 @@ func (s *RoleGRPCService) RemoveRole(ctx context.Context, req *pb.RemoveRoleRequ
 	if err != nil {
 		return nil, err
 	}
-	if !hasPermission(actor.Permissions, "roles.assign") {
-		return nil, status.Error(codes.PermissionDenied, "insufficient permissions to remove role assignments")
-	}
 	if req.GetUserId() == 0 || req.GetRoleId() == 0 {
 		return nil, status.Error(codes.InvalidArgument, "user_id and role_id are required")
 	}
+	// Authorize roles.assign at the target scope (see AssignRole) — not the flat union.
 	scope := core.Scope{ProjectID: uint(req.GetProjectId()), EnvironmentID: uint(req.GetEnvironmentId())}
+	if err := authorizeScoped(ctx, s.core, actor.UserID, "roles.assign", scope); err != nil {
+		return nil, err
+	}
 	if err := s.core.RemoveUserRole(ctx, actor.UserID, uint(req.GetUserId()), uint(req.GetRoleId()), scope); err != nil {
 		return nil, mapRoleError(err)
 	}
@@ -222,8 +225,8 @@ func (s *RoleGRPCService) GetUserRoles(ctx context.Context, req *pb.GetUserRoles
 	if err != nil {
 		return nil, err
 	}
-	if !hasPermission(actor.Permissions, "roles.read") {
-		return nil, status.Error(codes.PermissionDenied, "insufficient permissions to read role assignments")
+	if err := authorizeGlobal(ctx, s.core, actor.UserID, "roles.read"); err != nil {
+		return nil, err
 	}
 	assignment, err := s.core.GetUserRoleAssignment(ctx, uint(req.GetUserId()))
 	if err != nil {

--- a/server/grpc/services/role_service_test.go
+++ b/server/grpc/services/role_service_test.go
@@ -16,6 +16,9 @@ func newRoleService(t *testing.T) (*RoleGRPCService, *testhelper.RBACTestHelper)
 	t.Helper()
 	h := testhelper.NewRBACTestHelper(t)
 	t.Cleanup(h.Cleanup)
+	// Admin-context user (id 1) = super_admin (global); denied tests use an
+	// ungranted user id so core.Authorize refuses them.
+	h.AssignUserRole(t, 1, 1, nil)
 	return NewRoleService(h.CoreService), h
 }
 
@@ -57,7 +60,7 @@ func TestRoleService_CreateRole_Unauthenticated(t *testing.T) {
 
 func TestRoleService_CreateRole_PermissionDenied(t *testing.T) {
 	svc, _ := newRoleService(t)
-	ctx := authCtx(1, "reader", "roles.read")
+	ctx := authCtx(7, "reader") // ungranted user → denied
 	_, err := svc.CreateRole(ctx, &pb.CreateRoleRequest{
 		Name: "x", Description: "y", Permissions: []string{"secrets.read"},
 	})
@@ -148,6 +151,35 @@ func TestRoleService_AssignAndGetUserRoles(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "assignee", got.GetUsername())
 	assert.GreaterOrEqual(t, len(got.GetRoles()), 1)
+}
+
+// Regression for the flat-vs-scoped gRPC bug: a caller holding admin/roles.assign
+// ONLY at project 1 may assign within project 1 but NOT cross-project into project
+// 2. Before the fix, AssignRole checked the flat global permission union, so a
+// project-1 admin could grant roles into any project.
+func TestRoleService_AssignRole_ScopedCrossProjectDenied(t *testing.T) {
+	svc, h := newRoleService(t)
+	proj1 := uint(1)
+	h.AssignUserRole(t, 50, 2, &proj1) // user 50 = admin (role 2) at project 1 only
+	target := h.CreateTestUser(t, "xtarget", 600)
+	roles, err := svc.ListRoles(roleAdminCtx(), &pb.ListRolesRequest{})
+	require.NoError(t, err)
+	roleID := roles.GetRoles()[0].GetId()
+	ctx := authCtx(50, "projadmin") // perms slice is ignored — authz is scope-resolved
+	p1, p2 := uint32(1), uint32(2)
+
+	// Within the caller's project: allowed (project-scoped admin bypass).
+	_, err = svc.AssignRole(ctx, &pb.AssignRoleRequest{
+		UserId: intToU32(int(target.ID)), RoleId: roleID, ProjectId: &p1,
+	})
+	require.NoError(t, err)
+
+	// Into a different project: denied — the grant doesn't apply there.
+	_, err = svc.AssignRole(ctx, &pb.AssignRoleRequest{
+		UserId: intToU32(int(target.ID)), RoleId: roleID, ProjectId: &p2,
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.PermissionDenied, status.Code(err))
 }
 
 func TestRoleService_RemoveRole(t *testing.T) {

--- a/server/grpc/services/share_service.go
+++ b/server/grpc/services/share_service.go
@@ -96,8 +96,10 @@ func (s *ShareGRPCService) ListUserShares(ctx context.Context, req *pb.ListUserS
 	if err != nil {
 		return nil, err
 	}
+	// Self-scoped: returns only the caller's own shares, so a flat secrets.read
+	// check is sufficient (no cross-tenant access — see hasPermission's note).
 	if !hasPermission(user.Permissions, "secrets.read") {
-		return nil, status.Error(codes.PermissionDenied, "insufficient permissions to view shares")
+		return nil, status.Error(codes.PermissionDenied, "insufficient permissions")
 	}
 
 	shares, err := s.core.ListSharesByUser(ctx, user.UserID)
@@ -114,8 +116,9 @@ func (s *ShareGRPCService) ListSharedSecrets(ctx context.Context, req *pb.ListSh
 	if err != nil {
 		return nil, err
 	}
+	// Self-scoped (caller's own shared-with-me secrets) — flat check is sufficient.
 	if !hasPermission(user.Permissions, "secrets.read") {
-		return nil, status.Error(codes.PermissionDenied, "insufficient permissions to view shared secrets")
+		return nil, status.Error(codes.PermissionDenied, "insufficient permissions")
 	}
 
 	secrets, err := s.core.ListSharedSecrets(ctx, user.UserID)

--- a/server/grpc/services/system_service.go
+++ b/server/grpc/services/system_service.go
@@ -12,8 +12,6 @@ import (
 	pb "github.com/keyorixhq/keyorix/server/proto/pb"
 	"github.com/shirou/gopsutil/v4/cpu"
 	"github.com/shirou/gopsutil/v4/disk"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -55,8 +53,8 @@ func (s *SystemGRPCService) GetSystemInfo(ctx context.Context, _ *emptypb.Empty)
 	if err != nil {
 		return nil, err
 	}
-	if !hasPermission(actor.Permissions, "system.read") {
-		return nil, status.Error(codes.PermissionDenied, "insufficient permissions to read system info")
+	if err := authorizeGlobal(ctx, s.core, actor.UserID, "system.read"); err != nil {
+		return nil, err
 	}
 
 	info := &pb.SystemInfo{
@@ -95,8 +93,8 @@ func (s *SystemGRPCService) GetMetrics(ctx context.Context, _ *emptypb.Empty) (*
 	if err != nil {
 		return nil, err
 	}
-	if !hasPermission(actor.Permissions, "system.read") {
-		return nil, status.Error(codes.PermissionDenied, "insufficient permissions to read metrics")
+	if err := authorizeGlobal(ctx, s.core, actor.UserID, "system.read"); err != nil {
+		return nil, err
 	}
 
 	// Request/performance metrics from the gRPC metrics interceptor.

--- a/server/grpc/services/system_service_test.go
+++ b/server/grpc/services/system_service_test.go
@@ -17,6 +17,9 @@ func newSystemService(t *testing.T) *SystemGRPCService {
 	t.Helper()
 	h := testhelper.NewRBACTestHelper(t)
 	t.Cleanup(h.Cleanup)
+	// Admin-context user (id 1) = super_admin (global); denied tests use an
+	// ungranted user id so core.Authorize refuses them.
+	h.AssignUserRole(t, 1, 1, nil)
 	cfg := &config.Config{Environment: "test"}
 	cfg.Storage.Type = "local"
 	return NewSystemService(h.CoreService, cfg)
@@ -55,7 +58,7 @@ func TestSystemService_GetSystemInfo_Unauthenticated(t *testing.T) {
 
 func TestSystemService_GetSystemInfo_PermissionDenied(t *testing.T) {
 	svc := newSystemService(t)
-	ctx := authCtx(1, "nobody") // no system.read
+	ctx := authCtx(7, "nobody") // ungranted user → denied
 	_, err := svc.GetSystemInfo(ctx, &emptypb.Empty{})
 	require.Error(t, err)
 	assert.Equal(t, codes.PermissionDenied, status.Code(err))

--- a/server/grpc/services/user_service.go
+++ b/server/grpc/services/user_service.go
@@ -38,8 +38,8 @@ func (s *UserGRPCService) CreateUser(ctx context.Context, req *pb.CreateUserRequ
 	if err != nil {
 		return nil, err
 	}
-	if !hasPermission(actor.Permissions, "users.write") {
-		return nil, status.Error(codes.PermissionDenied, "insufficient permissions to create users")
+	if err := authorizeGlobal(ctx, s.core, actor.UserID, "users.write"); err != nil {
+		return nil, err
 	}
 	if req.GetUsername() == "" || req.GetEmail() == "" {
 		return nil, status.Error(codes.InvalidArgument, "username and email are required")
@@ -106,8 +106,8 @@ func (s *UserGRPCService) GetUser(ctx context.Context, req *pb.GetUserRequest) (
 	if err != nil {
 		return nil, err
 	}
-	if !hasPermission(actor.Permissions, "users.read") {
-		return nil, status.Error(codes.PermissionDenied, "insufficient permissions to read users")
+	if err := authorizeGlobal(ctx, s.core, actor.UserID, "users.read"); err != nil {
+		return nil, err
 	}
 	u, err := s.core.GetUser(ctx, uint(req.GetId()))
 	if err != nil {
@@ -122,8 +122,8 @@ func (s *UserGRPCService) UpdateUser(ctx context.Context, req *pb.UpdateUserRequ
 	if err != nil {
 		return nil, err
 	}
-	if !hasPermission(actor.Permissions, "users.write") {
-		return nil, status.Error(codes.PermissionDenied, "insufficient permissions to update users")
+	if err := authorizeGlobal(ctx, s.core, actor.UserID, "users.write"); err != nil {
+		return nil, err
 	}
 	if req.GetId() == 0 {
 		return nil, status.Error(codes.InvalidArgument, "id is required")
@@ -147,8 +147,8 @@ func (s *UserGRPCService) DeleteUser(ctx context.Context, req *pb.DeleteUserRequ
 	if err != nil {
 		return nil, err
 	}
-	if !hasPermission(actor.Permissions, "users.delete") {
-		return nil, status.Error(codes.PermissionDenied, "insufficient permissions to delete users")
+	if err := authorizeGlobal(ctx, s.core, actor.UserID, "users.delete"); err != nil {
+		return nil, err
 	}
 	if req.GetId() == 0 {
 		return nil, status.Error(codes.InvalidArgument, "id is required")
@@ -165,8 +165,8 @@ func (s *UserGRPCService) ListUsers(ctx context.Context, req *pb.ListUsersReques
 	if err != nil {
 		return nil, err
 	}
-	if !hasPermission(actor.Permissions, "users.read") {
-		return nil, status.Error(codes.PermissionDenied, "insufficient permissions to list users")
+	if err := authorizeGlobal(ctx, s.core, actor.UserID, "users.read"); err != nil {
+		return nil, err
 	}
 	page, pageSize := normalizePage(req.GetPage(), req.GetPageSize())
 

--- a/server/grpc/services/user_service_test.go
+++ b/server/grpc/services/user_service_test.go
@@ -18,6 +18,9 @@ func newUserService(t *testing.T) *UserGRPCService {
 	t.Helper()
 	h := testhelper.NewRBACTestHelper(t)
 	t.Cleanup(h.Cleanup)
+	// Grant the admin-context user (id 1) super_admin globally so core.Authorize
+	// admits the admin tests; denied tests use an ungranted user id.
+	h.AssignUserRole(t, 1, 1, nil)
 	return NewUserService(h.CoreService)
 }
 
@@ -55,7 +58,7 @@ func TestUserService_CreateUser_Unauthenticated(t *testing.T) {
 
 func TestUserService_CreateUser_PermissionDenied(t *testing.T) {
 	svc := newUserService(t)
-	ctx := authCtx(1, "reader", "users.read") // no write
+	ctx := authCtx(7, "reader") // ungranted user → denied
 	_, err := svc.CreateUser(ctx, &pb.CreateUserRequest{
 		Username: "x", Email: "x@example.com", Password: strPtr("password123"),
 	})


### PR DESCRIPTION
A gRPC authorization audit (the natural follow-on to the HTTP route sweep) found the **flat-vs-scoped class** (#53/#54/#88/#90) was only **partially** closed. Secret and Share services correctly scope-check via `core.Authorize`, but **Role, User, Audit and System** services still gated on `hasPermission(UserContext.Permissions, …)` — the **flat union** of the caller's grants across every scope. So a permission held only at one project was treated as held everywhere.

## Impact (when gRPC is enabled — `Server.GRPC.Enabled`)

- **HIGH** — `RoleService.AssignRole`/`RemoveRole` take an arbitrary target `project_id` but checked `roles.assign` only flatly → a **project-A admin could grant any role (incl. `project_admin`) into any project B**. `CreateRole`/`UpdateRole`/`DeleteRole` and `UserService.CreateUser`/`UpdateUser`/`DeleteUser` are global ops a project-scoped `roles.write`/`users.write` holder could reach (and `CreateUser` can assign roles in arbitrary projects).
- **MEDIUM** — `GetUser`/`ListUsers`/`GetRole`/`ListRoles`/`GetUserRoles`, all Audit reads, and System info/metrics: a project-scoped read permission could read **install-wide** data.

## Fix

Add `authorizeScoped` / `authorizeGlobal` helpers over `core.Authorize` and route every Role/User/Audit/System RPC through them — **global** scope for install-wide ops, the request's `{project, environment}` for `AssignRole`/`RemoveRole` — identical to HTTP. Also future-proofs the PAT (ADR-042) / machine (ADR-030) paths: if gRPC ever accepts those tokens, restrictions and no-admin-bypass apply automatically rather than being silently bypassed by the flat slice. `ShareService.ListUserShares`/`ListSharedSecrets` keep the flat check (self-scoped — returns only the caller's own shares).

## Tests

Regression: a project-1 admin can `AssignRole` within project 1 but is **denied cross-project** into project 2. The existing service tests now seed a real `super_admin` grant for the admin-context user (the flat `Permissions` slice is no longer consulted) and denied tests use an ungranted user. golangci-lint 0 · gitleaks clean · full suite green. `SECURITY-VERIFICATION.md` corrected (the class was previously recorded as fully closed — it was Secret/Share only).

Note: gRPC is opt-in (default off), so this affects only deployments that enable it — but it's a real privesc there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)