### PR TITLE
feat(access-review): project role-based access recertification (ISO 27001 A.5.18)

### DIFF
--- a/docs/REMOTE_CLI_SETUP.md
+++ b/docs/REMOTE_CLI_SETUP.md
@@ -187,6 +187,22 @@ keyorix rotation create --name db-creds-30d --scope project --project-id 5 \
 keyorix rotation status
 ```
 
+### Access Review Commands
+
+Periodic access recertification (ISO 27001 A.5.18 / SOC 2 CC6.2–6.3): review who
+can reach a project's secrets via an assigned role. Requires `roles.read` at the
+project scope.
+
+- `keyorix access-review --project-id N` (aliases `recert`) — lists every principal
+  (user or group) with role-based access to project N's secrets, the role granting
+  it, and the highest secrets action (read/write/delete/admin). Share-based grants
+  (per-secret) are a separate review surface (planned).
+
+```bash
+# Quarterly access review for project 5:
+keyorix access-review --project-id 5
+```
+
 ## Deployment Scenarios
 
 ### Development Environment

--- a/internal/cli/accessreview/accessreview.go
+++ b/internal/cli/accessreview/accessreview.go
@@ -1,0 +1,86 @@
+// Package accessreview provides `keyorix access-review` — the role-based access
+// recertification report for a project (ISO 27001 A.5.18 / SOC 2 CC6.2-6.3): who
+// (user or group) can reach the project's secrets via an assigned role, and at
+// what level. Talks to GET /api/v1/projects/{id}/access-review (gated by
+// roles.read at the project scope).
+package accessreview
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/spf13/cobra"
+)
+
+var flagProject int
+
+// AccessReviewCmd is the `keyorix access-review` command.
+var AccessReviewCmd = &cobra.Command{
+	Use:     "access-review",
+	Aliases: []string{"access-recert", "recert"},
+	Short:   "Review who has role-based access to a project's secrets (ISO 27001 A.5.18)",
+	Long: `List every principal (user or group) that can reach a project's secrets via an
+assigned role, with the highest secrets action that role grants — the role-based
+standing-access surface for periodic access recertification. Requires roles.read
+at the project scope.`,
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		if flagProject <= 0 {
+			return fmt.Errorf("--project-id is required")
+		}
+		c, ok := common.NewRemoteClient()
+		if !ok {
+			return fmt.Errorf("not connected to a server — run: keyorix connect <server>")
+		}
+		var out struct {
+			Entries []entryView `json:"entries"`
+			Count   int         `json:"count"`
+		}
+		if err := c.Get(context.Background(), "/api/v1/projects/"+strconv.Itoa(flagProject)+"/access-review", &out); err != nil {
+			return err
+		}
+		if len(out.Entries) == 0 {
+			fmt.Printf("No role-based access to project %d's secrets.\n", flagProject)
+			return nil
+		}
+		fmt.Printf("Role-based access review — project %d (%d principal grant(s)):\n\n", flagProject, len(out.Entries))
+		fmt.Printf("%-7s %-24s %-16s %-8s %s\n", "TYPE", "PRINCIPAL", "ROLE", "ACCESS", "SCOPE")
+		for _, e := range out.Entries {
+			scope := "project"
+			if e.EnvironmentID > 0 {
+				scope = fmt.Sprintf("env=%d", e.EnvironmentID)
+			}
+			principal := e.PrincipalName
+			if e.PrincipalType == "user" && e.Email != "" {
+				principal = fmt.Sprintf("%s <%s>", e.PrincipalName, e.Email)
+			}
+			fmt.Printf("%-7s %-24s %-16s %-8s %s\n", e.PrincipalType, truncate(principal, 24), e.RoleName, e.AccessLevel, scope)
+		}
+		return nil
+	},
+}
+
+type entryView struct {
+	PrincipalType string `json:"principal_type"`
+	PrincipalName string `json:"principal_name"`
+	Email         string `json:"email"`
+	RoleName      string `json:"role_name"`
+	AccessLevel   string `json:"access_level"`
+	EnvironmentID uint   `json:"environment_id"`
+}
+
+func init() {
+	AccessReviewCmd.Flags().IntVar(&flagProject, "project-id", 0, "Project to review (required)")
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	if n <= 1 {
+		return s[:n]
+	}
+	return s[:n-1] + "…"
+}

--- a/internal/cli/accessreview/accessreview_test.go
+++ b/internal/cli/accessreview/accessreview_test.go
@@ -1,0 +1,37 @@
+package accessreview
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAccessReview_Wiring(t *testing.T) {
+	assert.Equal(t, "access-review", AccessReviewCmd.Name())
+	assert.Contains(t, AccessReviewCmd.Aliases, "recert")
+	assert.NotNil(t, AccessReviewCmd.Flags().Lookup("project-id"))
+}
+
+func TestAccessReview_RequiresProject(t *testing.T) {
+	flagProject = 0
+	err := AccessReviewCmd.RunE(AccessReviewCmd, nil)
+	require.ErrorContains(t, err, "--project-id is required")
+}
+
+func TestAccessReview_GetsProjectReview(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_, _ = w.Write([]byte(`{"data":{"entries":[{"principal_type":"user","principal_name":"alice","email":"a@x.io","role_name":"editor","access_level":"write","environment_id":0},{"principal_type":"group","principal_name":"devs","role_name":"viewer","access_level":"read","environment_id":0}],"count":2}}`))
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+
+	flagProject = 7
+	require.NoError(t, AccessReviewCmd.RunE(AccessReviewCmd, nil))
+	assert.Equal(t, "/api/v1/projects/7/access-review", gotPath)
+}

--- a/internal/cli/main.go
+++ b/internal/cli/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/keyorixhq/keyorix/internal/cli/accessreview"
 	"github.com/keyorixhq/keyorix/internal/cli/anomalies"
 	"github.com/keyorixhq/keyorix/internal/cli/audit"
 	"github.com/keyorixhq/keyorix/internal/cli/auth"
@@ -63,6 +64,7 @@ func init() {
 	rootCmd.AddCommand(pat.PATCmd)
 	rootCmd.AddCommand(audit.AuditCmd)
 	rootCmd.AddCommand(rotation.RotationCmd)
+	rootCmd.AddCommand(accessreview.AccessReviewCmd)
 }
 
 // Execute runs the root command

--- a/internal/core/access_review.go
+++ b/internal/core/access_review.go
@@ -1,0 +1,124 @@
+// access_review.go — access recertification (ISO 27001 A.5.18 / SOC 2 CC6.2-6.3).
+//
+// GenerateProjectAccessReview enumerates the *role-based* standing access to a
+// project's secrets: every project-scoped role grant (to a user or a group) whose
+// role confers a secrets.* permission, with the highest secrets action it grants.
+// This is the primary recertification surface — "who can reach this project's
+// secrets via their assigned role, and at what level". Per-secret share grants
+// (the granular exceptions) are a separate review surface.
+package core
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// AccessReviewEntry is one principal's role-based access to a project's secrets.
+type AccessReviewEntry struct {
+	PrincipalType string `json:"principal_type"` // "user" | "group"
+	PrincipalID   uint   `json:"principal_id"`
+	PrincipalName string `json:"principal_name"` // username or group name
+	Email         string `json:"email,omitempty"`
+	RoleName      string `json:"role_name"`
+	AccessLevel   string `json:"access_level"`   // highest secrets.* action: read|write|delete|admin
+	EnvironmentID uint   `json:"environment_id"` // 0 = the whole project
+}
+
+// secretsActionRank orders secrets.* actions so a review reports the strongest
+// access a role confers.
+var secretsActionRank = map[string]int{"read": 1, "write": 2, "delete": 3, "admin": 4}
+
+// highestSecretsAction returns the strongest secrets.* action in a permission set,
+// or "" when the role grants no secret access at all.
+func highestSecretsAction(perms []*models.Permission) string {
+	best, bestRank := "", 0
+	for _, p := range perms {
+		if p.Resource != "secrets" {
+			continue
+		}
+		if r := secretsActionRank[p.Action]; r > bestRank {
+			best, bestRank = p.Action, r
+		}
+	}
+	return best
+}
+
+// GenerateProjectAccessReview returns the role-based access principals for a
+// project's secrets (ISO 27001 A.5.18). Each entry is a (principal, role) grant
+// scoped to the project whose role confers a secrets.* permission. A principal
+// with several qualifying roles yields several entries.
+func (c *KeyorixCore) GenerateProjectAccessReview(ctx context.Context, projectID uint) ([]*AccessReviewEntry, error) {
+	if projectID == 0 {
+		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "project ID is required")
+	}
+
+	assignments, err := c.storage.ListProjectRoleAssignments(ctx, projectID)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+
+	type roleInfo struct{ name, action string }
+	roleCache := map[uint]roleInfo{}
+	resolveRole := func(roleID uint) (roleInfo, error) {
+		if ri, ok := roleCache[roleID]; ok {
+			return ri, nil
+		}
+		perms, err := c.storage.GetRolePermissions(ctx, roleID)
+		if err != nil {
+			return roleInfo{}, err
+		}
+		ri := roleInfo{action: highestSecretsAction(perms)}
+		if role, err := c.storage.GetRole(ctx, roleID); err == nil && role != nil {
+			ri.name = role.Name
+		}
+		roleCache[roleID] = ri
+		return ri, nil
+	}
+
+	userNames := map[uint][2]string{} // id -> {name, email}
+	groupNames := map[uint]string{}
+
+	var entries []*AccessReviewEntry
+	for _, a := range assignments {
+		ri, err := resolveRole(a.RoleID)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+		}
+		if ri.action == "" {
+			continue // role grants no secret access — not a secret-access reviewer
+		}
+
+		entry := &AccessReviewEntry{
+			PrincipalType: a.PrincipalType,
+			PrincipalID:   a.PrincipalID,
+			RoleName:      ri.name,
+			AccessLevel:   ri.action,
+			EnvironmentID: a.EnvironmentID,
+		}
+		switch a.PrincipalType {
+		case "group":
+			name, ok := groupNames[a.PrincipalID]
+			if !ok {
+				if g, err := c.storage.GetGroup(ctx, a.PrincipalID); err == nil && g != nil {
+					name = g.Name
+				}
+				groupNames[a.PrincipalID] = name
+			}
+			entry.PrincipalName = name
+		default: // user
+			ne, ok := userNames[a.PrincipalID]
+			if !ok {
+				if u, err := c.storage.GetUser(ctx, a.PrincipalID); err == nil && u != nil {
+					ne = [2]string{u.Username, u.Email}
+				}
+				userNames[a.PrincipalID] = ne
+			}
+			entry.PrincipalName, entry.Email = ne[0], ne[1]
+		}
+		entries = append(entries, entry)
+	}
+	return entries, nil
+}

--- a/internal/core/access_review_external_test.go
+++ b/internal/core/access_review_external_test.go
@@ -1,0 +1,54 @@
+package core_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/testhelper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func uptr(u uint) *uint { return &u }
+
+// GenerateProjectAccessReview reports every project-scoped role grant whose role
+// confers a secrets.* permission (users and groups), with the highest action, and
+// excludes roles that grant no secret access.
+func TestGenerateProjectAccessReview(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+
+	const proj = uint(2)
+	// alice: editor (secrets.read+write) at project 2 → write.
+	h.CreateTestUser(t, "alice", 10)
+	h.AssignUserRole(t, 10, 3, uptr(proj))
+	// bob: auditor (audit.read, NO secrets.*) at project 2 → excluded.
+	h.CreateTestUser(t, "bob", 11)
+	h.AssignUserRole(t, 11, 5, uptr(proj))
+	// carol: viewer (secrets.read) at a DIFFERENT project → excluded from project 2.
+	h.CreateTestUser(t, "carol", 12)
+	h.AssignUserRole(t, 12, 4, uptr(uint(3)))
+	// devs group: viewer (secrets.read) at project 2 → read.
+	h.CreateTestGroup(t, "devs", "", 100)
+	h.AssignGroupRole(t, 100, 4, uptr(proj))
+
+	review, err := h.CoreService.GenerateProjectAccessReview(context.Background(), proj)
+	require.NoError(t, err)
+
+	type got struct{ typ, name, level string }
+	var rows []got
+	for _, e := range review {
+		rows = append(rows, got{e.PrincipalType, e.PrincipalName, e.AccessLevel})
+	}
+	assert.ElementsMatch(t, []got{
+		{"user", "alice", "write"},
+		{"group", "devs", "read"},
+	}, rows, "alice (editor→write) and the devs group (viewer→read); bob (auditor, no secrets) and carol (other project) excluded")
+}
+
+func TestGenerateProjectAccessReview_RequiresProject(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	_, err := h.CoreService.GenerateProjectAccessReview(context.Background(), 0)
+	require.Error(t, err)
+}

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -100,6 +100,14 @@ func (m *MockStorage) ListProjectMembers(_ context.Context, _ uint) ([]storage.P
 	return nil, nil
 }
 
+func (m *MockStorage) ListProjectRoleAssignments(ctx context.Context, projectID uint) ([]storage.RoleAssignment, error) {
+	args := m.Called(ctx, projectID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]storage.RoleAssignment), args.Error(1)
+}
+
 func (m *MockStorage) CreateProjectInvitation(ctx context.Context, inv *models.ProjectInvitation) (*models.ProjectInvitation, error) {
 	args := m.Called(ctx, inv)
 	if args.Get(0) == nil {
@@ -1254,9 +1262,9 @@ func (m *MockStorage) UpsertMFASecret(_ context.Context, _ *models.MFASecret) er
 func (m *MockStorage) GetMFASecret(_ context.Context, _ uint) (*models.MFASecret, error) {
 	return nil, nil
 }
-func (m *MockStorage) ActivateMFASecret(_ context.Context, _ uint) error          { return nil }
-func (m *MockStorage) DeleteMFAForUser(_ context.Context, _ uint) error            { return nil }
-func (m *MockStorage) SetUserMFAEnabled(_ context.Context, _ uint, _ bool) error   { return nil }
+func (m *MockStorage) ActivateMFASecret(_ context.Context, _ uint) error         { return nil }
+func (m *MockStorage) DeleteMFAForUser(_ context.Context, _ uint) error          { return nil }
+func (m *MockStorage) SetUserMFAEnabled(_ context.Context, _ uint, _ bool) error { return nil }
 func (m *MockStorage) CreateMFARecoveryCodes(_ context.Context, _ uint, _ []string) error {
 	return nil
 }

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -42,6 +42,11 @@ type Storage interface {
 	ListEnvironmentsByProject(ctx context.Context, projectID uint) ([]*models.Environment, error)
 	ListEnvironmentsByProjectIncludingDeleted(ctx context.Context, projectID uint) ([]*models.Environment, error)
 	ListProjectMembers(ctx context.Context, projectID uint) ([]ProjectMember, error)
+	// ListProjectRoleAssignments returns every direct (user) and group role grant
+	// scoped to the project (project_id = projectID, any environment) — the raw
+	// rows for a project access review. Global (project 0) grants are excluded:
+	// those are install-level, reviewed separately.
+	ListProjectRoleAssignments(ctx context.Context, projectID uint) ([]RoleAssignment, error)
 
 	// Project invitations (ADR-024).
 	CreateProjectInvitation(ctx context.Context, inv *models.ProjectInvitation) (*models.ProjectInvitation, error)
@@ -618,4 +623,16 @@ type ProjectMember struct {
 	Email       string `json:"email"`
 	RoleID      uint   `json:"role_id"`
 	RoleName    string `json:"role_name"`
+}
+
+// RoleAssignment is one principal↔role grant at a scope — the raw rows behind an
+// access review (ISO 27001 A.5.18). Unlike ProjectMember it does NOT collapse a
+// principal to a single role: a user/group with several roles at a scope yields
+// several RoleAssignments. PrincipalType is "user" or "group".
+type RoleAssignment struct {
+	PrincipalType string `json:"principal_type"`
+	PrincipalID   uint   `json:"principal_id"`
+	RoleID        uint   `json:"role_id"`
+	ProjectID     uint   `json:"project_id"`
+	EnvironmentID uint   `json:"environment_id"`
 }

--- a/internal/storage/store/local_rbac.go
+++ b/internal/storage/store/local_rbac.go
@@ -162,6 +162,38 @@ func (ls *LocalStorage) GetUserRoleIDsAt(ctx context.Context, userID uint, scope
 	return ids, nil
 }
 
+// ListProjectRoleAssignments returns every role assignment scoped to the project
+// (project_id = projectID, any environment) for both users (user_roles) and groups
+// (group_roles) — the raw grant rows behind a project access review. Global
+// (project 0) assignments are deliberately excluded (install-level, reviewed
+// separately). A principal with several roles at the project yields several rows.
+func (ls *LocalStorage) ListProjectRoleAssignments(ctx context.Context, projectID uint) ([]storage.RoleAssignment, error) {
+	var out []storage.RoleAssignment
+
+	var userRows []models.UserRole
+	if err := ls.db.WithContext(ctx).Where("project_id = ?", projectID).Find(&userRows).Error; err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	for _, r := range userRows {
+		out = append(out, storage.RoleAssignment{
+			PrincipalType: "user", PrincipalID: r.UserID, RoleID: r.RoleID,
+			ProjectID: r.ProjectID, EnvironmentID: r.EnvironmentID,
+		})
+	}
+
+	var groupRows []models.GroupRole
+	if err := ls.db.WithContext(ctx).Where("project_id = ?", projectID).Find(&groupRows).Error; err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	for _, r := range groupRows {
+		out = append(out, storage.RoleAssignment{
+			PrincipalType: "group", PrincipalID: r.GroupID, RoleID: r.RoleID,
+			ProjectID: r.ProjectID, EnvironmentID: r.EnvironmentID,
+		})
+	}
+	return out, nil
+}
+
 // GetUserRoleIDsExact returns the IDs of roles directly assigned to userID at
 // exactly the given scope (no global/inherited matching). Used for full
 // replacement of a user's roles at one scope.

--- a/internal/storage/store/remote_rbac.go
+++ b/internal/storage/store/remote_rbac.go
@@ -365,6 +365,10 @@ func (rs *RemoteStorage) ListProjectMembers(_ context.Context, _ uint) ([]storag
 	return nil, remoteUnsupported("ListProjectMembers")
 }
 
+func (rs *RemoteStorage) ListProjectRoleAssignments(_ context.Context, _ uint) ([]storage.RoleAssignment, error) {
+	return nil, remoteUnsupported("ListProjectRoleAssignments")
+}
+
 func (rs *RemoteStorage) GetEnvironment(_ context.Context, _ uint) (*models.Environment, error) {
 	return nil, remoteUnsupported("GetEnvironment")
 }

--- a/server/http/handlers/openapi.yaml
+++ b/server/http/handlers/openapi.yaml
@@ -503,6 +503,29 @@ paths:
         '400': {$ref: '#/components/responses/Error'}
         '401': {$ref: '#/components/responses/Error'}
 
+  /api/v1/projects/{id}/access-review:
+    get:
+      tags: [Projects]
+      summary: Role-based access recertification report (ISO 27001 A.5.18)
+      description: >-
+        Every project-scoped role grant (user or group) whose role confers a
+        secrets.* permission, with the highest action it grants — the role-based
+        standing-access surface for periodic access reviews. Requires roles.read at
+        the project scope.
+      operationId: getProjectAccessReview
+      security: [{bearerAuth: []}]
+      parameters:
+        - {name: id, in: path, required: true, schema: {type: integer, format: uint32}}
+      responses:
+        '200':
+          description: >-
+            Envelope {data, message}. data: {entries[], count}; each entry is
+            {principal_type (user|group), principal_id, principal_name, email,
+            role_name, access_level (read|write|delete|admin), environment_id}.
+        '400': {$ref: '#/components/responses/Error'}
+        '401': {$ref: '#/components/responses/Error'}
+        '403': {$ref: '#/components/responses/Error'}
+
   /api/v1/projects/{id}/members:
     get:
       tags: [Members]

--- a/server/http/handlers/project_members.go
+++ b/server/http/handlers/project_members.go
@@ -24,6 +24,23 @@ func (h *CatalogHandler) ListProjectMembers(w http.ResponseWriter, r *http.Reque
 	sendSuccess(w, map[string]interface{}{"members": members}, "")
 }
 
+// GetProjectAccessReview handles GET /api/v1/projects/{id}/access-review — the
+// role-based access recertification report (ISO 27001 A.5.18): every project-scoped
+// role grant whose role confers a secrets.* permission, with the highest action.
+func (h *CatalogHandler) GetProjectAccessReview(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		sendError(w, "InvalidParameter", "Invalid project ID", http.StatusBadRequest, nil)
+		return
+	}
+	entries, err := h.coreService.GenerateProjectAccessReview(r.Context(), uint(id))
+	if err != nil {
+		sendError(w, "Error", err.Error(), http.StatusInternalServerError, nil)
+		return
+	}
+	sendSuccess(w, map[string]interface{}{"entries": entries, "count": len(entries)}, "")
+}
+
 // AddProjectMember handles POST /api/v1/projects/{id}/members
 func (h *CatalogHandler) AddProjectMember(w http.ResponseWriter, r *http.Request) {
 	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -197,6 +197,7 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		// view the roster; mutations require roles.assign at the project scope, so
 		// a project_admin can manage their own project's members.
 		r.With(customMiddleware.RequireScopedPermission("users.read", projectScope)).Get("/projects/{id}/members", catalogHandler.ListProjectMembers)
+		r.With(customMiddleware.RequireScopedPermission("roles.read", projectScope)).Get("/projects/{id}/access-review", catalogHandler.GetProjectAccessReview)
 		r.With(customMiddleware.RequireScopedPermission("roles.assign", projectScope)).Post("/projects/{id}/members", catalogHandler.AddProjectMember)
 		r.With(customMiddleware.RequireScopedPermission("roles.assign", projectScope)).Put("/projects/{id}/members/{userId}", catalogHandler.UpdateProjectMember)
 		r.With(customMiddleware.RequireScopedPermission("roles.assign", projectScope)).Delete("/projects/{id}/members/{userId}", catalogHandler.RemoveProjectMember)


### PR DESCRIPTION
## What

First deliverable of the access-recertification roadmap. Answers the question a security review (ISO 27001 **A.5.18**, SOC 2 CC6.2–6.3, NIS2) always asks and Keyorix couldn't: **"who can reach this project's secrets via an assigned role, and at what level?"**

- **Storage** — `ListProjectRoleAssignments(projectID)` enumerates every project-scoped `user_roles` + `group_roles` grant. Unlike `ListProjectMembers` it does **not** collapse a principal to a single role (a user/group with several roles yields several rows); global/install-level grants are excluded (reviewed separately).
- **Core** — `GenerateProjectAccessReview` resolves each grant's role to its highest `secrets.*` action (`read` < `write` < `delete` < `admin`), drops roles with no secret access, and resolves user/group names.
- **API** — `GET /api/v1/projects/{id}/access-review`, gated by `roles.read` at the project scope. **Read-only — no access-control change.**
- **CLI** — `keyorix access-review --project-id N` (alias `recert`) prints the review table.

## Tests

Core via the real RBAC helper: an `editor`→write user and a `viewer`→read group are reported; an `auditor` role (no `secrets.*`) and a grant in a *different* project are excluded. CLI wiring + httptest GET + project-id-required. gofmt clean, golangci-lint 0, full suites green; openapi + REMOTE_CLI_SETUP updated.

## Roadmap (you picked 1 → 2 → 3)
This is **1a** (role-based standing access). Next: **1b** share-based per-secret grants (the granular exceptions), then **1c** attest/revoke workflow; then **2** just-in-time/time-bound access; then **3** surface in the web UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)