### PR TITLE
feat(secrets): copy a secret into another environment (promote)

### DIFF
--- a/internal/core/secret_copy.go
+++ b/internal/core/secret_copy.go
@@ -1,0 +1,67 @@
+// secret_copy.go — copy a secret's current value and metadata into another environment
+// of the same project (e.g. promote staging → production). The copy is a brand-new,
+// independently-owned secret (owned by the copier, fresh version 1) — not a link, so
+// the two diverge from then on. Reading the source value is permission-checked here;
+// creating in the target environment is authorized by the caller (transport). Staying
+// within one project prevents a cross-project value exfiltration via copy.
+package core
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// CopySecret creates a new secret in targetEnvID with the source secret's value and
+// metadata (type, classification, description). newName defaults to the source name
+// when empty. The actor must be able to read the source (enforced here) and — checked
+// by the transport — to create in the target environment. The target environment must
+// belong to the same project as the source.
+func (c *KeyorixCore) CopySecret(ctx context.Context, sourceID, targetEnvID uint, newName, actorUsername string, actorID uint) (*models.SecretNode, error) {
+	if sourceID == 0 || targetEnvID == 0 {
+		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "source secret ID and target environment ID are required")
+	}
+
+	source, err := c.GetSecret(ctx, sourceID)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorSecretNotFound", nil), err)
+	}
+
+	// Same-project guard: the target environment must live in the source's project,
+	// so a copy can never move a value across a project boundary.
+	targetEnv, err := c.storage.GetEnvironment(ctx, targetEnvID)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorValidation", nil), err)
+	}
+	if targetEnv.ProjectID != source.ProjectID {
+		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "target environment must be in the same project as the source")
+	}
+
+	// Read the source value — permission-checked (the actor must be able to read it).
+	value, err := c.GetSecretValueWithPermissionCheck(ctx, sourceID, actorID)
+	if err != nil {
+		return nil, err
+	}
+
+	name := strings.TrimSpace(newName)
+	if name == "" {
+		name = source.Name
+	}
+
+	// CreateSecret re-validates the value policy, the env↔project link, and name
+	// uniqueness within the target environment.
+	return c.CreateSecret(ctx, &CreateSecretRequest{
+		Name:           name,
+		Value:          value,
+		ProjectID:      source.ProjectID,
+		EnvironmentID:  targetEnvID,
+		Type:           source.Type,
+		Classification: source.Classification,
+		Description:    source.Description,
+		CreatedBy:      actorUsername,
+		OwnerID:        actorID,
+	})
+}

