### PR TITLE
fix(cli): route storage through the factory, not direct sqlite.Open (ADR-049)

### DIFF
--- a/docs/adr-049-cli-storage-via-factory.md
+++ b/docs/adr-049-cli-storage-via-factory.md
@@ -1,0 +1,112 @@
+# ADR-049: CLI commands must obtain storage via the factory
+
+## Status
+
+Accepted. (ADR-048 was assigned to the CGO-free SQLite driver decision; this
+decision took the next free number.)
+
+## Context
+
+Keyorix has a single storage seam: `storage.NewStorageFactory().CreateStorage(cfg)`
+switches on `cfg.Storage.Type` (`remote` / `postgres`(`postgresql`) / `local`(default
+SQLite)) and returns a `storage.Storage` over the right backend, applying connection-pool
+settings and the full migration set. The server, and the newer CLI entry points
+(`internal/cli/modes.go`, `internal/cli/common/common.go` via `InitializeCoreService`),
+all go through this factory, so they honor the operator's configured backend.
+
+A set of older CLI subcommands do not. They open the database directly with
+`gorm.Open(sqlite.Open(cfg.Storage.Database.Path), …)`, hardwiring SQLite and ignoring
+`cfg.Storage.Type` entirely:
+
+    internal/cli/encryption/auth_encryption_stats.go   (openDatabase — pure SQLite, ignores Type)
+    internal/cli/rbac/{assign_role,remove_role,check_permission,
+                       list_permissions,list_roles,list_user_roles}.go
+    internal/cli/secret/{update,delete,versions}.go
+    internal/cli/share/{create,list,update,revoke,shared_secrets,group_shares}.go
+
+(`internal/cli/encryption/encryption.go` is a near-miss: its `openDBForRotation` already
+switches on `cfg.Storage.Type` and handles Postgres, but it still imports the SQLite
+driver directly and re-implements the factory's connection/pool logic.)
+
+This is a **latent correctness bug**. Against our production-default Postgres backend,
+every one of these subcommands silently opens (or *creates*) a local `secrets.db` SQLite
+file and operates on an empty, wrong database instead of talking to Postgres. The command
+appears to succeed — it just touched the wrong store. For an air-gapped operator who
+typo's `storage.type`, the failure mode is equally quiet.
+
+The config-resolution path is *not* the problem: `config.LoadConfig()` is literally
+`Load("")`, the same call `InitializeCoreService` uses, and both honor
+`KEYORIX_CONFIG_PATH`. Backend selection is driven only by the `storage.type` YAML field
+(there is no env override for the backend). So the only divergence is the storage-open
+step — these commands bypass the factory.
+
+## Decision
+
+**CLI commands must obtain their database access through the storage package. Direct
+driver opens (`gorm.Open(sqlite.Open(...))`, `postgres.Open(...)`) in CLI command files
+are prohibited.** Backend selection belongs to one place — the factory — keyed off
+`cfg.Storage.Type`.
+
+There are two sanctioned entry points, both of which honor `cfg.Storage.Type`:
+
+- **`common.InitializeStorage()` → `storage.Storage` (the normal case).** Loads config via
+  the same `config.Load("")` path as the rest of the CLI and returns
+  `NewStorageFactory().CreateStorage(cfg)`. Commands that need the core service wrap it
+  with `core.NewKeyorixCore(st)`; commands that talk to storage directly (e.g. RBAC
+  `ListRoles`) use the returned `storage.Storage`. This replaces the per-command
+  `gorm.Open` + ad-hoc partial `AutoMigrate` + `store.NewLocalStorage` dance — the factory
+  already runs the full, idempotent migration set.
+
+- **`storage.OpenGormDB(cfg)` → `*gorm.DB` (the rare raw-DB case).** A small helper in the
+  `internal/storage` package (the factory's own package — *not* a CLI file) that opens a
+  `*gorm.DB` for the configured local backend, switching on `cfg.Storage.Type` and applying
+  the same pool settings as the factory. It exists for the two encryption admin commands
+  that legitimately need a raw `*gorm.DB`: the DEK rotation sweep (`RotateDEKWithSweep`
+  owns its own transaction — ADR-010) and the auth-encryption statistics counters
+  (`db.Model(...).Count(...)`). These genuinely cannot use the `storage.Storage` abstraction,
+  but they still must not hardwire SQLite — so the driver selection moves *into the factory
+  package* and out of the CLI command files. Remote storage has no local `*gorm.DB`; these
+  host-local admin commands already require a non-remote backend.
+
+The crucial property either way: **the SQLite and Postgres driver imports live only in the
+`internal/storage` package** (the factory and its sibling `OpenGormDB` helper). No CLI
+command file imports a GORM driver or decides which backend to open.
+
+## Scope / non-goals
+
+- **SQLite stays.** It remains a fully supported embedded / air-gapped / test backend. This
+  ADR removes the *bypass*, not the backend.
+- **The factory is unchanged.** `internal/storage/factory.go` keeps all three backends and
+  its default-backend behavior. `OpenGormDB` is an additive sibling; it does not alter
+  `CreateStorage`.
+- **No new config knob.** Backend selection stays driven solely by `storage.type`. No
+  `KEYORIX_STORAGE_TYPE` or Viper `AutomaticEnv` is introduced.
+- The factory's `default`-case treatment of *unknown* `storage.type` values (currently
+  folded into SQLite) is a separate footgun tracked as its own follow-up ADR — explicitly
+  out of scope here.
+
+## Alternatives considered
+
+- **Add a `DB()` accessor to `storage.LocalStorage`** so the encryption commands can reach
+  the raw `*gorm.DB` through the abstraction. Rejected: it leaks the GORM handle through an
+  interface that exists precisely to hide it, and would also need a meaningless
+  implementation on `RemoteStorage`. A factory-package `OpenGormDB` keeps the raw handle a
+  storage-layer concern without widening the `Storage` interface — consistent with the
+  existing decision (ADR-010 addendum) to keep raw-DB rotation a private helper rather than
+  a storage accessor.
+- **Leave the encryption commands as-is** because `encryption.go` already handles Postgres.
+  Rejected: `auth_encryption_stats.go` is still pure-SQLite, and both files duplicate the
+  factory's connection logic and import the driver directly — exactly the bypass this ADR
+  closes. Centralizing the open keeps a single source of truth for how Keyorix connects.
+
+## Consequences
+
+- Every CLI subcommand honors `cfg.Storage.Type`: a Postgres-backed deployment is reachable
+  from the CLI, and no command silently creates a stray `secrets.db`.
+- Driver selection and pool configuration have one home (`internal/storage`). Adding or
+  changing a backend is a factory-package change; CLI commands are unaffected.
+- Per-command partial `AutoMigrate` calls disappear — commands inherit the factory's
+  complete, idempotent migration set, removing a class of "table not found" drift between
+  CLI and server.
+- Tests continue to construct SQLite in-memory storage directly; that is intended and
+  unaffected (the prohibition is about production command paths, not test setup).

--- a/internal/cli/common/common.go
+++ b/internal/cli/common/common.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/keyorixhq/keyorix/internal/config"
 	"github.com/keyorixhq/keyorix/internal/core"
+	corestorage "github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/delivery"
 	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/storage"
@@ -57,6 +58,27 @@ func InitializeCoreService() (*core.KeyorixCore, error) {
 		svc.SetCredentialDelivery(nil, cd.BaseURL)
 	}
 	return svc, nil
+}
+
+// InitializeStorage builds a storage.Storage from the resolved configuration via
+// the storage factory, so the backend is selected by cfg.Storage.Type
+// (local/postgres/remote) instead of being hardwired. CLI commands that need
+// storage — directly, or wrapped in a core service via core.NewKeyorixCore — must
+// use this instead of opening the database with a GORM driver themselves
+// (ADR-049). Config is resolved through the same config.Load("") path
+// (KEYORIX_CONFIG_PATH-based) that the rest of the CLI and the server use, so a
+// command and the server read identical configuration.
+func InitializeStorage() (corestorage.Storage, error) {
+	cfg, err := config.Load("")
+	if err != nil {
+		return nil, fmt.Errorf("failed to load config: %w", err)
+	}
+
+	st, err := storage.NewStorageFactory().CreateStorage(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create storage: %w", err)
+	}
+	return st, nil
 }
 
 // PrintProvisionResult prints how a setup link was delivered (ADR-028). In out-of-band

