### PR TITLE
fix(sharing): exclude expired shares from a secret's share list

### DIFF
--- a/internal/core/sharing_query.go
+++ b/internal/core/sharing_query.go
@@ -41,7 +41,9 @@ func (c *KeyorixCore) ListSecretShares(ctx context.Context, secretID uint) ([]*m
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}
-	return shares, nil
+	// Drop expired time-bound shares so the list matches what actually authorizes
+	// (every enforcement path filters via activeShares); they're swept separately.
+	return activeShares(shares, c.now()), nil
 }
 
 // ListSecretSharesWithPermissionCheck lists a secret's shares, but only for its
@@ -64,7 +66,8 @@ func (c *KeyorixCore) ListSecretSharesWithPermissionCheck(ctx context.Context, s
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}
-	return shares, nil
+	// Drop expired time-bound shares — see ListSecretShares.
+	return activeShares(shares, c.now()), nil
 }
 
 // ListSharesByUser lists shares involving the user (received as recipient + outgoing as owner).

--- a/internal/core/sharing_test.go
+++ b/internal/core/sharing_test.go
@@ -298,6 +298,7 @@ func TestKeyorixCore_ListSecretShares(t *testing.T) {
 	mockStorage := new(MockStorage)
 	core := &KeyorixCore{
 		storage: mockStorage,
+		now:     time.Now,
 	}
 	ctx := context.Background()
 
@@ -323,6 +324,32 @@ func TestKeyorixCore_ListSecretShares(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, shares, result)
 	mockStorage.AssertExpectations(t)
+}
+
+// ListSecretShares must drop expired time-bound shares so the list matches what
+// actually authorizes (the enforcement paths filter the same way).
+func TestKeyorixCore_ListSecretShares_FiltersExpired(t *testing.T) {
+	now := time.Date(2026, 6, 22, 12, 0, 0, 0, time.UTC)
+	past := now.Add(-1 * time.Hour)
+	future := now.Add(1 * time.Hour)
+	mockStorage := new(MockStorage)
+	core := &KeyorixCore{storage: mockStorage, now: func() time.Time { return now }}
+	ctx := context.Background()
+
+	mockStorage.On("GetSecret", ctx, uint(1)).Return(&models.SecretNode{ID: 1, OwnerID: 1}, nil)
+	mockStorage.On("ListSharesBySecret", ctx, uint(1)).Return([]*models.ShareRecord{
+		{ID: 1, SecretID: 1, RecipientID: 2, Permission: "read"},                     // permanent
+		{ID: 2, SecretID: 1, RecipientID: 3, Permission: "read", ExpiresAt: &past},   // expired → dropped
+		{ID: 3, SecretID: 1, RecipientID: 4, Permission: "read", ExpiresAt: &future}, // live time-bound
+	}, nil)
+
+	result, err := core.ListSecretShares(ctx, 1)
+	require.NoError(t, err)
+	ids := make([]uint, 0, len(result))
+	for _, s := range result {
+		ids = append(ids, s.ID)
+	}
+	assert.Equal(t, []uint{1, 3}, ids, "the expired share is excluded")
 }
 
 func TestKeyorixCore_ListSharesByUser(t *testing.T) {


### PR DESCRIPTION
## What

`ListSecretShares` / `ListSecretSharesWithPermissionCheck` returned shares straight from storage, **including expired time-bound shares** — while every authorization path filters them via `activeShares`, and the recipient-side "shared with me" list already excludes them at the storage query. So an expired share appeared in a secret's share list as if it still granted access, until the JIT sweep removed the row.

## How

Filter both list functions through `activeShares(c.now())` so the list matches what actually authorizes. (Expired rows are still swept separately by the scheduler.)

## Tests
- A secret's share list drops an expired time-bound share, keeping the permanent and still-valid ones.
- Updated the existing `ListSecretShares` unit test to set `now` (the function now reads the clock).

Local gates: build, `go vet`, `gofmt`, golangci-lint **0**, gosec **0**; core + handler + CLI packages green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)