### PR TITLE
feat(sso): JIT auto-provisioning on SSO first-login (opt-in)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -637,8 +637,9 @@ Each provider's endpoints are **discovered** from its issuer
 redirect URL are needed. On callback Keyorix verifies the id_token (signature against
 the issuer's JWKS, issuer, audience = `client_id`, expiry, and the nonce it issued)
 and maps the identity to a Keyorix user — by the IdP subject (matched against the SCIM
-`externalId`) first, then by email. There is **no auto-provisioning**: the account
-must already exist (provision it via SCIM or invite). A suspended user is refused.
+`externalId`) first, then by email. By default there is **no auto-provisioning**: the
+account must already exist (provision it via SCIM or invite). A suspended user is
+refused.
 
 ```yaml
 sso:
@@ -650,12 +651,25 @@ sso:
       client_secret: ""          # prefer the KEYORIX_SSO_OKTA_CLIENT_SECRET env var
       redirect_url: https://keyorix.example.com/auth/sso/okta/callback
       scopes: [openid, profile, email]
+      auto_provision: false      # JIT-create an account on first login (default off)
+      default_role: system_viewer # baseline role for JIT-provisioned users
 ```
 
 > The client secret is read from `KEYORIX_SSO_<NAME>_CLIENT_SECRET` (name upper-cased,
 > e.g. `KEYORIX_SSO_OKTA_CLIENT_SECRET`). Register the `redirect_url` exactly as above
 > at the IdP. A provider whose discovery fails at startup is skipped with a warning,
 > not fatal.
+
+**Just-in-time (JIT) provisioning.** Set `auto_provision: true` on a provider to
+JIT-create a Keyorix account the first time an identity that matches no existing user
+signs in — useful when an IdP isn't wired for SCIM push. The account is created
+**active** and passwordless (the IdP is the authenticator), with the IdP subject
+stored as its `externalId` for future reconciliation, and is granted `default_role`
+(`system_viewer` when unset; an unknown role grants nothing — least-privilege on
+misconfiguration). The JIT creation is audited as `auth.sso_jit_provisioned`. The IdP
+must return an `email` claim (request the `email` scope), or the login is refused. A
+later SCIM push for the same `externalId` reconciles to the same account. Leave
+`auto_provision` off to require that accounts be provisioned ahead of time.
 
 ## membership
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -671,6 +671,12 @@ must return an `email` claim (request the `email` scope), or the login is refuse
 later SCIM push for the same `externalId` reconciles to the same account. Leave
 `auto_provision` off to require that accounts be provisioned ahead of time.
 
+> **Email trust.** An email an IdP explicitly marks unverified (`email_verified:
+> false`) is not used to match an existing account or to provision a new one — only
+> the subject (`externalId`) match applies for that login. An absent `email_verified`
+> claim is treated as trusted (it is optional in OIDC; some enterprise IdPs such as
+> Entra ID omit it for a configured, trusted issuer).
+
 ## membership
 
 Project-membership onboarding mode (ADR-022).

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -706,6 +706,16 @@ type SSOProviderConfig struct {
 	ClientSecret string   `yaml:"client_secret"` // prefer KEYORIX_SSO_<NAME>_CLIENT_SECRET
 	RedirectURL  string   `yaml:"redirect_url"`  // must equal <public-host>/auth/sso/<name>/callback
 	Scopes       []string `yaml:"scopes"`        // default [openid, profile, email]
+
+	// AutoProvision JIT-creates a Keyorix account on a first SSO login whose verified
+	// identity matches no existing user — so an IdP that isn't wired for SCIM push can
+	// still onboard users on demand. Opt-in (default off): when false, an unknown
+	// identity is refused, exactly as before.
+	AutoProvision bool `yaml:"auto_provision"`
+	// DefaultRole is the install-wide baseline role granted to a JIT-provisioned user
+	// (default "system_viewer"). A misconfigured/unknown role grants nothing —
+	// least-privilege on misconfiguration.
+	DefaultRole string `yaml:"default_role"`
 }
 
 // GetClientSecret returns the resolved client secret, preferring the per-provider

