### PR TITLE
feat(projects): project hygiene summary — one-call security posture

### DIFF
--- a/internal/core/project_hygiene.go
+++ b/internal/core/project_hygiene.go
@@ -1,0 +1,80 @@
+// project_hygiene.go — a project's security-hygiene posture at a glance: one call that
+// counts the cleanup signals already computed individually elsewhere — secrets whose
+// owner departed ([[secret_orphaned]]), secrets unused for a long window, secrets
+// expiring/expired, and stale machine identities ([[machine_identities]]). Returns
+// COUNTS only (no names or values), so it is safe to surface broadly and cheap to poll
+// for a dashboard. Project-scoped (route-gated secrets.read).
+package core
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+)
+
+// ProjectHygiene is the count of each cleanup signal for a project.
+type ProjectHygiene struct {
+	OrphanedSecrets        int `json:"orphaned_secrets"`
+	UnusedSecrets          int `json:"unused_secrets"`
+	ExpiringSecrets        int `json:"expiring_secrets"` // expiring within the window, or already expired
+	StaleMachineIdentities int `json:"stale_machine_identities"`
+}
+
+// Hygiene-summary default windows (days). Each is overridable by the caller.
+const (
+	defaultHygieneUnusedDays   = 90
+	defaultHygieneExpiringDays = 30
+	defaultHygieneStaleMIDays  = 90
+)
+
+// ProjectHygieneSummary tallies the project's outstanding hygiene signals. The windows
+// (in days) default when non-positive. Counts only — never names or values.
+func (c *KeyorixCore) ProjectHygieneSummary(ctx context.Context, projectID uint, unusedDays, expiringDays, staleMIDays int) (*ProjectHygiene, error) {
+	if projectID == 0 {
+		return nil, fmt.Errorf("project ID is required")
+	}
+	if unusedDays <= 0 {
+		unusedDays = defaultHygieneUnusedDays
+	}
+	if expiringDays <= 0 {
+		expiringDays = defaultHygieneExpiringDays
+	}
+	if staleMIDays <= 0 {
+		staleMIDays = defaultHygieneStaleMIDays
+	}
+
+	out := &ProjectHygiene{}
+
+	orphaned, err := c.storage.ListOrphanedSecrets(ctx, projectID)
+	if err != nil {
+		return nil, fmt.Errorf("orphaned secrets: %w", err)
+	}
+	out.OrphanedSecrets = len(orphaned)
+
+	unused, err := c.UnusedSecrets(ctx, &projectID, unusedDays)
+	if err != nil {
+		return nil, fmt.Errorf("unused secrets: %w", err)
+	}
+	out.UnusedSecrets = len(unused)
+
+	// Expiring/expired: count secrets with an expiration before now+window. PageSize 1
+	// keeps it a count query — we only read the total.
+	cutoff := c.now().Add(time.Duration(expiringDays) * 24 * time.Hour)
+	_, expiring, err := c.storage.ListSecrets(ctx, &storage.SecretFilter{
+		ProjectID: &projectID, ExpiresBefore: &cutoff, Page: 1, PageSize: 1,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("expiring secrets: %w", err)
+	}
+	out.ExpiringSecrets = int(expiring)
+
+	staleMI, err := c.ListStaleMachineIdentities(ctx, projectID, time.Duration(staleMIDays)*24*time.Hour)
+	if err != nil {
+		return nil, fmt.Errorf("stale machine identities: %w", err)
+	}
+	out.StaleMachineIdentities = len(staleMI)
+
+	return out, nil
+}

--- a/internal/core/project_hygiene_test.go
+++ b/internal/core/project_hygiene_test.go
@@ -1,0 +1,86 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestProjectHygieneSummary(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	sqlDB, _ := db.DB()
+	sqlDB.SetMaxOpenConns(1)
+	require.NoError(t, db.AutoMigrate(
+		&models.SecretNode{}, &models.SecretVersion{}, &models.User{}, &models.Project{},
+		&models.Environment{}, &models.SecretAccessLog{}, &models.MachineIdentity{}, &models.AuditEvent{},
+	))
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "owner", Email: "o@t.com"}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 2, Username: "leaver", Email: "l@t.com"}).Error)
+
+	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
+	ctx := context.Background()
+	now := time.Now()
+
+	p, err := c.storage.CreateProject(ctx, &models.Project{Name: "p1"})
+	require.NoError(t, err)
+	e, err := c.storage.CreateEnvironment(ctx, &models.Environment{Name: "production", ProjectID: p.ID})
+	require.NoError(t, err)
+
+	mk := func(name string, ownerID uint, exp *time.Time) uint {
+		s, err := c.storage.CreateSecret(ctx, &models.SecretNode{
+			Name: name, ProjectID: p.ID, EnvironmentID: e.ID, Type: "password", OwnerID: ownerID,
+			IsSecret: true, Expiration: exp, CreatedAt: now, UpdatedAt: now,
+		})
+		require.NoError(t, err)
+		return s.ID
+	}
+
+	soon := now.Add(10 * 24 * time.Hour)
+	_ = mk("kept", 1, nil)              // not orphaned/expiring; unused (no read)
+	_ = mk("orphan", 2, nil)            // orphaned (owner 2 deleted); unused
+	_ = mk("expiring", 1, &soon)        // expiring within 30d; unused
+	freshID := mk("fresh-read", 1, nil) // has a recent read → not unused
+
+	// A recent read for fresh-read so it is not counted as unused.
+	require.NoError(t, c.storage.CreateSecretAccessLog(ctx, &models.SecretAccessLog{
+		SecretNodeID: freshID, AccessedBy: "owner", Action: "read", AccessTime: now,
+	}))
+
+	// Offboard user 2 so "orphan" is orphaned.
+	require.NoError(t, c.storage.DeleteUser(ctx, 2))
+
+	// Machine identities: one stale (active, last seen 200d ago), one fresh.
+	old := now.Add(-200 * 24 * time.Hour)
+	require.NoError(t, db.Create(&models.MachineIdentity{ProjectID: p.ID, Name: "ci-old", IdentityType: "ci", State: MachineActive, CreatedAt: old, LastSeenAt: &old}).Error)
+	require.NoError(t, db.Create(&models.MachineIdentity{ProjectID: p.ID, Name: "ci-new", IdentityType: "ci", State: MachineActive, CreatedAt: now, LastSeenAt: &now}).Error)
+
+	t.Run("counts each hygiene signal independently", func(t *testing.T) {
+		h, err := c.ProjectHygieneSummary(ctx, p.ID, 90, 30, 90)
+		require.NoError(t, err)
+		assert.Equal(t, 1, h.OrphanedSecrets, "only 'orphan' (owner deleted)")
+		assert.Equal(t, 1, h.ExpiringSecrets, "only 'expiring' within 30d")
+		assert.Equal(t, 1, h.StaleMachineIdentities, "only 'ci-old'")
+		assert.Equal(t, 3, h.UnusedSecrets, "kept + orphan + expiring; fresh-read excluded")
+	})
+
+	t.Run("a project ID of zero is rejected", func(t *testing.T) {
+		_, err := c.ProjectHygieneSummary(ctx, 0, 0, 0, 0)
+		require.Error(t, err)
+	})
+
+	t.Run("windows default when non-positive", func(t *testing.T) {
+		h, err := c.ProjectHygieneSummary(ctx, p.ID, 0, 0, 0)
+		require.NoError(t, err)
+		assert.Equal(t, 1, h.OrphanedSecrets)
+	})
+}

