### PR TITLE
feat(encryption): Shamir K-of-N split-custody KEK provider

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -140,6 +140,12 @@ storage:
       # external secret store Keyorix has no built-in client for.
       # exec_command: ["op", "read", "op://vault/keyorix-kek/value"]
 
+      # type: shamir — reconstruct the KEK from K-of-N Shamir shares (no single
+      # custodian holds it). Provide at least the threshold many shares (hex/base64)
+      # via files and/or env vars. Generate with `keyorix encryption shamir-split`.
+      # shamir_share_files: [/etc/keyorix/share-1.hex, /etc/keyorix/share-2.hex, /etc/keyorix/share-3.hex]
+      # shamir_share_env: [KX_KEK_SHARE_1, KX_KEK_SHARE_2]
+
       # type: aws-kms / gcp-kms / azure-kms — envelope-wrap the KEK with a cloud
       # KMS/HSM key (ADR-041); the wrapping key stays in the KMS/HSM. Credentials
       # come from the standard cloud environment (AWS: env/instance-profile/IRSA;
@@ -161,6 +167,16 @@ storage:
   helper. Output is 32 raw bytes or a hex/base64 encoding thereof. The command runs
   at startup (fail-closed, 30s timeout) and `KEYORIX_MASTER_PASSWORD` is **not**
   required. The argv is trusted deployment config, like `file_path`/`env_var`.
+- **`shamir`**: the KEK is split into **N Shamir shares** with a **K-of-N**
+  threshold, so no single custodian holds it and at least K must combine to unseal
+  (separation of duties for the master key). Generate with `keyorix encryption
+  shamir-split --shares N --threshold K` (the KEK is never printed/stored — only the
+  shares are). Provide at least K shares at startup via `shamir_share_files` and/or
+  `shamir_share_env` (each a hex/base64 share); the server reconstructs the KEK in
+  memory. `KEYORIX_MASTER_PASSWORD` is **not** required. Move an existing install
+  onto it with `keyorix encryption migrate-provider --to-type shamir
+  --to-shamir-share-files …`. ⚠️ Losing more than N-K shares makes the KEK — and all
+  data — permanently unrecoverable; store and back up shares separately.
 - **`aws-kms`** / **`gcp-kms`** / **`azure-kms`** (ADR-041): the KEK is a random key
   **wrapped by a cloud KMS/HSM key**; only the wrapped blob is on disk
   (`wrapped_key_path`), unwrapped via the KMS at startup. The wrapping key never

--- a/internal/cli/encryption/migrate_provider.go
+++ b/internal/cli/encryption/migrate_provider.go
@@ -34,6 +34,8 @@ var (
 	mpToFilePath       string
 	mpToEnvVar         string
 	mpToExecCommand    []string
+	mpToShareFiles     []string
+	mpToShareEnv       []string
 	mpToSaltPath       string
 	mpConfirm          bool
 )
