### PR TITLE
test(sharing): fix List-User-Shares assertion for the paginated /shares DTO

### DIFF
--- a/server/http/sharing_integration_test.go
+++ b/server/http/sharing_integration_test.go
@@ -308,21 +308,23 @@ func TestSharingHTTPIntegration(t *testing.T) {
 			err = json.NewDecoder(resp.Body).Decode(&response)
 			require.NoError(t, err)
 
+			// GET /api/v1/shares returns a paginated list of enriched ShareViews
+			// (camelCase): {data: [...], total, page, pageSize, totalPages} (#288).
 			data := response["data"].(map[string]interface{})
-			shares := data["shares"].([]interface{})
+			shares := data["data"].([]interface{})
 			assert.GreaterOrEqual(t, len(shares), 1)
 
 			// Find our share
 			var foundShare map[string]interface{}
 			for _, s := range shares {
 				share := s.(map[string]interface{})
-				if uint(share["ID"].(float64)) == shareID {
+				if uint(share["id"].(float64)) == shareID {
 					foundShare = share
 					break
 				}
 			}
 			require.NotNil(t, foundShare)
-			assert.Equal(t, "write", foundShare["Permission"])
+			assert.Equal(t, "write", foundShare["permission"])
 		})
 
 		// Step 7: Revoke the share


### PR DESCRIPTION
## Summary

#288 changed `GET /api/v1/shares` from `{shares:[...]}` (raw PascalCase models) to a paginated, enriched **ShareView** envelope `{data:[...], total, page, pageSize, totalPages}` (camelCase). `TestSharingHTTPIntegration`'s **"List User Shares"** step still read `data["shares"]` + `share["ID"]`/`["Permission"]`, so it **panicked** on the now-nil `shares` key (a regression that was on `main`).

Fix: read `data["data"]` + `share["id"]`/`["permission"]`. The other steps use `/secrets/{id}/shares` and `/shared-secrets`, whose shape #288 did not change.

## Test plan
- `go test ./server/http/ -run TestSharingHTTPIntegration` ✅ (was panicking, now passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)