### PR TITLE
feat(compliance): auditor evidence pack export (B)

### DIFF
--- a/docs/REMOTE_CLI_SETUP.md
+++ b/docs/REMOTE_CLI_SETUP.md
@@ -292,9 +292,17 @@ NIS2 / DORA) — it rolls up the state of the controls Keyorix enforces. Require
   (overdue / due-soon), second-factor coverage (% of active users with MFA or a
   passkey), and break-glass usage (active / total activations).
 
+- `keyorix compliance export [--output FILE]` — export a timestamped **evidence
+  pack** (the posture plus the records that substantiate it: the audit-chain anchor,
+  the access-review campaigns, the break-glass register, and overdue rotations) as
+  JSON, to stdout or a file — the artifact an auditor archives.
+
 ```bash
 # Quarterly controls-posture snapshot:
 keyorix compliance report
+
+# Archive the evidence pack for an audit period:
+keyorix compliance export --output evidence-2026Q4.json
 ```
 
 ## Deployment Scenarios

--- a/internal/cli/compliance/compliance.go
+++ b/internal/cli/compliance/compliance.go
@@ -4,8 +4,11 @@
 package compliance
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
+	"os"
 
 	"github.com/keyorixhq/keyorix/internal/cli/common"
 	"github.com/spf13/cobra"
@@ -99,6 +102,43 @@ var reportCmd = &cobra.Command{
 	},
 }
 
+var exportOutput string
+
+var exportCmd = &cobra.Command{
+	Use:   "export",
+	Short: "Export the auditor evidence pack (posture + supporting records) as JSON",
+	Long: `Export a timestamped evidence pack — the posture plus the records that
+substantiate it (the audit-chain anchor, access-review campaigns, the break-glass
+register, and overdue rotations) — as JSON, for an auditor to archive. Writes to
+stdout by default, or to --output FILE.`,
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		c, ok := common.NewRemoteClient()
+		if !ok {
+			return fmt.Errorf("not connected to a server — run: keyorix connect <server>")
+		}
+		var raw json.RawMessage
+		if err := c.Get(context.Background(), "/api/v1/compliance/evidence", &raw); err != nil {
+			return err
+		}
+		var pretty bytes.Buffer
+		if err := json.Indent(&pretty, raw, "", "  "); err != nil {
+			pretty.Write(raw) // fall back to the raw bytes if indent fails
+		}
+		pretty.WriteByte('\n')
+		if exportOutput != "" {
+			if err := os.WriteFile(exportOutput, pretty.Bytes(), 0o600); err != nil {
+				return fmt.Errorf("failed to write %s: %w", exportOutput, err)
+			}
+			fmt.Printf("Evidence pack written to %s.\n", exportOutput)
+			return nil
+		}
+		_, _ = os.Stdout.Write(pretty.Bytes())
+		return nil
+	},
+}
+
 func init() {
-	ComplianceCmd.AddCommand(reportCmd)
+	exportCmd.Flags().StringVar(&exportOutput, "output", "", "Write the evidence pack to a file instead of stdout")
+	ComplianceCmd.AddCommand(reportCmd, exportCmd)
 }

