### PR TITLE
feat(mfa): regenerate recovery codes + remaining-count surface

### DIFF
--- a/internal/core/mfa.go
+++ b/internal/core/mfa.go
@@ -128,6 +128,64 @@ func (c *KeyorixCore) DisableMFA(ctx context.Context, userID uint, codeOrPasswor
 	return nil
 }
 
+// RegenerateMFARecoveryCodes issues a fresh set of recovery codes after verifying a
+// current TOTP code OR the account password (same re-auth as DisableMFA), replacing
+// any existing codes (used and unused). The plaintext codes are returned once and
+// never stored. Invalidating the old set means a regenerate also revokes leaked or
+// previously-recorded codes.
+func (c *KeyorixCore) RegenerateMFARecoveryCodes(ctx context.Context, userID uint, codeOrPassword string) ([]string, error) {
+	user, err := c.storage.GetUser(ctx, userID)
+	if err != nil {
+		return nil, fmt.Errorf("user not found")
+	}
+	if !user.MFAEnabled {
+		return nil, fmt.Errorf("MFA is not enabled")
+	}
+	ok := false
+	if secret, err := c.loadTOTPSecret(ctx, userID); err == nil && c.validateTOTP(secret, codeOrPassword) {
+		ok = true
+	}
+	if !ok && bcrypt.CompareHashAndPassword([]byte(user.PasswordHash), []byte(codeOrPassword)) == nil {
+		ok = true
+	}
+	if !ok {
+		c.auditMFAFailed(ctx, userID, "regenerate_recovery_codes")
+		return nil, fmt.Errorf("invalid code or password")
+	}
+	codes, hashes, err := generateRecoveryCodes(mfaRecoveryCodeCount)
+	if err != nil {
+		return nil, err
+	}
+	if err := c.storage.DeleteMFARecoveryCodes(ctx, userID); err != nil {
+		return nil, fmt.Errorf("failed to clear old recovery codes: %w", err)
+	}
+	if err := c.storage.CreateMFARecoveryCodes(ctx, userID, hashes); err != nil {
+		return nil, fmt.Errorf("failed to store recovery codes: %w", err)
+	}
+	uid := userID
+	c.writeAuditEventFull(ctx, "mfa.recovery_codes_regenerated", &uid, nil, nil, "",
+		fmt.Sprintf("user %s regenerated MFA recovery codes", user.Username))
+	return codes, nil
+}
+
+// MFARecoveryCodesRemaining reports how many unused recovery codes the user has
+// (and the original total), so the account UI can surface a "running low" warning.
+// Returns (0, 0) when MFA is not enabled.
+func (c *KeyorixCore) MFARecoveryCodesRemaining(ctx context.Context, userID uint) (remaining, total int, err error) {
+	user, err := c.storage.GetUser(ctx, userID)
+	if err != nil {
+		return 0, 0, fmt.Errorf("user not found")
+	}
+	if !user.MFAEnabled {
+		return 0, 0, nil
+	}
+	remaining, err = c.storage.CountUnusedMFARecoveryCodes(ctx, userID)
+	if err != nil {
+		return 0, 0, err
+	}
+	return remaining, mfaRecoveryCodeCount, nil
+}
+
 // CreateMFAChallenge issues a short-lived single-use challenge for an MFA-enabled
 // user that has passed the password step. Only the token hash is stored.
 func (c *KeyorixCore) CreateMFAChallenge(ctx context.Context, userID uint) (string, error) {

--- a/internal/core/mfa_test.go
+++ b/internal/core/mfa_test.go
@@ -129,3 +129,88 @@ func TestMFA_ActivateRejectsWrongCode(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, u.MFAEnabled, "a failed activation must not enable MFA")
 }
