### PR TITLE
feat(secrets): bulk-renew expiring secrets — POST …/secrets/extend-expiring

### DIFF
--- a/internal/core/secret_extend_expiring.go
+++ b/internal/core/secret_extend_expiring.go
@@ -1,0 +1,54 @@
+// secret_extend_expiring.go — bulk expiry renewal: push out the expiration of every
+// secret in a project that is expiring (or already expired) within a window, in one
+// call. The expiring list ([[secret_expiring]]) and the hygiene summary surface these;
+// this is the remediation — renew them before they lapse instead of editing each by
+// hand. Never reads or changes a secret's value. Project-scoped (route-gated
+// secrets.write). Parallels the bulk reassign-owner / suspend-all operations.
+package core
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+const defaultExtendWindowDays = 90
+
+// ExtendExpiringSecrets sets a new expiration of now+newWindowDays on every secret in
+// the project expiring within withinDays (already-expired included), and returns the
+// number extended. A secret whose current expiration is already later than the new one
+// is left untouched (this only ever pushes expiry out, never pulls it in). Best-effort:
+// a per-secret update failure is skipped so one bad row doesn't abort the rest. Each
+// renewal is audited as secret.updated.
+func (c *KeyorixCore) ExtendExpiringSecrets(ctx context.Context, projectID uint, withinDays, newWindowDays int, actor string, actorID uint) (int, error) {
+	if projectID == 0 || actorID == 0 {
+		return 0, fmt.Errorf("project ID and actor ID are required")
+	}
+	if newWindowDays <= 0 {
+		newWindowDays = defaultExtendWindowDays
+	}
+	if newWindowDays > maxExpiringWindowDays {
+		newWindowDays = maxExpiringWindowDays
+	}
+	newExpiry := c.now().Add(time.Duration(newWindowDays) * 24 * time.Hour)
+
+	secrets, err := c.ListExpiringSecrets(ctx, projectID, withinDays)
+	if err != nil {
+		return 0, err
+	}
+
+	extended := 0
+	for _, s := range secrets {
+		// Only push expiry out, never in — skip a secret already dated past the new window.
+		if s.Expiration != nil && !s.Expiration.Before(newExpiry) {
+			continue
+		}
+		s.Expiration = &newExpiry
+		if _, err := c.storage.UpdateSecret(ctx, s); err != nil {
+			continue // best-effort: skip per-secret failures, keep going
+		}
+		c.LogSecretUpdatedWithProject(ctx, actorID, s.ID, projectID, actor, s.Name, "", "")
+		extended++
+	}
+	return extended, nil
+}

--- a/internal/core/secret_extend_expiring_test.go
+++ b/internal/core/secret_extend_expiring_test.go
@@ -1,0 +1,79 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestExtendExpiringSecrets(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	sqlDB, _ := db.DB()
+	sqlDB.SetMaxOpenConns(1)
+	require.NoError(t, db.AutoMigrate(
+		&models.SecretNode{}, &models.SecretVersion{}, &models.Project{}, &models.Environment{},
+		&models.AuditEvent{}, &models.SecretAccessLog{},
+	))
+	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
+	ctx := context.Background()
+	now := time.Now()
+
+	p, err := c.storage.CreateProject(ctx, &models.Project{Name: "p1"})
+	require.NoError(t, err)
+	e, err := c.storage.CreateEnvironment(ctx, &models.Environment{Name: "production", ProjectID: p.ID})
+	require.NoError(t, err)
+
+	mk := func(name string, exp *time.Time) uint {
+		s, err := c.storage.CreateSecret(ctx, &models.SecretNode{
+			Name: name, ProjectID: p.ID, EnvironmentID: e.ID, Type: "password", OwnerID: 1, IsSecret: true,
+			Expiration: exp, CreatedAt: now, UpdatedAt: now,
+		})
+		require.NoError(t, err)
+		return s.ID
+	}
+
+	expired := now.Add(-2 * 24 * time.Hour)
+	soon := now.Add(10 * 24 * time.Hour)
+	far := now.Add(300 * 24 * time.Hour)
+
+	expiredID := mk("expired", &expired)
+	soonID := mk("soon", &soon)
+	farID := mk("far", &far)   // outside the 30d window — untouched
+	neverID := mk("never", nil) // no expiry — untouched
+
+	t.Run("renews expiring/expired secrets to now+window, leaves others", func(t *testing.T) {
+		n, err := c.ExtendExpiringSecrets(ctx, p.ID, 30, 90, "admin", 1)
+		require.NoError(t, err)
+		assert.Equal(t, 2, n, "expired + soon renewed; far + never untouched")
+
+		want := now.Add(90 * 24 * time.Hour)
+		get := func(id uint) *models.SecretNode {
+			s, err := c.storage.GetSecret(ctx, id)
+			require.NoError(t, err)
+			return s
+		}
+		require.NotNil(t, get(expiredID).Expiration)
+		assert.WithinDuration(t, want, *get(expiredID).Expiration, time.Minute)
+		assert.WithinDuration(t, want, *get(soonID).Expiration, time.Minute)
+		// far (300d out) is already past the 90d window → left as-is; never stays nil.
+		assert.WithinDuration(t, far, *get(farID).Expiration, time.Minute)
+		assert.Nil(t, get(neverID).Expiration)
+	})
+
+	t.Run("a project ID or actor ID of zero is rejected", func(t *testing.T) {
+		_, err := c.ExtendExpiringSecrets(ctx, 0, 30, 90, "admin", 1)
+		require.Error(t, err)
+		_, err = c.ExtendExpiringSecrets(ctx, p.ID, 30, 90, "admin", 0)
+		require.Error(t, err)
+	})
+}

