### PR TITLE
feat(cli): secret rollback command (parity with HTTP/web)

### DIFF
--- a/internal/cli/secret/rollback.go
+++ b/internal/cli/secret/rollback.go
@@ -1,0 +1,58 @@
+package secret
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/spf13/cobra"
+)
+
+var (
+	rollbackID      uint
+	rollbackVersion int
+)
+
+var rollbackCmd = &cobra.Command{
+	Use:   "rollback",
+	Short: "Restore a secret to the value of a prior version",
+	Long: `Restore a secret to an earlier version's value. The old value is re-instated as a
+NEW version (history stays append-only, so the rollback itself can be undone).
+
+List the available versions with: keyorix secret versions --id <id>.
+Requires secrets.write at the secret's scope.`,
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		if rollbackID == 0 {
+			return fmt.Errorf("--id is required")
+		}
+		if rollbackVersion <= 0 {
+			return fmt.Errorf("--version must be a positive version number")
+		}
+		c, ok := common.NewRemoteClient()
+		if !ok {
+			return fmt.Errorf("not connected to a server — run: keyorix connect <server>")
+		}
+		return runRollbackRemote(c, rollbackID, rollbackVersion)
+	},
+}
+
+// runRollbackRemote POSTs the rollback request to the server. Split out from the
+// command so it can be exercised against an httptest server.
+func runRollbackRemote(c *common.RemoteClient, id uint, version int) error {
+	body := map[string]interface{}{"version": version}
+	var out struct{}
+	path := "/api/v1/secrets/" + strconv.Itoa(int(id)) + "/rollback"
+	if err := c.Post(context.Background(), path, body, &out); err != nil {
+		return err
+	}
+	fmt.Printf("✓ Secret %d rolled back to the value of version %d (as a new version).\n", id, version)
+	return nil
+}
+
+func init() {
+	rollbackCmd.Flags().UintVar(&rollbackID, "id", 0, "Secret ID (required)")
+	rollbackCmd.Flags().IntVar(&rollbackVersion, "version", 0, "Version number to restore (required)")
+	SecretCmd.AddCommand(rollbackCmd)
+}

--- a/internal/cli/secret/rollback_remote_test.go
+++ b/internal/cli/secret/rollback_remote_test.go
@@ -1,0 +1,56 @@
+package secret
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// runRollbackRemote should POST {"version":N} to /secrets/{id}/rollback and
+// surface server errors verbatim.
+func TestRunRollbackRemote(t *testing.T) {
+	var gotPath string
+	var postBody map[string]interface{}
+	status := http.StatusOK
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		gotPath = r.URL.Path
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &postBody)
+		if status != http.StatusOK {
+			w.WriteHeader(status)
+			return
+		}
+		_, _ = w.Write([]byte(`{"data":{"ID":42,"Name":"db-pass"}}`))
+	}))
+	defer srv.Close()
+
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+	rc, ok := common.NewRemoteClient()
+	require.True(t, ok)
+
+	t.Run("posts version to the rollback route", func(t *testing.T) {
+		status = http.StatusOK
+		postBody = nil
+		require.NoError(t, runRollbackRemote(rc, 42, 3))
+		assert.Equal(t, "/api/v1/secrets/42/rollback", gotPath)
+		assert.EqualValues(t, 3, postBody["version"])
+	})
+
+	t.Run("surfaces a server error (e.g. current/unknown version)", func(t *testing.T) {
+		status = http.StatusBadRequest
+		err := runRollbackRemote(rc, 42, 9)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "400")
+	})
+}


### PR DESCRIPTION
## Summary

Adds a `secret rollback` CLI command, bringing the rollback surface to the CLI alongside the existing `secret rotate`. Pairs with the server-side rollback (#282) and the web Rollback action (keyorix-web #53).

```
keyorix secret rollback --id <id> --version <n>
```

It POSTs `{version}` to `/api/v1/secrets/{id}/rollback` through the shared `RemoteClient` seam; the server re-instates the chosen version's value as a **new** version (history stays append-only) and enforces scoped `secrets.write`. `--id` / `--version` are validated locally and server errors (unknown / current version → 400/404) are surfaced verbatim.

The request core is split into `runRollbackRemote(rc, id, version)` so it's testable against an `httptest` server.

**Note:** gRPC has no discrete rotate RPC (rotation goes through `UpdateSecret`), so a gRPC rollback RPC is intentionally deferred — it would be net-new surface, not parity.

## Test plan

- `go build ./...` ✅
- `go test ./internal/cli/secret/` ✅ — new `TestRunRollbackRemote`: asserts the route + body, and that a server error passes through.
- `gosec -severity medium` ✅ · `golangci-lint` ✅ (0 issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)