### PR TITLE
feat(secrets): per-secret read statistics endpoint

### DIFF
--- a/internal/core/secret_access_stats.go
+++ b/internal/core/secret_access_stats.go
@@ -1,0 +1,79 @@
+// secret_access_stats.go — per-secret access statistics: a single, focused read of how
+// much a secret is actually used (lifetime read count + a recent-window summary). It
+// answers "is this secret used, and by whom lately?" directly, instead of cross-
+// referencing the deployment-wide usage analytics, the per-user access log, and the
+// composite risk score. Read-only; never returns the secret value.
+package core
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// SecretAccessStats summarises a secret's read activity. TotalReads is the durable
+// lifetime counter (summed across versions, survives access-log retention); the *Window
+// fields cover the last WindowDays of the (retained) access log.
+type SecretAccessStats struct {
+	SecretID      uint       `json:"secret_id"`
+	TotalReads    int        `json:"total_reads"`
+	Versions      int        `json:"versions"`
+	WindowDays    int        `json:"window_days"`
+	ReadsInWindow int        `json:"reads_in_window"`
+	UniqueReaders int        `json:"unique_readers"`
+	LastReadAt    *time.Time `json:"last_read_at,omitempty"`
+}
+
+// GetSecretAccessStats returns read statistics for a secret, enforcing secrets.read on
+// the secret first. windowDays bounds the recent-activity summary (clamped to [1, 365],
+// default 30 when <= 0). Lifetime TotalReads comes from the per-version read counters;
+// the window fields are computed from the access log's "read" entries. No value is read.
+func (c *KeyorixCore) GetSecretAccessStats(ctx context.Context, secretID, actorID uint, windowDays int) (*SecretAccessStats, error) {
+	if secretID == 0 {
+		return nil, fmt.Errorf("secret ID is required")
+	}
+	if _, err := c.EnforceSecretReadPermission(ctx, secretID, actorID); err != nil {
+		return nil, err
+	}
+
+	switch {
+	case windowDays <= 0:
+		windowDays = 30
+	case windowDays > 365:
+		windowDays = 365
+	}
+
+	stats := &SecretAccessStats{SecretID: secretID, WindowDays: windowDays}
+
+	// Lifetime reads — summed from the durable per-version counters.
+	versions, err := c.storage.GetSecretVersions(ctx, secretID)
+	if err != nil {
+		return nil, fmt.Errorf("get versions: %w", err)
+	}
+	stats.Versions = len(versions)
+	for _, v := range versions {
+		stats.TotalReads += v.ReadCount
+	}
+
+	// Recent window — from the access log's "read" entries.
+	since := c.now().AddDate(0, 0, -windowDays)
+	logs, err := c.storage.ListSecretAccessLogs(ctx, secretID, since)
+	if err != nil {
+		return nil, fmt.Errorf("list access logs: %w", err)
+	}
+	readers := map[string]struct{}{}
+	for i := range logs {
+		l := logs[i]
+		if l.Action != "read" {
+			continue
+		}
+		stats.ReadsInWindow++
+		readers[l.AccessedBy] = struct{}{}
+		if stats.LastReadAt == nil || l.AccessTime.After(*stats.LastReadAt) {
+			t := l.AccessTime
+			stats.LastReadAt = &t
+		}
+	}
+	stats.UniqueReaders = len(readers)
+	return stats, nil
+}

