### PR TITLE
feat(secrets): secret-expiry reminders (proactive expiry hygiene)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,6 +25,9 @@ type Config struct {
 	// RotationReminders configures the opt-in background scheduler that notifies
 	// project admins of secrets overdue / approaching their rotation deadline.
 	RotationReminders RotationRemindersConfig `yaml:"rotation_reminders"`
+	// ExpiryReminders configures the opt-in background scheduler that notifies project
+	// admins of secrets that have expired or are approaching their expiration.
+	ExpiryReminders ExpiryRemindersConfig `yaml:"expiry_reminders"`
 	// AutoRotation configures the opt-in background scheduler that actually rotates
 	// auto-rotate-enabled secrets overdue under a policy (ADR-046), regenerating their
 	// value. Distinct from rotation_reminders, which only notifies.
@@ -900,6 +903,24 @@ func (p *SSOProviderConfig) GetClientSecret() string {
 type RotationRemindersConfig struct {
 	Enabled  bool   `yaml:"enabled"`
 	Schedule string `yaml:"schedule"`
+}
+
+// ExpiryRemindersConfig configures the opt-in secret-expiry reminder scheduler.
+type ExpiryRemindersConfig struct {
+	Enabled  bool   `yaml:"enabled"`
+	Schedule string `yaml:"schedule"`
+	LeadDays int    `yaml:"lead_days"` // notify this many days before expiry (0 = default 14)
+}
+
+// GetInterval returns the expiry-reminder run interval (Go duration, e.g. "24h");
+// defaults to 24h when unset or unparseable.
+func (c ExpiryRemindersConfig) GetInterval() time.Duration {
+	if c.Schedule != "" {
+		if d, err := time.ParseDuration(c.Schedule); err == nil && d > 0 {
+			return d
+		}
+	}
+	return 24 * time.Hour
 }
 
 // AutoRotationConfig configures the opt-in automated-rotation scheduler (ADR-046) and

--- a/internal/core/expiry_reminders.go
+++ b/internal/core/expiry_reminders.go
@@ -1,0 +1,130 @@
+// expiry_reminders.go — proactive secret-expiry hygiene: a background scheduler
+// (opt-in, see main.go) finds secrets that are expired or approaching their expiration
+// and notifies project admins, so a secret never silently lapses and breaks its
+// consumers. Mirrors the rotation-reminder mechanism (notify project approvers once,
+// de-duplicating standing reminders).
+package core
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// NotificationExpiryReminder marks an in-app secret-expiry reminder notification.
+const NotificationExpiryReminder = "secret.expiry_reminder"
+
+// SendExpiryReminders finds every secret expiring within leadDays (or already expired)
+// and, for each project with such secrets, sends ONE standing digest notification to
+// each of that project's admins. De-duplicates like rotation reminders: an admin who
+// already has an unread expiry reminder for the project is not re-notified. leadDays <= 0
+// falls back to the default lead window. Returns the number of notifications created.
+func (c *KeyorixCore) SendExpiryReminders(ctx context.Context, leadDays int) (int, error) {
+	if leadDays <= 0 {
+		leadDays = defaultExpiryLeadDays
+	}
+	now := c.now()
+	cutoff := now.Add(time.Duration(leadDays) * 24 * time.Hour)
+	secrets, err := c.listSecretsExpiringBefore(ctx, cutoff)
+	if err != nil {
+		return 0, err
+	}
+
+	// Tally expired / soon-to-expire secrets per project.
+	type counts struct{ expired, soon int }
+	byProject := map[uint]*counts{}
+	for _, s := range secrets {
+		if s.Expiration == nil {
+			continue
+		}
+		ct := byProject[s.ProjectID]
+		if ct == nil {
+			ct = &counts{}
+			byProject[s.ProjectID] = ct
+		}
+		if s.Expiration.Before(now) {
+			ct.expired++
+		} else {
+			ct.soon++
+		}
+	}
+
+	sent := 0
+	for projectID, ct := range byProject {
+		if projectID == 0 || (ct.expired == 0 && ct.soon == 0) {
+			continue
+		}
+		members, err := c.storage.ListProjectMembers(ctx, projectID)
+		if err != nil {
+			continue
+		}
+		pid := projectID
+		msg := expiryReminderMessage(c.projectLabel(ctx, projectID), ct.expired, ct.soon)
+		for _, mbr := range members {
+			if !isApproverRole(mbr.RoleName) {
+				continue
+			}
+			if c.hasUnreadExpiryReminder(ctx, mbr.UserID, projectID) {
+				continue // a standing reminder already exists — don't pile up
+			}
+			c.notify(ctx, mbr.UserID, NotificationExpiryReminder,
+				"Secrets expiring", msg, &pid, "/secrets/expiry")
+			sent++
+		}
+	}
+	return sent, nil
+}
+
+const (
+	defaultExpiryLeadDays  = 14
+	expiryReminderPageSize = 500
+)
+
+// listSecretsExpiringBefore returns every secret (across all projects) whose expiration
+// is set and before cutoff, paging through all of them — expiry evaluation must not
+// silently cap.
+func (c *KeyorixCore) listSecretsExpiringBefore(ctx context.Context, cutoff time.Time) ([]*models.SecretNode, error) {
+	var all []*models.SecretNode
+	for page := 1; ; page++ {
+		secrets, total, err := c.storage.ListSecrets(ctx, &storage.SecretFilter{
+			Page: page, PageSize: expiryReminderPageSize, ExpiresBefore: &cutoff,
+		})
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, secrets...)
+		if len(secrets) < expiryReminderPageSize || int64(len(all)) >= total {
+			break
+		}
+	}
+	return all, nil
+}
+
+// hasUnreadExpiryReminder reports whether the user already has an unread expiry-reminder
+// notification for the given project.
+func (c *KeyorixCore) hasUnreadExpiryReminder(ctx context.Context, userID, projectID uint) bool {
+	notes, err := c.storage.ListNotifications(ctx, userID, true, 100)
+	if err != nil {
+		return false // on a read error, prefer notifying over silently skipping
+	}
+	for _, n := range notes {
+		if n.Type == NotificationExpiryReminder && n.ProjectID != nil && *n.ProjectID == projectID {
+			return true
+		}
+	}
+	return false
+}
+
+func expiryReminderMessage(project string, expired, soon int) string {
+	switch {
+	case expired > 0 && soon > 0:
+		return fmt.Sprintf("%d secret(s) in %s have expired and %d more are expiring soon.", expired, project, soon)
+	case expired > 0:
+		return fmt.Sprintf("%d secret(s) in %s have expired.", expired, project)
+	default:
+		return fmt.Sprintf("%d secret(s) in %s are expiring soon.", soon, project)
+	}
+}

--- a/internal/core/expiry_reminders_test.go
+++ b/internal/core/expiry_reminders_test.go
@@ -1,0 +1,103 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// newExpiryReminderCore sets up a real-SQLite core with one project, a project_admin
+// member (user 5) and a viewer (user 6), and secrets in various expiry states.
+func newExpiryReminderCore(t *testing.T) (*KeyorixCore, *gorm.DB, time.Time) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.User{}, &models.Role{}, &models.UserRole{}, &models.Project{},
+		&models.Environment{}, &models.SecretNode{}, &models.Notification{},
+	))
+
+	now := time.Date(2026, 6, 13, 10, 0, 0, 0, time.UTC)
+	at := func(days int) *time.Time { t := now.AddDate(0, 0, days); return &t }
+	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "payments"}).Error)
+	require.NoError(t, db.Create(&models.Environment{ID: 2, Name: "production", ProjectID: 1}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 5, Username: "ada", Email: "ada@x.io", IsActive: true}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 6, Username: "viewer", Email: "v@x.io", IsActive: true}).Error)
+	require.NoError(t, db.Create(&models.Role{ID: 1, Name: "project_admin"}).Error)
+	require.NoError(t, db.Create(&models.Role{ID: 2, Name: "project_viewer"}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 5, RoleID: 1, ProjectID: 1}).Error) // admin
+	require.NoError(t, db.Create(&models.UserRole{UserID: 6, RoleID: 2, ProjectID: 1}).Error) // viewer
+
+	base := models.SecretNode{ProjectID: 1, EnvironmentID: 2, Type: "password", CreatedAt: now}
+	expired := base
+	expired.ID, expired.Name, expired.Expiration = 10, "expired-key", at(-1) // already expired
+	soon := base
+	soon.ID, soon.Name, soon.Expiration = 11, "soon-key", at(7) // within the 14-day lead
+	far := base
+	far.ID, far.Name, far.Expiration = 12, "far-key", at(60) // outside the lead window
+	noExp := base
+	noExp.ID, noExp.Name = 13, "no-expiry" // no expiration at all
+	for _, s := range []models.SecretNode{expired, soon, far, noExp} {
+		require.NoError(t, db.Create(&s).Error)
+	}
+
+	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: func() time.Time { return now }}
+	return c, db, now
+}
+
+func TestSendExpiryReminders(t *testing.T) {
+	ctx := context.Background()
+	c, db, _ := newExpiryReminderCore(t)
+
+	// First run: the project_admin (user 5) is notified for the expired + soon secrets;
+	// the viewer (user 6) is not; the far-future and no-expiry secrets don't count.
+	sent, err := c.SendExpiryReminders(ctx, 14)
+	require.NoError(t, err)
+	assert.Equal(t, 1, sent, "only the project admin is notified")
+
+	var notes []models.Notification
+	require.NoError(t, db.Where("type = ?", NotificationExpiryReminder).Find(&notes).Error)
+	require.Len(t, notes, 1)
+	assert.Equal(t, uint(5), notes[0].UserID)
+	require.NotNil(t, notes[0].ProjectID)
+	assert.Equal(t, uint(1), *notes[0].ProjectID)
+	assert.Contains(t, notes[0].Message, "expired")
+	assert.Contains(t, notes[0].Message, "expiring soon")
+	assert.Contains(t, notes[0].Message, "payments")
+
+	// Second run while unread: deduped.
+	sent, err = c.SendExpiryReminders(ctx, 14)
+	require.NoError(t, err)
+	assert.Equal(t, 0, sent, "a standing unread reminder is not duplicated")
+
+	// Once read, still-expiring secrets nudge again.
+	require.NoError(t, db.Model(&models.Notification{}).Where("id = ?", notes[0].ID).Update("is_read", true).Error)
+	sent, err = c.SendExpiryReminders(ctx, 14)
+	require.NoError(t, err)
+	assert.Equal(t, 1, sent, "after reading, still-expiring secrets re-notify")
+}
+
+func TestSendExpiryReminders_NothingDue(t *testing.T) {
+	ctx := context.Background()
+	c, db, _ := newExpiryReminderCore(t)
+	// Remove the expired + soon secrets; only far-future and no-expiry remain.
+	require.NoError(t, db.Where("id IN ?", []uint{10, 11}).Delete(&models.SecretNode{}).Error)
+
+	sent, err := c.SendExpiryReminders(ctx, 14)
+	require.NoError(t, err)
+	assert.Equal(t, 0, sent)
+}
+
+func TestExpiryReminderMessage(t *testing.T) {
+	assert.Contains(t, expiryReminderMessage("p", 3, 2), "3 secret(s) in p have expired")
+	assert.Contains(t, expiryReminderMessage("p", 3, 2), "2 more are expiring soon")
+	assert.Equal(t, "1 secret(s) in p have expired.", expiryReminderMessage("p", 1, 0))
+	assert.Contains(t, expiryReminderMessage("p", 0, 4), "expiring soon")
+}

