### PR TITLE
feat(rotation): per-secret generator spec — length + charset (ADR-046)

### DIFF
--- a/docs/adr-046-automated-secret-rotation.md
+++ b/docs/adr-046-automated-secret-rotation.md
@@ -56,8 +56,13 @@ value automatically — which is the intended pattern.
   credentials. Deferred; the generated-value path covers Keyorix-owned secrets — the
   common toil — with no new trust surface. This ADR leaves room for backend executors
   later (the opt-in + scheduler are reusable).
-- **A generator spec per secret** (length/charset): deferred in favor of one strong
-  alphanumeric default; add a spec if a real need appears.
+- **A generator spec per secret** (length/charset): now supported — a secret may set
+  `rotation_length` (8–256, default 32) and `rotation_charset` (one of `alphanumeric`
+  [default] / `lower_alphanumeric` / `hex` / `alphanumeric_symbols`) via the toggle
+  endpoint, so the generated value can meet a system's password requirements. Defaults
+  preserve the original 32-char alphanumeric behavior; an unknown charset fails the
+  request (and, defensively, falls back to alphanumeric at generation — never an empty
+  alphabet). A full template language was rejected as overkill for v1.
 
 ## Consequences
 

--- a/internal/core/rotation_executor.go
+++ b/internal/core/rotation_executor.go
@@ -21,19 +21,65 @@ const (
 	EventSecretAutoRotateConfig = "secret.auto_rotate_configured"
 )
 
-// rotatedValueLength / rotatedValueCharset define the generated value: 32 chars over a
-// 62-symbol alphanumeric set (~190 bits of entropy). Alphanumeric only, so a consumer
-// that reads the value back never trips over shell/URL metacharacters.
+// Default generated value: 32 chars over a 62-symbol alphanumeric set (~190 bits).
+// Alphanumeric so a consumer reading it back never trips over shell/URL metacharacters.
 const (
-	rotatedValueLength  = 32
-	rotatedValueCharset = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
+	rotatedValueLength    = 32
+	rotatedValueMinLength = 8
+	rotatedValueMaxLength = 256
 )
 
