### PR TITLE
release: prep v0.17.0 (CHANGELOG + Helm chart 0.17.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to Keyorix are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## v0.17.0 — 2026-06-13
+
+### Added
+- **Rotation-reminder scheduler** — an opt-in background job
+  (`rotation_reminders.enabled`) that proactively notifies project admins (in-app)
+  of secrets overdue or approaching their rotation deadline under an active
+  rotation policy, turning the reactive rotation-health views into proactive
+  nudges (a NIS2/ISO credential-rotation-hygiene control). One standing reminder
+  per project per admin, de-duplicated while unread; single-replica-gated in HA.
+  Default off; `schedule` (Go duration) controls the cadence (default 24h). ([#150])
+
+[#150]: https://github.com/keyorixhq/keyorix/pull/150
+
 ## v0.16.0 — 2026-06-13
 
 ### Added

--- a/deploy/helm/keyorix/Chart.yaml
+++ b/deploy/helm/keyorix/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix
 description: Self-hosted Keyorix secrets manager (API server + web UI + PostgreSQL)
 type: application
 # Chart version — bump on chart changes.
-version: 0.16.0
+version: 0.17.0
 # The Keyorix app version this chart deploys by default (the image tag).
-appVersion: "0.16.0"
+appVersion: "0.17.0"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix


### PR DESCRIPTION
Minor release **v0.17.0** — proactive rotation-reminder scheduler ([#150]): an opt-in background job that notifies project admins of secrets overdue/approaching their rotation deadline (a NIS2/ISO credential-rotation-hygiene control). Default off; no config/schema changes.

CHANGELOG + Helm chart `version`/`appVersion` → 0.17.0. Tag `v0.17.0` after merge fires the pipelines.

[#150]: https://github.com/keyorixhq/keyorix/pull/150

🤖 Generated with [Claude Code](https://claude.com/claude-code)