### PR TITLE
feat(compliance): signed, verifiable evidence packs (ISO 27001 / SOC 2)

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -12,6 +12,13 @@ useDefault = true
 
 [allowlist]
 description = "Demo / docs / scripts / test fixtures — non-real sample credentials"
+# HKDF domain-separation labels (constant info strings used to derive purpose-bound
+# keys from the DEK) — public, not secrets, but the generic-api-key heuristic flags
+# the `…KeyInfo = "…"` shape.
+regexes = [
+  '''keyorix-audit-checkpoint-v1''',
+  '''keyorix-evidence-signature-v1''',
+]
 paths = [
   '''demo/.*''',
   '''.*\.md''',

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -468,6 +468,14 @@ evidence_delivery:
 > in the audit note but does not fail the export when a file was also written. The
 > webhook token is read from `KEYORIX_EVIDENCE_WEBHOOK_TOKEN` when set.
 
+When **encryption is enabled**, each exported pack is **signed**: a detached
+`<file>.json.sig` is written next to it (and the webhook delivery carries the
+signature in the `X-Keyorix-Evidence-Signature` header). The signature is an HMAC
+keyed by a DEK-derived key the database/DBA does not hold, so an archived pack's
+authenticity is provable later — verify with `keyorix compliance verify --file
+<pack>` (it asks the server, which recomputes the HMAC; a signature made under a
+pre-rotation DEK is reported as unverifiable rather than tampered).
+
 ## rotation_reminders
 
 An opt-in background scheduler that notifies project admins (in-app) of secrets

--- a/internal/cli/compliance/compliance.go
+++ b/internal/cli/compliance/compliance.go
@@ -6,9 +6,11 @@ package compliance
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/keyorixhq/keyorix/internal/cli/common"
 	"github.com/spf13/cobra"
@@ -274,7 +276,64 @@ var controlsCmd = &cobra.Command{
 	},
 }
 
+var (
+	verifyFile string
+	verifySig  string
+)
+
+var verifyCmd = &cobra.Command{
+	Use:   "verify",
+	Short: "Verify an exported evidence pack against its detached signature",
+	Long: `Verify the authenticity of an archived evidence pack. Reads the pack file and
+its signature (default <file>.sig) and asks the server to recompute the HMAC with its
+DEK-derived signing key — proving the pack was produced by this deployment and has
+not been modified. Requires server-side encryption (the signing key is DEK-derived).`,
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		if verifyFile == "" {
+			return fmt.Errorf("--file is required")
+		}
+		sigPath := verifySig
+		if sigPath == "" {
+			sigPath = verifyFile + ".sig"
+		}
+		data, err := os.ReadFile(verifyFile) // #nosec G304 -- operator-supplied path
+		if err != nil {
+			return fmt.Errorf("failed to read %s: %w", verifyFile, err)
+		}
+		sig, err := os.ReadFile(sigPath) // #nosec G304 -- operator-supplied path
+		if err != nil {
+			return fmt.Errorf("failed to read signature %s: %w", sigPath, err)
+		}
+		c, ok := common.NewRemoteClient()
+		if !ok {
+			return fmt.Errorf("not connected to a server — run: keyorix connect <server>")
+		}
+		body := map[string]string{
+			"data_b64":  base64.StdEncoding.EncodeToString(data),
+			"signature": strings.TrimSpace(string(sig)),
+		}
+		var res struct {
+			Valid          bool   `json:"valid"`
+			KeyVersion     string `json:"key_version"`
+			CurrentVersion string `json:"current_version"`
+			Reason         string `json:"reason"`
+		}
+		if err := c.Post(context.Background(), "/api/v1/compliance/evidence/verify", body, &res); err != nil {
+			return err
+		}
+		if res.Valid {
+			fmt.Printf("VALID — %s is authentic and unmodified (key version %s).\n", verifyFile, res.KeyVersion)
+			return nil
+		}
+		fmt.Printf("NOT VERIFIED — %s\n", res.Reason)
+		return fmt.Errorf("evidence pack failed verification")
+	},
+}
+
 func init() {
 	exportCmd.Flags().StringVar(&exportOutput, "output", "", "Write the evidence pack to a file instead of stdout")
-	ComplianceCmd.AddCommand(reportCmd, controlsCmd, exportCmd)
+	verifyCmd.Flags().StringVar(&verifyFile, "file", "", "Path to the evidence pack JSON to verify (required)")
+	verifyCmd.Flags().StringVar(&verifySig, "sig", "", "Path to the signature file (default <file>.sig)")
+	ComplianceCmd.AddCommand(reportCmd, controlsCmd, exportCmd, verifyCmd)
 }

