### PR TITLE
feat(k8s): --dry-run and --once modes for the sync agent

### DIFF
--- a/cmd/keyorix-k8s-sync/main.go
+++ b/cmd/keyorix-k8s-sync/main.go
@@ -29,6 +29,8 @@ import (
 func main() {
 	configPath := flag.String("config", envOr("KEYORIX_K8S_SYNC_CONFIG", "/etc/keyorix/k8s-sync.yaml"),
 		"path to the sync config (YAML)")
+	once := flag.Bool("once", false, "run a single reconcile pass and exit (for CI / one-shot Jobs)")
+	dryRun := flag.Bool("dry-run", false, "report what would change without writing any Secret")
 	flag.Parse()
 
 	cfg, err := k8ssync.LoadConfig(*configPath)
@@ -46,7 +48,11 @@ func main() {
 		log.Fatalf("k8s-sync: kubernetes: %v", err)
 	}
 
-	engine := k8ssync.NewEngine(k8ssync.NewKeyorixFetcher(cfg.KeyorixURL, token), sink)
+	var engineOpts []k8ssync.Option
+	if *dryRun {
+		engineOpts = append(engineOpts, k8ssync.WithDryRun())
+	}
+	engine := k8ssync.NewEngine(k8ssync.NewKeyorixFetcher(cfg.KeyorixURL, token), sink, engineOpts...)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -57,6 +63,22 @@ func main() {
 		log.Println("k8s-sync: shutdown signal received")
 		cancel()
 	}()
+
+	// One-shot mode: a single reconcile, then exit non-zero if anything failed (handy
+	// as a CI gate or a Kubernetes Job). No health server / loop.
+	if *once {
+		mode := ""
+		if *dryRun {
+			mode = " (dry-run)"
+		}
+		log.Printf("k8s-sync: one-shot reconcile of %d mapping(s) from %s%s",
+			len(cfg.Mappings), cfg.KeyorixURL, mode)
+		res := k8ssync.Sync(ctx, engine, cfg.Mappings, log.Printf)
+		if res.Failed > 0 {
+			os.Exit(1)
+		}
+		return
+	}
 
 	// Health/readiness server for Kubernetes probes (/healthz, /readyz, /status).
 	status := k8ssync.NewStatus()
@@ -76,8 +98,12 @@ func main() {
 		_ = healthSrv.Shutdown(shutdownCtx)
 	}()
 
-	log.Printf("k8s-sync: syncing %d mapping(s) from %s every %s (health :%d)",
-		len(cfg.Mappings), cfg.KeyorixURL, cfg.GetInterval(), cfg.GetHealthPort())
+	loopMode := ""
+	if *dryRun {
+		loopMode = " (dry-run)"
+	}
+	log.Printf("k8s-sync: syncing %d mapping(s) from %s every %s (health :%d)%s",
+		len(cfg.Mappings), cfg.KeyorixURL, cfg.GetInterval(), cfg.GetHealthPort(), loopMode)
 	k8ssync.Run(ctx, engine, cfg.Mappings, cfg.GetInterval(), log.Printf, status)
 	log.Println("k8s-sync: stopped")
 }

--- a/docs/k8s-sync.md
+++ b/docs/k8s-sync.md
@@ -60,6 +60,17 @@ keyorix-k8s-sync -config /etc/keyorix/k8s-sync.yaml
 
 Logs are counts and target identities only — secret values are never logged.
 
+### Flags
+
+- `-once` — run a single reconcile pass and exit (no health server / loop). Exits
+  non-zero if any target failed, so it works as a CI gate or a Kubernetes `Job`.
+- `-dry-run` — report what *would* change (created/updated/unchanged counts) without
+  writing any Secret. Combine with `-once` to validate config and preview a sync.
+
+```
+keyorix-k8s-sync -config ./k8s-sync.yaml -once -dry-run
+```
+
 ## Health & probes
 
 The agent serves probe endpoints on `health_port` (default `8080`):

--- a/internal/k8ssync/sync.go
+++ b/internal/k8ssync/sync.go
@@ -95,6 +95,16 @@ func (e *Engine) Reconcile(ctx context.Context, mappings []SecretMapping) (Resul
 			continue
 		}
 
+		// In dry-run, tally what WOULD change but don't write.
+		if e.dryRun {
+			if current == nil {
+				res.Created++
+			} else {
+				res.Updated++
+			}
+			continue
+		}
+
 		if aerr := e.sink.Apply(ctx, t.namespace, t.name, desired); aerr != nil {
 			res.Failed++
 			res.Errors = append(res.Errors, fmt.Sprintf("%s: apply: %v", t, aerr))
@@ -113,11 +123,25 @@ func (e *Engine) Reconcile(ctx context.Context, mappings []SecretMapping) (Resul
 type Engine struct {
 	fetcher Fetcher
 	sink    Sink
+	dryRun  bool
+}
+
+// Option configures an Engine.
+type Option func(*Engine)
+
+// WithDryRun makes the engine compute the diff and report what WOULD change without
+// writing any Secret — for config validation and safe previews.
+func WithDryRun() Option {
+	return func(e *Engine) { e.dryRun = true }
 }
 
 // NewEngine constructs an Engine over the given Fetcher and Sink.
-func NewEngine(fetcher Fetcher, sink Sink) *Engine {
-	return &Engine{fetcher: fetcher, sink: sink}
+func NewEngine(fetcher Fetcher, sink Sink, opts ...Option) *Engine {
+	e := &Engine{fetcher: fetcher, sink: sink}
+	for _, opt := range opts {
+		opt(e)
+	}
+	return e
 }
 
 // buildDesired fetches every mapping's referenced value and assembles the target

--- a/internal/k8ssync/sync_test.go
+++ b/internal/k8ssync/sync_test.go
@@ -127,6 +127,25 @@ func TestReconcile_FetchFailureSkipsWholeTarget(t *testing.T) {
 	assert.Contains(t, res.Errors[0], "app/creds")
 }
 
+func TestReconcile_DryRunReportsButDoesNotWrite(t *testing.T) {
+	f := &fakeFetcher{values: map[string][]byte{"prod/new": []byte("v"), "prod/chg": []byte("rotated")}}
+	s := newFakeSink()
+	s.existing["app/changed"] = map[string][]byte{"K": []byte("old")} // would update
+	s.existing["app/same"] = map[string][]byte{"K": []byte("v")}      // unchanged
+	e := NewEngine(f, s, WithDryRun())
+
+	res, err := e.Reconcile(context.Background(), []SecretMapping{
+		{Ref: "prod/new", Namespace: "app", Name: "created", Key: "K"}, // would create
+		{Ref: "prod/chg", Namespace: "app", Name: "changed", Key: "K"}, // would update
+		{Ref: "prod/new", Namespace: "app", Name: "same", Key: "K"},    // unchanged
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, res.Created, "dry-run still reports a would-create")
+	assert.Equal(t, 1, res.Updated, "dry-run still reports a would-update")
+	assert.Equal(t, 1, res.Unchanged)
+	assert.Empty(t, s.applied, "dry-run must not write any Secret")
+}
+
 func TestReconcile_OneTargetFailureDoesNotBlockOthers(t *testing.T) {
 	f := &fakeFetcher{
 		values: map[string][]byte{"prod/ok": []byte("v")},


### PR DESCRIPTION
## Summary

Two operational modes for the K8s sync agent.

- **Engine** gains a functional-options constructor + **`WithDryRun()`**: in dry-run, `Reconcile` computes the diff and tallies what *would* be created/updated but **writes nothing**. `NewEngine` stays backward-compatible (variadic opts).
- **Agent flags:**
  - **`-once`** — run a single reconcile and exit; exits **non-zero if any target failed** (a CI gate or a Kubernetes `Job` — no health server / loop).
  - **`-dry-run`** — report would-change counts without writing; combine with `-once` to validate config and preview a sync.

```
keyorix-k8s-sync -config ./k8s-sync.yaml -once -dry-run
```

## Test plan
- `go build ./...` ✅ · agent builds ✅ · `go test ./internal/k8ssync/` ✅ · `gosec` ✅ · `golangci-lint` ✅ — **no new deps**
- New test: dry-run reports would-create / would-update / unchanged but applies nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)