### PR TITLE
feat(recertification): scheduled access recertification cadence (ISO A.5.18)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -16,7 +16,7 @@ The config file is located via, in order: an explicit path argument, then
 - [secrets](#secrets) · [security + require_mfa](#security) (ADR-034)
 - [webauthn](#webauthn) (ADR-036) · [dynamic_secrets](#dynamic_secrets) (ADR-035)
 - [oidc](#oidc) (ADR-031) · [session](#session) · [password_policy](#password_policy) (ADR-025)
-- [soft_delete + purge](#soft_delete--purge) (ADR-032) · [data_retention](#data_retention) (A.5.33) · [evidence_delivery](#evidence_delivery) · [rotation_reminders](#rotation_reminders) · [audit_checkpoints](#audit_checkpoints) (ADR-029) · [jit_access_expiry](#jit_access_expiry) · [break_glass](#break_glass) · [audit.siem](#auditsiem)
+- [soft_delete + purge](#soft_delete--purge) (ADR-032) · [data_retention](#data_retention) (A.5.33) · [recertification](#recertification) (A.5.18) · [evidence_delivery](#evidence_delivery) · [rotation_reminders](#rotation_reminders) · [audit_checkpoints](#audit_checkpoints) (ADR-029) · [jit_access_expiry](#jit_access_expiry) · [break_glass](#break_glass) · [audit.siem](#auditsiem)
 - [membership](#membership) (ADR-022) · [credential_delivery](#credential_delivery) (ADR-028)
 
 ---
@@ -345,6 +345,31 @@ data_retention:
 
 The configured windows surface in the compliance posture (`keyorix compliance report`
 → "Data retention") as evidence that storage-limitation is actively enforced.
+
+## recertification
+
+An opt-in background scheduler that enforces an **access-recertification cadence**
+(ISO 27001 A.5.18, "review access rights at planned intervals"). On each run it
+walks every project and finds those **due for review** — never reviewed, or whose
+most-recent review campaign closed more than `cadence_days` ago — that have no
+campaign currently open. For each due project: when `auto_open` is true it opens a
+fresh recertification campaign (system-actored, snapshotting current access);
+otherwise it sends the project's admins an in-app reminder to open one. It also
+nudges admins of an in-flight campaign that still has pending items. Reminders
+de-dupe against an unread one, so they don't pile up. Single-replica-gated (ADR-039);
+opening a campaign is a create, not a delete, so it runs even under a legal hold.
+
+The cadence also drives the compliance posture's **projects-overdue** count (and
+`keyorix compliance report` → Access governance → "overdue for recert"), so the
+overdue signal is visible to auditors even before you enable `auto_open`.
+
+```yaml
+recertification:
+  enabled: true
+  schedule: "24h"        # Go duration between runs (default 24h)
+  cadence_days: 90       # a project is due this many days after its last campaign closed (default 90)
+  auto_open: false       # true = auto-open a campaign for overdue projects; false = remind admins only
+```
 
 ## evidence_delivery
 

--- a/internal/cli/compliance/compliance.go
+++ b/internal/cli/compliance/compliance.go
@@ -34,6 +34,7 @@ type posture struct {
 		ProjectsNeverReviewed    int `json:"projects_never_reviewed"`
 		OpenCampaigns            int `json:"open_campaigns"`
 		PendingItems             int `json:"pending_items"`
+		ProjectsOverdue          int `json:"projects_overdue"`
 		DormantRoleGrants        int `json:"dormant_role_grants"`
 		SoDViolations            int `json:"sod_violations"`
 	} `json:"access_governance"`
@@ -117,6 +118,7 @@ var reportCmd = &cobra.Command{
 		fmt.Printf("  projects                  : %d\n", p.AccessGovernance.Projects)
 		fmt.Printf("  with an open campaign     : %d\n", p.AccessGovernance.ProjectsWithOpenCampaign)
 		fmt.Printf("  never reviewed            : %d\n", p.AccessGovernance.ProjectsNeverReviewed)
+		fmt.Printf("  overdue for recert        : %d\n", p.AccessGovernance.ProjectsOverdue)
 		fmt.Printf("  open campaigns / pending  : %d / %d\n", p.AccessGovernance.OpenCampaigns, p.AccessGovernance.PendingItems)
 		fmt.Printf("  dormant role grants       : %d\n", p.AccessGovernance.DormantRoleGrants)
 		fmt.Printf("  separation-of-duties viol.: %d\n", p.AccessGovernance.SoDViolations)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -46,6 +46,10 @@ type Config struct {
 	// the auditor evidence pack and writes it to an output directory for off-box
 	// archival (ISO 27001 / SOC 2 continuous evidence).
 	EvidenceDelivery EvidenceDeliveryConfig `yaml:"evidence_delivery"`
+	// Recertification configures the opt-in scheduler that enforces an access-review
+	// cadence (ISO 27001 A.5.18): reminding admins of (or auto-opening) recert
+	// campaigns for projects overdue for review.
+	Recertification RecertificationConfig `yaml:"recertification"`
 	// DynamicSecrets configures the on-demand database-credentials engine and its
 	// auto-revoke sweep (ADR-035). Disabled (zero value) = the API is still served
 	// but no background sweeper runs; enable to auto-revoke leases at expiry.
@@ -519,6 +523,34 @@ type EvidenceDeliveryConfig struct {
 // GetInterval returns the evidence-export run interval, parsing Schedule as a Go
 // duration (e.g. "24h"); defaults to 24h when unset or unparseable.
 func (c EvidenceDeliveryConfig) GetInterval() time.Duration {
+	if c.Schedule != "" {
+		if d, err := time.ParseDuration(c.Schedule); err == nil && d > 0 {
+			return d
+		}
+	}
+	return 24 * time.Hour
+}
+
+// RecertificationConfig configures scheduled access recertification (ISO 27001
+// A.5.18, "review access rights at planned intervals"). When Enabled, a background
+// job finds projects whose access is due for review — never reviewed, or last
+// reviewed more than CadenceDays ago — and, if AutoOpen, opens a recert campaign for
+// each (system-actored); otherwise it reminds the project's admins to. It also nudges
+// admins of in-flight campaigns that still have pending items. Opt-in (default off).
+type RecertificationConfig struct {
+	Enabled  bool   `yaml:"enabled"`
+	Schedule string `yaml:"schedule"`
+	// CadenceDays is the review interval; a project becomes due this many days after
+	// its last campaign closed. 0 = the default (90 days).
+	CadenceDays int `yaml:"cadence_days"`
+	// AutoOpen, when true, opens a campaign automatically for an overdue project;
+	// when false the scheduler only reminds admins to open one themselves.
+	AutoOpen bool `yaml:"auto_open"`
+}
+
+// GetInterval returns the recertification run interval, parsing Schedule as a Go
+// duration (e.g. "24h"); defaults to 24h when unset or unparseable.
+func (c RecertificationConfig) GetInterval() time.Duration {
 	if c.Schedule != "" {
 		if d, err := time.ParseDuration(c.Schedule); err == nil && d > 0 {
 			return d

--- a/internal/core/compliance_posture.go
+++ b/internal/core/compliance_posture.go
@@ -34,6 +34,7 @@ type AccessGovernancePosture struct {
 	ProjectsNeverReviewed    int `json:"projects_never_reviewed"`
 	OpenCampaigns            int `json:"open_campaigns"`
 	PendingItems             int `json:"pending_items"`       // undecided items across open campaigns
+	ProjectsOverdue          int `json:"projects_overdue"`    // overdue for recertification (A.5.18 cadence)
 	DormantRoleGrants        int `json:"dormant_role_grants"` // user role grants with no/old secret access
 	SoDViolations            int `json:"sod_violations"`      // principals holding a forbidden permission pair (A.5.3)
 }
@@ -252,6 +253,7 @@ func (c *KeyorixCore) accessGovernancePosture(ctx context.Context, p *Compliance
 		return fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
 	}
 	p.AccessGovernance.Projects = len(projects)
+	recertCutoff := c.now().AddDate(0, 0, -c.recertCadence())
 	for _, proj := range projects {
 		pid := proj.ID
 
@@ -260,16 +262,21 @@ func (c *KeyorixCore) accessGovernancePosture(ctx context.Context, p *Compliance
 			if len(campaigns) == 0 {
 				p.AccessGovernance.ProjectsNeverReviewed++
 			}
-			hasOpen := false
-			for _, cw := range campaigns {
-				if cw.Campaign.State == CampaignStateOpen {
-					hasOpen = true
-					p.AccessGovernance.OpenCampaigns++
-					p.AccessGovernance.PendingItems += cw.Progress.Pending
-				}
-			}
-			if hasOpen {
+			open, lastClosed := splitCampaigns(campaigns)
+			if open != nil {
 				p.AccessGovernance.ProjectsWithOpenCampaign++
+				p.AccessGovernance.OpenCampaigns++
+				p.AccessGovernance.PendingItems += open.Progress.Pending
+			} else {
+				// No review in progress — overdue if never reviewed, or the last
+				// campaign closed longer ago than the recertification cadence (A.5.18).
+				overdue := lastClosed == nil
+				if lastClosed != nil && lastClosed.Campaign.ClosedAt != nil {
+					overdue = lastClosed.Campaign.ClosedAt.Before(recertCutoff)
+				}
+				if overdue {
+					p.AccessGovernance.ProjectsOverdue++
+				}
 			}
 		}
 

--- a/internal/core/recertification.go
+++ b/internal/core/recertification.go
@@ -1,0 +1,162 @@
+// recertification.go — scheduled access recertification (ISO 27001 A.5.18, "review
+// access rights at planned intervals"). access_review_campaign.go provides the
+// manual cycle (open → decide → close); this enforces the *cadence*: a background
+// scheduler (opt-in, see main.go) finds projects whose access is due for review —
+// never reviewed, or last reviewed longer ago than the configured window — and
+// either auto-opens a campaign (system-actored) or reminds the project's admins to,
+// and nudges admins of in-flight campaigns that still have pending items.
+package core
+
+import (
+	"context"
+	"fmt"
+)
+
+// DefaultRecertificationCadenceDays is the review interval assumed when none is
+// configured (a quarter — a common recertification cadence).
+const DefaultRecertificationCadenceDays = 90
+
+// NotificationRecertificationDue marks an in-app recertification reminder.
+const NotificationRecertificationDue = "access_review.recertification_due"
+
+// RecertificationResult reports what one scheduled run did.
+type RecertificationResult struct {
+	Opened   int `json:"opened"`   // campaigns auto-opened for overdue projects
+	Reminded int `json:"reminded"` // admin notifications sent
+}
+
+// SetRecertificationCadence records the review cadence (days) so the compliance
+// posture can flag overdue projects. 0 leaves the default in effect.
+func (c *KeyorixCore) SetRecertificationCadence(days int) {
+	c.recertCadenceDays = days
+}
+
+// recertCadence returns the effective cadence in days (the configured value, or the
+// default when unset).
+func (c *KeyorixCore) recertCadence() int {
+	if c.recertCadenceDays > 0 {
+		return c.recertCadenceDays
+	}
+	return DefaultRecertificationCadenceDays
+}
+
+// RunScheduledRecertification enforces the recertification cadence across every
+// project. For each project it determines whether access is "due" — never reviewed,
+// or the most recent campaign closed more than cadenceDays ago — and that no
+// campaign is currently open. For a due project: when autoOpen it opens a fresh
+// campaign (system-actored) and notifies the project's admins; otherwise it notifies
+// them that a review is due. Separately, a project whose open campaign still has
+// pending items prompts a reminder to finish it. Admin reminders de-dupe against an
+// existing unread recertification notification so they don't pile up. Returns the
+// number of campaigns opened and admins notified. Auto-open is a create, not a
+// delete, so this is NOT legal-hold-gated.
+func (c *KeyorixCore) RunScheduledRecertification(ctx context.Context, cadenceDays int, autoOpen bool) (*RecertificationResult, error) {
+	if cadenceDays <= 0 {
+		cadenceDays = DefaultRecertificationCadenceDays
+	}
+	projects, err := c.ListProjects(ctx)
+	if err != nil {
+		return nil, err
+	}
+	res := &RecertificationResult{}
+	cutoff := c.now().AddDate(0, 0, -cadenceDays)
+
+	for _, proj := range projects {
+		pid := proj.ID
+		campaigns, err := c.ListAccessReviewCampaigns(ctx, pid)
+		if err != nil {
+			continue // a per-project read error must not abort the whole sweep
+		}
+		open, lastClosed := splitCampaigns(campaigns)
+
+		// A review is already in progress — nudge admins only if items remain.
+		if open != nil {
+			if open.Progress.Pending > 0 {
+				res.Reminded += c.remindRecertificationAdmins(ctx, pid,
+					fmt.Sprintf("Access recertification for %s has %d item(s) still pending review.",
+						c.projectLabel(ctx, pid), open.Progress.Pending))
+			}
+			continue
+		}
+
+		// No open campaign — is the project due for one?
+		due := lastClosed == nil // never reviewed
+		if lastClosed != nil && lastClosed.Campaign.ClosedAt != nil {
+			due = lastClosed.Campaign.ClosedAt.Before(cutoff)
+		}
+		if !due {
+			continue
+		}
+
+		if autoOpen {
+			name := fmt.Sprintf("Scheduled recertification %s", c.now().Format("2006-01-02"))
+			if _, err := c.OpenAccessReviewCampaign(WithActorType(ctx, ActorTypeSystem), 0, pid, name); err != nil {
+				continue
+			}
+			res.Opened++
+			res.Reminded += c.remindRecertificationAdmins(ctx, pid,
+				fmt.Sprintf("A scheduled access-recertification campaign was opened for %s — please review and attest the listed access.",
+					c.projectLabel(ctx, pid)))
+		} else {
+			res.Reminded += c.remindRecertificationAdmins(ctx, pid,
+				fmt.Sprintf("Access in %s is due for recertification (ISO 27001 A.5.18) — please open a review campaign.",
+					c.projectLabel(ctx, pid)))
+		}
+	}
+	return res, nil
+}
+
+// splitCampaigns returns the open campaign (if any) and the most-recent closed one.
+// The list is newest-first, so the first match in each case is the latest.
+func splitCampaigns(campaigns []*CampaignWithProgress) (open *CampaignWithProgress, lastClosed *CampaignWithProgress) {
+	for _, cw := range campaigns {
+		if cw.Campaign.State == CampaignStateOpen {
+			if open == nil {
+				open = cw
+			}
+			continue
+		}
+		if lastClosed == nil {
+			lastClosed = cw
+		}
+	}
+	return open, lastClosed
+}
+
+// remindRecertificationAdmins sends one standing reminder to each of the project's
+// admins, skipping any who already hold an unread one. Returns the number sent.
+func (c *KeyorixCore) remindRecertificationAdmins(ctx context.Context, projectID uint, msg string) int {
+	members, err := c.storage.ListProjectMembers(ctx, projectID)
+	if err != nil {
+		return 0
+	}
+	pid := projectID
+	sent := 0
+	for _, mbr := range members {
+		if !isApproverRole(mbr.RoleName) {
+			continue
+		}
+		if c.hasUnreadRecertificationReminder(ctx, mbr.UserID, projectID) {
+			continue
+		}
+		c.notify(ctx, mbr.UserID, NotificationRecertificationDue,
+			"Access recertification", msg, &pid, "/projects")
+		sent++
+	}
+	return sent
+}
+
+// hasUnreadRecertificationReminder reports whether the user already holds an unread
+// recertification reminder for the project.
+func (c *KeyorixCore) hasUnreadRecertificationReminder(ctx context.Context, userID, projectID uint) bool {
+	notes, err := c.storage.ListNotifications(ctx, userID, true, 100)
+	if err != nil {
+		return false // on a read error, prefer notifying over silently skipping
+	}
+	for _, n := range notes {
+		if n.Type == NotificationRecertificationDue && n.ProjectID != nil && *n.ProjectID == projectID {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/core/recertification_external_test.go
+++ b/internal/core/recertification_external_test.go
@@ -1,0 +1,88 @@
+package core_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/testhelper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func hasOpenCampaign(campaigns []*core.CampaignWithProgress) bool {
+	for _, c := range campaigns {
+		if c.Campaign.State == core.CampaignStateOpen {
+			return true
+		}
+	}
+	return false
+}
+
+// A never-reviewed project with an admin gets one reminder; a second run does not
+// re-notify (the admin still holds an unread one).
+func TestRunScheduledRecertification_RemindsAndDedupes(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	migrateCampaignTables(t, h)
+	require.NoError(t, h.DB.AutoMigrate(&models.Notification{}))
+
+	ctx := context.Background()
+	h.CreateTestUser(t, "carol", 20)
+	h.AssignUserRole(t, 20, 2, uptr(2)) // admin on project 2 (role 2 = "admin")
+
+	res, err := h.CoreService.RunScheduledRecertification(ctx, 90, false)
+	require.NoError(t, err)
+	assert.Equal(t, 0, res.Opened, "auto_open off → nothing opened")
+	assert.GreaterOrEqual(t, res.Reminded, 1, "project 2's admin is reminded")
+
+	// The admin holds an unread recertification reminder for project 2.
+	notes, err := h.CoreService.Storage().ListNotifications(ctx, 20, true, 100)
+	require.NoError(t, err)
+	found := false
+	for _, n := range notes {
+		if n.Type == core.NotificationRecertificationDue && n.ProjectID != nil && *n.ProjectID == 2 {
+			found = true
+		}
+	}
+	assert.True(t, found, "carol has an unread recertification reminder for project 2")
+
+	res2, err := h.CoreService.RunScheduledRecertification(ctx, 90, false)
+	require.NoError(t, err)
+	assert.Equal(t, 0, res2.Reminded, "an unread reminder suppresses a duplicate")
+}
+
+// With auto_open on, an overdue project (last campaign closed > cadence ago) gets a
+// fresh open campaign, while a recently-reviewed project does not.
+func TestRunScheduledRecertification_AutoOpensOverdueNotRecent(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	migrateCampaignTables(t, h)
+	require.NoError(t, h.DB.AutoMigrate(&models.Notification{}))
+
+	ctx := context.Background()
+	now := time.Now()
+	oldClosed := now.AddDate(0, 0, -200)   // overdue under a 90-day cadence
+	recentClosed := now.AddDate(0, 0, -10) // within the cadence
+
+	require.NoError(t, h.DB.Create(&models.AccessReviewCampaign{
+		ProjectID: 2, Name: "old", State: core.CampaignStateClosed, ClosedAt: &oldClosed,
+	}).Error)
+	require.NoError(t, h.DB.Create(&models.AccessReviewCampaign{
+		ProjectID: 3, Name: "recent", State: core.CampaignStateClosed, ClosedAt: &recentClosed,
+	}).Error)
+
+	res, err := h.CoreService.RunScheduledRecertification(ctx, 90, true)
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, res.Opened, 1)
+
+	camps2, err := h.CoreService.ListAccessReviewCampaigns(ctx, 2)
+	require.NoError(t, err)
+	assert.True(t, hasOpenCampaign(camps2), "overdue project 2 gets a fresh open campaign")
+
+	camps3, err := h.CoreService.ListAccessReviewCampaigns(ctx, 3)
+	require.NoError(t, err)
+	assert.False(t, hasOpenCampaign(camps3), "recently-reviewed project 3 is left alone")
+}

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -56,6 +56,10 @@ type KeyorixCore struct {
 	// (ISO A.5.33) so the compliance posture can report them; zero value = no
 	// retention configured. Set from config at startup via SetRetentionPolicy.
 	retentionPolicy RetentionPolicy
+	// recertCadenceDays is the access-recertification review interval (ISO A.5.18),
+	// in days; 0 = the default cadence. Used by the posture to flag overdue projects.
+	// Set from config at startup via SetRecertificationCadence.
+	recertCadenceDays int
 	// oidcVerifier verifies federated machine-identity JWTs (ADR-031); nil = OIDC
 	// auth disabled. Set from config via SetOIDCVerifier.
 	oidcVerifier *OIDCVerifier

--- a/server/http/handlers/openapi.yaml
+++ b/server/http/handlers/openapi.yaml
@@ -2818,7 +2818,8 @@ paths:
         A deployment-wide, on-demand snapshot of the control posture for auditors,
         rolling up: audit-trail integrity (chain verified, chained events,
         checkpointed), access governance (projects, with-open-campaign,
-        never-reviewed, open campaigns + pending items, dormant role grants,
+        never-reviewed, projects overdue for recertification (A.5.18 cadence),
+        open campaigns + pending items, dormant role grants,
         separation-of-duties violations), rotation hygiene (covered secrets,
         overdue, due-soon), identity
         (active users, with-second-factor + percent), emergency access

--- a/server/main.go
+++ b/server/main.go
@@ -143,6 +143,7 @@ const (
 	schedLockJITExpiry    int64 = 0x4B455953_4A495445 // "KEYSJITE"
 	schedLockRetention    int64 = 0x4B455953_52455445 // "KEYSRETE"
 	schedLockEvidence     int64 = 0x4B455953_45564944 // "KEYSEVID"
+	schedLockRecertify    int64 = 0x4B455953_52454354 // "KEYSRECT"
 )
 
 // initializeEncryption sources the KEK per the configured key provider (ADR-038)
@@ -281,6 +282,10 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 		BreakGlassDays:             cfg.DataRetention.BreakGlassDays,
 		ResolvedAccessRequestsDays: cfg.DataRetention.ResolvedAccessRequestsDays,
 	})
+
+	// Wire the access-recertification cadence (A.5.18) so the posture flags overdue
+	// projects; the scheduler below acts on it when enabled.
+	coreService.SetRecertificationCadence(cfg.Recertification.CadenceDays)
 
 	// Wire the credential-delivery channel (ADR-028). New selects out-of-band/SMTP/
 	// log from the configured mode and fails loud on a bad mode (e.g. smtp with no
@@ -542,6 +547,47 @@ func startHTTPServer(ctx context.Context, cfg *config.Config) error {
 				select {
 				case <-ticker.C:
 					runReminders()
+				case <-ctx.Done():
+					return
+				}
+			}
+		}()
+	}
+
+	// Start the scheduled access-recertification scheduler (ISO 27001 A.5.18) —
+	// opt-in. Finds projects overdue for review and either auto-opens a recert
+	// campaign (when auto_open) or reminds the project's admins to; also nudges
+	// admins of in-flight campaigns with pending items. A create/notify, not a
+	// delete, so NOT legal-hold-gated. Single-replica-gated (ADR-039) so a campaign
+	// is opened once per project per tick in HA.
+	if cfg.Recertification.Enabled {
+		interval := cfg.Recertification.GetInterval()
+		cadence := cfg.Recertification.CadenceDays
+		autoOpen := cfg.Recertification.AutoOpen
+		log.Printf("Recertification scheduler enabled: every %s (cadence %dd, auto_open=%t)", interval, cadence, autoOpen)
+		go func() {
+			ticker := time.NewTicker(interval)
+			defer ticker.Stop()
+			runRecert := func() {
+				if _, err := coreService.Storage().WithSchedulerLock(ctx, schedLockRecertify, func() error {
+					res, rerr := coreService.RunScheduledRecertification(ctx, cadence, autoOpen)
+					if rerr != nil {
+						log.Printf("Recertification error: %v", rerr)
+						return rerr
+					}
+					if res.Opened > 0 || res.Reminded > 0 {
+						log.Printf("Recertification: opened %d campaign(s), sent %d reminder(s)", res.Opened, res.Reminded)
+					}
+					return nil
+				}); err != nil {
+					log.Printf("Recertification scheduler error: %v", err)
+				}
+			}
+			runRecert() // run once on startup
+			for {
+				select {
+				case <-ticker.C:
+					runRecert()
 				case <-ctx.Done():
 					return
 				}


### PR DESCRIPTION
## What

Turns access recertification from a manual action into an **enforced cadence** (ISO 27001 A.5.18, "review access rights at planned intervals"). Campaigns already existed (open → decide → close); this finds projects that are *due* for review and acts on them.

## How

- **config** — `recertification {enabled, schedule, cadence_days, auto_open}`.
- **core** — `RunScheduledRecertification` walks every project. A project is *due* if it was never reviewed, or its most-recent campaign closed more than `cadence_days` ago, and no campaign is currently open. For a due project: when `auto_open` it opens a fresh **system-actored** campaign (snapshotting current access); otherwise it reminds the project's admins to. It also nudges admins of an in-flight campaign that still has pending items. Reminders de-dupe against an unread one (mirrors the rotation-reminder pattern). A create/notify, not a delete → **not** legal-hold-gated.
- **posture** — `AccessGovernance.ProjectsOverdue`, driven by a cadence set from config, surfaced in `keyorix compliance report` (Access governance → "overdue for recert") and the OpenAPI description — so the overdue signal is visible to auditors even before `auto_open` is enabled.
- **scheduler** (`main.go`) — opt-in, single-replica-gated (ADR-039, new lock id); runs once on startup then on the interval.

## Tests

- A never-reviewed project reminds its admin and de-dupes on re-run.
- `auto_open` opens a campaign for an overdue project (last close > cadence) but leaves a recently-reviewed one untouched.
- Full suite green (only the known local-only `/sw.js` route-test artifact, green in CI).

Batch 1 of 4 (recertification → notification channels → evidence sinks → classification UX), per "lets do 1 2 4 3".

🤖 Generated with [Claude Code](https://claude.com/claude-code)