### PR TITLE
feat(compliance): map ENS (RD 311/2022) into the live control matrix (ADR-051)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,9 @@ All notable changes to Keyorix are documented here. This project follows
   (RD 311/2022) measure (`op.acc.*` / `op.exp.*` / `mp.info.*` / …) alongside ISO 27001
   / SOC 2 / NIS2 / DORA, with the same live pass/gap/not-configured status. Lets an ENS
   auditor pull the secret-management control set mapped to RD 311/2022 with its current
-  state. Mappings are consistent with `docs/compliance/ENS-CONTROLS.md`. (ADR-051) ([#410])
+  state. Mappings are consistent with `docs/compliance/ENS-CONTROLS.md`. (ADR-051) ([#411])
 
-[#410]: https://github.com/keyorixhq/keyorix/pull/410
+[#411]: https://github.com/keyorixhq/keyorix/pull/411
 
 ## v0.74.0 — 2026-06-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to Keyorix are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## Unreleased
+
+### Added
+- **ENS in the compliance control matrix** — every control in the live control matrix
+  (`GET /api/v1/compliance/controls`, gRPC, and the `compliance-controls.csv` auditor
+  export) now carries an `ens` reference to its Spanish *Esquema Nacional de Seguridad*
+  (RD 311/2022) measure (`op.acc.*` / `op.exp.*` / `mp.info.*` / …) alongside ISO 27001
+  / SOC 2 / NIS2 / DORA, with the same live pass/gap/not-configured status. Lets an ENS
+  auditor pull the secret-management control set mapped to RD 311/2022 with its current
+  state. Mappings are consistent with `docs/compliance/ENS-CONTROLS.md`. (ADR-051) ([#410])
+
+[#410]: https://github.com/keyorixhq/keyorix/pull/410
+
 ## v0.74.0 — 2026-06-22
 
 Group lifecycle, audit completeness, and a few correctness fixes.

--- a/docs/adr-051-ens-control-framework.md
+++ b/docs/adr-051-ens-control-framework.md
@@ -1,0 +1,72 @@
+# ADR-051: ENS in the compliance control matrix
+
+## Status
+
+Accepted.
+
+## Context
+
+Keyorix exposes a live **compliance control matrix** (`GetComplianceControls`,
+`internal/core/control_framework.go`): each technical control it enforces is mapped to
+the relevant clauses of the regimes an auditor cares about — **ISO 27001 / SOC 2 /
+NIS2 / DORA** — and evaluated to a live `pass` / `gap` / `not_configured` status from
+the current posture. It surfaces over REST (`GET /api/v1/compliance/controls`), gRPC,
+and a `compliance-controls.csv` auditor export, and is embedded in the evidence pack.
+
+Spain's **Esquema Nacional de Seguridad (ENS)** — *Real Decreto 311/2022*, Anexo II —
+is the national security scheme that gates the public-sector / ENISA-aligned track the
+strategy depends on, and the legal entity (Keyorix SL) is Spanish. A standalone
+controls statement already exists (`docs/compliance/ENS-CONTROLS.md`), but ENS was the
+one regime **not** represented in the live matrix, so the product could not produce an
+ENS-mapped control set with current status the way it can for the other four.
+
+## Decision
+
+Add ENS as a fifth dimension of the existing control matrix rather than a parallel
+structure.
+
+- **Model.** A new `ENS []string` field on `FrameworkRefs` (`json:"ens,omitempty"`),
+  carrying RD 311/2022 Anexo II measure codes (`org.*` / `op.*` / `mp.*`).
+- **Mapping.** Every one of the 11 controls in `EvaluateControls` gains its ENS
+  measure(s), e.g. access recertification → `op.acc.4`, second factor → `op.acc.5/6`,
+  tamper-evident audit → `op.exp.8` (registro de actividad) + `op.exp.10` (protección
+  de los registros de actividad), secret rotation → `op.exp.11` (protección de claves
+  criptográficas), anomaly detection → `op.mon.1` + `op.exp.7`, classification →
+  `mp.info.2`. The codes are kept consistent with the `ENS-CONTROLS.md` statement.
+- **Surfaces.** The new field flows automatically through the JSON API and the evidence
+  pack (which embed the struct), and is explicitly wired into the CSV export (a new
+  `ens` column) and the gRPC `FrameworkRefs` message (field 5, proto regenerated).
+- **Status is unchanged.** ENS reuses each control's existing posture-derived status —
+  no new evaluation logic, since the underlying control (and therefore whether it
+  passes) is the same; only the regime it is *labelled* under is added.
+
+## Scope and positioning
+
+This maps Keyorix's **technical** controls to ENS measures; it does **not** claim ENS
+certification. ENS conformity is assessed per *information system* and is largely the
+operator's responsibility (security policy, risk analysis, categorisation, personnel,
+physical environment — the `org.*` framework). The matrix supports an operator's ENS
+compliance for the secret-management function; exact sub-measure codes and the system's
+*categoría* (BÁSICA / MEDIA / ALTA) are confirmed with a licensed ENS auditor, as the
+controls statement notes. The measure codes are therefore a best-effort, auditor-
+confirmable mapping, consistent with how the other four regimes are treated.
+
+## Alternatives considered
+
+- **A separate ENS-only endpoint / structure.** Rejected — it would duplicate the
+  status-evaluation logic and let the ENS view drift from the other regimes. One matrix
+  with five columns keeps a single source of truth.
+- **Documentation only (leave `ENS-CONTROLS.md` as the sole artifact).** Rejected — the
+  whole point of the live matrix is current, machine-readable status; ENS was the lone
+  regime an auditor couldn't pull programmatically.
+- **Encoding the full ENS categoría / dimension model (C/I/A/T/D, BÁSICA/MEDIA/ALTA).**
+  Deferred — that is an operator-/system-level assessment, not a product control state;
+  the dimension narrative lives in `ENS-CONTROLS.md`.
+
+## Deferred follow-ups
+
+- Surface the ENS column in the keyorix-web compliance UI (separate repo) — the matrix
+  page renders ISO/SOC2/NIS2/DORA today; ENS is carried in the API already.
+- Optional per-regime filtering of the matrix (show only the ENS view).
+- Map any future controls (e.g. backup/continuity `op.cont`, comms `mp.com`) as those
+  postures become first-class matrix entries.

--- a/docs/compliance/ENS-CONTROLS.md
+++ b/docs/compliance/ENS-CONTROLS.md
@@ -55,7 +55,7 @@ for the secrets it manages:
 
 **Status:** Shipped.
 
-### Marco operacional — Registro de la actividad (`op.exp.8`)
+### Marco operacional — Registro de la actividad y su protección (`op.exp.8`, `op.exp.10`)
 
 **Keyorix provides** (full treatment in [`AUDIT-LOG-PROVISIONS.md`](./AUDIT-LOG-PROVISIONS.md)):
 - A complete activity log of every security-relevant event (secret CRUD, sharing,
@@ -63,10 +63,10 @@ for the secrets it manages:
   impersonation start/end), each carrying **actor identity, timestamp, and
   outcome** — the core ENS *registro de actividad* requirement, with proportionate
   detail for higher categorías.
-- **Tamper-evidence** — a SHA-256 **hash chain** over audit events makes any
-  modification, deletion, insertion, or reorder detectable
-  (`GET /api/v1/audit/verify`), supporting integridad/trazabilidad of the log
-  itself.
+- **Tamper-evidence (op.exp.10 — protección de los registros de actividad)** — a
+  SHA-256 **hash chain** over audit events makes any modification, deletion,
+  insertion, or reorder detectable (`GET /api/v1/audit/verify`), supporting
+  integridad/trazabilidad of the log itself.
 - **Actor attribution** including delegated actions (`impersonated_by`/
   `acting_as`), and **SIEM** export (Splunk / Datadog / webhook + pull export).
 
@@ -75,7 +75,7 @@ for the secrets it manages:
 ### Marco operacional — Protección de claves criptográficas & monitorización
 
 **Keyorix provides:**
-- **Protección de claves criptográficas** — envelope encryption: a Data
+- **Protección de claves criptográficas (op.exp.11)** — envelope encryption: a Data
   Encryption Key (DEK) wrapped by a passphrase-derived Key Encryption Key (KEK,
   PBKDF2, 600k iterations); the wrapped DEK and KEK salt live on a dedicated
   persisted volume; KEK bytes are wiped from memory after unwrap. Operator-driven
@@ -94,6 +94,13 @@ for the secrets it manages:
   rest with **AES-256-GCM**; Additional Authenticated Data binds each ciphertext
   to its `secretID:projectID:version`, preventing ciphertext substitution between
   secrets.
+- **Calificación de la información (mp.info.2)** — per-secret data classification,
+  surfaced as a posture control so an operator can evidence that managed secrets are
+  classified.
+- **Datos de carácter personal / storage limitation (mp.info.1)** — a configurable
+  data-retention scheduler ages out compliance records past their window (respecting
+  legal hold), and a **litigation/legal hold (mp.info.6)** blocks purges to preserve
+  records under investigation.
 - **No plaintext exposure** — no secret values, passphrases, key bytes, or raw
   tokens are written to logs (audited across every sink); reusable credentials are
   SHA-256-hashed at rest and never compared in plaintext.
@@ -133,6 +140,16 @@ audit trail that evidences that the operator's procedures are followed.
 | `mp.info.3` — Cifrado | C, I | AES-256-GCM at rest, AAD-bound | Shipped |
 | `mp.com` — Comunicaciones | C, A, I | TLS in transit; signed/validated federation | Shipped (TLS operator-configured) |
 | `org.*` — Marco organizativo | — | Supported operationally; operator-defined | Operator |
+
+## Live in the product
+
+These ENS measure codes are not just documentation: the running product's **compliance
+control matrix** (`GET /api/v1/compliance/controls`, its gRPC equivalent, and the
+`compliance-controls.csv` auditor export) now carries an `ens` reference on every
+control alongside ISO 27001 / SOC 2 / NIS2 / DORA, each with a **live pass / gap /
+not-configured status** derived from the deployment's current posture (ADR-051). An
+ENS auditor can therefore pull the secret-management control set, mapped to RD 311/2022
+measures, with its current state — rather than reconciling this document by hand.
 
 > The technical-control evidence behind these claims — the security audits
 > performed and the issues found and fixed — is recorded in

--- a/internal/core/compliance_evidence.go
+++ b/internal/core/compliance_evidence.go
@@ -1,5 +1,5 @@
 // compliance_evidence.go — an auditor evidence pack (ISO 27001 / SOC 2 / NIS2 /
-// DORA). Where GetCompliancePosture (compliance_posture.go) is the at-a-glance
+// DORA / ENS). Where GetCompliancePosture (compliance_posture.go) is the at-a-glance
 // summary, GenerateComplianceEvidence bundles the posture together with the
 // supporting records that substantiate it — the tamper-evidence audit anchor, the
 // access-recertification campaigns, the break-glass register, and the overdue
@@ -53,7 +53,7 @@ type EvidenceRotation struct {
 type ComplianceEvidence struct {
 	GeneratedAt     time.Time                      `json:"generated_at"`
 	Posture         *CompliancePosture             `json:"posture"`
-	Controls        []ControlState                 `json:"controls"` // framework matrix (ISO/SOC2/NIS2/DORA)
+	Controls        []ControlState                 `json:"controls"` // framework matrix (ISO/SOC2/NIS2/DORA/ENS)
 	AuditAnchor     AuditAnchor                    `json:"audit_anchor"`
 	Campaigns       []EvidenceCampaign             `json:"campaigns"`
 	BreakGlass      []*models.BreakGlassActivation `json:"break_glass"`

--- a/internal/core/control_framework.go
+++ b/internal/core/control_framework.go
@@ -1,6 +1,6 @@
 // control_framework.go — the compliance control matrix (ISO 27001 / SOC 2 / NIS2 /
-// DORA). Where GetCompliancePosture reports raw figures, GetComplianceControls maps
-// each control Keyorix enforces to its clause references across the regimes an
+// DORA / ENS). Where GetCompliancePosture reports raw figures, GetComplianceControls
+// maps each control Keyorix enforces to its clause references across the regimes an
 // auditor cares about, and evaluates a live status (pass / gap / not-configured)
 // from the posture. It turns the scattered A.5.x tiles into one auditor-ready
 // framework map. Read-only; gated by system.read.
@@ -27,6 +27,10 @@ type FrameworkRefs struct {
 	SOC2     []string `json:"soc2,omitempty"`      // Trust Services Criteria, e.g. "CC6.1"
 	NIS2     []string `json:"nis2,omitempty"`      // article refs, e.g. "Art.21(2)(i)"
 	DORA     []string `json:"dora,omitempty"`      // article refs, e.g. "Art.9"
+	// ENS maps to the security measures of Spain's Esquema Nacional de Seguridad
+	// (Real Decreto 311/2022, Anexo II), e.g. "op.acc.4". Codes name the measure in
+	// the org.* (organisational) / op.* (operational) / mp.* (protection) frameworks.
+	ENS []string `json:"ens,omitempty"`
 }
 
 // ControlState is one control's evaluated posture for the framework matrix.
@@ -94,67 +98,67 @@ func EvaluateControls(p *CompliancePosture) []ControlState {
 			ID: "audit-trail-integrity", Name: "Tamper-evident audit trail", Area: "Audit & accountability",
 			Status:     gapIf(!p.AuditIntegrity.ChainVerified),
 			Detail:     fmt.Sprintf("chain verified=%t, checkpointed=%t, %d events", p.AuditIntegrity.ChainVerified, p.AuditIntegrity.Checkpointed, p.AuditIntegrity.ChainedEvents),
-			Frameworks: FrameworkRefs{ISO27001: []string{"A.5.28", "A.8.15"}, SOC2: []string{"CC7.2", "CC4.1"}, NIS2: []string{"Art.21(2)(i)"}, DORA: []string{"Art.9"}},
+			Frameworks: FrameworkRefs{ISO27001: []string{"A.5.28", "A.8.15"}, SOC2: []string{"CC7.2", "CC4.1"}, NIS2: []string{"Art.21(2)(i)"}, DORA: []string{"Art.9"}, ENS: []string{"op.exp.8", "op.exp.10"}},
 		},
 		{
 			ID: "access-recertification", Name: "Access recertification at planned intervals", Area: "Access governance",
 			Status:     gapIf(ag.ProjectsOverdue > 0 || ag.ProjectsNeverReviewed > 0),
 			Detail:     fmt.Sprintf("%d overdue, %d never reviewed, %d pending items", ag.ProjectsOverdue, ag.ProjectsNeverReviewed, ag.PendingItems),
-			Frameworks: FrameworkRefs{ISO27001: []string{"A.5.18"}, SOC2: []string{"CC6.2", "CC6.3"}, NIS2: []string{"Art.21(2)(i)"}, DORA: []string{"Art.9"}},
+			Frameworks: FrameworkRefs{ISO27001: []string{"A.5.18"}, SOC2: []string{"CC6.2", "CC6.3"}, NIS2: []string{"Art.21(2)(i)"}, DORA: []string{"Art.9"}, ENS: []string{"op.acc.4"}},
 		},
 		{
 			ID: "dormant-access", Name: "No dormant standing access", Area: "Access governance",
 			Status:     gapIf(ag.DormantRoleGrants > 0),
 			Detail:     fmt.Sprintf("%d dormant role grant(s)", ag.DormantRoleGrants),
-			Frameworks: FrameworkRefs{ISO27001: []string{"A.5.18", "A.8.2"}, SOC2: []string{"CC6.1"}},
+			Frameworks: FrameworkRefs{ISO27001: []string{"A.5.18", "A.8.2"}, SOC2: []string{"CC6.1"}, ENS: []string{"op.acc.2", "op.acc.4"}},
 		},
 		{
 			ID: "separation-of-duties", Name: "Separation of duties (no toxic combinations)", Area: "Access governance",
 			Status:     gapIf(ag.SoDViolations > 0),
 			Detail:     fmt.Sprintf("%d SoD violation(s)", ag.SoDViolations),
-			Frameworks: FrameworkRefs{ISO27001: []string{"A.5.3"}, SOC2: []string{"CC5.1"}, DORA: []string{"Art.5"}},
+			Frameworks: FrameworkRefs{ISO27001: []string{"A.5.3"}, SOC2: []string{"CC5.1"}, DORA: []string{"Art.5"}, ENS: []string{"op.acc.3"}},
 		},
 		{
 			ID: "second-factor", Name: "Second-factor coverage", Area: "Identity",
 			Status:     gapIf(p.Identity.SecondFactorPercent < 100),
 			Detail:     fmt.Sprintf("%d%% of active users have a second factor", p.Identity.SecondFactorPercent),
-			Frameworks: FrameworkRefs{ISO27001: []string{"A.5.17", "A.8.5"}, SOC2: []string{"CC6.1"}, NIS2: []string{"Art.21(2)(j)"}, DORA: []string{"Art.9"}},
+			Frameworks: FrameworkRefs{ISO27001: []string{"A.5.17", "A.8.5"}, SOC2: []string{"CC6.1"}, NIS2: []string{"Art.21(2)(j)"}, DORA: []string{"Art.9"}, ENS: []string{"op.acc.5", "op.acc.6"}},
 		},
 		{
 			ID: "secret-rotation", Name: "Secret-rotation hygiene", Area: "Cryptography",
 			Status:     gapIf(p.Rotation.Overdue > 0),
 			Detail:     fmt.Sprintf("%d overdue, %d due soon of %d covered", p.Rotation.Overdue, p.Rotation.DueSoon, p.Rotation.CoveredSecrets),
-			Frameworks: FrameworkRefs{ISO27001: []string{"A.5.15", "A.8.24"}, SOC2: []string{"CC6.1"}, NIS2: []string{"Art.21(2)(h)"}},
+			Frameworks: FrameworkRefs{ISO27001: []string{"A.5.15", "A.8.24"}, SOC2: []string{"CC6.1"}, NIS2: []string{"Art.21(2)(h)"}, ENS: []string{"op.exp.11"}},
 		},
 		{
 			ID: "data-classification", Name: "Secret data classification", Area: "Asset management",
 			Status:     gapIf(p.Classification.Unclassified > 0),
 			Detail:     fmt.Sprintf("%d of %d secrets unclassified", p.Classification.Unclassified, p.Classification.TotalSecrets),
-			Frameworks: FrameworkRefs{ISO27001: []string{"A.5.12", "A.5.13"}, SOC2: []string{"CC3.2"}},
+			Frameworks: FrameworkRefs{ISO27001: []string{"A.5.12", "A.5.13"}, SOC2: []string{"CC3.2"}, ENS: []string{"mp.info.2"}},
 		},
 		{
 			ID: "anomaly-detection", Name: "Access-anomaly detection & response", Area: "Detection",
 			Status:     gapIf(p.Anomalies.HighSeverityOpen > 0),
 			Detail:     fmt.Sprintf("%d open anomalies (%d high severity)", p.Anomalies.Unacknowledged, p.Anomalies.HighSeverityOpen),
-			Frameworks: FrameworkRefs{ISO27001: []string{"A.8.16"}, SOC2: []string{"CC7.2", "CC7.3"}, NIS2: []string{"Art.21(2)(b)"}, DORA: []string{"Art.10"}},
+			Frameworks: FrameworkRefs{ISO27001: []string{"A.8.16"}, SOC2: []string{"CC7.2", "CC7.3"}, NIS2: []string{"Art.21(2)(b)"}, DORA: []string{"Art.10"}, ENS: []string{"op.mon.1", "op.exp.7"}},
 		},
 		{
 			ID: "emergency-access", Name: "Governed emergency (break-glass) access", Area: "Access governance",
 			Status:     ControlStatusPass, // presence of the register is the control; usage is informational
 			Detail:     fmt.Sprintf("%d active, %d total activations (all audited)", p.EmergencyAccess.ActiveActivations, p.EmergencyAccess.TotalActivations),
-			Frameworks: FrameworkRefs{ISO27001: []string{"A.5.15"}, SOC2: []string{"CC6.1"}, DORA: []string{"Art.9"}},
+			Frameworks: FrameworkRefs{ISO27001: []string{"A.5.15"}, SOC2: []string{"CC6.1"}, DORA: []string{"Art.9"}, ENS: []string{"op.acc.4", "op.exp.7"}},
 		},
 		{
 			ID: "data-retention", Name: "Data-retention / storage limitation", Area: "Data governance",
 			Status:     statusFromBool(p.Retention.Enabled),
 			Detail:     retentionDetail(p.Retention),
-			Frameworks: FrameworkRefs{ISO27001: []string{"A.5.33"}, SOC2: []string{"CC3.2"}, DORA: []string{"Art.12"}},
+			Frameworks: FrameworkRefs{ISO27001: []string{"A.5.33"}, SOC2: []string{"CC3.2"}, DORA: []string{"Art.12"}, ENS: []string{"mp.info.1"}},
 		},
 		{
 			ID: "legal-hold", Name: "Litigation/investigation legal hold", Area: "Data governance",
 			Status:     ControlStatusPass, // capability present; active state is informational
 			Detail:     legalHoldDetail(p.LegalHold),
-			Frameworks: FrameworkRefs{ISO27001: []string{"A.5.34"}, DORA: []string{"Art.12"}},
+			Frameworks: FrameworkRefs{ISO27001: []string{"A.5.34"}, DORA: []string{"Art.12"}, ENS: []string{"mp.info.6"}},
 		},
 	}
 }

--- a/internal/core/control_framework_test.go
+++ b/internal/core/control_framework_test.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -37,6 +38,7 @@ func TestEvaluateControls_HealthyPosture(t *testing.T) {
 	for _, c := range controls {
 		assert.NotEqual(t, ControlStatusGap, c.Status, "healthy posture has no gaps: %s", c.ID)
 		assert.NotEmpty(t, c.Frameworks.ISO27001, "control %s maps to an ISO 27001 clause", c.ID)
+		assert.NotEmpty(t, c.Frameworks.ENS, "control %s maps to an ENS measure", c.ID)
 		assert.NotEmpty(t, c.Name)
 	}
 	// Retention enabled → pass.
@@ -67,6 +69,27 @@ func TestEvaluateControls_GapsFromPosture(t *testing.T) {
 	assert.Equal(t, ControlStatusGap, findControl(t, controls, "anomaly-detection").Status)
 	// Retention unconfigured is "not configured", not a hard gap.
 	assert.Equal(t, ControlStatusNotConfigured, findControl(t, controls, "data-retention").Status)
+}
+
+// Every ENS reference is a well-formed RD 311/2022 measure code: it names one of the
+// three measure frameworks (org. / op. / mp.) so the matrix can't carry a typo'd or
+// stray code that an auditor would reject.
+func TestEvaluateControls_ENSMeasureCodesWellFormed(t *testing.T) {
+	controls := EvaluateControls(&CompliancePosture{})
+	validPrefix := func(code string) bool {
+		for _, p := range []string{"org.", "op.", "mp."} {
+			if strings.HasPrefix(code, p) {
+				return true
+			}
+		}
+		return false
+	}
+	for _, c := range controls {
+		for _, code := range c.Frameworks.ENS {
+			assert.True(t, validPrefix(code),
+				"control %s has ENS code %q outside the org./op./mp. frameworks", c.ID, code)
+		}
+	}
 }
 
 func TestGetComplianceControls_SummaryTallies(t *testing.T) {

--- a/server/grpc/services/compliance_service.go
+++ b/server/grpc/services/compliance_service.go
@@ -160,6 +160,7 @@ func complianceControlsToProto(c *core.ComplianceControls) *pb.ComplianceControl
 				Soc2:      ctl.Frameworks.SOC2,
 				Nis2:      ctl.Frameworks.NIS2,
 				Dora:      ctl.Frameworks.DORA,
+				Ens:       ctl.Frameworks.ENS,
 			},
 		})
 	}

--- a/server/http/handlers/compliance_controls_csv.go
+++ b/server/http/handlers/compliance_controls_csv.go
@@ -1,6 +1,6 @@
 // compliance_controls_csv.go — ExportComplianceControlsCSV: the compliance control
-// matrix (each control mapped to ISO 27001 / SOC 2 / NIS2 / DORA clauses with its live
-// pass/gap status) as a CSV attachment for an auditor's spreadsheet. The JSON form is
+// matrix (each control mapped to ISO 27001 / SOC 2 / NIS2 / DORA / ENS clauses with its
+// live pass/gap status) as a CSV attachment for an auditor's spreadsheet. The JSON form is
 // GET /compliance/controls; this is the compliance-export-family CSV counterpart, beside
 // the audit-log and asset-inventory CSVs.
 package handlers
@@ -34,7 +34,7 @@ func (h *DashboardHandler) ExportComplianceControlsCSV(w http.ResponseWriter, r 
 
 	cw := csv.NewWriter(w)
 	defer cw.Flush()
-	_ = cw.Write([]string{"id", "name", "area", "status", "detail", "iso_27001", "soc2", "nis2", "dora"})
+	_ = cw.Write([]string{"id", "name", "area", "status", "detail", "iso_27001", "soc2", "nis2", "dora", "ens"})
 	for _, ctrl := range matrix.Controls {
 		_ = cw.Write([]string{
 			ctrl.ID,
@@ -46,6 +46,7 @@ func (h *DashboardHandler) ExportComplianceControlsCSV(w http.ResponseWriter, r 
 			strings.Join(ctrl.Frameworks.SOC2, "; "),
 			strings.Join(ctrl.Frameworks.NIS2, "; "),
 			strings.Join(ctrl.Frameworks.DORA, "; "),
+			strings.Join(ctrl.Frameworks.ENS, "; "),
 		})
 	}
 }

--- a/server/http/handlers/compliance_controls_csv_test.go
+++ b/server/http/handlers/compliance_controls_csv_test.go
@@ -42,7 +42,7 @@ func TestExportComplianceControlsCSV(t *testing.T) {
 		body := w.Body.String()
 		lines := strings.Split(strings.TrimSpace(body), "\n")
 		require.GreaterOrEqual(t, len(lines), 2, "header + at least one control")
-		assert.Equal(t, "id,name,area,status,detail,iso_27001,soc2,nis2,dora", strings.TrimSpace(lines[0]))
+		assert.Equal(t, "id,name,area,status,detail,iso_27001,soc2,nis2,dora,ens", strings.TrimSpace(lines[0]))
 		// The tamper-evident audit-trail control and its ISO ref come through.
 		assert.Contains(t, body, "audit-trail-integrity")
 		assert.Contains(t, body, "A.5.28")

--- a/server/proto/keyorix.proto
+++ b/server/proto/keyorix.proto
@@ -1070,6 +1070,8 @@ message FrameworkRefs {
   repeated string soc2 = 2;
   repeated string nis2 = 3;
   repeated string dora = 4;
+  // ENS — Spain's Esquema Nacional de Seguridad (RD 311/2022) measure codes.
+  repeated string ens = 5;
 }
 
 message ControlState {

--- a/server/proto/pb/keyorix.pb.go
+++ b/server/proto/pb/keyorix.pb.go
@@ -7686,11 +7686,13 @@ func (x *CompliancePosture) GetRisk() *RiskPosture {
 }
 
 type FrameworkRefs struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Iso_27001     []string               `protobuf:"bytes,1,rep,name=iso_27001,json=iso27001,proto3" json:"iso_27001,omitempty"`
-	Soc2          []string               `protobuf:"bytes,2,rep,name=soc2,proto3" json:"soc2,omitempty"`
-	Nis2          []string               `protobuf:"bytes,3,rep,name=nis2,proto3" json:"nis2,omitempty"`
-	Dora          []string               `protobuf:"bytes,4,rep,name=dora,proto3" json:"dora,omitempty"`
+	state     protoimpl.MessageState `protogen:"open.v1"`
+	Iso_27001 []string               `protobuf:"bytes,1,rep,name=iso_27001,json=iso27001,proto3" json:"iso_27001,omitempty"`
+	Soc2      []string               `protobuf:"bytes,2,rep,name=soc2,proto3" json:"soc2,omitempty"`
+	Nis2      []string               `protobuf:"bytes,3,rep,name=nis2,proto3" json:"nis2,omitempty"`
+	Dora      []string               `protobuf:"bytes,4,rep,name=dora,proto3" json:"dora,omitempty"`
+	// ENS — Spain's Esquema Nacional de Seguridad (RD 311/2022) measure codes.
+	Ens           []string `protobuf:"bytes,5,rep,name=ens,proto3" json:"ens,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -7749,6 +7751,13 @@ func (x *FrameworkRefs) GetNis2() []string {
 func (x *FrameworkRefs) GetDora() []string {
 	if x != nil {
 		return x.Dora
+	}
+	return nil
+}
+
+func (x *FrameworkRefs) GetEns() []string {
+	if x != nil {
+		return x.Ens
 	}
 	return nil
 }
@@ -9131,12 +9140,13 @@ const file_keyorix_proto_rawDesc = "" +
 	"legal_hold\x18\t \x01(\v2\x1c.keyorix.v1.LegalHoldPostureR\tlegalHold\x12:\n" +
 	"\tretention\x18\n" +
 	" \x01(\v2\x1c.keyorix.v1.RetentionPostureR\tretention\x12+\n" +
-	"\x04risk\x18\v \x01(\v2\x17.keyorix.v1.RiskPostureR\x04risk\"h\n" +
+	"\x04risk\x18\v \x01(\v2\x17.keyorix.v1.RiskPostureR\x04risk\"z\n" +
 	"\rFrameworkRefs\x12\x1b\n" +
 	"\tiso_27001\x18\x01 \x03(\tR\biso27001\x12\x12\n" +
 	"\x04soc2\x18\x02 \x03(\tR\x04soc2\x12\x12\n" +
 	"\x04nis2\x18\x03 \x03(\tR\x04nis2\x12\x12\n" +
-	"\x04dora\x18\x04 \x03(\tR\x04dora\"\xb1\x01\n" +
+	"\x04dora\x18\x04 \x03(\tR\x04dora\x12\x10\n" +
+	"\x03ens\x18\x05 \x03(\tR\x03ens\"\xb1\x01\n" +
 	"\fControlState\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12\x12\n" +


### PR DESCRIPTION
## What

Adds **ENS** (Spain's *Esquema Nacional de Seguridad*, RD 311/2022) as a fifth dimension of the live compliance control matrix, alongside ISO 27001 / SOC 2 / NIS2 / DORA. ENS was the one regime not represented in the matrix, so the product could not produce an ENS-mapped control set with current status the way it can for the others.

## How

- New `ENS []string` field on `FrameworkRefs`; all 11 controls in `EvaluateControls` mapped to their RD 311/2022 Anexo II measures (`op.acc.*`, `op.exp.8`/`op.exp.10`/`op.exp.11`, `op.mon.1`, `mp.info.*`).
- ENS reuses each control's existing posture-derived pass/gap/not-configured status — no new evaluation logic, just the added regime label.
- Fans out to every surface: JSON API + evidence pack (struct-embedded), a new `ens` CSV column, and gRPC (`FrameworkRefs` field 5, proto regenerated).
- Mappings kept consistent with `docs/compliance/ENS-CONTROLS.md`, which gains the matching sub-measure numbers and a "live in the product" note.

This maps Keyorix's **technical** controls to ENS measures; it does not claim ENS certification (a per-system, largely operator-level assessment).

## Testing

- Every control maps to an ENS measure; all ENS codes are well-formed `org./op./mp.` measures; CSV header assertion updated.
- gofmt / build / gosec / golangci-lint / `buf lint` clean.

See **ADR-051**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)