### PR TITLE
feat(cli): dynamic-secret get-config and classify

### DIFF
--- a/internal/cli/dynamic/dynamic.go
+++ b/internal/cli/dynamic/dynamic.go
@@ -37,6 +37,7 @@ var (
 	flagEnvID     int
 	flagTTL       int
 	flagYes       bool
+	flagLevel     string
 )
 
 func init() {
@@ -45,8 +46,69 @@ func init() {
 	issueCmd.Flags().IntVar(&flagTTL, "ttl", 0, "Lease TTL in seconds (0 = the config default)")
 	renewCmd.Flags().IntVar(&flagTTL, "ttl", 0, "Renewal TTL in seconds (0 = the config default)")
 	revokeAllCmd.Flags().BoolVar(&flagYes, "yes", false, "Skip the confirmation prompt")
+	classifyCmd.Flags().StringVar(&flagLevel, "level", "", "Classification level (required)")
+	_ = classifyCmd.MarkFlagRequired("level")
 
-	DynamicSecretCmd.AddCommand(listCmd, issueCmd, leasesCmd, renewCmd, revokeCmd, revokeAllCmd)
+	DynamicSecretCmd.AddCommand(listCmd, getConfigCmd, issueCmd, leasesCmd, renewCmd, revokeCmd, revokeAllCmd, classifyCmd)
+}
+
+// printConfig renders a single config's details.
+func printConfig(cfg configView) {
+	fmt.Printf("ID:             %d\n", cfg.ID)
+	fmt.Printf("Name:           %s\n", cfg.Name)
+	fmt.Printf("Project ID:     %d\n", cfg.ProjectID)
+	fmt.Printf("Environment ID: %d\n", cfg.EnvironmentID)
+	fmt.Printf("Backend:        %s\n", cfg.BackendType)
+	fmt.Printf("Default TTL:    %ds\n", cfg.DefaultTTLSeconds)
+	fmt.Printf("Max TTL:        %ds\n", cfg.MaxTTLSeconds)
+	if cfg.Classification != "" {
+		fmt.Printf("Classification: %s\n", cfg.Classification)
+	}
+}
+
+var getConfigCmd = &cobra.Command{
+	Use:   "get-config <config-id>",
+	Short: "Show a dynamic-secret config's details",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(_ *cobra.Command, args []string) error {
+		c, err := client()
+		if err != nil {
+			return err
+		}
+		id, err := strconv.Atoi(args[0])
+		if err != nil {
+			return fmt.Errorf("invalid config id: %s", args[0])
+		}
+		var cfg configView
+		if err := c.Get(context.Background(), fmt.Sprintf("/api/v1/dynamic-secrets/configs/%d", id), &cfg); err != nil {
+			return err
+		}
+		printConfig(cfg)
+		return nil
+	},
+}
+
+var classifyCmd = &cobra.Command{
+	Use:   "classify <config-id>",
+	Short: "Set a dynamic-secret config's classification level",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(_ *cobra.Command, args []string) error {
+		c, err := client()
+		if err != nil {
+			return err
+		}
+		id, err := strconv.Atoi(args[0])
+		if err != nil {
+			return fmt.Errorf("invalid config id: %s", args[0])
+		}
+		var cfg configView
+		body := map[string]string{"classification": flagLevel}
+		if err := c.Patch(context.Background(), fmt.Sprintf("/api/v1/dynamic-secrets/configs/%d/classification", id), body, &cfg); err != nil {
+			return err
+		}
+		fmt.Printf("✅ Classification set to %q for config %d.\n", flagLevel, id)
+		return nil
+	},
 }
 
 func client() (*common.RemoteClient, error) {
@@ -65,6 +127,7 @@ type configView struct {
 	BackendType       string `json:"backend_type"`
 	DefaultTTLSeconds int    `json:"default_ttl_seconds"`
 	MaxTTLSeconds     int    `json:"max_ttl_seconds"`
+	Classification    string `json:"classification"`
 }
 
 type issuedLease struct {

--- a/internal/cli/dynamic/dynamic_test.go
+++ b/internal/cli/dynamic/dynamic_test.go
@@ -18,9 +18,10 @@ func TestCommandWiring(t *testing.T) {
 	for _, sub := range DynamicSecretCmd.Commands() {
 		names[sub.Name()] = true
 	}
-	for _, want := range []string{"list", "issue", "leases", "renew", "revoke", "revoke-all", "create"} {
+	for _, want := range []string{"list", "issue", "leases", "renew", "revoke", "revoke-all", "create", "get-config", "classify"} {
 		assert.True(t, names[want], "missing subcommand %q", want)
 	}
+	assert.NotNil(t, classifyCmd.Flags().Lookup("level"))
 	assert.Contains(t, DynamicSecretCmd.Aliases, "dyn")
 	assert.NotNil(t, issueCmd.Flags().Lookup("ttl"))
 	assert.NotNil(t, listCmd.Flags().Lookup("project-id"))
@@ -127,6 +128,50 @@ func TestRevokeAllAgainstMockServer(t *testing.T) {
 	assert.Equal(t, http.MethodPost, gotMethod)
 	assert.Equal(t, "/api/v1/dynamic-secrets/configs/7/revoke-all", gotPath)
 	assert.Contains(t, out, "revoked 3")
+}
+
+func TestGetConfigAgainstMockServer(t *testing.T) {
+	var gotMethod, gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod, gotPath = r.Method, r.URL.Path
+		_, _ = w.Write([]byte(`{"data":{"id":7,"name":"app-db","backend_type":"postgres","default_ttl_seconds":3600,"max_ttl_seconds":7200,"classification":"restricted"}}`))
+	}))
+	defer srv.Close()
+
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+
+	out := captureStdout(t, func() {
+		require.NoError(t, getConfigCmd.RunE(getConfigCmd, []string{"7"}))
+	})
+	assert.Equal(t, http.MethodGet, gotMethod)
+	assert.Equal(t, "/api/v1/dynamic-secrets/configs/7", gotPath)
+	assert.Contains(t, out, "app-db")
+	assert.Contains(t, out, "restricted")
+}
+
+func TestClassifyAgainstMockServer(t *testing.T) {
+	var gotMethod, gotPath string
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod, gotPath = r.Method, r.URL.Path
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		_, _ = w.Write([]byte(`{"data":{"id":7,"name":"app-db","classification":"restricted"}}`))
+	}))
+	defer srv.Close()
+
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+	flagLevel = "restricted"
+	t.Cleanup(func() { flagLevel = "" })
+
+	out := captureStdout(t, func() {
+		require.NoError(t, classifyCmd.RunE(classifyCmd, []string{"7"}))
+	})
+	assert.Equal(t, http.MethodPatch, gotMethod)
+	assert.Equal(t, "/api/v1/dynamic-secrets/configs/7/classification", gotPath)
+	assert.Equal(t, "restricted", gotBody["classification"])
+	assert.Contains(t, out, "restricted")
 }
 
 func TestIssueRejectsBadConfigID(t *testing.T) {


### PR DESCRIPTION
## What

The dynamic-secret config **classification** and single-config **read** existed over HTTP and gRPC but had **no CLI** — operators had to drop to a raw API client. Closes that surface gap.

- `keyorix dynamic-secret get-config <id>` — show one config (backend, TTLs, classification) via `GET /dynamic-secrets/configs/{id}`.
- `keyorix dynamic-secret classify <id> --level <level>` — set the config's classification via `PATCH /dynamic-secrets/configs/{id}/classification`.

`configView` gains a `classification` field so both commands display it.

## Tests
- `get-config` and `classify` each drive a stub server, asserting method/path/body and output.
- Command-wiring test updated to require both subcommands + the `--level` flag.

Local gates: build, `go vet`, `gofmt`, golangci-lint **0**, gosec **0**; dynamic CLI package green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)