--- a/internal/cli/encryption/auth_encryption_stats.go
+++ b/internal/cli/encryption/auth_encryption_stats.go
@@ -8,13 +8,16 @@ import (
 	"fmt"
 
 	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/storage"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
-	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 )
 
 func openDatabase(cfg *config.Config) (*gorm.DB, error) {
-	return gorm.Open(sqlite.Open(cfg.Storage.Database.Path), &gorm.Config{})
+	// Honor cfg.Storage.Type via the storage package instead of hardwiring SQLite
+	// (ADR-049). OpenGormDB does not migrate — these auth-encryption commands run
+	// against an already-initialized database.
+	return storage.OpenGormDB(cfg)
 }
 
 func showAuthEncryptionStats(db *gorm.DB, encryptionEnabled bool) error {

--- a/internal/cli/encryption/encryption.go
+++ b/internal/cli/encryption/encryption.go
@@ -3,13 +3,11 @@ package encryption
 import (
 	"fmt"
 	"os"
-	"time"
 
 	"github.com/keyorixhq/keyorix/internal/config"
 	"github.com/keyorixhq/keyorix/internal/encryption"
+	"github.com/keyorixhq/keyorix/internal/storage"
 	"github.com/spf13/cobra"
-	"gorm.io/driver/postgres"
-	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 )
 
@@ -199,7 +197,12 @@ func rotateWithConfig(cfg *config.Config, confirm bool) error {
 	}
 	defer service.Shutdown()
 
-	db, err := openDBForRotation(cfg)
+	// RotateDEKWithSweep needs a raw *gorm.DB so it can own the re-encryption
+	// transaction (ADR-010), which the storage.Storage abstraction can't provide.
+	// OpenGormDB honors cfg.Storage.Type and keeps the driver selection inside the
+	// storage package rather than this CLI file (ADR-049). The remote-storage guard
+	// above means this only reaches the local sqlite/postgres branches.
+	db, err := storage.OpenGormDB(cfg)
 	if err != nil {
 		return fmt.Errorf("failed to open database for rotation: %w", err)
 	}
@@ -213,53 +216,6 @@ func rotateWithConfig(cfg *config.Config, confirm bool) error {
 	fmt.Println("✅ DEK rotated successfully")
 	fmt.Printf("📋 New key version: %s\n", service.GetKeyVersion())
 	return nil
-}
-
-// openDBForRotation opens a *gorm.DB connection that mirrors the connection
-// logic in internal/storage/factory.go. We deliberately do not go through the
-// storage abstraction — RotateDEKWithSweep needs a raw *gorm.DB so it can own
-// the transaction. See the ADR-010 addendum for why this is a private CLI
-// helper rather than an accessor on storage.LocalStorage.
-func openDBForRotation(cfg *config.Config) (*gorm.DB, error) {
-	switch cfg.Storage.Type {
-	case "postgres", "postgresql":
-		dsn := config.BuildPostgresDSN(&cfg.Storage.Database)
-		if dsn == "" {
-			return nil, fmt.Errorf("postgres storage requires a DSN or host/name/user fields")
-		}
-		db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
-		if err != nil {
-			return nil, fmt.Errorf("failed to connect to postgres: %w", err)
-		}
-		return applyDBPool(db, &cfg.Storage.Database)
-	default:
-		dbPath := cfg.Storage.Database.Path
-		if dbPath == "" {
-			dbPath = "./secrets.db"
-		}
-		db, err := gorm.Open(sqlite.Open(dbPath), &gorm.Config{})
-		if err != nil {
-			return nil, fmt.Errorf("failed to connect to database: %w", err)
-		}
-		return applyDBPool(db, &cfg.Storage.Database)
-	}
-}
-
-func applyDBPool(db *gorm.DB, dbCfg *config.DatabaseConfig) (*gorm.DB, error) {
-	sqlDB, err := db.DB()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get underlying sql.DB: %w", err)
-	}
-	if dbCfg.MaxOpenConns > 0 {
-		sqlDB.SetMaxOpenConns(dbCfg.MaxOpenConns)
-	}
-	if dbCfg.MaxIdleConns > 0 {
-		sqlDB.SetMaxIdleConns(dbCfg.MaxIdleConns)
-	}
-	if dbCfg.ConnMaxLifetimeMinutes > 0 {
-		sqlDB.SetConnMaxLifetime(time.Duration(dbCfg.ConnMaxLifetimeMinutes) * time.Minute)
-	}
-	return db, nil
 }
 
 func closeDB(db *gorm.DB) {

--- a/internal/cli/rbac/assign_role.go
+++ b/internal/cli/rbac/assign_role.go
@@ -5,12 +5,8 @@ import (
 	"fmt"
 
 	"github.com/keyorixhq/keyorix/internal/cli/common"
-	"github.com/keyorixhq/keyorix/internal/config"
 	"github.com/keyorixhq/keyorix/internal/core"
-	"github.com/keyorixhq/keyorix/internal/storage/store"
 	"github.com/spf13/cobra"
-	"gorm.io/driver/sqlite"
-	"gorm.io/gorm"
 )
 
 var assignRoleCmd = &cobra.Command{
@@ -39,23 +35,14 @@ func runAssignRole(cmd *cobra.Command, args []string) error {
 		return runAssignRoleRemote(ctx, rc, userEmail, roleName)
 	}
 
-	// Load configuration
-	cfg, err := config.LoadConfig()
+	// Obtain storage via the factory so the backend honors cfg.Storage.Type (ADR-049).
+	st, err := common.InitializeStorage()
 	if err != nil {
-		return fmt.Errorf("failed to load config: %w", err)
+		return err
 	}
-
-	// Initialize database
-	db, err := gorm.Open(sqlite.Open(cfg.Storage.Database.Path), &gorm.Config{})
-	if err != nil {
-		return fmt.Errorf("failed to connect to database: %w", err)
-	}
-
-	// Create storage layer
-	storage := store.NewLocalStorage(db)
 
 	// Create core service
-	coreService := core.NewKeyorixCore(storage)
+	coreService := core.NewKeyorixCore(st)
 
 	// Use core service to assign role
 	err = coreService.AssignRoleToUser(ctx, userEmail, roleName)

--- a/internal/cli/rbac/check_permission.go
+++ b/internal/cli/rbac/check_permission.go
@@ -6,13 +6,8 @@ import (
 	"strings"
 
 	"github.com/keyorixhq/keyorix/internal/cli/common"
-	"github.com/keyorixhq/keyorix/internal/config"
 	"github.com/keyorixhq/keyorix/internal/core"
-	"github.com/keyorixhq/keyorix/internal/storage/models"
-	"github.com/keyorixhq/keyorix/internal/storage/store"
 	"github.com/spf13/cobra"
-	"gorm.io/driver/sqlite"
-	"gorm.io/gorm"
 )
 
 var checkPermissionCmd = &cobra.Command{
@@ -41,26 +36,14 @@ func runCheckPermission(cmd *cobra.Command, args []string) error {
 		return runCheckPermissionRemote(ctx, rc, checkUserEmail, checkPermissionName)
 	}
 
-	// Load configuration
-	cfg, err := config.LoadConfig()
+	// Obtain storage via the factory so the backend honors cfg.Storage.Type (ADR-049).
+	st, err := common.InitializeStorage()
 	if err != nil {
-		return fmt.Errorf("failed to load config: %w", err)
+		return err
 	}
 
-	// Connect to database
-	db, err := gorm.Open(sqlite.Open(cfg.Storage.Database.Path), &gorm.Config{})
-	if err != nil {
-		return fmt.Errorf("failed to connect to database: %w", err)
-	}
-
-	// Auto-migrate models
-	if err := db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.User{}, &models.Role{}); err != nil {
-		return fmt.Errorf("failed to migrate database: %w", err)
-	}
-
-	// Initialize storage and core service
-	storage := store.NewLocalStorage(db)
-	service := core.NewKeyorixCore(storage)
+	// Initialize core service
+	service := core.NewKeyorixCore(st)
 
 	// Permissions are named "resource.action" (e.g. secrets.read, system.admin).
 	resource, action, perr := splitPermissionName(checkPermissionName)

--- a/internal/cli/rbac/list_permissions.go
+++ b/internal/cli/rbac/list_permissions.go
@@ -5,13 +5,8 @@ import (
 	"fmt"
 
 	"github.com/keyorixhq/keyorix/internal/cli/common"
-	"github.com/keyorixhq/keyorix/internal/config"
 	"github.com/keyorixhq/keyorix/internal/core"
-	"github.com/keyorixhq/keyorix/internal/storage/models"
-	"github.com/keyorixhq/keyorix/internal/storage/store"
 	"github.com/spf13/cobra"
-	"gorm.io/driver/sqlite"
-	"gorm.io/gorm"
 )
 
 var listPermissionsCmd = &cobra.Command{
@@ -34,26 +29,14 @@ func runListPermissions(cmd *cobra.Command, args []string) error {
 		return runListPermissionsRemote(ctx, rc, listPermissionsUserEmail)
 	}
 
-	// Load configuration
-	cfg, err := config.LoadConfig()
+	// Obtain storage via the factory so the backend honors cfg.Storage.Type (ADR-049).
+	st, err := common.InitializeStorage()
 	if err != nil {
-		return fmt.Errorf("failed to load config: %w", err)
+		return err
 	}
 
-	// Connect to database
-	db, err := gorm.Open(sqlite.Open(cfg.Storage.Database.Path), &gorm.Config{})
-	if err != nil {
-		return fmt.Errorf("failed to connect to database: %w", err)
-	}
-
-	// Auto-migrate models
-	if err := db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.User{}, &models.Role{}); err != nil {
-		return fmt.Errorf("failed to migrate database: %w", err)
-	}
-
-	// Initialize storage and core service
-	storage := store.NewLocalStorage(db)
-	service := core.NewKeyorixCore(storage)
+	// Initialize core service
+	service := core.NewKeyorixCore(st)
 
 	permissions, err := service.ListUserPermissionsByEmail(ctx, listPermissionsUserEmail)
 	if err != nil {

--- a/internal/cli/rbac/list_roles.go
+++ b/internal/cli/rbac/list_roles.go
@@ -5,12 +5,7 @@ import (
 	"fmt"
 
 	"github.com/keyorixhq/keyorix/internal/cli/common"
-	"github.com/keyorixhq/keyorix/internal/config"
-	"github.com/keyorixhq/keyorix/internal/storage/models"
-	"github.com/keyorixhq/keyorix/internal/storage/store"
 	"github.com/spf13/cobra"
-	"gorm.io/driver/sqlite"
-	"gorm.io/gorm"
 )
 
 var listRolesCmd = &cobra.Command{
@@ -26,29 +21,15 @@ func runListRoles(cmd *cobra.Command, args []string) error {
 		return runListRolesRemote(ctx, rc)
 	}
 
-	// Load configuration
-	cfg, err := config.LoadConfig()
+	// Obtain storage via the factory so the backend honors cfg.Storage.Type (ADR-049).
+	st, err := common.InitializeStorage()
 	if err != nil {
-		return fmt.Errorf("failed to load config: %w", err)
+		return err
 	}
-
-	// Connect to database
-	db, err := gorm.Open(sqlite.Open(cfg.Storage.Database.Path), &gorm.Config{})
-	if err != nil {
-		return fmt.Errorf("failed to connect to database: %w", err)
-	}
-
-	// Auto-migrate models
-	if err := db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.User{}, &models.Role{}); err != nil {
-		return fmt.Errorf("failed to migrate database: %w", err)
-	}
-
-	// Initialize storage
-	storage := store.NewLocalStorage(db)
 
 	// TODO: Implement ListRoles in core service
 	// For now, use storage directly
-	roles, err := storage.ListRoles(ctx)
+	roles, err := st.ListRoles(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to list roles: %w", err)
 	}

--- a/internal/cli/rbac/list_user_roles.go
+++ b/internal/cli/rbac/list_user_roles.go
@@ -5,13 +5,8 @@ import (
 	"fmt"
 
 	"github.com/keyorixhq/keyorix/internal/cli/common"
-	"github.com/keyorixhq/keyorix/internal/config"
 	"github.com/keyorixhq/keyorix/internal/core"
-	"github.com/keyorixhq/keyorix/internal/storage/models"
-	"github.com/keyorixhq/keyorix/internal/storage/store"
 	"github.com/spf13/cobra"
-	"gorm.io/driver/sqlite"
-	"gorm.io/gorm"
 )
 
 var listUserRolesCmd = &cobra.Command{
@@ -34,26 +29,14 @@ func runListUserRoles(cmd *cobra.Command, args []string) error {
 		return runListUserRolesRemote(ctx, rc, listUserEmail)
 	}
 
-	// Load configuration
-	cfg, err := config.LoadConfig()
+	// Obtain storage via the factory so the backend honors cfg.Storage.Type (ADR-049).
+	st, err := common.InitializeStorage()
 	if err != nil {
-		return fmt.Errorf("failed to load config: %w", err)
+		return err
 	}
 
-	// Connect to database
-	db, err := gorm.Open(sqlite.Open(cfg.Storage.Database.Path), &gorm.Config{})
-	if err != nil {
-		return fmt.Errorf("failed to connect to database: %w", err)
-	}
-
-	// Auto-migrate models
-	if err := db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.User{}, &models.Role{}); err != nil {
-		return fmt.Errorf("failed to migrate database: %w", err)
-	}
-
-	// Initialize storage and core service
-	storage := store.NewLocalStorage(db)
-	service := core.NewKeyorixCore(storage)
+	// Initialize core service
+	service := core.NewKeyorixCore(st)
 
 	roles, err := service.ListUserRolesByEmail(ctx, listUserEmail)
 	if err != nil {

--- a/internal/cli/rbac/remove_role.go
+++ b/internal/cli/rbac/remove_role.go
@@ -5,12 +5,8 @@ import (
 	"fmt"
 
 	"github.com/keyorixhq/keyorix/internal/cli/common"
-	"github.com/keyorixhq/keyorix/internal/config"
 	"github.com/keyorixhq/keyorix/internal/core"
-	"github.com/keyorixhq/keyorix/internal/storage/store"
 	"github.com/spf13/cobra"
-	"gorm.io/driver/sqlite"
-	"gorm.io/gorm"
 )
 
 var removeRoleCmd = &cobra.Command{
@@ -39,23 +35,14 @@ func runRemoveRole(cmd *cobra.Command, args []string) error {
 		return runRemoveRoleRemote(ctx, rc, removeUserEmail, removeRoleName)
 	}
 
-	// Load configuration
-	cfg, err := config.LoadConfig()
+	// Obtain storage via the factory so the backend honors cfg.Storage.Type (ADR-049).
+	st, err := common.InitializeStorage()
 	if err != nil {
-		return fmt.Errorf("failed to load config: %w", err)
+		return err
 	}
-
-	// Initialize database
-	db, err := gorm.Open(sqlite.Open(cfg.Storage.Database.Path), &gorm.Config{})
-	if err != nil {
-		return fmt.Errorf("failed to connect to database: %w", err)
-	}
-
-	// Create storage layer
-	storage := store.NewLocalStorage(db)
 
 	// Create core service
-	coreService := core.NewKeyorixCore(storage)
+	coreService := core.NewKeyorixCore(st)
 
 	// Use core service to remove role
 	err = coreService.RemoveRoleFromUser(ctx, removeUserEmail, removeRoleName)

--- a/internal/cli/secret/delete.go
+++ b/internal/cli/secret/delete.go
@@ -7,13 +7,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/cli/common"
 	"github.com/keyorixhq/keyorix/internal/core"
-	"github.com/keyorixhq/keyorix/internal/storage/models"
-	"github.com/keyorixhq/keyorix/internal/storage/store"
 	"github.com/spf13/cobra"
-	"gorm.io/driver/sqlite"
-	"gorm.io/gorm"
 )
 
 var (
@@ -49,25 +45,11 @@ func runDelete(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("either --id or --name is required")
 	}
 
-	// Load configuration
-	cfg, err := config.LoadConfig()
+	// Obtain storage via the factory so the backend honors cfg.Storage.Type (ADR-049).
+	storageImpl, err := common.InitializeStorage()
 	if err != nil {
-		return fmt.Errorf("failed to load config: %w", err)
+		return err
 	}
-
-	// Connect to database
-	db, err := gorm.Open(sqlite.Open(cfg.Storage.Database.Path), &gorm.Config{})
-	if err != nil {
-		return fmt.Errorf("failed to connect to database: %w", err)
-	}
-
-	// Auto-migrate models (ensure tables exist)
-	if err := db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}); err != nil {
-		return fmt.Errorf("failed to migrate database: %w", err)
-	}
-
-	// Initialize storage and core service
-	storageImpl := store.NewLocalStorage(db)
 	service := core.NewKeyorixCore(storageImpl)
 
 	// Create context

--- a/internal/cli/secret/update.go
+++ b/internal/cli/secret/update.go
@@ -13,14 +13,10 @@ import (
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/cli/common"
-	"github.com/keyorixhq/keyorix/internal/config"
 	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
-	"github.com/keyorixhq/keyorix/internal/storage/store"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
-	"gorm.io/driver/sqlite"
-	"gorm.io/gorm"
 )
 
 var (
@@ -67,24 +63,12 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 		return runUpdateRemote(rc)
 	}
 
-	cfg, err := config.LoadConfig()
+	// Obtain storage via the factory so the backend honors cfg.Storage.Type (ADR-049).
+	st, err := common.InitializeStorage()
 	if err != nil {
-		return fmt.Errorf("failed to load config: %w", err)
+		return err
 	}
-
-	db, err := gorm.Open(sqlite.Open(cfg.Storage.Database.Path), &gorm.Config{})
-	if err != nil {
-		return fmt.Errorf("failed to connect to database: %w", err)
-	}
-
-	// Auto-migrate models (ensure tables exist)
-	if err := db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}); err != nil {
-		return fmt.Errorf("failed to migrate database: %w", err)
-	}
-
-	// Initialize storage and core service
-	storageImpl := store.NewLocalStorage(db)
-	service := core.NewKeyorixCore(storageImpl)
+	service := core.NewKeyorixCore(st)
 
 	// Create context
 	ctx := context.Background()

--- a/internal/cli/secret/versions.go
+++ b/internal/cli/secret/versions.go
@@ -6,13 +6,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/cli/common"
 	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
-	"github.com/keyorixhq/keyorix/internal/storage/store"
 	"github.com/spf13/cobra"
-	"gorm.io/driver/sqlite"
-	"gorm.io/gorm"
 )
 
 var (
@@ -41,26 +38,12 @@ func runVersions(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("secret ID is required (use --id)")
 	}
 
-	// Load configuration
-	cfg, err := config.LoadConfig()
+	// Obtain storage via the factory so the backend honors cfg.Storage.Type (ADR-049).
+	st, err := common.InitializeStorage()
 	if err != nil {
-		return fmt.Errorf("failed to load config: %w", err)
+		return err
 	}
-
-	// Connect to database
-	db, err := gorm.Open(sqlite.Open(cfg.Storage.Database.Path), &gorm.Config{})
-	if err != nil {
-		return fmt.Errorf("failed to connect to database: %w", err)
-	}
-
-	// Auto-migrate models (ensure tables exist)
-	if err := db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}); err != nil {
-		return fmt.Errorf("failed to migrate database: %w", err)
-	}
-
-	// Initialize storage and core service
-	storageImpl := store.NewLocalStorage(db)
-	service := core.NewKeyorixCore(storageImpl)
+	service := core.NewKeyorixCore(st)
 
 	// Create context
 	ctx := context.Background()

