### PR TITLE
release: prep v0.64.0 (CHANGELOG + Helm charts)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,37 @@
 All notable changes to Keyorix are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## v0.64.0 — 2026-06-19
+
+Audit CSV export, access-change notifications, and secret promote/copy.
+
+### Added
+- **Audit log CSV export** — `GET /audit/export.csv` (and `keyorix audit export --csv`)
+  download audit events as CSV for compliance hand-off, distinct from the JSON
+  SIEM feed. ([#345], [#346])
+- **Access-change notifications** — the affected user is now notified when a secret
+  is shared with them, when ownership is transferred to them (with a single summary
+  for bulk reassignment), and when their share is revoked — fanned out to group
+  members for group shares. ([#347], [#348], [#349], [#350])
+- **Copy a secret to another environment** — `POST /secrets/{id}/copy` (and
+  `keyorix secret copy`) promote a secret's value and metadata into another
+  environment of the same project (e.g. staging → production), with two-sided
+  authorization. ([#353], [#354])
+- **`keyorix secret expiring`** — list a project's expiring/expired secrets for
+  renewal triage. ([#351])
+- **`keyorix secret info`** — one-shot secret metadata summary (no value). ([#352])
+
+[#345]: https://github.com/keyorixhq/keyorix/pull/345
+[#346]: https://github.com/keyorixhq/keyorix/pull/346
+[#347]: https://github.com/keyorixhq/keyorix/pull/347
+[#348]: https://github.com/keyorixhq/keyorix/pull/348
+[#349]: https://github.com/keyorixhq/keyorix/pull/349
+[#350]: https://github.com/keyorixhq/keyorix/pull/350
+[#351]: https://github.com/keyorixhq/keyorix/pull/351
+[#352]: https://github.com/keyorixhq/keyorix/pull/352
+[#353]: https://github.com/keyorixhq/keyorix/pull/353
+[#354]: https://github.com/keyorixhq/keyorix/pull/354
+
 ## v0.63.0 — 2026-06-19
 
 Secret descriptions and hygiene triage.

--- a/deploy/helm/keyorix-k8s-sync/Chart.yaml
+++ b/deploy/helm/keyorix-k8s-sync/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix-k8s-sync
 description: Keyorix Kubernetes sync agent — materialises Keyorix secrets into native Kubernetes Secrets
 type: application
 # Chart version — tracks the Keyorix release version (published in lockstep).
-version: 0.63.0
+version: 0.64.0
 # The keyorix-k8s-sync image tag this chart deploys by default.
-appVersion: "0.63.0"
+appVersion: "0.64.0"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix

--- a/deploy/helm/keyorix/Chart.yaml
+++ b/deploy/helm/keyorix/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix
 description: Self-hosted Keyorix secrets manager (API server + web UI + PostgreSQL)
 type: application
 # Chart version — bump on chart changes.
-version: 0.63.0
+version: 0.64.0
 # The Keyorix app version this chart deploys by default (the image tag).
-appVersion: "0.63.0"
+appVersion: "0.64.0"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix


### PR DESCRIPTION
Release prep for **v0.64.0** — audit CSV export, access-change notifications, and secret promote/copy.

### Bundled since v0.63.0
- **Audit CSV export** — `GET /audit/export.csv` + `keyorix audit export --csv` ([#345], [#346])
- **Access-change notifications** — shared / ownership-transferred / revoked, incl. group fan-out ([#347], [#348], [#349], [#350])
- **Secret copy/promote** — `POST /secrets/{id}/copy` + `keyorix secret copy` ([#353], [#354])
- **`keyorix secret expiring`** ([#351]) and **`keyorix secret info`** ([#352])

### This PR
- CHANGELOG v0.64.0 section + PR link refs.
- Helm charts bumped lockstep to 0.64.0.

After merge: tag `v0.64.0` → release.yml (binaries + OCI charts) + docker-publish.yml (images).

🤖 Generated with [Claude Code](https://claude.com/claude-code)