### PR TITLE
feat(audit): push-driven StreamAuditLogs via in-process broker

### DIFF
--- a/internal/core/audit_stream.go
+++ b/internal/core/audit_stream.go
@@ -1,0 +1,68 @@
+// audit_stream.go — an in-process pub/sub broker that wakes live audit tails the
+// instant an audit event is written, so the gRPC StreamAuditLogs RPC can deliver
+// events push-driven instead of polling the database on a fixed interval.
+//
+// The broker carries a coalescing SIGNAL, not the events themselves: on each write it
+// pokes every subscriber's 1-buffered channel (non-blocking — it must never slow the
+// audit write path), and the subscriber responds by reading the new rows from storage
+// using its forward cursor. Keeping the database authoritative means no event is ever
+// lost to a full channel or a slow consumer; the signal only collapses the latency
+// between "written" and "delivered".
+package core
+
+import "sync"
+
+// auditBroker fans a write signal out to live audit-stream subscribers.
+type auditBroker struct {
+	mu   sync.Mutex
+	next int
+	subs map[int]chan struct{}
+}
+
+func newAuditBroker() *auditBroker {
+	return &auditBroker{subs: make(map[int]chan struct{})}
+}
+
+// subscribe registers a tail and returns its id plus a channel that receives a
+// (coalesced) tick whenever an audit event is written. Unsubscribe with the id.
+func (b *auditBroker) subscribe() (int, <-chan struct{}) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	id := b.next
+	b.next++
+	ch := make(chan struct{}, 1)
+	b.subs[id] = ch
+	return id, ch
+}
+
+func (b *auditBroker) unsubscribe(id int) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	delete(b.subs, id)
+}
+
+// signal pokes every subscriber. The 1-slot buffer coalesces bursts (a subscriber
+// that hasn't drained its previous tick keeps just one pending), and the default
+// branch makes every send non-blocking so a slow tail never stalls an audit write.
+func (b *auditBroker) signal() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for _, ch := range b.subs {
+		select {
+		case ch <- struct{}{}:
+		default:
+		}
+	}
+}
+
+// SubscribeAuditStream registers a live audit tail; the returned channel ticks
+// whenever an audit event is written. Callers MUST call UnsubscribeAuditStream with
+// the returned id when done (e.g. on stream close) to avoid leaking the subscription.
+func (c *KeyorixCore) SubscribeAuditStream() (int, <-chan struct{}) {
+	return c.auditStream.subscribe()
+}
+
+// UnsubscribeAuditStream removes a tail registered with SubscribeAuditStream.
+func (c *KeyorixCore) UnsubscribeAuditStream(id int) {
+	c.auditStream.unsubscribe(id)
+}

