### PR TITLE
feat(access-review): dormant / unused-access detection (B — least-privilege)

### DIFF
--- a/docs/REMOTE_CLI_SETUP.md
+++ b/docs/REMOTE_CLI_SETUP.md
@@ -196,7 +196,10 @@ project scope.
 - `keyorix access-review --project-id N` (aliases `recert`) — lists every grant of
   access to project N's secrets: role-based standing access (the role granting it +
   the highest secrets action) and per-secret grants (ownership and direct/group
-  shares). The `SOURCE` column says which mechanism conferred each grant.
+  shares). The `SOURCE` column says which mechanism conferred each grant. The
+  `LAST-USED` column shows how long ago each **user** last accessed a secret in the
+  project (from the audit trail) — `never` or a value marked `stale` (≥90 days)
+  flags dormant standing access to prune; groups show `—` (not aggregated).
 
 Close the recertification loop by acting on each grant — every decision is audited
 (`access_review.attested` / `access_review.revoked`):

--- a/internal/cli/accessreview/accessreview.go
+++ b/internal/cli/accessreview/accessreview.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"time"
 
 	"github.com/keyorixhq/keyorix/internal/cli/common"
 	"github.com/spf13/cobra"
@@ -46,7 +47,7 @@ at the project scope.`,
 			return nil
 		}
 		fmt.Printf("Access review — project %d (%d grant(s)):\n\n", flagProject, len(out.Entries))
-		fmt.Printf("%-13s %-6s %-26s %-7s %s\n", "SOURCE", "TYPE", "PRINCIPAL", "ACCESS", "DETAIL")
+		fmt.Printf("%-13s %-6s %-24s %-7s %-11s %s\n", "SOURCE", "TYPE", "PRINCIPAL", "ACCESS", "LAST-USED", "DETAIL")
 		for _, e := range out.Entries {
 			principal := e.PrincipalName
 			if e.PrincipalType == "user" && e.Email != "" {
@@ -63,24 +64,43 @@ at the project scope.`,
 			default: // owner / direct_share / group_share
 				detail = "secret=" + e.SecretName
 			}
-			fmt.Printf("%-13s %-6s %-26s %-7s %s\n", e.Source, e.PrincipalType, truncate(principal, 26), e.AccessLevel, detail)
+			fmt.Printf("%-13s %-6s %-24s %-7s %-11s %s\n", e.Source, e.PrincipalType, truncate(principal, 24), e.AccessLevel, lastUsedLabel(e.PrincipalType, e.LastUsedAt), detail)
 		}
 		return nil
 	},
 }
 
 type entryView struct {
-	PrincipalType string `json:"principal_type"`
-	PrincipalID   uint   `json:"principal_id"`
-	PrincipalName string `json:"principal_name"`
-	Email         string `json:"email"`
-	Source        string `json:"source"`
-	RoleID        uint   `json:"role_id"`
-	RoleName      string `json:"role_name"`
-	AccessLevel   string `json:"access_level"`
-	EnvironmentID uint   `json:"environment_id"`
-	SecretID      uint   `json:"secret_id"`
-	SecretName    string `json:"secret_name"`
+	PrincipalType string     `json:"principal_type"`
+	PrincipalID   uint       `json:"principal_id"`
+	PrincipalName string     `json:"principal_name"`
+	Email         string     `json:"email"`
+	Source        string     `json:"source"`
+	RoleID        uint       `json:"role_id"`
+	RoleName      string     `json:"role_name"`
+	AccessLevel   string     `json:"access_level"`
+	EnvironmentID uint       `json:"environment_id"`
+	SecretID      uint       `json:"secret_id"`
+	SecretName    string     `json:"secret_name"`
+	LastUsedAt    *time.Time `json:"last_used_at"`
+}
+
+// lastUsedLabel renders a principal's recency for the LAST-USED column: a short
+// age for user principals ("12d", "94d stale" past 90 days), "never" for a user
+// with no recorded secret access (the strongest dormant-access signal), and "—"
+// for groups (whose last-use is not aggregated).
+func lastUsedLabel(principalType string, t *time.Time) string {
+	if principalType != "user" {
+		return "—"
+	}
+	if t == nil || t.IsZero() {
+		return "never"
+	}
+	days := int(time.Since(*t).Hours() / 24)
+	if days >= 90 {
+		return fmt.Sprintf("%dd stale", days)
+	}
+	return fmt.Sprintf("%dd", days)
 }
 
 // decisionFlags are shared by the revoke and attest subcommands to identify one

--- a/internal/cli/accessreview/campaign.go
+++ b/internal/cli/accessreview/campaign.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"time"
 
 	"github.com/keyorixhq/keyorix/internal/cli/common"
 	"github.com/spf13/cobra"
