### PR TITLE
feat(rotation): cloud-key rotation — generate-upstream contract + AWS IAM (ADR-047)

### DIFF
--- a/docs/adr-047-backend-rotation-executors.md
+++ b/docs/adr-047-backend-rotation-executors.md
@@ -10,7 +10,12 @@ stored if the upstream apply fails. Manageable over HTTP/gRPC/CLI (scoped
 account names/passwords emitted as doubled-quote/backslash literals — injection-safe
 under both default and NO_BACKSLASH_ESCAPES sql_modes). Cloud-key APIs (KMS/IAM)
 would need a different contract (the cloud *generates* the new key rather than accepting
-one) and are a separate follow-up.
+one). That contract now exists as `rotation.GeneratingExecutor` (`GenerateUpstream(ref)
+→ value`): the rotation flow prefers it over `Rotate`, storing the value the upstream
+minted. The first such backend is **AWS IAM** — rotating a user's access key by minting
+a fresh pair (deleting prior keys) and storing `{access_key_id, secret_access_key}` as
+JSON. Credentials come from the ambient AWS chain; the same fail-closed `allowed_refs`
+guardrail (on IAM usernames) applies.
 
 ## Context
 

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets v1.5.0
 	github.com/aws/aws-sdk-go-v2 v1.42.0
 	github.com/aws/aws-sdk-go-v2/config v1.32.24
+	github.com/aws/aws-sdk-go-v2/service/iam v1.54.5
 	github.com/aws/aws-sdk-go-v2/service/kms v1.53.4
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.103.3
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.42.3

--- a/go.sum
+++ b/go.sum
@@ -54,6 +54,8 @@ github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.29 h1:RdwIf/CuUsvJX3RgJa
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.29/go.mod h1:71wt8W2EgswdZy9Mf9KNnzxZ3TiZlv4caKghPktDOkA=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.30 h1:VTGy885W5DKBxWRUJbym9hytNaYzsyaPkCHGRRMAOhU=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.30/go.mod h1:AS0HycUvJRFvTt613AYDOgO2jzw+00cVSMny8XB3yMY=
+github.com/aws/aws-sdk-go-v2/service/iam v1.54.5 h1:a/gAOhIOi+vHYeRU224WIXlJrLXs4Z1Qbm92vfX64jc=
+github.com/aws/aws-sdk-go-v2/service/iam v1.54.5/go.mod h1:tMNzI+fYFCk4cIdZ7FEybLzShwnmWkfxQw85ED1b4ng=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.12 h1:ZD2+BSw9vFsNlKYIasSNt3uDbjqqXIBcM13UJv/Lx2k=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.12/go.mod h1:Ms4zlcVBbXbiP7EVLhl+lgjvA/a7YphqQ3Ih3174EmI=
 github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.22 h1:V51LGlOq/1VsDsHUdoklAQi7rMmx4qQubvFYAlP2254=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -921,6 +921,7 @@ type RotationBackendConfig struct {
 	Name        string   `yaml:"name"`
 	Type        string   `yaml:"type"`
 	DSNEnv      string   `yaml:"dsn_env"`
+	Region      string   `yaml:"region"` // for cloud backends (e.g. aws-iam); creds from the ambient chain
 	AllowedRefs []string `yaml:"allowed_refs"`
 }
 

--- a/internal/core/rotation_executor.go
+++ b/internal/core/rotation_executor.go
@@ -147,19 +147,24 @@ func (c *KeyorixCore) RunAutoRotation(ctx context.Context) (int, error) {
 				continue
 			}
 			// Backend rotation (ADR-047): if the secret names a configured executor,
