### PR TITLE
release: prep v0.73.1 (CHANGELOG + Helm charts 0.73.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to Keyorix are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## v0.73.1 — 2026-06-22
+
+Security fix.
+
+### Fixed
+- **max_reads is now enforced atomically** — a limited-use secret could be read
+  more than its `max_reads` cap under concurrent requests (a check-then-act race),
+  and a storage error on the read-counter update failed open. Reads are now gated
+  by a single atomic conditional update and fail closed, so concurrent reads can
+  never collectively exceed the cap. ([#400])
+
+[#400]: https://github.com/keyorixhq/keyorix/pull/400
+
 ## v0.73.0 — 2026-06-21
 
 Complete audit coverage for governance mutations.

--- a/deploy/helm/keyorix-k8s-sync/Chart.yaml
+++ b/deploy/helm/keyorix-k8s-sync/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix-k8s-sync
 description: Keyorix Kubernetes sync agent — materialises Keyorix secrets into native Kubernetes Secrets
 type: application
 # Chart version — tracks the Keyorix release version (published in lockstep).
-version: 0.73.0
+version: 0.73.1
 # The keyorix-k8s-sync image tag this chart deploys by default.
-appVersion: "0.73.0"
+appVersion: "0.73.1"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix

--- a/deploy/helm/keyorix/Chart.yaml
+++ b/deploy/helm/keyorix/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix
 description: Self-hosted Keyorix secrets manager (API server + web UI + PostgreSQL)
 type: application
 # Chart version — bump on chart changes.
-version: 0.73.0
+version: 0.73.1
 # The Keyorix app version this chart deploys by default (the image tag).
-appVersion: "0.73.0"
+appVersion: "0.73.1"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix


### PR DESCRIPTION
Patch release prep for **v0.73.1** — a security fix.

## Included since v0.73.0
- **max_reads enforced atomically** — closes a concurrent-read bypass (check-then-act race) and fails closed on a read-counter error. ([#400])

Charts bumped lockstep: `keyorix` and `keyorix-k8s-sync` → 0.73.1. `helm lint` clean. Tag `v0.73.1` pushed after merge to trigger the release + image-publish workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)