### PR TITLE
feat(compliance): S3 Object Lock legal-hold toggle on the evidence sink

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -471,6 +471,7 @@ evidence_delivery:
     use_path_style: false                   # set true for MinIO and some gateways
     lock_mode: ""                           # "" | governance | compliance (S3 Object Lock / WORM)
     lock_retain_days: 0                     # retention window; required (>0) when lock_mode is set
+    legal_hold: false                       # place an indefinite S3 Object Lock legal hold on each object
 ```
 
 > The off-box targets let evidence survive the node without a mounted volume. A file
@@ -497,6 +498,13 @@ evidence_delivery:
 > property Keyorix cannot set); this configures the per-object retention applied on
 > write. A misconfigured bucket surfaces as a delivery error (non-fatal when a local
 > file was also written).
+>
+> **Legal hold.** `legal_hold: true` additionally places an S3 Object Lock *legal
+> hold* on each uploaded object — an **indefinite** hold with no expiry date that
+> blocks deletion/overwrite until a principal with `s3:PutObjectLegalHold` explicitly
+> clears it (e.g. for litigation/investigation preservation). It is independent of
+> `lock_mode` (use either or both); like retention it requires the bucket to have
+> Object Lock enabled.
 
 When **encryption is enabled**, each exported pack is **signed**: a detached
 `<file>.json.sig` is written next to it (and the webhook delivery carries the

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -556,6 +556,10 @@ type EvidenceObjectStoreConfig struct {
 	LockMode string `yaml:"lock_mode"`
 	// LockRetainDays is the retention window in days; required (> 0) when LockMode set.
 	LockRetainDays int `yaml:"lock_retain_days"`
+	// LegalHold places an indefinite S3 Object Lock legal hold on each uploaded
+	// object (no expiry; cleared only out-of-band). Independent of LockMode; the
+	// bucket must have Object Lock enabled.
+	LegalHold bool `yaml:"legal_hold"`
 }
 
 // EvidenceWebhookConfig configures the off-box webhook target: each run POSTs the

--- a/internal/evidencesink/objectstore.go
+++ b/internal/evidencesink/objectstore.go
@@ -42,6 +42,11 @@ type ObjectStoreConfig struct {
 	// LockRetainDays is the retention period in days applied from upload time.
 	// Required (> 0) when LockMode is set.
 	LockRetainDays int
+	// LegalHold places an S3 Object Lock legal hold on each uploaded object — an
+	// indefinite hold (no expiry) that blocks deletion/overwrite until a principal
+	// with s3:PutObjectLegalHold explicitly clears it. Independent of LockMode; the
+	// bucket must have Object Lock enabled.
+	LegalHold bool
 }
 
 // s3PutAPI is the slice of the S3 client the sink uses — an interface seam so the
@@ -52,12 +57,13 @@ type s3PutAPI interface {
 
 // ObjectStore delivers the evidence pack to an S3-compatible bucket.
 type ObjectStore struct {
-	api      s3PutAPI
-	bucket   string
-	prefix   string
-	lockMode s3types.ObjectLockMode // "" when object lock is off
-	retain   time.Duration
-	now      func() time.Time
+	api       s3PutAPI
+	bucket    string
+	prefix    string
+	lockMode  s3types.ObjectLockMode // "" when object lock is off
+	retain    time.Duration
+	legalHold bool
+	now       func() time.Time
 }
 
 // objectLockMode maps the config string to the S3 enum, validating it.
@@ -102,12 +108,13 @@ func NewObjectStore(ctx context.Context, cfg ObjectStoreConfig) (*ObjectStore, e
 		o.UsePathStyle = cfg.UsePathStyle
 	})
 	return &ObjectStore{
-		api:      client,
-		bucket:   cfg.Bucket,
-		prefix:   normalizePrefix(cfg.Prefix),
-		lockMode: lockMode,
-		retain:   time.Duration(cfg.LockRetainDays) * 24 * time.Hour,
-		now:      time.Now,
+		api:       client,
+		bucket:    cfg.Bucket,
+		prefix:    normalizePrefix(cfg.Prefix),
+		lockMode:  lockMode,
+		retain:    time.Duration(cfg.LockRetainDays) * 24 * time.Hour,
+		legalHold: cfg.LegalHold,
+		now:       time.Now,
 	}, nil
 }
 
@@ -140,13 +147,23 @@ func (o *ObjectStore) putInput(key string, body io.Reader, contentType string) *
 		in.ObjectLockMode = o.lockMode
 		in.ObjectLockRetainUntilDate = aws.Time(o.now().Add(o.retain))
 	}
+	if o.legalHold {
+		in.ObjectLockLegalHoldStatus = s3types.ObjectLockLegalHoldStatusOn
+	}
 	return in
 }
 
 // Target labels this forwarder in the export result.
 func (o *ObjectStore) Target() string {
+	var marks []string
 	if o.lockMode != "" {
-		return fmt.Sprintf("objectstore:%s/%s (lock:%s)", o.bucket, o.prefix, strings.ToLower(string(o.lockMode)))
+		marks = append(marks, "lock:"+strings.ToLower(string(o.lockMode)))
+	}
+	if o.legalHold {
+		marks = append(marks, "legal-hold")
+	}
+	if len(marks) > 0 {
+		return fmt.Sprintf("objectstore:%s/%s (%s)", o.bucket, o.prefix, strings.Join(marks, ","))
 	}
 	return fmt.Sprintf("objectstore:%s/%s", o.bucket, o.prefix)
 }

--- a/internal/evidencesink/objectstore_test.go
+++ b/internal/evidencesink/objectstore_test.go
@@ -17,6 +17,7 @@ type putCall struct {
 	bucket, key, body, ctype string
 	lockMode                 s3types.ObjectLockMode
 	retainUntil              *time.Time
+	legalHold                s3types.ObjectLockLegalHoldStatus
 }
 
 type fakeS3 struct {
@@ -28,7 +29,7 @@ func (f *fakeS3) PutObject(_ context.Context, in *s3.PutObjectInput, _ ...func(*
 	b, _ := io.ReadAll(in.Body)
 	f.calls = append(f.calls, putCall{
 		bucket: deref(in.Bucket), key: deref(in.Key), body: string(b), ctype: deref(in.ContentType),
-		lockMode: in.ObjectLockMode, retainUntil: in.ObjectLockRetainUntilDate,
+		lockMode: in.ObjectLockMode, retainUntil: in.ObjectLockRetainUntilDate, legalHold: in.ObjectLockLegalHoldStatus,
 	})
 	if f.err != nil {
 		return nil, f.err
@@ -88,6 +89,26 @@ func TestObjectStore_ObjectLockStampsRetentionOnEveryObject(t *testing.T) {
 		assert.Equal(t, fixed.Add(7*24*time.Hour), *c.retainUntil, "retain-until = now + window")
 	}
 	assert.Contains(t, o.Target(), "lock:compliance")
+}
+
+func TestObjectStore_LegalHoldStampsEveryObject(t *testing.T) {
+	api := &fakeS3{}
+	o := &ObjectStore{api: api, bucket: "evidence-bkt", prefix: "", legalHold: true, now: time.Now}
+
+	require.NoError(t, o.ForwardEvidence(context.Background(), "pack.json", []byte(`{}`), "v1:abc"))
+	require.Len(t, api.calls, 2)
+	for _, c := range api.calls {
+		assert.Equal(t, s3types.ObjectLockLegalHoldStatusOn, c.legalHold, "every object gets a legal hold")
+		assert.Empty(t, string(c.lockMode), "legal hold is independent of retention mode")
+	}
+	assert.Contains(t, o.Target(), "legal-hold")
+}
+
+func TestObjectStore_NoLegalHoldByDefault(t *testing.T) {
+	api := &fakeS3{}
+	o := newTestObjectStore(api, "")
+	require.NoError(t, o.ForwardEvidence(context.Background(), "pack.json", []byte(`{}`), ""))
+	assert.Empty(t, string(api.calls[0].legalHold))
 }
 
 func TestNewObjectStore_ObjectLockValidation(t *testing.T) {

--- a/server/main.go
+++ b/server/main.go
@@ -328,6 +328,7 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 			UsePathStyle:   os.UsePathStyle,
 			LockMode:       os.LockMode,
 			LockRetainDays: os.LockRetainDays,
+			LegalHold:      os.LegalHold,
 		})
 		if oerr != nil {
 			return nil, nil, fmt.Errorf("failed to init evidence object-store target: %w", oerr)


### PR DESCRIPTION
## What

Complements the retention WORM control (#215) with an **S3 Object Lock legal hold** on the evidence object-store sink. When `legal_hold: true`, each uploaded evidence pack + signature gets an **indefinite** hold (no expiry date) that blocks deletion/overwrite until a principal with `s3:PutObjectLegalHold` explicitly clears it — for litigation/investigation preservation.

## How

- **`evidencesink`**: `ObjectStore.legalHold`; `putInput` sets `ObjectLockLegalHoldStatus=ON` on every PutObject (pack + `.sig`). **Independent of `lock_mode`** — use retention, legal hold, or both. `Target()` surfaces `legal-hold`.
- **Config**: `evidence_delivery.object_store.legal_hold`, wired through `main`.
- **Docs**: `CONFIGURATION.md` legal-hold note (indefinite; cleared out-of-band; bucket must have Object Lock enabled).

## Tests

`objectstore_test.go`: legal hold stamps `ON` on every object and is independent of retention mode; default = no hold. gofmt clean, golangci-lint 0, gitleaks clean. Config-only (no new routes); no new server dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)