### PR TITLE
feat(access-review): attest/revoke decisions — close the recertification loop (1c)

### DIFF
--- a/docs/REMOTE_CLI_SETUP.md
+++ b/docs/REMOTE_CLI_SETUP.md
@@ -198,9 +198,33 @@ project scope.
   the highest secrets action) and per-secret grants (ownership and direct/group
   shares). The `SOURCE` column says which mechanism conferred each grant.
 
+Close the recertification loop by acting on each grant — every decision is audited
+(`access_review.attested` / `access_review.revoked`):
+
+- `keyorix access-review attest --project-id N --source <role|direct_share|group_share>
+  --principal-id P [--role-id R | --secret-id S]` — certify a grant was reviewed and
+  intentionally kept (audit-only, the evidence of recertification; changes no
+  access). Requires `roles.read`.
+- `keyorix access-review revoke --project-id N --source <role|direct_share|group_share>
+  --principal-id P [--role-id R | --secret-id S] [--environment-id E]
+  [--principal-type user|group]` — remove the grant: a project-scoped role
+  assignment (`--source role --role-id R`) or a secret share (`--source
+  direct_share|group_share --secret-id S`). Ownership cannot be revoked here.
+  Requires `roles.assign`.
+
 ```bash
 # Quarterly access review for project 5:
 keyorix access-review --project-id 5
+
+# Keep alice's editor role (role 3) — record the attestation:
+keyorix access-review attest --project-id 5 --source role --principal-id 42 --role-id 3
+
+# Revoke the devs group's (group 100) editor role at project 5:
+keyorix access-review revoke --project-id 5 --source role --principal-type group \
+  --principal-id 100 --role-id 3
+
+# Revoke a direct share of secret 500 from user 42:
+keyorix access-review revoke --project-id 5 --source direct_share --principal-id 42 --secret-id 500
 ```
 
 ## Deployment Scenarios

