### PR TITLE
feat(secrets): suspend / resume a secret (incident-response freeze)

### DIFF
--- a/internal/core/secret_suspend.go
+++ b/internal/core/secret_suspend.go
@@ -1,0 +1,71 @@
+// secret_suspend.go — suspend/resume a secret. Suspending blocks value reads (an
+// incident-response control: a suspected-compromised secret can be frozen without
+// deleting it, preserving its versions, shares, and audit trail) and is reversible.
+// Metadata, listing, and management operations stay available so the secret can be
+// inspected, rotated, or resumed while suspended.
+package core
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// Secret lifecycle statuses.
+const (
+	SecretStatusActive    = "active"
+	SecretStatusSuspended = "suspended"
+)
+
+// Audit event types for suspend/resume.
+const (
+	EventSecretSuspended = "secret.suspended"
+	EventSecretResumed   = "secret.resumed"
+)
+
+// SuspendSecret freezes value reads of a secret (idempotent). The caller (transport)
+// must have enforced scoped secrets.write.
+func (c *KeyorixCore) SuspendSecret(ctx context.Context, secretID, actorID uint, reason string) (*models.SecretNode, error) {
+	secret, err := c.storage.GetSecret(ctx, secretID)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorSecretNotFound", nil), err)
+	}
+	if secret.Status == SecretStatusSuspended {
+		return secret, nil // already suspended — no-op, no duplicate audit
+	}
+	secret.Status = SecretStatusSuspended
+	secret.UpdatedAt = c.now()
+	updated, err := c.storage.UpdateSecret(ctx, secret)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	uid, sid := actorID, secretID
+	desc := fmt.Sprintf("suspended secret %q", updated.Name)
+	if reason != "" {
+		desc += ": " + reason
+	}
+	c.writeAuditEvent(ctx, EventSecretSuspended, &uid, &sid, desc)
+	return updated, nil
+}
+
+// ResumeSecret restores value reads of a suspended secret (idempotent).
+func (c *KeyorixCore) ResumeSecret(ctx context.Context, secretID, actorID uint) (*models.SecretNode, error) {
+	secret, err := c.storage.GetSecret(ctx, secretID)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorSecretNotFound", nil), err)
+	}
+	if secret.Status != SecretStatusSuspended {
+		return secret, nil // not suspended — no-op
+	}
+	secret.Status = SecretStatusActive
+	secret.UpdatedAt = c.now()
+	updated, err := c.storage.UpdateSecret(ctx, secret)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	uid, sid := actorID, secretID
+	c.writeAuditEvent(ctx, EventSecretResumed, &uid, &sid, fmt.Sprintf("resumed secret %q", updated.Name))
+	return updated, nil
+}

--- a/internal/core/secret_suspend_test.go
+++ b/internal/core/secret_suspend_test.go
@@ -1,0 +1,84 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func newSuspendFixture(t *testing.T) (*KeyorixCore, uint, *gorm.DB) {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	sqlDB, _ := db.DB()
+	sqlDB.SetMaxOpenConns(1)
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.AuditEvent{}))
+	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
+	ctx := context.Background()
+	secret, err := c.storage.CreateSecret(ctx, &models.SecretNode{
+		Name: "db", ProjectID: 1, EnvironmentID: 1, Type: "password", OwnerID: 1, IsSecret: true,
+		Status: SecretStatusActive, CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	})
+	require.NoError(t, err)
+	_, err = c.storage.CreateSecretVersion(ctx, &models.SecretVersion{
+		SecretNodeID: secret.ID, VersionNumber: 1, EncryptedValue: []byte("v"),
+	})
+	require.NoError(t, err)
+	return c, secret.ID, db
+}
+
+func TestSuspendResumeSecret(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("suspend blocks value reads; resume restores them", func(t *testing.T) {
+		c, id, _ := newSuspendFixture(t)
+		// Readable before suspension.
+		_, err := c.GetSecretValue(ctx, id)
+		require.NoError(t, err)
+
+		s, err := c.SuspendSecret(ctx, id, 1, "suspected leak")
+		require.NoError(t, err)
+		assert.Equal(t, SecretStatusSuspended, s.Status)
+
+		_, err = c.GetSecretValue(ctx, id)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "suspended")
+		_, err = c.GetSecretValueByVersion(ctx, id, 1)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "suspended")
+
+		s, err = c.ResumeSecret(ctx, id, 1)
+		require.NoError(t, err)
+		assert.Equal(t, SecretStatusActive, s.Status)
+		_, err = c.GetSecretValue(ctx, id)
+		require.NoError(t, err, "value is readable again after resume")
+	})
+
+	t.Run("suspend is idempotent and audited once", func(t *testing.T) {
+		c, id, db := newSuspendFixture(t)
+		_, err := c.SuspendSecret(ctx, id, 1, "")
+		require.NoError(t, err)
+		_, err = c.SuspendSecret(ctx, id, 1, "") // no-op
+		require.NoError(t, err)
+
+		var count int64
+		require.NoError(t, db.Model(&models.AuditEvent{}).Where("event_type = ?", EventSecretSuspended).Count(&count).Error)
+		assert.EqualValues(t, 1, count, "re-suspending an already-suspended secret does not re-audit")
+	})
+
+	t.Run("resume on a non-suspended secret is a no-op", func(t *testing.T) {
+		c, id, _ := newSuspendFixture(t)
+		s, err := c.ResumeSecret(ctx, id, 1)
+		require.NoError(t, err)
+		assert.Equal(t, SecretStatusActive, s.Status)
+	})
+}

