### PR TITLE
feat(cli): machine token-hygiene — stale/expired machine creds (admin)

### DIFF
--- a/internal/cli/machine/token_hygiene.go
+++ b/internal/cli/machine/token_hygiene.go
@@ -1,0 +1,87 @@
+package machine
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/spf13/cobra"
+)
+
+var tokenHygieneDays int
+
+// machineTokenHygieneRow mirrors a GET /machine-token-hygiene entry (safe DTO — no hash).
+type machineTokenHygieneRow struct {
+	ID                uint   `json:"id"`
+	MachineIdentityID uint   `json:"machine_identity_id"`
+	Name              string `json:"name"`
+	TokenPrefix       string `json:"token_prefix"`
+	LastUsedAt        string `json:"last_used_at"`
+	Expired           bool   `json:"expired"`
+	Stale             bool   `json:"stale"`
+}
+
+var tokenHygieneCmd = &cobra.Command{
+	Use:   "token-hygiene",
+	Short: "List stale or expired-but-active machine tokens across all identities (admin)",
+	Long: `Show the deployment-wide machine-identity credentials that should probably be
+revoked: ones that have expired but were never revoked, and ones unused for a long
+window (non-human token sprawl). Requires global system.read. Never prints a secret.`,
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		c, ok := common.NewRemoteClient()
+		if !ok {
+			return fmt.Errorf("not connected to a server — run: keyorix connect <server>")
+		}
+		rows, err := fetchMachineTokenHygiene(context.Background(), c, tokenHygieneDays)
+		if err != nil {
+			return err
+		}
+		if len(rows) == 0 {
+			fmt.Println("No stale or expired machine tokens.")
+			return nil
+		}
+		fmt.Printf("%-5s %-22s %-16s %-8s %-8s %s\n", "ID", "NAME", "PREFIX", "MACHINE", "FLAGS", "LAST USED")
+		for _, r := range rows {
+			last := r.LastUsedAt
+			if last == "" {
+				last = "never"
+			}
+			fmt.Printf("%-5d %-22s %-16s %-8d %-8s %s\n", r.ID, r.Name, r.TokenPrefix+"…", r.MachineIdentityID, machineFlagLabel(r), last)
+		}
+		return nil
+	},
+}
+
+func machineFlagLabel(r machineTokenHygieneRow) string {
+	switch {
+	case r.Expired && r.Stale:
+		return "exp,stale"
+	case r.Expired:
+		return "expired"
+	default:
+		return "stale"
+	}
+}
+
+// fetchMachineTokenHygiene GETs the hygiene list (split out for httptest tests).
+// days <= 0 lets the server default (90).
+func fetchMachineTokenHygiene(ctx context.Context, c *common.RemoteClient, days int) ([]machineTokenHygieneRow, error) {
+	path := "/api/v1/machine-token-hygiene"
+	if days > 0 {
+		path += "?days=" + strconv.Itoa(days)
+	}
+	var body struct {
+		Tokens []machineTokenHygieneRow `json:"tokens"`
+	}
+	if err := c.Get(ctx, path, &body); err != nil {
+		return nil, err
+	}
+	return body.Tokens, nil
+}
+
+func init() {
+	tokenHygieneCmd.Flags().IntVar(&tokenHygieneDays, "days", 0, "Staleness window in days (default server-side: 90, cap 3650)")
+	MachineCmd.AddCommand(tokenHygieneCmd)
+}

--- a/internal/cli/machine/token_hygiene_remote_test.go
+++ b/internal/cli/machine/token_hygiene_remote_test.go
@@ -1,0 +1,46 @@
+package machine
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func mtHygieneStub(t *testing.T) (*common.RemoteClient, func()) {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/machine-token-hygiene" {
+			_, _ = w.Write([]byte(`{"data":{"tokens":[{"id":2,"machine_identity_id":5,"name":"ci","token_prefix":"kx_machine_ci","last_used_at":"","expired":false,"stale":true},{"id":7,"machine_identity_id":9,"name":"old","token_prefix":"kx_machine_old","expired":true,"stale":false}],"total":2}}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	rc, ok := common.NewRemoteClient()
+	require.True(t, ok)
+	return rc, srv.Close
+}
+
+func TestFetchMachineTokenHygiene(t *testing.T) {
+	rc, done := mtHygieneStub(t)
+	defer done()
+	rows, err := fetchMachineTokenHygiene(context.Background(), rc, 30)
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+	assert.Equal(t, "ci", rows[0].Name)
+	assert.True(t, rows[0].Stale)
+	assert.Equal(t, uint(9), rows[1].MachineIdentityID)
+	assert.True(t, rows[1].Expired)
+}
+
+func TestMachineFlagLabel(t *testing.T) {
+	assert.Equal(t, "stale", machineFlagLabel(machineTokenHygieneRow{Stale: true}))
+	assert.Equal(t, "expired", machineFlagLabel(machineTokenHygieneRow{Expired: true}))
+	assert.Equal(t, "exp,stale", machineFlagLabel(machineTokenHygieneRow{Expired: true, Stale: true}))
+}


### PR DESCRIPTION
## What

CLI for machine-token hygiene (#359):

```
keyorix machine token-hygiene [--days N]
```

prints the deployment-wide machine-identity credentials that are **expired-but-active** or **stale** (`ID / NAME / PREFIX / MACHINE / FLAGS / LAST USED`).

## How

- GETs `/api/v1/machine-token-hygiene` via `common.RemoteClient` (server enforces global `system.read`).
- `fetchMachineTokenHygiene` split out for httptest; `machineFlagLabel` formats the expired/stale combination. Never prints a token secret (DTO carries only the prefix).

## Test

`TestFetchMachineTokenHygiene` (stale vs expired + machine id) and `TestMachineFlagLabel`. gofmt / go build / go test / gosec / golangci-lint all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)