### PR TITLE
fix(sharing): GET /shares returns a paginated, enriched DTO

### DIFF
--- a/internal/core/shares_expiry_test.go
+++ b/internal/core/shares_expiry_test.go
@@ -189,6 +189,30 @@ func TestUpdateShareExpiry(t *testing.T) {
 	})
 }
 
+func TestListUserShareViews(t *testing.T) {
+	ctx := context.Background()
+	c, secretID, now, _ := newSharesExpiryFixture(t)
+
+	exp := now.Add(time.Hour)
+	_, err := c.ShareSecret(ctx, &ShareSecretRequest{
+		SecretID: secretID, RecipientID: 2, Permission: "read", SharedBy: 1, ExpiresAt: &exp,
+	})
+	require.NoError(t, err)
+
+	// The owner's view list resolves recipient + creator names and carries the expiry.
+	views, err := c.ListUserShareViews(ctx, 1)
+	require.NoError(t, err)
+	require.Len(t, views, 1)
+	v := views[0]
+	assert.Equal(t, secretID, v.SecretID)
+	assert.Equal(t, "user", v.RecipientType)
+	assert.Equal(t, "recip2", v.RecipientName, "recipient id should resolve to a username")
+	assert.Equal(t, "owner", v.CreatedBy, "owner id should resolve to a username")
+	assert.Equal(t, "read", v.Permission)
+	require.NotNil(t, v.ExpiresAt)
+	assert.True(t, v.ExpiresAt.Equal(exp))
+}
+
 // mustShare is a thin wrapper returning just the core, secret, and base now for the
 // subtests that don't need the db handle.
 func mustShare(t *testing.T) (*KeyorixCore, uint, time.Time) {

--- a/internal/core/sharing_query.go
+++ b/internal/core/sharing_query.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"time"
 
 	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
@@ -97,6 +98,80 @@ func (c *KeyorixCore) ListSharesByUser(ctx context.Context, userID uint) ([]*mod
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
 	return out, nil
+}
+
+// ShareView is an enriched, transport-ready share record: recipient and creator are
+// resolved to display names and the JSON is camelCase to match the web client (which
+// consumes the /shares list verbatim, without field mapping).
+type ShareView struct {
+	ID            uint       `json:"id"`
+	SecretID      uint       `json:"secretId"`
+	RecipientType string     `json:"recipientType"` // "user" | "group"
+	RecipientID   uint       `json:"recipientId"`
+	RecipientName string     `json:"recipientName"`
+	Permission    string     `json:"permission"`
+	ExpiresAt     *time.Time `json:"expiresAt,omitempty"` // nil = permanent (time-bound shares)
+	CreatedAt     time.Time  `json:"createdAt"`
+	CreatedBy     string     `json:"createdBy"` // username of the share's owner
+}
+
+// ListUserShareViews returns the user's shares (received + owned) as enriched views
+// with recipient/creator names resolved, ready to serialise for the web sharing UI.
+func (c *KeyorixCore) ListUserShareViews(ctx context.Context, userID uint) ([]ShareView, error) {
+	shares, err := c.ListSharesByUser(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+
+	userNames := map[uint]string{}
+	resolveUser := func(id uint) string {
+		if id == 0 {
+			return ""
+		}
+		if n, ok := userNames[id]; ok {
+			return n
+		}
+		name := fmt.Sprintf("User %d", id)
+		if u, err := c.storage.GetUser(ctx, id); err == nil && u != nil && u.Username != "" {
+			name = u.Username
+		}
+		userNames[id] = name
+		return name
+	}
+	groupNames := map[uint]string{}
+	resolveGroup := func(id uint) string {
+		if n, ok := groupNames[id]; ok {
+			return n
+		}
+		name := fmt.Sprintf("Group %d", id)
+		if g, err := c.storage.GetGroup(ctx, id); err == nil && g != nil && g.Name != "" {
+			name = g.Name
+		}
+		groupNames[id] = name
+		return name
+	}
+
+	views := make([]ShareView, 0, len(shares))
+	for _, s := range shares {
+		v := ShareView{
+			ID:          s.ID,
+			SecretID:    s.SecretID,
+			RecipientID: s.RecipientID,
+			Permission:  s.Permission,
+			ExpiresAt:   s.ExpiresAt,
+			CreatedAt:   s.CreatedAt,
+			CreatedBy:   resolveUser(s.OwnerID),
+		}
+		if s.IsGroup {
+			v.RecipientType = "group"
+			v.RecipientName = resolveGroup(s.RecipientID)
+		} else {
+			v.RecipientType = "user"
+			v.RecipientName = resolveUser(s.RecipientID)
+		}
+		views = append(views, v)
+	}
+	return views, nil
 }
 
 // CheckSharePermission checks if a user has permission to access a secret.

--- a/server/http/handlers/shares_query.go
+++ b/server/http/handlers/shares_query.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/keyorixhq/keyorix/server/middleware"
 )
@@ -48,7 +49,11 @@ func (h *ShareHandler) ListSecretShares(w http.ResponseWriter, r *http.Request) 
 	h.sendSuccess(w, map[string]interface{}{"shares": shares}, "")
 }
 
