### PR TITLE
feat(notify): Slack and Microsoft Teams notification channels

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -403,10 +403,21 @@ notifications:
     password: ""                 # prefer the KEYORIX_NOTIFY_SMTP_PASSWORD env var
     from: "keyorix@example.com"
     tls: "starttls"              # starttls | implicit | none(dev-only)
+  slack:
+    enabled: true
+    webhook_url: ""              # prefer the KEYORIX_NOTIFY_SLACK_WEBHOOK env var
+  teams:
+    enabled: true
+    webhook_url: ""              # prefer the KEYORIX_NOTIFY_TEAMS_WEBHOOK env var
 ```
 
+The **slack** and **teams** channels POST to an incoming-webhook URL (Slack: a
+`{text}` message; Teams: a MessageCard). The webhook URL embeds the platform's secret
+token, so set it via the env var.
+
 > Secrets are read from `KEYORIX_NOTIFY_WEBHOOK_TOKEN` / `KEYORIX_NOTIFY_SMTP_PASSWORD`
-> when set, falling back to the YAML value — keep secrets out of the config file.
+> / `KEYORIX_NOTIFY_SLACK_WEBHOOK` / `KEYORIX_NOTIFY_TEAMS_WEBHOOK` when set, falling
+> back to the YAML value — keep secrets out of the config file.
 
 ## evidence_delivery
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -599,6 +599,25 @@ func (c RecertificationConfig) GetInterval() time.Duration {
 type NotificationsConfig struct {
 	Webhook NotificationWebhookConfig `yaml:"webhook"`
 	Email   NotificationEmailConfig   `yaml:"email"`
+	Slack   NotificationChatConfig    `yaml:"slack"`
+	Teams   NotificationChatConfig    `yaml:"teams"`
+}
+
+// NotificationChatConfig configures a Slack or Teams channel: an incoming-webhook
+// URL (which carries the platform's secret token, so prefer the env var).
+type NotificationChatConfig struct {
+	Enabled    bool   `yaml:"enabled"`
+	WebhookURL string `yaml:"webhook_url"`
+}
+
+// GetWebhookURL returns the resolved Slack incoming-webhook URL.
+func (c *NotificationsConfig) GetSlackWebhookURL() string {
+	return resolveSecret("KEYORIX_NOTIFY_SLACK_WEBHOOK", c.Slack.WebhookURL)
+}
+
+// GetTeamsWebhookURL returns the resolved Teams incoming-webhook URL.
+func (c *NotificationsConfig) GetTeamsWebhookURL() string {
+	return resolveSecret("KEYORIX_NOTIFY_TEAMS_WEBHOOK", c.Teams.WebhookURL)
 }
 
 // NotificationEmailConfig configures the SMTP notification channel: each

--- a/internal/notifychan/chat.go
+++ b/internal/notifychan/chat.go
@@ -1,0 +1,160 @@
+// chat.go — Slack / Microsoft Teams notification channels. Both accept an incoming
+// webhook URL that carries its own secret token; the only per-platform difference is
+// the JSON payload shape (Slack: {text}; Teams: a MessageCard). Like the other sinks
+// it delivers asynchronously off a bounded queue so a slow chat endpoint never blocks
+// the triggering action.
+package notifychan
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+)
+
+const (
+	chatTimeout   = 10 * time.Second
+	chatQueueSize = 256
+)
+
+// ChatKind selects the payload format for the chat webhook.
+type ChatKind string
+
+const (
+	ChatSlack ChatKind = "slack"
+	ChatTeams ChatKind = "teams"
+)
+
+// ChatConfig configures a Slack/Teams channel: the platform and its incoming-webhook
+// URL (which embeds the platform's secret token).
+type ChatConfig struct {
+	Kind       ChatKind
+	WebhookURL string
+}
+
+// ChatSink delivers notifications to a Slack or Teams incoming webhook.
+type ChatSink struct {
+	cfg     ChatConfig
+	client  *http.Client
+	queue   chan core.NotificationEvent
+	wg      sync.WaitGroup
+	mu      sync.Mutex
+	dropped int
+}
+
+// NewChat builds a chat sink and starts its worker. The kind must be slack|teams and
+// the webhook URL is required. Close() drains in-flight events at shutdown.
+func NewChat(cfg ChatConfig) (*ChatSink, error) {
+	switch cfg.Kind {
+	case ChatSlack, ChatTeams:
+	default:
+		return nil, fmt.Errorf("notifychan: unknown chat kind %q (want slack|teams)", cfg.Kind)
+	}
+	if cfg.WebhookURL == "" {
+		return nil, fmt.Errorf("notifychan: chat webhook_url is required")
+	}
+	s := &ChatSink{
+		cfg:    cfg,
+		client: &http.Client{Timeout: chatTimeout},
+		queue:  make(chan core.NotificationEvent, chatQueueSize),
+	}
+	s.wg.Add(1)
+	go s.worker()
+	return s, nil
+}
+
+// Deliver enqueues the event. Non-blocking; drops (and counts) when the queue is full.
+func (s *ChatSink) Deliver(ev core.NotificationEvent) {
+	if s == nil {
+		return
+	}
+	select {
+	case s.queue <- ev:
+	default:
+		s.mu.Lock()
+		s.dropped++
+		dropped := s.dropped
+		s.mu.Unlock()
+		log.Printf("notifychan: %s queue full, dropped notification (total dropped: %d)", s.cfg.Kind, dropped)
+	}
+}
+
+func (s *ChatSink) worker() {
+	defer s.wg.Done()
+	for ev := range s.queue {
+		if err := s.send(context.Background(), ev); err != nil {
+			log.Printf("notifychan: %s delivery failed: %v", s.cfg.Kind, err)
+		}
+	}
+}
+
+func (s *ChatSink) send(ctx context.Context, ev core.NotificationEvent) error {
+	body, err := json.Marshal(chatPayload(s.cfg.Kind, ev))
+	if err != nil {
+		return fmt.Errorf("marshal %s payload: %w", s.cfg.Kind, err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.cfg.WebhookURL, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("%s webhook returned %s", s.cfg.Kind, strings.TrimSpace(resp.Status))
+	}
+	return nil
+}
+
+// chatText renders the notification as a single plain-text message (no remote
+// resources), shared by both platforms.
+func chatText(ev core.NotificationEvent) string {
+	var b strings.Builder
+	if ev.Title != "" {
+		fmt.Fprintf(&b, "*%s*\n", ev.Title)
+	}
+	b.WriteString(ev.Message)
+	if ev.Link != "" {
+		fmt.Fprintf(&b, "\n%s", ev.Link)
+	}
+	return b.String()
+}
+
+// chatPayload builds the platform-specific JSON body. Slack incoming webhooks take
+// {text}; Teams connectors take a MessageCard.
+func chatPayload(kind ChatKind, ev core.NotificationEvent) interface{} {
+	text := chatText(ev)
+	if kind == ChatTeams {
+		title := ev.Title
+		if title == "" {
+			title = "Keyorix notification"
+		}
+		return map[string]interface{}{
+			"@type":    "MessageCard",
+			"@context": "https://schema.org/extensions",
+			"summary":  title,
+			"title":    title,
+			"text":     ev.Message,
+		}
+	}
+	return map[string]string{"text": text}
+}
+
+// Close stops the worker after draining queued events.
+func (s *ChatSink) Close() {
+	if s == nil {
+		return
+	}
+	close(s.queue)
+	s.wg.Wait()
+}

--- a/internal/notifychan/chat_test.go
+++ b/internal/notifychan/chat_test.go
@@ -1,0 +1,69 @@
+package notifychan
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func captureChatServer(t *testing.T) (*httptest.Server, func() []byte) {
+	t.Helper()
+	var mu sync.Mutex
+	var body []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		body = b
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, func() []byte {
+		mu.Lock()
+		defer mu.Unlock()
+		return body
+	}
+}
+
+func TestChatSink_SlackPayload(t *testing.T) {
+	srv, get := captureChatServer(t)
+	sink, err := NewChat(ChatConfig{Kind: ChatSlack, WebhookURL: srv.URL})
+	require.NoError(t, err)
+	pid := uint(3)
+	sink.Deliver(core.NotificationEvent{Title: "Secrets due for rotation", Message: "2 overdue in Payments.", ProjectID: &pid, Link: "/rotation-policies"})
+	sink.Close()
+
+	var payload map[string]string
+	require.NoError(t, json.Unmarshal(get(), &payload))
+	assert.Contains(t, payload["text"], "Secrets due for rotation")
+	assert.Contains(t, payload["text"], "2 overdue in Payments.")
+	assert.Contains(t, payload["text"], "/rotation-policies")
+}
+
+func TestChatSink_TeamsPayload(t *testing.T) {
+	srv, get := captureChatServer(t)
+	sink, err := NewChat(ChatConfig{Kind: ChatTeams, WebhookURL: srv.URL})
+	require.NoError(t, err)
+	sink.Deliver(core.NotificationEvent{Title: "Anomaly detected", Message: "off-hours access by ada."})
+	sink.Close()
+
+	var card map[string]interface{}
+	require.NoError(t, json.Unmarshal(get(), &card))
+	assert.Equal(t, "MessageCard", card["@type"])
+	assert.Equal(t, "Anomaly detected", card["title"])
+	assert.Equal(t, "off-hours access by ada.", card["text"])
+}
+
+func TestNewChat_Validation(t *testing.T) {
+	_, err := NewChat(ChatConfig{Kind: "irc", WebhookURL: "https://x"})
+	require.Error(t, err)
+	_, err = NewChat(ChatConfig{Kind: ChatSlack})
+	require.Error(t, err)
+}

--- a/server/main.go
+++ b/server/main.go
@@ -277,6 +277,22 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 		notifySinks = append(notifySinks, sink)
 		log.Printf("Notification email channel enabled (host=%s)", ec.Host)
 	}
+	if cfg.Notifications.Slack.Enabled {
+		sink, serr := notifychan.NewChat(notifychan.ChatConfig{Kind: notifychan.ChatSlack, WebhookURL: cfg.Notifications.GetSlackWebhookURL()})
+		if serr != nil {
+			return nil, nil, fmt.Errorf("failed to init Slack notification channel: %w", serr)
+		}
+		notifySinks = append(notifySinks, sink)
+		log.Printf("Notification Slack channel enabled")
+	}
+	if cfg.Notifications.Teams.Enabled {
+		sink, terr := notifychan.NewChat(notifychan.ChatConfig{Kind: notifychan.ChatTeams, WebhookURL: cfg.Notifications.GetTeamsWebhookURL()})
+		if terr != nil {
+			return nil, nil, fmt.Errorf("failed to init Teams notification channel: %w", terr)
+		}
+		notifySinks = append(notifySinks, sink)
+		log.Printf("Notification Teams channel enabled")
+	}
 	if sink := notifychan.NewMulti(notifySinks...); sink != nil {
 		coreService.SetNotificationSink(sink)
 	}


### PR DESCRIPTION
## What

Adds **Slack** and **Microsoft Teams** to the notification channels (on the `notifychan` abstraction), so the in-app notifications Keyorix creates (approvals, anomaly alerts, rotation/recert reminders, break-glass) reach a team channel — not just email/webhook/bell.

Batch 2 part a (the channel); the scheduled compliance digest follows.

## How

- **internal/notifychan** — `ChatSink`: async (bounded queue + worker) POST to an incoming-webhook URL; **Slack** gets a `{text}` message, **Teams** a MessageCard. Drops rather than blocks on a wedged endpoint; `Close()` drains.
- **config** — `notifications.{slack,teams} {enabled, webhook_url}`; URLs from `KEYORIX_NOTIFY_SLACK_WEBHOOK` / `KEYORIX_NOTIFY_TEAMS_WEBHOOK` (the URL embeds the platform token). Wired into the existing multi-sink fan-out.
- **docs** — `CONFIGURATION.md` notifications.

## Tests

- Slack `{text}` payload carries title/message/link; Teams MessageCard shape; `NewChat` validation (kind + url required).

🤖 Generated with [Claude Code](https://claude.com/claude-code)