### PR TITLE
feat(groups): soft-delete + restore (lifecycle parity, no auth leak)

### DIFF
--- a/internal/core/groups.go
+++ b/internal/core/groups.go
@@ -16,9 +16,10 @@ import (
 // Group lifecycle audit event types (API/CLI-driven; the SCIM provisioning path
 // has its own scim.group_* events). Surfaced in the audit log like other mutations.
 const (
-	EventGroupCreated = "group.created"
-	EventGroupUpdated = "group.updated"
-	EventGroupDeleted = "group.deleted"
+	EventGroupCreated  = "group.created"
+	EventGroupUpdated  = "group.updated"
+	EventGroupDeleted  = "group.deleted"
+	EventGroupRestored = "group.restored"
 )
 
 // CreateGroup creates a new group. actorID is the admin performing it (0 = no
@@ -87,6 +88,19 @@ func (c *KeyorixCore) DeleteGroup(ctx context.Context, actorID, id uint) error {
 	}
 	c.writeAuditEvent(ctx, EventGroupDeleted, actorPtr(actorID), nil,
 		fmt.Sprintf("group %q (id %d) deleted", group.Name, id))
+	return nil
+}
+
+// RestoreGroup reverses a soft-delete, bringing the group back with the role grants
+// and memberships it had at deletion. See CreateGroup for actorID semantics.
+func (c *KeyorixCore) RestoreGroup(ctx context.Context, actorID, id uint) error {
+	if id == 0 {
+		return fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "group ID is required")
+	}
+	if err := c.storage.RestoreGroup(ctx, id); err != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	c.writeAuditEvent(ctx, EventGroupRestored, actorPtr(actorID), nil, fmt.Sprintf("group %d restored", id))
 	return nil
 }
 

--- a/internal/core/groups_audit_test.go
+++ b/internal/core/groups_audit_test.go
@@ -51,6 +51,16 @@ func TestGroupCRUDAudit(t *testing.T) {
 	require.NoError(t, c.DeleteGroup(ctx, 42, g.ID))
 	n, _ = lastActor(EventGroupDeleted)
 	assert.Equal(t, int64(1), n)
+
+	require.NoError(t, c.RestoreGroup(ctx, 42, g.ID))
+	n, actor = lastActor(EventGroupRestored)
+	assert.Equal(t, int64(1), n)
+	require.NotNil(t, actor)
+	assert.Equal(t, uint(42), *actor)
+	// The restored group is retrievable again.
+	restored, err := c.GetGroup(ctx, g.ID)
+	require.NoError(t, err)
+	assert.Equal(t, g.ID, restored.ID)
 }
 
 // A CLI invocation (actorID 0) still audits, with no actor recorded.

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -766,6 +766,11 @@ func (m *MockStorage) DeleteGroup(ctx context.Context, id uint) error {
 	return args.Error(0)
 }
 
