### PR TITLE
feat(risk): risk register — governed, time-bound exceptions (ISO 27001 A.5.8)

### DIFF
--- a/internal/cli/main.go
+++ b/internal/cli/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/keyorixhq/keyorix/internal/cli/project"
 	"github.com/keyorixhq/keyorix/internal/cli/rbac"
 	"github.com/keyorixhq/keyorix/internal/cli/request"
+	"github.com/keyorixhq/keyorix/internal/cli/risk"
 	"github.com/keyorixhq/keyorix/internal/cli/rotation"
 	"github.com/keyorixhq/keyorix/internal/cli/run"
 	"github.com/keyorixhq/keyorix/internal/cli/secret"
@@ -55,6 +56,7 @@ func init() {
 	rootCmd.AddCommand(group.GroupCmd)
 	rootCmd.AddCommand(invite.InviteCmd)
 	rootCmd.AddCommand(legalhold.LegalHoldCmd)
+	rootCmd.AddCommand(risk.RiskCmd)
 	rootCmd.AddCommand(request.RequestCmd)
 	rootCmd.AddCommand(share.ShareCmd)
 	rootCmd.AddCommand(auth.AuthCmd)

--- a/internal/cli/risk/risk.go
+++ b/internal/cli/risk/risk.go
@@ -1,0 +1,136 @@
+// Package risk provides `keyorix risk` — the risk register / exceptions (ISO 27001
+// A.5.8 risk treatment): governed, time-bound acceptances of a known control gap.
+// Talks to /api/v1/risk-exceptions (list reads system.read; add/revoke system.write).
+package risk
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/spf13/cobra"
+)
+
+// RiskCmd is the `keyorix risk` command.
+var RiskCmd = &cobra.Command{
+	Use:   "risk",
+	Short: "Risk register — governed, time-bound exceptions to control gaps (A.5.8)",
+	Long: `Record and review accepted risk exceptions: a known control gap, accepted by
+an owner with a justification, that sunsets at a fixed date. An active exception is
+the evidence that a gap is governed (accepted with a deadline) rather than ignored.`,
+}
+
+type exceptionView struct {
+	ID            uint   `json:"id"`
+	Title         string `json:"title"`
+	Category      string `json:"category"`
+	Reference     string `json:"reference"`
+	Justification string `json:"justification"`
+	Status        string `json:"status"`
+	ExpiresAt     string `json:"expires_at"`
+	CreatedBy     uint   `json:"created_by"`
+}
+
+var listAll bool
+
+var listCmd = &cobra.Command{
+	Use:          "list",
+	Short:        "List risk exceptions (active by default; --all includes expired)",
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		c, ok := common.NewRemoteClient()
+		if !ok {
+			return fmt.Errorf("not connected to a server — run: keyorix connect <server>")
+		}
+		path := "/api/v1/risk-exceptions"
+		if listAll {
+			path += "?all=true"
+		}
+		var out struct {
+			Exceptions []exceptionView `json:"exceptions"`
+		}
+		if err := c.Get(context.Background(), path, &out); err != nil {
+			return err
+		}
+		if len(out.Exceptions) == 0 {
+			fmt.Println("No risk exceptions.")
+			return nil
+		}
+		for _, e := range out.Exceptions {
+			fmt.Printf("[%s] #%d %s (category=%s, ref=%q)\n", e.Status, e.ID, e.Title, e.Category, e.Reference)
+			fmt.Printf("        expires %s — %s\n", e.ExpiresAt, e.Justification)
+		}
+		return nil
+	},
+}
+
+var (
+	addTitle, addCategory, addReference, addJustification, addExpires string
+)
+
+var addCmd = &cobra.Command{
+	Use:          "add",
+	Short:        "Record a risk exception (accept a control gap for a bounded time)",
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		if addTitle == "" || addJustification == "" {
+			return fmt.Errorf("--title and --justification are required")
+		}
+		if addExpires == "" {
+			return fmt.Errorf("--expires is required (RFC3339, e.g. 2026-12-31T00:00:00Z)")
+		}
+		if _, err := time.Parse(time.RFC3339, addExpires); err != nil {
+			return fmt.Errorf("--expires must be RFC3339 (e.g. 2026-12-31T00:00:00Z)")
+		}
+		c, ok := common.NewRemoteClient()
+		if !ok {
+			return fmt.Errorf("not connected to a server — run: keyorix connect <server>")
+		}
+		body := map[string]string{
+			"title": addTitle, "category": addCategory, "reference": addReference,
+			"justification": addJustification, "expires_at": addExpires,
+		}
+		var out struct {
+			Exception exceptionView `json:"exception"`
+		}
+		if err := c.Post(context.Background(), "/api/v1/risk-exceptions", body, &out); err != nil {
+			return err
+		}
+		fmt.Printf("Risk exception recorded (id=%d), expiring %s.\n", out.Exception.ID, addExpires)
+		return nil
+	},
+}
+
+var revokeID uint
+
+var revokeCmd = &cobra.Command{
+	Use:          "revoke",
+	Short:        "Revoke a risk exception before its expiry",
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		if revokeID == 0 {
+			return fmt.Errorf("--id is required")
+		}
+		c, ok := common.NewRemoteClient()
+		if !ok {
+			return fmt.Errorf("not connected to a server — run: keyorix connect <server>")
+		}
+		if err := c.Delete(context.Background(), fmt.Sprintf("/api/v1/risk-exceptions/%d", revokeID)); err != nil {
+			return err
+		}
+		fmt.Printf("Risk exception %d revoked.\n", revokeID)
+		return nil
+	},
+}
+
+func init() {
+	listCmd.Flags().BoolVar(&listAll, "all", false, "Include expired exceptions (history)")
+	addCmd.Flags().StringVar(&addTitle, "title", "", "Short name for the accepted risk (required)")
+	addCmd.Flags().StringVar(&addCategory, "category", "other", "sod | mfa | rotation | dormant_access | classification | other")
+	addCmd.Flags().StringVar(&addReference, "reference", "", "What it applies to (a user, an SoD pair, a secret)")
+	addCmd.Flags().StringVar(&addJustification, "justification", "", "Why the risk is accepted (required, recorded for audit)")
+	addCmd.Flags().StringVar(&addExpires, "expires", "", "When the exception sunsets (RFC3339, required)")
+	revokeCmd.Flags().UintVar(&revokeID, "id", 0, "ID of the exception to revoke (required)")
+	RiskCmd.AddCommand(listCmd, addCmd, revokeCmd)
+}

