### PR TITLE
feat(hygiene): deployment-wide secret-hygiene rollup — GET /hygiene

### DIFF
--- a/internal/core/deployment_hygiene.go
+++ b/internal/core/deployment_hygiene.go
@@ -1,0 +1,61 @@
+// deployment_hygiene.go — install-wide hygiene rollup: aggregate every project's
+// hygiene posture (orphaned / unused / expiring secrets, stale machine identities,
+// rotation-overdue) into deployment-wide totals plus a per-project breakdown of the
+// projects that actually carry debt. Counts only — no names or values of secrets —
+// so it is safe to surface to an admin overseeing many projects, and cheap enough to
+// poll for a dashboard. Parallels the deployment-wide PAT ([[pat_hygiene]]) and
+// machine-token hygiene views; built on the per-project [[project_hygiene]] summary.
+package core
+
+import (
+	"context"
+	"fmt"
+)
+
+// DeploymentHygiene is the install-wide hygiene rollup: summed totals across all
+// projects plus a per-project breakdown limited to projects with outstanding signals.
+type DeploymentHygiene struct {
+	Totals   ProjectHygiene            `json:"totals"`
+	Projects []ProjectHygieneBreakdown `json:"projects"`
+}
+
+// ProjectHygieneBreakdown is one project's hygiene counts, identified for the admin.
+type ProjectHygieneBreakdown struct {
+	ProjectID   uint   `json:"project_id"`
+	ProjectName string `json:"project_name"`
+	ProjectHygiene
+}
+
+// DeploymentHygieneSummary sums each hygiene signal across every (live) project and
+// lists the projects with at least one outstanding signal. Healthy projects are
+// omitted from the breakdown but contribute their (zero) counts to the totals. The
+// windows (in days) default when non-positive, matching ProjectHygieneSummary.
+func (c *KeyorixCore) DeploymentHygieneSummary(ctx context.Context, unusedDays, expiringDays, staleMIDays int) (*DeploymentHygiene, error) {
+	projects, err := c.ListProjects(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list projects: %w", err)
+	}
+
+	out := &DeploymentHygiene{Projects: make([]ProjectHygieneBreakdown, 0)}
+	for _, p := range projects {
+		summary, err := c.ProjectHygieneSummary(ctx, p.ID, unusedDays, expiringDays, staleMIDays)
+		if err != nil {
+			return nil, fmt.Errorf("project %d hygiene: %w", p.ID, err)
+		}
+		out.Totals.OrphanedSecrets += summary.OrphanedSecrets
+		out.Totals.UnusedSecrets += summary.UnusedSecrets
+		out.Totals.ExpiringSecrets += summary.ExpiringSecrets
+		out.Totals.StaleMachineIdentities += summary.StaleMachineIdentities
+		out.Totals.RotationOverdue += summary.RotationOverdue
+
+		if summary.OrphanedSecrets+summary.UnusedSecrets+summary.ExpiringSecrets+
+			summary.StaleMachineIdentities+summary.RotationOverdue > 0 {
+			out.Projects = append(out.Projects, ProjectHygieneBreakdown{
+				ProjectID:      p.ID,
+				ProjectName:    p.Name,
+				ProjectHygiene: *summary,
+			})
+		}
+	}
+	return out, nil
+}

--- a/internal/core/deployment_hygiene_test.go
+++ b/internal/core/deployment_hygiene_test.go
@@ -1,0 +1,85 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestDeploymentHygieneSummary(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	sqlDB, _ := db.DB()
+	sqlDB.SetMaxOpenConns(1)
+	require.NoError(t, db.AutoMigrate(
+		&models.SecretNode{}, &models.SecretVersion{}, &models.User{}, &models.Project{},
+		&models.Environment{}, &models.SecretAccessLog{}, &models.MachineIdentity{}, &models.AuditEvent{},
+		&models.RotationPolicy{},
+	))
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "owner", Email: "o@t.com"}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 2, Username: "leaver", Email: "l@t.com"}).Error)
+
+	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
+	ctx := context.Background()
+	now := time.Now()
+
+	// p1 carries debt: one orphaned secret (owner 2 departs) + one expiring secret.
+	p1, err := c.storage.CreateProject(ctx, &models.Project{Name: "p1"})
+	require.NoError(t, err)
+	e1, err := c.storage.CreateEnvironment(ctx, &models.Environment{Name: "production", ProjectID: p1.ID})
+	require.NoError(t, err)
+	soon := now.Add(10 * 24 * time.Hour)
+	_, err = c.storage.CreateSecret(ctx, &models.SecretNode{
+		Name: "orphan", ProjectID: p1.ID, EnvironmentID: e1.ID, Type: "password", OwnerID: 2,
+		IsSecret: true, CreatedAt: now, UpdatedAt: now,
+	})
+	require.NoError(t, err)
+	_, err = c.storage.CreateSecret(ctx, &models.SecretNode{
+		Name: "expiring", ProjectID: p1.ID, EnvironmentID: e1.ID, Type: "password", OwnerID: 1,
+		IsSecret: true, Expiration: &soon, CreatedAt: now, UpdatedAt: now,
+	})
+	require.NoError(t, err)
+	require.NoError(t, c.storage.DeleteUser(ctx, 2)) // offboard → "orphan" is orphaned
+
+	// p2 is clean: a single secret with a recent read (not unused), live owner, no expiry.
+	p2, err := c.storage.CreateProject(ctx, &models.Project{Name: "p2"})
+	require.NoError(t, err)
+	e2, err := c.storage.CreateEnvironment(ctx, &models.Environment{Name: "production", ProjectID: p2.ID})
+	require.NoError(t, err)
+	clean, err := c.storage.CreateSecret(ctx, &models.SecretNode{
+		Name: "ok", ProjectID: p2.ID, EnvironmentID: e2.ID, Type: "password", OwnerID: 1,
+		IsSecret: true, CreatedAt: now, UpdatedAt: now,
+	})
+	require.NoError(t, err)
+	require.NoError(t, c.storage.CreateSecretAccessLog(ctx, &models.SecretAccessLog{
+		SecretNodeID: clean.ID, AccessedBy: "owner", Action: "read", AccessTime: now,
+	}))
+
+	t.Run("totals sum across projects; breakdown lists only projects with debt", func(t *testing.T) {
+		h, err := c.DeploymentHygieneSummary(ctx, 90, 30, 90)
+		require.NoError(t, err)
+		assert.Equal(t, 1, h.Totals.OrphanedSecrets)
+		assert.Equal(t, 1, h.Totals.ExpiringSecrets)
+		assert.Equal(t, 2, h.Totals.UnusedSecrets, "both p1 secrets are unused; p2's was read")
+
+		require.Len(t, h.Projects, 1, "only p1 has outstanding signals")
+		assert.Equal(t, p1.ID, h.Projects[0].ProjectID)
+		assert.Equal(t, "p1", h.Projects[0].ProjectName)
+		assert.Equal(t, 1, h.Projects[0].OrphanedSecrets)
+	})
+
+	t.Run("windows default when non-positive", func(t *testing.T) {
+		h, err := c.DeploymentHygieneSummary(ctx, 0, 0, 0)
+		require.NoError(t, err)
+		assert.Equal(t, 1, h.Totals.OrphanedSecrets)
+	})
+}

