### PR TITLE
feat(secrets): project-wide suspend / resume (breach freeze)

### DIFF
--- a/internal/core/project_suspend_test.go
+++ b/internal/core/project_suspend_test.go
@@ -1,0 +1,78 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestSuspendResumeProjectSecrets(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	sqlDB, _ := db.DB()
+	sqlDB.SetMaxOpenConns(1)
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.AuditEvent{}, &models.Project{}, &models.Environment{}))
+	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
+	ctx := context.Background()
+
+	// Two projects, each with an environment (the secret list query joins environments).
+	p1, err := c.storage.CreateProject(ctx, &models.Project{Name: "p1"})
+	require.NoError(t, err)
+	e1, err := c.storage.CreateEnvironment(ctx, &models.Environment{Name: "production", ProjectID: p1.ID})
+	require.NoError(t, err)
+	p2, err := c.storage.CreateProject(ctx, &models.Project{Name: "p2"})
+	require.NoError(t, err)
+	e2, err := c.storage.CreateEnvironment(ctx, &models.Environment{Name: "production", ProjectID: p2.ID})
+	require.NoError(t, err)
+
+	// Project p1: three secrets (one already suspended). Project p2: one (must be untouched).
+	mk := func(name string, projectID, envID uint, status string) uint {
+		s, err := c.storage.CreateSecret(ctx, &models.SecretNode{
+			Name: name, ProjectID: projectID, EnvironmentID: envID, Type: "password", OwnerID: 1, IsSecret: true,
+			Status: status, CreatedAt: time.Now(), UpdatedAt: time.Now(),
+		})
+		require.NoError(t, err)
+		return s.ID
+	}
+	mk("a", p1.ID, e1.ID, SecretStatusActive)
+	mk("b", p1.ID, e1.ID, SecretStatusActive)
+	mk("c", p1.ID, e1.ID, SecretStatusSuspended) // already suspended
+	otherID := mk("z", p2.ID, e2.ID, SecretStatusActive)
+
+	t.Run("suspend-all suspends only the active secrets in the project", func(t *testing.T) {
+		n, err := c.SuspendProjectSecrets(ctx, p1.ID, 1, "breach")
+		require.NoError(t, err)
+		assert.Equal(t, 2, n, "the already-suspended one is skipped")
+
+		// Project 2's secret is untouched.
+		other, _ := c.storage.GetSecret(ctx, otherID)
+		assert.Equal(t, SecretStatusActive, other.Status)
+	})
+
+	t.Run("resume-all resumes every suspended secret in the project", func(t *testing.T) {
+		n, err := c.ResumeProjectSecrets(ctx, p1.ID, 1)
+		require.NoError(t, err)
+		assert.Equal(t, 3, n, "all three (now suspended) are resumed")
+
+		// A second resume is a no-op.
+		n, err = c.ResumeProjectSecrets(ctx, p1.ID, 1)
+		require.NoError(t, err)
+		assert.Equal(t, 0, n)
+	})
+
+	t.Run("validates ids", func(t *testing.T) {
+		_, err := c.SuspendProjectSecrets(ctx, 0, 1, "")
+		require.Error(t, err)
+		_, err = c.ResumeProjectSecrets(ctx, 1, 0)
+		require.Error(t, err)
+	})
+}

--- a/internal/core/secret_suspend.go
+++ b/internal/core/secret_suspend.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
@@ -48,6 +49,74 @@ func (c *KeyorixCore) SuspendSecret(ctx context.Context, secretID, actorID uint,
 	}
 	c.writeAuditEvent(ctx, EventSecretSuspended, &uid, &sid, desc)
 	return updated, nil
