### PR TITLE
fix(connect): ref-grant matching honors group-derived roles (ADR-045)

### DIFF
--- a/docs/adr-045-connect-per-reference-rbac.md
+++ b/docs/adr-045-connect-per-reference-rbac.md
@@ -47,9 +47,13 @@ that is in fact still unscoped.
 
 Enforcement lives in the core layer (`ReadFederatedSecret`), so it protects **every**
 transport uniformly — HTTP and the gRPC `ConnectService` alike. The caller's roles are
-resolved from the correct identity store for the actor kind — `user_roles` for users,
-`machine_identity_roles` for machine identities — so the policy is enforceable for both
-human and machine principals (at global scope, since Connect is a global surface).
+resolved exactly as canonical authorization resolves them, so the per-reference policy
+is consistent with the rest of RBAC: a user's **effective** roles — direct assignments
+**plus group-derived roles** — and, for a machine identity, its `machine_identity_roles`
+(at global scope, since Connect is a global surface). Resolving only direct roles would
+wrongly deny a user whose granted role comes via a group even though `connect.read`
+itself honors it. **Group-based scoping therefore works out of the box**: grant a
+ref-prefix to a role and manage who holds it through group membership.
 
 ## The deny-by-default footgun (documented)
 

--- a/internal/core/connect.go
+++ b/internal/core/connect.go
@@ -150,28 +150,29 @@ func (c *KeyorixCore) connectRefAllowed(ctx context.Context, actorType string, p
 	return false, nil
 }
 
-// actorRoleIDs resolves the caller's role IDs from the correct identity store for the
-// actor kind — machine identities hold roles in machine_identity_roles, users in
-// user_roles — so the per-reference policy is enforceable for both. Connect is a
-// global surface, so roles are resolved at global scope.
+// actorRoleIDs resolves the caller's EFFECTIVE role IDs the same way canonical
+// authorization does, so the per-reference policy matches the rest of RBAC: machine
+// identities resolve from machine_identity_roles; users resolve their direct roles
+// PLUS group-derived roles (scopedRoleIDs). Resolving only direct roles would deny a
+// user whose granted role comes via a group even though connect.read itself honors it.
+// Connect is a global surface, so roles are resolved at global scope.
 func (c *KeyorixCore) actorRoleIDs(ctx context.Context, actorType string, principalID uint) (map[uint]bool, error) {
-	set := map[uint]bool{}
+	var ids []uint
+	var err error
 	if actorType == ActorTypeMachine {
-		ids, err := c.storage.GetMachineRoleIDsAt(ctx, principalID, Scope{})
+		ids, err = c.storage.GetMachineRoleIDsAt(ctx, principalID, Scope{})
 		if err != nil {
 			return nil, fmt.Errorf("connect ref-grant: load machine roles: %w", err)
 		}
-		for _, id := range ids {
-			set[id] = true
+	} else {
+		ids, err = c.scopedRoleIDs(ctx, principalID, Scope{})
+		if err != nil {
+			return nil, fmt.Errorf("connect ref-grant: load actor roles: %w", err)
 		}
-		return set, nil
 	}
-	roles, err := c.GetUserRolesByID(ctx, principalID)
-	if err != nil {
-		return nil, fmt.Errorf("connect ref-grant: load actor roles: %w", err)
-	}
-	for _, r := range roles {
-		set[r.ID] = true
+	set := make(map[uint]bool, len(ids))
+	for _, id := range ids {
+		set[id] = true
 	}
 	return set, nil
 }

--- a/internal/core/connect_rbac_test.go
+++ b/internal/core/connect_rbac_test.go
@@ -19,7 +19,11 @@ func connectRBACCore(t *testing.T, conns ...connect.Connector) (*KeyorixCore, *g
 	t.Helper()
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
-	require.NoError(t, db.AutoMigrate(&models.Role{}, &models.UserRole{}, &models.MachineIdentityRole{}, &models.ConnectRefGrant{}, &models.AuditEvent{}))
+	require.NoError(t, db.AutoMigrate(
+		&models.Role{}, &models.UserRole{}, &models.MachineIdentityRole{},
+		&models.Group{}, &models.UserGroup{}, &models.GroupRole{},
+		&models.ConnectRefGrant{}, &models.AuditEvent{},
+	))
 	c := &KeyorixCore{storage: store.NewLocalStorage(db)}
 	if len(conns) > 0 {
 		c.SetConnectManager(connect.NewManager(conns))
@@ -146,6 +150,29 @@ func TestConnectRefRBAC_MachineIdentityRoles(t *testing.T) {
 	_, err = c.ReadFederatedSecret(ctx, ActorTypeMachine, 99, "aws", "metrics/qps")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not permitted")
+}
+
+// A grant for a role the caller holds only VIA GROUP MEMBERSHIP must authorize them —
+// the per-reference policy resolves effective roles (direct + group-derived) the same
+// way connect.read itself is authorized (ADR-045).
+func TestConnectRefRBAC_GroupDerivedRole(t *testing.T) {
+	c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v"})
+	// Role 5 exists; user 1 is NOT directly assigned it — they're in group 3, and
+	// group 3 has role 5.
+	require.NoError(t, db.Create(&models.Role{ID: 5, Name: "metrics"}).Error)
+	require.NoError(t, db.Create(&models.Group{ID: 3, Name: "analytics"}).Error)
+	require.NoError(t, db.Create(&models.UserGroup{UserID: 1, GroupID: 3}).Error)
+	require.NoError(t, db.Create(&models.GroupRole{GroupID: 3, RoleID: 5}).Error)
+	seedGrant(t, c, 5, "aws", "metrics/")
+
+	// The user reaches the grant through their group-derived role.
+	val, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 1, "aws", "metrics/qps")
+	require.NoError(t, err)
+	assert.Equal(t, "v", val)
+
+	// Still deny-by-default outside the granted prefix.
+	_, err = c.ReadFederatedSecret(context.Background(), ActorTypeUser, 1, "aws", "db/x")
+	require.Error(t, err)
 }
 
 func TestConnectRefAllowed_Direct(t *testing.T) {


### PR DESCRIPTION
A correctness/consistency fix for per-reference RBAC (ADR-045), delivering **group-based scoping** as a side effect.

## The bug
`connectRefAllowed` resolved only a user's **direct** roles (`GetUserRolesByID`). But canonical authorization — including the `connect.read` check that gates the very same request — resolves **direct + group-derived** roles (`scopedRoleIDs`). So a user whose granted role came via a group passed `connect.read` yet was **wrongly denied** by a ref-grant for that role.

## The fix
Enforcement now resolves the caller's **effective** roles the same way authz does:
- **users** → `scopedRoleIDs` (direct **+ group-derived**, at global scope)
- **machines** → `machine_identity_roles`

This aligns the per-reference policy with the rest of RBAC and makes **group-based scoping work out of the box**: grant a ref-prefix to a role and manage who holds it via group membership — no separate group-grant mechanism needed.

## Tests
A user reaches a ref-grant through a group-derived role, and is still deny-by-default outside the granted prefix. gofmt/build/test/gosec/golangci-lint/gitleaks clean. ADR-045 updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)