### PR TITLE
feat(dynamic-secrets): AWS STS cloud-IAM backend (ADR-035)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -242,20 +242,31 @@ dynamic_secrets:
 Targets are registered via the API — or from the terminal with
 `keyorix dynamic-secret create` (the admin DSN is read from the
 `KEYORIX_DYNAMIC_ADMIN_DSN` env var or a hidden prompt, never a flag) — with an
-admin DSN, a backend type (`postgres`, `mysql`, `mongodb`, or `redis`), an optional
-creation template, and a default TTL. The creation template form depends on the
-backend:
+admin DSN, a backend type (`postgres`, `mysql`, `mongodb`, `redis`, or `aws-sts`), an
+optional creation template, and a default TTL. The creation template form depends on
+the backend:
 - SQL backends (`postgres`, `mysql`) — an SQL grant template using `{{name}}`.
 - `mongodb` — a JSON role spec (`{"roles": [{"role": "readWrite", "db": "app"}]}`);
   the admin DSN is a MongoDB connection URI.
 - `redis` — whitespace-separated ACL rule tokens (`~app:* +@read +@write`); the
   admin DSN is a Redis URI (`redis://:pass@host:6379/0`, or `rediss://…` for TLS)
   for a user that holds the `+acl` command.
+- `aws-sts` (cloud IAM) — the "admin DSN" is instead a small JSON config:
+  `{"role_arn":"arn:aws:iam::123456789012:role/keyorix-dyn","region":"eu-west-1","duration_seconds":3600}`
+  (only `role_arn` is required). Issuing a lease calls `sts:AssumeRole` and returns
+  short-lived **AWS credentials** (`access_key_id` / `secret_access_key` /
+  `session_token`) rather than a username/password. The optional creation template is
+  an inline **STS session policy** (JSON) that scopes the assumed role down. AWS
+  credentials for the AssumeRole call itself come from the standard chain
+  (env / instance-profile / IRSA), like the KMS and S3 integrations. STS credentials
+  are **self-expiring and cannot be revoked or renewed** — a revoke is a no-op and a
+  renew is refused (issue a new lease); minimum duration is 15 minutes (AWS limit).
 
 > **Enable the sweeper for MySQL, MongoDB and Redis targets.** Their accounts have
 > no `VALID UNTIL` equivalent, so a lease TTL is enforced *only* by the sweeper —
 > issuing is refused while it is disabled. PostgreSQL roles additionally carry a
-> DB-level expiry (belt-and-suspenders).
+> DB-level expiry (belt-and-suspenders). `aws-sts` is exempt: AWS enforces the
+> credential's expiry, so it can issue with the sweeper off.
 
 ---
 

--- a/internal/cli/dynamic/config_create.go
+++ b/internal/cli/dynamic/config_create.go
@@ -36,11 +36,19 @@ short-lived users — is read from the ` + adminDSNEnv + ` environment variable,
 prompted for with hidden input. It is never accepted as a flag (so it cannot land
 in shell history); the server encrypts it at rest and never returns it.
 
+For the aws-sts backend the "admin DSN" is instead a small JSON config
+({"role_arn":"...","region":"...","duration_seconds":3600}); the optional
+creation template is an inline STS session policy that scopes the assumed role
+down. AWS credentials for the AssumeRole call come from the standard chain
+(env / instance-profile / IRSA).
+
 Examples:
   keyorix dynamic-secret create --name app-db --project-id 1 --backend postgres \
     --creation-template 'GRANT SELECT ON ALL TABLES IN SCHEMA public TO {{name}};'
   keyorix dynamic-secret create --name cache --project-id 1 --backend redis \
