### PR TITLE
feat(audit): external-notary anchoring of audit checkpoints (RFC 3161)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -620,11 +620,20 @@ next write retries — it never blocks checkpointing.
 audit:
   checkpoint_notary:
     enabled: true
-    type: rfc3161           # the only type today (default)
+    type: rfc3161                  # the only type today (default)
     url: https://freetsa.org/tsr   # TSA timestamp-query endpoint
-    timeout: "15s"          # Go duration for the TSA round-trip (default 15s)
+    timeout: "15s"                 # Go duration for the TSA round-trip (default 15s)
+    ca_cert_path: /etc/keyorix/tsa-ca.pem  # PEM of the TSA's trusted root/CA cert(s)
 ```
 
+> `ca_cert_path` is the **trust anchor** used to *verify* a stored anchor's issuer.
+> Verification chains the token's signer to one of these roots (with the
+> time-stamping EKU), so a self-signed/untrusted token — which the very actor the
+> anchor defends against (a DEK + database-write attacker) could otherwise mint — is
+> rejected. Without `ca_cert_path`, anchoring still records tokens but verification
+> **fails closed** (it will not assert an unverifiable proof). Supply the TSA's CA
+> bundle (e.g. FreeTSA's `cacert.pem`).
+>
 > The new checkpoint's anchor (asserted time + TSA) is shown by
 > `keyorix audit checkpoint`. Requires `audit_checkpoints` to be doing the writing
 > (which requires encryption — the checkpoint signing key is DEK-derived).

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -605,6 +605,30 @@ audit_checkpoints:
   schedule: "12h"         # Go duration between checkpoint writes (default 24h)
 ```
 
+**External-notary anchoring** (`audit.checkpoint_notary`, opt-in). The checkpoint
+HMAC is keyed by a DEK-derived key the running server holds — which detects
+truncation/rewrite by a *database* actor, but an attacker who also obtains the DEK
+could forge a checkpoint. Anchoring each written checkpoint to an external **RFC
+3161 timestamp authority (TSA)** adds an independent, signed proof-of-existence over
+the checkpoint's canonical bytes that binds it to a third party's clock and signing
+key — which that attacker does not control, and cannot backdate. The TSA token is
+stored on the checkpoint and re-verifiable offline. Anchoring is **best-effort**: a
+TSA failure leaves the checkpoint un-anchored (still a valid checkpoint) and the
+next write retries — it never blocks checkpointing.
+
+```yaml
+audit:
+  checkpoint_notary:
+    enabled: true
+    type: rfc3161           # the only type today (default)
+    url: https://freetsa.org/tsr   # TSA timestamp-query endpoint
+    timeout: "15s"          # Go duration for the TSA round-trip (default 15s)
+```
+
+> The new checkpoint's anchor (asserted time + TSA) is shown by
+> `keyorix audit checkpoint`. Requires `audit_checkpoints` to be doing the writing
+> (which requires encryption — the checkpoint signing key is DEK-derived).
+
 ## jit_access_expiry
 
 An opt-in background sweeper for **just-in-time / time-bound access**. A role grant

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.103.3
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.42.3
 	github.com/aws/aws-sdk-go-v2/service/sts v1.43.3
+	github.com/digitorus/timestamp v0.0.0-20250524132541-c45532741eea
 	github.com/go-chi/chi/v5 v5.2.2
 	github.com/go-chi/cors v1.2.1
 	github.com/go-sql-driver/mysql v1.10.0
@@ -73,6 +74,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
+	github.com/digitorus/pkcs7 v0.0.0-20230713084857-e76b763bdc49 // indirect
 	github.com/ebitengine/purego v0.10.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -95,6 +95,10 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
+github.com/digitorus/pkcs7 v0.0.0-20230713084857-e76b763bdc49 h1:h+XMRXf+WLY0h/3itqE8OT3TgjCMHK4nq2FNGi0au2c=
+github.com/digitorus/pkcs7 v0.0.0-20230713084857-e76b763bdc49/go.mod h1:SKVExuS+vpu2l9IoOc0RwqE7NYnb0JlcFHFnEJkVDzc=
+github.com/digitorus/timestamp v0.0.0-20250524132541-c45532741eea h1:ALRwvjsSP53QmnN3Bcj0NpR8SsFLnskny/EIMebAk1c=
+github.com/digitorus/timestamp v0.0.0-20250524132541-c45532741eea/go.mod h1:GvWntX9qiTlOud0WkQ6ewFm0LPy5JUR1Xo0Ngbd1w6Y=
 github.com/ebitengine/purego v0.10.0 h1:QIw4xfpWT6GWTzaW5XEKy3HXoqrJGx1ijYHzTF0/ISU=
 github.com/ebitengine/purego v0.10.0/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/envoyproxy/go-control-plane v0.14.0 h1:hbG2kr4RuFj222B6+7T83thSPqLjwBIfQawTkC++2HA=

--- a/internal/cli/audit/audit.go
+++ b/internal/cli/audit/audit.go
@@ -209,11 +209,13 @@ since a point in time with --since --all.`,
 
 // checkpointResult mirrors the /audit/checkpoint payload (ADR-029).
 type checkpointResult struct {
-	ID            uint   `json:"id"`
-	ChainedEvents int64  `json:"chained_events"`
-	HeadID        uint   `json:"head_id"`
-	HeadHash      string `json:"head_hash"`
-	KeyVersion    string `json:"key_version"`
+	ID             uint   `json:"id"`
+	ChainedEvents  int64  `json:"chained_events"`
+	HeadID         uint   `json:"head_id"`
+	HeadHash       string `json:"head_hash"`
+	KeyVersion     string `json:"key_version"`
+	AnchoredAt     string `json:"anchored_at"`
+	AnchorProvider string `json:"anchor_provider"`
 }
 
 var checkpointCmd = &cobra.Command{
@@ -243,6 +245,10 @@ verify (broken, or a prior signed checkpoint proves a truncation).`,
 		fmt.Printf("  chained events: %d\n", out.ChainedEvents)
 		fmt.Printf("  head id:        %d\n", out.HeadID)
 		fmt.Printf("  head hash:      %s\n", out.HeadHash)
