### PR TITLE
feat(access): break-glass emergency access (C — NIS2/DORA incident response)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -16,7 +16,7 @@ The config file is located via, in order: an explicit path argument, then
 - [secrets](#secrets) · [security + require_mfa](#security) (ADR-034)
 - [webauthn](#webauthn) (ADR-036) · [dynamic_secrets](#dynamic_secrets) (ADR-035)
 - [oidc](#oidc) (ADR-031) · [session](#session) · [password_policy](#password_policy) (ADR-025)
-- [soft_delete + purge](#soft_delete--purge) (ADR-032) · [rotation_reminders](#rotation_reminders) · [audit_checkpoints](#audit_checkpoints) (ADR-029) · [jit_access_expiry](#jit_access_expiry) · [audit.siem](#auditsiem)
+- [soft_delete + purge](#soft_delete--purge) (ADR-032) · [rotation_reminders](#rotation_reminders) · [audit_checkpoints](#audit_checkpoints) (ADR-029) · [jit_access_expiry](#jit_access_expiry) · [break_glass](#break_glass) · [audit.siem](#auditsiem)
 - [membership](#membership) (ADR-022) · [credential_delivery](#credential_delivery) (ADR-028)
 
 ---
@@ -369,6 +369,29 @@ sweeper (anywhere) runs.
 jit_access_expiry:
   enabled: true
   schedule: "1h"          # Go duration between expiry sweeps (default 1h)
+```
+
+## break_glass
+
+Opt-in **self-service emergency access** (incident response — NIS2/DORA). When
+enabled, any authenticated user can `POST /api/v1/projects/{id}/break-glass` (or run
+`keyorix break-glass activate`) to **immediately** self-grant the configured
+emergency role at that project — no approval. The activation is **time-bound** (it
+auto-expires via the JIT mechanism, so it stops authorizing on its own), requires a
+**written justification**, is **loudly audited** (`break_glass.activated`), and
+**alerts the project's admins**. Each activation is a queryable record for post-hoc
+review (`GET …/break-glass`, `keyorix break-glass list`).
+
+Deliberately not RBAC-gated — the point is access the caller does *not* have — so
+the controls are: it must be enabled here, every use is justified + audited +
+alerted, the grant expires, and an admin can revoke it early.
+
+```yaml
+break_glass:
+  enabled: true
+  emergency_role: "project_admin"   # role granted on activation
+  default_ttl: "4h"                 # grant lifetime when none is requested
+  max_ttl: "24h"                    # ceiling on a requested TTL
 ```
 
 ## audit.siem

--- a/docs/REMOTE_CLI_SETUP.md
+++ b/docs/REMOTE_CLI_SETUP.md
@@ -257,6 +257,29 @@ keyorix access-review campaign decide --project-id 5 --campaign-id 1 --item-id 9
 keyorix access-review campaign close --project-id 5 --campaign-id 1
 ```
 
+### Break-Glass Commands
+
+Self-service emergency access (incident response — NIS2/DORA). Must be enabled
+server-side (`break_glass` config). Activation is **not** permission-gated — the
+controls are the mandatory justification, a loud audit event, an admin alert, and
+auto-expiry. `list`/`revoke` are review actions (`roles.read` / `roles.assign`).
+
+- `keyorix break-glass activate --project-id N --justification "…" [--ttl 2h]` —
+  immediately self-grant the configured emergency role at project N, time-bound.
+- `keyorix break-glass list --project-id N` — the project's activations (an active
+  grant past its expiry shows as `expired`).
+- `keyorix break-glass revoke --project-id N --activation-id A` — end an active
+  grant early.
+
+```bash
+# On-call engineer elevates during a production incident:
+keyorix break-glass activate --project-id 5 --justification "PROD outage INC-4821" --ttl 2h
+
+# Security reviews emergency access after the incident:
+keyorix break-glass list --project-id 5
+keyorix break-glass revoke --project-id 5 --activation-id 7
+```
+
 ## Deployment Scenarios
 
 ### Development Environment

--- a/internal/cli/breakglass/breakglass.go
+++ b/internal/cli/breakglass/breakglass.go
@@ -1,0 +1,151 @@
+// Package breakglass provides `keyorix break-glass` — self-service emergency
+// access (NIS2/DORA incident response). `activate` immediately self-grants the
+// configured emergency role, time-bound, with a required justification (loudly
+// audited, admins alerted); `list` and `revoke` are the review actions. Talks to
+// /api/v1/projects/{id}/break-glass.
+package breakglass
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/spf13/cobra"
+)
+
+var (
+	bgProject    int
+	bgJustify    string
+	bgTTL        string
+	bgActivation int
+)
+
+// BreakGlassCmd is the `keyorix break-glass` command.
+var BreakGlassCmd = &cobra.Command{
+	Use:   "break-glass",
+	Short: "Self-service emergency access (incident response)",
+	Long: `Activate emergency access to a project: immediately self-grant the configured
+emergency role, time-bound and auto-expiring, with a written justification. Every
+activation is loudly audited and alerts the project's admins. Use list/revoke to
+review and end activations.`,
+}
+
+func bgBase(project int) string {
+	return "/api/v1/projects/" + strconv.Itoa(project) + "/break-glass"
+}
+
+type activationView struct {
+	ID            uint   `json:"id"`
+	UserID        uint   `json:"user_id"`
+	RoleName      string `json:"role_name"`
+	Justification string `json:"justification"`
+	State         string `json:"state"`
+	ExpiresAt     string `json:"expires_at"`
+	CreatedAt     string `json:"created_at"`
+}
+
+var activateCmd = &cobra.Command{
+	Use:          "activate",
+	Short:        "Activate emergency access (self-grant the emergency role, time-bound)",
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		if bgProject <= 0 {
+			return fmt.Errorf("--project-id is required")
+		}
+		if bgJustify == "" {
+			return fmt.Errorf("--justification is required")
+		}
+		c, ok := common.NewRemoteClient()
+		if !ok {
+			return fmt.Errorf("not connected to a server — run: keyorix connect <server>")
+		}
+		var out struct {
+			Activation activationView `json:"activation"`
+		}
+		body := map[string]string{"justification": bgJustify, "ttl": bgTTL}
+		if err := c.Post(context.Background(), bgBase(bgProject), body, &out); err != nil {
+			return err
+		}
+		fmt.Printf("Emergency access activated (id=%d): role %q until %s.\n",
+			out.Activation.ID, out.Activation.RoleName, out.Activation.ExpiresAt)
+		return nil
+	},
+}
+
+var listCmd = &cobra.Command{
+	Use:          "list",
+	Short:        "List a project's break-glass activations (for review)",
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		if bgProject <= 0 {
+			return fmt.Errorf("--project-id is required")
+		}
+		c, ok := common.NewRemoteClient()
+		if !ok {
+			return fmt.Errorf("not connected to a server — run: keyorix connect <server>")
+		}
+		var out struct {
+			Activations []activationView `json:"activations"`
+			Count       int              `json:"count"`
+		}
+		if err := c.Get(context.Background(), bgBase(bgProject), &out); err != nil {
+			return err
+		}
+		if out.Count == 0 {
+			fmt.Printf("No break-glass activations for project %d.\n", bgProject)
+			return nil
+		}
+		fmt.Printf("Break-glass activations — project %d:\n\n", bgProject)
+		fmt.Printf("%-5s %-8s %-9s %-16s %-20s %s\n", "ID", "USER", "STATE", "ROLE", "EXPIRES", "JUSTIFICATION")
+		for _, a := range out.Activations {
+			fmt.Printf("%-5d %-8d %-9s %-16s %-20s %s\n", a.ID, a.UserID, a.State, truncate(a.RoleName, 16), a.ExpiresAt, a.Justification)
+		}
+		return nil
+	},
+}
+
+var revokeCmd = &cobra.Command{
+	Use:          "revoke",
+	Short:        "Revoke an active emergency grant early",
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		if bgProject <= 0 || bgActivation <= 0 {
+			return fmt.Errorf("--project-id and --activation-id are required")
+		}
+		c, ok := common.NewRemoteClient()
+		if !ok {
+			return fmt.Errorf("not connected to a server — run: keyorix connect <server>")
+		}
+		path := fmt.Sprintf("%s/%d/revoke", bgBase(bgProject), bgActivation)
+		var out struct{}
+		if err := c.Post(context.Background(), path, map[string]string{}, &out); err != nil {
+			return err
+		}
+		fmt.Printf("Revoked break-glass activation %d in project %d.\n", bgActivation, bgProject)
+		return nil
+	},
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	if n <= 1 {
+		return s[:n]
+	}
+	return s[:n-1] + "…"
+}
+
+func init() {
+	activateCmd.Flags().IntVar(&bgProject, "project-id", 0, "Project to activate emergency access for (required)")
+	activateCmd.Flags().StringVar(&bgJustify, "justification", "", "Written reason for emergency access (required)")
+	activateCmd.Flags().StringVar(&bgTTL, "ttl", "", "Grant lifetime override, e.g. 2h (default + capped by server config)")
+
+	listCmd.Flags().IntVar(&bgProject, "project-id", 0, "Project (required)")
+
+	revokeCmd.Flags().IntVar(&bgProject, "project-id", 0, "Project (required)")
+	revokeCmd.Flags().IntVar(&bgActivation, "activation-id", 0, "Activation to revoke (required)")
+
+	BreakGlassCmd.AddCommand(activateCmd, listCmd, revokeCmd)
+}

--- a/internal/cli/main.go
+++ b/internal/cli/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/keyorixhq/keyorix/internal/cli/anomalies"
 	"github.com/keyorixhq/keyorix/internal/cli/audit"
 	"github.com/keyorixhq/keyorix/internal/cli/auth"
+	"github.com/keyorixhq/keyorix/internal/cli/breakglass"
 	"github.com/keyorixhq/keyorix/internal/cli/config"
 	"github.com/keyorixhq/keyorix/internal/cli/connect"
 	"github.com/keyorixhq/keyorix/internal/cli/dynamic"
@@ -65,6 +66,7 @@ func init() {
 	rootCmd.AddCommand(audit.AuditCmd)
 	rootCmd.AddCommand(rotation.RotationCmd)
 	rootCmd.AddCommand(accessreview.AccessReviewCmd)
+	rootCmd.AddCommand(breakglass.BreakGlassCmd)
 }
 
 // Execute runs the root command

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,6 +31,8 @@ type Config struct {
 	// JITAccessExpiry configures the opt-in background sweeper that removes
 	// time-bound role grants whose expiry has passed (just-in-time access).
 	JITAccessExpiry JITAccessExpiryConfig `yaml:"jit_access_expiry"`
+	// BreakGlass configures opt-in self-service emergency access (incident response).
+	BreakGlass BreakGlassConfig `yaml:"break_glass"`
 	// DynamicSecrets configures the on-demand database-credentials engine and its
 	// auto-revoke sweep (ADR-035). Disabled (zero value) = the API is still served
 	// but no background sweeper runs; enable to auto-revoke leases at expiry.
@@ -509,6 +511,37 @@ func (c JITAccessExpiryConfig) GetInterval() time.Duration {
 		}
 	}
 	return time.Hour
+}
+
+// BreakGlassConfig configures self-service emergency access (break-glass): a user
+// can immediately self-grant a time-bound emergency role with a written
+// justification, loudly audited, for incident response (NIS2/DORA). Opt-in
+// (default off — disabled means the endpoint refuses).
+type BreakGlassConfig struct {
+	Enabled       bool   `yaml:"enabled"`
+	EmergencyRole string `yaml:"emergency_role"` // role granted on activation (e.g. "project_admin")
+	DefaultTTL    string `yaml:"default_ttl"`    // grant lifetime when none requested (e.g. "4h")
+	MaxTTL        string `yaml:"max_ttl"`        // ceiling on a requested TTL (e.g. "24h")
+}
+
+// GetDefaultTTL returns the default emergency-grant lifetime; defaults to 4h.
+func (c BreakGlassConfig) GetDefaultTTL() time.Duration {
+	if c.DefaultTTL != "" {
+		if d, err := time.ParseDuration(c.DefaultTTL); err == nil && d > 0 {
+			return d
+		}
+	}
+	return 4 * time.Hour
+}
+
+// GetMaxTTL returns the ceiling on a requested emergency-grant TTL; defaults to 24h.
+func (c BreakGlassConfig) GetMaxTTL() time.Duration {
+	if c.MaxTTL != "" {
+		if d, err := time.ParseDuration(c.MaxTTL); err == nil && d > 0 {
+			return d
+		}
+	}
+	return 24 * time.Hour
 }
 
 // WebAuthnConfig configures the WebAuthn relying party (ADR-036). RPID is the

