### PR TITLE
feat(cli): hygiene — deployment-wide secret-hygiene rollup

### DIFF
--- a/internal/cli/hygiene/hygiene.go
+++ b/internal/cli/hygiene/hygiene.go
@@ -1,0 +1,114 @@
+// Package hygiene is the top-level `keyorix hygiene` command: the deployment-wide
+// secret-hygiene rollup — install-wide totals of every project's cleanup signals plus
+// a per-project breakdown of the projects that carry debt. The per-project view is
+// `keyorix project hygiene <id>`; this is the admin's bird's-eye counterpart.
+package hygiene
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/spf13/cobra"
+)
+
+var (
+	unusedDays   int
+	expiringDays int
+	staleDays    int
+)
+
+// counts mirrors the per-project hygiene tally (counts only).
+type counts struct {
+	OrphanedSecrets        int `json:"orphaned_secrets"`
+	UnusedSecrets          int `json:"unused_secrets"`
+	ExpiringSecrets        int `json:"expiring_secrets"`
+	StaleMachineIdentities int `json:"stale_machine_identities"`
+	RotationOverdue        int `json:"rotation_overdue"`
+}
+
+// projectBreakdown is one project's counts, identified.
+type projectBreakdown struct {
+	ProjectID   uint   `json:"project_id"`
+	ProjectName string `json:"project_name"`
+	counts
+}
+
+// rollup mirrors the GET /hygiene response.
+type rollup struct {
+	Totals   counts             `json:"totals"`
+	Projects []projectBreakdown `json:"projects"`
+}
+
+// HygieneCmd is the top-level deployment-wide hygiene command.
+var HygieneCmd = &cobra.Command{
+	Use:   "hygiene",
+	Short: "Deployment-wide secret-hygiene rollup across all projects (admin)",
+	Long: `Summarize every project's outstanding cleanup signals in one call: secrets whose
+owner departed, secrets unused for a long window, secrets expiring/expired, stale
+machine identities, and secrets overdue for rotation. Shows install-wide totals plus a
+per-project breakdown of the projects that carry debt. Requires global system.read.
+Counts only — never secret names or values.`,
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		c, ok := common.NewRemoteClient()
+		if !ok {
+			return fmt.Errorf("not connected to a server — run: keyorix connect <server>")
+		}
+		r, err := fetchDeploymentHygiene(context.Background(), c, unusedDays, expiringDays, staleDays)
+		if err != nil {
+			return err
+		}
+		printRollup(r)
+		return nil
+	},
+}
+
+func printRollup(r *rollup) {
+	fmt.Println("Deployment-wide hygiene totals:")
+	fmt.Printf("  orphaned secrets         %d\n", r.Totals.OrphanedSecrets)
+	fmt.Printf("  unused secrets           %d\n", r.Totals.UnusedSecrets)
+	fmt.Printf("  expiring/expired secrets %d\n", r.Totals.ExpiringSecrets)
+	fmt.Printf("  stale machine identities %d\n", r.Totals.StaleMachineIdentities)
+	fmt.Printf("  rotation overdue         %d\n", r.Totals.RotationOverdue)
+
+	if len(r.Projects) == 0 {
+		fmt.Println("\nNo projects carry outstanding signals. ✅")
+		return
+	}
+	fmt.Printf("\nProjects with debt (%d):\n", len(r.Projects))
+	fmt.Printf("%-6s %-22s %-9s %-7s %-9s %-9s %s\n", "ID", "NAME", "ORPHANED", "UNUSED", "EXPIRING", "STALE-MI", "ROT-OVERDUE")
+	for _, p := range r.Projects {
+		fmt.Printf("%-6d %-22s %-9d %-7d %-9d %-9d %d\n",
+			p.ProjectID, p.ProjectName, p.OrphanedSecrets, p.UnusedSecrets,
+			p.ExpiringSecrets, p.StaleMachineIdentities, p.RotationOverdue)
+	}
+}
+
+// fetchDeploymentHygiene GETs the rollup (split out for httptest tests). Non-positive
+// windows are omitted so the server applies its defaults.
+func fetchDeploymentHygiene(ctx context.Context, c *common.RemoteClient, unused, expiring, stale int) (*rollup, error) {
+	path := "/api/v1/hygiene"
+	sep := "?"
+	add := func(key string, val int) {
+		if val > 0 {
+			path += sep + key + "=" + fmt.Sprintf("%d", val)
+			sep = "&"
+		}
+	}
+	add("unused_days", unused)
+	add("expiring_days", expiring)
+	add("stale_days", stale)
+
+	var out rollup
+	if err := c.Get(ctx, path, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func init() {
+	HygieneCmd.Flags().IntVar(&unusedDays, "unused-days", 0, "Unused-secret window in days (default server-side: 90)")
+	HygieneCmd.Flags().IntVar(&expiringDays, "expiring-days", 0, "Expiring-secret window in days (default server-side: 30)")
+	HygieneCmd.Flags().IntVar(&staleDays, "stale-days", 0, "Stale-machine-identity window in days (default server-side: 90)")
+}

--- a/internal/cli/hygiene/hygiene_remote_test.go
+++ b/internal/cli/hygiene/hygiene_remote_test.go
@@ -1,0 +1,66 @@
+package hygiene
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func hygieneStub(t *testing.T, body string) (*common.RemoteClient, func(), *string) {
+	t.Helper()
+	var gotQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/hygiene" {
+			gotQuery = r.URL.RawQuery
+			_, _ = w.Write([]byte(body))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	rc, ok := common.NewRemoteClient()
+	require.True(t, ok)
+	return rc, srv.Close, &gotQuery
+}
+
+func TestFetchDeploymentHygiene(t *testing.T) {
+	const body = `{"data":{"totals":{"orphaned_secrets":1,"unused_secrets":3,"expiring_secrets":2,"stale_machine_identities":0,"rotation_overdue":1},"projects":[{"project_id":7,"project_name":"web","orphaned_secrets":1,"unused_secrets":2,"expiring_secrets":1,"stale_machine_identities":0,"rotation_overdue":1}]}}`
+	rc, done, _ := hygieneStub(t, body)
+	defer done()
+
+	r, err := fetchDeploymentHygiene(context.Background(), rc, 0, 0, 0)
+	require.NoError(t, err)
+	assert.Equal(t, 1, r.Totals.OrphanedSecrets)
+	assert.Equal(t, 3, r.Totals.UnusedSecrets)
+	require.Len(t, r.Projects, 1)
+	assert.Equal(t, uint(7), r.Projects[0].ProjectID)
+	assert.Equal(t, "web", r.Projects[0].ProjectName)
+	assert.Equal(t, 1, r.Projects[0].RotationOverdue)
+}
+
+func TestFetchDeploymentHygiene_PassesWindows(t *testing.T) {
+	rc, done, gotQuery := hygieneStub(t, `{"data":{"totals":{},"projects":[]}}`)
+	defer done()
+
+	_, err := fetchDeploymentHygiene(context.Background(), rc, 30, 7, 60)
+	require.NoError(t, err)
+	// Only positive windows are sent; zero ones are omitted.
+	assert.Contains(t, *gotQuery, "unused_days=30")
+	assert.Contains(t, *gotQuery, "expiring_days=7")
+	assert.Contains(t, *gotQuery, "stale_days=60")
+}
+
+func TestFetchDeploymentHygiene_OmitsZeroWindows(t *testing.T) {
+	rc, done, gotQuery := hygieneStub(t, `{"data":{"totals":{},"projects":[]}}`)
+	defer done()
+
+	_, err := fetchDeploymentHygiene(context.Background(), rc, 0, 0, 0)
+	require.NoError(t, err)
+	assert.Empty(t, *gotQuery, "no window flags → no query string")
+}

--- a/internal/cli/main.go
+++ b/internal/cli/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/keyorixhq/keyorix/internal/cli/dynamic"
 	"github.com/keyorixhq/keyorix/internal/cli/encryption"
 	"github.com/keyorixhq/keyorix/internal/cli/group"
+	"github.com/keyorixhq/keyorix/internal/cli/hygiene"
 	"github.com/keyorixhq/keyorix/internal/cli/invite"
 	"github.com/keyorixhq/keyorix/internal/cli/legalhold"
 	"github.com/keyorixhq/keyorix/internal/cli/machine"
@@ -75,6 +76,7 @@ func init() {
 	rootCmd.AddCommand(breakglass.BreakGlassCmd)
 	rootCmd.AddCommand(compliance.ComplianceCmd)
 	rootCmd.AddCommand(sodcli.SoDCmd)
+	rootCmd.AddCommand(hygiene.HygieneCmd)
 }
 
 // Execute runs the root command


### PR DESCRIPTION
## What

CLI for the #365 `GET /hygiene` endpoint. `keyorix hygiene` prints the install-wide secret-hygiene rollup:

- **Totals** of the 5 cleanup signals across all projects (orphaned / unused / expiring / stale-MI / rotation-overdue).
- A **per-project breakdown** table of the projects that actually carry debt.

Top-level command — the admin's bird's-eye counterpart to the project-scoped `keyorix project hygiene <id>`. Requires global `system.read`; counts only, never secret names or values.

Optional `--unused-days / --expiring-days / --stale-days` windows; only positive values are sent so the server applies its defaults.

## Test

`fetchDeploymentHygiene` split out for httptest: decodes totals + breakdown, passes positive window params through, omits zero windows from the query string.

## Gates (local)

gofmt clean · `go build ./...` · `go vet` · package tests pass · golangci-lint 0 · gosec 0 · verified `hygiene --help` + command registration.

Completes the deployment-hygiene rollup on the CLI surface (server #365). Web admin panel (beside the PAT/machine-token hygiene panels) remains as the follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)