### PR TITLE
feat(secrets): secret dependency tracking + impact/rotation-order (ADR-052)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,25 @@
 All notable changes to Keyorix are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## Unreleased
+
+### Added
+- **Secret dependency tracking** — declare that one secret depends on another (e.g. an
+  app token derived from a DB password, or a cert chain) and Keyorix maintains the
+  per-project dependency graph. Answers two questions before a rotation: **impact /
+  blast radius** (`GET /api/v1/secrets/{id}/impact` — the transitive dependents that
+  break if you rotate it) and **rotation order** (`GET /api/v1/projects/{id}/rotation-order`
+  — a safe sequence where each secret precedes anything depending on it). Manage edges
+  via `GET/POST /secrets/{id}/dependencies` + `DELETE /secrets/{id}/dependencies/{depId}`,
+  gated by scoped `secrets.read`/`secrets.write` and audited. Edges are confined to a
+  single project + environment (matching Keyorix's environment-granular authorization)
+  and the graph is kept acyclic (self-edges, duplicates, cross-project/-environment, and
+  cycles are rejected). Metadata only — no
+  secret value is read. This is the prerequisite for automated rotation planning; the
+  topological order is the deterministic core of that. (ADR-052) ([#411])
+
+[#411]: https://github.com/keyorixhq/keyorix/pull/411
+
 ## v0.74.0 — 2026-06-22
 
 Group lifecycle, audit completeness, and a few correctness fixes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,9 @@ All notable changes to Keyorix are documented here. This project follows
   and the graph is kept acyclic (self-edges, duplicates, cross-project/-environment, and
   cycles are rejected). Metadata only — no
   secret value is read. This is the prerequisite for automated rotation planning; the
-  topological order is the deterministic core of that. (ADR-052) ([#411])
+  topological order is the deterministic core of that. (ADR-052) ([#412])
 
-[#411]: https://github.com/keyorixhq/keyorix/pull/411
+[#412]: https://github.com/keyorixhq/keyorix/pull/412
 
 ## v0.74.0 — 2026-06-22
 

--- a/docs/adr-052-secret-dependency-tracking.md
+++ b/docs/adr-052-secret-dependency-tracking.md
@@ -1,0 +1,91 @@
+# ADR-052: Secret dependency tracking
+
+## Status
+
+Accepted.
+
+## Context
+
+Keyorix can rotate secrets — manually, on a schedule, and (ADR-046/047) automatically,
+including against upstream backends. But it has no notion that one secret *depends on*
+another: a database password whose value is embedded in an application token; a root CA
+that signs an intermediate that signs a leaf certificate; an API key referenced by a
+derived service credential. Without that knowledge two questions an operator must answer
+before rotating anything go unanswered:
+
+- **Impact / blast radius** — "if I rotate this secret, what else breaks or must be
+  refreshed?"
+- **Rotation order** — "in what sequence should I rotate a set of related secrets so I
+  don't invalidate a dependent before its dependency is in place?"
+
+The M3 roadmap lists *"Automated rotation planning — AI proposes rotation sequence"*
+with the note **"Requires secret dependency tracking first."** This ADR builds that
+prerequisite — and, since a topological sort of the dependency graph *is* a correct
+rotation sequence, it delivers the planning value deterministically, leaving any
+AI/heuristic layer as later polish rather than a dependency.
+
+## Decision
+
+Model an explicit, operator-declared **directed dependency graph** over secrets and
+answer the two questions from it.
+
+- **Edge model.** `SecretDependency` is one directed edge — `DependentSecretID` depends
+  on `DependsOnSecretID` — within a single project **and environment** (the project id
+  is denormalised onto the row for cheap project-scoped queries). The pair is unique.
+- **Invariant: the graph is a DAG, confined to one environment.** At add time the core
+  rejects a self-edge, a duplicate, an endpoint that isn't a real secret, an edge whose
+  endpoints are in different projects **or environments**, and — crucially — any edge
+  that would introduce a **cycle** (checked by testing whether the prospective
+  dependency can already reach the dependent over existing edges). Keeping the graph
+  acyclic is what makes a rotation order always exist.
+- **Authorization is environment-granular.** A grant is scoped to {project,
+  environment}, and the HTTP layer authorizes the caller on the *path* secret's
+  environment. Confining every edge to a single environment is what makes that
+  authorization also cover the dependency secret — a cross-environment edge would let a
+  caller scoped to one environment reference (and then read the name of) a secret in
+  another. `DELETE` additionally requires the edge to *reference* the path secret, so
+  the same environment-scoped grant governs the removal. (This closed a cross-
+  environment IDOR caught in pre-merge security review.)
+- **Queries (pure, unit-tested graph functions over the project's edges):**
+  - *Impact* — `GetSecretImpact` returns the transitive **dependents** of a secret in
+    breadth-first order with hop-distance: the blast radius of rotating it.
+  - *Rotation order* — `GetProjectRotationOrder` returns a topological order (Kahn's
+    algorithm, deterministic ascending-id tie-break) in which every secret precedes any
+    secret that depends on it — i.e. rotate foundational secrets first, then refresh
+    their dependents.
+- **API (HTTP, project-scoped via the secret in the path).** Under `/secrets/{id}`:
+  `GET/POST /dependencies`, `DELETE /dependencies/{depId}`, `GET /impact`; plus
+  `GET /projects/{id}/rotation-order`. Reads require scoped `secrets.read`, mutations
+  scoped `secrets.write` — the same RBAC as the secrets themselves; `DELETE` additionally
+  checks the edge *references* the path secret so the environment-scoped grant actually
+  guards it.
+- **Audit.** Adding/removing an edge writes `secret.dependency_added` /
+  `secret.dependency_removed`, attributed to the actor and the dependent secret.
+- **Metadata only.** The graph is built from declared relationships and secret
+  *names*; no secret value is ever read.
+
+## Alternatives considered
+
+- **Infer dependencies automatically** (e.g. scan values for one secret embedded in
+  another). Rejected — it would require reading plaintext values (against the
+  metadata-only principle) and is unreliable; the operator's explicit declaration is the
+  trust boundary, mirroring how classification and rotation policies are operator-set.
+- **Allow cycles and best-effort order.** Rejected — a cycle has no valid rotation order
+  and almost always indicates a modelling error; failing closed at add keeps every later
+  query total and meaningful.
+- **Jump straight to "AI proposes a rotation sequence."** Deferred — the deterministic
+  topological order is correct and explainable; an AI layer can later optimise across
+  maintenance windows, risk, or batching, on top of this graph.
+- **A global cross-project graph.** Rejected for now — dependencies are naturally
+  project-scoped, and per-project keeps authorization and the queries simple.
+
+## Deferred follow-ups
+
+- The "AI proposes rotation sequence" layer (windows / batching / risk weighting) on top
+  of the topological order.
+- Wiring the rotation order into the automated-rotation executor (ADR-046) so a planned
+  rotation runs dependency-first automatically.
+- gRPC + CLI surfaces and a keyorix-web graph visualisation (the API is the first
+  vertical).
+- Cascade behaviour on secret soft-delete/restore (currently an edge to a deleted secret
+  simply stops resolving a name; a future pass could prune or flag it).

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -271,6 +271,35 @@ func (m *MockStorage) DeleteSoDPolicy(ctx context.Context, id uint) error {
 	return args.Error(0)
 }
 
+func (m *MockStorage) CreateSecretDependency(ctx context.Context, d *models.SecretDependency) (*models.SecretDependency, error) {
+	args := m.Called(ctx, d)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.SecretDependency), args.Error(1)
+}
+
+func (m *MockStorage) GetSecretDependency(ctx context.Context, id uint) (*models.SecretDependency, error) {
+	args := m.Called(ctx, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.SecretDependency), args.Error(1)
+}
+
+func (m *MockStorage) ListSecretDependenciesForProject(ctx context.Context, projectID uint) ([]*models.SecretDependency, error) {
+	args := m.Called(ctx, projectID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*models.SecretDependency), args.Error(1)
+}
+
+func (m *MockStorage) DeleteSecretDependency(ctx context.Context, id uint) error {
+	args := m.Called(ctx, id)
+	return args.Error(0)
+}
+
 func (m *MockStorage) CreateLegalHold(ctx context.Context, h *models.LegalHold) (*models.LegalHold, error) {
 	args := m.Called(ctx, h)
 	if args.Get(0) == nil {

--- a/internal/core/secret_dependencies.go
+++ b/internal/core/secret_dependencies.go
@@ -1,0 +1,393 @@
+// secret_dependencies.go — the per-project secret dependency graph (ADR-052).
+// An operator declares that one secret "depends on" another (e.g. an app token
+// derived from a DB password); Keyorix maintains the directed graph and answers two
+// questions from it: impact analysis ("if I rotate this secret, what else is
+// affected?" — its transitive dependents) and rotation ordering (a safe sequence to
+// rotate a project's secrets so each is rotated before anything that depends on it).
+// The graph is kept acyclic: self-edges, duplicates, and cycles are rejected at add.
+// Metadata only — secret values are never read. Authz is enforced at the HTTP layer
+// (secrets.read to view, secrets.write to mutate), scoped to the secret's project.
+package core
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// Secret-dependency audit event types.
+const (
+	EventSecretDependencyAdded   = "secret.dependency_added"   // #nosec G101 -- audit event type, not a credential
+	EventSecretDependencyRemoved = "secret.dependency_removed" // #nosec G101 -- audit event type, not a credential
+)
+
+// SecretRef is a secret identified for a dependency view (id + name; never a value).
+type SecretRef struct {
+	SecretID   uint   `json:"secret_id"`
+	SecretName string `json:"secret_name"`
+}
+
+// DependencyEdge is one edge as seen from a focal secret: the other secret it links
+// to, plus the edge id (so it can be removed) and the operator's note.
+type DependencyEdge struct {
+	ID         uint   `json:"id"`
+	SecretID   uint   `json:"secret_id"`
+	SecretName string `json:"secret_name"`
+	Note       string `json:"note,omitempty"`
+}
+
+// SecretDependencies is a focal secret's direct neighbours in both directions.
+type SecretDependencies struct {
+	SecretID   uint             `json:"secret_id"`
+	DependsOn  []DependencyEdge `json:"depends_on"` // secrets this one depends on
+	Dependents []DependencyEdge `json:"dependents"` // secrets that depend on this one
+}
+
+// ImpactedSecret is a transitive dependent reached during impact analysis, with the
+// shortest hop-distance from the rotated secret.
+type ImpactedSecret struct {
+	SecretID   uint   `json:"secret_id"`
+	SecretName string `json:"secret_name"`
+	Depth      int    `json:"depth"`
+}
+
+// SecretImpact is the blast radius of rotating/changing a secret.
+type SecretImpact struct {
+	SecretID   uint             `json:"secret_id"`
+	SecretName string           `json:"secret_name"`
+	Affected   []ImpactedSecret `json:"affected"`
+}
+
+// RotationOrder is a safe rotation sequence for a project's dependency graph: each
+// secret appears before any secret that depends on it.
+type RotationOrder struct {
+	ProjectID uint        `json:"project_id"`
+	Order     []SecretRef `json:"order"`
+}
+
+// AddSecretDependency declares that dependentID depends on dependsOnID. Both must be
+// real secrets in the same project; self-edges, duplicates, and edges that would
+// introduce a cycle are rejected. actorID is the acting principal.
+func (c *KeyorixCore) AddSecretDependency(ctx context.Context, actorID, dependentID, dependsOnID uint, note string) (*models.SecretDependency, error) {
+	if dependentID == dependsOnID {
+		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "a secret cannot depend on itself")
+	}
+	dependent, err := c.requireSecret(ctx, dependentID)
+	if err != nil {
+		return nil, err
+	}
+	dependsOn, err := c.requireSecret(ctx, dependsOnID)
+	if err != nil {
+		return nil, err
+	}
+	// Both endpoints must be in the same project AND environment. Authorization is
+	// environment-granular (a grant is scoped to {project, environment}), and the HTTP
+	// layer only authorizes the caller on the path secret's environment — so confining
+	// the edge to that one environment is what makes the path-secret authorization also
+	// cover the dependency secret. A cross-environment edge would let a caller scoped to
+	// one environment reference (and later read the name of) a secret in another.
+	if dependent.ProjectID != dependsOn.ProjectID || dependent.EnvironmentID != dependsOn.EnvironmentID {
+		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "both secrets must be in the same project and environment")
+	}
+
+	edges, err := c.storage.ListSecretDependenciesForProject(ctx, dependent.ProjectID)
+	if err != nil {
+		return nil, err
+	}
+	for _, e := range edges {
+		if e.DependentSecretID == dependentID && e.DependsOnSecretID == dependsOnID {
+			return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "this dependency already exists")
+		}
+	}
+	// A cycle would form iff dependsOnID can already reach dependentID over existing
+	// edges (then dependent → dependsOn → … → dependent closes the loop).
+	if dependencyReachable(edges, dependsOnID, dependentID) {
+		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "this dependency would create a cycle")
+	}
+
+	created, err := c.storage.CreateSecretDependency(ctx, &models.SecretDependency{
+		ProjectID:         dependent.ProjectID,
+		DependentSecretID: dependentID,
+		DependsOnSecretID: dependsOnID,
+		Note:              note,
+		CreatedBy:         actorID,
+		CreatedAt:         c.now(),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	c.writeAuditEvent(ctx, EventSecretDependencyAdded, actorPtr(actorID), &dependentID,
+		fmt.Sprintf("declared secret %q depends on %q", dependent.Name, dependsOn.Name))
+	return created, nil
+}
+
+// RemoveSecretDependency deletes one edge. focalSecretID is the secret the request is
+// scoped to (the {id} in the route): the edge must actually reference that secret, so
+// the environment-scoped authorization the caller passed on focalSecretID also governs
+// the edge. Matching on project alone would be too coarse — authorization is
+// environment-granular, and a caller could otherwise delete an edge between two secrets
+// in another environment of the same project. actorID is the acting principal.
+func (c *KeyorixCore) RemoveSecretDependency(ctx context.Context, actorID, focalSecretID, edgeID uint) error {
+	if _, err := c.requireSecret(ctx, focalSecretID); err != nil {
+		return err
+	}
+	edge, err := c.storage.GetSecretDependency(ctx, edgeID)
+	if err != nil {
+		return err
+	}
+	if edge.DependentSecretID != focalSecretID && edge.DependsOnSecretID != focalSecretID {
+		return fmt.Errorf("%s: dependency %d does not reference secret %d", i18n.T("ErrorNotFound", nil), edgeID, focalSecretID)
+	}
+	if err := c.storage.DeleteSecretDependency(ctx, edgeID); err != nil {
+		return err
+	}
+	dep := edge.DependentSecretID
+	c.writeAuditEvent(ctx, EventSecretDependencyRemoved, actorPtr(actorID), &dep,
+		fmt.Sprintf("removed dependency of secret %d on secret %d", edge.DependentSecretID, edge.DependsOnSecretID))
+	return nil
+}
+
+// ListSecretDependencies returns a secret's direct dependencies and dependents, with
+// names resolved.
+func (c *KeyorixCore) ListSecretDependencies(ctx context.Context, secretID uint) (*SecretDependencies, error) {
+	secret, err := c.requireSecret(ctx, secretID)
+	if err != nil {
+		return nil, err
+	}
+	edges, err := c.storage.ListSecretDependenciesForProject(ctx, secret.ProjectID)
+	if err != nil {
+		return nil, err
+	}
+	info := c.resolveSecretInfo(ctx, edges)
+	// Defence-in-depth: only consider edges whose BOTH endpoints actually live in the
+	// focal secret's environment — independent of the add-time same-environment guard —
+	// so the view can never surface a name from another environment the caller may not
+	// be authorized on, even if a cross-environment edge were somehow present.
+	edges = edgesWithinEnvironment(edges, info, secret.EnvironmentID)
+	out := &SecretDependencies{SecretID: secretID, DependsOn: []DependencyEdge{}, Dependents: []DependencyEdge{}}
+	for _, e := range edges {
+		switch secretID {
+		case e.DependentSecretID:
+			out.DependsOn = append(out.DependsOn, DependencyEdge{ID: e.ID, SecretID: e.DependsOnSecretID, SecretName: info[e.DependsOnSecretID].name, Note: e.Note})
+		case e.DependsOnSecretID:
+			out.Dependents = append(out.Dependents, DependencyEdge{ID: e.ID, SecretID: e.DependentSecretID, SecretName: info[e.DependentSecretID].name, Note: e.Note})
+		}
+	}
+	return out, nil
+}
+
+// GetSecretImpact returns the blast radius of rotating/changing a secret: every
+// secret that transitively depends on it, with hop-distance, in breadth-first order.
+func (c *KeyorixCore) GetSecretImpact(ctx context.Context, secretID uint) (*SecretImpact, error) {
+	secret, err := c.requireSecret(ctx, secretID)
+	if err != nil {
+		return nil, err
+	}
+	edges, err := c.storage.ListSecretDependenciesForProject(ctx, secret.ProjectID)
+	if err != nil {
+		return nil, err
+	}
+	info := c.resolveSecretInfo(ctx, edges)
+	edges = edgesWithinEnvironment(edges, info, secret.EnvironmentID) // defence-in-depth, as in ListSecretDependencies
+	affected := transitiveDependents(edges, secretID)
+	out := &SecretImpact{SecretID: secretID, SecretName: secret.Name, Affected: make([]ImpactedSecret, 0, len(affected))}
+	for _, a := range affected {
+		out.Affected = append(out.Affected, ImpactedSecret{SecretID: a.id, SecretName: info[a.id].name, Depth: a.depth})
+	}
+	return out, nil
+}
+
+// GetProjectRotationOrder returns a safe rotation sequence for a project's dependency
+// graph: each secret precedes any secret that depends on it. Only secrets that appear
+// in the graph are ordered (standalone secrets can rotate at any time).
+func (c *KeyorixCore) GetProjectRotationOrder(ctx context.Context, projectID uint) (*RotationOrder, error) {
+	edges, err := c.storage.ListSecretDependenciesForProject(ctx, projectID)
+	if err != nil {
+		return nil, err
+	}
+	order, ok := topologicalRotationOrder(edges)
+	if !ok {
+		// Defensive: cycles are rejected at add, so a remaining cycle is a data fault.
+		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorInternal", nil), "the dependency graph contains a cycle")
+	}
+	// Rotation order is project-wide (authorized by a project-scoped grant that spans
+	// all environments), so no per-environment filter here.
+	info := c.resolveSecretInfo(ctx, edges)
+	out := &RotationOrder{ProjectID: projectID, Order: make([]SecretRef, 0, len(order))}
+	for _, id := range order {
+		out.Order = append(out.Order, SecretRef{SecretID: id, SecretName: info[id].name})
+	}
+	return out, nil
+}
+
+// requireSecret loads a secret node and verifies it is an actual secret (not a folder)
+// — the endpoints of a dependency must both be secrets.
+func (c *KeyorixCore) requireSecret(ctx context.Context, id uint) (*models.SecretNode, error) {
+	node, err := c.storage.GetSecret(ctx, id)
+	if err != nil {
+		return nil, fmt.Errorf("%s: secret %d not found", i18n.T("ErrorNotFound", nil), id)
+	}
+	if !node.IsSecret {
+		return nil, fmt.Errorf("%s: %d is not a secret", i18n.T("ErrorValidation", nil), id)
+	}
+	return node, nil
+}
+
+// secretInfo is the per-secret metadata the views need: its name and the environment
+// it actually lives in (the latter is the authoritative value for the env filter).
+type secretInfo struct {
+	name string
+	env  uint
+}
+
+// resolveSecretInfo builds an id→{name,env} map for every secret referenced by edges,
+// so the views can show names and filter by real environment without an extra
+// round-trip per row. A secret that no longer resolves is absent from the map (zero
+// value), so it is treated as not in any caller's environment.
+func (c *KeyorixCore) resolveSecretInfo(ctx context.Context, edges []*models.SecretDependency) map[uint]secretInfo {
+	ids := make(map[uint]struct{})
+	for _, e := range edges {
+		ids[e.DependentSecretID] = struct{}{}
+		ids[e.DependsOnSecretID] = struct{}{}
+	}
+	info := make(map[uint]secretInfo, len(ids))
+	for id := range ids {
+		if node, err := c.storage.GetSecret(ctx, id); err == nil {
+			info[id] = secretInfo{name: node.Name, env: node.EnvironmentID}
+		}
+	}
+	return info
+}
+
+// --- pure graph helpers (no storage; unit-testable in isolation) ---
+
+// edgesWithinEnvironment keeps only edges whose BOTH endpoints actually live in the
+// given environment, per the resolved info. Edges never cross environments (enforced at
+// add), so this is defence-in-depth: it keeps the read paths safe even if a
+// cross-environment edge were somehow present, because it checks the endpoints' real
+// environments rather than trusting any field on the edge.
+func edgesWithinEnvironment(edges []*models.SecretDependency, info map[uint]secretInfo, environmentID uint) []*models.SecretDependency {
+	out := make([]*models.SecretDependency, 0, len(edges))
+	for _, e := range edges {
+		if info[e.DependentSecretID].env == environmentID && info[e.DependsOnSecretID].env == environmentID {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// dependentsAdjacency builds the reverse adjacency for impact analysis: for each
+// secret, the set of secrets that directly depend on it (its dependents). Neighbour
+// lists are sorted for deterministic traversal.
+func dependentsAdjacency(edges []*models.SecretDependency) map[uint][]uint {
+	adj := make(map[uint][]uint)
+	for _, e := range edges {
+		adj[e.DependsOnSecretID] = append(adj[e.DependsOnSecretID], e.DependentSecretID)
+	}
+	for k := range adj {
+		sort.Slice(adj[k], func(i, j int) bool { return adj[k][i] < adj[k][j] })
+	}
+	return adj
+}
+
+// dependencyReachable reports whether `to` is reachable from `from` following
+// depends-on edges (from depends on … depends on to). Used to detect cycles before
+// adding an edge.
+func dependencyReachable(edges []*models.SecretDependency, from, to uint) bool {
+	adj := make(map[uint][]uint)
+	for _, e := range edges {
+		adj[e.DependentSecretID] = append(adj[e.DependentSecretID], e.DependsOnSecretID)
+	}
+	seen := map[uint]bool{from: true}
+	stack := []uint{from}
+	for len(stack) > 0 {
+		n := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		for _, next := range adj[n] {
+			if next == to {
+				return true
+			}
+			if !seen[next] {
+				seen[next] = true
+				stack = append(stack, next)
+			}
+		}
+	}
+	return false
+}
+
+type impacted struct {
+	id    uint
+	depth int
+}
+
+// transitiveDependents returns every secret that transitively depends on secretID, in
+// breadth-first order with the shortest hop-distance. Excludes secretID itself.
+func transitiveDependents(edges []*models.SecretDependency, secretID uint) []impacted {
+	adj := dependentsAdjacency(edges)
+	seen := map[uint]bool{secretID: true}
+	out := []impacted{}
+	queue := []impacted{{id: secretID, depth: 0}}
+	for len(queue) > 0 {
+		cur := queue[0]
+		queue = queue[1:]
+		for _, dep := range adj[cur.id] {
+			if seen[dep] {
+				continue
+			}
+			seen[dep] = true
+			out = append(out, impacted{id: dep, depth: cur.depth + 1})
+			queue = append(queue, impacted{id: dep, depth: cur.depth + 1})
+		}
+	}
+	return out
+}
+
+// topologicalRotationOrder returns the secrets in a project's dependency graph in a
+// safe rotation order — each secret before any that depends on it — using Kahn's
+// algorithm with deterministic tie-breaking (ascending secret id). ok is false if a
+// cycle prevents a complete ordering (should not happen: cycles are rejected at add).
+func topologicalRotationOrder(edges []*models.SecretDependency) (order []uint, ok bool) {
+	// Prerequisite graph: rotate a dependency before its dependent, so an edge
+	// (dependent depends on dependsOn) means dependsOn → dependent must precede.
+	adj := make(map[uint][]uint) // dependsOn → its dependents
+	indeg := make(map[uint]int)  // count of prerequisites (dependencies) per node
+	nodes := make(map[uint]struct{})
+	for _, e := range edges {
+		adj[e.DependsOnSecretID] = append(adj[e.DependsOnSecretID], e.DependentSecretID)
+		indeg[e.DependentSecretID]++
+		nodes[e.DependentSecretID] = struct{}{}
+		nodes[e.DependsOnSecretID] = struct{}{}
+	}
+	// Seed the queue with nodes that depend on nothing, smallest id first.
+	ready := []uint{}
+	for n := range nodes {
+		if indeg[n] == 0 {
+			ready = append(ready, n)
+		}
+	}
+	sort.Slice(ready, func(i, j int) bool { return ready[i] < ready[j] })
+
+	order = make([]uint, 0, len(nodes))
+	for len(ready) > 0 {
+		n := ready[0]
+		ready = ready[1:]
+		order = append(order, n)
+		next := append([]uint(nil), adj[n]...)
+		sort.Slice(next, func(i, j int) bool { return next[i] < next[j] })
+		for _, m := range next {
+			indeg[m]--
+			if indeg[m] == 0 {
+				// Insert keeping `ready` sorted so the output is deterministic.
+				pos := sort.Search(len(ready), func(i int) bool { return ready[i] >= m })
+				ready = append(ready, 0)
+				copy(ready[pos+1:], ready[pos:])
+				ready[pos] = m
+			}
+		}
+	}
+	return order, len(order) == len(nodes)
+}

--- a/internal/core/secret_dependencies_test.go
+++ b/internal/core/secret_dependencies_test.go
@@ -1,0 +1,239 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// edge is a terse constructor for the pure-helper tests.
+func edge(dependent, dependsOn uint) *models.SecretDependency {
+	return &models.SecretDependency{DependentSecretID: dependent, DependsOnSecretID: dependsOn}
+}
+
+func TestDependencyReachable(t *testing.T) {
+	// 1→2→3 (1 depends on 2 depends on 3), plus 4→2.
+	edges := []*models.SecretDependency{edge(1, 2), edge(2, 3), edge(4, 2)}
+	assert.True(t, dependencyReachable(edges, 1, 3), "1 transitively depends on 3")
+	assert.True(t, dependencyReachable(edges, 1, 2))
+	assert.False(t, dependencyReachable(edges, 3, 1), "3 does not depend on 1")
+	assert.True(t, dependencyReachable(edges, 4, 3), "4→2→3 reachable")
+	assert.False(t, dependencyReachable(edges, 2, 4), "2 does not reach 4")
+}
+
+func TestTransitiveDependents(t *testing.T) {
+	// 3 is depended on by 2 and 4; 2 is depended on by 1. So rotating 3 impacts 2,4 (depth1) then 1 (depth2).
+	edges := []*models.SecretDependency{edge(1, 2), edge(2, 3), edge(4, 3)}
+	got := transitiveDependents(edges, 3)
+	require.Len(t, got, 3)
+	// BFS order: depth-1 dependents of 3 first (2,4 sorted), then 1.
+	assert.Equal(t, uint(2), got[0].id)
+	assert.Equal(t, 1, got[0].depth)
+	assert.Equal(t, uint(4), got[1].id)
+	assert.Equal(t, 1, got[1].depth)
+	assert.Equal(t, uint(1), got[2].id)
+	assert.Equal(t, 2, got[2].depth)
+
+	// A leaf nobody depends on has no impact.
+	assert.Empty(t, transitiveDependents(edges, 1))
+}
+
+func TestTopologicalRotationOrder(t *testing.T) {
+	// Diamond: 1 depends on 2 and 3; both 2 and 3 depend on 4.
+	// Safe rotation = dependencies first: 4 before {2,3} before 1.
+	edges := []*models.SecretDependency{edge(1, 2), edge(1, 3), edge(2, 4), edge(3, 4)}
+	order, ok := topologicalRotationOrder(edges)
+	require.True(t, ok)
+	require.Equal(t, []uint{4, 2, 3, 1}, order, "4 first, then 2,3 (sorted), then 1")
+
+	// Determinism: same input → same order.
+	order2, _ := topologicalRotationOrder(edges)
+	assert.Equal(t, order, order2)
+}
+
+func TestTopologicalRotationOrderDetectsCycle(t *testing.T) {
+	// A hand-built cycle 1→2→1 (the add path prevents this; the sort must still flag it).
+	edges := []*models.SecretDependency{edge(1, 2), edge(2, 1)}
+	_, ok := topologicalRotationOrder(edges)
+	assert.False(t, ok, "a cyclic graph yields no complete ordering")
+}
+
+// --- integration tests against a real in-memory store ---
+
+func newDepCore(t *testing.T) (*KeyorixCore, *gorm.DB) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretDependency{}, &models.AuditEvent{}))
+	now := time.Date(2026, 6, 22, 9, 0, 0, 0, time.UTC)
+	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: func() time.Time { return now }}
+	return c, db
+}
+
+// mkSecret inserts a secret node (environment 1) and returns its id.
+func mkSecret(t *testing.T, db *gorm.DB, projectID uint, name string) uint {
+	return mkSecretEnv(t, db, projectID, 1, name)
+}
+
+// mkSecretEnv inserts a secret node in a specific environment and returns its id.
+func mkSecretEnv(t *testing.T, db *gorm.DB, projectID, environmentID uint, name string) uint {
+	t.Helper()
+	s := &models.SecretNode{ProjectID: projectID, EnvironmentID: environmentID, Name: name, IsSecret: true, Status: "active"}
+	require.NoError(t, db.Create(s).Error)
+	return s.ID
+}
+
+func TestAddSecretDependency_Validation(t *testing.T) {
+	ctx := context.Background()
+	c, db := newDepCore(t)
+	dbPass := mkSecret(t, db, 1, "db-password")
+	appTok := mkSecret(t, db, 1, "app-token")
+	otherProj := mkSecret(t, db, 2, "other-secret")
+
+	t.Run("happy path", func(t *testing.T) {
+		got, err := c.AddSecretDependency(ctx, 10, appTok, dbPass, "app token derives from db password")
+		require.NoError(t, err)
+		assert.Equal(t, appTok, got.DependentSecretID)
+		assert.Equal(t, dbPass, got.DependsOnSecretID)
+		assert.Equal(t, uint(1), got.ProjectID)
+	})
+
+	t.Run("self-dependency rejected", func(t *testing.T) {
+		_, err := c.AddSecretDependency(ctx, 10, dbPass, dbPass, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "itself")
+	})
+
+	t.Run("cross-project rejected", func(t *testing.T) {
+		_, err := c.AddSecretDependency(ctx, 10, appTok, otherProj, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "same project")
+	})
+
+	t.Run("duplicate rejected", func(t *testing.T) {
+		_, err := c.AddSecretDependency(ctx, 10, appTok, dbPass, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "already exists")
+	})
+
+	t.Run("cycle rejected", func(t *testing.T) {
+		// appTok already depends on dbPass; making dbPass depend on appTok is a cycle.
+		_, err := c.AddSecretDependency(ctx, 10, dbPass, appTok, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cycle")
+	})
+
+	t.Run("missing secret rejected", func(t *testing.T) {
+		_, err := c.AddSecretDependency(ctx, 10, appTok, 9999, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "9999")
+	})
+}
+
+// A dependency must stay within one environment — authorization is environment-
+// granular, so a cross-environment edge would let an env-scoped caller reference a
+// secret in another environment of the same project.
+func TestAddSecretDependency_CrossEnvironmentRejected(t *testing.T) {
+	ctx := context.Background()
+	c, db := newDepCore(t)
+	staging := mkSecretEnv(t, db, 1, 1, "app-token")     // project 1, env 1
+	prod := mkSecretEnv(t, db, 1, 2, "prod-db-password") // project 1, env 2
+	_, err := c.AddSecretDependency(ctx, 10, staging, prod, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "environment")
+}
+
+// Removal is scoped to the focal secret: the edge must reference it, so a caller
+// authorized only on another secret cannot delete an unrelated edge.
+func TestRemoveSecretDependency_RequiresFocalReference(t *testing.T) {
+	ctx := context.Background()
+	c, db := newDepCore(t)
+	a := mkSecret(t, db, 1, "a")
+	b := mkSecret(t, db, 1, "b")
+	other := mkSecret(t, db, 1, "other")
+	e, err := c.AddSecretDependency(ctx, 1, a, b, "")
+	require.NoError(t, err)
+
+	// 'other' is not part of edge a→b → removal scoped to 'other' is rejected.
+	err = c.RemoveSecretDependency(ctx, 1, other, e.ID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not reference")
+
+	// Scoped to the dependent secret 'a' → allowed.
+	require.NoError(t, c.RemoveSecretDependency(ctx, 1, a, e.ID))
+}
+
+// Defence-in-depth: even if a cross-environment edge is somehow present (here inserted
+// directly, bypassing the add guard), the read paths must not surface the other
+// environment's secret — they filter to the focal secret's environment independently.
+func TestSecretDependencyReadsFilterByEnvironment(t *testing.T) {
+	ctx := context.Background()
+	c, db := newDepCore(t)
+	envA := mkSecretEnv(t, db, 1, 1, "env-a-secret")
+	envB := mkSecretEnv(t, db, 1, 2, "env-b-secret")
+	// Forge a cross-environment edge (env-A depends on env-B) directly in storage,
+	// bypassing the add-time guard. The endpoints span two environments.
+	require.NoError(t, db.Create(&models.SecretDependency{
+		ProjectID: 1, DependentSecretID: envA, DependsOnSecretID: envB,
+	}).Error)
+
+	deps, err := c.ListSecretDependencies(ctx, envA)
+	require.NoError(t, err)
+	assert.Empty(t, deps.DependsOn, "a cross-environment edge must not appear in env-A's view")
+
+	impact, err := c.GetSecretImpact(ctx, envB)
+	require.NoError(t, err)
+	assert.Empty(t, impact.Affected, "impact from env-B must not cross into env-A via a forged edge")
+}
+
+func TestSecretDependencyImpactAndOrderAndRemove(t *testing.T) {
+	ctx := context.Background()
+	c, db := newDepCore(t)
+	root := mkSecret(t, db, 1, "root-ca")
+	mid := mkSecret(t, db, 1, "intermediate")
+	leaf := mkSecret(t, db, 1, "service-cert")
+
+	// service-cert depends on intermediate depends on root-ca.
+	_, err := c.AddSecretDependency(ctx, 1, mid, root, "")
+	require.NoError(t, err)
+	e2, err := c.AddSecretDependency(ctx, 1, leaf, mid, "")
+	require.NoError(t, err)
+
+	// Impact of rotating root-ca: intermediate (depth1) then service-cert (depth2).
+	impact, err := c.GetSecretImpact(ctx, root)
+	require.NoError(t, err)
+	require.Len(t, impact.Affected, 2)
+	assert.Equal(t, "intermediate", impact.Affected[0].SecretName)
+	assert.Equal(t, 1, impact.Affected[0].Depth)
+	assert.Equal(t, "service-cert", impact.Affected[1].SecretName)
+	assert.Equal(t, 2, impact.Affected[1].Depth)
+
+	// Rotation order: root-ca, intermediate, service-cert.
+	order, err := c.GetProjectRotationOrder(ctx, 1)
+	require.NoError(t, err)
+	require.Len(t, order.Order, 3)
+	assert.Equal(t, []string{"root-ca", "intermediate", "service-cert"},
+		[]string{order.Order[0].SecretName, order.Order[1].SecretName, order.Order[2].SecretName})
+
+	// List from the middle secret: depends on root, depended on by leaf.
+	view, err := c.ListSecretDependencies(ctx, mid)
+	require.NoError(t, err)
+	require.Len(t, view.DependsOn, 1)
+	assert.Equal(t, "root-ca", view.DependsOn[0].SecretName)
+	require.Len(t, view.Dependents, 1)
+	assert.Equal(t, "service-cert", view.Dependents[0].SecretName)
+
+	// Remove the leaf→mid edge; impact of root shrinks to just intermediate.
+	require.NoError(t, c.RemoveSecretDependency(ctx, 1, leaf, e2.ID))
+	impact, err = c.GetSecretImpact(ctx, root)
+	require.NoError(t, err)
+	require.Len(t, impact.Affected, 1)
+	assert.Equal(t, "intermediate", impact.Affected[0].SecretName)
+}

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -86,6 +86,12 @@ type Storage interface {
 	ListSoDPolicies(ctx context.Context) ([]*models.SoDPolicy, error)
 	DeleteSoDPolicy(ctx context.Context, id uint) error
 
+	// Secret dependency edges (ADR-052) — the per-project secret dependency graph.
+	CreateSecretDependency(ctx context.Context, d *models.SecretDependency) (*models.SecretDependency, error)
+	GetSecretDependency(ctx context.Context, id uint) (*models.SecretDependency, error)
+	ListSecretDependenciesForProject(ctx context.Context, projectID uint) ([]*models.SecretDependency, error)
+	DeleteSecretDependency(ctx context.Context, id uint) error
+
 	// Legal hold (ISO 27001 A.5.34 / eDiscovery) — a deployment-wide hold that
 	// blocks the purge jobs from hard-deleting records while active.
 	CreateLegalHold(ctx context.Context, h *models.LegalHold) (*models.LegalHold, error)

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -308,6 +308,7 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 	riskExceptionExists := tableExists(db, "risk_exceptions")
 	ssoLoginStateExists := tableExists(db, "sso_login_states")
 	sodExists := tableExists(db, "sod_policies")
+	secretDepExists := tableExists(db, "secret_dependencies")
 	pwHistExists := tableExists(db, "password_histories")
 	machineExists := tableExists(db, "machine_identities")
 	machineCredExists := tableExists(db, "machine_identity_credentials")
@@ -511,6 +512,13 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 	if !sodExists {
 		if err := db.AutoMigrate(&models.SoDPolicy{}); err != nil {
 			return fmt.Errorf("failed to migrate sod_policies table: %w", err)
+		}
+	}
+
+	// Create the secret-dependency edge table if missing (ADR-052, additive).
+	if !secretDepExists {
+		if err := db.AutoMigrate(&models.SecretDependency{}); err != nil {
+			return fmt.Errorf("failed to migrate secret_dependencies table: %w", err)
 		}
 	}
 

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -473,6 +473,26 @@ type SecretNode struct {
 	DeletedAt gorm.DeletedAt `gorm:"index"`
 }
 
+// SecretDependency is a directed edge in a project's secret dependency graph:
+// the secret DependentSecretID "depends on" DependsOnSecretID — i.e. rotating the
+// dependency may require updating or re-issuing the dependent (e.g. an application
+// token derived from a database password, or a config value that embeds another
+// secret). Metadata only; never the secret values. The graph drives impact analysis
+// ("what breaks if I rotate this?") and rotation ordering (ADR-052). Both endpoints
+// are secrets in the same project AND environment (authorization is environment-
+// granular, so an edge is confined to one environment); self-edges, duplicates,
+// cross-environment edges, and cycles are rejected at create so the graph stays a DAG.
+type SecretDependency struct {
+	ID        uint `gorm:"primaryKey" json:"id"`
+	ProjectID uint `gorm:"index;not null" json:"project_id"` // denormalised from the endpoints (same for both)
+	// DependentSecretID depends on DependsOnSecretID. The pair is unique.
+	DependentSecretID uint      `gorm:"not null;uniqueIndex:idx_secret_dep_edge" json:"dependent_secret_id"`
+	DependsOnSecretID uint      `gorm:"not null;uniqueIndex:idx_secret_dep_edge" json:"depends_on_secret_id"`
+	Note              string    `json:"note,omitempty"`
+	CreatedBy         uint      `json:"created_by,omitempty"`
+	CreatedAt         time.Time `json:"created_at"`
+}
+
 type SecretVersion struct {
 	ID                 uint `gorm:"primaryKey"`
 	SecretNodeID       uint

--- a/internal/storage/store/local_secret_dependencies.go
+++ b/internal/storage/store/local_secret_dependencies.go
@@ -1,0 +1,47 @@
+// local_secret_dependencies.go — secret dependency-graph edge persistence (ADR-052).
+// Each row is a directed edge "dependent depends on depends_on" within one project;
+// the core layer builds the graph from a project's edges for impact analysis and
+// rotation ordering. For the remote equivalent see remote_secret_dependencies.go.
+package store
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+func (ls *LocalStorage) CreateSecretDependency(ctx context.Context, d *models.SecretDependency) (*models.SecretDependency, error) {
+	if err := ls.db.WithContext(ctx).Create(d).Error; err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	return d, nil
+}
+
+func (ls *LocalStorage) GetSecretDependency(ctx context.Context, id uint) (*models.SecretDependency, error) {
+	var d models.SecretDependency
+	if err := ls.db.WithContext(ctx).First(&d, id).Error; err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorNotFound", nil), err)
+	}
+	return &d, nil
+}
+
+func (ls *LocalStorage) ListSecretDependenciesForProject(ctx context.Context, projectID uint) ([]*models.SecretDependency, error) {
+	var rows []*models.SecretDependency
+	if err := ls.db.WithContext(ctx).Where("project_id = ?", projectID).Order("id ASC").Find(&rows).Error; err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	return rows, nil
+}
+
+func (ls *LocalStorage) DeleteSecretDependency(ctx context.Context, id uint) error {
+	result := ls.db.WithContext(ctx).Delete(&models.SecretDependency{}, id)
+	if result.Error != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), result.Error)
+	}
+	if result.RowsAffected == 0 {
+		return fmt.Errorf("%s", i18n.T("ErrorNotFound", nil))
+	}
+	return nil
+}

--- a/internal/storage/store/remote_secret_dependencies.go
+++ b/internal/storage/store/remote_secret_dependencies.go
@@ -1,0 +1,25 @@
+// remote_secret_dependencies.go — secret dependency edges for RemoteStorage.
+// Processed server-side; stubs here. See local_secret_dependencies.go.
+package store
+
+import (
+	"context"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+func (rs *RemoteStorage) CreateSecretDependency(_ context.Context, _ *models.SecretDependency) (*models.SecretDependency, error) {
+	return nil, remoteUnsupported("CreateSecretDependency")
+}
+
+func (rs *RemoteStorage) GetSecretDependency(_ context.Context, _ uint) (*models.SecretDependency, error) {
+	return nil, remoteUnsupported("GetSecretDependency")
+}
+
+func (rs *RemoteStorage) ListSecretDependenciesForProject(_ context.Context, _ uint) ([]*models.SecretDependency, error) {
+	return nil, remoteUnsupported("ListSecretDependenciesForProject")
+}
+
+func (rs *RemoteStorage) DeleteSecretDependency(_ context.Context, _ uint) error {
+	return remoteUnsupported("DeleteSecretDependency")
+}

--- a/server/http/handlers/secret_dependencies.go
+++ b/server/http/handlers/secret_dependencies.go
@@ -1,0 +1,155 @@
+// secret_dependencies.go — per-secret dependency-graph handlers (ADR-052).
+//
+// Routes (under /api/v1/secrets, project-scoped from the {id} secret):
+//
+//	GET    /{id}/dependencies            — the secret's direct dependencies + dependents
+//	POST   /{id}/dependencies            — declare that {id} depends on another secret
+//	DELETE /{id}/dependencies/{depId}    — remove one dependency edge
+//	GET    /{id}/impact                  — blast radius (transitive dependents)
+//
+// Plus, under /api/v1/projects (project-scoped):
+//
+//	GET    /{id}/rotation-order          — a safe rotation sequence for the project graph
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/keyorixhq/keyorix/server/middleware"
+)
+
+// dependencyErrorStatus maps a core dependency error to an HTTP status by its message,
+// matching the convention used across the secret handlers.
+func dependencyErrorStatus(msg string) int {
+	switch {
+	case strings.Contains(msg, "not found"):
+		return http.StatusNotFound
+	case strings.Contains(msg, "cannot depend on itself"),
+		strings.Contains(msg, "same project"),
+		strings.Contains(msg, "already exists"),
+		strings.Contains(msg, "cycle"),
+		strings.Contains(msg, "is not a secret"):
+		return http.StatusBadRequest
+	case strings.Contains(msg, "permission"), strings.Contains(msg, "not authorized"):
+		return http.StatusForbidden
+	default:
+		return http.StatusInternalServerError
+	}
+}
+
+// ListSecretDependencies handles GET /api/v1/secrets/{id}/dependencies
+func (h *SecretHandler) ListSecretDependencies(w http.ResponseWriter, r *http.Request) {
+	if middleware.GetUserFromContext(r.Context()) == nil {
+		h.sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		h.sendError(w, "InvalidParameter", "Invalid secret ID", http.StatusBadRequest, nil)
+		return
+	}
+	deps, err := h.coreService.ListSecretDependencies(r.Context(), uint(id))
+	if err != nil {
+		h.sendError(w, "Error", err.Error(), dependencyErrorStatus(err.Error()), nil)
+		return
+	}
+	h.sendSuccess(w, deps, "")
+}
+
+// AddSecretDependency handles POST /api/v1/secrets/{id}/dependencies
+func (h *SecretHandler) AddSecretDependency(w http.ResponseWriter, r *http.Request) {
+	userCtx := middleware.GetUserFromContext(r.Context())
+	if userCtx == nil {
+		h.sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		h.sendError(w, "InvalidParameter", "Invalid secret ID", http.StatusBadRequest, nil)
+		return
+	}
+	var reqBody struct {
+		DependsOnID uint   `json:"depends_on_id"`
+		Note        string `json:"note"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
+		h.sendError(w, "InvalidJSON", "Invalid JSON in request body", http.StatusBadRequest, nil)
+		return
+	}
+	if reqBody.DependsOnID == 0 {
+		h.sendError(w, "InvalidParameter", "depends_on_id is required", http.StatusBadRequest, nil)
+		return
+	}
+	dep, err := h.coreService.AddSecretDependency(r.Context(), userCtx.UserID, uint(id), reqBody.DependsOnID, reqBody.Note)
+	if err != nil {
+		h.sendError(w, "Error", err.Error(), dependencyErrorStatus(err.Error()), nil)
+		return
+	}
+	h.sendSuccess(w, dep, "Dependency added")
+}
+
+// RemoveSecretDependency handles DELETE /api/v1/secrets/{id}/dependencies/{depId}
+func (h *SecretHandler) RemoveSecretDependency(w http.ResponseWriter, r *http.Request) {
+	userCtx := middleware.GetUserFromContext(r.Context())
+	if userCtx == nil {
+		h.sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		h.sendError(w, "InvalidParameter", "Invalid secret ID", http.StatusBadRequest, nil)
+		return
+	}
+	depID, err := strconv.ParseUint(chi.URLParam(r, "depId"), 10, 32)
+	if err != nil {
+		h.sendError(w, "InvalidParameter", "Invalid dependency ID", http.StatusBadRequest, nil)
+		return
+	}
+	if err := h.coreService.RemoveSecretDependency(r.Context(), userCtx.UserID, uint(id), uint(depID)); err != nil {
+		h.sendError(w, "Error", err.Error(), dependencyErrorStatus(err.Error()), nil)
+		return
+	}
+	h.sendSuccess(w, map[string]bool{"removed": true}, "Dependency removed")
+}
+
+// GetSecretImpact handles GET /api/v1/secrets/{id}/impact
+func (h *SecretHandler) GetSecretImpact(w http.ResponseWriter, r *http.Request) {
+	if middleware.GetUserFromContext(r.Context()) == nil {
+		h.sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		h.sendError(w, "InvalidParameter", "Invalid secret ID", http.StatusBadRequest, nil)
+		return
+	}
+	impact, err := h.coreService.GetSecretImpact(r.Context(), uint(id))
+	if err != nil {
+		h.sendError(w, "Error", err.Error(), dependencyErrorStatus(err.Error()), nil)
+		return
+	}
+	h.sendSuccess(w, impact, "")
+}
+
+// GetProjectRotationOrder handles GET /api/v1/projects/{id}/rotation-order
+func (h *SecretHandler) GetProjectRotationOrder(w http.ResponseWriter, r *http.Request) {
+	if middleware.GetUserFromContext(r.Context()) == nil {
+		h.sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		h.sendError(w, "InvalidParameter", "Invalid project ID", http.StatusBadRequest, nil)
+		return
+	}
+	order, err := h.coreService.GetProjectRotationOrder(r.Context(), uint(id))
+	if err != nil {
+		h.sendError(w, "Error", err.Error(), dependencyErrorStatus(err.Error()), nil)
+		return
+	}
+	h.sendSuccess(w, order, "")
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -243,6 +243,7 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		r.With(customMiddleware.RequireScopedPermission("secrets.delete", projectScope)).Delete("/projects/{id}", catalogHandler.DeleteProject)
 		r.With(customMiddleware.RequireScopedPermission("secrets.write", projectScope)).Post("/projects/{id}/restore", catalogHandler.RestoreProject)
 		r.With(customMiddleware.RequireScopedPermission("secrets.read", projectScope)).Get("/projects/{id}/drift", catalogHandler.GetProjectDrift)
+		r.With(customMiddleware.RequireScopedPermission("secrets.read", projectScope)).Get("/projects/{id}/rotation-order", secretHandler.GetProjectRotationOrder)
 		// Project membership (ADR-021 two-tier model). Read = project members may
 		// view the roster; mutations require roles.assign at the project scope, so
 		// a project_admin can manage their own project's members.
@@ -373,6 +374,12 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.With(customMiddleware.RequireScopedPermission("secrets.read", secretScope)).Get("/{id}/audit", secretHandler.AuditTrail)
 			r.With(customMiddleware.RequireScopedPermission("secrets.read", secretScope)).Get("/{id}/tags", secretHandler.GetTags)
 			r.With(customMiddleware.RequireScopedPermission("secrets.write", secretScope)).Put("/{id}/tags", secretHandler.SetTags)
+
+			// Secret dependency graph (ADR-052).
+			r.With(customMiddleware.RequireScopedPermission("secrets.read", secretScope)).Get("/{id}/dependencies", secretHandler.ListSecretDependencies)
+			r.With(customMiddleware.RequireScopedPermission("secrets.write", secretScope)).Post("/{id}/dependencies", secretHandler.AddSecretDependency)
+			r.With(customMiddleware.RequireScopedPermission("secrets.write", secretScope)).Delete("/{id}/dependencies/{depId}", secretHandler.RemoveSecretDependency)
+			r.With(customMiddleware.RequireScopedPermission("secrets.read", secretScope)).Get("/{id}/impact", secretHandler.GetSecretImpact)
 
 			// Create: authorized inside the handler (scope comes from the body).
 			r.Post("/", secretHandler.CreateSecret)


### PR DESCRIPTION
## What

A per-project **secret dependency graph**: declare "secret A depends on secret B" (e.g. an app token derived from a DB password, or a cert chain) and Keyorix answers the two questions you need before rotating anything:

- **Impact / blast radius** — `GET /secrets/{id}/impact` — the transitive dependents that break if you rotate it.
- **Rotation order** — `GET /projects/{id}/rotation-order` — a safe sequence where each secret precedes anything that depends on it.

This is the prerequisite the M3 roadmap notes for *"Automated rotation planning."* A topological sort of the DAG **is** a correct rotation sequence, so the deterministic core of the planning is delivered here; the "AI proposes" layer becomes optional polish.

## How

- `SecretDependency` edge model + additive migration; storage CRUD (local + remote stub).
- Core graph logic: add / list / remove + **cycle rejection** (kept a DAG) + pure, unit-tested impact (BFS) and topological rotation-order (Kahn, deterministic).
- HTTP API `GET/POST /secrets/{id}/dependencies`, `DELETE /secrets/{id}/dependencies/{depId}`, `GET /secrets/{id}/impact`, `GET /projects/{id}/rotation-order` — scoped `secrets.read`/`secrets.write`, audited (`secret.dependency_added`/`removed`). Metadata only — no secret value is read.

## Security

Pre-merge security review caught a **cross-environment IDOR** (Keyorix authorizes at project **+ environment** granularity; the first cut only checked project). Fixed: edges confined to a single project **and** environment; `DELETE` requires the edge to reference the path secret; reads independently filter to the focal secret's **real** endpoint environments (defense-in-depth, with a forged-edge regression test). A second reviewer adversarially confirmed all findings closed.

## Testing

- Pure graph: reachability, transitive-dependents/depth, topological order + determinism, cycle detection.
- Integration: add validation (self/cross-project/cross-environment/duplicate/cycle/missing), impact + rotation-order + remove, focal-reference enforcement, cross-env read filtering.
- gofmt / build / vet / gosec / golangci-lint clean.

See **ADR-052**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)