### PR TITLE
feat(secrets): filter the secret list by tag

### DIFF
--- a/internal/core/secret_filter_expiry_test.go
+++ b/internal/core/secret_filter_expiry_test.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -32,7 +33,7 @@ func TestApplySecretFilters_ExpiresBefore(t *testing.T) {
 		sec("never", nil),
 	}
 
-	out := c.applySecretFilters(in, &models.SecretListFilter{ExpiresBefore: &cutoff})
+	out := c.applySecretFilters(context.Background(), in, &models.SecretListFilter{ExpiresBefore: &cutoff})
 
 	names := make([]string, 0, len(out))
 	for _, s := range out {
@@ -42,6 +43,6 @@ func TestApplySecretFilters_ExpiresBefore(t *testing.T) {
 		"only secrets strictly before the cutoff pass; at-cutoff, far-future and never-expiring are excluded")
 
 	// Without the filter, everything passes (no behavior change for existing callers).
-	all := c.applySecretFilters(in, &models.SecretListFilter{})
+	all := c.applySecretFilters(context.Background(), in, &models.SecretListFilter{})
 	assert.Len(t, all, 5)
 }

--- a/internal/core/secret_listing_classification_test.go
+++ b/internal/core/secret_listing_classification_test.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"context"
 	"testing"
 
 	"github.com/keyorixhq/keyorix/internal/storage/models"
@@ -20,16 +21,16 @@ func TestApplySecretFilters_Classification(t *testing.T) {
 	}
 
 	restricted := "restricted"
-	got := c.applySecretFilters(in, &models.SecretListFilter{Classification: &restricted})
+	got := c.applySecretFilters(context.Background(), in, &models.SecretListFilter{Classification: &restricted})
 	assert.Len(t, got, 1)
 	assert.Equal(t, "r1", got[0].Name)
 
 	unclassified := "unclassified"
-	got = c.applySecretFilters(in, &models.SecretListFilter{Classification: &unclassified})
+	got = c.applySecretFilters(context.Background(), in, &models.SecretListFilter{Classification: &unclassified})
 	assert.Len(t, got, 1)
 	assert.Equal(t, "u1", got[0].Name, "'unclassified' matches the empty label")
 
 	// No classification filter → all pass through.
-	got = c.applySecretFilters(in, &models.SecretListFilter{})
+	got = c.applySecretFilters(context.Background(), in, &models.SecretListFilter{})
 	assert.Len(t, got, 3)
 }

