### PR TITLE
feat(rotation): MySQL backend rotation executor (ADR-047)

### DIFF
--- a/docs/adr-047-backend-rotation-executors.md
+++ b/docs/adr-047-backend-rotation-executors.md
@@ -2,11 +2,15 @@
 
 ## Status
 
-Accepted. PostgreSQL executor shipped and wired into the auto-rotation flow: a secret
+Accepted. PostgreSQL and MySQL executors shipped and wired into the auto-rotation flow: a secret
 with `rotation_backend` + `rotation_ref` set has its new value applied upstream (the
 executor) before being stored in Keyorix, so the two never drift — and the value is NOT
 stored if the upstream apply fails. Manageable over HTTP/gRPC/CLI (scoped
-`secrets.write`). Further backends (MySQL, cloud-key APIs) follow.
+`secrets.write`). MySQL is the second backend (`ALTER USER … IDENTIFIED BY`, with
+account names/passwords emitted as doubled-quote/backslash literals — injection-safe
+under both default and NO_BACKSLASH_ESCAPES sql_modes). Cloud-key APIs (KMS/IAM)
+would need a different contract (the cloud *generates* the new key rather than accepting
+one) and are a separate follow-up.
 
 ## Context
 

--- a/internal/rotation/mysql.go
+++ b/internal/rotation/mysql.go
@@ -1,0 +1,111 @@
+// mysql.go — the MySQL rotation executor (ADR-047). Rotate sets an account's password
+// via ALTER USER against an admin connection opened from the backend's DSN. Account
+// names and the password are emitted as single-quoted MySQL string literals with
+// internal quotes and backslashes doubled, so neither can break out of the statement
+// (injection-safe in both the default and NO_BACKSLASH_ESCAPES sql_modes).
+package rotation
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+
+	_ "github.com/go-sql-driver/mysql" // registers the "mysql" sql driver
+)
+
+// mysqlConn is the slice of a MySQL connection the executor uses — an interface seam so
+// the driver stays contained here and tests inject a fake.
+type mysqlConn interface {
+	Exec(ctx context.Context, query string) error
+	Close() error
+}
+
+// MySQLExecutor rotates MySQL account passwords.
+type MySQLExecutor struct {
+	name        string
+	dsn         string
+	allowedRefs []string
+	// newConn opens an admin connection; nil uses the real database/sql conn. Tests inject.
+	newConn func(ctx context.Context, dsn string) (mysqlConn, error)
+}
+
+// NewMySQLExecutor builds a MySQL rotation executor. dsn is the admin connection string
+// (operator-provided, env-sourced, scoped to the accounts it may rotate). allowedRefs,
+// when non-empty, restricts which account names this backend will rotate (prefix
+// allowlist); a rotation backend must declare one (fail-closed).
+func NewMySQLExecutor(name, dsn string, allowedRefs []string) *MySQLExecutor {
+	return &MySQLExecutor{name: name, dsn: dsn, allowedRefs: allowedRefs}
+}
+
+func (e *MySQLExecutor) Name() string { return e.name }
+func (e *MySQLExecutor) Type() string { return "mysql" }
+
+func (e *MySQLExecutor) conn(ctx context.Context) (mysqlConn, error) {
+	if e.newConn != nil {
+		return e.newConn(ctx, e.dsn)
+	}
+	db, err := sql.Open("mysql", e.dsn)
+	if err != nil {
+		return nil, fmt.Errorf("mysql: open: %w", err)
+	}
+	return &mysqlDBConn{db: db}, nil
+}
+
+// Rotate sets account `ref`'s password to newValue via ALTER USER. ref is the account
+// name as `user` or `user@host` (host defaults to '%').
+func (e *MySQLExecutor) Rotate(ctx context.Context, ref, newValue string) error {
+	if ref == "" {
+		return fmt.Errorf("mysql: account name (ref) is required")
+	}
+	if newValue == "" {
+		return fmt.Errorf("mysql: new value is required")
+	}
+	// Fail closed: a rotation backend runs privileged DDL with an admin DSN, so it must
+	// carry an explicit allow-list.
+	if len(e.allowedRefs) == 0 {
+		return fmt.Errorf("mysql: backend %q has no allowed_refs configured — refusing to rotate (fail-closed)", e.name)
+	}
+	if !prefixAllowed(e.allowedRefs, ref) {
+		return fmt.Errorf("mysql: account %q is not permitted by this backend's allowed_refs", ref)
+	}
+	if e.dsn == "" {
+		return fmt.Errorf("mysql: backend %q has no admin DSN configured", e.name)
+	}
+	c, err := e.conn(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = c.Close() }()
+
+	user, host, _ := strings.Cut(ref, "@")
+	if host == "" {
+		host = "%"
+	}
+	// ALTER USER 'user'@'host' IDENTIFIED BY 'pw' — every component a quoted literal
+	// with internal quotes/backslashes doubled, so none can escape the statement.
+	q := fmt.Sprintf("ALTER USER %s@%s IDENTIFIED BY %s",
+		quoteMySQLString(user), quoteMySQLString(host), quoteMySQLString(newValue))
+	if err := c.Exec(ctx, q); err != nil {
+		return fmt.Errorf("mysql: rotate account %q: %w", ref, err)
+	}
+	return nil
+}
+
+// quoteMySQLString renders s as a single-quoted MySQL string literal with internal
+// backslashes and single-quotes doubled — injection-safe under both the default and
+// NO_BACKSLASH_ESCAPES sql_modes.
+func quoteMySQLString(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `'`, `''`)
+	return "'" + s + "'"
+}
+
+// mysqlDBConn adapts *sql.DB to the mysqlConn seam.
+type mysqlDBConn struct{ db *sql.DB }
+
+func (m *mysqlDBConn) Exec(ctx context.Context, query string) error {
+	_, err := m.db.ExecContext(ctx, query)
+	return err
+}
+func (m *mysqlDBConn) Close() error { return m.db.Close() }

