### PR TITLE
feat(cli): secret trash + restore — recycle-bin workflow

### DIFF
--- a/internal/cli/secret/recycle.go
+++ b/internal/cli/secret/recycle.go
@@ -1,0 +1,113 @@
+package secret
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/spf13/cobra"
+)
+
+var (
+	trashProject uint
+	trashLimit   int
+	restoreID    uint
+)
+
+// trashRow mirrors a GET /projects/{id}/secrets/deleted entry (snake_case DTO).
+type trashRow struct {
+	ID             uint   `json:"id"`
+	Name           string `json:"name"`
+	Type           string `json:"type"`
+	Classification string `json:"classification"`
+	DeletedAt      string `json:"deleted_at"`
+}
+
+var trashCmd = &cobra.Command{
+	Use:   "trash",
+	Short: "List a project's soft-deleted (restorable) secrets",
+	Long: `Show the recycle bin for a project: secrets that were deleted but are still
+restorable (until the purge job reaps them), newest-deleted first. Use the ID with
+'keyorix secret restore --id <id>'. Requires secrets.read at the project scope.`,
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		if trashProject == 0 {
+			return fmt.Errorf("--project is required")
+		}
+		c, ok := common.NewRemoteClient()
+		if !ok {
+			return fmt.Errorf("not connected to a server — run: keyorix connect <server>")
+		}
+		rows, err := fetchTrash(context.Background(), c, trashProject, trashLimit)
+		if err != nil {
+			return err
+		}
+		if len(rows) == 0 {
+			fmt.Println("Recycle bin is empty.")
+			return nil
+		}
+		fmt.Printf("%-8s %-24s %-12s %-14s %s\n", "ID", "NAME", "TYPE", "CLASS", "DELETED")
+		for _, r := range rows {
+			fmt.Printf("%-8d %-24s %-12s %-14s %s\n", r.ID, r.Name, r.Type, r.Classification, r.DeletedAt)
+		}
+		return nil
+	},
+}
+
+var restoreCmd = &cobra.Command{
+	Use:   "restore",
+	Short: "Restore a soft-deleted secret",
+	Long: `Restore a soft-deleted secret by clearing its deletion, returning it to the live
+list. Find restorable secrets with 'keyorix secret trash --project <id>'. Requires
+secrets.write at the secret's scope.`,
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		if restoreID == 0 {
+			return fmt.Errorf("--id is required")
+		}
+		c, ok := common.NewRemoteClient()
+		if !ok {
+			return fmt.Errorf("not connected to a server — run: keyorix connect <server>")
+		}
+		if err := restoreSecret(context.Background(), c, restoreID); err != nil {
+			return err
+		}
+		fmt.Printf("✅ Secret %d restored.\n", restoreID)
+		return nil
+	},
+}
+
+// fetchTrash GETs the project's recycle bin (split out for httptest tests).
+// limit <= 0 lets the server default (100).
+func fetchTrash(ctx context.Context, c *common.RemoteClient, projectID uint, limit int) ([]trashRow, error) {
+	path := "/api/v1/projects/" + strconv.Itoa(int(projectID)) + "/secrets/deleted"
+	if limit > 0 {
+		path += "?limit=" + strconv.Itoa(limit)
+	}
+	var body struct {
+		Deleted []trashRow `json:"deleted"`
+	}
+	if err := c.Get(ctx, path, &body); err != nil {
+		return nil, err
+	}
+	return body.Deleted, nil
+}
+
+// restoreSecret POSTs the restore (split out for httptest tests). The endpoint
+// returns {"id":…,"restored":true}; we decode it so the envelope is consumed.
+func restoreSecret(ctx context.Context, c *common.RemoteClient, id uint) error {
+	var out struct {
+		ID       uint `json:"id"`
+		Restored bool `json:"restored"`
+	}
+	return c.Post(ctx, "/api/v1/secrets/"+strconv.Itoa(int(id))+"/restore", struct{}{}, &out)
+}
+
+func init() {
+	trashCmd.Flags().UintVar(&trashProject, "project", 0, "Project ID (required)")
+	trashCmd.Flags().IntVar(&trashLimit, "limit", 0, "Max entries to show (default server-side: 100, cap 500)")
+	restoreCmd.Flags().UintVar(&restoreID, "id", 0, "Secret ID (required)")
+	SecretCmd.AddCommand(trashCmd)
+	SecretCmd.AddCommand(restoreCmd)
+}

