### PR TITLE
feat(rotation): proactive rotation-reminder scheduler

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -16,7 +16,7 @@ The config file is located via, in order: an explicit path argument, then
 - [secrets](#secrets) · [security + require_mfa](#security) (ADR-034)
 - [webauthn](#webauthn) (ADR-036) · [dynamic_secrets](#dynamic_secrets) (ADR-035)
 - [oidc](#oidc) (ADR-031) · [session](#session) · [password_policy](#password_policy) (ADR-025)
-- [soft_delete + purge](#soft_delete--purge) (ADR-032) · [audit.siem](#auditsiem)
+- [soft_delete + purge](#soft_delete--purge) (ADR-032) · [rotation_reminders](#rotation_reminders) · [audit.siem](#auditsiem)
 - [membership](#membership) (ADR-022) · [credential_delivery](#credential_delivery) (ADR-028)
 
 ---
@@ -317,6 +317,20 @@ soft_delete:
 purge:
   enabled: true
   schedule: "24h"         # Go duration between purge runs (default 24h)
+```
+
+## rotation_reminders
+
+An opt-in background scheduler that notifies project admins (in-app) of secrets
+**overdue or approaching** their rotation deadline under an active rotation policy —
+proactive rotation hygiene (a NIS2/ISO control). One standing reminder per project
+per admin; once read, a still-overdue secret nudges again on the next run.
+Single-replica-gated (ADR-039) so admins aren't notified N times in HA.
+
+```yaml
+rotation_reminders:
+  enabled: true
+  schedule: "24h"         # Go duration between reminder runs (default 24h)
 ```
 
 ## audit.siem

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,6 +21,9 @@ type Config struct {
 	Security    SecurityConfig   `yaml:"security"`
 	SoftDelete  SoftDeleteConfig `yaml:"soft_delete"`
 	Purge       PurgeConfig      `yaml:"purge"`
+	// RotationReminders configures the opt-in background scheduler that notifies
+	// project admins of secrets overdue / approaching their rotation deadline.
+	RotationReminders RotationRemindersConfig `yaml:"rotation_reminders"`
 	// DynamicSecrets configures the on-demand database-credentials engine and its
 	// auto-revoke sweep (ADR-035). Disabled (zero value) = the API is still served
 	// but no background sweeper runs; enable to auto-revoke leases at expiry.
@@ -440,6 +443,25 @@ func (c *CredentialDeliveryConfig) DeliveryConfig() delivery.Config {
 type PurgeConfig struct {
 	Enabled  bool   `yaml:"enabled"`
 	Schedule string `yaml:"schedule"`
+}
+
+// RotationRemindersConfig configures the rotation-reminder scheduler: a background
+// job that notifies project admins of secrets overdue/approaching their rotation
+// deadline under an active rotation policy. Opt-in (default off).
+type RotationRemindersConfig struct {
+	Enabled  bool   `yaml:"enabled"`
+	Schedule string `yaml:"schedule"`
+}
+
+// GetInterval returns the rotation-reminder run interval (Go duration, e.g. "24h");
+// defaults to 24h when unset or unparseable.
+func (c RotationRemindersConfig) GetInterval() time.Duration {
+	if c.Schedule != "" {
+		if d, err := time.ParseDuration(c.Schedule); err == nil && d > 0 {
+			return d
+		}
+	}
+	return 24 * time.Hour
 }
 
 // WebAuthnConfig configures the WebAuthn relying party (ADR-036). RPID is the

--- a/internal/core/rotation_policies.go
+++ b/internal/core/rotation_policies.go
@@ -36,6 +36,7 @@ type RotationPolicyEvaluation struct {
 	PolicyName    string     `json:"policy_name"`
 	SecretID      uint       `json:"secret_id"`
 	SecretName    string     `json:"secret_name"`
+	ProjectID     uint       `json:"project_id"`
 	LastRotatedAt *time.Time `json:"last_rotated_at"`
 	DaysOverdue   int        `json:"days_overdue"` // positive = overdue, negative = days remaining
 	IsOverdue     bool       `json:"is_overdue"`
@@ -256,6 +257,7 @@ func (c *KeyorixCore) EvaluateRotationPolicies(ctx context.Context, projectID *u
 					PolicyName:    policy.Name,
 					SecretID:      secret.ID,
 					SecretName:    secret.Name,
+					ProjectID:     secret.ProjectID,
 					LastRotatedAt: secret.LastRotatedAt,
 					DaysOverdue:   daysOverdue,
 					IsOverdue:     isOverdue,

--- a/internal/core/rotation_reminders.go
+++ b/internal/core/rotation_reminders.go
@@ -1,0 +1,99 @@
+// rotation_reminders.go — proactive rotation hygiene (a NIS2/ISO control): a
+// background scheduler (opt-in, see main.go) evaluates active rotation policies and
+// notifies project admins of secrets overdue or approaching their rotation deadline.
+package core
+
+import (
+	"context"
+	"fmt"
+)
+
+// NotificationRotationDue marks an in-app rotation-reminder notification.
+const NotificationRotationDue = "rotation.reminder"
+
+// SendRotationReminders evaluates every active rotation policy and, for each project
+// with secrets overdue or approaching rotation, sends ONE standing digest
+// notification to each of that project's admins. It de-duplicates: an admin who
+// already has an unread rotation reminder for the project is not re-notified, so
+// reminders don't pile up — once they read it (and the secret is still overdue) the
+// next run nudges them again. Returns the number of notifications created.
+func (c *KeyorixCore) SendRotationReminders(ctx context.Context) (int, error) {
+	evals, err := c.EvaluateRotationPolicies(ctx, nil)
+	if err != nil {
+		return 0, err
+	}
+	if len(evals) == 0 {
+		return 0, nil
+	}
+
+	// Tally overdue / approaching secrets per project.
+	type counts struct{ overdue, approaching int }
+	byProject := map[uint]*counts{}
+	for _, e := range evals {
+		if e.ProjectID == 0 {
+			continue
+		}
+		ct := byProject[e.ProjectID]
+		if ct == nil {
+			ct = &counts{}
+			byProject[e.ProjectID] = ct
+		}
+		switch {
+		case e.IsOverdue:
+			ct.overdue++
+		case e.IsApproaching:
+			ct.approaching++
+		}
+	}
+
+	sent := 0
+	for projectID, ct := range byProject {
+		if ct.overdue == 0 && ct.approaching == 0 {
+			continue
+		}
+		members, err := c.storage.ListProjectMembers(ctx, projectID)
+		if err != nil {
+			continue
+		}
+		pid := projectID
+		msg := rotationReminderMessage(c.projectLabel(ctx, projectID), ct.overdue, ct.approaching)
+		for _, mbr := range members {
+			if !isApproverRole(mbr.RoleName) {
+				continue
+			}
+			if c.hasUnreadRotationReminder(ctx, mbr.UserID, projectID) {
+				continue // a standing reminder already exists — don't pile up
+			}
+			c.notify(ctx, mbr.UserID, NotificationRotationDue,
+				"Secrets due for rotation", msg, &pid, "/rotation-policies")
+			sent++
+		}
+	}
+	return sent, nil
+}
+
+// hasUnreadRotationReminder reports whether the user already has an unread
+// rotation-reminder notification for the given project.
+func (c *KeyorixCore) hasUnreadRotationReminder(ctx context.Context, userID, projectID uint) bool {
+	notes, err := c.storage.ListNotifications(ctx, userID, true, 100)
+	if err != nil {
+		return false // on a read error, prefer notifying over silently skipping
+	}
+	for _, n := range notes {
+		if n.Type == NotificationRotationDue && n.ProjectID != nil && *n.ProjectID == projectID {
+			return true
+		}
+	}
+	return false
+}
+
+func rotationReminderMessage(project string, overdue, approaching int) string {
+	switch {
+	case overdue > 0 && approaching > 0:
+		return fmt.Sprintf("%d secret(s) in %s are overdue for rotation and %d more are approaching their deadline.", overdue, project, approaching)
+	case overdue > 0:
+		return fmt.Sprintf("%d secret(s) in %s are overdue for rotation.", overdue, project)
+	default:
+		return fmt.Sprintf("%d secret(s) in %s are approaching their rotation deadline.", approaching, project)
+	}
+}

--- a/internal/core/rotation_reminders_test.go
+++ b/internal/core/rotation_reminders_test.go
@@ -1,0 +1,101 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// newRotationReminderCore sets up a real-SQLite core with one project, a
+// project_admin member (user 5), and a secret overdue under an active rotation
+// policy, for exercising SendRotationReminders end to end.
+func newRotationReminderCore(t *testing.T) (*KeyorixCore, *gorm.DB, time.Time) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.User{}, &models.Role{}, &models.UserRole{}, &models.Project{},
+		&models.Environment{}, &models.SecretNode{}, &models.RotationPolicy{}, &models.Notification{},
+	))
+
+	now := time.Date(2026, 6, 13, 10, 0, 0, 0, time.UTC)
+	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "payments"}).Error)
+	require.NoError(t, db.Create(&models.Environment{ID: 2, Name: "production", ProjectID: 1}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 5, Username: "ada", Email: "ada@x.io", IsActive: true}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 6, Username: "viewer", Email: "v@x.io", IsActive: true}).Error)
+	require.NoError(t, db.Create(&models.Role{ID: 1, Name: "project_admin"}).Error)
+	require.NoError(t, db.Create(&models.Role{ID: 2, Name: "project_viewer"}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 5, RoleID: 1, ProjectID: 1}).Error) // admin
+	require.NoError(t, db.Create(&models.UserRole{UserID: 6, RoleID: 2, ProjectID: 1}).Error) // viewer (no reminder)
+	// A secret created 100 days ago, never rotated → overdue under a 30-day policy.
+	require.NoError(t, db.Create(&models.SecretNode{
+		ID: 10, Name: "db-password", ProjectID: 1, EnvironmentID: 2, Type: "password",
+		CreatedAt: now.AddDate(0, 0, -100),
+	}).Error)
+	pid := uint(1)
+	require.NoError(t, db.Create(&models.RotationPolicy{
+		Name: "30-day", Scope: "project", ProjectID: &pid,
+		IntervalDays: 30, AlertDaysBefore: 7, IsActive: true, CreatedBy: "ada",
+	}).Error)
+
+	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: func() time.Time { return now }}
+	return c, db, now
+}
+
+func TestSendRotationReminders(t *testing.T) {
+	ctx := context.Background()
+	c, db, _ := newRotationReminderCore(t)
+
+	// First run: the project_admin (user 5) is notified; the viewer (user 6) is not.
+	sent, err := c.SendRotationReminders(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 1, sent, "only the project admin is notified")
+
+	var notes []models.Notification
+	require.NoError(t, db.Where("type = ?", NotificationRotationDue).Find(&notes).Error)
+	require.Len(t, notes, 1)
+	assert.Equal(t, uint(5), notes[0].UserID)
+	require.NotNil(t, notes[0].ProjectID)
+	assert.Equal(t, uint(1), *notes[0].ProjectID)
+	assert.Contains(t, notes[0].Message, "overdue")
+	assert.Contains(t, notes[0].Message, "payments")
+
+	// Second run while the reminder is still UNREAD: deduped — no new notification.
+	sent, err = c.SendRotationReminders(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 0, sent, "a standing unread reminder is not duplicated")
+	var n int64
+	require.NoError(t, db.Model(&models.Notification{}).Where("type = ?", NotificationRotationDue).Count(&n).Error)
+	assert.Equal(t, int64(1), n)
+
+	// Once read, a still-overdue secret nudges the admin again on the next run.
+	require.NoError(t, db.Model(&models.Notification{}).Where("id = ?", notes[0].ID).Update("is_read", true).Error)
+	sent, err = c.SendRotationReminders(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 1, sent, "after reading, a still-overdue secret re-notifies")
+}
+
+func TestSendRotationReminders_NothingDue(t *testing.T) {
+	ctx := context.Background()
+	c, db, now := newRotationReminderCore(t)
+	// Rotate the secret now → no longer overdue/approaching.
+	require.NoError(t, db.Model(&models.SecretNode{}).Where("id = ?", 10).Update("last_rotated_at", now).Error)
+
+	sent, err := c.SendRotationReminders(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 0, sent)
+}
+
+func TestRotationReminderMessage(t *testing.T) {
+	assert.Contains(t, rotationReminderMessage("p", 3, 2), "3 secret(s) in p are overdue")
+	assert.Contains(t, rotationReminderMessage("p", 3, 2), "2 more are approaching")
+	assert.Equal(t, "1 secret(s) in p are overdue for rotation.", rotationReminderMessage("p", 1, 0))
+	assert.Contains(t, rotationReminderMessage("p", 0, 4), "approaching their rotation deadline")
+}

--- a/server/main.go
+++ b/server/main.go
@@ -138,6 +138,7 @@ const (
 	schedLockPurge        int64 = 0x4B455953_50555247 // "KEYSPURG"
 	schedLockDynamicSweep int64 = 0x4B455953_44594E53 // "KEYSDYNS"
 	schedLockLoginPrune   int64 = 0x4B455953_4C474E50 // "KEYSLGNP"
+	schedLockRotationRmdr int64 = 0x4B455953_524F5452 // "KEYSROTR"
 )
 
 // initializeEncryption sources the KEK per the configured key provider (ADR-038)
@@ -380,6 +381,43 @@ func startHTTPServer(ctx context.Context, cfg *config.Config) error {
 				select {
 				case <-ticker.C:
 					runPurge()
+				case <-ctx.Done():
+					return
+				}
+			}
+		}()
+	}
+
+	// Start the rotation-reminder scheduler — opt-in. Notifies project admins of
+	// secrets overdue/approaching their rotation deadline (proactive rotation
+	// hygiene; a NIS2/ISO control). Single-replica-gated (ADR-039) so admins aren't
+	// notified N times in an HA deployment.
+	if cfg.RotationReminders.Enabled {
+		interval := cfg.RotationReminders.GetInterval()
+		log.Printf("Rotation-reminder scheduler enabled: every %s", interval)
+		go func() {
+			ticker := time.NewTicker(interval)
+			defer ticker.Stop()
+			runReminders := func() {
+				if _, err := coreService.Storage().WithSchedulerLock(ctx, schedLockRotationRmdr, func() error {
+					n, rerr := coreService.SendRotationReminders(ctx)
+					if rerr != nil {
+						log.Printf("Rotation-reminder error: %v", rerr)
+						return rerr
+					}
+					if n > 0 {
+						log.Printf("Rotation reminders: sent %d notification(s)", n)
+					}
+					return nil
+				}); err != nil {
+					log.Printf("Rotation-reminder scheduler error: %v", err)
+				}
+			}
+			runReminders() // run once on startup
+			for {
+				select {
+				case <-ticker.C:
+					runReminders()
 				case <-ctx.Done():
 					return
 				}


### PR DESCRIPTION
Rotation policies flagged overdue secrets in the dashboard/health views, but nothing **proactively told owners to act**. This adds an opt-in background scheduler that notifies project admins (in-app) of secrets overdue / approaching their rotation deadline — proactive rotation hygiene, a NIS2/ISO credential-rotation control.

## How
- **`core.SendRotationReminders`** evaluates every active rotation policy (`EvaluateRotationPolicies`, now carrying the secret's `ProjectID`), tallies overdue / approaching secrets per project, and sends **one standing digest notification** to each project admin (the same approver-role set as access-request notifications). **De-duplicated:** an admin with an unread reminder for the project isn't re-notified (no pile-up); once read, a still-overdue secret nudges again on the next run.
- **`config.RotationReminders { enabled, schedule }`** (default off; 24h interval), wired as a background scheduler in `main.go` behind the **HA scheduler lock** (ADR-039) so admins aren't notified once per replica.
- Reuses the existing rotation-policy evaluation, notification, project-member, and scheduler-lock machinery — **no new storage surface**.

## Tests (real SQLite)
An overdue secret notifies the `project_admin` but not a viewer; a second run is deduped; after the reminder is read a still-overdue secret re-notifies; nothing-due sends nothing; the message formatter. `CONFIGURATION.md` documents the new block. lint 0 · gitleaks clean · full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)