### PR TITLE
feat(encryption): exec KEK provider — resolve the KEK from a command

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -126,7 +126,7 @@ storage:
 
     # key_provider — default is "password" when omitted.
     key_provider:
-      type: password              # password | file | env | aws-kms | gcp-kms | azure-kms
+      type: password              # password | file | env | exec | aws-kms | gcp-kms | azure-kms
 
       # type: file — read raw key material from a path (mounted CSI/sealed
       # secret, KMS sidecar output). Accepts 32 raw bytes, hex, or base64.
@@ -134,6 +134,11 @@ storage:
 
       # type: env — read the KEK (hex or base64) from the named env var's value.
       # env_var: KEYORIX_KEK
+
+      # type: exec — run a resolver command and read the KEK (32 raw bytes, or
+      # hex/base64) from its stdout. argv form (no shell); fetches from any
+      # external secret store Keyorix has no built-in client for.
+      # exec_command: ["op", "read", "op://vault/keyorix-kek/value"]
 
       # type: aws-kms / gcp-kms / azure-kms — envelope-wrap the KEK with a cloud
       # KMS/HSM key (ADR-041); the wrapping key stays in the KMS/HSM. Credentials
@@ -150,6 +155,12 @@ storage:
   prior releases — existing `dek.key` files keep working.
 - **`file`** / **`env`**: the KEK is externally managed (e.g. injected by a KMS,
   CSI driver, or sealed/SOPS secret). `KEYORIX_MASTER_PASSWORD` is **not** required.
+- **`exec`**: the KEK is produced on stdout by an operator-configured resolver
+  command (`exec_command`, an argv run **without a shell**) — e.g. `op read …`
+  (1Password), `sops -d kek.enc`, `vault read -field=kek …`, or a CSI/sidecar
+  helper. Output is 32 raw bytes or a hex/base64 encoding thereof. The command runs
+  at startup (fail-closed, 30s timeout) and `KEYORIX_MASTER_PASSWORD` is **not**
+  required. The argv is trusted deployment config, like `file_path`/`env_var`.
 - **`aws-kms`** / **`gcp-kms`** / **`azure-kms`** (ADR-041): the KEK is a random key
   **wrapped by a cloud KMS/HSM key**; only the wrapped blob is on disk
   (`wrapped_key_path`), unwrapped via the KMS at startup. The wrapping key never

--- a/internal/cli/encryption/migrate_provider.go
+++ b/internal/cli/encryption/migrate_provider.go
@@ -33,6 +33,7 @@ var (
 	mpToWrappedKeyPath string
 	mpToFilePath       string
 	mpToEnvVar         string
+	mpToExecCommand    []string
 	mpToSaltPath       string
 	mpConfirm          bool
 )
