### PR TITLE
feat(rotation): gRPC + CLI auto-rotate toggle parity (ADR-046)

### DIFF
--- a/internal/cli/secret/autorotate.go
+++ b/internal/cli/secret/autorotate.go
@@ -1,0 +1,67 @@
+package secret
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/spf13/cobra"
+)
+
+var (
+	autoRotateID      uint
+	autoRotateOff     bool
+	autoRotateLength  int
+	autoRotateCharset string
+)
+
+var autoRotateCmd = &cobra.Command{
+	Use:   "auto-rotate",
+	Short: "Enable/disable automated rotation for a secret (ADR-046)",
+	Long: `Opt a secret into automated rotation: when it is overdue under an active
+rotation policy, Keyorix regenerates its value on schedule. Optionally set the generated
+value's shape with --length and --charset. Use --off to disable.
+
+Enable only for secrets whose value Keyorix owns — auto-rotation changes the stored
+value without touching any upstream system. Requires secrets.write at the secret's scope.`,
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		if autoRotateID == 0 {
+			return fmt.Errorf("--id is required")
+		}
+		switch autoRotateCharset {
+		case "", "alphanumeric", "lower_alphanumeric", "hex", "alphanumeric_symbols":
+		default:
+			return fmt.Errorf("--charset must be alphanumeric, lower_alphanumeric, hex, or alphanumeric_symbols")
+		}
+		c, ok := common.NewRemoteClient()
+		if !ok {
+			return fmt.Errorf("not connected to a server — run: keyorix connect <server>")
+		}
+		body := map[string]interface{}{
+			"enabled": !autoRotateOff,
+			"length":  autoRotateLength,
+			"charset": autoRotateCharset,
+		}
+		var out struct{}
+		path := "/api/v1/secrets/" + strconv.Itoa(int(autoRotateID)) + "/auto-rotate"
+		if err := c.Patch(context.Background(), path, body, &out); err != nil {
+			return err
+		}
+		if autoRotateOff {
+			fmt.Printf("Auto-rotation disabled for secret %d.\n", autoRotateID)
+		} else {
+			fmt.Printf("Auto-rotation enabled for secret %d.\n", autoRotateID)
+		}
+		return nil
+	},
+}
+
+func init() {
+	autoRotateCmd.Flags().UintVar(&autoRotateID, "id", 0, "Secret ID (required)")
+	autoRotateCmd.Flags().BoolVar(&autoRotateOff, "off", false, "Disable auto-rotation (default enables)")
+	autoRotateCmd.Flags().IntVar(&autoRotateLength, "length", 0, "Generated value length (8–256, 0 = default 32)")
+	autoRotateCmd.Flags().StringVar(&autoRotateCharset, "charset", "", "alphanumeric|lower_alphanumeric|hex|alphanumeric_symbols (empty = default)")
+	SecretCmd.AddCommand(autoRotateCmd)
+}

--- a/server/grpc/services/secret_service.go
+++ b/server/grpc/services/secret_service.go
@@ -160,6 +160,25 @@ func (s *SecretGRPCService) DeleteSecret(ctx context.Context, req *pb.DeleteSecr
 	return &emptypb.Empty{}, nil
 }
 
