### PR TITLE
feat(secrets): recycle bin — list a project's soft-deleted secrets

### DIFF
--- a/internal/core/secret_recycle_bin.go
+++ b/internal/core/secret_recycle_bin.go
@@ -1,0 +1,48 @@
+// secret_recycle_bin.go — the recycle bin: list a project's soft-deleted (restorable)
+// secrets so an operator can discover what to restore. Secrets soft-delete on DELETE
+// (ADR-033) and are reaped by the purge job after the retention window; until then a
+// restore is possible, but the restore route needs the secret's ID — which, without
+// this view, an operator has no way to find. Read-only and metadata-only: it never
+// returns or touches a secret value. Project-scoped (route-gated secrets.read).
+package core
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// defaultRecycleBinLimit bounds the trash listing when no limit is given.
+const defaultRecycleBinLimit = 100
+
+// maxRecycleBinLimit caps a single trash page.
+const maxRecycleBinLimit = 500
+
+// ListDeletedSecrets returns the project's soft-deleted secrets, most-recently-deleted
+// first, for the restore UI. `limit` is clamped to [1, maxRecycleBinLimit]; a
+// non-positive limit falls back to defaultRecycleBinLimit. Returns metadata only.
+func (c *KeyorixCore) ListDeletedSecrets(ctx context.Context, projectID uint, limit int) ([]*models.SecretNode, error) {
+	if projectID == 0 {
+		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "project ID is required")
+	}
+	if limit <= 0 {
+		limit = defaultRecycleBinLimit
+	}
+	if limit > maxRecycleBinLimit {
+		limit = maxRecycleBinLimit
+	}
+	secrets, _, err := c.storage.ListSecrets(ctx, &storage.SecretFilter{
+		ProjectID:   &projectID,
+		DeletedOnly: true,
+		Page:        1,
+		PageSize:    limit,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	// Already newest-deleted first (ordered in the storage query, before LIMIT).
+	return secrets, nil
+}

--- a/internal/core/secret_recycle_bin_test.go
+++ b/internal/core/secret_recycle_bin_test.go
@@ -1,0 +1,100 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestListDeletedSecrets(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	sqlDB, _ := db.DB()
+	sqlDB.SetMaxOpenConns(1)
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.AuditEvent{}, &models.Project{}, &models.Environment{}))
+	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
+	ctx := context.Background()
+
+	// Two projects, each with an environment (the list query joins environments).
+	p1, err := c.storage.CreateProject(ctx, &models.Project{Name: "p1"})
+	require.NoError(t, err)
+	e1, err := c.storage.CreateEnvironment(ctx, &models.Environment{Name: "production", ProjectID: p1.ID})
+	require.NoError(t, err)
+	p2, err := c.storage.CreateProject(ctx, &models.Project{Name: "p2"})
+	require.NoError(t, err)
+	e2, err := c.storage.CreateEnvironment(ctx, &models.Environment{Name: "production", ProjectID: p2.ID})
+	require.NoError(t, err)
+
+	mk := func(name string, projectID, envID uint) uint {
+		s, err := c.storage.CreateSecret(ctx, &models.SecretNode{
+			Name: name, ProjectID: projectID, EnvironmentID: envID, Type: "password", OwnerID: 1, IsSecret: true,
+			CreatedAt: time.Now(), UpdatedAt: time.Now(),
+		})
+		require.NoError(t, err)
+		return s.ID
+	}
+
+	live := mk("alive", p1.ID, e1.ID)
+	delOld := mk("old", p1.ID, e1.ID)
+	delNew := mk("new", p1.ID, e1.ID)
+	otherProj := mk("other", p2.ID, e2.ID)
+
+	// Soft-delete two in p1 (old first, then new) and one in p2. The brief gap
+	// keeps the deleted_at timestamps distinct so the newest-first order is stable.
+	require.NoError(t, c.storage.DeleteSecret(ctx, delOld))
+	time.Sleep(10 * time.Millisecond)
+	require.NoError(t, c.storage.DeleteSecret(ctx, delNew))
+	require.NoError(t, c.storage.DeleteSecret(ctx, otherProj))
+
+	t.Run("returns only this project's soft-deleted secrets", func(t *testing.T) {
+		got, err := c.ListDeletedSecrets(ctx, p1.ID, 0)
+		require.NoError(t, err)
+		require.Len(t, got, 2, "the live secret and the other project's deleted one must not appear")
+		ids := map[uint]bool{got[0].ID: true, got[1].ID: true}
+		assert.True(t, ids[delOld] && ids[delNew])
+		assert.False(t, ids[live])
+		assert.False(t, ids[otherProj])
+		for _, s := range got {
+			assert.True(t, s.DeletedAt.Valid, "every entry is soft-deleted")
+		}
+	})
+
+	t.Run("newest-deleted first", func(t *testing.T) {
+		got, err := c.ListDeletedSecrets(ctx, p1.ID, 0)
+		require.NoError(t, err)
+		require.Len(t, got, 2)
+		assert.Equal(t, delNew, got[0].ID, "the most-recently-deleted secret leads")
+		assert.Equal(t, delOld, got[1].ID)
+	})
+
+	t.Run("limit is honored", func(t *testing.T) {
+		got, err := c.ListDeletedSecrets(ctx, p1.ID, 1)
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		assert.Equal(t, delNew, got[0].ID)
+	})
+
+	t.Run("a project ID of zero is rejected", func(t *testing.T) {
+		_, err := c.ListDeletedSecrets(ctx, 0, 0)
+		require.Error(t, err)
+	})
+
+	t.Run("an empty bin returns no entries", func(t *testing.T) {
+		empty, err := c.storage.CreateProject(ctx, &models.Project{Name: "empty"})
+		require.NoError(t, err)
+		_, err = c.storage.CreateEnvironment(ctx, &models.Environment{Name: "production", ProjectID: empty.ID})
+		require.NoError(t, err)
+		got, err := c.ListDeletedSecrets(ctx, empty.ID, 0)
+		require.NoError(t, err)
+		assert.Empty(t, got)
+	})
+}

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -525,6 +525,10 @@ type SecretFilter struct {
 	// IncludeDeleted, when true, also returns soft-deleted secrets (ADR-033) —
 	// for a restore UI. Default false: GORM auto-scopes deleted_at IS NULL.
 	IncludeDeleted bool
+	// DeletedOnly, when true, returns ONLY soft-deleted secrets (deleted_at IS NOT
+	// NULL) — the recycle-bin / restore view. Implies reaching past GORM's
+	// soft-delete scope. Takes precedence over IncludeDeleted.
+	DeletedOnly bool
 }
 
 // DriftSecretRow is one secret's drift-relevant projection: which environment it

