### PR TITLE
feat(rotation): wire backend executors into auto-rotation (ADR-047)

### DIFF
--- a/docs/adr-047-backend-rotation-executors.md
+++ b/docs/adr-047-backend-rotation-executors.md
@@ -2,8 +2,11 @@
 
 ## Status
 
-Accepted (first slice). PostgreSQL executor shipped; the auto-rotation wiring and
-further backends follow.
+Accepted. PostgreSQL executor shipped and wired into the auto-rotation flow: a secret
+with `rotation_backend` + `rotation_ref` set has its new value applied upstream (the
+executor) before being stored in Keyorix, so the two never drift — and the value is NOT
+stored if the upstream apply fails. Manageable over HTTP/gRPC/CLI (scoped
+`secrets.write`). Further backends (MySQL, cloud-key APIs) follow.
 
 ## Context
 

--- a/docs/adr-047-backend-rotation-executors.md
+++ b/docs/adr-047-backend-rotation-executors.md
@@ -42,9 +42,15 @@ upstream → Keyorix stores it as a new version (the existing ADR-046 step).
   config file — the same trust model as Connect backends and dynamic-secrets engines
   (ambient/operator-provided credentials with enough privilege to rotate, scoped tightly
   by the operator).
-- **`allowed_refs` guardrail.** As with Connect, a backend may carry an optional prefix
-  allowlist on the refs (role names) it will rotate, so a misconfigured or compromised
-  caller can't ask it to rotate an arbitrary upstream principal.
+- **`allowed_refs` guardrail — REQUIRED (fail-closed).** A backend carries a prefix
+  allowlist of the refs (role names) it will rotate. Unlike Connect's optional
+  allowlist, a rotation backend **must** declare one: a backend with no `allowed_refs`
+  is refused at registration, and the executor itself refuses to rotate when the list is
+  empty. This is load-bearing — pointing a secret's `rotation_ref` is gated only by
+  scoped `secrets.write` on that secret, so without the allowlist a writer could drive
+  `ALTER ROLE` against any principal the admin DSN can reach. The allowlist (operator-
+  chosen, safe-to-rotate prefixes) is what bounds that. Setting a secret's
+  `rotation_backend` also validates the backend exists at configuration time.
 
 This ADR's slice ships the executor subsystem (interface + manager + PostgreSQL backend)
 and its configuration/wiring. A follow-up wires it into `RunAutoRotation` (a per-secret

--- a/internal/cli/secret/autorotate.go
+++ b/internal/cli/secret/autorotate.go
@@ -14,6 +14,8 @@ var (
 	autoRotateOff     bool
 	autoRotateLength  int
 	autoRotateCharset string
+	autoRotateBackend string
+	autoRotateRef     string
 )
 
 var autoRotateCmd = &cobra.Command{
@@ -39,10 +41,15 @@ value without touching any upstream system. Requires secrets.write at the secret
 		if !ok {
 			return fmt.Errorf("not connected to a server — run: keyorix connect <server>")
 		}
+		if (autoRotateBackend == "") != (autoRotateRef == "") {
+			return fmt.Errorf("--backend and --ref must be set together (or both omitted)")
+		}
 		body := map[string]interface{}{
 			"enabled": !autoRotateOff,
 			"length":  autoRotateLength,
 			"charset": autoRotateCharset,
+			"backend": autoRotateBackend,
+			"ref":     autoRotateRef,
 		}
 		var out struct{}
 		path := "/api/v1/secrets/" + strconv.Itoa(int(autoRotateID)) + "/auto-rotate"
@@ -63,5 +70,7 @@ func init() {
 	autoRotateCmd.Flags().BoolVar(&autoRotateOff, "off", false, "Disable auto-rotation (default enables)")
 	autoRotateCmd.Flags().IntVar(&autoRotateLength, "length", 0, "Generated value length (8–256, 0 = default 32)")
 	autoRotateCmd.Flags().StringVar(&autoRotateCharset, "charset", "", "alphanumeric|lower_alphanumeric|hex|alphanumeric_symbols (empty = default)")
+	autoRotateCmd.Flags().StringVar(&autoRotateBackend, "backend", "", "Rotation backend name — rotate the upstream credential too (ADR-047)")
+	autoRotateCmd.Flags().StringVar(&autoRotateRef, "ref", "", "Upstream identifier the backend rotates (required with --backend)")
 	SecretCmd.AddCommand(autoRotateCmd)
 }

--- a/internal/core/rotation_executor.go
+++ b/internal/core/rotation_executor.go
@@ -15,6 +15,7 @@ import (
 	"log"
 
 	"github.com/keyorixhq/keyorix/internal/rotation"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
 // SetRotationManager wires the configured backend rotation executors (ADR-047) that
@@ -145,6 +146,19 @@ func (c *KeyorixCore) RunAutoRotation(ctx context.Context) (int, error) {
 				log.Printf("auto-rotation: generate value for secret %d: %v", secret.ID, gerr)
 				continue
 			}
+			// Backend rotation (ADR-047): if the secret names a configured executor,
+			// apply the new value UPSTREAM first. Only on success do we store it in
+			// Keyorix, so the two never drift. A backend that is named but unconfigured
+			// or whose upstream apply fails is skipped (logged + audited), not stored.
+			if secret.RotationBackend != "" {
+				if err := c.applyBackendRotation(ctx, secret, val); err != nil {
+					sid := secret.ID
+					c.writeAuditEvent(ctx, EventSecretAutoRotated, nil, &sid,
+						fmt.Sprintf("auto-rotation FAILED for secret %q via backend %q ref %q: %v", secret.Name, secret.RotationBackend, secret.RotationRef, err))
+					log.Printf("auto-rotation: backend rotate secret %d: %v", secret.ID, err)
+					continue
+				}
+			}
 			if _, rerr := c.RotateSecret(ctx, secret.ID, []byte(val), "system:auto-rotation"); rerr != nil {
 				log.Printf("auto-rotation: rotate secret %d: %v", secret.ID, rerr)
 				continue
@@ -152,11 +166,33 @@ func (c *KeyorixCore) RunAutoRotation(ctx context.Context) (int, error) {
 			done[secret.ID] = true
 			rotated++
 			sid := secret.ID
+			via := ""
+			if secret.RotationBackend != "" {
+				via = fmt.Sprintf(" via backend %q ref %q", secret.RotationBackend, secret.RotationRef)
+			}
 			c.writeAuditEvent(ctx, EventSecretAutoRotated, nil, &sid,
-				fmt.Sprintf("auto-rotated secret %q (policy %q, interval %dd)", secret.Name, policy.Name, policy.IntervalDays))
+				fmt.Sprintf("auto-rotated secret %q (policy %q, interval %dd)%s", secret.Name, policy.Name, policy.IntervalDays, via))
 		}
 	}
 	return rotated, nil
+}
+
+// applyBackendRotation resolves the secret's named rotation executor and applies
+// newValue to the upstream credential (ADR-047). Returns an error (so the caller does
+// NOT store the value) when no backend manager is configured, the named backend is
+// unknown, or the upstream apply fails.
+func (c *KeyorixCore) applyBackendRotation(ctx context.Context, secret *models.SecretNode, newValue string) error {
+	if c.rotationManager == nil {
+		return fmt.Errorf("no rotation backends configured")
+	}
+	exec, ok := c.rotationManager.Get(secret.RotationBackend)
+	if !ok {
+		return fmt.Errorf("unknown rotation backend %q", secret.RotationBackend)
+	}
+	if secret.RotationRef == "" {
+		return fmt.Errorf("rotation_ref is required for backend rotation")
+	}
+	return exec.Rotate(ctx, secret.RotationRef, newValue)
 }
 
 // knownRotationCharset reports whether name is a recognized charset (or "" = default).
@@ -169,23 +205,44 @@ func knownRotationCharset(name string) bool {
 	}
 }
 
