### PR TITLE
feat(secrets): org-wide secret inventory CSV — GET /secrets/inventory.csv

### DIFF
--- a/internal/core/secret_inventory_deployment.go
+++ b/internal/core/secret_inventory_deployment.go
@@ -1,0 +1,46 @@
+// secret_inventory_deployment.go — the deployment-wide secret asset inventory: every
+// live secret across every project as one metadata manifest (no values), for an
+// org-wide ISO 27001 A.5.9 asset register. The per-project view is [[secret_inventory]]
+// (SecretsInventory); this is the admin's all-projects counterpart, parallel to the
+// deployment-wide hygiene rollup. Counts/metadata only. Deployment-wide (route-gated
+// system.read).
+package core
+
+import (
+	"context"
+	"fmt"
+)
+
+// DeploymentSecretInventoryItem is one secret's metadata row plus its project, for the
+// org-wide manifest. Never a value.
+type DeploymentSecretInventoryItem struct {
+	ProjectID   uint   `json:"project_id"`
+	ProjectName string `json:"project_name"`
+	SecretInventoryItem
+}
+
+// DeploymentSecretsInventory returns the metadata manifest of every live secret across
+// all projects, project-by-project (each project's secrets resolved via the per-project
+// inventory), ordered by project then environment then name. Never reads a value.
+func (c *KeyorixCore) DeploymentSecretsInventory(ctx context.Context) ([]DeploymentSecretInventoryItem, error) {
+	projects, err := c.ListProjects(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list projects: %w", err)
+	}
+
+	out := make([]DeploymentSecretInventoryItem, 0)
+	for _, p := range projects {
+		items, err := c.SecretsInventory(ctx, p.ID)
+		if err != nil {
+			return nil, fmt.Errorf("project %d inventory: %w", p.ID, err)
+		}
+		for _, it := range items {
+			out = append(out, DeploymentSecretInventoryItem{
+				ProjectID:           p.ID,
+				ProjectName:         p.Name,
+				SecretInventoryItem: it,
+			})
+		}
+	}
+	return out, nil
+}

--- a/internal/core/secret_inventory_deployment_test.go
+++ b/internal/core/secret_inventory_deployment_test.go
@@ -1,0 +1,62 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestDeploymentSecretsInventory(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	sqlDB, _ := db.DB()
+	sqlDB.SetMaxOpenConns(1)
+	require.NoError(t, db.AutoMigrate(
+		&models.SecretNode{}, &models.SecretVersion{}, &models.User{}, &models.Project{}, &models.Environment{},
+	))
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "alice", Email: "a@t.com"}).Error)
+
+	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
+	ctx := context.Background()
+	now := time.Now()
+
+	mkProject := func(name string) *models.Project {
+		p, err := c.storage.CreateProject(ctx, &models.Project{Name: name})
+		require.NoError(t, err)
+		e, err := c.storage.CreateEnvironment(ctx, &models.Environment{Name: "production", ProjectID: p.ID})
+		require.NoError(t, err)
+		_, err = c.storage.CreateSecret(ctx, &models.SecretNode{
+			Name: name + "-key", ProjectID: p.ID, EnvironmentID: e.ID, Type: "password", OwnerID: 1,
+			IsSecret: true, CreatedAt: now, UpdatedAt: now,
+		})
+		require.NoError(t, err)
+		return p
+	}
+	pa := mkProject("alpha")
+	pb := mkProject("beta")
+
+	t.Run("manifests every project's secrets, project name attached", func(t *testing.T) {
+		inv, err := c.DeploymentSecretsInventory(ctx)
+		require.NoError(t, err)
+		require.Len(t, inv, 2)
+
+		byProject := map[uint]DeploymentSecretInventoryItem{}
+		for _, it := range inv {
+			byProject[it.ProjectID] = it
+		}
+		assert.Equal(t, "alpha", byProject[pa.ID].ProjectName)
+		assert.Equal(t, "alpha-key", byProject[pa.ID].Name)
+		assert.Equal(t, "production", byProject[pa.ID].EnvironmentName)
+		assert.Equal(t, "alice", byProject[pa.ID].OwnerUsername)
+		assert.Equal(t, "beta", byProject[pb.ID].ProjectName)
+	})
+}

