### PR TITLE
feat(notifications): notify a recipient when their share is revoked

### DIFF
--- a/internal/core/notifications.go
+++ b/internal/core/notifications.go
@@ -21,6 +21,7 @@ const (
 	NotificationAccessApproved             = "access_request.approved"
 	NotificationAccessRejected             = "access_request.rejected"
 	NotificationSecretShared               = "secret.shared"
+	NotificationSecretShareRevoked         = "secret.share_revoked"
 	NotificationSecretOwnershipTransferred = "secret.ownership_transferred"
 )
 
@@ -152,6 +153,24 @@ func (c *KeyorixCore) notifySecretShared(ctx context.Context, secret *models.Sec
 	c.notify(ctx, recipientID, NotificationSecretShared,
 		"Secret shared with you",
 		fmt.Sprintf("You were granted %s access to secret %q.", permission, secret.Name),
+		pid, fmt.Sprintf("/secrets/%d", secret.ID))
+}
+
+// notifySecretShareRevoked tells a recipient their access to a secret was revoked.
+// Direct shares only (a group share has no single user); skips the actor revoking
+// their own share. Best-effort.
+func (c *KeyorixCore) notifySecretShareRevoked(ctx context.Context, secret *models.SecretNode, recipientID, revokedBy uint) {
+	if secret == nil || recipientID == 0 || recipientID == revokedBy {
+		return
+	}
+	var pid *uint
+	if secret.ProjectID != 0 {
+		p := secret.ProjectID
+		pid = &p
+	}
+	c.notify(ctx, recipientID, NotificationSecretShareRevoked,
+		"Secret access revoked",
+		fmt.Sprintf("Your access to secret %q was revoked.", secret.Name),
 		pid, fmt.Sprintf("/secrets/%d", secret.ID))
 }
 

--- a/internal/core/notifications_test.go
+++ b/internal/core/notifications_test.go
@@ -221,3 +221,34 @@ func TestNotifySecretsReassigned(t *testing.T) {
 		store.AssertNotCalled(t, "CreateNotification", mock.Anything, mock.Anything)
 	})
 }
+
+func TestNotifySecretShareRevoked(t *testing.T) {
+	mkCore := func(store *MockStorage) *KeyorixCore {
+		return &KeyorixCore{storage: store, now: func() time.Time { return time.Unix(0, 0) }}
+	}
+	secret := &models.SecretNode{ID: 7, Name: "db", ProjectID: 3}
+
+	t.Run("notifies the recipient their access was revoked", func(t *testing.T) {
+		store := new(MockStorage)
+		c := mkCore(store)
+		ctx := context.Background()
+		var got *models.Notification
+		store.On("CreateNotification", ctx, mock.MatchedBy(func(n *models.Notification) bool {
+			got = n
+			return n.UserID == 2 && n.Type == NotificationSecretShareRevoked
+		})).Return(&models.Notification{ID: 1}, nil)
+
+		c.notifySecretShareRevoked(ctx, secret, 2, 1)
+		store.AssertExpectations(t)
+		require.NotNil(t, got)
+		assert.Contains(t, got.Message, "access to secret")
+		assert.Equal(t, "/secrets/7", got.Link)
+	})
+
+	t.Run("skips when the actor revokes their own share", func(t *testing.T) {
+		store := new(MockStorage)
+		c := mkCore(store)
+		c.notifySecretShareRevoked(context.Background(), secret, 1, 1)
+		store.AssertNotCalled(t, "CreateNotification", mock.Anything, mock.Anything)
+	})
+}

--- a/internal/core/sharing.go
+++ b/internal/core/sharing.go
@@ -181,6 +181,10 @@ func (c *KeyorixCore) RevokeShare(ctx context.Context, shareID uint, revokedBy u
 	if err := c.storage.DeleteShareRecord(ctx, shareID); err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}
+	// Tell the recipient their access was revoked (direct shares only). Best-effort.
+	if !shareRecord.IsGroup {
+		c.notifySecretShareRevoked(ctx, secret, shareRecord.RecipientID, revokedBy)
+	}
 	return nil
 }
 

--- a/internal/core/sharing_test.go
+++ b/internal/core/sharing_test.go
@@ -256,6 +256,8 @@ func TestKeyorixCore_RevokeShare(t *testing.T) {
 	mockStorage.On("GetSecret", ctx, uint(1)).Return(secret, nil)
 	mockStorage.On("DeleteShareRecord", ctx, uint(1)).Return(nil)
 	mockStorage.On("LogAuditEvent", ctx, mock.AnythingOfType("*models.AuditEvent")).Return(nil)
+	// Revoking a direct share notifies the recipient (best-effort).
+	mockStorage.On("CreateNotification", ctx, mock.AnythingOfType("*models.Notification")).Return(&models.Notification{}, nil)
 
 	// Execute
 	err := core.RevokeShare(ctx, 1, 1)


### PR DESCRIPTION
## What

Completes the share-lifecycle notifications (#347 share granted, #348 ownership): a user whose access is **revoked** now learns about it instead of silently losing access.

> Secret access revoked — *Your access to secret "db" was revoked.*

## How

- `RevokeShare` notifies the recipient for **direct shares only** (a group share has no single user); skips the actor revoking their own share. New type `secret.share_revoked`. Best-effort; never blocks the revoke.

## Test

`TestNotifySecretShareRevoked`: recipient notified with type/message/link; skipped on self-revoke. The existing `RevokeShare` mock test now expects the best-effort `CreateNotification`.

gofmt / go build / go test / gosec / golangci-lint all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)