### PR TITLE
feat(validation): bound description length on projects, groups, rotation policies

### DIFF
--- a/internal/core/catalog.go
+++ b/internal/core/catalog.go
@@ -32,6 +32,9 @@ func (c *KeyorixCore) UpdateProject(ctx context.Context, id uint, name, descript
 	if name == "" {
 		return nil, fmt.Errorf("project name is required")
 	}
+	if err := validateDescription(description); err != nil {
+		return nil, err
+	}
 	project, err := c.storage.GetProject(ctx, id)
 	if err != nil {
 		return nil, err
@@ -123,6 +126,9 @@ func (c *KeyorixCore) CreateProject(ctx context.Context, name, description strin
 	if name == "" {
 		return nil, fmt.Errorf("project name is required")
 	}
+	if err := validateDescription(description); err != nil {
+		return nil, err
+	}
 	project, err := c.storage.CreateProject(ctx, &models.Project{Name: name, Description: description})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create project: %w", err)
@@ -164,6 +170,9 @@ func (c *KeyorixCore) GetEnvironment(ctx context.Context, id uint) (*models.Envi
 func (c *KeyorixCore) CreateProjectWithEnvs(ctx context.Context, name, description string, envNames []string) (*models.Project, error) {
 	if name == "" {
 		return nil, fmt.Errorf("project name is required")
+	}
+	if err := validateDescription(description); err != nil {
+		return nil, err
 	}
 	project, err := c.storage.CreateProject(ctx, &models.Project{Name: name, Description: description})
 	if err != nil {

--- a/internal/core/description_bounds_test.go
+++ b/internal/core/description_bounds_test.go
@@ -1,0 +1,45 @@
+package core
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestValidateDescription(t *testing.T) {
+	assert.NoError(t, validateDescription(""))
+	assert.NoError(t, validateDescription(strings.Repeat("x", maxSecretDescriptionLen)))
+	assert.Error(t, validateDescription(strings.Repeat("x", maxSecretDescriptionLen+1)))
+	// Whitespace is trimmed before measuring.
+	assert.NoError(t, validateDescription("  "+strings.Repeat("x", maxSecretDescriptionLen-2)+"  "))
+}
+
+// The cap is enforced at the governance create/update choke points (covers HTTP+CLI).
+func TestCreateProject_RejectsOverlongDescription(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.Project{}, &models.Environment{}, &models.Group{}, &models.AuditEvent{}))
+	c := NewKeyorixCore(store.NewLocalStorage(db))
+	ctx := context.Background()
+
+	_, err = c.CreateProject(ctx, "p", strings.Repeat("x", maxSecretDescriptionLen+1))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "description exceeds")
+
+	_, err = c.CreateGroup(ctx, 0, &CreateGroupRequest{Name: "g", Description: strings.Repeat("x", maxSecretDescriptionLen+1)})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "description exceeds")
+
+	// A normal description is accepted.
+	_, err = c.CreateProject(ctx, "ok", "a reasonable description")
+	require.NoError(t, err)
+}

--- a/internal/core/groups.go
+++ b/internal/core/groups.go
@@ -139,12 +139,12 @@ func (c *KeyorixCore) validateCreateGroupRequest(req *CreateGroupRequest) error 
 	if req.Name == "" {
 		return fmt.Errorf("group name is required")
 	}
-	return nil
+	return validateDescription(req.Description)
 }
 
 func (c *KeyorixCore) validateUpdateGroupRequest(req *UpdateGroupRequest) error {
 	if req.ID == 0 {
 		return fmt.Errorf("group ID is required")
 	}
-	return nil
+	return validateDescription(req.Description)
 }

--- a/internal/core/rotation_policies.go
+++ b/internal/core/rotation_policies.go
@@ -63,6 +63,9 @@ func (c *KeyorixCore) CreateRotationPolicy(ctx context.Context, actorID uint, re
 	if req.AlertDaysBefore >= req.IntervalDays {
 		return nil, fmt.Errorf("alert_days_before must be less than interval_days")
 	}
+	if err := validateDescription(req.Description); err != nil {
+		return nil, err
+	}
 
 	policy := &models.RotationPolicy{
 		Name:            req.Name,
@@ -105,6 +108,9 @@ func (c *KeyorixCore) ListRotationPolicies(ctx context.Context, projectID *uint,
 func (c *KeyorixCore) UpdateRotationPolicy(ctx context.Context, actorID uint, req *UpdateRotationPolicyRequest) (*models.RotationPolicy, error) {
 	if req.AlertDaysBefore >= req.IntervalDays {
 		return nil, fmt.Errorf("alert_days_before must be less than interval_days")
+	}
+	if err := validateDescription(req.Description); err != nil {
+		return nil, err
 	}
 
 	policy, err := c.storage.GetRotationPolicy(ctx, req.ID)

--- a/internal/core/secret_description.go
+++ b/internal/core/secret_description.go
@@ -16,6 +16,16 @@ import (
 // maxSecretDescriptionLen bounds the free-text note.
 const maxSecretDescriptionLen = 1024
 
+// validateDescription bounds a free-text description for governance entities
+// (projects, groups, rotation policies), matching the secret-description cap, so a
+// metadata field can't be used to bloat storage. Empty is allowed.
+func validateDescription(description string) error {
+	if len(strings.TrimSpace(description)) > maxSecretDescriptionLen {
+		return fmt.Errorf("description exceeds %d characters", maxSecretDescriptionLen)
+	}
+	return nil
+}
+
 // SetSecretDescription sets (or clears, with "") the secret's description. The actor
 // must be able to write the secret. The note is trimmed and length-bounded. Audited.
 func (c *KeyorixCore) SetSecretDescription(ctx context.Context, actorID, secretID uint, description string) (*models.SecretNode, error) {


### PR DESCRIPTION
## What

Secret descriptions were capped at 1024 chars, but **project**, **group**, and **rotation-policy** descriptions were unbounded — a metadata field that could be used to bloat storage. (A recon pass flagged these as the remaining unvalidated write paths.)

## How

- Shared `validateDescription` helper (same 1024-char cap as secrets) next to the existing constant.
- Enforced at the **core** create/update choke points — `CreateProject` / `CreateProjectWithEnvs` / `UpdateProject`, group create/update validators, and rotation-policy create/update — so both the HTTP and CLI paths are covered. Empty allowed; whitespace trimmed before measuring.

## Tests
- The helper bounds/allows correctly (empty, at-cap, over-cap, whitespace-trimmed).
- `CreateProject` and `CreateGroup` reject an over-length description and accept a normal one.

Local gates: build, `go vet`, `gofmt`, golangci-lint **0**, gosec **0**; core + handler + CLI packages green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)