-// ListShares handles GET /api/v1/shares
+// ListShares handles GET /api/v1/shares — returns the caller's shares (received +
+// owned) as a paginated list of enriched views (recipient/creator names resolved,
+// expiry included). Supports ?secretId= and ?recipientType=user|group filters and
+// ?page / ?pageSize paging. The response shape matches the web client's
+// PaginatedResponse (camelCase), which consumes it without field mapping.
 func (h *ShareHandler) ListShares(w http.ResponseWriter, r *http.Request) {
 	userCtx := middleware.GetUserFromContext(r.Context())
 	if userCtx == nil {
@@ -56,14 +61,77 @@ func (h *ShareHandler) ListShares(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	shares, err := h.coreService.ListSharesByUser(r.Context(), userCtx.UserID)
+	views, err := h.coreService.ListUserShareViews(r.Context(), userCtx.UserID)
 	if err != nil {
 		log.Printf("Error listing shares: %v", err)
 		h.sendError(w, "InternalError", "Failed to list shares", http.StatusInternalServerError, nil)
 		return
 	}
 
-	h.sendSuccess(w, map[string]interface{}{"shares": shares}, "")
+	// Optional server-side filters.
+	if v := r.URL.Query().Get("secretId"); v != "" {
+		if sid, perr := strconv.ParseUint(v, 10, 32); perr == nil {
+			views = filterShareViews(views, func(s core.ShareView) bool { return s.SecretID == uint(sid) })
+		}
+	}
+	if rt := r.URL.Query().Get("recipientType"); rt == "user" || rt == "group" {
+		views = filterShareViews(views, func(s core.ShareView) bool { return s.RecipientType == rt })
+	}
+
+	page := atoiDefault(r.URL.Query().Get("page"), 1)
+	pageSize := atoiDefault(r.URL.Query().Get("pageSize"), 20)
+	if page < 1 {
+		page = 1
+	}
+	if pageSize < 1 || pageSize > 200 {
+		pageSize = 20
+	}
+
+	total := len(views)
+	totalPages := (total + pageSize - 1) / pageSize
+	start := (page - 1) * pageSize
+	if start > total {
+		start = total
+	}
+	end := start + pageSize
+	if end > total {
+		end = total
+	}
+	pageItems := views[start:end]
+	if pageItems == nil {
+		pageItems = []core.ShareView{}
+	}
+
+	h.sendSuccess(w, map[string]interface{}{
+		"data":       pageItems,
+		"total":      total,
+		"page":       page,
+		"pageSize":   pageSize,
+		"totalPages": totalPages,
+	}, "")
+}
+
+// filterShareViews returns the views satisfying keep.
+func filterShareViews(views []core.ShareView, keep func(core.ShareView) bool) []core.ShareView {
+	out := views[:0:0]
+	for _, v := range views {
+		if keep(v) {
+			out = append(out, v)
+		}
+	}
+	return out
+}
+
+// atoiDefault parses s as an int, returning def on empty/invalid input.
+func atoiDefault(s string, def int) int {
+	if s == "" {
+		return def
+	}
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		return def
+	}
+	return n
 }
 
 // ListSharedSecrets handles GET /api/v1/shared-secrets


### PR DESCRIPTION
## Summary

`GET /api/v1/shares` returned `{shares: [...]}` of **raw `ShareRecord` models** — PascalCase, no resolved recipient/creator names, unpaginated. The web client consumes the response **verbatim** as a `PaginatedResponse<ShareRecord>` of camelCase fields (`recipientName`, `createdBy`, …), so the Sharing Management page rendered **empty** against a real backend.

This returns what the client expects:

- **`core.ListUserShareViews`** resolves each share's recipient (user *or* group) and creator to display names (cached lookups) and carries the expiry, as a camelCase-tagged `ShareView`.
- **`GET /shares`** now returns `{data, total, page, pageSize, totalPages}`, supports `?secretId` / `?recipientType` filters and `?page` / `?pageSize` paging, and includes **`expiresAt`** so the UI can show time-bound shares.

Companion web PR adds the "Expires" column.

## Test plan
- `go build ./...` ✅ · full `go test ./internal/core/` ✅ · `gosec -severity medium` ✅ · `golangci-lint` ✅ (0 issues)
- New `TestListUserShareViews`: resolves recipient + creator usernames and includes the expiry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)