### PR TITLE
feat(secrets): list a project's expiring secrets (renewal triage)

### DIFF
--- a/internal/core/secret_expiring.go
+++ b/internal/core/secret_expiring.go
@@ -1,0 +1,57 @@
+// secret_expiring.go — list a project's secrets that are expiring (or already expired)
+// within a window, soonest-first, so an operator can renew or rotate them before they
+// lapse. The project hygiene summary ([[project_hygiene]]) counts these; this returns
+// the actual secrets to act on. Read-only and metadata-only — never a value.
+// Project-scoped (route-gated secrets.read).
+package core
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+const (
+	defaultExpiringWindowDays = 30
+	maxExpiringWindowDays     = 3650
+	expiringScanPageSize      = 500
+)
+
+// ListExpiringSecrets returns the project's secrets whose expiration falls before
+// now+window (already-expired included), soonest-first. `withinDays` is clamped to
+// [1, maxExpiringWindowDays]; non-positive falls back to the default. Metadata only.
+func (c *KeyorixCore) ListExpiringSecrets(ctx context.Context, projectID uint, withinDays int) ([]*models.SecretNode, error) {
+	if projectID == 0 {
+		return nil, fmt.Errorf("project ID is required")
+	}
+	if withinDays <= 0 {
+		withinDays = defaultExpiringWindowDays
+	}
+	if withinDays > maxExpiringWindowDays {
+		withinDays = maxExpiringWindowDays
+	}
+	cutoff := c.now().Add(time.Duration(withinDays) * 24 * time.Hour)
+
+	secrets, _, err := c.storage.ListSecrets(ctx, &storage.SecretFilter{
+		ProjectID:     &projectID,
+		ExpiresBefore: &cutoff,
+		Page:          1,
+		PageSize:      expiringScanPageSize,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("%w", err)
+	}
+	// Soonest expiration first (already-expired lead). A returned row always has a
+	// non-nil Expiration (the filter requires it), but guard defensively.
+	sort.SliceStable(secrets, func(i, j int) bool {
+		if secrets[i].Expiration == nil || secrets[j].Expiration == nil {
+			return secrets[j].Expiration != nil
+		}
+		return secrets[i].Expiration.Before(*secrets[j].Expiration)
+	})
+	return secrets, nil
+}

--- a/internal/core/secret_expiring_test.go
+++ b/internal/core/secret_expiring_test.go
@@ -1,0 +1,80 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestListExpiringSecrets(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	sqlDB, _ := db.DB()
+	sqlDB.SetMaxOpenConns(1)
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.Project{}, &models.Environment{}))
+	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
+	ctx := context.Background()
+	now := time.Now()
+
+	p, err := c.storage.CreateProject(ctx, &models.Project{Name: "p1"})
+	require.NoError(t, err)
+	e, err := c.storage.CreateEnvironment(ctx, &models.Environment{Name: "production", ProjectID: p.ID})
+	require.NoError(t, err)
+	p2, err := c.storage.CreateProject(ctx, &models.Project{Name: "p2"})
+	require.NoError(t, err)
+	e2, err := c.storage.CreateEnvironment(ctx, &models.Environment{Name: "production", ProjectID: p2.ID})
+	require.NoError(t, err)
+
+	mk := func(name string, projectID, envID uint, exp *time.Time) uint {
+		s, err := c.storage.CreateSecret(ctx, &models.SecretNode{
+			Name: name, ProjectID: projectID, EnvironmentID: envID, Type: "password", OwnerID: 1, IsSecret: true,
+			Expiration: exp, CreatedAt: now, UpdatedAt: now,
+		})
+		require.NoError(t, err)
+		return s.ID
+	}
+
+	expired := now.Add(-2 * 24 * time.Hour)
+	soon := now.Add(10 * 24 * time.Hour)
+	far := now.Add(100 * 24 * time.Hour)
+
+	expiredID := mk("expired", p.ID, e.ID, &expired)
+	soonID := mk("soon", p.ID, e.ID, &soon)
+	_ = mk("far", p.ID, e.ID, &far)      // outside a 30d window
+	_ = mk("never", p.ID, e.ID, nil)     // no expiration
+	_ = mk("other", p2.ID, e2.ID, &soon) // different project
+
+	t.Run("lists expiring/expired within the window, soonest-first, project-scoped", func(t *testing.T) {
+		got, err := c.ListExpiringSecrets(ctx, p.ID, 30)
+		require.NoError(t, err)
+		require.Len(t, got, 2, "expired + soon; far/never/other-project excluded")
+		assert.Equal(t, expiredID, got[0].ID, "already-expired leads")
+		assert.Equal(t, soonID, got[1].ID)
+	})
+
+	t.Run("a wider window includes the far one", func(t *testing.T) {
+		got, err := c.ListExpiringSecrets(ctx, p.ID, 200)
+		require.NoError(t, err)
+		assert.Len(t, got, 3)
+	})
+
+	t.Run("a project ID of zero is rejected", func(t *testing.T) {
+		_, err := c.ListExpiringSecrets(ctx, 0, 30)
+		require.Error(t, err)
+	})
+
+	t.Run("non-positive window falls back to the default (30d)", func(t *testing.T) {
+		got, err := c.ListExpiringSecrets(ctx, p.ID, 0)
+		require.NoError(t, err)
+		assert.Len(t, got, 2)
+	})
+}

