### PR TITLE
feat(compliance): export the control matrix as CSV

### DIFF
--- a/server/http/handlers/compliance_controls_csv.go
+++ b/server/http/handlers/compliance_controls_csv.go
@@ -1,0 +1,51 @@
+// compliance_controls_csv.go — ExportComplianceControlsCSV: the compliance control
+// matrix (each control mapped to ISO 27001 / SOC 2 / NIS2 / DORA clauses with its live
+// pass/gap status) as a CSV attachment for an auditor's spreadsheet. The JSON form is
+// GET /compliance/controls; this is the compliance-export-family CSV counterpart, beside
+// the audit-log and asset-inventory CSVs.
+package handlers
+
+import (
+	"encoding/csv"
+	"net/http"
+	"strings"
+
+	"github.com/keyorixhq/keyorix/server/middleware"
+)
+
+// ExportComplianceControlsCSV handles GET /api/v1/compliance/controls.csv — the evaluated
+// control matrix as a CSV attachment (id, name, area, status, detail, and the framework
+// clause refs). Deployment-wide system.read is enforced by the router.
+func (h *DashboardHandler) ExportComplianceControlsCSV(w http.ResponseWriter, r *http.Request) {
+	if middleware.GetUserFromContext(r.Context()) == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+
+	matrix, err := h.coreService.GetComplianceControls(r.Context())
+	if err != nil {
+		sendError(w, "InternalServerError", "Failed to evaluate compliance controls", http.StatusInternalServerError, nil)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/csv; charset=utf-8")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.Header().Set("Content-Disposition", `attachment; filename="compliance-controls.csv"`)
+
+	cw := csv.NewWriter(w)
+	defer cw.Flush()
+	_ = cw.Write([]string{"id", "name", "area", "status", "detail", "iso_27001", "soc2", "nis2", "dora"})
+	for _, ctrl := range matrix.Controls {
+		_ = cw.Write([]string{
+			ctrl.ID,
+			ctrl.Name,
+			ctrl.Area,
+			string(ctrl.Status),
+			ctrl.Detail,
+			strings.Join(ctrl.Frameworks.ISO27001, "; "),
+			strings.Join(ctrl.Frameworks.SOC2, "; "),
+			strings.Join(ctrl.Frameworks.NIS2, "; "),
+			strings.Join(ctrl.Frameworks.DORA, "; "),
+		})
+	}
+}

--- a/server/http/handlers/compliance_controls_csv_test.go
+++ b/server/http/handlers/compliance_controls_csv_test.go
@@ -1,0 +1,57 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestExportComplianceControlsCSV(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.User{}, &models.Role{}, &models.UserRole{}, &models.Project{},
+		&models.Environment{}, &models.SecretNode{}, &models.RotationPolicy{},
+		&models.AuditEvent{}, &models.AnomalyAlert{}, &models.LegalHold{},
+		&models.SoDPolicy{}, &models.AccessReviewCampaign{}, &models.AccessReviewItem{},
+		&models.BreakGlassActivation{}, &models.AccessRequest{}, &models.RiskException{},
+	))
+
+	h := NewDashboardHandler(core.NewKeyorixCore(store.NewLocalStorage(db)))
+
+	t.Run("returns the control matrix as a CSV with framework refs", func(t *testing.T) {
+		req := withUserCtx(httptest.NewRequest(http.MethodGet, "/api/v1/compliance/controls.csv", nil))
+		w := httptest.NewRecorder()
+		h.ExportComplianceControlsCSV(w, req)
+
+		require.Equal(t, http.StatusOK, w.Code)
+		assert.Contains(t, w.Header().Get("Content-Type"), "text/csv")
+		assert.Contains(t, w.Header().Get("Content-Disposition"), "compliance-controls.csv")
+
+		body := w.Body.String()
+		lines := strings.Split(strings.TrimSpace(body), "\n")
+		require.GreaterOrEqual(t, len(lines), 2, "header + at least one control")
+		assert.Equal(t, "id,name,area,status,detail,iso_27001,soc2,nis2,dora", strings.TrimSpace(lines[0]))
+		// The tamper-evident audit-trail control and its ISO ref come through.
+		assert.Contains(t, body, "audit-trail-integrity")
+		assert.Contains(t, body, "A.5.28")
+	})
+
+	t.Run("requires a user context", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/compliance/controls.csv", nil)
+		w := httptest.NewRecorder()
+		h.ExportComplianceControlsCSV(w, req)
+		assert.Equal(t, http.StatusUnauthorized, w.Code)
+	})
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -565,6 +565,8 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		r.With(customMiddleware.RequirePermission("system.read")).Get("/compliance/posture", dashboardHandler.GetCompliancePosture)
 		// Compliance control matrix — controls mapped to ISO/SOC2/NIS2/DORA + status.
 		r.With(customMiddleware.RequirePermission("system.read")).Get("/compliance/controls", dashboardHandler.GetComplianceControls)
+		// Control matrix as CSV — the same matrix for an auditor's spreadsheet.
+		r.With(customMiddleware.RequirePermission("system.read")).Get("/compliance/controls.csv", dashboardHandler.ExportComplianceControlsCSV)
 		// Compliance digest — on-demand human-readable summary (the scheduled-broadcast text).
 		r.With(customMiddleware.RequirePermission("system.read")).Get("/compliance/digest", dashboardHandler.GetComplianceDigest)
 		// Legal hold (ISO A.5.34): status reads system.read; place/lift system.write.


### PR DESCRIPTION
The compliance control matrix (each control mapped to ISO 27001 / SOC 2 / NIS2 / DORA clauses with its live pass/gap status) was JSON-only — an auditor preparing an audit wants it in a spreadsheet. This adds the CSV counterpart, completing the compliance-export family beside the audit-log, asset-inventory, and access-recertification CSVs.

### What's added
- **`GET /api/v1/compliance/controls.csv`** → CSV attachment: `id, name, area, status, detail, iso_27001, soc2, nis2, dora` (framework refs joined by `; `). Deployment-wide `system.read`, beside `/compliance/controls`.
- Reuses the existing `GetComplianceControls`; **no new core logic**. Read-only.

### Tests
Handler test: CSV header + a known control and its ISO ref; 401 without user context. gofmt/vet/golangci-lint 0/gosec 0; router builds with no chi conflict.

> The local-only `TestEveryMutatingRouteDeniesReadOnly` `/sw.js` + `/evidence/verify` failures are pre-existing and unrelated (this route is a GET); green in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)