--- a/internal/core/secret_listing_query.go
+++ b/internal/core/secret_listing_query.go
@@ -35,7 +35,7 @@ func (c *KeyorixCore) ListSecretsInScope(ctx context.Context, filter *models.Sec
 	for _, secret := range secrets {
 		all = append(all, &models.SecretWithSharingInfo{SecretNode: secret})
 	}
-	all = c.applySecretFilters(all, filter)
+	all = c.applySecretFilters(ctx, all, filter)
 	c.sortSecrets(all, filter.SortBy, filter.SortOrder)
 
 	total := int64(len(all))
@@ -112,7 +112,7 @@ func (c *KeyorixCore) ListSecretsWithSharingInfo(ctx context.Context, userID uin
 	}
 
 	// Apply post-fetch filters (search, type, shared-only)
-	all = c.applySecretFilters(all, filter)
+	all = c.applySecretFilters(ctx, all, filter)
 
 	// Sort
 	c.sortSecrets(all, filter.SortBy, filter.SortOrder)
@@ -225,10 +225,17 @@ func (c *KeyorixCore) getSharedSecretsWithSharingInfo(ctx context.Context, userI
 	return result, nil
 }
 
-func (c *KeyorixCore) applySecretFilters(secrets []*models.SecretWithSharingInfo, filter *models.SecretListFilter) []*models.SecretWithSharingInfo {
+func (c *KeyorixCore) applySecretFilters(ctx context.Context, secrets []*models.SecretWithSharingInfo, filter *models.SecretListFilter) []*models.SecretWithSharingInfo {
+	// Tag filter: require every requested tag (AND). Resolved per secret only when a
+	// tag filter is present, so the common no-tag list path does no extra queries.
+	want := normalizeTagFilter(filter.Tags)
+
 	var out []*models.SecretWithSharingInfo
 	for _, s := range secrets {
 		if filter.ShowSharedOnly && !s.IsShared {
+			continue
+		}
+		if len(want) > 0 && !c.secretHasAllTags(ctx, s.ID, want) {
 			continue
 		}
 		if filter.Search != nil && *filter.Search != "" {
@@ -256,6 +263,41 @@ func (c *KeyorixCore) applySecretFilters(secrets []*models.SecretWithSharingInfo
 		out = append(out, s)
 	}
 	return out
+}
+
+// normalizeTagFilter trims/lowercases/de-duplicates requested tag filters (matching
+// how tags are stored), dropping empties.
+func normalizeTagFilter(in []string) []string {
+	seen := make(map[string]bool, len(in))
+	out := make([]string, 0, len(in))
+	for _, raw := range in {
+		t := strings.ToLower(strings.TrimSpace(raw))
+		if t == "" || seen[t] {
+			continue
+		}
+		seen[t] = true
+		out = append(out, t)
+	}
+	return out
+}
+
+// secretHasAllTags reports whether the secret carries every tag in want. A storage
+// error is treated as "no match" (fail closed — the secret is excluded).
+func (c *KeyorixCore) secretHasAllTags(ctx context.Context, secretID uint, want []string) bool {
+	have, err := c.storage.GetSecretTags(ctx, secretID)
+	if err != nil {
+		return false
+	}
+	set := make(map[string]bool, len(have))
+	for _, t := range have {
+		set[t] = true
+	}
+	for _, w := range want {
+		if !set[w] {
+			return false
+		}
+	}
+	return true
 }
 
 // sortSecrets sorts the secret list by name, created_at, updated_at, or owner.

--- a/internal/core/secret_tag_filter_test.go
+++ b/internal/core/secret_tag_filter_test.go
@@ -1,0 +1,84 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestListSecretsInScope_TagFilter(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	sqlDB, _ := db.DB()
+	sqlDB.SetMaxOpenConns(1)
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.User{}, &models.AuditEvent{}, &models.Project{}, &models.Environment{}, &models.Tag{}, &models.SecretTag{}))
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "owner", Email: "o@t.com"}).Error)
+
+	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
+	ctx := context.Background()
+	p, err := c.storage.CreateProject(ctx, &models.Project{Name: "p1"})
+	require.NoError(t, err)
+	e, err := c.storage.CreateEnvironment(ctx, &models.Environment{Name: "production", ProjectID: p.ID})
+	require.NoError(t, err)
+
+	mk := func(name string, tags ...string) uint {
+		s, err := c.storage.CreateSecret(ctx, &models.SecretNode{
+			Name: name, ProjectID: p.ID, EnvironmentID: e.ID, Type: "password", OwnerID: 1, IsSecret: true,
+			CreatedAt: time.Now(), UpdatedAt: time.Now(),
+		})
+		require.NoError(t, err)
+		if len(tags) > 0 {
+			_, err := c.SetSecretTags(ctx, s.ID, 1, tags)
+			require.NoError(t, err)
+		}
+		return s.ID
+	}
+
+	mk("db", "prod", "tier1")
+	mk("cache", "prod")
+	mk("scratch") // untagged
+
+	scope := func(tags ...string) []*models.SecretWithSharingInfo {
+		resp, err := c.ListSecretsInScope(ctx, &models.SecretListFilter{ProjectID: &p.ID, Tags: tags})
+		require.NoError(t, err)
+		return resp.Secrets
+	}
+
+	t.Run("no tag filter returns all", func(t *testing.T) {
+		assert.Len(t, scope(), 3)
+	})
+
+	t.Run("single tag returns matching secrets", func(t *testing.T) {
+		got := scope("prod")
+		names := map[string]bool{}
+		for _, s := range got {
+			names[s.Name] = true
+		}
+		assert.Len(t, got, 2)
+		assert.True(t, names["db"] && names["cache"])
+		assert.False(t, names["scratch"])
+	})
+
+	t.Run("multiple tags are AND (narrowing)", func(t *testing.T) {
+		got := scope("prod", "tier1")
+		require.Len(t, got, 1)
+		assert.Equal(t, "db", got[0].Name)
+	})
+
+	t.Run("tag match is case-insensitive", func(t *testing.T) {
+		assert.Len(t, scope("PROD"), 2)
+	})
+
+	t.Run("an unknown tag matches nothing", func(t *testing.T) {
+		assert.Empty(t, scope("nope"))
+	})
+}

--- a/server/http/handlers/secrets_list.go
+++ b/server/http/handlers/secrets_list.go
@@ -78,6 +78,15 @@ func (h *SecretHandler) ListSecrets(w http.ResponseWriter, r *http.Request) {
 		// with no label (handled in the storage layer).
 		filter.Classification = &cls
 	}
+	// Tag filter: repeatable ?tag=a&tag=b or a single comma-separated ?tag=a,b.
+	// A secret must carry every requested tag (AND).
+	for _, raw := range r.URL.Query()["tag"] {
+		for _, part := range strings.Split(raw, ",") {
+			if t := strings.TrimSpace(part); t != "" {
+				filter.Tags = append(filter.Tags, t)
+			}
+		}
+	}
 	if projectStr := r.URL.Query().Get("project_id"); projectStr != "" {
 		if pID, err := strconv.ParseUint(projectStr, 10, 32); err == nil {
 			pIDUint := uint(pID)


### PR DESCRIPTION
## What

The payoff for secret tags (#335): filter the secret list by tag.

```
GET /api/v1/secrets?tag=prod&tag=tier1      # repeatable
GET /api/v1/secrets?tag=prod,tier1          # or comma-separated
```

Returns only secrets carrying **every** requested tag (AND / narrowing). Works across both list paths — admin/project scope (`ListSecretsInScope`) and the per-user owned+shared view (`ListSecretsWithSharingInfo`) — since both converge on `applySecretFilters`.

## How

- **handler** — parse repeatable / comma-separated `?tag=` into `SecretListFilter.Tags`.
- **core** — `applySecretFilters` now takes `ctx` and, when tags are requested, keeps a secret only if `GetSecretTags` returns all of them. Requested tags are normalized (trim/lowercase/dedupe) to match how tags are stored → case-insensitive. Fail-closed: a tag-lookup error excludes the secret. When no tag filter is set, **no extra queries run** (the common list path is unchanged).

## Test

`TestListSecretsInScope_TagFilter`: no-filter returns all, single tag, multi-tag AND, case-insensitive, unknown tag matches nothing. Existing `applySecretFilters` tests (classification, expiry) updated for the new `ctx` parameter.

gofmt / go build / go test / gosec / golangci-lint all clean.

## Follow-ups

CLI `secret tag` (get/set) and a tag editor + filter chip in the web UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)