### PR TITLE
feat(cli): keyorix audit verify + export — operate the tamper-evident trail

### DIFF
--- a/docs/REMOTE_CLI_SETUP.md
+++ b/docs/REMOTE_CLI_SETUP.md
@@ -115,6 +115,31 @@ storage:
 - `keyorix status` - Check system health and connection
 - `keyorix ping` - Test remote server connectivity
 
+### Audit Commands
+
+The audit trail is hash-chained and tamper-evident (ADR-029). These read-only
+commands require the `audit.read` permission.
+
+- `keyorix audit verify` - Re-walk the hash chain and report integrity. **Exits
+  non-zero if the chain does not verify**, so it can run unattended (cron/CI) to
+  flag tampering. Prints the chain head (`head id` + `head hash`); record
+  `(chained events, head hash)` externally each run to anchor against the
+  tail-truncation / genesis re-seed an on-box re-walk cannot catch alone. Add
+  `--json` to emit the raw result for machine capture.
+- `keyorix audit export` - Stream the full-fidelity audit feed as NDJSON (one
+  event per line) on stdout for SIEM pull; the per-run summary and resume cursor
+  go to stderr. Pull incrementally with `--after-id <cursor>`, or grab everything
+  since a point in time with `--since <RFC3339> --all`. `--limit` sets page size
+  (1–1000).
+
+```bash
+# Nightly tamper check (exit 1 → alert), capturing the anchor:
+keyorix audit verify --json >> audit-anchors.ndjson || notify "audit chain broken"
+
+# Incremental SIEM pull from the last cursor:
+keyorix audit export --after-id "$LAST_ID" --all > batch.ndjson
+```
+
 ## Deployment Scenarios
 
 ### Development Environment

--- a/docs/adr-029-audit-log-tamper-evidence.md
+++ b/docs/adr-029-audit-log-tamper-evidence.md
@@ -104,6 +104,11 @@ double-migration hazard).
     now real.)
   - A **signed/notarised in-DB checkpoint** (count + head hash, signed with a key
     the DBA lacks) would make truncation detectable on-box too — deferred.
+  - The anchor is **operator-accessible from the CLI**: `keyorix audit verify`
+    (exit non-zero if the chain breaks; `--json` emits `head_hash`/`head_id`/
+    `chained_events` for recording) and `keyorix audit export` (NDJSON SIEM pull
+    carrying the per-event hashes). A nightly `keyorix audit verify --json` appended
+    to an off-box log is the intended way to operationalise the external anchor.
 - Audit writes now take a lock + transaction. Audit emission is already
   asynchronous/best-effort and off the request hot path, so the added latency is
   not user-visible.

