### PR TITLE
release: prep v0.13.3 (CHANGELOG + Helm chart 0.13.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,36 @@
 All notable changes to Keyorix are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## v0.13.3 — 2026-06-13
+
+Further security/correctness fixes from the access-control & integrity audit. No
+new features; no config or schema changes.
+
+### Fixed
+- **OIDC/JWKS: bounded stale-key fallback** (ADR-031). On a transient JWKS refetch
+  failure the resolver fell back to a cached signing key with no age bound, so a
+  key the issuer rotated out (e.g. because it was compromised) could keep verifying
+  federation tokens indefinitely while the issuer's JWKS endpoint was unreachable.
+  The fallback is now bounded to a short grace window past the cache TTL; beyond it
+  a failed refetch fails closed. (Affects deployments using OIDC/Kubernetes-JWT
+  federation.) ([#138])
+- **Audit log: tamper-evidence anchor** (ADR-029). On-box chain re-verification
+  could not detect tail-truncation or a genesis re-seed (a shorter, self-consistent
+  chain still verifies), and the documented "SIEM export anchors the head"
+  mitigation was not actually wired — the export omitted the chain hashes.
+  `GET /audit/verify` now returns the chain `head_hash`/`head_id`, and
+  `GET /audit/export` now carries each event's `prev_hash`/`entry_hash`, so an
+  off-box observer can detect truncation. ([#139])
+
+### Internal
+- Added a router-wide regression guard asserting a read-only persona cannot succeed
+  at any mutating route — preventing the access-control privilege-escalation class
+  fixed in v0.13.2 from recurring. ([#140])
+
+[#138]: https://github.com/keyorixhq/keyorix/pull/138
+[#139]: https://github.com/keyorixhq/keyorix/pull/139
+[#140]: https://github.com/keyorixhq/keyorix/pull/140
+
 ## v0.13.2 — 2026-06-13
 
 Authorization-hardening fixes from a systematic adversarial audit of the access

--- a/deploy/helm/keyorix/Chart.yaml
+++ b/deploy/helm/keyorix/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix
 description: Self-hosted Keyorix secrets manager (API server + web UI + PostgreSQL)
 type: application
 # Chart version — bump on chart changes.
-version: 0.13.2
+version: 0.13.3
 # The Keyorix app version this chart deploys by default (the image tag).
-appVersion: "0.13.2"
+appVersion: "0.13.3"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix


### PR DESCRIPTION
Patch release **v0.13.3** — further security/correctness fixes from the access-control & integrity audit. No new features; no config or schema changes.

- **OIDC/JWKS stale-key fallback bound** ([#138]) — a rotated-out (possibly compromised) signing key can no longer verify federation tokens indefinitely during a JWKS outage. (Affects OIDC/K8s-JWT federation deployments.)
- **Audit-log tamper-evidence anchor** ([#139]) — `/audit/verify` now returns the chain `head_hash`; `/audit/export` now carries `prev_hash`/`entry_hash`, delivering the off-box anchor that detects tail-truncation (ADR-029).
- **Internal:** router-wide regression guard preventing the v0.13.2 access-control privesc class from recurring ([#140]).

CHANGELOG + Helm chart `version`/`appVersion` → 0.13.3. Tag `v0.13.3` after merge fires the release + chart + image pipelines.

[#138]: https://github.com/keyorixhq/keyorix/pull/138
[#139]: https://github.com/keyorixhq/keyorix/pull/139
[#140]: https://github.com/keyorixhq/keyorix/pull/140

🤖 Generated with [Claude Code](https://claude.com/claude-code)