--- a/internal/cli/secret/recycle_remote_test.go
+++ b/internal/cli/secret/recycle_remote_test.go
@@ -1,0 +1,62 @@
+package secret
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func recycleStub(t *testing.T) (*common.RemoteClient, func()) {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/projects/3/secrets/deleted":
+			_, _ = w.Write([]byte(`{"data":{"deleted":[{"id":9,"name":"old-db","type":"password","classification":"confidential","deleted_at":"2026-06-18T12:00:00Z"},{"id":8,"name":"old-api","type":"token","classification":"","deleted_at":"2026-06-18T10:00:00Z"}],"total":2}}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/secrets/9/restore":
+			_, _ = w.Write([]byte(`{"data":{"id":9,"restored":true},"message":"Secret restored"}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	rc, ok := common.NewRemoteClient()
+	require.True(t, ok)
+	return rc, srv.Close
+}
+
+func TestFetchTrash(t *testing.T) {
+	rc, done := recycleStub(t)
+	defer done()
+	rows, err := fetchTrash(context.Background(), rc, 3, 0)
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+	assert.Equal(t, uint(9), rows[0].ID, "newest-deleted first")
+	assert.Equal(t, "old-db", rows[0].Name)
+	assert.Equal(t, "confidential", rows[0].Classification)
+	assert.Equal(t, "token", rows[1].Type)
+}
+
+func TestFetchTrash_NotFound(t *testing.T) {
+	rc, done := recycleStub(t)
+	defer done()
+	_, err := fetchTrash(context.Background(), rc, 999, 0)
+	require.Error(t, err)
+}
+
+func TestRestoreSecret(t *testing.T) {
+	rc, done := recycleStub(t)
+	defer done()
+	require.NoError(t, restoreSecret(context.Background(), rc, 9))
+}
+
+func TestRestoreSecret_NotFound(t *testing.T) {
+	rc, done := recycleStub(t)
+	defer done()
+	require.Error(t, restoreSecret(context.Background(), rc, 1))
+}

--- a/server/http/handlers/secrets_crud.go
+++ b/server/http/handlers/secrets_crud.go
@@ -270,7 +270,7 @@ func (h *SecretHandler) RestoreSecret(w http.ResponseWriter, r *http.Request) {
 		h.sendError(w, "Error", err.Error(), status, nil)
 		return
 	}
-	h.sendSuccess(w, nil, "Secret restored")
+	h.sendSuccess(w, map[string]interface{}{"id": id, "restored": true}, "Secret restored")
 }
 
 // UpdateSecret handles PUT /api/v1/secrets/{id}


### PR DESCRIPTION
## What

CLI for the recycle bin (#323):

```
keyorix secret trash --project <id> [--limit N]   # list restorable secrets
keyorix secret restore --id <id>                  # bring one back
```

`trash` lists a project's soft-deleted secrets newest-first (`ID / NAME / TYPE / CLASS / DELETED`); `restore` clears the soft-delete. Completes the delete→discover→restore loop on the CLI.

## How

- `trash` GETs `/projects/{id}/secrets/deleted` (server enforces `secrets.read` @ project).
- `restore` POSTs `/secrets/{id}/restore` (server enforces `secrets.write` @ the secret's scope via `ScopeFromDeletedSecretParam`).
- The `RestoreSecret` handler now returns `{"id":…,"restored":true}` instead of a `null` data payload — the shared client envelope decoder rejects an empty `data` field. Backward-compatible: callers used the `message`, and no test asserted the old null shape.
- `fetchTrash` / `restoreSecret` split out for httptest coverage.

## Security

- No local authz — the server gates are authoritative (`secrets.read`/`secrets.write` at the right scope).
- Metadata only; no secret value is fetched or printed.

## Test

`TestFetchTrash` (newest-first parse incl classification), `TestRestoreSecret` (happy path), plus not-found error paths.

gofmt / go build / go test / gosec / golangci-lint all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)