### PR TITLE
release: prep v0.29.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to Keyorix are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## v0.29.0 — 2026-06-15
+
+The immutable-evidence release: lock archived compliance evidence as WORM.
+
+### Added
+- **S3 Object Lock (WORM) on the evidence object-store sink** — each scheduled
+  evidence pack and its detached signature can be uploaded with an S3 Object Lock
+  retention (`governance` or `compliance` mode + a retain-until window), so archived
+  evidence cannot be overwritten or deleted before it expires — tamper-resistant
+  evidence an auditor can rely on. The bucket must be created with Object Lock
+  enabled; configure via `evidence_delivery.object_store.{lock_mode,lock_retain_days}`.
+  ([#215])
+
+### Notes
+- Additive and opt-in (object lock is off unless `lock_mode` is set). No schema changes.
+
+[#215]: https://github.com/keyorixhq/keyorix/pull/215
+
 ## v0.28.0 — 2026-06-15
 
 The classification-coverage release: data-sensitivity labels now span every

--- a/deploy/helm/keyorix/Chart.yaml
+++ b/deploy/helm/keyorix/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix
 description: Self-hosted Keyorix secrets manager (API server + web UI + PostgreSQL)
 type: application
 # Chart version — bump on chart changes.
-version: 0.28.0
+version: 0.29.0
 # The Keyorix app version this chart deploys by default (the image tag).
-appVersion: "0.28.0"
+appVersion: "0.29.0"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix


### PR DESCRIPTION
Release prep for **v0.29.0** — the immutable-evidence release.

Bundles on top of v0.28.0:
- #215 — S3 Object Lock (WORM) retention on the evidence object-store sink

Changes: CHANGELOG v0.29.0 entry + Helm chart `0.28.0` → `0.29.0`. No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)