### PR TITLE
feat(notifications): fan share/revoke notices out to group members

### DIFF
--- a/internal/core/notifications.go
+++ b/internal/core/notifications.go
@@ -138,9 +138,8 @@ func (c *KeyorixCore) notifyAccessResolved(ctx context.Context, req *models.Acce
 		&pid, link)
 }
 
-// notifySecretShared tells a recipient a secret was shared with them directly. Group
-// shares are skipped (the grant is to the group, not an identifiable user to notify);
-// self-shares are skipped. Best-effort — failure never blocks the share.
+// notifySecretShared tells a recipient a secret was shared with them directly. Self-
+// shares are skipped. Best-effort — failure never blocks the share.
 func (c *KeyorixCore) notifySecretShared(ctx context.Context, secret *models.SecretNode, recipientID, sharedBy uint, permission string) {
 	if secret == nil || recipientID == 0 || recipientID == sharedBy {
 		return
@@ -154,6 +153,22 @@ func (c *KeyorixCore) notifySecretShared(ctx context.Context, secret *models.Sec
 		"Secret shared with you",
 		fmt.Sprintf("You were granted %s access to secret %q.", permission, secret.Name),
 		pid, fmt.Sprintf("/secrets/%d", secret.ID))
+}
+
+// notifyGroupSecretShared fans the "shared with you" notification out to every member
+// of a group a secret was shared with (excluding the sharer). Best-effort — a member
+// lookup failure just means no fan-out.
+func (c *KeyorixCore) notifyGroupSecretShared(ctx context.Context, secret *models.SecretNode, groupID, sharedBy uint, permission string) {
+	if secret == nil {
+		return
+	}
+	members, err := c.storage.ListGroupMembers(ctx, groupID)
+	if err != nil {
+		return
+	}
+	for _, m := range members {
+		c.notifySecretShared(ctx, secret, m.ID, sharedBy, permission)
+	}
 }
 
 // notifySecretShareRevoked tells a recipient their access to a secret was revoked.
@@ -172,6 +187,21 @@ func (c *KeyorixCore) notifySecretShareRevoked(ctx context.Context, secret *mode
 		"Secret access revoked",
 		fmt.Sprintf("Your access to secret %q was revoked.", secret.Name),
 		pid, fmt.Sprintf("/secrets/%d", secret.ID))
+}
+
+// notifyGroupSecretShareRevoked fans the revoke notification out to every member of a
+// group whose share was revoked (excluding the actor). Best-effort.
+func (c *KeyorixCore) notifyGroupSecretShareRevoked(ctx context.Context, secret *models.SecretNode, groupID, revokedBy uint) {
+	if secret == nil {
+		return
+	}
+	members, err := c.storage.ListGroupMembers(ctx, groupID)
+	if err != nil {
+		return
+	}
+	for _, m := range members {
+		c.notifySecretShareRevoked(ctx, secret, m.ID, revokedBy)
+	}
 }
 
 // notifySecretOwnershipTransferred tells a user they are now the owner of a secret.

--- a/internal/core/notifications_test.go
+++ b/internal/core/notifications_test.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -251,4 +252,33 @@ func TestNotifySecretShareRevoked(t *testing.T) {
 		c.notifySecretShareRevoked(context.Background(), secret, 1, 1)
 		store.AssertNotCalled(t, "CreateNotification", mock.Anything, mock.Anything)
 	})
+}
+
+func TestNotifyGroupSecretShared(t *testing.T) {
+	store := new(MockStorage)
+	c := &KeyorixCore{storage: store, now: func() time.Time { return time.Unix(0, 0) }}
+	ctx := context.Background()
+	secret := &models.SecretNode{ID: 7, Name: "db", ProjectID: 3}
+
+	// Group 9 has members 1 (the sharer), 2, 3.
+	store.On("ListGroupMembers", ctx, uint(9)).Return([]*models.User{{ID: 1}, {ID: 2}, {ID: 3}}, nil)
+	notified := map[uint]bool{}
+	store.On("CreateNotification", ctx, mock.MatchedBy(func(n *models.Notification) bool {
+		notified[n.UserID] = true
+		return n.Type == NotificationSecretShared
+	})).Return(&models.Notification{ID: 1}, nil)
+
+	c.notifyGroupSecretShared(ctx, secret, 9, 1, "read")
+
+	assert.True(t, notified[2] && notified[3], "members 2 and 3 notified")
+	assert.False(t, notified[1], "the sharer is not notified of their own grant")
+}
+
+func TestNotifyGroupSecretShared_LookupErrorIsNoOp(t *testing.T) {
+	store := new(MockStorage)
+	c := &KeyorixCore{storage: store, now: func() time.Time { return time.Unix(0, 0) }}
+	ctx := context.Background()
+	store.On("ListGroupMembers", ctx, uint(9)).Return(nil, errors.New("boom"))
+	c.notifyGroupSecretShared(ctx, &models.SecretNode{ID: 7}, 9, 1, "read")
+	store.AssertNotCalled(t, "CreateNotification", mock.Anything, mock.Anything)
 }

--- a/internal/core/sharing.go
+++ b/internal/core/sharing.go
@@ -84,10 +84,11 @@ func (c *KeyorixCore) ShareSecret(ctx context.Context, req *ShareSecretRequest) 
 	}
 	if req.IsGroup {
 		c.LogGroupShareCreated(ctx, auditCtx)
+		// Fan the "shared with you" notice out to each group member. Best-effort.
+		c.notifyGroupSecretShared(ctx, secret, req.RecipientID, req.SharedBy, req.Permission)
 	} else {
 		c.LogShareCreated(ctx, auditCtx)
-		// Tell the recipient they've been granted access (direct shares only —
-		// a group share has no single user to notify). Best-effort.
+		// Tell the recipient they've been granted access. Best-effort.
 		c.notifySecretShared(ctx, secret, req.RecipientID, req.SharedBy, req.Permission)
 	}
 
@@ -181,8 +182,10 @@ func (c *KeyorixCore) RevokeShare(ctx context.Context, shareID uint, revokedBy u
 	if err := c.storage.DeleteShareRecord(ctx, shareID); err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}
-	// Tell the recipient their access was revoked (direct shares only). Best-effort.
-	if !shareRecord.IsGroup {
+	// Tell the affected user(s) their access was revoked. Best-effort.
+	if shareRecord.IsGroup {
+		c.notifyGroupSecretShareRevoked(ctx, secret, shareRecord.RecipientID, revokedBy)
+	} else {
 		c.notifySecretShareRevoked(ctx, secret, shareRecord.RecipientID, revokedBy)
 	}
 	return nil


### PR DESCRIPTION
## What

Closes the gap in the share-lifecycle notifications (#347 grant / #349 revoke): sharing a secret with a **group**, or revoking a group share, now notifies **each member** — not just direct-user shares.

## How

- `notifyGroupSecretShared` / `notifyGroupSecretShareRevoked` expand the group via `ListGroupMembers` and reuse the per-user notify helpers (which already skip the actor/self).
- `ShareSecret` and `RevokeShare` now notify in **both** the group and direct branches.
- Best-effort: a member-lookup failure simply means no fan-out, never blocking the share/revoke.

## Test

`TestNotifyGroupSecretShared`: a group share notifies every member except the sharer; `TestNotifyGroupSecretShared_LookupErrorIsNoOp`: a member-lookup error produces no notifications.

gofmt / go build / go test / gosec / golangci-lint all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)