### PR TITLE
feat(notify): SMTP email notification channel + multi-channel fan-out (A.5.5)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -380,9 +380,11 @@ notification is still written to the in-app bell; when a channel is enabled it i
 **also** fanned out, best-effort and asynchronously (a slow or down endpoint drops
 rather than stalling the triggering action).
 
-The **webhook** channel POSTs each notification as a JSON body
+Two channels are available; enable either or both (both → each notification is
+delivered to all). The **webhook** channel POSTs each notification as a JSON body
 (`{user_id, email, type, title, message, project_id, link}`) to `endpoint`,
-optionally bearer-authenticated.
+optionally bearer-authenticated. The **email** channel sends a plaintext message to
+the recipient via the operator's SMTP relay (same settings as `credential_delivery`).
 
 ```yaml
 notifications:
@@ -391,10 +393,18 @@ notifications:
     endpoint: "https://hooks.example.com/keyorix"
     token: ""                    # prefer the KEYORIX_NOTIFY_WEBHOOK_TOKEN env var
     insecure_skip_verify: false  # TLS verification off — self-signed endpoints only
+  email:
+    enabled: true
+    host: "smtp.example.com"
+    port: 587
+    username: "keyorix"
+    password: ""                 # prefer the KEYORIX_NOTIFY_SMTP_PASSWORD env var
+    from: "keyorix@example.com"
+    tls: "starttls"              # starttls | implicit | none(dev-only)
 ```
 
