### PR TITLE
release: prep v0.58.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,26 @@
 All notable changes to Keyorix are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## v0.58.0 — 2026-06-18
+
+Incident response: suspend/resume a secret.
+
+### Added
+- **Suspend / resume a secret** — freeze value reads of a suspected-compromised
+  secret without deleting it (versions, shares, and audit trail are preserved);
+  reversible. A suspended secret refuses reads on every value path, even for the
+  owner, while metadata/listing/management stay available. `POST /secrets/{id}/suspend`
+  (optional reason) and `/resume` (scoped `secrets.write`, audited
+  `secret.suspended` / `secret.resumed`), plus `keyorix secret suspend|resume`. ([#313], [#314])
+
+### Fixed
+- The secret-value quality policy is now enforced on `UpdateSecret` too, not just
+  create and rotate — closing a path where a weak value could be set via update. ([#312])
+
+[#312]: https://github.com/keyorixhq/keyorix/pull/312
+[#313]: https://github.com/keyorixhq/keyorix/pull/313
+[#314]: https://github.com/keyorixhq/keyorix/pull/314
+
 ## v0.57.0 — 2026-06-18
 
 Secret governance: ownership transfer, value policy, access inspector, HTTP render.

--- a/deploy/helm/keyorix-k8s-sync/Chart.yaml
+++ b/deploy/helm/keyorix-k8s-sync/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix-k8s-sync
 description: Keyorix Kubernetes sync agent — materialises Keyorix secrets into native Kubernetes Secrets
 type: application
 # Chart version — tracks the Keyorix release version (published in lockstep).
-version: 0.57.0
+version: 0.58.0
 # The keyorix-k8s-sync image tag this chart deploys by default.
-appVersion: "0.57.0"
+appVersion: "0.58.0"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix

--- a/deploy/helm/keyorix/Chart.yaml
+++ b/deploy/helm/keyorix/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix
 description: Self-hosted Keyorix secrets manager (API server + web UI + PostgreSQL)
 type: application
 # Chart version — bump on chart changes.
-version: 0.57.0
+version: 0.58.0
 # The Keyorix app version this chart deploys by default (the image tag).
-appVersion: "0.57.0"
+appVersion: "0.58.0"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix


### PR DESCRIPTION
## v0.58.0 — Incident response: suspend/resume a secret

Bumps CHANGELOG + Helm charts to **0.58.0**. Bundles the commits since v0.57.0:

- **#313** — suspend / resume a secret (freeze value reads without deleting; reversible; audited)
- **#314** — `keyorix secret suspend|resume` CLI commands
- **#312** — enforce the secret-value policy on `UpdateSecret` too (closes a bypass)

Both charts → 0.58.0 (lockstep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)