### PR TITLE
feat(cli): keyorix system info — show the connected server's build identity

### DIFF
--- a/internal/cli/system/info.go
+++ b/internal/cli/system/info.go
@@ -1,0 +1,88 @@
+package system
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/spf13/cobra"
+)
+
+// systemInfo mirrors the GET /api/v1/system/info response (snake_case DTO), the fields
+// this command displays.
+type systemInfo struct {
+	Version     string          `json:"version"`
+	GitCommit   string          `json:"git_commit"`
+	GoVersion   string          `json:"go_version"`
+	OS          string          `json:"os"`
+	Arch        string          `json:"arch"`
+	Uptime      string          `json:"uptime"`
+	Environment string          `json:"environment"`
+	Features    map[string]bool `json:"features"`
+	Database    struct {
+		Type      string `json:"type"`
+		Connected bool   `json:"connected"`
+	} `json:"database"`
+	Security struct {
+		TLSEnabled       bool   `json:"tls_enabled"`
+		AuthEnabled      bool   `json:"auth_enabled"`
+		EncryptionMethod string `json:"encryption_method"`
+		AuditEnabled     bool   `json:"audit_enabled"`
+	} `json:"security"`
+}
+
+// fetchSystemInfo GETs the server's system info (split out for httptest tests).
+func fetchSystemInfo(ctx context.Context, c *common.RemoteClient) (systemInfo, error) {
+	var info systemInfo
+	if err := c.Get(ctx, "/api/v1/system/info", &info); err != nil {
+		return systemInfo{}, err
+	}
+	return info, nil
+}
+
+var infoCmd = &cobra.Command{
+	Use:   "info",
+	Short: "Show the connected server's build identity and configuration",
+	Long: `Display the remote Keyorix server's version, commit, runtime, and feature/security
+configuration (GET /system/info). Useful for confirming which build you're talking to.
+Requires a connection to a server and system.read.`,
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		c, ok := common.NewRemoteClient()
+		if !ok {
+			return fmt.Errorf("not connected to a server — run: keyorix connect <server>")
+		}
+		info, err := fetchSystemInfo(context.Background(), c)
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("Version:     %s\n", info.Version)
+		fmt.Printf("Commit:      %s\n", info.GitCommit)
+		fmt.Printf("Go:          %s\n", info.GoVersion)
+		fmt.Printf("Platform:    %s/%s\n", info.OS, info.Arch)
+		fmt.Printf("Uptime:      %s\n", info.Uptime)
+		fmt.Printf("Environment: %s\n", info.Environment)
+		fmt.Printf("Database:    %s (connected=%t)\n", info.Database.Type, info.Database.Connected)
+		fmt.Printf("Security:    tls=%t auth=%t audit=%t encryption=%s\n",
+			info.Security.TLSEnabled, info.Security.AuthEnabled, info.Security.AuditEnabled, info.Security.EncryptionMethod)
+
+		if len(info.Features) > 0 {
+			names := make([]string, 0, len(info.Features))
+			for k := range info.Features {
+				names = append(names, k)
+			}
+			sort.Strings(names)
+			fmt.Print("Features:    ")
+			for i, n := range names {
+				if i > 0 {
+					fmt.Print(", ")
+				}
+				fmt.Printf("%s=%t", n, info.Features[n])
+			}
+			fmt.Println()
+		}
+		return nil
+	},
+}

--- a/internal/cli/system/info_remote_test.go
+++ b/internal/cli/system/info_remote_test.go
@@ -1,0 +1,54 @@
+package system
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func systemInfoStub(t *testing.T) (*common.RemoteClient, func()) {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/system/info" {
+			_, _ = w.Write([]byte(`{"data":{"version":"v0.68.0","git_commit":"abc1234","go_version":"go1.26","os":"linux","arch":"amd64","uptime":"3h","environment":"production","features":{"tls_enabled":true,"grpc_enabled":false},"database":{"type":"postgres","connected":true},"security":{"tls_enabled":true,"auth_enabled":true,"encryption_method":"AES-256-GCM","audit_enabled":true}}}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	rc, ok := common.NewRemoteClient()
+	require.True(t, ok)
+	return rc, srv.Close
+}
+
+func TestFetchSystemInfo(t *testing.T) {
+	rc, done := systemInfoStub(t)
+	defer done()
+	info, err := fetchSystemInfo(context.Background(), rc)
+	require.NoError(t, err)
+	assert.Equal(t, "v0.68.0", info.Version)
+	assert.Equal(t, "abc1234", info.GitCommit)
+	assert.Equal(t, "postgres", info.Database.Type)
+	assert.True(t, info.Database.Connected)
+	assert.Equal(t, "AES-256-GCM", info.Security.EncryptionMethod)
+	assert.True(t, info.Features["tls_enabled"])
+}
+
+func TestFetchSystemInfo_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	c, ok := common.NewRemoteClient()
+	require.True(t, ok)
+	_, err := fetchSystemInfo(context.Background(), c)
+	require.Error(t, err)
+}

--- a/internal/cli/system/system.go
+++ b/internal/cli/system/system.go
@@ -13,4 +13,5 @@ func init() {
 	SystemCmd.AddCommand(InitCmd)
 	SystemCmd.AddCommand(auditCmd)
 	SystemCmd.AddCommand(validateCmd)
+	SystemCmd.AddCommand(infoCmd)
 }


### PR DESCRIPTION
There was no CLI way to read the server's version/build info: `keyorix status` and `ping` measure connectivity only, and `keyorix version` reports the **CLI's own** version. With the server now reporting an honest version (#379), operators should be able to read it from the CLI.

### What's added
- **`keyorix system info`** — GETs `/system/info` and prints version, commit, Go runtime, platform, uptime, environment, database type/connected, security flags, and the feature matrix. Requires a connection + `system.read`. `fetchSystemInfo` split out for httptest. No new deps.

### Tests
Decode (version/commit/db/security/features) + server-error path. gofmt/vet/golangci-lint 0/gosec 0.

Closes the loop on the operability arc: real readiness (#378) + honest server version (#379) + an operator-facing CLI to read it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)