### PR TITLE
release: prep v0.50.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to Keyorix are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## v0.50.0 — 2026-06-17
+
+### Added
+- **GCP service-account key rotation** (ADR-047) — a generate-upstream backend (like AWS
+  IAM): rotation mints a fresh user-managed service-account key, deletes the account's
+  prior user-managed keys, and stores the new key file. Credentials come from Application
+  Default Credentials; fail-closed on a required `allowed_refs`. ([#275])
+
+With this release, backend rotation spans **PostgreSQL · MySQL · MongoDB · Redis**
+(password-set) and **AWS IAM · GCP service-account keys** (generate-upstream).
+
+[#275]: https://github.com/keyorixhq/keyorix/pull/275
+
 ## v0.49.0 — 2026-06-17
 
 ### Added

--- a/deploy/helm/keyorix/Chart.yaml
+++ b/deploy/helm/keyorix/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix
 description: Self-hosted Keyorix secrets manager (API server + web UI + PostgreSQL)
 type: application
 # Chart version — bump on chart changes.
-version: 0.49.0
+version: 0.50.0
 # The Keyorix app version this chart deploys by default (the image tag).
-appVersion: "0.49.0"
+appVersion: "0.50.0"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix


### PR DESCRIPTION
Cuts **v0.50.0** — GCP service-account key rotation (#275, ADR-047): a generate-upstream backend that mints a fresh user-managed key, deletes prior keys, and stores the new key file (ADC creds, fail-closed `allowed_refs`).

Backend rotation now spans **PostgreSQL · MySQL · MongoDB · Redis** (password-set) + **AWS IAM · GCP service-account keys** (generate-upstream). Chart + appVersion → `0.50.0`; CHANGELOG updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)