### PR TITLE
feat(auth): per-environment PAT confinement — completes ADR-042 scoping axes

### DIFF
--- a/docs/adr-042-pat-permission-scoping.md
+++ b/docs/adr-042-pat-permission-scoping.md
@@ -96,12 +96,25 @@ runs. An existing token, or one created without a restriction, is unaffected
   already serve the "first-class non-human principal" need; this is the lighter
   "narrow a token I already trust myself to hold" case.
 
+## Addendum (2026-06-13): per-environment confinement
+
+The scoping axes are now complete: a PAT may also be confined to a single
+**environment** via `environment_scope` (a third optional dimension alongside the
+permission allowlist and `project_scope`). `PATRestriction.EnvironmentID` denies
+any check whose resolved scope is a different environment — or a project-level /
+global scope (`environment 0`). Secret-level checks carry the secret's
+environment, so this confines a token to that env's secrets (e.g. a staging-only
+CI credential); broader project-level operations resolve `environment 0` and are
+therefore denied for an environment-scoped token — correct least privilege.
+Environment ids are globally unique, so confining to an environment also pins its
+project. Additive `environment_scope` column (default 0 = any), enforced via the
+same ctx-carried filter at the `Authorize`/`AuthorizePrincipal` chokepoint;
+existing tokens are unaffected.
+
 ## Deferred
 
-- **Per-environment confinement** (a token bound to `prod` only) — `Scope` already
-  carries an environment axis; the model/filter can extend to it when needed.
-- **Frontend (My Account) UI** to pick scopes/project when creating a token — the
-  API and storage are complete; the keyorix-web token-creation dialog is the
-  remaining surface.
+- **Frontend env dropdown** — the My Account scope picker (keyorix-web) offers the
+  permission allowlist + project; an environment selector (cascading from the
+  chosen project) is the remaining UI surface for `environment_scope`.
 - **Scope presets** (e.g. a "read-only" macro expanding to the read permissions).
-- **CLI `--scope` / `--project` flags** on token creation.
+- **CLI `--scope` / `--project` / `--environment` flags** on token creation.

--- a/internal/core/authz.go
+++ b/internal/core/authz.go
@@ -32,6 +32,15 @@ type PATRestriction struct {
 	// any check at a different project — or at global/system scope (project 0) —
 	// is denied. Zero = any scope the owner can reach.
 	ProjectID uint
+	// EnvironmentID, when non-zero, further restricts the token to that one
+	// environment: any check whose resolved scope is a different environment — or a
+	// project-level/global scope (environment 0) — is denied. Environment ids are
+	// globally unique, so this confines the token to that env's project too. Zero =
+	// any environment. (Secret-level checks carry the secret's environment; broader
+	// project-level operations resolve environment 0 and so are denied for an
+	// environment-scoped token — correct least privilege for, e.g., a staging-only
+	// CI credential.)
+	EnvironmentID uint
 }
 
 // Allows reports whether this restriction permits exercising permission at scope.