--- a/internal/core/break_glass.go
+++ b/internal/core/break_glass.go
@@ -1,0 +1,183 @@
+// break_glass.go — self-service emergency access ("break-glass"). When enabled, a
+// user can immediately self-grant a configured emergency role, time-bound (it
+// auto-expires via the JIT mechanism), with a mandatory written justification. The
+// activation is loudly audited (break_glass.activated) and fans out an alert to the
+// project's admins, and is recorded as a queryable BreakGlassActivation for
+// post-hoc review (NIS2/DORA incident response). Deliberately un-gated by RBAC —
+// the whole point is access the user does NOT already have — so the controls are:
+// it must be enabled, every use is justified + audited + alerted, and it expires.
+package core
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// Break-glass states and audit events.
+const (
+	BreakGlassActive  = "active"
+	BreakGlassExpired = "expired"
+	BreakGlassRevoked = "revoked"
+
+	EventBreakGlassActivated = "break_glass.activated" // #nosec G101 -- audit event type, not a credential
+	EventBreakGlassRevoked   = "break_glass.revoked"   // #nosec G101 -- audit event type, not a credential
+)
+
+// BreakGlassPolicy is the deployment configuration for emergency access, wired from
+// config at startup via SetBreakGlassPolicy.
+type BreakGlassPolicy struct {
+	Enabled       bool
+	EmergencyRole string
+	DefaultTTL    time.Duration
+	MaxTTL        time.Duration
+}
+
+// SetBreakGlassPolicy configures self-service emergency access (default: disabled).
+func (c *KeyorixCore) SetBreakGlassPolicy(p BreakGlassPolicy) {
+	c.breakGlassPolicy = p
+}
+
+// ActivateBreakGlass immediately grants the requesting user the configured emergency
+// role at the project scope, time-bound (default or a capped requested TTL), records
+// the justified activation, audits it loudly, and alerts the project's admins.
+// userID is the activating (self) user; ttlOverride is an optional Go duration.
+func (c *KeyorixCore) ActivateBreakGlass(ctx context.Context, projectID, userID uint, justification, ttlOverride string) (*models.BreakGlassActivation, error) {
+	if !c.breakGlassPolicy.Enabled {
+		return nil, fmt.Errorf("%s", i18n.T("ErrorPermissionDenied", nil))
+	}
+	if projectID == 0 || userID == 0 {
+		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "project ID and user are required")
+	}
+	if justification == "" {
+		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "a justification is required for emergency access")
+	}
+	if c.breakGlassPolicy.EmergencyRole == "" {
+		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "no emergency role is configured")
+	}
+	role, err := c.storage.GetRoleByName(ctx, c.breakGlassPolicy.EmergencyRole)
+	if err != nil {
+		return nil, fmt.Errorf("emergency role %q not found: %w", c.breakGlassPolicy.EmergencyRole, err)
+	}
+
+	ttl := c.breakGlassPolicy.DefaultTTL
+	if ttl <= 0 {
+		ttl = 4 * time.Hour
+	}
+	if ttlOverride != "" {
+		d, perr := time.ParseDuration(ttlOverride)
+		if perr != nil || d <= 0 {
+			return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "ttl must be a positive Go duration (e.g. 2h)")
+		}
+		ttl = d
+	}
+	if max := c.breakGlassPolicy.MaxTTL; max > 0 && ttl > max {
+		ttl = max // cap a requested TTL at the configured ceiling
+	}
+
+	now := c.now()
+	expiresAt := now.Add(ttl)
+	scope := storage.Scope{ProjectID: projectID}
+	// Self-granted: actor == the activating user. Time-bound so it auto-expires.
+	if err := c.AssignUserRoleWithExpiry(ctx, userID, userID, role.ID, scope, expiresAt); err != nil {
+		return nil, fmt.Errorf("failed to grant emergency role: %w", err)
+	}
+
+	activation, err := c.storage.CreateBreakGlassActivation(ctx, &models.BreakGlassActivation{
+		ProjectID:     projectID,
+		UserID:        userID,
+		RoleID:        role.ID,
+		RoleName:      role.Name,
+		Justification: justification,
+		State:         BreakGlassActive,
+		ExpiresAt:     &expiresAt,
+		CreatedAt:     now,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+
+	c.auditProjectScoped(ctx, EventBreakGlassActivated, userID, projectID,
+		fmt.Sprintf("break-glass: user %d self-granted %q until %s — %s",
+			userID, role.Name, expiresAt.UTC().Format(time.RFC3339), justification))
+	c.notifyBreakGlassAdmins(ctx, userID, projectID, role.Name, expiresAt)
+	return activation, nil
+}
+
+// ListBreakGlassActivations returns the project's activations, newest first. An
+// active record whose expiry has passed is reported as expired (the grant is gone
+// by then, swept or filtered out — the record's stored state is reconciled lazily).
+func (c *KeyorixCore) ListBreakGlassActivations(ctx context.Context, projectID uint) ([]*models.BreakGlassActivation, error) {
+	if projectID == 0 {
+		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "project ID is required")
+	}
+	rows, err := c.storage.ListBreakGlassActivations(ctx, projectID)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	now := c.now()
+	for _, a := range rows {
+		if a.State == BreakGlassActive && a.ExpiresAt != nil && a.ExpiresAt.Before(now) {
+			a.State = BreakGlassExpired
+		}
+	}
+	return rows, nil
+}
+
+// RevokeBreakGlass ends an active emergency grant early: removes the role assignment
+// (best-effort — it may already have auto-expired) and marks the record revoked.
+// actorID is the admin performing the revoke.
+func (c *KeyorixCore) RevokeBreakGlass(ctx context.Context, actorID, projectID, activationID uint) error {
+	if projectID == 0 {
+		return fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "project ID is required")
+	}
+	activation, err := c.storage.GetBreakGlassActivation(ctx, activationID)
+	if err != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorNotFound", nil), err)
+	}
+	if activation.ProjectID != projectID {
+		return fmt.Errorf("%s", i18n.T("ErrorNotFound", nil))
+	}
+	if activation.State != BreakGlassActive {
+		return fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "activation is not active")
+	}
+	// Remove the grant early. If it already auto-expired the row is gone — ignore
+	// that error and still reconcile the record.
+	scope := storage.Scope{ProjectID: projectID}
+	_ = c.RemoveUserRole(ctx, actorID, activation.UserID, activation.RoleID, scope)
+
+	now := c.now()
+	activation.State = BreakGlassRevoked
+	activation.RevokedBy = actorID
+	activation.RevokedAt = &now
+	if err := c.storage.UpdateBreakGlassActivation(ctx, activation); err != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	c.auditProjectScoped(ctx, EventBreakGlassRevoked, actorID, projectID,
+		fmt.Sprintf("break-glass: revoked activation %d (user %d, role %q) early", activation.ID, activation.UserID, activation.RoleName))
+	return nil
+}
+
+// notifyBreakGlassAdmins alerts the project's approver-role members that emergency
+// access was activated (best-effort).
+func (c *KeyorixCore) notifyBreakGlassAdmins(ctx context.Context, actorID, projectID uint, roleName string, expiresAt time.Time) {
+	members, err := c.storage.ListProjectMembers(ctx, projectID)
+	if err != nil {
+		return
+	}
+	pid := projectID
+	title := "Break-glass emergency access activated"
+	msg := fmt.Sprintf("User %d self-granted emergency role %q until %s. Review the audit trail.",
+		actorID, roleName, expiresAt.UTC().Format(time.RFC3339))
+	link := fmt.Sprintf("/projects/%d/access-review", projectID)
+	for _, m := range members {
+		if !isApproverRole(m.RoleName) {
+			continue
+		}
+		c.notify(ctx, m.UserID, EventBreakGlassActivated, title, msg, &pid, link)
+	}
+}

