### PR TITLE
fix(secrets): enforce max_reads atomically (close concurrent-read bypass)

### DIFF
--- a/internal/core/max_reads_enforce_test.go
+++ b/internal/core/max_reads_enforce_test.go
@@ -1,0 +1,92 @@
+package core
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func newMaxReadsCore(t *testing.T) (*KeyorixCore, *gorm.DB) {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	sqlDB, _ := db.DB()
+	sqlDB.SetMaxOpenConns(1) // sqlite: serialize connections (statements stay atomic)
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}))
+	return &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}, db
+}
+
+// seedMaxReadsSecret creates a secret with the given max_reads and one version.
+func seedMaxReadsSecret(t *testing.T, c *KeyorixCore, max int) uint {
+	t.Helper()
+	ctx := context.Background()
+	maxReads := max
+	s, err := c.storage.CreateSecret(ctx, &models.SecretNode{
+		Name: "one-shot", ProjectID: 1, EnvironmentID: 1, Type: "password",
+		IsSecret: true, MaxReads: &maxReads, CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	})
+	require.NoError(t, err)
+	_, err = c.storage.CreateSecretVersion(ctx, &models.SecretVersion{
+		SecretNodeID: s.ID, VersionNumber: 1, EncryptedValue: []byte("v"),
+	})
+	require.NoError(t, err)
+	return s.ID
+}
+
+func TestMaxReads_SequentialStopsAtCap(t *testing.T) {
+	c, _ := newMaxReadsCore(t)
+	id := seedMaxReadsSecret(t, c, 3)
+	ctx := context.Background()
+
+	for i := 0; i < 3; i++ {
+		_, err := c.GetSecretValue(ctx, id)
+		require.NoError(t, err, "read %d should be within the cap", i+1)
+	}
+	_, err := c.GetSecretValue(ctx, id)
+	require.Error(t, err, "the 4th read must be denied")
+	assert.Contains(t, err.Error(), i18n.T("ErrorMaxReadsExceeded", nil))
+}
+
+// The race fix: N concurrent reads of a max-reads=K secret must yield exactly K
+// successes, never more. Before the atomic check-and-increment, concurrent readers
+// could all pass the in-memory check and exceed the cap.
+func TestMaxReads_ConcurrentNeverExceedsCap(t *testing.T) {
+	c, db := newMaxReadsCore(t)
+	const cap = 5
+	const readers = 50
+	id := seedMaxReadsSecret(t, c, cap)
+
+	var success int64
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for i := 0; i < readers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			if _, err := c.GetSecretValue(context.Background(), id); err == nil {
+				atomic.AddInt64(&success, 1)
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	assert.Equal(t, int64(cap), success, "exactly cap reads may succeed under concurrency")
+
+	// The persisted read_count must never overshoot the cap either.
+	var v models.SecretVersion
+	require.NoError(t, db.Where("secret_node_id = ?", id).First(&v).Error)
+	assert.LessOrEqual(t, v.ReadCount, cap, "read_count must not exceed the cap")
+}

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -518,6 +518,11 @@ func (m *MockStorage) IncrementSecretReadCount(ctx context.Context, versionID ui
 	return args.Error(0)
 }
 
+func (m *MockStorage) TryIncrementSecretReadCount(ctx context.Context, versionID uint, maxReads int) (bool, error) {
+	args := m.Called(ctx, versionID, maxReads)
+	return args.Bool(0), args.Error(1)
+}
+
 // Secret Sharing Management
 
 func (m *MockStorage) CreateShareRecord(ctx context.Context, share *models.ShareRecord) (*models.ShareRecord, error) {

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -208,6 +208,12 @@ type Storage interface {
 	CreateSecretVersion(ctx context.Context, version *models.SecretVersion) (*models.SecretVersion, error)
 	GetLatestSecretVersion(ctx context.Context, secretID uint) (*models.SecretVersion, error)
 	IncrementSecretReadCount(ctx context.Context, versionID uint) error
+	// TryIncrementSecretReadCount atomically increments a version's read count only
+	// while it is still below maxReads, in a single conditional UPDATE. Returns true
+	// when the increment happened (the read is within the cap), false when the cap is
+	// already reached (or the version is gone). This is the race-free gate for
+	// max-reads enforcement: concurrent reads can never collectively exceed the cap.
+	TryIncrementSecretReadCount(ctx context.Context, versionID uint, maxReads int) (bool, error)
 
 	// Secret Sharing Management
 	CreateShareRecord(ctx context.Context, share *models.ShareRecord) (*models.ShareRecord, error)

--- a/internal/core/versions.go
+++ b/internal/core/versions.go
@@ -207,10 +207,16 @@ func (c *KeyorixCore) GetSecretValueByVersionWithPermissionCheck(ctx context.Con
 // Shared by GetSecretValue and GetSecretValueWithPermissionCheck.
 func (c *KeyorixCore) readVersionValue(ctx context.Context, secret *models.SecretNode, version *models.SecretVersion) ([]byte, error) {
 	if secret.MaxReads != nil && *secret.MaxReads > 0 {
-		if version.ReadCount >= *secret.MaxReads {
+		// Atomic check-and-increment: the conditional UPDATE serializes concurrent
+		// reads on the row, so they can never collectively exceed the cap. Fail closed
+		// — if enforcement can't be confirmed, don't hand back the value.
+		ok, err := c.storage.TryIncrementSecretReadCount(ctx, version.ID, *secret.MaxReads)
+		if err != nil {
+			return nil, fmt.Errorf("max-reads enforcement failed: %w", err)
+		}
+		if !ok {
 			return nil, fmt.Errorf("%s", i18n.T("ErrorMaxReadsExceeded", nil))
 		}
-		_ = c.storage.IncrementSecretReadCount(ctx, version.ID) // non-fatal; don't fail the read
 	}
 	if c.encryption != nil {
 		return c.encryption.RetrieveSecret(version.ID)

--- a/internal/storage/store/local_secrets.go
+++ b/internal/storage/store/local_secrets.go
@@ -475,3 +475,17 @@ func (ls *LocalStorage) IncrementSecretReadCount(ctx context.Context, versionID 
 	}
 	return nil
 }
+
+// TryIncrementSecretReadCount atomically increments read_count only while it is
+// still below maxReads. The conditional WHERE makes check-and-increment a single
+// row-level-serialized UPDATE, so concurrent reads of a max-reads secret can never
+// collectively exceed the cap. RowsAffected==1 means this read is within the cap.
+func (ls *LocalStorage) TryIncrementSecretReadCount(ctx context.Context, versionID uint, maxReads int) (bool, error) {
+	res := ls.db.WithContext(ctx).Model(&models.SecretVersion{}).
+		Where("id = ? AND read_count < ?", versionID, maxReads).
+		UpdateColumn("read_count", gorm.Expr("read_count + 1"))
+	if res.Error != nil {
+		return false, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), res.Error)
+	}
+	return res.RowsAffected == 1, nil
+}

--- a/internal/storage/store/remote_secrets.go
+++ b/internal/storage/store/remote_secrets.go
@@ -285,3 +285,15 @@ func (rs *RemoteStorage) IncrementSecretReadCount(ctx context.Context, versionID
 	}
 	return nil
 }
+
+// TryIncrementSecretReadCount is server-side enforcement: the authoritative,
+// race-free max-reads gate runs in the server against its local storage. The remote
+// value-read path goes through the server's API (which enforces there), so this
+// method is not on a remote value-read hot path; delegate the increment and report
+// success. Errors propagate so the caller can fail closed.
+func (rs *RemoteStorage) TryIncrementSecretReadCount(ctx context.Context, versionID uint, _ int) (bool, error) {
+	if err := rs.IncrementSecretReadCount(ctx, versionID); err != nil {
+		return false, err
+	}
+	return true, nil
+}


### PR DESCRIPTION
## The bug (security correctness, HIGH)

`max_reads` enforcement was a **check-then-act race**. In `readVersionValue`:

```go
if version.ReadCount >= *secret.MaxReads { return ...exceeded }
_ = c.storage.IncrementSecretReadCount(ctx, version.ID) // non-fatal; don't fail the read
```

- **Race:** two concurrent reads of a `max_reads=N` secret both see `ReadCount < N`, both pass, both increment — the value is returned **more than N times**, defeating one-time / limited-use secrets.
- **Fail-open:** the increment error was ignored, so a storage hiccup meant the counter never advanced → effectively unlimited reads.

## The fix

Atomic compare-and-swap at the storage layer — new `TryIncrementSecretReadCount(versionID, maxReads)` does a single conditional UPDATE:

```sql
UPDATE secret_versions SET read_count = read_count + 1 WHERE id = ? AND read_count < ?
```

`RowsAffected == 1` ⇒ the read is within the cap. Concurrent reads **serialize on the row**, so they can never collectively exceed the cap. `readVersionValue` now **fails closed** — if enforcement can't be confirmed, it returns an error instead of the value. Remote storage delegates to the server, which enforces atomically against its local storage.

## Tests
- Sequential reads stop at the cap (4th read of a cap-3 secret denied).
- **Concurrency:** 50 concurrent reads of a cap-5 secret yield **exactly 5** successes and `read_count` never overshoots — passes `-race` (×3).

Local gates: build, `go vet`, `gofmt`, golangci-lint **0**, gosec **0**; core + storage packages green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)