### PR TITLE
feat(sharing): time-bound (expiring) secret shares — JIT secret access

### DIFF
--- a/internal/core/group_sharing.go
+++ b/internal/core/group_sharing.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
@@ -14,6 +15,8 @@ type GroupShareSecretRequest struct {
 	GroupID    uint   `json:"group_id" validate:"required"`
 	Permission string `json:"permission" validate:"required,oneof=read write"`
 	SharedBy   uint   `json:"shared_by" validate:"required"`
+	// ExpiresAt, when set, makes the group share time-bound; see ShareSecretRequest.ExpiresAt.
+	ExpiresAt *time.Time `json:"expires_at,omitempty"`
 }
 
 // ShareSecretWithGroup shares a secret with a group
@@ -35,6 +38,11 @@ func (c *KeyorixCore) ShareSecretWithGroup(ctx context.Context, req *GroupShareS
 		return nil, fmt.Errorf("not authorized to share this secret")
 	}
 
+	// A time-bound share must expire in the future (see ShareSecret).
+	if req.ExpiresAt != nil && !req.ExpiresAt.After(c.now()) {
+		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "share expiry must be in the future")
+	}
+
 	// Create share record
 	shareRecord := &models.ShareRecord{
 		SecretID:    req.SecretID,
@@ -42,6 +50,7 @@ func (c *KeyorixCore) ShareSecretWithGroup(ctx context.Context, req *GroupShareS
 		RecipientID: req.GroupID,
 		IsGroup:     true,
 		Permission:  req.Permission,
+		ExpiresAt:   req.ExpiresAt,
 	}
 
 	// Validate the group share record

--- a/internal/core/jit_access.go
+++ b/internal/core/jit_access.go
@@ -34,6 +34,31 @@ func (c *KeyorixCore) AssignGroupRoleWithExpiry(ctx context.Context, actorID, gr
 	return nil
 }
 
+// EventShareExpired is audited when a time-bound secret share is swept after expiry.
+const EventShareExpired = "share.expired"
+
+// RemoveExpiredShares removes every time-bound secret share whose expiry is at or
+// before `before` and audits each as share.expired (the system sweep, no actor).
+// Returns the number removed. Idempotent. Expired shares already stop authorizing
+// the instant they pass (the permission queries filter on expiry); this just reclaims
+// the rows and writes the expiry audit trail. Backs the JIT access-expiry scheduler.
+func (c *KeyorixCore) RemoveExpiredShares(ctx context.Context, before time.Time) (int, error) {
+	removed, err := c.storage.DeleteExpiredShareRecords(ctx, before)
+	if err != nil {
+		return 0, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	for _, s := range removed {
+		sid := s.SecretID
+		recipientKind := "user"
+		if s.IsGroup {
+			recipientKind = "group"
+		}
+		c.writeAuditEvent(ctx, EventShareExpired, nil, &sid,
+			fmt.Sprintf("time-bound share of secret %d expired for %s %d", s.SecretID, recipientKind, s.RecipientID))
+	}
+	return len(removed), nil
+}
+
 // RemoveExpiredRoleGrants removes every user/group role grant whose expiry is at or
 // before `before` and audits each as role.expired (actor 0 = the system sweep).
 // Returns the number of grants removed. Idempotent — a tick that finds nothing

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -573,6 +573,14 @@ func (m *MockStorage) CheckSharePermission(ctx context.Context, secretID, userID
 	return args.String(0), args.Error(1)
 }
 
+func (m *MockStorage) DeleteExpiredShareRecords(ctx context.Context, before time.Time) ([]*models.ShareRecord, error) {
+	args := m.Called(ctx, before)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*models.ShareRecord), args.Error(1)
+}
+
 // User Management
 
 func (m *MockStorage) CreateUser(ctx context.Context, user *models.User) (*models.User, error) {

--- a/internal/core/permissions.go
+++ b/internal/core/permissions.go
@@ -3,11 +3,31 @@ package core
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
+
+// shareActive reports whether a share still authorizes at time now: a nil ExpiresAt
+// is permanent, otherwise the share stops authorizing the instant it passes (a
+// time-bound / JIT secret share, mirroring UserRole.ExpiresAt). The JIT sweeper later
+// reclaims the row, but enforcement denies an expired share immediately regardless.
+func shareActive(share *models.ShareRecord, now time.Time) bool {
+	return share.ExpiresAt == nil || now.Before(*share.ExpiresAt)
+}
+
+// activeShares returns only the shares still authorizing at now (drops expired ones).
+func activeShares(shares []*models.ShareRecord, now time.Time) []*models.ShareRecord {
+	active := make([]*models.ShareRecord, 0, len(shares))
+	for _, s := range shares {
+		if shareActive(s, now) {
+			active = append(active, s)
+		}
+	}
+	return active
+}
 
 // secretOwnedBy reports whether actorID is the owner of a secret with the given
 // OwnerID. A zero OwnerID means the secret has NO human owner — e.g. one created by
@@ -67,6 +87,9 @@ func (c *KeyorixCore) CheckSecretPermission(ctx context.Context, secretID, userI
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
 	}
+	// Drop expired (time-bound) shares before any authorization: an expired share
+	// must never grant access, even though the sweep that reclaims its row runs later.
+	shares = activeShares(shares, c.now())
 
 	// Check direct shares.
 	for _, share := range shares {

--- a/internal/core/secret_listing_sharing.go
+++ b/internal/core/secret_listing_sharing.go
@@ -71,6 +71,9 @@ func (c *KeyorixCore) GetSecretSharingStatusWithIndicators(ctx context.Context, 
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
 	}
+	// Expired (time-bound) shares no longer authorize, so the reported sharing
+	// status must not count or display them — keep it consistent with enforcement.
+	shares = activeShares(shares, c.now())
 
 	isOwner := secretOwnedBy(secret.OwnerID, userID)
 	userPermission := ""
@@ -145,6 +148,8 @@ func (c *KeyorixCore) GetUserSecretPermission(ctx context.Context, secretID, use
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
 	}
+	// An expired share grants no permission — match the authorization gate.
+	shares = activeShares(shares, c.now())
 
 	for _, share := range shares {
 		if !share.IsGroup && share.RecipientID == userID {

--- a/internal/core/shares_expiry_test.go
+++ b/internal/core/shares_expiry_test.go
@@ -1,0 +1,174 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// newSharesExpiryFixture spins up an in-memory core with an owner (1) and two recipients
+// (2, 3), one owned secret, and a controllable clock seeded to the real wall clock. The
+// clock matters for core-level enforcement (CheckSecretPermission uses c.now()), while
+// the storage listing/permission queries use time.Now() directly — so the fixture's base
+// is the real now to keep the two in agreement. Returns the core, secret ID, base now, db.
+func newSharesExpiryFixture(t *testing.T) (*KeyorixCore, uint, time.Time, *gorm.DB) {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+
+	// Private in-memory DB (no shared cache) so each fixture is fully isolated; a
+	// single connection keeps the one :memory: database alive for the test's duration.
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	sqlDB.SetMaxOpenConns(1)
+
+	require.NoError(t, db.AutoMigrate(
+		&models.SecretNode{}, &models.SecretVersion{}, &models.ShareRecord{},
+		&models.AuditEvent{}, &models.User{}, &models.Group{}, &models.UserGroup{},
+	))
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "owner", Email: "owner@test.com"}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 2, Username: "recip2", Email: "recip2@test.com"}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 3, Username: "recip3", Email: "recip3@test.com"}).Error)
+
+	now := time.Now()
+	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: func() time.Time { return now }}
+
+	secret, err := c.storage.CreateSecret(context.Background(), &models.SecretNode{
+		Name: "s", ProjectID: 1, EnvironmentID: 1, Type: "password", OwnerID: 1, IsSecret: true,
+		CreatedAt: now, UpdatedAt: now,
+	})
+	require.NoError(t, err)
+	return c, secret.ID, now, db
+}
+
+func TestShareExpiry_Enforcement(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("active future-dated share authorizes and lists", func(t *testing.T) {
+		c, secretID, now, _ := newSharesExpiryFixture(t)
+		future := now.Add(time.Hour)
+		_, err := c.ShareSecret(ctx, &ShareSecretRequest{
+			SecretID: secretID, RecipientID: 2, Permission: "read", SharedBy: 1, ExpiresAt: &future,
+		})
+		require.NoError(t, err)
+
+		_, err = c.CheckSecretPermission(ctx, secretID, 2, PermissionRead)
+		require.NoError(t, err, "an unexpired share must grant read")
+
+		shared, err := c.ListSharedSecrets(ctx, 2)
+		require.NoError(t, err)
+		assert.Len(t, shared, 1)
+	})
+
+	t.Run("expired share denies (core enforcement via clock)", func(t *testing.T) {
+		c, secretID, now := mustShare(t)
+		// Create with a future expiry (passes validation), then advance the clock past it.
+		exp := now.Add(time.Minute)
+		_, err := c.ShareSecret(ctx, &ShareSecretRequest{
+			SecretID: secretID, RecipientID: 2, Permission: "read", SharedBy: 1, ExpiresAt: &exp,
+		})
+		require.NoError(t, err)
+
+		c.now = func() time.Time { return now.Add(time.Hour) }
+		_, err = c.CheckSecretPermission(ctx, secretID, 2, PermissionRead)
+		require.Error(t, err, "an expired share must NOT grant access")
+	})
+
+	t.Run("expired share is hidden from the shared-with-me listing", func(t *testing.T) {
+		c, secretID, now, db := newSharesExpiryFixture(t)
+		// Insert an already-expired row directly (ShareSecret would reject a past expiry).
+		past := now.Add(-time.Minute)
+		require.NoError(t, db.Create(&models.ShareRecord{
+			SecretID: secretID, OwnerID: 1, RecipientID: 2, Permission: "read", ExpiresAt: &past,
+		}).Error)
+
+		shared, err := c.ListSharedSecrets(ctx, 2)
+		require.NoError(t, err)
+		assert.Empty(t, shared, "an expired share must not surface in the shared-with-me list")
+
+		_, err = c.CheckSecretPermission(ctx, secretID, 2, PermissionRead)
+		require.Error(t, err, "an expired share must not authorize")
+	})
+
+	t.Run("share with a past expiry is rejected at creation", func(t *testing.T) {
+		c, secretID, now, _ := newSharesExpiryFixture(t)
+		past := now.Add(-time.Minute)
+		_, err := c.ShareSecret(ctx, &ShareSecretRequest{
+			SecretID: secretID, RecipientID: 2, Permission: "read", SharedBy: 1, ExpiresAt: &past,
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "future")
+	})
+
+	t.Run("permanent share (nil expiry) keeps authorizing", func(t *testing.T) {
+		c, secretID, now, _ := newSharesExpiryFixture(t)
+		_, err := c.ShareSecret(ctx, &ShareSecretRequest{
+			SecretID: secretID, RecipientID: 2, Permission: "read", SharedBy: 1,
+		})
+		require.NoError(t, err)
+		c.now = func() time.Time { return now.Add(1000 * time.Hour) }
+		_, err = c.CheckSecretPermission(ctx, secretID, 2, PermissionRead)
+		require.NoError(t, err)
+	})
+}
+
+// mustShare is a thin wrapper returning just the core, secret, and base now for the
+// subtests that don't need the db handle.
+func mustShare(t *testing.T) (*KeyorixCore, uint, time.Time) {
+	t.Helper()
+	c, secretID, now, _ := newSharesExpiryFixture(t)
+	return c, secretID, now
+}
+
+func TestRemoveExpiredShares(t *testing.T) {
+	ctx := context.Background()
+	c, secretID, now, db := newSharesExpiryFixture(t)
+
+	// A soon-to-expire share for recipient 2.
+	exp := now.Add(time.Minute)
+	expiring, err := c.ShareSecret(ctx, &ShareSecretRequest{
+		SecretID: secretID, RecipientID: 2, Permission: "read", SharedBy: 1, ExpiresAt: &exp,
+	})
+	require.NoError(t, err)
+	// A permanent share for a different recipient (3) so it isn't upserted onto the first.
+	permanent, err := c.ShareSecret(ctx, &ShareSecretRequest{
+		SecretID: secretID, RecipientID: 3, Permission: "read", SharedBy: 1,
+	})
+	require.NoError(t, err)
+
+	// Sweeping before the expiry removes nothing (no-op tick is idempotent).
+	n, err := c.RemoveExpiredShares(ctx, now)
+	require.NoError(t, err)
+	assert.Equal(t, 0, n)
+
+	// Sweeping after the expiry removes exactly the expired share.
+	n, err = c.RemoveExpiredShares(ctx, now.Add(time.Hour))
+	require.NoError(t, err)
+	assert.Equal(t, 1, n)
+
+	// The permanent share survives; the expired one is gone.
+	shares, err := c.storage.ListSharesBySecret(ctx, secretID)
+	require.NoError(t, err)
+	require.Len(t, shares, 1)
+	assert.Equal(t, permanent.ID, shares[0].ID)
+	assert.NotEqual(t, expiring.ID, shares[0].ID)
+
+	// A second sweep is a no-op.
+	n, err = c.RemoveExpiredShares(ctx, now.Add(2*time.Hour))
+	require.NoError(t, err)
+	assert.Equal(t, 0, n)
+
+	// The expiry was audited as share.expired.
+	var count int64
+	require.NoError(t, db.Model(&models.AuditEvent{}).Where("event_type = ?", EventShareExpired).Count(&count).Error)
+	assert.EqualValues(t, 1, count)
+}

--- a/internal/core/sharing.go
+++ b/internal/core/sharing.go
@@ -8,6 +8,7 @@ package core
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
@@ -20,6 +21,9 @@ type ShareSecretRequest struct {
 	IsGroup     bool   `json:"is_group"`
 	Permission  string `json:"permission" validate:"required,oneof=read write"`
 	SharedBy    uint   `json:"shared_by" validate:"required"`
+	// ExpiresAt, when set, makes the share time-bound (just-in-time access): it stops
+	// authorizing the instant it passes and is later swept. nil = a permanent share.
+	ExpiresAt *time.Time `json:"expires_at,omitempty"`
 }
 
 // UpdateShareRequest represents a request to update a share's permissions.
@@ -47,12 +51,19 @@ func (c *KeyorixCore) ShareSecret(ctx context.Context, req *ShareSecretRequest) 
 		return nil, fmt.Errorf("%s", i18n.T("ErrorPermissionDenied", nil))
 	}
 
