### PR TITLE
feat(connect): per-reference RBAC grants (ADR-045)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -970,8 +970,19 @@ connect:
 - Backend credentials come from the **ambient identity chain** (AWS: env /
   instance-profile / IRSA; GCP: ADC; Azure: `DefaultAzureCredential`; Vault:
   `token_env`), never from this config. A backend failure surfaces as `502 Bad Gateway`.
-- A federated read is bounded by **two** controls: the backend identity's IAM policy
-  (the load-bearing one — scope the connector's credentials to exactly the intended
-  secrets) and, optionally, the per-connector **`allowed_refs`** prefix allowlist
-  enforced in Keyorix before the backend call. Set both: any holder of global
-  `secrets.read` can otherwise read every secret the connector's identity can reach.
+- A federated read is bounded by up to **three** controls: the backend identity's IAM
+  policy (the load-bearing one — scope the connector's credentials to exactly the
+  intended secrets); optionally the per-connector **`allowed_refs`** prefix allowlist
+  enforced in Keyorix before the backend call; and optionally **per-reference RBAC
+  grants** (ADR-045) — a `(role, connector, ref_prefix)` allowlist. Set the IAM policy
+  for sure: any holder of `connect.read` can otherwise read every secret the
+  connector's identity can reach.
+- **Per-reference RBAC (ADR-045)** scopes *which roles* may read *which refs* on a
+  connector. It is opt-in per connector: a connector with **no** grants behaves as
+  before (governed by `connect.read` + `allowed_refs`), but once a connector has any
+  grant it is **deny-by-default** — only a caller holding a role with a matching
+  ref-prefix grant may read, and a denied read is audited. Manage grants at
+  `GET /api/v1/connect/ref-grants` (`roles.read`), `POST /api/v1/connect/ref-grants`
+  and `DELETE /api/v1/connect/ref-grants/{id}` (`roles.write`). To keep an admin role's
+  blanket access while scoping others, give it an **empty-prefix** grant (matches every
+  ref) on the connector.

--- a/docs/adr-043-secret-store-federation.md
+++ b/docs/adr-043-secret-store-federation.md
@@ -4,8 +4,8 @@
 
 Accepted — AWS Secrets Manager, GCP Secret Manager, Azure Key Vault, and
 HashiCorp Vault read-through shipped, over HTTP and gRPC, gated by the dedicated
-`connect.read` permission (ADR-044). Caching and finer per-reference scoping are
-planned follow-ups.
+`connect.read` permission (ADR-044) with optional per-reference RBAC scoping
+(ADR-045). Caching remains a planned follow-up.
 
 ## Context
 

