### PR TITLE
feat(secrets): asset-inventory CSV export — GET /projects/{id}/secrets/inventory.csv

### DIFF
--- a/internal/core/secret_inventory.go
+++ b/internal/core/secret_inventory.go
@@ -1,0 +1,98 @@
+// secret_inventory.go — a project's secret asset inventory: a metadata manifest of
+// every live secret (name, environment, type, classification, owner, timestamps) with
+// NO secret values. Backs the compliance asset-inventory export (ISO 27001 A.5.9 —
+// inventory of information assets). Counts/metadata only, so it is safe to hand to an
+// auditor. Project-scoped (route-gated secrets.read), parallel to [[project_hygiene]].
+package core
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+)
+
+// secretInventoryMaxRows bounds a single inventory pull.
+const secretInventoryMaxRows = 10000
+
+// SecretInventoryItem is one secret's metadata row — never its value.
+type SecretInventoryItem struct {
+	ID              uint       `json:"id"`
+	Name            string     `json:"name"`
+	EnvironmentID   uint       `json:"environment_id"`
+	EnvironmentName string     `json:"environment_name"`
+	Type            string     `json:"type"`
+	Classification  string     `json:"classification"`
+	OwnerID         uint       `json:"owner_id"`
+	OwnerUsername   string     `json:"owner_username"`
+	CreatedAt       time.Time  `json:"created_at"`
+	Expiration      *time.Time `json:"expiration,omitempty"`
+	LastRotatedAt   *time.Time `json:"last_rotated_at,omitempty"`
+}
+
+// SecretsInventory returns the metadata manifest of every live secret in the project
+// (folders excluded), environment/owner names resolved, sorted by environment then
+// name. Never reads or returns a secret value. Bounded to secretInventoryMaxRows.
+func (c *KeyorixCore) SecretsInventory(ctx context.Context, projectID uint) ([]SecretInventoryItem, error) {
+	if projectID == 0 {
+		return nil, fmt.Errorf("project ID is required")
+	}
+
+	secrets, _, err := c.storage.ListSecrets(ctx, &storage.SecretFilter{
+		ProjectID: &projectID, Page: 1, PageSize: secretInventoryMaxRows,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list secrets: %w", err)
+	}
+
+	// Resolve environment names once (id → name) for this project.
+	envName := map[uint]string{}
+	if envs, err := c.storage.ListEnvironmentsByProject(ctx, projectID); err == nil {
+		for _, e := range envs {
+			envName[e.ID] = e.Name
+		}
+	}
+
+	// Resolve owner usernames once per distinct owner.
+	ownerName := map[uint]string{}
+	for _, s := range secrets {
+		if s.IsSecret && s.OwnerID != 0 {
+			ownerName[s.OwnerID] = ""
+		}
+	}
+	for id := range ownerName {
+		if u, err := c.storage.GetUser(ctx, id); err == nil && u != nil {
+			ownerName[id] = u.Username
+		}
+	}
+
+	out := make([]SecretInventoryItem, 0, len(secrets))
+	for _, s := range secrets {
+		if !s.IsSecret {
+			continue // skip folder nodes — an inventory lists assets, not containers
+		}
+		out = append(out, SecretInventoryItem{
+			ID:              s.ID,
+			Name:            s.Name,
+			EnvironmentID:   s.EnvironmentID,
+			EnvironmentName: envName[s.EnvironmentID],
+			Type:            s.Type,
+			Classification:  s.Classification,
+			OwnerID:         s.OwnerID,
+			OwnerUsername:   ownerName[s.OwnerID],
+			CreatedAt:       s.CreatedAt,
+			Expiration:      s.Expiration,
+			LastRotatedAt:   s.LastRotatedAt,
+		})
+	}
+
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].EnvironmentName != out[j].EnvironmentName {
+			return out[i].EnvironmentName < out[j].EnvironmentName
+		}
+		return out[i].Name < out[j].Name
+	})
+	return out, nil
+}

