### PR TITLE
feat(compliance): S3-compatible object-storage evidence sink

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -448,25 +448,43 @@ Each export also emits a `compliance.evidence_exported` audit event, so an insta
 [`audit.siem`](#auditsiem) forwarder receives the delivery signal too. Read-only, so
 it runs even while a legal hold is active. Single-replica-gated (ADR-039).
 
-Deliver to a local directory, an off-box **webhook** (POST of the pack JSON), or
-both. At least one target must be configured when enabled.
+Deliver to a local directory, an off-box **webhook** (POST of the pack JSON), an
+**S3-compatible object store**, or any combination. At least one target must be
+configured when enabled; when several are set the pack fans out to all of them.
 
 ```yaml
 evidence_delivery:
   enabled: true
   schedule: "24h"                           # Go duration between exports (default 24h)
-  output_dir: "/var/lib/keyorix/evidence"   # local archive; omit to deliver by webhook only
+  output_dir: "/var/lib/keyorix/evidence"   # local archive; omit to deliver off-box only
   webhook:
     enabled: true
     endpoint: "https://evidence.example.com/keyorix"
     token: ""                               # prefer the KEYORIX_EVIDENCE_WEBHOOK_TOKEN env var
     insecure_skip_verify: false             # TLS verification off — self-signed endpoints only
+  object_store:
+    enabled: true
+    bucket: "acme-compliance-evidence"      # required when enabled
+    prefix: "keyorix/evidence/"             # optional key prefix
+    region: "eu-west-1"
+    endpoint: ""                            # optional — set for S3-compatible stores (MinIO/R2/…)
+    use_path_style: false                   # set true for MinIO and some gateways
 ```
 
-> The webhook lets evidence survive the node without a mounted volume. A file write
-> is the primary durable target (its failure is fatal); a webhook failure is recorded
-> in the audit note but does not fail the export when a file was also written. The
-> webhook token is read from `KEYORIX_EVIDENCE_WEBHOOK_TOKEN` when set.
+> The off-box targets let evidence survive the node without a mounted volume. A file
+> write is the primary durable target (its failure is fatal); an off-box delivery
+> failure is recorded in the audit note but does not fail the export when a file was
+> also written. The webhook token is read from `KEYORIX_EVIDENCE_WEBHOOK_TOKEN` when
+> set.
+>
+> **Object store.** Works with AWS S3 and S3-compatible stores (MinIO, Cloudflare R2,
+> Backblaze B2, GCS interop) — point `endpoint` at the store and set `use_path_style:
+> true` where required. The pack is uploaded to `<prefix><filename>` and, when signed,
+> the detached signature to `<prefix><filename>.sig`. **Credentials are never taken in
+> Keyorix config**: they resolve via the standard AWS credential chain
+> (`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` env vars, shared config, or
+> instance/workload identity). Point the bucket at object-lock / immutable storage for
+> WORM-grade evidence retention.
 
 When **encryption is enabled**, each exported pack is **signed**: a detached
 `<file>.json.sig` is written next to it (and the webhook delivery carries the

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.42.0
 	github.com/aws/aws-sdk-go-v2/config v1.32.24
 	github.com/aws/aws-sdk-go-v2/service/kms v1.53.4
+	github.com/aws/aws-sdk-go-v2/service/s3 v1.103.3
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.42.3
 	github.com/go-chi/chi/v5 v5.2.2
 	github.com/go-chi/cors v1.2.1
@@ -52,13 +53,16 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/internal v1.2.0 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.7.0 // indirect
+	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.13 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.23 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.29 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.29 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.29 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.30 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.12 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.22 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.29 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.29 // indirect
 	github.com/aws/aws-sdk-go-v2/service/signin v1.1.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.31.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.36.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,8 @@ github.com/BurntSushi/toml v1.5.0 h1:W5quZX/G/csjUnuI8SUYlsHs9M38FC7znL0lIO+DvMg
 github.com/BurntSushi/toml v1.5.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/aws/aws-sdk-go-v2 v1.42.0 h1:XvXMJTkFQtpBKIWZnmr9ZEOc2InWM2yldjXEJ/bymhA=
 github.com/aws/aws-sdk-go-v2 v1.42.0/go.mod h1:27+ACypSLljLAEKsCYOmrjKh83vuTRkuAe9Uv/3A4bg=
+github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.13 h1:p1BBrg/Hhp6uK7zpejeI8QFXHJeC/mynzi04Sl03k9g=
+github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.13/go.mod h1:8cIfkE9MDhkRZGpQ22aV6/lkYeYSozpz16Smrs5x4Ls=
 github.com/aws/aws-sdk-go-v2/config v1.32.24 h1:aEDEj533yGdVvEHfkCY0D/1FbDrjnZr4pIulxRjqpHs=
 github.com/aws/aws-sdk-go-v2/config v1.32.24/go.mod h1:yZtrGKJGlqfEW+/m2uTsJK+Jz7xF5R0eZfgcIG9m1ss=
 github.com/aws/aws-sdk-go-v2/credentials v1.19.23 h1:Zhu3GOpRCkNjtE/gJpuPDsytSnaCCTQk8neAGsgzG5Y=
@@ -52,10 +54,16 @@ github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.30 h1:VTGy885W5DKBxWRUJbym9hytNaY
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.30/go.mod h1:AS0HycUvJRFvTt613AYDOgO2jzw+00cVSMny8XB3yMY=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.12 h1:ZD2+BSw9vFsNlKYIasSNt3uDbjqqXIBcM13UJv/Lx2k=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.12/go.mod h1:Ms4zlcVBbXbiP7EVLhl+lgjvA/a7YphqQ3Ih3174EmI=
+github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.22 h1:V51LGlOq/1VsDsHUdoklAQi7rMmx4qQubvFYAlP2254=
+github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.22/go.mod h1:4Pzhyz8hJOm2bepgl+NjvRx8vlUFAIIvJnZ/MkcNPpU=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.29 h1:DRebniUGZ2MqiiIVmQJ04vIXr918hubdHMnarSLEWyU=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.29/go.mod h1:LfRkPCD8YHDM2E5eTkos2UpwYeZnBcVarTa8L59bJHA=
+github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.29 h1:hiME6pBzC7OTl9LMtlyTWBuEl1f4QBcUmFDKC7MLXtc=
+github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.29/go.mod h1:G7RP+uhagpKtKhd1BM9N6JQqjCcGEU47K5lBVZQyRQw=
 github.com/aws/aws-sdk-go-v2/service/kms v1.53.4 h1:PEgVSsWtR8NNxsDxFL2Ywisi7R+1EFQARGsT4q3mWwI=
 github.com/aws/aws-sdk-go-v2/service/kms v1.53.4/go.mod h1:3EeKyDGPGSCEphG2OolwNGNF45RvQIfm27AYYpfEWrw=
+github.com/aws/aws-sdk-go-v2/service/s3 v1.103.3 h1:JRseEu/vIDMaWis4bSw0QbXL+cvIGc1XnX076H5ZXLE=
+github.com/aws/aws-sdk-go-v2/service/s3 v1.103.3/go.mod h1:77ZAgynvx1txMvDG8gGWoWkO1augYDxkp9JElWFgjQU=
 github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.42.3 h1:L9gPLf3sFH1/ao3oB2QZcaX1xGYi8hj+WJlsf3/dN+M=
 github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.42.3/go.mod h1:9DKRlwDCw2OUDlyCIFcQCroL5M0mQTUU9qW8JEDcXmI=
 github.com/aws/aws-sdk-go-v2/service/signin v1.1.5 h1:6Xt6Ztjkwdia/7EtEaG7ki/qZUYlCcd7tGUotQed1QE=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -531,10 +531,26 @@ func (c DataRetentionConfig) GetInterval() time.Duration {
 // the delivery signal too. Opt-in (Enabled, default off); at least one target
 // (OutputDir or Webhook) must be configured.
 type EvidenceDeliveryConfig struct {
-	Enabled   bool                  `yaml:"enabled"`
-	Schedule  string                `yaml:"schedule"`
-	OutputDir string                `yaml:"output_dir"`
-	Webhook   EvidenceWebhookConfig `yaml:"webhook"`
+	Enabled     bool                      `yaml:"enabled"`
+	Schedule    string                    `yaml:"schedule"`
+	OutputDir   string                    `yaml:"output_dir"`
+	Webhook     EvidenceWebhookConfig     `yaml:"webhook"`
+	ObjectStore EvidenceObjectStoreConfig `yaml:"object_store"`
+}
+
+// EvidenceObjectStoreConfig configures the off-box S3-compatible object-storage
+// target: each run uploads the pack (and detached signature) to a bucket. Works with
+// AWS S3 and S3-compatible stores (MinIO, Cloudflare R2, Backblaze B2, GCS interop)
+// via a custom endpoint. Credentials resolve via the standard AWS credential chain
+// (AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY env vars, shared config, or
+// instance/workload identity) — never from Keyorix config.
+type EvidenceObjectStoreConfig struct {
+	Enabled      bool   `yaml:"enabled"`
+	Bucket       string `yaml:"bucket"`         // required when enabled
+	Prefix       string `yaml:"prefix"`         // optional key prefix, e.g. "keyorix/evidence/"
+	Region       string `yaml:"region"`         // bucket region
+	Endpoint     string `yaml:"endpoint"`       // optional custom endpoint for S3-compatible stores
+	UsePathStyle bool   `yaml:"use_path_style"` // path-style addressing (MinIO and some gateways)
 }
 
 // EvidenceWebhookConfig configures the off-box webhook target: each run POSTs the
@@ -553,7 +569,7 @@ func (c *EvidenceWebhookConfig) GetToken() string {
 
 // HasTarget reports whether at least one delivery target is configured.
 func (c EvidenceDeliveryConfig) HasTarget() bool {
-	return c.OutputDir != "" || c.Webhook.Enabled
+	return c.OutputDir != "" || c.Webhook.Enabled || c.ObjectStore.Enabled
 }
 
 // GetInterval returns the evidence-export run interval, parsing Schedule as a Go

--- a/internal/core/evidence_export.go
+++ b/internal/core/evidence_export.go
@@ -23,9 +23,12 @@ const evidenceFileTimeLayout = "20060102T150405Z"
 // EvidenceForwarder ships a marshalled evidence pack to an off-box target (e.g. a
 // webhook / object store). Called only from the once-a-day evidence scheduler, so a
 // synchronous implementation is fine. Defined here (not in the sink package) so core
-// has no dependency on the forwarder implementation.
+// has no dependency on the forwarder implementation. name is the suggested object
+// name (keyorix-evidence-<ts>.json) — an object store keys on it; a webhook may
+// ignore it. Target returns a short label for the export result (e.g. "webhook").
 type EvidenceForwarder interface {
-	ForwardEvidence(ctx context.Context, data []byte, signature string) error
+	ForwardEvidence(ctx context.Context, name string, data []byte, signature string) error
+	Target() string
 }
 
 // SetEvidenceForwarder wires an off-box evidence target. The server calls this at
@@ -70,11 +73,14 @@ func (c *KeyorixCore) ExportComplianceEvidence(ctx context.Context, outputDir st
 
 	res := &EvidenceExportResult{Bytes: len(data), Signed: signed}
 
+	// The pack's canonical name — used both as the local filename and the off-box
+	// object key, so a file and an object-store copy of the same run line up.
+	name := fmt.Sprintf("keyorix-evidence-%s.json", ev.GeneratedAt.UTC().Format(evidenceFileTimeLayout))
+
 	if outputDir != "" {
 		if err := os.MkdirAll(outputDir, 0o700); err != nil {
 			return nil, fmt.Errorf("evidence export: create output dir: %w", err)
 		}
-		name := fmt.Sprintf("keyorix-evidence-%s.json", ev.GeneratedAt.UTC().Format(evidenceFileTimeLayout))
 		if err := securefiles.SecureWriteFile(outputDir, name, data, 0o600); err != nil {
 			return nil, fmt.Errorf("evidence export: write: %w", err)
 		}
@@ -89,15 +95,15 @@ func (c *KeyorixCore) ExportComplianceEvidence(ctx context.Context, outputDir st
 
 	forwardNote := ""
 	if c.evidenceForwarder != nil {
-		if err := c.evidenceForwarder.ForwardEvidence(ctx, data, signature); err != nil {
+		if err := c.evidenceForwarder.ForwardEvidence(ctx, name, data, signature); err != nil {
 			// Best-effort secondary target: record the failure but don't drop the
 			// export when a durable file was also written.
-			forwardNote = fmt.Sprintf("; webhook delivery FAILED: %v", err)
+			forwardNote = fmt.Sprintf("; off-box delivery FAILED: %v", err)
 			if res.Path == "" {
-				return nil, fmt.Errorf("evidence export: webhook delivery failed: %w", err)
+				return nil, fmt.Errorf("evidence export: off-box delivery failed: %w", err)
 			}
 		} else {
-			res.Targets = append(res.Targets, "webhook")
+			res.Targets = append(res.Targets, c.evidenceForwarder.Target())
 		}
 	}
 

--- a/internal/core/evidence_export_test.go
+++ b/internal/core/evidence_export_test.go
@@ -96,17 +96,21 @@ func TestExportComplianceEvidence_EmptyOutputDirErrors(t *testing.T) {
 
 type fakeEvidenceForwarder struct {
 	calls int
+	name  string
 	data  []byte
 	sig   string
 	err   error
 }
 
-func (f *fakeEvidenceForwarder) ForwardEvidence(_ context.Context, data []byte, signature string) error {
+func (f *fakeEvidenceForwarder) ForwardEvidence(_ context.Context, name string, data []byte, signature string) error {
 	f.calls++
+	f.name = name
 	f.data = data
 	f.sig = signature
 	return f.err
 }
+
+func (f *fakeEvidenceForwarder) Target() string { return "webhook" }
 
 func TestExportComplianceEvidence_WebhookOnly(t *testing.T) {
 	ctx := context.Background()
@@ -118,6 +122,7 @@ func TestExportComplianceEvidence_WebhookOnly(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 1, fwd.calls)
 	assert.Greater(t, len(fwd.data), 0)
+	assert.Contains(t, fwd.name, "keyorix-evidence-", "the forwarder receives the canonical pack name")
 	assert.Empty(t, res.Path)
 	assert.Equal(t, []string{"webhook"}, res.Targets)
 

--- a/internal/evidencesink/multi.go
+++ b/internal/evidencesink/multi.go
@@ -1,0 +1,49 @@
+// multi.go — fan the scheduled evidence pack out to several off-box targets at once
+// (e.g. a webhook AND an object-store bucket), so an operator isn't forced to pick a
+// single off-box destination.
+package evidencesink
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// Forwarder is an off-box evidence delivery target. It mirrors core.EvidenceForwarder
+// structurally so this package needs no dependency on core.
+type Forwarder interface {
+	ForwardEvidence(ctx context.Context, name string, data []byte, signature string) error
+	Target() string
+}
+
+// Multi delivers the evidence pack to every configured target. ForwardEvidence
+// attempts ALL targets and aggregates failures — the pack reaches as many targets as
+// possible, and an error is returned if any target failed (the core then handles it
+// like any forwarder failure: non-fatal when a local file was also written).
+type Multi struct{ forwarders []Forwarder }
+
+// NewMulti builds a Multi over the given forwarders.
+func NewMulti(fwds ...Forwarder) *Multi { return &Multi{forwarders: fwds} }
+
+// ForwardEvidence delivers to every target, collecting any errors.
+func (m *Multi) ForwardEvidence(ctx context.Context, name string, data []byte, signature string) error {
+	var errs []string
+	for _, f := range m.forwarders {
+		if err := f.ForwardEvidence(ctx, name, data, signature); err != nil {
+			errs = append(errs, fmt.Sprintf("%s: %v", f.Target(), err))
+		}
+	}
+	if len(errs) > 0 {
+		return fmt.Errorf("%s", strings.Join(errs, "; "))
+	}
+	return nil
+}
+
+// Target joins the labels of the wrapped targets, e.g. "webhook+objectstore:b/p".
+func (m *Multi) Target() string {
+	labels := make([]string, 0, len(m.forwarders))
+	for _, f := range m.forwarders {
+		labels = append(labels, f.Target())
+	}
+	return strings.Join(labels, "+")
+}

--- a/internal/evidencesink/multi_test.go
+++ b/internal/evidencesink/multi_test.go
@@ -1,0 +1,45 @@
+package evidencesink
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type stubForwarder struct {
+	label string
+	calls int
+	err   error
+}
+
+func (s *stubForwarder) ForwardEvidence(_ context.Context, _ string, _ []byte, _ string) error {
+	s.calls++
+	return s.err
+}
+func (s *stubForwarder) Target() string { return s.label }
+
+func TestMulti_DeliversToAllTargets(t *testing.T) {
+	a := &stubForwarder{label: "webhook"}
+	b := &stubForwarder{label: "objectstore:bkt/"}
+	m := NewMulti(a, b)
+
+	require.NoError(t, m.ForwardEvidence(context.Background(), "pack.json", []byte(`{}`), "v1:x"))
+	assert.Equal(t, 1, a.calls)
+	assert.Equal(t, 1, b.calls)
+	assert.Equal(t, "webhook+objectstore:bkt/", m.Target())
+}
+
+func TestMulti_AttemptsAllAndAggregatesErrors(t *testing.T) {
+	a := &stubForwarder{label: "webhook", err: errors.New("boom")}
+	b := &stubForwarder{label: "objectstore:bkt/"} // succeeds
+	m := NewMulti(a, b)
+
+	err := m.ForwardEvidence(context.Background(), "pack.json", []byte(`{}`), "")
+	require.Error(t, err, "any failure surfaces as an error")
+	assert.Equal(t, 1, a.calls)
+	assert.Equal(t, 1, b.calls, "a failing target does not stop the others")
+	assert.Contains(t, err.Error(), "webhook")
+}

--- a/internal/evidencesink/objectstore.go
+++ b/internal/evidencesink/objectstore.go
@@ -1,0 +1,105 @@
+// objectstore.go — an S3-compatible object-storage evidence target. Each scheduled
+// run uploads the pack (and, when signed, its detached HMAC signature) to a bucket,
+// so evidence survives the node without a mounted volume and lands in immutable /
+// object-locked storage an auditor can pull from. Works with AWS S3 and S3-compatible
+// stores (MinIO, Cloudflare R2, Backblaze B2, GCS interop) via a custom endpoint.
+// This is the ONLY file that imports the S3 SDK, keeping the dependency contained.
+package evidencesink
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+// ObjectStoreConfig configures the S3-compatible object-storage target. Credentials
+// are NOT taken here — they resolve via the standard AWS chain (AWS_ACCESS_KEY_ID /
+// AWS_SECRET_ACCESS_KEY env vars, shared config, or instance/workload identity).
+type ObjectStoreConfig struct {
+	Bucket       string // required — destination bucket
+	Prefix       string // optional key prefix, e.g. "keyorix/evidence/"
+	Region       string // bucket region (any value for some S3-compatible stores)
+	Endpoint     string // optional custom endpoint for S3-compatible stores (MinIO/R2/…)
+	UsePathStyle bool   // path-style addressing — required by MinIO and some gateways
+}
+
+// s3PutAPI is the slice of the S3 client the sink uses — an interface seam so the
+// delivery logic is unit-tested with a fake and the SDK stays inside this adapter.
+type s3PutAPI interface {
+	PutObject(ctx context.Context, in *s3.PutObjectInput, opts ...func(*s3.Options)) (*s3.PutObjectOutput, error)
+}
+
+// ObjectStore delivers the evidence pack to an S3-compatible bucket.
+type ObjectStore struct {
+	api    s3PutAPI
+	bucket string
+	prefix string
+}
+
+// NewObjectStore builds the S3-compatible sink. The bucket is required; credentials
+// resolve via the default AWS credential chain.
+func NewObjectStore(ctx context.Context, cfg ObjectStoreConfig) (*ObjectStore, error) {
+	if cfg.Bucket == "" {
+		return nil, fmt.Errorf("evidencesink: object-store bucket is required")
+	}
+	var loadOpts []func(*awsconfig.LoadOptions) error
+	if cfg.Region != "" {
+		loadOpts = append(loadOpts, awsconfig.WithRegion(cfg.Region))
+	}
+	awsCfg, err := awsconfig.LoadDefaultConfig(ctx, loadOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("evidencesink: load AWS config: %w", err)
+	}
+	client := s3.NewFromConfig(awsCfg, func(o *s3.Options) {
+		if cfg.Endpoint != "" {
+			o.BaseEndpoint = aws.String(cfg.Endpoint)
+		}
+		o.UsePathStyle = cfg.UsePathStyle
+	})
+	return &ObjectStore{api: client, bucket: cfg.Bucket, prefix: normalizePrefix(cfg.Prefix)}, nil
+}
+
+// ForwardEvidence uploads the pack to <prefix><name> and, when signed, the detached
+// signature to <prefix><name>.sig. A failure on either upload fails the delivery.
+func (o *ObjectStore) ForwardEvidence(ctx context.Context, name string, data []byte, signature string) error {
+	key := o.prefix + name
+	if _, err := o.api.PutObject(ctx, &s3.PutObjectInput{
+		Bucket:      aws.String(o.bucket),
+		Key:         aws.String(key),
+		Body:        bytes.NewReader(data),
+		ContentType: aws.String("application/json"),
+	}); err != nil {
+		return fmt.Errorf("evidencesink: put %s: %w", key, err)
+	}
+	if signature != "" {
+		sigKey := key + ".sig"
+		if _, err := o.api.PutObject(ctx, &s3.PutObjectInput{
+			Bucket:      aws.String(o.bucket),
+			Key:         aws.String(sigKey),
+			Body:        strings.NewReader(signature),
+			ContentType: aws.String("text/plain"),
+		}); err != nil {
+			return fmt.Errorf("evidencesink: put %s: %w", sigKey, err)
+		}
+	}
+	return nil
+}
+
+// Target labels this forwarder in the export result.
+func (o *ObjectStore) Target() string {
+	return fmt.Sprintf("objectstore:%s/%s", o.bucket, o.prefix)
+}
+
+// normalizePrefix ensures a non-empty prefix ends in a single "/" so keys join cleanly.
+func normalizePrefix(p string) string {
+	p = strings.TrimSpace(p)
+	if p == "" {
+		return ""
+	}
+	return strings.TrimSuffix(p, "/") + "/"
+}

--- a/internal/evidencesink/objectstore_test.go
+++ b/internal/evidencesink/objectstore_test.go
@@ -1,0 +1,95 @@
+package evidencesink
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type putCall struct {
+	bucket, key, body, ctype string
+}
+
+type fakeS3 struct {
+	calls []putCall
+	err   error
+}
+
+func (f *fakeS3) PutObject(_ context.Context, in *s3.PutObjectInput, _ ...func(*s3.Options)) (*s3.PutObjectOutput, error) {
+	b, _ := io.ReadAll(in.Body)
+	f.calls = append(f.calls, putCall{
+		bucket: deref(in.Bucket), key: deref(in.Key), body: string(b), ctype: deref(in.ContentType),
+	})
+	if f.err != nil {
+		return nil, f.err
+	}
+	return &s3.PutObjectOutput{}, nil
+}
+
+func deref(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}
+
+func newTestObjectStore(api s3PutAPI, prefix string) *ObjectStore {
+	return &ObjectStore{api: api, bucket: "evidence-bkt", prefix: normalizePrefix(prefix)}
+}
+
+func TestObjectStore_UploadsPackAndSignature(t *testing.T) {
+	api := &fakeS3{}
+	o := newTestObjectStore(api, "keyorix/evidence")
+
+	err := o.ForwardEvidence(context.Background(), "keyorix-evidence-20260615T100000Z.json", []byte(`{"a":1}`), "v1:abc")
+	require.NoError(t, err)
+	require.Len(t, api.calls, 2, "pack + detached signature")
+
+	pack := api.calls[0]
+	assert.Equal(t, "evidence-bkt", pack.bucket)
+	assert.Equal(t, "keyorix/evidence/keyorix-evidence-20260615T100000Z.json", pack.key)
+	assert.Equal(t, `{"a":1}`, pack.body)
+	assert.Equal(t, "application/json", pack.ctype)
+
+	sig := api.calls[1]
+	assert.Equal(t, "keyorix/evidence/keyorix-evidence-20260615T100000Z.json.sig", sig.key)
+	assert.Equal(t, "v1:abc", sig.body)
+}
+
+func TestObjectStore_NoSignatureSkipsSigObject(t *testing.T) {
+	api := &fakeS3{}
+	o := newTestObjectStore(api, "") // no prefix
+
+	require.NoError(t, o.ForwardEvidence(context.Background(), "pack.json", []byte(`{}`), ""))
+	require.Len(t, api.calls, 1, "only the pack when unsigned")
+	assert.Equal(t, "pack.json", api.calls[0].key, "empty prefix → key is just the name")
+}
+
+func TestObjectStore_PutFailurePropagates(t *testing.T) {
+	api := &fakeS3{err: errors.New("access denied")}
+	o := newTestObjectStore(api, "p")
+	err := o.ForwardEvidence(context.Background(), "pack.json", []byte(`{}`), "")
+	require.Error(t, err)
+}
+
+func TestObjectStore_Target(t *testing.T) {
+	o := newTestObjectStore(&fakeS3{}, "keyorix/evidence")
+	assert.Equal(t, "objectstore:evidence-bkt/keyorix/evidence/", o.Target())
+}
+
+func TestNewObjectStore_RequiresBucket(t *testing.T) {
+	_, err := NewObjectStore(context.Background(), ObjectStoreConfig{})
+	require.Error(t, err)
+}
+
+func TestNormalizePrefix(t *testing.T) {
+	assert.Equal(t, "", normalizePrefix(""))
+	assert.Equal(t, "a/", normalizePrefix("a"))
+	assert.Equal(t, "a/b/", normalizePrefix("a/b"))
+	assert.Equal(t, "a/b/", normalizePrefix("a/b/"))
+}

--- a/internal/evidencesink/webhook.go
+++ b/internal/evidencesink/webhook.go
@@ -42,15 +42,19 @@ func NewWebhook(cfg WebhookConfig) (*Webhook, error) {
 	return &Webhook{cfg: cfg, client: &http.Client{Timeout: webhookTimeout, Transport: transport}}, nil
 }
 
-// ForwardEvidence POSTs the marshalled evidence pack as application/json. When the
-// pack is signed, the detached HMAC signature is sent in the X-Keyorix-Evidence-
-// Signature header so the receiver can record it for later verification.
-func (w *Webhook) ForwardEvidence(ctx context.Context, data []byte, signature string) error {
+// ForwardEvidence POSTs the marshalled evidence pack as application/json. The pack's
+// canonical name rides in X-Keyorix-Evidence-Filename, and when the pack is signed
+// the detached HMAC signature is sent in X-Keyorix-Evidence-Signature so the receiver
+// can record both for later verification.
+func (w *Webhook) ForwardEvidence(ctx context.Context, name string, data []byte, signature string) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, w.cfg.Endpoint, bytes.NewReader(data))
 	if err != nil {
 		return err
 	}
 	req.Header.Set("Content-Type", "application/json")
+	if name != "" {
+		req.Header.Set("X-Keyorix-Evidence-Filename", name)
+	}
 	if signature != "" {
 		req.Header.Set("X-Keyorix-Evidence-Signature", signature)
 	}
@@ -67,3 +71,6 @@ func (w *Webhook) ForwardEvidence(ctx context.Context, data []byte, signature st
 	}
 	return nil
 }
+
+// Target labels this forwarder in the export result.
+func (w *Webhook) Target() string { return "webhook" }

--- a/internal/evidencesink/webhook_test.go
+++ b/internal/evidencesink/webhook_test.go
@@ -14,15 +14,18 @@ import (
 
 func TestWebhook_PostsEvidenceWithAuth(t *testing.T) {
 	var (
-		mu    sync.Mutex
-		body  []byte
-		auth  string
-		ctype string
+		mu       sync.Mutex
+		body     []byte
+		auth     string
+		ctype    string
+		sig      string
+		filename string
 	)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		b, _ := io.ReadAll(r.Body)
 		mu.Lock()
 		body, auth, ctype = b, r.Header.Get("Authorization"), r.Header.Get("Content-Type")
+		sig, filename = r.Header.Get("X-Keyorix-Evidence-Signature"), r.Header.Get("X-Keyorix-Evidence-Filename")
 		mu.Unlock()
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -30,13 +33,16 @@ func TestWebhook_PostsEvidenceWithAuth(t *testing.T) {
 
 	wh, err := NewWebhook(WebhookConfig{Endpoint: srv.URL, Token: "ev-tok"})
 	require.NoError(t, err)
-	require.NoError(t, wh.ForwardEvidence(context.Background(), []byte(`{"generated_at":"x"}`), "v1:abc"))
+	require.NoError(t, wh.ForwardEvidence(context.Background(), "keyorix-evidence-20260615T100000Z.json", []byte(`{"generated_at":"x"}`), "v1:abc"))
 
 	mu.Lock()
 	defer mu.Unlock()
 	assert.Equal(t, `{"generated_at":"x"}`, string(body))
 	assert.Equal(t, "Bearer ev-tok", auth)
 	assert.Equal(t, "application/json", ctype)
+	assert.Equal(t, "v1:abc", sig)
+	assert.Equal(t, "keyorix-evidence-20260615T100000Z.json", filename)
+	assert.Equal(t, "webhook", wh.Target())
 }
 
 func TestWebhook_ErrorsOnNon2xx(t *testing.T) {
@@ -46,7 +52,7 @@ func TestWebhook_ErrorsOnNon2xx(t *testing.T) {
 	defer srv.Close()
 	wh, err := NewWebhook(WebhookConfig{Endpoint: srv.URL})
 	require.NoError(t, err)
-	require.Error(t, wh.ForwardEvidence(context.Background(), []byte(`{}`), ""))
+	require.Error(t, wh.ForwardEvidence(context.Background(), "pack.json", []byte(`{}`), ""))
 }
 
 func TestNewWebhook_RequiresEndpoint(t *testing.T) {

--- a/server/main.go
+++ b/server/main.go
@@ -303,8 +303,10 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 		coreService.SetNotificationSink(sink)
 	}
 
-	// Wire an off-box evidence webhook target if configured, so the scheduled
-	// evidence pack is POSTed off-box in addition to (or instead of) a local dir.
+	// Wire any off-box evidence targets (webhook and/or S3-compatible object store),
+	// so the scheduled evidence pack is delivered off-box in addition to (or instead
+	// of) a local dir. When both are configured the pack fans out to both.
+	var evidenceTargets []evidencesink.Forwarder
 	if ew := cfg.EvidenceDelivery.Webhook; ew.Enabled {
 		fwd, ferr := evidencesink.NewWebhook(evidencesink.WebhookConfig{
 			Endpoint:           ew.Endpoint,
@@ -314,8 +316,29 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 		if ferr != nil {
 			return nil, nil, fmt.Errorf("failed to init evidence webhook target: %w", ferr)
 		}
-		coreService.SetEvidenceForwarder(fwd)
+		evidenceTargets = append(evidenceTargets, fwd)
 		log.Printf("Evidence webhook target enabled (endpoint=%s)", ew.Endpoint)
+	}
+	if os := cfg.EvidenceDelivery.ObjectStore; os.Enabled {
+		sink, oerr := evidencesink.NewObjectStore(context.Background(), evidencesink.ObjectStoreConfig{
+			Bucket:       os.Bucket,
+			Prefix:       os.Prefix,
+			Region:       os.Region,
+			Endpoint:     os.Endpoint,
+			UsePathStyle: os.UsePathStyle,
+		})
+		if oerr != nil {
+			return nil, nil, fmt.Errorf("failed to init evidence object-store target: %w", oerr)
+		}
+		evidenceTargets = append(evidenceTargets, sink)
+		log.Printf("Evidence object-store target enabled (bucket=%s, prefix=%q)", os.Bucket, os.Prefix)
+	}
+	switch len(evidenceTargets) {
+	case 0:
+	case 1:
+		coreService.SetEvidenceForwarder(evidenceTargets[0])
+	default:
+		coreService.SetEvidenceForwarder(evidencesink.NewMulti(evidenceTargets...))
 	}
 
 	// Apply the project membership validation mode (ADR-022). Empty = allowlist.


### PR DESCRIPTION
## What

Adds an **off-box S3-compatible object-storage target** for the scheduled compliance evidence pack. Previously the pack could go to a local dir and/or a webhook; this adds durable bucket archival so evidence can land in **immutable / object-locked (WORM)** storage an auditor pulls from. Reverses the earlier "object store deliberately skipped (heavy cloud SDK)" call — AWS SDK v2 is already a server dependency (KMS), so adding the `s3` service package is incremental.

## How

- **`internal/evidencesink/objectstore.go`** — S3-compatible sink. Works with AWS S3, MinIO, Cloudflare R2, Backblaze B2, GCS interop (custom `endpoint` + `use_path_style`). Uploads the pack to `<prefix><name>` and, when signed, the detached signature to `<prefix><name>.sig`. **Credentials resolve via the standard AWS chain — never from Keyorix config.** The SDK is contained to this one file behind an `s3PutAPI` interface seam (mirrors how `awskms` isolates its SDK), so delivery logic is unit-tested with a fake.
- **`internal/evidencesink/multi.go`** — fan-out forwarder so webhook **and** object store can both be active; attempts all targets, aggregates failures.
- `core.EvidenceForwarder` gains a `name` param (canonical pack filename → object key) and a `Target()` label; the export computes the name once so file + object copies of a run line up. The webhook now also sends `X-Keyorix-Evidence-Filename`.
- **Config**: `evidence_delivery.object_store {enabled, bucket, prefix, region, endpoint, use_path_style}`; `HasTarget()` includes it; `main` wires a single or multi forwarder.

## Notes

- No new server attack surface: endpoint/bucket are operator-configured (trusted, like the existing webhook endpoint); no untrusted input reaches the sink.
- Failure semantics unchanged: a local file write stays the primary durable target (fatal on failure); an off-box delivery failure is recorded in the audit note but non-fatal when a file was also written.

## Tests

`objectstore_test.go` (pack+sig upload, key/prefix construction, unsigned skip, put-failure propagation, `Target()`, bucket-required), `multi_test.go` (delivers to all, aggregates errors without stopping), updated `webhook_test.go` (filename + signature headers, `Target()`), updated `evidence_export_test.go` fake. gofmt clean, golangci-lint 0, gitleaks clean. Only local failure is the known `/sw.js` artifact (green in CI).

## Docs

`CONFIGURATION.md` evidence_delivery object-store section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)