--- a/server/http/handlers/secrets_inventory_deployment_csv.go
+++ b/server/http/handlers/secrets_inventory_deployment_csv.go
@@ -1,0 +1,62 @@
+// secrets_inventory_deployment_csv.go — DeploymentSecretsInventoryCSV handler: the
+// org-wide secret asset inventory (every project's secrets, metadata only, never
+// values) as a CSV attachment for compliance. Deployment-wide system.read is enforced
+// by the router. Parallels the per-project secrets_inventory_csv handler.
+package handlers
+
+import (
+	"encoding/csv"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/keyorixhq/keyorix/server/middleware"
+)
+
+// DeploymentSecretsInventoryCSV handles GET /api/v1/secrets/inventory.csv — every live
+// secret across all projects as a CSV attachment (project, id, name, environment, type,
+// classification, owner, created, expiration, last-rotated). No secret values.
+func (h *SecretHandler) DeploymentSecretsInventoryCSV(w http.ResponseWriter, r *http.Request) {
+	if middleware.GetUserFromContext(r.Context()) == nil {
+		h.sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+
+	items, err := h.coreService.DeploymentSecretsInventory(r.Context())
+	if err != nil {
+		h.sendError(w, "InternalError", "Failed to build secret inventory", http.StatusInternalServerError, nil)
+		return
+	}
+
+	tstr := func(t *time.Time) string {
+		if t == nil {
+			return ""
+		}
+		return t.UTC().Format(time.RFC3339)
+	}
+
+	w.Header().Set("Content-Type", "text/csv; charset=utf-8")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.Header().Set("Content-Disposition", `attachment; filename="secret-inventory-all-projects.csv"`)
+
+	cw := csv.NewWriter(w)
+	defer cw.Flush()
+	_ = cw.Write([]string{
+		"project", "id", "name", "environment", "type", "classification",
+		"owner", "created_at", "expiration", "last_rotated_at",
+	})
+	for _, it := range items {
+		_ = cw.Write([]string{
+			it.ProjectName,
+			strconv.FormatUint(uint64(it.ID), 10),
+			it.Name,
+			it.EnvironmentName,
+			it.Type,
+			it.Classification,
+			it.OwnerUsername,
+			it.CreatedAt.UTC().Format(time.RFC3339),
+			tstr(it.Expiration),
+			tstr(it.LastRotatedAt),
+		})
+	}
+}

--- a/server/http/handlers/secrets_inventory_deployment_csv_test.go
+++ b/server/http/handlers/secrets_inventory_deployment_csv_test.go
@@ -1,0 +1,59 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestDeploymentSecretsInventoryCSV(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.SecretNode{}, &models.SecretVersion{}, &models.User{}, &models.Project{}, &models.Environment{},
+	))
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "alice", Email: "a@t.com"}).Error)
+	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "alpha"}).Error)
+	require.NoError(t, db.Create(&models.Environment{ID: 1, Name: "production", ProjectID: 1}).Error)
+	require.NoError(t, db.Create(&models.SecretNode{
+		Name: "db-pass", ProjectID: 1, EnvironmentID: 1, Type: "password", OwnerID: 1,
+		IsSecret: true, CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	}).Error)
+
+	h, err := NewSecretHandler(core.NewKeyorixCore(store.NewLocalStorage(db)))
+	require.NoError(t, err)
+
+	t.Run("returns an org-wide CSV with a project column and the secret metadata", func(t *testing.T) {
+		req := withUserCtx(httptest.NewRequest(http.MethodGet, "/api/v1/secrets/inventory.csv", nil))
+		w := httptest.NewRecorder()
+		h.DeploymentSecretsInventoryCSV(w, req)
+
+		require.Equal(t, http.StatusOK, w.Code)
+		assert.Contains(t, w.Header().Get("Content-Type"), "text/csv")
+		assert.Contains(t, w.Header().Get("Content-Disposition"), "secret-inventory-all-projects.csv")
+
+		body := w.Body.String()
+		lines := strings.Split(strings.TrimSpace(body), "\n")
+		require.GreaterOrEqual(t, len(lines), 2)
+		assert.Equal(t, "project,id,name,environment,type,classification,owner,created_at,expiration,last_rotated_at", strings.TrimSpace(lines[0]))
+		assert.Contains(t, body, "alpha")
+		assert.Contains(t, body, "db-pass")
+	})
+
+	t.Run("requires a user context", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/secrets/inventory.csv", nil)
+		w := httptest.NewRecorder()
+		h.DeploymentSecretsInventoryCSV(w, req)
+		assert.Equal(t, http.StatusUnauthorized, w.Code)
+	})
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -335,6 +335,10 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			// Usage analytics (static paths, before /{id}).
 			r.With(customMiddleware.RequireScopedPermission("secrets.read", customMiddleware.ScopeFromQuery)).Get("/usage/most-accessed", secretHandler.UsageMostAccessed)
 			r.With(customMiddleware.RequireScopedPermission("secrets.read", customMiddleware.ScopeFromQuery)).Get("/usage/unused", secretHandler.UsageUnused)
