### PR TITLE
release: prep v0.54.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,38 @@
 All notable changes to Keyorix are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## v0.54.0 — 2026-06-17
+
+Kubernetes integration: sync Keyorix secrets into native Kubernetes Secrets.
+
+### Added
+- **Kubernetes sync agent** (`keyorix-k8s-sync`) — a small in-cluster agent that
+  materialises selected Keyorix secrets into native Kubernetes Secrets and refreshes
+  them as the upstream values rotate. It authenticates to Keyorix with a
+  machine-identity token and writes Secrets via the Kubernetes API (Server-Side Apply)
+  using its service-account credentials — **no `client-go` dependency**. A reconcile
+  creates/updates a target Secret only when its data changes and never writes a Secret
+  partially if any value fails to fetch. ([#291], [#292], [#293], [#294])
+- **Agent container image** — published to `ghcr.io/keyorixhq/keyorix-k8s-sync`
+  alongside the server image. ([#295])
+- **Helm chart** (`deploy/helm/keyorix-k8s-sync`) — deploys the agent with
+  least-privilege RBAC (a `RoleBinding` to a `secrets` `get`/`create`/`patch`
+  `ClusterRole` per target namespace), config, and the token sourced from an existing
+  Secret. ([#296])
+- **Health & probes** — the agent serves `/healthz`, `/readyz` (gated on the first
+  successful reconcile), and `/status`; the chart wires liveness/readiness probes. ([#297])
+- **`-once` and `-dry-run` modes** — run a single reconcile (a CI gate / Kubernetes
+  `Job`; non-zero exit on failure) and preview what would change without writing. ([#298])
+
+[#291]: https://github.com/keyorixhq/keyorix/pull/291
+[#292]: https://github.com/keyorixhq/keyorix/pull/292
+[#293]: https://github.com/keyorixhq/keyorix/pull/293
+[#294]: https://github.com/keyorixhq/keyorix/pull/294
+[#295]: https://github.com/keyorixhq/keyorix/pull/295
+[#296]: https://github.com/keyorixhq/keyorix/pull/296
+[#297]: https://github.com/keyorixhq/keyorix/pull/297
+[#298]: https://github.com/keyorixhq/keyorix/pull/298
+
 ## v0.53.0 — 2026-06-17
 
 Access-anomaly detection and secret-sharing lifecycle improvements.

--- a/deploy/helm/keyorix-k8s-sync/Chart.yaml
+++ b/deploy/helm/keyorix-k8s-sync/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix-k8s-sync
 description: Keyorix Kubernetes sync agent — materialises Keyorix secrets into native Kubernetes Secrets
 type: application
 # Chart version — bump on chart changes.
-version: 0.1.0
+version: 0.1.1
 # The keyorix-k8s-sync image tag this chart deploys by default.
-appVersion: "0.53.0"
+appVersion: "0.54.0"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix

--- a/deploy/helm/keyorix/Chart.yaml
+++ b/deploy/helm/keyorix/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix
 description: Self-hosted Keyorix secrets manager (API server + web UI + PostgreSQL)
 type: application
 # Chart version — bump on chart changes.
-version: 0.53.0
+version: 0.54.0
 # The Keyorix app version this chart deploys by default (the image tag).
-appVersion: "0.53.0"
+appVersion: "0.54.0"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix


### PR DESCRIPTION
## v0.54.0 — Kubernetes integration

Bumps CHANGELOG + Helm charts. Bundles the full Kubernetes integration merged since v0.53.0:

- **#291–#294** — the `keyorix-k8s-sync` agent (reconcile engine, Keyorix fetcher, REST sink, binary/config) — syncs Keyorix secrets into native Kubernetes Secrets, **no `client-go` dependency**
- **#295** — agent container image → `ghcr.io/keyorixhq/keyorix-k8s-sync`
- **#296** — Helm chart with least-privilege RBAC
- **#297** — health/readiness probes
- **#298** — `-once` / `-dry-run` modes

Chart bumps: `keyorix` → 0.54.0; `keyorix-k8s-sync` → chart 0.1.1 / appVersion 0.54.0 (the agent image the `v0.54.0` tag will publish via docker-publish's semver tag).

> Follow-up (not in this release): wire `deploy/helm/keyorix-k8s-sync` into the OCI chart-publish step (release.yml currently publishes only the main chart).

🤖 Generated with [Claude Code](https://claude.com/claude-code)