--- a/server/http/handlers/secrets_expiring.go
+++ b/server/http/handlers/secrets_expiring.go
@@ -1,0 +1,63 @@
+// secrets_expiring.go — ExpiringSecrets handler: a project's secrets expiring (or
+// already expired) within a window, soonest-first, for proactive renewal.
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/keyorixhq/keyorix/server/middleware"
+)
+
+type expiringSecretEntry struct {
+	ID             uint   `json:"id"`
+	Name           string `json:"name"`
+	Type           string `json:"type"`
+	Classification string `json:"classification,omitempty"`
+	EnvironmentID  uint   `json:"environment_id"`
+	Expiration     string `json:"expiration,omitempty"`
+	Expired        bool   `json:"expired"`
+}
+
+// ExpiringSecrets handles GET /api/v1/projects/{id}/secrets/expiring?days=N — the
+// project's secrets expiring (or already expired) within the window, soonest-first.
+// Scoped secrets.read (project) is enforced by the router. days defaults to 30, cap 3650.
+func (h *SecretHandler) ExpiringSecrets(w http.ResponseWriter, r *http.Request) {
+	if middleware.GetUserFromContext(r.Context()) == nil {
+		h.sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		h.sendError(w, "BadRequest", "Invalid project ID", http.StatusBadRequest, nil)
+		return
+	}
+	days := 0
+	if v := r.URL.Query().Get("days"); v != "" {
+		if n, perr := strconv.Atoi(v); perr == nil {
+			days = n
+		}
+	}
+
+	secrets, err := h.coreService.ListExpiringSecrets(r.Context(), uint(id), days)
+	if err != nil {
+		h.sendError(w, "InternalError", "Failed to list expiring secrets", http.StatusInternalServerError, nil)
+		return
+	}
+
+	now := time.Now()
+	entries := make([]expiringSecretEntry, 0, len(secrets))
+	for _, s := range secrets {
+		e := expiringSecretEntry{
+			ID: s.ID, Name: s.Name, Type: s.Type, Classification: s.Classification, EnvironmentID: s.EnvironmentID,
+		}
+		if s.Expiration != nil {
+			e.Expiration = s.Expiration.UTC().Format(time.RFC3339)
+			e.Expired = s.Expiration.Before(now)
+		}
+		entries = append(entries, e)
+	}
+	h.sendSuccess(w, map[string]interface{}{"expiring": entries, "total": len(entries)}, "")
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -304,6 +304,7 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		r.With(customMiddleware.RequireScopedPermission("secrets.read", projectScope)).Get("/projects/{id}/secrets/deleted", secretHandler.DeletedSecrets)
 		r.With(customMiddleware.RequireScopedPermission("secrets.read", projectScope)).Get("/projects/{id}/secrets/orphaned", secretHandler.OrphanedSecrets)
 		r.With(customMiddleware.RequireScopedPermission("secrets.read", projectScope)).Get("/projects/{id}/hygiene", secretHandler.ProjectHygiene)
+		r.With(customMiddleware.RequireScopedPermission("secrets.read", projectScope)).Get("/projects/{id}/secrets/expiring", secretHandler.ExpiringSecrets)
 		r.With(customMiddleware.RequireScopedPermission("secrets.write", projectScope)).Post("/projects/{id}/secrets/suspend-all", secretHandler.SuspendProjectSecrets)
 		r.With(customMiddleware.RequireScopedPermission("secrets.write", projectScope)).Post("/projects/{id}/secrets/resume-all", secretHandler.ResumeProjectSecrets)
 		r.With(customMiddleware.RequireScopedPermission("secrets.write", projectScope)).Post("/projects/{id}/secrets/reassign-owner", secretHandler.ReassignOwner)


### PR DESCRIPTION
## What

Makes the project hygiene summary's **expiring** count actionable: `GET /api/v1/projects/{id}/secrets/expiring?days=N` lists the project's secrets expiring (or already expired) within the window, **soonest-first**, so an operator can renew or rotate them before they lapse.

Completes the pattern: the hygiene card counts (#338), this lists, the operator acts.

## How

- **core** — `ListExpiringSecrets(projectID, withinDays)` reuses the wired `ListSecrets(ProjectID, ExpiresBefore)` filter; window clamped to `[1,3650]` (default 30); sorts soonest-first (already-expired lead); zero `projectID` rejected. Metadata only.
- **http** — scoped `secrets.read` (project). DTO `id/name/type/classification/environment_id/expiration` + an `expired` flag.

## Security

- Project-scoped `secrets.read` route gate; metadata only — no secret value.

## Test

`TestListExpiringSecrets`: window filtering (expired + soon in; far / never-expiring / other-project out), soonest-first ordering, a wider window includes the far one, zero-ID rejected, default window.

gofmt / go build / go test / gosec / golangci-lint all clean.

## Follow-ups

CLI `secret expiring` and a "renew" prompt from the web hygiene card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)