--- a/internal/core/break_glass_external_test.go
+++ b/internal/core/break_glass_external_test.go
@@ -1,0 +1,137 @@
+package core_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/testhelper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func enableBreakGlass(h *testhelper.RBACTestHelper, role string, def, max time.Duration) {
+	h.CoreService.SetBreakGlassPolicy(core.BreakGlassPolicy{
+		Enabled: true, EmergencyRole: role, DefaultTTL: def, MaxTTL: max,
+	})
+}
+
+func migrateBreakGlass(t *testing.T, h *testhelper.RBACTestHelper) {
+	require.NoError(t, h.DB.AutoMigrate(&models.BreakGlassActivation{}, &models.AuditEvent{}))
+}
+
+// Activating break-glass time-bound-grants the configured emergency role to the
+// caller and records the justified activation.
+func TestActivateBreakGlass_GrantsTimeBoundRole(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	migrateBreakGlass(t, h)
+	enableBreakGlass(h, "editor", 4*time.Hour, 24*time.Hour) // role 3
+
+	const proj = uint(2)
+	ctx := context.Background()
+	h.CreateTestUser(t, "alice", 10)
+
+	act, err := h.CoreService.ActivateBreakGlass(ctx, proj, 10, "prod incident #42", "")
+	require.NoError(t, err)
+	assert.Equal(t, core.BreakGlassActive, act.State)
+	assert.Equal(t, uint(3), act.RoleID)
+	require.NotNil(t, act.ExpiresAt)
+	assert.WithinDuration(t, time.Now().Add(4*time.Hour), *act.ExpiresAt, 2*time.Minute)
+
+	// alice now holds the emergency (editor) role at the project, time-bound.
+	ids, err := h.Storage.GetUserRoleIDsAt(ctx, 10, storage.Scope{ProjectID: proj})
+	require.NoError(t, err)
+	assert.Contains(t, ids, uint(3), "emergency role is active")
+
+	list, err := h.CoreService.ListBreakGlassActivations(ctx, proj)
+	require.NoError(t, err)
+	require.Len(t, list, 1)
+	assert.Equal(t, "prod incident #42", list[0].Justification)
+}
+
+// A requested TTL is capped at the configured maximum.
+func TestActivateBreakGlass_CapsTTL(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	migrateBreakGlass(t, h)
+	enableBreakGlass(h, "editor", 4*time.Hour, 1*time.Hour) // max 1h
+
+	ctx := context.Background()
+	h.CreateTestUser(t, "alice", 10)
+	act, err := h.CoreService.ActivateBreakGlass(ctx, 2, 10, "incident", "10h")
+	require.NoError(t, err)
+	require.NotNil(t, act.ExpiresAt)
+	assert.WithinDuration(t, time.Now().Add(1*time.Hour), *act.ExpiresAt, 2*time.Minute, "10h request capped at the 1h max")
+}
+
+// Break-glass refuses when disabled, and a justification is mandatory.
+func TestActivateBreakGlass_DisabledAndJustificationRequired(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	migrateBreakGlass(t, h)
+
+	ctx := context.Background()
+	h.CreateTestUser(t, "alice", 10)
+
+	// Disabled (default policy) → refused.
+	_, err := h.CoreService.ActivateBreakGlass(ctx, 2, 10, "incident", "")
+	require.Error(t, err)
+
+	// Enabled but no justification → refused.
+	enableBreakGlass(h, "editor", time.Hour, time.Hour)
+	_, err = h.CoreService.ActivateBreakGlass(ctx, 2, 10, "", "")
+	require.Error(t, err)
+}
+
+// Revoking an activation removes the grant early and marks it revoked.
+func TestRevokeBreakGlass_RemovesGrant(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	migrateBreakGlass(t, h)
+	enableBreakGlass(h, "editor", 4*time.Hour, 24*time.Hour)
+
+	const proj = uint(2)
+	ctx := context.Background()
+	h.CreateTestUser(t, "alice", 10)
+
+	act, err := h.CoreService.ActivateBreakGlass(ctx, proj, 10, "incident", "")
+	require.NoError(t, err)
+
+	require.NoError(t, h.CoreService.RevokeBreakGlass(ctx, 1, proj, act.ID))
+
+	// The emergency role is gone.
+	ids, err := h.Storage.GetUserRoleIDsAt(ctx, 10, storage.Scope{ProjectID: proj})
+	require.NoError(t, err)
+	assert.NotContains(t, ids, uint(3))
+
+	// The record is revoked, and re-revoking fails.
+	list, err := h.CoreService.ListBreakGlassActivations(ctx, proj)
+	require.NoError(t, err)
+	require.Len(t, list, 1)
+	assert.Equal(t, core.BreakGlassRevoked, list[0].State)
+	require.Error(t, h.CoreService.RevokeBreakGlass(ctx, 1, proj, act.ID))
+}
+
+// List reports an active record past its expiry as expired (lazy reconciliation).
+func TestListBreakGlassActivations_ExpiredReconciliation(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	migrateBreakGlass(t, h)
+
+	const proj = uint(2)
+	ctx := context.Background()
+	past := time.Now().Add(-time.Hour)
+	require.NoError(t, h.DB.Create(&models.BreakGlassActivation{
+		ProjectID: proj, UserID: 10, RoleID: 3, RoleName: "editor",
+		Justification: "old", State: core.BreakGlassActive, ExpiresAt: &past, CreatedAt: past,
+	}).Error)
+
+	list, err := h.CoreService.ListBreakGlassActivations(ctx, proj)
+	require.NoError(t, err)
+	require.Len(t, list, 1)
+	assert.Equal(t, core.BreakGlassExpired, list[0].State, "an active grant past expiry reads as expired")
+}

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -229,6 +229,35 @@ func (m *MockStorage) LastUserSecretActivity(ctx context.Context, projectID uint
 	return args.Get(0).(map[uint]time.Time), args.Error(1)
 }
 