--- a/internal/core/compliance_evidence.go
+++ b/internal/core/compliance_evidence.go
@@ -59,6 +59,7 @@ type ComplianceEvidence struct {
 	BreakGlass      []*models.BreakGlassActivation `json:"break_glass"`
 	RotationOverdue []EvidenceRotation             `json:"rotation_overdue"`
 	SoDViolations   []SoDViolation                 `json:"sod_violations"`
+	RiskExceptions  []*RiskExceptionView           `json:"risk_exceptions"` // active governed exceptions (A.5.8)
 }
 
 // GenerateComplianceEvidence assembles the evidence pack. Like the posture, it is an
@@ -76,6 +77,12 @@ func (c *KeyorixCore) GenerateComplianceEvidence(ctx context.Context) (*Complian
 		BreakGlass:      []*models.BreakGlassActivation{},
 		RotationOverdue: []EvidenceRotation{},
 		SoDViolations:   []SoDViolation{},
+		RiskExceptions:  []*RiskExceptionView{},
+	}
+
+	// Active risk exceptions (the governed-acceptance register).
+	if exceptions, err := c.ListRiskExceptions(ctx, true); err == nil {
+		ev.RiskExceptions = exceptions
 	}
 
 	// Separation-of-duties violations (the toxic-combination register).

--- a/internal/core/compliance_posture.go
+++ b/internal/core/compliance_posture.go
@@ -95,6 +95,14 @@ type RetentionPosture struct {
 	ResolvedAccessRequestsDays int  `json:"resolved_access_requests_days"`
 }
 
