### PR TITLE
feat(cli): secret dependency graph + rotation order commands (ADR-052)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,9 +35,15 @@ All notable changes to Keyorix are documented here. This project follows
   cycles are rejected). Metadata only — no secret value is read. This is the
   prerequisite for automated rotation planning; the topological order is the
   deterministic core of that. (ADR-052) ([#412])
+- **CLI for the secret dependency graph** — `keyorix secret deps list|add|rm|impact`
+  and `keyorix rotation order <project-id>` bring the ADR-052 dependency graph to the
+  terminal: declare/list/remove edges, see a secret's rotation blast radius, and print
+  a project's safe rotation order. Thin REST clients over the existing endpoints,
+  scoped server-side. ([#414])
 
 [#410]: https://github.com/keyorixhq/keyorix/pull/410
 [#411]: https://github.com/keyorixhq/keyorix/pull/411
+[#414]: https://github.com/keyorixhq/keyorix/pull/414
 [#412]: https://github.com/keyorixhq/keyorix/pull/412
 
 ## v0.74.0 — 2026-06-22

--- a/internal/cli/rotation/order.go
+++ b/internal/cli/rotation/order.go
@@ -1,0 +1,71 @@
+// order.go — the `keyorix rotation order` CLI (ADR-052): print a safe rotation
+// sequence for a project's secret dependency graph, where each secret is listed
+// before anything that depends on it. Talks to GET /api/v1/projects/{id}/rotation-order
+// (scoped by the caller's secrets.read permission server-side).
+package rotation
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/spf13/cobra"
+)
+
+type rotationStep struct {
+	SecretID   uint   `json:"secret_id"`
+	SecretName string `json:"secret_name"`
+}
+
+type rotationOrderView struct {
+	ProjectID uint           `json:"project_id"`
+	Order     []rotationStep `json:"order"`
+}
+
+var orderCmd = &cobra.Command{
+	Use:   "order <project-id>",
+	Short: "Print a safe rotation sequence for a project's dependency graph",
+	Long: `Print the order in which a project's secrets should be rotated so that each secret
+is rotated before anything that depends on it (a topological sort of the dependency
+graph, ADR-052). Only secrets that appear in the graph are listed.`,
+	Args:         cobra.ExactArgs(1),
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, args []string) error {
+		projectID, err := strconv.ParseUint(strings.TrimSpace(args[0]), 10, 32)
+		if err != nil || projectID == 0 {
+			return fmt.Errorf("invalid project id %q", args[0])
+		}
+		c, ok := common.NewRemoteClient()
+		if !ok {
+			return fmt.Errorf("not connected to a server — run: keyorix connect <server>")
+		}
+		view, err := fetchRotationOrder(context.Background(), c, uint(projectID))
+		if err != nil {
+			return err
+		}
+		if len(view.Order) == 0 {
+			fmt.Println("No secret dependencies in this project — secrets can rotate in any order.")
+			return nil
+		}
+		fmt.Printf("Rotation order for project %d (rotate top to bottom):\n", view.ProjectID)
+		for i, s := range view.Order {
+			fmt.Printf("  %2d. %-6d %s\n", i+1, s.SecretID, s.SecretName)
+		}
+		return nil
+	},
+}
+
+// fetchRotationOrder is split out for httptest-backed tests.
+func fetchRotationOrder(ctx context.Context, c *common.RemoteClient, projectID uint) (*rotationOrderView, error) {
+	var v rotationOrderView
+	if err := c.Get(ctx, fmt.Sprintf("/api/v1/projects/%d/rotation-order", projectID), &v); err != nil {
+		return nil, err
+	}
+	return &v, nil
+}
+
+func init() {
+	RotationCmd.AddCommand(orderCmd)
+}

--- a/internal/cli/rotation/order_remote_test.go
+++ b/internal/cli/rotation/order_remote_test.go
@@ -1,0 +1,33 @@
+package rotation
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFetchRotationOrder(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/projects/1/rotation-order" {
+			_, _ = w.Write([]byte(`{"data":{"project_id":1,"order":[{"secret_id":4,"secret_name":"root-ca"},{"secret_id":2,"secret_name":"intermediate"},{"secret_id":1,"secret_name":"service-cert"}]}}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	rc, ok := common.NewRemoteClient()
+	require.True(t, ok)
+
+	v, err := fetchRotationOrder(context.Background(), rc, 1)
+	require.NoError(t, err)
+	require.Len(t, v.Order, 3)
+	assert.Equal(t, "root-ca", v.Order[0].SecretName)
+	assert.Equal(t, "service-cert", v.Order[2].SecretName)
+}

--- a/internal/cli/secret/dependencies.go
+++ b/internal/cli/secret/dependencies.go
@@ -1,0 +1,234 @@
+// dependencies.go — the `keyorix secret deps` CLI (ADR-052): inspect and manage a
+// secret's dependency graph from the terminal, and see the blast radius of rotating
+// it. All commands talk to the server's REST API under /api/v1/secrets/{id}/...,
+// scoped by the caller's secrets.read / secrets.write permission server-side.
+package secret
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/spf13/cobra"
+)
+
+type depEdgeView struct {
+	ID         uint   `json:"id"`
+	SecretID   uint   `json:"secret_id"`
+	SecretName string `json:"secret_name"`
+	Note       string `json:"note"`
+}
+
+type depsView struct {
+	SecretID   uint          `json:"secret_id"`
+	DependsOn  []depEdgeView `json:"depends_on"`
+	Dependents []depEdgeView `json:"dependents"`
+}
+
+type impactedView struct {
+	SecretID   uint   `json:"secret_id"`
+	SecretName string `json:"secret_name"`
+	Depth      int    `json:"depth"`
+}
+
+type impactView struct {
+	SecretID   uint           `json:"secret_id"`
+	SecretName string         `json:"secret_name"`
+	Affected   []impactedView `json:"affected"`
+}
+
+var depNote string
+
+var depsCmd = &cobra.Command{
+	Use:     "deps",
+	Aliases: []string{"dependencies"},
+	Short:   "Inspect and manage a secret's dependency graph",
+	Long: `Manage the secret dependency graph (ADR-052): declare that one secret depends on
+another, list a secret's dependencies and dependents, and see the blast radius of
+rotating it. Dependencies drive rotation impact analysis and ordering.`,
+}
+
+var depsListCmd = &cobra.Command{
+	Use:          "list <secret-id>",
+	Short:        "Show what a secret depends on and what depends on it",
+	Args:         cobra.ExactArgs(1),
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, args []string) error {
+		id, err := parseSecretArg(args[0])
+		if err != nil {
+			return err
+		}
+		c, err := depsClient()
+		if err != nil {
+			return err
+		}
+		v, err := fetchDependencies(context.Background(), c, id)
+		if err != nil {
+			return err
+		}
+		printDependencies(v)
+		return nil
+	},
+}
+
+var depsAddCmd = &cobra.Command{
+	Use:          "add <secret-id> <depends-on-id>",
+	Short:        "Declare that <secret-id> depends on <depends-on-id>",
+	Args:         cobra.ExactArgs(2),
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, args []string) error {
+		id, err := parseSecretArg(args[0])
+		if err != nil {
+			return err
+		}
+		dependsOn, err := parseSecretArg(args[1])
+		if err != nil {
+			return err
+		}
+		c, err := depsClient()
+		if err != nil {
+			return err
+		}
+		body := map[string]interface{}{"depends_on_id": dependsOn, "note": depNote}
+		var out depEdgeView
+		if err := c.Post(context.Background(), fmt.Sprintf("/api/v1/secrets/%d/dependencies", id), body, &out); err != nil {
+			return err
+		}
+		fmt.Printf("Added: secret %d now depends on secret %d (edge %d).\n", id, dependsOn, out.ID)
+		return nil
+	},
+}
+
+var depsRemoveCmd = &cobra.Command{
+	Use:          "rm <secret-id> <edge-id>",
+	Aliases:      []string{"remove", "delete"},
+	Short:        "Remove a dependency edge (edge id from `deps list`)",
+	Args:         cobra.ExactArgs(2),
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, args []string) error {
+		id, err := parseSecretArg(args[0])
+		if err != nil {
+			return err
+		}
+		edgeID, err := parseSecretArg(args[1])
+		if err != nil {
+			return err
+		}
+		c, err := depsClient()
+		if err != nil {
+			return err
+		}
+		if err := c.Delete(context.Background(), fmt.Sprintf("/api/v1/secrets/%d/dependencies/%d", id, edgeID)); err != nil {
+			return err
+		}
+		fmt.Printf("Removed dependency edge %d from secret %d.\n", edgeID, id)
+		return nil
+	},
+}
+
+var depsImpactCmd = &cobra.Command{
+	Use:          "impact <secret-id>",
+	Short:        "Show the blast radius of rotating a secret (transitive dependents)",
+	Args:         cobra.ExactArgs(1),
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, args []string) error {
+		id, err := parseSecretArg(args[0])
+		if err != nil {
+			return err
+		}
+		c, err := depsClient()
+		if err != nil {
+			return err
+		}
+		v, err := fetchImpact(context.Background(), c, id)
+		if err != nil {
+			return err
+		}
+		printImpact(v)
+		return nil
+	},
+}
+
+// fetchDependencies / fetchImpact are split out so the rendering can be tested against
+// an httptest-backed client.
+func fetchDependencies(ctx context.Context, c *common.RemoteClient, id uint) (*depsView, error) {
+	var v depsView
+	if err := c.Get(ctx, fmt.Sprintf("/api/v1/secrets/%d/dependencies", id), &v); err != nil {
+		return nil, err
+	}
+	return &v, nil
+}
+
+func fetchImpact(ctx context.Context, c *common.RemoteClient, id uint) (*impactView, error) {
+	var v impactView
+	if err := c.Get(ctx, fmt.Sprintf("/api/v1/secrets/%d/impact", id), &v); err != nil {
+		return nil, err
+	}
+	return &v, nil
+}
+
+func printDependencies(v *depsView) {
+	fmt.Printf("Depends on (%d):\n", len(v.DependsOn))
+	if len(v.DependsOn) == 0 {
+		fmt.Println("  (none — this secret stands alone)")
+	}
+	for _, e := range v.DependsOn {
+		fmt.Printf("  edge %-5d → secret %-5d %s%s\n", e.ID, e.SecretID, e.SecretName, noteSuffix(e.Note))
+	}
+	fmt.Printf("Used by (%d):\n", len(v.Dependents))
+	if len(v.Dependents) == 0 {
+		fmt.Println("  (none)")
+	}
+	for _, e := range v.Dependents {
+		fmt.Printf("  edge %-5d ← secret %-5d %s%s\n", e.ID, e.SecretID, e.SecretName, noteSuffix(e.Note))
+	}
+}
+
+func printImpact(v *impactView) {
+	if len(v.Affected) == 0 {
+		fmt.Printf("Rotating %s (secret %d) affects no other secrets.\n", v.SecretName, v.SecretID)
+		return
+	}
+	fmt.Printf("Rotating %s (secret %d) affects %d secret(s):\n", v.SecretName, v.SecretID, len(v.Affected))
+	for _, a := range v.Affected {
+		fmt.Printf("  %-5d %-26s (%d hop%s)\n", a.SecretID, a.SecretName, a.Depth, plural(a.Depth))
+	}
+}
+
+func noteSuffix(note string) string {
+	if strings.TrimSpace(note) == "" {
+		return ""
+	}
+	return "  — " + note
+}
+
+func plural(n int) string {
+	if n == 1 {
+		return ""
+	}
+	return "s"
+}
+
+func parseSecretArg(s string) (uint, error) {
+	n, err := strconv.ParseUint(strings.TrimSpace(s), 10, 32)
+	if err != nil || n == 0 {
+		return 0, fmt.Errorf("invalid secret id %q", s)
+	}
+	return uint(n), nil
+}
+
+func depsClient() (*common.RemoteClient, error) {
+	c, ok := common.NewRemoteClient()
+	if !ok {
+		return nil, fmt.Errorf("not connected to a server — run: keyorix connect <server>")
+	}
+	return c, nil
+}
+
+func init() {
+	depsAddCmd.Flags().StringVar(&depNote, "note", "", "Optional note describing the dependency")
+	depsCmd.AddCommand(depsListCmd, depsAddCmd, depsRemoveCmd, depsImpactCmd)
+	SecretCmd.AddCommand(depsCmd)
+}

--- a/internal/cli/secret/dependencies_remote_test.go
+++ b/internal/cli/secret/dependencies_remote_test.go
@@ -1,0 +1,79 @@
+package secret
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func depsStub(t *testing.T) (*common.RemoteClient, func()) {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/secrets/7/dependencies":
+			_, _ = w.Write([]byte(`{"data":{"secret_id":7,"depends_on":[{"id":10,"secret_id":2,"secret_name":"db-password","note":"derives from"}],"dependents":[{"id":11,"secret_id":3,"secret_name":"edge-cert"}]}}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/secrets/7/impact":
+			_, _ = w.Write([]byte(`{"data":{"secret_id":7,"secret_name":"app-token","affected":[{"secret_id":3,"secret_name":"edge-cert","depth":1},{"secret_id":4,"secret_name":"gateway","depth":2}]}}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/secrets/7/dependencies":
+			_, _ = w.Write([]byte(`{"data":{"id":12,"secret_id":2,"secret_name":"db-password"}}`))
+		case r.Method == http.MethodDelete && r.URL.Path == "/api/v1/secrets/7/dependencies/12":
+			_, _ = w.Write([]byte(`{"data":{"removed":true}}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	rc, ok := common.NewRemoteClient()
+	require.True(t, ok)
+	return rc, srv.Close
+}
+
+func TestFetchDependencies(t *testing.T) {
+	rc, done := depsStub(t)
+	defer done()
+	v, err := fetchDependencies(context.Background(), rc, 7)
+	require.NoError(t, err)
+	require.Len(t, v.DependsOn, 1)
+	assert.Equal(t, uint(10), v.DependsOn[0].ID)
+	assert.Equal(t, "db-password", v.DependsOn[0].SecretName)
+	assert.Equal(t, "derives from", v.DependsOn[0].Note)
+	require.Len(t, v.Dependents, 1)
+	assert.Equal(t, "edge-cert", v.Dependents[0].SecretName)
+}
+
+func TestFetchImpact(t *testing.T) {
+	rc, done := depsStub(t)
+	defer done()
+	v, err := fetchImpact(context.Background(), rc, 7)
+	require.NoError(t, err)
+	assert.Equal(t, "app-token", v.SecretName)
+	require.Len(t, v.Affected, 2)
+	assert.Equal(t, "edge-cert", v.Affected[0].SecretName)
+	assert.Equal(t, 1, v.Affected[0].Depth)
+	assert.Equal(t, 2, v.Affected[1].Depth)
+}
+
+func TestDepsAddAndRemove(t *testing.T) {
+	rc, done := depsStub(t)
+	defer done()
+	var out depEdgeView
+	require.NoError(t, rc.Post(context.Background(), "/api/v1/secrets/7/dependencies", map[string]interface{}{"depends_on_id": 2}, &out))
+	assert.Equal(t, uint(12), out.ID)
+	require.NoError(t, rc.Delete(context.Background(), "/api/v1/secrets/7/dependencies/12"))
+}
+
+func TestParseSecretArg(t *testing.T) {
+	id, err := parseSecretArg(" 42 ")
+	require.NoError(t, err)
+	assert.Equal(t, uint(42), id)
+	_, err = parseSecretArg("0")
+	assert.Error(t, err)
+	_, err = parseSecretArg("abc")
+	assert.Error(t, err)
+}


### PR DESCRIPTION
Brings the ADR-052 secret dependency graph to the terminal (keyorix is a CLI-first product; this was a deferred follow-up in ADR-052).

## Commands
- `keyorix secret deps list <secret-id>` — what a secret depends on and what depends on it (with edge ids).
- `keyorix secret deps add <secret-id> <depends-on-id> [--note]` — declare a dependency.
- `keyorix secret deps rm <secret-id> <edge-id>` — remove an edge.
- `keyorix secret deps impact <secret-id>` — blast radius (transitive dependents, with hop distance).
- `keyorix rotation order <project-id>` — a project's safe rotation order (topological sort of the graph).

## How
Thin REST clients over the existing `/api/v1/secrets/{id}/...` and `/api/v1/projects/{id}/rotation-order` endpoints, using the standard `common.RemoteClient`. All authorization is server-side (scoped `secrets.read`/`secrets.write`). Fetch logic is factored into testable helpers.

## Testing
- httptest-backed remote tests for `fetchDependencies`, `fetchImpact`, `fetchRotationOrder`, add/remove, and id parsing.
- gofmt / build / vet / gosec / golangci-lint clean; command registration smoke-checked via `--help`.

No server changes — pure CLI wrappers over shipped endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)