### PR TITLE
feat(secrets): per-secret access history (recent reads)

### DIFF
--- a/internal/core/secret_access_history.go
+++ b/internal/core/secret_access_history.go
@@ -1,0 +1,28 @@
+// secret_access_history.go — per-secret access history: the recent reads of a secret
+// (who, when, from where). Complements the access inspector (who CAN read) with who
+// HAS read — an investigation aid. Read-only; the caller must be able to read the
+// secret. Returns access-log metadata only (accessor, IP, user-agent, time, action),
+// never any secret value.
+package core
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// ListSecretAccessHistory returns the secret's access-log entries since `since`. The
+// actor must be able to read the secret.
+func (c *KeyorixCore) ListSecretAccessHistory(ctx context.Context, secretID, actorID uint, since time.Time) ([]models.SecretAccessLog, error) {
+	if _, err := c.EnforceSecretReadPermission(ctx, secretID, actorID); err != nil {
+		return nil, err
+	}
+	logs, err := c.storage.ListSecretAccessLogs(ctx, secretID, since)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	return logs, nil
+}

--- a/internal/core/secret_access_history_test.go
+++ b/internal/core/secret_access_history_test.go
@@ -1,0 +1,60 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestListSecretAccessHistory(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	sqlDB, _ := db.DB()
+	sqlDB.SetMaxOpenConns(1)
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.User{}, &models.SecretAccessLog{}))
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "owner", Email: "o@t.com"}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 2, Username: "mallory", Email: "m@t.com"}).Error)
+
+	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
+	ctx := context.Background()
+	secret, err := c.storage.CreateSecret(ctx, &models.SecretNode{
+		Name: "db", ProjectID: 1, EnvironmentID: 1, Type: "password", OwnerID: 1, IsSecret: true,
+		CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	})
+	require.NoError(t, err)
+
+	now := time.Now()
+	// Two recent reads + one outside the window.
+	require.NoError(t, c.storage.CreateSecretAccessLog(ctx, &models.SecretAccessLog{
+		SecretNodeID: secret.ID, AccessedBy: "owner", Action: "read", IPAddress: "10.0.0.1", AccessTime: now.Add(-1 * time.Hour),
+	}))
+	require.NoError(t, c.storage.CreateSecretAccessLog(ctx, &models.SecretAccessLog{
+		SecretNodeID: secret.ID, AccessedBy: "owner", Action: "read", IPAddress: "10.0.0.2", AccessTime: now.Add(-2 * time.Hour),
+	}))
+	require.NoError(t, c.storage.CreateSecretAccessLog(ctx, &models.SecretAccessLog{
+		SecretNodeID: secret.ID, AccessedBy: "owner", Action: "read", IPAddress: "10.0.0.3", AccessTime: now.Add(-40 * 24 * time.Hour),
+	}))
+
+	t.Run("owner sees recent reads within the window", func(t *testing.T) {
+		logs, err := c.ListSecretAccessHistory(ctx, secret.ID, 1, now.Add(-7*24*time.Hour))
+		require.NoError(t, err)
+		assert.Len(t, logs, 2, "the 40-day-old entry is outside the 7-day window")
+		for _, l := range logs {
+			assert.Equal(t, "read", l.Action)
+		}
+	})
+
+	t.Run("a non-reader is denied", func(t *testing.T) {
+		_, err := c.ListSecretAccessHistory(ctx, secret.ID, 2, now.Add(-7*24*time.Hour))
+		require.Error(t, err)
+	})
+}

--- a/server/http/handlers/secrets_access_history.go
+++ b/server/http/handlers/secrets_access_history.go
@@ -1,0 +1,58 @@
+// secrets_access_history.go — AccessHistory handler: recent reads of a secret.
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/server/middleware"
+)
+
+// AccessHistory handles GET /api/v1/secrets/{id}/access-log?days=N — the secret's
+// recent access-log entries (who read it, when, from where). Scoped secrets.read is
+// enforced by the router; core re-checks the caller's read access. days defaults to
+// 30 and is capped at 365.
+func (h *SecretHandler) AccessHistory(w http.ResponseWriter, r *http.Request) {
+	userCtx := middleware.GetUserFromContext(r.Context())
+	if userCtx == nil {
+		h.sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		h.sendError(w, "BadRequest", "Invalid secret ID", http.StatusBadRequest, nil)
+		return
+	}
+
+	days := 30
+	if v := r.URL.Query().Get("days"); v != "" {
+		if n, perr := strconv.Atoi(v); perr == nil && n > 0 {
+			days = n
+		}
+	}
+	if days > 365 {
+		days = 365
+	}
+	since := time.Now().AddDate(0, 0, -days)
+
+	logs, err := h.coreService.ListSecretAccessHistory(r.Context(), uint(id), userCtx.UserID, since)
+	if err != nil {
+		switch {
+		case strings.Contains(err.Error(), "not found"):
+			h.sendError(w, "NotFound", "Secret not found", http.StatusNotFound, nil)
+		case strings.Contains(err.Error(), "permission") || strings.Contains(err.Error(), "not authorized"):
+			h.sendError(w, "Forbidden", "Not authorized to view this secret's access log", http.StatusForbidden, nil)
+		default:
+			h.sendError(w, "InternalError", "Failed to list access history", http.StatusInternalServerError, nil)
+		}
+		return
+	}
+	if logs == nil {
+		logs = []models.SecretAccessLog{}
+	}
+	h.sendSuccess(w, map[string]interface{}{"access_log": logs, "total": len(logs)}, "")
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -324,6 +324,7 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.With(customMiddleware.RequireScopedPermission("secrets.read", secretScope)).Get("/{id}/risk", secretHandler.GetSecretRisk)
 			r.With(customMiddleware.RequireScopedPermission("secrets.read", secretScope)).Get("/{id}/shares", shareHandler.ListSecretShares)
 			r.With(customMiddleware.RequireScopedPermission("secrets.read", secretScope)).Get("/{id}/access", secretHandler.ListAccessors)
+			r.With(customMiddleware.RequireScopedPermission("secrets.read", secretScope)).Get("/{id}/access-log", secretHandler.AccessHistory)
 
 			// Create: authorized inside the handler (scope comes from the body).
 			r.Post("/", secretHandler.CreateSecret)


### PR DESCRIPTION
## Summary

Complements the access inspector (#310, "who **can** read") with "who **has** read" — an investigation aid surfacing a secret's recent access-log entries.

- **`core.ListSecretAccessHistory(secretID, actorID, since)`** — requires the caller to be able to read the secret, then returns `storage.ListSecretAccessLogs` (metadata only: accessor, IP, user-agent, time, action; **never the value**).
- **`GET /api/v1/secrets/{id}/access-log?days=N`** (scoped `secrets.read`; `days` default 30, capped 365) → `{access_log, total}`.

## Test plan
- `go build ./...` ✅ · `go test ./internal/core/` ✅ · `gosec` ✅ · `golangci-lint` ✅ — no new deps
- Owner sees reads within the window (older entries excluded); a non-reader is denied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)