### PR TITLE
feat(secrets): bulk-rename toward naming-policy conformance — server + CLI

### DIFF
--- a/internal/cli/secret/bulk_rename.go
+++ b/internal/cli/secret/bulk_rename.go
@@ -1,0 +1,134 @@
+package secret
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/spf13/cobra"
+)
+
+var (
+	bulkRenameProject uint
+	bulkRenameApply   bool
+	bulkRenamePairs   []string
+)
+
+// bulkRenameEntry is one requested rename in the POST body (snake_case DTO).
+type bulkRenameEntry struct {
+	ID      uint   `json:"id"`
+	NewName string `json:"new_name"`
+}
+
+// bulkRenameOutcome mirrors one outcome in the bulk-rename report.
+type bulkRenameOutcome struct {
+	ID      uint   `json:"id"`
+	OldName string `json:"old_name"`
+	NewName string `json:"new_name"`
+	Status  string `json:"status"`
+	Reason  string `json:"reason"`
+}
+
+// bulkRenameReport mirrors the report envelope's data object.
+type bulkRenameReport struct {
+	DryRun   bool                `json:"dry_run"`
+	Renamed  int                 `json:"renamed"`
+	Skipped  int                 `json:"skipped"`
+	Outcomes []bulkRenameOutcome `json:"outcomes"`
+}
+
+var bulkRenameCmd = &cobra.Command{
+	Use:   "bulk-rename",
+	Short: "Rename secrets toward naming-policy conformance",
+	Long: `Rename one or more secrets in a project in a single call — the remediation for the
+secrets that "secret name-conformance" lists as violating the current naming policy.
+
+Each new name must itself satisfy the policy (you can only rename TOWARD conformance) and
+must not collide with another secret in the same environment; any entry failing a check
+is skipped with a reason while the rest proceed.
+
+Specify renames as --rename <id>=<new-name> (repeatable). By default this is a DRY RUN
+that only reports what would change; pass --apply to actually rename. Requires
+secrets.write at the project scope.
+
+  keyorix secret bulk-rename --project 7 --rename 12=APP_DB_PASSWORD --rename 15=APP_API_KEY
+  keyorix secret bulk-rename --project 7 --rename 12=APP_DB_PASSWORD --apply`,
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		if bulkRenameProject == 0 {
+			return fmt.Errorf("--project is required")
+		}
+		if len(bulkRenamePairs) == 0 {
+			return fmt.Errorf("at least one --rename <id>=<new-name> is required")
+		}
+		entries, err := parseRenamePairs(bulkRenamePairs)
+		if err != nil {
+			return err
+		}
+
+		c, ok := common.NewRemoteClient()
+		if !ok {
+			return fmt.Errorf("not connected to a server — run: keyorix connect <server>")
+		}
+
+		report, err := postBulkRename(context.Background(), c, bulkRenameProject, entries, !bulkRenameApply)
+		if err != nil {
+			return err
+		}
+
+		if report.DryRun {
+			fmt.Printf("Dry run — no changes made. Pass --apply to rename.\n\n")
+		}
+		fmt.Printf("%-8s %-24s %-24s %-14s %s\n", "ID", "OLD NAME", "NEW NAME", "STATUS", "REASON")
+		for _, o := range report.Outcomes {
+			fmt.Printf("%-8d %-24s %-24s %-14s %s\n", o.ID, o.OldName, o.NewName, o.Status, o.Reason)
+		}
+		verb := "renamed"
+		if report.DryRun {
+			verb = "would be renamed"
+		}
+		fmt.Printf("\n%d %s, %d skipped.\n", report.Renamed, verb, report.Skipped)
+		return nil
+	},
+}
+
+// parseRenamePairs turns ["12=NAME","15=OTHER"] into rename entries, splitting on the
+// FIRST '=' so a new name may itself contain '='.
+func parseRenamePairs(pairs []string) ([]bulkRenameEntry, error) {
+	entries := make([]bulkRenameEntry, 0, len(pairs))
+	for _, p := range pairs {
+		idStr, name, found := strings.Cut(p, "=")
+		if !found {
+			return nil, fmt.Errorf("invalid --rename %q: expected <id>=<new-name>", p)
+		}
+		id, err := strconv.ParseUint(strings.TrimSpace(idStr), 10, 32)
+		if err != nil || id == 0 {
+			return nil, fmt.Errorf("invalid --rename %q: %q is not a valid secret ID", p, idStr)
+		}
+		if strings.TrimSpace(name) == "" {
+			return nil, fmt.Errorf("invalid --rename %q: new name is empty", p)
+		}
+		entries = append(entries, bulkRenameEntry{ID: uint(id), NewName: name})
+	}
+	return entries, nil
+}
+
+// postBulkRename POSTs the rename request (split out for httptest tests).
+func postBulkRename(ctx context.Context, c *common.RemoteClient, projectID uint, entries []bulkRenameEntry, dryRun bool) (bulkRenameReport, error) {
+	path := "/api/v1/projects/" + strconv.Itoa(int(projectID)) + "/secrets/bulk-rename"
+	body := map[string]interface{}{"renames": entries, "dry_run": dryRun}
+	var report bulkRenameReport
+	if err := c.Post(ctx, path, body, &report); err != nil {
+		return bulkRenameReport{}, err
+	}
+	return report, nil
+}
+
+func init() {
+	bulkRenameCmd.Flags().UintVar(&bulkRenameProject, "project", 0, "Project ID (required)")
+	bulkRenameCmd.Flags().StringArrayVar(&bulkRenamePairs, "rename", nil, "Rename as <id>=<new-name> (repeatable)")
+	bulkRenameCmd.Flags().BoolVar(&bulkRenameApply, "apply", false, "Actually rename (default is a dry run)")
+	SecretCmd.AddCommand(bulkRenameCmd)
+}