+// RiskPosture summarises the risk register (ISO 27001 A.5.8 risk treatment): how
+// many governed, time-bound exceptions are currently active and how many expire soon
+// (so an auditor sees accepted-with-a-deadline risks rather than ungoverned gaps).
+type RiskPosture struct {
+	ActiveExceptions int `json:"active_exceptions"`
+	ExpiringSoon     int `json:"expiring_soon"` // active exceptions expiring within the soon window
+}
+
 // CompliancePosture is the deployment's control posture at a point in time.
 type CompliancePosture struct {
 	GeneratedAt      time.Time               `json:"generated_at"`
@@ -107,7 +115,12 @@ type CompliancePosture struct {
 	Anomalies        AnomaliesPosture        `json:"anomalies"`
 	LegalHold        LegalHoldPosture        `json:"legal_hold"`
 	Retention        RetentionPosture        `json:"retention"`
+	Risk             RiskPosture             `json:"risk"`
 }
+
+// riskExpiringSoonWindow is how far ahead an active exception counts as "expiring
+// soon" in the posture.
+const riskExpiringSoonWindow = 14 * 24 * time.Hour
 
 // GetCompliancePosture aggregates the deployment's control posture. It is an
 // on-demand admin report (it walks every project for the access-governance roll-up),
@@ -177,6 +190,11 @@ func (c *KeyorixCore) GetCompliancePosture(ctx context.Context) (*CompliancePost
 	if hold, err := c.storage.GetActiveLegalHold(ctx); err == nil && hold != nil {
 		at := hold.PlacedAt
 		p.LegalHold = LegalHoldPosture{Active: true, PlacedAt: &at, Reason: hold.Reason}
+	}
+
+	// Risk register — governed, time-bound exceptions (A.5.8).
+	if active, soon, err := c.CountActiveRiskExceptions(ctx, riskExpiringSoonWindow); err == nil {
+		p.Risk = RiskPosture{ActiveExceptions: active, ExpiringSoon: soon}
 	}
 
 	// Data-retention windows (A.5.33).

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -292,6 +292,35 @@ func (m *MockStorage) UpdateLegalHold(ctx context.Context, h *models.LegalHold) 
 	return args.Error(0)
 }
 
+func (m *MockStorage) CreateRiskException(ctx context.Context, e *models.RiskException) (*models.RiskException, error) {
+	args := m.Called(ctx, e)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.RiskException), args.Error(1)
+}
+
+func (m *MockStorage) ListRiskExceptions(ctx context.Context, activeOnly bool) ([]*models.RiskException, error) {
+	args := m.Called(ctx, activeOnly)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*models.RiskException), args.Error(1)
+}
+
+func (m *MockStorage) GetRiskException(ctx context.Context, id uint) (*models.RiskException, error) {
+	args := m.Called(ctx, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.RiskException), args.Error(1)
+}
+
+func (m *MockStorage) UpdateRiskException(ctx context.Context, e *models.RiskException) error {
+	args := m.Called(ctx, e)
+	return args.Error(0)
+}
+
 func (m *MockStorage) CreateBreakGlassActivation(ctx context.Context, a *models.BreakGlassActivation) (*models.BreakGlassActivation, error) {
 	args := m.Called(ctx, a)
 	if args.Get(0) == nil {

--- a/internal/core/risk_exceptions.go
+++ b/internal/core/risk_exceptions.go
@@ -1,0 +1,136 @@
+// risk_exceptions.go — the risk register / exceptions (ISO 27001 A.5.8 risk
+// treatment / A.5.36 compliance with policies). An exception is a governed,
+// time-bound acceptance of a known control gap: a named risk, accepted by an owner
+// with a written justification, that sunsets at a fixed date. It turns a raw
+// posture violation into a *governed* exception an auditor can see was accepted with
+// a deadline, not silently ignored. Effective status (active/expired/revoked) is
+// computed at read time from the revoked flag and the expiry.
+package core
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// Effective risk-exception status (computed from revoked + expiry).
+const (
+	ExceptionStatusActive  = "active"
+	ExceptionStatusExpired = "expired"
+	ExceptionStatusRevoked = "revoked"
+
+	EventRiskExceptionCreated = "risk.exception_created"
+	EventRiskExceptionRevoked = "risk.exception_revoked"
+)
+
+// validExceptionCategories are the risk areas an exception may cover (aligned with
+// the posture controls so an exception can annotate a specific gap).
+var validExceptionCategories = map[string]struct{}{
+	"sod": {}, "mfa": {}, "rotation": {}, "dormant_access": {}, "classification": {}, "other": {},
+}
+
+// RiskExceptionView is a stored exception plus its effective status at read time.
+type RiskExceptionView struct {
+	*models.RiskException
+	Status string `json:"status"` // active | expired | revoked (computed)
+}
+
+// exceptionStatus computes the effective status from the revoked flag and expiry.
+func exceptionStatus(e *models.RiskException, now time.Time) string {
+	if e.Revoked {
+		return ExceptionStatusRevoked
+	}
+	if !e.ExpiresAt.After(now) {
+		return ExceptionStatusExpired
+	}
+	return ExceptionStatusActive
+}
+
+// CreateRiskException records a governed, time-bound acceptance of a control gap.
+// actorID is the accepting owner; expiresAt must be in the future.
+func (c *KeyorixCore) CreateRiskException(ctx context.Context, actorID uint, title, category, reference, justification string, expiresAt time.Time) (*models.RiskException, error) {
+	if title == "" || justification == "" {
+		return nil, fmt.Errorf("title and justification are required")
+	}
+	if _, ok := validExceptionCategories[category]; !ok {
+		return nil, fmt.Errorf("category must be one of sod|mfa|rotation|dormant_access|classification|other")
+	}
+	if !expiresAt.After(c.now()) {
+		return nil, fmt.Errorf("expires_at must be in the future (exceptions are time-bound)")
+	}
+	created, err := c.storage.CreateRiskException(ctx, &models.RiskException{
+		Title: title, Category: category, Reference: reference, Justification: justification,
+		CreatedBy: actorID, CreatedAt: c.now(), ExpiresAt: expiresAt,
+	})
+	if err != nil {
+		return nil, err
+	}
+	c.writeAuditEvent(ctx, EventRiskExceptionCreated, actorPtr(actorID), nil,
+		fmt.Sprintf("risk exception %d accepted: %q (category=%s, ref=%q) until %s",
+			created.ID, title, category, reference, expiresAt.UTC().Format(time.RFC3339)))
+	return created, nil
+}
+
+// ListRiskExceptions returns exceptions with their effective status. When activeOnly
+// is set, only currently-active (not revoked, not expired) exceptions are returned;
+// otherwise every non-revoked exception is returned (expired included, for history).
+func (c *KeyorixCore) ListRiskExceptions(ctx context.Context, activeOnly bool) ([]*RiskExceptionView, error) {
+	rows, err := c.storage.ListRiskExceptions(ctx, activeOnly) // activeOnly excludes revoked at storage
+	if err != nil {
+		return nil, err
+	}
+	now := c.now()
+	out := make([]*RiskExceptionView, 0, len(rows))
+	for _, e := range rows {
+		st := exceptionStatus(e, now)
+		if activeOnly && st != ExceptionStatusActive {
+			continue // storage dropped revoked; drop expired here too
+		}
+		out = append(out, &RiskExceptionView{RiskException: e, Status: st})
+	}
+	return out, nil
+}
+
+// RevokeRiskException withdraws an exception before its expiry. actorID is the admin.
+func (c *KeyorixCore) RevokeRiskException(ctx context.Context, actorID, id uint) error {
+	e, err := c.storage.GetRiskException(ctx, id)
+	if err != nil {
+		return err
+	}
+	if e.Revoked {
+		return fmt.Errorf("risk exception %d is already revoked", id)
+	}
+	now := c.now()
+	e.Revoked = true
+	e.RevokedBy = actorID
+	e.RevokedAt = &now
+	if err := c.storage.UpdateRiskException(ctx, e); err != nil {
+		return err
+	}
+	c.writeAuditEvent(ctx, EventRiskExceptionRevoked, actorPtr(actorID), nil,
+		fmt.Sprintf("risk exception %d revoked: %q", id, e.Title))
+	return nil
+}
+
+// CountActiveRiskExceptions returns how many exceptions are currently active and how
+// many of those expire within the `soon` window — for the compliance posture.
+func (c *KeyorixCore) CountActiveRiskExceptions(ctx context.Context, soon time.Duration) (active, expiringSoon int, err error) {
+	rows, err := c.storage.ListRiskExceptions(ctx, true)
+	if err != nil {
+		return 0, 0, err
+	}
+	now := c.now()
+	cutoff := now.Add(soon)
+	for _, e := range rows {
+		if exceptionStatus(e, now) != ExceptionStatusActive {
+			continue
+		}
+		active++
+		if e.ExpiresAt.Before(cutoff) {
+			expiringSoon++
+		}
+	}
+	return active, expiringSoon, nil
+}

--- a/internal/core/risk_exceptions_test.go
+++ b/internal/core/risk_exceptions_test.go
@@ -1,0 +1,99 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func riskCore(store *MockStorage, now time.Time) *KeyorixCore {
+	return &KeyorixCore{storage: store, now: func() time.Time { return now }}
+}
+
+func TestCreateRiskException_ValidatesAndAudits(t *testing.T) {
+	now := time.Date(2026, 6, 14, 0, 0, 0, 0, time.UTC)
+	store := new(MockStorage)
+	store.On("CreateRiskException", mock.Anything, mock.MatchedBy(func(e *models.RiskException) bool {
+		return e.Title == "accept SoD for migration" && e.Category == "sod" && e.CreatedBy == 9
+	})).Return(&models.RiskException{ID: 1, Title: "accept SoD for migration"}, nil)
+	var audited string
+	store.On("LogAuditEvent", mock.Anything, mock.MatchedBy(func(ev *models.AuditEvent) bool {
+		if ev.EventType == EventRiskExceptionCreated {
+			audited = ev.EventType
+			return true
+		}
+		return false
+	})).Return(nil)
+
+	c := riskCore(store, now)
+	_, err := c.CreateRiskException(context.Background(), 9, "accept SoD for migration", "sod", "alice+roles.assign/secrets.delete", "temporary during cutover", now.AddDate(0, 0, 30))
+	require.NoError(t, err)
+	assert.Equal(t, EventRiskExceptionCreated, audited)
+}
+
+func TestCreateRiskException_Rejects(t *testing.T) {
+	now := time.Now()
+	c := riskCore(new(MockStorage), now)
+
+	_, err := c.CreateRiskException(context.Background(), 1, "", "sod", "", "", now.Add(time.Hour))
+	require.Error(t, err, "title + justification required")
+
+	_, err = c.CreateRiskException(context.Background(), 1, "t", "bogus", "", "j", now.Add(time.Hour))
+	require.Error(t, err, "invalid category")
+
+	_, err = c.CreateRiskException(context.Background(), 1, "t", "sod", "", "j", now.Add(-time.Hour))
+	require.Error(t, err, "expiry must be in the future")
+}
+
+func TestListRiskExceptions_ComputesStatusAndFilters(t *testing.T) {
+	now := time.Date(2026, 6, 14, 0, 0, 0, 0, time.UTC)
+	store := new(MockStorage)
+	rows := []*models.RiskException{
+		{ID: 1, Title: "active", ExpiresAt: now.AddDate(0, 0, 10)},  // active
+		{ID: 2, Title: "expired", ExpiresAt: now.AddDate(0, 0, -1)}, // expired
+	}
+	store.On("ListRiskExceptions", mock.Anything, true).Return(rows, nil)
+
+	c := riskCore(store, now)
+
+	// activeOnly drops the expired one.
+	active, err := c.ListRiskExceptions(context.Background(), true)
+	require.NoError(t, err)
+	require.Len(t, active, 1)
+	assert.Equal(t, ExceptionStatusActive, active[0].Status)
+	assert.Equal(t, "active", active[0].Title)
+}
+
+func TestRevokeRiskException(t *testing.T) {
+	now := time.Now()
+	store := new(MockStorage)
+	store.On("GetRiskException", mock.Anything, uint(5)).Return(&models.RiskException{ID: 5, Title: "x"}, nil)
+	store.On("UpdateRiskException", mock.Anything, mock.MatchedBy(func(e *models.RiskException) bool {
+		return e.ID == 5 && e.Revoked && e.RevokedBy == 3 && e.RevokedAt != nil
+	})).Return(nil)
+	store.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
+
+	c := riskCore(store, now)
+	require.NoError(t, c.RevokeRiskException(context.Background(), 3, 5))
+}
+
+func TestCountActiveRiskExceptions(t *testing.T) {
+	now := time.Date(2026, 6, 14, 0, 0, 0, 0, time.UTC)
+	store := new(MockStorage)
+	store.On("ListRiskExceptions", mock.Anything, true).Return([]*models.RiskException{
+		{ID: 1, ExpiresAt: now.AddDate(0, 0, 3)},  // active, expiring soon (<14d)
+		{ID: 2, ExpiresAt: now.AddDate(0, 0, 60)}, // active, not soon
+		{ID: 3, ExpiresAt: now.AddDate(0, 0, -1)}, // expired
+	}, nil)
+
+	c := riskCore(store, now)
+	active, soon, err := c.CountActiveRiskExceptions(context.Background(), riskExpiringSoonWindow)
+	require.NoError(t, err)
+	assert.Equal(t, 2, active)
+	assert.Equal(t, 1, soon)
+}

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -92,6 +92,15 @@ type Storage interface {
 	GetActiveLegalHold(ctx context.Context) (*models.LegalHold, error)
 	UpdateLegalHold(ctx context.Context, h *models.LegalHold) error
 
+	// Risk exceptions (ISO 27001 A.5.8 risk treatment) — governed, time-bound
+	// acceptances of a known control gap. CreateRiskException records one;
+	// ListRiskExceptions returns all (activeOnly excludes revoked rows; expiry is
+	// computed in core); GetRiskException/UpdateRiskException support revoke.
+	CreateRiskException(ctx context.Context, e *models.RiskException) (*models.RiskException, error)
+	ListRiskExceptions(ctx context.Context, activeOnly bool) ([]*models.RiskException, error)
+	GetRiskException(ctx context.Context, id uint) (*models.RiskException, error)
+	UpdateRiskException(ctx context.Context, e *models.RiskException) error
+
 	// Break-glass emergency-access activations (NIS2/DORA incident response).
 	CreateBreakGlassActivation(ctx context.Context, a *models.BreakGlassActivation) (*models.BreakGlassActivation, error)
 	GetBreakGlassActivation(ctx context.Context, id uint) (*models.BreakGlassActivation, error)

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -264,6 +264,7 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 	campaignExists := tableExists(db, "access_review_campaigns")
 	breakGlassExists := tableExists(db, "break_glass_activations")
 	legalHoldExists := tableExists(db, "legal_holds")
+	riskExceptionExists := tableExists(db, "risk_exceptions")
 	sodExists := tableExists(db, "sod_policies")
 	pwHistExists := tableExists(db, "password_histories")
 	machineExists := tableExists(db, "machine_identities")
@@ -422,6 +423,13 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 	if !legalHoldExists {
 		if err := db.AutoMigrate(&models.LegalHold{}); err != nil {
 			return fmt.Errorf("failed to migrate legal_holds table: %w", err)
+		}
+	}
+
+	// Create the risk-exceptions table if missing (A.5.8 risk treatment, additive).
+	if !riskExceptionExists {
+		if err := db.AutoMigrate(&models.RiskException{}); err != nil {
+			return fmt.Errorf("failed to migrate risk_exceptions table: %w", err)
 		}
 	}
 

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -116,6 +116,26 @@ type LegalHold struct {
 	ReleasedAt *time.Time `json:"released_at,omitempty"`
 }
 
+// RiskException records a governed acceptance of a known control gap or policy
+// exception (ISO 27001 A.5.8 risk treatment / A.5.36 compliance-with-policies): a
+// named risk, accepted by an owner with a written justification, for a bounded time.
+// While active (not revoked and not past ExpiresAt) it is the auditable evidence that
+// a gap is *accepted with a sunset*, not silently ignored — so an auditor sees a
+// governed exception rather than a raw violation. Exceptions are always time-bound.
+type RiskException struct {
+	ID            uint       `gorm:"primaryKey" json:"id"`
+	Title         string     `json:"title"`
+	Category      string     `json:"category"`            // sod | mfa | rotation | dormant_access | classification | other
+	Reference     string     `json:"reference,omitempty"` // what it applies to (a user, an SoD pair, a secret)
+	Justification string     `json:"justification"`
+	CreatedBy     uint       `json:"created_by"`
+	CreatedAt     time.Time  `json:"created_at"`
+	ExpiresAt     time.Time  `gorm:"index" json:"expires_at"` // required — exceptions sunset
+	Revoked       bool       `gorm:"index" json:"revoked"`    // true = withdrawn before expiry
+	RevokedBy     uint       `json:"revoked_by,omitempty"`
+	RevokedAt     *time.Time `json:"revoked_at,omitempty"`
+}
+
 // BreakGlassActivation records a self-service emergency-access elevation: a user
 // immediately self-granted a time-bound emergency role (no approval), with a
 // written justification, for incident response (NIS2/DORA). The grant itself is a

--- a/internal/storage/store/local_risk_exceptions.go
+++ b/internal/storage/store/local_risk_exceptions.go
@@ -1,0 +1,54 @@
+// local_risk_exceptions.go — risk-exception persistence (ISO 27001 A.5.8 risk
+// treatment). For the remote equivalent see remote_risk_exceptions.go (server-side).
+package store
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"gorm.io/gorm"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+func (ls *LocalStorage) CreateRiskException(ctx context.Context, e *models.RiskException) (*models.RiskException, error) {
+	if err := ls.db.WithContext(ctx).Create(e).Error; err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	return e, nil
+}
+
+// ListRiskExceptions returns risk exceptions newest-first. When activeOnly is set,
+// revoked rows are excluded (expiry is computed in core, not at the storage layer).
+func (ls *LocalStorage) ListRiskExceptions(ctx context.Context, activeOnly bool) ([]*models.RiskException, error) {
+	var rows []*models.RiskException
+	q := ls.db.WithContext(ctx).Order("id DESC")
+	if activeOnly {
+		q = q.Where("revoked = ?", false)
+	}
+	if err := q.Find(&rows).Error; err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	return rows, nil
+}
+
+func (ls *LocalStorage) GetRiskException(ctx context.Context, id uint) (*models.RiskException, error) {
+	var e models.RiskException
+	err := ls.db.WithContext(ctx).First(&e, id).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, fmt.Errorf("%s", i18n.T("ErrorNotFound", nil))
+	}
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	return &e, nil
+}
+
+func (ls *LocalStorage) UpdateRiskException(ctx context.Context, e *models.RiskException) error {
+	if err := ls.db.WithContext(ctx).Save(e).Error; err != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	return nil
+}

--- a/internal/storage/store/local_risk_exceptions_test.go
+++ b/internal/storage/store/local_risk_exceptions_test.go
@@ -1,0 +1,52 @@
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func newRiskTestStore(t *testing.T) *LocalStorage {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.RiskException{}))
+	return NewLocalStorage(db)
+}
+
+func TestRiskExceptions_CreateListRevoke(t *testing.T) {
+	ls := newRiskTestStore(t)
+	ctx := context.Background()
+	exp := time.Now().AddDate(0, 0, 30)
+
+	a, err := ls.CreateRiskException(ctx, &models.RiskException{Title: "a", Category: "sod", ExpiresAt: exp})
+	require.NoError(t, err)
+	_, err = ls.CreateRiskException(ctx, &models.RiskException{Title: "b", Category: "mfa", ExpiresAt: exp, Revoked: true})
+	require.NoError(t, err)
+
+	// activeOnly excludes the revoked row.
+	active, err := ls.ListRiskExceptions(ctx, true)
+	require.NoError(t, err)
+	require.Len(t, active, 1)
+	assert.Equal(t, "a", active[0].Title)
+
+	// Without activeOnly, both are returned.
+	all, err := ls.ListRiskExceptions(ctx, false)
+	require.NoError(t, err)
+	assert.Len(t, all, 2)
+
+	// Revoke via update; it then drops out of the active list.
+	got, err := ls.GetRiskException(ctx, a.ID)
+	require.NoError(t, err)
+	got.Revoked = true
+	require.NoError(t, ls.UpdateRiskException(ctx, got))
+	active, err = ls.ListRiskExceptions(ctx, true)
+	require.NoError(t, err)
+	assert.Empty(t, active)
+}

