### PR TITLE
feat(rotation): GCP service-account key rotation (ADR-047)

### DIFF
--- a/docs/adr-047-backend-rotation-executors.md
+++ b/docs/adr-047-backend-rotation-executors.md
@@ -2,8 +2,9 @@
 
 ## Status
 
-Accepted. PostgreSQL, MySQL, MongoDB, and Redis (password-set) plus AWS IAM
-(generate-upstream) executors shipped and wired into the auto-rotation flow: a secret
+Accepted. PostgreSQL, MySQL, MongoDB, and Redis (password-set) plus AWS IAM and GCP
+service-account keys (generate-upstream) executors shipped and wired into the
+auto-rotation flow: a secret
 with `rotation_backend` + `rotation_ref` set has its new value applied upstream (the
 executor) before being stored in Keyorix, so the two never drift — and the value is NOT
 stored if the upstream apply fails. Manageable over HTTP/gRPC/CLI (scoped

--- a/internal/rotation/gcpsa.go
+++ b/internal/rotation/gcpsa.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"strings"
 
 	iam "google.golang.org/api/iam/v1"
 )
@@ -66,6 +67,11 @@ func (e *GCPServiceAccountKeyExecutor) client(ctx context.Context) (gcpKeyAPI, e
 func (e *GCPServiceAccountKeyExecutor) GenerateUpstream(ctx context.Context, ref string) (string, error) {
 	if ref == "" {
 		return "", fmt.Errorf("gcp-service-account: service-account email (ref) is required")
+	}
+	// ref is concatenated into the SA resource name; an email never contains '/', so
+	// reject one defensively (it cannot then introduce extra path segments).
+	if strings.ContainsRune(ref, '/') {
+		return "", fmt.Errorf("gcp-service-account: ref %q must be a service-account email, not a resource path", ref)
 	}
 	if len(e.allowedRefs) == 0 {
 		return "", fmt.Errorf("gcp-service-account: backend %q has no allowed_refs configured — refusing to rotate (fail-closed)", e.name)

--- a/internal/rotation/gcpsa.go
+++ b/internal/rotation/gcpsa.go
@@ -1,0 +1,140 @@
+// gcpsa.go — the GCP service-account key rotation executor (ADR-047), a GENERATE-upstream
+// backend: it rotates a service account's key by minting a fresh user-managed key (GCP
+// generates it — Keyorix does not supply it) and deleting the account's prior
+// user-managed keys, then returns the new key file (JSON) for Keyorix to store.
+// Credentials come from Application Default Credentials, never from Keyorix config.
+package rotation
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+
+	iam "google.golang.org/api/iam/v1"
+)
+
+// gcpServiceAccountMaxKeys is GCP's per-account limit on user-managed keys; free a slot
+// before creating when already at the limit.
+const gcpServiceAccountMaxKeys = 10
+
+// gcpKeyAPI is the high-level slice of the IAM key API the executor uses — an interface
+// seam so the SDK stays contained here and tests inject a fake. saName is the resource
+// name "projects/-/serviceAccounts/<email>"; keyName is a full key resource name.
+type gcpKeyAPI interface {
+	ListKeyNames(ctx context.Context, saName string) ([]string, error)
+	CreateKey(ctx context.Context, saName string) (keyName, privateKeyJSON string, err error)
+	DeleteKey(ctx context.Context, keyName string) error
+}
+
+// GCPServiceAccountKeyExecutor rotates a GCP service account's user-managed key. The
+// stored value is the new key file as JSON.
+type GCPServiceAccountKeyExecutor struct {
+	name        string
+	allowedRefs []string
+	newClient   func(ctx context.Context) (gcpKeyAPI, error)
+}
+
+// NewGCPServiceAccountKeyExecutor builds a GCP service-account key rotation executor.
+// allowedRefs restricts which service-account emails it may rotate (prefix allowlist) —
+// required (fail-closed).
+func NewGCPServiceAccountKeyExecutor(name string, allowedRefs []string) *GCPServiceAccountKeyExecutor {
+	return &GCPServiceAccountKeyExecutor{name: name, allowedRefs: allowedRefs}
+}
+
+func (e *GCPServiceAccountKeyExecutor) Name() string { return e.name }
+func (e *GCPServiceAccountKeyExecutor) Type() string { return "gcp-service-account" }
+
+// Rotate is not the path for a generate-upstream backend: the key is minted by GCP.
+func (e *GCPServiceAccountKeyExecutor) Rotate(_ context.Context, _, _ string) error {
+	return fmt.Errorf("gcp-service-account: backend mints the new key upstream; use GenerateUpstream")
+}
+
+func (e *GCPServiceAccountKeyExecutor) client(ctx context.Context) (gcpKeyAPI, error) {
+	if e.newClient != nil {
+		return e.newClient(ctx)
+	}
+	svc, err := iam.NewService(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("gcp-service-account: new client: %w", err)
+	}
+	return &gcpIAMClient{svc: svc}, nil
+}
+
+// GenerateUpstream rotates service account `ref` (its email): free a slot if at the
+// key limit, mint a fresh user-managed key, delete the prior user-managed keys, and
+// return the new key file JSON.
+func (e *GCPServiceAccountKeyExecutor) GenerateUpstream(ctx context.Context, ref string) (string, error) {
+	if ref == "" {
+		return "", fmt.Errorf("gcp-service-account: service-account email (ref) is required")
+	}
+	if len(e.allowedRefs) == 0 {
+		return "", fmt.Errorf("gcp-service-account: backend %q has no allowed_refs configured — refusing to rotate (fail-closed)", e.name)
+	}
+	if !prefixAllowed(e.allowedRefs, ref) {
+		return "", fmt.Errorf("gcp-service-account: account %q is not permitted by this backend's allowed_refs", ref)
+	}
+	cl, err := e.client(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	saName := "projects/-/serviceAccounts/" + ref
+	prior, err := cl.ListKeyNames(ctx, saName)
+	if err != nil {
+		return "", fmt.Errorf("gcp-service-account: list keys for %q: %w", ref, err)
+	}
+	if len(prior) >= gcpServiceAccountMaxKeys {
+		if err := cl.DeleteKey(ctx, prior[0]); err != nil {
+			return "", fmt.Errorf("gcp-service-account: free key slot for %q: %w", ref, err)
+		}
+		prior = prior[1:]
+	}
+
+	_, keyJSON, err := cl.CreateKey(ctx, saName)
+	if err != nil {
+		return "", fmt.Errorf("gcp-service-account: create key for %q: %w", ref, err)
+	}
+	if keyJSON == "" {
+		return "", fmt.Errorf("gcp-service-account: create key for %q returned no key material", ref)
+	}
+
+	// Remove every prior user-managed key so only the freshly-minted one remains.
+	// Best-effort: a delete failure is not fatal (the new key is live and will be stored).
+	for _, kn := range prior {
+		_ = cl.DeleteKey(ctx, kn)
+	}
+	return keyJSON, nil
+}
+
+// gcpIAMClient adapts *iam.Service to the gcpKeyAPI seam.
+type gcpIAMClient struct{ svc *iam.Service }
+
+func (g *gcpIAMClient) ListKeyNames(ctx context.Context, saName string) ([]string, error) {
+	resp, err := g.svc.Projects.ServiceAccounts.Keys.List(saName).KeyTypes("USER_MANAGED").Context(ctx).Do()
+	if err != nil {
+		return nil, err
+	}
+	names := make([]string, 0, len(resp.Keys))
+	for _, k := range resp.Keys {
+		names = append(names, k.Name)
+	}
+	return names, nil
+}
+
+func (g *gcpIAMClient) CreateKey(ctx context.Context, saName string) (string, string, error) {
+	key, err := g.svc.Projects.ServiceAccounts.Keys.Create(saName, &iam.CreateServiceAccountKeyRequest{}).Context(ctx).Do()
+	if err != nil {
+		return "", "", err
+	}
+	// PrivateKeyData is the base64-encoded key file; decode to the JSON credentials.
+	raw, err := base64.StdEncoding.DecodeString(key.PrivateKeyData)
+	if err != nil {
+		return "", "", fmt.Errorf("decode private key data: %w", err)
+	}
+	return key.Name, string(raw), nil
+}
+
+func (g *gcpIAMClient) DeleteKey(ctx context.Context, keyName string) error {
+	_, err := g.svc.Projects.ServiceAccounts.Keys.Delete(keyName).Context(ctx).Do()
+	return err
+}

--- a/internal/rotation/gcpsa_test.go
+++ b/internal/rotation/gcpsa_test.go
@@ -84,6 +84,13 @@ func TestGCPSA_GenerateUpstream_Errors(t *testing.T) {
 		_, err := gcpWith(&fakeGCP{}, "svc-").GenerateUpstream(context.Background(), "")
 		require.Error(t, err)
 	})
+	t.Run("ref with slash rejected", func(t *testing.T) {
+		fake := &fakeGCP{newJSON: "{}"}
+		_, err := gcpWith(fake, "svc-").GenerateUpstream(context.Background(), "svc-app@p.iam/keys/x")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "resource path")
+		assert.Empty(t, fake.createdAt, "a path-shaped ref never reaches GCP")
+	})
 	t.Run("fail-closed without allowed_refs", func(t *testing.T) {
 		_, err := gcpWith(&fakeGCP{}).GenerateUpstream(context.Background(), "svc-app@p.iam")
 		require.Error(t, err)

--- a/internal/rotation/gcpsa_test.go
+++ b/internal/rotation/gcpsa_test.go
@@ -1,0 +1,105 @@
+package rotation
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeGCP struct {
+	existing  []string // current user-managed key names
+	newName   string
+	newJSON   string
+	createErr error
+	createdAt string // saName passed to CreateKey
+	deleted   []string
+}
+
+func (f *fakeGCP) ListKeyNames(_ context.Context, _ string) ([]string, error) {
+	return append([]string(nil), f.existing...), nil
+}
+func (f *fakeGCP) CreateKey(_ context.Context, saName string) (string, string, error) {
+	if f.createErr != nil {
+		return "", "", f.createErr
+	}
+	f.createdAt = saName
+	return f.newName, f.newJSON, nil
+}
+func (f *fakeGCP) DeleteKey(_ context.Context, keyName string) error {
+	f.deleted = append(f.deleted, keyName)
+	return nil
+}
+
+func gcpWith(fake *fakeGCP, allowed ...string) *GCPServiceAccountKeyExecutor {
+	e := NewGCPServiceAccountKeyExecutor("gcp", allowed)
+	e.newClient = func(context.Context) (gcpKeyAPI, error) { return fake, nil }
+	return e
+}
+
+func TestGCPSA_TypeAndName(t *testing.T) {
+	e := NewGCPServiceAccountKeyExecutor("prod-gcp", nil)
+	assert.Equal(t, "prod-gcp", e.Name())
+	assert.Equal(t, "gcp-service-account", e.Type())
+}
+
+func TestGCPSA_RotateNotSupported(t *testing.T) {
+	err := gcpWith(&fakeGCP{}, "svc-").Rotate(context.Background(), "svc-app@p.iam", "v")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "GenerateUpstream")
+}
+
+func TestGCPSA_GenerateUpstream_NoPriorKeys(t *testing.T) {
+	fake := &fakeGCP{newName: "projects/-/serviceAccounts/svc-app@p.iam/keys/NEW", newJSON: `{"type":"service_account"}`}
+	v, err := gcpWith(fake, "svc-").GenerateUpstream(context.Background(), "svc-app@p.iam")
+	require.NoError(t, err)
+	assert.Equal(t, `{"type":"service_account"}`, v)
+	assert.Equal(t, "projects/-/serviceAccounts/svc-app@p.iam", fake.createdAt)
+	assert.Empty(t, fake.deleted)
+}
+
+func TestGCPSA_GenerateUpstream_DeletesPriorKeys(t *testing.T) {
+	fake := &fakeGCP{existing: []string{"k/OLD1", "k/OLD2"}, newName: "k/NEW", newJSON: `{"k":"v"}`}
+	_, err := gcpWith(fake, "svc-").GenerateUpstream(context.Background(), "svc-app@p.iam")
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"k/OLD1", "k/OLD2"}, fake.deleted, "all prior user-managed keys removed")
+}
+
+func TestGCPSA_GenerateUpstream_FreesSlotAtLimit(t *testing.T) {
+	existing := make([]string, gcpServiceAccountMaxKeys) // at the limit
+	for i := range existing {
+		existing[i] = "k/OLD" + string(rune('A'+i))
+	}
+	fake := &fakeGCP{existing: existing, newName: "k/NEW", newJSON: `{"k":"v"}`}
+	_, err := gcpWith(fake, "svc-").GenerateUpstream(context.Background(), "svc-app@p.iam")
+	require.NoError(t, err)
+	// All prior keys deleted (one to free the slot, the rest after create).
+	assert.Len(t, fake.deleted, gcpServiceAccountMaxKeys)
+}
+
+func TestGCPSA_GenerateUpstream_Errors(t *testing.T) {
+	t.Run("empty ref", func(t *testing.T) {
+		_, err := gcpWith(&fakeGCP{}, "svc-").GenerateUpstream(context.Background(), "")
+		require.Error(t, err)
+	})
+	t.Run("fail-closed without allowed_refs", func(t *testing.T) {
+		_, err := gcpWith(&fakeGCP{}).GenerateUpstream(context.Background(), "svc-app@p.iam")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no allowed_refs")
+	})
+	t.Run("guardrail", func(t *testing.T) {
+		fake := &fakeGCP{newJSON: "{}"}
+		_, err := gcpWith(fake, "svc-").GenerateUpstream(context.Background(), "root@p.iam")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not permitted")
+		assert.Empty(t, fake.createdAt, "a disallowed ref never reaches GCP")
+	})
+	t.Run("create error propagates", func(t *testing.T) {
+		fake := &fakeGCP{createErr: errors.New("PermissionDenied")}
+		_, err := gcpWith(fake, "svc-").GenerateUpstream(context.Background(), "svc-app@p.iam")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "PermissionDenied")
+	})
+}

