### PR TITLE
feat(access-review): add per-secret owner + share grants (1b)

### DIFF
--- a/docs/REMOTE_CLI_SETUP.md
+++ b/docs/REMOTE_CLI_SETUP.md
@@ -193,10 +193,10 @@ Periodic access recertification (ISO 27001 A.5.18 / SOC 2 CC6.2–6.3): review w
 can reach a project's secrets via an assigned role. Requires `roles.read` at the
 project scope.
 
-- `keyorix access-review --project-id N` (aliases `recert`) — lists every principal
-  (user or group) with role-based access to project N's secrets, the role granting
-  it, and the highest secrets action (read/write/delete/admin). Share-based grants
-  (per-secret) are a separate review surface (planned).
+- `keyorix access-review --project-id N` (aliases `recert`) — lists every grant of
+  access to project N's secrets: role-based standing access (the role granting it +
+  the highest secrets action) and per-secret grants (ownership and direct/group
+  shares). The `SOURCE` column says which mechanism conferred each grant.
 
 ```bash
 # Quarterly access review for project 5:

--- a/internal/cli/accessreview/accessreview.go
+++ b/internal/cli/accessreview/accessreview.go
@@ -42,21 +42,28 @@ at the project scope.`,
 			return err
 		}
 		if len(out.Entries) == 0 {
-			fmt.Printf("No role-based access to project %d's secrets.\n", flagProject)
+			fmt.Printf("No access to project %d's secrets.\n", flagProject)
 			return nil
 		}
-		fmt.Printf("Role-based access review — project %d (%d principal grant(s)):\n\n", flagProject, len(out.Entries))
-		fmt.Printf("%-7s %-24s %-16s %-8s %s\n", "TYPE", "PRINCIPAL", "ROLE", "ACCESS", "SCOPE")
+		fmt.Printf("Access review — project %d (%d grant(s)):\n\n", flagProject, len(out.Entries))
+		fmt.Printf("%-13s %-6s %-26s %-7s %s\n", "SOURCE", "TYPE", "PRINCIPAL", "ACCESS", "DETAIL")
 		for _, e := range out.Entries {
-			scope := "project"
-			if e.EnvironmentID > 0 {
-				scope = fmt.Sprintf("env=%d", e.EnvironmentID)
-			}
 			principal := e.PrincipalName
 			if e.PrincipalType == "user" && e.Email != "" {
 				principal = fmt.Sprintf("%s <%s>", e.PrincipalName, e.Email)
 			}
-			fmt.Printf("%-7s %-24s %-16s %-8s %s\n", e.PrincipalType, truncate(principal, 24), e.RoleName, e.AccessLevel, scope)
+			detail := ""
+			switch e.Source {
+			case "role":
+				scope := "project"
+				if e.EnvironmentID > 0 {
+					scope = fmt.Sprintf("env=%d", e.EnvironmentID)
+				}
+				detail = fmt.Sprintf("role=%s (%s)", e.RoleName, scope)
+			default: // owner / direct_share / group_share
+				detail = "secret=" + e.SecretName
+			}
+			fmt.Printf("%-13s %-6s %-26s %-7s %s\n", e.Source, e.PrincipalType, truncate(principal, 26), e.AccessLevel, detail)
 		}
 		return nil
 	},
