### PR TITLE
feat(audit): gap-free StreamAuditLogs resume via after_id cursor

### DIFF
--- a/server/grpc/services/audit_service.go
+++ b/server/grpc/services/audit_service.go
@@ -158,14 +158,24 @@ func (s *AuditGRPCService) StreamAuditLogs(req *pb.StreamAuditLogsRequest, strea
 	subID, wake := s.core.SubscribeAuditStream()
 	defer s.core.UnsubscribeAuditStream(subID)
 
-	cursor, err := s.latestAuditID(ctx)
-	if err != nil {
-		return status.Error(codes.Internal, "failed to start audit stream")
+	// Resume from a client-supplied cursor (gap-free reconnect): start just after
+	// after_id and replay the backlog before tailing live. Default (0/unset) starts at
+	// the current head, tailing only new events.
+	var cursor uint
+	if req.AfterId != nil && req.GetAfterId() > 0 {
+		cursor = uint(req.GetAfterId())
+	} else {
+		head, err := s.latestAuditID(ctx)
+		if err != nil {
+			return status.Error(codes.Internal, "failed to start audit stream")
+		}
+		cursor = head
 	}
 
 	fallback := time.NewTicker(auditStreamFallbackInterval)
 	defer fallback.Stop()
 
+	// Replay any backlog after the resume cursor immediately, then block for live ticks.
 	drain := func() error {
 		for {
 			after := cursor
@@ -195,6 +205,12 @@ func (s *AuditGRPCService) StreamAuditLogs(req *pb.StreamAuditLogsRequest, strea
 				return nil
 			}
 		}
+	}
+
+	// Deliver the resume backlog (if any) before waiting for live events; for the
+	// default head-start cursor this is a no-op.
+	if err := drain(); err != nil {
+		return err
 	}
 
 	for {

--- a/server/grpc/services/audit_stream_test.go
+++ b/server/grpc/services/audit_stream_test.go
@@ -80,6 +80,40 @@ func TestAuditService_StreamAuditLogs_PermissionDenied(t *testing.T) {
 	assert.Equal(t, codes.PermissionDenied, status.Code(err))
 }
 
+func TestAuditService_StreamAuditLogs_ResumesFromCursor(t *testing.T) {
+	svc, db := newStreamCore(t)
+
+	// Two pre-existing events. A client that last saw id e1 reconnects with
+	// after_id=e1 and must receive the backlog (e2) without any new write.
+	uid := uint(1)
+	e1 := &models.AuditEvent{EventType: "role.assigned", UserID: &uid, EventTime: time.Now()}
+	require.NoError(t, db.Create(e1).Error)
+	e2 := &models.AuditEvent{EventType: "role.removed", UserID: &uid, EventTime: time.Now()}
+	require.NoError(t, db.Create(e2).Error)
+
+	ctx, cancel := context.WithCancel(authCtx(1, "admin", "audit.read"))
+	defer cancel()
+	stream := &fakeAuditStream{ctx: ctx}
+
+	after := uint32(e1.ID)
+	done := make(chan error, 1)
+	go func() {
+		done <- svc.StreamAuditLogs(&pb.StreamAuditLogsRequest{AfterId: &after}, stream)
+	}()
+
+	// The backlog after e1 (i.e. e2) is replayed immediately, before any new event.
+	require.Eventually(t, func() bool { return stream.count() >= 1 }, time.Second, 10*time.Millisecond)
+	assert.Equal(t, "role.removed", stream.first().GetEventType())
+
+	cancel()
+	select {
+	case err := <-done:
+		assert.ErrorIs(t, err, context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("stream did not return after cancel")
+	}
+}
+
 func TestAuditService_StreamAuditLogs_TailsNewEvents(t *testing.T) {
 	// These events are inserted directly into the DB (bypassing the emitAudit funnel
 	// that normally fires the push signal), so delivery here rides the fallback

--- a/server/proto/keyorix.proto
+++ b/server/proto/keyorix.proto
@@ -477,6 +477,11 @@ message StreamAuditLogsRequest {
   optional string event_type = 1;
   optional uint32 user_id = 2;
   optional uint32 project_id = 3;
+  // after_id resumes the tail just after this audit event id: the stream first
+  // replays the backlog of matching events with id > after_id, then continues live.
+  // Omit (or 0) to tail only new events from the current head. Lets a disconnected
+  // SIEM consumer reconnect from its last-seen id without losing the gap.
+  optional uint32 after_id = 4;
 }
 
 // ---------------------------------------------------------------------------

--- a/server/proto/pb/keyorix.pb.go
+++ b/server/proto/pb/keyorix.pb.go
@@ -3040,10 +3040,15 @@ func (x *GetRBACAuditLogsResponse) GetTotalPages() uint32 {
 }
 
 type StreamAuditLogsRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	EventType     *string                `protobuf:"bytes,1,opt,name=event_type,json=eventType,proto3,oneof" json:"event_type,omitempty"`
-	UserId        *uint32                `protobuf:"varint,2,opt,name=user_id,json=userId,proto3,oneof" json:"user_id,omitempty"`
-	ProjectId     *uint32                `protobuf:"varint,3,opt,name=project_id,json=projectId,proto3,oneof" json:"project_id,omitempty"`
+	state     protoimpl.MessageState `protogen:"open.v1"`
+	EventType *string                `protobuf:"bytes,1,opt,name=event_type,json=eventType,proto3,oneof" json:"event_type,omitempty"`
+	UserId    *uint32                `protobuf:"varint,2,opt,name=user_id,json=userId,proto3,oneof" json:"user_id,omitempty"`
+	ProjectId *uint32                `protobuf:"varint,3,opt,name=project_id,json=projectId,proto3,oneof" json:"project_id,omitempty"`
+	// after_id resumes the tail just after this audit event id: the stream first
+	// replays the backlog of matching events with id > after_id, then continues live.
+	// Omit (or 0) to tail only new events from the current head. Lets a disconnected
+	// SIEM consumer reconnect from its last-seen id without losing the gap.
+	AfterId       *uint32 `protobuf:"varint,4,opt,name=after_id,json=afterId,proto3,oneof" json:"after_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -3095,6 +3100,13 @@ func (x *StreamAuditLogsRequest) GetUserId() uint32 {
 func (x *StreamAuditLogsRequest) GetProjectId() uint32 {
 	if x != nil && x.ProjectId != nil {
 		return *x.ProjectId
+	}
+	return 0
+}
+
+func (x *StreamAuditLogsRequest) GetAfterId() uint32 {
+	if x != nil && x.AfterId != nil {
+		return *x.AfterId
 	}
 	return 0
 }
@@ -8606,17 +8618,19 @@ const file_keyorix_proto_rawDesc = "" +
 	"\x04page\x18\x03 \x01(\rR\x04page\x12\x1b\n" +
 	"\tpage_size\x18\x04 \x01(\rR\bpageSize\x12\x1f\n" +
 	"\vtotal_pages\x18\x05 \x01(\rR\n" +
-	"totalPages\"\xa8\x01\n" +
+	"totalPages\"\xd5\x01\n" +
 	"\x16StreamAuditLogsRequest\x12\"\n" +
 	"\n" +
 	"event_type\x18\x01 \x01(\tH\x00R\teventType\x88\x01\x01\x12\x1c\n" +
 	"\auser_id\x18\x02 \x01(\rH\x01R\x06userId\x88\x01\x01\x12\"\n" +
 	"\n" +
-	"project_id\x18\x03 \x01(\rH\x02R\tprojectId\x88\x01\x01B\r\n" +
+	"project_id\x18\x03 \x01(\rH\x02R\tprojectId\x88\x01\x01\x12\x1e\n" +
+	"\bafter_id\x18\x04 \x01(\rH\x03R\aafterId\x88\x01\x01B\r\n" +
 	"\v_event_typeB\n" +
 	"\n" +
 	"\b_user_idB\r\n" +
-	"\v_project_id\"\xa9\x02\n" +
+	"\v_project_idB\v\n" +
+	"\t_after_id\"\xa9\x02\n" +
 	"\vShareRecord\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\rR\x02id\x12\x1b\n" +
 	"\tsecret_id\x18\x02 \x01(\rR\bsecretId\x12\x19\n" +


### PR DESCRIPTION
A reconnecting audit-stream consumer (e.g. a SIEM) previously always started at the **current head**, losing events written during the disconnect. This adds gap-free resume.

## Change
- `StreamAuditLogsRequest` gains an optional **`after_id`**. When set, the stream resumes **just after** that id — replaying the matching backlog (`id > after_id`) before tailing live — so a client that tracks its last-seen id reconnects with **no gap**.
- Unset / `0` keeps the existing head-start (tail-only) behavior — fully backward compatible.
- Cursor initialized from `after_id` when provided (else head); an initial drain delivers the backlog before the wait loop. Same `audit.read` gate + event_type/user/project filters.

## Tests
Resume from a cursor replays the backlog immediately (no new write required); `-race` clean. gofmt/build/test/gosec/golangci-lint/gitleaks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)