### PR TITLE
release: prep v0.67.0 (CHANGELOG + Helm charts 0.67.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,31 @@
 All notable changes to Keyorix are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## v0.67.0 — 2026-06-20
+
+Secret-name governance and an access-recertification export.
+
+### Added
+- **Secret naming-policy conformance** — the optional naming policy is enforced
+  only at create time, so this surfaces existing secrets whose names violate the
+  current policy (e.g. after it's added or tightened), per project
+  (`GET /projects/{id}/secrets/name-conformance`, `keyorix secret
+  name-conformance --project <id>`) and deployment-wide
+  (`GET /secrets/name-conformance`, the same CLI command with `--project`
+  omitted), with web panels on Project Settings and the Admin page. Each
+  violation carries the exact reason create-time enforcement would give.
+  ([#371], [#372])
+- **Access-review campaign CSV export** — download a recertification campaign
+  (ISO 27001 A.5.18) as a CSV record of every reviewed grant and its
+  attest/revoke decision, for an auditor to archive
+  (`GET /projects/{id}/access-review/campaigns/{campaignId}/export.csv`).
+  Extends the compliance-export family beside the audit-log and asset-inventory
+  CSVs. ([#373])
+
+[#371]: https://github.com/keyorixhq/keyorix/pull/371
+[#372]: https://github.com/keyorixhq/keyorix/pull/372
+[#373]: https://github.com/keyorixhq/keyorix/pull/373
+
 ## v0.66.0 — 2026-06-20
 
 Bulk environment promotion, deployment-wide hygiene, and a secret asset register.

--- a/deploy/helm/keyorix-k8s-sync/Chart.yaml
+++ b/deploy/helm/keyorix-k8s-sync/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix-k8s-sync
 description: Keyorix Kubernetes sync agent — materialises Keyorix secrets into native Kubernetes Secrets
 type: application
 # Chart version — tracks the Keyorix release version (published in lockstep).
-version: 0.66.0
+version: 0.67.0
 # The keyorix-k8s-sync image tag this chart deploys by default.
-appVersion: "0.66.0"
+appVersion: "0.67.0"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix

--- a/deploy/helm/keyorix/Chart.yaml
+++ b/deploy/helm/keyorix/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix
 description: Self-hosted Keyorix secrets manager (API server + web UI + PostgreSQL)
 type: application
 # Chart version — bump on chart changes.
-version: 0.66.0
+version: 0.67.0
 # The Keyorix app version this chart deploys by default (the image tag).
-appVersion: "0.66.0"
+appVersion: "0.67.0"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix


### PR DESCRIPTION
Prep the v0.67.0 release: CHANGELOG entry + Helm chart bumps (`keyorix`, `keyorix-k8s-sync`) 0.66.0 → 0.67.0.

Contents since v0.66.0:

- **Secret naming-policy conformance** — surfaces existing secrets whose names violate the current naming policy (enforced only at create time), per project + deployment-wide, across server/CLI/web. (#371, #372)
- **Access-review campaign CSV export** — download a recertification campaign (ISO 27001 A.5.18) as an auditable CSV record of every reviewed grant and its attest/revoke decision. (#373)

Docs/charts only; both charts `helm lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)