### PR TITLE
feat(sod): surface separation-of-duties in the compliance posture + evidence (B)

### DIFF
--- a/internal/cli/compliance/compliance.go
+++ b/internal/cli/compliance/compliance.go
@@ -35,6 +35,7 @@ type posture struct {
 		OpenCampaigns            int `json:"open_campaigns"`
 		PendingItems             int `json:"pending_items"`
 		DormantRoleGrants        int `json:"dormant_role_grants"`
+		SoDViolations            int `json:"sod_violations"`
 	} `json:"access_governance"`
 	Rotation struct {
 		CoveredSecrets int `json:"covered_secrets"`
@@ -87,6 +88,7 @@ var reportCmd = &cobra.Command{
 		fmt.Printf("  never reviewed            : %d\n", p.AccessGovernance.ProjectsNeverReviewed)
 		fmt.Printf("  open campaigns / pending  : %d / %d\n", p.AccessGovernance.OpenCampaigns, p.AccessGovernance.PendingItems)
 		fmt.Printf("  dormant role grants       : %d\n", p.AccessGovernance.DormantRoleGrants)
+		fmt.Printf("  separation-of-duties viol.: %d\n", p.AccessGovernance.SoDViolations)
 
 		fmt.Println("\nRotation hygiene (ISO A.5.15)")
 		fmt.Printf("  covered secrets : %d\n", p.Rotation.CoveredSecrets)

--- a/internal/core/compliance_evidence.go
+++ b/internal/core/compliance_evidence.go
@@ -57,6 +57,7 @@ type ComplianceEvidence struct {
 	Campaigns       []EvidenceCampaign             `json:"campaigns"`
 	BreakGlass      []*models.BreakGlassActivation `json:"break_glass"`
 	RotationOverdue []EvidenceRotation             `json:"rotation_overdue"`
+	SoDViolations   []SoDViolation                 `json:"sod_violations"`
 }
 
 // GenerateComplianceEvidence assembles the evidence pack. Like the posture, it is an
@@ -72,6 +73,12 @@ func (c *KeyorixCore) GenerateComplianceEvidence(ctx context.Context) (*Complian
 		Campaigns:       []EvidenceCampaign{},
 		BreakGlass:      []*models.BreakGlassActivation{},
 		RotationOverdue: []EvidenceRotation{},
+		SoDViolations:   []SoDViolation{},
+	}
+
+	// Separation-of-duties violations (the toxic-combination register).
+	if violations, err := c.DetectSoDViolations(ctx); err == nil {
+		ev.SoDViolations = violations
 	}
 
 	// Audit anchor.

--- a/internal/core/compliance_posture.go
+++ b/internal/core/compliance_posture.go
@@ -35,6 +35,7 @@ type AccessGovernancePosture struct {
 	OpenCampaigns            int `json:"open_campaigns"`
 	PendingItems             int `json:"pending_items"`       // undecided items across open campaigns
 	DormantRoleGrants        int `json:"dormant_role_grants"` // user role grants with no/old secret access
+	SoDViolations            int `json:"sod_violations"`      // principals holding a forbidden permission pair (A.5.3)
 }
 
 // RotationPosture summarises secret-rotation hygiene (ISO A.5.15 / NIS2).
@@ -110,6 +111,11 @@ func (c *KeyorixCore) GetCompliancePosture(ctx context.Context) (*CompliancePost
 	// Access governance + emergency access — per project.
 	if err := c.accessGovernancePosture(ctx, p); err != nil {
 		return nil, err
+	}
+
+	// Separation-of-duties violations (A.5.3).
+	if violations, err := c.DetectSoDViolations(ctx); err == nil {
+		p.AccessGovernance.SoDViolations = len(violations)
 	}
 	return p, nil
 }

--- a/internal/core/sod_compliance_external_test.go
+++ b/internal/core/sod_compliance_external_test.go
@@ -1,0 +1,38 @@
+package core_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/testhelper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// SoD violations surface in both the compliance posture (as a count) and the
+// evidence pack (as the toxic-combination register).
+func TestSoD_SurfacesInPostureAndEvidence(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(
+		&models.SoDPolicy{}, &models.AuditEvent{}, &models.AccessReviewCampaign{},
+		&models.AccessReviewItem{}, &models.BreakGlassActivation{}, &models.RotationPolicy{},
+	))
+
+	ctx := context.Background()
+	h.CreateTestUser(t, "alice", 10)
+	h.AssignUserRole(t, 10, 3, nil) // editor → secrets.write + users.read
+	_, err := h.CoreService.CreateSoDPolicy(ctx, 1, "write-vs-useradmin", "", "secrets.write", "users.read")
+	require.NoError(t, err)
+
+	p, err := h.CoreService.GetCompliancePosture(ctx)
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, p.AccessGovernance.SoDViolations, 1, "alice's editor role violates the policy")
+
+	ev, err := h.CoreService.GenerateComplianceEvidence(ctx)
+	require.NoError(t, err)
+	require.NotEmpty(t, ev.SoDViolations)
+	assert.Equal(t, "write-vs-useradmin", ev.SoDViolations[0].PolicyName)
+	assert.Equal(t, "alice", ev.SoDViolations[0].Username)
+}

--- a/server/http/handlers/openapi.yaml
+++ b/server/http/handlers/openapi.yaml
@@ -2782,8 +2782,9 @@ paths:
         A deployment-wide, on-demand snapshot of the control posture for auditors,
         rolling up: audit-trail integrity (chain verified, chained events,
         checkpointed), access governance (projects, with-open-campaign,
-        never-reviewed, open campaigns + pending items, dormant role grants),
-        rotation hygiene (covered secrets, overdue, due-soon), identity
+        never-reviewed, open campaigns + pending items, dormant role grants,
+        separation-of-duties violations), rotation hygiene (covered secrets,
+        overdue, due-soon), identity
         (active users, with-second-factor + percent), and emergency access
         (active/total break-glass activations). Requires system.read.
       operationId: getCompliancePosture
@@ -2811,7 +2812,7 @@ paths:
         '200':
           description: >-
             Envelope {data}. data: {generated_at, posture, audit_anchor, campaigns[],
-            break_glass[], rotation_overdue[]}.
+            break_glass[], rotation_overdue[], sod_violations[]}.
         '401': {$ref: '#/components/responses/Error'}
         '403': {$ref: '#/components/responses/Error'}
   /api/v1/sod/policies:


### PR DESCRIPTION
## What

Plugs the SoD detection (#179) into the auditor-facing compliance artifacts: the **posture** now counts SoD violations (principals holding a forbidden permission pair, A.5.3) under access governance, and the **evidence pack** carries the full violations register — so the toxic-combination control shows up alongside audit integrity, recertification, rotation, 2FA, and break-glass. Second item of the SoD batch.

## Surfaces

- **core**: `GetCompliancePosture` sets `AccessGovernance.SoDViolations` (count via `DetectSoDViolations`); `GenerateComplianceEvidence` adds `SoDViolations[]` (the register).
- **CLI**: `keyorix compliance report` prints a "separation-of-duties viol." line.

## Tests

A violating editor surfaces as a posture count and an evidence entry.

## Docs

openapi posture/evidence descriptions note `sod_violations`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)