@@ -63,12 +65,14 @@ restart — the printed summary shows the exact block.`,
 func init() {
 	EncryptionCmd.AddCommand(migrateProviderCmd)
 	f := migrateProviderCmd.Flags()
-	f.StringVar(&mpToType, "to-type", "", "target provider: password|file|env|exec|aws-kms|gcp-kms|azure-kms (required)")
+	f.StringVar(&mpToType, "to-type", "", "target provider: password|file|env|exec|shamir|aws-kms|gcp-kms|azure-kms (required)")
 	f.StringVar(&mpToKMSKeyID, "to-kms-key-id", "", "target KMS key id/ARN/resource-name/URL (kms types)")
 	f.StringVar(&mpToWrappedKeyPath, "to-wrapped-key-path", "", "where to store the KMS-wrapped KEK blob (kms types)")
 	f.StringVar(&mpToFilePath, "to-file-path", "", "path to the raw KEK material (file type)")
 	f.StringVar(&mpToEnvVar, "to-env-var", "", "env var holding the raw KEK (env type)")
 	f.StringSliceVar(&mpToExecCommand, "to-exec-command", nil, "resolver argv whose stdout supplies the KEK (exec type), e.g. op,read,op://vault/kek/value")
+	f.StringSliceVar(&mpToShareFiles, "to-shamir-share-files", nil, "paths to >=threshold Shamir share files (shamir type)")
+	f.StringSliceVar(&mpToShareEnv, "to-shamir-share-env", nil, "env var names holding Shamir shares (shamir type)")
 	f.StringVar(&mpToSaltPath, "to-salt-path", "", "salt path for the target password provider (default: current salt_path)")
 	f.BoolVar(&mpConfirm, "confirm", false, "required acknowledgement before re-wrapping the DEK")
 }
@@ -82,6 +86,8 @@ type migrateOpts struct {
 	toFilePath       string
 	toEnvVar         string
 	toExecCommand    []string
+	toShareFiles     []string
+	toShareEnv       []string
 	toSaltPath       string
 }
 
@@ -97,6 +103,8 @@ func runMigrateProvider(cmd *cobra.Command, args []string) error {
 		toFilePath:       mpToFilePath,
 		toEnvVar:         mpToEnvVar,
 		toExecCommand:    mpToExecCommand,
+		toShareFiles:     mpToShareFiles,
+		toShareEnv:       mpToShareEnv,
 		toSaltPath:       mpToSaltPath,
 	}
 	return migrateProviderWithConfig(cfg, opts, mpConfirm)
@@ -129,6 +137,12 @@ func targetEncryptionConfig(cur *config.EncryptionConfig, opts migrateOpts) (con
 			return tgt, fmt.Errorf("--to-exec-command is required for --to-type exec")
 		}
 		kp.ExecCommand = opts.toExecCommand
+	case "shamir":
+		if len(opts.toShareFiles)+len(opts.toShareEnv) < 2 {
+			return tgt, fmt.Errorf("--to-type shamir requires at least 2 shares via --to-shamir-share-files/--to-shamir-share-env (the threshold)")
+		}
+		kp.ShamirShareFiles = opts.toShareFiles
+		kp.ShamirShareEnv = opts.toShareEnv
 	case "aws-kms", "gcp-kms", "azure-kms":
 		if opts.toKMSKeyID == "" {
 			return tgt, fmt.Errorf("--to-kms-key-id is required for --to-type %s", opts.toType)
@@ -142,7 +156,7 @@ func targetEncryptionConfig(cur *config.EncryptionConfig, opts migrateOpts) (con
 		kp.KMSKeyID = opts.toKMSKeyID
 		kp.WrappedKeyPath = opts.toWrappedKeyPath
 	default:
-		return tgt, fmt.Errorf("unknown --to-type %q (supported: password, file, env, exec, aws-kms, gcp-kms, azure-kms)", opts.toType)
+		return tgt, fmt.Errorf("unknown --to-type %q (supported: password, file, env, exec, shamir, aws-kms, gcp-kms, azure-kms)", opts.toType)
 	}
 	tgt.KeyProvider = kp
 	return tgt, nil
@@ -175,7 +189,7 @@ func migrateProviderWithConfig(cfg *config.Config, opts migrateOpts, confirm boo
 		return fmt.Errorf("KEK-provider migration must run on the server host. Current storage type is 'remote' — connect to the server and run this command there")
 	}
 	if opts.toType == "" {
-		return fmt.Errorf("--to-type is required (password|file|env|exec|aws-kms|gcp-kms|azure-kms)")
+		return fmt.Errorf("--to-type is required (password|file|env|exec|shamir|aws-kms|gcp-kms|azure-kms)")
 	}
 	tgtEnc, err := targetEncryptionConfig(enc, opts)
 	if err != nil {

--- a/internal/cli/encryption/migrate_provider_test.go
+++ b/internal/cli/encryption/migrate_provider_test.go
@@ -173,6 +173,23 @@ func TestTargetEncryptionConfig(t *testing.T) {
 		}
 	})
 
+	t.Run("shamir requires at least 2 shares", func(t *testing.T) {
+		_, err := targetEncryptionConfig(cur, migrateOpts{toType: "shamir", toShareFiles: []string{"only-one"}})
+		if err == nil || !strings.Contains(err.Error(), "at least 2 shares") {
+			t.Fatalf("expected shamir threshold requirement, got: %v", err)
+		}
+	})
+
+	t.Run("shamir carries the share sources", func(t *testing.T) {
+		tgt, err := targetEncryptionConfig(cur, migrateOpts{toType: "shamir", toShareFiles: []string{"a", "b"}, toShareEnv: []string{"C"}})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if tgt.KeyProvider.Type != "shamir" || len(tgt.KeyProvider.ShamirShareFiles) != 2 || len(tgt.KeyProvider.ShamirShareEnv) != 1 {
+			t.Fatalf("expected shamir provider with 2 files + 1 env, got %+v", tgt.KeyProvider)
+		}
+	})
+
 	t.Run("password overrides salt path", func(t *testing.T) {
 		tgt, err := targetEncryptionConfig(cur, migrateOpts{toType: "password", toSaltPath: "keys/new.salt"})
 		if err != nil {

--- a/internal/cli/encryption/shamir_split.go
+++ b/internal/cli/encryption/shamir_split.go
@@ -56,7 +56,7 @@ unrecoverable. Store shares separately and back them up.`,
 		if _, err := cryptorand.Read(kek); err != nil {
 			return fmt.Errorf("generate KEK: %w", err)
 		}
-		shares, err := crypto.Split(kek, ssShares, ssThreshold)
+		shares, err := crypto.SplitKEK(kek, ssShares, ssThreshold)
 		if err != nil {
 			return err
 		}

