### PR TITLE
feat(sso): human SSO login via OIDC (authorization-code flow)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -17,7 +17,7 @@ The config file is located via, in order: an explicit path argument, then
 - [webauthn](#webauthn) (ADR-036) · [dynamic_secrets](#dynamic_secrets) (ADR-035)
 - [oidc](#oidc) (ADR-031) · [session](#session) · [password_policy](#password_policy) (ADR-025)
 - [soft_delete + purge](#soft_delete--purge) (ADR-032) · [data_retention](#data_retention) (A.5.33) · [recertification](#recertification) (A.5.18) · [notifications](#notifications) · [evidence_delivery](#evidence_delivery) · [rotation_reminders](#rotation_reminders) · [audit_checkpoints](#audit_checkpoints) (ADR-029) · [jit_access_expiry](#jit_access_expiry) · [break_glass](#break_glass) · [audit.siem](#auditsiem)
-- [scim](#scim) (RFC 7644) · [membership](#membership) (ADR-022) · [credential_delivery](#credential_delivery) (ADR-028)
+- [scim](#scim) (RFC 7644) · [sso](#sso) (OIDC) · [membership](#membership) (ADR-022) · [credential_delivery](#credential_delivery) (ADR-028)
 
 ---
 
@@ -34,6 +34,7 @@ the file:
 | `KEYORIX_API_KEY` | API key for remote-client mode |
 | `KEYORIX_SIEM_TOKEN` | SIEM push token (`audit.siem`) |
 | `KEYORIX_SCIM_TOKEN` | SCIM provisioning bearer token (`scim`) |
+| `KEYORIX_SSO_<NAME>_CLIENT_SECRET` | per-provider OIDC client secret (`sso`) |
 | `KEYORIX_SMTP_PASSWORD` | SMTP relay password (`credential_delivery.smtp`) |
 | `KEYORIX_DOMAIN` | substituted into `server` origins in the shipped example configs |
 | _(operator-named)_ | the raw KEK, when `key_provider.type: env` (see [key_provider](#encryption--kek-providers)) |
@@ -587,6 +588,39 @@ scim:
 
 > Set `token` only via `KEYORIX_SCIM_TOKEN`. Point your IdP's SCIM connector at
 > `https://<host>/scim/v2` with that token as the bearer credential.
+
+## sso
+
+Human single-sign-on login via **OIDC** (authorization-code flow). When enabled, the
+login page offers a "Sign in with <provider>" button: the user authenticates at their
+IdP and Keyorix mints the same session a password login would — so an IdP-provisioned
+([`scim`](#scim)) user, who has no password, can actually sign in. SSO logins bypass
+Keyorix-local MFA (the IdP is the authenticator).
+
+Each provider's endpoints are **discovered** from its issuer
+(`/.well-known/openid-configuration`), so only the issuer + client credentials +
+redirect URL are needed. On callback Keyorix verifies the id_token (signature against
+the issuer's JWKS, issuer, audience = `client_id`, expiry, and the nonce it issued)
+and maps the identity to a Keyorix user — by the IdP subject (matched against the SCIM
+`externalId`) first, then by email. There is **no auto-provisioning**: the account
+must already exist (provision it via SCIM or invite). A suspended user is refused.
+
+```yaml
+sso:
+  enabled: true
+  providers:
+    - name: okta                 # also the URL slug: /auth/sso/okta/login
+      issuer: https://your-tenant.okta.com
+      client_id: 0oa...
+      client_secret: ""          # prefer the KEYORIX_SSO_OKTA_CLIENT_SECRET env var
+      redirect_url: https://keyorix.example.com/auth/sso/okta/callback
+      scopes: [openid, profile, email]
+```
+
+> The client secret is read from `KEYORIX_SSO_<NAME>_CLIENT_SECRET` (name upper-cased,
+> e.g. `KEYORIX_SSO_OKTA_CLIENT_SECRET`). Register the `redirect_url` exactly as above
+> at the IdP. A provider whose discovery fails at startup is skipped with a warning,
+> not fatal.
 
 ## membership
 

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/wneessen/go-mail v0.7.3
 	go.mongodb.org/mongo-driver v1.17.9
 	golang.org/x/crypto v0.52.0
+	golang.org/x/oauth2 v0.36.0
 	golang.org/x/term v0.43.0
 	golang.org/x/text v0.37.0
 	google.golang.org/api v0.274.0
@@ -120,7 +121,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.42.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	golang.org/x/net v0.55.0 // indirect
-	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/time v0.15.0 // indirect

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/delivery"
@@ -56,6 +57,10 @@ type Config struct {
 	// SCIM configures the SCIM 2.0 provisioning endpoints (RFC 7644) used by an IdP
 	// to provision/deprovision users. Disabled (zero value) = /scim/v2 is not served.
 	SCIM SCIMConfig `yaml:"scim"`
+	// SSO configures human single-sign-on login via OIDC (authorization-code flow):
+	// users sign in through their IdP and Keyorix mints a session. Disabled (zero
+	// value) = the /auth/sso endpoints are not served.
+	SSO SSOConfig `yaml:"sso"`
 	// DynamicSecrets configures the on-demand database-credentials engine and its
 	// auto-revoke sweep (ADR-035). Disabled (zero value) = the API is still served
 	// but no background sweeper runs; enable to auto-revoke leases at expiry.
@@ -639,6 +644,32 @@ type SCIMConfig struct {
 // GetToken returns the resolved SCIM bearer token, preferring the env var.
 func (s *SCIMConfig) GetToken() string {
 	return resolveSecret("KEYORIX_SCIM_TOKEN", s.Token)
+}
+
+// SSOConfig configures human OIDC single-sign-on. Opt-in (default off). Each
+// provider is an OIDC IdP; users are matched to a Keyorix account by the IdP
+// subject (against the SCIM externalId) and, failing that, by email.
+type SSOConfig struct {
+	Enabled   bool                `yaml:"enabled"`
+	Providers []SSOProviderConfig `yaml:"providers"`
+}
+
+// SSOProviderConfig is one configured OIDC provider. Endpoints are discovered from
+// the issuer's /.well-known/openid-configuration at startup, so only the issuer +
+// client credentials + redirect URL are required.
+type SSOProviderConfig struct {
+	Name         string   `yaml:"name"`          // operator label + URL slug (e.g. "okta")
+	Issuer       string   `yaml:"issuer"`        // OIDC issuer URL
+	ClientID     string   `yaml:"client_id"`     // the OAuth client id registered at the IdP
+	ClientSecret string   `yaml:"client_secret"` // prefer KEYORIX_SSO_<NAME>_CLIENT_SECRET
+	RedirectURL  string   `yaml:"redirect_url"`  // must equal <public-host>/auth/sso/<name>/callback
+	Scopes       []string `yaml:"scopes"`        // default [openid, profile, email]
+}
+
+// GetClientSecret returns the resolved client secret, preferring the per-provider
+// env var KEYORIX_SSO_<NAME>_CLIENT_SECRET (name upper-cased).
+func (p *SSOProviderConfig) GetClientSecret() string {
+	return resolveSecret("KEYORIX_SSO_"+strings.ToUpper(p.Name)+"_CLIENT_SECRET", p.ClientSecret)
 }
 
 // RotationRemindersConfig configures the rotation-reminder scheduler: a background

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -321,6 +321,19 @@ func (m *MockStorage) UpdateRiskException(ctx context.Context, e *models.RiskExc
 	return args.Error(0)
 }
 
+func (m *MockStorage) CreateSSOLoginState(ctx context.Context, s *models.SSOLoginState) error {
+	args := m.Called(ctx, s)
+	return args.Error(0)
+}
+
+func (m *MockStorage) ConsumeSSOLoginState(ctx context.Context, state string) (*models.SSOLoginState, error) {
+	args := m.Called(ctx, state)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.SSOLoginState), args.Error(1)
+}
+
 func (m *MockStorage) CreateBreakGlassActivation(ctx context.Context, a *models.BreakGlassActivation) (*models.BreakGlassActivation, error) {
 	args := m.Called(ctx, a)
 	if args.Get(0) == nil {

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -69,6 +69,10 @@ type KeyorixCore struct {
 	// oidcVerifier verifies federated machine-identity JWTs (ADR-031); nil = OIDC
 	// auth disabled. Set from config via SetOIDCVerifier.
 	oidcVerifier *OIDCVerifier
+	// ssoProviders are the configured human-SSO OIDC providers (keyed by name);
+	// ssoJWKS verifies their id_tokens. Empty = SSO disabled. Set via SetSSOProviders.
+	ssoProviders map[string]*SSOProvider
+	ssoJWKS      JWKSResolver
 	// membershipValidationMode is the ADR-022 install-level onboarding mode;
 	// "" = allowlist default. Set via SetMembershipValidationMode.
 	membershipValidationMode string

--- a/internal/core/sso.go
+++ b/internal/core/sso.go
@@ -139,7 +139,7 @@ func (c *KeyorixCore) CompleteSSO(ctx context.Context, providerName, code, state
 	if err != nil {
 		return nil, nil, "", err
 	}
-	c.RecordLogin(ctx, user.ID)
+	_ = c.RecordLogin(ctx, user.ID) // best-effort last-login stamp
 	c.writeAuditEvent(ctx, EventSSOLogin, actorPtr(user.ID), nil,
 		fmt.Sprintf("SSO login via %s (subject=%s)", providerName, sub))
 	return session, user, st.ReturnTo, nil

--- a/internal/core/sso.go
+++ b/internal/core/sso.go
@@ -1,0 +1,232 @@
+// sso.go — human single-sign-on via OIDC (authorization-code flow). A user clicks
+// "Sign in with SSO", is redirected to their IdP, and on callback Keyorix verifies
+// the id_token (signature via the issuer's JWKS, issuer, audience=client_id, expiry,
+// and the nonce it issued), maps the identity to a Keyorix user (the SCIM externalId
+// first, then email), and mints the SAME session a password login would — so an
+// IdP-provisioned (passwordless) user can actually sign in. SSO logins bypass
+// Keyorix-local MFA: the IdP is the trusted authenticator.
+package core
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"golang.org/x/oauth2"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+const (
+	ssoStateTTL       = 10 * time.Minute
+	EventSSOLogin     = "auth.sso_login"
+	ssoClockSkew      = 60 * time.Second
+	ssoCompleteSuffix = "/auth/sso/complete"
+)
+
+// SSOProvider is a resolved OIDC provider whose endpoints have been discovered.
+type SSOProvider struct {
+	Name        string
+	Issuer      string
+	ClientID    string
+	OAuth       *oauth2.Config // ClientID/Secret + discovered Auth/Token endpoints + redirect
+	CompleteURL string         // <redirect origin>/auth/sso/complete — where the browser lands
+}
+
+// SetSSOProviders wires the configured providers (built from config + discovery at
+// startup) and the JWKS resolver used to verify id_tokens. nil/empty disables SSO.
+func (c *KeyorixCore) SetSSOProviders(providers map[string]*SSOProvider, jwks JWKSResolver) {
+	c.ssoProviders = providers
+	c.ssoJWKS = jwks
+}
+
+// SSOEnabled reports whether any SSO provider is configured.
+func (c *KeyorixCore) SSOEnabled() bool { return len(c.ssoProviders) > 0 }
+
+// SSOProviderNames returns the configured provider names, sorted — for the login page.
+func (c *KeyorixCore) SSOProviderNames() []string {
+	names := make([]string, 0, len(c.ssoProviders))
+	for n := range c.ssoProviders {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// SSOCompleteURL returns the browser-facing completion URL for a provider.
+func (c *KeyorixCore) SSOCompleteURL(provider string) (string, bool) {
+	if p, ok := c.ssoProviders[provider]; ok {
+		return p.CompleteURL, true
+	}
+	return "", false
+}
+
+// BeginSSO creates and stores the CSRF state + nonce and returns the IdP
+// authorization URL to redirect the browser to.
+func (c *KeyorixCore) BeginSSO(ctx context.Context, providerName, returnTo string) (string, error) {
+	p, ok := c.ssoProviders[providerName]
+	if !ok {
+		return "", fmt.Errorf("unknown SSO provider %q", providerName)
+	}
+	state, err := randToken()
+	if err != nil {
+		return "", err
+	}
+	nonce, err := randToken()
+	if err != nil {
+		return "", err
+	}
+	if err := c.storage.CreateSSOLoginState(ctx, &models.SSOLoginState{
+		State:     state,
+		Nonce:     nonce,
+		Provider:  providerName,
+		ReturnTo:  sanitizeReturnTo(returnTo),
+		ExpiresAt: c.now().Add(ssoStateTTL),
+		CreatedAt: c.now(),
+	}); err != nil {
+		return "", err
+	}
+	return p.OAuth.AuthCodeURL(state, oauth2.SetAuthURLParam("nonce", nonce)), nil
+}
+
+// CompleteSSO consumes the state, exchanges the code, verifies the id_token, maps it
+// to a user, and mints a session. Returns the session, the user, and the in-app path
+// to land on (ReturnTo, may be empty).
+func (c *KeyorixCore) CompleteSSO(ctx context.Context, providerName, code, state, userAgent, ip string) (*models.Session, *models.User, string, error) {
+	p, ok := c.ssoProviders[providerName]
+	if !ok {
+		return nil, nil, "", fmt.Errorf("unknown SSO provider")
+	}
+	st, err := c.storage.ConsumeSSOLoginState(ctx, state)
+	if err != nil {
+		return nil, nil, "", fmt.Errorf("invalid or expired login state")
+	}
+	if st.Provider != providerName {
+		return nil, nil, "", fmt.Errorf("login state does not match the callback provider")
+	}
+	if c.now().After(st.ExpiresAt) {
+		return nil, nil, "", fmt.Errorf("login state expired")
+	}
+
+	tok, err := p.OAuth.Exchange(ctx, code)
+	if err != nil {
+		return nil, nil, "", fmt.Errorf("authorization-code exchange failed: %w", err)
+	}
+	rawID, _ := tok.Extra("id_token").(string)
+	if rawID == "" {
+		return nil, nil, "", fmt.Errorf("the token response carried no id_token")
+	}
+	sub, email, err := c.verifyIDToken(ctx, p, st.Nonce, rawID)
+	if err != nil {
+		return nil, nil, "", err
+	}
+
+	user, err := c.resolveSSOUser(ctx, sub, email)
+	if err != nil {
+		return nil, nil, "", err
+	}
+	if AccountLoginBlocked(user.AccountState) {
+		return nil, nil, "", fmt.Errorf("account suspended")
+	}
+
+	session, err := c.mintSession(ctx, user.ID, userAgent, ip)
+	if err != nil {
+		return nil, nil, "", err
+	}
+	c.RecordLogin(ctx, user.ID)
+	c.writeAuditEvent(ctx, EventSSOLogin, actorPtr(user.ID), nil,
+		fmt.Sprintf("SSO login via %s (subject=%s)", providerName, sub))
+	return session, user, st.ReturnTo, nil
+}
+
+// resolveSSOUser maps the IdP identity to a Keyorix user: the SCIM externalId
+// (subject) first, then email. No auto-provisioning — the account must already exist.
+func (c *KeyorixCore) resolveSSOUser(ctx context.Context, sub, email string) (*models.User, error) {
+	notFound := i18n.T("ErrorUserNotFound", nil)
+	if sub != "" {
+		if u, err := c.storage.GetUserByExternalID(ctx, sub); err == nil {
+			return u, nil
+		} else if !strings.Contains(err.Error(), notFound) {
+			return nil, err
+		}
+	}
+	if email != "" {
+		if u, err := c.storage.GetUserByEmail(ctx, email); err == nil {
+			return u, nil
+		} else if !strings.Contains(err.Error(), notFound) {
+			return nil, err
+		}
+	}
+	return nil, fmt.Errorf("no Keyorix account matches this SSO identity")
+}
+
+// verifyIDToken validates the id_token's signature (asymmetric only), issuer,
+// audience (= the provider's client_id), expiry, and the nonce, returning the
+// subject and email claims.
+func (c *KeyorixCore) verifyIDToken(ctx context.Context, p *SSOProvider, expectedNonce, raw string) (sub, email string, err error) {
+	var claims struct {
+		jwt.RegisteredClaims
+		Email string `json:"email"`
+		Nonce string `json:"nonce"`
+	}
+	parser := jwt.NewParser(
+		jwt.WithValidMethods([]string{"RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512"}),
+		jwt.WithLeeway(ssoClockSkew),
+		jwt.WithExpirationRequired(),
+	)
+	keyfn := func(t *jwt.Token) (interface{}, error) {
+		iss, ierr := t.Claims.GetIssuer()
+		if ierr != nil || iss != p.Issuer {
+			return nil, fmt.Errorf("issuer mismatch")
+		}
+		kid, _ := t.Header["kid"].(string)
+		return c.ssoJWKS.Key(ctx, p.Issuer, kid)
+	}
+	token, err := parser.ParseWithClaims(raw, &claims, keyfn)
+	if err != nil {
+		return "", "", fmt.Errorf("id_token verification failed: %w", err)
+	}
+	if !token.Valid || claims.Issuer != p.Issuer {
+		return "", "", fmt.Errorf("id_token invalid")
+	}
+	audOK := false
+	for _, a := range claims.Audience {
+		if a == p.ClientID {
+			audOK = true
+			break
+		}
+	}
+	if !audOK {
+		return "", "", fmt.Errorf("id_token audience does not match the client id")
+	}
+	if expectedNonce == "" || claims.Nonce != expectedNonce {
+		return "", "", fmt.Errorf("id_token nonce mismatch")
+	}
+	if strings.TrimSpace(claims.Subject) == "" {
+		return "", "", fmt.Errorf("id_token has no subject")
+	}
+	return claims.Subject, claims.Email, nil
+}
+
+func randToken() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("failed to generate token: %w", err)
+	}
+	return hex.EncodeToString(b), nil
+}
+
+// sanitizeReturnTo allows only a same-origin in-app path (leading single slash), so
+// the post-login redirect can't be turned into an open redirect.
+func sanitizeReturnTo(s string) string {
+	if strings.HasPrefix(s, "/") && !strings.HasPrefix(s, "//") {
+		return s
+	}
+	return ""
+}

--- a/internal/core/sso_test.go
+++ b/internal/core/sso_test.go
@@ -1,0 +1,145 @@
+package core
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"fmt"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"golang.org/x/oauth2"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func ssoTestCore(t *testing.T) (*KeyorixCore, *MockStorage, *rsa.PrivateKey, *SSOProvider) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	store := new(MockStorage)
+	p := &SSOProvider{
+		Name: "okta", Issuer: "https://idp.test", ClientID: "client-1",
+		OAuth: &oauth2.Config{
+			ClientID:    "client-1",
+			Endpoint:    oauth2.Endpoint{AuthURL: "https://idp.test/authorize", TokenURL: "https://idp.test/token"},
+			RedirectURL: "https://keyorix.test/auth/sso/okta/callback",
+			Scopes:      []string{"openid", "email"},
+		},
+		CompleteURL: "https://keyorix.test/auth/sso/complete",
+	}
+	c := &KeyorixCore{
+		storage:      store,
+		now:          time.Now,
+		ssoJWKS:      staticResolver{kid: "kid-1", key: &key.PublicKey},
+		ssoProviders: map[string]*SSOProvider{"okta": p},
+	}
+	return c, store, key, p
+}
+
+func TestVerifyIDToken(t *testing.T) {
+	c, _, key, p := ssoTestCore(t)
+	ctx := context.Background()
+	base := func() jwt.MapClaims {
+		return jwt.MapClaims{
+			"iss": "https://idp.test", "aud": "client-1", "sub": "okta|123",
+			"email": "ada@x.io", "nonce": "N1", "exp": time.Now().Add(time.Hour).Unix(),
+		}
+	}
+
+	sub, email, err := c.verifyIDToken(ctx, p, "N1", signToken(t, key, "kid-1", base()))
+	require.NoError(t, err)
+	assert.Equal(t, "okta|123", sub)
+	assert.Equal(t, "ada@x.io", email)
+
+	// Wrong audience → rejected.
+	bad := base()
+	bad["aud"] = "someone-else"
+	_, _, err = c.verifyIDToken(ctx, p, "N1", signToken(t, key, "kid-1", bad))
+	require.Error(t, err)
+
+	// Nonce mismatch → rejected (replay / mix-up protection).
+	_, _, err = c.verifyIDToken(ctx, p, "WRONG", signToken(t, key, "kid-1", base()))
+	require.Error(t, err)
+
+	// Expired → rejected.
+	exp := base()
+	exp["exp"] = time.Now().Add(-time.Hour).Unix()
+	_, _, err = c.verifyIDToken(ctx, p, "N1", signToken(t, key, "kid-1", exp))
+	require.Error(t, err)
+
+	// Wrong issuer → rejected (keyfn refuses it).
+	iss := base()
+	iss["iss"] = "https://evil.test"
+	_, _, err = c.verifyIDToken(ctx, p, "N1", signToken(t, key, "kid-1", iss))
+	require.Error(t, err)
+}
+
+func TestResolveSSOUser(t *testing.T) {
+	notFound := func() error { return fmt.Errorf("%s", i18n.T("ErrorUserNotFound", nil)) }
+
+	t.Run("externalId match wins", func(t *testing.T) {
+		c, store, _, _ := ssoTestCore(t)
+		store.On("GetUserByExternalID", mock.Anything, "okta|123").Return(&models.User{ID: 7}, nil)
+		u, err := c.resolveSSOUser(context.Background(), "okta|123", "ada@x.io")
+		require.NoError(t, err)
+		assert.Equal(t, uint(7), u.ID)
+		store.AssertNotCalled(t, "GetUserByEmail", mock.Anything, mock.Anything)
+	})
+
+	t.Run("falls back to email", func(t *testing.T) {
+		c, store, _, _ := ssoTestCore(t)
+		store.On("GetUserByExternalID", mock.Anything, "okta|123").Return((*models.User)(nil), notFound())
+		store.On("GetUserByEmail", mock.Anything, "ada@x.io").Return(&models.User{ID: 9}, nil)
+		u, err := c.resolveSSOUser(context.Background(), "okta|123", "ada@x.io")
+		require.NoError(t, err)
+		assert.Equal(t, uint(9), u.ID)
+	})
+
+	t.Run("no match errors", func(t *testing.T) {
+		c, store, _, _ := ssoTestCore(t)
+		store.On("GetUserByExternalID", mock.Anything, "okta|123").Return((*models.User)(nil), notFound())
+		store.On("GetUserByEmail", mock.Anything, "ada@x.io").Return((*models.User)(nil), notFound())
+		_, err := c.resolveSSOUser(context.Background(), "okta|123", "ada@x.io")
+		require.Error(t, err)
+	})
+}
+
+func TestBeginSSO_BuildsAuthURLWithStateAndNonce(t *testing.T) {
+	c, store, _, _ := ssoTestCore(t)
+	var captured *models.SSOLoginState
+	store.On("CreateSSOLoginState", mock.Anything, mock.MatchedBy(func(s *models.SSOLoginState) bool {
+		captured = s
+		return s.Provider == "okta" && s.State != "" && s.Nonce != ""
+	})).Return(nil)
+
+	raw, err := c.BeginSSO(context.Background(), "okta", "/secrets")
+	require.NoError(t, err)
+	u, err := url.Parse(raw)
+	require.NoError(t, err)
+	assert.Equal(t, "idp.test", u.Host)
+	q := u.Query()
+	assert.Equal(t, captured.State, q.Get("state"))
+	assert.Equal(t, captured.Nonce, q.Get("nonce"))
+	assert.Equal(t, "client-1", q.Get("client_id"))
+	assert.Equal(t, "/secrets", captured.ReturnTo)
+}
+
+func TestBeginSSO_UnknownProvider(t *testing.T) {
+	c, _, _, _ := ssoTestCore(t)
+	_, err := c.BeginSSO(context.Background(), "nope", "")
+	require.Error(t, err)
+}
+
+func TestSanitizeReturnTo(t *testing.T) {
+	assert.Equal(t, "/secrets", sanitizeReturnTo("/secrets"))
+	assert.Equal(t, "", sanitizeReturnTo("//evil.com"))
+	assert.Equal(t, "", sanitizeReturnTo("https://evil.com"))
+	assert.Equal(t, "", sanitizeReturnTo("evil"))
+}

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -101,6 +101,11 @@ type Storage interface {
 	GetRiskException(ctx context.Context, id uint) (*models.RiskException, error)
 	UpdateRiskException(ctx context.Context, e *models.RiskException) error
 
+	// SSO login state (OIDC human SSO) — short-lived CSRF/nonce state.
+	// ConsumeSSOLoginState is single-use: it returns the row and deletes it.
+	CreateSSOLoginState(ctx context.Context, s *models.SSOLoginState) error
+	ConsumeSSOLoginState(ctx context.Context, state string) (*models.SSOLoginState, error)
+
 	// Break-glass emergency-access activations (NIS2/DORA incident response).
 	CreateBreakGlassActivation(ctx context.Context, a *models.BreakGlassActivation) (*models.BreakGlassActivation, error)
 	GetBreakGlassActivation(ctx context.Context, id uint) (*models.BreakGlassActivation, error)

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -270,6 +270,7 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 	breakGlassExists := tableExists(db, "break_glass_activations")
 	legalHoldExists := tableExists(db, "legal_holds")
 	riskExceptionExists := tableExists(db, "risk_exceptions")
+	ssoLoginStateExists := tableExists(db, "sso_login_states")
 	sodExists := tableExists(db, "sod_policies")
 	pwHistExists := tableExists(db, "password_histories")
 	machineExists := tableExists(db, "machine_identities")
@@ -435,6 +436,13 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 	if !riskExceptionExists {
 		if err := db.AutoMigrate(&models.RiskException{}); err != nil {
 			return fmt.Errorf("failed to migrate risk_exceptions table: %w", err)
+		}
+	}
+
+	// Create the SSO-login-state table if missing (OIDC human SSO, additive).
+	if !ssoLoginStateExists {
+		if err := db.AutoMigrate(&models.SSOLoginState{}); err != nil {
+			return fmt.Errorf("failed to migrate sso_login_states table: %w", err)
 		}
 	}
 

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -116,6 +116,21 @@ type LegalHold struct {
 	ReleasedAt *time.Time `json:"released_at,omitempty"`
 }
 
+// SSOLoginState is the short-lived CSRF/nonce state for an in-flight OIDC
+// authorization-code login (RFC 6749 §10.12 / the OIDC nonce). It is created when
+// the user is redirected to the IdP and consumed single-use on callback, binding the
+// returned id_token's nonce to this browser and proving the callback's state was the
+// one we issued. Expires within minutes.
+type SSOLoginState struct {
+	ID        uint      `gorm:"primaryKey"`
+	State     string    `gorm:"uniqueIndex;not null"` // random CSRF token; the lookup key
+	Nonce     string    `gorm:"not null"`             // bound into the requested id_token
+	Provider  string    `gorm:"not null"`
+	ReturnTo  string    // optional in-app path to land on after login
+	ExpiresAt time.Time `gorm:"index"`
+	CreatedAt time.Time
+}
+
 // RiskException records a governed acceptance of a known control gap or policy
 // exception (ISO 27001 A.5.8 risk treatment / A.5.36 compliance-with-policies): a
 // named risk, accepted by an owner with a written justification, for a bounded time.

--- a/internal/storage/store/local_sso.go
+++ b/internal/storage/store/local_sso.go
@@ -1,0 +1,38 @@
+// local_sso.go — short-lived OIDC-login state (human SSO). See remote_sso.go for
+// the server-side-only remote stubs.
+package store
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"gorm.io/gorm"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+func (ls *LocalStorage) CreateSSOLoginState(ctx context.Context, s *models.SSOLoginState) error {
+	if err := ls.db.WithContext(ctx).Create(s).Error; err != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	return nil
+}
+
+// ConsumeSSOLoginState returns the state row and deletes it (single use), so a
+// callback's state can never be replayed. Returns the not-found error if absent.
+func (ls *LocalStorage) ConsumeSSOLoginState(ctx context.Context, state string) (*models.SSOLoginState, error) {
+	var s models.SSOLoginState
+	err := ls.db.WithContext(ctx).Where("state = ?", state).First(&s).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, fmt.Errorf("%s", i18n.T("ErrorNotFound", nil))
+	}
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	if err := ls.db.WithContext(ctx).Delete(&models.SSOLoginState{}, s.ID).Error; err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	return &s, nil
+}

--- a/internal/storage/store/local_sso_test.go
+++ b/internal/storage/store/local_sso_test.go
@@ -1,0 +1,34 @@
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestSSOLoginState_CreateConsumeIsSingleUse(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.SSOLoginState{}))
+	ls := NewLocalStorage(db)
+	ctx := context.Background()
+
+	require.NoError(t, ls.CreateSSOLoginState(ctx, &models.SSOLoginState{
+		State: "st-1", Nonce: "n-1", Provider: "okta", ExpiresAt: time.Now().Add(10 * time.Minute),
+	}))
+
+	got, err := ls.ConsumeSSOLoginState(ctx, "st-1")
+	require.NoError(t, err)
+	assert.Equal(t, "n-1", got.Nonce)
+	assert.Equal(t, "okta", got.Provider)
+
+	// Second consume of the same state fails — it was deleted (no replay).
+	_, err = ls.ConsumeSSOLoginState(ctx, "st-1")
+	require.Error(t, err)
+}

--- a/internal/storage/store/remote_sso.go
+++ b/internal/storage/store/remote_sso.go
@@ -1,0 +1,17 @@
+// remote_sso.go — SSO login state for RemoteStorage. The OIDC login flow is
+// server-side only; stubs here. See local_sso.go.
+package store
+
+import (
+	"context"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+func (rs *RemoteStorage) CreateSSOLoginState(_ context.Context, _ *models.SSOLoginState) error {
+	return remoteUnsupported("CreateSSOLoginState")
+}
+
+func (rs *RemoteStorage) ConsumeSSOLoginState(_ context.Context, _ string) (*models.SSOLoginState, error) {
+	return nil, remoteUnsupported("ConsumeSSOLoginState")
+}

--- a/server/http/handlers/sso.go
+++ b/server/http/handlers/sso.go
@@ -28,7 +28,9 @@ func (h *AuthHandler) BeginSSO(w http.ResponseWriter, r *http.Request) {
 		sendError(w, "SSOError", err.Error(), http.StatusBadRequest, nil)
 		return
 	}
-	http.Redirect(w, r, authURL, http.StatusFound)
+	// authURL is built by core from the provider's operator-configured, discovery-
+	// resolved OIDC authorization endpoint (plus our state/nonce) — never user input.
+	http.Redirect(w, r, authURL, http.StatusFound) // #nosec G710 -- operator-configured IdP endpoint, not user-controlled
 }
 
 // CompleteSSO handles GET /auth/sso/{provider}/callback — exchanges the code, mints a
@@ -73,7 +75,10 @@ func (h *AuthHandler) CompleteSSO(w http.ResponseWriter, r *http.Request) {
 }
 
 // redirectFragment 302-redirects to base#<encoded values>, delivering the token (or
-// an error) to the SPA without it touching query logs.
+// an error) to the SPA without it touching query logs. base is the provider's
+// operator-configured completion URL (SSOCompleteURL); the fragment carries data.
 func (h *AuthHandler) redirectFragment(w http.ResponseWriter, r *http.Request, base string, values url.Values) {
-	http.Redirect(w, r, base+"#"+values.Encode(), http.StatusFound)
+	// base is operator-configured (the SSO completion URL derived from redirect_url),
+	// not user input; the fragment is data the SPA reads.
+	http.Redirect(w, r, base+"#"+values.Encode(), http.StatusFound) // #nosec G710 -- operator-configured completion URL, not user-controlled
 }

--- a/server/http/handlers/sso.go
+++ b/server/http/handlers/sso.go
@@ -1,0 +1,79 @@
+// sso.go — human SSO login endpoints (OIDC authorization-code flow). All three are
+// unauthenticated (mounted outside the session middleware): the login redirect, the
+// IdP callback, and the provider list the login page reads. On success the callback
+// hands the SPA its session by redirecting to the web completion page with the token
+// in the URL fragment (kept out of server logs / the Referer header).
+package handlers
+
+import (
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// ListSSOProviders handles GET /auth/sso/providers — the enabled provider names, so
+// the login page can render the right "Sign in with …" buttons.
+func (h *AuthHandler) ListSSOProviders(w http.ResponseWriter, _ *http.Request) {
+	sendSuccess(w, map[string]interface{}{"providers": h.coreService.SSOProviderNames()}, "")
+}
+
+// BeginSSO handles GET /auth/sso/{provider}/login — redirects the browser to the IdP
+// authorization endpoint with a fresh state + nonce.
+func (h *AuthHandler) BeginSSO(w http.ResponseWriter, r *http.Request) {
+	provider := chi.URLParam(r, "provider")
+	authURL, err := h.coreService.BeginSSO(r.Context(), provider, r.URL.Query().Get("return_to"))
+	if err != nil {
+		sendError(w, "SSOError", err.Error(), http.StatusBadRequest, nil)
+		return
+	}
+	http.Redirect(w, r, authURL, http.StatusFound)
+}
+
+// CompleteSSO handles GET /auth/sso/{provider}/callback — exchanges the code, mints a
+// session, and redirects to the SPA completion page with the token in the fragment.
+func (h *AuthHandler) CompleteSSO(w http.ResponseWriter, r *http.Request) {
+	provider := chi.URLParam(r, "provider")
+	completeURL, ok := h.coreService.SSOCompleteURL(provider)
+	if !ok {
+		sendError(w, "SSOError", "unknown SSO provider", http.StatusBadRequest, nil)
+		return
+	}
+
+	q := r.URL.Query()
+	if errParam := q.Get("error"); errParam != "" {
+		// The IdP itself reported an error (e.g. access_denied).
+		h.redirectFragment(w, r, completeURL, url.Values{"error": {errParam}})
+		return
+	}
+	code, state := q.Get("code"), q.Get("state")
+	if code == "" || state == "" {
+		h.redirectFragment(w, r, completeURL, url.Values{"error": {"missing code or state"}})
+		return
+	}
+
+	session, _, returnTo, err := h.coreService.CompleteSSO(r.Context(), provider, code, state, r.Header.Get("User-Agent"), r.RemoteAddr)
+	if err != nil {
+		h.redirectFragment(w, r, completeURL, url.Values{"error": {err.Error()}})
+		return
+	}
+
+	frag := url.Values{"token": {session.SessionToken}}
+	if session.ExpiresAt != nil {
+		frag.Set("expires_at", session.ExpiresAt.Format(time.RFC3339))
+	}
+	if session.AbsoluteExpiresAt != nil {
+		frag.Set("absolute_expires_at", session.AbsoluteExpiresAt.Format(time.RFC3339))
+	}
+	if returnTo != "" {
+		frag.Set("return_to", returnTo)
+	}
+	h.redirectFragment(w, r, completeURL, frag)
+}
+
+// redirectFragment 302-redirects to base#<encoded values>, delivering the token (or
+// an error) to the SPA without it touching query logs.
+func (h *AuthHandler) redirectFragment(w http.ResponseWriter, r *http.Request, base string, values url.Values) {
+	http.Redirect(w, r, base+"#"+values.Encode(), http.StatusFound)
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -93,6 +93,14 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 	r.Get("/auth/setup/{token}", authHandler.GetSetupToken)
 	r.Post("/auth/setup/consume", authHandler.ConsumeSetup)
 
+	// Human SSO login (OIDC authorization-code flow) — unauthenticated: the IdP is
+	// the authenticator. The login redirect, the IdP callback, and the provider list
+	// the login page reads. With sso disabled the provider list is empty and BeginSSO
+	// 400s on any provider.
+	r.Get("/auth/sso/providers", authHandler.ListSSOProviders)
+	r.Get("/auth/sso/{provider}/login", authHandler.BeginSSO)
+	r.Get("/auth/sso/{provider}/callback", authHandler.CompleteSSO)
+
 	// Health check endpoint
 	r.Get("/health", handlers.HealthCheck)
 

--- a/server/main.go
+++ b/server/main.go
@@ -21,10 +21,12 @@ package main
 import (
 	"context"
 	"crypto/tls"
+	"encoding/json"
 	"fmt"
 	"log"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -46,6 +48,7 @@ import (
 	"github.com/keyorixhq/keyorix/server/grpc"
 	httpServer "github.com/keyorixhq/keyorix/server/http"
 	"golang.org/x/crypto/acme/autocert"
+	"golang.org/x/oauth2"
 )
 
 func main() {
@@ -369,6 +372,17 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 		}
 		coreService.SetOIDCVerifier(verifier)
 		log.Printf("OIDC federation enabled for %d issuer(s)", len(oidc.Issuers))
+	}
+
+	// Wire human SSO login (OIDC authorization-code flow) when configured. Each
+	// provider's endpoints are discovered from its issuer; a provider whose discovery
+	// fails is skipped with a warning rather than failing startup.
+	if sso := cfg.SSO; sso.Enabled && len(sso.Providers) > 0 {
+		providers, jwks, n := buildSSOProviders(sso)
+		if n > 0 {
+			coreService.SetSSOProviders(providers, jwks)
+			log.Printf("Human SSO enabled for %d provider(s)", n)
+		}
 	}
 
 	// Wire WebAuthn / passkeys (ADR-036) when configured. A bad RP config (no
@@ -971,4 +985,95 @@ func resolveOutboundIP() string {
 	}
 	defer conn.Close() //nolint:errcheck
 	return conn.LocalAddr().(*net.UDPAddr).IP.String()
+}
+
+// oidcDiscovery is the subset of an OIDC discovery document we need.
+type oidcDiscovery struct {
+	AuthorizationEndpoint string `json:"authorization_endpoint"`
+	TokenEndpoint         string `json:"token_endpoint"`
+	JWKSURI               string `json:"jwks_uri"`
+}
+
+// discoverOIDC fetches an issuer's /.well-known/openid-configuration.
+func discoverOIDC(issuer string) (*oidcDiscovery, error) {
+	u := strings.TrimRight(issuer, "/") + "/.well-known/openid-configuration"
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Get(u) // #nosec G107 -- issuer is operator-configured, not user input
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("discovery returned %s", resp.Status)
+	}
+	var d oidcDiscovery
+	if err := json.NewDecoder(resp.Body).Decode(&d); err != nil {
+		return nil, err
+	}
+	if d.AuthorizationEndpoint == "" || d.TokenEndpoint == "" || d.JWKSURI == "" {
+		return nil, fmt.Errorf("discovery document is missing required endpoints")
+	}
+	return &d, nil
+}
+
+// ssoCompleteURL derives the SPA completion URL (<redirect origin>/auth/sso/complete)
+// from a provider's redirect_url.
+func ssoCompleteURL(redirectURL string) (string, error) {
+	u, err := url.Parse(redirectURL)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return "", fmt.Errorf("invalid redirect_url %q", redirectURL)
+	}
+	return u.Scheme + "://" + u.Host + "/auth/sso/complete", nil
+}
+
+// buildSSOProviders discovers each configured provider and builds the resolved
+// providers + a JWKS resolver over their issuers. A provider that is misconfigured
+// or whose discovery fails is skipped with a warning (it must not block startup).
+func buildSSOProviders(sso config.SSOConfig) (map[string]*core.SSOProvider, core.JWKSResolver, int) {
+	providers := map[string]*core.SSOProvider{}
+	jwksURIs := map[string]string{}
+	for i := range sso.Providers {
+		pc := sso.Providers[i]
+		if pc.Name == "" || pc.Issuer == "" || pc.ClientID == "" || pc.RedirectURL == "" {
+			log.Printf("SSO provider %q misconfigured (name/issuer/client_id/redirect_url required); skipping", pc.Name)
+			continue
+		}
+		disc, err := discoverOIDC(pc.Issuer)
+		if err != nil {
+			log.Printf("SSO provider %q discovery failed: %v; skipping", pc.Name, err)
+			continue
+		}
+		completeURL, err := ssoCompleteURL(pc.RedirectURL)
+		if err != nil {
+			log.Printf("SSO provider %q: %v; skipping", pc.Name, err)
+			continue
+		}
+		scopes := pc.Scopes
+		if len(scopes) == 0 {
+			scopes = []string{"openid", "profile", "email"}
+		}
+		providers[pc.Name] = &core.SSOProvider{
+			Name:     pc.Name,
+			Issuer:   pc.Issuer,
+			ClientID: pc.ClientID,
+			OAuth: &oauth2.Config{
+				ClientID:     pc.ClientID,
+				ClientSecret: pc.GetClientSecret(),
+				Endpoint:     oauth2.Endpoint{AuthURL: disc.AuthorizationEndpoint, TokenURL: disc.TokenEndpoint},
+				RedirectURL:  pc.RedirectURL,
+				Scopes:       scopes,
+			},
+			CompleteURL: completeURL,
+		}
+		jwksURIs[pc.Issuer] = disc.JWKSURI
+	}
+	if len(providers) == 0 {
+		return nil, nil, 0
+	}
+	resolver, err := core.NewHTTPJWKSResolver(jwksURIs)
+	if err != nil {
+		log.Printf("SSO disabled: jwks resolver init failed: %v", err)
+		return nil, nil, 0
+	}
+	return providers, resolver, len(providers)
 }


### PR DESCRIPTION
## What

SCIM provisions users but they have **no password and couldn't sign in**. This adds **human SSO**: a user authenticates at their IdP and Keyorix mints the *same* session a password login would — completing the enterprise identity loop (IdP provisions via SCIM → user signs in via SSO).

Batch 1 of the program (SSO → Slack/Teams + digests → signed evidence), per "1 2 3". Backend; the web "Sign in with SSO" button + completion page follow.

## How

- **config** — `sso {enabled, providers[{name, issuer, client_id, client_secret, redirect_url, scopes}]}`; secret from `KEYORIX_SSO_<NAME>_CLIENT_SECRET`.
- **core** (`sso.go`) — `BeginSSO` (store CSRF state + nonce, build the authorize URL), `CompleteSSO` (consume state, exchange the code via `x/oauth2`, verify the id_token, map to a user, mint via the shared `mintSession`). `verifyIDToken` checks **signature (asymmetric only, via the reused `HTTPJWKSResolver`), issuer, audience = client_id, expiry, and the nonce**. Mapping: `sub` → SCIM `externalId`, then email; **suspended users refused; no auto-provisioning**. SSO bypasses Keyorix-local MFA (the IdP authenticates). Audited `auth.sso_login`.
- **storage** — `SSOLoginState` (single-use CSRF/nonce; additive table + migration); Create/Consume across the interface (local + remote stub + mock).
- **handler/router** — unauthenticated `GET /auth/sso/providers`, `/auth/sso/{provider}/login` (302 to IdP), `/auth/sso/{provider}/callback` (mint → 302 to the SPA `/auth/sso/complete` with the token in the **URL fragment**, kept out of logs/Referer).
- **startup** — OIDC **discovery** per provider builds the `oauth2.Config` + JWKS resolver; a provider whose discovery fails is skipped, not fatal.
- **docs** — `CONFIGURATION.md` `sso` section.

## Tests

- id_token verification: valid / bad-aud / bad-nonce / expired / wrong-issuer.
- User resolution: externalId-first, email fallback, no-match error.
- `BeginSSO` URL carries state+nonce; `return_to` open-redirect sanitisation; single-use state consume (no replay).

🤖 Generated with [Claude Code](https://claude.com/claude-code)