### PR TITLE
feat(template): keyorix secret render command (2/n)

### DIFF
--- a/internal/cli/secret/render.go
+++ b/internal/cli/secret/render.go
@@ -1,0 +1,131 @@
+package secret
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/keyorixhq/keyorix/internal/secrettemplate"
+	"github.com/spf13/cobra"
+)
+
+var renderOutput string
+
+var renderCmd = &cobra.Command{
+	Use:   "render [template-file]",
+	Short: "Render a template, expanding ${secret:<environment>/<name>} references",
+	Long: `Render a template file (or stdin) to stdout (or --output), replacing each
+${secret:<environment>/<name>} placeholder with that secret's current value.
+
+Only secrets you can read are resolved; a missing or forbidden reference fails the
+render without writing partial output. Useful for generating a .env or config file
+from live Keyorix secrets.
+
+Examples:
+  keyorix secret render app.env.tpl -o app.env
+  cat app.env.tpl | keyorix secret render`,
+	Args:         cobra.MaximumNArgs(1),
+	SilenceUsage: true,
+	RunE:         runRender,
+}
+
+func init() {
+	renderCmd.Flags().StringVarP(&renderOutput, "output", "o", "", "Write to this file instead of stdout")
+	SecretCmd.AddCommand(renderCmd)
+}
+
+func runRender(_ *cobra.Command, args []string) error {
+	var tmpl []byte
+	var err error
+	if len(args) == 1 && args[0] != "-" {
+		tmpl, err = os.ReadFile(args[0]) // #nosec G304 -- operator-provided template path
+		if err != nil {
+			return fmt.Errorf("read template: %w", err)
+		}
+	} else {
+		tmpl, err = io.ReadAll(os.Stdin)
+		if err != nil {
+			return fmt.Errorf("read template from stdin: %w", err)
+		}
+	}
+
+	rc, ok := common.NewRemoteClient()
+	if !ok {
+		return fmt.Errorf("not connected to a server — run: keyorix connect <server>")
+	}
+
+	out, err := renderWith(context.Background(), rc, string(tmpl))
+	if err != nil {
+		return err
+	}
+
+	if renderOutput != "" {
+		// #nosec G703 -- renderOutput is the operator's own --output flag (trusted CLI input).
+		if err := os.WriteFile(renderOutput, []byte(out), 0o600); err != nil {
+			return fmt.Errorf("write output: %w", err)
+		}
+		fmt.Printf("✓ Rendered to %s\n", renderOutput)
+		return nil
+	}
+	fmt.Print(out)
+	return nil
+}
+
+// renderWith expands the template using a resolver backed by the remote client. Split
+// out from the command so it can be exercised against an httptest server.
+func renderWith(ctx context.Context, rc *common.RemoteClient, tmpl string) (string, error) {
+	return secrettemplate.Render(tmpl, keyorixResolver(ctx, rc))
+}
+
+// keyorixResolver resolves "<environment>/<name>" to the secret's value over the API:
+// list the environment's secrets to find the id (exact, case-insensitive name match),
+// then read the value. The name segment may contain slashes (path-like names).
+func keyorixResolver(ctx context.Context, rc *common.RemoteClient) secrettemplate.Resolver {
+	return func(ref string) (string, error) {
+		env, name, err := splitSecretRef(ref)
+		if err != nil {
+			return "", err
+		}
+		var list struct {
+			Secrets []struct {
+				ID   uint   `json:"ID"`
+				Name string `json:"Name"`
+			} `json:"secrets"`
+		}
+		path := fmt.Sprintf("/api/v1/secrets?environment=%s&page_size=1000&page=1", url.QueryEscape(env))
+		if err := rc.Get(ctx, path, &list); err != nil {
+			return "", fmt.Errorf("list secrets in %q: %w", env, err)
+		}
+		var id uint
+		for _, s := range list.Secrets {
+			if strings.EqualFold(s.Name, name) {
+				id = s.ID
+				break
+			}
+		}
+		if id == 0 {
+			return "", fmt.Errorf("secret %q not found in environment %q", name, env)
+		}
+		var vb struct {
+			Value string `json:"value"`
+		}
+		if err := rc.Get(ctx, fmt.Sprintf("/api/v1/secrets/%d?include_value=true", id), &vb); err != nil {
+			return "", fmt.Errorf("read value: %w", err)
+		}
+		return vb.Value, nil
+	}
+}
+
+// splitSecretRef splits "<environment>/<name>"; the name may contain further slashes.
+func splitSecretRef(ref string) (env, name string, err error) {
+	ref = strings.TrimSpace(ref)
+	i := strings.IndexByte(ref, '/')
+	if i <= 0 || i == len(ref)-1 {
+		return "", "", fmt.Errorf("invalid reference %q: expected \"<environment>/<name>\"", ref)
+	}
+	return ref[:i], ref[i+1:], nil
+}

