### PR TITLE
feat(users): expose active login-lockout in the user API response

### DIFF
--- a/server/http/handlers/users_handler.go
+++ b/server/http/handlers/users_handler.go
@@ -85,6 +85,12 @@ func userToAPIResponse(u *models.User) map[string]interface{} {
 	if u.DeletedAt.Valid {
 		out["deleted_at"] = u.DeletedAt.Time.UTC().Format(time.RFC3339)
 	}
+	// Surface an ACTIVE per-account login lockout (ADR-040 hardening) so an admin can
+	// see a locked-out account and clear it via POST /users/{id}/unlock. Only emitted
+	// while the lock is in the future; an expired lock reads as unlocked.
+	if u.LoginLockedUntil != nil && time.Now().Before(*u.LoginLockedUntil) {
+		out["login_locked_until"] = u.LoginLockedUntil.UTC().Format(time.RFC3339)
+	}
 	return out
 }
 

--- a/server/http/handlers/users_lockout_response_test.go
+++ b/server/http/handlers/users_lockout_response_test.go
@@ -1,0 +1,28 @@
+package handlers
+
+import (
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUserToAPIResponse_LoginLockout(t *testing.T) {
+	t.Run("active lock is surfaced", func(t *testing.T) {
+		until := time.Now().Add(30 * time.Minute)
+		out := userToAPIResponse(&models.User{ID: 1, Username: "bob", LoginLockedUntil: &until})
+		assert.Contains(t, out, "login_locked_until", "an active lockout must be visible to admins")
+	})
+
+	t.Run("no lock → field absent", func(t *testing.T) {
+		out := userToAPIResponse(&models.User{ID: 1, Username: "bob"})
+		assert.NotContains(t, out, "login_locked_until")
+	})
+
+	t.Run("expired lock → field absent", func(t *testing.T) {
+		past := time.Now().Add(-time.Minute)
+		out := userToAPIResponse(&models.User{ID: 1, Username: "bob", LoginLockedUntil: &past})
+		assert.NotContains(t, out, "login_locked_until", "an expired lock reads as unlocked")
+	})
+}


### PR DESCRIPTION
## Summary

#229 added per-account login lockout and an admin `POST /users/{id}/unlock` endpoint, but the lockout state was never exposed in the user API — so an admin couldn't *see* a locked-out account in the console, and the unlock was reachable only via the raw API.

`userToAPIResponse` now emits **`login_locked_until`** when a lock is **active** (set and in the future). An absent or expired lock omits the field, so its mere presence is a direct "currently locked" signal the web console can render with an Unlock action (follow-up web PR).

## Tests

active lock surfaced; no-lock and expired-lock omit the field. gofmt / golangci-lint / gosec clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)