### PR TITLE
feat(anomaly): filter the alerts list by severity and type

### DIFF
--- a/internal/core/anomaly.go
+++ b/internal/core/anomaly.go
@@ -195,6 +195,26 @@ func (d *AnomalyDetector) ListAlerts(ctx context.Context, acknowledged *bool) ([
 	return d.storage.ListAnomalyAlerts(ctx, acknowledged)
 }
 
+// FilterAlerts narrows a set of alerts to those matching the given severity
+// (low/medium/high) and/or alert type (off_hours/new_ip/new_user/frequency_spike).
+// An empty string for either is "no constraint", so FilterAlerts(a, "", "") == a.
+func FilterAlerts(alerts []models.AnomalyAlert, severity, alertType string) []models.AnomalyAlert {
+	if severity == "" && alertType == "" {
+		return alerts
+	}
+	out := make([]models.AnomalyAlert, 0, len(alerts))
+	for _, a := range alerts {
+		if severity != "" && a.Severity != severity {
+			continue
+		}
+		if alertType != "" && a.AlertType != alertType {
+			continue
+		}
+		out = append(out, a)
+	}
+	return out
+}
+
 // AcknowledgeAlert marks an alert as acknowledged.
 func (d *AnomalyDetector) AcknowledgeAlert(ctx context.Context, id uint) error {
 	return d.storage.AcknowledgeAnomalyAlert(ctx, id)

--- a/internal/core/anomaly_test.go
+++ b/internal/core/anomaly_test.go
@@ -5,6 +5,8 @@ import (
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBuildBaseline(t *testing.T) {
@@ -108,6 +110,34 @@ func TestVolumeSpike(t *testing.T) {
 	if a.AccessedBy != "" || a.IPAddress != "" {
 		t.Errorf("aggregate spike alert should carry no accessor/IP, got by=%q ip=%q", a.AccessedBy, a.IPAddress)
 	}
+}
+
+func TestFilterAlerts(t *testing.T) {
+	alerts := []models.AnomalyAlert{
+		{AlertType: "off_hours", Severity: "medium"},
+		{AlertType: "new_ip", Severity: "high"},
+		{AlertType: "frequency_spike", Severity: "medium"},
+		{AlertType: "new_user", Severity: "high"},
+	}
+
+	// No constraint returns the input unchanged.
+	assert.Len(t, FilterAlerts(alerts, "", ""), 4)
+
+	// Severity only.
+	high := FilterAlerts(alerts, "high", "")
+	assert.Len(t, high, 2)
+	for _, a := range high {
+		assert.Equal(t, "high", a.Severity)
+	}
+
+	// Type only.
+	spikes := FilterAlerts(alerts, "", "frequency_spike")
+	require.Len(t, spikes, 1)
+	assert.Equal(t, "frequency_spike", spikes[0].AlertType)
+
+	// Both must match (AND).
+	assert.Empty(t, FilterAlerts(alerts, "high", "frequency_spike"), "high + frequency_spike matches nothing here")
+	require.Len(t, FilterAlerts(alerts, "medium", "off_hours"), 1)
 }
 
 func kindsOf(alerts []models.AnomalyAlert) map[string]bool {

--- a/server/http/handlers/audit_anomaly.go
+++ b/server/http/handlers/audit_anomaly.go
@@ -35,6 +35,9 @@ func ListAnomalyAlerts(w http.ResponseWriter, r *http.Request) {
 		sendError(w, "InternalError", "Failed to list anomaly alerts", http.StatusInternalServerError, nil)
 		return
 	}
+	// Optional ?severity=low|medium|high and ?alertType=off_hours|new_ip|new_user|
+	// frequency_spike narrow the list server-side (an empty value is no constraint).
+	alerts = core.FilterAlerts(alerts, r.URL.Query().Get("severity"), r.URL.Query().Get("alertType"))
 	sendSuccess(w, map[string]interface{}{"alerts": alerts, "total": len(alerts)}, "")
 }
 


### PR DESCRIPTION
## Summary

`GET /api/v1/anomalies` only filtered by acknowledged state. Adds optional `?severity=low|medium|high` and `?alertType=off_hours|new_ip|new_user|frequency_spike` query filters, applied via a pure, unit-tested **`core.FilterAlerts`** (empty value = no constraint; the two AND together). Lets the API/CLI and the web alerts view narrow to, e.g., open high-severity new-IP alerts.

Companion web PR adds an alert-type filter + humanized labels to the alerts table.

## Test plan
- `go build ./...` ✅ · `go test ./internal/core/` ✅ · `gosec -severity medium` ✅ · `golangci-lint` ✅ (0 issues)
- New `TestFilterAlerts`: no-constraint passthrough, severity-only, type-only, and AND.

🤖 Generated with [Claude Code](https://claude.com/claude-code)