### PR TITLE
release: prep v0.57.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,36 @@
 All notable changes to Keyorix are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## v0.57.0 — 2026-06-18
+
+Secret governance: ownership transfer, value policy, access inspector, HTTP render.
+
+### Added
+- **Secret ownership transfer** — hand a secret to another user (recover orphaned
+  secrets when an owner leaves). The current owner can transfer; an authorized caller
+  can recover a secret whose owner is gone (the lookup fails closed on a transient
+  error, so an active owner's secret can't be taken). `POST /secrets/{id}/transfer-ownership`,
+  audited `secret.owner_transferred`. ([#307])
+- **Secret-value quality policy** — an opt-in (off-by-default) gate that rejects weak/
+  placeholder values (`changeme`, too-short, a configurable denylist) at create and
+  rotate. The rejection reason never echoes the value. ([#309])
+- **"Who can access" inspector** — `GET /secrets/{id}/access` lists every user who can
+  read a secret (owner + direct + group shares, members expanded; expired shares
+  excluded), for least-privilege review. ([#310])
+- **HTTP template render** — `POST /projects/{id}/secrets/render` expands
+  `${secret:<environment>/<name>}` references within a project, resolving only the
+  caller's readable secrets. ([#306])
+
+### Fixed
+- Corrected an integration test's assertion against the paginated `/shares` response
+  shape introduced in v0.54.0. ([#308])
+
+[#306]: https://github.com/keyorixhq/keyorix/pull/306
+[#307]: https://github.com/keyorixhq/keyorix/pull/307
+[#308]: https://github.com/keyorixhq/keyorix/pull/308
+[#309]: https://github.com/keyorixhq/keyorix/pull/309
+[#310]: https://github.com/keyorixhq/keyorix/pull/310
+
 ## v0.56.0 — 2026-06-17
 
 Secret templating: render config/`.env` files from live secrets.

--- a/deploy/helm/keyorix-k8s-sync/Chart.yaml
+++ b/deploy/helm/keyorix-k8s-sync/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix-k8s-sync
 description: Keyorix Kubernetes sync agent — materialises Keyorix secrets into native Kubernetes Secrets
 type: application
 # Chart version — tracks the Keyorix release version (published in lockstep).
-version: 0.56.0
+version: 0.57.0
 # The keyorix-k8s-sync image tag this chart deploys by default.
-appVersion: "0.56.0"
+appVersion: "0.57.0"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix

--- a/deploy/helm/keyorix/Chart.yaml
+++ b/deploy/helm/keyorix/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix
 description: Self-hosted Keyorix secrets manager (API server + web UI + PostgreSQL)
 type: application
 # Chart version — bump on chart changes.
-version: 0.56.0
+version: 0.57.0
 # The Keyorix app version this chart deploys by default (the image tag).
-appVersion: "0.56.0"
+appVersion: "0.57.0"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix


### PR DESCRIPTION
## v0.57.0 — Secret governance

Bumps CHANGELOG + Helm charts to **0.57.0**. Bundles the commits since v0.56.0:

- **#307** — secret ownership transfer (recover orphaned secrets; fail-closed authz)
- **#309** — opt-in secret-value quality policy (reject weak/placeholder values)
- **#310** — "who can access" inspector (`GET /secrets/{id}/access`)
- **#306** — HTTP template render (`POST /projects/{id}/secrets/render`)
- **#308** — test fix for the paginated `/shares` shape

Both charts → 0.57.0 (lockstep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)