--- a/server/http/handlers/project_hygiene.go
+++ b/server/http/handlers/project_hygiene.go
@@ -1,0 +1,42 @@
+// project_hygiene.go — ProjectHygiene handler: a project's security-hygiene posture
+// (counts of orphaned / unused / expiring secrets and stale machine identities).
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/keyorixhq/keyorix/server/middleware"
+)
+
+// ProjectHygiene handles GET /api/v1/projects/{id}/hygiene — a one-call posture summary
+// for the project (counts only). Scoped secrets.read (project) is enforced by the
+// router. Optional ?unused_days / ?expiring_days / ?stale_days override the windows.
+func (h *SecretHandler) ProjectHygiene(w http.ResponseWriter, r *http.Request) {
+	if middleware.GetUserFromContext(r.Context()) == nil {
+		h.sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		h.sendError(w, "BadRequest", "Invalid project ID", http.StatusBadRequest, nil)
+		return
+	}
+	qint := func(key string) int {
+		if v := r.URL.Query().Get(key); v != "" {
+			if n, perr := strconv.Atoi(v); perr == nil {
+				return n
+			}
+		}
+		return 0
+	}
+
+	summary, err := h.coreService.ProjectHygieneSummary(r.Context(), uint(id),
+		qint("unused_days"), qint("expiring_days"), qint("stale_days"))
+	if err != nil {
+		h.sendError(w, "InternalError", "Failed to compute hygiene summary", http.StatusInternalServerError, nil)
+		return
+	}
+	h.sendSuccess(w, summary, "")
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -303,6 +303,7 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		r.With(customMiddleware.RequireScopedPermission("secrets.read", projectScope)).Post("/projects/{id}/secrets/render", secretHandler.RenderTemplate)
 		r.With(customMiddleware.RequireScopedPermission("secrets.read", projectScope)).Get("/projects/{id}/secrets/deleted", secretHandler.DeletedSecrets)
 		r.With(customMiddleware.RequireScopedPermission("secrets.read", projectScope)).Get("/projects/{id}/secrets/orphaned", secretHandler.OrphanedSecrets)
+		r.With(customMiddleware.RequireScopedPermission("secrets.read", projectScope)).Get("/projects/{id}/hygiene", secretHandler.ProjectHygiene)
 		r.With(customMiddleware.RequireScopedPermission("secrets.write", projectScope)).Post("/projects/{id}/secrets/suspend-all", secretHandler.SuspendProjectSecrets)
 		r.With(customMiddleware.RequireScopedPermission("secrets.write", projectScope)).Post("/projects/{id}/secrets/resume-all", secretHandler.ResumeProjectSecrets)
 		r.With(customMiddleware.RequireScopedPermission("secrets.write", projectScope)).Post("/projects/{id}/secrets/reassign-owner", secretHandler.ReassignOwner)


### PR DESCRIPTION
## What

A **project hygiene summary**: `GET /api/v1/projects/{id}/hygiene` returns, in one call, the counts of the project's outstanding cleanup signals:

```json
{ "orphaned_secrets": 1, "unused_secrets": 3, "expiring_secrets": 1, "stale_machine_identities": 1 }
```

It aggregates signals this codebase already computes individually — orphaned secrets (#326), unused secrets, expiring/expired secrets, stale machine identities (#319) — into an at-a-glance posture. **Counts only** (no names or values), so it's safe to surface broadly and cheap to poll for a dashboard.

## How

- **core** — `ProjectHygieneSummary(projectID, unusedDays, expiringDays, staleMIDays)` reuses `ListOrphanedSecrets` / `UnusedSecrets` / `ListStaleMachineIdentities` plus a count-only `ListSecrets(ExpiresBefore)` (PageSize 1, reads the total). Windows default when non-positive; zero `projectID` rejected.
- **http** — scoped `secrets.read` (project), with optional `?unused_days` / `?expiring_days` / `?stale_days` overrides.

## Security

- Project-scoped `secrets.read` route gate; returns only integer counts (no secret/identity names or values).

## Test

`TestProjectHygieneSummary`: each signal counted independently in one fixture (orphaned 1, expiring 1, stale MI 1, unused 3 — a fresh-read secret excluded), zero-ID rejected, windows default.

gofmt / go build / go test / gosec / golangci-lint all clean.

## Follow-ups

CLI `project hygiene` + a posture card on the web project page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)