### PR TITLE
feat(audit): record rotation-policy create/update/delete

### DIFF
--- a/internal/core/rotation_policies.go
+++ b/internal/core/rotation_policies.go
@@ -43,7 +43,17 @@ type RotationPolicyEvaluation struct {
 	IsApproaching bool       `json:"is_approaching"`
 }
 
-func (c *KeyorixCore) CreateRotationPolicy(ctx context.Context, req *CreateRotationPolicyRequest) (*models.RotationPolicy, error) {
+// Rotation-policy lifecycle audit event types. Like other governance mutations,
+// policy create/update/delete are recorded in the audit log.
+const (
+	EventRotationPolicyCreated = "rotation_policy.created"
+	EventRotationPolicyUpdated = "rotation_policy.updated"
+	EventRotationPolicyDeleted = "rotation_policy.deleted"
+)
+
+// CreateRotationPolicy creates a rotation policy. actorID is the admin performing it
+// (0 = no authenticated principal).
+func (c *KeyorixCore) CreateRotationPolicy(ctx context.Context, actorID uint, req *CreateRotationPolicyRequest) (*models.RotationPolicy, error) {
 	if req.Scope == "environment" && req.EnvironmentID == nil {
 		return nil, fmt.Errorf("environment_id is required when scope is 'environment'")
 	}
@@ -70,6 +80,8 @@ func (c *KeyorixCore) CreateRotationPolicy(ctx context.Context, req *CreateRotat
 	if err := c.storage.CreateRotationPolicy(ctx, policy); err != nil {
 		return nil, fmt.Errorf("failed to create rotation policy: %w", err)
 	}
+	c.writeAuditEvent(ctx, EventRotationPolicyCreated, actorPtr(actorID), nil,
+		fmt.Sprintf("rotation policy %q (id %d, %s scope) created", policy.Name, policy.ID, policy.Scope))
 	return policy, nil
 }
 
@@ -89,7 +101,8 @@ func (c *KeyorixCore) ListRotationPolicies(ctx context.Context, projectID *uint,
 	return policies, nil
 }
 
-func (c *KeyorixCore) UpdateRotationPolicy(ctx context.Context, req *UpdateRotationPolicyRequest) (*models.RotationPolicy, error) {
+// UpdateRotationPolicy updates a rotation policy. See CreateRotationPolicy for actorID.
+func (c *KeyorixCore) UpdateRotationPolicy(ctx context.Context, actorID uint, req *UpdateRotationPolicyRequest) (*models.RotationPolicy, error) {
 	if req.AlertDaysBefore >= req.IntervalDays {
 		return nil, fmt.Errorf("alert_days_before must be less than interval_days")
 	}
@@ -109,16 +122,22 @@ func (c *KeyorixCore) UpdateRotationPolicy(ctx context.Context, req *UpdateRotat
 	if err := c.storage.UpdateRotationPolicy(ctx, policy); err != nil {
 		return nil, fmt.Errorf("failed to update rotation policy: %w", err)
 	}
+	c.writeAuditEvent(ctx, EventRotationPolicyUpdated, actorPtr(actorID), nil,
+		fmt.Sprintf("rotation policy %q (id %d) updated", policy.Name, policy.ID))
 	return policy, nil
 }
 
-func (c *KeyorixCore) DeleteRotationPolicy(ctx context.Context, id uint) error {
-	if _, err := c.storage.GetRotationPolicy(ctx, id); err != nil {
+// DeleteRotationPolicy deletes a rotation policy. See CreateRotationPolicy for actorID.
+func (c *KeyorixCore) DeleteRotationPolicy(ctx context.Context, actorID, id uint) error {
+	policy, err := c.storage.GetRotationPolicy(ctx, id)
+	if err != nil {
 		return fmt.Errorf("failed to get rotation policy: %w", err)
 	}
 	if err := c.storage.DeleteRotationPolicy(ctx, id); err != nil {
 		return fmt.Errorf("failed to delete rotation policy: %w", err)
 	}
+	c.writeAuditEvent(ctx, EventRotationPolicyDeleted, actorPtr(actorID), nil,
+		fmt.Sprintf("rotation policy %q (id %d) deleted", policy.Name, id))
 	return nil
 }
 

--- a/internal/core/rotation_policies_audit_test.go
+++ b/internal/core/rotation_policies_audit_test.go
@@ -1,0 +1,51 @@
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// Rotation-policy CRUD must be audited (create/update/delete) — previously these
+// wrote nothing, completing the governance-audit gap alongside roles and groups.
+func TestRotationPolicyCRUDAudit(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.RotationPolicy{}, &models.AuditEvent{}))
+	c := &KeyorixCore{storage: store.NewLocalStorage(db)}
+	ctx := context.Background()
+
+	count := func(eventType string) int64 {
+		var n int64
+		require.NoError(t, db.Model(&models.AuditEvent{}).Where("event_type = ?", eventType).Count(&n).Error)
+		return n
+	}
+
+	pid := uint(1)
+	p, err := c.CreateRotationPolicy(ctx, 9, &CreateRotationPolicyRequest{
+		Name: "90-day", Scope: "project", ProjectID: &pid,
+		IntervalDays: 90, AlertDaysBefore: 7, CreatedBy: "admin",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), count(EventRotationPolicyCreated))
+
+	var ev models.AuditEvent
+	require.NoError(t, db.Where("event_type = ?", EventRotationPolicyCreated).First(&ev).Error)
+	require.NotNil(t, ev.UserID)
+	assert.Equal(t, uint(9), *ev.UserID, "acting admin recorded")
+
+	_, err = c.UpdateRotationPolicy(ctx, 9, &UpdateRotationPolicyRequest{
+		ID: p.ID, Name: "60-day", IntervalDays: 60, AlertDaysBefore: 7, IsActive: true,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), count(EventRotationPolicyUpdated))
+
+	require.NoError(t, c.DeleteRotationPolicy(ctx, 9, p.ID))
+	assert.Equal(t, int64(1), count(EventRotationPolicyDeleted))
+}

--- a/server/http/handlers/rotation_policies_handler.go
+++ b/server/http/handlers/rotation_policies_handler.go
@@ -159,7 +159,7 @@ func (h *RotationPolicyHandler) Create(w http.ResponseWriter, r *http.Request) {
 		CreatedBy:       userCtx.Username,
 	}
 
-	policy, err := h.coreService.CreateRotationPolicy(r.Context(), req)
+	policy, err := h.coreService.CreateRotationPolicy(r.Context(), userCtx.UserID, req)
 	if err != nil {
 		log.Printf("Error creating rotation policy: %v", err)
 		if strings.Contains(err.Error(), "required") || strings.Contains(err.Error(), "must be less than") {
@@ -246,7 +246,7 @@ func (h *RotationPolicyHandler) Update(w http.ResponseWriter, r *http.Request) {
 		IsActive:        reqBody.IsActive,
 	}
 
-	policy, err := h.coreService.UpdateRotationPolicy(r.Context(), req)
+	policy, err := h.coreService.UpdateRotationPolicy(r.Context(), userCtx.UserID, req)
 	if err != nil {
 		log.Printf("Error updating rotation policy: %v", err)
 		if strings.Contains(err.Error(), "not found") {
@@ -277,7 +277,7 @@ func (h *RotationPolicyHandler) Delete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := h.coreService.DeleteRotationPolicy(r.Context(), uint(id)); err != nil {
+	if err := h.coreService.DeleteRotationPolicy(r.Context(), userCtx.UserID, uint(id)); err != nil {
 		log.Printf("Error deleting rotation policy: %v", err)
 		if strings.Contains(err.Error(), "not found") {
 			h.sendError(w, "NotFound", "Rotation policy not found", http.StatusNotFound, nil)

--- a/server/http/handlers/rotation_policies_simple_test.go
+++ b/server/http/handlers/rotation_policies_simple_test.go
@@ -118,7 +118,7 @@ func TestRotationPolicyDelete204(t *testing.T) {
 	handler, coreService := setupRotationPolicyTest(t)
 
 	projectID := uint(1)
-	policy, err := coreService.CreateRotationPolicy(context.Background(), &core.CreateRotationPolicyRequest{
+	policy, err := coreService.CreateRotationPolicy(context.Background(), 1, &core.CreateRotationPolicyRequest{
 		Name:            "To Delete",
 		Scope:           "project",
 		ProjectID:       &projectID,


### PR DESCRIPTION
## What

Rotation-policy CRUD mutated storage with **no audit event** — completing the governance-audit gap closed for roles (#396) and groups (#397). Policy changes alter the rotation/compliance posture of every covered secret, so they belong in the audit log.

## How

- New `rotation_policy.created` / `.updated` / `.deleted` events.
- Threaded an `actorID` through the three core methods; emit the event after a successful mutation (via the shared `writeAuditEvent`). The only callers are the HTTP handlers (no CLI), which pass the authenticated user.

## Tests
- Create / update / delete each write their event, with the acting admin recorded.

Local gates: build, `go vet`, `gofmt`, golangci-lint **0**, gosec **0**; core + handler packages green.

## Governance-audit theme complete
Roles (#396), groups (#397), and rotation policies (this) are now all audited. Remaining recon-vein items: pagination on unbounded list endpoints, and rotation-policy update silently ignoring scope fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)