### PR TITLE
release: prep v0.49.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to Keyorix are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## v0.49.0 — 2026-06-17
+
+### Added
+- **MongoDB and Redis rotation backends** (ADR-047) — automated rotation can now rotate
+  a MongoDB account (`updateUser`) or a Redis ACL user (`ACL SETUSER … resetpass`) in
+  place, alongside PostgreSQL and MySQL. Both pass the username/password as typed/discrete
+  values (injection-safe by construction) and are fail-closed on a required
+  `allowed_refs`. ([#273])
+
+Backend rotation now spans PostgreSQL · MySQL · MongoDB · Redis (password-set) and AWS
+IAM (generate-upstream).
+
+[#273]: https://github.com/keyorixhq/keyorix/pull/273
+
 ## v0.48.0 — 2026-06-16
 
 More rotation backends (ADR-047).

--- a/deploy/helm/keyorix/Chart.yaml
+++ b/deploy/helm/keyorix/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix
 description: Self-hosted Keyorix secrets manager (API server + web UI + PostgreSQL)
 type: application
 # Chart version — bump on chart changes.
-version: 0.48.0
+version: 0.49.0
 # The Keyorix app version this chart deploys by default (the image tag).
-appVersion: "0.48.0"
+appVersion: "0.49.0"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix


### PR DESCRIPTION
Cuts **v0.49.0** — MongoDB + Redis rotation backends (#273, ADR-047): rotate a MongoDB account (`updateUser`) or a Redis ACL user (`ACL SETUSER … resetpass`) in place, injection-safe and fail-closed on `allowed_refs`.

Backend rotation now spans PostgreSQL · MySQL · MongoDB · Redis (password-set) + AWS IAM (generate-upstream). Chart + appVersion → `0.49.0`; CHANGELOG updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)