--- a/internal/cli/share/create.go
+++ b/internal/cli/share/create.go
@@ -4,13 +4,10 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/cli/common"
 	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
-	"github.com/keyorixhq/keyorix/internal/storage/store"
 	"github.com/spf13/cobra"
-	"gorm.io/driver/sqlite"
-	"gorm.io/gorm"
 )
 
 var (
@@ -42,25 +39,12 @@ func runCreate(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("invalid permission: %s (must be 'read' or 'write')", createPermission)
 	}
 
-	// Load config and connect to database
-	cfg, err := config.Load("keyorix.yaml")
+	// Obtain storage via the factory so the backend honors cfg.Storage.Type (ADR-049).
+	st, err := common.InitializeStorage()
 	if err != nil {
-		return fmt.Errorf("failed to load config: %w", err)
+		return err
 	}
-
-	db, err := gorm.Open(sqlite.Open(cfg.Storage.Database.Path), &gorm.Config{})
-	if err != nil {
-		return fmt.Errorf("failed to connect to database: %w", err)
-	}
-
-	// Auto-migrate models (ensure tables exist)
-	if err := db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.ShareRecord{}, &models.Group{}, &models.UserGroup{}); err != nil {
-		return fmt.Errorf("failed to migrate database: %w", err)
-	}
-
-	// Initialize storage and service
-	storage := store.NewLocalStorage(db)
-	service := core.NewKeyorixCore(storage)
+	service := core.NewKeyorixCore(st)
 
 	// Create context
 	ctx := context.Background()

