### PR TITLE
feat(access-review): export a recertification campaign as CSV

### DIFF
--- a/server/http/handlers/access_review_campaign_export_csv.go
+++ b/server/http/handlers/access_review_campaign_export_csv.go
@@ -1,0 +1,90 @@
+// access_review_campaign_export_csv.go — ExportAccessReviewCampaignCSV: a CSV download
+// of an access-review campaign's items + decisions, for an auditor to archive as the
+// signed-off recertification record (ISO 27001 A.5.18). Parallels the audit CSV export;
+// reuses GetAccessReviewCampaign for the data and resolves reviewer names once.
+package handlers
+
+import (
+	"encoding/csv"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/keyorixhq/keyorix/server/middleware"
+)
+
+// ExportAccessReviewCampaignCSV handles GET
+// /api/v1/projects/{id}/access-review/campaigns/{campaignId}/export.csv — every item of
+// the campaign with its recertification decision as a CSV attachment. Scoped roles.read
+// (project) is enforced by the router. No secret values.
+func (h *CatalogHandler) ExportAccessReviewCampaignCSV(w http.ResponseWriter, r *http.Request) {
+	if middleware.GetUserFromContext(r.Context()) == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	projectID, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		sendError(w, "InvalidParameter", "Invalid project ID", http.StatusBadRequest, nil)
+		return
+	}
+	campaignID, err := strconv.ParseUint(chi.URLParam(r, "campaignId"), 10, 32)
+	if err != nil {
+		sendError(w, "InvalidParameter", "Invalid campaign ID", http.StatusBadRequest, nil)
+		return
+	}
+
+	detail, err := h.coreService.GetAccessReviewCampaign(r.Context(), uint(projectID), uint(campaignID))
+	if err != nil {
+		sendError(w, "Error", err.Error(), campaignStatusForError(err.Error()), nil)
+		return
+	}
+
+	// Resolve reviewer (decided_by) usernames once per distinct decider.
+	deciderName := map[uint]string{}
+	for _, it := range detail.Items {
+		if it.DecidedBy != 0 {
+			deciderName[it.DecidedBy] = ""
+		}
+	}
+	for id := range deciderName {
+		if u, err := h.coreService.Storage().GetUser(r.Context(), id); err == nil && u != nil {
+			deciderName[id] = u.Username
+		}
+	}
+
+	tstr := func(t *time.Time) string {
+		if t == nil {
+			return ""
+		}
+		return t.UTC().Format(time.RFC3339)
+	}
+
+	w.Header().Set("Content-Type", "text/csv; charset=utf-8")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.Header().Set("Content-Disposition", `attachment; filename="access-review-campaign-`+strconv.FormatUint(campaignID, 10)+`.csv"`)
+
+	cw := csv.NewWriter(w)
+	defer cw.Flush()
+	_ = cw.Write([]string{
+		"principal_type", "principal", "email", "source", "role", "access_level",
+		"environment_id", "secret", "last_used_at", "decision", "reason", "decided_by", "decided_at",
+	})
+	for _, it := range detail.Items {
+		_ = cw.Write([]string{
+			it.PrincipalType,
+			it.PrincipalName,
+			it.Email,
+			it.Source,
+			it.RoleName,
+			it.AccessLevel,
+			strconv.FormatUint(uint64(it.EnvironmentID), 10),
+			it.SecretName,
+			tstr(it.LastUsedAt),
+			it.Decision,
+			it.Reason,
+			deciderName[it.DecidedBy],
+			tstr(it.DecidedAt),
+		})
+	}
+}

