### PR TITLE
release: prep v0.65.0 (CHANGELOG + Helm charts)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,32 @@
 All notable changes to Keyorix are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## v0.65.0 — 2026-06-19
+
+Secret naming governance, machine-token hygiene, and richer search.
+
+### Added
+- **Secret naming policy** — an optional, operator-configured naming convention
+  (regex + max length) enforced at create, plus `GET /secrets/policy` so clients
+  can show the convention and pre-validate (surfaced as a hint in the web create
+  form). Off by default. ([#357], [#358])
+- **Machine-token hygiene** — `GET /machine-token-hygiene` (and
+  `keyorix machine token-hygiene`) surface deployment-wide machine credentials
+  that are expired-but-active or stale, with an admin web panel — completing
+  credential hygiene across PATs, sessions, and machine tokens. ([#359], [#360])
+- **Rotation-overdue in the project hygiene summary** — secrets past their
+  rotation policy's interval are now counted in `GET /projects/{id}/hygiene`
+  (and the CLI / web posture card). ([#356])
+- **Richer secret search** — the secret list `?search=` now matches a secret's
+  description and tags, not just its name. ([#361])
+
+[#356]: https://github.com/keyorixhq/keyorix/pull/356
+[#357]: https://github.com/keyorixhq/keyorix/pull/357
+[#358]: https://github.com/keyorixhq/keyorix/pull/358
+[#359]: https://github.com/keyorixhq/keyorix/pull/359
+[#360]: https://github.com/keyorixhq/keyorix/pull/360
+[#361]: https://github.com/keyorixhq/keyorix/pull/361
+
 ## v0.64.0 — 2026-06-19
 
 Audit CSV export, access-change notifications, and secret promote/copy.

--- a/deploy/helm/keyorix-k8s-sync/Chart.yaml
+++ b/deploy/helm/keyorix-k8s-sync/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix-k8s-sync
 description: Keyorix Kubernetes sync agent — materialises Keyorix secrets into native Kubernetes Secrets
 type: application
 # Chart version — tracks the Keyorix release version (published in lockstep).
-version: 0.64.0
+version: 0.65.0
 # The keyorix-k8s-sync image tag this chart deploys by default.
-appVersion: "0.64.0"
+appVersion: "0.65.0"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix

--- a/deploy/helm/keyorix/Chart.yaml
+++ b/deploy/helm/keyorix/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix
 description: Self-hosted Keyorix secrets manager (API server + web UI + PostgreSQL)
 type: application
 # Chart version — bump on chart changes.
-version: 0.64.0
+version: 0.65.0
 # The Keyorix app version this chart deploys by default (the image tag).
-appVersion: "0.64.0"
+appVersion: "0.65.0"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix


### PR DESCRIPTION
Release prep for **v0.65.0** — secret naming governance, machine-token hygiene, and richer search.

### Bundled since v0.64.0
- **Secret naming policy** + `GET /secrets/policy` (web create-form hint) ([#357], [#358])
- **Machine-token hygiene** — endpoint + CLI + admin panel ([#359], [#360])
- **Rotation-overdue** in the project hygiene summary ([#356])
- **Richer secret search** — name + description + tags ([#361])

(Web pieces ship with the app: naming-policy hint #77, machine-token panel #78, rotation tile #76.)

### This PR
- CHANGELOG v0.65.0 + PR link refs.
- Helm charts bumped lockstep to 0.65.0.

After merge: tag `v0.65.0` → release.yml (binaries + OCI charts) + docker-publish.yml (images).

🤖 Generated with [Claude Code](https://claude.com/claude-code)