### PR TITLE
feat(sod): separation-of-duties policies + violation detection (A — ISO 27001 A.5.3)

### DIFF
--- a/docs/REMOTE_CLI_SETUP.md
+++ b/docs/REMOTE_CLI_SETUP.md
@@ -305,6 +305,28 @@ keyorix compliance report
 keyorix compliance export --output evidence-2026Q4.json
 ```
 
+### Separation-of-Duties Commands
+
+Separation of duties (ISO 27001 A.5.3 / SOX): define **toxic combinations** — two
+permissions one principal must not hold together — and find who violates them.
+Listing needs `system.read`; creating/deleting policies needs `system.write`.
+
+- `keyorix sod policy list` — the defined policies.
+- `keyorix sod policy create --name <n> --permission-a <perm> --permission-b <perm>
+  [--description …]` — define a conflicting pair (the two permissions must differ).
+- `keyorix sod policy delete --id N` — retire a policy.
+- `keyorix sod violations` — principals whose effective permissions include both
+  sides of a policy.
+
+```bash
+# Approving access and administering secrets shouldn't be the same person:
+keyorix sod policy create --name "approve-vs-admin" \
+  --permission-a roles.assign --permission-b secrets.delete
+
+# Who currently violates a policy?
+keyorix sod violations
+```
+
 ## Deployment Scenarios
 
 ### Development Environment

--- a/internal/cli/main.go
+++ b/internal/cli/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/keyorixhq/keyorix/internal/cli/run"
 	"github.com/keyorixhq/keyorix/internal/cli/secret"
 	"github.com/keyorixhq/keyorix/internal/cli/share"
+	sodcli "github.com/keyorixhq/keyorix/internal/cli/sod"
 	"github.com/keyorixhq/keyorix/internal/cli/status"
 	"github.com/keyorixhq/keyorix/internal/cli/system"
 	"github.com/keyorixhq/keyorix/internal/cli/user"
@@ -69,6 +70,7 @@ func init() {
 	rootCmd.AddCommand(accessreview.AccessReviewCmd)
 	rootCmd.AddCommand(breakglass.BreakGlassCmd)
 	rootCmd.AddCommand(compliance.ComplianceCmd)
+	rootCmd.AddCommand(sodcli.SoDCmd)
 }
 
 // Execute runs the root command

--- a/internal/cli/sod/sod.go
+++ b/internal/cli/sod/sod.go
@@ -1,0 +1,176 @@
+// Package sod provides `keyorix sod` — separation-of-duties policies and violation
+// detection (ISO 27001 A.5.3 / SOX). A policy names two permissions one principal
+// must not hold together; violations are the users who do. Talks to /api/v1/sod/*
+// (reads need system.read, policy changes system.write).
+package sod
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/spf13/cobra"
+)
+
+// SoDCmd is the `keyorix sod` command.
+var SoDCmd = &cobra.Command{
+	Use:   "sod",
+	Short: "Separation-of-duties policies and violations (ISO 27001 A.5.3)",
+	Long:  "Define toxic permission combinations and find the principals who hold both sides.",
+}
+
+var policyCmd = &cobra.Command{
+	Use:   "policy",
+	Short: "Manage separation-of-duties policies",
+}
+
+type policyView struct {
+	ID          uint   `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	PermissionA string `json:"permission_a"`
+	PermissionB string `json:"permission_b"`
+}
+
+type violationView struct {
+	PolicyName  string `json:"policy_name"`
+	Username    string `json:"username"`
+	Email       string `json:"email"`
+	PermissionA string `json:"permission_a"`
+	PermissionB string `json:"permission_b"`
+}
+
+var (
+	sName  string
+	sDesc  string
+	sPermA string
+	sPermB string
+	sID    int
+)
+
+var policyListCmd = &cobra.Command{
+	Use:          "list",
+	Short:        "List separation-of-duties policies",
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		c, ok := common.NewRemoteClient()
+		if !ok {
+			return fmt.Errorf("not connected to a server — run: keyorix connect <server>")
+		}
+		var out struct {
+			Policies []policyView `json:"policies"`
+			Count    int          `json:"count"`
+		}
+		if err := c.Get(context.Background(), "/api/v1/sod/policies", &out); err != nil {
+			return err
+		}
+		if out.Count == 0 {
+			fmt.Println("No separation-of-duties policies defined.")
+			return nil
+		}
+		fmt.Printf("%-5s %-26s %-22s %s\n", "ID", "NAME", "PERMISSION A", "PERMISSION B")
+		for _, p := range out.Policies {
+			fmt.Printf("%-5d %-26s %-22s %s\n", p.ID, truncate(p.Name, 26), p.PermissionA, p.PermissionB)
+		}
+		return nil
+	},
+}
+
+var policyCreateCmd = &cobra.Command{
+	Use:          "create",
+	Short:        "Create a separation-of-duties policy (two conflicting permissions)",
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		if sName == "" || sPermA == "" || sPermB == "" {
+			return fmt.Errorf("--name, --permission-a and --permission-b are required")
+		}
+		c, ok := common.NewRemoteClient()
+		if !ok {
+			return fmt.Errorf("not connected to a server — run: keyorix connect <server>")
+		}
+		body := map[string]string{"name": sName, "description": sDesc, "permission_a": sPermA, "permission_b": sPermB}
+		var out struct {
+			Policy policyView `json:"policy"`
+		}
+		if err := c.Post(context.Background(), "/api/v1/sod/policies", body, &out); err != nil {
+			return err
+		}
+		fmt.Printf("Created SoD policy %d (%q): %s + %s must not be held together.\n", out.Policy.ID, sName, sPermA, sPermB)
+		return nil
+	},
+}
+
+var policyDeleteCmd = &cobra.Command{
+	Use:          "delete",
+	Short:        "Delete a separation-of-duties policy",
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		if sID <= 0 {
+			return fmt.Errorf("--id is required")
+		}
+		c, ok := common.NewRemoteClient()
+		if !ok {
+			return fmt.Errorf("not connected to a server — run: keyorix connect <server>")
+		}
+		if err := c.Delete(context.Background(), "/api/v1/sod/policies/"+strconv.Itoa(sID)); err != nil {
+			return err
+		}
+		fmt.Printf("Deleted SoD policy %d.\n", sID)
+		return nil
+	},
+}
+
+var violationsCmd = &cobra.Command{
+	Use:          "violations",
+	Short:        "List principals that violate a separation-of-duties policy",
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		c, ok := common.NewRemoteClient()
+		if !ok {
+			return fmt.Errorf("not connected to a server — run: keyorix connect <server>")
+		}
+		var out struct {
+			Violations []violationView `json:"violations"`
+			Count      int             `json:"count"`
+		}
+		if err := c.Get(context.Background(), "/api/v1/sod/violations", &out); err != nil {
+			return err
+		}
+		if out.Count == 0 {
+			fmt.Println("No separation-of-duties violations.")
+			return nil
+		}
+		fmt.Printf("%d violation(s):\n\n", out.Count)
+		fmt.Printf("%-26s %-22s %-22s %s\n", "POLICY", "USER", "PERMISSION A", "PERMISSION B")
+		for _, v := range out.Violations {
+			user := v.Username
+			if v.Email != "" {
+				user = fmt.Sprintf("%s <%s>", v.Username, v.Email)
+			}
+			fmt.Printf("%-26s %-22s %-22s %s\n", truncate(v.PolicyName, 26), truncate(user, 22), v.PermissionA, v.PermissionB)
+		}
+		return nil
+	},
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	if n <= 1 {
+		return s[:n]
+	}
+	return s[:n-1] + "…"
+}
+
+func init() {
+	policyCreateCmd.Flags().StringVar(&sName, "name", "", "Policy name (required)")
+	policyCreateCmd.Flags().StringVar(&sDesc, "description", "", "Description")
+	policyCreateCmd.Flags().StringVar(&sPermA, "permission-a", "", "First permission, e.g. roles.assign (required)")
+	policyCreateCmd.Flags().StringVar(&sPermB, "permission-b", "", "Second permission, e.g. secrets.delete (required)")
+	policyDeleteCmd.Flags().IntVar(&sID, "id", 0, "Policy ID to delete (required)")
+
+	policyCmd.AddCommand(policyListCmd, policyCreateCmd, policyDeleteCmd)
+	SoDCmd.AddCommand(policyCmd, violationsCmd)
+}

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -229,6 +229,35 @@ func (m *MockStorage) LastUserSecretActivity(ctx context.Context, projectID uint
 	return args.Get(0).(map[uint]time.Time), args.Error(1)
 }
 
