### PR TITLE
feat(k8s): Prometheus /metrics for the sync agent

### DIFF
--- a/deploy/helm/keyorix-k8s-sync/templates/deployment.yaml
+++ b/deploy/helm/keyorix-k8s-sync/templates/deployment.yaml
@@ -15,6 +15,10 @@ spec:
       annotations:
         # Roll the pod when the config changes.
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        # Prometheus scrape hints for the agent's /metrics endpoint.
+        prometheus.io/scrape: "true"
+        prometheus.io/port: {{ .Values.healthPort | default 8080 | quote }}
+        prometheus.io/path: /metrics
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/docs/k8s-sync.md
+++ b/docs/k8s-sync.md
@@ -78,6 +78,9 @@ The agent serves probe endpoints on `health_port` (default `8080`):
 - `GET /healthz` — liveness; always `200` while the process is responsive.
 - `GET /readyz` — readiness; `503` until the first reconcile completes, then `200`.
 - `GET /status` — JSON of the last pass (counts + timestamp + error count; no values).
+- `GET /metrics` — Prometheus metrics: `keyorix_k8s_sync_reconcile_passes_total`,
+  `keyorix_k8s_sync_secrets_total{outcome=…}`, `keyorix_k8s_sync_last_run_timestamp_seconds`,
+  and `keyorix_k8s_sync_last_failed`. The chart adds `prometheus.io/scrape` pod annotations.
 
 The Helm chart wires `/healthz` and `/readyz` as the Deployment's liveness and
 readiness probes.

--- a/internal/k8ssync/health.go
+++ b/internal/k8ssync/health.go
@@ -2,20 +2,25 @@ package k8ssync
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"sync"
 	"time"
 )
 
-// Status tracks the outcome of the most recent reconcile pass so the agent can serve
-// Kubernetes liveness/readiness probes. It is safe for concurrent use: the reconcile
-// loop records results while the HTTP handler reads them.
+// Status tracks the outcome of the most recent reconcile pass — plus cumulative
+// totals across all passes — so the agent can serve Kubernetes liveness/readiness
+// probes and Prometheus metrics. Safe for concurrent use: the reconcile loop records
+// results while the HTTP handlers read them.
 type Status struct {
 	mu      sync.Mutex
 	ran     bool
 	lastRun time.Time
 	last    Result
-	now     func() time.Time
+	passes  int64
+	// Cumulative target-Secret outcomes across all passes (monotonic counters).
+	totCreated, totUpdated, totUnchanged, totFailed int64
+	now                                             func() time.Time
 }
 
 // NewStatus returns a Status with a real clock.
@@ -23,13 +28,19 @@ func NewStatus() *Status {
 	return &Status{now: time.Now}
 }
 
-// Record stores the result of a completed reconcile pass.
+// Record stores the result of a completed reconcile pass and folds it into the
+// cumulative totals.
 func (s *Status) Record(res Result) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.ran = true
 	s.lastRun = s.now()
 	s.last = res
+	s.passes++
+	s.totCreated += int64(res.Created)
+	s.totUpdated += int64(res.Updated)
+	s.totUnchanged += int64(res.Unchanged)
+	s.totFailed += int64(res.Failed)
 }
 
 func (s *Status) snapshot() (bool, time.Time, Result) {
@@ -77,5 +88,42 @@ func (s *Status) Handler() http.Handler {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(body)
 	})
+	mux.HandleFunc("/metrics", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain; version=0.0.4")
+		_, _ = w.Write([]byte(s.metrics()))
+	})
 	return mux
