### PR TITLE
feat(legal-hold): deployment-wide legal hold blocks all purges (A — ISO A.5.34)

### DIFF
--- a/docs/REMOTE_CLI_SETUP.md
+++ b/docs/REMOTE_CLI_SETUP.md
@@ -305,6 +305,26 @@ keyorix compliance report
 keyorix compliance export --output evidence-2026Q4.json
 ```
 
+### Legal Hold
+
+A deployment-wide **litigation / investigation hold** (ISO 27001 A.5.34 /
+eDiscovery / DORA record-keeping). While a hold is active, the background purge jobs
+(retention purge, JIT-expiry sweep, login-attempt prune) are **blocked from
+hard-deleting any records**, so data subject to the hold is preserved. Status reads
+need `system.read`; placing/lifting needs `system.write`. Placing and lifting are
+audited.
+
+- `keyorix legal-hold status` — whether a hold is active (and since when / why).
+- `keyorix legal-hold place --reason "…"` — place a hold (blocks all purges).
+- `keyorix legal-hold lift` — release the hold (purges resume next tick).
+
+```bash
+# Freeze all deletion for an investigation, then release when cleared:
+keyorix legal-hold place --reason "litigation hold — case INC-7"
+keyorix legal-hold status
+keyorix legal-hold lift
+```
+
 ### Separation-of-Duties Commands
 
 Separation of duties (ISO 27001 A.5.3 / SOX): define **toxic combinations** — two

--- a/internal/cli/compliance/compliance.go
+++ b/internal/cli/compliance/compliance.go
@@ -63,6 +63,10 @@ type posture struct {
 		Unacknowledged   int `json:"unacknowledged"`
 		HighSeverityOpen int `json:"high_severity_open"`
 	} `json:"anomalies"`
+	LegalHold struct {
+		Active bool   `json:"active"`
+		Reason string `json:"reason"`
+	} `json:"legal_hold"`
 }
 
 func yesNo(b bool) string {
@@ -121,6 +125,13 @@ var reportCmd = &cobra.Command{
 
 		fmt.Println("\nAccess anomalies (NIS2 detection)")
 		fmt.Printf("  open / high-severity : %d / %d\n", p.Anomalies.Unacknowledged, p.Anomalies.HighSeverityOpen)
+
+		fmt.Println("\nLegal hold (ISO A.5.34)")
+		if p.LegalHold.Active {
+			fmt.Printf("  ACTIVE — purges blocked (%s)\n", p.LegalHold.Reason)
+		} else {
+			fmt.Println("  none — purges run normally")
+		}
 		return nil
 	},
 }

--- a/internal/cli/legalhold/legalhold.go
+++ b/internal/cli/legalhold/legalhold.go
@@ -1,0 +1,102 @@
+// Package legalhold provides `keyorix legal-hold` — a deployment-wide litigation /
+// investigation hold (ISO 27001 A.5.34 / eDiscovery). While active, the background
+// purge jobs are blocked from hard-deleting any records. Talks to /api/v1/legal-hold
+// (status reads system.read; place/lift system.write).
+package legalhold
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/spf13/cobra"
+)
+
+// LegalHoldCmd is the `keyorix legal-hold` command.
+var LegalHoldCmd = &cobra.Command{
+	Use:   "legal-hold",
+	Short: "Deployment-wide legal hold — block purges to preserve records (A.5.34)",
+	Long: `Place or lift a litigation/investigation hold. While a hold is active, the
+retention-purge, JIT-expiry, and login-prune jobs are blocked from hard-deleting
+any records, so data subject to legal hold is preserved.`,
+}
+
+type holdView struct {
+	ID       uint   `json:"id"`
+	Reason   string `json:"reason"`
+	PlacedBy uint   `json:"placed_by"`
+	PlacedAt string `json:"placed_at"`
+}
+
+var statusCmd = &cobra.Command{
+	Use:          "status",
+	Short:        "Show whether a legal hold is active",
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		c, ok := common.NewRemoteClient()
+		if !ok {
+			return fmt.Errorf("not connected to a server — run: keyorix connect <server>")
+		}
+		var out struct {
+			Active bool     `json:"active"`
+			Hold   holdView `json:"hold"`
+		}
+		if err := c.Get(context.Background(), "/api/v1/legal-hold", &out); err != nil {
+			return err
+		}
+		if !out.Active {
+			fmt.Println("No legal hold is active. Purge jobs run normally.")
+			return nil
+		}
+		fmt.Printf("LEGAL HOLD ACTIVE (id=%d) since %s — purges are blocked.\n  Reason: %s\n",
+			out.Hold.ID, out.Hold.PlacedAt, out.Hold.Reason)
+		return nil
+	},
+}
+
+var placeReason string
+
+var placeCmd = &cobra.Command{
+	Use:          "place",
+	Short:        "Place a legal hold (block all purges until lifted)",
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		if placeReason == "" {
+			return fmt.Errorf("--reason is required")
+		}
+		c, ok := common.NewRemoteClient()
+		if !ok {
+			return fmt.Errorf("not connected to a server — run: keyorix connect <server>")
+		}
+		var out struct {
+			Hold holdView `json:"hold"`
+		}
+		if err := c.Post(context.Background(), "/api/v1/legal-hold", map[string]string{"reason": placeReason}, &out); err != nil {
+			return err
+		}
+		fmt.Printf("Legal hold placed (id=%d). All purge jobs are now blocked until lifted.\n", out.Hold.ID)
+		return nil
+	},
+}
+
+var liftCmd = &cobra.Command{
+	Use:          "lift",
+	Short:        "Lift the active legal hold (resume purges)",
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		c, ok := common.NewRemoteClient()
+		if !ok {
+			return fmt.Errorf("not connected to a server — run: keyorix connect <server>")
+		}
+		if err := c.Delete(context.Background(), "/api/v1/legal-hold"); err != nil {
+			return err
+		}
+		fmt.Println("Legal hold lifted. Purge jobs will resume on their next tick.")
+		return nil
+	},
+}
+
+func init() {
+	placeCmd.Flags().StringVar(&placeReason, "reason", "", "Why the hold is placed (required, recorded for audit)")
+	LegalHoldCmd.AddCommand(statusCmd, placeCmd, liftCmd)
+}

--- a/internal/cli/main.go
+++ b/internal/cli/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/keyorixhq/keyorix/internal/cli/encryption"
 	"github.com/keyorixhq/keyorix/internal/cli/group"
 	"github.com/keyorixhq/keyorix/internal/cli/invite"
+	"github.com/keyorixhq/keyorix/internal/cli/legalhold"
 	"github.com/keyorixhq/keyorix/internal/cli/machine"
 	"github.com/keyorixhq/keyorix/internal/cli/migrate"
 	"github.com/keyorixhq/keyorix/internal/cli/pat"
@@ -53,6 +54,7 @@ func init() {
 	rootCmd.AddCommand(user.UserCmd)
 	rootCmd.AddCommand(group.GroupCmd)
 	rootCmd.AddCommand(invite.InviteCmd)
+	rootCmd.AddCommand(legalhold.LegalHoldCmd)
 	rootCmd.AddCommand(request.RequestCmd)
 	rootCmd.AddCommand(share.ShareCmd)
 	rootCmd.AddCommand(auth.AuthCmd)

--- a/internal/core/compliance_posture.go
+++ b/internal/core/compliance_posture.go
@@ -58,6 +58,14 @@ type EmergencyAccessPosture struct {
 	TotalActivations  int `json:"total_activations"`
 }
 
+// LegalHoldPosture reports whether a litigation/investigation hold is in effect
+// (ISO 27001 A.5.34) — while active the purge jobs preserve all records.
+type LegalHoldPosture struct {
+	Active   bool       `json:"active"`
+	PlacedAt *time.Time `json:"placed_at,omitempty"`
+	Reason   string     `json:"reason,omitempty"`
+}
+
 // AnomaliesPosture summarises detected access anomalies (NIS2 detection).
 type AnomaliesPosture struct {
 	Unacknowledged   int `json:"unacknowledged"`     // open alerts awaiting review
@@ -84,6 +92,7 @@ type CompliancePosture struct {
 	EmergencyAccess  EmergencyAccessPosture  `json:"emergency_access"`
 	Classification   ClassificationPosture   `json:"classification"`
 	Anomalies        AnomaliesPosture        `json:"anomalies"`
+	LegalHold        LegalHoldPosture        `json:"legal_hold"`
 }
 
 // GetCompliancePosture aggregates the deployment's control posture. It is an
@@ -148,6 +157,12 @@ func (c *KeyorixCore) GetCompliancePosture(ctx context.Context) (*CompliancePost
 				p.Anomalies.HighSeverityOpen++
 			}
 		}
+	}
+
+	// Legal hold (A.5.34).
+	if hold, err := c.storage.GetActiveLegalHold(ctx); err == nil && hold != nil {
+		at := hold.PlacedAt
+		p.LegalHold = LegalHoldPosture{Active: true, PlacedAt: &at, Reason: hold.Reason}
 	}
 	return p, nil
 }

--- a/internal/core/legal_hold.go
+++ b/internal/core/legal_hold.go
@@ -1,0 +1,81 @@
+// legal_hold.go — deployment-wide legal hold (ISO 27001 A.5.34 / eDiscovery / DORA
+// record-keeping). While a hold is active the background purge/retention jobs are
+// blocked from hard-deleting records (the schedulers call IsLegalHoldActive each
+// tick), so data subject to litigation or investigation is preserved. Placing and
+// lifting a hold are audited; the row history is the evidence of when holds applied.
+package core
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// Legal-hold audit event types.
+const (
+	EventLegalHoldPlaced = "data.legal_hold_placed"
+	EventLegalHoldLifted = "data.legal_hold_lifted"
+)
+
+// GetActiveLegalHold returns the current active hold, or (nil, nil) when none.
+func (c *KeyorixCore) GetActiveLegalHold(ctx context.Context) (*models.LegalHold, error) {
+	return c.storage.GetActiveLegalHold(ctx)
+}
+
+// IsLegalHoldActive reports whether a legal hold is currently in effect. The purge
+// schedulers call this each tick and skip when it returns true; on error they must
+// fail SAFE (skip the purge), so a transient lookup failure never risks destroying
+// data that may be under hold.
+func (c *KeyorixCore) IsLegalHoldActive(ctx context.Context) (bool, error) {
+	hold, err := c.storage.GetActiveLegalHold(ctx)
+	if err != nil {
+		return false, err
+	}
+	return hold != nil, nil
+}
+
+// PlaceLegalHold activates a deployment-wide legal hold with a reason. Refuses if a
+// hold is already active. actorID is the placing admin.
+func (c *KeyorixCore) PlaceLegalHold(ctx context.Context, actorID uint, reason string) (*models.LegalHold, error) {
+	if reason == "" {
+		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "a reason is required to place a legal hold")
+	}
+	if active, err := c.storage.GetActiveLegalHold(ctx); err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	} else if active != nil {
+		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "a legal hold is already active")
+	}
+	hold, err := c.storage.CreateLegalHold(ctx, &models.LegalHold{
+		Reason: reason, PlacedBy: actorID, PlacedAt: c.now(), Released: false,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	c.writeAuditEvent(ctx, EventLegalHoldPlaced, actorPtr(actorID), nil,
+		fmt.Sprintf("legal hold %d placed: %s", hold.ID, reason))
+	return hold, nil
+}
+
+// LiftLegalHold releases the active hold so the purge jobs resume. Refuses if no
+// hold is active. actorID is the lifting admin.
+func (c *KeyorixCore) LiftLegalHold(ctx context.Context, actorID uint) error {
+	hold, err := c.storage.GetActiveLegalHold(ctx)
+	if err != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	if hold == nil {
+		return fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "no legal hold is active")
+	}
+	now := c.now()
+	hold.Released = true
+	hold.ReleasedBy = actorID
+	hold.ReleasedAt = &now
+	if err := c.storage.UpdateLegalHold(ctx, hold); err != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	c.writeAuditEvent(ctx, EventLegalHoldLifted, actorPtr(actorID), nil,
+		fmt.Sprintf("legal hold %d lifted", hold.ID))
+	return nil
+}

--- a/internal/core/legal_hold_external_test.go
+++ b/internal/core/legal_hold_external_test.go
@@ -1,0 +1,75 @@
+package core_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/testhelper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A legal hold can be placed once and lifted once; while active IsLegalHoldActive
+// reports true (the purge jobs gate on it).
+func TestLegalHold_PlaceAndLift(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(&models.LegalHold{}, &models.AuditEvent{}))
+	ctx := context.Background()
+
+	// No hold initially.
+	active, err := h.CoreService.IsLegalHoldActive(ctx)
+	require.NoError(t, err)
+	assert.False(t, active)
+
+	// A reason is required.
+	_, err = h.CoreService.PlaceLegalHold(ctx, 1, "")
+	require.Error(t, err)
+
+	// Place a hold.
+	hold, err := h.CoreService.PlaceLegalHold(ctx, 1, "litigation INC-7")
+	require.NoError(t, err)
+	assert.False(t, hold.Released)
+
+	active, err = h.CoreService.IsLegalHoldActive(ctx)
+	require.NoError(t, err)
+	assert.True(t, active, "purges are now blocked")
+
+	// A second hold is refused while one is active.
+	_, err = h.CoreService.PlaceLegalHold(ctx, 1, "another")
+	require.Error(t, err)
+
+	// Lift it.
+	require.NoError(t, h.CoreService.LiftLegalHold(ctx, 1))
+	active, err = h.CoreService.IsLegalHoldActive(ctx)
+	require.NoError(t, err)
+	assert.False(t, active)
+
+	// Lifting again (none active) is refused.
+	require.Error(t, h.CoreService.LiftLegalHold(ctx, 1))
+}
+
+// The compliance posture reflects an active legal hold.
+func TestLegalHold_SurfacesInPosture(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(
+		&models.LegalHold{}, &models.AuditEvent{}, &models.SecretNode{}, &models.AnomalyAlert{},
+		&models.AccessReviewCampaign{}, &models.AccessReviewItem{}, &models.BreakGlassActivation{},
+		&models.RotationPolicy{}, &models.SoDPolicy{},
+	))
+	ctx := context.Background()
+
+	p, err := h.CoreService.GetCompliancePosture(ctx)
+	require.NoError(t, err)
+	assert.False(t, p.LegalHold.Active)
+
+	_, err = h.CoreService.PlaceLegalHold(ctx, 1, "investigation")
+	require.NoError(t, err)
+
+	p, err = h.CoreService.GetCompliancePosture(ctx)
+	require.NoError(t, err)
+	assert.True(t, p.LegalHold.Active)
+	assert.Equal(t, "investigation", p.LegalHold.Reason)
+}

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -271,6 +271,27 @@ func (m *MockStorage) DeleteSoDPolicy(ctx context.Context, id uint) error {
 	return args.Error(0)
 }
 
+func (m *MockStorage) CreateLegalHold(ctx context.Context, h *models.LegalHold) (*models.LegalHold, error) {
+	args := m.Called(ctx, h)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.LegalHold), args.Error(1)
+}
+
+func (m *MockStorage) GetActiveLegalHold(ctx context.Context) (*models.LegalHold, error) {
+	args := m.Called(ctx)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.LegalHold), args.Error(1)
+}
+
+func (m *MockStorage) UpdateLegalHold(ctx context.Context, h *models.LegalHold) error {
+	args := m.Called(ctx, h)
+	return args.Error(0)
+}
+
 func (m *MockStorage) CreateBreakGlassActivation(ctx context.Context, a *models.BreakGlassActivation) (*models.BreakGlassActivation, error) {
 	args := m.Called(ctx, a)
 	if args.Get(0) == nil {

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -86,6 +86,12 @@ type Storage interface {
 	ListSoDPolicies(ctx context.Context) ([]*models.SoDPolicy, error)
 	DeleteSoDPolicy(ctx context.Context, id uint) error
 
+	// Legal hold (ISO 27001 A.5.34 / eDiscovery) — a deployment-wide hold that
+	// blocks the purge jobs from hard-deleting records while active.
+	CreateLegalHold(ctx context.Context, h *models.LegalHold) (*models.LegalHold, error)
+	GetActiveLegalHold(ctx context.Context) (*models.LegalHold, error)
+	UpdateLegalHold(ctx context.Context, h *models.LegalHold) error
+
 	// Break-glass emergency-access activations (NIS2/DORA incident response).
 	CreateBreakGlassActivation(ctx context.Context, a *models.BreakGlassActivation) (*models.BreakGlassActivation, error)
 	GetBreakGlassActivation(ctx context.Context, id uint) (*models.BreakGlassActivation, error)

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -263,6 +263,7 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 	accessReqApprovalsExists := tableExists(db, "access_request_approvals")
 	campaignExists := tableExists(db, "access_review_campaigns")
 	breakGlassExists := tableExists(db, "break_glass_activations")
+	legalHoldExists := tableExists(db, "legal_holds")
 	sodExists := tableExists(db, "sod_policies")
 	pwHistExists := tableExists(db, "password_histories")
 	machineExists := tableExists(db, "machine_identities")
@@ -414,6 +415,13 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 	if !breakGlassExists {
 		if err := db.AutoMigrate(&models.BreakGlassActivation{}); err != nil {
 			return fmt.Errorf("failed to migrate break_glass_activations table: %w", err)
+		}
+	}
+
+	// Create the legal-holds table if missing (additive).
+	if !legalHoldExists {
+		if err := db.AutoMigrate(&models.LegalHold{}); err != nil {
+			return fmt.Errorf("failed to migrate legal_holds table: %w", err)
 		}
 	}
 

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -101,6 +101,21 @@ type SoDPolicy struct {
 // TableName pins the table name (GORM would otherwise derive "so_d_policies").
 func (SoDPolicy) TableName() string { return "sod_policies" }
 
+// LegalHold is a deployment-wide litigation/investigation hold (ISO 27001 A.5.34 /
+// eDiscovery / DORA record-keeping). While one is active (Released = false), the
+// background purge/retention jobs must not hard-delete any records, so data under
+// hold is preserved. Placing/lifting is audited; the row history is the evidence
+// of when holds were in effect.
+type LegalHold struct {
+	ID         uint       `gorm:"primaryKey" json:"id"`
+	Reason     string     `json:"reason"`
+	PlacedBy   uint       `json:"placed_by"`
+	PlacedAt   time.Time  `json:"placed_at"`
+	Released   bool       `gorm:"index" json:"released"` // false = active
+	ReleasedBy uint       `json:"released_by,omitempty"`
+	ReleasedAt *time.Time `json:"released_at,omitempty"`
+}
+
 // BreakGlassActivation records a self-service emergency-access elevation: a user
 // immediately self-granted a time-bound emergency role (no approval), with a
 // written justification, for incident response (NIS2/DORA). The grant itself is a

--- a/internal/storage/store/local_legal_hold.go
+++ b/internal/storage/store/local_legal_hold.go
@@ -1,0 +1,42 @@
+// local_legal_hold.go — legal-hold persistence (ISO 27001 A.5.34 / eDiscovery).
+// For the remote equivalent see remote_legal_hold.go (server-side only).
+package store
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"gorm.io/gorm"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+func (ls *LocalStorage) CreateLegalHold(ctx context.Context, h *models.LegalHold) (*models.LegalHold, error) {
+	if err := ls.db.WithContext(ctx).Create(h).Error; err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	return h, nil
+}
+
+// GetActiveLegalHold returns the current un-released hold, or (nil, nil) when none
+// is active.
+func (ls *LocalStorage) GetActiveLegalHold(ctx context.Context) (*models.LegalHold, error) {
+	var h models.LegalHold
+	err := ls.db.WithContext(ctx).Where("released = ?", false).Order("id DESC").First(&h).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	return &h, nil
+}
+
+func (ls *LocalStorage) UpdateLegalHold(ctx context.Context, h *models.LegalHold) error {
+	if err := ls.db.WithContext(ctx).Save(h).Error; err != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	return nil
+}

--- a/internal/storage/store/remote_legal_hold.go
+++ b/internal/storage/store/remote_legal_hold.go
@@ -1,0 +1,21 @@
+// remote_legal_hold.go — legal hold for RemoteStorage. Processed server-side;
+// stubs here. See local_legal_hold.go.
+package store
+
+import (
+	"context"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+func (rs *RemoteStorage) CreateLegalHold(_ context.Context, _ *models.LegalHold) (*models.LegalHold, error) {
+	return nil, remoteUnsupported("CreateLegalHold")
+}
+
+func (rs *RemoteStorage) GetActiveLegalHold(_ context.Context) (*models.LegalHold, error) {
+	return nil, remoteUnsupported("GetActiveLegalHold")
+}
+
+func (rs *RemoteStorage) UpdateLegalHold(_ context.Context, _ *models.LegalHold) error {
+	return remoteUnsupported("UpdateLegalHold")
+}

--- a/server/http/handlers/legal_hold.go
+++ b/server/http/handlers/legal_hold.go
@@ -1,0 +1,70 @@
+// legal_hold.go — deployment-wide legal-hold endpoints (ISO 27001 A.5.34). Status
+// reads need system.read; placing/lifting needs system.write (wired in router.go).
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/keyorixhq/keyorix/server/middleware"
+)
+
+// GetLegalHold handles GET /api/v1/legal-hold — the current hold (or {active:false}).
+func (h *DashboardHandler) GetLegalHold(w http.ResponseWriter, r *http.Request) {
+	hold, err := h.coreService.GetActiveLegalHold(r.Context())
+	if err != nil {
+		sendError(w, "Error", err.Error(), http.StatusInternalServerError, nil)
+		return
+	}
+	if hold == nil {
+		sendSuccess(w, map[string]interface{}{"active": false}, "")
+		return
+	}
+	sendSuccess(w, map[string]interface{}{"active": true, "hold": hold}, "")
+}
+
+// PlaceLegalHold handles POST /api/v1/legal-hold — activate a hold with a reason.
+func (h *DashboardHandler) PlaceLegalHold(w http.ResponseWriter, r *http.Request) {
+	actor := middleware.GetUserFromContext(r.Context())
+	if actor == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	var body struct {
+		Reason string `json:"reason"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		sendError(w, "InvalidJSON", "Invalid request body", http.StatusBadRequest, nil)
+		return
+	}
+	hold, err := h.coreService.PlaceLegalHold(r.Context(), actor.UserID, body.Reason)
+	if err != nil {
+		status := http.StatusInternalServerError
+		if strings.Contains(err.Error(), "required") || strings.Contains(err.Error(), "already active") {
+			status = http.StatusBadRequest
+		}
+		sendError(w, "Error", err.Error(), status, nil)
+		return
+	}
+	w.WriteHeader(http.StatusCreated)
+	sendSuccess(w, map[string]interface{}{"hold": hold}, "Legal hold placed")
+}
+
+// LiftLegalHold handles DELETE /api/v1/legal-hold — release the active hold.
+func (h *DashboardHandler) LiftLegalHold(w http.ResponseWriter, r *http.Request) {
+	actor := middleware.GetUserFromContext(r.Context())
+	if actor == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	if err := h.coreService.LiftLegalHold(r.Context(), actor.UserID); err != nil {
+		status := http.StatusInternalServerError
+		if strings.Contains(err.Error(), "no legal hold") {
+			status = http.StatusBadRequest
+		}
+		sendError(w, "Error", err.Error(), status, nil)
+		return
+	}
+	sendSuccess(w, nil, "Legal hold lifted")
+}

