### PR TITLE
release: prep v0.66.0 (CHANGELOG + Helm charts 0.66.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,38 @@
 All notable changes to Keyorix are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## v0.66.0 — 2026-06-20
+
+Bulk environment promotion, deployment-wide hygiene, and a secret asset register.
+
+### Added
+- **Bulk environment promotion** — copy all of an environment's secrets into
+  another environment in one call
+  (`POST /projects/{id}/environments/{envId}/copy-secrets` and
+  `keyorix secret copy-environment`), instead of promoting each secret by hand.
+  ([#363], [#364])
+- **Deployment-wide secret-hygiene rollup** — `GET /hygiene` (and
+  `keyorix hygiene`) aggregate every project's hygiene posture
+  (orphaned / recycle-bin / expiring / rotation-overdue counts) into a single
+  deployment-wide view for admins. ([#365], [#366])
+- **Secret asset inventory (CSV)** — a metadata-only asset register for auditors
+  (ISO 27001 A.5.9): `GET /projects/{id}/secrets/inventory.csv` per project and
+  `GET /secrets/inventory.csv` org-wide, exported from the web UI. Lists every
+  live secret's metadata (name, environment, type, classification, owner,
+  timestamps) and never reads or returns a value. ([#367], [#369])
+- **Bulk-renew expiring secrets** — `POST /projects/{id}/secrets/extend-expiring`
+  pushes the expiration of all soon-to-expire secrets out to a new window
+  (default 90 days), surfaced as an "Extend all" button on the project's
+  expiring-secrets panel. Only ever extends, never shortens. ([#368])
+
+[#363]: https://github.com/keyorixhq/keyorix/pull/363
+[#364]: https://github.com/keyorixhq/keyorix/pull/364
+[#365]: https://github.com/keyorixhq/keyorix/pull/365
+[#366]: https://github.com/keyorixhq/keyorix/pull/366
+[#367]: https://github.com/keyorixhq/keyorix/pull/367
+[#368]: https://github.com/keyorixhq/keyorix/pull/368
+[#369]: https://github.com/keyorixhq/keyorix/pull/369
+
 ## v0.65.0 — 2026-06-19
 
 Secret naming governance, machine-token hygiene, and richer search.

--- a/deploy/helm/keyorix-k8s-sync/Chart.yaml
+++ b/deploy/helm/keyorix-k8s-sync/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix-k8s-sync
 description: Keyorix Kubernetes sync agent — materialises Keyorix secrets into native Kubernetes Secrets
 type: application
 # Chart version — tracks the Keyorix release version (published in lockstep).
-version: 0.65.0
+version: 0.66.0
 # The keyorix-k8s-sync image tag this chart deploys by default.
-appVersion: "0.65.0"
+appVersion: "0.66.0"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix

--- a/deploy/helm/keyorix/Chart.yaml
+++ b/deploy/helm/keyorix/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix
 description: Self-hosted Keyorix secrets manager (API server + web UI + PostgreSQL)
 type: application
 # Chart version — bump on chart changes.
-version: 0.65.0
+version: 0.66.0
 # The Keyorix app version this chart deploys by default (the image tag).
-appVersion: "0.65.0"
+appVersion: "0.66.0"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix


### PR DESCRIPTION
Prep the v0.66.0 release: CHANGELOG entry + Helm chart bumps (`keyorix`, `keyorix-k8s-sync`) 0.65.0 → 0.66.0.

Contents since v0.65.0:

- **Bulk environment promotion** — copy all of an env's secrets into another env (`POST /projects/{id}/environments/{envId}/copy-secrets` + `keyorix secret copy-environment`). (#363, #364)
- **Deployment-wide secret-hygiene rollup** — `GET /hygiene` + `keyorix hygiene` aggregate every project's posture for admins. (#365, #366)
- **Secret asset inventory (CSV)** — metadata-only asset register (ISO 27001 A.5.9), per-project (`GET /projects/{id}/secrets/inventory.csv`) and org-wide (`GET /secrets/inventory.csv`); never returns a value. (#367, #369)
- **Bulk-renew expiring secrets** — `POST /projects/{id}/secrets/extend-expiring` extends (never shortens) soon-to-expire secrets. (#368)

Docs/charts only; both charts `helm lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)