### PR TITLE
feat(cli): keyorix rotation — manage rotation policies + posture from the CLI

### DIFF
--- a/docs/REMOTE_CLI_SETUP.md
+++ b/docs/REMOTE_CLI_SETUP.md
@@ -154,6 +154,31 @@ keyorix audit export --after-id "$LAST_ID" --all > batch.ndjson
 keyorix audit checkpoint
 ```
 
+### Rotation Commands
+
+Manage secret-rotation policies (credential-rotation hygiene — a NIS2 / ISO
+A.5.15 control) from the terminal. Reads need `secrets.read`, writes `secrets.write`,
+at the policy's project/environment scope.
+
+- `keyorix rotation list [--project-id N] [--environment-id N]` - List policies.
+- `keyorix rotation create --name <n> --scope project|environment --interval-days <d>
+  [--project-id N | --environment-id N] [--alert-days-before N] [--description …]` -
+  Create a policy. A `project`-scoped policy needs `--project-id`; an
+  `environment`-scoped one needs `--environment-id`.
+- `keyorix rotation show <id>` / `keyorix rotation delete <id>` - Inspect / remove.
+- `keyorix rotation status [--project-id N]` - List policy-covered secrets that are
+  **overdue or approaching** their rotation deadline (the actionable posture view);
+  prints a clean "all within window" when nothing is due.
+
+```bash
+# A 30-day rotation policy for project 5, warning 7 days out:
+keyorix rotation create --name db-creds-30d --scope project --project-id 5 \
+  --interval-days 30 --alert-days-before 7
+
+# What needs rotating now?
+keyorix rotation status
+```
+
 ## Deployment Scenarios
 
 ### Development Environment

--- a/internal/cli/main.go
+++ b/internal/cli/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/keyorixhq/keyorix/internal/cli/project"
 	"github.com/keyorixhq/keyorix/internal/cli/rbac"
 	"github.com/keyorixhq/keyorix/internal/cli/request"
+	"github.com/keyorixhq/keyorix/internal/cli/rotation"
 	"github.com/keyorixhq/keyorix/internal/cli/run"
 	"github.com/keyorixhq/keyorix/internal/cli/secret"
 	"github.com/keyorixhq/keyorix/internal/cli/share"
@@ -61,6 +62,7 @@ func init() {
 	rootCmd.AddCommand(dynamic.DynamicSecretCmd)
 	rootCmd.AddCommand(pat.PATCmd)
 	rootCmd.AddCommand(audit.AuditCmd)
+	rootCmd.AddCommand(rotation.RotationCmd)
 }
 
 // Execute runs the root command

--- a/internal/cli/rotation/rotation.go
+++ b/internal/cli/rotation/rotation.go
@@ -1,0 +1,291 @@
+// Package rotation provides the `keyorix rotation` CLI — manage secret-rotation
+// policies (credential-rotation hygiene, a NIS2 / ISO A.5.15 control) from the
+// terminal: list, create, inspect and delete policies, and see which policy-
+// covered secrets are overdue or approaching their rotation deadline. All commands
+// talk to the server's REST API under /api/v1/rotation-policies (scoped by the
+// caller's secrets.read / secrets.write permission, server-side).
+package rotation
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/spf13/cobra"
+)
+
+// RotationCmd is the root `keyorix rotation` command.
+var RotationCmd = &cobra.Command{
+	Use:     "rotation",
+	Aliases: []string{"rotation-policy", "rotate"},
+	Short:   "Manage secret-rotation policies and see rotation posture",
+}
+
+var (
+	cName     string
+	cDesc     string
+	cScope    string
+	cProject  int
+	cEnv      int
+	cInterval int
+	cAlert    int
+	cNotify   bool
+
+	lProject int
+	lEnv     int
+
+	sProject int
+)
+
+func init() {
+	createCmd.Flags().StringVar(&cName, "name", "", "Policy name (required)")
+	createCmd.Flags().StringVar(&cDesc, "description", "", "Policy description")
+	createCmd.Flags().StringVar(&cScope, "scope", "", "Scope: project | environment (required)")
+	createCmd.Flags().IntVar(&cProject, "project-id", 0, "Target project (required when --scope project)")
+	createCmd.Flags().IntVar(&cEnv, "environment-id", 0, "Target environment (required when --scope environment)")
+	createCmd.Flags().IntVar(&cInterval, "interval-days", 0, "Rotation interval in days, 1–365 (required)")
+	createCmd.Flags().IntVar(&cAlert, "alert-days-before", 7, "Warn this many days before the deadline (0–90)")
+	createCmd.Flags().BoolVar(&cNotify, "notify-on-breach", true, "Notify when a covered secret goes overdue")
+
+	listCmd.Flags().IntVar(&lProject, "project-id", 0, "Filter by project")
+	listCmd.Flags().IntVar(&lEnv, "environment-id", 0, "Filter by environment")
+
+	statusCmd.Flags().IntVar(&sProject, "project-id", 0, "Limit to a single project")
+
+	RotationCmd.AddCommand(listCmd, createCmd, showCmd, deleteCmd, statusCmd)
+}
+
+func client() (*common.RemoteClient, error) {
+	c, ok := common.NewRemoteClient()
+	if !ok {
+		return nil, fmt.Errorf("not connected to a server — run: keyorix connect <server>")
+	}
+	return c, nil
+}
+
+// policyView mirrors a RotationPolicy. The model has no JSON tags so the server
+// emits PascalCase keys; encoding/json decodes case-insensitively, so these tags
+// match.
+type policyView struct {
+	ID              uint   `json:"id"`
+	Name            string `json:"name"`
+	Description     string `json:"description"`
+	Scope           string `json:"scope"`
+	ProjectID       *uint  `json:"project_id"`
+	EnvironmentID   *uint  `json:"environment_id"`
+	IntervalDays    int    `json:"interval_days"`
+	AlertDaysBefore int    `json:"alert_days_before"`
+	NotifyOnBreach  bool   `json:"notify_on_breach"`
+	IsActive        bool   `json:"is_active"`
+	CreatedBy       string `json:"created_by"`
+}
+
+// evalView mirrors a RotationPolicyEvaluation (snake_case json tags on the server).
+type evalView struct {
+	PolicyName    string `json:"policy_name"`
+	SecretID      uint   `json:"secret_id"`
+	SecretName    string `json:"secret_name"`
+	ProjectID     uint   `json:"project_id"`
+	DaysOverdue   int    `json:"days_overdue"`
+	IsOverdue     bool   `json:"is_overdue"`
+	IsApproaching bool   `json:"is_approaching"`
+}
+
+func scopeTarget(p policyView) string {
+	if p.Scope == "project" && p.ProjectID != nil {
+		return fmt.Sprintf("project=%d", *p.ProjectID)
+	}
+	if p.Scope == "environment" && p.EnvironmentID != nil {
+		return fmt.Sprintf("env=%d", *p.EnvironmentID)
+	}
+	return p.Scope
+}
+
+var listCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List rotation policies",
+	RunE: func(_ *cobra.Command, _ []string) error {
+		c, err := client()
+		if err != nil {
+			return err
+		}
+		q := url.Values{}
+		if lProject > 0 {
+			q.Set("project_id", strconv.Itoa(lProject))
+		}
+		if lEnv > 0 {
+			q.Set("environment_id", strconv.Itoa(lEnv))
+		}
+		path := "/api/v1/rotation-policies"
+		if len(q) > 0 {
+			path += "?" + q.Encode()
+		}
+		var policies []policyView
+		if err := c.Get(context.Background(), path, &policies); err != nil {
+			return err
+		}
+		if len(policies) == 0 {
+			fmt.Println("No rotation policies.")
+			return nil
+		}
+		fmt.Printf("%-5s %-24s %-14s %-9s %-7s %s\n", "ID", "NAME", "TARGET", "INTERVAL", "ACTIVE", "ALERT")
+		for _, p := range policies {
+			fmt.Printf("%-5d %-24s %-14s %-9s %-7t %dd\n",
+				p.ID, p.Name, scopeTarget(p), fmt.Sprintf("%dd", p.IntervalDays), p.IsActive, p.AlertDaysBefore)
+		}
+		return nil
+	},
+}
+
+var createCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create a rotation policy",
+	RunE: func(_ *cobra.Command, _ []string) error {
+		if strings.TrimSpace(cName) == "" {
+			return fmt.Errorf("--name is required")
+		}
+		if cScope != "project" && cScope != "environment" {
+			return fmt.Errorf("--scope must be 'project' or 'environment'")
+		}
+		if cInterval < 1 || cInterval > 365 {
+			return fmt.Errorf("--interval-days must be between 1 and 365")
+		}
+		if cScope == "project" && cProject == 0 {
+			return fmt.Errorf("--project-id is required when --scope project")
+		}
+		if cScope == "environment" && cEnv == 0 {
+			return fmt.Errorf("--environment-id is required when --scope environment")
+		}
+
+		body := map[string]any{
+			"name":              cName,
+			"scope":             cScope,
+			"interval_days":     cInterval,
+			"alert_days_before": cAlert,
+			"notify_on_breach":  cNotify,
+		}
+		if cDesc != "" {
+			body["description"] = cDesc
+		}
+		if cProject > 0 {
+			body["project_id"] = cProject
+		}
+		if cEnv > 0 {
+			body["environment_id"] = cEnv
+		}
+
+		c, err := client()
+		if err != nil {
+			return err
+		}
+		var p policyView
+		if err := c.Post(context.Background(), "/api/v1/rotation-policies", body, &p); err != nil {
+			return err
+		}
+		fmt.Printf("Created rotation policy #%d %q (%s, every %dd, alert %dd before).\n",
+			p.ID, p.Name, scopeTarget(p), p.IntervalDays, p.AlertDaysBefore)
+		return nil
+	},
+}
+
+var showCmd = &cobra.Command{
+	Use:   "show <id>",
+	Short: "Show a rotation policy",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(_ *cobra.Command, args []string) error {
+		id, err := strconv.Atoi(args[0])
+		if err != nil {
+			return fmt.Errorf("invalid policy id: %s", args[0])
+		}
+		c, err := client()
+		if err != nil {
+			return err
+		}
+		var p policyView
+		if err := c.Get(context.Background(), fmt.Sprintf("/api/v1/rotation-policies/%d", id), &p); err != nil {
+			return err
+		}
+		fmt.Printf("id:               %d\n", p.ID)
+		fmt.Printf("name:             %s\n", p.Name)
+		if p.Description != "" {
+			fmt.Printf("description:      %s\n", p.Description)
+		}
+		fmt.Printf("target:           %s\n", scopeTarget(p))
+		fmt.Printf("interval:         %d days\n", p.IntervalDays)
+		fmt.Printf("alert before:     %d days\n", p.AlertDaysBefore)
+		fmt.Printf("notify on breach: %t\n", p.NotifyOnBreach)
+		fmt.Printf("active:           %t\n", p.IsActive)
+		fmt.Printf("created by:       %s\n", p.CreatedBy)
+		return nil
+	},
+}
+
+var deleteCmd = &cobra.Command{
+	Use:   "delete <id>",
+	Short: "Delete a rotation policy",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(_ *cobra.Command, args []string) error {
+		id, err := strconv.Atoi(args[0])
+		if err != nil {
+			return fmt.Errorf("invalid policy id: %s", args[0])
+		}
+		c, err := client()
+		if err != nil {
+			return err
+		}
+		if err := c.Delete(context.Background(), fmt.Sprintf("/api/v1/rotation-policies/%d", id)); err != nil {
+			return err
+		}
+		fmt.Printf("Rotation policy %d deleted.\n", id)
+		return nil
+	},
+}
+
+var statusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Show policy-covered secrets that are overdue or approaching rotation",
+	RunE: func(_ *cobra.Command, _ []string) error {
+		c, err := client()
+		if err != nil {
+			return err
+		}
+		path := "/api/v1/rotation-policies/evaluate"
+		if sProject > 0 {
+			path += "?project_id=" + strconv.Itoa(sProject)
+		}
+		var evals []evalView
+		if err := c.Get(context.Background(), path, &evals); err != nil {
+			return err
+		}
+		overdue, approaching := 0, 0
+		for _, e := range evals {
+			if e.IsOverdue {
+				overdue++
+			} else if e.IsApproaching {
+				approaching++
+			}
+		}
+		if overdue == 0 && approaching == 0 {
+			fmt.Println("All policy-covered secrets are within their rotation window.")
+			return nil
+		}
+		fmt.Printf("%-6s %-26s %-9s %-10s %s\n", "SECRET", "NAME", "PROJECT", "STATUS", "DAYS")
+		for _, e := range evals {
+			var status, days string
+			switch {
+			case e.IsOverdue:
+				status, days = "OVERDUE", fmt.Sprintf("%d over", e.DaysOverdue)
+			case e.IsApproaching:
+				status, days = "approaching", fmt.Sprintf("%d left", -e.DaysOverdue)
+			default:
+				continue
+			}
+			fmt.Printf("%-6d %-26s %-9d %-10s %s\n", e.SecretID, e.SecretName, e.ProjectID, status, days)
+		}
+		fmt.Printf("\n%d overdue, %d approaching.\n", overdue, approaching)
+		return nil
+	},
+}

--- a/internal/cli/rotation/rotation_test.go
+++ b/internal/cli/rotation/rotation_test.go
@@ -1,0 +1,114 @@
+package rotation
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCommandWiring(t *testing.T) {
+	names := map[string]bool{}
+	for _, sub := range RotationCmd.Commands() {
+		names[sub.Name()] = true
+	}
+	for _, want := range []string{"list", "create", "show", "delete", "status"} {
+		assert.True(t, names[want], "missing subcommand %q", want)
+	}
+	assert.Contains(t, RotationCmd.Aliases, "rotation-policy")
+	for _, f := range []string{"name", "scope", "interval-days", "project-id", "environment-id", "alert-days-before"} {
+		assert.NotNilf(t, createCmd.Flags().Lookup(f), "create missing --%s", f)
+	}
+}
+
+func setRemote(t *testing.T, url string) {
+	t.Helper()
+	t.Setenv("KEYORIX_SERVER", url)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+}
+
+func TestCreate_PostsBodyAndScope(t *testing.T) {
+	var gotMethod, gotPath string
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod, gotPath = r.Method, r.URL.Path
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		// Server emits PascalCase keys (model has no json tags); decode is case-insensitive.
+		_, _ = w.Write([]byte(`{"data":{"ID":3,"Name":"db-30d","Scope":"project","ProjectID":5,"IntervalDays":30,"AlertDaysBefore":7}}`))
+	}))
+	defer srv.Close()
+	setRemote(t, srv.URL)
+
+	cName, cScope, cProject, cEnv, cInterval, cAlert, cNotify, cDesc = "db-30d", "project", 5, 0, 30, 7, true, ""
+	require.NoError(t, createCmd.RunE(createCmd, nil))
+
+	assert.Equal(t, http.MethodPost, gotMethod)
+	assert.Equal(t, "/api/v1/rotation-policies", gotPath)
+	assert.Equal(t, "db-30d", gotBody["name"])
+	assert.Equal(t, "project", gotBody["scope"])
+	assert.Equal(t, float64(5), gotBody["project_id"])
+	assert.Equal(t, float64(30), gotBody["interval_days"])
+}
+
+func TestCreate_Validation(t *testing.T) {
+	t.Run("name required", func(t *testing.T) {
+		cName, cScope, cInterval = "", "project", 30
+		require.ErrorContains(t, createCmd.RunE(createCmd, nil), "--name is required")
+	})
+	t.Run("scope must be valid", func(t *testing.T) {
+		cName, cScope, cInterval = "x", "global", 30
+		require.ErrorContains(t, createCmd.RunE(createCmd, nil), "--scope must be")
+	})
+	t.Run("interval range", func(t *testing.T) {
+		cName, cScope, cInterval = "x", "project", 0
+		require.ErrorContains(t, createCmd.RunE(createCmd, nil), "--interval-days must be between")
+	})
+	t.Run("project scope needs project id", func(t *testing.T) {
+		cName, cScope, cInterval, cProject = "x", "project", 30, 0
+		require.ErrorContains(t, createCmd.RunE(createCmd, nil), "--project-id is required")
+	})
+	t.Run("environment scope needs environment id", func(t *testing.T) {
+		cName, cScope, cInterval, cEnv = "x", "environment", 30, 0
+		require.ErrorContains(t, createCmd.RunE(createCmd, nil), "--environment-id is required")
+	})
+}
+
+func TestList_FiltersAndDecodesPascalCase(t *testing.T) {
+	var gotQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		_, _ = w.Write([]byte(`{"data":[{"ID":1,"Name":"p","Scope":"environment","EnvironmentID":9,"IntervalDays":90,"IsActive":true,"AlertDaysBefore":7}]}`))
+	}))
+	defer srv.Close()
+	setRemote(t, srv.URL)
+
+	lProject, lEnv = 5, 0
+	require.NoError(t, listCmd.RunE(listCmd, nil))
+	assert.Contains(t, gotQuery, "project_id=5")
+}
+
+func TestStatus_UsesEvaluate(t *testing.T) {
+	var gotPath, gotQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath, gotQuery = r.URL.Path, r.URL.RawQuery
+		_, _ = w.Write([]byte(`{"data":[{"secret_id":10,"secret_name":"db","project_id":5,"days_overdue":3,"is_overdue":true}]}`))
+	}))
+	defer srv.Close()
+	setRemote(t, srv.URL)
+
+	sProject = 5
+	require.NoError(t, statusCmd.RunE(statusCmd, nil))
+	assert.Equal(t, "/api/v1/rotation-policies/evaluate", gotPath)
+	assert.Contains(t, gotQuery, "project_id=5")
+}
+
+func TestScopeTarget(t *testing.T) {
+	pid := uint(5)
+	eid := uint(9)
+	assert.Equal(t, "project=5", scopeTarget(policyView{Scope: "project", ProjectID: &pid}))
+	assert.Equal(t, "env=9", scopeTarget(policyView{Scope: "environment", EnvironmentID: &eid}))
+	assert.Equal(t, "project", scopeTarget(policyView{Scope: "project"}))
+}


### PR DESCRIPTION
## What

Rotation policies — credential-rotation hygiene, a NIS2 / ISO A.5.15 control — had a full **API + web UI but no CLI**. This adds the `keyorix rotation` command group so operators can manage them from the terminal (automation, IaC, CI) and see rotation posture at a glance:

- `keyorix rotation list [--project-id N] [--environment-id N]`
- `keyorix rotation create --name <n> --scope project|environment --interval-days <d> [--project-id N | --environment-id N] [--alert-days-before N] [--description …] [--notify-on-breach]`
- `keyorix rotation show <id>` / `keyorix rotation delete <id>`
- `keyorix rotation status [--project-id N]` — the actionable view: policy-covered secrets **overdue or approaching** their deadline (via `/rotation-policies/evaluate`); prints "all within window" when nothing is due.

Shared `RemoteClient`, all authorization server-side (scoped `secrets.read` / `secrets.write`). CLI-side validation mirrors the server (scope ∈ {project, environment}; interval 1–365; the matching `--project-id`/`--environment-id` required for the scope). Additive new package — no server change.

## Tests

httptest-backed: command wiring + aliases; create posts the correct body & scope; the five validation guards; list applies the project filter and decodes the model's PascalCase keys (case-insensitive); `status` hits `/evaluate` with the project filter; `scopeTarget` rendering.

gofmt clean, golangci-lint 0 issues, `go build ./...` + `./internal/cli/...` suites green. Docs: REMOTE_CLI_SETUP "Rotation Commands".

🤖 Generated with [Claude Code](https://claude.com/claude-code)