### PR TITLE
feat(admin): force-logout — revoke all of a user's active sessions

### DIFF
--- a/internal/core/account_sessions.go
+++ b/internal/core/account_sessions.go
@@ -1,0 +1,43 @@
+// account_sessions.go — admin force-logout: revoke every active session of a user
+// without changing their account state. Distinct from suspension (which also drops
+// sessions but blocks login): use this when a user's sessions may be compromised
+// (stolen laptop, leaked token) but the account should stay active once they
+// re-authenticate. Complements offboarding ([[secret_orphaned]]) and PAT hygiene
+// ([[pat_hygiene]]) — the human-session half of cutting off access. Admin-only
+// (route-gated users.write); audited.
+package core
+
+import (
+	"context"
+	"fmt"
+)
+
+// EventUserSessionsRevoked is audited when an admin force-logs-out a user.
+const EventUserSessionsRevoked = "account.sessions_revoked"
+
+// RevokeUserSessions terminates every active session belonging to userID, returning
+// the number revoked. The account state is left unchanged — the user can log back in.
+// adminID is the actor (for the audit trail).
+func (c *KeyorixCore) RevokeUserSessions(ctx context.Context, adminID, userID uint) (int, error) {
+	if userID == 0 {
+		return 0, fmt.Errorf("user ID is required")
+	}
+	if _, err := c.storage.GetUser(ctx, userID); err != nil {
+		return 0, fmt.Errorf("user not found: %w", err)
+	}
+
+	sessions, err := c.storage.ListSessionsByUser(ctx, userID)
+	if err != nil {
+		return 0, fmt.Errorf("failed to list sessions: %w", err)
+	}
+	n := len(sessions)
+	// exceptID 0 matches no session, so this drops them all.
+	if err := c.storage.DeleteSessionsForUserExcept(ctx, userID, 0); err != nil {
+		return 0, fmt.Errorf("failed to revoke sessions: %w", err)
+	}
+
+	aid := adminID
+	c.writeAuditEventFull(ctx, EventUserSessionsRevoked, &aid, nil, nil, "",
+		fmt.Sprintf("revoked %d active session(s) for user %d", n, userID))
+	return n, nil
+}

--- a/internal/core/account_sessions_test.go
+++ b/internal/core/account_sessions_test.go
@@ -1,0 +1,79 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestRevokeUserSessions(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	sqlDB, _ := db.DB()
+	sqlDB.SetMaxOpenConns(1)
+	require.NoError(t, db.AutoMigrate(&models.User{}, &models.Session{}, &models.AuditEvent{}))
+	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
+	ctx := context.Background()
+
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "admin", Email: "a@t.com"}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 2, Username: "target", Email: "t@t.com"}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 3, Username: "bystander", Email: "b@t.com"}).Error)
+
+	mkSession := func(id, userID uint, token string) {
+		require.NoError(t, db.Create(&models.Session{ID: id, UserID: userID, SessionToken: token, CreatedAt: time.Now()}).Error)
+	}
+	mkSession(10, 2, "t-a") // target's
+	mkSession(11, 2, "t-b") // target's
+	mkSession(12, 3, "b-a") // bystander's — must survive
+
+	t.Run("revokes all of the target's sessions, leaves others", func(t *testing.T) {
+		n, err := c.RevokeUserSessions(ctx, 1, 2)
+		require.NoError(t, err)
+		assert.Equal(t, 2, n)
+
+		left, err := c.storage.ListSessionsByUser(ctx, 2)
+		require.NoError(t, err)
+		assert.Empty(t, left, "target has no sessions left")
+
+		other, err := c.storage.ListSessionsByUser(ctx, 3)
+		require.NoError(t, err)
+		assert.Len(t, other, 1, "bystander's session untouched")
+	})
+
+	t.Run("the account state is unchanged (force-logout, not suspend)", func(t *testing.T) {
+		u, err := c.storage.GetUser(ctx, 2)
+		require.NoError(t, err)
+		assert.NotEqual(t, AccountSuspended, u.AccountState)
+	})
+
+	t.Run("a second run revokes nothing", func(t *testing.T) {
+		n, err := c.RevokeUserSessions(ctx, 1, 2)
+		require.NoError(t, err)
+		assert.Equal(t, 0, n)
+	})
+
+	t.Run("an audit event is recorded", func(t *testing.T) {
+		var count int64
+		require.NoError(t, db.Model(&models.AuditEvent{}).Where("event_type = ?", EventUserSessionsRevoked).Count(&count).Error)
+		assert.GreaterOrEqual(t, count, int64(1))
+	})
+
+	t.Run("a missing user is rejected", func(t *testing.T) {
+		_, err := c.RevokeUserSessions(ctx, 1, 999)
+		require.Error(t, err)
+	})
+
+	t.Run("user ID zero is rejected", func(t *testing.T) {
+		_, err := c.RevokeUserSessions(ctx, 1, 0)
+		require.Error(t, err)
+	})
+}