--- a/internal/core/secret_access_stats_test.go
+++ b/internal/core/secret_access_stats_test.go
@@ -1,0 +1,78 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestGetSecretAccessStats(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	sqlDB, _ := db.DB()
+	sqlDB.SetMaxOpenConns(1)
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.User{}, &models.SecretAccessLog{}))
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "owner", Email: "o@t.com"}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 2, Username: "mallory", Email: "m@t.com"}).Error)
+
+	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
+	ctx := context.Background()
+	secret, err := c.storage.CreateSecret(ctx, &models.SecretNode{
+		Name: "db", ProjectID: 1, EnvironmentID: 1, Type: "password", OwnerID: 1, IsSecret: true,
+		CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	})
+	require.NoError(t, err)
+
+	// Two versions carry the durable lifetime read counters (3 + 5 = 8).
+	require.NoError(t, db.Create(&models.SecretVersion{SecretNodeID: secret.ID, VersionNumber: 1, ReadCount: 3}).Error)
+	require.NoError(t, db.Create(&models.SecretVersion{SecretNodeID: secret.ID, VersionNumber: 2, ReadCount: 5}).Error)
+
+	now := time.Now()
+	mk := func(by, action string, when time.Time) {
+		require.NoError(t, c.storage.CreateSecretAccessLog(ctx, &models.SecretAccessLog{
+			SecretNodeID: secret.ID, AccessedBy: by, Action: action, AccessTime: when,
+		}))
+	}
+	mk("owner", "read", now.Add(-1*time.Hour))     // in window
+	mk("alice", "read", now.Add(-2*time.Hour))     // in window, different reader
+	mk("owner", "update", now.Add(-1*time.Hour))   // not a read → excluded
+	mk("owner", "read", now.Add(-40*24*time.Hour)) // outside the 30-day window
+
+	t.Run("aggregates lifetime + recent-window read stats", func(t *testing.T) {
+		stats, err := c.GetSecretAccessStats(ctx, secret.ID, 1, 0) // 0 → default 30-day window
+		require.NoError(t, err)
+		assert.Equal(t, 8, stats.TotalReads, "summed from version read counters")
+		assert.Equal(t, 2, stats.Versions)
+		assert.Equal(t, 30, stats.WindowDays)
+		assert.Equal(t, 2, stats.ReadsInWindow, "two reads in window; the update and the 40-day-old read are excluded")
+		assert.Equal(t, 2, stats.UniqueReaders, "owner + alice")
+		require.NotNil(t, stats.LastReadAt)
+		assert.WithinDuration(t, now.Add(-1*time.Hour), *stats.LastReadAt, time.Minute)
+	})
+
+	t.Run("window is clamped (cap 365)", func(t *testing.T) {
+		stats, err := c.GetSecretAccessStats(ctx, secret.ID, 1, 1000)
+		require.NoError(t, err)
+		assert.Equal(t, 365, stats.WindowDays)
+		assert.Equal(t, 3, stats.ReadsInWindow, "365-day window now includes the 40-day-old read")
+	})
+
+	t.Run("a non-reader is denied", func(t *testing.T) {
+		_, err := c.GetSecretAccessStats(ctx, secret.ID, 2, 0)
+		require.Error(t, err)
+	})
+
+	t.Run("a zero secret ID is rejected", func(t *testing.T) {
+		_, err := c.GetSecretAccessStats(ctx, 0, 1, 0)
+		require.Error(t, err)
+	})
+}

--- a/server/http/handlers/secrets_access_stats.go
+++ b/server/http/handlers/secrets_access_stats.go
@@ -1,0 +1,49 @@
+// secrets_access_stats.go — GetSecretAccessStats handler: per-secret read statistics
+// (lifetime total + a recent-window summary), for a quick "is this secret used?" answer.
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/keyorixhq/keyorix/server/middleware"
+)
+
+// GetSecretAccessStats handles GET /api/v1/secrets/{id}/stats?days=N — read statistics
+// for the secret: lifetime total reads + reads / unique readers / last-read over the
+// window (default 30 days, cap 365). Scoped secrets.read (enforced in core); no value.
+func (h *SecretHandler) GetSecretAccessStats(w http.ResponseWriter, r *http.Request) {
+	userCtx := middleware.GetUserFromContext(r.Context())
+	if userCtx == nil {
+		h.sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		h.sendError(w, "BadRequest", "Invalid secret ID", http.StatusBadRequest, nil)
+		return
+	}
+
+	days := 0 // let core default to 30
+	if v := r.URL.Query().Get("days"); v != "" {
+		if n, perr := strconv.Atoi(v); perr == nil {
+			days = n
+		}
+	}
+
+	stats, err := h.coreService.GetSecretAccessStats(r.Context(), uint(id), userCtx.UserID, days)
+	if err != nil {
+		switch {
+		case strings.Contains(err.Error(), "not found"):
+			h.sendError(w, "NotFound", "Secret not found", http.StatusNotFound, nil)
+		case strings.Contains(err.Error(), "permission") || strings.Contains(err.Error(), "not authorized"):
+			h.sendError(w, "Forbidden", "Not authorized to view this secret", http.StatusForbidden, nil)
+		default:
+			h.sendError(w, "InternalError", "Failed to compute access stats", http.StatusInternalServerError, nil)
+		}
+		return
+	}
+	h.sendSuccess(w, stats, "")
+}

