### PR TITLE
feat(pat): personal-access-token hygiene — admin view of stale/expired tokens

### DIFF
--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -1095,6 +1095,14 @@ func (m *MockStorage) ListPersonalAccessTokensByUser(ctx context.Context, userID
 	return args.Get(0).([]*models.PersonalAccessToken), args.Error(1)
 }
 
+func (m *MockStorage) ListActivePersonalAccessTokens(ctx context.Context) ([]*models.PersonalAccessToken, error) {
+	args := m.Called(ctx)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*models.PersonalAccessToken), args.Error(1)
+}
+
 func (m *MockStorage) GetPersonalAccessTokenByID(ctx context.Context, id uint) (*models.PersonalAccessToken, error) {
 	args := m.Called(ctx, id)
 	if args.Get(0) == nil {

--- a/internal/core/pat_hygiene.go
+++ b/internal/core/pat_hygiene.go
@@ -1,0 +1,60 @@
+// pat_hygiene.go — deployment-wide personal-access-token hygiene: surface the
+// non-revoked PATs that should probably be cleaned up — ones that have expired but
+// were never revoked, and ones that have gone stale (unused for a long window). A
+// long-lived bearer credential that is expired-but-active or abandoned is exactly the
+// kind of token sprawl an attacker reuses, so this gives an admin one place to find
+// and revoke them. Parallels the stale-machine-identity and unused-secret hygiene
+// views. Read-only; never returns a token hash or plaintext. Admin-scoped (route-gated).
+package core
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// defaultPATStaleAfter is the staleness window used when the caller passes none: a PAT
+// unused (or, if never used, uncreated-against) for 90 days is flagged stale.
+const defaultPATStaleAfter = 90 * 24 * time.Hour
+
+// PATHygieneEntry is one flagged token plus why it was flagged. The embedded token
+// carries only metadata; callers must not surface its TokenHash.
+type PATHygieneEntry struct {
+	Token   *models.PersonalAccessToken
+	Expired bool // ExpiresAt is in the past (but the token was never revoked)
+	Stale   bool // not used within the staleness window (never-used counts from creation)
+}
+
+// ListPATHygiene returns the non-revoked PATs that are expired-but-active or stale
+// (unused for longer than staleAfter; a never-used token counts from its creation).
+// Healthy tokens are omitted. Newest-created first (the storage order is preserved).
+func (c *KeyorixCore) ListPATHygiene(ctx context.Context, staleAfter time.Duration) ([]PATHygieneEntry, error) {
+	if staleAfter <= 0 {
+		staleAfter = defaultPATStaleAfter
+	}
+	tokens, err := c.storage.ListActivePersonalAccessTokens(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	now := c.now()
+	cutoff := now.Add(-staleAfter)
+
+	var out []PATHygieneEntry
+	for _, t := range tokens {
+		expired := t.ExpiresAt != nil && t.ExpiresAt.Before(now)
+
+		last := t.CreatedAt
+		if t.LastUsedAt != nil {
+			last = *t.LastUsedAt
+		}
+		stale := last.Before(cutoff)
+
+		if expired || stale {
+			out = append(out, PATHygieneEntry{Token: t, Expired: expired, Stale: stale})
+		}
+	}
+	return out, nil
+}

--- a/internal/core/pat_hygiene_test.go
+++ b/internal/core/pat_hygiene_test.go
@@ -1,0 +1,86 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestListPATHygiene(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	sqlDB, _ := db.DB()
+	sqlDB.SetMaxOpenConns(1)
+	require.NoError(t, db.AutoMigrate(&models.PersonalAccessToken{}))
+
+	now := time.Date(2026, 6, 18, 12, 0, 0, 0, time.UTC)
+	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: func() time.Time { return now }}
+	ctx := context.Background()
+
+	ago := func(d time.Duration) *time.Time { v := now.Add(-d); return &v }
+	ahead := func(d time.Duration) *time.Time { v := now.Add(d); return &v }
+	day := 24 * time.Hour
+
+	mk := func(id uint, name string, created time.Time, lastUsed, expires *time.Time, revoked bool) {
+		require.NoError(t, db.Create(&models.PersonalAccessToken{
+			ID: id, UserID: 7, Name: name, TokenHash: name + "-hash", TokenPrefix: "kx_pat_" + name,
+			CreatedAt: created, LastUsedAt: lastUsed, ExpiresAt: expires, Revoked: revoked,
+		}).Error)
+	}
+
+	mk(1, "healthy", now.Add(-10*day), ago(1*day), ahead(30*day), false)  // recent use, not expired
+	mk(2, "stale", now.Add(-200*day), ago(120*day), ahead(30*day), false) // unused 120d → stale
+	mk(3, "never-old", now.Add(-120*day), nil, nil, false)                // never used, created 120d ago → stale
+	mk(4, "never-new", now.Add(-5*day), nil, nil, false)                  // never used, created 5d ago → healthy
+	mk(5, "expired", now.Add(-10*day), ago(1*day), ago(2*day), false)     // expired but recently used → expired only
+	mk(6, "revoked-stale", now.Add(-200*day), ago(150*day), nil, true)    // stale but revoked → excluded
+
+	t.Run("flags stale and expired-but-active, excludes healthy and revoked", func(t *testing.T) {
+		entries, err := c.ListPATHygiene(ctx, 90*day)
+		require.NoError(t, err)
+		byName := map[string]PATHygieneEntry{}
+		for _, e := range entries {
+			byName[e.Token.Name] = e
+		}
+		require.Len(t, entries, 3, "stale + never-old + expired")
+		assert.True(t, byName["stale"].Stale)
+		assert.False(t, byName["stale"].Expired)
+		assert.True(t, byName["never-old"].Stale)
+		assert.True(t, byName["expired"].Expired)
+		assert.False(t, byName["expired"].Stale, "used yesterday — not stale")
+		_, healthy := byName["healthy"]
+		assert.False(t, healthy)
+		_, fresh := byName["never-new"]
+		assert.False(t, fresh)
+		_, revoked := byName["revoked-stale"]
+		assert.False(t, revoked, "revoked tokens are excluded at the storage layer")
+	})
+
+	t.Run("a shorter window flags more tokens", func(t *testing.T) {
+		// Under a 4-day window, the never-used token created 5 days ago also goes stale.
+		entries, err := c.ListPATHygiene(ctx, 4*day)
+		require.NoError(t, err)
+		names := map[string]bool{}
+		for _, e := range entries {
+			names[e.Token.Name] = true
+		}
+		assert.True(t, names["never-new"], "created 5d ago, never used → stale under a 4d window")
+		assert.False(t, names["healthy"], "used 1d ago → still not stale under a 4d window")
+	})
+
+	t.Run("a non-positive window falls back to the default", func(t *testing.T) {
+		entries, err := c.ListPATHygiene(ctx, 0)
+		require.NoError(t, err)
+		// 90-day default: same three as the explicit 90-day call.
+		assert.Len(t, entries, 3)
+	})
+}

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -458,6 +458,9 @@ type Storage interface {
 	// Personal Access Token Management (ADR-027) — user-owned bearer credentials.
 	CreatePersonalAccessToken(ctx context.Context, t *models.PersonalAccessToken) (*models.PersonalAccessToken, error)
 	ListPersonalAccessTokensByUser(ctx context.Context, userID uint) ([]*models.PersonalAccessToken, error)
+	// ListActivePersonalAccessTokens returns every non-revoked PAT across all users —
+	// the deployment-wide view for token-hygiene auditing (stale / expired-but-active).
+	ListActivePersonalAccessTokens(ctx context.Context) ([]*models.PersonalAccessToken, error)
 	GetPersonalAccessTokenByID(ctx context.Context, id uint) (*models.PersonalAccessToken, error)
 	GetPersonalAccessTokenByHash(ctx context.Context, hash string) (*models.PersonalAccessToken, error)
 	RevokePersonalAccessToken(ctx context.Context, id uint) error

--- a/internal/storage/store/local_auth.go
+++ b/internal/storage/store/local_auth.go
@@ -201,6 +201,19 @@ func (ls *LocalStorage) ListPersonalAccessTokensByUser(ctx context.Context, user
 	return tokens, nil
 }
 
+// ListActivePersonalAccessTokens returns every non-revoked PAT, newest first — the
+// deployment-wide token-hygiene view.
+func (ls *LocalStorage) ListActivePersonalAccessTokens(ctx context.Context) ([]*models.PersonalAccessToken, error) {
+	var tokens []*models.PersonalAccessToken
+	if err := ls.db.WithContext(ctx).
+		Where("revoked = ?", false).
+		Order("created_at DESC").
+		Find(&tokens).Error; err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	return tokens, nil
+}
+
 func (ls *LocalStorage) GetPersonalAccessTokenByID(ctx context.Context, id uint) (*models.PersonalAccessToken, error) {
 	var t models.PersonalAccessToken
 	if err := ls.db.WithContext(ctx).First(&t, id).Error; err != nil {

--- a/internal/storage/store/remote_auth.go
+++ b/internal/storage/store/remote_auth.go
@@ -260,6 +260,10 @@ func (rs *RemoteStorage) ListPersonalAccessTokensByUser(_ context.Context, _ uin
 	return nil, errUnsupportedRemote
 }
 
+func (rs *RemoteStorage) ListActivePersonalAccessTokens(_ context.Context) ([]*models.PersonalAccessToken, error) {
+	return nil, errUnsupportedRemote
+}
+
 func (rs *RemoteStorage) GetPersonalAccessTokenByID(_ context.Context, _ uint) (*models.PersonalAccessToken, error) {
 	return nil, errUnsupportedRemote
 }

--- a/server/http/handlers/pat_handler.go
+++ b/server/http/handlers/pat_handler.go
@@ -86,6 +86,51 @@ func (h *PATHandler) ListPATs(w http.ResponseWriter, r *http.Request) {
 	sendSuccess(w, out, "")
 }
 
+// patHygieneResponse is one flagged token in the admin hygiene view: the safe PAT DTO
+// (no hash) plus the owner and the reasons it was flagged.
+type patHygieneResponse struct {
+	patResponse
+	UserID  uint `json:"user_id"`
+	Expired bool `json:"expired"`
+	Stale   bool `json:"stale"`
+}
+
+// PATHygiene handles GET /api/v1/pat-hygiene?days=N — the deployment-wide list of
+// non-revoked tokens that are expired-but-active or stale (unused for the window), so
+// an admin can revoke token sprawl. Global system.read is enforced by the router.
+// days defaults to 90 and is capped at 3650.
+func (h *PATHandler) PATHygiene(w http.ResponseWriter, r *http.Request) {
+	if middleware.GetUserFromContext(r.Context()) == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	days := 90
+	if v := r.URL.Query().Get("days"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			days = n
+		}
+	}
+	if days > 3650 {
+		days = 3650
+	}
+
+	entries, err := h.coreService.ListPATHygiene(r.Context(), time.Duration(days)*24*time.Hour)
+	if err != nil {
+		sendError(w, "InternalError", "Failed to list token hygiene", http.StatusInternalServerError, nil)
+		return
+	}
+	out := make([]patHygieneResponse, 0, len(entries))
+	for _, e := range entries {
+		out = append(out, patHygieneResponse{
+			patResponse: toPATResponse(e.Token),
+			UserID:      e.Token.UserID,
+			Expired:     e.Expired,
+			Stale:       e.Stale,
+		})
+	}
+	sendSuccess(w, map[string]interface{}{"tokens": out, "total": len(out)}, "")
+}
+
 type createPATRequestBody struct {
 	Name      string  `json:"name"`
 	ExpiresAt *string `json:"expires_at"` // RFC3339; omit/null for a non-expiring token

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -518,6 +518,10 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.Get("/metrics", handlers.GetMetrics)
 		})
 
+		// Personal-access-token hygiene — deployment-wide stale / expired-but-active
+		// tokens an admin should revoke (token sprawl).
+		r.With(customMiddleware.RequirePermission("system.read")).Get("/pat-hygiene", patHandler.PATHygiene)
+
 		// Compliance posture — deployment-wide controls snapshot for auditors.
 		r.With(customMiddleware.RequirePermission("system.read")).Get("/compliance/posture", dashboardHandler.GetCompliancePosture)
 		// Compliance control matrix — controls mapped to ISO/SOC2/NIS2/DORA + status.


### PR DESCRIPTION
## What

Adds **PAT hygiene**: `GET /api/v1/pat-hygiene?days=N` — a deployment-wide list of non-revoked personal access tokens that are **expired-but-active** or **stale** (unused beyond a window), so an admin can find and revoke token sprawl.

A long-lived PAT that expired without being revoked, or sits abandoned, is textbook token sprawl — exactly what an attacker reuses. There was only a per-user self-list (`/auth/tokens`); no deployment-wide visibility. This parallels the stale-machine-identity (#319) and unused-secret hygiene views.

## How

- **storage** — `ListActivePersonalAccessTokens`: every non-revoked PAT across all users. Remote adapter returns unsupported (server-side hygiene).
- **core** — `ListPATHygiene(staleAfter)`: flags non-revoked PATs that are expired-but-active (`ExpiresAt` in the past) or stale (unused beyond the window; a never-used token counts from creation). Healthy tokens omitted. Default window 90 days.
- **http** — `GET /pat-hygiene`, gated global `system.read` (same as the other deployment-wide admin reads). The DTO reuses the safe PAT response (**never the token hash**) plus `user_id` and `expired`/`stale` flags. `days` default 90, capped at 3650.

## Security

- Admin-gated (`system.read`); read-only.
- **Never exposes a token hash or plaintext** — the response reuses the existing safe PAT DTO (display prefix only).

## Test

`TestListPATHygiene`: flags stale + never-used-old + expired-but-active, excludes healthy / fresh / revoked; a shorter window flags more; a non-positive window falls back to the 90-day default.

gofmt / go build / go test / gosec / golangci-lint all clean. (The local-only `/sw.js` + `evidence/verify` mutating-route failures are unrelated — this is a GET.)

## Follow-ups

CLI `pat hygiene` (admin) + a web admin panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)