### PR TITLE
feat(compliance): control matrix mapped to ISO 27001 / SOC 2 / NIS2 / DORA

### DIFF
--- a/internal/cli/compliance/compliance.go
+++ b/internal/cli/compliance/compliance.go
@@ -199,7 +199,82 @@ stdout by default, or to --output FILE.`,
 	},
 }
 
+// controlMatrix mirrors GET /api/v1/compliance/controls.
+type controlMatrix struct {
+	GeneratedAt string `json:"generated_at"`
+	Summary     struct {
+		Total         int `json:"total"`
+		Pass          int `json:"pass"`
+		Gap           int `json:"gap"`
+		NotConfigured int `json:"not_configured"`
+	} `json:"summary"`
+	Controls []struct {
+		Name       string `json:"name"`
+		Area       string `json:"area"`
+		Status     string `json:"status"`
+		Detail     string `json:"detail"`
+		Frameworks struct {
+			ISO27001 []string `json:"iso_27001"`
+			SOC2     []string `json:"soc2"`
+			NIS2     []string `json:"nis2"`
+			DORA     []string `json:"dora"`
+		} `json:"frameworks"`
+	} `json:"controls"`
+}
+
+func statusMark(s string) string {
+	switch s {
+	case "pass":
+		return "PASS"
+	case "gap":
+		return "GAP "
+	default:
+		return "n/a "
+	}
+}
+
+func joinRefs(refs ...[]string) string {
+	var all []string
+	for _, r := range refs {
+		all = append(all, r...)
+	}
+	if len(all) == 0 {
+		return "—"
+	}
+	out := all[0]
+	for _, r := range all[1:] {
+		out += ", " + r
+	}
+	return out
+}
+
+var controlsCmd = &cobra.Command{
+	Use:          "controls",
+	Short:        "Control matrix — controls mapped to ISO 27001 / SOC 2 / NIS2 / DORA with status",
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		c, ok := common.NewRemoteClient()
+		if !ok {
+			return fmt.Errorf("not connected to a server — run: keyorix connect <server>")
+		}
+		var m controlMatrix
+		if err := c.Get(context.Background(), "/api/v1/compliance/controls", &m); err != nil {
+			return err
+		}
+		fmt.Printf("Control matrix — %s\n", m.GeneratedAt)
+		fmt.Printf("  %d controls: %d pass, %d gap, %d not-configured\n\n", m.Summary.Total, m.Summary.Pass, m.Summary.Gap, m.Summary.NotConfigured)
+		for _, ctrl := range m.Controls {
+			fmt.Printf("[%s] %s (%s)\n", statusMark(ctrl.Status), ctrl.Name, ctrl.Area)
+			fmt.Printf("        %s\n", ctrl.Detail)
+			fmt.Printf("        ISO: %s | SOC2: %s | NIS2: %s | DORA: %s\n",
+				joinRefs(ctrl.Frameworks.ISO27001), joinRefs(ctrl.Frameworks.SOC2),
+				joinRefs(ctrl.Frameworks.NIS2), joinRefs(ctrl.Frameworks.DORA))
+		}
+		return nil
+	},
+}
+
 func init() {
 	exportCmd.Flags().StringVar(&exportOutput, "output", "", "Write the evidence pack to a file instead of stdout")
-	ComplianceCmd.AddCommand(reportCmd, exportCmd)
+	ComplianceCmd.AddCommand(reportCmd, controlsCmd, exportCmd)
 }

--- a/internal/core/compliance_evidence.go
+++ b/internal/core/compliance_evidence.go
@@ -53,6 +53,7 @@ type EvidenceRotation struct {
 type ComplianceEvidence struct {
 	GeneratedAt     time.Time                      `json:"generated_at"`
 	Posture         *CompliancePosture             `json:"posture"`
+	Controls        []ControlState                 `json:"controls"` // framework matrix (ISO/SOC2/NIS2/DORA)
 	AuditAnchor     AuditAnchor                    `json:"audit_anchor"`
 	Campaigns       []EvidenceCampaign             `json:"campaigns"`
 	BreakGlass      []*models.BreakGlassActivation `json:"break_glass"`
@@ -70,6 +71,7 @@ func (c *KeyorixCore) GenerateComplianceEvidence(ctx context.Context) (*Complian
 	ev := &ComplianceEvidence{
 		GeneratedAt:     c.now(),
 		Posture:         posture,
+		Controls:        EvaluateControls(posture),
 		Campaigns:       []EvidenceCampaign{},
 		BreakGlass:      []*models.BreakGlassActivation{},
 		RotationOverdue: []EvidenceRotation{},

--- a/internal/core/control_framework.go
+++ b/internal/core/control_framework.go
@@ -1,0 +1,184 @@
+// control_framework.go — the compliance control matrix (ISO 27001 / SOC 2 / NIS2 /
+// DORA). Where GetCompliancePosture reports raw figures, GetComplianceControls maps
+// each control Keyorix enforces to its clause references across the regimes an
+// auditor cares about, and evaluates a live status (pass / gap / not-configured)
+// from the posture. It turns the scattered A.5.x tiles into one auditor-ready
+// framework map. Read-only; gated by system.read.
+package core
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// ControlStatus is a control's evaluated state.
+type ControlStatus string
+
+const (
+	ControlStatusPass          ControlStatus = "pass"
+	ControlStatusGap           ControlStatus = "gap"
+	ControlStatusNotConfigured ControlStatus = "not_configured"
+)
+
+// FrameworkRefs maps a control to clauses across the regimes Keyorix targets.
+type FrameworkRefs struct {
+	ISO27001 []string `json:"iso_27001,omitempty"` // Annex A:2022 control ids, e.g. "A.5.18"
+	SOC2     []string `json:"soc2,omitempty"`      // Trust Services Criteria, e.g. "CC6.1"
+	NIS2     []string `json:"nis2,omitempty"`      // article refs, e.g. "Art.21(2)(i)"
+	DORA     []string `json:"dora,omitempty"`      // article refs, e.g. "Art.9"
+}
+
+// ControlState is one control's evaluated posture for the framework matrix.
+type ControlState struct {
+	ID         string        `json:"id"`
+	Name       string        `json:"name"`
+	Area       string        `json:"area"`
+	Status     ControlStatus `json:"status"`
+	Detail     string        `json:"detail"`
+	Frameworks FrameworkRefs `json:"frameworks"`
+}
+
+// ControlsSummary tallies controls by status.
+type ControlsSummary struct {
+	Total         int `json:"total"`
+	Pass          int `json:"pass"`
+	Gap           int `json:"gap"`
+	NotConfigured int `json:"not_configured"`
+}
+
+// ComplianceControls is the evaluated control matrix at a point in time.
+type ComplianceControls struct {
+	GeneratedAt time.Time       `json:"generated_at"`
+	Controls    []ControlState  `json:"controls"`
+	Summary     ControlsSummary `json:"summary"`
+}
+
+// GetComplianceControls evaluates the control matrix from the current posture.
+func (c *KeyorixCore) GetComplianceControls(ctx context.Context) (*ComplianceControls, error) {
+	p, err := c.GetCompliancePosture(ctx)
+	if err != nil {
+		return nil, err
+	}
+	controls := EvaluateControls(p)
+	out := &ComplianceControls{GeneratedAt: c.now(), Controls: controls}
+	out.Summary.Total = len(controls)
+	for _, ctrl := range controls {
+		switch ctrl.Status {
+		case ControlStatusPass:
+			out.Summary.Pass++
+		case ControlStatusGap:
+			out.Summary.Gap++
+		case ControlStatusNotConfigured:
+			out.Summary.NotConfigured++
+		}
+	}
+	return out, nil
+}
+
+// gapIf returns Gap when bad is true, else Pass — the common two-state evaluation.
+func gapIf(bad bool) ControlStatus {
+	if bad {
+		return ControlStatusGap
+	}
+	return ControlStatusPass
+}
+
+// EvaluateControls derives the control matrix from a posture snapshot. It is a pure
+// function (no storage) so the mapping and status logic are unit-testable in
+// isolation. The order is stable (grouped by area) for a deterministic report.
+func EvaluateControls(p *CompliancePosture) []ControlState {
+	ag := p.AccessGovernance
+	return []ControlState{
+		{
+			ID: "audit-trail-integrity", Name: "Tamper-evident audit trail", Area: "Audit & accountability",
+			Status:     gapIf(!p.AuditIntegrity.ChainVerified),
+			Detail:     fmt.Sprintf("chain verified=%t, checkpointed=%t, %d events", p.AuditIntegrity.ChainVerified, p.AuditIntegrity.Checkpointed, p.AuditIntegrity.ChainedEvents),
+			Frameworks: FrameworkRefs{ISO27001: []string{"A.5.28", "A.8.15"}, SOC2: []string{"CC7.2", "CC4.1"}, NIS2: []string{"Art.21(2)(i)"}, DORA: []string{"Art.9"}},
+		},
+		{
+			ID: "access-recertification", Name: "Access recertification at planned intervals", Area: "Access governance",
+			Status:     gapIf(ag.ProjectsOverdue > 0 || ag.ProjectsNeverReviewed > 0),
+			Detail:     fmt.Sprintf("%d overdue, %d never reviewed, %d pending items", ag.ProjectsOverdue, ag.ProjectsNeverReviewed, ag.PendingItems),
+			Frameworks: FrameworkRefs{ISO27001: []string{"A.5.18"}, SOC2: []string{"CC6.2", "CC6.3"}, NIS2: []string{"Art.21(2)(i)"}, DORA: []string{"Art.9"}},
+		},
+		{
+			ID: "dormant-access", Name: "No dormant standing access", Area: "Access governance",
+			Status:     gapIf(ag.DormantRoleGrants > 0),
+			Detail:     fmt.Sprintf("%d dormant role grant(s)", ag.DormantRoleGrants),
+			Frameworks: FrameworkRefs{ISO27001: []string{"A.5.18", "A.8.2"}, SOC2: []string{"CC6.1"}},
+		},
+		{
+			ID: "separation-of-duties", Name: "Separation of duties (no toxic combinations)", Area: "Access governance",
+			Status:     gapIf(ag.SoDViolations > 0),
+			Detail:     fmt.Sprintf("%d SoD violation(s)", ag.SoDViolations),
+			Frameworks: FrameworkRefs{ISO27001: []string{"A.5.3"}, SOC2: []string{"CC5.1"}, DORA: []string{"Art.5"}},
+		},
+		{
+			ID: "second-factor", Name: "Second-factor coverage", Area: "Identity",
+			Status:     gapIf(p.Identity.SecondFactorPercent < 100),
+			Detail:     fmt.Sprintf("%d%% of active users have a second factor", p.Identity.SecondFactorPercent),
+			Frameworks: FrameworkRefs{ISO27001: []string{"A.5.17", "A.8.5"}, SOC2: []string{"CC6.1"}, NIS2: []string{"Art.21(2)(j)"}, DORA: []string{"Art.9"}},
+		},
+		{
+			ID: "secret-rotation", Name: "Secret-rotation hygiene", Area: "Cryptography",
+			Status:     gapIf(p.Rotation.Overdue > 0),
+			Detail:     fmt.Sprintf("%d overdue, %d due soon of %d covered", p.Rotation.Overdue, p.Rotation.DueSoon, p.Rotation.CoveredSecrets),
+			Frameworks: FrameworkRefs{ISO27001: []string{"A.5.15", "A.8.24"}, SOC2: []string{"CC6.1"}, NIS2: []string{"Art.21(2)(h)"}},
+		},
+		{
+			ID: "data-classification", Name: "Secret data classification", Area: "Asset management",
+			Status:     gapIf(p.Classification.Unclassified > 0),
+			Detail:     fmt.Sprintf("%d of %d secrets unclassified", p.Classification.Unclassified, p.Classification.TotalSecrets),
+			Frameworks: FrameworkRefs{ISO27001: []string{"A.5.12", "A.5.13"}, SOC2: []string{"CC3.2"}},
+		},
+		{
+			ID: "anomaly-detection", Name: "Access-anomaly detection & response", Area: "Detection",
+			Status:     gapIf(p.Anomalies.HighSeverityOpen > 0),
+			Detail:     fmt.Sprintf("%d open anomalies (%d high severity)", p.Anomalies.Unacknowledged, p.Anomalies.HighSeverityOpen),
+			Frameworks: FrameworkRefs{ISO27001: []string{"A.8.16"}, SOC2: []string{"CC7.2", "CC7.3"}, NIS2: []string{"Art.21(2)(b)"}, DORA: []string{"Art.10"}},
+		},
+		{
+			ID: "emergency-access", Name: "Governed emergency (break-glass) access", Area: "Access governance",
+			Status:     ControlStatusPass, // presence of the register is the control; usage is informational
+			Detail:     fmt.Sprintf("%d active, %d total activations (all audited)", p.EmergencyAccess.ActiveActivations, p.EmergencyAccess.TotalActivations),
+			Frameworks: FrameworkRefs{ISO27001: []string{"A.5.15"}, SOC2: []string{"CC6.1"}, DORA: []string{"Art.9"}},
+		},
+		{
+			ID: "data-retention", Name: "Data-retention / storage limitation", Area: "Data governance",
+			Status:     statusFromBool(p.Retention.Enabled),
+			Detail:     retentionDetail(p.Retention),
+			Frameworks: FrameworkRefs{ISO27001: []string{"A.5.33"}, SOC2: []string{"CC3.2"}, DORA: []string{"Art.12"}},
+		},
+		{
+			ID: "legal-hold", Name: "Litigation/investigation legal hold", Area: "Data governance",
+			Status:     ControlStatusPass, // capability present; active state is informational
+			Detail:     legalHoldDetail(p.LegalHold),
+			Frameworks: FrameworkRefs{ISO27001: []string{"A.5.34"}, DORA: []string{"Art.12"}},
+		},
+	}
+}
+
+// statusFromBool maps an enabled flag to pass / not-configured (an unset optional
+// control is "not configured" rather than a gap — it may not apply to every install).
+func statusFromBool(enabled bool) ControlStatus {
+	if enabled {
+		return ControlStatusPass
+	}
+	return ControlStatusNotConfigured
+}
+
+func retentionDetail(r RetentionPosture) string {
+	if !r.Enabled {
+		return "no retention windows configured (records kept indefinitely)"
+	}
+	return fmt.Sprintf("windows set: anomaly=%dd, reviews=%dd, break-glass=%dd, requests=%dd",
+		r.AnomalyAlertsDays, r.ClosedAccessReviewsDays, r.BreakGlassDays, r.ResolvedAccessRequestsDays)
+}
+
+func legalHoldDetail(h LegalHoldPosture) string {
+	if h.Active {
+		return fmt.Sprintf("ACTIVE — purges blocked (%s)", h.Reason)
+	}
+	return "available; none currently active"
+}

--- a/internal/core/control_framework_test.go
+++ b/internal/core/control_framework_test.go
@@ -1,0 +1,79 @@
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// findControl returns the control with the given id (or fails the test).
+func findControl(t *testing.T, controls []ControlState, id string) ControlState {
+	t.Helper()
+	for _, c := range controls {
+		if c.ID == id {
+			return c
+		}
+	}
+	t.Fatalf("control %q not found", id)
+	return ControlState{}
+}
+
+// A fully-healthy posture yields all controls pass/not-configured, never a gap, and
+// every control carries an ISO 27001 reference.
+func TestEvaluateControls_HealthyPosture(t *testing.T) {
+	p := &CompliancePosture{
+		AuditIntegrity:   AuditIntegrityPosture{ChainVerified: true, Checkpointed: true, ChainedEvents: 100},
+		AccessGovernance: AccessGovernancePosture{Projects: 3},
+		Rotation:         RotationPosture{CoveredSecrets: 10},
+		Identity:         IdentityPosture{ActiveUsers: 5, UsersWithSecondFactor: 5, SecondFactorPercent: 100},
+		Classification:   ClassificationPosture{TotalSecrets: 10},
+		Anomalies:        AnomaliesPosture{},
+		Retention:        RetentionPosture{Enabled: true, AnomalyAlertsDays: 90},
+	}
+	controls := EvaluateControls(p)
+	require.NotEmpty(t, controls)
+	for _, c := range controls {
+		assert.NotEqual(t, ControlStatusGap, c.Status, "healthy posture has no gaps: %s", c.ID)
+		assert.NotEmpty(t, c.Frameworks.ISO27001, "control %s maps to an ISO 27001 clause", c.ID)
+		assert.NotEmpty(t, c.Name)
+	}
+	// Retention enabled → pass.
+	assert.Equal(t, ControlStatusPass, findControl(t, controls, "data-retention").Status)
+}
+
+// Each unhealthy posture figure flips the matching control to a gap.
+func TestEvaluateControls_GapsFromPosture(t *testing.T) {
+	p := &CompliancePosture{
+		AuditIntegrity: AuditIntegrityPosture{ChainVerified: false},
+		AccessGovernance: AccessGovernancePosture{
+			Projects: 4, ProjectsOverdue: 2, ProjectsNeverReviewed: 1, DormantRoleGrants: 3, SoDViolations: 1,
+		},
+		Rotation:       RotationPosture{Overdue: 2},
+		Identity:       IdentityPosture{ActiveUsers: 5, UsersWithSecondFactor: 3, SecondFactorPercent: 60},
+		Classification: ClassificationPosture{TotalSecrets: 10, Unclassified: 4},
+		Anomalies:      AnomaliesPosture{Unacknowledged: 3, HighSeverityOpen: 1},
+		Retention:      RetentionPosture{Enabled: false},
+	}
+	controls := EvaluateControls(p)
+	assert.Equal(t, ControlStatusGap, findControl(t, controls, "audit-trail-integrity").Status)
+	assert.Equal(t, ControlStatusGap, findControl(t, controls, "access-recertification").Status)
+	assert.Equal(t, ControlStatusGap, findControl(t, controls, "dormant-access").Status)
+	assert.Equal(t, ControlStatusGap, findControl(t, controls, "separation-of-duties").Status)
+	assert.Equal(t, ControlStatusGap, findControl(t, controls, "second-factor").Status)
+	assert.Equal(t, ControlStatusGap, findControl(t, controls, "secret-rotation").Status)
+	assert.Equal(t, ControlStatusGap, findControl(t, controls, "data-classification").Status)
+	assert.Equal(t, ControlStatusGap, findControl(t, controls, "anomaly-detection").Status)
+	// Retention unconfigured is "not configured", not a hard gap.
+	assert.Equal(t, ControlStatusNotConfigured, findControl(t, controls, "data-retention").Status)
+}
+
+func TestGetComplianceControls_SummaryTallies(t *testing.T) {
+	c, _, _ := newEvidenceExportCore(t) // real in-memory store, empty deployment
+	got, err := c.GetComplianceControls(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, len(got.Controls), got.Summary.Total)
+	assert.Equal(t, got.Summary.Total, got.Summary.Pass+got.Summary.Gap+got.Summary.NotConfigured)
+	assert.False(t, got.GeneratedAt.IsZero())
+}

--- a/server/http/handlers/dashboard.go
+++ b/server/http/handlers/dashboard.go
@@ -46,6 +46,18 @@ func (h *DashboardHandler) GetCompliancePosture(w http.ResponseWriter, r *http.R
 	sendSuccess(w, posture, "")
 }
 
+// GetComplianceControls handles GET /api/v1/compliance/controls — the control
+// matrix mapping each enforced control to its ISO 27001 / SOC 2 / NIS2 / DORA
+// references with a live status; gated by system.read in the router.
+func (h *DashboardHandler) GetComplianceControls(w http.ResponseWriter, r *http.Request) {
+	controls, err := h.coreService.GetComplianceControls(r.Context())
+	if err != nil {
+		sendError(w, "InternalServerError", "Failed to evaluate compliance controls", http.StatusInternalServerError, nil)
+		return
+	}
+	sendSuccess(w, controls, "")
+}
+
 // GetComplianceEvidence handles GET /api/v1/compliance/evidence — the auditor
 // evidence pack (posture + supporting records); gated by system.read in the router.
 func (h *DashboardHandler) GetComplianceEvidence(w http.ResponseWriter, r *http.Request) {

--- a/server/http/handlers/openapi.yaml
+++ b/server/http/handlers/openapi.yaml
@@ -2838,6 +2838,26 @@ paths:
             rotation, identity, emergency_access} — see the description for each group's fields.
         '401': {$ref: '#/components/responses/Error'}
         '403': {$ref: '#/components/responses/Error'}
+  /api/v1/compliance/controls:
+    get:
+      tags: [Dashboard]
+      summary: Compliance control matrix (ISO 27001 / SOC 2 / NIS2 / DORA)
+      description: >-
+        The control matrix: each control Keyorix enforces, mapped to its clause
+        references across ISO 27001 Annex A, SOC 2 Trust Services Criteria, NIS2,
+        and DORA, with a live status derived from the posture (pass | gap |
+        not_configured) and a human-readable detail. Includes a summary tally.
+        Requires system.read.
+      operationId: getComplianceControls
+      security: [{bearerAuth: []}]
+      responses:
+        '200':
+          description: >-
+            Envelope {data}. data: {generated_at, summary {total, pass, gap,
+            not_configured}, controls[] {id, name, area, status, detail, frameworks
+            {iso_27001[], soc2[], nis2[], dora[]}}}.
+        '401': {$ref: '#/components/responses/Error'}
+        '403': {$ref: '#/components/responses/Error'}
   /api/v1/compliance/evidence:
     get:
       tags: [Dashboard]

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -457,6 +457,8 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 
 		// Compliance posture — deployment-wide controls snapshot for auditors.
 		r.With(customMiddleware.RequirePermission("system.read")).Get("/compliance/posture", dashboardHandler.GetCompliancePosture)
+		// Compliance control matrix — controls mapped to ISO/SOC2/NIS2/DORA + status.
+		r.With(customMiddleware.RequirePermission("system.read")).Get("/compliance/controls", dashboardHandler.GetComplianceControls)
 		// Legal hold (ISO A.5.34): status reads system.read; place/lift system.write.
 		r.With(customMiddleware.RequirePermission("system.read")).Get("/legal-hold", dashboardHandler.GetLegalHold)
 		r.With(customMiddleware.RequirePermission("system.write")).Post("/legal-hold", dashboardHandler.PlaceLegalHold)


### PR DESCRIPTION
## What

A first-class **compliance control matrix**: each control Keyorix enforces, mapped to its clause references across **ISO 27001 Annex A, SOC 2 TSC, NIS2, and DORA**, with a **live status** (pass / gap / not_configured) derived from the posture. Turns the scattered A.5.x posture tiles into one auditor-ready framework map.

Batch 1 of the next program (control matrix → risk register → SCIM), per "1 3 4".

## How

- **core** — `control_framework.go`: `EvaluateControls(posture)` is a **pure function** (no storage) mapping ~11 controls to `FrameworkRefs` + a status; `GetComplianceControls` wraps it with a summary tally. Pass/gap is derived from posture figures; an unset *optional* control (retention) is `not_configured`, not a hard gap.
- **API** — `GET /compliance/controls` (system.read): handler + route + openapi.
- **evidence** — the matrix is embedded in the evidence pack (additive `Controls` field).
- **CLI** — `keyorix compliance controls` prints the matrix with per-framework refs and a pass/gap/not-configured summary.

## Tests

- Pure-function coverage: a healthy posture has **no gaps** and every control carries an ISO ref; each unhealthy figure flips its control to a **gap**; retention-unconfigured → `not_configured`; `GetComplianceControls` summary tallies.

Web (a Framework-matrix panel on the Compliance page) follows in keyorix-web.

🤖 Generated with [Claude Code](https://claude.com/claude-code)