### PR TITLE
feat(k8s): health/readiness endpoints + Deployment probes for the agent

### DIFF
--- a/cmd/keyorix-k8s-sync/main.go
+++ b/cmd/keyorix-k8s-sync/main.go
@@ -14,11 +14,14 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"log"
+	"net/http"
 	"os"
 	"os/signal"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/keyorixhq/keyorix/internal/k8ssync"
 )
@@ -55,9 +58,27 @@ func main() {
 		cancel()
 	}()
 
-	log.Printf("k8s-sync: syncing %d mapping(s) from %s every %s",
-		len(cfg.Mappings), cfg.KeyorixURL, cfg.GetInterval())
-	k8ssync.Run(ctx, engine, cfg.Mappings, cfg.GetInterval(), log.Printf)
+	// Health/readiness server for Kubernetes probes (/healthz, /readyz, /status).
+	status := k8ssync.NewStatus()
+	healthSrv := &http.Server{
+		Addr:              fmt.Sprintf(":%d", cfg.GetHealthPort()),
+		Handler:           status.Handler(),
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	go func() {
+		if err := healthSrv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Printf("k8s-sync: health server error: %v", err)
+		}
+	}()
+	defer func() {
+		shutdownCtx, c := context.WithTimeout(context.Background(), 5*time.Second)
+		defer c()
+		_ = healthSrv.Shutdown(shutdownCtx)
+	}()
+
+	log.Printf("k8s-sync: syncing %d mapping(s) from %s every %s (health :%d)",
+		len(cfg.Mappings), cfg.KeyorixURL, cfg.GetInterval(), cfg.GetHealthPort())
+	k8ssync.Run(ctx, engine, cfg.Mappings, cfg.GetInterval(), log.Printf, status)
 	log.Println("k8s-sync: stopped")
 }
 

--- a/deploy/helm/keyorix-k8s-sync/templates/configmap.yaml
+++ b/deploy/helm/keyorix-k8s-sync/templates/configmap.yaml
@@ -9,6 +9,7 @@ data:
   k8s-sync.yaml: |
     keyorix_url: {{ required "keyorix.url is required" .Values.keyorix.url | quote }}
     interval: {{ .Values.keyorix.interval | default "5m" | quote }}
+    health_port: {{ .Values.healthPort | default 8080 }}
     mappings:
     {{- if .Values.mappings }}
       {{- toYaml .Values.mappings | nindent 6 }}

--- a/deploy/helm/keyorix-k8s-sync/templates/deployment.yaml
+++ b/deploy/helm/keyorix-k8s-sync/templates/deployment.yaml
@@ -36,6 +36,21 @@ spec:
                 secretKeyRef:
                   name: {{ required "keyorix.tokenSecret.name is required" .Values.keyorix.tokenSecret.name }}
                   key: {{ .Values.keyorix.tokenSecret.key | default "token" }}
