### PR TITLE
feat(secrets): optional secret naming policy (regex + max length)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -95,6 +95,10 @@ type Config struct {
 	// placeholder values at create/rotate). Disabled (zero value) by default.
 	SecretValuePolicy SecretValuePolicyConfig `yaml:"secret_value_policy"`
 
+	// SecretNamePolicy is an optional naming convention on secret NAMES (regex /
+	// max-length, enforced at create). Disabled (zero value) by default.
+	SecretNamePolicy SecretNamePolicyConfig `yaml:"secret_name_policy"`
+
 	// PasswordPolicy is optional. When the block is absent (zero value), the
 	// server keeps its conservative built-in defaults (see core.DefaultPasswordPolicy);
 	// when present, the install's values fully replace them.
@@ -1269,4 +1273,12 @@ type SecretValuePolicyConfig struct {
 	MinLength     int      `yaml:"min_length"`     // reject values shorter than this (0 = no minimum)
 	RejectCommon  bool     `yaml:"reject_common"`  // reject a built-in denylist of weak/placeholder values
 	ExtraDenylist []string `yaml:"extra_denylist"` // additional rejected values (case-insensitive)
+}
+
+// SecretNamePolicyConfig configures the opt-in secret naming convention
+// (core.SecretNamePolicy). Disabled unless Enabled is true.
+type SecretNamePolicyConfig struct {
+	Enabled   bool   `yaml:"enabled"`
+	Pattern   string `yaml:"pattern"`    // RE2 regex the name must match (anchor with ^…$); empty = no regex check
+	MaxLength int    `yaml:"max_length"` // reject names longer than this (0 = no maximum)
 }

--- a/internal/core/secret_name_policy.go
+++ b/internal/core/secret_name_policy.go
@@ -1,0 +1,55 @@
+// secret_name_policy.go — an optional, operator-configured naming convention for
+// secrets: a regex the name must match and/or a maximum length, enforced at create
+// time. Lets an org keep secret names consistent (e.g. UPPER_SNAKE, a team prefix).
+// OFF by default, so existing installs are unaffected until they opt in. Distinct from
+// the value gate ([[secret_value_policy]]); this governs the NAME, never the value.
+package core
+
+import (
+	"fmt"
+	"regexp"
+	"unicode/utf8"
+)
+
+// SecretNamePolicy describes the naming convention applied to a secret's name on
+// create. Pattern is an RE2 regular expression; operators should anchor it (^…$) for
+// a whole-name match. Empty Pattern skips the regex check; MaxLength 0 skips the
+// length check.
+type SecretNamePolicy struct {
+	Enabled   bool
+	Pattern   string
+	MaxLength int
+}
+
+// DefaultSecretNamePolicy returns the disabled (no-op) policy.
+func DefaultSecretNamePolicy() SecretNamePolicy { return SecretNamePolicy{} }
+
+// validateSecretName checks a name against the configured naming policy. Returns a
+// non-nil error describing the violation; a disabled policy always passes. The regex
+// is pre-compiled by SetSecretNamePolicy (c.secretNameRe).
+func (c *KeyorixCore) validateSecretName(name string) error {
+	p := c.secretNamePolicy
+	if !p.Enabled {
+		return nil
+	}
+	if p.MaxLength > 0 && utf8.RuneCountInString(name) > p.MaxLength {
+		return fmt.Errorf("secret name exceeds the %d-character maximum", p.MaxLength)
+	}
+	if c.secretNameRe != nil && !c.secretNameRe.MatchString(name) {
+		return fmt.Errorf("secret name does not match the required pattern %q", p.Pattern)
+	}
+	return nil
+}
+
+// compileNamePattern compiles a name-policy pattern, used by SetSecretNamePolicy and
+// reusable for config validation. Returns nil regexp for an empty pattern.
+func compileNamePattern(pattern string) (*regexp.Regexp, error) {
+	if pattern == "" {
+		return nil, nil
+	}
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return nil, fmt.Errorf("invalid secret name pattern: %w", err)
+	}
+	return re, nil
+}