--- a/internal/core/compliance_evidence.go
+++ b/internal/core/compliance_evidence.go
@@ -1,0 +1,119 @@
+// compliance_evidence.go — an auditor evidence pack (ISO 27001 / SOC 2 / NIS2 /
+// DORA). Where GetCompliancePosture (compliance_posture.go) is the at-a-glance
+// summary, GenerateComplianceEvidence bundles the posture together with the
+// supporting records that substantiate it — the tamper-evidence audit anchor, the
+// access-recertification campaigns, the break-glass register, and the overdue
+// rotations — as one timestamped, archivable object an auditor can keep.
+package core
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// AuditAnchor is the tamper-evidence anchor of the audit hash chain (ADR-029): an
+// auditor records (chained_events, head_hash) externally to detect later truncation.
+type AuditAnchor struct {
+	Valid         bool   `json:"valid"`
+	ChainedEvents int64  `json:"chained_events"`
+	HeadID        uint   `json:"head_id"`
+	HeadHash      string `json:"head_hash"`
+	Checkpointed  bool   `json:"checkpointed"`
+}
+
+// EvidenceCampaign is one access-recertification campaign in the evidence pack: the
+// "we reviewed access" record (closed campaigns are completed reviews).
+type EvidenceCampaign struct {
+	ProjectID uint       `json:"project_id"`
+	ID        uint       `json:"id"`
+	Name      string     `json:"name"`
+	State     string     `json:"state"`
+	CreatedAt time.Time  `json:"created_at"`
+	ClosedAt  *time.Time `json:"closed_at,omitempty"`
+	Total     int        `json:"total"`
+	Attested  int        `json:"attested"`
+	Revoked   int        `json:"revoked"`
+	Pending   int        `json:"pending"`
+}
+
+// EvidenceRotation is one secret overdue for rotation (an open hygiene gap).
+type EvidenceRotation struct {
+	ProjectID   uint   `json:"project_id,omitempty"`
+	SecretID    uint   `json:"secret_id"`
+	SecretName  string `json:"secret_name"`
+	PolicyName  string `json:"policy_name"`
+	DaysOverdue int    `json:"days_overdue"`
+}
+
+// ComplianceEvidence is the auditor evidence pack at a point in time.
+type ComplianceEvidence struct {
+	GeneratedAt     time.Time                      `json:"generated_at"`
+	Posture         *CompliancePosture             `json:"posture"`
+	AuditAnchor     AuditAnchor                    `json:"audit_anchor"`
+	Campaigns       []EvidenceCampaign             `json:"campaigns"`
+	BreakGlass      []*models.BreakGlassActivation `json:"break_glass"`
+	RotationOverdue []EvidenceRotation             `json:"rotation_overdue"`
+}
+
+// GenerateComplianceEvidence assembles the evidence pack. Like the posture, it is an
+// on-demand admin export that walks every project.
+func (c *KeyorixCore) GenerateComplianceEvidence(ctx context.Context) (*ComplianceEvidence, error) {
+	posture, err := c.GetCompliancePosture(ctx)
+	if err != nil {
+		return nil, err
+	}
+	ev := &ComplianceEvidence{
+		GeneratedAt:     c.now(),
+		Posture:         posture,
+		Campaigns:       []EvidenceCampaign{},
+		BreakGlass:      []*models.BreakGlassActivation{},
+		RotationOverdue: []EvidenceRotation{},
+	}
+
+	// Audit anchor.
+	if v, err := c.VerifyAuditChain(ctx); err == nil && v != nil {
+		ev.AuditAnchor = AuditAnchor{
+			Valid: v.Valid, ChainedEvents: v.ChainedEvents,
+			HeadID: v.HeadID, HeadHash: v.HeadHash, Checkpointed: v.Checkpointed,
+		}
+	}
+
+	// Overdue rotations (deployment-wide).
+	if statuses, err := c.GetRotationStatus(ctx, nil); err == nil {
+		for _, s := range statuses {
+			if s.Status == RotationStatusOverdue {
+				ev.RotationOverdue = append(ev.RotationOverdue, EvidenceRotation{
+					SecretID: s.SecretID, SecretName: s.SecretName,
+					PolicyName: s.PolicyName, DaysOverdue: s.DaysOverdue,
+				})
+			}
+		}
+	}
+
+	// Campaigns + break-glass register, per project.
+	projects, err := c.ListProjects(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	for _, proj := range projects {
+		pid := proj.ID
+		if camps, err := c.ListAccessReviewCampaigns(ctx, pid); err == nil {
+			for _, cw := range camps {
+				ev.Campaigns = append(ev.Campaigns, EvidenceCampaign{
+					ProjectID: pid, ID: cw.Campaign.ID, Name: cw.Campaign.Name,
+					State: cw.Campaign.State, CreatedAt: cw.Campaign.CreatedAt, ClosedAt: cw.Campaign.ClosedAt,
+					Total: cw.Progress.Total, Attested: cw.Progress.Attested,
+					Revoked: cw.Progress.Revoked, Pending: cw.Progress.Pending,
+				})
+			}
+		}
+		if acts, err := c.ListBreakGlassActivations(ctx, pid); err == nil {
+			ev.BreakGlass = append(ev.BreakGlass, acts...)
+		}
+	}
+	return ev, nil
+}

--- a/internal/core/compliance_evidence_external_test.go
+++ b/internal/core/compliance_evidence_external_test.go
@@ -1,0 +1,61 @@
+package core_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/testhelper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// GenerateComplianceEvidence bundles the posture with its supporting records — the
+// audit anchor, campaigns, and the break-glass register.
+func TestGenerateComplianceEvidence_BundlesRecords(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(
+		&models.AuditEvent{}, &models.AccessReviewCampaign{}, &models.AccessReviewItem{},
+		&models.BreakGlassActivation{}, &models.RotationPolicy{},
+	))
+
+	const proj = uint(2)
+	ctx := context.Background()
+	h.CreateTestUser(t, "alice", 10)
+	h.AssignUserRole(t, 10, 3, uptr(proj))
+
+	// A campaign (the recertification record) and an active break-glass activation.
+	camp, err := h.CoreService.OpenAccessReviewCampaign(ctx, 1, proj, "Q4 review")
+	require.NoError(t, err)
+	future := time.Now().Add(time.Hour)
+	require.NoError(t, h.DB.Create(&models.BreakGlassActivation{
+		ProjectID: proj, UserID: 10, RoleID: 3, RoleName: "editor",
+		Justification: "incident INC-1", State: "active", ExpiresAt: &future, CreatedAt: time.Now(),
+	}).Error)
+
+	ev, err := h.CoreService.GenerateComplianceEvidence(ctx)
+	require.NoError(t, err)
+
+	require.NotNil(t, ev.Posture, "the pack embeds the posture summary")
+
+	// The campaign appears with its project and tally.
+	var found bool
+	for _, c := range ev.Campaigns {
+		if c.ID == camp.Campaign.ID {
+			found = true
+			assert.Equal(t, proj, c.ProjectID)
+			assert.Equal(t, "Q4 review", c.Name)
+			assert.GreaterOrEqual(t, c.Total, 1)
+		}
+	}
+	assert.True(t, found, "the campaign is in the evidence pack")
+
+	// The break-glass activation is in the register.
+	require.Len(t, ev.BreakGlass, 1)
+	assert.Equal(t, "incident INC-1", ev.BreakGlass[0].Justification)
+
+	// The audit anchor reflects the chained events (the campaign-opened audit).
+	assert.GreaterOrEqual(t, ev.AuditAnchor.ChainedEvents, int64(1))
+}