--- a/internal/core/sso.go
+++ b/internal/core/sso.go
@@ -5,6 +5,11 @@
 // first, then email), and mints the SAME session a password login would — so an
 // IdP-provisioned (passwordless) user can actually sign in. SSO logins bypass
 // Keyorix-local MFA: the IdP is the trusted authenticator.
+//
+// When a provider has auto_provision enabled, a first login whose verified identity
+// matches no existing account JIT-creates one (active, passwordless, default_role
+// baseline) instead of being refused — so an IdP that isn't wired for SCIM push can
+// still onboard users on demand. Off by default: an unknown identity is refused.
 package core
 
 import (
@@ -24,10 +29,12 @@ import (
 )
 
 const (
-	ssoStateTTL       = 10 * time.Minute
-	EventSSOLogin     = "auth.sso_login"
-	ssoClockSkew      = 60 * time.Second
-	ssoCompleteSuffix = "/auth/sso/complete"
+	ssoStateTTL          = 10 * time.Minute
+	EventSSOLogin        = "auth.sso_login"
+	EventSSOJITProvision = "auth.sso_jit_provisioned"
+	ssoClockSkew         = 60 * time.Second
+	ssoCompleteSuffix    = "/auth/sso/complete"
+	ssoDefaultRole       = "system_viewer"
 )
 
 // SSOProvider is a resolved OIDC provider whose endpoints have been discovered.
@@ -37,6 +44,9 @@ type SSOProvider struct {
 	ClientID    string
 	OAuth       *oauth2.Config // ClientID/Secret + discovered Auth/Token endpoints + redirect
 	CompleteURL string         // <redirect origin>/auth/sso/complete — where the browser lands
+
+	AutoProvision bool   // JIT-create an account on first login for an unknown identity
+	DefaultRole   string // baseline role for JIT-provisioned users ("" → system_viewer)
 }
 
 // SetSSOProviders wires the configured providers (built from config + discovery at
@@ -122,7 +132,7 @@ func (c *KeyorixCore) CompleteSSO(ctx context.Context, providerName, code, state
 	if rawID == "" {
 		return nil, nil, "", fmt.Errorf("the token response carried no id_token")
 	}
-	sub, email, err := c.verifyIDToken(ctx, p, st.Nonce, rawID)
+	sub, email, name, err := c.verifyIDToken(ctx, p, st.Nonce, rawID)
 	if err != nil {
 		return nil, nil, "", err
 	}
@@ -130,6 +140,15 @@ func (c *KeyorixCore) CompleteSSO(ctx context.Context, providerName, code, state
 	user, err := c.resolveSSOUser(ctx, sub, email)
 	if err != nil {
 		return nil, nil, "", err
+	}
+	if user == nil {
+		// No Keyorix account matches this verified identity.
+		if !p.AutoProvision {
+			return nil, nil, "", fmt.Errorf("no Keyorix account matches this SSO identity")
+		}
+		if user, err = c.provisionSSOUser(ctx, p, sub, email, name); err != nil {
+			return nil, nil, "", err
+		}
 	}
 	if AccountLoginBlocked(user.AccountState) {
 		return nil, nil, "", fmt.Errorf("account suspended")
@@ -146,7 +165,8 @@ func (c *KeyorixCore) CompleteSSO(ctx context.Context, providerName, code, state
 }
 
 // resolveSSOUser maps the IdP identity to a Keyorix user: the SCIM externalId
-// (subject) first, then email. No auto-provisioning — the account must already exist.
+// (subject) first, then email. Returns (nil, nil) when neither matches — the caller
+// decides whether to refuse the login or JIT-provision the account.
 func (c *KeyorixCore) resolveSSOUser(ctx context.Context, sub, email string) (*models.User, error) {
 	notFound := i18n.T("ErrorUserNotFound", nil)
 	if sub != "" {
@@ -163,16 +183,68 @@ func (c *KeyorixCore) resolveSSOUser(ctx context.Context, sub, email string) (*m
 			return nil, err
 		}
 	}
-	return nil, fmt.Errorf("no Keyorix account matches this SSO identity")
+	return nil, nil
+}
+
+// provisionSSOUser JIT-creates a Keyorix account for a verified SSO identity that
+// matches no existing user (auto_provision must be enabled — the caller gates this).
+// The identity has already passed full id_token verification (signature, issuer,
+// audience, expiry, nonce), so the IdP subject is trusted as the externalId. The
+// account is created ACTIVE — the IdP has authenticated it and the user signs in via
+// SSO — with an unusable local password; it deliberately does NOT start in
+// pending_first_login (which would trap an SSO user in a password-change-only
+// restricted session they can never clear). The baseline role is the provider's
+// default_role (system_viewer when unset); an unknown role grants nothing.
+func (c *KeyorixCore) provisionSSOUser(ctx context.Context, p *SSOProvider, sub, email, name string) (*models.User, error) {
+	if strings.TrimSpace(email) == "" {
+		return nil, fmt.Errorf("the IdP returned no email; cannot auto-provision an account")
+	}
+	// Guard against a race / case where a user materialised between the resolve and
+	// here: reuse it rather than create a duplicate.
+	if existing, ferr := c.FindSCIMUser(ctx, sub, email); ferr == nil && existing != nil {
+		return existing, nil
+	}
+	username, err := c.deriveSCIMUsername(ctx, email)
+	if err != nil {
+		return nil, err
+	}
+	hash, err := randomPasswordHash()
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	displayName := strings.TrimSpace(name)
+	if displayName == "" {
+		displayName = email
+	}
+	now := c.now()
+	created, err := c.storage.CreateUser(ctx, &models.User{
+		Username: username, Email: email, DisplayName: displayName,
+		PasswordHash: hash, IsActive: true, AccountState: AccountActive, ExternalID: sub,
+		PasswordChangedAt: &now, CreatedAt: now, UpdatedAt: now,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	role := strings.TrimSpace(p.DefaultRole)
+	if role == "" {
+		role = ssoDefaultRole
+	}
+	if r, rerr := c.storage.GetRoleByName(ctx, role); rerr == nil {
+		_ = c.storage.AssignRole(ctx, created.ID, r.ID, Scope{})
+	}
+	c.writeAuditEvent(ctx, EventSSOJITProvision, actorPtr(created.ID), nil,
+		fmt.Sprintf("SSO JIT-provisioned user %d via %s (externalId=%q, role=%s)", created.ID, p.Name, sub, role))
+	return created, nil
 }
 
 // verifyIDToken validates the id_token's signature (asymmetric only), issuer,
 // audience (= the provider's client_id), expiry, and the nonce, returning the
-// subject and email claims.
-func (c *KeyorixCore) verifyIDToken(ctx context.Context, p *SSOProvider, expectedNonce, raw string) (sub, email string, err error) {
+// subject, email, and (best-effort) name claims.
+func (c *KeyorixCore) verifyIDToken(ctx context.Context, p *SSOProvider, expectedNonce, raw string) (sub, email, name string, err error) {
 	var claims struct {
 		jwt.RegisteredClaims
 		Email string `json:"email"`
+		Name  string `json:"name"`
 		Nonce string `json:"nonce"`
 	}
 	parser := jwt.NewParser(
@@ -190,10 +262,10 @@ func (c *KeyorixCore) verifyIDToken(ctx context.Context, p *SSOProvider, expecte
 	}
 	token, err := parser.ParseWithClaims(raw, &claims, keyfn)
 	if err != nil {
-		return "", "", fmt.Errorf("id_token verification failed: %w", err)
+		return "", "", "", fmt.Errorf("id_token verification failed: %w", err)
 	}
 	if !token.Valid || claims.Issuer != p.Issuer {
-		return "", "", fmt.Errorf("id_token invalid")
+		return "", "", "", fmt.Errorf("id_token invalid")
 	}
 	audOK := false
 	for _, a := range claims.Audience {
@@ -203,15 +275,15 @@ func (c *KeyorixCore) verifyIDToken(ctx context.Context, p *SSOProvider, expecte
 		}
 	}
 	if !audOK {
-		return "", "", fmt.Errorf("id_token audience does not match the client id")
+		return "", "", "", fmt.Errorf("id_token audience does not match the client id")
 	}
 	if expectedNonce == "" || claims.Nonce != expectedNonce {
-		return "", "", fmt.Errorf("id_token nonce mismatch")
+		return "", "", "", fmt.Errorf("id_token nonce mismatch")
 	}
 	if strings.TrimSpace(claims.Subject) == "" {
-		return "", "", fmt.Errorf("id_token has no subject")
+		return "", "", "", fmt.Errorf("id_token has no subject")
 	}
-	return claims.Subject, claims.Email, nil
+	return claims.Subject, claims.Email, claims.Name, nil
 }
 
 func randToken() (string, error) {

--- a/internal/core/sso.go
+++ b/internal/core/sso.go
@@ -237,15 +237,31 @@ func (c *KeyorixCore) provisionSSOUser(ctx context.Context, p *SSOProvider, sub,
 	return created, nil
 }
 
+// ssoBool unmarshals a JSON boolean OR the strings "true"/"false" — some IdPs send
+// email_verified as a string rather than a bool, and a strict bool field would fail
+// the whole token parse. A pointer to it distinguishes "absent" (nil) from "false".
+type ssoBool bool
+
+func (b *ssoBool) UnmarshalJSON(data []byte) error {
+	*b = ssoBool(strings.Trim(string(data), `"`) == "true")
+	return nil
+}
+
 // verifyIDToken validates the id_token's signature (asymmetric only), issuer,
 // audience (= the provider's client_id), expiry, and the nonce, returning the
-// subject, email, and (best-effort) name claims.
+// subject, email, and (best-effort) name claims. The email is returned only when the
+// IdP has not explicitly marked it unverified (email_verified: false) — so an IdP
+// that lets a user self-assert an arbitrary, unverified address cannot use it to
+// match an existing account or seed a JIT-provisioned one. An absent email_verified
+// claim is treated as trusted: it is OPTIONAL in OIDC and common enterprise IdPs
+// (e.g. Entra ID) omit it for a configured, trusted issuer.
 func (c *KeyorixCore) verifyIDToken(ctx context.Context, p *SSOProvider, expectedNonce, raw string) (sub, email, name string, err error) {
 	var claims struct {
 		jwt.RegisteredClaims
-		Email string `json:"email"`
-		Name  string `json:"name"`
-		Nonce string `json:"nonce"`
+		Email         string   `json:"email"`
+		EmailVerified *ssoBool `json:"email_verified"`
+		Name          string   `json:"name"`
+		Nonce         string   `json:"nonce"`
 	}
 	parser := jwt.NewParser(
 		jwt.WithValidMethods([]string{"RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512"}),
@@ -283,7 +299,14 @@ func (c *KeyorixCore) verifyIDToken(ctx context.Context, p *SSOProvider, expecte
 	if strings.TrimSpace(claims.Subject) == "" {
 		return "", "", "", fmt.Errorf("id_token has no subject")
 	}
-	return claims.Subject, claims.Email, claims.Name, nil
+	email = claims.Email
+	if email != "" && claims.EmailVerified != nil && !bool(*claims.EmailVerified) {
+		// The IdP explicitly says this address is unverified — don't trust it for
+		// identity. The subject (externalId) match still works; only the email
+		// fallback / JIT-provisioning lose this untrusted address.
+		email = ""
+	}
+	return claims.Subject, email, claims.Name, nil
 }
 
 func randToken() (string, error) {

--- a/internal/core/sso_test.go
+++ b/internal/core/sso_test.go
@@ -84,6 +84,52 @@ func TestVerifyIDToken(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestVerifyIDToken_EmailVerified(t *testing.T) {
+	c, _, key, p := ssoTestCore(t)
+	ctx := context.Background()
+	base := func() jwt.MapClaims {
+		return jwt.MapClaims{
+			"iss": "https://idp.test", "aud": "client-1", "sub": "okta|123",
+			"email": "ada@x.io", "nonce": "N1", "exp": time.Now().Add(time.Hour).Unix(),
+		}
+	}
+
+	// email_verified absent → email is trusted (OIDC-optional; Entra omits it).
+	_, email, _, err := c.verifyIDToken(ctx, p, "N1", signToken(t, key, "kid-1", base()))
+	require.NoError(t, err)
+	assert.Equal(t, "ada@x.io", email)
+
+	// email_verified: true → email trusted.
+	ok := base()
+	ok["email_verified"] = true
+	_, email, _, err = c.verifyIDToken(ctx, p, "N1", signToken(t, key, "kid-1", ok))
+	require.NoError(t, err)
+	assert.Equal(t, "ada@x.io", email)
+
+	// email_verified: false → email DROPPED (untrusted), but the token still verifies
+	// and the subject is unaffected.
+	no := base()
+	no["email_verified"] = false
+	sub, email, _, err := c.verifyIDToken(ctx, p, "N1", signToken(t, key, "kid-1", no))
+	require.NoError(t, err)
+	assert.Equal(t, "okta|123", sub)
+	assert.Empty(t, email)
+
+	// email_verified sent as the string "false" → also dropped (no parse failure).
+	noStr := base()
+	noStr["email_verified"] = "false"
+	_, email, _, err = c.verifyIDToken(ctx, p, "N1", signToken(t, key, "kid-1", noStr))
+	require.NoError(t, err)
+	assert.Empty(t, email)
+
+	// email_verified sent as the string "true" → trusted.
+	okStr := base()
+	okStr["email_verified"] = "true"
+	_, email, _, err = c.verifyIDToken(ctx, p, "N1", signToken(t, key, "kid-1", okStr))
+	require.NoError(t, err)
+	assert.Equal(t, "ada@x.io", email)
+}
+
 func TestResolveSSOUser(t *testing.T) {
 	notFound := func() error { return fmt.Errorf("%s", i18n.T("ErrorUserNotFound", nil)) }
 

--- a/internal/core/sso_test.go
+++ b/internal/core/sso_test.go
@@ -53,31 +53,34 @@ func TestVerifyIDToken(t *testing.T) {
 		}
 	}
 
-	sub, email, err := c.verifyIDToken(ctx, p, "N1", signToken(t, key, "kid-1", base()))
+	b := base()
+	b["name"] = "Ada Lovelace"
+	sub, email, name, err := c.verifyIDToken(ctx, p, "N1", signToken(t, key, "kid-1", b))
 	require.NoError(t, err)
 	assert.Equal(t, "okta|123", sub)
 	assert.Equal(t, "ada@x.io", email)
+	assert.Equal(t, "Ada Lovelace", name)
 
 	// Wrong audience → rejected.
 	bad := base()
 	bad["aud"] = "someone-else"
-	_, _, err = c.verifyIDToken(ctx, p, "N1", signToken(t, key, "kid-1", bad))
+	_, _, _, err = c.verifyIDToken(ctx, p, "N1", signToken(t, key, "kid-1", bad))
 	require.Error(t, err)
 
 	// Nonce mismatch → rejected (replay / mix-up protection).
-	_, _, err = c.verifyIDToken(ctx, p, "WRONG", signToken(t, key, "kid-1", base()))
+	_, _, _, err = c.verifyIDToken(ctx, p, "WRONG", signToken(t, key, "kid-1", base()))
 	require.Error(t, err)
 
 	// Expired → rejected.
 	exp := base()
 	exp["exp"] = time.Now().Add(-time.Hour).Unix()
-	_, _, err = c.verifyIDToken(ctx, p, "N1", signToken(t, key, "kid-1", exp))
+	_, _, _, err = c.verifyIDToken(ctx, p, "N1", signToken(t, key, "kid-1", exp))
 	require.Error(t, err)
 
 	// Wrong issuer → rejected (keyfn refuses it).
 	iss := base()
 	iss["iss"] = "https://evil.test"
-	_, _, err = c.verifyIDToken(ctx, p, "N1", signToken(t, key, "kid-1", iss))
+	_, _, _, err = c.verifyIDToken(ctx, p, "N1", signToken(t, key, "kid-1", iss))
 	require.Error(t, err)
 }
 
@@ -102,12 +105,92 @@ func TestResolveSSOUser(t *testing.T) {
 		assert.Equal(t, uint(9), u.ID)
 	})
 
-	t.Run("no match errors", func(t *testing.T) {
+	t.Run("no match returns nil (caller decides)", func(t *testing.T) {
 		c, store, _, _ := ssoTestCore(t)
 		store.On("GetUserByExternalID", mock.Anything, "okta|123").Return((*models.User)(nil), notFound())
 		store.On("GetUserByEmail", mock.Anything, "ada@x.io").Return((*models.User)(nil), notFound())
-		_, err := c.resolveSSOUser(context.Background(), "okta|123", "ada@x.io")
+		u, err := c.resolveSSOUser(context.Background(), "okta|123", "ada@x.io")
+		require.NoError(t, err)
+		assert.Nil(t, u)
+	})
+}
+
+func TestProvisionSSOUser(t *testing.T) {
+	notFound := func() error { return fmt.Errorf("%s", i18n.T("ErrorUserNotFound", nil)) }
+
+	t.Run("JIT-creates an active passwordless user with the default role", func(t *testing.T) {
+		c, store, _, p := ssoTestCore(t)
+		// No existing match (FindSCIMUser re-check), unique username derivation.
+		store.On("GetUserByExternalID", mock.Anything, "okta|123").Return((*models.User)(nil), notFound())
+		store.On("GetUserByEmail", mock.Anything, "ada@x.io").Return((*models.User)(nil), notFound())
+		store.On("GetUserByUsername", mock.Anything, "ada").Return((*models.User)(nil), notFound())
+		var created *models.User
+		store.On("CreateUser", mock.Anything, mock.MatchedBy(func(u *models.User) bool {
+			created = u
+			return true
+		})).Return(&models.User{ID: 42}, nil)
+		store.On("GetRoleByName", mock.Anything, "system_viewer").Return(&models.Role{ID: 3}, nil)
+		store.On("AssignRole", mock.Anything, uint(42), uint(3), mock.Anything).Return(nil)
+		store.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
+
+		u, err := c.provisionSSOUser(context.Background(), p, "okta|123", "ada@x.io", "Ada Lovelace")
+		require.NoError(t, err)
+		assert.Equal(t, uint(42), u.ID)
+		// Active (not pending_first_login — an SSO user must not be trapped in a
+		// restricted password-change-only session), externalId pinned, real display name.
+		assert.Equal(t, AccountActive, created.AccountState)
+		assert.True(t, created.IsActive)
+		assert.Equal(t, "okta|123", created.ExternalID)
+		assert.Equal(t, "ada@x.io", created.Email)
+		assert.Equal(t, "Ada Lovelace", created.DisplayName)
+		assert.NotEmpty(t, created.PasswordHash) // unusable random hash, not blank
+	})
+
+	t.Run("refuses when the IdP returned no email", func(t *testing.T) {
+		c, _, _, p := ssoTestCore(t)
+		_, err := c.provisionSSOUser(context.Background(), p, "okta|123", "", "Ada")
 		require.Error(t, err)
+	})
+
+	t.Run("reuses an existing user instead of duplicating", func(t *testing.T) {
+		c, store, _, p := ssoTestCore(t)
+		store.On("GetUserByExternalID", mock.Anything, "okta|123").Return(&models.User{ID: 5}, nil)
+		u, err := c.provisionSSOUser(context.Background(), p, "okta|123", "ada@x.io", "Ada")
+		require.NoError(t, err)
+		assert.Equal(t, uint(5), u.ID)
+		store.AssertNotCalled(t, "CreateUser", mock.Anything, mock.Anything)
+	})
+
+	t.Run("honours a configured default_role", func(t *testing.T) {
+		c, store, _, p := ssoTestCore(t)
+		p.DefaultRole = "project_admin"
+		store.On("GetUserByExternalID", mock.Anything, "okta|123").Return((*models.User)(nil), notFound())
+		store.On("GetUserByEmail", mock.Anything, "ada@x.io").Return((*models.User)(nil), notFound())
+		store.On("GetUserByUsername", mock.Anything, "ada").Return((*models.User)(nil), notFound())
+		store.On("CreateUser", mock.Anything, mock.Anything).Return(&models.User{ID: 7}, nil)
+		store.On("GetRoleByName", mock.Anything, "project_admin").Return(&models.Role{ID: 9}, nil)
+		store.On("AssignRole", mock.Anything, uint(7), uint(9), mock.Anything).Return(nil)
+		store.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
+
+		_, err := c.provisionSSOUser(context.Background(), p, "okta|123", "ada@x.io", "Ada")
+		require.NoError(t, err)
+		store.AssertCalled(t, "GetRoleByName", mock.Anything, "project_admin")
+	})
+
+	t.Run("an unknown default_role grants nothing but still provisions", func(t *testing.T) {
+		c, store, _, p := ssoTestCore(t)
+		p.DefaultRole = "does_not_exist"
+		store.On("GetUserByExternalID", mock.Anything, "okta|123").Return((*models.User)(nil), notFound())
+		store.On("GetUserByEmail", mock.Anything, "ada@x.io").Return((*models.User)(nil), notFound())
+		store.On("GetUserByUsername", mock.Anything, "ada").Return((*models.User)(nil), notFound())
+		store.On("CreateUser", mock.Anything, mock.Anything).Return(&models.User{ID: 8}, nil)
+		store.On("GetRoleByName", mock.Anything, "does_not_exist").Return((*models.Role)(nil), notFound())
+		store.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
+
+		u, err := c.provisionSSOUser(context.Background(), p, "okta|123", "ada@x.io", "Ada")
+		require.NoError(t, err)
+		assert.Equal(t, uint(8), u.ID)
+		store.AssertNotCalled(t, "AssignRole", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 	})
 }
 

--- a/server/main.go
+++ b/server/main.go
@@ -1122,7 +1122,9 @@ func buildSSOProviders(sso config.SSOConfig) (map[string]*core.SSOProvider, core
 				RedirectURL:  pc.RedirectURL,
 				Scopes:       scopes,
 			},
-			CompleteURL: completeURL,
+			CompleteURL:   completeURL,
+			AutoProvision: pc.AutoProvision,
+			DefaultRole:   pc.DefaultRole,
 		}
 		jwksURIs[pc.Issuer] = disc.JWKSURI
 	}


### PR DESCRIPTION
## What

Completes the identity arc shipped in v0.26.0. Today a first SSO login whose verified identity matches no existing Keyorix account is **refused** — the account must be provisioned via SCIM or invited first (the #203 SSO batch explicitly did not auto-provision). For IdPs that aren't wired for SCIM push, this adds an opt-in, per-provider `auto_provision` toggle that **JIT-creates the account on first login** instead.

## How

- **Config** (`SSOProviderConfig`): `auto_provision bool` (default off) + `default_role string` (baseline role for JIT users; `system_viewer` when unset).
- **Core** (`provisionSSOUser`): only reachable when `auto_provision` is on and `resolveSSOUser` finds no match. The identity has already passed full id_token verification (signature, issuer, audience, expiry, nonce) so the IdP subject is trusted as the `externalId`. The account is created **active** and passwordless — it deliberately does **not** start `pending_first_login` (which would trap an SSO user in a password-change-only restricted session it can never clear). Baseline role is `default_role`; an unknown role grants nothing (least-privilege on misconfiguration). Audited as `auth.sso_jit_provisioned`.
- `resolveSSOUser` now returns `(nil, nil)` on no-match so the caller decides refuse-vs-provision; `verifyIDToken` also returns the `name` claim for the display name.

## Security

Self-reviewed via the security-review skill (auth-sensitive). Two candidate findings (email-based account takeover; email-seeding privesc) were investigated and filtered: the account-takeover path **pre-exists** in #203 (email fallback in `resolveSSOUser`, fires regardless of this flag) and role binding is user-ID-based with the invitation-accept flow refusing existing emails. One agreed hardening was applied:

- **`email_verified` handling** — an email an IdP explicitly marks `email_verified: false` is no longer used to match or provision (only the subject/externalId match applies for that login). An **absent** claim stays trusted, because it's optional in OIDC and enterprise IdPs like **Entra ID omit it** — a strict requirement would break their email matching. Parsed tolerantly (JSON bool or `"true"`/`"false"` string).

## Tests

`TestProvisionSSOUser` (active+passwordless+externalId+default role; empty-email refusal; existing-user reuse; configured/unknown `default_role`), `TestVerifyIDToken_EmailVerified` (absent/true/false/string variants), updated `TestResolveSSOUser`. gofmt clean, golangci-lint 0, gitleaks clean. The only local test failure is the known `/sw.js` single-binary artifact (green in CI).

## Docs

`CONFIGURATION.md` SSO section: JIT provisioning + email-trust note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)