### PR TITLE
feat(rotation): Azure AD app-secret rotation (ADR-047)

### DIFF
--- a/docs/adr-047-backend-rotation-executors.md
+++ b/docs/adr-047-backend-rotation-executors.md
@@ -2,9 +2,9 @@
 
 ## Status
 
-Accepted. PostgreSQL, MySQL, MongoDB, and Redis (password-set) plus AWS IAM and GCP
-service-account keys (generate-upstream) executors shipped and wired into the
-auto-rotation flow: a secret
+Accepted. PostgreSQL, MySQL, MongoDB, and Redis (password-set) plus AWS IAM, GCP
+service-account keys, and Azure AD app secrets (generate-upstream) executors shipped and
+wired into the auto-rotation flow: a secret
 with `rotation_backend` + `rotation_ref` set has its new value applied upstream (the
 executor) before being stored in Keyorix, so the two never drift — and the value is NOT
 stored if the upstream apply fails. Manageable over HTTP/gRPC/CLI (scoped

--- a/internal/rotation/azure.go
+++ b/internal/rotation/azure.go
@@ -13,6 +13,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
+	"strings"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -74,6 +76,13 @@ func (e *AzureAppSecretExecutor) client(ctx context.Context) (azureGraphAPI, err
 func (e *AzureAppSecretExecutor) GenerateUpstream(ctx context.Context, ref string) (string, error) {
 	if ref == "" {
 		return "", fmt.Errorf("azure-app: application object id (ref) is required")
+	}
+	// ref is interpolated into the Graph URL path; an app object id is a GUID, so reject
+	// any path/query metacharacter. Without this, a crafted ref that begins with an
+	// allowed prefix (e.g. "<allowed-guid>/../<victim-guid>") could path-traverse to a
+	// different application and defeat allowed_refs.
+	if strings.ContainsAny(ref, "/?#%") {
+		return "", fmt.Errorf("azure-app: invalid application object id %q (must be a bare GUID)", ref)
 	}
 	if len(e.allowedRefs) == 0 {
 		return "", fmt.Errorf("azure-app: backend %q has no allowed_refs configured — refusing to rotate (fail-closed)", e.name)
@@ -163,8 +172,8 @@ func (c *azureGraphClient) ListPasswordKeyIDs(ctx context.Context, appID string)
 			KeyID string `json:"keyId"`
 		} `json:"passwordCredentials"`
 	}
-	url := fmt.Sprintf("%s/applications/%s?$select=passwordCredentials", azureGraphBase, appID)
-	if err := c.do(ctx, http.MethodGet, url, nil, &out); err != nil {
+	reqURL := fmt.Sprintf("%s/applications/%s?$select=passwordCredentials", azureGraphBase, url.PathEscape(appID))
+	if err := c.do(ctx, http.MethodGet, reqURL, nil, &out); err != nil {
 		return nil, err
 	}
 	ids := make([]string, 0, len(out.PasswordCredentials))
@@ -181,14 +190,14 @@ func (c *azureGraphClient) AddPassword(ctx context.Context, appID string) (strin
 	var out struct {
 		SecretText string `json:"secretText"`
 	}
-	url := fmt.Sprintf("%s/applications/%s/addPassword", azureGraphBase, appID)
-	if err := c.do(ctx, http.MethodPost, url, body, &out); err != nil {
+	reqURL := fmt.Sprintf("%s/applications/%s/addPassword", azureGraphBase, url.PathEscape(appID))
+	if err := c.do(ctx, http.MethodPost, reqURL, body, &out); err != nil {
 		return "", err
 	}
 	return out.SecretText, nil
 }
 
 func (c *azureGraphClient) RemovePassword(ctx context.Context, appID, keyID string) error {
-	url := fmt.Sprintf("%s/applications/%s/removePassword", azureGraphBase, appID)
-	return c.do(ctx, http.MethodPost, url, map[string]any{"keyId": keyID}, nil)
+	reqURL := fmt.Sprintf("%s/applications/%s/removePassword", azureGraphBase, url.PathEscape(appID))
+	return c.do(ctx, http.MethodPost, reqURL, map[string]any{"keyId": keyID}, nil)
 }

--- a/internal/rotation/azure.go
+++ b/internal/rotation/azure.go
@@ -1,0 +1,194 @@
+// azure.go — the Azure AD application rotation executor (ADR-047), a GENERATE-upstream
+// backend: it rotates an app registration's client secret by minting a fresh secret via
+// Microsoft Graph (addPassword) and removing the app's prior secrets, then returns the
+// new client secret for Keyorix to store. Credentials come from the ambient Azure
+// identity chain (DefaultAzureCredential), never from Keyorix config. The Graph calls go
+// over net/http (no Graph SDK dependency), authenticated with an azidentity token.
+package rotation
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+)
+
+const (
+	azureGraphBase   = "https://graph.microsoft.com/v1.0"
+	azureGraphScope  = "https://graph.microsoft.com/.default"
+	azureHTTPTimeout = 30 * time.Second
+)
+
+// azureGraphAPI is the high-level slice of Microsoft Graph the executor uses — an
+// interface seam so the HTTP/SDK details stay contained and tests inject a fake. appID
+// is the application's object id.
+type azureGraphAPI interface {
+	ListPasswordKeyIDs(ctx context.Context, appID string) ([]string, error)
+	AddPassword(ctx context.Context, appID string) (secretText string, err error)
+	RemovePassword(ctx context.Context, appID, keyID string) error
+}
+
+// AzureAppSecretExecutor rotates an Azure AD application's client secret. The stored
+// value is the new secret text.
+type AzureAppSecretExecutor struct {
+	name        string
+	allowedRefs []string
+	newClient   func(ctx context.Context) (azureGraphAPI, error)
+}
+
+// NewAzureAppSecretExecutor builds an Azure app-secret rotation executor. allowedRefs
+// restricts which application object ids it may rotate (prefix allowlist) — required
+// (fail-closed).
+func NewAzureAppSecretExecutor(name string, allowedRefs []string) *AzureAppSecretExecutor {
+	return &AzureAppSecretExecutor{name: name, allowedRefs: allowedRefs}
+}
+
+func (e *AzureAppSecretExecutor) Name() string { return e.name }
+func (e *AzureAppSecretExecutor) Type() string { return "azure-app" }
+
+// Rotate is not the path for a generate-upstream backend: the secret is minted by Azure.
+func (e *AzureAppSecretExecutor) Rotate(_ context.Context, _, _ string) error {
+	return fmt.Errorf("azure-app: backend mints the new secret upstream; use GenerateUpstream")
+}
+
+func (e *AzureAppSecretExecutor) client(ctx context.Context) (azureGraphAPI, error) {
+	if e.newClient != nil {
+		return e.newClient(ctx)
+	}
+	cred, err := azidentity.NewDefaultAzureCredential(nil)
+	if err != nil {
+		return nil, fmt.Errorf("azure-app: default credential: %w", err)
+	}
+	return &azureGraphClient{cred: cred, http: &http.Client{Timeout: azureHTTPTimeout}}, nil
+}
+
+// GenerateUpstream rotates application `ref` (its object id): mint a fresh client secret
+// and delete the app's prior secrets, returning the new secret text.
+func (e *AzureAppSecretExecutor) GenerateUpstream(ctx context.Context, ref string) (string, error) {
+	if ref == "" {
+		return "", fmt.Errorf("azure-app: application object id (ref) is required")
+	}
+	if len(e.allowedRefs) == 0 {
+		return "", fmt.Errorf("azure-app: backend %q has no allowed_refs configured — refusing to rotate (fail-closed)", e.name)
+	}
+	if !prefixAllowed(e.allowedRefs, ref) {
+		return "", fmt.Errorf("azure-app: application %q is not permitted by this backend's allowed_refs", ref)
+	}
+	cl, err := e.client(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	prior, err := cl.ListPasswordKeyIDs(ctx, ref)
+	if err != nil {
+		return "", fmt.Errorf("azure-app: list secrets for %q: %w", ref, err)
+	}
+	secret, err := cl.AddPassword(ctx, ref)
+	if err != nil {
+		return "", fmt.Errorf("azure-app: add secret for %q: %w", ref, err)
+	}
+	if secret == "" {
+		return "", fmt.Errorf("azure-app: add secret for %q returned no secret text", ref)
+	}
+	// Remove the prior secrets so only the freshly-minted one remains. Best-effort: a
+	// delete failure is not fatal (the new secret is live and will be stored).
+	for _, kid := range prior {
+		_ = cl.RemovePassword(ctx, ref, kid)
+	}
+	return secret, nil
+}
+
+// azureGraphClient calls Microsoft Graph over net/http with an azidentity bearer token.
+type azureGraphClient struct {
+	cred azcore.TokenCredential
+	http *http.Client
+}
+
+func (c *azureGraphClient) token(ctx context.Context) (string, error) {
+	tok, err := c.cred.GetToken(ctx, policy.TokenRequestOptions{Scopes: []string{azureGraphScope}})
+	if err != nil {
+		return "", fmt.Errorf("acquire graph token: %w", err)
+	}
+	return tok.Token, nil
+}
+
+// do issues an authenticated Graph request and decodes a JSON response into out (out may
+// be nil for no-content responses).
+func (c *azureGraphClient) do(ctx context.Context, method, url string, body, out any) error {
+	tok, err := c.token(ctx)
+	if err != nil {
+		return err
+	}
+	var rdr io.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		if err != nil {
+			return err
+		}
+		rdr = bytes.NewReader(b)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, url, rdr)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+tok)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		msg, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
+		return fmt.Errorf("graph %s returned %d: %s", method, resp.StatusCode, bytes.TrimSpace(msg))
+	}
+	if out != nil {
+		return json.NewDecoder(resp.Body).Decode(out)
+	}
+	return nil
+}
+
+func (c *azureGraphClient) ListPasswordKeyIDs(ctx context.Context, appID string) ([]string, error) {
+	var out struct {
+		PasswordCredentials []struct {
+			KeyID string `json:"keyId"`
+		} `json:"passwordCredentials"`
+	}
+	url := fmt.Sprintf("%s/applications/%s?$select=passwordCredentials", azureGraphBase, appID)
+	if err := c.do(ctx, http.MethodGet, url, nil, &out); err != nil {
+		return nil, err
+	}
+	ids := make([]string, 0, len(out.PasswordCredentials))
+	for _, p := range out.PasswordCredentials {
+		if p.KeyID != "" {
+			ids = append(ids, p.KeyID)
+		}
+	}
+	return ids, nil
+}
+
+func (c *azureGraphClient) AddPassword(ctx context.Context, appID string) (string, error) {
+	body := map[string]any{"passwordCredential": map[string]any{"displayName": "keyorix-rotated"}}
+	var out struct {
+		SecretText string `json:"secretText"`
+	}
+	url := fmt.Sprintf("%s/applications/%s/addPassword", azureGraphBase, appID)
+	if err := c.do(ctx, http.MethodPost, url, body, &out); err != nil {
+		return "", err
+	}
+	return out.SecretText, nil
+}
+
+func (c *azureGraphClient) RemovePassword(ctx context.Context, appID, keyID string) error {
+	url := fmt.Sprintf("%s/applications/%s/removePassword", azureGraphBase, appID)
+	return c.do(ctx, http.MethodPost, url, map[string]any{"keyId": keyID}, nil)
+}

--- a/internal/rotation/azure_test.go
+++ b/internal/rotation/azure_test.go
@@ -75,6 +75,14 @@ func TestAzure_GenerateUpstream_Errors(t *testing.T) {
 		_, err := azureWith(&fakeAzure{}, "app-").GenerateUpstream(context.Background(), "")
 		require.Error(t, err)
 	})
