### PR TITLE
fix(secrets): ownerless (machine-created) secrets are owned by nobody

### DIFF
--- a/internal/core/group_sharing.go
+++ b/internal/core/group_sharing.go
@@ -31,7 +31,7 @@ func (c *KeyorixCore) ShareSecretWithGroup(ctx context.Context, req *GroupShareS
 	// Only the owner may share a secret — mirror the direct (non-group) path.
 	// Without this, any caller with secrets.write could group-share a secret they
 	// do not own, granting their group read/write access to it.
-	if secret.OwnerID != req.SharedBy {
+	if !secretOwnedBy(secret.OwnerID, req.SharedBy) {
 		return nil, fmt.Errorf("not authorized to share this secret")
 	}
 

--- a/internal/core/permissions.go
+++ b/internal/core/permissions.go
@@ -9,6 +9,17 @@ import (
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
+// secretOwnedBy reports whether actorID is the owner of a secret with the given
+// OwnerID. A zero OwnerID means the secret has NO human owner — e.g. one created by
+// a machine identity (ADR-023/030 store OwnerID 0 for machines) or a legacy/ownerless
+// row. Such a secret must be owned by nobody: without the zero guard, a machine
+// actor (whose ID is also 0) would match every ownerless secret via 0 == 0 and gain
+// owner-level rights over all of them. Ownership therefore requires a non-zero,
+// matching id on both sides.
+func secretOwnedBy(ownerID, actorID uint) bool {
+	return ownerID != 0 && ownerID == actorID
+}
+
 // PermissionLevel represents the level of access a user has to a secret.
 type PermissionLevel string
 
@@ -43,7 +54,7 @@ func (c *KeyorixCore) CheckSecretPermission(ctx context.Context, secretID, userI
 	}
 
 	// Owners have all permissions.
-	if secret.OwnerID == userID {
+	if secretOwnedBy(secret.OwnerID, userID) {
 		return &PermissionContext{
 			SecretID:   secretID,
 			UserID:     userID,

--- a/internal/core/secret_listing_sharing.go
+++ b/internal/core/secret_listing_sharing.go
@@ -72,7 +72,7 @@ func (c *KeyorixCore) GetSecretSharingStatusWithIndicators(ctx context.Context, 
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
 	}
 
-	isOwner := secret.OwnerID == userID
+	isOwner := secretOwnedBy(secret.OwnerID, userID)
 	userPermission := ""
 	if !isOwner {
 		for _, share := range shares {
@@ -132,7 +132,7 @@ func (c *KeyorixCore) GetUserSecretPermission(ctx context.Context, secretID, use
 		return nil, err
 	}
 
-	if secret.OwnerID == userID {
+	if secretOwnedBy(secret.OwnerID, userID) {
 		return &models.UserSecretPermission{
 			SecretID:   secretID,
 			UserID:     userID,

--- a/internal/core/secret_owned_by_test.go
+++ b/internal/core/secret_owned_by_test.go
@@ -1,0 +1,70 @@
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSecretOwnedBy(t *testing.T) {
+	cases := []struct {
+		name  string
+		owner uint
+		actor uint
+		want  bool
+	}{
+		{"human owner matches", 5, 5, true},
+		{"human non-owner", 5, 6, false},
+		{"ownerless vs machine (both zero) is NOT ownership", 0, 0, false},
+		{"ownerless vs human", 0, 5, false},
+		{"human-owned vs machine actor", 5, 0, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, secretOwnedBy(tc.owner, tc.actor))
+		})
+	}
+}
+
+// TestRevokeShare_MachineCannotManageOwnerlessSecret is the security regression for
+// the OwnerID=0 gap: a machine actor (id 0) must NOT be treated as the owner of an
+// ownerless (machine-created) secret, so it cannot revoke shares on it.
+func TestRevokeShare_MachineCannotManageOwnerlessSecret(t *testing.T) {
+	mockStorage := new(MockStorage)
+	core := &KeyorixCore{storage: mockStorage}
+	ctx := context.Background()
+
+	mockStorage.On("GetShareRecord", ctx, uint(1)).
+		Return(&models.ShareRecord{ID: 1, SecretID: 7, OwnerID: 0, RecipientID: 2}, nil)
+	mockStorage.On("GetSecret", ctx, uint(7)).
+		Return(&models.SecretNode{ID: 7, Name: "machine-secret", OwnerID: 0}, nil)
+
+	// revokedBy = 0 (a machine). Before the fix, 0 == 0 passed the owner gate.
+	err := core.RevokeShare(ctx, 1, 0)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), i18n.T("ErrorPermissionDenied", nil))
+	// It must not have proceeded to delete the share.
+	mockStorage.AssertNotCalled(t, "DeleteShareRecord", mock.Anything, mock.Anything)
+}
+
+// TestShareSecret_OwnerlessSecretNotShareable confirms an ownerless secret can't be
+// shared via the owner gate even by a non-zero caller (defence in depth).
+func TestShareSecret_OwnerlessSecretNotShareable(t *testing.T) {
+	mockStorage := new(MockStorage)
+	core := &KeyorixCore{storage: mockStorage}
+	ctx := context.Background()
+
+	mockStorage.On("GetSecret", ctx, uint(7)).
+		Return(&models.SecretNode{ID: 7, Name: "machine-secret", OwnerID: 0}, nil)
+
+	_, err := core.ShareSecret(ctx, &ShareSecretRequest{
+		SecretID: 7, RecipientID: 2, Permission: "read", SharedBy: 9,
+	})
+	require.Error(t, err)
+	mockStorage.AssertNotCalled(t, "CreateShareRecord", mock.Anything, mock.Anything)
+}

--- a/internal/core/secret_risk.go
+++ b/internal/core/secret_risk.go
@@ -171,7 +171,10 @@ func (c *KeyorixCore) countReads(ctx context.Context, secretID uint, since time.
 // countPrincipals counts the distinct users that can read a secret: the owner
 // plus direct share recipients plus the members of any group it is shared with.
 func (c *KeyorixCore) countPrincipals(ctx context.Context, secret *models.SecretNode) int {
-	principals := map[uint]struct{}{secret.OwnerID: {}}
+	principals := map[uint]struct{}{}
+	if secret.OwnerID != 0 { // an ownerless (machine-created) secret has no owner principal
+		principals[secret.OwnerID] = struct{}{}
+	}
 	shares, err := c.storage.ListSharesBySecret(ctx, secret.ID)
 	if err != nil {
 		return len(principals)

--- a/internal/core/sharing.go
+++ b/internal/core/sharing.go
@@ -40,9 +40,10 @@ func (c *KeyorixCore) ShareSecret(ctx context.Context, req *ShareSecretRequest) 
 		return nil, err
 	}
 
-	// Only the secret owner may share it.
+	// Only the secret owner may share it (an ownerless / machine-created secret —
+	// OwnerID 0 — is owned by nobody and cannot be shared via the owner gate).
 	// Sharing semantics: same-project only (RBAC is global; ownership enforces project boundary).
-	if secret.OwnerID != req.SharedBy {
+	if !secretOwnedBy(secret.OwnerID, req.SharedBy) {
 		return nil, fmt.Errorf("%s", i18n.T("ErrorPermissionDenied", nil))
 	}
 
@@ -89,7 +90,7 @@ func (c *KeyorixCore) UpdateSharePermission(ctx context.Context, req *UpdateShar
 	if err != nil {
 		return nil, err
 	}
-	if secret.OwnerID != req.UpdatedBy {
+	if !secretOwnedBy(secret.OwnerID, req.UpdatedBy) {
 		return nil, fmt.Errorf("%s", i18n.T("ErrorPermissionDenied", nil))
 	}
 
@@ -128,7 +129,7 @@ func (c *KeyorixCore) RevokeShare(ctx context.Context, shareID uint, revokedBy u
 	if err != nil {
 		return err
 	}
-	if secret.OwnerID != revokedBy {
+	if !secretOwnedBy(secret.OwnerID, revokedBy) {
 		return fmt.Errorf("%s", i18n.T("ErrorPermissionDenied", nil))
 	}
 

--- a/internal/core/sharing_query.go
+++ b/internal/core/sharing_query.go
@@ -56,7 +56,7 @@ func (c *KeyorixCore) ListSecretSharesWithPermissionCheck(ctx context.Context, s
 	if err != nil {
 		return nil, err
 	}
-	if secret.OwnerID != userID {
+	if !secretOwnedBy(secret.OwnerID, userID) {
 		return nil, fmt.Errorf("not authorized to view shares for this secret")
 	}
 	shares, err := c.storage.ListSharesBySecret(ctx, secretID)


### PR DESCRIPTION
## Summary

A secret created by a machine identity (ADR-023/030) is stored with `OwnerID = 0`. The owner-equality gates compared `OwnerID` to the actor id directly, so a **machine actor — whose id is also 0 — matched every ownerless secret via `0 == 0`** and was treated as its owner: owner-level permission context, plus the ability to share / update-share / revoke / view-shares of any ownerless secret.

Front-gated by scoped RBAC (a machine still needs `secrets.write` at that secret's project), so it is **not** a cross-project bypass — but it is a real correctness gap in the ownership model, surfaced by the #159 security review, and identical on the pre-existing HTTP path.

## Fix

A new `secretOwnedBy(ownerID, actorID)` requires a **non-zero id matching on both sides**, applied at every owner gate:
- `GetSecretPermissionContext` (owner ⇒ all permissions)
- the two listing/permission owner checks (`secret_listing_sharing.go`)
- `ShareSecret`, `UpdateSharePermission`, `RevokeShare`, `ListSharesBySecret` authz, and group-share

An ownerless secret is now owned by **nobody**, so these owner-gated operations are denied for it. `countPrincipals` also no longer counts a phantom principal `0` for an ownerless secret.

This is the **decision-free hardening subset** (close the false co-ownership). A fuller machine-namespaced owner-identity model — i.e. whether machine secret-*sharing* is a real use case — stays deferred pending that product decision.

## Security note

The change is **strictly more restrictive** — it only removes an over-grant where `0 == 0` previously passed; it cannot introduce a new grant. Human-owned secrets (non-zero `OwnerID`) are unaffected (verified by the full core regression suite).

## Tests

`secretOwnedBy` truth table; a machine (id 0) cannot revoke shares on an ownerless secret; an ownerless secret is not shareable. Full `internal/core` suite green; gofmt / golangci-lint / gosec clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)