### PR TITLE
feat(notifications): notify the new owner on ownership transfer

### DIFF
--- a/internal/core/notifications.go
+++ b/internal/core/notifications.go
@@ -16,11 +16,12 @@ import (
 
 // Notification types.
 const (
-	NotificationMembershipActivated = "membership.activated"
-	NotificationAccessRequested     = "access_request.created"
-	NotificationAccessApproved      = "access_request.approved"
-	NotificationAccessRejected      = "access_request.rejected"
-	NotificationSecretShared        = "secret.shared"
+	NotificationMembershipActivated        = "membership.activated"
+	NotificationAccessRequested            = "access_request.created"
+	NotificationAccessApproved             = "access_request.approved"
+	NotificationAccessRejected             = "access_request.rejected"
+	NotificationSecretShared               = "secret.shared"
+	NotificationSecretOwnershipTransferred = "secret.ownership_transferred"
 )
 
 // approverRoleNames are the project/system roles whose holders can approve access
@@ -152,6 +153,40 @@ func (c *KeyorixCore) notifySecretShared(ctx context.Context, secret *models.Sec
 		"Secret shared with you",
 		fmt.Sprintf("You were granted %s access to secret %q.", permission, secret.Name),
 		pid, fmt.Sprintf("/secrets/%d", secret.ID))
+}
+
+// notifySecretOwnershipTransferred tells a user they are now the owner of a secret.
+// Skipped when the actor transferred it to themselves. Best-effort.
+func (c *KeyorixCore) notifySecretOwnershipTransferred(ctx context.Context, secret *models.SecretNode, newOwnerID, actorID uint) {
+	if secret == nil || newOwnerID == 0 || newOwnerID == actorID {
+		return
+	}
+	var pid *uint
+	if secret.ProjectID != 0 {
+		p := secret.ProjectID
+		pid = &p
+	}
+	c.notify(ctx, newOwnerID, NotificationSecretOwnershipTransferred,
+		"You are now a secret owner",
+		fmt.Sprintf("You were made the owner of secret %q.", secret.Name),
+		pid, fmt.Sprintf("/secrets/%d", secret.ID))
+}
+
+// notifySecretsReassigned tells a new owner that a batch of secrets was re-homed to
+// them (bulk offboarding) — one summary instead of one-per-secret. Best-effort.
+func (c *KeyorixCore) notifySecretsReassigned(ctx context.Context, newOwnerID, actorID, projectID uint, count int) {
+	if newOwnerID == 0 || newOwnerID == actorID || count == 0 {
+		return
+	}
+	var pid *uint
+	if projectID != 0 {
+		p := projectID
+		pid = &p
+	}
+	c.notify(ctx, newOwnerID, NotificationSecretOwnershipTransferred,
+		"Secrets reassigned to you",
+		fmt.Sprintf("%d secret(s) in %s were reassigned to you.", count, c.projectLabel(ctx, projectID)),
+		pid, fmt.Sprintf("/projects/%d", projectID))
 }
 
 // ── Self-scoped reads/writes (the authenticated user) ───────────────────────

--- a/internal/core/notifications_test.go
+++ b/internal/core/notifications_test.go
@@ -160,3 +160,64 @@ func TestNotifySecretShared(t *testing.T) {
 		store.AssertNotCalled(t, "CreateNotification", mock.Anything, mock.Anything)
 	})
 }
