### PR TITLE
release: prep v0.73.0 (CHANGELOG + Helm charts 0.73.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,27 @@
 All notable changes to Keyorix are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## v0.73.0 — 2026-06-21
+
+Complete audit coverage for governance mutations.
+
+### Added
+- **Role-definition changes are audited** — creating, updating, or deleting a role
+  now records `role.created` / `role.updated` / `role.deleted` in the RBAC audit
+  log, closing a gap where role definitions (which control what privileges exist)
+  changed without a trace, even though role assignments were already audited.
+  ([#396])
+- **Group changes are audited** — `group.created` / `group.updated` /
+  `group.deleted` on the API/CLI path, matching the SCIM provisioning path which
+  already audited. ([#397])
+- **Rotation-policy changes are audited** — `rotation_policy.created` /
+  `.updated` / `.deleted`, so changes to a policy's rotation/compliance posture
+  for its covered secrets are traceable. ([#398])
+
+[#396]: https://github.com/keyorixhq/keyorix/pull/396
+[#397]: https://github.com/keyorixhq/keyorix/pull/397
+[#398]: https://github.com/keyorixhq/keyorix/pull/398
+
 ## v0.72.0 — 2026-06-21
 
 Access visibility and operator controls over HTTP.

--- a/deploy/helm/keyorix-k8s-sync/Chart.yaml
+++ b/deploy/helm/keyorix-k8s-sync/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix-k8s-sync
 description: Keyorix Kubernetes sync agent — materialises Keyorix secrets into native Kubernetes Secrets
 type: application
 # Chart version — tracks the Keyorix release version (published in lockstep).
-version: 0.72.0
+version: 0.73.0
 # The keyorix-k8s-sync image tag this chart deploys by default.
-appVersion: "0.72.0"
+appVersion: "0.73.0"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix

--- a/deploy/helm/keyorix/Chart.yaml
+++ b/deploy/helm/keyorix/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix
 description: Self-hosted Keyorix secrets manager (API server + web UI + PostgreSQL)
 type: application
 # Chart version — bump on chart changes.
-version: 0.72.0
+version: 0.73.0
 # The Keyorix app version this chart deploys by default (the image tag).
-appVersion: "0.72.0"
+appVersion: "0.73.0"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix


### PR DESCRIPTION
Release prep for **v0.73.0** — CHANGELOG entry + both Helm charts bumped to 0.73.0 (lockstep).

## Included since v0.72.0 — complete audit coverage for governance mutations
- **Role-definition changes audited** — `role.created/updated/deleted`. ([#396])
- **Group changes audited** — `group.created/updated/deleted`. ([#397])
- **Rotation-policy changes audited** — `rotation_policy.created/updated/deleted`. ([#398])

Closes the gap where these governance objects changed without an audit trail, even though secrets/shares/SCIM were already audited.

Charts bumped lockstep: `keyorix` and `keyorix-k8s-sync` → 0.73.0. `helm lint` clean. Tag `v0.73.0` pushed after merge to trigger the release + image-publish workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)