### PR TITLE
feat(secrets): description/notes field on a secret

### DIFF
--- a/internal/core/secret_description.go
+++ b/internal/core/secret_description.go
@@ -1,0 +1,47 @@
+// secret_description.go — an optional free-text note on a secret (what it's for, which
+// upstream it belongs to, who to contact). Pure metadata: it is never the value and is
+// readable by anyone who can read the secret. Set requires write on the secret and is
+// audited. Settable at creation (CreateSecretRequest.Description) or later via this.
+package core
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// maxSecretDescriptionLen bounds the free-text note.
+const maxSecretDescriptionLen = 1024
+
+// SetSecretDescription sets (or clears, with "") the secret's description. The actor
+// must be able to write the secret. The note is trimmed and length-bounded. Audited.
+func (c *KeyorixCore) SetSecretDescription(ctx context.Context, actorID, secretID uint, description string) (*models.SecretNode, error) {
+	if _, err := c.EnforceSecretWritePermission(ctx, secretID, actorID); err != nil {
+		return nil, err
+	}
+	desc := strings.TrimSpace(description)
+	if len(desc) > maxSecretDescriptionLen {
+		return nil, fmt.Errorf("%s: description exceeds %d characters", i18n.T("ErrorValidation", nil), maxSecretDescriptionLen)
+	}
+	secret, err := c.storage.GetSecret(ctx, secretID)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorSecretNotFound", nil), err)
+	}
+	if secret.Description == desc {
+		return secret, nil // no-op
+	}
+	secret.Description = desc
+	secret.UpdatedAt = c.now()
+	updated, err := c.storage.UpdateSecret(ctx, secret)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	uid := actorID
+	sid := secretID
+	c.writeAuditEvent(ctx, "secret.description_updated", &uid, &sid,
+		fmt.Sprintf("updated description of secret %d", secretID))
+	return updated, nil
+}

--- a/internal/core/secret_description_test.go
+++ b/internal/core/secret_description_test.go
@@ -1,0 +1,89 @@
+package core
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestSetSecretDescription(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	sqlDB, _ := db.DB()
+	sqlDB.SetMaxOpenConns(1)
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.User{}, &models.AuditEvent{}))
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "owner", Email: "o@t.com"}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 2, Username: "mallory", Email: "m@t.com"}).Error)
+
+	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
+	ctx := context.Background()
+	secret, err := c.storage.CreateSecret(ctx, &models.SecretNode{
+		Name: "db", ProjectID: 1, EnvironmentID: 1, Type: "password", OwnerID: 1, IsSecret: true,
+		CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	})
+	require.NoError(t, err)
+
+	t.Run("owner sets a description (trimmed)", func(t *testing.T) {
+		got, err := c.SetSecretDescription(ctx, 1, secret.ID, "  prod DB password — contact dba@  ")
+		require.NoError(t, err)
+		assert.Equal(t, "prod DB password — contact dba@", got.Description)
+		read, _ := c.storage.GetSecret(ctx, secret.ID)
+		assert.Equal(t, "prod DB password — contact dba@", read.Description)
+	})
+
+	t.Run("clearing to empty works", func(t *testing.T) {
+		got, err := c.SetSecretDescription(ctx, 1, secret.ID, "")
+		require.NoError(t, err)
+		assert.Equal(t, "", got.Description)
+	})
+
+	t.Run("a non-writer is denied", func(t *testing.T) {
+		_, err := c.SetSecretDescription(ctx, 2, secret.ID, "nope")
+		require.Error(t, err)
+	})
+
+	t.Run("an over-long description is rejected", func(t *testing.T) {
+		_, err := c.SetSecretDescription(ctx, 1, secret.ID, strings.Repeat("a", maxSecretDescriptionLen+1))
+		require.Error(t, err)
+	})
+}
+
+func TestCreateSecret_Description(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	sqlDB, _ := db.DB()
+	sqlDB.SetMaxOpenConns(1)
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.Project{}, &models.Environment{}, &models.AuditEvent{}))
+	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
+	ctx := context.Background()
+	p, _ := c.storage.CreateProject(ctx, &models.Project{Name: "p1"})
+	e, _ := c.storage.CreateEnvironment(ctx, &models.Environment{Name: "production", ProjectID: p.ID})
+
+	t.Run("description is persisted at creation", func(t *testing.T) {
+		s, err := c.CreateSecret(ctx, &CreateSecretRequest{
+			Name: "db", Value: []byte("supersecret1"), ProjectID: p.ID, EnvironmentID: e.ID,
+			Type: "password", CreatedBy: "owner", OwnerID: 1, Description: "  the prod DB  ",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "the prod DB", s.Description)
+	})
+
+	t.Run("an over-long description is rejected at creation", func(t *testing.T) {
+		_, err := c.CreateSecret(ctx, &CreateSecretRequest{
+			Name: "db2", Value: []byte("supersecret1"), ProjectID: p.ID, EnvironmentID: e.ID,
+			Type: "password", CreatedBy: "owner", OwnerID: 1, Description: strings.Repeat("a", maxSecretDescriptionLen+1),
+		})
+		require.Error(t, err)
+	})
+}

