### PR TITLE
fix(audit): expose chain head + export hashes so truncation is detectable (ADR-029)

### DIFF
--- a/docs/adr-029-audit-log-tamper-evidence.md
+++ b/docs/adr-029-audit-log-tamper-evidence.md
@@ -85,8 +85,25 @@ double-migration hazard).
 - **Detectable**, not **prevented**: an attacker with DB write access can still
   modify rows, but cannot do so *undetectably* without recomputing the entire
   forward chain — and cannot at all if a verified `entry_hash` has been exported
-  off-box (SIEM push already forwards every event). Re-anchoring the head to an
-  external notary/SIEM is a future enhancement.
+  off-box. Re-anchoring the head to an external notary is a future enhancement.
+- **On-box re-verification cannot, by itself, detect tail-truncation or a
+  genesis re-seed** (clarified 2026-06-13 after an internal audit). Because the
+  genesis hash is a fixed public constant and nothing on-box records how long the
+  chain *should* be, deleting the most recent N events — or wiping the chain and
+  re-seeding from genesis — leaves a shorter-but-self-consistent chain that
+  `VerifyAuditChain` accepts. Reorder, insert and middle-deletion remain
+  detectable (they break the linkage). Truncation/re-seed detection requires an
+  **off-box anchor**, now actually delivered:
+  - the verification API returns the chain **`head_hash` + `head_id` +
+    `chained_events`**; an external monitor recording these sees the count drop or
+    the head move for a known prefix — the truncation signal; and
+  - the audit **export** (`GET /audit/export`, SIEM pull) now carries each event's
+    `prev_hash`/`entry_hash`, so the off-box observer holds the chain links and can
+    prove a later on-box head diverges. (Previously the export omitted the hashes,
+    so the "exported `entry_hash` anchors the head" claim was aspirational; it is
+    now real.)
+  - A **signed/notarised in-DB checkpoint** (count + head hash, signed with a key
+    the DBA lacks) would make truncation detectable on-box too — deferred.
 - Audit writes now take a lock + transaction. Audit emission is already
   asynchronous/best-effort and off the request hot path, so the added latency is
   not user-visible.

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -566,6 +566,15 @@ type AuditChainVerification struct {
 	// Reason is a human-readable description of the first failure, empty when
 	// Valid.
 	Reason string
+	// HeadHash is the entry_hash of the last chained event (the chain head),
+	// genesis when there are no chained events. HeadID is its id. Surfaced so an
+	// external monitor can record (ChainedEvents, HeadHash) and detect tail-
+	// truncation or a genesis re-seed — which an unanchored on-box re-walk cannot
+	// catch on its own (ADR-029): a shorter-but-self-consistent chain still
+	// verifies, so the count dropping or the head changing for a known prefix is
+	// the off-box tamper signal.
+	HeadHash string
+	HeadID   uint
 }
 
 // UnusedSecretStat is one row of the unused-secrets report. LastRead is nil when

--- a/internal/storage/store/local_audit_chain.go
+++ b/internal/storage/store/local_audit_chain.go
@@ -124,6 +124,7 @@ func (ls *LocalStorage) VerifyAuditChain(ctx context.Context) (*storage.AuditCha
 	prevHash := auditGenesisHash
 	started := false
 	var lastID uint
+	var headID uint
 
 	for {
 		var batch []*models.AuditEvent
@@ -161,6 +162,7 @@ func (ls *LocalStorage) VerifyAuditChain(ctx context.Context) (*storage.AuditCha
 			}
 
 			prevHash = e.EntryHash
+			headID = e.ID
 			result.ChainedEvents++
 		}
 
@@ -169,6 +171,11 @@ func (ls *LocalStorage) VerifyAuditChain(ctx context.Context) (*storage.AuditCha
 		}
 	}
 
+	// Record the verified head so an external monitor can anchor on it and detect
+	// tail-truncation / re-seed (which a self-consistent shorter chain otherwise
+	// passes). prevHash holds the last chained entry_hash, or genesis if none.
+	result.HeadHash = prevHash
+	result.HeadID = headID
 	return result, nil
 }
 

--- a/internal/storage/store/local_audit_chain_test.go
+++ b/internal/storage/store/local_audit_chain_test.go
@@ -56,6 +56,34 @@ func TestLogAuditEvent_BuildsChain(t *testing.T) {
 	assert.Nil(t, v.FirstBrokenID)
 }
 
