### PR TITLE
fix(dashboard): don't silently cap the expiring-secrets warning at 100

### DIFF
--- a/internal/core/dashboard.go
+++ b/internal/core/dashboard.go
@@ -216,15 +216,6 @@ func (c *KeyorixCore) getExpiringSecrets(ctx context.Context, username string) [
 	now := time.Now().UTC()
 	cutoff := now.Add(30 * 24 * time.Hour)
 
-	secrets, _, err := c.storage.ListSecrets(ctx, &storage.SecretFilter{
-		CreatedBy: &username,
-		Page:      1,
-		PageSize:  100,
-	})
-	if err != nil {
-		return nil
-	}
-
 	// Build environment name lookup once
 	envNames := map[uint]string{}
 	if envs, err := c.storage.ListEnvironments(ctx); err == nil {
@@ -233,34 +224,43 @@ func (c *KeyorixCore) getExpiringSecrets(ctx context.Context, username string) [
 		}
 	}
 
+	// Page through every matching secret — a user with many secrets must not have
+	// an expiring one silently dropped from the dashboard warning. The expiration
+	// filter (expiration < cutoff) keeps the matched set small and does the
+	// expired/expiring selection in the query.
+	const pageSize = 200
 	var result []ExpiringSecret
-	for _, s := range secrets {
-		if s.Expiration == nil {
-			continue
-		}
-		exp := s.Expiration.UTC()
-		expired := exp.Before(now)
-		expiring := exp.Before(cutoff) // within 30 days from now
-
-		if !expired && !expiring {
-			continue // more than 30 days away, skip
-		}
-
-		daysLeft := int(exp.Sub(now).Hours() / 24) // negative when expired
-
-		envName := envNames[s.EnvironmentID]
-		if envName == "" {
-			envName = "unknown"
-		}
-
-		result = append(result, ExpiringSecret{
-			ID:          s.ID,
-			Name:        s.Name,
-			Environment: envName,
-			ExpiresAt:   exp,
-			DaysLeft:    daysLeft,
-			Expired:     expired,
+	for page := 1; ; page++ {
+		secrets, total, err := c.storage.ListSecrets(ctx, &storage.SecretFilter{
+			CreatedBy:     &username,
+			ExpiresBefore: &cutoff,
+			Page:          page,
+			PageSize:      pageSize,
 		})
+		if err != nil {
+			break
+		}
+		for _, s := range secrets {
+			if s.Expiration == nil {
+				continue // defensive; the filter already excludes nulls
+			}
+			exp := s.Expiration.UTC()
+			envName := envNames[s.EnvironmentID]
+			if envName == "" {
+				envName = "unknown"
+			}
+			result = append(result, ExpiringSecret{
+				ID:          s.ID,
+				Name:        s.Name,
+				Environment: envName,
+				ExpiresAt:   exp,
+				DaysLeft:    int(exp.Sub(now).Hours() / 24), // negative when expired
+				Expired:     exp.Before(now),
+			})
+		}
+		if len(secrets) < pageSize || int64(len(result)) >= total {
+			break
+		}
 	}
 
 	// Sort: expired first (most overdue first), then soonest-expiring

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -395,6 +395,9 @@ type SecretFilter struct {
 	OwnerID       *uint
 	CreatedAfter  *time.Time
 	CreatedBefore *time.Time
+	// ExpiresBefore, when set, restricts to secrets with a non-null expiration
+	// earlier than the given time (i.e. already expired or expiring before it).
+	ExpiresBefore *time.Time
 	Page          int
 	PageSize      int
 	// IncludeDeleted, when true, also returns soft-deleted secrets (ADR-033) —

--- a/internal/storage/store/local_secrets.go
+++ b/internal/storage/store/local_secrets.go
@@ -340,6 +340,9 @@ func (ls *LocalStorage) ListSecrets(ctx context.Context, filter *storage.SecretF
 	if filter.OwnerID != nil {
 		query = query.Where("secret_nodes.owner_id = ?", *filter.OwnerID)
 	}
+	if filter.ExpiresBefore != nil {
+		query = query.Where("secret_nodes.expiration IS NOT NULL AND secret_nodes.expiration < ?", *filter.ExpiresBefore)
+	}
 	if filter.CreatedAfter != nil {
 		query = query.Where("secret_nodes.created_at > ?", *filter.CreatedAfter)
 	}

--- a/internal/storage/store/local_secrets_expiry_test.go
+++ b/internal/storage/store/local_secrets_expiry_test.go
@@ -1,0 +1,45 @@
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The ExpiresBefore filter returns only secrets with a non-null expiration before
+// the cutoff (already expired or expiring within the window), excluding
+// later-expiring and never-expiring secrets.
+func TestListSecrets_ExpiresBeforeFilter(t *testing.T) {
+	ls := newSecretScopeTestStore(t)
+	ctx := context.Background()
+	require.NoError(t, ls.db.Create(&models.Environment{ID: 1, ProjectID: 5, Name: "dev"}).Error)
+
+	now := time.Date(2026, 6, 13, 10, 0, 0, 0, time.UTC)
+	cutoff := now.Add(30 * 24 * time.Hour)
+	mk := func(name string, exp *time.Time) {
+		require.NoError(t, ls.db.Create(&models.SecretNode{
+			ProjectID: 5, EnvironmentID: 1, Name: name, IsSecret: true, Type: "api_key", Status: "active",
+			Expiration: exp,
+		}).Error)
+	}
+	expired := now.Add(-24 * time.Hour)
+	soon := now.Add(10 * 24 * time.Hour)
+	far := now.Add(60 * 24 * time.Hour)
+	mk("expired", &expired)
+	mk("soon", &soon)
+	mk("far", &far)
+	mk("no-expiry", nil)
+
+	got, total, err := ls.ListSecrets(ctx, &storage.SecretFilter{
+		ExpiresBefore: &cutoff, Page: 1, PageSize: 100,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), total)
+	assert.ElementsMatch(t, []string{"expired", "soon"}, secretNames(got),
+		"only secrets expiring before the cutoff match; far-future and never-expiring are excluded")
+}

--- a/internal/storage/store/remote_secrets.go
+++ b/internal/storage/store/remote_secrets.go
@@ -159,6 +159,7 @@ func buildSecretFilterPath(filter *storage.SecretFilter) string {
 	params.addString("type", filter.Type)
 	params.addString("created_by", filter.CreatedBy)
 	params.addUint("owner_id", filter.OwnerID)
+	params.addTime("expires_before", filter.ExpiresBefore)
 	params.addTime("created_after", filter.CreatedAfter)
 	params.addTime("created_before", filter.CreatedBefore)
 	params.addTags("tags", filter.Tags)


### PR DESCRIPTION
## The bug

`getExpiringSecrets` (the dashboard "expiring secrets" warning) listed the user's secrets with a single `ListSecrets(PageSize: 100)` call and filtered for expiring ones in memory. A user with **more than 100 created secrets** could have an expiring — or already-expired — secret **silently dropped** from the warning, so they're never told it's about to expire.

## The fix

Adds an `ExpiresBefore` filter to `storage.SecretFilter` (`expiration IS NOT NULL AND expiration < cutoff`), honored by `LocalStorage` and serialized by the remote client. `getExpiringSecrets` now pushes the expired/expiring selection into the **query** (so the matched set is small) and **pages through all of it** — no cap. Same 30-day window, same output shape and sort.

This also gives the codebase a reusable expiration-window filter (useful for any expiry alerting).

## Tests

Storage `ExpiresBefore` filter returns only secrets expiring before the cutoff (expired + soon), excluding far-future and never-expiring. gofmt clean, golangci-lint 0 issues, core + store suites green.

Part of a small sweep of silent single-page caps (cf. #164 rotation evaluation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)