### PR TITLE
build(k8s): publish the keyorix-k8s-sync Helm chart to GHCR on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,13 +50,15 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v5
 
-      - name: Package + push chart to GHCR (OCI)
+      - name: Package + push charts to GHCR (OCI)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Chart version = the tag without the leading 'v' (semver); app version
-          # = the full tag, so the chart pins the matching image by default.
+          # = the full tag, so each chart pins its matching image by default.
           version="${GITHUB_REF_NAME#v}"
-          helm package deploy/helm/keyorix --version "$version" --app-version "$version"
+          helm package deploy/helm/keyorix          --version "$version" --app-version "$version"
+          helm package deploy/helm/keyorix-k8s-sync --version "$version" --app-version "$version"
           echo "$GH_TOKEN" | helm registry login ghcr.io -u "${{ github.actor }}" --password-stdin
-          helm push "keyorix-${version}.tgz" oci://ghcr.io/keyorixhq/charts
+          helm push "keyorix-${version}.tgz"          oci://ghcr.io/keyorixhq/charts
+          helm push "keyorix-k8s-sync-${version}.tgz" oci://ghcr.io/keyorixhq/charts

--- a/deploy/helm/keyorix-k8s-sync/README.md
+++ b/deploy/helm/keyorix-k8s-sync/README.md
@@ -12,7 +12,13 @@ First create a Secret holding the agent's Keyorix machine-identity token:
 kubectl -n keyorix create secret generic keyorix-token --from-literal=token=<TOKEN>
 ```
 
-Then install with your mappings:
+Then install with your mappings — from the published OCI chart:
+
+```sh
+helm install kx-sync oci://ghcr.io/keyorixhq/charts/keyorix-k8s-sync --version <release> \
+```
+
+…or from this repo checkout:
 
 ```sh
 helm install kx-sync deploy/helm/keyorix-k8s-sync \


### PR DESCRIPTION
## Summary

`release.yml`'s chart-publish step packaged + pushed only the main `keyorix` chart, so the agent chart was **install-from-repo only**. Now it packages + pushes `deploy/helm/keyorix-k8s-sync` alongside it (same `--version`/`--app-version` = the release tag), so it's `helm pull`-able from `oci://ghcr.io/keyorixhq/charts/keyorix-k8s-sync`.

The chart README gains an OCI-install example.

## Test plan
- Verified `helm package deploy/helm/keyorix-k8s-sync --version <v> --app-version <v>` produces `keyorix-k8s-sync-<v>.tgz` (the filename the push step expects).
- The publish itself runs on the next release tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)