### PR TITLE
feat(cli): pat hygiene — list stale/expired tokens across all users (admin)

### DIFF
--- a/internal/cli/pat/hygiene.go
+++ b/internal/cli/pat/hygiene.go
@@ -1,0 +1,89 @@
+package pat
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/spf13/cobra"
+)
+
+var hygieneDays int
+
+// hygieneRow mirrors a GET /pat-hygiene token entry (safe DTO — no token hash).
+type hygieneRow struct {
+	ID          uint   `json:"id"`
+	Name        string `json:"name"`
+	TokenPrefix string `json:"token_prefix"`
+	UserID      uint   `json:"user_id"`
+	ExpiresAt   string `json:"expires_at"`
+	LastUsedAt  string `json:"last_used_at"`
+	Expired     bool   `json:"expired"`
+	Stale       bool   `json:"stale"`
+}
+
+var hygieneCmd = &cobra.Command{
+	Use:   "hygiene",
+	Short: "List stale or expired-but-active tokens across all users (admin)",
+	Long: `Show the deployment-wide personal access tokens that should probably be revoked:
+ones that have expired but were never revoked, and ones unused for a long window
+(token sprawl). Requires global system.read. Never prints a token's secret.`,
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		c, err := client()
+		if err != nil {
+			return err
+		}
+		rows, err := fetchPATHygiene(context.Background(), c, hygieneDays)
+		if err != nil {
+			return err
+		}
+		if len(rows) == 0 {
+			fmt.Println("No stale or expired tokens.")
+			return nil
+		}
+		fmt.Printf("%-5s %-22s %-14s %-7s %-8s %s\n", "ID", "NAME", "PREFIX", "USER", "FLAGS", "LAST USED")
+		for _, r := range rows {
+			flags := flagLabel(r)
+			last := r.LastUsedAt
+			if last == "" {
+				last = "never"
+			}
+			fmt.Printf("%-5d %-22s %-14s %-7d %-8s %s\n", r.ID, r.Name, r.TokenPrefix+"…", r.UserID, flags, last)
+		}
+		return nil
+	},
+}
+
+func flagLabel(r hygieneRow) string {
+	switch {
+	case r.Expired && r.Stale:
+		return "exp,stale"
+	case r.Expired:
+		return "expired"
+	default:
+		return "stale"
+	}
+}
+
+// fetchPATHygiene GETs the hygiene list (split out for httptest tests). days <= 0 lets
+// the server default (90).
+func fetchPATHygiene(ctx context.Context, c *common.RemoteClient, days int) ([]hygieneRow, error) {
+	path := "/api/v1/pat-hygiene"
+	if days > 0 {
+		path += "?days=" + strconv.Itoa(days)
+	}
+	var body struct {
+		Tokens []hygieneRow `json:"tokens"`
+	}
+	if err := c.Get(ctx, path, &body); err != nil {
+		return nil, err
+	}
+	return body.Tokens, nil
+}
+
+func init() {
+	hygieneCmd.Flags().IntVar(&hygieneDays, "days", 0, "Staleness window in days (default server-side: 90, cap 3650)")
+	PATCmd.AddCommand(hygieneCmd)
+}

--- a/internal/cli/pat/hygiene_remote_test.go
+++ b/internal/cli/pat/hygiene_remote_test.go
@@ -1,0 +1,47 @@
+package pat
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func hygieneStub(t *testing.T) (*common.RemoteClient, func()) {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/pat-hygiene" {
+			_, _ = w.Write([]byte(`{"data":{"tokens":[{"id":2,"name":"ci","token_prefix":"kx_pat_ci","user_id":7,"last_used_at":"","expired":false,"stale":true},{"id":5,"name":"old","token_prefix":"kx_pat_old","user_id":9,"expires_at":"2026-01-01T00:00:00Z","last_used_at":"2026-06-17T00:00:00Z","expired":true,"stale":false}],"total":2}}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	rc, ok := common.NewRemoteClient()
+	require.True(t, ok)
+	return rc, srv.Close
+}
+
+func TestFetchPATHygiene(t *testing.T) {
+	rc, done := hygieneStub(t)
+	defer done()
+	rows, err := fetchPATHygiene(context.Background(), rc, 30)
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+	assert.Equal(t, "ci", rows[0].Name)
+	assert.True(t, rows[0].Stale)
+	assert.False(t, rows[0].Expired)
+	assert.Equal(t, uint(9), rows[1].UserID)
+	assert.True(t, rows[1].Expired)
+}
+
+func TestFlagLabel(t *testing.T) {
+	assert.Equal(t, "stale", flagLabel(hygieneRow{Stale: true}))
+	assert.Equal(t, "expired", flagLabel(hygieneRow{Expired: true}))
+	assert.Equal(t, "exp,stale", flagLabel(hygieneRow{Expired: true, Stale: true}))
+}


### PR DESCRIPTION
## What

CLI for PAT hygiene (#330):

```
keyorix pat hygiene [--days N]
```

prints the deployment-wide non-revoked tokens that are **expired-but-active** or **stale** (`ID / NAME / PREFIX / USER / FLAGS / LAST USED`), so an admin can spot token sprawl and revoke it.

## How

- GETs `/api/v1/pat-hygiene` via `common.RemoteClient` (server enforces global `system.read`).
- `fetchPATHygiene` split out for httptest coverage; `flagLabel` formats the expired/stale combination.

## Security

- No local authz — the server gate is authoritative.
- **Never prints a token secret** — the DTO carries only the display prefix.

## Test

`TestFetchPATHygiene` (stale vs expired flags + user id) and `TestFlagLabel`. gofmt / go build / go test / gosec / golangci-lint all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)