### PR TITLE
release: prep v0.15.0 (CHANGELOG + Helm chart 0.15.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,29 @@
 All notable changes to Keyorix are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## v0.15.0 — 2026-06-13
+
+Migration reach and least-privilege completion. No config or schema changes
+(the PAT scoping column is an additive, default-off migration).
+
+### Added
+- **Import from Google Cloud Secret Manager** — `keyorix secret import --source gcp
+  --gcp-project <id>` is the fourth live migration source after Vault, AWS Secrets
+  Manager and Azure Key Vault, completing big-3 cloud coverage. Authenticates with
+  Application Default Credentials, reads each secret's latest enabled version, and
+  explodes JSON values per field. Credentials stay CLI-side; the GCP SDK links into
+  the CLI binary only. ([#145])
+- **Per-environment PAT confinement** — a personal access token can now be confined
+  to a single environment (`environment_scope` on `POST /auth/tokens`), the third
+  and final least-privilege scoping axis alongside the permission allowlist and
+  project confinement (ADR-042). A token scoped to an environment may act only on
+  that environment's secrets — e.g. a staging-only CI credential. Enforced before
+  the admin bypass, so it bounds even an admin's own token. Existing tokens are
+  unaffected. ([#146])
+
+[#145]: https://github.com/keyorixhq/keyorix/pull/145
+[#146]: https://github.com/keyorixhq/keyorix/pull/146
+
 ## v0.14.0 — 2026-06-13
 
 Dynamic-secrets expansion: a fourth backend and full CLI lifecycle coverage.

--- a/deploy/helm/keyorix/Chart.yaml
+++ b/deploy/helm/keyorix/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix
 description: Self-hosted Keyorix secrets manager (API server + web UI + PostgreSQL)
 type: application
 # Chart version — bump on chart changes.
-version: 0.14.0
+version: 0.15.0
 # The Keyorix app version this chart deploys by default (the image tag).
-appVersion: "0.14.0"
+appVersion: "0.15.0"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix


### PR DESCRIPTION
Minor release **v0.15.0** — migration reach + least-privilege completion. No config/schema changes (the PAT scoping column is additive, default-off).

- **GCP Secret Manager import** ([#145]) — `keyorix secret import --source gcp`, the 4th live migration source (Vault/AWS/Azure/GCP).
- **Per-environment PAT confinement** ([#146]) — the third/final ADR-042 scoping axis; a token can be confined to one environment (staging-only CI credential).

CHANGELOG + Helm chart `version`/`appVersion` → 0.15.0. Tag `v0.15.0` after merge fires the release + chart + image pipelines.

[#145]: https://github.com/keyorixhq/keyorix/pull/145
[#146]: https://github.com/keyorixhq/keyorix/pull/146

🤖 Generated with [Claude Code](https://claude.com/claude-code)