--- a/internal/core/secrets.go
+++ b/internal/core/secrets.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/core/storage"
@@ -32,6 +33,8 @@ type CreateSecretRequest struct {
 	// Classification is an optional data-sensitivity label (A.5.12): "" or one of
 	// public|internal|confidential|restricted.
 	Classification string `json:"classification,omitempty"`
+	// Description is an optional free-text note (≤maxSecretDescriptionLen chars).
+	Description string `json:"description,omitempty"`
 }
 
 // UpdateSecretRequest represents a request to update an existing secret.
@@ -58,6 +61,9 @@ func (c *KeyorixCore) CreateSecret(ctx context.Context, req *CreateSecretRequest
 	if err := c.secretValuePolicy.Validate(req.Value); err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorValidation", nil), err)
 	}
+	if len(strings.TrimSpace(req.Description)) > maxSecretDescriptionLen {
+		return nil, fmt.Errorf("%s: description exceeds %d characters", i18n.T("ErrorValidation", nil), maxSecretDescriptionLen)
+	}
 
 	// Verify the environment belongs to the stated project.
 	env, err := c.storage.GetEnvironment(ctx, req.EnvironmentID)
@@ -82,6 +88,7 @@ func (c *KeyorixCore) CreateSecret(ctx context.Context, req *CreateSecretRequest
 		ProjectID:      req.ProjectID,
 		EnvironmentID:  req.EnvironmentID,
 		Type:           req.Type,
+		Description:    strings.TrimSpace(req.Description),
 		MaxReads:       req.MaxReads,
 		Expiration:     req.Expiration,
 		Classification: req.Classification,

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -426,9 +426,12 @@ type SecretNode struct {
 	Name          string `gorm:"not null"`
 	IsSecret      bool   `gorm:"default:false"`
 	Type          string
-	MaxReads      *int
-	Expiration    *time.Time
-	Metadata      JSON
+	// Description is an optional free-text note about the secret — what it is, which
+	// upstream it belongs to, who to contact. Metadata only; never the value.
+	Description string
+	MaxReads    *int
+	Expiration  *time.Time
+	Metadata    JSON
 	// Classification is the data sensitivity label (ISO 27001 A.5.12/A.5.13):
 	// "" = unclassified, else one of public|internal|confidential|restricted. Drives
 	// the classification posture and lets a review find high-sensitivity secrets.

--- a/server/http/handlers/secrets_description.go
+++ b/server/http/handlers/secrets_description.go
@@ -1,0 +1,51 @@
+// secrets_description.go — DescribeSecret handler: set/clear a secret's free-text note.
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/keyorixhq/keyorix/server/middleware"
+)
+
+// DescribeSecret handles PATCH /api/v1/secrets/{id}/description with {"description":"…"}
+// — set or clear the secret's free-text note. Gated by secrets.write at the secret's
+// scope (via the route middleware); core re-checks write access.
+func (h *SecretHandler) DescribeSecret(w http.ResponseWriter, r *http.Request) {
+	userCtx := middleware.GetUserFromContext(r.Context())
+	if userCtx == nil {
+		h.sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		h.sendError(w, "InvalidParameter", "Invalid secret ID", http.StatusBadRequest, nil)
+		return
+	}
+	var reqBody struct {
+		Description string `json:"description"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
+		h.sendError(w, "InvalidJSON", "Invalid JSON in request body", http.StatusBadRequest, nil)
+		return
+	}
+	secret, err := h.coreService.SetSecretDescription(r.Context(), userCtx.UserID, uint(id), reqBody.Description)
+	if err != nil {
+		status := http.StatusInternalServerError
+		msg := err.Error()
+		switch {
+		case strings.Contains(msg, "exceeds"):
+			status = http.StatusBadRequest
+		case strings.Contains(msg, "not found"):
+			status = http.StatusNotFound
+		case strings.Contains(msg, "permission") || strings.Contains(msg, "not authorized"):
+			status = http.StatusForbidden
+		}
+		h.sendError(w, "Error", msg, status, nil)
+		return
+	}
+	h.sendSuccess(w, secret, "Description updated")
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -340,6 +340,7 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.Post("/", secretHandler.CreateSecret)
 			r.With(customMiddleware.RequireScopedPermission("secrets.write", secretScope)).Put("/{id}", secretHandler.UpdateSecret)
 			r.With(customMiddleware.RequireScopedPermission("secrets.write", secretScope)).Patch("/{id}/classification", secretHandler.ClassifySecret)
+			r.With(customMiddleware.RequireScopedPermission("secrets.write", secretScope)).Patch("/{id}/description", secretHandler.DescribeSecret)
 			r.With(customMiddleware.RequireScopedPermission("secrets.write", secretScope)).Patch("/{id}/auto-rotate", secretHandler.SetAutoRotate)
 			r.With(customMiddleware.RequireScopedPermission("secrets.write", secretScope)).Post("/{id}/rotate", secretHandler.RotateSecret)
 			r.With(customMiddleware.RequireScopedPermission("secrets.write", secretScope)).Post("/{id}/rollback", secretHandler.RollbackSecret)


### PR DESCRIPTION
## What

A free-text **description** on a secret — what it's for, which upstream it belongs to, who to contact. Common metadata that was missing.

- Settable at creation (`CreateSecretRequest.description`) or later via `PATCH /api/v1/secrets/{id}/description` `{ "description": "…" }`.
- Surfaces automatically in the secret GET response.

## How

- **model** — `SecretNode.Description` (additive column; GORM AutoMigrate adds it). Pure metadata; never the value.
- **create** — accepted and persisted (trimmed, ≤1024 chars); over-long rejected.
- **update** — `SetSecretDescription(actorID, secretID, desc)`: write-gated (`EnforceSecretWritePermission`), trimmed, length-bounded, no-op when unchanged, audited (`secret.description_updated`). Reuses `GetSecret`/`UpdateSecret` — no new storage method.
- **http** — PATCH mirrors the classification PATCH; scoped `secrets.write`.

## Security

- Per-secret write authorization re-checked in core; the PATCH **returns 403 to the read-only persona** (verified).
- Metadata only — no secret value involved.

## Test

`TestSetSecretDescription` (set/trim, clear, non-writer denied, over-long rejected) and `TestCreateSecret_Description` (create-time persistence + over-long rejection).

gofmt / go build / go test / gosec / golangci-lint all clean.

## Follow-ups

CLI flag (`secret create --description`, `secret describe`) and a description field in the web create form + detail view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)