### PR TITLE
feat(auth): per-account login lockout with exponential backoff (opt-in)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -221,6 +221,14 @@ clears the counter; an admin can clear a lock immediately with
 `POST /api/v1/users/{id}/unlock` (`users.write`). It binds to the account (not the
 IP), so rotating source IPs cannot evade it, and the lock auto-expires (no scheduler).
 
+> **Tradeoff — account-lockout denial of service.** Because the lock binds to the
+> account, anyone who knows a username can deliberately fail logins to keep that
+> account locked. This is inherent to *any* account-bound lockout; here it is bounded
+> by `max_cooldown` (the lock always self-heals) and an admin can clear it instantly.
+> Keep `base_cooldown`/`max_cooldown` short enough that a lock-out attack degrades to a
+> brief wait rather than a lasting denial — a large `max_cooldown` (e.g. hours) turns
+> this defense into a weapon an attacker can wield against your users.
+
 ---
 
 ## webauthn

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -197,6 +197,12 @@ security:
   auto_fix_file_permissions: true
   allow_unsafe_file_permissions: false
   require_mfa: false              # true = mandate a second factor for interactive login
+  login_lockout:
+    enabled: false                # opt-in per-account lockout (brute-force protection)
+    max_attempts: 5               # failed password logins within the window before locking
+    window: "15m"                 # consecutive-failure window
+    base_cooldown: "1m"           # lock duration for the first lockout
+    max_cooldown: "1h"            # ceiling for the exponential backoff
 ```
 
 With `require_mfa: true`, an interactive (session-authenticated) user **without** a
@@ -205,6 +211,15 @@ secret **or** a passkey satisfies it. Non-interactive credentials — personal
 access tokens, machine tokens, OIDC — are **exempt** so automation is never broken.
 Per-project MFA (ADR-037) is set per project via the API
 (`PUT /projects/{id}` `{ "require_mfa": true }`), independent of this flag.
+
+**Per-account login lockout** (`login_lockout`, opt-in) is brute-force protection
+distinct from the per-IP rate limiter (ADR-040): after `max_attempts` failed
+password logins within `window`, the account is locked for a cooldown that **backs
+off exponentially** across repeated lockouts (`base_cooldown` × 2ⁿ, capped at
+`max_cooldown`). While locked, even a correct password is refused. A successful login
+clears the counter; an admin can clear a lock immediately with
+`POST /api/v1/users/{id}/unlock` (`users.write`). It binds to the account (not the
+IP), so rotating source IPs cannot evade it, and the lock auto-expires (no scheduler).
 
 ---
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -323,6 +323,51 @@ type SecurityConfig struct {
 	// user without MFA enabled is confined to the MFA-enrolment endpoints until
 	// they enrol. Non-interactive credentials (PAT/machine/OIDC) are exempt.
 	RequireMFA bool `yaml:"require_mfa"`
+	// LoginLockout configures per-account login lockout (brute-force protection):
+	// after MaxAttempts failed password logins within Window, the account is locked
+	// for an exponentially-backing-off cooldown. Distinct from the per-IP rate
+	// limiter (ADR-040). Opt-in (default off).
+	LoginLockout LoginLockoutConfig `yaml:"login_lockout"`
+}
+
+// parseDurationDefault parses a Go duration string, returning def when empty or
+// unparseable / non-positive.
+func parseDurationDefault(raw string, def time.Duration) time.Duration {
+	if raw == "" {
+		return def
+	}
+	if d, err := time.ParseDuration(raw); err == nil && d > 0 {
+		return d
+	}
+	return def
+}
+
+// LoginLockoutConfig configures per-account login lockout.
+type LoginLockoutConfig struct {
+	Enabled      bool   `yaml:"enabled"`
+	MaxAttempts  int    `yaml:"max_attempts"`  // failures within the window before locking (default 5)
+	Window       string `yaml:"window"`        // Go duration; consecutive-failure window (default 15m)
+	BaseCooldown string `yaml:"base_cooldown"` // lock duration for the first lockout (default 1m)
+	MaxCooldown  string `yaml:"max_cooldown"`  // cap for the exponential backoff (default 1h)
+}
+
+func (c LoginLockoutConfig) GetMaxAttempts() int {
+	if c.MaxAttempts > 0 {
+		return c.MaxAttempts
+	}
+	return 5
+}
+
+func (c LoginLockoutConfig) GetWindow() time.Duration {
+	return parseDurationDefault(c.Window, 15*time.Minute)
+}
+
+func (c LoginLockoutConfig) GetBaseCooldown() time.Duration {
+	return parseDurationDefault(c.BaseCooldown, time.Minute)
+}
+
+func (c LoginLockoutConfig) GetMaxCooldown() time.Duration {
+	return parseDurationDefault(c.MaxCooldown, time.Hour)
 }
 
 type SoftDeleteConfig struct {

--- a/internal/core/auth.go
+++ b/internal/core/auth.go
@@ -44,9 +44,17 @@ func (c *KeyorixCore) Login(ctx context.Context, req *LoginRequest) (*models.Ses
 	if err != nil {
 		return nil, nil, fmt.Errorf("invalid credentials")
 	}
+	// Per-account lockout gate: while locked, refuse regardless of the password (and
+	// before spending a bcrypt comparison), so repeated guessing can't progress.
+	if c.loginLocked(user) {
+		return nil, nil, fmt.Errorf("account temporarily locked due to repeated failed logins; try again later")
+	}
 	if err := bcrypt.CompareHashAndPassword([]byte(user.PasswordHash), []byte(req.Password)); err != nil {
+		c.recordFailedLogin(ctx, user) // increment + lock at the threshold
 		return nil, nil, fmt.Errorf("invalid credentials")
 	}
+	// Correct password — clear any accumulated lockout state.
+	c.clearLoginFailures(ctx, user)
 	// A suspended account is refused login outright (ADR-025). Restricted states
 	// (pending_first_login / password_reset_required) still log in, but the auth
 	// middleware confines the session to the password-change allowlist.

--- a/internal/core/login_lockout.go
+++ b/internal/core/login_lockout.go
@@ -1,0 +1,117 @@
+// login_lockout.go — per-account login lockout (brute-force protection). After
+// MaxAttempts failed password logins within Window, the account is locked for an
+// exponentially-backing-off cooldown; a successful login or an admin unlock resets
+// it. This is distinct from the per-IP rate limiter (ADR-040): lockout binds to a
+// specific account, so an attacker cannot evade it by rotating source IPs, and it
+// rejects even a correct password while the lock is active. State lives on the User
+// (failed_login_attempts / last_failed_login_at / login_locked_until /
+// login_lockout_count); the lock auto-expires on read — no sweeper needed.
+package core
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// LoginLockoutPolicy is the resolved lockout configuration (built from
+// config.LoginLockoutConfig at startup). The zero value is disabled.
+type LoginLockoutPolicy struct {
+	Enabled      bool
+	MaxAttempts  int
+	Window       time.Duration
+	BaseCooldown time.Duration
+	MaxCooldown  time.Duration
+}
+
+const (
+	EventAccountLocked   = "account.locked"
+	EventAccountUnlocked = "account.unlocked"
+)
+
+// loginLocked reports whether the user is currently within an active lockout window.
+func (c *KeyorixCore) loginLocked(user *models.User) bool {
+	return c.loginLockout.Enabled && user.LoginLockedUntil != nil && c.now().Before(*user.LoginLockedUntil)
+}
+
+// cooldownFor returns the lock duration for the nth lockout (1-based): an
+// exponential backoff BaseCooldown * 2^(n-1), capped at MaxCooldown.
+func (p LoginLockoutPolicy) cooldownFor(lockoutCount int) time.Duration {
+	cd := p.BaseCooldown
+	for i := 1; i < lockoutCount && cd < p.MaxCooldown; i++ {
+		cd *= 2
+	}
+	if cd > p.MaxCooldown {
+		cd = p.MaxCooldown
+	}
+	return cd
+}
+
+// recordFailedLogin increments the user's failed-attempt counter (resetting it when
+// the previous failure is older than the window) and locks the account once it
+// reaches MaxAttempts. Best-effort persistence: a storage error must not change the
+// "invalid credentials" outcome the caller returns.
+func (c *KeyorixCore) recordFailedLogin(ctx context.Context, user *models.User) {
+	if !c.loginLockout.Enabled {
+		return
+	}
+	now := c.now()
+	// A stale failure (older than the window) starts a fresh count.
+	if user.LastFailedLoginAt != nil && now.Sub(*user.LastFailedLoginAt) > c.loginLockout.Window {
+		user.FailedLoginAttempts = 0
+	}
+	user.FailedLoginAttempts++
+	user.LastFailedLoginAt = &now
+
+	if user.FailedLoginAttempts >= c.loginLockout.MaxAttempts {
+		user.LoginLockoutCount++
+		until := now.Add(c.loginLockout.cooldownFor(user.LoginLockoutCount))
+		user.LoginLockedUntil = &until
+		user.FailedLoginAttempts = 0 // window counter resets; the lock now gates
+		uid := user.ID
+		c.writeAuditEventFull(ctx, EventAccountLocked, &uid, nil, nil, "",
+			fmt.Sprintf("account %d locked until %s after repeated failed logins (lockout #%d)",
+				user.ID, until.UTC().Format(time.RFC3339), user.LoginLockoutCount))
+	}
+	_, _ = c.storage.UpdateUser(ctx, user)
+}
+
+// clearLoginFailures resets the lockout state after a successful authentication.
+// It writes only when there is something to clear, so the happy path adds no extra
+// write on every login.
+func (c *KeyorixCore) clearLoginFailures(ctx context.Context, user *models.User) {
+	if user.FailedLoginAttempts == 0 && user.LoginLockedUntil == nil && user.LoginLockoutCount == 0 {
+		return
+	}
+	user.FailedLoginAttempts = 0
+	user.LastFailedLoginAt = nil
+	user.LoginLockedUntil = nil
+	user.LoginLockoutCount = 0
+	_, _ = c.storage.UpdateUser(ctx, user)
+}
+
+// UnlockUser clears a user's login-lockout state (admin action; audited). It does
+// not change the account_state — a suspended account stays suspended.
+func (c *KeyorixCore) UnlockUser(ctx context.Context, adminID, userID uint) error {
+	if userID == 0 {
+		return fmt.Errorf("user ID is required")
+	}
+	user, err := c.storage.GetUser(ctx, userID)
+	if err != nil {
+		return fmt.Errorf("user not found: %w", err)
+	}
+	user.FailedLoginAttempts = 0
+	user.LastFailedLoginAt = nil
+	user.LoginLockedUntil = nil
+	user.LoginLockoutCount = 0
+	user.UpdatedAt = c.now()
+	if _, err := c.storage.UpdateUser(ctx, user); err != nil {
+		return fmt.Errorf("failed to unlock user: %w", err)
+	}
+	aid := adminID
+	c.writeAuditEventFull(ctx, EventAccountUnlocked, &aid, nil, nil, "",
+		fmt.Sprintf("user %d login lockout cleared by admin %d", userID, adminID))
+	return nil
+}

--- a/internal/core/login_lockout_test.go
+++ b/internal/core/login_lockout_test.go
@@ -1,0 +1,144 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/bcrypt"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+const lockoutTestPassword = "Secret#Pass123"
+
+// newLockoutTestCore builds a real-SQLite core with login lockout enabled
+// (3 attempts / 15m window / 5m base / 1h max) and a user "alice". The returned
+// clock pointer lets a test advance time to cross the cooldown.
+func newLockoutTestCore(t *testing.T, enabled bool) (*KeyorixCore, *gorm.DB, *time.Time) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.User{}, &models.Session{}, &models.AuditEvent{}))
+	hash, err := bcrypt.GenerateFromPassword([]byte(lockoutTestPassword), bcrypt.DefaultCost)
+	require.NoError(t, err)
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "alice", PasswordHash: string(hash), AccountState: AccountActive}).Error)
+
+	clock := time.Date(2026, 6, 15, 10, 0, 0, 0, time.UTC)
+	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: func() time.Time { return clock }, passwordPolicy: DefaultPasswordPolicy()}
+	if enabled {
+		c.SetLoginLockoutPolicy(LoginLockoutPolicy{Enabled: true, MaxAttempts: 3, Window: 15 * time.Minute, BaseCooldown: 5 * time.Minute, MaxCooldown: time.Hour})
+	}
+	return c, db, &clock
+}
+
+func login(c *KeyorixCore, password string) error {
+	_, _, err := c.Login(context.Background(), &LoginRequest{Username: "alice", Password: password})
+	return err
+}
+
+func reloadUser(t *testing.T, db *gorm.DB) *models.User {
+	t.Helper()
+	var u models.User
+	require.NoError(t, db.First(&u, 1).Error)
+	return &u
+}
+
+func TestLoginLockout_LocksAfterMaxAttempts(t *testing.T) {
+	c, db, _ := newLockoutTestCore(t, true)
+
+	// 3 wrong-password attempts → still "invalid credentials", then locked.
+	for i := 0; i < 3; i++ {
+		require.ErrorContains(t, login(c, "wrong"), "invalid credentials")
+	}
+	u := reloadUser(t, db)
+	require.NotNil(t, u.LoginLockedUntil, "account should be locked after 3 failures")
+	assert.Equal(t, 1, u.LoginLockoutCount)
+
+	// A correct password is still refused while locked.
+	require.ErrorContains(t, login(c, lockoutTestPassword), "temporarily locked")
+}
+
+func TestLoginLockout_ExpiryThenExponentialBackoff(t *testing.T) {
+	c, db, clock := newLockoutTestCore(t, true)
+
+	for i := 0; i < 3; i++ {
+		_ = login(c, "wrong")
+	}
+	first := reloadUser(t, db)
+	require.NotNil(t, first.LoginLockedUntil)
+	assert.Equal(t, (*clock).Add(5*time.Minute), first.LoginLockedUntil.UTC(), "first lockout = base cooldown")
+
+	// Advance past the cooldown → correct password succeeds and clears the state.
+	*clock = clock.Add(6 * time.Minute)
+	require.NoError(t, login(c, lockoutTestPassword))
+	u := reloadUser(t, db)
+	assert.Nil(t, u.LoginLockedUntil)
+	assert.Equal(t, 0, u.FailedLoginAttempts)
+	assert.Equal(t, 0, u.LoginLockoutCount, "a successful login resets the backoff counter")
+}
+
+func TestLoginLockout_BackoffGrowsAcrossLockouts(t *testing.T) {
+	c, db, clock := newLockoutTestCore(t, true)
+	// Don't let a successful login reset the counter between lockouts: lock, wait out
+	// the cooldown, then lock again — the 2nd cooldown should be 2× the first.
+	for i := 0; i < 3; i++ {
+		_ = login(c, "wrong")
+	}
+	assert.Equal(t, (*clock).Add(5*time.Minute), reloadUser(t, db).LoginLockedUntil.UTC())
+
+	*clock = clock.Add(6 * time.Minute) // lock expired, but no successful login
+	for i := 0; i < 3; i++ {
+		_ = login(c, "wrong")
+	}
+	u := reloadUser(t, db)
+	assert.Equal(t, 2, u.LoginLockoutCount)
+	assert.Equal(t, (*clock).Add(10*time.Minute), u.LoginLockedUntil.UTC(), "second lockout = 2× base")
+}
+
+func TestLoginLockout_WindowResetsStaleFailures(t *testing.T) {
+	c, db, clock := newLockoutTestCore(t, true)
+	_ = login(c, "wrong")
+	_ = login(c, "wrong") // 2 failures, under the threshold
+
+	*clock = clock.Add(20 * time.Minute) // past the 15m window
+	_ = login(c, "wrong")                // stale failures dropped → this is failure #1
+	u := reloadUser(t, db)
+	assert.Equal(t, 1, u.FailedLoginAttempts)
+	assert.Nil(t, u.LoginLockedUntil, "stale failures shouldn't accumulate into a lock")
+}
+
+func TestLoginLockout_SuccessResetsCounter(t *testing.T) {
+	c, db, _ := newLockoutTestCore(t, true)
+	_ = login(c, "wrong")
+	_ = login(c, "wrong")
+	require.NoError(t, login(c, lockoutTestPassword))
+	assert.Equal(t, 0, reloadUser(t, db).FailedLoginAttempts)
+}
+
+func TestLoginLockout_UnlockUserClearsState(t *testing.T) {
+	c, db, _ := newLockoutTestCore(t, true)
+	for i := 0; i < 3; i++ {
+		_ = login(c, "wrong")
+	}
+	require.NotNil(t, reloadUser(t, db).LoginLockedUntil)
+
+	require.NoError(t, c.UnlockUser(context.Background(), 99, 1))
+	u := reloadUser(t, db)
+	assert.Nil(t, u.LoginLockedUntil)
+	assert.Equal(t, 0, u.LoginLockoutCount)
+	require.NoError(t, login(c, lockoutTestPassword), "login works again after unlock")
+}
+
+func TestLoginLockout_DisabledNeverLocks(t *testing.T) {
+	c, db, _ := newLockoutTestCore(t, false)
+	for i := 0; i < 10; i++ {
+		_ = login(c, "wrong")
+	}
+	assert.Nil(t, reloadUser(t, db).LoginLockedUntil, "no lockout when the policy is disabled")
+	require.NoError(t, login(c, lockoutTestPassword))
+}

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -45,6 +45,7 @@ type KeyorixCore struct {
 	webauthnRP     *webauthn.WebAuthn
 	now            func() time.Time // For testability
 	passwordPolicy PasswordPolicy
+	loginLockout   LoginLockoutPolicy // per-account login lockout (disabled by default)
 	auditForwarder AuditForwarder
 	// notificationSink fans each in-app notification out to an external channel
 	// (email/webhook). nil = in-app only. Set from config via SetNotificationSink.
@@ -240,6 +241,13 @@ func (c *KeyorixCore) WebAuthnEnabled() bool { return c.webauthnRP != nil }
 // configures a password_policy block.
 func (c *KeyorixCore) SetPasswordPolicy(p PasswordPolicy) {
 	c.passwordPolicy = p
+}
+
+// SetLoginLockoutPolicy enables/configures per-account login lockout. The server
+// calls this at startup when security.login_lockout is enabled; left unset, lockout
+// is disabled (Enabled=false).
+func (c *KeyorixCore) SetLoginLockoutPolicy(p LoginLockoutPolicy) {
+	c.loginLockout = p
 }
 
 // SetSetupTokenTTL overrides the setup-token lifetime (ADR-028). The server calls

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -181,6 +181,22 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 		db.Exec("ALTER TABLE users ADD COLUMN external_id TEXT NOT NULL DEFAULT ''")
 	}
 
+	// Per-account login lockout (brute-force protection). Additive; safe on existing DBs.
+	if tableExists(db, "users") {
+		if !columnExists(db, "users", "failed_login_attempts") {
+			db.Exec("ALTER TABLE users ADD COLUMN failed_login_attempts INTEGER NOT NULL DEFAULT 0")
+		}
+		if !columnExists(db, "users", "last_failed_login_at") {
+			db.Exec("ALTER TABLE users ADD COLUMN last_failed_login_at TIMESTAMP WITH TIME ZONE")
+		}
+		if !columnExists(db, "users", "login_locked_until") {
+			db.Exec("ALTER TABLE users ADD COLUMN login_locked_until TIMESTAMP WITH TIME ZONE")
+		}
+		if !columnExists(db, "users", "login_lockout_count") {
+			db.Exec("ALTER TABLE users ADD COLUMN login_lockout_count INTEGER NOT NULL DEFAULT 0")
+		}
+	}
+
 	// Enrich sessions for the My Account "active sessions" view (device/IP/last-active).
 	if tableExists(db, "sessions") {
 		if !columnExists(db, "sessions", "user_agent") {

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -240,9 +240,18 @@ type User struct {
 	// externalId, RFC 7644). Empty for locally-created users. Indexed for the SCIM
 	// reconciliation lookup; not unique (legacy/blank rows coexist).
 	ExternalID string `gorm:"index"`
-	CreatedAt  time.Time
-	UpdatedAt  time.Time
-	DeletedAt  gorm.DeletedAt `gorm:"index"` // soft delete — set by DELETE /users/{id}, cleared by restore
+	// Per-account login lockout (brute-force protection). FailedLoginAttempts counts
+	// consecutive failed password logins within the configured window;
+	// LoginLockedUntil (when set and in the future) refuses login regardless of the
+	// password; LoginLockoutCount drives the exponential backoff across repeated
+	// lockouts. All reset on a successful login or an admin unlock.
+	FailedLoginAttempts int `gorm:"default:0"`
+	LastFailedLoginAt   *time.Time
+	LoginLockedUntil    *time.Time
+	LoginLockoutCount   int `gorm:"default:0"`
+	CreatedAt           time.Time
+	UpdatedAt           time.Time
+	DeletedAt           gorm.DeletedAt `gorm:"index"` // soft delete — set by DELETE /users/{id}, cleared by restore
 }
 
 // MFASecret holds a user's TOTP shared secret, encrypted at rest. One row per

--- a/server/http/handlers/users_crud.go
+++ b/server/http/handlers/users_crud.go
@@ -325,6 +325,31 @@ func (h *UserHandler) RestoreUser(w http.ResponseWriter, r *http.Request) {
 	sendSuccess(w, nil, "User restored successfully")
 }
 
+// UnlockUser handles POST /api/v1/users/{id}/unlock — clears a user's login-lockout
+// state (failed-attempt counter + active lock) after repeated failed logins.
+func (h *UserHandler) UnlockUser(w http.ResponseWriter, r *http.Request) {
+	userCtx := middleware.GetUserFromContext(r.Context())
+	if userCtx == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	idStr := chi.URLParam(r, "id")
+	id, err := strconv.ParseUint(idStr, 10, 32)
+	if err != nil {
+		sendError(w, "InvalidParameter", "Invalid user ID", http.StatusBadRequest, nil)
+		return
+	}
+	if err := h.coreService.UnlockUser(r.Context(), userCtx.UserID, uint(id)); err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			sendError(w, "NotFound", "User not found", http.StatusNotFound, nil)
+			return
+		}
+		sendError(w, "InternalError", "Failed to unlock user", http.StatusInternalServerError, nil)
+		return
+	}
+	sendSuccess(w, nil, "User login lockout cleared")
+}
+
 // accountStateAction is the shared handler body for the admin account-state
 // transitions (ADR-025). transition performs the state change.
 func (h *UserHandler) accountStateAction(w http.ResponseWriter, r *http.Request, okMessage string, transition func(ctx context.Context, adminID, userID uint) error) {

--- a/server/http/handlers/users_handler.go
+++ b/server/http/handlers/users_handler.go
@@ -276,6 +276,15 @@ func RestoreUser(w http.ResponseWriter, r *http.Request) {
 	defaultUserHandler.RestoreUser(w, r)
 }
 
+// UnlockUser handles POST /api/v1/users/{id}/unlock — clears login lockout.
+func UnlockUser(w http.ResponseWriter, r *http.Request) {
+	if defaultUserHandler == nil {
+		sendError(w, "ServiceUnavailable", "User handler not initialised", http.StatusServiceUnavailable, nil)
+		return
+	}
+	defaultUserHandler.UnlockUser(w, r)
+}
+
 // SuspendUser handles POST /api/v1/users/{id}/suspend (ADR-025).
 func SuspendUser(w http.ResponseWriter, r *http.Request) {
 	if defaultUserHandler == nil {

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -381,6 +381,7 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.With(customMiddleware.RequirePermission("users.write")).Put("/{id}", handlers.UpdateUser)
 			r.With(customMiddleware.RequirePermission("users.write")).Delete("/{id}", handlers.DeleteUser)
 			r.With(customMiddleware.RequirePermission("users.write")).Post("/{id}/restore", handlers.RestoreUser)
+			r.With(customMiddleware.RequirePermission("users.write")).Post("/{id}/unlock", handlers.UnlockUser)
 			// Account state transitions (ADR-025).
 			r.With(customMiddleware.RequirePermission("users.write")).Post("/{id}/suspend", handlers.SuspendUser)
 			r.With(customMiddleware.RequirePermission("users.write")).Post("/{id}/reactivate", handlers.ReactivateUser)

--- a/server/main.go
+++ b/server/main.go
@@ -235,6 +235,20 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 		})
 	}
 
+	// Apply per-account login lockout if enabled (brute-force protection, distinct
+	// from the per-IP rate limiter).
+	if ll := cfg.Security.LoginLockout; ll.Enabled {
+		coreService.SetLoginLockoutPolicy(core.LoginLockoutPolicy{
+			Enabled:      true,
+			MaxAttempts:  ll.GetMaxAttempts(),
+			Window:       ll.GetWindow(),
+			BaseCooldown: ll.GetBaseCooldown(),
+			MaxCooldown:  ll.GetMaxCooldown(),
+		})
+		log.Printf("Per-account login lockout enabled (max_attempts=%d, window=%s, base_cooldown=%s, max_cooldown=%s)",
+			ll.GetMaxAttempts(), ll.GetWindow(), ll.GetBaseCooldown(), ll.GetMaxCooldown())
+	}
+
 	// Wire native SIEM audit forwarding if configured. New returns (nil, nil)
 	// when disabled, so SetAuditForwarder(nil) keeps forwarding off.
 	if sc := cfg.Audit.SIEM; sc.Enabled {


### PR DESCRIPTION
## Summary

Per-account login lockout — brute-force protection distinct from the per-IP rate limiter (ADR-040). After `security.login_lockout.max_attempts` failed password logins within `window`, the account is locked for a cooldown that backs off exponentially across repeated lockouts (`base_cooldown × 2^(n-1)`, capped at `max_cooldown`). Binds to the account (not the IP), so rotating source IPs can't evade it. **Opt-in (default off).**

## How it works

- **Model**: `User` gains `failed_login_attempts` / `last_failed_login_at` / `login_locked_until` / `login_lockout_count` (additive migration, safe on existing DBs).
- **Core**: `Login` gates on an active lock **before** the bcrypt compare — a correct password is refused while locked and no bcrypt cycles are spent. A mismatch records a windowed failure (locks at the threshold); a success clears the state. The lock auto-expires on read — no sweeper. `account.locked` / `account.unlocked` are audited.
- **Admin unlock**: `POST /api/v1/users/{id}/unlock` (`users.write`) clears a lock immediately without touching `account_state` (a suspended account stays suspended).
- **Config**: `security.login_lockout {enabled, max_attempts, window, base_cooldown, max_cooldown}`, wired in `main` when enabled.

## Security review

Ran the security-review skill on the diff — no HIGH/MEDIUM findings. Lock gate placement verified before bcrypt; the distinct "locked" string never reaches the client (handler flattens to generic 401); `UnlockUser` gated behind `users.write` and cannot un-suspend; static migration SQL. The one residual behavior — account-lockout DoS — is inherent to any account-bound lockout, is bounded by `max_cooldown` + admin unlock, and is now documented as an explicit tradeoff.

## Tests

`lock after N`, `correct-password-refused-while-locked`, `expiry`, `exponential backoff across lockouts`, `window reset of stale failures`, `reset-on-success`, `UnlockUser`, `disabled-never-locks`. gofmt/golangci-lint/gosec/gitleaks clean; the new `/unlock` route returns 403 to a read-only persona.

🤖 Generated with [Claude Code](https://claude.com/claude-code)