### PR TITLE
release: prep v0.75.0 (CHANGELOG + Helm charts 0.75.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to Keyorix are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## v0.75.0 — 2026-06-22
+
+Observability and CLI parity.
+
+### Added
+- **gRPC metrics on `/metrics`** — gRPC request volume, outcomes, and cumulative
+  handler time are now exported to Prometheus (`keyorix_grpc_requests_total{status}`
+  and `keyorix_grpc_request_duration_seconds_total`) on the same endpoint as the
+  HTTP metrics, instead of being reachable only via an authenticated RPC. ([#407])
+- **CLI for dynamic-secret config classification and inspection** —
+  `keyorix dynamic-secret get-config <id>` shows a single config (backend, TTLs,
+  classification) and `keyorix dynamic-secret classify <id> --level <level>` sets
+  its classification, matching the HTTP/gRPC surfaces. ([#408])
+
+[#407]: https://github.com/keyorixhq/keyorix/pull/407
+[#408]: https://github.com/keyorixhq/keyorix/pull/408
+
 ## v0.74.0 — 2026-06-22
 
 Group lifecycle, audit completeness, and a few correctness fixes.

--- a/deploy/helm/keyorix-k8s-sync/Chart.yaml
+++ b/deploy/helm/keyorix-k8s-sync/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix-k8s-sync
 description: Keyorix Kubernetes sync agent — materialises Keyorix secrets into native Kubernetes Secrets
 type: application
 # Chart version — tracks the Keyorix release version (published in lockstep).
-version: 0.74.0
+version: 0.75.0
 # The keyorix-k8s-sync image tag this chart deploys by default.
-appVersion: "0.74.0"
+appVersion: "0.75.0"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix

--- a/deploy/helm/keyorix/Chart.yaml
+++ b/deploy/helm/keyorix/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix
 description: Self-hosted Keyorix secrets manager (API server + web UI + PostgreSQL)
 type: application
 # Chart version — bump on chart changes.
-version: 0.74.0
+version: 0.75.0
 # The Keyorix app version this chart deploys by default (the image tag).
-appVersion: "0.74.0"
+appVersion: "0.75.0"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix


### PR DESCRIPTION
Release prep for **v0.75.0** — CHANGELOG entry + both Helm charts bumped to 0.75.0 (lockstep).

## Included since v0.74.0
- **gRPC metrics on `/metrics`** — `keyorix_grpc_requests_total{status}` + `keyorix_grpc_request_duration_seconds_total`, Prometheus-scrapable. ([#407])
- **CLI for dynamic-secret config inspect/classify** — `get-config` + `classify`. ([#408])

Charts bumped lockstep: `keyorix` and `keyorix-k8s-sync` → 0.75.0. `helm lint` clean. Tag `v0.75.0` pushed after merge to trigger the release + image-publish workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)