### PR TITLE
feat(rotation): MongoDB + Redis rotation backends (ADR-047)

### DIFF
--- a/docs/adr-047-backend-rotation-executors.md
+++ b/docs/adr-047-backend-rotation-executors.md
@@ -2,7 +2,8 @@
 
 ## Status
 
-Accepted. PostgreSQL and MySQL executors shipped and wired into the auto-rotation flow: a secret
+Accepted. PostgreSQL, MySQL, MongoDB, and Redis (password-set) plus AWS IAM
+(generate-upstream) executors shipped and wired into the auto-rotation flow: a secret
 with `rotation_backend` + `rotation_ref` set has its new value applied upstream (the
 executor) before being stored in Keyorix, so the two never drift — and the value is NOT
 stored if the upstream apply fails. Manageable over HTTP/gRPC/CLI (scoped

--- a/internal/rotation/mongodb.go
+++ b/internal/rotation/mongodb.go
@@ -1,0 +1,100 @@
+// mongodb.go — the MongoDB rotation executor (ADR-047). Rotate sets an account's
+// password via the updateUser command against an admin connection. The username and
+// password are passed as typed BSON values (not concatenated into a command string), so
+// neither can be interpreted as a command — injection is structurally impossible.
+package rotation
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+const mongoOpTimeout = 10 * time.Second
+
+// mongoRotateAuthDB is the database the rotated account is defined in. Admin-managed
+// accounts live in "admin"; rotation targets that, consistent with the dynamic engine.
+const mongoRotateAuthDB = "admin"
+
+// mongoConn is the high-level seam the executor uses — set a user's password and close.
+// The driver stays contained in the real implementation; tests inject a fake.
+type mongoConn interface {
+	UpdateUserPassword(ctx context.Context, user, password string) error
+	Close(ctx context.Context)
+}
+
+// MongoExecutor rotates a MongoDB account's password (in the admin database).
+type MongoExecutor struct {
+	name        string
+	dsn         string
+	allowedRefs []string
+	newConn     func(ctx context.Context, dsn string) (mongoConn, error)
+}
+
+// NewMongoExecutor builds a MongoDB rotation executor. dsn is the admin connection
+// string (operator-provided, env-sourced). allowedRefs restricts which usernames it may
+// rotate (prefix allowlist) — required (fail-closed).
+func NewMongoExecutor(name, dsn string, allowedRefs []string) *MongoExecutor {
+	return &MongoExecutor{name: name, dsn: dsn, allowedRefs: allowedRefs}
+}
+
+func (e *MongoExecutor) Name() string { return e.name }
+func (e *MongoExecutor) Type() string { return "mongodb" }
+
+func (e *MongoExecutor) conn(ctx context.Context) (mongoConn, error) {
+	if e.newConn != nil {
+		return e.newConn(ctx, e.dsn)
+	}
+	cctx, cancel := context.WithTimeout(ctx, mongoOpTimeout)
+	defer cancel()
+	client, err := mongo.Connect(cctx, options.Client().ApplyURI(e.dsn))
+	if err != nil {
+		return nil, fmt.Errorf("mongodb: connect: %w", err)
+	}
+	return &mongoClientConn{client: client}, nil
+}
+
+// Rotate sets account `ref`'s password to newValue via updateUser.
+func (e *MongoExecutor) Rotate(ctx context.Context, ref, newValue string) error {
+	if ref == "" {
+		return fmt.Errorf("mongodb: username (ref) is required")
+	}
+	if newValue == "" {
+		return fmt.Errorf("mongodb: new value is required")
+	}
+	if len(e.allowedRefs) == 0 {
+		return fmt.Errorf("mongodb: backend %q has no allowed_refs configured — refusing to rotate (fail-closed)", e.name)
+	}
+	if !prefixAllowed(e.allowedRefs, ref) {
+		return fmt.Errorf("mongodb: user %q is not permitted by this backend's allowed_refs", ref)
+	}
+	if e.dsn == "" {
+		return fmt.Errorf("mongodb: backend %q has no admin DSN configured", e.name)
+	}
+	c, err := e.conn(ctx)
+	if err != nil {
+		return err
+	}
+	defer c.Close(ctx)
+	if err := c.UpdateUserPassword(ctx, ref, newValue); err != nil {
+		return fmt.Errorf("mongodb: rotate user %q: %w", ref, err)
+	}
+	return nil
+}
+
+// mongoClientConn adapts *mongo.Client to the mongoConn seam.
+type mongoClientConn struct{ client *mongo.Client }
+
+func (m *mongoClientConn) UpdateUserPassword(ctx context.Context, user, password string) error {
+	cctx, cancel := context.WithTimeout(ctx, mongoOpTimeout)
+	defer cancel()
+	// updateUser takes the name/pwd as typed BSON values — never string-concatenated.
+	cmd := bson.D{{Key: "updateUser", Value: user}, {Key: "pwd", Value: password}}
+	return m.client.Database(mongoRotateAuthDB).RunCommand(cctx, cmd).Err()
+}
+
+func (m *mongoClientConn) Close(context.Context) { _ = m.client.Disconnect(context.Background()) }

--- a/internal/rotation/mongodb_test.go
+++ b/internal/rotation/mongodb_test.go
@@ -1,0 +1,71 @@
+package rotation
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeMongo struct {
+	gotUser, gotPass string
+	called           bool
+	err              error
+}
+
+func (f *fakeMongo) UpdateUserPassword(_ context.Context, user, pass string) error {
+	f.called = true
+	f.gotUser, f.gotPass = user, pass
+	return f.err
+}
+func (f *fakeMongo) Close(context.Context) {}
+
+func mongoWith(fake *fakeMongo, allowed ...string) *MongoExecutor {
+	e := NewMongoExecutor("mongo", "mongodb://admin:pw@db:27017", allowed)
+	e.newConn = func(context.Context, string) (mongoConn, error) { return fake, nil }
+	return e
+}
+
+func TestMongo_TypeAndName(t *testing.T) {
+	e := NewMongoExecutor("prod-mongo", "dsn", nil)
+	assert.Equal(t, "prod-mongo", e.Name())
+	assert.Equal(t, "mongodb", e.Type())
+}
+
+func TestMongo_RotatePassesUserAndPassword(t *testing.T) {
+	fake := &fakeMongo{}
+	require.NoError(t, mongoWith(fake, "app_").Rotate(context.Background(), "app_svc", "n3w"))
+	assert.True(t, fake.called)
+	assert.Equal(t, "app_svc", fake.gotUser)
+	assert.Equal(t, "n3w", fake.gotPass)
+}
+
+func TestMongo_RotateErrors(t *testing.T) {
+	t.Run("empty ref", func(t *testing.T) {
+		fake := &fakeMongo{}
+		require.Error(t, mongoWith(fake, "x").Rotate(context.Background(), "", "v"))
+		assert.False(t, fake.called)
+	})
+	t.Run("fail-closed without allowed_refs", func(t *testing.T) {
+		fake := &fakeMongo{}
+		err := mongoWith(fake).Rotate(context.Background(), "any", "v")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no allowed_refs")
+		assert.False(t, fake.called)
+	})
+	t.Run("guardrail", func(t *testing.T) {
+		fake := &fakeMongo{}
+		err := mongoWith(fake, "app_").Rotate(context.Background(), "root", "v")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not permitted")
+		assert.False(t, fake.called)
+	})
+	t.Run("backend error", func(t *testing.T) {
+		fake := &fakeMongo{err: errors.New("UserNotFound")}
+		err := mongoWith(fake, "app_").Rotate(context.Background(), "app_svc", "v")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "UserNotFound")
+	})
+}

