### PR TITLE
feat(rotation): automated rotation planning (ADR-053)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,10 +35,20 @@ All notable changes to Keyorix are documented here. This project follows
   cycles are rejected). Metadata only — no secret value is read. This is the
   prerequisite for automated rotation planning; the topological order is the
   deterministic core of that. (ADR-052) ([#412])
+- **Automated rotation planning** — `GET /api/v1/projects/{id}/rotation-plan` composes
+  rotation status, secret risk, and the dependency graph (ADR-052) into an ordered,
+  dependency-respecting **plan**: the project's overdue/due-soon secrets, batched into
+  parallel-safe **waves** (each secret rotates after anything it depends on) and
+  prioritised by **urgency** within a wave (overdue beats due-soon; more days past due +
+  higher risk rank higher). Each entry carries human-readable reasons ("30 days
+  overdue", "high risk", "rotate after db-password"). Deterministic and explainable —
+  appropriate for an air-gapped security operation; an LLM advisor can later sit on top
+  of the structured plan. (ADR-053) ([#413])
 
 [#410]: https://github.com/keyorixhq/keyorix/pull/410
 [#411]: https://github.com/keyorixhq/keyorix/pull/411
 [#412]: https://github.com/keyorixhq/keyorix/pull/412
+[#413]: https://github.com/keyorixhq/keyorix/pull/413
 
 ## v0.74.0 — 2026-06-22
 

--- a/docs/adr-053-automated-rotation-planning.md
+++ b/docs/adr-053-automated-rotation-planning.md
@@ -1,0 +1,74 @@
+# ADR-053: Automated rotation planning
+
+## Status
+
+Accepted.
+
+## Context
+
+Keyorix knows which secrets are *due* for rotation (rotation policies +
+`GetRotationStatus` classify covered secrets as overdue / due-soon / ok), how *risky*
+each secret is (`ComputeSecretRiskScore`, a composite of expiry / rotation-age / usage /
+exposure), and how secrets *depend* on each other (the dependency graph, ADR-052). What
+it did not have is the thing that ties those together: a **plan** an operator can act on
+— *which* secrets to rotate, in *what order*, and *why*.
+
+The M3 roadmap item is "Automated rotation planning — AI proposes rotation sequence."
+With the dependency graph shipped (ADR-052), the prerequisite is met and the core of the
+plan can be produced deterministically.
+
+## Decision
+
+Add `GenerateRotationPlan(projectID)` that composes the three existing signals into an
+ordered, batched, explainable **rotation plan**, exposed at
+`GET /api/v1/projects/{id}/rotation-plan` (scoped `secrets.read`).
+
+- **Candidates.** The plan covers exactly the policy-covered secrets that are **overdue
+  or due-soon** (healthy secrets are omitted). A secret covered by several policies
+  appears once, keeping its most-urgent classification.
+- **Waves.** The candidates are partitioned into dependency-respecting **waves** by a
+  level-by-level Kahn topological sort over the dependency subgraph *induced by the
+  candidates* (`rotationWaves`): wave 0 holds candidates with no in-plan dependency, and
+  a candidate appears one wave after the last candidate it depends on. Secrets within a
+  wave have no rotation dependency on each other, so they are **safe to rotate in
+  parallel**. (Edges to non-candidate secrets impose no ordering — you don't rotate a
+  healthy dependency just because a dependent is due.)
+- **Priority.** Within each wave, secrets are ordered by an **urgency** score
+  (`rotationUrgency`): overdue always outranks due-soon; within a class, more time past
+  due (capped) and higher composite risk raise the score. Deterministic, with secret id
+  breaking ties.
+- **Rationale.** Each planned rotation carries human-readable `reasons` ("30 days
+  overdue", "high risk (score 78)", "rotate after db-password") and the `after_secret_ids`
+  it must follow — so the plan is auditable and overridable, not a black box.
+
+### Why deterministic, not an LLM
+
+The "planning" is a deterministic, explainable algorithm, not an opaque model. That is
+the right choice for a **security operation** in Keyorix's **on-prem / air-gapped**
+deployments (ENS/ENISA posture): the order is reproducible, justifiable to an auditor,
+and carries no external dependency or data-egress in the rotation decision path. The
+structured plan is deliberately shaped so an **optional LLM advisor** could later narrate
+it, batch it across maintenance windows, or weight it by business context — sitting *on
+top of* the structured output, never in the security-critical path. That advisor is a
+deferred follow-up, not part of this ADR.
+
+## Alternatives considered
+
+- **LLM-generated plan in the rotation path.** Rejected — incompatible with the air-gap
+  / determinism / auditability requirements; an advisor on top of the deterministic plan
+  captures the upside without the risk.
+- **A flat ordered list (reuse `GetProjectRotationOrder`).** Insufficient — it orders the
+  *whole* dependency graph regardless of what's due, and can't express which secrets are
+  safe to rotate together or why each is urgent. The plan is candidate-scoped and
+  wave-batched.
+- **Auto-execute the plan.** Out of scope here — execution is the existing auto-rotation
+  executor's job (ADR-046/047). This ADR is planning; wiring the plan into the executor
+  (rotate wave-by-wave) is a deferred follow-up.
+
+## Deferred follow-ups
+
+- An **LLM advisor** that narrates / window-batches / risk-weights the plan.
+- Wiring the plan into the **auto-rotation executor** (ADR-046) so a project rotates
+  wave-by-wave, dependency-first, automatically.
+- A deployment-wide plan (all projects) and an environment-scoped variant.
+- gRPC + CLI surfaces and a keyorix-web plan view (API-only first vertical).

--- a/internal/core/rotation_planner.go
+++ b/internal/core/rotation_planner.go
@@ -1,0 +1,255 @@
+// rotation_planner.go — automated rotation planning (ADR-053). Given a project's
+// rotation posture (which policy-covered secrets are overdue / due soon), the secrets'
+// composite risk, and the secret dependency graph (ADR-052), GenerateRotationPlan
+// produces an ordered, batched, explainable plan: dependency-respecting *waves* of
+// secrets safe to rotate together, each secret prioritised by urgency and annotated
+// with why it is in the plan and what it must follow.
+//
+// The "planning" is a deterministic, explainable algorithm (urgency scoring +
+// dependency-aware wave batching), not an opaque model — appropriate for a security
+// operation in an on-prem / air-gapped deployment. An optional LLM advisor that
+// narrates or further optimises the plan can later sit on top of this structured
+// output (see ADR-053); it is not in the rotation decision path.
+package core
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// PlannedRotation is one secret's place in the rotation plan, with the rationale an
+// operator needs to act on (or override) it.
+type PlannedRotation struct {
+	SecretID       uint     `json:"secret_id"`
+	SecretName     string   `json:"secret_name"`
+	Status         string   `json:"status"`           // overdue | due_soon
+	DaysOverdue    int      `json:"days_overdue"`     // positive = overdue, negative = days remaining
+	RiskScore      int      `json:"risk_score"`       // 0-100 composite (0 if not computable)
+	RiskBand       string   `json:"risk_band"`        // low | medium | high
+	Urgency        int      `json:"urgency"`          // composite priority; higher rotates sooner
+	AutoRotate     bool     `json:"auto_rotate"`      // self-rotates (ADR-046) vs needs a human
+	AfterSecretIDs []uint   `json:"after_secret_ids"` // in-plan dependencies that must rotate first
+	Reasons        []string `json:"reasons"`          // human-readable rationale
+}
+
+// RotationWave is a set of secrets with no rotation dependency on each other, safe to
+// rotate together (in parallel). Wave 0 has no in-plan dependencies; a secret in wave
+// N depends only on secrets in waves < N.
+type RotationWave struct {
+	Index   int               `json:"index"`
+	Secrets []PlannedRotation `json:"secrets"`
+}
+
+// RotationPlan is the full ordered plan for a project.
+type RotationPlan struct {
+	ProjectID    uint           `json:"project_id"`
+	TotalSecrets int            `json:"total_secrets"`
+	OverdueCount int            `json:"overdue_count"`
+	DueSoonCount int            `json:"due_soon_count"`
+	Waves        []RotationWave `json:"waves"`
+}
+
+// GenerateRotationPlan builds the rotation plan for a project: every policy-covered
+// secret that is overdue or due soon, ordered into dependency-respecting waves and
+// prioritised by urgency within each wave. Returns an empty plan (no waves) when
+// nothing needs rotation.
+func (c *KeyorixCore) GenerateRotationPlan(ctx context.Context, projectID uint) (*RotationPlan, error) {
+	status, err := c.GetRotationStatus(ctx, &projectID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Candidates: secrets needing rotation, deduped per secret (a secret covered by
+	// several policies appears once, keeping the most urgent classification).
+	candidates := map[uint]*RotationStatusEntry{}
+	for _, e := range status {
+		if e.Status != RotationStatusOverdue && e.Status != RotationStatusDueSoon {
+			continue
+		}
+		if prev, ok := candidates[e.SecretID]; !ok || moreUrgentEntry(e, prev) {
+			candidates[e.SecretID] = e
+		}
+	}
+
+	plan := &RotationPlan{ProjectID: projectID, Waves: []RotationWave{}}
+	if len(candidates) == 0 {
+		return plan, nil
+	}
+
+	candidateSet := make(map[uint]bool, len(candidates))
+	for id := range candidates {
+		candidateSet[id] = true
+	}
+
+	edges, err := c.storage.ListSecretDependenciesForProject(ctx, projectID)
+	if err != nil {
+		return nil, err
+	}
+	waves, ok := rotationWaves(edges, candidateSet)
+	if !ok {
+		// Defensive: the dependency graph is kept acyclic at add (ADR-052).
+		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorInternal", nil), "the dependency graph contains a cycle")
+	}
+
+	// In-plan dependencies per candidate (edges to other candidates).
+	dependsOnInPlan := map[uint][]uint{}
+	for _, e := range edges {
+		if candidateSet[e.DependentSecretID] && candidateSet[e.DependsOnSecretID] {
+			dependsOnInPlan[e.DependentSecretID] = append(dependsOnInPlan[e.DependentSecretID], e.DependsOnSecretID)
+		}
+	}
+
+	for wi, ids := range waves {
+		wave := RotationWave{Index: wi, Secrets: make([]PlannedRotation, 0, len(ids))}
+		for _, id := range ids {
+			entry := candidates[id]
+			pr := c.planSecret(ctx, entry, dependsOnInPlan[id], candidates)
+			wave.Secrets = append(wave.Secrets, pr)
+			if entry.Status == RotationStatusOverdue {
+				plan.OverdueCount++
+			} else {
+				plan.DueSoonCount++
+			}
+		}
+		// Most urgent first within the wave; secret id breaks ties for determinism.
+		sort.Slice(wave.Secrets, func(i, j int) bool {
+			if wave.Secrets[i].Urgency != wave.Secrets[j].Urgency {
+				return wave.Secrets[i].Urgency > wave.Secrets[j].Urgency
+			}
+			return wave.Secrets[i].SecretID < wave.Secrets[j].SecretID
+		})
+		plan.Waves = append(plan.Waves, wave)
+	}
+	plan.TotalSecrets = len(candidates)
+	return plan, nil
+}
+
+// planSecret turns a candidate entry into a PlannedRotation with urgency and reasons.
+func (c *KeyorixCore) planSecret(ctx context.Context, e *RotationStatusEntry, deps []uint, candidates map[uint]*RotationStatusEntry) PlannedRotation {
+	riskScore, riskBand := 0, ""
+	if r, err := c.ComputeSecretRiskScore(ctx, e.SecretID); err == nil && r != nil {
+		riskScore, riskBand = r.Score, r.Band
+	}
+
+	pr := PlannedRotation{
+		SecretID:    e.SecretID,
+		SecretName:  e.SecretName,
+		Status:      e.Status,
+		DaysOverdue: e.DaysOverdue,
+		RiskScore:   riskScore,
+		RiskBand:    riskBand,
+		Urgency:     rotationUrgency(e.Status, e.DaysOverdue, riskScore),
+		AutoRotate:  e.AutoRotate,
+	}
+
+	if e.Status == RotationStatusOverdue {
+		pr.Reasons = append(pr.Reasons, fmt.Sprintf("%d days overdue", e.DaysOverdue))
+	} else {
+		pr.Reasons = append(pr.Reasons, fmt.Sprintf("due in %d days", -e.DaysOverdue))
+	}
+	if riskScore >= 34 {
+		pr.Reasons = append(pr.Reasons, fmt.Sprintf("%s risk (score %d)", riskBand, riskScore))
+	}
+	if e.AutoRotate {
+		pr.Reasons = append(pr.Reasons, "self-rotating")
+	}
+	if len(deps) > 0 {
+		sort.Slice(deps, func(i, j int) bool { return deps[i] < deps[j] })
+		pr.AfterSecretIDs = deps
+		names := make([]string, 0, len(deps))
+		for _, d := range deps {
+			if dc, ok := candidates[d]; ok {
+				names = append(names, dc.SecretName)
+			}
+		}
+		if len(names) > 0 {
+			pr.Reasons = append(pr.Reasons, "rotate after "+strings.Join(names, ", "))
+		}
+	}
+	return pr
+}
+
+// moreUrgentEntry reports whether a is a more urgent rotation classification than b
+// (overdue beats due_soon; within a class, the larger DaysOverdue is more urgent).
+func moreUrgentEntry(a, b *RotationStatusEntry) bool {
+	rank := func(s string) int {
+		if s == RotationStatusOverdue {
+			return 2
+		}
+		return 1
+	}
+	if ra, rb := rank(a.Status), rank(b.Status); ra != rb {
+		return ra > rb
+	}
+	return a.DaysOverdue > b.DaysOverdue
+}
+
+// rotationUrgency scores a candidate so the plan rotates the most pressing secrets
+// first. Overdue always outranks due-soon; within a class, more time past due (or less
+// time remaining) and higher composite risk raise the score. Deterministic.
+func rotationUrgency(status string, daysOverdue, riskScore int) int {
+	base := 0
+	switch status {
+	case RotationStatusOverdue:
+		// 1000 + days past due (capped so a single ancient secret can't dominate).
+		over := daysOverdue
+		if over > 365 {
+			over = 365
+		}
+		base = 1000 + over
+	case RotationStatusDueSoon:
+		// 500 + (negative days-remaining) → closer to due ranks higher.
+		base = 500 + daysOverdue
+	}
+	return base + riskScore
+}
+
+// rotationWaves partitions the candidate secrets into dependency-ordered waves via a
+// level-by-level Kahn topological sort over the dependency subgraph induced by the
+// candidates: wave 0 holds candidates with no in-plan dependency, and a candidate
+// appears one wave after the last candidate it depends on. ok is false if a cycle
+// prevents a complete ordering (not expected: the graph is acyclic by construction).
+func rotationWaves(edges []*models.SecretDependency, candidates map[uint]bool) (waves [][]uint, ok bool) {
+	adj := map[uint][]uint{} // dependsOn -> dependents, among candidates
+	indeg := make(map[uint]int, len(candidates))
+	for id := range candidates {
+		indeg[id] = 0
+	}
+	for _, e := range edges {
+		if candidates[e.DependentSecretID] && candidates[e.DependsOnSecretID] {
+			adj[e.DependsOnSecretID] = append(adj[e.DependsOnSecretID], e.DependentSecretID)
+			indeg[e.DependentSecretID]++
+		}
+	}
+
+	placed := make(map[uint]bool, len(candidates))
+	remaining := len(candidates)
+	for remaining > 0 {
+		level := []uint{}
+		for id := range candidates {
+			if !placed[id] && indeg[id] == 0 {
+				level = append(level, id)
+			}
+		}
+		if len(level) == 0 {
+			return waves, false // cycle
+		}
+		sort.Slice(level, func(i, j int) bool { return level[i] < level[j] })
+		for _, id := range level {
+			placed[id] = true
+			remaining--
+		}
+		for _, id := range level {
+			for _, dep := range adj[id] {
+				indeg[dep]--
+			}
+		}
+		waves = append(waves, level)
+	}
+	return waves, true
+}

--- a/internal/core/rotation_planner_test.go
+++ b/internal/core/rotation_planner_test.go
@@ -1,0 +1,165 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// --- pure helpers ---
+
+func TestRotationUrgency(t *testing.T) {
+	// Overdue always outranks due-soon, regardless of risk.
+	overdue := rotationUrgency(RotationStatusOverdue, 0, 0)
+	dueSoon := rotationUrgency(RotationStatusDueSoon, -1, 100)
+	assert.Greater(t, overdue, dueSoon, "any overdue beats any due-soon")
+
+	// Within overdue, more days past due and higher risk raise the score.
+	assert.Greater(t, rotationUrgency(RotationStatusOverdue, 30, 50), rotationUrgency(RotationStatusOverdue, 5, 50))
+	assert.Greater(t, rotationUrgency(RotationStatusOverdue, 10, 80), rotationUrgency(RotationStatusOverdue, 10, 10))
+
+	// Within due-soon, closer to due (less negative) ranks higher.
+	assert.Greater(t, rotationUrgency(RotationStatusDueSoon, -2, 0), rotationUrgency(RotationStatusDueSoon, -10, 0))
+
+	// The overdue cap prevents one ancient secret from dwarfing everything.
+	assert.Equal(t, rotationUrgency(RotationStatusOverdue, 9999, 0), rotationUrgency(RotationStatusOverdue, 365, 0))
+}
+
+func TestMoreUrgentEntry(t *testing.T) {
+	od := &RotationStatusEntry{Status: RotationStatusOverdue, DaysOverdue: 5}
+	ds := &RotationStatusEntry{Status: RotationStatusDueSoon, DaysOverdue: -2}
+	assert.True(t, moreUrgentEntry(od, ds))
+	assert.False(t, moreUrgentEntry(ds, od))
+	assert.True(t, moreUrgentEntry(
+		&RotationStatusEntry{Status: RotationStatusOverdue, DaysOverdue: 40},
+		&RotationStatusEntry{Status: RotationStatusOverdue, DaysOverdue: 10},
+	))
+}
+
+func TestRotationWaves(t *testing.T) {
+	// 1 depends on 2; 3 stands alone. Wave 0 = {2,3}, wave 1 = {1}.
+	edges := []*models.SecretDependency{edge(1, 2)}
+	candidates := map[uint]bool{1: true, 2: true, 3: true}
+	waves, ok := rotationWaves(edges, candidates)
+	require.True(t, ok)
+	require.Len(t, waves, 2)
+	assert.Equal(t, []uint{2, 3}, waves[0], "no-dependency candidates rotate first")
+	assert.Equal(t, []uint{1}, waves[1], "the dependent rotates after its dependency")
+}
+
+func TestRotationWavesIgnoresNonCandidateEdges(t *testing.T) {
+	// 1 depends on 2, but 2 is not in the plan → 1 has no in-plan dependency.
+	edges := []*models.SecretDependency{edge(1, 2)}
+	candidates := map[uint]bool{1: true}
+	waves, ok := rotationWaves(edges, candidates)
+	require.True(t, ok)
+	require.Len(t, waves, 1)
+	assert.Equal(t, []uint{1}, waves[0])
+}
+
+func TestRotationWavesDetectsCycle(t *testing.T) {
+	edges := []*models.SecretDependency{edge(1, 2), edge(2, 1)}
+	_, ok := rotationWaves(edges, map[uint]bool{1: true, 2: true})
+	assert.False(t, ok)
+}
+
+// --- integration against a real in-memory store ---
+
+func newPlannerCore(t *testing.T, now time.Time) (*KeyorixCore, *gorm.DB) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.Project{}, &models.Environment{}, &models.SecretNode{}, &models.RotationPolicy{},
+		&models.SecretDependency{}, &models.ShareRecord{}, &models.SecretAccessLog{}, &models.AuditEvent{},
+	))
+	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: func() time.Time { return now }}
+	return c, db
+}
+
+func TestGenerateRotationPlan(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 6, 22, 12, 0, 0, 0, time.UTC)
+	c, db := newPlannerCore(t, now)
+	projectID := uint(1)
+	daysAgo := func(d int) *time.Time { tt := now.Add(-time.Duration(d) * 24 * time.Hour); return &tt }
+
+	require.NoError(t, db.Create(&models.Project{ID: projectID, Name: "prod"}).Error)
+	require.NoError(t, db.Create(&models.Environment{ID: 1, ProjectID: projectID, Name: "production"}).Error)
+	require.NoError(t, db.Create(&models.RotationPolicy{
+		Name: "90-day", Scope: "project", ProjectID: &projectID, IntervalDays: 90, AlertDaysBefore: 14, IsActive: true,
+	}).Error)
+
+	mk := func(id uint, name string, last *time.Time) {
+		require.NoError(t, db.Create(&models.SecretNode{
+			ID: id, Name: name, ProjectID: projectID, EnvironmentID: 1, IsSecret: true, Status: "active",
+			OwnerID: 1, LastRotatedAt: last,
+		}).Error)
+	}
+	mk(1, "overdue-app", daysAgo(120)) // 30 days overdue
+	mk(2, "overdue-db", daysAgo(200))  // 110 days overdue (more urgent)
+	mk(3, "due-soon-key", daysAgo(80)) // 10 days remaining → due_soon
+	mk(4, "healthy-key", daysAgo(5))   // ok → excluded from the plan
+
+	// overdue-app depends on overdue-db → it must rotate in a later wave.
+	_, err := c.AddSecretDependency(ctx, 1, 1, 2, "app token derives from db password")
+	require.NoError(t, err)
+
+	plan, err := c.GenerateRotationPlan(ctx, projectID)
+	require.NoError(t, err)
+
+	assert.Equal(t, 3, plan.TotalSecrets)
+	assert.Equal(t, 2, plan.OverdueCount)
+	assert.Equal(t, 1, plan.DueSoonCount)
+	require.Len(t, plan.Waves, 2, "the dependency forces a second wave")
+
+	// Wave 0: overdue-db (dependency, most urgent) before due-soon-key; overdue-app is NOT here.
+	w0 := plan.Waves[0].Secrets
+	require.Len(t, w0, 2)
+	assert.Equal(t, "overdue-db", w0[0].SecretName)
+	assert.Equal(t, "due-soon-key", w0[1].SecretName)
+	assert.Greater(t, w0[0].Urgency, w0[1].Urgency)
+
+	// Wave 1: overdue-app, which must follow overdue-db.
+	w1 := plan.Waves[1].Secrets
+	require.Len(t, w1, 1)
+	assert.Equal(t, "overdue-app", w1[0].SecretName)
+	assert.Equal(t, []uint{2}, w1[0].AfterSecretIDs)
+
+	// Rationale is present and specific.
+	assert.Contains(t, joinReasons(w1[0].Reasons), "30 days overdue")
+	assert.Contains(t, joinReasons(w1[0].Reasons), "rotate after overdue-db")
+	assert.Contains(t, joinReasons(w0[1].Reasons), "due in 10 days")
+}
+
+func TestGenerateRotationPlanEmptyWhenNothingDue(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 6, 22, 12, 0, 0, 0, time.UTC)
+	c, db := newPlannerCore(t, now)
+	projectID := uint(1)
+	require.NoError(t, db.Create(&models.RotationPolicy{
+		Name: "90-day", Scope: "project", ProjectID: &projectID, IntervalDays: 90, AlertDaysBefore: 14, IsActive: true,
+	}).Error)
+	tt := now.Add(-5 * 24 * time.Hour)
+	require.NoError(t, db.Create(&models.SecretNode{ID: 1, Name: "healthy", ProjectID: projectID, EnvironmentID: 1, IsSecret: true, Status: "active", OwnerID: 1, LastRotatedAt: &tt}).Error)
+
+	plan, err := c.GenerateRotationPlan(ctx, projectID)
+	require.NoError(t, err)
+	assert.Equal(t, 0, plan.TotalSecrets)
+	assert.Empty(t, plan.Waves)
+}
+
+func joinReasons(rs []string) string {
+	out := ""
+	for _, r := range rs {
+		out += r + " | "
+	}
+	return out
+}

--- a/server/http/handlers/secret_dependencies.go
+++ b/server/http/handlers/secret_dependencies.go
@@ -153,3 +153,24 @@ func (h *SecretHandler) GetProjectRotationOrder(w http.ResponseWriter, r *http.R
 	}
 	h.sendSuccess(w, order, "")
 }
+
+// GetProjectRotationPlan handles GET /api/v1/projects/{id}/rotation-plan (ADR-053):
+// an ordered, dependency-respecting plan of the project's secrets that are overdue or
+// due soon, batched into parallel-safe waves and prioritised by urgency.
+func (h *SecretHandler) GetProjectRotationPlan(w http.ResponseWriter, r *http.Request) {
+	if middleware.GetUserFromContext(r.Context()) == nil {
+		h.sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		h.sendError(w, "InvalidParameter", "Invalid project ID", http.StatusBadRequest, nil)
+		return
+	}
+	plan, err := h.coreService.GenerateRotationPlan(r.Context(), uint(id))
+	if err != nil {
+		h.sendError(w, "Error", err.Error(), dependencyErrorStatus(err.Error()), nil)
+		return
+	}
+	h.sendSuccess(w, plan, "")
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -244,6 +244,7 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		r.With(customMiddleware.RequireScopedPermission("secrets.write", projectScope)).Post("/projects/{id}/restore", catalogHandler.RestoreProject)
 		r.With(customMiddleware.RequireScopedPermission("secrets.read", projectScope)).Get("/projects/{id}/drift", catalogHandler.GetProjectDrift)
 		r.With(customMiddleware.RequireScopedPermission("secrets.read", projectScope)).Get("/projects/{id}/rotation-order", secretHandler.GetProjectRotationOrder)
+		r.With(customMiddleware.RequireScopedPermission("secrets.read", projectScope)).Get("/projects/{id}/rotation-plan", secretHandler.GetProjectRotationPlan)
 		// Project membership (ADR-021 two-tier model). Read = project members may
 		// view the roster; mutations require roles.assign at the project scope, so
 		// a project_admin can manage their own project's members.


### PR DESCRIPTION
## What

Closes the M3 "Automated rotation planning" item, building on the dependency graph (ADR-052). `GET /api/v1/projects/{id}/rotation-plan` (scoped `secrets.read`) returns an ordered, dependency-respecting **plan** for rotating a project's secrets.

- **Candidates** — the project's policy-covered secrets that are **overdue or due-soon** (healthy ones omitted; a secret under multiple policies appears once at its most-urgent class).
- **Waves** — candidates batched by a level-by-level Kahn sort over the dependency subgraph *induced by the candidates*: wave 0 has no in-plan dependency; a secret rotates one wave after anything it depends on. Secrets within a wave are **safe to rotate in parallel**. Edges to non-due secrets impose no ordering.
- **Priority** — within a wave, ordered by **urgency** (overdue beats due-soon; more days past due, capped, + higher composite risk rank higher; deterministic).
- **Rationale** — each entry carries `reasons` ("30 days overdue", "high risk (score 78)", "rotate after db-password") + `after_secret_ids`, so the plan is auditable and overridable.

## Why deterministic, not an LLM

The planner is a deterministic, explainable algorithm — the right call for a security operation in **air-gapped / ENS** deployments (reproducible, auditable, no data egress in the rotation path). The structured plan is shaped so an **optional LLM advisor** (narrate / window-batch / risk-weight) can sit *on top* later, never in the decision path. See ADR-053.

## Testing

- Pure helpers: `rotationWaves` (parallel-safe grouping, non-candidate edges ignored, cycle detection), `rotationUrgency`, `moreUrgentEntry`.
- Real-store integration: overdue/due-soon/healthy + a dependency → verifies wave split, ordering, counts, and rationale.
- gofmt / build / vet / gosec / golangci-lint clean.

API-only first vertical (gRPC/CLI/web + executor wiring deferred — see ADR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)