@@ -44,6 +53,11 @@ func (r *PATRestriction) Allows(permission string, scope Scope) bool {
 	// scope (ProjectID 0 — system-wide actions like users.read) is therefore
 	// denied for a project-scoped token: it is not a system credential.
 	if r.ProjectID != 0 && scope.ProjectID != r.ProjectID {
+		return false
+	}
+	// An environment-scoped token may act ONLY within its environment; a check at a
+	// different (or project-level/global) environment is denied.
+	if r.EnvironmentID != 0 && scope.EnvironmentID != r.EnvironmentID {
 		return false
 	}
 	if len(r.Permissions) == 0 {

--- a/internal/core/authz_pat_test.go
+++ b/internal/core/authz_pat_test.go
@@ -36,6 +36,12 @@ func TestPATRestriction_Allows(t *testing.T) {
 		{"both axes must pass — wrong project", &PATRestriction{Permissions: []string{"secrets.read"}, ProjectID: 5}, "secrets.read", Scope{ProjectID: 6}, false},
 		{"both axes must pass — wrong perm", &PATRestriction{Permissions: []string{"secrets.read"}, ProjectID: 5}, "secrets.write", proj5, false},
 		{"both axes pass", &PATRestriction{Permissions: []string{"secrets.read"}, ProjectID: 5}, "secrets.read", proj5, true},
+		// Environment axis (ADR-042 env confinement).
+		{"env-scoped token allowed within its env", &PATRestriction{EnvironmentID: 9}, "secrets.read", Scope{ProjectID: 5, EnvironmentID: 9}, true},
+		{"env-scoped token denied in other env", &PATRestriction{EnvironmentID: 9}, "secrets.read", Scope{ProjectID: 5, EnvironmentID: 8}, false},
+		{"env-scoped token denied at project-level scope (env 0)", &PATRestriction{EnvironmentID: 9}, "secrets.read", proj5, false},
+		{"project+env both pass", &PATRestriction{ProjectID: 5, EnvironmentID: 9}, "secrets.read", Scope{ProjectID: 5, EnvironmentID: 9}, true},
+		{"project+env — wrong env denied", &PATRestriction{ProjectID: 5, EnvironmentID: 9}, "secrets.read", Scope{ProjectID: 5, EnvironmentID: 8}, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/core/pat.go
+++ b/internal/core/pat.go
@@ -3,8 +3,9 @@
 // A PAT is a long-lived bearer credential a user creates from the My Account page.
 // It authenticates API requests AS that user. By default it inherits the owner's
 // full permission set; optionally (ADR-042) it carries a least-privilege
-// restriction — a permission allowlist and/or a single-project scope — that
-// narrows it below the owner (never above). The raw token is returned once on
+// restriction — a permission allowlist and/or a single-project or single-
+// environment scope — that narrows it below the owner (never above). The raw
+// token is returned once on
 // creation; only its SHA-256 hash is stored. Raw tokens carry the patPrefix so the
 // auth middleware can route them to ValidatePATToken and secret scanners can detect
 // leaks.
@@ -39,11 +40,12 @@ type CreatePATResult struct {
 
 // CreateOwnPAT generates a new personal access token for the caller. expiresAt may
 // be nil for a non-expiring token. scopes, when non-empty, is a least-privilege
-// permission allowlist (ADR-042); projectScope, when non-zero, confines the token
-// to a single project. Both only ever NARROW the token below its owner — they are
-// enforced at request time as a filter intersected with the owner's live
-// permissions, so a token can never grant more than its owner currently holds.
-func (c *KeyorixCore) CreateOwnPAT(ctx context.Context, userID uint, name string, expiresAt *time.Time, scopes []string, projectScope uint) (*CreatePATResult, error) {
+// permission allowlist (ADR-042); projectScope/environmentScope, when non-zero,
+// confine the token to a single project / environment. All only ever NARROW the
+// token below its owner — they are enforced at request time as a filter
+// intersected with the owner's live permissions, so a token can never grant more
+// than its owner currently holds.
+func (c *KeyorixCore) CreateOwnPAT(ctx context.Context, userID uint, name string, expiresAt *time.Time, scopes []string, projectScope, environmentScope uint) (*CreatePATResult, error) {
 	if userID == 0 {
 		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "user ID is required")
 	}
@@ -63,14 +65,15 @@ func (c *KeyorixCore) CreateOwnPAT(ctx context.Context, userID uint, name string
 	raw := patPrefix + base64.RawURLEncoding.EncodeToString(b)
 
 	pat := &models.PersonalAccessToken{
-		UserID:       userID,
-		Name:         strings.TrimSpace(name),
-		TokenHash:    sha256Hex(raw),
-		TokenPrefix:  raw[:len(patPrefix)+6], // e.g. "kx_pat_ab12cd" for display
-		Scopes:       scopesJSON,
-		ProjectScope: projectScope,
-		ExpiresAt:    expiresAt,
-		CreatedAt:    c.now(),
+		UserID:           userID,
+		Name:             strings.TrimSpace(name),
+		TokenHash:        sha256Hex(raw),
+		TokenPrefix:      raw[:len(patPrefix)+6], // e.g. "kx_pat_ab12cd" for display
+		Scopes:           scopesJSON,
+		ProjectScope:     projectScope,
+		EnvironmentScope: environmentScope,
+		ExpiresAt:        expiresAt,
+		CreatedAt:        c.now(),
 	}
 	created, err := c.storage.CreatePersonalAccessToken(ctx, pat)
 	if err != nil {
@@ -191,8 +194,8 @@ func DecodePATScopes(raw string) []string {
 // the token is unrestricted (no scopes and no project confinement).
 func patRestrictionFrom(pat *models.PersonalAccessToken) *PATRestriction {
 	scopes := DecodePATScopes(pat.Scopes)
-	if len(scopes) == 0 && pat.ProjectScope == 0 {
+	if len(scopes) == 0 && pat.ProjectScope == 0 && pat.EnvironmentScope == 0 {
 		return nil
 	}
-	return &PATRestriction{Permissions: scopes, ProjectID: pat.ProjectScope}
+	return &PATRestriction{Permissions: scopes, ProjectID: pat.ProjectScope, EnvironmentID: pat.EnvironmentScope}
 }

--- a/internal/core/pat_scoping_e2e_test.go
+++ b/internal/core/pat_scoping_e2e_test.go
@@ -55,7 +55,7 @@ func TestPATScoping_EndToEnd_RealRBAC(t *testing.T) {
 	})
 
 	t.Run("permission-scoped PAT bounds the admin to read-only", func(t *testing.T) {
-		res, err := c.CreateOwnPAT(ctx, admin.ID, "ci-read", nil, []string{"secrets.read"}, 0)
+		res, err := c.CreateOwnPAT(ctx, admin.ID, "ci-read", nil, []string{"secrets.read"}, 0, 0)
 		require.NoError(t, err)
 
 		user, _, restriction, err := c.ValidatePATToken(ctx, res.PlainToken)
@@ -74,7 +74,7 @@ func TestPATScoping_EndToEnd_RealRBAC(t *testing.T) {
 	})
 
 	t.Run("project-scoped PAT is confined to its project", func(t *testing.T) {
-		res, err := c.CreateOwnPAT(ctx, admin.ID, "ci-proj3", nil, nil, 3)
+		res, err := c.CreateOwnPAT(ctx, admin.ID, "ci-proj3", nil, nil, 3, 0)
 		require.NoError(t, err)
 		_, _, restriction, err := c.ValidatePATToken(ctx, res.PlainToken)
 		require.NoError(t, err)
@@ -94,8 +94,30 @@ func TestPATScoping_EndToEnd_RealRBAC(t *testing.T) {
 		assert.False(t, globalScope, "a project-scoped token is not a system-wide credential")
 	})
 
+	t.Run("environment-scoped PAT is confined to its environment", func(t *testing.T) {
+		res, err := c.CreateOwnPAT(ctx, admin.ID, "ci-env7", nil, nil, 0, 7) // env 7 only
+		require.NoError(t, err)
+		_, _, restriction, err := c.ValidatePATToken(ctx, res.PlainToken)
+		require.NoError(t, err)
+		require.NotNil(t, restriction)
+		require.Equal(t, uint(7), restriction.EnvironmentID)
+		rctx := WithPATRestriction(ctx, restriction)
+
+		inEnv, err := c.AuthorizePrincipal(rctx, ActorTypeUser, admin.ID, "secrets.write", Scope{ProjectID: 3, EnvironmentID: 7})
+		require.NoError(t, err)
+		assert.True(t, inEnv, "writes within the token's environment flow through the admin bypass")
+
+		otherEnv, err := c.AuthorizePrincipal(rctx, ActorTypeUser, admin.ID, "secrets.write", Scope{ProjectID: 3, EnvironmentID: 8})
+		require.NoError(t, err)
+		assert.False(t, otherEnv, "an env-7 token cannot touch env 8")
+
+		projectLevel, err := c.AuthorizePrincipal(rctx, ActorTypeUser, admin.ID, "secrets.write", Scope{ProjectID: 3})
+		require.NoError(t, err)
+		assert.False(t, projectLevel, "an env-scoped token cannot do project-level (env 0) operations")
+	})
+
 	t.Run("unrestricted PAT resolves to no restriction and keeps full inheritance", func(t *testing.T) {
-		res, err := c.CreateOwnPAT(ctx, admin.ID, "ci-full", nil, nil, 0)
+		res, err := c.CreateOwnPAT(ctx, admin.ID, "ci-full", nil, nil, 0, 0)
 		require.NoError(t, err)
 		_, _, restriction, err := c.ValidatePATToken(ctx, res.PlainToken)
 		require.NoError(t, err)

--- a/internal/core/pat_test.go
+++ b/internal/core/pat_test.go
@@ -23,7 +23,7 @@ func TestCreateOwnPAT(t *testing.T) {
 			Run(func(args mock.Arguments) { captured = args.Get(1).(*models.PersonalAccessToken) }).
 			Return(&models.PersonalAccessToken{ID: 1}, nil)
 
-		res, err := c.CreateOwnPAT(ctx, 1, "ci-token", nil, nil, 0)
+		res, err := c.CreateOwnPAT(ctx, 1, "ci-token", nil, nil, 0, 0)
 		require.NoError(t, err)
 		assert.True(t, strings.HasPrefix(res.PlainToken, patPrefix), "raw token carries the kx_pat_ prefix")
 		require.NotNil(t, captured)
@@ -42,7 +42,7 @@ func TestCreateOwnPAT(t *testing.T) {
 			Run(func(args mock.Arguments) { captured = args.Get(1).(*models.PersonalAccessToken) }).
 			Return(&models.PersonalAccessToken{ID: 1}, nil)
 
-		_, err := c.CreateOwnPAT(ctx, 1, "ci-read-only", nil, []string{"secrets.read", "  ", "secrets.read"}, 7)
+		_, err := c.CreateOwnPAT(ctx, 1, "ci-read-only", nil, []string{"secrets.read", "  ", "secrets.read"}, 7, 0)
 		require.NoError(t, err)
 		require.NotNil(t, captured)
 		// Blanks dropped, duplicates removed, encoded as JSON.
@@ -58,7 +58,7 @@ func TestCreateOwnPAT(t *testing.T) {
 	t.Run("rejects an empty name", func(t *testing.T) {
 		ms := new(MockStorage)
 		c := NewKeyorixCore(ms)
-		_, err := c.CreateOwnPAT(ctx, 1, "   ", nil, nil, 0)
+		_, err := c.CreateOwnPAT(ctx, 1, "   ", nil, nil, 0, 0)
 		require.Error(t, err)
 		ms.AssertNotCalled(t, "CreatePersonalAccessToken", mock.Anything, mock.Anything)
 	})

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -286,7 +286,7 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 		}
 	} else {
 		m := db.Migrator()
-		for _, col := range []string{"Scopes", "ProjectScope"} {
+		for _, col := range []string{"Scopes", "ProjectScope", "EnvironmentScope"} {
 			if !m.HasColumn(&models.PersonalAccessToken{}, col) {
 				if err := m.AddColumn(&models.PersonalAccessToken{}, col); err != nil {
 					return fmt.Errorf("failed to add personal_access_tokens.%s column: %w", col, err)

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -382,10 +382,14 @@ type PersonalAccessToken struct {
 	// project's scope (and denies global/system-wide actions). 0 = any scope the
 	// owner can reach. Mirrors the 0 = global sentinel used throughout RBAC.
 	ProjectScope uint `gorm:"default:0"`
-	LastUsedAt   *time.Time
-	ExpiresAt    *time.Time // nil = never expires
-	Revoked      bool       `gorm:"default:false"`
-	CreatedAt    time.Time
+	// EnvironmentScope, when non-zero, further confines the token to a single
+	// environment (ADR-042). 0 = any environment. Environment ids are globally
+	// unique, so this also pins the project.
+	EnvironmentScope uint `gorm:"default:0"`
+	LastUsedAt       *time.Time
+	ExpiresAt        *time.Time // nil = never expires
+	Revoked          bool       `gorm:"default:false"`
+	CreatedAt        time.Time
 }
 
 // SetupToken is the single-use, hashed-at-rest bearer string that lets a brand-new

--- a/server/http/handlers/openapi.yaml
+++ b/server/http/handlers/openapi.yaml
@@ -330,6 +330,7 @@ paths:
                 expires_at: {type: string, format: date-time, nullable: true, description: 'RFC3339; omit/null for non-expiring'}
                 scopes: {type: array, items: {type: string}, description: 'ADR-042 least-privilege allowlist (e.g. ["secrets.read"], supports "*" and "secrets.*"). Omit/empty = inherit the owner''s full permissions. Only ever narrows below the owner.'}
                 project_scope: {type: integer, description: 'ADR-042: confine the token to a single project id; 0/omit = any project the owner can reach.'}
+                environment_scope: {type: integer, description: 'ADR-042: confine the token to a single environment id; 0/omit = any environment. Env ids are globally unique, so this also pins the project.'}
       responses:
         '201': {description: 'Token created; plaintext token in data.token shown once'}
         '400': {$ref: '#/components/responses/Error'}

--- a/server/http/handlers/pat_handler.go
+++ b/server/http/handlers/pat_handler.go
@@ -33,26 +33,28 @@ func NewPATHandler(coreService *core.KeyorixCore) *PATHandler {
 // scopes/project_scope surface the ADR-042 least-privilege restriction (read-only;
 // a token's scope is fixed at creation).
 type patResponse struct {
-	ID           uint     `json:"id"`
-	Name         string   `json:"name"`
-	TokenPrefix  string   `json:"token_prefix"`
-	Revoked      bool     `json:"revoked"`
-	CreatedAt    string   `json:"created_at"`
-	ExpiresAt    *string  `json:"expires_at"`
-	LastUsedAt   *string  `json:"last_used_at"`
-	Scopes       []string `json:"scopes"`        // empty = inherits the owner's full permissions
-	ProjectScope uint     `json:"project_scope"` // 0 = any project the owner can reach
+	ID               uint     `json:"id"`
+	Name             string   `json:"name"`
+	TokenPrefix      string   `json:"token_prefix"`
+	Revoked          bool     `json:"revoked"`
+	CreatedAt        string   `json:"created_at"`
+	ExpiresAt        *string  `json:"expires_at"`
+	LastUsedAt       *string  `json:"last_used_at"`
+	Scopes           []string `json:"scopes"`            // empty = inherits the owner's full permissions
+	ProjectScope     uint     `json:"project_scope"`     // 0 = any project the owner can reach
+	EnvironmentScope uint     `json:"environment_scope"` // 0 = any environment
 }
 
 func toPATResponse(t *models.PersonalAccessToken) patResponse {
 	resp := patResponse{
-		ID:           t.ID,
-		Name:         t.Name,
-		TokenPrefix:  t.TokenPrefix,
-		Revoked:      t.Revoked,
-		CreatedAt:    t.CreatedAt.UTC().Format(time.RFC3339),
-		Scopes:       core.DecodePATScopes(t.Scopes),
-		ProjectScope: t.ProjectScope,
+		ID:               t.ID,
+		Name:             t.Name,
+		TokenPrefix:      t.TokenPrefix,
+		Revoked:          t.Revoked,
+		CreatedAt:        t.CreatedAt.UTC().Format(time.RFC3339),
+		Scopes:           core.DecodePATScopes(t.Scopes),
+		ProjectScope:     t.ProjectScope,
+		EnvironmentScope: t.EnvironmentScope,
 	}
 	if t.ExpiresAt != nil {
 		v := t.ExpiresAt.UTC().Format(time.RFC3339)
@@ -92,6 +94,8 @@ type createPATRequestBody struct {
 	Scopes []string `json:"scopes"`
 	// ProjectScope optionally confines the token to a single project (0/omit = any).
 	ProjectScope uint `json:"project_scope"`
+	// EnvironmentScope optionally confines the token to one environment (0/omit = any).
+	EnvironmentScope uint `json:"environment_scope"`
 }
 
 // CreatePAT handles POST /auth/tokens. The raw token is returned exactly once.
@@ -117,7 +121,7 @@ func (h *PATHandler) CreatePAT(w http.ResponseWriter, r *http.Request) {
 		expiresAt = &t
 	}
 
-	result, err := h.coreService.CreateOwnPAT(r.Context(), userCtx.UserID, body.Name, expiresAt, body.Scopes, body.ProjectScope)
+	result, err := h.coreService.CreateOwnPAT(r.Context(), userCtx.UserID, body.Name, expiresAt, body.Scopes, body.ProjectScope, body.EnvironmentScope)
 	if err != nil {
 		sendError(w, "BadRequest", err.Error(), http.StatusBadRequest, nil)
 		return


### PR DESCRIPTION
A personal access token could already be scoped to a permission allowlist and/or a single **project** (ADR-042). This adds the third and final axis — an optional single-**environment** confinement — so a token can be, e.g., a **staging-only CI credential**.

## How
- `PersonalAccessToken.EnvironmentScope` — additive column (default 0 = any env), migrated via the `Migrator` on existing DBs alongside `Scopes`/`ProjectScope`.
- `PATRestriction.EnvironmentID` — `Allows()` denies any check whose resolved scope is a **different environment**, or a project-level/global scope (`environment 0`). Enforced at the same `Authorize`/`AuthorizePrincipal` chokepoint as the other axes, **before role resolution and the admin bypass**, so it bounds even a global admin's own token.
- **Semantics:** secret-level checks carry the secret's environment, so this confines the token to that env's secrets; broader project-level operations resolve `environment 0` and are therefore denied — correct least privilege. Env ids are globally unique, so confining to an env also pins its project. A pure narrowing filter; existing/unrestricted tokens unaffected.
- **API:** `POST /auth/tokens` accepts optional `environment_scope`; the DTO surfaces it read-only. `openapi.yaml` updated.

## Tests
`Allows()` env-axis table (within/other env, project-level denied, project+env both-must-pass); real-RBAC e2e — an **env-7-confined token on a GLOBAL ADMIN** may write in env 7 but is denied env 8 and project-level (env 0). lint 0 · gitleaks clean · full suite green.

ADR-042 addendum documents the now-complete scoping axes; the frontend env dropdown (cascading from the chosen project) is noted as the remaining UI surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)