### PR TITLE
release: prep v0.21.0 (CHANGELOG + Helm chart 0.21.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to Keyorix are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## v0.21.0 — 2026-06-14
+
+### Added
+- **Dual-control (N-of-M) approval for access requests (ISO 27001 A.5.3 / SOX)** —
+  an access request can now require multiple **distinct** approvers before the role
+  is granted, so no single admin can unilaterally grant access. Configure the
+  threshold with `dual_control.required_approvals` (default 1 = single approval).
+  Below the threshold the request stays pending; the listing shows the M-of-K
+  progress, remaining approvers are notified, and each sign-off is audited. A
+  requester can never approve their own request (maker ≠ checker). The web console
+  shows the approval progress on the pending-requests view. ([#184])
+
+[#184]: https://github.com/keyorixhq/keyorix/pull/184
+
 ## v0.20.0 — 2026-06-14
 
 The compliance-reporting & data-classification release: turn the controls Keyorix

--- a/deploy/helm/keyorix/Chart.yaml
+++ b/deploy/helm/keyorix/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix
 description: Self-hosted Keyorix secrets manager (API server + web UI + PostgreSQL)
 type: application
 # Chart version — bump on chart changes.
-version: 0.20.0
+version: 0.21.0
 # The Keyorix app version this chart deploys by default (the image tag).
-appVersion: "0.20.0"
+appVersion: "0.21.0"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix


### PR DESCRIPTION
## Release prep — v0.21.0

**Dual-control (N-of-M) approval for access requests** (#184): a request can require multiple **distinct** approvers before the role is granted (maker ≠ checker), gated by `dual_control.required_approvals`. The web console shows the M-of-K approval progress.

## Changes in this PR

- `CHANGELOG.md` — v0.21.0 section
- `deploy/helm/keyorix/Chart.yaml` — `version` + `appVersion` → 0.21.0

Additive schema only (new `access_request_approvals` table) — safe on existing databases. `helm lint` passes.

On merge: tag `v0.21.0` → release + docker-publish workflows → verify artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)