### PR TITLE
feat(secrets): bulk owner reassignment — re-home a departed user's secrets

### DIFF
--- a/internal/core/secret_reassign_owner.go
+++ b/internal/core/secret_reassign_owner.go
@@ -1,0 +1,50 @@
+// secret_reassign_owner.go — bulk owner reassignment: hand every secret a departing
+// user owned in a project to a new owner in one call. Completes the offboarding
+// workflow — [[secret_orphaned]] finds the secrets a gone owner left behind, this
+// re-homes them. Each secret goes through the single-secret transfer, so the same
+// authorization (actor is the current owner, or the owner is gone) and the same
+// per-secret audit event apply to every one.
+package core
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+)
+
+// ReassignOwnedSecrets transfers every secret in projectID currently owned by
+// fromOwnerID to toOwnerID, returning the number reassigned. Secrets whose individual
+// transfer is unauthorized or fails are skipped (best-effort, like the project-wide
+// suspend), so a partial failure does not abort the rest. The actor must satisfy the
+// per-secret transfer rule for each (it does for the offboarding case: the old owner is
+// gone). Each reassignment is audited as secret.owner_transferred.
+func (c *KeyorixCore) ReassignOwnedSecrets(ctx context.Context, projectID, fromOwnerID, toOwnerID, actorID uint) (int, error) {
+	if projectID == 0 || fromOwnerID == 0 || toOwnerID == 0 || actorID == 0 {
+		return 0, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "project ID, from-owner, to-owner and actor ID are required")
+	}
+	if fromOwnerID == toOwnerID {
+		return 0, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "from-owner and to-owner must differ")
+	}
+	// The new owner must exist (fail fast — TransferSecretOwnership re-checks per secret).
+	if _, err := c.storage.GetUser(ctx, toOwnerID); err != nil {
+		return 0, fmt.Errorf("%s: new owner %d not found", i18n.T("ErrorValidation", nil), toOwnerID)
+	}
+
+	secrets, err := c.listProjectSecrets(ctx, projectID)
+	if err != nil {
+		return 0, err
+	}
+
+	reassigned := 0
+	for _, s := range secrets {
+		if s.OwnerID != fromOwnerID {
+			continue
+		}
+		if _, err := c.TransferSecretOwnership(ctx, s.ID, toOwnerID, actorID); err != nil {
+			continue // skip per-secret failures; keep going
+		}
+		reassigned++
+	}
+	return reassigned, nil
+}

--- a/internal/core/secret_reassign_owner_test.go
+++ b/internal/core/secret_reassign_owner_test.go
@@ -1,0 +1,93 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestReassignOwnedSecrets(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	sqlDB, _ := db.DB()
+	sqlDB.SetMaxOpenConns(1)
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.User{}, &models.AuditEvent{}, &models.Project{}, &models.Environment{}))
+	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
+	ctx := context.Background()
+
+	// admin (actor), leaver (departing owner), heir (new owner), bystander.
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "admin", Email: "a@t.com"}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 2, Username: "leaver", Email: "l@t.com"}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 3, Username: "heir", Email: "h@t.com"}).Error)
+
+	p1, err := c.storage.CreateProject(ctx, &models.Project{Name: "p1"})
+	require.NoError(t, err)
+	e1, err := c.storage.CreateEnvironment(ctx, &models.Environment{Name: "production", ProjectID: p1.ID})
+	require.NoError(t, err)
+	p2, err := c.storage.CreateProject(ctx, &models.Project{Name: "p2"})
+	require.NoError(t, err)
+	e2, err := c.storage.CreateEnvironment(ctx, &models.Environment{Name: "production", ProjectID: p2.ID})
+	require.NoError(t, err)
+
+	mk := func(name string, projectID, envID, ownerID uint) uint {
+		s, err := c.storage.CreateSecret(ctx, &models.SecretNode{
+			Name: name, ProjectID: projectID, EnvironmentID: envID, Type: "password", OwnerID: ownerID, IsSecret: true,
+			CreatedAt: time.Now(), UpdatedAt: time.Now(),
+		})
+		require.NoError(t, err)
+		return s.ID
+	}
+
+	a := mk("a", p1.ID, e1.ID, 2)         // leaver's
+	b := mk("b", p1.ID, e1.ID, 2)         // leaver's
+	keep := mk("keep", p1.ID, e1.ID, 1)   // admin's — untouched
+	other := mk("other", p2.ID, e2.ID, 2) // leaver's but different project — untouched
+
+	// Offboard the leaver so the owner-gone recovery path authorizes the transfer.
+	require.NoError(t, c.storage.DeleteUser(ctx, 2))
+
+	t.Run("reassigns only the leaver's secrets in the project", func(t *testing.T) {
+		n, err := c.ReassignOwnedSecrets(ctx, p1.ID, 2, 3, 1)
+		require.NoError(t, err)
+		assert.Equal(t, 2, n)
+
+		for _, id := range []uint{a, b} {
+			s, _ := c.storage.GetSecret(ctx, id)
+			assert.Equal(t, uint(3), s.OwnerID, "secret reassigned to heir")
+		}
+		ks, _ := c.storage.GetSecret(ctx, keep)
+		assert.Equal(t, uint(1), ks.OwnerID, "admin's secret untouched")
+		os, _ := c.storage.GetSecret(ctx, other)
+		assert.Equal(t, uint(2), os.OwnerID, "other project's secret untouched")
+	})
+
+	t.Run("a second run is a no-op (nothing left owned by the leaver)", func(t *testing.T) {
+		n, err := c.ReassignOwnedSecrets(ctx, p1.ID, 2, 3, 1)
+		require.NoError(t, err)
+		assert.Equal(t, 0, n)
+	})
+
+	t.Run("from == to is rejected", func(t *testing.T) {
+		_, err := c.ReassignOwnedSecrets(ctx, p1.ID, 3, 3, 1)
+		require.Error(t, err)
+	})
+
+	t.Run("a non-existent new owner is rejected", func(t *testing.T) {
+		_, err := c.ReassignOwnedSecrets(ctx, p1.ID, 2, 999, 1)
+		require.Error(t, err)
+	})
+
+	t.Run("zero IDs are rejected", func(t *testing.T) {
+		_, err := c.ReassignOwnedSecrets(ctx, 0, 2, 3, 1)
+		require.Error(t, err)
+	})
+}

