### PR TITLE
feat(audit): record group create/update/delete

### DIFF
--- a/internal/cli/group/create.go
+++ b/internal/cli/group/create.go
@@ -35,7 +35,7 @@ func runCreate(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to initialize service: %w", err)
 	}
 	ctx := context.Background()
-	g, err := service.CreateGroup(ctx, &core.CreateGroupRequest{
+	g, err := service.CreateGroup(ctx, 0, &core.CreateGroupRequest{ // actorID 0: local/unauthenticated CLI
 		Name:        createName,
 		Description: createDescription,
 	})

--- a/internal/cli/group/delete.go
+++ b/internal/cli/group/delete.go
@@ -30,7 +30,7 @@ func runDelete(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to initialize service: %w", err)
 	}
 	ctx := context.Background()
-	if err := service.DeleteGroup(ctx, deleteGroupID); err != nil {
+	if err := service.DeleteGroup(ctx, 0, deleteGroupID); err != nil { // actorID 0: local/unauthenticated CLI
 		return fmt.Errorf("failed to delete group: %w", err)
 	}
 	fmt.Printf("Group %d deleted.\n", deleteGroupID)

--- a/internal/cli/group/update.go
+++ b/internal/cli/group/update.go
@@ -40,7 +40,7 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to initialize service: %w", err)
 	}
 	ctx := context.Background()
-	g, err := service.UpdateGroup(ctx, &core.UpdateGroupRequest{
+	g, err := service.UpdateGroup(ctx, 0, &core.UpdateGroupRequest{ // actorID 0: local/unauthenticated CLI
 		ID:          updateGroupID,
 		Name:        updateGroupName,
 		Description: updateGroupDescription,

--- a/internal/core/groups.go
+++ b/internal/core/groups.go
@@ -13,8 +13,17 @@ import (
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
-// CreateGroup creates a new group.
-func (c *KeyorixCore) CreateGroup(ctx context.Context, req *CreateGroupRequest) (*models.Group, error) {
+// Group lifecycle audit event types (API/CLI-driven; the SCIM provisioning path
+// has its own scim.group_* events). Surfaced in the audit log like other mutations.
+const (
+	EventGroupCreated = "group.created"
+	EventGroupUpdated = "group.updated"
+	EventGroupDeleted = "group.deleted"
+)
+
+// CreateGroup creates a new group. actorID is the admin performing it (0 = no
+// authenticated principal, e.g. a local CLI invocation).
+func (c *KeyorixCore) CreateGroup(ctx context.Context, actorID uint, req *CreateGroupRequest) (*models.Group, error) {
 	if err := c.validateCreateGroupRequest(req); err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorValidation", nil), err)
 	}
@@ -23,6 +32,8 @@ func (c *KeyorixCore) CreateGroup(ctx context.Context, req *CreateGroupRequest) 
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}
+	c.writeAuditEvent(ctx, EventGroupCreated, actorPtr(actorID), nil,
+		fmt.Sprintf("group %q (id %d) created", created.Name, created.ID))
 	return created, nil
 }
 
@@ -38,8 +49,8 @@ func (c *KeyorixCore) GetGroup(ctx context.Context, id uint) (*models.Group, err
 	return group, nil
 }
 
-// UpdateGroup updates an existing group.
-func (c *KeyorixCore) UpdateGroup(ctx context.Context, req *UpdateGroupRequest) (*models.Group, error) {
+// UpdateGroup updates an existing group. See CreateGroup for actorID semantics.
+func (c *KeyorixCore) UpdateGroup(ctx context.Context, actorID uint, req *UpdateGroupRequest) (*models.Group, error) {
 	if err := c.validateUpdateGroupRequest(req); err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorValidation", nil), err)
 	}
@@ -57,20 +68,25 @@ func (c *KeyorixCore) UpdateGroup(ctx context.Context, req *UpdateGroupRequest) 
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}
+	c.writeAuditEvent(ctx, EventGroupUpdated, actorPtr(actorID), nil,
+		fmt.Sprintf("group %q (id %d) updated", updated.Name, updated.ID))
 	return updated, nil
 }
 
-// DeleteGroup deletes a group by ID.
-func (c *KeyorixCore) DeleteGroup(ctx context.Context, id uint) error {
+// DeleteGroup deletes a group by ID. See CreateGroup for actorID semantics.
+func (c *KeyorixCore) DeleteGroup(ctx context.Context, actorID, id uint) error {
 	if id == 0 {
 		return fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "group ID is required")
 	}
-	if _, err := c.storage.GetGroup(ctx, id); err != nil {
+	group, err := c.storage.GetGroup(ctx, id)
+	if err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
 	}
 	if err := c.storage.DeleteGroup(ctx, id); err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}
+	c.writeAuditEvent(ctx, EventGroupDeleted, actorPtr(actorID), nil,
+		fmt.Sprintf("group %q (id %d) deleted", group.Name, id))
 	return nil
 }
 

--- a/internal/core/groups_audit_test.go
+++ b/internal/core/groups_audit_test.go
@@ -1,0 +1,72 @@
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// Group CRUD must be audited (create/update/delete), like other governance
+// mutations — previously these wrote nothing on the API/CLI path.
+func TestGroupCRUDAudit(t *testing.T) {
+	require.NoError(t, i18n.Initialize(&config.Config{
+		Locale: config.LocaleConfig{Language: "en", FallbackLanguage: "en"},
+	}))
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.Group{}, &models.GroupRole{}, &models.UserGroup{}, &models.AuditEvent{},
+	))
+	c := &KeyorixCore{storage: store.NewLocalStorage(db)}
+	ctx := context.Background()
+
+	lastActor := func(eventType string) (int64, *uint) {
+		var ev models.AuditEvent
+		var n int64
+		require.NoError(t, db.Model(&models.AuditEvent{}).Where("event_type = ?", eventType).Count(&n).Error)
+		_ = db.Where("event_type = ?", eventType).Order("id DESC").First(&ev).Error
+		return n, ev.UserID
+	}
+
+	g, err := c.CreateGroup(ctx, 42, &CreateGroupRequest{Name: "ops-team", Description: "ops"})
+	require.NoError(t, err)
+	n, actor := lastActor(EventGroupCreated)
+	assert.Equal(t, int64(1), n)
+	require.NotNil(t, actor)
+	assert.Equal(t, uint(42), *actor, "the acting admin is recorded")
+
+	_, err = c.UpdateGroup(ctx, 42, &UpdateGroupRequest{ID: g.ID, Description: "platform ops"})
+	require.NoError(t, err)
+	n, _ = lastActor(EventGroupUpdated)
+	assert.Equal(t, int64(1), n)
+
+	require.NoError(t, c.DeleteGroup(ctx, 42, g.ID))
+	n, _ = lastActor(EventGroupDeleted)
+	assert.Equal(t, int64(1), n)
+}
+
+// A CLI invocation (actorID 0) still audits, with no actor recorded.
+func TestGroupCreateAudit_UnauthenticatedActor(t *testing.T) {
+	require.NoError(t, i18n.Initialize(&config.Config{
+		Locale: config.LocaleConfig{Language: "en", FallbackLanguage: "en"},
+	}))
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.Group{}, &models.AuditEvent{}))
+	c := &KeyorixCore{storage: store.NewLocalStorage(db)}
+
+	_, err = c.CreateGroup(context.Background(), 0, &CreateGroupRequest{Name: "cli-group"})
+	require.NoError(t, err)
+
+	var ev models.AuditEvent
+	require.NoError(t, db.Where("event_type = ?", EventGroupCreated).First(&ev).Error)
+	assert.Nil(t, ev.UserID, "actorID 0 records no actor")
+}