--- a/server/main.go
+++ b/server/main.go
@@ -148,6 +148,7 @@ const (
 	schedLockDynamicSweep int64 = 0x4B455953_44594E53 // "KEYSDYNS"
 	schedLockLoginPrune   int64 = 0x4B455953_4C474E50 // "KEYSLGNP"
 	schedLockRotationRmdr int64 = 0x4B455953_524F5452 // "KEYSROTR"
+	schedLockExpiryRmdr   int64 = 0x4B455953_45585052 // "KEYSEXPR"
 	schedLockAutoRotate   int64 = 0x4B455953_4155544F // "KEYSAUTO"
 	schedLockAuditCkpt    int64 = 0x4B455953_41434B50 // "KEYSACKP"
 	schedLockJITExpiry    int64 = 0x4B455953_4A495445 // "KEYSJITE"
@@ -839,6 +840,43 @@ func startHTTPServer(ctx context.Context, cfg *config.Config) error {
 				select {
 				case <-ticker.C:
 					runReminders()
+				case <-ctx.Done():
+					return
+				}
+			}
+		}()
+	}
+
+	// Start the secret-expiry reminder scheduler — opt-in. Notifies project admins of
+	// secrets that have expired or are approaching expiration, so a secret never silently
+	// lapses. Single-replica-gated (ADR-039) so admins aren't notified N times in HA.
+	if cfg.ExpiryReminders.Enabled {
+		interval := cfg.ExpiryReminders.GetInterval()
+		leadDays := cfg.ExpiryReminders.LeadDays
+		log.Printf("Expiry-reminder scheduler enabled: every %s (lead %dd)", interval, leadDays)
+		go func() {
+			ticker := time.NewTicker(interval)
+			defer ticker.Stop()
+			runExpiry := func() {
+				if _, err := coreService.Storage().WithSchedulerLock(ctx, schedLockExpiryRmdr, func() error {
+					n, rerr := coreService.SendExpiryReminders(ctx, leadDays)
+					if rerr != nil {
+						log.Printf("Expiry-reminder error: %v", rerr)
+						return rerr
+					}
+					if n > 0 {
+						log.Printf("Expiry reminders: sent %d notification(s)", n)
+					}
+					return nil
+				}); err != nil {
+					log.Printf("Expiry-reminder scheduler error: %v", err)
+				}
+			}
+			runExpiry() // run once on startup
+			for {
+				select {
+				case <-ticker.C:
+					runExpiry()
 				case <-ctx.Done():
 					return
 				}


### PR DESCRIPTION
Secrets with an expiration were tracked and displayed but **never proactively flagged** — a secret could silently lapse and break its consumers. This adds an opt-in **expiry-reminder scheduler** mirroring the rotation reminders.

## Changes
- **core**: `SendExpiryReminders(leadDays)` — lists secrets with an expiration before the cutoff (paged, reusing the `SecretFilter.ExpiresBefore` query), tallies **expired vs soon** per project, notifies **approver-role** members (skips viewers) **once** per standing reminder (deduped on unread, so reminders don't pile up). Reuses `notify` / `ListProjectMembers` / `projectLabel`.
- **config**: `expiry_reminders { enabled, schedule, lead_days }` (lead defaults to 14 days).
- **main**: opt-in scheduler, single-replica-gated (ADR-039), mirroring the rotation-reminder block.

## Tests
Admin notified (viewer not) for expired+soon, far-future/no-expiry excluded; dedup while unread + re-notify after read; nothing-due; message variants. gofmt/build/test/gosec/golangci-lint/gitleaks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)