### PR TITLE
feat(projects): add rotation-overdue to the hygiene summary

### DIFF
--- a/internal/cli/project/hygiene.go
+++ b/internal/cli/project/hygiene.go
@@ -15,6 +15,7 @@ type hygieneSummary struct {
 	UnusedSecrets          int `json:"unused_secrets"`
 	ExpiringSecrets        int `json:"expiring_secrets"`
 	StaleMachineIdentities int `json:"stale_machine_identities"`
+	RotationOverdue        int `json:"rotation_overdue"`
 }
 
 var hygieneCmd = &cobra.Command{
@@ -43,6 +44,7 @@ identities. Requires secrets.read at the project scope.`,
 		fmt.Printf("  unused secrets           %d\n", h.UnusedSecrets)
 		fmt.Printf("  expiring/expired secrets %d\n", h.ExpiringSecrets)
 		fmt.Printf("  stale machine identities %d\n", h.StaleMachineIdentities)
+		fmt.Printf("  rotation overdue         %d\n", h.RotationOverdue)
 		return nil
 	},
 }

--- a/internal/core/project_hygiene.go
+++ b/internal/core/project_hygiene.go
@@ -20,6 +20,7 @@ type ProjectHygiene struct {
 	UnusedSecrets          int `json:"unused_secrets"`
 	ExpiringSecrets        int `json:"expiring_secrets"` // expiring within the window, or already expired
 	StaleMachineIdentities int `json:"stale_machine_identities"`
+	RotationOverdue        int `json:"rotation_overdue"` // secrets past their rotation policy's interval
 }
 
 // Hygiene-summary default windows (days). Each is overridable by the caller.
@@ -75,6 +76,17 @@ func (c *KeyorixCore) ProjectHygieneSummary(ctx context.Context, projectID uint,
 		return nil, fmt.Errorf("stale machine identities: %w", err)
 	}
 	out.StaleMachineIdentities = len(staleMI)
+
+	// Secrets past their rotation policy's interval (reuses the rotation-status eval).
+	statuses, err := c.GetRotationStatus(ctx, &projectID)
+	if err != nil {
+		return nil, fmt.Errorf("rotation status: %w", err)
+	}
+	for _, s := range statuses {
+		if s.Status == RotationStatusOverdue {
+			out.RotationOverdue++
+		}
+	}
 
 	return out, nil
 }

--- a/internal/core/project_hygiene_test.go
+++ b/internal/core/project_hygiene_test.go
@@ -23,6 +23,7 @@ func TestProjectHygieneSummary(t *testing.T) {
 	require.NoError(t, db.AutoMigrate(
 		&models.SecretNode{}, &models.SecretVersion{}, &models.User{}, &models.Project{},
 		&models.Environment{}, &models.SecretAccessLog{}, &models.MachineIdentity{}, &models.AuditEvent{},
+		&models.RotationPolicy{},
 	))
 	require.NoError(t, db.Create(&models.User{ID: 1, Username: "owner", Email: "o@t.com"}).Error)
 	require.NoError(t, db.Create(&models.User{ID: 2, Username: "leaver", Email: "l@t.com"}).Error)
@@ -71,6 +72,27 @@ func TestProjectHygieneSummary(t *testing.T) {
 		assert.Equal(t, 1, h.ExpiringSecrets, "only 'expiring' within 30d")
 		assert.Equal(t, 1, h.StaleMachineIdentities, "only 'ci-old'")
 		assert.Equal(t, 3, h.UnusedSecrets, "kept + orphan + expiring; fresh-read excluded")
+		assert.Equal(t, 0, h.RotationOverdue, "no rotation policies yet")
+	})
+
+	t.Run("counts secrets overdue for rotation once a policy applies", func(t *testing.T) {
+		// A project-scoped policy with a 1-day interval — every secret (all created
+		// 'now', none rotated) is past due by the time we look... actually daysSince=0,
+		// so make the interval 0 to force overdue, or use an already-old secret.
+		require.NoError(t, c.storage.CreateRotationPolicy(ctx, &models.RotationPolicy{
+			Name: "30-day", Scope: "project", ProjectID: &p.ID, IntervalDays: 1, AlertDaysBefore: 1,
+			IsActive: true, CreatedBy: "owner",
+		}))
+		old := now.Add(-10 * 24 * time.Hour)
+		_, err := c.storage.CreateSecret(ctx, &models.SecretNode{
+			Name: "stale-rot", ProjectID: p.ID, EnvironmentID: e.ID, Type: "password", OwnerID: 1,
+			IsSecret: true, CreatedAt: old, UpdatedAt: old,
+		})
+		require.NoError(t, err)
+
+		h, err := c.ProjectHygieneSummary(ctx, p.ID, 90, 30, 90)
+		require.NoError(t, err)
+		assert.GreaterOrEqual(t, h.RotationOverdue, 1, "the 10-day-old secret is overdue under a 1-day policy")
 	})
 
 	t.Run("a project ID of zero is rejected", func(t *testing.T) {


### PR DESCRIPTION
## What

The project hygiene posture (#338) counted orphaned / unused / expiring secrets and stale machine identities — but **not** secrets past their rotation policy's interval, the one hygiene signal already computed elsewhere (compliance evidence) yet missing from the at-a-glance view. Now included as `rotation_overdue`.

## How

- **core** — `ProjectHygieneSummary` gains `rotation_overdue`, counted by reusing `GetRotationStatus(&projectID)` and tallying `RotationStatusOverdue` entries. No new query path — the same evaluator the `/rotation-policies/status` endpoint uses.
- **cli** — `keyorix project hygiene` prints the new "rotation overdue" line.
- The HTTP handler returns the struct directly, so the JSON field surfaces with no handler change.

## Test

`TestProjectHygieneSummary`: `rotation_overdue` is 0 with no policies; ≥1 once a project-scoped policy makes an old, un-rotated secret overdue. (Existing fixture now migrates `RotationPolicy`.)

gofmt / go build / go test / gosec / golangci-lint all clean.

## Follow-up

Add a rotation-overdue tile to the web hygiene posture card (#72).

🤖 Generated with [Claude Code](https://claude.com/claude-code)