### PR TITLE
feat(secrets): transfer secret ownership (recover orphaned secrets)

### DIFF
--- a/internal/core/secret_ownership.go
+++ b/internal/core/secret_ownership.go
@@ -1,0 +1,69 @@
+// secret_ownership.go — transfer a secret's ownership to another user. A secret's
+// owner is the only principal that can manage/share it (CheckSecretPermission grants
+// PermissionOwner only to the owner), so when an owner leaves the org their secrets
+// are effectively orphaned. Transfer hands ownership to another user — either by the
+// current owner, or (for recovery) by any authorized writer when the current owner is
+// gone (ownerless or a deleted account).
+package core
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// EventSecretOwnerTransferred is audited when a secret's ownership changes hands.
+const EventSecretOwnerTransferred = "secret.owner_transferred"
+
+// TransferSecretOwnership sets secretID's owner to newOwnerID. The caller (transport)
+// must have enforced scoped secrets.write. Authorization here: the actor must be the
+// current owner, OR the current owner must be gone (ownerless, or an account that no
+// longer exists) — so an active owner's secret can't be taken from under them, while a
+// departed owner's secrets can be recovered. newOwnerID must be an existing user.
+func (c *KeyorixCore) TransferSecretOwnership(ctx context.Context, secretID, newOwnerID, actorID uint) (*models.SecretNode, error) {
+	if secretID == 0 || newOwnerID == 0 || actorID == 0 {
+		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "secret ID, new owner ID and actor ID are required")
+	}
+
+	secret, err := c.storage.GetSecret(ctx, secretID)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorSecretNotFound", nil), err)
+	}
+	if secret.OwnerID == newOwnerID {
+		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "secret is already owned by that user")
+	}
+	if _, err := c.storage.GetUser(ctx, newOwnerID); err != nil {
+		return nil, fmt.Errorf("%s: new owner %d not found", i18n.T("ErrorValidation", nil), newOwnerID)
+	}
+
+	// Authorize: the current owner may hand it off; otherwise it must be ownerless or
+	// owned by an account that no longer exists (recovery).
+	if !secretOwnedBy(secret.OwnerID, actorID) && !c.currentOwnerGone(ctx, secret.OwnerID) {
+		return nil, fmt.Errorf("%s: only the current owner can transfer this secret", i18n.T("ErrorPermissionDenied", nil))
+	}
+
+	oldOwner := secret.OwnerID
+	secret.OwnerID = newOwnerID
+	updated, err := c.storage.UpdateSecret(ctx, secret)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+
+	uid := actorID
+	sid := secretID
+	c.writeAuditEvent(ctx, EventSecretOwnerTransferred, &uid, &sid,
+		fmt.Sprintf("transferred ownership of secret %q from user %d to user %d", updated.Name, oldOwner, newOwnerID))
+	return updated, nil
+}
+
+// currentOwnerGone reports whether a secret's owner is absent: ownerless (0) or an
+// account that no longer exists.
+func (c *KeyorixCore) currentOwnerGone(ctx context.Context, ownerID uint) bool {
+	if ownerID == 0 {
+		return true
+	}
+	u, err := c.storage.GetUser(ctx, ownerID)
+	return err != nil || u == nil
+}

--- a/internal/core/secret_ownership.go
+++ b/internal/core/secret_ownership.go
@@ -8,8 +8,10 @@ package core
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
+	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
@@ -58,12 +60,15 @@ func (c *KeyorixCore) TransferSecretOwnership(ctx context.Context, secretID, new
 	return updated, nil
 }
 
-// currentOwnerGone reports whether a secret's owner is absent: ownerless (0) or an
-// account that no longer exists.
+// currentOwnerGone reports whether a secret's owner is positively absent: ownerless
+// (0) or an account confirmed not to exist. It FAILS CLOSED — a transient GetUser
+// error returns false (owner assumed present), so a non-owner cannot ride a momentary
+// lookup failure into seizing an actively-owned secret. Only the typed not-found
+// sentinel counts as "gone".
 func (c *KeyorixCore) currentOwnerGone(ctx context.Context, ownerID uint) bool {
 	if ownerID == 0 {
 		return true
 	}
-	u, err := c.storage.GetUser(ctx, ownerID)
-	return err != nil || u == nil
+	_, err := c.storage.GetUser(ctx, ownerID)
+	return errors.Is(err, storage.ErrUserNotFound)
 }

