### PR TITLE
feat(rbac): connect.read permission + idempotent permission reconciliation (ADR-044)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -949,7 +949,9 @@ connect:
         - secret/data/keyorix/
 ```
 
-- Reads are **read-only** and gated by `secrets.read`; each is audited as
+- Reads are **read-only** and gated by the dedicated `connect.read` permission
+  (ADR-044) — distinct from `secrets.read`, so external-store access is granted
+  explicitly (it ships granted to `admin` / `system_admin`); each is audited as
   `connect.secret_read`. The value is returned to the caller and never stored.
 - `ref` (query parameter) is connector-specific — for **AWS Secrets Manager** it is
   the secret **name or ARN** (a binary secret is returned base64-encoded); for **GCP

--- a/docs/adr-043-secret-store-federation.md
+++ b/docs/adr-043-secret-store-federation.md
@@ -39,7 +39,7 @@ Add **Keyorix Connect**: a **read-through** federation layer.
 - `GET /api/v1/connect/{name}/secret?ref=<id>` — read-through a secret. `ref` is
   connector-specific (for AWS Secrets Manager: the secret name or ARN).
 
-Both are gated by `secrets.read` (a federated read is a secret read) and audited.
+Both are gated by the dedicated `connect.read` permission (ADR-044) and audited.
 
 ## Alternatives considered
 

--- a/docs/adr-044-rbac-permission-reconciliation.md
+++ b/docs/adr-044-rbac-permission-reconciliation.md
@@ -1,0 +1,64 @@
+# ADR-044: Idempotent RBAC permission reconciliation on startup
+
+## Status
+
+Accepted.
+
+## Context
+
+RBAC permissions and the baseline role→permission grants are seeded once, on first
+boot, by `BootstrapSystem` (which no-ops when any user already exists). There was no
+mechanism to introduce a *new* canonical permission to an already-initialised
+deployment: an upgrade that adds a permission would leave existing installs with no
+role holding it, so any route gated on the new permission would be unreachable until
+an operator hand-created and granted it.
+
+This blocked, for example, giving Keyorix Connect (ADR-043) its own `connect.read`
+permission instead of reusing `secrets.read` — the least-privilege improvement the
+#243 review asked for — because upgraded installs would lose Connect access.
+
+## Decision
+
+Reconcile the canonical permission catalog on **every server startup**, additively
+and **non-clobbering**:
+
+- If the permission set is empty, do nothing — the install is pre-bootstrap, and
+  `BootstrapSystem` will seed everything (including any new permission, since it
+  reads the same `defaultPermissions`). This avoids colliding with first-boot seeding.
+- Otherwise, for each canonical permission **that does not already exist**, create it
+  and grant it to exactly the canonical roles whose definition lists it (only when
+  the role exists and does not already hold it).
+- Permissions that **already exist are never touched** — no grant is added or removed
+  for them. This is the load-bearing safety property: an operator who deliberately
+  removed a default grant (or added a custom one) keeps their customization. Only
+  genuinely-new permissions flow out, and only to their baseline roles.
+
+Reconciliation is best-effort: a failure is logged, not fatal (it must never block
+startup), and it is naturally idempotent (a second run finds nothing new).
+
+### First use: `connect.read`
+
+`connect.read` is added to the catalog and granted to the admin roles
+(`admin` / `system_admin`) by default. The Keyorix Connect routes switch from
+`secrets.read` to `connect.read`, so holding native read access no longer implies
+read access to external stores.
+
+## Alternatives considered
+
+- **A seed/migration version counter** (apply permission migrations for versions >
+  current): more general (also handles renames/removals) but heavier machinery. The
+  "create-if-missing, grant-only-to-new" rule covers the additive case — by far the
+  common one — with no version bookkeeping and no clobbering risk.
+- **Reconcile every role→permission grant to match the defaults**: rejected — it
+  would re-add grants an operator deliberately removed (and couldn't express intent
+  to drop a default), fighting the operator instead of helping them.
+
+## Consequences
+
+- Adding a new canonical permission is now safe across upgrades: list it in
+  `defaultPermissions` and in the role definitions that should hold it.
+- **Behavior change for Connect:** a non-admin principal that could use Connect via
+  `secrets.read` now needs `connect.read` (admins are unaffected). This is an
+  intentional least-privilege tightening of a recently-shipped, opt-in feature.
+- New *roles* are out of scope here (only permissions reconcile); add that mechanism
+  if a future release introduces a new default role that upgrades must receive.

--- a/internal/core/auth_bootstrap.go
+++ b/internal/core/auth_bootstrap.go
@@ -51,6 +51,7 @@ var defaultPermissions = []bootstrapPermissionDef{
 	{"audit.read", "View audit logs", "audit", "read"},
 	{"system.read", "View system information", "system", "read"},
 	{"system.write", "Manage service accounts and API tokens", "system", "write"},
+	{"connect.read", "Read secrets from external stores via Keyorix Connect (ADR-043)", "connect", "read"},
 }
 
 // adminPermissions lists the permission names granted to the admin role.
@@ -59,6 +60,7 @@ var adminPermissions = []string{
 	"users.read", "users.write", "users.delete",
 	"roles.read", "roles.write", "roles.assign",
 	"audit.read", "system.read", "system.write",
+	"connect.read",
 }
 
 // editorPermissions lists the permission names granted to the editor role.

--- a/internal/core/rbac_reconcile.go
+++ b/internal/core/rbac_reconcile.go
@@ -1,0 +1,90 @@
+// rbac_reconcile.go — idempotent, additive reconciliation of the canonical RBAC
+// permission catalog on startup (ADR-044). BootstrapSystem seeds permissions once on
+// first boot; this tops up an ALREADY-initialised install with any canonical
+// permission added in a later release, granting it only to its baseline roles.
+//
+// Non-clobbering: it only ever CREATES missing permissions and grants those new ones
+// to their canonical roles. Permissions that already exist are left entirely alone —
+// no grant is added or removed — so an operator's grant customizations are preserved.
+package core
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// ReconcileRBACPermissions creates any canonical permission missing from an
+// initialised install and grants each newly-created permission to the canonical
+// roles whose definition lists it. It is a no-op on a pre-bootstrap (empty) install
+// — BootstrapSystem seeds those — and best-effort: errors are logged, never fatal.
+func (c *KeyorixCore) ReconcileRBACPermissions(ctx context.Context) error {
+	existing, err := c.storage.ListPermissions(ctx)
+	if err != nil {
+		return fmt.Errorf("rbac reconcile: list permissions: %w", err)
+	}
+	if len(existing) == 0 {
+		return nil // not yet bootstrapped; first-boot seeding owns this
+	}
+	have := make(map[string]bool, len(existing))
+	for _, p := range existing {
+		have[p.Name] = true
+	}
+
+	created := make(map[string]uint)
+	for _, def := range defaultPermissions {
+		if have[def.Name] {
+			continue
+		}
+		p, err := c.storage.CreatePermission(ctx, &models.Permission{
+			Name:        def.Name,
+			Description: def.Description,
+			Resource:    def.Resource,
+			Action:      def.Action,
+		})
+		if err != nil {
+			log.Printf("rbac reconcile: create permission %s: %v", def.Name, err)
+			continue
+		}
+		created[def.Name] = p.ID
+	}
+	if len(created) == 0 {
+		return nil
+	}
+
+	// Grant each newly-created permission to the canonical roles that should hold it
+	// (only roles that exist, only when the grant is missing). Existing permissions
+	// are never re-granted here.
+	for _, rdef := range defaultRoles {
+		role, err := c.storage.GetRoleByName(ctx, rdef.Name)
+		if err != nil || role == nil {
+			continue // role not present in this install
+		}
+		rolePerms, err := c.storage.GetRolePermissions(ctx, role.ID)
+		if err != nil {
+			continue
+		}
+		held := make(map[string]bool, len(rolePerms))
+		for _, p := range rolePerms {
+			held[p.Name] = true
+		}
+		for _, permName := range rdef.Permissions {
+			id, isNew := created[permName]
+			if !isNew || held[permName] {
+				continue
+			}
+			if err := c.storage.AssignPermissionToRole(ctx, role.ID, id); err != nil {
+				log.Printf("rbac reconcile: grant %s to role %s: %v", permName, rdef.Name, err)
+			}
+		}
+	}
+
+	names := make([]string, 0, len(created))
+	for name := range created {
+		names = append(names, name)
+	}
+	log.Printf("RBAC reconcile: added %d new permission(s) and granted them to baseline roles: %v", len(created), names)
+	return nil
+}

--- a/internal/core/rbac_reconcile_test.go
+++ b/internal/core/rbac_reconcile_test.go
@@ -1,0 +1,125 @@
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func newRBACReconcileCore(t *testing.T) (*KeyorixCore, *gorm.DB) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.Role{}, &models.Permission{}, &models.RolePermission{}))
+	return &KeyorixCore{storage: store.NewLocalStorage(db)}, db
+}
+
+// seedOldCatalog simulates an install seeded BEFORE connect.read existed: every
+// canonical permission except connect.read, with admin/system_admin/viewer roles
+// granted their (pre-connect) baseline.
+func seedOldCatalog(t *testing.T, c *KeyorixCore, db *gorm.DB) {
+	t.Helper()
+	ctx := context.Background()
+	for _, def := range defaultPermissions {
+		if def.Name == "connect.read" {
+			continue // the "new" permission this install predates
+		}
+		_, err := c.storage.CreatePermission(ctx, &models.Permission{Name: def.Name, Description: def.Description, Resource: def.Resource, Action: def.Action})
+		require.NoError(t, err)
+	}
+	for _, rdef := range defaultRoles {
+		role, err := c.storage.CreateRole(ctx, &models.Role{Name: rdef.Name, Description: rdef.Description})
+		require.NoError(t, err)
+		for _, permName := range rdef.Permissions {
+			if permName == "connect.read" {
+				continue
+			}
+			var p models.Permission
+			require.NoError(t, db.Where("name = ?", permName).First(&p).Error)
+			require.NoError(t, c.storage.AssignPermissionToRole(ctx, role.ID, p.ID))
+		}
+	}
+}
+
+func roleHasPerm(t *testing.T, c *KeyorixCore, role, perm string) bool {
+	t.Helper()
+	r, err := c.storage.GetRoleByName(context.Background(), role)
+	require.NoError(t, err)
+	perms, err := c.storage.GetRolePermissions(context.Background(), r.ID)
+	require.NoError(t, err)
+	for _, p := range perms {
+		if p.Name == perm {
+			return true
+		}
+	}
+	return false
+}
+
+func TestReconcileRBAC_AddsNewPermissionToBaselineRoles(t *testing.T) {
+	c, db := newRBACReconcileCore(t)
+	seedOldCatalog(t, c, db)
+	ctx := context.Background()
+
+	// Precondition: connect.read does not exist and no role holds it.
+	require.False(t, roleHasPerm(t, c, "admin", "connect.read"))
+
+	require.NoError(t, c.ReconcileRBACPermissions(ctx))
+
+	// connect.read now exists and is granted to the admin roles (its baseline) ...
+	assert.True(t, roleHasPerm(t, c, "admin", "connect.read"))
+	assert.True(t, roleHasPerm(t, c, "system_admin", "connect.read"))
+	// ... but NOT to roles whose definition omits it (least privilege).
+	assert.False(t, roleHasPerm(t, c, "viewer", "connect.read"))
+	assert.False(t, roleHasPerm(t, c, "system_viewer", "connect.read"))
+}
+
+func TestReconcileRBAC_DoesNotClobberExistingGrants(t *testing.T) {
+	c, db := newRBACReconcileCore(t)
+	seedOldCatalog(t, c, db)
+	ctx := context.Background()
+
+	// Simulate an operator customization: REMOVE secrets.delete from the editor role.
+	editor, err := c.storage.GetRoleByName(ctx, "editor")
+	require.NoError(t, err)
+	var del models.Permission
+	require.NoError(t, db.Where("name = ?", "secrets.delete").First(&del).Error)
+	require.NoError(t, c.storage.RemovePermissionFromRole(ctx, editor.ID, del.ID))
+	require.False(t, roleHasPerm(t, c, "editor", "secrets.delete"))
+
+	require.NoError(t, c.ReconcileRBACPermissions(ctx))
+
+	// Reconcile must NOT re-add the operator-removed grant (only new permissions flow).
+	assert.False(t, roleHasPerm(t, c, "editor", "secrets.delete"), "existing-permission grants are never reconciled")
+}
+
+func TestReconcileRBAC_NoopOnFreshInstall(t *testing.T) {
+	c, _ := newRBACReconcileCore(t)
+	// Empty catalog (pre-bootstrap): reconcile must do nothing.
+	require.NoError(t, c.ReconcileRBACPermissions(context.Background()))
+	perms, err := c.storage.ListPermissions(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, perms, "pre-bootstrap reconcile creates nothing — bootstrap owns seeding")
+}
+
+func TestReconcileRBAC_Idempotent(t *testing.T) {
+	c, db := newRBACReconcileCore(t)
+	seedOldCatalog(t, c, db)
+	ctx := context.Background()
+	require.NoError(t, c.ReconcileRBACPermissions(ctx))
+	require.NoError(t, c.ReconcileRBACPermissions(ctx)) // second run: nothing new
+
+	// admin still has exactly one connect.read grant (no duplicate row).
+	r, err := c.storage.GetRoleByName(ctx, "admin")
+	require.NoError(t, err)
+	var n int64
+	var connectID uint
+	require.NoError(t, db.Model(&models.Permission{}).Select("id").Where("name = ?", "connect.read").First(&connectID).Error)
+	require.NoError(t, db.Model(&models.RolePermission{}).Where("role_id = ? AND permission_id = ?", r.ID, connectID).Count(&n).Error)
+	assert.Equal(t, int64(1), n, "no duplicate grant on a second reconcile")
+}

--- a/server/http/handlers/connect.go
+++ b/server/http/handlers/connect.go
@@ -1,6 +1,7 @@
 // connect.go — HTTP handlers for Keyorix Connect (ADR-043): list configured
 // external-store connectors and proxy an authorized, audited read-through of a
-// secret. Both are gated by secrets.read in the router; values are never persisted.
+// secret. Both are gated by connect.read in the router (ADR-044); values are never
+// persisted.
 package handlers
 
 import (

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -220,8 +220,10 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		// project has no parent scope, so it requires global write.
 		projectScope := customMiddleware.ScopeFromProjectParam("id")
 		// Keyorix Connect (ADR-043): read-through federation to external secret stores.
-		r.With(customMiddleware.RequirePermission("secrets.read")).Get("/connect/connectors", connectHandler.ListConnectors)
-		r.With(customMiddleware.RequirePermission("secrets.read")).Get("/connect/{name}/secret", connectHandler.GetSecret)
+		// Gated by the dedicated connect.read permission (ADR-044) — distinct from
+		// native secrets.read, so external-store access is granted explicitly.
+		r.With(customMiddleware.RequirePermission("connect.read")).Get("/connect/connectors", connectHandler.ListConnectors)
+		r.With(customMiddleware.RequirePermission("connect.read")).Get("/connect/{name}/secret", connectHandler.GetSecret)
 		r.With(customMiddleware.RequirePermission("secrets.read")).Get("/projects", catalogHandler.ListProjects)
 		r.With(customMiddleware.RequireScopedPermission("secrets.read", projectScope)).Get("/projects/{id}", catalogHandler.GetProject)
 		r.With(customMiddleware.RequirePermission("secrets.write")).Post("/projects", catalogHandler.CreateProject)

--- a/server/main.go
+++ b/server/main.go
@@ -219,6 +219,14 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 	}
 
 	coreService := core.NewKeyorixCore(store)
+
+	// Top up the canonical RBAC permission catalog (ADR-044): adds any permission
+	// introduced in a later release to an already-initialised install, granting it to
+	// its baseline roles. No-op pre-bootstrap and best-effort (never blocks startup).
+	if err := coreService.ReconcileRBACPermissions(context.Background()); err != nil {
+		log.Printf("RBAC permission reconciliation: %v (continuing)", err)
+	}
+
 	if encSvc != nil {
 		// Wire the initialised encryption service for reversibly-encrypted auth
 		// secrets (the TOTP MFA secret, which cannot be hashed).


### PR DESCRIPTION
## Summary

Gives Keyorix Connect its own `connect.read` permission instead of reusing `secrets.read` (the least-privilege follow-up from the #243 review), plus the upgrade-safe seeding mechanism that unblocks it (ADR-044).

## How it works

- **`ReconcileRBACPermissions`** runs on **every startup** — additive and **non-clobbering**: it creates any canonical permission missing from an already-initialised install and grants each *new* one only to its baseline roles. **Permissions that already exist are never re-granted**, so operator grant customizations are preserved. It **no-ops on a pre-bootstrap (empty) install** (first-boot seeding owns that — no collision), is best-effort (logged, never blocks startup), and idempotent.
- **catalog**: `connect.read` added to `defaultPermissions` and to the admin roles (`admin` / `system_admin`).
- **routes**: `/connect/*` switch from `secrets.read` → `connect.read`.
- **main**: reconcile wired into `initializeCoreService`.
- **docs**: ADR-044; ADR-043 + CONFIGURATION updated.

## Behavior change (intentional)

A non-admin that used Connect via `secrets.read` now needs `connect.read`. Admins are unaffected, and reconcile grants `connect.read` to `admin`/`system_admin` automatically on upgrade. This is the least-privilege tightening of a recently-shipped, opt-in feature.

## Security

The reconcile only **creates missing permissions** and grants **new** ones to their **baseline roles** (verified: `connect.read` → admin/system_admin, never viewers); it never alters grants for existing permissions (tested against an operator-removed grant). No-op pre-bootstrap; idempotent (no duplicate grants on re-run). I'll run the security-review skill on this diff.

## Tests

reconcile adds a new permission to baseline roles only, doesn't clobber an operator-removed grant, no-ops on fresh install, idempotent. gofmt / golangci-lint / gosec clean; only the documented local-only `TestEveryMutatingRouteDeniesReadOnly` fails locally (green in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)