--- a/server/http/handlers/openapi.yaml
+++ b/server/http/handlers/openapi.yaml
@@ -2823,8 +2823,9 @@ paths:
         overdue, due-soon), identity
         (active users, with-second-factor + percent), emergency access
         (active/total break-glass activations), data classification (secret
-        counts per sensitivity level + unclassified), and anomalies (open /
-        high-severity access-anomaly alerts). Requires system.read.
+        counts per sensitivity level + unclassified), anomalies (open /
+        high-severity access-anomaly alerts), and legal hold (active + reason).
+        Requires system.read.
       operationId: getCompliancePosture
       security: [{bearerAuth: []}]
       responses:
@@ -2851,6 +2852,50 @@ paths:
           description: >-
             Envelope {data}. data: {generated_at, posture, audit_anchor, campaigns[],
             break_glass[], rotation_overdue[], sod_violations[]}.
+        '401': {$ref: '#/components/responses/Error'}
+        '403': {$ref: '#/components/responses/Error'}
+  /api/v1/legal-hold:
+    get:
+      tags: [Dashboard]
+      summary: Legal-hold status (ISO 27001 A.5.34 / eDiscovery)
+      description: >-
+        Whether a deployment-wide litigation/investigation hold is active. While
+        active, the background purge jobs are blocked from hard-deleting records.
+        Requires system.read.
+      operationId: getLegalHold
+      security: [{bearerAuth: []}]
+      responses:
+        '200': {description: "Envelope {data}. data: {active} or {active:true, hold:{id, reason, placed_by, placed_at}}."}
+        '401': {$ref: '#/components/responses/Error'}
+        '403': {$ref: '#/components/responses/Error'}
+    post:
+      tags: [Dashboard]
+      summary: Place a legal hold (block all purges)
+      description: "Activate a hold with a reason; refuses if one is already active. Requires system.write."
+      operationId: placeLegalHold
+      security: [{bearerAuth: []}]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [reason]
+              properties:
+                reason: {type: string, description: "Why the hold is placed (recorded for audit)"}
+      responses:
+        '201': {description: "Envelope {data}. data: {hold}."}
+        '400': {$ref: '#/components/responses/Error'}
+        '401': {$ref: '#/components/responses/Error'}
+        '403': {$ref: '#/components/responses/Error'}
+    delete:
+      tags: [Dashboard]
+      summary: Lift the active legal hold (resume purges)
+      operationId: liftLegalHold
+      security: [{bearerAuth: []}]
+      responses:
+        '200': {description: "Envelope {data, message}. Legal hold lifted."}
+        '400': {$ref: '#/components/responses/Error'}
         '401': {$ref: '#/components/responses/Error'}
         '403': {$ref: '#/components/responses/Error'}
   /api/v1/sod/policies:

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -457,6 +457,10 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 
 		// Compliance posture — deployment-wide controls snapshot for auditors.
 		r.With(customMiddleware.RequirePermission("system.read")).Get("/compliance/posture", dashboardHandler.GetCompliancePosture)
