### PR TITLE
feat(projects): seed environments on project create over HTTP (+ fix CLI --envs in remote mode)

### DIFF
--- a/internal/cli/project/create.go
+++ b/internal/cli/project/create.go
@@ -44,7 +44,10 @@ func runCreate(cmd *cobra.Command, args []string) error {
 		if len(envList) == 0 {
 			return fmt.Errorf("--envs must not be empty")
 		}
-		body["envs"] = envList
+		// Field name must match the server's CreateProject handler ("environments");
+		// it previously sent "envs", which the server ignored — so --envs was silently
+		// dropped in remote mode and the project got the default environment set.
+		body["environments"] = envList
 	}
 
 	if rc, ok := common.NewRemoteClient(); ok {

--- a/server/http/handlers/catalog.go
+++ b/server/http/handlers/catalog.go
@@ -92,12 +92,30 @@ func (h *CatalogHandler) CreateProject(w http.ResponseWriter, r *http.Request) {
 	var body struct {
 		Name        string `json:"name"`
 		Description string `json:"description"`
+		// Environments, when non-empty, seeds the project with exactly these
+		// environments instead of the default development/staging/production set —
+		// one call for infrastructure-as-code provisioning. Blank entries are dropped.
+		Environments []string `json:"environments"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		sendError(w, "InvalidJSON", "Invalid request body", http.StatusBadRequest, nil)
 		return
 	}
-	project, err := h.coreService.CreateProject(r.Context(), body.Name, body.Description)
+
+	envs := make([]string, 0, len(body.Environments))
+	for _, e := range body.Environments {
+		if e = strings.TrimSpace(e); e != "" {
+			envs = append(envs, e)
+		}
+	}
+
+	var project *models.Project
+	var err error
+	if len(envs) > 0 {
+		project, err = h.coreService.CreateProjectWithEnvs(r.Context(), body.Name, body.Description, envs)
+	} else {
+		project, err = h.coreService.CreateProject(r.Context(), body.Name, body.Description)
+	}
 	if err != nil {
 		sendError(w, "Error", err.Error(), http.StatusInternalServerError, nil)
 		return

--- a/server/http/handlers/catalog_create_project_test.go
+++ b/server/http/handlers/catalog_create_project_test.go
@@ -1,0 +1,82 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func newCreateProjectHandler(t *testing.T) (*CatalogHandler, *gorm.DB) {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.Project{}, &models.Environment{}))
+	return NewCatalogHandler(core.NewKeyorixCore(store.NewLocalStorage(db))), db
+}
+
+func postCreateProject(t *testing.T, h *CatalogHandler, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := withUserCtx(httptest.NewRequest(http.MethodPost, "/api/v1/projects", strings.NewReader(body)))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.CreateProject(w, req)
+	return w
+}
+
+func envNames(t *testing.T, db *gorm.DB, projectID uint) []string {
+	t.Helper()
+	var envs []models.Environment
+	require.NoError(t, db.Where("project_id = ?", projectID).Order("name").Find(&envs).Error)
+	names := make([]string, 0, len(envs))
+	for _, e := range envs {
+		names = append(names, e.Name)
+	}
+	return names
+}
+
+func TestCreateProject_DefaultEnvironments(t *testing.T) {
+	h, db := newCreateProjectHandler(t)
+
+	w := postCreateProject(t, h, `{"name":"web"}`)
+
+	require.Equal(t, http.StatusCreated, w.Code)
+	var p models.Project
+	require.NoError(t, db.Where("name = ?", "web").First(&p).Error)
+	// Default set is seeded when no environments are supplied.
+	assert.ElementsMatch(t, []string{"development", "staging", "production"}, envNames(t, db, p.ID))
+}
+
+func TestCreateProject_CustomEnvironments(t *testing.T) {
+	h, db := newCreateProjectHandler(t)
+
+	// Blank entries are dropped; exactly the supplied set is seeded (no defaults).
+	w := postCreateProject(t, h, `{"name":"api","environments":["dev","prod","  "]}`)
+
+	require.Equal(t, http.StatusCreated, w.Code)
+	var p models.Project
+	require.NoError(t, db.Where("name = ?", "api").First(&p).Error)
+	assert.ElementsMatch(t, []string{"dev", "prod"}, envNames(t, db, p.ID))
+}
+
+func TestCreateProject_BlankEnvironmentsFallBackToDefaults(t *testing.T) {
+	h, db := newCreateProjectHandler(t)
+
+	// An environments array of only blanks behaves like omitting it → default set.
+	w := postCreateProject(t, h, `{"name":"svc","environments":["  ",""]}`)
+
+	require.Equal(t, http.StatusCreated, w.Code)
+	var p models.Project
+	require.NoError(t, db.Where("name = ?", "svc").First(&p).Error)
+	assert.ElementsMatch(t, []string{"development", "staging", "production"}, envNames(t, db, p.ID))
+}


### PR DESCRIPTION
## What

`POST /api/v1/projects` only ever created a project with the default `development`/`staging`/`production` environments — no way to provision a custom environment set in a single call (infrastructure-as-code / org onboarding).

It also surfaced a **latent CLI bug**: `keyorix project create --envs ...` posted the field as `envs`, which the server never read — so **against a server the flag was silently ignored** and the project got the default environments anyway. (Embedded direct-DB mode worked, via `CreateProjectWithEnvs`.)

## How

- Add an optional `environments` field to the create handler: when non-empty it seeds **exactly** those (blank entries dropped) via the existing `CreateProjectWithEnvs`; omitted or all-blank keeps the default set. **No new route.**
- Align the CLI remote body to send `environments` (matching the handler), fixing the silently-dropped `--envs`.

## Tests
- Default set when `environments` is omitted.
- Exactly the custom set, with blank entries dropped.
- An all-blank array falls back to the default set.

Local gates: build, `go vet`, `gofmt`, golangci-lint **0**, gosec **0**; handler + CLI packages green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)