### PR TITLE
feat(machine-identities): stale-identity detection (hygiene)

### DIFF
--- a/internal/core/machine_identities.go
+++ b/internal/core/machine_identities.go
@@ -15,6 +15,7 @@ package core
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
@@ -95,6 +96,33 @@ func (c *KeyorixCore) CreateMachineIdentity(ctx context.Context, projectID uint,
 // ListMachineIdentities returns the machine identities in a project.
 func (c *KeyorixCore) ListMachineIdentities(ctx context.Context, projectID uint) ([]*models.MachineIdentity, error) {
 	return c.storage.ListMachineIdentities(ctx, projectID)
+}
+
+// ListStaleMachineIdentities returns a project's ACTIVE machine identities that have
+// not authenticated within olderThan — abandoned credentials that are candidates for
+// revocation (a security-hygiene aid). An identity that has never been seen counts
+// from its creation time, so a freshly-created one isn't flagged until it has had the
+// full window to be used. Suspended/revoked identities are excluded (already handled).
+func (c *KeyorixCore) ListStaleMachineIdentities(ctx context.Context, projectID uint, olderThan time.Duration) ([]*models.MachineIdentity, error) {
+	all, err := c.storage.ListMachineIdentities(ctx, projectID)
+	if err != nil {
+		return nil, err
+	}
+	cutoff := c.now().Add(-olderThan)
+	var stale []*models.MachineIdentity
+	for _, m := range all {
+		if m.State != MachineActive {
+			continue
+		}
+		last := m.CreatedAt
+		if m.LastSeenAt != nil {
+			last = *m.LastSeenAt
+		}
+		if last.Before(cutoff) {
+			stale = append(stale, m)
+		}
+	}
+	return stale, nil
 }
 
 // TransitionMachineIdentity advances a machine identity to a new state,

--- a/internal/core/machine_identities_stale_test.go
+++ b/internal/core/machine_identities_stale_test.go
@@ -1,0 +1,59 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestListStaleMachineIdentities(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	sqlDB, _ := db.DB()
+	sqlDB.SetMaxOpenConns(1)
+	require.NoError(t, db.AutoMigrate(&models.MachineIdentity{}))
+
+	now := time.Date(2026, 6, 18, 12, 0, 0, 0, time.UTC)
+	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: func() time.Time { return now }}
+	ctx := context.Background()
+
+	old := now.Add(-120 * 24 * time.Hour)
+	recent := now.Add(-10 * 24 * time.Hour)
+	mk := func(name, state string, created time.Time, lastSeen *time.Time) {
+		require.NoError(t, db.Create(&models.MachineIdentity{
+			ProjectID: 1, Name: name, IdentityType: "ci", State: state, CreatedAt: created, UpdatedAt: created, LastSeenAt: lastSeen,
+		}).Error)
+	}
+	mk("stale-seen", MachineActive, old, &old)     // seen long ago → stale
+	mk("never-old", MachineActive, old, nil)       // created long ago, never seen → stale
+	mk("recent-seen", MachineActive, old, &recent) // seen recently → not stale
+	mk("brand-new", MachineActive, recent, nil)    // created recently, never seen → NOT stale yet
+	mk("revoked-old", MachineRevoked, old, &old)   // not active → excluded
+	mk("other-project", MachineActive, old, &old)  // different project (set below)
+
+	// Move the last one to project 2.
+	require.NoError(t, db.Model(&models.MachineIdentity{}).Where("name = ?", "other-project").Update("project_id", 2).Error)
+
+	stale, err := c.ListStaleMachineIdentities(ctx, 1, 90*24*time.Hour)
+	require.NoError(t, err)
+	names := map[string]bool{}
+	for _, m := range stale {
+		names[m.Name] = true
+	}
+	assert.True(t, names["stale-seen"], "seen long ago is stale")
+	assert.True(t, names["never-old"], "created long ago + never seen is stale")
+	assert.False(t, names["recent-seen"], "recently seen is not stale")
+	assert.False(t, names["brand-new"], "recently created + never seen is not stale yet")
+	assert.False(t, names["revoked-old"], "non-active is excluded")
+	assert.False(t, names["other-project"], "another project's identity is excluded")
+	assert.Len(t, stale, 2)
+}

