### PR TITLE
feat(classification): secret data classification (A — ISO 27001 A.5.12/A.5.13)

### DIFF
--- a/docs/REMOTE_CLI_SETUP.md
+++ b/docs/REMOTE_CLI_SETUP.md
@@ -327,6 +327,22 @@ keyorix sod policy create --name "approve-vs-admin" \
 keyorix sod violations
 ```
 
+### Data Classification
+
+Label secrets with their data sensitivity (ISO 27001 A.5.12 / A.5.13) — `public`,
+`internal`, `confidential`, or `restricted` (empty = unclassified). The label drives
+the compliance classification posture (`keyorix compliance report`). Requires
+`secrets.write` at the secret's scope.
+
+- `keyorix secret classify --id N --level confidential` — set (or clear, with an
+  empty `--level`) a secret's classification. The label is also accepted as
+  `classification` at create time.
+
+```bash
+# Mark a production database password as restricted:
+keyorix secret classify --id 42 --level restricted
+```
+
 ## Deployment Scenarios
 
 ### Development Environment

--- a/internal/cli/common/remote_client.go
+++ b/internal/cli/common/remote_client.go
@@ -166,6 +166,36 @@ func (c *RemoteClient) Put(ctx context.Context, path string, body interface{}, o
 	return nil
 }
 
+// Patch sends a PATCH to path with a JSON body and decodes the response envelope
+// into out (out may be nil).
+func (c *RemoteClient) Patch(ctx context.Context, path string, body interface{}, out interface{}) error {
+	data, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("marshal request body: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPatch, c.Endpoint+path, bytes.NewReader(data))
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.Token)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.hc.Do(req)
+	if err != nil {
+		return fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("server returned HTTP %d for %s", resp.StatusCode, path)
+	}
+	if out != nil {
+		return decodeEnvelope(resp, out, path)
+	}
+	return nil
+}
+
 // DeleteWithBody sends a DELETE to path carrying a JSON body (some endpoints —
 // e.g. DELETE /user-roles — identify the target in the body rather than the URL).
 // No response body is expected.

--- a/internal/cli/secret/classify.go
+++ b/internal/cli/secret/classify.go
@@ -1,0 +1,55 @@
+package secret
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/spf13/cobra"
+)
+
+var (
+	classifyID    uint
+	classifyLevel string
+)
+
+var classifyCmd = &cobra.Command{
+	Use:   "classify",
+	Short: "Set a secret's data-classification label (ISO 27001 A.5.12)",
+	Long: `Label a secret with its data-sensitivity classification: public, internal,
+confidential, or restricted (or empty to clear). The label drives the compliance
+classification posture. Requires secrets.write at the secret's scope.`,
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		if classifyID == 0 {
+			return fmt.Errorf("--id is required")
+		}
+		switch classifyLevel {
+		case "", "public", "internal", "confidential", "restricted":
+		default:
+			return fmt.Errorf("--level must be public, internal, confidential, restricted, or empty to clear")
+		}
+		c, ok := common.NewRemoteClient()
+		if !ok {
+			return fmt.Errorf("not connected to a server — run: keyorix connect <server>")
+		}
+		var out struct{}
+		path := "/api/v1/secrets/" + strconv.Itoa(int(classifyID)) + "/classification"
+		if err := c.Patch(context.Background(), path, map[string]string{"classification": classifyLevel}, &out); err != nil {
+			return err
+		}
+		label := classifyLevel
+		if label == "" {
+			label = "unclassified"
+		}
+		fmt.Printf("Secret %d classified as %s.\n", classifyID, label)
+		return nil
+	},
+}
+
+func init() {
+	classifyCmd.Flags().UintVar(&classifyID, "id", 0, "Secret ID (required)")
+	classifyCmd.Flags().StringVar(&classifyLevel, "level", "", "public|internal|confidential|restricted (empty clears)")
+	SecretCmd.AddCommand(classifyCmd)
+}

