### PR TITLE
feat(cli): secret copy — promote a secret to another environment

### DIFF
--- a/internal/cli/secret/copy.go
+++ b/internal/cli/secret/copy.go
@@ -1,0 +1,63 @@
+package secret
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/spf13/cobra"
+)
+
+var (
+	copyID      uint
+	copyToEnv   uint
+	copyNewName string
+)
+
+var copyCmd = &cobra.Command{
+	Use:   "copy",
+	Short: "Copy a secret's value and metadata into another environment",
+	Long: `Promote a secret into another environment of the same project (e.g. staging →
+production) without re-typing the value. Creates a new, independently-owned secret with
+the source's value, type, classification, and description. Requires secrets.read on the
+source and secrets.write in the target environment.`,
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		if copyID == 0 || copyToEnv == 0 {
+			return fmt.Errorf("--id and --to-environment are required")
+		}
+		c, ok := common.NewRemoteClient()
+		if !ok {
+			return fmt.Errorf("not connected to a server — run: keyorix connect <server>")
+		}
+		id, err := copySecret(context.Background(), c, copyID, copyToEnv, copyNewName)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("✅ Copied secret %d to environment %d as new secret %d.\n", copyID, copyToEnv, id)
+		return nil
+	},
+}
+
+// copySecret POSTs the copy and returns the new secret's ID (split out for tests).
+func copySecret(ctx context.Context, c *common.RemoteClient, id, toEnv uint, name string) (uint, error) {
+	body := map[string]interface{}{"environment_id": toEnv}
+	if name != "" {
+		body["name"] = name
+	}
+	var out struct {
+		ID uint `json:"ID"`
+	}
+	if err := c.Post(ctx, "/api/v1/secrets/"+strconv.Itoa(int(id))+"/copy", body, &out); err != nil {
+		return 0, err
+	}
+	return out.ID, nil
+}
+
+func init() {
+	copyCmd.Flags().UintVar(&copyID, "id", 0, "Source secret ID (required)")
+	copyCmd.Flags().UintVar(&copyToEnv, "to-environment", 0, "Target environment ID, same project (required)")
+	copyCmd.Flags().StringVar(&copyNewName, "name", "", "Name for the copy (default: the source name)")
+	SecretCmd.AddCommand(copyCmd)
+}

--- a/internal/cli/secret/copy_remote_test.go
+++ b/internal/cli/secret/copy_remote_test.go
@@ -1,0 +1,50 @@
+package secret
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func copyStub(t *testing.T) (*common.RemoteClient, func()) {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && r.URL.Path == "/api/v1/secrets/5/copy" {
+			b, _ := io.ReadAll(r.Body)
+			var got map[string]interface{}
+			_ = json.Unmarshal(b, &got)
+			if got["environment_id"] != nil {
+				_, _ = w.Write([]byte(`{"data":{"ID":42,"Name":"db"},"message":"Secret copied"}`))
+				return
+			}
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	rc, ok := common.NewRemoteClient()
+	require.True(t, ok)
+	return rc, srv.Close
+}
+
+func TestCopySecret(t *testing.T) {
+	rc, done := copyStub(t)
+	defer done()
+	id, err := copySecret(context.Background(), rc, 5, 3, "db-prod")
+	require.NoError(t, err)
+	assert.Equal(t, uint(42), id)
+}
+
+func TestCopySecret_NotFound(t *testing.T) {
+	rc, done := copyStub(t)
+	defer done()
+	_, err := copySecret(context.Background(), rc, 999, 3, "")
+	require.Error(t, err)
+}


### PR DESCRIPTION
## What

CLI for the copy/promote feature (#353):

```
keyorix secret copy --id <id> --to-environment <envID> [--name <name>]
```

POSTs `/secrets/{id}/copy` and reports the new secret's ID. The server enforces `secrets.read` on the source + `secrets.write` on the target (same project).

## How

- `copySecret` split out for httptest coverage (the stub asserts the body carries `environment_id`).

## Test

`TestCopySecret` (returns the new ID) + not-found error path. gofmt / go build / go test / gosec / golangci-lint all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)