### PR TITLE
feat(secrets): version rollback — restore a prior version's value (operational undo)

### DIFF
--- a/internal/core/rollback_test.go
+++ b/internal/core/rollback_test.go
@@ -1,0 +1,71 @@
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func rollbackCore(t *testing.T) (*KeyorixCore, *gorm.DB) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.AuditEvent{}))
+	return &KeyorixCore{storage: store.NewLocalStorage(db)}, db
+}
+
+func TestRollbackSecret(t *testing.T) {
+	ctx := context.Background()
+	c, db := rollbackCore(t)
+	require.NoError(t, db.Create(&models.SecretNode{ID: 1, Name: "db-password", Type: "password"}).Error)
+	require.NoError(t, db.Create(&models.SecretVersion{
+		SecretNodeID: 1, VersionNumber: 1, EncryptedValue: []byte("v1-secret"), EncryptionMetadata: []byte("{}"),
+	}).Error)
+	// Rotate to v2 (a "bad" change we'll undo).
+	_, err := c.RotateSecret(ctx, 1, []byte("v2-bad"), "ada")
+	require.NoError(t, err)
+
+	// Roll back to v1 → re-instated as a NEW version (v3) with v1's value.
+	secret, err := c.RollbackSecret(ctx, 1, 1, 5, "ada")
+	require.NoError(t, err)
+	require.NotNil(t, secret)
+
+	latest, err := c.storage.GetLatestSecretVersion(ctx, 1)
+	require.NoError(t, err)
+	assert.Equal(t, 3, latest.VersionNumber, "rollback appends a new version")
+	assert.Equal(t, "v1-secret", string(latest.EncryptedValue), "the new version carries the old value")
+
+	// History is append-only: v1 and v2 still exist.
+	versions, err := c.storage.GetSecretVersions(ctx, 1)
+	require.NoError(t, err)
+	assert.Len(t, versions, 3)
+
+	// A rollback was audited.
+	var n int64
+	require.NoError(t, db.Model(&models.AuditEvent{}).Where("event_type = ?", EventSecretRolledBack).Count(&n).Error)
+	assert.Equal(t, int64(1), n)
+}
+
+func TestRollbackSecret_Errors(t *testing.T) {
+	ctx := context.Background()
+	c, db := rollbackCore(t)
+	require.NoError(t, db.Create(&models.SecretNode{ID: 1, Name: "k", Type: "password"}).Error)
+	require.NoError(t, db.Create(&models.SecretVersion{
+		SecretNodeID: 1, VersionNumber: 1, EncryptedValue: []byte("v1"), EncryptionMetadata: []byte("{}"),
+	}).Error)
+
+	// Rolling back to the current (only) version is a no-op → rejected.
+	_, err := c.RollbackSecret(ctx, 1, 1, 5, "ada")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already the current version")
+
+	// An unknown version is rejected.
+	_, err = c.RollbackSecret(ctx, 1, 99, 5, "ada")
+	require.Error(t, err)
+}

--- a/internal/core/versions.go
+++ b/internal/core/versions.go
@@ -149,6 +149,43 @@ func (c *KeyorixCore) GetSecretValueByVersion(ctx context.Context, secretID uint
 	return version.EncryptedValue, nil
 }
 
