### PR TITLE
fix(secrets): list owned secrets by owner_id, not the created_by username

### DIFF
--- a/internal/core/permissions.go
+++ b/internal/core/permissions.go
@@ -191,8 +191,10 @@ func (c *KeyorixCore) ListUserPermissions(ctx context.Context, userID uint) ([]*
 
 	var permissions []*models.UserSecretPermission
 
+	// Owned == owner_id (the canonical ownership), not created_by (a username
+	// string). Page 1 with an explicit size; a zero PageSize would emit LIMIT 0.
 	ownedSecrets, _, err := c.storage.ListSecrets(ctx, &storage.SecretFilter{
-		CreatedBy: &[]string{fmt.Sprintf("%d", userID)}[0],
+		OwnerID: &userID, Page: 1, PageSize: 10000,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)

--- a/internal/core/secret_listing_query.go
+++ b/internal/core/secret_listing_query.go
@@ -159,13 +159,17 @@ func (c *KeyorixCore) ListSecretsWithSharingInfo(ctx context.Context, userID uin
 func (c *KeyorixCore) getOwnedSecretsWithSharingInfo(ctx context.Context, userID uint, filter *models.SecretListFilter) ([]*models.SecretWithSharingInfo, error) {
 	storageFilter := c.convertToStorageFilter(filter)
 
-	// created_by stores the username string, not the numeric ID.
-	// Look up the user to get the correct username for filtering.
+	// Resolve the user first — fail closed for an unknown/zero principal (e.g. a
+	// machine identity has no owning user, so it owns no secrets).
 	user, err := c.storage.GetUser(ctx, userID)
 	if err != nil || user == nil {
 		return nil, fmt.Errorf("failed to resolve user for secret listing: %w", err)
 	}
-	storageFilter.CreatedBy = &user.Username
+	// "Owned" means owner_id == userID — the canonical ownership the permission
+	// model uses (CheckSecretPermission), not the created_by username string. The
+	// username proxy missed CLI-created secrets (created_by "cli-user") and could
+	// mis-attribute ownership across a deleted-then-reused username.
+	storageFilter.OwnerID = &userID
 
 	secrets, _, err := c.storage.ListSecrets(ctx, storageFilter)
 	if err != nil {

--- a/internal/core/sharing_indicators_test.go
+++ b/internal/core/sharing_indicators_test.go
@@ -195,9 +195,10 @@ func TestListSecretsWithSharingInfo(t *testing.T) {
 		Type:    "password",
 	}
 
-	// Mock storage calls for owned secrets (CreatedBy is resolved to username, not numeric ID)
+	// Owned secrets are filtered by owner_id (the canonical ownership), not the
+	// created_by username.
 	mockStorage.On("ListSecrets", mock.Anything, mock.MatchedBy(func(filter *storage.SecretFilter) bool {
-		return filter.CreatedBy != nil && *filter.CreatedBy == "owner"
+		return filter.OwnerID != nil && *filter.OwnerID == userID
 	})).Return([]*models.SecretNode{ownedSecret}, int64(1), nil)
 
 	// Mock shares for owned secret
@@ -282,7 +283,7 @@ func TestSecretListFiltering(t *testing.T) {
 
 		mockStorage.On("GetUser", mock.Anything, uint(1)).Return(&models.User{ID: 1, Username: "owner"}, nil)
 		mockStorage.On("ListSecrets", mock.Anything, mock.MatchedBy(func(filter *storage.SecretFilter) bool {
-			return filter.CreatedBy != nil && *filter.CreatedBy == "owner"
+			return filter.OwnerID != nil && *filter.OwnerID == userID
 		})).Return([]*models.SecretNode{ownedSecret}, int64(1), nil)
 
 		mockStorage.On("ListSharesBySecret", mock.Anything, uint(1)).Return([]*models.ShareRecord{}, nil)

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -389,6 +389,10 @@ type SecretFilter struct {
 	Type          *string
 	Tags          []string
 	CreatedBy     *string
+	// OwnerID, when set, restricts to secrets owned by that user (owner_id) — the
+	// canonical ownership the permission model uses (CheckSecretPermission), as
+	// opposed to the mutable created_by username string.
+	OwnerID       *uint
 	CreatedAfter  *time.Time
 	CreatedBefore *time.Time
 	Page          int

--- a/internal/storage/store/local_secrets.go
+++ b/internal/storage/store/local_secrets.go
@@ -337,6 +337,9 @@ func (ls *LocalStorage) ListSecrets(ctx context.Context, filter *storage.SecretF
 	if filter.CreatedBy != nil {
 		query = query.Where("secret_nodes.created_by = ?", *filter.CreatedBy)
 	}
+	if filter.OwnerID != nil {
+		query = query.Where("secret_nodes.owner_id = ?", *filter.OwnerID)
+	}
 	if filter.CreatedAfter != nil {
 		query = query.Where("secret_nodes.created_at > ?", *filter.CreatedAfter)
 	}

--- a/internal/storage/store/local_secrets_scope_test.go
+++ b/internal/storage/store/local_secrets_scope_test.go
@@ -117,3 +117,30 @@ func TestListSecrets_Pagination(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, got2, 1, "last page returns the remainder")
 }
+
+// The OwnerID filter selects by owner_id (the canonical ownership), not the
+// created_by username — so it includes a secret whose created_by differs from the
+// owner's username (e.g. a CLI-created "cli-user" secret) that a created_by filter
+// would miss, and excludes another user's secrets.
+func TestListSecrets_OwnerFilter(t *testing.T) {
+	ls := newSecretScopeTestStore(t)
+	ctx := context.Background()
+	require.NoError(t, ls.db.Create(&models.Environment{ID: 1, ProjectID: 5, Name: "dev"}).Error)
+	for _, s := range []models.SecretNode{
+		{ProjectID: 5, EnvironmentID: 1, OwnerID: 7, CreatedBy: "alice", Name: "alice-secret", IsSecret: true, Type: "api_key", Status: "active"},
+		{ProjectID: 5, EnvironmentID: 1, OwnerID: 7, CreatedBy: "cli-user", Name: "cli-secret", IsSecret: true, Type: "api_key", Status: "active"},
+		{ProjectID: 5, EnvironmentID: 1, OwnerID: 8, CreatedBy: "bob", Name: "bob-secret", IsSecret: true, Type: "api_key", Status: "active"},
+	} {
+		require.NoError(t, ls.db.Create(&s).Error)
+	}
+
+	got, total, err := ls.ListSecrets(ctx, &storage.SecretFilter{OwnerID: uptr(7), Page: 1, PageSize: 100})
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), total)
+	assert.ElementsMatch(t, []string{"alice-secret", "cli-secret"}, secretNames(got),
+		"owner 7 owns both, including the CLI secret whose created_by != the owner's username")
+
+	got, _, err = ls.ListSecrets(ctx, &storage.SecretFilter{OwnerID: uptr(8), Page: 1, PageSize: 100})
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"bob-secret"}, secretNames(got), "owner 8 sees only its own")
+}

--- a/internal/storage/store/remote_secrets.go
+++ b/internal/storage/store/remote_secrets.go
@@ -158,6 +158,7 @@ func buildSecretFilterPath(filter *storage.SecretFilter) string {
 	params.addUint("environment_id", filter.EnvironmentID)
 	params.addString("type", filter.Type)
 	params.addString("created_by", filter.CreatedBy)
+	params.addUint("owner_id", filter.OwnerID)
 	params.addTime("created_after", filter.CreatedAfter)
 	params.addTime("created_before", filter.CreatedBefore)
 	params.addTags("tags", filter.Tags)


### PR DESCRIPTION
## The bug (live)

"Show owned secrets" (`ListSecretsWithSharingInfo` → `getOwnedSecretsWithSharingInfo`) filtered secrets by `created_by == <the caller's username>` — a fragile string proxy. But the permission model defines ownership as `owner_id == userID` (`CheckSecretPermission`: `secret.OwnerID == userID`). The mismatch meant:

- secrets whose `created_by` ≠ the owner's username were **invisible** in the owner's list — notably **CLI-created secrets** (stored with `created_by: "cli-user"`);
- a **deleted-then-reused username** could mis-attribute a prior user's secrets to whoever inherits the name.

## The fix

- Adds an `OwnerID *uint` filter to `storage.SecretFilter` (a genuinely missing capability — "which secrets does user X own"), honored by `LocalStorage.ListSecrets` and serialized by the remote client.
- Switches `getOwnedSecretsWithSharingInfo` to filter by `OwnerID = userID`, keeping the `GetUser` lookup as the **fail-closed validity check** (a machine principal — `userID 0` — owns nothing, unchanged).
- The owned list now exactly matches the ownership the permission model enforces.
- Also fixes the same latent bug in the (currently unused) `ListUserPermissions`, which additionally passed `PageSize: 0` → `LIMIT 0` (returned nothing).

**No broadening of access:** `owner_id = userID` returns strictly the caller's own secrets — this is *stricter and more accurate* than the username proxy, never broader.

## Tests

Storage `OwnerID` filter incl. the CLI-secret case (`created_by` ≠ username, correctly matched by `owner_id`) and other-owner exclusion; existing owned-list mock matchers updated from `created_by` to `owner_id`. gofmt clean, golangci-lint 0 issues, core + store suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)