### PR TITLE
release: prep v0.59.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,27 @@
 All notable changes to Keyorix are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## v0.59.0 — 2026-06-18
+
+Secret investigation, project-wide incident response, and machine-identity hygiene.
+
+### Added
+- **Per-secret access history** — `GET /secrets/{id}/access-log?days=N` lists who has
+  read a secret recently (accessor, IP, time), complementing the access inspector. ([#316])
+- **Project-wide suspend / resume** — `POST /projects/{id}/secrets/suspend-all` and
+  `/resume-all` freeze or restore value reads of every secret in a project (breach
+  response). ([#317])
+- **CLI investigation commands** — `keyorix secret access` (who can read) and
+  `keyorix secret access-log` (who has read). ([#318])
+- **Stale machine-identity detection** — `GET /projects/{id}/machine-identities/stale?days=N`
+  surfaces active machine identities not authenticated within the window — abandoned
+  credentials to revoke. ([#319])
+
+[#316]: https://github.com/keyorixhq/keyorix/pull/316
+[#317]: https://github.com/keyorixhq/keyorix/pull/317
+[#318]: https://github.com/keyorixhq/keyorix/pull/318
+[#319]: https://github.com/keyorixhq/keyorix/pull/319
+
 ## v0.58.0 — 2026-06-18
 
 Incident response: suspend/resume a secret.

--- a/deploy/helm/keyorix-k8s-sync/Chart.yaml
+++ b/deploy/helm/keyorix-k8s-sync/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix-k8s-sync
 description: Keyorix Kubernetes sync agent — materialises Keyorix secrets into native Kubernetes Secrets
 type: application
 # Chart version — tracks the Keyorix release version (published in lockstep).
-version: 0.58.0
+version: 0.59.0
 # The keyorix-k8s-sync image tag this chart deploys by default.
-appVersion: "0.58.0"
+appVersion: "0.59.0"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix

--- a/deploy/helm/keyorix/Chart.yaml
+++ b/deploy/helm/keyorix/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix
 description: Self-hosted Keyorix secrets manager (API server + web UI + PostgreSQL)
 type: application
 # Chart version — bump on chart changes.
-version: 0.58.0
+version: 0.59.0
 # The Keyorix app version this chart deploys by default (the image tag).
-appVersion: "0.58.0"
+appVersion: "0.59.0"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix


### PR DESCRIPTION
## v0.59.0 — Investigation, project-wide incident response, machine-identity hygiene

Bumps CHANGELOG + Helm charts to **0.59.0**. Bundles the commits since v0.58.0:

- **#316** — per-secret access history (`GET /secrets/{id}/access-log`)
- **#317** — project-wide suspend / resume (`/projects/{id}/secrets/suspend-all` | `resume-all`)
- **#318** — `keyorix secret access` / `access-log` CLI commands
- **#319** — stale machine-identity detection (`GET /projects/{id}/machine-identities/stale`)

Both charts → 0.59.0 (lockstep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)