### PR TITLE
feat(template): HTTP render endpoint — POST /projects/{id}/secrets/render (3/n)

### DIFF
--- a/internal/core/secret_render.go
+++ b/internal/core/secret_render.go
@@ -1,0 +1,67 @@
+// secret_render.go — server-side rendering of templates that embed secret
+// references (${secret:<environment>/<name>}). Resolution is scoped to one project,
+// where an environment name and a secret name are unique, so a reference resolves
+// unambiguously. Each referenced value is read through the per-secret permission
+// check, so the caller only ever renders secrets they may read.
+package core
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/secrettemplate"
+)
+
+// RenderSecretTemplate expands ${secret:<environment>/<name>} references in template
+// against the given project, returning the rendered output. A reference to an unknown
+// environment/secret, or one the user cannot read, fails the whole render (no partial
+// output). Values are never logged.
+func (c *KeyorixCore) RenderSecretTemplate(ctx context.Context, template string, projectID, userID uint) (string, error) {
+	if projectID == 0 {
+		return "", fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "project ID is required")
+	}
+	if userID == 0 {
+		return "", fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "user ID is required")
+	}
+
+	envs, err := c.storage.ListEnvironmentsByProject(ctx, projectID)
+	if err != nil {
+		return "", fmt.Errorf("list environments: %w", err)
+	}
+	envByName := make(map[string]uint, len(envs))
+	for _, e := range envs {
+		envByName[e.Name] = e.ID
+	}
+
+	return secrettemplate.Render(template, func(ref string) (string, error) {
+		envName, secretName, err := splitRenderRef(ref)
+		if err != nil {
+			return "", err
+		}
+		envID, ok := envByName[envName]
+		if !ok {
+			return "", fmt.Errorf("environment %q not found in this project", envName)
+		}
+		secret, err := c.storage.GetSecretByName(ctx, secretName, projectID, envID)
+		if err != nil || secret == nil {
+			return "", fmt.Errorf("secret %q not found in %s", secretName, envName)
+		}
+		val, err := c.GetSecretValueWithPermissionCheck(ctx, secret.ID, userID)
+		if err != nil {
+			return "", err
+		}
+		return string(val), nil
+	})
+}
+
+// splitRenderRef splits "<environment>/<name>"; the name may contain further slashes.
+func splitRenderRef(ref string) (env, name string, err error) {
+	ref = strings.TrimSpace(ref)
+	i := strings.IndexByte(ref, '/')
+	if i <= 0 || i == len(ref)-1 {
+		return "", "", fmt.Errorf("invalid reference %q: expected \"<environment>/<name>\"", ref)
+	}
+	return ref[:i], ref[i+1:], nil
+}

