### PR TITLE
feat(evidence): off-box webhook target for scheduled evidence delivery

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -419,15 +419,25 @@ Each export also emits a `compliance.evidence_exported` audit event, so an insta
 [`audit.siem`](#auditsiem) forwarder receives the delivery signal too. Read-only, so
 it runs even while a legal hold is active. Single-replica-gated (ADR-039).
 
+Deliver to a local directory, an off-box **webhook** (POST of the pack JSON), or
+both. At least one target must be configured when enabled.
+
 ```yaml
 evidence_delivery:
   enabled: true
   schedule: "24h"                           # Go duration between exports (default 24h)
-  output_dir: "/var/lib/keyorix/evidence"   # required when enabled; mount to durable storage
+  output_dir: "/var/lib/keyorix/evidence"   # local archive; omit to deliver by webhook only
+  webhook:
+    enabled: true
+    endpoint: "https://evidence.example.com/keyorix"
+    token: ""                               # prefer the KEYORIX_EVIDENCE_WEBHOOK_TOKEN env var
+    insecure_skip_verify: false             # TLS verification off — self-signed endpoints only
 ```
 
-> Point `output_dir` at a volume that is backed up off-box (or synced to object
-> storage) — the value of scheduled delivery is that the evidence survives the node.
+> The webhook lets evidence survive the node without a mounted volume. A file write
+> is the primary durable target (its failure is fatal); a webhook failure is recorded
+> in the audit note but does not fail the export when a file was also written. The
+> webhook token is read from `KEYORIX_EVIDENCE_WEBHOOK_TOKEN` when set.
 
 ## rotation_reminders
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -513,14 +513,36 @@ func (c DataRetentionConfig) GetInterval() time.Duration {
 // EvidenceDeliveryConfig configures the scheduled compliance-evidence export
 // (ISO 27001 / SOC 2 continuous evidence): a background job that periodically
 // generates the auditor evidence pack (the posture plus the records that
-// substantiate it) and writes it as a timestamped JSON file under OutputDir, for
-// off-box archival/backup. Each run also emits a compliance.evidence_exported
-// audit event, so an installed SIEM forwarder receives the delivery signal too.
-// Opt-in (Enabled, default off); OutputDir is required when enabled.
+// substantiate it) and delivers it to the configured targets — a timestamped JSON
+// file under OutputDir, and/or a Webhook that POSTs the pack off-box (so evidence
+// survives the node without a mounted volume). Each run also emits a
+// compliance.evidence_exported audit event, so an installed SIEM forwarder receives
+// the delivery signal too. Opt-in (Enabled, default off); at least one target
+// (OutputDir or Webhook) must be configured.
 type EvidenceDeliveryConfig struct {
-	Enabled   bool   `yaml:"enabled"`
-	Schedule  string `yaml:"schedule"`
-	OutputDir string `yaml:"output_dir"`
+	Enabled   bool                  `yaml:"enabled"`
+	Schedule  string                `yaml:"schedule"`
+	OutputDir string                `yaml:"output_dir"`
+	Webhook   EvidenceWebhookConfig `yaml:"webhook"`
+}
+
+// EvidenceWebhookConfig configures the off-box webhook target: each run POSTs the
+// evidence pack JSON to Endpoint, optionally bearer-authenticated.
+type EvidenceWebhookConfig struct {
+	Enabled            bool   `yaml:"enabled"`
+	Endpoint           string `yaml:"endpoint"`
+	Token              string `yaml:"token"` // use KEYORIX_EVIDENCE_WEBHOOK_TOKEN env var instead
+	InsecureSkipVerify bool   `yaml:"insecure_skip_verify"`
+}
+
+// GetToken returns the resolved webhook token, preferring the environment variable.
+func (c *EvidenceWebhookConfig) GetToken() string {
+	return resolveSecret("KEYORIX_EVIDENCE_WEBHOOK_TOKEN", c.Token)
+}
+
+// HasTarget reports whether at least one delivery target is configured.
+func (c EvidenceDeliveryConfig) HasTarget() bool {
+	return c.OutputDir != "" || c.Webhook.Enabled
 }
 
 // GetInterval returns the evidence-export run interval, parsing Schedule as a Go

--- a/internal/core/evidence_export.go
+++ b/internal/core/evidence_export.go
@@ -20,22 +20,39 @@ import (
 // lexicographically by time: keyorix-evidence-20060102T150405Z.json.
 const evidenceFileTimeLayout = "20060102T150405Z"
 
-// EvidenceExportResult reports the outcome of one scheduled evidence export.
-type EvidenceExportResult struct {
-	Path  string `json:"path"`
-	Bytes int    `json:"bytes"`
+// EvidenceForwarder ships a marshalled evidence pack to an off-box target (e.g. a
+// webhook / object store). Called only from the once-a-day evidence scheduler, so a
+// synchronous implementation is fine. Defined here (not in the sink package) so core
+// has no dependency on the forwarder implementation.
+type EvidenceForwarder interface {
+	ForwardEvidence(ctx context.Context, data []byte) error
 }
 
-// ExportComplianceEvidence generates the evidence pack and writes it as a
-// timestamped JSON file (0600) under outputDir, which is created (0700) if absent.
-// It returns the written path. The write is followed by a system-actored
-// compliance.evidence_exported audit event so the export is itself part of the
-// tamper-evident trail and is forwarded to a SIEM. An empty outputDir is a
-// misconfiguration error. Read-only with respect to the data it captures, so it
-// is NOT gated by legal hold.
+// SetEvidenceForwarder wires an off-box evidence target. The server calls this at
+// startup when evidence_delivery configures a webhook. nil = local-file only.
+func (c *KeyorixCore) SetEvidenceForwarder(f EvidenceForwarder) {
+	c.evidenceForwarder = f
+}
+
+// EvidenceExportResult reports the outcome of one scheduled evidence export.
+type EvidenceExportResult struct {
+	Path    string   `json:"path,omitempty"` // local file written, if a directory was configured
+	Bytes   int      `json:"bytes"`
+	Targets []string `json:"targets"` // where the pack was delivered (e.g. "file:/path", "webhook")
+}
+
+// ExportComplianceEvidence generates the evidence pack and delivers it to every
+// configured target: a timestamped JSON file (0600) under outputDir (created 0700
+// if absent) when outputDir is set, and/or an off-box forwarder (webhook) when one
+// is wired. At least one target must be configured. The delivery is followed by a
+// system-actored compliance.evidence_exported audit event, so the export is itself
+// part of the tamper-evident trail and is forwarded to a SIEM. A file-write failure
+// is fatal (the file is the primary durable target); a forwarder failure is logged
+// in the audit note but does not fail the export when a file was also written.
+// Read-only with respect to the data it captures, so it is NOT legal-hold-gated.
 func (c *KeyorixCore) ExportComplianceEvidence(ctx context.Context, outputDir string) (*EvidenceExportResult, error) {
-	if outputDir == "" {
-		return nil, fmt.Errorf("evidence export: output_dir is not configured")
+	if outputDir == "" && c.evidenceForwarder == nil {
+		return nil, fmt.Errorf("evidence export: no delivery target configured (set output_dir or a webhook)")
 	}
 	ev, err := c.GenerateComplianceEvidence(ctx)
 	if err != nil {
@@ -45,19 +62,39 @@ func (c *KeyorixCore) ExportComplianceEvidence(ctx context.Context, outputDir st
 	if err != nil {
 		return nil, fmt.Errorf("evidence export: marshal: %w", err)
 	}
-	if err := os.MkdirAll(outputDir, 0o700); err != nil {
-		return nil, fmt.Errorf("evidence export: create output dir: %w", err)
+
+	res := &EvidenceExportResult{Bytes: len(data)}
+
+	if outputDir != "" {
+		if err := os.MkdirAll(outputDir, 0o700); err != nil {
+			return nil, fmt.Errorf("evidence export: create output dir: %w", err)
+		}
+		name := fmt.Sprintf("keyorix-evidence-%s.json", ev.GeneratedAt.UTC().Format(evidenceFileTimeLayout))
+		if err := securefiles.SecureWriteFile(outputDir, name, data, 0o600); err != nil {
+			return nil, fmt.Errorf("evidence export: write: %w", err)
+		}
+		res.Path = filepath.Join(outputDir, name)
+		res.Targets = append(res.Targets, "file:"+res.Path)
 	}
-	name := fmt.Sprintf("keyorix-evidence-%s.json", ev.GeneratedAt.UTC().Format(evidenceFileTimeLayout))
-	if err := securefiles.SecureWriteFile(outputDir, name, data, 0o600); err != nil {
-		return nil, fmt.Errorf("evidence export: write: %w", err)
+
+	forwardNote := ""
+	if c.evidenceForwarder != nil {
+		if err := c.evidenceForwarder.ForwardEvidence(ctx, data); err != nil {
+			// Best-effort secondary target: record the failure but don't drop the
+			// export when a durable file was also written.
+			forwardNote = fmt.Sprintf("; webhook delivery FAILED: %v", err)
+			if res.Path == "" {
+				return nil, fmt.Errorf("evidence export: webhook delivery failed: %w", err)
+			}
+		} else {
+			res.Targets = append(res.Targets, "webhook")
+		}
 	}
-	path := filepath.Join(outputDir, name)
 
 	sysCtx := WithActorType(ctx, ActorTypeSystem)
 	c.writeAuditEvent(sysCtx, "compliance.evidence_exported", nil, nil,
-		fmt.Sprintf("compliance evidence pack exported to %s (%d bytes; %d campaigns, %d break-glass activations, %d overdue rotations, %d SoD violations)",
-			path, len(data), len(ev.Campaigns), len(ev.BreakGlass), len(ev.RotationOverdue), len(ev.SoDViolations)))
+		fmt.Sprintf("compliance evidence pack exported to %v (%d bytes; %d campaigns, %d break-glass activations, %d overdue rotations, %d SoD violations)%s",
+			res.Targets, len(data), len(ev.Campaigns), len(ev.BreakGlass), len(ev.RotationOverdue), len(ev.SoDViolations), forwardNote))
 
-	return &EvidenceExportResult{Path: path, Bytes: len(data)}, nil
+	return res, nil
 }

--- a/internal/core/evidence_export_test.go
+++ b/internal/core/evidence_export_test.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -68,4 +69,68 @@ func TestExportComplianceEvidence_EmptyOutputDirErrors(t *testing.T) {
 	_, err := c.ExportComplianceEvidence(context.Background(), "")
 	require.Error(t, err)
 	assert.True(t, strings.Contains(err.Error(), "output_dir"), "error names the misconfig")
+}
+
+type fakeEvidenceForwarder struct {
+	calls int
+	data  []byte
+	err   error
+}
+
+func (f *fakeEvidenceForwarder) ForwardEvidence(_ context.Context, data []byte) error {
+	f.calls++
+	f.data = data
+	return f.err
+}
+
+func TestExportComplianceEvidence_WebhookOnly(t *testing.T) {
+	ctx := context.Background()
+	c, db, _ := newEvidenceExportCore(t)
+	fwd := &fakeEvidenceForwarder{}
+	c.SetEvidenceForwarder(fwd)
+
+	res, err := c.ExportComplianceEvidence(ctx, "") // no dir → webhook is the only target
+	require.NoError(t, err)
+	assert.Equal(t, 1, fwd.calls)
+	assert.Greater(t, len(fwd.data), 0)
+	assert.Empty(t, res.Path)
+	assert.Equal(t, []string{"webhook"}, res.Targets)
+
+	var n int64
+	require.NoError(t, db.Model(&models.AuditEvent{}).
+		Where("event_type = ?", "compliance.evidence_exported").Count(&n).Error)
+	assert.Equal(t, int64(1), n)
+}
+
+func TestExportComplianceEvidence_FileAndWebhook(t *testing.T) {
+	ctx := context.Background()
+	c, _, _ := newEvidenceExportCore(t)
+	fwd := &fakeEvidenceForwarder{}
+	c.SetEvidenceForwarder(fwd)
+
+	res, err := c.ExportComplianceEvidence(ctx, t.TempDir())
+	require.NoError(t, err)
+	assert.Equal(t, 1, fwd.calls)
+	assert.NotEmpty(t, res.Path)
+	assert.Len(t, res.Targets, 2, "delivered to both file and webhook")
+}
+
+func TestExportComplianceEvidence_WebhookFailureWithFileSucceeds(t *testing.T) {
+	ctx := context.Background()
+	c, _, _ := newEvidenceExportCore(t)
+	c.SetEvidenceForwarder(&fakeEvidenceForwarder{err: errors.New("boom")})
+
+	res, err := c.ExportComplianceEvidence(ctx, t.TempDir())
+	require.NoError(t, err, "a file was written, so a webhook failure is non-fatal")
+	assert.NotEmpty(t, res.Path)
+	assert.Equal(t, []string{"file:" + res.Path}, res.Targets, "the failed webhook is not listed as a target")
+}
+
+func TestExportComplianceEvidence_WebhookOnlyFailureErrors(t *testing.T) {
+	ctx := context.Background()
+	c, _, _ := newEvidenceExportCore(t)
+	c.SetEvidenceForwarder(&fakeEvidenceForwarder{err: errors.New("boom")})
+
+	_, err := c.ExportComplianceEvidence(ctx, "") // webhook-only and it fails → fatal
+	require.Error(t, err)
 }

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -49,6 +49,9 @@ type KeyorixCore struct {
 	// notificationSink fans each in-app notification out to an external channel
 	// (email/webhook). nil = in-app only. Set from config via SetNotificationSink.
 	notificationSink NotificationSink
+	// evidenceForwarder ships the scheduled compliance-evidence pack to an off-box
+	// target (webhook). nil = local-file only. Set via SetEvidenceForwarder.
+	evidenceForwarder EvidenceForwarder
 	// breakGlassPolicy configures self-service emergency access; zero value =
 	// disabled. Set from config at startup via SetBreakGlassPolicy.
 	breakGlassPolicy BreakGlassPolicy

--- a/internal/evidencesink/webhook.go
+++ b/internal/evidencesink/webhook.go
@@ -1,0 +1,64 @@
+// Package evidencesink implements off-box delivery targets for the scheduled
+// compliance-evidence pack (ISO 27001 / SOC 2 continuous evidence), beyond the
+// local output directory: a webhook that POSTs the pack so evidence survives the
+// node without a mounted volume. Implements core.EvidenceForwarder.
+package evidencesink
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const webhookTimeout = 30 * time.Second // the evidence pack can be large
+
+// WebhookConfig configures the evidence webhook target.
+type WebhookConfig struct {
+	Endpoint           string // full destination URL (POST target)
+	Token              string // optional bearer token
+	InsecureSkipVerify bool   // skip TLS verification (self-signed only)
+}
+
+// Webhook POSTs the evidence pack JSON to an HTTP endpoint. Delivery is synchronous
+// — it is only called from the once-a-day evidence scheduler, never a hot path.
+type Webhook struct {
+	cfg    WebhookConfig
+	client *http.Client
+}
+
+// NewWebhook builds an evidence webhook target. The endpoint is required.
+func NewWebhook(cfg WebhookConfig) (*Webhook, error) {
+	if cfg.Endpoint == "" {
+		return nil, fmt.Errorf("evidencesink: webhook endpoint is required")
+	}
+	transport := &http.Transport{}
+	if cfg.InsecureSkipVerify {
+		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} // #nosec G402 -- opt-in for self-signed endpoints
+	}
+	return &Webhook{cfg: cfg, client: &http.Client{Timeout: webhookTimeout, Transport: transport}}, nil
+}
+
+// ForwardEvidence POSTs the marshalled evidence pack as application/json.
+func (w *Webhook) ForwardEvidence(ctx context.Context, data []byte) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, w.cfg.Endpoint, bytes.NewReader(data))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if w.cfg.Token != "" {
+		req.Header.Set("Authorization", "Bearer "+w.cfg.Token)
+	}
+	resp, err := w.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("evidence webhook endpoint returned %s", strings.TrimSpace(resp.Status))
+	}
+	return nil
+}

--- a/internal/evidencesink/webhook_test.go
+++ b/internal/evidencesink/webhook_test.go
@@ -1,0 +1,55 @@
+package evidencesink
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWebhook_PostsEvidenceWithAuth(t *testing.T) {
+	var (
+		mu    sync.Mutex
+		body  []byte
+		auth  string
+		ctype string
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		body, auth, ctype = b, r.Header.Get("Authorization"), r.Header.Get("Content-Type")
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	wh, err := NewWebhook(WebhookConfig{Endpoint: srv.URL, Token: "ev-tok"})
+	require.NoError(t, err)
+	require.NoError(t, wh.ForwardEvidence(context.Background(), []byte(`{"generated_at":"x"}`)))
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, `{"generated_at":"x"}`, string(body))
+	assert.Equal(t, "Bearer ev-tok", auth)
+	assert.Equal(t, "application/json", ctype)
+}
+
+func TestWebhook_ErrorsOnNon2xx(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	wh, err := NewWebhook(WebhookConfig{Endpoint: srv.URL})
+	require.NoError(t, err)
+	require.Error(t, wh.ForwardEvidence(context.Background(), []byte(`{}`)))
+}
+
+func TestNewWebhook_RequiresEndpoint(t *testing.T) {
+	_, err := NewWebhook(WebhookConfig{})
+	require.Error(t, err)
+}

--- a/server/main.go
+++ b/server/main.go
@@ -39,6 +39,7 @@ import (
 	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/keyorixhq/keyorix/internal/delivery"
 	"github.com/keyorixhq/keyorix/internal/encryption"
+	"github.com/keyorixhq/keyorix/internal/evidencesink"
 	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/notifychan"
 	appstorage "github.com/keyorixhq/keyorix/internal/storage"
@@ -275,6 +276,21 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 	}
 	if sink := notifychan.NewMulti(notifySinks...); sink != nil {
 		coreService.SetNotificationSink(sink)
+	}
+
+	// Wire an off-box evidence webhook target if configured, so the scheduled
+	// evidence pack is POSTed off-box in addition to (or instead of) a local dir.
+	if ew := cfg.EvidenceDelivery.Webhook; ew.Enabled {
+		fwd, ferr := evidencesink.NewWebhook(evidencesink.WebhookConfig{
+			Endpoint:           ew.Endpoint,
+			Token:              ew.GetToken(),
+			InsecureSkipVerify: ew.InsecureSkipVerify,
+		})
+		if ferr != nil {
+			return nil, nil, fmt.Errorf("failed to init evidence webhook target: %w", ferr)
+		}
+		coreService.SetEvidenceForwarder(fwd)
+		log.Printf("Evidence webhook target enabled (endpoint=%s)", ew.Endpoint)
 	}
 
 	// Apply the project membership validation mode (ADR-022). Empty = allowlist.
@@ -632,17 +648,17 @@ func startHTTPServer(ctx context.Context, cfg *config.Config) error {
 	}
 
 	// Start the scheduled compliance-evidence delivery (ISO 27001 / SOC 2) — opt-in.
-	// Periodically generates the auditor evidence pack and writes it to the output
-	// directory for off-box archival; each export emits an audit event (forwarded to
-	// a SIEM if configured). Single-replica-gated (ADR-039) so one timestamped pack
-	// is written per tick. Not legal-hold-gated (it only reads).
+	// Periodically generates the auditor evidence pack and delivers it to the
+	// configured targets (a local directory and/or a webhook); each export emits an
+	// audit event (forwarded to a SIEM if configured). Single-replica-gated (ADR-039)
+	// so one pack is delivered per tick. Not legal-hold-gated (it only reads).
 	if cfg.EvidenceDelivery.Enabled {
-		outputDir := cfg.EvidenceDelivery.OutputDir
-		if outputDir == "" {
-			log.Printf("Evidence-delivery scheduler enabled but output_dir is empty; skipping")
+		if !cfg.EvidenceDelivery.HasTarget() {
+			log.Printf("Evidence-delivery scheduler enabled but no target (output_dir or webhook) is configured; skipping")
 		} else {
+			outputDir := cfg.EvidenceDelivery.OutputDir
 			interval := cfg.EvidenceDelivery.GetInterval()
-			log.Printf("Evidence-delivery scheduler enabled: every %s → %s", interval, outputDir)
+			log.Printf("Evidence-delivery scheduler enabled: every %s (dir=%q, webhook=%t)", interval, outputDir, cfg.EvidenceDelivery.Webhook.Enabled)
 			go func() {
 				ticker := time.NewTicker(interval)
 				defer ticker.Stop()
@@ -653,7 +669,7 @@ func startHTTPServer(ctx context.Context, cfg *config.Config) error {
 							log.Printf("Evidence-delivery error: %v", err)
 							return err
 						}
-						log.Printf("Evidence pack exported: %s (%d bytes)", res.Path, res.Bytes)
+						log.Printf("Evidence pack exported: %d bytes → %v", res.Bytes, res.Targets)
 						return nil
 					}); err != nil {
 						log.Printf("Evidence-delivery scheduler error: %v", err)


### PR DESCRIPTION
## What

Scheduled evidence delivery (#190) wrote the pack to a **local directory only** — which needs a mounted, separately-backed-up volume to survive the node. This adds a **webhook** target that POSTs the pack off-box. Deliver to a directory, a webhook, or both.

Batch 4 of 4, per "lets do 1 2 4 3".

## How

- **internal/evidencesink** — `Webhook` implements `core.EvidenceForwarder`: a synchronous HTTP POST of the evidence JSON (optional `Bearer` token, `InsecureSkipVerify`). Synchronous is fine — it runs only from the once-a-day scheduler, never a hot path.
- **core** — `EvidenceForwarder` interface + `evidenceForwarder` field + `SetEvidenceForwarder` (mirrors `AuditForwarder`). `ExportComplianceEvidence` now delivers to **every** configured target and reports `res.Targets`. A file write stays the **primary durable target** (its failure is fatal); a webhook failure is recorded in the audit note but is **non-fatal when a file was also written**. At least one target is required.
- **config** — `evidence_delivery.webhook {enabled, endpoint, token, insecure_skip_verify}`; token from `KEYORIX_EVIDENCE_WEBHOOK_TOKEN`. The scheduler now runs when **either** a dir or a webhook is configured (`HasTarget`).
- **docs** — `CONFIGURATION.md` shows the webhook target.

## Tests

- Webhook-only delivers + audits; file+webhook hits both; webhook failure with a file is non-fatal (not listed as a target); webhook-only failure is fatal.
- Sink POSTs JSON with `Bearer` auth, errors on non-2xx, requires an endpoint.

> Note: object-storage (S3/GCS) sinks were intentionally skipped to avoid heavy cloud SDK deps; a webhook covers off-box delivery dependency-free and integrates with any storage via a small receiver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)