### PR TITLE
feat(anomaly): ML anomaly detection via Isolation Forest (ADR-050)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,9 @@ All notable changes to Keyorix are documented here. This project follows
   **combinations** that are unremarkable signal-by-signal. Pure-Go, no new
   dependencies; metadata only (no secret value is examined); deterministic (seeded).
   Flagged accesses emit an `ml_outlier` alert through the existing alert pipeline.
-  Config-gated under `anomaly_alerts.ml` (default off). (ADR-050) ([#409])
+  Config-gated under `anomaly_alerts.ml` (default off). (ADR-050) ([#410])
 
-[#409]: https://github.com/keyorixhq/keyorix/pull/409
+[#410]: https://github.com/keyorixhq/keyorix/pull/410
 
 ## v0.74.0 — 2026-06-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to Keyorix are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## Unreleased
+
+### Added
+- **ML anomaly detection (Isolation Forest)** — an opt-in machine-learning pass that
+  complements the existing rule-based access-anomaly detection. Each scan trains a
+  per-secret Isolation Forest on the secret's 30-day access baseline and flags
+  accesses whose joint pattern (hour, IP rarity, user rarity) is a multivariate
+  outlier — catching what the binary rules miss: a **known-but-rare** actor or IP, and
+  **combinations** that are unremarkable signal-by-signal. Pure-Go, no new
+  dependencies; metadata only (no secret value is examined); deterministic (seeded).
+  Flagged accesses emit an `ml_outlier` alert through the existing alert pipeline.
+  Config-gated under `anomaly_alerts.ml` (default off). (ADR-050) ([#409])
+
+[#409]: https://github.com/keyorixhq/keyorix/pull/409
+
 ## v0.74.0 — 2026-06-22
 
 Group lifecycle, audit completeness, and a few correctness fixes.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -743,6 +743,33 @@ anomaly_alerts:
   schedule: "1h"          # Go duration between scan+alert passes (default 1h)
 ```
 
+### anomaly_alerts.ml — Isolation Forest detection (ADR-050)
+
+An optional **machine-learning** detection pass that complements the statistical rules
+above. Each scan trains a per-secret [Isolation Forest](https://en.wikipedia.org/wiki/Isolation_forest)
+on the secret's 30-day access baseline and flags accesses whose joint pattern (hour,
+IP rarity, user rarity) is a multivariate outlier — catching two things the binary
+rules miss: a **known-but-rare** actor or IP (the new-user/new-IP rules only see
+"known"), and **combinations** that are unremarkable signal-by-signal. Flagged accesses
+emit an `ml_outlier` anomaly alert that flows through the same list / acknowledge /
+alert / retention paths as every other alert. Metadata only — no secret value is ever
+examined.
+
+`ml.enabled` is **independent** of `anomaly_alerts.enabled`: it gates whether the scan
+additionally runs the ML pass; `anomaly_alerts.enabled` gates whether detected
+anomalies are pushed out. Opt-in (default off).
+
+```yaml
+anomaly_alerts:
+  enabled: true
+  ml:
+    enabled: true
+    threshold: 0.60       # anomaly-score cutoff in (0.5,1.0); higher = fewer alerts (default 0.60)
+    num_trees: 100        # forest size (default 100)
+    sample_size: 256      # per-tree subsample ψ (default 256)
+    seed: 1               # RNG seed; fixed so scoring is reproducible (default 1)
+```
+
 ## audit.siem
 
 Native push of audit events to a SIEM. The token is read from `KEYORIX_SIEM_TOKEN`

--- a/docs/adr-050-ml-anomaly-detection.md
+++ b/docs/adr-050-ml-anomaly-detection.md
@@ -1,0 +1,102 @@
+# ADR-050: ML-based anomaly detection (Isolation Forest)
+
+## Status
+
+Accepted.
+
+## Context
+
+Keyorix already detects anomalous secret access (ADR-026): a per-secret statistical
+detector (`internal/core/anomaly.go`) learns a 30-day baseline and emits `AnomalyAlert`
+rows surfaced in the Anomaly Alerts UI and pushed to admins / SIEM when alerting is
+enabled (ADR-026 + the NIS2 detection-&-response posture).
+
+Those detectors are **single-signal rules**: off-hours by a fixed 22:00–06:00 clock
+band, a never-before-seen IP, a never-before-seen user, and a read-volume spike. Each
+fires on one binary condition, which leaves two real gaps:
+
+- **Graduated rarity.** The `new_user` / `new_ip` rules are binary — an actor is
+  "known" or "unknown". An identity that *is* in the baseline but is used only rarely
+  (a human who touches a service-account secret a handful of times a month) never trips
+  a rule, yet a sudden use of it is exactly the kind of event worth surfacing.
+- **Multivariate combinations.** An access whose hour, source IP and actor are each
+  individually unremarkable but *jointly* rare is invisible to any single rule.
+
+The M3 roadmap (and the ENISA AI-feature narrative) calls for an ML anomaly detector.
+This ADR records that decision and its scope.
+
+## Decision
+
+Add an opt-in **Isolation Forest** pass (Liu, Ting & Zhou, 2008) layered onto the
+existing detector — it complements the rules, it does not replace them.
+
+- **Algorithm.** A dependency-free, pure-Go Isolation Forest
+  (`internal/core/isolation_forest.go`): an ensemble of randomly-grown binary trees on
+  subsamples of the *normal* baseline. A point's average path length to isolation is
+  its anomaly score `s = 2^(-E[h(x)]/c(ψ))` in (0,1); points isolated quickly (short
+  paths) score high. Unsupervised — no labels, which we do not have.
+- **Per-secret model.** Each detection pass, for each secret with at least 20 baseline
+  accesses, a forest is trained on that secret's 30-day access history and used to
+  score the last hour's accesses. Below the floor the pass abstains (too little to
+  learn; the rules already cover sparse-history secrets).
+- **Features (`internal/core/anomaly_ml.go`).** Four low, interpretable dimensions per
+  access — hour-of-day as a cyclic `(sin, cos)` pair, the baseline occurrence count of
+  the access's IP, and of its user. Hour is encoded on the unit circle so 23:00 and
+  01:00 are adjacent and every hour is an *interior* point (an unused hour lands in an
+  empty interior region the forest isolates well; a raw 0–23 integer would make an
+  off-pattern hour an extrapolation point, which Isolation Forest separates poorly).
+  The count features give the graduated-rarity signal the binary rules lack.
+- **Alerts.** An access scoring above the threshold emits an `ml_outlier`
+  `AnomalyAlert` carrying its score, accessor and IP. Severity is `high` at score ≥
+  0.75, else `medium`. These flow through the same storage, list/filter, acknowledge,
+  alerting and retention paths as every other alert — no new surface.
+- **Determinism.** The model RNG is seeded (`math/rand`, config `seed`, default 1), so
+  scoring is reproducible across restarts and testable. This RNG drives model sampling
+  only; no security decision rides on it (it is not `crypto/rand`, by design).
+- **Config-gated, default off.** `anomaly_alerts.ml` (`enabled`, `threshold`,
+  `num_trees`, `sample_size`, `seed`). `ml.enabled` is independent of
+  `anomaly_alerts.enabled`: the former gates whether the scan additionally runs the ML
+  pass, the latter gates whether *any* detected anomaly is pushed out. The ML pass runs
+  inside the existing single-replica-gated scheduler (ADR-039).
+
+## Threshold choice
+
+With this deliberately low-dimensional feature set, normal accesses cluster near 0.5
+and the genuinely rare tail reaches ~0.65–0.8, so the default cutoff is **0.60** —
+clearly above the 0.5 noise floor while still catching the rare tail. It is an operator
+dial; raise it to reduce volume, lower it to widen the net. Empirically a brand-new
+actor+IP (which the rules also catch) scores into the high band (~0.77), so the ML
+score *corroborates* the rules rather than contradicting them, while a known-but-rare
+actor at a normal hour (which no rule catches) scores ~0.67 — the headline value-add.
+
+## Privacy & safety
+
+Metadata only — like the rest of the anomaly subsystem the forest never sees a secret
+value; its features are derived solely from access-log timestamps, actor names and IPs.
+The pass is best-effort and isolated: a training/scoring failure for one secret is
+skipped, never aborting the scan, and with the feature off the system behaves exactly
+as before.
+
+## Alternatives considered
+
+- **More features / higher dimensionality (user-agent, action, day-of-week, inter-
+  arrival time).** Deferred. The four chosen features are interpretable and already
+  cover the two gaps; more dimensions dilute the signal in a low-data per-secret regime
+  and make alerts harder to explain. Easy to extend later via `accessFeatures`.
+- **A global (all-secrets) model instead of per-secret.** Rejected for now — "normal"
+  is per-secret (a CI secret read thousands of times vs. a break-glass secret read
+  twice), and a per-secret model needs no cross-secret feature normalisation.
+- **An external ML service / Python sidecar.** Rejected — a pure-Go in-process forest
+  keeps the single-binary deployment model, adds no dependency or attack surface, and
+  is fast on this data volume.
+- **Replacing the statistical rules.** Rejected — the rules are cheap, explainable and
+  catch binary novelty deterministically; ML adds the rare/combination signal on top.
+
+## Deferred follow-ups
+
+- Richer features (user-agent / action / inter-arrival) behind `accessFeatures`.
+- Score persisted on the alert row + a UI column / sort, and an explanation of *which*
+  feature drove the score.
+- Per-secret adaptive thresholds (contamination-based) instead of one global cutoff.
+- Online / incremental model refresh rather than retrain-per-pass (only matters at much
+  larger access volumes).

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1064,6 +1064,23 @@ func (c BreakGlassConfig) GetMaxTTL() time.Duration {
 type AnomalyAlertsConfig struct {
 	Enabled  bool   `yaml:"enabled"`
 	Schedule string `yaml:"schedule"`
+	// ML configures the optional Isolation Forest detection pass (ADR-050). It is
+	// independent of Enabled (which gates alert *push*): ML.Enabled gates whether the
+	// detection scan additionally scores accesses for multivariate outliers.
+	ML AnomalyMLConfig `yaml:"ml"`
+}
+
+// AnomalyMLConfig configures the Isolation Forest anomaly-detection pass (ADR-050).
+// Opt-in (default off). When enabled, each detection scan trains a per-secret forest
+// on the secret's 30-day access baseline and flags recent accesses whose joint
+// feature vector (hour, IP novelty, user novelty) is a multivariate outlier — the
+// single-signal statistical rules miss these. Metadata only; no secret values.
+type AnomalyMLConfig struct {
+	Enabled    bool    `yaml:"enabled"`
+	Threshold  float64 `yaml:"threshold"`   // anomaly-score cutoff (0.5,1.0); default 0.60
+	NumTrees   int     `yaml:"num_trees"`   // ensemble size; default 100
+	SampleSize int     `yaml:"sample_size"` // per-tree subsample (psi); default 256
+	Seed       int64   `yaml:"seed"`        // RNG seed for reproducible scoring; default 1
 }
 
 // GetInterval returns the anomaly scan/alert interval (Go duration); defaults to 1h.

--- a/internal/core/anomaly.go
+++ b/internal/core/anomaly.go
@@ -8,10 +8,12 @@ import (
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
-// AnomalyDetector detects anomalous secret access patterns using statistical baselines.
-// Operates on metadata only — secret values are never examined.
+// AnomalyDetector detects anomalous secret access patterns using statistical baselines
+// and, when enabled, an Isolation Forest (ADR-050). Operates on metadata only — secret
+// values are never examined.
 type AnomalyDetector struct {
 	storage StorageInterface
+	ml      MLConfig // ML pass; disabled by default (see SetMLConfig)
 }
 
 // StorageInterface is satisfied by *storage.LocalStorage and *storage.RemoteStorage.
@@ -22,9 +24,17 @@ type StorageInterface = interface {
 	AcknowledgeAnomalyAlert(ctx context.Context, id uint) error
 }
 
-// NewAnomalyDetector creates a new AnomalyDetector.
+// NewAnomalyDetector creates a new AnomalyDetector with the ML pass disabled.
 func NewAnomalyDetector(storage StorageInterface) *AnomalyDetector {
 	return &AnomalyDetector{storage: storage}
+}
+
+// SetMLConfig enables (or reconfigures) the Isolation Forest pass. Defaults are
+// applied per-pass, so passing a zero-valued config with Enabled=true uses the
+// recommended parameters. With Enabled=false (the zero value) only the statistical
+// rules run.
+func (d *AnomalyDetector) SetMLConfig(cfg MLConfig) {
+	d.ml = cfg
 }
 
 // accessBaseline holds statistical baseline for a secret's access patterns.
@@ -69,6 +79,15 @@ func (d *AnomalyDetector) RunDetection(ctx context.Context, secrets []models.Sec
 		// baseline (one alert per secret per pass, not per access).
 		if alert := volumeSpikeAlert(secret, len(recentLogs), baseline, now); alert != nil {
 			_ = d.storage.CreateAnomalyAlert(ctx, alert)
+		}
+
+		// ML pass (opt-in): score this window's accesses against an Isolation Forest
+		// trained on the secret's full 30-day baseline, catching multivariate outliers
+		// the single-signal rules above miss.
+		if d.ml.Enabled {
+			for _, alert := range mlOutlierAlerts(secret, baselineLogs, recentLogs, d.ml, now) {
+				_ = d.storage.CreateAnomalyAlert(ctx, &alert)
+			}
 		}
 	}
 	return nil

--- a/internal/core/anomaly_ml.go
+++ b/internal/core/anomaly_ml.go
@@ -1,0 +1,163 @@
+package core
+
+import (
+	"fmt"
+	"math"
+	"math/rand"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// ML-based anomaly detection (ADR-050) layered onto the statistical rules in
+// anomaly.go. The rules fire on a single binary signal (off-hours by a fixed clock
+// band, a never-before-seen IP, a never-before-seen user, a volume spike). They are
+// blind to two things an Isolation Forest catches:
+//
+//   - graduated rarity — an actor or IP that *is* in the baseline but is used only
+//     rarely (the new_user/new_ip rules see "known" and stay silent);
+//   - multivariate combinations — an access whose hour, source and actor are each
+//     unremarkable alone but jointly fall in a sparse region of the learned pattern.
+//
+// A forest trained on the secret's 30-day access baseline scores each recent access
+// on its joint feature vector; points it isolates quickly (a short average path
+// length) are flagged as ml_outlier. It does not replace the rules — it complements
+// them, and where a brand-new actor trips both, the higher ML score corroborates the
+// rule. Metadata only — secret values are never examined.
+
+const (
+	// mlMinTrainSamples is the floor of baseline access events below which ML scoring
+	// is skipped: an Isolation Forest learns nothing useful from a handful of points,
+	// and the statistical rules already cover sparse-history secrets. The forest is
+	// per-secret, so this is per-secret history, not global.
+	mlMinTrainSamples = 20
+	// mlHighSeverityScore is the anomaly-score cutoff at or above which an ml_outlier
+	// is reported "high" rather than "medium". Scores approach 1.0 for points the
+	// forest isolates almost immediately.
+	mlHighSeverityScore = 0.75
+)
+
+// MLConfig gates and parameterises the Isolation Forest pass. Disabled by default;
+// the statistical detection in anomaly.go always runs regardless. Normalise via
+// withDefaults before use so a partially-specified config still has sane values.
+type MLConfig struct {
+	Enabled    bool
+	Threshold  float64 // anomaly-score cutoff in (0.5,1.0); events scoring above it are flagged
+	NumTrees   int     // ensemble size
+	SampleSize int     // per-tree subsample size (psi)
+	Seed       int64   // RNG seed, for reproducible scoring
+}
+
+// withDefaults returns a copy with any unset/out-of-range fields filled with the
+// defaults from the paper's recommendations (100 trees, psi=256) and a threshold
+// tuned to this feature set's score distribution: with the low-dimensional access
+// features, normal accesses cluster near 0.5 and the genuinely rare tail reaches
+// ~0.65–0.8, so 0.60 cleanly separates them while staying clear of the noise floor.
+// A non-positive seed becomes a fixed constant so scoring stays deterministic across
+// restarts rather than drifting with wall-clock entropy.
+func (c MLConfig) withDefaults() MLConfig {
+	if c.Threshold <= 0.5 || c.Threshold >= 1.0 {
+		c.Threshold = 0.60
+	}
+	if c.NumTrees <= 0 {
+		c.NumTrees = 100
+	}
+	if c.SampleSize <= 1 {
+		c.SampleSize = 256
+	}
+	if c.Seed <= 0 {
+		c.Seed = 1
+	}
+	return c
+}
+
+// accessFeatures turns one access-log entry into the feature vector the forest splits
+// on, using the supplied baseline frequency maps for the novelty signals. Four
+// dimensions, deliberately low and interpretable:
+//
+//	[0],[1] hour of day, cyclically encoded as (sin,cos) of 2π·hour/24
+//	[2]     baseline count of this IP   — 0 for an unseen IP; small for a rarely-seen one
+//	[3]     baseline count of this user — 0 for an unseen user; small for a rare one
+//
+// Hour is encoded on the unit circle rather than as a raw 0–23 integer for two
+// reasons: it makes 23:00 and 01:00 adjacent (a raw integer would call them maximally
+// distant), and it places every hour in the *interior* of a bounded space, so an
+// access at an unused hour falls in an empty interior region the forest isolates
+// quickly — a raw out-of-range integer would be an extrapolation point, which
+// Isolation Forest separates poorly. Each tree splits on a single feature's own
+// observed range, so the differing scales (unit-circle vs. counts) need no
+// normalisation.
+func accessFeatures(lg models.SecretAccessLog, ipFreq, userFreq map[string]int) []float64 {
+	radians := 2 * math.Pi * float64(lg.AccessTime.UTC().Hour()) / 24
+	return []float64{
+		math.Sin(radians),
+		math.Cos(radians),
+		float64(ipFreq[lg.IPAddress]),
+		float64(userFreq[lg.AccessedBy]),
+	}
+}
+
+// mlOutlierAlerts trains a per-secret Isolation Forest on the baseline access logs and
+// returns an ml_outlier alert for each recent access whose anomaly score exceeds the
+// configured threshold. Returns nil when there is too little baseline to train on or
+// the forest could not be grown — the caller then relies on the statistical rules.
+func mlOutlierAlerts(secret models.SecretNode, baselineLogs, recentLogs []models.SecretAccessLog, cfg MLConfig, now time.Time) []models.AnomalyAlert {
+	cfg = cfg.withDefaults()
+	if len(baselineLogs) < mlMinTrainSamples || len(recentLogs) == 0 {
+		return nil
+	}
+
+	ipFreq := make(map[string]int, len(baselineLogs))
+	userFreq := make(map[string]int, len(baselineLogs))
+	for _, lg := range baselineLogs {
+		if lg.IPAddress != "" {
+			ipFreq[lg.IPAddress]++
+		}
+		if lg.AccessedBy != "" {
+			userFreq[lg.AccessedBy]++
+		}
+	}
+
+	train := make([][]float64, len(baselineLogs))
+	for i, lg := range baselineLogs {
+		train[i] = accessFeatures(lg, ipFreq, userFreq)
+	}
+
+	rng := rand.New(rand.NewSource(cfg.Seed)) // #nosec G404 -- model sampling must be reproducible, not unpredictable; no security decision rides on this RNG
+	forest := newIsolationForest(train, cfg.NumTrees, cfg.SampleSize, rng)
+	if forest == nil {
+		return nil
+	}
+
+	var alerts []models.AnomalyAlert
+	for _, lg := range recentLogs {
+		score := forest.score(accessFeatures(lg, ipFreq, userFreq))
+		if score < cfg.Threshold {
+			continue
+		}
+		severity := "medium"
+		if score >= mlHighSeverityScore {
+			severity = "high"
+		}
+		alerts = append(alerts, models.AnomalyAlert{
+			SecretNodeID: secret.ID,
+			SecretName:   secret.Name,
+			AlertType:    "ml_outlier",
+			Severity:     severity,
+			Description: fmt.Sprintf("ML detected an anomalous access pattern (score %.2f): %s from %s at %s UTC differs from this secret's learned baseline",
+				score, displayOrUnknown(lg.AccessedBy), displayOrUnknown(lg.IPAddress), lg.AccessTime.UTC().Format("15:04")),
+			AccessedBy: lg.AccessedBy,
+			IPAddress:  lg.IPAddress,
+			DetectedAt: now,
+		})
+	}
+	return alerts
+}
+
+// displayOrUnknown renders an empty actor/IP as a readable placeholder in alert text.
+func displayOrUnknown(s string) string {
+	if s == "" {
+		return "an unknown source"
+	}
+	return s
+}

--- a/internal/core/anomaly_ml_test.go
+++ b/internal/core/anomaly_ml_test.go
@@ -1,0 +1,139 @@
+package core
+
+import (
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+func TestMLConfigWithDefaults(t *testing.T) {
+	got := MLConfig{Enabled: true}.withDefaults()
+	if got.Threshold != 0.60 || got.NumTrees != 100 || got.SampleSize != 256 || got.Seed != 1 {
+		t.Fatalf("defaults not applied: %+v", got)
+	}
+	// Out-of-range values are corrected; valid ones are kept.
+	got = MLConfig{Enabled: true, Threshold: 1.5, NumTrees: -3, SampleSize: 0, Seed: -1}.withDefaults()
+	if got.Threshold != 0.60 || got.NumTrees != 100 || got.SampleSize != 256 || got.Seed != 1 {
+		t.Fatalf("out-of-range not corrected: %+v", got)
+	}
+	got = MLConfig{Enabled: true, Threshold: 0.8, NumTrees: 50, SampleSize: 128, Seed: 9}.withDefaults()
+	if got.Threshold != 0.8 || got.NumTrees != 50 || got.SampleSize != 128 || got.Seed != 9 {
+		t.Fatalf("valid values must be preserved: %+v", got)
+	}
+}
+
+// buildBaselineLogs synthesises a believable 30-day access history with a graduated
+// frequency distribution: a dominant service account "app" from two IPs during
+// business hours, plus a rare-but-known human "alice" (~5%) from her own IP. This is
+// the distribution the rules cannot fully reason about — "alice" is known, so the
+// new_user rule never fires for her.
+func buildBaselineLogs(n int, start time.Time) []models.SecretAccessLog {
+	logs := make([]models.SecretAccessLog, 0, n)
+	for i := 0; i < n; i++ {
+		user, ip := "app", "10.0.0.1"
+		if i%3 == 0 {
+			ip = "10.0.0.2"
+		}
+		if i%20 == 0 { // alice ~5% of accesses, always from her own (rare) IP
+			user, ip = "alice", "10.0.0.3"
+		}
+		day := time.Duration(i%30) * 24 * time.Hour
+		hour := time.Duration(9+(i%9)) * time.Hour // business hours 09:00–17:00
+		logs = append(logs, models.SecretAccessLog{
+			AccessedBy: user,
+			IPAddress:  ip,
+			AccessTime: start.Add(-day).Truncate(24 * time.Hour).Add(hour),
+		})
+	}
+	return logs
+}
+
+// TestMLOutlierAlertsFlagsRareKnownActor is the headline value-add: a known-but-rare
+// actor at a normal business hour is flagged, while the dominant actor's identical-
+// pattern access is not. Crucially the new_user/new_ip rules stay silent here (alice
+// and her IP are both in the baseline), so this is a detection the rules cannot make.
+func TestMLOutlierAlertsFlagsRareKnownActor(t *testing.T) {
+	now := time.Date(2026, 6, 22, 12, 0, 0, 0, time.UTC)
+	secret := models.SecretNode{ID: 7, Name: "prod-db"}
+	baseline := buildBaselineLogs(160, now)
+
+	recent := []models.SecretAccessLog{
+		{AccessedBy: "alice", IPAddress: "10.0.0.3", AccessTime: time.Date(2026, 6, 22, 14, 0, 0, 0, time.UTC)}, // rare, known → outlier
+		{AccessedBy: "app", IPAddress: "10.0.0.1", AccessTime: time.Date(2026, 6, 22, 14, 0, 0, 0, time.UTC)},   // normal → no alert
+	}
+	alerts := mlOutlierAlerts(secret, baseline, recent, MLConfig{Enabled: true, Seed: 1}, now)
+	if len(alerts) != 1 {
+		t.Fatalf("expected exactly 1 ml_outlier (the rare actor), got %d: %+v", len(alerts), alerts)
+	}
+	a := alerts[0]
+	if a.AlertType != "ml_outlier" {
+		t.Errorf("AlertType = %q, want ml_outlier", a.AlertType)
+	}
+	if a.SecretNodeID != 7 || a.SecretName != "prod-db" {
+		t.Errorf("alert not attributed to the secret: %+v", a)
+	}
+	if a.AccessedBy != "alice" || a.IPAddress != "10.0.0.3" {
+		t.Errorf("alert should carry the outlier accessor/IP, got by=%q ip=%q", a.AccessedBy, a.IPAddress)
+	}
+	if a.Severity != "medium" {
+		t.Errorf("a rare-but-known actor should be medium severity, got %q", a.Severity)
+	}
+}
+
+// TestMLOutlierAlertsHighSeverityForStranger confirms a brand-new actor+IP (which the
+// rules also catch) scores into the high-severity band, so the ML signal corroborates
+// rather than contradicts the rules.
+func TestMLOutlierAlertsHighSeverityForStranger(t *testing.T) {
+	now := time.Date(2026, 6, 22, 12, 0, 0, 0, time.UTC)
+	secret := models.SecretNode{ID: 7, Name: "prod-db"}
+	baseline := buildBaselineLogs(160, now)
+
+	recent := []models.SecretAccessLog{
+		{AccessedBy: "mallory", IPAddress: "8.8.8.8", AccessTime: time.Date(2026, 6, 22, 3, 0, 0, 0, time.UTC)},
+	}
+	alerts := mlOutlierAlerts(secret, baseline, recent, MLConfig{Enabled: true, Seed: 1}, now)
+	if len(alerts) != 1 {
+		t.Fatalf("expected the stranger to be flagged, got %d alerts", len(alerts))
+	}
+	if alerts[0].Severity != "high" {
+		t.Errorf("a brand-new actor+IP should be high severity, got %q", alerts[0].Severity)
+	}
+}
+
+func TestMLOutlierAlertsNoFalsePositiveOnNormal(t *testing.T) {
+	now := time.Date(2026, 6, 22, 12, 0, 0, 0, time.UTC)
+	secret := models.SecretNode{ID: 7, Name: "prod-db"}
+	baseline := buildBaselineLogs(160, now)
+
+	// Several accesses indistinguishable from the dominant baseline pattern.
+	recent := []models.SecretAccessLog{
+		{AccessedBy: "app", IPAddress: "10.0.0.1", AccessTime: time.Date(2026, 6, 22, 10, 0, 0, 0, time.UTC)},
+		{AccessedBy: "app", IPAddress: "10.0.0.2", AccessTime: time.Date(2026, 6, 22, 15, 0, 0, 0, time.UTC)},
+	}
+	alerts := mlOutlierAlerts(secret, baseline, recent, MLConfig{Enabled: true, Seed: 1}, now)
+	if len(alerts) != 0 {
+		t.Fatalf("normal-pattern accesses must not be flagged, got %d: %+v", len(alerts), alerts)
+	}
+}
+
+func TestMLOutlierAlertsSkipsSparseBaseline(t *testing.T) {
+	now := time.Date(2026, 6, 22, 12, 0, 0, 0, time.UTC)
+	secret := models.SecretNode{ID: 7, Name: "prod-db"}
+	baseline := buildBaselineLogs(mlMinTrainSamples-1, now) // below the training floor
+	recent := []models.SecretAccessLog{
+		{AccessedBy: "mallory", IPAddress: "8.8.8.8", AccessTime: time.Date(2026, 6, 22, 3, 0, 0, 0, time.UTC)},
+	}
+	if alerts := mlOutlierAlerts(secret, baseline, recent, MLConfig{Enabled: true}, now); alerts != nil {
+		t.Fatalf("ML must abstain on a sparse baseline, got %+v", alerts)
+	}
+}
+
+func TestMLOutlierAlertsEmptyRecent(t *testing.T) {
+	now := time.Date(2026, 6, 22, 12, 0, 0, 0, time.UTC)
+	secret := models.SecretNode{ID: 7, Name: "prod-db"}
+	baseline := buildBaselineLogs(160, now)
+	if alerts := mlOutlierAlerts(secret, baseline, nil, MLConfig{Enabled: true}, now); alerts != nil {
+		t.Fatalf("no recent accesses → no alerts, got %+v", alerts)
+	}
+}

--- a/internal/core/isolation_forest.go
+++ b/internal/core/isolation_forest.go
@@ -1,0 +1,207 @@
+package core
+
+import (
+	"math"
+	"math/rand"
+)
+
+// Isolation Forest (Liu, Ting & Zhou, 2008) — an unsupervised outlier detector.
+// The intuition: anomalies are "few and different", so a random binary partition of
+// the feature space isolates them in fewer splits than normal points. We build an
+// ensemble of randomly-grown trees on a subsample of the *normal* distribution (the
+// learned baseline), then score new points by their average path length: a short
+// path (isolated quickly) means anomalous.
+//
+// This is a pure-Go, dependency-free implementation operating on []float64 feature
+// vectors. It is deliberately small — the secret-access feature space is low-
+// dimensional (see anomaly_ml.go) — and fully deterministic given a seeded RNG so
+// scores are reproducible and testable. Like the rest of the anomaly subsystem it
+// only ever sees access *metadata*, never secret values.
+
+// eulerGamma is the Euler–Mascheroni constant, used in the harmonic-number
+// approximation H(i) ≈ ln(i) + γ within the path-length normalisation c(n).
+const eulerGamma = 0.5772156649
+
+// iTreeNode is a node of a single isolation tree. Internal nodes carry a random
+// split (a feature index and threshold); external (leaf) nodes carry the size of the
+// subsample that reached them, so an unbuilt subtree's expected depth can be folded
+// into the path length via c(size).
+type iTreeNode struct {
+	left, right *iTreeNode
+	splitFeat   int
+	splitVal    float64
+	size        int // population at a leaf; 0 for internal nodes
+	external    bool
+}
+
+// isolationForest is a trained ensemble. psi is the subsample size actually used to
+// grow each tree; it is the normaliser for the anomaly score.
+type isolationForest struct {
+	trees []*iTreeNode
+	psi   int
+}
+
+// avgPathLength is c(n): the average path length of an unsuccessful search in a binary
+// search tree of n nodes. It normalises observed path lengths so the score is
+// comparable across forests grown on different subsample sizes.
+func avgPathLength(n int) float64 {
+	switch {
+	case n <= 1:
+		return 0
+	case n == 2:
+		return 1
+	default:
+		h := math.Log(float64(n-1)) + eulerGamma
+		return 2*h - 2*float64(n-1)/float64(n)
+	}
+}
+
+// newIsolationForest grows numTrees isolation trees, each on an independent random
+// subsample of at most sampleSize rows drawn from data. Returns nil when there is too
+// little data to learn from (fewer than 2 rows) — callers treat a nil forest as "no
+// ML signal" and fall back to the statistical rules.
+func newIsolationForest(data [][]float64, numTrees, sampleSize int, rng *rand.Rand) *isolationForest {
+	if len(data) < 2 || numTrees < 1 {
+		return nil
+	}
+	psi := sampleSize
+	if psi > len(data) {
+		psi = len(data)
+	}
+	if psi < 2 {
+		psi = 2
+	}
+	// Height limit per the paper: anomalies are isolated well above this, so growing
+	// deeper only refines the (already long) paths of normal points.
+	heightLimit := int(math.Ceil(math.Log2(float64(psi))))
+
+	f := &isolationForest{psi: psi, trees: make([]*iTreeNode, 0, numTrees)}
+	for t := 0; t < numTrees; t++ {
+		sub := subsample(data, psi, rng)
+		f.trees = append(f.trees, buildITree(sub, 0, heightLimit, rng))
+	}
+	return f
+}
+
+// subsample draws k rows from data without replacement via a partial Fisher–Yates
+// shuffle over an index permutation, so each tree sees a different slice of the
+// baseline. Rows are shared by reference (read-only during training).
+func subsample(data [][]float64, k int, rng *rand.Rand) [][]float64 {
+	n := len(data)
+	idx := make([]int, n)
+	for i := range idx {
+		idx[i] = i
+	}
+	if k > n {
+		k = n
+	}
+	for i := 0; i < k; i++ {
+		j := i + rng.Intn(n-i)
+		idx[i], idx[j] = idx[j], idx[i]
+	}
+	out := make([][]float64, k)
+	for i := 0; i < k; i++ {
+		out[i] = data[idx[i]]
+	}
+	return out
+}
+
+// buildITree grows one isolation tree by recursively splitting on a random feature at
+// a random threshold within that feature's observed range. Recursion stops at the
+// height limit, at a single (or empty) sample, or when the chosen feature is constant
+// across the node (no separating split exists).
+func buildITree(samples [][]float64, depth, heightLimit int, rng *rand.Rand) *iTreeNode {
+	if depth >= heightLimit || len(samples) <= 1 {
+		return &iTreeNode{external: true, size: len(samples)}
+	}
+	// Choose the split feature among those that actually vary in this node. Picking a
+	// constant feature would yield a degenerate (one-sided) split and waste depth, so a
+	// node is only a leaf when *every* feature is constant (the points are identical).
+	feat, minV, maxV, ok := pickSplitFeature(samples, rng)
+	if !ok {
+		return &iTreeNode{external: true, size: len(samples)}
+	}
+	split := minV + rng.Float64()*(maxV-minV)
+
+	left := make([][]float64, 0, len(samples))
+	right := make([][]float64, 0, len(samples))
+	for _, s := range samples {
+		if s[feat] < split {
+			left = append(left, s)
+		} else {
+			right = append(right, s)
+		}
+	}
+	return &iTreeNode{
+		splitFeat: feat,
+		splitVal:  split,
+		left:      buildITree(left, depth+1, heightLimit, rng),
+		right:     buildITree(right, depth+1, heightLimit, rng),
+	}
+}
+
+// pickSplitFeature returns a uniformly random feature among those with a non-zero
+// range across samples, plus that feature's min and max. ok is false when no feature
+// varies (all sampled points are identical), so the node must become a leaf.
+func pickSplitFeature(samples [][]float64, rng *rand.Rand) (feat int, minV, maxV float64, ok bool) {
+	nFeat := len(samples[0])
+	type rng2 struct{ lo, hi float64 }
+	ranges := make([]rng2, nFeat)
+	for f := 0; f < nFeat; f++ {
+		ranges[f] = rng2{samples[0][f], samples[0][f]}
+	}
+	for _, s := range samples {
+		for f := 0; f < nFeat; f++ {
+			if s[f] < ranges[f].lo {
+				ranges[f].lo = s[f]
+			}
+			if s[f] > ranges[f].hi {
+				ranges[f].hi = s[f]
+			}
+		}
+	}
+	varying := make([]int, 0, nFeat)
+	for f := 0; f < nFeat; f++ {
+		if ranges[f].hi > ranges[f].lo {
+			varying = append(varying, f)
+		}
+	}
+	if len(varying) == 0 {
+		return 0, 0, 0, false
+	}
+	feat = varying[rng.Intn(len(varying))]
+	return feat, ranges[feat].lo, ranges[feat].hi, true
+}
+
+// pathLength returns the depth at which x is isolated in one tree, folding in the
+// expected remaining depth c(size) when x lands in a leaf that still holds >1 sample
+// (i.e. an unbuilt subtree truncated by the height limit).
+func pathLength(x []float64, node *iTreeNode, depth int) float64 {
+	if node.external {
+		return float64(depth) + avgPathLength(node.size)
+	}
+	if x[node.splitFeat] < node.splitVal {
+		return pathLength(x, node.left, depth+1)
+	}
+	return pathLength(x, node.right, depth+1)
+}
+
+// score returns the isolation-forest anomaly score s(x) = 2^(-E[h(x)] / c(psi)),
+// in [0,1): values approaching 1 are strongly anomalous (consistently short paths),
+// values around 0.5 are indistinguishable from normal. Returns 0.5 for a forest that
+// failed to grow (defensive — newIsolationForest returns nil rather than such a one).
+func (f *isolationForest) score(x []float64) float64 {
+	if f == nil || len(f.trees) == 0 {
+		return 0.5
+	}
+	var total float64
+	for _, t := range f.trees {
+		total += pathLength(x, t, 0)
+	}
+	avg := total / float64(len(f.trees))
+	norm := avgPathLength(f.psi)
+	if norm == 0 {
+		return 0.5
+	}
+	return math.Pow(2, -avg/norm)
+}

--- a/internal/core/isolation_forest_test.go
+++ b/internal/core/isolation_forest_test.go
@@ -1,0 +1,91 @@
+package core
+
+import (
+	"math"
+	"math/rand"
+	"testing"
+)
+
+func TestAvgPathLength(t *testing.T) {
+	// Documented anchor values: c(1)=0, c(2)=1; c(n) grows ~ln(n).
+	if got := avgPathLength(1); got != 0 {
+		t.Fatalf("c(1) = %v, want 0", got)
+	}
+	if got := avgPathLength(2); got != 1 {
+		t.Fatalf("c(2) = %v, want 1", got)
+	}
+	if c10, c100 := avgPathLength(10), avgPathLength(100); !(c100 > c10 && c10 > 1) {
+		t.Fatalf("expected monotone growth 1 < c(10) < c(100), got c(10)=%v c(100)=%v", c10, c100)
+	}
+}
+
+// TestIsolationForestSeparatesOutlier is the core behavioural guarantee: a point far
+// outside a tight normal cluster scores higher (more anomalous) than a point inside it.
+func TestIsolationForestSeparatesOutlier(t *testing.T) {
+	rng := rand.New(rand.NewSource(42))
+	// 200 normal points clustered tightly around (10,10,10).
+	data := make([][]float64, 0, 201)
+	for i := 0; i < 200; i++ {
+		data = append(data, []float64{
+			10 + rng.Float64(),
+			10 + rng.Float64(),
+			10 + rng.Float64(),
+		})
+	}
+	forest := newIsolationForest(data, 100, 256, rand.New(rand.NewSource(7)))
+	if forest == nil {
+		t.Fatal("expected a trained forest")
+	}
+
+	normal := forest.score([]float64{10.5, 10.5, 10.5})
+	outlier := forest.score([]float64{100, 100, 100})
+	if outlier <= normal {
+		t.Fatalf("expected outlier score > normal score, got outlier=%.3f normal=%.3f", outlier, normal)
+	}
+	if outlier < 0.6 {
+		t.Errorf("a clear outlier should score well above 0.5, got %.3f", outlier)
+	}
+	if normal > 0.6 {
+		t.Errorf("an in-cluster point should score near 0.5, got %.3f", normal)
+	}
+}
+
+// TestIsolationForestDeterministic verifies the seed makes scoring reproducible — the
+// property the rest of the system relies on for stable, testable alerts.
+func TestIsolationForestDeterministic(t *testing.T) {
+	data := make([][]float64, 100)
+	for i := range data {
+		data[i] = []float64{float64(i % 24), float64(i % 5), float64(i % 7)}
+	}
+	x := []float64{3, 0, 0}
+	a := newIsolationForest(data, 50, 64, rand.New(rand.NewSource(99))).score(x)
+	b := newIsolationForest(data, 50, 64, rand.New(rand.NewSource(99))).score(x)
+	if math.Abs(a-b) > 1e-12 {
+		t.Fatalf("same seed must give identical scores, got %v vs %v", a, b)
+	}
+}
+
+func TestIsolationForestTooLittleData(t *testing.T) {
+	if f := newIsolationForest([][]float64{{1, 2, 3}}, 100, 256, rand.New(rand.NewSource(1))); f != nil {
+		t.Fatal("a single-row dataset should yield no forest")
+	}
+	if f := newIsolationForest(nil, 100, 256, rand.New(rand.NewSource(1))); f != nil {
+		t.Fatal("empty data should yield no forest")
+	}
+}
+
+func TestIsolationForestConstantFeatures(t *testing.T) {
+	// All-identical points: no split can separate them, so every score collapses to
+	// the neutral 0.5 — nothing is flagged. Must not panic or diverge.
+	data := make([][]float64, 50)
+	for i := range data {
+		data[i] = []float64{5, 5, 5}
+	}
+	forest := newIsolationForest(data, 50, 32, rand.New(rand.NewSource(3)))
+	if forest == nil {
+		t.Fatal("expected a forest even on constant data")
+	}
+	if s := forest.score([]float64{5, 5, 5}); math.Abs(s-0.5) > 0.2 {
+		t.Errorf("constant data should score ~0.5, got %v", s)
+	}
+}

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -888,7 +888,7 @@ type AnomalyAlert struct {
 	ID           uint `gorm:"primaryKey"`
 	SecretNodeID uint `gorm:"index"`
 	SecretName   string
-	AlertType    string // off_hours, new_ip, frequency_spike, new_user
+	AlertType    string // off_hours, new_ip, frequency_spike, new_user, ml_outlier
 	Severity     string // low, medium, high
 	Description  string
 	AccessedBy   string

--- a/server/http/handlers/audit_anomaly.go
+++ b/server/http/handlers/audit_anomaly.go
@@ -36,7 +36,8 @@ func ListAnomalyAlerts(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Optional ?severity=low|medium|high and ?alertType=off_hours|new_ip|new_user|
-	// frequency_spike narrow the list server-side (an empty value is no constraint).
+	// frequency_spike|ml_outlier narrow the list server-side (an empty value is no
+	// constraint).
 	alerts = core.FilterAlerts(alerts, r.URL.Query().Get("severity"), r.URL.Query().Get("alertType"))
 	sendSuccess(w, map[string]interface{}{"alerts": alerts, "total": len(alerts)}, "")
 }

--- a/server/main.go
+++ b/server/main.go
@@ -686,6 +686,16 @@ func startHTTPServer(ctx context.Context, cfg *config.Config) error {
 	// anomalies to project admins + the audit/SIEM pipeline.
 	go func() {
 		detector := core.NewAnomalyDetector(coreService.Storage())
+		if mlc := cfg.AnomalyAlerts.ML; mlc.Enabled {
+			detector.SetMLConfig(core.MLConfig{
+				Enabled:    true,
+				Threshold:  mlc.Threshold,
+				NumTrees:   mlc.NumTrees,
+				SampleSize: mlc.SampleSize,
+				Seed:       mlc.Seed,
+			})
+			log.Printf("Anomaly ML (Isolation Forest) detection enabled")
+		}
 		alertsEnabled := cfg.AnomalyAlerts.Enabled
 		interval := cfg.AnomalyAlerts.GetInterval()
 		if alertsEnabled {


### PR DESCRIPTION
## What

Adds an **opt-in Isolation Forest** anomaly-detection pass layered onto the existing rule-based access-anomaly detector (ADR-026). It complements the rules — it does not replace them.

The binary rules (off-hours by a fixed band, never-before-seen IP/user, volume spike) are blind to two things the forest catches:
- **Graduated rarity** — a *known-but-rare* actor or IP (the `new_user`/`new_ip` rules only see "known").
- **Multivariate combinations** — an access whose hour, source, and actor are each unremarkable but jointly rare.

## How

- Pure-Go Isolation Forest (`internal/core/isolation_forest.go`) — no new dependencies; deterministic (seeded RNG) so scoring is reproducible and testable.
- Per-secret model trained on the secret's 30-day access baseline; features are hour-of-day (cyclic sin/cos) + baseline IP/user frequency. Abstains below 20 baseline samples.
- Flagged accesses emit an `ml_outlier` alert (severity high ≥0.75 else medium) through the existing storage / list / acknowledge / alert / retention pipeline.
- Config-gated `anomaly_alerts.ml` (default off); runs in the existing single-replica scan scheduler. Metadata only — no secret value is examined.

## Testing

- Isolation Forest: separation, determinism, edge cases (too-little-data, constant features).
- ML glue: rare-known-actor flagged (the rule-invisible value-add), brand-new actor → high severity, no false positive on normal, sparse-baseline/empty-window abstain.
- gofmt / build / vet / gosec / golangci-lint clean; security-reviewed (no findings).

See **ADR-050** for the design and threshold rationale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)