### PR TITLE
feat(cli): secret expiring — list a project's expiring secrets

### DIFF
--- a/internal/cli/secret/expiring.go
+++ b/internal/cli/secret/expiring.go
@@ -1,0 +1,81 @@
+package secret
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/spf13/cobra"
+)
+
+var (
+	expiringProject uint
+	expiringDays    int
+)
+
+// expiringRow mirrors a GET /projects/{id}/secrets/expiring entry (snake_case DTO).
+type expiringRow struct {
+	ID            uint   `json:"id"`
+	Name          string `json:"name"`
+	Type          string `json:"type"`
+	EnvironmentID uint   `json:"environment_id"`
+	Expiration    string `json:"expiration"`
+	Expired       bool   `json:"expired"`
+}
+
+var expiringCmd = &cobra.Command{
+	Use:   "expiring",
+	Short: "List a project's secrets expiring (or already expired) within a window",
+	Long: `Show a project's secrets expiring soon (or already expired), soonest-first, so you can
+renew or rotate them before they lapse. Requires secrets.read at the project scope.`,
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		if expiringProject == 0 {
+			return fmt.Errorf("--project is required")
+		}
+		c, ok := common.NewRemoteClient()
+		if !ok {
+			return fmt.Errorf("not connected to a server — run: keyorix connect <server>")
+		}
+		rows, err := fetchExpiring(context.Background(), c, expiringProject, expiringDays)
+		if err != nil {
+			return err
+		}
+		if len(rows) == 0 {
+			fmt.Println("No expiring secrets.")
+			return nil
+		}
+		fmt.Printf("%-8s %-24s %-12s %-10s %s\n", "ID", "NAME", "TYPE", "STATE", "EXPIRES")
+		for _, r := range rows {
+			state := "expiring"
+			if r.Expired {
+				state = "EXPIRED"
+			}
+			fmt.Printf("%-8d %-24s %-12s %-10s %s\n", r.ID, r.Name, r.Type, state, r.Expiration)
+		}
+		return nil
+	},
+}
+
+// fetchExpiring GETs the project's expiring secrets (split out for httptest tests).
+// days <= 0 lets the server default (30).
+func fetchExpiring(ctx context.Context, c *common.RemoteClient, projectID uint, days int) ([]expiringRow, error) {
+	path := "/api/v1/projects/" + strconv.Itoa(int(projectID)) + "/secrets/expiring"
+	if days > 0 {
+		path += "?days=" + strconv.Itoa(days)
+	}
+	var body struct {
+		Expiring []expiringRow `json:"expiring"`
+	}
+	if err := c.Get(ctx, path, &body); err != nil {
+		return nil, err
+	}
+	return body.Expiring, nil
+}
+
+func init() {
+	expiringCmd.Flags().UintVar(&expiringProject, "project", 0, "Project ID (required)")
+	expiringCmd.Flags().IntVar(&expiringDays, "days", 0, "Window in days (default server-side: 30, cap 3650)")
+	SecretCmd.AddCommand(expiringCmd)
+}

--- a/internal/cli/secret/expiring_remote_test.go
+++ b/internal/cli/secret/expiring_remote_test.go
@@ -1,0 +1,47 @@
+package secret
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func expiringStub(t *testing.T) (*common.RemoteClient, func()) {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/projects/4/secrets/expiring" {
+			_, _ = w.Write([]byte(`{"data":{"expiring":[{"id":9,"name":"old-cert","type":"certificate","environment_id":2,"expiration":"2026-06-10T00:00:00Z","expired":true},{"id":8,"name":"api-key","type":"token","environment_id":2,"expiration":"2026-06-25T00:00:00Z","expired":false}],"total":2}}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	rc, ok := common.NewRemoteClient()
+	require.True(t, ok)
+	return rc, srv.Close
+}
+
+func TestFetchExpiring(t *testing.T) {
+	rc, done := expiringStub(t)
+	defer done()
+	rows, err := fetchExpiring(context.Background(), rc, 4, 30)
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+	assert.Equal(t, uint(9), rows[0].ID)
+	assert.True(t, rows[0].Expired)
+	assert.Equal(t, "api-key", rows[1].Name)
+	assert.False(t, rows[1].Expired)
+}
+
+func TestFetchExpiring_NotFound(t *testing.T) {
+	rc, done := expiringStub(t)
+	defer done()
+	_, err := fetchExpiring(context.Background(), rc, 999, 0)
+	require.Error(t, err)
+}


### PR DESCRIPTION
## What

CLI for the expiring-secrets triage list (#343), alongside `secret orphaned`:

```
keyorix secret expiring --project <id> [--days N]
```

prints the project's secrets expiring soon (or already expired), soonest-first — `ID / NAME / TYPE / STATE / EXPIRES`, where `STATE` flags already-`EXPIRED` rows.

## How

- GETs `/projects/{id}/secrets/expiring` via `common.RemoteClient` (server enforces `secrets.read` @ project).
- `fetchExpiring` split out for httptest coverage.

## Test

`TestFetchExpiring` (parse incl expired flag + ordering) + not-found error path. gofmt / go build / go test / gosec / golangci-lint all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)