### PR TITLE
test(storage): machine-RBAC environment-axis scope isolation guard

### DIFF
--- a/internal/storage/store/local_machine_credentials_test.go
+++ b/internal/storage/store/local_machine_credentials_test.go
@@ -112,3 +112,32 @@ func TestMachineRoleGrantScopeResolution(t *testing.T) {
 	require.NoError(t, err)
 	assert.ElementsMatch(t, []uint{100}, ids)
 }
+
+// Environment-axis isolation: GetMachineRoleIDsAt uses the same
+// "(env = 0 OR env = ?)" structure as the user query, so an env-scoped grant must
+// not leak across projects at the same environment. This is the parenthesisation
+// guard for machines (cf. the user-RBAC scope-boundary tests).
+func TestMachineRoleGrantScopeResolution_EnvCrossLeak(t *testing.T) {
+	ls := newMachineCredTestStore(t)
+	ctx := context.Background()
+	const machineID = uint(1)
+
+	// role 300 granted at exactly project 2 / env 9.
+	require.NoError(t, ls.AssignMachineRole(ctx, machineID, 300, storage.Scope{ProjectID: 2, EnvironmentID: 9}))
+
+	ids, err := ls.GetMachineRoleIDsAt(ctx, machineID, storage.Scope{ProjectID: 2, EnvironmentID: 9})
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []uint{300}, ids, "applies at its exact project/env")
+
+	ids, err = ls.GetMachineRoleIDsAt(ctx, machineID, storage.Scope{ProjectID: 3, EnvironmentID: 9})
+	require.NoError(t, err)
+	assert.Empty(t, ids, "env-9 grant in project 2 must NOT leak to project 3 at env 9")
+
+	ids, err = ls.GetMachineRoleIDsAt(ctx, machineID, storage.Scope{ProjectID: 2, EnvironmentID: 8})
+	require.NoError(t, err)
+	assert.Empty(t, ids, "does not apply at a different environment")
+
+	ids, err = ls.GetMachineRoleIDsAt(ctx, machineID, storage.Scope{ProjectID: 2})
+	require.NoError(t, err)
+	assert.Empty(t, ids, "an env-scoped grant does not apply at project-level env 0")
+}


### PR DESCRIPTION
## What

`GetMachineRoleIDsAt`'s existing test covered the project-axis exclusion (a project-2 grant not matching project 3) but **not the environment axis**. The query uses the same `(env = 0 OR env = ?)` structure as the user-RBAC query, so it's vulnerable to the same parenthesisation-regression class that #160 guards for users: an env-scoped grant leaking across projects at the same environment.

Adds that case: a machine role at project 2 / env 9 applies there but is **denied** at project 3 / env 9 (the cross-leak guard), at project 2 / env 8, and at project-2 / env-0 (project level).

Completes the tenant-isolation scope-boundary trilogy at the SQL level: **user-direct (#160), user-group (#160), machine (this)** + secret-visibility (#161). Test-only; no behavior change. gofmt clean, golangci-lint 0 issues, store suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)