### PR TITLE
feat(rotation): alert on auto-rotation failures (ADR-046)

### DIFF
--- a/docs/adr-046-automated-secret-rotation.md
+++ b/docs/adr-046-automated-secret-rotation.md
@@ -70,5 +70,8 @@ value automatically — which is the intended pattern.
   audited.
 - New per-secret column `auto_rotate` (additive migration) and an opt-in scheduler;
   both off by default, so existing installs are unchanged.
-- Management of the flag currently lands over HTTP; gRPC/CLI/web toggles are follow-ups
-  (the executor and audit trail are transport-agnostic).
+- Management of the flag is available over HTTP / gRPC / CLI / web.
+- **Failure alerting:** a silently-failed auto-rotation is a security event, so each run
+  that leaves any secret unrotated broadcasts one summary (secret names + reasons, never
+  values) to the configured notification channel (Slack/Teams/webhook), in addition to
+  the per-failure audit events. No-op when no channel is wired.

--- a/internal/core/rotation_executor.go
+++ b/internal/core/rotation_executor.go
@@ -13,10 +13,42 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"sort"
+	"strings"
 
 	"github.com/keyorixhq/keyorix/internal/rotation"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
+
+// EventAutoRotationFailures is audited once per run when one or more secrets failed.
+const EventAutoRotationFailures = "rotation.failures_alerted"
+
+// notifyRotationFailures broadcasts a single summary of the run's rotation failures to
+// the configured notification channel (Slack/Teams/webhook) — a silently-failed
+// credential rotation is a security event operators must see. No-op when no sink is
+// wired or nothing failed; the sink is non-blocking. Also audited.
+func (c *KeyorixCore) notifyRotationFailures(ctx context.Context, failed map[uint]string) {
+	if len(failed) == 0 {
+		return
+	}
+	lines := make([]string, 0, len(failed))
+	for _, msg := range failed {
+		lines = append(lines, "• "+msg)
+	}
+	sort.Strings(lines) // stable, deterministic ordering
+	sysCtx := WithActorType(ctx, ActorTypeSystem)
+	c.writeAuditEvent(sysCtx, EventAutoRotationFailures, nil, nil,
+		fmt.Sprintf("auto-rotation: %d secret(s) failed to rotate", len(failed)))
+	if c.notificationSink == nil {
+		return
+	}
+	c.notificationSink.Deliver(NotificationEvent{
+		Type:    "rotation.failed",
+		Title:   fmt.Sprintf("Auto-rotation: %d secret(s) failed to rotate", len(failed)),
+		Message: "The following secrets could not be auto-rotated:\n" + strings.Join(lines, "\n"),
+		Link:    "/secrets",
+	})
+}
 
 // SetRotationManager wires the configured backend rotation executors (ADR-047) that
 // apply a new credential to an upstream system. nil (the default) leaves backend
@@ -119,6 +151,9 @@ func (c *KeyorixCore) RunAutoRotation(ctx context.Context) (int, error) {
 	now := c.now()
 	rotated := 0
 	done := make(map[uint]bool)
+	// failed records the last failure per secret id; a secret that later rotates under
+	// another covering policy is removed, so only genuine end-of-run failures remain.
+	failed := make(map[uint]string)
 
 	for _, policy := range policies {
 		if !policy.IsActive {
@@ -144,6 +179,7 @@ func (c *KeyorixCore) RunAutoRotation(ctx context.Context) (int, error) {
 			val, gerr := generateRotatedValueSpec(secret.RotationLength, secret.RotationCharset)
 			if gerr != nil {
 				log.Printf("auto-rotation: generate value for secret %d: %v", secret.ID, gerr)
+				failed[secret.ID] = fmt.Sprintf("%q: generate value: %v", secret.Name, gerr)
 				continue
 			}
 			// Backend rotation (ADR-047): if the secret names a configured executor,
@@ -160,14 +196,17 @@ func (c *KeyorixCore) RunAutoRotation(ctx context.Context) (int, error) {
 					c.writeAuditEvent(ctx, EventSecretAutoRotated, nil, &sid,
 						fmt.Sprintf("auto-rotation FAILED for secret %q via backend %q ref %q: %v", secret.Name, secret.RotationBackend, secret.RotationRef, err))
 					log.Printf("auto-rotation: backend rotate secret %d: %v", secret.ID, err)
+					failed[secret.ID] = fmt.Sprintf("%q via backend %q ref %q: %v", secret.Name, secret.RotationBackend, secret.RotationRef, err)
 					continue
 				}
 				storeVal = upstreamVal
 			}
 			if _, rerr := c.RotateSecret(ctx, secret.ID, []byte(storeVal), "system:auto-rotation"); rerr != nil {
 				log.Printf("auto-rotation: rotate secret %d: %v", secret.ID, rerr)
+				failed[secret.ID] = fmt.Sprintf("%q: store new version: %v", secret.Name, rerr)
 				continue
 			}
+			delete(failed, secret.ID) // rotated successfully (e.g. under a later policy)
 			done[secret.ID] = true
 			rotated++
 			sid := secret.ID
@@ -179,6 +218,7 @@ func (c *KeyorixCore) RunAutoRotation(ctx context.Context) (int, error) {
 				fmt.Sprintf("auto-rotated secret %q (policy %q, interval %dd)%s", secret.Name, policy.Name, policy.IntervalDays, via))
 		}
 	}
+	c.notifyRotationFailures(ctx, failed)
 	return rotated, nil
 }
 