+}
+
+// metrics renders the agent's state in the Prometheus text exposition format. Written
+// by hand to avoid a client-library dependency (the metric set is small and stable).
+func (s *Status) metrics() string {
+	s.mu.Lock()
+	ran := s.ran
+	lastRun := s.lastRun
+	last := s.last
+	passes := s.passes
+	c, u, n, f := s.totCreated, s.totUpdated, s.totUnchanged, s.totFailed
+	s.mu.Unlock()
+
+	var lastTS int64
+	if ran {
+		lastTS = lastRun.Unix()
+	}
+	return fmt.Sprintf(`# HELP keyorix_k8s_sync_reconcile_passes_total Reconcile passes completed.
+# TYPE keyorix_k8s_sync_reconcile_passes_total counter
+keyorix_k8s_sync_reconcile_passes_total %d
+# HELP keyorix_k8s_sync_secrets_total Cumulative target-Secret outcomes across all passes.
+# TYPE keyorix_k8s_sync_secrets_total counter
+keyorix_k8s_sync_secrets_total{outcome="created"} %d
+keyorix_k8s_sync_secrets_total{outcome="updated"} %d
+keyorix_k8s_sync_secrets_total{outcome="unchanged"} %d
+keyorix_k8s_sync_secrets_total{outcome="failed"} %d
+# HELP keyorix_k8s_sync_last_run_timestamp_seconds Unix time of the last completed reconcile (0 if none).
+# TYPE keyorix_k8s_sync_last_run_timestamp_seconds gauge
+keyorix_k8s_sync_last_run_timestamp_seconds %d
+# HELP keyorix_k8s_sync_last_failed Target Secrets that failed in the most recent reconcile.
+# TYPE keyorix_k8s_sync_last_failed gauge
+keyorix_k8s_sync_last_failed %d
+`, passes, c, u, n, f, lastTS, last.Failed)
 }

--- a/internal/k8ssync/health_test.go
+++ b/internal/k8ssync/health_test.go
@@ -35,6 +35,31 @@ func TestHealth_ReadinessGatesOnFirstSync(t *testing.T) {
 	assert.Equal(t, http.StatusOK, get(t, h, "/readyz").Code)
 }
 
+func TestHealth_MetricsExposition(t *testing.T) {
+	s := NewStatus()
+	h := s.Handler()
+
+	// Two passes accumulate into the counters; the gauge reflects the last pass.
+	s.Record(Result{Created: 1, Updated: 0, Unchanged: 2, Failed: 0})
+	s.Record(Result{Created: 0, Updated: 3, Unchanged: 2, Failed: 1})
+
+	body := get(t, h, "/metrics").Body.String()
+	assert.Contains(t, body, "keyorix_k8s_sync_reconcile_passes_total 2")
+	assert.Contains(t, body, `keyorix_k8s_sync_secrets_total{outcome="created"} 1`)
+	assert.Contains(t, body, `keyorix_k8s_sync_secrets_total{outcome="updated"} 3`)
+	assert.Contains(t, body, `keyorix_k8s_sync_secrets_total{outcome="unchanged"} 4`)
+	assert.Contains(t, body, `keyorix_k8s_sync_secrets_total{outcome="failed"} 1`)
+	assert.Contains(t, body, "keyorix_k8s_sync_last_failed 1")
+	// Well-formed exposition: every metric has a HELP and TYPE line.
+	assert.Contains(t, body, "# TYPE keyorix_k8s_sync_reconcile_passes_total counter")
+}
+
+func TestHealth_MetricsBeforeFirstRun(t *testing.T) {
+	body := get(t, NewStatus().Handler(), "/metrics").Body.String()
+	assert.Contains(t, body, "keyorix_k8s_sync_reconcile_passes_total 0")
+	assert.Contains(t, body, "keyorix_k8s_sync_last_run_timestamp_seconds 0")
+}
+
 func TestHealth_StatusReportsCounts(t *testing.T) {
 	s := NewStatus()
 	h := s.Handler()


### PR DESCRIPTION
## Summary

The agent now exposes **`/metrics`** on its health port in the Prometheus text format — hand-written, **no client-library dependency** (the metric set is small and stable):

- `keyorix_k8s_sync_reconcile_passes_total` (counter)
- `keyorix_k8s_sync_secrets_total{outcome="created|updated|unchanged|failed"}` (counter)
- `keyorix_k8s_sync_last_run_timestamp_seconds` (gauge)
- `keyorix_k8s_sync_last_failed` (gauge)

`Status` accumulates cumulative totals across passes (folded in by `Record`) alongside the existing last-pass snapshot. The Helm Deployment gains `prometheus.io/scrape` pod annotations (port + `/metrics` path). Docs updated.

## Test plan
- `go build ./...` ✅ · `go test ./internal/k8ssync/` ✅ · `gosec` ✅ · `golangci-lint` ✅ — **no new deps**
- `helm` + `kubeconform` 6/6 (scrape annotations render)
- Tests: metrics exposition (counters accumulate over two passes, the gauge reflects the last pass, HELP/TYPE present) + zeros before the first run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)