### PR TITLE
feat(connect): Azure Key Vault read-through connector (ADR-043)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -933,7 +933,7 @@ connect:
   enabled: true
   connectors:
     - name: prod-aws            # API path key (unique); GET /api/v1/connect/prod-aws/secret?ref=…
-      type: aws-secrets-manager # aws-secrets-manager | gcp-secret-manager | vault
+      type: aws-secrets-manager # aws-secrets-manager | gcp-secret-manager | azure-key-vault | vault
       region: eu-west-1         # AWS region (aws-secrets-manager)
       allowed_refs:             # optional prefix allowlist — a ref must match one
         - keyorix/              # (defense-in-depth on top of the backend's IAM scope)
@@ -941,6 +941,11 @@ connect:
       type: gcp-secret-manager  # ref is the version resource name (creds from ADC)
       allowed_refs:
         - projects/my-proj/secrets/keyorix-
+    - name: prod-azure
+      type: azure-key-vault     # ref is the secret name (or name/version); creds from DefaultAzureCredential
+      address: https://myvault.vault.azure.net/   # the Key Vault URL
+      allowed_refs:
+        - keyorix-
     - name: prod-vault
       type: vault               # ref is the read path; KV v2 is unwrapped
       address: https://vault.example.com:8200
@@ -956,12 +961,15 @@ connect:
 - `ref` (query parameter) is connector-specific — for **AWS Secrets Manager** it is
   the secret **name or ARN** (a binary secret is returned base64-encoded); for **GCP
   Secret Manager** it is the **version resource name**
-  (`projects/P/secrets/NAME/versions/latest`); for **Vault** it is the **read path**
+  (`projects/P/secrets/NAME/versions/latest`); for **Azure Key Vault** it is the
+  **secret name** (optionally `name/version`; a bare name reads the current version)
+  within the connector's `address` vault; for **Vault** it is the **read path**
   (e.g. `secret/data/myapp` for KV v2, whose inner `data` map is returned). GCP
-  credentials come from ADC / workload identity; the Vault token comes from `token_env`.
+  credentials come from ADC / workload identity; Azure from `DefaultAzureCredential`
+  (managed/workload identity / env / CLI); the Vault token comes from `token_env`.
 - Backend credentials come from the **ambient identity chain** (AWS: env /
-  instance-profile / IRSA; GCP: ADC; Vault: `token_env`), never from this config. A
-  backend failure surfaces as `502 Bad Gateway`.
+  instance-profile / IRSA; GCP: ADC; Azure: `DefaultAzureCredential`; Vault:
+  `token_env`), never from this config. A backend failure surfaces as `502 Bad Gateway`.
 - A federated read is bounded by **two** controls: the backend identity's IAM policy
   (the load-bearing one — scope the connector's credentials to exactly the intended
   secrets) and, optionally, the per-connector **`allowed_refs`** prefix allowlist

--- a/docs/adr-043-secret-store-federation.md
+++ b/docs/adr-043-secret-store-federation.md
@@ -2,9 +2,10 @@
 
 ## Status
 
