### PR TITLE
feat(connect): HashiCorp Vault read-through connector

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -933,7 +933,7 @@ connect:
   enabled: true
   connectors:
     - name: prod-aws            # API path key (unique); GET /api/v1/connect/prod-aws/secret?ref=…
-      type: aws-secrets-manager # aws-secrets-manager | gcp-secret-manager (Vault is a follow-up)
+      type: aws-secrets-manager # aws-secrets-manager | gcp-secret-manager | vault
       region: eu-west-1         # AWS region (aws-secrets-manager)
       allowed_refs:             # optional prefix allowlist — a ref must match one
         - keyorix/              # (defense-in-depth on top of the backend's IAM scope)
@@ -941,6 +941,12 @@ connect:
       type: gcp-secret-manager  # ref is the version resource name (creds from ADC)
       allowed_refs:
         - projects/my-proj/secrets/keyorix-
+    - name: prod-vault
+      type: vault               # ref is the read path; KV v2 is unwrapped
+      address: https://vault.example.com:8200
+      token_env: VAULT_TOKEN    # env var holding the Vault token (default VAULT_TOKEN)
+      allowed_refs:
+        - secret/data/keyorix/
 ```
 
 - Reads are **read-only** and gated by `secrets.read`; each is audited as
@@ -948,11 +954,12 @@ connect:
 - `ref` (query parameter) is connector-specific — for **AWS Secrets Manager** it is
   the secret **name or ARN** (a binary secret is returned base64-encoded); for **GCP
   Secret Manager** it is the **version resource name**
-  (`projects/P/secrets/NAME/versions/latest`). GCP credentials come from Application
-  Default Credentials (ADC) / workload identity.
+  (`projects/P/secrets/NAME/versions/latest`); for **Vault** it is the **read path**
+  (e.g. `secret/data/myapp` for KV v2, whose inner `data` map is returned). GCP
+  credentials come from ADC / workload identity; the Vault token comes from `token_env`.
 - Backend credentials come from the **ambient identity chain** (AWS: env /
-  instance-profile / IRSA), never from this config. A backend failure surfaces as
-  `502 Bad Gateway`.
+  instance-profile / IRSA; GCP: ADC; Vault: `token_env`), never from this config. A
+  backend failure surfaces as `502 Bad Gateway`.
 - A federated read is bounded by **two** controls: the backend identity's IAM policy
   (the load-bearing one — scope the connector's credentials to exactly the intended
   secrets) and, optionally, the per-connector **`allowed_refs`** prefix allowlist

--- a/docs/adr-043-secret-store-federation.md
+++ b/docs/adr-043-secret-store-federation.md
@@ -2,8 +2,9 @@
 
 ## Status
 
-Accepted — AWS Secrets Manager and GCP Secret Manager read-through shipped.
-HashiCorp Vault, caching, and finer scoping are planned follow-ups.
+Accepted — AWS Secrets Manager, GCP Secret Manager, and HashiCorp Vault
+read-through shipped. Caching, a dedicated `connect.read` permission, and finer
+per-reference scoping are planned follow-ups.
 
 ## Context
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -110,6 +110,12 @@ type ConnectorConfig struct {
 	Name   string `yaml:"name"`
 	Type   string `yaml:"type"`
 	Region string `yaml:"region"`
+	// Address is the backend base URL for type "vault" (e.g. https://vault:8200).
+	Address string `yaml:"address"`
+	// TokenEnv names the environment variable holding the backend token for type
+	// "vault" (default "VAULT_TOKEN"). The token is read from the environment, never
+	// from this file.
+	TokenEnv string `yaml:"token_env"`
 	// AllowedRefs, when non-empty, restricts which secret references this connector
 	// may read: a requested ref must have one of these prefixes (a defense-in-depth
 	// guardrail in Keyorix's layer, on top of the backend identity's IAM policy). An

--- a/internal/connect/vault.go
+++ b/internal/connect/vault.go
@@ -1,0 +1,99 @@
+// vault.go — the HashiCorp Vault read-through connector. GetSecret reads a path via
+// Vault's HTTP API (GET {address}/v1/{ref}) with a token, and returns the secret's
+// data as JSON. KV v2 is detected and unwrapped (the value lives under data.data).
+//
+// Implemented directly over net/http (no Vault SDK dependency): a KV read is a
+// single authenticated GET. The token comes from an environment variable (trusted,
+// like the other backends' ambient credentials), never from the request.
+package connect
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// vaultMaxResponseBytes caps the read body (a KV secret is small); guards a hostile/
+// misbehaving endpoint.
+const vaultMaxResponseBytes = 1 << 20 // 1 MiB
+
+// VaultConnector reads secrets from HashiCorp Vault over its HTTP API.
+type VaultConnector struct {
+	name        string
+	address     string // e.g. https://vault.example.com:8200
+	token       string
+	allowedRefs []string
+	client      *http.Client
+}
+
+// NewVaultConnector builds a Vault connector. address is the Vault base URL; token
+// is the Vault token (sourced from the environment by the caller). allowedRefs, when
+// non-empty, restricts readable paths to those with one of the given prefixes.
+func NewVaultConnector(name, address, token string, allowedRefs []string) *VaultConnector {
+	return &VaultConnector{
+		name:        name,
+		address:     strings.TrimRight(address, "/"),
+		token:       token,
+		allowedRefs: allowedRefs,
+		client:      &http.Client{Timeout: 15 * time.Second},
+	}
+}
+
+func (c *VaultConnector) Name() string { return c.name }
+func (c *VaultConnector) Type() string { return "vault" }
+
+func (c *VaultConnector) GetSecret(ctx context.Context, ref string) (string, error) {
+	if ref == "" {
+		return "", fmt.Errorf("vault: secret reference (path) is required, e.g. secret/data/myapp")
+	}
+	if !prefixAllowed(c.allowedRefs, ref) {
+		return "", fmt.Errorf("vault: ref %q is not permitted by this connector's allowed_refs", ref)
+	}
+	if c.address == "" {
+		return "", fmt.Errorf("vault: connector address is not configured")
+	}
+	if c.token == "" {
+		return "", fmt.Errorf("vault: no token configured (set the connector's token_env)")
+	}
+
+	url := c.address + "/v1/" + strings.TrimLeft(ref, "/")
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", fmt.Errorf("vault: new request: %w", err)
+	}
+	req.Header.Set("X-Vault-Token", c.token)
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("vault: get %q: %w", ref, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("vault: %s returned HTTP %d for %q", c.address, resp.StatusCode, ref)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, vaultMaxResponseBytes))
+	if err != nil {
+		return "", fmt.Errorf("vault: read response: %w", err)
+	}
+
+	// Vault wraps the secret under "data". KV v2 nests it again under data.data
+	// (alongside data.metadata); KV v1 puts the secret map directly under data.
+	var env struct {
+		Data json.RawMessage `json:"data"`
+	}
+	if err := json.Unmarshal(body, &env); err != nil || len(env.Data) == 0 {
+		return "", fmt.Errorf("vault: secret %q has no data", ref)
+	}
+	var kv2 struct {
+		Data     json.RawMessage `json:"data"`
+		Metadata json.RawMessage `json:"metadata"`
+	}
+	if err := json.Unmarshal(env.Data, &kv2); err == nil && len(kv2.Data) > 0 && len(kv2.Metadata) > 0 {
+		return string(kv2.Data), nil // KV v2: return the inner data map
+	}
+	return string(env.Data), nil // KV v1: the data map itself
+}

--- a/internal/connect/vault_test.go
+++ b/internal/connect/vault_test.go
@@ -1,0 +1,88 @@
+package connect
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeVault stands up an in-process Vault HTTP endpoint that requires the token and
+// serves canned responses keyed by request path.
+func fakeVault(t *testing.T, token string, responses map[string]string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Vault-Token") != token {
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+		body, ok := responses[r.URL.Path]
+		if !ok {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestVault_TypeAndName(t *testing.T) {
+	c := NewVaultConnector("prod-vault", "https://v:8200", "t", nil)
+	assert.Equal(t, "prod-vault", c.Name())
+	assert.Equal(t, "vault", c.Type())
+}
+
+func TestVault_GetSecret_KVv2(t *testing.T) {
+	// KV v2 nests the secret under data.data, with a sibling data.metadata.
+	srv := fakeVault(t, "tok", map[string]string{
+		"/v1/secret/data/myapp": `{"data":{"data":{"password":"p@ss","user":"svc"},"metadata":{"version":3}}}`,
+	})
+	c := NewVaultConnector("v", srv.URL, "tok", nil)
+	val, err := c.GetSecret(context.Background(), "secret/data/myapp")
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"password":"p@ss","user":"svc"}`, val, "KV v2 inner data map is returned")
+}
+
+func TestVault_GetSecret_KVv1(t *testing.T) {
+	srv := fakeVault(t, "tok", map[string]string{
+		"/v1/secret/legacy": `{"data":{"apikey":"abc123"}}`,
+	})
+	c := NewVaultConnector("v", srv.URL, "tok", nil)
+	val, err := c.GetSecret(context.Background(), "secret/legacy")
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"apikey":"abc123"}`, val, "KV v1 data map is returned as-is")
+}
+
+func TestVault_GetSecret_Errors(t *testing.T) {
+	srv := fakeVault(t, "tok", map[string]string{"/v1/ok": `{"data":{"x":"y"}}`})
+
+	t.Run("empty ref", func(t *testing.T) {
+		_, err := NewVaultConnector("v", srv.URL, "tok", nil).GetSecret(context.Background(), "")
+		require.Error(t, err)
+	})
+	t.Run("missing token", func(t *testing.T) {
+		_, err := NewVaultConnector("v", srv.URL, "", nil).GetSecret(context.Background(), "ok")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no token")
+	})
+	t.Run("wrong token → 403", func(t *testing.T) {
+		_, err := NewVaultConnector("v", srv.URL, "bad", nil).GetSecret(context.Background(), "ok")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "HTTP 403")
+	})
+	t.Run("not found → 404", func(t *testing.T) {
+		_, err := NewVaultConnector("v", srv.URL, "tok", nil).GetSecret(context.Background(), "nope")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "HTTP 404")
+	})
+	t.Run("allowed_refs guardrail", func(t *testing.T) {
+		c := NewVaultConnector("v", srv.URL, "tok", []string{"secret/keyorix/"})
+		_, err := c.GetSecret(context.Background(), "secret/other")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not permitted")
+	})
+}

--- a/server/main.go
+++ b/server/main.go
@@ -366,6 +366,16 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 				connectors = append(connectors, connect.NewAWSSecretsManagerConnector(cn.Name, cn.Region, cn.AllowedRefs))
 			case "gcp-secret-manager":
 				connectors = append(connectors, connect.NewGCPSecretManagerConnector(cn.Name, cn.AllowedRefs))
+			case "vault":
+				tokenEnv := cn.TokenEnv
+				if tokenEnv == "" {
+					tokenEnv = "VAULT_TOKEN"
+				}
+				token := os.Getenv(tokenEnv)
+				if token == "" {
+					log.Printf("Keyorix Connect: vault connector %q has no token (%s unset) — reads will fail", cn.Name, tokenEnv)
+				}
+				connectors = append(connectors, connect.NewVaultConnector(cn.Name, cn.Address, token, cn.AllowedRefs))
 			default:
 				log.Printf("Keyorix Connect: skipping connector %q with unknown type %q", cn.Name, cn.Type)
 			}


### PR DESCRIPTION
## Summary

The third **Keyorix Connect** backend (ADR-043), completing the **AWS / GCP / Vault** trio — the "read your existing Vault secrets through Keyorix" migration story. `type: vault` reads a path via Vault's HTTP API (`GET {address}/v1/{ref}`) with a token and returns the secret's data as JSON; **KV v2 is detected and unwrapped** (inner `data.data`), KV v1 returns the data map as-is.

## How it works

- **`VaultConnector`** over `net/http` — **no new dependency** (a KV read is a single authenticated GET). `address` from config; the token comes from `token_env` (default `VAULT_TOKEN`), read from the environment — never the request. Reuses the shared `allowed_refs` prefix guardrail. 1 MiB response cap; backend failure → `502`.
- **config**: `ConnectorConfig.Address` + `TokenEnv`.
- **main**: `case "vault"` (warns if the token env is unset).
- **docs**: CONFIGURATION + ADR-043 (AWS + GCP + Vault shipped; caching / `connect.read` permission / per-reference scoping remain follow-ups).

## Security

Same read-only, RBAC-gated (`secrets.read`), audited (`connect.secret_read`) model as the AWS/GCP connectors reviewed in #243 — the new code is a token-auth HTTP GET with no new auth/exposure surface; the token is env-sourced and only ever sent as the `X-Vault-Token` header. (No separate heavyweight review for a structurally-identical third backend.)

## Tests

In-process fake Vault: KV v2 unwrap, KV v1, empty-ref / missing-token / 403 / 404, `allowed_refs` guardrail. gofmt / golangci-lint / gosec / gitleaks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)