### PR TITLE
feat(cli): `keyorix pat` — create/list/revoke personal access tokens

### DIFF
--- a/docs/adr-042-pat-permission-scoping.md
+++ b/docs/adr-042-pat-permission-scoping.md
@@ -117,4 +117,4 @@ existing tokens are unaffected.
   permission allowlist + project; an environment selector (cascading from the
   chosen project) is the remaining UI surface for `environment_scope`.
 - **Scope presets** (e.g. a "read-only" macro expanding to the read permissions).
-- **CLI `--scope` / `--project` / `--environment` flags** on token creation.
+- ~~CLI flags on token creation~~ — **shipped**: `keyorix pat create --scope … --project-id … --environment-id …` (plus `pat list` / `pat revoke`).

--- a/internal/cli/main.go
+++ b/internal/cli/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/keyorixhq/keyorix/internal/cli/invite"
 	"github.com/keyorixhq/keyorix/internal/cli/machine"
 	"github.com/keyorixhq/keyorix/internal/cli/migrate"
+	"github.com/keyorixhq/keyorix/internal/cli/pat"
 	"github.com/keyorixhq/keyorix/internal/cli/project"
 	"github.com/keyorixhq/keyorix/internal/cli/rbac"
 	"github.com/keyorixhq/keyorix/internal/cli/request"
@@ -57,6 +58,7 @@ func init() {
 	rootCmd.AddCommand(system.SystemCmd)
 	rootCmd.AddCommand(anomalies.AnomaliesCmd)
 	rootCmd.AddCommand(dynamic.DynamicSecretCmd)
+	rootCmd.AddCommand(pat.PATCmd)
 }
 
 // Execute runs the root command

