### PR TITLE
feat(secrets): org-wide naming-policy conformance — server + CLI

### DIFF
--- a/internal/cli/secret/name_conformance.go
+++ b/internal/cli/secret/name_conformance.go
@@ -12,16 +12,19 @@ import (
 var nameConformanceProject uint
 
 // nameConformanceViolation mirrors one violation in the
-// GET /projects/{id}/secrets/name-conformance report (snake_case DTO).
+// GET /projects/{id}/secrets/name-conformance report (snake_case DTO). The org-wide
+// report adds project_id/project_name, captured here too (zero for the project view).
 type nameConformanceViolation struct {
 	ID            uint   `json:"id"`
 	Name          string `json:"name"`
 	Type          string `json:"type"`
 	EnvironmentID uint   `json:"environment_id"`
 	Reason        string `json:"reason"`
+	ProjectName   string `json:"project_name"`
 }
 
-// nameConformanceReport mirrors the report envelope's data object.
+// nameConformanceReport mirrors the report envelope's data object (both the per-project
+// and the deployment-wide shapes; the latter tags each violation with its project).
 type nameConformanceReport struct {
 	PolicyEnabled bool                       `json:"policy_enabled"`
 	Pattern       string                     `json:"pattern"`
@@ -32,24 +35,32 @@ type nameConformanceReport struct {
 
 var nameConformanceCmd = &cobra.Command{
 	Use:   "name-conformance",
-	Short: "List a project's secrets whose names violate the current naming policy",
+	Short: "List secrets whose names violate the current naming policy",
 	Long: `Show the live secrets whose names fail the current secret naming policy. The policy is
 enforced only when a secret is created, so names can fall out of conformance after the
 policy is added or tightened — this surfaces those stragglers so you can rename them.
-Requires secrets.read at the project scope.`,
+
+With --project, scopes to one project (requires secrets.read at the project scope).
+Without --project, reports across every project (requires system.read — admin view).`,
 	SilenceUsage: true,
 	RunE: func(_ *cobra.Command, _ []string) error {
-		if nameConformanceProject == 0 {
-			return fmt.Errorf("--project is required")
-		}
 		c, ok := common.NewRemoteClient()
 		if !ok {
 			return fmt.Errorf("not connected to a server — run: keyorix connect <server>")
 		}
-		report, err := fetchNameConformance(context.Background(), c, nameConformanceProject)
+
+		orgWide := nameConformanceProject == 0
+		var report nameConformanceReport
+		var err error
+		if orgWide {
+			report, err = fetchDeploymentNameConformance(context.Background(), c)
+		} else {
+			report, err = fetchNameConformance(context.Background(), c, nameConformanceProject)
+		}
 		if err != nil {
 			return err
 		}
+
 		if !report.PolicyEnabled {
 			fmt.Println("No secret naming policy is configured — nothing to check.")
 			return nil
@@ -59,15 +70,22 @@ Requires secrets.read at the project scope.`,
 			return nil
 		}
 		fmt.Printf("%d of %d secret(s) violate the naming policy:\n\n", len(report.Violations), report.TotalSecrets)
-		fmt.Printf("%-8s %-24s %-12s %s\n", "ID", "NAME", "TYPE", "REASON")
-		for _, v := range report.Violations {
-			fmt.Printf("%-8d %-24s %-12s %s\n", v.ID, v.Name, v.Type, v.Reason)
+		if orgWide {
+			fmt.Printf("%-20s %-8s %-24s %-12s %s\n", "PROJECT", "ID", "NAME", "TYPE", "REASON")
+			for _, v := range report.Violations {
+				fmt.Printf("%-20s %-8d %-24s %-12s %s\n", v.ProjectName, v.ID, v.Name, v.Type, v.Reason)
+			}
+		} else {
+			fmt.Printf("%-8s %-24s %-12s %s\n", "ID", "NAME", "TYPE", "REASON")
+			for _, v := range report.Violations {
+				fmt.Printf("%-8d %-24s %-12s %s\n", v.ID, v.Name, v.Type, v.Reason)
+			}
 		}
 		return nil
 	},
 }
 
-// fetchNameConformance GETs the project's naming-policy conformance report
+// fetchNameConformance GETs a project's naming-policy conformance report
 // (split out for httptest tests).
 func fetchNameConformance(ctx context.Context, c *common.RemoteClient, projectID uint) (nameConformanceReport, error) {
 	path := "/api/v1/projects/" + strconv.Itoa(int(projectID)) + "/secrets/name-conformance"
@@ -78,7 +96,17 @@ func fetchNameConformance(ctx context.Context, c *common.RemoteClient, projectID
 	return report, nil
 }
 
+// fetchDeploymentNameConformance GETs the org-wide naming-policy conformance report
+// (split out for httptest tests).
+func fetchDeploymentNameConformance(ctx context.Context, c *common.RemoteClient) (nameConformanceReport, error) {
+	var report nameConformanceReport
+	if err := c.Get(ctx, "/api/v1/secrets/name-conformance", &report); err != nil {
+		return nameConformanceReport{}, err
+	}
+	return report, nil
+}
+
 func init() {
-	nameConformanceCmd.Flags().UintVar(&nameConformanceProject, "project", 0, "Project ID (required)")
+	nameConformanceCmd.Flags().UintVar(&nameConformanceProject, "project", 0, "Project ID (omit for an org-wide admin view)")
 	SecretCmd.AddCommand(nameConformanceCmd)
 }

--- a/internal/cli/secret/name_conformance_remote_test.go
+++ b/internal/cli/secret/name_conformance_remote_test.go
@@ -45,3 +45,31 @@ func TestFetchNameConformance_NotFound(t *testing.T) {
 	_, err := fetchNameConformance(context.Background(), rc, 999)
 	require.Error(t, err)
 }
+
+func deploymentNameConformanceStub(t *testing.T) (*common.RemoteClient, func()) {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/secrets/name-conformance" {
+			_, _ = w.Write([]byte(`{"data":{"policy_enabled":true,"pattern":"^[A-Z][A-Z0-9_]*$","max_length":0,"total_secrets":5,"violations":[{"id":8,"name":"db-pass","type":"password","environment_id":2,"reason":"secret name does not match the required pattern","project_name":"alpha"}]}}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	rc, ok := common.NewRemoteClient()
+	require.True(t, ok)
+	return rc, srv.Close
+}
+
+func TestFetchDeploymentNameConformance(t *testing.T) {
+	rc, done := deploymentNameConformanceStub(t)
+	defer done()
+	rep, err := fetchDeploymentNameConformance(context.Background(), rc)
+	require.NoError(t, err)
+	assert.True(t, rep.PolicyEnabled)
+	assert.Equal(t, 5, rep.TotalSecrets)
+	require.Len(t, rep.Violations, 1)
+	assert.Equal(t, "db-pass", rep.Violations[0].Name)
+	assert.Equal(t, "alpha", rep.Violations[0].ProjectName)
+}

--- a/internal/core/secret_name_conformance_deployment.go
+++ b/internal/core/secret_name_conformance_deployment.go
@@ -1,0 +1,70 @@
+// secret_name_conformance_deployment.go — the deployment-wide secret-name conformance
+// report: every live secret across every project whose name violates the CURRENT naming
+// policy, as one list. The naming policy is global, so an admin who adds or tightens it
+// wants a single view of all violators across the deployment rather than checking each
+// project. The per-project view is [[secret_name_conformance]] (SecretNameConformance);
+// this is the admin's all-projects counterpart, parallel to the deployment-wide asset
+// inventory ([[secret_inventory_deployment]]) and hygiene rollup. Never reads a value.
+// Deployment-wide (route-gated system.read).
+package core
+
+import (
+	"context"
+	"fmt"
+)
+
+// DeploymentSecretNameViolation is one naming-policy violation plus its project.
+type DeploymentSecretNameViolation struct {
+	ProjectID   uint   `json:"project_id"`
+	ProjectName string `json:"project_name"`
+	SecretNameViolation
+}
+
+// DeploymentSecretNameConformanceReport is the deployment-wide conformance summary. The
+// policy is global, so PolicyEnabled/Pattern/MaxLength describe the single install-wide
+// policy; PolicyEnabled=false means none is configured and the scan is skipped.
+type DeploymentSecretNameConformanceReport struct {
+	PolicyEnabled bool                            `json:"policy_enabled"`
+	Pattern       string                          `json:"pattern,omitempty"`
+	MaxLength     int                             `json:"max_length,omitempty"`
+	TotalSecrets  int                             `json:"total_secrets"`
+	Violations    []DeploymentSecretNameViolation `json:"violations"`
+}
+
+// DeploymentSecretNameConformance scans every live secret across all projects (each via
+// the per-project SecretNameConformance) and returns those whose name violates the
+// current naming policy, each tagged with its project, ordered by project then name.
+// Skips the scan entirely when no policy is configured. Never reads a value.
+func (c *KeyorixCore) DeploymentSecretNameConformance(ctx context.Context) (*DeploymentSecretNameConformanceReport, error) {
+	report := &DeploymentSecretNameConformanceReport{
+		PolicyEnabled: c.secretNamePolicy.Enabled,
+		Pattern:       c.secretNamePolicy.Pattern,
+		MaxLength:     c.secretNamePolicy.MaxLength,
+		Violations:    []DeploymentSecretNameViolation{},
+	}
+	// No policy configured → nothing can be in violation; skip scanning every project.
+	if !c.secretNamePolicy.Enabled {
+		return report, nil
+	}
+
+	projects, err := c.ListProjects(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list projects: %w", err)
+	}
+
+	for _, p := range projects {
+		sub, err := c.SecretNameConformance(ctx, p.ID)
+		if err != nil {
+			return nil, fmt.Errorf("project %d conformance: %w", p.ID, err)
+		}
+		report.TotalSecrets += sub.TotalSecrets
+		for _, v := range sub.Violations {
+			report.Violations = append(report.Violations, DeploymentSecretNameViolation{
+				ProjectID:           p.ID,
+				ProjectName:         p.Name,
+				SecretNameViolation: v,
+			})
+		}
+	}
+	return report, nil
+}

--- a/internal/core/secret_name_conformance_deployment_test.go
+++ b/internal/core/secret_name_conformance_deployment_test.go
@@ -1,0 +1,84 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestDeploymentSecretNameConformance(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	sqlDB, _ := db.DB()
+	sqlDB.SetMaxOpenConns(1)
+	require.NoError(t, db.AutoMigrate(
+		&models.SecretNode{}, &models.SecretVersion{}, &models.Project{}, &models.Environment{},
+	))
+
+	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
+	ctx := context.Background()
+	now := time.Now()
+
+	// Two projects; each gets one conforming and one non-conforming name, created
+	// directly via storage (i.e. before any policy existed).
+	mkProject := func(name string, secretNames ...string) {
+		p, err := c.storage.CreateProject(ctx, &models.Project{Name: name})
+		require.NoError(t, err)
+		e, err := c.storage.CreateEnvironment(ctx, &models.Environment{Name: "production", ProjectID: p.ID})
+		require.NoError(t, err)
+		for _, sn := range secretNames {
+			_, err = c.storage.CreateSecret(ctx, &models.SecretNode{
+				Name: sn, ProjectID: p.ID, EnvironmentID: e.ID, Type: "password", OwnerID: 1,
+				IsSecret: true, CreatedAt: now, UpdatedAt: now,
+			})
+			require.NoError(t, err)
+		}
+	}
+	mkProject("alpha", "DB_PASSWORD", "alpha-key") // alpha-key violates
+	mkProject("beta", "API_TOKEN", "beta key")     // "beta key" violates (space)
+
+	t.Run("no policy → enabled false, scan skipped, no violations", func(t *testing.T) {
+		require.NoError(t, c.SetSecretNamePolicy(SecretNamePolicy{}))
+		rep, err := c.DeploymentSecretNameConformance(ctx)
+		require.NoError(t, err)
+		assert.False(t, rep.PolicyEnabled)
+		assert.Empty(t, rep.Violations)
+		assert.Zero(t, rep.TotalSecrets)
+	})
+
+	t.Run("aggregates violations across all projects, each tagged with its project", func(t *testing.T) {
+		require.NoError(t, c.SetSecretNamePolicy(SecretNamePolicy{Enabled: true, Pattern: "^[A-Z][A-Z0-9_]*$"}))
+		rep, err := c.DeploymentSecretNameConformance(ctx)
+		require.NoError(t, err)
+		assert.True(t, rep.PolicyEnabled)
+		assert.Equal(t, 4, rep.TotalSecrets, "two projects × two secrets")
+		require.Len(t, rep.Violations, 2)
+
+		byName := map[string]DeploymentSecretNameViolation{}
+		for _, v := range rep.Violations {
+			byName[v.Name] = v
+		}
+		require.Contains(t, byName, "alpha-key")
+		assert.Equal(t, "alpha", byName["alpha-key"].ProjectName)
+		require.Contains(t, byName, "beta key")
+		assert.Equal(t, "beta", byName["beta key"].ProjectName)
+		assert.Contains(t, byName["beta key"].Reason, "pattern")
+	})
+
+	t.Run("when every name conforms, no violations but total counted", func(t *testing.T) {
+		require.NoError(t, c.SetSecretNamePolicy(SecretNamePolicy{Enabled: true, Pattern: "^[A-Za-z0-9_ -]+$"}))
+		rep, err := c.DeploymentSecretNameConformance(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, 4, rep.TotalSecrets)
+		assert.Empty(t, rep.Violations)
+	})
+}

--- a/server/http/handlers/secrets_name_conformance_deployment.go
+++ b/server/http/handlers/secrets_name_conformance_deployment.go
@@ -1,0 +1,29 @@
+// secrets_name_conformance_deployment.go — DeploymentSecretNameConformance handler: the
+// org-wide naming-policy conformance report (every project's live secrets whose names
+// violate the current naming policy). Deployment-wide system.read is enforced by the
+// router. Parallels the per-project SecretNameConformance handler.
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/keyorixhq/keyorix/server/middleware"
+)
+
+// DeploymentSecretNameConformance handles GET /api/v1/secrets/name-conformance — every
+// live secret across all projects whose name violates the current naming policy, each
+// tagged with its project. Returns an empty (policy_enabled false) report when no naming
+// policy is configured.
+func (h *SecretHandler) DeploymentSecretNameConformance(w http.ResponseWriter, r *http.Request) {
+	if middleware.GetUserFromContext(r.Context()) == nil {
+		h.sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+
+	report, err := h.coreService.DeploymentSecretNameConformance(r.Context())
+	if err != nil {
+		h.sendError(w, "InternalError", "Failed to evaluate naming-policy conformance", http.StatusInternalServerError, nil)
+		return
+	}
+	h.sendSuccess(w, report, "")
+}

--- a/server/http/handlers/secrets_name_conformance_deployment_test.go
+++ b/server/http/handlers/secrets_name_conformance_deployment_test.go
@@ -1,0 +1,54 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestDeploymentSecretNameConformanceHandler(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.SecretNode{}, &models.SecretVersion{}, &models.Project{}, &models.Environment{},
+	))
+	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "alpha"}).Error)
+	require.NoError(t, db.Create(&models.Environment{ID: 1, Name: "production", ProjectID: 1}).Error)
+	require.NoError(t, db.Create(&models.SecretNode{
+		Name: "db-pass", ProjectID: 1, EnvironmentID: 1, Type: "password", OwnerID: 1, IsSecret: true,
+		CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	}).Error)
+
+	cs := core.NewKeyorixCore(store.NewLocalStorage(db))
+	require.NoError(t, cs.SetSecretNamePolicy(core.SecretNamePolicy{Enabled: true, Pattern: "^[A-Z][A-Z0-9_]*$"}))
+	h, err := NewSecretHandler(cs)
+	require.NoError(t, err)
+
+	t.Run("reports the violating name tagged with its project", func(t *testing.T) {
+		req := withUserCtx(httptest.NewRequest(http.MethodGet, "/api/v1/secrets/name-conformance", nil))
+		w := httptest.NewRecorder()
+		h.DeploymentSecretNameConformance(w, req)
+
+		require.Equal(t, http.StatusOK, w.Code)
+		body := w.Body.String()
+		assert.Contains(t, body, `"policy_enabled":true`)
+		assert.Contains(t, body, `"project_name":"alpha"`)
+		assert.Contains(t, body, "db-pass")
+	})
+
+	t.Run("requires a user context", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/secrets/name-conformance", nil)
+		w := httptest.NewRecorder()
+		h.DeploymentSecretNameConformance(w, req)
+		assert.Equal(t, http.StatusUnauthorized, w.Code)
+	})
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -342,6 +342,10 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			// project's secrets, metadata only (no values). Deployment-wide system.read;
 			// static path, before /{id}.
 			r.With(customMiddleware.RequirePermission("system.read")).Get("/inventory.csv", secretHandler.DeploymentSecretsInventoryCSV)
+			// Org-wide naming-policy conformance — every project's secrets whose names
+			// violate the current (global) policy. Deployment-wide system.read; static
+			// path, before /{id}.
+			r.With(customMiddleware.RequirePermission("system.read")).Get("/name-conformance", secretHandler.DeploymentSecretNameConformance)
 			r.With(customMiddleware.RequireScopedPermission("secrets.read", secretScope)).Get("/{id}", secretHandler.GetSecret)
 			r.With(customMiddleware.RequireScopedPermission("secrets.read", secretScope)).Get("/{id}/versions", secretHandler.GetSecretVersions)
 			r.With(customMiddleware.RequireScopedPermission("secrets.read", secretScope)).Get("/{id}/risk", secretHandler.GetSecretRisk)


### PR DESCRIPTION
Deployment-wide counterpart to the per-project conformance report (#371). The secret naming policy is **global**, so an admin who adds or tightens it wants **one** view of every violating secret across all projects rather than checking each by hand — mirroring how the asset inventory got an org-wide rollup (#367 → #369) and hygiene got a deployment rollup (#365).

### What's added
- **`core.DeploymentSecretNameConformance`** — iterates every project, reuses the tested per-project `SecretNameConformance`, tags each violation with its project, aggregates `total_secrets`; skips the scan entirely when no policy is set. Never reads a value.
- **`GET /api/v1/secrets/name-conformance`** — deployment-wide `system.read`; registered as a **static** path inside the `/secrets` subrouter (before `/{id}`), per the `/inventory.csv` + `/policy` + `/usage/*` precedent. Verified the full router builds with no chi conflict.
- **`keyorix secret name-conformance`** — `--project` is now **optional**: omit it for the org-wide admin view (adds a PROJECT column), keep it for one project.

### Tests
Core (no policy → skip; aggregates across projects with project tags; all-conform), handler (reports violation tagged with project + 401 without user ctx), CLI (org-wide + per-project fetch + not-found). gofmt/vet/golangci-lint 0/gosec 0.

> The local-only `TestEveryMutatingRouteDeniesReadOnly` `/sw.js` + `/evidence/verify` failures are pre-existing and unrelated (this route is a GET); green in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)