### PR TITLE
feat(rotation): backend rotation executor subsystem + PostgreSQL (ADR-047)

### DIFF
--- a/docs/adr-047-backend-rotation-executors.md
+++ b/docs/adr-047-backend-rotation-executors.md
@@ -1,0 +1,71 @@
+# ADR-047: Backend rotation executors
+
+## Status
+
+Accepted (first slice). PostgreSQL executor shipped; the auto-rotation wiring and
+further backends follow.
+
+## Context
+
+Automated rotation (ADR-046) regenerates a secret's value in Keyorix and stores it as a
+new version. That is correct only for **Keyorix-owned** secrets — values that exist
+solely in Keyorix, where consumers read the current value on each use. It deliberately
+refuses to touch a secret that mirrors an **external** credential (a database user's
+password, a cloud access key), because changing the Keyorix copy would desynchronize it
+from the upstream and break everything that authenticates with the real credential.
+
+That leaves the most valuable rotation case — the long-lived shared credential teams
+actually worry about — still manual. To auto-rotate those, rotation must also **apply
+the new credential to the upstream system**.
+
+## Decision
+
+Introduce **rotation executors**: a backend that, given a reference and a freshly
+generated value, sets that credential in the upstream system. The full rotation of an
+externally-owned secret then becomes: generate a new value → executor applies it
+upstream → Keyorix stores it as a new version (the existing ADR-046 step).
+
+- **Interface seam.** `rotation.Executor { Name(); Type(); Rotate(ctx, ref, newValue) }`,
+  with the backend driver/SDK contained behind the implementation (and a fake-able inner
+  seam for unit tests), mirroring Keyorix Connect's connector model (ADR-043) and the
+  dynamic-secrets engines (ADR-035). A `rotation.Manager` is the name→executor registry.
+- **First backend: PostgreSQL.** `Rotate(role, newPassword)` runs
+  `ALTER ROLE <role> WITH PASSWORD <pw>` against an admin connection. The role name is
+  quoted as an identifier and the password as a string literal (both escaped), so
+  neither can break out of the statement (DDL can't bind parameters).
+- **Admin credentials come from the operator, never from a secret.** Each configured
+  backend names an environment variable holding its admin DSN
+  (`KEYORIX_ROTATION_<NAME>_DSN`-style); the DSN is read from the environment, not the
+  config file — the same trust model as Connect backends and dynamic-secrets engines
+  (ambient/operator-provided credentials with enough privilege to rotate, scoped tightly
+  by the operator).
+- **`allowed_refs` guardrail.** As with Connect, a backend may carry an optional prefix
+  allowlist on the refs (role names) it will rotate, so a misconfigured or compromised
+  caller can't ask it to rotate an arbitrary upstream principal.
+
+This ADR's slice ships the executor subsystem (interface + manager + PostgreSQL backend)
+and its configuration/wiring. A follow-up wires it into `RunAutoRotation` (a per-secret
+`rotation_backend` + `rotation_ref`, used in place of the generate-only path) and adds
+further backends.
+
+## Alternatives considered
+
+- **Reuse the dynamic-secrets engines.** Dynamic secrets *mint ephemeral* credentials
+  (create-on-lease, drop-on-expiry); rotation *replaces a long-lived named* credential
+  in place. Different lifecycle and SQL, though they share the "admin connection to a
+  backend" shape — worth factoring later, not now.
+- **Run rotation SQL through the app's GORM/pgx pool.** Rejected — the rotation admin
+  connection is a distinct, more-privileged identity than the app's data-plane DB user
+  and must not share the pool; it is opened per-rotation from the backend's own DSN.
+- **Parameterized DDL.** Not possible in PostgreSQL (identifiers and the password in
+  `ALTER ROLE` cannot be bind parameters), hence explicit identifier/literal quoting.
+
+## Consequences
+
+- Externally-owned secrets become auto-rotatable once the wiring lands, closing the main
+  remaining rotation gap.
+- A new trust surface: an admin DSN per backend. It is operator-configured, env-sourced,
+  and should be scoped to exactly the principals it must rotate (plus the `allowed_refs`
+  guardrail). Documented accordingly.
+- The executor model is reusable: adding a backend (MySQL, a cloud key API) is a new
+  `Executor` implementation behind the same seam.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -902,10 +902,36 @@ type RotationRemindersConfig struct {
 	Schedule string `yaml:"schedule"`
 }
 
-// AutoRotationConfig configures the opt-in automated-rotation scheduler (ADR-046).
+// AutoRotationConfig configures the opt-in automated-rotation scheduler (ADR-046) and
+// the backend rotation executors it can drive (ADR-047).
 type AutoRotationConfig struct {
 	Enabled  bool   `yaml:"enabled"`
 	Schedule string `yaml:"schedule"`
+	// Backends are the upstream rotation executors (ADR-047) — e.g. a PostgreSQL admin
+	// connection that can ALTER ROLE. Each backend's admin DSN is read from its named
+	// environment variable, never from this file.
+	Backends []RotationBackendConfig `yaml:"backends"`
+}
+
+// RotationBackendConfig describes one upstream rotation executor (ADR-047). Name is the
+// registry key; Type selects the backend ("postgresql"); DSNEnv names the environment
+// variable holding the admin connection string. AllowedRefs optionally restricts which
+// references (e.g. role names) the backend may rotate, by prefix.
+type RotationBackendConfig struct {
+	Name        string   `yaml:"name"`
+	Type        string   `yaml:"type"`
+	DSNEnv      string   `yaml:"dsn_env"`
+	AllowedRefs []string `yaml:"allowed_refs"`
+}
+
+// GetDSN returns the backend admin DSN from its configured environment variable
+// (empty when DSNEnv is unset or the variable is empty — the credential never lives in
+// the config file).
+func (c RotationBackendConfig) GetDSN() string {
+	if c.DSNEnv == "" {
+		return ""
+	}
+	return os.Getenv(c.DSNEnv)
 }
 
 // GetInterval returns the auto-rotation run interval (Go duration, e.g. "1h");

--- a/internal/core/rotation_executor.go
+++ b/internal/core/rotation_executor.go
@@ -13,7 +13,24 @@ import (
 	"context"
 	"fmt"
 	"log"
+
+	"github.com/keyorixhq/keyorix/internal/rotation"
 )
+
+// SetRotationManager wires the configured backend rotation executors (ADR-047) that
+// apply a new credential to an upstream system. nil (the default) leaves backend
+// rotation disabled — auto-rotation then only regenerates Keyorix-owned values.
+func (c *KeyorixCore) SetRotationManager(m *rotation.Manager) {
+	c.rotationManager = m
+}
+
+// RotationBackendNames lists the configured rotation-backend names (for discovery).
+func (c *KeyorixCore) RotationBackendNames() []string {
+	if c.rotationManager == nil {
+		return nil
+	}
+	return c.rotationManager.Names()
+}
 
 // Audit events for automated rotation (ADR-046).
 const (

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -13,6 +13,7 @@ import (
 	"github.com/keyorixhq/keyorix/internal/dynamic"
 	"github.com/keyorixhq/keyorix/internal/encryption"
 	"github.com/keyorixhq/keyorix/internal/notary"
+	"github.com/keyorixhq/keyorix/internal/rotation"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
@@ -60,6 +61,9 @@ type KeyorixCore struct {
 	// connectManager proxies read-through federation to external secret stores
 	// (ADR-043). nil = Keyorix Connect disabled. Set via SetConnectManager.
 	connectManager *connect.Manager
+	// rotationManager holds the backend rotation executors (ADR-047) that apply a new
+	// credential to an upstream system during rotation. nil = no backends configured.
+	rotationManager *rotation.Manager
 	// evidenceForwarder ships the scheduled compliance-evidence pack to an off-box
 	// target (webhook). nil = local-file only. Set via SetEvidenceForwarder.
 	evidenceForwarder EvidenceForwarder

--- a/internal/rotation/postgres.go
+++ b/internal/rotation/postgres.go
@@ -1,0 +1,101 @@
+// postgres.go — the PostgreSQL rotation executor (ADR-047). Rotate sets a role's
+// password via ALTER ROLE against an admin connection opened from the backend's DSN.
+// DDL cannot bind parameters, so the role name is quoted as an identifier and the
+// password as a string literal, both escaped, so neither can break out of the statement.
+package rotation
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// pgConn is the slice of a pgx connection the executor uses — an interface seam so the
+// driver stays contained here and tests inject a fake.
+type pgConn interface {
+	Exec(ctx context.Context, sql string) error
+	Close(ctx context.Context)
+}
+
+// PostgresExecutor rotates PostgreSQL role passwords.
+type PostgresExecutor struct {
+	name        string
+	dsn         string
+	allowedRefs []string
+	// newConn opens an admin connection; nil uses the real pgx connection. Tests inject.
+	newConn func(ctx context.Context, dsn string) (pgConn, error)
+}
+
+// NewPostgresExecutor builds a PostgreSQL rotation executor. dsn is the admin connection
+// string (operator-provided, env-sourced, scoped to the roles it may rotate). allowedRefs,
+// when non-empty, restricts which role names this backend will rotate (prefix allowlist).
+func NewPostgresExecutor(name, dsn string, allowedRefs []string) *PostgresExecutor {
+	return &PostgresExecutor{name: name, dsn: dsn, allowedRefs: allowedRefs}
+}
+
+func (e *PostgresExecutor) Name() string { return e.name }
+func (e *PostgresExecutor) Type() string { return "postgresql" }
+
+func (e *PostgresExecutor) conn(ctx context.Context) (pgConn, error) {
+	if e.newConn != nil {
+		return e.newConn(ctx, e.dsn)
+	}
+	c, err := pgx.Connect(ctx, e.dsn)
+	if err != nil {
+		return nil, fmt.Errorf("postgresql: connect: %w", err)
+	}
+	return &pgxConn{c: c}, nil
+}
+
+// Rotate sets role `ref`'s password to newValue via ALTER ROLE.
+func (e *PostgresExecutor) Rotate(ctx context.Context, ref, newValue string) error {
+	if ref == "" {
+		return fmt.Errorf("postgresql: role name (ref) is required")
+	}
+	if newValue == "" {
+		return fmt.Errorf("postgresql: new value is required")
+	}
+	if !prefixAllowed(e.allowedRefs, ref) {
+		return fmt.Errorf("postgresql: role %q is not permitted by this backend's allowed_refs", ref)
+	}
+	if e.dsn == "" {
+		return fmt.Errorf("postgresql: backend %q has no admin DSN configured", e.name)
+	}
+	c, err := e.conn(ctx)
+	if err != nil {
+		return err
+	}
+	defer c.Close(ctx)
+
+	// DDL can't bind parameters; quote the identifier and the password literal so neither
+	// can escape the statement.
+	sql := fmt.Sprintf("ALTER ROLE %s WITH PASSWORD %s", quoteIdentifier(ref), quoteLiteral(newValue))
+	if err := c.Exec(ctx, sql); err != nil {
+		return fmt.Errorf("postgresql: rotate role %q: %w", ref, err)
+	}
+	return nil
+}
+
+// quoteIdentifier renders s as a double-quoted PostgreSQL identifier (internal quotes
+// doubled), so a crafted role name cannot break out into SQL.
+func quoteIdentifier(s string) string {
+	return `"` + strings.ReplaceAll(s, `"`, `""`) + `"`
+}
+
+// quoteLiteral renders s as a single-quoted PostgreSQL string literal (internal quotes
+// doubled). Relies on standard_conforming_strings (the default), so backslashes are
+// literal.
+func quoteLiteral(s string) string {
+	return `'` + strings.ReplaceAll(s, `'`, `''`) + `'`
+}
+
+// pgxConn adapts *pgx.Conn to the pgConn seam.
+type pgxConn struct{ c *pgx.Conn }
+
+func (p *pgxConn) Exec(ctx context.Context, sql string) error {
+	_, err := p.c.Exec(ctx, sql)
+	return err
+}
+func (p *pgxConn) Close(ctx context.Context) { _ = p.c.Close(ctx) }

--- a/internal/rotation/postgres_test.go
+++ b/internal/rotation/postgres_test.go
@@ -1,0 +1,85 @@
+package rotation
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakePG struct {
+	sql    string
+	called bool
+	err    error
+}
+
+func (f *fakePG) Exec(_ context.Context, sql string) error {
+	f.called = true
+	f.sql = sql
+	return f.err
+}
+func (f *fakePG) Close(context.Context) {}
+
+func pgWith(fake *fakePG, allowed ...string) *PostgresExecutor {
+	e := NewPostgresExecutor("pg", "postgres://admin@db/postgres", allowed)
+	e.newConn = func(context.Context, string) (pgConn, error) { return fake, nil }
+	return e
+}
+
+func TestPostgres_TypeAndName(t *testing.T) {
+	e := NewPostgresExecutor("prod-pg", "dsn", nil)
+	assert.Equal(t, "prod-pg", e.Name())
+	assert.Equal(t, "postgresql", e.Type())
+}
+
+func TestPostgres_RotateBuildsAlterRole(t *testing.T) {
+	fake := &fakePG{}
+	require.NoError(t, pgWith(fake).Rotate(context.Background(), "app_svc", "n3wp4ss"))
+	assert.True(t, fake.called)
+	assert.Equal(t, `ALTER ROLE "app_svc" WITH PASSWORD 'n3wp4ss'`, fake.sql)
+}
+
+// A crafted role name / password cannot break out of the statement: identifiers double
+// internal double-quotes, literals double internal single-quotes.
+func TestPostgres_RotateEscapesInjection(t *testing.T) {
+	fake := &fakePG{}
+	err := pgWith(fake).Rotate(context.Background(), `ro"le`, `pa'ss`)
+	require.NoError(t, err)
+	assert.Equal(t, `ALTER ROLE "ro""le" WITH PASSWORD 'pa''ss'`, fake.sql)
+}
+
+func TestPostgres_RotateErrors(t *testing.T) {
+	t.Run("empty ref", func(t *testing.T) {
+		fake := &fakePG{}
+		require.Error(t, pgWith(fake).Rotate(context.Background(), "", "v"))
+		assert.False(t, fake.called)
+	})
+	t.Run("empty value", func(t *testing.T) {
+		fake := &fakePG{}
+		require.Error(t, pgWith(fake).Rotate(context.Background(), "role", ""))
+		assert.False(t, fake.called)
+	})
+	t.Run("allowed_refs guardrail", func(t *testing.T) {
+		fake := &fakePG{}
+		e := pgWith(fake, "app_")
+		err := e.Rotate(context.Background(), "root", "v")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not permitted")
+		assert.False(t, fake.called, "a disallowed ref must not reach the backend")
+	})
+	t.Run("missing dsn", func(t *testing.T) {
+		fake := &fakePG{}
+		e := NewPostgresExecutor("pg", "", nil)
+		e.newConn = func(context.Context, string) (pgConn, error) { return fake, nil }
+		require.Error(t, e.Rotate(context.Background(), "role", "v"))
+		assert.False(t, fake.called)
+	})
+	t.Run("backend error propagates", func(t *testing.T) {
+		fake := &fakePG{err: errors.New("permission denied for role")}
+		err := pgWith(fake).Rotate(context.Background(), "role", "v")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "permission denied")
+	})
+}

--- a/internal/rotation/rotation.go
+++ b/internal/rotation/rotation.go
@@ -1,0 +1,72 @@
+// Package rotation implements backend rotation executors (ADR-047): given a reference
+// and a freshly generated value, an executor applies that credential to an upstream
+// system (e.g. ALTER ROLE on a database), so an externally-owned secret can be rotated
+// in place — not just regenerated inside Keyorix. The backend driver/SDK is contained
+// behind each Executor (with a fake-able inner seam), and the Manager is the
+// name→executor registry the core consumes.
+package rotation
+
+import (
+	"context"
+	"strings"
+)
+
+// Executor applies a new credential to an upstream system during rotation. Rotate sets
+// the credential identified by ref (e.g. a database role name) to newValue. It must
+// fail (return a non-nil error) rather than partially apply, so the caller only records
+// the new value in Keyorix once the upstream change succeeded.
+type Executor interface {
+	// Name is the operator-assigned backend name (the registry key); unique per install.
+	Name() string
+	// Type identifies the backend kind, e.g. "postgresql".
+	Type() string
+	// Rotate applies newValue to the credential named ref in the backing system.
+	Rotate(ctx context.Context, ref, newValue string) error
+}
+
+// Manager holds the configured rotation executors, keyed by name.
+type Manager struct {
+	execs map[string]Executor
+}
+
+// NewManager builds a manager from the given executors (later entries win on a name
+// collision, though operators should keep names unique).
+func NewManager(execs []Executor) *Manager {
+	m := &Manager{execs: make(map[string]Executor, len(execs))}
+	for _, e := range execs {
+		if e != nil {
+			m.execs[e.Name()] = e
+		}
+	}
+	return m
+}
+
+// Get returns the executor registered under name.
+func (m *Manager) Get(name string) (Executor, bool) {
+	e, ok := m.execs[name]
+	return e, ok
+}
+
+// Names lists the configured backend names (for discovery), in no particular order.
+func (m *Manager) Names() []string {
+	names := make([]string, 0, len(m.execs))
+	for n := range m.execs {
+		names = append(names, n)
+	}
+	return names
+}
+
+// prefixAllowed reports whether ref is permitted by an allowed-refs prefix allowlist: an
+// empty list places no restriction; otherwise ref must begin with one of the prefixes.
+// A guardrail on top of the backend admin identity's own privileges.
+func prefixAllowed(allowed []string, ref string) bool {
+	if len(allowed) == 0 {
+		return true
+	}
+	for _, p := range allowed {
+		if p != "" && strings.HasPrefix(ref, p) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/rotation/rotation_test.go
+++ b/internal/rotation/rotation_test.go
@@ -1,0 +1,32 @@
+package rotation
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type stubExec struct{ name string }
+
+func (s stubExec) Name() string                                 { return s.name }
+func (s stubExec) Type() string                                 { return "stub" }
+func (s stubExec) Rotate(context.Context, string, string) error { return nil }
+
+func TestManager_RegistryAndNilSkip(t *testing.T) {
+	m := NewManager([]Executor{stubExec{name: "a"}, stubExec{name: "b"}, nil})
+	a, ok := m.Get("a")
+	require.True(t, ok)
+	assert.Equal(t, "a", a.Name())
+	_, ok = m.Get("missing")
+	assert.False(t, ok)
+	assert.ElementsMatch(t, []string{"a", "b"}, m.Names())
+}
+
+func TestPrefixAllowed(t *testing.T) {
+	assert.True(t, prefixAllowed(nil, "anything"))             // empty = unrestricted
+	assert.True(t, prefixAllowed([]string{"app_"}, "app_svc")) // prefix match
+	assert.False(t, prefixAllowed([]string{"app_"}, "root"))   // no match
+	assert.False(t, prefixAllowed([]string{""}, "x"))          // empty prefix never matches
+}

--- a/server/main.go
+++ b/server/main.go
@@ -47,6 +47,7 @@ import (
 	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/notary"
 	"github.com/keyorixhq/keyorix/internal/notifychan"
+	"github.com/keyorixhq/keyorix/internal/rotation"
 	appstorage "github.com/keyorixhq/keyorix/internal/storage"
 	"github.com/keyorixhq/keyorix/server/grpc"
 	httpServer "github.com/keyorixhq/keyorix/server/http"
@@ -394,6 +395,29 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 		if len(connectors) > 0 {
 			coreService.SetConnectManager(connect.NewManager(connectors))
 			log.Printf("Keyorix Connect enabled (%d connector(s))", len(connectors))
+		}
+	}
+
+	// Wire backend rotation executors (ADR-047) — upstream systems whose credentials the
+	// auto-rotation flow can rotate in place. Admin DSNs come from the environment, never
+	// the config file.
+	if len(cfg.AutoRotation.Backends) > 0 {
+		var execs []rotation.Executor
+		for _, b := range cfg.AutoRotation.Backends {
+			switch b.Type {
+			case "postgresql":
+				dsn := b.GetDSN()
+				if dsn == "" {
+					log.Printf("Rotation backend %q has no admin DSN (%s unset) — rotations will fail", b.Name, b.DSNEnv)
+				}
+				execs = append(execs, rotation.NewPostgresExecutor(b.Name, dsn, b.AllowedRefs))
+			default:
+				log.Printf("Rotation backend %q: unknown type %q, skipping", b.Name, b.Type)
+			}
+		}
+		if len(execs) > 0 {
+			coreService.SetRotationManager(rotation.NewManager(execs))
+			log.Printf("Backend rotation executors enabled (%d backend(s))", len(execs))
 		}
 	}
 


### PR DESCRIPTION
First slice of **backend rotation** (ADR-047): the engine that lets rotation apply a new credential to an **upstream** system, so an externally-owned secret (e.g. a DB role's password) can eventually be rotated *in place* — not just regenerated inside Keyorix (ADR-046's limit).

## Changes
- **`internal/rotation`**: `Executor { Name, Type, Rotate(ctx, ref, newValue) }` + `Manager` registry (mirrors the Connect connector model). **`PostgresExecutor`** runs `ALTER ROLE <role> WITH PASSWORD <pw>` against an admin connection (pgx) behind a fake-able `pgConn` seam.
- **SQL safety**: DDL can't bind parameters, so the role is quoted as an identifier (internal `"` doubled) and the password as a string literal (internal `'` doubled) — neither can break out of the statement. Optional `allowed_refs` prefix guardrail on the role names a backend will rotate.
- **config**: `auto_rotation.backends` — each names a `type` + an env var holding the admin **DSN** (never in the file) + optional `allowed_refs`.
- **core/main**: `SetRotationManager` + `RotationBackendNames`; `main` builds the manager from config (DSN from env) and wires it.
- **docs**: ADR-047 (trust model — the admin DSN is operator-provided, env-sourced, and should be scoped to exactly the principals it rotates).

## Scope
This ships the executor subsystem + config/wiring. A **follow-up** wires it into `RunAutoRotation` (a per-secret `rotation_backend` + `rotation_ref`, used in place of the generate-only path) and adds further backends.

## Tests
Manager registry; `ALTER ROLE` construction; **injection escaping** (crafted role/password stay quoted); empty ref/value, missing DSN, `allowed_refs` guardrail, backend-error propagation. `-race` clean. gofmt/build/test/gosec/golangci-lint/gitleaks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)