### PR TITLE
feat(anomaly): proactive alerting for detected access anomalies (A — NIS2)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -408,6 +408,23 @@ dual_control:
   required_approvals: 2   # distinct approvers needed per access request (default 1)
 ```
 
+## anomaly_alerts
+
+**Proactive alerting** for detected access anomalies (NIS2 detection & response).
+Anomaly detection (off-hours / new-IP / new-user access to secrets) always runs on
+the scan schedule; when this is enabled, each **newly detected** anomaly is also
+pushed out — an in-app alert to the project's admins **and** a
+`security.anomaly_detected` audit event (which the SIEM forwarder picks up, so
+anomalies reach your SOC). Each anomaly is announced once. Single-replica-gated
+(ADR-039). Opt-in (default off — detection still runs and alerts are visible via
+`keyorix anomalies list` / the API, just not pushed).
+
+```yaml
+anomaly_alerts:
+  enabled: true
+  schedule: "1h"          # Go duration between scan+alert passes (default 1h)
+```
+
 ## audit.siem
 
 Native push of audit events to a SIEM. The token is read from `KEYORIX_SIEM_TOKEN`

--- a/internal/cli/compliance/compliance.go
+++ b/internal/cli/compliance/compliance.go
@@ -59,6 +59,10 @@ type posture struct {
 		Restricted   int `json:"restricted"`
 		Unclassified int `json:"unclassified"`
 	} `json:"classification"`
+	Anomalies struct {
+		Unacknowledged   int `json:"unacknowledged"`
+		HighSeverityOpen int `json:"high_severity_open"`
+	} `json:"anomalies"`
 }
 
 func yesNo(b bool) string {
@@ -114,6 +118,9 @@ var reportCmd = &cobra.Command{
 		fmt.Printf("  restricted / confidential : %d / %d\n", p.Classification.Restricted, p.Classification.Confidential)
 		fmt.Printf("  internal / public         : %d / %d\n", p.Classification.Internal, p.Classification.Public)
 		fmt.Printf("  unclassified              : %d\n", p.Classification.Unclassified)
+
+		fmt.Println("\nAccess anomalies (NIS2 detection)")
+		fmt.Printf("  open / high-severity : %d / %d\n", p.Anomalies.Unacknowledged, p.Anomalies.HighSeverityOpen)
 		return nil
 	},
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,6 +35,8 @@ type Config struct {
 	BreakGlass BreakGlassConfig `yaml:"break_glass"`
 	// DualControl configures N-of-M approval for access-request grants (A.5.3).
 	DualControl DualControlConfig `yaml:"dual_control"`
+	// AnomalyAlerts configures proactive alerting for detected access anomalies.
+	AnomalyAlerts AnomalyAlertsConfig `yaml:"anomaly_alerts"`
 	// DynamicSecrets configures the on-demand database-credentials engine and its
 	// auto-revoke sweep (ADR-035). Disabled (zero value) = the API is still served
 	// but no background sweeper runs; enable to auto-revoke leases at expiry.
@@ -544,6 +546,25 @@ func (c BreakGlassConfig) GetMaxTTL() time.Duration {
 		}
 	}
 	return 24 * time.Hour
+}
+
+// AnomalyAlertsConfig configures proactive alerting for detected access anomalies
+// (NIS2 detection & response). The hourly detection scan always runs; when this is
+// enabled, each newly detected anomaly is also pushed to the project's admins
+// (in-app) and the audit trail / SIEM. Opt-in (default off).
+type AnomalyAlertsConfig struct {
+	Enabled  bool   `yaml:"enabled"`
+	Schedule string `yaml:"schedule"`
+}
+
+// GetInterval returns the anomaly scan/alert interval (Go duration); defaults to 1h.
+func (c AnomalyAlertsConfig) GetInterval() time.Duration {
+	if c.Schedule != "" {
+		if d, err := time.ParseDuration(c.Schedule); err == nil && d > 0 {
+			return d
+		}
+	}
+	return time.Hour
 }
 
 // DualControlConfig configures N-of-M approval (dual control) for access-request

--- a/internal/core/anomaly_alerting.go
+++ b/internal/core/anomaly_alerting.go
@@ -1,0 +1,87 @@
+// anomaly_alerting.go — proactive alerting for detected anomalies (NIS2 detection
+// & response). Detection (anomaly.go) persists AnomalyAlert rows; this pushes the
+// not-yet-alerted ones out — to the project's admins (in-app notification) and to
+// the audit trail (event security.anomaly_detected, which the SIEM forwarder picks
+// up) — and marks them alerted so each anomaly is announced once. Run by the
+// anomaly scheduler after each detection pass when anomaly_alerts is enabled.
+package core
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// EventAnomalyDetected is the audit event type emitted for each anomaly pushed out;
+// it flows through the SIEM forwarder like any audit event.
+const EventAnomalyDetected = "security.anomaly_detected" // #nosec G101 -- audit event type, not a credential
+
+// AlertNewAnomalies pushes every not-yet-alerted anomaly to the project's admins
+// and the audit/SIEM pipeline, marking each alerted. Returns the number announced.
+// Idempotent: an already-alerted anomaly is skipped.
+func (c *KeyorixCore) AlertNewAnomalies(ctx context.Context) (int, error) {
+	alerts, err := c.storage.ListUnalertedAnomalyAlerts(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("failed to list unalerted anomalies: %w", err)
+	}
+	announced := 0
+	for i := range alerts {
+		a := &alerts[i]
+
+		// Resolve the owning project (for scoping the audit event + admin notify).
+		var projectID uint
+		if a.SecretNodeID != 0 {
+			if s, err := c.storage.GetSecret(ctx, a.SecretNodeID); err == nil && s != nil {
+				projectID = s.ProjectID
+			}
+		}
+
+		// Audit + SIEM: a security event for the SOC, regardless of project.
+		var sid, pid *uint
+		if a.SecretNodeID != 0 {
+			s := a.SecretNodeID
+			sid = &s
+		}
+		if projectID != 0 {
+			p := projectID
+			pid = &p
+		}
+		c.writeAuditEventFull(ctx, EventAnomalyDetected, nil, sid, pid, a.IPAddress,
+			fmt.Sprintf("anomaly (%s, %s): %s", a.AlertType, a.Severity, a.Description))
+
+		// In-app: alert the project's approver-role members.
+		c.notifyAnomalyAdmins(ctx, projectID, a)
+
+		if err := c.storage.MarkAnomalyAlertAlerted(ctx, a.ID); err != nil {
+			// Couldn't mark alerted — skip counting so a retry re-announces rather
+			// than silently dropping (the audit event is already out, harmless dup).
+			continue
+		}
+		announced++
+	}
+	return announced, nil
+}
+
+// notifyAnomalyAdmins sends an in-app alert to the project's approver-role members
+// (best-effort). With no resolvable project the in-app notify is skipped (the audit
+// + SIEM event still carries it).
+func (c *KeyorixCore) notifyAnomalyAdmins(ctx context.Context, projectID uint, a *models.AnomalyAlert) {
+	if projectID == 0 {
+		return
+	}
+	members, err := c.storage.ListProjectMembers(ctx, projectID)
+	if err != nil {
+		return
+	}
+	pid := projectID
+	title := fmt.Sprintf("Anomaly detected (%s)", a.Severity)
+	msg := fmt.Sprintf("%s on secret %q by %s from %s — %s", a.AlertType, a.SecretName, a.AccessedBy, a.IPAddress, a.Description)
+	link := fmt.Sprintf("/projects/%d", projectID)
+	for _, m := range members {
+		if !isApproverRole(m.RoleName) {
+			continue
+		}
+		c.notify(ctx, m.UserID, EventAnomalyDetected, title, msg, &pid, link)
+	}
+}

--- a/internal/core/anomaly_alerting_external_test.go
+++ b/internal/core/anomaly_alerting_external_test.go
@@ -1,0 +1,64 @@
+package core_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/testhelper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// AlertNewAnomalies pushes each not-yet-alerted anomaly out (audit/SIEM event +
+// admin notify), marks it alerted, and is idempotent on a second pass.
+func TestAlertNewAnomalies(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(&models.AnomalyAlert{}, &models.AuditEvent{}, &models.SecretNode{}))
+
+	ctx := context.Background()
+	require.NoError(t, h.DB.Create(&models.SecretNode{ID: 500, ProjectID: 2, Name: "db-pw", Status: "active", IsSecret: true}).Error)
+	require.NoError(t, h.DB.Create(&models.AnomalyAlert{
+		SecretNodeID: 500, SecretName: "db-pw", AlertType: "new_ip", Severity: "high",
+		Description: "access from a new IP", AccessedBy: "alice", IPAddress: "203.0.113.9",
+		DetectedAt: time.Now(),
+	}).Error)
+
+	n, err := h.CoreService.AlertNewAnomalies(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 1, n)
+
+	// A security.anomaly_detected audit event was emitted (flows to SIEM).
+	var events int64
+	require.NoError(t, h.DB.Model(&models.AuditEvent{}).
+		Where("event_type = ?", core.EventAnomalyDetected).Count(&events).Error)
+	assert.Equal(t, int64(1), events)
+
+	// Idempotent — a second pass announces nothing.
+	n, err = h.CoreService.AlertNewAnomalies(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 0, n)
+}
+
+// The compliance posture counts open (unacknowledged) anomalies, with a high-severity tally.
+func TestCompliancePosture_Anomalies(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(
+		&models.AnomalyAlert{}, &models.SecretNode{}, &models.AuditEvent{}, &models.AccessReviewCampaign{},
+		&models.AccessReviewItem{}, &models.BreakGlassActivation{}, &models.RotationPolicy{}, &models.SoDPolicy{},
+	))
+
+	ctx := context.Background()
+	require.NoError(t, h.DB.Create(&models.AnomalyAlert{AlertType: "new_ip", Severity: "high", DetectedAt: time.Now()}).Error)
+	require.NoError(t, h.DB.Create(&models.AnomalyAlert{AlertType: "off_hours", Severity: "medium", DetectedAt: time.Now()}).Error)
+	require.NoError(t, h.DB.Create(&models.AnomalyAlert{AlertType: "new_user", Severity: "high", Acknowledged: true, DetectedAt: time.Now()}).Error)
+
+	p, err := h.CoreService.GetCompliancePosture(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 2, p.Anomalies.Unacknowledged, "two open alerts (the acknowledged one excluded)")
+	assert.Equal(t, 1, p.Anomalies.HighSeverityOpen, "one of the open alerts is high severity")
+}

--- a/internal/core/compliance_posture.go
+++ b/internal/core/compliance_posture.go
@@ -58,6 +58,12 @@ type EmergencyAccessPosture struct {
 	TotalActivations  int `json:"total_activations"`
 }
 
+// AnomaliesPosture summarises detected access anomalies (NIS2 detection).
+type AnomaliesPosture struct {
+	Unacknowledged   int `json:"unacknowledged"`     // open alerts awaiting review
+	HighSeverityOpen int `json:"high_severity_open"` // open alerts of high severity
+}
+
 // ClassificationPosture summarises secret data-classification coverage (A.5.12).
 type ClassificationPosture struct {
 	TotalSecrets int `json:"total_secrets"`
@@ -77,6 +83,7 @@ type CompliancePosture struct {
 	Identity         IdentityPosture         `json:"identity"`
 	EmergencyAccess  EmergencyAccessPosture  `json:"emergency_access"`
 	Classification   ClassificationPosture   `json:"classification"`
+	Anomalies        AnomaliesPosture        `json:"anomalies"`
 }
 
 // GetCompliancePosture aggregates the deployment's control posture. It is an
@@ -131,6 +138,17 @@ func (c *KeyorixCore) GetCompliancePosture(ctx context.Context) (*CompliancePost
 
 	// Data-classification coverage (A.5.12).
 	p.Classification = c.classificationPosture(ctx)
+
+	// Open access anomalies (NIS2 detection).
+	unack := false
+	if alerts, err := c.storage.ListAnomalyAlerts(ctx, &unack); err == nil {
+		p.Anomalies.Unacknowledged = len(alerts)
+		for _, a := range alerts {
+			if a.Severity == "high" {
+				p.Anomalies.HighSeverityOpen++
+			}
+		}
+	}
 	return p, nil
 }
 

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -882,6 +882,19 @@ func (m *MockStorage) AcknowledgeAnomalyAlert(ctx context.Context, id uint) erro
 	return args.Error(0)
 }
 
+func (m *MockStorage) ListUnalertedAnomalyAlerts(ctx context.Context) ([]models.AnomalyAlert, error) {
+	args := m.Called(ctx)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]models.AnomalyAlert), args.Error(1)
+}
+
+func (m *MockStorage) MarkAnomalyAlertAlerted(ctx context.Context, id uint) error {
+	args := m.Called(ctx, id)
+	return args.Error(0)
+}
+
 func (m *MockStorage) GetAuditLogs(ctx context.Context, filter *storage.AuditFilter) ([]*models.AuditEvent, int64, error) {
 	args := m.Called(ctx, filter)
 	if args.Get(0) == nil {

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -296,6 +296,10 @@ type Storage interface {
 	CreateAnomalyAlert(ctx context.Context, alert *models.AnomalyAlert) error
 	ListAnomalyAlerts(ctx context.Context, acknowledged *bool) ([]models.AnomalyAlert, error)
 	AcknowledgeAnomalyAlert(ctx context.Context, id uint) error
+	// ListUnalertedAnomalyAlerts returns alerts not yet pushed out (alerted=false),
+	// and MarkAnomalyAlertAlerted flags one as pushed — for proactive alerting.
+	ListUnalertedAnomalyAlerts(ctx context.Context) ([]models.AnomalyAlert, error)
+	MarkAnomalyAlertAlerted(ctx context.Context, id uint) error
 	GetAuditLogs(ctx context.Context, filter *AuditFilter) ([]*models.AuditEvent, int64, error)
 	GetRBACAuditLogs(ctx context.Context, filter *RBACAuditFilter) ([]*RBACAuditLog, int64, error)
 	// AuditRetentionStats returns the total audit event count and the oldest /

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -151,6 +151,10 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 	if tableExists(db, "secret_nodes") && !columnExists(db, "secret_nodes", "classification") {
 		db.Exec("ALTER TABLE secret_nodes ADD COLUMN classification TEXT DEFAULT ''")
 	}
+	// Anomaly alerting: additive `alerted` flag (false = not yet pushed out).
+	if tableExists(db, "anomaly_alerts") && !columnExists(db, "anomaly_alerts", "alerted") {
+		db.Exec("ALTER TABLE anomaly_alerts ADD COLUMN alerted BOOLEAN DEFAULT FALSE")
+	}
 
 	// Track last successful login per user (nil = never logged in).
 	if tableExists(db, "users") && !columnExists(db, "users", "last_login_at") {

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -770,7 +770,10 @@ type AnomalyAlert struct {
 	IPAddress    string
 	DetectedAt   time.Time `gorm:"index"`
 	Acknowledged bool      `gorm:"default:false"`
-	CreatedAt    time.Time
+	// Alerted is set once the anomaly has been pushed out (admin notification +
+	// SIEM forward) so the alerter doesn't re-notify on every scan.
+	Alerted   bool `gorm:"default:false;index"`
+	CreatedAt time.Time
 }
 
 // MachineIdentity is a non-human project member (ADR-023): a CI runner, a

--- a/internal/storage/store/local_audit.go
+++ b/internal/storage/store/local_audit.go
@@ -309,6 +309,18 @@ func (ls *LocalStorage) AcknowledgeAnomalyAlert(ctx context.Context, id uint) er
 	return ls.db.WithContext(ctx).Model(&models.AnomalyAlert{}).Where("id = ?", id).Update("acknowledged", true).Error
 }
 
+func (ls *LocalStorage) ListUnalertedAnomalyAlerts(ctx context.Context) ([]models.AnomalyAlert, error) {
+	var rows []models.AnomalyAlert
+	if err := ls.db.WithContext(ctx).Where("alerted = ?", false).Order("detected_at ASC").Find(&rows).Error; err != nil {
+		return nil, fmt.Errorf("failed to list unalerted anomaly alerts: %w", err)
+	}
+	return rows, nil
+}
+
+func (ls *LocalStorage) MarkAnomalyAlertAlerted(ctx context.Context, id uint) error {
+	return ls.db.WithContext(ctx).Model(&models.AnomalyAlert{}).Where("id = ?", id).Update("alerted", true).Error
+}
+
 // GetDistinctActiveUserIDs returns the IDs of users who have logged in since the given time.
 func (ls *LocalStorage) GetDistinctActiveUserIDs(ctx context.Context, since time.Time) ([]uint, error) {
 	var ids []uint

--- a/internal/storage/store/remote_audit.go
+++ b/internal/storage/store/remote_audit.go
@@ -173,6 +173,14 @@ func (rs *RemoteStorage) AcknowledgeAnomalyAlert(_ context.Context, _ uint) erro
 	return fmt.Errorf("AcknowledgeAnomalyAlert not available in remote mode")
 }
 
+func (rs *RemoteStorage) ListUnalertedAnomalyAlerts(_ context.Context) ([]models.AnomalyAlert, error) {
+	return nil, fmt.Errorf("ListUnalertedAnomalyAlerts not available in remote mode")
+}
+
+func (rs *RemoteStorage) MarkAnomalyAlertAlerted(_ context.Context, _ uint) error {
+	return fmt.Errorf("MarkAnomalyAlertAlerted not available in remote mode")
+}
+
 // GetDistinctActiveUserIDs is not available in remote mode.
 func (rs *RemoteStorage) GetDistinctActiveUserIDs(_ context.Context, _ time.Time) ([]uint, error) {
 	return nil, fmt.Errorf("GetDistinctActiveUserIDs not available in remote mode")

--- a/server/http/handlers/openapi.yaml
+++ b/server/http/handlers/openapi.yaml
@@ -2822,8 +2822,9 @@ paths:
         separation-of-duties violations), rotation hygiene (covered secrets,
         overdue, due-soon), identity
         (active users, with-second-factor + percent), emergency access
-        (active/total break-glass activations), and data classification (secret
-        counts per sensitivity level + unclassified). Requires system.read.
+        (active/total break-glass activations), data classification (secret
+        counts per sensitivity level + unclassified), and anomalies (open /
+        high-severity access-anomaly alerts). Requires system.read.
       operationId: getCompliancePosture
       security: [{bearerAuth: []}]
       responses:

--- a/server/main.go
+++ b/server/main.go
@@ -347,15 +347,32 @@ func startHTTPServer(ctx context.Context, cfg *config.Config) error {
 		return fmt.Errorf("failed to create HTTP router: %w", err)
 	}
 
-	// Start anomaly detection scheduler (runs every hour). Single-replica-gated
-	// (ADR-039) so N replicas don't emit N copies of each alert.
+	// Start anomaly detection scheduler. Single-replica-gated (ADR-039) so N
+	// replicas don't emit N copies of each alert. When anomaly_alerts is enabled,
+	// each detection pass is followed by an alerting pass that pushes newly detected
+	// anomalies to project admins + the audit/SIEM pipeline.
 	go func() {
 		detector := core.NewAnomalyDetector(coreService.Storage())
-		ticker := time.NewTicker(1 * time.Hour)
+		alertsEnabled := cfg.AnomalyAlerts.Enabled
+		interval := cfg.AnomalyAlerts.GetInterval()
+		if alertsEnabled {
+			log.Printf("Anomaly alerting enabled: scan + alert every %s", interval)
+		}
+		ticker := time.NewTicker(interval)
 		defer ticker.Stop()
 		runDetect := func() {
 			if _, err := coreService.Storage().WithSchedulerLock(ctx, schedLockAnomaly, func() error {
-				return detector.RunDetection(ctx, coreService.ListActiveSecrets(ctx))
+				if derr := detector.RunDetection(ctx, coreService.ListActiveSecrets(ctx)); derr != nil {
+					return derr
+				}
+				if alertsEnabled {
+					if n, aerr := coreService.AlertNewAnomalies(ctx); aerr != nil {
+						return aerr
+					} else if n > 0 {
+						log.Printf("Anomaly alerting: announced %d new anomaly alert(s)", n)
+					}
+				}
+				return nil
 			}); err != nil {
 				log.Printf("Anomaly detection scheduler error: %v", err)
 			}


### PR DESCRIPTION
## What

Anomaly **detection** (off-hours / new-IP / new-user access to secrets) already ran on an hourly scan and persisted alerts — but they just **sat in the DB** until a human checked the CLI/UI. This closes the detection-**and-response** gap (NIS2 Art. 21): each *newly detected* anomaly is now pushed out —

- to the project's **admins** as an in-app notification, and
- to the **audit trail** as a `security.anomaly_detected` event, which the **SIEM forwarder picks up** — so anomalies finally reach the SOC (they previously bypassed the audit/SIEM pipeline entirely).

Each anomaly is announced once (a new `alerted` flag), the alerting pass runs after each detection scan when enabled, and the open-anomaly count joins the compliance posture. First item of the anomaly-alerting batch (this → web).

## Surfaces

- **model**: `AnomalyAlert.Alerted` (additive column migration).
- **storage**: `ListUnalertedAnomalyAlerts` + `MarkAnomalyAlertAlerted` (Local, Remote stub, mock, interface).
- **core**: `AlertNewAnomalies` (audit/SIEM event + admin notify per alert, idempotent); `AnomaliesPosture` (open / high-severity-open) on the compliance posture.
- **config**: `anomaly_alerts` block (enabled, schedule) — the existing anomaly scheduler is now config-driven and runs the alerting pass when enabled (HA single-replica).
- **CLI**: `keyorix compliance report` gains an Access-anomalies line.

## Tests

Alerting emits the audit event + is idempotent (second pass announces nothing); the posture counts open + high-severity anomalies (acknowledged excluded).

## Docs

openapi posture note + CONFIGURATION `anomaly_alerts` block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)