### PR TITLE
feat(cli): secret orphaned — list secrets whose owner departed

### DIFF
--- a/internal/cli/secret/orphaned.go
+++ b/internal/cli/secret/orphaned.go
@@ -1,0 +1,69 @@
+package secret
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/spf13/cobra"
+)
+
+var orphanedProject uint
+
+// orphanedRow mirrors a GET /projects/{id}/secrets/orphaned entry (snake_case DTO).
+type orphanedRow struct {
+	ID             uint   `json:"id"`
+	Name           string `json:"name"`
+	Type           string `json:"type"`
+	Classification string `json:"classification"`
+	OwnerID        uint   `json:"owner_id"`
+}
+
+var orphanedCmd = &cobra.Command{
+	Use:   "orphaned",
+	Short: "List secrets whose owner is no longer a live user",
+	Long: `Show a project's secrets whose owner has been deleted (offboarding hygiene). Each is
+left without an accountable owner — re-assign one with 'keyorix secret transfer-ownership'.
+Requires secrets.read at the project scope.`,
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		if orphanedProject == 0 {
+			return fmt.Errorf("--project is required")
+		}
+		c, ok := common.NewRemoteClient()
+		if !ok {
+			return fmt.Errorf("not connected to a server — run: keyorix connect <server>")
+		}
+		rows, err := fetchOrphaned(context.Background(), c, orphanedProject)
+		if err != nil {
+			return err
+		}
+		if len(rows) == 0 {
+			fmt.Println("No orphaned secrets.")
+			return nil
+		}
+		fmt.Printf("%-8s %-24s %-12s %-14s %s\n", "ID", "NAME", "TYPE", "CLASS", "EX-OWNER")
+		for _, r := range rows {
+			fmt.Printf("%-8d %-24s %-12s %-14s %d\n", r.ID, r.Name, r.Type, r.Classification, r.OwnerID)
+		}
+		return nil
+	},
+}
+
+// fetchOrphaned GETs the project's orphaned secrets (split out for httptest tests).
+func fetchOrphaned(ctx context.Context, c *common.RemoteClient, projectID uint) ([]orphanedRow, error) {
+	path := "/api/v1/projects/" + strconv.Itoa(int(projectID)) + "/secrets/orphaned"
+	var body struct {
+		Orphaned []orphanedRow `json:"orphaned"`
+	}
+	if err := c.Get(ctx, path, &body); err != nil {
+		return nil, err
+	}
+	return body.Orphaned, nil
+}
+
+func init() {
+	orphanedCmd.Flags().UintVar(&orphanedProject, "project", 0, "Project ID (required)")
+	SecretCmd.AddCommand(orphanedCmd)
+}

--- a/internal/cli/secret/orphaned_remote_test.go
+++ b/internal/cli/secret/orphaned_remote_test.go
@@ -1,0 +1,48 @@
+package secret
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func orphanedStub(t *testing.T) (*common.RemoteClient, func()) {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/projects/4/secrets/orphaned":
+			_, _ = w.Write([]byte(`{"data":{"orphaned":[{"id":11,"name":"ghost","type":"password","classification":"confidential","owner_id":99},{"id":12,"name":"orphan-a","type":"token","classification":"","owner_id":2}],"total":2}}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	rc, ok := common.NewRemoteClient()
+	require.True(t, ok)
+	return rc, srv.Close
+}
+
+func TestFetchOrphaned(t *testing.T) {
+	rc, done := orphanedStub(t)
+	defer done()
+	rows, err := fetchOrphaned(context.Background(), rc, 4)
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+	assert.Equal(t, uint(11), rows[0].ID)
+	assert.Equal(t, "ghost", rows[0].Name)
+	assert.Equal(t, uint(99), rows[0].OwnerID)
+	assert.Equal(t, "token", rows[1].Type)
+}
+
+func TestFetchOrphaned_NotFound(t *testing.T) {
+	rc, done := orphanedStub(t)
+	defer done()
+	_, err := fetchOrphaned(context.Background(), rc, 999)
+	require.Error(t, err)
+}


### PR DESCRIPTION
## What

CLI for orphaned-secret detection (#326):

```
keyorix secret orphaned --project <id>
```

prints a project's secrets whose owner is no longer a live user (`ID / NAME / TYPE / CLASS / EX-OWNER`), so an admin can re-assign with `secret transfer-ownership`. Offboarding-hygiene companion to ownership transfer.

## How

- GETs `/projects/{id}/secrets/orphaned` via `common.RemoteClient` (server enforces `secrets.read` @ project).
- `fetchOrphaned` split out for httptest coverage.

## Security

- No local authz — the server gate is authoritative. Metadata only; no value fetched or printed.

## Test

`TestFetchOrphaned` (parse incl ex-owner id) + not-found error path. gofmt / go build / go test / gosec / golangci-lint all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)