--- a/server/http/handlers/dashboard.go
+++ b/server/http/handlers/dashboard.go
@@ -46,6 +46,17 @@ func (h *DashboardHandler) GetCompliancePosture(w http.ResponseWriter, r *http.R
 	sendSuccess(w, posture, "")
 }
 
+// GetComplianceEvidence handles GET /api/v1/compliance/evidence — the auditor
+// evidence pack (posture + supporting records); gated by system.read in the router.
+func (h *DashboardHandler) GetComplianceEvidence(w http.ResponseWriter, r *http.Request) {
+	evidence, err := h.coreService.GenerateComplianceEvidence(r.Context())
+	if err != nil {
+		sendError(w, "InternalServerError", "Failed to assemble compliance evidence", http.StatusInternalServerError, nil)
+		return
+	}
+	sendSuccess(w, evidence, "")
+}
+
 // GetActivity handles GET /api/v1/dashboard/activity
 func (h *DashboardHandler) GetActivity(w http.ResponseWriter, r *http.Request) {
 	userCtx := middleware.GetUserFromContext(r.Context())

--- a/server/http/handlers/openapi.yaml
+++ b/server/http/handlers/openapi.yaml
@@ -2795,6 +2795,25 @@ paths:
             rotation, identity, emergency_access} — see the description for each group's fields.
         '401': {$ref: '#/components/responses/Error'}
         '403': {$ref: '#/components/responses/Error'}
+  /api/v1/compliance/evidence:
+    get:
+      tags: [Dashboard]
+      summary: Auditor evidence pack (posture + supporting records)
+      description: >-
+        A timestamped, archivable evidence bundle: the posture plus the records that
+        substantiate it — the audit-chain anchor {valid, chained_events, head_id,
+        head_hash, checkpointed}, the access-review campaigns (per project, with
+        tallies), the break-glass register, and the overdue rotations. Requires
+        system.read.
+      operationId: getComplianceEvidence
+      security: [{bearerAuth: []}]
+      responses:
+        '200':
+          description: >-
+            Envelope {data}. data: {generated_at, posture, audit_anchor, campaigns[],
+            break_glass[], rotation_overdue[]}.
+        '401': {$ref: '#/components/responses/Error'}
+        '403': {$ref: '#/components/responses/Error'}
   /api/v1/dashboard/activity:
     get:
       tags: [Dashboard]

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -456,6 +456,8 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 
 		// Compliance posture — deployment-wide controls snapshot for auditors.
 		r.With(customMiddleware.RequirePermission("system.read")).Get("/compliance/posture", dashboardHandler.GetCompliancePosture)
+		// Compliance evidence pack — posture + supporting records, for archival.
+		r.With(customMiddleware.RequirePermission("system.read")).Get("/compliance/evidence", dashboardHandler.GetComplianceEvidence)
 	})
 
 	// Swagger UI (optional, based on config)


### PR DESCRIPTION
## What

Where the posture report (#177) is the at-a-glance summary, the **evidence pack** bundles it with the records that substantiate it — a timestamped, archivable artifact an auditor keeps. Second item of the compliance-evidence batch.

Contents:
- **Audit-chain anchor** — `{valid, chained_events, head_id, head_hash, checkpointed}`, the external tamper-evidence anchor (ADR-029)
- **Access-review campaigns** per project, with tallies (the recertification record)
- **Break-glass register** (the emergency-access log)
- **Overdue rotations** (the open hygiene gaps)

## Surfaces

- **core**: `GenerateComplianceEvidence` + the evidence structs (`compliance_evidence.go`); reuses `GetCompliancePosture`, `VerifyAuditChain`, `GetRotationStatus`, and per-project `ListAccessReviewCampaigns` / `ListBreakGlassActivations`.
- **API**: `GET /api/v1/compliance/evidence` on the dashboard handler, gated `system.read`.
- **CLI**: `keyorix compliance export [--output FILE]` — pretty JSON to stdout or a file.

## Tests

The pack embeds the posture and contains the campaign (with tally), the break-glass activation, and an audit anchor reflecting the chained events.

## Docs

openapi endpoint + REMOTE_CLI export note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)