--- a/internal/cli/encryption/shamir_split.go
+++ b/internal/cli/encryption/shamir_split.go
@@ -1,0 +1,91 @@
+// shamir_split.go — `keyorix encryption shamir-split`.
+//
+// Generates a fresh random 32-byte KEK and splits it into N Shamir shares with a
+// K-of-N threshold (ADR-038), then prints/writes the shares. The KEK itself is
+// NEVER printed or stored — it only ever exists reconstructed in memory at startup
+// when at least K custodians supply their shares. Distribute one share per
+// custodian, then point key_provider.type: shamir at >=K of them (or migrate an
+// existing install with `migrate-provider --to-type shamir`).
+package encryption
+
+import (
+	cryptorand "crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/keyorixhq/keyorix/internal/crypto"
+	"github.com/spf13/cobra"
+)
+
+var (
+	ssShares    int
+	ssThreshold int
+	ssOutDir    string
+)
+
+var shamirSplitCmd = &cobra.Command{
+	Use:   "shamir-split",
+	Short: "Generate a new KEK split into K-of-N Shamir shares",
+	Long: `Generate a fresh random 32-byte key-encryption key (KEK) and split it into N
+Shamir shares such that any K of them reconstruct it and any K-1 reveal nothing
+(ADR-038). Use it to put the master key under split custody — no single party holds
+it.
+
+The KEK is NEVER printed or written anywhere; only the shares are emitted. Give one
+share to each custodian. To USE it, set storage.encryption.key_provider.type to
+"shamir" and list at least K share files/env vars — the server reconstructs the KEK
+in memory at startup. For an EXISTING (already-encrypted) install, re-wrap the DEK
+onto these shares with:
+
+    keyorix encryption migrate-provider --to-type shamir \
+        --to-shamir-share-files share-1.hex,share-2.hex,share-3.hex --confirm
+
+WARNING: losing more than N-K shares makes the KEK — and thus all data — permanently
+unrecoverable. Store shares separately and back them up.`,
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		if ssThreshold < 2 {
+			return fmt.Errorf("--threshold must be at least 2")
+		}
+		if ssShares < ssThreshold {
+			return fmt.Errorf("--shares (%d) must be >= --threshold (%d)", ssShares, ssThreshold)
+		}
+		kek := make([]byte, crypto.KEKSize)
+		if _, err := cryptorand.Read(kek); err != nil {
+			return fmt.Errorf("generate KEK: %w", err)
+		}
+		shares, err := crypto.Split(kek, ssShares, ssThreshold)
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("Generated a new 32-byte KEK split into %d shares (threshold %d).\n", ssShares, ssThreshold)
+		fmt.Println("The KEK itself is not stored — keep at least the threshold many shares safe.")
+		fmt.Println()
+		for i, s := range shares {
+			enc := hex.EncodeToString(s)
+			if ssOutDir == "" {
+				fmt.Printf("  share %d: %s\n", i+1, enc)
+				continue
+			}
+			path := filepath.Join(ssOutDir, fmt.Sprintf("share-%d.hex", i+1))
+			if err := os.WriteFile(path, []byte(enc+"\n"), 0600); err != nil {
+				return fmt.Errorf("write %s: %w", path, err)
+			}
+			fmt.Printf("  share %d -> %s\n", i+1, path)
+		}
+		fmt.Println()
+		fmt.Printf("Configure: key_provider.type: shamir with at least %d of the shares.\n", ssThreshold)
+		return nil
+	},
+}
+
+func init() {
+	EncryptionCmd.AddCommand(shamirSplitCmd)
+	f := shamirSplitCmd.Flags()
+	f.IntVar(&ssShares, "shares", 5, "total number of shares to generate (N)")
+	f.IntVar(&ssThreshold, "threshold", 3, "shares required to reconstruct the KEK (K)")
+	f.StringVar(&ssOutDir, "out-dir", "", "write shares to this directory as share-N.hex (default: print to stdout)")
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -282,11 +282,12 @@ type EncryptionConfig struct {
 // KeyProviderConfig selects the KEK source. type: "password" (default) derives the
 // KEK from KEYORIX_MASTER_PASSWORD; "file" reads raw key material from FilePath;
 // "env" reads it from the EnvVar's value (hex or base64); "exec" runs ExecCommand
-// and reads the KEK from its stdout; "aws-kms" / "gcp-kms" / "azure-kms"
+// and reads the KEK from its stdout; "shamir" reconstructs it from K-of-N Shamir
+// shares (ShamirShareFiles / ShamirShareEnv); "aws-kms" / "gcp-kms" / "azure-kms"
 // envelope-wrap the KEK with a cloud KMS/HSM key (ADR-041) and store the wrapped
 // blob at WrappedKeyPath. file/env/exec suit a KEK injected by a sealed/SOPS secret,
-// a CSI driver, or any external secret store; the KMS providers keep the wrapping
-// key in the cloud HSM.
+// a CSI driver, or any external secret store; shamir splits it across custodians;
+// the KMS providers keep the wrapping key in the cloud HSM.
 type KeyProviderConfig struct {
 	Type     string `yaml:"type"`
 	FilePath string `yaml:"file_path"`
@@ -306,6 +307,13 @@ type KeyProviderConfig struct {
 	// deployment fetch the KEK from any external secret store (e.g.
 	// ["op","read","op://vault/kek/value"], ["sops","-d","kek.enc"]).
 	ExecCommand []string `yaml:"exec_command"`
+	// ShamirShareFiles / ShamirShareEnv list the K-of-N Shamir shares for type
+	// "shamir": the KEK is reconstructed by combining the shares read from these file
+	// paths and/or env-var values (each a hex/base64 share from
+	// `keyorix encryption shamir-split`). Provide at least the threshold many; no
+	// single share reveals the KEK.
+	ShamirShareFiles []string `yaml:"shamir_share_files"`
+	ShamirShareEnv   []string `yaml:"shamir_share_env"`
 }
 
 type SecretsConfig struct {

--- a/internal/crypto/shamir.go
+++ b/internal/crypto/shamir.go
@@ -1,0 +1,163 @@
+// shamir.go — Shamir's Secret Sharing over GF(2^8) (Rijndael field, reducing
+// polynomial 0x11b). Split a secret into N shares such that any K reconstruct it
+// and any K-1 reveal nothing. Keyorix uses it to split the 32-byte KEK across
+// custodians (ADR-038): no single party holds the key, and K-of-N must combine
+// their shares to unseal — separation of duties for the master key.
+//
+// Dependency-free and byte-wise: each secret byte is the constant term of an
+// independent degree-(K-1) polynomial; a share is the polynomial evaluations at a
+// distinct non-zero x plus that x as the final byte. Reconstruction is Lagrange
+// interpolation at x=0.
+package crypto
+
+import (
+	"crypto/rand"
+	"fmt"
+)
+
+// gfMul multiplies two GF(2^8) elements (Russian-peasant, reducing by 0x11b).
+func gfMul(a, b byte) byte {
+	var p byte
+	for i := 0; i < 8; i++ {
+		if b&1 != 0 {
+			p ^= a
+		}
+		hi := a & 0x80
+		a <<= 1
+		if hi != 0 {
+			a ^= 0x1b // x^8 ≡ x^4+x^3+x+1 (the 0x11b reduction, low byte)
+		}
+		b >>= 1
+	}
+	return p
+}
+
+// gfPow raises a to the e-th power in GF(2^8) (square-and-multiply).
+func gfPow(a byte, e int) byte {
+	r := byte(1)
+	base := a
+	for e > 0 {
+		if e&1 == 1 {
+			r = gfMul(r, base)
+		}
+		base = gfMul(base, base)
+		e >>= 1
+	}
+	return r
+}
+
+// gfInv returns the multiplicative inverse of a (a^254, since a^255 = 1 for a != 0).
+// a must be non-zero (callers only invert differences of distinct x-coordinates).
+func gfInv(a byte) byte { return gfPow(a, 254) }
+
+// gfEval evaluates the polynomial with the given coefficients (constant term first)
+// at x, via Horner's method in GF(2^8).
+func gfEval(coeffs []byte, x byte) byte {
+	var r byte
+	for i := len(coeffs) - 1; i >= 0; i-- {
+		r = gfMul(r, x) ^ coeffs[i]
+	}
+	return r
+}
+
+// Split divides secret into parts shares, of which any threshold reconstruct it.
+// 2 <= threshold <= parts <= 255. Each returned share is len(secret)+1 bytes: the
+// secret-byte evaluations followed by the share's distinct x-coordinate.
+func Split(secret []byte, parts, threshold int) ([][]byte, error) {
+	if len(secret) == 0 {
+		return nil, fmt.Errorf("shamir: cannot split an empty secret")
+	}
+	if threshold < 2 {
+		return nil, fmt.Errorf("shamir: threshold must be at least 2, got %d", threshold)
+	}
+	if parts < threshold {
+		return nil, fmt.Errorf("shamir: parts (%d) must be >= threshold (%d)", parts, threshold)
+	}
+	if parts > 255 {
+		return nil, fmt.Errorf("shamir: parts must be <= 255, got %d", parts)
+	}
+
+	shares := make([][]byte, parts)
+	for i := range shares {
+		s := make([]byte, len(secret)+1)
+		s[len(secret)] = byte(i + 1) // distinct non-zero x-coordinate (1..parts)
+		shares[i] = s
+	}
+
+	// Each secret byte is the constant term of an independent random degree-(K-1)
+	// polynomial; evaluate it at every share's x-coordinate.
+	coeffs := make([]byte, threshold)
+	for bi, sb := range secret {
+		coeffs[0] = sb
+		if _, err := rand.Read(coeffs[1:]); err != nil {
+			return nil, fmt.Errorf("shamir: read randomness: %w", err)
+		}
+		for _, s := range shares {
+			s[bi] = gfEval(coeffs, s[len(secret)])
+		}
+	}
+	return shares, nil
+}
+
+// Combine reconstructs the secret from shares (any threshold-many of the original
+// shares). It requires >= 2 shares of equal length with distinct, non-zero
+// x-coordinates. Supplying fewer than the original threshold returns a well-formed
+// but incorrect secret (that is the security property — it reveals nothing), so the
+// caller must validate the result (e.g. that the KEK round-trips).
+func Combine(shares [][]byte) ([]byte, error) {
+	if len(shares) < 2 {
+		return nil, fmt.Errorf("shamir: need at least 2 shares, got %d", len(shares))
+	}
+	shareLen := len(shares[0])
+	if shareLen < 2 {
+		return nil, fmt.Errorf("shamir: shares must be at least 2 bytes")
+	}
+	secretLen := shareLen - 1
+
+	xs := make([]byte, len(shares))
+	seen := make(map[byte]bool, len(shares))
+	for i, s := range shares {
+		if len(s) != shareLen {
+			return nil, fmt.Errorf("shamir: shares have mismatched lengths")
+		}
+		x := s[secretLen]
+		if x == 0 {
+			return nil, fmt.Errorf("shamir: share has invalid zero x-coordinate")
+		}
+		if seen[x] {
+			return nil, fmt.Errorf("shamir: duplicate share x-coordinate %d", x)
+		}
+		seen[x] = true
+		xs[i] = x
+	}
+
+	secret := make([]byte, secretLen)
+	ys := make([]byte, len(shares))
+	for bi := 0; bi < secretLen; bi++ {
+		for i, s := range shares {
+			ys[i] = s[bi]
+		}
+		secret[bi] = interpolateAtZero(xs, ys)
+	}
+	return secret, nil
+}
+
+// interpolateAtZero evaluates the Lagrange interpolation of the points (xs[i],ys[i])
+// at x=0 in GF(2^8). In this field subtraction is XOR and negation is identity, so
+// (0 - x_j) = x_j and (x_i - x_j) = x_i ^ x_j.
+func interpolateAtZero(xs, ys []byte) byte {
+	var result byte
+	for i := range xs {
+		num := byte(1)
+		den := byte(1)
+		for j := range xs {
+			if i == j {
+				continue
+			}
+			num = gfMul(num, xs[j])
+			den = gfMul(den, xs[i]^xs[j])
+		}
+		result ^= gfMul(ys[i], gfMul(num, gfInv(den)))
+	}
+	return result
+}

--- a/internal/crypto/shamir_provider.go
+++ b/internal/crypto/shamir_provider.go
@@ -9,6 +9,53 @@ import (
 	"strings"
 )
 
+// kekShareMagic frames a KEK before splitting so a reconstruction can be checked:
+// it precedes the embedded threshold and the KEK bytes in the split payload. A
+// reconstruction from too-few/wrong shares yields garbage whose first bytes will
+// not equal the magic, so combineKEK rejects it — making sub-threshold unseal
+// fail closed even on a FRESH install (where there is no existing wrapped DEK to
+// fail against). The byte after the magic carries the threshold K so the provider
+// can enforce that at least K shares were actually supplied.
+const kekShareMagic = "KXK1"
+
+// kekFrameLen is the framed-payload length: magic + 1 threshold byte + KEK.
+const kekFrameLen = len(kekShareMagic) + 1 + KEKSize
+
+// SplitKEK frames a 32-byte KEK (magic ‖ threshold ‖ KEK) and Shamir-splits it into
+// parts shares with the given threshold. Reconstructing with combineKEK then both
+// recovers the KEK and verifies enough correct shares were combined.
+func SplitKEK(kek []byte, parts, threshold int) ([][]byte, error) {
+	if len(kek) != KEKSize {
+		return nil, fmt.Errorf("shamir: KEK must be %d bytes, got %d", KEKSize, len(kek))
+	}
+	if threshold < 2 || threshold > 255 {
+		return nil, fmt.Errorf("shamir: threshold must be between 2 and 255, got %d", threshold)
+	}
+	payload := make([]byte, 0, kekFrameLen)
+	payload = append(payload, kekShareMagic...)
+	payload = append(payload, byte(threshold))
+	payload = append(payload, kek...)
+	return Split(payload, parts, threshold)
+}
+
+// combineKEK reconstructs a KEK from shares produced by SplitKEK. It fails closed
+// when the magic does not match (too few or incorrect shares were combined) or
+// when fewer than the embedded threshold shares were supplied.
+func combineKEK(shares [][]byte) ([]byte, error) {
+	payload, err := Combine(shares)
+	if err != nil {
+		return nil, err
+	}
+	if len(payload) != kekFrameLen || string(payload[:len(kekShareMagic)]) != kekShareMagic {
+		return nil, fmt.Errorf("shamir: insufficient or incorrect shares — the reconstructed key failed its integrity check (supply at least the threshold many correct shares)")
+	}
+	threshold := int(payload[len(kekShareMagic)])
+	if len(shares) < threshold {
+		return nil, fmt.Errorf("shamir: %d shares supplied but the split requires %d (threshold)", len(shares), threshold)
+	}
+	return validateKEK(payload[len(kekShareMagic)+1:], "shamir")
+}
+
 // ShamirKeyProvider reconstructs the KEK from K-of-N Shamir shares (ADR-038): no
 // single custodian holds the key. Each configured source — a file path or an
 // environment variable — carries one share (hex or base64 of the raw share bytes,
@@ -60,16 +107,16 @@ func (p *ShamirKeyProvider) KEK() ([]byte, error) {
 	}
 
 	if len(shares) < 2 {
-		return nil, fmt.Errorf("shamir key provider: need at least 2 shares (the configured threshold), got %d", len(shares))
+		return nil, fmt.Errorf("shamir key provider: need at least 2 shares, got %d", len(shares))
 	}
-	kek, err := Combine(shares)
+	// combineKEK enforces the embedded threshold and verifies the framing magic, so
+	// a sub-threshold or wrong set of shares fails closed here — including on a fresh
+	// install, where there is no existing wrapped DEK for a wrong KEK to fail against.
+	kek, err := combineKEK(shares)
 	if err != nil {
 		return nil, fmt.Errorf("shamir key provider: %w", err)
 	}
-	// A wrong/insufficient set of shares yields a wrong-length or simply incorrect
-	// key; the size check catches the length case, and an incorrect 32-byte key
-	// fails closed downstream when it cannot unwrap the DEK.
-	return validateKEK(kek, "shamir")
+	return kek, nil
 }
 
 // decodeShare accepts a Shamir share as raw bytes, hex, or base64 and returns the

--- a/internal/crypto/shamir_provider.go
+++ b/internal/crypto/shamir_provider.go
@@ -1,0 +1,96 @@
+package crypto
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// ShamirKeyProvider reconstructs the KEK from K-of-N Shamir shares (ADR-038): no
+// single custodian holds the key. Each configured source — a file path or an
+// environment variable — carries one share (hex or base64 of the raw share bytes,
+// as emitted by `keyorix encryption shamir-split`). At KEK() time it reads the
+// supplied shares (the operator provides at least the threshold many) and combines
+// them; the result must be exactly KEKSize bytes or the unseal fails closed (too
+// few / wrong shares reconstruct garbage rather than the real key).
+type ShamirKeyProvider struct {
+	shareFiles []string
+	shareEnv   []string
+}
+
+// NewShamirKeyProvider builds a provider from share file paths and/or env var names.
+func NewShamirKeyProvider(shareFiles, shareEnv []string) *ShamirKeyProvider {
+	return &ShamirKeyProvider{shareFiles: shareFiles, shareEnv: shareEnv}
+}
+
+func (p *ShamirKeyProvider) Name() string { return "shamir" }
+
+func (p *ShamirKeyProvider) KEK() ([]byte, error) {
+	var shares [][]byte
+	for _, path := range p.shareFiles {
+		if path == "" {
+			continue
+		}
+		data, err := os.ReadFile(path) // #nosec G304 -- operator-configured trusted share path
+		if err != nil {
+			return nil, fmt.Errorf("shamir key provider: read share %s: %w", path, err)
+		}
+		share, err := decodeShare(bytes.TrimSpace(data))
+		if err != nil {
+			return nil, fmt.Errorf("shamir key provider: share %s: %w", path, err)
+		}
+		shares = append(shares, share)
+	}
+	for _, envVar := range p.shareEnv {
+		if envVar == "" {
+			continue
+		}
+		val := os.Getenv(envVar)
+		if val == "" {
+			return nil, fmt.Errorf("shamir key provider: env var %s is not set or empty", envVar)
+		}
+		share, err := decodeShare([]byte(val))
+		if err != nil {
+			return nil, fmt.Errorf("shamir key provider: env var %s: %w", envVar, err)
+		}
+		shares = append(shares, share)
+	}
+
+	if len(shares) < 2 {
+		return nil, fmt.Errorf("shamir key provider: need at least 2 shares (the configured threshold), got %d", len(shares))
+	}
+	kek, err := Combine(shares)
+	if err != nil {
+		return nil, fmt.Errorf("shamir key provider: %w", err)
+	}
+	// A wrong/insufficient set of shares yields a wrong-length or simply incorrect
+	// key; the size check catches the length case, and an incorrect 32-byte key
+	// fails closed downstream when it cannot unwrap the DEK.
+	return validateKEK(kek, "shamir")
+}
+
+// decodeShare accepts a Shamir share as raw bytes, hex, or base64 and returns the
+// raw share bytes. Shares are KEKSize+1 bytes (a 1-byte x-coordinate), so unlike a
+// KEK they are not a fixed-length match — decode by trying hex then base64, else
+// treat the input as already-raw.
+func decodeShare(material []byte) ([]byte, error) {
+	s := strings.TrimSpace(string(material))
+	if s == "" {
+		return nil, fmt.Errorf("empty share")
+	}
+	if b, err := hex.DecodeString(s); err == nil && len(b) >= 2 {
+		return b, nil
+	}
+	for _, enc := range []*base64.Encoding{base64.StdEncoding, base64.RawStdEncoding, base64.URLEncoding, base64.RawURLEncoding} {
+		if b, err := enc.DecodeString(s); err == nil && len(b) >= 2 {
+			return b, nil
+		}
+	}
+	if len(material) >= 2 {
+		return material, nil
+	}
+	return nil, fmt.Errorf("share must be raw bytes, hex, or base64 (at least 2 bytes)")
+}

--- a/internal/crypto/shamir_provider_test.go
+++ b/internal/crypto/shamir_provider_test.go
@@ -1,0 +1,79 @@
+package crypto
+
+import (
+	"encoding/base64"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestShamirKeyProvider_Name(t *testing.T) {
+	assert.Equal(t, "shamir", NewShamirKeyProvider(nil, nil).Name())
+}
+
+func TestShamirKeyProvider_CombinesSharesFromFilesAndEnv(t *testing.T) {
+	dir := t.TempDir()
+	kek := testKEK() // 32 bytes
+	shares, err := Split(kek, 5, 3)
+	require.NoError(t, err)
+
+	// Two shares as hex files, one as a base64 env var → threshold 3 reached.
+	f1 := filepath.Join(dir, "s1")
+	f2 := filepath.Join(dir, "s2")
+	require.NoError(t, os.WriteFile(f1, []byte(hex.EncodeToString(shares[0])+"\n"), 0600))
+	require.NoError(t, os.WriteFile(f2, []byte(hex.EncodeToString(shares[1])), 0600))
+	t.Setenv("KX_SHARE_3", base64.StdEncoding.EncodeToString(shares[2]))
+
+	got, err := NewShamirKeyProvider([]string{f1, f2}, []string{"KX_SHARE_3"}).KEK()
+	require.NoError(t, err)
+	assert.Equal(t, kek, got)
+}
+
+func TestShamirKeyProvider_TooFewSharesFailsClosed(t *testing.T) {
+	dir := t.TempDir()
+	kek := testKEK()
+	shares, err := Split(kek, 5, 3)
+	require.NoError(t, err)
+	f1 := filepath.Join(dir, "s1")
+	require.NoError(t, os.WriteFile(f1, []byte(hex.EncodeToString(shares[0])), 0600))
+
+	// Only one share configured — below the minimum, rejected outright.
+	_, err = NewShamirKeyProvider([]string{f1}, nil).KEK()
+	require.Error(t, err)
+}
+
+func TestShamirKeyProvider_WrongLengthSecretRejected(t *testing.T) {
+	dir := t.TempDir()
+	// Split a NON-32-byte secret: combining recovers it, but the KEK size check rejects.
+	shares, err := Split([]byte("not-thirty-two-bytes"), 3, 2)
+	require.NoError(t, err)
+	f1 := filepath.Join(dir, "s1")
+	f2 := filepath.Join(dir, "s2")
+	require.NoError(t, os.WriteFile(f1, []byte(hex.EncodeToString(shares[0])), 0600))
+	require.NoError(t, os.WriteFile(f2, []byte(hex.EncodeToString(shares[1])), 0600))
+
+	_, err = NewShamirKeyProvider([]string{f1, f2}, nil).KEK()
+	require.Error(t, err, "a reconstructed secret that isn't 32 bytes must be rejected")
+}
+
+func TestShamirKeyProvider_Errors(t *testing.T) {
+	t.Run("missing file", func(t *testing.T) {
+		_, err := NewShamirKeyProvider([]string{filepath.Join(t.TempDir(), "nope")}, nil).KEK()
+		require.Error(t, err)
+	})
+	t.Run("unset env", func(t *testing.T) {
+		_, err := NewShamirKeyProvider(nil, []string{"KX_SHARE_DOES_NOT_EXIST"}).KEK()
+		require.Error(t, err)
+	})
+	t.Run("garbage share", func(t *testing.T) {
+		dir := t.TempDir()
+		f := filepath.Join(dir, "g")
+		require.NoError(t, os.WriteFile(f, []byte("!"), 0600))
+		_, err := NewShamirKeyProvider([]string{f}, []string{}).KEK()
+		require.Error(t, err)
+	})
+}

--- a/internal/crypto/shamir_provider_test.go
+++ b/internal/crypto/shamir_provider_test.go
@@ -18,7 +18,7 @@ func TestShamirKeyProvider_Name(t *testing.T) {
 func TestShamirKeyProvider_CombinesSharesFromFilesAndEnv(t *testing.T) {
 	dir := t.TempDir()
 	kek := testKEK() // 32 bytes
-	shares, err := Split(kek, 5, 3)
+	shares, err := SplitKEK(kek, 5, 3)
 	require.NoError(t, err)
 
 	// Two shares as hex files, one as a base64 env var → threshold 3 reached.
@@ -36,7 +36,7 @@ func TestShamirKeyProvider_CombinesSharesFromFilesAndEnv(t *testing.T) {
 func TestShamirKeyProvider_TooFewSharesFailsClosed(t *testing.T) {
 	dir := t.TempDir()
 	kek := testKEK()
-	shares, err := Split(kek, 5, 3)
+	shares, err := SplitKEK(kek, 5, 3)
 	require.NoError(t, err)
 	f1 := filepath.Join(dir, "s1")
 	require.NoError(t, os.WriteFile(f1, []byte(hex.EncodeToString(shares[0])), 0600))
@@ -46,10 +46,30 @@ func TestShamirKeyProvider_TooFewSharesFailsClosed(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestShamirKeyProvider_WrongLengthSecretRejected(t *testing.T) {
+// TestShamirKeyProvider_SubThresholdRejected is the core fail-closed guarantee:
+// supplying fewer than the split's threshold (but >= 2) must be REJECTED rather
+// than silently reconstructing a wrong KEK — even though Combine itself would
+// happily return a 32-byte value. The framing magic + embedded threshold catch it.
+func TestShamirKeyProvider_SubThresholdRejected(t *testing.T) {
 	dir := t.TempDir()
-	// Split a NON-32-byte secret: combining recovers it, but the KEK size check rejects.
-	shares, err := Split([]byte("not-thirty-two-bytes"), 3, 2)
+	kek := testKEK()
+	shares, err := SplitKEK(kek, 5, 3) // threshold 3
+	require.NoError(t, err)
+	// Supply only 2 of the 3 required shares.
+	f1 := filepath.Join(dir, "s1")
+	f2 := filepath.Join(dir, "s2")
+	require.NoError(t, os.WriteFile(f1, []byte(hex.EncodeToString(shares[0])), 0600))
+	require.NoError(t, os.WriteFile(f2, []byte(hex.EncodeToString(shares[1])), 0600))
+
+	_, err = NewShamirKeyProvider([]string{f1, f2}, nil).KEK()
+	require.Error(t, err, "below-threshold shares must fail closed, not reconstruct a wrong KEK")
+}
+
+func TestShamirKeyProvider_UnframedSharesRejected(t *testing.T) {
+	dir := t.TempDir()
+	// Raw Split (not SplitKEK) produces shares without the KEK framing — the provider
+	// must reject them rather than accept an unverified reconstruction.
+	shares, err := Split(testKEK(), 3, 2)
 	require.NoError(t, err)
 	f1 := filepath.Join(dir, "s1")
 	f2 := filepath.Join(dir, "s2")
@@ -57,7 +77,7 @@ func TestShamirKeyProvider_WrongLengthSecretRejected(t *testing.T) {
 	require.NoError(t, os.WriteFile(f2, []byte(hex.EncodeToString(shares[1])), 0600))
 
 	_, err = NewShamirKeyProvider([]string{f1, f2}, nil).KEK()
-	require.Error(t, err, "a reconstructed secret that isn't 32 bytes must be rejected")
+	require.Error(t, err, "shares without the KEK framing must be rejected")
 }
 
 func TestShamirKeyProvider_Errors(t *testing.T) {

--- a/internal/crypto/shamir_test.go
+++ b/internal/crypto/shamir_test.go
@@ -1,0 +1,95 @@
+package crypto
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestShamir_RoundTrip_AnyThresholdSubset(t *testing.T) {
+	secret := testKEK() // 32 bytes
+	shares, err := Split(secret, 5, 3)
+	require.NoError(t, err)
+	require.Len(t, shares, 5)
+	for _, s := range shares {
+		require.Len(t, s, len(secret)+1)
+	}
+
+	// Any 3 of the 5 shares reconstruct the secret; exhaustively check several subsets.
+	subsets := [][]int{{0, 1, 2}, {0, 2, 4}, {1, 3, 4}, {2, 3, 4}, {0, 1, 4}}
+	for _, idx := range subsets {
+		sub := [][]byte{shares[idx[0]], shares[idx[1]], shares[idx[2]]}
+		got, err := Combine(sub)
+		require.NoError(t, err)
+		assert.True(t, bytes.Equal(secret, got), "subset %v must reconstruct", idx)
+	}
+
+	// More than threshold also works.
+	got, err := Combine(shares)
+	require.NoError(t, err)
+	assert.Equal(t, secret, got)
+}
+
+func TestShamir_BelowThresholdDoesNotReveal(t *testing.T) {
+	secret := testKEK()
+	shares, err := Split(secret, 5, 3)
+	require.NoError(t, err)
+
+	// 2 shares (< threshold 3) combine to a well-formed but WRONG secret — it must
+	// not equal the real one (that is the secrecy guarantee). Combine still succeeds
+	// structurally, so callers must validate (e.g. KEK round-trips the DEK).
+	wrong, err := Combine([][]byte{shares[0], shares[1]})
+	require.NoError(t, err)
+	assert.False(t, bytes.Equal(secret, wrong), "2 of 3 shares must not reconstruct the secret")
+}
+
+func TestShamir_2of2(t *testing.T) {
+	secret := []byte("a-shorter-secret")
+	shares, err := Split(secret, 2, 2)
+	require.NoError(t, err)
+	got, err := Combine(shares)
+	require.NoError(t, err)
+	assert.Equal(t, secret, got)
+}
+
+func TestShamir_SplitValidation(t *testing.T) {
+	_, err := Split(nil, 5, 3)
+	require.Error(t, err)
+	_, err = Split([]byte("x"), 5, 1) // threshold < 2
+	require.Error(t, err)
+	_, err = Split([]byte("x"), 2, 3) // parts < threshold
+	require.Error(t, err)
+	_, err = Split([]byte("x"), 256, 2) // parts > 255
+	require.Error(t, err)
+}
+
+func TestShamir_CombineValidation(t *testing.T) {
+	secret := testKEK()
+	shares, err := Split(secret, 3, 2)
+	require.NoError(t, err)
+
+	t.Run("too few shares", func(t *testing.T) {
+		_, err := Combine([][]byte{shares[0]})
+		require.Error(t, err)
+	})
+	t.Run("mismatched lengths", func(t *testing.T) {
+		_, err := Combine([][]byte{shares[0], append([]byte{0x1}, shares[1]...)})
+		require.Error(t, err)
+	})
+	t.Run("duplicate x-coordinate", func(t *testing.T) {
+		_, err := Combine([][]byte{shares[0], shares[0]})
+		require.Error(t, err)
+	})
+}
+
+// TestGF_FieldAxioms spot-checks the GF(2^8) arithmetic the split/combine relies on.
+func TestGF_FieldAxioms(t *testing.T) {
+	// Multiplicative identity and inverse for every non-zero element.
+	for a := 1; a < 256; a++ {
+		x := byte(a)
+		assert.Equal(t, x, gfMul(x, 1), "1 is the identity")
+		assert.Equal(t, byte(1), gfMul(x, gfInv(x)), "a * a^-1 == 1 for a=%d", a)
+	}
+}

--- a/internal/encryption/keyprovider_compat_test.go
+++ b/internal/encryption/keyprovider_compat_test.go
@@ -93,7 +93,7 @@ func TestKeyProvider_EnvRoundTrip(t *testing.T) {
 func TestKeyProvider_ShamirRoundTrip(t *testing.T) {
 	dir := t.TempDir()
 	kek := bytes.Repeat([]byte{0x3D}, 32)
-	shares, err := crypto.Split(kek, 5, 3)
+	shares, err := crypto.SplitKEK(kek, 5, 3)
 	require.NoError(t, err)
 	var files []string
 	for i := 0; i < 3; i++ { // write the threshold-many shares

--- a/internal/encryption/keyprovider_compat_test.go
+++ b/internal/encryption/keyprovider_compat_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
+	"encoding/hex"
 	"os"
 	"path/filepath"
 	"testing"
@@ -84,6 +85,23 @@ func TestKeyProvider_EnvRoundTrip(t *testing.T) {
 	raw := bytes.Repeat([]byte{0x5C}, 32)
 	t.Setenv("KX_COMPAT_KEK", base64.StdEncoding.EncodeToString(raw))
 	roundTrip(t, dir, func() crypto.KeyProvider { return crypto.NewEnvKeyProvider("KX_COMPAT_KEK") })
+}
+
+// TestKeyProvider_ShamirRoundTrip proves a Shamir-reconstructed KEK wraps/unwraps
+// the DEK end-to-end: a KEK is split into shares written to disk, and a KeyManager
+// using K of those shares unwraps the identical DEK across restarts.
+func TestKeyProvider_ShamirRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	kek := bytes.Repeat([]byte{0x3D}, 32)
+	shares, err := crypto.Split(kek, 5, 3)
+	require.NoError(t, err)
+	var files []string
+	for i := 0; i < 3; i++ { // write the threshold-many shares
+		p := filepath.Join(dir, "share-"+string(rune('a'+i)))
+		require.NoError(t, os.WriteFile(p, []byte(hex.EncodeToString(shares[i])), 0600))
+		files = append(files, p)
+	}
+	roundTrip(t, dir, func() crypto.KeyProvider { return crypto.NewShamirKeyProvider(files, nil) })
 }
 
 // TestKeyProvider_KMSRoundTrip proves a KMS-envelope KEK wraps/unwraps the DEK

--- a/internal/encryption/service.go
+++ b/internal/encryption/service.go
@@ -84,8 +84,9 @@ func (s *Service) buildKeyProvider(passphrase string) (crypto.KeyProvider, error
 // NewKeyProviderFromConfig builds the KEK source described by an EncryptionConfig
 // (ADR-038/ADR-041). The default and the absent/zero value is the passphrase
 // provider, byte-identical to the historical derivation; file/env supply
-// externally-managed raw key material and exec fetches it from a resolver command;
-// the *-kms providers envelope-wrap the KEK with a cloud KMS key. baseDir resolves
+// externally-managed raw key material, exec fetches it from a resolver command,
+// and shamir reconstructs it from K-of-N shares; the *-kms providers envelope-wrap
+// the KEK with a cloud KMS key. baseDir resolves
 // provider-relative paths (salt /
 // wrapped_key_path). Exported so the KEK-provider migration tool can build a
 // *target* provider from a different config than the running service's.
@@ -100,6 +101,8 @@ func NewKeyProviderFromConfig(cfg *config.EncryptionConfig, baseDir, passphrase 
 		return crypto.NewEnvKeyProvider(kp.EnvVar), nil
 	case "exec":
 		return crypto.NewExecKeyProvider(kp.ExecCommand), nil
+	case "shamir":
+		return crypto.NewShamirKeyProvider(kp.ShamirShareFiles, kp.ShamirShareEnv), nil
 	case "aws-kms":
 		kmsClient, err := awskms.New(context.Background(), kp.KMSKeyID)
 		if err != nil {
@@ -119,7 +122,7 @@ func NewKeyProviderFromConfig(cfg *config.EncryptionConfig, baseDir, passphrase 
 		}
 		return crypto.NewKMSKeyProvider(kmsClient, "azure-kms", baseDir, kp.WrappedKeyPath), nil
 	default:
-		return nil, fmt.Errorf("unknown encryption key_provider type %q (supported: password, file, env, exec, aws-kms, gcp-kms, azure-kms)", kp.Type)
+		return nil, fmt.Errorf("unknown encryption key_provider type %q (supported: password, file, env, exec, shamir, aws-kms, gcp-kms, azure-kms)", kp.Type)
 	}
 }
 


### PR DESCRIPTION
## Summary

A tier-2 KEK source (ADR-038) that puts the master key under **split custody**: the 32-byte KEK is divided into **N Shamir shares** with a **K-of-N** threshold, so no single custodian holds it and at least K must combine their shares to unseal — separation of duties for the master key (ISO 27001 / NIS2).

## How it works

- **crypto** — dependency-free Shamir's Secret Sharing over GF(2⁸) (Rijndael field, 0x11b): byte-wise random polynomials, evaluation, Lagrange interpolation at x=0. `Split`/`Combine`.
- **crypto** — `ShamirKeyProvider` reconstructs the KEK by combining shares read from configured files and/or env vars (hex/base64). **Fails closed** when the result isn't exactly 32 bytes — too few or wrong shares reconstruct garbage, never the real key.
- **config** — `key_provider.type: shamir` + `shamir_share_files` / `shamir_share_env`.
- **cli** — `keyorix encryption shamir-split --shares N --threshold K` generates a fresh KEK and emits only the shares (the KEK is never printed or stored); `migrate-provider --to-type shamir --to-shamir-share-files …` re-wraps an existing DEK onto them.

## Security

- The KEK exists reconstructed only in memory at startup; `shamir-split` never writes or prints it. K-1 shares reveal nothing (the secrecy property — tested).
- Crypto is hand-rolled but standard and thoroughly tested: GF field axioms (multiplicative inverse for every non-zero element), arbitrary K-subset reconstruction, below-threshold non-disclosure, fail-closed on wrong/short shares, and an end-to-end DEK wrap/unwrap under a reconstructed KEK.
- Share file/env paths are trusted deployment config (like `file_path`/`env_var`).

## Tests

GF axioms, split/combine round-trips (multiple subsets), below-threshold, validation, provider file+env combine, fail-closed cases, end-to-end encryption-service round-trip, migrate-provider shamir target validation. gofmt/golangci-lint/gosec clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)