--- a/internal/rotation/redis.go
+++ b/internal/rotation/redis.go
@@ -1,0 +1,91 @@
+// redis.go — the Redis rotation executor (ADR-047). Rotate replaces an ACL user's
+// password via `ACL SETUSER <user> resetpass ><newpass>`. The username and password are
+// passed as DISCRETE command arguments (never concatenated into a command string), so
+// neither can be parsed as an ACL token — injection is structurally impossible.
+package rotation
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+const redisOpTimeout = 10 * time.Second
+
+// redisConn is the high-level seam the executor uses — set a user's password and close.
+type redisConn interface {
+	SetUserPassword(ctx context.Context, user, password string) error
+	Close() error
+}
+
+// RedisExecutor rotates a Redis ACL user's password (keeping its other ACL rules).
+type RedisExecutor struct {
+	name        string
+	dsn         string
+	allowedRefs []string
+	newConn     func(ctx context.Context, dsn string) (redisConn, error)
+}
+
+// NewRedisExecutor builds a Redis rotation executor. dsn is the admin connection URL
+// (redis://… , operator-provided, env-sourced). allowedRefs restricts which ACL
+// usernames it may rotate (prefix allowlist) — required (fail-closed).
+func NewRedisExecutor(name, dsn string, allowedRefs []string) *RedisExecutor {
+	return &RedisExecutor{name: name, dsn: dsn, allowedRefs: allowedRefs}
+}
+
+func (e *RedisExecutor) Name() string { return e.name }
+func (e *RedisExecutor) Type() string { return "redis" }
+
+func (e *RedisExecutor) conn(ctx context.Context) (redisConn, error) {
+	if e.newConn != nil {
+		return e.newConn(ctx, e.dsn)
+	}
+	opt, err := redis.ParseURL(e.dsn)
+	if err != nil {
+		return nil, fmt.Errorf("redis: parse url: %w", err)
+	}
+	return &redisClientConn{client: redis.NewClient(opt)}, nil
+}
+
+// Rotate replaces ACL user `ref`'s password with newValue.
+func (e *RedisExecutor) Rotate(ctx context.Context, ref, newValue string) error {
+	if ref == "" {
+		return fmt.Errorf("redis: ACL username (ref) is required")
+	}
+	if newValue == "" {
+		return fmt.Errorf("redis: new value is required")
+	}
+	if len(e.allowedRefs) == 0 {
+		return fmt.Errorf("redis: backend %q has no allowed_refs configured — refusing to rotate (fail-closed)", e.name)
+	}
+	if !prefixAllowed(e.allowedRefs, ref) {
+		return fmt.Errorf("redis: user %q is not permitted by this backend's allowed_refs", ref)
+	}
+	if e.dsn == "" {
+		return fmt.Errorf("redis: backend %q has no admin DSN configured", e.name)
+	}
+	c, err := e.conn(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = c.Close() }()
+	if err := c.SetUserPassword(ctx, ref, newValue); err != nil {
+		return fmt.Errorf("redis: rotate user %q: %w", ref, err)
+	}
+	return nil
+}
+
+// redisClientConn adapts *redis.Client to the redisConn seam.
+type redisClientConn struct{ client *redis.Client }
+
+func (r *redisClientConn) SetUserPassword(ctx context.Context, user, password string) error {
+	cctx, cancel := context.WithTimeout(ctx, redisOpTimeout)
+	defer cancel()
+	// resetpass clears existing passwords, then >password adds the new one — the user's
+	// other ACL rules/enabled state are preserved. Args are discrete bulk strings.
+	return r.client.Do(cctx, "ACL", "SETUSER", user, "resetpass", ">"+password).Err()
+}
+
+func (r *redisClientConn) Close() error { return r.client.Close() }

