### PR TITLE
feat(access-review): periodic recertification campaigns (A — ISO 27001 A.5.18)

### DIFF
--- a/docs/REMOTE_CLI_SETUP.md
+++ b/docs/REMOTE_CLI_SETUP.md
@@ -227,6 +227,33 @@ keyorix access-review revoke --project-id 5 --source role --principal-type group
 keyorix access-review revoke --project-id 5 --source direct_share --principal-id 42 --secret-id 500
 ```
 
+For a **tracked, periodic** recertification (ISO 27001 A.5.18 — review "at planned
+intervals"), run a **campaign**: open it to snapshot the current access into
+reviewable items, decide each, then close it to freeze the cycle as audit evidence.
+Reads need `roles.read`, mutations `roles.assign`.
+
+- `keyorix access-review campaign open --project-id N [--name "…"]` — open a campaign
+  (snapshots current access into pending items).
+- `keyorix access-review campaign list --project-id N` — campaigns + progress
+  (total / pending / attested / revoked).
+- `keyorix access-review campaign show --project-id N --campaign-id C` — the campaign
+  and each item (snapshot + decision); note the `ITEM` ids for `decide`.
+- `keyorix access-review campaign decide --project-id N --campaign-id C --item-id I
+  --action attest|revoke [--reason "…"]` — decide one item (revoke removes the grant).
+- `keyorix access-review campaign close --project-id N --campaign-id C [--force]` —
+  close the campaign (refuses while items are pending unless `--force`).
+
+```bash
+# Open the quarterly campaign and list items to review:
+keyorix access-review campaign open --project-id 5 --name "Q4 2026 access recertification"
+keyorix access-review campaign show --project-id 5 --campaign-id 1
+
+# Keep item 7, revoke item 9, then close once every item is decided:
+keyorix access-review campaign decide --project-id 5 --campaign-id 1 --item-id 7 --action attest
+keyorix access-review campaign decide --project-id 5 --campaign-id 1 --item-id 9 --action revoke --reason "left team"
+keyorix access-review campaign close --project-id 5 --campaign-id 1
+```
+
 ## Deployment Scenarios
 
 ### Development Environment

--- a/internal/cli/accessreview/campaign.go
+++ b/internal/cli/accessreview/campaign.go
@@ -1,0 +1,241 @@
+// campaign.go — `keyorix access-review campaign …`: manage periodic
+// access-recertification campaigns (ISO 27001 A.5.18). Open snapshots the current
+// access review into items; decide attests/revokes each; close freezes the cycle
+// as evidence. Talks to /api/v1/projects/{id}/access-review/campaigns (reads need
+// roles.read, mutations roles.assign, at the project scope).
+package accessreview
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/spf13/cobra"
+)
+
+type campaignView struct {
+	ID        uint   `json:"id"`
+	ProjectID uint   `json:"project_id"`
+	Name      string `json:"name"`
+	State     string `json:"state"`
+}
+
+type progressView struct {
+	Total    int `json:"total"`
+	Pending  int `json:"pending"`
+	Attested int `json:"attested"`
+	Revoked  int `json:"revoked"`
+}
+
+type itemView struct {
+	ID            uint   `json:"id"`
+	PrincipalType string `json:"principal_type"`
+	PrincipalName string `json:"principal_name"`
+	Email         string `json:"email"`
+	Source        string `json:"source"`
+	RoleName      string `json:"role_name"`
+	AccessLevel   string `json:"access_level"`
+	SecretName    string `json:"secret_name"`
+	Decision      string `json:"decision"`
+}
+
+var (
+	cProject  int
+	cCampaign int
+	cItem     int
+	cName     string
+	cAction   string
+	cReason   string
+	cForce    bool
+)
+
+var campaignCmd = &cobra.Command{
+	Use:   "campaign",
+	Short: "Manage access-review campaigns (periodic recertification cycles, A.5.18)",
+	Long: `Run periodic access recertification as a tracked campaign: open snapshots the
+project's current access into reviewable items, decide attests or revokes each, and
+close freezes the cycle as audit evidence.`,
+}
+
+func campaignBase(project int) string {
+	return "/api/v1/projects/" + strconv.Itoa(project) + "/access-review/campaigns"
+}
+
+func progressStr(p progressView) string {
+	return fmt.Sprintf("%d total — %d pending, %d attested, %d revoked", p.Total, p.Pending, p.Attested, p.Revoked)
+}
+
+var campaignOpenCmd = &cobra.Command{
+	Use:          "open",
+	Short:        "Open a new access-review campaign (snapshots current access)",
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		if cProject <= 0 {
+			return fmt.Errorf("--project-id is required")
+		}
+		c, ok := common.NewRemoteClient()
+		if !ok {
+			return fmt.Errorf("not connected to a server — run: keyorix connect <server>")
+		}
+		var out struct {
+			Campaign campaignView `json:"campaign"`
+			Progress progressView `json:"progress"`
+		}
+		if err := c.Post(context.Background(), campaignBase(cProject), map[string]string{"name": cName}, &out); err != nil {
+			return err
+		}
+		fmt.Printf("Opened campaign %d (%q) for project %d — %s.\n", out.Campaign.ID, out.Campaign.Name, cProject, progressStr(out.Progress))
+		fmt.Printf("Review items: keyorix access-review campaign show --project-id %d --campaign-id %d\n", cProject, out.Campaign.ID)
+		return nil
+	},
+}
+
+var campaignListCmd = &cobra.Command{
+	Use:          "list",
+	Short:        "List a project's access-review campaigns",
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		if cProject <= 0 {
+			return fmt.Errorf("--project-id is required")
+		}
+		c, ok := common.NewRemoteClient()
+		if !ok {
+			return fmt.Errorf("not connected to a server — run: keyorix connect <server>")
+		}
+		var out struct {
+			Campaigns []struct {
+				Campaign campaignView `json:"campaign"`
+				Progress progressView `json:"progress"`
+			} `json:"campaigns"`
+			Count int `json:"count"`
+		}
+		if err := c.Get(context.Background(), campaignBase(cProject), &out); err != nil {
+			return err
+		}
+		if out.Count == 0 {
+			fmt.Printf("No access-review campaigns for project %d.\n", cProject)
+			return nil
+		}
+		fmt.Printf("Access-review campaigns — project %d:\n\n", cProject)
+		fmt.Printf("%-5s %-8s %-28s %s\n", "ID", "STATE", "NAME", "PROGRESS")
+		for _, c := range out.Campaigns {
+			fmt.Printf("%-5d %-8s %-28s %s\n", c.Campaign.ID, c.Campaign.State, truncate(c.Campaign.Name, 28), progressStr(c.Progress))
+		}
+		return nil
+	},
+}
+
+var campaignShowCmd = &cobra.Command{
+	Use:          "show",
+	Short:        "Show a campaign and its items (snapshot + decisions)",
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		if cProject <= 0 || cCampaign <= 0 {
+			return fmt.Errorf("--project-id and --campaign-id are required")
+		}
+		c, ok := common.NewRemoteClient()
+		if !ok {
+			return fmt.Errorf("not connected to a server — run: keyorix connect <server>")
+		}
+		var out struct {
+			Campaign campaignView `json:"campaign"`
+			Items    []itemView   `json:"items"`
+			Progress progressView `json:"progress"`
+		}
+		if err := c.Get(context.Background(), campaignBase(cProject)+"/"+strconv.Itoa(cCampaign), &out); err != nil {
+			return err
+		}
+		fmt.Printf("Campaign %d (%q) — %s — %s\n\n", out.Campaign.ID, out.Campaign.Name, out.Campaign.State, progressStr(out.Progress))
+		if len(out.Items) == 0 {
+			fmt.Println("No items.")
+			return nil
+		}
+		fmt.Printf("%-6s %-10s %-13s %-24s %-7s %s\n", "ITEM", "DECISION", "SOURCE", "PRINCIPAL", "ACCESS", "DETAIL")
+		for _, it := range out.Items {
+			principal := it.PrincipalName
+			if it.PrincipalType == "user" && it.Email != "" {
+				principal = fmt.Sprintf("%s <%s>", it.PrincipalName, it.Email)
+			}
+			detail := "secret=" + it.SecretName
+			if it.Source == "role" {
+				detail = "role=" + it.RoleName
+			}
+			fmt.Printf("%-6d %-10s %-13s %-24s %-7s %s\n", it.ID, it.Decision, it.Source, truncate(principal, 24), it.AccessLevel, detail)
+		}
+		return nil
+	},
+}
+
+var campaignDecideCmd = &cobra.Command{
+	Use:          "decide",
+	Short:        "Decide on one campaign item: attest (keep) or revoke",
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		if cProject <= 0 || cCampaign <= 0 || cItem <= 0 {
+			return fmt.Errorf("--project-id, --campaign-id and --item-id are required")
+		}
+		if cAction != "attest" && cAction != "revoke" {
+			return fmt.Errorf("--action must be attest or revoke")
+		}
+		c, ok := common.NewRemoteClient()
+		if !ok {
+			return fmt.Errorf("not connected to a server — run: keyorix connect <server>")
+		}
+		path := fmt.Sprintf("%s/%d/items/%d/decide", campaignBase(cProject), cCampaign, cItem)
+		var out struct{}
+		if err := c.Post(context.Background(), path, map[string]string{"action": cAction, "reason": cReason}, &out); err != nil {
+			return err
+		}
+		fmt.Printf("Item %d %sed in campaign %d.\n", cItem, cAction, cCampaign)
+		return nil
+	},
+}
+
+var campaignCloseCmd = &cobra.Command{
+	Use:          "close",
+	Short:        "Close a campaign (freeze as evidence); refuses pending items unless --force",
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		if cProject <= 0 || cCampaign <= 0 {
+			return fmt.Errorf("--project-id and --campaign-id are required")
+		}
+		c, ok := common.NewRemoteClient()
+		if !ok {
+			return fmt.Errorf("not connected to a server — run: keyorix connect <server>")
+		}
+		path := fmt.Sprintf("%s/%d/close", campaignBase(cProject), cCampaign)
+		var out struct {
+			Campaign campaignView `json:"campaign"`
+			Progress progressView `json:"progress"`
+		}
+		if err := c.Post(context.Background(), path, map[string]bool{"force": cForce}, &out); err != nil {
+			return err
+		}
+		fmt.Printf("Closed campaign %d — %s.\n", out.Campaign.ID, progressStr(out.Progress))
+		return nil
+	},
+}
+
+func init() {
+	campaignOpenCmd.Flags().IntVar(&cProject, "project-id", 0, "Project to review (required)")
+	campaignOpenCmd.Flags().StringVar(&cName, "name", "", "Campaign name (e.g. \"Q4 2026 access recertification\")")
+
+	campaignListCmd.Flags().IntVar(&cProject, "project-id", 0, "Project (required)")
+
+	campaignShowCmd.Flags().IntVar(&cProject, "project-id", 0, "Project (required)")
+	campaignShowCmd.Flags().IntVar(&cCampaign, "campaign-id", 0, "Campaign to show (required)")
+
+	campaignDecideCmd.Flags().IntVar(&cProject, "project-id", 0, "Project (required)")
+	campaignDecideCmd.Flags().IntVar(&cCampaign, "campaign-id", 0, "Campaign (required)")
+	campaignDecideCmd.Flags().IntVar(&cItem, "item-id", 0, "Item to decide (required)")
+	campaignDecideCmd.Flags().StringVar(&cAction, "action", "", "attest | revoke (required)")
+	campaignDecideCmd.Flags().StringVar(&cReason, "reason", "", "Optional reviewer note")
+
+	campaignCloseCmd.Flags().IntVar(&cProject, "project-id", 0, "Project (required)")
+	campaignCloseCmd.Flags().IntVar(&cCampaign, "campaign-id", 0, "Campaign to close (required)")
+	campaignCloseCmd.Flags().BoolVar(&cForce, "force", false, "Close even if items remain pending")
+
+	campaignCmd.AddCommand(campaignOpenCmd, campaignListCmd, campaignShowCmd, campaignDecideCmd, campaignCloseCmd)
+	AccessReviewCmd.AddCommand(campaignCmd)
+}

--- a/internal/core/access_review_campaign.go
+++ b/internal/core/access_review_campaign.go
@@ -1,0 +1,250 @@
+// access_review_campaign.go — periodic access-recertification campaigns (ISO 27001
+// A.5.18, "review access rights at planned intervals"). A campaign turns the
+// point-in-time access review (access_review.go) into a managed cycle:
+//
+//   - Open  — snapshot the project's current access-review entries into immutable
+//     campaign items (each "pending"). Audited access_review.campaign_opened.
+//   - Decide — a reviewer attests (keeps) or revokes each item; revoke removes the
+//     underlying grant via RevokeAccessReviewGrant. Each decision is audited.
+//   - Close — freeze the campaign as evidence the review was performed; refuses
+//     while items are still pending unless forced. Audited access_review.campaign_closed.
+package core
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// Campaign + item states and decision actions.
+const (
+	CampaignStateOpen   = "open"
+	CampaignStateClosed = "closed"
+
+	ReviewItemPending  = "pending"
+	ReviewItemAttested = "attested"
+	ReviewItemRevoked  = "revoked"
+
+	EventCampaignOpened = "access_review.campaign_opened" // #nosec G101 -- audit event type, not a credential
+	EventCampaignClosed = "access_review.campaign_closed" // #nosec G101 -- audit event type, not a credential
+)
+
+// CampaignProgress summarises a campaign's recertification state.
+type CampaignProgress struct {
+	Total    int `json:"total"`
+	Pending  int `json:"pending"`
+	Attested int `json:"attested"`
+	Revoked  int `json:"revoked"`
+}
+
+// CampaignWithProgress is a campaign plus its decision tally (for list views).
+type CampaignWithProgress struct {
+	Campaign *models.AccessReviewCampaign `json:"campaign"`
+	Progress CampaignProgress             `json:"progress"`
+}
+
+// CampaignDetail is a campaign with its items and progress (for the detail view).
+type CampaignDetail struct {
+	Campaign *models.AccessReviewCampaign `json:"campaign"`
+	Items    []*models.AccessReviewItem   `json:"items"`
+	Progress CampaignProgress             `json:"progress"`
+}
+
+func tallyProgress(items []*models.AccessReviewItem) CampaignProgress {
+	p := CampaignProgress{Total: len(items)}
+	for _, it := range items {
+		switch it.Decision {
+		case ReviewItemAttested:
+			p.Attested++
+		case ReviewItemRevoked:
+			p.Revoked++
+		default:
+			p.Pending++
+		}
+	}
+	return p
+}
+
+// OpenAccessReviewCampaign snapshots the project's current access review into a new
+// campaign's items (each pending) and returns the campaign with its (all-pending)
+// progress. actorID is the opener.
+func (c *KeyorixCore) OpenAccessReviewCampaign(ctx context.Context, actorID, projectID uint, name string) (*CampaignWithProgress, error) {
+	if projectID == 0 {
+		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "project ID is required")
+	}
+	entries, err := c.GenerateProjectAccessReview(ctx, projectID)
+	if err != nil {
+		return nil, err
+	}
+	if name == "" {
+		name = "Access review"
+	}
+	campaign, err := c.storage.CreateAccessReviewCampaign(ctx, &models.AccessReviewCampaign{
+		ProjectID: projectID,
+		Name:      name,
+		State:     CampaignStateOpen,
+		CreatedBy: actorID,
+		CreatedAt: c.now(),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	items := make([]*models.AccessReviewItem, 0, len(entries))
+	for _, e := range entries {
+		items = append(items, &models.AccessReviewItem{
+			CampaignID:    campaign.ID,
+			PrincipalType: e.PrincipalType,
+			PrincipalID:   e.PrincipalID,
+			PrincipalName: e.PrincipalName,
+			Email:         e.Email,
+			Source:        e.Source,
+			RoleID:        e.RoleID,
+			RoleName:      e.RoleName,
+			AccessLevel:   e.AccessLevel,
+			EnvironmentID: e.EnvironmentID,
+			SecretID:      e.SecretID,
+			SecretName:    e.SecretName,
+			Decision:      ReviewItemPending,
+		})
+	}
+	if err := c.storage.CreateAccessReviewItems(ctx, items); err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	c.auditProjectScoped(ctx, EventCampaignOpened, actorID, projectID,
+		fmt.Sprintf("opened access-review campaign %d (%q) with %d item(s)", campaign.ID, name, len(items)))
+	return &CampaignWithProgress{Campaign: campaign, Progress: CampaignProgress{Total: len(items), Pending: len(items)}}, nil
+}
+
+// ListAccessReviewCampaigns returns the project's campaigns, newest first, each
+// with its decision tally.
+func (c *KeyorixCore) ListAccessReviewCampaigns(ctx context.Context, projectID uint) ([]*CampaignWithProgress, error) {
+	if projectID == 0 {
+		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "project ID is required")
+	}
+	campaigns, err := c.storage.ListAccessReviewCampaigns(ctx, projectID)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	out := make([]*CampaignWithProgress, 0, len(campaigns))
+	for _, camp := range campaigns {
+		items, err := c.storage.ListAccessReviewItems(ctx, camp.ID)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+		}
+		out = append(out, &CampaignWithProgress{Campaign: camp, Progress: tallyProgress(items)})
+	}
+	return out, nil
+}
+
+// loadScopedCampaign fetches a campaign and enforces that it belongs to projectID
+// (so a campaign id from another project cannot be reached through this project's
+// scope — the same cross-project guard as the access-request flow).
+func (c *KeyorixCore) loadScopedCampaign(ctx context.Context, projectID, campaignID uint) (*models.AccessReviewCampaign, error) {
+	campaign, err := c.storage.GetAccessReviewCampaign(ctx, campaignID)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorNotFound", nil), err)
+	}
+	if campaign.ProjectID != projectID {
+		return nil, fmt.Errorf("%s", i18n.T("ErrorNotFound", nil))
+	}
+	return campaign, nil
+}
+
+// GetAccessReviewCampaign returns a campaign (scoped to projectID), its items, and
+// its progress.
+func (c *KeyorixCore) GetAccessReviewCampaign(ctx context.Context, projectID, campaignID uint) (*CampaignDetail, error) {
+	campaign, err := c.loadScopedCampaign(ctx, projectID, campaignID)
+	if err != nil {
+		return nil, err
+	}
+	items, err := c.storage.ListAccessReviewItems(ctx, campaignID)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	return &CampaignDetail{Campaign: campaign, Items: items, Progress: tallyProgress(items)}, nil
+}
+
+// DecideAccessReviewItem records a reviewer's decision on one item of an open
+// campaign: "attest" keeps the grant (evidence only), "revoke" removes the
+// underlying grant via RevokeAccessReviewGrant. actorID is the reviewer.
+func (c *KeyorixCore) DecideAccessReviewItem(ctx context.Context, actorID, projectID, campaignID, itemID uint, action, reason string) error {
+	campaign, err := c.loadScopedCampaign(ctx, projectID, campaignID)
+	if err != nil {
+		return err
+	}
+	if campaign.State != CampaignStateOpen {
+		return fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "campaign is closed; decisions can only be made on an open campaign")
+	}
+	item, err := c.storage.GetAccessReviewItem(ctx, itemID)
+	if err != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorNotFound", nil), err)
+	}
+	if item.CampaignID != campaignID {
+		return fmt.Errorf("%s", i18n.T("ErrorNotFound", nil))
+	}
+
+	decision := AccessReviewDecision{
+		Source:        item.Source,
+		PrincipalType: item.PrincipalType,
+		PrincipalID:   item.PrincipalID,
+		RoleID:        item.RoleID,
+		EnvironmentID: item.EnvironmentID,
+		SecretID:      item.SecretID,
+	}
+	switch action {
+	case "attest":
+		if err := c.AttestAccessReviewGrant(ctx, actorID, projectID, decision); err != nil {
+			return err
+		}
+		item.Decision = ReviewItemAttested
+	case "revoke":
+		if err := c.RevokeAccessReviewGrant(ctx, actorID, projectID, decision); err != nil {
+			return err
+		}
+		item.Decision = ReviewItemRevoked
+	default:
+		return fmt.Errorf("%s: action must be attest or revoke", i18n.T("ErrorValidation", nil))
+	}
+	now := c.now()
+	item.Reason = reason
+	item.DecidedBy = actorID
+	item.DecidedAt = &now
+	if err := c.storage.UpdateAccessReviewItem(ctx, item); err != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	return nil
+}
+
+// CloseAccessReviewCampaign freezes a campaign as the evidence record. It refuses
+// while items remain pending unless force is set (so an auditor sees either a fully
+// decided cycle or an explicit early close). actorID is the closer.
+func (c *KeyorixCore) CloseAccessReviewCampaign(ctx context.Context, actorID, projectID, campaignID uint, force bool) (*CampaignWithProgress, error) {
+	campaign, err := c.loadScopedCampaign(ctx, projectID, campaignID)
+	if err != nil {
+		return nil, err
+	}
+	if campaign.State == CampaignStateClosed {
+		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "campaign is already closed")
+	}
+	items, err := c.storage.ListAccessReviewItems(ctx, campaignID)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	progress := tallyProgress(items)
+	if progress.Pending > 0 && !force {
+		return nil, fmt.Errorf("%s: %d item(s) still pending — decide them or close with force", i18n.T("ErrorValidation", nil), progress.Pending)
+	}
+	now := c.now()
+	campaign.State = CampaignStateClosed
+	campaign.ClosedBy = actorID
+	campaign.ClosedAt = &now
+	if err := c.storage.UpdateAccessReviewCampaign(ctx, campaign); err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	c.auditProjectScoped(ctx, EventCampaignClosed, actorID, projectID,
+		fmt.Sprintf("closed access-review campaign %d: %d attested, %d revoked, %d pending of %d",
+			campaign.ID, progress.Attested, progress.Revoked, progress.Pending, progress.Total))
+	return &CampaignWithProgress{Campaign: campaign, Progress: progress}, nil
+}

--- a/internal/core/access_review_campaign_external_test.go
+++ b/internal/core/access_review_campaign_external_test.go
@@ -1,0 +1,156 @@
+package core_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/testhelper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func migrateCampaignTables(t *testing.T, h *testhelper.RBACTestHelper) {
+	require.NoError(t, h.DB.AutoMigrate(&models.AccessReviewCampaign{}, &models.AccessReviewItem{}, &models.AuditEvent{}))
+}
+
+// Opening a campaign snapshots the current access review into pending items.
+func TestOpenAccessReviewCampaign_SnapshotsEntries(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	migrateCampaignTables(t, h)
+
+	const proj = uint(2)
+	ctx := context.Background()
+	h.CreateTestUser(t, "alice", 10)
+	h.AssignUserRole(t, 10, 3, uptr(proj)) // editor → one role entry
+
+	res, err := h.CoreService.OpenAccessReviewCampaign(ctx, 1, proj, "Q4 2026")
+	require.NoError(t, err)
+	assert.Equal(t, core.CampaignStateOpen, res.Campaign.State)
+	assert.Equal(t, "Q4 2026", res.Campaign.Name)
+	assert.Equal(t, 1, res.Progress.Total)
+	assert.Equal(t, 1, res.Progress.Pending)
+
+	detail, err := h.CoreService.GetAccessReviewCampaign(ctx, proj, res.Campaign.ID)
+	require.NoError(t, err)
+	require.Len(t, detail.Items, 1)
+	assert.Equal(t, core.ReviewItemPending, detail.Items[0].Decision)
+	assert.Equal(t, "alice", detail.Items[0].PrincipalName)
+}
+
+// Attesting an item marks it kept; revoking removes the underlying grant.
+func TestDecideAccessReviewItem_AttestAndRevoke(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	migrateCampaignTables(t, h)
+
+	const proj = uint(2)
+	ctx := context.Background()
+	h.CreateTestUser(t, "alice", 10)
+	h.CreateTestUser(t, "bob", 11)
+	h.AssignUserRole(t, 10, 3, uptr(proj)) // alice editor
+	h.AssignUserRole(t, 11, 4, uptr(proj)) // bob viewer
+
+	res, err := h.CoreService.OpenAccessReviewCampaign(ctx, 1, proj, "review")
+	require.NoError(t, err)
+	detail, err := h.CoreService.GetAccessReviewCampaign(ctx, proj, res.Campaign.ID)
+	require.NoError(t, err)
+	require.Len(t, detail.Items, 2)
+
+	// Identify alice's and bob's items.
+	var aliceItem, bobItem uint
+	for _, it := range detail.Items {
+		if it.PrincipalID == 10 {
+			aliceItem = it.ID
+		} else if it.PrincipalID == 11 {
+			bobItem = it.ID
+		}
+	}
+	require.NotZero(t, aliceItem)
+	require.NotZero(t, bobItem)
+
+	// Attest alice (kept), revoke bob (removed).
+	require.NoError(t, h.CoreService.DecideAccessReviewItem(ctx, 1, proj, res.Campaign.ID, aliceItem, "attest", ""))
+	require.NoError(t, h.CoreService.DecideAccessReviewItem(ctx, 1, proj, res.Campaign.ID, bobItem, "revoke", "left team"))
+
+	after, err := h.CoreService.GetAccessReviewCampaign(ctx, proj, res.Campaign.ID)
+	require.NoError(t, err)
+	assert.Equal(t, 1, after.Progress.Attested)
+	assert.Equal(t, 1, after.Progress.Revoked)
+	assert.Equal(t, 0, after.Progress.Pending)
+
+	// bob's editor/viewer grant is actually gone from the live review; alice's stays.
+	review, err := h.CoreService.GenerateProjectAccessReview(ctx, proj)
+	require.NoError(t, err)
+	var names []string
+	for _, e := range review {
+		names = append(names, e.PrincipalName)
+	}
+	assert.Contains(t, names, "alice")
+	assert.NotContains(t, names, "bob")
+}
+
+// Closing refuses while items are pending unless forced; a closed campaign rejects
+// further decisions.
+func TestCloseAccessReviewCampaign_PendingGuardAndForce(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	migrateCampaignTables(t, h)
+
+	const proj = uint(2)
+	ctx := context.Background()
+	h.CreateTestUser(t, "alice", 10)
+	h.AssignUserRole(t, 10, 3, uptr(proj))
+
+	res, err := h.CoreService.OpenAccessReviewCampaign(ctx, 1, proj, "review")
+	require.NoError(t, err)
+
+	// One pending item → close without force fails.
+	_, err = h.CoreService.CloseAccessReviewCampaign(ctx, 1, proj, res.Campaign.ID, false)
+	require.Error(t, err)
+
+	// Force-close succeeds and freezes the campaign.
+	closed, err := h.CoreService.CloseAccessReviewCampaign(ctx, 1, proj, res.Campaign.ID, true)
+	require.NoError(t, err)
+	assert.Equal(t, core.CampaignStateClosed, closed.Campaign.State)
+
+	// A closed campaign rejects further decisions.
+	detail, err := h.CoreService.GetAccessReviewCampaign(ctx, proj, res.Campaign.ID)
+	require.NoError(t, err)
+	err = h.CoreService.DecideAccessReviewItem(ctx, 1, proj, res.Campaign.ID, detail.Items[0].ID, "attest", "")
+	require.Error(t, err)
+
+	// Re-closing is rejected.
+	_, err = h.CoreService.CloseAccessReviewCampaign(ctx, 1, proj, res.Campaign.ID, true)
+	require.Error(t, err)
+}
+
+// A campaign id from another project is not reachable through this project's scope.
+func TestAccessReviewCampaign_CrossProjectGuard(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	migrateCampaignTables(t, h)
+
+	ctx := context.Background()
+	h.CreateTestUser(t, "alice", 10)
+	h.AssignUserRole(t, 10, 3, uptr(uint(2)))
+
+	res, err := h.CoreService.OpenAccessReviewCampaign(ctx, 1, 2, "p2")
+	require.NoError(t, err)
+
+	// Reaching campaign (project 2) through project 3 must fail.
+	_, err = h.CoreService.GetAccessReviewCampaign(ctx, 3, res.Campaign.ID)
+	require.Error(t, err)
+	err = h.CoreService.DecideAccessReviewItem(ctx, 1, 3, res.Campaign.ID, 1, "attest", "")
+	require.Error(t, err)
+}
+
+func TestOpenAccessReviewCampaign_RequiresProject(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	migrateCampaignTables(t, h)
+	_, err := h.CoreService.OpenAccessReviewCampaign(context.Background(), 1, 0, "x")
+	require.Error(t, err)
+}

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -166,6 +166,61 @@ func (m *MockStorage) ListAccessRequests(ctx context.Context, projectID uint) ([
 	return args.Get(0).([]*models.AccessRequest), args.Error(1)
 }
 
+func (m *MockStorage) CreateAccessReviewCampaign(ctx context.Context, c *models.AccessReviewCampaign) (*models.AccessReviewCampaign, error) {
+	args := m.Called(ctx, c)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.AccessReviewCampaign), args.Error(1)
+}
+
+func (m *MockStorage) GetAccessReviewCampaign(ctx context.Context, id uint) (*models.AccessReviewCampaign, error) {
+	args := m.Called(ctx, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.AccessReviewCampaign), args.Error(1)
+}
+
+func (m *MockStorage) ListAccessReviewCampaigns(ctx context.Context, projectID uint) ([]*models.AccessReviewCampaign, error) {
+	args := m.Called(ctx, projectID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*models.AccessReviewCampaign), args.Error(1)
+}
+
+func (m *MockStorage) UpdateAccessReviewCampaign(ctx context.Context, c *models.AccessReviewCampaign) error {
+	args := m.Called(ctx, c)
+	return args.Error(0)
+}
+
+func (m *MockStorage) CreateAccessReviewItems(ctx context.Context, items []*models.AccessReviewItem) error {
+	args := m.Called(ctx, items)
+	return args.Error(0)
+}
+
+func (m *MockStorage) ListAccessReviewItems(ctx context.Context, campaignID uint) ([]*models.AccessReviewItem, error) {
+	args := m.Called(ctx, campaignID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*models.AccessReviewItem), args.Error(1)
+}
+
+func (m *MockStorage) GetAccessReviewItem(ctx context.Context, id uint) (*models.AccessReviewItem, error) {
+	args := m.Called(ctx, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.AccessReviewItem), args.Error(1)
+}
+
+func (m *MockStorage) UpdateAccessReviewItem(ctx context.Context, item *models.AccessReviewItem) error {
+	args := m.Called(ctx, item)
+	return args.Error(0)
+}
+
 func (m *MockStorage) GetEnvironment(_ context.Context, id uint) (*models.Environment, error) {
 	return &models.Environment{ID: id, ProjectID: 1, Name: "test"}, nil
 }

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -59,6 +59,17 @@ type Storage interface {
 	GetAccessRequest(ctx context.Context, id uint) (*models.AccessRequest, error)
 	UpdateAccessRequest(ctx context.Context, req *models.AccessRequest) error
 	ListAccessRequests(ctx context.Context, projectID uint) ([]*models.AccessRequest, error)
+
+	// Access-review campaigns (ISO 27001 A.5.18) — periodic recertification cycles
+	// and the per-grant items captured within them.
+	CreateAccessReviewCampaign(ctx context.Context, c *models.AccessReviewCampaign) (*models.AccessReviewCampaign, error)
+	GetAccessReviewCampaign(ctx context.Context, id uint) (*models.AccessReviewCampaign, error)
+	ListAccessReviewCampaigns(ctx context.Context, projectID uint) ([]*models.AccessReviewCampaign, error)
+	UpdateAccessReviewCampaign(ctx context.Context, c *models.AccessReviewCampaign) error
+	CreateAccessReviewItems(ctx context.Context, items []*models.AccessReviewItem) error
+	ListAccessReviewItems(ctx context.Context, campaignID uint) ([]*models.AccessReviewItem, error)
+	GetAccessReviewItem(ctx context.Context, id uint) (*models.AccessReviewItem, error)
+	UpdateAccessReviewItem(ctx context.Context, item *models.AccessReviewItem) error
 	// Machine identities (ADR-023) — non-human project members.
 	CreateMachineIdentity(ctx context.Context, m *models.MachineIdentity) (*models.MachineIdentity, error)
 	GetMachineIdentity(ctx context.Context, id uint) (*models.MachineIdentity, error)

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -252,6 +252,7 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 	patExists := tableExists(db, "personal_access_tokens")
 	invitationsExists := tableExists(db, "project_invitations")
 	accessReqExists := tableExists(db, "access_requests")
+	campaignExists := tableExists(db, "access_review_campaigns")
 	pwHistExists := tableExists(db, "password_histories")
 	machineExists := tableExists(db, "machine_identities")
 	machineCredExists := tableExists(db, "machine_identity_credentials")
@@ -381,6 +382,13 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 	if !accessReqExists {
 		if err := db.AutoMigrate(&models.AccessRequest{}); err != nil {
 			return fmt.Errorf("failed to migrate access_requests table: %w", err)
+		}
+	}
+
+	// Create the access-review campaign tables if missing (A.5.18, additive).
+	if !campaignExists {
+		if err := db.AutoMigrate(&models.AccessReviewCampaign{}, &models.AccessReviewItem{}); err != nil {
+			return fmt.Errorf("failed to migrate access_review_campaign tables: %w", err)
 		}
 	}
 

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -70,6 +70,48 @@ type AccessRequest struct {
 	ResolvedAt    *time.Time
 }
 
+// AccessReviewCampaign is a periodic access-recertification cycle for a project
+// (ISO 27001 A.5.18 — review at planned intervals). Opening a campaign snapshots
+// the project's current access-review entries into AccessReviewItem rows; reviewers
+// then decide each (attest/revoke); closing it freezes the record as evidence the
+// review was performed. State machine: open → closed.
+type AccessReviewCampaign struct {
+	ID        uint       `gorm:"primaryKey" json:"id"`
+	ProjectID uint       `gorm:"index" json:"project_id"`
+	Name      string     `json:"name"`  // human label, e.g. "Q4 2026 access recertification"
+	State     string     `json:"state"` // open | closed
+	CreatedBy uint       `json:"created_by"`
+	CreatedAt time.Time  `json:"created_at"`
+	ClosedBy  uint       `json:"closed_by,omitempty"`
+	ClosedAt  *time.Time `json:"closed_at,omitempty"`
+}
+
+// AccessReviewItem is one access grant captured in a campaign at open time, plus
+// the reviewer's recertification decision. The grant fields mirror an
+// AccessReviewEntry (a frozen snapshot — the live grant may change or be revoked
+// after capture). Decision: pending → attested | revoked.
+type AccessReviewItem struct {
+	ID         uint `gorm:"primaryKey" json:"id"`
+	CampaignID uint `gorm:"index" json:"campaign_id"`
+	// Snapshot of the AccessReviewEntry at open time.
+	PrincipalType string `json:"principal_type"`
+	PrincipalID   uint   `json:"principal_id"`
+	PrincipalName string `json:"principal_name"`
+	Email         string `json:"email,omitempty"`
+	Source        string `json:"source"` // role | owner | direct_share | group_share
+	RoleID        uint   `json:"role_id,omitempty"`
+	RoleName      string `json:"role_name,omitempty"`
+	AccessLevel   string `json:"access_level"`
+	EnvironmentID uint   `json:"environment_id"`
+	SecretID      uint   `json:"secret_id,omitempty"`
+	SecretName    string `json:"secret_name,omitempty"`
+	// Recertification decision.
+	Decision  string     `json:"decision"`         // pending | attested | revoked
+	Reason    string     `json:"reason,omitempty"` // optional reviewer note
+	DecidedBy uint       `json:"decided_by,omitempty"`
+	DecidedAt *time.Time `json:"decided_at,omitempty"`
+}
+
 type User struct {
 	ID           uint   `gorm:"primaryKey"`
 	Username     string `gorm:"uniqueIndex;not null"`

--- a/internal/storage/store/local_access_review_campaigns.go
+++ b/internal/storage/store/local_access_review_campaigns.go
@@ -1,0 +1,87 @@
+// local_access_review_campaigns.go — access-review campaign + item persistence
+// (ISO 27001 A.5.18). For the remote (HTTP) equivalent see
+// remote_access_review_campaigns.go (server-side only — stubs there).
+package store
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// --- Campaigns ---
+
+func (ls *LocalStorage) CreateAccessReviewCampaign(ctx context.Context, c *models.AccessReviewCampaign) (*models.AccessReviewCampaign, error) {
+	if err := ls.db.WithContext(ctx).Create(c).Error; err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	return c, nil
+}
+
+func (ls *LocalStorage) GetAccessReviewCampaign(ctx context.Context, id uint) (*models.AccessReviewCampaign, error) {
+	var c models.AccessReviewCampaign
+	if err := ls.db.WithContext(ctx).First(&c, id).Error; err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorNotFound", nil), err)
+	}
+	return &c, nil
+}
+
+func (ls *LocalStorage) ListAccessReviewCampaigns(ctx context.Context, projectID uint) ([]*models.AccessReviewCampaign, error) {
+	var rows []*models.AccessReviewCampaign
+	err := ls.db.WithContext(ctx).
+		Where("project_id = ?", projectID).
+		Order("created_at DESC").
+		Find(&rows).Error
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	return rows, nil
+}
+
+func (ls *LocalStorage) UpdateAccessReviewCampaign(ctx context.Context, c *models.AccessReviewCampaign) error {
+	if err := ls.db.WithContext(ctx).Save(c).Error; err != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	return nil
+}
+
+// --- Items ---
+
+func (ls *LocalStorage) CreateAccessReviewItems(ctx context.Context, items []*models.AccessReviewItem) error {
+	if len(items) == 0 {
+		return nil
+	}
+	if err := ls.db.WithContext(ctx).Create(items).Error; err != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	return nil
+}
+
+func (ls *LocalStorage) ListAccessReviewItems(ctx context.Context, campaignID uint) ([]*models.AccessReviewItem, error) {
+	var rows []*models.AccessReviewItem
+	err := ls.db.WithContext(ctx).
+		Where("campaign_id = ?", campaignID).
+		Order("id ASC").
+		Find(&rows).Error
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	return rows, nil
+}
+
+func (ls *LocalStorage) GetAccessReviewItem(ctx context.Context, id uint) (*models.AccessReviewItem, error) {
+	var item models.AccessReviewItem
+	if err := ls.db.WithContext(ctx).First(&item, id).Error; err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorNotFound", nil), err)
+	}
+	return &item, nil
+}
+
+func (ls *LocalStorage) UpdateAccessReviewItem(ctx context.Context, item *models.AccessReviewItem) error {
+	if err := ls.db.WithContext(ctx).Save(item).Error; err != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	return nil
+}

--- a/internal/storage/store/remote_access_review_campaigns.go
+++ b/internal/storage/store/remote_access_review_campaigns.go
@@ -1,0 +1,42 @@
+// remote_access_review_campaigns.go — access-review campaigns for RemoteStorage
+// (ISO 27001 A.5.18). Processed server-side; stubs here. For the local (GORM)
+// equivalent see local_access_review_campaigns.go.
+package store
+
+import (
+	"context"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+func (rs *RemoteStorage) CreateAccessReviewCampaign(_ context.Context, _ *models.AccessReviewCampaign) (*models.AccessReviewCampaign, error) {
+	return nil, remoteUnsupported("CreateAccessReviewCampaign")
+}
+
+func (rs *RemoteStorage) GetAccessReviewCampaign(_ context.Context, _ uint) (*models.AccessReviewCampaign, error) {
+	return nil, remoteUnsupported("GetAccessReviewCampaign")
+}
+
+func (rs *RemoteStorage) ListAccessReviewCampaigns(_ context.Context, _ uint) ([]*models.AccessReviewCampaign, error) {
+	return nil, remoteUnsupported("ListAccessReviewCampaigns")
+}
+
+func (rs *RemoteStorage) UpdateAccessReviewCampaign(_ context.Context, _ *models.AccessReviewCampaign) error {
+	return remoteUnsupported("UpdateAccessReviewCampaign")
+}
+
+func (rs *RemoteStorage) CreateAccessReviewItems(_ context.Context, _ []*models.AccessReviewItem) error {
+	return remoteUnsupported("CreateAccessReviewItems")
+}
+
+func (rs *RemoteStorage) ListAccessReviewItems(_ context.Context, _ uint) ([]*models.AccessReviewItem, error) {
+	return nil, remoteUnsupported("ListAccessReviewItems")
+}
+
+func (rs *RemoteStorage) GetAccessReviewItem(_ context.Context, _ uint) (*models.AccessReviewItem, error) {
+	return nil, remoteUnsupported("GetAccessReviewItem")
+}
+
+func (rs *RemoteStorage) UpdateAccessReviewItem(_ context.Context, _ *models.AccessReviewItem) error {
+	return remoteUnsupported("UpdateAccessReviewItem")
+}

--- a/server/http/handlers/access_review_campaigns.go
+++ b/server/http/handlers/access_review_campaigns.go
@@ -1,0 +1,164 @@
+// access_review_campaigns.go — endpoints for periodic access-review campaigns
+// (ISO 27001 A.5.18). All are project-scoped; gets need roles.read and mutations
+// roles.assign (wired in router.go).
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/keyorixhq/keyorix/server/middleware"
+)
+
+// campaignStatusForError maps a core error to an HTTP status (shared shape).
+func campaignStatusForError(msg string) int {
+	switch {
+	case strings.Contains(msg, "not found"):
+		return http.StatusNotFound
+	case strings.Contains(msg, "required") || strings.Contains(msg, "must be") ||
+		strings.Contains(msg, "still pending") || strings.Contains(msg, "already closed") ||
+		strings.Contains(msg, "campaign is closed") || strings.Contains(msg, "ownership cannot be revoked"):
+		return http.StatusBadRequest
+	default:
+		return http.StatusInternalServerError
+	}
+}
+
+// OpenAccessReviewCampaign handles POST /api/v1/projects/{id}/access-review/campaigns.
+func (h *CatalogHandler) OpenAccessReviewCampaign(w http.ResponseWriter, r *http.Request) {
+	projectID, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		sendError(w, "InvalidParameter", "Invalid project ID", http.StatusBadRequest, nil)
+		return
+	}
+	userCtx := middleware.GetUserFromContext(r.Context())
+	if userCtx == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	var body struct {
+		Name string `json:"name"`
+	}
+	// Body is optional; ignore decode errors on an empty body.
+	_ = json.NewDecoder(r.Body).Decode(&body)
+	result, err := h.coreService.OpenAccessReviewCampaign(r.Context(), userCtx.UserID, uint(projectID), body.Name)
+	if err != nil {
+		sendError(w, "Error", err.Error(), campaignStatusForError(err.Error()), nil)
+		return
+	}
+	w.WriteHeader(http.StatusCreated)
+	sendSuccess(w, map[string]interface{}{"campaign": result.Campaign, "progress": result.Progress}, "Campaign opened")
+}
+
+// ListAccessReviewCampaigns handles GET /api/v1/projects/{id}/access-review/campaigns.
+func (h *CatalogHandler) ListAccessReviewCampaigns(w http.ResponseWriter, r *http.Request) {
+	projectID, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		sendError(w, "InvalidParameter", "Invalid project ID", http.StatusBadRequest, nil)
+		return
+	}
+	campaigns, err := h.coreService.ListAccessReviewCampaigns(r.Context(), uint(projectID))
+	if err != nil {
+		sendError(w, "Error", err.Error(), http.StatusInternalServerError, nil)
+		return
+	}
+	sendSuccess(w, map[string]interface{}{"campaigns": campaigns, "count": len(campaigns)}, "")
+}
+
+// GetAccessReviewCampaign handles GET /api/v1/projects/{id}/access-review/campaigns/{campaignId}.
+func (h *CatalogHandler) GetAccessReviewCampaign(w http.ResponseWriter, r *http.Request) {
+	projectID, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		sendError(w, "InvalidParameter", "Invalid project ID", http.StatusBadRequest, nil)
+		return
+	}
+	campaignID, err := strconv.ParseUint(chi.URLParam(r, "campaignId"), 10, 32)
+	if err != nil {
+		sendError(w, "InvalidParameter", "Invalid campaign ID", http.StatusBadRequest, nil)
+		return
+	}
+	detail, err := h.coreService.GetAccessReviewCampaign(r.Context(), uint(projectID), uint(campaignID))
+	if err != nil {
+		sendError(w, "Error", err.Error(), campaignStatusForError(err.Error()), nil)
+		return
+	}
+	sendSuccess(w, map[string]interface{}{
+		"campaign": detail.Campaign, "items": detail.Items, "progress": detail.Progress,
+	}, "")
+}
+
+// DecideAccessReviewCampaignItem handles
+// POST /api/v1/projects/{id}/access-review/campaigns/{campaignId}/items/{itemId}/decide.
+func (h *CatalogHandler) DecideAccessReviewCampaignItem(w http.ResponseWriter, r *http.Request) {
+	projectID, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		sendError(w, "InvalidParameter", "Invalid project ID", http.StatusBadRequest, nil)
+		return
+	}
+	campaignID, err := strconv.ParseUint(chi.URLParam(r, "campaignId"), 10, 32)
+	if err != nil {
+		sendError(w, "InvalidParameter", "Invalid campaign ID", http.StatusBadRequest, nil)
+		return
+	}
+	itemID, err := strconv.ParseUint(chi.URLParam(r, "itemId"), 10, 32)
+	if err != nil {
+		sendError(w, "InvalidParameter", "Invalid item ID", http.StatusBadRequest, nil)
+		return
+	}
+	userCtx := middleware.GetUserFromContext(r.Context())
+	if userCtx == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	var body struct {
+		Action string `json:"action"`
+		Reason string `json:"reason"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		sendError(w, "InvalidJSON", "Invalid request body", http.StatusBadRequest, nil)
+		return
+	}
+	if body.Action == "" {
+		sendError(w, "ValidationError", "action is required (attest|revoke)", http.StatusBadRequest, nil)
+		return
+	}
+	if err := h.coreService.DecideAccessReviewItem(r.Context(), userCtx.UserID, uint(projectID), uint(campaignID), uint(itemID), body.Action, body.Reason); err != nil {
+		sendError(w, "Error", err.Error(), campaignStatusForError(err.Error()), nil)
+		return
+	}
+	sendSuccess(w, nil, "Decision recorded")
+}
+
+// CloseAccessReviewCampaign handles
+// POST /api/v1/projects/{id}/access-review/campaigns/{campaignId}/close.
+func (h *CatalogHandler) CloseAccessReviewCampaign(w http.ResponseWriter, r *http.Request) {
+	projectID, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		sendError(w, "InvalidParameter", "Invalid project ID", http.StatusBadRequest, nil)
+		return
+	}
+	campaignID, err := strconv.ParseUint(chi.URLParam(r, "campaignId"), 10, 32)
+	if err != nil {
+		sendError(w, "InvalidParameter", "Invalid campaign ID", http.StatusBadRequest, nil)
+		return
+	}
+	userCtx := middleware.GetUserFromContext(r.Context())
+	if userCtx == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	var body struct {
+		Force bool `json:"force"`
+	}
+	_ = json.NewDecoder(r.Body).Decode(&body)
+	result, err := h.coreService.CloseAccessReviewCampaign(r.Context(), userCtx.UserID, uint(projectID), uint(campaignID), body.Force)
+	if err != nil {
+		sendError(w, "Error", err.Error(), campaignStatusForError(err.Error()), nil)
+		return
+	}
+	sendSuccess(w, map[string]interface{}{"campaign": result.Campaign, "progress": result.Progress}, "Campaign closed")
+}

