### PR TITLE
feat(machine-identity): migrate a user to a machine identity over HTTP (ADR-023)

### DIFF
--- a/server/http/handlers/machine_identities.go
+++ b/server/http/handlers/machine_identities.go
@@ -95,6 +95,53 @@ func (h *CatalogHandler) CreateMachineIdentity(w http.ResponseWriter, r *http.Re
 	sendSuccess(w, map[string]interface{}{"machine_identity": m}, "Machine identity created")
 }
 
+// MigrateUserToMachine handles POST /api/v1/projects/{id}/machine-identities/migrate-from-user
+// (ADR-023) — converts a service-account-shaped human user into a project machine
+// identity and, unless keep_user is set, suspends the source user so it can no longer log
+// in. The user is never deleted. Needs roles.assign (project) AND users.write (the suspend).
+func (h *CatalogHandler) MigrateUserToMachine(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		sendError(w, "InvalidParameter", "Invalid project ID", http.StatusBadRequest, nil)
+		return
+	}
+	actor := middleware.GetUserFromContext(r.Context())
+	if actor == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	var body struct {
+		Username     string `json:"username"`
+		IdentityType string `json:"identity_type"`
+		Name         string `json:"name"`
+		// KeepUser leaves the source user able to log in; the default (false) suspends
+		// it so the human-login path is closed once the machine identity exists.
+		KeepUser bool `json:"keep_user"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		sendError(w, "InvalidJSON", "Invalid request body", http.StatusBadRequest, nil)
+		return
+	}
+	if body.Username == "" {
+		sendError(w, "ValidationError", "username is required", http.StatusBadRequest, nil)
+		return
+	}
+
+	m, err := h.coreService.MigrateUserToMachine(r.Context(), body.Username, uint(id), body.IdentityType, body.Name, actor.UserID, !body.KeepUser)
+	if err != nil {
+		status := http.StatusInternalServerError
+		if strings.Contains(err.Error(), "not found") {
+			status = http.StatusNotFound
+		} else if strings.Contains(err.Error(), "required") || strings.Contains(err.Error(), "invalid identity_type") {
+			status = http.StatusBadRequest
+		}
+		sendError(w, "Error", err.Error(), status, nil)
+		return
+	}
+	w.WriteHeader(http.StatusCreated)
+	sendSuccess(w, map[string]interface{}{"machine_identity": m}, "User migrated to machine identity")
+}
+
 // TransitionMachineIdentity handles PUT /api/v1/projects/{id}/machine-identities/{machineId}.
 // Body: {"action": "activate" | "suspend" | "revoke"}.
 func (h *CatalogHandler) TransitionMachineIdentity(w http.ResponseWriter, r *http.Request) {

--- a/server/http/handlers/machine_identities_migrate_test.go
+++ b/server/http/handlers/machine_identities_migrate_test.go
@@ -1,0 +1,91 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func newMigrateHandler(t *testing.T) (*CatalogHandler, *gorm.DB) {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.User{}, &models.MachineIdentity{}, &models.Project{}, &models.Session{}, &models.AuditEvent{},
+	))
+	require.NoError(t, db.Create(&models.Project{ID: 3, Name: "platform"}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 7, Username: "ci-bot", Email: "ci-bot@x.io", AccountState: core.AccountActive}).Error)
+	return NewCatalogHandler(core.NewKeyorixCore(store.NewLocalStorage(db))), db
+}
+
+func TestMigrateUserToMachineHandler(t *testing.T) {
+	t.Run("creates the machine identity and suspends the source user by default", func(t *testing.T) {
+		h, db := newMigrateHandler(t)
+		req := withUserCtx(withChiParam(
+			httptest.NewRequest(http.MethodPost, "/api/v1/projects/3/machine-identities/migrate-from-user",
+				strings.NewReader(`{"username":"ci-bot"}`)), "id", "3"))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+
+		h.MigrateUserToMachine(w, req)
+
+		require.Equal(t, http.StatusCreated, w.Code)
+		var m models.MachineIdentity
+		require.NoError(t, db.Where("project_id = ? AND name = ?", 3, "ci-bot").First(&m).Error)
+		// Source user suspended (default — human login closed), never deleted.
+		var u models.User
+		require.NoError(t, db.First(&u, 7).Error)
+		assert.Equal(t, core.AccountSuspended, u.AccountState)
+	})
+
+	t.Run("keep_user leaves the source account active", func(t *testing.T) {
+		h, db := newMigrateHandler(t)
+		req := withUserCtx(withChiParam(
+			httptest.NewRequest(http.MethodPost, "/api/v1/projects/3/machine-identities/migrate-from-user",
+				strings.NewReader(`{"username":"ci-bot","name":"ci","keep_user":true}`)), "id", "3"))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+
+		h.MigrateUserToMachine(w, req)
+
+		require.Equal(t, http.StatusCreated, w.Code)
+		var u models.User
+		require.NoError(t, db.First(&u, 7).Error)
+		assert.Equal(t, core.AccountActive, u.AccountState, "keep_user must not suspend")
+	})
+
+	t.Run("unknown user is a 404", func(t *testing.T) {
+		h, _ := newMigrateHandler(t)
+		req := withUserCtx(withChiParam(
+			httptest.NewRequest(http.MethodPost, "/api/v1/projects/3/machine-identities/migrate-from-user",
+				strings.NewReader(`{"username":"ghost"}`)), "id", "3"))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+
+		h.MigrateUserToMachine(w, req)
+		assert.Equal(t, http.StatusNotFound, w.Code)
+	})
+
+	t.Run("missing username is a 400", func(t *testing.T) {
+		h, _ := newMigrateHandler(t)
+		req := withUserCtx(withChiParam(
+			httptest.NewRequest(http.MethodPost, "/api/v1/projects/3/machine-identities/migrate-from-user",
+				strings.NewReader(`{}`)), "id", "3"))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+
+		h.MigrateUserToMachine(w, req)
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -295,6 +295,11 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		r.With(customMiddleware.RequireScopedPermission("users.read", projectScope)).Get("/projects/{id}/machine-identities", catalogHandler.ListMachineIdentities)
 		r.With(customMiddleware.RequireScopedPermission("users.read", projectScope)).Get("/projects/{id}/machine-identities/stale", catalogHandler.ListStaleMachineIdentities)
 		r.With(customMiddleware.RequireScopedPermission("roles.assign", projectScope)).Post("/projects/{id}/machine-identities", catalogHandler.CreateMachineIdentity)
+		// User→machine migration creates a machine identity (roles.assign, project) AND
+		// suspends the source user (users.write, global) — require both.
+		r.With(customMiddleware.RequireScopedPermission("roles.assign", projectScope)).
+			With(customMiddleware.RequirePermission("users.write")).
+			Post("/projects/{id}/machine-identities/migrate-from-user", catalogHandler.MigrateUserToMachine)
 		r.With(customMiddleware.RequireScopedPermission("roles.assign", projectScope)).Put("/projects/{id}/machine-identities/{machineId}", catalogHandler.TransitionMachineIdentity)
 		r.With(customMiddleware.RequireScopedPermission("roles.assign", projectScope)).Patch("/projects/{id}/machine-identities/{machineId}/classification", catalogHandler.ClassifyMachineIdentity)
 		r.With(customMiddleware.RequireScopedPermission("roles.assign", projectScope)).Patch("/projects/{id}/machine-identities/{machineId}/tokens/{tokenId}/classification", catalogHandler.ClassifyMachineToken)


### PR DESCRIPTION
## What

The user→machine conversion (ADR-023) existed only in the CLI (`keyorix migrate user-to-machine`) — no HTTP endpoint, so it couldn't be driven from automation or the dashboard.

## How

`POST /api/v1/projects/{id}/machine-identities/migrate-from-user` with `{username, identity_type?, name?, keep_user?}`:
- Materialises a project machine identity for the user, and unless `keep_user` is set, **suspends** the source user so the human-login path is closed. The user is **never deleted** (suspension is reversible and preserves audit/ownership history).
- Delegates to the already-tested `core.MigrateUserToMachine`.

The operation spans two privilege domains — creating a machine identity (`roles.assign`, project) and suspending a user (`users.write`, global) — so **the route requires both**. Unknown user → 404; missing username → 400.

## Tests
- Default suspends the source user; `keep_user` leaves it active; unknown user → 404; missing username → 400.
- The new mutating route is denied (403) to the read-only persona (`TestEveryMutatingRouteDeniesReadOnly`).

Local gates: build, `go vet`, `gofmt`, golangci-lint **0**, gosec **0**; handler package green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)