### PR TITLE
feat(sharing): GET /groups/{id}/shared-secrets — secrets a group can reach

### DIFF
--- a/internal/core/group_sharing.go
+++ b/internal/core/group_sharing.go
@@ -92,15 +92,40 @@ func (c *KeyorixCore) ListGroupShares(ctx context.Context, groupID uint) ([]*mod
 	return shares, nil
 }
 
-// ListGroupSharedSecrets lists all secrets shared with a group
+// ListGroupSharedSecrets lists the live secrets currently shared with a group — the
+// "what can this group reach via shares" view. Composes the group's share records
+// (ListSharesByGroup) with the secrets themselves, skipping expired time-bound shares
+// (which no longer authorize) and any share whose secret is gone, and de-duplicating
+// by secret. Never reads a value.
 func (c *KeyorixCore) ListGroupSharedSecrets(ctx context.Context, groupID uint) ([]*models.SecretNode, error) {
 	if groupID == 0 {
 		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "group ID is required")
 	}
 
-	// This would require a new method in the storage interface
-	// For now, we'll just return an empty list
-	return []*models.SecretNode{}, nil
+	shares, err := c.storage.ListSharesByGroup(ctx, groupID)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+
+	now := c.now()
+	secrets := make([]*models.SecretNode, 0, len(shares))
+	seen := make(map[uint]bool, len(shares))
+	for _, s := range shares {
+		// An expired time-bound share no longer authorizes, so it must not surface here.
+		if s.ExpiresAt != nil && !s.ExpiresAt.After(now) {
+			continue
+		}
+		if seen[s.SecretID] {
+			continue
+		}
+		secret, err := c.storage.GetSecret(ctx, s.SecretID)
+		if err != nil || secret == nil {
+			continue // secret deleted/missing — skip it
+		}
+		seen[s.SecretID] = true
+		secrets = append(secrets, secret)
+	}
+	return secrets, nil
 }
 
 // CheckUserGroupPermission checks if a user has permission to access a secret via group membership

--- a/internal/core/group_sharing_test.go
+++ b/internal/core/group_sharing_test.go
@@ -230,6 +230,47 @@ func TestKeyorixCore_ListGroupShares_ValidationError(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestKeyorixCore_ListGroupSharedSecrets(t *testing.T) {
+	require.NoError(t, i18n.Initialize(&config.Config{
+		Locale: config.LocaleConfig{Language: "en", FallbackLanguage: "en"},
+	}))
+	now := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
+	ms := new(MockStorage)
+	c := &KeyorixCore{storage: ms, now: func() time.Time { return now }}
+	ctx := context.Background()
+
+	past := now.Add(-1 * time.Hour)
+	future := now.Add(1 * time.Hour)
+	shares := []*models.ShareRecord{
+		{ID: 1, SecretID: 1, RecipientID: 2, IsGroup: true, Permission: "read"},                     // live
+		{ID: 2, SecretID: 1, RecipientID: 2, IsGroup: true, Permission: "write"},                    // dup secret → deduped
+		{ID: 3, SecretID: 2, RecipientID: 2, IsGroup: true, Permission: "read", ExpiresAt: &past},   // expired → excluded
+		{ID: 4, SecretID: 3, RecipientID: 2, IsGroup: true, Permission: "read", ExpiresAt: &future}, // live time-bound
+		{ID: 5, SecretID: 4, RecipientID: 2, IsGroup: true, Permission: "read"},                     // secret gone → skipped
+	}
+	ms.On("ListSharesByGroup", ctx, uint(2)).Return(shares, nil)
+	ms.On("GetSecret", ctx, uint(1)).Return(&models.SecretNode{ID: 1, Name: "alpha"}, nil)
+	ms.On("GetSecret", ctx, uint(3)).Return(&models.SecretNode{ID: 3, Name: "gamma"}, nil)
+	ms.On("GetSecret", ctx, uint(4)).Return((*models.SecretNode)(nil), errors.New("not found"))
+
+	result, err := c.ListGroupSharedSecrets(ctx, 2)
+	require.NoError(t, err)
+
+	ids := make([]uint, 0, len(result))
+	for _, s := range result {
+		ids = append(ids, s.ID)
+	}
+	assert.Equal(t, []uint{1, 3}, ids, "live + future shares only, deduped, missing skipped")
+	// The expired share's secret is never even loaded.
+	ms.AssertNotCalled(t, "GetSecret", ctx, uint(2))
+}
+
+func TestKeyorixCore_ListGroupSharedSecrets_ValidationError(t *testing.T) {
+	c := &KeyorixCore{storage: new(MockStorage), now: time.Now}
+	_, err := c.ListGroupSharedSecrets(context.Background(), 0)
+	assert.Error(t, err)
+}
+
 // Regression (security review): a non-owner must not be able to group-share a
 // secret they don't own, even with secrets.write — the owner check in
 // ShareSecretWithGroup enforces it (previously missing).

--- a/server/http/handlers/shares_group_secrets_test.go
+++ b/server/http/handlers/shares_group_secrets_test.go
@@ -1,0 +1,64 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestListGroupSharedSecretsHandler(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.ShareRecord{}, &models.Group{}))
+
+	// Two secrets, both shared with group 7 — one live, one via an expired share.
+	require.NoError(t, db.Create(&models.SecretNode{ID: 1, Name: "alpha", IsSecret: true, OwnerID: 1}).Error)
+	require.NoError(t, db.Create(&models.SecretNode{ID: 2, Name: "beta", IsSecret: true, OwnerID: 1}).Error)
+	past := time.Now().Add(-1 * time.Hour)
+	require.NoError(t, db.Create(&models.ShareRecord{ID: 1, SecretID: 1, OwnerID: 1, RecipientID: 7, IsGroup: true, Permission: "read"}).Error)
+	require.NoError(t, db.Create(&models.ShareRecord{ID: 2, SecretID: 2, OwnerID: 1, RecipientID: 7, IsGroup: true, Permission: "read", ExpiresAt: &past}).Error)
+
+	h, err := NewShareHandler(core.NewKeyorixCore(store.NewLocalStorage(db)))
+	require.NoError(t, err)
+
+	t.Run("returns the live shared secret and excludes the expired share", func(t *testing.T) {
+		req := withUserCtx(withChiParam(httptest.NewRequest(http.MethodGet, "/api/v1/groups/7/shared-secrets", nil), "id", "7"))
+		w := httptest.NewRecorder()
+		h.ListGroupSharedSecrets(w, req)
+
+		require.Equal(t, http.StatusOK, w.Code)
+		data := decodeData(t, w)
+		secrets := data["secrets"].([]interface{})
+		require.Len(t, secrets, 1, "only the live (non-expired) share surfaces")
+		// SecretNode has no JSON tags, so it serializes with Go field names (PascalCase),
+		// matching the existing /shared-secrets endpoint.
+		assert.Equal(t, "alpha", secrets[0].(map[string]interface{})["Name"])
+	})
+
+	t.Run("requires a user context", func(t *testing.T) {
+		req := withChiParam(httptest.NewRequest(http.MethodGet, "/api/v1/groups/7/shared-secrets", nil), "id", "7")
+		w := httptest.NewRecorder()
+		h.ListGroupSharedSecrets(w, req)
+		assert.Equal(t, http.StatusUnauthorized, w.Code)
+	})
+
+	t.Run("a group with no shares returns an empty list", func(t *testing.T) {
+		req := withUserCtx(withChiParam(httptest.NewRequest(http.MethodGet, "/api/v1/groups/99/shared-secrets", nil), "id", "99"))
+		w := httptest.NewRecorder()
+		h.ListGroupSharedSecrets(w, req)
+
+		require.Equal(t, http.StatusOK, w.Code)
+		assert.Empty(t, decodeData(t, w)["secrets"].([]interface{}))
+	})
+}

