### PR TITLE
feat(secrets): bulk environment promotion — copy all secrets env → env

### DIFF
--- a/internal/core/secret_copy_environment.go
+++ b/internal/core/secret_copy_environment.go
@@ -1,0 +1,67 @@
+// secret_copy_environment.go — bulk environment promotion: copy every secret in one
+// environment into another of the same project (e.g. seed production from staging).
+// Each secret goes through the single-secret CopySecret, so the same per-secret read
+// authorization, value handling, and same-project guard apply; a name that already
+// exists in the target is skipped (not overwritten), so a copy never clobbers. Reading
+// values is permission-checked; creating in the target is authorized by the caller.
+package core
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+)
+
+const copyEnvPageSize = 500
+
+// CopyEnvironmentSecrets copies every secret in sourceEnvID into targetEnvID (same
+// project), returning how many were copied and how many were skipped (a name already
+// present in the target, or a per-secret failure). The two environments must belong to
+// the same project.
+func (c *KeyorixCore) CopyEnvironmentSecrets(ctx context.Context, projectID, sourceEnvID, targetEnvID uint, actorUsername string, actorID uint) (copied, skipped int, err error) {
+	if projectID == 0 || sourceEnvID == 0 || targetEnvID == 0 {
+		return 0, 0, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "project, source and target environment IDs are required")
+	}
+	if sourceEnvID == targetEnvID {
+		return 0, 0, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "source and target environments must differ")
+	}
+
+	// Both environments must belong to the authorized project — so the project-scoped
+	// write gate the caller passed actually covers this copy (no cross-project bypass).
+	srcEnv, err := c.storage.GetEnvironment(ctx, sourceEnvID)
+	if err != nil {
+		return 0, 0, fmt.Errorf("%s: %w", i18n.T("ErrorValidation", nil), err)
+	}
+	tgtEnv, err := c.storage.GetEnvironment(ctx, targetEnvID)
+	if err != nil {
+		return 0, 0, fmt.Errorf("%s: %w", i18n.T("ErrorValidation", nil), err)
+	}
+	if srcEnv.ProjectID != projectID || tgtEnv.ProjectID != projectID {
+		return 0, 0, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "both environments must belong to the given project")
+	}
+
+	// Page through the source environment's secrets.
+	for page := 1; ; page++ {
+		secrets, total, lerr := c.storage.ListSecrets(ctx, &storage.SecretFilter{
+			EnvironmentID: &sourceEnvID, Page: page, PageSize: copyEnvPageSize,
+		})
+		if lerr != nil {
+			return copied, skipped, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), lerr)
+		}
+		for _, s := range secrets {
+			if _, cerr := c.CopySecret(ctx, s.ID, targetEnvID, "", actorUsername, actorID); cerr != nil {
+				// A name that already exists in the target is the common case — skip it
+				// (never clobber); other per-secret failures are skipped too, best-effort.
+				skipped++
+				continue
+			}
+			copied++
+		}
+		if len(secrets) < copyEnvPageSize || int64(page*copyEnvPageSize) >= total {
+			break
+		}
+	}
+	return copied, skipped, nil
+}

--- a/internal/core/secret_copy_environment_test.go
+++ b/internal/core/secret_copy_environment_test.go
@@ -1,0 +1,73 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestCopyEnvironmentSecrets(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	sqlDB, _ := db.DB()
+	sqlDB.SetMaxOpenConns(1)
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.Project{}, &models.Environment{}, &models.AuditEvent{}))
+	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
+	ctx := context.Background()
+	p, _ := c.storage.CreateProject(ctx, &models.Project{Name: "p1"})
+	staging, _ := c.storage.CreateEnvironment(ctx, &models.Environment{Name: "staging", ProjectID: p.ID})
+	prod, _ := c.storage.CreateEnvironment(ctx, &models.Environment{Name: "production", ProjectID: p.ID})
+	p2, _ := c.storage.CreateProject(ctx, &models.Project{Name: "p2"})
+	otherEnv, _ := c.storage.CreateEnvironment(ctx, &models.Environment{Name: "production", ProjectID: p2.ID})
+
+	mk := func(envID uint, name string) {
+		_, err := c.CreateSecret(ctx, &CreateSecretRequest{
+			Name: name, Value: []byte("supersecret1"), ProjectID: p.ID, EnvironmentID: envID,
+			Type: "password", CreatedBy: "owner", OwnerID: 1,
+		})
+		require.NoError(t, err)
+	}
+	mk(staging.ID, "db")
+	mk(staging.ID, "api")
+	mk(prod.ID, "db") // pre-existing in target → name clash, should be skipped
+
+	t.Run("copies new secrets, skips name clashes", func(t *testing.T) {
+		copied, skipped, err := c.CopyEnvironmentSecrets(ctx, p.ID, staging.ID, prod.ID, "owner", 1)
+		require.NoError(t, err)
+		assert.Equal(t, 1, copied, "only 'api' is new in prod")
+		assert.Equal(t, 1, skipped, "'db' already exists in prod")
+
+		// prod now has db (original) + api (copied).
+		resp, err := c.ListSecretsInScope(ctx, &models.SecretListFilter{ProjectID: &p.ID, EnvironmentID: &prod.ID})
+		require.NoError(t, err)
+		names := map[string]bool{}
+		for _, s := range resp.Secrets {
+			names[s.Name] = true
+		}
+		assert.True(t, names["db"] && names["api"])
+	})
+
+	t.Run("a cross-project target is rejected", func(t *testing.T) {
+		_, _, err := c.CopyEnvironmentSecrets(ctx, p.ID, staging.ID, otherEnv.ID, "owner", 1)
+		require.Error(t, err)
+	})
+
+	t.Run("source == target is rejected", func(t *testing.T) {
+		_, _, err := c.CopyEnvironmentSecrets(ctx, p.ID, staging.ID, staging.ID, "owner", 1)
+		require.Error(t, err)
+	})
+
+	t.Run("required IDs are validated", func(t *testing.T) {
+		_, _, err := c.CopyEnvironmentSecrets(ctx, 0, staging.ID, prod.ID, "owner", 1)
+		require.Error(t, err)
+	})
+}

