### PR TITLE
feat(secrets): optional secret-value quality policy (reject weak values)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -91,6 +91,10 @@ type Config struct {
 	// setup link (ADR-028). Absent (zero value) = auto mode, out-of-band when no SMTP.
 	CredentialDelivery CredentialDeliveryConfig `yaml:"credential_delivery"`
 
+	// SecretValuePolicy is an optional quality gate on secret VALUES (reject weak/
+	// placeholder values at create/rotate). Disabled (zero value) by default.
+	SecretValuePolicy SecretValuePolicyConfig `yaml:"secret_value_policy"`
+
 	// PasswordPolicy is optional. When the block is absent (zero value), the
 	// server keeps its conservative built-in defaults (see core.DefaultPasswordPolicy);
 	// when present, the install's values fully replace them.
@@ -1256,4 +1260,13 @@ func Save(path string, cfg *Config) error {
 	}
 
 	return nil
+}
+
+// SecretValuePolicyConfig configures the opt-in secret-value quality gate
+// (core.SecretValuePolicy). Disabled unless Enabled is true.
+type SecretValuePolicyConfig struct {
+	Enabled       bool     `yaml:"enabled"`
+	MinLength     int      `yaml:"min_length"`     // reject values shorter than this (0 = no minimum)
+	RejectCommon  bool     `yaml:"reject_common"`  // reject a built-in denylist of weak/placeholder values
+	ExtraDenylist []string `yaml:"extra_denylist"` // additional rejected values (case-insensitive)
 }

--- a/internal/core/secret_value_policy.go
+++ b/internal/core/secret_value_policy.go
@@ -1,0 +1,57 @@
+// secret_value_policy.go — an optional, operator-configured quality gate on the
+// VALUES stored in secrets (distinct from the user-login PasswordPolicy in ADR-025).
+// When enabled it rejects obviously-weak or placeholder secret values at create and
+// rotate time, so a "changeme" never silently becomes a production credential. The
+// policy is OFF by default, so existing installs are unaffected until they opt in.
+package core
+
+import (
+	"fmt"
+	"strings"
+)
+
+// SecretValuePolicy describes the quality rules applied to a secret's value on write.
+type SecretValuePolicy struct {
+	Enabled bool
+	// MinLength rejects values shorter than this many bytes (0 = no minimum).
+	MinLength int
+	// RejectCommon rejects a built-in denylist of weak/placeholder values.
+	RejectCommon bool
+	// ExtraDenylist adds installation-specific rejected values (case-insensitive).
+	ExtraDenylist []string
+}
+
+// DefaultSecretValuePolicy returns the disabled (no-op) policy.
+func DefaultSecretValuePolicy() SecretValuePolicy { return SecretValuePolicy{} }
+
+// commonWeakValues is a small built-in denylist of values that are never an
+// acceptable secret. Keys are lower-cased and trimmed.
+var commonWeakValues = map[string]bool{
+	"": true, "changeme": true, "change-me": true, "changeit": true,
+	"password": true, "passw0rd": true, "p@ssw0rd": true, "secret": true,
+	"123456": true, "1234567": true, "12345678": true, "123456789": true,
+	"qwerty": true, "admin": true, "root": true, "test": true, "letmein": true,
+	"default": true, "example": true, "demo": true, "null": true, "none": true,
+	"tbd": true, "todo": true, "xxx": true,
+}
+
+// Validate returns a non-nil error (describing the reason ONLY — never echoing the
+// value) when value violates the policy. A disabled policy always passes.
+func (p SecretValuePolicy) Validate(value []byte) error {
+	if !p.Enabled {
+		return nil
+	}
+	if p.MinLength > 0 && len(value) < p.MinLength {
+		return fmt.Errorf("secret value is shorter than the %d-character minimum", p.MinLength)
+	}
+	norm := strings.ToLower(strings.TrimSpace(string(value)))
+	if p.RejectCommon && commonWeakValues[norm] {
+		return fmt.Errorf("secret value is a known weak or placeholder value")
+	}
+	for _, d := range p.ExtraDenylist {
+		if strings.ToLower(strings.TrimSpace(d)) == norm {
+			return fmt.Errorf("secret value is on the configured denylist")
+		}
+	}
+	return nil
+}

--- a/internal/core/secret_value_policy_test.go
+++ b/internal/core/secret_value_policy_test.go
@@ -1,0 +1,45 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSecretValuePolicy_Disabled(t *testing.T) {
+	p := DefaultSecretValuePolicy() // disabled
+	require.NoError(t, p.Validate([]byte("changeme")))
+	require.NoError(t, p.Validate([]byte("")))
+	require.NoError(t, p.Validate([]byte("x")))
+}
+
+func TestSecretValuePolicy_MinLength(t *testing.T) {
+	p := SecretValuePolicy{Enabled: true, MinLength: 12}
+	err := p.Validate([]byte("short"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "12-character minimum")
+	require.NoError(t, p.Validate([]byte("a-sufficiently-long-value")))
+}
+
+func TestSecretValuePolicy_RejectCommon(t *testing.T) {
+	p := SecretValuePolicy{Enabled: true, RejectCommon: true}
+	for _, weak := range []string{"changeme", "CHANGEME", "  password  ", "123456", "secret", "admin", ""} {
+		require.Error(t, p.Validate([]byte(weak)), "%q should be rejected", weak)
+	}
+	require.NoError(t, p.Validate([]byte("Tr0ub4dor&3-x9fQ")))
+}
+
+func TestSecretValuePolicy_ExtraDenylist(t *testing.T) {
+	p := SecretValuePolicy{Enabled: true, ExtraDenylist: []string{"acme-default", "Internal-Test"}}
+	require.Error(t, p.Validate([]byte("acme-default")))
+	require.Error(t, p.Validate([]byte("internal-test")), "case-insensitive")
+	require.NoError(t, p.Validate([]byte("a-real-secret")))
+}
+
+func TestSecretValuePolicy_ErrorNeverEchoesValue(t *testing.T) {
+	p := SecretValuePolicy{Enabled: true, RejectCommon: true, MinLength: 20}
+	err := p.Validate([]byte("changeme"))
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "changeme", "the reason must not leak the value")
+}