@@ -29,15 +30,16 @@ type progressView struct {
 }
 
 type itemView struct {
-	ID            uint   `json:"id"`
-	PrincipalType string `json:"principal_type"`
-	PrincipalName string `json:"principal_name"`
-	Email         string `json:"email"`
-	Source        string `json:"source"`
-	RoleName      string `json:"role_name"`
-	AccessLevel   string `json:"access_level"`
-	SecretName    string `json:"secret_name"`
-	Decision      string `json:"decision"`
+	ID            uint       `json:"id"`
+	PrincipalType string     `json:"principal_type"`
+	PrincipalName string     `json:"principal_name"`
+	Email         string     `json:"email"`
+	Source        string     `json:"source"`
+	RoleName      string     `json:"role_name"`
+	AccessLevel   string     `json:"access_level"`
+	SecretName    string     `json:"secret_name"`
+	LastUsedAt    *time.Time `json:"last_used_at"`
+	Decision      string     `json:"decision"`
 }
 
 var (
@@ -151,7 +153,7 @@ var campaignShowCmd = &cobra.Command{
 			fmt.Println("No items.")
 			return nil
 		}
-		fmt.Printf("%-6s %-10s %-13s %-24s %-7s %s\n", "ITEM", "DECISION", "SOURCE", "PRINCIPAL", "ACCESS", "DETAIL")
+		fmt.Printf("%-6s %-10s %-13s %-22s %-7s %-11s %s\n", "ITEM", "DECISION", "SOURCE", "PRINCIPAL", "ACCESS", "LAST-USED", "DETAIL")
 		for _, it := range out.Items {
 			principal := it.PrincipalName
 			if it.PrincipalType == "user" && it.Email != "" {
@@ -161,7 +163,7 @@ var campaignShowCmd = &cobra.Command{
 			if it.Source == "role" {
 				detail = "role=" + it.RoleName
 			}
-			fmt.Printf("%-6d %-10s %-13s %-24s %-7s %s\n", it.ID, it.Decision, it.Source, truncate(principal, 24), it.AccessLevel, detail)
+			fmt.Printf("%-6d %-10s %-13s %-22s %-7s %-11s %s\n", it.ID, it.Decision, it.Source, truncate(principal, 22), it.AccessLevel, lastUsedLabel(it.PrincipalType, it.LastUsedAt), detail)
 		}
 		return nil
 	},

--- a/internal/core/access_review.go
+++ b/internal/core/access_review.go
@@ -9,6 +9,7 @@ package core
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/i18n"
@@ -34,6 +35,10 @@ type AccessReviewEntry struct {
 	EnvironmentID uint   `json:"environment_id"` // 0 = the whole project (role grants)
 	SecretID      uint   `json:"secret_id,omitempty"`
 	SecretName    string `json:"secret_name,omitempty"`
+	// LastUsedAt is the principal's most recent secret access in the project (from
+	// the audit trail) — nil = no recorded activity, the signal for dormant standing
+	// access. Set for user principals only; group last-use is not aggregated.
+	LastUsedAt *time.Time `json:"last_used_at,omitempty"`
 }
 
 // secretsActionRank orders secrets.* actions so a review reports the strongest
@@ -172,6 +177,19 @@ func (c *KeyorixCore) GenerateProjectAccessReview(ctx context.Context, projectID
 				e.PrincipalName, e.Email = resolveUser(sh.RecipientID)
 			}
 			entries = append(entries, e)
+		}
+	}
+
+	// Annotate user principals with their last secret-access time (dormant-access
+	// detection). Best-effort: a lookup failure simply leaves LastUsedAt nil.
+	if activity, err := c.storage.LastUserSecretActivity(ctx, projectID); err == nil {
+		for _, e := range entries {
+			if e.PrincipalType == "user" {
+				if t, ok := activity[e.PrincipalID]; ok {
+					tt := t
+					e.LastUsedAt = &tt
+				}
+			}
 		}
 	}
 	return entries, nil

--- a/internal/core/access_review_campaign.go
+++ b/internal/core/access_review_campaign.go
@@ -106,6 +106,7 @@ func (c *KeyorixCore) OpenAccessReviewCampaign(ctx context.Context, actorID, pro
 			EnvironmentID: e.EnvironmentID,
 			SecretID:      e.SecretID,
 			SecretName:    e.SecretName,
+			LastUsedAt:    e.LastUsedAt,
 			Decision:      ReviewItemPending,
 		})
 	}

