### PR TITLE
feat(cli): keyorix audit logs — query the audit trail with filters

### DIFF
--- a/docs/REMOTE_CLI_SETUP.md
+++ b/docs/REMOTE_CLI_SETUP.md
@@ -130,6 +130,11 @@ The audit trail is hash-chained and tamper-evident (ADR-029). `verify` and
   signed-checkpoint scheduler (`audit_checkpoints`, ADR-029), verify also enforces
   the chain against the latest in-DB checkpoint — detecting that truncation
   **on-box** — and reports `checkpointed`.
+- `keyorix audit logs` - Query the trail as a human-readable table for interactive
+  investigation / compliance spot-checks. Filters: `--event-type` (e.g.
+  `secret.deleted`), `--user-id`, `--project-id`, `--actor-type`
+  (user|machine_identity|system), `--since`/`--until` (RFC3339), `--limit` (1–100).
+  For bulk/machine consumption use `export` instead.
 - `keyorix audit export` - Stream the full-fidelity audit feed as NDJSON (one
   event per line) on stdout for SIEM pull; the per-run summary and resume cursor
   go to stderr. Pull incrementally with `--after-id <cursor>`, or grab everything
@@ -149,6 +154,9 @@ keyorix audit verify --json >> audit-anchors.ndjson || notify "audit chain broke
 
 # Incremental SIEM pull from the last cursor:
 keyorix audit export --after-id "$LAST_ID" --all > batch.ndjson
+
+# Who deleted secrets in project 5 since the start of the month?
+keyorix audit logs --event-type secret.deleted --project-id 5 --since 2026-06-01T00:00:00Z
 
 # Re-baseline on-box detection right after a DEK rotation:
 keyorix audit checkpoint

