### PR TITLE
feat(secrets): naming-policy conformance report — server + CLI

### DIFF
--- a/internal/cli/secret/name_conformance.go
+++ b/internal/cli/secret/name_conformance.go
@@ -1,0 +1,84 @@
+package secret
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/spf13/cobra"
+)
+
+var nameConformanceProject uint
+
+// nameConformanceViolation mirrors one violation in the
+// GET /projects/{id}/secrets/name-conformance report (snake_case DTO).
+type nameConformanceViolation struct {
+	ID            uint   `json:"id"`
+	Name          string `json:"name"`
+	Type          string `json:"type"`
+	EnvironmentID uint   `json:"environment_id"`
+	Reason        string `json:"reason"`
+}
+
+// nameConformanceReport mirrors the report envelope's data object.
+type nameConformanceReport struct {
+	PolicyEnabled bool                       `json:"policy_enabled"`
+	Pattern       string                     `json:"pattern"`
+	MaxLength     int                        `json:"max_length"`
+	TotalSecrets  int                        `json:"total_secrets"`
+	Violations    []nameConformanceViolation `json:"violations"`
+}
+
+var nameConformanceCmd = &cobra.Command{
+	Use:   "name-conformance",
+	Short: "List a project's secrets whose names violate the current naming policy",
+	Long: `Show the live secrets whose names fail the current secret naming policy. The policy is
+enforced only when a secret is created, so names can fall out of conformance after the
+policy is added or tightened — this surfaces those stragglers so you can rename them.
+Requires secrets.read at the project scope.`,
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		if nameConformanceProject == 0 {
+			return fmt.Errorf("--project is required")
+		}
+		c, ok := common.NewRemoteClient()
+		if !ok {
+			return fmt.Errorf("not connected to a server — run: keyorix connect <server>")
+		}
+		report, err := fetchNameConformance(context.Background(), c, nameConformanceProject)
+		if err != nil {
+			return err
+		}
+		if !report.PolicyEnabled {
+			fmt.Println("No secret naming policy is configured — nothing to check.")
+			return nil
+		}
+		if len(report.Violations) == 0 {
+			fmt.Printf("All %d secret(s) conform to the naming policy.\n", report.TotalSecrets)
+			return nil
+		}
+		fmt.Printf("%d of %d secret(s) violate the naming policy:\n\n", len(report.Violations), report.TotalSecrets)
+		fmt.Printf("%-8s %-24s %-12s %s\n", "ID", "NAME", "TYPE", "REASON")
+		for _, v := range report.Violations {
+			fmt.Printf("%-8d %-24s %-12s %s\n", v.ID, v.Name, v.Type, v.Reason)
+		}
+		return nil
+	},
+}
+
+// fetchNameConformance GETs the project's naming-policy conformance report
+// (split out for httptest tests).
+func fetchNameConformance(ctx context.Context, c *common.RemoteClient, projectID uint) (nameConformanceReport, error) {
+	path := "/api/v1/projects/" + strconv.Itoa(int(projectID)) + "/secrets/name-conformance"
+	var report nameConformanceReport
+	if err := c.Get(ctx, path, &report); err != nil {
+		return nameConformanceReport{}, err
+	}
+	return report, nil
+}
+
+func init() {
+	nameConformanceCmd.Flags().UintVar(&nameConformanceProject, "project", 0, "Project ID (required)")
+	SecretCmd.AddCommand(nameConformanceCmd)
+}

