### PR TITLE
feat(server): real readiness probe that checks the database

### DIFF
--- a/deploy/helm/keyorix/templates/server-deployment.yaml
+++ b/deploy/helm/keyorix/templates/server-deployment.yaml
@@ -71,7 +71,7 @@ spec:
             periodSeconds: 20
           readinessProbe:
             httpGet:
-              path: /health
+              path: /readyz
               port: http
             initialDelaySeconds: 5
             periodSeconds: 10

--- a/server/http/handlers/readiness.go
+++ b/server/http/handlers/readiness.go
@@ -1,0 +1,30 @@
+// readiness.go — ReadinessCheck: a real readiness probe that verifies the server can
+// actually serve traffic by pinging its database (core.HealthCheck → SELECT 1). It
+// returns 200 when ready and 503 when a dependency is down, so a Kubernetes readiness
+// probe stops routing traffic to a replica whose database is unreachable. This is
+// distinct from /health (HealthCheck), which is a lightweight liveness signal that must
+// NOT depend on the database — a transient DB blip should not restart the pod.
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+)
+
+// ReadinessCheck returns a handler for GET /readyz that reports whether the server is
+// ready to serve traffic (database reachable). 200 = ready, 503 = not ready. The error
+// detail is intentionally generic so internals aren't leaked on an unauthenticated route.
+func ReadinessCheck(svc *core.KeyorixCore) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Cache-Control", "no-cache")
+		if err := svc.HealthCheck(r.Context()); err != nil {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_ = json.NewEncoder(w).Encode(map[string]string{"status": "not_ready", "reason": "database unreachable"})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]string{"status": "ready"})
+	}
+}

--- a/server/http/handlers/readiness_test.go
+++ b/server/http/handlers/readiness_test.go
@@ -1,0 +1,42 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestReadinessCheck(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+
+	h := ReadinessCheck(core.NewKeyorixCore(store.NewLocalStorage(db)))
+
+	t.Run("reports ready when the database is reachable", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+		w := httptest.NewRecorder()
+		h(w, req)
+
+		require.Equal(t, http.StatusOK, w.Code)
+		assert.Contains(t, w.Body.String(), `"status":"ready"`)
+	})
+
+	t.Run("reports 503 not_ready when the database is unreachable", func(t *testing.T) {
+		require.NoError(t, sqlDB.Close()) // sever the DB connection → SELECT 1 fails
+		req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+		w := httptest.NewRecorder()
+		h(w, req)
+
+		require.Equal(t, http.StatusServiceUnavailable, w.Code)
+		assert.Contains(t, w.Body.String(), `"status":"not_ready"`)
+	})
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -102,8 +102,13 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 	r.Get("/auth/sso/{provider}/login", authHandler.BeginSSO)
 	r.Get("/auth/sso/{provider}/callback", authHandler.CompleteSSO)
 
-	// Health check endpoint
+	// Health check endpoint — lightweight liveness signal (does not touch the DB, so a
+	// transient DB outage won't get the pod restarted).
 	r.Get("/health", handlers.HealthCheck)
+
+	// Readiness probe — verifies the database is reachable before routing traffic to
+	// this replica. Unauthenticated, like /health (k8s probes are unauthenticated).
+	r.Get("/readyz", handlers.ReadinessCheck(coreService))
 
 	// Prometheus metrics — unauthenticated by design (standard for scraping); keep
 	// it inside your perimeter. Exposes HTTP request metrics + Go runtime/process.


### PR DESCRIPTION
`/health` is a **mock** — it always returns `"healthy"` with hardcoded database/storage status. The Helm chart pointed **both** the liveness and readiness probes at it, so a replica whose database is unreachable was still marked **Ready** and kept receiving traffic. This adds a genuine readiness check.

### What's added
- **`GET /readyz`** — pings the database via the existing `core.HealthCheck` (`SELECT 1`); `200 {"status":"ready"}` when reachable, `503 {"status":"not_ready"}` when not. Unauthenticated, like `/health` (k8s probes are unauthenticated). Error detail is generic so internals aren't leaked.
- **Helm**: the server `readinessProbe` now targets `/readyz`; `livenessProbe` stays on `/health` (liveness must not depend on the DB — a transient blip shouldn't restart the pod). The web frontend's own nginx `/health` is untouched.

### Why
A readiness probe that can't fail is not a readiness probe. With this, Kubernetes stops routing traffic to a replica that can't reach its database, and restores it when the DB recovers — without restarting the pod.

### Tests
Handler test: ready → 200; DB connection closed → 503. gofmt/vet/golangci-lint 0/gosec 0; `helm lint` clean; rendered probe paths verified (`readiness=/readyz`, `liveness=/health`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)