### PR TITLE
feat(admin): on-demand triggers for scheduled notification/alert jobs

### DIFF
--- a/server/http/handlers/admin_jobs.go
+++ b/server/http/handlers/admin_jobs.go
@@ -1,0 +1,91 @@
+// admin_jobs.go — on-demand triggers for the notification/alert jobs that
+// otherwise only run on their background schedulers (anomaly alerting, rotation and
+// expiry reminders, the compliance digest). After an incident or a config change an
+// operator often needs to dispatch these immediately rather than wait for the next
+// tick. All are deployment-wide admin actions, gated by system.write in the router.
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/server/middleware"
+)
+
+// AdminJobsHandler exposes the scheduled jobs as manual triggers.
+type AdminJobsHandler struct {
+	coreService *core.KeyorixCore
+}
+
+// NewAdminJobsHandler creates a new AdminJobsHandler.
+func NewAdminJobsHandler(coreService *core.KeyorixCore) *AdminJobsHandler {
+	return &AdminJobsHandler{coreService: coreService}
+}
+
+// RunAnomalyAlerts handles POST /api/v1/admin/jobs/anomaly-alerts — broadcast alerts
+// for any new (unalerted) anomaly findings now. Returns {alerted}.
+func (h *AdminJobsHandler) RunAnomalyAlerts(w http.ResponseWriter, r *http.Request) {
+	if middleware.GetUserFromContext(r.Context()) == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	n, err := h.coreService.AlertNewAnomalies(r.Context())
+	if err != nil {
+		sendError(w, "Error", err.Error(), http.StatusInternalServerError, nil)
+		return
+	}
+	sendSuccess(w, map[string]interface{}{"alerted": n}, "")
+}
+
+// RunRotationReminders handles POST /api/v1/admin/jobs/rotation-reminders — send
+// rotation-due reminders now. Returns {sent}.
+func (h *AdminJobsHandler) RunRotationReminders(w http.ResponseWriter, r *http.Request) {
+	if middleware.GetUserFromContext(r.Context()) == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	n, err := h.coreService.SendRotationReminders(r.Context())
+	if err != nil {
+		sendError(w, "Error", err.Error(), http.StatusInternalServerError, nil)
+		return
+	}
+	sendSuccess(w, map[string]interface{}{"sent": n}, "")
+}
+
+// RunExpiryReminders handles POST /api/v1/admin/jobs/expiry-reminders?lead_days=N —
+// send expiry reminders for secrets expiring within the lead window (default 14 when
+// lead_days is omitted or non-positive). Returns {sent}.
+func (h *AdminJobsHandler) RunExpiryReminders(w http.ResponseWriter, r *http.Request) {
+	if middleware.GetUserFromContext(r.Context()) == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	leadDays := 0 // core applies the default when <= 0
+	if v := r.URL.Query().Get("lead_days"); v != "" {
+		if d, perr := strconv.Atoi(v); perr == nil {
+			leadDays = d
+		}
+	}
+	n, err := h.coreService.SendExpiryReminders(r.Context(), leadDays)
+	if err != nil {
+		sendError(w, "Error", err.Error(), http.StatusInternalServerError, nil)
+		return
+	}
+	sendSuccess(w, map[string]interface{}{"sent": n}, "")
+}
+
+// RunComplianceDigest handles POST /api/v1/admin/jobs/compliance-digest — broadcast the
+// compliance digest now. Returns {sent} (false when there were no recipients/changes).
+func (h *AdminJobsHandler) RunComplianceDigest(w http.ResponseWriter, r *http.Request) {
+	if middleware.GetUserFromContext(r.Context()) == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	sent, err := h.coreService.SendComplianceDigest(r.Context())
+	if err != nil {
+		sendError(w, "Error", err.Error(), http.StatusInternalServerError, nil)
+		return
+	}
+	sendSuccess(w, map[string]interface{}{"sent": sent}, "")
+}

