### PR TITLE
feat(audit): CSV export of audit logs (compliance hand-off)

### DIFF
--- a/server/http/handlers/audit_export_csv.go
+++ b/server/http/handlers/audit_export_csv.go
@@ -1,0 +1,104 @@
+// audit_export_csv.go — ExportAuditLogsCSV: a CSV download of audit events for
+// compliance hand-off and spreadsheets. Distinct from the JSON /audit/export (SIEM
+// pull): this is a single bounded, human/auditor-friendly file with a header row.
+package handlers
+
+import (
+	"encoding/csv"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/server/middleware"
+)
+
+// csvExportMaxRows bounds a single CSV download.
+const csvExportMaxRows = 10000
+
+// ExportAuditLogsCSV handles GET /api/v1/audit/export.csv — newest-first audit events
+// as a CSV attachment. Gated by audit.read (the /audit group). Filters: ?project_id,
+// ?user_id, ?since / ?until (RFC3339), ?limit (default 1000, cap csvExportMaxRows).
+func (h *AuditHandler) ExportAuditLogsCSV(w http.ResponseWriter, r *http.Request) {
+	if middleware.GetUserFromContext(r.Context()) == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+
+	limit := 1000
+	if l, err := strconv.Atoi(r.URL.Query().Get("limit")); err == nil && l > 0 && l <= csvExportMaxRows {
+		limit = l
+	}
+	filter := &storage.AuditFilter{PageSize: limit}
+	if v := r.URL.Query().Get("project_id"); v != "" {
+		if n, err := strconv.ParseUint(v, 10, 32); err == nil {
+			p := uint(n)
+			filter.ProjectID = &p
+		}
+	}
+	if v := r.URL.Query().Get("user_id"); v != "" {
+		if n, err := strconv.ParseUint(v, 10, 32); err == nil {
+			u := uint(n)
+			filter.UserID = &u
+		}
+	}
+	if v := r.URL.Query().Get("since"); v != "" {
+		if t, err := time.Parse(time.RFC3339, v); err == nil {
+			filter.StartTime = &t
+		}
+	}
+	if v := r.URL.Query().Get("until"); v != "" {
+		if t, err := time.Parse(time.RFC3339, v); err == nil {
+			filter.EndTime = &t
+		}
+	}
+
+	events, _, err := h.coreService.Storage().GetAuditLogs(r.Context(), filter)
+	if err != nil {
+		sendError(w, "InternalServerError", "Failed to export audit logs", http.StatusInternalServerError, nil)
+		return
+	}
+	actorNames := h.coreService.ResolveUsernames(r.Context(), events)
+	name := func(id *uint) string {
+		if id == nil {
+			return ""
+		}
+		return actorNames[*id]
+	}
+	uintStr := func(id *uint) string {
+		if id == nil {
+			return ""
+		}
+		return strconv.FormatUint(uint64(*id), 10)
+	}
+
+	w.Header().Set("Content-Type", "text/csv; charset=utf-8")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.Header().Set("Content-Disposition", `attachment; filename="audit-export.csv"`)
+
+	cw := csv.NewWriter(w)
+	defer cw.Flush()
+	_ = cw.Write([]string{
+		"id", "event_time", "event_type", "actor", "actor_type",
+		"user_id", "project_id", "secret_id", "ip_address", "success", "description",
+	})
+	for _, e := range events {
+		success := "true"
+		if e.Success != nil && !*e.Success {
+			success = "false"
+		}
+		_ = cw.Write([]string{
+			strconv.FormatUint(uint64(e.ID), 10),
+			e.EventTime.UTC().Format(time.RFC3339),
+			e.EventType,
+			name(e.UserID),
+			actorTypeOrDefault(e.ActorType),
+			uintStr(e.UserID),
+			uintStr(e.ProjectID),
+			uintStr(e.SecretNodeID),
+			e.IPAddress,
+			success,
+			e.Description,
+		})
+	}
+}

--- a/server/http/handlers/audit_export_csv_test.go
+++ b/server/http/handlers/audit_export_csv_test.go
@@ -1,0 +1,59 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestExportAuditLogsCSV(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.AuditEvent{}, &models.User{}))
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "alice", Email: "a@t.com"}).Error)
+
+	uid := uint(1)
+	pid := uint(5)
+	tru := true
+	require.NoError(t, db.Create(&models.AuditEvent{
+		EventType: "secret.created", UserID: &uid, ProjectID: &pid, Success: &tru,
+		Description: "created db", IPAddress: "10.0.0.1", EventTime: time.Now(),
+	}).Error)
+
+	h := NewAuditHandler(core.NewKeyorixCore(store.NewLocalStorage(db)))
+
+	t.Run("returns a CSV attachment with a header and the event", func(t *testing.T) {
+		req := withUserCtx(httptest.NewRequest(http.MethodGet, "/api/v1/audit/export.csv", nil))
+		w := httptest.NewRecorder()
+		h.ExportAuditLogsCSV(w, req)
+
+		require.Equal(t, http.StatusOK, w.Code)
+		assert.Contains(t, w.Header().Get("Content-Type"), "text/csv")
+		assert.Contains(t, w.Header().Get("Content-Disposition"), "audit-export.csv")
+
+		body := w.Body.String()
+		lines := strings.Split(strings.TrimSpace(body), "\n")
+		require.GreaterOrEqual(t, len(lines), 2)
+		assert.Equal(t, "id,event_time,event_type,actor,actor_type,user_id,project_id,secret_id,ip_address,success,description", strings.TrimSpace(lines[0]))
+		assert.Contains(t, body, "secret.created")
+		assert.Contains(t, body, "alice")
+		assert.Contains(t, body, "created db")
+	})
+
+	t.Run("requires a user context", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/audit/export.csv", nil)
+		w := httptest.NewRecorder()
+		h.ExportAuditLogsCSV(w, req)
+		assert.Equal(t, http.StatusUnauthorized, w.Code)
+	})
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -508,6 +508,7 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.Use(customMiddleware.RequirePermission("audit.read"))
 			r.Get("/logs", auditHandler.GetAuditLogs)
 			r.Get("/export", auditHandler.ExportAuditLogs)
+			r.Get("/export.csv", auditHandler.ExportAuditLogsCSV)
 			r.Get("/rbac-logs", auditHandler.GetRBACAuditLogs)
 			r.Get("/retention", auditHandler.GetAuditRetention)
 			r.Get("/verify", auditHandler.VerifyAuditChain)


### PR DESCRIPTION
## What

A **CSV download** of audit events for compliance hand-off and spreadsheets:

```
GET /api/v1/audit/export.csv?project_id=&user_id=&since=&until=&limit=
```

Returns a `text/csv` attachment (`audit-export.csv`), newest-first, with a header row and columns: `id, event_time, event_type, actor, actor_type, user_id, project_id, secret_id, ip_address, success, description`.

Distinct from the existing `/audit/export` (JSON, cursor-paginated, for **SIEM pull**) — this is a single bounded, auditor-friendly file.

## How

- Gated `audit.read` (the `/audit` route group).
- Filters: `?project_id`, `?user_id`, `?since` / `?until` (RFC3339), `?limit` (default 1000, cap 10000).
- Reuses `GetAuditLogs` + `ResolveUsernames`; `encoding/csv` handles field quoting/escaping.

## Test

`TestExportAuditLogsCSV`: returns a CSV attachment (correct Content-Type + Content-Disposition) with the header row and the seeded event (resolved actor name); requires a user context (401 otherwise).

gofmt / go build / go test / gosec / golangci-lint all clean. (The `/sw.js` + `evidence/verify` mutating-route failures are the known local-only ones — this is a GET.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)