--- a/internal/rotation/redis_test.go
+++ b/internal/rotation/redis_test.go
@@ -1,0 +1,66 @@
+package rotation
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeRedis struct {
+	gotUser, gotPass string
+	called           bool
+	err              error
+}
+
+func (f *fakeRedis) SetUserPassword(_ context.Context, user, pass string) error {
+	f.called = true
+	f.gotUser, f.gotPass = user, pass
+	return f.err
+}
+func (f *fakeRedis) Close() error { return nil }
+
+func redisWith(fake *fakeRedis, allowed ...string) *RedisExecutor {
+	e := NewRedisExecutor("redis", "redis://default:pw@db:6379/0", allowed)
+	e.newConn = func(context.Context, string) (redisConn, error) { return fake, nil }
+	return e
+}
+
+func TestRedis_TypeAndName(t *testing.T) {
+	e := NewRedisExecutor("prod-redis", "dsn", nil)
+	assert.Equal(t, "prod-redis", e.Name())
+	assert.Equal(t, "redis", e.Type())
+}
+
+func TestRedis_RotatePassesUserAndPassword(t *testing.T) {
+	fake := &fakeRedis{}
+	require.NoError(t, redisWith(fake, "svc-").Rotate(context.Background(), "svc-app", "n3w"))
+	assert.True(t, fake.called)
+	assert.Equal(t, "svc-app", fake.gotUser)
+	assert.Equal(t, "n3w", fake.gotPass)
+}
+
+func TestRedis_RotateErrors(t *testing.T) {
+	t.Run("fail-closed without allowed_refs", func(t *testing.T) {
+		fake := &fakeRedis{}
+		err := redisWith(fake).Rotate(context.Background(), "any", "v")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no allowed_refs")
+		assert.False(t, fake.called)
+	})
+	t.Run("guardrail", func(t *testing.T) {
+		fake := &fakeRedis{}
+		err := redisWith(fake, "svc-").Rotate(context.Background(), "root", "v")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not permitted")
+		assert.False(t, fake.called)
+	})
+	t.Run("backend error", func(t *testing.T) {
+		fake := &fakeRedis{err: errors.New("NOPERM")}
+		err := redisWith(fake, "svc-").Rotate(context.Background(), "svc-app", "v")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "NOPERM")
+	})
+}