@@ -62,11 +63,12 @@ restart — the printed summary shows the exact block.`,
 func init() {
 	EncryptionCmd.AddCommand(migrateProviderCmd)
 	f := migrateProviderCmd.Flags()
-	f.StringVar(&mpToType, "to-type", "", "target provider: password|file|env|aws-kms|gcp-kms|azure-kms (required)")
+	f.StringVar(&mpToType, "to-type", "", "target provider: password|file|env|exec|aws-kms|gcp-kms|azure-kms (required)")
 	f.StringVar(&mpToKMSKeyID, "to-kms-key-id", "", "target KMS key id/ARN/resource-name/URL (kms types)")
 	f.StringVar(&mpToWrappedKeyPath, "to-wrapped-key-path", "", "where to store the KMS-wrapped KEK blob (kms types)")
 	f.StringVar(&mpToFilePath, "to-file-path", "", "path to the raw KEK material (file type)")
 	f.StringVar(&mpToEnvVar, "to-env-var", "", "env var holding the raw KEK (env type)")
+	f.StringSliceVar(&mpToExecCommand, "to-exec-command", nil, "resolver argv whose stdout supplies the KEK (exec type), e.g. op,read,op://vault/kek/value")
 	f.StringVar(&mpToSaltPath, "to-salt-path", "", "salt path for the target password provider (default: current salt_path)")
 	f.BoolVar(&mpConfirm, "confirm", false, "required acknowledgement before re-wrapping the DEK")
 }
@@ -79,6 +81,7 @@ type migrateOpts struct {
 	toWrappedKeyPath string
 	toFilePath       string
 	toEnvVar         string
+	toExecCommand    []string
 	toSaltPath       string
 }
 
@@ -93,6 +96,7 @@ func runMigrateProvider(cmd *cobra.Command, args []string) error {
 		toWrappedKeyPath: mpToWrappedKeyPath,
 		toFilePath:       mpToFilePath,
 		toEnvVar:         mpToEnvVar,
+		toExecCommand:    mpToExecCommand,
 		toSaltPath:       mpToSaltPath,
 	}
 	return migrateProviderWithConfig(cfg, opts, mpConfirm)
@@ -120,6 +124,11 @@ func targetEncryptionConfig(cur *config.EncryptionConfig, opts migrateOpts) (con
 			return tgt, fmt.Errorf("--to-env-var is required for --to-type env")
 		}
 		kp.EnvVar = opts.toEnvVar
+	case "exec":
+		if len(opts.toExecCommand) == 0 {
+			return tgt, fmt.Errorf("--to-exec-command is required for --to-type exec")
+		}
+		kp.ExecCommand = opts.toExecCommand
 	case "aws-kms", "gcp-kms", "azure-kms":
 		if opts.toKMSKeyID == "" {
 			return tgt, fmt.Errorf("--to-kms-key-id is required for --to-type %s", opts.toType)
@@ -133,7 +142,7 @@ func targetEncryptionConfig(cur *config.EncryptionConfig, opts migrateOpts) (con
 		kp.KMSKeyID = opts.toKMSKeyID
 		kp.WrappedKeyPath = opts.toWrappedKeyPath
 	default:
-		return tgt, fmt.Errorf("unknown --to-type %q (supported: password, file, env, aws-kms, gcp-kms, azure-kms)", opts.toType)
+		return tgt, fmt.Errorf("unknown --to-type %q (supported: password, file, env, exec, aws-kms, gcp-kms, azure-kms)", opts.toType)
 	}
 	tgt.KeyProvider = kp
 	return tgt, nil
@@ -166,7 +175,7 @@ func migrateProviderWithConfig(cfg *config.Config, opts migrateOpts, confirm boo
 		return fmt.Errorf("KEK-provider migration must run on the server host. Current storage type is 'remote' — connect to the server and run this command there")
 	}
 	if opts.toType == "" {
-		return fmt.Errorf("--to-type is required (password|file|env|aws-kms|gcp-kms|azure-kms)")
+		return fmt.Errorf("--to-type is required (password|file|env|exec|aws-kms|gcp-kms|azure-kms)")
 	}
 	tgtEnc, err := targetEncryptionConfig(enc, opts)
 	if err != nil {

--- a/internal/cli/encryption/migrate_provider_test.go
+++ b/internal/cli/encryption/migrate_provider_test.go
@@ -156,6 +156,23 @@ func TestTargetEncryptionConfig(t *testing.T) {
 		}
 	})
 
+	t.Run("exec requires command", func(t *testing.T) {
+		_, err := targetEncryptionConfig(cur, migrateOpts{toType: "exec"})
+		if err == nil || !strings.Contains(err.Error(), "--to-exec-command") {
+			t.Fatalf("expected exec-command requirement, got: %v", err)
+		}
+	})
+
+	t.Run("exec carries the resolver argv", func(t *testing.T) {
+		tgt, err := targetEncryptionConfig(cur, migrateOpts{toType: "exec", toExecCommand: []string{"op", "read", "op://vault/kek/value"}})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if tgt.KeyProvider.Type != "exec" || len(tgt.KeyProvider.ExecCommand) != 3 {
+			t.Fatalf("expected exec provider with 3-element argv, got %+v", tgt.KeyProvider)
+		}
+	})
+
 	t.Run("password overrides salt path", func(t *testing.T) {
 		tgt, err := targetEncryptionConfig(cur, migrateOpts{toType: "password", toSaltPath: "keys/new.salt"})
 		if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -281,10 +281,12 @@ type EncryptionConfig struct {
 
 // KeyProviderConfig selects the KEK source. type: "password" (default) derives the
 // KEK from KEYORIX_MASTER_PASSWORD; "file" reads raw key material from FilePath;
-// "env" reads it from the EnvVar's value (hex or base64); "aws-kms" / "gcp-kms" /
-// "azure-kms" envelope-wrap the KEK with a cloud KMS/HSM key (ADR-041) and store
-// the wrapped blob at WrappedKeyPath. file/env suit a KEK injected by a sealed/SOPS
-// secret or CSI driver; the KMS providers keep the wrapping key in the cloud HSM.
+// "env" reads it from the EnvVar's value (hex or base64); "exec" runs ExecCommand
+// and reads the KEK from its stdout; "aws-kms" / "gcp-kms" / "azure-kms"
+// envelope-wrap the KEK with a cloud KMS/HSM key (ADR-041) and store the wrapped
+// blob at WrappedKeyPath. file/env/exec suit a KEK injected by a sealed/SOPS secret,
+// a CSI driver, or any external secret store; the KMS providers keep the wrapping
+// key in the cloud HSM.
 type KeyProviderConfig struct {
 	Type     string `yaml:"type"`
 	FilePath string `yaml:"file_path"`
@@ -298,6 +300,12 @@ type KeyProviderConfig struct {
 	// WrappedKeyPath is where the KMS-wrapped KEK blob lives (aws-kms / gcp-kms /
 	// azure-kms).
 	WrappedKeyPath string `yaml:"wrapped_key_path"`
+	// ExecCommand is the argv for type "exec": the resolver command (argv[0] is the
+	// binary, the rest are arguments) whose stdout supplies the KEK as raw 32 bytes
+	// or a hex/base64 encoding thereof. Run directly without a shell. Lets a
+	// deployment fetch the KEK from any external secret store (e.g.
+	// ["op","read","op://vault/kek/value"], ["sops","-d","kek.enc"]).
+	ExecCommand []string `yaml:"exec_command"`
 }
 
 type SecretsConfig struct {

--- a/internal/crypto/exec_provider.go
+++ b/internal/crypto/exec_provider.go
@@ -1,0 +1,83 @@
+package crypto
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"time"
+)
+
+// execKeyTimeout bounds how long the resolver command may run before the KEK
+// fetch is abandoned. Generous enough for a network round-trip to a secret store,
+// short enough that a hung helper fails startup loudly rather than wedging it.
+const execKeyTimeout = 30 * time.Second
+
+// ExecKeyProvider sources the KEK by running an operator-configured command and
+// reading the key material (raw 32 bytes, or hex/base64 thereof) from its stdout.
+// It is the universal escape hatch for any secret store Keyorix has no built-in
+// client for — e.g. `op read op://vault/kek/value` (1Password), `sops -d kek.enc`,
+// `vault read -field=kek secret/keyorix`, or a CSI/sidecar helper.
+//
+// The command is an explicit argv (argv[0] is the binary, the rest are args); it
+// is executed directly WITHOUT a shell, so there is no shell-injection surface.
+// The argv comes from the deployment's encryption config and is trusted on the
+// same footing as the file path / env var the other raw providers read.
+type ExecKeyProvider struct {
+	command []string
+}
+
+// NewExecKeyProvider builds an exec provider from an argv (argv[0] = binary).
+func NewExecKeyProvider(command []string) *ExecKeyProvider {
+	return &ExecKeyProvider{command: command}
+}
+
+func (p *ExecKeyProvider) Name() string { return "exec" }
+
+func (p *ExecKeyProvider) KEK() ([]byte, error) {
+	if len(p.command) == 0 || p.command[0] == "" {
+		return nil, fmt.Errorf("exec key provider: exec_command is required (argv, e.g. [\"op\", \"read\", \"op://vault/kek/value\"])")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), execKeyTimeout)
+	defer cancel()
+
+	// #nosec G204 -- the argv is operator-configured deployment config (trusted on
+	// the same footing as a file path or env var), run without a shell.
+	cmd := exec.CommandContext(ctx, p.command[0], p.command[1:]...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return nil, fmt.Errorf("exec key provider: command %q timed out after %s", p.command[0], execKeyTimeout)
+		}
+		// stderr can carry the helper's own diagnostic, but may also echo the
+		// secret — surface only a trimmed, bounded tail and never the stdout.
+		return nil, fmt.Errorf("exec key provider: command %q failed: %w%s", p.command[0], err, stderrHint(stderr.Bytes()))
+	}
+	// Trim a single trailing newline for the encoded forms (helpers usually print
+	// one), but never mangle exactly-32 raw bytes.
+	out := stdout.Bytes()
+	if len(out) != KEKSize {
+		out = bytes.TrimRight(out, "\r\n")
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("exec key provider: command %q produced no output", p.command[0])
+	}
+	return decodeKeyMaterial(out, "exec")
+}
+
+// stderrHint returns a short, bounded "(stderr: …)" suffix for an exec failure,
+// or "" when stderr was empty. Bounded so a misbehaving helper can't flood the
+// startup error, and it is only ever shown on a non-zero exit.
+func stderrHint(b []byte) string {
+	b = bytes.TrimSpace(b)
+	if len(b) == 0 {
+		return ""
+	}
+	const max = 200
+	if len(b) > max {
+		b = append(b[:max:max], []byte("…")...)
+	}
+	return fmt.Sprintf(" (stderr: %s)", b)
+}

