### PR TITLE
chore(ci): bump actions off Node 20 (checkout@v6, setup-go@v6, setup-helm@v5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,10 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.26'
 
@@ -58,10 +58,10 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.26'
 
@@ -75,7 +75,7 @@ jobs:
   gitleaks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # Full history: a secret committed and later deleted is still leaked.
           fetch-depth: 0
@@ -91,10 +91,10 @@ jobs:
   helm-chart:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v5
 
       - name: helm lint
         run: |

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -14,7 +14,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Log in to GHCR
         uses: docker/login-action@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,10 +20,10 @@ jobs:
   build-and-release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.26'
 
@@ -45,10 +45,10 @@ jobs:
   publish-chart:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v5
 
       - name: Package + push chart to GHCR (OCI)
         env:


### PR DESCRIPTION
## What

Bumps the GitHub Actions that were emitting **Node 20 deprecation** annotations to their current Node-24 majors, ahead of the runner removing Node 20 on **Sept 16 2026**.

| Action | Was | Now |
|---|---|---|
| `actions/checkout` | v4 | **v6** |
| `actions/setup-go` | v5 | **v6** |
| `azure/setup-helm` | v4 | **v5** |

Across `ci.yml`, `release.yml`, `docker-publish.yml`. Versions verified as the current latest majors. Usages are bare or use stable inputs (`go-version: '1.26'`), so the major bumps carry no behaviour change.

`golangci-lint-action@v8` and the `docker/*` actions were **not** flagged as Node 20 and are left as-is to keep the change minimal.

## Validation

Self-validating — this PR's own CI run exercises the bumped `checkout`/`setup-go` (build-and-test, lint) and `setup-helm` (helm-chart) actions. If any version didn't resolve or changed behaviour, the run would fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)