--- a/server/http/handlers/admin_jobs_test.go
+++ b/server/http/handlers/admin_jobs_test.go
@@ -1,0 +1,78 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func newAdminJobsHandler(t *testing.T) *AdminJobsHandler {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	// Union of what the lightweight jobs touch (anomaly / rotation / expiry).
+	require.NoError(t, db.AutoMigrate(
+		&models.User{}, &models.Role{}, &models.UserRole{}, &models.Project{}, &models.Environment{},
+		&models.SecretNode{}, &models.Notification{}, &models.RotationPolicy{},
+		&models.AnomalyAlert{}, &models.AuditEvent{},
+	))
+	return NewAdminJobsHandler(core.NewKeyorixCore(store.NewLocalStorage(db)))
+}
+
+func postJob(h http.HandlerFunc, target string, auth bool) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodPost, target, nil)
+	if auth {
+		req = withUserCtx(req)
+	}
+	w := httptest.NewRecorder()
+	h(w, req)
+	return w
+}
+
+func TestAdminJobsHandlers_HappyPath(t *testing.T) {
+	h := newAdminJobsHandler(t)
+
+	t.Run("anomaly-alerts returns alerted count on empty state", func(t *testing.T) {
+		w := postJob(h.RunAnomalyAlerts, "/api/v1/admin/jobs/anomaly-alerts", true)
+		require.Equal(t, http.StatusOK, w.Code)
+		assert.EqualValues(t, 0, decodeData(t, w)["alerted"])
+	})
+
+	t.Run("rotation-reminders returns sent count", func(t *testing.T) {
+		w := postJob(h.RunRotationReminders, "/api/v1/admin/jobs/rotation-reminders", true)
+		require.Equal(t, http.StatusOK, w.Code)
+		assert.EqualValues(t, 0, decodeData(t, w)["sent"])
+	})
+
+	t.Run("expiry-reminders honors lead_days and returns sent count", func(t *testing.T) {
+		w := postJob(h.RunExpiryReminders, "/api/v1/admin/jobs/expiry-reminders?lead_days=30", true)
+		require.Equal(t, http.StatusOK, w.Code)
+		assert.EqualValues(t, 0, decodeData(t, w)["sent"])
+	})
+}
+
+func TestAdminJobsHandlers_RequireUserContext(t *testing.T) {
+	h := newAdminJobsHandler(t)
+	cases := map[string]http.HandlerFunc{
+		"anomaly-alerts":     h.RunAnomalyAlerts,
+		"rotation-reminders": h.RunRotationReminders,
+		"expiry-reminders":   h.RunExpiryReminders,
+		"compliance-digest":  h.RunComplianceDigest,
+	}
+	for name, fn := range cases {
+		t.Run(name+" is unauthorized without a user context", func(t *testing.T) {
+			w := postJob(fn, "/api/v1/admin/jobs/"+name, false)
+			assert.Equal(t, http.StatusUnauthorized, w.Code)
+		})
+	}
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -70,6 +70,7 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 	usersRolesHandler := handlers.NewUsersRolesHandler(coreService)
 	notificationHandler := handlers.NewNotificationHandler(coreService)
 	connectHandler := handlers.NewConnectHandler(coreService)
+	adminJobsHandler := handlers.NewAdminJobsHandler(coreService)
 
 	// Auth endpoints (no authentication middleware)
 	r.Post("/auth/login", authHandler.Login)
@@ -608,6 +609,17 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		r.With(customMiddleware.RequirePermission("system.write")).Post("/sod/policies", catalogHandler.CreateSoDPolicy)
 		r.With(customMiddleware.RequirePermission("system.write")).Delete("/sod/policies/{id}", catalogHandler.DeleteSoDPolicy)
 		r.With(customMiddleware.RequirePermission("system.read")).Get("/sod/violations", catalogHandler.ListSoDViolations)
+
+		// On-demand triggers for the notification/alert jobs that otherwise run only on
+		// their background schedulers — dispatch immediately after an incident or config
+		// change. Deployment-wide admin actions, gated by system.write.
+		r.Route("/admin/jobs", func(r chi.Router) {
+			r.Use(customMiddleware.RequirePermission("system.write"))
+			r.Post("/anomaly-alerts", adminJobsHandler.RunAnomalyAlerts)
+			r.Post("/rotation-reminders", adminJobsHandler.RunRotationReminders)
+			r.Post("/expiry-reminders", adminJobsHandler.RunExpiryReminders)
+			r.Post("/compliance-digest", adminJobsHandler.RunComplianceDigest)
+		})
 	})
 
 	// Swagger UI (optional, based on config)


### PR DESCRIPTION
## What

Anomaly alerting, rotation/expiry reminders, and the compliance digest ran **only on their background schedulers** — after an incident or a config change an operator had to wait for the next tick. This surfaces each as a manual trigger over the existing, already-tested core functions.

## How

New `/api/v1/admin/jobs` group, gated by `system.write`:

| Endpoint | Result |
|---|---|
| `POST /admin/jobs/anomaly-alerts` | `{alerted}` |
| `POST /admin/jobs/rotation-reminders` | `{sent}` |
| `POST /admin/jobs/expiry-reminders?lead_days=N` | `{sent}` (core applies the default lead when omitted) |
| `POST /admin/jobs/compliance-digest` | `{sent}` |

New `AdminJobsHandler`; each method is a thin wrapper over `AlertNewAnomalies` / `SendRotationReminders` / `SendExpiryReminders` / `SendComplianceDigest`.

## Tests
- Anomaly / rotation / expiry happy paths return their count on empty state (expiry exercises `lead_days`).
- All four are unauthorized without a user context.
- All four are denied (403) to the read-only persona (`TestEveryMutatingRouteDeniesReadOnly`).

Local gates: build, `go vet`, `gofmt`, golangci-lint **0**, gosec **0**; handler package green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)