--- a/internal/core/scim_groups.go
+++ b/internal/core/scim_groups.go
@@ -24,7 +24,9 @@ func (c *KeyorixCore) ProvisionSCIMGroup(ctx context.Context, actorID uint, disp
 	if displayName == "" {
 		return nil, fmt.Errorf("displayName is required")
 	}
-	group, err := c.CreateGroup(ctx, &CreateGroupRequest{Name: displayName})
+	// Storage-direct: the SCIM path emits its own scim.group_provisioned event below,
+	// so it must not also fire the generic group.created from CreateGroup.
+	group, err := c.storage.CreateGroup(ctx, &models.Group{Name: displayName})
 	if err != nil {
 		return nil, err
 	}
@@ -109,7 +111,9 @@ func (c *KeyorixCore) PatchSCIMGroup(ctx context.Context, actorID, groupID uint,
 // DeprovisionSCIMGroup handles a SCIM DELETE — removes the group (membership links
 // go with it).
 func (c *KeyorixCore) DeprovisionSCIMGroup(ctx context.Context, actorID, groupID uint) error {
-	if err := c.DeleteGroup(ctx, groupID); err != nil {
+	// Storage-direct: the SCIM path emits scim.group_deprovisioned below, not the
+	// generic group.deleted. storage.DeleteGroup still errors on a missing group.
+	if err := c.storage.DeleteGroup(ctx, groupID); err != nil {
 		return err
 	}
 	c.writeAuditEvent(ctx, EventSCIMGroupDeprovisioned, actorPtr(actorID), nil,

--- a/server/http/handlers/groups_handler.go
+++ b/server/http/handlers/groups_handler.go
@@ -80,7 +80,7 @@ func (h *GroupHandler) CreateGroup(w http.ResponseWriter, r *http.Request) {
 		sendError(w, "ValidationError", "Invalid request data", http.StatusBadRequest, err)
 		return
 	}
-	created, err := h.coreService.CreateGroup(r.Context(), &core.CreateGroupRequest{
+	created, err := h.coreService.CreateGroup(r.Context(), userCtx.UserID, &core.CreateGroupRequest{
 		Name:        body.Name,
 		Description: body.Description,
 	})
@@ -148,7 +148,7 @@ func (h *GroupHandler) UpdateGroup(w http.ResponseWriter, r *http.Request) {
 		sendError(w, "ValidationError", "Invalid request data", http.StatusBadRequest, err)
 		return
 	}
-	updated, err := h.coreService.UpdateGroup(r.Context(), &core.UpdateGroupRequest{
+	updated, err := h.coreService.UpdateGroup(r.Context(), userCtx.UserID, &core.UpdateGroupRequest{
 		ID:          uint(id),
 		Name:        body.Name,
 		Description: body.Description,
@@ -178,7 +178,7 @@ func (h *GroupHandler) DeleteGroup(w http.ResponseWriter, r *http.Request) {
 		sendError(w, "InvalidParameter", "Invalid group ID", http.StatusBadRequest, nil)
 		return
 	}
-	if err := h.coreService.DeleteGroup(r.Context(), uint(id)); err != nil {
+	if err := h.coreService.DeleteGroup(r.Context(), userCtx.UserID, uint(id)); err != nil {
 		log.Printf("Error deleting group: %v", err)
 		if strings.Contains(err.Error(), "not found") || strings.Contains(err.Error(), i18n.T("ErrorGroupNotFound", nil)) {
 			sendError(w, "NotFound", "Group not found", http.StatusNotFound, nil)


### PR DESCRIPTION
## What

Group CRUD on the API/CLI path wrote **no audit event** — `CreateGroup`, `UpdateGroup`, `DeleteGroup` mutated storage silently, while the SCIM provisioning path audits (`scim.group_*`). Another governance blind spot, the sibling of role-definition audit (#396).

## How

- New `group.created` / `group.updated` / `group.deleted` events.
- Threaded an `actorID` through the three core methods; emit the event after a successful mutation (via the shared `writeAuditEvent`, mirroring SCIM). HTTP handlers pass the authenticated user; the local CLI passes `0` (no actor recorded, matching the existing CLI convention).
- The SCIM path now calls storage directly, so it keeps emitting **only** its own `scim.group_*` events — no double-audit.

## Tests
- Create / update / delete each write their event with the acting admin recorded.
- An `actorID`-0 (CLI) create audits with no actor.

Local gates: build, `go vet`, `gofmt`, golangci-lint **0**, gosec **0**; core + handler + CLI packages green.

## Follow-up
Remaining audit gap: rotation-policy CRUD (next).

🤖 Generated with [Claude Code](https://claude.com/claude-code)