@@ -66,9 +73,11 @@ type entryView struct {
 	PrincipalType string `json:"principal_type"`
 	PrincipalName string `json:"principal_name"`
 	Email         string `json:"email"`
+	Source        string `json:"source"`
 	RoleName      string `json:"role_name"`
 	AccessLevel   string `json:"access_level"`
 	EnvironmentID uint   `json:"environment_id"`
+	SecretName    string `json:"secret_name"`
 }
 
 func init() {

--- a/internal/core/access_review.go
+++ b/internal/core/access_review.go
@@ -1,30 +1,38 @@
 // access_review.go — access recertification (ISO 27001 A.5.18 / SOC 2 CC6.2-6.3).
 //
-// GenerateProjectAccessReview enumerates the *role-based* standing access to a
-// project's secrets: every project-scoped role grant (to a user or a group) whose
-// role confers a secrets.* permission, with the highest secrets action it grants.
-// This is the primary recertification surface — "who can reach this project's
-// secrets via their assigned role, and at what level". Per-secret share grants
-// (the granular exceptions) are a separate review surface.
+// GenerateProjectAccessReview enumerates who can reach a project's secrets and how:
+// the role-based standing access (project-scoped role grants whose role confers a
+// secrets.* permission) plus the per-secret grants (ownership and direct/group
+// shares). Each entry's Source says which mechanism conferred the access.
 package core
 
 import (
 	"context"
 	"fmt"
 
+	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
-// AccessReviewEntry is one principal's role-based access to a project's secrets.
+// AccessReviewEntry is one grant of access to a project's secrets, for an access
+// review. Source distinguishes how the access is conferred:
+//   - "role"          — a project-scoped role grant (project-wide; SecretID 0,
+//     RoleName set, AccessLevel = the role's highest secrets.* action)
+//   - "owner"         — the principal owns a specific secret (SecretID set)
+//   - "direct_share"  — a secret shared directly with a user (SecretID set)
+//   - "group_share"   — a secret shared with a group (SecretID set)
 type AccessReviewEntry struct {
 	PrincipalType string `json:"principal_type"` // "user" | "group"
 	PrincipalID   uint   `json:"principal_id"`
 	PrincipalName string `json:"principal_name"` // username or group name
 	Email         string `json:"email,omitempty"`
-	RoleName      string `json:"role_name"`
-	AccessLevel   string `json:"access_level"`   // highest secrets.* action: read|write|delete|admin
-	EnvironmentID uint   `json:"environment_id"` // 0 = the whole project
+	Source        string `json:"source"` // role | owner | direct_share | group_share
+	RoleName      string `json:"role_name,omitempty"`
+	AccessLevel   string `json:"access_level"`   // read|write|delete|admin (role) or read|write|owner (share)
+	EnvironmentID uint   `json:"environment_id"` // 0 = the whole project (role grants)
+	SecretID      uint   `json:"secret_id,omitempty"`
+	SecretName    string `json:"secret_name,omitempty"`
 }
 
 // secretsActionRank orders secrets.* actions so a review reports the strongest
@@ -46,10 +54,10 @@ func highestSecretsAction(perms []*models.Permission) string {
 	return best
 }
 
-// GenerateProjectAccessReview returns the role-based access principals for a
-// project's secrets (ISO 27001 A.5.18). Each entry is a (principal, role) grant
-// scoped to the project whose role confers a secrets.* permission. A principal
-// with several qualifying roles yields several entries.
+// GenerateProjectAccessReview returns every grant of access to a project's secrets
+// (ISO 27001 A.5.18): the role-based standing access (project-scoped role grants
+// whose role confers a secrets.* permission) and the per-secret grants (ownership
+// and direct/group shares). Each entry's Source identifies the mechanism.
 func (c *KeyorixCore) GenerateProjectAccessReview(ctx context.Context, projectID uint) ([]*AccessReviewEntry, error) {
 	if projectID == 0 {
 		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "project ID is required")
@@ -78,10 +86,35 @@ func (c *KeyorixCore) GenerateProjectAccessReview(ctx context.Context, projectID
 		return ri, nil
 	}
 
-	userNames := map[uint][2]string{} // id -> {name, email}
-	groupNames := map[uint]string{}
+	userCache := map[uint][2]string{} // id -> {name, email}
+	resolveUser := func(id uint) (string, string) {
+		if ne, ok := userCache[id]; ok {
+			return ne[0], ne[1]
+		}
+		ne := [2]string{}
+		if u, err := c.storage.GetUser(ctx, id); err == nil && u != nil {
+			ne = [2]string{u.Username, u.Email}
+		}
+		userCache[id] = ne
+		return ne[0], ne[1]
+	}
+	groupCache := map[uint]string{}
+	resolveGroup := func(id uint) string {
+		if n, ok := groupCache[id]; ok {
+			return n
+		}
+		n := ""
+		if g, err := c.storage.GetGroup(ctx, id); err == nil && g != nil {
+			n = g.Name
+		}
+		groupCache[id] = n
+		return n
+	}
 
 	var entries []*AccessReviewEntry
+
+	// (1) Role-based standing access — project-scoped role grants whose role confers
+	// a secrets.* permission. Applies project-wide (no specific secret).
 	for _, a := range assignments {
 		ri, err := resolveRole(a.RoleID)
 		if err != nil {
@@ -90,35 +123,74 @@ func (c *KeyorixCore) GenerateProjectAccessReview(ctx context.Context, projectID
 		if ri.action == "" {
 			continue // role grants no secret access — not a secret-access reviewer
 		}
-
 		entry := &AccessReviewEntry{
 			PrincipalType: a.PrincipalType,
 			PrincipalID:   a.PrincipalID,
+			Source:        "role",
 			RoleName:      ri.name,
 			AccessLevel:   ri.action,
 			EnvironmentID: a.EnvironmentID,
 		}
-		switch a.PrincipalType {
-		case "group":
-			name, ok := groupNames[a.PrincipalID]
-			if !ok {
-				if g, err := c.storage.GetGroup(ctx, a.PrincipalID); err == nil && g != nil {
-					name = g.Name
-				}
-				groupNames[a.PrincipalID] = name
-			}
-			entry.PrincipalName = name
-		default: // user
-			ne, ok := userNames[a.PrincipalID]
-			if !ok {
-				if u, err := c.storage.GetUser(ctx, a.PrincipalID); err == nil && u != nil {
-					ne = [2]string{u.Username, u.Email}
-				}
-				userNames[a.PrincipalID] = ne
-			}
-			entry.PrincipalName, entry.Email = ne[0], ne[1]
+		if a.PrincipalType == "group" {
+			entry.PrincipalName = resolveGroup(a.PrincipalID)
+		} else {
+			entry.PrincipalName, entry.Email = resolveUser(a.PrincipalID)
 		}
 		entries = append(entries, entry)
 	}
+
+	// (2) Per-secret grants — ownership plus direct/group shares (the granular
+	// exceptions, beyond the project's role-based access).
+	secrets, err := c.listAllProjectSecrets(ctx, projectID)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	for _, s := range secrets {
+		if s.OwnerID != 0 {
+			name, email := resolveUser(s.OwnerID)
+			entries = append(entries, &AccessReviewEntry{
+				PrincipalType: "user", PrincipalID: s.OwnerID, PrincipalName: name, Email: email,
+				Source: "owner", AccessLevel: "owner", SecretID: s.ID, SecretName: s.Name,
+			})
+		}
+		shares, err := c.storage.ListSharesBySecret(ctx, s.ID)
+		if err != nil {
+			continue // best-effort; a secret whose shares can't be read is skipped
+		}
+		for _, sh := range shares {
+			e := &AccessReviewEntry{
+				PrincipalID: sh.RecipientID, AccessLevel: sh.Permission,
+				SecretID: s.ID, SecretName: s.Name,
+			}
+			if sh.IsGroup {
+				e.PrincipalType, e.Source = "group", "group_share"
+				e.PrincipalName = resolveGroup(sh.RecipientID)
+			} else {
+				e.PrincipalType, e.Source = "user", "direct_share"
+				e.PrincipalName, e.Email = resolveUser(sh.RecipientID)
+			}
+			entries = append(entries, e)
+		}
+	}
 	return entries, nil
+}
+
+// listAllProjectSecrets pages through every secret in a project (no silent cap).
+func (c *KeyorixCore) listAllProjectSecrets(ctx context.Context, projectID uint) ([]*models.SecretNode, error) {
+	const pageSize = 500
+	pid := projectID
+	var all []*models.SecretNode
+	for page := 1; ; page++ {
+		secrets, total, err := c.storage.ListSecrets(ctx, &storage.SecretFilter{
+			ProjectID: &pid, Page: page, PageSize: pageSize,
+		})
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, secrets...)
+		if len(secrets) < pageSize || int64(len(all)) >= total {
+			break
+		}
+	}
+	return all, nil
 }

--- a/internal/core/access_review_external_test.go
+++ b/internal/core/access_review_external_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/keyorixhq/keyorix/internal/testhelper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -44,6 +45,37 @@ func TestGenerateProjectAccessReview(t *testing.T) {
 		{"user", "alice", "write"},
 		{"group", "devs", "read"},
 	}, rows, "alice (editor→write) and the devs group (viewer→read); bob (auditor, no secrets) and carol (other project) excluded")
+}
+
+// The review also reports per-secret grants: ownership and direct/group shares.
+func TestGenerateProjectAccessReview_SharesAndOwnership(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(&models.SecretNode{}, &models.Environment{}, &models.ShareRecord{}))
+
+	const proj = uint(2)
+	h.CreateTestUser(t, "alice", 10) // owner
+	h.CreateTestUser(t, "bob", 11)   // direct-share recipient
+	h.CreateTestGroup(t, "devs", "", 100)
+
+	require.NoError(t, h.DB.Create(&models.Environment{ID: 20, ProjectID: proj, Name: "prod"}).Error)
+	require.NoError(t, h.DB.Create(&models.SecretNode{
+		ID: 500, ProjectID: proj, EnvironmentID: 20, OwnerID: 10, Name: "db-pw", Type: "password", Status: "active", IsSecret: true,
+	}).Error)
+	require.NoError(t, h.DB.Create(&models.ShareRecord{SecretID: 500, RecipientID: 11, IsGroup: false, Permission: "read"}).Error)
+	require.NoError(t, h.DB.Create(&models.ShareRecord{SecretID: 500, RecipientID: 100, IsGroup: true, Permission: "write"}).Error)
+
+	review, err := h.CoreService.GenerateProjectAccessReview(context.Background(), proj)
+	require.NoError(t, err)
+
+	type got struct{ source, typ, name, level, secret string }
+	var rows []got
+	for _, e := range review {
+		rows = append(rows, got{e.Source, e.PrincipalType, e.PrincipalName, e.AccessLevel, e.SecretName})
+	}
+	assert.Contains(t, rows, got{"owner", "user", "alice", "owner", "db-pw"})
+	assert.Contains(t, rows, got{"direct_share", "user", "bob", "read", "db-pw"})
+	assert.Contains(t, rows, got{"group_share", "group", "devs", "write", "db-pw"})
 }
 
 func TestGenerateProjectAccessReview_RequiresProject(t *testing.T) {

--- a/server/http/handlers/openapi.yaml
+++ b/server/http/handlers/openapi.yaml
@@ -506,12 +506,12 @@ paths:
   /api/v1/projects/{id}/access-review:
     get:
       tags: [Projects]
-      summary: Role-based access recertification report (ISO 27001 A.5.18)
+      summary: Access recertification report (ISO 27001 A.5.18)
       description: >-
-        Every project-scoped role grant (user or group) whose role confers a
-        secrets.* permission, with the highest action it grants — the role-based
-        standing-access surface for periodic access reviews. Requires roles.read at
-        the project scope.
+        Who can reach the project's secrets and how: role-based standing access
+        (project-scoped role grants conferring a secrets.* permission) plus the
+        per-secret grants (ownership and direct/group shares). Requires roles.read
+        at the project scope.
       operationId: getProjectAccessReview
       security: [{bearerAuth: []}]
       parameters:
@@ -521,7 +521,8 @@ paths:
           description: >-
             Envelope {data, message}. data: {entries[], count}; each entry is
             {principal_type (user|group), principal_id, principal_name, email,
-            role_name, access_level (read|write|delete|admin), environment_id}.
+            source (role|owner|direct_share|group_share), role_name, access_level,
+            environment_id, secret_id, secret_name}.
         '400': {$ref: '#/components/responses/Error'}
         '401': {$ref: '#/components/responses/Error'}
         '403': {$ref: '#/components/responses/Error'}


### PR DESCRIPTION
## What (roadmap 1b)

Enriches the project access review (#169 = 1a, role-based) with the **granular per-secret grants**: each secret's **owner** and its **direct/group shares**. Every entry now carries a `Source` — `role` | `owner` | `direct_share` | `group_share` — plus the secret it concerns. Together this is the complete *"who can reach this project's secrets, and how"* for an ISO 27001 A.5.18 review.

- `GenerateProjectAccessReview` pages through **all** project secrets (no silent cap) and emits an owner entry per owned secret + a share entry per direct/group share. Groups are reported as the group principal (not expanded to members — you recertify the *grant*). Name resolution cached.
- `AccessReviewEntry` gains `Source`, `SecretID`, `SecretName`.
- CLI table reworked to `SOURCE | TYPE | PRINCIPAL | ACCESS | DETAIL`.

## Tests

A secret owned by a user, with a direct share and a group share, yields the owner + direct_share + group_share entries (with the secret name); the existing role-based test is unchanged. gofmt clean, golangci-lint 0, suites green; openapi + docs updated.

## Roadmap
1a ✅ (#169) → **1b (this)** → 1c attest/revoke → 2 JIT/time-bound → 3 web UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)