+          ports:
+            - name: health
+              containerPort: {{ .Values.healthPort | default 8080 }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: health
+            initialDelaySeconds: 5
+            periodSeconds: 15
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: health
+            initialDelaySeconds: 5
+            periodSeconds: 10
           volumeMounts:
             - name: config
               mountPath: /etc/keyorix

--- a/deploy/helm/keyorix-k8s-sync/values.yaml
+++ b/deploy/helm/keyorix-k8s-sync/values.yaml
@@ -21,6 +21,9 @@ keyorix:
     name: ""        # required: a Secret holding the Keyorix machine-identity token
     key: token      # the key within that Secret
 
+# healthPort is where the agent serves /healthz, /readyz and /status (probes).
+healthPort: 8080
+
 # mappings: each copies one Keyorix secret ("<environment>/<name>") into one key of
 # one Kubernetes Secret. Several mappings may target the same Secret.
 #   - ref: production/db-password

--- a/docs/k8s-sync.md
+++ b/docs/k8s-sync.md
@@ -60,5 +60,16 @@ keyorix-k8s-sync -config /etc/keyorix/k8s-sync.yaml
 
 Logs are counts and target identities only — secret values are never logged.
 
+## Health & probes
+
+The agent serves probe endpoints on `health_port` (default `8080`):
+
+- `GET /healthz` — liveness; always `200` while the process is responsive.
+- `GET /readyz` — readiness; `503` until the first reconcile completes, then `200`.
+- `GET /status` — JSON of the last pass (counts + timestamp + error count; no values).
+
+The Helm chart wires `/healthz` and `/readyz` as the Deployment's liveness and
+readiness probes.
+
 > A Helm chart that deploys the agent with its RBAC and config ships separately
 > (`deploy/helm/keyorix-k8s-sync`).

--- a/internal/k8ssync/config.go
+++ b/internal/k8ssync/config.go
@@ -15,7 +15,8 @@ import (
 // KEYORIX_TOKEN environment variable so it can come from a mounted Secret.
 type Config struct {
 	KeyorixURL string          `yaml:"keyorix_url"`
-	Interval   string          `yaml:"interval"` // Go duration (e.g. "5m"); default 5m
+	Interval   string          `yaml:"interval"`    // Go duration (e.g. "5m"); default 5m
+	HealthPort int             `yaml:"health_port"` // probe/status HTTP port; default 8080
 	Mappings   []SecretMapping `yaml:"mappings"`
 }
 
@@ -65,4 +66,14 @@ func (c *Config) GetInterval() time.Duration {
 		}
 	}
 	return defaultSyncInterval
+}
+
+const defaultHealthPort = 8080
+
+// GetHealthPort returns the health/probe HTTP port, defaulting to 8080 when unset.
+func (c *Config) GetHealthPort() int {
+	if c.HealthPort > 0 {
+		return c.HealthPort
+	}
+	return defaultHealthPort
 }

--- a/internal/k8ssync/health.go
+++ b/internal/k8ssync/health.go
@@ -1,0 +1,81 @@
+package k8ssync
+
+import (
+	"encoding/json"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// Status tracks the outcome of the most recent reconcile pass so the agent can serve
+// Kubernetes liveness/readiness probes. It is safe for concurrent use: the reconcile
+// loop records results while the HTTP handler reads them.
+type Status struct {
+	mu      sync.Mutex
+	ran     bool
+	lastRun time.Time
+	last    Result
+	now     func() time.Time
+}
+
+// NewStatus returns a Status with a real clock.
+func NewStatus() *Status {
+	return &Status{now: time.Now}
+}
+
+// Record stores the result of a completed reconcile pass.
+func (s *Status) Record(res Result) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.ran = true
+	s.lastRun = s.now()
+	s.last = res
+}
+
+func (s *Status) snapshot() (bool, time.Time, Result) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.ran, s.lastRun, s.last
+}
+
+// Handler serves the agent's probe + status endpoints:
+//   - GET /healthz — liveness: always 200 while the process is responsive.
+//   - GET /readyz  — readiness: 200 once at least one reconcile pass has completed,
+//     503 before that (so traffic/rollout waits for the first sync).
+//   - GET /status  — JSON of the last pass (counts + timestamp), for observability.
+//
+// No secret values are exposed — only counts, a timestamp, and an error count.
+func (s *Status) Handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+	mux.HandleFunc("/readyz", func(w http.ResponseWriter, _ *http.Request) {
+		ran, _, _ := s.snapshot()
+		if !ran {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte("no reconcile completed yet"))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ready"))
+	})
+	mux.HandleFunc("/status", func(w http.ResponseWriter, _ *http.Request) {
+		ran, lastRun, last := s.snapshot()
+		body := map[string]interface{}{
+			"ran":       ran,
+			"created":   last.Created,
+			"updated":   last.Updated,
+			"unchanged": last.Unchanged,
+			"failed":    last.Failed,
+			"errors":    len(last.Errors),
+		}
+		if ran {
+			body["last_run"] = lastRun.UTC().Format(time.RFC3339)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(body)
+	})
+	return mux
+}