--- a/internal/crypto/exec_provider_test.go
+++ b/internal/crypto/exec_provider_test.go
@@ -1,0 +1,97 @@
+package crypto
+
+import (
+	"encoding/base64"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testKEK returns a deterministic 32-byte key for the exec tests.
+func testKEK() []byte {
+	raw := make([]byte, KEKSize)
+	for i := range raw {
+		raw[i] = byte(i * 7)
+	}
+	return raw
+}
+
+func TestExecKeyProvider_AcceptsRawHexBase64(t *testing.T) {
+	dir := t.TempDir()
+	raw := testKEK()
+
+	cases := map[string][]byte{
+		"raw":       raw,
+		"hex":       []byte(hex.EncodeToString(raw)),
+		"hex+nl":    []byte(hex.EncodeToString(raw) + "\n"),
+		"base64":    []byte(base64.StdEncoding.EncodeToString(raw)),
+		"base64+nl": []byte(base64.StdEncoding.EncodeToString(raw) + "\n"),
+	}
+	for name, content := range cases {
+		t.Run(name, func(t *testing.T) {
+			path := filepath.Join(dir, name+".key")
+			require.NoError(t, os.WriteFile(path, content, 0600))
+			// `cat <file>` stands in for a real resolver command (op/sops/vault/…).
+			kek, err := NewExecKeyProvider([]string{"cat", path}).KEK()
+			require.NoError(t, err)
+			assert.Equal(t, raw, kek)
+		})
+	}
+}
+
+func TestExecKeyProvider_Name(t *testing.T) {
+	assert.Equal(t, "exec", NewExecKeyProvider([]string{"cat"}).Name())
+}
+
+func TestExecKeyProvider_Errors(t *testing.T) {
+	dir := t.TempDir()
+
+	t.Run("empty command rejected", func(t *testing.T) {
+		_, err := NewExecKeyProvider(nil).KEK()
+		require.Error(t, err)
+		_, err = NewExecKeyProvider([]string{""}).KEK()
+		require.Error(t, err)
+	})
+
+	t.Run("command not found", func(t *testing.T) {
+		_, err := NewExecKeyProvider([]string{filepath.Join(dir, "keyorix-kek-helper-does-not-exist")}).KEK()
+		require.Error(t, err)
+	})
+
+	t.Run("nonzero exit", func(t *testing.T) {
+		// `false` exits 1 with no output — a resolver that failed to fetch the key.
+		_, err := NewExecKeyProvider([]string{"false"}).KEK()
+		require.Error(t, err)
+	})
+
+	t.Run("no output rejected", func(t *testing.T) {
+		// `true` succeeds but prints nothing.
+		_, err := NewExecKeyProvider([]string{"true"}).KEK()
+		require.ErrorContains(t, err, "no output")
+	})
+
+	t.Run("garbage output rejected", func(t *testing.T) {
+		path := filepath.Join(dir, "garbage.key")
+		require.NoError(t, os.WriteFile(path, []byte("not-a-valid-key"), 0600))
+		_, err := NewExecKeyProvider([]string{"cat", path}).KEK()
+		require.Error(t, err, "output that does not decode to 32 bytes must be rejected")
+	})
+}
+
+func TestStderrHint(t *testing.T) {
+	assert.Equal(t, "", stderrHint(nil))
+	assert.Equal(t, "", stderrHint([]byte("   \n")))
+	assert.Equal(t, " (stderr: boom)", stderrHint([]byte("  boom\n")))
+
+	long := make([]byte, 500)
+	for i := range long {
+		long[i] = 'x'
+	}
+	hint := stderrHint(long)
+	assert.Less(t, len(hint), 500, "a flood of stderr must be bounded")
+	assert.Contains(t, hint, "…")
+}

--- a/internal/encryption/service.go
+++ b/internal/encryption/service.go
@@ -84,8 +84,9 @@ func (s *Service) buildKeyProvider(passphrase string) (crypto.KeyProvider, error
 // NewKeyProviderFromConfig builds the KEK source described by an EncryptionConfig
 // (ADR-038/ADR-041). The default and the absent/zero value is the passphrase
 // provider, byte-identical to the historical derivation; file/env supply
-// externally-managed raw key material; the *-kms providers envelope-wrap the KEK
-// with a cloud KMS key. baseDir resolves provider-relative paths (salt /
+// externally-managed raw key material and exec fetches it from a resolver command;
+// the *-kms providers envelope-wrap the KEK with a cloud KMS key. baseDir resolves
+// provider-relative paths (salt /
 // wrapped_key_path). Exported so the KEK-provider migration tool can build a
 // *target* provider from a different config than the running service's.
 func NewKeyProviderFromConfig(cfg *config.EncryptionConfig, baseDir, passphrase string) (crypto.KeyProvider, error) {
@@ -97,6 +98,8 @@ func NewKeyProviderFromConfig(cfg *config.EncryptionConfig, baseDir, passphrase 
 		return crypto.NewFileKeyProvider(kp.FilePath), nil
 	case "env":
 		return crypto.NewEnvKeyProvider(kp.EnvVar), nil
+	case "exec":
+		return crypto.NewExecKeyProvider(kp.ExecCommand), nil
 	case "aws-kms":
 		kmsClient, err := awskms.New(context.Background(), kp.KMSKeyID)
 		if err != nil {
@@ -116,7 +119,7 @@ func NewKeyProviderFromConfig(cfg *config.EncryptionConfig, baseDir, passphrase 
 		}
 		return crypto.NewKMSKeyProvider(kmsClient, "azure-kms", baseDir, kp.WrappedKeyPath), nil
 	default:
-		return nil, fmt.Errorf("unknown encryption key_provider type %q (supported: password, file, env, aws-kms, gcp-kms, azure-kms)", kp.Type)
+		return nil, fmt.Errorf("unknown encryption key_provider type %q (supported: password, file, env, exec, aws-kms, gcp-kms, azure-kms)", kp.Type)
 	}
 }
 


### PR DESCRIPTION
## Summary

A new tier-2 KEK source (ADR-038) alongside `password` / `file` / `env` / `*-kms`: **`type: exec`** runs an operator-configured resolver command and reads the KEK (raw 32 bytes, or hex/base64) from its stdout. It's the universal escape hatch for any external secret store Keyorix has no built-in client for — 1Password (`op read`), sops (`sops -d`), Vault (`vault read -field`), or a CSI/sidecar helper.

## How it works

- **crypto** — `ExecKeyProvider` runs the argv **directly without a shell** (argv[0] is the binary), so there is no shell-injection surface; the argv is trusted deployment config on the same footing as `file_path` / `env_var`. 30s fail-closed timeout, bounded stderr hint on failure, reuses `decodeKeyMaterial` for raw/hex/base64. `#nosec G204` (trusted argv).
- **config** — `KeyProviderConfig.ExecCommand` (`[]string`, `exec_command`); wired into `NewKeyProviderFromConfig` as `case "exec"`.
- **cli** — `keyorix encryption migrate-provider --to-type exec --to-exec-command op,read,op://vault/kek/value` re-wraps an existing install's DEK onto the exec provider (no data re-encryption).
- **docs** — `CONFIGURATION.md` `key_provider` exec entry.

## Security notes

The command and its args come only from the deployment's encryption config (trusted, like a file path or env var) and run **without a shell** — no interpolation of untrusted input, no injection surface. Output must decode to exactly 32 bytes or startup fails closed. stderr is bounded and only surfaced on a non-zero exit; stdout (the key) is never logged.

## Tests

raw/hex/base64 round-trips (via `cat`), empty/not-found/nonzero-exit/no-output/garbage error paths, `stderrHint` bounding; `migrate-provider` exec target + arg validation. gofmt / golangci-lint / gosec clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)