### PR TITLE
release: prep v0.56.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to Keyorix are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## v0.56.0 — 2026-06-17
+
+Secret templating: render config/`.env` files from live secrets.
+
+### Added
+- **Secret-reference templating** — a template can embed `${secret:<environment>/<name>}`
+  placeholders that expand to a secret's current value (`$$` escapes a literal `$`).
+  `keyorix secret render <template>` renders a file (or stdin) to stdout or `--output`,
+  resolving only the secrets the caller can read and failing without partial output on a
+  missing/forbidden reference — handy for generating a `.env` or config file. ([#303], [#304])
+
+[#303]: https://github.com/keyorixhq/keyorix/pull/303
+[#304]: https://github.com/keyorixhq/keyorix/pull/304
+
 ## v0.55.0 — 2026-06-17
 
 Kubernetes sync agent: observability + distribution.

--- a/deploy/helm/keyorix-k8s-sync/Chart.yaml
+++ b/deploy/helm/keyorix-k8s-sync/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix-k8s-sync
 description: Keyorix Kubernetes sync agent — materialises Keyorix secrets into native Kubernetes Secrets
 type: application
 # Chart version — tracks the Keyorix release version (published in lockstep).
-version: 0.55.0
+version: 0.56.0
 # The keyorix-k8s-sync image tag this chart deploys by default.
-appVersion: "0.55.0"
+appVersion: "0.56.0"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix

--- a/deploy/helm/keyorix/Chart.yaml
+++ b/deploy/helm/keyorix/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix
 description: Self-hosted Keyorix secrets manager (API server + web UI + PostgreSQL)
 type: application
 # Chart version — bump on chart changes.
-version: 0.55.0
+version: 0.56.0
 # The Keyorix app version this chart deploys by default (the image tag).
-appVersion: "0.55.0"
+appVersion: "0.56.0"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix


### PR DESCRIPTION
## v0.56.0 — Secret templating

Bumps CHANGELOG + Helm charts to **0.56.0**. Bundles the two commits since v0.55.0:

- **#303** — the pure `${secret:<env>/<name>}` template engine
- **#304** — `keyorix secret render` (render a file/stdin → stdout/`-o`, resolving only the caller's readable secrets, no partial output on failure)

Both charts → 0.56.0 (in lockstep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)