### PR TITLE
feat(k8s): sync agent binary + config + reconcile loop + docs (4/n)

### DIFF
--- a/cmd/keyorix-k8s-sync/main.go
+++ b/cmd/keyorix-k8s-sync/main.go
@@ -1,0 +1,69 @@
+/*
+Keyorix Kubernetes sync agent — materialises selected Keyorix secrets into
+Kubernetes Secrets and keeps them current as upstream values rotate.
+
+Runs in-cluster: it authenticates to Keyorix with a machine-identity token
+(KEYORIX_TOKEN) and writes Secrets via the Kubernetes API using its mounted
+service-account credentials. Configure the mappings in a YAML file (default
+/etc/keyorix/k8s-sync.yaml, or -config / KEYORIX_K8S_SYNC_CONFIG).
+
+Copyright (C) 2025 Keyorix Contributors. Licensed under the AGPL-3.0-or-later.
+*/
+package main
+
+import (
+	"context"
+	"flag"
+	"log"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+
+	"github.com/keyorixhq/keyorix/internal/k8ssync"
+)
+
+func main() {
+	configPath := flag.String("config", envOr("KEYORIX_K8S_SYNC_CONFIG", "/etc/keyorix/k8s-sync.yaml"),
+		"path to the sync config (YAML)")
+	flag.Parse()
+
+	cfg, err := k8ssync.LoadConfig(*configPath)
+	if err != nil {
+		log.Fatalf("k8s-sync: config: %v", err)
+	}
+
+	token := strings.TrimSpace(os.Getenv("KEYORIX_TOKEN"))
+	if token == "" {
+		log.Fatalf("k8s-sync: KEYORIX_TOKEN is required (the Keyorix machine-identity token)")
+	}
+
+	sink, err := k8ssync.NewInClusterSink()
+	if err != nil {
+		log.Fatalf("k8s-sync: kubernetes: %v", err)
+	}
+
+	engine := k8ssync.NewEngine(k8ssync.NewKeyorixFetcher(cfg.KeyorixURL, token), sink)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		<-sig
+		log.Println("k8s-sync: shutdown signal received")
+		cancel()
+	}()
+
+	log.Printf("k8s-sync: syncing %d mapping(s) from %s every %s",
+		len(cfg.Mappings), cfg.KeyorixURL, cfg.GetInterval())
+	k8ssync.Run(ctx, engine, cfg.Mappings, cfg.GetInterval(), log.Printf)
+	log.Println("k8s-sync: stopped")
+}
+
+func envOr(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}

--- a/docs/k8s-sync.md
+++ b/docs/k8s-sync.md
@@ -1,0 +1,64 @@
+# Keyorix Kubernetes sync agent
+
+`keyorix-k8s-sync` materialises selected Keyorix secrets into native **Kubernetes
+Secrets** and keeps them current as the upstream values rotate. Workloads consume the
+synced Secret the usual way (env var or mounted file) — they never talk to Keyorix
+directly.
+
+It runs **in-cluster** as a small Deployment:
+
+- authenticates to Keyorix with a **machine-identity token** (`KEYORIX_TOKEN`),
+- writes Secrets via the Kubernetes API using its mounted **service-account**
+  credentials (no `client-go` — a thin REST client, so the image stays tiny),
+- reconciles on an interval, creating/updating a target Secret **only when its data
+  changes** and never writing a Secret partially if any value fails to fetch.
+
+## Configuration
+
+A YAML file (default `/etc/keyorix/k8s-sync.yaml`, override with `-config` or
+`KEYORIX_K8S_SYNC_CONFIG`):
+
+```yaml
+keyorix_url: https://keyorix.internal   # the Keyorix server base URL
+interval: 5m                            # reconcile interval (Go duration; default 5m)
+mappings:
+  # Each mapping copies one Keyorix secret into one key of one Kubernetes Secret.
+  # Several mappings may target the same Secret with different keys.
+  - ref: production/db-password         # "<environment>/<name>" in Keyorix
+    namespace: app                      # target Kubernetes namespace
+    name: db-creds                      # target Kubernetes Secret name
+    key: DB_PASSWORD                    # key within that Secret's data
+  - ref: production/api-key
+    namespace: app
+    name: db-creds
+    key: API_KEY
+```
+
+The Keyorix auth token is **not** in this file — it is read from the `KEYORIX_TOKEN`
+environment variable (mount it from a Kubernetes Secret). Give that token a
+least-privilege machine identity that can read only the referenced secrets.
+
+## Kubernetes RBAC
+
+The agent's service account needs to read and write Secrets in each target namespace:
+
+```
+verbs:     [get, create, patch]
+resources: [secrets]
+```
+
+Bind a `Role` with those permissions in every target namespace (or a `ClusterRole`
+with namespace-scoped `RoleBinding`s). The agent uses Server-Side Apply with the field
+manager `keyorix-sync`, so it owns the `data` it writes and prunes keys it no longer
+maps.
+
+## Running
+
+```
+keyorix-k8s-sync -config /etc/keyorix/k8s-sync.yaml
+```
+
+Logs are counts and target identities only — secret values are never logged.
+
+> A Helm chart that deploys the agent with its RBAC and config ships separately
+> (`deploy/helm/keyorix-k8s-sync`).