+}
+
+const projectSuspendPageSize = 500
+
+// SuspendProjectSecrets freezes value reads of every active secret in a project (a
+// breach-response "freeze the project" action) and returns how many it suspended.
+// Already-suspended secrets are left untouched; a per-secret failure is skipped so one
+// bad secret doesn't abort the freeze. The caller must have enforced scoped
+// secrets.write on the project.
+func (c *KeyorixCore) SuspendProjectSecrets(ctx context.Context, projectID, actorID uint, reason string) (int, error) {
+	if projectID == 0 || actorID == 0 {
+		return 0, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "project ID and actor ID are required")
+	}
+	secrets, err := c.listProjectSecrets(ctx, projectID)
+	if err != nil {
+		return 0, err
+	}
+	n := 0
+	for _, s := range secrets {
+		if s.Status == SecretStatusSuspended {
+			continue
+		}
+		if _, err := c.SuspendSecret(ctx, s.ID, actorID, reason); err == nil {
+			n++
+		}
+	}
+	return n, nil
+}
+
+// ResumeProjectSecrets restores value reads of every suspended secret in a project and
+// returns how many it resumed. See SuspendProjectSecrets for semantics.
+func (c *KeyorixCore) ResumeProjectSecrets(ctx context.Context, projectID, actorID uint) (int, error) {
+	if projectID == 0 || actorID == 0 {
+		return 0, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "project ID and actor ID are required")
+	}
+	secrets, err := c.listProjectSecrets(ctx, projectID)
+	if err != nil {
+		return 0, err
+	}
+	n := 0
+	for _, s := range secrets {
+		if s.Status != SecretStatusSuspended {
+			continue
+		}
+		if _, err := c.ResumeSecret(ctx, s.ID, actorID); err == nil {
+			n++
+		}
+	}
+	return n, nil
+}
+
+// listProjectSecrets pages through every secret in a project.
+func (c *KeyorixCore) listProjectSecrets(ctx context.Context, projectID uint) ([]*models.SecretNode, error) {
+	pid := projectID
+	var all []*models.SecretNode
+	for page := 1; ; page++ {
+		secrets, total, err := c.storage.ListSecrets(ctx, &storage.SecretFilter{
+			ProjectID: &pid, Page: page, PageSize: projectSuspendPageSize,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+		}
+		all = append(all, secrets...)
+		if len(secrets) < projectSuspendPageSize || int64(len(all)) >= total {
+			break
+		}
+	}
+	return all, nil
 }
 
 // ResumeSecret restores value reads of a suspended secret (idempotent).

--- a/server/http/handlers/projects_suspend.go
+++ b/server/http/handlers/projects_suspend.go
@@ -1,0 +1,58 @@
+// projects_suspend.go — project-wide suspend/resume: freeze or restore value reads of
+// every secret in a project (incident response).
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/keyorixhq/keyorix/server/middleware"
+)
+
+// SuspendProjectSecrets handles POST /api/v1/projects/{id}/secrets/suspend-all with an
+// optional {"reason": "..."}. Scoped secrets.write (project) is enforced by the router.
+func (h *SecretHandler) SuspendProjectSecrets(w http.ResponseWriter, r *http.Request) {
+	userCtx := middleware.GetUserFromContext(r.Context())
+	if userCtx == nil {
+		h.sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		h.sendError(w, "BadRequest", "Invalid project ID", http.StatusBadRequest, nil)
+		return
+	}
+	var reqBody struct {
+		Reason string `json:"reason"`
+	}
+	_ = json.NewDecoder(r.Body).Decode(&reqBody) // optional
+
+	n, err := h.coreService.SuspendProjectSecrets(r.Context(), uint(id), userCtx.UserID, reqBody.Reason)
+	if err != nil {
+		h.sendError(w, "InternalError", "Failed to suspend project secrets", http.StatusInternalServerError, nil)
+		return
+	}
+	h.sendSuccess(w, map[string]interface{}{"suspended": n}, "")
+}
+
+// ResumeProjectSecrets handles POST /api/v1/projects/{id}/secrets/resume-all.
+func (h *SecretHandler) ResumeProjectSecrets(w http.ResponseWriter, r *http.Request) {
+	userCtx := middleware.GetUserFromContext(r.Context())
+	if userCtx == nil {
+		h.sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		h.sendError(w, "BadRequest", "Invalid project ID", http.StatusBadRequest, nil)
+		return
+	}
+	n, err := h.coreService.ResumeProjectSecrets(r.Context(), uint(id), userCtx.UserID)
+	if err != nil {
+		h.sendError(w, "InternalError", "Failed to resume project secrets", http.StatusInternalServerError, nil)
+		return
+	}
+	h.sendSuccess(w, map[string]interface{}{"resumed": n}, "")
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -300,6 +300,8 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		r.With(customMiddleware.RequireScopedPermission("users.read", projectScope)).Get("/projects/{id}/machine-identities/{machineId}/oidc-bindings", catalogHandler.ListOIDCBindings)
 		r.With(customMiddleware.RequireScopedPermission("roles.assign", projectScope)).Delete("/projects/{id}/machine-identities/{machineId}/oidc-bindings/{bindingId}", catalogHandler.DeleteOIDCBinding)
 		r.With(customMiddleware.RequireScopedPermission("secrets.read", projectScope)).Post("/projects/{id}/secrets/render", secretHandler.RenderTemplate)
+		r.With(customMiddleware.RequireScopedPermission("secrets.write", projectScope)).Post("/projects/{id}/secrets/suspend-all", secretHandler.SuspendProjectSecrets)
+		r.With(customMiddleware.RequireScopedPermission("secrets.write", projectScope)).Post("/projects/{id}/secrets/resume-all", secretHandler.ResumeProjectSecrets)
 		r.With(customMiddleware.RequireScopedPermission("secrets.read", projectScope)).Get("/projects/{id}/environments", catalogHandler.ListProjectEnvironments)
 		r.With(customMiddleware.RequireScopedPermission("secrets.write", projectScope)).Post("/projects/{id}/environments", catalogHandler.CreateProjectEnvironment)
 		// Environment restore is nested under the project so the scope resolves


### PR DESCRIPTION
## Summary

Escalates the per-secret suspend (#313) to a whole project — a breach-response **"freeze the project" / "thaw the project"** action.

- **`core.SuspendProjectSecrets` / `ResumeProjectSecrets`** page the project's secrets and suspend the active ones / resume the suspended ones (each via `SuspendSecret`/`ResumeSecret`, so per-secret audit is preserved); already-in-state secrets are skipped; a per-secret failure is skipped rather than aborting the run. Returns the count.
- **`POST /api/v1/projects/{id}/secrets/suspend-all` `{reason?}`** and **`/resume-all`**, scoped `secrets.write` on the project (route-gated like the project render endpoint). Real mutations — verified they **deny the read-only persona**.

## Test plan
- `go build ./...` ✅ · full `go test ./internal/core/` ✅ · `gosec` ✅ · `golangci-lint` ✅ — no new deps
- suspend-all freezes only active (skips already-suspended) and leaves other projects untouched; resume-all thaws all suspended + a second run is a no-op; id validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)