### PR TITLE
feat(connect): glob ref-grant patterns (ADR-045)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -981,7 +981,9 @@ connect:
   connector. It is opt-in per connector: a connector with **no** grants behaves as
   before (governed by `connect.read` + `allowed_refs`), but once a connector has any
   grant it is **deny-by-default** — only a caller holding a role with a matching
-  ref-prefix grant may read, and a denied read is audited. Manage grants at
+  ref-prefix grant may read, and a denied read is audited. A grant pattern is a
+  **prefix** by default; one containing glob metacharacters (`*`, `?`, `[`) matches as
+  a shell-style glob (`*` does not cross `/`), e.g. `prod/*/db`. Manage grants at
   `GET /api/v1/connect/ref-grants` (`roles.read`), `POST /api/v1/connect/ref-grants`
   and `DELETE /api/v1/connect/ref-grants/{id}` (`roles.write`). To keep an admin role's
   blanket access while scoping others, give it an **empty-prefix** grant (matches every

--- a/docs/adr-045-connect-per-reference-rbac.md
+++ b/docs/adr-045-connect-per-reference-rbac.md
@@ -24,8 +24,13 @@ deployment where different teams share one connector but should see different se
 Add **per-reference grants**: a `(role, connector, ref_prefix)` allowlist that refines
 `connect.read`, enforced in `ReadFederatedSecret` before the backend call.
 
-- A grant authorizes any `ref` whose value begins with `ref_prefix` (an empty prefix =
-  all refs on that connector) for holders of the role.
+- A grant authorizes a `ref` for holders of the role when the grant's pattern matches.
+  A pattern with **no** glob metacharacters (`*`, `?`, `[`) matches as a **prefix** (an
+  empty pattern = all refs on that connector); a pattern **containing** a metacharacter
+  matches as a shell-style **glob** via `path.Match`, where `*` does not cross `/`. So
+  `metrics/` grants everything under `metrics/`, `metrics/*` grants exactly one further
+  path segment, and `prod/*/db` matches `prod/<env>/db`. A malformed glob matches
+  nothing (fails closed).
 - Enforcement is **deny-by-default, but only for connectors that have at least one
   grant**:
   - a connector with **no** grants is governed exactly as before — `connect.read` plus
@@ -66,10 +71,12 @@ implicit admin bypass.
 
 ## Alternatives considered
 
-- **Glob / regex ref patterns** instead of prefixes: more expressive but inconsistent
-  with the existing `allowed_refs` prefix semantics and harder to reason about for
-  least-privilege. Prefix matching covers the hierarchical-path naming every supported
-  backend uses; revisit if a real need for mid-path wildcards appears.
+- **Regex ref patterns**: rejected as too sharp an edge for an allowlist (catastrophic
+  backtracking, hard to reason about for least-privilege). Shell-style globs via
+  `path.Match` were instead added **additively** on top of prefixes (a plain pattern
+  stays a prefix, so existing grants are unchanged; a pattern with `*`/`?`/`[` matches
+  as a glob), which covers mid-path wildcards (`prod/*/db`) without the regex hazards.
+  The coarse connector-level `allowed_refs` guardrail remains prefix-only for now.
 - **User-scoped (not role-scoped) grants**: rejected — Keyorix authorization is
   role-based throughout; per-user grants would fork the model and not compose with
   groups.

--- a/internal/core/connect.go
+++ b/internal/core/connect.go
@@ -6,6 +6,7 @@ package core
 import (
 	"context"
 	"fmt"
+	"path"
 	"strings"
 
 	"github.com/keyorixhq/keyorix/internal/connect"
@@ -143,11 +144,25 @@ func (c *KeyorixCore) connectRefAllowed(ctx context.Context, actorType string, p
 		return false, err
 	}
 	for _, g := range grants {
-		if roleSet[g.RoleID] && strings.HasPrefix(ref, g.RefPrefix) {
+		if roleSet[g.RoleID] && refMatches(g.RefPrefix, ref) {
 			return true, nil
 		}
 	}
 	return false, nil
+}
+
+// refMatches reports whether ref is covered by a grant's pattern (ADR-045). A pattern
+// with no glob metacharacters (*, ?, [) is matched as a PREFIX — backward compatible,
+// and "" matches everything. A pattern containing a metacharacter is matched as a
+// shell-style glob via path.Match, where * does not cross '/'. So "metrics/" still
+// grants everything under metrics/, "metrics/*" grants exactly one further path
+// segment, and "prod/*/db" matches prod/<env>/db. A malformed glob matches nothing.
+func refMatches(pattern, ref string) bool {
+	if !strings.ContainsAny(pattern, "*?[") {
+		return strings.HasPrefix(ref, pattern)
+	}
+	ok, err := path.Match(pattern, ref)
+	return err == nil && ok
 }
 
 // actorRoleIDs resolves the caller's EFFECTIVE role IDs the same way canonical

--- a/internal/core/connect_rbac_test.go
+++ b/internal/core/connect_rbac_test.go
@@ -175,6 +175,47 @@ func TestConnectRefRBAC_GroupDerivedRole(t *testing.T) {
 	require.Error(t, err)
 }
 
+// Glob patterns (ADR-045): a pattern with metacharacters matches via path.Match
+// (* not crossing '/'); a plain pattern stays a prefix match (backward compatible).
+func TestConnectRefRBAC_GlobPatterns(t *testing.T) {
+	c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v"})
+	seedRoleForUser(t, db, 1, 5, "reader")
+	seedGrant(t, c, 5, "aws", "prod/*/db") // exactly one segment between prod/ and /db
+	ctx := context.Background()
+
+	val, err := c.ReadFederatedSecret(ctx, ActorTypeUser, 1, "aws", "prod/eu/db")
+	require.NoError(t, err)
+	assert.Equal(t, "v", val)
+
+	// * does not cross '/', so a two-segment middle does not match.
+	_, err = c.ReadFederatedSecret(ctx, ActorTypeUser, 1, "aws", "prod/eu/west/db")
+	require.Error(t, err)
+	// A different leaf does not match.
+	_, err = c.ReadFederatedSecret(ctx, ActorTypeUser, 1, "aws", "prod/eu/secrets")
+	require.Error(t, err)
+}
+
+func TestRefMatches(t *testing.T) {
+	cases := []struct {
+		pattern, ref string
+		want         bool
+	}{
+		{"", "anything", true},              // empty prefix = all
+		{"metrics/", "metrics/qps", true},   // plain prefix
+		{"metrics/", "db/x", false},         // prefix miss
+		{"metrics/*", "metrics/qps", true},  // glob, one segment
+		{"metrics/*", "metrics/a/b", false}, // * does not cross '/'
+		{"prod/*/db", "prod/eu/db", true},   // middle wildcard
+		{"prod/*/db", "prod/eu/west/db", false},
+		{"db?", "db1", true}, // single-char wildcard
+		{"db?", "db", false},
+		{"[", "anything", false}, // malformed glob matches nothing
+	}
+	for _, tc := range cases {
+		assert.Equalf(t, tc.want, refMatches(tc.pattern, tc.ref), "refMatches(%q, %q)", tc.pattern, tc.ref)
+	}
+}
+
 func TestConnectRefAllowed_Direct(t *testing.T) {
 	c, db := connectRBACCore(t)
 	seedRoleForUser(t, db, 1, 5, "reader")


### PR DESCRIPTION
Per-reference grants (ADR-045) now accept **shell-style glob** patterns, added **additively** so existing grants are untouched.

## Semantics
- A pattern with **no** metacharacters → **prefix** match (unchanged; empty = all refs).
- A pattern containing `*` `?` `[` → glob via `path.Match` (where `*` does **not** cross `/`).

So `metrics/` still grants everything under it, `metrics/*` grants exactly one further segment, and `prod/*/db` matches `prod/<env>/db`. A malformed glob matches nothing (fails closed).

## Why glob, not regex
Regex was rejected — catastrophic-backtracking risk and hard to reason about for an allowlist. Globs cover mid-path wildcards without the hazard. The coarse connector-level `allowed_refs` guardrail stays prefix-only for now.

## Tests
`refMatches` truth table (prefix vs glob, `/`-boundary, single-char, malformed) + an end-to-end `prod/*/db` enforcement case. gofmt/build/test/gosec/golangci-lint/gitleaks clean. ADR-045 + CONFIGURATION updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)