### PR TITLE
feat(observability): expose gRPC metrics on the Prometheus /metrics endpoint

### DIFF
--- a/server/grpc/interceptors/prometheus.go
+++ b/server/grpc/interceptors/prometheus.go
@@ -1,0 +1,58 @@
+// prometheus.go — bridges the in-memory gRPC metrics (atomic counters in
+// metrics.go) into the default Prometheus registry, so gRPC request volume,
+// outcomes, and latency are scrapable from the same /metrics endpoint as the HTTP
+// metrics. Without this, gRPC observability was reachable only via an
+// authenticated SystemService.GetMetrics RPC — not Prometheus time series.
+package interceptors
+
+import (
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// grpcCollector reports the gRPC counters on each scrape (read live from the
+// atomics), so it never drifts from the interceptor's view and adds no per-request
+// cost. Counters are monotonic, matching Prometheus' counter semantics.
+type grpcCollector struct {
+	requests *prometheus.Desc
+	duration *prometheus.Desc
+}
+
+func newGRPCCollector() *grpcCollector {
+	return &grpcCollector{
+		requests: prometheus.NewDesc(
+			"keyorix_grpc_requests_total",
+			"Total gRPC unary requests, by outcome (success or error).",
+			[]string{"status"}, nil,
+		),
+		duration: prometheus.NewDesc(
+			"keyorix_grpc_request_duration_seconds_total",
+			"Cumulative gRPC unary handler time in seconds; divide its rate by the request rate for average latency.",
+			nil, nil,
+		),
+	}
+}
+
+func (c *grpcCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.requests
+	ch <- c.duration
+}
+
+func (c *grpcCollector) Collect(ch chan<- prometheus.Metric) {
+	m := GetGRPCMetrics()
+	ch <- prometheus.MustNewConstMetric(c.requests, prometheus.CounterValue, float64(m.SuccessRequests), "success")
+	ch <- prometheus.MustNewConstMetric(c.requests, prometheus.CounterValue, float64(m.ErrorRequests), "error")
+	ch <- prometheus.MustNewConstMetric(c.duration, prometheus.CounterValue, float64(m.TotalDuration)/1e9)
+}
+
+var registerOnce sync.Once
+
+// RegisterPrometheusMetrics registers the gRPC metrics collector on the default
+// Prometheus registry (the one promhttp.Handler serves at /metrics). Safe to call
+// more than once.
+func RegisterPrometheusMetrics() {
+	registerOnce.Do(func() {
+		prometheus.MustRegister(newGRPCCollector())
+	})
+}

--- a/server/grpc/interceptors/prometheus_test.go
+++ b/server/grpc/interceptors/prometheus_test.go
@@ -1,0 +1,54 @@
+package interceptors
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+// The collector reports gRPC request outcomes as Prometheus counters, driven by the
+// same atomics the MetricsInterceptor increments.
+func TestGRPCPrometheusCollector(t *testing.T) {
+	// Reset the package-global counters for a deterministic comparison.
+	atomic.StoreInt64(&grpcMetrics.TotalRequests, 0)
+	atomic.StoreInt64(&grpcMetrics.SuccessRequests, 0)
+	atomic.StoreInt64(&grpcMetrics.ErrorRequests, 0)
+	atomic.StoreInt64(&grpcMetrics.TotalDuration, 0)
+
+	intercept := MetricsInterceptor()
+	info := &grpc.UnaryServerInfo{FullMethod: "/keyorix.SecretService/Get"}
+	ok := func(context.Context, interface{}) (interface{}, error) { return "ok", nil }
+	fail := func(context.Context, interface{}) (interface{}, error) { return nil, errors.New("boom") }
+
+	_, _ = intercept(context.Background(), nil, info, ok)
+	_, _ = intercept(context.Background(), nil, info, ok)
+	_, _ = intercept(context.Background(), nil, info, fail)
+
+	reg := prometheus.NewRegistry()
+	reg.MustRegister(newGRPCCollector())
+
+	expected := `
+# HELP keyorix_grpc_requests_total Total gRPC unary requests, by outcome (success or error).
+# TYPE keyorix_grpc_requests_total counter
+keyorix_grpc_requests_total{status="error"} 1
+keyorix_grpc_requests_total{status="success"} 2
+`
+	// Filter to the deterministic counter (duration depends on wall-clock).
+	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(expected), "keyorix_grpc_requests_total"))
+}
+
+// RegisterPrometheusMetrics is safe to call repeatedly (it would otherwise panic on
+// a duplicate registration).
+func TestRegisterPrometheusMetricsIdempotent(t *testing.T) {
+	require.NotPanics(t, func() {
+		RegisterPrometheusMetrics()
+		RegisterPrometheusMetrics()
+	})
+}

--- a/server/grpc/server.go
+++ b/server/grpc/server.go
@@ -19,6 +19,9 @@ import (
 // tokens against the shared core service. Service registration is wired in a
 // later phase; until then the server runs with interceptors only.
 func NewServer(cfg *config.Config, coreService *core.KeyorixCore) (*grpc.Server, error) {
+	// Surface the gRPC interceptor metrics on the shared Prometheus /metrics endpoint.
+	interceptors.RegisterPrometheusMetrics()
+
 	// Create server options
 	opts := []grpc.ServerOption{
 		grpc.ChainUnaryInterceptor(


### PR DESCRIPTION
## What

gRPC request volume, outcomes, and latency lived **only in in-memory atomic counters** — reachable solely via the authenticated `SystemService.GetMetrics` RPC. Prometheus could scrape the HTTP metrics (`/metrics`) but had **no gRPC time series**, a real blind spot for gRPC-primary deployments.

## How

- A Prometheus `Collector` that reports the gRPC counters **live on each scrape** (reads the existing atomics — no per-request cost, never drifts from the interceptor).
- Registered on the **default registry** that `promhttp.Handler()` already serves at `/metrics`, wired in `grpc.NewServer` next to the metrics interceptor.
- Emits, mirroring the HTTP metric style:
  - `keyorix_grpc_requests_total{status="success"|"error"}`
  - `keyorix_grpc_request_duration_seconds_total` (rate-divide by request rate for average latency)

## Tests
- The outcomes counter reflects interceptor success/error counts (driven through the real interceptor, compared via `testutil.GatherAndCompare`).
- Registration is idempotent (no double-register panic).

Local gates: build, `go vet`, `gofmt`, golangci-lint **0**, gosec **0**; gRPC packages green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)