--- a/internal/cli/share/group_shares.go
+++ b/internal/cli/share/group_shares.go
@@ -6,13 +6,9 @@ import (
 	"os"
 	"text/tabwriter"
 
-	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/cli/common"
 	"github.com/keyorixhq/keyorix/internal/core"
-	"github.com/keyorixhq/keyorix/internal/storage/models"
-	"github.com/keyorixhq/keyorix/internal/storage/store"
 	"github.com/spf13/cobra"
-	"gorm.io/driver/sqlite"
-	"gorm.io/gorm"
 )
 
 var (
@@ -34,25 +30,12 @@ func init() {
 }
 
 func runGroupShares(cmd *cobra.Command, args []string) error {
-	// Load config and connect to database
-	cfg, err := config.Load("keyorix.yaml")
+	// Obtain storage via the factory so the backend honors cfg.Storage.Type (ADR-049).
+	st, err := common.InitializeStorage()
 	if err != nil {
-		return fmt.Errorf("failed to load config: %w", err)
+		return err
 	}
-
-	db, err := gorm.Open(sqlite.Open(cfg.Storage.Database.Path), &gorm.Config{})
-	if err != nil {
-		return fmt.Errorf("failed to connect to database: %w", err)
-	}
-
-	// Auto-migrate models (ensure tables exist)
-	if err := db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.ShareRecord{}, &models.Group{}, &models.UserGroup{}); err != nil {
-		return fmt.Errorf("failed to migrate database: %w", err)
-	}
-
-	// Initialize storage and service
-	storage := store.NewLocalStorage(db)
-	service := core.NewKeyorixCore(storage)
+	service := core.NewKeyorixCore(st)
 
 	// Call service
 	ctx := context.Background()

--- a/internal/cli/share/list.go
+++ b/internal/cli/share/list.go
@@ -7,13 +7,8 @@ import (
 	"text/tabwriter"
 
 	"github.com/keyorixhq/keyorix/internal/cli/common"
-	"github.com/keyorixhq/keyorix/internal/config"
 	"github.com/keyorixhq/keyorix/internal/core"
-	"github.com/keyorixhq/keyorix/internal/storage/models"
-	"github.com/keyorixhq/keyorix/internal/storage/store"
 	"github.com/spf13/cobra"
-	"gorm.io/driver/sqlite"
-	"gorm.io/gorm"
 )
 
 var (
@@ -36,25 +31,12 @@ func runList(cmd *cobra.Command, args []string) error {
 		return runListRemote(rc, listSecretID)
 	}
 
-	// Load config and connect to database
-	cfg, err := config.Load("keyorix.yaml")
+	// Obtain storage via the factory so the backend honors cfg.Storage.Type (ADR-049).
+	st, err := common.InitializeStorage()
 	if err != nil {
-		return fmt.Errorf("failed to load config: %w", err)
+		return err
 	}
-
-	db, err := gorm.Open(sqlite.Open(cfg.Storage.Database.Path), &gorm.Config{})
-	if err != nil {
-		return fmt.Errorf("failed to connect to database: %w", err)
-	}
-
-	// Auto-migrate models (ensure tables exist)
-	if err := db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.ShareRecord{}); err != nil {
-		return fmt.Errorf("failed to migrate database: %w", err)
-	}
-
-	// Initialize storage and service
-	storage := store.NewLocalStorage(db)
-	service := core.NewKeyorixCore(storage)
+	service := core.NewKeyorixCore(st)
 
 	// Call service
 	ctx := context.Background()

--- a/internal/cli/share/revoke.go
+++ b/internal/cli/share/revoke.go
@@ -4,13 +4,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/cli/common"
 	"github.com/keyorixhq/keyorix/internal/core"
-	"github.com/keyorixhq/keyorix/internal/storage/models"
-	"github.com/keyorixhq/keyorix/internal/storage/store"
 	"github.com/spf13/cobra"
-	"gorm.io/driver/sqlite"
-	"gorm.io/gorm"
 )
 
 var (
@@ -29,25 +25,12 @@ func init() {
 }
 
 func runRevoke(cmd *cobra.Command, args []string) error {
-	// Load config and connect to database
-	cfg, err := config.Load("keyorix.yaml")
+	// Obtain storage via the factory so the backend honors cfg.Storage.Type (ADR-049).
+	st, err := common.InitializeStorage()
 	if err != nil {
-		return fmt.Errorf("failed to load config: %w", err)
+		return err
 	}
-
-	db, err := gorm.Open(sqlite.Open(cfg.Storage.Database.Path), &gorm.Config{})
-	if err != nil {
-		return fmt.Errorf("failed to connect to database: %w", err)
-	}
-
-	// Auto-migrate models (ensure tables exist)
-	if err := db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.ShareRecord{}); err != nil {
-		return fmt.Errorf("failed to migrate database: %w", err)
-	}
-
-	// Initialize storage and service
-	storage := store.NewLocalStorage(db)
-	service := core.NewKeyorixCore(storage)
+	service := core.NewKeyorixCore(st)
 
 	// Call service
 	ctx := context.Background()

--- a/internal/cli/share/shared_secrets.go
+++ b/internal/cli/share/shared_secrets.go
@@ -7,13 +7,8 @@ import (
 	"text/tabwriter"
 
 	"github.com/keyorixhq/keyorix/internal/cli/common"
-	"github.com/keyorixhq/keyorix/internal/config"
 	"github.com/keyorixhq/keyorix/internal/core"
-	"github.com/keyorixhq/keyorix/internal/storage/models"
-	"github.com/keyorixhq/keyorix/internal/storage/store"
 	"github.com/spf13/cobra"
-	"gorm.io/driver/sqlite"
-	"gorm.io/gorm"
 )
 
 var (
@@ -39,25 +34,12 @@ func runSharedSecrets(cmd *cobra.Command, args []string) error {
 		return runSharedSecretsRemote(rc)
 	}
 
-	// Load config and connect to database
-	cfg, err := config.Load("keyorix.yaml")
+	// Obtain storage via the factory so the backend honors cfg.Storage.Type (ADR-049).
+	st, err := common.InitializeStorage()
 	if err != nil {
-		return fmt.Errorf("failed to load config: %w", err)
+		return err
 	}
-
-	db, err := gorm.Open(sqlite.Open(cfg.Storage.Database.Path), &gorm.Config{})
-	if err != nil {
-		return fmt.Errorf("failed to connect to database: %w", err)
-	}
-
-	// Auto-migrate models (ensure tables exist)
-	if err := db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.ShareRecord{}); err != nil {
-		return fmt.Errorf("failed to migrate database: %w", err)
-	}
-
-	// Initialize storage and service
-	storage := store.NewLocalStorage(db)
-	service := core.NewKeyorixCore(storage)
+	service := core.NewKeyorixCore(st)
 
 	// Call service
 	ctx := context.Background()

--- a/internal/cli/share/update.go
+++ b/internal/cli/share/update.go
@@ -4,13 +4,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/cli/common"
 	"github.com/keyorixhq/keyorix/internal/core"
-	"github.com/keyorixhq/keyorix/internal/storage/models"
-	"github.com/keyorixhq/keyorix/internal/storage/store"
 	"github.com/spf13/cobra"
-	"gorm.io/driver/sqlite"
-	"gorm.io/gorm"
 )
 
 var (
@@ -38,25 +34,12 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("invalid permission: %s (must be 'read' or 'write')", updatePermission)
 	}
 
