### PR TITLE
feat(grpc): authenticate personal access tokens over gRPC (ADR-042)

### DIFF
--- a/docs/adr-042-pat-permission-scoping.md
+++ b/docs/adr-042-pat-permission-scoping.md
@@ -122,6 +122,19 @@ project. Additive `environment_scope` column (default 0 = any), enforced via the
 same ctx-carried filter at the `Authorize`/`AuthorizePrincipal` chokepoint;
 existing tokens are unaffected.
 
+## Addendum (2026-06-13): PAT authentication over gRPC
+
+PATs now authenticate over **gRPC**, not just HTTP. Previously the gRPC auth
+interceptor validated only session tokens, so a `kx_pat_` token was rejected
+outright (fail-closed, but an HTTP/gRPC parity gap — #136 had already made gRPC
+*authorization* identical to HTTP). The unary and stream interceptors now route
+the `kx_pat_` prefix to `ValidatePATToken` and, critically, carry the returned
+restriction onto the handler context via `core.WithPATRestriction` — so the
+least-privilege filter is enforced at the same `core.Authorize` chokepoint the
+gRPC RPCs already funnel through, exactly as over HTTP. (Machine-identity tokens
+over gRPC remain a separate item — they authenticate as a machine principal and
+use `AuthorizePrincipal`/actor-type plumbing the gRPC layer does not yet carry.)
+
 ## Deferred
 
 - **Frontend env dropdown** — the My Account scope picker (keyorix-web) offers the

--- a/server/grpc/interceptors/auth.go
+++ b/server/grpc/interceptors/auth.go
@@ -5,11 +5,16 @@ import (
 	"strings"
 
 	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 )
+
+// patTokenPrefix marks a personal access token (ADR-027/042); anything else is
+// treated as a session token. Matches the HTTP middleware's routing.
+const patTokenPrefix = "kx_pat_"
 
 // UserContext represents the authenticated user context for gRPC
 type UserContext struct {
@@ -37,13 +42,18 @@ func AuthInterceptor(coreService *core.KeyorixCore) grpc.UnaryServerInterceptor 
 		}
 
 		// Extract and validate token
-		userCtx, err := authenticateRequest(ctx, coreService)
+		userCtx, restriction, err := authenticateRequest(ctx, coreService)
 		if err != nil {
 			return nil, err
 		}
 
 		// Add user context to request context
 		newCtx := context.WithValue(ctx, userContextKey, userCtx)
+		// Carry a PAT's least-privilege restriction (ADR-042) so core.Authorize
+		// enforces it on every authorization check this RPC makes.
+		if restriction != nil {
+			newCtx = core.WithPATRestriction(newCtx, restriction)
+		}
 		return handler(newCtx, req)
 	}
 }
@@ -58,15 +68,19 @@ func StreamAuthInterceptor(coreService *core.KeyorixCore) grpc.StreamServerInter
 		}
 
 		// Extract and validate token
-		userCtx, err := authenticateRequest(stream.Context(), coreService)
+		userCtx, restriction, err := authenticateRequest(stream.Context(), coreService)
 		if err != nil {
 			return err
 		}
 
-		// Create a new stream with user context
+		// Create a new stream with user context (+ PAT restriction when present).
+		streamCtx := context.WithValue(stream.Context(), userContextKey, userCtx)
+		if restriction != nil {
+			streamCtx = core.WithPATRestriction(streamCtx, restriction)
+		}
 		wrappedStream := &wrappedServerStream{
 			ServerStream: stream,
-			ctx:          context.WithValue(stream.Context(), userContextKey, userCtx),
+			ctx:          streamCtx,
 		}
 
 		return handler(srv, wrappedStream)
@@ -83,47 +97,60 @@ func (w *wrappedServerStream) Context() context.Context {
 	return w.ctx
 }
 
