### PR TITLE
feat(audit): record secret/project/environment restore

### DIFF
--- a/internal/core/catalog.go
+++ b/internal/core/catalog.go
@@ -90,9 +90,15 @@ func (c *KeyorixCore) DeleteProject(ctx context.Context, id uint, force bool) er
 }
 
 // RestoreProject reverses a soft-delete, bringing back the project and the
-// environments and secrets that were removed with it.
-func (c *KeyorixCore) RestoreProject(ctx context.Context, id uint) error {
-	return c.storage.RestoreProject(ctx, id)
+// environments and secrets that were removed with it. actorID is the acting admin
+// (0 = none). Audited as project.restored.
+func (c *KeyorixCore) RestoreProject(ctx context.Context, actorID, id uint) error {
+	if err := c.storage.RestoreProject(ctx, id); err != nil {
+		return err
+	}
+	pid := id
+	c.writeAuditEventFull(ctx, "project.restored", actorPtr(actorID), nil, &pid, "", fmt.Sprintf("project %d restored", id))
+	return nil
 }
 
 // DeleteEnvironment deletes an environment by ID.
@@ -102,8 +108,14 @@ func (c *KeyorixCore) DeleteEnvironment(ctx context.Context, id uint) error {
 
 // RestoreEnvironment clears the soft-delete on an environment, scoped to
 // projectID so a caller authorized for one project cannot restore another's.
-func (c *KeyorixCore) RestoreEnvironment(ctx context.Context, projectID, id uint) error {
-	return c.storage.RestoreEnvironment(ctx, projectID, id)
+// actorID is the acting admin (0 = none). Audited as environment.restored.
+func (c *KeyorixCore) RestoreEnvironment(ctx context.Context, actorID, projectID, id uint) error {
+	if err := c.storage.RestoreEnvironment(ctx, projectID, id); err != nil {
+		return err
+	}
+	pid := projectID
+	c.writeAuditEventFull(ctx, "environment.restored", actorPtr(actorID), nil, &pid, "", fmt.Sprintf("environment %d restored in project %d", id, projectID))
+	return nil
 }
 
 // CreateProject creates a new project and seeds it with default environments.

--- a/internal/core/restore_audit_test.go
+++ b/internal/core/restore_audit_test.go
@@ -1,0 +1,61 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// Restore operations must be audited (the inverse of the delete events), so a
+// soft-deleted secret/project/environment reappearing leaves a trail.
+func TestRestoreOperationsAudit(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.SecretNode{}, &models.SecretVersion{}, &models.Project{}, &models.Environment{}, &models.AuditEvent{},
+	))
+	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
+	ctx := context.Background()
+
+	auditActor := func(eventType string) *uint {
+		var ev models.AuditEvent
+		require.NoError(t, db.Where("event_type = ?", eventType).First(&ev).Error, "expected a %s event", eventType)
+		return ev.UserID
+	}
+
+	t.Run("secret.restored", func(t *testing.T) {
+		s, err := c.storage.CreateSecret(ctx, &models.SecretNode{Name: "k", ProjectID: 1, EnvironmentID: 999, IsSecret: true, CreatedAt: time.Now(), UpdatedAt: time.Now()})
+		require.NoError(t, err)
+		require.NoError(t, c.storage.DeleteSecret(ctx, s.ID))
+		require.NoError(t, c.RestoreSecret(ctx, 42, s.ID))
+		require.NotNil(t, auditActor("secret.restored"))
+		assert.Equal(t, uint(42), *auditActor("secret.restored"))
+	})
+
+	t.Run("project.restored", func(t *testing.T) {
+		p, err := c.storage.CreateProject(ctx, &models.Project{Name: "proj"})
+		require.NoError(t, err)
+		require.NoError(t, c.storage.DeleteProject(ctx, p.ID))
+		require.NoError(t, c.RestoreProject(ctx, 42, p.ID))
+		require.NotNil(t, auditActor("project.restored"))
+	})
+
+	t.Run("environment.restored", func(t *testing.T) {
+		p, err := c.storage.CreateProject(ctx, &models.Project{Name: "proj2"})
+		require.NoError(t, err)
+		e, err := c.storage.CreateEnvironment(ctx, &models.Environment{Name: "staging", ProjectID: p.ID})
+		require.NoError(t, err)
+		require.NoError(t, c.storage.DeleteEnvironment(ctx, e.ID))
+		require.NoError(t, c.RestoreEnvironment(ctx, 42, p.ID, e.ID))
+		require.NotNil(t, auditActor("environment.restored"))
+	})
+}

--- a/internal/core/secrets.go
+++ b/internal/core/secrets.go
@@ -256,14 +256,18 @@ func (c *KeyorixCore) DeleteSecretWithPermissionCheck(ctx context.Context, id, u
 }
 
 // RestoreSecret clears a soft-deleted secret's deleted_at (ADR-033), bringing it
-// back within the retention window.
-func (c *KeyorixCore) RestoreSecret(ctx context.Context, id uint) error {
+// back within the retention window. actorID is the admin performing it (0 = no
+// authenticated principal). Audited as secret.restored — the inverse of the
+// secret.deleted event, so a deleted secret reappearing leaves a trail.
+func (c *KeyorixCore) RestoreSecret(ctx context.Context, actorID, id uint) error {
 	if id == 0 {
 		return fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "secret ID is required")
 	}
 	if err := c.storage.RestoreSecret(ctx, id); err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}
+	sid := id
+	c.writeAuditEvent(ctx, "secret.restored", actorPtr(actorID), &sid, fmt.Sprintf("secret %d restored", id))
 	return nil
 }
 