+		if out.AnchoredAt != "" {
+			fmt.Printf("  anchored at:    %s\n", out.AnchoredAt)
+			fmt.Printf("  anchor:         %s\n", out.AnchorProvider)
+		}
 		return nil
 	},
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -408,6 +408,12 @@ type CheckpointNotaryConfig struct {
 	Type    string `yaml:"type"` // "rfc3161" (default)
 	URL     string `yaml:"url"`  // TSA query endpoint, e.g. https://freetsa.org/tsr
 	Timeout string `yaml:"timeout"`
+	// CACertPath is a PEM bundle of the TSA's trusted root/CA cert(s). REQUIRED to
+	// verify a stored anchor's issuer — without it anchoring still records tokens,
+	// but verification fails closed (an untrusted/self-signed issuer must not be
+	// trusted, since the checkpoint-row writer is the actor the anchor defends
+	// against).
+	CACertPath string `yaml:"ca_cert_path"`
 }
 
 // GetTimeout returns the TSA round-trip timeout (default 15s when unset/unparseable).

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -395,6 +395,24 @@ func (c SoftDeleteConfig) GetRetentionDays() int {
 // AuditConfig groups audit-log delivery integrations.
 type AuditConfig struct {
 	SIEM SIEMConfig `yaml:"siem"`
+	// CheckpointNotary anchors each written audit checkpoint to an external RFC 3161
+	// timestamp authority for a forge-proof proof-of-existence (ADR-029). Opt-in.
+	CheckpointNotary CheckpointNotaryConfig `yaml:"checkpoint_notary"`
+}
+
+// CheckpointNotaryConfig configures external-notary anchoring of audit checkpoints.
+// type is currently always "rfc3161" (the default when enabled). URL is the TSA's
+// timestamp-query endpoint; Timeout is a Go duration (default 15s).
+type CheckpointNotaryConfig struct {
+	Enabled bool   `yaml:"enabled"`
+	Type    string `yaml:"type"` // "rfc3161" (default)
+	URL     string `yaml:"url"`  // TSA query endpoint, e.g. https://freetsa.org/tsr
+	Timeout string `yaml:"timeout"`
+}
+
+// GetTimeout returns the TSA round-trip timeout (default 15s when unset/unparseable).
+func (c CheckpointNotaryConfig) GetTimeout() time.Duration {
+	return parseDurationDefault(c.Timeout, 15*time.Second)
 }
 
 // MembershipConfig configures the project membership lifecycle (ADR-022).

--- a/internal/core/audit_checkpoint.go
+++ b/internal/core/audit_checkpoint.go
@@ -18,8 +18,11 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"log"
+	"time"
 
 	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/notary"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
@@ -36,6 +39,52 @@ func (c *KeyorixCore) SetAuditCheckpointKey(key []byte, keyVersion string) {
 // (i.e. a signing key is configured — encryption is enabled).
 func (c *KeyorixCore) AuditCheckpointsAvailable() bool {
 	return len(c.auditCkptKey) > 0
+}
+
+// SetCheckpointNotary wires an external notary (RFC 3161 TSA) that anchors each
+// freshly-written checkpoint for a forge-proof proof-of-existence (ADR-029).
+// Called at startup when audit.checkpoint_notary is enabled; left unset, no
+// external anchoring is performed.
+func (c *KeyorixCore) SetCheckpointNotary(n notary.Notary) {
+	c.checkpointNotary = n
+}
+
+// anchorCheckpoint best-effort anchors a checkpoint's canonical bytes with the
+// configured notary and persists the receipt on the row. A notary/storage failure
+// is logged and swallowed: an unanchored checkpoint is still a valid checkpoint,
+// and the next write retries — anchoring must never fail checkpointing.
+func (c *KeyorixCore) anchorCheckpoint(ctx context.Context, cp *models.AuditCheckpoint) {
+	if c.checkpointNotary == nil {
+		return
+	}
+	rec, err := c.checkpointNotary.Anchor(ctx, []byte(checkpointCanonical(cp)))
+	if err != nil {
+		log.Printf("audit checkpoint #%d: external anchor failed (left unanchored): %v", cp.ID, err)
+		return
+	}
+	if err := c.storage.UpdateAuditCheckpointAnchor(ctx, cp.ID, rec.Token, rec.Time, rec.Provider); err != nil {
+		log.Printf("audit checkpoint #%d: anchored but failed to persist receipt: %v", cp.ID, err)
+		return
+	}
+	at := rec.Time
+	cp.AnchorToken = rec.Token
+	cp.AnchoredAt = &at
+	cp.AnchorProvider = rec.Provider
+}
+
+// VerifyCheckpointAnchor re-verifies a checkpoint's external-notary receipt: it
+// confirms the stored RFC 3161 token is valid and bound to this exact checkpoint
+// (its canonical bytes), returning the authority-asserted time. ok is false with a
+// nil error when the checkpoint carries no anchor (none was configured/succeeded).
+func (c *KeyorixCore) VerifyCheckpointAnchor(cp *models.AuditCheckpoint) (anchoredAt time.Time, ok bool, err error) {
+	if cp == nil || len(cp.AnchorToken) == 0 {
+		return time.Time{}, false, nil
+	}
+	at, err := notary.VerifyReceipt([]byte(checkpointCanonical(cp)), cp.AnchorToken)
+	if err != nil {
+		return time.Time{}, true, err
+	}
+	return at, true, nil
 }
 
 // WriteAuditCheckpoint verifies the audit chain and, if it is intact, appends a
@@ -83,6 +132,8 @@ func (c *KeyorixCore) WriteAuditCheckpoint(ctx context.Context) (*models.AuditCh
 	if err := c.storage.CreateAuditCheckpoint(ctx, newCP); err != nil {
 		return nil, false, fmt.Errorf("failed to write audit checkpoint: %w", err)
 	}
+	// Best-effort external anchor (RFC 3161) — never fails the checkpoint write.
+	c.anchorCheckpoint(ctx, newCP)
 	return newCP, true, nil
 }
 

--- a/internal/core/audit_checkpoint.go
+++ b/internal/core/audit_checkpoint.go
@@ -16,6 +16,7 @@ import (
 	"context"
 	"crypto/hmac"
 	"crypto/sha256"
+	"crypto/x509"
 	"encoding/hex"
 	"fmt"
 	"log"
@@ -49,6 +50,13 @@ func (c *KeyorixCore) SetCheckpointNotary(n notary.Notary) {
 	c.checkpointNotary = n
 }
 
+// SetCheckpointAnchorRoots wires the trusted TSA root pool used to verify stored
+// checkpoint anchors (the issuer trust anchor). Without it, VerifyCheckpointAnchor
+// fails closed rather than trusting an unverifiable token.
+func (c *KeyorixCore) SetCheckpointAnchorRoots(roots *x509.CertPool) {
+	c.checkpointAnchorRoots = roots
+}
+
 // anchorCheckpoint best-effort anchors a checkpoint's canonical bytes with the
 // configured notary and persists the receipt on the row. A notary/storage failure
 // is logged and swallowed: an unanchored checkpoint is still a valid checkpoint,
@@ -80,7 +88,7 @@ func (c *KeyorixCore) VerifyCheckpointAnchor(cp *models.AuditCheckpoint) (anchor
 	if cp == nil || len(cp.AnchorToken) == 0 {
 		return time.Time{}, false, nil
 	}
-	at, err := notary.VerifyReceipt([]byte(checkpointCanonical(cp)), cp.AnchorToken)
+	at, err := notary.VerifyReceipt(c.checkpointAnchorRoots, []byte(checkpointCanonical(cp)), cp.AnchorToken)
 	if err != nil {
 		return time.Time{}, true, err
 	}

--- a/internal/core/audit_checkpoint_test.go
+++ b/internal/core/audit_checkpoint_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/keyorixhq/keyorix/internal/notary"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/keyorixhq/keyorix/internal/storage/store"
 	"github.com/stretchr/testify/assert"
@@ -63,6 +64,77 @@ func TestAuditCheckpoint_HappyPath(t *testing.T) {
 	assert.True(t, v.Valid)
 	assert.True(t, v.Checkpointed)
 	assert.Empty(t, v.CheckpointReason)
+}
+
+// fakeNotary is a stand-in external authority for the anchoring wiring tests
+// (the real RFC 3161 verify path is covered by the notary package round-trip).
+type fakeNotary struct {
+	token   []byte
+	at      time.Time
+	err     error
+	calls   int
+	lastMsg []byte
+}
+
+func (f *fakeNotary) Anchor(_ context.Context, msg []byte) (*notary.Receipt, error) {
+	f.calls++
+	f.lastMsg = append([]byte(nil), msg...)
+	if f.err != nil {
+		return nil, f.err
+	}
+	return &notary.Receipt{Token: f.token, Time: f.at, Provider: "fake"}, nil
+}
+func (f *fakeNotary) Provider() string { return "fake" }
+
+func TestAuditCheckpoint_AnchorsWhenNotarySet(t *testing.T) {
+	ctx := context.Background()
+	c, db := newCheckpointCore(t)
+	logEvents(t, c, 3)
+	fn := &fakeNotary{token: []byte("opaque-tsa-token"), at: time.Date(2026, 6, 15, 9, 0, 0, 0, time.UTC)}
+	c.SetCheckpointNotary(fn)
+
+	cp, written, err := c.WriteAuditCheckpoint(ctx)
+	require.NoError(t, err)
+	require.True(t, written)
+
+	// The receipt is reflected on the returned checkpoint...
+	require.Equal(t, 1, fn.calls)
+	require.NotNil(t, cp.AnchoredAt)
+	assert.Equal(t, "fake", cp.AnchorProvider)
+	assert.Equal(t, []byte("opaque-tsa-token"), cp.AnchorToken)
+	// ...the notary saw exactly the checkpoint's canonical bytes...
+	assert.Equal(t, []byte(checkpointCanonical(cp)), fn.lastMsg)
+	// ...and the receipt was persisted on the row.
+	var row models.AuditCheckpoint
+	require.NoError(t, db.First(&row, cp.ID).Error)
+	assert.Equal(t, []byte("opaque-tsa-token"), row.AnchorToken)
+	require.NotNil(t, row.AnchoredAt)
+	assert.Equal(t, "fake", row.AnchorProvider)
+}
+
+func TestAuditCheckpoint_AnchorIsBestEffort(t *testing.T) {
+	ctx := context.Background()
+	c, db := newCheckpointCore(t)
+	logEvents(t, c, 2)
+	c.SetCheckpointNotary(&fakeNotary{err: fmt.Errorf("tsa unreachable")})
+
+	// A notary failure must NOT fail the checkpoint write.
+	cp, written, err := c.WriteAuditCheckpoint(ctx)
+	require.NoError(t, err)
+	require.True(t, written)
+	assert.Nil(t, cp.AnchoredAt)
+
+	var row models.AuditCheckpoint
+	require.NoError(t, db.First(&row, cp.ID).Error)
+	assert.Empty(t, row.AnchorToken, "an un-anchored checkpoint is still a valid checkpoint")
+}
+
+func TestVerifyCheckpointAnchor_NoAnchor(t *testing.T) {
+	c, _ := newCheckpointCore(t)
+	at, ok, err := c.VerifyCheckpointAnchor(&models.AuditCheckpoint{ID: 1})
+	require.NoError(t, err)
+	assert.False(t, ok)
+	assert.True(t, at.IsZero())
 }
 
 func TestAuditCheckpoint_DetectsTailTruncation(t *testing.T) {

--- a/internal/core/audit_checkpoint_test.go
+++ b/internal/core/audit_checkpoint_test.go
@@ -137,6 +137,17 @@ func TestVerifyCheckpointAnchor_NoAnchor(t *testing.T) {
 	assert.True(t, at.IsZero())
 }
 
+func TestVerifyCheckpointAnchor_NoTrustAnchorFailsClosed(t *testing.T) {
+	c, _ := newCheckpointCore(t)
+	// A checkpoint carries an anchor token, but no trust anchor is configured:
+	// verification must fail closed (ok=true, error) rather than assert a proof.
+	cp := &models.AuditCheckpoint{ID: 1, AnchorToken: []byte("some-token")}
+	_, ok, err := c.VerifyCheckpointAnchor(cp)
+	assert.True(t, ok, "an anchor is present")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "trust anchor")
+}
+
 func TestAuditCheckpoint_DetectsTailTruncation(t *testing.T) {
 	ctx := context.Background()
 	c, db := newCheckpointCore(t)

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -942,6 +942,11 @@ func (m *MockStorage) LatestAuditCheckpoint(ctx context.Context) (*models.AuditC
 	return args.Get(0).(*models.AuditCheckpoint), args.Error(1)
 }
 
+func (m *MockStorage) UpdateAuditCheckpointAnchor(ctx context.Context, id uint, token []byte, anchoredAt time.Time, provider string) error {
+	args := m.Called(ctx, id, token, anchoredAt, provider)
+	return args.Error(0)
+}
+
 func (m *MockStorage) AuditEntryHashByID(ctx context.Context, id uint) (string, bool, error) {
 	args := m.Called(ctx, id)
 	return args.String(0), args.Bool(1), args.Error(2)

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"crypto/x509"
 	"fmt"
 	"time"
 
@@ -106,6 +107,10 @@ type KeyorixCore struct {
 	// an external authority (RFC 3161 TSA) for a forge-proof proof-of-existence
 	// (ADR-029). nil = no external anchoring. Set at startup via SetCheckpointNotary.
 	checkpointNotary notary.Notary
+	// checkpointAnchorRoots is the trusted TSA root pool used to VERIFY stored
+	// checkpoint anchors (the issuer trust anchor). nil = anchors cannot be verified
+	// (fail closed). Set at startup via SetCheckpointAnchorRoots.
+	checkpointAnchorRoots *x509.CertPool
 	// evidenceSignKey / evidenceSignKeyVersion sign and verify exported compliance-
 	// evidence packs (HMAC, DEK-derived, domain-separated from the checkpoint key).
 	// nil = signing unavailable (encryption disabled). Set via SetEvidenceSignKey.

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -10,6 +10,7 @@ import (
 	"github.com/keyorixhq/keyorix/internal/delivery"
 	"github.com/keyorixhq/keyorix/internal/dynamic"
 	"github.com/keyorixhq/keyorix/internal/encryption"
+	"github.com/keyorixhq/keyorix/internal/notary"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
@@ -101,6 +102,10 @@ type KeyorixCore struct {
 	// enforced after a DEK rotation.
 	auditCkptKey        []byte
 	auditCkptKeyVersion string
+	// checkpointNotary, when set, anchors each freshly-written audit checkpoint to
+	// an external authority (RFC 3161 TSA) for a forge-proof proof-of-existence
+	// (ADR-029). nil = no external anchoring. Set at startup via SetCheckpointNotary.
+	checkpointNotary notary.Notary
 	// evidenceSignKey / evidenceSignKeyVersion sign and verify exported compliance-
 	// evidence packs (HMAC, DEK-derived, domain-separated from the checkpoint key).
 	// nil = signing unavailable (encryption disabled). Set via SetEvidenceSignKey.

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -359,6 +359,10 @@ type Storage interface {
 	VerifyAuditChain(ctx context.Context) (*AuditChainVerification, error)
 	// CreateAuditCheckpoint appends a signed checkpoint of the chain head (ADR-029).
 	CreateAuditCheckpoint(ctx context.Context, cp *models.AuditCheckpoint) error
+	// UpdateAuditCheckpointAnchor stores the external-notary anchor (RFC 3161 token,
+	// asserted time, provider) on an existing checkpoint row (ADR-029); the signed
+	// fields stay immutable.
+	UpdateAuditCheckpointAnchor(ctx context.Context, id uint, token []byte, anchoredAt time.Time, provider string) error
 	// LatestAuditCheckpoint returns the most recently written checkpoint, or
 	// (nil, nil) when none exists yet.
 	LatestAuditCheckpoint(ctx context.Context) (*models.AuditCheckpoint, error)

--- a/internal/notary/notary.go
+++ b/internal/notary/notary.go
@@ -1,0 +1,59 @@
+// Package notary anchors a message to an external authority that returns an
+// independent, signed proof the message existed at a point in time — so a proof
+// the running server cannot forge or backdate. Keyorix uses it to anchor audit
+// checkpoints (ADR-029): the on-box checkpoint is HMAC-signed with a DEK-derived
+// key, which detects truncation/rewrite by a database actor, but an attacker who
+// also holds the DEK could forge it. An external RFC 3161 timestamp over the same
+// checkpoint binds it to a third party's clock and signing key, which that
+// attacker does not control — strengthening the tamper-evidence story for ISO
+// 27001 / SOC 2 / eIDAS.
+//
+// The Notary interface keeps the anchoring backend pluggable (and fake-able in
+// tests); RFC3161 is the first implementation.
+package notary
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"time"
+
+	"github.com/digitorus/timestamp"
+)
+
+// Receipt is an external authority's proof over an anchored message.
+type Receipt struct {
+	Token    []byte    // opaque proof (an RFC 3161 TimeStampToken, DER)
+	Time     time.Time // the time the authority asserts the message existed at
+	Provider string    // identifies the authority, e.g. "rfc3161:https://freetsa.org/tsr"
+}
+
+// Notary anchors a message with an external authority and returns a Receipt. The
+// message is the raw bytes being anchored (the backend hashes it as needed); the
+// caller passes the SAME bytes to VerifyReceipt later.
+type Notary interface {
+	Anchor(ctx context.Context, message []byte) (*Receipt, error)
+	// Provider identifies the configured authority (for logging / receipt tagging).
+	Provider() string
+}
+
+// VerifyReceipt re-checks an RFC 3161 receipt token against the original message:
+// it parses (and signature-validates) the token, confirms the token's hashed
+// message equals SHA-256(message) — so the receipt is bound to exactly this
+// message — and returns the authority's asserted time. A parse/signature failure
+// or a digest mismatch is an error: the receipt does not prove this message.
+func VerifyReceipt(message, token []byte) (time.Time, error) {
+	if len(token) == 0 {
+		return time.Time{}, fmt.Errorf("notary: empty receipt token")
+	}
+	ts, err := timestamp.Parse(token)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("notary: invalid timestamp token: %w", err)
+	}
+	want := sha256.Sum256(message)
+	if !bytes.Equal(ts.HashedMessage, want[:]) {
+		return time.Time{}, fmt.Errorf("notary: receipt does not bind this message (timestamped digest differs)")
+	}
+	return ts.Time, nil
+}

--- a/internal/notary/notary.go
+++ b/internal/notary/notary.go
@@ -16,9 +16,11 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
+	"crypto/x509"
 	"fmt"
 	"time"
 
+	"github.com/digitorus/pkcs7"
 	"github.com/digitorus/timestamp"
 )
 
@@ -38,12 +40,21 @@ type Notary interface {
 	Provider() string
 }
 
-// VerifyReceipt re-checks an RFC 3161 receipt token against the original message:
-// it parses (and signature-validates) the token, confirms the token's hashed
-// message equals SHA-256(message) — so the receipt is bound to exactly this
-// message — and returns the authority's asserted time. A parse/signature failure
-// or a digest mismatch is an error: the receipt does not prove this message.
-func VerifyReceipt(message, token []byte) (time.Time, error) {
+// VerifyReceipt re-checks an RFC 3161 receipt token against the original message.
+// It (1) verifies the token's signature chains to one of the configured TSA roots
+// with the time-stamping extended key usage — so a self-signed or otherwise
+// untrusted issuer is rejected; (2) confirms the token's hashed message equals
+// SHA-256(message), binding the receipt to exactly this message; and (3) returns
+// the authority's asserted time.
+//
+// roots is REQUIRED: without a trust anchor a token's issuer cannot be trusted, so
+// an attacker who can write the checkpoint row (the very actor the anchor defends
+// against) could mint a self-signed token over the same bytes. A nil roots
+// therefore fails closed rather than asserting an unverifiable proof.
+func VerifyReceipt(roots *x509.CertPool, message, token []byte) (time.Time, error) {
+	if roots == nil {
+		return time.Time{}, fmt.Errorf("notary: no TSA trust anchor configured — cannot verify receipt issuer")
+	}
 	if len(token) == 0 {
 		return time.Time{}, fmt.Errorf("notary: empty receipt token")
 	}
@@ -54,6 +65,25 @@ func VerifyReceipt(message, token []byte) (time.Time, error) {
 	want := sha256.Sum256(message)
 	if !bytes.Equal(ts.HashedMessage, want[:]) {
 		return time.Time{}, fmt.Errorf("notary: receipt does not bind this message (timestamped digest differs)")
+	}
+	// Chain-verify the token's signer to a configured root with the time-stamping
+	// EKU. timestamp.Parse only checks the signature is internally consistent (it
+	// uses an empty trust store), so this is the step that establishes the issuer
+	// is a trusted TSA and not an attacker's self-signed cert.
+	p7, err := pkcs7.Parse(token)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("notary: parse token for chain verification: %w", err)
+	}
+	intermediates := x509.NewCertPool()
+	for _, c := range p7.Certificates {
+		intermediates.AddCert(c)
+	}
+	if err := p7.VerifyWithOpts(x509.VerifyOptions{
+		Roots:         roots,
+		Intermediates: intermediates,
+		KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageTimeStamping},
+	}); err != nil {
+		return time.Time{}, fmt.Errorf("notary: receipt issuer not trusted: %w", err)
 	}
 	return ts.Time, nil
 }

--- a/internal/notary/notary_test.go
+++ b/internal/notary/notary_test.go
@@ -53,12 +53,13 @@ func newTestTSA(t *testing.T, fixedTime time.Time) (*httptest.Server, crypto.Sig
 			return
 		}
 		ts := &timestamp.Timestamp{
-			HashAlgorithm: req.HashAlgorithm,
-			HashedMessage: req.HashedMessage,
-			Time:          fixedTime,
-			Nonce:         req.Nonce,
-			Policy:        asn1.ObjectIdentifier{1, 2, 3, 4, 1},
-			SerialNumber:  big.NewInt(42),
+			HashAlgorithm:     req.HashAlgorithm,
+			HashedMessage:     req.HashedMessage,
+			Time:              fixedTime,
+			Nonce:             req.Nonce,
+			Policy:            asn1.ObjectIdentifier{1, 2, 3, 4, 1},
+			SerialNumber:      big.NewInt(42),
+			AddTSACertificate: true, // embed the signing cert so the token is self-contained
 		}
 		resp, err := ts.CreateResponseWithOpts(cert, key, crypto.SHA256)
 		if err != nil {
@@ -74,7 +75,9 @@ func newTestTSA(t *testing.T, fixedTime time.Time) (*httptest.Server, crypto.Sig
 
 func TestRFC3161_AnchorAndVerifyRoundTrip(t *testing.T) {
 	fixedTime := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
-	srv, _, _ := newTestTSA(t, fixedTime)
+	srv, _, cert := newTestTSA(t, fixedTime)
+	roots := x509.NewCertPool()
+	roots.AddCert(cert)
 
 	msg := []byte("v1\x00128\x0099\x00deadbeef\x00v1")
 	rec, err := NewRFC3161(srv.URL, 5*time.Second).Anchor(context.Background(), msg)
@@ -83,24 +86,36 @@ func TestRFC3161_AnchorAndVerifyRoundTrip(t *testing.T) {
 	assert.WithinDuration(t, fixedTime, rec.Time, time.Second)
 	assert.Equal(t, "rfc3161:"+srv.URL, rec.Provider)
 
-	// The receipt verifies against the original message and yields the TSA time.
-	at, err := VerifyReceipt(msg, rec.Token)
+	// The receipt verifies against the original message + trusted root, yielding the TSA time.
+	at, err := VerifyReceipt(roots, msg, rec.Token)
 	require.NoError(t, err)
 	assert.WithinDuration(t, fixedTime, at, time.Second)
 
 	// A different message must NOT verify against the same token.
-	_, err = VerifyReceipt([]byte("v1\x00129\x0099\x00deadbeef\x00v1"), rec.Token)
+	_, err = VerifyReceipt(roots, []byte("v1\x00129\x0099\x00deadbeef\x00v1"), rec.Token)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "does not bind")
+
+	// A token from an UNTRUSTED issuer (empty/other root pool) must be rejected —
+	// this is the trust-anchor check that stops a DB+DEK attacker forging a token.
+	_, err = VerifyReceipt(x509.NewCertPool(), msg, rec.Token)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not trusted")
+
+	// A nil trust anchor fails closed rather than asserting an unverifiable proof.
+	_, err = VerifyReceipt(nil, msg, rec.Token)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "trust anchor")
 }
 
 func TestVerifyReceipt_Errors(t *testing.T) {
+	roots := x509.NewCertPool()
 	t.Run("empty token", func(t *testing.T) {
-		_, err := VerifyReceipt([]byte("m"), nil)
+		_, err := VerifyReceipt(roots, []byte("m"), nil)
 		require.Error(t, err)
 	})
 	t.Run("garbage token", func(t *testing.T) {
-		_, err := VerifyReceipt([]byte("m"), []byte("not-a-token"))
+		_, err := VerifyReceipt(roots, []byte("m"), []byte("not-a-token"))
 		require.Error(t, err)
 	})
 }

--- a/internal/notary/notary_test.go
+++ b/internal/notary/notary_test.go
@@ -1,0 +1,125 @@
+package notary
+
+import (
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"io"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/digitorus/timestamp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestTSA stands up an in-process RFC 3161 Time-Stamp Authority backed by a
+// self-signed timestamping cert. It parses each request and returns a real signed
+// TimeStampToken stamped at fixedTime, so the client path is exercised end to end.
+func newTestTSA(t *testing.T, fixedTime time.Time) (*httptest.Server, crypto.Signer, *x509.Certificate) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "Test TSA"},
+		NotBefore:             fixedTime.Add(-time.Hour),
+		NotAfter:              fixedTime.Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageTimeStamping},
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+	cert, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, "read", http.StatusBadRequest)
+			return
+		}
+		req, err := timestamp.ParseRequest(body)
+		if err != nil {
+			http.Error(w, "parse", http.StatusBadRequest)
+			return
+		}
+		ts := &timestamp.Timestamp{
+			HashAlgorithm: req.HashAlgorithm,
+			HashedMessage: req.HashedMessage,
+			Time:          fixedTime,
+			Nonce:         req.Nonce,
+			Policy:        asn1.ObjectIdentifier{1, 2, 3, 4, 1},
+			SerialNumber:  big.NewInt(42),
+		}
+		resp, err := ts.CreateResponseWithOpts(cert, key, crypto.SHA256)
+		if err != nil {
+			http.Error(w, "create: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/timestamp-reply")
+		_, _ = w.Write(resp)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, key, cert
+}
+
+func TestRFC3161_AnchorAndVerifyRoundTrip(t *testing.T) {
+	fixedTime := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
+	srv, _, _ := newTestTSA(t, fixedTime)
+
+	msg := []byte("v1\x00128\x0099\x00deadbeef\x00v1")
+	rec, err := NewRFC3161(srv.URL, 5*time.Second).Anchor(context.Background(), msg)
+	require.NoError(t, err)
+	require.NotEmpty(t, rec.Token)
+	assert.WithinDuration(t, fixedTime, rec.Time, time.Second)
+	assert.Equal(t, "rfc3161:"+srv.URL, rec.Provider)
+
+	// The receipt verifies against the original message and yields the TSA time.
+	at, err := VerifyReceipt(msg, rec.Token)
+	require.NoError(t, err)
+	assert.WithinDuration(t, fixedTime, at, time.Second)
+
+	// A different message must NOT verify against the same token.
+	_, err = VerifyReceipt([]byte("v1\x00129\x0099\x00deadbeef\x00v1"), rec.Token)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not bind")
+}
+
+func TestVerifyReceipt_Errors(t *testing.T) {
+	t.Run("empty token", func(t *testing.T) {
+		_, err := VerifyReceipt([]byte("m"), nil)
+		require.Error(t, err)
+	})
+	t.Run("garbage token", func(t *testing.T) {
+		_, err := VerifyReceipt([]byte("m"), []byte("not-a-token"))
+		require.Error(t, err)
+	})
+}
+
+func TestRFC3161_Anchor_HTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "nope", http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(srv.Close)
+	_, err := NewRFC3161(srv.URL, 5*time.Second).Anchor(context.Background(), []byte("m"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "HTTP 503")
+}
+
+func TestRFC3161_Anchor_GarbageResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("not-a-timestamp-response"))
+	}))
+	t.Cleanup(srv.Close)
+	_, err := NewRFC3161(srv.URL, 5*time.Second).Anchor(context.Background(), []byte("m"))
+	require.Error(t, err)
+}

