### PR TITLE
feat(cli): audit export --csv (compliance hand-off from the terminal)

### DIFF
--- a/internal/cli/audit/audit.go
+++ b/internal/cli/audit/audit.go
@@ -12,6 +12,7 @@ package audit
 
 import (
 	"context"
+	"encoding/csv"
 	"encoding/json"
 	"fmt"
 	"net/url"
@@ -34,6 +35,7 @@ var (
 	flagAfterID uint
 	flagLimit   int
 	flagAll     bool
+	flagCSV     bool
 
 	// logs filters
 	logEventType string
@@ -51,6 +53,7 @@ func init() {
 	exportCmd.Flags().UintVar(&flagAfterID, "after-id", 0, "Resume after this event id (exclusive cursor)")
 	exportCmd.Flags().IntVar(&flagLimit, "limit", 100, "Events per page (1–1000)")
 	exportCmd.Flags().BoolVar(&flagAll, "all", false, "Follow the cursor to the end, emitting every event")
+	exportCmd.Flags().BoolVar(&flagCSV, "csv", false, "Emit CSV (header + one row per event) instead of NDJSON")
 
 	logsCmd.Flags().StringVar(&logEventType, "event-type", "", "Filter by event type (e.g. secret.read, secret.deleted)")
 	logsCmd.Flags().UintVar(&logUserID, "user-id", 0, "Filter by actor user id")
@@ -144,6 +147,28 @@ type exportPage struct {
 	NextCursor *uint             `json:"next_cursor"`
 }
 
+// csvEventRow is the subset of an exported audit event projected into CSV columns.
+type csvEventRow struct {
+	ID          uint   `json:"id"`
+	EventType   string `json:"event_type"`
+	Timestamp   string `json:"timestamp"`
+	Actor       string `json:"actor"`
+	ActorType   string `json:"actor_type"`
+	UserID      *uint  `json:"user_id"`
+	ProjectID   *uint  `json:"project_id"`
+	SecretID    *uint  `json:"secret_id"`
+	IPAddress   string `json:"ip_address"`
+	Success     bool   `json:"success"`
+	Description string `json:"description"`
+}
+
+func uintPtrStr(p *uint) string {
+	if p == nil {
+		return ""
+	}
+	return strconv.FormatUint(uint64(*p), 10)
+}
+
 var exportCmd = &cobra.Command{
 	Use:   "export",
 	Short: "Stream the audit feed as NDJSON (one event per line) for SIEM pull",
@@ -168,6 +193,15 @@ since a point in time with --since --all.`,
 			return err
 		}
 
+		var cw *csv.Writer
+		if flagCSV {
+			cw = csv.NewWriter(cmd.OutOrStdout())
+			_ = cw.Write([]string{
+				"id", "event_time", "event_type", "actor", "actor_type",
+				"user_id", "project_id", "secret_id", "ip_address", "success", "description",
+			})
+		}
+
 		after := flagAfterID
 		total := 0
 		var lastCursor *uint
@@ -186,6 +220,18 @@ since a point in time with --since --all.`,
 				return err
 			}
 			for _, e := range page.Events {
+				if cw != nil {
+					var row csvEventRow
+					if err := json.Unmarshal(e, &row); err != nil {
+						continue
+					}
+					_ = cw.Write([]string{
+						strconv.FormatUint(uint64(row.ID), 10), row.Timestamp, row.EventType,
+						row.Actor, row.ActorType, uintPtrStr(row.UserID), uintPtrStr(row.ProjectID),
+						uintPtrStr(row.SecretID), row.IPAddress, strconv.FormatBool(row.Success), row.Description,
+					})
+					continue
+				}
 				// json.RawMessage from the server is already compact (no newlines) → NDJSON.
 				_, _ = fmt.Fprintln(cmd.OutOrStdout(), string(e))
 			}
@@ -196,6 +242,9 @@ since a point in time with --since --all.`,
 				break
 			}
 			after = *page.NextCursor
+		}
+		if cw != nil {
+			cw.Flush()
 		}
 
 		if lastCursor != nil {

--- a/internal/cli/audit/audit_test.go
+++ b/internal/cli/audit/audit_test.go
@@ -228,3 +228,26 @@ func TestExport_Validation(t *testing.T) {
 		assert.Contains(t, err.Error(), "invalid --since")
 	})
 }
+
+func TestExport_CSV(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"events":[{"id":1,"event_type":"secret.created","timestamp":"2026-06-19T10:00:00Z","actor":"alice","actor_type":"user","user_id":7,"project_id":5,"ip_address":"10.0.0.1","success":true,"description":"created db"}],"count":1,"next_cursor":null}}`))
+	}))
+	defer srv.Close()
+	setRemote(t, srv.URL)
+
+	var out, errOut bytes.Buffer
+	exportCmd.SetOut(&out)
+	exportCmd.SetErr(&errOut)
+	flagSince, flagAfterID, flagLimit, flagAll, flagCSV = "", 0, 100, false, true
+	defer func() { flagCSV = false }()
+	require.NoError(t, exportCmd.RunE(exportCmd, nil))
+
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	require.Len(t, lines, 2, "header + one event row")
+	assert.Equal(t, "id,event_time,event_type,actor,actor_type,user_id,project_id,secret_id,ip_address,success,description", lines[0])
+	assert.Contains(t, lines[1], "secret.created")
+	assert.Contains(t, lines[1], "alice")
+	assert.Contains(t, lines[1], "created db")
+	assert.Contains(t, lines[1], "1,2026-06-19T10:00:00Z")
+}


### PR DESCRIPTION
## What

Pairs with the server CSV export (#345). `keyorix audit export --csv` emits the audit feed as CSV (header + one row per event) instead of NDJSON — pipe it to a file for an auditor or spreadsheet.

```
keyorix audit export --csv --all --since 2026-06-01T00:00:00Z > audit.csv
```

## How

- Reuses the existing cursor-follow loop (`--all`, `--since`, `--after-id`, `--limit`), formatting each fetched event client-side via `encoding/csv`. The per-run summary still goes to stderr so stdout stays clean.
- Columns: `id, event_time, event_type, actor, actor_type, user_id, project_id, secret_id, ip_address, success, description`.

## Test

`TestExport_CSV`: `--csv` emits a header + one row with the resolved actor and fields; the flag is reset after so it doesn't leak into the other export tests.

gofmt / go build / go test / gosec / golangci-lint all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)