### PR TITLE
feat(secrets): classification filter on GET /secrets (ISO A.5.12)

### DIFF
--- a/internal/core/secret_listing_classification_test.go
+++ b/internal/core/secret_listing_classification_test.go
@@ -1,0 +1,35 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func swi(name, classification string) *models.SecretWithSharingInfo {
+	return &models.SecretWithSharingInfo{
+		SecretNode: &models.SecretNode{Name: name, Classification: classification},
+	}
+}
+
+func TestApplySecretFilters_Classification(t *testing.T) {
+	c := &KeyorixCore{}
+	in := []*models.SecretWithSharingInfo{
+		swi("r1", "restricted"), swi("c1", "confidential"), swi("u1", ""),
+	}
+
+	restricted := "restricted"
+	got := c.applySecretFilters(in, &models.SecretListFilter{Classification: &restricted})
+	assert.Len(t, got, 1)
+	assert.Equal(t, "r1", got[0].Name)
+
+	unclassified := "unclassified"
+	got = c.applySecretFilters(in, &models.SecretListFilter{Classification: &unclassified})
+	assert.Len(t, got, 1)
+	assert.Equal(t, "u1", got[0].Name, "'unclassified' matches the empty label")
+
+	// No classification filter → all pass through.
+	got = c.applySecretFilters(in, &models.SecretListFilter{})
+	assert.Len(t, got, 3)
+}

--- a/internal/core/secret_listing_query.go
+++ b/internal/core/secret_listing_query.go
@@ -239,6 +239,15 @@ func (c *KeyorixCore) applySecretFilters(secrets []*models.SecretWithSharingInfo
 		if filter.Type != nil && *filter.Type != "" && s.Type != *filter.Type {
 			continue
 		}
+		if filter.Classification != nil && *filter.Classification != "" {
+			if *filter.Classification == "unclassified" {
+				if s.Classification != "" {
+					continue
+				}
+			} else if s.Classification != *filter.Classification {
+				continue
+			}
+		}
 		if filter.ExpiresBefore != nil {
 			if s.Expiration == nil || !s.Expiration.Before(*filter.ExpiresBefore) {
 				continue // no expiration, or expires at/after the cutoff
@@ -293,6 +302,7 @@ func (c *KeyorixCore) convertToStorageFilter(filter *models.SecretListFilter) *s
 		Page:           filter.Page,
 		PageSize:       filter.PageSize,
 		Type:           filter.Type,
+		Classification: filter.Classification,
 		CreatedBy:      filter.CreatedBy,
 		ProjectID:      filter.ProjectID,
 		EnvironmentID:  filter.EnvironmentID,

--- a/internal/storage/models/secret_with_sharing.go
+++ b/internal/storage/models/secret_with_sharing.go
@@ -34,10 +34,13 @@ type SecretListFilter struct {
 	ProjectID     *uint
 	EnvironmentID *uint
 	Type          *string
-	Tags          []string
-	CreatedBy     *string
-	CreatedAfter  *time.Time
-	CreatedBefore *time.Time
+	// Classification filters by data-sensitivity label (ISO A.5.12); "unclassified"
+	// matches secrets with no label.
+	Classification *string
+	Tags           []string
+	CreatedBy      *string
+	CreatedAfter   *time.Time
+	CreatedBefore  *time.Time
 	// ExpiresBefore, when set, returns only secrets with a non-null expiration
 	// before this time (already expired or expiring within the window).
 	ExpiresBefore *time.Time

--- a/internal/storage/store/local_secrets_classification_test.go
+++ b/internal/storage/store/local_secrets_classification_test.go
@@ -1,0 +1,42 @@
+package store
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The classification filter returns only secrets with the requested label, and
+// "unclassified" matches secrets with an empty classification (ISO A.5.12).
+func TestListSecrets_ClassificationFilter(t *testing.T) {
+	ls := newSecretScopeTestStore(t)
+	ctx := context.Background()
+	require.NoError(t, ls.db.Create(&models.Environment{ID: 1, ProjectID: 5, Name: "dev"}).Error)
+
+	mk := func(name, classification string) {
+		require.NoError(t, ls.db.Create(&models.SecretNode{
+			ProjectID: 5, EnvironmentID: 1, Name: name, IsSecret: true, Type: "api_key", Status: "active",
+			Classification: classification,
+		}).Error)
+	}
+	mk("r1", "restricted")
+	mk("r2", "restricted")
+	mk("c1", "confidential")
+	mk("u1", "") // unclassified
+
+	level := "restricted"
+	got, total, err := ls.ListSecrets(ctx, &storage.SecretFilter{Classification: &level, Page: 1, PageSize: 100})
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), total)
+	assert.ElementsMatch(t, []string{"r1", "r2"}, secretNames(got))
+
+	unclassified := "unclassified"
+	got, total, err = ls.ListSecrets(ctx, &storage.SecretFilter{Classification: &unclassified, Page: 1, PageSize: 100})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), total)
+	assert.ElementsMatch(t, []string{"u1"}, secretNames(got))
+}

