### PR TITLE
feat(audit): signed in-DB checkpoints for on-box truncation detection (ADR-029)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -16,7 +16,7 @@ The config file is located via, in order: an explicit path argument, then
 - [secrets](#secrets) · [security + require_mfa](#security) (ADR-034)
 - [webauthn](#webauthn) (ADR-036) · [dynamic_secrets](#dynamic_secrets) (ADR-035)
 - [oidc](#oidc) (ADR-031) · [session](#session) · [password_policy](#password_policy) (ADR-025)
-- [soft_delete + purge](#soft_delete--purge) (ADR-032) · [rotation_reminders](#rotation_reminders) · [audit.siem](#auditsiem)
+- [soft_delete + purge](#soft_delete--purge) (ADR-032) · [rotation_reminders](#rotation_reminders) · [audit_checkpoints](#audit_checkpoints) (ADR-029) · [audit.siem](#auditsiem)
 - [membership](#membership) (ADR-022) · [credential_delivery](#credential_delivery) (ADR-028)
 
 ---
@@ -331,6 +331,24 @@ Single-replica-gated (ADR-039) so admins aren't notified N times in HA.
 rotation_reminders:
   enabled: true
   schedule: "24h"         # Go duration between reminder runs (default 24h)
+```
+
+## audit_checkpoints
+
+An opt-in background scheduler that signs the audit hash-chain head (ADR-029) so
+**tail-truncation and genesis re-seed are detectable on-box**, not just via an
+off-box anchor. Each run records a `(chained_events, head_id, head_hash)`
+checkpoint with an HMAC keyed by a DEK-derived key the database/DBA does not hold;
+`keyorix audit verify` (and `GET /audit/verify`) then enforce the live chain
+against the latest checkpoint. Single-replica-gated (ADR-039).
+
+**Requires encryption enabled** — the signing key is derived from the DEK, so with
+encryption off the scheduler logs a warning and does nothing.
+
+```yaml
+audit_checkpoints:
+  enabled: true
+  schedule: "12h"         # Go duration between checkpoint writes (default 24h)
 ```
 
 ## audit.siem

--- a/docs/REMOTE_CLI_SETUP.md
+++ b/docs/REMOTE_CLI_SETUP.md
@@ -125,7 +125,10 @@ commands require the `audit.read` permission.
   flag tampering. Prints the chain head (`head id` + `head hash`); record
   `(chained events, head hash)` externally each run to anchor against the
   tail-truncation / genesis re-seed an on-box re-walk cannot catch alone. Add
-  `--json` to emit the raw result for machine capture.
+  `--json` to emit the raw result for machine capture. When the server runs the
+  signed-checkpoint scheduler (`audit_checkpoints`, ADR-029), verify also enforces
+  the chain against the latest in-DB checkpoint — detecting that truncation
+  **on-box** — and reports `checkpointed`.
 - `keyorix audit export` - Stream the full-fidelity audit feed as NDJSON (one
   event per line) on stdout for SIEM pull; the per-run summary and resume cursor
   go to stderr. Pull incrementally with `--after-id <cursor>`, or grab everything

--- a/docs/adr-029-audit-log-tamper-evidence.md
+++ b/docs/adr-029-audit-log-tamper-evidence.md
@@ -102,8 +102,23 @@ double-migration hazard).
     prove a later on-box head diverges. (Previously the export omitted the hashes,
     so the "exported `entry_hash` anchors the head" claim was aspirational; it is
     now real.)
-  - A **signed/notarised in-DB checkpoint** (count + head hash, signed with a key
-    the DBA lacks) would make truncation detectable on-box too — deferred.
+  - A **signed/notarised in-DB checkpoint** makes truncation detectable **on-box**
+    too — **delivered.** An opt-in scheduler (`audit_checkpoints.enabled`, HA-gated)
+    periodically writes an `audit_checkpoints` row recording the verified
+    `(chained_events, head_id, head_hash)` plus an **HMAC-SHA256 signature** keyed
+    by a key the running server holds in memory but the database/DBA does not — it
+    is HKDF-derived from the DEK (`encryption.Service.AuditCheckpointKey`, info
+    `keyorix-audit-checkpoint-v1`), so signed checkpoints require encryption
+    enabled. `VerifyAuditChain` then verifies the live chain against the latest
+    checkpoint: a chain shorter than the certified length, or a rewritten certified
+    head, flips `valid` to false with a `checkpoint_reason` — catching the
+    tail-truncation / genesis re-seed the bare re-walk cannot. A checkpoint row
+    altered without the key fails its signature check (itself a tamper signal); a
+    new checkpoint is refused over a chain that no longer verifies, so a truncation
+    is never silently re-baselined away. A checkpoint signed under a superseded DEK
+    version (after a key rotation) is recorded but not enforced, avoiding false
+    positives. Surfaced as `checkpointed`/`checkpoint_reason` on `/audit/verify` and
+    in `keyorix audit verify`.
   - The anchor is **operator-accessible from the CLI**: `keyorix audit verify`
     (exit non-zero if the chain breaks; `--json` emits `head_hash`/`head_id`/
     `chained_events` for recording) and `keyorix audit export` (NDJSON SIEM pull

--- a/docs/adr-029-audit-log-tamper-evidence.md
+++ b/docs/adr-029-audit-log-tamper-evidence.md
@@ -110,15 +110,38 @@ double-migration hazard).
     is HKDF-derived from the DEK (`encryption.Service.AuditCheckpointKey`, info
     `keyorix-audit-checkpoint-v1`), so signed checkpoints require encryption
     enabled. `VerifyAuditChain` then verifies the live chain against the latest
-    checkpoint: a chain shorter than the certified length, or a rewritten certified
-    head, flips `valid` to false with a `checkpoint_reason` — catching the
-    tail-truncation / genesis re-seed the bare re-walk cannot. A checkpoint row
-    altered without the key fails its signature check (itself a tamper signal); a
-    new checkpoint is refused over a chain that no longer verifies, so a truncation
-    is never silently re-baselined away. A checkpoint signed under a superseded DEK
-    version (after a key rotation) is recorded but not enforced, avoiding false
-    positives. Surfaced as `checkpointed`/`checkpoint_reason` on `/audit/verify` and
-    in `keyorix audit verify`.
+    checkpoint. The checkpoint is **authenticated first** (the HMAC covers every
+    field, so nothing it claims — including `key_version` — is trusted until the
+    signature verifies under the current key); then a chain shorter than the
+    certified length, or a rewritten certified head, flips `valid` to false with a
+    `checkpoint_reason` — catching the tail-truncation / genesis re-seed the bare
+    re-walk cannot. A checkpoint row altered in **any** field without the key fails
+    the signature check and is reported as a tamper signal — there is deliberately
+    no unauthenticated field (e.g. `key_version`) a DB-level actor can edit to skip
+    enforcement. A new checkpoint is refused over a chain shorter than an
+    authenticated prior checkpoint, so a truncation is never silently re-baselined
+    away. Surfaced as `checkpointed`/`checkpoint_reason` on `/audit/verify` and in
+    `keyorix audit verify`.
+  - **DEK rotation:** a checkpoint signed under a superseded DEK cannot be
+    re-verified on-box, so after a rotation `verify` fails closed (reports invalid)
+    until the next checkpoint write re-baselines under the new key — the scheduler
+    does this on its next tick / at startup (`WriteAuditCheckpoint` re-baselines
+    over an *unverifiable* prior checkpoint but still refuses over an *authenticated*
+    truncation). Trusting the unauthenticated `key_version` to suppress that alarm
+    was rejected — it would let an attacker forge the rotation case to mask a
+    truncation.
+  - **Residual (honest scope):** enforcement consults the latest checkpoint row.
+    A DB-level actor who can write `audit_checkpoints` can therefore *neutralise*
+    on-box enforcement — delete every row, or overwrite the latest slot with an
+    unverifiable row — which makes `verify` **fail closed** (reports invalid) until
+    the next scheduler write re-baselines; if they truncate within that window the
+    fresh checkpoint blesses the shortened chain. In all such cases detection
+    reverts to the off-box external anchor above (#139): an external monitor that
+    recorded `(ChainedEvents, HeadHash)` sees the count drop. What a DB-level actor
+    can **never** do is *forge* a checkpoint that makes `verify` return valid over a
+    truncated chain — the HMAC key is never in the database. (Enforcing the latest
+    *signature-valid* checkpoint rather than the latest row would shrink this window
+    further; deferred as hardening.)
   - The anchor is **operator-accessible from the CLI**: `keyorix audit verify`
     (exit non-zero if the chain breaks; `--json` emits `head_hash`/`head_id`/
     `chained_events` for recording) and `keyorix audit export` (NDJSON SIEM pull

--- a/internal/cli/audit/audit.go
+++ b/internal/cli/audit/audit.go
@@ -57,13 +57,15 @@ func client() (*common.RemoteClient, error) {
 
 // verifyResult mirrors the /audit/verify payload (ADR-029).
 type verifyResult struct {
-	Valid           bool   `json:"valid"`
-	ChainedEvents   int    `json:"chained_events"`
-	UnchainedEvents int    `json:"unchained_events"`
-	HeadHash        string `json:"head_hash"`
-	HeadID          uint   `json:"head_id"`
-	FirstBrokenID   uint   `json:"first_broken_id"`
-	Reason          string `json:"reason"`
+	Valid            bool   `json:"valid"`
+	ChainedEvents    int    `json:"chained_events"`
+	UnchainedEvents  int    `json:"unchained_events"`
+	HeadHash         string `json:"head_hash"`
+	HeadID           uint   `json:"head_id"`
+	FirstBrokenID    uint   `json:"first_broken_id"`
+	Reason           string `json:"reason"`
+	Checkpointed     bool   `json:"checkpointed"`
+	CheckpointReason string `json:"checkpoint_reason"`
 }
 
 var verifyCmd = &cobra.Command{
@@ -98,10 +100,16 @@ var verifyCmd = &cobra.Command{
 			fmt.Printf("  unchained events: %d\n", v.UnchainedEvents)
 			fmt.Printf("  head id:          %d\n", v.HeadID)
 			fmt.Printf("  head hash:        %s\n", v.HeadHash)
-			fmt.Println("  ↑ record (chained events, head hash) externally to anchor against truncation/re-seed")
+			if v.Checkpointed {
+				fmt.Println("  checkpoint:       verified against a signed in-DB checkpoint (on-box truncation detection)")
+			} else {
+				fmt.Println("  checkpoint:       none enforced (record (chained events, head hash) externally to anchor)")
+			}
 			if !v.Valid {
 				fmt.Printf("  first broken id:  %d\n", v.FirstBrokenID)
 				fmt.Printf("  reason:           %s\n", v.Reason)
+			} else if v.CheckpointReason != "" {
+				fmt.Printf("  note:             %s\n", v.CheckpointReason)
 			}
 		}
 

--- a/internal/cli/audit/audit.go
+++ b/internal/cli/audit/audit.go
@@ -101,7 +101,7 @@ var verifyCmd = &cobra.Command{
 			fmt.Printf("  head id:          %d\n", v.HeadID)
 			fmt.Printf("  head hash:        %s\n", v.HeadHash)
 			if v.Checkpointed {
-				fmt.Println("  checkpoint:       verified against a signed in-DB checkpoint (on-box truncation detection)")
+				fmt.Println("  checkpoint:       checked against a signed in-DB checkpoint (on-box truncation detection)")
 			} else {
 				fmt.Println("  checkpoint:       none enforced (record (chained events, head hash) externally to anchor)")
 			}

--- a/internal/cli/audit/audit_test.go
+++ b/internal/cli/audit/audit_test.go
@@ -48,6 +48,21 @@ func TestVerify_Valid(t *testing.T) {
 	assert.Equal(t, "/api/v1/audit/verify", gotPath)
 }
 
+func TestVerify_CheckpointTruncationExitsNonZero(t *testing.T) {
+	// A self-consistent chain walk (valid=false here) flagged by the signed
+	// checkpoint must still surface as a non-zero exit with the checkpoint reason.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"valid":false,"chained_events":3,"unchained_events":0,"head_hash":"h","head_id":3,"checkpointed":true,"reason":"audit trail truncated below signed checkpoint #1: it certified 5 chained events, only 3 remain","checkpoint_reason":"audit trail truncated below signed checkpoint #1: it certified 5 chained events, only 3 remain"}}`))
+	}))
+	defer srv.Close()
+	setRemote(t, srv.URL)
+
+	flagJSON = false
+	err := verifyCmd.RunE(verifyCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "truncated below signed checkpoint")
+}
+
 func TestVerify_BrokenExitsNonZero(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write([]byte(`{"data":{"valid":false,"chained_events":10,"unchained_events":0,"head_hash":"h","head_id":10,"first_broken_id":7,"reason":"hash mismatch at id 7"}}`))

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,6 +24,10 @@ type Config struct {
 	// RotationReminders configures the opt-in background scheduler that notifies
 	// project admins of secrets overdue / approaching their rotation deadline.
 	RotationReminders RotationRemindersConfig `yaml:"rotation_reminders"`
+	// AuditCheckpoints configures the opt-in background scheduler that writes
+	// signed checkpoints of the audit hash chain (ADR-029) for on-box truncation
+	// detection. Requires encryption enabled (the signing key is DEK-derived).
+	AuditCheckpoints AuditCheckpointsConfig `yaml:"audit_checkpoints"`
 	// DynamicSecrets configures the on-demand database-credentials engine and its
 	// auto-revoke sweep (ADR-035). Disabled (zero value) = the API is still served
 	// but no background sweeper runs; enable to auto-revoke leases at expiry.
@@ -456,6 +460,25 @@ type RotationRemindersConfig struct {
 // GetInterval returns the rotation-reminder run interval (Go duration, e.g. "24h");
 // defaults to 24h when unset or unparseable.
 func (c RotationRemindersConfig) GetInterval() time.Duration {
+	if c.Schedule != "" {
+		if d, err := time.ParseDuration(c.Schedule); err == nil && d > 0 {
+			return d
+		}
+	}
+	return 24 * time.Hour
+}
+
+// AuditCheckpointsConfig configures the audit-checkpoint scheduler: a background
+// job that signs the audit hash-chain head (ADR-029) so tail-truncation / re-seed
+// is detectable on-box. Opt-in (default off); requires encryption enabled.
+type AuditCheckpointsConfig struct {
+	Enabled  bool   `yaml:"enabled"`
+	Schedule string `yaml:"schedule"`
+}
+
+// GetInterval returns the checkpoint write interval (Go duration, e.g. "12h");
+// defaults to 24h when unset or unparseable.
+func (c AuditCheckpointsConfig) GetInterval() time.Duration {
 	if c.Schedule != "" {
 		if d, err := time.ParseDuration(c.Schedule); err == nil && d > 0 {
 			return d

--- a/internal/core/audit_checkpoint.go
+++ b/internal/core/audit_checkpoint.go
@@ -48,37 +48,59 @@ func (c *KeyorixCore) WriteAuditCheckpoint(ctx context.Context) (*models.AuditCh
 	if !c.AuditCheckpointsAvailable() {
 		return nil, false, nil
 	}
-	v, err := c.VerifyAuditChain(ctx)
+	// Verify the raw chain (walk only, no checkpoint enforcement) so we never sign
+	// a head over a broken chain.
+	raw, err := c.storage.VerifyAuditChain(ctx)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to verify audit chain: %w", err)
+	}
+	if !raw.Valid {
+		return nil, false, fmt.Errorf("refusing to checkpoint a chain that does not verify: %s", raw.Reason)
+	}
+	// Refuse to re-baseline over a truncation that an AUTHENTICATED prior checkpoint
+	// proves — otherwise a scheduled write would silently bless a shortened chain and
+	// erase the evidence. An unverifiable prior checkpoint (a stale one after a DEK
+	// rotation) does not block re-baselining; that is how the system recovers from a
+	// key rotation.
+	cp, err := c.storage.LatestAuditCheckpoint(ctx)
 	if err != nil {
 		return nil, false, err
 	}
-	if !v.Valid {
-		reason := v.Reason
-		if reason == "" {
-			reason = v.CheckpointReason
+	if cp != nil && c.checkpointSignatureValid(cp) {
+		if reason, tampered, err := c.checkpointTruncation(ctx, raw.ChainedEvents, cp); err != nil {
+			return nil, false, err
+		} else if tampered {
+			return nil, false, fmt.Errorf("refusing to checkpoint: %s", reason)
 		}
-		return nil, false, fmt.Errorf("refusing to checkpoint a chain that does not verify: %s", reason)
 	}
-	cp := &models.AuditCheckpoint{
-		ChainedEvents: v.ChainedEvents,
-		HeadID:        v.HeadID,
-		HeadHash:      v.HeadHash,
+	newCP := &models.AuditCheckpoint{
+		ChainedEvents: raw.ChainedEvents,
+		HeadID:        raw.HeadID,
+		HeadHash:      raw.HeadHash,
 		KeyVersion:    c.auditCkptKeyVersion,
 	}
-	cp.Signature = c.signCheckpoint(cp)
-	if err := c.storage.CreateAuditCheckpoint(ctx, cp); err != nil {
+	newCP.Signature = c.signCheckpoint(newCP)
+	if err := c.storage.CreateAuditCheckpoint(ctx, newCP); err != nil {
 		return nil, false, fmt.Errorf("failed to write audit checkpoint: %w", err)
 	}
-	return cp, true, nil
+	return newCP, true, nil
 }
 
 // enforceAuditCheckpoint augments a chain-walk verdict with on-box checkpoint
-// verification: it loads the latest signed checkpoint and, if its signature is
-// authentic and current, requires the live chain to still be at least as long as
-// the checkpoint certified, with the certified head row unchanged. Any shortfall
-// or head rewrite flips Valid to false. A checkpoint signed under a superseded
-// DEK version is recorded but not enforced (it cannot be re-verified after a key
-// rotation). A signature that does not recompute is itself a tamper signal.
+// verification. It loads the latest checkpoint and authenticates it with the
+// current signing key FIRST: the HMAC covers every field (including key_version),
+// so nothing the checkpoint claims is trusted until the signature verifies. A row
+// altered without the key fails here — there is no field a DB-level actor can set
+// to skip enforcement. Once authenticated, the live chain must still be at least
+// as long as the checkpoint certified, with the certified head row unchanged; any
+// shortfall or head rewrite flips Valid to false.
+//
+// A signature that does not verify is treated as a tamper signal (Valid=false). It
+// also fires for a stale checkpoint signed under a superseded DEK version after a
+// key rotation — by design: we cannot re-verify an old-key signature on-box, and
+// silently trusting the unauthenticated key_version field would reopen the bypass.
+// WriteAuditCheckpoint re-baselines under the new key (it does not block on an
+// unverifiable checkpoint), clearing the state on the next checkpoint write.
 func (c *KeyorixCore) enforceAuditCheckpoint(ctx context.Context, v *storage.AuditChainVerification) error {
 	if !c.AuditCheckpointsAvailable() {
 		return nil
@@ -90,42 +112,55 @@ func (c *KeyorixCore) enforceAuditCheckpoint(ctx context.Context, v *storage.Aud
 	if cp == nil {
 		return nil // none written yet
 	}
-	if cp.KeyVersion != c.auditCkptKeyVersion {
-		v.CheckpointReason = fmt.Sprintf(
-			"latest audit checkpoint #%d was signed under key version %q (current %q); not enforced after a key rotation",
-			cp.ID, cp.KeyVersion, c.auditCkptKeyVersion)
-		return nil
-	}
 
 	v.Checkpointed = true
 
 	if !c.checkpointSignatureValid(cp) {
 		c.failCheckpoint(v, nil,
-			fmt.Sprintf("audit checkpoint #%d signature is invalid — the checkpoint row was tampered (forged without the signing key)", cp.ID))
+			fmt.Sprintf("audit checkpoint #%d does not verify under the current signing key — the checkpoint was tampered, or a DEK rotation occurred and no fresh checkpoint has been written yet", cp.ID))
 		return nil
 	}
-	if v.ChainedEvents < cp.ChainedEvents {
-		c.failCheckpoint(v, nil,
-			fmt.Sprintf("audit trail truncated below signed checkpoint #%d: it certified %d chained events, only %d remain",
-				cp.ID, cp.ChainedEvents, v.ChainedEvents))
-		return nil
-	}
-	hash, found, err := c.storage.AuditEntryHashByID(ctx, cp.HeadID)
+	reason, tampered, err := c.checkpointTruncation(ctx, v.ChainedEvents, cp)
 	if err != nil {
 		return err
 	}
-	headID := cp.HeadID
-	if !found {
-		c.failCheckpoint(v, &headID,
-			fmt.Sprintf("audit event #%d certified by checkpoint #%d is missing (tail-truncation or genesis re-seed)", cp.HeadID, cp.ID))
-		return nil
-	}
-	if hash != cp.HeadHash {
-		c.failCheckpoint(v, &headID,
-			fmt.Sprintf("audit event #%d hash differs from signed checkpoint #%d (certified head was rewritten)", cp.HeadID, cp.ID))
-		return nil
+	if tampered {
+		var brokenID *uint
+		if cp.HeadID != 0 {
+			id := cp.HeadID
+			brokenID = &id
+		}
+		c.failCheckpoint(v, brokenID, reason)
 	}
 	return nil
+}
+
+// checkpointTruncation compares the live chain length and certified head against an
+// already-authenticated checkpoint, returning (reason, true) when the chain has
+// been truncated below it or its certified head row was removed/rewritten. The
+// caller MUST have validated cp's signature first.
+func (c *KeyorixCore) checkpointTruncation(ctx context.Context, chainedEvents int64, cp *models.AuditCheckpoint) (string, bool, error) {
+	if chainedEvents < cp.ChainedEvents {
+		return fmt.Sprintf("audit trail truncated below signed checkpoint #%d: it certified %d chained events, only %d remain",
+			cp.ID, cp.ChainedEvents, chainedEvents), true, nil
+	}
+	if cp.HeadID == 0 {
+		// The checkpoint certified the empty/genesis chain (no chained events yet);
+		// there is no head row to compare. The count check above is the only
+		// invariant — the chain only ever grows — so this is not a truncation.
+		return "", false, nil
+	}
+	hash, found, err := c.storage.AuditEntryHashByID(ctx, cp.HeadID)
+	if err != nil {
+		return "", false, err
+	}
+	if !found {
+		return fmt.Sprintf("audit event #%d certified by checkpoint #%d is missing (tail-truncation or genesis re-seed)", cp.HeadID, cp.ID), true, nil
+	}
+	if hash != cp.HeadHash {
+		return fmt.Sprintf("audit event #%d hash differs from signed checkpoint #%d (certified head was rewritten)", cp.HeadID, cp.ID), true, nil
+	}
+	return "", false, nil
 }
 
 // failCheckpoint records a checkpoint-detected tamper on the verdict without

--- a/internal/core/audit_checkpoint.go
+++ b/internal/core/audit_checkpoint.go
@@ -1,0 +1,158 @@
+// audit_checkpoint.go — signed checkpoints over the audit hash chain (ADR-029).
+//
+// The hash chain alone makes any modification/insertion/deletion of a present
+// row detectable, but an unanchored on-box re-walk cannot catch tail-truncation
+// or a genesis re-seed: a shorter, self-consistent chain still verifies. A
+// checkpoint closes that gap on-box. It records (chained_events, head_id,
+// head_hash) and signs them with an HMAC keyed by a DEK-derived key the running
+// server holds in memory but the database/DBA does not (see
+// encryption.Service.AuditCheckpointKey). Verifying the live chain against the
+// latest signed checkpoint then detects a drop below the certified length or a
+// rewrite of the certified head — tampering a DB-level actor cannot hide without
+// the signing key.
+package core
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// SetAuditCheckpointKey wires the DEK-derived HMAC key (and the DEK key version
+// it was derived from) used to sign and verify audit checkpoints. Called at
+// startup when encryption is enabled; with no key set, checkpoints are
+// unavailable and VerifyAuditChain runs without on-box checkpoint enforcement.
+func (c *KeyorixCore) SetAuditCheckpointKey(key []byte, keyVersion string) {
+	c.auditCkptKey = key
+	c.auditCkptKeyVersion = keyVersion
+}
+
+// AuditCheckpointsAvailable reports whether signed checkpoints can be written
+// (i.e. a signing key is configured — encryption is enabled).
+func (c *KeyorixCore) AuditCheckpointsAvailable() bool {
+	return len(c.auditCkptKey) > 0
+}
+
+// WriteAuditCheckpoint verifies the audit chain and, if it is intact, appends a
+// fresh signed checkpoint of the current head. It returns (nil, false, nil) when
+// checkpoints are unavailable (no signing key / encryption disabled), and an
+// error when the chain does not verify — refusing to notarise a tampered state,
+// and refusing to re-baseline over a truncation already flagged by an existing
+// checkpoint (VerifyAuditChain enforces prior checkpoints).
+func (c *KeyorixCore) WriteAuditCheckpoint(ctx context.Context) (*models.AuditCheckpoint, bool, error) {
+	if !c.AuditCheckpointsAvailable() {
+		return nil, false, nil
+	}
+	v, err := c.VerifyAuditChain(ctx)
+	if err != nil {
+		return nil, false, err
+	}
+	if !v.Valid {
+		reason := v.Reason
+		if reason == "" {
+			reason = v.CheckpointReason
+		}
+		return nil, false, fmt.Errorf("refusing to checkpoint a chain that does not verify: %s", reason)
+	}
+	cp := &models.AuditCheckpoint{
+		ChainedEvents: v.ChainedEvents,
+		HeadID:        v.HeadID,
+		HeadHash:      v.HeadHash,
+		KeyVersion:    c.auditCkptKeyVersion,
+	}
+	cp.Signature = c.signCheckpoint(cp)
+	if err := c.storage.CreateAuditCheckpoint(ctx, cp); err != nil {
+		return nil, false, fmt.Errorf("failed to write audit checkpoint: %w", err)
+	}
+	return cp, true, nil
+}
+
+// enforceAuditCheckpoint augments a chain-walk verdict with on-box checkpoint
+// verification: it loads the latest signed checkpoint and, if its signature is
+// authentic and current, requires the live chain to still be at least as long as
+// the checkpoint certified, with the certified head row unchanged. Any shortfall
+// or head rewrite flips Valid to false. A checkpoint signed under a superseded
+// DEK version is recorded but not enforced (it cannot be re-verified after a key
+// rotation). A signature that does not recompute is itself a tamper signal.
+func (c *KeyorixCore) enforceAuditCheckpoint(ctx context.Context, v *storage.AuditChainVerification) error {
+	if !c.AuditCheckpointsAvailable() {
+		return nil
+	}
+	cp, err := c.storage.LatestAuditCheckpoint(ctx)
+	if err != nil {
+		return err
+	}
+	if cp == nil {
+		return nil // none written yet
+	}
+	if cp.KeyVersion != c.auditCkptKeyVersion {
+		v.CheckpointReason = fmt.Sprintf(
+			"latest audit checkpoint #%d was signed under key version %q (current %q); not enforced after a key rotation",
+			cp.ID, cp.KeyVersion, c.auditCkptKeyVersion)
+		return nil
+	}
+
+	v.Checkpointed = true
+
+	if !c.checkpointSignatureValid(cp) {
+		c.failCheckpoint(v, nil,
+			fmt.Sprintf("audit checkpoint #%d signature is invalid — the checkpoint row was tampered (forged without the signing key)", cp.ID))
+		return nil
+	}
+	if v.ChainedEvents < cp.ChainedEvents {
+		c.failCheckpoint(v, nil,
+			fmt.Sprintf("audit trail truncated below signed checkpoint #%d: it certified %d chained events, only %d remain",
+				cp.ID, cp.ChainedEvents, v.ChainedEvents))
+		return nil
+	}
+	hash, found, err := c.storage.AuditEntryHashByID(ctx, cp.HeadID)
+	if err != nil {
+		return err
+	}
+	headID := cp.HeadID
+	if !found {
+		c.failCheckpoint(v, &headID,
+			fmt.Sprintf("audit event #%d certified by checkpoint #%d is missing (tail-truncation or genesis re-seed)", cp.HeadID, cp.ID))
+		return nil
+	}
+	if hash != cp.HeadHash {
+		c.failCheckpoint(v, &headID,
+			fmt.Sprintf("audit event #%d hash differs from signed checkpoint #%d (certified head was rewritten)", cp.HeadID, cp.ID))
+		return nil
+	}
+	return nil
+}
+
+// failCheckpoint records a checkpoint-detected tamper on the verdict without
+// clobbering a more specific chain-walk failure that may already be present.
+func (c *KeyorixCore) failCheckpoint(v *storage.AuditChainVerification, brokenID *uint, reason string) {
+	v.Valid = false
+	v.CheckpointReason = reason
+	if v.Reason == "" {
+		v.Reason = reason
+	}
+	if v.FirstBrokenID == nil && brokenID != nil {
+		v.FirstBrokenID = brokenID
+	}
+}
+
+// checkpointCanonical is the exact byte string signed/verified for a checkpoint.
+// Null-separated and version-prefixed so fields cannot be ambiguously re-split.
+func checkpointCanonical(cp *models.AuditCheckpoint) string {
+	return fmt.Sprintf("v1\x00%d\x00%d\x00%s\x00%s", cp.ChainedEvents, cp.HeadID, cp.HeadHash, cp.KeyVersion)
+}
+
+func (c *KeyorixCore) signCheckpoint(cp *models.AuditCheckpoint) string {
+	mac := hmac.New(sha256.New, c.auditCkptKey)
+	mac.Write([]byte(checkpointCanonical(cp)))
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+func (c *KeyorixCore) checkpointSignatureValid(cp *models.AuditCheckpoint) bool {
+	return hmac.Equal([]byte(c.signCheckpoint(cp)), []byte(cp.Signature))
+}

--- a/internal/core/audit_checkpoint_test.go
+++ b/internal/core/audit_checkpoint_test.go
@@ -101,7 +101,59 @@ func TestAuditCheckpoint_DetectsForgedCheckpoint(t *testing.T) {
 	v, err := c.VerifyAuditChain(ctx)
 	require.NoError(t, err)
 	assert.False(t, v.Valid)
-	assert.Contains(t, v.CheckpointReason, "signature is invalid")
+	assert.Contains(t, v.CheckpointReason, "does not verify under the current signing key")
+}
+
+// A DB-level actor must not be able to disable enforcement by editing the
+// unauthenticated key_version column — the HMAC binds key_version, so the edit
+// fails the signature check (regression guard for the pre-merge security finding).
+func TestAuditCheckpoint_TamperedKeyVersionDetected(t *testing.T) {
+	ctx := context.Background()
+	c, db := newCheckpointCore(t)
+	logEvents(t, c, 5)
+	_, _, err := c.WriteAuditCheckpoint(ctx)
+	require.NoError(t, err)
+
+	// Attacker flips key_version to force the (old) "not enforced" branch, then
+	// truncates. The signature now fails, so enforcement is NOT skipped.
+	require.NoError(t, db.Exec("UPDATE audit_checkpoints SET key_version = 'forged'").Error)
+	require.NoError(t, db.Exec("DELETE FROM audit_events WHERE id >= 4").Error)
+
+	v, err := c.VerifyAuditChain(ctx)
+	require.NoError(t, err)
+	assert.False(t, v.Valid, "a tampered key_version must not disable enforcement")
+	assert.Contains(t, v.CheckpointReason, "does not verify under the current signing key")
+}
+
+// After a genuine DEK rotation the prior checkpoint cannot be re-verified, so
+// verify reports invalid until the next checkpoint write re-baselines under the
+// new key — and that write must succeed (no deadlock).
+func TestAuditCheckpoint_RotationRebaselines(t *testing.T) {
+	ctx := context.Background()
+	c, _ := newCheckpointCore(t)
+	logEvents(t, c, 5)
+	_, _, err := c.WriteAuditCheckpoint(ctx) // signed under "v1"
+	require.NoError(t, err)
+
+	// Rotate the DEK → a new signing key + version.
+	c.SetAuditCheckpointKey(bytes.Repeat([]byte{0x9}, 32), "v2")
+
+	// The stale "v1" checkpoint no longer verifies → flagged (fail closed).
+	v, err := c.VerifyAuditChain(ctx)
+	require.NoError(t, err)
+	assert.False(t, v.Valid, "a stale checkpoint after rotation is not silently trusted")
+	assert.Contains(t, v.CheckpointReason, "does not verify under the current signing key")
+
+	// A fresh checkpoint re-baselines under the new key (no deadlock).
+	cp, written, err := c.WriteAuditCheckpoint(ctx)
+	require.NoError(t, err)
+	require.True(t, written)
+	assert.Equal(t, "v2", cp.KeyVersion)
+
+	v, err = c.VerifyAuditChain(ctx)
+	require.NoError(t, err)
+	assert.True(t, v.Valid, "recovered after re-baseline")
+	assert.True(t, v.Checkpointed)
 }
 
 func TestAuditCheckpoint_NoKeyIsNoOp(t *testing.T) {
@@ -121,22 +173,24 @@ func TestAuditCheckpoint_NoKeyIsNoOp(t *testing.T) {
 	assert.False(t, v.Checkpointed, "no key → no on-box checkpoint enforcement")
 }
 
-func TestAuditCheckpoint_KeyVersionMismatchNotEnforced(t *testing.T) {
+// A checkpoint written over an empty chain (HeadID=0) must not later false-alarm
+// once events accumulate — there is no head row 0 to "go missing".
+func TestAuditCheckpoint_GenesisCheckpointNoFalsePositive(t *testing.T) {
 	ctx := context.Background()
-	c, db := newCheckpointCore(t)
-	logEvents(t, c, 5)
-	_, _, err := c.WriteAuditCheckpoint(ctx) // signed under "v1"
-	require.NoError(t, err)
+	c, _ := newCheckpointCore(t)
 
-	// Simulate a DEK rotation: the in-memory key version moves on.
-	c.SetAuditCheckpointKey(bytes.Repeat([]byte{0x7}, 32), "v2")
-	require.NoError(t, db.Exec("DELETE FROM audit_events WHERE id >= 4").Error)
+	cp, written, err := c.WriteAuditCheckpoint(ctx) // empty chain → certifies 0
+	require.NoError(t, err)
+	require.True(t, written)
+	assert.Equal(t, int64(0), cp.ChainedEvents)
+	assert.Equal(t, uint(0), cp.HeadID)
+
+	logEvents(t, c, 4) // chain grows past the genesis checkpoint
 
 	v, err := c.VerifyAuditChain(ctx)
 	require.NoError(t, err)
-	assert.True(t, v.Valid, "a checkpoint signed under a superseded key version is not enforced")
-	assert.False(t, v.Checkpointed)
-	assert.Contains(t, v.CheckpointReason, "not enforced")
+	assert.True(t, v.Valid, "a growing chain is not a truncation of the genesis checkpoint")
+	assert.True(t, v.Checkpointed)
 }
 
 func TestAuditCheckpoint_RefusesBrokenChain(t *testing.T) {
@@ -167,7 +221,7 @@ func TestAuditCheckpoint_NoRebaselineOverTruncation(t *testing.T) {
 	_, written, err := c.WriteAuditCheckpoint(ctx)
 	require.Error(t, err)
 	assert.False(t, written)
-	assert.Contains(t, err.Error(), "does not verify")
+	assert.Contains(t, err.Error(), "truncated below signed checkpoint")
 
 	var n int64
 	require.NoError(t, db.Model(&models.AuditCheckpoint{}).Count(&n).Error)

--- a/internal/core/audit_checkpoint_test.go
+++ b/internal/core/audit_checkpoint_test.go
@@ -1,0 +1,199 @@
+package core
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// newCheckpointCore builds a real-SQLite core with a fixed checkpoint signing key.
+func newCheckpointCore(t *testing.T) (*KeyorixCore, *gorm.DB) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.AuditEvent{}, &models.AuditCheckpoint{}))
+	c := &KeyorixCore{storage: store.NewLocalStorage(db)}
+	c.SetAuditCheckpointKey(bytes.Repeat([]byte{0x7}, 32), "v1")
+	return c, db
+}
+
+func logEvents(t *testing.T, c *KeyorixCore, n int) {
+	t.Helper()
+	// A fixed, second-aligned UTC base so EventTime round-trips through SQLite
+	// exactly (sub-microsecond precision from time.Now() would not, making the
+	// recomputed entry hash flaky).
+	base := time.Date(2026, 6, 13, 10, 0, 0, 0, time.UTC)
+	tr := true
+	for i := 0; i < n; i++ {
+		require.NoError(t, c.storage.LogAuditEvent(context.Background(), &models.AuditEvent{
+			EventType:   "secret.read",
+			Description: fmt.Sprintf("event %d", i),
+			Success:     &tr,
+			EventTime:   base.Add(time.Duration(i) * time.Second),
+			// Set explicitly: the column defaults to "user", and the hash binds
+			// ActorType raw, so an unset field would hash "" but store "user".
+			ActorType: "user",
+		}))
+	}
+}
+
+func TestAuditCheckpoint_HappyPath(t *testing.T) {
+	ctx := context.Background()
+	c, _ := newCheckpointCore(t)
+	logEvents(t, c, 5)
+
+	cp, written, err := c.WriteAuditCheckpoint(ctx)
+	require.NoError(t, err)
+	require.True(t, written)
+	assert.Equal(t, int64(5), cp.ChainedEvents)
+	assert.Equal(t, "v1", cp.KeyVersion)
+	assert.NotEmpty(t, cp.Signature)
+
+	v, err := c.VerifyAuditChain(ctx)
+	require.NoError(t, err)
+	assert.True(t, v.Valid)
+	assert.True(t, v.Checkpointed)
+	assert.Empty(t, v.CheckpointReason)
+}
+
+func TestAuditCheckpoint_DetectsTailTruncation(t *testing.T) {
+	ctx := context.Background()
+	c, db := newCheckpointCore(t)
+	logEvents(t, c, 5)
+	_, _, err := c.WriteAuditCheckpoint(ctx) // certifies 5
+	require.NoError(t, err)
+
+	// Drop the tail → a self-consistent SHORTER chain. The bare re-walk passes;
+	// only the signed checkpoint catches the drop.
+	require.NoError(t, db.Exec("DELETE FROM audit_events WHERE id >= 4").Error)
+
+	raw, err := c.storage.VerifyAuditChain(ctx)
+	require.NoError(t, err)
+	assert.True(t, raw.Valid, "the bare chain walk cannot catch tail-truncation on its own")
+
+	v, err := c.VerifyAuditChain(ctx)
+	require.NoError(t, err)
+	assert.False(t, v.Valid, "the checkpoint catches it")
+	assert.True(t, v.Checkpointed)
+	assert.Contains(t, v.CheckpointReason, "truncated below signed checkpoint")
+}
+
+func TestAuditCheckpoint_DetectsForgedCheckpoint(t *testing.T) {
+	ctx := context.Background()
+	c, db := newCheckpointCore(t)
+	logEvents(t, c, 5)
+	_, _, err := c.WriteAuditCheckpoint(ctx)
+	require.NoError(t, err)
+
+	// A DB-level actor lowers the certified count to mask a planned truncation,
+	// but cannot re-sign without the key → signature no longer recomputes.
+	require.NoError(t, db.Exec("UPDATE audit_checkpoints SET chained_events = 1").Error)
+
+	v, err := c.VerifyAuditChain(ctx)
+	require.NoError(t, err)
+	assert.False(t, v.Valid)
+	assert.Contains(t, v.CheckpointReason, "signature is invalid")
+}
+
+func TestAuditCheckpoint_NoKeyIsNoOp(t *testing.T) {
+	ctx := context.Background()
+	c, _ := newCheckpointCore(t)
+	c.SetAuditCheckpointKey(nil, "") // simulate encryption disabled
+	logEvents(t, c, 3)
+
+	cp, written, err := c.WriteAuditCheckpoint(ctx)
+	require.NoError(t, err)
+	assert.False(t, written)
+	assert.Nil(t, cp)
+
+	v, err := c.VerifyAuditChain(ctx)
+	require.NoError(t, err)
+	assert.True(t, v.Valid)
+	assert.False(t, v.Checkpointed, "no key → no on-box checkpoint enforcement")
+}
+
+func TestAuditCheckpoint_KeyVersionMismatchNotEnforced(t *testing.T) {
+	ctx := context.Background()
+	c, db := newCheckpointCore(t)
+	logEvents(t, c, 5)
+	_, _, err := c.WriteAuditCheckpoint(ctx) // signed under "v1"
+	require.NoError(t, err)
+
+	// Simulate a DEK rotation: the in-memory key version moves on.
+	c.SetAuditCheckpointKey(bytes.Repeat([]byte{0x7}, 32), "v2")
+	require.NoError(t, db.Exec("DELETE FROM audit_events WHERE id >= 4").Error)
+
+	v, err := c.VerifyAuditChain(ctx)
+	require.NoError(t, err)
+	assert.True(t, v.Valid, "a checkpoint signed under a superseded key version is not enforced")
+	assert.False(t, v.Checkpointed)
+	assert.Contains(t, v.CheckpointReason, "not enforced")
+}
+
+func TestAuditCheckpoint_RefusesBrokenChain(t *testing.T) {
+	ctx := context.Background()
+	c, db := newCheckpointCore(t)
+	logEvents(t, c, 5)
+
+	// Delete a MIDDLE row → linkage breaks; the chain does not verify.
+	require.NoError(t, db.Exec("DELETE FROM audit_events WHERE id = 3").Error)
+
+	_, written, err := c.WriteAuditCheckpoint(ctx)
+	require.Error(t, err)
+	assert.False(t, written)
+	assert.Contains(t, err.Error(), "refusing to checkpoint")
+}
+
+func TestAuditCheckpoint_NoRebaselineOverTruncation(t *testing.T) {
+	ctx := context.Background()
+	c, db := newCheckpointCore(t)
+	logEvents(t, c, 5)
+	_, _, err := c.WriteAuditCheckpoint(ctx) // certifies 5
+	require.NoError(t, err)
+
+	require.NoError(t, db.Exec("DELETE FROM audit_events WHERE id >= 4").Error) // truncate to 3
+
+	// A subsequent scheduled checkpoint must NOT silently re-baseline to the
+	// shorter chain (which would erase the tamper evidence going forward).
+	_, written, err := c.WriteAuditCheckpoint(ctx)
+	require.Error(t, err)
+	assert.False(t, written)
+	assert.Contains(t, err.Error(), "does not verify")
+
+	var n int64
+	require.NoError(t, db.Model(&models.AuditCheckpoint{}).Count(&n).Error)
+	assert.Equal(t, int64(1), n, "no new checkpoint papered over the truncation")
+}
+
+func TestAuditCheckpoint_SignDeterministicAndBinding(t *testing.T) {
+	c := &KeyorixCore{}
+	c.SetAuditCheckpointKey(bytes.Repeat([]byte{0x1}, 32), "v1")
+	cp := &models.AuditCheckpoint{ChainedEvents: 5, HeadID: 5, HeadHash: "abc", KeyVersion: "v1"}
+	sig := c.signCheckpoint(cp)
+	require.NotEmpty(t, sig)
+	assert.Equal(t, sig, c.signCheckpoint(cp), "deterministic for fixed inputs")
+
+	cp.Signature = sig
+	assert.True(t, c.checkpointSignatureValid(cp))
+
+	for _, mut := range []func(){
+		func() { cp.ChainedEvents = 4 },
+		func() { cp.HeadID = 6 },
+		func() { cp.HeadHash = "abd" },
+		func() { cp.KeyVersion = "v2" },
+	} {
+		fresh := &models.AuditCheckpoint{ChainedEvents: 5, HeadID: 5, HeadHash: "abc", KeyVersion: "v1", Signature: sig}
+		cp = fresh
+		mut()
+		assert.False(t, c.checkpointSignatureValid(cp), "every signed field is bound")
+	}
+}

--- a/internal/core/audit_retention.go
+++ b/internal/core/audit_retention.go
@@ -67,12 +67,18 @@ func (c *KeyorixCore) AuditRetentionCoverage(ctx context.Context) (*AuditRetenti
 }
 
 // VerifyAuditChain re-walks the tamper-evidence hash chain (ADR-029) and reports
-// whether the audit trail is intact. Backs GET /api/v1/audit/verify — see
+// whether the audit trail is intact. When a signing key is configured, it also
+// verifies the live chain against the latest signed checkpoint — adding on-box
+// detection of tail-truncation / genesis re-seed that the bare re-walk cannot
+// catch. Backs GET /api/v1/audit/verify — see
 // docs/adr-029-audit-log-tamper-evidence.md.
 func (c *KeyorixCore) VerifyAuditChain(ctx context.Context) (*storage.AuditChainVerification, error) {
 	v, err := c.storage.VerifyAuditChain(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to verify audit chain: %w", err)
+	}
+	if err := c.enforceAuditCheckpoint(ctx, v); err != nil {
+		return nil, fmt.Errorf("failed to verify audit checkpoint: %w", err)
 	}
 	return v, nil
 }

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -678,6 +678,24 @@ func (m *MockStorage) VerifyAuditChain(ctx context.Context) (*storage.AuditChain
 	return args.Get(0).(*storage.AuditChainVerification), args.Error(1)
 }
 
+func (m *MockStorage) CreateAuditCheckpoint(ctx context.Context, cp *models.AuditCheckpoint) error {
+	args := m.Called(ctx, cp)
+	return args.Error(0)
+}
+
+func (m *MockStorage) LatestAuditCheckpoint(ctx context.Context) (*models.AuditCheckpoint, error) {
+	args := m.Called(ctx)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.AuditCheckpoint), args.Error(1)
+}
+
+func (m *MockStorage) AuditEntryHashByID(ctx context.Context, id uint) (string, bool, error) {
+	args := m.Called(ctx, id)
+	return args.String(0), args.Bool(1), args.Error(2)
+}
+
 func (m *MockStorage) UnusedSecrets(ctx context.Context, projectID *uint, notReadSince time.Time) ([]storage.UnusedSecretStat, error) {
 	args := m.Called(ctx, projectID, notReadSince)
 	if args.Get(0) == nil {

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -67,6 +67,15 @@ type KeyorixCore struct {
 	// setupBaseURL is the absolute base (e.g. https://keyorix.acme.internal) used to
 	// build setup links. Required to mint a link; a relative link is a misconfig.
 	setupBaseURL string
+	// auditCkptKey signs/verifies audit-chain checkpoints (ADR-029): a DEK-derived
+	// HMAC key the database/DBA does not hold. nil = signed checkpoints unavailable
+	// (encryption disabled), in which case WriteAuditCheckpoint is a no-op and
+	// VerifyAuditChain runs without on-box checkpoint enforcement. Set at startup
+	// via SetAuditCheckpointKey. auditCkptKeyVersion records which DEK version it
+	// was derived from, so a checkpoint signed under a superseded key is not
+	// enforced after a DEK rotation.
+	auditCkptKey        []byte
+	auditCkptKeyVersion string
 }
 
 // AuditForwarder ships persisted audit events to an external sink (e.g. a SIEM).

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -262,6 +262,14 @@ type Storage interface {
 	// with the offending event id. A leading run of pre-ADR-029 rows with empty
 	// hashes is counted as an unchained legacy prefix, not a failure.
 	VerifyAuditChain(ctx context.Context) (*AuditChainVerification, error)
+	// CreateAuditCheckpoint appends a signed checkpoint of the chain head (ADR-029).
+	CreateAuditCheckpoint(ctx context.Context, cp *models.AuditCheckpoint) error
+	// LatestAuditCheckpoint returns the most recently written checkpoint, or
+	// (nil, nil) when none exists yet.
+	LatestAuditCheckpoint(ctx context.Context) (*models.AuditCheckpoint, error)
+	// AuditEntryHashByID returns the entry_hash of the audit row with the given
+	// id; found is false when no such row exists (e.g. it was truncated away).
+	AuditEntryHashByID(ctx context.Context, id uint) (hash string, found bool, err error)
 	GetDistinctActiveUserIDs(ctx context.Context, since time.Time) ([]uint, error)
 	// CountImpersonatedActions returns the number of impersonated audit events
 	// recorded for actingAs by impersonator since `since`, excluding the
@@ -575,6 +583,15 @@ type AuditChainVerification struct {
 	// the off-box tamper signal.
 	HeadHash string
 	HeadID   uint
+
+	// Checkpointed is true when the live chain was additionally verified against
+	// a signed in-DB checkpoint (ADR-029) — an on-box anchor a DBA cannot forge.
+	// When a valid checkpoint exists and the chain has dropped below it (or the
+	// checkpointed head changed), Valid is false and CheckpointReason explains it.
+	// CheckpointReason also carries non-fatal notes (e.g. a checkpoint signed
+	// under a superseded key version, which is recorded but not enforced).
+	Checkpointed     bool
+	CheckpointReason string
 }
 
 // UnusedSecretStat is one row of the unused-secrets report. LastRead is nil when

--- a/internal/encryption/audit_checkpoint_key_test.go
+++ b/internal/encryption/audit_checkpoint_key_test.go
@@ -1,0 +1,41 @@
+package encryption
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAuditCheckpointKey_DerivedAndStable(t *testing.T) {
+	svc, _ := newTestService(t, "test-passphrase-for-unit-tests")
+
+	key, ver, ok := svc.AuditCheckpointKey()
+	require.True(t, ok, "an enabled+initialised service must yield a checkpoint key")
+	assert.Len(t, key, 32, "checkpoint key is 32 bytes")
+	assert.NotEmpty(t, ver, "key version is reported")
+
+	// Deterministic for the same DEK.
+	key2, ver2, ok2 := svc.AuditCheckpointKey()
+	require.True(t, ok2)
+	assert.True(t, bytes.Equal(key, key2), "derivation is stable for a fixed DEK")
+	assert.Equal(t, ver, ver2)
+
+	// Domain separation: the checkpoint key is not the raw DEK.
+	dek := svc.keyManager.GetDEK()
+	assert.False(t, bytes.Equal(key, dek), "checkpoint key must be HKDF-derived, not the DEK itself")
+}
+
+func TestAuditCheckpointKey_UnavailableWhenDisabled(t *testing.T) {
+	// Encryption disabled → no DEK → no checkpoint key.
+	svc := NewService(&config.EncryptionConfig{Enabled: false}, t.TempDir())
+	_, _, ok := svc.AuditCheckpointKey()
+	assert.False(t, ok, "a disabled service has no signing key")
+
+	// Enabled but not initialised → also unavailable.
+	svc2 := NewService(&config.EncryptionConfig{Enabled: true, DEKPath: "dek.key", SaltPath: "kek.salt"}, t.TempDir())
+	_, _, ok2 := svc2.AuditCheckpointKey()
+	assert.False(t, ok2, "an uninitialised service has no DEK yet")
+}

--- a/internal/encryption/service.go
+++ b/internal/encryption/service.go
@@ -5,11 +5,15 @@ package encryption
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"sync"
+
+	"golang.org/x/crypto/hkdf"
 
 	"github.com/keyorixhq/keyorix/internal/config"
 	"github.com/keyorixhq/keyorix/internal/crypto"
@@ -126,6 +130,37 @@ func (s *Service) IsInitialized() bool {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.initialized
+}
+
+// auditCheckpointKeyInfo domain-separates the audit-checkpoint signing key from
+// the DEK's other uses (HKDF info parameter). Bump the suffix only if the
+// derivation scheme changes.
+const auditCheckpointKeyInfo = "keyorix-audit-checkpoint-v1"
+
+// AuditCheckpointKey derives a 32-byte HMAC key for signing audit-chain
+// checkpoints (ADR-029) from the current DEK via HKDF-SHA256, alongside the
+// current key version. The key is bound to the DEK but domain-separated from
+// secret encryption, so it is held only in application memory and never written
+// to the database — a checkpoint therefore cannot be forged from database access
+// alone. Returns ok=false when encryption is disabled or uninitialised (no DEK),
+// in which case signed checkpoints are unavailable.
+func (s *Service) AuditCheckpointKey() (key []byte, keyVersion string, ok bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if !s.config.Enabled || !s.initialized {
+		return nil, "", false
+	}
+	dek := s.keyManager.GetDEK()
+	defer wipeBytes(dek)
+	if len(dek) == 0 {
+		return nil, "", false
+	}
+	r := hkdf.New(sha256.New, dek, nil, []byte(auditCheckpointKeyInfo))
+	out := make([]byte, 32)
+	if _, err := io.ReadFull(r, out); err != nil {
+		return nil, "", false
+	}
+	return out, s.keyManager.GetKeyVersion(), true
 }
 
 // EncryptSecret encrypts plaintext and returns (encryptedBytes, metadataBytes, error).

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -268,6 +268,7 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 	webauthnCredExists := tableExists(db, "web_authn_credentials")
 	webauthnSessExists := tableExists(db, "web_authn_sessions")
 	loginAttemptExists := tableExists(db, "login_attempts")
+	auditCkptExists := tableExists(db, "audit_checkpoints")
 
 	// Create rotation_policies if missing (additive, safe on existing DBs).
 	if !rotationExists {
@@ -349,6 +350,14 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 	if !loginAttemptExists {
 		if err := db.AutoMigrate(&models.LoginAttempt{}); err != nil {
 			return fmt.Errorf("failed to migrate login_attempts table: %w", err)
+		}
+	}
+
+	// Create the audit_checkpoints table if missing (ADR-029 signed checkpoints,
+	// additive, safe on existing DBs).
+	if !auditCkptExists {
+		if err := db.AutoMigrate(&models.AuditCheckpoint{}); err != nil {
+			return fmt.Errorf("failed to migrate audit_checkpoints table: %w", err)
 		}
 	}
 
@@ -470,6 +479,7 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 		// it again re-inspects the just-created table and trips the pgx "insufficient
 		// arguments" bug on a fresh Postgres first boot (same hazard as RotationPolicy).
 		&models.AuditEvent{},
+		&models.AuditCheckpoint{},
 		&models.Setting{},
 		&models.SystemMetadata{},
 		&models.APIClient{},

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -508,6 +508,24 @@ type AuditEvent struct {
 	EntryHash string `gorm:"index"`
 }
 
+// AuditCheckpoint is a signed notarisation of the audit hash-chain head
+// (ADR-029). Signature is an HMAC over (ChainedEvents, HeadID, HeadHash,
+// KeyVersion) keyed by a DEK-derived key the database/DBA does not hold, so a
+// checkpoint cannot be forged from database access alone. Re-verifying the live
+// chain against the latest signed checkpoint detects on-box tail-truncation or a
+// genesis re-seed — which an unanchored re-walk of a self-consistent (shorter)
+// chain cannot catch. Append-only: a new checkpoint is added each cycle, never
+// updated.
+type AuditCheckpoint struct {
+	ID            uint      `gorm:"primaryKey" json:"id"`
+	ChainedEvents int64     `json:"chained_events"`
+	HeadID        uint      `json:"head_id"`
+	HeadHash      string    `json:"head_hash"`
+	KeyVersion    string    `json:"key_version"`
+	Signature     string    `gorm:"not null" json:"signature"` // hex HMAC-SHA256
+	CreatedAt     time.Time `json:"created_at"`
+}
+
 type Setting struct {
 	ID     uint `gorm:"primaryKey"`
 	UserID *uint

--- a/internal/storage/store/local_audit_checkpoint.go
+++ b/internal/storage/store/local_audit_checkpoint.go
@@ -1,0 +1,63 @@
+// local_audit_checkpoint.go — signed checkpoints over the audit hash chain
+// (ADR-029). A checkpoint records (chained_events, head_id, head_hash) at a
+// point in time with an HMAC the application holds the key for; re-verifying the
+// live chain against the latest checkpoint detects on-box tail-truncation or a
+// genesis re-seed that an unanchored re-walk cannot. The signing/verification of
+// the HMAC lives in the core layer (which holds the DEK-derived key); this file
+// only persists and reads checkpoint rows.
+package store
+
+import (
+	"context"
+	"errors"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"gorm.io/gorm"
+)
+
+// CreateAuditCheckpoint appends a signed checkpoint row (append-only).
+func (ls *LocalStorage) CreateAuditCheckpoint(ctx context.Context, cp *models.AuditCheckpoint) error {
+	return ls.db.WithContext(ctx).Create(cp).Error
+}
+
+// LatestAuditCheckpoint returns the most recent checkpoint by id, or (nil, nil)
+// when none has been written yet.
+func (ls *LocalStorage) LatestAuditCheckpoint(ctx context.Context) (*models.AuditCheckpoint, error) {
+	var cp models.AuditCheckpoint
+	err := ls.db.WithContext(ctx).Order("id DESC").Limit(1).Take(&cp).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &cp, nil
+}
+
+// AuditEntryHashByID returns the entry_hash of one audit row. found is false when
+// the row no longer exists — the signal that a checkpointed head was truncated.
+func (ls *LocalStorage) AuditEntryHashByID(ctx context.Context, id uint) (string, bool, error) {
+	var row struct{ EntryHash string }
+	err := ls.db.WithContext(ctx).
+		Model(&models.AuditEvent{}).
+		Select("entry_hash").
+		Where("id = ?", id).
+		Limit(1).
+		Scan(&row).Error
+	if err != nil {
+		return "", false, err
+	}
+	// Scan leaves row zero-valued when no record matched; distinguish a missing
+	// row from a genuinely-empty hash via a separate existence count.
+	var n int64
+	if err := ls.db.WithContext(ctx).
+		Model(&models.AuditEvent{}).
+		Where("id = ?", id).
+		Count(&n).Error; err != nil {
+		return "", false, err
+	}
+	if n == 0 {
+		return "", false, nil
+	}
+	return row.EntryHash, true, nil
+}

--- a/internal/storage/store/remote_audit.go
+++ b/internal/storage/store/remote_audit.go
@@ -143,6 +143,21 @@ func (rs *RemoteStorage) VerifyAuditChain(_ context.Context) (*storage.AuditChai
 	return nil, fmt.Errorf("VerifyAuditChain not available in remote mode")
 }
 
+// CreateAuditCheckpoint is not available in remote mode; checkpointing is server-side.
+func (rs *RemoteStorage) CreateAuditCheckpoint(_ context.Context, _ *models.AuditCheckpoint) error {
+	return fmt.Errorf("CreateAuditCheckpoint not available in remote mode")
+}
+
+// LatestAuditCheckpoint is not available in remote mode; checkpointing is server-side.
+func (rs *RemoteStorage) LatestAuditCheckpoint(_ context.Context) (*models.AuditCheckpoint, error) {
+	return nil, fmt.Errorf("LatestAuditCheckpoint not available in remote mode")
+}
+
+// AuditEntryHashByID is not available in remote mode; chain verification runs server-side.
+func (rs *RemoteStorage) AuditEntryHashByID(_ context.Context, _ uint) (string, bool, error) {
+	return "", false, fmt.Errorf("AuditEntryHashByID not available in remote mode")
+}
+
 // CreateAnomalyAlert is not available in remote mode; anomaly detection is server-side.
 func (rs *RemoteStorage) CreateAnomalyAlert(_ context.Context, _ *models.AnomalyAlert) error {
 	return fmt.Errorf("CreateAnomalyAlert not available in remote mode")

--- a/server/http/handlers/audit.go
+++ b/server/http/handlers/audit.go
@@ -365,10 +365,16 @@ func (h *AuditHandler) VerifyAuditChain(w http.ResponseWriter, r *http.Request) 
 		// detect tail-truncation / re-seed that an on-box re-walk can't catch alone.
 		"head_hash": v.HeadHash,
 		"head_id":   v.HeadID,
+		// checkpointed=true when the chain was also verified against a signed in-DB
+		// checkpoint (ADR-029) — on-box truncation detection a DBA cannot forge.
+		"checkpointed": v.Checkpointed,
 	}
 	if !v.Valid {
 		resp["first_broken_id"] = v.FirstBrokenID
 		resp["reason"] = v.Reason
+	}
+	if v.CheckpointReason != "" {
+		resp["checkpoint_reason"] = v.CheckpointReason
 	}
 	sendSuccess(w, resp, "")
 }

--- a/server/main.go
+++ b/server/main.go
@@ -139,6 +139,7 @@ const (
 	schedLockDynamicSweep int64 = 0x4B455953_44594E53 // "KEYSDYNS"
 	schedLockLoginPrune   int64 = 0x4B455953_4C474E50 // "KEYSLGNP"
 	schedLockRotationRmdr int64 = 0x4B455953_524F5452 // "KEYSROTR"
+	schedLockAuditCkpt    int64 = 0x4B455953_41434B50 // "KEYSACKP"
 )
 
 // initializeEncryption sources the KEK per the configured key provider (ADR-038)
@@ -195,6 +196,12 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 		// Wire the initialised encryption service for reversibly-encrypted auth
 		// secrets (the TOTP MFA secret, which cannot be hashed).
 		coreService.SetAuthEncryptor(encSvc)
+		// Derive the audit-checkpoint signing key from the DEK (ADR-029) so signed
+		// checkpoints — and on-box truncation detection — are available. Unavailable
+		// when encryption is off (no DEK).
+		if key, keyVer, ok := encSvc.AuditCheckpointKey(); ok {
+			coreService.SetAuditCheckpointKey(key, keyVer)
+		}
 	}
 
 	// Apply a configured password policy, if any. An absent block leaves the
@@ -423,6 +430,47 @@ func startHTTPServer(ctx context.Context, cfg *config.Config) error {
 				}
 			}
 		}()
+	}
+
+	// Start the audit-checkpoint scheduler (ADR-029) — opt-in. Periodically signs
+	// the verified audit-chain head so tail-truncation / genesis re-seed becomes
+	// detectable on-box. HA-gated so one replica writes per tick. Requires
+	// encryption (the signing key is DEK-derived); skipped with a warning if not.
+	if cfg.AuditCheckpoints.Enabled {
+		if !coreService.AuditCheckpointsAvailable() {
+			log.Printf("Audit-checkpoint scheduler requested but encryption is disabled (no signing key); skipping")
+		} else {
+			interval := cfg.AuditCheckpoints.GetInterval()
+			log.Printf("Audit-checkpoint scheduler enabled: every %s", interval)
+			go func() {
+				ticker := time.NewTicker(interval)
+				defer ticker.Stop()
+				writeCheckpoint := func() {
+					if _, err := coreService.Storage().WithSchedulerLock(ctx, schedLockAuditCkpt, func() error {
+						cp, written, werr := coreService.WriteAuditCheckpoint(ctx)
+						if werr != nil {
+							log.Printf("Audit-checkpoint error: %v", werr)
+							return werr
+						}
+						if written {
+							log.Printf("Audit checkpoint written: #%d head=%d events=%d", cp.ID, cp.HeadID, cp.ChainedEvents)
+						}
+						return nil
+					}); err != nil {
+						log.Printf("Audit-checkpoint scheduler error: %v", err)
+					}
+				}
+				writeCheckpoint() // run once on startup
+				for {
+					select {
+					case <-ticker.C:
+						writeCheckpoint()
+					case <-ctx.Done():
+						return
+					}
+				}
+			}()
+		}
 	}
 
 	// Start the dynamic-secrets auto-revoke sweeper (ADR-035) — opt-in. Revokes


### PR DESCRIPTION
## What

Closes the one honestly-flagged gap in the ADR-029 tamper-evidence story: an unanchored on-box re-walk cannot catch **tail-truncation / genesis re-seed** (a shorter, self-consistent chain still verifies). #139 added an *external* anchor and #152 a CLI to record it; this adds **on-box** detection a DBA cannot forge.

An opt-in, HA-gated scheduler signs the verified chain head — `(chained_events, head_id, head_hash)` — with an **HMAC-SHA256** keyed by a key the running server holds in memory but the database/DBA does **not** (HKDF-derived from the DEK, domain-separated). `VerifyAuditChain` then enforces the live chain against the latest signed checkpoint, so `GET /audit/verify` and `keyorix audit verify` detect truncation on-box (broken checkpoint → non-zero CLI exit).

## Mechanism

- `encryption.Service.AuditCheckpointKey()` — DEK→HKDF-SHA256 32-byte signing key + key version; `ok=false` when encryption is off.
- `models.AuditCheckpoint` + additive migration (new table, safe on existing DBs).
- Storage: `CreateAuditCheckpoint` / `LatestAuditCheckpoint` / `AuditEntryHashByID` (LocalStorage; RemoteStorage stubs — checkpointing is server-side).
- core: `WriteAuditCheckpoint` (verify-then-sign, refuses over an authenticated truncation), `enforceAuditCheckpoint` folded into `VerifyAuditChain` (new `checkpointed` / `checkpoint_reason` fields).
- Opt-in scheduler `audit_checkpoints.{enabled,schedule}` (default off, new HA lock id); skipped with a warning when encryption is disabled.

## Security

This diff was **security-reviewed pre-merge**, which caught a HIGH bypass in the first cut (an unauthenticated `key_version` check ran before the HMAC, letting a DB-level actor disable enforcement). Fixed in the second commit: **the signature is authenticated first**; the HMAC covers every field, so no unauthenticated column can skip enforcement — every branch fails closed. Re-review confirmed the bypass closed; only the documented residual remains (a DB actor who can write the checkpoint table reverts detection to the off-box anchor, but can never **forge** a valid checkpoint over a truncated chain — the key is never in the DB). `hmac.Equal` constant-time compare; GORM-parameterized queries.

## Tests

encryption key derivation (stable, domain-separated, unavailable when disabled); core happy-path, tail-truncation detection, forged-checkpoint, **tampered-key_version (bypass regression guard)**, **rotation fail-closed-then-rebaseline**, **genesis no-false-positive**, no-key no-op, refuse-broken-chain, no-rebaseline-over-truncation, sign determinism/binding; CLI checkpoint-truncation non-zero exit. Docs: ADR-029 (deferred→delivered, with the security model + residuals), CONFIGURATION, REMOTE_CLI_SETUP.

gofmt clean, golangci-lint 0 issues, `go build ./...` + full changed-package suites green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)