### PR TITLE
fix(rotation): page through all secrets in evaluation — drop the silent 1000 cap

### DIFF
--- a/internal/core/rotation_eval_cap_test.go
+++ b/internal/core/rotation_eval_cap_test.go
@@ -1,0 +1,55 @@
+package core
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// Rotation evaluation must page through ALL of a policy's secrets — a project with
+// more than one page must not have the secrets past the page silently skipped
+// (which would hide overdue secrets from the reminder scheduler and status views).
+func TestEvaluateRotationPolicies_NoSilentCap(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.Environment{}, &models.RotationPolicy{}))
+
+	now := time.Date(2026, 6, 13, 10, 0, 0, 0, time.UTC)
+	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: func() time.Time { return now }}
+
+	pid := uint(1)
+	require.NoError(t, db.Create(&models.Environment{ID: 1, ProjectID: 1, Name: "dev"}).Error)
+	require.NoError(t, db.Create(&models.RotationPolicy{
+		Name: "30-day", Scope: "project", ProjectID: &pid,
+		IntervalDays: 30, AlertDaysBefore: 7, IsActive: true, CreatedBy: "x",
+	}).Error)
+
+	// 1001 secrets — more than the old single-page cap of 1000 — all created 100
+	// days ago, so all overdue. A regression to a single capped ListSecrets call
+	// would drop at least one and fail this test.
+	const n = 1001
+	secrets := make([]*models.SecretNode, 0, n)
+	for i := 0; i < n; i++ {
+		secrets = append(secrets, &models.SecretNode{
+			ProjectID: 1, EnvironmentID: 1, Name: fmt.Sprintf("s%d", i), Type: "password",
+			CreatedAt: now.AddDate(0, 0, -100),
+		})
+	}
+	require.NoError(t, db.CreateInBatches(secrets, 200).Error)
+
+	evals, err := c.EvaluateRotationPolicies(context.Background(), nil)
+	require.NoError(t, err)
+	assert.Len(t, evals, n, "every overdue secret is evaluated, not capped at one page")
+
+	status, err := c.GetRotationStatus(context.Background(), nil)
+	require.NoError(t, err)
+	assert.Len(t, status, n, "status covers every secret too, not capped at one page")
+}

--- a/internal/core/rotation_policies.go
+++ b/internal/core/rotation_policies.go
@@ -151,6 +151,36 @@ type RotationStatusEntry struct {
 // active rotation policy (optionally scoped to a project), classified as
 // overdue / due_soon / ok. Secrets never rotated fall back to their creation
 // time, mirroring EvaluateRotationPolicies.
+// scopedPolicySecrets returns every secret in a rotation policy's scope, paging
+// through all of them. Rotation evaluation must NOT silently cap: a project (or
+// environment) with more than one page of secrets would otherwise have the
+// secrets past the cap never checked for rotation — so overdue ones would be
+// missed by both the reminder scheduler and the status/evaluate views.
+func (c *KeyorixCore) scopedPolicySecrets(ctx context.Context, policy *models.RotationPolicy) ([]*models.SecretNode, error) {
+	const pageSize = 500
+	var projectID, environmentID *uint
+	if policy.Scope == "project" {
+		projectID = policy.ProjectID
+	} else {
+		environmentID = policy.EnvironmentID
+	}
+
+	var all []*models.SecretNode
+	for page := 1; ; page++ {
+		secrets, total, err := c.storage.ListSecrets(ctx, &storage.SecretFilter{
+			Page: page, PageSize: pageSize, ProjectID: projectID, EnvironmentID: environmentID,
+		})
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, secrets...)
+		if len(secrets) < pageSize || int64(len(all)) >= total {
+			break
+		}
+	}
+	return all, nil
+}
+
 func (c *KeyorixCore) GetRotationStatus(ctx context.Context, projectID *uint) ([]*RotationStatusEntry, error) {
 	policies, err := c.storage.ListRotationPolicies(ctx, projectID, nil)
 	if err != nil {
@@ -165,14 +195,7 @@ func (c *KeyorixCore) GetRotationStatus(ctx context.Context, projectID *uint) ([
 			continue
 		}
 
-		filter := &storage.SecretFilter{Page: 1, PageSize: 1000}
-		if policy.Scope == "project" {
-			filter.ProjectID = policy.ProjectID
-		} else {
-			filter.EnvironmentID = policy.EnvironmentID
-		}
-
-		secrets, _, err := c.storage.ListSecrets(ctx, filter)
+		secrets, err := c.scopedPolicySecrets(ctx, policy)
 		if err != nil {
 			continue
 		}
@@ -226,14 +249,7 @@ func (c *KeyorixCore) EvaluateRotationPolicies(ctx context.Context, projectID *u
 			continue
 		}
 
-		filter := &storage.SecretFilter{Page: 1, PageSize: 1000}
-		if policy.Scope == "project" {
-			filter.ProjectID = policy.ProjectID
-		} else {
-			filter.EnvironmentID = policy.EnvironmentID
-		}
-
-		secrets, _, err := c.storage.ListSecrets(ctx, filter)
+		secrets, err := c.scopedPolicySecrets(ctx, policy)
 		if err != nil {
 			continue
 		}


### PR DESCRIPTION
## The bug

`EvaluateRotationPolicies` and `GetRotationStatus` each listed a policy's secrets with a single `ListSecrets(PageSize: 1000)` call. A project (or environment) with **more than 1000 secrets** had everything past the first page **silently skipped** — so overdue secrets beyond the cap were never reported by:

- the **rotation-reminder scheduler** (#150), and
- the **`rotation status` / evaluate views + CLI** (#156).

For a credential-rotation-hygiene control (NIS2/ISO A.5.15), that's a silent compliance gap — and it's reachable (max secrets per user is 10,000, so >1000 in a project is realistic).

## The fix

Extracts `scopedPolicySecrets`, which **pages through every secret** in the policy's scope (project or environment), and uses it in both call sites. Same best-effort behavior on error (skip the policy), same date math.

## Test

1001 overdue secrets under one policy → both `EvaluateRotationPolicies` and `GetRotationStatus` return all 1001. A regression to a single capped call would drop at least one and fail the test. gofmt clean, golangci-lint 0 issues, core + rotation handler suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)