--- a/server/http/handlers/openapi.yaml
+++ b/server/http/handlers/openapi.yaml
@@ -576,6 +576,120 @@ paths:
         '403': {$ref: '#/components/responses/Error'}
         '404': {$ref: '#/components/responses/Error'}
 
+  /api/v1/projects/{id}/access-review/campaigns:
+    get:
+      tags: [Projects]
+      summary: List access-review campaigns (periodic recertification, A.5.18)
+      description: >-
+        The project's recertification campaigns, newest first, each with its
+        decision tally {total, pending, attested, revoked}. Requires roles.read.
+      operationId: listAccessReviewCampaigns
+      security: [{bearerAuth: []}]
+      parameters:
+        - {name: id, in: path, required: true, schema: {type: integer, format: uint32}}
+      responses:
+        '200': {description: "Envelope {data}. data: {campaigns[] of {campaign, progress}, count}."}
+        '400': {$ref: '#/components/responses/Error'}
+        '401': {$ref: '#/components/responses/Error'}
+        '403': {$ref: '#/components/responses/Error'}
+    post:
+      tags: [Projects]
+      summary: Open an access-review campaign (snapshot current access)
+      description: >-
+        Snapshot the project's current access review into per-grant campaign items
+        (each pending) for a tracked recertification cycle. Requires roles.assign.
+      operationId: openAccessReviewCampaign
+      security: [{bearerAuth: []}]
+      parameters:
+        - {name: id, in: path, required: true, schema: {type: integer, format: uint32}}
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name: {type: string, description: "Campaign label, e.g. \"Q4 2026 access recertification\""}
+      responses:
+        '201': {description: "Envelope {data}. data: {campaign, progress}."}
+        '400': {$ref: '#/components/responses/Error'}
+        '401': {$ref: '#/components/responses/Error'}
+        '403': {$ref: '#/components/responses/Error'}
+
+  /api/v1/projects/{id}/access-review/campaigns/{campaignId}:
+    get:
+      tags: [Projects]
+      summary: Get a campaign with its items and progress
+      operationId: getAccessReviewCampaign
+      security: [{bearerAuth: []}]
+      parameters:
+        - {name: id, in: path, required: true, schema: {type: integer, format: uint32}}
+        - {name: campaignId, in: path, required: true, schema: {type: integer, format: uint32}}
+      responses:
+        '200': {description: "Envelope {data}. data: {campaign, items[] (snapshot + decision), progress}."}
+        '400': {$ref: '#/components/responses/Error'}
+        '401': {$ref: '#/components/responses/Error'}
+        '403': {$ref: '#/components/responses/Error'}
+        '404': {$ref: '#/components/responses/Error'}
+
+  /api/v1/projects/{id}/access-review/campaigns/{campaignId}/items/{itemId}/decide:
+    post:
+      tags: [Projects]
+      summary: Decide one campaign item (attest or revoke)
+      description: >-
+        Record a recertification decision on one item of an open campaign: attest
+        keeps the grant (evidence only); revoke removes the underlying grant. Both
+        audited. Requires roles.assign.
+      operationId: decideAccessReviewCampaignItem
+      security: [{bearerAuth: []}]
+      parameters:
+        - {name: id, in: path, required: true, schema: {type: integer, format: uint32}}
+        - {name: campaignId, in: path, required: true, schema: {type: integer, format: uint32}}
+        - {name: itemId, in: path, required: true, schema: {type: integer, format: uint32}}
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [action]
+              properties:
+                action: {type: string, enum: [attest, revoke]}
+                reason: {type: string, description: "Optional reviewer note"}
+      responses:
+        '200': {description: "Envelope {data, message}. Decision recorded."}
+        '400': {$ref: '#/components/responses/Error'}
+        '401': {$ref: '#/components/responses/Error'}
+        '403': {$ref: '#/components/responses/Error'}
+        '404': {$ref: '#/components/responses/Error'}
+
+  /api/v1/projects/{id}/access-review/campaigns/{campaignId}/close:
+    post:
+      tags: [Projects]
+      summary: Close a campaign (freeze as evidence)
+      description: >-
+        Freeze the campaign as the recertification evidence record. Refuses while
+        items remain pending unless force=true. Requires roles.assign.
+      operationId: closeAccessReviewCampaign
+      security: [{bearerAuth: []}]
+      parameters:
+        - {name: id, in: path, required: true, schema: {type: integer, format: uint32}}
+        - {name: campaignId, in: path, required: true, schema: {type: integer, format: uint32}}
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                force: {type: boolean, description: "Close even if items remain pending"}
+      responses:
+        '200': {description: "Envelope {data}. data: {campaign, progress}."}
+        '400': {$ref: '#/components/responses/Error'}
+        '401': {$ref: '#/components/responses/Error'}
+        '403': {$ref: '#/components/responses/Error'}
+        '404': {$ref: '#/components/responses/Error'}
+
   /api/v1/projects/{id}/members:
     get:
       tags: [Members]

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -202,6 +202,13 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		// (roles.read); revoke removes the grant and needs roles.assign.
 		r.With(customMiddleware.RequireScopedPermission("roles.read", projectScope)).Post("/projects/{id}/access-review/attest", catalogHandler.AttestProjectAccessReview)
 		r.With(customMiddleware.RequireScopedPermission("roles.assign", projectScope)).Post("/projects/{id}/access-review/revoke", catalogHandler.RevokeProjectAccessReview)
