### PR TITLE
feat(machine): machine-token hygiene — admin view of stale/expired creds

### DIFF
--- a/internal/core/machine_token_hygiene.go
+++ b/internal/core/machine_token_hygiene.go
@@ -1,0 +1,57 @@
+// machine_token_hygiene.go — deployment-wide machine-token hygiene: the non-revoked
+// machine-identity credentials that should probably be cleaned up — expired-but-never-
+// revoked, or stale (unused for a long window). The non-human counterpart to PAT
+// hygiene ([[pat_hygiene]]): an abandoned or expired machine token is the same kind of
+// reusable credential an attacker prizes. Read-only; never returns a token hash.
+// Admin-scoped (route-gated).
+package core
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// defaultMachineTokenStaleAfter is the staleness window used when none is given.
+const defaultMachineTokenStaleAfter = 90 * 24 * time.Hour
+
+// MachineTokenHygieneEntry is one flagged machine credential plus why. The embedded
+// credential carries only metadata; callers must not surface its TokenHash.
+type MachineTokenHygieneEntry struct {
+	Credential *models.MachineIdentityCredential
+	Expired    bool // ExpiresAt is in the past (but the token was never revoked)
+	Stale      bool // not used within the staleness window (never-used counts from creation)
+}
+
+// ListMachineTokenHygiene returns the non-revoked machine credentials that are
+// expired-but-active or stale (unused beyond staleAfter; a never-used token counts
+// from creation). Healthy tokens are omitted. staleAfter defaults when non-positive.
+func (c *KeyorixCore) ListMachineTokenHygiene(ctx context.Context, staleAfter time.Duration) ([]MachineTokenHygieneEntry, error) {
+	if staleAfter <= 0 {
+		staleAfter = defaultMachineTokenStaleAfter
+	}
+	creds, err := c.storage.ListActiveMachineIdentityCredentials(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list machine credentials: %w", err)
+	}
+	now := c.now()
+	cutoff := now.Add(-staleAfter)
+
+	var out []MachineTokenHygieneEntry
+	for _, t := range creds {
+		expired := t.ExpiresAt != nil && t.ExpiresAt.Before(now)
+
+		last := t.CreatedAt
+		if t.LastUsedAt != nil {
+			last = *t.LastUsedAt
+		}
+		stale := last.Before(cutoff)
+
+		if expired || stale {
+			out = append(out, MachineTokenHygieneEntry{Credential: t, Expired: expired, Stale: stale})
+		}
+	}
+	return out, nil
+}

--- a/internal/core/machine_token_hygiene_test.go
+++ b/internal/core/machine_token_hygiene_test.go
@@ -1,0 +1,71 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestListMachineTokenHygiene(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	sqlDB, _ := db.DB()
+	sqlDB.SetMaxOpenConns(1)
+	require.NoError(t, db.AutoMigrate(&models.MachineIdentityCredential{}))
+
+	now := time.Date(2026, 6, 19, 12, 0, 0, 0, time.UTC)
+	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: func() time.Time { return now }}
+	ctx := context.Background()
+
+	ago := func(d time.Duration) *time.Time { v := now.Add(-d); return &v }
+	ahead := func(d time.Duration) *time.Time { v := now.Add(d); return &v }
+	day := 24 * time.Hour
+
+	mk := func(id uint, name string, created time.Time, lastUsed, expires *time.Time, revoked bool) {
+		require.NoError(t, db.Create(&models.MachineIdentityCredential{
+			ID: id, MachineIdentityID: 5, Name: name, TokenHash: name + "-h", TokenPrefix: "kx_machine_" + name,
+			CreatedAt: created, LastUsedAt: lastUsed, ExpiresAt: expires, Revoked: revoked,
+		}).Error)
+	}
+
+	mk(1, "healthy", now.Add(-10*day), ago(1*day), ahead(30*day), false)  // recent + not expired
+	mk(2, "stale", now.Add(-200*day), ago(120*day), ahead(30*day), false) // unused 120d → stale
+	mk(3, "never-old", now.Add(-120*day), nil, nil, false)                // never used, old → stale
+	mk(4, "never-new", now.Add(-5*day), nil, nil, false)                  // never used, new → healthy
+	mk(5, "expired", now.Add(-10*day), ago(1*day), ago(2*day), false)     // expired, recent use → expired only
+	mk(6, "revoked-stale", now.Add(-200*day), ago(150*day), nil, true)    // stale but revoked → excluded
+
+	t.Run("flags stale + expired-but-active, excludes healthy/fresh/revoked", func(t *testing.T) {
+		entries, err := c.ListMachineTokenHygiene(ctx, 90*day)
+		require.NoError(t, err)
+		byName := map[string]MachineTokenHygieneEntry{}
+		for _, e := range entries {
+			byName[e.Credential.Name] = e
+		}
+		require.Len(t, entries, 3)
+		assert.True(t, byName["stale"].Stale && !byName["stale"].Expired)
+		assert.True(t, byName["never-old"].Stale)
+		assert.True(t, byName["expired"].Expired && !byName["expired"].Stale)
+		_, healthy := byName["healthy"]
+		_, fresh := byName["never-new"]
+		_, revoked := byName["revoked-stale"]
+		assert.False(t, healthy)
+		assert.False(t, fresh)
+		assert.False(t, revoked, "revoked excluded at the storage layer")
+	})
+
+	t.Run("non-positive window falls back to the default", func(t *testing.T) {
+		entries, err := c.ListMachineTokenHygiene(ctx, 0)
+		require.NoError(t, err)
+		assert.Len(t, entries, 3)
+	})
+}

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -1409,6 +1409,14 @@ func (m *MockStorage) ListMachineIdentityCredentials(ctx context.Context, machin
 	return args.Get(0).([]*models.MachineIdentityCredential), args.Error(1)
 }
 
