### PR TITLE
feat(compliance): S3 Object Lock (WORM) retention on the evidence sink

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -469,6 +469,8 @@ evidence_delivery:
     region: "eu-west-1"
     endpoint: ""                            # optional — set for S3-compatible stores (MinIO/R2/…)
     use_path_style: false                   # set true for MinIO and some gateways
+    lock_mode: ""                           # "" | governance | compliance (S3 Object Lock / WORM)
+    lock_retain_days: 0                     # retention window; required (>0) when lock_mode is set
 ```
 
 > The off-box targets let evidence survive the node without a mounted volume. A file
@@ -483,8 +485,18 @@ evidence_delivery:
 > the detached signature to `<prefix><filename>.sig`. **Credentials are never taken in
 > Keyorix config**: they resolve via the standard AWS credential chain
 > (`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` env vars, shared config, or
-> instance/workload identity). Point the bucket at object-lock / immutable storage for
-> WORM-grade evidence retention.
+> instance/workload identity).
+>
+> **Object Lock (WORM).** Set `lock_mode` to `governance` or `compliance` (with
+> `lock_retain_days`) to stamp every uploaded pack and signature with an S3 Object
+> Lock retention period, so the evidence cannot be overwritten or deleted before it
+> expires — tamper-resistant archival an auditor can rely on. `compliance` mode cannot
+> be shortened or removed by anyone (including the root account) until expiry;
+> `governance` allows override by principals with the `s3:BypassGovernanceRetention`
+> permission. **The bucket must be created with Object Lock enabled** (a bucket
+> property Keyorix cannot set); this configures the per-object retention applied on
+> write. A misconfigured bucket surfaces as a delivery error (non-fatal when a local
+> file was also written).
 
 When **encryption is enabled**, each exported pack is **signed**: a detached
 `<file>.json.sig` is written next to it (and the webhook delivery carries the

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -551,6 +551,11 @@ type EvidenceObjectStoreConfig struct {
 	Region       string `yaml:"region"`         // bucket region
 	Endpoint     string `yaml:"endpoint"`       // optional custom endpoint for S3-compatible stores
 	UsePathStyle bool   `yaml:"use_path_style"` // path-style addressing (MinIO and some gateways)
+	// LockMode opts into S3 Object Lock (WORM) on each uploaded object: "" (off),
+	// "governance", or "compliance". The bucket must have Object Lock enabled.
+	LockMode string `yaml:"lock_mode"`
+	// LockRetainDays is the retention window in days; required (> 0) when LockMode set.
+	LockRetainDays int `yaml:"lock_retain_days"`
 }
 
 // EvidenceWebhookConfig configures the off-box webhook target: each run POSTs the

--- a/internal/evidencesink/objectstore.go
+++ b/internal/evidencesink/objectstore.go
@@ -4,17 +4,26 @@
 // object-locked storage an auditor can pull from. Works with AWS S3 and S3-compatible
 // stores (MinIO, Cloudflare R2, Backblaze B2, GCS interop) via a custom endpoint.
 // This is the ONLY file that imports the S3 SDK, keeping the dependency contained.
+//
+// When object-lock is configured, each uploaded object is stamped with an S3 Object
+// Lock retention (GOVERNANCE or COMPLIANCE mode + a retain-until date) so the evidence
+// is WORM-protected — it cannot be overwritten or deleted before it expires. The
+// bucket itself must have Object Lock enabled (a create-time bucket property an
+// operator sets); this sets the per-object retention on write.
 package evidencesink
 
 import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 )
 
 // ObjectStoreConfig configures the S3-compatible object-storage target. Credentials
@@ -26,6 +35,13 @@ type ObjectStoreConfig struct {
 	Region       string // bucket region (any value for some S3-compatible stores)
 	Endpoint     string // optional custom endpoint for S3-compatible stores (MinIO/R2/…)
 	UsePathStyle bool   // path-style addressing — required by MinIO and some gateways
+
+	// LockMode opts into S3 Object Lock retention on each uploaded object: ""
+	// (off), "governance", or "compliance". The bucket must have Object Lock enabled.
+	LockMode string
+	// LockRetainDays is the retention period in days applied from upload time.
+	// Required (> 0) when LockMode is set.
+	LockRetainDays int
 }
 
 // s3PutAPI is the slice of the S3 client the sink uses — an interface seam so the
@@ -36,9 +52,26 @@ type s3PutAPI interface {
 
 // ObjectStore delivers the evidence pack to an S3-compatible bucket.
 type ObjectStore struct {
-	api    s3PutAPI
-	bucket string
-	prefix string
+	api      s3PutAPI
+	bucket   string
+	prefix   string
+	lockMode s3types.ObjectLockMode // "" when object lock is off
+	retain   time.Duration
+	now      func() time.Time
+}
+
+// objectLockMode maps the config string to the S3 enum, validating it.
+func objectLockMode(mode string) (s3types.ObjectLockMode, error) {
+	switch strings.ToLower(strings.TrimSpace(mode)) {
+	case "":
+		return "", nil
+	case "governance":
+		return s3types.ObjectLockModeGovernance, nil
+	case "compliance":
+		return s3types.ObjectLockModeCompliance, nil
+	default:
+		return "", fmt.Errorf("evidencesink: object_lock_mode must be governance, compliance, or empty (got %q)", mode)
+	}
 }
 
 // NewObjectStore builds the S3-compatible sink. The bucket is required; credentials
@@ -46,6 +79,13 @@ type ObjectStore struct {
 func NewObjectStore(ctx context.Context, cfg ObjectStoreConfig) (*ObjectStore, error) {
 	if cfg.Bucket == "" {
 		return nil, fmt.Errorf("evidencesink: object-store bucket is required")
+	}
+	lockMode, err := objectLockMode(cfg.LockMode)
+	if err != nil {
+		return nil, err
+	}
+	if lockMode != "" && cfg.LockRetainDays <= 0 {
+		return nil, fmt.Errorf("evidencesink: object_lock_retain_days must be > 0 when object_lock_mode is set")
 	}
 	var loadOpts []func(*awsconfig.LoadOptions) error
 	if cfg.Region != "" {
@@ -61,37 +101,53 @@ func NewObjectStore(ctx context.Context, cfg ObjectStoreConfig) (*ObjectStore, e
 		}
 		o.UsePathStyle = cfg.UsePathStyle
 	})
-	return &ObjectStore{api: client, bucket: cfg.Bucket, prefix: normalizePrefix(cfg.Prefix)}, nil
+	return &ObjectStore{
+		api:      client,
+		bucket:   cfg.Bucket,
+		prefix:   normalizePrefix(cfg.Prefix),
+		lockMode: lockMode,
+		retain:   time.Duration(cfg.LockRetainDays) * 24 * time.Hour,
+		now:      time.Now,
+	}, nil
 }
 
 // ForwardEvidence uploads the pack to <prefix><name> and, when signed, the detached
 // signature to <prefix><name>.sig. A failure on either upload fails the delivery.
 func (o *ObjectStore) ForwardEvidence(ctx context.Context, name string, data []byte, signature string) error {
 	key := o.prefix + name
-	if _, err := o.api.PutObject(ctx, &s3.PutObjectInput{
-		Bucket:      aws.String(o.bucket),
-		Key:         aws.String(key),
-		Body:        bytes.NewReader(data),
-		ContentType: aws.String("application/json"),
-	}); err != nil {
+	if _, err := o.api.PutObject(ctx, o.putInput(key, bytes.NewReader(data), "application/json")); err != nil {
 		return fmt.Errorf("evidencesink: put %s: %w", key, err)
 	}
 	if signature != "" {
 		sigKey := key + ".sig"
-		if _, err := o.api.PutObject(ctx, &s3.PutObjectInput{
-			Bucket:      aws.String(o.bucket),
-			Key:         aws.String(sigKey),
-			Body:        strings.NewReader(signature),
-			ContentType: aws.String("text/plain"),
-		}); err != nil {
+		if _, err := o.api.PutObject(ctx, o.putInput(sigKey, strings.NewReader(signature), "text/plain")); err != nil {
 			return fmt.Errorf("evidencesink: put %s: %w", sigKey, err)
 		}
 	}
 	return nil
 }
 
+// putInput builds a PutObjectInput, adding Object Lock retention when configured so
+// the written object is WORM-protected for the retention window.
+func (o *ObjectStore) putInput(key string, body io.Reader, contentType string) *s3.PutObjectInput {
+	in := &s3.PutObjectInput{
+		Bucket:      aws.String(o.bucket),
+		Key:         aws.String(key),
+		Body:        body,
+		ContentType: aws.String(contentType),
+	}
+	if o.lockMode != "" {
+		in.ObjectLockMode = o.lockMode
+		in.ObjectLockRetainUntilDate = aws.Time(o.now().Add(o.retain))
+	}
+	return in
+}
+
 // Target labels this forwarder in the export result.
 func (o *ObjectStore) Target() string {
+	if o.lockMode != "" {
+		return fmt.Sprintf("objectstore:%s/%s (lock:%s)", o.bucket, o.prefix, strings.ToLower(string(o.lockMode)))
+	}
 	return fmt.Sprintf("objectstore:%s/%s", o.bucket, o.prefix)
 }
 

--- a/internal/evidencesink/objectstore_test.go
+++ b/internal/evidencesink/objectstore_test.go
@@ -5,14 +5,18 @@ import (
 	"errors"
 	"io"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 type putCall struct {
 	bucket, key, body, ctype string
+	lockMode                 s3types.ObjectLockMode
+	retainUntil              *time.Time
 }
 
 type fakeS3 struct {
@@ -24,6 +28,7 @@ func (f *fakeS3) PutObject(_ context.Context, in *s3.PutObjectInput, _ ...func(*
 	b, _ := io.ReadAll(in.Body)
 	f.calls = append(f.calls, putCall{
 		bucket: deref(in.Bucket), key: deref(in.Key), body: string(b), ctype: deref(in.ContentType),
+		lockMode: in.ObjectLockMode, retainUntil: in.ObjectLockRetainUntilDate,
 	})
 	if f.err != nil {
 		return nil, f.err
@@ -39,7 +44,7 @@ func deref(s *string) string {
 }
 
 func newTestObjectStore(api s3PutAPI, prefix string) *ObjectStore {
-	return &ObjectStore{api: api, bucket: "evidence-bkt", prefix: normalizePrefix(prefix)}
+	return &ObjectStore{api: api, bucket: "evidence-bkt", prefix: normalizePrefix(prefix), now: time.Now}
 }
 
 func TestObjectStore_UploadsPackAndSignature(t *testing.T) {
@@ -59,6 +64,40 @@ func TestObjectStore_UploadsPackAndSignature(t *testing.T) {
 	sig := api.calls[1]
 	assert.Equal(t, "keyorix/evidence/keyorix-evidence-20260615T100000Z.json.sig", sig.key)
 	assert.Equal(t, "v1:abc", sig.body)
+
+	// No object lock by default.
+	assert.Empty(t, string(pack.lockMode))
+	assert.Nil(t, pack.retainUntil)
+}
+
+func TestObjectStore_ObjectLockStampsRetentionOnEveryObject(t *testing.T) {
+	api := &fakeS3{}
+	fixed := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
+	o := &ObjectStore{
+		api: api, bucket: "evidence-bkt", prefix: "",
+		lockMode: s3types.ObjectLockModeCompliance,
+		retain:   7 * 24 * time.Hour,
+		now:      func() time.Time { return fixed },
+	}
+
+	require.NoError(t, o.ForwardEvidence(context.Background(), "pack.json", []byte(`{}`), "v1:abc"))
+	require.Len(t, api.calls, 2, "pack + signature both locked")
+	for _, c := range api.calls {
+		assert.Equal(t, s3types.ObjectLockModeCompliance, c.lockMode, "every object carries the lock mode")
+		require.NotNil(t, c.retainUntil)
+		assert.Equal(t, fixed.Add(7*24*time.Hour), *c.retainUntil, "retain-until = now + window")
+	}
+	assert.Contains(t, o.Target(), "lock:compliance")
+}
+
+func TestNewObjectStore_ObjectLockValidation(t *testing.T) {
+	ctx := context.Background()
+	// Unknown mode rejected.
+	_, err := NewObjectStore(ctx, ObjectStoreConfig{Bucket: "b", LockMode: "weak"})
+	require.Error(t, err)
+	// Mode set but no retention → rejected.
+	_, err = NewObjectStore(ctx, ObjectStoreConfig{Bucket: "b", LockMode: "governance"})
+	require.Error(t, err)
 }
 
 func TestObjectStore_NoSignatureSkipsSigObject(t *testing.T) {

--- a/server/main.go
+++ b/server/main.go
@@ -321,11 +321,13 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 	}
 	if os := cfg.EvidenceDelivery.ObjectStore; os.Enabled {
 		sink, oerr := evidencesink.NewObjectStore(context.Background(), evidencesink.ObjectStoreConfig{
-			Bucket:       os.Bucket,
-			Prefix:       os.Prefix,
-			Region:       os.Region,
-			Endpoint:     os.Endpoint,
-			UsePathStyle: os.UsePathStyle,
+			Bucket:         os.Bucket,
+			Prefix:         os.Prefix,
+			Region:         os.Region,
+			Endpoint:       os.Endpoint,
+			UsePathStyle:   os.UsePathStyle,
+			LockMode:       os.LockMode,
+			LockRetainDays: os.LockRetainDays,
 		})
 		if oerr != nil {
 			return nil, nil, fmt.Errorf("failed to init evidence object-store target: %w", oerr)


### PR DESCRIPTION
## What

Completes the object-storage evidence sink (#209). An operator can now have each uploaded evidence pack (and its detached signature) stamped with an **S3 Object Lock retention**, so archived evidence is **WORM-protected** — it cannot be overwritten or deleted before it expires. That immutability is what auditors actually want from off-box evidence; previously we could write to a bucket but not guarantee tamper-resistance.

## How

- **`evidencesink`**: `ObjectStore` gains `lock_mode` (`governance` | `compliance`) + a retention window. `putInput` stamps `ObjectLockMode` + `ObjectLockRetainUntilDate` (`now()` + window) on **every** PutObject (pack and `.sig`). `now()` is injected for deterministic tests. `NewObjectStore` validates (unknown mode rejected; `lock_retain_days` required when a mode is set). `Target()` surfaces `lock:<mode>`.
- **Config**: `evidence_delivery.object_store.{lock_mode, lock_retain_days}`, wired through `main`.
- **Docs**: `CONFIGURATION.md` Object Lock section.

## Notes

- The **bucket must be created with Object Lock enabled** (a bucket property Keyorix can't set); this configures the per-object retention applied on write. A misconfigured bucket surfaces as a delivery error (non-fatal when a local file was also written).
- `compliance` mode can't be shortened/removed by anyone (incl. root) until expiry; `governance` allows override with `s3:BypassGovernanceRetention`.
- No new server dependency (`s3/types` is part of the already-vendored s3 module).

## Tests

`objectstore_test.go`: lock stamps mode + `retain-until = now + window` on every object; default = no lock; `NewObjectStore` lock validation (unknown mode, missing retention). gofmt clean, golangci-lint 0, gitleaks clean. No new routes (config-only), so the only local mutating-route-test failures are the pre-existing `/sw.js` + `evidence/verify` artifacts — green in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)