--- a/docs/adr-045-connect-per-reference-rbac.md
+++ b/docs/adr-045-connect-per-reference-rbac.md
@@ -1,0 +1,81 @@
+# ADR-045: Per-reference RBAC for Keyorix Connect
+
+## Status
+
+Accepted.
+
+## Context
+
+Keyorix Connect (ADR-043) proxies authorized, audited read-through to external secret
+stores. Until now a federated read was bounded by exactly two controls:
+
+1. the global **`connect.read`** permission (ADR-044) — a caller either may use Connect
+   or may not; and
+2. the operator-configured per-connector **`allowed_refs`** prefix allowlist — a
+   *uniform* bound that applies identically to every caller.
+
+There was no way to say "role A may read `metrics/*` from this connector, but only
+role B may read `db/*`." Any holder of `connect.read` could read every reference the
+connector's backend identity (and `allowed_refs`) permitted — too coarse for a
+deployment where different teams share one connector but should see different secrets.
+
+## Decision
+
+Add **per-reference grants**: a `(role, connector, ref_prefix)` allowlist that refines
+`connect.read`, enforced in `ReadFederatedSecret` before the backend call.
+
+- A grant authorizes any `ref` whose value begins with `ref_prefix` (an empty prefix =
+  all refs on that connector) for holders of the role.
+- Enforcement is **deny-by-default, but only for connectors that have at least one
+  grant**:
+  - a connector with **no** grants is governed exactly as before — `connect.read` plus
+    `allowed_refs` (fully backward compatible, opt-in);
+  - once a connector has **any** grant, a read is permitted only if one of the caller's
+    roles holds a matching grant. A principal whose roles do not match — including one
+    with no resolvable roles — is denied.
+- A caller holding several roles is allowed if **any** of them matches (union).
+- Denied reads are audited as `connect.secret_read` with a `DENIED by per-reference
+  policy` description, so an attempted out-of-scope read is visible.
+
+Grants are managed over HTTP: `GET /connect/ref-grants` (gated `roles.read`),
+`POST /connect/ref-grants` and `DELETE /connect/ref-grants/{id}` (gated `roles.write`)
+— they are role-authorization configuration, so they reuse the role-management
+permissions rather than `connect.read`. Create/delete are audited
+(`connect.ref_grant_create` / `connect.ref_grant_delete`). A grant for an unknown
+(typo'd) connector is rejected, so an operator cannot believe they scoped a connector
+that is in fact still unscoped.
+
+Enforcement lives in the core layer (`ReadFederatedSecret`), so it protects **every**
+transport uniformly — HTTP and the gRPC `ConnectService` alike.
+
+## The deny-by-default footgun (documented)
+
+Defining the first grant on a connector flips it to deny-by-default: roles without a
+matching grant immediately lose access to it. This is the point of the feature, but it
+can surprise an operator who expected admins to retain blanket access. To keep an admin
+role's broad access while scoping others, grant that role an **empty-prefix** grant on
+the connector (which matches every ref). This is explicit and auditable rather than an
+implicit admin bypass.
+
+## Alternatives considered
+
+- **Glob / regex ref patterns** instead of prefixes: more expressive but inconsistent
+  with the existing `allowed_refs` prefix semantics and harder to reason about for
+  least-privilege. Prefix matching covers the hierarchical-path naming every supported
+  backend uses; revisit if a real need for mid-path wildcards appears.
+- **User-scoped (not role-scoped) grants**: rejected — Keyorix authorization is
+  role-based throughout; per-user grants would fork the model and not compose with
+  groups.
+- **An implicit admin bypass** (a privileged permission that ignores ref-grants):
+  rejected — it would reintroduce the coarse "sees everything" behavior the feature
+  exists to remove. An explicit empty-prefix grant expresses the same intent visibly.
+
+## Consequences
+
+- Connect access can now be scoped per team without splitting one external store into
+  many connectors.
+- Backward compatible: existing deployments (no grants) are unaffected; the policy is
+  opt-in per connector.
+- Out of scope here (possible follow-ups): gRPC/CLI/web management surfaces for grants
+  (enforcement already covers all read transports); group-scoped grants;
+  caching (still cautioned for stale-secret reasons).

--- a/docs/adr-045-connect-per-reference-rbac.md
+++ b/docs/adr-045-connect-per-reference-rbac.md
@@ -46,7 +46,10 @@ permissions rather than `connect.read`. Create/delete are audited
 that is in fact still unscoped.
 
 Enforcement lives in the core layer (`ReadFederatedSecret`), so it protects **every**
-transport uniformly — HTTP and the gRPC `ConnectService` alike.
+transport uniformly — HTTP and the gRPC `ConnectService` alike. The caller's roles are
+resolved from the correct identity store for the actor kind — `user_roles` for users,
+`machine_identity_roles` for machine identities — so the policy is enforceable for both
+human and machine principals (at global scope, since Connect is a global surface).
 
 ## The deny-by-default footgun (documented)
 

--- a/internal/core/connect.go
+++ b/internal/core/connect.go
@@ -42,9 +42,11 @@ func (c *KeyorixCore) ConnectConnectorNames() []string {
 }
 
 // ReadFederatedSecret proxies a read of ref from the named external-store connector
-// and audits it. The caller (HTTP layer) must have already enforced RBAC. The value
-// is returned to the caller and never persisted.
-func (c *KeyorixCore) ReadFederatedSecret(ctx context.Context, actorID uint, connectorName, ref string) (string, error) {
+// and audits it. The caller (transport layer) must have already enforced the global
+// connect.read permission; actorType ("user" / "machine_identity") and principalID
+// identify the caller for per-reference RBAC (ADR-045). The value is returned to the
+// caller and never persisted.
+func (c *KeyorixCore) ReadFederatedSecret(ctx context.Context, actorType string, principalID uint, connectorName, ref string) (string, error) {
 	if c.connectManager == nil {
 		return "", fmt.Errorf("keyorix connect is not enabled")
 	}
@@ -52,12 +54,12 @@ func (c *KeyorixCore) ReadFederatedSecret(ctx context.Context, actorID uint, con
 	if !ok {
 		return "", fmt.Errorf("unknown connector %q", connectorName)
 	}
-	uid := actorID
+	uid := principalID
 
 	// Per-reference RBAC (ADR-045): once a connector has any ref-grant, the read is
 	// permitted only if one of the caller's roles holds a matching grant. A connector
 	// with no grants is governed solely by connect.read + allowed_refs (unchanged).
-	allowed, err := c.connectRefAllowed(ctx, actorID, connectorName, ref)
+	allowed, err := c.connectRefAllowed(ctx, actorType, principalID, connectorName, ref)
 	if err != nil {
 		return "", err
 	}
@@ -128,7 +130,7 @@ func (c *KeyorixCore) DeleteConnectRefGrant(ctx context.Context, actorID, id uin
 // prefix of ref. Otherwise the read is denied — deny-by-default once a connector is
 // scoped, so a principal whose roles do not match (including one with no resolvable
 // roles) cannot read from a grant-scoped connector.
-func (c *KeyorixCore) connectRefAllowed(ctx context.Context, actorID uint, connectorName, ref string) (bool, error) {
+func (c *KeyorixCore) connectRefAllowed(ctx context.Context, actorType string, principalID uint, connectorName, ref string) (bool, error) {
 	grants, err := c.storage.ListConnectRefGrantsByConnector(ctx, connectorName)
 	if err != nil {
 		return false, fmt.Errorf("connect ref-grant lookup: %w", err)
@@ -136,13 +138,9 @@ func (c *KeyorixCore) connectRefAllowed(ctx context.Context, actorID uint, conne
 	if len(grants) == 0 {
 		return true, nil // no per-ref policy for this connector
 	}
-	roles, err := c.GetUserRolesByID(ctx, actorID)
+	roleSet, err := c.actorRoleIDs(ctx, actorType, principalID)
 	if err != nil {
-		return false, fmt.Errorf("connect ref-grant: load actor roles: %w", err)
-	}
-	roleSet := make(map[uint]bool, len(roles))
-	for _, r := range roles {
-		roleSet[r.ID] = true
+		return false, err
 	}
 	for _, g := range grants {
 		if roleSet[g.RoleID] && strings.HasPrefix(ref, g.RefPrefix) {
@@ -150,4 +148,30 @@ func (c *KeyorixCore) connectRefAllowed(ctx context.Context, actorID uint, conne
 		}
 	}
 	return false, nil
+}
+
+// actorRoleIDs resolves the caller's role IDs from the correct identity store for the
+// actor kind — machine identities hold roles in machine_identity_roles, users in
+// user_roles — so the per-reference policy is enforceable for both. Connect is a
+// global surface, so roles are resolved at global scope.
+func (c *KeyorixCore) actorRoleIDs(ctx context.Context, actorType string, principalID uint) (map[uint]bool, error) {
+	set := map[uint]bool{}
+	if actorType == ActorTypeMachine {
+		ids, err := c.storage.GetMachineRoleIDsAt(ctx, principalID, Scope{})
+		if err != nil {
+			return nil, fmt.Errorf("connect ref-grant: load machine roles: %w", err)
+		}
+		for _, id := range ids {
+			set[id] = true
+		}
+		return set, nil
+	}
+	roles, err := c.GetUserRolesByID(ctx, principalID)
+	if err != nil {
+		return nil, fmt.Errorf("connect ref-grant: load actor roles: %w", err)
+	}
+	for _, r := range roles {
+		set[r.ID] = true
+	}
+	return set, nil
 }

--- a/internal/core/connect.go
+++ b/internal/core/connect.go
@@ -6,13 +6,21 @@ package core
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/keyorixhq/keyorix/internal/connect"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
 // EventConnectSecretRead is audited on every federated read (success or failure is
 // distinguished by the description).
 const EventConnectSecretRead = "connect.secret_read"
+
+// Per-reference grant management events (ADR-045).
+const (
+	EventConnectRefGrantCreate = "connect.ref_grant_create"
+	EventConnectRefGrantDelete = "connect.ref_grant_delete"
+)
 
 // SetConnectManager wires the configured external-store connectors (ADR-043). nil
 // (the default) leaves Keyorix Connect disabled.
@@ -45,6 +53,20 @@ func (c *KeyorixCore) ReadFederatedSecret(ctx context.Context, actorID uint, con
 		return "", fmt.Errorf("unknown connector %q", connectorName)
 	}
 	uid := actorID
+
+	// Per-reference RBAC (ADR-045): once a connector has any ref-grant, the read is
+	// permitted only if one of the caller's roles holds a matching grant. A connector
+	// with no grants is governed solely by connect.read + allowed_refs (unchanged).
+	allowed, err := c.connectRefAllowed(ctx, actorID, connectorName, ref)
+	if err != nil {
+		return "", err
+	}
+	if !allowed {
+		c.writeAuditEvent(ctx, EventConnectSecretRead, &uid, nil,
+			fmt.Sprintf("federated read DENIED by per-reference policy: connector %q (%s) ref %q", connectorName, conn.Type(), ref))
+		return "", fmt.Errorf("ref %q is not permitted for your roles on connector %q", ref, connectorName)
+	}
+
 	value, err := conn.GetSecret(ctx, ref)
 	if err != nil {
 		c.writeAuditEvent(ctx, EventConnectSecretRead, &uid, nil,
@@ -54,4 +76,78 @@ func (c *KeyorixCore) ReadFederatedSecret(ctx context.Context, actorID uint, con
 	c.writeAuditEvent(ctx, EventConnectSecretRead, &uid, nil,
 		fmt.Sprintf("federated read via connector %q (%s) ref %q", connectorName, conn.Type(), ref))
 	return value, nil
+}
+
+// ListConnectRefGrants returns every per-reference grant (ADR-045), for management.
+func (c *KeyorixCore) ListConnectRefGrants(ctx context.Context) ([]*models.ConnectRefGrant, error) {
+	return c.storage.ListConnectRefGrants(ctx)
+}
+
+// CreateConnectRefGrant adds a per-reference grant (ADR-045): role roleID may read any
+// ref under refPrefix ("" = all) on connectorName. The connector must be configured —
+// scoping a non-existent (typo'd) connector is rejected so an operator can't believe
+// they restricted a connector that is in fact still unscoped. Audited.
+func (c *KeyorixCore) CreateConnectRefGrant(ctx context.Context, actorID, roleID uint, connectorName, refPrefix string) (*models.ConnectRefGrant, error) {
+	if c.connectManager == nil {
+		return nil, fmt.Errorf("keyorix connect is not enabled")
+	}
+	if _, ok := c.connectManager.Get(connectorName); !ok {
+		return nil, fmt.Errorf("unknown connector %q", connectorName)
+	}
+	if roleID == 0 {
+		return nil, fmt.Errorf("a role is required for a connect ref-grant")
+	}
+	g, err := c.storage.CreateConnectRefGrant(ctx, &models.ConnectRefGrant{
+		RoleID:    roleID,
+		Connector: connectorName,
+		RefPrefix: refPrefix,
+	})
+	if err != nil {
+		return nil, err
+	}
+	uid := actorID
+	c.writeAuditEvent(ctx, EventConnectRefGrantCreate, &uid, nil,
+		fmt.Sprintf("connect ref-grant: role %d may read ref-prefix %q on connector %q", roleID, refPrefix, connectorName))
+	return g, nil
+}
+
+// DeleteConnectRefGrant removes a per-reference grant by id. Audited.
+func (c *KeyorixCore) DeleteConnectRefGrant(ctx context.Context, actorID, id uint) error {
+	if err := c.storage.DeleteConnectRefGrant(ctx, id); err != nil {
+		return err
+	}
+	uid := actorID
+	c.writeAuditEvent(ctx, EventConnectRefGrantDelete, &uid, nil,
+		fmt.Sprintf("connect ref-grant %d deleted", id))
+	return nil
+}
+
+// connectRefAllowed applies the per-reference RBAC policy (ADR-045) for a federated
+// read. It returns true when the connector has no ref-grants (the policy is opt-in,
+// per connector), or when one of the caller's roles holds a grant whose RefPrefix is a
+// prefix of ref. Otherwise the read is denied — deny-by-default once a connector is
+// scoped, so a principal whose roles do not match (including one with no resolvable
+// roles) cannot read from a grant-scoped connector.
+func (c *KeyorixCore) connectRefAllowed(ctx context.Context, actorID uint, connectorName, ref string) (bool, error) {
+	grants, err := c.storage.ListConnectRefGrantsByConnector(ctx, connectorName)
+	if err != nil {
+		return false, fmt.Errorf("connect ref-grant lookup: %w", err)
+	}
+	if len(grants) == 0 {
+		return true, nil // no per-ref policy for this connector
+	}
+	roles, err := c.GetUserRolesByID(ctx, actorID)
+	if err != nil {
+		return false, fmt.Errorf("connect ref-grant: load actor roles: %w", err)
+	}
+	roleSet := make(map[uint]bool, len(roles))
+	for _, r := range roles {
+		roleSet[r.ID] = true
+	}
+	for _, g := range grants {
+		if roleSet[g.RoleID] && strings.HasPrefix(ref, g.RefPrefix) {
+			return true, nil
+		}
+	}
+	return false, nil
 }

--- a/internal/core/connect_rbac_test.go
+++ b/internal/core/connect_rbac_test.go
@@ -1,0 +1,144 @@
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/connect"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// connectRBACCore builds a core backed by a real (in-memory) store so per-reference
+// grants and role assignments actually resolve through the enforcement path.
+func connectRBACCore(t *testing.T, conns ...connect.Connector) (*KeyorixCore, *gorm.DB) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.Role{}, &models.UserRole{}, &models.ConnectRefGrant{}, &models.AuditEvent{}))
+	c := &KeyorixCore{storage: store.NewLocalStorage(db)}
+	if len(conns) > 0 {
+		c.SetConnectManager(connect.NewManager(conns))
+	}
+	return c, db
+}
+
+func seedRoleForUser(t *testing.T, db *gorm.DB, userID, roleID uint, name string) {
+	t.Helper()
+	require.NoError(t, db.Create(&models.Role{ID: roleID, Name: name}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: userID, RoleID: roleID}).Error)
+}
+
+func seedGrant(t *testing.T, c *KeyorixCore, roleID uint, connector, prefix string) {
+	t.Helper()
+	_, err := c.storage.CreateConnectRefGrant(context.Background(), &models.ConnectRefGrant{RoleID: roleID, Connector: connector, RefPrefix: prefix})
+	require.NoError(t, err)
+}
+
+// With no grants on a connector, behavior is unchanged — connect.read + allowed_refs
+// govern, and the read goes through (backward compatible).
+func TestConnectRefRBAC_NoGrantsAllows(t *testing.T) {
+	c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v"})
+	seedRoleForUser(t, db, 1, 5, "reader")
+	val, err := c.ReadFederatedSecret(context.Background(), 1, "aws", "anything/at/all")
+	require.NoError(t, err)
+	assert.Equal(t, "v", val)
+}
+
+// Once a connector has a grant, a ref under a granted prefix held by one of the
+// caller's roles is allowed; a ref outside every granted prefix is denied.
+func TestConnectRefRBAC_PrefixScopes(t *testing.T) {
+	c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v"})
+	seedRoleForUser(t, db, 1, 5, "metrics-reader")
+	seedGrant(t, c, 5, "aws", "metrics/")
+
+	val, err := c.ReadFederatedSecret(context.Background(), 1, "aws", "metrics/qps")
+	require.NoError(t, err)
+	assert.Equal(t, "v", val)
+
+	_, err = c.ReadFederatedSecret(context.Background(), 1, "aws", "db/password")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not permitted")
+}
+
+// A grant for a role the caller does NOT hold does not authorize them (deny-by-default
+// once the connector is scoped).
+func TestConnectRefRBAC_RoleMismatchDenied(t *testing.T) {
+	c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v"})
+	seedRoleForUser(t, db, 1, 5, "reader")
+	seedGrant(t, c, 9, "aws", "metrics/") // granted to role 9, not the user's role 5
+
+	_, err := c.ReadFederatedSecret(context.Background(), 1, "aws", "metrics/qps")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not permitted")
+}
+
+// An empty-prefix grant authorizes every ref on the connector for that role.
+func TestConnectRefRBAC_EmptyPrefixAllowsAll(t *testing.T) {
+	c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v"})
+	seedRoleForUser(t, db, 1, 5, "broad-reader")
+	seedGrant(t, c, 5, "aws", "")
+
+	for _, ref := range []string{"metrics/x", "db/y", "anything"} {
+		val, err := c.ReadFederatedSecret(context.Background(), 1, "aws", ref)
+		require.NoError(t, err, ref)
+		assert.Equal(t, "v", val)
+	}
+}
+
+// Grants on one connector do not constrain a different connector that has none.
+func TestConnectRefRBAC_OtherConnectorUnaffected(t *testing.T) {
+	c, db := connectRBACCore(t,
+		fakeConnector{name: "aws", val: "a"},
+		fakeConnector{name: "gcp", val: "g"},
+	)
+	seedRoleForUser(t, db, 1, 5, "reader")
+	seedGrant(t, c, 5, "aws", "metrics/") // scopes aws only
+
+	// gcp has no grants → unaffected.
+	val, err := c.ReadFederatedSecret(context.Background(), 1, "gcp", "projects/p/secrets/x/versions/latest")
+	require.NoError(t, err)
+	assert.Equal(t, "g", val)
+
+	// aws is scoped → a non-matching ref is denied.
+	_, err = c.ReadFederatedSecret(context.Background(), 1, "aws", "db/x")
+	require.Error(t, err)
+}
+
+// A caller holding multiple roles is allowed if ANY of them has a matching grant.
+func TestConnectRefRBAC_MultiRoleUnion(t *testing.T) {
+	c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v"})
+	require.NoError(t, db.Create(&models.Role{ID: 5, Name: "metrics"}).Error)
+	require.NoError(t, db.Create(&models.Role{ID: 6, Name: "db"}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 5}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 6}).Error)
+	seedGrant(t, c, 6, "aws", "db/") // only the db role grants db/
+
+	val, err := c.ReadFederatedSecret(context.Background(), 1, "aws", "db/password")
+	require.NoError(t, err)
+	assert.Equal(t, "v", val)
+}
+
+func TestConnectRefAllowed_Direct(t *testing.T) {
+	c, db := connectRBACCore(t)
+	seedRoleForUser(t, db, 1, 5, "reader")
+	seedGrant(t, c, 5, "aws", "metrics/")
+	ctx := context.Background()
+
+	ok, err := c.connectRefAllowed(ctx, 1, "aws", "metrics/foo")
+	require.NoError(t, err)
+	assert.True(t, ok)
+
+	ok, err = c.connectRefAllowed(ctx, 1, "aws", "secrets/foo")
+	require.NoError(t, err)
+	assert.False(t, ok)
+
+	// A connector with no grants is unconstrained.
+	ok, err = c.connectRefAllowed(ctx, 1, "vault", "secret/data/x")
+	require.NoError(t, err)
+	assert.True(t, ok)
+}

--- a/internal/core/connect_rbac_test.go
+++ b/internal/core/connect_rbac_test.go
@@ -19,7 +19,7 @@ func connectRBACCore(t *testing.T, conns ...connect.Connector) (*KeyorixCore, *g
 	t.Helper()
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
-	require.NoError(t, db.AutoMigrate(&models.Role{}, &models.UserRole{}, &models.ConnectRefGrant{}, &models.AuditEvent{}))
+	require.NoError(t, db.AutoMigrate(&models.Role{}, &models.UserRole{}, &models.MachineIdentityRole{}, &models.ConnectRefGrant{}, &models.AuditEvent{}))
 	c := &KeyorixCore{storage: store.NewLocalStorage(db)}
 	if len(conns) > 0 {
 		c.SetConnectManager(connect.NewManager(conns))
@@ -44,7 +44,7 @@ func seedGrant(t *testing.T, c *KeyorixCore, roleID uint, connector, prefix stri
 func TestConnectRefRBAC_NoGrantsAllows(t *testing.T) {
 	c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v"})
 	seedRoleForUser(t, db, 1, 5, "reader")
-	val, err := c.ReadFederatedSecret(context.Background(), 1, "aws", "anything/at/all")
+	val, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 1, "aws", "anything/at/all")
 	require.NoError(t, err)
 	assert.Equal(t, "v", val)
 }
@@ -56,11 +56,11 @@ func TestConnectRefRBAC_PrefixScopes(t *testing.T) {
 	seedRoleForUser(t, db, 1, 5, "metrics-reader")
 	seedGrant(t, c, 5, "aws", "metrics/")
 
-	val, err := c.ReadFederatedSecret(context.Background(), 1, "aws", "metrics/qps")
+	val, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 1, "aws", "metrics/qps")
 	require.NoError(t, err)
 	assert.Equal(t, "v", val)
 
-	_, err = c.ReadFederatedSecret(context.Background(), 1, "aws", "db/password")
+	_, err = c.ReadFederatedSecret(context.Background(), ActorTypeUser, 1, "aws", "db/password")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not permitted")
 }
@@ -72,7 +72,7 @@ func TestConnectRefRBAC_RoleMismatchDenied(t *testing.T) {
 	seedRoleForUser(t, db, 1, 5, "reader")
 	seedGrant(t, c, 9, "aws", "metrics/") // granted to role 9, not the user's role 5
 
-	_, err := c.ReadFederatedSecret(context.Background(), 1, "aws", "metrics/qps")
+	_, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 1, "aws", "metrics/qps")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not permitted")
 }
@@ -84,7 +84,7 @@ func TestConnectRefRBAC_EmptyPrefixAllowsAll(t *testing.T) {
 	seedGrant(t, c, 5, "aws", "")
 
 	for _, ref := range []string{"metrics/x", "db/y", "anything"} {
-		val, err := c.ReadFederatedSecret(context.Background(), 1, "aws", ref)
+		val, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 1, "aws", ref)
 		require.NoError(t, err, ref)
 		assert.Equal(t, "v", val)
 	}
@@ -100,12 +100,12 @@ func TestConnectRefRBAC_OtherConnectorUnaffected(t *testing.T) {
 	seedGrant(t, c, 5, "aws", "metrics/") // scopes aws only
 
 	// gcp has no grants → unaffected.
-	val, err := c.ReadFederatedSecret(context.Background(), 1, "gcp", "projects/p/secrets/x/versions/latest")
+	val, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 1, "gcp", "projects/p/secrets/x/versions/latest")
 	require.NoError(t, err)
 	assert.Equal(t, "g", val)
 
 	// aws is scoped → a non-matching ref is denied.
-	_, err = c.ReadFederatedSecret(context.Background(), 1, "aws", "db/x")
+	_, err = c.ReadFederatedSecret(context.Background(), ActorTypeUser, 1, "aws", "db/x")
 	require.Error(t, err)
 }
 
@@ -118,9 +118,34 @@ func TestConnectRefRBAC_MultiRoleUnion(t *testing.T) {
 	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 6}).Error)
 	seedGrant(t, c, 6, "aws", "db/") // only the db role grants db/
 
-	val, err := c.ReadFederatedSecret(context.Background(), 1, "aws", "db/password")
+	val, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 1, "aws", "db/password")
 	require.NoError(t, err)
 	assert.Equal(t, "v", val)
+}
+
+// A machine identity's grants resolve from machine_identity_roles (not user_roles), so
+// the per-reference policy is enforceable for machine principals too (ADR-045).
+func TestConnectRefRBAC_MachineIdentityRoles(t *testing.T) {
+	c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v"})
+	require.NoError(t, db.Create(&models.Role{ID: 7, Name: "ci-metrics"}).Error)
+	require.NoError(t, db.Create(&models.MachineIdentityRole{MachineIdentityID: 42, RoleID: 7}).Error)
+	seedGrant(t, c, 7, "aws", "metrics/")
+	ctx := context.Background()
+
+	// Machine 42 holds role 7, which is granted metrics/* → allowed.
+	val, err := c.ReadFederatedSecret(ctx, ActorTypeMachine, 42, "aws", "metrics/qps")
+	require.NoError(t, err)
+	assert.Equal(t, "v", val)
+
+	// Same machine, ref outside the granted prefix → denied.
+	_, err = c.ReadFederatedSecret(ctx, ActorTypeMachine, 42, "aws", "db/password")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not permitted")
+
+	// A different machine with no matching role → denied (deny-by-default).
+	_, err = c.ReadFederatedSecret(ctx, ActorTypeMachine, 99, "aws", "metrics/qps")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not permitted")
 }
 
 func TestConnectRefAllowed_Direct(t *testing.T) {
@@ -129,16 +154,16 @@ func TestConnectRefAllowed_Direct(t *testing.T) {
 	seedGrant(t, c, 5, "aws", "metrics/")
 	ctx := context.Background()
 
-	ok, err := c.connectRefAllowed(ctx, 1, "aws", "metrics/foo")
+	ok, err := c.connectRefAllowed(ctx, ActorTypeUser, 1, "aws", "metrics/foo")
 	require.NoError(t, err)
 	assert.True(t, ok)
 
-	ok, err = c.connectRefAllowed(ctx, 1, "aws", "secrets/foo")
+	ok, err = c.connectRefAllowed(ctx, ActorTypeUser, 1, "aws", "secrets/foo")
 	require.NoError(t, err)
 	assert.False(t, ok)
 
 	// A connector with no grants is unconstrained.
-	ok, err = c.connectRefAllowed(ctx, 1, "vault", "secret/data/x")
+	ok, err = c.connectRefAllowed(ctx, ActorTypeUser, 1, "vault", "secret/data/x")
 	require.NoError(t, err)
 	assert.True(t, ok)
 }

--- a/internal/core/connect_test.go
+++ b/internal/core/connect_test.go
@@ -38,7 +38,7 @@ func TestReadFederatedSecret_Success(t *testing.T) {
 	c, ms := connectTestCore(t, fakeConnector{name: "aws", val: "v3ry-secret"})
 	require.True(t, c.ConnectEnabled())
 
-	val, err := c.ReadFederatedSecret(context.Background(), 1, "aws", "prod/db")
+	val, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 1, "aws", "prod/db")
 	require.NoError(t, err)
 	assert.Equal(t, "v3ry-secret", val)
 	// The read is audited.
@@ -47,7 +47,7 @@ func TestReadFederatedSecret_Success(t *testing.T) {
 
 func TestReadFederatedSecret_UnknownConnector(t *testing.T) {
 	c, _ := connectTestCore(t, fakeConnector{name: "aws", val: "x"})
-	_, err := c.ReadFederatedSecret(context.Background(), 1, "nope", "ref")
+	_, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 1, "nope", "ref")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown connector")
 }
@@ -55,14 +55,14 @@ func TestReadFederatedSecret_UnknownConnector(t *testing.T) {
 func TestReadFederatedSecret_DisabledWhenNoManager(t *testing.T) {
 	c := &KeyorixCore{storage: new(MockStorage)}
 	assert.False(t, c.ConnectEnabled())
-	_, err := c.ReadFederatedSecret(context.Background(), 1, "aws", "ref")
+	_, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 1, "aws", "ref")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not enabled")
 }
 
 func TestReadFederatedSecret_BackendErrorAudited(t *testing.T) {
 	c, ms := connectTestCore(t, fakeConnector{name: "aws", err: errors.New("AccessDenied")})
-	_, err := c.ReadFederatedSecret(context.Background(), 1, "aws", "ref")
+	_, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 1, "aws", "ref")
 	require.Error(t, err)
 	// A failed read is still audited (with FAILED in the description).
 	ms.AssertCalled(t, "LogAuditEvent", mock.Anything, mock.Anything)

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -1247,6 +1247,21 @@ func (m *MockStorage) RemovePermissionFromRole(_ context.Context, _, _ uint) err
 	return nil
 }
 
