### PR TITLE
feat(compliance): controls-posture report (A — ISO 27001 / SOC 2 / NIS2 / DORA)

### DIFF
--- a/docs/REMOTE_CLI_SETUP.md
+++ b/docs/REMOTE_CLI_SETUP.md
@@ -280,6 +280,23 @@ keyorix break-glass list --project-id 5
 keyorix break-glass revoke --project-id 5 --activation-id 7
 ```
 
+### Compliance Commands
+
+A single deployment-wide controls-posture report for auditors (ISO 27001 / SOC 2 /
+NIS2 / DORA) — it rolls up the state of the controls Keyorix enforces. Requires
+`system.read`.
+
+- `keyorix compliance report` — print the posture: audit-trail integrity (chain
+  verified + checkpointed), access-governance coverage (projects reviewed / never
+  reviewed, open campaigns + pending items, dormant role grants), rotation hygiene
+  (overdue / due-soon), second-factor coverage (% of active users with MFA or a
+  passkey), and break-glass usage (active / total activations).
+
+```bash
+# Quarterly controls-posture snapshot:
+keyorix compliance report
+```
+
 ## Deployment Scenarios
 
 ### Development Environment

--- a/internal/cli/compliance/compliance.go
+++ b/internal/cli/compliance/compliance.go
@@ -1,0 +1,104 @@
+// Package compliance provides `keyorix compliance` — the deployment's controls-
+// posture report for auditors (ISO 27001 / SOC 2 / NIS2 / DORA). Talks to
+// GET /api/v1/compliance/posture (gated by system.read).
+package compliance
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/spf13/cobra"
+)
+
+// ComplianceCmd is the `keyorix compliance` command.
+var ComplianceCmd = &cobra.Command{
+	Use:   "compliance",
+	Short: "Deployment controls-posture report (ISO 27001 / SOC 2 / NIS2 / DORA)",
+}
+
+type posture struct {
+	GeneratedAt    string `json:"generated_at"`
+	AuditIntegrity struct {
+		ChainVerified bool   `json:"chain_verified"`
+		ChainedEvents int64  `json:"chained_events"`
+		Checkpointed  bool   `json:"checkpointed"`
+		Reason        string `json:"reason"`
+	} `json:"audit_integrity"`
+	AccessGovernance struct {
+		Projects                 int `json:"projects"`
+		ProjectsWithOpenCampaign int `json:"projects_with_open_campaign"`
+		ProjectsNeverReviewed    int `json:"projects_never_reviewed"`
+		OpenCampaigns            int `json:"open_campaigns"`
+		PendingItems             int `json:"pending_items"`
+		DormantRoleGrants        int `json:"dormant_role_grants"`
+	} `json:"access_governance"`
+	Rotation struct {
+		CoveredSecrets int `json:"covered_secrets"`
+		Overdue        int `json:"overdue"`
+		DueSoon        int `json:"due_soon"`
+	} `json:"rotation"`
+	Identity struct {
+		ActiveUsers           int `json:"active_users"`
+		UsersWithSecondFactor int `json:"users_with_second_factor"`
+		SecondFactorPercent   int `json:"second_factor_percent"`
+	} `json:"identity"`
+	EmergencyAccess struct {
+		ActiveActivations int `json:"active_activations"`
+		TotalActivations  int `json:"total_activations"`
+	} `json:"emergency_access"`
+}
+
+func yesNo(b bool) string {
+	if b {
+		return "yes"
+	}
+	return "no"
+}
+
+var reportCmd = &cobra.Command{
+	Use:          "report",
+	Short:        "Print the deployment's controls-posture report",
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		c, ok := common.NewRemoteClient()
+		if !ok {
+			return fmt.Errorf("not connected to a server — run: keyorix connect <server>")
+		}
+		var p posture
+		if err := c.Get(context.Background(), "/api/v1/compliance/posture", &p); err != nil {
+			return err
+		}
+		fmt.Printf("Compliance posture — %s\n\n", p.GeneratedAt)
+
+		fmt.Println("Audit integrity (ADR-029)")
+		fmt.Printf("  chain verified : %s (%d chained events)\n", yesNo(p.AuditIntegrity.ChainVerified), p.AuditIntegrity.ChainedEvents)
+		fmt.Printf("  checkpointed   : %s\n", yesNo(p.AuditIntegrity.Checkpointed))
+		if p.AuditIntegrity.Reason != "" {
+			fmt.Printf("  note           : %s\n", p.AuditIntegrity.Reason)
+		}
+
+		fmt.Println("\nAccess governance (ISO A.5.18)")
+		fmt.Printf("  projects                  : %d\n", p.AccessGovernance.Projects)
+		fmt.Printf("  with an open campaign     : %d\n", p.AccessGovernance.ProjectsWithOpenCampaign)
+		fmt.Printf("  never reviewed            : %d\n", p.AccessGovernance.ProjectsNeverReviewed)
+		fmt.Printf("  open campaigns / pending  : %d / %d\n", p.AccessGovernance.OpenCampaigns, p.AccessGovernance.PendingItems)
+		fmt.Printf("  dormant role grants       : %d\n", p.AccessGovernance.DormantRoleGrants)
+
+		fmt.Println("\nRotation hygiene (ISO A.5.15)")
+		fmt.Printf("  covered secrets : %d\n", p.Rotation.CoveredSecrets)
+		fmt.Printf("  overdue/due-soon: %d / %d\n", p.Rotation.Overdue, p.Rotation.DueSoon)
+
+		fmt.Println("\nIdentity (second factor)")
+		fmt.Printf("  active users        : %d\n", p.Identity.ActiveUsers)
+		fmt.Printf("  with second factor  : %d (%d%%)\n", p.Identity.UsersWithSecondFactor, p.Identity.SecondFactorPercent)
+
+		fmt.Println("\nEmergency access (break-glass)")
+		fmt.Printf("  active / total activations : %d / %d\n", p.EmergencyAccess.ActiveActivations, p.EmergencyAccess.TotalActivations)
+		return nil
+	},
+}
+
+func init() {
+	ComplianceCmd.AddCommand(reportCmd)
+}

--- a/internal/cli/main.go
+++ b/internal/cli/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/keyorixhq/keyorix/internal/cli/audit"
 	"github.com/keyorixhq/keyorix/internal/cli/auth"
 	"github.com/keyorixhq/keyorix/internal/cli/breakglass"
+	"github.com/keyorixhq/keyorix/internal/cli/compliance"
 	"github.com/keyorixhq/keyorix/internal/cli/config"
 	"github.com/keyorixhq/keyorix/internal/cli/connect"
 	"github.com/keyorixhq/keyorix/internal/cli/dynamic"
@@ -67,6 +68,7 @@ func init() {
 	rootCmd.AddCommand(rotation.RotationCmd)
 	rootCmd.AddCommand(accessreview.AccessReviewCmd)
 	rootCmd.AddCommand(breakglass.BreakGlassCmd)
+	rootCmd.AddCommand(compliance.ComplianceCmd)
 }
 
 // Execute runs the root command

--- a/internal/core/compliance_posture.go
+++ b/internal/core/compliance_posture.go
@@ -1,0 +1,215 @@
+// compliance_posture.go — a single, deployment-wide controls-posture snapshot for
+// auditors (ISO 27001 / SOC 2 / NIS2 / DORA). GetCompliancePosture rolls up the
+// state of the controls Keyorix already enforces — audit-trail integrity, access
+// recertification coverage, dormant standing access, secret-rotation hygiene,
+// second-factor coverage, and break-glass usage — into one structured object,
+// grouped by control area. Read-only; gated by system.read.
+package core
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+)
+
+// dormantThreshold is how long without a secret access marks a standing grant
+// dormant in the posture roll-up.
+const dormantThreshold = 90 * 24 * time.Hour
+
+// AuditIntegrityPosture summarises the tamper-evident audit trail (ADR-029).
+type AuditIntegrityPosture struct {
+	ChainVerified bool   `json:"chain_verified"`
+	ChainedEvents int64  `json:"chained_events"`
+	Checkpointed  bool   `json:"checkpointed"`
+	Reason        string `json:"reason,omitempty"` // failure/notes when not fully verified
+}
+
+// AccessGovernancePosture summarises access recertification + dormant access.
+type AccessGovernancePosture struct {
+	Projects                 int `json:"projects"`
+	ProjectsWithOpenCampaign int `json:"projects_with_open_campaign"`
+	ProjectsNeverReviewed    int `json:"projects_never_reviewed"`
+	OpenCampaigns            int `json:"open_campaigns"`
+	PendingItems             int `json:"pending_items"`       // undecided items across open campaigns
+	DormantRoleGrants        int `json:"dormant_role_grants"` // user role grants with no/old secret access
+}
+
+// RotationPosture summarises secret-rotation hygiene (ISO A.5.15 / NIS2).
+type RotationPosture struct {
+	CoveredSecrets int `json:"covered_secrets"`
+	Overdue        int `json:"overdue"`
+	DueSoon        int `json:"due_soon"`
+}
+
+// IdentityPosture summarises second-factor (MFA / passkey) coverage.
+type IdentityPosture struct {
+	ActiveUsers           int `json:"active_users"`
+	UsersWithSecondFactor int `json:"users_with_second_factor"`
+	SecondFactorPercent   int `json:"second_factor_percent"`
+}
+
+// EmergencyAccessPosture summarises break-glass usage (NIS2/DORA).
+type EmergencyAccessPosture struct {
+	ActiveActivations int `json:"active_activations"`
+	TotalActivations  int `json:"total_activations"`
+}
+
+// CompliancePosture is the deployment's control posture at a point in time.
+type CompliancePosture struct {
+	GeneratedAt      time.Time               `json:"generated_at"`
+	AuditIntegrity   AuditIntegrityPosture   `json:"audit_integrity"`
+	AccessGovernance AccessGovernancePosture `json:"access_governance"`
+	Rotation         RotationPosture         `json:"rotation"`
+	Identity         IdentityPosture         `json:"identity"`
+	EmergencyAccess  EmergencyAccessPosture  `json:"emergency_access"`
+}
+
+// GetCompliancePosture aggregates the deployment's control posture. It is an
+// on-demand admin report (it walks every project for the access-governance roll-up),
+// not a hot path.
+func (c *KeyorixCore) GetCompliancePosture(ctx context.Context) (*CompliancePosture, error) {
+	p := &CompliancePosture{GeneratedAt: c.now()}
+
+	// Audit-trail integrity.
+	if v, err := c.VerifyAuditChain(ctx); err == nil && v != nil {
+		p.AuditIntegrity = AuditIntegrityPosture{
+			ChainVerified: v.Valid,
+			ChainedEvents: v.ChainedEvents,
+			Checkpointed:  v.Checkpointed,
+		}
+		if !v.Valid {
+			p.AuditIntegrity.Reason = v.Reason
+		} else if v.CheckpointReason != "" {
+			p.AuditIntegrity.Reason = v.CheckpointReason
+		}
+	} else if err != nil {
+		p.AuditIntegrity.Reason = err.Error()
+	}
+
+	// Second-factor coverage across active users.
+	if id, err := c.identityPosture(ctx); err == nil {
+		p.Identity = id
+	}
+
+	// Rotation hygiene (deployment-wide).
+	if statuses, err := c.GetRotationStatus(ctx, nil); err == nil {
+		p.Rotation.CoveredSecrets = len(statuses)
+		for _, s := range statuses {
+			switch s.Status {
+			case RotationStatusOverdue:
+				p.Rotation.Overdue++
+			case RotationStatusDueSoon:
+				p.Rotation.DueSoon++
+			}
+		}
+	}
+
+	// Access governance + emergency access — per project.
+	if err := c.accessGovernancePosture(ctx, p); err != nil {
+		return nil, err
+	}
+	return p, nil
+}
+
+// identityPosture counts active users and how many have a second factor (MFA or
+// passkey), paging through all of them (no silent cap).
+func (c *KeyorixCore) identityPosture(ctx context.Context) (IdentityPosture, error) {
+	const pageSize = 500
+	var out IdentityPosture
+	for page := 1; ; page++ {
+		users, total, err := c.storage.ListUsers(ctx, &storage.UserFilter{Page: page, PageSize: pageSize})
+		if err != nil {
+			return out, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+		}
+		for _, u := range users {
+			if !u.IsActive {
+				continue
+			}
+			out.ActiveUsers++
+			if u.MFAEnabled || u.WebAuthnEnabled {
+				out.UsersWithSecondFactor++
+			}
+		}
+		if len(users) < pageSize || int64(page*pageSize) >= total {
+			break
+		}
+	}
+	if out.ActiveUsers > 0 {
+		out.SecondFactorPercent = out.UsersWithSecondFactor * 100 / out.ActiveUsers
+	}
+	return out, nil
+}
+
+// accessGovernancePosture walks every project, rolling up campaign coverage,
+// dormant role grants, and break-glass usage.
+func (c *KeyorixCore) accessGovernancePosture(ctx context.Context, p *CompliancePosture) error {
+	projects, err := c.ListProjects(ctx)
+	if err != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	p.AccessGovernance.Projects = len(projects)
+	for _, proj := range projects {
+		pid := proj.ID
+
+		campaigns, err := c.ListAccessReviewCampaigns(ctx, pid)
+		if err == nil {
+			if len(campaigns) == 0 {
+				p.AccessGovernance.ProjectsNeverReviewed++
+			}
+			hasOpen := false
+			for _, cw := range campaigns {
+				if cw.Campaign.State == CampaignStateOpen {
+					hasOpen = true
+					p.AccessGovernance.OpenCampaigns++
+					p.AccessGovernance.PendingItems += cw.Progress.Pending
+				}
+			}
+			if hasOpen {
+				p.AccessGovernance.ProjectsWithOpenCampaign++
+			}
+		}
+
+		p.AccessGovernance.DormantRoleGrants += c.countDormantRoleGrants(ctx, pid)
+
+		if acts, err := c.ListBreakGlassActivations(ctx, pid); err == nil {
+			p.EmergencyAccess.TotalActivations += len(acts)
+			for _, a := range acts {
+				if a.State == BreakGlassActive {
+					p.EmergencyAccess.ActiveActivations++
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// countDormantRoleGrants counts distinct users holding a role grant in the project
+// who have not accessed a secret recently (or ever) — stale standing access. Cheap:
+// the project's role assignments + the last-activity map, no full secret walk.
+func (c *KeyorixCore) countDormantRoleGrants(ctx context.Context, projectID uint) int {
+	assignments, err := c.storage.ListProjectRoleAssignments(ctx, projectID)
+	if err != nil {
+		return 0
+	}
+	activity, err := c.storage.LastUserSecretActivity(ctx, projectID)
+	if err != nil {
+		return 0
+	}
+	cutoff := c.now().Add(-dormantThreshold)
+	seen := map[uint]bool{}
+	dormant := 0
+	for _, a := range assignments {
+		if a.PrincipalType != "user" || seen[a.PrincipalID] {
+			continue
+		}
+		seen[a.PrincipalID] = true
+		last, ok := activity[a.PrincipalID]
+		if !ok || last.Before(cutoff) {
+			dormant++
+		}
+	}
+	return dormant
+}

--- a/internal/core/compliance_posture_external_test.go
+++ b/internal/core/compliance_posture_external_test.go
@@ -1,0 +1,86 @@
+package core_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/testhelper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// GetCompliancePosture rolls up second-factor coverage, access-review campaign
+// coverage, dormant role grants, and break-glass usage across the deployment.
+func TestGetCompliancePosture_RollsUpControls(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(
+		&models.AuditEvent{}, &models.AccessReviewCampaign{}, &models.AccessReviewItem{}, &models.BreakGlassActivation{}, &models.RotationPolicy{},
+	))
+
+	const proj = uint(2)
+	ctx := context.Background()
+	h.CreateTestUser(t, "alice", 10)
+	h.CreateTestUser(t, "bob", 11)
+	// alice has a second factor; bob does not → 50% coverage.
+	require.NoError(t, h.DB.Model(&models.User{}).Where("id = ?", 10).Update("mfa_enabled", true).Error)
+
+	// alice holds a role grant in project 2 with no secret activity → dormant.
+	h.AssignUserRole(t, 10, 3, uptr(proj))
+	// An open campaign on project 2.
+	_, err := h.CoreService.OpenAccessReviewCampaign(ctx, 1, proj, "Q4")
+	require.NoError(t, err)
+	// An active break-glass activation in project 2.
+	future := time.Now().Add(time.Hour)
+	require.NoError(t, h.DB.Create(&models.BreakGlassActivation{
+		ProjectID: proj, UserID: 10, RoleID: 3, RoleName: "editor",
+		Justification: "incident", State: "active", ExpiresAt: &future, CreatedAt: time.Now(),
+	}).Error)
+
+	p, err := h.CoreService.GetCompliancePosture(ctx)
+	require.NoError(t, err)
+
+	// Identity: 2 active users, 1 with a second factor.
+	assert.Equal(t, 2, p.Identity.ActiveUsers)
+	assert.Equal(t, 1, p.Identity.UsersWithSecondFactor)
+	assert.Equal(t, 50, p.Identity.SecondFactorPercent)
+
+	// Access governance: one open campaign covering one project; alice is dormant.
+	assert.Equal(t, 1, p.AccessGovernance.OpenCampaigns)
+	assert.Equal(t, 1, p.AccessGovernance.ProjectsWithOpenCampaign)
+	assert.GreaterOrEqual(t, p.AccessGovernance.DormantRoleGrants, 1)
+	assert.GreaterOrEqual(t, p.AccessGovernance.PendingItems, 1)
+
+	// Emergency access: the active break-glass activation is counted.
+	assert.Equal(t, 1, p.EmergencyAccess.ActiveActivations)
+	assert.Equal(t, 1, p.EmergencyAccess.TotalActivations)
+
+	// Audit integrity: the chain of legitimately-written events verifies.
+	assert.True(t, p.AuditIntegrity.ChainVerified)
+}
+
+// A recent secret access keeps a role grant out of the dormant tally.
+func TestCompliancePosture_RecentActivityNotDormant(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(
+		&models.AuditEvent{}, &models.AccessReviewCampaign{}, &models.AccessReviewItem{}, &models.BreakGlassActivation{}, &models.RotationPolicy{},
+	))
+
+	const proj = uint(2)
+	ctx := context.Background()
+	h.CreateTestUser(t, "alice", 10)
+	h.AssignUserRole(t, 10, 3, uptr(proj))
+
+	aid := uint(10)
+	pid := proj
+	require.NoError(t, h.DB.Create(&models.AuditEvent{
+		EventType: "secret.read", UserID: &aid, ProjectID: &pid, EventTime: time.Now().Add(-time.Hour),
+	}).Error)
+
+	p, err := h.CoreService.GetCompliancePosture(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 0, p.AccessGovernance.DormantRoleGrants, "alice accessed a secret recently — not dormant")
+}

--- a/server/http/handlers/dashboard.go
+++ b/server/http/handlers/dashboard.go
@@ -35,6 +35,17 @@ func (h *DashboardHandler) GetStats(w http.ResponseWriter, r *http.Request) {
 	sendSuccess(w, stats, "")
 }
 
+// GetCompliancePosture handles GET /api/v1/compliance/posture — the deployment-wide
+// controls-posture snapshot for auditors (gated by system.read in the router).
+func (h *DashboardHandler) GetCompliancePosture(w http.ResponseWriter, r *http.Request) {
+	posture, err := h.coreService.GetCompliancePosture(r.Context())
+	if err != nil {
+		sendError(w, "InternalServerError", "Failed to compute compliance posture", http.StatusInternalServerError, nil)
+		return
+	}
+	sendSuccess(w, posture, "")
+}
+
 // GetActivity handles GET /api/v1/dashboard/activity
 func (h *DashboardHandler) GetActivity(w http.ResponseWriter, r *http.Request) {
 	userCtx := middleware.GetUserFromContext(r.Context())

--- a/server/http/handlers/openapi.yaml
+++ b/server/http/handlers/openapi.yaml
@@ -2774,6 +2774,27 @@ paths:
             expiringSecrets[] (id, name, environment, expiresAt, daysLeft, expired), and
             recentActivity[] (id, type, secretName, timestamp, actor).
         '401': {$ref: '#/components/responses/Error'}
+  /api/v1/compliance/posture:
+    get:
+      tags: [Dashboard]
+      summary: Deployment controls-posture report (ISO 27001 / SOC 2 / NIS2 / DORA)
+      description: >-
+        A deployment-wide, on-demand snapshot of the control posture for auditors,
+        rolling up: audit-trail integrity (chain verified, chained events,
+        checkpointed), access governance (projects, with-open-campaign,
+        never-reviewed, open campaigns + pending items, dormant role grants),
+        rotation hygiene (covered secrets, overdue, due-soon), identity
+        (active users, with-second-factor + percent), and emergency access
+        (active/total break-glass activations). Requires system.read.
+      operationId: getCompliancePosture
+      security: [{bearerAuth: []}]
+      responses:
+        '200':
+          description: >-
+            Envelope {data}. data: {generated_at, audit_integrity, access_governance,
+            rotation, identity, emergency_access} — see the description for each group's fields.
+        '401': {$ref: '#/components/responses/Error'}
+        '403': {$ref: '#/components/responses/Error'}
   /api/v1/dashboard/activity:
     get:
       tags: [Dashboard]

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -453,6 +453,9 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.Get("/info", handlers.MakeSystemInfoHandler(cfg))
 			r.Get("/metrics", handlers.GetMetrics)
 		})
+
+		// Compliance posture — deployment-wide controls snapshot for auditors.
+		r.With(customMiddleware.RequirePermission("system.read")).Get("/compliance/posture", dashboardHandler.GetCompliancePosture)
 	})
 
 	// Swagger UI (optional, based on config)


### PR DESCRIPTION
## What

A single **deployment-wide, on-demand snapshot** of the controls Keyorix already enforces — the artifact an auditor / ENISA evaluator asks to see. First item of the compliance-evidence batch (report → evidence export → web dashboard).

Rolls up, grouped by control area:
- **Audit-trail integrity** — chain verified, chained events, checkpointed (ADR-029)
- **Access governance** — projects, with-open-campaign, never-reviewed, open campaigns + pending items, dormant role grants (A.5.18)
- **Rotation hygiene** — covered secrets, overdue, due-soon (A.5.15)
- **Identity** — active users, with a second factor, coverage %
- **Emergency access** — active / total break-glass activations (NIS2/DORA)

## How

Reuses the existing subsystems rather than re-deriving: `VerifyAuditChain`, `GetRotationStatus(nil)`, `ListUsers` (paged, no silent cap), and per-project `ListAccessReviewCampaigns` + `ListBreakGlassActivations`. Dormant role grants are counted **cheaply** from `ListProjectRoleAssignments` + `LastUserSecretActivity` (no full secret walk).

## Surfaces

- **core**: `GetCompliancePosture` + grouped posture structs (`compliance_posture.go`)
- **API**: `GET /api/v1/compliance/posture` on the dashboard handler, gated `system.read`
- **CLI**: `keyorix compliance report` (formatted posture)

## Tests

Rolls up 2FA coverage (50%), one open campaign / project, dormant role grant, active break-glass; a recent secret access keeps a grant out of the dormant tally.

## Docs

openapi endpoint + REMOTE_CLI compliance section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)