+func (m *MockStorage) ListActiveMachineIdentityCredentials(ctx context.Context) ([]*models.MachineIdentityCredential, error) {
+	args := m.Called(ctx)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*models.MachineIdentityCredential), args.Error(1)
+}
+
 func (m *MockStorage) UpdateMachineIdentityCredential(ctx context.Context, c *models.MachineIdentityCredential) error {
 	args := m.Called(ctx, c)
 	return args.Error(0)

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -125,6 +125,10 @@ type Storage interface {
 	GetMachineIdentityCredentialByHash(ctx context.Context, hash string) (*models.MachineIdentityCredential, error)
 	GetMachineIdentityCredentialByID(ctx context.Context, id uint) (*models.MachineIdentityCredential, error)
 	ListMachineIdentityCredentials(ctx context.Context, machineID uint) ([]*models.MachineIdentityCredential, error)
+	// ListActiveMachineIdentityCredentials returns every non-revoked machine
+	// credential across all identities — the deployment-wide view for token-hygiene
+	// auditing (stale / expired-but-active).
+	ListActiveMachineIdentityCredentials(ctx context.Context) ([]*models.MachineIdentityCredential, error)
 	UpdateMachineIdentityCredential(ctx context.Context, c *models.MachineIdentityCredential) error
 	RevokeMachineIdentityCredential(ctx context.Context, id uint) error
 	// CountMachineIdentityCredentialsByClassification returns install-wide counts

--- a/internal/storage/store/local_machine_credentials.go
+++ b/internal/storage/store/local_machine_credentials.go
@@ -51,6 +51,20 @@ func (ls *LocalStorage) ListMachineIdentityCredentials(ctx context.Context, mach
 	return rows, nil
 }
 
+// ListActiveMachineIdentityCredentials returns every non-revoked machine credential,
+// newest first — the deployment-wide token-hygiene view.
+func (ls *LocalStorage) ListActiveMachineIdentityCredentials(ctx context.Context) ([]*models.MachineIdentityCredential, error) {
+	var rows []*models.MachineIdentityCredential
+	err := ls.db.WithContext(ctx).
+		Where("revoked = ?", false).
+		Order("created_at DESC").
+		Find(&rows).Error
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	return rows, nil
+}
+
 func (ls *LocalStorage) UpdateMachineIdentityCredential(ctx context.Context, c *models.MachineIdentityCredential) error {
 	if err := ls.db.WithContext(ctx).Save(c).Error; err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)

--- a/internal/storage/store/remote_machine_identities.go
+++ b/internal/storage/store/remote_machine_identities.go
@@ -48,6 +48,10 @@ func (rs *RemoteStorage) ListMachineIdentityCredentials(_ context.Context, _ uin
 	return nil, remoteUnsupported("ListMachineIdentityCredentials")
 }
 
+func (rs *RemoteStorage) ListActiveMachineIdentityCredentials(_ context.Context) ([]*models.MachineIdentityCredential, error) {
+	return nil, remoteUnsupported("ListActiveMachineIdentityCredentials")
+}
+
 func (rs *RemoteStorage) UpdateMachineIdentityCredential(_ context.Context, _ *models.MachineIdentityCredential) error {
 	return remoteUnsupported("UpdateMachineIdentityCredential")
 }

--- a/server/http/handlers/machine_token_hygiene.go
+++ b/server/http/handlers/machine_token_hygiene.go
@@ -1,0 +1,68 @@
+// machine_token_hygiene.go — MachineTokenHygiene handler: deployment-wide stale /
+// expired-but-active machine credentials an admin should revoke (token sprawl).
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/keyorixhq/keyorix/server/middleware"
+)
+
+// machineTokenHygieneEntry is the safe wire shape for one flagged machine credential —
+// metadata + flags only, never the token hash.
+type machineTokenHygieneEntry struct {
+	ID                uint   `json:"id"`
+	MachineIdentityID uint   `json:"machine_identity_id"`
+	Name              string `json:"name"`
+	TokenPrefix       string `json:"token_prefix"`
+	LastUsedAt        string `json:"last_used_at,omitempty"`
+	ExpiresAt         string `json:"expires_at,omitempty"`
+	Expired           bool   `json:"expired"`
+	Stale             bool   `json:"stale"`
+}
+
+// MachineTokenHygiene handles GET /api/v1/machine-token-hygiene?days=N — the
+// deployment-wide non-revoked machine credentials that are expired-but-active or stale.
+// Global system.read is enforced by the router. days defaults to 90, cap 3650.
+func (h *CatalogHandler) MachineTokenHygiene(w http.ResponseWriter, r *http.Request) {
+	if middleware.GetUserFromContext(r.Context()) == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	days := 90
+	if v := r.URL.Query().Get("days"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			days = n
+		}
+	}
+	if days > 3650 {
+		days = 3650
+	}
+
+	entries, err := h.coreService.ListMachineTokenHygiene(r.Context(), time.Duration(days)*24*time.Hour)
+	if err != nil {
+		sendError(w, "InternalError", "Failed to list machine-token hygiene", http.StatusInternalServerError, nil)
+		return
+	}
+	out := make([]machineTokenHygieneEntry, 0, len(entries))
+	for _, e := range entries {
+		row := machineTokenHygieneEntry{
+			ID:                e.Credential.ID,
+			MachineIdentityID: e.Credential.MachineIdentityID,
+			Name:              e.Credential.Name,
+			TokenPrefix:       e.Credential.TokenPrefix,
+			Expired:           e.Expired,
+			Stale:             e.Stale,
+		}
+		if e.Credential.LastUsedAt != nil {
+			row.LastUsedAt = e.Credential.LastUsedAt.UTC().Format(time.RFC3339)
+		}
+		if e.Credential.ExpiresAt != nil {
+			row.ExpiresAt = e.Credential.ExpiresAt.UTC().Format(time.RFC3339)
+		}
+		out = append(out, row)
+	}
+	sendSuccess(w, map[string]interface{}{"tokens": out, "total": len(out)}, "")
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -534,6 +534,9 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		// Personal-access-token hygiene — deployment-wide stale / expired-but-active
 		// tokens an admin should revoke (token sprawl).
 		r.With(customMiddleware.RequirePermission("system.read")).Get("/pat-hygiene", patHandler.PATHygiene)
+		// Machine-token hygiene — deployment-wide stale / expired-but-active machine
+		// credentials an admin should revoke (non-human token sprawl).
+		r.With(customMiddleware.RequirePermission("system.read")).Get("/machine-token-hygiene", catalogHandler.MachineTokenHygiene)
 
 		// Compliance posture — deployment-wide controls snapshot for auditors.
 		r.With(customMiddleware.RequirePermission("system.read")).Get("/compliance/posture", dashboardHandler.GetCompliancePosture)


### PR DESCRIPTION
## What

The non-human counterpart to PAT hygiene (#330): `GET /api/v1/machine-token-hygiene?days=N` — a deployment-wide view of non-revoked machine-identity credentials that are **expired-but-active** or **stale** (unused beyond a window).

An abandoned or expired machine token is the same kind of reusable credential an attacker prizes, but there was only a per-machine token list — no fleet-wide visibility. This completes credential-hygiene coverage across **humans** (PATs #330, sessions #332) and **machines**.

## How

- **storage** — `ListActiveMachineIdentityCredentials` (every non-revoked machine credential). Remote adapter unsupported (server-side hygiene).
- **core** — `ListMachineTokenHygiene(staleAfter)`: flags expired-but-active or stale (a never-used token counts from creation); healthy omitted; default 90d.
- **http** — gated global `system.read` (matches PAT hygiene). DTO = `id / machine_identity_id / name / token_prefix / last_used_at / expires_at` + `expired`/`stale` — **never the token hash**.

## Test

`TestListMachineTokenHygiene` (fixed clock): flags stale + never-used-old + expired, excludes healthy / fresh / revoked; non-positive window → default.

gofmt / go build / go test / gosec / golangci-lint all clean. (The `/sw.js` + `evidence/verify` mutating-route failures are the known local-only ones — this is a GET.)

## Follow-ups

CLI `machine token-hygiene` + a web admin panel (beside the PAT-hygiene panel #69).

🤖 Generated with [Claude Code](https://claude.com/claude-code)