--- a/internal/core/secret_copy_test.go
+++ b/internal/core/secret_copy_test.go
@@ -1,0 +1,81 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestCopySecret(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	sqlDB, _ := db.DB()
+	sqlDB.SetMaxOpenConns(1)
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.User{}, &models.Project{}, &models.Environment{}, &models.AuditEvent{}))
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "owner", Email: "o@t.com"}).Error)
+
+	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
+	ctx := context.Background()
+	p1, _ := c.storage.CreateProject(ctx, &models.Project{Name: "p1"})
+	staging, _ := c.storage.CreateEnvironment(ctx, &models.Environment{Name: "staging", ProjectID: p1.ID})
+	prod, _ := c.storage.CreateEnvironment(ctx, &models.Environment{Name: "production", ProjectID: p1.ID})
+	p2, _ := c.storage.CreateProject(ctx, &models.Project{Name: "p2"})
+	otherEnv, _ := c.storage.CreateEnvironment(ctx, &models.Environment{Name: "production", ProjectID: p2.ID})
+
+	src, err := c.CreateSecret(ctx, &CreateSecretRequest{
+		Name: "db-url", Value: []byte("postgres://secret"), ProjectID: p1.ID, EnvironmentID: staging.ID,
+		Type: "connection-string", Classification: "confidential", Description: "the prod DB",
+		CreatedBy: "owner", OwnerID: 1,
+	})
+	require.NoError(t, err)
+
+	t.Run("copies value + metadata into the target environment", func(t *testing.T) {
+		copied, err := c.CopySecret(ctx, src.ID, prod.ID, "", "owner", 1)
+		require.NoError(t, err)
+		assert.NotEqual(t, src.ID, copied.ID, "a distinct new secret")
+		assert.Equal(t, "db-url", copied.Name)
+		assert.Equal(t, prod.ID, copied.EnvironmentID)
+		assert.Equal(t, "connection-string", copied.Type)
+		assert.Equal(t, "confidential", copied.Classification)
+		assert.Equal(t, "the prod DB", copied.Description)
+		assert.Equal(t, uint(1), copied.OwnerID)
+
+		// The value carried over.
+		val, err := c.GetSecretValueWithPermissionCheck(ctx, copied.ID, 1)
+		require.NoError(t, err)
+		assert.Equal(t, "postgres://secret", string(val))
+	})
+
+	t.Run("a new name can be given", func(t *testing.T) {
+		copied, err := c.CopySecret(ctx, src.ID, prod.ID, "db-url-renamed", "owner", 1)
+		require.NoError(t, err)
+		assert.Equal(t, "db-url-renamed", copied.Name)
+	})
+
+	t.Run("copying to an environment in another project is rejected", func(t *testing.T) {
+		_, err := c.CopySecret(ctx, src.ID, otherEnv.ID, "", "owner", 1)
+		require.Error(t, err)
+	})
+
+	t.Run("a duplicate name in the target environment is rejected", func(t *testing.T) {
+		// "db-url" already copied into prod above.
+		_, err := c.CopySecret(ctx, src.ID, prod.ID, "", "owner", 1)
+		require.Error(t, err)
+	})
+
+	t.Run("required IDs are validated", func(t *testing.T) {
+		_, err := c.CopySecret(ctx, 0, prod.ID, "", "owner", 1)
+		require.Error(t, err)
+		_, err = c.CopySecret(ctx, src.ID, 0, "", "owner", 1)
+		require.Error(t, err)
+	})
+}

