### PR TITLE
feat(audit): record role-definition changes (create/update/delete)

### DIFF
--- a/internal/core/audit.go
+++ b/internal/core/audit.go
@@ -19,6 +19,10 @@ const (
 	EventRoleGroupRemoved  = "role.group_removed"  // #nosec G101 -- audit event type, not a credential
 	EventPermissionAdded   = "permission.assigned" // #nosec G101 -- audit event type, not a credential
 	EventPermissionRemoved = "permission.removed"  // #nosec G101 -- audit event type, not a credential
+	// Role-definition lifecycle (the role itself, not an assignment of it).
+	EventRoleCreated = "role.created"
+	EventRoleUpdated = "role.updated"
+	EventRoleDeleted = "role.deleted"
 )
 
 // rbacAuditEventTypes is the set of event types that make up the RBAC audit log.
@@ -26,6 +30,7 @@ var rbacAuditEventTypes = []string{
 	EventRoleAssigned, EventRoleRemoved, EventRoleExpired,
 	EventRoleGroupAssigned, EventRoleGroupRemoved,
 	EventPermissionAdded, EventPermissionRemoved,
+	EventRoleCreated, EventRoleUpdated, EventRoleDeleted,
 }
 
 // rbacAuditDetail is the structured payload stored in an RBAC event's Diff field,
@@ -96,6 +101,27 @@ func (c *KeyorixCore) logPermissionChange(ctx context.Context, eventType, verb s
 		RoleID:       roleID,
 		PermissionID: permissionID,
 	})
+}
+
+// LogRoleCreated / LogRoleUpdated / LogRoleDeleted record a change to a role
+// DEFINITION (distinct from assigning a role to a principal). Role definitions are
+// global, so no scope. actorID is the admin who made the change (0 = no
+// authenticated principal). They surface in the RBAC audit log alongside grants.
+func (c *KeyorixCore) LogRoleCreated(ctx context.Context, actorID, roleID uint, name string) {
+	c.logRoleDefinitionChange(ctx, EventRoleCreated, "created", actorID, roleID, name)
+}
+
+func (c *KeyorixCore) LogRoleUpdated(ctx context.Context, actorID, roleID uint, name string) {
+	c.logRoleDefinitionChange(ctx, EventRoleUpdated, "updated", actorID, roleID, name)
+}
+
+func (c *KeyorixCore) LogRoleDeleted(ctx context.Context, actorID, roleID uint, name string) {
+	c.logRoleDefinitionChange(ctx, EventRoleDeleted, "deleted", actorID, roleID, name)
+}
+
+func (c *KeyorixCore) logRoleDefinitionChange(ctx context.Context, eventType, verb string, actorID, roleID uint, name string) {
+	desc := fmt.Sprintf("role %q (id %d) %s", name, roleID, verb)
+	c.writeRBACAudit(ctx, eventType, desc, actorID, Scope{}, rbacAuditDetail{RoleID: roleID})
 }
 
 // writeRBACAudit is the shared writer for RBAC audit events: actor as UserID,

--- a/server/http/handlers/rbac.go
+++ b/server/http/handlers/rbac.go
@@ -180,6 +180,7 @@ func (h *RBACHandler) CreateRole(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	h.coreService.LogRoleCreated(r.Context(), userCtx.UserID, role.ID, role.Name)
 	w.WriteHeader(http.StatusCreated)
 	sendSuccess(w, map[string]interface{}{"role": role, "permissions": assignedPerms}, "Role created successfully")
 }
@@ -253,6 +254,7 @@ func (h *RBACHandler) UpdateRole(w http.ResponseWriter, r *http.Request) {
 		sendError(w, "InternalError", "Failed to update role", http.StatusInternalServerError, nil)
 		return
 	}