--- a/internal/cli/secret/name_conformance_remote_test.go
+++ b/internal/cli/secret/name_conformance_remote_test.go
@@ -1,0 +1,47 @@
+package secret
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func nameConformanceStub(t *testing.T) (*common.RemoteClient, func()) {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/projects/4/secrets/name-conformance" {
+			_, _ = w.Write([]byte(`{"data":{"policy_enabled":true,"pattern":"^[A-Z][A-Z0-9_]*$","max_length":0,"total_secrets":3,"violations":[{"id":8,"name":"db-pass","type":"password","environment_id":2,"reason":"secret name does not match the required pattern \"^[A-Z][A-Z0-9_]*$\""}]}}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	rc, ok := common.NewRemoteClient()
+	require.True(t, ok)
+	return rc, srv.Close
+}
+
+func TestFetchNameConformance(t *testing.T) {
+	rc, done := nameConformanceStub(t)
+	defer done()
+	rep, err := fetchNameConformance(context.Background(), rc, 4)
+	require.NoError(t, err)
+	assert.True(t, rep.PolicyEnabled)
+	assert.Equal(t, 3, rep.TotalSecrets)
+	require.Len(t, rep.Violations, 1)
+	assert.Equal(t, "db-pass", rep.Violations[0].Name)
+	assert.Contains(t, rep.Violations[0].Reason, "pattern")
+}
+
+func TestFetchNameConformance_NotFound(t *testing.T) {
+	rc, done := nameConformanceStub(t)
+	defer done()
+	_, err := fetchNameConformance(context.Background(), rc, 999)
+	require.Error(t, err)
+}

--- a/internal/core/secret_name_conformance.go
+++ b/internal/core/secret_name_conformance.go
@@ -1,0 +1,87 @@
+// secret_name_conformance.go — a project's secret-name conformance report against the
+// CURRENT naming policy ([[secret_name_policy]]). The naming convention is enforced only
+// at create time, so a name can fall out of conformance after the policy is added or
+// tightened (existing names are never retroactively checked). This read-only scan finds
+// the live secrets whose names now violate the policy so an operator can rename them.
+// Never reads a secret value; mirrors [[secret_inventory]] (project-scoped secrets.read).
+package core
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+)
+
+// SecretNameViolation is one live secret whose name fails the current naming policy.
+type SecretNameViolation struct {
+	ID             uint   `json:"id"`
+	Name           string `json:"name"`
+	Type           string `json:"type"`
+	Classification string `json:"classification,omitempty"`
+	EnvironmentID  uint   `json:"environment_id"`
+	Reason         string `json:"reason"`
+}
+
+// SecretNameConformanceReport is a project's secret-name conformance summary against the
+// current naming policy. PolicyEnabled=false means no naming policy is configured, so
+// there are no violations by definition and the scan is skipped.
+type SecretNameConformanceReport struct {
+	PolicyEnabled bool                  `json:"policy_enabled"`
+	Pattern       string                `json:"pattern,omitempty"`
+	MaxLength     int                   `json:"max_length,omitempty"`
+	TotalSecrets  int                   `json:"total_secrets"`
+	Violations    []SecretNameViolation `json:"violations"`
+}
+
+// SecretNameConformance scans every live secret in the project (folders excluded) and
+// lists those whose name fails the current naming policy, each with the violation
+// reason (the exact message create-time enforcement would produce). Reuses the same
+// validateSecretName check so the report can never drift from enforcement. Never reads
+// a value. Bounded to secretInventoryMaxRows; sorted by name.
+func (c *KeyorixCore) SecretNameConformance(ctx context.Context, projectID uint) (*SecretNameConformanceReport, error) {
+	if projectID == 0 {
+		return nil, fmt.Errorf("project ID is required")
+	}
+
+	report := &SecretNameConformanceReport{
+		PolicyEnabled: c.secretNamePolicy.Enabled,
+		Pattern:       c.secretNamePolicy.Pattern,
+		MaxLength:     c.secretNamePolicy.MaxLength,
+		Violations:    []SecretNameViolation{},
+	}
+	// No policy configured → nothing can be in violation; skip the scan entirely.
+	if !c.secretNamePolicy.Enabled {
+		return report, nil
+	}
+
+	secrets, _, err := c.storage.ListSecrets(ctx, &storage.SecretFilter{
+		ProjectID: &projectID, Page: 1, PageSize: secretInventoryMaxRows,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list secrets: %w", err)
+	}
+
+	for _, s := range secrets {
+		if !s.IsSecret {
+			continue // skip folder nodes — only assets have governed names
+		}
+		report.TotalSecrets++
+		if verr := c.validateSecretName(s.Name); verr != nil {
+			report.Violations = append(report.Violations, SecretNameViolation{
+				ID:             s.ID,
+				Name:           s.Name,
+				Type:           s.Type,
+				Classification: s.Classification,
+				EnvironmentID:  s.EnvironmentID,
+				Reason:         verr.Error(),
+			})
+		}
+	}
+
+	sort.Slice(report.Violations, func(i, j int) bool {
+		return report.Violations[i].Name < report.Violations[j].Name
+	})
+	return report, nil
+}

--- a/internal/core/secret_name_conformance_test.go
+++ b/internal/core/secret_name_conformance_test.go
@@ -1,0 +1,98 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestSecretNameConformance(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	sqlDB, _ := db.DB()
+	sqlDB.SetMaxOpenConns(1)
+	require.NoError(t, db.AutoMigrate(
+		&models.SecretNode{}, &models.SecretVersion{}, &models.Project{}, &models.Environment{},
+	))
+
+	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
+	ctx := context.Background()
+	now := time.Now()
+
+	p, err := c.storage.CreateProject(ctx, &models.Project{Name: "p1"})
+	require.NoError(t, err)
+	env, err := c.storage.CreateEnvironment(ctx, &models.Environment{Name: "production", ProjectID: p.ID})
+	require.NoError(t, err)
+
+	// Secrets created directly via storage — i.e. BEFORE any naming policy existed, so
+	// non-conforming names are present (the real scenario: a policy added/tightened later).
+	mk := func(name string) {
+		_, e := c.storage.CreateSecret(ctx, &models.SecretNode{
+			Name: name, ProjectID: p.ID, EnvironmentID: env.ID, Type: "password", OwnerID: 1,
+			IsSecret: true, CreatedAt: now, UpdatedAt: now,
+		})
+		require.NoError(t, e)
+	}
+	mk("DB_PASSWORD")           // conforms (UPPER_SNAKE, within length)
+	mk("db-password")           // violates pattern (lowercase + hyphen)
+	mk("VERY_LONG_SECRET_NAME") // conforms pattern but exceeds the length cap
+	// A folder node — must be excluded (only assets have governed names).
+	_, err = c.storage.CreateSecret(ctx, &models.SecretNode{
+		Name: "a folder!", ProjectID: p.ID, EnvironmentID: env.ID, IsSecret: false, CreatedAt: now, UpdatedAt: now,
+	})
+	require.NoError(t, err)
+
+	t.Run("no policy configured → enabled false, no scan, no violations", func(t *testing.T) {
+		require.NoError(t, c.SetSecretNamePolicy(SecretNamePolicy{}))
+		rep, err := c.SecretNameConformance(ctx, p.ID)
+		require.NoError(t, err)
+		assert.False(t, rep.PolicyEnabled)
+		assert.Empty(t, rep.Violations)
+		assert.Zero(t, rep.TotalSecrets, "the scan is skipped when no policy is set")
+	})
+
+	t.Run("flags non-conforming names with reasons; excludes folders; sorts by name", func(t *testing.T) {
+		require.NoError(t, c.SetSecretNamePolicy(SecretNamePolicy{
+			Enabled: true, Pattern: "^[A-Z][A-Z0-9_]*$", MaxLength: 12,
+		}))
+		rep, err := c.SecretNameConformance(ctx, p.ID)
+		require.NoError(t, err)
+		assert.True(t, rep.PolicyEnabled)
+		assert.Equal(t, "^[A-Z][A-Z0-9_]*$", rep.Pattern)
+		assert.Equal(t, 12, rep.MaxLength)
+		assert.Equal(t, 3, rep.TotalSecrets, "three secrets scanned; the folder is excluded")
+
+		require.Len(t, rep.Violations, 2)
+		// Sorted by name: "VERY_LONG_SECRET_NAME" < "db-password" (uppercase sorts first).
+		assert.Equal(t, "VERY_LONG_SECRET_NAME", rep.Violations[0].Name)
+		assert.Contains(t, rep.Violations[0].Reason, "maximum", "length cap is the first check")
+		assert.Equal(t, "db-password", rep.Violations[1].Name)
+		assert.Contains(t, rep.Violations[1].Reason, "pattern")
+		assert.Equal(t, env.ID, rep.Violations[1].EnvironmentID)
+	})
+
+	t.Run("when every name conforms, violations is empty but total is counted", func(t *testing.T) {
+		require.NoError(t, c.SetSecretNamePolicy(SecretNamePolicy{
+			Enabled: true, Pattern: "^[A-Za-z0-9_-]+$", MaxLength: 100,
+		}))
+		rep, err := c.SecretNameConformance(ctx, p.ID)
+		require.NoError(t, err)
+		assert.True(t, rep.PolicyEnabled)
+		assert.Equal(t, 3, rep.TotalSecrets)
+		assert.Empty(t, rep.Violations)
+	})
+
+	t.Run("a project ID of zero is rejected", func(t *testing.T) {
+		_, err := c.SecretNameConformance(ctx, 0)
+		require.Error(t, err)
+	})
+}

--- a/server/http/handlers/secrets_name_conformance.go
+++ b/server/http/handlers/secrets_name_conformance.go
@@ -1,0 +1,35 @@
+// secrets_name_conformance.go — SecretNameConformance handler: a project's secrets whose
+// names violate the CURRENT naming policy. The policy is enforced only at create time, so
+// this surfaces names that fell out of conformance after the policy was added or tightened.
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/keyorixhq/keyorix/server/middleware"
+)
+
+// SecretNameConformance handles GET /api/v1/projects/{id}/secrets/name-conformance — the
+// project's live secrets whose names fail the current naming policy, each with the reason.
+// Scoped secrets.read (project) is enforced by the router. Returns an empty (policy_enabled
+// false) report when no naming policy is configured.
+func (h *SecretHandler) SecretNameConformance(w http.ResponseWriter, r *http.Request) {
+	if middleware.GetUserFromContext(r.Context()) == nil {
+		h.sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		h.sendError(w, "BadRequest", "Invalid project ID", http.StatusBadRequest, nil)
+		return
+	}
+
+	report, err := h.coreService.SecretNameConformance(r.Context(), uint(id))
+	if err != nil {
+		h.sendError(w, "InternalError", "Failed to evaluate naming-policy conformance", http.StatusInternalServerError, nil)
+		return
+	}
+	h.sendSuccess(w, report, "")
+}

--- a/server/http/handlers/secrets_name_conformance_test.go
+++ b/server/http/handlers/secrets_name_conformance_test.go
@@ -1,0 +1,60 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestSecretNameConformanceHandler(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.SecretNode{}, &models.SecretVersion{}, &models.Project{}, &models.Environment{},
+	))
+	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "p1"}).Error)
+	require.NoError(t, db.Create(&models.Environment{ID: 1, Name: "production", ProjectID: 1}).Error)
+	// One conforming name, one created out-of-policy (lowercase + hyphen).
+	require.NoError(t, db.Create(&models.SecretNode{
+		Name: "DB_PASSWORD", ProjectID: 1, EnvironmentID: 1, Type: "password", OwnerID: 1, IsSecret: true,
+		CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	}).Error)
+	require.NoError(t, db.Create(&models.SecretNode{
+		Name: "db-pass", ProjectID: 1, EnvironmentID: 1, Type: "password", OwnerID: 1, IsSecret: true,
+		CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	}).Error)
+
+	cs := core.NewKeyorixCore(store.NewLocalStorage(db))
+	require.NoError(t, cs.SetSecretNamePolicy(core.SecretNamePolicy{Enabled: true, Pattern: "^[A-Z][A-Z0-9_]*$"}))
+	h, err := NewSecretHandler(cs)
+	require.NoError(t, err)
+
+	t.Run("reports the non-conforming name with the policy enabled", func(t *testing.T) {
+		req := withChiParam(withUserCtx(httptest.NewRequest(http.MethodGet, "/api/v1/projects/1/secrets/name-conformance", nil)), "id", "1")
+		w := httptest.NewRecorder()
+		h.SecretNameConformance(w, req)
+
+		require.Equal(t, http.StatusOK, w.Code)
+		body := w.Body.String()
+		assert.Contains(t, body, `"policy_enabled":true`)
+		assert.Contains(t, body, `"total_secrets":2`)
+		assert.Contains(t, body, "db-pass")
+		assert.Contains(t, body, "pattern")
+	})
+
+	t.Run("requires a user context", func(t *testing.T) {
+		req := withChiParam(httptest.NewRequest(http.MethodGet, "/api/v1/projects/1/secrets/name-conformance", nil), "id", "1")
+		w := httptest.NewRecorder()
+		h.SecretNameConformance(w, req)
+		assert.Equal(t, http.StatusUnauthorized, w.Code)
+	})
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -308,6 +308,9 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		// Asset inventory (ISO 27001 A.5.9) — CSV metadata manifest of the project's
 		// secrets (no values) for compliance hand-off.
 		r.With(customMiddleware.RequireScopedPermission("secrets.read", projectScope)).Get("/projects/{id}/secrets/inventory.csv", secretHandler.SecretsInventoryCSV)
+		// Naming-policy conformance — live secrets whose names violate the current naming
+		// policy (enforced only at create, so a tightened policy leaves stragglers).
+		r.With(customMiddleware.RequireScopedPermission("secrets.read", projectScope)).Get("/projects/{id}/secrets/name-conformance", secretHandler.SecretNameConformance)
 		r.With(customMiddleware.RequireScopedPermission("secrets.write", projectScope)).Post("/projects/{id}/secrets/suspend-all", secretHandler.SuspendProjectSecrets)
 		r.With(customMiddleware.RequireScopedPermission("secrets.write", projectScope)).Post("/projects/{id}/secrets/resume-all", secretHandler.ResumeProjectSecrets)
 		r.With(customMiddleware.RequireScopedPermission("secrets.write", projectScope)).Post("/projects/{id}/secrets/reassign-owner", secretHandler.ReassignOwner)


### PR DESCRIPTION
The optional secret naming policy (#357) is enforced only at **create** time, so when an operator adds or tightens it, secrets created earlier can sit out of conformance with no way to find them. This adds a read-only scan that lists the live secrets whose names violate the **current** policy, each with the exact reason create-time enforcement would give.

It reuses the same `validateSecretName` check used on create, so the report can never drift from enforcement.

### What's added
- **`core.SecretNameConformance(projectID)`** — scans every live secret (folders excluded), returns `{policy_enabled, pattern, max_length, total_secrets, violations[]}`; skips the scan entirely when no policy is configured. Never reads a value; bounded to 10k rows; mirrors `SecretsInventory`.
- **`GET /api/v1/projects/{id}/secrets/name-conformance`** — scoped `secrets.read` (project); JSON triage list alongside `/secrets/expiring` and `/secrets/orphaned`.
- **`keyorix secret name-conformance --project <id>`** — prints the violations table, or a clear message when the policy is off / everything conforms.

Closes the naming-governance loop: enforce on create (#357/#358) + audit existing.

### Tests
Core (policy off → no scan; flags pattern + length violations with reasons; folders excluded; all-conform; zero-ID rejected), handler (reports violation + 401 without user ctx), CLI (decode + not-found). gofmt/vet/golangci-lint 0/gosec 0.

> Note: the local-only `TestEveryMutatingRouteDeniesReadOnly` `/sw.js` + `/compliance/evidence/verify` failures are pre-existing and unrelated (this route is a GET); green in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)