+// EventSecretRolledBack is audited when a secret is restored to a prior version.
+const EventSecretRolledBack = "secret.rolled_back"
+
+// RollbackSecret restores a secret to the value of a prior version by re-instating that
+// value as a NEW version — version history stays append-only (the rollback itself is a
+// new version, so it too can be undone). The caller (transport) must have enforced
+// scoped secrets.write. Unlike a value read, this fetches the historical version
+// directly (no max-reads / expiry guard) since a restore is a write, not a use.
+func (c *KeyorixCore) RollbackSecret(ctx context.Context, secretID uint, targetVersion int, actorID uint, actorName string) (*models.SecretNode, error) {
+	version, err := c.GetSecretVersion(ctx, secretID, targetVersion)
+	if err != nil {
+		return nil, err
+	}
+	latest, err := c.storage.GetLatestSecretVersion(ctx, secretID)
+	if err == nil && latest != nil && latest.VersionNumber == targetVersion {
+		return nil, fmt.Errorf("version %d is already the current version", targetVersion)
+	}
+	var val []byte
+	if c.encryption != nil {
+		val, err = c.encryption.RetrieveSecret(version.ID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read version %d: %w", targetVersion, err)
+		}
+	} else {
+		val = version.EncryptedValue
+	}
+	secret, err := c.RotateSecret(ctx, secretID, val, actorName)
+	if err != nil {
+		return nil, err
+	}
+	uid := actorID
+	sid := secretID
+	c.writeAuditEvent(ctx, EventSecretRolledBack, &uid, &sid,
+		fmt.Sprintf("rolled back secret %q to the value of version %d", secret.Name, targetVersion))
+	return secret, nil
+}
+
 // GetSecretValueByVersionWithPermissionCheck retrieves the decrypted value of a specific version with permission validation.
 func (c *KeyorixCore) GetSecretValueByVersionWithPermissionCheck(ctx context.Context, secretID, userID uint, versionNumber int) ([]byte, error) {
 	if userID == 0 {

--- a/server/http/handlers/secrets_versions.go
+++ b/server/http/handlers/secrets_versions.go
@@ -6,6 +6,7 @@ package handlers
 
 import (
 	"encoding/json"
+	"fmt"
 	"log"
 	"net/http"
 	"strconv"
@@ -97,4 +98,43 @@ func (h *SecretHandler) RotateSecret(w http.ResponseWriter, r *http.Request) {
 	go h.coreService.LogSecretRotatedWithProject(core.DetachedAuditContext(r.Context()), userCtx.UserID, uint(id), secret.ProjectID, userCtx.Username, secret.Name, ip, ua) // #nosec G118
 
 	h.sendSuccess(w, secret, "Secret rotated successfully")
+}
+
+// RollbackSecret handles POST /api/v1/secrets/{id}/rollback — restores the secret to a
+// prior version's value as a new version. Scoped secrets.write (route-gated).
+func (h *SecretHandler) RollbackSecret(w http.ResponseWriter, r *http.Request) {
+	userCtx := middleware.GetUserFromContext(r.Context())
+	if userCtx == nil {
+		h.sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 64)
+	if err != nil {
+		h.sendError(w, "BadRequest", "Invalid secret ID", http.StatusBadRequest, nil)
+		return
+	}
+	var reqBody struct {
+		Version int `json:"version" validate:"required"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
+		h.sendError(w, "InvalidJSON", "Invalid JSON in request body", http.StatusBadRequest, nil)
+		return
+	}
+	if reqBody.Version <= 0 {
+		h.sendError(w, "ValidationError", "version must be a positive version number", http.StatusBadRequest, nil)
+		return
+	}
+	secret, err := h.coreService.RollbackSecret(r.Context(), uint(id), reqBody.Version, userCtx.UserID, userCtx.Username)
+	if err != nil {
+		switch {
+		case strings.Contains(err.Error(), "not found"):
+			h.sendError(w, "NotFound", err.Error(), http.StatusNotFound, nil)
+		case strings.Contains(err.Error(), "already the current version"), strings.Contains(err.Error(), "version number must be positive"):
+			h.sendError(w, "ValidationError", err.Error(), http.StatusBadRequest, nil)
+		default:
+			h.sendError(w, "InternalError", "Failed to roll back secret", http.StatusInternalServerError, nil)
+		}
+		return
+	}
+	h.sendSuccess(w, secret, fmt.Sprintf("Secret rolled back to version %d", reqBody.Version))
 }

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -329,6 +329,7 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.With(customMiddleware.RequireScopedPermission("secrets.write", secretScope)).Patch("/{id}/classification", secretHandler.ClassifySecret)
 			r.With(customMiddleware.RequireScopedPermission("secrets.write", secretScope)).Patch("/{id}/auto-rotate", secretHandler.SetAutoRotate)
 			r.With(customMiddleware.RequireScopedPermission("secrets.write", secretScope)).Post("/{id}/rotate", secretHandler.RotateSecret)
+			r.With(customMiddleware.RequireScopedPermission("secrets.write", secretScope)).Post("/{id}/rollback", secretHandler.RollbackSecret)
 			r.With(customMiddleware.RequireScopedPermission("secrets.write", secretScope)).Post("/{id}/share", shareHandler.ShareSecret)
 
 			r.With(customMiddleware.RequireScopedPermission("secrets.delete", secretScope)).Delete("/{id}", secretHandler.DeleteSecret)


### PR DESCRIPTION
Lets an operator **undo a bad secret change or rotation** by restoring a prior version's value. The restore is re-instated as a **new version**, so history stays append-only (the rollback itself can be undone), and it's audited as `secret.rolled_back`.

## Changes
- **core**: `RollbackSecret(secretID, targetVersion, actorID, actorName)` — fetches the historical version directly (no max-reads/expiry guard, since a restore is a *write* not a *use*), refuses rolling back to the current head, re-instates the value via the existing rotate path, and audits. Reuses `GetSecretVersion` + `encryption.RetrieveSecret`.
- **http**: `POST /secrets/{id}/rollback {version}`, scoped `secrets.write` (route-gated, like `/rotate`); unknown version → `404`, current-version/invalid → `400`.

## Security
No new trust surface — it restores a value the writer already has access to, reusing the rotate + version machinery (route-gated `secrets.write`). The new mutating route is verified **403** to a read-only persona.

## Tests
Rollback appends a new version with the old value, history append-only, audited; reject current-version and unknown-version. gofmt/build/test/gosec/golangci-lint/gitleaks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)