+	// A time-bound share must expire in the future; a past/now expiry would create a
+	// share that never authorizes.
+	if req.ExpiresAt != nil && !req.ExpiresAt.After(c.now()) {
+		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "share expiry must be in the future")
+	}
+
 	shareRecord := &models.ShareRecord{
 		SecretID:    req.SecretID,
 		OwnerID:     secret.OwnerID,
 		RecipientID: req.RecipientID,
 		IsGroup:     req.IsGroup,
 		Permission:  req.Permission,
+		ExpiresAt:   req.ExpiresAt,
 	}
 	createdShare, err := c.storage.CreateShareRecord(ctx, shareRecord)
 	if err != nil {

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -208,6 +208,10 @@ type Storage interface {
 	ListSharesByGroup(ctx context.Context, groupID uint) ([]*models.ShareRecord, error)
 	ListSharedSecrets(ctx context.Context, userID uint) ([]*models.SecretNode, error)
 	CheckSharePermission(ctx context.Context, secretID, userID uint) (string, error)
+	// DeleteExpiredShareRecords removes time-bound shares whose ExpiresAt is non-NULL
+	// and at or before the cutoff, returning the removed rows so the caller can audit
+	// each expiry. Server-side only (run by the JIT expiry scheduler).
+	DeleteExpiredShareRecords(ctx context.Context, before time.Time) ([]*models.ShareRecord, error)
 
 	// User Management
 	CreateUser(ctx context.Context, user *models.User) (*models.User, error)

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -821,9 +821,14 @@ type ShareRecord struct {
 	RecipientID uint   `gorm:"index"`
 	IsGroup     bool   `gorm:"default:false"`
 	Permission  string `gorm:"default:read"` // "read" or "write"
-	CreatedAt   time.Time
-	UpdatedAt   time.Time
-	DeletedAt   gorm.DeletedAt `gorm:"index"`
+	// ExpiresAt makes a share time-bound (just-in-time secret access): nil = permanent;
+	// otherwise the share stops authorizing the moment it passes and is swept by the
+	// JIT expiry scheduler. The permission queries filter on it directly so an expired
+	// share is denied immediately, before the sweep removes the row. Mirrors UserRole.ExpiresAt.
+	ExpiresAt *time.Time `gorm:"index"`
+	CreatedAt time.Time
+	UpdatedAt time.Time
+	DeletedAt gorm.DeletedAt `gorm:"index"`
 }
 
 type GRPCService struct {

--- a/internal/storage/store/local_sharing.go
+++ b/internal/storage/store/local_sharing.go
@@ -116,6 +116,33 @@ func (ls *LocalStorage) DeleteShareRecord(ctx context.Context, shareID uint) err
 	return nil
 }
 
+// DeleteExpiredShareRecords soft-deletes time-bound shares whose ExpiresAt is
+// non-NULL and at or before the cutoff, returning the removed rows so the caller can
+// audit each. Runs in a transaction so the rows it reports are exactly the rows it
+// removed. Idempotent — a tick that finds nothing removes nothing.
+func (ls *LocalStorage) DeleteExpiredShareRecords(ctx context.Context, before time.Time) ([]*models.ShareRecord, error) {
+	var removed []*models.ShareRecord
+	err := ls.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Where(
+			"expires_at IS NOT NULL AND expires_at <= ? AND deleted_at IS NULL", before,
+		).Find(&removed).Error; err != nil {
+			return err
+		}
+		if len(removed) == 0 {
+			return nil
+		}
+		ids := make([]uint, len(removed))
+		for i, s := range removed {
+			ids[i] = s.ID
+		}
+		return tx.Where("id IN ?", ids).Delete(&models.ShareRecord{}).Error
+	})
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorDatabaseOperation", nil), err)
+	}
+	return removed, nil
+}
+
 // ListSharesBySecret lists active share records for a secret.
 func (ls *LocalStorage) ListSharesBySecret(ctx context.Context, secretID uint) ([]*models.ShareRecord, error) {
 	var shares []*models.ShareRecord
@@ -155,12 +182,16 @@ func (ls *LocalStorage) ListSharesByGroup(ctx context.Context, groupID uint) ([]
 // ListSharedSecrets returns all secrets shared with userID, directly or via group membership.
 func (ls *LocalStorage) ListSharedSecrets(ctx context.Context, userID uint) ([]*models.SecretNode, error) {
 	var secrets []*models.SecretNode
+	// Expired (time-bound) shares no longer authorize, so they must not surface in
+	// the "shared with me" listing either — filter them the same way the auth queries do.
+	now := time.Now()
 	directQuery := `
 		SELECT s.* FROM secret_nodes s
 		JOIN share_records sr ON s.id = sr.secret_id
 		WHERE sr.recipient_id = ? AND sr.is_group = ? AND sr.deleted_at IS NULL AND s.deleted_at IS NULL
+		  AND (sr.expires_at IS NULL OR sr.expires_at > ?)
 	`
-	if err := ls.db.Raw(directQuery, userID, false).Scan(&secrets).Error; err != nil {
+	if err := ls.db.Raw(directQuery, userID, false, now).Scan(&secrets).Error; err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorDatabaseOperation", nil), err)
 	}
 
@@ -169,9 +200,10 @@ func (ls *LocalStorage) ListSharedSecrets(ctx context.Context, userID uint) ([]*
 		JOIN share_records sr ON s.id = sr.secret_id
 		JOIN user_groups ug ON sr.recipient_id = ug.group_id
 		WHERE ug.user_id = ? AND sr.is_group = ? AND sr.deleted_at IS NULL AND s.deleted_at IS NULL
+		  AND (sr.expires_at IS NULL OR sr.expires_at > ?)
 	`
 	var groupSecrets []*models.SecretNode
-	if err := ls.db.Raw(groupQuery, userID, true).Scan(&groupSecrets).Error; err != nil {
+	if err := ls.db.Raw(groupQuery, userID, true, now).Scan(&groupSecrets).Error; err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorDatabaseOperation", nil), err)
 	}
 
@@ -193,10 +225,12 @@ func (ls *LocalStorage) CheckSharePermission(ctx context.Context, secretID, user
 		return "write", nil
 	}
 
+	// Skip expired (time-bound) shares — an expired share grants no permission.
+	now := time.Now()
 	var directShare models.ShareRecord
 	err := ls.db.Where(
-		"secret_id = ? AND recipient_id = ? AND is_group = ? AND deleted_at IS NULL",
-		secretID, userID, false,
+		"secret_id = ? AND recipient_id = ? AND is_group = ? AND deleted_at IS NULL AND (expires_at IS NULL OR expires_at > ?)",
+		secretID, userID, false, now,
 	).First(&directShare).Error
 	if err == nil {
 		return directShare.Permission, nil
@@ -209,9 +243,10 @@ func (ls *LocalStorage) CheckSharePermission(ctx context.Context, secretID, user
 		SELECT sr.* FROM share_records sr
 		JOIN user_groups ug ON sr.recipient_id = ug.group_id
 		WHERE sr.secret_id = ? AND ug.user_id = ? AND sr.is_group = ? AND sr.deleted_at IS NULL
+		  AND (sr.expires_at IS NULL OR sr.expires_at > ?)
 		LIMIT 1
 	`
-	res := ls.db.Raw(groupQuery, secretID, userID, true).Scan(&groupShare)
+	res := ls.db.Raw(groupQuery, secretID, userID, true, now).Scan(&groupShare)
 	if res.Error == nil && groupShare.ID != 0 {
 		return groupShare.Permission, nil
 	} else if res.Error != nil && !errors.Is(res.Error, gorm.ErrRecordNotFound) {

--- a/internal/storage/store/remote_sharing.go
+++ b/internal/storage/store/remote_sharing.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
@@ -169,4 +170,9 @@ func (rs *RemoteStorage) CheckSharePermission(ctx context.Context, secretID, use
 		return "", fmt.Errorf("failed to parse response: %w", err)
 	}
 	return result.Permission, nil
+}
+
+// DeleteExpiredShareRecords is server-side only (run by the JIT expiry scheduler).
+func (rs *RemoteStorage) DeleteExpiredShareRecords(_ context.Context, _ time.Time) ([]*models.ShareRecord, error) {
+	return nil, remoteUnsupported("DeleteExpiredShareRecords")
 }

--- a/server/http/handlers/shares_crud.go
+++ b/server/http/handlers/shares_crud.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/keyorixhq/keyorix/internal/core"
@@ -33,9 +34,10 @@ func (h *ShareHandler) ShareSecret(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var reqBody struct {
-		RecipientID uint   `json:"recipient_id" validate:"required"`
-		IsGroup     bool   `json:"is_group"`
-		Permission  string `json:"permission" validate:"required,oneof=read write"`
+		RecipientID uint       `json:"recipient_id" validate:"required"`
+		IsGroup     bool       `json:"is_group"`
+		Permission  string     `json:"permission" validate:"required,oneof=read write"`
+		ExpiresAt   *time.Time `json:"expires_at"` // optional: time-bound (JIT) share
 	}
 	if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
 		h.sendError(w, "InvalidJSON", "Invalid JSON in request body", http.StatusBadRequest, nil)
@@ -55,6 +57,7 @@ func (h *ShareHandler) ShareSecret(w http.ResponseWriter, r *http.Request) {
 			GroupID:    reqBody.RecipientID,
 			Permission: reqBody.Permission,
 			SharedBy:   userCtx.UserID,
+			ExpiresAt:  reqBody.ExpiresAt,
 		})
 	} else {
 		shareRecord, shareErr = h.coreService.ShareSecret(r.Context(), &core.ShareSecretRequest{
@@ -63,6 +66,7 @@ func (h *ShareHandler) ShareSecret(w http.ResponseWriter, r *http.Request) {
 			IsGroup:     false,
 			Permission:  reqBody.Permission,
 			SharedBy:    userCtx.UserID,
+			ExpiresAt:   reqBody.ExpiresAt,
 		})
 	}
 
@@ -72,6 +76,8 @@ func (h *ShareHandler) ShareSecret(w http.ResponseWriter, r *http.Request) {
 			h.sendError(w, "NotFound", "Secret not found", http.StatusNotFound, nil)
 		} else if strings.Contains(shareErr.Error(), "not authorized") {
 			h.sendError(w, "Forbidden", "Not authorized to share this secret", http.StatusForbidden, nil)
+		} else if strings.Contains(shareErr.Error(), "expiry must be in the future") {
+			h.sendError(w, "ValidationError", "Share expiry must be in the future", http.StatusBadRequest, nil)
 		} else {
 			h.sendError(w, "InternalError", "Failed to share secret", http.StatusInternalServerError, nil)
 		}

--- a/server/main.go
+++ b/server/main.go
@@ -1099,13 +1099,24 @@ func startHTTPServer(ctx context.Context, cfg *config.Config) error {
 				}
 				// Single-replica-gated (ADR-039): one replica sweeps per tick.
 				if _, err := coreService.Storage().WithSchedulerLock(ctx, schedLockJITExpiry, func() error {
-					n, rerr := coreService.RemoveExpiredRoleGrants(ctx, time.Now())
+					now := time.Now()
+					n, rerr := coreService.RemoveExpiredRoleGrants(ctx, now)
 					if rerr != nil {
 						log.Printf("JIT access-expiry sweep error: %v", rerr)
 						return rerr
 					}
 					if n > 0 {
 						log.Printf("JIT access-expiry sweep removed %d expired grant(s)", n)
+					}
+					// The same sweep reclaims expired time-bound secret shares (both already
+					// stop authorizing immediately; this keeps the tables clean + audited).
+					sn, serr := coreService.RemoveExpiredShares(ctx, now)
+					if serr != nil {
+						log.Printf("JIT access-expiry share-sweep error: %v", serr)
+						return serr
+					}
+					if sn > 0 {
+						log.Printf("JIT access-expiry sweep removed %d expired share(s)", sn)
 					}
 					return nil
 				}); err != nil {


### PR DESCRIPTION
## Summary

A secret share can now carry an optional **`ExpiresAt`**, mirroring the existing time-bound role grants (`UserRole.ExpiresAt` / JIT access). Until now a direct or group share was permanent; this lets an owner grant **temporary** access to a secret that lapses on its own.

### Enforcement (the security core) — an expired share authorizes nothing
- `core.CheckSecretPermission` drops expired shares (via `c.now()`) before checking either direct or group grants — the single authorization chokepoint (the filtered slice is also what `CheckGroupPermissions` sees).
- The storage permission/listing queries (`CheckSharePermission`, `ListSharedSecrets`) filter `expires_at IS NULL OR expires_at > now`, so expired shares neither authorize nor surface in "shared with me".
- `ShareSecret` / `ShareSecretWithGroup` reject a past/now expiry at creation.
- `GetSecretSharingStatusWithIndicators` / `GetUserSecretPermission` also filter expired shares so reported status matches enforcement.

### Reclamation
`RemoveExpiredShares` + `storage.DeleteExpiredShareRecords` soft-delete lapsed shares and audit each as `share.expired`. Folded into the existing **JIT access-expiry sweeper** (single-replica-gated, ADR-039) — the same tick that reclaims expired role grants. The sweep is hygiene only; enforcement already denies an expired share immediately.

### API
`POST /api/v1/secrets/{id}/share` accepts an optional `expires_at` (RFC3339); a past value → 400.

## Test plan
- `go build ./...` ✅ · `gosec -severity medium` ✅ · `golangci-lint` ✅ (0 issues)
- `go test ./internal/core/... ./internal/storage/... ./server/...` ✅ (the only failures are the pre-existing local-only `/sw.js` + `evidence/verify` cases in `TestEveryMutatingRouteDeniesReadOnly`, green in CI; the share routes correctly return 403 to a read-only persona).
- New `shares_expiry_test.go`: active share authorizes + lists; expired share denies (core clock) and is hidden from the listing (storage); past-expiry rejected at creation; permanent (nil) share unaffected; sweep removes only the expired row, audits it, and is idempotent.
- Security-reviewed (authorization surface): no HIGH/MEDIUM findings; the invariant "an expired share never authorizes a value read" holds across all value-bearing paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)