--- a/internal/k8ssync/config.go
+++ b/internal/k8ssync/config.go
@@ -1,0 +1,68 @@
+package k8ssync
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Config is the Keyorix Kubernetes sync agent's configuration: where the Keyorix
+// server is, how often to reconcile, and which secrets map to which Kubernetes
+// Secrets. The Keyorix auth token is NOT part of this file — it is read from the
+// KEYORIX_TOKEN environment variable so it can come from a mounted Secret.
+type Config struct {
+	KeyorixURL string          `yaml:"keyorix_url"`
+	Interval   string          `yaml:"interval"` // Go duration (e.g. "5m"); default 5m
+	Mappings   []SecretMapping `yaml:"mappings"`
+}
+
+const defaultSyncInterval = 5 * time.Minute
+
+// LoadConfig reads and validates the agent config at path.
+func LoadConfig(path string) (*Config, error) {
+	raw, err := os.ReadFile(path) // #nosec G304 -- operator-provided config path
+	if err != nil {
+		return nil, fmt.Errorf("read config %s: %w", path, err)
+	}
+	var c Config
+	if err := yaml.Unmarshal(raw, &c); err != nil {
+		return nil, fmt.Errorf("parse config %s: %w", path, err)
+	}
+	if err := c.validate(); err != nil {
+		return nil, err
+	}
+	return &c, nil
+}
+
+func (c *Config) validate() error {
+	if strings.TrimSpace(c.KeyorixURL) == "" {
+		return fmt.Errorf("keyorix_url is required")
+	}
+	if len(c.Mappings) == 0 {
+		return fmt.Errorf("at least one mapping is required")
+	}
+	for i, m := range c.Mappings {
+		if err := validateMapping(m); err != nil {
+			return fmt.Errorf("mapping %d: %w", i, err)
+		}
+	}
+	if c.Interval != "" {
+		if _, err := time.ParseDuration(c.Interval); err != nil {
+			return fmt.Errorf("invalid interval %q: %w", c.Interval, err)
+		}
+	}
+	return nil
+}
+
+// GetInterval returns the reconcile interval, defaulting to 5m when unset.
+func (c *Config) GetInterval() time.Duration {
+	if c.Interval != "" {
+		if d, err := time.ParseDuration(c.Interval); err == nil && d > 0 {
+			return d
+		}
+	}
+	return defaultSyncInterval
+}

--- a/internal/k8ssync/config_test.go
+++ b/internal/k8ssync/config_test.go
@@ -1,0 +1,105 @@
+package k8ssync
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func writeConfig(t *testing.T, body string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "k8s-sync.yaml")
+	require.NoError(t, os.WriteFile(p, []byte(body), 0o600))
+	return p
+}
+
+func TestLoadConfig_Valid(t *testing.T) {
+	p := writeConfig(t, `
+keyorix_url: https://keyorix.internal
+interval: 2m
+mappings:
+  - ref: production/db-password
+    namespace: app
+    name: db-creds
+    key: DB_PASSWORD
+  - ref: production/api-key
+    namespace: app
+    name: db-creds
+    key: API_KEY
+`)
+	cfg, err := LoadConfig(p)
+	require.NoError(t, err)
+	assert.Equal(t, "https://keyorix.internal", cfg.KeyorixURL)
+	assert.Equal(t, 2*time.Minute, cfg.GetInterval())
+	require.Len(t, cfg.Mappings, 2)
+	assert.Equal(t, "production/db-password", cfg.Mappings[0].Ref)
+	assert.Equal(t, "DB_PASSWORD", cfg.Mappings[0].Key)
+}
+
+func TestLoadConfig_DefaultInterval(t *testing.T) {
+	p := writeConfig(t, `
+keyorix_url: https://k
+mappings:
+  - {ref: e/n, namespace: ns, name: s, key: K}
+`)
+	cfg, err := LoadConfig(p)
+	require.NoError(t, err)
+	assert.Equal(t, 5*time.Minute, cfg.GetInterval(), "interval defaults to 5m when unset")
+}
+
+func TestLoadConfig_Invalid(t *testing.T) {
+	cases := map[string]string{
+		"missing url": `
+mappings:
+  - {ref: e/n, namespace: ns, name: s, key: K}
+`,
+		"no mappings": `
+keyorix_url: https://k
+`,
+		"bad mapping": `
+keyorix_url: https://k
+mappings:
+  - {ref: e/n, namespace: ns, name: s}
+`,
+		"bad interval": `
+keyorix_url: https://k
+interval: "soon"
+mappings:
+  - {ref: e/n, namespace: ns, name: s, key: K}
+`,
+	}
+	for name, body := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, err := LoadConfig(writeConfig(t, body))
+			assert.Error(t, err)
+		})
+	}
+}
+
+func TestLoadConfig_MissingFile(t *testing.T) {
+	_, err := LoadConfig(filepath.Join(t.TempDir(), "nope.yaml"))
+	assert.Error(t, err)
+}
+
+func TestSync_LogsSummary(t *testing.T) {
+	var lines []string
+	logf := func(format string, args ...interface{}) {
+		lines = append(lines, fmt.Sprintf(format, args...))
+	}
+	f := &fakeFetcher{values: map[string][]byte{"e/n": []byte("v")}}
+	s := newFakeSink()
+	res := Sync(context.Background(), NewEngine(f, s), []SecretMapping{
+		{Ref: "e/n", Namespace: "ns", Name: "sec", Key: "K"},
+	}, logf)
+
+	assert.Equal(t, 1, res.Created)
+	require.NotEmpty(t, lines)
+	assert.Contains(t, lines[0], "created=1")
+	assert.Contains(t, lines[0], "failed=0")
+}