+// Keyorix Connect per-reference grants (ADR-045) — core enforcement is tested against
+// real SQLite, so these mock stubs just satisfy the interface.
+func (m *MockStorage) ListConnectRefGrantsByConnector(_ context.Context, _ string) ([]*models.ConnectRefGrant, error) {
+	return nil, nil
+}
+func (m *MockStorage) ListConnectRefGrants(_ context.Context) ([]*models.ConnectRefGrant, error) {
+	return nil, nil
+}
+func (m *MockStorage) CreateConnectRefGrant(_ context.Context, grant *models.ConnectRefGrant) (*models.ConnectRefGrant, error) {
+	return grant, nil
+}
+func (m *MockStorage) DeleteConnectRefGrant(_ context.Context, _ uint) error {
+	return nil
+}
+
 // Group-Role assignments
 
 func (m *MockStorage) GetGroupRoles(_ context.Context, _ uint) ([]*models.Role, error) {

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -307,6 +307,14 @@ type Storage interface {
 	GetRolePermissions(ctx context.Context, roleID uint) ([]*models.Permission, error)
 	RemovePermissionFromRole(ctx context.Context, roleID, permissionID uint) error
 
+	// Keyorix Connect per-reference grants (ADR-045). ListConnectRefGrantsByConnector
+	// returns the grants scoped to one connector (the enforcement path);
+	// ListConnectRefGrants returns all grants (management/listing).
+	ListConnectRefGrantsByConnector(ctx context.Context, connector string) ([]*models.ConnectRefGrant, error)
+	ListConnectRefGrants(ctx context.Context) ([]*models.ConnectRefGrant, error)
+	CreateConnectRefGrant(ctx context.Context, grant *models.ConnectRefGrant) (*models.ConnectRefGrant, error)
+	DeleteConnectRefGrant(ctx context.Context, id uint) error
+
 	// Group-Role assignments. Assign/Remove bind a role to a group at the given
 	// Scope (zero Scope = global).
 	GetGroupRoles(ctx context.Context, groupID uint) ([]*models.Role, error)

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -305,6 +305,7 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 	webauthnSessExists := tableExists(db, "web_authn_sessions")
 	loginAttemptExists := tableExists(db, "login_attempts")
 	auditCkptExists := tableExists(db, "audit_checkpoints")
+	connectRefGrantExists := tableExists(db, "connect_ref_grants")
 
 	// Create rotation_policies if missing (additive, safe on existing DBs).
 	if !rotationExists {
@@ -409,6 +410,14 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 					return fmt.Errorf("failed to add audit_checkpoints column %s: %w", col, err)
 				}
 			}
+		}
+	}
+
+	// Create connect_ref_grants if missing (ADR-045 per-reference Connect RBAC,
+	// additive, safe on existing DBs).
+	if !connectRefGrantExists {
+		if err := db.AutoMigrate(&models.ConnectRefGrant{}); err != nil {
+			return fmt.Errorf("failed to migrate connect_ref_grants table: %w", err)
 		}
 	}
 

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -377,6 +377,25 @@ type UserRole struct {
 	ExpiresAt *time.Time `gorm:"index"`
 }
 