--- a/internal/rotation/mysql_test.go
+++ b/internal/rotation/mysql_test.go
@@ -1,0 +1,85 @@
+package rotation
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeMySQL struct {
+	query  string
+	called bool
+	err    error
+}
+
+func (f *fakeMySQL) Exec(_ context.Context, q string) error {
+	f.called = true
+	f.query = q
+	return f.err
+}
+func (f *fakeMySQL) Close() error { return nil }
+
+func myWith(fake *fakeMySQL, allowed ...string) *MySQLExecutor {
+	e := NewMySQLExecutor("my", "user:pw@tcp(db:3306)/", allowed)
+	e.newConn = func(context.Context, string) (mysqlConn, error) { return fake, nil }
+	return e
+}
+
+func TestMySQL_TypeAndName(t *testing.T) {
+	e := NewMySQLExecutor("prod-my", "dsn", nil)
+	assert.Equal(t, "prod-my", e.Name())
+	assert.Equal(t, "mysql", e.Type())
+}
+
+func TestMySQL_RotateBuildsAlterUser(t *testing.T) {
+	fake := &fakeMySQL{}
+	// bare user → default host '%'
+	require.NoError(t, myWith(fake, "app_").Rotate(context.Background(), "app_svc", "n3wp4ss"))
+	assert.True(t, fake.called)
+	assert.Equal(t, `ALTER USER 'app_svc'@'%' IDENTIFIED BY 'n3wp4ss'`, fake.query)
+}
+
+func TestMySQL_RotateWithExplicitHost(t *testing.T) {
+	fake := &fakeMySQL{}
+	require.NoError(t, myWith(fake, "app_").Rotate(context.Background(), "app_svc@10.0.0.5", "pw"))
+	assert.Equal(t, `ALTER USER 'app_svc'@'10.0.0.5' IDENTIFIED BY 'pw'`, fake.query)
+}
+
+// A crafted account/password cannot break out: internal quotes and backslashes doubled.
+func TestMySQL_RotateEscapesInjection(t *testing.T) {
+	fake := &fakeMySQL{}
+	require.NoError(t, myWith(fake, "ro").Rotate(context.Background(), `ro'le`, `pa\'ss`))
+	assert.Equal(t, `ALTER USER 'ro''le'@'%' IDENTIFIED BY 'pa\\''ss'`, fake.query)
+}
+
+func TestMySQL_RotateFailsClosedWithoutAllowedRefs(t *testing.T) {
+	fake := &fakeMySQL{}
+	err := myWith(fake).Rotate(context.Background(), "any", "v") // no allowed_refs
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no allowed_refs")
+	assert.False(t, fake.called)
+}
+
+func TestMySQL_RotateErrors(t *testing.T) {
+	t.Run("empty ref", func(t *testing.T) {
+		fake := &fakeMySQL{}
+		require.Error(t, myWith(fake, "x").Rotate(context.Background(), "", "v"))
+		assert.False(t, fake.called)
+	})
+	t.Run("allowed_refs guardrail", func(t *testing.T) {
+		fake := &fakeMySQL{}
+		err := myWith(fake, "app_").Rotate(context.Background(), "root", "v")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not permitted")
+		assert.False(t, fake.called)
+	})
+	t.Run("backend error propagates", func(t *testing.T) {
+		fake := &fakeMySQL{err: errors.New("access denied")}
+		err := myWith(fake, "app_").Rotate(context.Background(), "app_svc", "v")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "access denied")
+	})
+}