--- a/internal/core/secret_ownership_test.go
+++ b/internal/core/secret_ownership_test.go
@@ -1,0 +1,97 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// newOwnershipFixture builds an in-memory core with users 1 (owner), 2, 3 and a
+// secret owned by user 1.
+func newOwnershipFixture(t *testing.T) (*KeyorixCore, uint) {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	sqlDB.SetMaxOpenConns(1)
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.User{}))
+	for _, u := range []models.User{
+		{ID: 1, Username: "owner", Email: "o@test.com"},
+		{ID: 2, Username: "alice", Email: "a@test.com"},
+		{ID: 3, Username: "bob", Email: "b@test.com"},
+	} {
+		require.NoError(t, db.Create(&u).Error)
+	}
+	st := store.NewLocalStorage(db)
+	c := &KeyorixCore{storage: st, now: time.Now}
+	secret, err := st.CreateSecret(context.Background(), &models.SecretNode{
+		Name: "db", ProjectID: 1, EnvironmentID: 1, Type: "password", OwnerID: 1, IsSecret: true,
+		CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	})
+	require.NoError(t, err)
+	return c, secret.ID
+}
+
+func TestTransferSecretOwnership(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("owner transfers to another user", func(t *testing.T) {
+		c, id := newOwnershipFixture(t)
+		updated, err := c.TransferSecretOwnership(ctx, id, 2, 1)
+		require.NoError(t, err)
+		assert.EqualValues(t, 2, updated.OwnerID)
+		// The new owner now has owner permission; the old owner does not.
+		_, err = c.CheckSecretPermission(ctx, id, 2, PermissionOwner)
+		require.NoError(t, err)
+		_, err = c.CheckSecretPermission(ctx, id, 1, PermissionOwner)
+		require.Error(t, err)
+	})
+
+	t.Run("non-owner cannot transfer an actively-owned secret", func(t *testing.T) {
+		c, id := newOwnershipFixture(t)
+		_, err := c.TransferSecretOwnership(ctx, id, 3, 2) // actor 2 is not the owner
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "only the current owner")
+	})
+
+	t.Run("recovery: a departed owner's secret can be transferred by anyone authorized", func(t *testing.T) {
+		c, id := newOwnershipFixture(t)
+		// Simulate the owner (user 1) leaving: delete the account.
+		require.NoError(t, c.storage.DeleteUser(ctx, 1))
+		updated, err := c.TransferSecretOwnership(ctx, id, 2, 3) // actor 3, owner gone
+		require.NoError(t, err)
+		assert.EqualValues(t, 2, updated.OwnerID)
+	})
+
+	t.Run("rejects a non-existent new owner", func(t *testing.T) {
+		c, id := newOwnershipFixture(t)
+		_, err := c.TransferSecretOwnership(ctx, id, 999, 1)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "new owner")
+	})
+
+	t.Run("rejects transferring to the current owner", func(t *testing.T) {
+		c, id := newOwnershipFixture(t)
+		_, err := c.TransferSecretOwnership(ctx, id, 1, 1)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "already owned")
+	})
+
+	t.Run("validates ids", func(t *testing.T) {
+		c, id := newOwnershipFixture(t)
+		_, err := c.TransferSecretOwnership(ctx, id, 0, 1)
+		require.Error(t, err)
+		_, err = c.TransferSecretOwnership(ctx, 0, 2, 1)
+		require.Error(t, err)
+	})
+}

