### PR TITLE
feat(cli): secret access / access-log commands (investigation parity)

### DIFF
--- a/internal/cli/secret/access.go
+++ b/internal/cli/secret/access.go
@@ -1,0 +1,125 @@
+package secret
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/spf13/cobra"
+)
+
+var (
+	accessID      uint
+	accessLogID   uint
+	accessLogDays int
+)
+
+// accessorRow mirrors the GET /secrets/{id}/access ShareView (camelCase).
+type accessorRow struct {
+	Username   string `json:"username"`
+	Permission string `json:"permission"`
+	Source     string `json:"source"`
+}
+
+// accessLogRow mirrors a GET /secrets/{id}/access-log entry (PascalCase model JSON).
+type accessLogRow struct {
+	AccessedBy string `json:"AccessedBy"`
+	Action     string `json:"Action"`
+	IPAddress  string `json:"IPAddress"`
+	AccessTime string `json:"AccessTime"`
+}
+
+var accessCmd = &cobra.Command{
+	Use:   "access",
+	Short: "List who can read a secret (owner + direct + group shares)",
+	Long: `Show the effective access list for a secret: every user who can read it, with their
+permission and how it was granted. Requires secrets.read at the secret's scope.`,
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		if accessID == 0 {
+			return fmt.Errorf("--id is required")
+		}
+		c, ok := common.NewRemoteClient()
+		if !ok {
+			return fmt.Errorf("not connected to a server — run: keyorix connect <server>")
+		}
+		rows, err := fetchAccessors(context.Background(), c, accessID)
+		if err != nil {
+			return err
+		}
+		if len(rows) == 0 {
+			fmt.Println("No accessors.")
+			return nil
+		}
+		fmt.Printf("%-24s %-10s %s\n", "USER", "PERMISSION", "SOURCE")
+		for _, r := range rows {
+			fmt.Printf("%-24s %-10s %s\n", r.Username, r.Permission, r.Source)
+		}
+		return nil
+	},
+}
+
+var accessLogCmd = &cobra.Command{
+	Use:   "access-log",
+	Short: "Show a secret's recent reads (who/when/from where)",
+	Long: `List the recent access-log entries for a secret. Requires secrets.read at the
+secret's scope.`,
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		if accessLogID == 0 {
+			return fmt.Errorf("--id is required")
+		}
+		c, ok := common.NewRemoteClient()
+		if !ok {
+			return fmt.Errorf("not connected to a server — run: keyorix connect <server>")
+		}
+		rows, err := fetchAccessLog(context.Background(), c, accessLogID, accessLogDays)
+		if err != nil {
+			return err
+		}
+		if len(rows) == 0 {
+			fmt.Println("No reads in the window.")
+			return nil
+		}
+		fmt.Printf("%-24s %-8s %-18s %s\n", "ACCESSED BY", "ACTION", "IP", "TIME")
+		for _, r := range rows {
+			fmt.Printf("%-24s %-8s %-18s %s\n", r.AccessedBy, r.Action, r.IPAddress, r.AccessTime)
+		}
+		return nil
+	},
+}
+
+// fetchAccessors GETs the effective access list (split out for httptest tests).
+func fetchAccessors(ctx context.Context, c *common.RemoteClient, id uint) ([]accessorRow, error) {
+	var body struct {
+		Accessors []accessorRow `json:"accessors"`
+	}
+	if err := c.Get(ctx, "/api/v1/secrets/"+strconv.Itoa(int(id))+"/access", &body); err != nil {
+		return nil, err
+	}
+	return body.Accessors, nil
+}
+
+// fetchAccessLog GETs recent reads. days <= 0 lets the server default (30).
+func fetchAccessLog(ctx context.Context, c *common.RemoteClient, id uint, days int) ([]accessLogRow, error) {
+	path := "/api/v1/secrets/" + strconv.Itoa(int(id)) + "/access-log"
+	if days > 0 {
+		path += "?days=" + strconv.Itoa(days)
+	}
+	var body struct {
+		AccessLog []accessLogRow `json:"access_log"`
+	}
+	if err := c.Get(ctx, path, &body); err != nil {
+		return nil, err
+	}
+	return body.AccessLog, nil
+}
+
+func init() {
+	accessCmd.Flags().UintVar(&accessID, "id", 0, "Secret ID (required)")
+	accessLogCmd.Flags().UintVar(&accessLogID, "id", 0, "Secret ID (required)")
+	accessLogCmd.Flags().IntVar(&accessLogDays, "days", 0, "Lookback in days (default server-side: 30)")
+	SecretCmd.AddCommand(accessCmd)
+	SecretCmd.AddCommand(accessLogCmd)
+}

--- a/internal/cli/secret/access_remote_test.go
+++ b/internal/cli/secret/access_remote_test.go
@@ -1,0 +1,60 @@
+package secret
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func accessStub(t *testing.T) (*common.RemoteClient, func()) {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/secrets/7/access":
+			_, _ = w.Write([]byte(`{"data":{"accessors":[{"user_id":1,"username":"owner","permission":"owner","source":"owner"},{"user_id":2,"username":"alice","permission":"read","source":"group_share:platform"}],"total":2}}`))
+		case "/api/v1/secrets/7/access-log":
+			_, _ = w.Write([]byte(`{"data":{"access_log":[{"AccessedBy":"owner","Action":"read","IPAddress":"10.0.0.1","AccessTime":"2026-06-18T10:00:00Z"}],"total":1}}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	rc, ok := common.NewRemoteClient()
+	require.True(t, ok)
+	return rc, srv.Close
+}
+
+func TestFetchAccessors(t *testing.T) {
+	rc, done := accessStub(t)
+	defer done()
+	rows, err := fetchAccessors(context.Background(), rc, 7)
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+	assert.Equal(t, "owner", rows[0].Username)
+	assert.Equal(t, "owner", rows[0].Permission)
+	assert.Equal(t, "group_share:platform", rows[1].Source)
+}
+
+func TestFetchAccessLog(t *testing.T) {
+	rc, done := accessStub(t)
+	defer done()
+	rows, err := fetchAccessLog(context.Background(), rc, 7, 30)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Equal(t, "owner", rows[0].AccessedBy)
+	assert.Equal(t, "read", rows[0].Action)
+	assert.Equal(t, "10.0.0.1", rows[0].IPAddress)
+}
+
+func TestFetchAccessors_NotFound(t *testing.T) {
+	rc, done := accessStub(t)
+	defer done()
+	_, err := fetchAccessors(context.Background(), rc, 999)
+	require.Error(t, err)
+}


### PR DESCRIPTION
## Summary

Rounds out the secret-investigation surface on the CLI, pairing with the HTTP endpoints (#310, #316) + web panels (#60, #62):

```
keyorix secret access     --id <id>             # who CAN read it (owner / direct / group)
keyorix secret access-log --id <id> [--days N]  # who HAS read it (recent reads)
```

Both read via the shared `RemoteClient` (`GET /secrets/{id}/access` and `/access-log`; the server enforces scoped `secrets.read`) and print a small table.

## Test plan
- `go build ./...` ✅ · `go test ./internal/cli/secret/` ✅ · `gosec` ✅ · `golangci-lint` ✅ — no new deps
- Fetch logic split into `fetchAccessors` / `fetchAccessLog` for `httptest`-backed tests: parse accessors (incl. group source), parse access-log (incl. IP), not-found error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)