-> The webhook token is read from `KEYORIX_NOTIFY_WEBHOOK_TOKEN` when set, falling
-> back to the YAML value — keep secrets out of the config file.
+> Secrets are read from `KEYORIX_NOTIFY_WEBHOOK_TOKEN` / `KEYORIX_NOTIFY_SMTP_PASSWORD`
+> when set, falling back to the YAML value — keep secrets out of the config file.
 
 ## evidence_delivery
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -564,9 +564,29 @@ func (c RecertificationConfig) GetInterval() time.Duration {
 
 // NotificationsConfig configures external delivery channels for in-app
 // notifications (ISO 27001 A.5.5 / SOC 2 operational alerting). Each channel is
-// opt-in; with none enabled, notifications remain in-app only.
+// opt-in; with none enabled, notifications remain in-app only. When more than one
+// is enabled, each notification is fanned out to all of them.
 type NotificationsConfig struct {
 	Webhook NotificationWebhookConfig `yaml:"webhook"`
+	Email   NotificationEmailConfig   `yaml:"email"`
+}
+
+// NotificationEmailConfig configures the SMTP notification channel: each
+// notification is emailed (plaintext) to the recipient via the operator's relay.
+// Mirrors the credential-delivery SMTP settings (ADR-028).
+type NotificationEmailConfig struct {
+	Enabled  bool   `yaml:"enabled"`
+	Host     string `yaml:"host"`
+	Port     int    `yaml:"port"`
+	Username string `yaml:"username"`
+	Password string `yaml:"password"` // use KEYORIX_NOTIFY_SMTP_PASSWORD env var instead
+	From     string `yaml:"from"`
+	TLS      string `yaml:"tls"` // starttls | implicit | none(dev-only)
+}
+
+// GetPassword returns the resolved SMTP password, preferring the environment variable.
+func (c *NotificationEmailConfig) GetPassword() string {
+	return resolveSecret("KEYORIX_NOTIFY_SMTP_PASSWORD", c.Password)
 }
 
 // NotificationWebhookConfig configures the webhook notification channel: each

--- a/internal/notifychan/email.go
+++ b/internal/notifychan/email.go
@@ -1,0 +1,165 @@
+// email.go — the SMTP notification channel. Like the credential-delivery mailer
+// (ADR-028) it delegates TLS correctness to wneessen/go-mail rather than hand-
+// rolling net/smtp. Sending is asynchronous (a bounded queue drained by a worker)
+// so Deliver never blocks the triggering action; events without a recipient email
+// are skipped.
+package notifychan
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+	"sync"
+	"time"
+
+	mail "github.com/wneessen/go-mail"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+)
+
+const (
+	emailTimeout   = 10 * time.Second
+	emailQueueSize = 256
+)
+
+// EmailConfig configures the SMTP notification channel.
+type EmailConfig struct {
+	Host     string
+	Port     int
+	Username string
+	Password string
+	From     string
+	TLS      string // starttls | implicit | none(dev-only)
+}
+
+// EmailSink delivers notifications as plaintext email via the operator's SMTP relay.
+type EmailSink struct {
+	cfg     EmailConfig
+	queue   chan core.NotificationEvent
+	wg      sync.WaitGroup
+	mu      sync.Mutex
+	dropped int
+}
+
+// NewEmail validates the SMTP settings and starts the delivery worker. Host and
+// From are required. Close() drains in-flight events at shutdown.
+func NewEmail(cfg EmailConfig) (*EmailSink, error) {
+	if cfg.Host == "" {
+		return nil, fmt.Errorf("notifychan: email smtp host is required")
+	}
+	if cfg.From == "" {
+		return nil, fmt.Errorf("notifychan: email smtp from address is required")
+	}
+	switch strings.ToLower(cfg.TLS) {
+	case "", "starttls", "implicit", "none":
+	default:
+		return nil, fmt.Errorf("notifychan: unknown smtp tls mode %q (want starttls|implicit|none)", cfg.TLS)
+	}
+	s := &EmailSink{cfg: cfg, queue: make(chan core.NotificationEvent, emailQueueSize)}
+	s.wg.Add(1)
+	go s.worker()
+	return s, nil
+}
+
+// Deliver enqueues the event. Non-blocking; drops (and counts) when the queue is
+// full so a wedged relay never stalls the caller.
+func (s *EmailSink) Deliver(ev core.NotificationEvent) {
+	if s == nil {
+		return
+	}
+	select {
+	case s.queue <- ev:
+	default:
+		s.mu.Lock()
+		s.dropped++
+		dropped := s.dropped
+		s.mu.Unlock()
+		log.Printf("notifychan: email queue full, dropped notification (total dropped: %d)", dropped)
+	}
+}
+
+func (s *EmailSink) worker() {
+	defer s.wg.Done()
+	for ev := range s.queue {
+		if ev.Email == "" {
+			continue // no address to send to
+		}
+		if err := s.send(context.Background(), ev); err != nil {
+			log.Printf("notifychan: email delivery to %s failed: %v", ev.Email, err)
+		}
+	}
+}
+
+func (s *EmailSink) send(ctx context.Context, ev core.NotificationEvent) error {
+	subject, body := renderEmail(ev)
+	msg := mail.NewMsg()
+	if err := msg.From(s.cfg.From); err != nil {
+		return fmt.Errorf("invalid from address %q: %w", s.cfg.From, err)
+	}
+	if err := msg.To(ev.Email); err != nil {
+		return fmt.Errorf("invalid recipient %q: %w", ev.Email, err)
+	}
+	msg.Subject(subject)
+	msg.SetBodyString(mail.TypeTextPlain, body)
+
+	client, err := s.newClient()
+	if err != nil {
+		return err
+	}
+	return client.DialAndSendWithContext(ctx, msg)
+}
+
+// newClient builds a go-mail client from the SMTP settings, selecting the TLS
+// policy and enabling auth only when a username is configured (an internal relay
+// may authenticate by network).
+func (s *EmailSink) newClient() (*mail.Client, error) {
+	opts := []mail.Option{mail.WithTimeout(emailTimeout)}
+	if s.cfg.Port > 0 {
+		opts = append(opts, mail.WithPort(s.cfg.Port))
+	}
+	switch strings.ToLower(s.cfg.TLS) {
+	case "implicit":
+		opts = append(opts, mail.WithSSL())
+	case "none":
+		opts = append(opts, mail.WithTLSPolicy(mail.NoTLS))
+	default: // "" or starttls
+		opts = append(opts, mail.WithTLSPolicy(mail.TLSMandatory))
+	}
+	if s.cfg.Username != "" {
+		opts = append(opts,
+			mail.WithSMTPAuth(mail.SMTPAuthAutoDiscover),
+			mail.WithUsername(s.cfg.Username),
+			mail.WithPassword(s.cfg.Password),
+		)
+	}
+	return mail.NewClient(s.cfg.Host, opts...)
+}
+
+// renderEmail produces the subject and plaintext body for a notification. No remote
+// resources or tracking — just the title, message, and an optional in-app link.
+func renderEmail(ev core.NotificationEvent) (subject, body string) {
+	subject = ev.Title
+	if subject == "" {
+		subject = "Keyorix notification"
+	}
+	var b strings.Builder
+	if ev.Message != "" {
+		b.WriteString(ev.Message)
+		b.WriteString("\n")
+	}
+	if ev.Link != "" {
+		fmt.Fprintf(&b, "\nOpen in Keyorix: %s\n", ev.Link)
+	}
+	b.WriteString("\n— Keyorix\n")
+	return subject, b.String()
+}
+
+// Close stops the worker after draining queued events.
+func (s *EmailSink) Close() {
+	if s == nil {
+		return
+	}
+	close(s.queue)
+	s.wg.Wait()
+}