+func (m *MockStorage) CreateSoDPolicy(ctx context.Context, p *models.SoDPolicy) (*models.SoDPolicy, error) {
+	args := m.Called(ctx, p)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.SoDPolicy), args.Error(1)
+}
+
+func (m *MockStorage) GetSoDPolicy(ctx context.Context, id uint) (*models.SoDPolicy, error) {
+	args := m.Called(ctx, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.SoDPolicy), args.Error(1)
+}
+
+func (m *MockStorage) ListSoDPolicies(ctx context.Context) ([]*models.SoDPolicy, error) {
+	args := m.Called(ctx)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*models.SoDPolicy), args.Error(1)
+}
+
+func (m *MockStorage) DeleteSoDPolicy(ctx context.Context, id uint) error {
+	args := m.Called(ctx, id)
+	return args.Error(0)
+}
+
 func (m *MockStorage) CreateBreakGlassActivation(ctx context.Context, a *models.BreakGlassActivation) (*models.BreakGlassActivation, error) {
 	args := m.Called(ctx, a)
 	if args.Get(0) == nil {

--- a/internal/core/sod.go
+++ b/internal/core/sod.go
@@ -1,0 +1,138 @@
+// sod.go — separation of duties (ISO 27001 A.5.3 / SOX). A SoD policy names two
+// permissions that one principal must not hold together (a "toxic combination",
+// e.g. "approve access requests" AND "administer secrets"). DetectSoDViolations
+// finds the users who effectively hold both sides of any policy. Policies are
+// managed by admins (system.write); detection + listing need system.read. The
+// violations feed the compliance posture/evidence and the web.
+package core
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// SoD audit event types.
+const (
+	EventSoDPolicyCreated = "sod.policy_created" // #nosec G101 -- audit event type, not a credential
+	EventSoDPolicyDeleted = "sod.policy_deleted" // #nosec G101 -- audit event type, not a credential
+)
+
+// SoDViolation is one user who effectively holds both permissions a policy forbids
+// together.
+type SoDViolation struct {
+	PolicyID    uint   `json:"policy_id"`
+	PolicyName  string `json:"policy_name"`
+	UserID      uint   `json:"user_id"`
+	Username    string `json:"username"`
+	Email       string `json:"email,omitempty"`
+	PermissionA string `json:"permission_a"`
+	PermissionB string `json:"permission_b"`
+}
+
+// CreateSoDPolicy defines a toxic-combination rule. The two permissions must be
+// present and distinct. actorID is the creating admin.
+func (c *KeyorixCore) CreateSoDPolicy(ctx context.Context, actorID uint, name, description, permA, permB string) (*models.SoDPolicy, error) {
+	name = strings.TrimSpace(name)
+	permA = strings.TrimSpace(permA)
+	permB = strings.TrimSpace(permB)
+	if name == "" {
+		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "a policy name is required")
+	}
+	if permA == "" || permB == "" {
+		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "two permissions are required")
+	}
+	if permA == permB {
+		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "the two permissions must be different")
+	}
+	policy, err := c.storage.CreateSoDPolicy(ctx, &models.SoDPolicy{
+		Name: name, Description: description, PermissionA: permA, PermissionB: permB,
+		CreatedBy: actorID, CreatedAt: c.now(),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	c.writeAuditEvent(ctx, EventSoDPolicyCreated, actorPtr(actorID), nil,
+		fmt.Sprintf("created SoD policy %d (%q): %s + %s", policy.ID, name, permA, permB))
+	return policy, nil
+}
+
+// ListSoDPolicies returns all separation-of-duties policies.
+func (c *KeyorixCore) ListSoDPolicies(ctx context.Context) ([]*models.SoDPolicy, error) {
+	policies, err := c.storage.ListSoDPolicies(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	return policies, nil
+}
+
+// DeleteSoDPolicy retires a policy. actorID is the acting admin.
+func (c *KeyorixCore) DeleteSoDPolicy(ctx context.Context, actorID, id uint) error {
+	if err := c.storage.DeleteSoDPolicy(ctx, id); err != nil {
+		return err
+	}
+	c.writeAuditEvent(ctx, EventSoDPolicyDeleted, actorPtr(actorID), nil,
+		fmt.Sprintf("deleted SoD policy %d", id))
+	return nil
+}
+
+// DetectSoDViolations evaluates every policy against every active user's effective
+// permissions and returns each principal that holds both sides of a policy. Empty
+// when there are no policies. It pages through all users (no silent cap).
+func (c *KeyorixCore) DetectSoDViolations(ctx context.Context) ([]SoDViolation, error) {
+	policies, err := c.storage.ListSoDPolicies(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	if len(policies) == 0 {
+		return []SoDViolation{}, nil
+	}
+
+	violations := []SoDViolation{}
+	const pageSize = 500
+	for page := 1; ; page++ {
+		users, total, err := c.storage.ListUsers(ctx, &storage.UserFilter{Page: page, PageSize: pageSize})
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+		}
+		for _, u := range users {
+			if !u.IsActive {
+				continue
+			}
+			perms, err := c.storage.GetUserPermissions(ctx, u.ID)
+			if err != nil {
+				continue // best-effort; a user whose permissions can't be read is skipped
+			}
+			held := make(map[string]bool, len(perms))
+			for _, p := range perms {
+				held[p.Name] = true
+			}
+			for _, pol := range policies {
+				if held[pol.PermissionA] && held[pol.PermissionB] {
+					violations = append(violations, SoDViolation{
+						PolicyID: pol.ID, PolicyName: pol.Name,
+						UserID: u.ID, Username: u.Username, Email: u.Email,
+						PermissionA: pol.PermissionA, PermissionB: pol.PermissionB,
+					})
+				}
+			}
+		}
+		if len(users) < pageSize || int64(page*pageSize) >= total {
+			break
+		}
+	}
+	return violations, nil
+}
+
+// actorPtr returns a *uint for an actor id (nil when 0/unauthenticated).
+func actorPtr(id uint) *uint {
+	if id == 0 {
+		return nil
+	}
+	a := id
+	return &a
+}

--- a/internal/core/sod_external_test.go
+++ b/internal/core/sod_external_test.go
@@ -1,0 +1,78 @@
+package core_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/testhelper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// DetectSoDViolations flags a user whose effective permissions include both sides
+// of a policy, and leaves a user holding only one side alone.
+func TestDetectSoDViolations(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(&models.SoDPolicy{}, &models.AuditEvent{}))
+
+	ctx := context.Background()
+	// editor (role 3) grants secrets.write + users.read; viewer (role 4) grants
+	// secrets.read + users.read (no secrets.write).
+	h.CreateTestUser(t, "alice", 10)
+	h.AssignUserRole(t, 10, 3, nil) // editor (global) → holds both
+	h.CreateTestUser(t, "bob", 11)
+	h.AssignUserRole(t, 11, 4, nil) // viewer → only users.read
+
+	_, err := h.CoreService.CreateSoDPolicy(ctx, 1, "write-vs-useradmin", "", "secrets.write", "users.read")
+	require.NoError(t, err)
+
+	violations, err := h.CoreService.DetectSoDViolations(ctx)
+	require.NoError(t, err)
+
+	var users []string
+	for _, v := range violations {
+		users = append(users, v.Username)
+		assert.Equal(t, "write-vs-useradmin", v.PolicyName)
+	}
+	assert.Contains(t, users, "alice", "alice (editor) holds both secrets.write and users.read")
+	assert.NotContains(t, users, "bob", "bob (viewer) lacks secrets.write")
+}
+
+// With no policies, there are no violations.
+func TestDetectSoDViolations_NoPolicies(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(&models.SoDPolicy{}))
+	h.CreateTestUser(t, "alice", 10)
+	h.AssignUserRole(t, 10, 3, nil)
+
+	v, err := h.CoreService.DetectSoDViolations(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, v)
+}
+
+// CreateSoDPolicy validates its inputs.
+func TestCreateSoDPolicy_Validation(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(&models.SoDPolicy{}, &models.AuditEvent{}))
+	ctx := context.Background()
+
+	_, err := h.CoreService.CreateSoDPolicy(ctx, 1, "", "", "a", "b")
+	require.Error(t, err, "name required")
+	_, err = h.CoreService.CreateSoDPolicy(ctx, 1, "n", "", "secrets.read", "secrets.read")
+	require.Error(t, err, "the two permissions must differ")
+	_, err = h.CoreService.CreateSoDPolicy(ctx, 1, "n", "", "secrets.read", "")
+	require.Error(t, err, "both permissions required")
+
+	// A valid policy is listed and deletable.
+	p, err := h.CoreService.CreateSoDPolicy(ctx, 1, "ok", "d", "roles.assign", "secrets.delete")
+	require.NoError(t, err)
+	list, err := h.CoreService.ListSoDPolicies(ctx)
+	require.NoError(t, err)
+	require.Len(t, list, 1)
+	require.NoError(t, h.CoreService.DeleteSoDPolicy(ctx, 1, p.ID))
+	require.Error(t, h.CoreService.DeleteSoDPolicy(ctx, 1, p.ID), "already deleted")
+}

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -77,6 +77,12 @@ type Storage interface {
 	GetAccessReviewItem(ctx context.Context, id uint) (*models.AccessReviewItem, error)
 	UpdateAccessReviewItem(ctx context.Context, item *models.AccessReviewItem) error
 
+	// Separation-of-duties policies (ISO 27001 A.5.3 / SOX) — toxic permission pairs.
+	CreateSoDPolicy(ctx context.Context, p *models.SoDPolicy) (*models.SoDPolicy, error)
+	GetSoDPolicy(ctx context.Context, id uint) (*models.SoDPolicy, error)
+	ListSoDPolicies(ctx context.Context) ([]*models.SoDPolicy, error)
+	DeleteSoDPolicy(ctx context.Context, id uint) error
+
 	// Break-glass emergency-access activations (NIS2/DORA incident response).
 	CreateBreakGlassActivation(ctx context.Context, a *models.BreakGlassActivation) (*models.BreakGlassActivation, error)
 	GetBreakGlassActivation(ctx context.Context, id uint) (*models.BreakGlassActivation, error)

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -254,6 +254,7 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 	accessReqExists := tableExists(db, "access_requests")
 	campaignExists := tableExists(db, "access_review_campaigns")
 	breakGlassExists := tableExists(db, "break_glass_activations")
+	sodExists := tableExists(db, "sod_policies")
 	pwHistExists := tableExists(db, "password_histories")
 	machineExists := tableExists(db, "machine_identities")
 	machineCredExists := tableExists(db, "machine_identity_credentials")
@@ -397,6 +398,13 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 	if !breakGlassExists {
 		if err := db.AutoMigrate(&models.BreakGlassActivation{}); err != nil {
 			return fmt.Errorf("failed to migrate break_glass_activations table: %w", err)
+		}
+	}
+
+	// Create the separation-of-duties policy table if missing (additive).
+	if !sodExists {
+		if err := db.AutoMigrate(&models.SoDPolicy{}); err != nil {
+			return fmt.Errorf("failed to migrate sod_policies table: %w", err)
 		}
 	}
 

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -70,6 +70,23 @@ type AccessRequest struct {
 	ResolvedAt    *time.Time
 }
 
+// SoDPolicy is a separation-of-duties rule (ISO 27001 A.5.3 / SOX): two permissions
+// that one principal must not hold together (a "toxic combination"). A user whose
+// effective permissions include BOTH PermissionA and PermissionB violates it. The
+// policy existing = active; delete it to retire the rule.
+type SoDPolicy struct {
+	ID          uint      `gorm:"primaryKey" json:"id"`
+	Name        string    `json:"name"`
+	Description string    `json:"description,omitempty"`
+	PermissionA string    `json:"permission_a"` // e.g. "roles.assign"
+	PermissionB string    `json:"permission_b"` // e.g. "secrets.delete"
+	CreatedBy   uint      `json:"created_by,omitempty"`
+	CreatedAt   time.Time `json:"created_at"`
+}
+
+// TableName pins the table name (GORM would otherwise derive "so_d_policies").
+func (SoDPolicy) TableName() string { return "sod_policies" }
+
 // BreakGlassActivation records a self-service emergency-access elevation: a user
 // immediately self-granted a time-bound emergency role (no approval), with a
 // written justification, for incident response (NIS2/DORA). The grant itself is a

--- a/internal/storage/store/local_sod.go
+++ b/internal/storage/store/local_sod.go
@@ -1,0 +1,45 @@
+// local_sod.go — separation-of-duties policy persistence (ISO 27001 A.5.3 / SOX).
+// For the remote equivalent see remote_sod.go (server-side only).
+package store
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+func (ls *LocalStorage) CreateSoDPolicy(ctx context.Context, p *models.SoDPolicy) (*models.SoDPolicy, error) {
+	if err := ls.db.WithContext(ctx).Create(p).Error; err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	return p, nil
+}
+
+func (ls *LocalStorage) GetSoDPolicy(ctx context.Context, id uint) (*models.SoDPolicy, error) {
+	var p models.SoDPolicy
+	if err := ls.db.WithContext(ctx).First(&p, id).Error; err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorNotFound", nil), err)
+	}
+	return &p, nil
+}
+
+func (ls *LocalStorage) ListSoDPolicies(ctx context.Context) ([]*models.SoDPolicy, error) {
+	var rows []*models.SoDPolicy
+	if err := ls.db.WithContext(ctx).Order("id ASC").Find(&rows).Error; err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	return rows, nil
+}
+
+func (ls *LocalStorage) DeleteSoDPolicy(ctx context.Context, id uint) error {
+	result := ls.db.WithContext(ctx).Delete(&models.SoDPolicy{}, id)
+	if result.Error != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), result.Error)
+	}
+	if result.RowsAffected == 0 {
+		return fmt.Errorf("%s", i18n.T("ErrorNotFound", nil))
+	}
+	return nil
+}

