### PR TITLE
release: prep v0.60.0 (CHANGELOG + Helm charts)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,28 @@
 All notable changes to Keyorix are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## v0.60.0 — 2026-06-18
+
+Secret audit trail and a recycle bin for deleted secrets.
+
+### Added
+- **Per-secret audit trail** — `GET /secrets/{id}/audit?limit=N` lists a secret's
+  lifecycle events (created, rotated, rolled-back, suspended/resumed, shared,
+  owner-transferred, reclassified) newest-first, completing the investigation triad
+  alongside the access inspector and access history. Metadata only — never a value. ([#321])
+- **CLI `secret audit`** — `keyorix secret audit --id <id> [--limit N]` prints a
+  secret's lifecycle events. ([#322])
+- **Recycle bin** — `GET /projects/{id}/secrets/deleted?limit=N` lists a project's
+  soft-deleted (restorable) secrets, newest-deleted first, so an operator can find
+  what to restore (the existing restore route needs the secret's ID). ([#323])
+- **CLI `secret trash` / `secret restore`** — `keyorix secret trash --project <id>`
+  lists restorable secrets and `keyorix secret restore --id <id>` brings one back. ([#324])
+
+[#321]: https://github.com/keyorixhq/keyorix/pull/321
+[#322]: https://github.com/keyorixhq/keyorix/pull/322
+[#323]: https://github.com/keyorixhq/keyorix/pull/323
+[#324]: https://github.com/keyorixhq/keyorix/pull/324
+
 ## v0.59.0 — 2026-06-18
 
 Secret investigation, project-wide incident response, and machine-identity hygiene.

--- a/deploy/helm/keyorix-k8s-sync/Chart.yaml
+++ b/deploy/helm/keyorix-k8s-sync/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix-k8s-sync
 description: Keyorix Kubernetes sync agent — materialises Keyorix secrets into native Kubernetes Secrets
 type: application
 # Chart version — tracks the Keyorix release version (published in lockstep).
-version: 0.59.0
+version: 0.60.0
 # The keyorix-k8s-sync image tag this chart deploys by default.
-appVersion: "0.59.0"
+appVersion: "0.60.0"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix

--- a/deploy/helm/keyorix/Chart.yaml
+++ b/deploy/helm/keyorix/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix
 description: Self-hosted Keyorix secrets manager (API server + web UI + PostgreSQL)
 type: application
 # Chart version — bump on chart changes.
-version: 0.59.0
+version: 0.60.0
 # The Keyorix app version this chart deploys by default (the image tag).
-appVersion: "0.59.0"
+appVersion: "0.60.0"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix


### PR DESCRIPTION
Release prep for **v0.60.0** — secret audit trail and a recycle bin for deleted secrets.

### Bundled since v0.59.0
- **Per-secret audit trail** — `GET /secrets/{id}/audit` ([#321])
- **CLI `secret audit`** ([#322])
- **Recycle bin** — `GET /projects/{id}/secrets/deleted` ([#323])
- **CLI `secret trash` / `secret restore`** ([#324])

(Web side, shipping with the app: History panel [keyorix-web#65], recycle-bin panel [keyorix-web#66].)

### This PR
- CHANGELOG v0.60.0 section + PR link refs.
- Helm charts bumped lockstep to 0.60.0 (`keyorix` + `keyorix-k8s-sync`, version + appVersion).

After merge: tag `v0.60.0` on main → release.yml (binaries + OCI charts) and docker-publish.yml (server + agent images).

🤖 Generated with [Claude Code](https://claude.com/claude-code)