--- a/internal/core/secret_ownership_test.go
+++ b/internal/core/secret_ownership_test.go
@@ -2,9 +2,11 @@ package core
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
+	coreStorage "github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/keyorixhq/keyorix/internal/storage/store"
@@ -13,6 +15,21 @@ import (
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 )
+
+// transientOwnerLookup wraps LocalStorage so GetUser(failID) returns a transient
+// (non-not-found) error, simulating a momentary backend failure during the owner
+// lookup. All other methods/users behave normally.
+type transientOwnerLookup struct {
+	*store.LocalStorage
+	failID uint
+}
+
+func (t *transientOwnerLookup) GetUser(ctx context.Context, id uint) (*models.User, error) {
+	if id == t.failID {
+		return nil, errors.New("db timeout") // transient, NOT storage.ErrUserNotFound
+	}
+	return t.LocalStorage.GetUser(ctx, id)
+}
 
 // newOwnershipFixture builds an in-memory core with users 1 (owner), 2, 3 and a
 // secret owned by user 1.
@@ -85,6 +102,25 @@ func TestTransferSecretOwnership(t *testing.T) {
 		_, err := c.TransferSecretOwnership(ctx, id, 1, 1)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "already owned")
+	})
+
+	t.Run("fail-closed: a transient owner-lookup error does NOT permit takeover", func(t *testing.T) {
+		c, id := newOwnershipFixture(t)
+		// Wrap storage so the OWNER lookup (user 1) fails transiently (not not-found),
+		// while other users resolve normally.
+		base := c.storage.(*store.LocalStorage)
+		c.storage = &transientOwnerLookup{LocalStorage: base, failID: 1}
+		_, err := c.TransferSecretOwnership(ctx, id, 2, 3) // non-owner actor, owner "errors"
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "only the current owner",
+			"a transient lookup error must be treated as owner-present (fail closed)")
+	})
+
+	t.Run("GetUser surfaces the typed not-found sentinel", func(t *testing.T) {
+		c, _ := newOwnershipFixture(t)
+		_, err := c.storage.GetUser(ctx, 999)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, coreStorage.ErrUserNotFound)
 	})
 
 	t.Run("validates ids", func(t *testing.T) {

--- a/internal/core/storage/errors.go
+++ b/internal/core/storage/errors.go
@@ -1,0 +1,9 @@
+package storage
+
+import "errors"
+
+// ErrUserNotFound is returned (wrapped) by GetUser when the user positively does not
+// exist, as distinct from a transient retrieval failure. Callers that must fail
+// closed on uncertainty — e.g. authorization decisions keyed on "is this account
+// gone?" — should match it with errors.Is rather than treating any error as absence.
+var ErrUserNotFound = errors.New("user not found")

--- a/internal/storage/store/local_users.go
+++ b/internal/storage/store/local_users.go
@@ -61,7 +61,9 @@ func (ls *LocalStorage) GetUser(ctx context.Context, id uint) (*models.User, err
 	var user models.User
 	if err := ls.db.WithContext(ctx).First(&user, id).Error; err != nil {
 		if err == gorm.ErrRecordNotFound {
-			return nil, fmt.Errorf("%s", i18n.T("ErrorUserNotFound", nil))
+			// Wrap the typed sentinel so callers can distinguish "absent" from a
+			// transient failure (e.g. ownership-transfer recovery must fail closed).
+			return nil, fmt.Errorf("%s: %w", i18n.T("ErrorUserNotFound", nil), storage.ErrUserNotFound)
 		}
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
 	}

--- a/server/http/handlers/secrets_ownership.go
+++ b/server/http/handlers/secrets_ownership.go
@@ -1,0 +1,56 @@
+// secrets_ownership.go — TransferOwnership handler: hand a secret's ownership to
+// another user (the only principal that can manage/share it).
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/keyorixhq/keyorix/server/middleware"
+)
+
+// TransferOwnership handles POST /api/v1/secrets/{id}/transfer-ownership with body
+// {"new_owner_id": N}. Scoped secrets.write is enforced by the router; the core layer
+// then requires the caller to be the current owner (or the owner to be gone).
+func (h *SecretHandler) TransferOwnership(w http.ResponseWriter, r *http.Request) {
+	userCtx := middleware.GetUserFromContext(r.Context())
+	if userCtx == nil {
+		h.sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		h.sendError(w, "BadRequest", "Invalid secret ID", http.StatusBadRequest, nil)
+		return
+	}
+	var reqBody struct {
+		NewOwnerID uint `json:"new_owner_id" validate:"required"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
+		h.sendError(w, "InvalidJSON", "Invalid JSON in request body", http.StatusBadRequest, nil)
+		return
+	}
+	if reqBody.NewOwnerID == 0 {
+		h.sendError(w, "ValidationError", "new_owner_id is required", http.StatusBadRequest, nil)
+		return
+	}
+
+	secret, err := h.coreService.TransferSecretOwnership(r.Context(), uint(id), reqBody.NewOwnerID, userCtx.UserID)
+	if err != nil {
+		switch {
+		case strings.Contains(err.Error(), "not found"):
+			h.sendError(w, "NotFound", err.Error(), http.StatusNotFound, nil)
+		case strings.Contains(err.Error(), "only the current owner"):
+			h.sendError(w, "Forbidden", "Only the current owner can transfer this secret", http.StatusForbidden, nil)
+		case strings.Contains(err.Error(), "already owned"):
+			h.sendError(w, "ValidationError", err.Error(), http.StatusBadRequest, nil)
+		default:
+			h.sendError(w, "InternalError", "Failed to transfer ownership", http.StatusInternalServerError, nil)
+		}
+		return
+	}
+	h.sendSuccess(w, secret, "Secret ownership transferred")
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -331,6 +331,7 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.With(customMiddleware.RequireScopedPermission("secrets.write", secretScope)).Patch("/{id}/auto-rotate", secretHandler.SetAutoRotate)
 			r.With(customMiddleware.RequireScopedPermission("secrets.write", secretScope)).Post("/{id}/rotate", secretHandler.RotateSecret)
 			r.With(customMiddleware.RequireScopedPermission("secrets.write", secretScope)).Post("/{id}/rollback", secretHandler.RollbackSecret)
+			r.With(customMiddleware.RequireScopedPermission("secrets.write", secretScope)).Post("/{id}/transfer-ownership", secretHandler.TransferOwnership)
 			r.With(customMiddleware.RequireScopedPermission("secrets.write", secretScope)).Post("/{id}/share", shareHandler.ShareSecret)
 
 			r.With(customMiddleware.RequireScopedPermission("secrets.delete", secretScope)).Delete("/{id}", secretHandler.DeleteSecret)


### PR DESCRIPTION
## Summary

A secret's owner is the only principal that can manage/share it, so when an owner leaves the org their secrets are effectively orphaned. This adds **ownership transfer**.

- **`core.TransferSecretOwnership(secretID, newOwnerID, actorID)`** — authorizes if the actor is the current owner, **or** the current owner is positively gone (ownerless, or a confirmed-deleted account). An active owner's secret can't be taken from under them; a departed owner's secrets can be recovered. New owner must exist; same-owner no-op is refused. Persists `OwnerID`, audits `secret.owner_transferred` (old→new + actor).
- **`POST /api/v1/secrets/{id}/transfer-ownership` `{new_owner_id}`** — scoped `secrets.write` (route-gated like rotate/rollback). Verified it **denies the read-only persona (403)**.

## Security review (HIGH found + fixed)
The first cut's `currentOwnerGone` treated **any** `GetUser` error as "owner gone" — a fail-open bug letting a non-owner seize an actively-owned secret during a transient lookup failure. **Fixed:** a typed `storage.ErrUserNotFound` sentinel; `currentOwnerGone` now treats the owner as gone **only** on a positively-confirmed not-found (`errors.Is`), failing closed on any transient error. Re-reviewed: correct and complete, no remaining issues.

## Test plan
- `go build ./...` ✅ · `go test ./internal/core/... ./internal/storage/...` ✅ · `gosec` ✅ · `golangci-lint` ✅ — no new deps
- Owner transfers (perm flips); non-owner can't take an active secret; recovery after the owner account is deleted; **fail-closed: a transient owner-lookup error does not permit takeover**; sentinel surfaced; non-existent/same owner; id validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)