--- a/server/main.go
+++ b/server/main.go
@@ -455,6 +455,14 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 					continue
 				}
 				execs = append(execs, rotation.NewAWSIAMExecutor(b.Name, b.Region, b.AllowedRefs))
+			case "gcp-service-account":
+				// Generate-upstream backend: GCP mints the key; credentials come from
+				// Application Default Credentials (no DSN). Fail-closed on allowed_refs.
+				if len(b.AllowedRefs) == 0 {
+					log.Printf("Rotation backend %q has no allowed_refs — refusing to register (fail-closed; set allowed_refs)", b.Name)
+					continue
+				}
+				execs = append(execs, rotation.NewGCPServiceAccountKeyExecutor(b.Name, b.AllowedRefs))
 			default:
 				log.Printf("Rotation backend %q: unknown type %q, skipping", b.Name, b.Type)
 			}


### PR DESCRIPTION
The last cloud-key provider — a **generate-upstream** backend like AWS IAM: rotate a GCP service account's key by minting a fresh user-managed key (GCP generates it) and deleting the account's prior user-managed keys, storing the new key file JSON.

## Changes
- **`GCPServiceAccountKeyExecutor.GenerateUpstream(saEmail)`**: free a slot if at the 10-key limit → `Keys.Create` → delete prior user-managed keys → return the decoded key JSON. Behind a high-level `gcpKeyAPI` seam (List/Create/Delete) over `google.golang.org/api` `iam/v1` — **no new go.mod dep** (sub-package of the already-vendored module). Creds from **Application Default Credentials** (no DSN). `Rotate()` errors (use `GenerateUpstream`).
- Same **fail-closed `allowed_refs`** (on SA emails); `type: gcp-service-account` wired.
- docs: ADR-047.

No core changes — the `GeneratingExecutor` path drives it.

## Tests
Key rotation (no prior / some prior / at the 10-key limit), JSON returned, `Rotate` unsupported, fail-closed, guardrail, create-error. gofmt/build/test/gosec/golangci-lint/gitleaks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)