-// authenticateRequest extracts the bearer session token from the request
-// metadata and validates it against the core service — the same session-token
-// path the HTTP API uses. On success it returns the authenticated user's
-// context (id, identity, roles, permissions) for downstream authorization.
-func authenticateRequest(ctx context.Context, coreService *core.KeyorixCore) (*UserContext, error) {
+// authenticateRequest extracts the bearer token from the request metadata and
+// validates it against the core service — the same paths the HTTP API uses. A
+// kx_pat_ token authenticates as its owning user via ValidatePATToken and may
+// carry a least-privilege restriction (ADR-042); anything else is a session
+// token. On success it returns the authenticated user's context (id, identity,
+// roles, permissions) and the PAT restriction (nil for sessions) for downstream
+// authorization.
+func authenticateRequest(ctx context.Context, coreService *core.KeyorixCore) (*UserContext, *core.PATRestriction, error) {
 	if coreService == nil {
 		// Fail closed: a server wired without a core service must not authenticate.
-		return nil, status.Errorf(codes.Internal, "authentication unavailable")
+		return nil, nil, status.Errorf(codes.Internal, "authentication unavailable")
 	}
 
 	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
-		return nil, status.Errorf(codes.Unauthenticated, "Missing metadata")
+		return nil, nil, status.Errorf(codes.Unauthenticated, "Missing metadata")
 	}
 
 	// Extract authorization header
 	authHeaders := md.Get("authorization")
 	if len(authHeaders) == 0 {
-		return nil, status.Errorf(codes.Unauthenticated, "Missing authorization header")
+		return nil, nil, status.Errorf(codes.Unauthenticated, "Missing authorization header")
 	}
 
 	authHeader := authHeaders[0]
 	if !strings.HasPrefix(authHeader, "Bearer ") {
-		return nil, status.Errorf(codes.Unauthenticated, "Invalid authorization header format")
+		return nil, nil, status.Errorf(codes.Unauthenticated, "Invalid authorization header format")
 	}
 
 	token := strings.TrimPrefix(authHeader, "Bearer ")
 	if token == "" {
-		return nil, status.Errorf(codes.Unauthenticated, "Missing token")
+		return nil, nil, status.Errorf(codes.Unauthenticated, "Missing token")
 	}
 
-	// Validate the session token (existence + expiry) and resolve the user.
-	user, _, err := coreService.ValidateSessionToken(ctx, token)
+	// Validate the token (existence + expiry/revocation) and resolve the user. A
+	// PAT resolves to its owner plus an optional restriction; both fail closed.
+	var (
+		user        *models.User
+		restriction *core.PATRestriction
+		err         error
+	)
+	if strings.HasPrefix(token, patTokenPrefix) {
+		user, _, restriction, err = coreService.ValidatePATToken(ctx, token)
+	} else {
+		user, _, err = coreService.ValidateSessionToken(ctx, token)
+	}
 	if err != nil {
-		return nil, status.Errorf(codes.Unauthenticated, "Invalid or expired token")
+		return nil, nil, status.Errorf(codes.Unauthenticated, "Invalid or expired token")
 	}
 
 	// Resolve roles + permissions for downstream per-method authorization.
 	identity, err := coreService.GetUserIdentity(ctx, user.ID)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to resolve user identity")
+		return nil, nil, status.Errorf(codes.Internal, "failed to resolve user identity")
 	}
 
 	return &UserContext{
@@ -132,7 +159,7 @@ func authenticateRequest(ctx context.Context, coreService *core.KeyorixCore) (*U
 		Email:       user.Email,
 		Roles:       identity.Roles,
 		Permissions: identity.Permissions,
-	}, nil
+	}, restriction, nil
 }
 
 // isPublicMethod checks if a gRPC method is public (doesn't require authentication)

--- a/server/grpc/interceptors/auth_test.go
+++ b/server/grpc/interceptors/auth_test.go
@@ -2,9 +2,11 @@ package interceptors
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/keyorixhq/keyorix/internal/testhelper"
 	"github.com/stretchr/testify/assert"
@@ -143,4 +145,59 @@ func TestAuthInterceptor_PublicMethodBypassesAuth(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "ok", resp)
 	assert.Nil(t, GetUserFromGRPCContext(captured), "public method must not set a user context")