--- a/server/http/handlers/secrets_copy.go
+++ b/server/http/handlers/secrets_copy.go
@@ -1,0 +1,72 @@
+// secrets_copy.go — CopySecret handler: copy a secret into another environment.
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/server/middleware"
+)
+
+// CopySecret handles POST /api/v1/secrets/{id}/copy with {"environment_id":N,"name":"…"}
+// — creates a new secret in the target environment (same project) with the source's
+// value and metadata. The route gates secrets.read on the source ({id}); this handler
+// additionally authorizes secrets.write at the target environment's scope, so the
+// caller must be allowed both to read the source and to create in the target.
+func (h *SecretHandler) CopySecret(w http.ResponseWriter, r *http.Request) {
+	userCtx := middleware.GetUserFromContext(r.Context())
+	if userCtx == nil {
+		h.sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		h.sendError(w, "BadRequest", "Invalid secret ID", http.StatusBadRequest, nil)
+		return
+	}
+	var reqBody struct {
+		EnvironmentID uint   `json:"environment_id"`
+		Name          string `json:"name"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
+		h.sendError(w, "BadRequest", "Invalid request body", http.StatusBadRequest, nil)
+		return
+	}
+	if reqBody.EnvironmentID == 0 {
+		h.sendError(w, "BadRequest", "environment_id is required", http.StatusBadRequest, nil)
+		return
+	}
+
+	// Authorize creating in the target environment (same project as the source).
+	source, err := h.coreService.GetSecret(r.Context(), uint(id))
+	if err != nil {
+		h.sendError(w, "NotFound", "Secret not found", http.StatusNotFound, nil)
+		return
+	}
+	scope := core.Scope{ProjectID: source.ProjectID, EnvironmentID: reqBody.EnvironmentID}
+	if allowed, aerr := h.coreService.AuthorizePrincipal(r.Context(), userCtx.ActorKind(), userCtx.PrincipalID(), "secrets.write", scope); aerr != nil || !allowed {
+		h.sendError(w, "Forbidden", "Insufficient permissions for the target environment", http.StatusForbidden, nil)
+		return
+	}
+
+	created, err := h.coreService.CopySecret(r.Context(), uint(id), reqBody.EnvironmentID, reqBody.Name, userCtx.Username, userCtx.UserID)
+	if err != nil {
+		msg := err.Error()
+		status := http.StatusInternalServerError
+		switch {
+		case strings.Contains(msg, "not found"):
+			status = http.StatusNotFound
+		case strings.Contains(msg, "same project") || strings.Contains(msg, "already exists") || strings.Contains(msg, "validation") || strings.Contains(msg, "required"):
+			status = http.StatusBadRequest
+		case strings.Contains(msg, "permission") || strings.Contains(msg, "not authorized"):
+			status = http.StatusForbidden
+		}
+		h.sendError(w, "Error", msg, status, nil)
+		return
+	}
+	h.sendSuccess(w, created, "Secret copied")
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -342,6 +342,9 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.With(customMiddleware.RequireScopedPermission("secrets.write", secretScope)).Put("/{id}", secretHandler.UpdateSecret)
 			r.With(customMiddleware.RequireScopedPermission("secrets.write", secretScope)).Patch("/{id}/classification", secretHandler.ClassifySecret)
 			r.With(customMiddleware.RequireScopedPermission("secrets.write", secretScope)).Patch("/{id}/description", secretHandler.DescribeSecret)
+			// Copy into another environment: read the source ({id}); the handler also
+			// authorizes secrets.write at the target environment's scope.
+			r.With(customMiddleware.RequireScopedPermission("secrets.read", secretScope)).Post("/{id}/copy", secretHandler.CopySecret)
 			r.With(customMiddleware.RequireScopedPermission("secrets.write", secretScope)).Patch("/{id}/auto-rotate", secretHandler.SetAutoRotate)
 			r.With(customMiddleware.RequireScopedPermission("secrets.write", secretScope)).Post("/{id}/rotate", secretHandler.RotateSecret)
 			r.With(customMiddleware.RequireScopedPermission("secrets.write", secretScope)).Post("/{id}/rollback", secretHandler.RollbackSecret)


### PR DESCRIPTION
## What

A common workflow that was missing: **promote a secret** staging → production (or any environment in the same project) without re-typing the value.

```
POST /api/v1/secrets/{id}/copy
{ "environment_id": N, "name": "optional-new-name" }
```

Creates a brand-new, independently-owned secret in the target environment with the source's value and metadata (type, classification, description). The copy is a fresh secret (new version 1, owned by the copier) — **not a link**, so the two diverge afterward.

## How

- **core** — `CopySecret(sourceID, targetEnvID, newName, actorUsername, actorID)`: reads the source value **permission-checked** (`GetSecretValueWithPermissionCheck`), enforces the target environment is in the **same project** (no cross-project value exfiltration via copy), then reuses `CreateSecret` (value policy, env↔project link, name uniqueness). `newName` defaults to the source name.
- **http** — the route gates `secrets.read` on the source (`{id}`); the handler **additionally authorizes `secrets.write` at the target environment's scope** (`AuthorizePrincipal`). So the caller needs both read-source and write-target.

## Security

- Two-sided authorization (read source + write target); same-project guard blocks cross-project value movement.
- **Verified 403 to the read-only persona** (TestEveryMutatingRouteDeniesReadOnly): the in-handler write authorization denies it.

## Test

`TestCopySecret`: copies value + metadata into the target, optional rename, cross-project rejected, duplicate-name rejected, required IDs validated.

gofmt / go build / go test / gosec / golangci-lint all clean.

## Follow-ups

CLI `secret copy` + a "Copy to environment" action in the web detail view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)