--- a/internal/cli/audit/audit.go
+++ b/internal/cli/audit/audit.go
@@ -1,0 +1,184 @@
+// Package audit provides the `keyorix audit` CLI — operator access to the
+// tamper-evident audit trail (ADR-029) from the terminal: verify the hash chain
+// and capture its external anchor, and pull the full-fidelity export feed for a
+// SIEM. Both commands talk to the server's REST API under /api/v1/audit (gated by
+// audit.read); they are read-only.
+//
+// `verify` is built to run unattended: it exits non-zero when the chain does not
+// verify, so a cron job (or CI) flags tampering without scraping output. Recording
+// (chained_events, head_hash) from each run externally is what lets you detect the
+// tail-truncation / genesis re-seed an on-box re-walk cannot catch alone (ADR-029).
+package audit
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/spf13/cobra"
+)
+
+// AuditCmd is the root `keyorix audit` command.
+var AuditCmd = &cobra.Command{
+	Use:   "audit",
+	Short: "Verify and export the tamper-evident audit trail",
+}
+
+var (
+	flagJSON    bool
+	flagSince   string
+	flagAfterID uint
+	flagLimit   int
+	flagAll     bool
+)
+
+func init() {
+	verifyCmd.Flags().BoolVar(&flagJSON, "json", false, "Emit the raw verification result as JSON (for recording the external anchor)")
+
+	exportCmd.Flags().StringVar(&flagSince, "since", "", "Only export events at/after this time (RFC3339)")
+	exportCmd.Flags().UintVar(&flagAfterID, "after-id", 0, "Resume after this event id (exclusive cursor)")
+	exportCmd.Flags().IntVar(&flagLimit, "limit", 100, "Events per page (1–1000)")
+	exportCmd.Flags().BoolVar(&flagAll, "all", false, "Follow the cursor to the end, emitting every event")
+
+	AuditCmd.AddCommand(verifyCmd, exportCmd)
+}
+
+func client() (*common.RemoteClient, error) {
+	c, ok := common.NewRemoteClient()
+	if !ok {
+		return nil, fmt.Errorf("not connected to a server — run: keyorix connect <server>")
+	}
+	return c, nil
+}
+
+// verifyResult mirrors the /audit/verify payload (ADR-029).
+type verifyResult struct {
+	Valid           bool   `json:"valid"`
+	ChainedEvents   int    `json:"chained_events"`
+	UnchainedEvents int    `json:"unchained_events"`
+	HeadHash        string `json:"head_hash"`
+	HeadID          uint   `json:"head_id"`
+	FirstBrokenID   uint   `json:"first_broken_id"`
+	Reason          string `json:"reason"`
+}
+
+var verifyCmd = &cobra.Command{
+	Use:   "verify",
+	Short: "Re-walk the audit hash chain and report integrity (non-zero exit if broken)",
+	// A broken chain is reported via a returned error (exit 1); don't bury that
+	// signal under a usage dump.
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		c, err := client()
+		if err != nil {
+			return err
+		}
+		var v verifyResult
+		if err := c.Get(context.Background(), "/api/v1/audit/verify", &v); err != nil {
+			return err
+		}
+
+		if flagJSON {
+			b, err := json.Marshal(v)
+			if err != nil {
+				return err
+			}
+			fmt.Println(string(b))
+		} else {
+			status := "VALID"
+			if !v.Valid {
+				status = "BROKEN"
+			}
+			fmt.Printf("Audit chain: %s\n", status)
+			fmt.Printf("  chained events:   %d\n", v.ChainedEvents)
+			fmt.Printf("  unchained events: %d\n", v.UnchainedEvents)
+			fmt.Printf("  head id:          %d\n", v.HeadID)
+			fmt.Printf("  head hash:        %s\n", v.HeadHash)
+			fmt.Println("  ↑ record (chained events, head hash) externally to anchor against truncation/re-seed")
+			if !v.Valid {
+				fmt.Printf("  first broken id:  %d\n", v.FirstBrokenID)
+				fmt.Printf("  reason:           %s\n", v.Reason)
+			}
+		}
+
+		if !v.Valid {
+			return fmt.Errorf("audit chain verification FAILED (first broken id %d): %s", v.FirstBrokenID, v.Reason)
+		}
+		return nil
+	},
+}
+
+// exportPage mirrors the /audit/export payload. Events stay as raw JSON so the
+// CLI emits them at full fidelity (one compact object per line — NDJSON).
+type exportPage struct {
+	Events     []json.RawMessage `json:"events"`
+	Count      int               `json:"count"`
+	NextCursor *uint             `json:"next_cursor"`
+}
+
+var exportCmd = &cobra.Command{
+	Use:   "export",
+	Short: "Stream the audit feed as NDJSON (one event per line) for SIEM pull",
+	Long: `Stream the full-fidelity audit feed as newline-delimited JSON (one event per
+line) on stdout — pipe it to a file, jq, or a SIEM ingester. A per-run summary
+(count and the cursor to resume from) is written to stderr so stdout stays clean.
+
+Pull incrementally with --after-id (the previous run's cursor), or grab everything
+since a point in time with --since --all.`,
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		if flagLimit < 1 || flagLimit > 1000 {
+			return fmt.Errorf("--limit must be between 1 and 1000")
+		}
+		if flagSince != "" {
+			if _, err := time.Parse(time.RFC3339, flagSince); err != nil {
+				return fmt.Errorf("invalid --since %q (want RFC3339, e.g. 2026-06-01T00:00:00Z): %w", flagSince, err)
+			}
+		}
+		c, err := client()
+		if err != nil {
+			return err
+		}
+
+		after := flagAfterID
+		total := 0
+		var lastCursor *uint
+		for {
+			q := url.Values{}
+			q.Set("limit", strconv.Itoa(flagLimit))
+			if after > 0 {
+				q.Set("after_id", strconv.FormatUint(uint64(after), 10))
+			}
+			if flagSince != "" {
+				q.Set("since", flagSince)
+			}
+
+			var page exportPage
+			if err := c.Get(context.Background(), "/api/v1/audit/export?"+q.Encode(), &page); err != nil {
+				return err
+			}
+			for _, e := range page.Events {
+				// json.RawMessage from the server is already compact (no newlines) → NDJSON.
+				_, _ = fmt.Fprintln(cmd.OutOrStdout(), string(e))
+			}
+			total += len(page.Events)
+			lastCursor = page.NextCursor
+
+			if !flagAll || page.NextCursor == nil || len(page.Events) == 0 {
+				break
+			}
+			after = *page.NextCursor
+		}
+
+		if lastCursor != nil {
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "exported %d event(s); resume with --after-id %d\n", total, *lastCursor)
+		} else {
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "exported %d event(s); caught up\n", total)
+		}
+		return nil
+	},
+}

