### PR TITLE
release: prep v0.16.0 (CHANGELOG + Helm chart 0.16.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to Keyorix are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## v0.16.0 — 2026-06-13
+
+### Added
+- **`keyorix pat` CLI** — create, list, and revoke personal access tokens from the
+  terminal (previously web-UI/API only). `pat create` surfaces the full ADR-042
+  least-privilege model via flags: `--scope` (repeatable permission allowlist),
+  `--project-id`, and `--environment-id` (which requires `--project-id`); the raw
+  token is printed exactly once. Completes the PAT least-privilege story across
+  backend, web UI, and CLI. ([#148])
+
+[#148]: https://github.com/keyorixhq/keyorix/pull/148
+
 ## v0.15.0 — 2026-06-13
 
 Migration reach and least-privilege completion. No config or schema changes

--- a/deploy/helm/keyorix/Chart.yaml
+++ b/deploy/helm/keyorix/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix
 description: Self-hosted Keyorix secrets manager (API server + web UI + PostgreSQL)
 type: application
 # Chart version — bump on chart changes.
-version: 0.15.0
+version: 0.16.0
 # The Keyorix app version this chart deploys by default (the image tag).
-appVersion: "0.15.0"
+appVersion: "0.16.0"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix


### PR DESCRIPTION
Minor release **v0.16.0** — `keyorix pat` CLI ([#148]): create/list/revoke personal access tokens from the terminal, with the full ADR-042 least-privilege scope flags (`--scope`/`--project-id`/`--environment-id`). Completes the PAT least-privilege story across backend, web UI, and CLI. No config/schema changes.

CHANGELOG + Helm chart `version`/`appVersion` → 0.16.0. Tag `v0.16.0` after merge fires the pipelines.

[#148]: https://github.com/keyorixhq/keyorix/pull/148

🤖 Generated with [Claude Code](https://claude.com/claude-code)