### PR TITLE
feat(evidence): scheduled compliance-evidence delivery (ISO 27001 / SOC 2)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -16,7 +16,7 @@ The config file is located via, in order: an explicit path argument, then
 - [secrets](#secrets) · [security + require_mfa](#security) (ADR-034)
 - [webauthn](#webauthn) (ADR-036) · [dynamic_secrets](#dynamic_secrets) (ADR-035)
 - [oidc](#oidc) (ADR-031) · [session](#session) · [password_policy](#password_policy) (ADR-025)
-- [soft_delete + purge](#soft_delete--purge) (ADR-032) · [data_retention](#data_retention) (A.5.33) · [rotation_reminders](#rotation_reminders) · [audit_checkpoints](#audit_checkpoints) (ADR-029) · [jit_access_expiry](#jit_access_expiry) · [break_glass](#break_glass) · [audit.siem](#auditsiem)
+- [soft_delete + purge](#soft_delete--purge) (ADR-032) · [data_retention](#data_retention) (A.5.33) · [evidence_delivery](#evidence_delivery) · [rotation_reminders](#rotation_reminders) · [audit_checkpoints](#audit_checkpoints) (ADR-029) · [jit_access_expiry](#jit_access_expiry) · [break_glass](#break_glass) · [audit.siem](#auditsiem)
 - [membership](#membership) (ADR-022) · [credential_delivery](#credential_delivery) (ADR-028)
 
 ---
@@ -345,6 +345,29 @@ data_retention:
 
 The configured windows surface in the compliance posture (`keyorix compliance report`
 → "Data retention") as evidence that storage-limitation is actively enforced.
+
+## evidence_delivery
+
+An opt-in background scheduler that periodically generates the **auditor evidence
+pack** (the same bundle as `keyorix compliance export` / `GET /compliance/evidence`
+— the posture plus the records that substantiate it) and writes it as a timestamped
+JSON file to `output_dir`, for off-box archival/backup (ISO 27001 / SOC 2 continuous
+evidence). Files are named `keyorix-evidence-<UTC-timestamp>.json` (mode `0600`; the
+directory is created `0700` if absent).
+
+Each export also emits a `compliance.evidence_exported` audit event, so an installed
+[`audit.siem`](#auditsiem) forwarder receives the delivery signal too. Read-only, so
+it runs even while a legal hold is active. Single-replica-gated (ADR-039).
+
+```yaml
+evidence_delivery:
+  enabled: true
+  schedule: "24h"                           # Go duration between exports (default 24h)
+  output_dir: "/var/lib/keyorix/evidence"   # required when enabled; mount to durable storage
+```
+
+> Point `output_dir` at a volume that is backed up off-box (or synced to object
+> storage) — the value of scheduled delivery is that the evidence survives the node.
 
 ## rotation_reminders
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -42,6 +42,10 @@ type Config struct {
 	// GDPR storage-limitation / DORA). Respects legal hold; audit events are never
 	// purged (append-only, ADR-029).
 	DataRetention DataRetentionConfig `yaml:"data_retention"`
+	// EvidenceDelivery configures the opt-in scheduler that periodically generates
+	// the auditor evidence pack and writes it to an output directory for off-box
+	// archival (ISO 27001 / SOC 2 continuous evidence).
+	EvidenceDelivery EvidenceDeliveryConfig `yaml:"evidence_delivery"`
 	// DynamicSecrets configures the on-demand database-credentials engine and its
 	// auto-revoke sweep (ADR-035). Disabled (zero value) = the API is still served
 	// but no background sweeper runs; enable to auto-revoke leases at expiry.
@@ -491,6 +495,30 @@ type DataRetentionConfig struct {
 // GetInterval returns the data-retention run interval, parsing Schedule as a Go
 // duration (e.g. "24h", "6h"); defaults to 24h when unset or unparseable.
 func (c DataRetentionConfig) GetInterval() time.Duration {
+	if c.Schedule != "" {
+		if d, err := time.ParseDuration(c.Schedule); err == nil && d > 0 {
+			return d
+		}
+	}
+	return 24 * time.Hour
+}
+
+// EvidenceDeliveryConfig configures the scheduled compliance-evidence export
+// (ISO 27001 / SOC 2 continuous evidence): a background job that periodically
+// generates the auditor evidence pack (the posture plus the records that
+// substantiate it) and writes it as a timestamped JSON file under OutputDir, for
+// off-box archival/backup. Each run also emits a compliance.evidence_exported
+// audit event, so an installed SIEM forwarder receives the delivery signal too.
+// Opt-in (Enabled, default off); OutputDir is required when enabled.
+type EvidenceDeliveryConfig struct {
+	Enabled   bool   `yaml:"enabled"`
+	Schedule  string `yaml:"schedule"`
+	OutputDir string `yaml:"output_dir"`
+}
+
+// GetInterval returns the evidence-export run interval, parsing Schedule as a Go
+// duration (e.g. "24h"); defaults to 24h when unset or unparseable.
+func (c EvidenceDeliveryConfig) GetInterval() time.Duration {
 	if c.Schedule != "" {
 		if d, err := time.ParseDuration(c.Schedule); err == nil && d > 0 {
 			return d

--- a/internal/core/evidence_export.go
+++ b/internal/core/evidence_export.go
@@ -1,0 +1,63 @@
+// evidence_export.go — scheduled delivery of the auditor evidence pack (ISO 27001
+// / SOC 2 continuous evidence). GenerateComplianceEvidence (compliance_evidence.go)
+// builds the pack on demand; this writes it to durable storage on a schedule so an
+// auditor has a timestamped archive without anyone remembering to export it. The
+// export also emits an audit event, so an installed SIEM forwarder receives the
+// delivery signal too.
+package core
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/keyorixhq/keyorix/internal/securefiles"
+)
+
+// evidenceFileTimeLayout names exported packs to the second, in UTC, sorted
+// lexicographically by time: keyorix-evidence-20060102T150405Z.json.
+const evidenceFileTimeLayout = "20060102T150405Z"
+
+// EvidenceExportResult reports the outcome of one scheduled evidence export.
+type EvidenceExportResult struct {
+	Path  string `json:"path"`
+	Bytes int    `json:"bytes"`
+}
+
+// ExportComplianceEvidence generates the evidence pack and writes it as a
+// timestamped JSON file (0600) under outputDir, which is created (0700) if absent.
+// It returns the written path. The write is followed by a system-actored
+// compliance.evidence_exported audit event so the export is itself part of the
+// tamper-evident trail and is forwarded to a SIEM. An empty outputDir is a
+// misconfiguration error. Read-only with respect to the data it captures, so it
+// is NOT gated by legal hold.
+func (c *KeyorixCore) ExportComplianceEvidence(ctx context.Context, outputDir string) (*EvidenceExportResult, error) {
+	if outputDir == "" {
+		return nil, fmt.Errorf("evidence export: output_dir is not configured")
+	}
+	ev, err := c.GenerateComplianceEvidence(ctx)
+	if err != nil {
+		return nil, err
+	}
+	data, err := json.MarshalIndent(ev, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("evidence export: marshal: %w", err)
+	}
+	if err := os.MkdirAll(outputDir, 0o700); err != nil {
+		return nil, fmt.Errorf("evidence export: create output dir: %w", err)
+	}
+	name := fmt.Sprintf("keyorix-evidence-%s.json", ev.GeneratedAt.UTC().Format(evidenceFileTimeLayout))
+	if err := securefiles.SecureWriteFile(outputDir, name, data, 0o600); err != nil {
+		return nil, fmt.Errorf("evidence export: write: %w", err)
+	}
+	path := filepath.Join(outputDir, name)
+
+	sysCtx := WithActorType(ctx, ActorTypeSystem)
+	c.writeAuditEvent(sysCtx, "compliance.evidence_exported", nil, nil,
+		fmt.Sprintf("compliance evidence pack exported to %s (%d bytes; %d campaigns, %d break-glass activations, %d overdue rotations, %d SoD violations)",
+			path, len(data), len(ev.Campaigns), len(ev.BreakGlass), len(ev.RotationOverdue), len(ev.SoDViolations)))
+
+	return &EvidenceExportResult{Path: path, Bytes: len(data)}, nil
+}

--- a/internal/core/evidence_export_test.go
+++ b/internal/core/evidence_export_test.go
@@ -1,0 +1,71 @@
+package core
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// newEvidenceExportCore builds a real-SQLite core on an empty deployment, migrating
+// the tables GenerateComplianceEvidence reads so the export runs end to end.
+func newEvidenceExportCore(t *testing.T) (*KeyorixCore, *gorm.DB, time.Time) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.User{}, &models.Role{}, &models.UserRole{}, &models.Project{},
+		&models.Environment{}, &models.SecretNode{}, &models.RotationPolicy{},
+		&models.AuditEvent{}, &models.AnomalyAlert{}, &models.LegalHold{},
+		&models.SoDPolicy{}, &models.AccessReviewCampaign{}, &models.AccessReviewItem{},
+		&models.BreakGlassActivation{}, &models.AccessRequest{},
+	))
+	now := time.Date(2026, 6, 14, 9, 30, 0, 0, time.UTC)
+	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: func() time.Time { return now }}
+	return c, db, now
+}
+
+func TestExportComplianceEvidence_WritesFileAndAudits(t *testing.T) {
+	ctx := context.Background()
+	c, db, now := newEvidenceExportCore(t)
+	dir := t.TempDir()
+
+	res, err := c.ExportComplianceEvidence(ctx, dir)
+	require.NoError(t, err)
+	require.NotEmpty(t, res.Path)
+	assert.Greater(t, res.Bytes, 0)
+
+	// The file is named by the generation timestamp and lives under the output dir.
+	wantName := "keyorix-evidence-" + now.UTC().Format(evidenceFileTimeLayout) + ".json"
+	assert.Equal(t, filepath.Join(dir, wantName), res.Path)
+
+	raw, err := os.ReadFile(res.Path)
+	require.NoError(t, err)
+	var ev ComplianceEvidence
+	require.NoError(t, json.Unmarshal(raw, &ev), "exported file is valid evidence JSON")
+	assert.False(t, ev.GeneratedAt.IsZero(), "evidence carries a generation time")
+	require.NotNil(t, ev.Posture, "evidence embeds the posture")
+
+	// The export is itself audited (system-actored) → forwarded to a SIEM.
+	var n int64
+	require.NoError(t, db.Model(&models.AuditEvent{}).
+		Where("event_type = ?", "compliance.evidence_exported").Count(&n).Error)
+	assert.Equal(t, int64(1), n)
+}
+
+func TestExportComplianceEvidence_EmptyOutputDirErrors(t *testing.T) {
+	c, _, _ := newEvidenceExportCore(t)
+	_, err := c.ExportComplianceEvidence(context.Background(), "")
+	require.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), "output_dir"), "error names the misconfig")
+}

--- a/server/main.go
+++ b/server/main.go
@@ -142,6 +142,7 @@ const (
 	schedLockAuditCkpt    int64 = 0x4B455953_41434B50 // "KEYSACKP"
 	schedLockJITExpiry    int64 = 0x4B455953_4A495445 // "KEYSJITE"
 	schedLockRetention    int64 = 0x4B455953_52455445 // "KEYSRETE"
+	schedLockEvidence     int64 = 0x4B455953_45564944 // "KEYSEVID"
 )
 
 // initializeEncryption sources the KEK per the configured key provider (ADR-038)
@@ -546,6 +547,47 @@ func startHTTPServer(ctx context.Context, cfg *config.Config) error {
 				}
 			}
 		}()
+	}
+
+	// Start the scheduled compliance-evidence delivery (ISO 27001 / SOC 2) — opt-in.
+	// Periodically generates the auditor evidence pack and writes it to the output
+	// directory for off-box archival; each export emits an audit event (forwarded to
+	// a SIEM if configured). Single-replica-gated (ADR-039) so one timestamped pack
+	// is written per tick. Not legal-hold-gated (it only reads).
+	if cfg.EvidenceDelivery.Enabled {
+		outputDir := cfg.EvidenceDelivery.OutputDir
+		if outputDir == "" {
+			log.Printf("Evidence-delivery scheduler enabled but output_dir is empty; skipping")
+		} else {
+			interval := cfg.EvidenceDelivery.GetInterval()
+			log.Printf("Evidence-delivery scheduler enabled: every %s → %s", interval, outputDir)
+			go func() {
+				ticker := time.NewTicker(interval)
+				defer ticker.Stop()
+				runExport := func() {
+					if _, err := coreService.Storage().WithSchedulerLock(ctx, schedLockEvidence, func() error {
+						res, err := coreService.ExportComplianceEvidence(ctx, outputDir)
+						if err != nil {
+							log.Printf("Evidence-delivery error: %v", err)
+							return err
+						}
+						log.Printf("Evidence pack exported: %s (%d bytes)", res.Path, res.Bytes)
+						return nil
+					}); err != nil {
+						log.Printf("Evidence-delivery scheduler error: %v", err)
+					}
+				}
+				runExport() // run once on startup
+				for {
+					select {
+					case <-ticker.C:
+						runExport()
+					case <-ctx.Done():
+						return
+					}
+				}
+			}()
+		}
 	}
 
 	// Start the audit-checkpoint scheduler (ADR-029) — opt-in. Periodically signs


### PR DESCRIPTION
## What

Adds an opt-in scheduler that **periodically generates the auditor evidence pack and writes it to durable storage** — turning the on-demand `keyorix compliance export` into continuous, automatic evidence delivery (ISO 27001 / SOC 2).

## How

- **config** — `evidence_delivery {enabled, schedule, output_dir}`.
- **core** — `ExportComplianceEvidence`: generates the pack (`GenerateComplianceEvidence`), writes it as `keyorix-evidence-<UTC-timestamp>.json` (mode `0600`, via `securefiles.SecureWriteFile`; `output_dir` created `0700` if absent), then emits a system-actored `compliance.evidence_exported` audit event — so the export is itself in the tamper-evident trail and is shipped to a SIEM if one is configured. Empty `output_dir` is a config error. Read-only → **not** legal-hold-gated.
- **scheduler** (`main.go`) — opt-in, single-replica-gated (ADR-039, new lock id); runs once on startup then on the interval.
- **docs** — `CONFIGURATION.md` `evidence_delivery` section (with a note to point `output_dir` at off-box-backed storage).

## Tests

- End-to-end on a real in-memory store: writes a valid evidence-JSON file, names it by the generation timestamp, embeds the posture, and records the `compliance.evidence_exported` audit event.
- Empty-output-dir misconfiguration returns an error.

Part 2 of 3 in the retention + evidence-delivery + classification-UI batch (part 1: #189).

🤖 Generated with [Claude Code](https://claude.com/claude-code)