### PR TITLE
feat(template): secret-reference template engine (1/n)

### DIFF
--- a/internal/secrettemplate/render.go
+++ b/internal/secrettemplate/render.go
@@ -1,0 +1,86 @@
+// Package secrettemplate renders templates that embed Keyorix secret references,
+// expanding ${secret:<ref>} placeholders to their values. It is the pure, transport-
+// and storage-agnostic core: the caller supplies a Resolver that maps a reference to
+// a value (with its own permission checks). Rendered output is never logged by this
+// package.
+package secrettemplate
+
+import (
+	"fmt"
+	"strings"
+)
+
+// marker is the placeholder prefix; a reference looks like ${secret:<ref>}.
+const marker = "${secret:"
+
+// Resolver maps a secret reference (the text between "${secret:" and "}") to its
+// value. It returns an error when the reference is unknown or inaccessible.
+type Resolver func(ref string) (string, error)
+
+// Render expands every ${secret:<ref>} placeholder in tmpl using resolve and returns
+// the result. Rules:
+//   - "$$" collapses to a literal "$" — so "$${secret:x}" renders the literal text
+//     "${secret:x}" without resolving anything.
+//   - a "$" not part of "$$" or a placeholder is literal.
+//   - an unterminated placeholder (no closing "}") or an empty ref is an error.
+//   - a resolver error aborts the render, naming the offending reference.
+//
+// References are collected in order; resolve is called once per occurrence.
+func Render(tmpl string, resolve Resolver) (string, error) {
+	var b strings.Builder
+	for i := 0; i < len(tmpl); {
+		c := tmpl[i]
+		if c != '$' {
+			b.WriteByte(c)
+			i++
+			continue
+		}
+		// c == '$'
+		if i+1 < len(tmpl) && tmpl[i+1] == '$' {
+			b.WriteByte('$') // "$$" -> "$"
+			i += 2
+			continue
+		}
+		if strings.HasPrefix(tmpl[i:], marker) {
+			rest := tmpl[i+len(marker):]
+			end := strings.IndexByte(rest, '}')
+			if end < 0 {
+				return "", fmt.Errorf("unterminated ${secret:…} placeholder at offset %d", i)
+			}
+			ref := strings.TrimSpace(rest[:end])
+			if ref == "" {
+				return "", fmt.Errorf("empty secret reference at offset %d", i)
+			}
+			val, err := resolve(ref)
+			if err != nil {
+				return "", fmt.Errorf("resolve %q: %w", ref, err)
+			}
+			b.WriteString(val)
+			i += len(marker) + end + 1 // past the closing '}'
+			continue
+		}
+		// A lone '$' that doesn't start a placeholder.
+		b.WriteByte('$')
+		i++
+	}
+	return b.String(), nil
+}
+
+// References returns the distinct secret references in tmpl, in first-seen order,
+// without resolving them — useful for a dry-run / "what does this template need?"
+// preflight. Malformed placeholders are reported as an error, matching Render.
+func References(tmpl string) ([]string, error) {
+	var refs []string
+	seen := map[string]bool{}
+	_, err := Render(tmpl, func(ref string) (string, error) {
+		if !seen[ref] {
+			seen[ref] = true
+			refs = append(refs, ref)
+		}
+		return "", nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return refs, nil
+}

--- a/internal/secrettemplate/render_test.go
+++ b/internal/secrettemplate/render_test.go
@@ -1,0 +1,77 @@
+package secrettemplate
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// upper is a trivial resolver that echoes a value per ref, or errors on "missing".
+func fakeResolve(ref string) (string, error) {
+	if ref == "missing" {
+		return "", errors.New("not found")
+	}
+	return "<" + ref + ">", nil
+}
+
+func TestRender_ExpandsReferences(t *testing.T) {
+	out, err := Render("db=${secret:prod/db} api=${secret:prod/api}", fakeResolve)
+	require.NoError(t, err)
+	assert.Equal(t, "db=<prod/db> api=<prod/api>", out)
+}
+
+func TestRender_NoPlaceholders(t *testing.T) {
+	out, err := Render("plain text, no refs, a lone $ and 100$ here", fakeResolve)
+	require.NoError(t, err)
+	assert.Equal(t, "plain text, no refs, a lone $ and 100$ here", out)
+}
+
+func TestRender_DollarEscape(t *testing.T) {
+	// "$$" collapses to "$", so "$${secret:x}" is the literal "${secret:x}".
+	out, err := Render("price=$$5 and $${secret:prod/db}", fakeResolve)
+	require.NoError(t, err)
+	assert.Equal(t, "price=$5 and ${secret:prod/db}", out)
+}
+
+func TestRender_TrimsRef(t *testing.T) {
+	out, err := Render("${secret:  prod/db  }", fakeResolve)
+	require.NoError(t, err)
+	assert.Equal(t, "<prod/db>", out)
+}
+
+func TestRender_Errors(t *testing.T) {
+	t.Run("unterminated", func(t *testing.T) {
+		_, err := Render("oops ${secret:prod/db", fakeResolve)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unterminated")
+	})
+	t.Run("empty ref", func(t *testing.T) {
+		_, err := Render("${secret:}", fakeResolve)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "empty secret reference")
+	})
+	t.Run("resolver error names the ref", func(t *testing.T) {
+		_, err := Render("x=${secret:missing}", fakeResolve)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `resolve "missing"`)
+	})
+}
+
+func TestRender_AdjacentAndRepeated(t *testing.T) {
+	out, err := Render("${secret:a}${secret:a}${secret:b}", fakeResolve)
+	require.NoError(t, err)
+	assert.Equal(t, "<a><a><b>", out)
+}
+
+func TestReferences(t *testing.T) {
+	refs, err := References("${secret:prod/db} then ${secret:prod/api} then ${secret:prod/db} again")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"prod/db", "prod/api"}, refs, "distinct, first-seen order")
+}
+
+func TestReferences_PropagatesMalformed(t *testing.T) {
+	_, err := References("${secret:unterminated")
+	require.Error(t, err)
+}


### PR DESCRIPTION
## Summary

First piece of **secret templating** — a pure engine that expands `${secret:<ref>}` placeholders in a template to their values, so operators can render config / `.env` files from live Keyorix secrets (and a secret can compose others).

`secrettemplate.Render(tmpl, resolve)` walks the template and resolves each `${secret:<ref>}` via a caller-supplied **`Resolver`** (which carries its own permission checks — the engine is transport/storage-agnostic and never logs values). Rules:
- `$$` → `$` (so `$${secret:x}` renders the literal `${secret:x}`)
- a lone `$` is literal
- unterminated or empty refs are errors; a resolver error aborts, naming the ref

`References(tmpl)` lists the distinct refs (first-seen order) without resolving — a preflight for a dry-run / "what does this template need?".

## Test plan
- `go build ./...` ✅ · `go test ./internal/secrettemplate/` ✅ · `gosec` ✅ · `golangci-lint` ✅ — **no new deps**
- expand / no-placeholders / `$$`-escape / ref-trim / errors (unterminated, empty, resolver) / adjacent+repeated / `References` dedup + malformed propagation.

### Next
**2/n** — a Keyorix resolver (read-with-permission) + a `keyorix secret render` CLI command and/or an HTTP render endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)