--- a/internal/cli/accessreview/accessreview.go
+++ b/internal/cli/accessreview/accessreview.go
@@ -71,17 +71,113 @@ at the project scope.`,
 
 type entryView struct {
 	PrincipalType string `json:"principal_type"`
+	PrincipalID   uint   `json:"principal_id"`
 	PrincipalName string `json:"principal_name"`
 	Email         string `json:"email"`
 	Source        string `json:"source"`
+	RoleID        uint   `json:"role_id"`
 	RoleName      string `json:"role_name"`
 	AccessLevel   string `json:"access_level"`
 	EnvironmentID uint   `json:"environment_id"`
+	SecretID      uint   `json:"secret_id"`
 	SecretName    string `json:"secret_name"`
+}
+
+// decisionFlags are shared by the revoke and attest subcommands to identify one
+// access-review entry. They mirror the columns the report prints.
+var (
+	dProject       int
+	dSource        string
+	dPrincipalType string
+	dPrincipalID   uint
+	dRoleID        uint
+	dEnvironmentID uint
+	dSecretID      uint
+)
+
+// decisionBody is the JSON sent to the revoke/attest endpoints.
+type decisionBody struct {
+	Source        string `json:"source"`
+	PrincipalType string `json:"principal_type,omitempty"`
+	PrincipalID   uint   `json:"principal_id"`
+	RoleID        uint   `json:"role_id,omitempty"`
+	EnvironmentID uint   `json:"environment_id,omitempty"`
+	SecretID      uint   `json:"secret_id,omitempty"`
+}
+
+func runDecision(action string) error {
+	if dProject <= 0 {
+		return fmt.Errorf("--project-id is required")
+	}
+	if dSource == "" {
+		return fmt.Errorf("--source is required (role|direct_share|group_share)")
+	}
+	if dPrincipalID == 0 {
+		return fmt.Errorf("--principal-id is required")
+	}
+	if dSource == "role" && dRoleID == 0 {
+		return fmt.Errorf("--role-id is required when --source=role")
+	}
+	if (dSource == "direct_share" || dSource == "group_share") && dSecretID == 0 {
+		return fmt.Errorf("--secret-id is required when --source=%s", dSource)
+	}
+	c, ok := common.NewRemoteClient()
+	if !ok {
+		return fmt.Errorf("not connected to a server — run: keyorix connect <server>")
+	}
+	body := decisionBody{
+		Source: dSource, PrincipalType: dPrincipalType, PrincipalID: dPrincipalID,
+		RoleID: dRoleID, EnvironmentID: dEnvironmentID, SecretID: dSecretID,
+	}
+	path := fmt.Sprintf("/api/v1/projects/%d/access-review/%s", dProject, action)
+	var out struct{}
+	if err := c.Post(context.Background(), path, body, &out); err != nil {
+		return err
+	}
+	verb := "Revoked"
+	if action == "attest" {
+		verb = "Attested"
+	}
+	fmt.Printf("%s %s grant for %s %d in project %d.\n", verb, dSource, dPrincipalType, dPrincipalID, dProject)
+	return nil
+}
+
+var revokeCmd = &cobra.Command{
+	Use:   "revoke",
+	Short: "Revoke an access-review grant (remove the role assignment or share)",
+	Long: `Remove the grant identified by the flags — a project-scoped role assignment
+(--source role --role-id N) or a secret share (--source direct_share|group_share
+--secret-id N). The removal is audited (access_review.revoked). Requires
+roles.assign at the project scope.`,
+	SilenceUsage: true,
+	RunE:         func(_ *cobra.Command, _ []string) error { return runDecision("revoke") },
+}
+
+var attestCmd = &cobra.Command{
+	Use:   "attest",
+	Short: "Attest an access-review grant (certify it was reviewed and kept)",
+	Long: `Record that the grant identified by the flags was reviewed and intentionally
+kept — the audit evidence of recertification (access_review.attested). Changes no
+access. Requires roles.read at the project scope.`,
+	SilenceUsage: true,
+	RunE:         func(_ *cobra.Command, _ []string) error { return runDecision("attest") },
+}
+
+func addDecisionFlags(cmd *cobra.Command) {
+	cmd.Flags().IntVar(&dProject, "project-id", 0, "Project the grant belongs to (required)")
+	cmd.Flags().StringVar(&dSource, "source", "", "Grant source: role|direct_share|group_share (required)")
+	cmd.Flags().StringVar(&dPrincipalType, "principal-type", "user", "Principal type: user|group (for role grants)")
+	cmd.Flags().UintVar(&dPrincipalID, "principal-id", 0, "User or group ID the grant is for (required)")
+	cmd.Flags().UintVar(&dRoleID, "role-id", 0, "Role ID (required when --source=role)")
+	cmd.Flags().UintVar(&dEnvironmentID, "environment-id", 0, "Environment scope of a role grant (0 = whole project)")
+	cmd.Flags().UintVar(&dSecretID, "secret-id", 0, "Secret ID (required when --source=direct_share|group_share)")
 }
 
 func init() {
 	AccessReviewCmd.Flags().IntVar(&flagProject, "project-id", 0, "Project to review (required)")
+	addDecisionFlags(revokeCmd)
+	addDecisionFlags(attestCmd)
+	AccessReviewCmd.AddCommand(revokeCmd, attestCmd)
 }
 
 func truncate(s string, n int) string {

--- a/internal/core/access_review.go
+++ b/internal/core/access_review.go
@@ -28,6 +28,7 @@ type AccessReviewEntry struct {
 	PrincipalName string `json:"principal_name"` // username or group name
 	Email         string `json:"email,omitempty"`
 	Source        string `json:"source"` // role | owner | direct_share | group_share
+	RoleID        uint   `json:"role_id,omitempty"`
 	RoleName      string `json:"role_name,omitempty"`
 	AccessLevel   string `json:"access_level"`   // read|write|delete|admin (role) or read|write|owner (share)
 	EnvironmentID uint   `json:"environment_id"` // 0 = the whole project (role grants)
@@ -127,6 +128,7 @@ func (c *KeyorixCore) GenerateProjectAccessReview(ctx context.Context, projectID
 			PrincipalType: a.PrincipalType,
 			PrincipalID:   a.PrincipalID,
 			Source:        "role",
+			RoleID:        a.RoleID,
 			RoleName:      ri.name,
 			AccessLevel:   ri.action,
 			EnvironmentID: a.EnvironmentID,

--- a/internal/core/access_review_external_test.go
+++ b/internal/core/access_review_external_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/keyorixhq/keyorix/internal/testhelper"
 	"github.com/stretchr/testify/assert"
@@ -82,5 +83,106 @@ func TestGenerateProjectAccessReview_RequiresProject(t *testing.T) {
 	h := testhelper.NewRBACTestHelper(t)
 	defer h.Cleanup()
 	_, err := h.CoreService.GenerateProjectAccessReview(context.Background(), 0)
+	require.Error(t, err)
+}
+
+// Revoking a role grant removes the underlying role assignment, so it no longer
+// appears in a subsequent review.
+func TestRevokeAccessReviewGrant_Role(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+
+	const proj = uint(2)
+	h.CreateTestUser(t, "alice", 10)
+	h.AssignUserRole(t, 10, 3, uptr(proj)) // editor → write
+
+	ctx := context.Background()
+	before, err := h.CoreService.GenerateProjectAccessReview(ctx, proj)
+	require.NoError(t, err)
+	require.Len(t, before, 1, "alice's editor grant is present before revoke")
+
+	err = h.CoreService.RevokeAccessReviewGrant(ctx, 1, proj, core.AccessReviewDecision{
+		Source: "role", PrincipalType: "user", PrincipalID: 10, RoleID: 3,
+	})
+	require.NoError(t, err)
+
+	after, err := h.CoreService.GenerateProjectAccessReview(ctx, proj)
+	require.NoError(t, err)
+	assert.Empty(t, after, "alice's role grant is gone after revoke")
+}
+
+// Revoking a group share removes that ShareRecord; revoking ownership is refused.
+func TestRevokeAccessReviewGrant_ShareAndOwner(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(&models.SecretNode{}, &models.Environment{}, &models.ShareRecord{}))
+
+	const proj = uint(2)
+	h.CreateTestUser(t, "alice", 10) // owner
+	h.CreateTestGroup(t, "devs", "", 100)
+	require.NoError(t, h.DB.Create(&models.Environment{ID: 20, ProjectID: proj, Name: "prod"}).Error)
+	require.NoError(t, h.DB.Create(&models.SecretNode{
+		ID: 500, ProjectID: proj, EnvironmentID: 20, OwnerID: 10, Name: "db-pw", Type: "password", Status: "active", IsSecret: true,
+	}).Error)
+	require.NoError(t, h.DB.Create(&models.ShareRecord{SecretID: 500, RecipientID: 100, IsGroup: true, Permission: "write"}).Error)
+
+	ctx := context.Background()
+	// Revoke the group share.
+	err := h.CoreService.RevokeAccessReviewGrant(ctx, 1, proj, core.AccessReviewDecision{
+		Source: "group_share", PrincipalID: 100, SecretID: 500,
+	})
+	require.NoError(t, err)
+
+	review, err := h.CoreService.GenerateProjectAccessReview(ctx, proj)
+	require.NoError(t, err)
+	for _, e := range review {
+		assert.NotEqual(t, "group_share", e.Source, "the group share is gone after revoke")
+	}
+
+	// Ownership cannot be revoked through the review.
+	err = h.CoreService.RevokeAccessReviewGrant(ctx, 1, proj, core.AccessReviewDecision{
+		Source: "owner", PrincipalID: 10, SecretID: 500,
+	})
+	require.Error(t, err)
+
+	// A share that doesn't exist is a not-found error, not a silent success.
+	err = h.CoreService.RevokeAccessReviewGrant(ctx, 1, proj, core.AccessReviewDecision{
+		Source: "direct_share", PrincipalID: 999, SecretID: 500,
+	})
+	require.Error(t, err)
+}
+
+// Attesting a grant changes no access but records an access_review.attested audit
+// event as the evidence of recertification.
+func TestAttestAccessReviewGrant_AuditsDecision(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(&models.AuditEvent{}))
+
+	const proj = uint(2)
+	h.CreateTestUser(t, "alice", 10)
+	h.AssignUserRole(t, 10, 3, uptr(proj))
+
+	ctx := context.Background()
+	err := h.CoreService.AttestAccessReviewGrant(ctx, 1, proj, core.AccessReviewDecision{
+		Source: "role", PrincipalType: "user", PrincipalID: 10, RoleID: 3,
+	})
+	require.NoError(t, err)
+
+	// The grant is untouched — still in the review.
+	review, err := h.CoreService.GenerateProjectAccessReview(ctx, proj)
+	require.NoError(t, err)
+	assert.Len(t, review, 1, "attest does not change access")
+
+	var count int64
+	require.NoError(t, h.DB.Model(&models.AuditEvent{}).
+		Where("event_type = ?", core.EventAccessReviewAttested).Count(&count).Error)
+	assert.Equal(t, int64(1), count, "an access_review.attested event was recorded")
+}
+
+func TestRevokeAccessReviewGrant_RequiresProject(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	err := h.CoreService.RevokeAccessReviewGrant(context.Background(), 1, 0, core.AccessReviewDecision{Source: "role"})
 	require.Error(t, err)
 }

--- a/internal/core/access_review_revoke.go
+++ b/internal/core/access_review_revoke.go
@@ -1,0 +1,154 @@
+// access_review_revoke.go — closing the access-recertification loop (ISO 27001
+// A.5.18 / SOC 2 CC6.2-6.3). GenerateProjectAccessReview (access_review.go) lists
+// who can reach a project's secrets; this file lets a reviewer act on each entry:
+//
+//   - Revoke  — remove the underlying grant (a role assignment or a share) so the
+//     access no longer exists. Audited as access_review.revoked.
+//   - Attest  — certify the grant was reviewed and kept. No state change; recorded
+//     as access_review.attested so the review itself is evidence of the control.
+//
+// Both decisions are authoritative recertification actions: the API gates revoke
+// behind roles.assign and attest behind roles.read at the project scope. The share
+// path deletes the ShareRecord directly (rather than RevokeShare, which requires
+// the caller to be the secret owner) because the reviewer acts on the scope's
+// authority, not ownership.
+package core
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+)
+
+// Access-review decision audit event types.
+const (
+	EventAccessReviewRevoked  = "access_review.revoked"  // #nosec G101 -- audit event type, not a credential
+	EventAccessReviewAttested = "access_review.attested" // #nosec G101 -- audit event type, not a credential
+)
+
+// AccessReviewDecision identifies a single access-review entry (a grant of access
+// to a project's secrets) for a recertification decision. The fields mirror an
+// AccessReviewEntry: Source says which mechanism conferred the grant, and the
+// remaining fields point at the specific assignment or share to act on.
+//   - Source "role"         → PrincipalType + PrincipalID + RoleID (+ EnvironmentID)
+//   - Source "direct_share" → PrincipalID (the user) + SecretID
+//   - Source "group_share"  → PrincipalID (the group) + SecretID
+type AccessReviewDecision struct {
+	Source        string `json:"source"`         // role | direct_share | group_share
+	PrincipalType string `json:"principal_type"` // user | group (for role grants)
+	PrincipalID   uint   `json:"principal_id"`
+	RoleID        uint   `json:"role_id,omitempty"`
+	EnvironmentID uint   `json:"environment_id,omitempty"`
+	SecretID      uint   `json:"secret_id,omitempty"`
+}
+
+// accessReviewAuditDetail is the structured payload stored in a recertification
+// event's Diff field, capturing exactly which grant was acted on.
+type accessReviewAuditDetail struct {
+	Source        string `json:"source"`
+	PrincipalType string `json:"principal_type,omitempty"`
+	PrincipalID   uint   `json:"principal_id,omitempty"`
+	RoleID        uint   `json:"role_id,omitempty"`
+	EnvironmentID uint   `json:"environment_id,omitempty"`
+	SecretID      uint   `json:"secret_id,omitempty"`
+}
+
+// RevokeAccessReviewGrant removes the grant identified by the decision: a project-
+// scoped role assignment (user or group) or a secret share (direct or group). The
+// underlying removal is itself audited (role.removed / role.group_removed for
+// roles), and a recertification-specific access_review.revoked event records the
+// decision with the acting reviewer. actorID is the reviewer performing the revoke.
+func (c *KeyorixCore) RevokeAccessReviewGrant(ctx context.Context, actorID, projectID uint, d AccessReviewDecision) error {
+	if projectID == 0 {
+		return fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "project ID is required")
+	}
+	switch d.Source {
+	case "role":
+		if d.PrincipalID == 0 || d.RoleID == 0 {
+			return fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "principal_id and role_id are required to revoke a role grant")
+		}
+		scope := Scope{ProjectID: projectID, EnvironmentID: d.EnvironmentID}
+		if d.PrincipalType == "group" {
+			if err := c.RemoveRoleFromGroup(ctx, actorID, d.PrincipalID, d.RoleID, scope); err != nil {
+				return err
+			}
+		} else {
+			if err := c.RemoveUserRole(ctx, actorID, d.PrincipalID, d.RoleID, scope); err != nil {
+				return err
+			}
+		}
+	case "direct_share", "group_share":
+		if d.PrincipalID == 0 || d.SecretID == 0 {
+			return fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "principal_id and secret_id are required to revoke a share")
+		}
+		if err := c.revokeReviewShare(ctx, d); err != nil {
+			return err
+		}
+	case "owner":
+		return fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "ownership cannot be revoked via access review; reassign or delete the secret instead")
+	default:
+		return fmt.Errorf("%s: unknown access-review source %q", i18n.T("ErrorValidation", nil), d.Source)
+	}
+	c.logAccessReviewDecision(ctx, EventAccessReviewRevoked, "revoked", actorID, projectID, d)
+	return nil
+}
+
+// revokeReviewShare deletes the ShareRecord matching the decision's secret +
+// recipient. It deletes the record directly (not via RevokeShare, which is owner-
+// gated) because access recertification acts on the project scope's authority.
+func (c *KeyorixCore) revokeReviewShare(ctx context.Context, d AccessReviewDecision) error {
+	isGroup := d.Source == "group_share"
+	shares, err := c.storage.ListSharesBySecret(ctx, d.SecretID)
+	if err != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	for _, sh := range shares {
+		if sh.RecipientID == d.PrincipalID && sh.IsGroup == isGroup {
+			if err := c.storage.DeleteShareRecord(ctx, sh.ID); err != nil {
+				return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+			}
+			return nil
+		}
+	}
+	return fmt.Errorf("%s: no matching share to revoke", i18n.T("ErrorNotFound", nil))
+}
+
+// AttestAccessReviewGrant records that the reviewer examined the grant and chose to
+// keep it. It changes no state — the access_review.attested event is the evidence
+// that the recertification was performed. actorID is the reviewer.
+func (c *KeyorixCore) AttestAccessReviewGrant(ctx context.Context, actorID, projectID uint, d AccessReviewDecision) error {
+	if projectID == 0 {
+		return fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "project ID is required")
+	}
+	if d.Source == "" {
+		return fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "source is required")
+	}
+	c.logAccessReviewDecision(ctx, EventAccessReviewAttested, "attested", actorID, projectID, d)
+	return nil
+}
+
+// logAccessReviewDecision writes the recertification audit event (actor as UserID,
+// the secret as SecretNodeID when the grant is per-secret, project as ProjectID,
+// and the full decision in the structured diff).
+func (c *KeyorixCore) logAccessReviewDecision(ctx context.Context, eventType, verb string, actorID, projectID uint, d AccessReviewDecision) {
+	encoded, _ := json.Marshal(accessReviewAuditDetail(d))
+	var actor *uint
+	if actorID != 0 {
+		a := actorID
+		actor = &a
+	}
+	var secretID *uint
+	if d.SecretID != 0 {
+		s := d.SecretID
+		secretID = &s
+	}
+	pid := projectID
+	principal := d.PrincipalType
+	if principal == "" {
+		principal = "principal"
+	}
+	desc := fmt.Sprintf("access review: %s %s grant for %s %d", verb, d.Source, principal, d.PrincipalID)
+	c.writeAuditEventDiff(ctx, eventType, actor, secretID, &pid, "", desc, string(encoded))
+}

--- a/server/http/handlers/openapi.yaml
+++ b/server/http/handlers/openapi.yaml
@@ -521,11 +521,60 @@ paths:
           description: >-
             Envelope {data, message}. data: {entries[], count}; each entry is
             {principal_type (user|group), principal_id, principal_name, email,
-            source (role|owner|direct_share|group_share), role_name, access_level,
-            environment_id, secret_id, secret_name}.
+            source (role|owner|direct_share|group_share), role_id, role_name,
+            access_level, environment_id, secret_id, secret_name}.
         '400': {$ref: '#/components/responses/Error'}
         '401': {$ref: '#/components/responses/Error'}
         '403': {$ref: '#/components/responses/Error'}
+
+  /api/v1/projects/{id}/access-review/attest:
+    post:
+      tags: [Projects]
+      summary: Attest an access-review grant (certify reviewed & kept)
+      description: >-
+        Record that the grant in the body was reviewed and intentionally kept —
+        the audit evidence of recertification (access_review.attested). Changes no
+        access. Requires roles.read at the project scope.
+      operationId: attestProjectAccessReview
+      security: [{bearerAuth: []}]
+      parameters:
+        - {name: id, in: path, required: true, schema: {type: integer, format: uint32}}
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: {$ref: '#/components/schemas/AccessReviewDecision'}
+      responses:
+        '200': {description: "Envelope {data, message}. Attested."}
+        '400': {$ref: '#/components/responses/Error'}
+        '401': {$ref: '#/components/responses/Error'}
+        '403': {$ref: '#/components/responses/Error'}
+
+  /api/v1/projects/{id}/access-review/revoke:
+    post:
+      tags: [Projects]
+      summary: Revoke an access-review grant (remove the role or share)
+      description: >-
+        Close the recertification loop by removing the grant in the body — a
+        project-scoped role assignment (source=role, role_id set) or a secret share
+        (source=direct_share|group_share, secret_id set). Audited as
+        access_review.revoked. Ownership (source=owner) cannot be revoked here.
+        Requires roles.assign at the project scope.
+      operationId: revokeProjectAccessReview
+      security: [{bearerAuth: []}]
+      parameters:
+        - {name: id, in: path, required: true, schema: {type: integer, format: uint32}}
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: {$ref: '#/components/schemas/AccessReviewDecision'}
+      responses:
+        '200': {description: "Envelope {data, message}. Access revoked."}
+        '400': {$ref: '#/components/responses/Error'}
+        '401': {$ref: '#/components/responses/Error'}
+        '403': {$ref: '#/components/responses/Error'}
+        '404': {$ref: '#/components/responses/Error'}
 
   /api/v1/projects/{id}/members:
     get:
@@ -2580,3 +2629,35 @@ components:
                   code: {type: integer}
                   message: {type: string}
                   type: {type: string}
+  schemas:
+    AccessReviewDecision:
+      type: object
+      description: >-
+        Identifies one access-review entry for a recertification decision
+        (attest or revoke). Mirrors an entry from GET .../access-review.
+      required: [source]
+      properties:
+        source:
+          type: string
+          enum: [role, direct_share, group_share]
+          description: Which mechanism conferred the grant.
+        principal_type:
+          type: string
+          enum: [user, group]
+          description: For a role grant, whether the principal is a user or a group.
+        principal_id:
+          type: integer
+          format: uint32
+          description: The user or group ID the grant is for.
+        role_id:
+          type: integer
+          format: uint32
+          description: Required when source=role.
+        environment_id:
+          type: integer
+          format: uint32
+          description: Environment scope of a role grant (0 = whole project).
+        secret_id:
+          type: integer
+          format: uint32
+          description: Required when source=direct_share or group_share.

--- a/server/http/handlers/project_members.go
+++ b/server/http/handlers/project_members.go
@@ -7,6 +7,9 @@ import (
 	"strings"
 
 	"github.com/go-chi/chi/v5"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/server/middleware"
 )
 
 // ListProjectMembers handles GET /api/v1/projects/{id}/members
@@ -39,6 +42,89 @@ func (h *CatalogHandler) GetProjectAccessReview(w http.ResponseWriter, r *http.R
 		return
 	}
 	sendSuccess(w, map[string]interface{}{"entries": entries, "count": len(entries)}, "")
+}
+
+// accessReviewDecisionBody is the request body for a recertification decision on
+// one access-review entry (revoke or attest). It mirrors the AccessReviewEntry the
+// review returned, identifying the grant to act on.
+type accessReviewDecisionBody struct {
+	Source        string `json:"source"`
+	PrincipalType string `json:"principal_type"`
+	PrincipalID   uint   `json:"principal_id"`
+	RoleID        uint   `json:"role_id"`
+	EnvironmentID uint   `json:"environment_id"`
+	SecretID      uint   `json:"secret_id"`
+}
+
+// decodeAccessReviewDecision parses the project ID, acting reviewer and decision
+// body shared by the revoke and attest handlers. It writes the error response and
+// returns ok=false on any failure.
+func (h *CatalogHandler) decodeAccessReviewDecision(w http.ResponseWriter, r *http.Request) (uint, uint, core.AccessReviewDecision, bool) {
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		sendError(w, "InvalidParameter", "Invalid project ID", http.StatusBadRequest, nil)
+		return 0, 0, core.AccessReviewDecision{}, false
+	}
+	userCtx := middleware.GetUserFromContext(r.Context())
+	if userCtx == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return 0, 0, core.AccessReviewDecision{}, false
+	}
+	var body accessReviewDecisionBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		sendError(w, "InvalidJSON", "Invalid request body", http.StatusBadRequest, nil)
+		return 0, 0, core.AccessReviewDecision{}, false
+	}
+	if body.Source == "" {
+		sendError(w, "ValidationError", "source is required", http.StatusBadRequest, nil)
+		return 0, 0, core.AccessReviewDecision{}, false
+	}
+	return uint(id), userCtx.UserID, core.AccessReviewDecision{
+		Source:        body.Source,
+		PrincipalType: body.PrincipalType,
+		PrincipalID:   body.PrincipalID,
+		RoleID:        body.RoleID,
+		EnvironmentID: body.EnvironmentID,
+		SecretID:      body.SecretID,
+	}, true
+}
+
+// RevokeProjectAccessReview handles POST /api/v1/projects/{id}/access-review/revoke
+// — close the recertification loop by removing the grant identified in the body (a
+// role assignment or a share). Gated by roles.assign at the project scope.
+func (h *CatalogHandler) RevokeProjectAccessReview(w http.ResponseWriter, r *http.Request) {
+	projectID, actorID, decision, ok := h.decodeAccessReviewDecision(w, r)
+	if !ok {
+		return
+	}
+	if err := h.coreService.RevokeAccessReviewGrant(r.Context(), actorID, projectID, decision); err != nil {
+		status := http.StatusInternalServerError
+		msg := err.Error()
+		switch {
+		case strings.Contains(msg, "required") || strings.Contains(msg, "unknown access-review source") || strings.Contains(msg, "ownership cannot be revoked"):
+			status = http.StatusBadRequest
+		case strings.Contains(msg, "no matching share") || strings.Contains(msg, "not found"):
+			status = http.StatusNotFound
+		}
+		sendError(w, "Error", msg, status, nil)
+		return
+	}
+	sendSuccess(w, nil, "Access revoked")
+}
+
+// AttestProjectAccessReview handles POST /api/v1/projects/{id}/access-review/attest
+// — certify the grant in the body was reviewed and kept (audit-only, the evidence
+// of recertification). Gated by roles.read at the project scope.
+func (h *CatalogHandler) AttestProjectAccessReview(w http.ResponseWriter, r *http.Request) {
+	projectID, actorID, decision, ok := h.decodeAccessReviewDecision(w, r)
+	if !ok {
+		return
+	}
+	if err := h.coreService.AttestAccessReviewGrant(r.Context(), actorID, projectID, decision); err != nil {
+		sendError(w, "Error", err.Error(), http.StatusBadRequest, nil)
+		return
+	}
+	sendSuccess(w, nil, "Access attested")
 }
 
 // AddProjectMember handles POST /api/v1/projects/{id}/members

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -198,6 +198,10 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		// a project_admin can manage their own project's members.
 		r.With(customMiddleware.RequireScopedPermission("users.read", projectScope)).Get("/projects/{id}/members", catalogHandler.ListProjectMembers)
 		r.With(customMiddleware.RequireScopedPermission("roles.read", projectScope)).Get("/projects/{id}/access-review", catalogHandler.GetProjectAccessReview)
+		// Recertification decisions (ISO 27001 A.5.18): attest is a reviewer action
+		// (roles.read); revoke removes the grant and needs roles.assign.
+		r.With(customMiddleware.RequireScopedPermission("roles.read", projectScope)).Post("/projects/{id}/access-review/attest", catalogHandler.AttestProjectAccessReview)
+		r.With(customMiddleware.RequireScopedPermission("roles.assign", projectScope)).Post("/projects/{id}/access-review/revoke", catalogHandler.RevokeProjectAccessReview)
 		r.With(customMiddleware.RequireScopedPermission("roles.assign", projectScope)).Post("/projects/{id}/members", catalogHandler.AddProjectMember)
 		r.With(customMiddleware.RequireScopedPermission("roles.assign", projectScope)).Put("/projects/{id}/members/{userId}", catalogHandler.UpdateProjectMember)
 		r.With(customMiddleware.RequireScopedPermission("roles.assign", projectScope)).Delete("/projects/{id}/members/{userId}", catalogHandler.RemoveProjectMember)


### PR DESCRIPTION
## What

Builds on the project access review (#169 report, #170 per-secret grants) to let a reviewer **act** on each entry — completing the ISO 27001 A.5.18 / SOC 2 CC6.2–6.3 recertification control:

- **Revoke** — remove the underlying grant: a project-scoped **role assignment** (user or group) or a **secret share** (direct/group). Role removal funnels through the existing audited `RemoveUserRole`/`RemoveRoleFromGroup`; the share path deletes the `ShareRecord` directly (not `RevokeShare`, which is owner-gated) because recertification acts on the project scope's authority, not ownership. Ownership itself cannot be revoked here.
- **Attest** — certify a grant was reviewed and intentionally kept; no state change, recorded as evidence.

Every decision emits a recertification audit event (`access_review.revoked` / `access_review.attested`) carrying the acting reviewer and the exact grant in the structured diff.

## Surfaces

- **core**: `AccessReviewDecision` + `RevokeAccessReviewGrant` / `AttestAccessReviewGrant` (new `access_review_revoke.go`); `AccessReviewEntry` gains `role_id` so a client can reference a role grant for revocation.
- **API**: `POST /api/v1/projects/{id}/access-review/{attest,revoke}` — attest gated by `roles.read`, revoke by `roles.assign` at the project scope.
- **CLI**: `keyorix access-review attest|revoke` subcommands.

## Tests

- revoke-role (grant gone from a subsequent review)
- revoke-group-share + owner-refused + not-found
- attest-audits-the-decision without changing access
- requires-project validation

## Docs

- openapi: two endpoints + `AccessReviewDecision` schema, `role_id` on the entry
- REMOTE_CLI_SETUP: attest/revoke usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)