### PR TITLE
release: prep v0.44.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,29 @@
 All notable changes to Keyorix are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## v0.44.0 — 2026-06-16
+
+Keyorix Connect per-reference RBAC — gRPC parity, group/glob support.
+
+### Added
+- **gRPC management of per-reference grants** — `ConnectService` gains
+  `ListRefGrants` / `CreateRefGrant` / `DeleteRefGrant` (gated `roles.read` /
+  `roles.write`), at parity with the HTTP `/connect/ref-grants` routes. ([#256])
+- **Glob ref-grant patterns** — a grant pattern is a prefix by default, or a
+  shell-style glob if it contains `*` `?` `[` (e.g. `prod/*/db`; `*` does not cross
+  `/`). Existing prefix grants are unchanged; a malformed glob matches nothing. ([#258])
+
+### Fixed
+- **Per-reference grants honor group-derived roles** — ref-grant matching now resolves
+  a caller's *effective* roles (direct **plus** group-derived for users,
+  `machine_identity_roles` for machines), consistent with how `connect.read` itself is
+  authorized. Previously a user whose granted role came via a group was wrongly denied.
+  ([#257])
+
+[#256]: https://github.com/keyorixhq/keyorix/pull/256
+[#257]: https://github.com/keyorixhq/keyorix/pull/257
+[#258]: https://github.com/keyorixhq/keyorix/pull/258
+
 ## v0.43.0 — 2026-06-16
 
 Fine-grained authorization for Keyorix Connect.

--- a/deploy/helm/keyorix/Chart.yaml
+++ b/deploy/helm/keyorix/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix
 description: Self-hosted Keyorix secrets manager (API server + web UI + PostgreSQL)
 type: application
 # Chart version — bump on chart changes.
-version: 0.43.0
+version: 0.44.0
 # The Keyorix app version this chart deploys by default (the image tag).
-appVersion: "0.43.0"
+appVersion: "0.44.0"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix


### PR DESCRIPTION
Cuts **v0.44.0**, shipping the three unreleased Connect per-reference RBAC commits on main:

- **gRPC ref-grant management** (#256) — `ConnectService` List/Create/Delete RefGrant, gated `roles.read`/`roles.write`.
- **Group-derived-role fix** (#257) — ref-grant matching resolves effective roles (direct + group + machine), consistent with `connect.read`.
- **Glob ref patterns** (#258) — prefix by default, shell-style glob when `*?[` present.

Chart + appVersion bumped to `0.44.0`; CHANGELOG updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)