### PR TITLE
feat(access): dual-control N-of-M approval for access requests (A — ISO 27001 A.5.3)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -394,6 +394,20 @@ break_glass:
   max_ttl: "24h"                    # ceiling on a requested TTL
 ```
 
+## dual_control
+
+**N-of-M approval (dual control)** for access-request grants (ISO 27001 A.5.3 /
+SOX): instead of one admin's approval granting the role immediately, a request
+requires `required_approvals` **distinct** approvers — and never the requester
+(maker ≠ checker) — before the role is granted. Each sign-off is audited; the
+request listing shows the M-of-K progress and remaining approvers are notified. A
+value of `1` (the default) keeps the single-approval behaviour.
+
+```yaml
+dual_control:
+  required_approvals: 2   # distinct approvers needed per access request (default 1)
+```
+
 ## audit.siem
 
 Native push of audit events to a SIEM. The token is read from `KEYORIX_SIEM_TOKEN`

--- a/internal/cli/request/review.go
+++ b/internal/cli/request/review.go
@@ -78,6 +78,12 @@ func runReview(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return fmt.Errorf("failed to approve access request: %w", err)
 		}
+		// Under dual control the request may still be pending more approvals.
+		if req.State != "approved" {
+			fmt.Printf("Approval recorded for access request %d (%d of %d) — more approvals needed before the role is granted.\n",
+				req.ID, req.ApprovalsReceived, req.RequiredApprovals)
+			return nil
+		}
 		grantNote := "permanently"
 		if ttl > 0 {
 			grantNote = fmt.Sprintf("for %s (time-bound)", ttl)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -33,6 +33,8 @@ type Config struct {
 	JITAccessExpiry JITAccessExpiryConfig `yaml:"jit_access_expiry"`
 	// BreakGlass configures opt-in self-service emergency access (incident response).
 	BreakGlass BreakGlassConfig `yaml:"break_glass"`
+	// DualControl configures N-of-M approval for access-request grants (A.5.3).
+	DualControl DualControlConfig `yaml:"dual_control"`
 	// DynamicSecrets configures the on-demand database-credentials engine and its
 	// auto-revoke sweep (ADR-035). Disabled (zero value) = the API is still served
 	// but no background sweeper runs; enable to auto-revoke leases at expiry.
@@ -542,6 +544,22 @@ func (c BreakGlassConfig) GetMaxTTL() time.Duration {
 		}
 	}
 	return 24 * time.Hour
+}
+
+// DualControlConfig configures N-of-M approval (dual control) for access-request
+// grants (ISO 27001 A.5.3 / SOX): a request grants its role only once this many
+// distinct approvers (none the requester) have approved. 0 or 1 = disabled (a
+// single approval grants, the default behaviour).
+type DualControlConfig struct {
+	RequiredApprovals int `yaml:"required_approvals"`
+}
+
+// GetRequiredApprovals returns the dual-control threshold (minimum 1).
+func (c DualControlConfig) GetRequiredApprovals() int {
+	if c.RequiredApprovals > 1 {
+		return c.RequiredApprovals
+	}
+	return 1
 }
 
 // WebAuthnConfig configures the WebAuthn relying party (ADR-036). RPID is the

--- a/internal/core/dual_control_external_test.go
+++ b/internal/core/dual_control_external_test.go
@@ -1,0 +1,100 @@
+package core_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/testhelper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func seedPendingRequest(t *testing.T, h *testhelper.RBACTestHelper, requester uint) uint {
+	req, err := h.Storage.CreateAccessRequest(context.Background(), &models.AccessRequest{
+		ProjectID: 2, UserID: requester, SuggestedRole: "editor", State: "pending",
+	})
+	require.NoError(t, err)
+	return req.ID
+}
+
+// With the default threshold (1), a single approval grants the role immediately.
+func TestApprove_SingleControlDefault(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(&models.AccessRequest{}, &models.AccessRequestApproval{}, &models.AuditEvent{}))
+
+	ctx := context.Background()
+	h.CreateTestUser(t, "alice", 10)  // requester
+	h.CreateTestUser(t, "admin1", 11) // approver
+	reqID := seedPendingRequest(t, h, 10)
+
+	req, err := h.CoreService.ApproveAccessRequestWithExpiry(ctx, 2, reqID, 11, "", 0)
+	require.NoError(t, err)
+	assert.Equal(t, "approved", req.State)
+
+	ids, err := h.Storage.GetUserRoleIDsAt(ctx, 10, storage.Scope{ProjectID: 2})
+	require.NoError(t, err)
+	assert.Contains(t, ids, uint(3), "editor granted on the single approval")
+}
+
+// With a threshold of 2, the role is granted only after two distinct approvers;
+// the requester can't approve, and an approver can't approve twice.
+func TestApprove_DualControl(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(&models.AccessRequest{}, &models.AccessRequestApproval{}, &models.AuditEvent{}))
+
+	ctx := context.Background()
+	h.CreateTestUser(t, "alice", 10)  // requester
+	h.CreateTestUser(t, "admin1", 11) // approver 1
+	h.CreateTestUser(t, "admin2", 12) // approver 2
+	h.CoreService.SetDualControlPolicy(2)
+	reqID := seedPendingRequest(t, h, 10)
+
+	// First approval: still pending, no grant yet.
+	req, err := h.CoreService.ApproveAccessRequestWithExpiry(ctx, 2, reqID, 11, "", 0)
+	require.NoError(t, err)
+	assert.Equal(t, "pending", req.State)
+	assert.Equal(t, 1, req.ApprovalsReceived)
+	assert.Equal(t, 2, req.RequiredApprovals)
+	ids, _ := h.Storage.GetUserRoleIDsAt(ctx, 10, storage.Scope{ProjectID: 2})
+	assert.NotContains(t, ids, uint(3), "no grant before the threshold")
+
+	// Same approver again → rejected.
+	_, err = h.CoreService.ApproveAccessRequestWithExpiry(ctx, 2, reqID, 11, "", 0)
+	require.Error(t, err)
+	// The requester cannot approve their own request.
+	_, err = h.CoreService.ApproveAccessRequestWithExpiry(ctx, 2, reqID, 10, "", 0)
+	require.Error(t, err)
+
+	// Second distinct approver reaches the threshold → granted.
+	req, err = h.CoreService.ApproveAccessRequestWithExpiry(ctx, 2, reqID, 12, "", 0)
+	require.NoError(t, err)
+	assert.Equal(t, "approved", req.State)
+	ids, _ = h.Storage.GetUserRoleIDsAt(ctx, 10, storage.Scope{ProjectID: 2})
+	assert.Contains(t, ids, uint(3), "editor granted once two approvers signed off")
+}
+
+// The listing annotates a pending request with its M-of-K progress.
+func TestListAccessRequests_AnnotatesProgress(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(&models.AccessRequest{}, &models.AccessRequestApproval{}, &models.AuditEvent{}))
+
+	ctx := context.Background()
+	h.CreateTestUser(t, "alice", 10)
+	h.CreateTestUser(t, "admin1", 11)
+	h.CoreService.SetDualControlPolicy(2)
+	reqID := seedPendingRequest(t, h, 10)
+	_, err := h.CoreService.ApproveAccessRequestWithExpiry(ctx, 2, reqID, 11, "", 0)
+	require.NoError(t, err)
+
+	list, err := h.CoreService.ListAccessRequests(ctx, 2)
+	require.NoError(t, err)
+	require.Len(t, list, 1)
+	assert.Equal(t, "pending", list[0].State)
+	assert.Equal(t, 1, list[0].ApprovalsReceived)
+	assert.Equal(t, 2, list[0].RequiredApprovals)
+}

--- a/internal/core/invitations.go
+++ b/internal/core/invitations.go
@@ -356,10 +356,18 @@ func (c *KeyorixCore) ListAccessRequests(ctx context.Context, projectID uint) ([
 		return nil, err
 	}
 	now := c.now()
+	required := c.requiredApprovals()
 	for _, req := range rows {
 		if req.State == AccessRequestPending && req.ExpiresAt != nil && now.After(*req.ExpiresAt) {
 			req.State = AccessRequestExpired
 			_ = c.storage.UpdateAccessRequest(ctx, req)
+		}
+		// Annotate the dual-control progress for a pending request.
+		if req.State == AccessRequestPending {
+			req.RequiredApprovals = required
+			if approvals, err := c.storage.ListAccessRequestApprovals(ctx, req.ID); err == nil {
+				req.ApprovalsReceived = len(approvals)
+			}
 		}
 	}
 	return rows, nil
@@ -372,10 +380,25 @@ func (c *KeyorixCore) ApproveAccessRequest(ctx context.Context, projectID, reque
 	return c.ApproveAccessRequestWithExpiry(ctx, projectID, requestID, approverID, grantedRole, 0)
 }
 
-// ApproveAccessRequestWithExpiry approves a pending request like ApproveAccessRequest
-// but, when grantTTL > 0, grants the role TIME-BOUND (just-in-time access): the
-// grant stops authorizing once the TTL elapses and is later swept by the JIT
-// expiry scheduler. grantTTL == 0 grants permanently.
+// SetDualControlPolicy sets the N-of-M approval threshold for access requests
+// (A.5.3). <=1 = single approval (the default).
+func (c *KeyorixCore) SetDualControlPolicy(requiredApprovals int) {
+	c.dualControlRequiredApprovals = requiredApprovals
+}
+
+// requiredApprovals returns the dual-control threshold (minimum 1).
+func (c *KeyorixCore) requiredApprovals() int {
+	if c.dualControlRequiredApprovals > 1 {
+		return c.dualControlRequiredApprovals
+	}
+	return 1
+}
+
+// ApproveAccessRequestWithExpiry records an approver's sign-off on a pending request
+// and, once the dual-control threshold of K distinct approvers (none the requester)
+// is reached, grants the role — TIME-BOUND when grantTTL > 0 (JIT). Below the
+// threshold the request stays pending and the returned request carries the M-of-K
+// progress. When K is 1 (the default) the first approval grants immediately.
 func (c *KeyorixCore) ApproveAccessRequestWithExpiry(ctx context.Context, projectID, requestID, approverID uint, grantedRole string, grantTTL time.Duration) (*models.AccessRequest, error) {
 	req, err := c.storage.GetAccessRequest(ctx, requestID)
 	if err != nil {
@@ -393,6 +416,10 @@ func (c *KeyorixCore) ApproveAccessRequestWithExpiry(ctx context.Context, projec
 	if grantTTL < 0 {
 		return nil, fmt.Errorf("grant TTL must not be negative")
 	}
+	// Maker ≠ checker: a requester cannot approve their own request.
+	if approverID == req.UserID {
+		return nil, fmt.Errorf("a requester cannot approve their own access request")
+	}
 	role := grantedRole
 	if role == "" {
 		role = req.SuggestedRole
@@ -404,8 +431,39 @@ func (c *KeyorixCore) ApproveAccessRequestWithExpiry(ctx context.Context, projec
 	if err != nil {
 		return nil, fmt.Errorf("unknown role %q: %w", role, err)
 	}
+
+	// One sign-off per distinct approver.
+	approvals, err := c.storage.ListAccessRequestApprovals(ctx, requestID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read approvals: %w", err)
+	}
+	for _, a := range approvals {
+		if a.ApproverID == approverID {
+			return nil, fmt.Errorf("you have already approved this request")
+		}
+	}
+
 	now := c.now()
-	// Grant the role at the project scope — time-bound when a TTL is given.
+	received := len(approvals) + 1
+	required := c.requiredApprovals()
+
+	// Below the threshold: record the approval, stay pending, notify, return progress.
+	if received < required {
+		if err := c.storage.CreateAccessRequestApproval(ctx, &models.AccessRequestApproval{
+			RequestID: requestID, ApproverID: approverID, CreatedAt: now,
+		}); err != nil {
+			return nil, fmt.Errorf("failed to record approval: %w", err)
+		}
+		c.auditProjectScoped(ctx, "access_request.approval_recorded", approverID, req.ProjectID,
+			fmt.Sprintf("approval %d of %d recorded for access request %d", received, required, req.ID))
+		c.notifyApprovalProgress(ctx, req, received, required)
+		req.ApprovalsReceived = received
+		req.RequiredApprovals = required
+		return req, nil
+	}
+
+	// Threshold reached. Grant the role FIRST so that a grant failure leaves the
+	// approval unrecorded (retryable) rather than stuck above-threshold-but-ungranted.
 	scope := storage.Scope{ProjectID: req.ProjectID}
 	grantDesc := role
 	if grantTTL > 0 {
@@ -419,6 +477,11 @@ func (c *KeyorixCore) ApproveAccessRequestWithExpiry(ctx context.Context, projec
 			return nil, fmt.Errorf("failed to grant role: %w", err)
 		}
 	}
+	if err := c.storage.CreateAccessRequestApproval(ctx, &models.AccessRequestApproval{
+		RequestID: requestID, ApproverID: approverID, CreatedAt: now,
+	}); err != nil {
+		return nil, fmt.Errorf("failed to record approval: %w", err)
+	}
 	req.State = AccessRequestApproved
 	req.GrantedRole = role
 	req.ResolvedBy = approverID
@@ -427,9 +490,30 @@ func (c *KeyorixCore) ApproveAccessRequestWithExpiry(ctx context.Context, projec
 		return nil, fmt.Errorf("failed to update access request: %w", err)
 	}
 	c.auditProjectScoped(ctx, "access_request.approved", approverID, req.ProjectID,
-		fmt.Sprintf("approved access request %d for user %d as %s", req.ID, req.UserID, grantDesc))
+		fmt.Sprintf("approved access request %d for user %d as %s (%d approval(s))", req.ID, req.UserID, grantDesc, received))
 	c.notifyAccessResolved(ctx, req, true)
+	req.ApprovalsReceived = received
+	req.RequiredApprovals = required
 	return req, nil
+}
+
+// notifyApprovalProgress alerts the project's approvers that a request needs more
+// sign-offs (best-effort).
+func (c *KeyorixCore) notifyApprovalProgress(ctx context.Context, req *models.AccessRequest, received, required int) {
+	members, err := c.storage.ListProjectMembers(ctx, req.ProjectID)
+	if err != nil {
+		return
+	}
+	pid := req.ProjectID
+	label := c.projectLabel(ctx, req.ProjectID)
+	link := fmt.Sprintf("/projects/%d", req.ProjectID)
+	msg := fmt.Sprintf("Access request %d for %s has %d of %d approvals — another approver is needed.", req.ID, label, received, required)
+	for _, mbr := range members {
+		if mbr.UserID == req.UserID || !isApproverRole(mbr.RoleName) {
+			continue
+		}
+		c.notify(ctx, mbr.UserID, NotificationAccessRequested, "Access request needs another approval", msg, &pid, link)
+	}
 }
 
 // RejectAccessRequest rejects a pending request with a reason.

--- a/internal/core/invitations_test.go
+++ b/internal/core/invitations_test.go
@@ -77,6 +77,8 @@ func TestApproveAccessRequest_GrantsRole(t *testing.T) {
 	store.On("LogAuditEvent", ctx, mock.MatchedBy(func(e *models.AuditEvent) bool {
 		return e.EventType == "access_request.approved"
 	})).Return(nil)
+	store.On("ListAccessRequestApprovals", ctx, uint(3)).Return([]*models.AccessRequestApproval{}, nil)
+	store.On("CreateAccessRequestApproval", ctx, mock.Anything).Return(nil)
 
 	allowNotifications(store) // best-effort outcome notification to the requester
 	out, err := c.ApproveAccessRequest(ctx, 1, 3, 9, "project_developer")
@@ -96,6 +98,8 @@ func TestApproveAccessRequest_FallsBackToSuggestedRole(t *testing.T) {
 	store.On("AssignRole", ctx, uint(2), uint(6), storage.Scope{ProjectID: 1}).Return(nil)
 	store.On("UpdateAccessRequest", ctx, mock.Anything).Return(nil)
 	store.On("LogAuditEvent", ctx, mock.Anything).Return(nil)
+	store.On("ListAccessRequestApprovals", ctx, uint(3)).Return([]*models.AccessRequestApproval{}, nil)
+	store.On("CreateAccessRequestApproval", ctx, mock.Anything).Return(nil)
 
 	allowNotifications(store) // best-effort outcome notification to the requester
 	// Empty grantedRole → uses the suggested role.

--- a/internal/core/jit_access_external_test.go
+++ b/internal/core/jit_access_external_test.go
@@ -109,7 +109,7 @@ func TestRemoveExpiredRoleGrants_NoopWhenNothingExpired(t *testing.T) {
 func TestApproveAccessRequestWithExpiry_TimeBound(t *testing.T) {
 	h := testhelper.NewRBACTestHelper(t)
 	defer h.Cleanup()
-	require.NoError(t, h.DB.AutoMigrate(&models.AccessRequest{}))
+	require.NoError(t, h.DB.AutoMigrate(&models.AccessRequest{}, &models.AccessRequestApproval{}))
 
 	const proj = uint(2)
 	ctx := context.Background()
@@ -140,7 +140,7 @@ func TestApproveAccessRequestWithExpiry_TimeBound(t *testing.T) {
 func TestApproveAccessRequest_PermanentByDefault(t *testing.T) {
 	h := testhelper.NewRBACTestHelper(t)
 	defer h.Cleanup()
-	require.NoError(t, h.DB.AutoMigrate(&models.AccessRequest{}))
+	require.NoError(t, h.DB.AutoMigrate(&models.AccessRequest{}, &models.AccessRequestApproval{}))
 
 	const proj = uint(2)
 	ctx := context.Background()

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -166,6 +166,19 @@ func (m *MockStorage) ListAccessRequests(ctx context.Context, projectID uint) ([
 	return args.Get(0).([]*models.AccessRequest), args.Error(1)
 }
 
+func (m *MockStorage) CreateAccessRequestApproval(ctx context.Context, a *models.AccessRequestApproval) error {
+	args := m.Called(ctx, a)
+	return args.Error(0)
+}
+
+func (m *MockStorage) ListAccessRequestApprovals(ctx context.Context, requestID uint) ([]*models.AccessRequestApproval, error) {
+	args := m.Called(ctx, requestID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*models.AccessRequestApproval), args.Error(1)
+}
+
 func (m *MockStorage) CreateAccessReviewCampaign(ctx context.Context, c *models.AccessReviewCampaign) (*models.AccessReviewCampaign, error) {
 	args := m.Called(ctx, c)
 	if args.Get(0) == nil {

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -49,6 +49,9 @@ type KeyorixCore struct {
 	// breakGlassPolicy configures self-service emergency access; zero value =
 	// disabled. Set from config at startup via SetBreakGlassPolicy.
 	breakGlassPolicy BreakGlassPolicy
+	// dualControlRequiredApprovals is the N-of-M approval threshold for access
+	// requests (A.5.3); 0/1 = single approval (disabled). Set via SetDualControlPolicy.
+	dualControlRequiredApprovals int
 	// oidcVerifier verifies federated machine-identity JWTs (ADR-031); nil = OIDC
 	// auth disabled. Set from config via SetOIDCVerifier.
 	oidcVerifier *OIDCVerifier

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -65,6 +65,9 @@ type Storage interface {
 	GetAccessRequest(ctx context.Context, id uint) (*models.AccessRequest, error)
 	UpdateAccessRequest(ctx context.Context, req *models.AccessRequest) error
 	ListAccessRequests(ctx context.Context, projectID uint) ([]*models.AccessRequest, error)
+	// Access-request approvals (N-of-M dual control). One row per approver sign-off.
+	CreateAccessRequestApproval(ctx context.Context, a *models.AccessRequestApproval) error
+	ListAccessRequestApprovals(ctx context.Context, requestID uint) ([]*models.AccessRequestApproval, error)
 
 	// Access-review campaigns (ISO 27001 A.5.18) — periodic recertification cycles
 	// and the per-grant items captured within them.

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -256,6 +256,7 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 	patExists := tableExists(db, "personal_access_tokens")
 	invitationsExists := tableExists(db, "project_invitations")
 	accessReqExists := tableExists(db, "access_requests")
+	accessReqApprovalsExists := tableExists(db, "access_request_approvals")
 	campaignExists := tableExists(db, "access_review_campaigns")
 	breakGlassExists := tableExists(db, "break_glass_activations")
 	sodExists := tableExists(db, "sod_policies")
@@ -388,6 +389,13 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 	if !accessReqExists {
 		if err := db.AutoMigrate(&models.AccessRequest{}); err != nil {
 			return fmt.Errorf("failed to migrate access_requests table: %w", err)
+		}
+	}
+
+	// Create the access-request approvals table if missing (N-of-M dual control).
+	if !accessReqApprovalsExists {
+		if err := db.AutoMigrate(&models.AccessRequestApproval{}); err != nil {
+			return fmt.Errorf("failed to migrate access_request_approvals table: %w", err)
 		}
 	}
 

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -68,6 +68,20 @@ type AccessRequest struct {
 	ExpiresAt     *time.Time
 	CreatedAt     time.Time
 	ResolvedAt    *time.Time
+	// ApprovalsReceived / RequiredApprovals are transient (not persisted): the
+	// dual-control progress (M of K) the API surfaces for a pending request.
+	ApprovalsReceived int `gorm:"-"`
+	RequiredApprovals int `gorm:"-"`
+}
+
+// AccessRequestApproval records one approver's sign-off on an access request, for
+// N-of-M dual control (ISO 27001 A.5.3 / SOX): a request grants the role only once
+// RequiredApprovals distinct approvers (none of them the requester) have approved.
+type AccessRequestApproval struct {
+	ID         uint `gorm:"primaryKey"`
+	RequestID  uint `gorm:"index;not null"`
+	ApproverID uint `gorm:"not null"`
+	CreatedAt  time.Time
 }
 
 // SoDPolicy is a separation-of-duties rule (ISO 27001 A.5.3 / SOX): two permissions

--- a/internal/storage/store/local_invitations.go
+++ b/internal/storage/store/local_invitations.go
@@ -82,3 +82,22 @@ func (ls *LocalStorage) ListAccessRequests(ctx context.Context, projectID uint) 
 	}
 	return rows, nil
 }
+
+func (ls *LocalStorage) CreateAccessRequestApproval(ctx context.Context, a *models.AccessRequestApproval) error {
+	if err := ls.db.WithContext(ctx).Create(a).Error; err != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	return nil
+}
+
+func (ls *LocalStorage) ListAccessRequestApprovals(ctx context.Context, requestID uint) ([]*models.AccessRequestApproval, error) {
+	var rows []*models.AccessRequestApproval
+	err := ls.db.WithContext(ctx).
+		Where("request_id = ?", requestID).
+		Order("id ASC").
+		Find(&rows).Error
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	return rows, nil
+}

--- a/internal/storage/store/remote_invitations.go
+++ b/internal/storage/store/remote_invitations.go
@@ -41,3 +41,11 @@ func (rs *RemoteStorage) UpdateAccessRequest(_ context.Context, _ *models.Access
 func (rs *RemoteStorage) ListAccessRequests(_ context.Context, _ uint) ([]*models.AccessRequest, error) {
 	return nil, remoteUnsupported("ListAccessRequests")
 }
+
+func (rs *RemoteStorage) CreateAccessRequestApproval(_ context.Context, _ *models.AccessRequestApproval) error {
+	return remoteUnsupported("CreateAccessRequestApproval")
+}
+
+func (rs *RemoteStorage) ListAccessRequestApprovals(_ context.Context, _ uint) ([]*models.AccessRequestApproval, error) {
+	return nil, remoteUnsupported("ListAccessRequestApprovals")
+}

--- a/server/http/handlers/openapi.yaml
+++ b/server/http/handlers/openapi.yaml
@@ -1144,7 +1144,10 @@ paths:
         - {name: id, in: path, required: true, schema: {type: integer}}
       responses:
         '200':
-          description: Envelope with `data.access_requests` (array of access-request objects).
+          description: >-
+            Envelope with `data.access_requests` (array of access-request objects).
+            Under dual control a pending request carries `ApprovalsReceived` /
+            `RequiredApprovals` (the M-of-K progress).
         '400': {$ref: '#/components/responses/Error'}
         '401': {$ref: '#/components/responses/Error'}
         '403': {$ref: '#/components/responses/Error'}
@@ -1173,6 +1176,11 @@ paths:
     put:
       tags: [AccessRequests]
       summary: Approve or reject an access request
+      description: >-
+        Approve records the caller's sign-off. Under dual control
+        (`dual_control.required_approvals` > 1) the role is granted only once that
+        many distinct approvers — none of them the requester — have approved;
+        before then the request stays pending.
       operationId: resolveAccessRequest
       security: [{bearerAuth: []}]
       parameters:

--- a/server/main.go
+++ b/server/main.go
@@ -265,6 +265,12 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 		MaxTTL:        cfg.BreakGlass.GetMaxTTL(),
 	})
 
+	// Wire N-of-M dual-control approval for access requests (1 = disabled).
+	coreService.SetDualControlPolicy(cfg.DualControl.GetRequiredApprovals())
+	if n := cfg.DualControl.GetRequiredApprovals(); n > 1 {
+		log.Printf("Dual-control approval enabled: %d approvals required per access request", n)
+	}
+
 	// Wire the credential-delivery channel (ADR-028). New selects out-of-band/SMTP/
 	// log from the configured mode and fails loud on a bad mode (e.g. smtp with no
 	// host), so a misconfigured install does not silently drop setup links.


### PR DESCRIPTION
## What

An access request can now require **K distinct approvers** before the role is granted — maker-checker / N-of-M **dual control**, so no single admin can unilaterally grant access (ISO 27001 A.5.3 / SOX). Below the threshold the request stays pending; the listing shows the **M-of-K progress** and remaining approvers are notified. First item of the dual-control batch (this → web).

Also a security tightening: **maker ≠ checker always** — a requester can no longer approve their own request (previously only RBAC-gated), applied even at the default threshold of 1.

## Surfaces

- **model**: `AccessRequestApproval` (request_id, approver_id) — one row per sign-off; transient `ApprovalsReceived`/`RequiredApprovals` on `AccessRequest` for the API. Additive migration.
- **storage**: Create/List access-request approvals (Local, Remote stub, mock, interface).
- **config**: `dual_control.required_approvals` (default 1 = single approval) → core via `SetDualControlPolicy`, wired in main.go.
- **core**: `ApproveAccessRequestWithExpiry` refactored to record each distinct approval (reject a duplicate or the requester self-approving) and grant only at threshold — the **grant happens before the approval is recorded** so a grant failure stays retryable; audited (`access_request.approval_recorded` below threshold, `.approved` at it); `notifyApprovalProgress` alerts approvers; `ListAccessRequests` annotates progress.
- **CLI**: `keyorix request review --action approve` reports partial-approval progress.

## Tests

Single-control default grants immediately; dual-control needs two distinct approvers, rejects a duplicate + self-approval, grants at the threshold; the listing shows progress. (Existing approve tests updated for the new storage calls + migrations.)

## Docs

openapi (resolve/list notes) + CONFIGURATION `dual_control` block.

> Note: a pre-existing local-only test artifact (`TestEveryMutatingRouteDeniesReadOnly` flags `/sw.js`, the embedded web-UI service worker, in single-binary builds) is unrelated to this change and was green in CI for the prior PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)