### PR TITLE
release: prep v0.70.0 (CHANGELOG + Helm charts 0.70.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,31 @@
 All notable changes to Keyorix are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## v0.70.0 — 2026-06-21
+
+Per-secret usage visibility, and CLI commands that finally honor the configured
+storage backend.
+
+### Added
+- **Per-secret read statistics** — `GET /api/v1/secrets/{id}/stats?days=N`
+  returns a focused per-secret usage view: the durable lifetime read total and
+  version count, plus a configurable recent window (reads, unique readers, last
+  read time). Answers "is this secret actually used, and by whom lately?" in one
+  scoped (`secrets.read`) call, beside `/{id}/access-log` and `/{id}/risk`, and
+  never reveals the value. ([#382])
+
+### Fixed
+- **CLI commands honor `storage.type`** — ~17 `rbac`, `secret`, `share`, and
+  `encryption` subcommands opened the database directly and hardwired SQLite, so
+  against a Postgres deployment they silently operated on a stray local
+  `secrets.db` instead of the real store. They now obtain storage through the
+  factory (or a `*gorm.DB` helper that honors `storage.type`), so every command
+  talks to the configured backend; SQLite stays supported for embedded/air-gapped
+  use. ([#383])
+
+[#382]: https://github.com/keyorixhq/keyorix/pull/382
+[#383]: https://github.com/keyorixhq/keyorix/pull/383
+
 ## v0.69.0 — 2026-06-21
 
 Operability: a real readiness probe and honest build identity.

--- a/deploy/helm/keyorix-k8s-sync/Chart.yaml
+++ b/deploy/helm/keyorix-k8s-sync/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix-k8s-sync
 description: Keyorix Kubernetes sync agent — materialises Keyorix secrets into native Kubernetes Secrets
 type: application
 # Chart version — tracks the Keyorix release version (published in lockstep).
-version: 0.69.0
+version: 0.70.0
 # The keyorix-k8s-sync image tag this chart deploys by default.
-appVersion: "0.69.0"
+appVersion: "0.70.0"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix

--- a/deploy/helm/keyorix/Chart.yaml
+++ b/deploy/helm/keyorix/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix
 description: Self-hosted Keyorix secrets manager (API server + web UI + PostgreSQL)
 type: application
 # Chart version — bump on chart changes.
-version: 0.69.0
+version: 0.70.0
 # The Keyorix app version this chart deploys by default (the image tag).
-appVersion: "0.69.0"
+appVersion: "0.70.0"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix


### PR DESCRIPTION
Prep for the v0.70.0 release.

- **CHANGELOG**: new v0.70.0 section.
- **Helm charts**: `keyorix` and `keyorix-k8s-sync` bumped to 0.70.0
  (`version` + `appVersion`).

Covers, since v0.69.0:
- Per-secret read statistics endpoint (#382)
- CLI commands obtain storage via the factory, honoring `storage.type`
  instead of hardwiring SQLite (#383, ADR-049)

The v0.70.0 tag is created after merge and triggers the image + chart publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)