+func (m *MockStorage) CreateBreakGlassActivation(ctx context.Context, a *models.BreakGlassActivation) (*models.BreakGlassActivation, error) {
+	args := m.Called(ctx, a)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.BreakGlassActivation), args.Error(1)
+}
+
+func (m *MockStorage) GetBreakGlassActivation(ctx context.Context, id uint) (*models.BreakGlassActivation, error) {
+	args := m.Called(ctx, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.BreakGlassActivation), args.Error(1)
+}
+
+func (m *MockStorage) ListBreakGlassActivations(ctx context.Context, projectID uint) ([]*models.BreakGlassActivation, error) {
+	args := m.Called(ctx, projectID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*models.BreakGlassActivation), args.Error(1)
+}
+
+func (m *MockStorage) UpdateBreakGlassActivation(ctx context.Context, a *models.BreakGlassActivation) error {
+	args := m.Called(ctx, a)
+	return args.Error(0)
+}
+
 func (m *MockStorage) GetEnvironment(_ context.Context, id uint) (*models.Environment, error) {
 	return &models.Environment{ID: id, ProjectID: 1, Name: "test"}, nil
 }

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -46,6 +46,9 @@ type KeyorixCore struct {
 	now            func() time.Time // For testability
 	passwordPolicy PasswordPolicy
 	auditForwarder AuditForwarder
+	// breakGlassPolicy configures self-service emergency access; zero value =
+	// disabled. Set from config at startup via SetBreakGlassPolicy.
+	breakGlassPolicy BreakGlassPolicy
 	// oidcVerifier verifies federated machine-identity JWTs (ADR-031); nil = OIDC
 	// auth disabled. Set from config via SetOIDCVerifier.
 	oidcVerifier *OIDCVerifier

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -76,6 +76,12 @@ type Storage interface {
 	ListAccessReviewItems(ctx context.Context, campaignID uint) ([]*models.AccessReviewItem, error)
 	GetAccessReviewItem(ctx context.Context, id uint) (*models.AccessReviewItem, error)
 	UpdateAccessReviewItem(ctx context.Context, item *models.AccessReviewItem) error
+
+	// Break-glass emergency-access activations (NIS2/DORA incident response).
+	CreateBreakGlassActivation(ctx context.Context, a *models.BreakGlassActivation) (*models.BreakGlassActivation, error)
+	GetBreakGlassActivation(ctx context.Context, id uint) (*models.BreakGlassActivation, error)
+	ListBreakGlassActivations(ctx context.Context, projectID uint) ([]*models.BreakGlassActivation, error)
+	UpdateBreakGlassActivation(ctx context.Context, a *models.BreakGlassActivation) error
 	// Machine identities (ADR-023) — non-human project members.
 	CreateMachineIdentity(ctx context.Context, m *models.MachineIdentity) (*models.MachineIdentity, error)
 	GetMachineIdentity(ctx context.Context, id uint) (*models.MachineIdentity, error)

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -253,6 +253,7 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 	invitationsExists := tableExists(db, "project_invitations")
 	accessReqExists := tableExists(db, "access_requests")
 	campaignExists := tableExists(db, "access_review_campaigns")
+	breakGlassExists := tableExists(db, "break_glass_activations")
 	pwHistExists := tableExists(db, "password_histories")
 	machineExists := tableExists(db, "machine_identities")
 	machineCredExists := tableExists(db, "machine_identity_credentials")
@@ -389,6 +390,13 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 	if !campaignExists {
 		if err := db.AutoMigrate(&models.AccessReviewCampaign{}, &models.AccessReviewItem{}); err != nil {
 			return fmt.Errorf("failed to migrate access_review_campaign tables: %w", err)
+		}
+	}
+
+	// Create the break-glass activations table if missing (additive).
+	if !breakGlassExists {
+		if err := db.AutoMigrate(&models.BreakGlassActivation{}); err != nil {
+			return fmt.Errorf("failed to migrate break_glass_activations table: %w", err)
 		}
 	}
 

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -70,6 +70,25 @@ type AccessRequest struct {
 	ResolvedAt    *time.Time
 }
 
+// BreakGlassActivation records a self-service emergency-access elevation: a user
+// immediately self-granted a time-bound emergency role (no approval), with a
+// written justification, for incident response (NIS2/DORA). The grant itself is a
+// JIT time-bound role assignment that auto-expires; this record is the queryable,
+// auditable evidence for post-hoc review. State: active → expired | revoked.
+type BreakGlassActivation struct {
+	ID            uint       `gorm:"primaryKey" json:"id"`
+	ProjectID     uint       `gorm:"index" json:"project_id"`
+	UserID        uint       `gorm:"index" json:"user_id"` // who activated it
+	RoleID        uint       `json:"role_id"`
+	RoleName      string     `json:"role_name"`
+	Justification string     `json:"justification"`
+	State         string     `json:"state"` // active | expired | revoked
+	ExpiresAt     *time.Time `gorm:"index" json:"expires_at,omitempty"`
+	CreatedAt     time.Time  `json:"created_at"`
+	RevokedBy     uint       `json:"revoked_by,omitempty"` // set on early revoke
+	RevokedAt     *time.Time `json:"revoked_at,omitempty"`
+}
+
 // AccessReviewCampaign is a periodic access-recertification cycle for a project
 // (ISO 27001 A.5.18 — review at planned intervals). Opening a campaign snapshots
 // the project's current access-review entries into AccessReviewItem rows; reviewers

--- a/internal/storage/store/local_break_glass.go
+++ b/internal/storage/store/local_break_glass.go
@@ -1,0 +1,45 @@
+// local_break_glass.go — break-glass emergency-access activation persistence
+// (NIS2/DORA incident response). For the remote equivalent see remote_break_glass.go.
+package store
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+func (ls *LocalStorage) CreateBreakGlassActivation(ctx context.Context, a *models.BreakGlassActivation) (*models.BreakGlassActivation, error) {
+	if err := ls.db.WithContext(ctx).Create(a).Error; err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	return a, nil
+}
+
+func (ls *LocalStorage) GetBreakGlassActivation(ctx context.Context, id uint) (*models.BreakGlassActivation, error) {
+	var a models.BreakGlassActivation
+	if err := ls.db.WithContext(ctx).First(&a, id).Error; err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorNotFound", nil), err)
+	}
+	return &a, nil
+}
+
+func (ls *LocalStorage) ListBreakGlassActivations(ctx context.Context, projectID uint) ([]*models.BreakGlassActivation, error) {
+	var rows []*models.BreakGlassActivation
+	err := ls.db.WithContext(ctx).
+		Where("project_id = ?", projectID).
+		Order("created_at DESC").
+		Find(&rows).Error
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	return rows, nil
+}
+
+func (ls *LocalStorage) UpdateBreakGlassActivation(ctx context.Context, a *models.BreakGlassActivation) error {
+	if err := ls.db.WithContext(ctx).Save(a).Error; err != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	return nil
+}

--- a/internal/storage/store/remote_break_glass.go
+++ b/internal/storage/store/remote_break_glass.go
@@ -1,0 +1,25 @@
+// remote_break_glass.go — break-glass activations for RemoteStorage. Processed
+// server-side; stubs here. See local_break_glass.go.
+package store
+
+import (
+	"context"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+func (rs *RemoteStorage) CreateBreakGlassActivation(_ context.Context, _ *models.BreakGlassActivation) (*models.BreakGlassActivation, error) {
+	return nil, remoteUnsupported("CreateBreakGlassActivation")
+}
+
+func (rs *RemoteStorage) GetBreakGlassActivation(_ context.Context, _ uint) (*models.BreakGlassActivation, error) {
+	return nil, remoteUnsupported("GetBreakGlassActivation")
+}
+
+func (rs *RemoteStorage) ListBreakGlassActivations(_ context.Context, _ uint) ([]*models.BreakGlassActivation, error) {
+	return nil, remoteUnsupported("ListBreakGlassActivations")
+}
+
+func (rs *RemoteStorage) UpdateBreakGlassActivation(_ context.Context, _ *models.BreakGlassActivation) error {
+	return remoteUnsupported("UpdateBreakGlassActivation")
+}

--- a/server/http/handlers/break_glass.go
+++ b/server/http/handlers/break_glass.go
@@ -1,0 +1,105 @@
+// break_glass.go — self-service emergency-access endpoints. Activation is NOT
+// RBAC-gated (the point is access the caller does not have); the controls are
+// config-enablement, a mandatory justification, loud audit, and auto-expiry. List
+// and revoke ARE gated (roles.read / roles.assign) — they're review actions.
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/keyorixhq/keyorix/server/middleware"
+)
+
+// ActivateBreakGlass handles POST /api/v1/projects/{id}/break-glass (self-service).
+func (h *CatalogHandler) ActivateBreakGlass(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		sendError(w, "InvalidParameter", "Invalid project ID", http.StatusBadRequest, nil)
+		return
+	}
+	actor := middleware.GetUserFromContext(r.Context())
+	if actor == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	var body struct {
+		Justification string `json:"justification"`
+		TTL           string `json:"ttl"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		sendError(w, "InvalidJSON", "Invalid request body", http.StatusBadRequest, nil)
+		return
+	}
+	if body.Justification == "" {
+		sendError(w, "ValidationError", "justification is required", http.StatusBadRequest, nil)
+		return
+	}
+	activation, err := h.coreService.ActivateBreakGlass(r.Context(), uint(id), actor.UserID, body.Justification, body.TTL)
+	if err != nil {
+		status := http.StatusInternalServerError
+		msg := err.Error()
+		switch {
+		case strings.Contains(msg, "permission denied"), strings.Contains(msg, "not enabled"):
+			status = http.StatusForbidden
+		case strings.Contains(msg, "required") || strings.Contains(msg, "ttl must") ||
+			strings.Contains(msg, "no emergency role") || strings.Contains(msg, "not found"):
+			status = http.StatusBadRequest
+		}
+		sendError(w, "Error", msg, status, nil)
+		return
+	}
+	w.WriteHeader(http.StatusCreated)
+	sendSuccess(w, map[string]interface{}{"activation": activation}, "Emergency access activated")
+}
+
+// ListBreakGlassActivations handles GET /api/v1/projects/{id}/break-glass.
+func (h *CatalogHandler) ListBreakGlassActivations(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		sendError(w, "InvalidParameter", "Invalid project ID", http.StatusBadRequest, nil)
+		return
+	}
+	activations, err := h.coreService.ListBreakGlassActivations(r.Context(), uint(id))
+	if err != nil {
+		sendError(w, "Error", err.Error(), http.StatusInternalServerError, nil)
+		return
+	}
+	sendSuccess(w, map[string]interface{}{"activations": activations, "count": len(activations)}, "")
+}
+
+// RevokeBreakGlass handles POST /api/v1/projects/{id}/break-glass/{activationId}/revoke.
+func (h *CatalogHandler) RevokeBreakGlass(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		sendError(w, "InvalidParameter", "Invalid project ID", http.StatusBadRequest, nil)
+		return
+	}
+	activationID, err := strconv.ParseUint(chi.URLParam(r, "activationId"), 10, 32)
+	if err != nil {
+		sendError(w, "InvalidParameter", "Invalid activation ID", http.StatusBadRequest, nil)
+		return
+	}
+	actor := middleware.GetUserFromContext(r.Context())
+	if actor == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	if err := h.coreService.RevokeBreakGlass(r.Context(), actor.UserID, uint(id), uint(activationID)); err != nil {
+		status := http.StatusInternalServerError
+		msg := err.Error()
+		switch {
+		case strings.Contains(msg, "not found"):
+			status = http.StatusNotFound
+		case strings.Contains(msg, "not active") || strings.Contains(msg, "required"):
+			status = http.StatusBadRequest
+		}
+		sendError(w, "Error", msg, status, nil)
+		return
+	}
+	sendSuccess(w, nil, "Emergency access revoked")
+}

--- a/server/http/handlers/openapi.yaml
+++ b/server/http/handlers/openapi.yaml
@@ -692,6 +692,70 @@ paths:
         '403': {$ref: '#/components/responses/Error'}
         '404': {$ref: '#/components/responses/Error'}
 
+  /api/v1/projects/{id}/break-glass:
+    post:
+      tags: [Projects]
+      summary: Activate break-glass emergency access (self-service)
+      description: >-
+        Immediately self-grant the configured emergency role at the project scope,
+        time-bound (default + capped by server config), with a required written
+        justification. NOT RBAC-gated — the controls are config-enablement, the
+        justification, a loud audit (break_glass.activated) + admin alert, and
+        auto-expiry. Returns 403 when break-glass is disabled.
+      operationId: activateBreakGlass
+      security: [{bearerAuth: []}]
+      parameters:
+        - {name: id, in: path, required: true, schema: {type: integer, format: uint32}}
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [justification]
+              properties:
+                justification: {type: string, description: "Written reason (required)"}
+                ttl: {type: string, description: "Optional grant-lifetime override, a Go duration (e.g. 2h); capped at the server max"}
+      responses:
+        '201': {description: "Envelope {data}. data: {activation}."}
+        '400': {$ref: '#/components/responses/Error'}
+        '401': {$ref: '#/components/responses/Error'}
+        '403': {$ref: '#/components/responses/Error'}
+    get:
+      tags: [Projects]
+      summary: List break-glass activations (for review)
+      description: >-
+        The project's emergency-access activations, newest first (an active grant
+        past its expiry reads as expired). Requires roles.read.
+      operationId: listBreakGlassActivations
+      security: [{bearerAuth: []}]
+      parameters:
+        - {name: id, in: path, required: true, schema: {type: integer, format: uint32}}
+      responses:
+        '200': {description: "Envelope {data}. data: {activations[] of {id, user_id, role_name, justification, state, expires_at, created_at}, count}."}
+        '400': {$ref: '#/components/responses/Error'}
+        '401': {$ref: '#/components/responses/Error'}
+        '403': {$ref: '#/components/responses/Error'}
+
+  /api/v1/projects/{id}/break-glass/{activationId}/revoke:
+    post:
+      tags: [Projects]
+      summary: Revoke an active break-glass grant early
+      description: >-
+        End an active emergency grant before its TTL — removes the role assignment
+        and marks the activation revoked. Requires roles.assign.
+      operationId: revokeBreakGlass
+      security: [{bearerAuth: []}]
+      parameters:
+        - {name: id, in: path, required: true, schema: {type: integer, format: uint32}}
+        - {name: activationId, in: path, required: true, schema: {type: integer, format: uint32}}
+      responses:
+        '200': {description: "Envelope {data, message}. Emergency access revoked."}
+        '400': {$ref: '#/components/responses/Error'}
+        '401': {$ref: '#/components/responses/Error'}
+        '403': {$ref: '#/components/responses/Error'}
+        '404': {$ref: '#/components/responses/Error'}
+
   /api/v1/projects/{id}/members:
     get:
       tags: [Members]

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -233,6 +233,12 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		r.Post("/projects/{id}/access-requests", catalogHandler.CreateAccessRequest)
 		r.With(customMiddleware.RequireScopedPermission("roles.assign", projectScope)).Put("/projects/{id}/access-requests/{requestId}", catalogHandler.ResolveAccessRequest)
 		r.Post("/projects/{id}/access-requests/{requestId}/withdraw", catalogHandler.WithdrawAccessRequest)
+		// Break-glass emergency access: activation is self-service (un-gated — the
+		// point is access the caller lacks; controlled by config + justification +
+		// audit + auto-expiry). Listing/revoking are review actions (roles.read/assign).
+		r.Post("/projects/{id}/break-glass", catalogHandler.ActivateBreakGlass)
+		r.With(customMiddleware.RequireScopedPermission("roles.read", projectScope)).Get("/projects/{id}/break-glass", catalogHandler.ListBreakGlassActivations)
+		r.With(customMiddleware.RequireScopedPermission("roles.assign", projectScope)).Post("/projects/{id}/break-glass/{activationId}/revoke", catalogHandler.RevokeBreakGlass)
 		// Machine identities (ADR-023): non-human members, segmented from humans.
 		r.With(customMiddleware.RequireScopedPermission("users.read", projectScope)).Get("/projects/{id}/machine-identities", catalogHandler.ListMachineIdentities)
 		r.With(customMiddleware.RequireScopedPermission("roles.assign", projectScope)).Post("/projects/{id}/machine-identities", catalogHandler.CreateMachineIdentity)

--- a/server/main.go
+++ b/server/main.go
@@ -257,6 +257,14 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 	// (MySQL/MongoDB) when it is disabled — otherwise the credential never expires.
 	coreService.SetDynamicSweepEnabled(cfg.DynamicSecrets.SweepEnabled)
 
+	// Wire self-service emergency access (break-glass); zero value = disabled.
+	coreService.SetBreakGlassPolicy(core.BreakGlassPolicy{
+		Enabled:       cfg.BreakGlass.Enabled,
+		EmergencyRole: cfg.BreakGlass.EmergencyRole,
+		DefaultTTL:    cfg.BreakGlass.GetDefaultTTL(),
+		MaxTTL:        cfg.BreakGlass.GetMaxTTL(),
+	})
+
 	// Wire the credential-delivery channel (ADR-028). New selects out-of-band/SMTP/
 	// log from the configured mode and fails loud on a bad mode (e.g. smtp with no
 	// host), so a misconfigured install does not silently drop setup links.


### PR DESCRIPTION
## What

Self-service **emergency elevation**: when enabled, any authenticated user can **immediately** self-grant the configured emergency role at a project — no approval — **time-bound and auto-expiring**, with a **mandatory written justification**. Each activation is loudly audited (`break_glass.activated`), **alerts the project's admins**, and is recorded as a queryable `BreakGlassActivation` for post-hoc review. The JIT counterpart to time-bound access (#172): *planned* time-bound grants vs. the *"I need in NOW, account for it later"* emergency path. Third item of the access-governance batch.

## Why un-gated is safe here

Deliberately **not** RBAC-gated — the whole point is access the caller doesn't have. The compensating controls are: must be **enabled** in config (off by default), **mandatory justification**, **loud audit + admin alert**, a **short server-clamped TTL** whose expiry the auth queries enforce immediately, and **admin early-revoke**.

**Security-reviewed** (self-service elevation path), PASS on all checks:
- enable-gate is first & unconditional — the default (disabled) policy grants nothing;
- the role is **config-bound** — the caller can't choose which role or another project's scope (body reads only `justification`/`ttl`, scope from the URL);
- TTL is parsed, rejected if non-positive, and **capped at `max_ttl`**, from the trusted server clock;
- the grant uses #172's `AssignUserRoleWithExpiry`, so expiry is enforced live (not just on sweep);
- revoke is **project-guarded**; list/revoke are gated (`roles.read`/`roles.assign`);
- the activate route sits under the auth middleware (un-gated for RBAC only — **not** reachable unauthenticated).

## Surfaces

- **model**: `BreakGlassActivation` (active|expired|revoked), additive migration.
- **storage**: Create/Get/List/Update (Local, Remote stubs, mock, interface).
- **config**: `break_glass` block (enabled, emergency_role, default_ttl, max_ttl) → core via `SetBreakGlassPolicy` (zero value = disabled).
- **core**: `ActivateBreakGlass` (grant + record + audit + admin notify), `ListBreakGlassActivations` (lazy expired-state reconciliation), `RevokeBreakGlass`.
- **API**: `POST /projects/{id}/break-glass` (self-service), `GET` (roles.read), `POST .../{id}/revoke` (roles.assign).
- **CLI**: `keyorix break-glass activate|list|revoke`.

## Tests

Grants a time-bound role + records it; TTL capped at max; disabled + no-justification refused; revoke removes the grant, marks revoked, re-revoke fails; expired-state reconciliation.

## Docs

openapi (3 endpoints) + CONFIGURATION `break_glass` block + REMOTE_CLI section.

> Minor known UX wart (non-security, fails closed): re-activating while a grant is still live returns 500 (`role already assigned`) rather than a clean 409 — left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)