### PR TITLE
feat(secrets): "who can access" inspector — effective access list

### DIFF
--- a/internal/core/secret_access_list.go
+++ b/internal/core/secret_access_list.go
@@ -1,0 +1,95 @@
+// secret_access_list.go — the effective access list for a secret: every USER who can
+// read it, resolved across the owner, direct user shares, and group shares (with group
+// membership expanded). A least-privilege / access-review aid ("who can read secret
+// X?"). Read-only; the caller must be able to read the secret. Expired (time-bound)
+// shares are excluded, matching enforcement. Note: holders of an admin role have
+// implicit access and are not enumerated here — this lists the per-secret grants.
+package core
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+)
+
+// SecretAccessor is one user with effective access to a secret.
+type SecretAccessor struct {
+	UserID     uint   `json:"user_id"`
+	Username   string `json:"username"`
+	Permission string `json:"permission"` // read | write | owner
+	Source     string `json:"source"`     // owner | direct_share | group_share:<group>
+}
+
+var permissionRank = map[string]int{"read": 1, "write": 2, "owner": 3}
+
+// ListSecretAccessors returns the distinct users who can access secretID, strongest
+// grant per user, sorted by username. The actor must be able to read the secret.
+func (c *KeyorixCore) ListSecretAccessors(ctx context.Context, secretID, actorID uint) ([]SecretAccessor, error) {
+	if _, err := c.EnforceSecretReadPermission(ctx, secretID, actorID); err != nil {
+		return nil, err
+	}
+	secret, err := c.storage.GetSecret(ctx, secretID)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorSecretNotFound", nil), err)
+	}
+
+	userNames := map[uint]string{}
+	resolveUser := func(id uint) string {
+		if n, ok := userNames[id]; ok {
+			return n
+		}
+		name := fmt.Sprintf("user %d", id)
+		if u, err := c.storage.GetUser(ctx, id); err == nil && u != nil && u.Username != "" {
+			name = u.Username
+		}
+		userNames[id] = name
+		return name
+	}
+
+	byUser := map[uint]SecretAccessor{}
+	add := func(uid uint, perm, source string) {
+		if uid == 0 {
+			return
+		}
+		if ex, ok := byUser[uid]; ok && permissionRank[ex.Permission] >= permissionRank[perm] {
+			return // keep the stronger grant
+		}
+		byUser[uid] = SecretAccessor{UserID: uid, Username: resolveUser(uid), Permission: perm, Source: source}
+	}
+
+	if secret.OwnerID != 0 {
+		add(secret.OwnerID, "owner", "owner")
+	}
+
+	shares, err := c.storage.ListSharesBySecret(ctx, secretID)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	for _, sh := range activeShares(shares, c.now()) {
+		if sh.IsGroup {
+			gname := fmt.Sprintf("group %d", sh.RecipientID)
+			if g, err := c.storage.GetGroup(ctx, sh.RecipientID); err == nil && g != nil && g.Name != "" {
+				gname = g.Name
+			}
+			members, err := c.storage.ListGroupMembers(ctx, sh.RecipientID)
+			if err != nil {
+				continue // skip an unresolvable group rather than fail the whole list
+			}
+			for _, m := range members {
+				userNames[m.ID] = m.Username // already loaded; prime the cache
+				add(m.ID, sh.Permission, "group_share:"+gname)
+			}
+		} else {
+			add(sh.RecipientID, sh.Permission, "direct_share")
+		}
+	}
+
+	out := make([]SecretAccessor, 0, len(byUser))
+	for _, a := range byUser {
+		out = append(out, a)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Username < out[j].Username })
+	return out, nil
+}