+// The verifier exposes the chain head so an external monitor can anchor on it. A
+// tail-truncation leaves a self-consistent shorter chain that on-box verify still
+// accepts (the documented ADR-029 limitation) — but the head hash and count change,
+// which is the off-box tamper signal.
+func TestVerifyAuditChain_HeadAnchorDetectsTruncation(t *testing.T) {
+	ls := newAuditChainTestStore(t)
+	base := time.Now().UTC()
+	appendEvent(t, ls, "auth.login", "first", base)
+	appendEvent(t, ls, "secret.read", "second", base.Add(time.Second))
+	e3 := appendEvent(t, ls, "secret.updated", "third", base.Add(2*time.Second))
+
+	v, err := ls.VerifyAuditChain(context.Background())
+	require.NoError(t, err)
+	require.True(t, v.Valid)
+	assert.Equal(t, int64(3), v.ChainedEvents)
+	assert.Equal(t, e3.EntryHash, v.HeadHash, "head anchors on the last chained event")
+	assert.Equal(t, e3.ID, v.HeadID)
+
+	// A DB-writer truncates the tail. On-box verify still passes…
+	require.NoError(t, ls.db.Where("id = ?", e3.ID).Delete(&models.AuditEvent{}).Error)
+	v2, err := ls.VerifyAuditChain(context.Background())
+	require.NoError(t, err)
+	assert.True(t, v2.Valid, "truncated chain stays internally consistent (the documented limitation)")
+	// …but the recorded anchor moved — the count dropped and the head changed.
+	assert.Equal(t, int64(2), v2.ChainedEvents)
+	assert.NotEqual(t, v.HeadHash, v2.HeadHash)
+}
+
 func TestVerifyAuditChain_DetectsModification(t *testing.T) {
 	ls := newAuditChainTestStore(t)
 	base := time.Now().UTC()

--- a/server/http/handlers/audit.go
+++ b/server/http/handlers/audit.go
@@ -164,6 +164,11 @@ type AuditExportEntry struct {
 	Impersonation  bool            `json:"impersonation,omitempty"`
 	ImpersonatedBy string          `json:"impersonated_by,omitempty"`
 	ActingAs       string          `json:"acting_as,omitempty"`
+	// PrevHash/EntryHash are the ADR-029 chain links. Exporting them gives the SIEM
+	// (the off-box observer) the anchor needed to detect on-box tampering —
+	// including tail-truncation, which on-box re-verification cannot catch.
+	PrevHash  string `json:"prev_hash,omitempty"`
+	EntryHash string `json:"entry_hash,omitempty"`
 }
 
 // ExportAuditLogs handles GET /api/v1/audit/export — a cursor-paginated,
@@ -227,6 +232,8 @@ func (h *AuditHandler) ExportAuditLogs(w http.ResponseWriter, r *http.Request) {
 			IPAddress:   e.IPAddress,
 			ActorType:   actorTypeOrDefault(e.ActorType),
 			Success:     success,
+			PrevHash:    e.PrevHash,
+			EntryHash:   e.EntryHash,
 		}
 		if e.Diff != "" {
 			entry.Diff = json.RawMessage(e.Diff)
@@ -354,6 +361,10 @@ func (h *AuditHandler) VerifyAuditChain(w http.ResponseWriter, r *http.Request) 
 		"valid":            v.Valid,
 		"chained_events":   v.ChainedEvents,
 		"unchained_events": v.UnchainedEvents,
+		// The verified chain head — record (chained_events, head_hash) externally to
+		// detect tail-truncation / re-seed that an on-box re-walk can't catch alone.
+		"head_hash": v.HeadHash,
+		"head_id":   v.HeadID,
 	}
 	if !v.Valid {
 		resp["first_broken_id"] = v.FirstBrokenID


### PR DESCRIPTION
An adversarial audit of the audit-log tamper-evidence hash chain (ADR-029).

## Verified solid (the claims hold)
The entry hash covers **every** security-relevant field (no field can change without changing `entry_hash`); reorder / insert / middle-deletion all break verification; the write path is fully serialized (process mutex + Postgres **xact advisory lock**) with **no unchained insert path**; the verifier genuinely **re-hashes every row** (no spot-check). The unkeyed "a DB-writer can recompute the whole forward chain" property is a **documented, accepted** limitation.

## Fixed — MEDIUM: tail-truncation / genesis re-seed passed verification
On-box `VerifyAuditChain` could **not** detect tail-truncation or a genesis re-seed: genesis is a fixed public constant and nothing records how long the chain *should* be, so deleting the most recent N events (or wiping + re-seeding) leaves a shorter, self-consistent chain that verifies as **valid**. ADR-029 leaned on "an exported `entry_hash` anchors the head" — but the export DTO **omitted the chain hashes**, so that anchor didn't actually exist.

**Fix — deliver the off-box anchor the ADR claims:**
- `GET /audit/verify` now returns **`head_hash` + `head_id`** (with `chained_events`); an external monitor recording these detects a count drop / moved head for a known prefix — the truncation signal.
- `GET /audit/export` (SIEM pull) now carries each event's **`prev_hash`/`entry_hash`**, so the off-box observer holds the chain links and can prove a later on-box head diverges.
- ADR-029 updated to document the limitation honestly and the now-real anchor; a signed in-DB checkpoint (on-box truncation detection) is noted as deferred.

## Test
A tail-truncation leaves on-box verify `Valid` (the documented limitation) **but** `head_hash` changes and `chained_events` drops — the detectable anchor. No data-path or hash-input change; existing chain tests unchanged. lint 0 · gitleaks clean · full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)