### PR TITLE
feat(rbac): GET /users/{id}/permissions — a user's effective permission set

### DIFF
--- a/internal/core/rbac_management.go
+++ b/internal/core/rbac_management.go
@@ -169,6 +169,18 @@ func (c *KeyorixCore) GetUserRolesByID(ctx context.Context, userID uint) ([]*mod
 	return roles, nil
 }
 
+// GetUserPermissionsByID returns a user's effective permission set — the
+// de-duplicated union of permissions across every role assigned to the user. This
+// is the "what can this user do" view for dashboards and access reviews; the CLI's
+// list-permissions assembles the same set client-side. Empty for an unknown user.
+func (c *KeyorixCore) GetUserPermissionsByID(ctx context.Context, userID uint) ([]*storage.Permission, error) {
+	perms, err := c.storage.GetUserPermissions(ctx, userID)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	return perms, nil
+}
+
 // SetUserRoles does a full replacement of the roles assigned to a user at the
 // given scope. Only assignments at exactly that scope are considered: roles
 // present there but not in roleIDs are removed; roles in roleIDs not already

--- a/server/http/handlers/rbac_real_test.go
+++ b/server/http/handlers/rbac_real_test.go
@@ -373,6 +373,46 @@ func TestRBACReal_AssignRoleToGroup_TimeBound(t *testing.T) {
 	require.NotNil(t, gr.ExpiresAt, "the group grant must carry the expiry")
 }
 
+// GET /users/{id}/permissions returns the effective permission set (union across the
+// user's roles) and excludes permissions granted only through an EXPIRED time-bound role.
+func TestRBACReal_GetUserPermissionsForUser(t *testing.T) {
+	db := openTestDB(t)
+	handler := NewUsersRolesHandler(core.NewKeyorixCore(store.NewLocalStorage(db)))
+
+	user := &models.User{Username: "perm-user", Email: "perm@example.com", PasswordHash: "x"}
+	require.NoError(t, db.Create(user).Error)
+	role := mustCreateRole(t, db, "reader")
+	expiredRole := mustCreateRole(t, db, "temp-writer")
+	readPerm := &models.Permission{Name: "secrets.read", Description: "read secrets", Resource: "secrets", Action: "read"}
+	writePerm := &models.Permission{Name: "secrets.write", Description: "write secrets", Resource: "secrets", Action: "write"}
+	require.NoError(t, db.Create(readPerm).Error)
+	require.NoError(t, db.Create(writePerm).Error)
+	require.NoError(t, db.Create(&models.RolePermission{RoleID: role.ID, PermissionID: readPerm.ID}).Error)
+	require.NoError(t, db.Create(&models.RolePermission{RoleID: expiredRole.ID, PermissionID: writePerm.ID}).Error)
+	// A live grant of the reader role, plus an already-expired grant of temp-writer.
+	past := time.Now().Add(-1 * time.Hour)
+	require.NoError(t, db.Create(&models.UserRole{UserID: user.ID, RoleID: role.ID}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: user.ID, RoleID: expiredRole.ID, ExpiresAt: &past}).Error)
+
+	req := withUserCtx(withChiParam(
+		httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/users/%d/permissions", user.ID), nil),
+		"id", fmt.Sprintf("%d", user.ID)))
+	w := httptest.NewRecorder()
+
+	handler.GetUserPermissionsForUser(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp map[string]interface{}
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	perms := resp["data"].(map[string]interface{})["permissions"].([]interface{})
+	names := make([]string, 0, len(perms))
+	for _, p := range perms {
+		names = append(names, p.(map[string]interface{})["name"].(string))
+	}
+	assert.Contains(t, names, "secrets.read")
+	assert.NotContains(t, names, "secrets.write", "an expired time-bound grant confers no permissions")
+}
+
 func TestRBACReal_Unauthorized(t *testing.T) {
 	handler, _, _ := setupRBACTestWithDB(t)
 

--- a/server/http/handlers/users_roles.go
+++ b/server/http/handlers/users_roles.go
@@ -69,6 +69,46 @@ func (h *UsersRolesHandler) GetUserRolesForUser(w http.ResponseWriter, r *http.R
 	sendSuccess(w, map[string]interface{}{"roles": apiRoles}, "")
 }
 
+// apiPermission is one entry in a user's effective-permission view.
+type apiPermission struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Resource    string `json:"resource"`
+	Action      string `json:"action"`
+}
+
+// GetUserPermissionsForUser handles GET /api/v1/users/{id}/permissions — the user's
+// effective permission set (the de-duplicated union across all assigned roles). The
+// "what can this user do" view for the dashboard and access reviews.
+func (h *UsersRolesHandler) GetUserPermissionsForUser(w http.ResponseWriter, r *http.Request) {
+	if middleware.GetUserFromContext(r.Context()) == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+
+	userID, ok := parseUintParam(w, r, "id")
+	if !ok {
+		return
+	}
+
+	perms, err := h.coreService.GetUserPermissionsByID(r.Context(), userID)
+	if err != nil {
+		log.Printf("Error getting permissions for user %d: %v", userID, err)
+		if strings.Contains(err.Error(), "not found") {
+			sendError(w, "NotFound", "User not found", http.StatusNotFound, nil)
+		} else {
+			sendError(w, "InternalError", "Failed to get user permissions", http.StatusInternalServerError, nil)
+		}
+		return
+	}
+
+	apiPerms := make([]apiPermission, 0, len(perms))
+	for _, p := range perms {
+		apiPerms = append(apiPerms, apiPermission{Name: p.Name, Description: p.Description, Resource: p.Resource, Action: p.Action})
+	}
+	sendSuccess(w, map[string]interface{}{"permissions": apiPerms}, "")
+}
+
 // apiUserMembership is one row of a user's project-assignments view (ADR-025).
 type apiUserMembership struct {
 	ProjectID   uint   `json:"project_id"`

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -459,6 +459,9 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			// Credential-delivery resend (ADR-028): reissue + redeliver a setup link.
 			r.With(customMiddleware.RequirePermission("users.write")).Post("/{id}/resend-setup-link", handlers.ResendSetupLink)
 			r.Get("/{id}/roles", usersRolesHandler.GetUserRolesForUser)
+			// Effective permission set (union across the user's roles) — a read, gated
+			// by the group-wide users.read like the roles view above.
+			r.Get("/{id}/permissions", usersRolesHandler.GetUserPermissionsForUser)
 			// Replacing a user's roles is a privilege grant — gate on roles.assign,
 			// not the group-wide users.read (which many non-admin roles hold).
 			r.With(customMiddleware.RequirePermission("roles.assign")).Put("/{id}/roles", usersRolesHandler.UpdateUserRoles)


### PR DESCRIPTION
## What

Exposes a user's **effective permission set** — the "what can this user do" view — over HTTP. It existed only in the CLI (`list-permissions` assembles it client-side by unioning each role's permissions); there was no server endpoint, so dashboards, access reviews, and integrations couldn't read it.

## How

`GET /api/v1/users/{id}/permissions` → `{permissions: [{name, description, resource, action}]}` — the de-duplicated union across the user's roles (`GetUserPermissionsByID` → `storage.GetUserPermissions`).

- Read-only, gated by the group-wide `users.read` (same as the sibling `GET /users/{id}/roles`).
- Permissions from an **expired time-bound role are excluded** (the storage query already filters on expiry), so the set reflects what the user can do *right now* — ties in with the new JIT time-bound grants.

## Tests
- Returns the effective set, and **omits** a permission granted only via an expired JIT grant.

Local gates: build, `go vet`, `gofmt`, golangci-lint **0**, gosec **0**; core + handler packages green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)