### PR TITLE
feat(connect): Keyorix Connect — read-through federation to external stores (ADR-043)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -920,3 +920,27 @@ credential_delivery:
 `out_of_band` / `log` return or log the link instead of emailing it (useful when no
 mail relay is available). A link-producing mode with an empty `base_url` is a
 misconfiguration — link minting refuses it rather than emitting a relative link.
+
+## connect
+
+**Keyorix Connect** (ADR-043) is opt-in **read-through federation** to external
+secret stores: it proxies an authorized, audited read of a secret's *current* value
+held in an external store, without importing or persisting it. Disabled by default;
+with no connectors the `/connect` endpoints are not served.
+
+```yaml
+connect:
+  enabled: true
+  connectors:
+    - name: prod-aws            # API path key (unique); GET /api/v1/connect/prod-aws/secret?ref=…
+      type: aws-secrets-manager # the only backend today (GCP SM / Vault are follow-ups)
+      region: eu-west-1
+```
+
+- Reads are **read-only** and gated by `secrets.read`; each is audited as
+  `connect.secret_read`. The value is returned to the caller and never stored.
+- `ref` (query parameter) is connector-specific — for AWS Secrets Manager it is the
+  secret **name or ARN**. A binary secret is returned base64-encoded.
+- Backend credentials come from the **ambient identity chain** (AWS: env /
+  instance-profile / IRSA), never from this config. A backend failure surfaces as
+  `502 Bad Gateway`.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -935,6 +935,8 @@ connect:
     - name: prod-aws            # API path key (unique); GET /api/v1/connect/prod-aws/secret?ref=…
       type: aws-secrets-manager # the only backend today (GCP SM / Vault are follow-ups)
       region: eu-west-1