--- a/internal/core/secret_name_policy_test.go
+++ b/internal/core/secret_name_policy_test.go
@@ -1,0 +1,76 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestSecretNamePolicy_Validate(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+
+	t.Run("disabled policy passes anything", func(t *testing.T) {
+		c := &KeyorixCore{}
+		require.NoError(t, c.SetSecretNamePolicy(SecretNamePolicy{}))
+		assert.NoError(t, c.validateSecretName("anything goes!"))
+	})
+
+	t.Run("an invalid pattern is rejected at set time", func(t *testing.T) {
+		c := &KeyorixCore{}
+		err := c.SetSecretNamePolicy(SecretNamePolicy{Enabled: true, Pattern: "("})
+		require.Error(t, err)
+	})
+
+	t.Run("pattern is enforced", func(t *testing.T) {
+		c := &KeyorixCore{}
+		require.NoError(t, c.SetSecretNamePolicy(SecretNamePolicy{Enabled: true, Pattern: "^[A-Z][A-Z0-9_]*$"}))
+		assert.NoError(t, c.validateSecretName("DB_PASSWORD"))
+		assert.Error(t, c.validateSecretName("db-password"), "lowercase/hyphen violates UPPER_SNAKE")
+	})
+
+	t.Run("max length is enforced", func(t *testing.T) {
+		c := &KeyorixCore{}
+		require.NoError(t, c.SetSecretNamePolicy(SecretNamePolicy{Enabled: true, MaxLength: 5}))
+		assert.NoError(t, c.validateSecretName("short"))
+		assert.Error(t, c.validateSecretName("toolong"))
+	})
+}
+
+func TestCreateSecret_NamePolicy(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	sqlDB, _ := db.DB()
+	sqlDB.SetMaxOpenConns(1)
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.Project{}, &models.Environment{}, &models.AuditEvent{}))
+	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
+	require.NoError(t, c.SetSecretNamePolicy(SecretNamePolicy{Enabled: true, Pattern: "^[A-Z][A-Z0-9_]*$"}))
+	ctx := context.Background()
+	p, _ := c.storage.CreateProject(ctx, &models.Project{Name: "p1"})
+	e, _ := c.storage.CreateEnvironment(ctx, &models.Environment{Name: "production", ProjectID: p.ID})
+
+	mkReq := func(name string) *CreateSecretRequest {
+		return &CreateSecretRequest{
+			Name: name, Value: []byte("supersecret1"), ProjectID: p.ID, EnvironmentID: e.ID,
+			Type: "password", CreatedBy: "owner", OwnerID: 1,
+		}
+	}
+
+	t.Run("a conforming name is accepted", func(t *testing.T) {
+		_, err := c.CreateSecret(ctx, mkReq("DB_PASSWORD"))
+		require.NoError(t, err)
+	})
+
+	t.Run("a non-conforming name is rejected", func(t *testing.T) {
+		_, err := c.CreateSecret(ctx, mkReq("db-password"))
+		require.Error(t, err)
+	})
+}

--- a/internal/core/secrets.go
+++ b/internal/core/secrets.go
@@ -61,6 +61,9 @@ func (c *KeyorixCore) CreateSecret(ctx context.Context, req *CreateSecretRequest
 	if err := c.secretValuePolicy.Validate(req.Value); err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorValidation", nil), err)
 	}
+	if err := c.validateSecretName(req.Name); err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorValidation", nil), err)
+	}
 	if len(strings.TrimSpace(req.Description)) > maxSecretDescriptionLen {
 		return nil, fmt.Errorf("%s: description exceeds %d characters", i18n.T("ErrorValidation", nil), maxSecretDescriptionLen)
 	}

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/x509"
 	"fmt"
+	"regexp"
 	"time"
 
 	"github.com/go-webauthn/webauthn/webauthn"