--- a/internal/core/secret_access_list_test.go
+++ b/internal/core/secret_access_list_test.go
@@ -1,0 +1,116 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestListSecretAccessors(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	sqlDB.SetMaxOpenConns(1)
+	require.NoError(t, db.AutoMigrate(
+		&models.SecretNode{}, &models.SecretVersion{}, &models.User{}, &models.ShareRecord{},
+		&models.Group{}, &models.UserGroup{},
+	))
+	// Users: 1 owner, 2 direct recipient, 3 & 4 group members, 5 expired-share recipient.
+	for _, u := range []models.User{
+		{ID: 1, Username: "owner", Email: "o@t.com"},
+		{ID: 2, Username: "alice", Email: "a@t.com"},
+		{ID: 3, Username: "bob", Email: "b@t.com"},
+		{ID: 4, Username: "carol", Email: "c@t.com"},
+		{ID: 5, Username: "dave", Email: "d@t.com"},
+	} {
+		require.NoError(t, db.Create(&u).Error)
+	}
+	require.NoError(t, db.Create(&models.Group{ID: 10, Name: "platform"}).Error)
+	require.NoError(t, db.Create(&models.UserGroup{UserID: 3, GroupID: 10}).Error)
+	require.NoError(t, db.Create(&models.UserGroup{UserID: 4, GroupID: 10}).Error)
+
+	now := time.Now()
+	st := store.NewLocalStorage(db)
+	c := &KeyorixCore{storage: st, now: func() time.Time { return now }}
+	ctx := context.Background()
+
+	secret, err := st.CreateSecret(ctx, &models.SecretNode{
+		Name: "db", ProjectID: 1, EnvironmentID: 1, Type: "password", OwnerID: 1, IsSecret: true,
+		CreatedAt: now, UpdatedAt: now,
+	})
+	require.NoError(t, err)
+	// Direct share to alice (write); group share to platform (read); expired share to dave.
+	_, err = c.ShareSecret(ctx, &ShareSecretRequest{SecretID: secret.ID, RecipientID: 2, Permission: "write", SharedBy: 1})
+	require.NoError(t, err)
+	_, err = c.ShareSecretWithGroup(ctx, &GroupShareSecretRequest{SecretID: secret.ID, GroupID: 10, Permission: "read", SharedBy: 1})
+	require.NoError(t, err)
+	past := now.Add(-time.Hour)
+	require.NoError(t, db.Create(&models.ShareRecord{SecretID: secret.ID, OwnerID: 1, RecipientID: 5, Permission: "read", ExpiresAt: &past}).Error)
+
+	accessors, err := c.ListSecretAccessors(ctx, secret.ID, 1)
+	require.NoError(t, err)
+
+	byName := map[string]SecretAccessor{}
+	for _, a := range accessors {
+		byName[a.Username] = a
+	}
+	// owner, alice (direct), bob + carol (group). dave is excluded (expired share).
+	assert.Len(t, accessors, 4)
+	assert.Equal(t, "owner", byName["owner"].Permission)
+	assert.Equal(t, "direct_share", byName["alice"].Source)
+	assert.Equal(t, "write", byName["alice"].Permission)
+	assert.Equal(t, "read", byName["bob"].Permission)
+	assert.Contains(t, byName["bob"].Source, "group_share:platform")
+	assert.Contains(t, byName, "carol")
+	assert.NotContains(t, byName, "dave", "an expired share must not grant access")
+
+	// Sorted by username.
+	for i := 1; i < len(accessors); i++ {
+		assert.LessOrEqual(t, accessors[i-1].Username, accessors[i].Username)
+	}
+}
+
+func TestListSecretAccessors_StrongestGrantWins(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	sqlDB, _ := db.DB()
+	sqlDB.SetMaxOpenConns(1)
+	require.NoError(t, db.AutoMigrate(
+		&models.SecretNode{}, &models.SecretVersion{}, &models.User{}, &models.ShareRecord{},
+		&models.Group{}, &models.UserGroup{},
+	))
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "owner", Email: "o@t.com"}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 2, Username: "alice", Email: "a@t.com"}).Error)
+	require.NoError(t, db.Create(&models.Group{ID: 10, Name: "g"}).Error)
+	require.NoError(t, db.Create(&models.UserGroup{UserID: 2, GroupID: 10}).Error)
+
+	now := time.Now()
+	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: func() time.Time { return now }}
+	ctx := context.Background()
+	secret, err := c.storage.CreateSecret(ctx, &models.SecretNode{Name: "s", ProjectID: 1, EnvironmentID: 1, Type: "password", OwnerID: 1, IsSecret: true, CreatedAt: now, UpdatedAt: now})
+	require.NoError(t, err)
+	// alice gets a group read share AND a direct write share — write should win.
+	_, err = c.ShareSecretWithGroup(ctx, &GroupShareSecretRequest{SecretID: secret.ID, GroupID: 10, Permission: "read", SharedBy: 1})
+	require.NoError(t, err)
+	_, err = c.ShareSecret(ctx, &ShareSecretRequest{SecretID: secret.ID, RecipientID: 2, Permission: "write", SharedBy: 1})
+	require.NoError(t, err)
+
+	accessors, err := c.ListSecretAccessors(ctx, secret.ID, 1)
+	require.NoError(t, err)
+	for _, a := range accessors {
+		if a.Username == "alice" {
+			assert.Equal(t, "write", a.Permission, "the stronger (write) grant wins over the group read")
+		}
+	}
+}

