### PR TITLE
feat(rotation): automated secret rotation executor (ADR-046)

### DIFF
--- a/docs/adr-046-automated-secret-rotation.md
+++ b/docs/adr-046-automated-secret-rotation.md
@@ -1,0 +1,69 @@
+# ADR-046: Automated secret rotation
+
+## Status
+
+Accepted.
+
+## Context
+
+Keyorix already had the *policy* and *visibility* halves of rotation: a
+`RotationPolicy` defines how often a secret should rotate (`interval_days`, scope),
+`GetRotationStatus` / `EvaluateRotationPolicies` classify covered secrets as
+ok/due-soon/overdue, and the rotation-reminder scheduler notifies admins. But nothing
+actually *rotated* anything — a human still had to call `RotateSecret` with a new value.
+
+For secrets whose value Keyorix owns (generated tokens/passwords with no external
+system to coordinate), that manual step is pure toil and a gap in rotation hygiene
+(NIS2 / ISO 27001 A.5 / SOC 2).
+
+## Decision
+
+Add an opt-in **automated-rotation executor** that regenerates the value of
+auto-rotate-enabled secrets when they fall overdue under an active policy.
+
+- **Per-secret opt-in.** `SecretNode.AutoRotate` (default false) marks a secret as
+  Keyorix-owned and safe to regenerate. It is toggled via
+  `PATCH /api/v1/secrets/{id}/auto-rotate` (gated by scoped `secrets.write`) and the
+  change is audited (`secret.auto_rotate_configured`).
+- **Executor.** `RunAutoRotation` walks active policies → covered secrets; for each
+  secret that is both `AutoRotate` and overdue (`days_since_last_rotation ≥
+  interval_days`) it generates a fresh value and rotates it (a new version), auditing
+  `secret.auto_rotated`. Best-effort per secret (a failure is logged and skipped, never
+  aborting the run); a secret covered by multiple policies rotates at most once per run.
+- **Generated value.** 32 characters over a 62-symbol alphanumeric set from
+  `crypto/rand` (~190 bits), alphanumeric-only so a consumer reading it back never
+  trips over shell/URL metacharacters.
+- **Scheduler.** Opt-in `auto_rotation` block (default off; default interval 1h),
+  single-replica-gated (ADR-039) so a secret rotates once per tick in HA. Distinct from
+  `rotation_reminders`, which only notifies.
+
+## Why opt-in and only "owned" secrets
+
+Auto-rotation changes the stored value **without touching any upstream system**. For a
+secret that mirrors an external credential (a cloud key, a DB password managed
+elsewhere), silently regenerating the Keyorix copy would desynchronize it from the real
+credential and break consumers. So auto-rotation is strictly opt-in per secret, and the
+opt-in is the operator's assertion that *this value is Keyorix's to regenerate*.
+Consumers that fetch the current value from Keyorix on each use then pick up the new
+value automatically — which is the intended pattern.
+
+## Alternatives considered
+
+- **Rotate everything a policy covers**: rejected — unsafe for externally-owned
+  secrets (see above). The per-secret opt-in is the safety boundary.
+- **Pluggable rotation "executors" per backend** (rotate the upstream credential too,
+  Vault-style): the powerful general case, but it needs per-system integrations and
+  credentials. Deferred; the generated-value path covers Keyorix-owned secrets — the
+  common toil — with no new trust surface. This ADR leaves room for backend executors
+  later (the opt-in + scheduler are reusable).
+- **A generator spec per secret** (length/charset): deferred in favor of one strong
+  alphanumeric default; add a spec if a real need appears.
+
+## Consequences
+
+- Keyorix-owned secrets can now rotate on schedule with zero human action, fully
+  audited.
+- New per-secret column `auto_rotate` (additive migration) and an opt-in scheduler;
+  both off by default, so existing installs are unchanged.
+- Management of the flag currently lands over HTTP; gRPC/CLI/web toggles are follow-ups
+  (the executor and audit trail are transport-agnostic).

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,6 +25,10 @@ type Config struct {
 	// RotationReminders configures the opt-in background scheduler that notifies
 	// project admins of secrets overdue / approaching their rotation deadline.
 	RotationReminders RotationRemindersConfig `yaml:"rotation_reminders"`
+	// AutoRotation configures the opt-in background scheduler that actually rotates
+	// auto-rotate-enabled secrets overdue under a policy (ADR-046), regenerating their
+	// value. Distinct from rotation_reminders, which only notifies.
+	AutoRotation AutoRotationConfig `yaml:"auto_rotation"`
 	// AuditCheckpoints configures the opt-in background scheduler that writes
 	// signed checkpoints of the audit hash chain (ADR-029) for on-box truncation
 	// detection. Requires encryption enabled (the signing key is DEK-derived).
@@ -896,6 +900,23 @@ func (p *SSOProviderConfig) GetClientSecret() string {
 type RotationRemindersConfig struct {
 	Enabled  bool   `yaml:"enabled"`
 	Schedule string `yaml:"schedule"`
+}
+
+// AutoRotationConfig configures the opt-in automated-rotation scheduler (ADR-046).
+type AutoRotationConfig struct {
+	Enabled  bool   `yaml:"enabled"`
+	Schedule string `yaml:"schedule"`
+}
+
+// GetInterval returns the auto-rotation run interval (Go duration, e.g. "1h");
+// defaults to 1h when unset or unparseable.
+func (c AutoRotationConfig) GetInterval() time.Duration {
+	if c.Schedule != "" {
+		if d, err := time.ParseDuration(c.Schedule); err == nil && d > 0 {
+			return d
+		}
+	}
+	return time.Hour
 }
 
 // GetInterval returns the rotation-reminder run interval (Go duration, e.g. "24h");

--- a/internal/core/rotation_executor.go
+++ b/internal/core/rotation_executor.go
@@ -1,0 +1,120 @@
+// rotation_executor.go — automated secret rotation (ADR-046). Rotation policies say
+// WHEN a secret should rotate and reminders nudge admins; this executor actually
+// rotates the secrets that opted in (SecretNode.AutoRotate) by regenerating their
+// value when they are overdue under an active covering policy.
+//
+// Only auto-rotate-enabled secrets are touched, and the new value is a freshly
+// generated random string — so this is for secrets whose value Keyorix owns. A secret
+// that mirrors an external system's credential must NOT enable auto-rotation, since
+// regenerating it here does not update the upstream.
+package core
+
+import (
+	"context"
+	"fmt"
+	"log"
+)
+
+// Audit events for automated rotation (ADR-046).
+const (
+	EventSecretAutoRotated      = "secret.auto_rotated"
+	EventSecretAutoRotateConfig = "secret.auto_rotate_configured"
+)
+
+// rotatedValueLength / rotatedValueCharset define the generated value: 32 chars over a
+// 62-symbol alphanumeric set (~190 bits of entropy). Alphanumeric only, so a consumer
+// that reads the value back never trips over shell/URL metacharacters.
+const (
+	rotatedValueLength  = 32
+	rotatedValueCharset = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
+)
+
+// generateRotatedValue returns a fresh random secret value (crypto/rand).
+func generateRotatedValue() (string, error) {
+	b := make([]byte, rotatedValueLength)
+	for i := range b {
+		ch, err := randChar(rotatedValueCharset)
+		if err != nil {
+			return "", err
+		}
+		b[i] = ch
+	}
+	return string(b), nil
+}
+
+// RunAutoRotation rotates every auto-rotate-enabled secret that is overdue under an
+// active rotation policy, regenerating its value (a new version) and auditing each
+// rotation. Best-effort per secret: a generate/rotate failure is logged and skipped,
+// never aborting the run. A secret covered by multiple policies is rotated at most once
+// per run. Returns the number of secrets rotated.
+func (c *KeyorixCore) RunAutoRotation(ctx context.Context) (int, error) {
+	policies, err := c.storage.ListRotationPolicies(ctx, nil, nil)
+	if err != nil {
+		return 0, fmt.Errorf("auto-rotation: list policies: %w", err)
+	}
+	now := c.now()
+	rotated := 0
+	done := make(map[uint]bool)
+
+	for _, policy := range policies {
+		if !policy.IsActive {
+			continue
+		}
+		secrets, err := c.scopedPolicySecrets(ctx, policy)
+		if err != nil {
+			continue
+		}
+		for _, secret := range secrets {
+			if !secret.AutoRotate || done[secret.ID] {
+				continue
+			}
+			lastRotated := secret.CreatedAt
+			if secret.LastRotatedAt != nil {
+				lastRotated = *secret.LastRotatedAt
+			}
+			daysSince := int(now.Sub(lastRotated).Hours() / 24)
+			if daysSince < policy.IntervalDays {
+				continue // not yet due under this policy
+			}
+
+			val, gerr := generateRotatedValue()
+			if gerr != nil {
+				log.Printf("auto-rotation: generate value for secret %d: %v", secret.ID, gerr)
+				continue
+			}
+			if _, rerr := c.RotateSecret(ctx, secret.ID, []byte(val), "system:auto-rotation"); rerr != nil {
+				log.Printf("auto-rotation: rotate secret %d: %v", secret.ID, rerr)
+				continue
+			}
+			done[secret.ID] = true
+			rotated++
+			sid := secret.ID
+			c.writeAuditEvent(ctx, EventSecretAutoRotated, nil, &sid,
+				fmt.Sprintf("auto-rotated secret %q (policy %q, interval %dd)", secret.Name, policy.Name, policy.IntervalDays))
+		}
+	}
+	return rotated, nil
+}
+
+// SetSecretAutoRotate enables or disables automated rotation for a secret and audits
+// the change. Enable only for secrets whose value Keyorix owns (see the file header).
+func (c *KeyorixCore) SetSecretAutoRotate(ctx context.Context, id uint, enabled bool, actorID uint) error {
+	secret, err := c.storage.GetSecret(ctx, id)
+	if err != nil {
+		return fmt.Errorf("secret not found: %w", err)
+	}
+	secret.AutoRotate = enabled
+	secret.UpdatedAt = c.now()
+	if _, err := c.storage.UpdateSecret(ctx, secret); err != nil {
+		return fmt.Errorf("failed to update secret: %w", err)
+	}
+	uid := actorID
+	sid := id
+	verb := "disabled"
+	if enabled {
+		verb = "enabled"
+	}
+	c.writeAuditEvent(ctx, EventSecretAutoRotateConfig, &uid, &sid,
+		fmt.Sprintf("auto-rotation %s for secret %q", verb, secret.Name))
+	return nil
+}

--- a/internal/core/rotation_executor_test.go
+++ b/internal/core/rotation_executor_test.go
@@ -1,0 +1,128 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func rotationExecCore(t *testing.T) (*KeyorixCore, *gorm.DB, time.Time) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.SecretNode{}, &models.SecretVersion{}, &models.RotationPolicy{}, &models.AuditEvent{},
+		&models.Project{}, &models.Environment{},
+	))
+	// ListSecrets(ProjectID) JOINs environments, so the scope needs a real env row.
+	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "proj"}).Error)
+	require.NoError(t, db.Create(&models.Environment{ID: 1, ProjectID: 1, Name: "prod"}).Error)
+	c := &KeyorixCore{storage: store.NewLocalStorage(db)}
+	fixed := time.Date(2026, 6, 16, 12, 0, 0, 0, time.UTC)
+	c.now = func() time.Time { return fixed }
+	return c, db, fixed
+}
+
+func seedRotatableSecret(t *testing.T, db *gorm.DB, id uint, name string, autoRotate bool, lastRotated time.Time) {
+	t.Helper()
+	lr := lastRotated
+	require.NoError(t, db.Create(&models.SecretNode{
+		ID: id, Name: name, ProjectID: 1, EnvironmentID: 1, IsSecret: true,
+		Status: "active", AutoRotate: autoRotate, LastRotatedAt: &lr, CreatedAt: lastRotated,
+	}).Error)
+	require.NoError(t, db.Create(&models.SecretVersion{
+		SecretNodeID: id, VersionNumber: 1, EncryptedValue: []byte("original-" + name),
+		EncryptionMetadata: []byte("{}"), CreatedAt: lastRotated,
+	}).Error)
+}
+
+func latestVersion(t *testing.T, db *gorm.DB, secretID uint) *models.SecretVersion {
+	t.Helper()
+	var v models.SecretVersion
+	require.NoError(t, db.Where("secret_node_id = ?", secretID).Order("version_number desc").First(&v).Error)
+	return &v
+}
+
+func TestRunAutoRotation_RotatesOverdueOptedInOnly(t *testing.T) {
+	c, db, fixed := rotationExecCore(t)
+	pid := uint(1)
+	require.NoError(t, db.Create(&models.RotationPolicy{
+		ID: 1, Name: "30-day", Scope: "project", ProjectID: &pid, IntervalDays: 30,
+		IsActive: true, CreatedBy: "admin",
+	}).Error)
+
+	seedRotatableSecret(t, db, 1, "due-managed", true, fixed.Add(-60*24*time.Hour))   // overdue + opted-in → rotate
+	seedRotatableSecret(t, db, 2, "fresh-managed", true, fixed.Add(-5*24*time.Hour))  // opted-in but not due → skip
+	seedRotatableSecret(t, db, 3, "due-external", false, fixed.Add(-60*24*time.Hour)) // overdue but not opted-in → skip
+
+	n, err := c.RunAutoRotation(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, n, "only the overdue, opted-in secret rotates")
+
+	// s1: new version with a freshly generated (different) value; LastRotatedAt advanced.
+	v1 := latestVersion(t, db, 1)
+	assert.Equal(t, 2, v1.VersionNumber, "due-managed secret gained a new version")
+	assert.NotEqual(t, "original-due-managed", string(v1.EncryptedValue))
+	assert.Len(t, string(v1.EncryptedValue), rotatedValueLength)
+	var s1 models.SecretNode
+	require.NoError(t, db.First(&s1, 1).Error)
+	require.NotNil(t, s1.LastRotatedAt)
+	assert.True(t, s1.LastRotatedAt.After(fixed.Add(-time.Minute)), "LastRotatedAt advanced to now")
+
+	// s2 and s3 are untouched (still on version 1).
+	assert.Equal(t, 1, latestVersion(t, db, 2).VersionNumber, "not-due secret unchanged")
+	assert.Equal(t, 1, latestVersion(t, db, 3).VersionNumber, "non-opted-in secret unchanged")
+}
+
+func TestRunAutoRotation_InactivePolicyIgnored(t *testing.T) {
+	c, db, fixed := rotationExecCore(t)
+	pid := uint(1)
+	require.NoError(t, db.Create(&models.RotationPolicy{
+		ID: 1, Name: "off", Scope: "project", ProjectID: &pid, IntervalDays: 30,
+		IsActive: true, CreatedBy: "admin",
+	}).Error)
+	// GORM applies the column default (is_active=true) for a zero-value bool on Create,
+	// so force it false explicitly to model an inactive policy.
+	require.NoError(t, db.Model(&models.RotationPolicy{}).Where("id = ?", 1).Update("is_active", false).Error)
+	seedRotatableSecret(t, db, 1, "due-managed", true, fixed.Add(-60*24*time.Hour))
+
+	n, err := c.RunAutoRotation(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 0, n, "no rotation under an inactive policy")
+	assert.Equal(t, 1, latestVersion(t, db, 1).VersionNumber)
+}
+
+func TestSetSecretAutoRotate_TogglesAndPersists(t *testing.T) {
+	c, db, fixed := rotationExecCore(t)
+	seedRotatableSecret(t, db, 1, "key", false, fixed.Add(-24*time.Hour))
+
+	require.NoError(t, c.SetSecretAutoRotate(context.Background(), 1, true, 9))
+	var s models.SecretNode
+	require.NoError(t, db.First(&s, 1).Error)
+	assert.True(t, s.AutoRotate)
+
+	require.NoError(t, c.SetSecretAutoRotate(context.Background(), 1, false, 9))
+	require.NoError(t, db.First(&s, 1).Error)
+	assert.False(t, s.AutoRotate)
+}
+
+func TestGenerateRotatedValue_UniqueAndCharset(t *testing.T) {
+	seen := map[string]bool{}
+	for i := 0; i < 50; i++ {
+		v, err := generateRotatedValue()
+		require.NoError(t, err)
+		assert.Len(t, v, rotatedValueLength)
+		for _, ch := range v {
+			assert.Contains(t, rotatedValueCharset, string(ch))
+		}
+		assert.False(t, seen[v], "values must not repeat")
+		seen[v] = true
+	}
+}

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -151,6 +151,10 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 	if tableExists(db, "secret_nodes") && !columnExists(db, "secret_nodes", "classification") {
 		db.Exec("ALTER TABLE secret_nodes ADD COLUMN classification TEXT DEFAULT ''")
 	}
