### PR TITLE
feat(sso): map IdP groups to Keyorix roles on login (opt-in)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -685,6 +685,9 @@ sso:
       default_role: system_viewer # baseline role for JIT-provisioned users
       group_sync: false          # reconcile native group memberships from the IdP (default off)
       groups_claim: groups       # id_token claim carrying group names (default "groups")
+      group_role_map:            # map IdP groups → Keyorix system roles (optional)
+        keyorix-admins: system_admin
+        keyorix-auditors: system_auditor
 ```
 
 > The client secret is read from `KEYORIX_SSO_<NAME>_CLIENT_SECRET` (name upper-cased,
@@ -728,6 +731,33 @@ audited as `auth.sso_groups_synced`.
 > sync is a safe no-op — it never strips memberships on a missing claim. Ensure the IdP
 > is configured to emit the group claim in the id_token (in Okta, add a groups claim to
 > the ID token; in Entra, configure the optional `groups` claim).
+
+**Group → role mapping.** `group_role_map` maps an IdP group (from the same
+`groups_claim`) to a Keyorix **system role**, so the IdP can drive role assignment
+directly — e.g. members of `keyorix-admins` become `system_admin` on login. It is
+**authoritative only over the mapped roles**: on each login the user is granted the
+roles their asserted groups map to and **loses any mapped role they no longer
+qualify for**, while roles *not* named in the map are never touched (so manually
+granted roles are safe). Like `group_sync`, an absent groups claim is a no-op (it
+won't strip roles), an unknown role name is skipped, and roles are bound at global
+scope. This works independently of `group_sync` (you can map roles without syncing
+group memberships, or both). Changes are audited as `auth.sso_roles_synced`.
+
+> Because it is authoritative over the mapped roles, prefer managing those roles
+> **only** through the IdP — a mapped role granted manually to an SSO user is removed
+> on their next login if the IdP doesn't assert the corresponding group.
+>
+> ⚠️ **Security — the mapped IdP groups become privilege grants.** Membership of any
+> group named in `group_role_map` directly drives Keyorix authorization on every
+> login, and a group mapped to `system_admin` confers **global administrator** access.
+> Only map groups whose membership is **governed by your IdP administrators** (e.g. an
+> Okta/Entra group whose roster only IdP admins can change) — never a self-service,
+> open-enrolment, or user-requestable group, or anyone who can join that group at the
+> IdP gains the mapped Keyorix role. Treat the mapping like handing out the role
+> itself: scope it to the least-privileged role that fits, and reserve admin mappings
+> for tightly controlled groups. Keyorix trusts the IdP's `groups` claim (verified
+> id_token) as the source of truth, so the IdP's group governance *is* your Keyorix
+> RBAC governance for these roles.
 
 ## membership
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -748,6 +748,11 @@ type SSOProviderConfig struct {
 	// GroupsClaim is the id_token claim carrying the group names (default "groups";
 	// some IdPs use "roles").
 	GroupsClaim string `yaml:"groups_claim"`
+	// GroupRoleMap maps an IdP group-claim value to a Keyorix (system) role name. When
+	// set, each login reconciles the user's grants of the MAPPED roles to their
+	// asserted groups (the IdP drives those assignments); roles outside the map are
+	// untouched. Uses groups_claim as the source. e.g. {keyorix-admins: system_admin}.
+	GroupRoleMap map[string]string `yaml:"group_role_map"`
 }
 
 // GetClientSecret returns the resolved client secret, preferring the per-provider

--- a/internal/core/sso.go
+++ b/internal/core/sso.go
@@ -35,6 +35,7 @@ const (
 	EventSSOLogin        = "auth.sso_login"
 	EventSSOJITProvision = "auth.sso_jit_provisioned"
 	EventSSOGroupsSynced = "auth.sso_groups_synced"
+	EventSSORolesSynced  = "auth.sso_roles_synced"
 	ssoClockSkew         = 60 * time.Second
 	ssoCompleteSuffix    = "/auth/sso/complete"
 	ssoDefaultRole       = "system_viewer"
@@ -54,6 +55,12 @@ type SSOProvider struct {
 
 	GroupSync   bool   // reconcile native group memberships from the IdP groups claim on login
 	GroupsClaim string // id_token claim carrying group names ("" → "groups")
+
+	// GroupRoleMap maps an IdP group-claim value to a Keyorix (system) role name. When
+	// non-empty, each login reconciles the user's grants of the MAPPED roles to match
+	// their asserted groups — the IdP drives those role assignments. Roles outside the
+	// map are never touched (so manual grants are safe).
+	GroupRoleMap map[string]string
 }
 
 // SetSSOProviders wires the configured providers (built from config + discovery at
@@ -161,10 +168,14 @@ func (c *KeyorixCore) CompleteSSO(ctx context.Context, providerName, code, state
 		return nil, nil, "", fmt.Errorf("account suspended")
 	}
 
-	// Reconcile native group memberships from the IdP's groups claim (best-effort —
-	// a sync failure must not block an otherwise-valid login).
+	// Reconcile native group memberships and/or mapped role grants from the IdP's
+	// groups claim (best-effort — a sync failure must not block an otherwise-valid
+	// login).
 	if p.GroupSync {
 		c.syncSSOGroups(ctx, p, user.ID, rawID)
+	}
+	if len(p.GroupRoleMap) > 0 {
+		c.syncSSORoles(ctx, p, user.ID, rawID)
 	}
 
 	session, err := c.mintSession(ctx, user.ID, userAgent, ip)
@@ -318,6 +329,78 @@ func (c *KeyorixCore) syncSSOGroups(ctx context.Context, p *SSOProvider, userID 
 	if added > 0 || removed > 0 {
 		c.writeAuditEvent(ctx, EventSSOGroupsSynced, actorPtr(userID), nil,
 			fmt.Sprintf("SSO group sync via %s: user %d (+%d/-%d native group memberships)", p.Name, userID, added, removed))
+	}
+}
+
+// syncSSORoles reconciles the user's grants of the MAPPED (system) roles to match the
+// roles their asserted IdP groups map to via GroupRoleMap — so the IdP drives those
+// role assignments. It is authoritative ONLY over the set of roles named in the map
+// (the "managed" roles): a managed role is granted when an asserted group maps to it
+// and removed when none do; a role NOT in the map is never touched, so manual grants
+// survive. Like group sync, an ABSENT groups claim is a no-op (so an IdP that omits
+// groups can't strip a user's roles), and it is best-effort (never blocks login).
+// Roles are bound at global scope (system roles); an unknown mapped role is skipped.
+func (c *KeyorixCore) syncSSORoles(ctx context.Context, p *SSOProvider, userID uint, rawID string) {
+	claim := strings.TrimSpace(p.GroupsClaim)
+	if claim == "" {
+		claim = ssoDefaultGroupClaim
+	}
+	asserted, present := extractTokenStringList(rawID, claim)
+	if !present {
+		return // IdP did not assert groups in the id_token — leave roles untouched.
+	}
+	assertedSet := make(map[string]bool, len(asserted))
+	for _, g := range asserted {
+		if g = strings.TrimSpace(g); g != "" {
+			assertedSet[g] = true
+		}
+	}
+
+	// desiredRoles = role names an asserted group maps to; managedRoles = every role
+	// name the map can grant (the authoritative scope).
+	desiredRoles := make(map[string]bool)
+	managedRoles := make(map[string]bool)
+	for group, role := range p.GroupRoleMap {
+		role = strings.TrimSpace(role)
+		if role == "" {
+			continue
+		}
+		managedRoles[role] = true
+		if assertedSet[group] {
+			desiredRoles[role] = true
+		}
+	}
+
+	// The user's current global-scope role names.
+	current, err := c.storage.GetUserRoles(ctx, userID)
+	if err != nil {
+		return
+	}
+	currentSet := make(map[string]bool, len(current))
+	for _, r := range current {
+		currentSet[r.Name] = true
+	}
+
+	added, removed := 0, 0
+	for role := range managedRoles {
+		r, rerr := c.storage.GetRoleByName(ctx, role)
+		if rerr != nil {
+			continue // unknown role — skip rather than fail the login
+		}
+		switch {
+		case desiredRoles[role] && !currentSet[role]:
+			if c.storage.AssignRole(ctx, userID, r.ID, Scope{}) == nil {
+				added++
+			}
+		case !desiredRoles[role] && currentSet[role]:
+			if c.storage.RemoveRole(ctx, userID, r.ID, Scope{}) == nil {
+				removed++
+			}
+		}
+	}
+	if added > 0 || removed > 0 {
+		c.writeAuditEvent(ctx, EventSSORolesSynced, actorPtr(userID), nil,
+			fmt.Sprintf("SSO role mapping via %s: user %d (+%d/-%d mapped role grants)", p.Name, userID, added, removed))
 	}
 }
 

--- a/internal/core/sso_test.go
+++ b/internal/core/sso_test.go
@@ -324,6 +324,51 @@ func TestSyncSSOGroups(t *testing.T) {
 	})
 }
 
+func TestSyncSSORoles(t *testing.T) {
+	t.Run("authoritative over mapped roles only", func(t *testing.T) {
+		c, store, key, p := ssoTestCore(t)
+		p.GroupRoleMap = map[string]string{"keyorix-admins": "system_admin", "keyorix-auditors": "system_auditor"}
+		// IdP asserts only keyorix-admins → system_admin desired; system_auditor (mapped,
+		// not asserted) must be removed; system_viewer (NOT mapped) left alone.
+		raw := signToken(t, key, "kid-1", jwt.MapClaims{"groups": []string{"keyorix-admins"}})
+		store.On("GetUserRoles", mock.Anything, uint(7)).Return([]*models.Role{
+			{ID: 20, Name: "system_auditor"}, {ID: 30, Name: "system_viewer"},
+		}, nil)
+		store.On("GetRoleByName", mock.Anything, "system_admin").Return(&models.Role{ID: 10, Name: "system_admin"}, nil)
+		store.On("GetRoleByName", mock.Anything, "system_auditor").Return(&models.Role{ID: 20, Name: "system_auditor"}, nil)
+		store.On("AssignRole", mock.Anything, uint(7), uint(10), mock.Anything).Return(nil)
+		store.On("RemoveRole", mock.Anything, uint(7), uint(20), mock.Anything).Return(nil)
+		store.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
+
+		c.syncSSORoles(context.Background(), p, 7, raw)
+
+		store.AssertCalled(t, "AssignRole", mock.Anything, uint(7), uint(10), mock.Anything)    // system_admin granted
+		store.AssertCalled(t, "RemoveRole", mock.Anything, uint(7), uint(20), mock.Anything)    // system_auditor revoked
+		store.AssertNotCalled(t, "RemoveRole", mock.Anything, uint(7), uint(30), mock.Anything) // system_viewer (unmapped) untouched
+	})
+
+	t.Run("absent groups claim → no-op (never touches roles)", func(t *testing.T) {
+		c, store, key, p := ssoTestCore(t)
+		p.GroupRoleMap = map[string]string{"keyorix-admins": "system_admin"}
+		raw := signToken(t, key, "kid-1", jwt.MapClaims{"sub": "okta|1"}) // no groups claim
+
+		c.syncSSORoles(context.Background(), p, 7, raw)
+		store.AssertNotCalled(t, "GetUserRoles", mock.Anything, mock.Anything)
+		store.AssertNotCalled(t, "RemoveRole", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	})
+
+	t.Run("unknown mapped role is skipped, login not failed", func(t *testing.T) {
+		c, store, key, p := ssoTestCore(t)
+		p.GroupRoleMap = map[string]string{"keyorix-admins": "does_not_exist"}
+		raw := signToken(t, key, "kid-1", jwt.MapClaims{"groups": []string{"keyorix-admins"}})
+		store.On("GetUserRoles", mock.Anything, uint(7)).Return([]*models.Role{}, nil)
+		store.On("GetRoleByName", mock.Anything, "does_not_exist").Return((*models.Role)(nil), fmt.Errorf("%s", i18n.T("ErrorUserNotFound", nil)))
+
+		c.syncSSORoles(context.Background(), p, 7, raw)
+		store.AssertNotCalled(t, "AssignRole", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	})
+}
+
 func TestBeginSSO_BuildsAuthURLWithStateAndNonce(t *testing.T) {
 	c, store, _, _ := ssoTestCore(t)
 	var captured *models.SSOLoginState

--- a/server/main.go
+++ b/server/main.go
@@ -1152,6 +1152,7 @@ func buildSSOProviders(sso config.SSOConfig) (map[string]*core.SSOProvider, core
 			DefaultRole:   pc.DefaultRole,
 			GroupSync:     pc.GroupSync,
 			GroupsClaim:   pc.GroupsClaim,
+			GroupRoleMap:  pc.GroupRoleMap,
 		}
 		jwksURIs[pc.Issuer] = disc.JWKSURI
 	}


### PR DESCRIPTION
## What

Extends SSO group handling (#210): `group_role_map` maps an IdP group-claim value to a Keyorix **system role**, so the IdP can drive role assignment directly (e.g. `keyorix-admins` → `system_admin`) without pre-granting roles in Keyorix.

## How

- **Authoritative only over the mapped roles**: on each login the user is granted the roles their asserted groups map to and **loses any mapped role they no longer qualify for**; roles *not* named in the map are never touched (manual grants survive).
- Like `group_sync`: an **absent** groups claim is a no-op (won't strip roles), an unknown role name is skipped, roles bind at global scope, and it's **best-effort** (never blocks login). Works independently of `group_sync`. Audited as `auth.sso_roles_synced`.
- `core.SSOProvider.GroupRoleMap` + `syncSSORoles` (reuses the verified-token groups extraction, hooked into `CompleteSSO` after the suspended check, before session mint); `config.SSOProviderConfig.GroupRoleMap`; wired through `main`.

## Security

Reviewed via the security-review skill — **no new vulnerabilities**. The token is fully verified before sync; the map is operator-controlled config; it adds no trust surface beyond the existing `group_sync` (which already consumes the same claim); revoke is scoped to mapped roles and can only reduce privilege; best-effort failures never leave an over-privileged state. The one actionable item — documentation — is included: a prominent caveat that mapped IdP groups become privilege grants and **must be governed by IdP administrators** (never self-service/open-enrolment groups), since a group mapped to `system_admin` confers global admin.

## Tests

`TestSyncSSORoles`: authoritative-over-mapped-roles (grant asserted, revoke mapped-but-unasserted, leave unmapped roles alone), absent-claim no-op, unknown-role skip. gofmt clean, golangci-lint 0, gitleaks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)