### PR TITLE
release: prep v0.61.0 (CHANGELOG + Helm charts)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,37 @@
 All notable changes to Keyorix are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## v0.61.0 — 2026-06-18
+
+Offboarding & incident response: cut off a departing or compromised user across
+all three credential types they hold — owned secrets, personal access tokens, and
+live sessions.
+
+### Added
+- **Orphaned-secret detection** — `GET /projects/{id}/secrets/orphaned` lists a
+  project's secrets whose owner is no longer a live user (offboarding), plus
+  `keyorix secret orphaned` and a project-settings alert in the web UI. ([#326], [#327])
+- **Bulk owner reassignment** — `POST /projects/{id}/secrets/reassign-owner`
+  re-homes every secret a departed user owned to a new owner in one call (each
+  re-authorized and audited individually), plus `keyorix secret reassign-owner`
+  and a per-former-owner "Reassign all" web action. ([#328], [#329])
+- **Personal-access-token hygiene** — `GET /pat-hygiene?days=N` surfaces the
+  deployment-wide non-revoked tokens that are expired-but-active or stale (token
+  sprawl), plus `keyorix pat hygiene` and an admin web panel. ([#330], [#331])
+- **Admin force-logout** — `POST /users/{id}/revoke-sessions` terminates all of a
+  user's active sessions without changing their account state (suspected session/
+  token theft), plus `keyorix user revoke-sessions` and a "Force log out" action
+  on the user detail page. ([#332], [#333])
+
+[#326]: https://github.com/keyorixhq/keyorix/pull/326
+[#327]: https://github.com/keyorixhq/keyorix/pull/327
+[#328]: https://github.com/keyorixhq/keyorix/pull/328
+[#329]: https://github.com/keyorixhq/keyorix/pull/329
+[#330]: https://github.com/keyorixhq/keyorix/pull/330
+[#331]: https://github.com/keyorixhq/keyorix/pull/331
+[#332]: https://github.com/keyorixhq/keyorix/pull/332
+[#333]: https://github.com/keyorixhq/keyorix/pull/333
+
 ## v0.60.0 — 2026-06-18
 
 Secret audit trail and a recycle bin for deleted secrets.

--- a/deploy/helm/keyorix-k8s-sync/Chart.yaml
+++ b/deploy/helm/keyorix-k8s-sync/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix-k8s-sync
 description: Keyorix Kubernetes sync agent — materialises Keyorix secrets into native Kubernetes Secrets
 type: application
 # Chart version — tracks the Keyorix release version (published in lockstep).
-version: 0.60.0
+version: 0.61.0
 # The keyorix-k8s-sync image tag this chart deploys by default.
-appVersion: "0.60.0"
+appVersion: "0.61.0"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix

--- a/deploy/helm/keyorix/Chart.yaml
+++ b/deploy/helm/keyorix/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix
 description: Self-hosted Keyorix secrets manager (API server + web UI + PostgreSQL)
 type: application
 # Chart version — bump on chart changes.
-version: 0.60.0
+version: 0.61.0
 # The Keyorix app version this chart deploys by default (the image tag).
-appVersion: "0.60.0"
+appVersion: "0.61.0"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix


### PR DESCRIPTION
Release prep for **v0.61.0** — offboarding & incident response across all three credential types a user holds.

### Bundled since v0.60.0
- **Orphaned-secret detection** — `GET /projects/{id}/secrets/orphaned` + CLI + web alert ([#326], [#327])
- **Bulk owner reassignment** — `POST /projects/{id}/secrets/reassign-owner` + CLI + web "Reassign all" ([#328], [#329])
- **PAT hygiene** — `GET /pat-hygiene` + CLI + admin web panel ([#330], [#331])
- **Admin force-logout** — `POST /users/{id}/revoke-sessions` + CLI + web action ([#332], [#333])

(Web counterparts ship with the app: keyorix-web #67–#70.)

### This PR
- CHANGELOG v0.61.0 section + PR link refs.
- Helm charts bumped lockstep to 0.61.0 (`keyorix` + `keyorix-k8s-sync`, version + appVersion).

After merge: tag `v0.61.0` on main → release.yml (binaries + OCI charts) and docker-publish.yml (server + agent images).

🤖 Generated with [Claude Code](https://claude.com/claude-code)