--- a/internal/core/audit_stream_test.go
+++ b/internal/core/audit_stream_test.go
@@ -1,0 +1,109 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAuditBroker_SignalDelivered(t *testing.T) {
+	b := newAuditBroker()
+	id, wake := b.subscribe()
+	defer b.unsubscribe(id)
+
+	b.signal()
+	select {
+	case <-wake:
+	case <-time.After(time.Second):
+		t.Fatal("expected a wake tick after signal")
+	}
+}
+
+func TestAuditBroker_SignalsCoalesce(t *testing.T) {
+	b := newAuditBroker()
+	id, wake := b.subscribe()
+	defer b.unsubscribe(id)
+
+	// Several signals with no drain in between collapse to a single pending tick
+	// (1-slot buffer) — the subscriber re-queries the DB once and catches up.
+	for i := 0; i < 5; i++ {
+		b.signal()
+	}
+	<-wake // one pending
+	select {
+	case <-wake:
+		t.Fatal("signals must coalesce to a single pending tick")
+	default:
+	}
+}
+
+func TestAuditBroker_SignalNonBlockingAndUnsubscribe(t *testing.T) {
+	b := newAuditBroker()
+	id, wake := b.subscribe()
+
+	// Fill the buffer, then signal again — must not block even though no one drains.
+	b.signal()
+	b.signal()
+	b.signal() // would deadlock if signal blocked on a full channel
+
+	b.unsubscribe(id)
+	// After unsubscribe, a signal reaches no one; the old channel gets nothing new.
+	b.signal()
+	<-wake // drain the one buffered tick from before unsubscribe
+	select {
+	case <-wake:
+		t.Fatal("no further ticks after unsubscribe")
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestAuditBroker_MultipleSubscribersAllWoken(t *testing.T) {
+	b := newAuditBroker()
+	id1, w1 := b.subscribe()
+	id2, w2 := b.subscribe()
+	defer b.unsubscribe(id1)
+	defer b.unsubscribe(id2)
+
+	b.signal()
+	for _, w := range []<-chan struct{}{w1, w2} {
+		select {
+		case <-w:
+		case <-time.After(time.Second):
+			t.Fatal("every subscriber must be woken")
+		}
+	}
+}
+
+// emitAudit must wake a live subscriber (the write→deliver hook), in addition to
+// persisting the row.
+func TestEmitAudit_SignalsSubscribers(t *testing.T) {
+	ms := new(MockStorage)
+	ms.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
+	c := &KeyorixCore{storage: ms, auditStream: newAuditBroker()}
+
+	id, wake := c.SubscribeAuditStream()
+	defer c.UnsubscribeAuditStream(id)
+
+	c.emitAudit(context.Background(), &models.AuditEvent{EventType: "test.event"})
+
+	select {
+	case <-wake:
+	case <-time.After(time.Second):
+		t.Fatal("emitAudit should wake live audit-stream subscribers")
+	}
+	ms.AssertCalled(t, "LogAuditEvent", mock.Anything, mock.Anything)
+}
+
+// A constructed core always has a non-nil broker (no lazy-init nil panic in emitAudit).
+func TestNewKeyorixCore_HasAuditBroker(t *testing.T) {
+	c := NewKeyorixCore(new(MockStorage))
+	require.NotNil(t, c.auditStream)
+	id, _ := c.SubscribeAuditStream()
+	c.UnsubscribeAuditStream(id)
+	assert.NotPanics(t, func() { c.auditStream.signal() })
+}

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -50,6 +50,10 @@ type KeyorixCore struct {
 	passwordPolicy PasswordPolicy
 	loginLockout   LoginLockoutPolicy // per-account login lockout (disabled by default)
 	auditForwarder AuditForwarder
+	// auditStream is the in-process pub/sub broker that wakes live audit tails
+	// (gRPC StreamAuditLogs) the instant an event is written, replacing fixed-interval
+	// DB polling. Always non-nil (set in the constructors).
+	auditStream *auditBroker
 	// notificationSink fans each in-app notification out to an external channel
 	// (email/webhook). nil = in-app only. Set from config via SetNotificationSink.
 	notificationSink NotificationSink
@@ -143,6 +147,11 @@ func (c *KeyorixCore) emitAudit(ctx context.Context, event *models.AuditEvent) {
 	if c.auditForwarder != nil {
 		c.auditForwarder.Forward(event)
 	}
+	// Wake any live audit tails (gRPC StreamAuditLogs). Non-blocking; subscribers
+	// then read the new rows from storage with their cursor (DB stays authoritative).
+	if c.auditStream != nil {
+		c.auditStream.signal()
+	}
 }
 
 // NotificationEvent is one user-facing notification handed to an external sink for
@@ -179,6 +188,7 @@ func NewKeyorixCore(storage storage.Storage) *KeyorixCore {
 		encryption:     nil,
 		now:            time.Now,
 		passwordPolicy: DefaultPasswordPolicy(),
+		auditStream:    newAuditBroker(),
 	}
 }
 
@@ -189,6 +199,7 @@ func NewKeyorixCoreWithEncryption(storage storage.Storage, enc *encryption.Secre
 		encryption:     enc,
 		now:            time.Now,
 		passwordPolicy: DefaultPasswordPolicy(),
+		auditStream:    newAuditBroker(),
 	}
 }
 

--- a/server/grpc/services/audit_service.go
+++ b/server/grpc/services/audit_service.go
@@ -14,9 +14,10 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-// Audit-stream tail tuning: how often to poll for new events, and the max events
-// drained per poll. The interval is a var so tests can shorten it.
-var auditStreamPollInterval = 2 * time.Second
+// Audit-stream tail tuning: a SAFETY-NET fallback interval (the common path is the
+// push signal from core.SubscribeAuditStream, not this) and the max events drained per
+// wake. The interval is a var so tests can shorten it.
+var auditStreamFallbackInterval = 30 * time.Second
 
 const auditStreamBatch = 100
 
@@ -133,11 +134,14 @@ func rbacEntryToProto(e *core.RBACAuditEntry) *pb.RBACAuditLog {
 }
 
 // StreamAuditLogs tails the audit log: it streams audit events as they occur
-// (events created after the stream opens — use GetAuditLogs for history),
-// applying the same event_type/user/project filters. Implemented by polling the
-// forward id cursor (AuditFilter.AfterID/Ascending) every auditStreamPollInterval,
-// which avoids a separate pub/sub broker and reuses the existing query path. The
-// stream ends when the client disconnects (context cancellation).
+// (events created after the stream opens — use GetAuditLogs for history), applying
+// the same event_type/user/project filters. It is PUSH-driven: an in-process broker
+// wakes the stream the instant an event is written (core.SubscribeAuditStream), then
+// the stream drains the new rows from its forward id cursor (AuditFilter.AfterID/
+// Ascending). The database stays authoritative — the signal only collapses latency, so
+// no event is lost to a slow consumer. A long fallback ticker is a safety net for any
+// write that did not signal (e.g. a path that bypasses the audit funnel). The stream
+// ends when the client disconnects (context cancellation).
 func (s *AuditGRPCService) StreamAuditLogs(req *pb.StreamAuditLogsRequest, stream pb.AuditService_StreamAuditLogsServer) error {
 	ctx := stream.Context()
 	actor := interceptors.GetUserFromGRPCContext(ctx)
@@ -148,20 +152,22 @@ func (s *AuditGRPCService) StreamAuditLogs(req *pb.StreamAuditLogsRequest, strea
 		return err
 	}
 
-	// Start at the current head so we tail new events, not the backlog.
+	// Subscribe BEFORE reading the head id so no write between the two is missed: a
+	// write in that window leaves a pending tick, and the first drain queries from the
+	// head cursor anyway.
+	subID, wake := s.core.SubscribeAuditStream()
+	defer s.core.UnsubscribeAuditStream(subID)
+
 	cursor, err := s.latestAuditID(ctx)
 	if err != nil {
 		return status.Error(codes.Internal, "failed to start audit stream")
 	}
 
-	ticker := time.NewTicker(auditStreamPollInterval)
-	defer ticker.Stop()
+	fallback := time.NewTicker(auditStreamFallbackInterval)
+	defer fallback.Stop()
 
-	for {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-ticker.C:
+	drain := func() error {
+		for {
 			after := cursor
 			events, _, err := s.core.Storage().GetAuditLogs(ctx, &corestorage.AuditFilter{
 				AfterID:   &after,
@@ -175,7 +181,7 @@ func (s *AuditGRPCService) StreamAuditLogs(req *pb.StreamAuditLogsRequest, strea
 				return status.Error(codes.Internal, "failed to read audit logs")
 			}
 			if len(events) == 0 {
-				continue
+				return nil
 			}
 			names := s.core.ResolveUsernames(ctx, events)
 			for _, e := range events {
@@ -183,6 +189,25 @@ func (s *AuditGRPCService) StreamAuditLogs(req *pb.StreamAuditLogsRequest, strea
 					return err // client gone / send failed
 				}
 				cursor = e.ID
+			}
+			// A full page may mean more is queued; loop until the cursor catches up.
+			if len(events) < auditStreamBatch {
+				return nil
+			}
+		}
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-wake:
+			if err := drain(); err != nil {
+				return err
+			}
+		case <-fallback.C:
+			if err := drain(); err != nil {
+				return err
 			}
 		}
 	}

--- a/server/grpc/services/audit_stream_test.go
+++ b/server/grpc/services/audit_stream_test.go
@@ -81,10 +81,14 @@ func TestAuditService_StreamAuditLogs_PermissionDenied(t *testing.T) {
 }
 
 func TestAuditService_StreamAuditLogs_TailsNewEvents(t *testing.T) {
-	// Fast poll for the test.
-	old := auditStreamPollInterval
-	auditStreamPollInterval = 15 * time.Millisecond
-	defer func() { auditStreamPollInterval = old }()
+	// These events are inserted directly into the DB (bypassing the emitAudit funnel
+	// that normally fires the push signal), so delivery here rides the fallback
+	// safety-net drain — shorten it for the test. The push (signal) path itself is
+	// unit-tested in package core (TestEmitAudit_SignalsSubscribers + broker tests);
+	// both paths run the same drain() send/cursor logic exercised below.
+	old := auditStreamFallbackInterval
+	auditStreamFallbackInterval = 15 * time.Millisecond
+	defer func() { auditStreamFallbackInterval = old }()
 
 	svc, db := newStreamCore(t)
 


### PR DESCRIPTION
The gRPC audit tail (`StreamAuditLogs`) polled the database on a fixed 2s interval. This replaces polling with a **push signal**.

## How
- A small in-process broker (`core.auditBroker`) wakes every live tail the instant an audit event is written; the stream then **drains the new rows from its forward cursor**.
- The broker carries only a **coalescing signal**, never the events — the **DB stays authoritative**, so nothing is lost to a slow/blocked consumer, and the signal merely collapses write→deliver latency from up-to-2s to ~immediate while removing steady-state poll load.
- `emitAudit` (the single audit funnel) signals after persisting; fan-out is **non-blocking** so a slow tail never stalls an audit write.

## Details
- `StreamAuditLogs` subscribes **before** reading the head cursor (no missed wake), drains on each wake, and keeps a long **30s fallback ticker** as a safety net for any write that bypasses the funnel. Same `audit.read` gate and event_type/user/project filters as before.
- Broker created in both core constructors (always non-nil).

## Tests
Broker: delivery / coalescing / non-blocking / multi-subscriber / unsubscribe. `emitAudit` signals subscribers. Constructor wires a non-nil broker. The existing gRPC tail test now drives via the (shortened) fallback drain — exercising the same send/cursor path. gofmt/build/test/gosec/golangci-lint/gitleaks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)