### PR TITLE
feat(compliance): on-demand compliance digest endpoint

### DIFF
--- a/server/http/handlers/compliance_digest_test.go
+++ b/server/http/handlers/compliance_digest_test.go
@@ -1,0 +1,47 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestGetComplianceDigestHandler(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	// The migration set GetCompliancePosture (which the digest builds on) reads from.
+	require.NoError(t, db.AutoMigrate(
+		&models.User{}, &models.Role{}, &models.UserRole{}, &models.Project{},
+		&models.Environment{}, &models.SecretNode{}, &models.RotationPolicy{},
+		&models.AuditEvent{}, &models.AnomalyAlert{}, &models.LegalHold{},
+		&models.SoDPolicy{}, &models.AccessReviewCampaign{}, &models.AccessReviewItem{},
+		&models.BreakGlassActivation{}, &models.AccessRequest{}, &models.RiskException{},
+	))
+
+	h := NewDashboardHandler(core.NewKeyorixCore(store.NewLocalStorage(db)))
+
+	t.Run("returns the on-demand digest title and body", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/compliance/digest", nil)
+		w := httptest.NewRecorder()
+		h.GetComplianceDigest(w, req)
+
+		require.Equal(t, http.StatusOK, w.Code)
+		body := w.Body.String()
+		assert.Contains(t, body, `"title"`)
+		assert.Contains(t, body, `"body"`)
+		// The digest title + posture summary lines come through.
+		assert.Contains(t, body, "Keyorix compliance digest")
+		assert.Contains(t, body, "Controls:")
+		assert.Contains(t, body, "Classification:")
+	})
+}

--- a/server/http/handlers/dashboard.go
+++ b/server/http/handlers/dashboard.go
@@ -48,6 +48,19 @@ func (h *DashboardHandler) GetCompliancePosture(w http.ResponseWriter, r *http.R
 	sendSuccess(w, posture, "")
 }
 
+// GetComplianceDigest handles GET /api/v1/compliance/digest — the on-demand,
+// human-readable compliance digest (the same title + body otherwise broadcast on a
+// schedule to the notification channels), so an admin can pull a point-in-time
+// summary without waiting for the scheduled send. Gated by system.read in the router.
+func (h *DashboardHandler) GetComplianceDigest(w http.ResponseWriter, r *http.Request) {
+	title, body, err := h.coreService.BuildComplianceDigest(r.Context())
+	if err != nil {
+		sendError(w, "InternalServerError", "Failed to build compliance digest", http.StatusInternalServerError, nil)
+		return
+	}
+	sendSuccess(w, map[string]string{"title": title, "body": body}, "")
+}
+
 // VerifyComplianceEvidence handles POST /api/v1/compliance/evidence/verify — checks
 // a previously-exported evidence pack against its detached signature. The pack bytes
 // are base64-encoded in the request so arbitrary JSON can ride in a JSON envelope.

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -565,6 +565,8 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		r.With(customMiddleware.RequirePermission("system.read")).Get("/compliance/posture", dashboardHandler.GetCompliancePosture)
 		// Compliance control matrix — controls mapped to ISO/SOC2/NIS2/DORA + status.
 		r.With(customMiddleware.RequirePermission("system.read")).Get("/compliance/controls", dashboardHandler.GetComplianceControls)
+		// Compliance digest — on-demand human-readable summary (the scheduled-broadcast text).
+		r.With(customMiddleware.RequirePermission("system.read")).Get("/compliance/digest", dashboardHandler.GetComplianceDigest)
 		// Legal hold (ISO A.5.34): status reads system.read; place/lift system.write.
 		r.With(customMiddleware.RequirePermission("system.read")).Get("/legal-hold", dashboardHandler.GetLegalHold)
 		r.With(customMiddleware.RequirePermission("system.write")).Post("/legal-hold", dashboardHandler.PlaceLegalHold)


### PR DESCRIPTION
The compliance digest (controls pass/gap, overdue recertifications, rotation gaps, unclassified secrets, open anomalies, risk exceptions, legal hold) was built only to be **broadcast on a schedule** to the notification channels — an admin couldn't pull the current summary on demand. This wires the existing, tested `BuildComplianceDigest` to a read endpoint.

### What's added
- **`GET /api/v1/compliance/digest`** → `{title, body}` — the same human-readable digest otherwise broadcast, as a point-in-time pull. Deployment-wide `system.read`, beside `/compliance/posture` and `/compliance/controls`.
- Read-only; **no new core logic** — reuses `BuildComplianceDigest` → `GetCompliancePosture` + `EvaluateControls`.

### Tests
Handler test: 200 with `title`/`body` and the posture summary lines. gofmt/vet/golangci-lint 0/gosec 0; router builds with no chi conflict.

> The local-only `TestEveryMutatingRouteDeniesReadOnly` `/sw.js` + `/evidence/verify` failures are pre-existing and unrelated (this route is a GET); green in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)