--- a/server/http/handlers/access_review_campaign_export_csv_test.go
+++ b/server/http/handlers/access_review_campaign_export_csv_test.go
@@ -1,0 +1,86 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestExportAccessReviewCampaignCSV(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.AccessReviewCampaign{}, &models.AccessReviewItem{}, &models.User{}, &models.Project{},
+	))
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "auditor", Email: "a@t.com"}).Error)
+	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "web"}).Error)
+	require.NoError(t, db.Create(&models.AccessReviewCampaign{
+		ID: 5, ProjectID: 1, Name: "Q4 2026", State: "closed", CreatedBy: 1, CreatedAt: time.Now(),
+	}).Error)
+	decided := time.Now()
+	require.NoError(t, db.Create(&models.AccessReviewItem{
+		ID: 1, CampaignID: 5, PrincipalType: "user", PrincipalID: 10, PrincipalName: "alice",
+		Source: "role", RoleName: "editor", AccessLevel: "write", EnvironmentID: 2,
+		Decision: "attested", DecidedBy: 1, DecidedAt: &decided,
+	}).Error)
+	require.NoError(t, db.Create(&models.AccessReviewItem{
+		ID: 2, CampaignID: 5, PrincipalType: "user", PrincipalID: 11, PrincipalName: "bob",
+		Source: "role", RoleName: "viewer", AccessLevel: "read", EnvironmentID: 2,
+		Decision: "revoked", Reason: "left team", DecidedBy: 1, DecidedAt: &decided,
+	}).Error)
+
+	h := NewCatalogHandler(core.NewKeyorixCore(store.NewLocalStorage(db)))
+
+	t.Run("returns a CSV record of the campaign's items and decisions", func(t *testing.T) {
+		req := withChiParams(withUserCtx(httptest.NewRequest(http.MethodGet,
+			"/api/v1/projects/1/access-review/campaigns/5/export.csv", nil)),
+			map[string]string{"id": "1", "campaignId": "5"})
+		w := httptest.NewRecorder()
+		h.ExportAccessReviewCampaignCSV(w, req)
+
+		require.Equal(t, http.StatusOK, w.Code)
+		assert.Contains(t, w.Header().Get("Content-Type"), "text/csv")
+		assert.Contains(t, w.Header().Get("Content-Disposition"), "access-review-campaign-5.csv")
+
+		body := w.Body.String()
+		lines := strings.Split(strings.TrimSpace(body), "\n")
+		require.Len(t, lines, 3, "header + two items")
+		assert.Equal(t, "principal_type,principal,email,source,role,access_level,environment_id,secret,last_used_at,decision,reason,decided_by,decided_at", strings.TrimSpace(lines[0]))
+		assert.Contains(t, body, "alice")
+		assert.Contains(t, body, "attested")
+		assert.Contains(t, body, "bob")
+		assert.Contains(t, body, "revoked")
+		assert.Contains(t, body, "left team")
+		assert.Contains(t, body, "auditor", "decider username is resolved")
+	})
+
+	t.Run("requires a user context", func(t *testing.T) {
+		req := withChiParams(httptest.NewRequest(http.MethodGet,
+			"/api/v1/projects/1/access-review/campaigns/5/export.csv", nil),
+			map[string]string{"id": "1", "campaignId": "5"})
+		w := httptest.NewRecorder()
+		h.ExportAccessReviewCampaignCSV(w, req)
+		assert.Equal(t, http.StatusUnauthorized, w.Code)
+	})
+
+	t.Run("a campaign from another project is not reachable", func(t *testing.T) {
+		req := withChiParams(withUserCtx(httptest.NewRequest(http.MethodGet,
+			"/api/v1/projects/2/access-review/campaigns/5/export.csv", nil)),
+			map[string]string{"id": "2", "campaignId": "5"})
+		w := httptest.NewRecorder()
+		h.ExportAccessReviewCampaignCSV(w, req)
+		assert.NotEqual(t, http.StatusOK, w.Code)
+	})
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -253,6 +253,9 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		r.With(customMiddleware.RequireScopedPermission("roles.read", projectScope)).Get("/projects/{id}/access-review/campaigns/{campaignId}", catalogHandler.GetAccessReviewCampaign)
 		r.With(customMiddleware.RequireScopedPermission("roles.assign", projectScope)).Post("/projects/{id}/access-review/campaigns/{campaignId}/items/{itemId}/decide", catalogHandler.DecideAccessReviewCampaignItem)
 		r.With(customMiddleware.RequireScopedPermission("roles.assign", projectScope)).Post("/projects/{id}/access-review/campaigns/{campaignId}/close", catalogHandler.CloseAccessReviewCampaign)
+		// CSV export of a campaign's items + decisions — the auditor's signed-off
+		// recertification record (ISO 27001 A.5.18). Read-only, roles.read (project).
+		r.With(customMiddleware.RequireScopedPermission("roles.read", projectScope)).Get("/projects/{id}/access-review/campaigns/{campaignId}/export.csv", catalogHandler.ExportAccessReviewCampaignCSV)
 		r.With(customMiddleware.RequireScopedPermission("roles.assign", projectScope)).Post("/projects/{id}/members", catalogHandler.AddProjectMember)
 		r.With(customMiddleware.RequireScopedPermission("roles.assign", projectScope)).Put("/projects/{id}/members/{userId}", catalogHandler.UpdateProjectMember)
 		r.With(customMiddleware.RequireScopedPermission("roles.assign", projectScope)).Delete("/projects/{id}/members/{userId}", catalogHandler.RemoveProjectMember)


### PR DESCRIPTION
An access-review campaign (ISO 27001 A.5.18) captures the whole recertification cycle — who had access, the reviewer's attest/revoke decision, the reason — but there was no way to hand an auditor the signed-off record; it lived only behind the JSON detail API. This adds a CSV export, parallel to the audit-log CSV export (`/audit/export.csv`).

### What's added
- **`GET /api/v1/projects/{id}/access-review/campaigns/{campaignId}/export.csv`** — every campaign item with its decision as a CSV attachment: `principal_type, principal, email, source, role, access_level, environment_id, secret, last_used_at, decision, reason, decided_by, decided_at`. Reviewer (`decided_by`) names resolved once. Never a secret value.
- Scoped `roles.read` (project), mirroring the campaign detail route; reuses the cross-project-guarded `GetAccessReviewCampaign`, so a campaign id from another project is not reachable. Read-only.

### No CLI
Matches the audit-CSV / inventory-CSV precedent — `RemoteClient` is JSON-only (no raw-body GET), so CSV exports are web/API download only.

### Tests
Handler: CSV record incl. resolved decider name, 401 without user ctx, cross-project not reachable. gofmt/vet/golangci-lint 0/gosec 0; router builds with no chi conflict.

> The local-only `TestEveryMutatingRouteDeniesReadOnly` `/sw.js` + `/evidence/verify` failures are pre-existing and unrelated (this route is a GET); green in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)