### PR TITLE
release: prep v0.40.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,25 @@
 All notable changes to Keyorix are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## v0.40.0 — 2026-06-16
+
+Keyorix Connect adds HashiCorp Vault.
+
+### Added
+- **Keyorix Connect — HashiCorp Vault backend** (ADR-043): a `vault` connector reads
+  a secret path via Vault's HTTP API and returns its data, completing the
+  AWS / GCP / Vault trio. KV v2 is detected and unwrapped; KV v1 returns the data map
+  as-is. Configure with `address` and `token_env` (default `VAULT_TOKEN`, read from
+  the environment); the per-connector `allowed_refs` prefix allowlist applies as for
+  the other backends. Read-only, gated by `secrets.read`, audited
+  `connect.secret_read`. ([#247])
+
+### Notes
+- No new dependency (a Vault KV read is a single authenticated HTTP GET). A dedicated
+  `connect.read` permission, caching, and per-reference scoping remain follow-ups.
+
+[#247]: https://github.com/keyorixhq/keyorix/pull/247
+
 ## v0.39.0 — 2026-06-16
 
 Keyorix Connect: read secrets from external stores through Keyorix.

--- a/deploy/helm/keyorix/Chart.yaml
+++ b/deploy/helm/keyorix/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix
 description: Self-hosted Keyorix secrets manager (API server + web UI + PostgreSQL)
 type: application
 # Chart version — bump on chart changes.
-version: 0.39.0
+version: 0.40.0
 # The Keyorix app version this chart deploys by default (the image tag).
-appVersion: "0.39.0"
+appVersion: "0.40.0"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix


### PR DESCRIPTION
Release prep for **v0.40.0** — Keyorix Connect HashiCorp Vault read-through backend (#247), completing the AWS / GCP / Vault trio.

- CHANGELOG: v0.40.0 section.
- Helm chart: version + appVersion → 0.40.0.

Merge → tag `v0.40.0` → release + docker-publish pipelines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)