### PR TITLE
feat(grpc): authenticate machine-identity tokens over gRPC (ADR-030)

### DIFF
--- a/docs/adr-042-pat-permission-scoping.md
+++ b/docs/adr-042-pat-permission-scoping.md
@@ -131,9 +131,15 @@ outright (fail-closed, but an HTTP/gRPC parity gap — #136 had already made gRP
 the `kx_pat_` prefix to `ValidatePATToken` and, critically, carry the returned
 restriction onto the handler context via `core.WithPATRestriction` — so the
 least-privilege filter is enforced at the same `core.Authorize` chokepoint the
-gRPC RPCs already funnel through, exactly as over HTTP. (Machine-identity tokens
-over gRPC remain a separate item — they authenticate as a machine principal and
-use `AuthorizePrincipal`/actor-type plumbing the gRPC layer does not yet carry.)
+gRPC RPCs already funnel through, exactly as over HTTP. **Machine-identity tokens
+over gRPC (ADR-030) shipped immediately after**: the interceptor routes the
+`kx_machine_` prefix to `ValidateMachineToken`, builds a machine principal
+(actor_type `machine_identity`, no owning user), and the gRPC service authz
+helpers now call `AuthorizePrincipal(actorKind, principalID, …)` instead of
+`Authorize(userID, …)` — identical to `Authorize` for users (so PAT and session
+paths are unchanged) but resolving machine roles with **no admin bypass** for
+machines. gRPC authentication now has full parity with HTTP: session, PAT, and
+machine.
 
 ## Deferred
 

--- a/server/grpc/interceptors/auth.go
+++ b/server/grpc/interceptors/auth.go
@@ -12,17 +12,44 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-// patTokenPrefix marks a personal access token (ADR-027/042); anything else is
-// treated as a session token. Matches the HTTP middleware's routing.
-const patTokenPrefix = "kx_pat_"
+// Token-kind prefixes — match the HTTP middleware's routing. kx_pat_ is a personal
+// access token (ADR-027/042); kx_machine_ a machine-identity token (ADR-030);
+// anything else is a session token.
+const (
+	patTokenPrefix     = "kx_pat_"
+	machineTokenPrefix = "kx_machine_"
+)
 
-// UserContext represents the authenticated user context for gRPC
+// UserContext represents the authenticated principal for gRPC — a human user, or
+// a machine identity (ADR-030) when MachineIdentityID is set and UserID is 0.
 type UserContext struct {
 	UserID      uint     `json:"user_id"`
 	Username    string   `json:"username"`
 	Email       string   `json:"email"`
 	Roles       []string `json:"roles"`
 	Permissions []string `json:"permissions"`
+	// ActorType is "machine_identity" for a machine principal, otherwise empty
+	// (treated as a user). MachineIdentityID is the machine's id for that case.
+	ActorType         string `json:"actor_type,omitempty"`
+	MachineIdentityID uint   `json:"machine_identity_id,omitempty"`
+}
+
+// ActorKind returns the principal's actor type ("user" or "machine_identity"),
+// defaulting to user for empty contexts.
+func (u *UserContext) ActorKind() string {
+	if u.ActorType == core.ActorTypeMachine {
+		return core.ActorTypeMachine
+	}
+	return core.ActorTypeUser
+}
+
+// PrincipalID returns the id to authorize against: the machine identity id for a
+// machine request, otherwise the user id.
+func (u *UserContext) PrincipalID() uint {
+	if u.ActorType == core.ActorTypeMachine {
+		return u.MachineIdentityID
+	}
+	return u.UserID
 }
 
 // contextKey is used for context keys to avoid collisions
@@ -129,6 +156,22 @@ func authenticateRequest(ctx context.Context, coreService *core.KeyorixCore) (*U
 	token := strings.TrimPrefix(authHeader, "Bearer ")
 	if token == "" {
 		return nil, nil, status.Errorf(codes.Unauthenticated, "Missing token")
+	}
+
+	// A machine-identity token (ADR-030) authenticates as a machine principal — no
+	// owning user, no admin bypass downstream (AuthorizePrincipal resolves machine
+	// roles). Routed by prefix, fails closed.
+	if strings.HasPrefix(token, machineTokenPrefix) {
+		machine, roles, err := coreService.ValidateMachineToken(ctx, token)
+		if err != nil {
+			return nil, nil, status.Errorf(codes.Unauthenticated, "Invalid or expired token")
+		}
+		return &UserContext{
+			Username:          machine.Name,
+			Roles:             roles,
+			ActorType:         core.ActorTypeMachine,
+			MachineIdentityID: machine.ID,
+		}, nil, nil
 	}
 
 	// Validate the token (existence + expiry/revocation) and resolve the user. A

--- a/server/grpc/interceptors/auth_test.go
+++ b/server/grpc/interceptors/auth_test.go
@@ -189,6 +189,51 @@ func TestAuthInterceptor_PATAuthenticatesAndEnforcesScope(t *testing.T) {
 	assert.False(t, readP3, "scope outside the token's project is denied")
 }
 
+// A machine-identity token (ADR-030) authenticates over gRPC (previously rejected)
+// as a machine principal, and authorization uses machine RBAC with NO admin bypass.
+func TestAuthInterceptor_MachineTokenAuthenticatesAndUsesMachineRBAC(t *testing.T) {
+	h := setupAuthHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(
+		&models.MachineIdentity{}, &models.MachineIdentityCredential{}, &models.MachineIdentityRole{}))
+
+	m, err := h.CoreService.CreateMachineIdentity(context.Background(), 2, "ci-bot", "service", "", 1)
+	require.NoError(t, err)
+	tok, err := h.CoreService.IssueMachineToken(context.Background(), 2, m.ID, "tok", nil, 1)
+	require.NoError(t, err)
+	require.True(t, strings.HasPrefix(tok.PlainToken, "kx_machine_"))
+	// Grant the machine viewer (secrets.read) in project 2 only.
+	require.NoError(t, h.CoreService.AssignMachineRole(context.Background(), m.ID, 4, core.Scope{ProjectID: 2}, 1))
+
+	var captured context.Context
+	interceptor := AuthInterceptor(h.CoreService)
+	_, err = interceptor(bearerCtx(tok.PlainToken), nil,
+		&grpc.UnaryServerInfo{FullMethod: secretMethod}, okHandler(&captured))
+	require.NoError(t, err, "a kx_machine_ token must authenticate over gRPC")
+
+	user := GetUserFromGRPCContext(captured)
+	require.NotNil(t, user)
+	assert.Equal(t, core.ActorTypeMachine, user.ActorType)
+	assert.Equal(t, m.ID, user.MachineIdentityID)
+	assert.Equal(t, uint(0), user.UserID, "a machine has no owning user")
+	assert.Equal(t, core.ActorTypeMachine, user.ActorKind())
+	assert.Equal(t, m.ID, user.PrincipalID())
+
+	// Machine RBAC via AuthorizePrincipal: granted read allowed, ungranted write
+	// denied — and no admin bypass (a machine is never a super-user).
+	readP2, err := h.CoreService.AuthorizePrincipal(captured, user.ActorKind(), user.PrincipalID(), "secrets.read", core.Scope{ProjectID: 2})
+	require.NoError(t, err)
+	assert.True(t, readP2, "granted machine role permits the scoped read")
+
+	writeP2, err := h.CoreService.AuthorizePrincipal(captured, user.ActorKind(), user.PrincipalID(), "secrets.write", core.Scope{ProjectID: 2})
+	require.NoError(t, err)
+	assert.False(t, writeP2, "machine holds only viewer — write denied, no admin bypass")
+
+	readP3, err := h.CoreService.AuthorizePrincipal(captured, user.ActorKind(), user.PrincipalID(), "secrets.read", core.Scope{ProjectID: 3})
+	require.NoError(t, err)
+	assert.False(t, readP3, "machine role is scoped to project 2 — denied in project 3")
+}
+
 // An invalid PAT fails closed with Unauthenticated, same as a bad session token.
 func TestAuthInterceptor_InvalidPATRejected(t *testing.T) {
 	h := setupAuthHelper(t)

--- a/server/grpc/services/audit_service.go
+++ b/server/grpc/services/audit_service.go
@@ -40,7 +40,7 @@ func (s *AuditGRPCService) GetAuditLogs(ctx context.Context, req *pb.GetAuditLog
 	if err != nil {
 		return nil, err
 	}
-	if err := authorizeGlobal(ctx, s.core, actor.UserID, "audit.read"); err != nil {
+	if err := authorizeGlobal(ctx, s.core, actor, "audit.read"); err != nil {
 		return nil, err
 	}
 	page, pageSize := normalizePage(req.GetPage(), req.GetPageSize())
@@ -81,7 +81,7 @@ func (s *AuditGRPCService) GetRBACAuditLogs(ctx context.Context, req *pb.GetRBAC
 	if err != nil {
 		return nil, err
 	}
-	if err := authorizeGlobal(ctx, s.core, actor.UserID, "audit.read"); err != nil {
+	if err := authorizeGlobal(ctx, s.core, actor, "audit.read"); err != nil {
 		return nil, err
 	}
 	page, pageSize := normalizePage(req.GetPage(), req.GetPageSize())
@@ -144,7 +144,7 @@ func (s *AuditGRPCService) StreamAuditLogs(req *pb.StreamAuditLogsRequest, strea
 	if actor == nil {
 		return status.Error(codes.Unauthenticated, "user not authenticated")
 	}
-	if err := authorizeGlobal(ctx, s.core, actor.UserID, "audit.read"); err != nil {
+	if err := authorizeGlobal(ctx, s.core, actor, "audit.read"); err != nil {
 		return err
 	}
 

--- a/server/grpc/services/conversions.go
+++ b/server/grpc/services/conversions.go
@@ -51,8 +51,12 @@ func hasPermission(permissions []string, required string) bool {
 // UserContext.Permissions is the FLAT union of the caller's grants across every
 // scope (the #53/#54/#88/#90 flat-vs-scoped bug class). Routing through
 // core.Authorize fixes that and future-proofs the PAT/machine paths.
-func authorizeScoped(ctx context.Context, cs *core.KeyorixCore, userID uint, perm string, scope core.Scope) error {
-	if allowed, err := cs.Authorize(ctx, userID, perm, scope); err != nil || !allowed {
+func authorizeScoped(ctx context.Context, cs *core.KeyorixCore, actor *interceptors.UserContext, perm string, scope core.Scope) error {
+	// AuthorizePrincipal is actor-aware: for a user it is identical to Authorize
+	// (PAT restriction + roles + admin bypass); for a machine identity it resolves
+	// machine roles with NO admin bypass. This is what makes machine tokens work
+	// over gRPC (ADR-030) with the same primitive HTTP uses.
+	if allowed, err := cs.AuthorizePrincipal(ctx, actor.ActorKind(), actor.PrincipalID(), perm, scope); err != nil || !allowed {
 		return status.Error(codes.PermissionDenied, "insufficient permissions")
 	}
 	return nil
@@ -61,8 +65,8 @@ func authorizeScoped(ctx context.Context, cs *core.KeyorixCore, userID uint, per
 // authorizeGlobal enforces perm at global scope (project 0) — for install-wide
 // operations (user/role/system/audit management) that HTTP gates with
 // RequirePermission. A grant held only at a project scope does NOT satisfy it.
-func authorizeGlobal(ctx context.Context, cs *core.KeyorixCore, userID uint, perm string) error {
-	return authorizeScoped(ctx, cs, userID, perm, core.Scope{})
+func authorizeGlobal(ctx context.Context, cs *core.KeyorixCore, actor *interceptors.UserContext, perm string) error {
+	return authorizeScoped(ctx, cs, actor, perm, core.Scope{})
 }
 
 // --- Pagination ---

--- a/server/grpc/services/role_service.go
+++ b/server/grpc/services/role_service.go
@@ -34,7 +34,7 @@ func (s *RoleGRPCService) CreateRole(ctx context.Context, req *pb.CreateRoleRequ
 	if err != nil {
 		return nil, err
 	}
-	if err := authorizeGlobal(ctx, s.core, actor.UserID, "roles.write"); err != nil {
+	if err := authorizeGlobal(ctx, s.core, actor, "roles.write"); err != nil {
 		return nil, err
 	}
 	if req.GetName() == "" || req.GetDescription() == "" || len(req.GetPermissions()) == 0 {
@@ -64,7 +64,7 @@ func (s *RoleGRPCService) GetRole(ctx context.Context, req *pb.GetRoleRequest) (
 	if err != nil {
 		return nil, err
 	}
-	if err := authorizeGlobal(ctx, s.core, actor.UserID, "roles.read"); err != nil {
+	if err := authorizeGlobal(ctx, s.core, actor, "roles.read"); err != nil {
 		return nil, err
 	}
 	return s.roleByID(ctx, uint(req.GetId()))
@@ -76,7 +76,7 @@ func (s *RoleGRPCService) UpdateRole(ctx context.Context, req *pb.UpdateRoleRequ
 	if err != nil {
 		return nil, err
 	}
-	if err := authorizeGlobal(ctx, s.core, actor.UserID, "roles.write"); err != nil {
+	if err := authorizeGlobal(ctx, s.core, actor, "roles.write"); err != nil {
 		return nil, err
 	}
 	if req.GetId() == 0 {
@@ -122,7 +122,7 @@ func (s *RoleGRPCService) DeleteRole(ctx context.Context, req *pb.DeleteRoleRequ
 	if err != nil {
 		return nil, err
 	}
-	if err := authorizeGlobal(ctx, s.core, actor.UserID, "roles.write"); err != nil {
+	if err := authorizeGlobal(ctx, s.core, actor, "roles.write"); err != nil {
 		return nil, err
 	}
 	if req.GetId() == 0 {
@@ -140,7 +140,7 @@ func (s *RoleGRPCService) ListRoles(ctx context.Context, req *pb.ListRolesReques
 	if err != nil {
 		return nil, err
 	}
-	if err := authorizeGlobal(ctx, s.core, actor.UserID, "roles.read"); err != nil {
+	if err := authorizeGlobal(ctx, s.core, actor, "roles.read"); err != nil {
 		return nil, err
 	}
 
@@ -185,7 +185,7 @@ func (s *RoleGRPCService) AssignRole(ctx context.Context, req *pb.AssignRoleRequ
 	// Authorize roles.assign AT THE TARGET scope, not the flat global union — else a
 	// project-A admin could grant roles into any project B (cross-project privesc).
 	scope := core.Scope{ProjectID: uint(req.GetProjectId()), EnvironmentID: uint(req.GetEnvironmentId())}
-	if err := authorizeScoped(ctx, s.core, actor.UserID, "roles.assign", scope); err != nil {
+	if err := authorizeScoped(ctx, s.core, actor, "roles.assign", scope); err != nil {
 		return nil, err
 	}
 	if err := s.core.AssignUserRole(ctx, actor.UserID, uint(req.GetUserId()), uint(req.GetRoleId()), scope); err != nil {
@@ -210,7 +210,7 @@ func (s *RoleGRPCService) RemoveRole(ctx context.Context, req *pb.RemoveRoleRequ
 	}
 	// Authorize roles.assign at the target scope (see AssignRole) — not the flat union.
 	scope := core.Scope{ProjectID: uint(req.GetProjectId()), EnvironmentID: uint(req.GetEnvironmentId())}
-	if err := authorizeScoped(ctx, s.core, actor.UserID, "roles.assign", scope); err != nil {
+	if err := authorizeScoped(ctx, s.core, actor, "roles.assign", scope); err != nil {
 		return nil, err
 	}
 	if err := s.core.RemoveUserRole(ctx, actor.UserID, uint(req.GetUserId()), uint(req.GetRoleId()), scope); err != nil {
@@ -225,7 +225,7 @@ func (s *RoleGRPCService) GetUserRoles(ctx context.Context, req *pb.GetUserRoles
 	if err != nil {
 		return nil, err
 	}
-	if err := authorizeGlobal(ctx, s.core, actor.UserID, "roles.read"); err != nil {
+	if err := authorizeGlobal(ctx, s.core, actor, "roles.read"); err != nil {
 		return nil, err
 	}
 	assignment, err := s.core.GetUserRoleAssignment(ctx, uint(req.GetUserId()))

--- a/server/grpc/services/secret_service.go
+++ b/server/grpc/services/secret_service.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/server/grpc/interceptors"
 	pb "github.com/keyorixhq/keyorix/server/proto/pb"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -42,7 +43,7 @@ func (s *SecretGRPCService) CreateSecret(ctx context.Context, req *pb.CreateSecr
 	// global permission set — a project-scoped writer must not create in another
 	// project. Mirrors the HTTP CreateSecret handler (scope from the body).
 	scope := core.Scope{ProjectID: uint(req.GetProjectId()), EnvironmentID: uint(req.GetEnvironmentId())}
-	if allowed, err := s.core.Authorize(ctx, user.UserID, "secrets.write", scope); err != nil || !allowed {
+	if allowed, err := s.core.AuthorizePrincipal(ctx, user.ActorKind(), user.PrincipalID(), "secrets.write", scope); err != nil || !allowed {
 		return nil, status.Error(codes.PermissionDenied, "insufficient permissions to create secrets in this project")
 	}
 
@@ -71,7 +72,7 @@ func (s *SecretGRPCService) GetSecret(ctx context.Context, req *pb.GetSecretRequ
 	if err != nil {
 		return nil, err
 	}
-	if err := authorizeSecretScoped(ctx, s.core, user.UserID, uint(req.GetId()), "secrets.read"); err != nil {
+	if err := authorizeSecretScoped(ctx, s.core, user, uint(req.GetId()), "secrets.read"); err != nil {
 		return nil, err
 	}
 	secret, err := s.core.GetSecretWithPermissionCheck(ctx, uint(req.GetId()), user.UserID)
@@ -89,7 +90,7 @@ func (s *SecretGRPCService) GetSecretValue(ctx context.Context, req *pb.GetSecre
 	if err != nil {
 		return nil, err
 	}
-	if err := authorizeSecretScoped(ctx, s.core, user.UserID, uint(req.GetId()), "secrets.read"); err != nil {
+	if err := authorizeSecretScoped(ctx, s.core, user, uint(req.GetId()), "secrets.read"); err != nil {
 		return nil, err
 	}
 	// Resolve the name first (metadata read, no read-count side effect).
@@ -117,7 +118,7 @@ func (s *SecretGRPCService) UpdateSecret(ctx context.Context, req *pb.UpdateSecr
 	if req.GetId() == 0 {
 		return nil, status.Error(codes.InvalidArgument, "id is required")
 	}
-	if err := authorizeSecretScoped(ctx, s.core, user.UserID, uint(req.GetId()), "secrets.write"); err != nil {
+	if err := authorizeSecretScoped(ctx, s.core, user, uint(req.GetId()), "secrets.write"); err != nil {
 		return nil, err
 	}
 
@@ -150,7 +151,7 @@ func (s *SecretGRPCService) DeleteSecret(ctx context.Context, req *pb.DeleteSecr
 	if req.GetId() == 0 {
 		return nil, status.Error(codes.InvalidArgument, "id is required")
 	}
-	if err := authorizeSecretScoped(ctx, s.core, user.UserID, uint(req.GetId()), "secrets.delete"); err != nil {
+	if err := authorizeSecretScoped(ctx, s.core, user, uint(req.GetId()), "secrets.delete"); err != nil {
 		return nil, err
 	}
 	if err := s.core.DeleteSecretWithPermissionCheck(ctx, uint(req.GetId()), user.UserID); err != nil {
@@ -169,7 +170,7 @@ func (s *SecretGRPCService) ListSecrets(ctx context.Context, req *pb.ListSecrets
 	// route's ScopeFromQuery); 0/0 means global. ListSecretsWithSharingInfo then
 	// filters the results to what the caller may actually see.
 	listScope := core.Scope{ProjectID: uint(req.GetProjectId()), EnvironmentID: uint(req.GetEnvironmentId())}
-	if allowed, err := s.core.Authorize(ctx, user.UserID, "secrets.read", listScope); err != nil || !allowed {
+	if allowed, err := s.core.AuthorizePrincipal(ctx, user.ActorKind(), user.PrincipalID(), "secrets.read", listScope); err != nil || !allowed {
 		return nil, status.Error(codes.PermissionDenied, "insufficient permissions to list secrets")
 	}
 
@@ -220,7 +221,7 @@ func (s *SecretGRPCService) GetSecretVersions(ctx context.Context, req *pb.GetSe
 	if err != nil {
 		return nil, err
 	}
-	if err := authorizeSecretScoped(ctx, s.core, user.UserID, uint(req.GetId()), "secrets.read"); err != nil {
+	if err := authorizeSecretScoped(ctx, s.core, user, uint(req.GetId()), "secrets.read"); err != nil {
 		return nil, err
 	}
 	versions, err := s.core.GetSecretVersionsWithPermissionCheck(ctx, uint(req.GetId()), user.UserID)
@@ -251,13 +252,13 @@ func (s *SecretGRPCService) GetSecretVersions(ctx context.Context, req *pb.GetSe
 // permission set. A missing secret yields NotFound (not PermissionDenied) to
 // avoid leaking existence; the downstream *WithPermissionCheck core calls still
 // enforce ownership/share on top of this.
-func authorizeSecretScoped(ctx context.Context, cs *core.KeyorixCore, userID, secretID uint, perm string) error {
+func authorizeSecretScoped(ctx context.Context, cs *core.KeyorixCore, actor *interceptors.UserContext, secretID uint, perm string) error {
 	secret, err := cs.Storage().GetSecret(ctx, secretID)
 	if err != nil {
 		return status.Error(codes.NotFound, "secret not found")
 	}
 	scope := core.Scope{ProjectID: secret.ProjectID, EnvironmentID: secret.EnvironmentID}
-	if allowed, err := cs.Authorize(ctx, userID, perm, scope); err != nil || !allowed {
+	if allowed, err := cs.AuthorizePrincipal(ctx, actor.ActorKind(), actor.PrincipalID(), perm, scope); err != nil || !allowed {
 		return status.Error(codes.PermissionDenied, "insufficient permissions for this secret")
 	}
 	return nil

--- a/server/grpc/services/share_service.go
+++ b/server/grpc/services/share_service.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/server/grpc/interceptors"
 	pb "github.com/keyorixhq/keyorix/server/proto/pb"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -43,7 +44,7 @@ func (s *ShareGRPCService) ShareSecret(ctx context.Context, req *pb.ShareSecretR
 	}
 	// Scope secrets.write to the shared secret's project (mirrors the HTTP
 	// /secrets/{id}/share route), not the flat global permission set.
-	if err := authorizeSecretScoped(ctx, s.core, user.UserID, uint(req.GetSecretId()), "secrets.write"); err != nil {
+	if err := authorizeSecretScoped(ctx, s.core, user, uint(req.GetSecretId()), "secrets.write"); err != nil {
 		return nil, err
 	}
 
@@ -79,7 +80,7 @@ func (s *ShareGRPCService) ListSecretShares(ctx context.Context, req *pb.ListSec
 	if req.GetSecretId() == 0 {
 		return nil, status.Error(codes.InvalidArgument, "secret_id is required")
 	}
-	if err := authorizeSecretScoped(ctx, s.core, user.UserID, uint(req.GetSecretId()), "secrets.read"); err != nil {
+	if err := authorizeSecretScoped(ctx, s.core, user, uint(req.GetSecretId()), "secrets.read"); err != nil {
 		return nil, err
 	}
 
@@ -152,7 +153,7 @@ func (s *ShareGRPCService) UpdateSharePermission(ctx context.Context, req *pb.Up
 	if req.GetPermission() != "read" && req.GetPermission() != "write" {
 		return nil, status.Error(codes.InvalidArgument, "permission must be 'read' or 'write'")
 	}
-	if err := s.authorizeShareScoped(ctx, user.UserID, uint(req.GetShareId()), "secrets.write"); err != nil {
+	if err := s.authorizeShareScoped(ctx, user, uint(req.GetShareId()), "secrets.write"); err != nil {
 		return nil, err
 	}
 
@@ -176,7 +177,7 @@ func (s *ShareGRPCService) RevokeShare(ctx context.Context, req *pb.RevokeShareR
 	if req.GetShareId() == 0 {
 		return nil, status.Error(codes.InvalidArgument, "share_id is required")
 	}
-	if err := s.authorizeShareScoped(ctx, user.UserID, uint(req.GetShareId()), "secrets.write"); err != nil {
+	if err := s.authorizeShareScoped(ctx, user, uint(req.GetShareId()), "secrets.write"); err != nil {
 		return nil, err
 	}
 	if err := s.core.RevokeShare(ctx, uint(req.GetShareId()), user.UserID); err != nil {
@@ -194,7 +195,7 @@ func (s *ShareGRPCService) RevokeShare(ctx context.Context, req *pb.RevokeShareR
 // ScopeFromShareParam, so mutating a specific share enforces the same scoped
 // RBAC as HTTP rather than the flat global set. A missing share/secret yields
 // NotFound; the downstream core call still enforces ownership.
-func (s *ShareGRPCService) authorizeShareScoped(ctx context.Context, userID, shareID uint, perm string) error {
+func (s *ShareGRPCService) authorizeShareScoped(ctx context.Context, actor *interceptors.UserContext, shareID uint, perm string) error {
 	share, err := s.core.Storage().GetShareRecord(ctx, shareID)
 	if err != nil {
 		return status.Error(codes.NotFound, "share not found")
@@ -204,7 +205,7 @@ func (s *ShareGRPCService) authorizeShareScoped(ctx context.Context, userID, sha
 		return status.Error(codes.NotFound, "share not found")
 	}
 	scope := core.Scope{ProjectID: secret.ProjectID, EnvironmentID: secret.EnvironmentID}
-	if allowed, err := s.core.Authorize(ctx, userID, perm, scope); err != nil || !allowed {
+	if allowed, err := s.core.AuthorizePrincipal(ctx, actor.ActorKind(), actor.PrincipalID(), perm, scope); err != nil || !allowed {
 		return status.Error(codes.PermissionDenied, "insufficient permissions for this share")
 	}
 	return nil

--- a/server/grpc/services/system_service.go
+++ b/server/grpc/services/system_service.go
@@ -53,7 +53,7 @@ func (s *SystemGRPCService) GetSystemInfo(ctx context.Context, _ *emptypb.Empty)
 	if err != nil {
 		return nil, err
 	}
-	if err := authorizeGlobal(ctx, s.core, actor.UserID, "system.read"); err != nil {
+	if err := authorizeGlobal(ctx, s.core, actor, "system.read"); err != nil {
 		return nil, err
 	}
 
@@ -93,7 +93,7 @@ func (s *SystemGRPCService) GetMetrics(ctx context.Context, _ *emptypb.Empty) (*
 	if err != nil {
 		return nil, err
 	}
-	if err := authorizeGlobal(ctx, s.core, actor.UserID, "system.read"); err != nil {
+	if err := authorizeGlobal(ctx, s.core, actor, "system.read"); err != nil {
 		return nil, err
 	}
 

--- a/server/grpc/services/user_service.go
+++ b/server/grpc/services/user_service.go
@@ -38,7 +38,7 @@ func (s *UserGRPCService) CreateUser(ctx context.Context, req *pb.CreateUserRequ
 	if err != nil {
 		return nil, err
 	}
-	if err := authorizeGlobal(ctx, s.core, actor.UserID, "users.write"); err != nil {
+	if err := authorizeGlobal(ctx, s.core, actor, "users.write"); err != nil {
 		return nil, err
 	}
 	if req.GetUsername() == "" || req.GetEmail() == "" {
@@ -106,7 +106,7 @@ func (s *UserGRPCService) GetUser(ctx context.Context, req *pb.GetUserRequest) (
 	if err != nil {
 		return nil, err
 	}
-	if err := authorizeGlobal(ctx, s.core, actor.UserID, "users.read"); err != nil {
+	if err := authorizeGlobal(ctx, s.core, actor, "users.read"); err != nil {
 		return nil, err
 	}
 	u, err := s.core.GetUser(ctx, uint(req.GetId()))
@@ -122,7 +122,7 @@ func (s *UserGRPCService) UpdateUser(ctx context.Context, req *pb.UpdateUserRequ
 	if err != nil {
 		return nil, err
 	}
-	if err := authorizeGlobal(ctx, s.core, actor.UserID, "users.write"); err != nil {
+	if err := authorizeGlobal(ctx, s.core, actor, "users.write"); err != nil {
 		return nil, err
 	}
 	if req.GetId() == 0 {
@@ -147,7 +147,7 @@ func (s *UserGRPCService) DeleteUser(ctx context.Context, req *pb.DeleteUserRequ
 	if err != nil {
 		return nil, err
 	}
-	if err := authorizeGlobal(ctx, s.core, actor.UserID, "users.delete"); err != nil {
+	if err := authorizeGlobal(ctx, s.core, actor, "users.delete"); err != nil {
 		return nil, err
 	}
 	if req.GetId() == 0 {
@@ -165,7 +165,7 @@ func (s *UserGRPCService) ListUsers(ctx context.Context, req *pb.ListUsersReques
 	if err != nil {
 		return nil, err
 	}
-	if err := authorizeGlobal(ctx, s.core, actor.UserID, "users.read"); err != nil {
+	if err := authorizeGlobal(ctx, s.core, actor, "users.read"); err != nil {
 		return nil, err
 	}
 	page, pageSize := normalizePage(req.GetPage(), req.GetPageSize())


### PR DESCRIPTION
## What

Completes gRPC authentication parity with HTTP — **session + PAT + machine**. After #158 (PATs over gRPC), machine-identity tokens were still rejected by the gRPC interceptor, yet machine-to-service is the canonical gRPC use case.

- **Interceptor**: routes the `kx_machine_` prefix to `ValidateMachineToken` and builds a machine principal on the gRPC `UserContext` (`actor_type=machine_identity`, no owning user). `UserContext` gains `ActorType`/`MachineIdentityID` + `ActorKind()`/`PrincipalID()`, mirroring the HTTP middleware.
- **Authz primitive**: the gRPC service helpers (`authorizeScoped`/`authorizeGlobal`) and the direct secret/share authz calls now use `AuthorizePrincipal(actorKind, principalID, …)` instead of `Authorize(userID, …)`. For a **user**, `AuthorizePrincipal` is identical to `Authorize` (PAT restriction + roles + admin bypass) — so **session and PAT paths are behaviorally unchanged** (all existing gRPC service tests pass). For a **machine** it resolves machine roles with **no admin bypass**.

Machine authentication (`ValidateMachineToken` re-checks revoked/expired/state every call) and machine RBAC are reused unchanged; only the gRPC front door and the authz primitive are new.

## Security

Reviewed with the security-review subagent (the diff changes the authz primitive for every gRPC RPC). **Verdict: sound, no new vulnerability** — confirmed: (1) machines get machine RBAC, no admin bypass, no `MachineIdentityID=0`/user-0 collision; (2) user/PAT paths behaviorally identical (`AuthorizePrincipal("user", id)` ≡ `Authorize(id)`, PAT restriction intact); (3) routing exclusive + fail-closed; (4) the machine-as-`UserID:0` downstream concern **fails closed everywhere** (`CheckSecretPermission` rejects `userID==0`; list paths error/deny). One informational, **pre-existing** finding (machine-created secrets get `OwnerID=0` — a shared ownerless namespace) is **identical on the already-shipped HTTP path**, front-gated by scoped RBAC, and belongs in the core ownership model — out of scope here; I'll track it as a follow-up.

## Tests

Real core via `RBACTestHelper`: a machine granted `viewer` (secrets.read) in project 2 authenticates over gRPC as a machine principal, is allowed scoped read, and **denied** `secrets.write` (no admin bypass) and project-3 read (out of scope). Existing user-path service + interceptor tests unchanged. ADR-042 addendum updated.

gofmt clean, golangci-lint 0 issues, `go build ./...` + all `./server/grpc/...` suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)