--- a/server/http/handlers/secrets_copy_environment.go
+++ b/server/http/handlers/secrets_copy_environment.go
@@ -1,0 +1,58 @@
+// secrets_copy_environment.go — CopyEnvironmentSecrets handler: bulk-promote every
+// secret from one environment to another (same project).
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/keyorixhq/keyorix/server/middleware"
+)
+
+// CopyEnvironmentSecrets handles POST /api/v1/projects/{id}/environments/{envId}/copy-secrets
+// with {"target_environment_id":N} — copies every secret in {envId} into the target
+// environment (same project), skipping name clashes. Scoped secrets.write (project) is
+// enforced by the router; core verifies both environments belong to the project.
+func (h *SecretHandler) CopyEnvironmentSecrets(w http.ResponseWriter, r *http.Request) {
+	userCtx := middleware.GetUserFromContext(r.Context())
+	if userCtx == nil {
+		h.sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	projectID, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		h.sendError(w, "BadRequest", "Invalid project ID", http.StatusBadRequest, nil)
+		return
+	}
+	sourceEnvID, err := strconv.ParseUint(chi.URLParam(r, "envId"), 10, 32)
+	if err != nil {
+		h.sendError(w, "BadRequest", "Invalid environment ID", http.StatusBadRequest, nil)
+		return
+	}
+	var reqBody struct {
+		TargetEnvironmentID uint `json:"target_environment_id"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
+		h.sendError(w, "BadRequest", "Invalid request body", http.StatusBadRequest, nil)
+		return
+	}
+	if reqBody.TargetEnvironmentID == 0 {
+		h.sendError(w, "BadRequest", "target_environment_id is required", http.StatusBadRequest, nil)
+		return
+	}
+
+	copied, skipped, err := h.coreService.CopyEnvironmentSecrets(r.Context(), uint(projectID), uint(sourceEnvID), reqBody.TargetEnvironmentID, userCtx.Username, userCtx.UserID)
+	if err != nil {
+		status := http.StatusInternalServerError
+		msg := err.Error()
+		if strings.Contains(msg, "must ") || strings.Contains(msg, "required") || strings.Contains(msg, "belong") || strings.Contains(msg, "validation") {
+			status = http.StatusBadRequest
+		}
+		h.sendError(w, "Error", msg, status, nil)
+		return
+	}
+	h.sendSuccess(w, map[string]interface{}{"copied": copied, "skipped": skipped}, "")
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -308,6 +308,7 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		r.With(customMiddleware.RequireScopedPermission("secrets.write", projectScope)).Post("/projects/{id}/secrets/suspend-all", secretHandler.SuspendProjectSecrets)
 		r.With(customMiddleware.RequireScopedPermission("secrets.write", projectScope)).Post("/projects/{id}/secrets/resume-all", secretHandler.ResumeProjectSecrets)
 		r.With(customMiddleware.RequireScopedPermission("secrets.write", projectScope)).Post("/projects/{id}/secrets/reassign-owner", secretHandler.ReassignOwner)
+		r.With(customMiddleware.RequireScopedPermission("secrets.write", projectScope)).Post("/projects/{id}/environments/{envId}/copy-secrets", secretHandler.CopyEnvironmentSecrets)
 		r.With(customMiddleware.RequireScopedPermission("secrets.read", projectScope)).Get("/projects/{id}/environments", catalogHandler.ListProjectEnvironments)
 		r.With(customMiddleware.RequireScopedPermission("secrets.write", projectScope)).Post("/projects/{id}/environments", catalogHandler.CreateProjectEnvironment)
 		// Environment restore is nested under the project so the scope resolves


### PR DESCRIPTION
## What

Builds on single-secret copy (#353): **promote a whole environment** in one call — seed production from staging without copying each secret by hand.

```
POST /api/v1/projects/{id}/environments/{envId}/copy-secrets
{ "target_environment_id": N }
→ { "copied": 12, "skipped": 3 }
```

Copies every secret in the source environment into the target (same project), **skipping any name already present in the target** (never clobbers).

## How

- **core** — `CopyEnvironmentSecrets(projectID, sourceEnvID, targetEnvID, actor, actorID)`: both environments must belong to `projectID` (so the project-scoped write gate actually covers the copy — no cross-project bypass); pages the source env's secrets and routes each through `CopySecret` (per-secret read auth, value policy, same-project guard, name uniqueness). Best-effort: a name clash or per-secret failure is skipped, not fatal.
- **http** — scoped `secrets.write` (project) — **denies the read-only persona** (verified).

## Test

`TestCopyEnvironmentSecrets`: copies new + skips name clashes (prod keeps its own `db`, gains `api`); cross-project target rejected; source==target rejected; IDs validated.

gofmt / go build / go test / gosec / golangci-lint all clean.

## Follow-ups

CLI `secret copy-environment` + a web "Promote environment" action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)