### PR TITLE
fix(oidc): bound the stale-JWKS fallback so rotated-out keys can't linger

### DIFF
--- a/docs/adr-031-oidc-federation.md
+++ b/docs/adr-031-oidc-federation.md
@@ -81,3 +81,18 @@ audit actoring are identical and already tested.
   enforced — the standard OIDC verification guarantees.
 - A revoked/suspended machine identity disables its federated access too
   (validation re-checks machine state every request, same as opaque tokens).
+
+### Bounded stale-JWKS fallback (hardening, 2026-06-13)
+
+An adversarial audit of this path confirmed the headline attacks are closed (alg
+pinned to asymmetric so `alg:none`/HMAC-with-public-key are rejected; signature
+verified before any claim is trusted; `iss` checked against the allowlist *before*
+the JWKS fetch and the fetch uses the operator-configured `jwks_uri`, not a
+token-derived URL — no SSRF; `aud`/`exp` required; the machine is resolved strictly
+from the verified `(iss,sub)`; no admin bypass). It found one weakness, now fixed:
+the JWKS resolver fell back to a **stale cached key with no age bound** when a
+refetch failed transiently, so a key the issuer rotated out (e.g. because it was
+compromised) could keep verifying tokens indefinitely while the issuer's JWKS
+endpoint was unreachable — defeating rotation-as-revocation. The fallback is now
+bounded to a short grace window past the cache TTL (`jwksStaleGrace`); beyond it a
+failed refetch fails closed.

--- a/internal/core/oidc_jwks.go
+++ b/internal/core/oidc_jwks.go
@@ -25,6 +25,14 @@ import (
 // jwksCacheTTL bounds how long a fetched key set is trusted before a refetch.
 const jwksCacheTTL = 1 * time.Hour
 
+// jwksStaleGrace bounds how far PAST the TTL a cached key set may still be served
+// as a fallback when a JWKS refetch fails transiently. Without a bound, a key the
+// issuer rotated out — e.g. because its private key was compromised — would keep
+// verifying federation tokens for as long as the issuer's JWKS endpoint is
+// unreachable from Keyorix, defeating rotation-as-revocation. After the grace
+// window, a failed refetch fails closed.
+const jwksStaleGrace = 10 * time.Minute
+
 // HTTPJWKSResolver implements JWKSResolver by fetching each issuer's jwks_uri.
 type HTTPJWKSResolver struct {
 	jwksURIs map[string]string // issuer -> jwks_uri (operator-configured)
@@ -107,8 +115,11 @@ func (r *HTTPJWKSResolver) Key(ctx context.Context, issuer, kid string) (interfa
 
 	keys, err := r.fetch(ctx, jwksURI)
 	if err != nil {
-		// Fall back to a stale cache rather than failing on a transient fetch error.
-		if entry != nil {
+		// Fall back to a recently-cached key set on a transient fetch error — but
+		// ONLY within a bounded grace window past the TTL, so a rotated-out (possibly
+		// compromised) key cannot be honoured indefinitely while the issuer is
+		// unreachable. Beyond the window, fail closed.
+		if entry != nil && time.Since(entry.fetchedAt) < jwksCacheTTL+jwksStaleGrace {
 			if k, ok := entry.keys[kid]; ok {
 				return k, nil
 			}

--- a/internal/core/oidc_jwks_test.go
+++ b/internal/core/oidc_jwks_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -53,6 +54,40 @@ func TestHTTPJWKSResolver_FetchAndCache(t *testing.T) {
 	// Unknown issuer fails.
 	_, err = r.Key(context.Background(), "https://other", "k1")
 	require.ErrorContains(t, err, "no jwks_uri")
+}
+
+// On a transient JWKS fetch failure, a cached key is served only within a bounded
+// grace window past the TTL — so a key the issuer rotated out (e.g. compromised)
+// cannot be honoured indefinitely while the issuer is unreachable.
+func TestHTTPJWKSResolver_StaleFallbackBounded(t *testing.T) {
+	key, _ := rsa.GenerateKey(rand.Reader, 2048)
+	// A JWKS endpoint that always fails, forcing reliance on the cache.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	r, err := NewHTTPJWKSResolver(map[string]string{"https://iss": srv.URL})
+	require.NoError(t, err)
+
+	seedCache := func(age time.Duration) {
+		r.mu.Lock()
+		r.cache["https://iss"] = &jwksEntry{
+			keys:      map[string]interface{}{"k1": &key.PublicKey},
+			fetchedAt: time.Now().Add(-age),
+		}
+		r.mu.Unlock()
+	}
+
+	// Stale but within the grace window: the cached key is served despite the fetch failure.
+	seedCache(jwksCacheTTL + jwksStaleGrace - time.Minute)
+	got, err := r.Key(context.Background(), "https://iss", "k1")
+	require.NoError(t, err)
+	assert.Equal(t, &key.PublicKey, got)
+
+	// Beyond the grace window: a failed refetch fails closed (rotated-out key not honoured).
+	seedCache(jwksCacheTTL + jwksStaleGrace + time.Minute)
+	_, err = r.Key(context.Background(), "https://iss", "k1")
+	require.Error(t, err)
 }
 
 func TestNewHTTPJWKSResolver_RejectsInsecureScheme(t *testing.T) {


### PR DESCRIPTION
An adversarial audit of the OIDC / Kubernetes-JWT federation path (ADR-031) — the surface that verifies attacker-influenceable external JWTs against a remote JWKS and maps `(iss,sub)` → a machine identity.

## Verified clean (the headline attacks)
alg pinned to asymmetric (so `alg:none` / HMAC-with-public-key are rejected) · signature verified before any claim is trusted · `iss` checked against the allowlist **before** the JWKS fetch, and the fetch uses the operator-configured `jwks_uri` (not a token-derived URL → **no SSRF**) · `aud`/`exp` required · machine resolved strictly from the verified `(iss,sub)` · no admin bypass · `CreateOIDCBinding` is `roles.assign`-gated and project-scoped.

## Fixed — MEDIUM: unbounded stale-key fallback
On a transient JWKS refetch failure the resolver fell back to a **stale cached key with no age bound**. A key the issuer **rotated out** (e.g. because its private key was compromised) could keep verifying federation tokens for as long as the issuer's JWKS endpoint was unreachable from Keyorix — defeating rotation-as-revocation, and worse where an attacker can also disrupt that connectivity (often the in-cluster API server).

**Fix:** bound the fallback to a short grace window past the cache TTL (`jwksStaleGrace = 10m`). Within the window a recently-cached key is still served on a transient error; beyond it a failed refetch **fails closed**.

## Test
Seeds the cache at controlled ages against a failing JWKS endpoint and asserts served-within-grace / denied-beyond-grace. golangci-lint 0 · gitleaks clean · full suite green. ADR-031 updated with the audit's verified-clean properties + this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)