### PR TITLE
feat(k8s): sync engine — reconcile Keyorix secrets into K8s Secrets (1/n)

### DIFF
--- a/internal/k8ssync/sync.go
+++ b/internal/k8ssync/sync.go
@@ -1,0 +1,189 @@
+// Package k8ssync holds the reconciliation engine for the Keyorix Kubernetes sync
+// agent: it materialises selected Keyorix secrets into Kubernetes Secrets and keeps
+// them current as the upstream values rotate.
+//
+// The engine is deliberately decoupled from both Keyorix and Kubernetes via the
+// Fetcher and Sink interfaces, so the diff/apply logic is pure and unit-testable;
+// later changes wire the real Keyorix API client (Fetcher) and a client-go-backed
+// Sink. Values are held only as long as a reconcile pass needs them and are never
+// logged.
+package k8ssync
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// SecretMapping maps one Keyorix secret reference to a key inside a target
+// Kubernetes Secret. Several mappings may target the same Secret with different keys.
+type SecretMapping struct {
+	Ref       string // Keyorix secret reference, e.g. "production/db-password"
+	Namespace string // target Kubernetes namespace
+	Name      string // target Kubernetes Secret name
+	Key       string // key within the Secret's data map
+}
+
+// Fetcher retrieves a secret value by reference from Keyorix.
+type Fetcher interface {
+	Fetch(ctx context.Context, ref string) ([]byte, error)
+}
+
+// Sink reads and writes Kubernetes Secrets. Get returns (nil, nil) when the Secret
+// does not exist. Apply creates or replaces the Secret's data.
+type Sink interface {
+	Get(ctx context.Context, namespace, name string) (map[string][]byte, error)
+	Apply(ctx context.Context, namespace, name string, data map[string][]byte) error
+}
+
+// Result summarises one reconcile pass. Created/Updated/Unchanged count target
+// Secrets (not individual keys); Failed counts targets skipped due to an error.
+type Result struct {
+	Created   int
+	Updated   int
+	Unchanged int
+	Failed    int
+	Errors    []string
+}
+
+// target is the (namespace, name) identity of a Kubernetes Secret.
+type target struct {
+	namespace string
+	name      string
+}
+
+func (t target) String() string { return t.namespace + "/" + t.name }
+
+// Reconcile groups the mappings by target Secret, fetches each referenced value,
+// and creates/updates the Secret only when its desired data differs from what's
+// already there. A fetch or apply failure for one target is recorded and skipped —
+// it never aborts the pass or writes a partial Secret — so other targets still sync.
+// The returned Result tallies the outcome.
+func (e *Engine) Reconcile(ctx context.Context, mappings []SecretMapping) (Result, error) {
+	var res Result
+
+	grouped, errs := groupByTarget(mappings)
+	res.Errors = append(res.Errors, errs...)
+	res.Failed += len(errs)
+
+	// Stable order so logs and tests are deterministic.
+	targets := make([]target, 0, len(grouped))
+	for t := range grouped {
+		targets = append(targets, t)
+	}
+	sort.Slice(targets, func(i, j int) bool { return targets[i].String() < targets[j].String() })
+
+	for _, t := range targets {
+		desired, ferr := e.buildDesired(ctx, grouped[t])
+		if ferr != nil {
+			res.Failed++
+			res.Errors = append(res.Errors, fmt.Sprintf("%s: %v", t, ferr))
+			continue
+		}
+
+		current, gerr := e.sink.Get(ctx, t.namespace, t.name)
+		if gerr != nil {
+			res.Failed++
+			res.Errors = append(res.Errors, fmt.Sprintf("%s: read: %v", t, gerr))
+			continue
+		}
+
+		if dataEqual(current, desired) {
+			res.Unchanged++
+			continue
+		}
+
+		if aerr := e.sink.Apply(ctx, t.namespace, t.name, desired); aerr != nil {
+			res.Failed++
+			res.Errors = append(res.Errors, fmt.Sprintf("%s: apply: %v", t, aerr))
+			continue
+		}
+		if current == nil {
+			res.Created++
+		} else {
+			res.Updated++
+		}
+	}
+	return res, nil
+}
+
+// Engine reconciles Keyorix secrets into Kubernetes Secrets via a Fetcher and Sink.
+type Engine struct {
+	fetcher Fetcher
+	sink    Sink
+}
+
+// NewEngine constructs an Engine over the given Fetcher and Sink.
+func NewEngine(fetcher Fetcher, sink Sink) *Engine {
+	return &Engine{fetcher: fetcher, sink: sink}
+}
+
+// buildDesired fetches every mapping's referenced value and assembles the target
+// Secret's desired data map. Any fetch error fails the whole target (so a transient
+// failure can't silently drop a key from an otherwise-complete Secret).
+func (e *Engine) buildDesired(ctx context.Context, mappings []SecretMapping) (map[string][]byte, error) {
+	desired := make(map[string][]byte, len(mappings))
+	for _, m := range mappings {
+		val, err := e.fetcher.Fetch(ctx, m.Ref)
+		if err != nil {
+			return nil, fmt.Errorf("fetch %q: %w", m.Ref, err)
+		}
+		desired[m.Key] = val
+	}
+	return desired, nil
+}
+
+// groupByTarget buckets mappings by their target Secret, validating each and
+// rejecting duplicate keys within one target. Invalid mappings are returned as error
+// strings (and excluded) rather than aborting the whole set.
+func groupByTarget(mappings []SecretMapping) (map[target][]SecretMapping, []string) {
+	grouped := make(map[target][]SecretMapping)
+	seen := make(map[string]bool) // "ns/name/key" → already mapped
+	var errs []string
+	for i, m := range mappings {
+		if err := validateMapping(m); err != nil {
+			errs = append(errs, fmt.Sprintf("mapping %d: %v", i, err))
+			continue
+		}
+		t := target{namespace: m.Namespace, name: m.Name}
+		dk := t.String() + "/" + m.Key
+		if seen[dk] {
+			errs = append(errs, fmt.Sprintf("mapping %d: duplicate key %q for Secret %s", i, m.Key, t))
+			continue
+		}
+		seen[dk] = true
+		grouped[t] = append(grouped[t], m)
+	}
+	return grouped, errs
+}
+
+// validateMapping rejects a mapping missing any required field.
+func validateMapping(m SecretMapping) error {
+	switch {
+	case strings.TrimSpace(m.Ref) == "":
+		return fmt.Errorf("ref is required")
+	case strings.TrimSpace(m.Namespace) == "":
+		return fmt.Errorf("namespace is required")
+	case strings.TrimSpace(m.Name) == "":
+		return fmt.Errorf("name is required")
+	case strings.TrimSpace(m.Key) == "":
+		return fmt.Errorf("key is required")
+	}
+	return nil
+}
+
+// dataEqual reports whether two Secret data maps hold exactly the same keys and bytes.
+func dataEqual(a, b map[string][]byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, av := range a {
+		bv, ok := b[k]
+		if !ok || !bytes.Equal(av, bv) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/k8ssync/sync_test.go
+++ b/internal/k8ssync/sync_test.go
@@ -1,0 +1,181 @@
+package k8ssync
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeFetcher serves values from a map; refs absent from the map return an error.
+type fakeFetcher struct {
+	values map[string][]byte
+	fail   map[string]bool
+}
+
+func (f *fakeFetcher) Fetch(_ context.Context, ref string) ([]byte, error) {
+	if f.fail[ref] {
+		return nil, errors.New("boom")
+	}
+	v, ok := f.values[ref]
+	if !ok {
+		return nil, errors.New("not found")
+	}
+	return v, nil
+}
+
+// fakeSink records applies and can simulate pre-existing Secrets and apply errors.
+type fakeSink struct {
+	existing map[string]map[string][]byte // "ns/name" → data
+	applied  map[string]map[string][]byte // "ns/name" → last applied data
+	applyErr map[string]bool
+	getErr   map[string]bool
+}
+
+func newFakeSink() *fakeSink {
+	return &fakeSink{
+		existing: map[string]map[string][]byte{},
+		applied:  map[string]map[string][]byte{},
+		applyErr: map[string]bool{},
+		getErr:   map[string]bool{},
+	}
+}
+
+func (s *fakeSink) key(ns, name string) string { return ns + "/" + name }
+
+func (s *fakeSink) Get(_ context.Context, ns, name string) (map[string][]byte, error) {
+	k := s.key(ns, name)
+	if s.getErr[k] {
+		return nil, errors.New("read error")
+	}
+	return s.existing[k], nil
+}
+
+func (s *fakeSink) Apply(_ context.Context, ns, name string, data map[string][]byte) error {
+	k := s.key(ns, name)
+	if s.applyErr[k] {
+		return errors.New("apply error")
+	}
+	s.applied[k] = data
+	s.existing[k] = data // reflect the write for subsequent comparisons
+	return nil
+}
+
+func TestReconcile_CreatesAbsentSecret(t *testing.T) {
+	f := &fakeFetcher{values: map[string][]byte{"prod/db": []byte("p4ss"), "prod/api": []byte("k3y")}}
+	s := newFakeSink()
+	e := NewEngine(f, s)
+
+	res, err := e.Reconcile(context.Background(), []SecretMapping{
+		{Ref: "prod/db", Namespace: "app", Name: "creds", Key: "DB_PASSWORD"},
+		{Ref: "prod/api", Namespace: "app", Name: "creds", Key: "API_KEY"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, res.Created)
+	assert.Equal(t, 0, res.Updated+res.Unchanged+res.Failed)
+	// Both keys landed in the one target Secret.
+	assert.Equal(t, map[string][]byte{"DB_PASSWORD": []byte("p4ss"), "API_KEY": []byte("k3y")}, s.applied["app/creds"])
+}
+
+func TestReconcile_UnchangedWhenEqual(t *testing.T) {
+	f := &fakeFetcher{values: map[string][]byte{"prod/db": []byte("p4ss")}}
+	s := newFakeSink()
+	s.existing["app/creds"] = map[string][]byte{"DB_PASSWORD": []byte("p4ss")}
+	e := NewEngine(f, s)
+
+	res, err := e.Reconcile(context.Background(), []SecretMapping{
+		{Ref: "prod/db", Namespace: "app", Name: "creds", Key: "DB_PASSWORD"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, res.Unchanged)
+	assert.Empty(t, s.applied, "an unchanged Secret must not be re-applied")
+}
+
+func TestReconcile_UpdatesOnRotation(t *testing.T) {
+	f := &fakeFetcher{values: map[string][]byte{"prod/db": []byte("rotated")}}
+	s := newFakeSink()
+	s.existing["app/creds"] = map[string][]byte{"DB_PASSWORD": []byte("old")}
+	e := NewEngine(f, s)
+
+	res, err := e.Reconcile(context.Background(), []SecretMapping{
+		{Ref: "prod/db", Namespace: "app", Name: "creds", Key: "DB_PASSWORD"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, res.Updated)
+	assert.Equal(t, []byte("rotated"), s.applied["app/creds"]["DB_PASSWORD"])
+}
+
+func TestReconcile_FetchFailureSkipsWholeTarget(t *testing.T) {
+	// One key fetches fine, the other fails: the Secret must NOT be written partially.
+	f := &fakeFetcher{
+		values: map[string][]byte{"prod/db": []byte("p4ss")},
+		fail:   map[string]bool{"prod/api": true},
+	}
+	s := newFakeSink()
+	e := NewEngine(f, s)
+
+	res, err := e.Reconcile(context.Background(), []SecretMapping{
+		{Ref: "prod/db", Namespace: "app", Name: "creds", Key: "DB_PASSWORD"},
+		{Ref: "prod/api", Namespace: "app", Name: "creds", Key: "API_KEY"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, res.Failed)
+	assert.Empty(t, s.applied, "a target with any failed fetch must not be applied")
+	require.Len(t, res.Errors, 1)
+	assert.Contains(t, res.Errors[0], "app/creds")
+}
+
+func TestReconcile_OneTargetFailureDoesNotBlockOthers(t *testing.T) {
+	f := &fakeFetcher{
+		values: map[string][]byte{"prod/ok": []byte("v")},
+		fail:   map[string]bool{"prod/bad": true},
+	}
+	s := newFakeSink()
+	e := NewEngine(f, s)
+
+	res, err := e.Reconcile(context.Background(), []SecretMapping{
+		{Ref: "prod/bad", Namespace: "app", Name: "broken", Key: "K"},
+		{Ref: "prod/ok", Namespace: "app", Name: "good", Key: "K"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, res.Created, "the healthy target still syncs")
+	assert.Equal(t, 1, res.Failed)
+	assert.Contains(t, s.applied, "app/good")
+	assert.NotContains(t, s.applied, "app/broken")
+}
+
+func TestReconcile_ApplyAndGetErrors(t *testing.T) {
+	f := &fakeFetcher{values: map[string][]byte{"r": []byte("v")}}
+	s := newFakeSink()
+	s.applyErr["app/applyfail"] = true
+	s.getErr["app/getfail"] = true
+	e := NewEngine(f, s)
+
+	res, err := e.Reconcile(context.Background(), []SecretMapping{
+		{Ref: "r", Namespace: "app", Name: "applyfail", Key: "K"},
+		{Ref: "r", Namespace: "app", Name: "getfail", Key: "K"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 2, res.Failed)
+	assert.Len(t, res.Errors, 2)
+}
+
+func TestReconcile_InvalidAndDuplicateMappings(t *testing.T) {
+	f := &fakeFetcher{values: map[string][]byte{"r": []byte("v")}}
+	s := newFakeSink()
+	e := NewEngine(f, s)
+
+	res, err := e.Reconcile(context.Background(), []SecretMapping{
+		{Ref: "", Namespace: "app", Name: "x", Key: "K"},    // invalid: no ref
+		{Ref: "r", Namespace: "", Name: "x", Key: "K"},      // invalid: no namespace
+		{Ref: "r", Namespace: "app", Name: "dup", Key: "K"}, // ok
+		{Ref: "r", Namespace: "app", Name: "dup", Key: "K"}, // duplicate key for same Secret
+	})
+	require.NoError(t, err)
+	// 2 invalid + 1 duplicate = 3 failures recorded; the one valid target is created.
+	assert.Equal(t, 3, res.Failed)
+	assert.Equal(t, 1, res.Created)
+	assert.Len(t, res.Errors, 3)
+}


### PR DESCRIPTION
## Summary

**First piece of the Kubernetes integration.** A pure **reconciliation engine** that materialises selected Keyorix secrets into Kubernetes Secrets and keeps them current as upstream values rotate.

It's decoupled from both ends via two interfaces — `Fetcher` (reads a Keyorix value by ref) and `Sink` (get / apply a K8s Secret) — so the diff/apply logic is pure and unit-testable **with no client-go or API dependency yet**.

`Engine.Reconcile`:
- groups mappings by target Secret (several Keyorix refs → keys in one Secret),
- fetches each ref and creates/updates the Secret **only when its desired data differs** (skips unchanged — no churn on every tick),
- is **fail-closed per target**: any fetch/read/apply error is recorded and that Secret is skipped, **never written partially**, so a transient failure can't drop a key — and other targets still sync.

### Roadmap (separate PRs)
2. real Keyorix API `Fetcher` (reuses the existing client + machine-identity auth)
3. client-go-backed `Sink` (create-or-update K8s Secrets)
4. the agent binary + mapping config + image + docs

## Test plan
- `go build ./...` ✅ · `go test ./internal/k8ssync/` ✅ · `gosec` ✅ · `golangci-lint` ✅ — **no new dependencies**
- Cases: create absent / unchanged / update-on-rotation / partial-fetch-skips-whole-target / one-target-failure-isolated / apply+get errors / invalid+duplicate mappings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)