### PR TITLE
release: prep v0.47.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,28 @@
 All notable changes to Keyorix are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## v0.47.0 — 2026-06-16
+
+Backend rotation executors (ADR-047) — rotate the upstream credential, not just the copy.
+
+### Added
+- **Backend rotation executors** — automated rotation can now rotate the **upstream**
+  credential in place, so externally-owned secrets (not just Keyorix-generated values)
+  can auto-rotate. A secret configured with a `rotation_backend` + `rotation_ref` has its
+  new value applied upstream by the backend executor **before** it is stored in Keyorix,
+  so the two never drift; if the upstream apply fails, nothing is stored. The first
+  backend is **PostgreSQL** (`ALTER ROLE … WITH PASSWORD`, injection-safe). Configure
+  via HTTP / gRPC / CLI `auto-rotate` (scoped `secrets.write`). ([#267], [#268])
+
+### Security
+- Rotation backends are **fail-closed**: each requires an `allowed_refs` allow-list (a
+  backend without one is refused at registration and the executor refuses to rotate),
+  bounding which upstream principals a rotation may touch; the named backend is validated
+  when a secret is configured. Admin DSNs are operator-provided and env-sourced. ([#268])
+
+[#267]: https://github.com/keyorixhq/keyorix/pull/267
+[#268]: https://github.com/keyorixhq/keyorix/pull/268
+
 ## v0.46.0 — 2026-06-16
 
 Automated secret rotation (ADR-046).

--- a/deploy/helm/keyorix/Chart.yaml
+++ b/deploy/helm/keyorix/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix
 description: Self-hosted Keyorix secrets manager (API server + web UI + PostgreSQL)
 type: application
 # Chart version — bump on chart changes.
-version: 0.46.0
+version: 0.47.0
 # The Keyorix app version this chart deploys by default (the image tag).
-appVersion: "0.46.0"
+appVersion: "0.47.0"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix


### PR DESCRIPTION
Cuts **v0.47.0** — backend rotation executors (ADR-047):

- **Engine + PostgreSQL** (#267) — `Executor`/`Manager` subsystem; `ALTER ROLE` backend (injection-safe) behind a fake-able seam.
- **Wire-in** (#268) — `RunAutoRotation` applies the new value upstream via the executor before storing it (no drift; not stored on failure). Configure via HTTP/gRPC/CLI, scoped `secrets.write`.
- **Fail-closed**: `allowed_refs` required per backend (refused without one), backend validated at config time; admin DSNs operator-provided + env-sourced. (Security review on #268 found and we fixed a privilege-escalation path before merge.)

Chart + appVersion bumped to `0.47.0`; CHANGELOG updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)