--- a/internal/cli/secret/render_remote_test.go
+++ b/internal/cli/secret/render_remote_test.go
@@ -1,0 +1,79 @@
+package secret
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// keyorixRenderStub serves the list + value endpoints the resolver uses.
+func keyorixRenderStub(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/api/v1/secrets" && r.URL.Query().Get("environment") == "prod":
+			_, _ = w.Write([]byte(`{"data":{"secrets":[{"ID":7,"Name":"db-password"},{"ID":9,"Name":"api-key"}]}}`))
+		case r.URL.Path == "/api/v1/secrets/7":
+			_, _ = w.Write([]byte(`{"data":{"value":"s3cr3t"}}`))
+		case r.URL.Path == "/api/v1/secrets/9":
+			_, _ = w.Write([]byte(`{"data":{"value":"k3y"}}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+}
+
+func newRenderClient(t *testing.T, srv *httptest.Server) *common.RemoteClient {
+	t.Helper()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+	rc, ok := common.NewRemoteClient()
+	require.True(t, ok)
+	return rc
+}
+
+func TestRenderWith(t *testing.T) {
+	srv := keyorixRenderStub(t)
+	defer srv.Close()
+	rc := newRenderClient(t, srv)
+
+	out, err := renderWith(context.Background(), rc,
+		"DB_PASSWORD=${secret:prod/db-password}\nAPI_KEY=${secret:prod/api-key}\n")
+	require.NoError(t, err)
+	assert.Equal(t, "DB_PASSWORD=s3cr3t\nAPI_KEY=k3y\n", out)
+}
+
+func TestRenderWith_LiteralAndEscape(t *testing.T) {
+	srv := keyorixRenderStub(t)
+	defer srv.Close()
+	rc := newRenderClient(t, srv)
+
+	out, err := renderWith(context.Background(), rc, "lit=$${secret:prod/db-password} val=${secret:prod/db-password}")
+	require.NoError(t, err)
+	assert.Equal(t, "lit=${secret:prod/db-password} val=s3cr3t", out)
+}
+
+func TestRenderWith_MissingRefFails(t *testing.T) {
+	srv := keyorixRenderStub(t)
+	defer srv.Close()
+	rc := newRenderClient(t, srv)
+
+	_, err := renderWith(context.Background(), rc, "x=${secret:prod/nope}")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestRenderWith_BadRef(t *testing.T) {
+	srv := keyorixRenderStub(t)
+	defer srv.Close()
+	rc := newRenderClient(t, srv)
+
+	_, err := renderWith(context.Background(), rc, "${secret:noslash}")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid reference")
+}


### PR DESCRIPTION
## Summary

Wires the template engine (#303) to a CLI command: render a template file (or stdin) to stdout (or `--output`), expanding `${secret:<environment>/<name>}` to live values.

`keyorixResolver(ctx, rc)` resolves a ref via the shared `RemoteClient` — list the environment's secrets to find the id (exact, case-insensitive name match), then read the value with `include_value`. **Only secrets the caller can read resolve**; a missing/forbidden ref or any malformed reference fails the render **without writing partial output**. Output file written `0600`.

```
keyorix secret render app.env.tpl -o app.env
cat app.env.tpl | keyorix secret render
```

## Test plan
- `go build ./...` ✅ · `go test ./internal/cli/secret/` ✅ · `gosec` ✅ · `golangci-lint` ✅
- Core split into `renderWith(ctx, rc, tmpl)` for `httptest`-backed tests: multi-ref render, `$$`-escape + literal, missing-ref failure, bad-ref. The G703 on the operator-supplied `--output` path is annotated (trusted CLI input).

### Next
**3/n** (optional) — an HTTP render endpoint for programmatic use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)