--- a/server/http/handlers/users_crud.go
+++ b/server/http/handlers/users_crud.go
@@ -394,6 +394,32 @@ func (h *UserHandler) RequirePasswordReset(w http.ResponseWriter, r *http.Reques
 	h.accountStateAction(w, r, "Password reset required", h.coreService.RequirePasswordReset)
 }
 
+// RevokeSessions handles POST /api/v1/users/{id}/revoke-sessions — admin force-logout:
+// terminate all of the user's active sessions without changing their account state
+// (e.g. suspected token/session theft). Scoped users.write is enforced by the router.
+func (h *UserHandler) RevokeSessions(w http.ResponseWriter, r *http.Request) {
+	admin := middleware.GetUserFromContext(r.Context())
+	if admin == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		sendError(w, "InvalidParameter", "Invalid user ID", http.StatusBadRequest, nil)
+		return
+	}
+	n, err := h.coreService.RevokeUserSessions(r.Context(), admin.UserID, uint(id))
+	if err != nil {
+		status := http.StatusInternalServerError
+		if strings.Contains(err.Error(), "not found") {
+			status = http.StatusNotFound
+		}
+		sendError(w, "Error", err.Error(), status, nil)
+		return
+	}
+	sendSuccess(w, map[string]interface{}{"revoked": n}, "Sessions revoked")
+}
+
 // ResendSetupLink handles POST /api/v1/users/{id}/resend-setup-link (ADR-028). It
 // reissues the user's account_setup link (superseding any prior one) and re-delivers
 // it, returning the delivery outcome — including the link itself in out-of-band mode.

--- a/server/http/handlers/users_handler.go
+++ b/server/http/handlers/users_handler.go
@@ -300,6 +300,15 @@ func SuspendUser(w http.ResponseWriter, r *http.Request) {
 	defaultUserHandler.SuspendUser(w, r)
 }
 
+// RevokeSessions handles POST /api/v1/users/{id}/revoke-sessions — admin force-logout.
+func RevokeSessions(w http.ResponseWriter, r *http.Request) {
+	if defaultUserHandler == nil {
+		sendError(w, "ServiceUnavailable", "User handler not initialised", http.StatusServiceUnavailable, nil)
+		return
+	}
+	defaultUserHandler.RevokeSessions(w, r)
+}
+
 // ReactivateUser handles POST /api/v1/users/{id}/reactivate (ADR-025).
 func ReactivateUser(w http.ResponseWriter, r *http.Request) {
 	if defaultUserHandler == nil {

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -411,6 +411,8 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.With(customMiddleware.RequirePermission("users.write")).Delete("/{id}", handlers.DeleteUser)
 			r.With(customMiddleware.RequirePermission("users.write")).Post("/{id}/restore", handlers.RestoreUser)
 			r.With(customMiddleware.RequirePermission("users.write")).Post("/{id}/unlock", handlers.UnlockUser)
+			// Admin force-logout: revoke all of a user's sessions (no state change).
+			r.With(customMiddleware.RequirePermission("users.write")).Post("/{id}/revoke-sessions", handlers.RevokeSessions)
 			// Account state transitions (ADR-025).
 			r.With(customMiddleware.RequirePermission("users.write")).Post("/{id}/suspend", handlers.SuspendUser)
 			r.With(customMiddleware.RequirePermission("users.write")).Post("/{id}/reactivate", handlers.ReactivateUser)


### PR DESCRIPTION
## What

Admin **force-logout**: `POST /api/v1/users/{id}/revoke-sessions` terminates every active session of a user immediately — **without changing their account state**. Use it for suspected session/token theft (stolen laptop, leaked session): the user is cut off now but can log back in after re-authenticating.

This is the human-session counterpart to the offboarding work — orphaned-secret re-homing (#326/#328) and PAT hygiene (#330) cut off a departing user's secrets and tokens; this cuts off their live sessions.

## How

- **core** — `RevokeUserSessions(adminID, userID)`: counts the user's sessions, drops them all via the existing `DeleteSessionsForUserExcept(userID, 0)` (exceptID `0` matches no session), audits `account.sessions_revoked`, returns the count. Account state is left untouched (distinct from suspend, which blocks login). Validates the user exists and a non-zero ID.
- **http** — scoped `users.write`; missing user → 404.

## Security

- Mutating route, gated `users.write` — **verified it returns 403 to the read-only persona** (TestEveryMutatingRouteDeniesReadOnly).
- Audited (`account.sessions_revoked`, actor = admin).

## Test

`TestRevokeUserSessions`: revokes only the target's sessions (a bystander's survive), account state unchanged, a second run revokes 0, an audit event is written, and missing/zero user IDs are rejected.

gofmt / go build / go test / gosec / golangci-lint all clean.

## Follow-ups

CLI `user revoke-sessions` + a web "Force log out" action on the user detail page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)