### PR TITLE
feat(cli): secret suspend / resume commands (parity with HTTP/web)

### DIFF
--- a/internal/cli/secret/suspend.go
+++ b/internal/cli/secret/suspend.go
@@ -1,0 +1,83 @@
+package secret
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/spf13/cobra"
+)
+
+var (
+	suspendID     uint
+	suspendReason string
+	resumeID      uint
+)
+
+var suspendCmd = &cobra.Command{
+	Use:   "suspend",
+	Short: "Suspend a secret — block value reads without deleting it",
+	Long: `Freeze a secret: value reads are refused until it is resumed. Versions, shares,
+and the audit trail are preserved. Useful for incident response on a suspected-
+compromised secret. Requires secrets.write at the secret's scope.`,
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		if suspendID == 0 {
+			return fmt.Errorf("--id is required")
+		}
+		c, ok := common.NewRemoteClient()
+		if !ok {
+			return fmt.Errorf("not connected to a server — run: keyorix connect <server>")
+		}
+		return runSuspendRemote(c, suspendID, suspendReason)
+	},
+}
+
+var resumeCmd = &cobra.Command{
+	Use:          "resume",
+	Short:        "Resume a suspended secret — restore value reads",
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		if resumeID == 0 {
+			return fmt.Errorf("--id is required")
+		}
+		c, ok := common.NewRemoteClient()
+		if !ok {
+			return fmt.Errorf("not connected to a server — run: keyorix connect <server>")
+		}
+		return runResumeRemote(c, resumeID)
+	},
+}
+
+// runSuspendRemote POSTs the suspend request (split out for httptest-backed tests).
+func runSuspendRemote(c *common.RemoteClient, id uint, reason string) error {
+	body := map[string]interface{}{}
+	if reason != "" {
+		body["reason"] = reason
+	}
+	var out struct{}
+	if err := c.Post(context.Background(), "/api/v1/secrets/"+strconv.Itoa(int(id))+"/suspend", body, &out); err != nil {
+		return err
+	}
+	fmt.Printf("✓ Secret %d suspended — value reads are now blocked.\n", id)
+	return nil
+}
+
+// runResumeRemote POSTs the resume request.
+func runResumeRemote(c *common.RemoteClient, id uint) error {
+	var out struct{}
+	if err := c.Post(context.Background(), "/api/v1/secrets/"+strconv.Itoa(int(id))+"/resume", map[string]interface{}{}, &out); err != nil {
+		return err
+	}
+	fmt.Printf("✓ Secret %d resumed — value reads are restored.\n", id)
+	return nil
+}
+
+func init() {
+	suspendCmd.Flags().UintVar(&suspendID, "id", 0, "Secret ID (required)")
+	suspendCmd.Flags().StringVar(&suspendReason, "reason", "", "Optional reason recorded in the audit event")
+	resumeCmd.Flags().UintVar(&resumeID, "id", 0, "Secret ID (required)")
+	SecretCmd.AddCommand(suspendCmd)
+	SecretCmd.AddCommand(resumeCmd)
+}

--- a/internal/cli/secret/suspend_remote_test.go
+++ b/internal/cli/secret/suspend_remote_test.go
@@ -1,0 +1,67 @@
+package secret
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunSuspendResumeRemote(t *testing.T) {
+	var gotPath string
+	var postBody map[string]interface{}
+	status := http.StatusOK
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		gotPath = r.URL.Path
+		b, _ := io.ReadAll(r.Body)
+		postBody = map[string]interface{}{}
+		_ = json.Unmarshal(b, &postBody)
+		if status != http.StatusOK {
+			w.WriteHeader(status)
+			return
+		}
+		_, _ = w.Write([]byte(`{"data":{"ID":42,"Name":"db"}}`))
+	}))
+	defer srv.Close()
+
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+	rc, ok := common.NewRemoteClient()
+	require.True(t, ok)
+
+	t.Run("suspend posts to the suspend route with the reason", func(t *testing.T) {
+		status = http.StatusOK
+		require.NoError(t, runSuspendRemote(rc, 42, "suspected leak"))
+		assert.Equal(t, "/api/v1/secrets/42/suspend", gotPath)
+		assert.Equal(t, "suspected leak", postBody["reason"])
+	})
+
+	t.Run("suspend omits an empty reason", func(t *testing.T) {
+		status = http.StatusOK
+		require.NoError(t, runSuspendRemote(rc, 42, ""))
+		_, has := postBody["reason"]
+		assert.False(t, has, "no reason key when none given")
+	})
+
+	t.Run("resume posts to the resume route", func(t *testing.T) {
+		status = http.StatusOK
+		require.NoError(t, runResumeRemote(rc, 42))
+		assert.Equal(t, "/api/v1/secrets/42/resume", gotPath)
+	})
+
+	t.Run("surfaces a server error", func(t *testing.T) {
+		status = http.StatusForbidden
+		err := runSuspendRemote(rc, 42, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "403")
+	})
+}


### PR DESCRIPTION
## Summary

Rounds out the suspend/resume feature (server #313, web keyorix-web #61) on the CLI:

```
keyorix secret suspend --id <id> [--reason "..."]
keyorix secret resume  --id <id>
```

Both POST via the shared `RemoteClient` to `/secrets/{id}/suspend|resume` (the server enforces scoped `secrets.write`); `--id` validated locally and server errors surfaced verbatim. The request core is split into `runSuspendRemote` / `runResumeRemote` for `httptest`-backed tests.

## Test plan
- `go build ./...` ✅ · `go test ./internal/cli/secret/` ✅ · `gosec` ✅ · `golangci-lint` ✅ — no new deps
- suspend posts to the suspend route with the reason; omits an empty reason; resume posts to the resume route; a server error passes through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)