### PR TITLE
feat(cli): secret copy-environment — bulk-promote an env via CLI

### DIFF
--- a/internal/cli/secret/copy_environment.go
+++ b/internal/cli/secret/copy_environment.go
@@ -1,0 +1,67 @@
+package secret
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/spf13/cobra"
+)
+
+var (
+	copyEnvProject uint
+	copyEnvFrom    uint
+	copyEnvTo      uint
+)
+
+var copyEnvironmentCmd = &cobra.Command{
+	Use:   "copy-environment",
+	Short: "Copy every secret from one environment into another (same project)",
+	Long: `Bulk-promote a whole environment — copy every secret from one environment into
+another of the same project (e.g. seed production from staging) in a single call.
+Name clashes in the target are skipped, never overwritten. Requires secrets.write in
+the target environment.`,
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		if copyEnvProject == 0 || copyEnvFrom == 0 || copyEnvTo == 0 {
+			return fmt.Errorf("--project, --from-environment and --to-environment are required")
+		}
+		if copyEnvFrom == copyEnvTo {
+			return fmt.Errorf("--from-environment and --to-environment must differ")
+		}
+		c, ok := common.NewRemoteClient()
+		if !ok {
+			return fmt.Errorf("not connected to a server — run: keyorix connect <server>")
+		}
+		copied, skipped, err := copyEnvironmentSecrets(context.Background(), c, copyEnvProject, copyEnvFrom, copyEnvTo)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("✅ Promoted environment %d → %d: %d copied, %d skipped (name clashes).\n", copyEnvFrom, copyEnvTo, copied, skipped)
+		return nil
+	},
+}
+
+// copyEnvironmentSecrets POSTs the bulk copy and returns the copied/skipped counts
+// (split out for tests).
+func copyEnvironmentSecrets(ctx context.Context, c *common.RemoteClient, projectID, fromEnv, toEnv uint) (copied, skipped int, err error) {
+	body := map[string]interface{}{"target_environment_id": toEnv}
+	var out struct {
+		Copied  int `json:"copied"`
+		Skipped int `json:"skipped"`
+	}
+	path := "/api/v1/projects/" + strconv.Itoa(int(projectID)) +
+		"/environments/" + strconv.Itoa(int(fromEnv)) + "/copy-secrets"
+	if err := c.Post(ctx, path, body, &out); err != nil {
+		return 0, 0, err
+	}
+	return out.Copied, out.Skipped, nil
+}
+
+func init() {
+	copyEnvironmentCmd.Flags().UintVar(&copyEnvProject, "project", 0, "Project ID (required)")
+	copyEnvironmentCmd.Flags().UintVar(&copyEnvFrom, "from-environment", 0, "Source environment ID (required)")
+	copyEnvironmentCmd.Flags().UintVar(&copyEnvTo, "to-environment", 0, "Target environment ID, same project (required)")
+	SecretCmd.AddCommand(copyEnvironmentCmd)
+}

--- a/internal/cli/secret/copy_environment_remote_test.go
+++ b/internal/cli/secret/copy_environment_remote_test.go
@@ -1,0 +1,51 @@
+package secret
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func copyEnvStub(t *testing.T) (*common.RemoteClient, func()) {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && r.URL.Path == "/api/v1/projects/7/environments/3/copy-secrets" {
+			b, _ := io.ReadAll(r.Body)
+			var got map[string]interface{}
+			_ = json.Unmarshal(b, &got)
+			if got["target_environment_id"] != nil {
+				_, _ = w.Write([]byte(`{"data":{"copied":4,"skipped":1},"message":""}`))
+				return
+			}
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	rc, ok := common.NewRemoteClient()
+	require.True(t, ok)
+	return rc, srv.Close
+}
+
+func TestCopyEnvironmentSecrets(t *testing.T) {
+	rc, done := copyEnvStub(t)
+	defer done()
+	copied, skipped, err := copyEnvironmentSecrets(context.Background(), rc, 7, 3, 5)
+	require.NoError(t, err)
+	assert.Equal(t, 4, copied)
+	assert.Equal(t, 1, skipped)
+}
+
+func TestCopyEnvironmentSecrets_NotFound(t *testing.T) {
+	rc, done := copyEnvStub(t)
+	defer done()
+	_, _, err := copyEnvironmentSecrets(context.Background(), rc, 99, 3, 5)
+	require.Error(t, err)
+}


### PR DESCRIPTION
## What

Adds `keyorix secret copy-environment` — the CLI surface for the #363 bulk environment promotion endpoint (`POST /projects/{id}/environments/{envId}/copy-secrets`). Lets an operator seed one environment from another (e.g. staging → production) in a single call:

```
keyorix secret copy-environment --project 7 --from-environment 3 --to-environment 5
✅ Promoted environment 3 → 5: 4 copied, 1 skipped (name clashes).
```

## Details

- Flags `--project / --from-environment / --to-environment`, all required; rejects `from == to`.
- Name clashes in the target are skipped server-side, never overwritten; the command prints the copied/skipped counts returned by the server.
- Helper `copyEnvironmentSecrets` split out for `httptest` coverage (copied/skipped decode + not-found error path).
- Mirrors the existing single-secret `secret copy` command. No new deps, no storage changes.

## Tests / gates (local)

gofmt clean · `go build ./...` · `go vet` · package tests pass · golangci-lint 0 issues · gosec 0 issues · verified `--help` + command registration.

Completes secret env-promotion on the CLI surface (server #363). Web "Promote environment" remains as the follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)