### PR TITLE
feat(secrets): tags on a secret — get/set free-form labels

### DIFF
--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -476,6 +476,19 @@ func (m *MockStorage) ListProjectSecretsForDrift(ctx context.Context, projectID 
 	return args.Get(0).([]storage.DriftSecretRow), args.Error(1)
 }
 
+func (m *MockStorage) GetSecretTags(ctx context.Context, secretID uint) ([]string, error) {
+	args := m.Called(ctx, secretID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]string), args.Error(1)
+}
+
+func (m *MockStorage) SetSecretTags(ctx context.Context, secretID uint, tagNames []string) error {
+	args := m.Called(ctx, secretID, tagNames)
+	return args.Error(0)
+}
+
 func (m *MockStorage) GetSecretVersions(ctx context.Context, secretID uint) ([]*models.SecretVersion, error) {
 	args := m.Called(ctx, secretID)
 	if args.Get(0) == nil {

--- a/internal/core/secret_tags.go
+++ b/internal/core/secret_tags.go
@@ -1,0 +1,84 @@
+// secret_tags.go — free-form tags on a secret, for organization and (follow-up)
+// tag-based search. Tags are lowercase, trimmed, de-duplicated labels shared across
+// secrets (a global Tag table, associated per secret). Get requires read on the
+// secret; Set requires write. Setting replaces the secret's whole tag set and is
+// audited. Tags are metadata only — they never carry or reveal a secret value.
+package core
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+)
+
+const (
+	maxSecretTags   = 20 // most tags one secret may carry
+	maxSecretTagLen = 50 // longest a single tag may be
+)
+
+// EventSecretTagsUpdated is audited when a secret's tag set changes.
+const EventSecretTagsUpdated = "secret.tags_updated"
+
+// GetSecretTags returns the secret's tags (sorted). The actor must be able to read it.
+func (c *KeyorixCore) GetSecretTags(ctx context.Context, secretID, actorID uint) ([]string, error) {
+	if _, err := c.EnforceSecretReadPermission(ctx, secretID, actorID); err != nil {
+		return nil, err
+	}
+	tags, err := c.storage.GetSecretTags(ctx, secretID)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	return tags, nil
+}
+
+// SetSecretTags replaces the secret's tags with the normalized input and returns the
+// stored set. The actor must be able to write the secret. Tag names are trimmed,
+// lowercased, de-duplicated, and bounded (≤20 tags, ≤50 chars each); empties are
+// dropped. Audited as secret.tags_updated.
+func (c *KeyorixCore) SetSecretTags(ctx context.Context, secretID, actorID uint, tags []string) ([]string, error) {
+	if _, err := c.EnforceSecretWritePermission(ctx, secretID, actorID); err != nil {
+		return nil, err
+	}
+	normalized, err := normalizeTags(tags)
+	if err != nil {
+		return nil, err
+	}
+	if err := c.storage.SetSecretTags(ctx, secretID, normalized); err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	uid := actorID
+	sid := secretID
+	c.writeAuditEvent(ctx, EventSecretTagsUpdated, &uid, &sid,
+		fmt.Sprintf("set %d tag(s) on secret %d", len(normalized), secretID))
+	return normalized, nil
+}
+
+// normalizeTags trims, lowercases, de-duplicates (preserving first-seen order), and
+// bounds a tag list. Returns a validation error if a tag is too long or there are too
+// many.
+func normalizeTags(in []string) ([]string, error) {
+	seen := make(map[string]bool, len(in))
+	out := make([]string, 0, len(in))
+	for _, raw := range in {
+		t := strings.ToLower(strings.TrimSpace(raw))
+		if t == "" {
+			continue
+		}
+		if len(t) > maxSecretTagLen {
+			return nil, fmt.Errorf("%s: tag %q exceeds %d characters", i18n.T("ErrorValidation", nil), t, maxSecretTagLen)
+		}
+		if seen[t] {
+			continue
+		}
+		seen[t] = true
+		out = append(out, t)
+	}
+	if len(out) > maxSecretTags {
+		return nil, fmt.Errorf("%s: at most %d tags per secret", i18n.T("ErrorValidation", nil), maxSecretTags)
+	}
+	sort.Strings(out)
+	return out, nil
+}

--- a/internal/core/secret_tags_test.go
+++ b/internal/core/secret_tags_test.go
@@ -1,0 +1,85 @@
+package core
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestSecretTags(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	sqlDB, _ := db.DB()
+	sqlDB.SetMaxOpenConns(1)
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.User{}, &models.AuditEvent{}, &models.Tag{}, &models.SecretTag{}))
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "owner", Email: "o@t.com"}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 2, Username: "mallory", Email: "m@t.com"}).Error)
+
+	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
+	ctx := context.Background()
+	secret, err := c.storage.CreateSecret(ctx, &models.SecretNode{
+		Name: "db", ProjectID: 1, EnvironmentID: 1, Type: "password", OwnerID: 1, IsSecret: true,
+		CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	})
+	require.NoError(t, err)
+
+	t.Run("owner sets tags, normalized (trim/lowercase/dedupe/sort)", func(t *testing.T) {
+		got, err := c.SetSecretTags(ctx, secret.ID, 1, []string{" Prod ", "prod", "DB", "  ", "tier1"})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"db", "prod", "tier1"}, got)
+	})
+
+	t.Run("owner reads them back", func(t *testing.T) {
+		got, err := c.GetSecretTags(ctx, secret.ID, 1)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"db", "prod", "tier1"}, got)
+	})
+
+	t.Run("set replaces the whole set", func(t *testing.T) {
+		got, err := c.SetSecretTags(ctx, secret.ID, 1, []string{"prod"})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"prod"}, got)
+		read, _ := c.GetSecretTags(ctx, secret.ID, 1)
+		assert.Equal(t, []string{"prod"}, read, "db and tier1 removed")
+	})
+
+	t.Run("clearing to empty works", func(t *testing.T) {
+		got, err := c.SetSecretTags(ctx, secret.ID, 1, []string{})
+		require.NoError(t, err)
+		assert.Empty(t, got)
+	})
+
+	t.Run("a non-reader cannot read tags", func(t *testing.T) {
+		_, err := c.GetSecretTags(ctx, secret.ID, 2)
+		require.Error(t, err)
+	})
+
+	t.Run("a non-writer cannot set tags", func(t *testing.T) {
+		_, err := c.SetSecretTags(ctx, secret.ID, 2, []string{"x"})
+		require.Error(t, err)
+	})
+
+	t.Run("an over-long tag is rejected", func(t *testing.T) {
+		_, err := c.SetSecretTags(ctx, secret.ID, 1, []string{strings.Repeat("a", 51)})
+		require.Error(t, err)
+	})
+
+	t.Run("too many tags are rejected", func(t *testing.T) {
+		many := make([]string, 0, 21)
+		for i := 0; i < 21; i++ {
+			many = append(many, "tag-"+string(rune('a'+i)))
+		}
+		_, err := c.SetSecretTags(ctx, secret.ID, 1, many)
+		require.Error(t, err)
+	})
+}

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -190,6 +190,10 @@ type Storage interface {
 	// a live user (the owner was deleted/soft-deleted) — offboarding hygiene, so an
 	// admin can re-assign ownership. Scoped to the project via the environment JOIN.
 	ListOrphanedSecrets(ctx context.Context, projectID uint) ([]*models.SecretNode, error)
+	// GetSecretTags returns a secret's tag names (sorted). SetSecretTags replaces a
+	// secret's tags wholesale, upserting Tag rows by name — secret organization/search.
+	GetSecretTags(ctx context.Context, secretID uint) ([]string, error)
+	SetSecretTags(ctx context.Context, secretID uint, tagNames []string) error
 	// ListProjectSecretsForDrift returns one lightweight row per secret in the
 	// project (folders excluded, secrets in soft-deleted environments excluded),
 	// carrying just the fields cross-environment drift detection pivots on:

--- a/internal/storage/store/local_secrets.go
+++ b/internal/storage/store/local_secrets.go
@@ -399,6 +399,42 @@ func (ls *LocalStorage) ListOrphanedSecrets(ctx context.Context, projectID uint)
 	return secrets, nil
 }
 