--- a/internal/storage/store/remote_sod.go
+++ b/internal/storage/store/remote_sod.go
@@ -1,0 +1,25 @@
+// remote_sod.go — separation-of-duties policies for RemoteStorage. Processed
+// server-side; stubs here. See local_sod.go.
+package store
+
+import (
+	"context"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+func (rs *RemoteStorage) CreateSoDPolicy(_ context.Context, _ *models.SoDPolicy) (*models.SoDPolicy, error) {
+	return nil, remoteUnsupported("CreateSoDPolicy")
+}
+
+func (rs *RemoteStorage) GetSoDPolicy(_ context.Context, _ uint) (*models.SoDPolicy, error) {
+	return nil, remoteUnsupported("GetSoDPolicy")
+}
+
+func (rs *RemoteStorage) ListSoDPolicies(_ context.Context) ([]*models.SoDPolicy, error) {
+	return nil, remoteUnsupported("ListSoDPolicies")
+}
+
+func (rs *RemoteStorage) DeleteSoDPolicy(_ context.Context, _ uint) error {
+	return remoteUnsupported("DeleteSoDPolicy")
+}

--- a/server/http/handlers/openapi.yaml
+++ b/server/http/handlers/openapi.yaml
@@ -2814,6 +2814,66 @@ paths:
             break_glass[], rotation_overdue[]}.
         '401': {$ref: '#/components/responses/Error'}
         '403': {$ref: '#/components/responses/Error'}
