### PR TITLE
release: prep v0.72.0 (CHANGELOG + Helm charts 0.72.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,29 @@
 All notable changes to Keyorix are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## v0.72.0 — 2026-06-21
+
+Access visibility and operator controls over HTTP.
+
+### Added
+- **Group access visibility** — `GET /api/v1/groups/{id}/shared-secrets` lists the
+  live secrets a group can reach via shares (skipping expired time-bound shares),
+  the group counterpart to the per-user permissions view. ([#392])
+- **User→machine migration over HTTP** —
+  `POST /api/v1/projects/{id}/machine-identities/migrate-from-user` converts a
+  service-account-shaped human user into a project machine identity and (unless
+  `keep_user` is set) suspends the source user, so the conversion can be driven
+  from automation or the dashboard, not just the CLI. Requires `roles.assign`
+  (project) and `users.write`. ([#393])
+- **On-demand job triggers** — a new `/api/v1/admin/jobs` group (`system.write`)
+  dispatches the scheduled notification/alert jobs immediately instead of waiting
+  for the next tick: `anomaly-alerts`, `rotation-reminders`,
+  `expiry-reminders?lead_days=N`, and `compliance-digest`. ([#394])
+
+[#392]: https://github.com/keyorixhq/keyorix/pull/392
+[#393]: https://github.com/keyorixhq/keyorix/pull/393
+[#394]: https://github.com/keyorixhq/keyorix/pull/394
+
 ## v0.71.0 — 2026-06-21
 
 Just-in-time access, RBAC visibility, and naming-policy remediation.

--- a/deploy/helm/keyorix-k8s-sync/Chart.yaml
+++ b/deploy/helm/keyorix-k8s-sync/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix-k8s-sync
 description: Keyorix Kubernetes sync agent — materialises Keyorix secrets into native Kubernetes Secrets
 type: application
 # Chart version — tracks the Keyorix release version (published in lockstep).
-version: 0.71.0
+version: 0.72.0
 # The keyorix-k8s-sync image tag this chart deploys by default.
-appVersion: "0.71.0"
+appVersion: "0.72.0"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix

--- a/deploy/helm/keyorix/Chart.yaml
+++ b/deploy/helm/keyorix/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix
 description: Self-hosted Keyorix secrets manager (API server + web UI + PostgreSQL)
 type: application
 # Chart version — bump on chart changes.
-version: 0.71.0
+version: 0.72.0
 # The Keyorix app version this chart deploys by default (the image tag).
-appVersion: "0.71.0"
+appVersion: "0.72.0"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix


### PR DESCRIPTION
Release prep for **v0.72.0** — CHANGELOG entry + both Helm charts bumped to 0.72.0 (lockstep).

## Included since v0.71.0
- **Group access visibility** — `GET /groups/{id}/shared-secrets`. ([#392])
- **User→machine migration over HTTP** — `POST /projects/{id}/machine-identities/migrate-from-user`. ([#393])
- **On-demand job triggers** — `/admin/jobs/{anomaly-alerts,rotation-reminders,expiry-reminders,compliance-digest}`. ([#394])

Charts bumped lockstep: `keyorix` and `keyorix-k8s-sync` → 0.72.0 (version + appVersion). `helm lint` clean.

Tag `v0.72.0` pushed after merge to trigger the release + image-publish workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)