### PR TITLE
feat(rbac): just-in-time / time-bound role grants (2)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -16,7 +16,7 @@ The config file is located via, in order: an explicit path argument, then
 - [secrets](#secrets) · [security + require_mfa](#security) (ADR-034)
 - [webauthn](#webauthn) (ADR-036) · [dynamic_secrets](#dynamic_secrets) (ADR-035)
 - [oidc](#oidc) (ADR-031) · [session](#session) · [password_policy](#password_policy) (ADR-025)
-- [soft_delete + purge](#soft_delete--purge) (ADR-032) · [rotation_reminders](#rotation_reminders) · [audit_checkpoints](#audit_checkpoints) (ADR-029) · [audit.siem](#auditsiem)
+- [soft_delete + purge](#soft_delete--purge) (ADR-032) · [rotation_reminders](#rotation_reminders) · [audit_checkpoints](#audit_checkpoints) (ADR-029) · [jit_access_expiry](#jit_access_expiry) · [audit.siem](#auditsiem)
 - [membership](#membership) (ADR-022) · [credential_delivery](#credential_delivery) (ADR-028)
 
 ---
@@ -349,6 +349,26 @@ encryption off the scheduler logs a warning and does nothing.
 audit_checkpoints:
   enabled: true
   schedule: "12h"         # Go duration between checkpoint writes (default 24h)
+```
+
+## jit_access_expiry
+
+An opt-in background sweeper for **just-in-time / time-bound access**. A role grant
+can carry an expiry — set it by approving an access request with a TTL (`keyorix
+request review --action approve --ttl 4h …`, or `grant_ttl` on the resolve API).
+An expired grant **stops authorizing immediately** (the authorization queries
+filter on expiry, so access is denied the moment the TTL passes — independent of
+this sweep); the sweeper then reclaims the rows and writes a `role.expired` audit
+event for each. Single-replica-gated (ADR-039).
+
+Leaving this disabled does not weaken enforcement — expired grants are still
+denied at authorization time — it only means the expired rows linger until a
+sweeper (anywhere) runs.
+
+```yaml
+jit_access_expiry:
+  enabled: true
+  schedule: "1h"          # Go duration between expiry sweeps (default 1h)
 ```
 
 ## audit.siem

--- a/internal/cli/request/review.go
+++ b/internal/cli/request/review.go
@@ -3,6 +3,7 @@ package request
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/keyorixhq/keyorix/internal/cli/common"
 	"github.com/spf13/cobra"
@@ -14,6 +15,7 @@ var (
 	reviewRole   string
 	reviewReason string
 	reviewBy     string
+	reviewTTL    string
 )
 
 var reviewCmd = &cobra.Command{
@@ -30,6 +32,7 @@ func init() {
 	reviewCmd.Flags().StringVar(&reviewAction, "action", "", "approve | reject (required)")
 	reviewCmd.Flags().StringVar(&reviewRole, "role", "", "Role to grant on approve (defaults to the suggested role)")
 	reviewCmd.Flags().StringVar(&reviewReason, "reason", "", "Reason on reject")
+	reviewCmd.Flags().StringVar(&reviewTTL, "ttl", "", "Time-bound the granted role on approve (Go duration, e.g. 4h); empty = permanent")
 	reviewCmd.Flags().StringVar(&reviewBy, "by", "", "Reviewer email address (required, for audit)")
 	_ = reviewCmd.MarkFlagRequired("id")
 	_ = reviewCmd.MarkFlagRequired("action")
@@ -64,12 +67,23 @@ func runReview(cmd *cobra.Command, args []string) error {
 
 	switch reviewAction {
 	case "approve":
-		req, err := service.ApproveAccessRequest(ctx, projectID, reviewID, approverID, reviewRole)
+		var ttl time.Duration
+		if reviewTTL != "" {
+			ttl, err = time.ParseDuration(reviewTTL)
+			if err != nil || ttl < 0 {
+				return fmt.Errorf("--ttl must be a non-negative Go duration (e.g. 4h)")
+			}
+		}
+		req, err := service.ApproveAccessRequestWithExpiry(ctx, projectID, reviewID, approverID, reviewRole, ttl)
 		if err != nil {
 			return fmt.Errorf("failed to approve access request: %w", err)
 		}
-		fmt.Printf("Access request %d approved: granted role %q to %s.\n",
-			req.ID, req.GrantedRole, userLabel(ctx, service, req.UserID))
+		grantNote := "permanently"
+		if ttl > 0 {
+			grantNote = fmt.Sprintf("for %s (time-bound)", ttl)
+		}
+		fmt.Printf("Access request %d approved: granted role %q to %s %s.\n",
+			req.ID, req.GrantedRole, userLabel(ctx, service, req.UserID), grantNote)
 	case "reject":
 		req, err := service.RejectAccessRequest(ctx, projectID, reviewID, approverID, reviewReason)
 		if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,6 +28,9 @@ type Config struct {
 	// signed checkpoints of the audit hash chain (ADR-029) for on-box truncation
 	// detection. Requires encryption enabled (the signing key is DEK-derived).
 	AuditCheckpoints AuditCheckpointsConfig `yaml:"audit_checkpoints"`
+	// JITAccessExpiry configures the opt-in background sweeper that removes
+	// time-bound role grants whose expiry has passed (just-in-time access).
+	JITAccessExpiry JITAccessExpiryConfig `yaml:"jit_access_expiry"`
 	// DynamicSecrets configures the on-demand database-credentials engine and its
 	// auto-revoke sweep (ADR-035). Disabled (zero value) = the API is still served
 	// but no background sweeper runs; enable to auto-revoke leases at expiry.
@@ -485,6 +488,27 @@ func (c AuditCheckpointsConfig) GetInterval() time.Duration {
 		}
 	}
 	return 24 * time.Hour
+}
+
+// JITAccessExpiryConfig configures the just-in-time access-expiry sweeper: a
+// background job that removes time-bound role grants whose expiry has passed and
+// audits each as role.expired. Expired grants stop authorizing immediately (the
+// authorization queries filter on expiry); this sweep reclaims the rows. Opt-in
+// (default off).
+type JITAccessExpiryConfig struct {
+	Enabled  bool   `yaml:"enabled"`
+	Schedule string `yaml:"schedule"`
+}
+
+// GetInterval returns the expiry-sweep interval (Go duration, e.g. "1h"); defaults
+// to 1h when unset or unparseable.
+func (c JITAccessExpiryConfig) GetInterval() time.Duration {
+	if c.Schedule != "" {
+		if d, err := time.ParseDuration(c.Schedule); err == nil && d > 0 {
+			return d
+		}
+	}
+	return time.Hour
 }
 
 // WebAuthnConfig configures the WebAuthn relying party (ADR-036). RPID is the

--- a/internal/core/audit.go
+++ b/internal/core/audit.go
@@ -14,6 +14,7 @@ import (
 const (
 	EventRoleAssigned      = "role.assigned"
 	EventRoleRemoved       = "role.removed"
+	EventRoleExpired       = "role.expired"        // #nosec G101 -- audit event type, not a credential
 	EventRoleGroupAssigned = "role.group_assigned" // #nosec G101 -- audit event type, not a credential
 	EventRoleGroupRemoved  = "role.group_removed"  // #nosec G101 -- audit event type, not a credential
 	EventPermissionAdded   = "permission.assigned" // #nosec G101 -- audit event type, not a credential
@@ -22,7 +23,7 @@ const (
 
 // rbacAuditEventTypes is the set of event types that make up the RBAC audit log.
 var rbacAuditEventTypes = []string{
-	EventRoleAssigned, EventRoleRemoved,
+	EventRoleAssigned, EventRoleRemoved, EventRoleExpired,
 	EventRoleGroupAssigned, EventRoleGroupRemoved,
 	EventPermissionAdded, EventPermissionRemoved,
 }

--- a/internal/core/invitations.go
+++ b/internal/core/invitations.go
@@ -366,9 +366,17 @@ func (c *KeyorixCore) ListAccessRequests(ctx context.Context, projectID uint) ([
 }
 
 // ApproveAccessRequest approves a pending request, granting grantedRole (falling
-// back to the suggested role) at the project scope. No auto-approval — an admin
-// performs this explicitly.
+// back to the suggested role) at the project scope, permanently. No auto-approval —
+// an admin performs this explicitly.
 func (c *KeyorixCore) ApproveAccessRequest(ctx context.Context, projectID, requestID, approverID uint, grantedRole string) (*models.AccessRequest, error) {
+	return c.ApproveAccessRequestWithExpiry(ctx, projectID, requestID, approverID, grantedRole, 0)
+}
+
+// ApproveAccessRequestWithExpiry approves a pending request like ApproveAccessRequest
+// but, when grantTTL > 0, grants the role TIME-BOUND (just-in-time access): the
+// grant stops authorizing once the TTL elapses and is later swept by the JIT
+// expiry scheduler. grantTTL == 0 grants permanently.
+func (c *KeyorixCore) ApproveAccessRequestWithExpiry(ctx context.Context, projectID, requestID, approverID uint, grantedRole string, grantTTL time.Duration) (*models.AccessRequest, error) {
 	req, err := c.storage.GetAccessRequest(ctx, requestID)
 	if err != nil {
 		return nil, fmt.Errorf("access request not found")
@@ -382,6 +390,9 @@ func (c *KeyorixCore) ApproveAccessRequest(ctx context.Context, projectID, reque
 	if req.State != AccessRequestPending {
 		return nil, fmt.Errorf("only a pending request can be approved (state is %s)", req.State)
 	}
+	if grantTTL < 0 {
+		return nil, fmt.Errorf("grant TTL must not be negative")
+	}
 	role := grantedRole
 	if role == "" {
 		role = req.SuggestedRole
@@ -393,11 +404,21 @@ func (c *KeyorixCore) ApproveAccessRequest(ctx context.Context, projectID, reque
 	if err != nil {
 		return nil, fmt.Errorf("unknown role %q: %w", role, err)
 	}
-	// Grant the role at the project scope.
-	if err := c.storage.AssignRole(ctx, req.UserID, roleModel.ID, storage.Scope{ProjectID: req.ProjectID}); err != nil {
-		return nil, fmt.Errorf("failed to grant role: %w", err)
-	}
 	now := c.now()
+	// Grant the role at the project scope — time-bound when a TTL is given.
+	scope := storage.Scope{ProjectID: req.ProjectID}
+	grantDesc := role
+	if grantTTL > 0 {
+		expiresAt := now.Add(grantTTL)
+		if err := c.storage.AssignRoleWithExpiry(ctx, req.UserID, roleModel.ID, scope, expiresAt); err != nil {
+			return nil, fmt.Errorf("failed to grant role: %w", err)
+		}
+		grantDesc = fmt.Sprintf("%s until %s (TTL %s)", role, expiresAt.UTC().Format(time.RFC3339), grantTTL)
+	} else {
+		if err := c.storage.AssignRole(ctx, req.UserID, roleModel.ID, scope); err != nil {
+			return nil, fmt.Errorf("failed to grant role: %w", err)
+		}
+	}
 	req.State = AccessRequestApproved
 	req.GrantedRole = role
 	req.ResolvedBy = approverID
@@ -406,7 +427,7 @@ func (c *KeyorixCore) ApproveAccessRequest(ctx context.Context, projectID, reque
 		return nil, fmt.Errorf("failed to update access request: %w", err)
 	}
 	c.auditProjectScoped(ctx, "access_request.approved", approverID, req.ProjectID,
-		fmt.Sprintf("approved access request %d for user %d as %s", req.ID, req.UserID, role))
+		fmt.Sprintf("approved access request %d for user %d as %s", req.ID, req.UserID, grantDesc))
 	c.notifyAccessResolved(ctx, req, true)
 	return req, nil
 }

--- a/internal/core/jit_access.go
+++ b/internal/core/jit_access.go
@@ -1,0 +1,64 @@
+// jit_access.go — just-in-time / time-bound role grants. A grant carries an
+// optional expiry; the storage authorization queries deny it the instant it
+// passes, and RemoveExpiredRoleGrants (run by the JIT scheduler) sweeps the rows
+// and audits each auto-expiry. The grant itself is created via the access-request
+// approval flow (invitations.go) or directly through these helpers.
+package core
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+)
+
+// AssignUserRoleWithExpiry assigns a time-bound role to a user at scope (the grant
+// stops authorizing once expiresAt passes) and records the assignment. actorID is
+// the granting principal (0 = unauthenticated/system).
+func (c *KeyorixCore) AssignUserRoleWithExpiry(ctx context.Context, actorID, userID, roleID uint, scope Scope, expiresAt time.Time) error {
+	if err := c.storage.AssignRoleWithExpiry(ctx, userID, roleID, scope, expiresAt); err != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	c.LogRoleAssigned(ctx, actorID, userID, roleID, scope)
+	return nil
+}
+
+// AssignGroupRoleWithExpiry assigns a time-bound role to a group at scope; see
+// AssignUserRoleWithExpiry.
+func (c *KeyorixCore) AssignGroupRoleWithExpiry(ctx context.Context, actorID, groupID, roleID uint, scope Scope, expiresAt time.Time) error {
+	if err := c.storage.AssignRoleToGroupWithExpiry(ctx, groupID, roleID, scope, expiresAt); err != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	c.LogGroupRoleAssigned(ctx, actorID, groupID, roleID, scope)
+	return nil
+}
+
+// RemoveExpiredRoleGrants removes every user/group role grant whose expiry is at or
+// before `before` and audits each as role.expired (actor 0 = the system sweep).
+// Returns the number of grants removed. Idempotent — a tick that finds nothing
+// removes nothing. Backs the JIT access-expiry scheduler.
+func (c *KeyorixCore) RemoveExpiredRoleGrants(ctx context.Context, before time.Time) (int, error) {
+	removed, err := c.storage.DeleteExpiredRoleGrants(ctx, before)
+	if err != nil {
+		return 0, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	for _, g := range removed {
+		scope := Scope{ProjectID: g.ProjectID, EnvironmentID: g.EnvironmentID}
+		detail := rbacAuditDetail{
+			RoleID:        g.RoleID,
+			ProjectID:     g.ProjectID,
+			EnvironmentID: g.EnvironmentID,
+		}
+		var desc string
+		if g.PrincipalType == "group" {
+			detail.GroupID = g.PrincipalID
+			desc = fmt.Sprintf("role %d expired for group %d", g.RoleID, g.PrincipalID)
+		} else {
+			detail.TargetUserID = g.PrincipalID
+			desc = fmt.Sprintf("role %d expired for user %d", g.RoleID, g.PrincipalID)
+		}
+		c.writeRBACAudit(ctx, EventRoleExpired, desc, 0, scope, detail)
+	}
+	return len(removed), nil
+}

--- a/internal/core/jit_access_external_test.go
+++ b/internal/core/jit_access_external_test.go
@@ -1,0 +1,160 @@
+package core_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/testhelper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// An expired time-bound grant must NOT authorize: the scope-aware role-resolution
+// query (which backs Authorize) filters it out the instant it passes, before any
+// sweep removes the row. A future grant still resolves.
+func TestTimeBoundGrant_ExpiredExcludedFromAuthQueries(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+
+	const proj = uint(2)
+	ctx := context.Background()
+	scope := storage.Scope{ProjectID: proj}
+	h.CreateTestUser(t, "alice", 10)
+
+	// Role 3 (editor) granted but already expired → excluded.
+	require.NoError(t, h.Storage.AssignRoleWithExpiry(ctx, 10, 3, scope, time.Now().Add(-time.Minute)))
+	// Role 4 (viewer) granted with a future expiry → still active.
+	require.NoError(t, h.Storage.AssignRoleWithExpiry(ctx, 10, 4, scope, time.Now().Add(time.Hour)))
+
+	ids, err := h.Storage.GetUserRoleIDsAt(ctx, 10, scope)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []uint{4}, ids, "expired editor grant excluded; future viewer grant kept")
+}
+
+// An expired grant must also be excluded from the flat role/permission lists that
+// build UserContext (and thus gRPC self-scoped permission checks / RequireRole),
+// not just the scope-aware queries — otherwise expired access still authorizes
+// those paths between sweeps.
+func TestTimeBoundGrant_ExpiredExcludedFromFlatRoleAndPermLists(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+
+	ctx := context.Background()
+	h.CreateTestUser(t, "alice", 10)
+	// Editor (role 3) grants secrets.read+write; grant it already-expired.
+	require.NoError(t, h.Storage.AssignRoleWithExpiry(ctx, 10, 3, storage.Scope{ProjectID: 2}, time.Now().Add(-time.Minute)))
+
+	roles, err := h.Storage.GetUserRoles(ctx, 10)
+	require.NoError(t, err)
+	assert.Empty(t, roles, "expired grant excluded from GetUserRoles (feeds UserContext.Roles)")
+
+	perms, err := h.Storage.GetUserPermissions(ctx, 10)
+	require.NoError(t, err)
+	assert.Empty(t, perms, "expired grant confers no permissions via GetUserPermissions (feeds UserContext.Permissions)")
+}
+
+// The sweep removes only expired grants (not permanent or future ones), returns
+// the count, and audits each removal as role.expired.
+func TestRemoveExpiredRoleGrants_SweepsAndAudits(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(&models.AuditEvent{}))
+
+	const proj = uint(2)
+	ctx := context.Background()
+	scope := storage.Scope{ProjectID: proj}
+	h.CreateTestUser(t, "alice", 10)
+	h.CreateTestUser(t, "bob", 11)
+
+	require.NoError(t, h.Storage.AssignRoleWithExpiry(ctx, 10, 3, scope, time.Now().Add(-time.Minute))) // expired
+	require.NoError(t, h.Storage.AssignRoleWithExpiry(ctx, 11, 4, scope, time.Now().Add(time.Hour)))    // future
+	require.NoError(t, h.Storage.AssignRole(ctx, 11, 3, scope))                                         // permanent
+
+	n, err := h.CoreService.RemoveExpiredRoleGrants(ctx, time.Now())
+	require.NoError(t, err)
+	assert.Equal(t, 1, n, "only the expired grant is removed")
+
+	// alice's expired editor grant is gone; bob's two grants remain.
+	aliceIDs, err := h.Storage.GetUserRoleIDsAt(ctx, 10, scope)
+	require.NoError(t, err)
+	assert.Empty(t, aliceIDs)
+	bobIDs, err := h.Storage.GetUserRoleIDsAt(ctx, 11, scope)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []uint{3, 4}, bobIDs)
+
+	var expiredEvents int64
+	require.NoError(t, h.DB.Model(&models.AuditEvent{}).
+		Where("event_type = ?", core.EventRoleExpired).Count(&expiredEvents).Error)
+	assert.Equal(t, int64(1), expiredEvents, "one role.expired event recorded")
+}
+
+// A second sweep with nothing expired removes nothing (idempotent).
+func TestRemoveExpiredRoleGrants_NoopWhenNothingExpired(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	ctx := context.Background()
+	h.CreateTestUser(t, "alice", 10)
+	require.NoError(t, h.Storage.AssignRole(ctx, 10, 3, storage.Scope{ProjectID: 2}))
+	n, err := h.CoreService.RemoveExpiredRoleGrants(ctx, time.Now())
+	require.NoError(t, err)
+	assert.Equal(t, 0, n)
+}
+
+// Approving an access request with a TTL grants the role time-bound: the grant row
+// carries an ExpiresAt roughly TTL in the future and is active until then.
+func TestApproveAccessRequestWithExpiry_TimeBound(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(&models.AccessRequest{}))
+
+	const proj = uint(2)
+	ctx := context.Background()
+	h.CreateTestUser(t, "alice", 10) // requester
+	h.CreateTestUser(t, "admin", 1)  // approver
+
+	created, err := h.Storage.CreateAccessRequest(ctx, &models.AccessRequest{
+		ProjectID: proj, UserID: 10, SuggestedRole: "editor", State: core.AccessRequestPending,
+	})
+	require.NoError(t, err)
+
+	_, err = h.CoreService.ApproveAccessRequestWithExpiry(ctx, proj, created.ID, 1, "editor", time.Hour)
+	require.NoError(t, err)
+
+	// The grant is active now (within the TTL window).
+	ids, err := h.Storage.GetUserRoleIDsAt(ctx, 10, storage.Scope{ProjectID: proj})
+	require.NoError(t, err)
+	assert.Contains(t, ids, uint(3), "the time-bound editor grant authorizes within its window")
+
+	// The stored grant carries an expiry ~1h out.
+	var ur models.UserRole
+	require.NoError(t, h.DB.Where("user_id = ? AND role_id = ? AND project_id = ?", 10, 3, proj).First(&ur).Error)
+	require.NotNil(t, ur.ExpiresAt, "the grant is time-bound, not permanent")
+	assert.WithinDuration(t, time.Now().Add(time.Hour), *ur.ExpiresAt, 2*time.Minute)
+}
+
+// With no TTL, approval grants a permanent role (ExpiresAt nil) — unchanged behavior.
+func TestApproveAccessRequest_PermanentByDefault(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(&models.AccessRequest{}))
+
+	const proj = uint(2)
+	ctx := context.Background()
+	h.CreateTestUser(t, "alice", 10)
+
+	created, err := h.Storage.CreateAccessRequest(ctx, &models.AccessRequest{
+		ProjectID: proj, UserID: 10, SuggestedRole: "editor", State: core.AccessRequestPending,
+	})
+	require.NoError(t, err)
+
+	_, err = h.CoreService.ApproveAccessRequest(ctx, proj, created.ID, 1, "editor")
+	require.NoError(t, err)
+
+	var ur models.UserRole
+	require.NoError(t, h.DB.Where("user_id = ? AND role_id = ? AND project_id = ?", 10, 3, proj).First(&ur).Error)
+	assert.Nil(t, ur.ExpiresAt, "default approval is permanent")
+}

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -587,9 +587,27 @@ func (m *MockStorage) AssignRole(ctx context.Context, userID, roleID uint, scope
 	return args.Error(0)
 }
 
+func (m *MockStorage) AssignRoleWithExpiry(ctx context.Context, userID, roleID uint, scope storage.Scope, expiresAt time.Time) error {
+	args := m.Called(ctx, userID, roleID, scope, expiresAt)
+	return args.Error(0)
+}
+
 func (m *MockStorage) RemoveRole(ctx context.Context, userID, roleID uint, scope storage.Scope) error {
 	args := m.Called(ctx, userID, roleID, scope)
 	return args.Error(0)
+}
+
+func (m *MockStorage) AssignRoleToGroupWithExpiry(ctx context.Context, groupID, roleID uint, scope storage.Scope, expiresAt time.Time) error {
+	args := m.Called(ctx, groupID, roleID, scope, expiresAt)
+	return args.Error(0)
+}
+
+func (m *MockStorage) DeleteExpiredRoleGrants(ctx context.Context, before time.Time) ([]storage.RoleAssignment, error) {
+	args := m.Called(ctx, before)
+	if v := args.Get(0); v != nil {
+		return v.([]storage.RoleAssignment), args.Error(1)
+	}
+	return nil, args.Error(1)
 }
 
 func (m *MockStorage) GetUserRoles(ctx context.Context, userID uint) ([]*models.Role, error) {

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -213,6 +213,10 @@ type Storage interface {
 	// and RoleSetHasPermission reports whether any of those roles grants a
 	// permission. Together they back core.Authorize.
 	AssignRole(ctx context.Context, userID, roleID uint, scope Scope) error
+	// AssignRoleWithExpiry binds a time-bound role to a user (just-in-time access):
+	// the grant stops authorizing the moment expiresAt passes (the auth queries
+	// filter on it) and is later swept by DeleteExpiredRoleGrants.
+	AssignRoleWithExpiry(ctx context.Context, userID, roleID uint, scope Scope, expiresAt time.Time) error
 	RemoveRole(ctx context.Context, userID, roleID uint, scope Scope) error
 	GetUserRoles(ctx context.Context, userID uint) ([]*models.Role, error)
 	GetUserRoleIDsAt(ctx context.Context, userID uint, scope Scope) ([]uint, error)
@@ -232,7 +236,14 @@ type Storage interface {
 	// Scope (zero Scope = global).
 	GetGroupRoles(ctx context.Context, groupID uint) ([]*models.Role, error)
 	AssignRoleToGroup(ctx context.Context, groupID, roleID uint, scope Scope) error
+	// AssignRoleToGroupWithExpiry binds a time-bound role to a group; see
+	// AssignRoleWithExpiry.
+	AssignRoleToGroupWithExpiry(ctx context.Context, groupID, roleID uint, scope Scope, expiresAt time.Time) error
 	RemoveRoleFromGroup(ctx context.Context, groupID, roleID uint, scope Scope) error
+	// DeleteExpiredRoleGrants removes user/group role grants whose ExpiresAt is at
+	// or before `before`, returning the removed grants so the caller can audit each
+	// expiry. Backs the JIT access-expiry scheduler.
+	DeleteExpiredRoleGrants(ctx context.Context, before time.Time) ([]RoleAssignment, error)
 
 	// Stats Snapshots
 	SaveStatsSnapshot(ctx context.Context, snapshot *models.StatsSnapshot) error

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -92,8 +92,8 @@ type User struct {
 	// a WebAuthn assertion as the second factor (see WebAuthnCredential).
 	WebAuthnEnabled bool `gorm:"default:false"`
 	CreatedAt       time.Time
-	UpdatedAt  time.Time
-	DeletedAt  gorm.DeletedAt `gorm:"index"` // soft delete — set by DELETE /users/{id}, cleared by restore
+	UpdatedAt       time.Time
+	DeletedAt       gorm.DeletedAt `gorm:"index"` // soft delete — set by DELETE /users/{id}, cleared by restore
 }
 
 // MFASecret holds a user's TOTP shared secret, encrypted at rest. One row per
@@ -212,6 +212,11 @@ type UserRole struct {
 	RoleID        uint `gorm:"primaryKey"`
 	ProjectID     uint `gorm:"primaryKey;not null;default:0"`
 	EnvironmentID uint `gorm:"primaryKey;not null;default:0"`
+	// ExpiresAt makes a grant time-bound (just-in-time access): nil = permanent;
+	// otherwise the grant stops authorizing the moment it passes and is swept by
+	// the JIT expiry scheduler. Authorization queries filter on it directly so an
+	// expired grant is denied immediately, before the sweep removes the row.
+	ExpiresAt *time.Time `gorm:"index"`
 }
 
 type Group struct {
@@ -232,6 +237,8 @@ type GroupRole struct {
 	RoleID        uint `gorm:"primaryKey"`
 	ProjectID     uint `gorm:"primaryKey;not null;default:0"`
 	EnvironmentID uint `gorm:"primaryKey;not null;default:0"`
+	// ExpiresAt makes a group grant time-bound; see UserRole.ExpiresAt.
+	ExpiresAt *time.Time `gorm:"index"`
 }
 
 type SecretNode struct {
@@ -284,7 +291,7 @@ type DynamicSecretConfig struct {
 	// CreationTemplate is operator-authored SQL run after the role is created,
 	// with {{name}} substituted by the generated (sanitized) role name. e.g.
 	// "GRANT SELECT ON ALL TABLES IN SCHEMA public TO {{name}};"
-	CreationTemplate string
+	CreationTemplate  string
 	DefaultTTLSeconds int
 	// MaxTTLSeconds caps the lifetime of any lease from this config (issue + all
 	// renewals), regardless of the TTL a caller requests. 0 = no ceiling.

--- a/internal/storage/store/local_rbac.go
+++ b/internal/storage/store/local_rbac.go
@@ -12,6 +12,7 @@ package store
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/i18n"
@@ -95,8 +96,19 @@ func (ls *LocalStorage) ListRoles(ctx context.Context) ([]*models.Role, error) {
 
 // --- RBAC assignment ---
 
-// AssignRole assigns a role to a user at scope; errors if already assigned there.
+// AssignRole assigns a permanent role to a user at scope; errors if already
+// assigned there.
 func (ls *LocalStorage) AssignRole(ctx context.Context, userID, roleID uint, scope storage.Scope) error {
+	return ls.assignUserRole(ctx, userID, roleID, scope, nil)
+}
+
+// AssignRoleWithExpiry assigns a time-bound role to a user at scope: the grant
+// stops authorizing once expiresAt passes and is later swept by the JIT scheduler.
+func (ls *LocalStorage) AssignRoleWithExpiry(ctx context.Context, userID, roleID uint, scope storage.Scope, expiresAt time.Time) error {
+	return ls.assignUserRole(ctx, userID, roleID, scope, &expiresAt)
+}
+
+func (ls *LocalStorage) assignUserRole(ctx context.Context, userID, roleID uint, scope storage.Scope, expiresAt *time.Time) error {
 	var existing models.UserRole
 	err := ls.db.WithContext(ctx).
 		Where("user_id = ? AND role_id = ? AND project_id = ? AND environment_id = ?",
@@ -112,6 +124,7 @@ func (ls *LocalStorage) AssignRole(ctx context.Context, userID, roleID uint, sco
 		RoleID:        roleID,
 		ProjectID:     scope.ProjectID,
 		EnvironmentID: scope.EnvironmentID,
+		ExpiresAt:     expiresAt,
 	}
 	if err := ls.db.WithContext(ctx).Create(&userRole).Error; err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
@@ -139,6 +152,7 @@ func (ls *LocalStorage) GetUserRoles(ctx context.Context, userID uint) ([]*model
 	err := ls.db.WithContext(ctx).Table("roles").
 		Joins("JOIN user_roles ON roles.id = user_roles.role_id").
 		Where("user_roles.user_id = ?", userID).
+		Where("user_roles.expires_at IS NULL OR user_roles.expires_at > ?", time.Now()).
 		Find(&roles).Error
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
@@ -155,6 +169,7 @@ func (ls *LocalStorage) GetUserRoleIDsAt(ctx context.Context, userID uint, scope
 		Where("user_id = ?", userID).
 		Where("project_id = 0 OR project_id = ?", scope.ProjectID).
 		Where("environment_id = 0 OR environment_id = ?", scope.EnvironmentID).
+		Where("expires_at IS NULL OR expires_at > ?", time.Now()).
 		Distinct().Pluck("role_id", &ids).Error
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
@@ -238,6 +253,7 @@ func (ls *LocalStorage) GetUserGroupRoleIDsAt(ctx context.Context, userID uint, 
 		Where("user_groups.user_id = ?", userID).
 		Where("group_roles.project_id = 0 OR group_roles.project_id = ?", scope.ProjectID).
 		Where("group_roles.environment_id = 0 OR group_roles.environment_id = ?", scope.EnvironmentID).
+		Where("group_roles.expires_at IS NULL OR group_roles.expires_at > ?", time.Now()).
 		Distinct().Pluck("group_roles.role_id", &ids).Error
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
@@ -271,6 +287,7 @@ func (ls *LocalStorage) CheckPermission(ctx context.Context, userID uint, resour
 		Joins("JOIN role_permissions ON permissions.id = role_permissions.permission_id").
 		Joins("JOIN user_roles ON role_permissions.role_id = user_roles.role_id").
 		Where("user_roles.user_id = ? AND permissions.resource = ? AND permissions.action = ?", userID, resource, action).
+		Where("user_roles.expires_at IS NULL OR user_roles.expires_at > ?", time.Now()).
 		Count(&count).Error
 	if err != nil {
 		return false, fmt.Errorf("%s: %w", i18n.T("ErrorInternalServer", nil), err)
@@ -339,8 +356,18 @@ func (ls *LocalStorage) GetGroupRoles(ctx context.Context, groupID uint) ([]*mod
 	return roles, nil
 }
 
-// AssignRoleToGroup assigns a role to a group at scope; errors if already assigned there.
+// AssignRoleToGroup assigns a permanent role to a group at scope; errors if
+// already assigned there.
 func (ls *LocalStorage) AssignRoleToGroup(ctx context.Context, groupID, roleID uint, scope storage.Scope) error {
+	return ls.assignGroupRole(ctx, groupID, roleID, scope, nil)
+}
+
+// AssignRoleToGroupWithExpiry assigns a time-bound role to a group at scope.
+func (ls *LocalStorage) AssignRoleToGroupWithExpiry(ctx context.Context, groupID, roleID uint, scope storage.Scope, expiresAt time.Time) error {
+	return ls.assignGroupRole(ctx, groupID, roleID, scope, &expiresAt)
+}
+
+func (ls *LocalStorage) assignGroupRole(ctx context.Context, groupID, roleID uint, scope storage.Scope, expiresAt *time.Time) error {
 	var existing models.GroupRole
 	err := ls.db.WithContext(ctx).
 		Where("group_id = ? AND role_id = ? AND project_id = ? AND environment_id = ?",
@@ -356,11 +383,57 @@ func (ls *LocalStorage) AssignRoleToGroup(ctx context.Context, groupID, roleID u
 		RoleID:        roleID,
 		ProjectID:     scope.ProjectID,
 		EnvironmentID: scope.EnvironmentID,
+		ExpiresAt:     expiresAt,
 	}
 	if err := ls.db.WithContext(ctx).Create(&groupRole).Error; err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}
 	return nil
+}
+
+// DeleteExpiredRoleGrants removes user_roles and group_roles whose ExpiresAt is
+// non-NULL and at or before the cutoff, returning the removed grants so the caller
+// can audit each expiry. Runs in a transaction so the rows it reports are exactly
+// the rows it deleted.
+func (ls *LocalStorage) DeleteExpiredRoleGrants(ctx context.Context, before time.Time) ([]storage.RoleAssignment, error) {
+	var removed []storage.RoleAssignment
+	err := ls.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var userRows []models.UserRole
+		if err := tx.Where("expires_at IS NOT NULL AND expires_at <= ?", before).Find(&userRows).Error; err != nil {
+			return err
+		}
+		var groupRows []models.GroupRole
+		if err := tx.Where("expires_at IS NOT NULL AND expires_at <= ?", before).Find(&groupRows).Error; err != nil {
+			return err
+		}
+		if len(userRows) > 0 {
+			if err := tx.Where("expires_at IS NOT NULL AND expires_at <= ?", before).Delete(&models.UserRole{}).Error; err != nil {
+				return err
+			}
+		}
+		if len(groupRows) > 0 {
+			if err := tx.Where("expires_at IS NOT NULL AND expires_at <= ?", before).Delete(&models.GroupRole{}).Error; err != nil {
+				return err
+			}
+		}
+		for _, r := range userRows {
+			removed = append(removed, storage.RoleAssignment{
+				PrincipalType: "user", PrincipalID: r.UserID, RoleID: r.RoleID,
+				ProjectID: r.ProjectID, EnvironmentID: r.EnvironmentID,
+			})
+		}
+		for _, r := range groupRows {
+			removed = append(removed, storage.RoleAssignment{
+				PrincipalType: "group", PrincipalID: r.GroupID, RoleID: r.RoleID,
+				ProjectID: r.ProjectID, EnvironmentID: r.EnvironmentID,
+			})
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	return removed, nil
 }
 
 // RemoveRoleFromGroup removes a role from a group at scope.
@@ -386,6 +459,7 @@ func (ls *LocalStorage) GetUserPermissions(ctx context.Context, userID uint) ([]
 		Joins("JOIN role_permissions ON permissions.id = role_permissions.permission_id").
 		Joins("JOIN user_roles ON role_permissions.role_id = user_roles.role_id").
 		Where("user_roles.user_id = ?", userID).
+		Where("user_roles.expires_at IS NULL OR user_roles.expires_at > ?", time.Now()).
 		Group("permissions.id").
 		Find(&permissions).Error
 	if err != nil {

--- a/internal/storage/store/remote_rbac.go
+++ b/internal/storage/store/remote_rbac.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
@@ -134,6 +135,22 @@ func (rs *RemoteStorage) AssignRole(ctx context.Context, userID, roleID uint, sc
 		return fmt.Errorf("assign role failed: %s", resp.Error.Error())
 	}
 	return nil
+}
+
+// AssignRoleWithExpiry is server-side only (the JIT grant happens during access-
+// request approval on the server); not driven over the remote client.
+func (rs *RemoteStorage) AssignRoleWithExpiry(_ context.Context, _, _ uint, _ storage.Scope, _ time.Time) error {
+	return remoteUnsupported("AssignRoleWithExpiry")
+}
+
+// AssignRoleToGroupWithExpiry is server-side only; see AssignRoleWithExpiry.
+func (rs *RemoteStorage) AssignRoleToGroupWithExpiry(_ context.Context, _, _ uint, _ storage.Scope, _ time.Time) error {
+	return remoteUnsupported("AssignRoleToGroupWithExpiry")
+}
+
+// DeleteExpiredRoleGrants is server-side only (run by the expiry scheduler).
+func (rs *RemoteStorage) DeleteExpiredRoleGrants(_ context.Context, _ time.Time) ([]storage.RoleAssignment, error) {
+	return nil, remoteUnsupported("DeleteExpiredRoleGrants")
 }
 
 // RemoveRole removes a role from a user at scope via remote API.

--- a/server/http/handlers/invitations.go
+++ b/server/http/handlers/invitations.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/keyorixhq/keyorix/internal/core"
@@ -273,6 +274,9 @@ func (h *CatalogHandler) ResolveAccessRequest(w http.ResponseWriter, r *http.Req
 		Action      string `json:"action"`
 		GrantedRole string `json:"granted_role"`
 		Reason      string `json:"reason"`
+		// GrantTTL (optional) makes an approval time-bound (just-in-time access):
+		// a Go duration string (e.g. "4h", "30m"). Empty/absent = permanent grant.
+		GrantTTL string `json:"grant_ttl"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		sendError(w, "InvalidJSON", "Invalid request body", http.StatusBadRequest, nil)
@@ -281,7 +285,15 @@ func (h *CatalogHandler) ResolveAccessRequest(w http.ResponseWriter, r *http.Req
 	var resolveErr error
 	switch body.Action {
 	case "approve":
-		_, resolveErr = h.coreService.ApproveAccessRequest(r.Context(), uint(projectID), uint(reqID), actor.UserID, body.GrantedRole)
+		var ttl time.Duration
+		if body.GrantTTL != "" {
+			ttl, err = time.ParseDuration(body.GrantTTL)
+			if err != nil || ttl < 0 {
+				sendError(w, "ValidationError", "grant_ttl must be a non-negative Go duration (e.g. 4h)", http.StatusBadRequest, nil)
+				return
+			}
+		}
+		_, resolveErr = h.coreService.ApproveAccessRequestWithExpiry(r.Context(), uint(projectID), uint(reqID), actor.UserID, body.GrantedRole, ttl)
 	case "reject":
 		_, resolveErr = h.coreService.RejectAccessRequest(r.Context(), uint(projectID), uint(reqID), actor.UserID, body.Reason)
 	default:

--- a/server/http/handlers/openapi.yaml
+++ b/server/http/handlers/openapi.yaml
@@ -1008,6 +1008,7 @@ paths:
               properties:
                 action: {type: string, enum: [approve, reject]}
                 granted_role: {type: string, description: Role to grant on approve}
+                grant_ttl: {type: string, description: "Optional on approve — time-bound (just-in-time) the granted role; a Go duration (e.g. 4h, 30m). Empty/absent = permanent. The grant stops authorizing once the TTL elapses and is swept by the JIT expiry scheduler."}
                 reason: {type: string, description: Reason on reject}
       responses:
         '200':

--- a/server/main.go
+++ b/server/main.go
@@ -140,6 +140,7 @@ const (
 	schedLockLoginPrune   int64 = 0x4B455953_4C474E50 // "KEYSLGNP"
 	schedLockRotationRmdr int64 = 0x4B455953_524F5452 // "KEYSROTR"
 	schedLockAuditCkpt    int64 = 0x4B455953_41434B50 // "KEYSACKP"
+	schedLockJITExpiry    int64 = 0x4B455953_4A495445 // "KEYSJITE"
 )
 
 // initializeEncryption sources the KEK per the configured key provider (ADR-038)
@@ -471,6 +472,44 @@ func startHTTPServer(ctx context.Context, cfg *config.Config) error {
 				}
 			}()
 		}
+	}
+
+	// Start the JIT access-expiry sweeper — opt-in. Removes time-bound role grants
+	// whose expiry has passed (auditing each as role.expired) and reclaims the rows.
+	// Expired grants already stop authorizing immediately (the auth queries filter
+	// on expiry); this just keeps the tables clean and writes the expiry audit trail.
+	if cfg.JITAccessExpiry.Enabled {
+		interval := cfg.JITAccessExpiry.GetInterval()
+		log.Printf("JIT access-expiry sweeper enabled: every %s", interval)
+		go func() {
+			ticker := time.NewTicker(interval)
+			defer ticker.Stop()
+			runSweep := func() {
+				// Single-replica-gated (ADR-039): one replica sweeps per tick.
+				if _, err := coreService.Storage().WithSchedulerLock(ctx, schedLockJITExpiry, func() error {
+					n, rerr := coreService.RemoveExpiredRoleGrants(ctx, time.Now())
+					if rerr != nil {
+						log.Printf("JIT access-expiry sweep error: %v", rerr)
+						return rerr
+					}
+					if n > 0 {
+						log.Printf("JIT access-expiry sweep removed %d expired grant(s)", n)
+					}
+					return nil
+				}); err != nil {
+					log.Printf("JIT access-expiry scheduler error: %v", err)
+				}
+			}
+			runSweep() // run once on startup
+			for {
+				select {
+				case <-ticker.C:
+					runSweep()
+				case <-ctx.Done():
+					return
+				}
+			}
+		}()
 	}
 
 	// Start the dynamic-secrets auto-revoke sweeper (ADR-035) — opt-in. Revokes


### PR DESCRIPTION
## What

Role grants can now carry an **expiry**, so access can be granted **just-in-time** and auto-expire — the time-bound-access half of the recertification story (ISO 27001 A.5.18, least-privilege). Builds on the access-review series (#169/#170/#171).

## Enforcement is immediate (not sweep-dependent)

The security crux: an expired grant must stop authorizing the **instant** it passes, not whenever a sweeper next runs. So the filter `expires_at IS NULL OR expires_at > now` is applied to every query that gates a permission decision or builds `UserContext`:

- `GetUserRoleIDsAt`, `GetUserGroupRoleIDsAt`, `CheckPermission` — the scope-aware authorization path (`Authorize`)
- `GetUserRoles`, `GetUserPermissions` — the flat lists feeding `UserContext.Roles`/`Permissions` (HTTP session/PAT, gRPC identity, `RequireRole`)

A background **sweeper** then reclaims the expired rows and audits each as `role.expired`.

## Surfaces

- **model**: `ExpiresAt *time.Time` on `UserRole` + `GroupRole` (additive, nullable, auto-migrated).
- **storage**: `AssignRoleWithExpiry` / `AssignRoleToGroupWithExpiry`; `DeleteExpiredRoleGrants` (select-then-delete in a tx, returns removed grants for auditing); expiry filter on the five queries above. RemoteStorage stubs return unsupported (server-side only); mock + interface updated.
- **core**: `AssignUserRoleWithExpiry` / `AssignGroupRoleWithExpiry`; `RemoveExpiredRoleGrants` (per-grant `role.expired` audit, system actor); new `EventRoleExpired`.
- **access-request approval**: `ApproveAccessRequestWithExpiry` grants time-bound when a TTL is given (expiry from the server clock, never client input; negative TTL rejected at handler/CLI/core). Wired via the resolve API (`grant_ttl`) and `keyorix request review --ttl 4h`.
- **scheduler**: opt-in `jit_access_expiry` sweeper, HA single-replica-gated (ADR-039, lock `KEYSJITE`), default 1h.

## Security review

Ran an adversarial review of the authorization change. Confirmed empirically (via GORM `ToSQL`) that each chained `.Where` is AND-parenthesized, so the generated SQL is `… AND (expires_at IS NULL OR expires_at > ?)` — **not** the precedence-bug shape that would leak any user's future-dated grant. The review surfaced that two gRPC self-scoped-read endpoints + the latent `RequireRole` middleware authorized off the unfiltered flat lists; **fixed in this PR** by filtering `GetUserRoles`/`GetUserPermissions` too (regression test added). Sweep, approval-path, and remote stubs all verified sound.

## Tests

Expired grant excluded from both scope-aware and flat auth queries (no cross-user leak); sweep removes only expired (never permanent/future) and audits; approve-with-TTL sets a ~TTL expiry; no-TTL stays permanent; sweep idempotent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)