+  /api/v1/sod/policies:
+    get:
+      tags: [Dashboard]
+      summary: List separation-of-duties policies (ISO 27001 A.5.3)
+      description: "Toxic permission combinations one principal must not hold together. Requires system.read."
+      operationId: listSoDPolicies
+      security: [{bearerAuth: []}]
+      responses:
+        '200': {description: "Envelope {data}. data: {policies[] of {id, name, description, permission_a, permission_b, created_at}, count}."}
+        '401': {$ref: '#/components/responses/Error'}
+        '403': {$ref: '#/components/responses/Error'}
+    post:
+      tags: [Dashboard]
+      summary: Create a separation-of-duties policy
+      description: "Define two permissions that must not be held together. Requires system.write."
+      operationId: createSoDPolicy
+      security: [{bearerAuth: []}]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [name, permission_a, permission_b]
+              properties:
+                name: {type: string}
+                description: {type: string}
+                permission_a: {type: string, description: "e.g. roles.assign"}
+                permission_b: {type: string, description: "e.g. secrets.delete (must differ from permission_a)"}
+      responses:
+        '201': {description: "Envelope {data}. data: {policy}."}
+        '400': {$ref: '#/components/responses/Error'}
+        '401': {$ref: '#/components/responses/Error'}
+        '403': {$ref: '#/components/responses/Error'}
+  /api/v1/sod/policies/{id}:
+    delete:
+      tags: [Dashboard]
+      summary: Delete a separation-of-duties policy
+      operationId: deleteSoDPolicy
+      security: [{bearerAuth: []}]
+      parameters:
+        - {name: id, in: path, required: true, schema: {type: integer, format: uint32}}
+      responses:
+        '200': {description: "Envelope {data, message}. Policy deleted."}
+        '401': {$ref: '#/components/responses/Error'}
+        '403': {$ref: '#/components/responses/Error'}
+        '404': {$ref: '#/components/responses/Error'}
+  /api/v1/sod/violations:
+    get:
+      tags: [Dashboard]
+      summary: List separation-of-duties violations
+      description: >-
+        Principals whose effective permissions include both sides of a policy.
+        Requires system.read.
+      operationId: listSoDViolations
+      security: [{bearerAuth: []}]
+      responses:
+        '200': {description: "Envelope {data}. data: {violations[] of {policy_id, policy_name, user_id, username, email, permission_a, permission_b}, count}."}
+        '401': {$ref: '#/components/responses/Error'}
+        '403': {$ref: '#/components/responses/Error'}
   /api/v1/dashboard/activity:
     get:
       tags: [Dashboard]