+	t.Run("ref with path metacharacters rejected", func(t *testing.T) {
+		fake := &fakeAzure{newSecret: "x"}
+		// would otherwise path-traverse to a different app despite the allowed prefix
+		_, err := azureWith(fake, "app-").GenerateUpstream(context.Background(), "app-1/../victim-2")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid application object id")
+		assert.Empty(t, fake.addedFor, "a path-shaped ref never reaches Azure")
+	})
 	t.Run("fail-closed without allowed_refs", func(t *testing.T) {
 		_, err := azureWith(&fakeAzure{}).GenerateUpstream(context.Background(), "app-123")
 		require.Error(t, err)

--- a/internal/rotation/azure_test.go
+++ b/internal/rotation/azure_test.go
@@ -1,0 +1,96 @@
+package rotation
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeAzure struct {
+	existing  []string // current password keyIds
+	newSecret string
+	addErr    error
+	listErr   error
+	removed   []string
+	addedFor  string
+}
+
+func (f *fakeAzure) ListPasswordKeyIDs(_ context.Context, _ string) ([]string, error) {
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	return append([]string(nil), f.existing...), nil
+}
+func (f *fakeAzure) AddPassword(_ context.Context, appID string) (string, error) {
+	if f.addErr != nil {
+		return "", f.addErr
+	}
+	f.addedFor = appID
+	return f.newSecret, nil
+}
+func (f *fakeAzure) RemovePassword(_ context.Context, _, keyID string) error {
+	f.removed = append(f.removed, keyID)
+	return nil
+}
+
+func azureWith(fake *fakeAzure, allowed ...string) *AzureAppSecretExecutor {
+	e := NewAzureAppSecretExecutor("azure", allowed)
+	e.newClient = func(context.Context) (azureGraphAPI, error) { return fake, nil }
+	return e
+}
+
+func TestAzure_TypeAndName(t *testing.T) {
+	e := NewAzureAppSecretExecutor("prod-azure", nil)
+	assert.Equal(t, "prod-azure", e.Name())
+	assert.Equal(t, "azure-app", e.Type())
+}
+
+func TestAzure_RotateNotSupported(t *testing.T) {
+	err := azureWith(&fakeAzure{}, "app-").Rotate(context.Background(), "app-123", "v")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "GenerateUpstream")
+}
+
+func TestAzure_GenerateUpstream_NoPriorSecrets(t *testing.T) {
+	fake := &fakeAzure{newSecret: "n3w-secret"}
+	v, err := azureWith(fake, "app-").GenerateUpstream(context.Background(), "app-123")
+	require.NoError(t, err)
+	assert.Equal(t, "n3w-secret", v)
+	assert.Equal(t, "app-123", fake.addedFor)
+	assert.Empty(t, fake.removed)
+}
+
+func TestAzure_GenerateUpstream_RemovesPriorSecrets(t *testing.T) {
+	fake := &fakeAzure{existing: []string{"kid1", "kid2"}, newSecret: "n3w"}
+	_, err := azureWith(fake, "app-").GenerateUpstream(context.Background(), "app-123")
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"kid1", "kid2"}, fake.removed, "all prior secrets removed")
+}
+
+func TestAzure_GenerateUpstream_Errors(t *testing.T) {
+	t.Run("empty ref", func(t *testing.T) {
+		_, err := azureWith(&fakeAzure{}, "app-").GenerateUpstream(context.Background(), "")
+		require.Error(t, err)
+	})
+	t.Run("fail-closed without allowed_refs", func(t *testing.T) {
+		_, err := azureWith(&fakeAzure{}).GenerateUpstream(context.Background(), "app-123")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no allowed_refs")
+	})
+	t.Run("guardrail", func(t *testing.T) {
+		fake := &fakeAzure{newSecret: "x"}
+		_, err := azureWith(fake, "app-").GenerateUpstream(context.Background(), "other-999")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not permitted")
+		assert.Empty(t, fake.addedFor, "a disallowed ref never reaches Azure")
+	})
+	t.Run("add error propagates", func(t *testing.T) {
+		fake := &fakeAzure{addErr: errors.New("Forbidden")}
+		_, err := azureWith(fake, "app-").GenerateUpstream(context.Background(), "app-123")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "Forbidden")
+	})
+}

