### PR TITLE
feat(connect): GCP Secret Manager read-through connector

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -933,16 +933,23 @@ connect:
   enabled: true
   connectors:
     - name: prod-aws            # API path key (unique); GET /api/v1/connect/prod-aws/secret?ref=…
-      type: aws-secrets-manager # the only backend today (GCP SM / Vault are follow-ups)
-      region: eu-west-1
+      type: aws-secrets-manager # aws-secrets-manager | gcp-secret-manager (Vault is a follow-up)
+      region: eu-west-1         # AWS region (aws-secrets-manager)
       allowed_refs:             # optional prefix allowlist — a ref must match one
         - keyorix/              # (defense-in-depth on top of the backend's IAM scope)
+    - name: prod-gcp
+      type: gcp-secret-manager  # ref is the version resource name (creds from ADC)
+      allowed_refs:
+        - projects/my-proj/secrets/keyorix-
 ```
 
 - Reads are **read-only** and gated by `secrets.read`; each is audited as
   `connect.secret_read`. The value is returned to the caller and never stored.
-- `ref` (query parameter) is connector-specific — for AWS Secrets Manager it is the
-  secret **name or ARN**. A binary secret is returned base64-encoded.
+- `ref` (query parameter) is connector-specific — for **AWS Secrets Manager** it is
+  the secret **name or ARN** (a binary secret is returned base64-encoded); for **GCP
+  Secret Manager** it is the **version resource name**
+  (`projects/P/secrets/NAME/versions/latest`). GCP credentials come from Application
+  Default Credentials (ADC) / workload identity.
 - Backend credentials come from the **ambient identity chain** (AWS: env /
   instance-profile / IRSA), never from this config. A backend failure surfaces as
   `502 Bad Gateway`.

--- a/docs/adr-043-secret-store-federation.md
+++ b/docs/adr-043-secret-store-federation.md
@@ -2,8 +2,8 @@
 
 ## Status
 
-Accepted — first slice shipped (AWS Secrets Manager read-through). GCP Secret
-Manager, HashiCorp Vault, and caching are planned follow-ups.
+Accepted — AWS Secrets Manager and GCP Secret Manager read-through shipped.
+HashiCorp Vault, caching, and finer scoping are planned follow-ups.
 
 ## Context
 

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/google/go-tpm v0.9.8
 	github.com/google/go-tpm-tools v0.4.9
+	github.com/googleapis/gax-go/v2 v2.22.0
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/nicksnyder/go-i18n/v2 v2.6.0
 	github.com/pquerna/otp v1.5.0
@@ -89,7 +90,6 @@ require (
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.16 // indirect
-	github.com/googleapis/gax-go/v2 v2.22.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect

--- a/internal/connect/awssm.go
+++ b/internal/connect/awssm.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
@@ -39,20 +38,6 @@ func NewAWSSecretsManagerConnector(name, region string, allowedRefs []string) *A
 	return &AWSSecretsManagerConnector{name: name, region: region, allowedRefs: allowedRefs}
 }
 
-// refAllowed reports whether ref is permitted by the connector's allowlist. An empty
-// allowlist permits everything (the backend IAM policy is then the only bound).
-func (c *AWSSecretsManagerConnector) refAllowed(ref string) bool {
-	if len(c.allowedRefs) == 0 {
-		return true
-	}
-	for _, p := range c.allowedRefs {
-		if p != "" && strings.HasPrefix(ref, p) {
-			return true
-		}
-	}
-	return false
-}
-
 func (c *AWSSecretsManagerConnector) Name() string { return c.name }
 func (c *AWSSecretsManagerConnector) Type() string { return "aws-secrets-manager" }
 
@@ -75,7 +60,7 @@ func (c *AWSSecretsManagerConnector) GetSecret(ctx context.Context, ref string) 
 	if ref == "" {
 		return "", fmt.Errorf("aws-secrets-manager: secret reference is required")
 	}
-	if !c.refAllowed(ref) {
+	if !prefixAllowed(c.allowedRefs, ref) {
 		return "", fmt.Errorf("aws-secrets-manager: ref %q is not permitted by this connector's allowed_refs", ref)
 	}
 	cl, err := c.client(ctx)

--- a/internal/connect/connect.go
+++ b/internal/connect/connect.go
@@ -9,7 +9,25 @@
 // an interface seam so the engine is unit-tested with a fake.
 package connect
 
-import "context"
+import (
+	"context"
+	"strings"
+)
+
+// prefixAllowed reports whether ref is permitted by an allowlist of prefixes. An
+// empty allowlist permits everything (the backend identity's own scope is then the
+// only bound). Shared by the connectors as a defense-in-depth guardrail (ADR-043).
+func prefixAllowed(allowed []string, ref string) bool {
+	if len(allowed) == 0 {
+		return true
+	}
+	for _, p := range allowed {
+		if p != "" && strings.HasPrefix(ref, p) {
+			return true
+		}
+	}
+	return false
+}
 
 // Connector reads a secret value from one external store. It is read-only: there is
 // no create/update/delete — federation proxies reads, it does not own the secret.

--- a/internal/connect/gcpsm.go
+++ b/internal/connect/gcpsm.go
@@ -1,0 +1,76 @@
+// gcpsm.go — the GCP Secret Manager read-through connector. GetSecret resolves a
+// reference (the secret VERSION resource name, e.g.
+// projects/PROJECT/secrets/NAME/versions/latest) to its current value via
+// AccessSecretVersion. Credentials come from Application Default Credentials (ADC) /
+// the workload identity — never from Keyorix config — mirroring the GCP KMS and STS
+// integrations.
+package connect
+
+import (
+	"context"
+	"fmt"
+
+	secretmanager "cloud.google.com/go/secretmanager/apiv1"
+	"cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
+	gax "github.com/googleapis/gax-go/v2"
+)
+
+// gcpSMAccessAPI is the slice of the Secret Manager client the connector uses — an
+// interface seam so it is unit-tested with a fake and the SDK stays contained here.
+// Close releases the underlying gRPC connection.
+type gcpSMAccessAPI interface {
+	AccessSecretVersion(ctx context.Context, req *secretmanagerpb.AccessSecretVersionRequest, opts ...gax.CallOption) (*secretmanagerpb.AccessSecretVersionResponse, error)
+	Close() error
+}
+
+// GCPSecretManagerConnector reads secrets from GCP Secret Manager.
+type GCPSecretManagerConnector struct {
+	name        string
+	allowedRefs []string
+	// newClient builds an SM client; nil uses the real client (ADC). Tests inject a fake.
+	newClient func(ctx context.Context) (gcpSMAccessAPI, error)
+}
+
+// NewGCPSecretManagerConnector builds a GCP Secret Manager connector. allowedRefs,
+// when non-empty, restricts readable references to those with one of the given
+// prefixes (a guardrail on top of the workload identity's IAM scope).
+func NewGCPSecretManagerConnector(name string, allowedRefs []string) *GCPSecretManagerConnector {
+	return &GCPSecretManagerConnector{name: name, allowedRefs: allowedRefs}
+}
+
+func (c *GCPSecretManagerConnector) Name() string { return c.name }
+func (c *GCPSecretManagerConnector) Type() string { return "gcp-secret-manager" }
+
+func (c *GCPSecretManagerConnector) client(ctx context.Context) (gcpSMAccessAPI, error) {
+	if c.newClient != nil {
+		return c.newClient(ctx)
+	}
+	cl, err := secretmanager.NewClient(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("gcp-secret-manager: new client: %w", err)
+	}
+	return cl, nil
+}
+
+func (c *GCPSecretManagerConnector) GetSecret(ctx context.Context, ref string) (string, error) {
+	if ref == "" {
+		return "", fmt.Errorf("gcp-secret-manager: secret reference is required (a version resource name, e.g. projects/P/secrets/NAME/versions/latest)")
+	}
+	if !prefixAllowed(c.allowedRefs, ref) {
+		return "", fmt.Errorf("gcp-secret-manager: ref %q is not permitted by this connector's allowed_refs", ref)
+	}
+	cl, err := c.client(ctx)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = cl.Close() }()
+
+	out, err := cl.AccessSecretVersion(ctx, &secretmanagerpb.AccessSecretVersionRequest{Name: ref})
+	if err != nil {
+		return "", fmt.Errorf("gcp-secret-manager: access %q: %w", ref, err)
+	}
+	if out.GetPayload() == nil || len(out.GetPayload().GetData()) == 0 {
+		return "", fmt.Errorf("gcp-secret-manager: secret %q has no value", ref)
+	}
+	return string(out.GetPayload().GetData()), nil
+}

--- a/internal/connect/gcpsm_test.go
+++ b/internal/connect/gcpsm_test.go
@@ -1,0 +1,75 @@
+package connect
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
+	gax "github.com/googleapis/gax-go/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeGCPSM is an injected stand-in for the GCP Secret Manager client.
+type fakeGCPSM struct {
+	out    *secretmanagerpb.AccessSecretVersionResponse
+	err    error
+	got    string
+	closed bool
+}
+
+func (f *fakeGCPSM) AccessSecretVersion(_ context.Context, req *secretmanagerpb.AccessSecretVersionRequest, _ ...gax.CallOption) (*secretmanagerpb.AccessSecretVersionResponse, error) {
+	f.got = req.GetName()
+	return f.out, f.err
+}
+func (f *fakeGCPSM) Close() error { f.closed = true; return nil }
+
+func gcpConnectorWith(name string, fake *fakeGCPSM, allowed ...string) *GCPSecretManagerConnector {
+	c := NewGCPSecretManagerConnector(name, allowed)
+	c.newClient = func(_ context.Context) (gcpSMAccessAPI, error) { return fake, nil }
+	return c
+}
+
+func TestGCPSM_TypeAndName(t *testing.T) {
+	c := NewGCPSecretManagerConnector("prod-gcp", nil)
+	assert.Equal(t, "prod-gcp", c.Name())
+	assert.Equal(t, "gcp-secret-manager", c.Type())
+}
+
+func TestGCPSM_GetSecret(t *testing.T) {
+	fake := &fakeGCPSM{out: &secretmanagerpb.AccessSecretVersionResponse{
+		Payload: &secretmanagerpb.SecretPayload{Data: []byte("g0ph3r")},
+	}}
+	ref := "projects/p/secrets/db/versions/latest"
+	val, err := gcpConnectorWith("gcp", fake).GetSecret(context.Background(), ref)
+	require.NoError(t, err)
+	assert.Equal(t, "g0ph3r", val)
+	assert.Equal(t, ref, fake.got, "the ref is passed as the version resource name")
+	assert.True(t, fake.closed, "the client is closed after use")
+}
+
+func TestGCPSM_GetSecret_Errors(t *testing.T) {
+	t.Run("empty ref", func(t *testing.T) {
+		_, err := gcpConnectorWith("gcp", &fakeGCPSM{}).GetSecret(context.Background(), "")
+		require.Error(t, err)
+	})
+	t.Run("backend error", func(t *testing.T) {
+		_, err := gcpConnectorWith("gcp", &fakeGCPSM{err: errors.New("PermissionDenied")}).GetSecret(context.Background(), "projects/p/secrets/x/versions/1")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "PermissionDenied")
+	})
+	t.Run("no value", func(t *testing.T) {
+		_, err := gcpConnectorWith("gcp", &fakeGCPSM{out: &secretmanagerpb.AccessSecretVersionResponse{}}).GetSecret(context.Background(), "projects/p/secrets/x/versions/1")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no value")
+	})
+	t.Run("allowed_refs guardrail", func(t *testing.T) {
+		fake := &fakeGCPSM{out: &secretmanagerpb.AccessSecretVersionResponse{Payload: &secretmanagerpb.SecretPayload{Data: []byte("x")}}}
+		c := gcpConnectorWith("gcp", fake, "projects/p/secrets/keyorix-")
+		_, err := c.GetSecret(context.Background(), "projects/p/secrets/other/versions/latest")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not permitted")
+		assert.Empty(t, fake.got, "a disallowed ref must not reach the backend")
+	})
+}

--- a/server/main.go
+++ b/server/main.go
@@ -364,6 +364,8 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 			switch cn.Type {
 			case "aws-secrets-manager":
 				connectors = append(connectors, connect.NewAWSSecretsManagerConnector(cn.Name, cn.Region, cn.AllowedRefs))
+			case "gcp-secret-manager":
+				connectors = append(connectors, connect.NewGCPSecretManagerConnector(cn.Name, cn.AllowedRefs))
 			default:
 				log.Printf("Keyorix Connect: skipping connector %q with unknown type %q", cn.Name, cn.Type)
 			}


### PR DESCRIPTION
## Summary

The second **Keyorix Connect** backend (ADR-043), making read-through federation **multi-cloud** (AWS + GCP, mirroring the dynamic-secrets AWS/GCP/Azure symmetry). `type: gcp-secret-manager` reads a secret via `AccessSecretVersion`; `ref` is the **version resource name** (`projects/P/secrets/NAME/versions/latest`). Credentials come from ADC / workload identity — never config.

## How it works

- **`GCPSecretManagerConnector`** behind a fake-able `gcpSMAccessAPI` seam (SDK contained; the client is closed after each use). Reuses the same `allowed_refs` prefix guardrail, now factored into a shared `prefixAllowed` helper (the AWS connector is refactored onto it too — no behaviour change).
- **main**: `case "gcp-secret-manager"`.
- **docs**: CONFIGURATION + ADR-043 (AWS + GCP shipped; Vault / caching / `connect.read` permission remain follow-ups).

**No new dependency** — `cloud.google.com/go/secretmanager` was already vendored (`gax-go` promoted to direct).

## Security

Same read-only, RBAC-gated (`secrets.read`), audited (`connect.secret_read`) model as the AWS connector reviewed in #243 — identical seam + `allowed_refs` guardrail, no new auth/exposure surface, value never logged. (No separate heavyweight review for a structurally-identical second backend.)

## Tests

string value; client closed-after-use; empty-ref / backend-error / no-value; `allowed_refs` guardrail rejects before the backend call. gofmt / golangci-lint / gosec / gitleaks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)