--- a/server/http/handlers/shares_query.go
+++ b/server/http/handlers/shares_query.go
@@ -155,6 +155,33 @@ func (h *ShareHandler) ListSharedSecrets(w http.ResponseWriter, r *http.Request)
 	h.sendSuccess(w, map[string]interface{}{"secrets": secrets}, "")
 }
 
+// ListGroupSharedSecrets handles GET /api/v1/groups/{id}/shared-secrets — the live
+// secrets currently shared with a group (the "what can this group reach" view).
+func (h *ShareHandler) ListGroupSharedSecrets(w http.ResponseWriter, r *http.Request) {
+	if middleware.GetUserFromContext(r.Context()) == nil {
+		h.sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+
+	groupID, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		h.sendError(w, "InvalidParameter", "Invalid group ID", http.StatusBadRequest, nil)
+		return
+	}
+
+	secrets, err := h.coreService.ListGroupSharedSecrets(r.Context(), uint(groupID))
+	if err != nil {
+		log.Printf("Error listing group shared secrets: %v", err)
+		h.sendError(w, "InternalError", "Failed to list group shared secrets", http.StatusInternalServerError, nil)
+		return
+	}
+	if secrets == nil {
+		secrets = []*models.SecretNode{}
+	}
+
+	h.sendSuccess(w, map[string]interface{}{"secrets": secrets}, "")
+}
+
 // GetSharingStatusWithIndicators handles GET /api/v1/secrets/{id}/sharing-status
 func (h *ShareHandler) GetSharingStatusWithIndicators(w http.ResponseWriter, r *http.Request) {
 	userCtx := middleware.GetUserFromContext(r.Context())

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -485,6 +485,9 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.With(customMiddleware.RequirePermission("users.write")).Put("/{id}", groupHandler.UpdateGroup)
 			r.With(customMiddleware.RequirePermission("users.write")).Delete("/{id}", groupHandler.DeleteGroup)
 			r.Get("/{id}/members", groupHandler.GetGroupMembers)
+			// Secrets a group can reach via shares — reveals secret names, so it needs
+			// secrets.read on top of the group-level users.read above.
+			r.With(customMiddleware.RequirePermission("secrets.read")).Get("/{id}/shared-secrets", shareHandler.ListGroupSharedSecrets)
 			// Adding/removing a group member confers (or revokes) every role the group
 			// holds — the same blast radius as a role grant, so gate on roles.assign
 			// (matching the group's role-grant routes below), not users.read.


### PR DESCRIPTION
## What

`ListGroupSharedSecrets` was a **stub returning an empty list** — a long-standing TODO (*"would require a new method in the storage interface"*) with no caller. This implements it and surfaces it: the **"what can this group reach via shares"** view, pairing with the user effective-permissions endpoint (#389) for access visibility.

## How

- Core composes the existing tested storage calls (`ListSharesByGroup` + `GetSecret`) — **no storage-interface change**. It skips **expired time-bound shares** (which no longer authorize), skips shares whose secret is gone, and de-duplicates by secret. Never reads a value.
- `GET /api/v1/groups/{id}/shared-secrets`, gated by `secrets.read` **on top of** the group subrouter's `users.read` (it reveals secret names).

## Tests
- Core: live + future-dated shares only, de-duplicated; an expired share is excluded **without even loading the secret**; a missing secret is skipped; zero group id rejected.
- Handler: live secret returned, expired excluded, auth required, empty group → empty list.

Local gates: build, `go vet`, `gofmt`, golangci-lint **0**, gosec **0**; core + handler packages green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)