+}
+
+// A personal access token authenticates over gRPC (previously rejected outright)
+// AND its ADR-042 least-privilege restriction rides the handler context, so
+// core.Authorize enforces scoping over gRPC exactly as it does over HTTP.
+func TestAuthInterceptor_PATAuthenticatesAndEnforcesScope(t *testing.T) {
+	h := setupAuthHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(&models.PersonalAccessToken{}))
+
+	h.CreateTestUser(t, "grpc-ci", 9100)
+	proj2 := uint(2)
+	h.AssignUserRole(t, 9100, 3, &proj2) // editor (secrets.read + secrets.write) in project 2
+
+	// A token confined to secrets.read in project 2 only.
+	res, err := h.CoreService.CreateOwnPAT(context.Background(), 9100, "ci", nil, []string{"secrets.read"}, 2, 0)
+	require.NoError(t, err)
+	require.True(t, strings.HasPrefix(res.PlainToken, "kx_pat_"))
+
+	var captured context.Context
+	interceptor := AuthInterceptor(h.CoreService)
+	resp, err := interceptor(bearerCtx(res.PlainToken), nil,
+		&grpc.UnaryServerInfo{FullMethod: secretMethod}, okHandler(&captured))
+	require.NoError(t, err, "a kx_pat_ token must now authenticate over gRPC")
+	assert.Equal(t, "ok", resp)
+
+	user := GetUserFromGRPCContext(captured)
+	require.NotNil(t, user)
+	assert.Equal(t, uint(9100), user.UserID, "authenticated as the PAT's owner")
+
+	// Restriction is on the handler context → core.Authorize enforces it.
+	readP2, err := h.CoreService.Authorize(captured, 9100, "secrets.read", core.Scope{ProjectID: 2})
+	require.NoError(t, err)
+	assert.True(t, readP2, "in-scope read allowed (restriction permits + owner's role grants)")
+
+	writeP2, err := h.CoreService.Authorize(captured, 9100, "secrets.write", core.Scope{ProjectID: 2})
+	require.NoError(t, err)
+	assert.False(t, writeP2, "permission outside the token's allowlist is denied")
+
+	readP3, err := h.CoreService.Authorize(captured, 9100, "secrets.read", core.Scope{ProjectID: 3})
+	require.NoError(t, err)
+	assert.False(t, readP3, "scope outside the token's project is denied")
+}
+
+// An invalid PAT fails closed with Unauthenticated, same as a bad session token.
+func TestAuthInterceptor_InvalidPATRejected(t *testing.T) {
+	h := setupAuthHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(&models.PersonalAccessToken{}))
+
+	interceptor := AuthInterceptor(h.CoreService)
+	_, err := interceptor(bearerCtx("kx_pat_bogus"), nil,
+		&grpc.UnaryServerInfo{FullMethod: secretMethod}, okHandler(nil))
+	require.Error(t, err)
+	assert.Equal(t, codes.Unauthenticated, status.Code(err))
 }


### PR DESCRIPTION
## What

PATs worked over HTTP but the gRPC auth interceptor validated **only session tokens**, so a `kx_pat_` token was rejected outright — a fail-closed HTTP/gRPC parity gap. #136 had already made gRPC *authorization* identical to HTTP; this is the matching **authentication** piece (the #129 deferred follow-up).

The unary + stream interceptors now route the `kx_pat_` prefix to `ValidatePATToken` and **carry the returned ADR-042 restriction onto the handler context** via `core.WithPATRestriction` — so least-privilege scoping is enforced at the same `core.Authorize` chokepoint the gRPC RPCs already funnel through, exactly as over HTTP. Session tokens are unchanged (nil restriction).

Machine-identity tokens over gRPC remain a separate item — they authenticate as a machine principal and need the `AuthorizePrincipal`/actor-type plumbing the gRPC layer does not yet carry (noted in the ADR).

## Tests

Real core via `RBACTestHelper`: a `secrets.read` / project-2 PAT on an **editor** owner (who holds read+write in project 2):
- authenticates over gRPC (previously rejected),
- **allows** in-scope `secrets.read` @ project 2,
- **denies** `secrets.write` @ project 2 (outside the token's allowlist),
- **denies** `secrets.read` @ project 3 (outside the token's project)

— proving the restriction rides the gRPC context and narrows even a capable owner. Plus invalid-PAT → `Unauthenticated`.

gofmt clean, golangci-lint 0 issues, `go build ./...` + all `./server/grpc/...` suites green. ADR-042 addendum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)