### PR TITLE
fix(cli): page through all secrets in run and secret get (drop the 1000 cap)

### DIFF
--- a/internal/cli/run/run.go
+++ b/internal/cli/run/run.go
@@ -132,26 +132,32 @@ func fetchSecretsEmbedded(ctx context.Context, project, env string) (map[string]
 		return nil, fmt.Errorf("environment %q not found", env)
 	}
 
-	// List all secrets in the project + environment
-	filter := &coreStorage.SecretFilter{
-		ProjectID:     &projectID,
-		EnvironmentID: &envID,
-		Page:          1,
-		PageSize:      1000,
-	}
-	secrets, _, err := svc.ListSecrets(ctx, filter)
-	if err != nil {
-		return nil, fmt.Errorf("failed to list secrets: %w", err)
-	}
-
-	result := make(map[string]string, len(secrets))
-	for _, s := range secrets {
-		val, err := svc.GetSecretValue(ctx, s.ID)
+	// Inject EVERY secret in the project + environment — page through all of them
+	// so a project with more than one page doesn't start the subprocess with
+	// silently missing environment variables.
+	const pageSize = 500
+	result := make(map[string]string)
+	for page := 1; ; page++ {
+		secrets, _, err := svc.ListSecrets(ctx, &coreStorage.SecretFilter{
+			ProjectID:     &projectID,
+			EnvironmentID: &envID,
+			Page:          page,
+			PageSize:      pageSize,
+		})
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "warning: skipping secret %q (id=%d): %v\n", s.Name, s.ID, err)
-			continue
+			return nil, fmt.Errorf("failed to list secrets: %w", err)
 		}
-		result[toEnvKey(s.Name)] = string(val)
+		for _, s := range secrets {
+			val, err := svc.GetSecretValue(ctx, s.ID)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "warning: skipping secret %q (id=%d): %v\n", s.Name, s.ID, err)
+				continue
+			}
+			result[toEnvKey(s.Name)] = string(val)
+		}
+		if len(secrets) < pageSize {
+			break
+		}
 	}
 	return result, nil
 }
@@ -240,33 +246,38 @@ func fetchSecretsRemote(ctx context.Context, endpoint, token, project, env strin
 		return nil, fmt.Errorf("environment %q not found on server", env)
 	}
 
-	// ── 3. List secrets ────────────────────────────────────────────────────────
-	listPath := fmt.Sprintf(
-		"/api/v1/secrets?project_id=%d&environment_id=%d&page_size=1000&page=1",
-		nsID, envID,
-	)
-	var secretsBody struct {
-		Secrets []struct {
-			ID   uint   `json:"id"`
-			Name string `json:"name"`
-		} `json:"secrets"`
-	}
-	if err := api.get(ctx, listPath, &secretsBody); err != nil {
-		return nil, fmt.Errorf("list secrets: %w", err)
-	}
-
-	// ── 4. Fetch each secret's decrypted value ─────────────────────────────────
-	result := make(map[string]string, len(secretsBody.Secrets))
-	for _, s := range secretsBody.Secrets {
-		var secretBody struct {
-			Value string `json:"value"`
+	// ── 3+4. Page through ALL secrets and fetch each value ─────────────────────
+	// (a single capped page would inject only the first page's env vars).
+	const pageSize = 500
+	result := make(map[string]string)
+	for page := 1; ; page++ {
+		listPath := fmt.Sprintf(
+			"/api/v1/secrets?project_id=%d&environment_id=%d&page_size=%d&page=%d",
+			nsID, envID, pageSize, page,
+		)
+		var secretsBody struct {
+			Secrets []struct {
+				ID   uint   `json:"id"`
+				Name string `json:"name"`
+			} `json:"secrets"`
 		}
-		path := fmt.Sprintf("/api/v1/secrets/%d?include_value=true", s.ID)
-		if err := api.get(ctx, path, &secretBody); err != nil {
-			fmt.Fprintf(os.Stderr, "warning: skipping secret %q (id=%d): %v\n", s.Name, s.ID, err)
-			continue
+		if err := api.get(ctx, listPath, &secretsBody); err != nil {
+			return nil, fmt.Errorf("list secrets: %w", err)
 		}
-		result[toEnvKey(s.Name)] = secretBody.Value
+		for _, s := range secretsBody.Secrets {
+			var secretBody struct {
+				Value string `json:"value"`
+			}
+			path := fmt.Sprintf("/api/v1/secrets/%d?include_value=true", s.ID)
+			if err := api.get(ctx, path, &secretBody); err != nil {
+				fmt.Fprintf(os.Stderr, "warning: skipping secret %q (id=%d): %v\n", s.Name, s.ID, err)
+				continue
+			}
+			result[toEnvKey(s.Name)] = secretBody.Value
+		}
+		if len(secretsBody.Secrets) < pageSize {
+			break
+		}
 	}
 	return result, nil
 }

--- a/internal/cli/secret/get.go
+++ b/internal/cli/secret/get.go
@@ -135,20 +135,29 @@ func runGetEmbedded(ctx context.Context) error {
 			return fmt.Errorf("failed to get secret: %w", err)
 		}
 	} else {
-		filter := &coreStorage.SecretFilter{Page: 1, PageSize: 1000}
-		if getProject != 0 {
-			filter.ProjectID = &getProject
-		}
-		if getEnv != 0 {
-			filter.EnvironmentID = &getEnv
-		}
-		secrets, _, err := service.ListSecrets(ctx, filter)
-		if err != nil {
-			return fmt.Errorf("failed to list secrets: %w", err)
-		}
-		for _, s := range secrets {
-			if strings.EqualFold(s.Name, getName) {
-				secret = s
+		// Page through the matching secrets to find the named one — a single capped
+		// page would fail to find a secret that sorts beyond it ("not found" for a
+		// secret that exists).
+		const pageSize = 500
+		for page := 1; secret == nil; page++ {
+			filter := &coreStorage.SecretFilter{Page: page, PageSize: pageSize}
+			if getProject != 0 {
+				filter.ProjectID = &getProject
+			}
+			if getEnv != 0 {
+				filter.EnvironmentID = &getEnv
+			}
+			secrets, _, err := service.ListSecrets(ctx, filter)
+			if err != nil {
+				return fmt.Errorf("failed to list secrets: %w", err)
+			}
+			for _, s := range secrets {
+				if strings.EqualFold(s.Name, getName) {
+					secret = s
+					break
+				}
+			}
+			if len(secrets) < pageSize {
 				break
 			}
 		}


### PR DESCRIPTION
## The bug

Two CLI paths listed secrets with a single `PageSize: 1000` / `page_size=1000` call:

- **`keyorix run`** (local *and* remote) injects each project+environment secret as an env var into the subprocess — a project with **>1000 secrets** starts the process with **silently missing env vars** (a nasty, hard-to-debug misconfiguration).
- **`keyorix secret get --name X`** lists secrets and linear-scans for the name — a secret sorting beyond the cap was reported **"not found"** although it exists.

## The fix

Both now **page through all matching secrets** (loop until a short page). Same behavior otherwise.

## Tests

The underlying `ListSecrets` pagination is covered by storage-layer tests (cf. #164 rotation, #165 dashboard). These are thin pagination loops over that, with no CLI test harness in the package — flagging honestly that they rely on the proven storage pagination + construction (loops break on a short page, terminate by construction). gofmt clean, golangci-lint 0 issues, build + `cli/secret` suite green.

Completes the silent single-page-cap sweep (#164 core, #165 dashboard, this CLI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)