### PR TITLE
feat(compliance): scheduled compliance digest to notification channels

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -16,7 +16,7 @@ The config file is located via, in order: an explicit path argument, then
 - [secrets](#secrets) · [security + require_mfa](#security) (ADR-034)
 - [webauthn](#webauthn) (ADR-036) · [dynamic_secrets](#dynamic_secrets) (ADR-035)
 - [oidc](#oidc) (ADR-031) · [session](#session) · [password_policy](#password_policy) (ADR-025)
-- [soft_delete + purge](#soft_delete--purge) (ADR-032) · [data_retention](#data_retention) (A.5.33) · [recertification](#recertification) (A.5.18) · [notifications](#notifications) · [evidence_delivery](#evidence_delivery) · [rotation_reminders](#rotation_reminders) · [audit_checkpoints](#audit_checkpoints) (ADR-029) · [jit_access_expiry](#jit_access_expiry) · [break_glass](#break_glass) · [audit.siem](#auditsiem)
+- [soft_delete + purge](#soft_delete--purge) (ADR-032) · [data_retention](#data_retention) (A.5.33) · [recertification](#recertification) (A.5.18) · [notifications](#notifications) · [compliance_digest](#compliance_digest) · [evidence_delivery](#evidence_delivery) · [rotation_reminders](#rotation_reminders) · [audit_checkpoints](#audit_checkpoints) (ADR-029) · [jit_access_expiry](#jit_access_expiry) · [break_glass](#break_glass) · [audit.siem](#auditsiem)
 - [scim](#scim) (RFC 7644) · [sso](#sso) (OIDC) · [membership](#membership) (ADR-022) · [credential_delivery](#credential_delivery) (ADR-028)
 
 ---
@@ -418,6 +418,22 @@ token, so set it via the env var.
 > Secrets are read from `KEYORIX_NOTIFY_WEBHOOK_TOKEN` / `KEYORIX_NOTIFY_SMTP_PASSWORD`
 > / `KEYORIX_NOTIFY_SLACK_WEBHOOK` / `KEYORIX_NOTIFY_TEAMS_WEBHOOK` when set, falling
 > back to the YAML value — keep secrets out of the config file.
+
+## compliance_digest
+
+An opt-in scheduler that periodically **broadcasts a compliance summary** to the
+configured notification channels (Slack/Teams/webhook) — a continuous-monitoring
+digest of the control matrix + posture: controls pass/gap, projects overdue for
+recertification, rotation gaps, unclassified secrets, open anomalies, and active risk
+exceptions. It's a single broadcast per run (one message to the channel), and a no-op
+when no [`notifications`](#notifications) channel is configured. Single-replica-gated
+(ADR-039).
+
+```yaml
+compliance_digest:
+  enabled: true
+  schedule: "168h"   # Go duration between digests (default 24h; e.g. 168h = weekly)
+```
 
 ## evidence_delivery
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -54,6 +54,9 @@ type Config struct {
 	// Notifications configures external delivery (email/webhook) of the in-app
 	// notifications Keyorix creates (approvals, anomalies, reminders, break-glass).
 	Notifications NotificationsConfig `yaml:"notifications"`
+	// ComplianceDigest configures the opt-in scheduler that periodically broadcasts a
+	// posture + control-matrix summary to the configured notification channels.
+	ComplianceDigest ComplianceDigestConfig `yaml:"compliance_digest"`
 	// SCIM configures the SCIM 2.0 provisioning endpoints (RFC 7644) used by an IdP
 	// to provision/deprovision users. Disabled (zero value) = /scim/v2 is not served.
 	SCIM SCIMConfig `yaml:"scim"`
@@ -618,6 +621,26 @@ func (c *NotificationsConfig) GetSlackWebhookURL() string {
 // GetTeamsWebhookURL returns the resolved Teams incoming-webhook URL.
 func (c *NotificationsConfig) GetTeamsWebhookURL() string {
 	return resolveSecret("KEYORIX_NOTIFY_TEAMS_WEBHOOK", c.Teams.WebhookURL)
+}
+
+// ComplianceDigestConfig configures the scheduled compliance digest (ISO 27001 /
+// SOC 2 continuous monitoring): a periodic posture + control-matrix summary
+// broadcast to the configured notification channels. Opt-in (default off); requires
+// at least one notification channel to have somewhere to deliver.
+type ComplianceDigestConfig struct {
+	Enabled  bool   `yaml:"enabled"`
+	Schedule string `yaml:"schedule"`
+}
+
+// GetInterval returns the digest interval, parsing Schedule as a Go duration (e.g.
+// "24h", "168h"); defaults to 24h when unset or unparseable.
+func (c ComplianceDigestConfig) GetInterval() time.Duration {
+	if c.Schedule != "" {
+		if d, err := time.ParseDuration(c.Schedule); err == nil && d > 0 {
+			return d
+		}
+	}
+	return 24 * time.Hour
 }
 
 // NotificationEmailConfig configures the SMTP notification channel: each

--- a/internal/core/compliance_digest.go
+++ b/internal/core/compliance_digest.go
@@ -1,0 +1,98 @@
+// compliance_digest.go — a scheduled compliance digest (ISO 27001 / SOC 2 continuous
+// monitoring): a periodic summary of the control matrix + posture (controls
+// pass/gap, overdue recertifications, rotation gaps, unclassified secrets, open
+// anomalies, active risk exceptions) broadcast to the configured notification
+// channels (Slack/Teams/webhook). It ties the control matrix to the notification
+// fan-out so an admin sees the deployment's compliance state where they work,
+// without opening the console.
+package core
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+const EventComplianceDigestSent = "compliance.digest_sent"
+
+// BuildComplianceDigest assembles the digest from the current posture + control
+// matrix. Returns a title and a plaintext body.
+func (c *KeyorixCore) BuildComplianceDigest(ctx context.Context) (title, body string, err error) {
+	p, err := c.GetCompliancePosture(ctx)
+	if err != nil {
+		return "", "", err
+	}
+	controls := EvaluateControls(p)
+	title, body = formatComplianceDigest(p, controls)
+	return title, body, nil
+}
+
+// formatComplianceDigest renders the digest from a posture snapshot + evaluated
+// controls. Pure (no storage) so it is unit-testable.
+func formatComplianceDigest(p *CompliancePosture, controls []ControlState) (title, body string) {
+	pass, gap := 0, 0
+	var gaps []string
+	for _, ctrl := range controls {
+		switch ctrl.Status {
+		case ControlStatusPass:
+			pass++
+		case ControlStatusGap:
+			gap++
+			gaps = append(gaps, ctrl.Name)
+		}
+	}
+
+	title = fmt.Sprintf("Keyorix compliance digest — %d/%d controls pass", pass, len(controls))
+	if gap > 0 {
+		title = fmt.Sprintf("Keyorix compliance digest — %d gap%s across %d controls", gap, plural(gap), len(controls))
+	}
+
+	var b strings.Builder
+	ag := p.AccessGovernance
+	fmt.Fprintf(&b, "Controls: %d pass, %d gap (of %d).\n", pass, gap, len(controls))
+	if gap > 0 {
+		fmt.Fprintf(&b, "Open gaps: %s.\n", strings.Join(gaps, ", "))
+	}
+	fmt.Fprintf(&b, "Access: %d project(s) overdue for recertification, %d never reviewed, %d SoD violation(s), %d dormant grant(s).\n",
+		ag.ProjectsOverdue, ag.ProjectsNeverReviewed, ag.SoDViolations, ag.DormantRoleGrants)
+	fmt.Fprintf(&b, "Rotation: %d overdue, %d due soon. Second factor: %d%% of active users.\n",
+		p.Rotation.Overdue, p.Rotation.DueSoon, p.Identity.SecondFactorPercent)
+	fmt.Fprintf(&b, "Classification: %d of %d secrets unclassified. Anomalies: %d open (%d high).\n",
+		p.Classification.Unclassified, p.Classification.TotalSecrets, p.Anomalies.Unacknowledged, p.Anomalies.HighSeverityOpen)
+	fmt.Fprintf(&b, "Risk register: %d active exception(s) (%d expiring soon).",
+		p.Risk.ActiveExceptions, p.Risk.ExpiringSoon)
+	if p.LegalHold.Active {
+		b.WriteString("\nA legal hold is ACTIVE — purges are blocked.")
+	}
+	return title, b.String()
+}
+
+func plural(n int) string {
+	if n == 1 {
+		return ""
+	}
+	return "s"
+}
+
+// SendComplianceDigest builds the digest and broadcasts it to the configured
+// notification channels (Slack/Teams/webhook). It is a single broadcast (no
+// per-user fan-out), so a chat channel gets one message. Returns whether a digest
+// was delivered (false when no notification channel is wired). Audited.
+func (c *KeyorixCore) SendComplianceDigest(ctx context.Context) (bool, error) {
+	if c.notificationSink == nil {
+		return false, nil // nowhere to deliver — no channel configured
+	}
+	title, body, err := c.BuildComplianceDigest(ctx)
+	if err != nil {
+		return false, err
+	}
+	c.notificationSink.Deliver(NotificationEvent{
+		Type:    "compliance.digest",
+		Title:   title,
+		Message: body,
+		Link:    "/compliance",
+	})
+	sysCtx := WithActorType(ctx, ActorTypeSystem)
+	c.writeAuditEvent(sysCtx, EventComplianceDigestSent, nil, nil, "compliance digest broadcast to notification channels")
+	return true, nil
+}

--- a/internal/core/compliance_digest_test.go
+++ b/internal/core/compliance_digest_test.go
@@ -1,0 +1,66 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFormatComplianceDigest(t *testing.T) {
+	p := &CompliancePosture{
+		AccessGovernance: AccessGovernancePosture{ProjectsOverdue: 2, SoDViolations: 1, DormantRoleGrants: 3},
+		Rotation:         RotationPosture{Overdue: 1, DueSoon: 2},
+		Identity:         IdentityPosture{SecondFactorPercent: 80},
+		Classification:   ClassificationPosture{TotalSecrets: 10, Unclassified: 4},
+		Anomalies:        AnomaliesPosture{Unacknowledged: 3, HighSeverityOpen: 1},
+		Risk:             RiskPosture{ActiveExceptions: 2, ExpiringSoon: 1},
+		LegalHold:        LegalHoldPosture{Active: true, Reason: "INC-7"},
+	}
+	controls := []ControlState{
+		{Name: "Tamper-evident audit trail", Status: ControlStatusPass},
+		{Name: "Access recertification", Status: ControlStatusGap},
+		{Name: "Secret rotation", Status: ControlStatusGap},
+	}
+	title, body := formatComplianceDigest(p, controls)
+	assert.Contains(t, title, "2 gaps across 3 controls")
+	assert.Contains(t, body, "1 pass, 2 gap")
+	assert.Contains(t, body, "Access recertification, Secret rotation")
+	assert.Contains(t, body, "2 project(s) overdue")
+	assert.Contains(t, body, "4 of 10 secrets unclassified")
+	assert.Contains(t, body, "2 active exception(s)")
+	assert.Contains(t, body, "legal hold is ACTIVE")
+}
+
+func TestFormatComplianceDigest_AllPass(t *testing.T) {
+	p := &CompliancePosture{Identity: IdentityPosture{SecondFactorPercent: 100}}
+	controls := []ControlState{{Name: "X", Status: ControlStatusPass}, {Name: "Y", Status: ControlStatusPass}}
+	title, _ := formatComplianceDigest(p, controls)
+	assert.Contains(t, title, "2/2 controls pass")
+}
+
+func TestSendComplianceDigest_NoSinkNoOp(t *testing.T) {
+	c := &KeyorixCore{storage: new(MockStorage), now: time.Now}
+	sent, err := c.SendComplianceDigest(context.Background())
+	require.NoError(t, err)
+	assert.False(t, sent, "no notification channel → nothing delivered")
+}
+
+func TestSendComplianceDigest_Broadcasts(t *testing.T) {
+	c, db, _ := newEvidenceExportCore(t) // real store, empty deployment
+	sink := &fakeSink{}
+	c.SetNotificationSink(sink)
+	sent, err := c.SendComplianceDigest(context.Background())
+	require.NoError(t, err)
+	assert.True(t, sent)
+	require.Len(t, sink.events, 1)
+	assert.Equal(t, "compliance.digest", sink.events[0].Type)
+	assert.Contains(t, sink.events[0].Title, "compliance digest")
+
+	var n int64
+	require.NoError(t, db.Model(&models.AuditEvent{}).Where("event_type = ?", "compliance.digest_sent").Count(&n).Error)
+	assert.Equal(t, int64(1), n)
+}

--- a/server/main.go
+++ b/server/main.go
@@ -149,6 +149,7 @@ const (
 	schedLockRetention    int64 = 0x4B455953_52455445 // "KEYSRETE"
 	schedLockEvidence     int64 = 0x4B455953_45564944 // "KEYSEVID"
 	schedLockRecertify    int64 = 0x4B455953_52454354 // "KEYSRECT"
+	schedLockDigest       int64 = 0x4B455953_44494753 // "KEYSDIGS"
 )
 
 // initializeEncryption sources the KEK per the configured key provider (ADR-038)
@@ -629,6 +630,43 @@ func startHTTPServer(ctx context.Context, cfg *config.Config) error {
 				select {
 				case <-ticker.C:
 					runReminders()
+				case <-ctx.Done():
+					return
+				}
+			}
+		}()
+	}
+
+	// Start the compliance-digest scheduler — opt-in. Periodically broadcasts a
+	// posture + control-matrix summary to the configured notification channels
+	// (Slack/Teams/webhook). Single-replica-gated (ADR-039) so the channel gets one
+	// digest per tick. A no-op (logged) when no notification channel is configured.
+	if cfg.ComplianceDigest.Enabled {
+		interval := cfg.ComplianceDigest.GetInterval()
+		log.Printf("Compliance-digest scheduler enabled: every %s", interval)
+		go func() {
+			ticker := time.NewTicker(interval)
+			defer ticker.Stop()
+			runDigest := func() {
+				if _, err := coreService.Storage().WithSchedulerLock(ctx, schedLockDigest, func() error {
+					sent, derr := coreService.SendComplianceDigest(ctx)
+					if derr != nil {
+						log.Printf("Compliance-digest error: %v", derr)
+						return derr
+					}
+					if !sent {
+						log.Printf("Compliance digest: no notification channel configured; nothing sent")
+					}
+					return nil
+				}); err != nil {
+					log.Printf("Compliance-digest scheduler error: %v", err)
+				}
+			}
+			runDigest() // run once on startup
+			for {
+				select {
+				case <-ticker.C:
+					runDigest()
 				case <-ctx.Done():
 					return
 				}


### PR DESCRIPTION
## What

Ties the **control matrix** to the **notification fan-out**: an opt-in scheduler that periodically **broadcasts a posture + control-matrix summary** to the configured channels (Slack/Teams/webhook), so admins see the deployment's compliance state where they work — continuous monitoring without opening the console.

Batch 2 part b (completes the Slack/Teams + digests batch).

## How

- **core** (`compliance_digest.go`) — `formatComplianceDigest` (pure) summarises controls pass/gap (+ the open gaps), recert-overdue/SoD/dormant access, rotation + second-factor, classification, anomalies, active risk exceptions, and an active legal hold. `SendComplianceDigest` broadcasts **one** `NotificationEvent` to the sink (one chat message, no per-user fan-out); no-op when no channel is wired; audited `compliance.digest_sent`.
- **config** — `compliance_digest {enabled, schedule}`.
- **scheduler** (`main.go`) — opt-in, single-replica-gated (ADR-039, new lock id); runs once on startup then on the interval.
- **docs** — `CONFIGURATION.md` `compliance_digest` section.

## Tests

- Digest formatting (gaps listed, figures, legal-hold note; all-pass title) and `SendComplianceDigest` (broadcasts + audits on a real store; no-op without a sink).

Backend-only (no web). Builds on the Slack/Teams channel (#204) and the control matrix (#198).

🤖 Generated with [Claude Code](https://claude.com/claude-code)