+		// Access-review campaigns (A.5.18 periodic recertification): reads roles.read,
+		// mutations roles.assign, at the project scope.
+		r.With(customMiddleware.RequireScopedPermission("roles.read", projectScope)).Get("/projects/{id}/access-review/campaigns", catalogHandler.ListAccessReviewCampaigns)
+		r.With(customMiddleware.RequireScopedPermission("roles.assign", projectScope)).Post("/projects/{id}/access-review/campaigns", catalogHandler.OpenAccessReviewCampaign)
+		r.With(customMiddleware.RequireScopedPermission("roles.read", projectScope)).Get("/projects/{id}/access-review/campaigns/{campaignId}", catalogHandler.GetAccessReviewCampaign)
+		r.With(customMiddleware.RequireScopedPermission("roles.assign", projectScope)).Post("/projects/{id}/access-review/campaigns/{campaignId}/items/{itemId}/decide", catalogHandler.DecideAccessReviewCampaignItem)
+		r.With(customMiddleware.RequireScopedPermission("roles.assign", projectScope)).Post("/projects/{id}/access-review/campaigns/{campaignId}/close", catalogHandler.CloseAccessReviewCampaign)
 		r.With(customMiddleware.RequireScopedPermission("roles.assign", projectScope)).Post("/projects/{id}/members", catalogHandler.AddProjectMember)
 		r.With(customMiddleware.RequireScopedPermission("roles.assign", projectScope)).Put("/projects/{id}/members/{userId}", catalogHandler.UpdateProjectMember)
 		r.With(customMiddleware.RequireScopedPermission("roles.assign", projectScope)).Delete("/projects/{id}/members/{userId}", catalogHandler.RemoveProjectMember)