--- a/server/http/handlers/openapi.yaml
+++ b/server/http/handlers/openapi.yaml
@@ -1403,6 +1403,7 @@ paths:
         - {name: environment_id, in: query, schema: {type: integer}}
         - {name: search, in: query, schema: {type: string}}
         - {name: type, in: query, schema: {type: string}}
+        - {name: classification, in: query, schema: {type: string, enum: [public, internal, confidential, restricted, unclassified]}, description: "Data-classification filter (A.5.12); 'unclassified' matches secrets with no label."}
         - {name: expires_before, in: query, schema: {type: string, format: date-time}, description: "RFC3339 — return only secrets with a non-null expiration before this time (expired or expiring soon)."}
         - {name: page, in: query, schema: {type: integer, default: 1}}
         - {name: page_size, in: query, schema: {type: integer, default: 20, maximum: 100}}

--- a/server/http/handlers/secrets_list.go
+++ b/server/http/handlers/secrets_list.go
@@ -73,6 +73,11 @@ func (h *SecretHandler) ListSecrets(w http.ResponseWriter, r *http.Request) {
 	if typeParam := strings.TrimSpace(r.URL.Query().Get("type")); typeParam != "" {
 		filter.Type = &typeParam
 	}
+	if cls := strings.TrimSpace(r.URL.Query().Get("classification")); cls != "" {
+		// Data-classification filter (ISO A.5.12); "unclassified" matches secrets
+		// with no label (handled in the storage layer).
+		filter.Classification = &cls
+	}
 	if projectStr := r.URL.Query().Get("project_id"); projectStr != "" {
 		if pID, err := strconv.ParseUint(projectStr, 10, 32); err == nil {
 			pIDUint := uint(pID)


### PR DESCRIPTION
## What

Wires a `?classification=` query param on `GET /secrets` end to end, so the web secrets list (separate keyorix-web PR) can filter by data-classification label.

## How

- **handler** — `GET /secrets` parses `?classification=` into the filter.
- **model/core** — `SecretListFilter.Classification` + propagation through `convertToStorageFilter`; `applySecretFilters` honours it on the in-memory (shared-secrets) path too. `"unclassified"` matches the empty label — same semantics as the storage layer (`local_secrets.go`).
- **openapi** — `classification` query param (enum `public|internal|confidential|restricted|unclassified`).

## Tests

- Storage filter: label match + `unclassified` matches empty.
- In-memory `applySecretFilters`: label, `unclassified`, and no-filter passthrough.

Batch 3 of 4 (backend half), per "lets do 1 2 4 3". The web half (list column + filter + compliance surfaces) follows in keyorix-web.

🤖 Generated with [Claude Code](https://claude.com/claude-code)