+// ConnectRefGrant scopes which secret references a role may read through a Keyorix
+// Connect connector (ADR-045) — a per-connector, per-role reference allowlist that
+// refines the global connect.read permission. A grant authorizes any ref whose value
+// begins with RefPrefix on the named connector for holders of RoleID (RefPrefix "" =
+// all refs on that connector).
+//
+// Enforcement is deny-by-default ONLY for connectors that have at least one grant:
+// when NO grant exists for a connector, that connector is governed solely by
+// connect.read plus the operator's allowed_refs (backward compatible); once any grant
+// exists for a connector, a read is permitted only if one of the caller's roles holds
+// a matching grant.
+type ConnectRefGrant struct {
+	ID        uint   `gorm:"primaryKey"`
+	RoleID    uint   `gorm:"not null;index;uniqueIndex:uq_connect_ref_grant,priority:1"`
+	Connector string `gorm:"not null;index;uniqueIndex:uq_connect_ref_grant,priority:2"`
+	RefPrefix string `gorm:"not null;uniqueIndex:uq_connect_ref_grant,priority:3"`
+	CreatedAt time.Time
+}
+
 type Group struct {
 	ID          uint   `gorm:"primaryKey"`
 	Name        string `gorm:"unique;not null"`

--- a/internal/storage/store/local_connect_ref_grants.go
+++ b/internal/storage/store/local_connect_ref_grants.go
@@ -1,0 +1,50 @@
+// local_connect_ref_grants.go — persistence for Keyorix Connect per-reference RBAC
+// grants (ADR-045). A grant scopes which secret references a role may read through a
+// given connector; enforcement (deny-by-default once a connector has any grant) lives
+// in the core layer. This file only stores and reads the grant rows.
+package store
+
+import (
+	"context"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// ListConnectRefGrantsByConnector returns the grants scoped to one connector — the
+// hot path consulted on every federated read.
+func (ls *LocalStorage) ListConnectRefGrantsByConnector(ctx context.Context, connector string) ([]*models.ConnectRefGrant, error) {
+	var grants []*models.ConnectRefGrant
+	if err := ls.db.WithContext(ctx).
+		Where("connector = ?", connector).
+		Find(&grants).Error; err != nil {
+		return nil, err
+	}
+	return grants, nil
+}
+
+// ListConnectRefGrants returns every grant (management/listing), ordered by connector
+// then role for a stable display.
+func (ls *LocalStorage) ListConnectRefGrants(ctx context.Context) ([]*models.ConnectRefGrant, error) {
+	var grants []*models.ConnectRefGrant
+	if err := ls.db.WithContext(ctx).
+		Order("connector asc, role_id asc, ref_prefix asc").
+		Find(&grants).Error; err != nil {
+		return nil, err
+	}
+	return grants, nil
+}
+
+// CreateConnectRefGrant persists a grant. The (role_id, connector, ref_prefix) unique
+// index makes re-creating an identical grant a conflict; callers should treat that as
+// idempotent at the API layer.
+func (ls *LocalStorage) CreateConnectRefGrant(ctx context.Context, grant *models.ConnectRefGrant) (*models.ConnectRefGrant, error) {
+	if err := ls.db.WithContext(ctx).Create(grant).Error; err != nil {
+		return nil, err
+	}
+	return grant, nil
+}
+
+// DeleteConnectRefGrant removes a grant by id (no-op if it does not exist).
+func (ls *LocalStorage) DeleteConnectRefGrant(ctx context.Context, id uint) error {
+	return ls.db.WithContext(ctx).Delete(&models.ConnectRefGrant{}, id).Error
+}

--- a/internal/storage/store/local_connect_ref_grants_test.go
+++ b/internal/storage/store/local_connect_ref_grants_test.go
@@ -1,0 +1,62 @@
+package store
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func newConnectGrantStore(t *testing.T) *LocalStorage {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.ConnectRefGrant{}))
+	return NewLocalStorage(db)
+}
+
+func TestConnectRefGrants_CRUDAndScoping(t *testing.T) {
+	ls := newConnectGrantStore(t)
+	ctx := context.Background()
+
+	_, err := ls.CreateConnectRefGrant(ctx, &models.ConnectRefGrant{RoleID: 5, Connector: "aws", RefPrefix: "metrics/"})
+	require.NoError(t, err)
+	_, err = ls.CreateConnectRefGrant(ctx, &models.ConnectRefGrant{RoleID: 6, Connector: "aws", RefPrefix: "db/"})
+	require.NoError(t, err)
+	g3, err := ls.CreateConnectRefGrant(ctx, &models.ConnectRefGrant{RoleID: 5, Connector: "gcp", RefPrefix: ""})
+	require.NoError(t, err)
+
+	// By-connector returns only that connector's grants (the enforcement path).
+	aws, err := ls.ListConnectRefGrantsByConnector(ctx, "aws")
+	require.NoError(t, err)
+	assert.Len(t, aws, 2)
+	for _, g := range aws {
+		assert.Equal(t, "aws", g.Connector)
+	}
+
+	// List-all returns every grant.
+	all, err := ls.ListConnectRefGrants(ctx)
+	require.NoError(t, err)
+	assert.Len(t, all, 3)
+
+	// Delete removes one; the rest remain.
+	require.NoError(t, ls.DeleteConnectRefGrant(ctx, g3.ID))
+	gcp, err := ls.ListConnectRefGrantsByConnector(ctx, "gcp")
+	require.NoError(t, err)
+	assert.Empty(t, gcp)
+}
+
+func TestConnectRefGrants_UniqueTriple(t *testing.T) {
+	ls := newConnectGrantStore(t)
+	ctx := context.Background()
+	_, err := ls.CreateConnectRefGrant(ctx, &models.ConnectRefGrant{RoleID: 5, Connector: "aws", RefPrefix: "metrics/"})
+	require.NoError(t, err)
+	// Re-creating the identical (role, connector, prefix) triple conflicts on the
+	// unique index.
+	_, err = ls.CreateConnectRefGrant(ctx, &models.ConnectRefGrant{RoleID: 5, Connector: "aws", RefPrefix: "metrics/"})
+	require.Error(t, err)
+}