--- a/internal/cli/secret/bulk_rename_remote_test.go
+++ b/internal/cli/secret/bulk_rename_remote_test.go
@@ -1,0 +1,78 @@
+package secret
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func bulkRenameStub(t *testing.T, capture *map[string]interface{}) (*common.RemoteClient, func()) {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && r.URL.Path == "/api/v1/projects/5/secrets/bulk-rename" {
+			b, _ := io.ReadAll(r.Body)
+			if capture != nil {
+				_ = json.Unmarshal(b, capture)
+			}
+			_, _ = w.Write([]byte(`{"data":{"dry_run":true,"renamed":1,"skipped":0,"outcomes":[{"id":12,"old_name":"db-pw","new_name":"DB_PW","status":"would_rename"}]}}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	rc, ok := common.NewRemoteClient()
+	require.True(t, ok)
+	return rc, srv.Close
+}
+
+func TestPostBulkRename(t *testing.T) {
+	var got map[string]interface{}
+	rc, done := bulkRenameStub(t, &got)
+	defer done()
+
+	rep, err := postBulkRename(context.Background(), rc, 5, []bulkRenameEntry{{ID: 12, NewName: "DB_PW"}}, true)
+	require.NoError(t, err)
+	assert.True(t, rep.DryRun)
+	assert.Equal(t, 1, rep.Renamed)
+	require.Len(t, rep.Outcomes, 1)
+	assert.Equal(t, "would_rename", rep.Outcomes[0].Status)
+
+	// The dry_run flag and renames were sent in the body.
+	assert.Equal(t, true, got["dry_run"])
+	renames, ok := got["renames"].([]interface{})
+	require.True(t, ok)
+	assert.Len(t, renames, 1)
+}
+
+func TestPostBulkRename_NotFound(t *testing.T) {
+	rc, done := bulkRenameStub(t, nil)
+	defer done()
+	_, err := postBulkRename(context.Background(), rc, 999, []bulkRenameEntry{{ID: 1, NewName: "X"}}, false)
+	require.Error(t, err)
+}
+
+func TestParseRenamePairs(t *testing.T) {
+	t.Run("parses id=name pairs and splits on the first =", func(t *testing.T) {
+		got, err := parseRenamePairs([]string{"12=DB_PASSWORD", "15=NAME=WITH=EQUALS"})
+		require.NoError(t, err)
+		require.Len(t, got, 2)
+		assert.Equal(t, uint(12), got[0].ID)
+		assert.Equal(t, "DB_PASSWORD", got[0].NewName)
+		assert.Equal(t, "NAME=WITH=EQUALS", got[1].NewName)
+	})
+
+	t.Run("rejects malformed pairs", func(t *testing.T) {
+		for _, bad := range []string{"noequals", "abc=NAME", "0=NAME", "12="} {
+			_, err := parseRenamePairs([]string{bad})
+			require.Error(t, err, "expected %q to be rejected", bad)
+		}
+	})
+}

--- a/internal/core/secret_bulk_rename.go
+++ b/internal/core/secret_bulk_rename.go
@@ -1,0 +1,151 @@
+// secret_bulk_rename.go — bulk rename of secrets toward naming-policy conformance. The
+// naming policy ([[secret_name_policy]]) is enforced only at create time, so the
+// conformance report ([[secret_name_conformance]]) surfaces live secrets whose names
+// have fallen out of conformance — this is the remediation: rename them in one call.
+// Each requested new name must itself satisfy the current policy (you can only rename
+// TOWARD conformance, never into a fresh violation) and must not collide with a sibling.
+// dry-run validates and reports what WOULD change without touching anything. Never reads
+// or changes a secret's value. Project-scoped (route-gated secrets.write). Parallels the
+// bulk extend-expiring / reassign-owner / suspend-all operations.
+package core
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Rename outcome statuses.
+const (
+	renameStatusRenamed     = "renamed"      // applied
+	renameStatusWouldRename = "would_rename" // dry-run: passed all checks, not applied
+	renameStatusSkipped     = "skipped"      // failed a precondition; reason carries why
+)
+
+// SecretRename is one requested rename: the target secret's ID and the new name.
+type SecretRename struct {
+	ID      uint   `json:"id"`
+	NewName string `json:"new_name"`
+}
+
+// SecretRenameOutcome reports what happened (or, in dry-run, would happen) for one
+// requested rename. Skipped outcomes carry the reason.
+type SecretRenameOutcome struct {
+	ID      uint   `json:"id"`
+	OldName string `json:"old_name,omitempty"`
+	NewName string `json:"new_name"`
+	Status  string `json:"status"`
+	Reason  string `json:"reason,omitempty"`
+}
+
+// BulkRenameReport summarizes a bulk-rename run. DryRun=true means nothing was changed;
+// Renamed counts the secrets that were (or, in dry-run, would be) renamed.
+type BulkRenameReport struct {
+	DryRun   bool                  `json:"dry_run"`
+	Renamed  int                   `json:"renamed"`
+	Skipped  int                   `json:"skipped"`
+	Outcomes []SecretRenameOutcome `json:"outcomes"`
+}
+
+// BulkRenameSecrets renames each requested secret to its new name, within a single
+// project. For every entry it enforces, in order: the secret exists and belongs to THIS
+// project (cross-project guard — a project-scoped caller can never reach another
+// project's secret), it is a secret and not a folder, the name actually changes, the new
+// name satisfies the current naming policy (rename toward conformance only), and the new
+// name does not collide with a sibling in the same environment. An entry failing any
+// check is skipped with a reason; the rest proceed (best-effort, like the other bulk
+// ops). With dryRun the checks run but nothing is persisted. Each applied rename is
+// audited as secret.updated with a name before/after diff. Never reads a secret value.
+func (c *KeyorixCore) BulkRenameSecrets(ctx context.Context, projectID uint, renames []SecretRename, dryRun bool, actor string, actorID uint, ip, ua string) (*BulkRenameReport, error) {
+	if projectID == 0 || actorID == 0 {
+		return nil, fmt.Errorf("project ID and actor ID are required")
+	}
+	if len(renames) == 0 {
+		return nil, fmt.Errorf("at least one rename is required")
+	}
+
+	report := &BulkRenameReport{DryRun: dryRun, Outcomes: make([]SecretRenameOutcome, 0, len(renames))}
+
+	skip := func(id uint, oldName, newName, reason string) {
+		report.Outcomes = append(report.Outcomes, SecretRenameOutcome{
+			ID: id, OldName: oldName, NewName: newName, Status: renameStatusSkipped, Reason: reason,
+		})
+		report.Skipped++
+	}
+
+	for _, rn := range renames {
+		newName := strings.TrimSpace(rn.NewName)
+		if rn.ID == 0 {
+			skip(rn.ID, "", newName, "secret ID is required")
+			continue
+		}
+		if newName == "" {
+			skip(rn.ID, "", "", "new name is empty")
+			continue
+		}
+
+		secret, err := c.storage.GetSecret(ctx, rn.ID)
+		if err != nil || secret == nil {
+			skip(rn.ID, "", newName, "secret not found")
+			continue
+		}
+		if secret.ProjectID != projectID {
+			skip(rn.ID, secret.Name, newName, "secret does not belong to this project")
+			continue
+		}
+		if !secret.IsSecret {
+			skip(rn.ID, secret.Name, newName, "not a secret (folder nodes have no governed name)")
+			continue
+		}
+		if secret.Name == newName {
+			skip(rn.ID, secret.Name, newName, "name unchanged")
+			continue
+		}
+		// Rename toward conformance only — refuse a new name that itself violates the
+		// current policy. (With no policy configured this always passes.)
+		if verr := c.validateSecretName(newName); verr != nil {
+			skip(rn.ID, secret.Name, newName, verr.Error())
+			continue
+		}
+		// Name uniqueness is scoped to (name, project, environment) — don't collide with
+		// a sibling already holding the target name.
+		if existing, err := c.storage.GetSecretByName(ctx, newName, secret.ProjectID, secret.EnvironmentID); err == nil && existing != nil && existing.ID != secret.ID {
+			skip(rn.ID, secret.Name, newName, "a secret with that name already exists in this environment")
+			continue
+		}
+
+		if dryRun {
+			report.Outcomes = append(report.Outcomes, SecretRenameOutcome{
+				ID: rn.ID, OldName: secret.Name, NewName: newName, Status: renameStatusWouldRename,
+			})
+			report.Renamed++
+			continue
+		}
+
+		oldName := secret.Name
+		secret.Name = newName
+		if _, err := c.storage.UpdateSecret(ctx, secret); err != nil {
+			skip(rn.ID, oldName, newName, "storage error")
+			continue
+		}
+		c.LogSecretUpdatedWithDiff(ctx, actorID, secret.ID, projectID, actor, newName, ip, ua, buildNameRenameDiff(oldName, newName))
+		report.Outcomes = append(report.Outcomes, SecretRenameOutcome{
+			ID: rn.ID, OldName: oldName, NewName: newName, Status: renameStatusRenamed,
+		})
+		report.Renamed++
+	}
+	return report, nil
+}
+
+// buildNameRenameDiff renders the audit before/after for a name change. Never carries a
+// value — only the renamed names.
+func buildNameRenameDiff(oldName, newName string) string {
+	b, err := json.Marshal(map[string]map[string]string{
+		"name": {"before": oldName, "after": newName},
+	})
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}

--- a/internal/core/secret_bulk_rename_test.go
+++ b/internal/core/secret_bulk_rename_test.go
@@ -1,0 +1,149 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestBulkRenameSecrets(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	sqlDB, _ := db.DB()
+	sqlDB.SetMaxOpenConns(1)
+	require.NoError(t, db.AutoMigrate(
+		&models.SecretNode{}, &models.SecretVersion{}, &models.Project{}, &models.Environment{},
+		&models.AuditEvent{}, &models.SecretAccessLog{},
+	))
+
+	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
+	ctx := context.Background()
+	now := time.Now()
+
+	p, err := c.storage.CreateProject(ctx, &models.Project{Name: "p1"})
+	require.NoError(t, err)
+	other, err := c.storage.CreateProject(ctx, &models.Project{Name: "p2"})
+	require.NoError(t, err)
+	env, err := c.storage.CreateEnvironment(ctx, &models.Environment{Name: "production", ProjectID: p.ID})
+	require.NoError(t, err)
+
+	mk := func(name string, projectID uint, isSecret bool) uint {
+		s, e := c.storage.CreateSecret(ctx, &models.SecretNode{
+			Name: name, ProjectID: projectID, EnvironmentID: env.ID, Type: "password", OwnerID: 1,
+			IsSecret: isSecret, CreatedAt: now, UpdatedAt: now,
+		})
+		require.NoError(t, e)
+		return s.ID
+	}
+
+	// A policy requiring UPPER_SNAKE so non-conforming names exist to remediate.
+	require.NoError(t, c.SetSecretNamePolicy(SecretNamePolicy{
+		Enabled: true, Pattern: "^[A-Z][A-Z0-9_]*$", MaxLength: 30,
+	}))
+
+	bad := mk("db-password", p.ID, true)          // violator we will fix
+	folder := mk("a folder", p.ID, false)         // folder node
+	taken := mk("EXISTING_NAME", p.ID, true)      // occupies a target name (collision)
+	foreign := mk("other-secret", other.ID, true) // belongs to another project
+	_ = taken
+
+	t.Run("zero project or actor is rejected", func(t *testing.T) {
+		_, err := c.BulkRenameSecrets(ctx, 0, []SecretRename{{ID: bad, NewName: "X"}}, false, "alice", 1, "", "")
+		require.Error(t, err)
+		_, err = c.BulkRenameSecrets(ctx, p.ID, []SecretRename{{ID: bad, NewName: "X"}}, false, "alice", 0, "", "")
+		require.Error(t, err)
+	})
+
+	t.Run("empty renames is rejected", func(t *testing.T) {
+		_, err := c.BulkRenameSecrets(ctx, p.ID, nil, false, "alice", 1, "", "")
+		require.Error(t, err)
+	})
+
+	t.Run("dry run validates but changes nothing", func(t *testing.T) {
+		rep, err := c.BulkRenameSecrets(ctx, p.ID, []SecretRename{{ID: bad, NewName: "DB_PASSWORD"}}, true, "alice", 1, "", "")
+		require.NoError(t, err)
+		assert.True(t, rep.DryRun)
+		assert.Equal(t, 1, rep.Renamed)
+		require.Len(t, rep.Outcomes, 1)
+		assert.Equal(t, renameStatusWouldRename, rep.Outcomes[0].Status)
+		assert.Equal(t, "db-password", rep.Outcomes[0].OldName)
+		assert.Equal(t, "DB_PASSWORD", rep.Outcomes[0].NewName)
+		// Nothing persisted.
+		s, err := c.storage.GetSecret(ctx, bad)
+		require.NoError(t, err)
+		assert.Equal(t, "db-password", s.Name)
+	})
+
+	t.Run("apply renames the secret and audits it", func(t *testing.T) {
+		rep, err := c.BulkRenameSecrets(ctx, p.ID, []SecretRename{{ID: bad, NewName: "DB_PASSWORD"}}, false, "alice", 1, "1.2.3.4", "cli")
+		require.NoError(t, err)
+		assert.False(t, rep.DryRun)
+		assert.Equal(t, 1, rep.Renamed)
+		assert.Equal(t, renameStatusRenamed, rep.Outcomes[0].Status)
+		s, err := c.storage.GetSecret(ctx, bad)
+		require.NoError(t, err)
+		assert.Equal(t, "DB_PASSWORD", s.Name)
+		// An audit event was written for the rename.
+		var n int64
+		require.NoError(t, db.Model(&models.AuditEvent{}).Where("event_type = ?", "secret.updated").Count(&n).Error)
+		assert.Positive(t, n)
+	})
+
+	t.Run("rejects a new name that itself violates the policy", func(t *testing.T) {
+		rep, err := c.BulkRenameSecrets(ctx, p.ID, []SecretRename{{ID: bad, NewName: "still-bad"}}, false, "alice", 1, "", "")
+		require.NoError(t, err)
+		assert.Equal(t, 0, rep.Renamed)
+		require.Len(t, rep.Outcomes, 1)
+		assert.Equal(t, renameStatusSkipped, rep.Outcomes[0].Status)
+		assert.Contains(t, rep.Outcomes[0].Reason, "pattern")
+	})
+
+	t.Run("skips a collision with an existing sibling name", func(t *testing.T) {
+		rep, err := c.BulkRenameSecrets(ctx, p.ID, []SecretRename{{ID: bad, NewName: "EXISTING_NAME"}}, false, "alice", 1, "", "")
+		require.NoError(t, err)
+		assert.Equal(t, 0, rep.Renamed)
+		assert.Equal(t, renameStatusSkipped, rep.Outcomes[0].Status)
+		assert.Contains(t, rep.Outcomes[0].Reason, "already exists")
+	})
+
+	t.Run("skips a folder node", func(t *testing.T) {
+		rep, err := c.BulkRenameSecrets(ctx, p.ID, []SecretRename{{ID: folder, NewName: "FOLDER_X"}}, false, "alice", 1, "", "")
+		require.NoError(t, err)
+		assert.Equal(t, 0, rep.Renamed)
+		assert.Contains(t, rep.Outcomes[0].Reason, "not a secret")
+	})
+
+	t.Run("cross-project guard: cannot rename another project's secret", func(t *testing.T) {
+		rep, err := c.BulkRenameSecrets(ctx, p.ID, []SecretRename{{ID: foreign, NewName: "OTHER_SECRET"}}, false, "alice", 1, "", "")
+		require.NoError(t, err)
+		assert.Equal(t, 0, rep.Renamed)
+		assert.Contains(t, rep.Outcomes[0].Reason, "does not belong")
+		// Untouched in its own project.
+		s, err := c.storage.GetSecret(ctx, foreign)
+		require.NoError(t, err)
+		assert.Equal(t, "other-secret", s.Name)
+	})
+
+	t.Run("missing secret, empty name, and unchanged name are each skipped", func(t *testing.T) {
+		rep, err := c.BulkRenameSecrets(ctx, p.ID, []SecretRename{
+			{ID: 99999, NewName: "GHOST"},
+			{ID: bad, NewName: "   "},
+			{ID: bad, NewName: "DB_PASSWORD"}, // already renamed to this above → unchanged
+		}, false, "alice", 1, "", "")
+		require.NoError(t, err)
+		assert.Equal(t, 0, rep.Renamed)
+		assert.Equal(t, 3, rep.Skipped)
+		assert.Contains(t, rep.Outcomes[0].Reason, "not found")
+		assert.Contains(t, rep.Outcomes[1].Reason, "empty")
+		assert.Contains(t, rep.Outcomes[2].Reason, "unchanged")
+	})
+}

--- a/server/http/handlers/secrets_bulk_rename.go
+++ b/server/http/handlers/secrets_bulk_rename.go
@@ -1,0 +1,53 @@
+// secrets_bulk_rename.go — BulkRenameSecrets handler: rename a project's secrets toward
+// naming-policy conformance in one call (the remediation for the name-conformance
+// report). Scoped secrets.write (project) is enforced by the router. Never touches values.
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/server/middleware"
+)
+
+// BulkRenameSecrets handles POST /api/v1/projects/{id}/secrets/bulk-rename with
+// {"renames":[{"id":N,"new_name":"..."}],"dry_run":false}. Each new name must satisfy
+// the current naming policy and not collide with a sibling; entries failing a check are
+// skipped (with a reason) while the rest proceed. dry_run validates and reports without
+// changing anything. Returns the BulkRenameReport. Never reads or changes a value.
+func (h *SecretHandler) BulkRenameSecrets(w http.ResponseWriter, r *http.Request) {
+	userCtx := middleware.GetUserFromContext(r.Context())
+	if userCtx == nil {
+		h.sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		h.sendError(w, "BadRequest", "Invalid project ID", http.StatusBadRequest, nil)
+		return
+	}
+	var reqBody struct {
+		Renames []core.SecretRename `json:"renames"`
+		DryRun  bool                `json:"dry_run"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
+		h.sendError(w, "BadRequest", "Invalid request body", http.StatusBadRequest, nil)
+		return
+	}
+
+	ip, ua := r.RemoteAddr, r.Header.Get("User-Agent")
+	report, err := h.coreService.BulkRenameSecrets(r.Context(), uint(id), reqBody.Renames, reqBody.DryRun, userCtx.Username, userCtx.UserID, ip, ua)
+	if err != nil {
+		status := http.StatusInternalServerError
+		if strings.Contains(err.Error(), "required") {
+			status = http.StatusBadRequest
+		}
+		h.sendError(w, "Error", err.Error(), status, nil)
+		return
+	}
+	h.sendSuccess(w, report, "")
+}

--- a/server/http/handlers/secrets_bulk_rename_test.go
+++ b/server/http/handlers/secrets_bulk_rename_test.go
@@ -1,0 +1,92 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestBulkRenameSecretsHandler(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.SecretNode{}, &models.SecretVersion{}, &models.Project{}, &models.Environment{},
+		&models.AuditEvent{}, &models.SecretAccessLog{}, &models.User{},
+	))
+	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "p1"}).Error)
+	require.NoError(t, db.Create(&models.Environment{ID: 1, Name: "production", ProjectID: 1}).Error)
+	require.NoError(t, db.Create(&models.SecretNode{
+		ID: 5, Name: "db-password", ProjectID: 1, EnvironmentID: 1, Type: "password", OwnerID: 1,
+		IsSecret: true, CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	}).Error)
+
+	c := core.NewKeyorixCore(store.NewLocalStorage(db))
+	require.NoError(t, c.SetSecretNamePolicy(core.SecretNamePolicy{
+		Enabled: true, Pattern: "^[A-Z][A-Z0-9_]*$", MaxLength: 30,
+	}))
+	h, err := NewSecretHandler(c)
+	require.NoError(t, err)
+
+	t.Run("dry run reports without changing anything", func(t *testing.T) {
+		body := strings.NewReader(`{"renames":[{"id":5,"new_name":"DB_PASSWORD"}],"dry_run":true}`)
+		req := withChiParam(withUserCtx(httptest.NewRequest(http.MethodPost, "/api/v1/projects/1/secrets/bulk-rename", body)), "id", "1")
+		w := httptest.NewRecorder()
+		h.BulkRenameSecrets(w, req)
+
+		require.Equal(t, http.StatusOK, w.Code)
+		assert.Contains(t, w.Body.String(), `"dry_run":true`)
+		assert.Contains(t, w.Body.String(), `"status":"would_rename"`)
+
+		var s models.SecretNode
+		require.NoError(t, db.First(&s, 5).Error)
+		assert.Equal(t, "db-password", s.Name, "dry run must not persist")
+	})
+
+	t.Run("apply renames the secret", func(t *testing.T) {
+		body := strings.NewReader(`{"renames":[{"id":5,"new_name":"DB_PASSWORD"}],"dry_run":false}`)
+		req := withChiParam(withUserCtx(httptest.NewRequest(http.MethodPost, "/api/v1/projects/1/secrets/bulk-rename", body)), "id", "1")
+		w := httptest.NewRecorder()
+		h.BulkRenameSecrets(w, req)
+
+		require.Equal(t, http.StatusOK, w.Code)
+		assert.Contains(t, w.Body.String(), `"renamed":1`)
+		assert.Contains(t, w.Body.String(), `"status":"renamed"`)
+
+		var s models.SecretNode
+		require.NoError(t, db.First(&s, 5).Error)
+		assert.Equal(t, "DB_PASSWORD", s.Name)
+	})
+
+	t.Run("requires a user context", func(t *testing.T) {
+		req := withChiParam(httptest.NewRequest(http.MethodPost, "/api/v1/projects/1/secrets/bulk-rename", nil), "id", "1")
+		w := httptest.NewRecorder()
+		h.BulkRenameSecrets(w, req)
+		assert.Equal(t, http.StatusUnauthorized, w.Code)
+	})
+
+	t.Run("invalid body is a 400", func(t *testing.T) {
+		body := strings.NewReader(`not json`)
+		req := withChiParam(withUserCtx(httptest.NewRequest(http.MethodPost, "/api/v1/projects/1/secrets/bulk-rename", body)), "id", "1")
+		w := httptest.NewRecorder()
+		h.BulkRenameSecrets(w, req)
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("empty renames is a 400", func(t *testing.T) {
+		body := strings.NewReader(`{"renames":[]}`)
+		req := withChiParam(withUserCtx(httptest.NewRequest(http.MethodPost, "/api/v1/projects/1/secrets/bulk-rename", body)), "id", "1")
+		w := httptest.NewRecorder()
+		h.BulkRenameSecrets(w, req)
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -324,6 +324,8 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		r.With(customMiddleware.RequireScopedPermission("secrets.write", projectScope)).Post("/projects/{id}/secrets/reassign-owner", secretHandler.ReassignOwner)
 		// Bulk expiry renewal — push out the expiration of every expiring/expired secret.
 		r.With(customMiddleware.RequireScopedPermission("secrets.write", projectScope)).Post("/projects/{id}/secrets/extend-expiring", secretHandler.ExtendExpiringSecrets)
+		// Bulk rename toward naming-policy conformance — remediation for name-conformance.
+		r.With(customMiddleware.RequireScopedPermission("secrets.write", projectScope)).Post("/projects/{id}/secrets/bulk-rename", secretHandler.BulkRenameSecrets)
 		r.With(customMiddleware.RequireScopedPermission("secrets.write", projectScope)).Post("/projects/{id}/environments/{envId}/copy-secrets", secretHandler.CopyEnvironmentSecrets)
 		r.With(customMiddleware.RequireScopedPermission("secrets.read", projectScope)).Get("/projects/{id}/environments", catalogHandler.ListProjectEnvironments)
 		r.With(customMiddleware.RequireScopedPermission("secrets.write", projectScope)).Post("/projects/{id}/environments", catalogHandler.CreateProjectEnvironment)


### PR DESCRIPTION
## What

Closes the long-open naming-governance follow-up: the **remediation** for the secret name-conformance report. The naming policy is enforced only at create time, so names fall out of conformance after a policy is added/tightened. Until now you could *find* the violators (`secret name-conformance`) but had to fix them one by one.

## How

**Core** `BulkRenameSecrets(projectID, renames, dryRun, actor, actorID, ip, ua)` — for each entry, in order:
- secret exists **and belongs to this project** (cross-project guard — a project-scoped caller can never reach another project's secret)
- it's a secret, not a folder
- the name actually changes
- the new name **satisfies the current policy** (rename *toward* conformance only — reuses `validateSecretName`, so it can never drift from create-time enforcement)
- no sibling collision in the same environment `(name, project, environment)`

Failing entries are **skipped with a reason**; the rest proceed (best-effort, mirroring `extend-expiring` / `reassign-owner`). **dry-run** validates and reports without persisting. Each applied rename is audited as `secret.updated` with a name before/after diff. Never reads a value.

**HTTP:** `POST /api/v1/projects/{id}/secrets/bulk-rename`, scoped `secrets.write` (project) — confirmed denied (403) for the read-only persona by `TestEveryMutatingRouteDeniesReadOnly`.

**CLI:** `keyorix secret bulk-rename --project N --rename <id>=<new-name>...` — **defaults to a DRY RUN**; `--apply` actually renames.

```
keyorix secret bulk-rename --project 7 --rename 12=APP_DB_PASSWORD --rename 15=APP_API_KEY
keyorix secret bulk-rename --project 7 --rename 12=APP_DB_PASSWORD --apply
```

## Tests
- Core: dry-run-no-op, apply+audit, policy-reject, collision, folder, cross-project guard, missing/empty/unchanged.
- Handler: dry-run vs apply, auth, bad body, empty renames.
- CLI: POST body shape, error path, `--rename` parsing (splits on first `=`, rejects malformed).

Local gates: build, `go vet`, `gofmt`, golangci-lint **0**, gosec **0**, all three test packages green.

## Follow-up
Web "rename violators" action on the conformance panels (server + CLI complete here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)