+// SetSecretAutoRotate enables/disables automated rotation for a secret and sets its
+// generated-value shape (ADR-046). Scoped secrets.write, mirroring the HTTP endpoint.
+func (s *SecretGRPCService) SetSecretAutoRotate(ctx context.Context, req *pb.SetSecretAutoRotateRequest) (*emptypb.Empty, error) {
+	user, err := requireUser(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if req.GetId() == 0 {
+		return nil, status.Error(codes.InvalidArgument, "id is required")
+	}
+	if err := authorizeSecretScoped(ctx, s.core, user, uint(req.GetId()), "secrets.write"); err != nil {
+		return nil, err
+	}
+	if err := s.core.SetSecretAutoRotate(ctx, uint(req.GetId()), req.GetEnabled(), int(req.GetLength()), req.GetCharset(), user.PrincipalID()); err != nil {
+		return nil, mapSecretError(err)
+	}
+	return &emptypb.Empty{}, nil
+}
+
 // ListSecrets lists secrets visible to the caller with sharing context.
 func (s *SecretGRPCService) ListSecrets(ctx context.Context, req *pb.ListSecretsRequest) (*pb.ListSecretsResponse, error) {
 	user, err := requireUser(ctx)
@@ -274,6 +293,8 @@ func mapSecretError(err error) error {
 		return status.Error(codes.PermissionDenied, "access denied to this secret")
 	case strings.Contains(msg, "already exists"):
 		return status.Error(codes.AlreadyExists, "secret with this name already exists")
+	case strings.Contains(msg, "unknown rotation charset"), strings.Contains(msg, "out of range"):
+		return status.Error(codes.InvalidArgument, msg)
 	default:
 		return status.Error(codes.Internal, "secret operation failed")
 	}

--- a/server/grpc/services/secret_service_test.go
+++ b/server/grpc/services/secret_service_test.go
@@ -296,3 +296,50 @@ func TestSecretService_GetSecretVersions(t *testing.T) {
 }
 
 func strPtr(s string) *string { return &s }
+
+func TestSecretService_SetSecretAutoRotate(t *testing.T) {
+	r := newSecretTestRig(t)
+	ctx := authCtx(1, "writer", "secrets.write", "secrets.read")
+	sec := r.createSecret(t, ctx, "rotatable", "v")
+
+	_, err := r.svc.SetSecretAutoRotate(ctx, &pb.SetSecretAutoRotateRequest{
+		Id: sec.GetId(), Enabled: true, Length: 48, Charset: "hex",
+	})
+	require.NoError(t, err)
+
+	var s models.SecretNode
+	require.NoError(t, r.db.First(&s, sec.GetId()).Error)
+	assert.True(t, s.AutoRotate)
+	assert.Equal(t, 48, s.RotationLength)
+	assert.Equal(t, "hex", s.RotationCharset)
+}
+
+func TestSecretService_SetSecretAutoRotate_BadCharset(t *testing.T) {
+	r := newSecretTestRig(t)
+	ctx := authCtx(1, "writer", "secrets.write", "secrets.read")
+	sec := r.createSecret(t, ctx, "rotatable", "v")
+
+	_, err := r.svc.SetSecretAutoRotate(ctx, &pb.SetSecretAutoRotateRequest{
+		Id: sec.GetId(), Enabled: true, Charset: "klingon",
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
+func TestSecretService_SetSecretAutoRotate_Unauthenticated(t *testing.T) {
+	r := newSecretTestRig(t)
+	_, err := r.svc.SetSecretAutoRotate(context.Background(), &pb.SetSecretAutoRotateRequest{Id: 1, Enabled: true})
+	require.Error(t, err)
+	assert.Equal(t, codes.Unauthenticated, status.Code(err))
+}
+
+func TestSecretService_SetSecretAutoRotate_PermissionDenied(t *testing.T) {
+	r := newSecretTestRig(t)
+	owner := authCtx(1, "writer", "secrets.write", "secrets.read")
+	sec := r.createSecret(t, owner, "rotatable", "v")
+
+	ctx := authCtx(2, "reader", "secrets.read") // no write grant
+	_, err := r.svc.SetSecretAutoRotate(ctx, &pb.SetSecretAutoRotateRequest{Id: sec.GetId(), Enabled: true})
+	require.Error(t, err)
+	assert.Equal(t, codes.PermissionDenied, status.Code(err))
+}

--- a/server/proto/keyorix.proto
+++ b/server/proto/keyorix.proto
@@ -29,6 +29,10 @@ service SecretService {
 
   // Get a secret's version history
   rpc GetSecretVersions(GetSecretVersionsRequest) returns (GetSecretVersionsResponse);
+
+  // Enable/disable automated rotation for a secret and set its generated-value shape
+  // (ADR-046). Requires scoped secrets.write.
+  rpc SetSecretAutoRotate(SetSecretAutoRotateRequest) returns (google.protobuf.Empty);
 }
 
 // Share service for managing secret sharing
@@ -214,6 +218,13 @@ message ListSecretsResponse {
 
 message GetSecretVersionsRequest {
   uint32 id = 1;
+}
+
+message SetSecretAutoRotateRequest {
+  uint32 id = 1;
+  bool enabled = 2;
+  int32 length = 3;  // 0 = default
+  string charset = 4; // "" = default alphanumeric
 }
 
 message SecretVersion {

--- a/server/proto/pb/keyorix.pb.go
+++ b/server/proto/pb/keyorix.pb.go
@@ -831,6 +831,74 @@ func (x *GetSecretVersionsRequest) GetId() uint32 {
 	return 0
 }
 
+type SetSecretAutoRotateRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            uint32                 `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
+	Enabled       bool                   `protobuf:"varint,2,opt,name=enabled,proto3" json:"enabled,omitempty"`
+	Length        int32                  `protobuf:"varint,3,opt,name=length,proto3" json:"length,omitempty"`  // 0 = default
+	Charset       string                 `protobuf:"bytes,4,opt,name=charset,proto3" json:"charset,omitempty"` // "" = default alphanumeric
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SetSecretAutoRotateRequest) Reset() {
+	*x = SetSecretAutoRotateRequest{}
+	mi := &file_keyorix_proto_msgTypes[9]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SetSecretAutoRotateRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SetSecretAutoRotateRequest) ProtoMessage() {}
+
+func (x *SetSecretAutoRotateRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_keyorix_proto_msgTypes[9]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SetSecretAutoRotateRequest.ProtoReflect.Descriptor instead.
+func (*SetSecretAutoRotateRequest) Descriptor() ([]byte, []int) {
+	return file_keyorix_proto_rawDescGZIP(), []int{9}
+}
+
+func (x *SetSecretAutoRotateRequest) GetId() uint32 {
+	if x != nil {
+		return x.Id
+	}
+	return 0
+}
+
+func (x *SetSecretAutoRotateRequest) GetEnabled() bool {
+	if x != nil {
+		return x.Enabled
+	}
+	return false
+}
+
+func (x *SetSecretAutoRotateRequest) GetLength() int32 {
+	if x != nil {
+		return x.Length
+	}
+	return 0
+}
+
+func (x *SetSecretAutoRotateRequest) GetCharset() string {
+	if x != nil {
+		return x.Charset
+	}
+	return ""
+}
+
 type SecretVersion struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	VersionNumber uint32                 `protobuf:"varint,1,opt,name=version_number,json=versionNumber,proto3" json:"version_number,omitempty"`
@@ -842,7 +910,7 @@ type SecretVersion struct {
 
 func (x *SecretVersion) Reset() {
 	*x = SecretVersion{}
-	mi := &file_keyorix_proto_msgTypes[9]
+	mi := &file_keyorix_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -854,7 +922,7 @@ func (x *SecretVersion) String() string {
 func (*SecretVersion) ProtoMessage() {}
 
 func (x *SecretVersion) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[9]
+	mi := &file_keyorix_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -867,7 +935,7 @@ func (x *SecretVersion) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SecretVersion.ProtoReflect.Descriptor instead.
 func (*SecretVersion) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{9}
+	return file_keyorix_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *SecretVersion) GetVersionNumber() uint32 {
@@ -900,7 +968,7 @@ type GetSecretVersionsResponse struct {
 
 func (x *GetSecretVersionsResponse) Reset() {
 	*x = GetSecretVersionsResponse{}
-	mi := &file_keyorix_proto_msgTypes[10]
+	mi := &file_keyorix_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -912,7 +980,7 @@ func (x *GetSecretVersionsResponse) String() string {
 func (*GetSecretVersionsResponse) ProtoMessage() {}
 
 func (x *GetSecretVersionsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[10]
+	mi := &file_keyorix_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -925,7 +993,7 @@ func (x *GetSecretVersionsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSecretVersionsResponse.ProtoReflect.Descriptor instead.
 func (*GetSecretVersionsResponse) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{10}
+	return file_keyorix_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *GetSecretVersionsResponse) GetVersions() []*SecretVersion {
@@ -954,7 +1022,7 @@ type User struct {
 
 func (x *User) Reset() {
 	*x = User{}
-	mi := &file_keyorix_proto_msgTypes[11]
+	mi := &file_keyorix_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -966,7 +1034,7 @@ func (x *User) String() string {
 func (*User) ProtoMessage() {}
 
 func (x *User) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[11]
+	mi := &file_keyorix_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -979,7 +1047,7 @@ func (x *User) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use User.ProtoReflect.Descriptor instead.
 func (*User) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{11}
+	return file_keyorix_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *User) GetId() uint32 {
@@ -1070,7 +1138,7 @@ type ProjectAssignment struct {
 
 func (x *ProjectAssignment) Reset() {
 	*x = ProjectAssignment{}
-	mi := &file_keyorix_proto_msgTypes[12]
+	mi := &file_keyorix_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1082,7 +1150,7 @@ func (x *ProjectAssignment) String() string {
 func (*ProjectAssignment) ProtoMessage() {}
 
 func (x *ProjectAssignment) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[12]
+	mi := &file_keyorix_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1095,7 +1163,7 @@ func (x *ProjectAssignment) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ProjectAssignment.ProtoReflect.Descriptor instead.
 func (*ProjectAssignment) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{12}
+	return file_keyorix_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *ProjectAssignment) GetProjectId() uint32 {
@@ -1133,7 +1201,7 @@ type CreateUserRequest struct {
 
 func (x *CreateUserRequest) Reset() {
 	*x = CreateUserRequest{}
-	mi := &file_keyorix_proto_msgTypes[13]
+	mi := &file_keyorix_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1145,7 +1213,7 @@ func (x *CreateUserRequest) String() string {
 func (*CreateUserRequest) ProtoMessage() {}
 
 func (x *CreateUserRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[13]
+	mi := &file_keyorix_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1158,7 +1226,7 @@ func (x *CreateUserRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateUserRequest.ProtoReflect.Descriptor instead.
 func (*CreateUserRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{13}
+	return file_keyorix_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *CreateUserRequest) GetUsername() string {
@@ -1243,7 +1311,7 @@ type CreateUserResponse struct {
 
 func (x *CreateUserResponse) Reset() {
 	*x = CreateUserResponse{}
-	mi := &file_keyorix_proto_msgTypes[14]
+	mi := &file_keyorix_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1255,7 +1323,7 @@ func (x *CreateUserResponse) String() string {
 func (*CreateUserResponse) ProtoMessage() {}
 
 func (x *CreateUserResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[14]
+	mi := &file_keyorix_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1268,7 +1336,7 @@ func (x *CreateUserResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateUserResponse.ProtoReflect.Descriptor instead.
 func (*CreateUserResponse) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{14}
+	return file_keyorix_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *CreateUserResponse) GetUser() *User {
@@ -1301,7 +1369,7 @@ type GetUserRequest struct {
 
 func (x *GetUserRequest) Reset() {
 	*x = GetUserRequest{}
-	mi := &file_keyorix_proto_msgTypes[15]
+	mi := &file_keyorix_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1313,7 +1381,7 @@ func (x *GetUserRequest) String() string {
 func (*GetUserRequest) ProtoMessage() {}
 
 func (x *GetUserRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[15]
+	mi := &file_keyorix_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1326,7 +1394,7 @@ func (x *GetUserRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetUserRequest.ProtoReflect.Descriptor instead.
 func (*GetUserRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{15}
+	return file_keyorix_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *GetUserRequest) GetId() uint32 {
@@ -1349,7 +1417,7 @@ type UpdateUserRequest struct {
 
 func (x *UpdateUserRequest) Reset() {
 	*x = UpdateUserRequest{}
-	mi := &file_keyorix_proto_msgTypes[16]
+	mi := &file_keyorix_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1361,7 +1429,7 @@ func (x *UpdateUserRequest) String() string {
 func (*UpdateUserRequest) ProtoMessage() {}
 
 func (x *UpdateUserRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[16]
+	mi := &file_keyorix_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1374,7 +1442,7 @@ func (x *UpdateUserRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateUserRequest.ProtoReflect.Descriptor instead.
 func (*UpdateUserRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{16}
+	return file_keyorix_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *UpdateUserRequest) GetId() uint32 {
@@ -1421,7 +1489,7 @@ type DeleteUserRequest struct {
 
 func (x *DeleteUserRequest) Reset() {
 	*x = DeleteUserRequest{}
-	mi := &file_keyorix_proto_msgTypes[17]
+	mi := &file_keyorix_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1433,7 +1501,7 @@ func (x *DeleteUserRequest) String() string {
 func (*DeleteUserRequest) ProtoMessage() {}
 
 func (x *DeleteUserRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[17]
+	mi := &file_keyorix_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1446,7 +1514,7 @@ func (x *DeleteUserRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteUserRequest.ProtoReflect.Descriptor instead.
 func (*DeleteUserRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{17}
+	return file_keyorix_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *DeleteUserRequest) GetId() uint32 {
@@ -1471,7 +1539,7 @@ type ListUsersRequest struct {
 
 func (x *ListUsersRequest) Reset() {
 	*x = ListUsersRequest{}
-	mi := &file_keyorix_proto_msgTypes[18]
+	mi := &file_keyorix_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1483,7 +1551,7 @@ func (x *ListUsersRequest) String() string {
 func (*ListUsersRequest) ProtoMessage() {}
 
 func (x *ListUsersRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[18]
+	mi := &file_keyorix_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1496,7 +1564,7 @@ func (x *ListUsersRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListUsersRequest.ProtoReflect.Descriptor instead.
 func (*ListUsersRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{18}
+	return file_keyorix_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *ListUsersRequest) GetPage() uint32 {
@@ -1554,7 +1622,7 @@ type ListUsersResponse struct {
 
 func (x *ListUsersResponse) Reset() {
 	*x = ListUsersResponse{}
-	mi := &file_keyorix_proto_msgTypes[19]
+	mi := &file_keyorix_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1566,7 +1634,7 @@ func (x *ListUsersResponse) String() string {
 func (*ListUsersResponse) ProtoMessage() {}
 
 func (x *ListUsersResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[19]
+	mi := &file_keyorix_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1579,7 +1647,7 @@ func (x *ListUsersResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListUsersResponse.ProtoReflect.Descriptor instead.
 func (*ListUsersResponse) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{19}
+	return file_keyorix_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *ListUsersResponse) GetUsers() []*User {
@@ -1630,7 +1698,7 @@ type Permission struct {
 
 func (x *Permission) Reset() {
 	*x = Permission{}
-	mi := &file_keyorix_proto_msgTypes[20]
+	mi := &file_keyorix_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1642,7 +1710,7 @@ func (x *Permission) String() string {
 func (*Permission) ProtoMessage() {}
 
 func (x *Permission) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[20]
+	mi := &file_keyorix_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1655,7 +1723,7 @@ func (x *Permission) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Permission.ProtoReflect.Descriptor instead.
 func (*Permission) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{20}
+	return file_keyorix_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *Permission) GetId() uint32 {
@@ -1707,7 +1775,7 @@ type Role struct {
 
 func (x *Role) Reset() {
 	*x = Role{}
-	mi := &file_keyorix_proto_msgTypes[21]
+	mi := &file_keyorix_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1719,7 +1787,7 @@ func (x *Role) String() string {
 func (*Role) ProtoMessage() {}
 
 func (x *Role) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[21]
+	mi := &file_keyorix_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1732,7 +1800,7 @@ func (x *Role) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Role.ProtoReflect.Descriptor instead.
 func (*Role) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{21}
+	return file_keyorix_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *Role) GetId() uint32 {
@@ -1789,7 +1857,7 @@ type CreateRoleRequest struct {
 
 func (x *CreateRoleRequest) Reset() {
 	*x = CreateRoleRequest{}
-	mi := &file_keyorix_proto_msgTypes[22]
+	mi := &file_keyorix_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1801,7 +1869,7 @@ func (x *CreateRoleRequest) String() string {
 func (*CreateRoleRequest) ProtoMessage() {}
 
 func (x *CreateRoleRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[22]
+	mi := &file_keyorix_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1814,7 +1882,7 @@ func (x *CreateRoleRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateRoleRequest.ProtoReflect.Descriptor instead.
 func (*CreateRoleRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{22}
+	return file_keyorix_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *CreateRoleRequest) GetName() string {
@@ -1847,7 +1915,7 @@ type GetRoleRequest struct {
 
 func (x *GetRoleRequest) Reset() {
 	*x = GetRoleRequest{}
-	mi := &file_keyorix_proto_msgTypes[23]
+	mi := &file_keyorix_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1859,7 +1927,7 @@ func (x *GetRoleRequest) String() string {
 func (*GetRoleRequest) ProtoMessage() {}
 
 func (x *GetRoleRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[23]
+	mi := &file_keyorix_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1872,7 +1940,7 @@ func (x *GetRoleRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetRoleRequest.ProtoReflect.Descriptor instead.
 func (*GetRoleRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{23}
+	return file_keyorix_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *GetRoleRequest) GetId() uint32 {
@@ -1894,7 +1962,7 @@ type UpdateRoleRequest struct {
 
 func (x *UpdateRoleRequest) Reset() {
 	*x = UpdateRoleRequest{}
-	mi := &file_keyorix_proto_msgTypes[24]
+	mi := &file_keyorix_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1906,7 +1974,7 @@ func (x *UpdateRoleRequest) String() string {
 func (*UpdateRoleRequest) ProtoMessage() {}
 
 func (x *UpdateRoleRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[24]
+	mi := &file_keyorix_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1919,7 +1987,7 @@ func (x *UpdateRoleRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateRoleRequest.ProtoReflect.Descriptor instead.
 func (*UpdateRoleRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{24}
+	return file_keyorix_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *UpdateRoleRequest) GetId() uint32 {
@@ -1952,7 +2020,7 @@ type DeleteRoleRequest struct {
 
 func (x *DeleteRoleRequest) Reset() {
 	*x = DeleteRoleRequest{}
-	mi := &file_keyorix_proto_msgTypes[25]
+	mi := &file_keyorix_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1964,7 +2032,7 @@ func (x *DeleteRoleRequest) String() string {
 func (*DeleteRoleRequest) ProtoMessage() {}
 
 func (x *DeleteRoleRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[25]
+	mi := &file_keyorix_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1977,7 +2045,7 @@ func (x *DeleteRoleRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteRoleRequest.ProtoReflect.Descriptor instead.
 func (*DeleteRoleRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{25}
+	return file_keyorix_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *DeleteRoleRequest) GetId() uint32 {
@@ -1997,7 +2065,7 @@ type ListRolesRequest struct {
 
 func (x *ListRolesRequest) Reset() {
 	*x = ListRolesRequest{}
-	mi := &file_keyorix_proto_msgTypes[26]
+	mi := &file_keyorix_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2009,7 +2077,7 @@ func (x *ListRolesRequest) String() string {
 func (*ListRolesRequest) ProtoMessage() {}
 
 func (x *ListRolesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[26]
+	mi := &file_keyorix_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2022,7 +2090,7 @@ func (x *ListRolesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListRolesRequest.ProtoReflect.Descriptor instead.
 func (*ListRolesRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{26}
+	return file_keyorix_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *ListRolesRequest) GetPage() uint32 {
@@ -2052,7 +2120,7 @@ type ListRolesResponse struct {
 
 func (x *ListRolesResponse) Reset() {
 	*x = ListRolesResponse{}
-	mi := &file_keyorix_proto_msgTypes[27]
+	mi := &file_keyorix_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2064,7 +2132,7 @@ func (x *ListRolesResponse) String() string {
 func (*ListRolesResponse) ProtoMessage() {}
 
 func (x *ListRolesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[27]
+	mi := &file_keyorix_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2077,7 +2145,7 @@ func (x *ListRolesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListRolesResponse.ProtoReflect.Descriptor instead.
 func (*ListRolesResponse) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{27}
+	return file_keyorix_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *ListRolesResponse) GetRoles() []*Role {
@@ -2129,7 +2197,7 @@ type AssignRoleRequest struct {
 
 func (x *AssignRoleRequest) Reset() {
 	*x = AssignRoleRequest{}
-	mi := &file_keyorix_proto_msgTypes[28]
+	mi := &file_keyorix_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2141,7 +2209,7 @@ func (x *AssignRoleRequest) String() string {
 func (*AssignRoleRequest) ProtoMessage() {}
 
 func (x *AssignRoleRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[28]
+	mi := &file_keyorix_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2154,7 +2222,7 @@ func (x *AssignRoleRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AssignRoleRequest.ProtoReflect.Descriptor instead.
 func (*AssignRoleRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{28}
+	return file_keyorix_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *AssignRoleRequest) GetUserId() uint32 {
@@ -2197,7 +2265,7 @@ type RoleAssignment struct {
 
 func (x *RoleAssignment) Reset() {
 	*x = RoleAssignment{}
-	mi := &file_keyorix_proto_msgTypes[29]
+	mi := &file_keyorix_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2209,7 +2277,7 @@ func (x *RoleAssignment) String() string {
 func (*RoleAssignment) ProtoMessage() {}
 
 func (x *RoleAssignment) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[29]
+	mi := &file_keyorix_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2222,7 +2290,7 @@ func (x *RoleAssignment) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RoleAssignment.ProtoReflect.Descriptor instead.
 func (*RoleAssignment) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{29}
+	return file_keyorix_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *RoleAssignment) GetUserId() uint32 {
@@ -2265,7 +2333,7 @@ type RemoveRoleRequest struct {
 
 func (x *RemoveRoleRequest) Reset() {
 	*x = RemoveRoleRequest{}
-	mi := &file_keyorix_proto_msgTypes[30]
+	mi := &file_keyorix_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2277,7 +2345,7 @@ func (x *RemoveRoleRequest) String() string {
 func (*RemoveRoleRequest) ProtoMessage() {}
 
 func (x *RemoveRoleRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[30]
+	mi := &file_keyorix_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2290,7 +2358,7 @@ func (x *RemoveRoleRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveRoleRequest.ProtoReflect.Descriptor instead.
 func (*RemoveRoleRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{30}
+	return file_keyorix_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *RemoveRoleRequest) GetUserId() uint32 {
@@ -2330,7 +2398,7 @@ type GetUserRolesRequest struct {
 
 func (x *GetUserRolesRequest) Reset() {
 	*x = GetUserRolesRequest{}
-	mi := &file_keyorix_proto_msgTypes[31]
+	mi := &file_keyorix_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2342,7 +2410,7 @@ func (x *GetUserRolesRequest) String() string {
 func (*GetUserRolesRequest) ProtoMessage() {}
 
 func (x *GetUserRolesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[31]
+	mi := &file_keyorix_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2355,7 +2423,7 @@ func (x *GetUserRolesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetUserRolesRequest.ProtoReflect.Descriptor instead.
 func (*GetUserRolesRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{31}
+	return file_keyorix_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *GetUserRolesRequest) GetUserId() uint32 {
@@ -2377,7 +2445,7 @@ type GetUserRolesResponse struct {
 
 func (x *GetUserRolesResponse) Reset() {
 	*x = GetUserRolesResponse{}
-	mi := &file_keyorix_proto_msgTypes[32]
+	mi := &file_keyorix_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2389,7 +2457,7 @@ func (x *GetUserRolesResponse) String() string {
 func (*GetUserRolesResponse) ProtoMessage() {}
 
 func (x *GetUserRolesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[32]
+	mi := &file_keyorix_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2402,7 +2470,7 @@ func (x *GetUserRolesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetUserRolesResponse.ProtoReflect.Descriptor instead.
 func (*GetUserRolesResponse) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{32}
+	return file_keyorix_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *GetUserRolesResponse) GetUserId() uint32 {
@@ -2458,7 +2526,7 @@ type AuditLog struct {
 
 func (x *AuditLog) Reset() {
 	*x = AuditLog{}
-	mi := &file_keyorix_proto_msgTypes[33]
+	mi := &file_keyorix_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2470,7 +2538,7 @@ func (x *AuditLog) String() string {
 func (*AuditLog) ProtoMessage() {}
 
 func (x *AuditLog) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[33]
+	mi := &file_keyorix_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2483,7 +2551,7 @@ func (x *AuditLog) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AuditLog.ProtoReflect.Descriptor instead.
 func (*AuditLog) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{33}
+	return file_keyorix_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *AuditLog) GetId() uint32 {
@@ -2607,7 +2675,7 @@ type GetAuditLogsRequest struct {
 
 func (x *GetAuditLogsRequest) Reset() {
 	*x = GetAuditLogsRequest{}
-	mi := &file_keyorix_proto_msgTypes[34]
+	mi := &file_keyorix_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2619,7 +2687,7 @@ func (x *GetAuditLogsRequest) String() string {
 func (*GetAuditLogsRequest) ProtoMessage() {}
 
 func (x *GetAuditLogsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[34]
+	mi := &file_keyorix_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2632,7 +2700,7 @@ func (x *GetAuditLogsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetAuditLogsRequest.ProtoReflect.Descriptor instead.
 func (*GetAuditLogsRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{34}
+	return file_keyorix_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *GetAuditLogsRequest) GetEventType() string {
@@ -2704,7 +2772,7 @@ type GetAuditLogsResponse struct {
 
 func (x *GetAuditLogsResponse) Reset() {
 	*x = GetAuditLogsResponse{}
-	mi := &file_keyorix_proto_msgTypes[35]
+	mi := &file_keyorix_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2716,7 +2784,7 @@ func (x *GetAuditLogsResponse) String() string {
 func (*GetAuditLogsResponse) ProtoMessage() {}
 
 func (x *GetAuditLogsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[35]
+	mi := &file_keyorix_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2729,7 +2797,7 @@ func (x *GetAuditLogsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetAuditLogsResponse.ProtoReflect.Descriptor instead.
 func (*GetAuditLogsResponse) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{35}
+	return file_keyorix_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *GetAuditLogsResponse) GetLogs() []*AuditLog {
@@ -2789,7 +2857,7 @@ type RBACAuditLog struct {
 
 func (x *RBACAuditLog) Reset() {
 	*x = RBACAuditLog{}
-	mi := &file_keyorix_proto_msgTypes[36]
+	mi := &file_keyorix_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2801,7 +2869,7 @@ func (x *RBACAuditLog) String() string {
 func (*RBACAuditLog) ProtoMessage() {}
 
 func (x *RBACAuditLog) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[36]
+	mi := &file_keyorix_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2814,7 +2882,7 @@ func (x *RBACAuditLog) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RBACAuditLog.ProtoReflect.Descriptor instead.
 func (*RBACAuditLog) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{36}
+	return file_keyorix_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *RBACAuditLog) GetId() uint32 {
@@ -2900,7 +2968,7 @@ type GetRBACAuditLogsRequest struct {
 
 func (x *GetRBACAuditLogsRequest) Reset() {
 	*x = GetRBACAuditLogsRequest{}
-	mi := &file_keyorix_proto_msgTypes[37]
+	mi := &file_keyorix_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2912,7 +2980,7 @@ func (x *GetRBACAuditLogsRequest) String() string {
 func (*GetRBACAuditLogsRequest) ProtoMessage() {}
 
 func (x *GetRBACAuditLogsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[37]
+	mi := &file_keyorix_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2925,7 +2993,7 @@ func (x *GetRBACAuditLogsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetRBACAuditLogsRequest.ProtoReflect.Descriptor instead.
 func (*GetRBACAuditLogsRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{37}
+	return file_keyorix_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *GetRBACAuditLogsRequest) GetAction() string {
@@ -2976,7 +3044,7 @@ type GetRBACAuditLogsResponse struct {
 
 func (x *GetRBACAuditLogsResponse) Reset() {
 	*x = GetRBACAuditLogsResponse{}
-	mi := &file_keyorix_proto_msgTypes[38]
+	mi := &file_keyorix_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2988,7 +3056,7 @@ func (x *GetRBACAuditLogsResponse) String() string {
 func (*GetRBACAuditLogsResponse) ProtoMessage() {}
 
 func (x *GetRBACAuditLogsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[38]
+	mi := &file_keyorix_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3001,7 +3069,7 @@ func (x *GetRBACAuditLogsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetRBACAuditLogsResponse.ProtoReflect.Descriptor instead.
 func (*GetRBACAuditLogsResponse) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{38}
+	return file_keyorix_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *GetRBACAuditLogsResponse) GetLogs() []*RBACAuditLog {
@@ -3055,7 +3123,7 @@ type StreamAuditLogsRequest struct {
 
 func (x *StreamAuditLogsRequest) Reset() {
 	*x = StreamAuditLogsRequest{}
-	mi := &file_keyorix_proto_msgTypes[39]
+	mi := &file_keyorix_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3067,7 +3135,7 @@ func (x *StreamAuditLogsRequest) String() string {
 func (*StreamAuditLogsRequest) ProtoMessage() {}
 
 func (x *StreamAuditLogsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[39]
+	mi := &file_keyorix_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3080,7 +3148,7 @@ func (x *StreamAuditLogsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StreamAuditLogsRequest.ProtoReflect.Descriptor instead.
 func (*StreamAuditLogsRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{39}
+	return file_keyorix_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *StreamAuditLogsRequest) GetEventType() string {
@@ -3127,7 +3195,7 @@ type ShareRecord struct {
 
 func (x *ShareRecord) Reset() {
 	*x = ShareRecord{}
-	mi := &file_keyorix_proto_msgTypes[40]
+	mi := &file_keyorix_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3139,7 +3207,7 @@ func (x *ShareRecord) String() string {
 func (*ShareRecord) ProtoMessage() {}
 
 func (x *ShareRecord) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[40]
+	mi := &file_keyorix_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3152,7 +3220,7 @@ func (x *ShareRecord) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ShareRecord.ProtoReflect.Descriptor instead.
 func (*ShareRecord) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{40}
+	return file_keyorix_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *ShareRecord) GetId() uint32 {
@@ -3223,7 +3291,7 @@ type ShareSecretRequest struct {
 
 func (x *ShareSecretRequest) Reset() {
 	*x = ShareSecretRequest{}
-	mi := &file_keyorix_proto_msgTypes[41]
+	mi := &file_keyorix_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3235,7 +3303,7 @@ func (x *ShareSecretRequest) String() string {
 func (*ShareSecretRequest) ProtoMessage() {}
 
 func (x *ShareSecretRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[41]
+	mi := &file_keyorix_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3248,7 +3316,7 @@ func (x *ShareSecretRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ShareSecretRequest.ProtoReflect.Descriptor instead.
 func (*ShareSecretRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{41}
+	return file_keyorix_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *ShareSecretRequest) GetSecretId() uint32 {
@@ -3288,7 +3356,7 @@ type ListSecretSharesRequest struct {
 
 func (x *ListSecretSharesRequest) Reset() {
 	*x = ListSecretSharesRequest{}
-	mi := &file_keyorix_proto_msgTypes[42]
+	mi := &file_keyorix_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3300,7 +3368,7 @@ func (x *ListSecretSharesRequest) String() string {
 func (*ListSecretSharesRequest) ProtoMessage() {}
 
 func (x *ListSecretSharesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[42]
+	mi := &file_keyorix_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3313,7 +3381,7 @@ func (x *ListSecretSharesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSecretSharesRequest.ProtoReflect.Descriptor instead.
 func (*ListSecretSharesRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{42}
+	return file_keyorix_proto_rawDescGZIP(), []int{43}
 }
 
 func (x *ListSecretSharesRequest) GetSecretId() uint32 {
@@ -3333,7 +3401,7 @@ type ListUserSharesRequest struct {
 
 func (x *ListUserSharesRequest) Reset() {
 	*x = ListUserSharesRequest{}
-	mi := &file_keyorix_proto_msgTypes[43]
+	mi := &file_keyorix_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3345,7 +3413,7 @@ func (x *ListUserSharesRequest) String() string {
 func (*ListUserSharesRequest) ProtoMessage() {}
 
 func (x *ListUserSharesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[43]
+	mi := &file_keyorix_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3358,7 +3426,7 @@ func (x *ListUserSharesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListUserSharesRequest.ProtoReflect.Descriptor instead.
 func (*ListUserSharesRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{43}
+	return file_keyorix_proto_rawDescGZIP(), []int{44}
 }
 
 func (x *ListUserSharesRequest) GetPage() uint32 {
@@ -3385,7 +3453,7 @@ type ListSharedSecretsRequest struct {
 
 func (x *ListSharedSecretsRequest) Reset() {
 	*x = ListSharedSecretsRequest{}
-	mi := &file_keyorix_proto_msgTypes[44]
+	mi := &file_keyorix_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3397,7 +3465,7 @@ func (x *ListSharedSecretsRequest) String() string {
 func (*ListSharedSecretsRequest) ProtoMessage() {}
 
 func (x *ListSharedSecretsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[44]
+	mi := &file_keyorix_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3410,7 +3478,7 @@ func (x *ListSharedSecretsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSharedSecretsRequest.ProtoReflect.Descriptor instead.
 func (*ListSharedSecretsRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{44}
+	return file_keyorix_proto_rawDescGZIP(), []int{45}
 }
 
 func (x *ListSharedSecretsRequest) GetPage() uint32 {
@@ -3440,7 +3508,7 @@ type ListSharesResponse struct {
 
 func (x *ListSharesResponse) Reset() {
 	*x = ListSharesResponse{}
-	mi := &file_keyorix_proto_msgTypes[45]
+	mi := &file_keyorix_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3452,7 +3520,7 @@ func (x *ListSharesResponse) String() string {
 func (*ListSharesResponse) ProtoMessage() {}
 
 func (x *ListSharesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[45]
+	mi := &file_keyorix_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3465,7 +3533,7 @@ func (x *ListSharesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSharesResponse.ProtoReflect.Descriptor instead.
 func (*ListSharesResponse) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{45}
+	return file_keyorix_proto_rawDescGZIP(), []int{46}
 }
 
 func (x *ListSharesResponse) GetShares() []*ShareRecord {
@@ -3513,7 +3581,7 @@ type UpdateSharePermissionRequest struct {
 
 func (x *UpdateSharePermissionRequest) Reset() {
 	*x = UpdateSharePermissionRequest{}
-	mi := &file_keyorix_proto_msgTypes[46]
+	mi := &file_keyorix_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3525,7 +3593,7 @@ func (x *UpdateSharePermissionRequest) String() string {
 func (*UpdateSharePermissionRequest) ProtoMessage() {}
 
 func (x *UpdateSharePermissionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[46]
+	mi := &file_keyorix_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3538,7 +3606,7 @@ func (x *UpdateSharePermissionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateSharePermissionRequest.ProtoReflect.Descriptor instead.
 func (*UpdateSharePermissionRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{46}
+	return file_keyorix_proto_rawDescGZIP(), []int{47}
 }
 
 func (x *UpdateSharePermissionRequest) GetShareId() uint32 {
@@ -3564,7 +3632,7 @@ type RevokeShareRequest struct {
 
 func (x *RevokeShareRequest) Reset() {
 	*x = RevokeShareRequest{}
-	mi := &file_keyorix_proto_msgTypes[47]
+	mi := &file_keyorix_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3576,7 +3644,7 @@ func (x *RevokeShareRequest) String() string {
 func (*RevokeShareRequest) ProtoMessage() {}
 
 func (x *RevokeShareRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[47]
+	mi := &file_keyorix_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3589,7 +3657,7 @@ func (x *RevokeShareRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RevokeShareRequest.ProtoReflect.Descriptor instead.
 func (*RevokeShareRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{47}
+	return file_keyorix_proto_rawDescGZIP(), []int{48}
 }
 
 func (x *RevokeShareRequest) GetShareId() uint32 {
@@ -3611,7 +3679,7 @@ type HealthResponse struct {
 
 func (x *HealthResponse) Reset() {
 	*x = HealthResponse{}
-	mi := &file_keyorix_proto_msgTypes[48]
+	mi := &file_keyorix_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3623,7 +3691,7 @@ func (x *HealthResponse) String() string {
 func (*HealthResponse) ProtoMessage() {}
 
 func (x *HealthResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[48]
+	mi := &file_keyorix_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3636,7 +3704,7 @@ func (x *HealthResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HealthResponse.ProtoReflect.Descriptor instead.
 func (*HealthResponse) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{48}
+	return file_keyorix_proto_rawDescGZIP(), []int{49}
 }
 
 func (x *HealthResponse) GetStatus() string {
@@ -3684,7 +3752,7 @@ type SystemInfo struct {
 
 func (x *SystemInfo) Reset() {
 	*x = SystemInfo{}
-	mi := &file_keyorix_proto_msgTypes[49]
+	mi := &file_keyorix_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3696,7 +3764,7 @@ func (x *SystemInfo) String() string {
 func (*SystemInfo) ProtoMessage() {}
 
 func (x *SystemInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[49]
+	mi := &file_keyorix_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3709,7 +3777,7 @@ func (x *SystemInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SystemInfo.ProtoReflect.Descriptor instead.
 func (*SystemInfo) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{49}
+	return file_keyorix_proto_rawDescGZIP(), []int{50}
 }
 
 func (x *SystemInfo) GetVersion() string {
@@ -3787,7 +3855,7 @@ type DatabaseInfo struct {
 
 func (x *DatabaseInfo) Reset() {
 	*x = DatabaseInfo{}
-	mi := &file_keyorix_proto_msgTypes[50]
+	mi := &file_keyorix_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3799,7 +3867,7 @@ func (x *DatabaseInfo) String() string {
 func (*DatabaseInfo) ProtoMessage() {}
 
 func (x *DatabaseInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[50]
+	mi := &file_keyorix_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3812,7 +3880,7 @@ func (x *DatabaseInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DatabaseInfo.ProtoReflect.Descriptor instead.
 func (*DatabaseInfo) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{50}
+	return file_keyorix_proto_rawDescGZIP(), []int{51}
 }
 
 func (x *DatabaseInfo) GetStatus() string {
@@ -3854,7 +3922,7 @@ type EncryptionInfo struct {
 
 func (x *EncryptionInfo) Reset() {
 	*x = EncryptionInfo{}
-	mi := &file_keyorix_proto_msgTypes[51]
+	mi := &file_keyorix_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3866,7 +3934,7 @@ func (x *EncryptionInfo) String() string {
 func (*EncryptionInfo) ProtoMessage() {}
 
 func (x *EncryptionInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[51]
+	mi := &file_keyorix_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3879,7 +3947,7 @@ func (x *EncryptionInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EncryptionInfo.ProtoReflect.Descriptor instead.
 func (*EncryptionInfo) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{51}
+	return file_keyorix_proto_rawDescGZIP(), []int{52}
 }
 
 func (x *EncryptionInfo) GetStatus() string {
@@ -3916,7 +3984,7 @@ type Metrics struct {
 
 func (x *Metrics) Reset() {
 	*x = Metrics{}
-	mi := &file_keyorix_proto_msgTypes[52]
+	mi := &file_keyorix_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3928,7 +3996,7 @@ func (x *Metrics) String() string {
 func (*Metrics) ProtoMessage() {}
 
 func (x *Metrics) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[52]
+	mi := &file_keyorix_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3941,7 +4009,7 @@ func (x *Metrics) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Metrics.ProtoReflect.Descriptor instead.
 func (*Metrics) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{52}
+	return file_keyorix_proto_rawDescGZIP(), []int{53}
 }
 
 func (x *Metrics) GetRequests() *RequestMetrics {
@@ -3991,7 +4059,7 @@ type RequestMetrics struct {
 
 func (x *RequestMetrics) Reset() {
 	*x = RequestMetrics{}
-	mi := &file_keyorix_proto_msgTypes[53]
+	mi := &file_keyorix_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4003,7 +4071,7 @@ func (x *RequestMetrics) String() string {
 func (*RequestMetrics) ProtoMessage() {}
 
 func (x *RequestMetrics) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[53]
+	mi := &file_keyorix_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4016,7 +4084,7 @@ func (x *RequestMetrics) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RequestMetrics.ProtoReflect.Descriptor instead.
 func (*RequestMetrics) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{53}
+	return file_keyorix_proto_rawDescGZIP(), []int{54}
 }
 
 func (x *RequestMetrics) GetTotal() uint64 {
@@ -4059,7 +4127,7 @@ type SecretMetrics struct {
 
 func (x *SecretMetrics) Reset() {
 	*x = SecretMetrics{}
-	mi := &file_keyorix_proto_msgTypes[54]
+	mi := &file_keyorix_proto_msgTypes[55]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4071,7 +4139,7 @@ func (x *SecretMetrics) String() string {
 func (*SecretMetrics) ProtoMessage() {}
 
 func (x *SecretMetrics) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[54]
+	mi := &file_keyorix_proto_msgTypes[55]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4084,7 +4152,7 @@ func (x *SecretMetrics) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SecretMetrics.ProtoReflect.Descriptor instead.
 func (*SecretMetrics) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{54}
+	return file_keyorix_proto_rawDescGZIP(), []int{55}
 }
 
 func (x *SecretMetrics) GetTotal() uint64 {
@@ -4126,7 +4194,7 @@ type UserMetrics struct {
 
 func (x *UserMetrics) Reset() {
 	*x = UserMetrics{}
-	mi := &file_keyorix_proto_msgTypes[55]
+	mi := &file_keyorix_proto_msgTypes[56]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4138,7 +4206,7 @@ func (x *UserMetrics) String() string {
 func (*UserMetrics) ProtoMessage() {}
 
 func (x *UserMetrics) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[55]
+	mi := &file_keyorix_proto_msgTypes[56]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4151,7 +4219,7 @@ func (x *UserMetrics) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UserMetrics.ProtoReflect.Descriptor instead.
 func (*UserMetrics) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{55}
+	return file_keyorix_proto_rawDescGZIP(), []int{56}
 }
 
 func (x *UserMetrics) GetTotal() uint64 {
@@ -4187,7 +4255,7 @@ type PerformanceMetrics struct {
 
 func (x *PerformanceMetrics) Reset() {
 	*x = PerformanceMetrics{}
-	mi := &file_keyorix_proto_msgTypes[56]
+	mi := &file_keyorix_proto_msgTypes[57]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4199,7 +4267,7 @@ func (x *PerformanceMetrics) String() string {
 func (*PerformanceMetrics) ProtoMessage() {}
 
 func (x *PerformanceMetrics) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[56]
+	mi := &file_keyorix_proto_msgTypes[57]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4212,7 +4280,7 @@ func (x *PerformanceMetrics) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PerformanceMetrics.ProtoReflect.Descriptor instead.
 func (*PerformanceMetrics) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{56}
+	return file_keyorix_proto_rawDescGZIP(), []int{57}
 }
 
 func (x *PerformanceMetrics) GetAvgResponseTimeMs() float64 {
@@ -4255,7 +4323,7 @@ type SystemMetrics struct {
 
 func (x *SystemMetrics) Reset() {
 	*x = SystemMetrics{}
-	mi := &file_keyorix_proto_msgTypes[57]
+	mi := &file_keyorix_proto_msgTypes[58]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4267,7 +4335,7 @@ func (x *SystemMetrics) String() string {
 func (*SystemMetrics) ProtoMessage() {}
 
 func (x *SystemMetrics) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[57]
+	mi := &file_keyorix_proto_msgTypes[58]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4280,7 +4348,7 @@ func (x *SystemMetrics) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SystemMetrics.ProtoReflect.Descriptor instead.
 func (*SystemMetrics) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{57}
+	return file_keyorix_proto_rawDescGZIP(), []int{58}
 }
 
 func (x *SystemMetrics) GetCpuUsagePercent() float64 {
@@ -4325,7 +4393,7 @@ type Project struct {
 
 func (x *Project) Reset() {
 	*x = Project{}
-	mi := &file_keyorix_proto_msgTypes[58]
+	mi := &file_keyorix_proto_msgTypes[59]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4337,7 +4405,7 @@ func (x *Project) String() string {
 func (*Project) ProtoMessage() {}
 
 func (x *Project) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[58]
+	mi := &file_keyorix_proto_msgTypes[59]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4350,7 +4418,7 @@ func (x *Project) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Project.ProtoReflect.Descriptor instead.
 func (*Project) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{58}
+	return file_keyorix_proto_rawDescGZIP(), []int{59}
 }
 
 func (x *Project) GetId() uint32 {
@@ -4408,7 +4476,7 @@ type Environment struct {
 
 func (x *Environment) Reset() {
 	*x = Environment{}
-	mi := &file_keyorix_proto_msgTypes[59]
+	mi := &file_keyorix_proto_msgTypes[60]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4420,7 +4488,7 @@ func (x *Environment) String() string {
 func (*Environment) ProtoMessage() {}
 
 func (x *Environment) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[59]
+	mi := &file_keyorix_proto_msgTypes[60]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4433,7 +4501,7 @@ func (x *Environment) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Environment.ProtoReflect.Descriptor instead.
 func (*Environment) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{59}
+	return file_keyorix_proto_rawDescGZIP(), []int{60}
 }
 
 func (x *Environment) GetId() uint32 {
@@ -4480,7 +4548,7 @@ type ListProjectsResponse struct {
 
 func (x *ListProjectsResponse) Reset() {
 	*x = ListProjectsResponse{}
-	mi := &file_keyorix_proto_msgTypes[60]
+	mi := &file_keyorix_proto_msgTypes[61]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4492,7 +4560,7 @@ func (x *ListProjectsResponse) String() string {
 func (*ListProjectsResponse) ProtoMessage() {}
 
 func (x *ListProjectsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[60]
+	mi := &file_keyorix_proto_msgTypes[61]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4505,7 +4573,7 @@ func (x *ListProjectsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListProjectsResponse.ProtoReflect.Descriptor instead.
 func (*ListProjectsResponse) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{60}
+	return file_keyorix_proto_rawDescGZIP(), []int{61}
 }
 
 func (x *ListProjectsResponse) GetProjects() []*Project {
@@ -4524,7 +4592,7 @@ type GetProjectRequest struct {
 
 func (x *GetProjectRequest) Reset() {
 	*x = GetProjectRequest{}
-	mi := &file_keyorix_proto_msgTypes[61]
+	mi := &file_keyorix_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4536,7 +4604,7 @@ func (x *GetProjectRequest) String() string {
 func (*GetProjectRequest) ProtoMessage() {}
 
 func (x *GetProjectRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[61]
+	mi := &file_keyorix_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4549,7 +4617,7 @@ func (x *GetProjectRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetProjectRequest.ProtoReflect.Descriptor instead.
 func (*GetProjectRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{61}
+	return file_keyorix_proto_rawDescGZIP(), []int{62}
 }
 
 func (x *GetProjectRequest) GetId() uint32 {
@@ -4569,7 +4637,7 @@ type CreateProjectRequest struct {
 
 func (x *CreateProjectRequest) Reset() {
 	*x = CreateProjectRequest{}
-	mi := &file_keyorix_proto_msgTypes[62]
+	mi := &file_keyorix_proto_msgTypes[63]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4581,7 +4649,7 @@ func (x *CreateProjectRequest) String() string {
 func (*CreateProjectRequest) ProtoMessage() {}
 
 func (x *CreateProjectRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[62]
+	mi := &file_keyorix_proto_msgTypes[63]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4594,7 +4662,7 @@ func (x *CreateProjectRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateProjectRequest.ProtoReflect.Descriptor instead.
 func (*CreateProjectRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{62}
+	return file_keyorix_proto_rawDescGZIP(), []int{63}
 }
 
 func (x *CreateProjectRequest) GetName() string {
@@ -4623,7 +4691,7 @@ type UpdateProjectRequest struct {
 
 func (x *UpdateProjectRequest) Reset() {
 	*x = UpdateProjectRequest{}
-	mi := &file_keyorix_proto_msgTypes[63]
+	mi := &file_keyorix_proto_msgTypes[64]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4635,7 +4703,7 @@ func (x *UpdateProjectRequest) String() string {
 func (*UpdateProjectRequest) ProtoMessage() {}
 
 func (x *UpdateProjectRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[63]
+	mi := &file_keyorix_proto_msgTypes[64]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4648,7 +4716,7 @@ func (x *UpdateProjectRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateProjectRequest.ProtoReflect.Descriptor instead.
 func (*UpdateProjectRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{63}
+	return file_keyorix_proto_rawDescGZIP(), []int{64}
 }
 
 func (x *UpdateProjectRequest) GetId() uint32 {
@@ -4689,7 +4757,7 @@ type DeleteProjectRequest struct {
 
 func (x *DeleteProjectRequest) Reset() {
 	*x = DeleteProjectRequest{}
-	mi := &file_keyorix_proto_msgTypes[64]
+	mi := &file_keyorix_proto_msgTypes[65]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4701,7 +4769,7 @@ func (x *DeleteProjectRequest) String() string {
 func (*DeleteProjectRequest) ProtoMessage() {}
 
 func (x *DeleteProjectRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[64]
+	mi := &file_keyorix_proto_msgTypes[65]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4714,7 +4782,7 @@ func (x *DeleteProjectRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteProjectRequest.ProtoReflect.Descriptor instead.
 func (*DeleteProjectRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{64}
+	return file_keyorix_proto_rawDescGZIP(), []int{65}
 }
 
 func (x *DeleteProjectRequest) GetId() uint32 {
@@ -4740,7 +4808,7 @@ type ListEnvironmentsRequest struct {
 
 func (x *ListEnvironmentsRequest) Reset() {
 	*x = ListEnvironmentsRequest{}
-	mi := &file_keyorix_proto_msgTypes[65]
+	mi := &file_keyorix_proto_msgTypes[66]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4752,7 +4820,7 @@ func (x *ListEnvironmentsRequest) String() string {
 func (*ListEnvironmentsRequest) ProtoMessage() {}
 
 func (x *ListEnvironmentsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[65]
+	mi := &file_keyorix_proto_msgTypes[66]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4765,7 +4833,7 @@ func (x *ListEnvironmentsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListEnvironmentsRequest.ProtoReflect.Descriptor instead.
 func (*ListEnvironmentsRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{65}
+	return file_keyorix_proto_rawDescGZIP(), []int{66}
 }
 
 func (x *ListEnvironmentsRequest) GetProjectId() uint32 {
@@ -4784,7 +4852,7 @@ type ListEnvironmentsResponse struct {
 
 func (x *ListEnvironmentsResponse) Reset() {
 	*x = ListEnvironmentsResponse{}
-	mi := &file_keyorix_proto_msgTypes[66]
+	mi := &file_keyorix_proto_msgTypes[67]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4796,7 +4864,7 @@ func (x *ListEnvironmentsResponse) String() string {
 func (*ListEnvironmentsResponse) ProtoMessage() {}
 
 func (x *ListEnvironmentsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[66]
+	mi := &file_keyorix_proto_msgTypes[67]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4809,7 +4877,7 @@ func (x *ListEnvironmentsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListEnvironmentsResponse.ProtoReflect.Descriptor instead.
 func (*ListEnvironmentsResponse) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{66}
+	return file_keyorix_proto_rawDescGZIP(), []int{67}
 }
 
 func (x *ListEnvironmentsResponse) GetEnvironments() []*Environment {
@@ -4839,7 +4907,7 @@ type MachineIdentity struct {
 
 func (x *MachineIdentity) Reset() {
 	*x = MachineIdentity{}
-	mi := &file_keyorix_proto_msgTypes[67]
+	mi := &file_keyorix_proto_msgTypes[68]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4851,7 +4919,7 @@ func (x *MachineIdentity) String() string {
 func (*MachineIdentity) ProtoMessage() {}
 
 func (x *MachineIdentity) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[67]
+	mi := &file_keyorix_proto_msgTypes[68]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4864,7 +4932,7 @@ func (x *MachineIdentity) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MachineIdentity.ProtoReflect.Descriptor instead.
 func (*MachineIdentity) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{67}
+	return file_keyorix_proto_rawDescGZIP(), []int{68}
 }
 
 func (x *MachineIdentity) GetId() uint32 {
@@ -4967,7 +5035,7 @@ type MachineToken struct {
 
 func (x *MachineToken) Reset() {
 	*x = MachineToken{}
-	mi := &file_keyorix_proto_msgTypes[68]
+	mi := &file_keyorix_proto_msgTypes[69]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4979,7 +5047,7 @@ func (x *MachineToken) String() string {
 func (*MachineToken) ProtoMessage() {}
 
 func (x *MachineToken) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[68]
+	mi := &file_keyorix_proto_msgTypes[69]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4992,7 +5060,7 @@ func (x *MachineToken) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MachineToken.ProtoReflect.Descriptor instead.
 func (*MachineToken) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{68}
+	return file_keyorix_proto_rawDescGZIP(), []int{69}
 }
 
 func (x *MachineToken) GetId() uint32 {
@@ -5060,7 +5128,7 @@ type ListMachineIdentitiesRequest struct {
 
 func (x *ListMachineIdentitiesRequest) Reset() {
 	*x = ListMachineIdentitiesRequest{}
-	mi := &file_keyorix_proto_msgTypes[69]
+	mi := &file_keyorix_proto_msgTypes[70]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5072,7 +5140,7 @@ func (x *ListMachineIdentitiesRequest) String() string {
 func (*ListMachineIdentitiesRequest) ProtoMessage() {}
 
 func (x *ListMachineIdentitiesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[69]
+	mi := &file_keyorix_proto_msgTypes[70]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5085,7 +5153,7 @@ func (x *ListMachineIdentitiesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListMachineIdentitiesRequest.ProtoReflect.Descriptor instead.
 func (*ListMachineIdentitiesRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{69}
+	return file_keyorix_proto_rawDescGZIP(), []int{70}
 }
 
 func (x *ListMachineIdentitiesRequest) GetProjectId() uint32 {
@@ -5104,7 +5172,7 @@ type ListMachineIdentitiesResponse struct {
 
 func (x *ListMachineIdentitiesResponse) Reset() {
 	*x = ListMachineIdentitiesResponse{}
-	mi := &file_keyorix_proto_msgTypes[70]
+	mi := &file_keyorix_proto_msgTypes[71]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5116,7 +5184,7 @@ func (x *ListMachineIdentitiesResponse) String() string {
 func (*ListMachineIdentitiesResponse) ProtoMessage() {}
 
 func (x *ListMachineIdentitiesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[70]
+	mi := &file_keyorix_proto_msgTypes[71]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5129,7 +5197,7 @@ func (x *ListMachineIdentitiesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListMachineIdentitiesResponse.ProtoReflect.Descriptor instead.
 func (*ListMachineIdentitiesResponse) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{70}
+	return file_keyorix_proto_rawDescGZIP(), []int{71}
 }
 
 func (x *ListMachineIdentitiesResponse) GetMachineIdentities() []*MachineIdentity {
@@ -5152,7 +5220,7 @@ type CreateMachineIdentityRequest struct {
 
 func (x *CreateMachineIdentityRequest) Reset() {
 	*x = CreateMachineIdentityRequest{}
-	mi := &file_keyorix_proto_msgTypes[71]
+	mi := &file_keyorix_proto_msgTypes[72]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5164,7 +5232,7 @@ func (x *CreateMachineIdentityRequest) String() string {
 func (*CreateMachineIdentityRequest) ProtoMessage() {}
 
 func (x *CreateMachineIdentityRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[71]
+	mi := &file_keyorix_proto_msgTypes[72]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5177,7 +5245,7 @@ func (x *CreateMachineIdentityRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateMachineIdentityRequest.ProtoReflect.Descriptor instead.
 func (*CreateMachineIdentityRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{71}
+	return file_keyorix_proto_rawDescGZIP(), []int{72}
 }
 
 func (x *CreateMachineIdentityRequest) GetProjectId() uint32 {
@@ -5226,7 +5294,7 @@ type TransitionMachineIdentityRequest struct {
 
 func (x *TransitionMachineIdentityRequest) Reset() {
 	*x = TransitionMachineIdentityRequest{}
-	mi := &file_keyorix_proto_msgTypes[72]
+	mi := &file_keyorix_proto_msgTypes[73]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5238,7 +5306,7 @@ func (x *TransitionMachineIdentityRequest) String() string {
 func (*TransitionMachineIdentityRequest) ProtoMessage() {}
 
 func (x *TransitionMachineIdentityRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[72]
+	mi := &file_keyorix_proto_msgTypes[73]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5251,7 +5319,7 @@ func (x *TransitionMachineIdentityRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TransitionMachineIdentityRequest.ProtoReflect.Descriptor instead.
 func (*TransitionMachineIdentityRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{72}
+	return file_keyorix_proto_rawDescGZIP(), []int{73}
 }
 
 func (x *TransitionMachineIdentityRequest) GetProjectId() uint32 {
@@ -5286,7 +5354,7 @@ type ClassifyMachineIdentityRequest struct {
 
 func (x *ClassifyMachineIdentityRequest) Reset() {
 	*x = ClassifyMachineIdentityRequest{}
-	mi := &file_keyorix_proto_msgTypes[73]
+	mi := &file_keyorix_proto_msgTypes[74]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5298,7 +5366,7 @@ func (x *ClassifyMachineIdentityRequest) String() string {
 func (*ClassifyMachineIdentityRequest) ProtoMessage() {}
 
 func (x *ClassifyMachineIdentityRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[73]
+	mi := &file_keyorix_proto_msgTypes[74]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5311,7 +5379,7 @@ func (x *ClassifyMachineIdentityRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ClassifyMachineIdentityRequest.ProtoReflect.Descriptor instead.
 func (*ClassifyMachineIdentityRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{73}
+	return file_keyorix_proto_rawDescGZIP(), []int{74}
 }
 
 func (x *ClassifyMachineIdentityRequest) GetProjectId() uint32 {
@@ -5348,7 +5416,7 @@ type IssueMachineTokenRequest struct {
 
 func (x *IssueMachineTokenRequest) Reset() {
 	*x = IssueMachineTokenRequest{}
-	mi := &file_keyorix_proto_msgTypes[74]
+	mi := &file_keyorix_proto_msgTypes[75]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5360,7 +5428,7 @@ func (x *IssueMachineTokenRequest) String() string {
 func (*IssueMachineTokenRequest) ProtoMessage() {}
 
 func (x *IssueMachineTokenRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[74]
+	mi := &file_keyorix_proto_msgTypes[75]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5373,7 +5441,7 @@ func (x *IssueMachineTokenRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IssueMachineTokenRequest.ProtoReflect.Descriptor instead.
 func (*IssueMachineTokenRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{74}
+	return file_keyorix_proto_rawDescGZIP(), []int{75}
 }
 
 func (x *IssueMachineTokenRequest) GetProjectId() uint32 {
@@ -5424,7 +5492,7 @@ type IssueMachineTokenResponse struct {
 
 func (x *IssueMachineTokenResponse) Reset() {
 	*x = IssueMachineTokenResponse{}
-	mi := &file_keyorix_proto_msgTypes[75]
+	mi := &file_keyorix_proto_msgTypes[76]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5436,7 +5504,7 @@ func (x *IssueMachineTokenResponse) String() string {
 func (*IssueMachineTokenResponse) ProtoMessage() {}
 
 func (x *IssueMachineTokenResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[75]
+	mi := &file_keyorix_proto_msgTypes[76]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5449,7 +5517,7 @@ func (x *IssueMachineTokenResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IssueMachineTokenResponse.ProtoReflect.Descriptor instead.
 func (*IssueMachineTokenResponse) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{75}
+	return file_keyorix_proto_rawDescGZIP(), []int{76}
 }
 
 func (x *IssueMachineTokenResponse) GetToken() string {
@@ -5497,7 +5565,7 @@ type ListMachineTokensRequest struct {
 
 func (x *ListMachineTokensRequest) Reset() {
 	*x = ListMachineTokensRequest{}
-	mi := &file_keyorix_proto_msgTypes[76]
+	mi := &file_keyorix_proto_msgTypes[77]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5509,7 +5577,7 @@ func (x *ListMachineTokensRequest) String() string {
 func (*ListMachineTokensRequest) ProtoMessage() {}
 
 func (x *ListMachineTokensRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[76]
+	mi := &file_keyorix_proto_msgTypes[77]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5522,7 +5590,7 @@ func (x *ListMachineTokensRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListMachineTokensRequest.ProtoReflect.Descriptor instead.
 func (*ListMachineTokensRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{76}
+	return file_keyorix_proto_rawDescGZIP(), []int{77}
 }
 
 func (x *ListMachineTokensRequest) GetProjectId() uint32 {
@@ -5548,7 +5616,7 @@ type ListMachineTokensResponse struct {
 
 func (x *ListMachineTokensResponse) Reset() {
 	*x = ListMachineTokensResponse{}
-	mi := &file_keyorix_proto_msgTypes[77]
+	mi := &file_keyorix_proto_msgTypes[78]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5560,7 +5628,7 @@ func (x *ListMachineTokensResponse) String() string {
 func (*ListMachineTokensResponse) ProtoMessage() {}
 
 func (x *ListMachineTokensResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[77]
+	mi := &file_keyorix_proto_msgTypes[78]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5573,7 +5641,7 @@ func (x *ListMachineTokensResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListMachineTokensResponse.ProtoReflect.Descriptor instead.
 func (*ListMachineTokensResponse) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{77}
+	return file_keyorix_proto_rawDescGZIP(), []int{78}
 }
 
 func (x *ListMachineTokensResponse) GetTokens() []*MachineToken {
@@ -5594,7 +5662,7 @@ type RevokeMachineTokenRequest struct {
 
 func (x *RevokeMachineTokenRequest) Reset() {
 	*x = RevokeMachineTokenRequest{}
-	mi := &file_keyorix_proto_msgTypes[78]
+	mi := &file_keyorix_proto_msgTypes[79]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5606,7 +5674,7 @@ func (x *RevokeMachineTokenRequest) String() string {
 func (*RevokeMachineTokenRequest) ProtoMessage() {}
 
 func (x *RevokeMachineTokenRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[78]
+	mi := &file_keyorix_proto_msgTypes[79]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5619,7 +5687,7 @@ func (x *RevokeMachineTokenRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RevokeMachineTokenRequest.ProtoReflect.Descriptor instead.
 func (*RevokeMachineTokenRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{78}
+	return file_keyorix_proto_rawDescGZIP(), []int{79}
 }
 
 func (x *RevokeMachineTokenRequest) GetProjectId() uint32 {
@@ -5655,7 +5723,7 @@ type ClassifyMachineTokenRequest struct {
 
 func (x *ClassifyMachineTokenRequest) Reset() {
 	*x = ClassifyMachineTokenRequest{}
-	mi := &file_keyorix_proto_msgTypes[79]
+	mi := &file_keyorix_proto_msgTypes[80]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5667,7 +5735,7 @@ func (x *ClassifyMachineTokenRequest) String() string {
 func (*ClassifyMachineTokenRequest) ProtoMessage() {}
 
 func (x *ClassifyMachineTokenRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[79]
+	mi := &file_keyorix_proto_msgTypes[80]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5680,7 +5748,7 @@ func (x *ClassifyMachineTokenRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ClassifyMachineTokenRequest.ProtoReflect.Descriptor instead.
 func (*ClassifyMachineTokenRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{79}
+	return file_keyorix_proto_rawDescGZIP(), []int{80}
 }
 
 func (x *ClassifyMachineTokenRequest) GetProjectId() uint32 {
@@ -5730,7 +5798,7 @@ type DynamicSecretConfig struct {
 
 func (x *DynamicSecretConfig) Reset() {
 	*x = DynamicSecretConfig{}
-	mi := &file_keyorix_proto_msgTypes[80]
+	mi := &file_keyorix_proto_msgTypes[81]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5742,7 +5810,7 @@ func (x *DynamicSecretConfig) String() string {
 func (*DynamicSecretConfig) ProtoMessage() {}
 
 func (x *DynamicSecretConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[80]
+	mi := &file_keyorix_proto_msgTypes[81]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5755,7 +5823,7 @@ func (x *DynamicSecretConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DynamicSecretConfig.ProtoReflect.Descriptor instead.
 func (*DynamicSecretConfig) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{80}
+	return file_keyorix_proto_rawDescGZIP(), []int{81}
 }
 
 func (x *DynamicSecretConfig) GetId() uint32 {
@@ -5852,7 +5920,7 @@ type DynamicSecretLease struct {
 
 func (x *DynamicSecretLease) Reset() {
 	*x = DynamicSecretLease{}
-	mi := &file_keyorix_proto_msgTypes[81]
+	mi := &file_keyorix_proto_msgTypes[82]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5864,7 +5932,7 @@ func (x *DynamicSecretLease) String() string {
 func (*DynamicSecretLease) ProtoMessage() {}
 
 func (x *DynamicSecretLease) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[81]
+	mi := &file_keyorix_proto_msgTypes[82]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5877,7 +5945,7 @@ func (x *DynamicSecretLease) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DynamicSecretLease.ProtoReflect.Descriptor instead.
 func (*DynamicSecretLease) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{81}
+	return file_keyorix_proto_rawDescGZIP(), []int{82}
 }
 
 func (x *DynamicSecretLease) GetLeaseId() string {
@@ -5958,7 +6026,7 @@ type IssuedCredential struct {
 
 func (x *IssuedCredential) Reset() {
 	*x = IssuedCredential{}
-	mi := &file_keyorix_proto_msgTypes[82]
+	mi := &file_keyorix_proto_msgTypes[83]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5970,7 +6038,7 @@ func (x *IssuedCredential) String() string {
 func (*IssuedCredential) ProtoMessage() {}
 
 func (x *IssuedCredential) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[82]
+	mi := &file_keyorix_proto_msgTypes[83]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5983,7 +6051,7 @@ func (x *IssuedCredential) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IssuedCredential.ProtoReflect.Descriptor instead.
 func (*IssuedCredential) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{82}
+	return file_keyorix_proto_rawDescGZIP(), []int{83}
 }
 
 func (x *IssuedCredential) GetLeaseId() string {
@@ -6031,7 +6099,7 @@ type ListDynamicConfigsRequest struct {
 
 func (x *ListDynamicConfigsRequest) Reset() {
 	*x = ListDynamicConfigsRequest{}
-	mi := &file_keyorix_proto_msgTypes[83]
+	mi := &file_keyorix_proto_msgTypes[84]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6043,7 +6111,7 @@ func (x *ListDynamicConfigsRequest) String() string {
 func (*ListDynamicConfigsRequest) ProtoMessage() {}
 
 func (x *ListDynamicConfigsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[83]
+	mi := &file_keyorix_proto_msgTypes[84]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6056,7 +6124,7 @@ func (x *ListDynamicConfigsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListDynamicConfigsRequest.ProtoReflect.Descriptor instead.
 func (*ListDynamicConfigsRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{83}
+	return file_keyorix_proto_rawDescGZIP(), []int{84}
 }
 
 func (x *ListDynamicConfigsRequest) GetProjectId() uint32 {
@@ -6082,7 +6150,7 @@ type ListDynamicConfigsResponse struct {
 
 func (x *ListDynamicConfigsResponse) Reset() {
 	*x = ListDynamicConfigsResponse{}
-	mi := &file_keyorix_proto_msgTypes[84]
+	mi := &file_keyorix_proto_msgTypes[85]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6094,7 +6162,7 @@ func (x *ListDynamicConfigsResponse) String() string {
 func (*ListDynamicConfigsResponse) ProtoMessage() {}
 
 func (x *ListDynamicConfigsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[84]
+	mi := &file_keyorix_proto_msgTypes[85]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6107,7 +6175,7 @@ func (x *ListDynamicConfigsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListDynamicConfigsResponse.ProtoReflect.Descriptor instead.
 func (*ListDynamicConfigsResponse) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{84}
+	return file_keyorix_proto_rawDescGZIP(), []int{85}
 }
 
 func (x *ListDynamicConfigsResponse) GetConfigs() []*DynamicSecretConfig {
@@ -6126,7 +6194,7 @@ type GetDynamicConfigRequest struct {
 
 func (x *GetDynamicConfigRequest) Reset() {
 	*x = GetDynamicConfigRequest{}
-	mi := &file_keyorix_proto_msgTypes[85]
+	mi := &file_keyorix_proto_msgTypes[86]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6138,7 +6206,7 @@ func (x *GetDynamicConfigRequest) String() string {
 func (*GetDynamicConfigRequest) ProtoMessage() {}
 
 func (x *GetDynamicConfigRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[85]
+	mi := &file_keyorix_proto_msgTypes[86]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6151,7 +6219,7 @@ func (x *GetDynamicConfigRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetDynamicConfigRequest.ProtoReflect.Descriptor instead.
 func (*GetDynamicConfigRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{85}
+	return file_keyorix_proto_rawDescGZIP(), []int{86}
 }
 
 func (x *GetDynamicConfigRequest) GetId() uint32 {
@@ -6178,7 +6246,7 @@ type CreateDynamicConfigRequest struct {
 
 func (x *CreateDynamicConfigRequest) Reset() {
 	*x = CreateDynamicConfigRequest{}
-	mi := &file_keyorix_proto_msgTypes[86]
+	mi := &file_keyorix_proto_msgTypes[87]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6190,7 +6258,7 @@ func (x *CreateDynamicConfigRequest) String() string {
 func (*CreateDynamicConfigRequest) ProtoMessage() {}
 
 func (x *CreateDynamicConfigRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[86]
+	mi := &file_keyorix_proto_msgTypes[87]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6203,7 +6271,7 @@ func (x *CreateDynamicConfigRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateDynamicConfigRequest.ProtoReflect.Descriptor instead.
 func (*CreateDynamicConfigRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{86}
+	return file_keyorix_proto_rawDescGZIP(), []int{87}
 }
 
 func (x *CreateDynamicConfigRequest) GetName() string {
@@ -6279,7 +6347,7 @@ type ClassifyDynamicConfigRequest struct {
 
 func (x *ClassifyDynamicConfigRequest) Reset() {
 	*x = ClassifyDynamicConfigRequest{}
-	mi := &file_keyorix_proto_msgTypes[87]
+	mi := &file_keyorix_proto_msgTypes[88]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6291,7 +6359,7 @@ func (x *ClassifyDynamicConfigRequest) String() string {
 func (*ClassifyDynamicConfigRequest) ProtoMessage() {}
 
 func (x *ClassifyDynamicConfigRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[87]
+	mi := &file_keyorix_proto_msgTypes[88]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6304,7 +6372,7 @@ func (x *ClassifyDynamicConfigRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ClassifyDynamicConfigRequest.ProtoReflect.Descriptor instead.
 func (*ClassifyDynamicConfigRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{87}
+	return file_keyorix_proto_rawDescGZIP(), []int{88}
 }
 
 func (x *ClassifyDynamicConfigRequest) GetId() uint32 {
@@ -6331,7 +6399,7 @@ type IssueLeaseRequest struct {
 
 func (x *IssueLeaseRequest) Reset() {
 	*x = IssueLeaseRequest{}
-	mi := &file_keyorix_proto_msgTypes[88]
+	mi := &file_keyorix_proto_msgTypes[89]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6343,7 +6411,7 @@ func (x *IssueLeaseRequest) String() string {
 func (*IssueLeaseRequest) ProtoMessage() {}
 
 func (x *IssueLeaseRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[88]
+	mi := &file_keyorix_proto_msgTypes[89]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6356,7 +6424,7 @@ func (x *IssueLeaseRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IssueLeaseRequest.ProtoReflect.Descriptor instead.
 func (*IssueLeaseRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{88}
+	return file_keyorix_proto_rawDescGZIP(), []int{89}
 }
 
 func (x *IssueLeaseRequest) GetConfigId() uint32 {
@@ -6382,7 +6450,7 @@ type ListLeasesRequest struct {
 
 func (x *ListLeasesRequest) Reset() {
 	*x = ListLeasesRequest{}
-	mi := &file_keyorix_proto_msgTypes[89]
+	mi := &file_keyorix_proto_msgTypes[90]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6394,7 +6462,7 @@ func (x *ListLeasesRequest) String() string {
 func (*ListLeasesRequest) ProtoMessage() {}
 
 func (x *ListLeasesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[89]
+	mi := &file_keyorix_proto_msgTypes[90]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6407,7 +6475,7 @@ func (x *ListLeasesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListLeasesRequest.ProtoReflect.Descriptor instead.
 func (*ListLeasesRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{89}
+	return file_keyorix_proto_rawDescGZIP(), []int{90}
 }
 
 func (x *ListLeasesRequest) GetConfigId() uint32 {
@@ -6426,7 +6494,7 @@ type ListLeasesResponse struct {
 
 func (x *ListLeasesResponse) Reset() {
 	*x = ListLeasesResponse{}
-	mi := &file_keyorix_proto_msgTypes[90]
+	mi := &file_keyorix_proto_msgTypes[91]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6438,7 +6506,7 @@ func (x *ListLeasesResponse) String() string {
 func (*ListLeasesResponse) ProtoMessage() {}
 
 func (x *ListLeasesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[90]
+	mi := &file_keyorix_proto_msgTypes[91]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6451,7 +6519,7 @@ func (x *ListLeasesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListLeasesResponse.ProtoReflect.Descriptor instead.
 func (*ListLeasesResponse) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{90}
+	return file_keyorix_proto_rawDescGZIP(), []int{91}
 }
 
 func (x *ListLeasesResponse) GetLeases() []*DynamicSecretLease {
@@ -6470,7 +6538,7 @@ type RevokeLeaseRequest struct {
 
 func (x *RevokeLeaseRequest) Reset() {
 	*x = RevokeLeaseRequest{}
-	mi := &file_keyorix_proto_msgTypes[91]
+	mi := &file_keyorix_proto_msgTypes[92]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6482,7 +6550,7 @@ func (x *RevokeLeaseRequest) String() string {
 func (*RevokeLeaseRequest) ProtoMessage() {}
 
 func (x *RevokeLeaseRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[91]
+	mi := &file_keyorix_proto_msgTypes[92]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6495,7 +6563,7 @@ func (x *RevokeLeaseRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RevokeLeaseRequest.ProtoReflect.Descriptor instead.
 func (*RevokeLeaseRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{91}
+	return file_keyorix_proto_rawDescGZIP(), []int{92}
 }
 
 func (x *RevokeLeaseRequest) GetLeaseId() string {
@@ -6515,7 +6583,7 @@ type RenewLeaseRequest struct {
 
 func (x *RenewLeaseRequest) Reset() {
 	*x = RenewLeaseRequest{}
-	mi := &file_keyorix_proto_msgTypes[92]
+	mi := &file_keyorix_proto_msgTypes[93]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6527,7 +6595,7 @@ func (x *RenewLeaseRequest) String() string {
 func (*RenewLeaseRequest) ProtoMessage() {}
 
 func (x *RenewLeaseRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[92]
+	mi := &file_keyorix_proto_msgTypes[93]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6540,7 +6608,7 @@ func (x *RenewLeaseRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RenewLeaseRequest.ProtoReflect.Descriptor instead.
 func (*RenewLeaseRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{92}
+	return file_keyorix_proto_rawDescGZIP(), []int{93}
 }
 
 func (x *RenewLeaseRequest) GetLeaseId() string {
@@ -6567,7 +6635,7 @@ type RenewLeaseResponse struct {
 
 func (x *RenewLeaseResponse) Reset() {
 	*x = RenewLeaseResponse{}
-	mi := &file_keyorix_proto_msgTypes[93]
+	mi := &file_keyorix_proto_msgTypes[94]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6579,7 +6647,7 @@ func (x *RenewLeaseResponse) String() string {
 func (*RenewLeaseResponse) ProtoMessage() {}
 
 func (x *RenewLeaseResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[93]
+	mi := &file_keyorix_proto_msgTypes[94]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6592,7 +6660,7 @@ func (x *RenewLeaseResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RenewLeaseResponse.ProtoReflect.Descriptor instead.
 func (*RenewLeaseResponse) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{93}
+	return file_keyorix_proto_rawDescGZIP(), []int{94}
 }
 
 func (x *RenewLeaseResponse) GetLeaseId() string {
@@ -6618,7 +6686,7 @@ type RevokeAllLeasesRequest struct {
 
 func (x *RevokeAllLeasesRequest) Reset() {
 	*x = RevokeAllLeasesRequest{}
-	mi := &file_keyorix_proto_msgTypes[94]
+	mi := &file_keyorix_proto_msgTypes[95]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6630,7 +6698,7 @@ func (x *RevokeAllLeasesRequest) String() string {
 func (*RevokeAllLeasesRequest) ProtoMessage() {}
 
 func (x *RevokeAllLeasesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[94]
+	mi := &file_keyorix_proto_msgTypes[95]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6643,7 +6711,7 @@ func (x *RevokeAllLeasesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RevokeAllLeasesRequest.ProtoReflect.Descriptor instead.
 func (*RevokeAllLeasesRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{94}
+	return file_keyorix_proto_rawDescGZIP(), []int{95}
 }
 
 func (x *RevokeAllLeasesRequest) GetConfigId() uint32 {
@@ -6663,7 +6731,7 @@ type RevokeAllLeasesResponse struct {
 
 func (x *RevokeAllLeasesResponse) Reset() {
 	*x = RevokeAllLeasesResponse{}
-	mi := &file_keyorix_proto_msgTypes[95]
+	mi := &file_keyorix_proto_msgTypes[96]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6675,7 +6743,7 @@ func (x *RevokeAllLeasesResponse) String() string {
 func (*RevokeAllLeasesResponse) ProtoMessage() {}
 
 func (x *RevokeAllLeasesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[95]
+	mi := &file_keyorix_proto_msgTypes[96]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6688,7 +6756,7 @@ func (x *RevokeAllLeasesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RevokeAllLeasesResponse.ProtoReflect.Descriptor instead.
 func (*RevokeAllLeasesResponse) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{95}
+	return file_keyorix_proto_rawDescGZIP(), []int{96}
 }
 
 func (x *RevokeAllLeasesResponse) GetRevoked() uint32 {
@@ -6717,7 +6785,7 @@ type AuditIntegrityPosture struct {
 
 func (x *AuditIntegrityPosture) Reset() {
 	*x = AuditIntegrityPosture{}
-	mi := &file_keyorix_proto_msgTypes[96]
+	mi := &file_keyorix_proto_msgTypes[97]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6729,7 +6797,7 @@ func (x *AuditIntegrityPosture) String() string {
 func (*AuditIntegrityPosture) ProtoMessage() {}
 
 func (x *AuditIntegrityPosture) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[96]
+	mi := &file_keyorix_proto_msgTypes[97]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6742,7 +6810,7 @@ func (x *AuditIntegrityPosture) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AuditIntegrityPosture.ProtoReflect.Descriptor instead.
 func (*AuditIntegrityPosture) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{96}
+	return file_keyorix_proto_rawDescGZIP(), []int{97}
 }
 
 func (x *AuditIntegrityPosture) GetChainVerified() bool {
@@ -6789,7 +6857,7 @@ type AccessGovernancePosture struct {
 
 func (x *AccessGovernancePosture) Reset() {
 	*x = AccessGovernancePosture{}
-	mi := &file_keyorix_proto_msgTypes[97]
+	mi := &file_keyorix_proto_msgTypes[98]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6801,7 +6869,7 @@ func (x *AccessGovernancePosture) String() string {
 func (*AccessGovernancePosture) ProtoMessage() {}
 
 func (x *AccessGovernancePosture) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[97]
+	mi := &file_keyorix_proto_msgTypes[98]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6814,7 +6882,7 @@ func (x *AccessGovernancePosture) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AccessGovernancePosture.ProtoReflect.Descriptor instead.
 func (*AccessGovernancePosture) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{97}
+	return file_keyorix_proto_rawDescGZIP(), []int{98}
 }
 
 func (x *AccessGovernancePosture) GetProjects() int32 {
@@ -6884,7 +6952,7 @@ type RotationPosture struct {
 
 func (x *RotationPosture) Reset() {
 	*x = RotationPosture{}
-	mi := &file_keyorix_proto_msgTypes[98]
+	mi := &file_keyorix_proto_msgTypes[99]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6896,7 +6964,7 @@ func (x *RotationPosture) String() string {
 func (*RotationPosture) ProtoMessage() {}
 
 func (x *RotationPosture) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[98]
+	mi := &file_keyorix_proto_msgTypes[99]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6909,7 +6977,7 @@ func (x *RotationPosture) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RotationPosture.ProtoReflect.Descriptor instead.
 func (*RotationPosture) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{98}
+	return file_keyorix_proto_rawDescGZIP(), []int{99}
 }
 
 func (x *RotationPosture) GetCoveredSecrets() int32 {
@@ -6944,7 +7012,7 @@ type IdentityPosture struct {
 
 func (x *IdentityPosture) Reset() {
 	*x = IdentityPosture{}
-	mi := &file_keyorix_proto_msgTypes[99]
+	mi := &file_keyorix_proto_msgTypes[100]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6956,7 +7024,7 @@ func (x *IdentityPosture) String() string {
 func (*IdentityPosture) ProtoMessage() {}
 
 func (x *IdentityPosture) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[99]
+	mi := &file_keyorix_proto_msgTypes[100]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6969,7 +7037,7 @@ func (x *IdentityPosture) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IdentityPosture.ProtoReflect.Descriptor instead.
 func (*IdentityPosture) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{99}
+	return file_keyorix_proto_rawDescGZIP(), []int{100}
 }
 
 func (x *IdentityPosture) GetActiveUsers() int32 {
@@ -7003,7 +7071,7 @@ type EmergencyAccessPosture struct {
 
 func (x *EmergencyAccessPosture) Reset() {
 	*x = EmergencyAccessPosture{}
-	mi := &file_keyorix_proto_msgTypes[100]
+	mi := &file_keyorix_proto_msgTypes[101]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7015,7 +7083,7 @@ func (x *EmergencyAccessPosture) String() string {
 func (*EmergencyAccessPosture) ProtoMessage() {}
 
 func (x *EmergencyAccessPosture) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[100]
+	mi := &file_keyorix_proto_msgTypes[101]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7028,7 +7096,7 @@ func (x *EmergencyAccessPosture) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EmergencyAccessPosture.ProtoReflect.Descriptor instead.
 func (*EmergencyAccessPosture) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{100}
+	return file_keyorix_proto_rawDescGZIP(), []int{101}
 }
 
 func (x *EmergencyAccessPosture) GetActiveActivations() int32 {
@@ -7059,7 +7127,7 @@ type ClassificationCounts struct {
 
 func (x *ClassificationCounts) Reset() {
 	*x = ClassificationCounts{}
-	mi := &file_keyorix_proto_msgTypes[101]
+	mi := &file_keyorix_proto_msgTypes[102]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7071,7 +7139,7 @@ func (x *ClassificationCounts) String() string {
 func (*ClassificationCounts) ProtoMessage() {}
 
 func (x *ClassificationCounts) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[101]
+	mi := &file_keyorix_proto_msgTypes[102]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7084,7 +7152,7 @@ func (x *ClassificationCounts) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ClassificationCounts.ProtoReflect.Descriptor instead.
 func (*ClassificationCounts) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{101}
+	return file_keyorix_proto_rawDescGZIP(), []int{102}
 }
 
 func (x *ClassificationCounts) GetTotal() int32 {
@@ -7146,7 +7214,7 @@ type ClassificationPosture struct {
 
 func (x *ClassificationPosture) Reset() {
 	*x = ClassificationPosture{}
-	mi := &file_keyorix_proto_msgTypes[102]
+	mi := &file_keyorix_proto_msgTypes[103]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7158,7 +7226,7 @@ func (x *ClassificationPosture) String() string {
 func (*ClassificationPosture) ProtoMessage() {}
 
 func (x *ClassificationPosture) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[102]
+	mi := &file_keyorix_proto_msgTypes[103]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7171,7 +7239,7 @@ func (x *ClassificationPosture) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ClassificationPosture.ProtoReflect.Descriptor instead.
 func (*ClassificationPosture) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{102}
+	return file_keyorix_proto_rawDescGZIP(), []int{103}
 }
 
 func (x *ClassificationPosture) GetTotalSecrets() int32 {
@@ -7247,7 +7315,7 @@ type AnomaliesPosture struct {
 
 func (x *AnomaliesPosture) Reset() {
 	*x = AnomaliesPosture{}
-	mi := &file_keyorix_proto_msgTypes[103]
+	mi := &file_keyorix_proto_msgTypes[104]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7259,7 +7327,7 @@ func (x *AnomaliesPosture) String() string {
 func (*AnomaliesPosture) ProtoMessage() {}
 
 func (x *AnomaliesPosture) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[103]
+	mi := &file_keyorix_proto_msgTypes[104]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7272,7 +7340,7 @@ func (x *AnomaliesPosture) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AnomaliesPosture.ProtoReflect.Descriptor instead.
 func (*AnomaliesPosture) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{103}
+	return file_keyorix_proto_rawDescGZIP(), []int{104}
 }
 
 func (x *AnomaliesPosture) GetUnacknowledged() int32 {
@@ -7300,7 +7368,7 @@ type LegalHoldPosture struct {
 
 func (x *LegalHoldPosture) Reset() {
 	*x = LegalHoldPosture{}
-	mi := &file_keyorix_proto_msgTypes[104]
+	mi := &file_keyorix_proto_msgTypes[105]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7312,7 +7380,7 @@ func (x *LegalHoldPosture) String() string {
 func (*LegalHoldPosture) ProtoMessage() {}
 
 func (x *LegalHoldPosture) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[104]
+	mi := &file_keyorix_proto_msgTypes[105]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7325,7 +7393,7 @@ func (x *LegalHoldPosture) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LegalHoldPosture.ProtoReflect.Descriptor instead.
 func (*LegalHoldPosture) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{104}
+	return file_keyorix_proto_rawDescGZIP(), []int{105}
 }
 
 func (x *LegalHoldPosture) GetActive() bool {
@@ -7362,7 +7430,7 @@ type RetentionPosture struct {
 
 func (x *RetentionPosture) Reset() {
 	*x = RetentionPosture{}
-	mi := &file_keyorix_proto_msgTypes[105]
+	mi := &file_keyorix_proto_msgTypes[106]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7374,7 +7442,7 @@ func (x *RetentionPosture) String() string {
 func (*RetentionPosture) ProtoMessage() {}
 
 func (x *RetentionPosture) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[105]
+	mi := &file_keyorix_proto_msgTypes[106]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7387,7 +7455,7 @@ func (x *RetentionPosture) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RetentionPosture.ProtoReflect.Descriptor instead.
 func (*RetentionPosture) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{105}
+	return file_keyorix_proto_rawDescGZIP(), []int{106}
 }
 
 func (x *RetentionPosture) GetEnabled() bool {
@@ -7435,7 +7503,7 @@ type RiskPosture struct {
 
 func (x *RiskPosture) Reset() {
 	*x = RiskPosture{}
-	mi := &file_keyorix_proto_msgTypes[106]
+	mi := &file_keyorix_proto_msgTypes[107]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7447,7 +7515,7 @@ func (x *RiskPosture) String() string {
 func (*RiskPosture) ProtoMessage() {}
 
 func (x *RiskPosture) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[106]
+	mi := &file_keyorix_proto_msgTypes[107]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7460,7 +7528,7 @@ func (x *RiskPosture) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RiskPosture.ProtoReflect.Descriptor instead.
 func (*RiskPosture) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{106}
+	return file_keyorix_proto_rawDescGZIP(), []int{107}
 }
 
 func (x *RiskPosture) GetActiveExceptions() int32 {
@@ -7496,7 +7564,7 @@ type CompliancePosture struct {
 
 func (x *CompliancePosture) Reset() {
 	*x = CompliancePosture{}
-	mi := &file_keyorix_proto_msgTypes[107]
+	mi := &file_keyorix_proto_msgTypes[108]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7508,7 +7576,7 @@ func (x *CompliancePosture) String() string {
 func (*CompliancePosture) ProtoMessage() {}
 
 func (x *CompliancePosture) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[107]
+	mi := &file_keyorix_proto_msgTypes[108]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7521,7 +7589,7 @@ func (x *CompliancePosture) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CompliancePosture.ProtoReflect.Descriptor instead.
 func (*CompliancePosture) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{107}
+	return file_keyorix_proto_rawDescGZIP(), []int{108}
 }
 
 func (x *CompliancePosture) GetGeneratedAt() *timestamppb.Timestamp {
@@ -7613,7 +7681,7 @@ type FrameworkRefs struct {
 
 func (x *FrameworkRefs) Reset() {
 	*x = FrameworkRefs{}
-	mi := &file_keyorix_proto_msgTypes[108]
+	mi := &file_keyorix_proto_msgTypes[109]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7625,7 +7693,7 @@ func (x *FrameworkRefs) String() string {
 func (*FrameworkRefs) ProtoMessage() {}
 
 func (x *FrameworkRefs) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[108]
+	mi := &file_keyorix_proto_msgTypes[109]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7638,7 +7706,7 @@ func (x *FrameworkRefs) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FrameworkRefs.ProtoReflect.Descriptor instead.
 func (*FrameworkRefs) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{108}
+	return file_keyorix_proto_rawDescGZIP(), []int{109}
 }
 
 func (x *FrameworkRefs) GetIso_27001() []string {
@@ -7683,7 +7751,7 @@ type ControlState struct {
 
 func (x *ControlState) Reset() {
 	*x = ControlState{}
-	mi := &file_keyorix_proto_msgTypes[109]
+	mi := &file_keyorix_proto_msgTypes[110]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7695,7 +7763,7 @@ func (x *ControlState) String() string {
 func (*ControlState) ProtoMessage() {}
 
 func (x *ControlState) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[109]
+	mi := &file_keyorix_proto_msgTypes[110]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7708,7 +7776,7 @@ func (x *ControlState) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ControlState.ProtoReflect.Descriptor instead.
 func (*ControlState) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{109}
+	return file_keyorix_proto_rawDescGZIP(), []int{110}
 }
 
 func (x *ControlState) GetId() string {
@@ -7765,7 +7833,7 @@ type ControlsSummary struct {
 
 func (x *ControlsSummary) Reset() {
 	*x = ControlsSummary{}
-	mi := &file_keyorix_proto_msgTypes[110]
+	mi := &file_keyorix_proto_msgTypes[111]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7777,7 +7845,7 @@ func (x *ControlsSummary) String() string {
 func (*ControlsSummary) ProtoMessage() {}
 
 func (x *ControlsSummary) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[110]
+	mi := &file_keyorix_proto_msgTypes[111]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7790,7 +7858,7 @@ func (x *ControlsSummary) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ControlsSummary.ProtoReflect.Descriptor instead.
 func (*ControlsSummary) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{110}
+	return file_keyorix_proto_rawDescGZIP(), []int{111}
 }
 
 func (x *ControlsSummary) GetTotal() int32 {
@@ -7832,7 +7900,7 @@ type ComplianceControls struct {
 
 func (x *ComplianceControls) Reset() {
 	*x = ComplianceControls{}
-	mi := &file_keyorix_proto_msgTypes[111]
+	mi := &file_keyorix_proto_msgTypes[112]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7844,7 +7912,7 @@ func (x *ComplianceControls) String() string {
 func (*ComplianceControls) ProtoMessage() {}
 
 func (x *ComplianceControls) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[111]
+	mi := &file_keyorix_proto_msgTypes[112]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7857,7 +7925,7 @@ func (x *ComplianceControls) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ComplianceControls.ProtoReflect.Descriptor instead.
 func (*ComplianceControls) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{111}
+	return file_keyorix_proto_rawDescGZIP(), []int{112}
 }
 
 func (x *ComplianceControls) GetGeneratedAt() *timestamppb.Timestamp {
@@ -7890,7 +7958,7 @@ type ConnectorList struct {
 
 func (x *ConnectorList) Reset() {
 	*x = ConnectorList{}
-	mi := &file_keyorix_proto_msgTypes[112]
+	mi := &file_keyorix_proto_msgTypes[113]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7902,7 +7970,7 @@ func (x *ConnectorList) String() string {
 func (*ConnectorList) ProtoMessage() {}
 
 func (x *ConnectorList) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[112]
+	mi := &file_keyorix_proto_msgTypes[113]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7915,7 +7983,7 @@ func (x *ConnectorList) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConnectorList.ProtoReflect.Descriptor instead.
 func (*ConnectorList) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{112}
+	return file_keyorix_proto_rawDescGZIP(), []int{113}
 }
 
 func (x *ConnectorList) GetConnectors() []string {
@@ -7935,7 +8003,7 @@ type ReadFederatedSecretRequest struct {
 
 func (x *ReadFederatedSecretRequest) Reset() {
 	*x = ReadFederatedSecretRequest{}
-	mi := &file_keyorix_proto_msgTypes[113]
+	mi := &file_keyorix_proto_msgTypes[114]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7947,7 +8015,7 @@ func (x *ReadFederatedSecretRequest) String() string {
 func (*ReadFederatedSecretRequest) ProtoMessage() {}
 
 func (x *ReadFederatedSecretRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[113]
+	mi := &file_keyorix_proto_msgTypes[114]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7960,7 +8028,7 @@ func (x *ReadFederatedSecretRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReadFederatedSecretRequest.ProtoReflect.Descriptor instead.
 func (*ReadFederatedSecretRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{113}
+	return file_keyorix_proto_rawDescGZIP(), []int{114}
 }
 
 func (x *ReadFederatedSecretRequest) GetConnector() string {
@@ -7988,7 +8056,7 @@ type FederatedSecretValue struct {
 
 func (x *FederatedSecretValue) Reset() {
 	*x = FederatedSecretValue{}
-	mi := &file_keyorix_proto_msgTypes[114]
+	mi := &file_keyorix_proto_msgTypes[115]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8000,7 +8068,7 @@ func (x *FederatedSecretValue) String() string {
 func (*FederatedSecretValue) ProtoMessage() {}
 
 func (x *FederatedSecretValue) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[114]
+	mi := &file_keyorix_proto_msgTypes[115]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8013,7 +8081,7 @@ func (x *FederatedSecretValue) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FederatedSecretValue.ProtoReflect.Descriptor instead.
 func (*FederatedSecretValue) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{114}
+	return file_keyorix_proto_rawDescGZIP(), []int{115}
 }
 
 func (x *FederatedSecretValue) GetConnector() string {
@@ -8049,7 +8117,7 @@ type ConnectRefGrant struct {
 
 func (x *ConnectRefGrant) Reset() {
 	*x = ConnectRefGrant{}
-	mi := &file_keyorix_proto_msgTypes[115]
+	mi := &file_keyorix_proto_msgTypes[116]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8061,7 +8129,7 @@ func (x *ConnectRefGrant) String() string {
 func (*ConnectRefGrant) ProtoMessage() {}
 
 func (x *ConnectRefGrant) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[115]
+	mi := &file_keyorix_proto_msgTypes[116]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8074,7 +8142,7 @@ func (x *ConnectRefGrant) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConnectRefGrant.ProtoReflect.Descriptor instead.
 func (*ConnectRefGrant) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{115}
+	return file_keyorix_proto_rawDescGZIP(), []int{116}
 }
 
 func (x *ConnectRefGrant) GetId() uint32 {
@@ -8114,7 +8182,7 @@ type ConnectRefGrantList struct {
 
 func (x *ConnectRefGrantList) Reset() {
 	*x = ConnectRefGrantList{}
-	mi := &file_keyorix_proto_msgTypes[116]
+	mi := &file_keyorix_proto_msgTypes[117]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8126,7 +8194,7 @@ func (x *ConnectRefGrantList) String() string {
 func (*ConnectRefGrantList) ProtoMessage() {}
 
 func (x *ConnectRefGrantList) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[116]
+	mi := &file_keyorix_proto_msgTypes[117]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8139,7 +8207,7 @@ func (x *ConnectRefGrantList) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConnectRefGrantList.ProtoReflect.Descriptor instead.
 func (*ConnectRefGrantList) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{116}
+	return file_keyorix_proto_rawDescGZIP(), []int{117}
 }
 
 func (x *ConnectRefGrantList) GetGrants() []*ConnectRefGrant {
@@ -8160,7 +8228,7 @@ type CreateConnectRefGrantRequest struct {
 
 func (x *CreateConnectRefGrantRequest) Reset() {
 	*x = CreateConnectRefGrantRequest{}
-	mi := &file_keyorix_proto_msgTypes[117]
+	mi := &file_keyorix_proto_msgTypes[118]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8172,7 +8240,7 @@ func (x *CreateConnectRefGrantRequest) String() string {
 func (*CreateConnectRefGrantRequest) ProtoMessage() {}
 
 func (x *CreateConnectRefGrantRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[117]
+	mi := &file_keyorix_proto_msgTypes[118]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8185,7 +8253,7 @@ func (x *CreateConnectRefGrantRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateConnectRefGrantRequest.ProtoReflect.Descriptor instead.
 func (*CreateConnectRefGrantRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{117}
+	return file_keyorix_proto_rawDescGZIP(), []int{118}
 }
 
 func (x *CreateConnectRefGrantRequest) GetRoleId() uint32 {
@@ -8218,7 +8286,7 @@ type DeleteConnectRefGrantRequest struct {
 
 func (x *DeleteConnectRefGrantRequest) Reset() {
 	*x = DeleteConnectRefGrantRequest{}
-	mi := &file_keyorix_proto_msgTypes[118]
+	mi := &file_keyorix_proto_msgTypes[119]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8230,7 +8298,7 @@ func (x *DeleteConnectRefGrantRequest) String() string {
 func (*DeleteConnectRefGrantRequest) ProtoMessage() {}
 
 func (x *DeleteConnectRefGrantRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[118]
+	mi := &file_keyorix_proto_msgTypes[119]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8243,7 +8311,7 @@ func (x *DeleteConnectRefGrantRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteConnectRefGrantRequest.ProtoReflect.Descriptor instead.
 func (*DeleteConnectRefGrantRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{118}
+	return file_keyorix_proto_rawDescGZIP(), []int{119}
 }
 
 func (x *DeleteConnectRefGrantRequest) GetId() uint32 {
@@ -8370,7 +8438,12 @@ const file_keyorix_proto_rawDesc = "" +
 	"ownedCount\x12!\n" +
 	"\fshared_count\x18\a \x01(\rR\vsharedCount\"*\n" +
 	"\x18GetSecretVersionsRequest\x12\x0e\n" +
-	"\x02id\x18\x01 \x01(\rR\x02id\"\x90\x01\n" +
+	"\x02id\x18\x01 \x01(\rR\x02id\"x\n" +
+	"\x1aSetSecretAutoRotateRequest\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\rR\x02id\x12\x18\n" +
+	"\aenabled\x18\x02 \x01(\bR\aenabled\x12\x16\n" +
+	"\x06length\x18\x03 \x01(\x05R\x06length\x12\x18\n" +
+	"\acharset\x18\x04 \x01(\tR\acharset\"\x90\x01\n" +
 	"\rSecretVersion\x12%\n" +
 	"\x0eversion_number\x18\x01 \x01(\rR\rversionNumber\x129\n" +
 	"\n" +
@@ -9089,7 +9162,7 @@ const file_keyorix_proto_rawDesc = "" +
 	"\n" +
 	"ref_prefix\x18\x03 \x01(\tR\trefPrefix\".\n" +
 	"\x1cDeleteConnectRefGrantRequest\x12\x0e\n" +
-	"\x02id\x18\x01 \x01(\rR\x02id2\x9c\x04\n" +
+	"\x02id\x18\x01 \x01(\rR\x02id2\xf3\x04\n" +
 	"\rSecretService\x12C\n" +
 	"\fCreateSecret\x12\x1f.keyorix.v1.CreateSecretRequest\x1a\x12.keyorix.v1.Secret\x12=\n" +
 	"\tGetSecret\x12\x1c.keyorix.v1.GetSecretRequest\x1a\x12.keyorix.v1.Secret\x12G\n" +
@@ -9097,7 +9170,8 @@ const file_keyorix_proto_rawDesc = "" +
 	"\fUpdateSecret\x12\x1f.keyorix.v1.UpdateSecretRequest\x1a\x12.keyorix.v1.Secret\x12G\n" +
 	"\fDeleteSecret\x12\x1f.keyorix.v1.DeleteSecretRequest\x1a\x16.google.protobuf.Empty\x12N\n" +
 	"\vListSecrets\x12\x1e.keyorix.v1.ListSecretsRequest\x1a\x1f.keyorix.v1.ListSecretsResponse\x12`\n" +
-	"\x11GetSecretVersions\x12$.keyorix.v1.GetSecretVersionsRequest\x1a%.keyorix.v1.GetSecretVersionsResponse2\x83\x04\n" +
+	"\x11GetSecretVersions\x12$.keyorix.v1.GetSecretVersionsRequest\x1a%.keyorix.v1.GetSecretVersionsResponse\x12U\n" +
+	"\x13SetSecretAutoRotate\x12&.keyorix.v1.SetSecretAutoRotateRequest\x1a\x16.google.protobuf.Empty2\x83\x04\n" +
 	"\fShareService\x12F\n" +
 	"\vShareSecret\x12\x1e.keyorix.v1.ShareSecretRequest\x1a\x17.keyorix.v1.ShareRecord\x12W\n" +
 	"\x10ListSecretShares\x12#.keyorix.v1.ListSecretSharesRequest\x1a\x1e.keyorix.v1.ListSharesResponse\x12S\n" +
@@ -9190,7 +9264,7 @@ func file_keyorix_proto_rawDescGZIP() []byte {
 	return file_keyorix_proto_rawDescData
 }
 
-var file_keyorix_proto_msgTypes = make([]protoimpl.MessageInfo, 125)
+var file_keyorix_proto_msgTypes = make([]protoimpl.MessageInfo, 126)
 var file_keyorix_proto_goTypes = []any{
 	(*Secret)(nil),                           // 0: keyorix.v1.Secret
 	(*SecretValue)(nil),                      // 1: keyorix.v1.SecretValue
@@ -9201,212 +9275,213 @@ var file_keyorix_proto_goTypes = []any{
 	(*ListSecretsRequest)(nil),               // 6: keyorix.v1.ListSecretsRequest
 	(*ListSecretsResponse)(nil),              // 7: keyorix.v1.ListSecretsResponse
 	(*GetSecretVersionsRequest)(nil),         // 8: keyorix.v1.GetSecretVersionsRequest
-	(*SecretVersion)(nil),                    // 9: keyorix.v1.SecretVersion
-	(*GetSecretVersionsResponse)(nil),        // 10: keyorix.v1.GetSecretVersionsResponse
-	(*User)(nil),                             // 11: keyorix.v1.User
-	(*ProjectAssignment)(nil),                // 12: keyorix.v1.ProjectAssignment
-	(*CreateUserRequest)(nil),                // 13: keyorix.v1.CreateUserRequest
-	(*CreateUserResponse)(nil),               // 14: keyorix.v1.CreateUserResponse
-	(*GetUserRequest)(nil),                   // 15: keyorix.v1.GetUserRequest
-	(*UpdateUserRequest)(nil),                // 16: keyorix.v1.UpdateUserRequest
-	(*DeleteUserRequest)(nil),                // 17: keyorix.v1.DeleteUserRequest
-	(*ListUsersRequest)(nil),                 // 18: keyorix.v1.ListUsersRequest
-	(*ListUsersResponse)(nil),                // 19: keyorix.v1.ListUsersResponse
-	(*Permission)(nil),                       // 20: keyorix.v1.Permission
-	(*Role)(nil),                             // 21: keyorix.v1.Role
-	(*CreateRoleRequest)(nil),                // 22: keyorix.v1.CreateRoleRequest
-	(*GetRoleRequest)(nil),                   // 23: keyorix.v1.GetRoleRequest
-	(*UpdateRoleRequest)(nil),                // 24: keyorix.v1.UpdateRoleRequest
-	(*DeleteRoleRequest)(nil),                // 25: keyorix.v1.DeleteRoleRequest
-	(*ListRolesRequest)(nil),                 // 26: keyorix.v1.ListRolesRequest
-	(*ListRolesResponse)(nil),                // 27: keyorix.v1.ListRolesResponse
-	(*AssignRoleRequest)(nil),                // 28: keyorix.v1.AssignRoleRequest
-	(*RoleAssignment)(nil),                   // 29: keyorix.v1.RoleAssignment
-	(*RemoveRoleRequest)(nil),                // 30: keyorix.v1.RemoveRoleRequest
-	(*GetUserRolesRequest)(nil),              // 31: keyorix.v1.GetUserRolesRequest
-	(*GetUserRolesResponse)(nil),             // 32: keyorix.v1.GetUserRolesResponse
-	(*AuditLog)(nil),                         // 33: keyorix.v1.AuditLog
-	(*GetAuditLogsRequest)(nil),              // 34: keyorix.v1.GetAuditLogsRequest
-	(*GetAuditLogsResponse)(nil),             // 35: keyorix.v1.GetAuditLogsResponse
-	(*RBACAuditLog)(nil),                     // 36: keyorix.v1.RBACAuditLog
-	(*GetRBACAuditLogsRequest)(nil),          // 37: keyorix.v1.GetRBACAuditLogsRequest
-	(*GetRBACAuditLogsResponse)(nil),         // 38: keyorix.v1.GetRBACAuditLogsResponse
-	(*StreamAuditLogsRequest)(nil),           // 39: keyorix.v1.StreamAuditLogsRequest
-	(*ShareRecord)(nil),                      // 40: keyorix.v1.ShareRecord
-	(*ShareSecretRequest)(nil),               // 41: keyorix.v1.ShareSecretRequest
-	(*ListSecretSharesRequest)(nil),          // 42: keyorix.v1.ListSecretSharesRequest
-	(*ListUserSharesRequest)(nil),            // 43: keyorix.v1.ListUserSharesRequest
-	(*ListSharedSecretsRequest)(nil),         // 44: keyorix.v1.ListSharedSecretsRequest
-	(*ListSharesResponse)(nil),               // 45: keyorix.v1.ListSharesResponse
-	(*UpdateSharePermissionRequest)(nil),     // 46: keyorix.v1.UpdateSharePermissionRequest
-	(*RevokeShareRequest)(nil),               // 47: keyorix.v1.RevokeShareRequest
-	(*HealthResponse)(nil),                   // 48: keyorix.v1.HealthResponse
-	(*SystemInfo)(nil),                       // 49: keyorix.v1.SystemInfo
-	(*DatabaseInfo)(nil),                     // 50: keyorix.v1.DatabaseInfo
-	(*EncryptionInfo)(nil),                   // 51: keyorix.v1.EncryptionInfo
-	(*Metrics)(nil),                          // 52: keyorix.v1.Metrics
-	(*RequestMetrics)(nil),                   // 53: keyorix.v1.RequestMetrics
-	(*SecretMetrics)(nil),                    // 54: keyorix.v1.SecretMetrics
-	(*UserMetrics)(nil),                      // 55: keyorix.v1.UserMetrics
-	(*PerformanceMetrics)(nil),               // 56: keyorix.v1.PerformanceMetrics
-	(*SystemMetrics)(nil),                    // 57: keyorix.v1.SystemMetrics
-	(*Project)(nil),                          // 58: keyorix.v1.Project
-	(*Environment)(nil),                      // 59: keyorix.v1.Environment
-	(*ListProjectsResponse)(nil),             // 60: keyorix.v1.ListProjectsResponse
-	(*GetProjectRequest)(nil),                // 61: keyorix.v1.GetProjectRequest
-	(*CreateProjectRequest)(nil),             // 62: keyorix.v1.CreateProjectRequest
-	(*UpdateProjectRequest)(nil),             // 63: keyorix.v1.UpdateProjectRequest
-	(*DeleteProjectRequest)(nil),             // 64: keyorix.v1.DeleteProjectRequest
-	(*ListEnvironmentsRequest)(nil),          // 65: keyorix.v1.ListEnvironmentsRequest
-	(*ListEnvironmentsResponse)(nil),         // 66: keyorix.v1.ListEnvironmentsResponse
-	(*MachineIdentity)(nil),                  // 67: keyorix.v1.MachineIdentity
-	(*MachineToken)(nil),                     // 68: keyorix.v1.MachineToken
-	(*ListMachineIdentitiesRequest)(nil),     // 69: keyorix.v1.ListMachineIdentitiesRequest
-	(*ListMachineIdentitiesResponse)(nil),    // 70: keyorix.v1.ListMachineIdentitiesResponse
-	(*CreateMachineIdentityRequest)(nil),     // 71: keyorix.v1.CreateMachineIdentityRequest
-	(*TransitionMachineIdentityRequest)(nil), // 72: keyorix.v1.TransitionMachineIdentityRequest
-	(*ClassifyMachineIdentityRequest)(nil),   // 73: keyorix.v1.ClassifyMachineIdentityRequest
-	(*IssueMachineTokenRequest)(nil),         // 74: keyorix.v1.IssueMachineTokenRequest
-	(*IssueMachineTokenResponse)(nil),        // 75: keyorix.v1.IssueMachineTokenResponse
-	(*ListMachineTokensRequest)(nil),         // 76: keyorix.v1.ListMachineTokensRequest
-	(*ListMachineTokensResponse)(nil),        // 77: keyorix.v1.ListMachineTokensResponse
-	(*RevokeMachineTokenRequest)(nil),        // 78: keyorix.v1.RevokeMachineTokenRequest
-	(*ClassifyMachineTokenRequest)(nil),      // 79: keyorix.v1.ClassifyMachineTokenRequest
-	(*DynamicSecretConfig)(nil),              // 80: keyorix.v1.DynamicSecretConfig
-	(*DynamicSecretLease)(nil),               // 81: keyorix.v1.DynamicSecretLease
-	(*IssuedCredential)(nil),                 // 82: keyorix.v1.IssuedCredential
-	(*ListDynamicConfigsRequest)(nil),        // 83: keyorix.v1.ListDynamicConfigsRequest
-	(*ListDynamicConfigsResponse)(nil),       // 84: keyorix.v1.ListDynamicConfigsResponse
-	(*GetDynamicConfigRequest)(nil),          // 85: keyorix.v1.GetDynamicConfigRequest
-	(*CreateDynamicConfigRequest)(nil),       // 86: keyorix.v1.CreateDynamicConfigRequest
-	(*ClassifyDynamicConfigRequest)(nil),     // 87: keyorix.v1.ClassifyDynamicConfigRequest
-	(*IssueLeaseRequest)(nil),                // 88: keyorix.v1.IssueLeaseRequest
-	(*ListLeasesRequest)(nil),                // 89: keyorix.v1.ListLeasesRequest
-	(*ListLeasesResponse)(nil),               // 90: keyorix.v1.ListLeasesResponse
-	(*RevokeLeaseRequest)(nil),               // 91: keyorix.v1.RevokeLeaseRequest
-	(*RenewLeaseRequest)(nil),                // 92: keyorix.v1.RenewLeaseRequest
-	(*RenewLeaseResponse)(nil),               // 93: keyorix.v1.RenewLeaseResponse
-	(*RevokeAllLeasesRequest)(nil),           // 94: keyorix.v1.RevokeAllLeasesRequest
-	(*RevokeAllLeasesResponse)(nil),          // 95: keyorix.v1.RevokeAllLeasesResponse
-	(*AuditIntegrityPosture)(nil),            // 96: keyorix.v1.AuditIntegrityPosture
-	(*AccessGovernancePosture)(nil),          // 97: keyorix.v1.AccessGovernancePosture
-	(*RotationPosture)(nil),                  // 98: keyorix.v1.RotationPosture
-	(*IdentityPosture)(nil),                  // 99: keyorix.v1.IdentityPosture
-	(*EmergencyAccessPosture)(nil),           // 100: keyorix.v1.EmergencyAccessPosture
-	(*ClassificationCounts)(nil),             // 101: keyorix.v1.ClassificationCounts
-	(*ClassificationPosture)(nil),            // 102: keyorix.v1.ClassificationPosture
-	(*AnomaliesPosture)(nil),                 // 103: keyorix.v1.AnomaliesPosture
-	(*LegalHoldPosture)(nil),                 // 104: keyorix.v1.LegalHoldPosture
-	(*RetentionPosture)(nil),                 // 105: keyorix.v1.RetentionPosture
-	(*RiskPosture)(nil),                      // 106: keyorix.v1.RiskPosture
-	(*CompliancePosture)(nil),                // 107: keyorix.v1.CompliancePosture
-	(*FrameworkRefs)(nil),                    // 108: keyorix.v1.FrameworkRefs
-	(*ControlState)(nil),                     // 109: keyorix.v1.ControlState
-	(*ControlsSummary)(nil),                  // 110: keyorix.v1.ControlsSummary
-	(*ComplianceControls)(nil),               // 111: keyorix.v1.ComplianceControls
-	(*ConnectorList)(nil),                    // 112: keyorix.v1.ConnectorList
-	(*ReadFederatedSecretRequest)(nil),       // 113: keyorix.v1.ReadFederatedSecretRequest
-	(*FederatedSecretValue)(nil),             // 114: keyorix.v1.FederatedSecretValue
-	(*ConnectRefGrant)(nil),                  // 115: keyorix.v1.ConnectRefGrant
-	(*ConnectRefGrantList)(nil),              // 116: keyorix.v1.ConnectRefGrantList
-	(*CreateConnectRefGrantRequest)(nil),     // 117: keyorix.v1.CreateConnectRefGrantRequest
-	(*DeleteConnectRefGrantRequest)(nil),     // 118: keyorix.v1.DeleteConnectRefGrantRequest
-	nil,                                      // 119: keyorix.v1.Secret.MetadataEntry
-	nil,                                      // 120: keyorix.v1.CreateSecretRequest.MetadataEntry
-	nil,                                      // 121: keyorix.v1.UpdateSecretRequest.MetadataEntry
-	nil,                                      // 122: keyorix.v1.HealthResponse.ServicesEntry
-	nil,                                      // 123: keyorix.v1.SystemInfo.FeaturesEntry
-	nil,                                      // 124: keyorix.v1.IssuedCredential.FieldsEntry
-	(*timestamppb.Timestamp)(nil),            // 125: google.protobuf.Timestamp
-	(*emptypb.Empty)(nil),                    // 126: google.protobuf.Empty
+	(*SetSecretAutoRotateRequest)(nil),       // 9: keyorix.v1.SetSecretAutoRotateRequest
+	(*SecretVersion)(nil),                    // 10: keyorix.v1.SecretVersion
+	(*GetSecretVersionsResponse)(nil),        // 11: keyorix.v1.GetSecretVersionsResponse
+	(*User)(nil),                             // 12: keyorix.v1.User
+	(*ProjectAssignment)(nil),                // 13: keyorix.v1.ProjectAssignment
+	(*CreateUserRequest)(nil),                // 14: keyorix.v1.CreateUserRequest
+	(*CreateUserResponse)(nil),               // 15: keyorix.v1.CreateUserResponse
+	(*GetUserRequest)(nil),                   // 16: keyorix.v1.GetUserRequest
+	(*UpdateUserRequest)(nil),                // 17: keyorix.v1.UpdateUserRequest
+	(*DeleteUserRequest)(nil),                // 18: keyorix.v1.DeleteUserRequest
+	(*ListUsersRequest)(nil),                 // 19: keyorix.v1.ListUsersRequest
+	(*ListUsersResponse)(nil),                // 20: keyorix.v1.ListUsersResponse
+	(*Permission)(nil),                       // 21: keyorix.v1.Permission
+	(*Role)(nil),                             // 22: keyorix.v1.Role
+	(*CreateRoleRequest)(nil),                // 23: keyorix.v1.CreateRoleRequest
+	(*GetRoleRequest)(nil),                   // 24: keyorix.v1.GetRoleRequest
+	(*UpdateRoleRequest)(nil),                // 25: keyorix.v1.UpdateRoleRequest
+	(*DeleteRoleRequest)(nil),                // 26: keyorix.v1.DeleteRoleRequest
+	(*ListRolesRequest)(nil),                 // 27: keyorix.v1.ListRolesRequest
+	(*ListRolesResponse)(nil),                // 28: keyorix.v1.ListRolesResponse
+	(*AssignRoleRequest)(nil),                // 29: keyorix.v1.AssignRoleRequest
+	(*RoleAssignment)(nil),                   // 30: keyorix.v1.RoleAssignment
+	(*RemoveRoleRequest)(nil),                // 31: keyorix.v1.RemoveRoleRequest
+	(*GetUserRolesRequest)(nil),              // 32: keyorix.v1.GetUserRolesRequest
+	(*GetUserRolesResponse)(nil),             // 33: keyorix.v1.GetUserRolesResponse
+	(*AuditLog)(nil),                         // 34: keyorix.v1.AuditLog
+	(*GetAuditLogsRequest)(nil),              // 35: keyorix.v1.GetAuditLogsRequest
+	(*GetAuditLogsResponse)(nil),             // 36: keyorix.v1.GetAuditLogsResponse
+	(*RBACAuditLog)(nil),                     // 37: keyorix.v1.RBACAuditLog
+	(*GetRBACAuditLogsRequest)(nil),          // 38: keyorix.v1.GetRBACAuditLogsRequest
+	(*GetRBACAuditLogsResponse)(nil),         // 39: keyorix.v1.GetRBACAuditLogsResponse
+	(*StreamAuditLogsRequest)(nil),           // 40: keyorix.v1.StreamAuditLogsRequest
+	(*ShareRecord)(nil),                      // 41: keyorix.v1.ShareRecord
+	(*ShareSecretRequest)(nil),               // 42: keyorix.v1.ShareSecretRequest
+	(*ListSecretSharesRequest)(nil),          // 43: keyorix.v1.ListSecretSharesRequest
+	(*ListUserSharesRequest)(nil),            // 44: keyorix.v1.ListUserSharesRequest
+	(*ListSharedSecretsRequest)(nil),         // 45: keyorix.v1.ListSharedSecretsRequest
+	(*ListSharesResponse)(nil),               // 46: keyorix.v1.ListSharesResponse
+	(*UpdateSharePermissionRequest)(nil),     // 47: keyorix.v1.UpdateSharePermissionRequest
+	(*RevokeShareRequest)(nil),               // 48: keyorix.v1.RevokeShareRequest
+	(*HealthResponse)(nil),                   // 49: keyorix.v1.HealthResponse
+	(*SystemInfo)(nil),                       // 50: keyorix.v1.SystemInfo
+	(*DatabaseInfo)(nil),                     // 51: keyorix.v1.DatabaseInfo
+	(*EncryptionInfo)(nil),                   // 52: keyorix.v1.EncryptionInfo
+	(*Metrics)(nil),                          // 53: keyorix.v1.Metrics
+	(*RequestMetrics)(nil),                   // 54: keyorix.v1.RequestMetrics
+	(*SecretMetrics)(nil),                    // 55: keyorix.v1.SecretMetrics
+	(*UserMetrics)(nil),                      // 56: keyorix.v1.UserMetrics
+	(*PerformanceMetrics)(nil),               // 57: keyorix.v1.PerformanceMetrics
+	(*SystemMetrics)(nil),                    // 58: keyorix.v1.SystemMetrics
+	(*Project)(nil),                          // 59: keyorix.v1.Project
+	(*Environment)(nil),                      // 60: keyorix.v1.Environment
+	(*ListProjectsResponse)(nil),             // 61: keyorix.v1.ListProjectsResponse
+	(*GetProjectRequest)(nil),                // 62: keyorix.v1.GetProjectRequest
+	(*CreateProjectRequest)(nil),             // 63: keyorix.v1.CreateProjectRequest
+	(*UpdateProjectRequest)(nil),             // 64: keyorix.v1.UpdateProjectRequest
+	(*DeleteProjectRequest)(nil),             // 65: keyorix.v1.DeleteProjectRequest
+	(*ListEnvironmentsRequest)(nil),          // 66: keyorix.v1.ListEnvironmentsRequest
+	(*ListEnvironmentsResponse)(nil),         // 67: keyorix.v1.ListEnvironmentsResponse
+	(*MachineIdentity)(nil),                  // 68: keyorix.v1.MachineIdentity
+	(*MachineToken)(nil),                     // 69: keyorix.v1.MachineToken
+	(*ListMachineIdentitiesRequest)(nil),     // 70: keyorix.v1.ListMachineIdentitiesRequest
+	(*ListMachineIdentitiesResponse)(nil),    // 71: keyorix.v1.ListMachineIdentitiesResponse
+	(*CreateMachineIdentityRequest)(nil),     // 72: keyorix.v1.CreateMachineIdentityRequest
+	(*TransitionMachineIdentityRequest)(nil), // 73: keyorix.v1.TransitionMachineIdentityRequest
+	(*ClassifyMachineIdentityRequest)(nil),   // 74: keyorix.v1.ClassifyMachineIdentityRequest
+	(*IssueMachineTokenRequest)(nil),         // 75: keyorix.v1.IssueMachineTokenRequest
+	(*IssueMachineTokenResponse)(nil),        // 76: keyorix.v1.IssueMachineTokenResponse
+	(*ListMachineTokensRequest)(nil),         // 77: keyorix.v1.ListMachineTokensRequest
+	(*ListMachineTokensResponse)(nil),        // 78: keyorix.v1.ListMachineTokensResponse
+	(*RevokeMachineTokenRequest)(nil),        // 79: keyorix.v1.RevokeMachineTokenRequest
+	(*ClassifyMachineTokenRequest)(nil),      // 80: keyorix.v1.ClassifyMachineTokenRequest
+	(*DynamicSecretConfig)(nil),              // 81: keyorix.v1.DynamicSecretConfig
+	(*DynamicSecretLease)(nil),               // 82: keyorix.v1.DynamicSecretLease
+	(*IssuedCredential)(nil),                 // 83: keyorix.v1.IssuedCredential
+	(*ListDynamicConfigsRequest)(nil),        // 84: keyorix.v1.ListDynamicConfigsRequest
+	(*ListDynamicConfigsResponse)(nil),       // 85: keyorix.v1.ListDynamicConfigsResponse
+	(*GetDynamicConfigRequest)(nil),          // 86: keyorix.v1.GetDynamicConfigRequest
+	(*CreateDynamicConfigRequest)(nil),       // 87: keyorix.v1.CreateDynamicConfigRequest
+	(*ClassifyDynamicConfigRequest)(nil),     // 88: keyorix.v1.ClassifyDynamicConfigRequest
+	(*IssueLeaseRequest)(nil),                // 89: keyorix.v1.IssueLeaseRequest
+	(*ListLeasesRequest)(nil),                // 90: keyorix.v1.ListLeasesRequest
+	(*ListLeasesResponse)(nil),               // 91: keyorix.v1.ListLeasesResponse
+	(*RevokeLeaseRequest)(nil),               // 92: keyorix.v1.RevokeLeaseRequest
+	(*RenewLeaseRequest)(nil),                // 93: keyorix.v1.RenewLeaseRequest
+	(*RenewLeaseResponse)(nil),               // 94: keyorix.v1.RenewLeaseResponse
+	(*RevokeAllLeasesRequest)(nil),           // 95: keyorix.v1.RevokeAllLeasesRequest
+	(*RevokeAllLeasesResponse)(nil),          // 96: keyorix.v1.RevokeAllLeasesResponse
+	(*AuditIntegrityPosture)(nil),            // 97: keyorix.v1.AuditIntegrityPosture
+	(*AccessGovernancePosture)(nil),          // 98: keyorix.v1.AccessGovernancePosture
+	(*RotationPosture)(nil),                  // 99: keyorix.v1.RotationPosture
+	(*IdentityPosture)(nil),                  // 100: keyorix.v1.IdentityPosture
+	(*EmergencyAccessPosture)(nil),           // 101: keyorix.v1.EmergencyAccessPosture
+	(*ClassificationCounts)(nil),             // 102: keyorix.v1.ClassificationCounts
+	(*ClassificationPosture)(nil),            // 103: keyorix.v1.ClassificationPosture
+	(*AnomaliesPosture)(nil),                 // 104: keyorix.v1.AnomaliesPosture
+	(*LegalHoldPosture)(nil),                 // 105: keyorix.v1.LegalHoldPosture
+	(*RetentionPosture)(nil),                 // 106: keyorix.v1.RetentionPosture
+	(*RiskPosture)(nil),                      // 107: keyorix.v1.RiskPosture
+	(*CompliancePosture)(nil),                // 108: keyorix.v1.CompliancePosture
+	(*FrameworkRefs)(nil),                    // 109: keyorix.v1.FrameworkRefs
+	(*ControlState)(nil),                     // 110: keyorix.v1.ControlState
+	(*ControlsSummary)(nil),                  // 111: keyorix.v1.ControlsSummary
+	(*ComplianceControls)(nil),               // 112: keyorix.v1.ComplianceControls
+	(*ConnectorList)(nil),                    // 113: keyorix.v1.ConnectorList
+	(*ReadFederatedSecretRequest)(nil),       // 114: keyorix.v1.ReadFederatedSecretRequest
+	(*FederatedSecretValue)(nil),             // 115: keyorix.v1.FederatedSecretValue
+	(*ConnectRefGrant)(nil),                  // 116: keyorix.v1.ConnectRefGrant
+	(*ConnectRefGrantList)(nil),              // 117: keyorix.v1.ConnectRefGrantList
+	(*CreateConnectRefGrantRequest)(nil),     // 118: keyorix.v1.CreateConnectRefGrantRequest
+	(*DeleteConnectRefGrantRequest)(nil),     // 119: keyorix.v1.DeleteConnectRefGrantRequest
+	nil,                                      // 120: keyorix.v1.Secret.MetadataEntry
+	nil,                                      // 121: keyorix.v1.CreateSecretRequest.MetadataEntry
+	nil,                                      // 122: keyorix.v1.UpdateSecretRequest.MetadataEntry
+	nil,                                      // 123: keyorix.v1.HealthResponse.ServicesEntry
+	nil,                                      // 124: keyorix.v1.SystemInfo.FeaturesEntry
+	nil,                                      // 125: keyorix.v1.IssuedCredential.FieldsEntry
+	(*timestamppb.Timestamp)(nil),            // 126: google.protobuf.Timestamp
+	(*emptypb.Empty)(nil),                    // 127: google.protobuf.Empty
 }
 var file_keyorix_proto_depIdxs = []int32{
-	125, // 0: keyorix.v1.Secret.expiration:type_name -> google.protobuf.Timestamp
-	119, // 1: keyorix.v1.Secret.metadata:type_name -> keyorix.v1.Secret.MetadataEntry
-	125, // 2: keyorix.v1.Secret.created_at:type_name -> google.protobuf.Timestamp
-	125, // 3: keyorix.v1.Secret.updated_at:type_name -> google.protobuf.Timestamp
-	125, // 4: keyorix.v1.CreateSecretRequest.expiration:type_name -> google.protobuf.Timestamp
-	120, // 5: keyorix.v1.CreateSecretRequest.metadata:type_name -> keyorix.v1.CreateSecretRequest.MetadataEntry
-	125, // 6: keyorix.v1.UpdateSecretRequest.expiration:type_name -> google.protobuf.Timestamp
-	121, // 7: keyorix.v1.UpdateSecretRequest.metadata:type_name -> keyorix.v1.UpdateSecretRequest.MetadataEntry
+	126, // 0: keyorix.v1.Secret.expiration:type_name -> google.protobuf.Timestamp
+	120, // 1: keyorix.v1.Secret.metadata:type_name -> keyorix.v1.Secret.MetadataEntry
+	126, // 2: keyorix.v1.Secret.created_at:type_name -> google.protobuf.Timestamp
+	126, // 3: keyorix.v1.Secret.updated_at:type_name -> google.protobuf.Timestamp
+	126, // 4: keyorix.v1.CreateSecretRequest.expiration:type_name -> google.protobuf.Timestamp
+	121, // 5: keyorix.v1.CreateSecretRequest.metadata:type_name -> keyorix.v1.CreateSecretRequest.MetadataEntry
+	126, // 6: keyorix.v1.UpdateSecretRequest.expiration:type_name -> google.protobuf.Timestamp
+	122, // 7: keyorix.v1.UpdateSecretRequest.metadata:type_name -> keyorix.v1.UpdateSecretRequest.MetadataEntry
 	0,   // 8: keyorix.v1.ListSecretsResponse.secrets:type_name -> keyorix.v1.Secret
-	125, // 9: keyorix.v1.SecretVersion.created_at:type_name -> google.protobuf.Timestamp
-	9,   // 10: keyorix.v1.GetSecretVersionsResponse.versions:type_name -> keyorix.v1.SecretVersion
-	125, // 11: keyorix.v1.User.last_login_at:type_name -> google.protobuf.Timestamp
-	125, // 12: keyorix.v1.User.created_at:type_name -> google.protobuf.Timestamp
-	125, // 13: keyorix.v1.User.updated_at:type_name -> google.protobuf.Timestamp
-	12,  // 14: keyorix.v1.CreateUserRequest.project_assignments:type_name -> keyorix.v1.ProjectAssignment
-	11,  // 15: keyorix.v1.CreateUserResponse.user:type_name -> keyorix.v1.User
-	11,  // 16: keyorix.v1.ListUsersResponse.users:type_name -> keyorix.v1.User
-	20,  // 17: keyorix.v1.Role.permissions:type_name -> keyorix.v1.Permission
-	125, // 18: keyorix.v1.Role.created_at:type_name -> google.protobuf.Timestamp
-	125, // 19: keyorix.v1.Role.updated_at:type_name -> google.protobuf.Timestamp
-	21,  // 20: keyorix.v1.ListRolesResponse.roles:type_name -> keyorix.v1.Role
-	21,  // 21: keyorix.v1.GetUserRolesResponse.roles:type_name -> keyorix.v1.Role
-	125, // 22: keyorix.v1.AuditLog.event_time:type_name -> google.protobuf.Timestamp
-	125, // 23: keyorix.v1.GetAuditLogsRequest.start_time:type_name -> google.protobuf.Timestamp
-	125, // 24: keyorix.v1.GetAuditLogsRequest.end_time:type_name -> google.protobuf.Timestamp
-	33,  // 25: keyorix.v1.GetAuditLogsResponse.logs:type_name -> keyorix.v1.AuditLog
-	125, // 26: keyorix.v1.RBACAuditLog.created_at:type_name -> google.protobuf.Timestamp
-	36,  // 27: keyorix.v1.GetRBACAuditLogsResponse.logs:type_name -> keyorix.v1.RBACAuditLog
-	125, // 28: keyorix.v1.ShareRecord.created_at:type_name -> google.protobuf.Timestamp
-	125, // 29: keyorix.v1.ShareRecord.updated_at:type_name -> google.protobuf.Timestamp
-	40,  // 30: keyorix.v1.ListSharesResponse.shares:type_name -> keyorix.v1.ShareRecord
-	125, // 31: keyorix.v1.HealthResponse.timestamp:type_name -> google.protobuf.Timestamp
-	122, // 32: keyorix.v1.HealthResponse.services:type_name -> keyorix.v1.HealthResponse.ServicesEntry
-	123, // 33: keyorix.v1.SystemInfo.features:type_name -> keyorix.v1.SystemInfo.FeaturesEntry
-	50,  // 34: keyorix.v1.SystemInfo.database:type_name -> keyorix.v1.DatabaseInfo
-	51,  // 35: keyorix.v1.SystemInfo.encryption:type_name -> keyorix.v1.EncryptionInfo
-	53,  // 36: keyorix.v1.Metrics.requests:type_name -> keyorix.v1.RequestMetrics
-	54,  // 37: keyorix.v1.Metrics.secrets:type_name -> keyorix.v1.SecretMetrics
-	55,  // 38: keyorix.v1.Metrics.users:type_name -> keyorix.v1.UserMetrics
-	56,  // 39: keyorix.v1.Metrics.performance:type_name -> keyorix.v1.PerformanceMetrics
-	57,  // 40: keyorix.v1.Metrics.system:type_name -> keyorix.v1.SystemMetrics
-	125, // 41: keyorix.v1.Project.created_at:type_name -> google.protobuf.Timestamp
-	125, // 42: keyorix.v1.Project.updated_at:type_name -> google.protobuf.Timestamp
-	125, // 43: keyorix.v1.Environment.created_at:type_name -> google.protobuf.Timestamp
-	125, // 44: keyorix.v1.Environment.updated_at:type_name -> google.protobuf.Timestamp
-	58,  // 45: keyorix.v1.ListProjectsResponse.projects:type_name -> keyorix.v1.Project
-	59,  // 46: keyorix.v1.ListEnvironmentsResponse.environments:type_name -> keyorix.v1.Environment
-	125, // 47: keyorix.v1.MachineIdentity.created_at:type_name -> google.protobuf.Timestamp
-	125, // 48: keyorix.v1.MachineIdentity.updated_at:type_name -> google.protobuf.Timestamp
-	125, // 49: keyorix.v1.MachineIdentity.last_seen_at:type_name -> google.protobuf.Timestamp
-	125, // 50: keyorix.v1.MachineIdentity.revoked_at:type_name -> google.protobuf.Timestamp
-	125, // 51: keyorix.v1.MachineToken.last_used_at:type_name -> google.protobuf.Timestamp
-	125, // 52: keyorix.v1.MachineToken.expires_at:type_name -> google.protobuf.Timestamp
-	125, // 53: keyorix.v1.MachineToken.created_at:type_name -> google.protobuf.Timestamp
-	67,  // 54: keyorix.v1.ListMachineIdentitiesResponse.machine_identities:type_name -> keyorix.v1.MachineIdentity
-	125, // 55: keyorix.v1.IssueMachineTokenResponse.expires_at:type_name -> google.protobuf.Timestamp
-	68,  // 56: keyorix.v1.ListMachineTokensResponse.tokens:type_name -> keyorix.v1.MachineToken
-	125, // 57: keyorix.v1.DynamicSecretConfig.created_at:type_name -> google.protobuf.Timestamp
-	125, // 58: keyorix.v1.DynamicSecretLease.issued_at:type_name -> google.protobuf.Timestamp
-	125, // 59: keyorix.v1.DynamicSecretLease.expires_at:type_name -> google.protobuf.Timestamp
-	125, // 60: keyorix.v1.DynamicSecretLease.revoked_at:type_name -> google.protobuf.Timestamp
-	125, // 61: keyorix.v1.IssuedCredential.expires_at:type_name -> google.protobuf.Timestamp
-	124, // 62: keyorix.v1.IssuedCredential.fields:type_name -> keyorix.v1.IssuedCredential.FieldsEntry
-	80,  // 63: keyorix.v1.ListDynamicConfigsResponse.configs:type_name -> keyorix.v1.DynamicSecretConfig
-	81,  // 64: keyorix.v1.ListLeasesResponse.leases:type_name -> keyorix.v1.DynamicSecretLease
-	125, // 65: keyorix.v1.RenewLeaseResponse.expires_at:type_name -> google.protobuf.Timestamp
-	101, // 66: keyorix.v1.ClassificationPosture.dynamic_configs:type_name -> keyorix.v1.ClassificationCounts
-	101, // 67: keyorix.v1.ClassificationPosture.machine_identities:type_name -> keyorix.v1.ClassificationCounts
-	101, // 68: keyorix.v1.ClassificationPosture.machine_credentials:type_name -> keyorix.v1.ClassificationCounts
-	125, // 69: keyorix.v1.LegalHoldPosture.placed_at:type_name -> google.protobuf.Timestamp
-	125, // 70: keyorix.v1.CompliancePosture.generated_at:type_name -> google.protobuf.Timestamp
-	96,  // 71: keyorix.v1.CompliancePosture.audit_integrity:type_name -> keyorix.v1.AuditIntegrityPosture
-	97,  // 72: keyorix.v1.CompliancePosture.access_governance:type_name -> keyorix.v1.AccessGovernancePosture
-	98,  // 73: keyorix.v1.CompliancePosture.rotation:type_name -> keyorix.v1.RotationPosture
-	99,  // 74: keyorix.v1.CompliancePosture.identity:type_name -> keyorix.v1.IdentityPosture
-	100, // 75: keyorix.v1.CompliancePosture.emergency_access:type_name -> keyorix.v1.EmergencyAccessPosture
-	102, // 76: keyorix.v1.CompliancePosture.classification:type_name -> keyorix.v1.ClassificationPosture
-	103, // 77: keyorix.v1.CompliancePosture.anomalies:type_name -> keyorix.v1.AnomaliesPosture
-	104, // 78: keyorix.v1.CompliancePosture.legal_hold:type_name -> keyorix.v1.LegalHoldPosture
-	105, // 79: keyorix.v1.CompliancePosture.retention:type_name -> keyorix.v1.RetentionPosture
-	106, // 80: keyorix.v1.CompliancePosture.risk:type_name -> keyorix.v1.RiskPosture
-	108, // 81: keyorix.v1.ControlState.frameworks:type_name -> keyorix.v1.FrameworkRefs
-	125, // 82: keyorix.v1.ComplianceControls.generated_at:type_name -> google.protobuf.Timestamp
-	109, // 83: keyorix.v1.ComplianceControls.controls:type_name -> keyorix.v1.ControlState
-	110, // 84: keyorix.v1.ComplianceControls.summary:type_name -> keyorix.v1.ControlsSummary
-	115, // 85: keyorix.v1.ConnectRefGrantList.grants:type_name -> keyorix.v1.ConnectRefGrant
+	126, // 9: keyorix.v1.SecretVersion.created_at:type_name -> google.protobuf.Timestamp
+	10,  // 10: keyorix.v1.GetSecretVersionsResponse.versions:type_name -> keyorix.v1.SecretVersion
+	126, // 11: keyorix.v1.User.last_login_at:type_name -> google.protobuf.Timestamp
+	126, // 12: keyorix.v1.User.created_at:type_name -> google.protobuf.Timestamp
+	126, // 13: keyorix.v1.User.updated_at:type_name -> google.protobuf.Timestamp
+	13,  // 14: keyorix.v1.CreateUserRequest.project_assignments:type_name -> keyorix.v1.ProjectAssignment
+	12,  // 15: keyorix.v1.CreateUserResponse.user:type_name -> keyorix.v1.User
+	12,  // 16: keyorix.v1.ListUsersResponse.users:type_name -> keyorix.v1.User
+	21,  // 17: keyorix.v1.Role.permissions:type_name -> keyorix.v1.Permission
+	126, // 18: keyorix.v1.Role.created_at:type_name -> google.protobuf.Timestamp
+	126, // 19: keyorix.v1.Role.updated_at:type_name -> google.protobuf.Timestamp
+	22,  // 20: keyorix.v1.ListRolesResponse.roles:type_name -> keyorix.v1.Role
+	22,  // 21: keyorix.v1.GetUserRolesResponse.roles:type_name -> keyorix.v1.Role
+	126, // 22: keyorix.v1.AuditLog.event_time:type_name -> google.protobuf.Timestamp
+	126, // 23: keyorix.v1.GetAuditLogsRequest.start_time:type_name -> google.protobuf.Timestamp
+	126, // 24: keyorix.v1.GetAuditLogsRequest.end_time:type_name -> google.protobuf.Timestamp
+	34,  // 25: keyorix.v1.GetAuditLogsResponse.logs:type_name -> keyorix.v1.AuditLog
+	126, // 26: keyorix.v1.RBACAuditLog.created_at:type_name -> google.protobuf.Timestamp
+	37,  // 27: keyorix.v1.GetRBACAuditLogsResponse.logs:type_name -> keyorix.v1.RBACAuditLog
+	126, // 28: keyorix.v1.ShareRecord.created_at:type_name -> google.protobuf.Timestamp
+	126, // 29: keyorix.v1.ShareRecord.updated_at:type_name -> google.protobuf.Timestamp
+	41,  // 30: keyorix.v1.ListSharesResponse.shares:type_name -> keyorix.v1.ShareRecord
+	126, // 31: keyorix.v1.HealthResponse.timestamp:type_name -> google.protobuf.Timestamp
+	123, // 32: keyorix.v1.HealthResponse.services:type_name -> keyorix.v1.HealthResponse.ServicesEntry
+	124, // 33: keyorix.v1.SystemInfo.features:type_name -> keyorix.v1.SystemInfo.FeaturesEntry
+	51,  // 34: keyorix.v1.SystemInfo.database:type_name -> keyorix.v1.DatabaseInfo
+	52,  // 35: keyorix.v1.SystemInfo.encryption:type_name -> keyorix.v1.EncryptionInfo
+	54,  // 36: keyorix.v1.Metrics.requests:type_name -> keyorix.v1.RequestMetrics
+	55,  // 37: keyorix.v1.Metrics.secrets:type_name -> keyorix.v1.SecretMetrics
+	56,  // 38: keyorix.v1.Metrics.users:type_name -> keyorix.v1.UserMetrics
+	57,  // 39: keyorix.v1.Metrics.performance:type_name -> keyorix.v1.PerformanceMetrics
+	58,  // 40: keyorix.v1.Metrics.system:type_name -> keyorix.v1.SystemMetrics
+	126, // 41: keyorix.v1.Project.created_at:type_name -> google.protobuf.Timestamp
+	126, // 42: keyorix.v1.Project.updated_at:type_name -> google.protobuf.Timestamp
+	126, // 43: keyorix.v1.Environment.created_at:type_name -> google.protobuf.Timestamp
+	126, // 44: keyorix.v1.Environment.updated_at:type_name -> google.protobuf.Timestamp
+	59,  // 45: keyorix.v1.ListProjectsResponse.projects:type_name -> keyorix.v1.Project
+	60,  // 46: keyorix.v1.ListEnvironmentsResponse.environments:type_name -> keyorix.v1.Environment
+	126, // 47: keyorix.v1.MachineIdentity.created_at:type_name -> google.protobuf.Timestamp
+	126, // 48: keyorix.v1.MachineIdentity.updated_at:type_name -> google.protobuf.Timestamp
+	126, // 49: keyorix.v1.MachineIdentity.last_seen_at:type_name -> google.protobuf.Timestamp
+	126, // 50: keyorix.v1.MachineIdentity.revoked_at:type_name -> google.protobuf.Timestamp
+	126, // 51: keyorix.v1.MachineToken.last_used_at:type_name -> google.protobuf.Timestamp
+	126, // 52: keyorix.v1.MachineToken.expires_at:type_name -> google.protobuf.Timestamp
+	126, // 53: keyorix.v1.MachineToken.created_at:type_name -> google.protobuf.Timestamp
+	68,  // 54: keyorix.v1.ListMachineIdentitiesResponse.machine_identities:type_name -> keyorix.v1.MachineIdentity
+	126, // 55: keyorix.v1.IssueMachineTokenResponse.expires_at:type_name -> google.protobuf.Timestamp
+	69,  // 56: keyorix.v1.ListMachineTokensResponse.tokens:type_name -> keyorix.v1.MachineToken
+	126, // 57: keyorix.v1.DynamicSecretConfig.created_at:type_name -> google.protobuf.Timestamp
+	126, // 58: keyorix.v1.DynamicSecretLease.issued_at:type_name -> google.protobuf.Timestamp
+	126, // 59: keyorix.v1.DynamicSecretLease.expires_at:type_name -> google.protobuf.Timestamp
+	126, // 60: keyorix.v1.DynamicSecretLease.revoked_at:type_name -> google.protobuf.Timestamp
+	126, // 61: keyorix.v1.IssuedCredential.expires_at:type_name -> google.protobuf.Timestamp
+	125, // 62: keyorix.v1.IssuedCredential.fields:type_name -> keyorix.v1.IssuedCredential.FieldsEntry
+	81,  // 63: keyorix.v1.ListDynamicConfigsResponse.configs:type_name -> keyorix.v1.DynamicSecretConfig
+	82,  // 64: keyorix.v1.ListLeasesResponse.leases:type_name -> keyorix.v1.DynamicSecretLease
+	126, // 65: keyorix.v1.RenewLeaseResponse.expires_at:type_name -> google.protobuf.Timestamp
+	102, // 66: keyorix.v1.ClassificationPosture.dynamic_configs:type_name -> keyorix.v1.ClassificationCounts
+	102, // 67: keyorix.v1.ClassificationPosture.machine_identities:type_name -> keyorix.v1.ClassificationCounts
+	102, // 68: keyorix.v1.ClassificationPosture.machine_credentials:type_name -> keyorix.v1.ClassificationCounts
+	126, // 69: keyorix.v1.LegalHoldPosture.placed_at:type_name -> google.protobuf.Timestamp
+	126, // 70: keyorix.v1.CompliancePosture.generated_at:type_name -> google.protobuf.Timestamp
+	97,  // 71: keyorix.v1.CompliancePosture.audit_integrity:type_name -> keyorix.v1.AuditIntegrityPosture
+	98,  // 72: keyorix.v1.CompliancePosture.access_governance:type_name -> keyorix.v1.AccessGovernancePosture
+	99,  // 73: keyorix.v1.CompliancePosture.rotation:type_name -> keyorix.v1.RotationPosture
+	100, // 74: keyorix.v1.CompliancePosture.identity:type_name -> keyorix.v1.IdentityPosture
+	101, // 75: keyorix.v1.CompliancePosture.emergency_access:type_name -> keyorix.v1.EmergencyAccessPosture
+	103, // 76: keyorix.v1.CompliancePosture.classification:type_name -> keyorix.v1.ClassificationPosture
+	104, // 77: keyorix.v1.CompliancePosture.anomalies:type_name -> keyorix.v1.AnomaliesPosture
+	105, // 78: keyorix.v1.CompliancePosture.legal_hold:type_name -> keyorix.v1.LegalHoldPosture
+	106, // 79: keyorix.v1.CompliancePosture.retention:type_name -> keyorix.v1.RetentionPosture
+	107, // 80: keyorix.v1.CompliancePosture.risk:type_name -> keyorix.v1.RiskPosture
+	109, // 81: keyorix.v1.ControlState.frameworks:type_name -> keyorix.v1.FrameworkRefs
+	126, // 82: keyorix.v1.ComplianceControls.generated_at:type_name -> google.protobuf.Timestamp
+	110, // 83: keyorix.v1.ComplianceControls.controls:type_name -> keyorix.v1.ControlState
+	111, // 84: keyorix.v1.ComplianceControls.summary:type_name -> keyorix.v1.ControlsSummary
+	116, // 85: keyorix.v1.ConnectRefGrantList.grants:type_name -> keyorix.v1.ConnectRefGrant
 	2,   // 86: keyorix.v1.SecretService.CreateSecret:input_type -> keyorix.v1.CreateSecretRequest
 	3,   // 87: keyorix.v1.SecretService.GetSecret:input_type -> keyorix.v1.GetSecretRequest
 	3,   // 88: keyorix.v1.SecretService.GetSecretValue:input_type -> keyorix.v1.GetSecretRequest
@@ -9414,125 +9489,127 @@ var file_keyorix_proto_depIdxs = []int32{
 	5,   // 90: keyorix.v1.SecretService.DeleteSecret:input_type -> keyorix.v1.DeleteSecretRequest
 	6,   // 91: keyorix.v1.SecretService.ListSecrets:input_type -> keyorix.v1.ListSecretsRequest
 	8,   // 92: keyorix.v1.SecretService.GetSecretVersions:input_type -> keyorix.v1.GetSecretVersionsRequest
-	41,  // 93: keyorix.v1.ShareService.ShareSecret:input_type -> keyorix.v1.ShareSecretRequest
-	42,  // 94: keyorix.v1.ShareService.ListSecretShares:input_type -> keyorix.v1.ListSecretSharesRequest
-	43,  // 95: keyorix.v1.ShareService.ListUserShares:input_type -> keyorix.v1.ListUserSharesRequest
-	44,  // 96: keyorix.v1.ShareService.ListSharedSecrets:input_type -> keyorix.v1.ListSharedSecretsRequest
-	46,  // 97: keyorix.v1.ShareService.UpdateSharePermission:input_type -> keyorix.v1.UpdateSharePermissionRequest
-	47,  // 98: keyorix.v1.ShareService.RevokeShare:input_type -> keyorix.v1.RevokeShareRequest
-	13,  // 99: keyorix.v1.UserService.CreateUser:input_type -> keyorix.v1.CreateUserRequest
-	15,  // 100: keyorix.v1.UserService.GetUser:input_type -> keyorix.v1.GetUserRequest
-	16,  // 101: keyorix.v1.UserService.UpdateUser:input_type -> keyorix.v1.UpdateUserRequest
-	17,  // 102: keyorix.v1.UserService.DeleteUser:input_type -> keyorix.v1.DeleteUserRequest
-	18,  // 103: keyorix.v1.UserService.ListUsers:input_type -> keyorix.v1.ListUsersRequest
-	22,  // 104: keyorix.v1.RoleService.CreateRole:input_type -> keyorix.v1.CreateRoleRequest
-	23,  // 105: keyorix.v1.RoleService.GetRole:input_type -> keyorix.v1.GetRoleRequest
-	24,  // 106: keyorix.v1.RoleService.UpdateRole:input_type -> keyorix.v1.UpdateRoleRequest
-	25,  // 107: keyorix.v1.RoleService.DeleteRole:input_type -> keyorix.v1.DeleteRoleRequest
-	26,  // 108: keyorix.v1.RoleService.ListRoles:input_type -> keyorix.v1.ListRolesRequest
-	28,  // 109: keyorix.v1.RoleService.AssignRole:input_type -> keyorix.v1.AssignRoleRequest
-	30,  // 110: keyorix.v1.RoleService.RemoveRole:input_type -> keyorix.v1.RemoveRoleRequest
-	31,  // 111: keyorix.v1.RoleService.GetUserRoles:input_type -> keyorix.v1.GetUserRolesRequest
-	34,  // 112: keyorix.v1.AuditService.GetAuditLogs:input_type -> keyorix.v1.GetAuditLogsRequest
-	37,  // 113: keyorix.v1.AuditService.GetRBACAuditLogs:input_type -> keyorix.v1.GetRBACAuditLogsRequest
-	39,  // 114: keyorix.v1.AuditService.StreamAuditLogs:input_type -> keyorix.v1.StreamAuditLogsRequest
-	126, // 115: keyorix.v1.SystemService.HealthCheck:input_type -> google.protobuf.Empty
-	126, // 116: keyorix.v1.SystemService.GetSystemInfo:input_type -> google.protobuf.Empty
-	126, // 117: keyorix.v1.SystemService.GetMetrics:input_type -> google.protobuf.Empty
-	126, // 118: keyorix.v1.ProjectService.ListProjects:input_type -> google.protobuf.Empty
-	61,  // 119: keyorix.v1.ProjectService.GetProject:input_type -> keyorix.v1.GetProjectRequest
-	62,  // 120: keyorix.v1.ProjectService.CreateProject:input_type -> keyorix.v1.CreateProjectRequest
-	63,  // 121: keyorix.v1.ProjectService.UpdateProject:input_type -> keyorix.v1.UpdateProjectRequest
-	64,  // 122: keyorix.v1.ProjectService.DeleteProject:input_type -> keyorix.v1.DeleteProjectRequest
-	65,  // 123: keyorix.v1.ProjectService.ListEnvironments:input_type -> keyorix.v1.ListEnvironmentsRequest
-	69,  // 124: keyorix.v1.MachineIdentityService.ListMachineIdentities:input_type -> keyorix.v1.ListMachineIdentitiesRequest
-	71,  // 125: keyorix.v1.MachineIdentityService.CreateMachineIdentity:input_type -> keyorix.v1.CreateMachineIdentityRequest
-	72,  // 126: keyorix.v1.MachineIdentityService.TransitionMachineIdentity:input_type -> keyorix.v1.TransitionMachineIdentityRequest
-	73,  // 127: keyorix.v1.MachineIdentityService.ClassifyMachineIdentity:input_type -> keyorix.v1.ClassifyMachineIdentityRequest
-	74,  // 128: keyorix.v1.MachineIdentityService.IssueMachineToken:input_type -> keyorix.v1.IssueMachineTokenRequest
-	76,  // 129: keyorix.v1.MachineIdentityService.ListMachineTokens:input_type -> keyorix.v1.ListMachineTokensRequest
-	78,  // 130: keyorix.v1.MachineIdentityService.RevokeMachineToken:input_type -> keyorix.v1.RevokeMachineTokenRequest
-	79,  // 131: keyorix.v1.MachineIdentityService.ClassifyMachineToken:input_type -> keyorix.v1.ClassifyMachineTokenRequest
-	83,  // 132: keyorix.v1.DynamicSecretService.ListConfigs:input_type -> keyorix.v1.ListDynamicConfigsRequest
-	85,  // 133: keyorix.v1.DynamicSecretService.GetConfig:input_type -> keyorix.v1.GetDynamicConfigRequest
-	86,  // 134: keyorix.v1.DynamicSecretService.CreateConfig:input_type -> keyorix.v1.CreateDynamicConfigRequest
-	87,  // 135: keyorix.v1.DynamicSecretService.ClassifyConfig:input_type -> keyorix.v1.ClassifyDynamicConfigRequest
-	88,  // 136: keyorix.v1.DynamicSecretService.IssueLease:input_type -> keyorix.v1.IssueLeaseRequest
-	89,  // 137: keyorix.v1.DynamicSecretService.ListLeases:input_type -> keyorix.v1.ListLeasesRequest
-	91,  // 138: keyorix.v1.DynamicSecretService.RevokeLease:input_type -> keyorix.v1.RevokeLeaseRequest
-	92,  // 139: keyorix.v1.DynamicSecretService.RenewLease:input_type -> keyorix.v1.RenewLeaseRequest
-	94,  // 140: keyorix.v1.DynamicSecretService.RevokeAllLeases:input_type -> keyorix.v1.RevokeAllLeasesRequest
-	126, // 141: keyorix.v1.ComplianceService.GetCompliancePosture:input_type -> google.protobuf.Empty
-	126, // 142: keyorix.v1.ComplianceService.GetComplianceControls:input_type -> google.protobuf.Empty
-	126, // 143: keyorix.v1.ConnectService.ListConnectors:input_type -> google.protobuf.Empty
-	113, // 144: keyorix.v1.ConnectService.ReadSecret:input_type -> keyorix.v1.ReadFederatedSecretRequest
-	126, // 145: keyorix.v1.ConnectService.ListRefGrants:input_type -> google.protobuf.Empty
-	117, // 146: keyorix.v1.ConnectService.CreateRefGrant:input_type -> keyorix.v1.CreateConnectRefGrantRequest
-	118, // 147: keyorix.v1.ConnectService.DeleteRefGrant:input_type -> keyorix.v1.DeleteConnectRefGrantRequest
-	0,   // 148: keyorix.v1.SecretService.CreateSecret:output_type -> keyorix.v1.Secret
-	0,   // 149: keyorix.v1.SecretService.GetSecret:output_type -> keyorix.v1.Secret
-	1,   // 150: keyorix.v1.SecretService.GetSecretValue:output_type -> keyorix.v1.SecretValue
-	0,   // 151: keyorix.v1.SecretService.UpdateSecret:output_type -> keyorix.v1.Secret
-	126, // 152: keyorix.v1.SecretService.DeleteSecret:output_type -> google.protobuf.Empty
-	7,   // 153: keyorix.v1.SecretService.ListSecrets:output_type -> keyorix.v1.ListSecretsResponse
-	10,  // 154: keyorix.v1.SecretService.GetSecretVersions:output_type -> keyorix.v1.GetSecretVersionsResponse
-	40,  // 155: keyorix.v1.ShareService.ShareSecret:output_type -> keyorix.v1.ShareRecord
-	45,  // 156: keyorix.v1.ShareService.ListSecretShares:output_type -> keyorix.v1.ListSharesResponse
-	45,  // 157: keyorix.v1.ShareService.ListUserShares:output_type -> keyorix.v1.ListSharesResponse
-	7,   // 158: keyorix.v1.ShareService.ListSharedSecrets:output_type -> keyorix.v1.ListSecretsResponse
-	40,  // 159: keyorix.v1.ShareService.UpdateSharePermission:output_type -> keyorix.v1.ShareRecord
-	126, // 160: keyorix.v1.ShareService.RevokeShare:output_type -> google.protobuf.Empty
-	14,  // 161: keyorix.v1.UserService.CreateUser:output_type -> keyorix.v1.CreateUserResponse
-	11,  // 162: keyorix.v1.UserService.GetUser:output_type -> keyorix.v1.User
-	11,  // 163: keyorix.v1.UserService.UpdateUser:output_type -> keyorix.v1.User
-	126, // 164: keyorix.v1.UserService.DeleteUser:output_type -> google.protobuf.Empty
-	19,  // 165: keyorix.v1.UserService.ListUsers:output_type -> keyorix.v1.ListUsersResponse
-	21,  // 166: keyorix.v1.RoleService.CreateRole:output_type -> keyorix.v1.Role
-	21,  // 167: keyorix.v1.RoleService.GetRole:output_type -> keyorix.v1.Role
-	21,  // 168: keyorix.v1.RoleService.UpdateRole:output_type -> keyorix.v1.Role
-	126, // 169: keyorix.v1.RoleService.DeleteRole:output_type -> google.protobuf.Empty
-	27,  // 170: keyorix.v1.RoleService.ListRoles:output_type -> keyorix.v1.ListRolesResponse
-	29,  // 171: keyorix.v1.RoleService.AssignRole:output_type -> keyorix.v1.RoleAssignment
-	126, // 172: keyorix.v1.RoleService.RemoveRole:output_type -> google.protobuf.Empty
-	32,  // 173: keyorix.v1.RoleService.GetUserRoles:output_type -> keyorix.v1.GetUserRolesResponse
-	35,  // 174: keyorix.v1.AuditService.GetAuditLogs:output_type -> keyorix.v1.GetAuditLogsResponse
-	38,  // 175: keyorix.v1.AuditService.GetRBACAuditLogs:output_type -> keyorix.v1.GetRBACAuditLogsResponse
-	33,  // 176: keyorix.v1.AuditService.StreamAuditLogs:output_type -> keyorix.v1.AuditLog
-	48,  // 177: keyorix.v1.SystemService.HealthCheck:output_type -> keyorix.v1.HealthResponse
-	49,  // 178: keyorix.v1.SystemService.GetSystemInfo:output_type -> keyorix.v1.SystemInfo
-	52,  // 179: keyorix.v1.SystemService.GetMetrics:output_type -> keyorix.v1.Metrics
-	60,  // 180: keyorix.v1.ProjectService.ListProjects:output_type -> keyorix.v1.ListProjectsResponse
-	58,  // 181: keyorix.v1.ProjectService.GetProject:output_type -> keyorix.v1.Project
-	58,  // 182: keyorix.v1.ProjectService.CreateProject:output_type -> keyorix.v1.Project
-	58,  // 183: keyorix.v1.ProjectService.UpdateProject:output_type -> keyorix.v1.Project
-	126, // 184: keyorix.v1.ProjectService.DeleteProject:output_type -> google.protobuf.Empty
-	66,  // 185: keyorix.v1.ProjectService.ListEnvironments:output_type -> keyorix.v1.ListEnvironmentsResponse
-	70,  // 186: keyorix.v1.MachineIdentityService.ListMachineIdentities:output_type -> keyorix.v1.ListMachineIdentitiesResponse
-	67,  // 187: keyorix.v1.MachineIdentityService.CreateMachineIdentity:output_type -> keyorix.v1.MachineIdentity
-	67,  // 188: keyorix.v1.MachineIdentityService.TransitionMachineIdentity:output_type -> keyorix.v1.MachineIdentity
-	67,  // 189: keyorix.v1.MachineIdentityService.ClassifyMachineIdentity:output_type -> keyorix.v1.MachineIdentity
-	75,  // 190: keyorix.v1.MachineIdentityService.IssueMachineToken:output_type -> keyorix.v1.IssueMachineTokenResponse
-	77,  // 191: keyorix.v1.MachineIdentityService.ListMachineTokens:output_type -> keyorix.v1.ListMachineTokensResponse
-	126, // 192: keyorix.v1.MachineIdentityService.RevokeMachineToken:output_type -> google.protobuf.Empty
-	68,  // 193: keyorix.v1.MachineIdentityService.ClassifyMachineToken:output_type -> keyorix.v1.MachineToken
-	84,  // 194: keyorix.v1.DynamicSecretService.ListConfigs:output_type -> keyorix.v1.ListDynamicConfigsResponse
-	80,  // 195: keyorix.v1.DynamicSecretService.GetConfig:output_type -> keyorix.v1.DynamicSecretConfig
-	80,  // 196: keyorix.v1.DynamicSecretService.CreateConfig:output_type -> keyorix.v1.DynamicSecretConfig
-	80,  // 197: keyorix.v1.DynamicSecretService.ClassifyConfig:output_type -> keyorix.v1.DynamicSecretConfig
-	82,  // 198: keyorix.v1.DynamicSecretService.IssueLease:output_type -> keyorix.v1.IssuedCredential
-	90,  // 199: keyorix.v1.DynamicSecretService.ListLeases:output_type -> keyorix.v1.ListLeasesResponse
-	126, // 200: keyorix.v1.DynamicSecretService.RevokeLease:output_type -> google.protobuf.Empty
-	93,  // 201: keyorix.v1.DynamicSecretService.RenewLease:output_type -> keyorix.v1.RenewLeaseResponse
-	95,  // 202: keyorix.v1.DynamicSecretService.RevokeAllLeases:output_type -> keyorix.v1.RevokeAllLeasesResponse
-	107, // 203: keyorix.v1.ComplianceService.GetCompliancePosture:output_type -> keyorix.v1.CompliancePosture
-	111, // 204: keyorix.v1.ComplianceService.GetComplianceControls:output_type -> keyorix.v1.ComplianceControls
-	112, // 205: keyorix.v1.ConnectService.ListConnectors:output_type -> keyorix.v1.ConnectorList
-	114, // 206: keyorix.v1.ConnectService.ReadSecret:output_type -> keyorix.v1.FederatedSecretValue
-	116, // 207: keyorix.v1.ConnectService.ListRefGrants:output_type -> keyorix.v1.ConnectRefGrantList
-	115, // 208: keyorix.v1.ConnectService.CreateRefGrant:output_type -> keyorix.v1.ConnectRefGrant
-	126, // 209: keyorix.v1.ConnectService.DeleteRefGrant:output_type -> google.protobuf.Empty
-	148, // [148:210] is the sub-list for method output_type
-	86,  // [86:148] is the sub-list for method input_type
+	9,   // 93: keyorix.v1.SecretService.SetSecretAutoRotate:input_type -> keyorix.v1.SetSecretAutoRotateRequest
+	42,  // 94: keyorix.v1.ShareService.ShareSecret:input_type -> keyorix.v1.ShareSecretRequest
+	43,  // 95: keyorix.v1.ShareService.ListSecretShares:input_type -> keyorix.v1.ListSecretSharesRequest
+	44,  // 96: keyorix.v1.ShareService.ListUserShares:input_type -> keyorix.v1.ListUserSharesRequest
+	45,  // 97: keyorix.v1.ShareService.ListSharedSecrets:input_type -> keyorix.v1.ListSharedSecretsRequest
+	47,  // 98: keyorix.v1.ShareService.UpdateSharePermission:input_type -> keyorix.v1.UpdateSharePermissionRequest
+	48,  // 99: keyorix.v1.ShareService.RevokeShare:input_type -> keyorix.v1.RevokeShareRequest
+	14,  // 100: keyorix.v1.UserService.CreateUser:input_type -> keyorix.v1.CreateUserRequest
+	16,  // 101: keyorix.v1.UserService.GetUser:input_type -> keyorix.v1.GetUserRequest
+	17,  // 102: keyorix.v1.UserService.UpdateUser:input_type -> keyorix.v1.UpdateUserRequest
+	18,  // 103: keyorix.v1.UserService.DeleteUser:input_type -> keyorix.v1.DeleteUserRequest
+	19,  // 104: keyorix.v1.UserService.ListUsers:input_type -> keyorix.v1.ListUsersRequest
+	23,  // 105: keyorix.v1.RoleService.CreateRole:input_type -> keyorix.v1.CreateRoleRequest
+	24,  // 106: keyorix.v1.RoleService.GetRole:input_type -> keyorix.v1.GetRoleRequest
+	25,  // 107: keyorix.v1.RoleService.UpdateRole:input_type -> keyorix.v1.UpdateRoleRequest
+	26,  // 108: keyorix.v1.RoleService.DeleteRole:input_type -> keyorix.v1.DeleteRoleRequest
+	27,  // 109: keyorix.v1.RoleService.ListRoles:input_type -> keyorix.v1.ListRolesRequest
+	29,  // 110: keyorix.v1.RoleService.AssignRole:input_type -> keyorix.v1.AssignRoleRequest
+	31,  // 111: keyorix.v1.RoleService.RemoveRole:input_type -> keyorix.v1.RemoveRoleRequest
+	32,  // 112: keyorix.v1.RoleService.GetUserRoles:input_type -> keyorix.v1.GetUserRolesRequest
+	35,  // 113: keyorix.v1.AuditService.GetAuditLogs:input_type -> keyorix.v1.GetAuditLogsRequest
+	38,  // 114: keyorix.v1.AuditService.GetRBACAuditLogs:input_type -> keyorix.v1.GetRBACAuditLogsRequest
+	40,  // 115: keyorix.v1.AuditService.StreamAuditLogs:input_type -> keyorix.v1.StreamAuditLogsRequest
+	127, // 116: keyorix.v1.SystemService.HealthCheck:input_type -> google.protobuf.Empty
+	127, // 117: keyorix.v1.SystemService.GetSystemInfo:input_type -> google.protobuf.Empty
+	127, // 118: keyorix.v1.SystemService.GetMetrics:input_type -> google.protobuf.Empty
+	127, // 119: keyorix.v1.ProjectService.ListProjects:input_type -> google.protobuf.Empty
+	62,  // 120: keyorix.v1.ProjectService.GetProject:input_type -> keyorix.v1.GetProjectRequest
+	63,  // 121: keyorix.v1.ProjectService.CreateProject:input_type -> keyorix.v1.CreateProjectRequest
+	64,  // 122: keyorix.v1.ProjectService.UpdateProject:input_type -> keyorix.v1.UpdateProjectRequest
+	65,  // 123: keyorix.v1.ProjectService.DeleteProject:input_type -> keyorix.v1.DeleteProjectRequest
+	66,  // 124: keyorix.v1.ProjectService.ListEnvironments:input_type -> keyorix.v1.ListEnvironmentsRequest
+	70,  // 125: keyorix.v1.MachineIdentityService.ListMachineIdentities:input_type -> keyorix.v1.ListMachineIdentitiesRequest
+	72,  // 126: keyorix.v1.MachineIdentityService.CreateMachineIdentity:input_type -> keyorix.v1.CreateMachineIdentityRequest
+	73,  // 127: keyorix.v1.MachineIdentityService.TransitionMachineIdentity:input_type -> keyorix.v1.TransitionMachineIdentityRequest
+	74,  // 128: keyorix.v1.MachineIdentityService.ClassifyMachineIdentity:input_type -> keyorix.v1.ClassifyMachineIdentityRequest
+	75,  // 129: keyorix.v1.MachineIdentityService.IssueMachineToken:input_type -> keyorix.v1.IssueMachineTokenRequest
+	77,  // 130: keyorix.v1.MachineIdentityService.ListMachineTokens:input_type -> keyorix.v1.ListMachineTokensRequest
+	79,  // 131: keyorix.v1.MachineIdentityService.RevokeMachineToken:input_type -> keyorix.v1.RevokeMachineTokenRequest
+	80,  // 132: keyorix.v1.MachineIdentityService.ClassifyMachineToken:input_type -> keyorix.v1.ClassifyMachineTokenRequest
+	84,  // 133: keyorix.v1.DynamicSecretService.ListConfigs:input_type -> keyorix.v1.ListDynamicConfigsRequest
+	86,  // 134: keyorix.v1.DynamicSecretService.GetConfig:input_type -> keyorix.v1.GetDynamicConfigRequest
+	87,  // 135: keyorix.v1.DynamicSecretService.CreateConfig:input_type -> keyorix.v1.CreateDynamicConfigRequest
+	88,  // 136: keyorix.v1.DynamicSecretService.ClassifyConfig:input_type -> keyorix.v1.ClassifyDynamicConfigRequest
+	89,  // 137: keyorix.v1.DynamicSecretService.IssueLease:input_type -> keyorix.v1.IssueLeaseRequest
+	90,  // 138: keyorix.v1.DynamicSecretService.ListLeases:input_type -> keyorix.v1.ListLeasesRequest
+	92,  // 139: keyorix.v1.DynamicSecretService.RevokeLease:input_type -> keyorix.v1.RevokeLeaseRequest
+	93,  // 140: keyorix.v1.DynamicSecretService.RenewLease:input_type -> keyorix.v1.RenewLeaseRequest
+	95,  // 141: keyorix.v1.DynamicSecretService.RevokeAllLeases:input_type -> keyorix.v1.RevokeAllLeasesRequest
+	127, // 142: keyorix.v1.ComplianceService.GetCompliancePosture:input_type -> google.protobuf.Empty
+	127, // 143: keyorix.v1.ComplianceService.GetComplianceControls:input_type -> google.protobuf.Empty
+	127, // 144: keyorix.v1.ConnectService.ListConnectors:input_type -> google.protobuf.Empty
+	114, // 145: keyorix.v1.ConnectService.ReadSecret:input_type -> keyorix.v1.ReadFederatedSecretRequest
+	127, // 146: keyorix.v1.ConnectService.ListRefGrants:input_type -> google.protobuf.Empty
+	118, // 147: keyorix.v1.ConnectService.CreateRefGrant:input_type -> keyorix.v1.CreateConnectRefGrantRequest
+	119, // 148: keyorix.v1.ConnectService.DeleteRefGrant:input_type -> keyorix.v1.DeleteConnectRefGrantRequest
+	0,   // 149: keyorix.v1.SecretService.CreateSecret:output_type -> keyorix.v1.Secret
+	0,   // 150: keyorix.v1.SecretService.GetSecret:output_type -> keyorix.v1.Secret
+	1,   // 151: keyorix.v1.SecretService.GetSecretValue:output_type -> keyorix.v1.SecretValue
+	0,   // 152: keyorix.v1.SecretService.UpdateSecret:output_type -> keyorix.v1.Secret
+	127, // 153: keyorix.v1.SecretService.DeleteSecret:output_type -> google.protobuf.Empty
+	7,   // 154: keyorix.v1.SecretService.ListSecrets:output_type -> keyorix.v1.ListSecretsResponse
+	11,  // 155: keyorix.v1.SecretService.GetSecretVersions:output_type -> keyorix.v1.GetSecretVersionsResponse
+	127, // 156: keyorix.v1.SecretService.SetSecretAutoRotate:output_type -> google.protobuf.Empty
+	41,  // 157: keyorix.v1.ShareService.ShareSecret:output_type -> keyorix.v1.ShareRecord
+	46,  // 158: keyorix.v1.ShareService.ListSecretShares:output_type -> keyorix.v1.ListSharesResponse
+	46,  // 159: keyorix.v1.ShareService.ListUserShares:output_type -> keyorix.v1.ListSharesResponse
+	7,   // 160: keyorix.v1.ShareService.ListSharedSecrets:output_type -> keyorix.v1.ListSecretsResponse
+	41,  // 161: keyorix.v1.ShareService.UpdateSharePermission:output_type -> keyorix.v1.ShareRecord
+	127, // 162: keyorix.v1.ShareService.RevokeShare:output_type -> google.protobuf.Empty
+	15,  // 163: keyorix.v1.UserService.CreateUser:output_type -> keyorix.v1.CreateUserResponse
+	12,  // 164: keyorix.v1.UserService.GetUser:output_type -> keyorix.v1.User
+	12,  // 165: keyorix.v1.UserService.UpdateUser:output_type -> keyorix.v1.User
+	127, // 166: keyorix.v1.UserService.DeleteUser:output_type -> google.protobuf.Empty
+	20,  // 167: keyorix.v1.UserService.ListUsers:output_type -> keyorix.v1.ListUsersResponse
+	22,  // 168: keyorix.v1.RoleService.CreateRole:output_type -> keyorix.v1.Role
+	22,  // 169: keyorix.v1.RoleService.GetRole:output_type -> keyorix.v1.Role
+	22,  // 170: keyorix.v1.RoleService.UpdateRole:output_type -> keyorix.v1.Role
+	127, // 171: keyorix.v1.RoleService.DeleteRole:output_type -> google.protobuf.Empty
+	28,  // 172: keyorix.v1.RoleService.ListRoles:output_type -> keyorix.v1.ListRolesResponse
+	30,  // 173: keyorix.v1.RoleService.AssignRole:output_type -> keyorix.v1.RoleAssignment
+	127, // 174: keyorix.v1.RoleService.RemoveRole:output_type -> google.protobuf.Empty
+	33,  // 175: keyorix.v1.RoleService.GetUserRoles:output_type -> keyorix.v1.GetUserRolesResponse
+	36,  // 176: keyorix.v1.AuditService.GetAuditLogs:output_type -> keyorix.v1.GetAuditLogsResponse
+	39,  // 177: keyorix.v1.AuditService.GetRBACAuditLogs:output_type -> keyorix.v1.GetRBACAuditLogsResponse
+	34,  // 178: keyorix.v1.AuditService.StreamAuditLogs:output_type -> keyorix.v1.AuditLog
+	49,  // 179: keyorix.v1.SystemService.HealthCheck:output_type -> keyorix.v1.HealthResponse
+	50,  // 180: keyorix.v1.SystemService.GetSystemInfo:output_type -> keyorix.v1.SystemInfo
+	53,  // 181: keyorix.v1.SystemService.GetMetrics:output_type -> keyorix.v1.Metrics
+	61,  // 182: keyorix.v1.ProjectService.ListProjects:output_type -> keyorix.v1.ListProjectsResponse
+	59,  // 183: keyorix.v1.ProjectService.GetProject:output_type -> keyorix.v1.Project
+	59,  // 184: keyorix.v1.ProjectService.CreateProject:output_type -> keyorix.v1.Project
+	59,  // 185: keyorix.v1.ProjectService.UpdateProject:output_type -> keyorix.v1.Project
+	127, // 186: keyorix.v1.ProjectService.DeleteProject:output_type -> google.protobuf.Empty
+	67,  // 187: keyorix.v1.ProjectService.ListEnvironments:output_type -> keyorix.v1.ListEnvironmentsResponse
+	71,  // 188: keyorix.v1.MachineIdentityService.ListMachineIdentities:output_type -> keyorix.v1.ListMachineIdentitiesResponse
+	68,  // 189: keyorix.v1.MachineIdentityService.CreateMachineIdentity:output_type -> keyorix.v1.MachineIdentity
+	68,  // 190: keyorix.v1.MachineIdentityService.TransitionMachineIdentity:output_type -> keyorix.v1.MachineIdentity
+	68,  // 191: keyorix.v1.MachineIdentityService.ClassifyMachineIdentity:output_type -> keyorix.v1.MachineIdentity
+	76,  // 192: keyorix.v1.MachineIdentityService.IssueMachineToken:output_type -> keyorix.v1.IssueMachineTokenResponse
+	78,  // 193: keyorix.v1.MachineIdentityService.ListMachineTokens:output_type -> keyorix.v1.ListMachineTokensResponse
+	127, // 194: keyorix.v1.MachineIdentityService.RevokeMachineToken:output_type -> google.protobuf.Empty
+	69,  // 195: keyorix.v1.MachineIdentityService.ClassifyMachineToken:output_type -> keyorix.v1.MachineToken
+	85,  // 196: keyorix.v1.DynamicSecretService.ListConfigs:output_type -> keyorix.v1.ListDynamicConfigsResponse
+	81,  // 197: keyorix.v1.DynamicSecretService.GetConfig:output_type -> keyorix.v1.DynamicSecretConfig
+	81,  // 198: keyorix.v1.DynamicSecretService.CreateConfig:output_type -> keyorix.v1.DynamicSecretConfig
+	81,  // 199: keyorix.v1.DynamicSecretService.ClassifyConfig:output_type -> keyorix.v1.DynamicSecretConfig
+	83,  // 200: keyorix.v1.DynamicSecretService.IssueLease:output_type -> keyorix.v1.IssuedCredential
+	91,  // 201: keyorix.v1.DynamicSecretService.ListLeases:output_type -> keyorix.v1.ListLeasesResponse
+	127, // 202: keyorix.v1.DynamicSecretService.RevokeLease:output_type -> google.protobuf.Empty
+	94,  // 203: keyorix.v1.DynamicSecretService.RenewLease:output_type -> keyorix.v1.RenewLeaseResponse
+	96,  // 204: keyorix.v1.DynamicSecretService.RevokeAllLeases:output_type -> keyorix.v1.RevokeAllLeasesResponse
+	108, // 205: keyorix.v1.ComplianceService.GetCompliancePosture:output_type -> keyorix.v1.CompliancePosture
+	112, // 206: keyorix.v1.ComplianceService.GetComplianceControls:output_type -> keyorix.v1.ComplianceControls
+	113, // 207: keyorix.v1.ConnectService.ListConnectors:output_type -> keyorix.v1.ConnectorList
+	115, // 208: keyorix.v1.ConnectService.ReadSecret:output_type -> keyorix.v1.FederatedSecretValue
+	117, // 209: keyorix.v1.ConnectService.ListRefGrants:output_type -> keyorix.v1.ConnectRefGrantList
+	116, // 210: keyorix.v1.ConnectService.CreateRefGrant:output_type -> keyorix.v1.ConnectRefGrant
+	127, // 211: keyorix.v1.ConnectService.DeleteRefGrant:output_type -> google.protobuf.Empty
+	149, // [149:212] is the sub-list for method output_type
+	86,  // [86:149] is the sub-list for method input_type
 	86,  // [86:86] is the sub-list for extension type_name
 	86,  // [86:86] is the sub-list for extension extendee
 	0,   // [0:86] is the sub-list for field type_name
@@ -9547,32 +9624,32 @@ func file_keyorix_proto_init() {
 	file_keyorix_proto_msgTypes[2].OneofWrappers = []any{}
 	file_keyorix_proto_msgTypes[4].OneofWrappers = []any{}
 	file_keyorix_proto_msgTypes[6].OneofWrappers = []any{}
-	file_keyorix_proto_msgTypes[11].OneofWrappers = []any{}
-	file_keyorix_proto_msgTypes[13].OneofWrappers = []any{}
+	file_keyorix_proto_msgTypes[12].OneofWrappers = []any{}
 	file_keyorix_proto_msgTypes[14].OneofWrappers = []any{}
-	file_keyorix_proto_msgTypes[16].OneofWrappers = []any{}
-	file_keyorix_proto_msgTypes[18].OneofWrappers = []any{}
-	file_keyorix_proto_msgTypes[24].OneofWrappers = []any{}
-	file_keyorix_proto_msgTypes[28].OneofWrappers = []any{}
-	file_keyorix_proto_msgTypes[30].OneofWrappers = []any{}
-	file_keyorix_proto_msgTypes[33].OneofWrappers = []any{}
+	file_keyorix_proto_msgTypes[15].OneofWrappers = []any{}
+	file_keyorix_proto_msgTypes[17].OneofWrappers = []any{}
+	file_keyorix_proto_msgTypes[19].OneofWrappers = []any{}
+	file_keyorix_proto_msgTypes[25].OneofWrappers = []any{}
+	file_keyorix_proto_msgTypes[29].OneofWrappers = []any{}
+	file_keyorix_proto_msgTypes[31].OneofWrappers = []any{}
 	file_keyorix_proto_msgTypes[34].OneofWrappers = []any{}
-	file_keyorix_proto_msgTypes[36].OneofWrappers = []any{}
+	file_keyorix_proto_msgTypes[35].OneofWrappers = []any{}
 	file_keyorix_proto_msgTypes[37].OneofWrappers = []any{}
-	file_keyorix_proto_msgTypes[39].OneofWrappers = []any{}
-	file_keyorix_proto_msgTypes[63].OneofWrappers = []any{}
-	file_keyorix_proto_msgTypes[67].OneofWrappers = []any{}
+	file_keyorix_proto_msgTypes[38].OneofWrappers = []any{}
+	file_keyorix_proto_msgTypes[40].OneofWrappers = []any{}
+	file_keyorix_proto_msgTypes[64].OneofWrappers = []any{}
 	file_keyorix_proto_msgTypes[68].OneofWrappers = []any{}
-	file_keyorix_proto_msgTypes[75].OneofWrappers = []any{}
-	file_keyorix_proto_msgTypes[81].OneofWrappers = []any{}
+	file_keyorix_proto_msgTypes[69].OneofWrappers = []any{}
+	file_keyorix_proto_msgTypes[76].OneofWrappers = []any{}
 	file_keyorix_proto_msgTypes[82].OneofWrappers = []any{}
+	file_keyorix_proto_msgTypes[83].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_keyorix_proto_rawDesc), len(file_keyorix_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   125,
+			NumMessages:   126,
 			NumExtensions: 0,
 			NumServices:   11,
 		},

--- a/server/proto/pb/keyorix_grpc.pb.go
+++ b/server/proto/pb/keyorix_grpc.pb.go
@@ -20,13 +20,14 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	SecretService_CreateSecret_FullMethodName      = "/keyorix.v1.SecretService/CreateSecret"
-	SecretService_GetSecret_FullMethodName         = "/keyorix.v1.SecretService/GetSecret"
-	SecretService_GetSecretValue_FullMethodName    = "/keyorix.v1.SecretService/GetSecretValue"
-	SecretService_UpdateSecret_FullMethodName      = "/keyorix.v1.SecretService/UpdateSecret"
-	SecretService_DeleteSecret_FullMethodName      = "/keyorix.v1.SecretService/DeleteSecret"
-	SecretService_ListSecrets_FullMethodName       = "/keyorix.v1.SecretService/ListSecrets"
-	SecretService_GetSecretVersions_FullMethodName = "/keyorix.v1.SecretService/GetSecretVersions"
+	SecretService_CreateSecret_FullMethodName        = "/keyorix.v1.SecretService/CreateSecret"
+	SecretService_GetSecret_FullMethodName           = "/keyorix.v1.SecretService/GetSecret"
+	SecretService_GetSecretValue_FullMethodName      = "/keyorix.v1.SecretService/GetSecretValue"
+	SecretService_UpdateSecret_FullMethodName        = "/keyorix.v1.SecretService/UpdateSecret"
+	SecretService_DeleteSecret_FullMethodName        = "/keyorix.v1.SecretService/DeleteSecret"
+	SecretService_ListSecrets_FullMethodName         = "/keyorix.v1.SecretService/ListSecrets"
+	SecretService_GetSecretVersions_FullMethodName   = "/keyorix.v1.SecretService/GetSecretVersions"
+	SecretService_SetSecretAutoRotate_FullMethodName = "/keyorix.v1.SecretService/SetSecretAutoRotate"
 )
 
 // SecretServiceClient is the client API for SecretService service.
@@ -49,6 +50,9 @@ type SecretServiceClient interface {
 	ListSecrets(ctx context.Context, in *ListSecretsRequest, opts ...grpc.CallOption) (*ListSecretsResponse, error)
 	// Get a secret's version history
 	GetSecretVersions(ctx context.Context, in *GetSecretVersionsRequest, opts ...grpc.CallOption) (*GetSecretVersionsResponse, error)
+	// Enable/disable automated rotation for a secret and set its generated-value shape
+	// (ADR-046). Requires scoped secrets.write.
+	SetSecretAutoRotate(ctx context.Context, in *SetSecretAutoRotateRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
 }
 
 type secretServiceClient struct {
@@ -129,6 +133,16 @@ func (c *secretServiceClient) GetSecretVersions(ctx context.Context, in *GetSecr
 	return out, nil
 }
 
+func (c *secretServiceClient) SetSecretAutoRotate(ctx context.Context, in *SetSecretAutoRotateRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(emptypb.Empty)
+	err := c.cc.Invoke(ctx, SecretService_SetSecretAutoRotate_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // SecretServiceServer is the server API for SecretService service.
 // All implementations must embed UnimplementedSecretServiceServer
 // for forward compatibility.
@@ -149,6 +163,9 @@ type SecretServiceServer interface {
 	ListSecrets(context.Context, *ListSecretsRequest) (*ListSecretsResponse, error)
 	// Get a secret's version history
 	GetSecretVersions(context.Context, *GetSecretVersionsRequest) (*GetSecretVersionsResponse, error)
+	// Enable/disable automated rotation for a secret and set its generated-value shape
+	// (ADR-046). Requires scoped secrets.write.
+	SetSecretAutoRotate(context.Context, *SetSecretAutoRotateRequest) (*emptypb.Empty, error)
 	mustEmbedUnimplementedSecretServiceServer()
 }
 
@@ -179,6 +196,9 @@ func (UnimplementedSecretServiceServer) ListSecrets(context.Context, *ListSecret
 }
 func (UnimplementedSecretServiceServer) GetSecretVersions(context.Context, *GetSecretVersionsRequest) (*GetSecretVersionsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetSecretVersions not implemented")
+}
+func (UnimplementedSecretServiceServer) SetSecretAutoRotate(context.Context, *SetSecretAutoRotateRequest) (*emptypb.Empty, error) {
+	return nil, status.Error(codes.Unimplemented, "method SetSecretAutoRotate not implemented")
 }
 func (UnimplementedSecretServiceServer) mustEmbedUnimplementedSecretServiceServer() {}
 func (UnimplementedSecretServiceServer) testEmbeddedByValue()                       {}
@@ -327,6 +347,24 @@ func _SecretService_GetSecretVersions_Handler(srv interface{}, ctx context.Conte
 	return interceptor(ctx, in, info, handler)
 }
 
+func _SecretService_SetSecretAutoRotate_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(SetSecretAutoRotateRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(SecretServiceServer).SetSecretAutoRotate(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: SecretService_SetSecretAutoRotate_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(SecretServiceServer).SetSecretAutoRotate(ctx, req.(*SetSecretAutoRotateRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // SecretService_ServiceDesc is the grpc.ServiceDesc for SecretService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -361,6 +399,10 @@ var SecretService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetSecretVersions",
 			Handler:    _SecretService_GetSecretVersions_Handler,
+		},
+		{
+			MethodName: "SetSecretAutoRotate",
+			Handler:    _SecretService_SetSecretAutoRotate_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},


### PR DESCRIPTION
The auto-rotate toggle (`PATCH /secrets/{id}/auto-rotate`, #263/#264) was HTTP-only. This brings it to the **gRPC** and **CLI** surfaces so automated rotation is manageable everywhere.

## Changes
- **proto/grpc**: `SecretService.SetSecretAutoRotate(id, enabled, length, charset)` → `Empty`, gated by scoped `secrets.write` via `authorizeSecretScoped` (mirrors the HTTP handler). Bad charset / out-of-range length → `InvalidArgument`.
- **cli**: `keyorix secret auto-rotate --id N [--off] [--length] [--charset]`, mirroring `secret classify` (PATCHes the existing endpoint via the remote client).

## Tests
gRPC: happy path persists the spec; bad charset → `InvalidArgument`; `Unauthenticated`; `PermissionDenied` for a non-writer. gofmt/build/test/gosec/golangci-lint/gitleaks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)