### PR TITLE
feat(cli): user revoke-sessions — force-logout from the CLI

### DIFF
--- a/internal/cli/user/lifecycle.go
+++ b/internal/cli/user/lifecycle.go
@@ -63,6 +63,42 @@ var forcePasswordResetCmd = &cobra.Command{
 	},
 }
 
+var (
+	revokeSessionsUserID uint
+	revokeSessionsBy     string
+)
+
+var revokeSessionsCmd = &cobra.Command{
+	Use:   "revoke-sessions",
+	Short: "Force-logout a user (revoke all active sessions)",
+	Long: "Terminate every active session of a user immediately, without changing their\n" +
+		"account state — for suspected session/token theft. The user can log back in after\n" +
+		"re-authenticating. To block login entirely, use 'suspend' instead.",
+	RunE: func(_ *cobra.Command, _ []string) error {
+		if revokeSessionsUserID == 0 {
+			return errors.New("user id is required (use --id)")
+		}
+		if revokeSessionsBy == "" {
+			return errors.New("acting admin email is required (use --by)")
+		}
+		service, err := common.InitializeCoreService()
+		if err != nil {
+			return fmt.Errorf("failed to initialize service: %w", err)
+		}
+		ctx := context.Background()
+		adminID, err := resolveAdminID(ctx, service, revokeSessionsBy)
+		if err != nil {
+			return err
+		}
+		n, err := service.RevokeUserSessions(ctx, adminID, revokeSessionsUserID)
+		if err != nil {
+			return fmt.Errorf("failed: %w", err)
+		}
+		fmt.Printf("Revoked %d active session(s) for user %d.\n", n, revokeSessionsUserID)
+		return nil
+	},
+}
+
 func init() {
 	suspendCmd.Flags().UintVar(&suspendUserID, "id", 0, "Target user ID (required)")
 	suspendCmd.Flags().StringVar(&suspendBy, "by", "", "Acting admin email (required, for audit)")
@@ -78,6 +114,11 @@ func init() {
 	forcePasswordResetCmd.Flags().StringVar(&forcePasswordResetBy, "by", "", "Acting admin email (required, for audit)")
 	_ = forcePasswordResetCmd.MarkFlagRequired("id")
 	_ = forcePasswordResetCmd.MarkFlagRequired("by")
+
+	revokeSessionsCmd.Flags().UintVar(&revokeSessionsUserID, "id", 0, "Target user ID (required)")
+	revokeSessionsCmd.Flags().StringVar(&revokeSessionsBy, "by", "", "Acting admin email (required, for audit)")
+	_ = revokeSessionsCmd.MarkFlagRequired("id")
+	_ = revokeSessionsCmd.MarkFlagRequired("by")
 }
 
 // runLifecycle is the shared body for the three account-state commands: it

--- a/internal/cli/user/user.go
+++ b/internal/cli/user/user.go
@@ -24,6 +24,7 @@ func init() {
 	UserCmd.AddCommand(suspendCmd)
 	UserCmd.AddCommand(reactivateCmd)
 	UserCmd.AddCommand(forcePasswordResetCmd)
+	UserCmd.AddCommand(revokeSessionsCmd)
 	UserCmd.AddCommand(resendSetupLinkCmd)
 }
 

--- a/internal/cli/user/user_test.go
+++ b/internal/cli/user/user_test.go
@@ -19,7 +19,7 @@ func TestUserCommandStructure(t *testing.T) {
 	}
 	for _, expected := range []string{
 		"create", "get", "update", "delete", "list",
-		"suspend", "reactivate", "force-password-reset",
+		"suspend", "reactivate", "force-password-reset", "revoke-sessions",
 	} {
 		assert.Contains(t, names, expected, "expected subcommand %q", expected)
 	}
@@ -30,6 +30,7 @@ func TestLifecycleRequiredFlags(t *testing.T) {
 		"suspend":              suspendCmd,
 		"reactivate":           reactivateCmd,
 		"force-password-reset": forcePasswordResetCmd,
+		"revoke-sessions":      revokeSessionsCmd,
 	}
 	for label, c := range cmds {
 		for _, name := range []string{"id", "by"} {


### PR DESCRIPTION
## What

CLI for admin force-logout (#332):

```
keyorix user revoke-sessions --id <id> --by <admin-email>
```

Terminates every active session of a user (no account-state change) — for suspected session/token theft — and prints the number revoked.

## How

- Mirrors the existing `suspend` / `reactivate` / `force-password-reset` lifecycle commands: operates on the **local DB** via the core service, resolves the audited actor from `--by`, and calls `RevokeUserSessions`.
- Registered on `UserCmd`; both `--id` and `--by` required.

## Test

`TestUserCommandStructure` and `TestLifecycleRequiredFlags` extended to cover `revoke-sessions` (present as a subcommand; both flags required). The underlying `RevokeUserSessions` core method is covered in #332.

gofmt / go build / go test / gosec / golangci-lint all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)