### PR TITLE
release: prep v0.41.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,30 @@
 All notable changes to Keyorix are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## v0.41.0 — 2026-06-16
+
+Least-privilege for Keyorix Connect + upgrade-safe permission seeding.
+
+### Added
+- **`connect.read` permission** — Keyorix Connect now has its own permission instead
+  of reusing `secrets.read`, so granting native secret-read access no longer implies
+  read access to external stores (ADR-044). It ships granted to `admin` /
+  `system_admin`. ([#249])
+- **Idempotent RBAC permission reconciliation on startup** — new canonical
+  permissions added in a release are now seeded into already-initialised installs
+  automatically (created and granted to their baseline roles), so an upgrade no longer
+  leaves a new permission unheld by any role. Additive and **non-clobbering**:
+  existing permissions' grants are never altered, preserving operator customizations;
+  a no-op on a pre-bootstrap install. ([#249])
+
+### Changed
+- The Keyorix Connect routes (`/connect/*`) now require `connect.read` instead of
+  `secrets.read`. **Upgrade note:** a non-admin principal that used Connect via
+  `secrets.read` must be granted `connect.read`; admins/`system_admin` receive it
+  automatically on first start after upgrade. ([#249])
+
+[#249]: https://github.com/keyorixhq/keyorix/pull/249
+
 ## v0.40.0 — 2026-06-16
 
 Keyorix Connect adds HashiCorp Vault.

--- a/deploy/helm/keyorix/Chart.yaml
+++ b/deploy/helm/keyorix/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix
 description: Self-hosted Keyorix secrets manager (API server + web UI + PostgreSQL)
 type: application
 # Chart version — bump on chart changes.
-version: 0.40.0
+version: 0.41.0
 # The Keyorix app version this chart deploys by default (the image tag).
-appVersion: "0.40.0"
+appVersion: "0.41.0"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix


### PR DESCRIPTION
Release prep for **v0.41.0** — `connect.read` permission + idempotent RBAC permission reconciliation (#249).

⚠️ Upgrade note: `/connect/*` now requires `connect.read`; admins/`system_admin` get it automatically on first start after upgrade (a non-admin that used Connect via `secrets.read` must be granted it).

- CHANGELOG: v0.41.0 section.
- Helm chart: version + appVersion → 0.41.0.

Merge → tag `v0.41.0` → release + docker-publish pipelines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)