### PR TITLE
release: prep v0.55.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to Keyorix are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## v0.55.0 — 2026-06-17
+
+Kubernetes sync agent: observability + distribution.
+
+### Added
+- **Prometheus metrics** — the sync agent serves `/metrics` (reconcile passes,
+  per-outcome Secret counts, last-run timestamp, last-failed gauge); the Helm chart
+  adds `prometheus.io/scrape` pod annotations. ([#301])
+- **Agent Helm chart published to GHCR** — `keyorix-k8s-sync` is now pushed to
+  `oci://ghcr.io/keyorixhq/charts/keyorix-k8s-sync` on release, so it can be installed
+  with `helm install … oci://…` rather than only from a repo checkout. ([#300])
+
+[#300]: https://github.com/keyorixhq/keyorix/pull/300
+[#301]: https://github.com/keyorixhq/keyorix/pull/301
+
 ## v0.54.0 — 2026-06-17
 
 Kubernetes integration: sync Keyorix secrets into native Kubernetes Secrets.

--- a/deploy/helm/keyorix-k8s-sync/Chart.yaml
+++ b/deploy/helm/keyorix-k8s-sync/Chart.yaml
@@ -2,10 +2,10 @@ apiVersion: v2
 name: keyorix-k8s-sync
 description: Keyorix Kubernetes sync agent — materialises Keyorix secrets into native Kubernetes Secrets
 type: application
-# Chart version — bump on chart changes.
-version: 0.1.1
+# Chart version — tracks the Keyorix release version (published in lockstep).
+version: 0.55.0
 # The keyorix-k8s-sync image tag this chart deploys by default.
-appVersion: "0.54.0"
+appVersion: "0.55.0"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix

--- a/deploy/helm/keyorix/Chart.yaml
+++ b/deploy/helm/keyorix/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix
 description: Self-hosted Keyorix secrets manager (API server + web UI + PostgreSQL)
 type: application
 # Chart version — bump on chart changes.
-version: 0.54.0
+version: 0.55.0
 # The Keyorix app version this chart deploys by default (the image tag).
-appVersion: "0.54.0"
+appVersion: "0.55.0"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix


### PR DESCRIPTION
## v0.55.0 — K8s sync agent: observability + distribution

Bumps CHANGELOG + Helm charts to **0.55.0**. Bundles the two commits since v0.54.0:

- **#301** — Prometheus `/metrics` on the agent + `prometheus.io/scrape` annotations
- **#300** — the `keyorix-k8s-sync` Helm chart is now published to `oci://ghcr.io/keyorixhq/charts/keyorix-k8s-sync` on release

Both charts → 0.55.0; the `keyorix-k8s-sync` chart now tracks the release version in lockstep (this tag publishes it to GHCR for the first time).

🤖 Generated with [Claude Code](https://claude.com/claude-code)