--- a/server/http/handlers/secrets_access_stats_test.go
+++ b/server/http/handlers/secrets_access_stats_test.go
@@ -1,0 +1,54 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestGetSecretAccessStatsHandler(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.User{}, &models.SecretAccessLog{}))
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "owner", Email: "o@t.com"}).Error)
+	require.NoError(t, db.Create(&models.SecretNode{
+		ID: 1, Name: "db", ProjectID: 1, EnvironmentID: 1, Type: "password", OwnerID: 1, IsSecret: true,
+		CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	}).Error)
+	require.NoError(t, db.Create(&models.SecretVersion{SecretNodeID: 1, VersionNumber: 1, ReadCount: 4}).Error)
+	require.NoError(t, db.Create(&models.SecretAccessLog{
+		SecretNodeID: 1, AccessedBy: "owner", Action: "read", AccessTime: time.Now().Add(-1 * time.Hour),
+	}).Error)
+
+	h, err := NewSecretHandler(core.NewKeyorixCore(store.NewLocalStorage(db)))
+	require.NoError(t, err)
+
+	t.Run("returns the secret's read statistics", func(t *testing.T) {
+		req := withChiParam(withUserCtx(httptest.NewRequest(http.MethodGet, "/api/v1/secrets/1/stats", nil)), "id", "1")
+		w := httptest.NewRecorder()
+		h.GetSecretAccessStats(w, req)
+
+		require.Equal(t, http.StatusOK, w.Code)
+		body := w.Body.String()
+		assert.Contains(t, body, `"total_reads":4`)
+		assert.Contains(t, body, `"reads_in_window":1`)
+		assert.Contains(t, body, `"unique_readers":1`)
+		assert.Contains(t, body, `"window_days":30`)
+	})
+
+	t.Run("requires a user context", func(t *testing.T) {
+		req := withChiParam(httptest.NewRequest(http.MethodGet, "/api/v1/secrets/1/stats", nil), "id", "1")
+		w := httptest.NewRecorder()
+		h.GetSecretAccessStats(w, req)
+		assert.Equal(t, http.StatusUnauthorized, w.Code)
+	})
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -360,6 +360,8 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.With(customMiddleware.RequireScopedPermission("secrets.read", secretScope)).Get("/{id}/shares", shareHandler.ListSecretShares)
 			r.With(customMiddleware.RequireScopedPermission("secrets.read", secretScope)).Get("/{id}/access", secretHandler.ListAccessors)
 			r.With(customMiddleware.RequireScopedPermission("secrets.read", secretScope)).Get("/{id}/access-log", secretHandler.AccessHistory)
+			// Per-secret read statistics — lifetime total + recent-window summary.
+			r.With(customMiddleware.RequireScopedPermission("secrets.read", secretScope)).Get("/{id}/stats", secretHandler.GetSecretAccessStats)
 			r.With(customMiddleware.RequireScopedPermission("secrets.read", secretScope)).Get("/{id}/audit", secretHandler.AuditTrail)
 			r.With(customMiddleware.RequireScopedPermission("secrets.read", secretScope)).Get("/{id}/tags", secretHandler.GetTags)
 			r.With(customMiddleware.RequireScopedPermission("secrets.write", secretScope)).Put("/{id}/tags", secretHandler.SetTags)


### PR DESCRIPTION
Answering "is this secret actually used, and by whom lately?" meant cross-referencing three places: the deployment-wide usage analytics, the per-user access log, and the composite risk score. This adds a single focused per-secret view.

### What's added
- **`core.GetSecretAccessStats(secretID, actor, windowDays)`** — enforces `secrets.read`, returns `{total_reads, versions, window_days, reads_in_window, unique_readers, last_read_at}`. `total_reads` is the **durable lifetime** counter (summed across version read counts, survives access-log retention); the window fields come from the access log's `read` entries. `windowDays` clamps to `[1,365]`, default 30. Never reads the value.
- **`GET /api/v1/secrets/{id}/stats?days=N`** — scoped `secrets.read`, beside `/{id}/access-log` and `/{id}/risk`.

### Tests
Core (lifetime + window aggregation, `update`/old-read excluded, window clamp, non-reader denied, zero-ID) + handler (stats body, 401). gofmt/vet/golangci-lint 0/gosec 0; router builds with no chi conflict.

> The local-only `TestEveryMutatingRouteDeniesReadOnly` `/sw.js` + `/evidence/verify` failures are pre-existing and unrelated (this route is a GET); green in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)