--- a/server/main.go
+++ b/server/main.go
@@ -463,6 +463,14 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 					continue
 				}
 				execs = append(execs, rotation.NewGCPServiceAccountKeyExecutor(b.Name, b.AllowedRefs))
+			case "azure-app":
+				// Generate-upstream backend: Azure mints the client secret via Graph;
+				// credentials come from the ambient Azure chain (no DSN). Fail-closed.
+				if len(b.AllowedRefs) == 0 {
+					log.Printf("Rotation backend %q has no allowed_refs — refusing to register (fail-closed; set allowed_refs)", b.Name)
+					continue
+				}
+				execs = append(execs, rotation.NewAzureAppSecretExecutor(b.Name, b.AllowedRefs))
 			default:
 				log.Printf("Rotation backend %q: unknown type %q, skipping", b.Name, b.Type)
 			}


### PR DESCRIPTION
Completes the **cloud generate-upstream trio** (AWS · GCP · Azure): rotate an Azure AD application's client secret by minting a fresh secret via **Microsoft Graph** (`addPassword`) and removing the app's prior secrets, storing the new secret text.

## Changes
- **`AzureAppSecretExecutor.GenerateUpstream(appObjectId)`**: list prior secret keyIds → `addPassword` → delete prior secrets → return the new `secretText`. Behind a fake-able `azureGraphAPI` seam; the real client calls Graph **over net/http** with an azidentity `DefaultAzureCredential` bearer token (graph `.default` scope) — **no Graph SDK dep** (azidentity/azcore already vendored). Creds from the ambient Azure chain (no DSN); `Rotate()` errors.
- Same **fail-closed `allowed_refs`** (on app object ids); `type: azure-app` wired.
- docs: ADR-047.

No core changes — the `GeneratingExecutor` path drives it.

## Tests
Secret rotation (no prior / prior secrets removed), secret returned, `Rotate` unsupported, fail-closed, guardrail, add-error. gofmt/build/test/gosec/golangci-lint/gitleaks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)