-    --creation-template '~app:* +@read'`,
+    --creation-template '~app:* +@read'
+  # aws-sts: paste {"role_arn":"arn:aws:iam::123456789012:role/keyorix-dyn","region":"eu-west-1"} at the prompt
+  keyorix dynamic-secret create --name aws-readonly --project-id 1 --backend aws-sts`,
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		if cfgName == "" || cfgProjectID == 0 || cfgBackend == "" {
 			return fmt.Errorf("--name, --project-id and --backend are required")
@@ -97,7 +105,7 @@ func init() {
 	f.StringVar(&cfgName, "name", "", "Config name (required)")
 	f.IntVar(&cfgProjectID, "project-id", 0, "Project ID (required)")
 	f.IntVar(&cfgEnvID, "environment-id", 0, "Environment ID (0 = project-wide)")
-	f.StringVar(&cfgBackend, "backend", "", "Backend: postgres | mysql | mongodb | redis (required)")
+	f.StringVar(&cfgBackend, "backend", "", "Backend: postgres | mysql | mongodb | redis | aws-sts (required)")
 	f.StringVar(&cfgTemplate, "creation-template", "", "Backend-specific grant/role/ACL template ({{name}} for SQL)")
 	f.IntVar(&cfgDefaultTTL, "default-ttl", 0, "Default lease TTL in seconds (0 = server default)")
 	f.IntVar(&cfgMaxTTL, "max-ttl", 0, "Max lease TTL ceiling in seconds (0 = no ceiling)")

--- a/internal/cli/dynamic/dynamic.go
+++ b/internal/cli/dynamic/dynamic.go
@@ -8,11 +8,22 @@ package dynamic
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strconv"
 
 	"github.com/keyorixhq/keyorix/internal/cli/common"
 	"github.com/spf13/cobra"
 )
+
+// sortedKeys returns a map's keys in deterministic order, for stable CLI output.
+func sortedKeys(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
 
 // DynamicSecretCmd is the root `keyorix dynamic-secret` command.
 var DynamicSecretCmd = &cobra.Command{
@@ -57,10 +68,11 @@ type configView struct {
 }
 
 type issuedLease struct {
-	LeaseID   string `json:"lease_id"`
-	Username  string `json:"username"`
-	Password  string `json:"password"`
-	ExpiresAt string `json:"expires_at"`
+	LeaseID   string            `json:"lease_id"`
+	Username  string            `json:"username"`
+	Password  string            `json:"password"`
+	Fields    map[string]string `json:"fields"`
+	ExpiresAt string            `json:"expires_at"`
 }
 
 type leaseView struct {
@@ -124,8 +136,16 @@ var issueCmd = &cobra.Command{
 		}
 		fmt.Println("Credential issued — shown once, auto-revokes at expiry.")
 		fmt.Printf("  lease:    %s\n", lease.LeaseID)
-		fmt.Printf("  username: %s\n", lease.Username)
-		fmt.Printf("  password: %s\n", lease.Password)
+		if lease.Username != "" {
+			fmt.Printf("  username: %s\n", lease.Username)
+		}
+		if lease.Password != "" {
+			fmt.Printf("  password: %s\n", lease.Password)
+		}
+		// Cloud-IAM backends (AWS STS) return their credential as fields.
+		for _, k := range sortedKeys(lease.Fields) {
+			fmt.Printf("  %-9s %s\n", k+":", lease.Fields[k])
+		}
 		fmt.Printf("  expires:  %s\n", lease.ExpiresAt)
 		return nil
 	},

--- a/internal/core/dynamic_secrets.go
+++ b/internal/core/dynamic_secrets.go
@@ -32,12 +32,15 @@ type CreateDynamicSecretConfigRequest struct {
 	Classification string
 }
 
-// IssuedLease is the credential returned to the caller once, on issue.
+// IssuedLease is the credential returned to the caller once, on issue. Database
+// backends populate Username/Password; cloud-IAM backends (AWS STS) leave those
+// empty and populate Fields (access_key_id, secret_access_key, session_token, …).
 type IssuedLease struct {
-	LeaseID   string    `json:"lease_id"`
-	Username  string    `json:"username"`
-	Password  string    `json:"password"`
-	ExpiresAt time.Time `json:"expires_at"`
+	LeaseID   string            `json:"lease_id"`
+	Username  string            `json:"username,omitempty"`
+	Password  string            `json:"password,omitempty"`
+	Fields    map[string]string `json:"fields,omitempty"`
+	ExpiresAt time.Time         `json:"expires_at"`
 }
 
 // CreateDynamicSecretConfig validates the backend, encrypts the admin DSN, and
@@ -192,7 +195,7 @@ func (c *KeyorixCore) IssueLease(ctx context.Context, configID uint, ttlSeconds 
 	pid := cfg.ProjectID
 	c.writeAuditEventFull(ctx, "dynamic_lease.issued", &uid, nil, &pid, "",
 		fmt.Sprintf("issued dynamic credential (lease=%s, config=%q, ttl=%s)", lease.LeaseID, cfg.Name, ttl))
-	return &IssuedLease{LeaseID: lease.LeaseID, Username: cred.Username, Password: cred.Password, ExpiresAt: expiresAt}, nil
+	return &IssuedLease{LeaseID: lease.LeaseID, Username: cred.Username, Password: cred.Password, Fields: cred.Fields, ExpiresAt: expiresAt}, nil
 }
 
 // cleanupOrphanedRole drops a just-minted role after a post-mint failure aborts the
@@ -372,6 +375,11 @@ func (c *KeyorixCore) RenewLease(ctx context.Context, leaseID string, ttlSeconds
 	cfg, err := c.storage.GetDynamicSecretConfig(ctx, lease.ConfigID)
 	if err != nil {
 		return time.Time{}, fmt.Errorf("config not found")
+	}
+	// Cloud-IAM backends (AWS STS) mint self-expiring credentials whose lifetime is
+	// fixed by the provider at issue — they cannot be renewed; issue a new lease.
+	if eng, eerr := c.dynamicEngine(cfg.BackendType); eerr == nil && eng.IsEphemeralBackend() {
+		return time.Time{}, fmt.Errorf("the %s backend mints self-expiring credentials that cannot be renewed; issue a new lease instead", cfg.BackendType)
 	}
 	newExpiry := c.now().Add(c.dynamicTTL(cfg, ttlSeconds))
 	// Never let renewal push total lifetime past the config's max-TTL ceiling.

--- a/internal/core/dynamic_secrets_test.go
+++ b/internal/core/dynamic_secrets_test.go
@@ -202,6 +202,25 @@ func TestDynamicSecrets_RenewExtendsAndRespectsMaxTTL(t *testing.T) {
 	require.Error(t, err, "renewal beyond the max-TTL ceiling is rejected")
 }
 
+// An ephemeral (cloud-IAM, e.g. AWS STS) backend surfaces its credential via Fields
+// and refuses renewal — its lifetime is fixed by the provider at issue.
+func TestDynamicSecrets_EphemeralBackendFieldsAndRenewRefused(t *testing.T) {
+	c, _, fake, _ := newDynamicTestCore(t)
+	fake.Ephemeral = true
+	fake.IssueFields = map[string]string{"access_key_id": "AKIA", "session_token": "tok"}
+	ctx := context.Background()
+	cfg := mkConfig(t, c, ctx)
+
+	issued, err := c.IssueLease(ctx, cfg.ID, 0, 7)
+	require.NoError(t, err)
+	assert.Equal(t, "AKIA", issued.Fields["access_key_id"])
+	assert.Equal(t, "tok", issued.Fields["session_token"])
+
+	_, err = c.RenewLease(ctx, issued.LeaseID, 1200, 7)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot be renewed")
+}
+
 func TestDynamicSecrets_RevokeLeasesForConfig(t *testing.T) {
 	c, _, fake, _ := newDynamicTestCore(t)
 	ctx := context.Background()

--- a/internal/dynamic/awssts.go
+++ b/internal/dynamic/awssts.go
@@ -1,0 +1,144 @@
+// awssts.go — the AWS STS dynamic-secret backend (ADR-035, cloud-IAM): instead of
+// minting a role on a database, it calls sts:AssumeRole to hand back short-lived AWS
+// credentials (AccessKeyId / SecretAccessKey / SessionToken). These are ephemeral —
+// AWS enforces their expiry and they cannot be revoked or renewed, so Revoke is a
+// no-op and Renew is refused (issue a fresh lease instead).
+//
+// The encrypted "admin DSN" carries this backend's JSON config instead of a database
+// connection string:
+//
+//	{"role_arn":"arn:aws:iam::123456789012:role/keyorix-dynamic",
+//	 "region":"eu-west-1","external_id":"...","duration_seconds":3600}
+//
+// role_arn is required; the rest are optional. The optional creation template is used
+// as an inline STS *session policy* (JSON) to further scope-down the assumed role.
+// AWS credentials/region for the AssumeRole call itself come from the standard chain
+// (env / instance-profile / IRSA), exactly like the KMS and S3 integrations.
+package dynamic
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+)
+
+// stsMinDurationSeconds is the AWS AssumeRole minimum (15 minutes).
+const stsMinDurationSeconds int32 = 900
+
+// stsAssumeAPI is the slice of the STS client the engine uses — an interface seam so
+// the engine is unit-tested with a fake and the SDK stays contained here.
+type stsAssumeAPI interface {
+	AssumeRole(ctx context.Context, in *sts.AssumeRoleInput, optFns ...func(*sts.Options)) (*sts.AssumeRoleOutput, error)
+}
+
+// AWSSTSEngine mints temporary AWS credentials via sts:AssumeRole.
+type AWSSTSEngine struct {
+	// newClient builds an STS client for a region; nil uses the real AWS client
+	// (the standard credential chain). Tests inject a fake.
+	newClient func(ctx context.Context, region string) (stsAssumeAPI, error)
+}
+
+func (e *AWSSTSEngine) BackendType() string        { return "aws-sts" }
+func (e *AWSSTSEngine) SupportsNativeExpiry() bool { return true } // AWS enforces the credential TTL
+func (e *AWSSTSEngine) IsEphemeralBackend() bool   { return true }
+
+type awsSTSConfig struct {
+	RoleARN         string `json:"role_arn"`
+	Region          string `json:"region,omitempty"`
+	ExternalID      string `json:"external_id,omitempty"`
+	DurationSeconds int32  `json:"duration_seconds,omitempty"`
+}
+
+func (e *AWSSTSEngine) client(ctx context.Context, region string) (stsAssumeAPI, error) {
+	if e.newClient != nil {
+		return e.newClient(ctx, region)
+	}
+	var opts []func(*awsconfig.LoadOptions) error
+	if region != "" {
+		opts = append(opts, awsconfig.WithRegion(region))
+	}
+	cfg, err := awsconfig.LoadDefaultConfig(ctx, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("aws-sts: load AWS config: %w", err)
+	}
+	return sts.NewFromConfig(cfg), nil
+}
+
+// Issue assumes the configured role and returns the temporary credential. roleName
+// is the generated session name (used only as a lease label — there is nothing to
+// drop on revoke). creationTemplate, when set, is an inline session policy.
+func (e *AWSSTSEngine) Issue(ctx context.Context, adminDSN, creationTemplate string, ttl time.Duration) (Credential, string, error) {
+	var cfg awsSTSConfig
+	if err := json.Unmarshal([]byte(adminDSN), &cfg); err != nil {
+		return Credential{}, "", fmt.Errorf("aws-sts: config must be JSON ({\"role_arn\":...}): %w", err)
+	}
+	if strings.TrimSpace(cfg.RoleARN) == "" {
+		return Credential{}, "", fmt.Errorf("aws-sts: role_arn is required")
+	}
+
+	duration := cfg.DurationSeconds
+	if duration <= 0 {
+		duration = int32(ttl.Seconds())
+	}
+	if duration < stsMinDurationSeconds {
+		duration = stsMinDurationSeconds // AWS rejects anything below 15 minutes
+	}
+
+	suffix, err := randString(12)
+	if err != nil {
+		return Credential{}, "", err
+	}
+	sessionName := "keyorix-dyn-" + suffix
+
+	in := &sts.AssumeRoleInput{
+		RoleArn:         aws.String(cfg.RoleARN),
+		RoleSessionName: aws.String(sessionName),
+		DurationSeconds: aws.Int32(duration),
+	}
+	if cfg.ExternalID != "" {
+		in.ExternalId = aws.String(cfg.ExternalID)
+	}
+	if tmpl := strings.TrimSpace(creationTemplate); tmpl != "" {
+		in.Policy = aws.String(tmpl) // session policy scopes the assumed role down
+	}
+
+	client, err := e.client(ctx, cfg.Region)
+	if err != nil {
+		return Credential{}, "", err
+	}
+	out, err := client.AssumeRole(ctx, in)
+	if err != nil {
+		return Credential{}, "", fmt.Errorf("aws-sts: assume role: %w", err)
+	}
+	if out.Credentials == nil {
+		return Credential{}, "", fmt.Errorf("aws-sts: assume role returned no credentials")
+	}
+
+	fields := map[string]string{
+		"access_key_id":     aws.ToString(out.Credentials.AccessKeyId),
+		"secret_access_key": aws.ToString(out.Credentials.SecretAccessKey),
+		"session_token":     aws.ToString(out.Credentials.SessionToken),
+	}
+	if cfg.Region != "" {
+		fields["region"] = cfg.Region
+	}
+	if out.Credentials.Expiration != nil {
+		fields["expiration"] = out.Credentials.Expiration.UTC().Format(time.RFC3339)
+	}
+	return Credential{Fields: fields}, sessionName, nil
+}
+
+// Revoke is a no-op: STS credentials self-expire and cannot be invalidated early.
+func (e *AWSSTSEngine) Revoke(_ context.Context, _, _ string) error { return nil }
+
+// Renew is refused: an STS credential's lifetime is fixed at issue. core.RenewLease
+// guards on IsEphemeralBackend before reaching here; this is a defensive backstop.
+func (e *AWSSTSEngine) Renew(_ context.Context, _, _ string, _ time.Time) error {
+	return fmt.Errorf("aws-sts: credentials are not renewable; issue a new lease instead")
+}

--- a/internal/dynamic/awssts_test.go
+++ b/internal/dynamic/awssts_test.go
@@ -1,0 +1,84 @@
+package dynamic
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	ststypes "github.com/aws/aws-sdk-go-v2/service/sts/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeSTS struct {
+	in  *sts.AssumeRoleInput
+	out *sts.AssumeRoleOutput
+	err error
+}
+
+func (f *fakeSTS) AssumeRole(_ context.Context, in *sts.AssumeRoleInput, _ ...func(*sts.Options)) (*sts.AssumeRoleOutput, error) {
+	f.in = in
+	return f.out, f.err
+}
+
+func newFakeSTSEngine(fake *fakeSTS) *AWSSTSEngine {
+	return &AWSSTSEngine{newClient: func(_ context.Context, _ string) (stsAssumeAPI, error) { return fake, nil }}
+}
+
+func TestAWSSTSEngine_Issue(t *testing.T) {
+	exp := time.Now().Add(time.Hour)
+	fake := &fakeSTS{out: &sts.AssumeRoleOutput{Credentials: &ststypes.Credentials{
+		AccessKeyId: aws.String("AKIAEXAMPLE"), SecretAccessKey: aws.String("sekret"),
+		SessionToken: aws.String("tok"), Expiration: &exp,
+	}}}
+	eng := newFakeSTSEngine(fake)
+
+	cfg := `{"role_arn":"arn:aws:iam::123456789012:role/keyorix-dyn","region":"eu-west-1"}`
+	cred, role, err := eng.Issue(context.Background(), cfg, `{"Version":"2012-10-17"}`, time.Hour)
+	require.NoError(t, err)
+
+	assert.True(t, strings.HasPrefix(role, "keyorix-dyn-"))
+	assert.Equal(t, "AKIAEXAMPLE", cred.Fields["access_key_id"])
+	assert.Equal(t, "sekret", cred.Fields["secret_access_key"])
+	assert.Equal(t, "tok", cred.Fields["session_token"])
+	assert.Equal(t, "eu-west-1", cred.Fields["region"])
+	assert.Empty(t, cred.Username)
+	assert.Empty(t, cred.Password)
+
+	// The AssumeRole call carried role ARN, the session policy, and a >= ttl duration.
+	require.NotNil(t, fake.in)
+	assert.Equal(t, "arn:aws:iam::123456789012:role/keyorix-dyn", aws.ToString(fake.in.RoleArn))
+	assert.Equal(t, `{"Version":"2012-10-17"}`, aws.ToString(fake.in.Policy))
+	assert.Equal(t, int32(3600), aws.ToInt32(fake.in.DurationSeconds))
+
+	// Engine semantics.
+	assert.True(t, eng.IsEphemeralBackend())
+	assert.True(t, eng.SupportsNativeExpiry())
+	assert.Equal(t, "aws-sts", eng.BackendType())
+	require.NoError(t, eng.Revoke(context.Background(), "", role)) // no-op
+	require.Error(t, eng.Renew(context.Background(), "", role, time.Now()))
+}
+
+func TestAWSSTSEngine_DurationClampedToMin(t *testing.T) {
+	exp := time.Now().Add(time.Hour)
+	fake := &fakeSTS{out: &sts.AssumeRoleOutput{Credentials: &ststypes.Credentials{
+		AccessKeyId: aws.String("a"), SecretAccessKey: aws.String("b"), SessionToken: aws.String("c"), Expiration: &exp,
+	}}}
+	eng := newFakeSTSEngine(fake)
+	_, _, err := eng.Issue(context.Background(), `{"role_arn":"arn:aws:iam::1:role/r"}`, "", 60*time.Second)
+	require.NoError(t, err)
+	assert.Equal(t, int32(900), aws.ToInt32(fake.in.DurationSeconds)) // AWS 15-min minimum
+}
+
+func TestAWSSTSEngine_ConfigValidation(t *testing.T) {
+	eng := newFakeSTSEngine(&fakeSTS{})
+	// Not JSON.
+	_, _, err := eng.Issue(context.Background(), "postgres://x", "", time.Hour)
+	require.Error(t, err)
+	// Missing role_arn.
+	_, _, err = eng.Issue(context.Background(), `{"region":"eu-west-1"}`, "", time.Hour)
+	require.Error(t, err)
+}

--- a/internal/dynamic/engine.go
+++ b/internal/dynamic/engine.go
@@ -12,9 +12,13 @@ import (
 )
 
 // Credential is an issued, short-lived credential returned to the caller once.
+// Database backends populate Username/Password; cloud-IAM backends (e.g. AWS STS)
+// have no username/password and instead populate Fields (access_key_id,
+// secret_access_key, session_token, …).
 type Credential struct {
-	Username string `json:"username"`
-	Password string `json:"password"`
+	Username string            `json:"username,omitempty"`
+	Password string            `json:"password,omitempty"`
+	Fields   map[string]string `json:"fields,omitempty"`
 }
 
 // CredentialEngine mints and revokes credentials on a target backend. The admin
@@ -37,6 +41,12 @@ type CredentialEngine interface {
 	// the sweeper disabled would mint a credential whose TTL is never enforced.
 	SupportsNativeExpiry() bool
 	BackendType() string
+	// IsEphemeralBackend reports whether the backend mints self-expiring,
+	// non-revocable credentials (e.g. AWS STS) rather than a persistent role on a
+	// target. For such backends Revoke is a no-op (nothing to drop) and Renew is
+	// refused — the credential's lifetime is fixed by the cloud provider at issue,
+	// so a new lease must be issued instead of extending an existing one.
+	IsEphemeralBackend() bool
 }
 
 // New returns the engine for a backend type.
@@ -50,8 +60,10 @@ func New(backendType string) (CredentialEngine, error) {
 		return &MongoEngine{}, nil
 	case "redis":
 		return &RedisEngine{}, nil
+	case "aws-sts":
+		return &AWSSTSEngine{}, nil
 	default:
-		return nil, fmt.Errorf("unsupported dynamic-secret backend %q (supported: postgres, mysql, mongodb, redis)", backendType)
+		return nil, fmt.Errorf("unsupported dynamic-secret backend %q (supported: postgres, mysql, mongodb, redis, aws-sts)", backendType)
 	}
 }
 
@@ -84,11 +96,14 @@ type FakeEngine struct {
 	FailIssue    bool
 	FailRevoke   bool
 	FailRenew    bool
-	NativeExpiry bool // when true, mimics a backend with DB-level TTL (e.g. Postgres)
+	NativeExpiry bool              // when true, mimics a backend with DB-level TTL (e.g. Postgres)
+	Ephemeral    bool              // when true, mimics a cloud-IAM backend (no revoke, no renew)
+	IssueFields  map[string]string // when set, returned in the issued Credential.Fields
 }
 
 func (f *FakeEngine) BackendType() string        { return "fake" }
 func (f *FakeEngine) SupportsNativeExpiry() bool { return f.NativeExpiry }
+func (f *FakeEngine) IsEphemeralBackend() bool   { return f.Ephemeral }
 
 func (f *FakeEngine) Issue(_ context.Context, _, _ string, _ time.Duration) (Credential, string, error) {
 	f.mu.Lock()
@@ -103,7 +118,7 @@ func (f *FakeEngine) Issue(_ context.Context, _, _ string, _ time.Duration) (Cre
 	role := "kx_fake_" + suffix
 	pw, _ := randString(16)
 	f.Issued = append(f.Issued, role)
-	return Credential{Username: role, Password: pw}, role, nil
+	return Credential{Username: role, Password: pw, Fields: f.IssueFields}, role, nil
 }
 
 func (f *FakeEngine) Revoke(_ context.Context, _, roleName string) error {

--- a/internal/dynamic/engine_test.go
+++ b/internal/dynamic/engine_test.go
@@ -26,6 +26,11 @@ func TestNew_Backends(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "redis", rd.BackendType())
 
+	aws, err := New("aws-sts")
+	require.NoError(t, err)
+	assert.Equal(t, "aws-sts", aws.BackendType())
+	assert.True(t, aws.IsEphemeralBackend(), "aws-sts mints self-expiring credentials")
+
 	_, err = New("cassandra")
 	require.Error(t, err, "an unsupported backend is rejected")
 }

--- a/internal/dynamic/mongodb.go
+++ b/internal/dynamic/mongodb.go
@@ -32,7 +32,8 @@ import (
 // database.
 type MongoEngine struct{}
 
-func (e *MongoEngine) BackendType() string { return "mongodb" }
+func (e *MongoEngine) BackendType() string      { return "mongodb" }
+func (e *MongoEngine) IsEphemeralBackend() bool { return false }
 
 // SupportsNativeExpiry is false: MongoDB users have no native expiry, so lease
 // expiry is enforced only by the auto-revoke sweeper (which must be enabled).

--- a/internal/dynamic/mysql.go
+++ b/internal/dynamic/mysql.go
@@ -24,7 +24,8 @@ import (
 // and is the documented SQL-injection trust boundary.
 type MySQLEngine struct{}
 
-func (e *MySQLEngine) BackendType() string { return "mysql" }
+func (e *MySQLEngine) BackendType() string      { return "mysql" }
+func (e *MySQLEngine) IsEphemeralBackend() bool { return false }
 
 // SupportsNativeExpiry is false: MySQL users have no VALID UNTIL, so lease expiry
 // is enforced only by the auto-revoke sweeper (which must be enabled).

--- a/internal/dynamic/postgres.go
+++ b/internal/dynamic/postgres.go
@@ -13,7 +13,8 @@ import (
 // using the admin DSN, and drops them on revoke.
 type PostgresEngine struct{}
 
-func (e *PostgresEngine) BackendType() string { return "postgres" }
+func (e *PostgresEngine) BackendType() string      { return "postgres" }
+func (e *PostgresEngine) IsEphemeralBackend() bool { return false }
 
 // SupportsNativeExpiry is true: PostgreSQL roles carry a VALID UNTIL, so the
 // credential disables itself at expiry even without the auto-revoke sweeper.

--- a/internal/dynamic/redis.go
+++ b/internal/dynamic/redis.go
@@ -30,7 +30,8 @@ import (
 // analogue of the SQL creation_template / Mongo role spec).
 type RedisEngine struct{}
 
-func (e *RedisEngine) BackendType() string { return "redis" }
+func (e *RedisEngine) BackendType() string      { return "redis" }
+func (e *RedisEngine) IsEphemeralBackend() bool { return false }
 
 // SupportsNativeExpiry is false: Redis ACL users have no native expiry, so lease
 // expiry is enforced only by the auto-revoke sweeper (which must be enabled).

--- a/server/grpc/services/dynamic_secret_service.go
+++ b/server/grpc/services/dynamic_secret_service.go
@@ -161,6 +161,7 @@ func (s *DynamicSecretGRPCService) IssueLease(ctx context.Context, req *pb.Issue
 		LeaseId:   lease.LeaseID,
 		Username:  lease.Username,
 		Password:  lease.Password,
+		Fields:    lease.Fields,
 		ExpiresAt: timestamppb.New(lease.ExpiresAt),
 	}, nil
 }

--- a/server/proto/keyorix.proto
+++ b/server/proto/keyorix.proto
@@ -869,6 +869,9 @@ message IssuedCredential {
   string username = 2;
   string password = 3;
   optional google.protobuf.Timestamp expires_at = 4;
+  // fields carries cloud-IAM credentials (e.g. AWS STS access_key_id /
+  // secret_access_key / session_token) for backends with no username/password.
+  map<string, string> fields = 5;
 }
 
 message ListDynamicConfigsRequest {

--- a/server/proto/pb/keyorix.pb.go
+++ b/server/proto/pb/keyorix.pb.go
@@ -5932,11 +5932,14 @@ func (x *DynamicSecretLease) GetRevokedAt() *timestamppb.Timestamp {
 }
 
 type IssuedCredential struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	LeaseId       string                 `protobuf:"bytes,1,opt,name=lease_id,json=leaseId,proto3" json:"lease_id,omitempty"`
-	Username      string                 `protobuf:"bytes,2,opt,name=username,proto3" json:"username,omitempty"`
-	Password      string                 `protobuf:"bytes,3,opt,name=password,proto3" json:"password,omitempty"`
-	ExpiresAt     *timestamppb.Timestamp `protobuf:"bytes,4,opt,name=expires_at,json=expiresAt,proto3,oneof" json:"expires_at,omitempty"`
+	state     protoimpl.MessageState `protogen:"open.v1"`
+	LeaseId   string                 `protobuf:"bytes,1,opt,name=lease_id,json=leaseId,proto3" json:"lease_id,omitempty"`
+	Username  string                 `protobuf:"bytes,2,opt,name=username,proto3" json:"username,omitempty"`
+	Password  string                 `protobuf:"bytes,3,opt,name=password,proto3" json:"password,omitempty"`
+	ExpiresAt *timestamppb.Timestamp `protobuf:"bytes,4,opt,name=expires_at,json=expiresAt,proto3,oneof" json:"expires_at,omitempty"`
+	// fields carries cloud-IAM credentials (e.g. AWS STS access_key_id /
+	// secret_access_key / session_token) for backends with no username/password.
+	Fields        map[string]string `protobuf:"bytes,5,rep,name=fields,proto3" json:"fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -5995,6 +5998,13 @@ func (x *IssuedCredential) GetPassword() string {
 func (x *IssuedCredential) GetExpiresAt() *timestamppb.Timestamp {
 	if x != nil {
 		return x.ExpiresAt
+	}
+	return nil
+}
+
+func (x *IssuedCredential) GetFields() map[string]string {
+	if x != nil {
+		return x.Fields
 	}
 	return nil
 }
@@ -7336,13 +7346,17 @@ const file_keyorix_proto_rawDesc = "" +
 	"\n" +
 	"_issued_atB\r\n" +
 	"\v_expires_atB\r\n" +
-	"\v_revoked_at\"\xb4\x01\n" +
+	"\v_revoked_at\"\xb1\x02\n" +
 	"\x10IssuedCredential\x12\x19\n" +
 	"\blease_id\x18\x01 \x01(\tR\aleaseId\x12\x1a\n" +
 	"\busername\x18\x02 \x01(\tR\busername\x12\x1a\n" +
 	"\bpassword\x18\x03 \x01(\tR\bpassword\x12>\n" +
 	"\n" +
-	"expires_at\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampH\x00R\texpiresAt\x88\x01\x01B\r\n" +
+	"expires_at\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampH\x00R\texpiresAt\x88\x01\x01\x12@\n" +
+	"\x06fields\x18\x05 \x03(\v2(.keyorix.v1.IssuedCredential.FieldsEntryR\x06fields\x1a9\n" +
+	"\vFieldsEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01B\r\n" +
 	"\v_expires_at\"a\n" +
 	"\x19ListDynamicConfigsRequest\x12\x1d\n" +
 	"\n" +
@@ -7479,7 +7493,7 @@ func file_keyorix_proto_rawDescGZIP() []byte {
 	return file_keyorix_proto_rawDescData
 }
 
-var file_keyorix_proto_msgTypes = make([]protoimpl.MessageInfo, 101)
+var file_keyorix_proto_msgTypes = make([]protoimpl.MessageInfo, 102)
 var file_keyorix_proto_goTypes = []any{
 	(*Secret)(nil),                           // 0: keyorix.v1.Secret
 	(*SecretValue)(nil),                      // 1: keyorix.v1.SecretValue
@@ -7582,42 +7596,43 @@ var file_keyorix_proto_goTypes = []any{
 	nil,                                      // 98: keyorix.v1.UpdateSecretRequest.MetadataEntry
 	nil,                                      // 99: keyorix.v1.HealthResponse.ServicesEntry
 	nil,                                      // 100: keyorix.v1.SystemInfo.FeaturesEntry
-	(*timestamppb.Timestamp)(nil),            // 101: google.protobuf.Timestamp
-	(*emptypb.Empty)(nil),                    // 102: google.protobuf.Empty
+	nil,                                      // 101: keyorix.v1.IssuedCredential.FieldsEntry
+	(*timestamppb.Timestamp)(nil),            // 102: google.protobuf.Timestamp
+	(*emptypb.Empty)(nil),                    // 103: google.protobuf.Empty
 }
 var file_keyorix_proto_depIdxs = []int32{
-	101, // 0: keyorix.v1.Secret.expiration:type_name -> google.protobuf.Timestamp
+	102, // 0: keyorix.v1.Secret.expiration:type_name -> google.protobuf.Timestamp
 	96,  // 1: keyorix.v1.Secret.metadata:type_name -> keyorix.v1.Secret.MetadataEntry
-	101, // 2: keyorix.v1.Secret.created_at:type_name -> google.protobuf.Timestamp
-	101, // 3: keyorix.v1.Secret.updated_at:type_name -> google.protobuf.Timestamp
-	101, // 4: keyorix.v1.CreateSecretRequest.expiration:type_name -> google.protobuf.Timestamp
+	102, // 2: keyorix.v1.Secret.created_at:type_name -> google.protobuf.Timestamp
+	102, // 3: keyorix.v1.Secret.updated_at:type_name -> google.protobuf.Timestamp
+	102, // 4: keyorix.v1.CreateSecretRequest.expiration:type_name -> google.protobuf.Timestamp
 	97,  // 5: keyorix.v1.CreateSecretRequest.metadata:type_name -> keyorix.v1.CreateSecretRequest.MetadataEntry
-	101, // 6: keyorix.v1.UpdateSecretRequest.expiration:type_name -> google.protobuf.Timestamp
+	102, // 6: keyorix.v1.UpdateSecretRequest.expiration:type_name -> google.protobuf.Timestamp
 	98,  // 7: keyorix.v1.UpdateSecretRequest.metadata:type_name -> keyorix.v1.UpdateSecretRequest.MetadataEntry
 	0,   // 8: keyorix.v1.ListSecretsResponse.secrets:type_name -> keyorix.v1.Secret
-	101, // 9: keyorix.v1.SecretVersion.created_at:type_name -> google.protobuf.Timestamp
+	102, // 9: keyorix.v1.SecretVersion.created_at:type_name -> google.protobuf.Timestamp
 	9,   // 10: keyorix.v1.GetSecretVersionsResponse.versions:type_name -> keyorix.v1.SecretVersion
-	101, // 11: keyorix.v1.User.last_login_at:type_name -> google.protobuf.Timestamp
-	101, // 12: keyorix.v1.User.created_at:type_name -> google.protobuf.Timestamp
-	101, // 13: keyorix.v1.User.updated_at:type_name -> google.protobuf.Timestamp
+	102, // 11: keyorix.v1.User.last_login_at:type_name -> google.protobuf.Timestamp
+	102, // 12: keyorix.v1.User.created_at:type_name -> google.protobuf.Timestamp
+	102, // 13: keyorix.v1.User.updated_at:type_name -> google.protobuf.Timestamp
 	12,  // 14: keyorix.v1.CreateUserRequest.project_assignments:type_name -> keyorix.v1.ProjectAssignment
 	11,  // 15: keyorix.v1.CreateUserResponse.user:type_name -> keyorix.v1.User
 	11,  // 16: keyorix.v1.ListUsersResponse.users:type_name -> keyorix.v1.User
 	20,  // 17: keyorix.v1.Role.permissions:type_name -> keyorix.v1.Permission
-	101, // 18: keyorix.v1.Role.created_at:type_name -> google.protobuf.Timestamp
-	101, // 19: keyorix.v1.Role.updated_at:type_name -> google.protobuf.Timestamp
+	102, // 18: keyorix.v1.Role.created_at:type_name -> google.protobuf.Timestamp
+	102, // 19: keyorix.v1.Role.updated_at:type_name -> google.protobuf.Timestamp
 	21,  // 20: keyorix.v1.ListRolesResponse.roles:type_name -> keyorix.v1.Role
 	21,  // 21: keyorix.v1.GetUserRolesResponse.roles:type_name -> keyorix.v1.Role
-	101, // 22: keyorix.v1.AuditLog.event_time:type_name -> google.protobuf.Timestamp
-	101, // 23: keyorix.v1.GetAuditLogsRequest.start_time:type_name -> google.protobuf.Timestamp
-	101, // 24: keyorix.v1.GetAuditLogsRequest.end_time:type_name -> google.protobuf.Timestamp
+	102, // 22: keyorix.v1.AuditLog.event_time:type_name -> google.protobuf.Timestamp
+	102, // 23: keyorix.v1.GetAuditLogsRequest.start_time:type_name -> google.protobuf.Timestamp
+	102, // 24: keyorix.v1.GetAuditLogsRequest.end_time:type_name -> google.protobuf.Timestamp
 	33,  // 25: keyorix.v1.GetAuditLogsResponse.logs:type_name -> keyorix.v1.AuditLog
-	101, // 26: keyorix.v1.RBACAuditLog.created_at:type_name -> google.protobuf.Timestamp
+	102, // 26: keyorix.v1.RBACAuditLog.created_at:type_name -> google.protobuf.Timestamp
 	36,  // 27: keyorix.v1.GetRBACAuditLogsResponse.logs:type_name -> keyorix.v1.RBACAuditLog
-	101, // 28: keyorix.v1.ShareRecord.created_at:type_name -> google.protobuf.Timestamp
-	101, // 29: keyorix.v1.ShareRecord.updated_at:type_name -> google.protobuf.Timestamp
+	102, // 28: keyorix.v1.ShareRecord.created_at:type_name -> google.protobuf.Timestamp
+	102, // 29: keyorix.v1.ShareRecord.updated_at:type_name -> google.protobuf.Timestamp
 	40,  // 30: keyorix.v1.ListSharesResponse.shares:type_name -> keyorix.v1.ShareRecord
-	101, // 31: keyorix.v1.HealthResponse.timestamp:type_name -> google.protobuf.Timestamp
+	102, // 31: keyorix.v1.HealthResponse.timestamp:type_name -> google.protobuf.Timestamp
 	99,  // 32: keyorix.v1.HealthResponse.services:type_name -> keyorix.v1.HealthResponse.ServicesEntry
 	100, // 33: keyorix.v1.SystemInfo.features:type_name -> keyorix.v1.SystemInfo.FeaturesEntry
 	50,  // 34: keyorix.v1.SystemInfo.database:type_name -> keyorix.v1.DatabaseInfo
@@ -7627,145 +7642,146 @@ var file_keyorix_proto_depIdxs = []int32{
 	55,  // 38: keyorix.v1.Metrics.users:type_name -> keyorix.v1.UserMetrics
 	56,  // 39: keyorix.v1.Metrics.performance:type_name -> keyorix.v1.PerformanceMetrics
 	57,  // 40: keyorix.v1.Metrics.system:type_name -> keyorix.v1.SystemMetrics
-	101, // 41: keyorix.v1.Project.created_at:type_name -> google.protobuf.Timestamp
-	101, // 42: keyorix.v1.Project.updated_at:type_name -> google.protobuf.Timestamp
-	101, // 43: keyorix.v1.Environment.created_at:type_name -> google.protobuf.Timestamp
-	101, // 44: keyorix.v1.Environment.updated_at:type_name -> google.protobuf.Timestamp
+	102, // 41: keyorix.v1.Project.created_at:type_name -> google.protobuf.Timestamp
+	102, // 42: keyorix.v1.Project.updated_at:type_name -> google.protobuf.Timestamp
+	102, // 43: keyorix.v1.Environment.created_at:type_name -> google.protobuf.Timestamp
+	102, // 44: keyorix.v1.Environment.updated_at:type_name -> google.protobuf.Timestamp
 	58,  // 45: keyorix.v1.ListProjectsResponse.projects:type_name -> keyorix.v1.Project
 	59,  // 46: keyorix.v1.ListEnvironmentsResponse.environments:type_name -> keyorix.v1.Environment
-	101, // 47: keyorix.v1.MachineIdentity.created_at:type_name -> google.protobuf.Timestamp
-	101, // 48: keyorix.v1.MachineIdentity.updated_at:type_name -> google.protobuf.Timestamp
-	101, // 49: keyorix.v1.MachineIdentity.last_seen_at:type_name -> google.protobuf.Timestamp
-	101, // 50: keyorix.v1.MachineIdentity.revoked_at:type_name -> google.protobuf.Timestamp
-	101, // 51: keyorix.v1.MachineToken.last_used_at:type_name -> google.protobuf.Timestamp
-	101, // 52: keyorix.v1.MachineToken.expires_at:type_name -> google.protobuf.Timestamp
-	101, // 53: keyorix.v1.MachineToken.created_at:type_name -> google.protobuf.Timestamp
+	102, // 47: keyorix.v1.MachineIdentity.created_at:type_name -> google.protobuf.Timestamp
+	102, // 48: keyorix.v1.MachineIdentity.updated_at:type_name -> google.protobuf.Timestamp
+	102, // 49: keyorix.v1.MachineIdentity.last_seen_at:type_name -> google.protobuf.Timestamp
+	102, // 50: keyorix.v1.MachineIdentity.revoked_at:type_name -> google.protobuf.Timestamp
+	102, // 51: keyorix.v1.MachineToken.last_used_at:type_name -> google.protobuf.Timestamp
+	102, // 52: keyorix.v1.MachineToken.expires_at:type_name -> google.protobuf.Timestamp
+	102, // 53: keyorix.v1.MachineToken.created_at:type_name -> google.protobuf.Timestamp
 	67,  // 54: keyorix.v1.ListMachineIdentitiesResponse.machine_identities:type_name -> keyorix.v1.MachineIdentity
-	101, // 55: keyorix.v1.IssueMachineTokenResponse.expires_at:type_name -> google.protobuf.Timestamp
+	102, // 55: keyorix.v1.IssueMachineTokenResponse.expires_at:type_name -> google.protobuf.Timestamp
 	68,  // 56: keyorix.v1.ListMachineTokensResponse.tokens:type_name -> keyorix.v1.MachineToken
-	101, // 57: keyorix.v1.DynamicSecretConfig.created_at:type_name -> google.protobuf.Timestamp
-	101, // 58: keyorix.v1.DynamicSecretLease.issued_at:type_name -> google.protobuf.Timestamp
-	101, // 59: keyorix.v1.DynamicSecretLease.expires_at:type_name -> google.protobuf.Timestamp
-	101, // 60: keyorix.v1.DynamicSecretLease.revoked_at:type_name -> google.protobuf.Timestamp
-	101, // 61: keyorix.v1.IssuedCredential.expires_at:type_name -> google.protobuf.Timestamp
-	80,  // 62: keyorix.v1.ListDynamicConfigsResponse.configs:type_name -> keyorix.v1.DynamicSecretConfig
-	81,  // 63: keyorix.v1.ListLeasesResponse.leases:type_name -> keyorix.v1.DynamicSecretLease
-	101, // 64: keyorix.v1.RenewLeaseResponse.expires_at:type_name -> google.protobuf.Timestamp
-	2,   // 65: keyorix.v1.SecretService.CreateSecret:input_type -> keyorix.v1.CreateSecretRequest
-	3,   // 66: keyorix.v1.SecretService.GetSecret:input_type -> keyorix.v1.GetSecretRequest
-	3,   // 67: keyorix.v1.SecretService.GetSecretValue:input_type -> keyorix.v1.GetSecretRequest
-	4,   // 68: keyorix.v1.SecretService.UpdateSecret:input_type -> keyorix.v1.UpdateSecretRequest
-	5,   // 69: keyorix.v1.SecretService.DeleteSecret:input_type -> keyorix.v1.DeleteSecretRequest
-	6,   // 70: keyorix.v1.SecretService.ListSecrets:input_type -> keyorix.v1.ListSecretsRequest
-	8,   // 71: keyorix.v1.SecretService.GetSecretVersions:input_type -> keyorix.v1.GetSecretVersionsRequest
-	41,  // 72: keyorix.v1.ShareService.ShareSecret:input_type -> keyorix.v1.ShareSecretRequest
-	42,  // 73: keyorix.v1.ShareService.ListSecretShares:input_type -> keyorix.v1.ListSecretSharesRequest
-	43,  // 74: keyorix.v1.ShareService.ListUserShares:input_type -> keyorix.v1.ListUserSharesRequest
-	44,  // 75: keyorix.v1.ShareService.ListSharedSecrets:input_type -> keyorix.v1.ListSharedSecretsRequest
-	46,  // 76: keyorix.v1.ShareService.UpdateSharePermission:input_type -> keyorix.v1.UpdateSharePermissionRequest
-	47,  // 77: keyorix.v1.ShareService.RevokeShare:input_type -> keyorix.v1.RevokeShareRequest
-	13,  // 78: keyorix.v1.UserService.CreateUser:input_type -> keyorix.v1.CreateUserRequest
-	15,  // 79: keyorix.v1.UserService.GetUser:input_type -> keyorix.v1.GetUserRequest
-	16,  // 80: keyorix.v1.UserService.UpdateUser:input_type -> keyorix.v1.UpdateUserRequest
-	17,  // 81: keyorix.v1.UserService.DeleteUser:input_type -> keyorix.v1.DeleteUserRequest
-	18,  // 82: keyorix.v1.UserService.ListUsers:input_type -> keyorix.v1.ListUsersRequest
-	22,  // 83: keyorix.v1.RoleService.CreateRole:input_type -> keyorix.v1.CreateRoleRequest
-	23,  // 84: keyorix.v1.RoleService.GetRole:input_type -> keyorix.v1.GetRoleRequest
-	24,  // 85: keyorix.v1.RoleService.UpdateRole:input_type -> keyorix.v1.UpdateRoleRequest
-	25,  // 86: keyorix.v1.RoleService.DeleteRole:input_type -> keyorix.v1.DeleteRoleRequest
-	26,  // 87: keyorix.v1.RoleService.ListRoles:input_type -> keyorix.v1.ListRolesRequest
-	28,  // 88: keyorix.v1.RoleService.AssignRole:input_type -> keyorix.v1.AssignRoleRequest
-	30,  // 89: keyorix.v1.RoleService.RemoveRole:input_type -> keyorix.v1.RemoveRoleRequest
-	31,  // 90: keyorix.v1.RoleService.GetUserRoles:input_type -> keyorix.v1.GetUserRolesRequest
-	34,  // 91: keyorix.v1.AuditService.GetAuditLogs:input_type -> keyorix.v1.GetAuditLogsRequest
-	37,  // 92: keyorix.v1.AuditService.GetRBACAuditLogs:input_type -> keyorix.v1.GetRBACAuditLogsRequest
-	39,  // 93: keyorix.v1.AuditService.StreamAuditLogs:input_type -> keyorix.v1.StreamAuditLogsRequest
-	102, // 94: keyorix.v1.SystemService.HealthCheck:input_type -> google.protobuf.Empty
-	102, // 95: keyorix.v1.SystemService.GetSystemInfo:input_type -> google.protobuf.Empty
-	102, // 96: keyorix.v1.SystemService.GetMetrics:input_type -> google.protobuf.Empty
-	102, // 97: keyorix.v1.ProjectService.ListProjects:input_type -> google.protobuf.Empty
-	61,  // 98: keyorix.v1.ProjectService.GetProject:input_type -> keyorix.v1.GetProjectRequest
-	62,  // 99: keyorix.v1.ProjectService.CreateProject:input_type -> keyorix.v1.CreateProjectRequest
-	63,  // 100: keyorix.v1.ProjectService.UpdateProject:input_type -> keyorix.v1.UpdateProjectRequest
-	64,  // 101: keyorix.v1.ProjectService.DeleteProject:input_type -> keyorix.v1.DeleteProjectRequest
-	65,  // 102: keyorix.v1.ProjectService.ListEnvironments:input_type -> keyorix.v1.ListEnvironmentsRequest
-	69,  // 103: keyorix.v1.MachineIdentityService.ListMachineIdentities:input_type -> keyorix.v1.ListMachineIdentitiesRequest
-	71,  // 104: keyorix.v1.MachineIdentityService.CreateMachineIdentity:input_type -> keyorix.v1.CreateMachineIdentityRequest
-	72,  // 105: keyorix.v1.MachineIdentityService.TransitionMachineIdentity:input_type -> keyorix.v1.TransitionMachineIdentityRequest
-	73,  // 106: keyorix.v1.MachineIdentityService.ClassifyMachineIdentity:input_type -> keyorix.v1.ClassifyMachineIdentityRequest
-	74,  // 107: keyorix.v1.MachineIdentityService.IssueMachineToken:input_type -> keyorix.v1.IssueMachineTokenRequest
-	76,  // 108: keyorix.v1.MachineIdentityService.ListMachineTokens:input_type -> keyorix.v1.ListMachineTokensRequest
-	78,  // 109: keyorix.v1.MachineIdentityService.RevokeMachineToken:input_type -> keyorix.v1.RevokeMachineTokenRequest
-	79,  // 110: keyorix.v1.MachineIdentityService.ClassifyMachineToken:input_type -> keyorix.v1.ClassifyMachineTokenRequest
-	83,  // 111: keyorix.v1.DynamicSecretService.ListConfigs:input_type -> keyorix.v1.ListDynamicConfigsRequest
-	85,  // 112: keyorix.v1.DynamicSecretService.GetConfig:input_type -> keyorix.v1.GetDynamicConfigRequest
-	86,  // 113: keyorix.v1.DynamicSecretService.CreateConfig:input_type -> keyorix.v1.CreateDynamicConfigRequest
-	87,  // 114: keyorix.v1.DynamicSecretService.ClassifyConfig:input_type -> keyorix.v1.ClassifyDynamicConfigRequest
-	88,  // 115: keyorix.v1.DynamicSecretService.IssueLease:input_type -> keyorix.v1.IssueLeaseRequest
-	89,  // 116: keyorix.v1.DynamicSecretService.ListLeases:input_type -> keyorix.v1.ListLeasesRequest
-	91,  // 117: keyorix.v1.DynamicSecretService.RevokeLease:input_type -> keyorix.v1.RevokeLeaseRequest
-	92,  // 118: keyorix.v1.DynamicSecretService.RenewLease:input_type -> keyorix.v1.RenewLeaseRequest
-	94,  // 119: keyorix.v1.DynamicSecretService.RevokeAllLeases:input_type -> keyorix.v1.RevokeAllLeasesRequest
-	0,   // 120: keyorix.v1.SecretService.CreateSecret:output_type -> keyorix.v1.Secret
-	0,   // 121: keyorix.v1.SecretService.GetSecret:output_type -> keyorix.v1.Secret
-	1,   // 122: keyorix.v1.SecretService.GetSecretValue:output_type -> keyorix.v1.SecretValue
-	0,   // 123: keyorix.v1.SecretService.UpdateSecret:output_type -> keyorix.v1.Secret
-	102, // 124: keyorix.v1.SecretService.DeleteSecret:output_type -> google.protobuf.Empty
-	7,   // 125: keyorix.v1.SecretService.ListSecrets:output_type -> keyorix.v1.ListSecretsResponse
-	10,  // 126: keyorix.v1.SecretService.GetSecretVersions:output_type -> keyorix.v1.GetSecretVersionsResponse
-	40,  // 127: keyorix.v1.ShareService.ShareSecret:output_type -> keyorix.v1.ShareRecord
-	45,  // 128: keyorix.v1.ShareService.ListSecretShares:output_type -> keyorix.v1.ListSharesResponse
-	45,  // 129: keyorix.v1.ShareService.ListUserShares:output_type -> keyorix.v1.ListSharesResponse
-	7,   // 130: keyorix.v1.ShareService.ListSharedSecrets:output_type -> keyorix.v1.ListSecretsResponse
-	40,  // 131: keyorix.v1.ShareService.UpdateSharePermission:output_type -> keyorix.v1.ShareRecord
-	102, // 132: keyorix.v1.ShareService.RevokeShare:output_type -> google.protobuf.Empty
-	14,  // 133: keyorix.v1.UserService.CreateUser:output_type -> keyorix.v1.CreateUserResponse
-	11,  // 134: keyorix.v1.UserService.GetUser:output_type -> keyorix.v1.User
-	11,  // 135: keyorix.v1.UserService.UpdateUser:output_type -> keyorix.v1.User
-	102, // 136: keyorix.v1.UserService.DeleteUser:output_type -> google.protobuf.Empty
-	19,  // 137: keyorix.v1.UserService.ListUsers:output_type -> keyorix.v1.ListUsersResponse
-	21,  // 138: keyorix.v1.RoleService.CreateRole:output_type -> keyorix.v1.Role
-	21,  // 139: keyorix.v1.RoleService.GetRole:output_type -> keyorix.v1.Role
-	21,  // 140: keyorix.v1.RoleService.UpdateRole:output_type -> keyorix.v1.Role
-	102, // 141: keyorix.v1.RoleService.DeleteRole:output_type -> google.protobuf.Empty
-	27,  // 142: keyorix.v1.RoleService.ListRoles:output_type -> keyorix.v1.ListRolesResponse
-	29,  // 143: keyorix.v1.RoleService.AssignRole:output_type -> keyorix.v1.RoleAssignment
-	102, // 144: keyorix.v1.RoleService.RemoveRole:output_type -> google.protobuf.Empty
-	32,  // 145: keyorix.v1.RoleService.GetUserRoles:output_type -> keyorix.v1.GetUserRolesResponse
-	35,  // 146: keyorix.v1.AuditService.GetAuditLogs:output_type -> keyorix.v1.GetAuditLogsResponse
-	38,  // 147: keyorix.v1.AuditService.GetRBACAuditLogs:output_type -> keyorix.v1.GetRBACAuditLogsResponse
-	33,  // 148: keyorix.v1.AuditService.StreamAuditLogs:output_type -> keyorix.v1.AuditLog
-	48,  // 149: keyorix.v1.SystemService.HealthCheck:output_type -> keyorix.v1.HealthResponse
-	49,  // 150: keyorix.v1.SystemService.GetSystemInfo:output_type -> keyorix.v1.SystemInfo
-	52,  // 151: keyorix.v1.SystemService.GetMetrics:output_type -> keyorix.v1.Metrics
-	60,  // 152: keyorix.v1.ProjectService.ListProjects:output_type -> keyorix.v1.ListProjectsResponse
-	58,  // 153: keyorix.v1.ProjectService.GetProject:output_type -> keyorix.v1.Project
-	58,  // 154: keyorix.v1.ProjectService.CreateProject:output_type -> keyorix.v1.Project
-	58,  // 155: keyorix.v1.ProjectService.UpdateProject:output_type -> keyorix.v1.Project
-	102, // 156: keyorix.v1.ProjectService.DeleteProject:output_type -> google.protobuf.Empty
-	66,  // 157: keyorix.v1.ProjectService.ListEnvironments:output_type -> keyorix.v1.ListEnvironmentsResponse
-	70,  // 158: keyorix.v1.MachineIdentityService.ListMachineIdentities:output_type -> keyorix.v1.ListMachineIdentitiesResponse
-	67,  // 159: keyorix.v1.MachineIdentityService.CreateMachineIdentity:output_type -> keyorix.v1.MachineIdentity
-	67,  // 160: keyorix.v1.MachineIdentityService.TransitionMachineIdentity:output_type -> keyorix.v1.MachineIdentity
-	67,  // 161: keyorix.v1.MachineIdentityService.ClassifyMachineIdentity:output_type -> keyorix.v1.MachineIdentity
-	75,  // 162: keyorix.v1.MachineIdentityService.IssueMachineToken:output_type -> keyorix.v1.IssueMachineTokenResponse
-	77,  // 163: keyorix.v1.MachineIdentityService.ListMachineTokens:output_type -> keyorix.v1.ListMachineTokensResponse
-	102, // 164: keyorix.v1.MachineIdentityService.RevokeMachineToken:output_type -> google.protobuf.Empty
-	68,  // 165: keyorix.v1.MachineIdentityService.ClassifyMachineToken:output_type -> keyorix.v1.MachineToken
-	84,  // 166: keyorix.v1.DynamicSecretService.ListConfigs:output_type -> keyorix.v1.ListDynamicConfigsResponse
-	80,  // 167: keyorix.v1.DynamicSecretService.GetConfig:output_type -> keyorix.v1.DynamicSecretConfig
-	80,  // 168: keyorix.v1.DynamicSecretService.CreateConfig:output_type -> keyorix.v1.DynamicSecretConfig
-	80,  // 169: keyorix.v1.DynamicSecretService.ClassifyConfig:output_type -> keyorix.v1.DynamicSecretConfig
-	82,  // 170: keyorix.v1.DynamicSecretService.IssueLease:output_type -> keyorix.v1.IssuedCredential
-	90,  // 171: keyorix.v1.DynamicSecretService.ListLeases:output_type -> keyorix.v1.ListLeasesResponse
-	102, // 172: keyorix.v1.DynamicSecretService.RevokeLease:output_type -> google.protobuf.Empty
-	93,  // 173: keyorix.v1.DynamicSecretService.RenewLease:output_type -> keyorix.v1.RenewLeaseResponse
-	95,  // 174: keyorix.v1.DynamicSecretService.RevokeAllLeases:output_type -> keyorix.v1.RevokeAllLeasesResponse
-	120, // [120:175] is the sub-list for method output_type
-	65,  // [65:120] is the sub-list for method input_type
-	65,  // [65:65] is the sub-list for extension type_name
-	65,  // [65:65] is the sub-list for extension extendee
-	0,   // [0:65] is the sub-list for field type_name
+	102, // 57: keyorix.v1.DynamicSecretConfig.created_at:type_name -> google.protobuf.Timestamp
+	102, // 58: keyorix.v1.DynamicSecretLease.issued_at:type_name -> google.protobuf.Timestamp
+	102, // 59: keyorix.v1.DynamicSecretLease.expires_at:type_name -> google.protobuf.Timestamp
+	102, // 60: keyorix.v1.DynamicSecretLease.revoked_at:type_name -> google.protobuf.Timestamp
+	102, // 61: keyorix.v1.IssuedCredential.expires_at:type_name -> google.protobuf.Timestamp
+	101, // 62: keyorix.v1.IssuedCredential.fields:type_name -> keyorix.v1.IssuedCredential.FieldsEntry
+	80,  // 63: keyorix.v1.ListDynamicConfigsResponse.configs:type_name -> keyorix.v1.DynamicSecretConfig
+	81,  // 64: keyorix.v1.ListLeasesResponse.leases:type_name -> keyorix.v1.DynamicSecretLease
+	102, // 65: keyorix.v1.RenewLeaseResponse.expires_at:type_name -> google.protobuf.Timestamp
+	2,   // 66: keyorix.v1.SecretService.CreateSecret:input_type -> keyorix.v1.CreateSecretRequest
+	3,   // 67: keyorix.v1.SecretService.GetSecret:input_type -> keyorix.v1.GetSecretRequest
+	3,   // 68: keyorix.v1.SecretService.GetSecretValue:input_type -> keyorix.v1.GetSecretRequest
+	4,   // 69: keyorix.v1.SecretService.UpdateSecret:input_type -> keyorix.v1.UpdateSecretRequest
+	5,   // 70: keyorix.v1.SecretService.DeleteSecret:input_type -> keyorix.v1.DeleteSecretRequest
+	6,   // 71: keyorix.v1.SecretService.ListSecrets:input_type -> keyorix.v1.ListSecretsRequest
+	8,   // 72: keyorix.v1.SecretService.GetSecretVersions:input_type -> keyorix.v1.GetSecretVersionsRequest
+	41,  // 73: keyorix.v1.ShareService.ShareSecret:input_type -> keyorix.v1.ShareSecretRequest
+	42,  // 74: keyorix.v1.ShareService.ListSecretShares:input_type -> keyorix.v1.ListSecretSharesRequest
+	43,  // 75: keyorix.v1.ShareService.ListUserShares:input_type -> keyorix.v1.ListUserSharesRequest
+	44,  // 76: keyorix.v1.ShareService.ListSharedSecrets:input_type -> keyorix.v1.ListSharedSecretsRequest
+	46,  // 77: keyorix.v1.ShareService.UpdateSharePermission:input_type -> keyorix.v1.UpdateSharePermissionRequest
+	47,  // 78: keyorix.v1.ShareService.RevokeShare:input_type -> keyorix.v1.RevokeShareRequest
+	13,  // 79: keyorix.v1.UserService.CreateUser:input_type -> keyorix.v1.CreateUserRequest
+	15,  // 80: keyorix.v1.UserService.GetUser:input_type -> keyorix.v1.GetUserRequest
+	16,  // 81: keyorix.v1.UserService.UpdateUser:input_type -> keyorix.v1.UpdateUserRequest
+	17,  // 82: keyorix.v1.UserService.DeleteUser:input_type -> keyorix.v1.DeleteUserRequest
+	18,  // 83: keyorix.v1.UserService.ListUsers:input_type -> keyorix.v1.ListUsersRequest
+	22,  // 84: keyorix.v1.RoleService.CreateRole:input_type -> keyorix.v1.CreateRoleRequest
+	23,  // 85: keyorix.v1.RoleService.GetRole:input_type -> keyorix.v1.GetRoleRequest
+	24,  // 86: keyorix.v1.RoleService.UpdateRole:input_type -> keyorix.v1.UpdateRoleRequest
+	25,  // 87: keyorix.v1.RoleService.DeleteRole:input_type -> keyorix.v1.DeleteRoleRequest
+	26,  // 88: keyorix.v1.RoleService.ListRoles:input_type -> keyorix.v1.ListRolesRequest
+	28,  // 89: keyorix.v1.RoleService.AssignRole:input_type -> keyorix.v1.AssignRoleRequest
+	30,  // 90: keyorix.v1.RoleService.RemoveRole:input_type -> keyorix.v1.RemoveRoleRequest
+	31,  // 91: keyorix.v1.RoleService.GetUserRoles:input_type -> keyorix.v1.GetUserRolesRequest
+	34,  // 92: keyorix.v1.AuditService.GetAuditLogs:input_type -> keyorix.v1.GetAuditLogsRequest
+	37,  // 93: keyorix.v1.AuditService.GetRBACAuditLogs:input_type -> keyorix.v1.GetRBACAuditLogsRequest
+	39,  // 94: keyorix.v1.AuditService.StreamAuditLogs:input_type -> keyorix.v1.StreamAuditLogsRequest
+	103, // 95: keyorix.v1.SystemService.HealthCheck:input_type -> google.protobuf.Empty
+	103, // 96: keyorix.v1.SystemService.GetSystemInfo:input_type -> google.protobuf.Empty
+	103, // 97: keyorix.v1.SystemService.GetMetrics:input_type -> google.protobuf.Empty
+	103, // 98: keyorix.v1.ProjectService.ListProjects:input_type -> google.protobuf.Empty
+	61,  // 99: keyorix.v1.ProjectService.GetProject:input_type -> keyorix.v1.GetProjectRequest
+	62,  // 100: keyorix.v1.ProjectService.CreateProject:input_type -> keyorix.v1.CreateProjectRequest
+	63,  // 101: keyorix.v1.ProjectService.UpdateProject:input_type -> keyorix.v1.UpdateProjectRequest
+	64,  // 102: keyorix.v1.ProjectService.DeleteProject:input_type -> keyorix.v1.DeleteProjectRequest
+	65,  // 103: keyorix.v1.ProjectService.ListEnvironments:input_type -> keyorix.v1.ListEnvironmentsRequest
+	69,  // 104: keyorix.v1.MachineIdentityService.ListMachineIdentities:input_type -> keyorix.v1.ListMachineIdentitiesRequest
+	71,  // 105: keyorix.v1.MachineIdentityService.CreateMachineIdentity:input_type -> keyorix.v1.CreateMachineIdentityRequest
+	72,  // 106: keyorix.v1.MachineIdentityService.TransitionMachineIdentity:input_type -> keyorix.v1.TransitionMachineIdentityRequest
+	73,  // 107: keyorix.v1.MachineIdentityService.ClassifyMachineIdentity:input_type -> keyorix.v1.ClassifyMachineIdentityRequest
+	74,  // 108: keyorix.v1.MachineIdentityService.IssueMachineToken:input_type -> keyorix.v1.IssueMachineTokenRequest
+	76,  // 109: keyorix.v1.MachineIdentityService.ListMachineTokens:input_type -> keyorix.v1.ListMachineTokensRequest
+	78,  // 110: keyorix.v1.MachineIdentityService.RevokeMachineToken:input_type -> keyorix.v1.RevokeMachineTokenRequest
+	79,  // 111: keyorix.v1.MachineIdentityService.ClassifyMachineToken:input_type -> keyorix.v1.ClassifyMachineTokenRequest
+	83,  // 112: keyorix.v1.DynamicSecretService.ListConfigs:input_type -> keyorix.v1.ListDynamicConfigsRequest
+	85,  // 113: keyorix.v1.DynamicSecretService.GetConfig:input_type -> keyorix.v1.GetDynamicConfigRequest
+	86,  // 114: keyorix.v1.DynamicSecretService.CreateConfig:input_type -> keyorix.v1.CreateDynamicConfigRequest
+	87,  // 115: keyorix.v1.DynamicSecretService.ClassifyConfig:input_type -> keyorix.v1.ClassifyDynamicConfigRequest
+	88,  // 116: keyorix.v1.DynamicSecretService.IssueLease:input_type -> keyorix.v1.IssueLeaseRequest
+	89,  // 117: keyorix.v1.DynamicSecretService.ListLeases:input_type -> keyorix.v1.ListLeasesRequest
+	91,  // 118: keyorix.v1.DynamicSecretService.RevokeLease:input_type -> keyorix.v1.RevokeLeaseRequest
+	92,  // 119: keyorix.v1.DynamicSecretService.RenewLease:input_type -> keyorix.v1.RenewLeaseRequest
+	94,  // 120: keyorix.v1.DynamicSecretService.RevokeAllLeases:input_type -> keyorix.v1.RevokeAllLeasesRequest
+	0,   // 121: keyorix.v1.SecretService.CreateSecret:output_type -> keyorix.v1.Secret
+	0,   // 122: keyorix.v1.SecretService.GetSecret:output_type -> keyorix.v1.Secret
+	1,   // 123: keyorix.v1.SecretService.GetSecretValue:output_type -> keyorix.v1.SecretValue
+	0,   // 124: keyorix.v1.SecretService.UpdateSecret:output_type -> keyorix.v1.Secret
+	103, // 125: keyorix.v1.SecretService.DeleteSecret:output_type -> google.protobuf.Empty
+	7,   // 126: keyorix.v1.SecretService.ListSecrets:output_type -> keyorix.v1.ListSecretsResponse
+	10,  // 127: keyorix.v1.SecretService.GetSecretVersions:output_type -> keyorix.v1.GetSecretVersionsResponse
+	40,  // 128: keyorix.v1.ShareService.ShareSecret:output_type -> keyorix.v1.ShareRecord
+	45,  // 129: keyorix.v1.ShareService.ListSecretShares:output_type -> keyorix.v1.ListSharesResponse
+	45,  // 130: keyorix.v1.ShareService.ListUserShares:output_type -> keyorix.v1.ListSharesResponse
+	7,   // 131: keyorix.v1.ShareService.ListSharedSecrets:output_type -> keyorix.v1.ListSecretsResponse
+	40,  // 132: keyorix.v1.ShareService.UpdateSharePermission:output_type -> keyorix.v1.ShareRecord
+	103, // 133: keyorix.v1.ShareService.RevokeShare:output_type -> google.protobuf.Empty
+	14,  // 134: keyorix.v1.UserService.CreateUser:output_type -> keyorix.v1.CreateUserResponse
+	11,  // 135: keyorix.v1.UserService.GetUser:output_type -> keyorix.v1.User
+	11,  // 136: keyorix.v1.UserService.UpdateUser:output_type -> keyorix.v1.User
+	103, // 137: keyorix.v1.UserService.DeleteUser:output_type -> google.protobuf.Empty
+	19,  // 138: keyorix.v1.UserService.ListUsers:output_type -> keyorix.v1.ListUsersResponse
+	21,  // 139: keyorix.v1.RoleService.CreateRole:output_type -> keyorix.v1.Role
+	21,  // 140: keyorix.v1.RoleService.GetRole:output_type -> keyorix.v1.Role
+	21,  // 141: keyorix.v1.RoleService.UpdateRole:output_type -> keyorix.v1.Role
+	103, // 142: keyorix.v1.RoleService.DeleteRole:output_type -> google.protobuf.Empty
+	27,  // 143: keyorix.v1.RoleService.ListRoles:output_type -> keyorix.v1.ListRolesResponse
+	29,  // 144: keyorix.v1.RoleService.AssignRole:output_type -> keyorix.v1.RoleAssignment
+	103, // 145: keyorix.v1.RoleService.RemoveRole:output_type -> google.protobuf.Empty
+	32,  // 146: keyorix.v1.RoleService.GetUserRoles:output_type -> keyorix.v1.GetUserRolesResponse
+	35,  // 147: keyorix.v1.AuditService.GetAuditLogs:output_type -> keyorix.v1.GetAuditLogsResponse
+	38,  // 148: keyorix.v1.AuditService.GetRBACAuditLogs:output_type -> keyorix.v1.GetRBACAuditLogsResponse
+	33,  // 149: keyorix.v1.AuditService.StreamAuditLogs:output_type -> keyorix.v1.AuditLog
+	48,  // 150: keyorix.v1.SystemService.HealthCheck:output_type -> keyorix.v1.HealthResponse
+	49,  // 151: keyorix.v1.SystemService.GetSystemInfo:output_type -> keyorix.v1.SystemInfo
+	52,  // 152: keyorix.v1.SystemService.GetMetrics:output_type -> keyorix.v1.Metrics
+	60,  // 153: keyorix.v1.ProjectService.ListProjects:output_type -> keyorix.v1.ListProjectsResponse
+	58,  // 154: keyorix.v1.ProjectService.GetProject:output_type -> keyorix.v1.Project
+	58,  // 155: keyorix.v1.ProjectService.CreateProject:output_type -> keyorix.v1.Project
+	58,  // 156: keyorix.v1.ProjectService.UpdateProject:output_type -> keyorix.v1.Project
+	103, // 157: keyorix.v1.ProjectService.DeleteProject:output_type -> google.protobuf.Empty
+	66,  // 158: keyorix.v1.ProjectService.ListEnvironments:output_type -> keyorix.v1.ListEnvironmentsResponse
+	70,  // 159: keyorix.v1.MachineIdentityService.ListMachineIdentities:output_type -> keyorix.v1.ListMachineIdentitiesResponse
+	67,  // 160: keyorix.v1.MachineIdentityService.CreateMachineIdentity:output_type -> keyorix.v1.MachineIdentity
+	67,  // 161: keyorix.v1.MachineIdentityService.TransitionMachineIdentity:output_type -> keyorix.v1.MachineIdentity
+	67,  // 162: keyorix.v1.MachineIdentityService.ClassifyMachineIdentity:output_type -> keyorix.v1.MachineIdentity
+	75,  // 163: keyorix.v1.MachineIdentityService.IssueMachineToken:output_type -> keyorix.v1.IssueMachineTokenResponse
+	77,  // 164: keyorix.v1.MachineIdentityService.ListMachineTokens:output_type -> keyorix.v1.ListMachineTokensResponse
+	103, // 165: keyorix.v1.MachineIdentityService.RevokeMachineToken:output_type -> google.protobuf.Empty
+	68,  // 166: keyorix.v1.MachineIdentityService.ClassifyMachineToken:output_type -> keyorix.v1.MachineToken
+	84,  // 167: keyorix.v1.DynamicSecretService.ListConfigs:output_type -> keyorix.v1.ListDynamicConfigsResponse
+	80,  // 168: keyorix.v1.DynamicSecretService.GetConfig:output_type -> keyorix.v1.DynamicSecretConfig
+	80,  // 169: keyorix.v1.DynamicSecretService.CreateConfig:output_type -> keyorix.v1.DynamicSecretConfig
+	80,  // 170: keyorix.v1.DynamicSecretService.ClassifyConfig:output_type -> keyorix.v1.DynamicSecretConfig
+	82,  // 171: keyorix.v1.DynamicSecretService.IssueLease:output_type -> keyorix.v1.IssuedCredential
+	90,  // 172: keyorix.v1.DynamicSecretService.ListLeases:output_type -> keyorix.v1.ListLeasesResponse
+	103, // 173: keyorix.v1.DynamicSecretService.RevokeLease:output_type -> google.protobuf.Empty
+	93,  // 174: keyorix.v1.DynamicSecretService.RenewLease:output_type -> keyorix.v1.RenewLeaseResponse
+	95,  // 175: keyorix.v1.DynamicSecretService.RevokeAllLeases:output_type -> keyorix.v1.RevokeAllLeasesResponse
+	121, // [121:176] is the sub-list for method output_type
+	66,  // [66:121] is the sub-list for method input_type
+	66,  // [66:66] is the sub-list for extension type_name
+	66,  // [66:66] is the sub-list for extension extendee
+	0,   // [0:66] is the sub-list for field type_name
 }
 
 func init() { file_keyorix_proto_init() }
@@ -7802,7 +7818,7 @@ func file_keyorix_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_keyorix_proto_rawDesc), len(file_keyorix_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   101,
+			NumMessages:   102,
 			NumExtensions: 0,
 			NumServices:   9,
 		},


### PR DESCRIPTION
## What

The first **cloud-IAM** dynamic-secret backend (the engine previously supported only postgres/mysql/mongodb/redis). The **`aws-sts`** backend mints short-lived AWS credentials via `sts:AssumeRole` instead of a role on a database.

## How (engine model extended minimally)

- **`Credential` / `IssuedLease` gain a `Fields` map** — DB backends keep `username`/`password`; cloud-IAM backends populate `Fields` (`access_key_id` / `secret_access_key` / `session_token`). Surfaced over HTTP (struct → JSON), gRPC (new `fields` map on `IssuedCredential`), and the CLI.
- **`CredentialEngine.IsEphemeralBackend()`** (true for `aws-sts`): STS credentials self-expire, so **Revoke is a no-op** and **Renew is refused** by `core.RenewLease` (issue a new lease instead). `SupportsNativeExpiry=true`, so it can issue with the sweeper off.
- The encrypted **"admin DSN" carries the backend's JSON config** for `aws-sts` (`{"role_arn":...,"region":...,"duration_seconds":...}`); the optional creation template is an inline **STS session policy** scoping the assumed role down. AWS creds for the AssumeRole call come from the standard chain (env / instance-profile / IRSA), like the KMS/S3 integrations. **No new dependency** (`sts` already vendored).
- `internal/dynamic/awssts.go`: `AWSSTSEngine` behind an `stsAssumeAPI` interface seam (fake-tested); duration clamped to AWS's 900s minimum.
- `dynamic.New` adds `aws-sts`; all engines implement `IsEphemeralBackend`.
- CLI: backend help + an `aws-sts` example; `issue` prints the credential `Fields`.
- Docs: `CONFIGURATION` dynamic-secrets `aws-sts` section.

## Tests

`awssts_test.go` (fake STS): issue → fields/role/duration, duration clamp to 900s, config validation, no-op revoke, renew error. `New("aws-sts")`. Core ephemeral path: `Fields` surfaced + renew refused. gofmt / golangci-lint / **gosec -severity medium** / gitleaks all clean. Only local full-suite failure is the unrelated `/sw.js` HTTP artifact.

## Follow-ups

GCP and Azure cloud backends, and a web console form for `aws-sts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)