--- a/server/http/handlers/machine_identities.go
+++ b/server/http/handlers/machine_identities.go
@@ -31,6 +31,31 @@ func (h *CatalogHandler) ListMachineIdentities(w http.ResponseWriter, r *http.Re
 	sendSuccess(w, map[string]interface{}{"machine_identities": identities}, "")
 }
 
+// ListStaleMachineIdentities handles GET /api/v1/projects/{id}/machine-identities/stale?days=N
+// — active machine identities not seen within the window (default 90, capped 3650).
+func (h *CatalogHandler) ListStaleMachineIdentities(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		sendError(w, "InvalidParameter", "Invalid project ID", http.StatusBadRequest, nil)
+		return
+	}
+	days := 90
+	if v := r.URL.Query().Get("days"); v != "" {
+		if n, perr := strconv.Atoi(v); perr == nil && n > 0 {
+			days = n
+		}
+	}
+	if days > 3650 {
+		days = 3650
+	}
+	identities, err := h.coreService.ListStaleMachineIdentities(r.Context(), uint(id), time.Duration(days)*24*time.Hour)
+	if err != nil {
+		sendError(w, "Error", err.Error(), http.StatusInternalServerError, nil)
+		return
+	}
+	sendSuccess(w, map[string]interface{}{"machine_identities": identities, "total": len(identities)}, "")
+}
+
 // CreateMachineIdentity handles POST /api/v1/projects/{id}/machine-identities.
 func (h *CatalogHandler) CreateMachineIdentity(w http.ResponseWriter, r *http.Request) {
 	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -285,6 +285,7 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		r.With(customMiddleware.RequireScopedPermission("roles.assign", projectScope)).Post("/projects/{id}/break-glass/{activationId}/revoke", catalogHandler.RevokeBreakGlass)
 		// Machine identities (ADR-023): non-human members, segmented from humans.
 		r.With(customMiddleware.RequireScopedPermission("users.read", projectScope)).Get("/projects/{id}/machine-identities", catalogHandler.ListMachineIdentities)
+		r.With(customMiddleware.RequireScopedPermission("users.read", projectScope)).Get("/projects/{id}/machine-identities/stale", catalogHandler.ListStaleMachineIdentities)
 		r.With(customMiddleware.RequireScopedPermission("roles.assign", projectScope)).Post("/projects/{id}/machine-identities", catalogHandler.CreateMachineIdentity)
 		r.With(customMiddleware.RequireScopedPermission("roles.assign", projectScope)).Put("/projects/{id}/machine-identities/{machineId}", catalogHandler.TransitionMachineIdentity)
 		r.With(customMiddleware.RequireScopedPermission("roles.assign", projectScope)).Patch("/projects/{id}/machine-identities/{machineId}/classification", catalogHandler.ClassifyMachineIdentity)


### PR DESCRIPTION
## Summary

Find abandoned machine credentials to revoke — a security-hygiene aid analogous to "unused secrets", built on the existing `LastSeenAt`.

- **`core.ListStaleMachineIdentities(projectID, olderThan)`** — a project's **active** machine identities not authenticated within the window. A never-seen identity counts from its **creation** time (so a freshly-created one isn't flagged until it's had the full window); suspended/revoked are excluded.
- **`GET /api/v1/projects/{id}/machine-identities/stale?days=N`** (scoped `users.read`, like the list; `days` default 90, capped 3650) → `{machine_identities, total}`.

## Test plan
- `go build ./...` ✅ · `go test ./internal/core/` ✅ · `gosec` ✅ · `golangci-lint` ✅ — no new deps
- seen-long-ago + never-seen-old are stale; recently-seen, brand-new (recently created, never seen), revoked, and other-project identities are excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)