--- a/server/http/handlers/catalog.go
+++ b/server/http/handlers/catalog.go
@@ -9,7 +9,16 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/server/middleware"
 )
+
+// actorID returns the acting user's ID from the request context (0 when absent).
+func actorID(r *http.Request) uint {
+	if u := middleware.GetUserFromContext(r.Context()); u != nil {
+		return u.UserID
+	}
+	return 0
+}
 
 // CatalogHandler handles project and environment endpoints.
 type CatalogHandler struct {
@@ -42,7 +51,7 @@ func (h *CatalogHandler) RestoreProject(w http.ResponseWriter, r *http.Request) 
 		sendError(w, "InvalidParameter", "Invalid project ID", http.StatusBadRequest, nil)
 		return
 	}
-	if err := h.coreService.RestoreProject(r.Context(), uint(id)); err != nil {
+	if err := h.coreService.RestoreProject(r.Context(), actorID(r), uint(id)); err != nil {
 		status := http.StatusInternalServerError
 		if strings.Contains(err.Error(), "not found") {
 			status = http.StatusNotFound
@@ -269,7 +278,7 @@ func (h *CatalogHandler) RestoreEnvironment(w http.ResponseWriter, r *http.Reque
 		sendError(w, "InvalidParameter", "Invalid environment ID", http.StatusBadRequest, nil)
 		return
 	}
-	if err := h.coreService.RestoreEnvironment(r.Context(), uint(projectID), uint(id)); err != nil {
+	if err := h.coreService.RestoreEnvironment(r.Context(), actorID(r), uint(projectID), uint(id)); err != nil {
 		status := http.StatusInternalServerError
 		if strings.Contains(err.Error(), "not found") {
 			status = http.StatusNotFound

--- a/server/http/handlers/secrets_crud.go
+++ b/server/http/handlers/secrets_crud.go
@@ -253,7 +253,8 @@ func (h *SecretHandler) GetSecret(w http.ResponseWriter, r *http.Request) {
 // soft-deleted secret's deleted_at (ADR-033). Authorized by the route's scoped
 // secrets.write gate at the secret's own project/environment.
 func (h *SecretHandler) RestoreSecret(w http.ResponseWriter, r *http.Request) {
-	if middleware.GetUserFromContext(r.Context()) == nil {
+	userCtx := middleware.GetUserFromContext(r.Context())
+	if userCtx == nil {
 		h.sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
 		return
 	}
@@ -262,7 +263,7 @@ func (h *SecretHandler) RestoreSecret(w http.ResponseWriter, r *http.Request) {
 		h.sendError(w, "InvalidParameter", "Invalid secret ID", http.StatusBadRequest, nil)
 		return
 	}
-	if err := h.coreService.RestoreSecret(r.Context(), uint(id)); err != nil {
+	if err := h.coreService.RestoreSecret(r.Context(), userCtx.UserID, uint(id)); err != nil {
 		status := http.StatusInternalServerError
 		if strings.Contains(err.Error(), "not found") {
 			status = http.StatusNotFound


### PR DESCRIPTION
## What

Soft-delete is audited (`secret.deleted`), but the inverse — **restoring** a soft-deleted secret, project, or environment — wrote nothing. A deleted object reappearing left no trail, an asymmetry in the audit/forensics record (a recon pass flagged restore as the unaudited half of the lifecycle).

## How

- New `secret.restored` / `project.restored` / `environment.restored` events.
- Threaded an `actorID` through the three core `Restore*` methods; emit the event after a successful restore.
- The secret-restore handler now passes the authenticated user; the catalog restore handlers gain a small `actorID(r)` helper (returns 0 when no user context).

## Tests
- Each restore writes its event; the acting admin is recorded on `secret.restored`.

Local gates: build, `go vet`, `gofmt`, golangci-lint **0**, gosec **0**; core + handler + CLI packages green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)