### PR TITLE
feat(k8s): Keyorix API Fetcher for the sync engine (2/n)

### DIFF
--- a/internal/k8ssync/keyorix_fetcher.go
+++ b/internal/k8ssync/keyorix_fetcher.go
@@ -1,0 +1,127 @@
+package k8ssync
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// KeyorixFetcher reads secret values from a Keyorix server over HTTP, resolving a
+// reference of the form "<environment>/<name>" (e.g. "production/db-password") to the
+// secret's current value. It satisfies Fetcher. Auth is a bearer token (typically a
+// machine-identity / service-account token); the token is sent on every request and
+// never logged.
+type KeyorixFetcher struct {
+	baseURL string
+	token   string
+	hc      *http.Client
+}
+
+// NewKeyorixFetcher builds a fetcher for the given Keyorix base URL (e.g.
+// https://keyorix.internal) and bearer token. A nil-safe default HTTP client with a
+// sane timeout is used.
+func NewKeyorixFetcher(baseURL, token string) *KeyorixFetcher {
+	return &KeyorixFetcher{
+		baseURL: strings.TrimRight(baseURL, "/"),
+		token:   token,
+		hc:      &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+// Fetch resolves ref ("<environment>/<name>") to the secret's id and returns its
+// current value.
+func (f *KeyorixFetcher) Fetch(ctx context.Context, ref string) ([]byte, error) {
+	env, name, err := parseRef(ref)
+	if err != nil {
+		return nil, err
+	}
+	id, err := f.resolveID(ctx, env, name)
+	if err != nil {
+		return nil, err
+	}
+	return f.fetchValue(ctx, id)
+}
+
+// parseRef splits "<environment>/<name>" into its parts. The name may itself contain
+// slashes (a path-like secret name); only the first segment is the environment.
+func parseRef(ref string) (env, name string, err error) {
+	ref = strings.TrimSpace(ref)
+	i := strings.IndexByte(ref, '/')
+	if i <= 0 || i == len(ref)-1 {
+		return "", "", fmt.Errorf("invalid ref %q: expected \"<environment>/<name>\"", ref)
+	}
+	return ref[:i], ref[i+1:], nil
+}
+
+// resolveID finds the id of the secret named name in environment env. The list is
+// filtered server-side by environment; the name match is exact (case-insensitive).
+func (f *KeyorixFetcher) resolveID(ctx context.Context, env, name string) (uint, error) {
+	q := url.Values{}
+	q.Set("environment", env)
+	q.Set("page_size", "1000")
+	q.Set("page", "1")
+	var body struct {
+		Secrets []struct {
+			ID   uint   `json:"ID"`
+			Name string `json:"Name"`
+		} `json:"secrets"`
+	}
+	if err := f.getJSON(ctx, "/api/v1/secrets?"+q.Encode(), &body); err != nil {
+		return 0, fmt.Errorf("list secrets in %q: %w", env, err)
+	}
+	for _, s := range body.Secrets {
+		if strings.EqualFold(s.Name, name) {
+			return s.ID, nil
+		}
+	}
+	return 0, fmt.Errorf("secret %q not found in environment %q", name, env)
+}
+
+// fetchValue returns the decrypted value of the secret with the given id.
+func (f *KeyorixFetcher) fetchValue(ctx context.Context, id uint) ([]byte, error) {
+	var body struct {
+		Value string `json:"value"`
+	}
+	if err := f.getJSON(ctx, fmt.Sprintf("/api/v1/secrets/%d?include_value=true", id), &body); err != nil {
+		return nil, fmt.Errorf("read secret %d value: %w", id, err)
+	}
+	return []byte(body.Value), nil
+}
+
+// getJSON performs an authenticated GET and decodes the {"data": …} envelope into out.
+func (f *KeyorixFetcher) getJSON(ctx context.Context, path string, out interface{}) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, f.baseURL+path, nil)
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+f.token)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := f.hc.Do(req)
+	if err != nil {
+		return fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		return fmt.Errorf("not authorized (HTTP %d) — check the agent's token and its permissions", resp.StatusCode)
+	}
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("server returned HTTP %d", resp.StatusCode)
+	}
+
+	var env struct {
+		Data json.RawMessage `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&env); err != nil {
+		return fmt.Errorf("decode response: %w", err)
+	}
+	if env.Data == nil {
+		return fmt.Errorf("empty data in response")
+	}
+	return json.Unmarshal(env.Data, out)
+}

--- a/internal/k8ssync/keyorix_fetcher_test.go
+++ b/internal/k8ssync/keyorix_fetcher_test.go
@@ -1,0 +1,92 @@
+package k8ssync
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseRef(t *testing.T) {
+	cases := []struct {
+		ref, env, name string
+		ok             bool
+	}{
+		{"production/db-password", "production", "db-password", true},
+		{"prod/app/config/url", "prod", "app/config/url", true}, // name may contain slashes
+		{"noslash", "", "", false},
+		{"/leading", "", "", false},
+		{"trailing/", "", "", false},
+		{"", "", "", false},
+	}
+	for _, c := range cases {
+		env, name, err := parseRef(c.ref)
+		if !c.ok {
+			assert.Error(t, err, "ref %q should be rejected", c.ref)
+			continue
+		}
+		require.NoError(t, err, "ref %q", c.ref)
+		assert.Equal(t, c.env, env)
+		assert.Equal(t, c.name, name)
+	}
+}
+
+// keyorixStub serves the two endpoints the fetcher uses: the filtered list and the
+// value read.
+func keyorixStub(t *testing.T, wantToken string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer "+wantToken {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		switch {
+		case r.URL.Path == "/api/v1/secrets" && r.URL.Query().Get("environment") == "production":
+			_, _ = w.Write([]byte(`{"data":{"secrets":[{"ID":7,"Name":"db-password"},{"ID":9,"Name":"api-key"}]}}`))
+		case r.URL.Path == "/api/v1/secrets/7" && r.URL.Query().Get("include_value") == "true":
+			_, _ = w.Write([]byte(`{"data":{"secret":{"ID":7,"Name":"db-password"},"value":"s3cr3t"}}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+}
+
+func TestKeyorixFetcher_Fetch(t *testing.T) {
+	srv := keyorixStub(t, "tok")
+	defer srv.Close()
+	f := NewKeyorixFetcher(srv.URL, "tok")
+
+	val, err := f.Fetch(context.Background(), "production/db-password")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("s3cr3t"), val)
+}
+
+func TestKeyorixFetcher_NotFound(t *testing.T) {
+	srv := keyorixStub(t, "tok")
+	defer srv.Close()
+	f := NewKeyorixFetcher(srv.URL, "tok")
+
+	_, err := f.Fetch(context.Background(), "production/missing")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestKeyorixFetcher_Unauthorized(t *testing.T) {
+	srv := keyorixStub(t, "tok")
+	defer srv.Close()
+	f := NewKeyorixFetcher(srv.URL, "wrong-token")
+
+	_, err := f.Fetch(context.Background(), "production/db-password")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not authorized")
+}
+
+func TestKeyorixFetcher_BadRef(t *testing.T) {
+	f := NewKeyorixFetcher("http://example.invalid", "tok")
+	_, err := f.Fetch(context.Background(), "noslash")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid ref")
+}


### PR DESCRIPTION
## Summary

**Piece 2 of the Kubernetes integration.** Implements the `Fetcher` seam against a live Keyorix server.

`KeyorixFetcher` resolves a reference `"<environment>/<name>"` to the secret's value over HTTP:
1. `GET /api/v1/secrets?environment=<env>` to find the id (exact, case-insensitive name match),
2. `GET /api/v1/secrets/{id}?include_value=true` for the value.

Bearer-token auth (a machine-identity / service-account token), sent on every request and **never logged**; `401/403` surface a clear "check the agent's token" error. The name segment may contain slashes (path-like names) — only the first segment is the environment.

## Test plan
- `go build ./...` ✅ · `go test ./internal/k8ssync/` ✅ · `gosec` ✅ · `golangci-lint` ✅ — **no new deps**
- `httptest`-backed: `parseRef` table (valid + leading/trailing/no-slash rejects), happy-path fetch, not-found, unauthorized (wrong token), bad ref.

### Next
**3/n** — a client-go-backed `Sink` that create-or-updates Kubernetes Secrets (this is where client-go enters the module). **4/n** — the agent binary + mapping config + image + docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)