--- a/internal/core/secrets.go
+++ b/internal/core/secrets.go
@@ -55,6 +55,9 @@ func (c *KeyorixCore) CreateSecret(ctx context.Context, req *CreateSecretRequest
 	if err := c.validateCreateSecretRequest(req); err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorValidation", nil), err)
 	}
+	if err := c.secretValuePolicy.Validate(req.Value); err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorValidation", nil), err)
+	}
 
 	// Verify the environment belongs to the stated project.
 	env, err := c.storage.GetEnvironment(ctx, req.EnvironmentID)
@@ -185,6 +188,9 @@ func (c *KeyorixCore) UpdateSecretWithPermissionCheck(ctx context.Context, req *
 
 // RotateSecret creates a new version with a new value and updates LastRotatedAt.
 func (c *KeyorixCore) RotateSecret(ctx context.Context, id uint, newValue []byte, rotatedBy string) (*models.SecretNode, error) {
+	if err := c.secretValuePolicy.Validate(newValue); err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorValidation", nil), err)
+	}
 	secret, err := c.storage.GetSecret(ctx, id)
 	if err != nil {
 		return nil, fmt.Errorf("secret not found: %w", err)

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -46,11 +46,12 @@ type KeyorixCore struct {
 	dynamicSweepEnabled bool
 	// webauthnRP is the WebAuthn relying party (ADR-036); nil = WebAuthn disabled.
 	// Set from config at startup via SetWebAuthn.
-	webauthnRP     *webauthn.WebAuthn
-	now            func() time.Time // For testability
-	passwordPolicy PasswordPolicy
-	loginLockout   LoginLockoutPolicy // per-account login lockout (disabled by default)
-	auditForwarder AuditForwarder
+	webauthnRP        *webauthn.WebAuthn
+	now               func() time.Time // For testability
+	passwordPolicy    PasswordPolicy
+	secretValuePolicy SecretValuePolicy  // optional quality gate on secret values (off by default)
+	loginLockout      LoginLockoutPolicy // per-account login lockout (disabled by default)
+	auditForwarder    AuditForwarder
 	// auditStream is the in-process pub/sub broker that wakes live audit tails
 	// (gRPC StreamAuditLogs) the instant an event is written, replacing fixed-interval
 	// DB polling. Always non-nil (set in the constructors).
@@ -270,6 +271,12 @@ func (c *KeyorixCore) WebAuthnEnabled() bool { return c.webauthnRP != nil }
 // configures a password_policy block.
 func (c *KeyorixCore) SetPasswordPolicy(p PasswordPolicy) {
 	c.passwordPolicy = p
+}
+
+// SetSecretValuePolicy enables/configures the secret-value quality gate (off by
+// default). The server calls this at startup when secret_value_policy.enabled is set.
+func (c *KeyorixCore) SetSecretValuePolicy(p SecretValuePolicy) {
+	c.secretValuePolicy = p
 }
 
 // SetLoginLockoutPolicy enables/configures per-account login lockout. The server

--- a/server/main.go
+++ b/server/main.go
@@ -286,6 +286,18 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 		})
 	}
 
+	// Apply the optional secret-value quality gate (reject weak/placeholder values).
+	if svp := cfg.SecretValuePolicy; svp.Enabled {
+		coreService.SetSecretValuePolicy(core.SecretValuePolicy{
+			Enabled:       true,
+			MinLength:     svp.MinLength,
+			RejectCommon:  svp.RejectCommon,
+			ExtraDenylist: svp.ExtraDenylist,
+		})
+		log.Printf("Secret-value policy enabled (min_length=%d, reject_common=%t, denylist=%d)",
+			svp.MinLength, svp.RejectCommon, len(svp.ExtraDenylist))
+	}
+
 	// Apply per-account login lockout if enabled (brute-force protection, distinct
 	// from the per-IP rate limiter).
 	if ll := cfg.Security.LoginLockout; ll.Enabled {


### PR DESCRIPTION
## Summary

A configurable, **OFF-by-default** quality gate on secret **values** (distinct from the user-login `PasswordPolicy`): reject weak/placeholder values at **create** and **rotate**, so a `changeme` never silently becomes a production credential.

- **`core.SecretValuePolicy{Enabled, MinLength, RejectCommon, ExtraDenylist}`** + `Validate()` — pure, returns the **reason only** (never echoes the value). Built-in denylist of common weak/placeholder values (`changeme`, `password`, `123456`, `admin`, …).
- `KeyorixCore` gains `secretValuePolicy` + `SetSecretValuePolicy` (mirrors `passwordPolicy`); **`CreateSecret`** and **`RotateSecret`** enforce it. Zero value = disabled → **no behaviour change** for existing installs.
- Config `secret_value_policy{enabled, min_length, reject_common, extra_denylist}`, wired in `main` at startup.

## Test plan
- `go build ./...` ✅ · `go test ./internal/core/ ./internal/config/` ✅ · `gosec` ✅ · `golangci-lint` ✅ — no new deps
- disabled passes everything; min-length; reject-common (case/space-insensitive, empty); extra denylist (case-insensitive); **error never echoes the value**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)