### PR TITLE
feat(compliance): classify dynamic-secret configs (A.5.12)

### DIFF
--- a/internal/cli/compliance/compliance.go
+++ b/internal/cli/compliance/compliance.go
@@ -55,12 +55,20 @@ type posture struct {
 		TotalActivations  int `json:"total_activations"`
 	} `json:"emergency_access"`
 	Classification struct {
-		TotalSecrets int `json:"total_secrets"`
-		Public       int `json:"public"`
-		Internal     int `json:"internal"`
-		Confidential int `json:"confidential"`
-		Restricted   int `json:"restricted"`
-		Unclassified int `json:"unclassified"`
+		TotalSecrets   int `json:"total_secrets"`
+		Public         int `json:"public"`
+		Internal       int `json:"internal"`
+		Confidential   int `json:"confidential"`
+		Restricted     int `json:"restricted"`
+		Unclassified   int `json:"unclassified"`
+		DynamicConfigs struct {
+			Total        int `json:"total"`
+			Restricted   int `json:"restricted"`
+			Confidential int `json:"confidential"`
+			Internal     int `json:"internal"`
+			Public       int `json:"public"`
+			Unclassified int `json:"unclassified"`
+		} `json:"dynamic_configs"`
 	} `json:"classification"`
 	Anomalies struct {
 		Unacknowledged   int `json:"unacknowledged"`
@@ -141,6 +149,8 @@ var reportCmd = &cobra.Command{
 		fmt.Printf("  restricted / confidential : %d / %d\n", p.Classification.Restricted, p.Classification.Confidential)
 		fmt.Printf("  internal / public         : %d / %d\n", p.Classification.Internal, p.Classification.Public)
 		fmt.Printf("  unclassified              : %d\n", p.Classification.Unclassified)
+		dc := p.Classification.DynamicConfigs
+		fmt.Printf("  dynamic configs (total / restricted / unclassified) : %d / %d / %d\n", dc.Total, dc.Restricted, dc.Unclassified)
 
 		fmt.Println("\nAccess anomalies (NIS2 detection)")
 		fmt.Printf("  open / high-severity : %d / %d\n", p.Anomalies.Unacknowledged, p.Anomalies.HighSeverityOpen)

--- a/internal/core/classify_dynamic_test.go
+++ b/internal/core/classify_dynamic_test.go
@@ -1,0 +1,84 @@
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func makeDynConfig(t *testing.T, c *KeyorixCore, name, classification string) uint {
+	t.Helper()
+	cfg, err := c.CreateDynamicSecretConfig(context.Background(), &CreateDynamicSecretConfigRequest{
+		Name:           name,
+		ProjectID:      1,
+		EnvironmentID:  1,
+		BackendType:    "postgres",
+		AdminDSN:       "postgres://admin:pw@localhost/db",
+		Classification: classification,
+		CreatedBy:      "admin",
+	})
+	require.NoError(t, err)
+	return cfg.ID
+}
+
+func TestCreateDynamicSecretConfig_WithClassification(t *testing.T) {
+	c, _, _, _ := newDynamicTestCore(t)
+
+	id := makeDynConfig(t, c, "analytics-ro", ClassificationConfidential)
+	cfg, err := c.GetDynamicSecretConfig(context.Background(), id)
+	require.NoError(t, err)
+	assert.Equal(t, "confidential", cfg.Classification)
+
+	// Invalid level is rejected at create.
+	_, err = c.CreateDynamicSecretConfig(context.Background(), &CreateDynamicSecretConfigRequest{
+		Name: "bad", ProjectID: 1, EnvironmentID: 1, BackendType: "postgres",
+		AdminDSN: "postgres://x", Classification: "top-secret", CreatedBy: "admin",
+	})
+	require.Error(t, err)
+}
+
+func TestClassifyDynamicSecretConfig(t *testing.T) {
+	c, _, _, _ := newDynamicTestCore(t)
+	ctx := context.Background()
+	id := makeDynConfig(t, c, "prod-admin", "") // starts unclassified
+
+	// Invalid level rejected.
+	_, err := c.ClassifyDynamicSecretConfig(ctx, 1, id, "secret")
+	require.Error(t, err)
+
+	// Set to restricted.
+	updated, err := c.ClassifyDynamicSecretConfig(ctx, 1, id, ClassificationRestricted)
+	require.NoError(t, err)
+	assert.Equal(t, "restricted", updated.Classification)
+
+	// Persisted.
+	reload, err := c.GetDynamicSecretConfig(ctx, id)
+	require.NoError(t, err)
+	assert.Equal(t, "restricted", reload.Classification)
+
+	// Clearing back to "" is allowed.
+	cleared, err := c.ClassifyDynamicSecretConfig(ctx, 1, id, "")
+	require.NoError(t, err)
+	assert.Empty(t, cleared.Classification)
+
+	// Unknown config id errors.
+	_, err = c.ClassifyDynamicSecretConfig(ctx, 1, 9999, ClassificationPublic)
+	require.Error(t, err)
+}
+
+func TestClassificationPosture_CoversDynamicConfigs(t *testing.T) {
+	c, _, _, _ := newDynamicTestCore(t)
+	makeDynConfig(t, c, "a", ClassificationRestricted)
+	makeDynConfig(t, c, "b", ClassificationRestricted)
+	makeDynConfig(t, c, "c", ClassificationInternal)
+	makeDynConfig(t, c, "d", "") // unclassified
+
+	p := c.classificationPosture(context.Background())
+	assert.Equal(t, 4, p.DynamicConfigs.Total)
+	assert.Equal(t, 2, p.DynamicConfigs.Restricted)
+	assert.Equal(t, 1, p.DynamicConfigs.Internal)
+	assert.Equal(t, 1, p.DynamicConfigs.Unclassified)
+	assert.Equal(t, 0, p.DynamicConfigs.Public)
+}

--- a/internal/core/compliance_posture.go
+++ b/internal/core/compliance_posture.go
@@ -74,6 +74,9 @@ type AnomaliesPosture struct {
 }
 
 // ClassificationPosture summarises secret data-classification coverage (A.5.12).
+// The flat fields count STATIC secrets (unchanged for back-compat); DynamicConfigs
+// (and, later, machine entities) extend coverage to the other secret-bearing
+// surfaces so the posture reflects classification across all of them.
 type ClassificationPosture struct {
 	TotalSecrets int `json:"total_secrets"`
 	Public       int `json:"public"`
@@ -81,6 +84,34 @@ type ClassificationPosture struct {
 	Confidential int `json:"confidential"`
 	Restricted   int `json:"restricted"`
 	Unclassified int `json:"unclassified"`
+	// DynamicConfigs counts dynamic-secret configs by classification (A.5.12).
+	DynamicConfigs ClassificationCounts `json:"dynamic_configs"`
+}
+
+// ClassificationCounts is a per-level tally of a set of classifiable entities.
+type ClassificationCounts struct {
+	Total        int `json:"total"`
+	Public       int `json:"public"`
+	Internal     int `json:"internal"`
+	Confidential int `json:"confidential"`
+	Restricted   int `json:"restricted"`
+	Unclassified int `json:"unclassified"`
+}
+
+// classificationCountsFromMap builds ClassificationCounts from a label→count map
+// (the empty label "" is the unclassified bucket).
+func classificationCountsFromMap(m map[string]int) ClassificationCounts {
+	cc := ClassificationCounts{
+		Public:       m[ClassificationPublic],
+		Internal:     m[ClassificationInternal],
+		Confidential: m[ClassificationConfidential],
+		Restricted:   m[ClassificationRestricted],
+		Unclassified: m[""],
+	}
+	for _, n := range m {
+		cc.Total += n
+	}
+	return cc
 }
 
 // RetentionPosture reports the configured data-retention windows (ISO 27001 A.5.33
@@ -224,7 +255,7 @@ func (c *KeyorixCore) classificationPosture(ctx context.Context) ClassificationP
 		}
 		return int(total)
 	}
-	return ClassificationPosture{
+	p := ClassificationPosture{
 		TotalSecrets: count(""),
 		Public:       count(ClassificationPublic),
 		Internal:     count(ClassificationInternal),
@@ -232,6 +263,10 @@ func (c *KeyorixCore) classificationPosture(ctx context.Context) ClassificationP
 		Restricted:   count(ClassificationRestricted),
 		Unclassified: count("unclassified"),
 	}
+	if m, err := c.storage.CountDynamicSecretConfigsByClassification(ctx); err == nil {
+		p.DynamicConfigs = classificationCountsFromMap(m)
+	}
+	return p
 }
 
 // identityPosture counts active users and how many have a second factor (MFA or

--- a/internal/core/dynamic_secrets.go
+++ b/internal/core/dynamic_secrets.go
@@ -27,6 +27,9 @@ type CreateDynamicSecretConfigRequest struct {
 	DefaultTTLSeconds int
 	MaxTTLSeconds     int
 	CreatedBy         string
+	// Classification is an optional data-sensitivity label (A.5.12) for the
+	// credentials this config mints: "" or one of public|internal|confidential|restricted.
+	Classification string
 }
 
 // IssuedLease is the credential returned to the caller once, on issue.
@@ -49,6 +52,9 @@ func (c *KeyorixCore) CreateDynamicSecretConfig(ctx context.Context, req *Create
 	if req.MaxTTLSeconds > 0 && req.DefaultTTLSeconds > req.MaxTTLSeconds {
 		return nil, fmt.Errorf("default_ttl_seconds (%d) cannot exceed max_ttl_seconds (%d)", req.DefaultTTLSeconds, req.MaxTTLSeconds)
 	}
+	if !IsValidClassification(req.Classification) {
+		return nil, fmt.Errorf("classification must be one of public, internal, confidential, restricted (or empty)")
+	}
 	dsnEnc, dsnMeta, err := c.encryptAuthSecret(req.AdminDSN)
 	if err != nil {
 		return nil, fmt.Errorf("failed to encrypt admin DSN: %w", err)
@@ -63,6 +69,7 @@ func (c *KeyorixCore) CreateDynamicSecretConfig(ctx context.Context, req *Create
 		CreationTemplate:  req.CreationTemplate,
 		DefaultTTLSeconds: req.DefaultTTLSeconds,
 		MaxTTLSeconds:     req.MaxTTLSeconds,
+		Classification:    req.Classification,
 		CreatedBy:         req.CreatedBy,
 		CreatedAt:         c.now(),
 		UpdatedAt:         c.now(),
@@ -82,6 +89,36 @@ func (c *KeyorixCore) GetDynamicSecretConfig(ctx context.Context, id uint) (*mod
 
 func (c *KeyorixCore) ListDynamicSecretConfigs(ctx context.Context, projectID, environmentID uint) ([]*models.DynamicSecretConfig, error) {
 	return c.storage.ListDynamicSecretConfigs(ctx, projectID, environmentID)
+}
+
+// ClassifyDynamicSecretConfig sets (or clears, with "") the data-classification
+// label on a dynamic-secret config and audits the change with a before/after diff.
+func (c *KeyorixCore) ClassifyDynamicSecretConfig(ctx context.Context, actorID uint, configID uint, level string) (*models.DynamicSecretConfig, error) {
+	if configID == 0 {
+		return nil, fmt.Errorf("config id is required")
+	}
+	if !IsValidClassification(level) {
+		return nil, fmt.Errorf("classification must be one of public, internal, confidential, restricted (or empty to clear)")
+	}
+	cfg, err := c.storage.GetDynamicSecretConfig(ctx, configID)
+	if err != nil {
+		return nil, fmt.Errorf("dynamic-secret config not found: %w", err)
+	}
+	if cfg.Classification == level {
+		return cfg, nil // no-op
+	}
+	old := cfg.Classification
+	cfg.Classification = level
+	cfg.UpdatedAt = c.now()
+	if err := c.storage.UpdateDynamicSecretConfig(ctx, cfg); err != nil {
+		return nil, err
+	}
+	aid := actorID
+	pid := cfg.ProjectID
+	diff := fmt.Sprintf(`{"classification":{"before":%q,"after":%q}}`, old, level)
+	c.writeAuditEventDiff(ctx, "dynamic_secret.config_classified", &aid, nil, &pid, "",
+		fmt.Sprintf("dynamic-secret config %q classification set to %q", cfg.Name, level), diff)
+	return cfg, nil
 }
 
 func (c *KeyorixCore) ListDynamicSecretLeases(ctx context.Context, configID uint) ([]*models.DynamicSecretLease, error) {

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -1543,6 +1543,12 @@ func (m *MockStorage) GetDynamicSecretConfig(_ context.Context, _ uint) (*models
 func (m *MockStorage) ListDynamicSecretConfigs(_ context.Context, _, _ uint) ([]*models.DynamicSecretConfig, error) {
 	return nil, nil
 }
+func (m *MockStorage) UpdateDynamicSecretConfig(_ context.Context, _ *models.DynamicSecretConfig) error {
+	return nil
+}
+func (m *MockStorage) CountDynamicSecretConfigsByClassification(_ context.Context) (map[string]int, error) {
+	return nil, nil
+}
 func (m *MockStorage) CreateDynamicSecretLease(_ context.Context, l *models.DynamicSecretLease) (*models.DynamicSecretLease, error) {
 	return l, nil
 }

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -392,6 +392,10 @@ type Storage interface {
 	CreateDynamicSecretConfig(ctx context.Context, c *models.DynamicSecretConfig) (*models.DynamicSecretConfig, error)
 	GetDynamicSecretConfig(ctx context.Context, id uint) (*models.DynamicSecretConfig, error)
 	ListDynamicSecretConfigs(ctx context.Context, projectID, environmentID uint) ([]*models.DynamicSecretConfig, error)
+	UpdateDynamicSecretConfig(ctx context.Context, c *models.DynamicSecretConfig) error
+	// CountDynamicSecretConfigsByClassification returns install-wide config counts
+	// keyed by classification label ("" = unclassified) for the compliance posture.
+	CountDynamicSecretConfigsByClassification(ctx context.Context) (map[string]int, error)
 	CreateDynamicSecretLease(ctx context.Context, l *models.DynamicSecretLease) (*models.DynamicSecretLease, error)
 	GetDynamicSecretLease(ctx context.Context, leaseID string) (*models.DynamicSecretLease, error)
 	ListDynamicSecretLeases(ctx context.Context, configID uint) ([]*models.DynamicSecretLease, error)

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -347,6 +347,10 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 				return fmt.Errorf("failed to add dynamic_secret_configs.max_ttl_seconds column: %w", err)
 			}
 		}
+		// Data classification (ISO A.5.12). Additive ("" = unclassified).
+		if tableExists(db, "dynamic_secret_configs") && !columnExists(db, "dynamic_secret_configs", "classification") {
+			db.Exec("ALTER TABLE dynamic_secret_configs ADD COLUMN classification TEXT DEFAULT ''")
+		}
 	}
 	if !dynLeaseExists {
 		if err := db.AutoMigrate(&models.DynamicSecretLease{}); err != nil {

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -449,9 +449,14 @@ type DynamicSecretConfig struct {
 	// MaxTTLSeconds caps the lifetime of any lease from this config (issue + all
 	// renewals), regardless of the TTL a caller requests. 0 = no ceiling.
 	MaxTTLSeconds int
-	CreatedBy     string
-	CreatedAt     time.Time
-	UpdatedAt     time.Time
+	// Classification is the data-sensitivity label of the credentials this config
+	// mints (ISO 27001 A.5.12/A.5.13): "" = unclassified, else one of
+	// public|internal|confidential|restricted. Folds into the classification posture
+	// so dynamic credentials are covered alongside static secrets.
+	Classification string `gorm:"index"`
+	CreatedBy      string
+	CreatedAt      time.Time
+	UpdatedAt      time.Time
 }
 
 // DynamicSecretLease is one issued credential: a short-lived role on the target

--- a/internal/storage/store/local_dynamic.go
+++ b/internal/storage/store/local_dynamic.go
@@ -36,6 +36,28 @@ func (ls *LocalStorage) ListDynamicSecretConfigs(ctx context.Context, projectID,
 	return cs, nil
 }
 
+func (ls *LocalStorage) UpdateDynamicSecretConfig(ctx context.Context, c *models.DynamicSecretConfig) error {
+	return ls.db.WithContext(ctx).Save(c).Error
+}
+
+// CountDynamicSecretConfigsByClassification returns config counts keyed by
+// classification label ("" = unclassified), install-wide, via a GROUP BY.
+func (ls *LocalStorage) CountDynamicSecretConfigsByClassification(ctx context.Context) (map[string]int, error) {
+	var rows []struct {
+		Classification string
+		N              int
+	}
+	if err := ls.db.WithContext(ctx).Model(&models.DynamicSecretConfig{}).
+		Select("classification, COUNT(*) AS n").Group("classification").Scan(&rows).Error; err != nil {
+		return nil, err
+	}
+	out := make(map[string]int, len(rows))
+	for _, r := range rows {
+		out[r.Classification] = r.N
+	}
+	return out, nil
+}
+
 func (ls *LocalStorage) CreateDynamicSecretLease(ctx context.Context, l *models.DynamicSecretLease) (*models.DynamicSecretLease, error) {
 	if err := ls.db.WithContext(ctx).Create(l).Error; err != nil {
 		return nil, err

--- a/internal/storage/store/remote_dynamic.go
+++ b/internal/storage/store/remote_dynamic.go
@@ -18,6 +18,12 @@ func (rs *RemoteStorage) GetDynamicSecretConfig(_ context.Context, _ uint) (*mod
 func (rs *RemoteStorage) ListDynamicSecretConfigs(_ context.Context, _, _ uint) ([]*models.DynamicSecretConfig, error) {
 	return nil, remoteUnsupported("ListDynamicSecretConfigs")
 }
+func (rs *RemoteStorage) UpdateDynamicSecretConfig(_ context.Context, _ *models.DynamicSecretConfig) error {
+	return remoteUnsupported("UpdateDynamicSecretConfig")
+}
+func (rs *RemoteStorage) CountDynamicSecretConfigsByClassification(_ context.Context) (map[string]int, error) {
+	return nil, remoteUnsupported("CountDynamicSecretConfigsByClassification")
+}
 func (rs *RemoteStorage) CreateDynamicSecretLease(_ context.Context, _ *models.DynamicSecretLease) (*models.DynamicSecretLease, error) {
 	return nil, remoteUnsupported("CreateDynamicSecretLease")
 }

--- a/server/http/handlers/dynamic_secrets.go
+++ b/server/http/handlers/dynamic_secrets.go
@@ -70,6 +70,7 @@ func (h *DynamicSecretHandler) CreateConfig(w http.ResponseWriter, r *http.Reque
 		CreationTemplate  string `json:"creation_template"`
 		DefaultTTLSeconds int    `json:"default_ttl_seconds"`
 		MaxTTLSeconds     int    `json:"max_ttl_seconds"`
+		Classification    string `json:"classification"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		sendError(w, "BadRequest", "Invalid request body", http.StatusBadRequest, nil)
@@ -89,6 +90,7 @@ func (h *DynamicSecretHandler) CreateConfig(w http.ResponseWriter, r *http.Reque
 		CreationTemplate:  body.CreationTemplate,
 		DefaultTTLSeconds: body.DefaultTTLSeconds,
 		MaxTTLSeconds:     body.MaxTTLSeconds,
+		Classification:    body.Classification,
 		CreatedBy:         userCtx.Username,
 	})
 	if err != nil {
@@ -242,6 +244,29 @@ func (h *DynamicSecretHandler) RevokeAllLeases(w http.ResponseWriter, r *http.Re
 	}, fmt.Sprintf("Revoked %d active lease(s); %d failed.", revoked, failed))
 }
 
+// ClassifyConfig handles PATCH /api/v1/dynamic-secrets/configs/{id}/classification —
+// sets (or clears) the config's data-classification label.
+func (h *DynamicSecretHandler) ClassifyConfig(w http.ResponseWriter, r *http.Request) {
+	userCtx := middleware.GetUserFromContext(r.Context())
+	cfg, ok := h.loadAuthorizedConfig(w, r, "secrets.write")
+	if !ok {
+		return
+	}
+	var body struct {
+		Classification string `json:"classification"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		sendError(w, "BadRequest", "Invalid request body", http.StatusBadRequest, nil)
+		return
+	}
+	updated, err := h.coreService.ClassifyDynamicSecretConfig(r.Context(), userCtx.UserID, cfg.ID, body.Classification)
+	if err != nil {
+		sendError(w, "Error", err.Error(), http.StatusBadRequest, nil)
+		return
+	}
+	sendSuccess(w, sanitizeConfig(updated), "Classification updated.")
+}
+
 // loadAuthorizedConfig loads the {id} config and authorizes the caller against
 // its scope. It writes the error response and returns ok=false on failure.
 func (h *DynamicSecretHandler) loadAuthorizedConfig(w http.ResponseWriter, r *http.Request, perm string) (*models.DynamicSecretConfig, bool) {
@@ -275,6 +300,7 @@ func sanitizeConfig(c *models.DynamicSecretConfig) map[string]interface{} {
 		"creation_template":   c.CreationTemplate,
 		"default_ttl_seconds": c.DefaultTTLSeconds,
 		"max_ttl_seconds":     c.MaxTTLSeconds,
+		"classification":      c.Classification,
 		"created_by":          c.CreatedBy,
 		"created_at":          c.CreatedAt,
 	}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -352,6 +352,7 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.Post("/configs", dynamicSecretHandler.CreateConfig)
 			r.Get("/configs", dynamicSecretHandler.ListConfigs)
 			r.Get("/configs/{id}", dynamicSecretHandler.GetConfig)
+			r.Patch("/configs/{id}/classification", dynamicSecretHandler.ClassifyConfig)
 			r.Post("/configs/{id}/issue", dynamicSecretHandler.IssueLease)
 			r.Get("/configs/{id}/leases", dynamicSecretHandler.ListLeases)
 			r.Post("/configs/{id}/revoke-all", dynamicSecretHandler.RevokeAllLeases)


### PR DESCRIPTION
## What

Extends data classification (ISO 27001 A.5.12/A.5.13), which today covers only static secrets, to **dynamic-secret configs** (ADR-035) — so the credentials a config mints carry a sensitivity tier and the compliance classification posture reflects them alongside static secrets. First of the "1 2 3" classification batch (machine identities + machine credentials follow in the next PR).

## How

- **Model**: `DynamicSecretConfig.Classification` (indexed; additive `ALTER TABLE` migration following the SecretNode pattern).
- **Core**: `CreateDynamicSecretConfigRequest.Classification` (validated at create via `IsValidClassification`); `ClassifyDynamicSecretConfig` sets/clears the label and audits a before/after diff (`dynamic_secret.config_classified`).
- **Storage**: `UpdateDynamicSecretConfig` + `CountDynamicSecretConfigsByClassification` (GROUP BY) added to the interface + local/remote(stub)/mock.
- **Posture**: `ClassificationPosture` gains a reusable `ClassificationCounts` and a `DynamicConfigs` tally — **existing static fields unchanged** (back-compat for the web UI). The `compliance report` CLI prints a dynamic-configs line.
- **HTTP**: `PATCH /api/v1/dynamic-secrets/configs/{id}/classification` (in-handler `secrets.write` authz, mirroring the other dynamic-secret routes); create body + sanitized output carry `classification`.

## Tests

`classify_dynamic_test.go` (real-SQLite dynamic core): create-with-classification (+ invalid rejected), classify set/clear/invalid-level/unknown-id, posture coverage tally. gofmt clean, golangci-lint 0, gitleaks clean.

The new PATCH route is verified by the existing `TestEveryMutatingRouteDeniesReadOnly` walk (returns 404/403 for a read-only persona, never 2xx). The only local failures in that test are pre-existing local-only artifacts (`/sw.js` web-embedding, and the `system.read` evidence/verify POST) — green in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)