--- a/internal/core/classification.go
+++ b/internal/core/classification.go
@@ -1,0 +1,69 @@
+// classification.go — data classification of secrets (ISO 27001 A.5.12 classification
+// of information / A.5.13 labelling). Each secret carries an optional sensitivity
+// label; the label drives the classification posture and lets a reviewer find the
+// high-sensitivity secrets. "" means unclassified.
+package core
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// Classification levels, lowest → highest sensitivity. "" (unclassified) is also
+// a valid stored state (not yet labelled).
+const (
+	ClassificationPublic       = "public"
+	ClassificationInternal     = "internal"
+	ClassificationConfidential = "confidential"
+	ClassificationRestricted   = "restricted"
+)
+
+// ClassificationLevels is the ordered set of valid (non-empty) labels.
+var ClassificationLevels = []string{
+	ClassificationPublic, ClassificationInternal, ClassificationConfidential, ClassificationRestricted,
+}
+
+// IsValidClassification reports whether level is "" (unclassified) or a known label.
+func IsValidClassification(level string) bool {
+	if level == "" {
+		return true
+	}
+	for _, l := range ClassificationLevels {
+		if l == level {
+			return true
+		}
+	}
+	return false
+}
+
+// ClassifySecret sets (or clears, with "") a secret's data-classification label and
+// audits the change as a secret.updated event with a before/after diff. actorID is
+// the acting user; username is for the audit description.
+func (c *KeyorixCore) ClassifySecret(ctx context.Context, actorID uint, username string, secretID uint, level string) (*models.SecretNode, error) {
+	if secretID == 0 {
+		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "secret ID is required")
+	}
+	if !IsValidClassification(level) {
+		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil),
+			"classification must be one of public, internal, confidential, restricted (or empty to clear)")
+	}
+	secret, err := c.storage.GetSecret(ctx, secretID)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorSecretNotFound", nil), err)
+	}
+	if secret.Classification == level {
+		return secret, nil // no-op
+	}
+	old := secret.Classification
+	secret.Classification = level
+	updated, err := c.storage.UpdateSecret(ctx, secret)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	diff := fmt.Sprintf(`{"classification":{"before":%q,"after":%q}}`, old, level)
+	c.LogSecretUpdatedWithDiff(ctx, actorID, secretID, secret.ProjectID, username, secret.Name, "", "", diff)
+	return updated, nil
+}

--- a/internal/core/classification_external_test.go
+++ b/internal/core/classification_external_test.go
@@ -1,0 +1,70 @@
+package core_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/testhelper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func strptr(s string) *string { return &s }
+
+// ClassifySecret sets a valid label, rejects an invalid one, and clears with "".
+func TestClassifySecret(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(&models.SecretNode{}, &models.AuditEvent{}))
+
+	ctx := context.Background()
+	require.NoError(t, h.DB.Create(&models.SecretNode{
+		ID: 500, ProjectID: 2, EnvironmentID: 20, Name: "db-pw", Type: "password", Status: "active", IsSecret: true,
+	}).Error)
+
+	// Invalid level is rejected.
+	_, err := h.CoreService.ClassifySecret(ctx, 1, "admin", 500, "top-secret")
+	require.Error(t, err)
+
+	// A valid level is set.
+	s, err := h.CoreService.ClassifySecret(ctx, 1, "admin", 500, core.ClassificationRestricted)
+	require.NoError(t, err)
+	assert.Equal(t, "restricted", s.Classification)
+
+	// Empty clears it.
+	s, err = h.CoreService.ClassifySecret(ctx, 1, "admin", 500, "")
+	require.NoError(t, err)
+	assert.Equal(t, "", s.Classification)
+}
+
+// The classification filter on ListSecrets matches a level, and "unclassified"
+// matches the empty label.
+func TestListSecrets_ClassificationFilter(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(&models.SecretNode{}))
+
+	ctx := context.Background()
+	require.NoError(t, h.DB.Create(&models.SecretNode{ID: 1, ProjectID: 2, Name: "a", Status: "active", IsSecret: true, Classification: "restricted"}).Error)
+	require.NoError(t, h.DB.Create(&models.SecretNode{ID: 2, ProjectID: 2, Name: "b", Status: "active", IsSecret: true, Classification: "internal"}).Error)
+	require.NoError(t, h.DB.Create(&models.SecretNode{ID: 3, ProjectID: 2, Name: "c", Status: "active", IsSecret: true, Classification: ""}).Error)
+
+	restricted, _, err := h.Storage.ListSecrets(ctx, &storage.SecretFilter{Classification: strptr("restricted"), Page: 1, PageSize: 50})
+	require.NoError(t, err)
+	require.Len(t, restricted, 1)
+	assert.Equal(t, "a", restricted[0].Name)
+
+	unclassified, _, err := h.Storage.ListSecrets(ctx, &storage.SecretFilter{Classification: strptr("unclassified"), Page: 1, PageSize: 50})
+	require.NoError(t, err)
+	require.Len(t, unclassified, 1)
+	assert.Equal(t, "c", unclassified[0].Name)
+}
+
+func TestIsValidClassification(t *testing.T) {
+	assert.True(t, core.IsValidClassification(""))
+	assert.True(t, core.IsValidClassification("confidential"))
+	assert.False(t, core.IsValidClassification("secret"))
+}