--- a/server/main.go
+++ b/server/main.go
@@ -427,6 +427,26 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 					log.Printf("Rotation backend %q has no admin DSN (%s unset) — rotations will fail", b.Name, b.DSNEnv)
 				}
 				execs = append(execs, rotation.NewMySQLExecutor(b.Name, dsn, b.AllowedRefs))
+			case "mongodb":
+				if len(b.AllowedRefs) == 0 {
+					log.Printf("Rotation backend %q has no allowed_refs — refusing to register (fail-closed; set allowed_refs)", b.Name)
+					continue
+				}
+				dsn := b.GetDSN()
+				if dsn == "" {
+					log.Printf("Rotation backend %q has no admin DSN (%s unset) — rotations will fail", b.Name, b.DSNEnv)
+				}
+				execs = append(execs, rotation.NewMongoExecutor(b.Name, dsn, b.AllowedRefs))
+			case "redis":
+				if len(b.AllowedRefs) == 0 {
+					log.Printf("Rotation backend %q has no allowed_refs — refusing to register (fail-closed; set allowed_refs)", b.Name)
+					continue
+				}
+				dsn := b.GetDSN()
+				if dsn == "" {
+					log.Printf("Rotation backend %q has no admin DSN (%s unset) — rotations will fail", b.Name, b.DSNEnv)
+				}
+				execs = append(execs, rotation.NewRedisExecutor(b.Name, dsn, b.AllowedRefs))
 			case "aws-iam":
 				// Generate-upstream backend: AWS mints the new key; credentials come from
 				// the ambient AWS chain (no DSN). Still fail-closed on allowed_refs.


### PR DESCRIPTION
Two more **password-set** rotation backends, reusing the `Executor.Rotate` seam — no new deps (the mongo + go-redis drivers are already vendored for dynamic secrets).

## Changes
- **`MongoExecutor`**: `updateUser` command (admin db) behind a high-level `mongoConn` seam. Username/password are **typed BSON values**, never concatenated → injection structurally impossible.
- **`RedisExecutor`**: `ACL SETUSER <user> resetpass ><newpass>` (keeps the user's other ACL rules) behind a `redisConn` seam. Username/password are **discrete command args** → injection structurally impossible.
- Both: same **fail-closed `allowed_refs`** (runtime + registration), env-sourced admin DSN, fake-able seam. Types `mongodb` / `redis` wired.
- docs: ADR-047 status.

Backend rotation now spans **PostgreSQL · MySQL · MongoDB · Redis** (password-set) + **AWS IAM** (generate-upstream).

## Tests
Rotate passes user+password to the backend; fail-closed without `allowed_refs`; guardrail; empty ref; backend-error. gofmt/build/test/gosec/golangci-lint/gitleaks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)