+
+// activateMFAForTest enrols + activates MFA for user 1 and returns the base32
+// secret (for generating TOTP codes) and the initial recovery codes.
+func activateMFAForTest(t *testing.T, c *KeyorixCore, fixed time.Time) (secret string, codes []string) {
+	t.Helper()
+	ctx := context.Background()
+	_, secret, err := c.BeginMFAEnrollment(ctx, 1)
+	require.NoError(t, err)
+	code, err := totp.GenerateCode(secret, fixed)
+	require.NoError(t, err)
+	codes, err = c.ActivateMFA(ctx, 1, code)
+	require.NoError(t, err)
+	return secret, codes
+}
+
+func TestMFA_RecoveryCodesRemaining(t *testing.T) {
+	c, _, fixed := newMFATestCore(t)
+	ctx := context.Background()
+
+	// Not enabled yet → (0, 0).
+	rem, total, err := c.MFARecoveryCodesRemaining(ctx, 1)
+	require.NoError(t, err)
+	assert.Equal(t, 0, rem)
+	assert.Equal(t, 0, total)
+
+	_, codes := activateMFAForTest(t, c, fixed)
+	rem, total, err = c.MFARecoveryCodesRemaining(ctx, 1)
+	require.NoError(t, err)
+	assert.Equal(t, 10, rem)
+	assert.Equal(t, 10, total)
+
+	// Consume one recovery code via a login → remaining drops to 9.
+	ch, err := c.CreateMFAChallenge(ctx, 1)
+	require.NoError(t, err)
+	_, _, err = c.VerifyMFALogin(ctx, ch, codes[0], "ua", "1.2.3.4")
+	require.NoError(t, err)
+	rem, _, err = c.MFARecoveryCodesRemaining(ctx, 1)
+	require.NoError(t, err)
+	assert.Equal(t, 9, rem, "one recovery code consumed")
+}
+
+func TestMFA_RegenerateRecoveryCodes(t *testing.T) {
+	c, _, fixed := newMFATestCore(t)
+	ctx := context.Background()
+	secret, original := activateMFAForTest(t, c, fixed)
+
+	// Regenerate with the password → a fresh distinct set; the old codes stop working.
+	fresh, err := c.RegenerateMFARecoveryCodes(ctx, 1, mfaTestPassword)
+	require.NoError(t, err)
+	require.Len(t, fresh, 10)
+	assert.NotEqual(t, original, fresh, "regenerated codes differ from the originals")
+
+	// An OLD code no longer authenticates (the set was replaced).
+	ch, err := c.CreateMFAChallenge(ctx, 1)
+	require.NoError(t, err)
+	_, _, err = c.VerifyMFALogin(ctx, ch, original[0], "ua", "1.2.3.4")
+	require.Error(t, err, "old recovery codes are revoked on regenerate")
+
+	// A NEW code works.
+	ch2, err := c.CreateMFAChallenge(ctx, 1)
+	require.NoError(t, err)
+	_, _, err = c.VerifyMFALogin(ctx, ch2, fresh[1], "ua", "1.2.3.4")
+	require.NoError(t, err)
+
+	// Regenerate with a current TOTP code also works (re-auth via code path).
+	totpCode, err := totp.GenerateCode(secret, fixed)
+	require.NoError(t, err)
+	_, err = c.RegenerateMFARecoveryCodes(ctx, 1, totpCode)
+	require.NoError(t, err)
+}
+
+func TestMFA_RegenerateRequiresReauth(t *testing.T) {
+	c, _, fixed := newMFATestCore(t)
+	ctx := context.Background()
+	activateMFAForTest(t, c, fixed)
+
+	_, err := c.RegenerateMFARecoveryCodes(ctx, 1, "wrong-password")
+	require.Error(t, err, "regenerate must reject a bad code/password")
+}
+
+func TestMFA_RegenerateRequiresMFAEnabled(t *testing.T) {
+	c, _, _ := newMFATestCore(t)
+	_, err := c.RegenerateMFARecoveryCodes(context.Background(), 1, mfaTestPassword)
+	require.Error(t, err, "regenerate requires MFA to be enabled")
+}

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -1553,6 +1553,10 @@ func (m *MockStorage) CreateMFARecoveryCodes(_ context.Context, _ uint, _ []stri
 func (m *MockStorage) ConsumeMFARecoveryCode(_ context.Context, _ uint, _ string, _ time.Time) (bool, error) {
 	return false, nil
 }
+func (m *MockStorage) CountUnusedMFARecoveryCodes(_ context.Context, _ uint) (int, error) {
+	return 0, nil
+}
+func (m *MockStorage) DeleteMFARecoveryCodes(_ context.Context, _ uint) error             { return nil }
 func (m *MockStorage) CreateMFAChallenge(_ context.Context, _ *models.MFAChallenge) error { return nil }
 func (m *MockStorage) ConsumeMFAChallenge(_ context.Context, _ string, _ time.Time) (*models.MFAChallenge, error) {
 	return nil, nil

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -399,6 +399,10 @@ type Storage interface {
 	CreateMFARecoveryCodes(ctx context.Context, userID uint, codeHashes []string) error
 	// ConsumeMFARecoveryCode marks a matching unused code used and reports whether one was consumed.
 	ConsumeMFARecoveryCode(ctx context.Context, userID uint, codeHash string, now time.Time) (bool, error)
+	// CountUnusedMFARecoveryCodes returns how many of the user's recovery codes remain unused.
+	CountUnusedMFARecoveryCodes(ctx context.Context, userID uint) (int, error)
+	// DeleteMFARecoveryCodes removes all of the user's recovery codes (the regenerate flow replaces them).
+	DeleteMFARecoveryCodes(ctx context.Context, userID uint) error
 	// Dynamic secrets (ADR-035).
 	CreateDynamicSecretConfig(ctx context.Context, c *models.DynamicSecretConfig) (*models.DynamicSecretConfig, error)
 	GetDynamicSecretConfig(ctx context.Context, id uint) (*models.DynamicSecretConfig, error)

--- a/internal/storage/store/local_mfa.go
+++ b/internal/storage/store/local_mfa.go
@@ -59,6 +59,21 @@ func (ls *LocalStorage) CreateMFARecoveryCodes(ctx context.Context, userID uint,
 	return ls.db.WithContext(ctx).Create(&rows).Error
 }
 
+// CountUnusedMFARecoveryCodes returns how many of the user's recovery codes remain
+// unused (so the UI can warn when the user is running low).
+func (ls *LocalStorage) CountUnusedMFARecoveryCodes(ctx context.Context, userID uint) (int, error) {
+	var n int64
+	err := ls.db.WithContext(ctx).Model(&models.MFARecoveryCode{}).
+		Where("user_id = ? AND used_at IS NULL", userID).Count(&n).Error
+	return int(n), err
+}
+
+// DeleteMFARecoveryCodes removes ALL of the user's recovery codes (used + unused)
+// without touching the TOTP secret — the regenerate flow replaces them wholesale.
+func (ls *LocalStorage) DeleteMFARecoveryCodes(ctx context.Context, userID uint) error {
+	return ls.db.WithContext(ctx).Where("user_id = ?", userID).Delete(&models.MFARecoveryCode{}).Error
+}
+
 // ConsumeMFARecoveryCode marks a matching unused code used; returns true if one
 // was consumed. The conditional UPDATE is atomic (no read-then-write race).
 func (ls *LocalStorage) ConsumeMFARecoveryCode(ctx context.Context, userID uint, codeHash string, now time.Time) (bool, error) {

--- a/internal/storage/store/remote_mfa.go
+++ b/internal/storage/store/remote_mfa.go
@@ -37,6 +37,14 @@ func (rs *RemoteStorage) ConsumeMFARecoveryCode(_ context.Context, _ uint, _ str
 	return false, remoteUnsupported("ConsumeMFARecoveryCode")
 }
 
+func (rs *RemoteStorage) CountUnusedMFARecoveryCodes(_ context.Context, _ uint) (int, error) {
+	return 0, remoteUnsupported("CountUnusedMFARecoveryCodes")
+}
+
+func (rs *RemoteStorage) DeleteMFARecoveryCodes(_ context.Context, _ uint) error {
+	return remoteUnsupported("DeleteMFARecoveryCodes")
+}
+
 func (rs *RemoteStorage) CreateMFAChallenge(_ context.Context, _ *models.MFAChallenge) error {
 	return remoteUnsupported("CreateMFAChallenge")
 }

--- a/server/http/handlers/mfa.go
+++ b/server/http/handlers/mfa.go
@@ -81,6 +81,56 @@ func (h *AuthHandler) DisableMFA(w http.ResponseWriter, r *http.Request) {
 	sendSuccess(w, map[string]interface{}{"mfa_enabled": false}, "MFA disabled")
 }
 
+// RegenerateRecoveryCodes issues a fresh set of recovery codes (replacing the old
+// ones) after verifying a current TOTP code or the password. The codes are returned
+// once and never shown again.
+func (h *AuthHandler) RegenerateRecoveryCodes(w http.ResponseWriter, r *http.Request) {
+	userCtx := middleware.GetUserFromContext(r.Context())
+	if userCtx == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	var body struct {
+		Code     string `json:"code"`
+		Password string `json:"password"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		sendError(w, "BadRequest", "Invalid request body", http.StatusBadRequest, nil)
+		return
+	}
+	proof := body.Code
+	if proof == "" {
+		proof = body.Password
+	}
+	codes, err := h.coreService.RegenerateMFARecoveryCodes(r.Context(), userCtx.UserID, proof)
+	if err != nil {
+		sendError(w, "Error", err.Error(), http.StatusBadRequest, nil)
+		return
+	}
+	sendSuccess(w, map[string]interface{}{
+		"recovery_codes": codes,
+	}, "New recovery codes generated. Save them now — they replace your old codes and will not be shown again.")
+}
+
+// RecoveryCodesStatus reports how many unused recovery codes remain (and the total),
+// so the account UI can prompt a regenerate when the user is running low.
+func (h *AuthHandler) RecoveryCodesStatus(w http.ResponseWriter, r *http.Request) {
+	userCtx := middleware.GetUserFromContext(r.Context())
+	if userCtx == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	remaining, total, err := h.coreService.MFARecoveryCodesRemaining(r.Context(), userCtx.UserID)
+	if err != nil {
+		sendError(w, "Error", err.Error(), http.StatusBadRequest, nil)
+		return
+	}
+	sendSuccess(w, map[string]interface{}{
+		"remaining": remaining,
+		"total":     total,
+	}, "")
+}
+
 // VerifyMFA completes the two-step login: it consumes the challenge from
 // /auth/login, verifies the TOTP (or recovery) code, and returns a session.
 func (h *AuthHandler) VerifyMFA(w http.ResponseWriter, r *http.Request) {

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -189,6 +189,8 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		r.Post("/auth/mfa/enroll", authHandler.EnrollMFA)
 		r.Post("/auth/mfa/activate", authHandler.ActivateMFA)
 		r.Post("/auth/mfa/disable", authHandler.DisableMFA)
+		r.Get("/auth/mfa/recovery-codes", authHandler.RecoveryCodesStatus)
+		r.Post("/auth/mfa/recovery-codes/regenerate", authHandler.RegenerateRecoveryCodes)
 		// WebAuthn / passkey self-service (acts on the authenticated caller's account).
 		r.Post("/auth/webauthn/register/begin", authHandler.BeginWebAuthnRegistration)
 		r.Post("/auth/webauthn/register/finish", authHandler.FinishWebAuthnRegistration)


### PR DESCRIPTION
## Summary

MFA recovery codes were issued **once** at activation, with no way to see how many remained or to obtain a fresh set after using/losing them — a standard MFA gap. This adds both.

## How it works

- **core** — `RegenerateMFARecoveryCodes(userID, codeOrPassword)` re-authenticates with a current TOTP code **or** the account password (the same proof `DisableMFA` requires), replaces **all** existing codes with a fresh set (so a regenerate also revokes leaked/old codes), and returns the plaintext **once** (never stored); audited `mfa.recovery_codes_regenerated`. `MFARecoveryCodesRemaining(userID)` returns `(unused, total)` for a "running low" warning.
- **storage** — `CountUnusedMFARecoveryCodes` + `DeleteMFARecoveryCodes` (interface + local; remote returns unsupported, like the other MFA self-service methods).
- **http** — `GET /auth/mfa/recovery-codes` (status) and `POST /auth/mfa/recovery-codes/regenerate`, self-service on the authenticated caller's own account.

## Security

- Regenerate requires re-auth (current TOTP code or password); a wrong proof is rejected and audited (`auditMFAFailed`). Requires MFA already enabled.
- New codes are returned once and only their SHA-256 hashes are stored; regenerating **revokes the entire old set** (replaces all rows), so previously-recorded/leaked codes stop working.
- Self-service only — acts on `userCtx.UserID`, no cross-user access; the new POST route is correctly not flagged by `TestEveryMutatingRouteDeniesReadOnly` (self-service `/auth/*`, re-auth-gated rather than RBAC-gated, like `/auth/mfa/disable`).

## Tests

remaining count (0 disabled → 10 after activation → decrements on use), regenerate replaces the set (old codes revoked, new ones work, TOTP-code re-auth path), rejects bad proof, requires MFA enabled. gofmt/golangci-lint/gosec clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)