### PR TITLE
feat(secrets): search secrets by description and tags, not just name

### DIFF
--- a/internal/core/secret_listing_query.go
+++ b/internal/core/secret_listing_query.go
@@ -239,7 +239,7 @@ func (c *KeyorixCore) applySecretFilters(ctx context.Context, secrets []*models.
 			continue
 		}
 		if filter.Search != nil && *filter.Search != "" {
-			if !strings.Contains(strings.ToLower(s.Name), strings.ToLower(*filter.Search)) {
+			if !c.secretMatchesSearch(ctx, s, strings.ToLower(*filter.Search)) {
 				continue
 			}
 		}
@@ -298,6 +298,29 @@ func (c *KeyorixCore) secretHasAllTags(ctx context.Context, secretID uint, want 
 		}
 	}
 	return true
+}
+
+// secretMatchesSearch reports whether the secret matches the (lower-cased) search
+// query by name, description, or any tag. Name/description are in-memory; tags are
+// looked up only when neither already matched (so the common name-hit costs nothing
+// extra). A tag-lookup error just means tags don't contribute to the match.
+func (c *KeyorixCore) secretMatchesSearch(ctx context.Context, s *models.SecretWithSharingInfo, q string) bool {
+	if strings.Contains(strings.ToLower(s.Name), q) {
+		return true
+	}
+	if s.Description != "" && strings.Contains(strings.ToLower(s.Description), q) {
+		return true
+	}
+	tags, err := c.storage.GetSecretTags(ctx, s.ID)
+	if err != nil {
+		return false
+	}
+	for _, t := range tags { // stored tags are already lower-cased
+		if strings.Contains(t, q) {
+			return true
+		}
+	}
+	return false
 }
 
 // sortSecrets sorts the secret list by name, created_at, updated_at, or owner.

--- a/internal/core/secret_search_metadata_test.go
+++ b/internal/core/secret_search_metadata_test.go
@@ -1,0 +1,66 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestSecretSearch_NameDescriptionTags(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	sqlDB, _ := db.DB()
+	sqlDB.SetMaxOpenConns(1)
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.Project{}, &models.Environment{}, &models.Tag{}, &models.SecretTag{}, &models.AuditEvent{}))
+	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
+	ctx := context.Background()
+	p, _ := c.storage.CreateProject(ctx, &models.Project{Name: "p1"})
+	e, _ := c.storage.CreateEnvironment(ctx, &models.Environment{Name: "production", ProjectID: p.ID})
+
+	mk := func(name, desc string, tags ...string) {
+		s, err := c.CreateSecret(ctx, &CreateSecretRequest{
+			Name: name, Value: []byte("supersecret1"), ProjectID: p.ID, EnvironmentID: e.ID,
+			Type: "password", CreatedBy: "owner", OwnerID: 1, Description: desc,
+		})
+		require.NoError(t, err)
+		if len(tags) > 0 {
+			_, err := c.SetSecretTags(ctx, s.ID, 1, tags)
+			require.NoError(t, err)
+		}
+	}
+	mk("alpha", "")
+	mk("beta", "the billing database")
+	mk("gamma", "", "payments")
+
+	search := func(q string) []string {
+		resp, err := c.ListSecretsInScope(ctx, &models.SecretListFilter{ProjectID: &p.ID, Search: &q})
+		require.NoError(t, err)
+		names := make([]string, 0, len(resp.Secrets))
+		for _, s := range resp.Secrets {
+			names = append(names, s.Name)
+		}
+		return names
+	}
+
+	t.Run("matches by name", func(t *testing.T) {
+		assert.Equal(t, []string{"alpha"}, search("alph"))
+	})
+	t.Run("matches by description", func(t *testing.T) {
+		assert.Equal(t, []string{"beta"}, search("billing"))
+	})
+	t.Run("matches by tag", func(t *testing.T) {
+		assert.Equal(t, []string{"gamma"}, search("payment"))
+	})
+	t.Run("no match returns nothing", func(t *testing.T) {
+		assert.Empty(t, search("zzz-nope"))
+	})
+}


### PR DESCRIPTION
## What

The secret-list `?search=` matched the **name only** — so a secret's description (#341) and tags (#335) were invisible to search. Now a search matches a secret if the query appears in its **name, description, or any tag**, across both list paths (admin scope + per-user owned/shared) via the shared `applySecretFilters`.

## How

- `secretMatchesSearch`: name and description checked in-memory; tags looked up **only when neither already matched** (so the common name-hit costs nothing extra). A tag-lookup error just means tags don't contribute. Case-insensitive (stored tags are already lower-cased).

## Test

`TestSecretSearch_NameDescriptionTags`: a query matches by name, by description, and by tag; a non-match returns nothing. Existing `applySecretFilters` tests (classification, expiry, tag-filter) still green.

gofmt / go build / go test / gosec / golangci-lint all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)