### PR TITLE
release: prep v0.74.0 (CHANGELOG + Helm charts 0.74.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,34 @@
 All notable changes to Keyorix are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## v0.74.0 — 2026-06-22
+
+Group lifecycle, audit completeness, and a few correctness fixes.
+
+### Added
+- **Groups can be soft-deleted and restored** — `DELETE /api/v1/groups/{id}` now
+  soft-deletes (reversible) and `POST /api/v1/groups/{id}/restore` brings the
+  group back with its prior role grants and memberships. A soft-deleted group
+  authorizes nothing (role inheritance and group shares both exclude it), and its
+  name is freed for reuse via a partial unique index. Audited as `group.deleted` /
+  `group.restored`. ([#405])
+- **Restore operations are audited** — restoring a secret, project, or environment
+  now records `secret.restored` / `project.restored` / `environment.restored`, the
+  inverse of the delete events. ([#402])
+
+### Fixed
+- **A secret's share list excludes expired shares** — `ListSecretShares` returned
+  expired time-bound shares that no longer authorized, disagreeing with
+  enforcement; it now filters them like every authorization path. ([#403])
+- **Description length is bounded** — project, group, and rotation-policy
+  descriptions are now capped (like secret descriptions) at the create/update
+  choke points. ([#404])
+
+[#402]: https://github.com/keyorixhq/keyorix/pull/402
+[#403]: https://github.com/keyorixhq/keyorix/pull/403
+[#404]: https://github.com/keyorixhq/keyorix/pull/404
+[#405]: https://github.com/keyorixhq/keyorix/pull/405
+
 ## v0.73.1 — 2026-06-22
 
 Security fix.

--- a/deploy/helm/keyorix-k8s-sync/Chart.yaml
+++ b/deploy/helm/keyorix-k8s-sync/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix-k8s-sync
 description: Keyorix Kubernetes sync agent — materialises Keyorix secrets into native Kubernetes Secrets
 type: application
 # Chart version — tracks the Keyorix release version (published in lockstep).
-version: 0.73.1
+version: 0.74.0
 # The keyorix-k8s-sync image tag this chart deploys by default.
-appVersion: "0.73.1"
+appVersion: "0.74.0"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix

--- a/deploy/helm/keyorix/Chart.yaml
+++ b/deploy/helm/keyorix/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix
 description: Self-hosted Keyorix secrets manager (API server + web UI + PostgreSQL)
 type: application
 # Chart version — bump on chart changes.
-version: 0.73.1
+version: 0.74.0
 # The Keyorix app version this chart deploys by default (the image tag).
-appVersion: "0.73.1"
+appVersion: "0.74.0"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix


### PR DESCRIPTION
Release prep for **v0.74.0** — CHANGELOG entry + both Helm charts bumped to 0.74.0 (lockstep).

## Included since v0.73.1
- **Groups soft-delete + restore** — reversible delete with no auth leak; name freed via partial unique index. ([#405])
- **Restore operations audited** — `secret.restored` / `project.restored` / `environment.restored`. ([#402])
- **Fix:** a secret's share list excludes expired shares. ([#403])
- **Fix:** governance descriptions are length-bounded. ([#404])

Charts bumped lockstep: `keyorix` and `keyorix-k8s-sync` → 0.74.0. `helm lint` clean. Tag `v0.74.0` pushed after merge to trigger the release + image-publish workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)