--- a/internal/core/evidence_export.go
+++ b/internal/core/evidence_export.go
@@ -25,7 +25,7 @@ const evidenceFileTimeLayout = "20060102T150405Z"
 // synchronous implementation is fine. Defined here (not in the sink package) so core
 // has no dependency on the forwarder implementation.
 type EvidenceForwarder interface {
-	ForwardEvidence(ctx context.Context, data []byte) error
+	ForwardEvidence(ctx context.Context, data []byte, signature string) error
 }
 
 // SetEvidenceForwarder wires an off-box evidence target. The server calls this at
@@ -39,6 +39,7 @@ type EvidenceExportResult struct {
 	Path    string   `json:"path,omitempty"` // local file written, if a directory was configured
 	Bytes   int      `json:"bytes"`
 	Targets []string `json:"targets"` // where the pack was delivered (e.g. "file:/path", "webhook")
+	Signed  bool     `json:"signed"`  // whether a detached HMAC signature was produced
 }
 
 // ExportComplianceEvidence generates the evidence pack and delivers it to every
@@ -63,7 +64,11 @@ func (c *KeyorixCore) ExportComplianceEvidence(ctx context.Context, outputDir st
 		return nil, fmt.Errorf("evidence export: marshal: %w", err)
 	}
 
-	res := &EvidenceExportResult{Bytes: len(data)}
+	// Sign the exact bytes we deliver (when encryption is enabled) so an archived
+	// pack's authenticity is provable later. signature is "" when unavailable.
+	signature, signed := c.signEvidence(data)
+
+	res := &EvidenceExportResult{Bytes: len(data), Signed: signed}
 
 	if outputDir != "" {
 		if err := os.MkdirAll(outputDir, 0o700); err != nil {
@@ -75,11 +80,16 @@ func (c *KeyorixCore) ExportComplianceEvidence(ctx context.Context, outputDir st
 		}
 		res.Path = filepath.Join(outputDir, name)
 		res.Targets = append(res.Targets, "file:"+res.Path)
+		// Write the detached signature alongside the pack (verify with `keyorix
+		// compliance verify`). Best-effort: a sig-write failure must not lose the pack.
+		if signed {
+			_ = securefiles.SecureWriteFile(outputDir, name+".sig", []byte(signature), 0o600)
+		}
 	}
 
 	forwardNote := ""
 	if c.evidenceForwarder != nil {
-		if err := c.evidenceForwarder.ForwardEvidence(ctx, data); err != nil {
+		if err := c.evidenceForwarder.ForwardEvidence(ctx, data, signature); err != nil {
 			// Best-effort secondary target: record the failure but don't drop the
 			// export when a durable file was also written.
 			forwardNote = fmt.Sprintf("; webhook delivery FAILED: %v", err)
@@ -93,8 +103,8 @@ func (c *KeyorixCore) ExportComplianceEvidence(ctx context.Context, outputDir st
 
 	sysCtx := WithActorType(ctx, ActorTypeSystem)
 	c.writeAuditEvent(sysCtx, "compliance.evidence_exported", nil, nil,
-		fmt.Sprintf("compliance evidence pack exported to %v (%d bytes; %d campaigns, %d break-glass activations, %d overdue rotations, %d SoD violations)%s",
-			res.Targets, len(data), len(ev.Campaigns), len(ev.BreakGlass), len(ev.RotationOverdue), len(ev.SoDViolations), forwardNote))
+		fmt.Sprintf("compliance evidence pack exported to %v (%d bytes, signed=%t; %d campaigns, %d break-glass activations, %d overdue rotations, %d SoD violations)%s",
+			res.Targets, len(data), signed, len(ev.Campaigns), len(ev.BreakGlass), len(ev.RotationOverdue), len(ev.SoDViolations), forwardNote))
 
 	return res, nil
 }

--- a/internal/core/evidence_export_test.go
+++ b/internal/core/evidence_export_test.go
@@ -64,6 +64,29 @@ func TestExportComplianceEvidence_WritesFileAndAudits(t *testing.T) {
 	assert.Equal(t, int64(1), n)
 }
 
+func TestExportComplianceEvidence_SignsAndVerifies(t *testing.T) {
+	c, _, _ := newEvidenceExportCore(t)
+	c.SetEvidenceSignKey([]byte("0123456789abcdef0123456789abcdef"), "v1")
+	dir := t.TempDir()
+
+	res, err := c.ExportComplianceEvidence(context.Background(), dir)
+	require.NoError(t, err)
+	assert.True(t, res.Signed, "a sign key is set, so the pack is signed")
+
+	sig, err := os.ReadFile(res.Path + ".sig")
+	require.NoError(t, err, "a detached .sig file is written next to the pack")
+	data, err := os.ReadFile(res.Path)
+	require.NoError(t, err)
+
+	vr := c.VerifyEvidenceSignature(data, strings.TrimSpace(string(sig)))
+	assert.True(t, vr.Valid, "the exported pack verifies against its signature")
+
+	// A byte flipped in the archived pack fails verification.
+	tampered := append([]byte{}, data...)
+	tampered[0] = '!'
+	assert.False(t, c.VerifyEvidenceSignature(tampered, strings.TrimSpace(string(sig))).Valid)
+}
+
 func TestExportComplianceEvidence_EmptyOutputDirErrors(t *testing.T) {
 	c, _, _ := newEvidenceExportCore(t)
 	_, err := c.ExportComplianceEvidence(context.Background(), "")
@@ -74,12 +97,14 @@ func TestExportComplianceEvidence_EmptyOutputDirErrors(t *testing.T) {
 type fakeEvidenceForwarder struct {
 	calls int
 	data  []byte
+	sig   string
 	err   error
 }
 
-func (f *fakeEvidenceForwarder) ForwardEvidence(_ context.Context, data []byte) error {
+func (f *fakeEvidenceForwarder) ForwardEvidence(_ context.Context, data []byte, signature string) error {
 	f.calls++
 	f.data = data
+	f.sig = signature
 	return f.err
 }
 

--- a/internal/core/evidence_signing.go
+++ b/internal/core/evidence_signing.go
@@ -1,0 +1,88 @@
+// evidence_signing.go — authenticity signatures for exported compliance-evidence
+// packs (ISO 27001 / SOC 2). The scheduled export HMAC-signs the exact bytes it
+// writes with a DEK-derived key the database/DBA does not hold (see
+// encryption.Service.EvidenceSignKey), so an archived pack's integrity is provable
+// on the server off-box. A signature is "<keyVersion>:<hmac-hex>"; a signature made
+// under a DEK version superseded by a rotation is reported as unverifiable rather
+// than a generic mismatch (mirrors the audit-checkpoint key-version handling).
+package core
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+)
+
+// SetEvidenceSignKey wires the DEK-derived HMAC key (and its DEK key version) used to
+// sign and verify evidence packs. Called at startup when encryption is enabled; with
+// no key set, packs are exported unsigned and verification is unavailable.
+func (c *KeyorixCore) SetEvidenceSignKey(key []byte, keyVersion string) {
+	c.evidenceSignKey = key
+	c.evidenceSignKeyVersion = keyVersion
+}
+
+// EvidenceSigningAvailable reports whether a signing key is configured (encryption on).
+func (c *KeyorixCore) EvidenceSigningAvailable() bool {
+	return len(c.evidenceSignKey) > 0
+}
+
+// signEvidence returns "<keyVersion>:<hmac-hex>" over data, or ("", false) when
+// signing is unavailable.
+func (c *KeyorixCore) signEvidence(data []byte) (string, bool) {
+	if !c.EvidenceSigningAvailable() {
+		return "", false
+	}
+	mac := hmac.New(sha256.New, c.evidenceSignKey)
+	mac.Write(data)
+	return c.evidenceSignKeyVersion + ":" + hex.EncodeToString(mac.Sum(nil)), true
+}
+
+// EvidenceVerifyResult reports the outcome of verifying a pack's signature.
+type EvidenceVerifyResult struct {
+	Valid          bool   `json:"valid"`
+	KeyVersion     string `json:"key_version,omitempty"`     // DEK version the signature was made under
+	CurrentVersion string `json:"current_version,omitempty"` // current signing-key (DEK) version
+	Reason         string `json:"reason,omitempty"`
+}
+
+// VerifyEvidenceSignature recomputes the HMAC over data and compares it to signature
+// in constant time. A signature made under a superseded DEK version is reported
+// unverifiable (not just invalid), so a post-rotation false alarm is distinguishable
+// from real tampering.
+func (c *KeyorixCore) VerifyEvidenceSignature(data []byte, signature string) *EvidenceVerifyResult {
+	if !c.EvidenceSigningAvailable() {
+		return &EvidenceVerifyResult{Reason: "evidence signing is unavailable (encryption disabled)"}
+	}
+	version, sigHex, ok := splitEvidenceSignature(signature)
+	if !ok {
+		return &EvidenceVerifyResult{Reason: "malformed signature"}
+	}
+	res := &EvidenceVerifyResult{KeyVersion: version, CurrentVersion: c.evidenceSignKeyVersion}
+	if version != c.evidenceSignKeyVersion {
+		res.Reason = "signature was made under a superseded key version (the DEK has rotated since); cannot verify"
+		return res
+	}
+	want, err := hex.DecodeString(sigHex)
+	if err != nil {
+		res.Reason = "malformed signature"
+		return res
+	}
+	mac := hmac.New(sha256.New, c.evidenceSignKey)
+	mac.Write(data)
+	if hmac.Equal(mac.Sum(nil), want) {
+		res.Valid = true
+		return res
+	}
+	res.Reason = "signature does not match — the pack was modified or signed by a different deployment"
+	return res
+}
+
+// splitEvidenceSignature parses "<version>:<hex>" on the first colon.
+func splitEvidenceSignature(s string) (version, hexSig string, ok bool) {
+	i := strings.IndexByte(s, ':')
+	if i <= 0 || i == len(s)-1 {
+		return "", "", false
+	}
+	return s[:i], s[i+1:], true
+}

--- a/internal/core/evidence_signing_test.go
+++ b/internal/core/evidence_signing_test.go
@@ -1,0 +1,48 @@
+package core
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEvidenceSignature_RoundTrip(t *testing.T) {
+	c := &KeyorixCore{}
+	c.SetEvidenceSignKey([]byte("0123456789abcdef0123456789abcdef"), "v1")
+	data := []byte(`{"generated_at":"2026-06-15T00:00:00Z"}`)
+
+	sig, ok := c.signEvidence(data)
+	require.True(t, ok)
+	require.True(t, strings.HasPrefix(sig, "v1:"))
+
+	res := c.VerifyEvidenceSignature(data, sig)
+	assert.True(t, res.Valid)
+
+	// Tampered data → invalid (not authentic).
+	res = c.VerifyEvidenceSignature([]byte(`{"generated_at":"changed"}`), sig)
+	assert.False(t, res.Valid)
+	assert.Contains(t, res.Reason, "does not match")
+
+	// Signature from a superseded key version → reported distinctly, not a mismatch.
+	superseded := "v0:" + strings.SplitN(sig, ":", 2)[1]
+	res = c.VerifyEvidenceSignature(data, superseded)
+	assert.False(t, res.Valid)
+	assert.Contains(t, res.Reason, "superseded")
+	assert.Equal(t, "v0", res.KeyVersion)
+	assert.Equal(t, "v1", res.CurrentVersion)
+
+	// Malformed signature.
+	assert.False(t, c.VerifyEvidenceSignature(data, "garbage").Valid)
+}
+
+func TestEvidenceSignature_UnavailableWithoutKey(t *testing.T) {
+	c := &KeyorixCore{}
+	assert.False(t, c.EvidenceSigningAvailable())
+	_, ok := c.signEvidence([]byte("x"))
+	assert.False(t, ok)
+	res := c.VerifyEvidenceSignature([]byte("x"), "v1:ab")
+	assert.False(t, res.Valid)
+	assert.Contains(t, res.Reason, "unavailable")
+}

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -100,6 +100,11 @@ type KeyorixCore struct {
 	// enforced after a DEK rotation.
 	auditCkptKey        []byte
 	auditCkptKeyVersion string
+	// evidenceSignKey / evidenceSignKeyVersion sign and verify exported compliance-
+	// evidence packs (HMAC, DEK-derived, domain-separated from the checkpoint key).
+	// nil = signing unavailable (encryption disabled). Set via SetEvidenceSignKey.
+	evidenceSignKey        []byte
+	evidenceSignKeyVersion string
 }
 
 // AuditForwarder ships persisted audit events to an external sink (e.g. a SIEM).

--- a/internal/encryption/service.go
+++ b/internal/encryption/service.go
@@ -163,6 +163,35 @@ func (s *Service) AuditCheckpointKey() (key []byte, keyVersion string, ok bool) 
 	return out, s.keyManager.GetKeyVersion(), true
 }
 
+// evidenceSignKeyInfo domain-separates the evidence-signing key from the DEK's
+// other uses (HKDF info parameter).
+const evidenceSignKeyInfo = "keyorix-evidence-signature-v1"
+
+// EvidenceSignKey derives a 32-byte HMAC key for signing exported compliance-
+// evidence packs from the current DEK via HKDF-SHA256, alongside the current key
+// version. Like AuditCheckpointKey it is DEK-bound but domain-separated and held
+// only in application memory — so an archived evidence pack's authenticity is
+// provable on the server without the key ever touching the database or the export.
+// Returns ok=false when encryption is disabled or uninitialised.
+func (s *Service) EvidenceSignKey() (key []byte, keyVersion string, ok bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if !s.config.Enabled || !s.initialized {
+		return nil, "", false
+	}
+	dek := s.keyManager.GetDEK()
+	defer wipeBytes(dek)
+	if len(dek) == 0 {
+		return nil, "", false
+	}
+	r := hkdf.New(sha256.New, dek, nil, []byte(evidenceSignKeyInfo))
+	out := make([]byte, 32)
+	if _, err := io.ReadFull(r, out); err != nil {
+		return nil, "", false
+	}
+	return out, s.keyManager.GetKeyVersion(), true
+}
+
 // EncryptSecret encrypts plaintext and returns (encryptedBytes, metadataBytes, error).
 func (s *Service) EncryptSecret(plaintext []byte) ([]byte, []byte, error) {
 	s.mu.RLock()

--- a/internal/evidencesink/webhook.go
+++ b/internal/evidencesink/webhook.go
@@ -42,13 +42,18 @@ func NewWebhook(cfg WebhookConfig) (*Webhook, error) {
 	return &Webhook{cfg: cfg, client: &http.Client{Timeout: webhookTimeout, Transport: transport}}, nil
 }
 
-// ForwardEvidence POSTs the marshalled evidence pack as application/json.
-func (w *Webhook) ForwardEvidence(ctx context.Context, data []byte) error {
+// ForwardEvidence POSTs the marshalled evidence pack as application/json. When the
+// pack is signed, the detached HMAC signature is sent in the X-Keyorix-Evidence-
+// Signature header so the receiver can record it for later verification.
+func (w *Webhook) ForwardEvidence(ctx context.Context, data []byte, signature string) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, w.cfg.Endpoint, bytes.NewReader(data))
 	if err != nil {
 		return err
 	}
 	req.Header.Set("Content-Type", "application/json")
+	if signature != "" {
+		req.Header.Set("X-Keyorix-Evidence-Signature", signature)
+	}
 	if w.cfg.Token != "" {
 		req.Header.Set("Authorization", "Bearer "+w.cfg.Token)
 	}

--- a/internal/evidencesink/webhook_test.go
+++ b/internal/evidencesink/webhook_test.go
@@ -30,7 +30,7 @@ func TestWebhook_PostsEvidenceWithAuth(t *testing.T) {
 
 	wh, err := NewWebhook(WebhookConfig{Endpoint: srv.URL, Token: "ev-tok"})
 	require.NoError(t, err)
-	require.NoError(t, wh.ForwardEvidence(context.Background(), []byte(`{"generated_at":"x"}`)))
+	require.NoError(t, wh.ForwardEvidence(context.Background(), []byte(`{"generated_at":"x"}`), "v1:abc"))
 
 	mu.Lock()
 	defer mu.Unlock()
@@ -46,7 +46,7 @@ func TestWebhook_ErrorsOnNon2xx(t *testing.T) {
 	defer srv.Close()
 	wh, err := NewWebhook(WebhookConfig{Endpoint: srv.URL})
 	require.NoError(t, err)
-	require.Error(t, wh.ForwardEvidence(context.Background(), []byte(`{}`)))
+	require.Error(t, wh.ForwardEvidence(context.Background(), []byte(`{}`), ""))
 }
 
 func TestNewWebhook_RequiresEndpoint(t *testing.T) {

--- a/server/http/handlers/dashboard.go
+++ b/server/http/handlers/dashboard.go
@@ -1,6 +1,8 @@
 package handlers
 
 import (
+	"encoding/base64"
+	"encoding/json"
 	"net/http"
 	"strconv"
 
@@ -44,6 +46,27 @@ func (h *DashboardHandler) GetCompliancePosture(w http.ResponseWriter, r *http.R
 		return
 	}
 	sendSuccess(w, posture, "")
+}
+
+// VerifyComplianceEvidence handles POST /api/v1/compliance/evidence/verify — checks
+// a previously-exported evidence pack against its detached signature. The pack bytes
+// are base64-encoded in the request so arbitrary JSON can ride in a JSON envelope.
+func (h *DashboardHandler) VerifyComplianceEvidence(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		DataB64   string `json:"data_b64"`
+		Signature string `json:"signature"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		sendError(w, "InvalidJSON", "Invalid request body", http.StatusBadRequest, nil)
+		return
+	}
+	data, err := base64.StdEncoding.DecodeString(body.DataB64)
+	if err != nil {
+		sendError(w, "InvalidParameter", "data_b64 must be base64-encoded", http.StatusBadRequest, nil)
+		return
+	}
+	result := h.coreService.VerifyEvidenceSignature(data, body.Signature)
+	sendSuccess(w, result, "")
 }
 
 // GetComplianceControls handles GET /api/v1/compliance/controls — the control

--- a/server/http/handlers/openapi.yaml
+++ b/server/http/handlers/openapi.yaml
@@ -2877,6 +2877,36 @@ paths:
             break_glass[], rotation_overdue[], sod_violations[]}.
         '401': {$ref: '#/components/responses/Error'}
         '403': {$ref: '#/components/responses/Error'}
+  /api/v1/compliance/evidence/verify:
+    post:
+      tags: [Dashboard]
+      summary: Verify an exported evidence pack against its signature
+      description: >-
+        Recomputes the HMAC over the supplied evidence-pack bytes with the server's
+        DEK-derived signing key and compares it to the detached signature — proving an
+        archived pack was produced by this deployment and is unmodified. The pack is
+        base64-encoded in data_b64 so arbitrary JSON can ride in the envelope. A
+        signature made under a superseded DEK version (post key-rotation) is reported
+        as unverifiable, distinct from a tamper mismatch. Requires system.read.
+      operationId: verifyComplianceEvidence
+      security: [{bearerAuth: []}]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [data_b64, signature]
+              properties:
+                data_b64:  {type: string, description: "Base64 of the evidence-pack bytes."}
+                signature: {type: string, description: "The detached signature ('<keyVersion>:<hmac-hex>')."}
+      responses:
+        '200':
+          description: >-
+            Envelope {data}. data: {valid, key_version, current_version, reason}.
+        '400': {$ref: '#/components/responses/Error'}
+        '401': {$ref: '#/components/responses/Error'}
+        '403': {$ref: '#/components/responses/Error'}
   /api/v1/legal-hold:
     get:
       tags: [Dashboard]

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -495,6 +495,8 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		r.With(customMiddleware.RequirePermission("system.write")).Delete("/legal-hold", dashboardHandler.LiftLegalHold)
 		// Compliance evidence pack — posture + supporting records, for archival.
 		r.With(customMiddleware.RequirePermission("system.read")).Get("/compliance/evidence", dashboardHandler.GetComplianceEvidence)
+		// Verify a previously-exported evidence pack against its detached signature.
+		r.With(customMiddleware.RequirePermission("system.read")).Post("/compliance/evidence/verify", dashboardHandler.VerifyComplianceEvidence)
 		// Risk register (ISO A.5.8): list reads system.read; create/revoke system.write.
 		r.With(customMiddleware.RequirePermission("system.read")).Get("/risk-exceptions", dashboardHandler.ListRiskExceptions)
 		r.With(customMiddleware.RequirePermission("system.write")).Post("/risk-exceptions", dashboardHandler.CreateRiskException)

--- a/server/main.go
+++ b/server/main.go
@@ -212,6 +212,11 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 		if key, keyVer, ok := encSvc.AuditCheckpointKey(); ok {
 			coreService.SetAuditCheckpointKey(key, keyVer)
 		}
+		// Derive the evidence-pack signing key from the DEK so scheduled evidence
+		// exports are signed (and verifiable). Unavailable when encryption is off.
+		if key, keyVer, ok := encSvc.EvidenceSignKey(); ok {
+			coreService.SetEvidenceSignKey(key, keyVer)
+		}
 	}
 
 	// Apply a configured password policy, if any. An absent block leaves the


### PR DESCRIPTION
## What

A scheduled evidence pack could be archived off-box, but its **authenticity wasn't provable** — a modified pack was indistinguishable from a genuine one. This **signs** each exported pack with a DEK-derived HMAC key the database/DBA does not hold, and adds a **verify** path, so an auditor can prove an archived pack came from this deployment and is unmodified.

Batch 3 of the "1 2 3" program (final piece).

## How

- **encryption** — `EvidenceSignKey()`: a 32-byte HKDF-SHA256 key from the DEK, **domain-separated** from the audit-checkpoint key; unavailable when encryption is off (mirrors `AuditCheckpointKey`).
- **core** (`evidence_signing.go`) — `SetEvidenceSignKey`, `signEvidence` (HMAC → `"<keyVersion>:<hex>"`), `VerifyEvidenceSignature` (**constant-time**; a signature under a **superseded DEK version** is reported as *unverifiable*, not a generic mismatch). `ExportComplianceEvidence` now signs the exact bytes it delivers: writes a detached `<file>.json.sig` and reports `Signed`.
- **evidencesink** — `ForwardEvidence` gains the signature, sent in the `X-Keyorix-Evidence-Signature` header (interface + webhook + mock/tests updated).
- **API** — `POST /compliance/evidence/verify` (system.read) `{data_b64, signature}` → `{valid, key_version, current_version, reason}`.
- **CLI** — `keyorix compliance verify --file <pack> [--sig <file>]` reads the pack + its `.sig` and asks the server to verify.
- **docs** — `CONFIGURATION.md` evidence_delivery.

## Tests

- Sign/verify round-trip: valid / tampered / superseded-version / malformed / no-key.
- Export writes a `.sig` that verifies; a flipped byte fails. Webhook carries the signature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)