--- a/internal/storage/store/local_secrets.go
+++ b/internal/storage/store/local_secrets.go
@@ -316,7 +316,14 @@ func (ls *LocalStorage) RestoreSecret(ctx context.Context, id uint) error {
 // passes a mismatched environment_id.
 func (ls *LocalStorage) ListSecrets(ctx context.Context, filter *storage.SecretFilter) ([]*models.SecretNode, int64, error) {
 	query := ls.db.WithContext(ctx).Model(&models.SecretNode{})
-	if filter.IncludeDeleted {
+	if filter.DeletedOnly {
+		// Recycle bin: only soft-deleted rows, newest-deleted first (ordered in SQL
+		// so it survives the LIMIT). Unscoped reaches past GORM's deleted_at IS NULL
+		// scope; the explicit predicate then keeps just the trashed secrets.
+		query = query.Unscoped().
+			Where("secret_nodes.deleted_at IS NOT NULL").
+			Order("secret_nodes.deleted_at DESC")
+	} else if filter.IncludeDeleted {
 		// Reach soft-deleted rows too (restore UI); GORM hides them by default.
 		query = query.Unscoped()
 	}

--- a/server/http/handlers/secrets_deleted.go
+++ b/server/http/handlers/secrets_deleted.go
@@ -1,0 +1,75 @@
+// secrets_deleted.go — DeletedSecrets handler: the recycle bin, a project's
+// soft-deleted (restorable) secrets.
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/server/middleware"
+)
+
+// deletedSecretEntry is the wire format for one trashed secret. Metadata only — no
+// value, ever.
+type deletedSecretEntry struct {
+	ID             uint   `json:"id"`
+	Name           string `json:"name"`
+	Type           string `json:"type"`
+	Classification string `json:"classification,omitempty"`
+	EnvironmentID  uint   `json:"environment_id"`
+	OwnerID        uint   `json:"owner_id"`
+	DeletedAt      string `json:"deleted_at,omitempty"`
+}
+
+// DeletedSecrets handles GET /api/v1/projects/{id}/secrets/deleted?limit=N — the
+// project's recycle bin (soft-deleted secrets, most-recently-deleted first), so an
+// operator can find a secret's ID to POST /secrets/{id}/restore. Scoped secrets.read
+// (project) is enforced by the router. limit defaults to 100, capped at 500.
+func (h *SecretHandler) DeletedSecrets(w http.ResponseWriter, r *http.Request) {
+	userCtx := middleware.GetUserFromContext(r.Context())
+	if userCtx == nil {
+		h.sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		h.sendError(w, "BadRequest", "Invalid project ID", http.StatusBadRequest, nil)
+		return
+	}
+
+	limit := 0
+	if v := r.URL.Query().Get("limit"); v != "" {
+		if n, perr := strconv.Atoi(v); perr == nil {
+			limit = n
+		}
+	}
+
+	secrets, err := h.coreService.ListDeletedSecrets(r.Context(), uint(id), limit)
+	if err != nil {
+		h.sendError(w, "InternalError", "Failed to list deleted secrets", http.StatusInternalServerError, nil)
+		return
+	}
+
+	entries := make([]deletedSecretEntry, 0, len(secrets))
+	for _, s := range secrets {
+		entries = append(entries, toDeletedSecretEntry(s))
+	}
+	h.sendSuccess(w, map[string]interface{}{"deleted": entries, "total": len(entries)}, "")
+}
+
+func toDeletedSecretEntry(s *models.SecretNode) deletedSecretEntry {
+	e := deletedSecretEntry{
+		ID:             s.ID,
+		Name:           s.Name,
+		Type:           s.Type,
+		Classification: s.Classification,
+		EnvironmentID:  s.EnvironmentID,
+		OwnerID:        s.OwnerID,
+	}
+	if s.DeletedAt.Valid {
+		e.DeletedAt = s.DeletedAt.Time.UTC().Format("2006-01-02T15:04:05Z07:00")
+	}
+	return e
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -301,6 +301,7 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		r.With(customMiddleware.RequireScopedPermission("users.read", projectScope)).Get("/projects/{id}/machine-identities/{machineId}/oidc-bindings", catalogHandler.ListOIDCBindings)
 		r.With(customMiddleware.RequireScopedPermission("roles.assign", projectScope)).Delete("/projects/{id}/machine-identities/{machineId}/oidc-bindings/{bindingId}", catalogHandler.DeleteOIDCBinding)
 		r.With(customMiddleware.RequireScopedPermission("secrets.read", projectScope)).Post("/projects/{id}/secrets/render", secretHandler.RenderTemplate)
+		r.With(customMiddleware.RequireScopedPermission("secrets.read", projectScope)).Get("/projects/{id}/secrets/deleted", secretHandler.DeletedSecrets)
 		r.With(customMiddleware.RequireScopedPermission("secrets.write", projectScope)).Post("/projects/{id}/secrets/suspend-all", secretHandler.SuspendProjectSecrets)
 		r.With(customMiddleware.RequireScopedPermission("secrets.write", projectScope)).Post("/projects/{id}/secrets/resume-all", secretHandler.ResumeProjectSecrets)
 		r.With(customMiddleware.RequireScopedPermission("secrets.read", projectScope)).Get("/projects/{id}/environments", catalogHandler.ListProjectEnvironments)


### PR DESCRIPTION
## What

Adds a **recycle bin**: `GET /api/v1/projects/{id}/secrets/deleted?limit=N` lists a project's soft-deleted (restorable) secrets, most-recently-deleted first.

Secrets soft-delete on DELETE (ADR-033) and stay restorable until the purge job reaps them, and `POST /secrets/{id}/restore` already exists — but it needs the secret's **ID**, which an operator had no way to discover. The existing `?include_deleted=true` list flag only *mixes* deleted rows into the live list; there was no dedicated trash view. This closes that loop.

## How

- **storage** — `SecretFilter.DeletedOnly`: returns ONLY soft-deleted rows (`deleted_at IS NOT NULL`), newest-deleted first, **ordered in SQL so it survives the LIMIT**. Reuses the existing project-scoped environment JOIN (cross-project anti-leak); the hot `ListSecrets` path is otherwise untouched.
- **core** — `ListDeletedSecrets(ctx, projectID, limit)`: limit clamped to `[1,500]` (default 100), zero `projectID` rejected. Metadata only.
- **http** — `GET /projects/{id}/secrets/deleted`, scoped `secrets.read` (project), registered beside the other project secret routes. DTO = `id/name/type/classification/environment_id/owner_id/deleted_at`.

## Security

- Project-scoped `secrets.read` route gate (same gate as the project's other secret reads); the env-JOIN prevents cross-project leakage.
- **Metadata only — never a value.** The DTO has no value field and the path reads no secret material.

## Test

`TestListDeletedSecrets`: only this project's deleted secrets (live secret + other project's deleted one excluded), newest-first, limit honored, zero-ID rejected, empty bin.

gofmt / go build / go test / gosec / golangci-lint all clean. (The local-only `/sw.js` + `evidence/verify` mutating-route failures are unrelated — this is a GET.)

## Follow-ups

CLI `secret trash` + `secret restore`, and a web recycle-bin panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)