### PR TITLE
feat(cli): project hygiene — show a project's security posture

### DIFF
--- a/internal/cli/project/hygiene.go
+++ b/internal/cli/project/hygiene.go
@@ -1,0 +1,61 @@
+package project
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/spf13/cobra"
+)
+
+// hygieneSummary mirrors the GET /projects/{id}/hygiene response (counts only).
+type hygieneSummary struct {
+	OrphanedSecrets        int `json:"orphaned_secrets"`
+	UnusedSecrets          int `json:"unused_secrets"`
+	ExpiringSecrets        int `json:"expiring_secrets"`
+	StaleMachineIdentities int `json:"stale_machine_identities"`
+}
+
+var hygieneCmd = &cobra.Command{
+	Use:   "hygiene <project-id>",
+	Short: "Show a project's security-hygiene posture (counts)",
+	Long: `Summarize a project's outstanding cleanup signals in one call: secrets whose owner
+departed, secrets unused for a long window, secrets expiring/expired, and stale machine
+identities. Requires secrets.read at the project scope.`,
+	Args:         cobra.ExactArgs(1),
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, args []string) error {
+		id, err := strconv.ParseUint(args[0], 10, 32)
+		if err != nil {
+			return fmt.Errorf("invalid project ID: %s", args[0])
+		}
+		c, ok := common.NewRemoteClient()
+		if !ok {
+			return fmt.Errorf("not connected to a server — run: keyorix connect <server>")
+		}
+		h, err := fetchHygiene(context.Background(), c, uint(id))
+		if err != nil {
+			return err
+		}
+		fmt.Printf("Hygiene for project %d:\n", id)
+		fmt.Printf("  orphaned secrets         %d\n", h.OrphanedSecrets)
+		fmt.Printf("  unused secrets           %d\n", h.UnusedSecrets)
+		fmt.Printf("  expiring/expired secrets %d\n", h.ExpiringSecrets)
+		fmt.Printf("  stale machine identities %d\n", h.StaleMachineIdentities)
+		return nil
+	},
+}
+
+// fetchHygiene GETs the project hygiene summary (split out for httptest tests).
+func fetchHygiene(ctx context.Context, c *common.RemoteClient, projectID uint) (*hygieneSummary, error) {
+	var out hygieneSummary
+	if err := c.Get(ctx, "/api/v1/projects/"+strconv.Itoa(int(projectID))+"/hygiene", &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func init() {
+	ProjectCmd.AddCommand(hygieneCmd)
+}

--- a/internal/cli/project/hygiene_remote_test.go
+++ b/internal/cli/project/hygiene_remote_test.go
@@ -1,0 +1,46 @@
+package project
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func hygieneStub(t *testing.T) (*common.RemoteClient, func()) {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/projects/7/hygiene" {
+			_, _ = w.Write([]byte(`{"data":{"orphaned_secrets":2,"unused_secrets":5,"expiring_secrets":1,"stale_machine_identities":3}}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	rc, ok := common.NewRemoteClient()
+	require.True(t, ok)
+	return rc, srv.Close
+}
+
+func TestFetchHygiene(t *testing.T) {
+	rc, done := hygieneStub(t)
+	defer done()
+	h, err := fetchHygiene(context.Background(), rc, 7)
+	require.NoError(t, err)
+	assert.Equal(t, 2, h.OrphanedSecrets)
+	assert.Equal(t, 5, h.UnusedSecrets)
+	assert.Equal(t, 1, h.ExpiringSecrets)
+	assert.Equal(t, 3, h.StaleMachineIdentities)
+}
+
+func TestFetchHygiene_NotFound(t *testing.T) {
+	rc, done := hygieneStub(t)
+	defer done()
+	_, err := fetchHygiene(context.Background(), rc, 999)
+	require.Error(t, err)
+}


### PR DESCRIPTION
## What

CLI for the project hygiene summary (#338):

```
keyorix project hygiene <project-id>
```

prints the project's outstanding cleanup counts — orphaned / unused / expiring secrets and stale machine identities.

## How

- GETs `/projects/{id}/hygiene` via `common.RemoteClient` (server enforces `secrets.read` @ project).
- `fetchHygiene` split out for httptest coverage.

## Test

`TestFetchHygiene` (all four counts parsed) + not-found error path. gofmt / go build / go test / gosec / golangci-lint all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)