-			// apply the new value UPSTREAM first. Only on success do we store it in
-			// Keyorix, so the two never drift. A backend that is named but unconfigured
-			// or whose upstream apply fails is skipped (logged + audited), not stored.
+			// rotate the credential UPSTREAM first and store the resulting value only on
+			// success, so the two never drift. For a generate-upstream backend (e.g. a
+			// cloud key API) the stored value is what the upstream minted; for a
+			// password-set backend it is the candidate we generated. A backend that is
+			// unconfigured/unknown or whose upstream apply fails is skipped (audited).
+			storeVal := val
 			if secret.RotationBackend != "" {
-				if err := c.applyBackendRotation(ctx, secret, val); err != nil {
+				upstreamVal, err := c.applyBackendRotation(ctx, secret, val)
+				if err != nil {
 					sid := secret.ID
 					c.writeAuditEvent(ctx, EventSecretAutoRotated, nil, &sid,
 						fmt.Sprintf("auto-rotation FAILED for secret %q via backend %q ref %q: %v", secret.Name, secret.RotationBackend, secret.RotationRef, err))
 					log.Printf("auto-rotation: backend rotate secret %d: %v", secret.ID, err)
 					continue
 				}
+				storeVal = upstreamVal
 			}
-			if _, rerr := c.RotateSecret(ctx, secret.ID, []byte(val), "system:auto-rotation"); rerr != nil {
+			if _, rerr := c.RotateSecret(ctx, secret.ID, []byte(storeVal), "system:auto-rotation"); rerr != nil {
 				log.Printf("auto-rotation: rotate secret %d: %v", secret.ID, rerr)
 				continue
 			}
@@ -177,22 +182,30 @@ func (c *KeyorixCore) RunAutoRotation(ctx context.Context) (int, error) {
 	return rotated, nil
 }
 
-// applyBackendRotation resolves the secret's named rotation executor and applies
-// newValue to the upstream credential (ADR-047). Returns an error (so the caller does
-// NOT store the value) when no backend manager is configured, the named backend is
-// unknown, or the upstream apply fails.
-func (c *KeyorixCore) applyBackendRotation(ctx context.Context, secret *models.SecretNode, newValue string) error {
+// applyBackendRotation resolves the secret's named rotation executor and rotates the
+// upstream credential (ADR-047). It returns the VALUE to store in Keyorix: for a
+// generate-upstream backend (rotation.GeneratingExecutor, e.g. a cloud key API) that is
+// the value the upstream minted; for a password-set backend it is the candidate passed
+// in (which the executor applied). Returns an error (so the caller does NOT store
+// anything) when no manager is configured, the backend is unknown, or the apply fails.
+func (c *KeyorixCore) applyBackendRotation(ctx context.Context, secret *models.SecretNode, candidate string) (string, error) {
 	if c.rotationManager == nil {
-		return fmt.Errorf("no rotation backends configured")
+		return "", fmt.Errorf("no rotation backends configured")
 	}
 	exec, ok := c.rotationManager.Get(secret.RotationBackend)
 	if !ok {
-		return fmt.Errorf("unknown rotation backend %q", secret.RotationBackend)
+		return "", fmt.Errorf("unknown rotation backend %q", secret.RotationBackend)
 	}
 	if secret.RotationRef == "" {
-		return fmt.Errorf("rotation_ref is required for backend rotation")
+		return "", fmt.Errorf("rotation_ref is required for backend rotation")
 	}
-	return exec.Rotate(ctx, secret.RotationRef, newValue)
+	if gen, ok := exec.(rotation.GeneratingExecutor); ok {
+		return gen.GenerateUpstream(ctx, secret.RotationRef)
+	}
+	if err := exec.Rotate(ctx, secret.RotationRef, candidate); err != nil {
+		return "", err
+	}
+	return candidate, nil
 }
 
 // knownRotationCharset reports whether name is a recognized charset (or "" = default).

--- a/internal/core/rotation_executor_test.go
+++ b/internal/core/rotation_executor_test.go
@@ -314,3 +314,59 @@ func TestSetSecretAutoRotate_RejectsUnknownBackend(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown rotation backend")
 }
+
+// fakeGenExecutor is a generate-upstream backend: GenerateUpstream mints the value.
+type fakeGenExecutor struct {
+	name   string
+	value  string
+	gotRef string
+	err    error
+}
+
+func (f *fakeGenExecutor) Name() string { return f.name }
+func (f *fakeGenExecutor) Type() string { return "fakegen" }
+func (f *fakeGenExecutor) Rotate(context.Context, string, string) error {
+	return errors.New("use GenerateUpstream")
+}
+func (f *fakeGenExecutor) GenerateUpstream(_ context.Context, ref string) (string, error) {
+	f.gotRef = ref
+	return f.value, f.err
+}
+
+// For a generate-upstream backend the STORED value is what the upstream minted, not the
+// Keyorix-generated candidate.
+func TestRunAutoRotation_GenerateUpstreamStored(t *testing.T) {
+	c, db, fixed := rotationExecCore(t)
+	pid := uint(1)
+	require.NoError(t, db.Create(&models.RotationPolicy{
+		ID: 1, Name: "30-day", Scope: "project", ProjectID: &pid, IntervalDays: 30, IsActive: true, CreatedBy: "admin",
+	}).Error)
+	fake := &fakeGenExecutor{name: "cloud", value: `{"access_key_id":"AKIANEW","secret_access_key":"s"}`}
+	c.SetRotationManager(rotation.NewManager([]rotation.Executor{fake}))
+	seedBackendSecret(t, db, 1, "cloud", "svc-app", fixed.Add(-60*24*time.Hour))
+
+	n, err := c.RunAutoRotation(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 1, n)
+	assert.Equal(t, "svc-app", fake.gotRef)
+	v := latestVersion(t, db, 1)
+	assert.Equal(t, 2, v.VersionNumber)
+	assert.Equal(t, fake.value, string(v.EncryptedValue), "stored value is the upstream-minted one, not a generated candidate")
+}
+
+// A generate-upstream failure stores nothing.
+func TestRunAutoRotation_GenerateUpstreamFailureNotStored(t *testing.T) {
+	c, db, fixed := rotationExecCore(t)
+	pid := uint(1)
+	require.NoError(t, db.Create(&models.RotationPolicy{
+		ID: 1, Name: "30-day", Scope: "project", ProjectID: &pid, IntervalDays: 30, IsActive: true, CreatedBy: "admin",
+	}).Error)
+	fake := &fakeGenExecutor{name: "cloud", err: errors.New("LimitExceeded")}
+	c.SetRotationManager(rotation.NewManager([]rotation.Executor{fake}))
+	seedBackendSecret(t, db, 1, "cloud", "svc-app", fixed.Add(-60*24*time.Hour))
+
+	n, err := c.RunAutoRotation(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 0, n)
+	assert.Equal(t, 1, latestVersion(t, db, 1).VersionNumber)
+}

--- a/internal/rotation/awsiam.go
+++ b/internal/rotation/awsiam.go
@@ -1,0 +1,138 @@
+// awsiam.go — the AWS IAM rotation executor (ADR-047), a GENERATE-upstream backend: it
+// rotates an IAM user's access key by minting a fresh key pair (the cloud generates the
+// value — Keyorix does not supply it) and removing the user's prior keys, then returns
+// the new credential as JSON for Keyorix to store. Credentials come from the ambient
+// AWS identity chain, never from Keyorix config.
+package rotation
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+)
+
+// iamAPI is the slice of the IAM client the executor uses — an interface seam so the
+// SDK stays contained here and tests inject a fake.
+type iamAPI interface {
+	ListAccessKeys(ctx context.Context, in *iam.ListAccessKeysInput, opts ...func(*iam.Options)) (*iam.ListAccessKeysOutput, error)
+	CreateAccessKey(ctx context.Context, in *iam.CreateAccessKeyInput, opts ...func(*iam.Options)) (*iam.CreateAccessKeyOutput, error)
+	DeleteAccessKey(ctx context.Context, in *iam.DeleteAccessKeyInput, opts ...func(*iam.Options)) (*iam.DeleteAccessKeyOutput, error)
+}
+
+// AWSIAMExecutor rotates an IAM user's access key. The stored value is JSON:
+// {"access_key_id":"…","secret_access_key":"…"}.
+type AWSIAMExecutor struct {
+	name        string
+	region      string
+	allowedRefs []string
+	// newClient builds an IAM client; nil uses the real client (ambient chain). Tests inject.
+	newClient func(ctx context.Context) (iamAPI, error)
+}
+
+// NewAWSIAMExecutor builds an AWS IAM rotation executor. region configures the client
+// (IAM is global; any region works). allowedRefs restricts which IAM usernames it may
+// rotate (prefix allowlist) — required (fail-closed).
+func NewAWSIAMExecutor(name, region string, allowedRefs []string) *AWSIAMExecutor {
+	return &AWSIAMExecutor{name: name, region: region, allowedRefs: allowedRefs}
+}
+
+func (e *AWSIAMExecutor) Name() string { return e.name }
+func (e *AWSIAMExecutor) Type() string { return "aws-iam" }
+
+// Rotate is not the path for a generate-upstream backend: the new value is minted by
+// AWS, not supplied. The rotation flow calls GenerateUpstream instead.
+func (e *AWSIAMExecutor) Rotate(_ context.Context, _, _ string) error {
+	return fmt.Errorf("aws-iam: backend mints the new value upstream; use GenerateUpstream")
+}
+
+func (e *AWSIAMExecutor) client(ctx context.Context) (iamAPI, error) {
+	if e.newClient != nil {
+		return e.newClient(ctx)
+	}
+	var opts []func(*awsconfig.LoadOptions) error
+	if e.region != "" {
+		opts = append(opts, awsconfig.WithRegion(e.region))
+	}
+	cfg, err := awsconfig.LoadDefaultConfig(ctx, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("aws-iam: load config: %w", err)
+	}
+	return iam.NewFromConfig(cfg), nil
+}
+
+// GenerateUpstream rotates IAM user `ref`'s access key: ensure room (delete a prior key
+// if the user is already at the two-key limit), create a fresh key, then delete every
+// prior key — so only the new key remains — and return it as JSON.
+func (e *AWSIAMExecutor) GenerateUpstream(ctx context.Context, ref string) (string, error) {
+	if ref == "" {
+		return "", fmt.Errorf("aws-iam: IAM username (ref) is required")
+	}
+	// Fail closed: a rotation backend wields a powerful ambient identity, so it must
+	// carry an explicit allow-list of the usernames it may rotate.
+	if len(e.allowedRefs) == 0 {
+		return "", fmt.Errorf("aws-iam: backend %q has no allowed_refs configured — refusing to rotate (fail-closed)", e.name)
+	}
+	if !prefixAllowed(e.allowedRefs, ref) {
+		return "", fmt.Errorf("aws-iam: user %q is not permitted by this backend's allowed_refs", ref)
+	}
+	cl, err := e.client(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	list, err := cl.ListAccessKeys(ctx, &iam.ListAccessKeysInput{UserName: aws.String(ref)})
+	if err != nil {
+		return "", fmt.Errorf("aws-iam: list access keys for %q: %w", ref, err)
+	}
+	prior := make([]string, 0, len(list.AccessKeyMetadata))
+	for _, k := range list.AccessKeyMetadata {
+		if k.AccessKeyId != nil {
+			prior = append(prior, *k.AccessKeyId)
+		}
+	}
+	// IAM caps a user at two access keys; free a slot before creating the new one.
+	if len(prior) >= 2 {
+		if err := e.deleteKey(ctx, cl, ref, prior[0]); err != nil {
+			return "", err
+		}
+		prior = prior[1:]
+	}
+
+	created, err := cl.CreateAccessKey(ctx, &iam.CreateAccessKeyInput{UserName: aws.String(ref)})
+	if err != nil {
+		return "", fmt.Errorf("aws-iam: create access key for %q: %w", ref, err)
+	}
+	if created.AccessKey == nil || created.AccessKey.AccessKeyId == nil || created.AccessKey.SecretAccessKey == nil {
+		return "", fmt.Errorf("aws-iam: create access key for %q returned no credential", ref)
+	}
+	newID := *created.AccessKey.AccessKeyId
+
+	// Remove every prior key so only the freshly-minted one remains. Best-effort: a
+	// delete failure is not fatal (the new key is already live and will be stored).
+	for _, id := range prior {
+		_ = e.deleteKey(ctx, cl, ref, id)
+	}
+
+	out, err := json.Marshal(map[string]string{
+		"access_key_id":     newID,
+		"secret_access_key": *created.AccessKey.SecretAccessKey,
+	})
+	if err != nil {
+		return "", fmt.Errorf("aws-iam: marshal credential: %w", err)
+	}
+	return string(out), nil
+}
+
+func (e *AWSIAMExecutor) deleteKey(ctx context.Context, cl iamAPI, user, keyID string) error {
+	if _, err := cl.DeleteAccessKey(ctx, &iam.DeleteAccessKeyInput{
+		UserName:    aws.String(user),
+		AccessKeyId: aws.String(keyID),
+	}); err != nil {
+		return fmt.Errorf("aws-iam: delete access key %s for %q: %w", keyID, user, err)
+	}
+	return nil
+}

--- a/internal/rotation/awsiam_test.go
+++ b/internal/rotation/awsiam_test.go
@@ -1,0 +1,119 @@
+package rotation
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeIAM struct {
+	existing  []string // current access key ids for the user
+	newID     string
+	newSecret string
+	createErr error
+	deleted   []string
+	createdAs string // username passed to CreateAccessKey
+}
+
+func (f *fakeIAM) ListAccessKeys(_ context.Context, in *iam.ListAccessKeysInput, _ ...func(*iam.Options)) (*iam.ListAccessKeysOutput, error) {
+	md := make([]iamtypes.AccessKeyMetadata, 0, len(f.existing))
+	for _, id := range f.existing {
+		id := id
+		md = append(md, iamtypes.AccessKeyMetadata{AccessKeyId: &id, UserName: in.UserName})
+	}
+	return &iam.ListAccessKeysOutput{AccessKeyMetadata: md}, nil
+}
+
+func (f *fakeIAM) CreateAccessKey(_ context.Context, in *iam.CreateAccessKeyInput, _ ...func(*iam.Options)) (*iam.CreateAccessKeyOutput, error) {
+	if f.createErr != nil {
+		return nil, f.createErr
+	}
+	f.createdAs = aws.ToString(in.UserName)
+	return &iam.CreateAccessKeyOutput{AccessKey: &iamtypes.AccessKey{
+		AccessKeyId: aws.String(f.newID), SecretAccessKey: aws.String(f.newSecret), UserName: in.UserName,
+	}}, nil
+}
+
+func (f *fakeIAM) DeleteAccessKey(_ context.Context, in *iam.DeleteAccessKeyInput, _ ...func(*iam.Options)) (*iam.DeleteAccessKeyOutput, error) {
+	f.deleted = append(f.deleted, aws.ToString(in.AccessKeyId))
+	return &iam.DeleteAccessKeyOutput{}, nil
+}
+
+func iamWith(fake *fakeIAM, allowed ...string) *AWSIAMExecutor {
+	e := NewAWSIAMExecutor("aws", "us-east-1", allowed)
+	e.newClient = func(context.Context) (iamAPI, error) { return fake, nil }
+	return e
+}
+
+func TestAWSIAM_TypeAndName(t *testing.T) {
+	e := NewAWSIAMExecutor("prod-aws", "", nil)
+	assert.Equal(t, "prod-aws", e.Name())
+	assert.Equal(t, "aws-iam", e.Type())
+}
+
+func TestAWSIAM_RotateNotSupported(t *testing.T) {
+	err := iamWith(&fakeIAM{}, "svc-").Rotate(context.Background(), "svc-app", "v")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "GenerateUpstream")
+}
+
+func TestAWSIAM_GenerateUpstream_NoExistingKeys(t *testing.T) {
+	fake := &fakeIAM{newID: "AKIANEW", newSecret: "s3cr3t"}
+	v, err := iamWith(fake, "svc-").GenerateUpstream(context.Background(), "svc-app")
+	require.NoError(t, err)
+	assert.Equal(t, "svc-app", fake.createdAs)
+	assert.Empty(t, fake.deleted, "no prior keys to delete")
+
+	var cred map[string]string
+	require.NoError(t, json.Unmarshal([]byte(v), &cred))
+	assert.Equal(t, "AKIANEW", cred["access_key_id"])
+	assert.Equal(t, "s3cr3t", cred["secret_access_key"])
+}
+
+func TestAWSIAM_GenerateUpstream_DeletesPriorKeys(t *testing.T) {
+	// One prior key → create new, then delete the prior.
+	fake := &fakeIAM{existing: []string{"AKIAOLD"}, newID: "AKIANEW", newSecret: "x"}
+	_, err := iamWith(fake, "svc-").GenerateUpstream(context.Background(), "svc-app")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"AKIAOLD"}, fake.deleted)
+}
+
+func TestAWSIAM_GenerateUpstream_TwoKeysFreesSlotFirst(t *testing.T) {
+	// At the 2-key limit → delete oldest (to make room), create, delete the remaining prior.
+	fake := &fakeIAM{existing: []string{"AKIA1", "AKIA2"}, newID: "AKIANEW", newSecret: "x"}
+	_, err := iamWith(fake, "svc-").GenerateUpstream(context.Background(), "svc-app")
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"AKIA1", "AKIA2"}, fake.deleted, "both prior keys removed; only the new one remains")
+}
+
+func TestAWSIAM_GenerateUpstream_Errors(t *testing.T) {
+	t.Run("empty ref", func(t *testing.T) {
+		_, err := iamWith(&fakeIAM{}, "svc-").GenerateUpstream(context.Background(), "")
+		require.Error(t, err)
+	})
+	t.Run("fail-closed without allowed_refs", func(t *testing.T) {
+		_, err := iamWith(&fakeIAM{}).GenerateUpstream(context.Background(), "svc-app")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no allowed_refs")
+	})
+	t.Run("allowed_refs guardrail", func(t *testing.T) {
+		fake := &fakeIAM{newID: "x", newSecret: "y"}
+		_, err := iamWith(fake, "svc-").GenerateUpstream(context.Background(), "root")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not permitted")
+		assert.Empty(t, fake.createdAs, "a disallowed ref never reaches AWS")
+	})
+	t.Run("create error propagates", func(t *testing.T) {
+		fake := &fakeIAM{createErr: errors.New("LimitExceeded")}
+		_, err := iamWith(fake, "svc-").GenerateUpstream(context.Background(), "svc-app")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "LimitExceeded")
+	})
+}

