### PR TITLE
feat(cli): secret info — one-shot metadata summary (no value)

### DIFF
--- a/internal/cli/secret/info.go
+++ b/internal/cli/secret/info.go
@@ -1,0 +1,101 @@
+package secret
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/spf13/cobra"
+)
+
+var infoID uint
+
+// infoView captures the metadata fields of a secret from the GET (raw model,
+// PascalCase JSON). The value is never fetched.
+type infoView struct {
+	ID             uint   `json:"ID"`
+	Name           string `json:"Name"`
+	Type           string `json:"Type"`
+	Classification string `json:"Classification"`
+	Status         string `json:"Status"`
+	Description    string `json:"Description"`
+	OwnerID        uint   `json:"OwnerID"`
+	IsShared       bool   `json:"IsShared"`
+	CreatedBy      string `json:"CreatedBy"`
+	Expiration     string `json:"Expiration"`
+	LastRotatedAt  string `json:"LastRotatedAt"`
+}
+
+var infoCmd = &cobra.Command{
+	Use:   "info",
+	Short: "Show a secret's metadata (no value)",
+	Long: `Print a one-shot summary of a secret's metadata — type, classification, status,
+description, owner, expiration, and tags — without retrieving the value. Requires
+secrets.read at the secret's scope.`,
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		if infoID == 0 {
+			return fmt.Errorf("--id is required")
+		}
+		c, ok := common.NewRemoteClient()
+		if !ok {
+			return fmt.Errorf("not connected to a server — run: keyorix connect <server>")
+		}
+		ctx := context.Background()
+		v, err := fetchInfo(ctx, c, infoID)
+		if err != nil {
+			return err
+		}
+		// Tags are a separate endpoint; best-effort (don't fail the summary on it).
+		tags, _ := getSecretTags(ctx, c, infoID)
+
+		line := func(label, val string) {
+			if val == "" {
+				val = "—"
+			}
+			fmt.Printf("  %-14s %s\n", label, val)
+		}
+		fmt.Printf("Secret %d: %s\n", v.ID, v.Name)
+		line("type", v.Type)
+		line("status", orDefault(v.Status, "active"))
+		line("classification", orDefault(v.Classification, "unclassified"))
+		line("owner", fmt.Sprintf("user #%d", v.OwnerID))
+		line("shared", boolWord(v.IsShared))
+		line("created by", v.CreatedBy)
+		line("expiration", v.Expiration)
+		line("last rotated", v.LastRotatedAt)
+		line("tags", strings.Join(tags, ", "))
+		line("description", v.Description)
+		return nil
+	},
+}
+
+func orDefault(v, def string) string {
+	if v == "" {
+		return def
+	}
+	return v
+}
+
+func boolWord(b bool) string {
+	if b {
+		return "yes"
+	}
+	return "no"
+}
+
+// fetchInfo GETs a secret's metadata (split out for httptest tests).
+func fetchInfo(ctx context.Context, c *common.RemoteClient, id uint) (*infoView, error) {
+	var v infoView
+	if err := c.Get(ctx, "/api/v1/secrets/"+strconv.Itoa(int(id)), &v); err != nil {
+		return nil, err
+	}
+	return &v, nil
+}
+
+func init() {
+	infoCmd.Flags().UintVar(&infoID, "id", 0, "Secret ID (required)")
+	SecretCmd.AddCommand(infoCmd)
+}

--- a/internal/cli/secret/info_remote_test.go
+++ b/internal/cli/secret/info_remote_test.go
@@ -1,0 +1,57 @@
+package secret
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func infoStub(t *testing.T) (*common.RemoteClient, func()) {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/secrets/7":
+			_, _ = w.Write([]byte(`{"data":{"ID":7,"Name":"db","Type":"password","Classification":"confidential","Status":"active","Description":"prod DB","OwnerID":3,"IsShared":true,"CreatedBy":"alice"}}`))
+		case "/api/v1/secrets/7/tags":
+			_, _ = w.Write([]byte(`{"data":{"tags":["prod","tier1"]}}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	rc, ok := common.NewRemoteClient()
+	require.True(t, ok)
+	return rc, srv.Close
+}
+
+func TestFetchInfo(t *testing.T) {
+	rc, done := infoStub(t)
+	defer done()
+	v, err := fetchInfo(context.Background(), rc, 7)
+	require.NoError(t, err)
+	assert.Equal(t, "db", v.Name)
+	assert.Equal(t, "confidential", v.Classification)
+	assert.Equal(t, uint(3), v.OwnerID)
+	assert.True(t, v.IsShared)
+	assert.Equal(t, "prod DB", v.Description)
+}
+
+func TestFetchInfo_NotFound(t *testing.T) {
+	rc, done := infoStub(t)
+	defer done()
+	_, err := fetchInfo(context.Background(), rc, 999)
+	require.Error(t, err)
+}
+
+func TestInfoHelpers(t *testing.T) {
+	assert.Equal(t, "active", orDefault("", "active"))
+	assert.Equal(t, "suspended", orDefault("suspended", "active"))
+	assert.Equal(t, "yes", boolWord(true))
+	assert.Equal(t, "no", boolWord(false))
+}


### PR DESCRIPTION
## What

```
keyorix secret info --id <id>
```

prints a secret's metadata in one view — type, status, classification, owner, shared, created-by, expiration, last-rotated, tags, and description — **without ever fetching the value**.

Complements `secret get` (value-focused) and the per-aspect commands (`tags` / `description` / `access` / `audit`) with a quick "what is this secret?" summary.

## How

- Composes the secret GET (raw model, PascalCase) with the `/tags` endpoint (best-effort — a tags failure doesn't sink the summary).
- `fetchInfo` split out for httptest coverage; `orDefault`/`boolWord` formatting helpers unit-tested.

## Test

`TestFetchInfo` (parses metadata incl shared/description), not-found error, `TestInfoHelpers`. gofmt / go build / go test / gosec / golangci-lint all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)