### PR TITLE
feat(secrets): per-secret audit trail — GET /secrets/{id}/audit

### DIFF
--- a/internal/core/secret_audit_trail.go
+++ b/internal/core/secret_audit_trail.go
@@ -1,0 +1,47 @@
+// secret_audit_trail.go — per-secret audit trail: the lifecycle events of a single
+// secret (created, rotated, rolled-back, suspended/resumed, shared, owner-transferred,
+// reclassified, …) in newest-first order. Complements the access inspector (who CAN
+// read) and access history (who HAS read) with WHAT HAPPENED to the secret — an
+// investigation aid. Read-only; the caller must be able to read the secret. Returns
+// audit-event metadata only (event type, actor, time, description, non-sensitive
+// diff), never any secret value.
+package core
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// defaultSecretAuditLimit bounds the trail when the caller does not specify a limit.
+const defaultSecretAuditLimit = 50
+
+// maxSecretAuditLimit caps the trail so a single request cannot pull an unbounded
+// page of audit rows.
+const maxSecretAuditLimit = 500
+
+// ListSecretAuditEvents returns the secret's audit-trail entries, newest first. The
+// actor must be able to read the secret. `limit` is clamped to [1, maxSecretAuditLimit];
+// a non-positive limit falls back to defaultSecretAuditLimit.
+func (c *KeyorixCore) ListSecretAuditEvents(ctx context.Context, secretID, actorID uint, limit int) ([]*models.AuditEvent, error) {
+	if _, err := c.EnforceSecretReadPermission(ctx, secretID, actorID); err != nil {
+		return nil, err
+	}
+	if limit <= 0 {
+		limit = defaultSecretAuditLimit
+	}
+	if limit > maxSecretAuditLimit {
+		limit = maxSecretAuditLimit
+	}
+	events, _, err := c.storage.GetAuditLogs(ctx, &storage.AuditFilter{
+		SecretID: &secretID,
+		PageSize: limit,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	return events, nil
+}

--- a/internal/core/secret_audit_trail_test.go
+++ b/internal/core/secret_audit_trail_test.go
@@ -1,0 +1,80 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestListSecretAuditEvents(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	sqlDB, _ := db.DB()
+	sqlDB.SetMaxOpenConns(1)
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.User{}, &models.AuditEvent{}))
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "owner", Email: "o@t.com"}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 2, Username: "mallory", Email: "m@t.com"}).Error)
+
+	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
+	ctx := context.Background()
+	secret, err := c.storage.CreateSecret(ctx, &models.SecretNode{
+		Name: "db", ProjectID: 1, EnvironmentID: 1, Type: "password", OwnerID: 1, IsSecret: true,
+		CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	})
+	require.NoError(t, err)
+
+	other, err := c.storage.CreateSecret(ctx, &models.SecretNode{
+		Name: "api", ProjectID: 1, EnvironmentID: 1, Type: "token", OwnerID: 1, IsSecret: true,
+		CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	})
+	require.NoError(t, err)
+
+	now := time.Now()
+	uid := uint(1)
+	// Three lifecycle events on the target secret, plus one on a different secret.
+	require.NoError(t, c.storage.LogAuditEvent(ctx, &models.AuditEvent{
+		EventType: "secret.created", UserID: &uid, SecretNodeID: &secret.ID, EventTime: now.Add(-3 * time.Hour),
+	}))
+	require.NoError(t, c.storage.LogAuditEvent(ctx, &models.AuditEvent{
+		EventType: "secret.rotated", UserID: &uid, SecretNodeID: &secret.ID, EventTime: now.Add(-2 * time.Hour),
+	}))
+	require.NoError(t, c.storage.LogAuditEvent(ctx, &models.AuditEvent{
+		EventType: "secret.suspended", UserID: &uid, SecretNodeID: &secret.ID, EventTime: now.Add(-1 * time.Hour),
+	}))
+	require.NoError(t, c.storage.LogAuditEvent(ctx, &models.AuditEvent{
+		EventType: "secret.created", UserID: &uid, SecretNodeID: &other.ID, EventTime: now.Add(-1 * time.Hour),
+	}))
+
+	t.Run("owner sees only this secret's events, newest first", func(t *testing.T) {
+		events, err := c.ListSecretAuditEvents(ctx, secret.ID, 1, 0)
+		require.NoError(t, err)
+		require.Len(t, events, 3, "the other secret's event must not leak in")
+		assert.Equal(t, "secret.suspended", events[0].EventType, "newest first")
+		assert.Equal(t, "secret.created", events[2].EventType)
+		for _, e := range events {
+			require.NotNil(t, e.SecretNodeID)
+			assert.Equal(t, secret.ID, *e.SecretNodeID)
+		}
+	})
+
+	t.Run("limit is honored", func(t *testing.T) {
+		events, err := c.ListSecretAuditEvents(ctx, secret.ID, 1, 1)
+		require.NoError(t, err)
+		require.Len(t, events, 1)
+		assert.Equal(t, "secret.suspended", events[0].EventType)
+	})
+
+	t.Run("a non-reader is denied", func(t *testing.T) {
+		_, err := c.ListSecretAuditEvents(ctx, secret.ID, 2, 0)
+		require.Error(t, err)
+	})
+}

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -565,7 +565,9 @@ type MembershipCounts struct {
 type AuditFilter struct {
 	ProjectID *uint
 	UserID    *uint
-	Action    *string
+	// SecretID restricts to events about a specific secret (secret_node_id).
+	SecretID *uint
+	Action   *string
 	// Actions matches any of several event types (event_type IN). Used to pull a
 	// related family of events together, e.g. the RBAC audit log (role.*).
 	Actions  []string

--- a/internal/storage/store/local_audit.go
+++ b/internal/storage/store/local_audit.go
@@ -195,6 +195,9 @@ func (ls *LocalStorage) GetAuditLogs(ctx context.Context, filter *storage.AuditF
 		if filter.UserID != nil {
 			query = query.Where("user_id = ?", *filter.UserID)
 		}
+		if filter.SecretID != nil {
+			query = query.Where("secret_node_id = ?", *filter.SecretID)
+		}
 		if filter.Action != nil {
 			query = query.Where("event_type = ?", *filter.Action)
 		}

--- a/internal/storage/store/remote_audit.go
+++ b/internal/storage/store/remote_audit.go
@@ -71,6 +71,7 @@ func buildAuditFilterPath(filter *storage.AuditFilter) string {
 	}
 	params := newQueryBuilder()
 	params.addUint("user_id", filter.UserID)
+	params.addUint("secret_id", filter.SecretID)
 	params.addString("action", filter.Action)
 	params.addString("resource", filter.Resource)
 	params.addString("actor_type", filter.ActorType)

--- a/server/http/handlers/audit.go
+++ b/server/http/handlers/audit.go
@@ -78,6 +78,12 @@ func (h *AuditHandler) GetAuditLogs(w http.ResponseWriter, r *http.Request) {
 			filter.ProjectID = &p
 		}
 	}
+	if sidStr := r.URL.Query().Get("secret_id"); sidStr != "" {
+		if sid, err := strconv.ParseUint(sidStr, 10, 32); err == nil {
+			s := uint(sid)
+			filter.SecretID = &s
+		}
+	}
 	if st := r.URL.Query().Get("start_time"); st != "" {
 		if t, err := time.Parse(time.RFC3339, st); err == nil {
 			filter.StartTime = &t

--- a/server/http/handlers/secrets_audit_trail.go
+++ b/server/http/handlers/secrets_audit_trail.go
@@ -1,0 +1,88 @@
+// secrets_audit_trail.go — AuditTrail handler: the lifecycle events of a single secret.
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/server/middleware"
+)
+
+// secretAuditEntry is the wire format for one lifecycle event of a secret. It exposes
+// only non-sensitive metadata — never a plaintext value (the stored diff records a
+// {"changed":true} marker for value changes, not the value itself).
+type secretAuditEntry struct {
+	ID            uint            `json:"id"`
+	EventType     string          `json:"event_type"`
+	Timestamp     string          `json:"timestamp"`
+	UserID        *uint           `json:"user_id,omitempty"`
+	ActorType     string          `json:"actor_type"`
+	Description   string          `json:"description"`
+	Success       bool            `json:"success"`
+	Diff          json.RawMessage `json:"diff,omitempty"`
+	Impersonation bool            `json:"impersonation,omitempty"`
+}
+
+// AuditTrail handles GET /api/v1/secrets/{id}/audit?limit=N — the secret's lifecycle
+// events (created, rotated, rolled-back, suspended/resumed, shared, owner-transferred,
+// reclassified, …) newest-first. Scoped secrets.read is enforced by the router; core
+// re-checks the caller's read access. limit defaults to 50 and is capped at 500.
+func (h *SecretHandler) AuditTrail(w http.ResponseWriter, r *http.Request) {
+	userCtx := middleware.GetUserFromContext(r.Context())
+	if userCtx == nil {
+		h.sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		h.sendError(w, "BadRequest", "Invalid secret ID", http.StatusBadRequest, nil)
+		return
+	}
+
+	limit := 0
+	if v := r.URL.Query().Get("limit"); v != "" {
+		if n, perr := strconv.Atoi(v); perr == nil {
+			limit = n
+		}
+	}
+
+	events, err := h.coreService.ListSecretAuditEvents(r.Context(), uint(id), userCtx.UserID, limit)
+	if err != nil {
+		switch {
+		case strings.Contains(err.Error(), "not found"):
+			h.sendError(w, "NotFound", "Secret not found", http.StatusNotFound, nil)
+		case strings.Contains(err.Error(), "permission") || strings.Contains(err.Error(), "not authorized"):
+			h.sendError(w, "Forbidden", "Not authorized to view this secret's audit trail", http.StatusForbidden, nil)
+		default:
+			h.sendError(w, "InternalError", "Failed to list audit trail", http.StatusInternalServerError, nil)
+		}
+		return
+	}
+
+	entries := make([]secretAuditEntry, 0, len(events))
+	for _, e := range events {
+		entries = append(entries, toSecretAuditEntry(e))
+	}
+	h.sendSuccess(w, map[string]interface{}{"audit": entries, "total": len(entries)}, "")
+}
+
+func toSecretAuditEntry(e *models.AuditEvent) secretAuditEntry {
+	entry := secretAuditEntry{
+		ID:            e.ID,
+		EventType:     e.EventType,
+		Timestamp:     e.EventTime.UTC().Format("2006-01-02T15:04:05Z07:00"),
+		UserID:        e.UserID,
+		ActorType:     e.ActorType,
+		Description:   e.Description,
+		Success:       e.Success == nil || *e.Success,
+		Impersonation: e.Impersonation,
+	}
+	if e.Diff != "" {
+		entry.Diff = json.RawMessage(e.Diff)
+	}
+	return entry
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -328,6 +328,7 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.With(customMiddleware.RequireScopedPermission("secrets.read", secretScope)).Get("/{id}/shares", shareHandler.ListSecretShares)
 			r.With(customMiddleware.RequireScopedPermission("secrets.read", secretScope)).Get("/{id}/access", secretHandler.ListAccessors)
 			r.With(customMiddleware.RequireScopedPermission("secrets.read", secretScope)).Get("/{id}/access-log", secretHandler.AccessHistory)
+			r.With(customMiddleware.RequireScopedPermission("secrets.read", secretScope)).Get("/{id}/audit", secretHandler.AuditTrail)
 
 			// Create: authorized inside the handler (scope comes from the body).
 			r.Post("/", secretHandler.CreateSecret)


### PR DESCRIPTION
## What

Adds a **per-secret audit trail**: `GET /api/v1/secrets/{id}/audit?limit=N` lists a single secret's lifecycle events (created, rotated, rolled-back, suspended/resumed, shared, owner-transferred, reclassified, …) newest-first.

This completes the investigation triad on a secret:
- **Who CAN read** — access inspector (`/{id}/access`, #310)
- **Who HAS read** — access history (`/{id}/access-log`, #316)
- **What HAPPENED** — audit trail (`/{id}/audit`, this PR)

## How

- **storage** — `AuditFilter` gains a `SecretID` field; `LocalStorage.GetAuditLogs` filters on `secret_node_id`, and the `RemoteStorage` audit-filter path adds `secret_id` so the HTTP adapter round-trips. The audit handler parses `secret_id`.
- **core** — `ListSecretAuditEvents(ctx, secretID, actorID, limit)`, gated by `EnforceSecretReadPermission`. Newest-first; `limit` clamped to `[1, 500]`, default 50. Read-only.
- **http** — `GET /api/v1/secrets/{id}/audit`, scoped `secrets.read`, registered beside `/{id}/access-log`. The DTO exposes `event_type / timestamp / user_id / actor_type / description / success / diff / impersonation` only.

## Security

- Authz re-checked in core via `EnforceSecretReadPermission` (route gate is defense-in-depth, not the only check).
- **Never returns a plaintext value** — the stored diff records a `{"changed":true}` marker for value changes, not the value; the DTO carries no value field.
- Limit is bounded so a single request can't pull an unbounded page.

## Test

`TestListSecretAuditEvents`: owner sees only this secret's events newest-first (no cross-secret leak), limit honored, non-reader denied.

gofmt / go build / go test / gosec / golangci-lint all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)