--- a/server/http/handlers/secrets_extend_expiring.go
+++ b/server/http/handlers/secrets_extend_expiring.go
@@ -1,0 +1,53 @@
+// secrets_extend_expiring.go — ExtendExpiringSecrets handler: bulk-renew the expiry of
+// a project's expiring/expired secrets in one call. Scoped secrets.write (project) is
+// enforced by the router.
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/keyorixhq/keyorix/server/middleware"
+)
+
+// ExtendExpiringSecrets handles POST /api/v1/projects/{id}/secrets/extend-expiring with
+// {"within_days":N,"new_window_days":M} — sets a new expiration of now+new_window_days
+// (default 90) on every secret expiring within within_days (default 30, already-expired
+// included). Returns {extended}. Only pushes expiry out, never in. Never touches values.
+func (h *SecretHandler) ExtendExpiringSecrets(w http.ResponseWriter, r *http.Request) {
+	userCtx := middleware.GetUserFromContext(r.Context())
+	if userCtx == nil {
+		h.sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		h.sendError(w, "BadRequest", "Invalid project ID", http.StatusBadRequest, nil)
+		return
+	}
+	var reqBody struct {
+		WithinDays    int `json:"within_days"`
+		NewWindowDays int `json:"new_window_days"`
+	}
+	// An empty body is valid — both windows fall back to their defaults.
+	if r.ContentLength != 0 {
+		if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
+			h.sendError(w, "BadRequest", "Invalid request body", http.StatusBadRequest, nil)
+			return
+		}
+	}
+
+	n, err := h.coreService.ExtendExpiringSecrets(r.Context(), uint(id), reqBody.WithinDays, reqBody.NewWindowDays, userCtx.Username, userCtx.UserID)
+	if err != nil {
+		status := http.StatusInternalServerError
+		if strings.Contains(err.Error(), "required") {
+			status = http.StatusBadRequest
+		}
+		h.sendError(w, "Error", err.Error(), status, nil)
+		return
+	}
+	h.sendSuccess(w, map[string]interface{}{"extended": n}, "")
+}