-Accepted — AWS Secrets Manager, GCP Secret Manager, and HashiCorp Vault
-read-through shipped. Caching, a dedicated `connect.read` permission, and finer
-per-reference scoping are planned follow-ups.
+Accepted — AWS Secrets Manager, GCP Secret Manager, Azure Key Vault, and
+HashiCorp Vault read-through shipped, over HTTP and gRPC, gated by the dedicated
+`connect.read` permission (ADR-044). Caching and finer per-reference scoping are
+planned follow-ups.
 
 ## Context
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -110,7 +110,9 @@ type ConnectorConfig struct {
 	Name   string `yaml:"name"`
 	Type   string `yaml:"type"`
 	Region string `yaml:"region"`
-	// Address is the backend base URL for type "vault" (e.g. https://vault:8200).
+	// Address is the backend base URL: the Vault server for type "vault"
+	// (e.g. https://vault:8200), or the Key Vault URL for type "azure-key-vault"
+	// (e.g. https://myvault.vault.azure.net/).
 	Address string `yaml:"address"`
 	// TokenEnv names the environment variable holding the backend token for type
 	// "vault" (default "VAULT_TOKEN"). The token is read from the environment, never

--- a/internal/connect/azurekv.go
+++ b/internal/connect/azurekv.go
@@ -1,0 +1,88 @@
+// azurekv.go — the Azure Key Vault read-through connector. GetSecret resolves a
+// reference (the secret name, optionally "name/version") within the connector's vault
+// to its current value via the Key Vault data-plane GetSecret. The vault URL is the
+// connector's configured address; credentials come from the ambient Azure identity
+// chain (managed identity / workload identity / env / CLI) via DefaultAzureCredential
+// — never from Keyorix config — mirroring the Azure KMS integration.
+package connect
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets"
+)
+
+// azKVGetAPI is the slice of the Key Vault secrets client the connector uses — an
+// interface seam so it is unit-tested with a fake and the SDK stays contained here.
+type azKVGetAPI interface {
+	GetSecret(ctx context.Context, name, version string, options *azsecrets.GetSecretOptions) (azsecrets.GetSecretResponse, error)
+}
+
+// AzureKeyVaultConnector reads secrets from an Azure Key Vault.
+type AzureKeyVaultConnector struct {
+	name        string
+	vaultURL    string
+	allowedRefs []string
+	// newClient builds a Key Vault client for vaultURL; nil uses the real client with
+	// DefaultAzureCredential. Tests inject a fake.
+	newClient func(ctx context.Context) (azKVGetAPI, error)
+}
+
+// NewAzureKeyVaultConnector builds an Azure Key Vault connector. vaultURL is the vault
+// base URL (e.g. https://myvault.vault.azure.net/). allowedRefs, when non-empty,
+// restricts readable references to those with one of the given prefixes (a guardrail
+// on top of the ambient identity's RBAC/access-policy scope).
+func NewAzureKeyVaultConnector(name, vaultURL string, allowedRefs []string) *AzureKeyVaultConnector {
+	return &AzureKeyVaultConnector{name: name, vaultURL: vaultURL, allowedRefs: allowedRefs}
+}
+
+func (c *AzureKeyVaultConnector) Name() string { return c.name }
+func (c *AzureKeyVaultConnector) Type() string { return "azure-key-vault" }
+
+func (c *AzureKeyVaultConnector) client(ctx context.Context) (azKVGetAPI, error) {
+	if c.newClient != nil {
+		return c.newClient(ctx)
+	}
+	cred, err := azidentity.NewDefaultAzureCredential(nil)
+	if err != nil {
+		return nil, fmt.Errorf("azure-key-vault: default credential: %w", err)
+	}
+	cl, err := azsecrets.NewClient(c.vaultURL, cred, nil)
+	if err != nil {
+		return nil, fmt.Errorf("azure-key-vault: new client: %w", err)
+	}
+	return cl, nil
+}
+
+func (c *AzureKeyVaultConnector) GetSecret(ctx context.Context, ref string) (string, error) {
+	if ref == "" {
+		return "", fmt.Errorf("azure-key-vault: secret reference is required (the secret name, optionally name/version)")
+	}
+	if c.vaultURL == "" {
+		return "", fmt.Errorf("azure-key-vault: connector %q has no vault address configured", c.name)
+	}
+	if !prefixAllowed(c.allowedRefs, ref) {
+		return "", fmt.Errorf("azure-key-vault: ref %q is not permitted by this connector's allowed_refs", ref)
+	}
+	// ref is "name" (latest) or "name/version"; version "" means the current version.
+	name, version, _ := strings.Cut(ref, "/")
+	if name == "" {
+		return "", fmt.Errorf("azure-key-vault: ref %q has an empty secret name", ref)
+	}
+
+	cl, err := c.client(ctx)
+	if err != nil {
+		return "", err
+	}
+	out, err := cl.GetSecret(ctx, name, version, nil)
+	if err != nil {
+		return "", fmt.Errorf("azure-key-vault: get %q: %w", ref, err)
+	}
+	if out.Value == nil {
+		return "", fmt.Errorf("azure-key-vault: secret %q has no value", ref)
+	}
+	return *out.Value, nil
+}