+func (m *MockStorage) RestoreGroup(ctx context.Context, id uint) error {
+	args := m.Called(ctx, id)
+	return args.Error(0)
+}
+
 func (m *MockStorage) ListGroups(ctx context.Context) ([]*models.Group, error) {
 	args := m.Called(ctx)
 	if args.Get(0) == nil {

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -286,6 +286,8 @@ type Storage interface {
 	GetGroup(ctx context.Context, id uint) (*models.Group, error)
 	UpdateGroup(ctx context.Context, group *models.Group) (*models.Group, error)
 	DeleteGroup(ctx context.Context, id uint) error
+	// RestoreGroup clears a soft-deleted group's deleted_at (with its grants/members).
+	RestoreGroup(ctx context.Context, id uint) error
 	ListGroups(ctx context.Context) ([]*models.Group, error)
 	AddUserToGroup(ctx context.Context, userID, groupID uint) error
 	RemoveUserFromGroup(ctx context.Context, userID, groupID uint) error

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -326,6 +326,7 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 	loginAttemptExists := tableExists(db, "login_attempts")
 	auditCkptExists := tableExists(db, "audit_checkpoints")
 	connectRefGrantExists := tableExists(db, "connect_ref_grants")
+	groupsExists := tableExists(db, "groups")
 
 	// Create rotation_policies if missing (additive, safe on existing DBs).
 	if !rotationExists {
@@ -584,11 +585,25 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 		}
 	}
 
+	// Groups gained soft-delete (DeletedAt) + a partial unique index on name. On an
+	// existing DB add the column and swap the plain unique index for the partial one
+	// (additive, idempotent); the full AutoMigrate below covers fresh DBs.
+	if groupsExists {
+		if m := db.Migrator(); !m.HasColumn(&models.Group{}, "DeletedAt") {
+			if err := m.AddColumn(&models.Group{}, "DeletedAt"); err != nil {
+				return fmt.Errorf("failed to add groups.deleted_at column: %w", err)
+			}
+		}
+		if err := ensureGroupNameIndex(db); err != nil {
+			return err
+		}
+	}
+
 	// Skip full AutoMigrate if already initialised (projects table present).
 	if projectsExists {
 		return nil
 	}
-	return db.AutoMigrate(
+	if err := db.AutoMigrate(
 		&models.Project{},
 		&models.Environment{},
 		&models.User{},
@@ -630,5 +645,25 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 		// feature). Including it here too made the full AutoMigrate re-inspect
 		// the already-created rotation_policies table, tripping the pgx
 		// "insufficient arguments" bug on a fresh DB's first boot.
-	)
+	); err != nil {
+		return err
+	}
+	// The Group model carries no plain unique tag on name; enforce uniqueness only
+	// among live groups via a partial index (so a soft-deleted name can be reused).
+	return ensureGroupNameIndex(db)
+}
+
+// ensureGroupNameIndex replaces any plain unique index on groups.name with a
+// partial unique index scoped to non-deleted rows, so a soft-deleted group's name
+// is freed for reuse while the group stays restorable. Idempotent; works on both
+// SQLite and Postgres (both support partial indexes and IF [NOT] EXISTS).
+func ensureGroupNameIndex(db *gorm.DB) error {
+	// Drop the legacy plain unique index from the old `unique` tag, if present.
+	if err := db.Exec("DROP INDEX IF EXISTS uni_groups_name").Error; err != nil {
+		return fmt.Errorf("failed to drop legacy groups name index: %w", err)
+	}
+	if err := db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS uniq_groups_name_active ON groups (name) WHERE deleted_at IS NULL").Error; err != nil {
+		return fmt.Errorf("failed to create partial groups name index: %w", err)
+	}
+	return nil
 }

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -397,9 +397,15 @@ type ConnectRefGrant struct {
 }
 
 type Group struct {
-	ID          uint   `gorm:"primaryKey"`
-	Name        string `gorm:"unique;not null"`
+	ID uint `gorm:"primaryKey"`
+	// Name uniqueness is enforced by a PARTIAL unique index (name WHERE deleted_at
+	// IS NULL), created in migrateDatabase — not the plain `unique` tag — so a
+	// soft-deleted group's name is freed for reuse while it stays restorable.
+	Name        string `gorm:"not null"`
 	Description string
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+	DeletedAt   gorm.DeletedAt `gorm:"index"` // soft delete (restorable)
 }
 
 type UserGroup struct {

--- a/internal/storage/store/group_soft_delete_test.go
+++ b/internal/storage/store/group_soft_delete_test.go
@@ -1,0 +1,99 @@
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func newGroupSoftDeleteStore(t *testing.T) *LocalStorage {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.Group{}, &models.UserGroup{}, &models.GroupRole{}, &models.Role{},
+		&models.ShareRecord{}, &models.SecretNode{}, &models.User{},
+	))
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "u1", Email: "u1@x.io"}).Error)
+	return NewLocalStorage(db)
+}
+
+// A soft-deleted group must grant NOTHING — neither inherited roles nor group
+// shares — even though its membership/grant/share rows are kept for restore. And
+// restoring it brings the access back.
+func TestGroupSoftDelete_RevokesThenRestoresAccess(t *testing.T) {
+	ls := newGroupSoftDeleteStore(t)
+	ctx := context.Background()
+
+	g, err := ls.CreateGroup(ctx, &models.Group{Name: "ops"})
+	require.NoError(t, err)
+	require.NoError(t, ls.AddUserToGroup(ctx, 1, g.ID))
+	require.NoError(t, ls.db.Create(&models.GroupRole{GroupID: g.ID, RoleID: 50}).Error)
+	// A secret shared with the group.
+	require.NoError(t, ls.db.Create(&models.SecretNode{ID: 7, Name: "s", IsSecret: true, CreatedAt: time.Now(), UpdatedAt: time.Now()}).Error)
+	require.NoError(t, ls.db.Create(&models.ShareRecord{SecretID: 7, RecipientID: g.ID, IsGroup: true, Permission: "read"}).Error)
+
+	roles := func() []uint {
+		ids, e := ls.GetUserGroupRoleIDsAt(ctx, 1, storage.Scope{})
+		require.NoError(t, e)
+		return ids
+	}
+	sharedSecretIDs := func() []uint {
+		secs, e := ls.ListSharedSecrets(ctx, 1)
+		require.NoError(t, e)
+		out := make([]uint, 0, len(secs))
+		for _, s := range secs {
+			out = append(out, s.ID)
+		}
+		return out
+	}
+
+	// Live group: the member inherits the role and sees the shared secret.
+	assert.Equal(t, []uint{50}, roles())
+	assert.Contains(t, sharedSecretIDs(), uint(7))
+
+	// Soft-delete the group → it authorizes nothing.
+	require.NoError(t, ls.DeleteGroup(ctx, g.ID))
+	_, err = ls.GetGroup(ctx, g.ID)
+	require.Error(t, err, "a soft-deleted group is not retrievable")
+	assert.Empty(t, roles(), "a soft-deleted group confers no inherited roles")
+	assert.NotContains(t, sharedSecretIDs(), uint(7), "a soft-deleted group's shares grant nothing")
+
+	// Restore → access returns (grants/memberships were preserved).
+	require.NoError(t, ls.RestoreGroup(ctx, g.ID))
+	got, err := ls.GetGroup(ctx, g.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "ops", got.Name)
+	assert.Equal(t, []uint{50}, roles(), "restore brings back inherited roles")
+	assert.Contains(t, sharedSecretIDs(), uint(7), "restore brings back group shares")
+}
+
+// The partial unique index frees a soft-deleted group's name for reuse while still
+// blocking two live groups from sharing a name.
+func TestGroupSoftDelete_NameReuse(t *testing.T) {
+	ls := newGroupSoftDeleteStore(t)
+	ctx := context.Background()
+	// The production migration creates this; replicate it for the test DB.
+	require.NoError(t, ls.db.Exec("CREATE UNIQUE INDEX uniq_groups_name_active ON groups (name) WHERE deleted_at IS NULL").Error)
+
+	g, err := ls.CreateGroup(ctx, &models.Group{Name: "dup"})
+	require.NoError(t, err)
+
+	// A second LIVE group with the same name is rejected.
+	_, err = ls.CreateGroup(ctx, &models.Group{Name: "dup"})
+	require.Error(t, err, "two live groups cannot share a name")
+
+	// After soft-delete, the name is free to reuse.
+	require.NoError(t, ls.DeleteGroup(ctx, g.ID))
+	_, err = ls.CreateGroup(ctx, &models.Group{Name: "dup"})
+	require.NoError(t, err, "a soft-deleted group's name is reusable")
+}