--- a/internal/core/rotation_executor_test.go
+++ b/internal/core/rotation_executor_test.go
@@ -370,3 +370,37 @@ func TestRunAutoRotation_GenerateUpstreamFailureNotStored(t *testing.T) {
 	assert.Equal(t, 0, n)
 	assert.Equal(t, 1, latestVersion(t, db, 1).VersionNumber)
 }
+
+// A rotation failure broadcasts a single summary notification (fakeSink is defined in
+// notification_dispatch_test.go).
+func TestRunAutoRotation_NotifiesFailures(t *testing.T) {
+	fake := &fakeExecutor{name: "pg", err: errors.New("connection refused")}
+	c, db, fixed := backendPolicyCore(t, fake)
+	sink := &fakeSink{}
+	c.SetNotificationSink(sink)
+	seedBackendSecret(t, db, 1, "pg", "app_svc", fixed.Add(-60*24*time.Hour)) // name "upstream-cred"
+
+	_, err := c.RunAutoRotation(context.Background())
+	require.NoError(t, err)
+	require.Len(t, sink.events, 1)
+	assert.Equal(t, "rotation.failed", sink.events[0].Type)
+	assert.Contains(t, sink.events[0].Title, "1 secret")
+	assert.Contains(t, sink.events[0].Message, "upstream-cred")
+	assert.Contains(t, sink.events[0].Message, "connection refused")
+}
+
+// A clean run (no failures) sends nothing.
+func TestRunAutoRotation_NoFailuresNoNotify(t *testing.T) {
+	c, db, fixed := rotationExecCore(t)
+	pid := uint(1)
+	require.NoError(t, db.Create(&models.RotationPolicy{
+		ID: 1, Name: "30-day", Scope: "project", ProjectID: &pid, IntervalDays: 30, IsActive: true, CreatedBy: "admin",
+	}).Error)
+	sink := &fakeSink{}
+	c.SetNotificationSink(sink)
+	seedRotatableSecret(t, db, 1, "k", true, fixed.Add(-60*24*time.Hour)) // generated → succeeds
+
+	_, err := c.RunAutoRotation(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, sink.events)
+}


### PR DESCRIPTION
A **silently-failed credential rotation** (backend unreachable, permission denied, store error) is a security event operators must see — until now `RunAutoRotation` only *audited* failures. Each run that leaves any secret unrotated now **broadcasts one summary notification** (secret names + reasons, never values) to the configured channel (Slack/Teams/webhook), plus a per-run audit event (`rotation.failures_alerted`).

## Details
- Failures are tracked **per secret id** and cleared if the secret later rotates under another covering policy, so only genuine end-of-run failures are reported; the summary is deterministically ordered.
- Non-blocking + no-op when no notification sink is wired; reuses the broadcast pattern from the compliance digest. **No secret value** appears in the message or audit.

## Tests
A backend failure broadcasts one `rotation.failed` event naming the secret + reason; a clean run sends nothing. gofmt/build/test/gosec/golangci-lint/gitleaks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)