+// GetSecretTags returns the secret's tag names, sorted.
+func (ls *LocalStorage) GetSecretTags(ctx context.Context, secretID uint) ([]string, error) {
+	var names []string
+	err := ls.db.WithContext(ctx).
+		Model(&models.Tag{}).
+		Joins("JOIN secret_tags ON secret_tags.tag_id = tags.id").
+		Where("secret_tags.secret_node_id = ?", secretID).
+		Order("tags.name ASC").
+		Pluck("tags.name", &names).Error
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	return names, nil
+}
+
+// SetSecretTags replaces the secret's tag associations with exactly tagNames,
+// upserting any new Tag rows by name. Runs in a transaction so the secret never
+// observes a partial tag set.
+func (ls *LocalStorage) SetSecretTags(ctx context.Context, secretID uint, tagNames []string) error {
+	return ls.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Where("secret_node_id = ?", secretID).Delete(&models.SecretTag{}).Error; err != nil {
+			return fmt.Errorf("clear tags: %w", err)
+		}
+		for _, name := range tagNames {
+			var tag models.Tag
+			if err := tx.Where(models.Tag{Name: name}).FirstOrCreate(&tag).Error; err != nil {
+				return fmt.Errorf("upsert tag %q: %w", name, err)
+			}
+			if err := tx.Create(&models.SecretTag{SecretNodeID: secretID, TagID: tag.ID}).Error; err != nil {
+				return fmt.Errorf("link tag %q: %w", name, err)
+			}
+		}
+		return nil
+	})
+}
+
 // --- Versions ---
 
 // CreateSecretVersion creates a new version of a secret.