--- a/server/http/handlers/sod.go
+++ b/server/http/handlers/sod.go
@@ -1,0 +1,88 @@
+// sod.go — separation-of-duties endpoints (ISO 27001 A.5.3 / SOX). Deployment-wide:
+// listing policies + violations needs system.read; creating/deleting policies needs
+// system.write (wired in router.go).
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/keyorixhq/keyorix/server/middleware"
+)
+
+// ListSoDPolicies handles GET /api/v1/sod/policies.
+func (h *CatalogHandler) ListSoDPolicies(w http.ResponseWriter, r *http.Request) {
+	policies, err := h.coreService.ListSoDPolicies(r.Context())
+	if err != nil {
+		sendError(w, "Error", err.Error(), http.StatusInternalServerError, nil)
+		return
+	}
+	sendSuccess(w, map[string]interface{}{"policies": policies, "count": len(policies)}, "")
+}
+
+// CreateSoDPolicy handles POST /api/v1/sod/policies.
+func (h *CatalogHandler) CreateSoDPolicy(w http.ResponseWriter, r *http.Request) {
+	actor := middleware.GetUserFromContext(r.Context())
+	if actor == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	var body struct {
+		Name        string `json:"name"`
+		Description string `json:"description"`
+		PermissionA string `json:"permission_a"`
+		PermissionB string `json:"permission_b"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		sendError(w, "InvalidJSON", "Invalid request body", http.StatusBadRequest, nil)
+		return
+	}
+	policy, err := h.coreService.CreateSoDPolicy(r.Context(), actor.UserID, body.Name, body.Description, body.PermissionA, body.PermissionB)
+	if err != nil {
+		status := http.StatusInternalServerError
+		if strings.Contains(err.Error(), "required") || strings.Contains(err.Error(), "must be different") {
+			status = http.StatusBadRequest
+		}
+		sendError(w, "Error", err.Error(), status, nil)
+		return
+	}
+	w.WriteHeader(http.StatusCreated)
+	sendSuccess(w, map[string]interface{}{"policy": policy}, "Policy created")
+}
+
+// DeleteSoDPolicy handles DELETE /api/v1/sod/policies/{id}.
+func (h *CatalogHandler) DeleteSoDPolicy(w http.ResponseWriter, r *http.Request) {
+	actor := middleware.GetUserFromContext(r.Context())
+	if actor == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		sendError(w, "InvalidParameter", "Invalid policy ID", http.StatusBadRequest, nil)
+		return
+	}
+	if err := h.coreService.DeleteSoDPolicy(r.Context(), actor.UserID, uint(id)); err != nil {
+		status := http.StatusInternalServerError
+		if strings.Contains(err.Error(), "not found") {
+			status = http.StatusNotFound
+		}
+		sendError(w, "Error", err.Error(), status, nil)
+		return
+	}
+	sendSuccess(w, nil, "Policy deleted")
+}
+
+// ListSoDViolations handles GET /api/v1/sod/violations.
+func (h *CatalogHandler) ListSoDViolations(w http.ResponseWriter, r *http.Request) {
+	violations, err := h.coreService.DetectSoDViolations(r.Context())
+	if err != nil {
+		sendError(w, "Error", err.Error(), http.StatusInternalServerError, nil)
+		return
+	}
+	sendSuccess(w, map[string]interface{}{"violations": violations, "count": len(violations)}, "")
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -458,6 +458,13 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		r.With(customMiddleware.RequirePermission("system.read")).Get("/compliance/posture", dashboardHandler.GetCompliancePosture)
 		// Compliance evidence pack — posture + supporting records, for archival.
 		r.With(customMiddleware.RequirePermission("system.read")).Get("/compliance/evidence", dashboardHandler.GetComplianceEvidence)
+
+		// Separation of duties (ISO A.5.3): list policies/violations (system.read);
+		// create/delete policies (system.write).
+		r.With(customMiddleware.RequirePermission("system.read")).Get("/sod/policies", catalogHandler.ListSoDPolicies)
+		r.With(customMiddleware.RequirePermission("system.write")).Post("/sod/policies", catalogHandler.CreateSoDPolicy)
+		r.With(customMiddleware.RequirePermission("system.write")).Delete("/sod/policies/{id}", catalogHandler.DeleteSoDPolicy)
+		r.With(customMiddleware.RequirePermission("system.read")).Get("/sod/violations", catalogHandler.ListSoDViolations)
 	})
 
 	// Swagger UI (optional, based on config)


### PR DESCRIPTION
## What

A **separation-of-duties** policy names two permissions one principal must not hold together (a "toxic combination" — e.g. *approve access requests* AND *administer secrets*). Violation detection finds the users whose effective permissions include **both** sides of any policy — the SoD / least-privilege control auditors specifically check (ISO 27001 A.5.3, SOX 404). First item of the SoD batch (this → posture/evidence integration → web).

## Surfaces

- **model**: `SoDPolicy` (name, `permission_a`, `permission_b`; existence = active, delete to retire), explicit table `sod_policies`; additive migration.
- **storage**: Create/Get/List/Delete (Local, Remote stubs, mock, interface).
- **core**: `CreateSoDPolicy` (validates name + two **distinct** permissions; audited), `ListSoDPolicies`, `DeleteSoDPolicy` (audited), `DetectSoDViolations` — evaluates every policy against every active user's effective permissions (`GetUserPermissions`, paged, no silent cap; #174's expiry filter means an expired grant doesn't count toward a violation).
- **API**: `GET /sod/policies` + `/sod/violations` (`system.read`); `POST` + `DELETE /sod/policies` (`system.write`).
- **CLI**: `keyorix sod policy list|create|delete` + `keyorix sod violations`.

## Tests

A user holding both permissions is flagged, one holding only one isn't; no policies → no violations; create-validation (name, distinct perms) + delete (incl. already-deleted → not-found).

## Docs

openapi (4 endpoints) + REMOTE_CLI SoD section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)