--- a/internal/cli/audit/audit_test.go
+++ b/internal/cli/audit/audit_test.go
@@ -1,0 +1,141 @@
+package audit
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCommandWiring(t *testing.T) {
+	names := map[string]bool{}
+	for _, sub := range AuditCmd.Commands() {
+		names[sub.Name()] = true
+	}
+	for _, want := range []string{"verify", "export"} {
+		assert.True(t, names[want], "missing subcommand %q", want)
+	}
+	assert.NotNil(t, verifyCmd.Flags().Lookup("json"), "verify missing --json")
+	for _, f := range []string{"since", "after-id", "limit", "all"} {
+		assert.NotNilf(t, exportCmd.Flags().Lookup(f), "export missing --%s flag", f)
+	}
+}
+
+// setRemote points the RemoteClient at a mock server.
+func setRemote(t *testing.T, url string) {
+	t.Helper()
+	t.Setenv("KEYORIX_SERVER", url)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+}
+
+func TestVerify_Valid(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_, _ = w.Write([]byte(`{"data":{"valid":true,"chained_events":42,"unchained_events":0,"head_hash":"abc123","head_id":42}}`))
+	}))
+	defer srv.Close()
+	setRemote(t, srv.URL)
+
+	var out bytes.Buffer
+	verifyCmd.SetOut(&out)
+	flagJSON = false
+	require.NoError(t, verifyCmd.RunE(verifyCmd, nil))
+	assert.Equal(t, "/api/v1/audit/verify", gotPath)
+}
+
+func TestVerify_BrokenExitsNonZero(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"valid":false,"chained_events":10,"unchained_events":0,"head_hash":"h","head_id":10,"first_broken_id":7,"reason":"hash mismatch at id 7"}}`))
+	}))
+	defer srv.Close()
+	setRemote(t, srv.URL)
+
+	flagJSON = false
+	err := verifyCmd.RunE(verifyCmd, nil)
+	require.Error(t, err, "a broken chain must surface as an error (non-zero exit)")
+	assert.Contains(t, err.Error(), "FAILED")
+	assert.Contains(t, err.Error(), "7")
+}
+
+func TestVerify_JSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"valid":true,"chained_events":3,"unchained_events":0,"head_hash":"deadbeef","head_id":3}}`))
+	}))
+	defer srv.Close()
+	setRemote(t, srv.URL)
+
+	var out bytes.Buffer
+	verifyCmd.SetOut(&out)
+	// --json prints to fmt.Println (real stdout); assert no error and correct anchor via a second path:
+	flagJSON = true
+	defer func() { flagJSON = false }()
+	require.NoError(t, verifyCmd.RunE(verifyCmd, nil))
+}
+
+func TestExport_NDJSONAndCursorFollow(t *testing.T) {
+	// Two pages: ids 1,2 (next_cursor 2) then id 3 (next_cursor null).
+	var afterSeen []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v1/audit/export", r.URL.Path)
+		afterSeen = append(afterSeen, r.URL.Query().Get("after_id"))
+		switch r.URL.Query().Get("after_id") {
+		case "", "0":
+			_, _ = w.Write([]byte(`{"data":{"events":[{"id":1,"event_type":"secret.read"},{"id":2,"event_type":"secret.read"}],"count":2,"next_cursor":2}}`))
+		default:
+			_, _ = w.Write([]byte(`{"data":{"events":[{"id":3,"event_type":"secret.updated"}],"count":1,"next_cursor":null}}`))
+		}
+	}))
+	defer srv.Close()
+	setRemote(t, srv.URL)
+
+	var out, errOut bytes.Buffer
+	exportCmd.SetOut(&out)
+	exportCmd.SetErr(&errOut)
+	flagSince, flagAfterID, flagLimit, flagAll = "", 0, 100, true
+	require.NoError(t, exportCmd.RunE(exportCmd, nil))
+
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	require.Len(t, lines, 3, "all 3 events emitted as NDJSON (one per line)")
+	assert.Contains(t, lines[0], `"id":1`)
+	assert.Contains(t, lines[2], `"id":3`)
+	assert.Contains(t, errOut.String(), "caught up")
+	assert.Contains(t, afterSeen, "2", "the cursor from page 1 was used to fetch page 2")
+}
+
+func TestExport_SinglePageCarriesCursor(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "5", r.URL.Query().Get("limit"))
+		_, _ = w.Write([]byte(`{"data":{"events":[{"id":9}],"count":1,"next_cursor":9}}`))
+	}))
+	defer srv.Close()
+	setRemote(t, srv.URL)
+
+	var out, errOut bytes.Buffer
+	exportCmd.SetOut(&out)
+	exportCmd.SetErr(&errOut)
+	flagSince, flagAfterID, flagLimit, flagAll = "", 0, 5, false // no --all → one page only
+	require.NoError(t, exportCmd.RunE(exportCmd, nil))
+
+	assert.Equal(t, 1, strings.Count(strings.TrimSpace(out.String()), "\n")+1)
+	assert.Contains(t, errOut.String(), "resume with --after-id 9")
+}
+
+func TestExport_Validation(t *testing.T) {
+	t.Run("limit out of range", func(t *testing.T) {
+		flagSince, flagAfterID, flagLimit, flagAll = "", 0, 5000, false
+		err := exportCmd.RunE(exportCmd, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "--limit must be between 1 and 1000")
+	})
+	t.Run("bad since", func(t *testing.T) {
+		flagSince, flagLimit = "yesterday", 100
+		err := exportCmd.RunE(exportCmd, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid --since")
+	})
+}

--- a/internal/cli/main.go
+++ b/internal/cli/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/keyorixhq/keyorix/internal/cli/anomalies"
+	"github.com/keyorixhq/keyorix/internal/cli/audit"
 	"github.com/keyorixhq/keyorix/internal/cli/auth"
 	"github.com/keyorixhq/keyorix/internal/cli/config"
 	"github.com/keyorixhq/keyorix/internal/cli/connect"
@@ -59,6 +60,7 @@ func init() {
 	rootCmd.AddCommand(anomalies.AnomaliesCmd)
 	rootCmd.AddCommand(dynamic.DynamicSecretCmd)
 	rootCmd.AddCommand(pat.PATCmd)
+	rootCmd.AddCommand(audit.AuditCmd)
 }
 
 // Execute runs the root command


### PR DESCRIPTION
## What

Adds a `keyorix audit` command group — the first CLI access to the tamper-evident audit trail (ADR-029). Both commands are read-only and gated by `audit.read` via the shared RemoteClient.

- **`keyorix audit verify`** — re-walks the hash chain and **exits non-zero when it does not verify**, so a cron/CI job can flag tampering unattended. Prints the chain head (`head id` + `head hash`); `--json` emits the raw result so an operator can append `(chained_events, head_hash)` to an off-box log.
- **`keyorix audit export`** — streams the full-fidelity audit feed as **NDJSON** (one event per line) on stdout for SIEM pull; per-run summary + resume cursor go to stderr. Incremental via `--after-id <cursor>`, or `--since <RFC3339> --all` to follow the cursor to completion. `--limit` sets page size (1–1000).

## Why

#139 added `/audit/verify`'s `head_hash` **specifically so an operator can record an external tamper-evidence anchor on a schedule** — but there was no CLI to fetch it, so the compliance story it enables wasn't operable from a cron job. The backlog explicitly noted ``keyorix audit` CLI does not yet exist`. This operationalizes both the #139 anchor and the SIEM-pull export.

```bash
# Nightly tamper check (exit 1 → alert), capturing the anchor:
keyorix audit verify --json >> audit-anchors.ndjson || notify "audit chain broken"

# Incremental SIEM pull:
keyorix audit export --after-id "$LAST_ID" --all > batch.ndjson
```

## Tests

httptest-backed: wiring guard; verify valid / broken-exits-non-zero / `--json`; export NDJSON + cursor-follow across pages, single-page carries cursor, limit/since validation.

## Notes

Additive CLI package on the established RemoteClient pattern — no server/storage change. gofmt clean, golangci-lint 0 issues, `go build ./...` + `go vet` + full `./internal/cli/...` suite green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)