--- a/server/http/handlers/secrets_extend_expiring_test.go
+++ b/server/http/handlers/secrets_extend_expiring_test.go
@@ -1,0 +1,53 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestExtendExpiringSecretsHandler(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.SecretNode{}, &models.SecretVersion{}, &models.Project{}, &models.Environment{},
+		&models.AuditEvent{}, &models.SecretAccessLog{}, &models.User{},
+	))
+	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "p1"}).Error)
+	require.NoError(t, db.Create(&models.Environment{ID: 1, Name: "production", ProjectID: 1}).Error)
+	expired := time.Now().Add(-48 * time.Hour)
+	require.NoError(t, db.Create(&models.SecretNode{
+		Name: "expired", ProjectID: 1, EnvironmentID: 1, Type: "password", OwnerID: 1, IsSecret: true,
+		Expiration: &expired, CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	}).Error)
+
+	h, err := NewSecretHandler(core.NewKeyorixCore(store.NewLocalStorage(db)))
+	require.NoError(t, err)
+
+	t.Run("renews expiring secrets and returns the count", func(t *testing.T) {
+		body := strings.NewReader(`{"within_days":30,"new_window_days":90}`)
+		req := withChiParam(withUserCtx(httptest.NewRequest(http.MethodPost, "/api/v1/projects/1/secrets/extend-expiring", body)), "id", "1")
+		w := httptest.NewRecorder()
+		h.ExtendExpiringSecrets(w, req)
+
+		require.Equal(t, http.StatusOK, w.Code)
+		assert.Contains(t, w.Body.String(), `"extended":1`)
+	})
+
+	t.Run("requires a user context", func(t *testing.T) {
+		req := withChiParam(httptest.NewRequest(http.MethodPost, "/api/v1/projects/1/secrets/extend-expiring", nil), "id", "1")
+		w := httptest.NewRecorder()
+		h.ExtendExpiringSecrets(w, req)
+		assert.Equal(t, http.StatusUnauthorized, w.Code)
+	})
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -311,6 +311,8 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		r.With(customMiddleware.RequireScopedPermission("secrets.write", projectScope)).Post("/projects/{id}/secrets/suspend-all", secretHandler.SuspendProjectSecrets)
 		r.With(customMiddleware.RequireScopedPermission("secrets.write", projectScope)).Post("/projects/{id}/secrets/resume-all", secretHandler.ResumeProjectSecrets)
 		r.With(customMiddleware.RequireScopedPermission("secrets.write", projectScope)).Post("/projects/{id}/secrets/reassign-owner", secretHandler.ReassignOwner)
+		// Bulk expiry renewal — push out the expiration of every expiring/expired secret.
+		r.With(customMiddleware.RequireScopedPermission("secrets.write", projectScope)).Post("/projects/{id}/secrets/extend-expiring", secretHandler.ExtendExpiringSecrets)
 		r.With(customMiddleware.RequireScopedPermission("secrets.write", projectScope)).Post("/projects/{id}/environments/{envId}/copy-secrets", secretHandler.CopyEnvironmentSecrets)
 		r.With(customMiddleware.RequireScopedPermission("secrets.read", projectScope)).Get("/projects/{id}/environments", catalogHandler.ListProjectEnvironments)
 		r.With(customMiddleware.RequireScopedPermission("secrets.write", projectScope)).Post("/projects/{id}/environments", catalogHandler.CreateProjectEnvironment)


### PR DESCRIPTION
## What

Several surfaces flag a project's expiring/expired secrets (hygiene summary, expiring list, deployment-hygiene rollup) but the only remediation was editing each secret's expiration by hand. This adds the **bulk remediation**: push out the expiry of every secret expiring within a window, in one call.

`POST /api/v1/projects/{id}/secrets/extend-expiring` with `{within_days, new_window_days}` (both optional → defaults 30 / 90) → `{extended}`. Scoped `secrets.write` (project), mirrors the `reassign-owner` / `suspend-all` bulk ops; empty body allowed.

## Details

- `core.ExtendExpiringSecrets` reuses `ListExpiringSecrets`, sets each match's expiration to `now + new_window_days`, and **only pushes expiry out** — a secret already dated past the new window is left untouched (never shortens).
- Best-effort: a per-secret update failure is skipped. Each renewal is audited `secret.updated`. Never reads or changes a secret value.

## Tests

- Core: renews expiring + expired, leaves far/never-expiring untouched, never shortens, rejects zero project/actor id.
- Handler: returns the count, unauthenticated → 401.

## Gates (local)

gofmt clean · `go build ./...` · `go vet` · `internal/core` + `server/http/handlers` tests pass · golangci-lint 0 · gosec 0.

Follow-up: web "Extend expiring" button on the expiring/hygiene surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)