### PR TITLE
release: prep v0.63.0 (CHANGELOG + Helm charts)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,26 @@
 All notable changes to Keyorix are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## v0.63.0 — 2026-06-19
+
+Secret descriptions and hygiene triage.
+
+### Added
+- **Secret description** — a free-text note on a secret (what it's for, its
+  upstream, who to contact): settable at creation and via
+  `PATCH /secrets/{id}/description`, plus `keyorix secret create --description`,
+  `keyorix secret description`, and a description editor on the web detail view. ([#341], [#342])
+- **List a project's expiring secrets** — `GET /projects/{id}/secrets/expiring?days=N`
+  lists secrets expiring (or already expired) within the window, soonest-first,
+  making the hygiene summary's expiring count actionable for renewal triage. ([#343])
+- **CLI `project hygiene`** — `keyorix project hygiene <id>` prints a project's
+  cleanup counts (orphaned / unused / expiring secrets, stale machine identities). ([#340])
+
+[#340]: https://github.com/keyorixhq/keyorix/pull/340
+[#341]: https://github.com/keyorixhq/keyorix/pull/341
+[#342]: https://github.com/keyorixhq/keyorix/pull/342
+[#343]: https://github.com/keyorixhq/keyorix/pull/343
+
 ## v0.62.0 — 2026-06-19
 
 Secret tags and a project hygiene summary.

--- a/deploy/helm/keyorix-k8s-sync/Chart.yaml
+++ b/deploy/helm/keyorix-k8s-sync/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix-k8s-sync
 description: Keyorix Kubernetes sync agent — materialises Keyorix secrets into native Kubernetes Secrets
 type: application
 # Chart version — tracks the Keyorix release version (published in lockstep).
-version: 0.62.0
+version: 0.63.0
 # The keyorix-k8s-sync image tag this chart deploys by default.
-appVersion: "0.62.0"
+appVersion: "0.63.0"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix

--- a/deploy/helm/keyorix/Chart.yaml
+++ b/deploy/helm/keyorix/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix
 description: Self-hosted Keyorix secrets manager (API server + web UI + PostgreSQL)
 type: application
 # Chart version — bump on chart changes.
-version: 0.62.0
+version: 0.63.0
 # The Keyorix app version this chart deploys by default (the image tag).
-appVersion: "0.62.0"
+appVersion: "0.63.0"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix


### PR DESCRIPTION
Release prep for **v0.63.0** — secret descriptions and hygiene triage.

### Bundled since v0.62.0
- **Secret description** — `PATCH /secrets/{id}/description` + create flag + CLI + web editor ([#341], [#342])
- **List expiring secrets** — `GET /projects/{id}/secrets/expiring?days=N` (renewal triage) ([#343])
- **CLI `project hygiene`** — `keyorix project hygiene <id>` ([#340])

(Web description editor ships with the app: keyorix-web #73; hygiene posture card #72.)

### This PR
- CHANGELOG v0.63.0 section + PR link refs.
- Helm charts bumped lockstep to 0.63.0.

After merge: tag `v0.63.0` → release.yml (binaries + OCI charts) and docker-publish.yml (images).

🤖 Generated with [Claude Code](https://claude.com/claude-code)