### PR TITLE
feat(anomaly): frequency-spike detection (activate the unused baseline)

### DIFF
--- a/internal/core/anomaly.go
+++ b/internal/core/anomaly.go
@@ -64,6 +64,12 @@ func (d *AnomalyDetector) RunDetection(ctx context.Context, secrets []models.Sec
 				_ = d.storage.CreateAnomalyAlert(ctx, &alert)
 			}
 		}
+
+		// Per-secret aggregate: a read-volume spike for the window versus the learned
+		// baseline (one alert per secret per pass, not per access).
+		if alert := volumeSpikeAlert(secret, len(recentLogs), baseline, now); alert != nil {
+			_ = d.storage.CreateAnomalyAlert(ctx, alert)
+		}
 	}
 	return nil
 }
@@ -141,6 +147,46 @@ func detectAnomalies(secret models.SecretNode, log models.SecretAccessLog, basel
 	}
 
 	return alerts
+}
+
+const (
+	// volumeSpikeMinCount is the absolute floor below which a burst is never flagged —
+	// avoids false positives on low-traffic secrets where a handful of reads dwarfs a
+	// near-zero baseline.
+	volumeSpikeMinCount = 10
+	// volumeSpikeMultiplier flags a window whose read count exceeds this many times the
+	// secret's learned hourly baseline.
+	volumeSpikeMultiplier = 3.0
+)
+
+// isVolumeSpike reports whether recentCount reads in the (one-hour) detection window
+// is anomalously high versus the secret's learned hourly baseline (dailyAvg / 24).
+// Requires both an absolute floor and a multiple of the baseline, so neither a quiet
+// secret seeing a few reads nor a busy secret at its normal rate is flagged.
+func isVolumeSpike(recentCount int, baseline accessBaseline) bool {
+	if recentCount < volumeSpikeMinCount {
+		return false
+	}
+	hourlyAvg := baseline.dailyAvg / 24.0
+	return float64(recentCount) > volumeSpikeMultiplier*hourlyAvg
+}
+
+// volumeSpikeAlert returns a frequency_spike alert when the window's read count is a
+// spike versus the baseline, or nil otherwise. The alert is a per-secret aggregate, so
+// it carries no single accessor/IP.
+func volumeSpikeAlert(secret models.SecretNode, recentCount int, baseline accessBaseline, now time.Time) *models.AnomalyAlert {
+	if !isVolumeSpike(recentCount, baseline) {
+		return nil
+	}
+	return &models.AnomalyAlert{
+		SecretNodeID: secret.ID,
+		SecretName:   secret.Name,
+		AlertType:    "frequency_spike",
+		Severity:     "medium",
+		Description: fmt.Sprintf("Unusual access volume: %d reads in the last hour (baseline ~%.1f/hour)",
+			recentCount, baseline.dailyAvg/24.0),
+		DetectedAt: now,
+	}
 }
 
 // ListAlerts returns anomaly alerts. acknowledged filters by state: nil returns