### PR DESCRIPTION
## What

Turns the point-in-time access review (#169–#171) into a **managed, periodic recertification cycle** — the "we review access *at planned intervals*, here's the evidence" control that ISO 27001 A.5.18 actually requires (and SOC 2 CC6.2–6.3 / NIS2 / DORA expect). First item of the new access-governance batch.

**Lifecycle:**
- **Open** — snapshot the project's current access-review entries into immutable campaign items (each `pending`). Audited `access_review.campaign_opened`.
- **Decide** — a reviewer **attests** (keeps) or **revokes** each item; revoke removes the underlying grant via the existing `RevokeAccessReviewGrant`, so each decision is audited as `access_review.revoked`/`.attested`. Owner items can be attested only (can't revoke ownership).
- **Close** — freeze the campaign as the evidence record; refuses while items remain pending unless `force`. Audited `access_review.campaign_closed` with the tally.

Cross-project guard: a campaign id is only reachable through its own project's scope (`loadScopedCampaign`), mirroring the access-request flow.

## Surfaces

- **model**: `AccessReviewCampaign` (open|closed) + `AccessReviewItem` (grant snapshot + decision), JSON-tagged for snake_case output; additive migration.
- **storage**: 8 CRUD methods — Local impl, Remote stubs (unsupported; server-side only), mock, interface.
- **core**: `Open`/`List`/`Get`/`Decide`/`Close` (`access_review_campaign.go`) with progress tallies; reuses `GenerateProjectAccessReview` for the snapshot and the attest/revoke grant logic for decisions.
- **API**: `GET/POST /projects/{id}/access-review/campaigns[/{id}[/items/{id}/decide | /close]]` — reads `roles.read`, mutations `roles.assign`.
- **CLI**: `keyorix access-review campaign open|list|show|decide|close`.

## Tests

Snapshot on open; attest keeps / revoke removes the live grant; close pending-guard + force + closed-campaign-rejects-decisions; cross-project guard; requires-project.

## Docs

openapi (5 endpoints) + REMOTE_CLI_SETUP campaign section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)