--- a/internal/storage/store/local_rbac.go
+++ b/internal/storage/store/local_rbac.go
@@ -250,6 +250,9 @@ func (ls *LocalStorage) GetUserGroupRoleIDsAt(ctx context.Context, userID uint, 
 	var ids []uint
 	err := ls.db.WithContext(ctx).Table("group_roles").
 		Joins("JOIN user_groups ON user_groups.group_id = group_roles.group_id").
+		// A soft-deleted group confers no roles, even though its membership/grant rows
+		// are kept for restore — exclude deleted groups from authorization.
+		Joins("JOIN groups ON groups.id = group_roles.group_id AND groups.deleted_at IS NULL").
 		Where("user_groups.user_id = ?", userID).
 		Where("group_roles.project_id = 0 OR group_roles.project_id = ?", scope.ProjectID).
 		Where("group_roles.environment_id = 0 OR group_roles.environment_id = ?", scope.EnvironmentID).

--- a/internal/storage/store/local_rbac_scope_test.go
+++ b/internal/storage/store/local_rbac_scope_test.go
@@ -26,7 +26,7 @@ func newRBACScopeTestStore(t *testing.T) *LocalStorage {
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
 	require.NoError(t, db.AutoMigrate(
-		&models.UserRole{}, &models.GroupRole{}, &models.UserGroup{}, &models.Role{},
+		&models.UserRole{}, &models.GroupRole{}, &models.UserGroup{}, &models.Role{}, &models.Group{},
 	))
 	return NewLocalStorage(db)
 }
@@ -100,6 +100,8 @@ func TestGetUserGroupRoleIDsAt_ScopeBoundary(t *testing.T) {
 	ls := newRBACScopeTestStore(t)
 	ctx := context.Background()
 	// user 1 ∈ group 100; group 100 grants role 50 project-5/env-9, role 60 global.
+	// A live (non-deleted) group is required — the authz query excludes deleted groups.
+	require.NoError(t, ls.db.Create(&models.Group{ID: 100, Name: "g100"}).Error)
 	require.NoError(t, ls.db.Create(&models.UserGroup{UserID: 1, GroupID: 100}).Error)
 	require.NoError(t, ls.db.Create(&models.GroupRole{GroupID: 100, RoleID: 50, ProjectID: 5, EnvironmentID: 9}).Error)
 	require.NoError(t, ls.db.Create(&models.GroupRole{GroupID: 100, RoleID: 60, ProjectID: 0, EnvironmentID: 0}).Error)

--- a/internal/storage/store/local_sharing.go
+++ b/internal/storage/store/local_sharing.go
@@ -199,10 +199,13 @@ func (ls *LocalStorage) ListSharedSecrets(ctx context.Context, userID uint) ([]*
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorDatabaseOperation", nil), err)
 	}
 
+	// JOIN groups … deleted_at IS NULL: a soft-deleted group's shares grant nothing,
+	// even though the share/membership rows are kept for restore.
 	groupQuery := `
 		SELECT s.* FROM secret_nodes s
 		JOIN share_records sr ON s.id = sr.secret_id
 		JOIN user_groups ug ON sr.recipient_id = ug.group_id
+		JOIN groups g ON g.id = ug.group_id AND g.deleted_at IS NULL
 		WHERE ug.user_id = ? AND sr.is_group = ? AND sr.deleted_at IS NULL AND s.deleted_at IS NULL
 		  AND (sr.expires_at IS NULL OR sr.expires_at > ?)
 	`
@@ -246,6 +249,7 @@ func (ls *LocalStorage) CheckSharePermission(ctx context.Context, secretID, user
 	groupQuery := `
 		SELECT sr.* FROM share_records sr
 		JOIN user_groups ug ON sr.recipient_id = ug.group_id
+		JOIN groups g ON g.id = ug.group_id AND g.deleted_at IS NULL
 		WHERE sr.secret_id = ? AND ug.user_id = ? AND sr.is_group = ? AND sr.deleted_at IS NULL
 		  AND (sr.expires_at IS NULL OR sr.expires_at > ?)
 		LIMIT 1

--- a/internal/storage/store/local_users.go
+++ b/internal/storage/store/local_users.go
@@ -250,18 +250,29 @@ func (ls *LocalStorage) DeleteGroup(ctx context.Context, id uint) error {
 	if _, err := ls.GetGroup(ctx, id); err != nil {
 		return err
 	}
-	if err := ls.db.WithContext(ctx).Where("group_id = ?", id).Delete(&models.GroupRole{}).Error; err != nil {
-		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
-	}
-	if err := ls.db.WithContext(ctx).Where("group_id = ?", id).Delete(&models.UserGroup{}).Error; err != nil {
-		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
-	}
+	// Soft-delete the group (DeletedAt), keeping its role grants and memberships so a
+	// restore brings the group back intact. A soft-deleted group authorizes nothing:
+	// the role-inheritance and group-share enforcement queries exclude deleted groups.
 	result := ls.db.WithContext(ctx).Delete(&models.Group{}, id)
 	if result.Error != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), result.Error)
 	}
 	if result.RowsAffected == 0 {
 		return fmt.Errorf("%s", i18n.T("ErrorGroupNotFound", nil))
+	}
+	return nil
+}
+
+// RestoreGroup clears a soft-deleted group's deleted_at, bringing it back with the
+// role grants and memberships it had at deletion.
+func (ls *LocalStorage) RestoreGroup(ctx context.Context, id uint) error {
+	result := ls.db.WithContext(ctx).Unscoped().Model(&models.Group{}).
+		Where("id = ? AND deleted_at IS NOT NULL", id).Update("deleted_at", nil)
+	if result.Error != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), result.Error)
+	}
+	if result.RowsAffected == 0 {
+		return fmt.Errorf("group not found or not deleted")
 	}
 	return nil
 }

--- a/internal/storage/store/remote_users.go
+++ b/internal/storage/store/remote_users.go
@@ -210,6 +210,10 @@ func (rs *RemoteStorage) DeleteGroup(_ context.Context, _ uint) error {
 	return remoteUnsupported("DeleteGroup")
 }
 
+func (rs *RemoteStorage) RestoreGroup(_ context.Context, _ uint) error {
+	return remoteUnsupported("RestoreGroup")
+}
+
 func (rs *RemoteStorage) ListGroups(_ context.Context) ([]*models.Group, error) {
 	return nil, remoteUnsupported("ListGroups")
 }

--- a/server/http/handlers/groups_handler.go
+++ b/server/http/handlers/groups_handler.go
@@ -189,3 +189,28 @@ func (h *GroupHandler) DeleteGroup(w http.ResponseWriter, r *http.Request) {
 	}
 	w.WriteHeader(http.StatusNoContent)
 }
+
+// RestoreGroup handles POST /api/v1/groups/{id}/restore — reverses a soft-delete,
+// bringing the group back with its prior role grants and memberships.
+func (h *GroupHandler) RestoreGroup(w http.ResponseWriter, r *http.Request) {
+	userCtx := middleware.GetUserFromContext(r.Context())
+	if userCtx == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		sendError(w, "InvalidParameter", "Invalid group ID", http.StatusBadRequest, nil)
+		return
+	}
+	if err := h.coreService.RestoreGroup(r.Context(), userCtx.UserID, uint(id)); err != nil {
+		log.Printf("Error restoring group: %v", err)
+		if strings.Contains(err.Error(), "not found") || strings.Contains(err.Error(), "not deleted") {
+			sendError(w, "NotFound", "Group not found or not deleted", http.StatusNotFound, nil)
+			return
+		}
+		sendError(w, "InternalError", "Failed to restore group", http.StatusInternalServerError, nil)
+		return
+	}
+	sendSuccess(w, nil, "Group restored")
+}

--- a/server/http/handlers/groups_restore_test.go
+++ b/server/http/handlers/groups_restore_test.go
@@ -1,0 +1,55 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestRestoreGroupHandler(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.Group{}, &models.UserGroup{}, &models.GroupRole{}, &models.AuditEvent{}))
+	c := core.NewKeyorixCore(store.NewLocalStorage(db))
+	h, err := NewGroupHandler(c)
+	require.NoError(t, err)
+
+	g, err := c.CreateGroup(context.Background(), 1, &core.CreateGroupRequest{Name: "ops"})
+	require.NoError(t, err)
+	require.NoError(t, c.DeleteGroup(context.Background(), 1, g.ID))
+
+	t.Run("restores a soft-deleted group", func(t *testing.T) {
+		req := withUserCtx(withChiParam(httptest.NewRequest(http.MethodPost, "/api/v1/groups/1/restore", nil), "id", "1"))
+		w := httptest.NewRecorder()
+		h.RestoreGroup(w, req)
+
+		require.Equal(t, http.StatusOK, w.Code)
+		_, err := c.GetGroup(context.Background(), g.ID)
+		assert.NoError(t, err, "group is retrievable after restore")
+	})
+
+	t.Run("restoring a live (not-deleted) group is a 404", func(t *testing.T) {
+		req := withUserCtx(withChiParam(httptest.NewRequest(http.MethodPost, "/api/v1/groups/1/restore", nil), "id", "1"))
+		w := httptest.NewRecorder()
+		h.RestoreGroup(w, req)
+		assert.Equal(t, http.StatusNotFound, w.Code)
+	})
+
+	t.Run("requires a user context", func(t *testing.T) {
+		req := withChiParam(httptest.NewRequest(http.MethodPost, "/api/v1/groups/1/restore", nil), "id", "1")
+		w := httptest.NewRecorder()
+		h.RestoreGroup(w, req)
+		assert.Equal(t, http.StatusUnauthorized, w.Code)
+	})
+}

--- a/server/http/handlers/rotation_policies_simple_test.go
+++ b/server/http/handlers/rotation_policies_simple_test.go
@@ -44,6 +44,7 @@ func setupRotationPolicyTest(t *testing.T) (*RotationPolicyHandler, *core.Keyori
 		&models.Permission{},
 		&models.RolePermission{},
 		&models.UserRole{},
+		&models.Group{},
 		&models.UserGroup{},
 		&models.GroupRole{},
 	)

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -490,6 +490,7 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.Get("/{id}", groupHandler.GetGroup)
 			r.With(customMiddleware.RequirePermission("users.write")).Put("/{id}", groupHandler.UpdateGroup)
 			r.With(customMiddleware.RequirePermission("users.write")).Delete("/{id}", groupHandler.DeleteGroup)
+			r.With(customMiddleware.RequirePermission("users.write")).Post("/{id}/restore", groupHandler.RestoreGroup)
 			r.Get("/{id}/members", groupHandler.GetGroupMembers)
 			// Secrets a group can reach via shares — reveals secret names, so it needs
 			// secrets.read on top of the group-level users.read above.


### PR DESCRIPTION
## What

Groups were the only core entity without soft-delete/restore — `DELETE /groups/{id}` hard-deleted the group and its grants/memberships, so an accidental delete was unrecoverable. (Founder-approved: build it + handle the name-uniqueness case.)

- `DELETE /api/v1/groups/{id}` → **soft-delete** (reversible).
- **New** `POST /api/v1/groups/{id}/restore` → brings the group back **with** its prior role grants and memberships. `users.write`, audited as `group.restored` (and `group.deleted` already audited).

## Security (the crux)

A soft-deleted group keeps its membership / role-grant / share rows (so restore is intact) — so it **must not authorize anything** while deleted. The three group-based **enforcement** queries now JOIN `groups` and exclude `deleted_at IS NOT NULL`:
- role inheritance — `GetUserGroupRoleIDsAt`
- group shares — `ListSharedSecrets` and `CheckSharePermission`

Tests assert a soft-deleted group confers **no inherited roles and no group shares**, and that restore brings both back.

## Name reuse

The plain unique index on `groups.name` is replaced by a **partial** unique index (`name WHERE deleted_at IS NULL`), created in `migrateDatabase` (drops the legacy `uni_groups_name`; idempotent; SQLite + Postgres both support partial indexes). A soft-deleted group's name is free to reuse, while two **live** groups still can't collide.

## Storage / migration

- `DeleteGroup` soft-deletes only (keeps grants/members); new `RestoreGroup` (+ interface + remote stub + mock).
- Existing-DB migration: adds the `deleted_at` column and swaps the index (additive, idempotent). Fresh DBs get it via AutoMigrate + the index step.
- Updated two test setups to migrate/seed the now-required live `groups` row for the authz join.

## Tests
- Storage: soft-delete revokes roles **and** group shares; restore brings them back; name reuse (live collision blocked, post-delete reuse allowed).
- Core: `group.restored` audited with actor; group retrievable after restore.
- Handler: restore happy path (200), not-deleted → 404, unauthenticated → 401. New mutating route denied (403) to the read-only persona.

Local gates: build, `go vet`, `gofmt`, golangci-lint **0**, gosec **0**; full suite green (only the pre-existing local-only `/sw.js` + `evidence/verify` guard-test flakes, unrelated — confirmed `groups/{id}/restore` returns 403).

🤖 Generated with [Claude Code](https://claude.com/claude-code)