+      allowed_refs:             # optional prefix allowlist — a ref must match one
+        - keyorix/              # (defense-in-depth on top of the backend's IAM scope)
 ```
 
 - Reads are **read-only** and gated by `secrets.read`; each is audited as
@@ -944,3 +946,8 @@ connect:
 - Backend credentials come from the **ambient identity chain** (AWS: env /
   instance-profile / IRSA), never from this config. A backend failure surfaces as
   `502 Bad Gateway`.
+- A federated read is bounded by **two** controls: the backend identity's IAM policy
+  (the load-bearing one — scope the connector's credentials to exactly the intended
+  secrets) and, optionally, the per-connector **`allowed_refs`** prefix allowlist
+  enforced in Keyorix before the backend call. Set both: any holder of global
+  `secrets.read` can otherwise read every secret the connector's identity can reach.

--- a/docs/adr-043-secret-store-federation.md
+++ b/docs/adr-043-secret-store-federation.md
@@ -1,0 +1,59 @@
+# ADR-043: Secret-store federation (Keyorix Connect)
+
+## Status
+
+Accepted — first slice shipped (AWS Secrets Manager read-through). GCP Secret
+Manager, HashiCorp Vault, and caching are planned follow-ups.
+
+## Context
+
+Teams adopting Keyorix often already hold secrets in an external store (AWS Secrets
+Manager, GCP Secret Manager, HashiCorp Vault). Migrating everything up front is a
+hard sell. They want to reach those existing secrets *through* Keyorix — with
+Keyorix's RBAC, audit trail, and a single API — without moving them.
+
+## Decision
+
+Add **Keyorix Connect**: a **read-through** federation layer.
+
+- A `Connector` (`internal/connect`) fetches the **current value** of a secret held
+  in an external store on demand. It is **read-only** — no create/update/delete:
+  federation proxies reads, it does not own the secret.
+- Keyorix **never imports or persists** the federated value. A read is proxied,
+  returned to the authorized caller, and **audited** (`connect.secret_read`); nothing
+  is stored. (This keeps the source of truth in the external store and avoids a
+  stale-copy / dual-write problem.)
+- Each backend's SDK is contained behind an **interface seam** (e.g. `smGetAPI`), so
+  the engine is unit-tested with a fake and the SDK dependency stays isolated —
+  mirroring the dynamic-secrets cloud backends (ADR-035).
+- Backend credentials come from the backend's **ambient identity chain** (e.g. the
+  AWS standard chain: env / instance-profile / IRSA), never from Keyorix config.
+- **Opt-in, disabled by default** (`connect.enabled`). The capability is independent
+  of how it is licensed/packaged (a commercial-tier gate can be layered later without
+  changing the model).
+
+### API
+
+- `GET /api/v1/connect/connectors` — list configured connector names.
+- `GET /api/v1/connect/{name}/secret?ref=<id>` — read-through a secret. `ref` is
+  connector-specific (for AWS Secrets Manager: the secret name or ARN).
+
+Both are gated by `secrets.read` (a federated read is a secret read) and audited.
+
+## Alternatives considered
+
+- **Import/sync** (copy external secrets into Keyorix): rejected for the first slice —
+  it creates a stale-copy / dual-write problem and a larger blast radius. Read-through
+  keeps the external store authoritative. Sync can be added later as an explicit,
+  separate mode.
+- **Per-connector credentials in config**: rejected — ambient identity (IRSA/instance
+  profile) is the established pattern in this codebase (KMS, STS, S3) and avoids
+  storing cloud credentials.
+
+## Consequences
+
+- A federated read depends on the external store's availability and latency (a
+  backend failure surfaces as `502 Bad Gateway`). Caching (with a TTL) is a planned
+  follow-up to bound this.
+- Authorization is coarse for now (`secrets.read` globally). Finer, per-connector or
+  per-reference scoping can be layered on later.

--- a/docs/adr-043-secret-store-federation.md
+++ b/docs/adr-043-secret-store-federation.md
@@ -55,5 +55,8 @@ Both are gated by `secrets.read` (a federated read is a secret read) and audited
 - A federated read depends on the external store's availability and latency (a
   backend failure surfaces as `502 Bad Gateway`). Caching (with a TTL) is a planned
   follow-up to bound this.
-- Authorization is coarse for now (`secrets.read` globally). Finer, per-connector or
-  per-reference scoping can be layered on later.
+- Authorization is coarse for now (`secrets.read` globally). A federated read is
+  bounded by the backend identity's IAM policy (the load-bearing control) plus an
+  optional per-connector `allowed_refs` prefix allowlist enforced in Keyorix before
+  the backend call. Finer per-reference RBAC and a dedicated `connect.read`
+  permission (so native read access doesn't imply external-store read) are follow-ups.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -88,6 +88,28 @@ type Config struct {
 	// server keeps its conservative built-in defaults (see core.DefaultPasswordPolicy);
 	// when present, the install's values fully replace them.
 	PasswordPolicy PasswordPolicyConfig `yaml:"password_policy"`
+
+	// Connect configures Keyorix Connect (ADR-043): read-through federation to
+	// external secret stores. Disabled (zero value) = the /connect endpoints are not
+	// served.
+	Connect ConnectConfig `yaml:"connect"`
+}
+
+// ConnectConfig configures read-through federation to external secret stores
+// (ADR-043). Opt-in: with no connectors (or Enabled false) the /connect API is off.
+type ConnectConfig struct {
+	Enabled    bool              `yaml:"enabled"`
+	Connectors []ConnectorConfig `yaml:"connectors"`
+}
+
+// ConnectorConfig describes one external-store connector. Name is the API path key
+// (unique); Type selects the backend ("aws-secrets-manager"); Region is the backend
+// region where applicable. Credentials come from the backend's ambient identity
+// chain, never from here.
+type ConnectorConfig struct {
+	Name   string `yaml:"name"`
+	Type   string `yaml:"type"`
+	Region string `yaml:"region"`
 }
 
 // PasswordPolicyConfig mirrors the password rules from ADR-025: synchronous

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -110,6 +110,12 @@ type ConnectorConfig struct {
 	Name   string `yaml:"name"`
 	Type   string `yaml:"type"`
 	Region string `yaml:"region"`
+	// AllowedRefs, when non-empty, restricts which secret references this connector
+	// may read: a requested ref must have one of these prefixes (a defense-in-depth
+	// guardrail in Keyorix's layer, on top of the backend identity's IAM policy). An
+	// empty list places no restriction here — the backend IAM scope is then the only
+	// bound, so prefer setting both.
+	AllowedRefs []string `yaml:"allowed_refs"`
 }
 
 // PasswordPolicyConfig mirrors the password rules from ADR-025: synchronous

--- a/internal/connect/awssm.go
+++ b/internal/connect/awssm.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
@@ -23,16 +24,33 @@ type smGetAPI interface {
 
 // AWSSecretsManagerConnector reads secrets from AWS Secrets Manager.
 type AWSSecretsManagerConnector struct {
-	name   string
-	region string
+	name        string
+	region      string
+	allowedRefs []string
 	// newClient builds an SM client for the region; nil uses the real AWS client
 	// (the standard credential chain). Tests inject a fake.
 	newClient func(ctx context.Context, region string) (smGetAPI, error)
 }
 
-// NewAWSSecretsManagerConnector builds an AWS Secrets Manager connector.
-func NewAWSSecretsManagerConnector(name, region string) *AWSSecretsManagerConnector {
-	return &AWSSecretsManagerConnector{name: name, region: region}
+// NewAWSSecretsManagerConnector builds an AWS Secrets Manager connector. allowedRefs,
+// when non-empty, restricts readable references to those with one of the given
+// prefixes (a guardrail on top of the AWS IAM scope of the ambient identity).
+func NewAWSSecretsManagerConnector(name, region string, allowedRefs []string) *AWSSecretsManagerConnector {
+	return &AWSSecretsManagerConnector{name: name, region: region, allowedRefs: allowedRefs}
+}
+
+// refAllowed reports whether ref is permitted by the connector's allowlist. An empty
+// allowlist permits everything (the backend IAM policy is then the only bound).
+func (c *AWSSecretsManagerConnector) refAllowed(ref string) bool {
+	if len(c.allowedRefs) == 0 {
+		return true
+	}
+	for _, p := range c.allowedRefs {
+		if p != "" && strings.HasPrefix(ref, p) {
+			return true
+		}
+	}
+	return false
 }
 
 func (c *AWSSecretsManagerConnector) Name() string { return c.name }
@@ -56,6 +74,9 @@ func (c *AWSSecretsManagerConnector) client(ctx context.Context) (smGetAPI, erro
 func (c *AWSSecretsManagerConnector) GetSecret(ctx context.Context, ref string) (string, error) {
 	if ref == "" {
 		return "", fmt.Errorf("aws-secrets-manager: secret reference is required")
+	}
+	if !c.refAllowed(ref) {
+		return "", fmt.Errorf("aws-secrets-manager: ref %q is not permitted by this connector's allowed_refs", ref)
 	}
 	cl, err := c.client(ctx)
 	if err != nil {

--- a/internal/connect/awssm.go
+++ b/internal/connect/awssm.go
@@ -1,0 +1,76 @@
+// awssm.go — the AWS Secrets Manager read-through connector. GetSecret resolves a
+// reference (the secret name or ARN) to its current value via GetSecretValue. AWS
+// credentials/region come from the standard chain (env / instance-profile / IRSA),
+// exactly like the STS dynamic backend and the KMS/S3 integrations — never from
+// Keyorix config.
+package connect
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+)
+
+// smGetAPI is the slice of the Secrets Manager client the connector uses — an
+// interface seam so it is unit-tested with a fake and the SDK stays contained here.
+type smGetAPI interface {
+	GetSecretValue(ctx context.Context, in *secretsmanager.GetSecretValueInput, optFns ...func(*secretsmanager.Options)) (*secretsmanager.GetSecretValueOutput, error)
+}
+
+// AWSSecretsManagerConnector reads secrets from AWS Secrets Manager.
+type AWSSecretsManagerConnector struct {
+	name   string
+	region string
+	// newClient builds an SM client for the region; nil uses the real AWS client
+	// (the standard credential chain). Tests inject a fake.
+	newClient func(ctx context.Context, region string) (smGetAPI, error)
+}
+
+// NewAWSSecretsManagerConnector builds an AWS Secrets Manager connector.
+func NewAWSSecretsManagerConnector(name, region string) *AWSSecretsManagerConnector {
+	return &AWSSecretsManagerConnector{name: name, region: region}
+}
+
+func (c *AWSSecretsManagerConnector) Name() string { return c.name }
+func (c *AWSSecretsManagerConnector) Type() string { return "aws-secrets-manager" }
+
+func (c *AWSSecretsManagerConnector) client(ctx context.Context) (smGetAPI, error) {
+	if c.newClient != nil {
+		return c.newClient(ctx, c.region)
+	}
+	var opts []func(*awsconfig.LoadOptions) error
+	if c.region != "" {
+		opts = append(opts, awsconfig.WithRegion(c.region))
+	}
+	cfg, err := awsconfig.LoadDefaultConfig(ctx, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("aws-secrets-manager: load AWS config: %w", err)
+	}
+	return secretsmanager.NewFromConfig(cfg), nil
+}
+
+func (c *AWSSecretsManagerConnector) GetSecret(ctx context.Context, ref string) (string, error) {
+	if ref == "" {
+		return "", fmt.Errorf("aws-secrets-manager: secret reference is required")
+	}
+	cl, err := c.client(ctx)
+	if err != nil {
+		return "", err
+	}
+	out, err := cl.GetSecretValue(ctx, &secretsmanager.GetSecretValueInput{SecretId: aws.String(ref)})
+	if err != nil {
+		return "", fmt.Errorf("aws-secrets-manager: get %q: %w", ref, err)
+	}
+	if out.SecretString != nil {
+		return *out.SecretString, nil
+	}
+	if len(out.SecretBinary) > 0 {
+		// A binary secret is returned base64-encoded (the AWS console convention).
+		return base64.StdEncoding.EncodeToString(out.SecretBinary), nil
+	}
+	return "", fmt.Errorf("aws-secrets-manager: secret %q has no value", ref)
+}

--- a/internal/connect/awssm_test.go
+++ b/internal/connect/awssm_test.go
@@ -1,0 +1,91 @@
+package connect
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeSM is an injected stand-in for the Secrets Manager client.
+type fakeSM struct {
+	out *secretsmanager.GetSecretValueOutput
+	err error
+	got string
+}
+
+func (f *fakeSM) GetSecretValue(_ context.Context, in *secretsmanager.GetSecretValueInput, _ ...func(*secretsmanager.Options)) (*secretsmanager.GetSecretValueOutput, error) {
+	f.got = aws.ToString(in.SecretId)
+	return f.out, f.err
+}
+
+func connectorWith(name string, fake *fakeSM) *AWSSecretsManagerConnector {
+	c := NewAWSSecretsManagerConnector(name, "eu-west-1")
+	c.newClient = func(_ context.Context, _ string) (smGetAPI, error) { return fake, nil }
+	return c
+}
+
+func TestAWSSM_TypeAndName(t *testing.T) {
+	c := NewAWSSecretsManagerConnector("prod-aws", "us-east-1")
+	assert.Equal(t, "prod-aws", c.Name())
+	assert.Equal(t, "aws-secrets-manager", c.Type())
+}
+
+func TestAWSSM_GetSecret_String(t *testing.T) {
+	fake := &fakeSM{out: &secretsmanager.GetSecretValueOutput{SecretString: aws.String("s3cr3t")}}
+	val, err := connectorWith("aws", fake).GetSecret(context.Background(), "prod/db")
+	require.NoError(t, err)
+	assert.Equal(t, "s3cr3t", val)
+	assert.Equal(t, "prod/db", fake.got, "the ref is passed as the SecretId")
+}
+
+func TestAWSSM_GetSecret_Binary(t *testing.T) {
+	fake := &fakeSM{out: &secretsmanager.GetSecretValueOutput{SecretBinary: []byte{0x00, 0x01, 0x02}}}
+	val, err := connectorWith("aws", fake).GetSecret(context.Background(), "bin")
+	require.NoError(t, err)
+	assert.Equal(t, "AAEC", val, "binary secrets are returned base64-encoded")
+}
+
+func TestAWSSM_GetSecret_Errors(t *testing.T) {
+	t.Run("empty ref", func(t *testing.T) {
+		_, err := connectorWith("aws", &fakeSM{}).GetSecret(context.Background(), "")
+		require.Error(t, err)
+	})
+	t.Run("backend error", func(t *testing.T) {
+		fake := &fakeSM{err: errors.New("AccessDenied")}
+		_, err := connectorWith("aws", fake).GetSecret(context.Background(), "x")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "AccessDenied")
+	})
+	t.Run("no value", func(t *testing.T) {
+		fake := &fakeSM{out: &secretsmanager.GetSecretValueOutput{}}
+		_, err := connectorWith("aws", fake).GetSecret(context.Background(), "x")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no value")
+	})
+}
+
+func TestManager_GetAndNames(t *testing.T) {
+	a := connectorWith("aws-a", &fakeSM{})
+	b := connectorWith("aws-b", &fakeSM{})
+	m := NewManager([]Connector{a, b, nil})
+
+	got, ok := m.Get("aws-a")
+	require.True(t, ok)
+	assert.Equal(t, "aws-a", got.Name())
+
+	_, ok = m.Get("missing")
+	assert.False(t, ok)
+
+	assert.ElementsMatch(t, []string{"aws-a", "aws-b"}, m.Names())
+
+	// nil Manager is safe.
+	var nilM *Manager
+	_, ok = nilM.Get("x")
+	assert.False(t, ok)
+	assert.Nil(t, nilM.Names())
+}

--- a/internal/connect/awssm_test.go
+++ b/internal/connect/awssm_test.go
@@ -24,15 +24,33 @@ func (f *fakeSM) GetSecretValue(_ context.Context, in *secretsmanager.GetSecretV
 }
 
 func connectorWith(name string, fake *fakeSM) *AWSSecretsManagerConnector {
-	c := NewAWSSecretsManagerConnector(name, "eu-west-1")
+	c := NewAWSSecretsManagerConnector(name, "eu-west-1", nil)
 	c.newClient = func(_ context.Context, _ string) (smGetAPI, error) { return fake, nil }
 	return c
 }
 
 func TestAWSSM_TypeAndName(t *testing.T) {
-	c := NewAWSSecretsManagerConnector("prod-aws", "us-east-1")
+	c := NewAWSSecretsManagerConnector("prod-aws", "us-east-1", nil)
 	assert.Equal(t, "prod-aws", c.Name())
 	assert.Equal(t, "aws-secrets-manager", c.Type())
+}
+
+func TestAWSSM_AllowedRefsGuardrail(t *testing.T) {
+	fake := &fakeSM{out: &secretsmanager.GetSecretValueOutput{SecretString: aws.String("ok")}}
+	c := NewAWSSecretsManagerConnector("aws", "eu-west-1", []string{"keyorix/", "shared/"})
+	c.newClient = func(_ context.Context, _ string) (smGetAPI, error) { return fake, nil }
+
+	// A ref matching an allowed prefix passes.
+	val, err := c.GetSecret(context.Background(), "keyorix/prod/db")
+	require.NoError(t, err)
+	assert.Equal(t, "ok", val)
+
+	// A ref outside the allowlist is rejected BEFORE any backend call.
+	fake.got = ""
+	_, err = c.GetSecret(context.Background(), "prod/root")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not permitted")
+	assert.Empty(t, fake.got, "a disallowed ref must not reach the backend")
 }
 
 func TestAWSSM_GetSecret_String(t *testing.T) {

--- a/internal/connect/connect.go
+++ b/internal/connect/connect.go
@@ -1,0 +1,63 @@
+// Package connect implements Keyorix Connect (ADR-043): read-through federation to
+// external secret stores. A Connector fetches the CURRENT value of a secret held in
+// an external store (AWS Secrets Manager, and later GCP Secret Manager / Vault) on
+// demand — Keyorix never imports or persists the value, it proxies an authorized,
+// audited read. This lets teams reach existing external secrets through Keyorix's
+// RBAC and audit trail without migrating them.
+//
+// Opt-in and disabled by default; each connector's backend SDK is contained behind
+// an interface seam so the engine is unit-tested with a fake.
+package connect
+
+import "context"
+
+// Connector reads a secret value from one external store. It is read-only: there is
+// no create/update/delete — federation proxies reads, it does not own the secret.
+type Connector interface {
+	// Name is the operator-assigned connector name (the API path key); unique per
+	// deployment.
+	Name() string
+	// Type identifies the backend kind, e.g. "aws-secrets-manager".
+	Type() string
+	// GetSecret returns the current value of the referenced secret. ref is
+	// connector-specific (for AWS Secrets Manager: the secret name or ARN).
+	GetSecret(ctx context.Context, ref string) (string, error)
+}
+
+// Manager holds the configured connectors, keyed by name.
+type Manager struct {
+	connectors map[string]Connector
+}
+
+// NewManager builds a Manager from the configured connectors (last-wins on a
+// duplicate name).
+func NewManager(connectors []Connector) *Manager {
+	m := &Manager{connectors: make(map[string]Connector, len(connectors))}
+	for _, c := range connectors {
+		if c != nil && c.Name() != "" {
+			m.connectors[c.Name()] = c
+		}
+	}
+	return m
+}
+
+// Get returns the connector with the given name.
+func (m *Manager) Get(name string) (Connector, bool) {
+	if m == nil {
+		return nil, false
+	}
+	c, ok := m.connectors[name]
+	return c, ok
+}
+
+// Names returns the configured connector names (for listing/discovery).
+func (m *Manager) Names() []string {
+	if m == nil {
+		return nil
+	}
+	out := make([]string, 0, len(m.connectors))
+	for name := range m.connectors {
+		out = append(out, name)
+	}
+	return out
+}

--- a/internal/core/connect.go
+++ b/internal/core/connect.go
@@ -1,0 +1,57 @@
+// connect.go — Keyorix Connect (ADR-043): authorized, audited read-through to
+// external secret stores. The HTTP layer gates access with RBAC; this layer resolves
+// the named connector, proxies the read, and audits it. Values are never persisted.
+package core
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/keyorixhq/keyorix/internal/connect"
+)
+
+// EventConnectSecretRead is audited on every federated read (success or failure is
+// distinguished by the description).
+const EventConnectSecretRead = "connect.secret_read"
+
+// SetConnectManager wires the configured external-store connectors (ADR-043). nil
+// (the default) leaves Keyorix Connect disabled.
+func (c *KeyorixCore) SetConnectManager(m *connect.Manager) {
+	c.connectManager = m
+}
+
+// ConnectEnabled reports whether any external-store connector is configured.
+func (c *KeyorixCore) ConnectEnabled() bool {
+	return c.connectManager != nil && len(c.connectManager.Names()) > 0
+}
+
+// ConnectConnectorNames lists the configured connector names (for discovery).
+func (c *KeyorixCore) ConnectConnectorNames() []string {
+	if c.connectManager == nil {
+		return nil
+	}
+	return c.connectManager.Names()
+}
+
+// ReadFederatedSecret proxies a read of ref from the named external-store connector
+// and audits it. The caller (HTTP layer) must have already enforced RBAC. The value
+// is returned to the caller and never persisted.
+func (c *KeyorixCore) ReadFederatedSecret(ctx context.Context, actorID uint, connectorName, ref string) (string, error) {
+	if c.connectManager == nil {
+		return "", fmt.Errorf("keyorix connect is not enabled")
+	}
+	conn, ok := c.connectManager.Get(connectorName)
+	if !ok {
+		return "", fmt.Errorf("unknown connector %q", connectorName)
+	}
+	uid := actorID
+	value, err := conn.GetSecret(ctx, ref)
+	if err != nil {
+		c.writeAuditEvent(ctx, EventConnectSecretRead, &uid, nil,
+			fmt.Sprintf("federated read FAILED via connector %q (%s) ref %q: %v", connectorName, conn.Type(), ref, err))
+		return "", err
+	}
+	c.writeAuditEvent(ctx, EventConnectSecretRead, &uid, nil,
+		fmt.Sprintf("federated read via connector %q (%s) ref %q", connectorName, conn.Type(), ref))
+	return value, nil
+}

--- a/internal/core/connect_test.go
+++ b/internal/core/connect_test.go
@@ -1,0 +1,69 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeConnector struct {
+	name string
+	val  string
+	err  error
+}
+
+func (f fakeConnector) Name() string { return f.name }
+func (f fakeConnector) Type() string { return "fake" }
+func (f fakeConnector) GetSecret(_ context.Context, _ string) (string, error) {
+	return f.val, f.err
+}
+
+func connectTestCore(t *testing.T, conns ...connect.Connector) (*KeyorixCore, *MockStorage) {
+	t.Helper()
+	ms := new(MockStorage)
+	ms.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
+	c := &KeyorixCore{storage: ms}
+	if len(conns) > 0 {
+		c.SetConnectManager(connect.NewManager(conns))
+	}
+	return c, ms
+}
+
+func TestReadFederatedSecret_Success(t *testing.T) {
+	c, ms := connectTestCore(t, fakeConnector{name: "aws", val: "v3ry-secret"})
+	require.True(t, c.ConnectEnabled())
+
+	val, err := c.ReadFederatedSecret(context.Background(), 1, "aws", "prod/db")
+	require.NoError(t, err)
+	assert.Equal(t, "v3ry-secret", val)
+	// The read is audited.
+	ms.AssertCalled(t, "LogAuditEvent", mock.Anything, mock.Anything)
+}
+
+func TestReadFederatedSecret_UnknownConnector(t *testing.T) {
+	c, _ := connectTestCore(t, fakeConnector{name: "aws", val: "x"})
+	_, err := c.ReadFederatedSecret(context.Background(), 1, "nope", "ref")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown connector")
+}
+
+func TestReadFederatedSecret_DisabledWhenNoManager(t *testing.T) {
+	c := &KeyorixCore{storage: new(MockStorage)}
+	assert.False(t, c.ConnectEnabled())
+	_, err := c.ReadFederatedSecret(context.Background(), 1, "aws", "ref")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not enabled")
+}
+
+func TestReadFederatedSecret_BackendErrorAudited(t *testing.T) {
+	c, ms := connectTestCore(t, fakeConnector{name: "aws", err: errors.New("AccessDenied")})
+	_, err := c.ReadFederatedSecret(context.Background(), 1, "aws", "ref")
+	require.Error(t, err)
+	// A failed read is still audited (with FAILED in the description).
+	ms.AssertCalled(t, "LogAuditEvent", mock.Anything, mock.Anything)
+}

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/go-webauthn/webauthn/webauthn"
+	"github.com/keyorixhq/keyorix/internal/connect"
 	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/delivery"
 	"github.com/keyorixhq/keyorix/internal/dynamic"
@@ -52,6 +53,9 @@ type KeyorixCore struct {
 	// notificationSink fans each in-app notification out to an external channel
 	// (email/webhook). nil = in-app only. Set from config via SetNotificationSink.
 	notificationSink NotificationSink
+	// connectManager proxies read-through federation to external secret stores
+	// (ADR-043). nil = Keyorix Connect disabled. Set via SetConnectManager.
+	connectManager *connect.Manager
 	// evidenceForwarder ships the scheduled compliance-evidence pack to an off-box
 	// target (webhook). nil = local-file only. Set via SetEvidenceForwarder.
 	evidenceForwarder EvidenceForwarder

--- a/server/http/handlers/connect.go
+++ b/server/http/handlers/connect.go
@@ -1,0 +1,58 @@
+// connect.go — HTTP handlers for Keyorix Connect (ADR-043): list configured
+// external-store connectors and proxy an authorized, audited read-through of a
+// secret. Both are gated by secrets.read in the router; values are never persisted.
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/server/middleware"
+)
+
+// ConnectHandler serves the /connect federation endpoints.
+type ConnectHandler struct {
+	coreService *core.KeyorixCore
+}
+
+// NewConnectHandler creates a connect handler.
+func NewConnectHandler(coreService *core.KeyorixCore) *ConnectHandler {
+	return &ConnectHandler{coreService: coreService}
+}
+
+// ListConnectors returns the configured connector names (discovery).
+func (h *ConnectHandler) ListConnectors(w http.ResponseWriter, r *http.Request) {
+	if middleware.GetUserFromContext(r.Context()) == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	sendSuccess(w, map[string]interface{}{"connectors": h.coreService.ConnectConnectorNames()}, "")
+}
+
+// GetSecret proxies a read-through of ?ref=… from the named connector.
+func (h *ConnectHandler) GetSecret(w http.ResponseWriter, r *http.Request) {
+	userCtx := middleware.GetUserFromContext(r.Context())
+	if userCtx == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	name := chi.URLParam(r, "name")
+	ref := r.URL.Query().Get("ref")
+	if ref == "" {
+		sendError(w, "InvalidParameter", "ref query parameter is required", http.StatusBadRequest, nil)
+		return
+	}
+	value, err := h.coreService.ReadFederatedSecret(r.Context(), userCtx.UserID, name, ref)
+	if err != nil {
+		// Unknown connector / disabled is a client error; backend failures surface as
+		// a bad gateway since the upstream store is external.
+		sendError(w, "ConnectError", err.Error(), http.StatusBadGateway, nil)
+		return
+	}
+	sendSuccess(w, map[string]interface{}{
+		"connector": name,
+		"ref":       ref,
+		"value":     value,
+	}, "")
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -69,6 +69,7 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 	rbacHandler := handlers.NewRBACHandler(coreService)
 	usersRolesHandler := handlers.NewUsersRolesHandler(coreService)
 	notificationHandler := handlers.NewNotificationHandler(coreService)
+	connectHandler := handlers.NewConnectHandler(coreService)
 
 	// Auth endpoints (no authentication middleware)
 	r.Post("/auth/login", authHandler.Login)
@@ -218,6 +219,9 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		// specific project/environment is scoped to that project. Creating a
 		// project has no parent scope, so it requires global write.
 		projectScope := customMiddleware.ScopeFromProjectParam("id")
+		// Keyorix Connect (ADR-043): read-through federation to external secret stores.
+		r.With(customMiddleware.RequirePermission("secrets.read")).Get("/connect/connectors", connectHandler.ListConnectors)
+		r.With(customMiddleware.RequirePermission("secrets.read")).Get("/connect/{name}/secret", connectHandler.GetSecret)
 		r.With(customMiddleware.RequirePermission("secrets.read")).Get("/projects", catalogHandler.ListProjects)
 		r.With(customMiddleware.RequireScopedPermission("secrets.read", projectScope)).Get("/projects/{id}", catalogHandler.GetProject)
 		r.With(customMiddleware.RequirePermission("secrets.write")).Post("/projects", catalogHandler.CreateProject)

--- a/server/main.go
+++ b/server/main.go
@@ -363,7 +363,7 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 		for _, cn := range cc.Connectors {
 			switch cn.Type {
 			case "aws-secrets-manager":
-				connectors = append(connectors, connect.NewAWSSecretsManagerConnector(cn.Name, cn.Region))
+				connectors = append(connectors, connect.NewAWSSecretsManagerConnector(cn.Name, cn.Region, cn.AllowedRefs))
 			default:
 				log.Printf("Keyorix Connect: skipping connector %q with unknown type %q", cn.Name, cn.Type)
 			}

--- a/server/main.go
+++ b/server/main.go
@@ -39,6 +39,7 @@ import (
 	"github.com/go-webauthn/webauthn/webauthn"
 	"github.com/keyorixhq/keyorix/internal/audit/siem"
 	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/connect"
 	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/keyorixhq/keyorix/internal/delivery"
 	"github.com/keyorixhq/keyorix/internal/encryption"
@@ -354,6 +355,23 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 	}
 	if sink := notifychan.NewMulti(notifySinks...); sink != nil {
 		coreService.SetNotificationSink(sink)
+	}
+
+	// Wire Keyorix Connect (ADR-043) read-through federation if enabled.
+	if cc := cfg.Connect; cc.Enabled && len(cc.Connectors) > 0 {
+		var connectors []connect.Connector
+		for _, cn := range cc.Connectors {
+			switch cn.Type {
+			case "aws-secrets-manager":
+				connectors = append(connectors, connect.NewAWSSecretsManagerConnector(cn.Name, cn.Region))
+			default:
+				log.Printf("Keyorix Connect: skipping connector %q with unknown type %q", cn.Name, cn.Type)
+			}
+		}
+		if len(connectors) > 0 {
+			coreService.SetConnectManager(connect.NewManager(connectors))
+			log.Printf("Keyorix Connect enabled (%d connector(s))", len(connectors))
+		}
 	}
 
 	// Wire any off-box evidence targets (webhook and/or S3-compatible object store),


### PR DESCRIPTION
## Summary

First slice of **Keyorix Connect** (ADR-043): **read-through federation** to external secret stores. It proxies an authorized, audited read of a secret's *current* value from an external store — **without importing or persisting it** — so teams can reach existing external secrets through Keyorix's RBAC + audit trail without migrating them.

This batch ships the model + one backend (**AWS Secrets Manager**); GCP Secret Manager, Vault, caching, and finer scoping are documented follow-ups.

## How it works

- **`internal/connect`** — a read-only `Connector` interface + `Manager` registry, and an AWS Secrets Manager connector behind a fake-able `smGetAPI` seam (SDK contained; AWS creds from the ambient chain — env/instance-profile/IRSA — never config). Binary secrets are returned base64-encoded.
- **core** — `ReadFederatedSecret(actorID, connector, ref)` resolves the connector, proxies the read, and audits `connect.secret_read` (success **and** failure). The value is returned to the caller and **never persisted**.
- **http** — `GET /connect/connectors` and `GET /connect/{name}/secret?ref=…`, both gated by `secrets.read`; an upstream failure surfaces as `502`.
- **config** — `connect{enabled, connectors:[…]}`, wired in `main` when enabled. **Disabled by default** — forces no pricing/tier decision now (a commercial gate can layer on later without changing the model).

## Security

Read-only proxy; nothing is written or cached. Every read is RBAC-gated (`secrets.read`) and audited with the actor, connector, and ref. The backend SDK is contained behind an interface seam; cloud credentials come from the ambient identity chain, not config. `ref`/connector come from an authenticated caller; the value is returned like a native `GetSecretValue`. (I'll run the security-review skill on this diff.)

## Tests

AWS SM string/binary/error/no-value (fake seam); manager get/names/nil-safety; core success / unknown-connector / disabled / backend-error-audited. gofmt / golangci-lint / gosec / gitleaks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)