### PR TITLE
release: prep v0.69.0 (CHANGELOG + Helm charts 0.69.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,29 @@
 All notable changes to Keyorix are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## v0.69.0 — 2026-06-21
+
+Operability: a real readiness probe and honest build identity.
+
+### Added
+- **Readiness probe** — `GET /readyz` verifies the database is reachable (200
+  ready / 503 not-ready), so Kubernetes stops routing to a replica whose database
+  is down and restores it on recovery. The Helm chart's readiness probe now
+  targets `/readyz`; the liveness probe stays on `/health` (liveness must not
+  depend on the database). ([#378])
+- **`keyorix system info`** — a CLI command that shows the connected server's
+  version, commit, runtime, uptime, and feature/security configuration. ([#380])
+
+### Changed
+- **Honest build identity** — `/health` and `/system/info` now report the real
+  build version and commit (injected at build time) instead of hardcoded
+  placeholders, and `/health` is a lightweight liveness signal that no longer
+  fabricates dependency-health claims. ([#379])
+
+[#378]: https://github.com/keyorixhq/keyorix/pull/378
+[#379]: https://github.com/keyorixhq/keyorix/pull/379
+[#380]: https://github.com/keyorixhq/keyorix/pull/380
+
 ## v0.68.0 — 2026-06-20
 
 Compliance read surface: an on-demand digest and a control-matrix export.

--- a/deploy/helm/keyorix-k8s-sync/Chart.yaml
+++ b/deploy/helm/keyorix-k8s-sync/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix-k8s-sync
 description: Keyorix Kubernetes sync agent — materialises Keyorix secrets into native Kubernetes Secrets
 type: application
 # Chart version — tracks the Keyorix release version (published in lockstep).
-version: 0.68.0
+version: 0.69.0
 # The keyorix-k8s-sync image tag this chart deploys by default.
-appVersion: "0.68.0"
+appVersion: "0.69.0"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix

--- a/deploy/helm/keyorix/Chart.yaml
+++ b/deploy/helm/keyorix/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix
 description: Self-hosted Keyorix secrets manager (API server + web UI + PostgreSQL)
 type: application
 # Chart version — bump on chart changes.
-version: 0.68.0
+version: 0.69.0
 # The Keyorix app version this chart deploys by default (the image tag).
-appVersion: "0.68.0"
+appVersion: "0.69.0"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix


### PR DESCRIPTION
Prep the v0.69.0 release: CHANGELOG entry + Helm chart bumps (`keyorix`, `keyorix-k8s-sync`) 0.68.0 → 0.69.0.

Contents since v0.68.0 (operability):

- **Readiness probe** — `GET /readyz` checks the database; the Helm readiness probe now targets it (liveness stays on `/health`). (#378)
- **Honest build identity** — `/health` and `/system/info` report the real build version + commit; `/health` no longer fabricates dependency-health. (#379)
- **`keyorix system info`** — CLI to read the connected server's version/build/config. (#380)

Docs/charts only; both charts `helm lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)