+		// Legal hold (ISO A.5.34): status reads system.read; place/lift system.write.
+		r.With(customMiddleware.RequirePermission("system.read")).Get("/legal-hold", dashboardHandler.GetLegalHold)
+		r.With(customMiddleware.RequirePermission("system.write")).Post("/legal-hold", dashboardHandler.PlaceLegalHold)
+		r.With(customMiddleware.RequirePermission("system.write")).Delete("/legal-hold", dashboardHandler.LiftLegalHold)
 		// Compliance evidence pack — posture + supporting records, for archival.
 		r.With(customMiddleware.RequirePermission("system.read")).Get("/compliance/evidence", dashboardHandler.GetComplianceEvidence)
 

--- a/server/main.go
+++ b/server/main.go
@@ -388,6 +388,23 @@ func startHTTPServer(ctx context.Context, cfg *config.Config) error {
 		}
 	}()
 
+	// legalHoldBlocks reports whether a deployment-wide legal hold (ISO A.5.34)
+	// should block a hard-delete purge job this tick. Fails SAFE: if the hold status
+	// can't be read it returns true (skip the purge), so records that may be under
+	// hold are never destroyed on a transient lookup error.
+	legalHoldBlocks := func(job string) bool {
+		active, err := coreService.IsLegalHoldActive(ctx)
+		if err != nil {
+			log.Printf("%s skipped: could not check legal-hold status: %v", job, err)
+			return true
+		}
+		if active {
+			log.Printf("%s skipped: a legal hold is active", job)
+			return true
+		}
+		return false
+	}
+
 	// Start the retention purge scheduler (ADR-032) — opt-in. Hard-deletes
 	// soft-deleted users/projects/environments older than the retention window.
 	if cfg.Purge.Enabled {
@@ -398,6 +415,9 @@ func startHTTPServer(ctx context.Context, cfg *config.Config) error {
 			ticker := time.NewTicker(interval)
 			defer ticker.Stop()
 			runPurge := func() {
+				if legalHoldBlocks("Retention purge") {
+					return
+				}
 				// Single-replica-gated (ADR-039): only one replica runs the purge.
 				if _, err := coreService.Storage().WithSchedulerLock(ctx, schedLockPurge, func() error {
 					cutoff := time.Now().AddDate(0, 0, -retentionDays)
@@ -516,6 +536,11 @@ func startHTTPServer(ctx context.Context, cfg *config.Config) error {
 			ticker := time.NewTicker(interval)
 			defer ticker.Stop()
 			runSweep := func() {
+				// A legal hold preserves the grant rows (the auth queries still deny
+				// expired grants immediately, so blocking the sweep loses no security).
+				if legalHoldBlocks("JIT access-expiry sweep") {
+					return
+				}
 				// Single-replica-gated (ADR-039): one replica sweeps per tick.
 				if _, err := coreService.Storage().WithSchedulerLock(ctx, schedLockJITExpiry, func() error {
 					n, rerr := coreService.RemoveExpiredRoleGrants(ctx, time.Now())
@@ -587,6 +612,9 @@ func startHTTPServer(ctx context.Context, cfg *config.Config) error {
 		ticker := time.NewTicker(1 * time.Hour)
 		defer ticker.Stop()
 		runPrune := func() {
+			if legalHoldBlocks("Login-attempt prune") {
+				return
+			}
 			if _, err := coreService.Storage().WithSchedulerLock(ctx, schedLockLoginPrune, func() error {
 				_, perr := coreService.PruneLoginAttempts(ctx)
 				return perr


### PR DESCRIPTION
## What

A **litigation/investigation legal hold** (ISO 27001 A.5.34 / eDiscovery / DORA record-keeping): while active, the background hard-delete jobs are **blocked**, so records subject to hold are preserved. Storage-backed and **runtime-toggleable** — place a hold NOW via API/CLI, no restart. First item of the legal-hold batch (this → web).

## Gated schedulers (every hard-delete path)

- the **retention purge** (ADR-032),
- the **JIT role-grant-expiry sweep** — the grant rows are evidence of who-had-access-when, and the auth queries still deny expired grants immediately, so blocking the sweep loses no security,
- the **login-attempt prune**.

The guard **fails SAFE** — if the hold status can't be read, the purge is skipped rather than risk destroying held data. The dynamic-secrets sweeper is deliberately **not** gated (it revokes credentials; it doesn't destroy records).

## Surfaces

- **model**: `LegalHold` (active until released; the row history is the evidence of when holds applied); additive migration.
- **storage**: Create/GetActive/Update (Local, Remote stubs, mock, interface).
- **core**: `PlaceLegalHold` (refuses a second hold) / `LiftLegalHold` / `IsLegalHoldActive`; both transitions audited (`data.legal_hold_placed`/`_lifted`). `LegalHoldPosture` (active + reason) on the compliance posture.
- **main.go**: a fail-safe `legalHoldBlocks()` guard wraps the purge/JIT/login-prune ticks.
- **API**: `GET/POST/DELETE /api/v1/legal-hold` (status `system.read`; place/lift `system.write`).
- **CLI**: `keyorix legal-hold status|place|lift`.

## Tests

Place-once/lift-once + refuse-double/refuse-none + required reason; the posture reflects an active hold.

## Docs

openapi (3 endpoints + posture note) + REMOTE_CLI legal-hold section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)