--- a/internal/core/secret_render_test.go
+++ b/internal/core/secret_render_test.go
@@ -1,0 +1,88 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// newRenderFixture builds an in-memory core with a project, a "production"
+// environment, and a secret "db-password"=s3cr3t owned by user 1.
+func newRenderFixture(t *testing.T) (*KeyorixCore, uint) {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	sqlDB.SetMaxOpenConns(1)
+	require.NoError(t, db.AutoMigrate(
+		&models.SecretNode{}, &models.SecretVersion{}, &models.User{},
+		&models.Project{}, &models.Environment{},
+	))
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "owner", Email: "o@test.com"}).Error)
+
+	st := store.NewLocalStorage(db)
+	c := &KeyorixCore{storage: st, now: time.Now}
+	ctx := context.Background()
+
+	proj, err := st.CreateProject(ctx, &models.Project{Name: "payments"})
+	require.NoError(t, err)
+	env, err := st.CreateEnvironment(ctx, &models.Environment{Name: "production", ProjectID: proj.ID})
+	require.NoError(t, err)
+	secret, err := st.CreateSecret(ctx, &models.SecretNode{
+		Name: "db-password", ProjectID: proj.ID, EnvironmentID: env.ID, Type: "password",
+		OwnerID: 1, IsSecret: true, CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	})
+	require.NoError(t, err)
+	_, err = st.CreateSecretVersion(ctx, &models.SecretVersion{
+		SecretNodeID: secret.ID, VersionNumber: 1, EncryptedValue: []byte("s3cr3t"),
+	})
+	require.NoError(t, err)
+	return c, proj.ID
+}
+
+func TestRenderSecretTemplate(t *testing.T) {
+	ctx := context.Background()
+	c, projectID := newRenderFixture(t)
+
+	t.Run("expands a known reference", func(t *testing.T) {
+		out, err := c.RenderSecretTemplate(ctx, "DB=${secret:production/db-password}", projectID, 1)
+		require.NoError(t, err)
+		assert.Equal(t, "DB=s3cr3t", out)
+	})
+
+	t.Run("unknown environment fails", func(t *testing.T) {
+		_, err := c.RenderSecretTemplate(ctx, "${secret:staging/db-password}", projectID, 1)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "environment")
+	})
+
+	t.Run("unknown secret fails", func(t *testing.T) {
+		_, err := c.RenderSecretTemplate(ctx, "${secret:production/nope}", projectID, 1)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("non-reader cannot resolve", func(t *testing.T) {
+		// User 2 owns nothing and has no share → the per-secret read check denies.
+		_, err := c.RenderSecretTemplate(ctx, "${secret:production/db-password}", projectID, 2)
+		require.Error(t, err)
+	})
+
+	t.Run("requires project + user", func(t *testing.T) {
+		_, err := c.RenderSecretTemplate(ctx, "x", 0, 1)
+		require.Error(t, err)
+		_, err = c.RenderSecretTemplate(ctx, "x", projectID, 0)
+		require.Error(t, err)
+	})
+}

--- a/server/http/handlers/secrets_render.go
+++ b/server/http/handlers/secrets_render.go
@@ -1,0 +1,55 @@
+// secrets_render.go — RenderTemplate handler: expand ${secret:env/name} references
+// in a template using the caller's read access, scoped to one project.
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/keyorixhq/keyorix/server/middleware"
+)
+
+// RenderTemplate handles POST /api/v1/projects/{id}/secrets/render — body
+// {"template": "...${secret:production/db-password}..."} → {"rendered": "..."}.
+// Read-only: it resolves references within the project the caller can read, per the
+// per-secret permission check.
+func (h *SecretHandler) RenderTemplate(w http.ResponseWriter, r *http.Request) {
+	userCtx := middleware.GetUserFromContext(r.Context())
+	if userCtx == nil {
+		h.sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		h.sendError(w, "BadRequest", "Invalid project ID", http.StatusBadRequest, nil)
+		return
+	}
+	var reqBody struct {
+		Template string `json:"template"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
+		h.sendError(w, "InvalidJSON", "Invalid JSON in request body", http.StatusBadRequest, nil)
+		return
+	}
+
+	rendered, err := h.coreService.RenderSecretTemplate(r.Context(), reqBody.Template, uint(id), userCtx.UserID)
+	if err != nil {
+		switch {
+		case strings.Contains(err.Error(), "not found"):
+			h.sendError(w, "NotFound", err.Error(), http.StatusNotFound, nil)
+		case strings.Contains(err.Error(), "permission") || strings.Contains(err.Error(), "not authorized"):
+			h.sendError(w, "Forbidden", "Not authorized to read a referenced secret", http.StatusForbidden, nil)
+		case strings.Contains(err.Error(), "invalid reference"), strings.Contains(err.Error(), "unterminated"),
+			strings.Contains(err.Error(), "empty secret reference"):
+			h.sendError(w, "ValidationError", err.Error(), http.StatusBadRequest, nil)
+		default:
+			h.sendError(w, "InternalError", "Failed to render template", http.StatusInternalServerError, nil)
+		}
+		return
+	}
+
+	h.sendSuccess(w, map[string]interface{}{"rendered": rendered}, "")
+}

--- a/server/http/integration_test.go
+++ b/server/http/integration_test.go
@@ -820,7 +820,13 @@ func TestEveryMutatingRouteDeniesReadOnly(t *testing.T) {
 	}
 	// Self-service (own account) and public routes a read-only/unauthenticated
 	// caller may legitimately reach; everything else mutating must be denied.
-	allowExact := map[string]bool{"/system/init": true, "/health": true, "/metrics": true}
+	// /secrets/render is a read operation behind a POST (it resolves secret refs the
+	// caller can already read, gated on secrets.read) — legitimately reachable by a
+	// read-only persona, like /system/init etc.
+	allowExact := map[string]bool{
+		"/system/init": true, "/health": true, "/metrics": true,
+		"/api/v1/projects/{id}/secrets/render": true,
+	}
 	allowPrefix := []string{"/auth/", "/api/v1/auth/", "/notifications", "/api/v1/notifications"}
 	allowed := func(route string) bool {
 		if allowExact[route] {

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -299,6 +299,7 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		r.With(customMiddleware.RequireScopedPermission("roles.assign", projectScope)).Post("/projects/{id}/machine-identities/{machineId}/oidc-bindings", catalogHandler.CreateOIDCBinding)
 		r.With(customMiddleware.RequireScopedPermission("users.read", projectScope)).Get("/projects/{id}/machine-identities/{machineId}/oidc-bindings", catalogHandler.ListOIDCBindings)
 		r.With(customMiddleware.RequireScopedPermission("roles.assign", projectScope)).Delete("/projects/{id}/machine-identities/{machineId}/oidc-bindings/{bindingId}", catalogHandler.DeleteOIDCBinding)
+		r.With(customMiddleware.RequireScopedPermission("secrets.read", projectScope)).Post("/projects/{id}/secrets/render", secretHandler.RenderTemplate)
 		r.With(customMiddleware.RequireScopedPermission("secrets.read", projectScope)).Get("/projects/{id}/environments", catalogHandler.ListProjectEnvironments)
 		r.With(customMiddleware.RequireScopedPermission("secrets.write", projectScope)).Post("/projects/{id}/environments", catalogHandler.CreateProjectEnvironment)
 		// Environment restore is nested under the project so the scope resolves


### PR DESCRIPTION
## Summary

Completes the secret-templating surface with a programmatic endpoint.

- **`core.RenderSecretTemplate(template, projectID, userID)`** — resolves `${secret:<environment>/<name>}` within **one project** (where an environment name and a secret name are unique, so a reference is unambiguous) and reads each value through `GetSecretValueWithPermissionCheck`, so the caller only renders secrets they may read. An unknown env/secret or a forbidden ref fails the **whole** render (no partial output); values are never logged.
- **`POST /api/v1/projects/{id}/secrets/render` `{template}` → `{rendered}`** — gated on **scoped `secrets.read`** (it's a read). Errors map to 400 / 403 / 404.
- It's a read-only POST, so it's **allowlisted** in `TestEveryMutatingRouteDeniesReadOnly` (verified: the route is no longer flagged; only the pre-existing local-only `/sw.js` + `evidence/verify` remain).

## Test plan
- `go build ./...` ✅ · `go test ./internal/core/` ✅ · mutating-route guard verified ✅ · `gosec` ✅ · `golangci-lint` ✅
- Core: expand / unknown-env / unknown-secret / non-reader-denied / requires project+user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)