### PR TITLE
feat(cli): secret audit — show a secret's lifecycle events

### DIFF
--- a/internal/cli/secret/audit.go
+++ b/internal/cli/secret/audit.go
@@ -1,0 +1,78 @@
+package secret
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/spf13/cobra"
+)
+
+var (
+	auditID    uint
+	auditLimit int
+)
+
+// auditRow mirrors a GET /secrets/{id}/audit entry (snake_case DTO). The diff is
+// rendered as a presence marker only — it never carries a plaintext value.
+type auditRow struct {
+	EventType   string `json:"event_type"`
+	Timestamp   string `json:"timestamp"`
+	ActorType   string `json:"actor_type"`
+	UserID      *uint  `json:"user_id"`
+	Description string `json:"description"`
+}
+
+var auditCmd = &cobra.Command{
+	Use:   "audit",
+	Short: "Show a secret's lifecycle events (created/rotated/suspended/shared/…)",
+	Long: `List the audit trail for a secret: what happened to it and when (created, rotated,
+rolled-back, suspended/resumed, shared, owner-transferred, reclassified), newest first.
+Requires secrets.read at the secret's scope. Never prints a plaintext value.`,
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		if auditID == 0 {
+			return fmt.Errorf("--id is required")
+		}
+		c, ok := common.NewRemoteClient()
+		if !ok {
+			return fmt.Errorf("not connected to a server — run: keyorix connect <server>")
+		}
+		rows, err := fetchAuditTrail(context.Background(), c, auditID, auditLimit)
+		if err != nil {
+			return err
+		}
+		if len(rows) == 0 {
+			fmt.Println("No audit events.")
+			return nil
+		}
+		fmt.Printf("%-26s %-24s %-8s %s\n", "EVENT", "TIME", "ACTOR", "DESCRIPTION")
+		for _, r := range rows {
+			fmt.Printf("%-26s %-24s %-8s %s\n", r.EventType, r.Timestamp, r.ActorType, r.Description)
+		}
+		return nil
+	},
+}
+
+// fetchAuditTrail GETs the secret's lifecycle events (split out for httptest tests).
+// limit <= 0 lets the server default (50).
+func fetchAuditTrail(ctx context.Context, c *common.RemoteClient, id uint, limit int) ([]auditRow, error) {
+	path := "/api/v1/secrets/" + strconv.Itoa(int(id)) + "/audit"
+	if limit > 0 {
+		path += "?limit=" + strconv.Itoa(limit)
+	}
+	var body struct {
+		Audit []auditRow `json:"audit"`
+	}
+	if err := c.Get(ctx, path, &body); err != nil {
+		return nil, err
+	}
+	return body.Audit, nil
+}
+
+func init() {
+	auditCmd.Flags().UintVar(&auditID, "id", 0, "Secret ID (required)")
+	auditCmd.Flags().IntVar(&auditLimit, "limit", 0, "Max events to show (default server-side: 50, cap 500)")
+	SecretCmd.AddCommand(auditCmd)
+}

--- a/internal/cli/secret/audit_remote_test.go
+++ b/internal/cli/secret/audit_remote_test.go
@@ -1,0 +1,49 @@
+package secret
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func auditStub(t *testing.T) (*common.RemoteClient, func()) {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/secrets/7/audit":
+			_, _ = w.Write([]byte(`{"data":{"audit":[{"id":3,"event_type":"secret.suspended","timestamp":"2026-06-18T12:00:00Z","actor_type":"user","user_id":1,"description":"frozen for incident"},{"id":2,"event_type":"secret.rotated","timestamp":"2026-06-18T11:00:00Z","actor_type":"user","user_id":1,"description":""},{"id":1,"event_type":"secret.created","timestamp":"2026-06-18T10:00:00Z","actor_type":"user","user_id":1,"description":""}],"total":3}}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	rc, ok := common.NewRemoteClient()
+	require.True(t, ok)
+	return rc, srv.Close
+}
+
+func TestFetchAuditTrail(t *testing.T) {
+	rc, done := auditStub(t)
+	defer done()
+	rows, err := fetchAuditTrail(context.Background(), rc, 7, 50)
+	require.NoError(t, err)
+	require.Len(t, rows, 3)
+	assert.Equal(t, "secret.suspended", rows[0].EventType, "newest first")
+	assert.Equal(t, "user", rows[0].ActorType)
+	require.NotNil(t, rows[0].UserID)
+	assert.Equal(t, uint(1), *rows[0].UserID)
+	assert.Equal(t, "secret.created", rows[2].EventType)
+}
+
+func TestFetchAuditTrail_NotFound(t *testing.T) {
+	rc, done := auditStub(t)
+	defer done()
+	_, err := fetchAuditTrail(context.Background(), rc, 999, 0)
+	require.Error(t, err)
+}


### PR DESCRIPTION
## What

CLI parity for the per-secret **audit trail** (#321):

```
keyorix secret audit --id <id> [--limit N]
```

prints a secret's lifecycle events (created, rotated, rolled-back, suspended/resumed, shared, owner-transferred, reclassified) newest-first as `EVENT / TIME / ACTOR / DESCRIPTION`.

This completes the CLI investigation triad next to `secret access` (who CAN read) and `secret access-log` (who HAS read), both from #318.

## How

- `audit.go` — cobra command `audit` registered on `SecretCmd`; `--id` (required), `--limit` (server defaults 50, cap 500). GETs `/api/v1/secrets/{id}/audit` via `common.RemoteClient` (server enforces `secrets.read`).
- `fetchAuditTrail` is split out so it's covered by an httptest stub.

## Security

- No local authz — the server gate (`secrets.read` + core `EnforceSecretReadPermission`) is authoritative.
- **Never prints a plaintext value** — the server DTO carries none; the CLI row type has no value field.

## Test

`TestFetchAuditTrail`: newest-first parse incl `user_id` + `actor_type`; `TestFetchAuditTrail_NotFound`: error path.

gofmt / go build / go test / gosec / golangci-lint all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)