### PR TITLE
feat(cli): secret reassign-owner — bulk re-home a departed user's secrets

### DIFF
--- a/internal/cli/secret/reassign_owner.go
+++ b/internal/cli/secret/reassign_owner.go
@@ -1,0 +1,61 @@
+package secret
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/spf13/cobra"
+)
+
+var (
+	reassignProject uint
+	reassignFrom    uint
+	reassignTo      uint
+)
+
+var reassignOwnerCmd = &cobra.Command{
+	Use:   "reassign-owner",
+	Short: "Re-home all of a departed user's secrets to a new owner",
+	Long: `Transfer every secret in a project owned by one user to another, in one call —
+the bulk completion of offboarding after 'keyorix secret orphaned' surfaces a gone
+owner's secrets. Requires secrets.write at the project scope; each secret is authorized
+individually (you must be its owner, or the current owner must be gone).`,
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		if reassignProject == 0 || reassignFrom == 0 || reassignTo == 0 {
+			return fmt.Errorf("--project, --from and --to are all required")
+		}
+		c, ok := common.NewRemoteClient()
+		if !ok {
+			return fmt.Errorf("not connected to a server — run: keyorix connect <server>")
+		}
+		n, err := reassignOwner(context.Background(), c, reassignProject, reassignFrom, reassignTo)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("✅ Reassigned %d secret(s) from user %d to user %d.\n", n, reassignFrom, reassignTo)
+		return nil
+	},
+}
+
+// reassignOwner POSTs the bulk reassignment and returns the count (split out for tests).
+func reassignOwner(ctx context.Context, c *common.RemoteClient, projectID, from, to uint) (int, error) {
+	path := "/api/v1/projects/" + strconv.Itoa(int(projectID)) + "/secrets/reassign-owner"
+	body := map[string]uint{"from_owner_id": from, "to_owner_id": to}
+	var out struct {
+		Reassigned int `json:"reassigned"`
+	}
+	if err := c.Post(ctx, path, body, &out); err != nil {
+		return 0, err
+	}
+	return out.Reassigned, nil
+}
+
+func init() {
+	reassignOwnerCmd.Flags().UintVar(&reassignProject, "project", 0, "Project ID (required)")
+	reassignOwnerCmd.Flags().UintVar(&reassignFrom, "from", 0, "Current owner's user ID (required)")
+	reassignOwnerCmd.Flags().UintVar(&reassignTo, "to", 0, "New owner's user ID (required)")
+	SecretCmd.AddCommand(reassignOwnerCmd)
+}

--- a/internal/cli/secret/reassign_owner_remote_test.go
+++ b/internal/cli/secret/reassign_owner_remote_test.go
@@ -1,0 +1,51 @@
+package secret
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func reassignStub(t *testing.T) (*common.RemoteClient, func()) {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && r.URL.Path == "/api/v1/projects/5/secrets/reassign-owner" {
+			// Echo back a count; assert the body carried the owner IDs.
+			b, _ := io.ReadAll(r.Body)
+			var got map[string]uint
+			_ = json.Unmarshal(b, &got)
+			if got["from_owner_id"] == 2 && got["to_owner_id"] == 3 {
+				_, _ = w.Write([]byte(`{"data":{"reassigned":4}}`))
+				return
+			}
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	rc, ok := common.NewRemoteClient()
+	require.True(t, ok)
+	return rc, srv.Close
+}
+
+func TestReassignOwner(t *testing.T) {
+	rc, done := reassignStub(t)
+	defer done()
+	n, err := reassignOwner(context.Background(), rc, 5, 2, 3)
+	require.NoError(t, err)
+	assert.Equal(t, 4, n)
+}
+
+func TestReassignOwner_NotFound(t *testing.T) {
+	rc, done := reassignStub(t)
+	defer done()
+	_, err := reassignOwner(context.Background(), rc, 999, 2, 3)
+	require.Error(t, err)
+}


### PR DESCRIPTION
## What

CLI for bulk owner reassignment (#328):

```
keyorix secret reassign-owner --project <id> --from <ownerID> --to <ownerID>
```

Transfers every secret in the project owned by `--from` to `--to` and reports the count — the bulk completion of offboarding after `secret orphaned` surfaces a gone owner's secrets.

## How

- POSTs `/projects/{id}/secrets/reassign-owner` `{from_owner_id,to_owner_id}` via `common.RemoteClient` (server enforces `secrets.write` @ project; each secret authorized individually).
- `reassignOwner` split out for httptest coverage (the stub asserts the request body carries both owner IDs).

## Security

- No local authz — the server gate is authoritative, and each per-secret transfer re-checks ownership/owner-gone, so this can't seize a live owner's secret.

## Test

`TestReassignOwner` (count + body assertion) + not-found error path. gofmt / go build / go test / gosec / golangci-lint all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)