--- a/server/http/handlers/deployment_hygiene.go
+++ b/server/http/handlers/deployment_hygiene.go
@@ -1,0 +1,37 @@
+// deployment_hygiene.go — DeploymentHygiene handler: the install-wide hygiene rollup
+// (per-project posture summed across every project, plus a breakdown of the projects
+// that carry debt). Counts only. Deployment-wide system.read is enforced by the router.
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/keyorixhq/keyorix/server/middleware"
+)
+
+// DeploymentHygiene handles GET /api/v1/hygiene — one call returning install-wide
+// hygiene totals + the projects with outstanding signals (counts only). Optional
+// ?unused_days / ?expiring_days / ?stale_days override the per-project windows.
+func (h *SecretHandler) DeploymentHygiene(w http.ResponseWriter, r *http.Request) {
+	if middleware.GetUserFromContext(r.Context()) == nil {
+		h.sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	qint := func(key string) int {
+		if v := r.URL.Query().Get(key); v != "" {
+			if n, perr := strconv.Atoi(v); perr == nil {
+				return n
+			}
+		}
+		return 0
+	}
+
+	summary, err := h.coreService.DeploymentHygieneSummary(r.Context(),
+		qint("unused_days"), qint("expiring_days"), qint("stale_days"))
+	if err != nil {
+		h.sendError(w, "InternalError", "Failed to compute hygiene rollup", http.StatusInternalServerError, nil)
+		return
+	}
+	h.sendSuccess(w, summary, "")
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -538,6 +538,9 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		// Machine-token hygiene — deployment-wide stale / expired-but-active machine
 		// credentials an admin should revoke (non-human token sprawl).
 		r.With(customMiddleware.RequirePermission("system.read")).Get("/machine-token-hygiene", catalogHandler.MachineTokenHygiene)
+		// Secret-hygiene rollup — deployment-wide totals of every project's posture
+		// (orphaned / unused / expiring / stale-MI / rotation-overdue) + per-project breakdown.
+		r.With(customMiddleware.RequirePermission("system.read")).Get("/hygiene", secretHandler.DeploymentHygiene)
 
 		// Compliance posture — deployment-wide controls snapshot for auditors.
 		r.With(customMiddleware.RequirePermission("system.read")).Get("/compliance/posture", dashboardHandler.GetCompliancePosture)


### PR DESCRIPTION
## What

Secret hygiene was **per-project only** (`/projects/{id}/hygiene`), while credential hygiene (PAT, machine-token) already had deployment-wide rollups (`/pat-hygiene`, `/machine-token-hygiene`). An admin overseeing many projects had no single view of total secret cleanup debt.

Adds `GET /api/v1/hygiene` — the install-wide secret-hygiene rollup:

- `core.DeploymentHygieneSummary` iterates every live project, sums the 5 signals (orphaned / unused / expiring / stale-MI / rotation-overdue) into install-wide **totals**, and returns a **per-project breakdown** limited to projects that actually carry debt (healthy projects are omitted from the list but still counted in totals).
- Counts only — never secret names or values.
- Deployment-wide `system.read` (mirrors `/pat-hygiene`); optional `?unused_days / ?expiring_days / ?stale_days` windows.
- Reuses the existing per-project evaluator — no new storage method.

## Test

Real in-memory SQLite: totals sum across a debt-carrying and a clean project; the breakdown lists only the former; windows default when non-positive.

## Gates (local)

gofmt clean · `go build ./...` · `go vet` · `internal/core` + `server/http/handlers` tests pass · golangci-lint 0 · gosec 0. (The known local-only `TestEveryMutatingRouteDeniesReadOnly` /sw.js + evidence/verify failure is unrelated — green in CI — and this new route is a read-only GET.)

Follow-up: CLI `hygiene` command + a web admin panel beside the credential-hygiene panels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)