--- a/internal/rotation/rotation.go
+++ b/internal/rotation/rotation.go
@@ -24,6 +24,17 @@ type Executor interface {
 	Rotate(ctx context.Context, ref, newValue string) error
 }
 
+// GeneratingExecutor is a rotation backend whose UPSTREAM mints the new value — e.g. a
+// cloud access-key API that issues a fresh key pair — rather than accepting a
+// Keyorix-generated one. GenerateUpstream performs the upstream rotation and returns the
+// new value to store in Keyorix (the candidate value the caller generated is ignored
+// for such backends). A backend signals this capability by implementing the interface;
+// the rotation flow prefers GenerateUpstream over Rotate when it is present.
+type GeneratingExecutor interface {
+	Executor
+	GenerateUpstream(ctx context.Context, ref string) (string, error)
+}
+
 // Manager holds the configured rotation executors, keyed by name.
 type Manager struct {
 	execs map[string]Executor

--- a/server/main.go
+++ b/server/main.go
@@ -427,6 +427,14 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 					log.Printf("Rotation backend %q has no admin DSN (%s unset) — rotations will fail", b.Name, b.DSNEnv)
 				}
 				execs = append(execs, rotation.NewMySQLExecutor(b.Name, dsn, b.AllowedRefs))
+			case "aws-iam":
+				// Generate-upstream backend: AWS mints the new key; credentials come from
+				// the ambient AWS chain (no DSN). Still fail-closed on allowed_refs.
+				if len(b.AllowedRefs) == 0 {
+					log.Printf("Rotation backend %q has no allowed_refs — refusing to register (fail-closed; set allowed_refs)", b.Name)
+					continue
+				}
+				execs = append(execs, rotation.NewAWSIAMExecutor(b.Name, b.Region, b.AllowedRefs))
 			default:
 				log.Printf("Rotation backend %q: unknown type %q, skipping", b.Name, b.Type)
 			}


