### PR TITLE
release: prep v0.62.0 (CHANGELOG + Helm charts)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,26 @@
 All notable changes to Keyorix are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## v0.62.0 — 2026-06-19
+
+Secret tags and a project hygiene summary.
+
+### Added
+- **Secret tags** — free-form labels on a secret: `GET`/`PUT /secrets/{id}/tags`
+  (normalized: trimmed, lowercased, de-duplicated, ≤20 tags, ≤50 chars), plus
+  `keyorix secret tags --id N [--set a,b]` and a tag editor on the web secret
+  detail view. ([#335], [#337])
+- **Filter secrets by tag** — `GET /secrets?tag=prod&tag=tier1` (or
+  `?tag=prod,tier1`) returns only secrets carrying every requested tag (AND). ([#336])
+- **Project hygiene summary** — `GET /projects/{id}/hygiene` returns one-call
+  counts of the project's outstanding cleanup signals (orphaned, unused, and
+  expiring secrets; stale machine identities) for an at-a-glance posture. ([#338])
+
+[#335]: https://github.com/keyorixhq/keyorix/pull/335
+[#336]: https://github.com/keyorixhq/keyorix/pull/336
+[#337]: https://github.com/keyorixhq/keyorix/pull/337
+[#338]: https://github.com/keyorixhq/keyorix/pull/338
+
 ## v0.61.0 — 2026-06-18
 
 Offboarding & incident response: cut off a departing or compromised user across

--- a/deploy/helm/keyorix-k8s-sync/Chart.yaml
+++ b/deploy/helm/keyorix-k8s-sync/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix-k8s-sync
 description: Keyorix Kubernetes sync agent — materialises Keyorix secrets into native Kubernetes Secrets
 type: application
 # Chart version — tracks the Keyorix release version (published in lockstep).
-version: 0.61.0
+version: 0.62.0
 # The keyorix-k8s-sync image tag this chart deploys by default.
-appVersion: "0.61.0"
+appVersion: "0.62.0"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix

--- a/deploy/helm/keyorix/Chart.yaml
+++ b/deploy/helm/keyorix/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix
 description: Self-hosted Keyorix secrets manager (API server + web UI + PostgreSQL)
 type: application
 # Chart version — bump on chart changes.
-version: 0.61.0
+version: 0.62.0
 # The Keyorix app version this chart deploys by default (the image tag).
-appVersion: "0.61.0"
+appVersion: "0.62.0"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix


### PR DESCRIPTION
Release prep for **v0.62.0** — secret tags and a project hygiene summary.

### Bundled since v0.61.0
- **Secret tags** — `GET`/`PUT /secrets/{id}/tags` + `keyorix secret tags` + web tag editor ([#335], [#337])
- **Filter secrets by tag** — `GET /secrets?tag=…` (AND) ([#336])
- **Project hygiene summary** — `GET /projects/{id}/hygiene` (counts of orphaned/unused/expiring secrets + stale machine identities) ([#338])

(Web tag editor ships with the app: keyorix-web #71.)

### This PR
- CHANGELOG v0.62.0 section + PR link refs.
- Helm charts bumped lockstep to 0.62.0 (`keyorix` + `keyorix-k8s-sync`).

After merge: tag `v0.62.0` on main → release.yml (binaries + OCI charts) and docker-publish.yml (images).

🤖 Generated with [Claude Code](https://claude.com/claude-code)