### PR TITLE
feat(cli): secret description — create flag + get/set command

### DIFF
--- a/internal/cli/secret/create.go
+++ b/internal/cli/secret/create.go
@@ -30,6 +30,7 @@ var (
 	createValue         string
 	createFromFile      string
 	createInteractive   bool
+	createDescription   string
 )
 
 var createCmd = &cobra.Command{
@@ -48,6 +49,7 @@ func init() {
 	createCmd.Flags().StringVar(&createValue, "value", "", "Secret value")
 	createCmd.Flags().StringVar(&createFromFile, "from-file", "", "Read secret value from file")
 	createCmd.Flags().BoolVar(&createInteractive, "interactive", false, "Interactive mode")
+	createCmd.Flags().StringVar(&createDescription, "description", "", "Optional free-text note about the secret")
 }
 
 func runCreate(cmd *cobra.Command, args []string) error {
@@ -85,6 +87,9 @@ func runCreateRemote(ctx context.Context, rc *common.RemoteClient, req *core.Cre
 	}
 	if req.Expiration != nil {
 		body["expiration"] = req.Expiration.Format(time.RFC3339)
+	}
+	if req.Description != "" {
+		body["description"] = req.Description
 	}
 
 	var secret models.SecretNode
@@ -157,6 +162,7 @@ func buildCreateRequest() (*core.CreateSecretRequest, error) {
 		Type:          createType,
 		ProjectID:     createProjectID,
 		EnvironmentID: createEnvironmentID,
+		Description:   createDescription,
 		CreatedBy:     "cli-user",
 	}
 

--- a/internal/cli/secret/description.go
+++ b/internal/cli/secret/description.go
@@ -1,0 +1,85 @@
+package secret
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/spf13/cobra"
+)
+
+var (
+	descID  uint
+	descSet string
+)
+
+var descriptionCmd = &cobra.Command{
+	Use:   "description",
+	Short: "Show or set a secret's description",
+	Long: `Show a secret's free-text note, or replace it with --set.
+
+Examples:
+  keyorix secret description --id 42                         # show the note
+  keyorix secret description --id 42 --set "prod DB; dba@"   # set the note
+  keyorix secret description --id 42 --set ""                # clear it
+
+Showing requires secrets.read; setting requires secrets.write at the secret's scope.`,
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		if descID == 0 {
+			return fmt.Errorf("--id is required")
+		}
+		c, ok := common.NewRemoteClient()
+		if !ok {
+			return fmt.Errorf("not connected to a server — run: keyorix connect <server>")
+		}
+		ctx := context.Background()
+
+		if cmd.Flags().Changed("set") {
+			if err := setSecretDescription(ctx, c, descID, descSet); err != nil {
+				return err
+			}
+		}
+		desc, err := getSecretDescription(ctx, c, descID)
+		if err != nil {
+			return err
+		}
+		if desc == "" {
+			fmt.Println("(no description)")
+			return nil
+		}
+		fmt.Println(desc)
+		return nil
+	},
+}
+
+// getSecretDescription reads the note from the secret GET (raw model: PascalCase
+// Description). Split out for httptest tests.
+func getSecretDescription(ctx context.Context, c *common.RemoteClient, id uint) (string, error) {
+	var body struct {
+		Description string `json:"Description"`
+		Desc2       string `json:"description"`
+	}
+	if err := c.Get(ctx, "/api/v1/secrets/"+strconv.Itoa(int(id)), &body); err != nil {
+		return "", err
+	}
+	if body.Description != "" {
+		return body.Description, nil
+	}
+	return body.Desc2, nil
+}
+
+// setSecretDescription PATCHes the secret's description. The endpoint returns the
+// updated secret; decode it into a throwaway so the response envelope is consumed.
+func setSecretDescription(ctx context.Context, c *common.RemoteClient, id uint, desc string) error {
+	var ignored struct{}
+	return c.Patch(ctx, "/api/v1/secrets/"+strconv.Itoa(int(id))+"/description",
+		map[string]string{"description": desc}, &ignored)
+}
+
+func init() {
+	descriptionCmd.Flags().UintVar(&descID, "id", 0, "Secret ID (required)")
+	descriptionCmd.Flags().StringVar(&descSet, "set", "", "Replace the description with this text (\"\" clears)")
+	SecretCmd.AddCommand(descriptionCmd)
+}

--- a/internal/cli/secret/description_remote_test.go
+++ b/internal/cli/secret/description_remote_test.go
@@ -1,0 +1,59 @@
+package secret
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func descStub(t *testing.T) (*common.RemoteClient, func()) {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/secrets/42":
+			// Raw model: PascalCase Description.
+			_, _ = w.Write([]byte(`{"data":{"ID":42,"Name":"db","Description":"prod DB; dba@"}}`))
+		case r.Method == http.MethodPatch && r.URL.Path == "/api/v1/secrets/42/description":
+			b, _ := io.ReadAll(r.Body)
+			var got map[string]string
+			_ = json.Unmarshal(b, &got)
+			// Echo back the updated secret (non-nil data, like the real handler).
+			_, _ = w.Write([]byte(`{"data":{"ID":42,"Name":"db","Description":"` + got["description"] + `"},"message":"Description updated"}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	rc, ok := common.NewRemoteClient()
+	require.True(t, ok)
+	return rc, srv.Close
+}
+
+func TestGetSecretDescription(t *testing.T) {
+	rc, done := descStub(t)
+	defer done()
+	d, err := getSecretDescription(context.Background(), rc, 42)
+	require.NoError(t, err)
+	assert.Equal(t, "prod DB; dba@", d)
+}
+
+func TestSetSecretDescription(t *testing.T) {
+	rc, done := descStub(t)
+	defer done()
+	require.NoError(t, setSecretDescription(context.Background(), rc, 42, "new note"))
+}
+
+func TestGetSecretDescription_NotFound(t *testing.T) {
+	rc, done := descStub(t)
+	defer done()
+	_, err := getSecretDescription(context.Background(), rc, 999)
+	require.Error(t, err)
+}


### PR DESCRIPTION
## What

Rounds out the secret description field (#341) on the CLI:

```
keyorix secret create --description "prod DB; dba@"   # set at creation
keyorix secret description --id 42                     # show
keyorix secret description --id 42 --set "…"           # set
keyorix secret description --id 42 --set ""            # clear
```

## How

- `secret create --description` includes the note in the create request (remote POST body + embedded path via `CreateSecretRequest.Description`).
- `secret description` shows or sets: show GETs the secret and reads the raw model's PascalCase `Description`; set PATCHes `/secrets/{id}/description`, decoding the returned secret into a throwaway so the response envelope is consumed (the decoder rejects unmarshaling into nil). Show-vs-set chosen by `cmd.Flags().Changed("set")`.

## Test

`TestGetSecretDescription` (parse), `TestSetSecretDescription` (PATCH round-trip), not-found error. gofmt / go build / go test / gosec / golangci-lint all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)