--- a/internal/connect/azurekv_test.go
+++ b/internal/connect/azurekv_test.go
@@ -1,0 +1,96 @@
+package connect
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeAzKV is an injected stand-in for the Azure Key Vault secrets client.
+type fakeAzKV struct {
+	value      *string
+	err        error
+	gotName    string
+	gotVersion string
+	called     bool
+}
+
+func (f *fakeAzKV) GetSecret(_ context.Context, name, version string, _ *azsecrets.GetSecretOptions) (azsecrets.GetSecretResponse, error) {
+	f.called = true
+	f.gotName, f.gotVersion = name, version
+	if f.err != nil {
+		return azsecrets.GetSecretResponse{}, f.err
+	}
+	return azsecrets.GetSecretResponse{Secret: azsecrets.Secret{Value: f.value}}, nil
+}
+
+func azKVConnectorWith(name, vaultURL string, fake *fakeAzKV, allowed ...string) *AzureKeyVaultConnector {
+	c := NewAzureKeyVaultConnector(name, vaultURL, allowed)
+	c.newClient = func(_ context.Context) (azKVGetAPI, error) { return fake, nil }
+	return c
+}
+
+func strptr(s string) *string { return &s }
+
+func TestAzureKV_TypeAndName(t *testing.T) {
+	c := NewAzureKeyVaultConnector("prod-az", "https://v.vault.azure.net/", nil)
+	assert.Equal(t, "prod-az", c.Name())
+	assert.Equal(t, "azure-key-vault", c.Type())
+}
+
+func TestAzureKV_GetSecret_Latest(t *testing.T) {
+	fake := &fakeAzKV{value: strptr("az-s3cr3t")}
+	val, err := azKVConnectorWith("az", "https://v.vault.azure.net/", fake).GetSecret(context.Background(), "db-password")
+	require.NoError(t, err)
+	assert.Equal(t, "az-s3cr3t", val)
+	assert.Equal(t, "db-password", fake.gotName)
+	assert.Equal(t, "", fake.gotVersion, "a bare name reads the current version")
+}
+
+func TestAzureKV_GetSecret_PinnedVersion(t *testing.T) {
+	fake := &fakeAzKV{value: strptr("v2")}
+	val, err := azKVConnectorWith("az", "https://v.vault.azure.net/", fake).GetSecret(context.Background(), "db-password/abc123")
+	require.NoError(t, err)
+	assert.Equal(t, "v2", val)
+	assert.Equal(t, "db-password", fake.gotName)
+	assert.Equal(t, "abc123", fake.gotVersion, "name/version pins the version")
+}
+
+func TestAzureKV_GetSecret_Errors(t *testing.T) {
+	t.Run("empty ref", func(t *testing.T) {
+		_, err := azKVConnectorWith("az", "https://v.vault.azure.net/", &fakeAzKV{}).GetSecret(context.Background(), "")
+		require.Error(t, err)
+	})
+	t.Run("missing vault address", func(t *testing.T) {
+		_, err := azKVConnectorWith("az", "", &fakeAzKV{}).GetSecret(context.Background(), "x")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no vault address")
+	})
+	t.Run("empty name", func(t *testing.T) {
+		_, err := azKVConnectorWith("az", "https://v.vault.azure.net/", &fakeAzKV{}).GetSecret(context.Background(), "/v1")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "empty secret name")
+	})
+	t.Run("backend error", func(t *testing.T) {
+		_, err := azKVConnectorWith("az", "https://v.vault.azure.net/", &fakeAzKV{err: errors.New("Forbidden")}).GetSecret(context.Background(), "x")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "Forbidden")
+	})
+	t.Run("no value", func(t *testing.T) {
+		_, err := azKVConnectorWith("az", "https://v.vault.azure.net/", &fakeAzKV{value: nil}).GetSecret(context.Background(), "x")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no value")
+	})
+	t.Run("allowed_refs guardrail", func(t *testing.T) {
+		fake := &fakeAzKV{value: strptr("x")}
+		c := azKVConnectorWith("az", "https://v.vault.azure.net/", fake, "keyorix-")
+		_, err := c.GetSecret(context.Background(), "other-secret")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not permitted")
+		assert.False(t, fake.called, "a disallowed ref must not reach the backend")
+	})
+}

--- a/server/main.go
+++ b/server/main.go
@@ -374,6 +374,8 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 				connectors = append(connectors, connect.NewAWSSecretsManagerConnector(cn.Name, cn.Region, cn.AllowedRefs))
 			case "gcp-secret-manager":
 				connectors = append(connectors, connect.NewGCPSecretManagerConnector(cn.Name, cn.AllowedRefs))
+			case "azure-key-vault":
+				connectors = append(connectors, connect.NewAzureKeyVaultConnector(cn.Name, cn.Address, cn.AllowedRefs))
 			case "vault":
 				tokenEnv := cn.TokenEnv
 				if tokenEnv == "" {


### PR DESCRIPTION
Completes the cloud secret-store set behind **Keyorix Connect** — **AWS SM / GCP SM / Azure KV / Vault** — mirroring the proven fake-able-seam pattern of the GCP (#244) and Vault (#247) connectors.

## Changes
- **`AzureKeyVaultConnector`** behind an `azKVGetAPI` interface seam (the `azsecrets` SDK stays contained and is unit-tested with a fake). `ref` is the secret **name**, optionally `name/version` (a bare name reads the current version); the vault URL comes from the connector's `address`.
- **Credentials** come from `DefaultAzureCredential` (managed/workload identity / env / CLI) — never from Keyorix config, mirroring the Azure KMS integration.
- Shared **`allowed_refs`** prefix guardrail enforced before the backend call; value never logged; backend failure surfaces as `502` via the existing handler.
- **No new dependency** — `azsecrets v1.5.0` is already vendored for `azure-kms`.
- `main`: `case "azure-key-vault"` wired into the connector switch; config `Address` doc extended; ADR-043 + CONFIGURATION updated.

## Security model
Same read-only / `connect.read`-gated / audited path as the other backends (covered by the #243 review) — no separate heavyweight review.

## Tests
Fake-Azure: latest read, pinned version, empty ref, missing address, empty name, backend error, no value, `allowed_refs` guardrail. gofmt / build / test / gosec / golangci-lint / gitleaks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)