--- a/internal/storage/store/remote_secrets.go
+++ b/internal/storage/store/remote_secrets.go
@@ -170,6 +170,15 @@ func (rs *RemoteStorage) ListOrphanedSecrets(_ context.Context, _ uint) ([]*mode
 	return nil, fmt.Errorf("ListOrphanedSecrets not available in remote mode")
 }
 
+// GetSecretTags / SetSecretTags are not available in remote mode; tag storage is server-side.
+func (rs *RemoteStorage) GetSecretTags(_ context.Context, _ uint) ([]string, error) {
+	return nil, fmt.Errorf("GetSecretTags not available in remote mode")
+}
+
+func (rs *RemoteStorage) SetSecretTags(_ context.Context, _ uint, _ []string) error {
+	return fmt.Errorf("SetSecretTags not available in remote mode")
+}
+
 // buildSecretFilterPath constructs the /api/v1/secrets query string from filter fields.
 func buildSecretFilterPath(filter *storage.SecretFilter) string {
 	if filter == nil {

--- a/server/http/handlers/secrets_tags.go
+++ b/server/http/handlers/secrets_tags.go
@@ -1,0 +1,83 @@
+// secrets_tags.go — GetTags / SetTags handlers: free-form tags on a secret.
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/keyorixhq/keyorix/server/middleware"
+)
+
+// GetTags handles GET /api/v1/secrets/{id}/tags — the secret's tags. Scoped
+// secrets.read is enforced by the router; core re-checks read access.
+func (h *SecretHandler) GetTags(w http.ResponseWriter, r *http.Request) {
+	userCtx := middleware.GetUserFromContext(r.Context())
+	if userCtx == nil {
+		h.sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		h.sendError(w, "BadRequest", "Invalid secret ID", http.StatusBadRequest, nil)
+		return
+	}
+	tags, err := h.coreService.GetSecretTags(r.Context(), uint(id), userCtx.UserID)
+	if err != nil {
+		h.tagError(w, err, "Failed to list tags")
+		return
+	}
+	if tags == nil {
+		tags = []string{}
+	}
+	h.sendSuccess(w, map[string]interface{}{"tags": tags}, "")
+}
+
+// SetTags handles PUT /api/v1/secrets/{id}/tags with {"tags":[...]} — replaces the
+// secret's tag set. Scoped secrets.write is enforced by the router; core re-checks
+// write access and normalizes the tags. Returns the stored set.
+func (h *SecretHandler) SetTags(w http.ResponseWriter, r *http.Request) {
+	userCtx := middleware.GetUserFromContext(r.Context())
+	if userCtx == nil {
+		h.sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		h.sendError(w, "BadRequest", "Invalid secret ID", http.StatusBadRequest, nil)
+		return
+	}
+	var body struct {
+		Tags []string `json:"tags"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		h.sendError(w, "BadRequest", "Invalid request body", http.StatusBadRequest, nil)
+		return
+	}
+	tags, err := h.coreService.SetSecretTags(r.Context(), uint(id), userCtx.UserID, body.Tags)
+	if err != nil {
+		h.tagError(w, err, "Failed to set tags")
+		return
+	}
+	if tags == nil {
+		tags = []string{}
+	}
+	h.sendSuccess(w, map[string]interface{}{"tags": tags}, "")
+}
+
+// tagError maps a core error to the right status for the tag endpoints.
+func (h *SecretHandler) tagError(w http.ResponseWriter, err error, fallback string) {
+	msg := err.Error()
+	switch {
+	case strings.Contains(msg, "not found"):
+		h.sendError(w, "NotFound", "Secret not found", http.StatusNotFound, nil)
+	case strings.Contains(msg, "permission") || strings.Contains(msg, "not authorized"):
+		h.sendError(w, "Forbidden", "Not authorized for this secret", http.StatusForbidden, nil)
+	case strings.Contains(msg, "validation") || strings.Contains(msg, "exceeds") || strings.Contains(msg, "at most"):
+		h.sendError(w, "BadRequest", msg, http.StatusBadRequest, nil)
+	default:
+		h.sendError(w, "InternalError", fallback, http.StatusInternalServerError, nil)
+	}
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -332,6 +332,8 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.With(customMiddleware.RequireScopedPermission("secrets.read", secretScope)).Get("/{id}/access", secretHandler.ListAccessors)
 			r.With(customMiddleware.RequireScopedPermission("secrets.read", secretScope)).Get("/{id}/access-log", secretHandler.AccessHistory)
 			r.With(customMiddleware.RequireScopedPermission("secrets.read", secretScope)).Get("/{id}/audit", secretHandler.AuditTrail)
+			r.With(customMiddleware.RequireScopedPermission("secrets.read", secretScope)).Get("/{id}/tags", secretHandler.GetTags)
+			r.With(customMiddleware.RequireScopedPermission("secrets.write", secretScope)).Put("/{id}/tags", secretHandler.SetTags)
 
 			// Create: authorized inside the handler (scope comes from the body).
 			r.Post("/", secretHandler.CreateSecret)


### PR DESCRIPTION
## What

Activates **secret tags**. The `Tag` / `SecretTag` tables shipped and were migrated, but **nothing ever read or wrote them** — dead scaffolding (`SecretFilter.Tags` was never wired either). This adds get/set of free-form labels on a secret, for organization. (Tag-based search/filter is a planned follow-up.)

- `GET /api/v1/secrets/{id}/tags` → `{tags:[...]}`
- `PUT /api/v1/secrets/{id}/tags` `{tags:[...]}` → the stored (normalized) set

## How

- **storage** — `GetSecretTags` (sorted names via the join) and `SetSecretTags` (transactional wholesale replace; upserts `Tag` rows by name). Remote adapter unsupported (tag storage is server-side).
- **core** — `GetSecretTags` (read-gated) / `SetSecretTags` (write-gated, `EnforceSecret*Permission`). Tag names are trimmed, lowercased, de-duplicated, sorted, and bounded (≤20 tags, ≤50 chars each); empties dropped. Set replaces the whole set and audits `secret.tags_updated`.
- **http** — `secrets.read` for GET, `secrets.write` for PUT.

## Security

- Per-secret read/write authorization re-checked in core (not just the route).
- **Metadata only — never a value.** Tags carry no secret material.
- The mutating PUT **returns 403 to the read-only persona** (verified via TestEveryMutatingRouteDeniesReadOnly).

## Test

`TestSecretTags`: normalize (trim/lowercase/dedupe/sort), read-back, replace semantics, clear-to-empty, non-reader & non-writer denied, over-long & too-many rejected.

gofmt / go build / go test / gosec / golangci-lint all clean.

## Follow-ups

Tag-based filtering in the secret list (`SecretFilter.Tags`), CLI `secret tag`, and a tag editor in the web secret detail view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)