### PR TITLE
feat(audit): on-demand checkpoint write — keyorix audit checkpoint (ADR-029)

### DIFF
--- a/docs/REMOTE_CLI_SETUP.md
+++ b/docs/REMOTE_CLI_SETUP.md
@@ -117,8 +117,9 @@ storage:
 
 ### Audit Commands
 
-The audit trail is hash-chained and tamper-evident (ADR-029). These read-only
-commands require the `audit.read` permission.
+The audit trail is hash-chained and tamper-evident (ADR-029). `verify` and
+`export` are read-only and require `audit.read`; `checkpoint` writes and requires
+`system.write` (admin-level).
 
 - `keyorix audit verify` - Re-walk the hash chain and report integrity. **Exits
   non-zero if the chain does not verify**, so it can run unattended (cron/CI) to
@@ -134,6 +135,13 @@ commands require the `audit.read` permission.
   go to stderr. Pull incrementally with `--after-id <cursor>`, or grab everything
   since a point in time with `--since <RFC3339> --all`. `--limit` sets page size
   (1–1000).
+- `keyorix audit checkpoint` - Write a signed checkpoint of the current verified
+  chain head on demand (ADR-029) so truncation is detectable **on-box**. Normally
+  the server's `audit_checkpoints` scheduler writes these; run this to re-baseline
+  immediately — most often right after a **DEK rotation**, when `verify` fails
+  closed until a fresh checkpoint is written under the new key. Requires server
+  encryption (the signing key is DEK-derived); the server refuses if the chain
+  does not verify.
 
 ```bash
 # Nightly tamper check (exit 1 → alert), capturing the anchor:
@@ -141,6 +149,9 @@ keyorix audit verify --json >> audit-anchors.ndjson || notify "audit chain broke
 
 # Incremental SIEM pull from the last cursor:
 keyorix audit export --after-id "$LAST_ID" --all > batch.ndjson
+
+# Re-baseline on-box detection right after a DEK rotation:
+keyorix audit checkpoint
 ```
 
 ## Deployment Scenarios

--- a/docs/adr-029-audit-log-tamper-evidence.md
+++ b/docs/adr-029-audit-log-tamper-evidence.md
@@ -125,11 +125,12 @@ double-migration hazard).
   - **DEK rotation:** a checkpoint signed under a superseded DEK cannot be
     re-verified on-box, so after a rotation `verify` fails closed (reports invalid)
     until the next checkpoint write re-baselines under the new key — the scheduler
-    does this on its next tick / at startup (`WriteAuditCheckpoint` re-baselines
-    over an *unverifiable* prior checkpoint but still refuses over an *authenticated*
-    truncation). Trusting the unauthenticated `key_version` to suppress that alarm
-    was rejected — it would let an attacker forge the rotation case to mask a
-    truncation.
+    does this on its next tick / at startup, and an operator can force it
+    immediately with `keyorix audit checkpoint` (`POST /api/v1/audit/checkpoint`,
+    system.write). `WriteAuditCheckpoint` re-baselines over an *unverifiable* prior
+    checkpoint but still refuses over an *authenticated* truncation. Trusting the
+    unauthenticated `key_version` to suppress that alarm was rejected — it would let
+    an attacker forge the rotation case to mask a truncation.
   - **Residual (honest scope):** enforcement consults the latest checkpoint row.
     A DB-level actor who can write `audit_checkpoints` can therefore *neutralise*
     on-box enforcement — delete every row, or overwrite the latest slot with an