### PR DESCRIPTION
Adds rotation for credentials the **upstream mints** (rather than accepts a value), and the first such backend: **AWS IAM access-key rotation**.

## The contract
- New **`rotation.GeneratingExecutor`** `{ Executor; GenerateUpstream(ref) → value }`. The rotation flow prefers `GenerateUpstream` over `Rotate` and stores the value the upstream returned. Password-set backends (PG/MySQL) are unchanged.

## AWS IAM backend
- `AWSIAMExecutor.GenerateUpstream(username)` rotates the user's access key: frees a slot if at the 2-key limit → `CreateAccessKey` → deletes the prior key(s) → returns `{access_key_id, secret_access_key}` as JSON. Behind a fake-able `iamAPI` seam; credentials from the **ambient AWS chain** (no DSN); region from config. `Rotate()` is unsupported (errors — the cloud mints the value). New dep: `aws-sdk-go-v2/service/iam`.
- Same **fail-closed `allowed_refs`** (on IAM usernames); `type: aws-iam` wired (refused without an allow-list).

## Core
`applyBackendRotation` returns the value to store and uses `GenerateUpstream` when the executor implements it; `RunAutoRotation` stores that value (no drift; on failure → skip + audit, nothing stored).

## Tests
IAM rotation (no prior keys / 1 prior / at 2-key limit), JSON shape, `Rotate` unsupported, fail-closed, guardrail, create-error; core stores the upstream-minted value and stores nothing on failure. gofmt/build/test/gosec/golangci-lint/gitleaks(staged) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)