### PR TITLE
feat(notify): external notification channels — webhook (A.5.5 / SOC 2)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -16,7 +16,7 @@ The config file is located via, in order: an explicit path argument, then
 - [secrets](#secrets) · [security + require_mfa](#security) (ADR-034)
 - [webauthn](#webauthn) (ADR-036) · [dynamic_secrets](#dynamic_secrets) (ADR-035)
 - [oidc](#oidc) (ADR-031) · [session](#session) · [password_policy](#password_policy) (ADR-025)
-- [soft_delete + purge](#soft_delete--purge) (ADR-032) · [data_retention](#data_retention) (A.5.33) · [recertification](#recertification) (A.5.18) · [evidence_delivery](#evidence_delivery) · [rotation_reminders](#rotation_reminders) · [audit_checkpoints](#audit_checkpoints) (ADR-029) · [jit_access_expiry](#jit_access_expiry) · [break_glass](#break_glass) · [audit.siem](#auditsiem)
+- [soft_delete + purge](#soft_delete--purge) (ADR-032) · [data_retention](#data_retention) (A.5.33) · [recertification](#recertification) (A.5.18) · [notifications](#notifications) · [evidence_delivery](#evidence_delivery) · [rotation_reminders](#rotation_reminders) · [audit_checkpoints](#audit_checkpoints) (ADR-029) · [jit_access_expiry](#jit_access_expiry) · [break_glass](#break_glass) · [audit.siem](#auditsiem)
 - [membership](#membership) (ADR-022) · [credential_delivery](#credential_delivery) (ADR-028)
 
 ---
@@ -370,6 +370,31 @@ recertification:
   cadence_days: 90       # a project is due this many days after its last campaign closed (default 90)
   auto_open: false       # true = auto-open a campaign for overdue projects; false = remind admins only
 ```
+
+## notifications
+
+External delivery channels for the in-app notifications Keyorix already creates —
+access-request approvals, anomaly alerts, rotation and recertification reminders, and
+break-glass activations (ISO 27001 A.5.5 / SOC 2 operational alerting). Each
+notification is still written to the in-app bell; when a channel is enabled it is
+**also** fanned out, best-effort and asynchronously (a slow or down endpoint drops
+rather than stalling the triggering action).
+
+The **webhook** channel POSTs each notification as a JSON body
+(`{user_id, email, type, title, message, project_id, link}`) to `endpoint`,
+optionally bearer-authenticated.
+
+```yaml
+notifications:
+  webhook:
+    enabled: true
+    endpoint: "https://hooks.example.com/keyorix"
+    token: ""                    # prefer the KEYORIX_NOTIFY_WEBHOOK_TOKEN env var
+    insecure_skip_verify: false  # TLS verification off — self-signed endpoints only
+```
+
+> The webhook token is read from `KEYORIX_NOTIFY_WEBHOOK_TOKEN` when set, falling
+> back to the YAML value — keep secrets out of the config file.
 
 ## evidence_delivery
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -50,6 +50,9 @@ type Config struct {
 	// cadence (ISO 27001 A.5.18): reminding admins of (or auto-opening) recert
 	// campaigns for projects overdue for review.
 	Recertification RecertificationConfig `yaml:"recertification"`
+	// Notifications configures external delivery (email/webhook) of the in-app
+	// notifications Keyorix creates (approvals, anomalies, reminders, break-glass).
+	Notifications NotificationsConfig `yaml:"notifications"`
 	// DynamicSecrets configures the on-demand database-credentials engine and its
 	// auto-revoke sweep (ADR-035). Disabled (zero value) = the API is still served
 	// but no background sweeper runs; enable to auto-revoke leases at expiry.
@@ -557,6 +560,27 @@ func (c RecertificationConfig) GetInterval() time.Duration {
 		}
 	}
 	return 24 * time.Hour
+}
+
+// NotificationsConfig configures external delivery channels for in-app
+// notifications (ISO 27001 A.5.5 / SOC 2 operational alerting). Each channel is
+// opt-in; with none enabled, notifications remain in-app only.
+type NotificationsConfig struct {
+	Webhook NotificationWebhookConfig `yaml:"webhook"`
+}
+
+// NotificationWebhookConfig configures the webhook notification channel: each
+// notification is POSTed as JSON to Endpoint, optionally bearer-authenticated.
+type NotificationWebhookConfig struct {
+	Enabled            bool   `yaml:"enabled"`
+	Endpoint           string `yaml:"endpoint"`
+	Token              string `yaml:"token"` // use KEYORIX_NOTIFY_WEBHOOK_TOKEN env var instead
+	InsecureSkipVerify bool   `yaml:"insecure_skip_verify"`
+}
+
+// GetToken returns the resolved webhook token, preferring the environment variable.
+func (c *NotificationWebhookConfig) GetToken() string {
+	return resolveSecret("KEYORIX_NOTIFY_WEBHOOK_TOKEN", c.Token)
 }
 
 // RotationRemindersConfig configures the rotation-reminder scheduler: a background

--- a/internal/core/notification_dispatch_test.go
+++ b/internal/core/notification_dispatch_test.go
@@ -1,0 +1,53 @@
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeSink struct{ events []NotificationEvent }
+
+func (f *fakeSink) Deliver(ev NotificationEvent) { f.events = append(f.events, ev) }
+
+func TestNotify_DispatchesToSinkWithResolvedEmail(t *testing.T) {
+	store := new(MockStorage)
+	store.On("CreateNotification", mock.Anything, mock.Anything).Return(&models.Notification{ID: 1}, nil)
+	store.On("GetUser", mock.Anything, uint(7)).Return(&models.User{ID: 7, Email: "ada@x.io"}, nil)
+
+	c := NewKeyorixCore(store)
+	sink := &fakeSink{}
+	c.SetNotificationSink(sink)
+
+	pid := uint(3)
+	c.notify(context.Background(), 7, NotificationAccessApproved, "Approved", "Your request was approved", &pid, "/projects/3")
+
+	require.Len(t, sink.events, 1)
+	ev := sink.events[0]
+	assert.Equal(t, uint(7), ev.UserID)
+	assert.Equal(t, "ada@x.io", ev.Email, "the recipient's email is resolved for the channel")
+	assert.Equal(t, NotificationAccessApproved, ev.Type)
+	require.NotNil(t, ev.ProjectID)
+	assert.Equal(t, uint(3), *ev.ProjectID)
+}
+
+func TestNotify_NoSink_SkipsDispatchAndEmailLookup(t *testing.T) {
+	store := new(MockStorage)
+	store.On("CreateNotification", mock.Anything, mock.Anything).Return(&models.Notification{ID: 1}, nil)
+	// No sink wired → GetUser must never be called (no needless query per notification).
+	c := NewKeyorixCore(store)
+	c.notify(context.Background(), 7, "x", "t", "m", nil, "")
+	store.AssertNotCalled(t, "GetUser", mock.Anything, mock.Anything)
+}
+
+func TestNotify_ZeroUser_DoesNothing(t *testing.T) {
+	store := new(MockStorage)
+	c := NewKeyorixCore(store)
+	c.SetNotificationSink(&fakeSink{})
+	c.notify(context.Background(), 0, "x", "t", "m", nil, "")
+	store.AssertNotCalled(t, "CreateNotification", mock.Anything, mock.Anything)
+}

--- a/internal/core/notifications.go
+++ b/internal/core/notifications.go
@@ -2,8 +2,9 @@
 //
 // Notifications are addressed to a single user and surfaced via the header bell.
 // Emission is best-effort: a delivery failure never blocks the action that
-// triggered it (same contract as audit emission). Delivery is in-app only;
-// email/Slack/Teams fan-out is an M3+ follow-up.
+// triggered it (same contract as audit emission). In addition to the in-app row,
+// notify() fans each event out to a configured external channel (email/webhook)
+// when a NotificationSink is wired.
 package core
 
 import (
@@ -48,6 +49,28 @@ func (c *KeyorixCore) notify(ctx context.Context, userID uint, nType, title, mes
 		Link:      link,
 		CreatedAt: c.now(),
 	})
+	c.dispatchNotification(ctx, userID, nType, title, message, projectID, link)
+}
+
+// dispatchNotification fans a notification out to the configured external channel
+// (email/webhook), resolving the recipient's email best-effort. A no-op when no
+// sink is wired; the sink itself is non-blocking, so this never delays the caller.
+func (c *KeyorixCore) dispatchNotification(ctx context.Context, userID uint, nType, title, message string, projectID *uint, link string) {
+	if c.notificationSink == nil {
+		return
+	}
+	ev := NotificationEvent{
+		UserID:    userID,
+		Type:      nType,
+		Title:     title,
+		Message:   message,
+		ProjectID: projectID,
+		Link:      link,
+	}
+	if u, err := c.storage.GetUser(ctx, userID); err == nil && u != nil {
+		ev.Email = u.Email
+	}
+	c.notificationSink.Deliver(ev)
 }
 
 // projectLabel returns a human label for a project ("Payments" or "#3").

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -46,6 +46,9 @@ type KeyorixCore struct {
 	now            func() time.Time // For testability
 	passwordPolicy PasswordPolicy
 	auditForwarder AuditForwarder
+	// notificationSink fans each in-app notification out to an external channel
+	// (email/webhook). nil = in-app only. Set from config via SetNotificationSink.
+	notificationSink NotificationSink
 	// breakGlassPolicy configures self-service emergency access; zero value =
 	// disabled. Set from config at startup via SetBreakGlassPolicy.
 	breakGlassPolicy BreakGlassPolicy
@@ -113,6 +116,33 @@ func (c *KeyorixCore) emitAudit(ctx context.Context, event *models.AuditEvent) {
 	if c.auditForwarder != nil {
 		c.auditForwarder.Forward(event)
 	}
+}
+
+// NotificationEvent is one user-facing notification handed to an external sink for
+// out-of-band delivery (email/webhook) alongside the persisted in-app row.
+type NotificationEvent struct {
+	UserID    uint   `json:"user_id"`
+	Email     string `json:"email,omitempty"` // recipient's address, resolved best-effort
+	Type      string `json:"type"`
+	Title     string `json:"title"`
+	Message   string `json:"message"`
+	ProjectID *uint  `json:"project_id,omitempty"`
+	Link      string `json:"link,omitempty"`
+}
+
+// NotificationSink delivers a NotificationEvent to an external channel (email,
+// webhook, …). Like AuditForwarder, implementations MUST be non-blocking and
+// best-effort: Deliver runs on the notification path and must never block or fail
+// the triggering operation. Defined here (not in the channel package) so core has
+// no dependency on the channel implementations.
+type NotificationSink interface {
+	Deliver(ev NotificationEvent)
+}
+
+// SetNotificationSink wires an external notification sink. The server calls this at
+// startup when the install configures a notifications channel. nil = in-app only.
+func (c *KeyorixCore) SetNotificationSink(s NotificationSink) {
+	c.notificationSink = s
 }
 
 // NewKeyorixCore creates a new instance of the core business logic.

--- a/internal/notifychan/webhook.go
+++ b/internal/notifychan/webhook.go
@@ -1,0 +1,127 @@
+// Package notifychan implements external notification channels (ISO 27001 A.5.5 /
+// SOC 2 — operational alerting): out-of-band delivery of the in-app notifications
+// Keyorix already creates (approvals, anomalies, rotation/recertification reminders,
+// break-glass) so they reach admins where they actually work, not just the header
+// bell. Each channel implements core.NotificationSink.
+//
+// WebhookSink mirrors the SIEM audit forwarder: a bounded queue drained by a worker
+// goroutine that POSTs the notification as JSON, so Deliver never blocks the
+// triggering operation and a slow/0down endpoint drops rather than stalls.
+package notifychan
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+)
+
+const (
+	webhookTimeout   = 10 * time.Second
+	webhookQueueSize = 256
+)
+
+// WebhookConfig configures the webhook notification channel.
+type WebhookConfig struct {
+	Endpoint           string // full destination URL (POST target)
+	Token              string // optional bearer token (Authorization: Bearer <token>)
+	InsecureSkipVerify bool   // skip TLS verification (test/self-signed only)
+}
+
+// WebhookSink delivers notifications to an HTTP endpoint as JSON, asynchronously.
+type WebhookSink struct {
+	cfg     WebhookConfig
+	client  *http.Client
+	queue   chan core.NotificationEvent
+	wg      sync.WaitGroup
+	mu      sync.Mutex
+	dropped int
+}
+
+// NewWebhook builds a webhook sink and starts its delivery worker. The endpoint is
+// required. The returned sink must be Close()d at shutdown to drain in-flight events.
+func NewWebhook(cfg WebhookConfig) (*WebhookSink, error) {
+	if cfg.Endpoint == "" {
+		return nil, fmt.Errorf("notifychan: webhook endpoint is required")
+	}
+	transport := &http.Transport{}
+	if cfg.InsecureSkipVerify {
+		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} // #nosec G402 -- opt-in for self-signed endpoints
+	}
+	s := &WebhookSink{
+		cfg:    cfg,
+		client: &http.Client{Timeout: webhookTimeout, Transport: transport},
+		queue:  make(chan core.NotificationEvent, webhookQueueSize),
+	}
+	s.wg.Add(1)
+	go s.worker()
+	return s, nil
+}
+
+// Deliver enqueues the event for asynchronous POST. Non-blocking: if the queue is
+// full (a wedged endpoint) the event is dropped and counted, never stalling the
+// caller.
+func (s *WebhookSink) Deliver(ev core.NotificationEvent) {
+	if s == nil {
+		return
+	}
+	select {
+	case s.queue <- ev:
+	default:
+		s.mu.Lock()
+		s.dropped++
+		dropped := s.dropped
+		s.mu.Unlock()
+		log.Printf("notifychan: webhook queue full, dropped notification (total dropped: %d)", dropped)
+	}
+}
+
+func (s *WebhookSink) worker() {
+	defer s.wg.Done()
+	for ev := range s.queue {
+		if err := s.send(context.Background(), ev); err != nil {
+			log.Printf("notifychan: webhook delivery failed: %v", err)
+		}
+	}
+}
+
+func (s *WebhookSink) send(ctx context.Context, ev core.NotificationEvent) error {
+	body, err := json.Marshal(ev)
+	if err != nil {
+		return fmt.Errorf("marshal notification: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.cfg.Endpoint, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if s.cfg.Token != "" {
+		req.Header.Set("Authorization", "Bearer "+s.cfg.Token)
+	}
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("webhook endpoint returned %s", strings.TrimSpace(resp.Status))
+	}
+	return nil
+}
+
+// Close stops the worker after draining queued events.
+func (s *WebhookSink) Close() {
+	if s == nil {
+		return
+	}
+	close(s.queue)
+	s.wg.Wait()
+}

--- a/internal/notifychan/webhook_test.go
+++ b/internal/notifychan/webhook_test.go
@@ -1,0 +1,84 @@
+package notifychan
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWebhookSink_DeliversJSONWithBearerAuth(t *testing.T) {
+	var (
+		mu    sync.Mutex
+		body  []byte
+		auth  string
+		ctype string
+		hits  int
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		body, auth, ctype, hits = b, r.Header.Get("Authorization"), r.Header.Get("Content-Type"), hits+1
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	sink, err := NewWebhook(WebhookConfig{Endpoint: srv.URL, Token: "secret-tok"})
+	require.NoError(t, err)
+
+	pid := uint(3)
+	sink.Deliver(core.NotificationEvent{
+		UserID: 7, Email: "ada@x.io", Type: "access_request.approved",
+		Title: "Approved", Message: "ok", ProjectID: &pid, Link: "/projects/3",
+	})
+	sink.Close() // drains the queue before returning
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, 1, hits)
+	assert.Equal(t, "Bearer secret-tok", auth)
+	assert.Equal(t, "application/json", ctype)
+
+	var ev core.NotificationEvent
+	require.NoError(t, json.Unmarshal(body, &ev))
+	assert.Equal(t, uint(7), ev.UserID)
+	assert.Equal(t, "ada@x.io", ev.Email)
+	assert.Equal(t, "access_request.approved", ev.Type)
+	require.NotNil(t, ev.ProjectID)
+	assert.Equal(t, uint(3), *ev.ProjectID)
+}
+
+func TestWebhookSink_NoTokenOmitsAuthHeader(t *testing.T) {
+	var (
+		mu   sync.Mutex
+		auth string
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		auth = r.Header.Get("Authorization")
+		mu.Unlock()
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	sink, err := NewWebhook(WebhookConfig{Endpoint: srv.URL})
+	require.NoError(t, err)
+	sink.Deliver(core.NotificationEvent{UserID: 1, Type: "x"})
+	sink.Close()
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Empty(t, auth)
+}
+
+func TestNewWebhook_RequiresEndpoint(t *testing.T) {
+	_, err := NewWebhook(WebhookConfig{})
+	require.Error(t, err)
+}

--- a/server/main.go
+++ b/server/main.go
@@ -40,6 +40,7 @@ import (
 	"github.com/keyorixhq/keyorix/internal/delivery"
 	"github.com/keyorixhq/keyorix/internal/encryption"
 	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/notifychan"
 	appstorage "github.com/keyorixhq/keyorix/internal/storage"
 	"github.com/keyorixhq/keyorix/server/grpc"
 	httpServer "github.com/keyorixhq/keyorix/server/http"
@@ -239,6 +240,22 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 		}
 		coreService.SetAuditForwarder(forwarder)
 		log.Printf("SIEM audit forwarding enabled (provider=%s)", sc.Provider)
+	}
+
+	// Wire external notification channels if configured. Each in-app notification is
+	// fanned out to the channel (best-effort, async); with none enabled it stays
+	// in-app only.
+	if wc := cfg.Notifications.Webhook; wc.Enabled {
+		sink, werr := notifychan.NewWebhook(notifychan.WebhookConfig{
+			Endpoint:           wc.Endpoint,
+			Token:              wc.GetToken(),
+			InsecureSkipVerify: wc.InsecureSkipVerify,
+		})
+		if werr != nil {
+			return nil, nil, fmt.Errorf("failed to init notification webhook channel: %w", werr)
+		}
+		coreService.SetNotificationSink(sink)
+		log.Printf("Notification webhook channel enabled (endpoint=%s)", wc.Endpoint)
 	}
 
 	// Apply the project membership validation mode (ADR-022). Empty = allowlist.


### PR DESCRIPTION
## What

In-app notifications (approvals, anomaly alerts, rotation/recertification reminders, break-glass) were **bell-only** — an admin not watching the console missed them. This adds a notification-sink abstraction and the first external channel: **webhook**.

Part 1 of batch 2 (notification channels); the **email** channel follows in a stacked PR.

## How

- **core** — `NotificationSink` interface + `NotificationEvent` (mirrors `AuditForwarder`); a `notificationSink` field + `SetNotificationSink`. `notify()` now also fans each event out via `dispatchNotification` (best-effort, resolving the recipient's email), and is a **no-op with no extra query** when no sink is wired — so existing behavior is unchanged unless a channel is enabled.
- **internal/notifychan** — `WebhookSink` mirrors the SIEM forwarder: a bounded queue drained by a worker goroutine that POSTs the notification as JSON (optional `Bearer` token, `InsecureSkipVerify`). `Deliver` never blocks the triggering action; a wedged endpoint **drops** rather than stalls. `Close()` drains on shutdown.
- **config** — `notifications.webhook {enabled, endpoint, token, insecure_skip_verify}`; token from `KEYORIX_NOTIFY_WEBHOOK_TOKEN`. Wired in `main.go` next to the SIEM forwarder.
- **docs** — `CONFIGURATION.md` notifications section.

## Tests

- `notify()` dispatches with resolved email; skips dispatch + the email lookup entirely when no sink; no-ops for user 0.
- Webhook delivers JSON with `Bearer` auth, omits the header without a token, and requires an endpoint.

Batch 2 of 4 (part a), per "lets do 1 2 4 3".

🤖 Generated with [Claude Code](https://claude.com/claude-code)