### PR TITLE
feat(secrets): expose active secret policies — GET /secrets/policy

### DIFF
--- a/internal/core/secret_policy_info.go
+++ b/internal/core/secret_policy_info.go
@@ -1,0 +1,43 @@
+// secret_policy_info.go — a read-only view of the active secret-name and secret-value
+// policies, so clients (the web create form, the CLI) can show the conventions and
+// pre-validate input instead of surprising the user with a server-side rejection.
+// Exposes only the non-sensitive rule flags — never the extra-denylist values.
+package core
+
+// SecretNamePolicyInfo is the client-facing view of the naming policy.
+type SecretNamePolicyInfo struct {
+	Enabled   bool   `json:"enabled"`
+	Pattern   string `json:"pattern,omitempty"`
+	MaxLength int    `json:"max_length,omitempty"`
+}
+
+// SecretValuePolicyInfo is the client-facing view of the value policy (flags only —
+// the extra denylist is intentionally not exposed).
+type SecretValuePolicyInfo struct {
+	Enabled      bool `json:"enabled"`
+	MinLength    int  `json:"min_length,omitempty"`
+	RejectCommon bool `json:"reject_common"`
+}
+
+// SecretPolicyInfo bundles the active create-time policies for clients.
+type SecretPolicyInfo struct {
+	Name  SecretNamePolicyInfo  `json:"name"`
+	Value SecretValuePolicyInfo `json:"value"`
+}
+
+// SecretPolicies returns the active secret-name and secret-value policies as a
+// non-sensitive, client-facing view.
+func (c *KeyorixCore) SecretPolicies() SecretPolicyInfo {
+	return SecretPolicyInfo{
+		Name: SecretNamePolicyInfo{
+			Enabled:   c.secretNamePolicy.Enabled,
+			Pattern:   c.secretNamePolicy.Pattern,
+			MaxLength: c.secretNamePolicy.MaxLength,
+		},
+		Value: SecretValuePolicyInfo{
+			Enabled:      c.secretValuePolicy.Enabled,
+			MinLength:    c.secretValuePolicy.MinLength,
+			RejectCommon: c.secretValuePolicy.RejectCommon,
+		},
+	}
+}

--- a/server/http/handlers/secrets_policy.go
+++ b/server/http/handlers/secrets_policy.go
@@ -1,0 +1,20 @@
+// secrets_policy.go — SecretPolicy handler: the active create-time secret policies.
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/keyorixhq/keyorix/server/middleware"
+)
+
+// SecretPolicy handles GET /api/v1/secrets/policy — the active secret-name and
+// secret-value policies (rule flags only, no denylist values), so a client can show
+// the conventions and pre-validate. Authenticated; no special permission (these are
+// the rules every creator is held to, not sensitive data).
+func (h *SecretHandler) SecretPolicy(w http.ResponseWriter, r *http.Request) {
+	if middleware.GetUserFromContext(r.Context()) == nil {
+		h.sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	h.sendSuccess(w, h.coreService.SecretPolicies(), "")
+}

--- a/server/http/handlers/secrets_policy_test.go
+++ b/server/http/handlers/secrets_policy_test.go
@@ -1,0 +1,47 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSecretPolicyHandler(t *testing.T) {
+	db := openTestDB(t)
+	svc := core.NewKeyorixCore(store.NewLocalStorage(db))
+	require.NoError(t, svc.SetSecretNamePolicy(core.SecretNamePolicy{Enabled: true, Pattern: "^[A-Z_]+$", MaxLength: 32}))
+	svc.SetSecretValuePolicy(core.SecretValuePolicy{Enabled: true, MinLength: 16, RejectCommon: true})
+	h, err := NewSecretHandler(svc)
+	require.NoError(t, err)
+
+	t.Run("returns the active policies", func(t *testing.T) {
+		req := withUserCtx(httptest.NewRequest(http.MethodGet, "/api/v1/secrets/policy", nil))
+		w := httptest.NewRecorder()
+		h.SecretPolicy(w, req)
+		require.Equal(t, http.StatusOK, w.Code)
+
+		var resp struct {
+			Data core.SecretPolicyInfo `json:"data"`
+		}
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		assert.True(t, resp.Data.Name.Enabled)
+		assert.Equal(t, "^[A-Z_]+$", resp.Data.Name.Pattern)
+		assert.Equal(t, 32, resp.Data.Name.MaxLength)
+		assert.True(t, resp.Data.Value.Enabled)
+		assert.Equal(t, 16, resp.Data.Value.MinLength)
+		assert.True(t, resp.Data.Value.RejectCommon)
+	})
+
+	t.Run("requires a user context", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/secrets/policy", nil)
+		w := httptest.NewRecorder()
+		h.SecretPolicy(w, req)
+		assert.Equal(t, http.StatusUnauthorized, w.Code)
+	})
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -324,6 +324,8 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		secretScope := customMiddleware.ScopeFromSecretParam("id")
 		r.Route("/secrets", func(r chi.Router) {
 			r.With(customMiddleware.RequireScopedPermission("secrets.read", customMiddleware.ScopeFromQuery)).Get("/", secretHandler.ListSecrets)
+			// Active create-time policies (naming/value) — any authenticated caller.
+			r.Get("/policy", secretHandler.SecretPolicy)
 			// Usage analytics (static paths, before /{id}).
 			r.With(customMiddleware.RequireScopedPermission("secrets.read", customMiddleware.ScopeFromQuery)).Get("/usage/most-accessed", secretHandler.UsageMostAccessed)
 			r.With(customMiddleware.RequireScopedPermission("secrets.read", customMiddleware.ScopeFromQuery)).Get("/usage/unused", secretHandler.UsageUnused)


### PR DESCRIPTION
## What

Clients had no way to learn the create-time rules (naming convention #357, value quality gate), so a user only discovered them via a server-side rejection. This adds a read endpoint so the web create form / CLI can **show the conventions and pre-validate**.

```
GET /api/v1/secrets/policy
→ { "name": {"enabled":true,"pattern":"^[A-Z_]+$","max_length":64},
    "value": {"enabled":true,"min_length":16,"reject_common":true} }
```

## How

- **core** — `SecretPolicies()` returns a non-sensitive, client-facing view. Exposes only the rule flags — **never the value extra-denylist**.
- **http** — static `/secrets/policy` route (chi prioritizes it over `/{id}`). Authenticated; no special permission (these are the rules every creator is held to, not sensitive data).

## Test

`TestSecretPolicyHandler`: returns the active name + value policy flags; requires a user context (401 otherwise).

gofmt / go build / go test / gosec / golangci-lint all clean. (The `/sw.js` + `evidence/verify` mutating-route failures are the known local-only ones — this is a GET.)

## Follow-ups

Use it in the web create form (show the pattern hint + pre-validate) and CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)