--- a/server/http/handlers/secrets_reassign_owner.go
+++ b/server/http/handlers/secrets_reassign_owner.go
@@ -1,0 +1,49 @@
+// secrets_reassign_owner.go — bulk owner reassignment: re-home a departed user's
+// secrets in a project to a new owner (offboarding).
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/keyorixhq/keyorix/server/middleware"
+)
+
+// ReassignOwner handles POST /api/v1/projects/{id}/secrets/reassign-owner with
+// {"from_owner_id":N,"to_owner_id":M} — transfers every secret in the project owned by
+// from_owner_id to to_owner_id (offboarding). Scoped secrets.write (project) is enforced
+// by the router; the per-secret transfer re-checks ownership/owner-gone authorization.
+func (h *SecretHandler) ReassignOwner(w http.ResponseWriter, r *http.Request) {
+	userCtx := middleware.GetUserFromContext(r.Context())
+	if userCtx == nil {
+		h.sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		h.sendError(w, "BadRequest", "Invalid project ID", http.StatusBadRequest, nil)
+		return
+	}
+	var reqBody struct {
+		FromOwnerID uint `json:"from_owner_id"`
+		ToOwnerID   uint `json:"to_owner_id"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
+		h.sendError(w, "BadRequest", "Invalid request body", http.StatusBadRequest, nil)
+		return
+	}
+
+	n, err := h.coreService.ReassignOwnedSecrets(r.Context(), uint(id), reqBody.FromOwnerID, reqBody.ToOwnerID, userCtx.UserID)
+	if err != nil {
+		status := http.StatusInternalServerError
+		if strings.Contains(err.Error(), "required") || strings.Contains(err.Error(), "must differ") || strings.Contains(err.Error(), "not found") {
+			status = http.StatusBadRequest
+		}
+		h.sendError(w, "Error", err.Error(), status, nil)
+		return
+	}
+	h.sendSuccess(w, map[string]interface{}{"reassigned": n}, "")
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -305,6 +305,7 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		r.With(customMiddleware.RequireScopedPermission("secrets.read", projectScope)).Get("/projects/{id}/secrets/orphaned", secretHandler.OrphanedSecrets)
 		r.With(customMiddleware.RequireScopedPermission("secrets.write", projectScope)).Post("/projects/{id}/secrets/suspend-all", secretHandler.SuspendProjectSecrets)
 		r.With(customMiddleware.RequireScopedPermission("secrets.write", projectScope)).Post("/projects/{id}/secrets/resume-all", secretHandler.ResumeProjectSecrets)
+		r.With(customMiddleware.RequireScopedPermission("secrets.write", projectScope)).Post("/projects/{id}/secrets/reassign-owner", secretHandler.ReassignOwner)
 		r.With(customMiddleware.RequireScopedPermission("secrets.read", projectScope)).Get("/projects/{id}/environments", catalogHandler.ListProjectEnvironments)
 		r.With(customMiddleware.RequireScopedPermission("secrets.write", projectScope)).Post("/projects/{id}/environments", catalogHandler.CreateProjectEnvironment)
 		// Environment restore is nested under the project so the scope resolves


### PR DESCRIPTION
## What

Completes the offboarding workflow. Orphaned-secret detection (#326) *finds* the secrets a departed owner left behind; this **re-homes them all in one call**:

```
POST /api/v1/projects/{id}/secrets/reassign-owner
{ "from_owner_id": N, "to_owner_id": M }
```

transfers every secret in the project owned by `from_owner_id` to `to_owner_id`, returning the count reassigned.

## How

- **core** — `ReassignOwnedSecrets(projectID, fromOwnerID, toOwnerID, actorID)`: pages the project's secrets and routes each match through the single-secret `TransferSecretOwnership`, so the **same authorization** (actor is the current owner, *or* the owner is gone — the offboarding case) and the **same per-secret `secret.owner_transferred` audit event** apply to every one. Best-effort: per-secret failures are skipped, not fatal (like project-wide suspend). Validates required IDs, `from != to`, and that the new owner exists.
- **http** — scoped `secrets.write` (project); validation errors → 400.

## Security

- Mutating route, gated `secrets.write` @ project — **verified it returns 403 to the read-only persona** (TestEveryMutatingRouteDeniesReadOnly).
- No bypass of the transfer rule: each secret is authorized individually, so this can't seize an actively-owned secret out from under a live owner — only re-home gone-owner (or actor-owned) secrets. Full audit trail preserved (one event per secret).

## Test

`TestReassignOwnedSecrets`: reassigns only the leaver's secrets in the project (admin's + other project's untouched), second run is a no-op, and `from==to` / missing new owner / zero IDs are rejected.

gofmt / go build / go test / gosec / golangci-lint all clean.

## Follow-ups

CLI `secret reassign-owner` + a web "reassign all" action next to the orphaned-secrets panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)