--- a/internal/core/secret_inventory_test.go
+++ b/internal/core/secret_inventory_test.go
@@ -1,0 +1,77 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestSecretsInventory(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	sqlDB, _ := db.DB()
+	sqlDB.SetMaxOpenConns(1)
+	require.NoError(t, db.AutoMigrate(
+		&models.SecretNode{}, &models.SecretVersion{}, &models.User{}, &models.Project{},
+		&models.Environment{}, &models.SecretAccessLog{},
+	))
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "alice", Email: "a@t.com"}).Error)
+
+	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
+	ctx := context.Background()
+	now := time.Now()
+
+	p, err := c.storage.CreateProject(ctx, &models.Project{Name: "p1"})
+	require.NoError(t, err)
+	prod, err := c.storage.CreateEnvironment(ctx, &models.Environment{Name: "production", ProjectID: p.ID})
+	require.NoError(t, err)
+	dev, err := c.storage.CreateEnvironment(ctx, &models.Environment{Name: "development", ProjectID: p.ID})
+	require.NoError(t, err)
+
+	exp := now.Add(48 * time.Hour)
+	_, err = c.storage.CreateSecret(ctx, &models.SecretNode{
+		Name: "db-pass", ProjectID: p.ID, EnvironmentID: prod.ID, Type: "password", OwnerID: 1,
+		Classification: "confidential", IsSecret: true, Expiration: &exp, CreatedAt: now, UpdatedAt: now,
+	})
+	require.NoError(t, err)
+	_, err = c.storage.CreateSecret(ctx, &models.SecretNode{
+		Name: "api-key", ProjectID: p.ID, EnvironmentID: dev.ID, Type: "api_key", OwnerID: 1,
+		IsSecret: true, CreatedAt: now, UpdatedAt: now,
+	})
+	require.NoError(t, err)
+	// A folder node — must be excluded from the inventory.
+	_, err = c.storage.CreateSecret(ctx, &models.SecretNode{
+		Name: "folder", ProjectID: p.ID, EnvironmentID: dev.ID, IsSecret: false, CreatedAt: now, UpdatedAt: now,
+	})
+	require.NoError(t, err)
+
+	t.Run("lists secret metadata, excludes folders, resolves names, sorts by env then name", func(t *testing.T) {
+		inv, err := c.SecretsInventory(ctx, p.ID)
+		require.NoError(t, err)
+		require.Len(t, inv, 2, "two secrets; the folder is excluded")
+
+		// Sorted by environment (development < production) then name.
+		assert.Equal(t, "development", inv[0].EnvironmentName)
+		assert.Equal(t, "api-key", inv[0].Name)
+		assert.Equal(t, "alice", inv[0].OwnerUsername)
+
+		assert.Equal(t, "production", inv[1].EnvironmentName)
+		assert.Equal(t, "db-pass", inv[1].Name)
+		assert.Equal(t, "confidential", inv[1].Classification)
+		require.NotNil(t, inv[1].Expiration)
+	})
+
+	t.Run("a project ID of zero is rejected", func(t *testing.T) {
+		_, err := c.SecretsInventory(ctx, 0)
+		require.Error(t, err)
+	})
+}

--- a/server/http/handlers/secrets_inventory_csv.go
+++ b/server/http/handlers/secrets_inventory_csv.go
@@ -1,0 +1,66 @@
+// secrets_inventory_csv.go — SecretsInventoryCSV handler: a CSV asset-inventory
+// manifest of a project's secrets (metadata only, never values) for compliance
+// hand-off (ISO 27001 A.5.9). Scoped secrets.read (project) is enforced by the router.
+package handlers
+
+import (
+	"encoding/csv"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/keyorixhq/keyorix/server/middleware"
+)
+
+// SecretsInventoryCSV handles GET /api/v1/projects/{id}/secrets/inventory.csv — every
+// live secret in the project as a CSV attachment (id, name, environment, type,
+// classification, owner, created, expiration, last-rotated). No secret values.
+func (h *SecretHandler) SecretsInventoryCSV(w http.ResponseWriter, r *http.Request) {
+	if middleware.GetUserFromContext(r.Context()) == nil {
+		h.sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		h.sendError(w, "BadRequest", "Invalid project ID", http.StatusBadRequest, nil)
+		return
+	}
+
+	items, err := h.coreService.SecretsInventory(r.Context(), uint(id))
+	if err != nil {
+		h.sendError(w, "InternalError", "Failed to build secret inventory", http.StatusInternalServerError, nil)
+		return
+	}
+
+	tstr := func(t *time.Time) string {
+		if t == nil {
+			return ""
+		}
+		return t.UTC().Format(time.RFC3339)
+	}
+
+	w.Header().Set("Content-Type", "text/csv; charset=utf-8")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.Header().Set("Content-Disposition", `attachment; filename="secret-inventory.csv"`)
+
+	cw := csv.NewWriter(w)
+	defer cw.Flush()
+	_ = cw.Write([]string{
+		"id", "name", "environment", "type", "classification",
+		"owner", "created_at", "expiration", "last_rotated_at",
+	})
+	for _, it := range items {
+		_ = cw.Write([]string{
+			strconv.FormatUint(uint64(it.ID), 10),
+			it.Name,
+			it.EnvironmentName,
+			it.Type,
+			it.Classification,
+			it.OwnerUsername,
+			it.CreatedAt.UTC().Format(time.RFC3339),
+			tstr(it.Expiration),
+			tstr(it.LastRotatedAt),
+		})
+	}
+}