--- a/internal/core/secrets.go
+++ b/internal/core/secrets.go
@@ -29,6 +29,9 @@ type CreateSecretRequest struct {
 	Tags          []string          `json:"tags,omitempty"`
 	CreatedBy     string            `json:"created_by" validate:"required"`
 	OwnerID       uint              `json:"owner_id,omitempty"`
+	// Classification is an optional data-sensitivity label (A.5.12): "" or one of
+	// public|internal|confidential|restricted.
+	Classification string `json:"classification,omitempty"`
 }
 
 // UpdateSecretRequest represents a request to update an existing secret.
@@ -67,19 +70,24 @@ func (c *KeyorixCore) CreateSecret(ctx context.Context, req *CreateSecretRequest
 		return nil, fmt.Errorf("%s", i18n.T("ErrorSecretAlreadyExists", nil))
 	}
 
+	if !IsValidClassification(req.Classification) {
+		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "invalid classification")
+	}
+
 	secret := &models.SecretNode{
-		Name:          req.Name,
-		ProjectID:     req.ProjectID,
-		EnvironmentID: req.EnvironmentID,
-		Type:          req.Type,
-		MaxReads:      req.MaxReads,
-		Expiration:    req.Expiration,
-		IsSecret:      true,
-		Status:        "active",
-		CreatedBy:     req.CreatedBy,
-		OwnerID:       req.OwnerID,
-		CreatedAt:     time.Now(),
-		UpdatedAt:     time.Now(),
+		Name:           req.Name,
+		ProjectID:      req.ProjectID,
+		EnvironmentID:  req.EnvironmentID,
+		Type:           req.Type,
+		MaxReads:       req.MaxReads,
+		Expiration:     req.Expiration,
+		Classification: req.Classification,
+		IsSecret:       true,
+		Status:         "active",
+		CreatedBy:      req.CreatedBy,
+		OwnerID:        req.OwnerID,
+		CreatedAt:      time.Now(),
+		UpdatedAt:      time.Now(),
 	}
 
 	createdSecret, err := c.storage.CreateSecret(ctx, secret)

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -443,8 +443,11 @@ type SecretFilter struct {
 	// ExpiresBefore, when set, restricts to secrets with a non-null expiration
 	// earlier than the given time (i.e. already expired or expiring before it).
 	ExpiresBefore *time.Time
-	Page          int
-	PageSize      int
+	// Classification, when set, restricts to secrets with that data-classification
+	// label (A.5.12). Use the sentinel "unclassified" to match the empty label.
+	Classification *string
+	Page           int
+	PageSize       int
 	// IncludeDeleted, when true, also returns soft-deleted secrets (ADR-033) —
 	// for a restore UI. Default false: GORM auto-scopes deleted_at IS NULL.
 	IncludeDeleted bool

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -147,6 +147,10 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 	if tableExists(db, "secret_nodes") && !columnExists(db, "secret_nodes", "deleted_at") {
 		db.Exec("ALTER TABLE secret_nodes ADD COLUMN deleted_at TIMESTAMP WITH TIME ZONE")
 	}
+	// Data classification (ISO A.5.12). Additive classification ("" = unclassified).
+	if tableExists(db, "secret_nodes") && !columnExists(db, "secret_nodes", "classification") {
+		db.Exec("ALTER TABLE secret_nodes ADD COLUMN classification TEXT DEFAULT ''")
+	}
 
 	// Track last successful login per user (nil = never logged in).
 	if tableExists(db, "users") && !columnExists(db, "users", "last_login_at") {

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -333,13 +333,17 @@ type SecretNode struct {
 	MaxReads      *int
 	Expiration    *time.Time
 	Metadata      JSON
-	Status        string `gorm:"default:'active'"`
-	CreatedBy     string
-	OwnerID       uint `gorm:"index"`
-	IsShared      bool `gorm:"default:false"`
-	CreatedAt     time.Time
-	UpdatedAt     time.Time
-	LastRotatedAt *time.Time
+	// Classification is the data sensitivity label (ISO 27001 A.5.12/A.5.13):
+	// "" = unclassified, else one of public|internal|confidential|restricted. Drives
+	// the classification posture and lets a review find high-sensitivity secrets.
+	Classification string `gorm:"index"`
+	Status         string `gorm:"default:'active'"`
+	CreatedBy      string
+	OwnerID        uint `gorm:"index"`
+	IsShared       bool `gorm:"default:false"`
+	CreatedAt      time.Time
+	UpdatedAt      time.Time
+	LastRotatedAt  *time.Time
 	// DeletedAt enables soft delete (ADR-033). DELETE stamps it; restore clears
 	// it; the purge scheduler hard-deletes rows past the retention window. GORM
 	// auto-scopes `deleted_at IS NULL` on model-based queries — raw/Table/Joins

--- a/internal/storage/store/local_secrets.go
+++ b/internal/storage/store/local_secrets.go
@@ -343,6 +343,13 @@ func (ls *LocalStorage) ListSecrets(ctx context.Context, filter *storage.SecretF
 	if filter.ExpiresBefore != nil {
 		query = query.Where("secret_nodes.expiration IS NOT NULL AND secret_nodes.expiration < ?", *filter.ExpiresBefore)
 	}
+	if filter.Classification != nil {
+		if *filter.Classification == "unclassified" {
+			query = query.Where("secret_nodes.classification = '' OR secret_nodes.classification IS NULL")
+		} else {
+			query = query.Where("secret_nodes.classification = ?", *filter.Classification)
+		}
+	}
 	if filter.CreatedAfter != nil {
 		query = query.Where("secret_nodes.created_at > ?", *filter.CreatedAfter)
 	}

--- a/server/http/handlers/openapi.yaml
+++ b/server/http/handlers/openapi.yaml
@@ -1429,6 +1429,7 @@ paths:
                 max_reads: {type: integer, minimum: 1, nullable: true}
                 metadata: {type: object, additionalProperties: {type: string}}
                 tags: {type: array, items: {type: string}}
+                classification: {type: string, description: "Optional data-sensitivity label (A.5.12): public|internal|confidential|restricted."}
       responses:
         '201':
           description: >-
@@ -1495,6 +1496,33 @@ paths:
         - {name: id, in: path, required: true, schema: {type: integer}}
       responses:
         '204': {description: Secret deleted (no content).}
+        '400': {$ref: '#/components/responses/Error'}
+        '401': {$ref: '#/components/responses/Error'}
+        '403': {$ref: '#/components/responses/Error'}
+        '404': {$ref: '#/components/responses/Error'}
+  /api/v1/secrets/{id}/classification:
+    patch:
+      tags: [Secrets]
+      summary: Set a secret's data-classification label (ISO 27001 A.5.12)
+      description: >-
+        Label the secret with its data sensitivity (or empty to clear). Drives the
+        compliance classification posture. Requires secrets.write at the secret's scope.
+      operationId: classifySecret
+      security: [{bearerAuth: []}]
+      parameters:
+        - {name: id, in: path, required: true, schema: {type: integer}}
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                classification:
+                  type: string
+                  description: "public|internal|confidential|restricted, or empty to clear."
+      responses:
+        '200': {description: "Envelope {data, message}. data is the updated secret node."}
         '400': {$ref: '#/components/responses/Error'}
         '401': {$ref: '#/components/responses/Error'}
         '403': {$ref: '#/components/responses/Error'}

--- a/server/http/handlers/secrets_crud.go
+++ b/server/http/handlers/secrets_crud.go
@@ -29,14 +29,15 @@ func (h *SecretHandler) CreateSecret(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var reqBody struct {
-		Name          string            `json:"name" validate:"required,min=1,max=255"`
-		Value         string            `json:"value" validate:"required"`
-		ProjectID     uint              `json:"project_id"`
-		EnvironmentID uint              `json:"environment_id" validate:"required"`
-		Type          string            `json:"type" validate:"required"`
-		MaxReads      *int              `json:"max_reads,omitempty" validate:"omitempty,min=1"`
-		Metadata      map[string]string `json:"metadata,omitempty"`
-		Tags          []string          `json:"tags,omitempty"`
+		Name           string            `json:"name" validate:"required,min=1,max=255"`
+		Value          string            `json:"value" validate:"required"`
+		ProjectID      uint              `json:"project_id"`
+		EnvironmentID  uint              `json:"environment_id" validate:"required"`
+		Type           string            `json:"type" validate:"required"`
+		MaxReads       *int              `json:"max_reads,omitempty" validate:"omitempty,min=1"`
+		Metadata       map[string]string `json:"metadata,omitempty"`
+		Tags           []string          `json:"tags,omitempty"`
+		Classification string            `json:"classification,omitempty"`
 	}
 
 	if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
@@ -64,16 +65,17 @@ func (h *SecretHandler) CreateSecret(w http.ResponseWriter, r *http.Request) {
 	}
 
 	req := &core.CreateSecretRequest{
-		Name:          reqBody.Name,
-		Value:         []byte(reqBody.Value),
-		ProjectID:     reqBody.ProjectID,
-		EnvironmentID: reqBody.EnvironmentID,
-		Type:          reqBody.Type,
-		MaxReads:      reqBody.MaxReads,
-		Metadata:      reqBody.Metadata,
-		Tags:          reqBody.Tags,
-		CreatedBy:     userCtx.Username,
-		OwnerID:       userCtx.UserID,
+		Name:           reqBody.Name,
+		Value:          []byte(reqBody.Value),
+		ProjectID:      reqBody.ProjectID,
+		EnvironmentID:  reqBody.EnvironmentID,
+		Type:           reqBody.Type,
+		MaxReads:       reqBody.MaxReads,
+		Metadata:       reqBody.Metadata,
+		Tags:           reqBody.Tags,
+		Classification: reqBody.Classification,
+		CreatedBy:      userCtx.Username,
+		OwnerID:        userCtx.UserID,
 	}
 
 	response, err := h.coreService.CreateSecret(r.Context(), req)
@@ -95,6 +97,43 @@ func (h *SecretHandler) CreateSecret(w http.ResponseWriter, r *http.Request) {
 
 	w.WriteHeader(http.StatusCreated)
 	h.sendSuccess(w, response, i18n.T("SuccessSecretCreated", nil))
+}
+
+// ClassifySecret handles PATCH /api/v1/secrets/{id}/classification — set or clear
+// the data-classification label (A.5.12). Gated by secrets.write at the secret's
+// scope (via the route middleware).
+func (h *SecretHandler) ClassifySecret(w http.ResponseWriter, r *http.Request) {
+	userCtx := middleware.GetUserFromContext(r.Context())
+	if userCtx == nil {
+		h.sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		h.sendError(w, "InvalidParameter", "Invalid secret ID", http.StatusBadRequest, nil)
+		return
+	}
+	var reqBody struct {
+		Classification string `json:"classification"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
+		h.sendError(w, "InvalidJSON", "Invalid JSON in request body", http.StatusBadRequest, nil)
+		return
+	}
+	secret, err := h.coreService.ClassifySecret(r.Context(), userCtx.UserID, userCtx.Username, uint(id), reqBody.Classification)
+	if err != nil {
+		status := http.StatusInternalServerError
+		msg := err.Error()
+		switch {
+		case strings.Contains(msg, "classification must be"):
+			status = http.StatusBadRequest
+		case strings.Contains(msg, "not found"):
+			status = http.StatusNotFound
+		}
+		h.sendError(w, "Error", msg, status, nil)
+		return
+	}
+	h.sendSuccess(w, secret, "Classification updated")
 }
 
 // GetSecret handles GET /api/v1/secrets/{id}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -280,6 +280,7 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			// Create: authorized inside the handler (scope comes from the body).
 			r.Post("/", secretHandler.CreateSecret)
 			r.With(customMiddleware.RequireScopedPermission("secrets.write", secretScope)).Put("/{id}", secretHandler.UpdateSecret)
+			r.With(customMiddleware.RequireScopedPermission("secrets.write", secretScope)).Patch("/{id}/classification", secretHandler.ClassifySecret)
 			r.With(customMiddleware.RequireScopedPermission("secrets.write", secretScope)).Post("/{id}/rotate", secretHandler.RotateSecret)
 			r.With(customMiddleware.RequireScopedPermission("secrets.write", secretScope)).Post("/{id}/share", shareHandler.ShareSecret)
 


### PR DESCRIPTION
## What

Each secret can carry a **data-sensitivity label** — `public` | `internal` | `confidential` | `restricted` (or `""` = unclassified) — the classification/labelling control auditors check (ISO 27001 A.5.12 classification, A.5.13 labelling), and the foundation the compliance posture builds on. First item of the data-classification batch (this → posture/evidence counts → web).

## Surfaces

- **model**: `Classification` on `SecretNode` (indexed); additive column migration (safe on existing DBs, default `""`).
- **core**: `ClassificationLevels` + `IsValidClassification`; `ClassifySecret` (set/clear, validated, audited as `secret.updated` with a before/after diff); `CreateSecretRequest` gains `Classification` (validated, set at creation).
- **storage**: `SecretFilter.Classification` (a level, or the `"unclassified"` sentinel for the empty label) + the `ListSecrets` WHERE clause.
- **API**: `PATCH /api/v1/secrets/{id}/classification` (`secrets.write` at the secret's scope, via the existing scope-from-secret middleware); create accepts `classification`.
- **CLI**: `keyorix secret classify --id N --level …` (+ a `RemoteClient.Patch` helper).

## Tests

set/clear/invalid level; the filter matches a level and `"unclassified"` matches the empty label; `IsValidClassification`.

## Docs

openapi (classify endpoint + create field) + REMOTE_CLI classification section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)