--- a/internal/core/anomaly_test.go
+++ b/internal/core/anomaly_test.go
@@ -1,0 +1,119 @@
+package core
+
+import (
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+func TestBuildBaseline(t *testing.T) {
+	now := time.Date(2026, 6, 17, 12, 0, 0, 0, time.UTC)
+	logs := []models.SecretAccessLog{
+		{IPAddress: "10.0.0.1", AccessedBy: "alice", AccessTime: now.Add(-1 * time.Hour)},       // in 7d
+		{IPAddress: "10.0.0.2", AccessedBy: "bob", AccessTime: now.Add(-2 * 24 * time.Hour)},    // in 7d
+		{IPAddress: "10.0.0.1", AccessedBy: "alice", AccessTime: now.Add(-20 * 24 * time.Hour)}, // older than 7d
+	}
+	b := buildBaseline(logs, now)
+	if !b.knownIPs["10.0.0.1"] || !b.knownIPs["10.0.0.2"] {
+		t.Fatalf("expected both IPs learned, got %v", b.knownIPs)
+	}
+	if !b.knownUsers["alice"] || !b.knownUsers["bob"] {
+		t.Fatalf("expected both users learned, got %v", b.knownUsers)
+	}
+	// 2 of 3 accesses fall in the last 7 days → dailyAvg = 2/7.
+	if want := 2.0 / 7.0; b.dailyAvg != want {
+		t.Fatalf("dailyAvg = %v, want %v", b.dailyAvg, want)
+	}
+}
+
+func TestDetectAnomalies(t *testing.T) {
+	secret := models.SecretNode{ID: 1, Name: "db"}
+	baseline := accessBaseline{
+		knownIPs:   map[string]bool{"10.0.0.1": true},
+		knownUsers: map[string]bool{"alice": true},
+	}
+
+	t.Run("off-hours + new IP + new user all fire", func(t *testing.T) {
+		// 03:00 UTC is off-hours; unknown IP + unknown user against a non-empty baseline.
+		lg := models.SecretAccessLog{
+			IPAddress:  "8.8.8.8",
+			AccessedBy: "mallory",
+			AccessTime: time.Date(2026, 6, 17, 3, 0, 0, 0, time.UTC),
+		}
+		got := kindsOf(detectAnomalies(secret, lg, baseline))
+		for _, want := range []string{"off_hours", "new_ip", "new_user"} {
+			if !got[want] {
+				t.Errorf("expected %s alert, got %v", want, got)
+			}
+		}
+	})
+
+	t.Run("business-hours known IP+user → no alert", func(t *testing.T) {
+		lg := models.SecretAccessLog{
+			IPAddress:  "10.0.0.1",
+			AccessedBy: "alice",
+			AccessTime: time.Date(2026, 6, 17, 14, 0, 0, 0, time.UTC),
+		}
+		if alerts := detectAnomalies(secret, lg, baseline); len(alerts) != 0 {
+			t.Fatalf("expected no alerts, got %v", kindsOf(alerts))
+		}
+	})
+
+	t.Run("empty baseline suppresses new-ip/new-user", func(t *testing.T) {
+		// Bootstrapping: with no history, an unknown IP/user must not flag (only off-hours,
+		// which is time-based, can fire). Use a business-hours time so nothing fires.
+		lg := models.SecretAccessLog{
+			IPAddress:  "8.8.8.8",
+			AccessedBy: "mallory",
+			AccessTime: time.Date(2026, 6, 17, 14, 0, 0, 0, time.UTC),
+		}
+		empty := accessBaseline{knownIPs: map[string]bool{}, knownUsers: map[string]bool{}}
+		if alerts := detectAnomalies(secret, lg, empty); len(alerts) != 0 {
+			t.Fatalf("expected no alerts against an empty baseline, got %v", kindsOf(alerts))
+		}
+	})
+}
+
+func TestVolumeSpike(t *testing.T) {
+	now := time.Date(2026, 6, 17, 12, 0, 0, 0, time.UTC)
+	secret := models.SecretNode{ID: 1, Name: "db"}
+
+	// Busy secret: dailyAvg 240 → hourlyAvg 10. Threshold = 3×10 = 30, floor 10.
+	busy := accessBaseline{dailyAvg: 240}
+	if isVolumeSpike(25, busy) {
+		t.Error("25 reads vs a 10/hour baseline should NOT be a spike (≤ 3×)")
+	}
+	if !isVolumeSpike(40, busy) {
+		t.Error("40 reads vs a 10/hour baseline should be a spike (> 3×)")
+	}
+
+	// Quiet secret: tiny baseline, but the absolute floor prevents flagging a few reads.
+	quiet := accessBaseline{dailyAvg: 1}
+	if isVolumeSpike(9, quiet) {
+		t.Error("9 reads is below the absolute floor and must not flag")
+	}
+	if !isVolumeSpike(12, quiet) {
+		t.Error("12 reads on a near-zero baseline should flag (floor met, far above 3×)")
+	}
+
+	// volumeSpikeAlert wraps the decision and carries no single accessor/IP.
+	if a := volumeSpikeAlert(secret, 25, busy, now); a != nil {
+		t.Errorf("expected nil alert below threshold, got %+v", a)
+	}
+	a := volumeSpikeAlert(secret, 40, busy, now)
+	if a == nil || a.AlertType != "frequency_spike" || a.SecretNodeID != 1 {
+		t.Fatalf("expected a frequency_spike alert for secret 1, got %+v", a)
+	}
+	if a.AccessedBy != "" || a.IPAddress != "" {
+		t.Errorf("aggregate spike alert should carry no accessor/IP, got by=%q ip=%q", a.AccessedBy, a.IPAddress)
+	}
+}
+
+func kindsOf(alerts []models.AnomalyAlert) map[string]bool {
+	m := map[string]bool{}
+	for _, a := range alerts {
+		m[a.AlertType] = true
+	}
+	return m
+}


### PR DESCRIPTION
## Summary

The access-anomaly detector already learns a per-secret access baseline — known IPs/users plus a 7-day daily average — but `dailyAvg` was **computed and never used**. The `frequency_spike` alert type the `AnomalyAlert` model documents was never actually emitted. This activates it.

Per detection pass, for each secret: if the window's read count clears an absolute floor (10) **and** exceeds 3× the learned hourly baseline (`dailyAvg / 24`), emit one aggregate **`frequency_spike`** alert (severity `medium`). The dual floor-plus-multiple condition avoids flagging:
- a *quiet* secret seeing a handful of reads (floor not met), or
- a *busy* secret at its normal rate (within 3×).

The alert is per-secret (no single accessor/IP) and rides the **existing** `AnomalyAlert` persistence + alerting (admin notify + `security.anomaly_detected` audit + SIEM) + retention path — no new scheduler, config, or API surface. Reads only access-log metadata; never secret values.

## Test plan
- `go build ./...` ✅ · `gosec -severity medium` ✅ · `golangci-lint` ✅ (0 issues)
- New `anomaly_test.go` (the package's first internal test for these pure helpers): `buildBaseline` (IP/user learning + 7-day `dailyAvg`), `detectAnomalies` (off-hours/new-ip/new-user fire together; an **empty baseline suppresses** new-ip/new-user so bootstrapping is quiet; business-hours known access is silent), and the volume-spike floor/multiple logic + alert shape.
- Existing `anomaly_alerting_external_test.go` still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)