--- a/internal/core/dormant_access_external_test.go
+++ b/internal/core/dormant_access_external_test.go
@@ -1,0 +1,77 @@
+package core_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/testhelper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The access review annotates user grants with their last secret-access time (the
+// most recent of several reads), and leaves it nil for a user with no recorded
+// activity — the dormant-access signal.
+func TestGenerateProjectAccessReview_AnnotatesLastUsed(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(&models.AuditEvent{}))
+
+	const proj = uint(2)
+	ctx := context.Background()
+	h.CreateTestUser(t, "alice", 10)
+	h.CreateTestUser(t, "bob", 11)
+	h.AssignUserRole(t, 10, 3, uptr(proj)) // alice editor — has activity
+	h.AssignUserRole(t, 11, 4, uptr(proj)) // bob viewer — never used it
+
+	pid := proj
+	aid := uint(10)
+	older := time.Now().Add(-72 * time.Hour)
+	newer := time.Now().Add(-1 * time.Hour)
+	require.NoError(t, h.DB.Create(&models.AuditEvent{EventType: "secret.read", UserID: &aid, ProjectID: &pid, EventTime: older}).Error)
+	require.NoError(t, h.DB.Create(&models.AuditEvent{EventType: "secret.read", UserID: &aid, ProjectID: &pid, EventTime: newer}).Error)
+
+	review, err := h.CoreService.GenerateProjectAccessReview(ctx, proj)
+	require.NoError(t, err)
+
+	var alice, bob *core.AccessReviewEntry
+	for _, e := range review {
+		switch e.PrincipalName {
+		case "alice":
+			alice = e
+		case "bob":
+			bob = e
+		}
+	}
+	require.NotNil(t, alice)
+	require.NotNil(t, bob)
+	require.NotNil(t, alice.LastUsedAt, "alice has recorded secret access")
+	assert.WithinDuration(t, newer, *alice.LastUsedAt, time.Second, "the most recent access wins")
+	assert.Nil(t, bob.LastUsedAt, "bob has no activity → dormant standing access")
+}
+
+// Activity in another project does not count toward this project's last-used.
+func TestGenerateProjectAccessReview_LastUsedIsProjectScoped(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(&models.AuditEvent{}))
+
+	const proj = uint(2)
+	ctx := context.Background()
+	h.CreateTestUser(t, "alice", 10)
+	h.AssignUserRole(t, 10, 3, uptr(proj))
+
+	aid := uint(10)
+	otherProj := uint(3)
+	require.NoError(t, h.DB.Create(&models.AuditEvent{
+		EventType: "secret.read", UserID: &aid, ProjectID: &otherProj, EventTime: time.Now(),
+	}).Error)
+
+	review, err := h.CoreService.GenerateProjectAccessReview(ctx, proj)
+	require.NoError(t, err)
+	require.Len(t, review, 1)
+	assert.Nil(t, review[0].LastUsedAt, "activity in project 3 doesn't count for project 2")
+}

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -221,6 +221,14 @@ func (m *MockStorage) UpdateAccessReviewItem(ctx context.Context, item *models.A
 	return args.Error(0)
 }
 