--- a/internal/storage/store/remote_risk_exceptions.go
+++ b/internal/storage/store/remote_risk_exceptions.go
@@ -1,0 +1,25 @@
+// remote_risk_exceptions.go — risk exceptions for RemoteStorage. Processed
+// server-side; stubs here. See local_risk_exceptions.go.
+package store
+
+import (
+	"context"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+func (rs *RemoteStorage) CreateRiskException(_ context.Context, _ *models.RiskException) (*models.RiskException, error) {
+	return nil, remoteUnsupported("CreateRiskException")
+}
+
+func (rs *RemoteStorage) ListRiskExceptions(_ context.Context, _ bool) ([]*models.RiskException, error) {
+	return nil, remoteUnsupported("ListRiskExceptions")
+}
+
+func (rs *RemoteStorage) GetRiskException(_ context.Context, _ uint) (*models.RiskException, error) {
+	return nil, remoteUnsupported("GetRiskException")
+}
+
+func (rs *RemoteStorage) UpdateRiskException(_ context.Context, _ *models.RiskException) error {
+	return remoteUnsupported("UpdateRiskException")
+}

--- a/server/http/handlers/openapi.yaml
+++ b/server/http/handlers/openapi.yaml
@@ -2921,6 +2921,61 @@ paths:
         '400': {$ref: '#/components/responses/Error'}
         '401': {$ref: '#/components/responses/Error'}
         '403': {$ref: '#/components/responses/Error'}
+  /api/v1/risk-exceptions:
+    get:
+      tags: [Dashboard]
+      summary: Risk register — governed, time-bound exceptions (ISO 27001 A.5.8)
+      description: >-
+        The risk register: governed acceptances of a known control gap, each with an
+        owner, justification, and sunset date. Active only by default; ?all=true
+        includes expired exceptions (history). Each carries a computed status
+        (active | expired | revoked). Requires system.read.
+      operationId: listRiskExceptions
+      parameters:
+        - {name: all, in: query, schema: {type: boolean}, description: "Include expired exceptions."}
+      security: [{bearerAuth: []}]
+      responses:
+        '200': {description: "Envelope {data}. data: {exceptions[] {id, title, category, reference, justification, status, expires_at, created_by, created_at}}."}
+        '401': {$ref: '#/components/responses/Error'}
+        '403': {$ref: '#/components/responses/Error'}
+    post:
+      tags: [Dashboard]
+      summary: Record a risk exception (accept a control gap for a bounded time)
+      description: "Accept a known gap with a justification and a required future expiry. Requires system.write."
+      operationId: createRiskException
+      security: [{bearerAuth: []}]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [title, justification, expires_at]
+              properties:
+                title: {type: string}
+                category: {type: string, enum: [sod, mfa, rotation, dormant_access, classification, other]}
+                reference: {type: string, description: "What it applies to (a user, an SoD pair, a secret)."}
+                justification: {type: string}
+                expires_at: {type: string, format: date-time, description: "RFC3339; must be in the future."}
+      responses:
+        '201': {description: "Envelope {data, message}. data: {exception}."}
+        '400': {$ref: '#/components/responses/Error'}
+        '401': {$ref: '#/components/responses/Error'}
+        '403': {$ref: '#/components/responses/Error'}
+  /api/v1/risk-exceptions/{id}:
+    delete:
+      tags: [Dashboard]
+      summary: Revoke a risk exception before its expiry (ISO 27001 A.5.8)
+      operationId: revokeRiskException
+      parameters:
+        - {name: id, in: path, required: true, schema: {type: integer}}
+      security: [{bearerAuth: []}]
+      responses:
+        '200': {description: "Envelope {data, message}. Risk exception revoked."}
+        '400': {$ref: '#/components/responses/Error'}
+        '401': {$ref: '#/components/responses/Error'}
+        '403': {$ref: '#/components/responses/Error'}
+        '404': {$ref: '#/components/responses/Error'}
   /api/v1/sod/policies:
     get:
       tags: [Dashboard]

--- a/server/http/handlers/risk_exceptions.go
+++ b/server/http/handlers/risk_exceptions.go
@@ -1,0 +1,92 @@
+// risk_exceptions.go — the risk register / exceptions endpoints (ISO 27001 A.5.8
+// risk treatment). Listing needs system.read; create/revoke need system.write
+// (wired in router.go).
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/keyorixhq/keyorix/server/middleware"
+)
+
+// ListRiskExceptions handles GET /api/v1/risk-exceptions — the register. ?all=true
+// includes expired exceptions (history); default is active only.
+func (h *DashboardHandler) ListRiskExceptions(w http.ResponseWriter, r *http.Request) {
+	activeOnly := r.URL.Query().Get("all") != "true"
+	exceptions, err := h.coreService.ListRiskExceptions(r.Context(), activeOnly)
+	if err != nil {
+		sendError(w, "Error", err.Error(), http.StatusInternalServerError, nil)
+		return
+	}
+	sendSuccess(w, map[string]interface{}{"exceptions": exceptions}, "")
+}
+
+// CreateRiskException handles POST /api/v1/risk-exceptions — accept a control gap for
+// a bounded time with a justification.
+func (h *DashboardHandler) CreateRiskException(w http.ResponseWriter, r *http.Request) {
+	actor := middleware.GetUserFromContext(r.Context())
+	if actor == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	var body struct {
+		Title         string `json:"title"`
+		Category      string `json:"category"`
+		Reference     string `json:"reference"`
+		Justification string `json:"justification"`
+		ExpiresAt     string `json:"expires_at"` // RFC3339
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		sendError(w, "InvalidJSON", "Invalid request body", http.StatusBadRequest, nil)
+		return
+	}
+	expiresAt, err := time.Parse(time.RFC3339, body.ExpiresAt)
+	if err != nil {
+		sendError(w, "InvalidParameter", "expires_at must be an RFC3339 timestamp", http.StatusBadRequest, nil)
+		return
+	}
+	exc, err := h.coreService.CreateRiskException(r.Context(), actor.UserID, body.Title, body.Category, body.Reference, body.Justification, expiresAt)
+	if err != nil {
+		status := http.StatusInternalServerError
+		if strings.Contains(err.Error(), "required") || strings.Contains(err.Error(), "must be") {
+			status = http.StatusBadRequest
+		}
+		sendError(w, "Error", err.Error(), status, nil)
+		return
+	}
+	w.WriteHeader(http.StatusCreated)
+	sendSuccess(w, map[string]interface{}{"exception": exc}, "Risk exception recorded")
+}
+
+// RevokeRiskException handles DELETE /api/v1/risk-exceptions/{id} — withdraw early.
+func (h *DashboardHandler) RevokeRiskException(w http.ResponseWriter, r *http.Request) {
+	actor := middleware.GetUserFromContext(r.Context())
+	if actor == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		sendError(w, "InvalidParameter", "Invalid exception ID", http.StatusBadRequest, nil)
+		return
+	}
+	if err := h.coreService.RevokeRiskException(r.Context(), actor.UserID, uint(id)); err != nil {
+		status := http.StatusInternalServerError
+		msg := err.Error()
+		switch {
+		case strings.Contains(msg, "already revoked"):
+			status = http.StatusBadRequest
+		case strings.Contains(msg, "not found"):
+			status = http.StatusNotFound
+		}
+		sendError(w, "Error", msg, status, nil)
+		return
+	}
+	sendSuccess(w, nil, "Risk exception revoked")
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -465,6 +465,10 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		r.With(customMiddleware.RequirePermission("system.write")).Delete("/legal-hold", dashboardHandler.LiftLegalHold)
 		// Compliance evidence pack — posture + supporting records, for archival.
 		r.With(customMiddleware.RequirePermission("system.read")).Get("/compliance/evidence", dashboardHandler.GetComplianceEvidence)