--- a/server/main.go
+++ b/server/main.go
@@ -417,6 +417,16 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 					log.Printf("Rotation backend %q has no admin DSN (%s unset) — rotations will fail", b.Name, b.DSNEnv)
 				}
 				execs = append(execs, rotation.NewPostgresExecutor(b.Name, dsn, b.AllowedRefs))
+			case "mysql":
+				if len(b.AllowedRefs) == 0 {
+					log.Printf("Rotation backend %q has no allowed_refs — refusing to register (fail-closed; set allowed_refs)", b.Name)
+					continue
+				}
+				dsn := b.GetDSN()
+				if dsn == "" {
+					log.Printf("Rotation backend %q has no admin DSN (%s unset) — rotations will fail", b.Name, b.DSNEnv)
+				}
+				execs = append(execs, rotation.NewMySQLExecutor(b.Name, dsn, b.AllowedRefs))
 			default:
 				log.Printf("Rotation backend %q: unknown type %q, skipping", b.Name, b.Type)
 			}


### PR DESCRIPTION
Second rotation backend (ADR-047), **reusing the `Executor` seam**: rotate a MySQL account's password in place via `ALTER USER`, so externally-owned MySQL credentials auto-rotate like the PostgreSQL ones.

## Changes
- **`MySQLExecutor.Rotate(ref, newValue)`**: `ALTER USER 'user'@'host' IDENTIFIED BY 'pw'` over `database/sql` (go-sql-driver/mysql) behind a fake-able `mysqlConn` seam. `ref` is `user` or `user@host` (host defaults to `%`).
- **Injection-safe**: account-name parts and the password are single-quoted literals with internal quotes **and** backslashes doubled — safe under both the default and `NO_BACKSLASH_ESCAPES` sql_modes (DDL can't bind params).
- **Fail-closed** like PostgreSQL: `allowed_refs` required (empty → refuse to rotate); `main` refuses to register an unbounded backend; `type: mysql` wired into the switch.
- **docs**: ADR-047 (MySQL added; cloud-key APIs noted as needing a different contract — the cloud generates the key).

No core changes — `RunAutoRotation` drives any `Executor` via the `Manager`, so MySQL works end-to-end once registered.

## Tests
`ALTER USER` construction, explicit host, **injection escaping** (quote+backslash doubled), fail-closed without `allowed_refs`, empty ref, guardrail, backend-error. gofmt/build/test/gosec/golangci-lint/gitleaks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)