### PR TITLE
feat(notifications): notify a recipient when a secret is shared with them

### DIFF
--- a/internal/core/notifications.go
+++ b/internal/core/notifications.go
@@ -20,6 +20,7 @@ const (
 	NotificationAccessRequested     = "access_request.created"
 	NotificationAccessApproved      = "access_request.approved"
 	NotificationAccessRejected      = "access_request.rejected"
+	NotificationSecretShared        = "secret.shared"
 )
 
 // approverRoleNames are the project/system roles whose holders can approve access
@@ -133,6 +134,24 @@ func (c *KeyorixCore) notifyAccessResolved(ctx context.Context, req *models.Acce
 		"Access request rejected",
 		fmt.Sprintf("Your request for access to %s was rejected.", label),
 		&pid, link)
+}
+
+// notifySecretShared tells a recipient a secret was shared with them directly. Group
+// shares are skipped (the grant is to the group, not an identifiable user to notify);
+// self-shares are skipped. Best-effort — failure never blocks the share.
+func (c *KeyorixCore) notifySecretShared(ctx context.Context, secret *models.SecretNode, recipientID, sharedBy uint, permission string) {
+	if secret == nil || recipientID == 0 || recipientID == sharedBy {
+		return
+	}
+	var pid *uint
+	if secret.ProjectID != 0 {
+		p := secret.ProjectID
+		pid = &p
+	}
+	c.notify(ctx, recipientID, NotificationSecretShared,
+		"Secret shared with you",
+		fmt.Sprintf("You were granted %s access to secret %q.", permission, secret.Name),
+		pid, fmt.Sprintf("/secrets/%d", secret.ID))
 }
 
 // ── Self-scoped reads/writes (the authenticated user) ───────────────────────

--- a/internal/core/notifications_test.go
+++ b/internal/core/notifications_test.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/stretchr/testify/assert"
@@ -117,4 +118,45 @@ func TestNotificationSelfScopedDelegations(t *testing.T) {
 	require.NoError(t, c.MarkNotificationRead(ctx, 5, 2))
 	require.NoError(t, c.MarkAllNotificationsRead(ctx, 2))
 	store.AssertExpectations(t)
+}
+
+func TestNotifySecretShared(t *testing.T) {
+	mkCore := func(store *MockStorage) *KeyorixCore {
+		return &KeyorixCore{storage: store, now: func() time.Time { return time.Unix(0, 0) }}
+	}
+	secret := &models.SecretNode{ID: 7, Name: "db", ProjectID: 3}
+
+	t.Run("notifies the recipient with type, message and link", func(t *testing.T) {
+		store := new(MockStorage)
+		c := mkCore(store)
+		ctx := context.Background()
+		var got *models.Notification
+		store.On("CreateNotification", ctx, mock.MatchedBy(func(n *models.Notification) bool {
+			got = n
+			return n.UserID == 2 && n.Type == NotificationSecretShared
+		})).Return(&models.Notification{ID: 1}, nil)
+
+		c.notifySecretShared(ctx, secret, 2, 1, "read")
+		store.AssertExpectations(t)
+		require.NotNil(t, got)
+		assert.Contains(t, got.Message, "read access")
+		assert.Contains(t, got.Message, "db")
+		assert.Equal(t, "/secrets/7", got.Link)
+		require.NotNil(t, got.ProjectID)
+		assert.Equal(t, uint(3), *got.ProjectID)
+	})
+
+	t.Run("skips a self-share (recipient == sharer)", func(t *testing.T) {
+		store := new(MockStorage)
+		c := mkCore(store)
+		c.notifySecretShared(context.Background(), secret, 1, 1, "read")
+		store.AssertNotCalled(t, "CreateNotification", mock.Anything, mock.Anything)
+	})
+
+	t.Run("skips a zero recipient", func(t *testing.T) {
+		store := new(MockStorage)
+		c := mkCore(store)
+		c.notifySecretShared(context.Background(), secret, 0, 1, "read")
+		store.AssertNotCalled(t, "CreateNotification", mock.Anything, mock.Anything)
+	})
 }

--- a/internal/core/sharing.go
+++ b/internal/core/sharing.go
@@ -86,6 +86,9 @@ func (c *KeyorixCore) ShareSecret(ctx context.Context, req *ShareSecretRequest) 
 		c.LogGroupShareCreated(ctx, auditCtx)
 	} else {
 		c.LogShareCreated(ctx, auditCtx)
+		// Tell the recipient they've been granted access (direct shares only —
+		// a group share has no single user to notify). Best-effort.
+		c.notifySecretShared(ctx, secret, req.RecipientID, req.SharedBy, req.Permission)
 	}
 
 	return createdShare, nil

--- a/internal/core/sharing_test.go
+++ b/internal/core/sharing_test.go
@@ -59,6 +59,8 @@ func TestKeyorixCore_ShareSecret(t *testing.T) {
 	mockStorage.On("GetSecret", ctx, uint(1)).Return(secret, nil)
 	mockStorage.On("CreateShareRecord", ctx, mock.AnythingOfType("*models.ShareRecord")).Return(shareRecord, nil)
 	mockStorage.On("LogAuditEvent", ctx, mock.AnythingOfType("*models.AuditEvent")).Return(nil)
+	// A direct share notifies the recipient (best-effort).
+	mockStorage.On("CreateNotification", ctx, mock.AnythingOfType("*models.Notification")).Return(&models.Notification{}, nil)
 
 	// Execute
 	result, err := core.ShareSecret(ctx, req)


### PR DESCRIPTION
## What

Sharing a secret didn't tell the recipient — they'd only discover the new access by stumbling on it. Now a **direct share fires an in-app notification** (and the configured external channel) to the recipient:

> Secret shared with you — *You were granted read access to secret "db".*

linking to the secret.

## How

- `notifySecretShared(secret, recipientID, sharedBy, permission)` via the existing `notify()` helper (new type `secret.shared`). Skips self-shares and zero recipients.
- Called from `ShareSecret` on **direct (non-group) shares only** — a group share has no single user to notify. Best-effort; never blocks the share.

## Test

`TestNotifySecretShared`: notifies the recipient with the right type / message / link / project; skips self-share and zero recipient. The existing `ShareSecret` mock test now expects the best-effort `CreateNotification`.

gofmt / go build / go test / gosec / golangci-lint all clean.

## Follow-ups

Notify on ownership transfer ("you now own X") and on share revocation; group-share fan-out to members.

🤖 Generated with [Claude Code](https://claude.com/claude-code)