--- a/internal/cli/audit/audit.go
+++ b/internal/cli/audit/audit.go
@@ -44,7 +44,7 @@ func init() {
 	exportCmd.Flags().IntVar(&flagLimit, "limit", 100, "Events per page (1–1000)")
 	exportCmd.Flags().BoolVar(&flagAll, "all", false, "Follow the cursor to the end, emitting every event")
 
-	AuditCmd.AddCommand(verifyCmd, exportCmd)
+	AuditCmd.AddCommand(verifyCmd, exportCmd, checkpointCmd)
 }
 
 func client() (*common.RemoteClient, error) {
@@ -187,6 +187,46 @@ since a point in time with --since --all.`,
 		} else {
 			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "exported %d event(s); caught up\n", total)
 		}
+		return nil
+	},
+}
+
+// checkpointResult mirrors the /audit/checkpoint payload (ADR-029).
+type checkpointResult struct {
+	ID            uint   `json:"id"`
+	ChainedEvents int64  `json:"chained_events"`
+	HeadID        uint   `json:"head_id"`
+	HeadHash      string `json:"head_hash"`
+	KeyVersion    string `json:"key_version"`
+}
+
+var checkpointCmd = &cobra.Command{
+	Use:   "checkpoint",
+	Short: "Write a signed checkpoint of the current audit-chain head (ADR-029)",
+	Long: `Sign a checkpoint of the current verified audit-chain head on demand, so
+tail-truncation / genesis re-seed is detectable on-box. Checkpoints are normally
+written by the server's background scheduler; run this to re-baseline immediately
+— most often right after a DEK rotation, when 'audit verify' fails closed until a
+fresh checkpoint is written under the new key.
+
+Requires the server to have encryption enabled (the signing key is DEK-derived)
+and the caller to hold system.write. The server refuses if the chain does not
+verify (broken, or a prior signed checkpoint proves a truncation).`,
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		c, err := client()
+		if err != nil {
+			return err
+		}
+		var out checkpointResult
+		if err := c.Post(context.Background(), "/api/v1/audit/checkpoint", nil, &out); err != nil {
+			return err
+		}
+		fmt.Println("Audit checkpoint written:")
+		fmt.Printf("  id:             %d\n", out.ID)
+		fmt.Printf("  chained events: %d\n", out.ChainedEvents)
+		fmt.Printf("  head id:        %d\n", out.HeadID)
+		fmt.Printf("  head hash:      %s\n", out.HeadHash)
 		return nil
 	},
 }

--- a/internal/cli/audit/audit_test.go
+++ b/internal/cli/audit/audit_test.go
@@ -16,7 +16,7 @@ func TestCommandWiring(t *testing.T) {
 	for _, sub := range AuditCmd.Commands() {
 		names[sub.Name()] = true
 	}
-	for _, want := range []string{"verify", "export"} {
+	for _, want := range []string{"verify", "export", "checkpoint"} {
 		assert.True(t, names[want], "missing subcommand %q", want)
 	}
 	assert.NotNil(t, verifyCmd.Flags().Lookup("json"), "verify missing --json")
@@ -90,6 +90,34 @@ func TestVerify_JSON(t *testing.T) {
 	flagJSON = true
 	defer func() { flagJSON = false }()
 	require.NoError(t, verifyCmd.RunE(verifyCmd, nil))
+}
+
+func TestCheckpoint_PostsAndReportsError(t *testing.T) {
+	t.Run("success posts to the checkpoint endpoint", func(t *testing.T) {
+		var gotMethod, gotPath string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotMethod, gotPath = r.Method, r.URL.Path
+			_, _ = w.Write([]byte(`{"data":{"id":7,"chained_events":42,"head_id":42,"head_hash":"abc","key_version":"v1"}}`))
+		}))
+		defer srv.Close()
+		setRemote(t, srv.URL)
+
+		require.NoError(t, checkpointCmd.RunE(checkpointCmd, nil))
+		assert.Equal(t, http.MethodPost, gotMethod)
+		assert.Equal(t, "/api/v1/audit/checkpoint", gotPath)
+	})
+
+	t.Run("server refusal surfaces as an error", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusConflict)
+			_, _ = w.Write([]byte(`{"error":"refusing to checkpoint"}`))
+		}))
+		defer srv.Close()
+		setRemote(t, srv.URL)
+
+		err := checkpointCmd.RunE(checkpointCmd, nil)
+		require.Error(t, err)
+	})
 }
 
 func TestExport_NDJSONAndCursorFollow(t *testing.T) {

--- a/server/http/handlers/audit.go
+++ b/server/http/handlers/audit.go
@@ -378,3 +378,39 @@ func (h *AuditHandler) VerifyAuditChain(w http.ResponseWriter, r *http.Request) 
 	}
 	sendSuccess(w, resp, "")
 }
+
+// WriteAuditCheckpoint handles POST /api/v1/audit/checkpoint — signs a checkpoint
+// of the current verified audit-chain head (ADR-029) on demand. The usual source
+// of checkpoints is the background scheduler; this lets an operator re-baseline
+// immediately — e.g. right after a DEK rotation, when verify fails closed until a
+// fresh checkpoint is written under the new key. Privileged (system.write, on top
+// of the audit group's audit.read).
+func (h *AuditHandler) WriteAuditCheckpoint(w http.ResponseWriter, r *http.Request) {
+	if middleware.GetUserFromContext(r.Context()) == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+
+	cp, written, err := h.coreService.WriteAuditCheckpoint(r.Context())
+	if err != nil {
+		// The chain did not verify (broken, or a prior signed checkpoint proves a
+		// truncation) — the server refuses to notarise it. Surface the reason so the
+		// operator can investigate; it is a precondition failure, not a server error.
+		sendError(w, "Conflict", err.Error(), http.StatusConflict, nil)
+		return
+	}
+	if !written {
+		sendError(w, "PreconditionFailed",
+			"signed audit checkpoints require encryption to be enabled (the signing key is derived from the DEK)",
+			http.StatusPreconditionFailed, nil)
+		return
+	}
+
+	sendSuccess(w, map[string]interface{}{
+		"id":             cp.ID,
+		"chained_events": cp.ChainedEvents,
+		"head_id":        cp.HeadID,
+		"head_hash":      cp.HeadHash,
+		"key_version":    cp.KeyVersion,
+	}, "audit checkpoint written")
+}

--- a/server/http/handlers/audit_checkpoint_handler_test.go
+++ b/server/http/handlers/audit_checkpoint_handler_test.go
@@ -1,0 +1,35 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+)
+
+// With encryption disabled the core holds no DEK-derived signing key, so an
+// on-demand checkpoint write is a precondition failure (412), not a 500.
+func TestAuditHandler_WriteCheckpoint_RequiresEncryption(t *testing.T) {
+	db := openTestDB(t)
+	h := NewAuditHandler(core.NewKeyorixCore(store.NewLocalStorage(db)))
+
+	req := withUserCtx(httptest.NewRequest(http.MethodPost, "/api/v1/audit/checkpoint", nil))
+	w := httptest.NewRecorder()
+	h.WriteAuditCheckpoint(w, req)
+
+	assert.Equal(t, http.StatusPreconditionFailed, w.Code)
+}
+
+func TestAuditHandler_WriteCheckpoint_RequiresUserContext(t *testing.T) {
+	db := openTestDB(t)
+	h := NewAuditHandler(core.NewKeyorixCore(store.NewLocalStorage(db)))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/audit/checkpoint", nil)
+	w := httptest.NewRecorder()
+	h.WriteAuditCheckpoint(w, req)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}

--- a/server/http/handlers/openapi.yaml
+++ b/server/http/handlers/openapi.yaml
@@ -2411,6 +2411,28 @@ paths:
             divergent event.
         '401': {$ref: '#/components/responses/Error'}
         '403': {$ref: '#/components/responses/Error'}
+  /api/v1/audit/checkpoint:
+    post:
+      tags: [Audit]
+      summary: Write a signed audit-chain checkpoint on demand (ADR-029)
+      description: >-
+        Signs a checkpoint of the current verified chain head for on-box truncation
+        detection. Requires system.write (above the audit group's audit.read) and
+        server-side encryption (the signing key is DEK-derived). Use to re-baseline
+        immediately after a DEK rotation.
+      operationId: writeAuditCheckpoint
+      security: [{bearerAuth: []}]
+      responses:
+        '200':
+          description: >-
+            Envelope {data, message}. data: {id, chained_events, head_id, head_hash,
+            key_version} of the new checkpoint.
+        '401': {$ref: '#/components/responses/Error'}
+        '403': {$ref: '#/components/responses/Error'}
+        '409':
+          description: The chain does not verify (broken, or a signed checkpoint proves a truncation); refused.
+        '412':
+          description: Signed checkpoints require encryption to be enabled.
   /api/v1/audit/anomalies:
     get:
       tags: [Audit]

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -422,6 +422,9 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.Get("/rbac-logs", auditHandler.GetRBACAuditLogs)
 			r.Get("/retention", auditHandler.GetAuditRetention)
 			r.Get("/verify", auditHandler.VerifyAuditChain)
+			// Writing a checkpoint is a privileged integrity-control action — gate it
+			// above the group's audit.read with system.write (admin-level).
+			r.With(customMiddleware.RequirePermission("system.write")).Post("/checkpoint", auditHandler.WriteAuditCheckpoint)
 			r.Get("/anomalies", handlers.ListAnomalyAlerts)
 			r.Post("/anomalies/{id}/acknowledge", handlers.AcknowledgeAnomalyAlert)
 		})


### PR DESCRIPTION
## What

Closes an operational gap from #153: the signed-checkpoint scheduler re-baselines on its own cadence, but after a **DEK rotation** `verify` fails closed until the next scheduled write — with no way to re-baseline *immediately*. This adds the operator action.

- **`POST /api/v1/audit/checkpoint`** → `core.WriteAuditCheckpoint`. Gated by `system.write` on top of the audit group's `audit.read` (a privileged integrity-control action). Outcome mapping: **200** with the new checkpoint; **409** when the chain does not verify (broken, or a signed checkpoint proves a truncation) and the server refuses; **412** when encryption is disabled (no DEK-derived signing key).
- **`keyorix audit checkpoint`** CLI — POSTs and prints the new checkpoint; intended for immediate re-baseline right after a DEK rotation.

## Security

The new route is privileged (`system.write`) and is correctly **denied to a read-only persona** — the #140 router-wide mutating-route guard test still passes over it. Writing a checkpoint can't corrupt anything: the server signs only a head it has re-verified, and refuses over a broken/truncated chain.

## Tests

handler requires-encryption (412) and requires-user-context (401); CLI posts to the endpoint and surfaces a server refusal as an error; command-wiring guard. Docs: REMOTE_CLI_SETUP (`audit checkpoint` + rotation-recovery example), ADR-029 (rotation recovery now operator-actionable), openapi.

gofmt clean, golangci-lint 0 issues, `go build ./...` + cli/audit + server/http suites green; openapi YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)