--- a/server/http/handlers/secrets_inventory_csv_test.go
+++ b/server/http/handlers/secrets_inventory_csv_test.go
@@ -1,0 +1,61 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestSecretsInventoryCSV(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.SecretNode{}, &models.SecretVersion{}, &models.User{}, &models.Project{}, &models.Environment{},
+	))
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "alice", Email: "a@t.com"}).Error)
+	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "p1"}).Error)
+	require.NoError(t, db.Create(&models.Environment{ID: 1, Name: "production", ProjectID: 1}).Error)
+	require.NoError(t, db.Create(&models.SecretNode{
+		Name: "db-pass", ProjectID: 1, EnvironmentID: 1, Type: "password", OwnerID: 1,
+		Classification: "confidential", IsSecret: true, CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	}).Error)
+
+	h, err := NewSecretHandler(core.NewKeyorixCore(store.NewLocalStorage(db)))
+	require.NoError(t, err)
+
+	t.Run("returns a CSV attachment with a header and the secret metadata, no value", func(t *testing.T) {
+		req := withChiParam(withUserCtx(httptest.NewRequest(http.MethodGet, "/api/v1/projects/1/secrets/inventory.csv", nil)), "id", "1")
+		w := httptest.NewRecorder()
+		h.SecretsInventoryCSV(w, req)
+
+		require.Equal(t, http.StatusOK, w.Code)
+		assert.Contains(t, w.Header().Get("Content-Type"), "text/csv")
+		assert.Contains(t, w.Header().Get("Content-Disposition"), "secret-inventory.csv")
+
+		body := w.Body.String()
+		lines := strings.Split(strings.TrimSpace(body), "\n")
+		require.GreaterOrEqual(t, len(lines), 2)
+		assert.Equal(t, "id,name,environment,type,classification,owner,created_at,expiration,last_rotated_at", strings.TrimSpace(lines[0]))
+		assert.Contains(t, body, "db-pass")
+		assert.Contains(t, body, "production")
+		assert.Contains(t, body, "confidential")
+		assert.Contains(t, body, "alice")
+	})
+
+	t.Run("requires a user context", func(t *testing.T) {
+		req := withChiParam(httptest.NewRequest(http.MethodGet, "/api/v1/projects/1/secrets/inventory.csv", nil), "id", "1")
+		w := httptest.NewRecorder()
+		h.SecretsInventoryCSV(w, req)
+		assert.Equal(t, http.StatusUnauthorized, w.Code)
+	})
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -305,6 +305,9 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		r.With(customMiddleware.RequireScopedPermission("secrets.read", projectScope)).Get("/projects/{id}/secrets/orphaned", secretHandler.OrphanedSecrets)
 		r.With(customMiddleware.RequireScopedPermission("secrets.read", projectScope)).Get("/projects/{id}/hygiene", secretHandler.ProjectHygiene)
 		r.With(customMiddleware.RequireScopedPermission("secrets.read", projectScope)).Get("/projects/{id}/secrets/expiring", secretHandler.ExpiringSecrets)
+		// Asset inventory (ISO 27001 A.5.9) — CSV metadata manifest of the project's
+		// secrets (no values) for compliance hand-off.
+		r.With(customMiddleware.RequireScopedPermission("secrets.read", projectScope)).Get("/projects/{id}/secrets/inventory.csv", secretHandler.SecretsInventoryCSV)
 		r.With(customMiddleware.RequireScopedPermission("secrets.write", projectScope)).Post("/projects/{id}/secrets/suspend-all", secretHandler.SuspendProjectSecrets)
 		r.With(customMiddleware.RequireScopedPermission("secrets.write", projectScope)).Post("/projects/{id}/secrets/resume-all", secretHandler.ResumeProjectSecrets)
 		r.With(customMiddleware.RequireScopedPermission("secrets.write", projectScope)).Post("/projects/{id}/secrets/reassign-owner", secretHandler.ReassignOwner)


### PR DESCRIPTION
## What

A compliance **asset inventory** (ISO 27001 A.5.9 — inventory of information assets). The existing `secret export` dumps decrypted **values** for migration; this is the opposite — a **metadata-only manifest** of a project's secrets (id, name, environment, type, classification, owner, created, expiration, last-rotated) with **no values**, safe to hand an auditor.

`GET /api/v1/projects/{id}/secrets/inventory.csv` → `text/csv` attachment; scoped `secrets.read` (project), mirrors the audit CSV export.

## Details

- `core.SecretsInventory` lists every live secret in the project (folder nodes excluded), resolves environment + owner names once (no N+1), sorts by environment then name; bounded to 10k rows.
- Never reads or emits a secret value.

## Tests

- Core: excludes folders, resolves env/owner names, sorts by env→name, rejects project id 0.
- Handler: CSV header + `secret-inventory.csv` attachment + metadata present (no value), unauthenticated → 401.

## Gates (local)

gofmt clean · `go build ./...` · `go vet` · `internal/core` + `server/http/handlers` tests pass · golangci-lint 0 · gosec 0.

Follow-up: CLI `secret inventory` + a web "Export inventory" button on the project page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)