### PR TITLE
harden(authz): guard the two non-funnelled authz paths against PAT scope (ADR-042)

### DIFF
--- a/docs/adr-042-pat-permission-scoping.md
+++ b/docs/adr-042-pat-permission-scoping.md
@@ -57,6 +57,17 @@ runs. An existing token, or one created without a restriction, is unaffected
   automatically — there is no route to forget to wire (the failure mode ADR-037's
   pre-merge review caught for per-project MFA).
 
+- **The two authz paths that do _not_ funnel through `Authorize` are guarded
+  directly.** `core.IsGlobalAdmin` (used to short-circuit scope-filtered listing)
+  and the role-based `middleware.RequireRole` gate resolve authorization without
+  calling `Authorize`, so a PAT restriction would not reach them. Both now fail
+  closed for a PAT-restricted request: `IsGlobalAdmin` returns false (a scoped
+  token is never treated as an unrestricted global admin — callers fall back to the
+  filtered path, which can only return a subset), and `RequireRole` denies outright
+  (a deliberately-scoped token must not satisfy a role gate's full breadth). Neither
+  is wired to a live route today; the guards close the gap pre-emptively so that
+  enforcement genuinely holds at *every* path, as claimed above.
+
 - **It is a filter, never an escalation.** `Authorize` still resolves the owner's
   live roles after the restriction passes. A token listing `secrets.write` whose
   owner has since lost that permission grants nothing. This is why creation does

--- a/internal/core/authz.go
+++ b/internal/core/authz.go
@@ -162,7 +162,17 @@ func (c *KeyorixCore) Authorize(ctx context.Context, userID uint, permission str
 
 // IsGlobalAdmin reports whether userID holds an admin role assigned globally
 // (project 0, environment 0). Used to short-circuit scope-filtered listing.
+//
+// A request carrying a PAT least-privilege restriction (ADR-042) is never treated
+// as an unrestricted global admin: the token was deliberately scoped below its
+// owner, so a caller that uses this to return unfiltered data must instead fall
+// back to the scope-filtered path. Returning false here is fail-closed — the
+// filtered path can only ever return a subset — and keeps the restriction honoured
+// on this otherwise un-funnelled authz path (it does not flow through Authorize).
 func (c *KeyorixCore) IsGlobalAdmin(ctx context.Context, userID uint) (bool, error) {
+	if patRestrictionFromContext(ctx) != nil {
+		return false, nil
+	}
 	roleIDs, err := c.scopedRoleIDs(ctx, userID, Scope{})
 	if err != nil {
 		return false, err

--- a/internal/core/authz_pat_test.go
+++ b/internal/core/authz_pat_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -117,5 +118,37 @@ func TestAuthorize_PATRestriction(t *testing.T) {
 		allowed, err := c.Authorize(ctx, 1, "secrets.write", Scope{ProjectID: 5})
 		require.NoError(t, err)
 		assert.True(t, allowed)
+	})
+}
+
+// IsGlobalAdmin must not treat a PAT-restricted request as an unrestricted global
+// admin (ADR-042) — it is an un-funnelled authz path, so the restriction is
+// enforced here directly (fail-closed) rather than via Authorize.
+func TestIsGlobalAdmin_PATRestrictionDeniesShortCircuit(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("a scoped token is never a global admin — without touching storage", func(t *testing.T) {
+		ms := new(MockStorage)
+		c := NewKeyorixCore(ms)
+		// Even though the owner (user 1) may be a global admin, a scoped token must
+		// not get the unfiltered-listing short-circuit.
+		rctx := WithPATRestriction(ctx, &PATRestriction{Permissions: []string{"secrets.read"}})
+
+		isAdmin, err := c.IsGlobalAdmin(rctx, 1)
+		require.NoError(t, err)
+		assert.False(t, isAdmin)
+		ms.AssertNotCalled(t, "GetUserRoleIDsAt")
+	})
+
+	t.Run("no restriction resolves admin normally", func(t *testing.T) {
+		ms := new(MockStorage)
+		c := NewKeyorixCore(ms)
+		ms.On("GetUserRoleIDsAt", ctx, uint(1), Scope{}).Return([]uint{10}, nil)
+		ms.On("GetUserGroupRoleIDsAt", ctx, uint(1), Scope{}).Return([]uint{}, nil)
+		ms.On("GetRoleByName", ctx, "super_admin").Return(&models.Role{ID: 10, Name: "super_admin"}, nil)
+
+		isAdmin, err := c.IsGlobalAdmin(ctx, 1)
+		require.NoError(t, err)
+		assert.True(t, isAdmin)
 	})
 }

--- a/server/middleware/auth.go
+++ b/server/middleware/auth.go
@@ -502,13 +502,23 @@ func derefUint(p *uint) uint {
 	return *p
 }
 
-// RequireRole returns a middleware that checks if the user has a specific role
+// RequireRole returns a middleware that checks if the user has a specific role.
+//
+// A request authenticated by a PAT carrying a least-privilege restriction
+// (ADR-042) is denied outright: a role gate confers the role's full breadth,
+// which a deliberately-scoped token must not satisfy. This keeps PAT scoping
+// honoured on this role-based gate, which does not funnel through core.Authorize
+// (where the restriction is otherwise enforced). Fail-closed.
 func RequireRole(role string) func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			userCtx := GetUserFromContext(r.Context())
 			if userCtx == nil {
 				unauthorizedResponse(w, "User context not found")
+				return
+			}
+			if userCtx.PATRestriction != nil {
+				forbiddenResponse(w, "A scoped personal access token cannot satisfy a role requirement")
 				return
 			}
 			for _, userRole := range userCtx.Roles {

--- a/server/middleware/auth_test.go
+++ b/server/middleware/auth_test.go
@@ -284,6 +284,39 @@ func TestRequireRole(t *testing.T) {
 	}
 }
 
+// A PAT carrying a least-privilege restriction (ADR-042) must not satisfy a role
+// gate, even when its owner holds the role — RequireRole does not funnel through
+// core.Authorize, so the restriction is enforced here directly (fail-closed).
+func TestRequireRole_DeniesScopedPAT(t *testing.T) {
+	testHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := RequireRole("admin")(testHandler)
+
+	t.Run("scoped PAT on an admin owner is forbidden", func(t *testing.T) {
+		userCtx := &UserContext{
+			UserID:         1,
+			Username:       "admin",
+			Roles:          []string{"admin", "user"},
+			PATRestriction: &core.PATRestriction{Permissions: []string{"secrets.read"}},
+		}
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req = req.WithContext(context.WithValue(req.Context(), userContextKey, userCtx))
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusForbidden, w.Code)
+	})
+
+	t.Run("same owner via a full session still passes", func(t *testing.T) {
+		userCtx := &UserContext{UserID: 1, Username: "admin", Roles: []string{"admin", "user"}}
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req = req.WithContext(context.WithValue(req.Context(), userContextKey, userCtx))
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+	})
+}
+
 func TestGetUserFromContext(t *testing.T) {
 	tests := []struct {
 		name         string


### PR DESCRIPTION
## What

ADR-042 states PAT least-privilege scoping is enforced at *every* authorization path, but two paths resolve authz **without** funnelling through `core.Authorize` (where the restriction is read), so a PAT restriction would not reach them:

- `core.IsGlobalAdmin` — short-circuits scope-filtered listing to return everything
- `middleware.RequireRole` — role-based gate

Neither is wired to a live route today (**zero non-test callers**), so there is no live bypass — this is the defense-in-depth follow-up flagged in the #129 pre-merge security review. Both now **fail closed** for a PAT-restricted request:

- `IsGlobalAdmin` returns `false` when a restriction is on the context — a scoped token is never treated as an unrestricted global admin, so callers fall back to the scope-filtered path (which can only return a subset).
- `RequireRole` denies outright — a deliberately-scoped token must not satisfy a role gate's full breadth.

If either is ever wired to a route, PAT scoping holds rather than being silently ignored.

## Tests

- `IsGlobalAdmin`: denies a scoped token without touching storage; resolves admin normally when no restriction is present.
- `RequireRole`: forbids a scoped PAT on an admin owner; a full session for the same owner still passes.

ADR-042 updated to document both guards. gofmt clean, golangci-lint 0 issues, `go build ./...` + core/middleware suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)