### PR TITLE
feat(cli): `keyorix dynamic-secret create` — register a target from the terminal

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -237,9 +237,12 @@ dynamic_secrets:
   sweep_interval: "1m"           # cadence (Go duration); default 1m
 ```
 
-Targets are registered via the API with an admin DSN, a backend type
-(`postgres`, `mysql`, `mongodb`, or `redis`), an optional creation template, and a
-default TTL. The creation template form depends on the backend:
+Targets are registered via the API — or from the terminal with
+`keyorix dynamic-secret create` (the admin DSN is read from the
+`KEYORIX_DYNAMIC_ADMIN_DSN` env var or a hidden prompt, never a flag) — with an
+admin DSN, a backend type (`postgres`, `mysql`, `mongodb`, or `redis`), an optional
+creation template, and a default TTL. The creation template form depends on the
+backend:
 - SQL backends (`postgres`, `mysql`) — an SQL grant template using `{{name}}`.
 - `mongodb` — a JSON role spec (`{"roles": [{"role": "readWrite", "db": "app"}]}`);
   the admin DSN is a MongoDB connection URI.

--- a/internal/cli/dynamic/config_create.go
+++ b/internal/cli/dynamic/config_create.go
@@ -1,0 +1,105 @@
+package dynamic
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"syscall"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/term"
+)
+
+// adminDSNEnv lets operators supply the privileged admin connection string out of
+// band (CI, scripts) instead of the interactive hidden prompt — never as a flag,
+// so it cannot land in shell history or process listings.
+const adminDSNEnv = "KEYORIX_DYNAMIC_ADMIN_DSN"
+
+var (
+	cfgName       string
+	cfgProjectID  int
+	cfgEnvID      int
+	cfgBackend    string
+	cfgTemplate   string
+	cfgDefaultTTL int
+	cfgMaxTTL     int
+)
+
+var createConfigCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Register a new dynamic-secret target config",
+	Long: `Register a target database/store Keyorix can mint on-demand credentials for.
+
+The admin DSN — a privileged connection string used only to create and drop the
+short-lived users — is read from the ` + adminDSNEnv + ` environment variable, or
+prompted for with hidden input. It is never accepted as a flag (so it cannot land
+in shell history); the server encrypts it at rest and never returns it.
+
+Examples:
+  keyorix dynamic-secret create --name app-db --project-id 1 --backend postgres \
+    --creation-template 'GRANT SELECT ON ALL TABLES IN SCHEMA public TO {{name}};'
+  keyorix dynamic-secret create --name cache --project-id 1 --backend redis \
+    --creation-template '~app:* +@read'`,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		if cfgName == "" || cfgProjectID == 0 || cfgBackend == "" {
+			return fmt.Errorf("--name, --project-id and --backend are required")
+		}
+		adminDSN, err := readAdminDSN()
+		if err != nil {
+			return err
+		}
+		c, err := client()
+		if err != nil {
+			return err
+		}
+		body := map[string]any{
+			"name":                cfgName,
+			"project_id":          cfgProjectID,
+			"environment_id":      cfgEnvID,
+			"backend_type":        cfgBackend,
+			"admin_dsn":           adminDSN,
+			"creation_template":   cfgTemplate,
+			"default_ttl_seconds": cfgDefaultTTL,
+			"max_ttl_seconds":     cfgMaxTTL,
+		}
+		var out configView
+		if err := c.Post(context.Background(), "/api/v1/dynamic-secrets/configs", body, &out); err != nil {
+			return err
+		}
+		fmt.Printf("Created dynamic-secret config #%d (%s, %s).\n", out.ID, out.Name, out.BackendType)
+		fmt.Printf("Issue a credential with: keyorix dynamic-secret issue %d\n", out.ID)
+		return nil
+	},
+}
+
+// readAdminDSN resolves the admin DSN from the environment, falling back to a
+// hidden interactive prompt. It is never read from a flag.
+func readAdminDSN() (string, error) {
+	if v := strings.TrimSpace(os.Getenv(adminDSNEnv)); v != "" {
+		return v, nil
+	}
+	fmt.Printf("Admin DSN for the %s target (input hidden): ", cfgBackend)
+	b, err := term.ReadPassword(int(syscall.Stdin))
+	fmt.Println()
+	if err != nil {
+		return "", fmt.Errorf("failed to read admin DSN (set %s for non-interactive use): %w", adminDSNEnv, err)
+	}
+	dsn := strings.TrimSpace(string(b))
+	if dsn == "" {
+		return "", fmt.Errorf("admin DSN is required")
+	}
+	return dsn, nil
+}
+
+func init() {
+	f := createConfigCmd.Flags()
+	f.StringVar(&cfgName, "name", "", "Config name (required)")
+	f.IntVar(&cfgProjectID, "project-id", 0, "Project ID (required)")
+	f.IntVar(&cfgEnvID, "environment-id", 0, "Environment ID (0 = project-wide)")
+	f.StringVar(&cfgBackend, "backend", "", "Backend: postgres | mysql | mongodb | redis (required)")
+	f.StringVar(&cfgTemplate, "creation-template", "", "Backend-specific grant/role/ACL template ({{name}} for SQL)")
+	f.IntVar(&cfgDefaultTTL, "default-ttl", 0, "Default lease TTL in seconds (0 = server default)")
+	f.IntVar(&cfgMaxTTL, "max-ttl", 0, "Max lease TTL ceiling in seconds (0 = no ceiling)")
+	DynamicSecretCmd.AddCommand(createConfigCmd)
+}

--- a/internal/cli/dynamic/dynamic_test.go
+++ b/internal/cli/dynamic/dynamic_test.go
@@ -1,6 +1,7 @@
 package dynamic
 
 import (
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -17,12 +18,16 @@ func TestCommandWiring(t *testing.T) {
 	for _, sub := range DynamicSecretCmd.Commands() {
 		names[sub.Name()] = true
 	}
-	for _, want := range []string{"list", "issue", "leases", "renew", "revoke", "revoke-all"} {
+	for _, want := range []string{"list", "issue", "leases", "renew", "revoke", "revoke-all", "create"} {
 		assert.True(t, names[want], "missing subcommand %q", want)
 	}
 	assert.Contains(t, DynamicSecretCmd.Aliases, "dyn")
 	assert.NotNil(t, issueCmd.Flags().Lookup("ttl"))
 	assert.NotNil(t, listCmd.Flags().Lookup("project-id"))
+	for _, want := range []string{"name", "project-id", "backend", "creation-template", "default-ttl", "max-ttl"} {
+		assert.NotNilf(t, createConfigCmd.Flags().Lookup(want), "create missing --%s flag", want)
+	}
+	assert.Nil(t, createConfigCmd.Flags().Lookup("admin-dsn"), "admin DSN must NOT be a flag (shell-history leak)")
 }
 
 // captureStdout runs fn with os.Stdout redirected and returns what it printed.
@@ -62,6 +67,45 @@ func TestIssueAgainstMockServer(t *testing.T) {
 	assert.Contains(t, out, "lease-abc")
 	assert.Contains(t, out, "kx_dyn_x9")
 	assert.Contains(t, out, "s3cr3t-pw")
+}
+
+// TestCreateConfigAgainstMockServer drives `create` against a stub API and checks
+// it POSTs to /configs with the admin DSN sourced from the env var (never a flag).
+func TestCreateConfigAgainstMockServer(t *testing.T) {
+	var gotMethod, gotPath string
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod, gotPath = r.Method, r.URL.Path
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		_, _ = w.Write([]byte(`{"data":{"id":42,"name":"app-db","backend_type":"postgres"}}`))
+	}))
+	defer srv.Close()
+
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+	t.Setenv(adminDSNEnv, "postgres://admin:p@db:5432/app")
+	cfgName, cfgProjectID, cfgEnvID, cfgBackend = "app-db", 1, 0, "postgres"
+	cfgTemplate, cfgDefaultTTL, cfgMaxTTL = "GRANT SELECT TO {{name}};", 3600, 0
+
+	out := captureStdout(t, func() {
+		require.NoError(t, createConfigCmd.RunE(createConfigCmd, nil))
+	})
+
+	assert.Equal(t, http.MethodPost, gotMethod)
+	assert.Equal(t, "/api/v1/dynamic-secrets/configs", gotPath)
+	// The admin DSN is read from the env var (never a flag) and posted to the server.
+	assert.Equal(t, "postgres://admin:p@db:5432/app", gotBody["admin_dsn"])
+	assert.Equal(t, "app-db", gotBody["name"])
+	assert.Equal(t, "postgres", gotBody["backend_type"])
+	assert.Contains(t, out, "config #42")
+}
+
+// Required flags are validated before any network/credential I/O.
+func TestCreateConfig_RequiresFlags(t *testing.T) {
+	cfgName, cfgProjectID, cfgBackend = "", 0, ""
+	err := createConfigCmd.RunE(createConfigCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "required")
 }
 
 func TestRevokeAllAgainstMockServer(t *testing.T) {


### PR DESCRIPTION
Dynamic-secret target configs could be created only via the API/UI — the CLI could `list`/`issue`/`renew`/`revoke` but not register a target. This adds the **`create`** command so operators can script target setup, rounding out the `keyorix dynamic-secret` CLI.

## Usage
```
keyorix dynamic-secret create --name app-db --project-id 1 --backend postgres \
  --creation-template 'GRANT SELECT ON ALL TABLES IN SCHEMA public TO {{name}};'

keyorix dynamic-secret create --name cache --project-id 1 --backend redis \
  --creation-template '~app:* +@read'
```

- Flags: `--name`, `--project-id` (required), `--backend` (postgres|mysql|mongodb|redis, required), `--environment-id`, `--creation-template`, `--default-ttl`, `--max-ttl`.
- **The admin DSN is NOT a flag** — it would land in shell history / process listings. It's read from `KEYORIX_DYNAMIC_ADMIN_DSN` for non-interactive use, else prompted for with **hidden input** (`term.ReadPassword`), matching how the CLI already reads API keys / secret values. The server encrypts it at rest and never returns it (unchanged).
- POSTs to `/api/v1/dynamic-secrets/configs` via the shared `RemoteClient` (same authz as the other commands); prints the new config id + an `issue` follow-up hint.

## Tests
Wiring guard extended (the `create` subcommand + its flags are present, and **admin-dsn is asserted NOT to be a flag**); `create` against a stub API asserts the POST path and that the admin DSN is sourced from the env var; required-flags validation. CONFIGURATION.md updated. lint 0 · gitleaks clean · full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)