### PR TITLE
feat(rbac): time-bound (JIT) role grants — surface expires_at on assign-role

### DIFF
--- a/internal/cli/rbac/assign_role.go
+++ b/internal/cli/rbac/assign_role.go
@@ -3,6 +3,7 @@ package rbac
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/keyorixhq/keyorix/internal/cli/common"
 	"github.com/keyorixhq/keyorix/internal/core"
@@ -12,18 +13,26 @@ import (
 var assignRoleCmd = &cobra.Command{
 	Use:   "assign-role",
 	Short: "Assign a role to a user",
-	Long:  "Assign a role to a user by email address",
-	RunE:  runAssignRole,
+	Long: `Assign a role to a user by email address.
+
+With --ttl, the grant is time-bound (just-in-time access): it stops authorizing
+once the window passes and is swept automatically. Useful for emergency or
+contractor access. Example: --ttl 4h grants the role for four hours.
+
+Time-bound grants require a server connection (run 'keyorix connect <server>').`,
+	RunE: runAssignRole,
 }
 
 var (
 	userEmail string
 	roleName  string
+	roleTTL   time.Duration
 )
 
 func init() {
 	assignRoleCmd.Flags().StringVar(&userEmail, "user", "", "User email address (required)")
 	assignRoleCmd.Flags().StringVar(&roleName, "role", "", "Role name to assign (required)")
+	assignRoleCmd.Flags().DurationVar(&roleTTL, "ttl", 0, "Time-bound grant lifetime (e.g. 4h, 30m); omit for a permanent grant")
 
 	_ = assignRoleCmd.MarkFlagRequired("user")
 	_ = assignRoleCmd.MarkFlagRequired("role")
@@ -31,8 +40,17 @@ func init() {
 
 func runAssignRole(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
+	if roleTTL < 0 {
+		return fmt.Errorf("--ttl must be positive")
+	}
 	if rc, ok := common.NewRemoteClient(); ok {
-		return runAssignRoleRemote(ctx, rc, userEmail, roleName)
+		return runAssignRoleRemote(ctx, rc, userEmail, roleName, roleTTL)
+	}
+
+	// Embedded (direct-DB) mode has no time-bound path — the JIT expiry sweep runs
+	// in the server, so a grant made here would never be reclaimed.
+	if roleTTL > 0 {
+		return fmt.Errorf("--ttl requires a server connection; run 'keyorix connect <server>'")
 	}
 
 	// Obtain storage via the factory so the backend honors cfg.Storage.Type (ADR-049).

--- a/internal/cli/rbac/remote.go
+++ b/internal/cli/rbac/remote.go
@@ -16,6 +16,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/keyorixhq/keyorix/internal/cli/common"
 )
@@ -195,7 +196,7 @@ func runCheckPermissionRemote(ctx context.Context, rc *common.RemoteClient, emai
 	return nil
 }
 
-func runAssignRoleRemote(ctx context.Context, rc *common.RemoteClient, email, role string) error {
+func runAssignRoleRemote(ctx context.Context, rc *common.RemoteClient, email, role string, ttl time.Duration) error {
 	userID, err := resolveUserIDByEmail(ctx, rc, email)
 	if err != nil {
 		return err
@@ -204,12 +205,19 @@ func runAssignRoleRemote(ctx context.Context, rc *common.RemoteClient, email, ro
 	if err != nil {
 		return err
 	}
-	body := map[string]uint{"user_id": userID, "role_id": roleID}
+	body := map[string]interface{}{"user_id": userID, "role_id": roleID}
+	if ttl > 0 {
+		body["expires_at"] = time.Now().Add(ttl).UTC().Format(time.RFC3339)
+	}
 	var out map[string]interface{}
 	if err := rc.Post(ctx, "/api/v1/user-roles", body, &out); err != nil {
 		return fmt.Errorf("failed to assign role: %w", err)
 	}
-	fmt.Printf("✅ Successfully assigned role '%s' to user '%s'\n", role, email)
+	if ttl > 0 {
+		fmt.Printf("✅ Assigned role '%s' to user '%s' for %s (time-bound)\n", role, email, ttl)
+	} else {
+		fmt.Printf("✅ Successfully assigned role '%s' to user '%s'\n", role, email)
+	}
 	return nil
 }
 

--- a/internal/cli/rbac/remote_test.go
+++ b/internal/cli/rbac/remote_test.go
@@ -2,9 +2,11 @@ package rbac
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/keyorixhq/keyorix/internal/cli/common"
 	"github.com/stretchr/testify/assert"
@@ -106,11 +108,43 @@ func TestRemoteCommandWrappers(t *testing.T) {
 	require.NoError(t, runListPermissionsRemote(ctx, rc, "alice@test.com"))
 	require.NoError(t, runCheckPermissionRemote(ctx, rc, "alice@test.com", "secrets.read"))
 	require.NoError(t, runCheckPermissionRemote(ctx, rc, "alice@test.com", "secrets.write")) // not held → ❌, still nil err
-	require.NoError(t, runAssignRoleRemote(ctx, rc, "alice@test.com", "admin"))
+	require.NoError(t, runAssignRoleRemote(ctx, rc, "alice@test.com", "admin", 0))
 	require.NoError(t, runRemoveRoleRemote(ctx, rc, "alice@test.com", "admin"))
 
 	// A malformed permission name is rejected before any request.
 	require.Error(t, runCheckPermissionRemote(ctx, rc, "alice@test.com", "notvalid"))
+}
+
+// A time-bound grant (--ttl) sends an expires_at in the future; a permanent grant
+// omits it entirely.
+func TestRunAssignRoleRemote_TimeBound(t *testing.T) {
+	var lastBody map[string]interface{}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/roles", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"roles":[{"id":1,"name":"admin","description":""}]}}`))
+	})
+	mux.HandleFunc("/api/v1/users", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"users":[{"id":5,"email":"alice@test.com"}]}}`))
+	})
+	mux.HandleFunc("/api/v1/user-roles", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&lastBody)
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"data":{"user_id":5,"role_id":1}}`))
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	rc := remoteClientFor(t, srv)
+	ctx := context.Background()
+
+	require.NoError(t, runAssignRoleRemote(ctx, rc, "alice@test.com", "admin", 4*time.Hour))
+	require.Contains(t, lastBody, "expires_at")
+	exp, err := time.Parse(time.RFC3339, lastBody["expires_at"].(string))
+	require.NoError(t, err)
+	assert.True(t, exp.After(time.Now()), "expiry must be in the future")
+
+	lastBody = nil
+	require.NoError(t, runAssignRoleRemote(ctx, rc, "alice@test.com", "admin", 0))
+	assert.NotContains(t, lastBody, "expires_at", "a permanent grant omits expires_at")
 }
 
 func TestRunAuditLogsRemote(t *testing.T) {

--- a/server/http/handlers/rbac.go
+++ b/server/http/handlers/rbac.go
@@ -16,6 +16,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/keyorixhq/keyorix/internal/core"
@@ -98,6 +99,10 @@ type AssignRoleRequest struct {
 	// ProjectID/EnvironmentID scope the assignment (0 = global). See core.Scope.
 	ProjectID     uint `json:"project_id"`
 	EnvironmentID uint `json:"environment_id"`
+	// ExpiresAt, when set, makes the grant time-bound (just-in-time access): the
+	// grant stops authorizing the instant it passes and the JIT scheduler sweeps it.
+	// Omit for a permanent grant. Must be in the future. Mirrors share expiry.
+	ExpiresAt *time.Time `json:"expires_at,omitempty"`
 }
 
 // RemoveRoleRequest is the request body for removing a role.
@@ -308,6 +313,18 @@ func (h *RBACHandler) DeleteRole(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
+// roleExpiryValid reports whether a time-bound grant's expiry is acceptable. A nil
+// expiry (permanent grant) is always valid; a set expiry must be in the future — an
+// already-past expiry would create a grant that never authorizes. On rejection it
+// writes a 400 and returns false (mirrors the share-expiry guard).
+func roleExpiryValid(w http.ResponseWriter, expiresAt *time.Time) bool {
+	if expiresAt != nil && !expiresAt.After(time.Now()) {
+		sendError(w, "ValidationError", "Role expiry must be in the future", http.StatusBadRequest, nil)
+		return false
+	}
+	return true
+}
+
 // AssignRole handles POST /api/v1/user-roles
 func (h *RBACHandler) AssignRole(w http.ResponseWriter, r *http.Request) {
 	userCtx := middleware.GetUserFromContext(r.Context())
@@ -326,10 +343,21 @@ func (h *RBACHandler) AssignRole(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if !roleExpiryValid(w, req.ExpiresAt) {
+		return
+	}
+
 	scope := core.Scope{ProjectID: req.ProjectID, EnvironmentID: req.EnvironmentID}
 	// Through the audited core choke point (records role.assigned with the actor),
-	// not storage directly — keeps this endpoint in the RBAC audit trail.
-	if err := h.coreService.AssignUserRole(r.Context(), userCtx.UserID, req.UserID, req.RoleID, scope); err != nil {
+	// not storage directly — keeps this endpoint in the RBAC audit trail. A set
+	// expiry routes through the time-bound (JIT) path.
+	var err error
+	if req.ExpiresAt != nil {
+		err = h.coreService.AssignUserRoleWithExpiry(r.Context(), userCtx.UserID, req.UserID, req.RoleID, scope, *req.ExpiresAt)
+	} else {
+		err = h.coreService.AssignUserRole(r.Context(), userCtx.UserID, req.UserID, req.RoleID, scope)
+	}
+	if err != nil {
 		log.Printf("Error assigning role: %v", err)
 		if strings.Contains(err.Error(), "already assigned") {
 			sendError(w, "ConflictError", "Role already assigned to user", http.StatusConflict, nil)
@@ -340,7 +368,7 @@ func (h *RBACHandler) AssignRole(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.WriteHeader(http.StatusCreated)
-	sendSuccess(w, map[string]interface{}{"user_id": req.UserID, "role_id": req.RoleID}, "Role assigned successfully")
+	sendSuccess(w, map[string]interface{}{"user_id": req.UserID, "role_id": req.RoleID, "expires_at": req.ExpiresAt}, "Role assigned successfully")
 }
 
 // RemoveRole handles DELETE /api/v1/user-roles
@@ -569,9 +597,10 @@ func (h *RBACHandler) AssignRoleToGroup(w http.ResponseWriter, r *http.Request) 
 	}
 
 	var body struct {
-		RoleID        uint `json:"role_id" validate:"required"`
-		ProjectID     uint `json:"project_id"`
-		EnvironmentID uint `json:"environment_id"`
+		RoleID        uint       `json:"role_id" validate:"required"`
+		ProjectID     uint       `json:"project_id"`
+		EnvironmentID uint       `json:"environment_id"`
+		ExpiresAt     *time.Time `json:"expires_at,omitempty"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		sendError(w, "InvalidJSON", "Invalid JSON in request body", http.StatusBadRequest, nil)
@@ -581,9 +610,19 @@ func (h *RBACHandler) AssignRoleToGroup(w http.ResponseWriter, r *http.Request) 
 		sendError(w, "ValidationError", "Invalid request data", http.StatusBadRequest, err)
 		return
 	}
+	if !roleExpiryValid(w, body.ExpiresAt) {
+		return
+	}
 
 	scope := core.Scope{ProjectID: body.ProjectID, EnvironmentID: body.EnvironmentID}
-	if err := h.coreService.AssignRoleToGroup(r.Context(), userCtx.UserID, groupID, body.RoleID, scope); err != nil {
+	// A set expiry routes through the time-bound (JIT) path.
+	var err error
+	if body.ExpiresAt != nil {
+		err = h.coreService.AssignGroupRoleWithExpiry(r.Context(), userCtx.UserID, groupID, body.RoleID, scope, *body.ExpiresAt)
+	} else {
+		err = h.coreService.AssignRoleToGroup(r.Context(), userCtx.UserID, groupID, body.RoleID, scope)
+	}
+	if err != nil {
 		log.Printf("Error assigning role to group: %v", err)
 		if strings.Contains(err.Error(), "not found") {
 			sendError(w, "NotFound", err.Error(), http.StatusNotFound, nil)
@@ -596,7 +635,7 @@ func (h *RBACHandler) AssignRoleToGroup(w http.ResponseWriter, r *http.Request) 
 	}
 
 	w.WriteHeader(http.StatusCreated)
-	sendSuccess(w, map[string]interface{}{"group_id": groupID, "role_id": body.RoleID}, "Role assigned to group successfully")
+	sendSuccess(w, map[string]interface{}{"group_id": groupID, "role_id": body.RoleID, "expires_at": body.ExpiresAt}, "Role assigned to group successfully")
 }
 
 // RemoveRoleFromGroup handles DELETE /api/v1/groups/{id}/roles/{roleId}

--- a/server/http/handlers/rbac_real_test.go
+++ b/server/http/handlers/rbac_real_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/keyorixhq/keyorix/internal/config"
@@ -270,6 +271,72 @@ func TestRBACReal_AssignRole_Conflict(t *testing.T) {
 
 	assert.Equal(t, http.StatusCreated, doAssign().Code)
 	assert.Equal(t, http.StatusConflict, doAssign().Code)
+}
+
+// A time-bound user grant (expires_at in the future) is created and persists the
+// expiry on the UserRole row, so the JIT sweep can later reclaim it.
+func TestRBACReal_AssignRole_TimeBound(t *testing.T) {
+	handler, _, db := setupRBACTestWithDB(t)
+	user := &models.User{Username: "jit-user", Email: "jit@example.com", PasswordHash: "x"}
+	require.NoError(t, db.Create(user).Error)
+	role := mustCreateRole(t, db, "jit-role")
+
+	expiry := time.Now().Add(2 * time.Hour).UTC().Format(time.RFC3339)
+	body := fmt.Sprintf(`{"user_id":%d,"role_id":%d,"expires_at":%q}`, user.ID, role.ID, expiry)
+	req := withUserCtx(httptest.NewRequest(http.MethodPost, "/api/v1/user-roles", bytes.NewBufferString(body)))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler.AssignRole(w, req)
+
+	assert.Equal(t, http.StatusCreated, w.Code)
+	var ur models.UserRole
+	require.NoError(t, db.Where("user_id = ? AND role_id = ?", user.ID, role.ID).First(&ur).Error)
+	require.NotNil(t, ur.ExpiresAt, "the grant must carry the expiry")
+	assert.True(t, ur.ExpiresAt.After(time.Now()))
+}
+
+// An already-past expiry is rejected before any grant is written.
+func TestRBACReal_AssignRole_PastExpiry_400(t *testing.T) {
+	handler, _, db := setupRBACTestWithDB(t)
+	user := &models.User{Username: "past-user", Email: "past@example.com", PasswordHash: "x"}
+	require.NoError(t, db.Create(user).Error)
+	role := mustCreateRole(t, db, "past-role")
+
+	expiry := time.Now().Add(-1 * time.Hour).UTC().Format(time.RFC3339)
+	body := fmt.Sprintf(`{"user_id":%d,"role_id":%d,"expires_at":%q}`, user.ID, role.ID, expiry)
+	req := withUserCtx(httptest.NewRequest(http.MethodPost, "/api/v1/user-roles", bytes.NewBufferString(body)))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler.AssignRole(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	var n int64
+	require.NoError(t, db.Model(&models.UserRole{}).Count(&n).Error)
+	assert.Zero(t, n, "no grant should be written when the expiry is rejected")
+}
+
+// A time-bound group grant persists the expiry on the GroupRole row.
+func TestRBACReal_AssignRoleToGroup_TimeBound(t *testing.T) {
+	handler, _, db := setupRBACTestWithDB(t)
+	group := mustCreateGroup(t, db, "jit-team")
+	role := mustCreateRole(t, db, "jit-team-role")
+
+	expiry := time.Now().Add(3 * time.Hour).UTC().Format(time.RFC3339)
+	body := fmt.Sprintf(`{"role_id":%d,"expires_at":%q}`, role.ID, expiry)
+	req := withUserCtx(withChiParam(
+		httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/v1/groups/%d/roles", group.ID), bytes.NewBufferString(body)),
+		"id", fmt.Sprintf("%d", group.ID)))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler.AssignRoleToGroup(w, req)
+
+	assert.Equal(t, http.StatusCreated, w.Code)
+	var gr models.GroupRole
+	require.NoError(t, db.Where("group_id = ? AND role_id = ?", group.ID, role.ID).First(&gr).Error)
+	require.NotNil(t, gr.ExpiresAt, "the group grant must carry the expiry")
 }
 
 func TestRBACReal_Unauthorized(t *testing.T) {


### PR DESCRIPTION
## What

Surfaces **time-bound (just-in-time) role grants** — a capability whose backend was fully built and tested but **unreachable**. `AssignUserRoleWithExpiry` / `AssignGroupRoleWithExpiry`, the storage expiry columns, and the JIT expiry sweep (`RemoveExpiredRoleGrants`) all existed, but the only way to create a time-bound grant was the internal break-glass path — no API, no CLI. `AssignGroupRoleWithExpiry` had **zero** non-test callers.

Use case: emergency / contractor / on-call access that auto-expires instead of lingering as standing privilege.

## How

Add an optional `expires_at` to the **existing** assign-role flow (mirrors how secret shares became time-bound), so a permanent grant is byte-for-byte unchanged and a set expiry routes through the JIT path:

- `POST /api/v1/user-roles` — `{user_id, role_id, …, "expires_at": <RFC3339>}`
- `POST /api/v1/groups/{id}/roles` — `{role_id, …, "expires_at": <RFC3339>}`

- A set expiry **must be in the future** (`roleExpiryValid` → 400 otherwise) — an already-past expiry would mint a grant that never authorizes (self-checking invariant at the boundary).
- The expiry persists on the `UserRole`/`GroupRole` row, so the **existing sweep reclaims it and audits the auto-expiry**.
- Permission gating (`roles.assign`) and the audited core choke point are unchanged.

**CLI:** `keyorix rbac assign-role --user … --role … --ttl 4h` grants the role for a duration (remote mode). Embedded direct-DB mode rejects `--ttl` with a clear message, since the expiry sweep runs in the server.

## Tests
- Time-bound user grant → 201 and the expiry persists on the `UserRole` row.
- Past expiry → 400 with **no** grant written.
- Time-bound group grant → 201, expiry on `GroupRole`.
- CLI sends `expires_at` for `--ttl` and omits it for a permanent grant.

Local gates: build, `go vet`, `gofmt`, golangci-lint **0**, gosec **0**, rbac handler + CLI packages green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)