### PR TITLE
feat(classification): classification coverage in the compliance posture (B)

### DIFF
--- a/internal/cli/compliance/compliance.go
+++ b/internal/cli/compliance/compliance.go
@@ -51,6 +51,14 @@ type posture struct {
 		ActiveActivations int `json:"active_activations"`
 		TotalActivations  int `json:"total_activations"`
 	} `json:"emergency_access"`
+	Classification struct {
+		TotalSecrets int `json:"total_secrets"`
+		Public       int `json:"public"`
+		Internal     int `json:"internal"`
+		Confidential int `json:"confidential"`
+		Restricted   int `json:"restricted"`
+		Unclassified int `json:"unclassified"`
+	} `json:"classification"`
 }
 
 func yesNo(b bool) string {
@@ -100,6 +108,12 @@ var reportCmd = &cobra.Command{
 
 		fmt.Println("\nEmergency access (break-glass)")
 		fmt.Printf("  active / total activations : %d / %d\n", p.EmergencyAccess.ActiveActivations, p.EmergencyAccess.TotalActivations)
+
+		fmt.Println("\nData classification (ISO A.5.12)")
+		fmt.Printf("  total secrets : %d\n", p.Classification.TotalSecrets)
+		fmt.Printf("  restricted / confidential : %d / %d\n", p.Classification.Restricted, p.Classification.Confidential)
+		fmt.Printf("  internal / public         : %d / %d\n", p.Classification.Internal, p.Classification.Public)
+		fmt.Printf("  unclassified              : %d\n", p.Classification.Unclassified)
 		return nil
 	},
 }

--- a/internal/core/classification_posture_external_test.go
+++ b/internal/core/classification_posture_external_test.go
@@ -1,0 +1,37 @@
+package core_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/testhelper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The compliance posture counts secrets per data-classification level (A.5.12),
+// with "unclassified" for the empty label.
+func TestCompliancePosture_ClassificationCounts(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(
+		&models.SecretNode{}, &models.AuditEvent{}, &models.AccessReviewCampaign{},
+		&models.AccessReviewItem{}, &models.BreakGlassActivation{}, &models.RotationPolicy{}, &models.SoDPolicy{},
+	))
+
+	ctx := context.Background()
+	require.NoError(t, h.DB.Create(&models.SecretNode{ID: 1, ProjectID: 2, Name: "a", Status: "active", IsSecret: true, Classification: "restricted"}).Error)
+	require.NoError(t, h.DB.Create(&models.SecretNode{ID: 2, ProjectID: 2, Name: "b", Status: "active", IsSecret: true, Classification: "internal"}).Error)
+	require.NoError(t, h.DB.Create(&models.SecretNode{ID: 3, ProjectID: 2, Name: "c", Status: "active", IsSecret: true, Classification: "internal"}).Error)
+	require.NoError(t, h.DB.Create(&models.SecretNode{ID: 4, ProjectID: 2, Name: "d", Status: "active", IsSecret: true, Classification: ""}).Error)
+
+	p, err := h.CoreService.GetCompliancePosture(ctx)
+	require.NoError(t, err)
+
+	assert.Equal(t, 4, p.Classification.TotalSecrets)
+	assert.Equal(t, 1, p.Classification.Restricted)
+	assert.Equal(t, 2, p.Classification.Internal)
+	assert.Equal(t, 1, p.Classification.Unclassified)
+	assert.Equal(t, 0, p.Classification.Confidential)
+}

--- a/internal/core/compliance_posture.go
+++ b/internal/core/compliance_posture.go
@@ -58,6 +58,16 @@ type EmergencyAccessPosture struct {
 	TotalActivations  int `json:"total_activations"`
 }
 
+// ClassificationPosture summarises secret data-classification coverage (A.5.12).
+type ClassificationPosture struct {
+	TotalSecrets int `json:"total_secrets"`
+	Public       int `json:"public"`
+	Internal     int `json:"internal"`
+	Confidential int `json:"confidential"`
+	Restricted   int `json:"restricted"`
+	Unclassified int `json:"unclassified"`
+}
+
 // CompliancePosture is the deployment's control posture at a point in time.
 type CompliancePosture struct {
 	GeneratedAt      time.Time               `json:"generated_at"`
@@ -66,6 +76,7 @@ type CompliancePosture struct {
 	Rotation         RotationPosture         `json:"rotation"`
 	Identity         IdentityPosture         `json:"identity"`
 	EmergencyAccess  EmergencyAccessPosture  `json:"emergency_access"`
+	Classification   ClassificationPosture   `json:"classification"`
 }
 
 // GetCompliancePosture aggregates the deployment's control posture. It is an
@@ -117,7 +128,35 @@ func (c *KeyorixCore) GetCompliancePosture(ctx context.Context) (*CompliancePost
 	if violations, err := c.DetectSoDViolations(ctx); err == nil {
 		p.AccessGovernance.SoDViolations = len(violations)
 	}
+
+	// Data-classification coverage (A.5.12).
+	p.Classification = c.classificationPosture(ctx)
 	return p, nil
+}
+
+// classificationPosture counts secrets per classification level via cheap count
+// queries (PageSize 1 → only the total), rather than walking every secret row.
+func (c *KeyorixCore) classificationPosture(ctx context.Context) ClassificationPosture {
+	count := func(level string) int {
+		f := &storage.SecretFilter{Page: 1, PageSize: 1}
+		if level != "" {
+			lvl := level
+			f.Classification = &lvl
+		}
+		_, total, err := c.storage.ListSecrets(ctx, f)
+		if err != nil {
+			return 0
+		}
+		return int(total)
+	}
+	return ClassificationPosture{
+		TotalSecrets: count(""),
+		Public:       count(ClassificationPublic),
+		Internal:     count(ClassificationInternal),
+		Confidential: count(ClassificationConfidential),
+		Restricted:   count(ClassificationRestricted),
+		Unclassified: count("unclassified"),
+	}
 }
 
 // identityPosture counts active users and how many have a second factor (MFA or

--- a/server/http/handlers/openapi.yaml
+++ b/server/http/handlers/openapi.yaml
@@ -2813,8 +2813,9 @@ paths:
         never-reviewed, open campaigns + pending items, dormant role grants,
         separation-of-duties violations), rotation hygiene (covered secrets,
         overdue, due-soon), identity
-        (active users, with-second-factor + percent), and emergency access
-        (active/total break-glass activations). Requires system.read.
+        (active users, with-second-factor + percent), emergency access
+        (active/total break-glass activations), and data classification (secret
+        counts per sensitivity level + unclassified). Requires system.read.
       operationId: getCompliancePosture
       security: [{bearerAuth: []}]
       responses:


### PR DESCRIPTION
## What

The posture report now counts secrets per **data-classification level** (A.5.12) — total, public/internal/confidential/restricted, and unclassified — so an auditor sees labelling coverage and the high-sensitivity footprint at a glance. The evidence pack carries it too (it embeds the posture). Second item of the data-classification batch.

## Surfaces

- **core**: `ClassificationPosture` group on `CompliancePosture`; computed via **cheap count queries** (`PageSize 1` → total only) per level, not a full secret walk.
- **CLI**: `keyorix compliance report` gains a "Data classification" section.

## Tests

Counts per level + unclassified from seeded secrets.

## Docs

openapi posture description notes the classification group.

🤖 Generated with [Claude Code](https://claude.com/claude-code)