+	// ADR-046: automated rotation opt-in. Additive auto_rotate (false = off).
+	if tableExists(db, "secret_nodes") && !columnExists(db, "secret_nodes", "auto_rotate") {
+		db.Exec("ALTER TABLE secret_nodes ADD COLUMN auto_rotate BOOLEAN NOT NULL DEFAULT false")
+	}
 	// Anomaly alerting: additive `alerted` flag (false = not yet pushed out).
 	if tableExists(db, "anomaly_alerts") && !columnExists(db, "anomaly_alerts", "alerted") {
 		db.Exec("ALTER TABLE anomaly_alerts ADD COLUMN alerted BOOLEAN DEFAULT FALSE")

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -440,6 +440,12 @@ type SecretNode struct {
 	CreatedAt      time.Time
 	UpdatedAt      time.Time
 	LastRotatedAt  *time.Time
+	// AutoRotate opts this secret into automated rotation (ADR-046): when set, and the
+	// secret is covered by an active rotation policy it is overdue under, the rotation
+	// executor regenerates its value on schedule. Off by default — only secrets whose
+	// value Keyorix owns (generated, no external consumer to coordinate) should enable
+	// it, since auto-rotation changes the stored value without touching any upstream.
+	AutoRotate bool `gorm:"not null;default:false"`
 	// DeletedAt enables soft delete (ADR-033). DELETE stamps it; restore clears
 	// it; the purge scheduler hard-deletes rows past the retention window. GORM
 	// auto-scopes `deleted_at IS NULL` on model-based queries — raw/Table/Joins

--- a/server/http/handlers/secrets_crud.go
+++ b/server/http/handlers/secrets_crud.go
@@ -136,6 +136,37 @@ func (h *SecretHandler) ClassifySecret(w http.ResponseWriter, r *http.Request) {
 	h.sendSuccess(w, secret, "Classification updated")
 }
 
+// SetAutoRotate handles PATCH /api/v1/secrets/{id}/auto-rotate — toggles automated
+// rotation (ADR-046) for a secret. Enable only for secrets whose value Keyorix owns.
+func (h *SecretHandler) SetAutoRotate(w http.ResponseWriter, r *http.Request) {
+	userCtx := middleware.GetUserFromContext(r.Context())
+	if userCtx == nil {
+		h.sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		h.sendError(w, "InvalidParameter", "Invalid secret ID", http.StatusBadRequest, nil)
+		return
+	}
+	var reqBody struct {
+		Enabled bool `json:"enabled"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
+		h.sendError(w, "InvalidJSON", "Invalid JSON in request body", http.StatusBadRequest, nil)
+		return
+	}
+	if err := h.coreService.SetSecretAutoRotate(r.Context(), uint(id), reqBody.Enabled, userCtx.UserID); err != nil {
+		status := http.StatusInternalServerError
+		if strings.Contains(err.Error(), "not found") {
+			status = http.StatusNotFound
+		}
+		h.sendError(w, "Error", err.Error(), status, nil)
+		return
+	}
+	h.sendSuccess(w, map[string]interface{}{"id": id, "auto_rotate": reqBody.Enabled}, "Auto-rotation updated")
+}
+
 // GetSecret handles GET /api/v1/secrets/{id}
 func (h *SecretHandler) GetSecret(w http.ResponseWriter, r *http.Request) {
 	userCtx := middleware.GetUserFromContext(r.Context())

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -327,6 +327,7 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.Post("/", secretHandler.CreateSecret)
 			r.With(customMiddleware.RequireScopedPermission("secrets.write", secretScope)).Put("/{id}", secretHandler.UpdateSecret)
 			r.With(customMiddleware.RequireScopedPermission("secrets.write", secretScope)).Patch("/{id}/classification", secretHandler.ClassifySecret)
+			r.With(customMiddleware.RequireScopedPermission("secrets.write", secretScope)).Patch("/{id}/auto-rotate", secretHandler.SetAutoRotate)
 			r.With(customMiddleware.RequireScopedPermission("secrets.write", secretScope)).Post("/{id}/rotate", secretHandler.RotateSecret)
 			r.With(customMiddleware.RequireScopedPermission("secrets.write", secretScope)).Post("/{id}/share", shareHandler.ShareSecret)
 

--- a/server/main.go
+++ b/server/main.go
@@ -147,6 +147,7 @@ const (
 	schedLockDynamicSweep int64 = 0x4B455953_44594E53 // "KEYSDYNS"
 	schedLockLoginPrune   int64 = 0x4B455953_4C474E50 // "KEYSLGNP"
 	schedLockRotationRmdr int64 = 0x4B455953_524F5452 // "KEYSROTR"
+	schedLockAutoRotate   int64 = 0x4B455953_4155544F // "KEYSAUTO"
 	schedLockAuditCkpt    int64 = 0x4B455953_41434B50 // "KEYSACKP"
 	schedLockJITExpiry    int64 = 0x4B455953_4A495445 // "KEYSJITE"
 	schedLockRetention    int64 = 0x4B455953_52455445 // "KEYSRETE"
@@ -754,6 +755,43 @@ func startHTTPServer(ctx context.Context, cfg *config.Config) error {
 				select {
 				case <-ticker.C:
 					runReminders()
+				case <-ctx.Done():
+					return
+				}
+			}
+		}()
+	}
+
+	// Start the automated-rotation scheduler — opt-in (ADR-046). Rotates auto-rotate-
+	// enabled secrets that are overdue under an active policy, regenerating their value.
+	// Single-replica-gated (ADR-039) so a secret rotates once per tick in an HA
+	// deployment.
+	if cfg.AutoRotation.Enabled {
+		interval := cfg.AutoRotation.GetInterval()
+		log.Printf("Auto-rotation scheduler enabled: every %s", interval)
+		go func() {
+			ticker := time.NewTicker(interval)
+			defer ticker.Stop()
+			runAutoRotation := func() {
+				if _, err := coreService.Storage().WithSchedulerLock(ctx, schedLockAutoRotate, func() error {
+					n, rerr := coreService.RunAutoRotation(ctx)
+					if rerr != nil {
+						log.Printf("Auto-rotation error: %v", rerr)
+						return rerr
+					}
+					if n > 0 {
+						log.Printf("Auto-rotation: rotated %d secret(s)", n)
+					}
+					return nil
+				}); err != nil {
+					log.Printf("Auto-rotation scheduler error: %v", err)
+				}
+			}
+			runAutoRotation() // run once on startup
+			for {
+				select {
+				case <-ticker.C:
+					runAutoRotation()
 				case <-ctx.Done():
 					return
 				}


### PR DESCRIPTION
Rotation policies + reminders said *when* to rotate, but nothing actually rotated. This adds an **opt-in executor** that regenerates the value of auto-rotate-enabled secrets once they fall overdue under an active policy — closing the rotation-hygiene gap for secrets Keyorix owns.

## Changes
- **model**: `SecretNode.AutoRotate` (additive migration, default false) — per-secret opt-in marking a value as Keyorix-owned and safe to regenerate.
- **core**: `RunAutoRotation` walks active policies → covered secrets; rotates each `AutoRotate`+overdue secret with a fresh `crypto/rand` value (32 alphanumeric chars, ~190 bits), best-effort per secret, **once per run**, auditing `secret.auto_rotated`. `SetSecretAutoRotate` toggles the flag (audited).
- **http**: `PATCH /secrets/{id}/auto-rotate` (scoped `secrets.write`), mirroring the classify endpoint.
- **scheduler**: opt-in `auto_rotation` block (default off, 1h), single-replica-gated (ADR-039); distinct from `rotation_reminders` (notify-only).
- **docs**: ADR-046.

## Safety model
Auto-rotation changes the stored value **without touching any upstream**, so it's strictly **opt-in per secret** — the operator's assertion that *this value is Keyorix's to regenerate*. A secret mirroring an external credential must not enable it. Consumers that fetch current values pick up the new value automatically.

## Tests
Executor rotates overdue+opted-in **only** (value changes, version bumps, `LastRotatedAt` advances); skips not-due / not-opted-in / inactive-policy; toggle persists; generator unique + charset. New mutating route verified **403** to a read-only persona. gofmt/build/test/gosec/golangci-lint/gitleaks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)