--- a/server/http/handlers/secrets_access_list.go
+++ b/server/http/handlers/secrets_access_list.go
@@ -1,0 +1,42 @@
+// secrets_access_list.go — ListAccessors handler: the effective access list for a
+// secret (who can read it).
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/keyorixhq/keyorix/server/middleware"
+)
+
+// ListAccessors handles GET /api/v1/secrets/{id}/access — returns the distinct users
+// who can read the secret (owner + direct + group shares). Scoped secrets.read is
+// enforced by the router; core re-checks the caller's read access.
+func (h *SecretHandler) ListAccessors(w http.ResponseWriter, r *http.Request) {
+	userCtx := middleware.GetUserFromContext(r.Context())
+	if userCtx == nil {
+		h.sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		h.sendError(w, "BadRequest", "Invalid secret ID", http.StatusBadRequest, nil)
+		return
+	}
+
+	accessors, err := h.coreService.ListSecretAccessors(r.Context(), uint(id), userCtx.UserID)
+	if err != nil {
+		switch {
+		case strings.Contains(err.Error(), "not found"):
+			h.sendError(w, "NotFound", "Secret not found", http.StatusNotFound, nil)
+		case strings.Contains(err.Error(), "permission") || strings.Contains(err.Error(), "not authorized"):
+			h.sendError(w, "Forbidden", "Not authorized to view this secret's access", http.StatusForbidden, nil)
+		default:
+			h.sendError(w, "InternalError", "Failed to list accessors", http.StatusInternalServerError, nil)
+		}
+		return
+	}
+	h.sendSuccess(w, map[string]interface{}{"accessors": accessors, "total": len(accessors)}, "")
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -323,6 +323,7 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.With(customMiddleware.RequireScopedPermission("secrets.read", secretScope)).Get("/{id}/versions", secretHandler.GetSecretVersions)
 			r.With(customMiddleware.RequireScopedPermission("secrets.read", secretScope)).Get("/{id}/risk", secretHandler.GetSecretRisk)
 			r.With(customMiddleware.RequireScopedPermission("secrets.read", secretScope)).Get("/{id}/shares", shareHandler.ListSecretShares)
+			r.With(customMiddleware.RequireScopedPermission("secrets.read", secretScope)).Get("/{id}/access", secretHandler.ListAccessors)
 
 			// Create: authorized inside the handler (scope comes from the body).
 			r.Post("/", secretHandler.CreateSecret)


### PR DESCRIPTION
## Summary

A read-only access-review aid: list **every user who can read a secret**, resolved across the owner, direct user shares, and group shares (group membership expanded). Useful for least-privilege review / ISO access recertification ("who can read secret X?").

- **`core.ListSecretAccessors(secretID, actorID)`** — requires the caller to be able to read the secret; returns distinct users (**strongest grant per user**, owner > write > read) with a `source` (`owner` | `direct_share` | `group_share:<group>`), sorted by username. **Excludes expired time-bound shares** (reuses `activeShares`). Admin-role holders have implicit access and are intentionally **not** enumerated — this lists the per-secret grants.
- **`GET /api/v1/secrets/{id}/access`** (scoped `secrets.read`) → `{accessors, total}`.

## Test plan
- `go build ./...` ✅ · `go test ./internal/core/` ✅ · `gosec` ✅ · `golangci-lint` ✅ — no new deps
- owner + direct + group (members expanded) included; expired share excluded; sorted by username; a stronger direct grant wins over a weaker group grant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)