-// generateRotatedValue returns a fresh random secret value (crypto/rand).
+// Named charsets a secret may select via RotationCharset (ADR-046). "" = alphanumeric.
+const (
+	charsetAlphanumeric = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
+	charsetLowerAlnum   = "abcdefghijklmnopqrstuvwxyz0123456789"
+	charsetHex          = "0123456789abcdef"
+	charsetAlnumSymbols = charsetAlphanumeric + "!@#$%^&*-_=+"
+	rotatedValueCharset = charsetAlphanumeric // back-compat alias (default)
+)
+
+// resolveCharset maps a RotationCharset name to its character set, defaulting to
+// alphanumeric for "" or an unknown name (fail-safe: never an empty alphabet).
+func resolveCharset(name string) string {
+	switch name {
+	case "lower_alphanumeric":
+		return charsetLowerAlnum
+	case "hex":
+		return charsetHex
+	case "alphanumeric_symbols":
+		return charsetAlnumSymbols
+	default:
+		return charsetAlphanumeric
+	}
+}
+
+// resolveLength clamps a requested length into [min,max], defaulting to 32 for 0.
+func resolveLength(n int) int {
+	if n <= 0 {
+		return rotatedValueLength
+	}
+	if n < rotatedValueMinLength {
+		return rotatedValueMinLength
+	}
+	if n > rotatedValueMaxLength {
+		return rotatedValueMaxLength
+	}
+	return n
+}
+
+// generateRotatedValue returns a fresh random value of the default shape (crypto/rand).
 func generateRotatedValue() (string, error) {
-	b := make([]byte, rotatedValueLength)
+	return generateRotatedValueSpec(0, "")
+}
+
+// generateRotatedValueSpec returns a fresh random value of the requested length and
+// charset (crypto/rand), applying the defaults/clamping above.
+func generateRotatedValueSpec(length int, charset string) (string, error) {
+	n := resolveLength(length)
+	set := resolveCharset(charset)
+	b := make([]byte, n)
 	for i := range b {
-		ch, err := randChar(rotatedValueCharset)
+		ch, err := randChar(set)
 		if err != nil {
 			return "", err
 		}
@@ -77,7 +123,7 @@ func (c *KeyorixCore) RunAutoRotation(ctx context.Context) (int, error) {
 				continue // not yet due under this policy
 			}
 
-			val, gerr := generateRotatedValue()
+			val, gerr := generateRotatedValueSpec(secret.RotationLength, secret.RotationCharset)
 			if gerr != nil {
 				log.Printf("auto-rotation: generate value for secret %d: %v", secret.ID, gerr)
 				continue
@@ -96,14 +142,33 @@ func (c *KeyorixCore) RunAutoRotation(ctx context.Context) (int, error) {
 	return rotated, nil
 }
 
-// SetSecretAutoRotate enables or disables automated rotation for a secret and audits
-// the change. Enable only for secrets whose value Keyorix owns (see the file header).
-func (c *KeyorixCore) SetSecretAutoRotate(ctx context.Context, id uint, enabled bool, actorID uint) error {
+// knownRotationCharset reports whether name is a recognized charset (or "" = default).
+func knownRotationCharset(name string) bool {
+	switch name {
+	case "", "alphanumeric", "lower_alphanumeric", "hex", "alphanumeric_symbols":
+		return true
+	default:
+		return false
+	}
+}
+
+// SetSecretAutoRotate enables or disables automated rotation for a secret and sets the
+// generated-value shape (length 0 = default, charset "" = default alphanumeric), then
+// audits the change. Enable only for secrets whose value Keyorix owns (see file header).
+func (c *KeyorixCore) SetSecretAutoRotate(ctx context.Context, id uint, enabled bool, length int, charset string, actorID uint) error {
+	if !knownRotationCharset(charset) {
+		return fmt.Errorf("unknown rotation charset %q (want alphanumeric|lower_alphanumeric|hex|alphanumeric_symbols)", charset)
+	}
+	if length != 0 && (length < rotatedValueMinLength || length > rotatedValueMaxLength) {
+		return fmt.Errorf("rotation length %d out of range (%d–%d, or 0 for default)", length, rotatedValueMinLength, rotatedValueMaxLength)
+	}
 	secret, err := c.storage.GetSecret(ctx, id)
 	if err != nil {
 		return fmt.Errorf("secret not found: %w", err)
 	}
 	secret.AutoRotate = enabled
+	secret.RotationLength = length
+	secret.RotationCharset = charset
 	secret.UpdatedAt = c.now()
 	if _, err := c.storage.UpdateSecret(ctx, secret); err != nil {
 		return fmt.Errorf("failed to update secret: %w", err)

--- a/internal/core/rotation_executor_test.go
+++ b/internal/core/rotation_executor_test.go
@@ -103,14 +103,82 @@ func TestSetSecretAutoRotate_TogglesAndPersists(t *testing.T) {
 	c, db, fixed := rotationExecCore(t)
 	seedRotatableSecret(t, db, 1, "key", false, fixed.Add(-24*time.Hour))
 
-	require.NoError(t, c.SetSecretAutoRotate(context.Background(), 1, true, 9))
+	// Enable with a generator spec.
+	require.NoError(t, c.SetSecretAutoRotate(context.Background(), 1, true, 48, "hex", 9))
 	var s models.SecretNode
 	require.NoError(t, db.First(&s, 1).Error)
 	assert.True(t, s.AutoRotate)
+	assert.Equal(t, 48, s.RotationLength)
+	assert.Equal(t, "hex", s.RotationCharset)
 
-	require.NoError(t, c.SetSecretAutoRotate(context.Background(), 1, false, 9))
+	require.NoError(t, c.SetSecretAutoRotate(context.Background(), 1, false, 0, "", 9))
 	require.NoError(t, db.First(&s, 1).Error)
 	assert.False(t, s.AutoRotate)
+}
+
+func TestSetSecretAutoRotate_ValidatesSpec(t *testing.T) {
+	c, db, fixed := rotationExecCore(t)
+	seedRotatableSecret(t, db, 1, "key", false, fixed.Add(-24*time.Hour))
+	ctx := context.Background()
+
+	err := c.SetSecretAutoRotate(ctx, 1, true, 0, "klingon", 9)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown rotation charset")
+
+	err = c.SetSecretAutoRotate(ctx, 1, true, 5000, "", 9)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "out of range")
+}
+
+func TestGenerateRotatedValueSpec_LengthAndCharset(t *testing.T) {
+	// hex charset, custom length.
+	v, err := generateRotatedValueSpec(48, "hex")
+	require.NoError(t, err)
+	assert.Len(t, v, 48)
+	for _, ch := range v {
+		assert.Contains(t, charsetHex, string(ch))
+	}
+	// length 0 → default; unknown charset → alphanumeric (fail-safe, never empty).
+	v, err = generateRotatedValueSpec(0, "bogus")
+	require.NoError(t, err)
+	assert.Len(t, v, rotatedValueLength)
+	for _, ch := range v {
+		assert.Contains(t, charsetAlphanumeric, string(ch))
+	}
+	// below-min length clamps up, not to zero-length.
+	v, err = generateRotatedValueSpec(2, "")
+	require.NoError(t, err)
+	assert.Len(t, v, rotatedValueMinLength)
+}
+
+// The executor honors a secret's generator spec.
+func TestRunAutoRotation_UsesSecretSpec(t *testing.T) {
+	c, db, fixed := rotationExecCore(t)
+	pid := uint(1)
+	require.NoError(t, db.Create(&models.RotationPolicy{
+		ID: 1, Name: "30-day", Scope: "project", ProjectID: &pid, IntervalDays: 30,
+		IsActive: true, CreatedBy: "admin",
+	}).Error)
+	// Overdue, opted-in, hex/16.
+	lr := fixed.Add(-60 * 24 * time.Hour)
+	require.NoError(t, db.Create(&models.SecretNode{
+		ID: 1, Name: "hex-key", ProjectID: 1, EnvironmentID: 1, IsSecret: true, Status: "active",
+		AutoRotate: true, RotationLength: 16, RotationCharset: "hex", LastRotatedAt: &lr, CreatedAt: lr,
+	}).Error)
+	require.NoError(t, db.Create(&models.SecretVersion{
+		SecretNodeID: 1, VersionNumber: 1, EncryptedValue: []byte("orig"), EncryptionMetadata: []byte("{}"), CreatedAt: lr,
+	}).Error)
+
+	n, err := c.RunAutoRotation(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 1, n)
+
+	v := latestVersion(t, db, 1)
+	assert.Equal(t, 2, v.VersionNumber)
+	assert.Len(t, string(v.EncryptedValue), 16)
+	for _, ch := range string(v.EncryptedValue) {
+		assert.Contains(t, charsetHex, string(ch))
+	}
 }
 
 func TestGenerateRotatedValue_UniqueAndCharset(t *testing.T) {

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -155,6 +155,15 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 	if tableExists(db, "secret_nodes") && !columnExists(db, "secret_nodes", "auto_rotate") {
 		db.Exec("ALTER TABLE secret_nodes ADD COLUMN auto_rotate BOOLEAN NOT NULL DEFAULT false")
 	}
+	// ADR-046: per-secret generated-value shape. Additive (0/'' = defaults).
+	if tableExists(db, "secret_nodes") {
+		if !columnExists(db, "secret_nodes", "rotation_length") {
+			db.Exec("ALTER TABLE secret_nodes ADD COLUMN rotation_length INTEGER NOT NULL DEFAULT 0")
+		}
+		if !columnExists(db, "secret_nodes", "rotation_charset") {
+			db.Exec("ALTER TABLE secret_nodes ADD COLUMN rotation_charset TEXT NOT NULL DEFAULT ''")
+		}
+	}
 	// Anomaly alerting: additive `alerted` flag (false = not yet pushed out).
 	if tableExists(db, "anomaly_alerts") && !columnExists(db, "anomaly_alerts", "alerted") {
 		db.Exec("ALTER TABLE anomaly_alerts ADD COLUMN alerted BOOLEAN DEFAULT FALSE")

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -446,6 +446,11 @@ type SecretNode struct {
 	// value Keyorix owns (generated, no external consumer to coordinate) should enable
 	// it, since auto-rotation changes the stored value without touching any upstream.
 	AutoRotate bool `gorm:"not null;default:false"`
+	// RotationLength / RotationCharset shape the value the auto-rotation executor
+	// generates (ADR-046). RotationLength 0 = the default length; RotationCharset "" =
+	// the default alphanumeric set. See the rotation executor for the named charsets.
+	RotationLength  int    `gorm:"not null;default:0"`
+	RotationCharset string `gorm:"not null;default:''"`
 	// DeletedAt enables soft delete (ADR-033). DELETE stamps it; restore clears
 	// it; the purge scheduler hard-deletes rows past the retention window. GORM
 	// auto-scopes `deleted_at IS NULL` on model-based queries — raw/Table/Joins

--- a/server/http/handlers/secrets_crud.go
+++ b/server/http/handlers/secrets_crud.go
@@ -150,21 +150,28 @@ func (h *SecretHandler) SetAutoRotate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var reqBody struct {
-		Enabled bool `json:"enabled"`
+		Enabled bool   `json:"enabled"`
+		Length  int    `json:"length"`  // 0 = default
+		Charset string `json:"charset"` // "" = default alphanumeric
 	}
 	if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
 		h.sendError(w, "InvalidJSON", "Invalid JSON in request body", http.StatusBadRequest, nil)
 		return
 	}
-	if err := h.coreService.SetSecretAutoRotate(r.Context(), uint(id), reqBody.Enabled, userCtx.UserID); err != nil {
+	if err := h.coreService.SetSecretAutoRotate(r.Context(), uint(id), reqBody.Enabled, reqBody.Length, reqBody.Charset, userCtx.UserID); err != nil {
 		status := http.StatusInternalServerError
-		if strings.Contains(err.Error(), "not found") {
+		switch {
+		case strings.Contains(err.Error(), "not found"):
 			status = http.StatusNotFound
+		case strings.Contains(err.Error(), "unknown rotation charset"), strings.Contains(err.Error(), "out of range"):
+			status = http.StatusBadRequest
 		}
 		h.sendError(w, "Error", err.Error(), status, nil)
 		return
 	}
-	h.sendSuccess(w, map[string]interface{}{"id": id, "auto_rotate": reqBody.Enabled}, "Auto-rotation updated")
+	h.sendSuccess(w, map[string]interface{}{
+		"id": id, "auto_rotate": reqBody.Enabled, "length": reqBody.Length, "charset": reqBody.Charset,
+	}, "Auto-rotation updated")
 }
 
 // GetSecret handles GET /api/v1/secrets/{id}


### PR DESCRIPTION
Extends automated rotation (ADR-046, #263): auto-rotation always emitted a fixed 32-char alphanumeric value, but real systems have password-shape requirements. A secret can now choose the **length and charset** of its generated value.

## Changes
- **model**: `SecretNode.RotationLength` (8–256, `0` = default 32) + `RotationCharset` (additive migration; `""` = alphanumeric).
- **generator**: named charsets — `alphanumeric` (default) / `lower_alphanumeric` / `hex` / `alphanumeric_symbols`; `generateRotatedValueSpec(length, charset)` clamps length and **fails safe** to alphanumeric on an unknown charset (never an empty alphabet). The executor uses each secret's spec.
- **api**: `SetSecretAutoRotate` validates the charset name + length range; `PATCH /secrets/{id}/auto-rotate` accepts optional `length`/`charset` (bad values → `400`).
- **docs**: ADR-046 updated.

Defaults preserve the prior 32-char alphanumeric behavior, so existing auto-rotate secrets are unchanged.

## Tests
Toggle persists spec; validation (unknown charset, out-of-range length); generator honors length+charset, clamps below-min, falls back on unknown charset; executor rotates with a hex/16 spec. gofmt/build/test/gosec/golangci-lint/gitleaks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)