### PR TITLE
feat(server): report the real build version on /health and /system/info

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,11 @@ BINARY_CLI=keyorix
 BINARY_SERVER=keyorix-server
 BUILD_DIR=./bin
 VERSION?=dev
-LDFLAGS=-ldflags "-X github.com/keyorixhq/keyorix/internal/cli.version=$(VERSION)"
+GIT_COMMIT?=$(shell git rev-parse --short HEAD 2>/dev/null || echo none)
+# Inject the build identity into both the CLI (internal/cli.version) and the shared
+# internal/version package (read by the server's /health + /system/info). Commit is
+# deterministic per source revision, so release builds stay reproducible (no build date).
+LDFLAGS=-ldflags "-X github.com/keyorixhq/keyorix/internal/cli.version=$(VERSION) -X github.com/keyorixhq/keyorix/internal/version.Version=$(VERSION) -X github.com/keyorixhq/keyorix/internal/version.Commit=$(GIT_COMMIT)"
 
 .PHONY: build build-cli build-server build-ui install install-cli install-server clean run db-up dev docker-build docker-up docker-down docker-logs proto proto-deps proto-lint release
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,13 @@
+// Package version holds the build identity of the Keyorix server and CLI, injected at
+// build time via -ldflags -X (see the Makefile). The defaults apply to a plain
+// `go build` / `go run` (a developer build); release binaries built via `make release
+// VERSION=<tag>` carry the real tag and commit.
+package version
+
+var (
+	// Version is the release version (a git tag like "v0.68.0"), or "dev" for an
+	// un-injected build.
+	Version = "dev"
+	// Commit is the short git commit the binary was built from, or "none".
+	Commit = "none"
+)

--- a/server/http/handlers/health.go
+++ b/server/http/handlers/health.go
@@ -4,39 +4,25 @@ import (
 	"encoding/json"
 	"net/http"
 	"time"
+
+	"github.com/keyorixhq/keyorix/internal/version"
 )
 
-// HealthResponse represents the health check response
-type HealthResponse struct {
-	Status    string            `json:"status"`
-	Timestamp time.Time         `json:"timestamp"`
-	Version   string            `json:"version"`
-	Services  map[string]string `json:"services"`
-}
+// processStart is captured when the package loads (≈ server start) so /health can report
+// a real uptime.
+var processStart = time.Now()
 
-// HealthCheck handles the health check endpoint
+// HealthCheck handles GET /health — a lightweight liveness signal: it reports that the
+// process is up and responsive. It deliberately does NOT check the database or other
+// dependencies (that is /readyz's job) — a transient dependency outage should not cause
+// the liveness probe to fail and restart the pod.
 func HealthCheck(w http.ResponseWriter, r *http.Request) {
-	startTime := time.Now().Add(-5 * time.Minute) // Mock uptime
-
 	health := map[string]interface{}{
 		"status":    "healthy",
 		"timestamp": time.Now().UTC(),
-		"uptime":    time.Since(startTime).String(),
-		"version":   "1.0.0",
-		"checks": map[string]interface{}{
-			"database": map[string]interface{}{
-				"status":  "healthy",
-				"latency": "2ms",
-			},
-			"encryption": map[string]interface{}{
-				"status":   "healthy",
-				"provider": "AES-256-GCM",
-			},
-			"storage": map[string]interface{}{
-				"status":     "healthy",
-				"free_space": "85%",
-			},
-		},
+		"uptime":    time.Since(processStart).String(),
+		"version":   version.Version,
+		"commit":    version.Commit,
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/server/http/handlers/health_test.go
+++ b/server/http/handlers/health_test.go
@@ -1,0 +1,33 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHealthCheck(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	w := httptest.NewRecorder()
+	HealthCheck(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var body map[string]interface{}
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&body))
+
+	// Liveness signal + the keys the probe/consumers rely on.
+	assert.Equal(t, "healthy", body["status"])
+	assert.Contains(t, body, "timestamp")
+	assert.Contains(t, body, "uptime")
+	assert.Contains(t, body, "version")
+
+	// The old handler fabricated dependency health (always "healthy" db/storage/
+	// encryption) — that lie is gone. Liveness must not claim DB health (see /readyz).
+	assert.NotContains(t, body, "checks")
+	assert.NotContains(t, w.Body.String(), "free_space")
+}

--- a/server/http/handlers/system.go
+++ b/server/http/handlers/system.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/version"
 	"github.com/keyorixhq/keyorix/server/middleware"
 )
 
@@ -135,9 +136,9 @@ func MakeSystemInfoHandler(cfg *config.Config) http.HandlerFunc {
 		grpcEnabled := cfg.Server.GRPC.Enabled
 
 		systemInfo := SystemInfo{
-			Version:     "0.1.0",
-			BuildTime:   "2026-05-06",
-			GitCommit:   "see git log",
+			Version:     version.Version,
+			BuildTime:   "unknown", // not injected — release builds stay byte-reproducible (commit identifies the source)
+			GitCommit:   version.Commit,
 			GoVersion:   runtime.Version(),
 			OS:          runtime.GOOS,
 			Arch:        runtime.GOARCH,


### PR DESCRIPTION
Both endpoints fabricated their build identity: `/health` hardcoded version `1.0.0` with a 5-minute mock uptime and a fake `checks{database,encryption,storage}` block that always said `"healthy"`; `/system/info` hardcoded `0.1.0` / `2026-05-06` / `"see git log"`. None reflected the actual build.

### What's added
- **`internal/version` package** (`Version`, `Commit`), injected at build via `-ldflags -X`. The Makefile now sets both from `VERSION` + git short SHA, so `make release VERSION=<tag>` produces **server** binaries that report the real tag and commit (the CLI already did this; the server didn't). Commit-only — no build date — keeps release builds byte-reproducible.
- **`/health`**: honest lightweight liveness — `status`, real `uptime` (from process start), `version`, `commit`. Dropped the fabricated dependency-health block (that's `/readyz`'s job; liveness must not claim DB health).
- **`/system/info`**: `version` + `git_commit` from the version package; `build_time` is `"unknown"` (not injected, for reproducibility).

### Tests
New `/health` unit test (honest keys present, fabricated `checks`/`free_space` gone) + existing integration assertions (`status="healthy"`, `timestamp`, `uptime`, `/system/info` `version`) still pass. gofmt/vet/golangci-lint 0/gosec 0; ldflags injection verified in a built binary (`v9.9.9-test` + commit embedded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)