+		// Risk register (ISO A.5.8): list reads system.read; create/revoke system.write.
+		r.With(customMiddleware.RequirePermission("system.read")).Get("/risk-exceptions", dashboardHandler.ListRiskExceptions)
+		r.With(customMiddleware.RequirePermission("system.write")).Post("/risk-exceptions", dashboardHandler.CreateRiskException)
+		r.With(customMiddleware.RequirePermission("system.write")).Delete("/risk-exceptions/{id}", dashboardHandler.RevokeRiskException)
 
 		// Separation of duties (ISO A.5.3): list policies/violations (system.read);
 		// create/delete policies (system.write).


### PR DESCRIPTION
## What

A **risk register**: a known control gap (an SoD violation, an unrotated secret, a service account without MFA), accepted by an owner with a written justification, that **sunsets at a fixed date**. Turns a raw posture violation into a *governed* exception an auditor can see was accepted-with-a-deadline, not silently tolerated.

Batch 3 of the program (control matrix → **risk register** → SCIM), per "1 3 4".

## How

- **model/storage** — `RiskException` (title, category, reference, justification, owner, `expires_at`, revoked) + additive migration; Create/List/Get/Update across the storage interface (local + remote stub + mock).
- **core** — `CreateRiskException` (validates category + a **future** expiry; audited `risk.exception_created`), `ListRiskExceptions` (effective status computed from revoked + expiry; `activeOnly` drops expired), `RevokeRiskException` (audited), `CountActiveRiskExceptions` (for the posture). Exceptions are **time-bound by construction**.
- **posture** — `RiskPosture {active_exceptions, expiring_soon}` (14-day window). The evidence pack embeds the active register.
- **API** — `GET /risk-exceptions` (system.read, `?all` for history), `POST` + `DELETE /{id}` (system.write); handler + routes + openapi.
- **CLI** — `keyorix risk list|add|revoke`.

## Tests

- core: create-validation + audit, status computation + `activeOnly` filter, revoke, count (active + expiring-soon).
- storage: create/list/revoke filtering on an in-memory DB.
- The new mutating routes correctly 403 a read-only persona (`TestEveryMutatingRouteDeniesReadOnly`).

Web (a risk-register panel + create/revoke on the Compliance page) follows in keyorix-web.

🤖 Generated with [Claude Code](https://claude.com/claude-code)