--- a/internal/notifychan/email_test.go
+++ b/internal/notifychan/email_test.go
@@ -1,0 +1,40 @@
+package notifychan
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRenderEmail(t *testing.T) {
+	subject, body := renderEmail(core.NotificationEvent{
+		Title: "Access recertification", Message: "Project Payments is due for review.", Link: "/projects/3",
+	})
+	assert.Equal(t, "Access recertification", subject)
+	assert.Contains(t, body, "due for review")
+	assert.Contains(t, body, "/projects/3")
+}
+
+func TestRenderEmail_DefaultsSubject(t *testing.T) {
+	subject, _ := renderEmail(core.NotificationEvent{Message: "x"})
+	assert.Equal(t, "Keyorix notification", subject)
+}
+
+func TestNewEmail_Validation(t *testing.T) {
+	_, err := NewEmail(EmailConfig{From: "ops@x.io"}) // missing host
+	require.Error(t, err)
+
+	_, err = NewEmail(EmailConfig{Host: "smtp.x.io"}) // missing from
+	require.Error(t, err)
+
+	_, err = NewEmail(EmailConfig{Host: "smtp.x.io", From: "ops@x.io", TLS: "bogus"})
+	require.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), "tls"))
+
+	s, err := NewEmail(EmailConfig{Host: "smtp.x.io", From: "ops@x.io", TLS: "starttls"})
+	require.NoError(t, err)
+	s.Close()
+}

--- a/internal/notifychan/multi.go
+++ b/internal/notifychan/multi.go
@@ -1,0 +1,38 @@
+// multi.go — fan-out across multiple notification channels. When more than one
+// channel is enabled, each notification is delivered to all of them; a slow or
+// failing channel cannot affect the others (each Deliver is itself non-blocking).
+package notifychan
+
+import "github.com/keyorixhq/keyorix/internal/core"
+
+// MultiSink delivers each event to every wrapped sink.
+type MultiSink struct {
+	sinks []core.NotificationSink
+}
+
+// NewMulti combines sinks into a single NotificationSink, dropping nils. It returns
+// nil when no real sink is given (so callers leave notifications in-app only), the
+// lone sink when exactly one is given, and a MultiSink otherwise.
+func NewMulti(sinks ...core.NotificationSink) core.NotificationSink {
+	live := make([]core.NotificationSink, 0, len(sinks))
+	for _, s := range sinks {
+		if s != nil {
+			live = append(live, s)
+		}
+	}
+	switch len(live) {
+	case 0:
+		return nil
+	case 1:
+		return live[0]
+	default:
+		return &MultiSink{sinks: live}
+	}
+}
+
+// Deliver fans the event out to every wrapped sink.
+func (m *MultiSink) Deliver(ev core.NotificationEvent) {
+	for _, s := range m.sinks {
+		s.Deliver(ev)
+	}
+}