+
+func TestNotifySecretOwnershipTransferred(t *testing.T) {
+	mkCore := func(store *MockStorage) *KeyorixCore {
+		return &KeyorixCore{storage: store, now: func() time.Time { return time.Unix(0, 0) }}
+	}
+	secret := &models.SecretNode{ID: 7, Name: "db", ProjectID: 3}
+
+	t.Run("notifies the new owner", func(t *testing.T) {
+		store := new(MockStorage)
+		c := mkCore(store)
+		ctx := context.Background()
+		var got *models.Notification
+		store.On("CreateNotification", ctx, mock.MatchedBy(func(n *models.Notification) bool {
+			got = n
+			return n.UserID == 2 && n.Type == NotificationSecretOwnershipTransferred
+		})).Return(&models.Notification{ID: 1}, nil)
+
+		c.notifySecretOwnershipTransferred(ctx, secret, 2, 1)
+		store.AssertExpectations(t)
+		require.NotNil(t, got)
+		assert.Contains(t, got.Message, "owner of secret")
+		assert.Equal(t, "/secrets/7", got.Link)
+	})
+
+	t.Run("skips a self-transfer (new owner == actor)", func(t *testing.T) {
+		store := new(MockStorage)
+		c := mkCore(store)
+		c.notifySecretOwnershipTransferred(context.Background(), secret, 1, 1)
+		store.AssertNotCalled(t, "CreateNotification", mock.Anything, mock.Anything)
+	})
+}
+
+func TestNotifySecretsReassigned(t *testing.T) {
+	mkCore := func(store *MockStorage) *KeyorixCore {
+		return &KeyorixCore{storage: store, now: func() time.Time { return time.Unix(0, 0) }}
+	}
+
+	t.Run("one summary notification with the count", func(t *testing.T) {
+		store := new(MockStorage)
+		c := mkCore(store)
+		ctx := context.Background()
+		var got *models.Notification
+		store.On("CreateNotification", ctx, mock.MatchedBy(func(n *models.Notification) bool {
+			got = n
+			return n.UserID == 3
+		})).Return(&models.Notification{ID: 1}, nil)
+
+		c.notifySecretsReassigned(ctx, 3, 1, 5, 4)
+		store.AssertExpectations(t)
+		require.NotNil(t, got)
+		assert.Contains(t, got.Message, "4 secret(s)")
+		assert.Equal(t, NotificationSecretOwnershipTransferred, got.Type)
+	})
+
+	t.Run("skips when nothing was reassigned", func(t *testing.T) {
+		store := new(MockStorage)
+		c := mkCore(store)
+		c.notifySecretsReassigned(context.Background(), 3, 1, 5, 0)
+		store.AssertNotCalled(t, "CreateNotification", mock.Anything, mock.Anything)
+	})
+}

--- a/internal/core/secret_ownership.go
+++ b/internal/core/secret_ownership.go
@@ -25,6 +25,19 @@ const EventSecretOwnerTransferred = "secret.owner_transferred"
 // longer exists) — so an active owner's secret can't be taken from under them, while a
 // departed owner's secrets can be recovered. newOwnerID must be an existing user.
 func (c *KeyorixCore) TransferSecretOwnership(ctx context.Context, secretID, newOwnerID, actorID uint) (*models.SecretNode, error) {
+	updated, err := c.transferOwnership(ctx, secretID, newOwnerID, actorID)
+	if err != nil {
+		return nil, err
+	}
+	// Tell the new owner they now own it (single transfer). Bulk reassignment uses
+	// transferOwnership directly and sends one summary instead. Best-effort.
+	c.notifySecretOwnershipTransferred(ctx, updated, newOwnerID, actorID)
+	return updated, nil
+}
+
+// transferOwnership performs the validated, audited ownership change without the
+// new-owner notification — the shared primitive for single and bulk transfer.
+func (c *KeyorixCore) transferOwnership(ctx context.Context, secretID, newOwnerID, actorID uint) (*models.SecretNode, error) {
 	if secretID == 0 || newOwnerID == 0 || actorID == 0 {
 		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "secret ID, new owner ID and actor ID are required")
 	}

--- a/internal/core/secret_reassign_owner.go
+++ b/internal/core/secret_reassign_owner.go
@@ -41,10 +41,13 @@ func (c *KeyorixCore) ReassignOwnedSecrets(ctx context.Context, projectID, fromO
 		if s.OwnerID != fromOwnerID {
 			continue
 		}
-		if _, err := c.TransferSecretOwnership(ctx, s.ID, toOwnerID, actorID); err != nil {
+		// Use the primitive (no per-secret notification) — one summary is sent below.
+		if _, err := c.transferOwnership(ctx, s.ID, toOwnerID, actorID); err != nil {
 			continue // skip per-secret failures; keep going
 		}
 		reassigned++
 	}
+	// One "N secrets reassigned to you" notification instead of one per secret.
+	c.notifySecretsReassigned(ctx, toOwnerID, actorID, projectID, reassigned)
 	return reassigned, nil
 }


### PR DESCRIPTION
## What

Extends the secret-sharing notification trigger (#347) to **ownership changes** — the new owner now learns they own a secret instead of finding out by accident.

- Single transfer → *"You were made the owner of secret X"*.
- Bulk reassignment (offboarding) → **one summary**: *"N secret(s) in <project> were reassigned to you"* (not one notification per secret).

## How

- `TransferSecretOwnership` notifies the new owner, skipping a self-transfer. The validated/audited change is factored into an internal `transferOwnership` primitive, so the notification is a thin wrapper on top.
- `ReassignOwnedSecrets` calls the primitive directly (no per-secret notification) and sends one `notifySecretsReassigned` summary at the end — informative without flooding.
- New type `secret.ownership_transferred`. Best-effort; never blocks the transfer.

## Test

`TestNotifySecretOwnershipTransferred` (new owner notified with type/message/link; self-transfer skipped) and `TestNotifySecretsReassigned` (summary carries the count; skipped when nothing reassigned). Existing transfer/reassign tests still green.

gofmt / go build / go test / gosec / golangci-lint all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)