### PR TITLE
feat(secrets): orphaned-secret detection — find secrets whose owner departed

### DIFF
--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -460,6 +460,14 @@ func (m *MockStorage) ListSecrets(ctx context.Context, filter *storage.SecretFil
 	return args.Get(0).([]*models.SecretNode), args.Get(1).(int64), args.Error(2)
 }
 
+func (m *MockStorage) ListOrphanedSecrets(ctx context.Context, projectID uint) ([]*models.SecretNode, error) {
+	args := m.Called(ctx, projectID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*models.SecretNode), args.Error(1)
+}
+
 func (m *MockStorage) ListProjectSecretsForDrift(ctx context.Context, projectID uint) ([]storage.DriftSecretRow, error) {
 	args := m.Called(ctx, projectID)
 	if args.Get(0) == nil {

--- a/internal/core/secret_orphaned.go
+++ b/internal/core/secret_orphaned.go
@@ -1,0 +1,27 @@
+// secret_orphaned.go — orphaned-secret detection: a project's secrets whose owner is
+// no longer a live user (the owner was offboarded / deleted). The natural companion to
+// ownership transfer ([[secret_ownership]]): this finds the secrets that need
+// re-assigning so no secret is left without an accountable owner. Read-only and
+// metadata-only — it never returns a secret value. Project-scoped (route-gated).
+package core
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// ListOrphanedSecrets returns the project's live secrets whose owner is no longer a
+// live user — offboarding hygiene, so an admin can transfer ownership. Metadata only.
+func (c *KeyorixCore) ListOrphanedSecrets(ctx context.Context, projectID uint) ([]*models.SecretNode, error) {
+	if projectID == 0 {
+		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "project ID is required")
+	}
+	secrets, err := c.storage.ListOrphanedSecrets(ctx, projectID)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	return secrets, nil
+}

--- a/internal/core/secret_orphaned_test.go
+++ b/internal/core/secret_orphaned_test.go
@@ -1,0 +1,99 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestListOrphanedSecrets(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	sqlDB, _ := db.DB()
+	sqlDB.SetMaxOpenConns(1)
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.User{}, &models.Project{}, &models.Environment{}))
+	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
+	ctx := context.Background()
+
+	// Two users: one stays, one will be offboarded.
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "owner", Email: "o@t.com"}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 2, Username: "leaver", Email: "l@t.com"}).Error)
+
+	// Two projects, each with an environment (the list query joins environments).
+	p1, err := c.storage.CreateProject(ctx, &models.Project{Name: "p1"})
+	require.NoError(t, err)
+	e1, err := c.storage.CreateEnvironment(ctx, &models.Environment{Name: "production", ProjectID: p1.ID})
+	require.NoError(t, err)
+	p2, err := c.storage.CreateProject(ctx, &models.Project{Name: "p2"})
+	require.NoError(t, err)
+	e2, err := c.storage.CreateEnvironment(ctx, &models.Environment{Name: "production", ProjectID: p2.ID})
+	require.NoError(t, err)
+
+	mk := func(name string, projectID, envID, ownerID uint) uint {
+		s, err := c.storage.CreateSecret(ctx, &models.SecretNode{
+			Name: name, ProjectID: projectID, EnvironmentID: envID, Type: "password", OwnerID: ownerID, IsSecret: true,
+			CreatedAt: time.Now(), UpdatedAt: time.Now(),
+		})
+		require.NoError(t, err)
+		return s.ID
+	}
+
+	keep := mk("kept", p1.ID, e1.ID, 1)         // owner stays — not orphaned
+	orphanA := mk("orphan-a", p1.ID, e1.ID, 2)  // owner will leave
+	orphanB := mk("orphan-b", p1.ID, e1.ID, 2)  // owner will leave
+	ghostOwner := mk("ghost", p1.ID, e1.ID, 99) // owner never existed
+	otherProj := mk("other", p2.ID, e2.ID, 2)   // different project — excluded
+
+	t.Run("a secret owned by a never-existent user is already orphaned", func(t *testing.T) {
+		got, err := c.ListOrphanedSecrets(ctx, p1.ID)
+		require.NoError(t, err)
+		ids := map[uint]bool{}
+		for _, s := range got {
+			ids[s.ID] = true
+		}
+		assert.True(t, ids[ghostOwner], "owner_id 99 has no live user")
+		assert.False(t, ids[keep], "live owner is not orphaned")
+		assert.False(t, ids[orphanA], "owner still live until offboarded")
+	})
+
+	// Offboard user 2 (soft-delete).
+	require.NoError(t, c.storage.DeleteUser(ctx, 2))
+
+	t.Run("offboarding the owner orphans their secrets, scoped to the project", func(t *testing.T) {
+		got, err := c.ListOrphanedSecrets(ctx, p1.ID)
+		require.NoError(t, err)
+		ids := map[uint]bool{}
+		for _, s := range got {
+			ids[s.ID] = true
+		}
+		assert.True(t, ids[orphanA])
+		assert.True(t, ids[orphanB])
+		assert.True(t, ids[ghostOwner])
+		assert.False(t, ids[keep], "owner 1 is still live")
+		assert.False(t, ids[otherProj], "other project's secret must not appear")
+		assert.Len(t, got, 3)
+	})
+
+	t.Run("results are ordered by name", func(t *testing.T) {
+		got, err := c.ListOrphanedSecrets(ctx, p1.ID)
+		require.NoError(t, err)
+		require.Len(t, got, 3)
+		assert.Equal(t, "ghost", got[0].Name)
+		assert.Equal(t, "orphan-a", got[1].Name)
+		assert.Equal(t, "orphan-b", got[2].Name)
+	})
+
+	t.Run("a project ID of zero is rejected", func(t *testing.T) {
+		_, err := c.ListOrphanedSecrets(ctx, 0)
+		require.Error(t, err)
+	})
+}

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -186,6 +186,10 @@ type Storage interface {
 	// so the restore route can resolve a deleted secret's scope (ADR-033).
 	GetSecretIncludingDeleted(ctx context.Context, id uint) (*models.SecretNode, error)
 	ListSecrets(ctx context.Context, filter *SecretFilter) ([]*models.SecretNode, int64, error)
+	// ListOrphanedSecrets returns a project's live secrets whose owner is no longer
+	// a live user (the owner was deleted/soft-deleted) — offboarding hygiene, so an
+	// admin can re-assign ownership. Scoped to the project via the environment JOIN.
+	ListOrphanedSecrets(ctx context.Context, projectID uint) ([]*models.SecretNode, error)
 	// ListProjectSecretsForDrift returns one lightweight row per secret in the
 	// project (folders excluded, secrets in soft-deleted environments excluded),
 	// carrying just the fields cross-environment drift detection pivots on:

--- a/internal/storage/store/local_secrets.go
+++ b/internal/storage/store/local_secrets.go
@@ -379,6 +379,26 @@ func (ls *LocalStorage) ListSecrets(ctx context.Context, filter *storage.SecretF
 	return secrets, total, nil
 }
 
+// ListOrphanedSecrets returns the project's live secrets whose owner is no longer a
+// live user (deleted or soft-deleted) — offboarding hygiene. The environment JOIN
+// scopes to the project (anti-leak, consistent with ListSecrets); the LEFT JOIN to a
+// non-soft-deleted user with no match (users.id IS NULL) is the "owner gone" test.
+// GORM auto-applies secret_nodes.deleted_at IS NULL, so only live secrets are listed.
+func (ls *LocalStorage) ListOrphanedSecrets(ctx context.Context, projectID uint) ([]*models.SecretNode, error) {
+	var secrets []*models.SecretNode
+	err := ls.db.WithContext(ctx).Model(&models.SecretNode{}).
+		Joins("JOIN environments ON environments.id = secret_nodes.environment_id AND environments.project_id = ?", projectID).
+		Joins("LEFT JOIN users ON users.id = secret_nodes.owner_id AND users.deleted_at IS NULL").
+		Where("secret_nodes.project_id = ?", projectID).
+		Where("users.id IS NULL").
+		Order("secret_nodes.name ASC").
+		Find(&secrets).Error
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	return secrets, nil
+}
+
 // --- Versions ---
 
 // CreateSecretVersion creates a new version of a secret.

--- a/internal/storage/store/remote_secrets.go
+++ b/internal/storage/store/remote_secrets.go
@@ -165,6 +165,11 @@ func (rs *RemoteStorage) ListProjectSecretsForDrift(_ context.Context, _ uint) (
 	return nil, fmt.Errorf("ListProjectSecretsForDrift not available in remote mode")
 }
 
+// ListOrphanedSecrets is not available in remote mode; the orphaned-owner JOIN runs server-side.
+func (rs *RemoteStorage) ListOrphanedSecrets(_ context.Context, _ uint) ([]*models.SecretNode, error) {
+	return nil, fmt.Errorf("ListOrphanedSecrets not available in remote mode")
+}
+
 // buildSecretFilterPath constructs the /api/v1/secrets query string from filter fields.
 func buildSecretFilterPath(filter *storage.SecretFilter) string {
 	if filter == nil {

--- a/server/http/handlers/secrets_orphaned.go
+++ b/server/http/handlers/secrets_orphaned.go
@@ -1,0 +1,58 @@
+// secrets_orphaned.go — OrphanedSecrets handler: a project's secrets whose owner is no
+// longer a live user (offboarding hygiene; re-assign with transfer-ownership).
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/keyorixhq/keyorix/server/middleware"
+)
+
+// orphanedSecretEntry is the wire format for one secret with a departed owner. Metadata
+// only — no value, ever.
+type orphanedSecretEntry struct {
+	ID             uint   `json:"id"`
+	Name           string `json:"name"`
+	Type           string `json:"type"`
+	Classification string `json:"classification,omitempty"`
+	EnvironmentID  uint   `json:"environment_id"`
+	OwnerID        uint   `json:"owner_id"`
+}
+
+// OrphanedSecrets handles GET /api/v1/projects/{id}/secrets/orphaned — the project's
+// live secrets whose owner is no longer a live user, so an admin can transfer
+// ownership (POST /secrets/{id}/transfer-ownership). Scoped secrets.read (project) is
+// enforced by the router.
+func (h *SecretHandler) OrphanedSecrets(w http.ResponseWriter, r *http.Request) {
+	userCtx := middleware.GetUserFromContext(r.Context())
+	if userCtx == nil {
+		h.sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		h.sendError(w, "BadRequest", "Invalid project ID", http.StatusBadRequest, nil)
+		return
+	}
+
+	secrets, err := h.coreService.ListOrphanedSecrets(r.Context(), uint(id))
+	if err != nil {
+		h.sendError(w, "InternalError", "Failed to list orphaned secrets", http.StatusInternalServerError, nil)
+		return
+	}
+
+	entries := make([]orphanedSecretEntry, 0, len(secrets))
+	for _, s := range secrets {
+		entries = append(entries, orphanedSecretEntry{
+			ID:             s.ID,
+			Name:           s.Name,
+			Type:           s.Type,
+			Classification: s.Classification,
+			EnvironmentID:  s.EnvironmentID,
+			OwnerID:        s.OwnerID,
+		})
+	}
+	h.sendSuccess(w, map[string]interface{}{"orphaned": entries, "total": len(entries)}, "")
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -302,6 +302,7 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		r.With(customMiddleware.RequireScopedPermission("roles.assign", projectScope)).Delete("/projects/{id}/machine-identities/{machineId}/oidc-bindings/{bindingId}", catalogHandler.DeleteOIDCBinding)
 		r.With(customMiddleware.RequireScopedPermission("secrets.read", projectScope)).Post("/projects/{id}/secrets/render", secretHandler.RenderTemplate)
 		r.With(customMiddleware.RequireScopedPermission("secrets.read", projectScope)).Get("/projects/{id}/secrets/deleted", secretHandler.DeletedSecrets)
+		r.With(customMiddleware.RequireScopedPermission("secrets.read", projectScope)).Get("/projects/{id}/secrets/orphaned", secretHandler.OrphanedSecrets)
 		r.With(customMiddleware.RequireScopedPermission("secrets.write", projectScope)).Post("/projects/{id}/secrets/suspend-all", secretHandler.SuspendProjectSecrets)
 		r.With(customMiddleware.RequireScopedPermission("secrets.write", projectScope)).Post("/projects/{id}/secrets/resume-all", secretHandler.ResumeProjectSecrets)
 		r.With(customMiddleware.RequireScopedPermission("secrets.read", projectScope)).Get("/projects/{id}/environments", catalogHandler.ListProjectEnvironments)


### PR DESCRIPTION
## What

Adds **orphaned-secret detection**: `GET /api/v1/projects/{id}/secrets/orphaned` lists a project's live secrets whose owner is no longer a live user.

Offboarding hygiene and the natural companion to **ownership transfer** — when a user is deleted, the secrets they owned are left without an accountable owner, and there was no way to find them. This surfaces them so an admin can re-assign (`POST /secrets/{id}/transfer-ownership`).

## How

- **storage** — `ListOrphanedSecrets(projectID)`: a `LEFT JOIN` to a non-soft-deleted user with no match (`users.id IS NULL`) is the "owner gone" test; the environment JOIN scopes to the project (cross-project anti-leak, same as `ListSecrets`); GORM auto-scopes to live secrets. Remote adapter returns not-supported (the JOIN runs server-side).
- **core** — `ListOrphanedSecrets(projectID)`: zero `projectID` rejected, metadata only.
- **http** — `GET /projects/{id}/secrets/orphaned`, scoped `secrets.read` (project), beside the recycle-bin route. DTO = `id/name/type/classification/environment_id/owner_id` (no value).

## Security

- Project-scoped `secrets.read` route gate; env-JOIN prevents cross-project leakage.
- Metadata only — no secret value is read or returned.

## Test

`TestListOrphanedSecrets`: never-existent owner already orphaned; offboarding (soft-delete) the owner orphans their secrets, scoped to the project (live-owner + other-project excluded); name-ordered; zero-ID rejected.

gofmt / go build / go test / gosec / golangci-lint all clean.

## Follow-ups

CLI `secret orphaned` + a web panel (likely in project settings, next to the recycle bin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)