+			// Org-wide secret asset inventory (ISO 27001 A.5.9) — CSV manifest of every
+			// project's secrets, metadata only (no values). Deployment-wide system.read;
+			// static path, before /{id}.
+			r.With(customMiddleware.RequirePermission("system.read")).Get("/inventory.csv", secretHandler.DeploymentSecretsInventoryCSV)
 			r.With(customMiddleware.RequireScopedPermission("secrets.read", secretScope)).Get("/{id}", secretHandler.GetSecret)
 			r.With(customMiddleware.RequireScopedPermission("secrets.read", secretScope)).Get("/{id}/versions", secretHandler.GetSecretVersions)
 			r.With(customMiddleware.RequireScopedPermission("secrets.read", secretScope)).Get("/{id}/risk", secretHandler.GetSecretRisk)


### PR DESCRIPTION
## What

The per-project asset inventory (#367) gives an auditor one project's manifest; an org-wide **ISO 27001 A.5.9 asset register** wants every secret across all projects in one file. This adds the deployment-wide counterpart — parallel to how the hygiene rollup (#365) extends per-project hygiene.

`GET /api/v1/secrets/inventory.csv` → `text/csv` attachment with a **project** column (project, id, name, environment, type, classification, owner, created, expiration, last-rotated). Deployment-wide `system.read`.

## Details

- `core.DeploymentSecretsInventory` iterates all projects, reuses the per-project `SecretsInventory` (folders excluded, env/owner names resolved), and attaches the project to each row. Never reads or returns a value.
- Registered as a **static path inside the `/secrets` subrouter** (before `/{id}`), matching the `/policy` + `/usage/*` precedent — so chi prioritizes it over `/secrets/{id}` with no route conflict.

## Tests

- Core: manifests every project's secrets with the project attached.
- Handler: CSV header + project column + `secret-inventory-all-projects.csv` attachment (no value), unauthenticated → 401.
- Verified the full router builds with no chi route conflict (only the known local-only `TestEveryMutatingRouteDeniesReadOnly` /sw.js failure remains — unrelated, green in CI; this is a GET).

## Gates (local)

gofmt clean · `go build ./...` · `go vet` · `internal/core` + `server/http/handlers` tests pass · golangci-lint 0 · gosec 0.

Follow-up: web "Export org inventory" button on an admin/compliance surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)