### PR TITLE
fix(notary): verify RFC 3161 chain at the token's genTime, not now

### DIFF
--- a/internal/notary/notary.go
+++ b/internal/notary/notary.go
@@ -82,6 +82,13 @@ func VerifyReceipt(roots *x509.CertPool, message, token []byte) (time.Time, erro
 		Roots:         roots,
 		Intermediates: intermediates,
 		KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageTimeStamping},
+		// Verify the chain AS OF the timestamp's asserted time, not time.Now(): an
+		// RFC 3161 timestamp must remain verifiable AFTER the TSA's signing cert
+		// expires — that durability is the whole point of trusted timestamping.
+		// Verifying against now would make every anchor unverifiable once its TSA
+		// cert lapsed (and is itself the more correct check: was the issuer trusted
+		// when it signed?).
+		CurrentTime: ts.Time,
 	}); err != nil {
 		return time.Time{}, fmt.Errorf("notary: receipt issuer not trusted: %w", err)
 	}

--- a/internal/notary/notary_test.go
+++ b/internal/notary/notary_test.go
@@ -28,10 +28,13 @@ func newTestTSA(t *testing.T, fixedTime time.Time) (*httptest.Server, crypto.Sig
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
 	require.NoError(t, err)
 	tmpl := &x509.Certificate{
-		SerialNumber:          big.NewInt(1),
-		Subject:               pkix.Name{CommonName: "Test TSA"},
-		NotBefore:             fixedTime.Add(-time.Hour),
-		NotAfter:              fixedTime.Add(24 * time.Hour),
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "Test TSA"},
+		// Wide validity so the test is never time-bombed: the in-process TSA signs at
+		// real wall-clock time (the embedded CMS signingTime is "now"), so the cert
+		// must cover real now, not just the fixed genTime.
+		NotBefore:             fixedTime.Add(-365 * 24 * time.Hour),
+		NotAfter:              fixedTime.Add(3650 * 24 * time.Hour),
 		KeyUsage:              x509.KeyUsageDigitalSignature,
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageTimeStamping},
 		BasicConstraintsValid: true,


### PR DESCRIPTION
## Summary

Two issues, one root cause.

**Production bug:** `VerifyReceipt` chain-verified the TSA signer against `time.Now()`, so an audit-checkpoint anchor (ADR-029 / #234) became **unverifiable once the TSA's signing cert expired** — backwards for trusted timestamping, whose entire point is a proof that outlives the signing cert. Fix: verify the chain **as of the token's asserted time** (`ts.Time`) — the correct question is "was the issuer trusted *when it signed*?". (The embedded CMS `signingTime` is still independently checked against cert validity by pkcs7, so a historical signing time within validity still verifies.)

**CI time-bomb (how it surfaced):** the in-process test TSA's cert was valid only ±a day around a fixed genTime; once wall-clock passed that window the suite began failing on every branch (the test signs at real time, so the cert must cover real now). Widened the test cert validity to a decade — no longer clock-dependent.

## Changes
- `notary.go`: `VerifyWithOpts` sets `CurrentTime: ts.Time`.
- `notary_test.go`: wide TSA cert validity window.

This unblocks CI (currently red repo-wide) and fixes a latent correctness bug in released code (v0.36.0). gofmt / golangci-lint / gosec clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)