--- a/internal/k8ssync/health_test.go
+++ b/internal/k8ssync/health_test.go
@@ -1,0 +1,60 @@
+package k8ssync
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func get(t *testing.T, h http.Handler, path string) *httptest.ResponseRecorder {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
+	return rec
+}
+
+func TestHealth_LivenessAlwaysOK(t *testing.T) {
+	h := NewStatus().Handler()
+	rec := get(t, h, "/healthz")
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestHealth_ReadinessGatesOnFirstSync(t *testing.T) {
+	s := NewStatus()
+	h := s.Handler()
+
+	// Before any reconcile: not ready.
+	assert.Equal(t, http.StatusServiceUnavailable, get(t, h, "/readyz").Code)
+
+	// After a pass completes: ready.
+	s.Record(Result{Created: 2})
+	assert.Equal(t, http.StatusOK, get(t, h, "/readyz").Code)
+}
+
+func TestHealth_StatusReportsCounts(t *testing.T) {
+	s := NewStatus()
+	h := s.Handler()
+
+	// Before a run.
+	var before map[string]interface{}
+	require.NoError(t, json.Unmarshal(get(t, h, "/status").Body.Bytes(), &before))
+	assert.Equal(t, false, before["ran"])
+	_, hasLastRun := before["last_run"]
+	assert.False(t, hasLastRun, "no last_run before the first pass")
+
+	// After a run with mixed outcomes.
+	s.Record(Result{Created: 1, Updated: 2, Unchanged: 3, Failed: 1, Errors: []string{"app/x: boom"}})
+	var after map[string]interface{}
+	require.NoError(t, json.Unmarshal(get(t, h, "/status").Body.Bytes(), &after))
+	assert.Equal(t, true, after["ran"])
+	assert.EqualValues(t, 1, after["created"])
+	assert.EqualValues(t, 2, after["updated"])
+	assert.EqualValues(t, 3, after["unchanged"])
+	assert.EqualValues(t, 1, after["failed"])
+	assert.EqualValues(t, 1, after["errors"], "error count, not the messages")
+	assert.Contains(t, after, "last_run")
+}

--- a/internal/k8ssync/runner.go
+++ b/internal/k8ssync/runner.go
@@ -25,15 +25,22 @@ func Sync(ctx context.Context, e *Engine, mappings []SecretMapping, logf Logf) R
 	return res
 }
 
-// Run reconciles once immediately, then every interval until ctx is cancelled.
-func Run(ctx context.Context, e *Engine, mappings []SecretMapping, interval time.Duration, logf Logf) {
-	Sync(ctx, e, mappings, logf)
+// Run reconciles once immediately, then every interval until ctx is cancelled. When
+// status is non-nil, each pass's result is recorded for the health/readiness probes.
+func Run(ctx context.Context, e *Engine, mappings []SecretMapping, interval time.Duration, logf Logf, status *Status) {
+	sync := func() {
+		res := Sync(ctx, e, mappings, logf)
+		if status != nil {
+			status.Record(res)
+		}
+	}
+	sync()
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 	for {
 		select {
 		case <-ticker.C:
-			Sync(ctx, e, mappings, logf)
+			sync()
 		case <-ctx.Done():
 			return
 		}


### PR DESCRIPTION
## Summary

The sync agent had no HTTP surface, so its Deployment couldn't be probed. This adds a small health server and wires it into the chart — making the agent production-probeable.

- **`internal/k8ssync/health.go`** — a thread-safe `Status` the reconcile loop records into, plus a `Handler` serving:
  - `GET /healthz` — liveness; always `200`.
  - `GET /readyz` — readiness; `503` until the first reconcile completes, then `200` (so rollout/traffic waits for the first sync).
  - `GET /status` — JSON of the last pass (counts + timestamp + **error count**, never values).
- **`runner.Run`** records each pass into an optional `*Status`; **`main`** starts the health server (config `health_port`, default `8080`) with graceful shutdown.
- **Helm** — `containerPort` + `liveness`(`/healthz`) and `readiness`(`/readyz`) probes; `health_port` rendered into the ConfigMap and exposed via `values.healthPort`.
- docs updated.

## Test plan
- `go build ./...` ✅ · `go test ./internal/k8ssync/` ✅ · `gosec` ✅ · `golangci-lint` ✅ — **no new deps**
- `helm lint` clean + `kubeconform` 6/6 valid (probes render)
- Health tests: liveness always OK, readiness gates on the first sync, `/status` reports counts (error *count*, not messages) + `last_run` only after a run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)