--- a/internal/cli/pat/pat.go
+++ b/internal/cli/pat/pat.go
@@ -1,0 +1,186 @@
+// Package pat provides the `keyorix pat` CLI — self-service Personal Access Tokens
+// (ADR-027/ADR-042) from the terminal: create a (optionally least-privilege-scoped)
+// token, list your tokens, and revoke one. All commands talk to the server's REST
+// API under /api/v1/auth/tokens (self-scoped to the authenticated caller); the raw
+// token is shown exactly once, on create.
+package pat
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/spf13/cobra"
+)
+
+// PATCmd is the root `keyorix pat` command.
+var PATCmd = &cobra.Command{
+	Use:     "pat",
+	Aliases: []string{"token", "tokens"},
+	Short:   "Create and manage personal access tokens",
+}
+
+var (
+	flagName    string
+	flagExpires string
+	flagScopes  []string
+	flagProject int
+	flagEnv     int
+)
+
+func init() {
+	createCmd.Flags().StringVar(&flagName, "name", "", "Token name (required)")
+	createCmd.Flags().StringVar(&flagExpires, "expires", "", "Expiry (RFC3339 or YYYY-MM-DD; omit = never)")
+	createCmd.Flags().StringArrayVar(&flagScopes, "scope", nil, "Least-privilege permission (repeatable; e.g. --scope secrets.read). Omit = inherit all your permissions")
+	createCmd.Flags().IntVar(&flagProject, "project-id", 0, "Confine the token to a single project (0 = any)")
+	createCmd.Flags().IntVar(&flagEnv, "environment-id", 0, "Confine the token to a single environment (0 = any; only with --project-id)")
+	PATCmd.AddCommand(createCmd, listCmd, revokeCmd)
+}
+
+func client() (*common.RemoteClient, error) {
+	c, ok := common.NewRemoteClient()
+	if !ok {
+		return nil, fmt.Errorf("not connected to a server — run: keyorix connect <server>")
+	}
+	return c, nil
+}
+
+type patView struct {
+	ID               uint     `json:"id"`
+	Name             string   `json:"name"`
+	TokenPrefix      string   `json:"token_prefix"`
+	Revoked          bool     `json:"revoked"`
+	ExpiresAt        *string  `json:"expires_at"`
+	LastUsedAt       *string  `json:"last_used_at"`
+	Scopes           []string `json:"scopes"`
+	ProjectScope     uint     `json:"project_scope"`
+	EnvironmentScope uint     `json:"environment_scope"`
+}
+
+var createCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create a personal access token (the raw token is shown once)",
+	RunE: func(_ *cobra.Command, _ []string) error {
+		if strings.TrimSpace(flagName) == "" {
+			return fmt.Errorf("--name is required")
+		}
+		if flagEnv > 0 && flagProject == 0 {
+			return fmt.Errorf("--environment-id requires --project-id (an environment belongs to a project)")
+		}
+		body := map[string]any{"name": flagName}
+		if flagExpires != "" {
+			exp, err := normalizeExpiry(flagExpires)
+			if err != nil {
+				return err
+			}
+			body["expires_at"] = exp
+		}
+		if len(flagScopes) > 0 {
+			body["scopes"] = flagScopes
+		}
+		if flagProject > 0 {
+			body["project_scope"] = flagProject
+		}
+		if flagEnv > 0 {
+			body["environment_scope"] = flagEnv
+		}
+
+		c, err := client()
+		if err != nil {
+			return err
+		}
+		var out struct {
+			Token string  `json:"token"`
+			Pat   patView `json:"pat"`
+		}
+		if err := c.Post(context.Background(), "/api/v1/auth/tokens", body, &out); err != nil {
+			return err
+		}
+		fmt.Println("Token created — copy it now, it will not be shown again:")
+		fmt.Printf("  %s\n", out.Token)
+		fmt.Printf("  id:    %d\n  name:  %s\n  scope: %s\n", out.Pat.ID, out.Pat.Name, describeScope(out.Pat))
+		return nil
+	},
+}
+
+var listCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List your personal access tokens",
+	RunE: func(_ *cobra.Command, _ []string) error {
+		c, err := client()
+		if err != nil {
+			return err
+		}
+		var tokens []patView
+		if err := c.Get(context.Background(), "/api/v1/auth/tokens", &tokens); err != nil {
+			return err
+		}
+		if len(tokens) == 0 {
+			fmt.Println("You have no personal access tokens.")
+			return nil
+		}
+		fmt.Printf("%-5s %-22s %-14s %-9s %s\n", "ID", "NAME", "PREFIX", "REVOKED", "SCOPE")
+		for _, t := range tokens {
+			fmt.Printf("%-5d %-22s %-14s %-9t %s\n", t.ID, t.Name, t.TokenPrefix+"…", t.Revoked, describeScope(t))
+		}
+		return nil
+	},
+}
+
+var revokeCmd = &cobra.Command{
+	Use:   "revoke <token-id>",
+	Short: "Revoke one of your tokens",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(_ *cobra.Command, args []string) error {
+		id, err := strconv.Atoi(args[0])
+		if err != nil {
+			return fmt.Errorf("invalid token id: %s", args[0])
+		}
+		c, err := client()
+		if err != nil {
+			return err
+		}
+		if err := c.Delete(context.Background(), fmt.Sprintf("/api/v1/auth/tokens/%d", id)); err != nil {
+			return err
+		}
+		fmt.Printf("Token %d revoked.\n", id)
+		return nil
+	},
+}
+
+// normalizeExpiry accepts an RFC3339 timestamp or a bare YYYY-MM-DD date (treated
+// as start-of-day UTC) and returns an RFC3339 string for the API.
+func normalizeExpiry(v string) (string, error) {
+	if strings.Contains(v, "T") {
+		if _, err := time.Parse(time.RFC3339, v); err != nil {
+			return "", fmt.Errorf("invalid --expires %q (want RFC3339 or YYYY-MM-DD): %w", v, err)
+		}
+		return v, nil
+	}
+	d, err := time.Parse("2006-01-02", v)
+	if err != nil {
+		return "", fmt.Errorf("invalid --expires %q (want RFC3339 or YYYY-MM-DD): %w", v, err)
+	}
+	return d.UTC().Format(time.RFC3339), nil
+}
+
+// describeScope renders a one-line summary of a token's least-privilege restriction.
+func describeScope(t patView) string {
+	if len(t.Scopes) == 0 && t.ProjectScope == 0 && t.EnvironmentScope == 0 {
+		return "full access"
+	}
+	parts := make([]string, 0, 3)
+	if t.ProjectScope > 0 {
+		parts = append(parts, fmt.Sprintf("project=%d", t.ProjectScope))
+	}
+	if t.EnvironmentScope > 0 {
+		parts = append(parts, fmt.Sprintf("env=%d", t.EnvironmentScope))
+	}
+	if len(t.Scopes) > 0 {
+		parts = append(parts, strings.Join(t.Scopes, ","))
+	}
+	return strings.Join(parts, " ")
+}