+func (m *MockStorage) LastUserSecretActivity(ctx context.Context, projectID uint) (map[uint]time.Time, error) {
+	args := m.Called(ctx, projectID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(map[uint]time.Time), args.Error(1)
+}
+
 func (m *MockStorage) GetEnvironment(_ context.Context, id uint) (*models.Environment, error) {
 	return &models.Environment{ID: id, ProjectID: 1, Name: "test"}, nil
 }

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -47,6 +47,12 @@ type Storage interface {
 	// rows for a project access review. Global (project 0) grants are excluded:
 	// those are install-level, reviewed separately.
 	ListProjectRoleAssignments(ctx context.Context, projectID uint) ([]RoleAssignment, error)
+	// LastUserSecretActivity returns, per user, the most recent secret-access time
+	// in the project (from the audit trail). Backs dormant-access detection in the
+	// access review — a grant whose principal has no recent activity is stale
+	// standing access to prune. Users with no recorded activity are absent from the
+	// map.
+	LastUserSecretActivity(ctx context.Context, projectID uint) (map[uint]time.Time, error)
 
 	// Project invitations (ADR-024).
 	CreateProjectInvitation(ctx context.Context, inv *models.ProjectInvitation) (*models.ProjectInvitation, error)

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -105,6 +105,9 @@ type AccessReviewItem struct {
 	EnvironmentID uint   `json:"environment_id"`
 	SecretID      uint   `json:"secret_id,omitempty"`
 	SecretName    string `json:"secret_name,omitempty"`
+	// LastUsedAt captures the principal's last secret-access time at open (dormant-
+	// access signal frozen into the evidence record); nil = no recorded activity.
+	LastUsedAt *time.Time `json:"last_used_at,omitempty"`
 	// Recertification decision.
 	Decision  string     `json:"decision"`         // pending | attested | revoked
 	Reason    string     `json:"reason,omitempty"` // optional reviewer note

--- a/internal/storage/store/local_access_activity.go
+++ b/internal/storage/store/local_access_activity.go
@@ -1,0 +1,52 @@
+// local_access_activity.go — last-secret-access timestamps per user, for
+// dormant-access detection in the access review. For the remote equivalent see
+// remote_access_activity.go (server-side only).
+package store
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+)
+
+// accessActivityEventTypes are the audit event types that count as "using" access
+// to a project's secrets (so a grant whose principal never triggers one is dormant).
+var accessActivityEventTypes = []string{"secret.read", "shared_secret_accessed"}
+
+// LastUserSecretActivity returns the most recent secret-access time per user in the
+// project, read from audit_events (where the read events carry user_id + project_id).
+//
+// It selects the typed event_time column ordered newest-first and keeps the first
+// row seen per user (rather than SQL MAX(), whose result is an untyped string that
+// SQLite can't scan into time.Time). No row cap — a user's only activity could be
+// old, and capping would mis-report them as never-active (a silent-truncation bug).
+func (ls *LocalStorage) LastUserSecretActivity(ctx context.Context, projectID uint) (map[uint]time.Time, error) {
+	type row struct {
+		UserID    uint
+		EventTime time.Time
+	}
+	var rows []row
+	err := ls.db.WithContext(ctx).
+		Table("audit_events").
+		Select("user_id, event_time").
+		Where("project_id = ?", projectID).
+		Where("event_type IN ?", accessActivityEventTypes).
+		Where("user_id IS NOT NULL").
+		Order("event_time DESC").
+		Scan(&rows).Error
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	out := make(map[uint]time.Time)
+	for _, r := range rows {
+		if r.UserID == 0 {
+			continue
+		}
+		if _, seen := out[r.UserID]; !seen { // first seen = latest (DESC order)
+			out[r.UserID] = r.EventTime
+		}
+	}
+	return out, nil
+}

--- a/internal/storage/store/remote_access_activity.go
+++ b/internal/storage/store/remote_access_activity.go
@@ -1,0 +1,12 @@
+// remote_access_activity.go — dormant-access activity lookup for RemoteStorage.
+// Computed server-side; stub here. See local_access_activity.go.
+package store
+
+import (
+	"context"
+	"time"
+)
+
+func (rs *RemoteStorage) LastUserSecretActivity(_ context.Context, _ uint) (map[uint]time.Time, error) {
+	return nil, remoteUnsupported("LastUserSecretActivity")
+}

--- a/server/http/handlers/openapi.yaml
+++ b/server/http/handlers/openapi.yaml
@@ -522,7 +522,9 @@ paths:
             Envelope {data, message}. data: {entries[], count}; each entry is
             {principal_type (user|group), principal_id, principal_name, email,
             source (role|owner|direct_share|group_share), role_id, role_name,
-            access_level, environment_id, secret_id, secret_name}.
+            access_level, environment_id, secret_id, secret_name, last_used_at
+            (the user principal's most recent secret access in the project — absent
+            = no recorded activity, i.e. dormant standing access)}.
         '400': {$ref: '#/components/responses/Error'}
         '401': {$ref: '#/components/responses/Error'}
         '403': {$ref: '#/components/responses/Error'}


### PR DESCRIPTION
## What

Annotates each access-review entry with the **user principal's last secret access** in the project (from the audit trail), so reviewers can spot and prune **stale standing access** — the least-privilege half of the recertification story (second item of the access-governance batch, after #173 campaigns). A grant whose principal has never used it (or not in 90+ days) is exactly what an ISO 27001 A.5.18 review should catch.

## Surfaces

- **storage**: `LastUserSecretActivity(projectID)` → last `secret.read`/`shared_secret_accessed` time per user. Selects the **typed** `event_time` column newest-first and keeps the first per user — SQL `MAX()` returns an untyped string SQLite can't scan into `time.Time`. **No row cap**, so a user whose only activity is old is never mis-reported as "never" (avoids the silent-truncation bug class).
- **core**: `GenerateProjectAccessReview` sets `AccessReviewEntry.LastUsedAt` (nil = dormant) for user principals; group last-use is not aggregated.
- **campaigns**: `AccessReviewItem` snapshots `LastUsedAt` at open, so the evidence record freezes dormancy-at-review-time.
- **CLI**: a `LAST-USED` column on `keyorix access-review` and `campaign show` — a short age, `never`, or `{n}d stale` past 90 days; `—` for groups.

## Tests

Most-recent-of-several wins; no-activity → nil; activity in another project doesn't count (project-scoped).

## Docs

`last_used_at` on the entry (openapi); LAST-USED column note (REMOTE_CLI_SETUP).

🤖 Generated with [Claude Code](https://claude.com/claude-code)