--- a/internal/storage/store/remote_rbac.go
+++ b/internal/storage/store/remote_rbac.go
@@ -263,6 +263,30 @@ func (rs *RemoteStorage) RemovePermissionFromRole(ctx context.Context, roleID, p
 	return nil
 }
 
+// Keyorix Connect per-reference grants (ADR-045) are a server-side concern: the live
+// federated-read path and grant management both run against LocalStorage, so the
+// remote (client) storage does not proxy these primitives.
+
+// ListConnectRefGrantsByConnector is not supported in remote storage.
+func (rs *RemoteStorage) ListConnectRefGrantsByConnector(_ context.Context, _ string) ([]*models.ConnectRefGrant, error) {
+	return nil, remoteUnsupported("ListConnectRefGrantsByConnector")
+}
+
+// ListConnectRefGrants is not supported in remote storage.
+func (rs *RemoteStorage) ListConnectRefGrants(_ context.Context) ([]*models.ConnectRefGrant, error) {
+	return nil, remoteUnsupported("ListConnectRefGrants")
+}
+
+// CreateConnectRefGrant is not supported in remote storage.
+func (rs *RemoteStorage) CreateConnectRefGrant(_ context.Context, _ *models.ConnectRefGrant) (*models.ConnectRefGrant, error) {
+	return nil, remoteUnsupported("CreateConnectRefGrant")
+}
+
+// DeleteConnectRefGrant is not supported in remote storage.
+func (rs *RemoteStorage) DeleteConnectRefGrant(_ context.Context, _ uint) error {
+	return remoteUnsupported("DeleteConnectRefGrant")
+}
+
 // GetGroupRoles lists the roles assigned to a group via remote API.
 func (rs *RemoteStorage) GetGroupRoles(ctx context.Context, groupID uint) ([]*models.Role, error) {
 	path := fmt.Sprintf("/api/v1/groups/%d/roles", groupID)

--- a/internal/testhelper/rbac_test_helper.go
+++ b/internal/testhelper/rbac_test_helper.go
@@ -62,6 +62,7 @@ func NewRBACTestHelper(t *testing.T) *RBACTestHelper {
 		&models.Environment{},
 		&models.SecretNode{},
 		&models.ShareRecord{},
+		&models.ConnectRefGrant{},
 	)
 	require.NoError(t, err)
 

--- a/server/grpc/services/connect_service.go
+++ b/server/grpc/services/connect_service.go
@@ -45,11 +45,7 @@ func (s *ConnectGRPCService) ReadSecret(ctx context.Context, req *pb.ReadFederat
 	if err := authorizeGlobal(ctx, s.core, actor, "connect.read"); err != nil {
 		return nil, err
 	}
-	principalID := actor.UserID
-	if actor.ActorKind() == core.ActorTypeMachine {
-		principalID = actor.MachineIdentityID
-	}
-	value, err := s.core.ReadFederatedSecret(ctx, actor.ActorKind(), principalID, req.GetConnector(), req.GetRef())
+	value, err := s.core.ReadFederatedSecret(ctx, actor.ActorKind(), actor.PrincipalID(), req.GetConnector(), req.GetRef())
 	if err != nil {
 		return nil, err
 	}

--- a/server/grpc/services/connect_service.go
+++ b/server/grpc/services/connect_service.go
@@ -45,7 +45,11 @@ func (s *ConnectGRPCService) ReadSecret(ctx context.Context, req *pb.ReadFederat
 	if err := authorizeGlobal(ctx, s.core, actor, "connect.read"); err != nil {
 		return nil, err
 	}
-	value, err := s.core.ReadFederatedSecret(ctx, actor.UserID, req.GetConnector(), req.GetRef())
+	principalID := actor.UserID
+	if actor.ActorKind() == core.ActorTypeMachine {
+		principalID = actor.MachineIdentityID
+	}
+	value, err := s.core.ReadFederatedSecret(ctx, actor.ActorKind(), principalID, req.GetConnector(), req.GetRef())
 	if err != nil {
 		return nil, err
 	}

--- a/server/http/handlers/connect.go
+++ b/server/http/handlers/connect.go
@@ -46,7 +46,11 @@ func (h *ConnectHandler) GetSecret(w http.ResponseWriter, r *http.Request) {
 		sendError(w, "InvalidParameter", "ref query parameter is required", http.StatusBadRequest, nil)
 		return
 	}
-	value, err := h.coreService.ReadFederatedSecret(r.Context(), userCtx.UserID, name, ref)
+	principalID := userCtx.UserID
+	if userCtx.ActorKind() == core.ActorTypeMachine && userCtx.MachineIdentityID != nil {
+		principalID = *userCtx.MachineIdentityID
+	}
+	value, err := h.coreService.ReadFederatedSecret(r.Context(), userCtx.ActorKind(), principalID, name, ref)
 	if err != nil {
 		// Unknown connector / disabled is a client error; backend failures surface as
 		// a bad gateway since the upstream store is external.

--- a/server/http/handlers/connect.go
+++ b/server/http/handlers/connect.go
@@ -46,11 +46,7 @@ func (h *ConnectHandler) GetSecret(w http.ResponseWriter, r *http.Request) {
 		sendError(w, "InvalidParameter", "ref query parameter is required", http.StatusBadRequest, nil)
 		return
 	}
-	principalID := userCtx.UserID
-	if userCtx.ActorKind() == core.ActorTypeMachine && userCtx.MachineIdentityID != nil {
-		principalID = *userCtx.MachineIdentityID
-	}
-	value, err := h.coreService.ReadFederatedSecret(r.Context(), userCtx.ActorKind(), principalID, name, ref)
+	value, err := h.coreService.ReadFederatedSecret(r.Context(), userCtx.ActorKind(), userCtx.PrincipalID(), name, ref)
 	if err != nil {
 		// Unknown connector / disabled is a client error; backend failures surface as
 		// a bad gateway since the upstream store is external.

--- a/server/http/handlers/connect.go
+++ b/server/http/handlers/connect.go
@@ -5,7 +5,9 @@
 package handlers
 
 import (
+	"encoding/json"
 	"net/http"
+	"strconv"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/keyorixhq/keyorix/internal/core"
@@ -56,4 +58,76 @@ func (h *ConnectHandler) GetSecret(w http.ResponseWriter, r *http.Request) {
 		"ref":       ref,
 		"value":     value,
 	}, "")
+}
+
+// ListRefGrants returns all per-reference grants (ADR-045) for management.
+func (h *ConnectHandler) ListRefGrants(w http.ResponseWriter, r *http.Request) {
+	if middleware.GetUserFromContext(r.Context()) == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	grants, err := h.coreService.ListConnectRefGrants(r.Context())
+	if err != nil {
+		sendError(w, "ConnectError", err.Error(), http.StatusInternalServerError, nil)
+		return
+	}
+	out := make([]map[string]interface{}, 0, len(grants))
+	for _, g := range grants {
+		out = append(out, map[string]interface{}{
+			"id":         g.ID,
+			"role_id":    g.RoleID,
+			"connector":  g.Connector,
+			"ref_prefix": g.RefPrefix,
+			"created_at": g.CreatedAt,
+		})
+	}
+	sendSuccess(w, map[string]interface{}{"grants": out}, "")
+}
+
+// CreateRefGrant adds a per-reference grant (ADR-045).
+func (h *ConnectHandler) CreateRefGrant(w http.ResponseWriter, r *http.Request) {
+	userCtx := middleware.GetUserFromContext(r.Context())
+	if userCtx == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	var body struct {
+		RoleID    uint   `json:"role_id"`
+		Connector string `json:"connector"`
+		RefPrefix string `json:"ref_prefix"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		sendError(w, "InvalidParameter", "invalid JSON body", http.StatusBadRequest, nil)
+		return
+	}
+	g, err := h.coreService.CreateConnectRefGrant(r.Context(), userCtx.UserID, body.RoleID, body.Connector, body.RefPrefix)
+	if err != nil {
+		sendError(w, "ConnectError", err.Error(), http.StatusBadRequest, nil)
+		return
+	}
+	sendSuccess(w, map[string]interface{}{
+		"id":         g.ID,
+		"role_id":    g.RoleID,
+		"connector":  g.Connector,
+		"ref_prefix": g.RefPrefix,
+	}, "Connect ref-grant created")
+}
+
+// DeleteRefGrant removes a per-reference grant by id.
+func (h *ConnectHandler) DeleteRefGrant(w http.ResponseWriter, r *http.Request) {
+	userCtx := middleware.GetUserFromContext(r.Context())
+	if userCtx == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 64)
+	if err != nil {
+		sendError(w, "InvalidParameter", "invalid grant id", http.StatusBadRequest, nil)
+		return
+	}
+	if err := h.coreService.DeleteConnectRefGrant(r.Context(), userCtx.UserID, uint(id)); err != nil {
+		sendError(w, "ConnectError", err.Error(), http.StatusInternalServerError, nil)
+		return
+	}
+	sendSuccess(w, map[string]interface{}{"id": id}, "Connect ref-grant deleted")
 }

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -224,6 +224,12 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		// native secrets.read, so external-store access is granted explicitly.
 		r.With(customMiddleware.RequirePermission("connect.read")).Get("/connect/connectors", connectHandler.ListConnectors)
 		r.With(customMiddleware.RequirePermission("connect.read")).Get("/connect/{name}/secret", connectHandler.GetSecret)
+		// Per-reference grant management (ADR-045) — scopes which refs which roles may
+		// read. Privileged role-authorization config, so gated by roles.read/roles.write
+		// rather than connect.read.
+		r.With(customMiddleware.RequirePermission("roles.read")).Get("/connect/ref-grants", connectHandler.ListRefGrants)
+		r.With(customMiddleware.RequirePermission("roles.write")).Post("/connect/ref-grants", connectHandler.CreateRefGrant)
+		r.With(customMiddleware.RequirePermission("roles.write")).Delete("/connect/ref-grants/{id}", connectHandler.DeleteRefGrant)
 		r.With(customMiddleware.RequirePermission("secrets.read")).Get("/projects", catalogHandler.ListProjects)
 		r.With(customMiddleware.RequireScopedPermission("secrets.read", projectScope)).Get("/projects/{id}", catalogHandler.GetProject)
 		r.With(customMiddleware.RequirePermission("secrets.write")).Post("/projects", catalogHandler.CreateProject)


### PR DESCRIPTION
Refines the global `connect.read` permission with a **`(role, connector, ref_prefix)`** allowlist, so different teams sharing one external-store connector can be scoped to different secrets — not just the uniform per-connector `allowed_refs`.

## Model & enforcement
- **`ConnectRefGrant`** `(role_id, connector, ref_prefix)`, unique triple; additive migration (new table, safe on existing DBs).
- Enforced in **`ReadFederatedSecret` before the backend call**, so it protects **every transport** (HTTP + gRPC `ConnectService`) uniformly.
- **Deny-by-default only once a connector has any grant.** A connector with no grants behaves exactly as before (`connect.read` + `allowed_refs`) — fully backward compatible, opt-in per connector.
- A caller is allowed if **any** of their roles holds a matching prefix grant; empty prefix = all refs. Denied reads are audited.

## Management
`GET /connect/ref-grants` (`roles.read`), `POST` + `DELETE /connect/ref-grants/{id}` (`roles.write`) — role-authorization config, audited on create/delete. A grant for an unknown (typo'd) connector is rejected so an operator can't mis-scope silently.

## Footgun, documented
Defining the first grant flips a connector to deny-by-default. To keep an admin role's blanket access while scoping others, give it an **empty-prefix** grant (matches every ref) — explicit and auditable rather than an implicit bypass. (See ADR-045.)

## Tests
Enforcement matrix (no-grants allows, prefix scopes, role-mismatch denied, empty-prefix allows-all, other-connector unaffected, multi-role union, direct `connectRefAllowed`) + storage CRUD/scoping/unique-triple. New mutating routes verified denied to a read-only persona. gofmt/build/test/gosec/golangci-lint/gitleaks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)