--- a/internal/cli/pat/pat_test.go
+++ b/internal/cli/pat/pat_test.go
@@ -1,0 +1,103 @@
+package pat
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCommandWiring(t *testing.T) {
+	names := map[string]bool{}
+	for _, sub := range PATCmd.Commands() {
+		names[sub.Name()] = true
+	}
+	for _, want := range []string{"create", "list", "revoke"} {
+		assert.True(t, names[want], "missing subcommand %q", want)
+	}
+	assert.Contains(t, PATCmd.Aliases, "token")
+	for _, f := range []string{"name", "expires", "scope", "project-id", "environment-id"} {
+		assert.NotNilf(t, createCmd.Flags().Lookup(f), "create missing --%s flag", f)
+	}
+}
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+	fn()
+	_ = w.Close()
+	os.Stdout = old
+	out, _ := io.ReadAll(r)
+	return string(out)
+}
+
+func TestCreateAgainstMockServer(t *testing.T) {
+	var gotMethod, gotPath string
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod, gotPath = r.Method, r.URL.Path
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		_, _ = w.Write([]byte(`{"data":{"token":"kx_pat_rawsecret","pat":{"id":7,"name":"ci","project_scope":5,"environment_scope":3,"scopes":["secrets.read"]}}}`))
+	}))
+	defer srv.Close()
+
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+	flagName, flagScopes, flagProject, flagEnv, flagExpires = "ci", []string{"secrets.read"}, 5, 3, ""
+
+	out := captureStdout(t, func() {
+		require.NoError(t, createCmd.RunE(createCmd, nil))
+	})
+
+	assert.Equal(t, http.MethodPost, gotMethod)
+	assert.Equal(t, "/api/v1/auth/tokens", gotPath)
+	assert.Equal(t, float64(5), gotBody["project_scope"])
+	assert.Equal(t, float64(3), gotBody["environment_scope"])
+	assert.Equal(t, []any{"secrets.read"}, gotBody["scopes"])
+	assert.Contains(t, out, "kx_pat_rawsecret", "the raw token is shown once")
+	assert.Contains(t, out, "project=5 env=3 secrets.read")
+}
+
+func TestCreate_Validation(t *testing.T) {
+	t.Run("name required", func(t *testing.T) {
+		flagName, flagProject, flagEnv = "", 0, 0
+		err := createCmd.RunE(createCmd, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "--name is required")
+	})
+	t.Run("env requires project", func(t *testing.T) {
+		flagName, flagProject, flagEnv = "ci", 0, 4
+		err := createCmd.RunE(createCmd, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "--environment-id requires --project-id")
+	})
+}
+
+func TestNormalizeExpiry(t *testing.T) {
+	got, err := normalizeExpiry("2026-12-31")
+	require.NoError(t, err)
+	assert.Equal(t, "2026-12-31T00:00:00Z", got)
+
+	got, err = normalizeExpiry("2026-12-31T10:00:00Z")
+	require.NoError(t, err)
+	assert.Equal(t, "2026-12-31T10:00:00Z", got)
+
+	_, err = normalizeExpiry("not-a-date")
+	require.Error(t, err)
+}
+
+func TestDescribeScope(t *testing.T) {
+	assert.Equal(t, "full access", describeScope(patView{}))
+	assert.Equal(t, "project=5 env=3 secrets.read",
+		describeScope(patView{ProjectScope: 5, EnvironmentScope: 3, Scopes: []string{"secrets.read"}}))
+	assert.Equal(t, "secrets.read,secrets.write",
+		describeScope(patView{Scopes: []string{"secrets.read", "secrets.write"}}))
+}


### PR DESCRIPTION
PATs could be created only from the web UI or the raw API — the CLI had no command for them. This adds **`keyorix pat`** (alias `token`) so operators can mint and manage their own tokens from the terminal, e.g. scripting a least-privilege CI token.

## Commands
```sh
keyorix pat create --name ci-reader --scope secrets.read --project-id 5 --environment-id 3
keyorix pat create --name backup --expires 2026-12-31
keyorix pat list
keyorix pat revoke 7
```

- **`pat create`** POSTs `/api/v1/auth/tokens` and prints the raw token **exactly once** + a one-line scope summary. Surfaces the full ADR-042 least-privilege model (permission allowlist + project + environment) — the last piece of that ADR's deferred CLI surface. `--environment-id` requires `--project-id` (an env belongs to a project), mirroring the server/UI rule.
- **`pat list`** — your tokens with their scope; **`pat revoke <id>`** — revoke one.
- Self-scoped under `/api/v1/auth/tokens` via the shared `RemoteClient` (same auth as the other CLI commands).

## Tests
Wiring guard (subcommands + flags + alias), create-against-stub-API (POST path + scope/project/env in body + raw token shown once), validation (name required, env-requires-project), `normalizeExpiry` (date→RFC3339), and the `describeScope` summary. ADR-042 deferred list updated. lint 0 · gitleaks clean · full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)