### PR TITLE
feat(compliance): classify machine identities & credentials (A.5.12)

### DIFF
--- a/internal/cli/compliance/compliance.go
+++ b/internal/cli/compliance/compliance.go
@@ -22,6 +22,16 @@ var ComplianceCmd = &cobra.Command{
 	Short: "Deployment controls-posture report (ISO 27001 / SOC 2 / NIS2 / DORA)",
 }
 
+// classCounts mirrors core.ClassificationCounts for the non-static-secret entities.
+type classCounts struct {
+	Total        int `json:"total"`
+	Public       int `json:"public"`
+	Internal     int `json:"internal"`
+	Confidential int `json:"confidential"`
+	Restricted   int `json:"restricted"`
+	Unclassified int `json:"unclassified"`
+}
+
 type posture struct {
 	GeneratedAt    string `json:"generated_at"`
 	AuditIntegrity struct {
@@ -55,20 +65,15 @@ type posture struct {
 		TotalActivations  int `json:"total_activations"`
 	} `json:"emergency_access"`
 	Classification struct {
-		TotalSecrets   int `json:"total_secrets"`
-		Public         int `json:"public"`
-		Internal       int `json:"internal"`
-		Confidential   int `json:"confidential"`
-		Restricted     int `json:"restricted"`
-		Unclassified   int `json:"unclassified"`
-		DynamicConfigs struct {
-			Total        int `json:"total"`
-			Restricted   int `json:"restricted"`
-			Confidential int `json:"confidential"`
-			Internal     int `json:"internal"`
-			Public       int `json:"public"`
-			Unclassified int `json:"unclassified"`
-		} `json:"dynamic_configs"`
+		TotalSecrets       int         `json:"total_secrets"`
+		Public             int         `json:"public"`
+		Internal           int         `json:"internal"`
+		Confidential       int         `json:"confidential"`
+		Restricted         int         `json:"restricted"`
+		Unclassified       int         `json:"unclassified"`
+		DynamicConfigs     classCounts `json:"dynamic_configs"`
+		MachineIdentities  classCounts `json:"machine_identities"`
+		MachineCredentials classCounts `json:"machine_credentials"`
 	} `json:"classification"`
 	Anomalies struct {
 		Unacknowledged   int `json:"unacknowledged"`
@@ -150,7 +155,11 @@ var reportCmd = &cobra.Command{
 		fmt.Printf("  internal / public         : %d / %d\n", p.Classification.Internal, p.Classification.Public)
 		fmt.Printf("  unclassified              : %d\n", p.Classification.Unclassified)
 		dc := p.Classification.DynamicConfigs
-		fmt.Printf("  dynamic configs (total / restricted / unclassified) : %d / %d / %d\n", dc.Total, dc.Restricted, dc.Unclassified)
+		fmt.Printf("  dynamic configs (total / restricted / unclassified)     : %d / %d / %d\n", dc.Total, dc.Restricted, dc.Unclassified)
+		mi := p.Classification.MachineIdentities
+		fmt.Printf("  machine identities (total / restricted / unclassified)  : %d / %d / %d\n", mi.Total, mi.Restricted, mi.Unclassified)
+		mc := p.Classification.MachineCredentials
+		fmt.Printf("  machine credentials (total / restricted / unclassified) : %d / %d / %d\n", mc.Total, mc.Restricted, mc.Unclassified)
 
 		fmt.Println("\nAccess anomalies (NIS2 detection)")
 		fmt.Printf("  open / high-severity : %d / %d\n", p.Anomalies.Unacknowledged, p.Anomalies.HighSeverityOpen)

--- a/internal/cli/machine/create.go
+++ b/internal/cli/machine/create.go
@@ -10,10 +10,11 @@ import (
 )
 
 var (
-	createProjectName string
-	createName        string
-	createType        string
-	createDescription string
+	createProjectName    string
+	createName           string
+	createType           string
+	createDescription    string
+	createClassification string
 )
 
 var createCmd = &cobra.Command{
@@ -27,6 +28,7 @@ func init() {
 	createCmd.Flags().StringVar(&createName, "name", "", "Machine identity name (required)")
 	createCmd.Flags().StringVar(&createType, "type", "other", "Identity type: ci | k8s | service | automation | other")
 	createCmd.Flags().StringVar(&createDescription, "description", "", "Description")
+	createCmd.Flags().StringVar(&createClassification, "classification", "", "Data classification: public | internal | confidential | restricted")
 }
 
 func runCreate(cmd *cobra.Command, args []string) error {
@@ -41,9 +43,10 @@ func runCreate(cmd *cobra.Command, args []string) error {
 
 	if rc, ok := common.NewRemoteClient(); ok {
 		body := map[string]interface{}{
-			"name":          createName,
-			"identity_type": createType,
-			"description":   createDescription,
+			"name":           createName,
+			"identity_type":  createType,
+			"description":    createDescription,
+			"classification": createClassification,
 		}
 		var resp struct {
 			MachineIdentity models.MachineIdentity `json:"machine_identity"`
@@ -62,7 +65,7 @@ func runCreate(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to initialize service: %w", err)
 	}
 	// Local mode has no authenticated user; record a system (0) creator.
-	m, err := svc.CreateMachineIdentity(ctx, projectID, createName, createType, createDescription, 0)
+	m, err := svc.CreateMachineIdentity(ctx, projectID, createName, createType, createDescription, createClassification, 0)
 	if err != nil {
 		return fmt.Errorf("failed to create machine identity: %w", err)
 	}

--- a/internal/core/classify_machine_test.go
+++ b/internal/core/classify_machine_test.go
@@ -1,0 +1,101 @@
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClassifyMachineIdentity(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("sets the label and audits", func(t *testing.T) {
+		store := new(MockStorage)
+		c := newMachineCore(store)
+		store.On("GetMachineIdentity", mock.Anything, uint(1)).Return(&models.MachineIdentity{ID: 1, ProjectID: 2, Name: "ci"}, nil)
+		var saved *models.MachineIdentity
+		store.On("UpdateMachineIdentity", mock.Anything, mock.MatchedBy(func(m *models.MachineIdentity) bool {
+			saved = m
+			return true
+		})).Return(nil)
+		store.On("LogAuditEvent", mock.Anything, mock.MatchedBy(func(e *models.AuditEvent) bool {
+			return e.EventType == "machine_identity.classified"
+		})).Return(nil)
+
+		m, err := c.ClassifyMachineIdentity(ctx, 2, 1, ClassificationRestricted, 9)
+		require.NoError(t, err)
+		assert.Equal(t, "restricted", m.Classification)
+		assert.Equal(t, "restricted", saved.Classification)
+	})
+
+	t.Run("invalid level rejected", func(t *testing.T) {
+		store := new(MockStorage)
+		c := newMachineCore(store)
+		_, err := c.ClassifyMachineIdentity(ctx, 2, 1, "secret", 9)
+		require.Error(t, err)
+		store.AssertNotCalled(t, "GetMachineIdentity", mock.Anything, mock.Anything)
+	})
+
+	t.Run("cross-project machine is not reachable", func(t *testing.T) {
+		store := new(MockStorage)
+		c := newMachineCore(store)
+		store.On("GetMachineIdentity", mock.Anything, uint(1)).Return(&models.MachineIdentity{ID: 1, ProjectID: 2}, nil)
+		_, err := c.ClassifyMachineIdentity(ctx, 999, 1, ClassificationInternal, 9) // wrong project
+		require.Error(t, err)
+		store.AssertNotCalled(t, "UpdateMachineIdentity", mock.Anything, mock.Anything)
+	})
+}
+
+func TestClassifyMachineToken(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("sets the label on a credential of the machine", func(t *testing.T) {
+		store := new(MockStorage)
+		c := newMachineCore(store)
+		store.On("GetMachineIdentity", mock.Anything, uint(1)).Return(&models.MachineIdentity{ID: 1, ProjectID: 2}, nil)
+		store.On("GetMachineIdentityCredentialByID", mock.Anything, uint(5)).Return(&models.MachineIdentityCredential{ID: 5, MachineIdentityID: 1}, nil)
+		store.On("UpdateMachineIdentityCredential", mock.Anything, mock.MatchedBy(func(cr *models.MachineIdentityCredential) bool {
+			return cr.Classification == "confidential"
+		})).Return(nil)
+		store.On("LogAuditEvent", mock.Anything, mock.MatchedBy(func(e *models.AuditEvent) bool {
+			return e.EventType == "machine_identity.token_classified"
+		})).Return(nil)
+
+		cred, err := c.ClassifyMachineToken(ctx, 2, 1, 5, ClassificationConfidential, 9)
+		require.NoError(t, err)
+		assert.Equal(t, "confidential", cred.Classification)
+	})
+
+	t.Run("credential of another machine is not reachable", func(t *testing.T) {
+		store := new(MockStorage)
+		c := newMachineCore(store)
+		store.On("GetMachineIdentity", mock.Anything, uint(1)).Return(&models.MachineIdentity{ID: 1, ProjectID: 2}, nil)
+		store.On("GetMachineIdentityCredentialByID", mock.Anything, uint(5)).Return(&models.MachineIdentityCredential{ID: 5, MachineIdentityID: 99}, nil)
+		_, err := c.ClassifyMachineToken(ctx, 2, 1, 5, ClassificationPublic, 9)
+		require.Error(t, err)
+		store.AssertNotCalled(t, "UpdateMachineIdentityCredential", mock.Anything, mock.Anything)
+	})
+}
+
+func TestClassificationPosture_CoversMachineEntities(t *testing.T) {
+	store := new(MockStorage)
+	c := newMachineCore(store)
+	// Static secrets + dynamic configs are not the focus here; let their counts be 0/err.
+	store.On("ListSecrets", mock.Anything, mock.Anything).Return(nil, int64(0), assertErr())
+	store.On("CountDynamicSecretConfigsByClassification", mock.Anything).Return(map[string]int(nil), assertErr())
+	store.On("CountMachineIdentitiesByClassification", mock.Anything).Return(map[string]int{"restricted": 2, "": 1}, nil)
+	store.On("CountMachineIdentityCredentialsByClassification", mock.Anything).Return(map[string]int{"confidential": 3}, nil)
+
+	p := c.classificationPosture(context.Background())
+	assert.Equal(t, 3, p.MachineIdentities.Total)
+	assert.Equal(t, 2, p.MachineIdentities.Restricted)
+	assert.Equal(t, 1, p.MachineIdentities.Unclassified)
+	assert.Equal(t, 3, p.MachineCredentials.Total)
+	assert.Equal(t, 3, p.MachineCredentials.Confidential)
+}
+
+func assertErr() error { return context.Canceled }

--- a/internal/core/compliance_posture.go
+++ b/internal/core/compliance_posture.go
@@ -86,6 +86,10 @@ type ClassificationPosture struct {
 	Unclassified int `json:"unclassified"`
 	// DynamicConfigs counts dynamic-secret configs by classification (A.5.12).
 	DynamicConfigs ClassificationCounts `json:"dynamic_configs"`
+	// MachineIdentities counts machine identities by classification (A.5.12).
+	MachineIdentities ClassificationCounts `json:"machine_identities"`
+	// MachineCredentials counts machine-token credentials by classification (A.5.12).
+	MachineCredentials ClassificationCounts `json:"machine_credentials"`
 }
 
 // ClassificationCounts is a per-level tally of a set of classifiable entities.
@@ -265,6 +269,12 @@ func (c *KeyorixCore) classificationPosture(ctx context.Context) ClassificationP
 	}
 	if m, err := c.storage.CountDynamicSecretConfigsByClassification(ctx); err == nil {
 		p.DynamicConfigs = classificationCountsFromMap(m)
+	}
+	if m, err := c.storage.CountMachineIdentitiesByClassification(ctx); err == nil {
+		p.MachineIdentities = classificationCountsFromMap(m)
+	}
+	if m, err := c.storage.CountMachineIdentityCredentialsByClassification(ctx); err == nil {
+		p.MachineCredentials = classificationCountsFromMap(m)
 	}
 	return p
 }

--- a/internal/core/machine_identities.go
+++ b/internal/core/machine_identities.go
@@ -59,7 +59,7 @@ func canTransitionMachine(from, to string) bool {
 }
 
 // CreateMachineIdentity creates an active machine identity in a project.
-func (c *KeyorixCore) CreateMachineIdentity(ctx context.Context, projectID uint, name, identityType, description string, createdBy uint) (*models.MachineIdentity, error) {
+func (c *KeyorixCore) CreateMachineIdentity(ctx context.Context, projectID uint, name, identityType, description, classification string, createdBy uint) (*models.MachineIdentity, error) {
 	if projectID == 0 || name == "" {
 		return nil, fmt.Errorf("project ID and name are required")
 	}
@@ -69,16 +69,20 @@ func (c *KeyorixCore) CreateMachineIdentity(ctx context.Context, projectID uint,
 	if _, ok := validMachineTypes[identityType]; !ok {
 		return nil, fmt.Errorf("invalid identity_type %q (want ci|k8s|service|automation|other)", identityType)
 	}
+	if !IsValidClassification(classification) {
+		return nil, fmt.Errorf("classification must be one of public, internal, confidential, restricted (or empty)")
+	}
 	now := c.now()
 	m := &models.MachineIdentity{
-		ProjectID:    projectID,
-		Name:         name,
-		IdentityType: identityType,
-		State:        MachineActive,
-		Description:  description,
-		CreatedBy:    createdBy,
-		CreatedAt:    now,
-		UpdatedAt:    now,
+		ProjectID:      projectID,
+		Name:           name,
+		IdentityType:   identityType,
+		State:          MachineActive,
+		Description:    description,
+		Classification: classification,
+		CreatedBy:      createdBy,
+		CreatedAt:      now,
+		UpdatedAt:      now,
 	}
 	created, err := c.storage.CreateMachineIdentity(ctx, m)
 	if err != nil {
@@ -115,6 +119,32 @@ func (c *KeyorixCore) TransitionMachineIdentity(ctx context.Context, projectID, 
 		return nil, fmt.Errorf("failed to update machine identity: %w", err)
 	}
 	c.logMachineEvent(ctx, "machine_identity."+machineVerb(to), m, actorID)
+	return m, nil
+}
+
+// ClassifyMachineIdentity sets (or clears, with "") the data-classification label
+// on a machine identity, project-scoped (cross-project guard), and audits the change.
+func (c *KeyorixCore) ClassifyMachineIdentity(ctx context.Context, projectID, id uint, level string, actorID uint) (*models.MachineIdentity, error) {
+	if !IsValidClassification(level) {
+		return nil, fmt.Errorf("classification must be one of public, internal, confidential, restricted (or empty to clear)")
+	}
+	m, err := c.machineInProject(ctx, projectID, id)
+	if err != nil {
+		return nil, err
+	}
+	if m.Classification == level {
+		return m, nil // no-op
+	}
+	old := m.Classification
+	m.Classification = level
+	m.UpdatedAt = c.now()
+	if err := c.storage.UpdateMachineIdentity(ctx, m); err != nil {
+		return nil, fmt.Errorf("failed to update machine identity: %w", err)
+	}
+	aid, pid := actorID, m.ProjectID
+	diff := fmt.Sprintf(`{"classification":{"before":%q,"after":%q}}`, old, level)
+	c.writeAuditEventDiff(ctx, "machine_identity.classified", &aid, nil, &pid, "",
+		fmt.Sprintf("machine identity %d (%s) classification set to %q", m.ID, m.Name, level), diff)
 	return m, nil
 }
 

--- a/internal/core/machine_identities_test.go
+++ b/internal/core/machine_identities_test.go
@@ -50,7 +50,7 @@ func TestCreateMachineIdentity(t *testing.T) {
 			return e.EventType == "machine_identity.created"
 		})).Return(nil)
 
-		m, err := c.CreateMachineIdentity(ctx, 1, "ci-runner", MachineTypeCI, "GitHub Actions", 9)
+		m, err := c.CreateMachineIdentity(ctx, 1, "ci-runner", MachineTypeCI, "GitHub Actions", "", 9)
 		require.NoError(t, err)
 		assert.Equal(t, MachineActive, m.State)
 		store.AssertExpectations(t)
@@ -59,7 +59,7 @@ func TestCreateMachineIdentity(t *testing.T) {
 	t.Run("rejects an unknown identity type", func(t *testing.T) {
 		store := new(MockStorage)
 		c := newMachineCore(store)
-		_, err := c.CreateMachineIdentity(context.Background(), 1, "x", "robot", "", 9)
+		_, err := c.CreateMachineIdentity(context.Background(), 1, "x", "robot", "", "", 9)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "invalid identity_type")
 		store.AssertNotCalled(t, "CreateMachineIdentity", mock.Anything, mock.Anything)
@@ -74,7 +74,7 @@ func TestCreateMachineIdentity(t *testing.T) {
 		})).Return(&models.MachineIdentity{ID: 11, IdentityType: MachineTypeOther, State: MachineActive}, nil)
 		store.On("LogAuditEvent", ctx, mock.Anything).Return(nil)
 
-		_, err := c.CreateMachineIdentity(ctx, 1, "x", "", "", 9)
+		_, err := c.CreateMachineIdentity(ctx, 1, "x", "", "", "", 9)
 		require.NoError(t, err)
 	})
 }

--- a/internal/core/machine_token.go
+++ b/internal/core/machine_token.go
@@ -47,13 +47,20 @@ func (c *KeyorixCore) machineInProject(ctx context.Context, projectID, machineID
 // IssueMachineToken mints an opaque bearer token for an active machine identity.
 // The raw token is returned once for out-of-band delivery; only its SHA-256 hash
 // is stored. Issuing requires the machine to be active and in the given project.
-func (c *KeyorixCore) IssueMachineToken(ctx context.Context, projectID, machineID uint, name string, expiresAt *time.Time, actorID uint) (*IssueMachineTokenResult, error) {
+func (c *KeyorixCore) IssueMachineToken(ctx context.Context, projectID, machineID uint, name string, expiresAt *time.Time, classification string, actorID uint) (*IssueMachineTokenResult, error) {
 	m, err := c.machineInProject(ctx, projectID, machineID)
 	if err != nil {
 		return nil, err
 	}
 	if m.State != MachineActive {
 		return nil, fmt.Errorf("cannot issue a token for a %s machine identity (must be active)", m.State)
+	}
+	if !IsValidClassification(classification) {
+		return nil, fmt.Errorf("classification must be one of public, internal, confidential, restricted (or empty)")
+	}
+	// Default a token's classification to its machine identity's tier when unset.
+	if classification == "" {
+		classification = m.Classification
 	}
 
 	b := make([]byte, 32)
@@ -68,6 +75,7 @@ func (c *KeyorixCore) IssueMachineToken(ctx context.Context, projectID, machineI
 		TokenHash:         sha256Hex(raw),
 		TokenPrefix:       raw[:len(machineTokenPrefix)+6], // "kx_machine_ab12cd"
 		ExpiresAt:         expiresAt,
+		Classification:    classification,
 		CreatedAt:         c.now(),
 	}
 	created, err := c.storage.CreateMachineIdentityCredential(ctx, cred)
@@ -103,6 +111,36 @@ func (c *KeyorixCore) RevokeMachineToken(ctx context.Context, projectID, machine
 	}
 	c.logMachineEvent(ctx, "machine_identity.token_revoked", m, actorID)
 	return nil
+}
+
+// ClassifyMachineToken sets (or clears, with "") the data-classification label on a
+// machine credential, after verifying the machine belongs to the project and the
+// credential to the machine. Audited.
+func (c *KeyorixCore) ClassifyMachineToken(ctx context.Context, projectID, machineID, credentialID uint, level string, actorID uint) (*models.MachineIdentityCredential, error) {
+	if !IsValidClassification(level) {
+		return nil, fmt.Errorf("classification must be one of public, internal, confidential, restricted (or empty to clear)")
+	}
+	m, err := c.machineInProject(ctx, projectID, machineID)
+	if err != nil {
+		return nil, err
+	}
+	cred, err := c.storage.GetMachineIdentityCredentialByID(ctx, credentialID)
+	if err != nil || cred.MachineIdentityID != machineID {
+		return nil, fmt.Errorf("token not found")
+	}
+	if cred.Classification == level {
+		return cred, nil // no-op
+	}
+	old := cred.Classification
+	cred.Classification = level
+	if err := c.storage.UpdateMachineIdentityCredential(ctx, cred); err != nil {
+		return nil, err
+	}
+	aid, pid := actorID, m.ProjectID
+	diff := fmt.Sprintf(`{"classification":{"before":%q,"after":%q}}`, old, level)
+	c.writeAuditEventDiff(ctx, "machine_identity.token_classified", &aid, nil, &pid, "",
+		fmt.Sprintf("machine credential %d (machine %d) classification set to %q", cred.ID, machineID, level), diff)
+	return cred, nil
 }
 
 // ValidateMachineToken resolves a raw machine token to its identity and granted

--- a/internal/core/machine_token_test.go
+++ b/internal/core/machine_token_test.go
@@ -19,13 +19,13 @@ func TestIssueMachineToken_ActiveOnly(t *testing.T) {
 	store.On("GetMachineIdentity", mock.Anything, uint(1)).Return(&models.MachineIdentity{ID: 1, ProjectID: 2, State: MachineSuspended}, nil).Once()
 	c := NewKeyorixCore(store)
 	c.now = func() time.Time { return fixed }
-	_, err := c.IssueMachineToken(context.Background(), 2, 1, "ci", nil, 7)
+	_, err := c.IssueMachineToken(context.Background(), 2, 1, "ci", nil, "", 7)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "must be active")
 
 	// Wrong project → not found (cross-project IDOR guard).
 	store.On("GetMachineIdentity", mock.Anything, uint(1)).Return(&models.MachineIdentity{ID: 1, ProjectID: 2, State: MachineActive}, nil)
-	_, err = c.IssueMachineToken(context.Background(), 999, 1, "ci", nil, 7)
+	_, err = c.IssueMachineToken(context.Background(), 999, 1, "ci", nil, "", 7)
 	require.ErrorContains(t, err, "not found")
 
 	// Active machine → token minted with the kx_machine_ prefix, hash stored.
@@ -34,7 +34,7 @@ func TestIssueMachineToken_ActiveOnly(t *testing.T) {
 		Return(&models.MachineIdentityCredential{ID: 5}, nil)
 	store.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
 
-	res, err := c.IssueMachineToken(context.Background(), 2, 1, "ci", nil, 7)
+	res, err := c.IssueMachineToken(context.Background(), 2, 1, "ci", nil, "", 7)
 	require.NoError(t, err)
 	require.True(t, strings.HasPrefix(res.PlainToken, "kx_machine_"))
 

--- a/internal/core/migrate_user_to_machine.go
+++ b/internal/core/migrate_user_to_machine.go
@@ -44,7 +44,7 @@ func (c *KeyorixCore) MigrateUserToMachine(ctx context.Context, username string,
 	}
 	desc := fmt.Sprintf("Migrated from user %q (id %d, %s)", user.Username, user.ID, user.Email)
 
-	m, err := c.CreateMachineIdentity(ctx, projectID, name, identityType, desc, actorID)
+	m, err := c.CreateMachineIdentity(ctx, projectID, name, identityType, desc, "", actorID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -1312,6 +1312,14 @@ func (m *MockStorage) ListMachineIdentities(ctx context.Context, projectID uint)
 	return args.Get(0).([]*models.MachineIdentity), args.Error(1)
 }
 
+func (m *MockStorage) CountMachineIdentitiesByClassification(ctx context.Context) (map[string]int, error) {
+	args := m.Called(ctx)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(map[string]int), args.Error(1)
+}
+
 func (m *MockStorage) CreateMachineIdentityCredential(ctx context.Context, c *models.MachineIdentityCredential) (*models.MachineIdentityCredential, error) {
 	args := m.Called(ctx, c)
 	if args.Get(0) == nil {
@@ -1342,6 +1350,19 @@ func (m *MockStorage) ListMachineIdentityCredentials(ctx context.Context, machin
 		return nil, args.Error(1)
 	}
 	return args.Get(0).([]*models.MachineIdentityCredential), args.Error(1)
+}
+
+func (m *MockStorage) UpdateMachineIdentityCredential(ctx context.Context, c *models.MachineIdentityCredential) error {
+	args := m.Called(ctx, c)
+	return args.Error(0)
+}
+
+func (m *MockStorage) CountMachineIdentityCredentialsByClassification(ctx context.Context) (map[string]int, error) {
+	args := m.Called(ctx)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(map[string]int), args.Error(1)
 }
 
 func (m *MockStorage) RevokeMachineIdentityCredential(ctx context.Context, id uint) error {

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -116,13 +116,20 @@ type Storage interface {
 	GetMachineIdentity(ctx context.Context, id uint) (*models.MachineIdentity, error)
 	UpdateMachineIdentity(ctx context.Context, m *models.MachineIdentity) error
 	ListMachineIdentities(ctx context.Context, projectID uint) ([]*models.MachineIdentity, error)
+	// CountMachineIdentitiesByClassification returns install-wide counts keyed by
+	// classification label ("" = unclassified) for the compliance posture.
+	CountMachineIdentitiesByClassification(ctx context.Context) (map[string]int, error)
 
 	// Machine-token credentials (ADR-030) — opaque bearer tokens, hashed at rest.
 	CreateMachineIdentityCredential(ctx context.Context, c *models.MachineIdentityCredential) (*models.MachineIdentityCredential, error)
 	GetMachineIdentityCredentialByHash(ctx context.Context, hash string) (*models.MachineIdentityCredential, error)
 	GetMachineIdentityCredentialByID(ctx context.Context, id uint) (*models.MachineIdentityCredential, error)
 	ListMachineIdentityCredentials(ctx context.Context, machineID uint) ([]*models.MachineIdentityCredential, error)
+	UpdateMachineIdentityCredential(ctx context.Context, c *models.MachineIdentityCredential) error
 	RevokeMachineIdentityCredential(ctx context.Context, id uint) error
+	// CountMachineIdentityCredentialsByClassification returns install-wide counts
+	// keyed by classification label ("" = unclassified) for the compliance posture.
+	CountMachineIdentityCredentialsByClassification(ctx context.Context) (map[string]int, error)
 	TouchMachineIdentityCredential(ctx context.Context, id uint, usedAt time.Time, staleness time.Duration) error
 
 	// Machine-identity role grants (ADR-030) — mirror the user_roles surface.

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -469,6 +469,9 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 		if err := db.AutoMigrate(&models.MachineIdentity{}); err != nil {
 			return fmt.Errorf("failed to migrate machine_identities table: %w", err)
 		}
+	} else if !columnExists(db, "machine_identities", "classification") {
+		// Data classification (ISO A.5.12). Additive ("" = unclassified).
+		db.Exec("ALTER TABLE machine_identities ADD COLUMN classification TEXT DEFAULT ''")
 	}
 
 	// Create machine-token tables if missing (ADR-030, additive, safe on existing DBs).
@@ -476,6 +479,8 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 		if err := db.AutoMigrate(&models.MachineIdentityCredential{}); err != nil {
 			return fmt.Errorf("failed to migrate machine_identity_credentials table: %w", err)
 		}
+	} else if !columnExists(db, "machine_identity_credentials", "classification") {
+		db.Exec("ALTER TABLE machine_identity_credentials ADD COLUMN classification TEXT DEFAULT ''")
 	}
 	if !machineRoleExists {
 		if err := db.AutoMigrate(&models.MachineIdentityRole{}); err != nil {

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -852,6 +852,9 @@ type MachineIdentity struct {
 	UpdatedAt    time.Time
 	LastSeenAt   *time.Time
 	RevokedAt    *time.Time
+	// Classification is the data-sensitivity tier this machine identity handles
+	// (ISO 27001 A.5.12): "" = unclassified, else public|internal|confidential|restricted.
+	Classification string `gorm:"index"`
 }
 
 // MachineIdentityCredential is an opaque bearer token a machine identity uses to
@@ -869,6 +872,9 @@ type MachineIdentityCredential struct {
 	ExpiresAt         *time.Time // nil = never expires
 	Revoked           bool       `gorm:"default:false"`
 	CreatedAt         time.Time
+	// Classification is the data-sensitivity tier of what this credential can reach
+	// (ISO 27001 A.5.12): "" = unclassified, else public|internal|confidential|restricted.
+	Classification string `gorm:"index"`
 }
 
 // MachineIdentityRole grants a role to a machine identity at a project/

--- a/internal/storage/store/classification_count.go
+++ b/internal/storage/store/classification_count.go
@@ -1,0 +1,27 @@
+// classification_count.go — shared helper for the compliance classification
+// posture: count rows of a classifiable table grouped by classification label.
+package store
+
+import (
+	"context"
+
+	"gorm.io/gorm"
+)
+
+// countByClassification returns row counts of model keyed by its classification
+// label ("" = unclassified), install-wide, via a single GROUP BY.
+func countByClassification(ctx context.Context, db *gorm.DB, model interface{}) (map[string]int, error) {
+	var rows []struct {
+		Classification string
+		N              int
+	}
+	if err := db.WithContext(ctx).Model(model).
+		Select("classification, COUNT(*) AS n").Group("classification").Scan(&rows).Error; err != nil {
+		return nil, err
+	}
+	out := make(map[string]int, len(rows))
+	for _, r := range rows {
+		out[r.Classification] = r.N
+	}
+	return out, nil
+}

--- a/internal/storage/store/local_dynamic.go
+++ b/internal/storage/store/local_dynamic.go
@@ -43,19 +43,7 @@ func (ls *LocalStorage) UpdateDynamicSecretConfig(ctx context.Context, c *models
 // CountDynamicSecretConfigsByClassification returns config counts keyed by
 // classification label ("" = unclassified), install-wide, via a GROUP BY.
 func (ls *LocalStorage) CountDynamicSecretConfigsByClassification(ctx context.Context) (map[string]int, error) {
-	var rows []struct {
-		Classification string
-		N              int
-	}
-	if err := ls.db.WithContext(ctx).Model(&models.DynamicSecretConfig{}).
-		Select("classification, COUNT(*) AS n").Group("classification").Scan(&rows).Error; err != nil {
-		return nil, err
-	}
-	out := make(map[string]int, len(rows))
-	for _, r := range rows {
-		out[r.Classification] = r.N
-	}
-	return out, nil
+	return countByClassification(ctx, ls.db, &models.DynamicSecretConfig{})
 }
 
 func (ls *LocalStorage) CreateDynamicSecretLease(ctx context.Context, l *models.DynamicSecretLease) (*models.DynamicSecretLease, error) {

--- a/internal/storage/store/local_machine_credentials.go
+++ b/internal/storage/store/local_machine_credentials.go
@@ -51,6 +51,17 @@ func (ls *LocalStorage) ListMachineIdentityCredentials(ctx context.Context, mach
 	return rows, nil
 }
 
+func (ls *LocalStorage) UpdateMachineIdentityCredential(ctx context.Context, c *models.MachineIdentityCredential) error {
+	if err := ls.db.WithContext(ctx).Save(c).Error; err != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	return nil
+}
+
+func (ls *LocalStorage) CountMachineIdentityCredentialsByClassification(ctx context.Context) (map[string]int, error) {
+	return countByClassification(ctx, ls.db, &models.MachineIdentityCredential{})
+}
+
 func (ls *LocalStorage) RevokeMachineIdentityCredential(ctx context.Context, id uint) error {
 	result := ls.db.WithContext(ctx).Model(&models.MachineIdentityCredential{}).
 		Where("id = ?", id).UpdateColumn("revoked", true)

--- a/internal/storage/store/local_machine_identities.go
+++ b/internal/storage/store/local_machine_identities.go
@@ -44,3 +44,7 @@ func (ls *LocalStorage) ListMachineIdentities(ctx context.Context, projectID uin
 	}
 	return rows, nil
 }
+
+func (ls *LocalStorage) CountMachineIdentitiesByClassification(ctx context.Context) (map[string]int, error) {
+	return countByClassification(ctx, ls.db, &models.MachineIdentity{})
+}

--- a/internal/storage/store/remote_machine_identities.go
+++ b/internal/storage/store/remote_machine_identities.go
@@ -28,6 +28,10 @@ func (rs *RemoteStorage) ListMachineIdentities(_ context.Context, _ uint) ([]*mo
 	return nil, remoteUnsupported("ListMachineIdentities")
 }
 
+func (rs *RemoteStorage) CountMachineIdentitiesByClassification(_ context.Context) (map[string]int, error) {
+	return nil, remoteUnsupported("CountMachineIdentitiesByClassification")
+}
+
 func (rs *RemoteStorage) CreateMachineIdentityCredential(_ context.Context, _ *models.MachineIdentityCredential) (*models.MachineIdentityCredential, error) {
 	return nil, remoteUnsupported("CreateMachineIdentityCredential")
 }
@@ -42,6 +46,14 @@ func (rs *RemoteStorage) GetMachineIdentityCredentialByID(_ context.Context, _ u
 
 func (rs *RemoteStorage) ListMachineIdentityCredentials(_ context.Context, _ uint) ([]*models.MachineIdentityCredential, error) {
 	return nil, remoteUnsupported("ListMachineIdentityCredentials")
+}
+
+func (rs *RemoteStorage) UpdateMachineIdentityCredential(_ context.Context, _ *models.MachineIdentityCredential) error {
+	return remoteUnsupported("UpdateMachineIdentityCredential")
+}
+
+func (rs *RemoteStorage) CountMachineIdentityCredentialsByClassification(_ context.Context) (map[string]int, error) {
+	return nil, remoteUnsupported("CountMachineIdentityCredentialsByClassification")
 }
 
 func (rs *RemoteStorage) RevokeMachineIdentityCredential(_ context.Context, _ uint) error {

--- a/server/grpc/interceptors/auth_test.go
+++ b/server/grpc/interceptors/auth_test.go
@@ -197,9 +197,9 @@ func TestAuthInterceptor_MachineTokenAuthenticatesAndUsesMachineRBAC(t *testing.
 	require.NoError(t, h.DB.AutoMigrate(
 		&models.MachineIdentity{}, &models.MachineIdentityCredential{}, &models.MachineIdentityRole{}))
 
-	m, err := h.CoreService.CreateMachineIdentity(context.Background(), 2, "ci-bot", "service", "", 1)
+	m, err := h.CoreService.CreateMachineIdentity(context.Background(), 2, "ci-bot", "service", "", "", 1)
 	require.NoError(t, err)
-	tok, err := h.CoreService.IssueMachineToken(context.Background(), 2, m.ID, "tok", nil, 1)
+	tok, err := h.CoreService.IssueMachineToken(context.Background(), 2, m.ID, "tok", nil, "", 1)
 	require.NoError(t, err)
 	require.True(t, strings.HasPrefix(tok.PlainToken, "kx_machine_"))
 	// Grant the machine viewer (secrets.read) in project 2 only.

--- a/server/http/handlers/machine_identities.go
+++ b/server/http/handlers/machine_identities.go
@@ -44,9 +44,10 @@ func (h *CatalogHandler) CreateMachineIdentity(w http.ResponseWriter, r *http.Re
 		return
 	}
 	var body struct {
-		Name         string `json:"name"`
-		IdentityType string `json:"identity_type"`
-		Description  string `json:"description"`
+		Name           string `json:"name"`
+		IdentityType   string `json:"identity_type"`
+		Description    string `json:"description"`
+		Classification string `json:"classification"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		sendError(w, "InvalidJSON", "Invalid request body", http.StatusBadRequest, nil)
@@ -56,7 +57,7 @@ func (h *CatalogHandler) CreateMachineIdentity(w http.ResponseWriter, r *http.Re
 		sendError(w, "ValidationError", "name is required", http.StatusBadRequest, nil)
 		return
 	}
-	m, err := h.coreService.CreateMachineIdentity(r.Context(), uint(id), body.Name, body.IdentityType, body.Description, actor.UserID)
+	m, err := h.coreService.CreateMachineIdentity(r.Context(), uint(id), body.Name, body.IdentityType, body.Description, body.Classification, actor.UserID)
 	if err != nil {
 		status := http.StatusInternalServerError
 		if strings.Contains(err.Error(), "invalid identity_type") || strings.Contains(err.Error(), "required") {
@@ -133,8 +134,9 @@ func (h *CatalogHandler) IssueMachineToken(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	var body struct {
-		Name          string `json:"name"`
-		ExpiresInDays int    `json:"expires_in_days"`
+		Name           string `json:"name"`
+		ExpiresInDays  int    `json:"expires_in_days"`
+		Classification string `json:"classification"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		sendError(w, "InvalidJSON", "Invalid request body", http.StatusBadRequest, nil)
@@ -145,7 +147,7 @@ func (h *CatalogHandler) IssueMachineToken(w http.ResponseWriter, r *http.Reques
 		t := time.Now().AddDate(0, 0, body.ExpiresInDays)
 		expiresAt = &t
 	}
-	result, err := h.coreService.IssueMachineToken(r.Context(), uint(projectID), uint(machineID), body.Name, expiresAt, actor.UserID)
+	result, err := h.coreService.IssueMachineToken(r.Context(), uint(projectID), uint(machineID), body.Name, expiresAt, body.Classification, actor.UserID)
 	if err != nil {
 		status := http.StatusInternalServerError
 		switch {
@@ -159,10 +161,11 @@ func (h *CatalogHandler) IssueMachineToken(w http.ResponseWriter, r *http.Reques
 	}
 	w.WriteHeader(http.StatusCreated)
 	sendSuccess(w, map[string]interface{}{
-		"token":      result.PlainToken, // shown once
-		"id":         result.Credential.ID,
-		"prefix":     result.Credential.TokenPrefix,
-		"expires_at": result.Credential.ExpiresAt,
+		"token":          result.PlainToken, // shown once
+		"id":             result.Credential.ID,
+		"prefix":         result.Credential.TokenPrefix,
+		"expires_at":     result.Credential.ExpiresAt,
+		"classification": result.Credential.Classification,
 	}, "Machine token issued — copy it now; it will not be shown again")
 }
 
@@ -187,13 +190,14 @@ func (h *CatalogHandler) ListMachineTokens(w http.ResponseWriter, r *http.Reques
 	out := make([]map[string]interface{}, 0, len(creds))
 	for _, c := range creds {
 		out = append(out, map[string]interface{}{
-			"id":           c.ID,
-			"name":         c.Name,
-			"prefix":       c.TokenPrefix,
-			"last_used_at": c.LastUsedAt,
-			"expires_at":   c.ExpiresAt,
-			"revoked":      c.Revoked,
-			"created_at":   c.CreatedAt,
+			"id":             c.ID,
+			"name":           c.Name,
+			"prefix":         c.TokenPrefix,
+			"last_used_at":   c.LastUsedAt,
+			"expires_at":     c.ExpiresAt,
+			"revoked":        c.Revoked,
+			"classification": c.Classification,
+			"created_at":     c.CreatedAt,
 		})
 	}
 	sendSuccess(w, map[string]interface{}{"tokens": out}, "")
@@ -230,6 +234,65 @@ func (h *CatalogHandler) RevokeMachineToken(w http.ResponseWriter, r *http.Reque
 		return
 	}
 	sendSuccess(w, nil, "Machine token revoked")
+}
+
+// ClassifyMachineIdentity handles PATCH
+// /api/v1/projects/{id}/machine-identities/{machineId}/classification.
+func (h *CatalogHandler) ClassifyMachineIdentity(w http.ResponseWriter, r *http.Request) {
+	projectID, machineID, actor, ok := h.machineRouteCtx(w, r)
+	if !ok {
+		return
+	}
+	var body struct {
+		Classification string `json:"classification"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		sendError(w, "InvalidJSON", "Invalid request body", http.StatusBadRequest, nil)
+		return
+	}
+	m, err := h.coreService.ClassifyMachineIdentity(r.Context(), projectID, machineID, body.Classification, actor.UserID)
+	if err != nil {
+		status := http.StatusBadRequest
+		if strings.Contains(err.Error(), "not found") {
+			status = http.StatusNotFound
+		}
+		sendError(w, "Error", err.Error(), status, nil)
+		return
+	}
+	sendSuccess(w, map[string]interface{}{"machine_identity": m}, "Classification updated")
+}
+
+// ClassifyMachineToken handles PATCH
+// /api/v1/projects/{id}/machine-identities/{machineId}/tokens/{tokenId}/classification.
+func (h *CatalogHandler) ClassifyMachineToken(w http.ResponseWriter, r *http.Request) {
+	projectID, machineID, actor, ok := h.machineRouteCtx(w, r)
+	if !ok {
+		return
+	}
+	tokenID, err := strconv.ParseUint(chi.URLParam(r, "tokenId"), 10, 32)
+	if err != nil {
+		sendError(w, "InvalidParameter", "Invalid token ID", http.StatusBadRequest, nil)
+		return
+	}
+	var body struct {
+		Classification string `json:"classification"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		sendError(w, "InvalidJSON", "Invalid request body", http.StatusBadRequest, nil)
+		return
+	}
+	cred, err := h.coreService.ClassifyMachineToken(r.Context(), projectID, machineID, uint(tokenID), body.Classification, actor.UserID)
+	if err != nil {
+		status := http.StatusBadRequest
+		if strings.Contains(err.Error(), "not found") {
+			status = http.StatusNotFound
+		}
+		sendError(w, "Error", err.Error(), status, nil)
+		return
+	}
+	sendSuccess(w, map[string]interface{}{
+		"id": cred.ID, "classification": cred.Classification,
+	}, "Classification updated")
 }
 
 // GrantMachineRole handles POST /api/v1/projects/{id}/machine-identities/{machineId}/roles.

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -273,6 +273,8 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		r.With(customMiddleware.RequireScopedPermission("users.read", projectScope)).Get("/projects/{id}/machine-identities", catalogHandler.ListMachineIdentities)
 		r.With(customMiddleware.RequireScopedPermission("roles.assign", projectScope)).Post("/projects/{id}/machine-identities", catalogHandler.CreateMachineIdentity)
 		r.With(customMiddleware.RequireScopedPermission("roles.assign", projectScope)).Put("/projects/{id}/machine-identities/{machineId}", catalogHandler.TransitionMachineIdentity)
+		r.With(customMiddleware.RequireScopedPermission("roles.assign", projectScope)).Patch("/projects/{id}/machine-identities/{machineId}/classification", catalogHandler.ClassifyMachineIdentity)
+		r.With(customMiddleware.RequireScopedPermission("roles.assign", projectScope)).Patch("/projects/{id}/machine-identities/{machineId}/tokens/{tokenId}/classification", catalogHandler.ClassifyMachineToken)
 		// Machine-token credentials + role grants (ADR-030).
 		r.With(customMiddleware.RequireScopedPermission("roles.assign", projectScope)).Post("/projects/{id}/machine-identities/{machineId}/tokens", catalogHandler.IssueMachineToken)
 		r.With(customMiddleware.RequireScopedPermission("users.read", projectScope)).Get("/projects/{id}/machine-identities/{machineId}/tokens", catalogHandler.ListMachineTokens)


### PR DESCRIPTION
## What

Completes the "1 2 3" classification batch (dynamic-secret configs shipped in #212). Data-classification labels now extend to **machine identities** (ADR-023) and **machine-token credentials** (ADR-030), so every secret-bearing surface carries a sensitivity tier and the compliance classification posture covers all of them.

## How

- **Models**: `MachineIdentity.Classification` + `MachineIdentityCredential.Classification` (indexed; additive `ALTER TABLE` migrations).
- **Core**: `CreateMachineIdentity` / `IssueMachineToken` take a classification (validated; **a token defaults to its identity's tier when unset**); `ClassifyMachineIdentity` + `ClassifyMachineToken` set/clear with audit (`machine_identity.classified` / `.token_classified`). Both are project-scoped (cross-project guard) and verify the credential belongs to the machine.
- **Storage**: `UpdateMachineIdentityCredential` + `Count*ByClassification` for both entities (shared `countByClassification` helper — the #212 dynamic-config count is refactored onto it) across interface + local/remote(stub)/mock.
- **Posture**: `ClassificationPosture` gains `MachineIdentities` + `MachineCredentials` `ClassificationCounts`; the `compliance report` CLI prints both lines.
- **HTTP**: `PATCH .../machine-identities/{machineId}/classification` and `.../tokens/{tokenId}/classification` (`roles.assign` middleware, matching the other machine mutations); create/issue bodies + list/issue output carry `classification`.
- **CLI**: `keyorix machine create --classification`.

## Tests

`classify_machine_test.go`: classify set / invalid-level / cross-project / foreign-credential guards, posture coverage. gofmt clean, golangci-lint 0, gitleaks clean. The two new PATCH routes return **403** to a read-only persona in the `TestEveryMutatingRouteDeniesReadOnly` walk (the only flagged routes there are the pre-existing local-only `/sw.js` and `system.read` evidence/verify — green in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)