### PR TITLE
feat(rotation): surface auto-rotate + backend in rotation status (ADR-046/047)

### DIFF
--- a/internal/core/rotation_policies.go
+++ b/internal/core/rotation_policies.go
@@ -145,6 +145,11 @@ type RotationStatusEntry struct {
 	DaysSinceRotation int        `json:"days_since_rotation"`
 	DaysOverdue       int        `json:"days_overdue"` // positive = overdue, negative = days remaining
 	Status            string     `json:"status"`       // overdue | due_soon | ok
+	// AutoRotate / RotationBackend surface whether this covered secret self-rotates
+	// (ADR-046/047) and via which backend ("" = regenerate in Keyorix), so an operator
+	// can tell a self-rotating secret from a reminder-only one at a glance.
+	AutoRotate      bool   `json:"auto_rotate"`
+	RotationBackend string `json:"rotation_backend,omitempty"`
 }
 
 // GetRotationStatus returns the rotation posture of every secret covered by an
@@ -228,6 +233,8 @@ func (c *KeyorixCore) GetRotationStatus(ctx context.Context, projectID *uint) ([
 				DaysSinceRotation: daysSince,
 				DaysOverdue:       daysOverdue,
 				Status:            status,
+				AutoRotate:        secret.AutoRotate,
+				RotationBackend:   secret.RotationBackend,
 			})
 		}
 	}

--- a/internal/core/rotation_status_test.go
+++ b/internal/core/rotation_status_test.go
@@ -37,7 +37,7 @@ func TestGetRotationStatus_Classification(t *testing.T) {
 
 	secrets := []*models.SecretNode{
 		{ID: 1, Name: "overdue-key", EnvironmentID: 2, LastRotatedAt: daysAgo(120)}, // 120 > 90 → overdue
-		{ID: 2, Name: "due-soon-key", EnvironmentID: 2, LastRotatedAt: daysAgo(80)}, // 90-80=10 <= 14 → due_soon
+		{ID: 2, Name: "due-soon-key", EnvironmentID: 2, LastRotatedAt: daysAgo(80), AutoRotate: true, RotationBackend: "prod-pg"}, // 90-80=10 <= 14 → due_soon
 		{ID: 3, Name: "healthy-key", EnvironmentID: 2, LastRotatedAt: daysAgo(10)},  // 90-10=80 > 14 → ok
 		{ID: 4, Name: "never-rotated", EnvironmentID: 2, CreatedAt: *daysAgo(200)},  // falls back to CreatedAt → overdue
 	}
@@ -64,4 +64,8 @@ func TestGetRotationStatus_Classification(t *testing.T) {
 	require.Equal(t, RotationStatusOverdue, byID[4].Status, "never-rotated falls back to CreatedAt")
 	require.Equal(t, uint(7), byID[1].PolicyID)
 	require.Equal(t, 90, byID[1].IntervalDays)
+	// Auto-rotation visibility flows through: a self-rotating secret reports its backend.
+	require.True(t, byID[2].AutoRotate)
+	require.Equal(t, "prod-pg", byID[2].RotationBackend)
+	require.False(t, byID[1].AutoRotate, "reminder-only secret is not auto-rotate")
 }


### PR DESCRIPTION
The `/rotation-policies/status` read model reported policy posture (overdue/due_soon/ok) but not whether a covered secret **self-rotates**. This adds `auto_rotate` + `rotation_backend` to `RotationStatusEntry` (populated from the secret), so an operator can tell a self-rotating secret (and via which backend) from a reminder-only one at a glance.

JSON-additive; the web rotation view consumes it in a follow-up.

## Test
A self-rotating secret reports `auto_rotate=true` + its backend; a reminder-only one reports `auto_rotate=false`. gofmt/build/test/gosec/golangci-lint/gitleaks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)