### PR TITLE
build(k8s): container image + GHCR publish for the sync agent (5/n)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,5 +1,5 @@
-# Builds the Keyorix API server container image and publishes it to GHCR so the
-# self-host docker-compose can pull a ready-made image.
+# Builds the Keyorix container images and publishes them to GHCR: the API server
+# (self-host docker-compose) and the Kubernetes sync agent (keyorix-k8s-sync).
 name: docker-publish
 
 on:
@@ -39,6 +39,42 @@ jobs:
         with:
           context: .
           file: server/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  # The Kubernetes sync agent image (keyorix-k8s-sync), published alongside the server.
+  build-and-push-k8s-sync:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Image metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/keyorixhq/keyorix-k8s-sync
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=sha,format=short
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: cmd/keyorix-k8s-sync/Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/cmd/keyorix-k8s-sync/Dockerfile
+++ b/cmd/keyorix-k8s-sync/Dockerfile
@@ -1,0 +1,19 @@
+# Build stage
+FROM golang:1.26-alpine AS builder
+RUN apk add --no-cache git
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go build \
+    -ldflags "-X github.com/keyorixhq/keyorix/internal/cli.version=dev" \
+    -trimpath -o /out/keyorix-k8s-sync ./cmd/keyorix-k8s-sync
+
+# Runtime stage — minimal, non-root. ca-certificates lets the agent reach the
+# Keyorix server over HTTPS; the Kubernetes API is trusted via the mounted SA CA.
+FROM alpine:latest
+RUN apk add --no-cache ca-certificates tzdata
+RUN addgroup -g 1001 keyorix && adduser -D -s /bin/sh -u 1001 -G keyorix keyorix
+COPY --from=builder /out/keyorix-k8s-sync /usr/local/bin/keyorix-k8s-sync
+USER keyorix
+ENTRYPOINT ["keyorix-k8s-sync"]


### PR DESCRIPTION
## Summary

**Piece 5 of the Kubernetes integration** — packaging the agent as a container image.

- **`cmd/keyorix-k8s-sync/Dockerfile`** — multi-stage, static (`CGO_ENABLED=0`) build into a minimal **non-root** alpine runtime with `ca-certificates` (to reach Keyorix over HTTPS; the K8s API is trusted via the mounted SA CA). Mirrors `server/Dockerfile`.
- **`docker-publish.yml`** — a second job builds + pushes **`ghcr.io/keyorixhq/keyorix-k8s-sync`** on `main` + tags, with the same tag scheme as the server image (semver, sha, branch, `latest`).

The agent ships as a **container image only** — the 9-asset GitHub release set is unchanged.

## Test plan
- Built the image locally (`docker build -f cmd/keyorix-k8s-sync/Dockerfile .`) ✅
- Ran it: starts and **fails closed** with a clear config error when no config is mounted ✅
- `go build ./...` ✅

### Next
**6/n** — the Helm chart (Deployment + ServiceAccount + RBAC + config) to deploy the agent in-cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)