### PR TITLE
feat(scim): SCIM 2.0 user provisioning (RFC 7644) — Users + ServiceProviderConfig

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -17,7 +17,7 @@ The config file is located via, in order: an explicit path argument, then
 - [webauthn](#webauthn) (ADR-036) · [dynamic_secrets](#dynamic_secrets) (ADR-035)
 - [oidc](#oidc) (ADR-031) · [session](#session) · [password_policy](#password_policy) (ADR-025)
 - [soft_delete + purge](#soft_delete--purge) (ADR-032) · [data_retention](#data_retention) (A.5.33) · [recertification](#recertification) (A.5.18) · [notifications](#notifications) · [evidence_delivery](#evidence_delivery) · [rotation_reminders](#rotation_reminders) · [audit_checkpoints](#audit_checkpoints) (ADR-029) · [jit_access_expiry](#jit_access_expiry) · [break_glass](#break_glass) · [audit.siem](#auditsiem)
-- [membership](#membership) (ADR-022) · [credential_delivery](#credential_delivery) (ADR-028)
+- [scim](#scim) (RFC 7644) · [membership](#membership) (ADR-022) · [credential_delivery](#credential_delivery) (ADR-028)
 
 ---
 
@@ -33,6 +33,7 @@ the file:
 | `KEYORIX_DB_PASSWORD` | PostgreSQL password |
 | `KEYORIX_API_KEY` | API key for remote-client mode |
 | `KEYORIX_SIEM_TOKEN` | SIEM push token (`audit.siem`) |
+| `KEYORIX_SCIM_TOKEN` | SCIM provisioning bearer token (`scim`) |
 | `KEYORIX_SMTP_PASSWORD` | SMTP relay password (`credential_delivery.smtp`) |
 | `KEYORIX_DOMAIN` | substituted into `server` origins in the shipped example configs |
 | _(operator-named)_ | the raw KEK, when `key_provider.type: env` (see [key_provider](#encryption--kek-providers)) |
@@ -559,6 +560,32 @@ audit:
     # token: ""                 # prefer KEYORIX_SIEM_TOKEN
     insecure_skip_verify: false # never true in production
 ```
+
+## scim
+
+SCIM 2.0 provisioning (RFC 7644). When enabled, Keyorix serves `/scim/v2` so an
+identity provider (Okta, Entra ID, …) can **provision, update, deactivate, and
+deprovision users** automatically. The endpoints are authenticated by a single
+**static bearer token** the IdP presents — separate from the session/PAT auth — and
+emit SCIM-format JSON, not the API envelope.
+
+A SCIM `userName` (typically an email/UPN) maps to the user's email; a compliant
+alphanumeric Keyorix username is **derived** from it, and the IdP's `externalId` is
+stored for reconciliation. Provisioned users have no usable password (they sign in
+via SSO or set one out-of-band) and start in `pending_first_login`; SCIM
+`active:false` (or DELETE) suspends the account and terminates its sessions.
+
+This first increment covers the **Users** resource and `ServiceProviderConfig`;
+Groups are a follow-up.
+
+```yaml
+scim:
+  enabled: true
+  token: ""        # prefer the KEYORIX_SCIM_TOKEN env var — the IdP's bearer token
+```
+
+> Set `token` only via `KEYORIX_SCIM_TOKEN`. Point your IdP's SCIM connector at
+> `https://<host>/scim/v2` with that token as the bearer credential.
 
 ## membership
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -53,6 +53,9 @@ type Config struct {
 	// Notifications configures external delivery (email/webhook) of the in-app
 	// notifications Keyorix creates (approvals, anomalies, reminders, break-glass).
 	Notifications NotificationsConfig `yaml:"notifications"`
+	// SCIM configures the SCIM 2.0 provisioning endpoints (RFC 7644) used by an IdP
+	// to provision/deprovision users. Disabled (zero value) = /scim/v2 is not served.
+	SCIM SCIMConfig `yaml:"scim"`
 	// DynamicSecrets configures the on-demand database-credentials engine and its
 	// auto-revoke sweep (ADR-035). Disabled (zero value) = the API is still served
 	// but no background sweeper runs; enable to auto-revoke leases at expiry.
@@ -623,6 +626,19 @@ type NotificationWebhookConfig struct {
 // GetToken returns the resolved webhook token, preferring the environment variable.
 func (c *NotificationWebhookConfig) GetToken() string {
 	return resolveSecret("KEYORIX_NOTIFY_WEBHOOK_TOKEN", c.Token)
+}
+
+// SCIMConfig configures SCIM 2.0 provisioning (RFC 7644). When Enabled, the
+// /scim/v2 endpoints are served, authenticated by a static bearer token an IdP
+// presents. Opt-in (default off).
+type SCIMConfig struct {
+	Enabled bool   `yaml:"enabled"`
+	Token   string `yaml:"token"` // use KEYORIX_SCIM_TOKEN env var instead
+}
+
+// GetToken returns the resolved SCIM bearer token, preferring the env var.
+func (s *SCIMConfig) GetToken() string {
+	return resolveSecret("KEYORIX_SCIM_TOKEN", s.Token)
 }
 
 // RotationRemindersConfig configures the rotation-reminder scheduler: a background

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -656,6 +656,14 @@ func (m *MockStorage) GetUserByUsername(ctx context.Context, username string) (*
 	return args.Get(0).(*models.User), args.Error(1)
 }
 
+func (m *MockStorage) GetUserByExternalID(ctx context.Context, externalID string) (*models.User, error) {
+	args := m.Called(ctx, externalID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.User), args.Error(1)
+}
+
 func (m *MockStorage) GetUserGroups(ctx context.Context, userID uint) ([]*models.Group, error) {
 	args := m.Called(ctx, userID)
 	if args.Get(0) == nil {

--- a/internal/core/scim.go
+++ b/internal/core/scim.go
@@ -1,0 +1,227 @@
+// scim.go — SCIM 2.0 user provisioning (RFC 7644). An IdP (Okta/Entra) provisions,
+// updates, deactivates, and deletes Keyorix users over /scim/v2 (see the SCIM
+// handler + the static-token middleware). A SCIM userName is typically an email/UPN,
+// which Keyorix usernames (alphanumeric) cannot hold verbatim, so a compliant
+// username is DERIVED from the userName and the IdP's stable externalId is stored
+// for reconciliation. Provisioned users have no usable password (a random,
+// discarded one) — they authenticate via SSO or set a password out-of-band — and
+// start in pending_first_login (or suspended when provisioned inactive).
+package core
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"golang.org/x/crypto/bcrypt"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+const (
+	EventSCIMUserProvisioned   = "scim.user_provisioned"
+	EventSCIMUserUpdated       = "scim.user_updated"
+	EventSCIMUserDeprovisioned = "scim.user_deprovisioned"
+)
+
+var scimNonAlphanum = regexp.MustCompile(`[^a-z0-9]`)
+
+// deriveSCIMUsername builds a unique alphanumeric username from a SCIM userName
+// (typically an email/UPN): its local-part, lowercased and stripped to [a-z0-9],
+// padded to the 3-char minimum, with a numeric suffix on collision.
+func (c *KeyorixCore) deriveSCIMUsername(ctx context.Context, userName string) (string, error) {
+	base := userName
+	if i := strings.IndexByte(base, '@'); i > 0 {
+		base = base[:i]
+	}
+	base = scimNonAlphanum.ReplaceAllString(strings.ToLower(base), "")
+	if len(base) < 3 {
+		base += "usr"
+	}
+	if len(base) > 40 {
+		base = base[:40]
+	}
+	notFound := i18n.T("ErrorUserNotFound", nil)
+	for i := 0; i < 1000; i++ {
+		candidate := base
+		if i > 0 {
+			candidate = fmt.Sprintf("%s%d", base, i)
+		}
+		_, err := c.storage.GetUserByUsername(ctx, candidate)
+		if err == nil {
+			continue // taken — try the next suffix
+		}
+		if strings.Contains(err.Error(), notFound) {
+			return candidate, nil // available
+		}
+		return "", err // a real lookup error
+	}
+	return "", fmt.Errorf("could not derive a unique username from %q", userName)
+}
+
+// randomPasswordHash mints a bcrypt hash of a random, discarded password so a
+// provisioned account has no usable password until the user sets one.
+func randomPasswordHash() (string, error) {
+	b := make([]byte, 24)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	hash, err := bcrypt.GenerateFromPassword([]byte(hex.EncodeToString(b)), bcrypt.DefaultCost)
+	if err != nil {
+		return "", err
+	}
+	return string(hash), nil
+}
+
+// FindSCIMUser resolves a provisioned user by externalId first, then by email
+// (SCIM userName). Returns (nil, nil) when neither matches — used by the handler to
+// implement userName-filter reconciliation.
+func (c *KeyorixCore) FindSCIMUser(ctx context.Context, externalID, email string) (*models.User, error) {
+	notFound := i18n.T("ErrorUserNotFound", nil)
+	if externalID != "" {
+		if u, err := c.storage.GetUserByExternalID(ctx, externalID); err == nil {
+			return u, nil
+		} else if !strings.Contains(err.Error(), notFound) {
+			return nil, err
+		}
+	}
+	if email != "" {
+		if u, err := c.storage.GetUserByEmail(ctx, email); err == nil {
+			return u, nil
+		} else if !strings.Contains(err.Error(), notFound) {
+			return nil, err
+		}
+	}
+	return nil, nil
+}
+
+// ProvisionSCIMUser creates a Keyorix user from a SCIM Create request. actorID is
+// the SCIM principal (0 for the provisioner). It refuses a duplicate externalId or
+// email.
+func (c *KeyorixCore) ProvisionSCIMUser(ctx context.Context, actorID uint, userName, displayName, email, externalID string, active bool) (*models.User, error) {
+	if userName == "" {
+		return nil, fmt.Errorf("userName is required")
+	}
+	if email == "" {
+		email = userName // SCIM userName is conventionally the email
+	}
+	if existing, _ := c.FindSCIMUser(ctx, externalID, email); existing != nil {
+		return nil, fmt.Errorf("a user already exists for this externalId/email")
+	}
+	username, err := c.deriveSCIMUsername(ctx, userName)
+	if err != nil {
+		return nil, err
+	}
+	if displayName == "" {
+		displayName = userName
+	}
+	hash, err := randomPasswordHash()
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	now := c.now()
+	state := AccountPendingFirstLogin
+	if !active {
+		state = AccountSuspended
+	}
+	created, err := c.storage.CreateUser(ctx, &models.User{
+		Username: username, Email: email, DisplayName: displayName,
+		PasswordHash: hash, IsActive: active, AccountState: state, ExternalID: externalID,
+		PasswordChangedAt: &now, CreatedAt: now, UpdatedAt: now,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	// Minimal install-wide baseline role (ADR-021), best-effort.
+	if role, rerr := c.storage.GetRoleByName(ctx, "system_viewer"); rerr == nil {
+		_ = c.storage.AssignRole(ctx, created.ID, role.ID, Scope{})
+	}
+	c.writeAuditEvent(ctx, EventSCIMUserProvisioned, actorPtr(actorID), nil,
+		fmt.Sprintf("SCIM provisioned user %d (username=%s, externalId=%q, active=%t)", created.ID, username, externalID, active))
+	return created, nil
+}
+
+// UpdateSCIMUser applies a SCIM Replace/PATCH to a user: displayName, email, and the
+// active flag (deactivation suspends the account and terminates sessions; activation
+// returns it to active). nil fields are left unchanged.
+func (c *KeyorixCore) UpdateSCIMUser(ctx context.Context, actorID, id uint, displayName, email *string, active *bool) (*models.User, error) {
+	user, err := c.storage.GetUser(ctx, id)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorUserNotFound", nil), err)
+	}
+	if displayName != nil {
+		user.DisplayName = *displayName
+	}
+	if email != nil && *email != "" {
+		user.Email = *email
+	}
+	deactivated := false
+	if active != nil {
+		user.IsActive = *active
+		if *active {
+			if AccountLoginBlocked(user.AccountState) {
+				user.AccountState = AccountActive
+			}
+		} else {
+			user.AccountState = AccountSuspended
+			deactivated = true
+		}
+	}
+	user.UpdatedAt = c.now()
+	updated, err := c.storage.UpdateUser(ctx, user)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	if deactivated {
+		// Suspension must be effective immediately, not lingering until tokens expire.
+		_ = c.storage.DeleteSessionsForUserExcept(ctx, id, 0)
+	}
+	c.writeAuditEvent(ctx, EventSCIMUserUpdated, actorPtr(actorID), nil,
+		fmt.Sprintf("SCIM updated user %d", id))
+	return updated, nil
+}
+
+// DeprovisionSCIMUser handles a SCIM DELETE: it suspends the user (blocks login,
+// terminates sessions) and soft-deletes the record, so the account is recoverable
+// within the retention window rather than hard-destroyed.
+func (c *KeyorixCore) DeprovisionSCIMUser(ctx context.Context, actorID, id uint) error {
+	user, err := c.storage.GetUser(ctx, id)
+	if err != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorUserNotFound", nil), err)
+	}
+	user.IsActive = false
+	user.AccountState = AccountSuspended
+	user.UpdatedAt = c.now()
+	if _, err := c.storage.UpdateUser(ctx, user); err != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	_ = c.storage.DeleteSessionsForUserExcept(ctx, id, 0)
+	if err := c.storage.DeleteUser(ctx, id); err != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	c.writeAuditEvent(ctx, EventSCIMUserDeprovisioned, actorPtr(actorID), nil,
+		fmt.Sprintf("SCIM deprovisioned user %d (%s)", id, user.Username))
+	return nil
+}
+
+// ListSCIMUsers returns users for a SCIM list, paging through all of them.
+func (c *KeyorixCore) ListSCIMUsers(ctx context.Context) ([]*models.User, error) {
+	const pageSize = 200
+	var out []*models.User
+	for page := 1; ; page++ {
+		users, total, err := c.storage.ListUsers(ctx, &storage.UserFilter{Page: page, PageSize: pageSize})
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+		}
+		out = append(out, users...)
+		if len(users) < pageSize || int64(page*pageSize) >= total {
+			break
+		}
+	}
+	return out, nil
+}

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -235,6 +235,9 @@ type Storage interface {
 	// who were created before the cutoff (ADR-025 stale-account warnings).
 	ListUsersInStateBefore(ctx context.Context, state string, before time.Time) ([]*models.User, error)
 	GetUserByUsername(ctx context.Context, username string) (*models.User, error)
+	// GetUserByExternalID resolves a SCIM-provisioned user by the IdP's externalId
+	// (RFC 7644). Returns the not-found error when no user carries that external id.
+	GetUserByExternalID(ctx context.Context, externalID string) (*models.User, error)
 	GetUserGroups(ctx context.Context, userID uint) ([]*models.Group, error)
 
 	// Password history (ADR-025 history_count). AddPasswordHistory records a

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -176,6 +176,11 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 		db.Exec("ALTER TABLE users ADD COLUMN mfa_enabled BOOLEAN NOT NULL DEFAULT false")
 	}
 
+	// SCIM external ID (RFC 7644). Additive; empty for locally-created users.
+	if tableExists(db, "users") && !columnExists(db, "users", "external_id") {
+		db.Exec("ALTER TABLE users ADD COLUMN external_id TEXT NOT NULL DEFAULT ''")
+	}
+
 	// Enrich sessions for the My Account "active sessions" view (device/IP/last-active).
 	if tableExists(db, "sessions") {
 		if !columnExists(db, "sessions", "user_agent") {

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -221,9 +221,13 @@ type User struct {
 	// security key (ADR-036); like MFAEnabled it makes login a two-step flow, with
 	// a WebAuthn assertion as the second factor (see WebAuthnCredential).
 	WebAuthnEnabled bool `gorm:"default:false"`
-	CreatedAt       time.Time
-	UpdatedAt       time.Time
-	DeletedAt       gorm.DeletedAt `gorm:"index"` // soft delete — set by DELETE /users/{id}, cleared by restore
+	// ExternalID is the IdP's stable identifier for a SCIM-provisioned user (SCIM
+	// externalId, RFC 7644). Empty for locally-created users. Indexed for the SCIM
+	// reconciliation lookup; not unique (legacy/blank rows coexist).
+	ExternalID string `gorm:"index"`
+	CreatedAt  time.Time
+	UpdatedAt  time.Time
+	DeletedAt  gorm.DeletedAt `gorm:"index"` // soft delete — set by DELETE /users/{id}, cleared by restore
 }
 
 // MFASecret holds a user's TOTP shared secret, encrypted at rest. One row per

--- a/internal/storage/store/local_users.go
+++ b/internal/storage/store/local_users.go
@@ -94,6 +94,17 @@ func (ls *LocalStorage) GetUserByUsername(ctx context.Context, username string) 
 	return &user, nil
 }
 
+func (ls *LocalStorage) GetUserByExternalID(ctx context.Context, externalID string) (*models.User, error) {
+	var user models.User
+	if err := ls.db.WithContext(ctx).Where("external_id = ?", externalID).First(&user).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, fmt.Errorf("%s", i18n.T("ErrorUserNotFound", nil))
+		}
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	return &user, nil
+}
+
 func (ls *LocalStorage) UpdateUser(ctx context.Context, user *models.User) (*models.User, error) {
 	if err := ls.db.WithContext(ctx).Save(user).Error; err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)

--- a/internal/storage/store/remote_users.go
+++ b/internal/storage/store/remote_users.go
@@ -77,6 +77,10 @@ func (rs *RemoteStorage) GetUserByUsername(_ context.Context, _ string) (*models
 	return nil, remoteUnsupported("GetUserByUsername")
 }
 
+func (rs *RemoteStorage) GetUserByExternalID(_ context.Context, _ string) (*models.User, error) {
+	return nil, remoteUnsupported("GetUserByExternalID")
+}
+
 // UpdateUser updates an existing user via remote API.
 func (rs *RemoteStorage) UpdateUser(ctx context.Context, user *models.User) (*models.User, error) {
 	path := fmt.Sprintf("/api/v1/users/%d", user.ID)

--- a/server/http/handlers/scim.go
+++ b/server/http/handlers/scim.go
@@ -1,0 +1,322 @@
+// scim.go — SCIM 2.0 provisioning endpoints (RFC 7644). Served under /scim/v2,
+// authenticated by the static SCIM token (see middleware.SCIMToken). Unlike the API
+// handlers these emit raw SCIM JSON (schemas/id/meta) and SCIM-format errors, not
+// the {data,message} envelope. This first increment covers the Users resource +
+// ServiceProviderConfig; Groups follow.
+package handlers
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+const (
+	scimContentType   = "application/scim+json"
+	scimUserSchema    = "urn:ietf:params:scim:schemas:core:2.0:User"
+	scimListSchema    = "urn:ietf:params:scim:api:messages:2.0:ListResponse"
+	scimErrorSchema   = "urn:ietf:params:scim:api:messages:2.0:Error"
+	scimPatchOpSchema = "urn:ietf:params:scim:api:messages:2.0:PatchOp"
+)
+
+// SCIMHandler serves the SCIM 2.0 user-provisioning endpoints.
+type SCIMHandler struct {
+	coreService *core.KeyorixCore
+}
+
+// NewSCIMHandler constructs the SCIM handler.
+func NewSCIMHandler(coreService *core.KeyorixCore) *SCIMHandler {
+	return &SCIMHandler{coreService: coreService}
+}
+
+func writeSCIM(w http.ResponseWriter, status int, body interface{}) {
+	w.Header().Set("Content-Type", scimContentType)
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+func scimError(w http.ResponseWriter, status int, detail string) {
+	writeSCIM(w, status, map[string]interface{}{
+		"schemas": []string{scimErrorSchema},
+		"status":  strconv.Itoa(status),
+		"detail":  detail,
+	})
+}
+
+// toSCIMUser maps a Keyorix user to a SCIM User resource. SCIM userName echoes the
+// email (what the IdP sent); the derived Keyorix username is internal.
+func toSCIMUser(u *models.User) map[string]interface{} {
+	active := u.IsActive && !core.AccountLoginBlocked(u.AccountState)
+	res := map[string]interface{}{
+		"schemas":     []string{scimUserSchema},
+		"id":          strconv.FormatUint(uint64(u.ID), 10),
+		"userName":    u.Email,
+		"displayName": u.DisplayName,
+		"active":      active,
+		"emails":      []map[string]interface{}{{"value": u.Email, "primary": true}},
+		"meta": map[string]interface{}{
+			"resourceType": "User",
+			"location":     fmt.Sprintf("/scim/v2/Users/%d", u.ID),
+		},
+	}
+	if u.ExternalID != "" {
+		res["externalId"] = u.ExternalID
+	}
+	return res
+}
+
+// scimUserPayload is the subset of the SCIM User schema we consume.
+type scimUserPayload struct {
+	UserName    string `json:"userName"`
+	ExternalID  string `json:"externalId"`
+	DisplayName string `json:"displayName"`
+	Active      *bool  `json:"active"`
+	Name        *struct {
+		Formatted string `json:"formatted"`
+	} `json:"name"`
+	Emails []struct {
+		Value   string `json:"value"`
+		Primary bool   `json:"primary"`
+	} `json:"emails"`
+}
+
+// primaryEmail returns the best email from the payload (primary, else first, else
+// the userName which is conventionally an email).
+func (p *scimUserPayload) primaryEmail() string {
+	for _, e := range p.Emails {
+		if e.Primary && e.Value != "" {
+			return e.Value
+		}
+	}
+	if len(p.Emails) > 0 && p.Emails[0].Value != "" {
+		return p.Emails[0].Value
+	}
+	return p.UserName
+}
+
+func (p *scimUserPayload) displayName() string {
+	if p.DisplayName != "" {
+		return p.DisplayName
+	}
+	if p.Name != nil {
+		return p.Name.Formatted
+	}
+	return ""
+}
+
+// GetServiceProviderConfig handles GET /scim/v2/ServiceProviderConfig — advertises
+// the SCIM features this server supports.
+func (h *SCIMHandler) GetServiceProviderConfig(w http.ResponseWriter, _ *http.Request) {
+	writeSCIM(w, http.StatusOK, map[string]interface{}{
+		"schemas":               []string{"urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig"},
+		"documentationUri":      "https://github.com/keyorixhq/keyorix",
+		"patch":                 map[string]bool{"supported": true},
+		"bulk":                  map[string]interface{}{"supported": false, "maxOperations": 0, "maxPayloadSize": 0},
+		"filter":                map[string]interface{}{"supported": true, "maxResults": 200},
+		"changePassword":        map[string]bool{"supported": false},
+		"sort":                  map[string]bool{"supported": false},
+		"etag":                  map[string]bool{"supported": false},
+		"authenticationSchemes": []map[string]interface{}{{"type": "oauthbearertoken", "name": "Bearer Token", "description": "Static SCIM bearer token"}},
+	})
+}
+
+var scimUserNameFilter = regexp.MustCompile(`(?i)userName\s+eq\s+"([^"]+)"`)
+
+// ListUsers handles GET /scim/v2/Users — optionally filtered by userName (the only
+// filter IdPs use for reconciliation). Returns a SCIM ListResponse.
+func (h *SCIMHandler) ListUsers(w http.ResponseWriter, r *http.Request) {
+	if filter := r.URL.Query().Get("filter"); filter != "" {
+		m := scimUserNameFilter.FindStringSubmatch(filter)
+		if m == nil {
+			scimError(w, http.StatusBadRequest, "only 'userName eq' filtering is supported")
+			return
+		}
+		user, err := h.coreService.FindSCIMUser(r.Context(), "", m[1])
+		if err != nil {
+			scimError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		resources := []map[string]interface{}{}
+		if user != nil {
+			resources = append(resources, toSCIMUser(user))
+		}
+		writeSCIM(w, http.StatusOK, listResponse(resources))
+		return
+	}
+	users, err := h.coreService.ListSCIMUsers(r.Context())
+	if err != nil {
+		scimError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	resources := make([]map[string]interface{}, 0, len(users))
+	for _, u := range users {
+		resources = append(resources, toSCIMUser(u))
+	}
+	writeSCIM(w, http.StatusOK, listResponse(resources))
+}
+
+func listResponse(resources []map[string]interface{}) map[string]interface{} {
+	return map[string]interface{}{
+		"schemas":      []string{scimListSchema},
+		"totalResults": len(resources),
+		"startIndex":   1,
+		"itemsPerPage": len(resources),
+		"Resources":    resources,
+	}
+}
+
+// GetUser handles GET /scim/v2/Users/{id}.
+func (h *SCIMHandler) GetUser(w http.ResponseWriter, r *http.Request) {
+	id, ok := scimID(w, r)
+	if !ok {
+		return
+	}
+	user, err := h.coreService.GetUser(r.Context(), id)
+	if err != nil {
+		scimError(w, http.StatusNotFound, "user not found")
+		return
+	}
+	writeSCIM(w, http.StatusOK, toSCIMUser(user))
+}
+
+// CreateUser handles POST /scim/v2/Users — provision a new user.
+func (h *SCIMHandler) CreateUser(w http.ResponseWriter, r *http.Request) {
+	var p scimUserPayload
+	if err := json.NewDecoder(r.Body).Decode(&p); err != nil {
+		scimError(w, http.StatusBadRequest, "invalid SCIM payload")
+		return
+	}
+	if p.UserName == "" {
+		scimError(w, http.StatusBadRequest, "userName is required")
+		return
+	}
+	active := true
+	if p.Active != nil {
+		active = *p.Active
+	}
+	user, err := h.coreService.ProvisionSCIMUser(r.Context(), 0, p.UserName, p.displayName(), p.primaryEmail(), p.ExternalID, active)
+	if err != nil {
+		status := http.StatusBadRequest
+		if strings.Contains(err.Error(), "already exists") {
+			status = http.StatusConflict
+		}
+		scimError(w, status, err.Error())
+		return
+	}
+	writeSCIM(w, http.StatusCreated, toSCIMUser(user))
+}
+
+// ReplaceUser handles PUT /scim/v2/Users/{id} — full replace of the mutable fields.
+func (h *SCIMHandler) ReplaceUser(w http.ResponseWriter, r *http.Request) {
+	id, ok := scimID(w, r)
+	if !ok {
+		return
+	}
+	var p scimUserPayload
+	if err := json.NewDecoder(r.Body).Decode(&p); err != nil {
+		scimError(w, http.StatusBadRequest, "invalid SCIM payload")
+		return
+	}
+	dn := p.displayName()
+	email := p.primaryEmail()
+	user, err := h.coreService.UpdateSCIMUser(r.Context(), 0, id, &dn, &email, p.Active)
+	if err != nil {
+		scimError(w, http.StatusNotFound, err.Error())
+		return
+	}
+	writeSCIM(w, http.StatusOK, toSCIMUser(user))
+}
+
+// scimPatch is a minimal SCIM PatchOp body.
+type scimPatch struct {
+	Operations []struct {
+		Op    string          `json:"op"`
+		Path  string          `json:"path"`
+		Value json.RawMessage `json:"value"`
+	} `json:"Operations"`
+}
+
+// PatchUser handles PATCH /scim/v2/Users/{id} — applies replace operations. The IdP
+// uses this chiefly to flip `active` (deactivate/reactivate); displayName is also
+// honoured. Other paths are accepted as no-ops so a provisioning run doesn't fail.
+func (h *SCIMHandler) PatchUser(w http.ResponseWriter, r *http.Request) {
+	id, ok := scimID(w, r)
+	if !ok {
+		return
+	}
+	var patch scimPatch
+	if err := json.NewDecoder(r.Body).Decode(&patch); err != nil {
+		scimError(w, http.StatusBadRequest, "invalid SCIM patch")
+		return
+	}
+	var active *bool
+	var displayName *string
+	for _, op := range patch.Operations {
+		if !strings.EqualFold(op.Op, "replace") && !strings.EqualFold(op.Op, "add") {
+			continue
+		}
+		switch strings.ToLower(strings.TrimSpace(op.Path)) {
+		case "active":
+			var b bool
+			if json.Unmarshal(op.Value, &b) == nil {
+				active = &b
+			}
+		case "displayname":
+			var s string
+			if json.Unmarshal(op.Value, &s) == nil {
+				displayName = &s
+			}
+		case "": // no path → value is an object of attributes
+			var obj struct {
+				Active      *bool   `json:"active"`
+				DisplayName *string `json:"displayName"`
+			}
+			if json.Unmarshal(op.Value, &obj) == nil {
+				if obj.Active != nil {
+					active = obj.Active
+				}
+				if obj.DisplayName != nil {
+					displayName = obj.DisplayName
+				}
+			}
+		}
+	}
+	user, err := h.coreService.UpdateSCIMUser(r.Context(), 0, id, displayName, nil, active)
+	if err != nil {
+		scimError(w, http.StatusNotFound, err.Error())
+		return
+	}
+	writeSCIM(w, http.StatusOK, toSCIMUser(user))
+}
+
+// DeleteUser handles DELETE /scim/v2/Users/{id} — deprovision (suspend + soft-delete).
+func (h *SCIMHandler) DeleteUser(w http.ResponseWriter, r *http.Request) {
+	id, ok := scimID(w, r)
+	if !ok {
+		return
+	}
+	if err := h.coreService.DeprovisionSCIMUser(r.Context(), 0, id); err != nil {
+		scimError(w, http.StatusNotFound, err.Error())
+		return
+	}
+	w.Header().Set("Content-Type", scimContentType)
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// scimID parses the {id} path parameter, writing a SCIM error on failure.
+func scimID(w http.ResponseWriter, r *http.Request) (uint, bool) {
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		scimError(w, http.StatusBadRequest, "invalid user id")
+		return 0, false
+	}
+	return uint(id), true
+}

--- a/server/http/handlers/scim_test.go
+++ b/server/http/handlers/scim_test.go
@@ -1,0 +1,132 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func setupSCIMTest(t *testing.T) (*SCIMHandler, *gorm.DB) {
+	t.Helper()
+	require.NoError(t, i18n.Initialize(&config.Config{
+		Locale: config.LocaleConfig{Language: "en", FallbackLanguage: "en"},
+	}))
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.User{}, &models.Role{}, &models.UserRole{}, &models.Session{}, &models.AuditEvent{},
+	))
+	require.NoError(t, db.Create(&models.Role{Name: "system_viewer"}).Error)
+	return NewSCIMHandler(core.NewKeyorixCore(store.NewLocalStorage(db))), db
+}
+
+// withID attaches a chi route param so chi.URLParam("id") resolves in the handler.
+func withID(req *http.Request, id string) *http.Request {
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", id)
+	return req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+}
+
+func decodeSCIM(t *testing.T, w *httptest.ResponseRecorder) map[string]interface{} {
+	t.Helper()
+	var m map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &m))
+	return m
+}
+
+func TestSCIM_ProvisionGetListDeactivateDelete(t *testing.T) {
+	h, db := setupSCIMTest(t)
+
+	// Create: an email-style userName derives an alphanumeric username and echoes externalId.
+	body := `{"schemas":["urn:ietf:params:scim:schemas:core:2.0:User"],"userName":"alice@corp.com","externalId":"okta-123","displayName":"Alice","active":true}`
+	w := httptest.NewRecorder()
+	h.CreateUser(w, httptest.NewRequest(http.MethodPost, "/scim/v2/Users", bytes.NewReader([]byte(body))))
+	require.Equal(t, http.StatusCreated, w.Code, w.Body.String())
+	created := decodeSCIM(t, w)
+	assert.Equal(t, "alice@corp.com", created["userName"])
+	assert.Equal(t, "okta-123", created["externalId"])
+	assert.Equal(t, true, created["active"])
+	id, _ := created["id"].(string)
+	require.NotEmpty(t, id)
+
+	// The stored user has a derived alphanumeric username and pending_first_login state.
+	var u models.User
+	require.NoError(t, db.Where("external_id = ?", "okta-123").First(&u).Error)
+	assert.Equal(t, "alice", u.Username)
+	assert.Equal(t, core.AccountPendingFirstLogin, u.AccountState)
+	assert.NotEmpty(t, u.PasswordHash, "a random (unusable) password is set")
+
+	// Get.
+	w = httptest.NewRecorder()
+	h.GetUser(w, withID(httptest.NewRequest(http.MethodGet, "/scim/v2/Users/"+id, nil), id))
+	require.Equal(t, http.StatusOK, w.Code)
+
+	// List with a userName filter returns exactly the one match.
+	w = httptest.NewRecorder()
+	h.ListUsers(w, httptest.NewRequest(http.MethodGet, "/scim/v2/Users?filter="+url.QueryEscape(`userName eq "alice@corp.com"`), nil))
+	require.Equal(t, http.StatusOK, w.Code)
+	list := decodeSCIM(t, w)
+	assert.Equal(t, float64(1), list["totalResults"])
+
+	// PATCH active=false → suspended.
+	patch := `{"schemas":["urn:ietf:params:scim:api:messages:2.0:PatchOp"],"Operations":[{"op":"replace","path":"active","value":false}]}`
+	w = httptest.NewRecorder()
+	h.PatchUser(w, withID(httptest.NewRequest(http.MethodPatch, "/scim/v2/Users/"+id, bytes.NewReader([]byte(patch))), id))
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, false, decodeSCIM(t, w)["active"])
+
+	var suspended models.User
+	require.NoError(t, db.Where("external_id = ?", "okta-123").First(&suspended).Error)
+	assert.Equal(t, core.AccountSuspended, suspended.AccountState)
+
+	// DELETE → 204 and the user is soft-deleted.
+	w = httptest.NewRecorder()
+	h.DeleteUser(w, withID(httptest.NewRequest(http.MethodDelete, "/scim/v2/Users/"+id, nil), id))
+	require.Equal(t, http.StatusNoContent, w.Code)
+	var count int64
+	require.NoError(t, db.Model(&models.User{}).Where("external_id = ?", "okta-123").Count(&count).Error)
+	assert.Equal(t, int64(0), count, "soft-deleted (excluded from default scope)")
+}
+
+func TestSCIM_CreateRequiresUserName(t *testing.T) {
+	h, _ := setupSCIMTest(t)
+	w := httptest.NewRecorder()
+	h.CreateUser(w, httptest.NewRequest(http.MethodPost, "/scim/v2/Users", bytes.NewReader([]byte(`{"displayName":"x"}`))))
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestSCIM_DuplicateConflict(t *testing.T) {
+	h, _ := setupSCIMTest(t)
+	body := `{"userName":"bob@corp.com","externalId":"e1"}`
+	w := httptest.NewRecorder()
+	h.CreateUser(w, httptest.NewRequest(http.MethodPost, "/scim/v2/Users", bytes.NewReader([]byte(body))))
+	require.Equal(t, http.StatusCreated, w.Code)
+	w = httptest.NewRecorder()
+	h.CreateUser(w, httptest.NewRequest(http.MethodPost, "/scim/v2/Users", bytes.NewReader([]byte(body))))
+	assert.Equal(t, http.StatusConflict, w.Code)
+}
+
+func TestSCIM_ServiceProviderConfig(t *testing.T) {
+	h, _ := setupSCIMTest(t)
+	w := httptest.NewRecorder()
+	h.GetServiceProviderConfig(w, httptest.NewRequest(http.MethodGet, "/scim/v2/ServiceProviderConfig", nil))
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Header().Get("Content-Type"), "scim+json")
+	cfg := decodeSCIM(t, w)
+	assert.NotNil(t, cfg["patch"])
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -139,6 +139,22 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 	})
 
 	// API v1 routes
+	// SCIM 2.0 provisioning (RFC 7644) — opt-in, authenticated by a static bearer
+	// token (NOT the session/PAT auth) so an IdP can provision/deprovision users.
+	if cfg.SCIM.Enabled {
+		scimHandler := handlers.NewSCIMHandler(coreService)
+		r.Route("/scim/v2", func(r chi.Router) {
+			r.Use(customMiddleware.SCIMToken(cfg.SCIM.GetToken()))
+			r.Get("/ServiceProviderConfig", scimHandler.GetServiceProviderConfig)
+			r.Get("/Users", scimHandler.ListUsers)
+			r.Post("/Users", scimHandler.CreateUser)
+			r.Get("/Users/{id}", scimHandler.GetUser)
+			r.Put("/Users/{id}", scimHandler.ReplaceUser)
+			r.Patch("/Users/{id}", scimHandler.PatchUser)
+			r.Delete("/Users/{id}", scimHandler.DeleteUser)
+		})
+	}
+
 	r.Route("/api/v1", func(r chi.Router) {
 		// Authentication middleware for API routes
 		r.Use(customMiddleware.Authentication(coreService))

--- a/server/middleware/scim.go
+++ b/server/middleware/scim.go
@@ -1,0 +1,29 @@
+// scim.go — static-bearer-token auth for the SCIM 2.0 endpoints (RFC 7644). Unlike
+// the session/PAT Authentication middleware, SCIM is authenticated by a single
+// provisioning token an IdP presents (KEYORIX_SCIM_TOKEN). The token is compared in
+// constant time, and failures return a SCIM-format error (not the API envelope).
+package middleware
+
+import (
+	"crypto/subtle"
+	"net/http"
+	"strings"
+)
+
+// SCIMToken gates the SCIM routes on a static bearer token. An empty configured
+// token denies every request (a misconfiguration fails closed).
+func SCIMToken(token string) func(http.Handler) http.Handler {
+	want := []byte(token)
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			presented := []byte(strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer "))
+			if len(want) == 0 || subtle.ConstantTimeCompare(presented, want) != 1 {
+				w.Header().Set("Content-Type", "application/scim+json")
+				w.WriteHeader(http.StatusUnauthorized)
+				_, _ = w.Write([]byte(`{"schemas":["urn:ietf:params:scim:api:messages:2.0:Error"],"status":"401","detail":"invalid or missing SCIM bearer token"}`))
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/server/middleware/scim_test.go
+++ b/server/middleware/scim_test.go
@@ -1,0 +1,39 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSCIMToken(t *testing.T) {
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+	h := SCIMToken("s3cret")(next)
+
+	call := func(auth string) int {
+		req := httptest.NewRequest(http.MethodGet, "/scim/v2/Users", nil)
+		if auth != "" {
+			req.Header.Set("Authorization", auth)
+		}
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+		return w.Code
+	}
+
+	assert.Equal(t, http.StatusOK, call("Bearer s3cret"), "valid token passes")
+	assert.Equal(t, http.StatusUnauthorized, call("Bearer wrong"), "wrong token denied")
+	assert.Equal(t, http.StatusUnauthorized, call(""), "missing token denied")
+}
+
+func TestSCIMToken_EmptyConfigDeniesAll(t *testing.T) {
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+	h := SCIMToken("")(next) // misconfigured: no token set
+
+	req := httptest.NewRequest(http.MethodGet, "/scim/v2/Users", nil)
+	req.Header.Set("Authorization", "Bearer ")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusUnauthorized, w.Code, "an empty configured token fails closed")
+}


### PR DESCRIPTION
## What

An opt-in **`/scim/v2`** endpoint group so an enterprise IdP (Okta, Entra) can provision/deprovision Keyorix users automatically over **SCIM 2.0 (RFC 7644)**. First increment: the **Users** resource + `ServiceProviderConfig`. Groups follow in 4b.

Batch 4 of the program (control matrix → risk register → **SCIM**), per "1 3 4".

## Decisions (per the scoping questions)

- **userName → derived alphanum username.** A SCIM `userName` (usually an email/UPN) maps to the user's email; a compliant alphanumeric Keyorix username is **derived** from it (local-part, deduped), and the IdP's `externalId` is stored for reconciliation.
- **Users-only first PR.**

## How

- **config** — `scim {enabled, token}`; token from `KEYORIX_SCIM_TOKEN`.
- **middleware** — `SCIMToken`: static bearer-token auth (**constant-time** compare), separate from session/PAT auth; **fails closed** on an empty token; SCIM-format 401. Mounted only on `/scim/v2` when enabled.
- **core** (`scim.go`) — `ProvisionSCIMUser` (derive username, store externalId, random unusable password, `pending_first_login`; users sign in via SSO / set a password out-of-band), `UpdateSCIMUser` (displayName/email/active), `DeprovisionSCIMUser` (suspend + terminate sessions + soft-delete), `FindSCIMUser` (externalId→email reconciliation), `ListSCIMUsers`. Audited `scim.user_provisioned/_updated/_deprovisioned`.
- **storage** — `User.external_id` (additive column + migration) + `GetUserByExternalID` across the interface (local + remote stub + mock).
- **handler** (`scim.go`) — SCIM JSON (schemas/id/meta) + SCIM error envelope; Users Create / List (`userName eq` filter) / Get / Replace / Patch (`active`, `displayName`) / Delete + `ServiceProviderConfig`.
- **docs** — `CONFIGURATION.md` `scim` section + `KEYORIX_SCIM_TOKEN`.

## Tests

- Handler end-to-end: provision → get → `userName` filter → PATCH deactivate (→ suspended) → DELETE (→ soft-deleted); derived username + `pending_first_login`; duplicate → 409; `userName` required; ServiceProviderConfig.
- Token middleware: valid passes; wrong/missing/empty-config → 401 (fail closed).
- The SCIM routes carry their own token auth and are only mounted when enabled (default-config route test unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)