### PR TITLE
release: prep v0.46.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,27 @@
 All notable changes to Keyorix are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## v0.46.0 — 2026-06-16
+
+Automated secret rotation (ADR-046).
+
+### Added
+- **Automated rotation executor** — an opt-in scheduler that actually rotates secrets,
+  not just tracks/reminds. A secret marked `auto_rotate` that is overdue under an active
+  rotation policy has its value regenerated (a new version) automatically, audited as
+  `secret.auto_rotated`. Opt-in per secret and only for Keyorix-owned (generated) values,
+  so externally-managed credentials are never silently changed. ([#263])
+- **Per-secret generated-value shape** — choose the rotated value's `length` (8–256,
+  default 32) and `charset` (`alphanumeric` [default] / `lower_alphanumeric` / `hex` /
+  `alphanumeric_symbols`) to meet a system's password requirements. ([#264])
+- **Manage auto-rotation everywhere** — toggle it over HTTP (`PATCH
+  /secrets/{id}/auto-rotate`), gRPC (`SecretService.SetSecretAutoRotate`), and the CLI
+  (`keyorix secret auto-rotate`), all gated by scoped `secrets.write`. ([#263], [#265])
+
+[#263]: https://github.com/keyorixhq/keyorix/pull/263
+[#264]: https://github.com/keyorixhq/keyorix/pull/264
+[#265]: https://github.com/keyorixhq/keyorix/pull/265
+
 ## v0.45.0 — 2026-06-16
 
 Real-time audit streaming for SIEM consumers.

--- a/deploy/helm/keyorix/Chart.yaml
+++ b/deploy/helm/keyorix/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix
 description: Self-hosted Keyorix secrets manager (API server + web UI + PostgreSQL)
 type: application
 # Chart version — bump on chart changes.
-version: 0.45.0
+version: 0.46.0
 # The Keyorix app version this chart deploys by default (the image tag).
-appVersion: "0.45.0"
+appVersion: "0.46.0"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix


### PR DESCRIPTION
Cuts **v0.46.0** — automated secret rotation (ADR-046), batching the three unreleased rotation commits:

- **Rotation executor** (#263) — opt-in scheduler that regenerates due, Keyorix-owned secrets; audited; safe (never touches externally-managed credentials).
- **Per-secret generator spec** (#264) — configurable length + charset.
- **gRPC + CLI toggle parity** (#265) — manage auto-rotation over HTTP/gRPC/CLI, scoped `secrets.write`.

Chart + appVersion bumped to `0.46.0`; CHANGELOG updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)