--- a/internal/notary/rfc3161.go
+++ b/internal/notary/rfc3161.go
@@ -1,0 +1,79 @@
+package notary
+
+import (
+	"bytes"
+	"context"
+	"crypto"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/digitorus/timestamp"
+)
+
+// defaultTimeout bounds the round-trip to the timestamp authority.
+const defaultTimeout = 15 * time.Second
+
+// maxResponseBytes caps how much of the TSA reply we read — a timestamp response
+// is a few KB; this guards against a misbehaving/hostile endpoint.
+const maxResponseBytes = 1 << 20 // 1 MiB
+
+// RFC3161 anchors a message with an RFC 3161 Time-Stamp Authority (TSA): it POSTs
+// a SHA-256 MessageImprint over the message and stores the returned signed
+// TimeStampToken as the receipt. Credentials/TLS come from the standard HTTP
+// client; the URL is operator-configured deployment config.
+type RFC3161 struct {
+	url    string
+	client *http.Client
+}
+
+// NewRFC3161 builds a TSA notary for the given query URL. A non-positive timeout
+// falls back to defaultTimeout.
+func NewRFC3161(url string, timeout time.Duration) *RFC3161 {
+	if timeout <= 0 {
+		timeout = defaultTimeout
+	}
+	return &RFC3161{url: url, client: &http.Client{Timeout: timeout}}
+}
+
+func (r *RFC3161) Provider() string { return "rfc3161:" + r.url }
+
+func (r *RFC3161) Anchor(ctx context.Context, message []byte) (*Receipt, error) {
+	// CreateRequest hashes the message (SHA-256) into the MessageImprint and asks
+	// the TSA to include its signing certificate so the token is self-contained.
+	reqDER, err := timestamp.CreateRequest(bytes.NewReader(message), &timestamp.RequestOptions{
+		Hash:         crypto.SHA256,
+		Certificates: true,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("rfc3161: build request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, r.url, bytes.NewReader(reqDER))
+	if err != nil {
+		return nil, fmt.Errorf("rfc3161: new request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/timestamp-query")
+	httpReq.Header.Set("Accept", "application/timestamp-reply")
+
+	resp, err := r.client.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("rfc3161: post to %s: %w", r.url, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("rfc3161: %s returned HTTP %d", r.url, resp.StatusCode)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+	if err != nil {
+		return nil, fmt.Errorf("rfc3161: read response: %w", err)
+	}
+
+	// ParseResponse validates the PKI status and the token's signature structure.
+	ts, err := timestamp.ParseResponse(body)
+	if err != nil {
+		return nil, fmt.Errorf("rfc3161: parse response: %w", err)
+	}
+	return &Receipt{Token: ts.RawToken, Time: ts.Time, Provider: r.Provider()}, nil
+}

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -399,6 +399,17 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 		if err := db.AutoMigrate(&models.AuditCheckpoint{}); err != nil {
 			return fmt.Errorf("failed to migrate audit_checkpoints table: %w", err)
 		}
+	} else {
+		// Add only the newer external-notary anchor columns on an existing table
+		// (additive; same pgx hazard as elsewhere — never full-AutoMigrate here).
+		m := db.Migrator()
+		for _, col := range []string{"AnchorToken", "AnchoredAt", "AnchorProvider"} {
+			if !m.HasColumn(&models.AuditCheckpoint{}, col) {
+				if err := m.AddColumn(&models.AuditCheckpoint{}, col); err != nil {
+					return fmt.Errorf("failed to add audit_checkpoints column %s: %w", col, err)
+				}
+			}
+		}
 	}
 
 	// Create project_invitations if missing (ADR-024, additive); otherwise add only

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -691,13 +691,20 @@ type AuditEvent struct {
 // chain cannot catch. Append-only: a new checkpoint is added each cycle, never
 // updated.
 type AuditCheckpoint struct {
-	ID            uint      `gorm:"primaryKey" json:"id"`
-	ChainedEvents int64     `json:"chained_events"`
-	HeadID        uint      `json:"head_id"`
-	HeadHash      string    `json:"head_hash"`
-	KeyVersion    string    `json:"key_version"`
-	Signature     string    `gorm:"not null" json:"signature"` // hex HMAC-SHA256
-	CreatedAt     time.Time `json:"created_at"`
+	ID            uint   `gorm:"primaryKey" json:"id"`
+	ChainedEvents int64  `json:"chained_events"`
+	HeadID        uint   `json:"head_id"`
+	HeadHash      string `json:"head_hash"`
+	KeyVersion    string `json:"key_version"`
+	Signature     string `gorm:"not null" json:"signature"` // hex HMAC-SHA256
+	// External-notary anchor (ADR-029): an independent RFC 3161 timestamp over the
+	// checkpoint's canonical bytes, proving it existed at AnchoredAt with a proof the
+	// server cannot forge. Nil/empty when no notary is configured or the anchor call
+	// failed (best-effort — an unanchored checkpoint is still a valid checkpoint).
+	AnchorToken    []byte     `json:"anchor_token,omitempty"`    // opaque RFC 3161 TimeStampToken (DER)
+	AnchoredAt     *time.Time `json:"anchored_at,omitempty"`     // the time the TSA asserts
+	AnchorProvider string     `json:"anchor_provider,omitempty"` // e.g. "rfc3161:https://freetsa.org/tsr"
+	CreatedAt      time.Time  `json:"created_at"`
 }
 
 type Setting struct {

--- a/internal/storage/store/local_audit_checkpoint.go
+++ b/internal/storage/store/local_audit_checkpoint.go
@@ -10,6 +10,7 @@ package store
 import (
 	"context"
 	"errors"
+	"time"
 
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"gorm.io/gorm"
@@ -18,6 +19,21 @@ import (
 // CreateAuditCheckpoint appends a signed checkpoint row (append-only).
 func (ls *LocalStorage) CreateAuditCheckpoint(ctx context.Context, cp *models.AuditCheckpoint) error {
 	return ls.db.WithContext(ctx).Create(cp).Error
+}
+
+// UpdateAuditCheckpointAnchor stores the external-notary anchor (RFC 3161 token +
+// asserted time + provider) on an already-written checkpoint row. Updates only the
+// three anchor columns, leaving the signed (chained_events, head, signature)
+// fields immutable.
+func (ls *LocalStorage) UpdateAuditCheckpointAnchor(ctx context.Context, id uint, token []byte, anchoredAt time.Time, provider string) error {
+	return ls.db.WithContext(ctx).
+		Model(&models.AuditCheckpoint{}).
+		Where("id = ?", id).
+		Updates(map[string]interface{}{
+			"anchor_token":    token,
+			"anchored_at":     anchoredAt,
+			"anchor_provider": provider,
+		}).Error
 }
 
 // LatestAuditCheckpoint returns the most recent checkpoint by id, or (nil, nil)

--- a/internal/storage/store/remote_audit.go
+++ b/internal/storage/store/remote_audit.go
@@ -153,6 +153,11 @@ func (rs *RemoteStorage) LatestAuditCheckpoint(_ context.Context) (*models.Audit
 	return nil, fmt.Errorf("LatestAuditCheckpoint not available in remote mode")
 }
 
+// UpdateAuditCheckpointAnchor is not available in remote mode; checkpointing is server-side.
+func (rs *RemoteStorage) UpdateAuditCheckpointAnchor(_ context.Context, _ uint, _ []byte, _ time.Time, _ string) error {
+	return fmt.Errorf("UpdateAuditCheckpointAnchor not available in remote mode")
+}
+
 // AuditEntryHashByID is not available in remote mode; chain verification runs server-side.
 func (rs *RemoteStorage) AuditEntryHashByID(_ context.Context, _ uint) (string, bool, error) {
 	return "", false, fmt.Errorf("AuditEntryHashByID not available in remote mode")

--- a/server/http/handlers/audit.go
+++ b/server/http/handlers/audit.go
@@ -406,11 +406,17 @@ func (h *AuditHandler) WriteAuditCheckpoint(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	sendSuccess(w, map[string]interface{}{
+	resp := map[string]interface{}{
 		"id":             cp.ID,
 		"chained_events": cp.ChainedEvents,
 		"head_id":        cp.HeadID,
 		"head_hash":      cp.HeadHash,
 		"key_version":    cp.KeyVersion,
-	}, "audit checkpoint written")
+	}
+	// Surface the external-notary anchor when one was obtained (ADR-029).
+	if cp.AnchoredAt != nil {
+		resp["anchored_at"] = cp.AnchoredAt.UTC()
+		resp["anchor_provider"] = cp.AnchorProvider
+	}
+	sendSuccess(w, resp, "audit checkpoint written")
 }

--- a/server/main.go
+++ b/server/main.go
@@ -21,6 +21,7 @@ package main
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -189,6 +190,20 @@ func initializeEncryption(cfg *config.Config) (*encryption.Service, error) {
 	return svc, nil
 }
 
+// loadCertPool reads a PEM bundle from path and returns a cert pool of its
+// certificates (the TSA trust anchor for verifying checkpoint anchors).
+func loadCertPool(path string) (*x509.CertPool, error) {
+	pem, err := os.ReadFile(path) // #nosec G304 -- operator-configured trusted CA bundle path
+	if err != nil {
+		return nil, err
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(pem) {
+		return nil, fmt.Errorf("no PEM certificates found in %s", path)
+	}
+	return pool, nil
+}
+
 func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.Service, error) {
 	// Use storage factory to support SQLite, PostgreSQL, and remote storage
 	factory := appstorage.NewStorageFactory()
@@ -229,7 +244,17 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 			log.Printf("Audit checkpoint notary enabled but no url set; skipping external anchoring")
 		} else {
 			coreService.SetCheckpointNotary(notary.NewRFC3161(cn.URL, cn.GetTimeout()))
-			log.Printf("Audit checkpoint external anchoring enabled (rfc3161, url=%s, timeout=%s)", cn.URL, cn.GetTimeout())
+			// Load the TSA trust anchor used to VERIFY stored anchors. Without it,
+			// anchoring still records tokens but verification fails closed (an
+			// untrusted issuer must not be trusted).
+			if cn.CACertPath == "" {
+				log.Printf("Audit checkpoint external anchoring enabled (rfc3161, url=%s) — WARNING: no ca_cert_path set, stored anchors cannot be verified", cn.URL)
+			} else if roots, err := loadCertPool(cn.CACertPath); err != nil {
+				log.Printf("Audit checkpoint notary: failed to load ca_cert_path %q (%v) — anchors cannot be verified", cn.CACertPath, err)
+			} else {
+				coreService.SetCheckpointAnchorRoots(roots)
+				log.Printf("Audit checkpoint external anchoring enabled (rfc3161, url=%s, timeout=%s, trust anchor=%s)", cn.URL, cn.GetTimeout(), cn.CACertPath)
+			}
 		}
 	}
 

--- a/server/main.go
+++ b/server/main.go
@@ -43,6 +43,7 @@ import (
 	"github.com/keyorixhq/keyorix/internal/encryption"
 	"github.com/keyorixhq/keyorix/internal/evidencesink"
 	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/notary"
 	"github.com/keyorixhq/keyorix/internal/notifychan"
 	appstorage "github.com/keyorixhq/keyorix/internal/storage"
 	"github.com/keyorixhq/keyorix/server/grpc"
@@ -216,6 +217,19 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 		// exports are signed (and verifiable). Unavailable when encryption is off.
 		if key, keyVer, ok := encSvc.EvidenceSignKey(); ok {
 			coreService.SetEvidenceSignKey(key, keyVer)
+		}
+	}
+
+	// Wire external-notary anchoring of audit checkpoints if enabled (ADR-029): each
+	// written checkpoint gets an independent RFC 3161 timestamp the server cannot
+	// forge. Anchoring is best-effort and only meaningful when checkpoints are
+	// written (which requires encryption).
+	if cn := cfg.Audit.CheckpointNotary; cn.Enabled {
+		if cn.URL == "" {
+			log.Printf("Audit checkpoint notary enabled but no url set; skipping external anchoring")
+		} else {
+			coreService.SetCheckpointNotary(notary.NewRFC3161(cn.URL, cn.GetTimeout()))
+			log.Printf("Audit checkpoint external anchoring enabled (rfc3161, url=%s, timeout=%s)", cn.URL, cn.GetTimeout())
 		}
 	}
 


### PR DESCRIPTION
## Summary

The audit-checkpoint HMAC (ADR-029) is keyed by a DEK-derived key the running server holds — which detects truncation/rewrite by a *database* actor, but an attacker who also obtains the DEK could forge a checkpoint. This anchors each written checkpoint to an external **RFC 3161 timestamp authority (TSA)**: an independent, signed proof-of-existence over the checkpoint's canonical bytes, bound to a third party's clock and signing key that such an attacker does not control and cannot backdate. Operationalizes the "record the external anchor" intent the `audit verify` CLI already hinted at.

## How it works

- **`internal/notary`** — a pluggable `Notary` interface + an RFC 3161 client (`digitorus/timestamp`) that POSTs a SHA-256 MessageImprint and stores the returned signed `TimeStampToken`. `VerifyReceipt` re-validates a token and confirms it binds the exact message. Fake-able at the seam; tested end-to-end against an in-process self-signed TSA.
- **core** — `SetCheckpointNotary`; `WriteAuditCheckpoint` anchors the new checkpoint **best-effort** (a TSA failure is logged and swallowed — an un-anchored checkpoint is still valid, and the next write retries); `VerifyCheckpointAnchor` re-checks a stored receipt.
- **model/storage** — `AuditCheckpoint` gains `anchor_token`/`anchored_at`/`anchor_provider` (additive migration, incl. `AddColumn` on existing tables); `UpdateAuditCheckpointAnchor` persists only those columns, leaving the signed fields immutable.
- **config** — `audit.checkpoint_notary {enabled, type, url, timeout}`, wired in `main`.
- **surface** — `POST /audit/checkpoint` and `keyorix audit checkpoint` report the anchor (asserted time + provider).

## Security

- The TSA URL is operator-configured deployment config (trusted, like `file_path`/`env_var`); the request is a digest, the stored token is opaque, and no secret/PII is sent or logged.
- Anchoring is **best-effort** — it never blocks or fails checkpointing (availability of the tamper-evidence trail is preserved even if the TSA is down).
- The stored token's signature is validated on parse; `VerifyReceipt` confirms the timestamped digest equals SHA-256 of the checkpoint's canonical bytes, so a token cannot be transplanted onto a different checkpoint.
- New dependency: `github.com/digitorus/timestamp` (purpose-built RFC 3161; hand-rolling CMS verification would be riskier).

## Tests

notary: full TSA round-trip (self-signed authority) + digest-mismatch / empty / garbage / HTTP-error paths. core: anchor persisted on write, best-effort on TSA failure, verify no-anchor case. gofmt/golangci-lint/gosec/gitleaks clean; only the documented local-only `TestEveryMutatingRouteDeniesReadOnly` (/sw.js + evidence/verify) fails locally (green in CI) — the `/audit/checkpoint` route still returns 403 to a read-only persona.

🤖 Generated with [Claude Code](https://claude.com/claude-code)