--- a/internal/core/versions.go
+++ b/internal/core/versions.go
@@ -105,6 +105,9 @@ func (c *KeyorixCore) GetSecretValue(ctx context.Context, secretID uint) ([]byte
 	if secret.Expiration != nil && time.Now().After(*secret.Expiration) {
 		return nil, fmt.Errorf("%s", i18n.T("ErrorSecretExpired", nil))
 	}
+	if secret.Status == SecretStatusSuspended {
+		return nil, fmt.Errorf("secret is suspended")
+	}
 	version, err := c.storage.GetLatestSecretVersion(ctx, secretID)
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorVersionNotFound", nil), err)
@@ -138,6 +141,9 @@ func (c *KeyorixCore) GetSecretValueByVersion(ctx context.Context, secretID uint
 	}
 	if secret.Expiration != nil && time.Now().After(*secret.Expiration) {
 		return nil, fmt.Errorf("%s", i18n.T("ErrorSecretExpired", nil))
+	}
+	if secret.Status == SecretStatusSuspended {
+		return nil, fmt.Errorf("secret is suspended")
 	}
 	version, err := c.GetSecretVersion(ctx, secretID, versionNumber)
 	if err != nil {

--- a/server/http/handlers/secrets_suspend.go
+++ b/server/http/handlers/secrets_suspend.go
@@ -1,0 +1,68 @@
+// secrets_suspend.go — SuspendSecret / ResumeSecret handlers: freeze or restore value
+// reads of a secret (incident response).
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/keyorixhq/keyorix/server/middleware"
+)
+
+// SuspendSecret handles POST /api/v1/secrets/{id}/suspend with an optional body
+// {"reason": "..."}. Scoped secrets.write is enforced by the router.
+func (h *SecretHandler) SuspendSecret(w http.ResponseWriter, r *http.Request) {
+	userCtx := middleware.GetUserFromContext(r.Context())
+	if userCtx == nil {
+		h.sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		h.sendError(w, "BadRequest", "Invalid secret ID", http.StatusBadRequest, nil)
+		return
+	}
+	var reqBody struct {
+		Reason string `json:"reason"`
+	}
+	_ = json.NewDecoder(r.Body).Decode(&reqBody) // body is optional
+
+	secret, err := h.coreService.SuspendSecret(r.Context(), uint(id), userCtx.UserID, reqBody.Reason)
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			h.sendError(w, "NotFound", "Secret not found", http.StatusNotFound, nil)
+		} else {
+			h.sendError(w, "InternalError", "Failed to suspend secret", http.StatusInternalServerError, nil)
+		}
+		return
+	}
+	h.sendSuccess(w, secret, "Secret suspended")
+}
+
+// ResumeSecret handles POST /api/v1/secrets/{id}/resume. Scoped secrets.write is
+// enforced by the router.
+func (h *SecretHandler) ResumeSecret(w http.ResponseWriter, r *http.Request) {
+	userCtx := middleware.GetUserFromContext(r.Context())
+	if userCtx == nil {
+		h.sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		h.sendError(w, "BadRequest", "Invalid secret ID", http.StatusBadRequest, nil)
+		return
+	}
+	secret, err := h.coreService.ResumeSecret(r.Context(), uint(id), userCtx.UserID)
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			h.sendError(w, "NotFound", "Secret not found", http.StatusNotFound, nil)
+		} else {
+			h.sendError(w, "InternalError", "Failed to resume secret", http.StatusInternalServerError, nil)
+		}
+		return
+	}
+	h.sendSuccess(w, secret, "Secret resumed")
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -333,6 +333,8 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.With(customMiddleware.RequireScopedPermission("secrets.write", secretScope)).Post("/{id}/rotate", secretHandler.RotateSecret)
 			r.With(customMiddleware.RequireScopedPermission("secrets.write", secretScope)).Post("/{id}/rollback", secretHandler.RollbackSecret)
 			r.With(customMiddleware.RequireScopedPermission("secrets.write", secretScope)).Post("/{id}/transfer-ownership", secretHandler.TransferOwnership)
+			r.With(customMiddleware.RequireScopedPermission("secrets.write", secretScope)).Post("/{id}/suspend", secretHandler.SuspendSecret)
+			r.With(customMiddleware.RequireScopedPermission("secrets.write", secretScope)).Post("/{id}/resume", secretHandler.ResumeSecret)
 			r.With(customMiddleware.RequireScopedPermission("secrets.write", secretScope)).Post("/{id}/share", shareHandler.ShareSecret)
 
 			r.With(customMiddleware.RequireScopedPermission("secrets.delete", secretScope)).Delete("/{id}", secretHandler.DeleteSecret)


### PR DESCRIPTION
## Summary

Block value reads of a suspected-compromised secret **without deleting it** — versions, shares, and the audit trail are preserved, and it's fully reversible.

- **`core.SuspendSecret` / `ResumeSecret`** toggle `Status` between `active` and `suspended` (idempotent; audited `secret.suspended` / `secret.resumed`; suspend takes an optional reason). The `Status` field existed but was never enforced.
- **`GetSecretValue` and `GetSecretValueByVersion`** now refuse a suspended secret (alongside the expiry check) — so a suspend blocks reads on **every value path, even for the owner**. Metadata / listing / management stay available so the secret can be inspected, rotated, or resumed while suspended.
- **`POST /secrets/{id}/suspend` `{reason?}`** and **`/resume`**, scoped `secrets.write` (route-gated like rotate/rollback). Real mutations — verified they **deny the read-only persona**.

## Test plan
- `go build ./...` ✅ · `go test ./internal/core/` ✅ · `gosec` ✅ · `golangci-lint` ✅ — no new deps
- suspend blocks both value-read paths + resume restores; suspend idempotent and audited once; resume on a non-suspended secret is a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)