+	h.coreService.LogRoleUpdated(r.Context(), userCtx.UserID, role.ID, role.Name)
 
 	// Replace permissions if provided.
 	if req.Permissions != nil {
@@ -310,6 +312,7 @@ func (h *RBACHandler) DeleteRole(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	h.coreService.LogRoleDeleted(r.Context(), userCtx.UserID, role.ID, role.Name)
 	w.WriteHeader(http.StatusNoContent)
 }
 

--- a/server/http/handlers/rbac_role_audit_test.go
+++ b/server/http/handlers/rbac_role_audit_test.go
@@ -1,0 +1,90 @@
+package handlers
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// Role-DEFINITION changes (create/update/delete) must be audited, like role
+// assignments — previously they wrote nothing, leaving a governance blind spot.
+func TestRBACRoleDefinitionAudit(t *testing.T) {
+	require.NoError(t, i18n.Initialize(&config.Config{
+		Locale: config.LocaleConfig{Language: "en", FallbackLanguage: "en"},
+	}))
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.Role{}, &models.Permission{}, &models.RolePermission{}, &models.AuditEvent{},
+	))
+	handler := NewRBACHandler(core.NewKeyorixCore(store.NewLocalStorage(db)))
+	// CreateRole requires at least one (resolvable) permission name.
+	require.NoError(t, db.Create(&models.Permission{Name: "secrets.read", Resource: "secrets", Action: "read"}).Error)
+
+	countEvents := func(eventType string) int64 {
+		var n int64
+		require.NoError(t, db.Model(&models.AuditEvent{}).Where("event_type = ?", eventType).Count(&n).Error)
+		return n
+	}
+
+	t.Run("create role writes role.created", func(t *testing.T) {
+		req := withUserCtx(httptest.NewRequest(http.MethodPost, "/api/v1/roles",
+			bytes.NewBufferString(`{"name":"auditor-x","description":"reads things","permissions":["secrets.read"]}`)))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		handler.CreateRole(w, req)
+
+		require.Equal(t, http.StatusCreated, w.Code)
+		assert.Equal(t, int64(1), countEvents(core.EventRoleCreated))
+	})
+
+	var roleID uint
+	require.NoError(t, db.Model(&models.Role{}).Where("name = ?", "auditor-x").Select("id").Scan(&roleID).Error)
+
+	t.Run("update role writes role.updated", func(t *testing.T) {
+		req := withUserCtx(withChiParam(httptest.NewRequest(http.MethodPut, fmt.Sprintf("/api/v1/roles/%d", roleID),
+			bytes.NewBufferString(`{"description":"reads more things"}`)), "id", fmt.Sprintf("%d", roleID)))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		handler.UpdateRole(w, req)
+
+		require.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, int64(1), countEvents(core.EventRoleUpdated))
+	})
+
+	t.Run("delete role writes role.deleted", func(t *testing.T) {
+		req := withUserCtx(withChiParam(httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/api/v1/roles/%d", roleID),
+			nil), "id", fmt.Sprintf("%d", roleID)))
+		w := httptest.NewRecorder()
+		handler.DeleteRole(w, req)
+
+		require.Equal(t, http.StatusNoContent, w.Code)
+		assert.Equal(t, int64(1), countEvents(core.EventRoleDeleted))
+	})
+
+	t.Run("a refused built-in delete writes no event", func(t *testing.T) {
+		require.NoError(t, db.Create(&models.Role{Name: "admin", Description: "built-in"}).Error)
+		var adminID uint
+		require.NoError(t, db.Model(&models.Role{}).Where("name = ?", "admin").Select("id").Scan(&adminID).Error)
+
+		req := withUserCtx(withChiParam(httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/api/v1/roles/%d", adminID),
+			nil), "id", fmt.Sprintf("%d", adminID)))
+		w := httptest.NewRecorder()
+		handler.DeleteRole(w, req)
+
+		require.Equal(t, http.StatusForbidden, w.Code)
+		assert.Equal(t, int64(1), countEvents(core.EventRoleDeleted), "still just the one earlier delete — the refused built-in delete audits nothing")
+	})
+}


### PR DESCRIPTION
## What

Role **assignments** were audited (`role.assigned` / `role.removed` / …), but changes to a role **definition** — which controls what privileges exist — wrote **nothing**: `CreateRole`, `UpdateRole`, and `DeleteRole` called storage directly with no audit event. That's a governance blind spot in a security/compliance product (a recon pass flagged the same gap on roles, groups, and rotation policies — this PR closes the roles half, the most privilege-critical).

## How

- New `role.created` / `role.updated` / `role.deleted` events, added to the RBAC audit-log event set so `ListRBACAuditLogs` surfaces them alongside grants.
- New `LogRoleCreated` / `LogRoleUpdated` / `LogRoleDeleted` core helpers (via the shared `writeRBACAudit`; role definitions are global, so no scope).
- Emitted from the handlers after a successful mutation — matching how the secrets handlers already invoke `Log*` helpers directly. A refused built-in delete (403) writes nothing.

## Tests
- Create / update / delete each write their event.
- A refused built-in-role delete audits nothing.

Local gates: build, `go vet`, `gofmt`, golangci-lint **0**, gosec **0**; core + handler packages green.

## Follow-up
Same audit gap exists on group CRUD and rotation-policy CRUD — separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)