### PR TITLE
feat(sso): JIT native-group sync from the IdP groups claim (opt-in)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -653,6 +653,8 @@ sso:
       scopes: [openid, profile, email]
       auto_provision: false      # JIT-create an account on first login (default off)
       default_role: system_viewer # baseline role for JIT-provisioned users
+      group_sync: false          # reconcile native group memberships from the IdP (default off)
+      groups_claim: groups       # id_token claim carrying group names (default "groups")
 ```
 
 > The client secret is read from `KEYORIX_SSO_<NAME>_CLIENT_SECRET` (name upper-cased,
@@ -676,6 +678,26 @@ later SCIM push for the same `externalId` reconciles to the same account. Leave
 > the subject (`externalId`) match applies for that login. An absent `email_verified`
 > claim is treated as trusted (it is optional in OIDC; some enterprise IdPs such as
 > Entra ID omit it for a configured, trusted issuer).
+
+**Group sync (JIT group membership).** Set `group_sync: true` to reconcile a user's
+**native Keyorix group memberships** from the IdP's group claim on each login — so the
+IdP drives group-based access without a separate SCIM push. The named claim
+(`groups_claim`, default `groups`; some IdPs use `roles`) is read from the verified
+id_token and the IdP is treated as **authoritative**: the user is added to native
+groups whose name matches an asserted group and **removed from native groups it did
+not assert**, so revoking a group at the IdP deprovisions the matching Keyorix access
+on next login. Only groups that **already exist natively** (provisioned via
+[`scim`](#scim) Groups or by an admin) are touched — an asserted group with no native
+counterpart is ignored, and groups are never created or deleted. The net change is
+audited as `auth.sso_groups_synced`.
+
+> Because it is authoritative, **do not mix `group_sync` with manual group assignment**
+> for SSO users — a manually-added membership not asserted by the IdP is removed on the
+> next login. If the `groups_claim` is **absent** from the id_token (e.g. the IdP only
+> emits groups at the userinfo endpoint, or behind a scope you didn't request), the
+> sync is a safe no-op — it never strips memberships on a missing claim. Ensure the IdP
+> is configured to emit the group claim in the id_token (in Okta, add a groups claim to
+> the ID token; in Entra, configure the optional `groups` claim).
 
 ## membership
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -716,6 +716,17 @@ type SSOProviderConfig struct {
 	// (default "system_viewer"). A misconfigured/unknown role grants nothing —
 	// least-privilege on misconfiguration.
 	DefaultRole string `yaml:"default_role"`
+
+	// GroupSync reconciles the user's NATIVE group memberships from the IdP's groups
+	// claim on each login (the IdP becomes the source of truth — membership is added
+	// for asserted groups and removed for non-asserted ones). Opt-in (default off).
+	// Only existing native groups (provisioned by SCIM or an admin) are touched; an
+	// asserted group with no native counterpart is ignored. If the groups claim is
+	// absent from the id_token, the sync is a no-op.
+	GroupSync bool `yaml:"group_sync"`
+	// GroupsClaim is the id_token claim carrying the group names (default "groups";
+	// some IdPs use "roles").
+	GroupsClaim string `yaml:"groups_claim"`
 }
 
 // GetClientSecret returns the resolved client secret, preferring the per-provider

--- a/internal/core/sso.go
+++ b/internal/core/sso.go
@@ -15,7 +15,9 @@ package core
 import (
 	"context"
 	"crypto/rand"
+	"encoding/base64"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
@@ -32,9 +34,11 @@ const (
 	ssoStateTTL          = 10 * time.Minute
 	EventSSOLogin        = "auth.sso_login"
 	EventSSOJITProvision = "auth.sso_jit_provisioned"
+	EventSSOGroupsSynced = "auth.sso_groups_synced"
 	ssoClockSkew         = 60 * time.Second
 	ssoCompleteSuffix    = "/auth/sso/complete"
 	ssoDefaultRole       = "system_viewer"
+	ssoDefaultGroupClaim = "groups"
 )
 
 // SSOProvider is a resolved OIDC provider whose endpoints have been discovered.
@@ -47,6 +51,9 @@ type SSOProvider struct {
 
 	AutoProvision bool   // JIT-create an account on first login for an unknown identity
 	DefaultRole   string // baseline role for JIT-provisioned users ("" → system_viewer)
+
+	GroupSync   bool   // reconcile native group memberships from the IdP groups claim on login
+	GroupsClaim string // id_token claim carrying group names ("" → "groups")
 }
 
 // SetSSOProviders wires the configured providers (built from config + discovery at
@@ -154,6 +161,12 @@ func (c *KeyorixCore) CompleteSSO(ctx context.Context, providerName, code, state
 		return nil, nil, "", fmt.Errorf("account suspended")
 	}
 
+	// Reconcile native group memberships from the IdP's groups claim (best-effort —
+	// a sync failure must not block an otherwise-valid login).
+	if p.GroupSync {
+		c.syncSSOGroups(ctx, p, user.ID, rawID)
+	}
+
 	session, err := c.mintSession(ctx, user.ID, userAgent, ip)
 	if err != nil {
 		return nil, nil, "", err
@@ -235,6 +248,122 @@ func (c *KeyorixCore) provisionSSOUser(ctx context.Context, p *SSOProvider, sub,
 	c.writeAuditEvent(ctx, EventSSOJITProvision, actorPtr(created.ID), nil,
 		fmt.Sprintf("SSO JIT-provisioned user %d via %s (externalId=%q, role=%s)", created.ID, p.Name, sub, role))
 	return created, nil
+}
+
+// syncSSOGroups reconciles the user's NATIVE group memberships to the groups the IdP
+// asserts in the (already-verified) id_token's configured groups claim. The IdP is
+// the source of truth: the user is added to native groups whose name matches an
+// asserted group and removed from native groups it didn't assert — so revoking a
+// group at the IdP deprovisions the corresponding Keyorix access on next login. It
+// only ever touches MEMBERSHIPS of groups that already exist natively (provisioned by
+// SCIM or an admin); it never creates or deletes groups, and an asserted group with
+// no native counterpart is ignored.
+//
+// Crucially, if the groups claim is ABSENT from the token (vs present-but-empty), the
+// sync is a no-op: many IdPs only emit groups in the userinfo endpoint or under a
+// specific scope, and treating "absent" as "assert no groups" would strip every
+// membership on login. Best-effort: errors are swallowed (the caller must not fail an
+// otherwise-valid login on a sync hiccup), but the net change is audited.
+func (c *KeyorixCore) syncSSOGroups(ctx context.Context, p *SSOProvider, userID uint, rawID string) {
+	claim := strings.TrimSpace(p.GroupsClaim)
+	if claim == "" {
+		claim = ssoDefaultGroupClaim
+	}
+	asserted, present := extractTokenStringList(rawID, claim)
+	if !present {
+		return // IdP did not assert groups in the id_token — leave memberships untouched.
+	}
+	assertedSet := make(map[string]bool, len(asserted))
+	for _, g := range asserted {
+		if g = strings.TrimSpace(g); g != "" {
+			assertedSet[g] = true
+		}
+	}
+
+	nativeGroups, err := c.storage.ListGroups(ctx)
+	if err != nil {
+		return
+	}
+	// Desired native group IDs = native groups whose name the IdP asserted.
+	desired := make(map[uint]bool)
+	for _, g := range nativeGroups {
+		if assertedSet[g.Name] {
+			desired[g.ID] = true
+		}
+	}
+	current, err := c.storage.GetUserGroups(ctx, userID)
+	if err != nil {
+		return
+	}
+	currentSet := make(map[uint]bool, len(current))
+	for _, g := range current {
+		currentSet[g.ID] = true
+	}
+
+	added, removed := 0, 0
+	for id := range desired {
+		if !currentSet[id] {
+			if err := c.storage.AddUserToGroup(ctx, userID, id); err == nil {
+				added++
+			}
+		}
+	}
+	for id := range currentSet {
+		if !desired[id] {
+			if err := c.storage.RemoveUserFromGroup(ctx, userID, id); err == nil {
+				removed++
+			}
+		}
+	}
+	if added > 0 || removed > 0 {
+		c.writeAuditEvent(ctx, EventSSOGroupsSynced, actorPtr(userID), nil,
+			fmt.Sprintf("SSO group sync via %s: user %d (+%d/-%d native group memberships)", p.Name, userID, added, removed))
+	}
+}
+
+// extractTokenStringList pulls a string-list claim from an ALREADY-VERIFIED id_token
+// (verifyIDToken ran on the same raw token immediately before). The claim name is
+// configurable, so it can't be a static struct tag; the verified payload is decoded
+// into a map and the claim coerced from []string, []any (of strings), or a single
+// string. Returns (values, present) — present distinguishes an absent claim from an
+// empty list.
+func extractTokenStringList(raw, claim string) ([]string, bool) {
+	parts := strings.Split(raw, ".")
+	if len(parts) != 3 {
+		return nil, false
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return nil, false
+	}
+	var claims map[string]json.RawMessage
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return nil, false
+	}
+	raw2, ok := claims[claim]
+	if !ok {
+		return nil, false
+	}
+	// Try []string, then []any (coerce string elements), then a single string.
+	var list []string
+	if err := json.Unmarshal(raw2, &list); err == nil {
+		return list, true
+	}
+	var anyList []any
+	if err := json.Unmarshal(raw2, &anyList); err == nil {
+		out := make([]string, 0, len(anyList))
+		for _, v := range anyList {
+			if s, isStr := v.(string); isStr {
+				out = append(out, s)
+			}
+		}
+		return out, true
+	}
+	var single string
+	if err := json.Unmarshal(raw2, &single); err == nil {
+		return []string{single}, true
+	}
+	return nil, true // claim present but an unrecognised shape — treat as empty assertion
 }
 
 // ssoBool unmarshals a JSON boolean OR the strings "true"/"false" — some IdPs send

--- a/internal/core/sso_test.go
+++ b/internal/core/sso_test.go
@@ -240,6 +240,90 @@ func TestProvisionSSOUser(t *testing.T) {
 	})
 }
 
+func TestExtractTokenStringList(t *testing.T) {
+	_, _, key, _ := ssoTestCore(t)
+	tok := func(claims jwt.MapClaims) string { return signToken(t, key, "kid-1", claims) }
+
+	t.Run("string array", func(t *testing.T) {
+		vals, present := extractTokenStringList(tok(jwt.MapClaims{"groups": []string{"admins", "devs"}}), "groups")
+		assert.True(t, present)
+		assert.Equal(t, []string{"admins", "devs"}, vals)
+	})
+
+	t.Run("absent claim → not present", func(t *testing.T) {
+		_, present := extractTokenStringList(tok(jwt.MapClaims{"sub": "x"}), "groups")
+		assert.False(t, present, "an absent claim must be distinguishable from an empty list")
+	})
+
+	t.Run("empty array → present and empty", func(t *testing.T) {
+		vals, present := extractTokenStringList(tok(jwt.MapClaims{"groups": []string{}}), "groups")
+		assert.True(t, present)
+		assert.Empty(t, vals)
+	})
+
+	t.Run("single string coerced to a list", func(t *testing.T) {
+		vals, present := extractTokenStringList(tok(jwt.MapClaims{"groups": "admins"}), "groups")
+		assert.True(t, present)
+		assert.Equal(t, []string{"admins"}, vals)
+	})
+
+	t.Run("configurable claim name", func(t *testing.T) {
+		vals, present := extractTokenStringList(tok(jwt.MapClaims{"roles": []string{"ops"}}), "roles")
+		assert.True(t, present)
+		assert.Equal(t, []string{"ops"}, vals)
+	})
+
+	t.Run("malformed token → not present", func(t *testing.T) {
+		_, present := extractTokenStringList("not-a-jwt", "groups")
+		assert.False(t, present)
+	})
+}
+
+func TestSyncSSOGroups(t *testing.T) {
+	t.Run("authoritative: adds asserted, removes non-asserted native groups", func(t *testing.T) {
+		c, store, key, p := ssoTestCore(t)
+		p.GroupSync = true
+		raw := signToken(t, key, "kid-1", jwt.MapClaims{"groups": []string{"admins", "devs"}})
+		// Native groups: admins(1), devs(2), ops(3). User currently in devs(2), ops(3).
+		store.On("ListGroups", mock.Anything).Return([]*models.Group{{ID: 1, Name: "admins"}, {ID: 2, Name: "devs"}, {ID: 3, Name: "ops"}}, nil)
+		store.On("GetUserGroups", mock.Anything, uint(7)).Return([]*models.Group{{ID: 2, Name: "devs"}, {ID: 3, Name: "ops"}}, nil)
+		store.On("AddUserToGroup", mock.Anything, uint(7), uint(1)).Return(nil)      // admins: asserted, not current → add
+		store.On("RemoveUserFromGroup", mock.Anything, uint(7), uint(3)).Return(nil) // ops: current, not asserted → remove
+		store.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
+
+		c.syncSSOGroups(context.Background(), p, 7, raw)
+
+		store.AssertCalled(t, "AddUserToGroup", mock.Anything, uint(7), uint(1))
+		store.AssertCalled(t, "RemoveUserFromGroup", mock.Anything, uint(7), uint(3))
+		// devs(2) already a member and still asserted → untouched.
+		store.AssertNotCalled(t, "AddUserToGroup", mock.Anything, uint(7), uint(2))
+		store.AssertNotCalled(t, "RemoveUserFromGroup", mock.Anything, uint(7), uint(2))
+	})
+
+	t.Run("ignores asserted groups with no native counterpart", func(t *testing.T) {
+		c, store, key, p := ssoTestCore(t)
+		p.GroupSync = true
+		raw := signToken(t, key, "kid-1", jwt.MapClaims{"groups": []string{"nonexistent"}})
+		store.On("ListGroups", mock.Anything).Return([]*models.Group{{ID: 1, Name: "admins"}}, nil)
+		store.On("GetUserGroups", mock.Anything, uint(7)).Return([]*models.Group{}, nil)
+
+		c.syncSSOGroups(context.Background(), p, 7, raw)
+		store.AssertNotCalled(t, "AddUserToGroup", mock.Anything, mock.Anything, mock.Anything)
+	})
+
+	t.Run("absent groups claim → no-op (never touches memberships)", func(t *testing.T) {
+		c, store, key, p := ssoTestCore(t)
+		p.GroupSync = true
+		raw := signToken(t, key, "kid-1", jwt.MapClaims{"sub": "okta|123"}) // no groups claim
+
+		c.syncSSOGroups(context.Background(), p, 7, raw)
+		// Returns before listing groups — so an IdP that omits groups in the id_token
+		// can't strip a user's memberships.
+		store.AssertNotCalled(t, "ListGroups", mock.Anything)
+		store.AssertNotCalled(t, "RemoveUserFromGroup", mock.Anything, mock.Anything, mock.Anything)
+	})
+}
+
 func TestBeginSSO_BuildsAuthURLWithStateAndNonce(t *testing.T) {
 	c, store, _, _ := ssoTestCore(t)
 	var captured *models.SSOLoginState

--- a/server/main.go
+++ b/server/main.go
@@ -1125,6 +1125,8 @@ func buildSSOProviders(sso config.SSOConfig) (map[string]*core.SSOProvider, core
 			CompleteURL:   completeURL,
 			AutoProvision: pc.AutoProvision,
 			DefaultRole:   pc.DefaultRole,
+			GroupSync:     pc.GroupSync,
+			GroupsClaim:   pc.GroupsClaim,
 		}
 		jwksURIs[pc.Issuer] = disc.JWKSURI
 	}


### PR DESCRIPTION
## What

Completes the SSO identity arc (after JIT user provisioning in #208). With `group_sync` enabled on a provider, each SSO login reconciles the user's **native Keyorix group memberships** from the IdP's groups claim in the verified id_token — so the IdP drives group-based access without a separate SCIM push.

## How

- **Authoritative**: the user is added to native groups matching an asserted group and **removed from native groups it did not assert** — revoking a group at the IdP deprovisions the matching Keyorix access on next login.
- Only groups that **already exist natively** (SCIM-provisioned via #201 or admin-created) are touched; an asserted group with no native counterpart is ignored. Groups are never created or deleted.
- The claim name is configurable (`groups_claim`, default `groups`; some IdPs use `roles`), extracted from the already-verified token (coerces `[]string` / `[]any` / single string).
- Net change audited as `auth.sso_groups_synced`. Best-effort: a sync error never blocks an otherwise-valid login.

## Safety / security

- **Absent claim → no-op.** If the `groups_claim` is *absent* from the id_token (vs present-but-empty), the sync does nothing and returns before touching memberships. Many IdPs only emit groups at the userinfo endpoint or behind a scope — treating "absent" as "assert nothing" would strip every membership on login. Present-empty *does* reconcile (authoritative).
- Group extraction runs only on the token `verifyIDToken` just validated (signature/issuer/audience/expiry/nonce); names are used solely for exact-match map lookup against native groups (no injection surface).
- Authoritative removal is documented with a caveat: don't mix `group_sync` with manual group assignment for SSO users.

## Tests

`TestSyncSSOGroups` (authoritative add/remove; ignores non-native asserted groups; absent-claim no-op never lists/removes), `TestExtractTokenStringList` (string array / absent / empty / single-string / configurable claim / malformed). gofmt clean, golangci-lint 0, gitleaks clean. Only local failure is the known `/sw.js` artifact (green in CI).

## Docs

`CONFIGURATION.md` SSO `group_sync` / `groups_claim` section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)