### PR TITLE
release: prep v0.36.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,30 @@
 All notable changes to Keyorix are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## v0.36.0 — 2026-06-15
+
+Independently verifiable audit trail: anchor checkpoints to a trusted timestamp
+authority.
+
+### Added
+- **External-notary anchoring of audit checkpoints (RFC 3161)** — each signed
+  audit checkpoint (ADR-029) can now be anchored to a trusted timestamp authority
+  (TSA), producing an independent, third-party-signed proof that the checkpoint
+  existed at a point in time — a proof the server cannot forge or backdate, even by
+  an attacker holding the data-encryption key. The TSA token is stored on the
+  checkpoint and re-verifiable offline. Configure via `audit.checkpoint_notary`
+  (`enabled`, `url`, `timeout`, `ca_cert_path`); anchoring is best-effort and never
+  blocks checkpointing. The anchor (asserted time + TSA) is shown by
+  `keyorix audit checkpoint`. ([#234])
+
+### Notes
+- Additive (three nullable `audit_checkpoints` columns) and opt-in. Verification
+  requires `ca_cert_path` (the TSA's trust anchor): the token signer is chained to
+  it with the time-stamping EKU, so an untrusted/self-signed token is rejected, and
+  verification fails closed when no trust anchor is configured.
+
+[#234]: https://github.com/keyorixhq/keyorix/pull/234
+
 ## v0.35.0 — 2026-06-15
 
 KEK flexibility + gRPC parity: resolve the KEK from any command, and pull

--- a/deploy/helm/keyorix/Chart.yaml
+++ b/deploy/helm/keyorix/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix
 description: Self-hosted Keyorix secrets manager (API server + web UI + PostgreSQL)
 type: application
 # Chart version — bump on chart changes.
-version: 0.35.0
+version: 0.36.0
 # The Keyorix app version this chart deploys by default (the image tag).
-appVersion: "0.35.0"
+appVersion: "0.36.0"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix


### PR DESCRIPTION
Release prep for **v0.36.0** — external-notary (RFC 3161) anchoring of audit checkpoints (#234).

- CHANGELOG: v0.36.0 section.
- Helm chart: version + appVersion → 0.36.0.

Merge → tag `v0.36.0` → release + docker-publish pipelines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)