### PR TITLE
feat(sharing): update/extend/clear a share's expiry

### DIFF
--- a/internal/core/secret_listing_test.go
+++ b/internal/core/secret_listing_test.go
@@ -285,6 +285,7 @@ func TestKeyorixCore_GetUserSecretPermission(t *testing.T) {
 	mockStorage := new(MockStorage)
 	core := &KeyorixCore{
 		storage: mockStorage,
+		now:     time.Now, // share-permission paths filter expired shares via c.now()
 	}
 	ctx := context.Background()
 

--- a/internal/core/shares_expiry_test.go
+++ b/internal/core/shares_expiry_test.go
@@ -121,6 +121,74 @@ func TestShareExpiry_Enforcement(t *testing.T) {
 	})
 }
 
+func TestUpdateShareExpiry(t *testing.T) {
+	ctx := context.Background()
+
+	// share creates a permanent read share of the fixture secret to recipient 2 and
+	// returns the core, the share, and the base clock.
+	share := func(t *testing.T) (*KeyorixCore, *models.ShareRecord, time.Time) {
+		c, secretID, now, _ := newSharesExpiryFixture(t)
+		rec, err := c.ShareSecret(ctx, &ShareSecretRequest{
+			SecretID: secretID, RecipientID: 2, Permission: "read", SharedBy: 1,
+		})
+		require.NoError(t, err)
+		return c, rec, now
+	}
+
+	t.Run("sets an expiry on a permanent share", func(t *testing.T) {
+		c, rec, now := share(t)
+		require.Nil(t, rec.ExpiresAt)
+		exp := now.Add(time.Hour)
+		updated, err := c.UpdateSharePermission(ctx, &UpdateShareRequest{
+			ShareID: rec.ID, Permission: "read", UpdatedBy: 1, ExpiresAt: &exp,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, updated.ExpiresAt)
+		assert.True(t, updated.ExpiresAt.Equal(exp))
+	})
+
+	t.Run("clears an expiry (back to permanent)", func(t *testing.T) {
+		c, rec, now := share(t)
+		exp := now.Add(time.Hour)
+		_, err := c.UpdateSharePermission(ctx, &UpdateShareRequest{
+			ShareID: rec.ID, Permission: "read", UpdatedBy: 1, ExpiresAt: &exp,
+		})
+		require.NoError(t, err)
+		updated, err := c.UpdateSharePermission(ctx, &UpdateShareRequest{
+			ShareID: rec.ID, Permission: "read", UpdatedBy: 1, ClearExpiry: true,
+		})
+		require.NoError(t, err)
+		assert.Nil(t, updated.ExpiresAt, "clear_expiry should make the share permanent")
+	})
+
+	t.Run("preserves expiry when the request changes only the permission", func(t *testing.T) {
+		c, rec, now := share(t)
+		exp := now.Add(time.Hour)
+		_, err := c.UpdateSharePermission(ctx, &UpdateShareRequest{
+			ShareID: rec.ID, Permission: "read", UpdatedBy: 1, ExpiresAt: &exp,
+		})
+		require.NoError(t, err)
+		// A permission-only update must not silently drop the expiry.
+		updated, err := c.UpdateSharePermission(ctx, &UpdateShareRequest{
+			ShareID: rec.ID, Permission: "write", UpdatedBy: 1,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "write", updated.Permission)
+		require.NotNil(t, updated.ExpiresAt, "permission-only update must preserve the expiry")
+		assert.True(t, updated.ExpiresAt.Equal(exp))
+	})
+
+	t.Run("rejects a past expiry", func(t *testing.T) {
+		c, rec, now := share(t)
+		past := now.Add(-time.Minute)
+		_, err := c.UpdateSharePermission(ctx, &UpdateShareRequest{
+			ShareID: rec.ID, Permission: "read", UpdatedBy: 1, ExpiresAt: &past,
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "future")
+	})
+}
+
 // mustShare is a thin wrapper returning just the core, secret, and base now for the
 // subtests that don't need the db handle.
 func mustShare(t *testing.T) (*KeyorixCore, uint, time.Time) {

--- a/internal/core/sharing.go
+++ b/internal/core/sharing.go
@@ -26,11 +26,16 @@ type ShareSecretRequest struct {
 	ExpiresAt *time.Time `json:"expires_at,omitempty"`
 }
 
-// UpdateShareRequest represents a request to update a share's permissions.
+// UpdateShareRequest represents a request to update a share's permissions and,
+// optionally, its time-bound expiry. Expiry semantics: ClearExpiry makes the share
+// permanent; otherwise a non-nil ExpiresAt sets/extends/shortens it (must be in the
+// future); leaving both unset preserves the share's current expiry.
 type UpdateShareRequest struct {
-	ShareID    uint   `json:"share_id" validate:"required"`
-	Permission string `json:"permission" validate:"required,oneof=read write"`
-	UpdatedBy  uint   `json:"updated_by" validate:"required"`
+	ShareID     uint       `json:"share_id" validate:"required"`
+	Permission  string     `json:"permission" validate:"required,oneof=read write"`
+	UpdatedBy   uint       `json:"updated_by" validate:"required"`
+	ExpiresAt   *time.Time `json:"expires_at,omitempty"`
+	ClearExpiry bool       `json:"clear_expiry,omitempty"`
 }
 
 // ShareSecret shares a secret with another user or group.
@@ -103,6 +108,19 @@ func (c *KeyorixCore) UpdateSharePermission(ctx context.Context, req *UpdateShar
 	}
 	if !secretOwnedBy(secret.OwnerID, req.UpdatedBy) {
 		return nil, fmt.Errorf("%s", i18n.T("ErrorPermissionDenied", nil))
+	}
+
+	// Resolve the share's expiry: clear it (permanent), set/extend/shorten it, or
+	// preserve the current value when the request specifies neither. A new expiry must
+	// be in the future, just like at creation.
+	switch {
+	case req.ClearExpiry:
+		shareRecord.ExpiresAt = nil
+	case req.ExpiresAt != nil:
+		if !req.ExpiresAt.After(c.now()) {
+			return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "share expiry must be in the future")
+		}
+		shareRecord.ExpiresAt = req.ExpiresAt
 	}
 
 	oldPermission := shareRecord.Permission

--- a/internal/storage/store/local_sharing.go
+++ b/internal/storage/store/local_sharing.go
@@ -97,6 +97,10 @@ func (ls *LocalStorage) UpdateShareRecord(ctx context.Context, share *models.Sha
 		return nil, err
 	}
 	existing.Permission = share.Permission
+	// ExpiresAt is caller-resolved (the core layer preserves the current value unless a
+	// change was requested), so copy it through — including nil to clear a time-bound
+	// share back to permanent. Save writes the nil as NULL.
+	existing.ExpiresAt = share.ExpiresAt
 	existing.UpdatedAt = time.Now()
 	if err := ls.db.Save(existing).Error; err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorDatabaseOperation", nil), err)

--- a/server/http/handlers/shares_crud.go
+++ b/server/http/handlers/shares_crud.go
@@ -104,7 +104,9 @@ func (h *ShareHandler) UpdateSharePermission(w http.ResponseWriter, r *http.Requ
 	}
 
 	var reqBody struct {
-		Permission string `json:"permission" validate:"required,oneof=read write"`
+		Permission  string     `json:"permission" validate:"required,oneof=read write"`
+		ExpiresAt   *time.Time `json:"expires_at"`   // optional: set/extend/shorten the time-bound expiry
+		ClearExpiry bool       `json:"clear_expiry"` // optional: make the share permanent
 	}
 	if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
 		h.sendError(w, "InvalidJSON", "Invalid JSON in request body", http.StatusBadRequest, nil)
@@ -116,9 +118,11 @@ func (h *ShareHandler) UpdateSharePermission(w http.ResponseWriter, r *http.Requ
 	}
 
 	shareRecord, err := h.coreService.UpdateSharePermission(r.Context(), &core.UpdateShareRequest{
-		ShareID:    uint(id),
-		Permission: reqBody.Permission,
-		UpdatedBy:  userCtx.UserID,
+		ShareID:     uint(id),
+		Permission:  reqBody.Permission,
+		UpdatedBy:   userCtx.UserID,
+		ExpiresAt:   reqBody.ExpiresAt,
+		ClearExpiry: reqBody.ClearExpiry,
 	})
 	if err != nil {
 		log.Printf("Error updating share permission: %v", err)
@@ -126,6 +130,8 @@ func (h *ShareHandler) UpdateSharePermission(w http.ResponseWriter, r *http.Requ
 			h.sendError(w, "NotFound", "Share not found", http.StatusNotFound, nil)
 		} else if strings.Contains(err.Error(), "not authorized") {
 			h.sendError(w, "Forbidden", "Not authorized to update this share", http.StatusForbidden, nil)
+		} else if strings.Contains(err.Error(), "expiry must be in the future") {
+			h.sendError(w, "ValidationError", "Share expiry must be in the future", http.StatusBadRequest, nil)
 		} else {
 			h.sendError(w, "InternalError", "Failed to update share permission", http.StatusInternalServerError, nil)
 		}


### PR DESCRIPTION
## Summary

Completes the time-bound shares work from v0.52.0. `UpdateSharePermission` could change a share's *permission* but not its *expiry*, so once a JIT share was created you couldn't extend it, shorten it, or make it permanent again. Now you can:

- **`UpdateShareRequest`** carries `ExpiresAt` (set / extend / shorten — must be in the future) and `ClearExpiry` (make permanent). Leaving **both unset preserves** the current expiry, so a permission-only update never silently drops it.
- The core resolves the final expiry (clear / set / preserve) and storage's `UpdateShareRecord` now persists `ExpiresAt` (including `nil` → `NULL`). Because the core always passes the intended final value, the existing **CLI/gRPC callers** (which don't set the new fields) preserve expiry automatically — no behaviour change for them.
- **`PUT /api/v1/shares/{id}`** accepts optional `expires_at` / `clear_expiry`; a past expiry → `400`.

## Incidental fix

`TestKeyorixCore_GetUserSecretPermission` built a `KeyorixCore` struct literal **without a `now` clock**, which segfaults now that the share-permission read paths filter expired shares via `c.now()` (added with time-bound shares in #284). Set `now: time.Now` in that test — production always sets it via `NewKeyorixCore`.

## Test plan
- `go build ./...` ✅ · full `go test ./internal/core/` ✅ · `gosec -severity medium` ✅ · `golangci-lint` ✅ (0 issues)
- New cases: set an expiry on a permanent share, clear back to permanent, **preserve expiry on a permission-only update**, reject a past expiry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)