--- a/internal/k8ssync/runner.go
+++ b/internal/k8ssync/runner.go
@@ -1,0 +1,41 @@
+package k8ssync
+
+import (
+	"context"
+	"time"
+)
+
+// Logf is a minimal logging sink (satisfied by log.Printf). The agent never logs
+// secret values — only counts, target identities, and error reasons.
+type Logf func(format string, args ...interface{})
+
+// Sync runs one reconcile pass and logs a one-line summary plus any per-target
+// errors. Returns the Result for callers/tests.
+func Sync(ctx context.Context, e *Engine, mappings []SecretMapping, logf Logf) Result {
+	res, err := e.Reconcile(ctx, mappings)
+	if err != nil {
+		logf("k8s-sync: reconcile error: %v", err)
+		return res
+	}
+	logf("k8s-sync: created=%d updated=%d unchanged=%d failed=%d",
+		res.Created, res.Updated, res.Unchanged, res.Failed)
+	for _, e := range res.Errors {
+		logf("k8s-sync: %s", e)
+	}
+	return res
+}
+
+// Run reconciles once immediately, then every interval until ctx is cancelled.
+func Run(ctx context.Context, e *Engine, mappings []SecretMapping, interval time.Duration, logf Logf) {
+	Sync(ctx, e, mappings, logf)
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			Sync(ctx, e, mappings, logf)
+		case <-ctx.Done():
+			return
+		}
+	}
+}

--- a/internal/k8ssync/sync.go
+++ b/internal/k8ssync/sync.go
@@ -20,10 +20,10 @@ import (
 // SecretMapping maps one Keyorix secret reference to a key inside a target
 // Kubernetes Secret. Several mappings may target the same Secret with different keys.
 type SecretMapping struct {
-	Ref       string // Keyorix secret reference, e.g. "production/db-password"
-	Namespace string // target Kubernetes namespace
-	Name      string // target Kubernetes Secret name
-	Key       string // key within the Secret's data map
+	Ref       string `yaml:"ref"`       // Keyorix secret reference, e.g. "production/db-password"
+	Namespace string `yaml:"namespace"` // target Kubernetes namespace
+	Name      string `yaml:"name"`      // target Kubernetes Secret name
+	Key       string `yaml:"key"`       // key within the Secret's data map
 }
 
 // Fetcher retrieves a secret value by reference from Keyorix.


### PR DESCRIPTION
## Summary

**Piece 4 of the Kubernetes integration** — wires the engine, `KeyorixFetcher`, and `RESTSink` into a runnable agent.

- **`internal/k8ssync/config.go`** — YAML config (`keyorix_url`, `interval`, `mappings[]`) with validation. The Keyorix token is **not** in the file — read from `KEYORIX_TOKEN` env so it can be mounted from a Secret. `SecretMapping` gained yaml tags.
- **`internal/k8ssync/runner.go`** — `Sync` (one reconcile + a one-line summary log; values never logged) and `Run` (reconcile immediately, then every interval until ctx is cancelled).
- **`cmd/keyorix-k8s-sync`** — the agent `main`: load config, require `KEYORIX_TOKEN`, build the in-cluster sink + Keyorix fetcher, run the loop with SIGINT/SIGTERM shutdown.
- **`docs/k8s-sync.md`** — config, RBAC (`get`/`create`/`patch` secrets per target namespace), run instructions.

## Test plan
- `go build ./...` ✅ · agent binary builds ✅ · `go test ./internal/k8ssync/` ✅ · `gosec` ✅ · `golangci-lint` ✅ — **no new deps** (reuses `gopkg.in/yaml.v3`)
- Config: valid / default-interval / invalid (missing url, no mappings, bad mapping, bad interval) / missing file; `Sync` logs the summary.

### Next
**5/n** — container image + release-pipeline wiring. **6/n** — the Helm chart + RBAC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)