--- a/internal/notifychan/multi_test.go
+++ b/internal/notifychan/multi_test.go
@@ -1,0 +1,34 @@
+package notifychan
+
+import (
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/stretchr/testify/assert"
+)
+
+type countingSink struct{ n int }
+
+func (c *countingSink) Deliver(core.NotificationEvent) { c.n++ }
+
+func TestNewMulti_FansOutToAll(t *testing.T) {
+	a, b := &countingSink{}, &countingSink{}
+	sink := NewMulti(a, b)
+	sink.Deliver(core.NotificationEvent{UserID: 1})
+	assert.Equal(t, 1, a.n)
+	assert.Equal(t, 1, b.n)
+}
+
+func TestNewMulti_NilWhenNoLiveSinks(t *testing.T) {
+	assert.Nil(t, NewMulti())
+	assert.Nil(t, NewMulti(nil, nil))
+}
+
+func TestNewMulti_UnwrapsSingle(t *testing.T) {
+	a := &countingSink{}
+	sink := NewMulti(nil, a)
+	// A lone live sink is returned directly (not wrapped).
+	assert.Equal(t, core.NotificationSink(a), sink)
+	sink.Deliver(core.NotificationEvent{UserID: 1})
+	assert.Equal(t, 1, a.n)
+}

--- a/server/main.go
+++ b/server/main.go
@@ -243,8 +243,9 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 	}
 
 	// Wire external notification channels if configured. Each in-app notification is
-	// fanned out to the channel (best-effort, async); with none enabled it stays
-	// in-app only.
+	// fanned out to every enabled channel (best-effort, async); with none enabled it
+	// stays in-app only.
+	var notifySinks []core.NotificationSink
 	if wc := cfg.Notifications.Webhook; wc.Enabled {
 		sink, werr := notifychan.NewWebhook(notifychan.WebhookConfig{
 			Endpoint:           wc.Endpoint,
@@ -254,8 +255,26 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 		if werr != nil {
 			return nil, nil, fmt.Errorf("failed to init notification webhook channel: %w", werr)
 		}
-		coreService.SetNotificationSink(sink)
+		notifySinks = append(notifySinks, sink)
 		log.Printf("Notification webhook channel enabled (endpoint=%s)", wc.Endpoint)
+	}
+	if ec := cfg.Notifications.Email; ec.Enabled {
+		sink, eerr := notifychan.NewEmail(notifychan.EmailConfig{
+			Host:     ec.Host,
+			Port:     ec.Port,
+			Username: ec.Username,
+			Password: ec.GetPassword(),
+			From:     ec.From,
+			TLS:      ec.TLS,
+		})
+		if eerr != nil {
+			return nil, nil, fmt.Errorf("failed to init notification email channel: %w", eerr)
+		}
+		notifySinks = append(notifySinks, sink)
+		log.Printf("Notification email channel enabled (host=%s)", ec.Host)
+	}
+	if sink := notifychan.NewMulti(notifySinks...); sink != nil {
+		coreService.SetNotificationSink(sink)
 	}
 
 	// Apply the project membership validation mode (ADR-022). Empty = allowlist.


### PR DESCRIPTION
## What

The **email** notification channel, completing batch 2 on top of the webhook sink (#193). Adds a multi-sink so webhook + email can run together (each notification delivered to all enabled channels).

## How

- **internal/notifychan** — `EmailSink` sends each notification as plaintext via the operator's SMTP relay, delegating TLS correctness to `wneessen/go-mail` (the same library as the ADR-028 credential mailer). Async (bounded queue + worker), skips events with no recipient email, drops rather than blocks on a wedged relay. `renderEmail` builds a tracking-free subject/body. `MultiSink` fans each event out to every enabled channel (returns nil when none, the lone sink when one).
- **config** — `notifications.email {enabled, host, port, username, password, from, tls}`; password from `KEYORIX_NOTIFY_SMTP_PASSWORD`. `main.go` now builds the enabled channels into `NewMulti` and wires the combined sink.
- **docs** — `CONFIGURATION.md` notifications shows both channels.

## Tests

- `renderEmail` subject/body + default subject.
- `NewEmail` validation (host/from required, bad TLS mode rejected).
- Multi-sink fan-out, nil-when-empty, single-unwrap.

Batch 2 of 4 (part b), per "lets do 1 2 4 3". With #193 merged, this branches off main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)