-	// Load config and connect to database
-	cfg, err := config.Load("keyorix.yaml")
+	// Obtain storage via the factory so the backend honors cfg.Storage.Type (ADR-049).
+	st, err := common.InitializeStorage()
 	if err != nil {
-		return fmt.Errorf("failed to load config: %w", err)
+		return err
 	}
-
-	db, err := gorm.Open(sqlite.Open(cfg.Storage.Database.Path), &gorm.Config{})
-	if err != nil {
-		return fmt.Errorf("failed to connect to database: %w", err)
-	}
-
-	// Auto-migrate models (ensure tables exist)
-	if err := db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.ShareRecord{}); err != nil {
-		return fmt.Errorf("failed to migrate database: %w", err)
-	}
-
-	// Initialize storage and service
-	storage := store.NewLocalStorage(db)
-	service := core.NewKeyorixCore(storage)
+	service := core.NewKeyorixCore(st)
 
 	// Create update request
 	req := &core.UpdateShareRequest{

--- a/internal/storage/gormdb.go
+++ b/internal/storage/gormdb.go
@@ -1,0 +1,59 @@
+package storage
+
+import (
+	"fmt"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"gorm.io/driver/postgres"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// OpenGormDB opens a raw *gorm.DB for the configured local backend, switching on
+// cfg.Storage.Type with the same mapping the factory uses (postgres/postgresql →
+// Postgres, anything else → SQLite) and applying the same connection-pool
+// settings via applyPoolSettings.
+//
+// Unlike the factory's CreateStorage, it deliberately does NOT run migrations: it
+// exists for the handful of CLI admin commands that need a raw *gorm.DB the
+// storage.Storage interface cannot provide — the DEK rotation sweep, which owns
+// its own transaction (ADR-010), and the auth-encryption statistics counters.
+// Those commands operate on an already-initialized database and must not trigger
+// schema changes as a side effect, so migration stays CreateStorage's job. This
+// keeps every GORM driver import inside internal/storage rather than in the CLI
+// command files (ADR-049).
+//
+// Remote storage has no local *gorm.DB; these are host-local admin commands and
+// require a non-remote backend.
+func OpenGormDB(cfg *config.Config) (*gorm.DB, error) {
+	switch cfg.Storage.Type {
+	case "remote":
+		return nil, fmt.Errorf("this command needs direct database access and cannot run against a remote backend; run it on the server host")
+	case "postgres", "postgresql":
+		dsn := config.BuildPostgresDSN(&cfg.Storage.Database)
+		if dsn == "" {
+			return nil, fmt.Errorf("postgres storage requires a DSN or host/name/user fields")
+		}
+		db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+		if err != nil {
+			return nil, fmt.Errorf("failed to connect to postgres: %w", err)
+		}
+		if err := applyPoolSettings(db, &cfg.Storage.Database); err != nil {
+			return nil, err
+		}
+		return db, nil
+	default: // "local", "" or any other value → SQLite (mirrors the factory)
+		dbPath := cfg.Storage.Database.Path
+		if dbPath == "" {
+			dbPath = "./secrets.db"
+		}
+		db, err := gorm.Open(sqlite.Open(dbPath), &gorm.Config{})
+		if err != nil {
+			return nil, fmt.Errorf("failed to connect to database: %w", err)
+		}
+		if err := applyPoolSettings(db, &cfg.Storage.Database); err != nil {
+			return nil, err
+		}
+		return db, nil
+	}
+}


### PR DESCRIPTION
## What

A set of older CLI subcommands opened the database directly with `gorm.Open(sqlite.Open(cfg.Storage.Database.Path), …)`, hardwiring SQLite and ignoring `cfg.Storage.Type`. Against the production-default Postgres backend, each silently opened (or *created*) a local `secrets.db` and operated on the wrong, empty database — the command appeared to succeed but touched the wrong store.

This routes them all through the single storage seam (the factory), so they honor the operator's configured backend, like the server and the newer CLI entry points already do.

## Changes
- New `internal/storage/gormdb.go` — `OpenGormDB` opens a raw `*gorm.DB` for the configured local backend (same postgres/sqlite mapping + pool settings as the factory).
- `internal/cli/common` — shared `InitializeStorage` helper.
- Migrated the direct-`sqlite.Open` subcommands to the factory: `encryption` (auth-stats), `rbac` (assign/remove/check/list-*), `secret` (update/delete/versions), `share` (create/list/update/revoke/shared/group).
- ADR-049 documents the decision.

## Validation
`go build ./...`, `go vet`, and `go test ./internal/cli/... ./internal/storage/...` all pass; gofmt/golangci-lint 0, gosec 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)