### PR TITLE
feat(secrets): expires_before filter on the secrets list API

### DIFF
--- a/internal/core/secret_filter_expiry_test.go
+++ b/internal/core/secret_filter_expiry_test.go
@@ -1,0 +1,47 @@
+package core
+
+import (
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+)
+
+// applySecretFilters honors ExpiresBefore: only secrets with a non-null expiration
+// before the cutoff pass (already expired or expiring within the window); secrets
+// expiring at/after the cutoff and never-expiring secrets are dropped. This backs
+// GET /api/v1/secrets?expires_before=… across the combined owned+shared list.
+func TestApplySecretFilters_ExpiresBefore(t *testing.T) {
+	c := &KeyorixCore{}
+	now := time.Date(2026, 6, 13, 10, 0, 0, 0, time.UTC)
+	cutoff := now.Add(30 * 24 * time.Hour)
+	soon := now.Add(10 * 24 * time.Hour)
+	expired := now.Add(-24 * time.Hour)
+	atCutoff := cutoff
+	far := now.Add(60 * 24 * time.Hour)
+
+	sec := func(name string, exp *time.Time) *models.SecretWithSharingInfo {
+		return &models.SecretWithSharingInfo{SecretNode: &models.SecretNode{Name: name, Expiration: exp}}
+	}
+	in := []*models.SecretWithSharingInfo{
+		sec("soon", &soon),
+		sec("expired", &expired),
+		sec("at-cutoff", &atCutoff),
+		sec("far", &far),
+		sec("never", nil),
+	}
+
+	out := c.applySecretFilters(in, &models.SecretListFilter{ExpiresBefore: &cutoff})
+
+	names := make([]string, 0, len(out))
+	for _, s := range out {
+		names = append(names, s.Name)
+	}
+	assert.ElementsMatch(t, []string{"soon", "expired"}, names,
+		"only secrets strictly before the cutoff pass; at-cutoff, far-future and never-expiring are excluded")
+
+	// Without the filter, everything passes (no behavior change for existing callers).
+	all := c.applySecretFilters(in, &models.SecretListFilter{})
+	assert.Len(t, all, 5)
+}

--- a/internal/core/secret_listing_query.go
+++ b/internal/core/secret_listing_query.go
@@ -239,6 +239,11 @@ func (c *KeyorixCore) applySecretFilters(secrets []*models.SecretWithSharingInfo
 		if filter.Type != nil && *filter.Type != "" && s.Type != *filter.Type {
 			continue
 		}
+		if filter.ExpiresBefore != nil {
+			if s.Expiration == nil || !s.Expiration.Before(*filter.ExpiresBefore) {
+				continue // no expiration, or expires at/after the cutoff
+			}
+		}
 		out = append(out, s)
 	}
 	return out

--- a/internal/storage/models/secret_with_sharing.go
+++ b/internal/storage/models/secret_with_sharing.go
@@ -38,6 +38,9 @@ type SecretListFilter struct {
 	CreatedBy     *string
 	CreatedAfter  *time.Time
 	CreatedBefore *time.Time
+	// ExpiresBefore, when set, returns only secrets with a non-null expiration
+	// before this time (already expired or expiring within the window).
+	ExpiresBefore *time.Time
 
 	// Sharing filters
 	ShowOwnedOnly  bool   // Show only secrets owned by the user

--- a/server/http/handlers/openapi.yaml
+++ b/server/http/handlers/openapi.yaml
@@ -1141,6 +1141,7 @@ paths:
         - {name: environment_id, in: query, schema: {type: integer}}
         - {name: search, in: query, schema: {type: string}}
         - {name: type, in: query, schema: {type: string}}
+        - {name: expires_before, in: query, schema: {type: string, format: date-time}, description: "RFC3339 — return only secrets with a non-null expiration before this time (expired or expiring soon)."}
         - {name: page, in: query, schema: {type: integer, default: 1}}
         - {name: page_size, in: query, schema: {type: integer, default: 20, maximum: 100}}
         - {name: show_owned_only, in: query, schema: {type: boolean}}

--- a/server/http/handlers/secrets_list.go
+++ b/server/http/handlers/secrets_list.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/keyorixhq/keyorix/server/middleware"
@@ -82,6 +83,11 @@ func (h *SecretHandler) ListSecrets(w http.ResponseWriter, r *http.Request) {
 		if eID, err := strconv.ParseUint(envStr, 10, 32); err == nil {
 			eIDUint := uint(eID)
 			filter.EnvironmentID = &eIDUint
+		}
+	}
+	if eb := r.URL.Query().Get("expires_before"); eb != "" {
+		if t, err := time.Parse(time.RFC3339, eb); err == nil {
+			filter.ExpiresBefore = &t
 		}
 	}
 


### PR DESCRIPTION
## What

The `ExpiresBefore` storage filter added in #165 was internal-only (powering the dashboard "expiring secrets" widget). This surfaces it on **`GET /api/v1/secrets?expires_before=<RFC3339>`** so a UI "expiring secrets" view or an ops script can list secrets that are already expired or expiring before a given time across a project — proactive expiry management, complementing rotation.

- Adds `ExpiresBefore` to `models.SecretListFilter`.
- Parses the RFC3339 `expires_before` query param in the list handler.
- Applies it in `applySecretFilters` (the in-memory post-filter over the combined owned+shared list) — only secrets with a **non-null expiration strictly before** the cutoff pass. No behavior change when the param is absent.

## Tests

`applySecretFilters` keeps expired+soon, drops at-cutoff / far-future / never-expiring, and is a no-op without the filter. openapi documents the param. gofmt clean, golangci-lint 0 issues, core + handler suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)