### PR TITLE
release: prep v0.68.0 (CHANGELOG + Helm charts 0.68.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,26 @@
 All notable changes to Keyorix are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## v0.68.0 — 2026-06-20
+
+Compliance read surface: an on-demand digest and a control-matrix export.
+
+### Added
+- **On-demand compliance digest** — `GET /compliance/digest` returns the
+  human-readable compliance summary (controls pass/gap, overdue recertifications,
+  rotation gaps, unclassified secrets, open anomalies, risk exceptions, legal
+  hold) that is otherwise broadcast to the notification channels on a schedule,
+  so an admin can pull a point-in-time report; shown with a copy button on the
+  Compliance page. ([#375])
+- **Control-matrix CSV export** — `GET /compliance/controls.csv` downloads the
+  control matrix (each control mapped to ISO 27001 / SOC 2 / NIS2 / DORA clauses
+  with its live pass/gap status) for an auditor's spreadsheet, with a download
+  button on the Compliance page. Completes the compliance-export family beside
+  the audit-log, asset-inventory, and access-recertification CSVs. ([#376])
+
+[#375]: https://github.com/keyorixhq/keyorix/pull/375
+[#376]: https://github.com/keyorixhq/keyorix/pull/376
+
 ## v0.67.0 — 2026-06-20
 
 Secret-name governance and an access-recertification export.

--- a/deploy/helm/keyorix-k8s-sync/Chart.yaml
+++ b/deploy/helm/keyorix-k8s-sync/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix-k8s-sync
 description: Keyorix Kubernetes sync agent — materialises Keyorix secrets into native Kubernetes Secrets
 type: application
 # Chart version — tracks the Keyorix release version (published in lockstep).
-version: 0.67.0
+version: 0.68.0
 # The keyorix-k8s-sync image tag this chart deploys by default.
-appVersion: "0.67.0"
+appVersion: "0.68.0"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix

--- a/deploy/helm/keyorix/Chart.yaml
+++ b/deploy/helm/keyorix/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix
 description: Self-hosted Keyorix secrets manager (API server + web UI + PostgreSQL)
 type: application
 # Chart version — bump on chart changes.
-version: 0.67.0
+version: 0.68.0
 # The Keyorix app version this chart deploys by default (the image tag).
-appVersion: "0.67.0"
+appVersion: "0.68.0"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix


### PR DESCRIPTION
Prep the v0.68.0 release: CHANGELOG entry + Helm chart bumps (`keyorix`, `keyorix-k8s-sync`) 0.67.0 → 0.68.0.

Contents since v0.67.0:

- **On-demand compliance digest** — `GET /compliance/digest` returns the human-readable compliance summary on demand (otherwise broadcast on a schedule), with a copy button on the Compliance page. (#375)
- **Control-matrix CSV export** — `GET /compliance/controls.csv` downloads the control matrix (ISO 27001 / SOC 2 / NIS2 / DORA mapping + pass/gap status), with a download button on the Compliance page. (#376)

Docs/charts only; both charts `helm lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)