--- a/internal/cli/audit/audit.go
+++ b/internal/cli/audit/audit.go
@@ -34,6 +34,14 @@ var (
 	flagAfterID uint
 	flagLimit   int
 	flagAll     bool
+
+	// logs filters
+	logEventType string
+	logUserID    uint
+	logProjectID uint
+	logActorType string
+	logUntil     string
+	logLimit     int
 )
 
 func init() {
@@ -44,7 +52,15 @@ func init() {
 	exportCmd.Flags().IntVar(&flagLimit, "limit", 100, "Events per page (1–1000)")
 	exportCmd.Flags().BoolVar(&flagAll, "all", false, "Follow the cursor to the end, emitting every event")
 
-	AuditCmd.AddCommand(verifyCmd, exportCmd, checkpointCmd)
+	logsCmd.Flags().StringVar(&logEventType, "event-type", "", "Filter by event type (e.g. secret.read, secret.deleted)")
+	logsCmd.Flags().UintVar(&logUserID, "user-id", 0, "Filter by actor user id")
+	logsCmd.Flags().UintVar(&logProjectID, "project-id", 0, "Filter by project id")
+	logsCmd.Flags().StringVar(&logActorType, "actor-type", "", "Filter by actor kind: user | machine_identity | system")
+	logsCmd.Flags().StringVar(&flagSince, "since", "", "Only events at/after this time (RFC3339)")
+	logsCmd.Flags().StringVar(&logUntil, "until", "", "Only events at/before this time (RFC3339)")
+	logsCmd.Flags().IntVar(&logLimit, "limit", 50, "Max events to show (1–100)")
+
+	AuditCmd.AddCommand(verifyCmd, exportCmd, checkpointCmd, logsCmd)
 }
 
 func client() (*common.RemoteClient, error) {
@@ -229,4 +245,109 @@ verify (broken, or a prior signed checkpoint proves a truncation).`,
 		fmt.Printf("  head hash:      %s\n", out.HeadHash)
 		return nil
 	},
+}
+
+// logEntry mirrors one row of the /audit/logs payload.
+type logEntry struct {
+	ID             uint   `json:"id"`
+	EventType      string `json:"event_type"`
+	Actor          string `json:"actor"`
+	ActorType      string `json:"actor_type"`
+	Description    string `json:"description"`
+	Timestamp      string `json:"timestamp"`
+	Impersonation  bool   `json:"impersonation"`
+	ImpersonatedBy string `json:"impersonated_by"`
+}
+
+type logsPage struct {
+	Logs  []logEntry `json:"logs"`
+	Total int64      `json:"total"`
+}
+
+var logsCmd = &cobra.Command{
+	Use:   "logs",
+	Short: "Query the audit trail with filters (human-readable table)",
+	Long: `Show audit events as a filtered table — for interactive investigation and
+compliance spot-checks (e.g. who deleted secrets last week). For bulk/machine
+consumption use 'keyorix audit export' (NDJSON) instead. Requires audit.read.`,
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		if logLimit < 1 || logLimit > 100 {
+			return fmt.Errorf("--limit must be between 1 and 100")
+		}
+		for label, v := range map[string]string{"--since": flagSince, "--until": logUntil} {
+			if v != "" {
+				if _, err := time.Parse(time.RFC3339, v); err != nil {
+					return fmt.Errorf("invalid %s %q (want RFC3339, e.g. 2026-06-01T00:00:00Z): %w", label, v, err)
+				}
+			}
+		}
+		if logActorType != "" && logActorType != "user" && logActorType != "machine_identity" && logActorType != "system" {
+			return fmt.Errorf("--actor-type must be user, machine_identity, or system")
+		}
+
+		q := url.Values{}
+		q.Set("page_size", strconv.Itoa(logLimit))
+		if logEventType != "" {
+			q.Set("action", logEventType)
+		}
+		if logUserID > 0 {
+			q.Set("user_id", strconv.FormatUint(uint64(logUserID), 10))
+		}
+		if logProjectID > 0 {
+			q.Set("project_id", strconv.FormatUint(uint64(logProjectID), 10))
+		}
+		if logActorType != "" {
+			q.Set("actor_type", logActorType)
+		}
+		if flagSince != "" {
+			q.Set("start_time", flagSince)
+		}
+		if logUntil != "" {
+			q.Set("end_time", logUntil)
+		}
+
+		c, err := client()
+		if err != nil {
+			return err
+		}
+		var page logsPage
+		if err := c.Get(context.Background(), "/api/v1/audit/logs?"+q.Encode(), &page); err != nil {
+			return err
+		}
+		if len(page.Logs) == 0 {
+			fmt.Println("No audit events match.")
+			return nil
+		}
+		fmt.Printf("%-6s %-20s %-16s %-9s %-22s %s\n", "ID", "TIME", "ACTOR", "KIND", "EVENT", "DESCRIPTION")
+		for _, e := range page.Logs {
+			actor := e.Actor
+			if e.Impersonation && e.ImpersonatedBy != "" {
+				actor = e.ImpersonatedBy + "→" + e.Actor
+			}
+			fmt.Printf("%-6d %-20s %-16s %-9s %-22s %s\n",
+				e.ID, shortTime(e.Timestamp), truncate(actor, 16), e.ActorType, truncate(e.EventType, 22), e.Description)
+		}
+		fmt.Printf("\nShowing %d of %d total event(s).\n", len(page.Logs), page.Total)
+		return nil
+	},
+}
+
+// shortTime renders an RFC3339 timestamp as "2006-01-02 15:04:05" (UTC), or the
+// raw string if it does not parse.
+func shortTime(s string) string {
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return t.UTC().Format("2006-01-02 15:04:05")
+	}
+	return s
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	if n <= 1 {
+		return s[:n]
+	}
+	return s[:n-1] + "…"
 }

--- a/internal/cli/audit/audit_test.go
+++ b/internal/cli/audit/audit_test.go
@@ -16,13 +16,59 @@ func TestCommandWiring(t *testing.T) {
 	for _, sub := range AuditCmd.Commands() {
 		names[sub.Name()] = true
 	}
-	for _, want := range []string{"verify", "export", "checkpoint"} {
+	for _, want := range []string{"verify", "export", "checkpoint", "logs"} {
 		assert.True(t, names[want], "missing subcommand %q", want)
 	}
 	assert.NotNil(t, verifyCmd.Flags().Lookup("json"), "verify missing --json")
 	for _, f := range []string{"since", "after-id", "limit", "all"} {
 		assert.NotNilf(t, exportCmd.Flags().Lookup(f), "export missing --%s flag", f)
 	}
+	for _, f := range []string{"event-type", "user-id", "project-id", "actor-type", "since", "until", "limit"} {
+		assert.NotNilf(t, logsCmd.Flags().Lookup(f), "logs missing --%s flag", f)
+	}
+}
+
+func TestLogs_FiltersAndRenders(t *testing.T) {
+	var gotPath, gotQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath, gotQuery = r.URL.Path, r.URL.RawQuery
+		_, _ = w.Write([]byte(`{"data":{"logs":[{"id":12,"event_type":"secret.deleted","actor":"ada","actor_type":"user","description":"deleted db-pw","timestamp":"2026-06-13T10:00:00Z"}],"total":1}}`))
+	}))
+	defer srv.Close()
+	setRemote(t, srv.URL)
+
+	logEventType, logUserID, logProjectID, logActorType, flagSince, logUntil, logLimit =
+		"secret.deleted", 5, 0, "user", "", "", 50
+	require.NoError(t, logsCmd.RunE(logsCmd, nil))
+
+	assert.Equal(t, "/api/v1/audit/logs", gotPath)
+	assert.Contains(t, gotQuery, "action=secret.deleted")
+	assert.Contains(t, gotQuery, "user_id=5")
+	assert.Contains(t, gotQuery, "actor_type=user")
+	assert.Contains(t, gotQuery, "page_size=50")
+}
+
+func TestLogs_Validation(t *testing.T) {
+	logEventType, logUserID, logProjectID, logActorType, flagSince, logUntil = "", 0, 0, "", "", ""
+	t.Run("limit range", func(t *testing.T) {
+		logLimit = 500
+		require.ErrorContains(t, logsCmd.RunE(logsCmd, nil), "--limit must be between 1 and 100")
+	})
+	t.Run("bad since", func(t *testing.T) {
+		logLimit, flagSince = 50, "last week"
+		require.ErrorContains(t, logsCmd.RunE(logsCmd, nil), "invalid --since")
+	})
+	t.Run("bad actor-type", func(t *testing.T) {
+		logLimit, flagSince, logActorType = 50, "", "robot"
+		require.ErrorContains(t, logsCmd.RunE(logsCmd, nil), "--actor-type must be")
+	})
+}
+
+func TestTruncateAndShortTime(t *testing.T) {
+	assert.Equal(t, "short", truncate("short", 16))
+	assert.Equal(t, "abcd…", truncate("abcdefgh", 5))
+	assert.Equal(t, "2026-06-13 10:00:00", shortTime("2026-06-13T10:00:00Z"))
+	assert.Equal(t, "not-a-time", shortTime("not-a-time"))
 }
 
 // setRemote points the RemoteClient at a mock server.


### PR DESCRIPTION
## What

Completes the `keyorix audit` command group. It had `verify`/`export`/`checkpoint`, but **no interactive query**: `export` is bulk NDJSON for SIEM ingestion, and the rich filtered view ("who deleted secrets in project 5 last week?") was web-UI/API-only.

`keyorix audit logs` (GET `/audit/logs`, `audit.read`) renders a human-readable table for incident investigation and compliance spot-checks:

- Filters: `--event-type` (e.g. `secret.deleted`), `--user-id`, `--project-id`, `--actor-type` (user|machine_identity|system), `--since`/`--until` (RFC3339), `--limit` (1–100).
- Resolves actor usernames, marks impersonation (`admin→target`), prints a `showing N of M` footer.
- For bulk/machine consumption, `export` remains the right tool.

Additive — no server change (the endpoint already exists).

## Tests

httptest-backed: command wiring + flags; filter→query-param mapping (`action`/`user_id`/`actor_type`/`page_size`); validation (limit range, RFC3339 `--since`/`--until`, actor-type enum); `truncate`/`shortTime` rendering helpers.

gofmt clean, golangci-lint 0 issues, `go build ./...` + `./internal/cli/...` suites green. Docs: REMOTE_CLI_SETUP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)