### PR TITLE
feat(rbac): group-roles response carries each grant's expiry

### DIFF
--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -1305,6 +1305,10 @@ func (m *MockStorage) GetGroupRoles(_ context.Context, _ uint) ([]*models.Role, 
 	return nil, nil
 }
 
+func (m *MockStorage) GetGroupRoleGrants(_ context.Context, _ uint) ([]*storage.GroupRoleGrant, error) {
+	return nil, nil
+}
+
 func (m *MockStorage) AssignRoleToGroup(_ context.Context, _, _ uint, _ storage.Scope) error {
 	return nil
 }

--- a/internal/core/rbac_management.go
+++ b/internal/core/rbac_management.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
@@ -80,6 +81,16 @@ func (c *KeyorixCore) GetGroupRoles(ctx context.Context, groupID uint) ([]*model
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
 	}
 	return roles, nil
+}
+
+// GetGroupRoleGrants returns a group's roles each with its time-bound expiry
+// (nil = permanent), so the API can surface remaining time on a just-in-time grant.
+func (c *KeyorixCore) GetGroupRoleGrants(ctx context.Context, groupID uint) ([]*storage.GroupRoleGrant, error) {
+	grants, err := c.storage.GetGroupRoleGrants(ctx, groupID)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	return grants, nil
 }
 
 // AssignRoleToGroup verifies both exist then assigns the role at scope and

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -334,6 +334,9 @@ type Storage interface {
 	// Group-Role assignments. Assign/Remove bind a role to a group at the given
 	// Scope (zero Scope = global).
 	GetGroupRoles(ctx context.Context, groupID uint) ([]*models.Role, error)
+	// GetGroupRoleGrants is GetGroupRoles plus each grant's time-bound expiry
+	// (nil = permanent), so callers can surface remaining time on a JIT grant.
+	GetGroupRoleGrants(ctx context.Context, groupID uint) ([]*GroupRoleGrant, error)
 	AssignRoleToGroup(ctx context.Context, groupID, roleID uint, scope Scope) error
 	// AssignRoleToGroupWithExpiry binds a time-bound role to a group; see
 	// AssignRoleWithExpiry.
@@ -773,4 +776,14 @@ type RoleAssignment struct {
 	RoleID        uint   `json:"role_id"`
 	ProjectID     uint   `json:"project_id"`
 	EnvironmentID uint   `json:"environment_id"`
+}
+
+// GroupRoleGrant is a role assigned to a group together with the grant's optional
+// time-bound expiry (nil = permanent). Mirrors a models.Role plus expires_at so the
+// group-roles API can show remaining time on a just-in-time grant.
+type GroupRoleGrant struct {
+	ID          uint       `json:"id"`
+	Name        string     `json:"name"`
+	Description string     `json:"description"`
+	ExpiresAt   *time.Time `json:"expires_at,omitempty"`
 }

--- a/internal/storage/store/local_rbac.go
+++ b/internal/storage/store/local_rbac.go
@@ -356,6 +356,21 @@ func (ls *LocalStorage) GetGroupRoles(ctx context.Context, groupID uint) ([]*mod
 	return roles, nil
 }
 
+// GetGroupRoleGrants is GetGroupRoles plus each grant's time-bound expiry, joined
+// from group_roles.expires_at (nil = permanent).
+func (ls *LocalStorage) GetGroupRoleGrants(ctx context.Context, groupID uint) ([]*storage.GroupRoleGrant, error) {
+	var grants []*storage.GroupRoleGrant
+	err := ls.db.WithContext(ctx).Table("roles").
+		Select("roles.id, roles.name, roles.description, group_roles.expires_at").
+		Joins("JOIN group_roles ON roles.id = group_roles.role_id").
+		Where("group_roles.group_id = ?", groupID).
+		Scan(&grants).Error
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	return grants, nil
+}
+
 // AssignRoleToGroup assigns a permanent role to a group at scope; errors if
 // already assigned there.
 func (ls *LocalStorage) AssignRoleToGroup(ctx context.Context, groupID, roleID uint, scope storage.Scope) error {

--- a/internal/storage/store/remote_rbac.go
+++ b/internal/storage/store/remote_rbac.go
@@ -137,6 +137,12 @@ func (rs *RemoteStorage) AssignRole(ctx context.Context, userID, roleID uint, sc
 	return nil
 }
 
+// GetGroupRoleGrants is server-side only (the HTTP handler reads it from local
+// storage); the remote client uses GetGroupRoles for the role list.
+func (rs *RemoteStorage) GetGroupRoleGrants(_ context.Context, _ uint) ([]*storage.GroupRoleGrant, error) {
+	return nil, remoteUnsupported("GetGroupRoleGrants")
+}
+
 // AssignRoleWithExpiry is server-side only (the JIT grant happens during access-
 // request approval on the server); not driven over the remote client.
 func (rs *RemoteStorage) AssignRoleWithExpiry(_ context.Context, _, _ uint, _ storage.Scope, _ time.Time) error {

--- a/server/http/handlers/rbac.go
+++ b/server/http/handlers/rbac.go
@@ -569,7 +569,9 @@ func (h *RBACHandler) GetGroupRoles(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	roles, err := h.coreService.GetGroupRoles(r.Context(), groupID)
+	// Grants carry each role's time-bound expiry (nil = permanent) so the UI can
+	// show remaining time on a JIT grant.
+	roles, err := h.coreService.GetGroupRoleGrants(r.Context(), groupID)
 	if err != nil {
 		log.Printf("Error getting group roles: %v", err)
 		if strings.Contains(err.Error(), "not found") {

--- a/server/http/handlers/rbac_real_test.go
+++ b/server/http/handlers/rbac_real_test.go
@@ -190,6 +190,40 @@ func TestRBACReal_GetGroupRoles200(t *testing.T) {
 	assert.Len(t, roles, 1)
 }
 
+// GetGroupRoles surfaces each grant's expiry: a permanent grant omits expires_at,
+// a time-bound grant carries it.
+func TestRBACReal_GetGroupRoles_CarriesExpiry(t *testing.T) {
+	handler, _, db := setupRBACTestWithDB(t)
+	group := mustCreateGroup(t, db, "exp-team")
+	permRole := mustCreateRole(t, db, "perm-role")
+	jitRole := mustCreateRole(t, db, "jit-role-g")
+	exp := time.Now().Add(2 * time.Hour)
+	require.NoError(t, db.Create(&models.GroupRole{GroupID: group.ID, RoleID: permRole.ID}).Error)
+	require.NoError(t, db.Create(&models.GroupRole{GroupID: group.ID, RoleID: jitRole.ID, ExpiresAt: &exp}).Error)
+
+	req := withUserCtx(withChiParam(
+		httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/groups/%d/roles", group.ID), nil),
+		"id", fmt.Sprintf("%d", group.ID)))
+	w := httptest.NewRecorder()
+
+	handler.GetGroupRoles(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp map[string]interface{}
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	roles := resp["data"].(map[string]interface{})["roles"].([]interface{})
+	require.Len(t, roles, 2)
+
+	byName := map[string]map[string]interface{}{}
+	for _, r := range roles {
+		m := r.(map[string]interface{})
+		byName[m["name"].(string)] = m
+	}
+	_, hasExpiry := byName["perm-role"]["expires_at"]
+	assert.False(t, hasExpiry, "a permanent grant omits expires_at")
+	assert.NotEmpty(t, byName["jit-role-g"]["expires_at"], "a time-bound grant carries expires_at")
+}
+
 func TestRBACReal_AssignRoleToGroup201(t *testing.T) {
 	handler, _, db := setupRBACTestWithDB(t)
 	group := mustCreateGroup(t, db, "ops-team")


### PR DESCRIPTION
## What

`GET /api/v1/groups/{id}/roles` returned bare roles, **dropping each time-bound grant's expiry** — so the dashboard couldn't show remaining time on a JIT group grant. This unblocks the display half of keyorix-web #90.

## How

- New `GetGroupRoleGrants` (storage + core) returns each role **plus its `expires_at`** (nil = permanent), via a join on `group_roles.expires_at`. New `storage.GroupRoleGrant` DTO.
- The handler now returns grants instead of bare roles. The response shape gains an **optional** `expires_at` per role — **backward compatible** (permanent grants omit it; old clients ignore it).
- `GetGroupRoles` is left unchanged. The remote-storage impl is a server-side-only stub (the handler reads local storage), matching the existing `remoteUnsupported` pattern for the other JIT methods.

## Tests
- Handler surfaces `expires_at` for a time-bound grant and omits it for a permanent one.
- `MockStorage` implements the new interface method.

Local gates: build, `go vet`, `gofmt`, golangci-lint **0**, gosec **0**; core + storage + handler packages green.

## Paired with
keyorix-web PR (renders the remaining-time badge from this field). The web side degrades gracefully against an older server (no badge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)