@@ -50,6 +51,8 @@ type KeyorixCore struct {
 	now               func() time.Time // For testability
 	passwordPolicy    PasswordPolicy
 	secretValuePolicy SecretValuePolicy  // optional quality gate on secret values (off by default)
+	secretNamePolicy  SecretNamePolicy   // optional naming convention for secrets (off by default)
+	secretNameRe      *regexp.Regexp     // compiled secretNamePolicy.Pattern (nil = no regex check)
 	loginLockout      LoginLockoutPolicy // per-account login lockout (disabled by default)
 	auditForwarder    AuditForwarder
 	// auditStream is the in-process pub/sub broker that wakes live audit tails
@@ -277,6 +280,19 @@ func (c *KeyorixCore) SetPasswordPolicy(p PasswordPolicy) {
 // default). The server calls this at startup when secret_value_policy.enabled is set.
 func (c *KeyorixCore) SetSecretValuePolicy(p SecretValuePolicy) {
 	c.secretValuePolicy = p
+}
+
+// SetSecretNamePolicy enables/configures the secret naming convention (off by
+// default). The server calls this at startup when secret_name_policy.enabled is set.
+// Returns an error (and leaves the policy disabled) if Pattern is not a valid regex.
+func (c *KeyorixCore) SetSecretNamePolicy(p SecretNamePolicy) error {
+	re, err := compileNamePattern(p.Pattern)
+	if err != nil {
+		return err
+	}
+	c.secretNamePolicy = p
+	c.secretNameRe = re
+	return nil
 }
 
 // SetLoginLockoutPolicy enables/configures per-account login lockout. The server

--- a/server/main.go
+++ b/server/main.go
@@ -298,6 +298,18 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 			svp.MinLength, svp.RejectCommon, len(svp.ExtraDenylist))
 	}
 
+	// Apply the optional secret naming convention (regex / max-length on names).
+	if snp := cfg.SecretNamePolicy; snp.Enabled {
+		if err := coreService.SetSecretNamePolicy(core.SecretNamePolicy{
+			Enabled:   true,
+			Pattern:   snp.Pattern,
+			MaxLength: snp.MaxLength,
+		}); err != nil {
+			log.Fatalf("Invalid secret_name_policy: %v", err)
+		}
+		log.Printf("Secret-name policy enabled (pattern=%q, max_length=%d)", snp.Pattern, snp.MaxLength)
+	}
+
 	// Apply per-account login lockout if enabled (brute-force protection, distinct
 	// from the per-IP rate limiter).
 	if ll := cfg.Security.LoginLockout; ll.Enabled {


### PR DESCRIPTION
## What

A governance control parallel to the secret-value policy: an operator can require secret **names** to follow a convention — a regex pattern and/or a max length — enforced at create time. Lets an org keep names consistent (e.g. `UPPER_SNAKE` or a team prefix). **OFF by default**; existing installs are unaffected until they opt in.

```yaml
secret_name_policy:
  enabled: true
  pattern: '^[A-Z][A-Z0-9_]*$'   # RE2, anchor for whole-name match
  max_length: 64
```

## How

- **core** — `SecretNamePolicy{Enabled, Pattern, MaxLength}` + `validateSecretName`, enforced in `CreateSecret` beside the value-policy check (so `CopySecret` is covered too). The pattern is RE2, **pre-compiled by `SetSecretNamePolicy`** — an invalid regex is rejected at set time, not on every create; `MaxLength` uses a UTF-8 rune count.
- **config** — `secret_name_policy {enabled, pattern, max_length}`; the server wires it at startup (fatal on an invalid pattern, consistent with other misconfig).

## Test

`TestSecretNamePolicy_Validate` (disabled passes anything; invalid pattern rejected at set; pattern + max-length enforced) and `TestCreateSecret_NamePolicy` (create accepts conforming / rejects non-conforming).

gofmt / go build / go test / gosec / golangci-lint all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)