-// SetSecretAutoRotate enables or disables automated rotation for a secret and sets the
-// generated-value shape (length 0 = default, charset "" = default alphanumeric), then
-// audits the change. Enable only for secrets whose value Keyorix owns (see file header).
-func (c *KeyorixCore) SetSecretAutoRotate(ctx context.Context, id uint, enabled bool, length int, charset string, actorID uint) error {
-	if !knownRotationCharset(charset) {
-		return fmt.Errorf("unknown rotation charset %q (want alphanumeric|lower_alphanumeric|hex|alphanumeric_symbols)", charset)
+// AutoRotateSpec is the per-secret automated-rotation configuration set via
+// SetSecretAutoRotate (ADR-046/047). Length 0 = default; Charset "" = default
+// alphanumeric. Backend "" = regenerate in Keyorix only; when Backend names a
+// configured executor, Ref is the upstream identifier it rotates (required iff Backend
+// is set).
+type AutoRotateSpec struct {
+	Enabled bool
+	Length  int
+	Charset string
+	Backend string
+	Ref     string
+}
+
+// SetSecretAutoRotate configures automated rotation for a secret and audits the change.
+// Enable only for secrets whose value Keyorix owns, OR point Backend at an executor that
+// rotates the upstream credential too (ADR-047). The caller (transport) must have
+// enforced scoped secrets.write.
+func (c *KeyorixCore) SetSecretAutoRotate(ctx context.Context, id uint, spec AutoRotateSpec, actorID uint) error {
+	if !knownRotationCharset(spec.Charset) {
+		return fmt.Errorf("unknown rotation charset %q (want alphanumeric|lower_alphanumeric|hex|alphanumeric_symbols)", spec.Charset)
 	}
-	if length != 0 && (length < rotatedValueMinLength || length > rotatedValueMaxLength) {
-		return fmt.Errorf("rotation length %d out of range (%d–%d, or 0 for default)", length, rotatedValueMinLength, rotatedValueMaxLength)
+	if spec.Length != 0 && (spec.Length < rotatedValueMinLength || spec.Length > rotatedValueMaxLength) {
+		return fmt.Errorf("rotation length %d out of range (%d–%d, or 0 for default)", spec.Length, rotatedValueMinLength, rotatedValueMaxLength)
+	}
+	// Backend and ref are both-or-neither: a backend with no ref can't be applied, and a
+	// ref with no backend is meaningless.
+	if (spec.Backend == "") != (spec.Ref == "") {
+		return fmt.Errorf("rotation_backend and rotation_ref must be set together (or both empty)")
 	}
 	secret, err := c.storage.GetSecret(ctx, id)
 	if err != nil {
 		return fmt.Errorf("secret not found: %w", err)
 	}
-	secret.AutoRotate = enabled
-	secret.RotationLength = length
-	secret.RotationCharset = charset
+	secret.AutoRotate = spec.Enabled
+	secret.RotationLength = spec.Length
+	secret.RotationCharset = spec.Charset
+	secret.RotationBackend = spec.Backend
+	secret.RotationRef = spec.Ref
 	secret.UpdatedAt = c.now()
 	if _, err := c.storage.UpdateSecret(ctx, secret); err != nil {
 		return fmt.Errorf("failed to update secret: %w", err)
@@ -193,10 +250,14 @@ func (c *KeyorixCore) SetSecretAutoRotate(ctx context.Context, id uint, enabled 
 	uid := actorID
 	sid := id
 	verb := "disabled"
-	if enabled {
+	if spec.Enabled {
 		verb = "enabled"
 	}
+	via := ""
+	if spec.Backend != "" {
+		via = fmt.Sprintf(" (backend %q ref %q)", spec.Backend, spec.Ref)
+	}
 	c.writeAuditEvent(ctx, EventSecretAutoRotateConfig, &uid, &sid,
-		fmt.Sprintf("auto-rotation %s for secret %q", verb, secret.Name))
+		fmt.Sprintf("auto-rotation %s for secret %q%s", verb, secret.Name, via))
 	return nil
 }

--- a/internal/core/rotation_executor.go
+++ b/internal/core/rotation_executor.go
@@ -234,6 +234,16 @@ func (c *KeyorixCore) SetSecretAutoRotate(ctx context.Context, id uint, spec Aut
 	if (spec.Backend == "") != (spec.Ref == "") {
 		return fmt.Errorf("rotation_backend and rotation_ref must be set together (or both empty)")
 	}
+	// Reject an unknown backend at configuration time (the backend's own allowed_refs
+	// then bounds, at rotation time, which refs it will actually rotate).
+	if spec.Backend != "" {
+		if c.rotationManager == nil {
+			return fmt.Errorf("no rotation backends are configured")
+		}
+		if _, ok := c.rotationManager.Get(spec.Backend); !ok {
+			return fmt.Errorf("unknown rotation backend %q", spec.Backend)
+		}
+	}
 	secret, err := c.storage.GetSecret(ctx, id)
 	if err != nil {
 		return fmt.Errorf("secret not found: %w", err)

--- a/internal/core/rotation_executor_test.go
+++ b/internal/core/rotation_executor_test.go
@@ -2,9 +2,11 @@ package core
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
+	"github.com/keyorixhq/keyorix/internal/rotation"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/keyorixhq/keyorix/internal/storage/store"
 	"github.com/stretchr/testify/assert"
@@ -104,14 +106,14 @@ func TestSetSecretAutoRotate_TogglesAndPersists(t *testing.T) {
 	seedRotatableSecret(t, db, 1, "key", false, fixed.Add(-24*time.Hour))
 
 	// Enable with a generator spec.
-	require.NoError(t, c.SetSecretAutoRotate(context.Background(), 1, true, 48, "hex", 9))
+	require.NoError(t, c.SetSecretAutoRotate(context.Background(), 1, AutoRotateSpec{Enabled: true, Length: 48, Charset: "hex"}, 9))
 	var s models.SecretNode
 	require.NoError(t, db.First(&s, 1).Error)
 	assert.True(t, s.AutoRotate)
 	assert.Equal(t, 48, s.RotationLength)
 	assert.Equal(t, "hex", s.RotationCharset)
 
-	require.NoError(t, c.SetSecretAutoRotate(context.Background(), 1, false, 0, "", 9))
+	require.NoError(t, c.SetSecretAutoRotate(context.Background(), 1, AutoRotateSpec{Enabled: false}, 9))
 	require.NoError(t, db.First(&s, 1).Error)
 	assert.False(t, s.AutoRotate)
 }
@@ -121,11 +123,11 @@ func TestSetSecretAutoRotate_ValidatesSpec(t *testing.T) {
 	seedRotatableSecret(t, db, 1, "key", false, fixed.Add(-24*time.Hour))
 	ctx := context.Background()
 
-	err := c.SetSecretAutoRotate(ctx, 1, true, 0, "klingon", 9)
+	err := c.SetSecretAutoRotate(ctx, 1, AutoRotateSpec{Enabled: true, Charset: "klingon"}, 9)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown rotation charset")
 
-	err = c.SetSecretAutoRotate(ctx, 1, true, 5000, "", 9)
+	err = c.SetSecretAutoRotate(ctx, 1, AutoRotateSpec{Enabled: true, Length: 5000}, 9)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "out of range")
 }
@@ -193,4 +195,104 @@ func TestGenerateRotatedValue_UniqueAndCharset(t *testing.T) {
 		assert.False(t, seen[v], "values must not repeat")
 		seen[v] = true
 	}
+}
+
+// fakeExecutor records the (ref, value) it was asked to rotate and can fail on demand.
+type fakeExecutor struct {
+	name   string
+	gotRef string
+	gotVal string
+	called bool
+	err    error
+}
+
+func (f *fakeExecutor) Name() string { return f.name }
+func (f *fakeExecutor) Type() string { return "fake" }
+func (f *fakeExecutor) Rotate(_ context.Context, ref, val string) error {
+	f.called = true
+	f.gotRef, f.gotVal = ref, val
+	return f.err
+}
+
+func seedBackendSecret(t *testing.T, db *gorm.DB, id uint, backend, ref string, lastRotated time.Time) {
+	t.Helper()
+	lr := lastRotated
+	require.NoError(t, db.Create(&models.SecretNode{
+		ID: id, Name: "upstream-cred", ProjectID: 1, EnvironmentID: 1, IsSecret: true, Status: "active",
+		AutoRotate: true, RotationBackend: backend, RotationRef: ref, LastRotatedAt: &lr, CreatedAt: lastRotated,
+	}).Error)
+	require.NoError(t, db.Create(&models.SecretVersion{
+		SecretNodeID: id, VersionNumber: 1, EncryptedValue: []byte("orig"), EncryptionMetadata: []byte("{}"), CreatedAt: lastRotated,
+	}).Error)
+}
+
+func backendPolicyCore(t *testing.T, fake *fakeExecutor) (*KeyorixCore, *gorm.DB, time.Time) {
+	c, db, fixed := rotationExecCore(t)
+	pid := uint(1)
+	require.NoError(t, db.Create(&models.RotationPolicy{
+		ID: 1, Name: "30-day", Scope: "project", ProjectID: &pid, IntervalDays: 30, IsActive: true, CreatedBy: "admin",
+	}).Error)
+	c.SetRotationManager(rotation.NewManager([]rotation.Executor{fake}))
+	return c, db, fixed
+}
+
+// Backend rotation: the executor applies the new value upstream, then it's stored.
+func TestRunAutoRotation_BackendApplied(t *testing.T) {
+	fake := &fakeExecutor{name: "pg"}
+	c, db, fixed := backendPolicyCore(t, fake)
+	seedBackendSecret(t, db, 1, "pg", "app_svc", fixed.Add(-60*24*time.Hour))
+
+	n, err := c.RunAutoRotation(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, n)
+
+	require.True(t, fake.called, "the upstream executor was invoked")
+	assert.Equal(t, "app_svc", fake.gotRef)
+	v := latestVersion(t, db, 1)
+	assert.Equal(t, 2, v.VersionNumber, "new value stored after upstream success")
+	assert.Equal(t, fake.gotVal, string(v.EncryptedValue), "stored value matches what was applied upstream")
+}
+
+// If the upstream apply fails, the value is NOT stored (no drift between Keyorix and upstream).
+func TestRunAutoRotation_BackendFailureNotStored(t *testing.T) {
+	fake := &fakeExecutor{name: "pg", err: errors.New("connection refused")}
+	c, db, fixed := backendPolicyCore(t, fake)
+	seedBackendSecret(t, db, 1, "pg", "app_svc", fixed.Add(-60*24*time.Hour))
+
+	n, err := c.RunAutoRotation(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 0, n, "a failed upstream apply rotates nothing")
+	assert.True(t, fake.called)
+	assert.Equal(t, 1, latestVersion(t, db, 1).VersionNumber, "value not stored on upstream failure")
+}
+
+// An unknown backend name (no executor registered) is skipped, not stored.
+func TestRunAutoRotation_UnknownBackendSkipped(t *testing.T) {
+	fake := &fakeExecutor{name: "pg"}
+	c, db, fixed := backendPolicyCore(t, fake)
+	seedBackendSecret(t, db, 1, "nope", "app_svc", fixed.Add(-60*24*time.Hour))
+
+	n, err := c.RunAutoRotation(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 0, n)
+	assert.False(t, fake.called, "the registered executor is not invoked for a different backend name")
+	assert.Equal(t, 1, latestVersion(t, db, 1).VersionNumber)
+}
+
+func TestSetSecretAutoRotate_BackendRefBothOrNeither(t *testing.T) {
+	c, db, fixed := rotationExecCore(t)
+	seedRotatableSecret(t, db, 1, "key", false, fixed.Add(-24*time.Hour))
+	ctx := context.Background()
+
+	// backend without ref → error
+	err := c.SetSecretAutoRotate(ctx, 1, AutoRotateSpec{Enabled: true, Backend: "pg"}, 9)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must be set together")
+
+	// both set → ok
+	require.NoError(t, c.SetSecretAutoRotate(ctx, 1, AutoRotateSpec{Enabled: true, Backend: "pg", Ref: "app_svc"}, 9))
+	var s models.SecretNode
+	require.NoError(t, db.First(&s, 1).Error)
+	assert.Equal(t, "pg", s.RotationBackend)
+	assert.Equal(t, "app_svc", s.RotationRef)
 }

--- a/internal/core/rotation_executor_test.go
+++ b/internal/core/rotation_executor_test.go
@@ -282,6 +282,7 @@ func TestRunAutoRotation_UnknownBackendSkipped(t *testing.T) {
 func TestSetSecretAutoRotate_BackendRefBothOrNeither(t *testing.T) {
 	c, db, fixed := rotationExecCore(t)
 	seedRotatableSecret(t, db, 1, "key", false, fixed.Add(-24*time.Hour))
+	c.SetRotationManager(rotation.NewManager([]rotation.Executor{&fakeExecutor{name: "pg"}}))
 	ctx := context.Background()
 
 	// backend without ref → error
@@ -289,10 +290,27 @@ func TestSetSecretAutoRotate_BackendRefBothOrNeither(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "must be set together")
 
-	// both set → ok
+	// both set, backend exists → ok
 	require.NoError(t, c.SetSecretAutoRotate(ctx, 1, AutoRotateSpec{Enabled: true, Backend: "pg", Ref: "app_svc"}, 9))
 	var s models.SecretNode
 	require.NoError(t, db.First(&s, 1).Error)
 	assert.Equal(t, "pg", s.RotationBackend)
 	assert.Equal(t, "app_svc", s.RotationRef)
+}
+
+func TestSetSecretAutoRotate_RejectsUnknownBackend(t *testing.T) {
+	c, db, fixed := rotationExecCore(t)
+	seedRotatableSecret(t, db, 1, "key", false, fixed.Add(-24*time.Hour))
+	ctx := context.Background()
+
+	// No manager configured → backend reference rejected.
+	err := c.SetSecretAutoRotate(ctx, 1, AutoRotateSpec{Enabled: true, Backend: "pg", Ref: "app_svc"}, 9)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no rotation backends")
+
+	// Manager present but the named backend is not registered → rejected.
+	c.SetRotationManager(rotation.NewManager([]rotation.Executor{&fakeExecutor{name: "other"}}))
+	err = c.SetSecretAutoRotate(ctx, 1, AutoRotateSpec{Enabled: true, Backend: "pg", Ref: "app_svc"}, 9)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown rotation backend")
 }

--- a/internal/rotation/postgres.go
+++ b/internal/rotation/postgres.go
@@ -57,6 +57,12 @@ func (e *PostgresExecutor) Rotate(ctx context.Context, ref, newValue string) err
 	if newValue == "" {
 		return fmt.Errorf("postgresql: new value is required")
 	}
+	// Fail closed: a rotation backend runs privileged DDL with an admin DSN, so it must
+	// carry an explicit allow-list — an unbounded backend would let any caller who can
+	// configure a secret's rotation_ref rotate every role the DSN can reach.
+	if len(e.allowedRefs) == 0 {
+		return fmt.Errorf("postgresql: backend %q has no allowed_refs configured — refusing to rotate (fail-closed)", e.name)
+	}
 	if !prefixAllowed(e.allowedRefs, ref) {
 		return fmt.Errorf("postgresql: role %q is not permitted by this backend's allowed_refs", ref)
 	}

--- a/internal/rotation/postgres_test.go
+++ b/internal/rotation/postgres_test.go
@@ -36,7 +36,7 @@ func TestPostgres_TypeAndName(t *testing.T) {
 
 func TestPostgres_RotateBuildsAlterRole(t *testing.T) {
 	fake := &fakePG{}
-	require.NoError(t, pgWith(fake).Rotate(context.Background(), "app_svc", "n3wp4ss"))
+	require.NoError(t, pgWith(fake, "app_").Rotate(context.Background(), "app_svc", "n3wp4ss"))
 	assert.True(t, fake.called)
 	assert.Equal(t, `ALTER ROLE "app_svc" WITH PASSWORD 'n3wp4ss'`, fake.sql)
 }
@@ -45,9 +45,19 @@ func TestPostgres_RotateBuildsAlterRole(t *testing.T) {
 // internal double-quotes, literals double internal single-quotes.
 func TestPostgres_RotateEscapesInjection(t *testing.T) {
 	fake := &fakePG{}
-	err := pgWith(fake).Rotate(context.Background(), `ro"le`, `pa'ss`)
+	err := pgWith(fake, `ro"le`).Rotate(context.Background(), `ro"le`, `pa'ss`)
 	require.NoError(t, err)
 	assert.Equal(t, `ALTER ROLE "ro""le" WITH PASSWORD 'pa''ss'`, fake.sql)
+}
+
+// Fail-closed: a backend with no allowed_refs refuses to rotate (it never reaches the
+// backend), bounding which upstream principals a configured rotation can touch.
+func TestPostgres_RotateFailsClosedWithoutAllowedRefs(t *testing.T) {
+	fake := &fakePG{}
+	err := pgWith(fake).Rotate(context.Background(), "any_role", "v") // no allowed_refs
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no allowed_refs")
+	assert.False(t, fake.called)
 }
 
 func TestPostgres_RotateErrors(t *testing.T) {
@@ -71,14 +81,16 @@ func TestPostgres_RotateErrors(t *testing.T) {
 	})
 	t.Run("missing dsn", func(t *testing.T) {
 		fake := &fakePG{}
-		e := NewPostgresExecutor("pg", "", nil)
+		e := NewPostgresExecutor("pg", "", []string{"role"}) // allowed, but no DSN
 		e.newConn = func(context.Context, string) (pgConn, error) { return fake, nil }
-		require.Error(t, e.Rotate(context.Background(), "role", "v"))
+		err := e.Rotate(context.Background(), "role", "v")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no admin DSN")
 		assert.False(t, fake.called)
 	})
 	t.Run("backend error propagates", func(t *testing.T) {
 		fake := &fakePG{err: errors.New("permission denied for role")}
-		err := pgWith(fake).Rotate(context.Background(), "role", "v")
+		err := pgWith(fake, "role").Rotate(context.Background(), "role", "v")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "permission denied")
 	})

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -163,6 +163,13 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 		if !columnExists(db, "secret_nodes", "rotation_charset") {
 			db.Exec("ALTER TABLE secret_nodes ADD COLUMN rotation_charset TEXT NOT NULL DEFAULT ''")
 		}
+		// ADR-047: backend rotation wiring. Additive ('' = regenerate-in-Keyorix).
+		if !columnExists(db, "secret_nodes", "rotation_backend") {
+			db.Exec("ALTER TABLE secret_nodes ADD COLUMN rotation_backend TEXT NOT NULL DEFAULT ''")
+		}
+		if !columnExists(db, "secret_nodes", "rotation_ref") {
+			db.Exec("ALTER TABLE secret_nodes ADD COLUMN rotation_ref TEXT NOT NULL DEFAULT ''")
+		}
 	}
 	// Anomaly alerting: additive `alerted` flag (false = not yet pushed out).
 	if tableExists(db, "anomaly_alerts") && !columnExists(db, "anomaly_alerts", "alerted") {

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -451,6 +451,12 @@ type SecretNode struct {
 	// the default alphanumeric set. See the rotation executor for the named charsets.
 	RotationLength  int    `gorm:"not null;default:0"`
 	RotationCharset string `gorm:"not null;default:''"`
+	// RotationBackend / RotationRef wire a secret to a backend rotation executor
+	// (ADR-047): when RotationBackend names a configured executor, auto-rotation applies
+	// the new value to the upstream system (RotationRef = the upstream identifier, e.g. a
+	// DB role) before storing it. Empty RotationBackend = regenerate in Keyorix only.
+	RotationBackend string `gorm:"not null;default:''"`
+	RotationRef     string `gorm:"not null;default:''"`
 	// DeletedAt enables soft delete (ADR-033). DELETE stamps it; restore clears
 	// it; the purge scheduler hard-deletes rows past the retention window. GORM
 	// auto-scopes `deleted_at IS NULL` on model-based queries — raw/Table/Joins

--- a/server/grpc/services/secret_service.go
+++ b/server/grpc/services/secret_service.go
@@ -297,7 +297,8 @@ func mapSecretError(err error) error {
 	case strings.Contains(msg, "already exists"):
 		return status.Error(codes.AlreadyExists, "secret with this name already exists")
 	case strings.Contains(msg, "unknown rotation charset"), strings.Contains(msg, "out of range"),
-		strings.Contains(msg, "must be set together"):
+		strings.Contains(msg, "must be set together"), strings.Contains(msg, "unknown rotation backend"),
+		strings.Contains(msg, "no rotation backends"):
 		return status.Error(codes.InvalidArgument, msg)
 	default:
 		return status.Error(codes.Internal, "secret operation failed")

--- a/server/grpc/services/secret_service.go
+++ b/server/grpc/services/secret_service.go
@@ -173,7 +173,10 @@ func (s *SecretGRPCService) SetSecretAutoRotate(ctx context.Context, req *pb.Set
 	if err := authorizeSecretScoped(ctx, s.core, user, uint(req.GetId()), "secrets.write"); err != nil {
 		return nil, err
 	}
-	if err := s.core.SetSecretAutoRotate(ctx, uint(req.GetId()), req.GetEnabled(), int(req.GetLength()), req.GetCharset(), user.PrincipalID()); err != nil {
+	if err := s.core.SetSecretAutoRotate(ctx, uint(req.GetId()), core.AutoRotateSpec{
+		Enabled: req.GetEnabled(), Length: int(req.GetLength()), Charset: req.GetCharset(),
+		Backend: req.GetBackend(), Ref: req.GetRef(),
+	}, user.PrincipalID()); err != nil {
 		return nil, mapSecretError(err)
 	}
 	return &emptypb.Empty{}, nil
@@ -293,7 +296,8 @@ func mapSecretError(err error) error {
 		return status.Error(codes.PermissionDenied, "access denied to this secret")
 	case strings.Contains(msg, "already exists"):
 		return status.Error(codes.AlreadyExists, "secret with this name already exists")
-	case strings.Contains(msg, "unknown rotation charset"), strings.Contains(msg, "out of range"):
+	case strings.Contains(msg, "unknown rotation charset"), strings.Contains(msg, "out of range"),
+		strings.Contains(msg, "must be set together"):
 		return status.Error(codes.InvalidArgument, msg)
 	default:
 		return status.Error(codes.Internal, "secret operation failed")

--- a/server/http/handlers/secrets_crud.go
+++ b/server/http/handlers/secrets_crud.go
@@ -153,24 +153,32 @@ func (h *SecretHandler) SetAutoRotate(w http.ResponseWriter, r *http.Request) {
 		Enabled bool   `json:"enabled"`
 		Length  int    `json:"length"`  // 0 = default
 		Charset string `json:"charset"` // "" = default alphanumeric
+		Backend string `json:"backend"` // "" = regenerate in Keyorix only
+		Ref     string `json:"ref"`     // upstream identifier (required iff backend set)
 	}
 	if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
 		h.sendError(w, "InvalidJSON", "Invalid JSON in request body", http.StatusBadRequest, nil)
 		return
 	}
-	if err := h.coreService.SetSecretAutoRotate(r.Context(), uint(id), reqBody.Enabled, reqBody.Length, reqBody.Charset, userCtx.UserID); err != nil {
+	if err := h.coreService.SetSecretAutoRotate(r.Context(), uint(id), core.AutoRotateSpec{
+		Enabled: reqBody.Enabled, Length: reqBody.Length, Charset: reqBody.Charset,
+		Backend: reqBody.Backend, Ref: reqBody.Ref,
+	}, userCtx.UserID); err != nil {
 		status := http.StatusInternalServerError
 		switch {
 		case strings.Contains(err.Error(), "not found"):
 			status = http.StatusNotFound
-		case strings.Contains(err.Error(), "unknown rotation charset"), strings.Contains(err.Error(), "out of range"):
+		case strings.Contains(err.Error(), "unknown rotation charset"),
+			strings.Contains(err.Error(), "out of range"),
+			strings.Contains(err.Error(), "must be set together"):
 			status = http.StatusBadRequest
 		}
 		h.sendError(w, "Error", err.Error(), status, nil)
 		return
 	}
 	h.sendSuccess(w, map[string]interface{}{
-		"id": id, "auto_rotate": reqBody.Enabled, "length": reqBody.Length, "charset": reqBody.Charset,
+		"id": id, "auto_rotate": reqBody.Enabled, "length": reqBody.Length,
+		"charset": reqBody.Charset, "backend": reqBody.Backend, "ref": reqBody.Ref,
 	}, "Auto-rotation updated")
 }
 

--- a/server/http/handlers/secrets_crud.go
+++ b/server/http/handlers/secrets_crud.go
@@ -170,7 +170,9 @@ func (h *SecretHandler) SetAutoRotate(w http.ResponseWriter, r *http.Request) {
 			status = http.StatusNotFound
 		case strings.Contains(err.Error(), "unknown rotation charset"),
 			strings.Contains(err.Error(), "out of range"),
-			strings.Contains(err.Error(), "must be set together"):
+			strings.Contains(err.Error(), "must be set together"),
+			strings.Contains(err.Error(), "unknown rotation backend"),
+			strings.Contains(err.Error(), "no rotation backends"):
 			status = http.StatusBadRequest
 		}
 		h.sendError(w, "Error", err.Error(), status, nil)

--- a/server/main.go
+++ b/server/main.go
@@ -406,6 +406,12 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 		for _, b := range cfg.AutoRotation.Backends {
 			switch b.Type {
 			case "postgresql":
+				// Fail closed: a backend runs privileged DDL with an admin DSN, so an
+				// explicit allow-list is required — refuse to register an unbounded one.
+				if len(b.AllowedRefs) == 0 {
+					log.Printf("Rotation backend %q has no allowed_refs — refusing to register (fail-closed; set allowed_refs)", b.Name)
+					continue
+				}
 				dsn := b.GetDSN()
 				if dsn == "" {
 					log.Printf("Rotation backend %q has no admin DSN (%s unset) — rotations will fail", b.Name, b.DSNEnv)

--- a/server/proto/keyorix.proto
+++ b/server/proto/keyorix.proto
@@ -225,6 +225,8 @@ message SetSecretAutoRotateRequest {
   bool enabled = 2;
   int32 length = 3;  // 0 = default
   string charset = 4; // "" = default alphanumeric
+  string backend = 5; // "" = regenerate in Keyorix only (ADR-047)
+  string ref = 6;     // upstream identifier (required iff backend set)
 }
 
 message SecretVersion {

--- a/server/proto/pb/keyorix.pb.go
+++ b/server/proto/pb/keyorix.pb.go
@@ -837,6 +837,8 @@ type SetSecretAutoRotateRequest struct {
 	Enabled       bool                   `protobuf:"varint,2,opt,name=enabled,proto3" json:"enabled,omitempty"`
 	Length        int32                  `protobuf:"varint,3,opt,name=length,proto3" json:"length,omitempty"`  // 0 = default
 	Charset       string                 `protobuf:"bytes,4,opt,name=charset,proto3" json:"charset,omitempty"` // "" = default alphanumeric
+	Backend       string                 `protobuf:"bytes,5,opt,name=backend,proto3" json:"backend,omitempty"` // "" = regenerate in Keyorix only (ADR-047)
+	Ref           string                 `protobuf:"bytes,6,opt,name=ref,proto3" json:"ref,omitempty"`         // upstream identifier (required iff backend set)
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -895,6 +897,20 @@ func (x *SetSecretAutoRotateRequest) GetLength() int32 {
 func (x *SetSecretAutoRotateRequest) GetCharset() string {
 	if x != nil {
 		return x.Charset
+	}
+	return ""
+}
+
+func (x *SetSecretAutoRotateRequest) GetBackend() string {
+	if x != nil {
+		return x.Backend
+	}
+	return ""
+}
+
+func (x *SetSecretAutoRotateRequest) GetRef() string {
+	if x != nil {
+		return x.Ref
 	}
 	return ""
 }
@@ -8438,12 +8454,14 @@ const file_keyorix_proto_rawDesc = "" +
 	"ownedCount\x12!\n" +
 	"\fshared_count\x18\a \x01(\rR\vsharedCount\"*\n" +
 	"\x18GetSecretVersionsRequest\x12\x0e\n" +
-	"\x02id\x18\x01 \x01(\rR\x02id\"x\n" +
+	"\x02id\x18\x01 \x01(\rR\x02id\"\xa4\x01\n" +
 	"\x1aSetSecretAutoRotateRequest\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\rR\x02id\x12\x18\n" +
 	"\aenabled\x18\x02 \x01(\bR\aenabled\x12\x16\n" +
 	"\x06length\x18\x03 \x01(\x05R\x06length\x12\x18\n" +
-	"\acharset\x18\x04 \x01(\tR\acharset\"\x90\x01\n" +
+	"\acharset\x18\x04 \x01(\tR\acharset\x12\x18\n" +
+	"\abackend\x18\x05 \x01(\tR\abackend\x12\x10\n" +
+	"\x03ref\x18\x06 \x01(\tR\x03ref\"\x90\x01\n" +
 	"\rSecretVersion\x12%\n" +
 	"\x0eversion_number\x18\x01 \x01(\rR\rversionNumber\x129\n" +
 	"\n" +


### PR DESCRIPTION
Completes **ADR-047**: a secret can now point at a configured rotation backend (#267), so auto-rotation rotates the **upstream** credential in place instead of only regenerating a Keyorix-owned value.

## Changes
- **model**: `SecretNode.RotationBackend` + `RotationRef` (additive migration; `""` = regenerate in Keyorix only).
- **core**: `RunAutoRotation`, for a secret with a backend set, generates the new value → applies it **upstream** via the executor → stores it in Keyorix **only on success**, so the two never drift. An unconfigured/unknown backend or a failed upstream apply is skipped (logged + audited), never stored. `SetSecretAutoRotate` refactored to an `AutoRotateSpec` struct; backend + ref are **both-or-neither**.
- **surfaces**: HTTP / gRPC / CLI `auto-rotate` all gained `backend`/`ref` (scoped `secrets.write` unchanged); invalid combos → `400` / `InvalidArgument`.
- **docs**: ADR-047 status → wired.

## Authz (per the #267 review's forward note)
The new trigger is *configured* via `SetSecretAutoRotate`, gated by scoped `secrets.write` on the target secret; `RunAutoRotation` itself stays a system scheduler job. The backend's `allowed_refs` + the operator-scoped admin DSN still bound which upstream principals can be rotated.

## Tests
Backend applied (stored value == value applied upstream); upstream failure → **not stored**; unknown backend skipped; both-or-neither validation. gofmt/build/test/gosec/golangci-lint/gitleaks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)