### PR TITLE
feat(secrets): certificate inspection — public X.509 metadata (ADR-054)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,10 +24,18 @@ All notable changes to Keyorix are documented here. This project follows
   / `GetSecretImpact` and `ProjectService.GetProjectRotationOrder` expose the ADR-052
   dependency graph over gRPC (read-only), mirroring the HTTP/CLI surfaces with the same
   scoped `secrets.read` authorization. ([#415])
+- **Certificate inspection** — `GET /api/v1/secrets/{id}/certificate` and
+  `keyorix secret cert <id>` parse a certificate-valued secret's leaf X.509 cert and
+  return its **public** metadata (subject, issuer, real `notAfter`/expiry, SANs, is-CA,
+  self-signed, algorithms) for PKI hygiene. Never returns the value or any private key
+  (only `CERTIFICATE` blocks are parsed), does **not** count against `max_reads`,
+  respects suspension, and is audited (`secret.certificate_inspected`). Scoped
+  `secrets.read`. (ADR-054) ([#416])
 
 [#413]: https://github.com/keyorixhq/keyorix/pull/413
 [#414]: https://github.com/keyorixhq/keyorix/pull/414
 [#415]: https://github.com/keyorixhq/keyorix/pull/415
+[#416]: https://github.com/keyorixhq/keyorix/pull/416
 
 ## v0.75.0 — 2026-06-22
 

--- a/docs/adr-054-certificate-inspection.md
+++ b/docs/adr-054-certificate-inspection.md
@@ -1,0 +1,69 @@
+# ADR-054: Certificate inspection
+
+## Status
+
+Accepted.
+
+## Context
+
+A large share of stored secrets are X.509 certificates (TLS certs, CA chains). Keyorix
+tracks a manually-set `Expiration` on a secret, but for a certificate the *real* expiry
+is `notAfter` inside the certificate itself — which Keyorix never looked at. Operators
+had no way to see a certificate's actual validity window, issuer, or SANs without
+exporting the value and running `openssl` by hand. Certificate hygiene (knowing what
+expires when, who issued it) is a concrete control under ENS (`mp.info`/`op.exp`) and
+NIS2.
+
+## Decision
+
+Add **certificate inspection**: `InspectCertificate(secretID)` parses the leaf X.509
+certificate from a secret's value and returns its **public metadata** — subject,
+issuer, serial, `notBefore`/`notAfter`, days-until-expiry, is-expired, is-CA,
+self-signed, SANs, signature & public-key algorithms. Exposed at
+`GET /api/v1/secrets/{id}/certificate` (scoped `secrets.read`) and
+`keyorix secret cert <id>`.
+
+The deliberate constraints:
+
+- **Public metadata only — never the value or any private key.** The parser only ever
+  reads `CERTIFICATE` PEM blocks; a bundled `PRIVATE KEY` block is ignored. The
+  response struct has no field that could carry the value or key material. So a caller
+  who can already `secrets.read`/reveal the secret learns nothing they couldn't already
+  obtain — inspection just parses the public part for them.
+- **Does NOT count against `max_reads`.** Reading a certificate's public metadata is not
+  value consumption, so inspection decrypts via the *non-counting* sibling of the value-
+  read path. A one-time-read certificate is not "spent" by inspecting its expiry. (This
+  is the one place that decrypts a value off the counting path — justified because
+  nothing secret leaves the boundary.)
+- **Respects suspension.** A suspended secret (frozen for incident response) is not
+  decrypted/inspected. Expired secrets *are* inspectable — seeing why is the point.
+- **Audited.** Every inspection writes `secret.certificate_inspected` (actor + secret +
+  issuer + expiry), so the access is on the trail like any value-adjacent read.
+- **Authorization** is scoped `secrets.read` (environment-granular), enforced at the
+  transport layer — the same gate as the other *value-derived* read endpoints
+  (`/{id}/risk`, `/{id}/impact`). This is deliberately the route-scope gate and **not**
+  the stricter per-user owner/share check the full-value reveal applies: a project
+  auditor or reader should be able to see certificate hygiene (what expires when)
+  without being a share-recipient of every secret. The exposed fields are the public
+  part of the certificate that any TLS client already sees, so this is not a new
+  exposure of secret material.
+
+## Alternatives considered
+
+- **Parse at write time and store cert metadata as fields.** Avoids decrypting on read,
+  but only covers certs created/rotated after the change (a backfill gap), complicates
+  the create/rotate path, and duplicates state that can be derived. Read-time inspection
+  works for every existing certificate immediately. Persisting parsed expiry as a
+  posture signal is a reasonable later addition on top of this.
+- **Count inspection against `max_reads`.** Rejected — it would let "check the expiry"
+  silently consume a one-time secret, which is surprising and wrong; the metadata is not
+  the secret.
+- **Return the full certificate PEM.** Unnecessary — the caller can already reveal the
+  value through the normal path; inspection's value is the *parsed* public fields.
+
+## Deferred follow-ups
+
+- Surface certificate `notAfter` in the expiry/rotation posture and dashboards (use the
+  real cert expiry, not just the manual field), and flag soon-expiring certs.
+- Full chain inspection (intermediates) and chain-validity, not just the leaf.
+- gRPC surface and a keyorix-web certificate panel on the secret detail page.

--- a/internal/cli/secret/certificate.go
+++ b/internal/cli/secret/certificate.go
@@ -1,0 +1,80 @@
+// certificate.go — the `keyorix secret cert` CLI (ADR-054): show the public X.509
+// metadata of a certificate-valued secret (subject, issuer, validity, SANs) so an
+// operator can check PKI hygiene from the terminal. Talks to
+// GET /api/v1/secrets/{id}/certificate; never prints the value or any private key.
+package secret
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+type certView struct {
+	SecretID           uint     `json:"secret_id"`
+	SecretName         string   `json:"secret_name"`
+	Subject            string   `json:"subject"`
+	Issuer             string   `json:"issuer"`
+	SerialNumber       string   `json:"serial_number"`
+	NotBefore          string   `json:"not_before"`
+	NotAfter           string   `json:"not_after"`
+	DaysUntilExpiry    int      `json:"days_until_expiry"`
+	IsExpired          bool     `json:"is_expired"`
+	IsCA               bool     `json:"is_ca"`
+	SelfSigned         bool     `json:"self_signed"`
+	DNSNames           []string `json:"dns_names"`
+	SignatureAlgorithm string   `json:"signature_algorithm"`
+	PublicKeyAlgorithm string   `json:"public_key_algorithm"`
+}
+
+var certCmd = &cobra.Command{
+	Use:          "cert <secret-id>",
+	Aliases:      []string{"certificate"},
+	Short:        "Show a certificate secret's public X.509 metadata (expiry, issuer, SANs)",
+	Args:         cobra.ExactArgs(1),
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, args []string) error {
+		id, err := parseSecretArg(args[0])
+		if err != nil {
+			return err
+		}
+		c, err := depsClient()
+		if err != nil {
+			return err
+		}
+		var v certView
+		if err := c.Get(context.Background(), fmt.Sprintf("/api/v1/secrets/%d/certificate", id), &v); err != nil {
+			return err
+		}
+		expiry := v.NotAfter
+		if v.IsExpired {
+			expiry += "  (EXPIRED)"
+		} else {
+			expiry += fmt.Sprintf("  (%d days left)", v.DaysUntilExpiry)
+		}
+		fmt.Printf("Certificate: %s (secret %d)\n", v.SecretName, v.SecretID)
+		fmt.Printf("  Subject:    %s\n", v.Subject)
+		fmt.Printf("  Issuer:     %s%s\n", v.Issuer, selfSignedNote(v.SelfSigned))
+		fmt.Printf("  Serial:     %s\n", v.SerialNumber)
+		fmt.Printf("  Valid from: %s\n", v.NotBefore)
+		fmt.Printf("  Expires:    %s\n", expiry)
+		if len(v.DNSNames) > 0 {
+			fmt.Printf("  SANs:       %v\n", v.DNSNames)
+		}
+		fmt.Printf("  CA:         %t\n", v.IsCA)
+		fmt.Printf("  Algorithms: %s / %s\n", v.SignatureAlgorithm, v.PublicKeyAlgorithm)
+		return nil
+	},
+}
+
+func selfSignedNote(selfSigned bool) string {
+	if selfSigned {
+		return "  (self-signed)"
+	}
+	return ""
+}
+
+func init() {
+	SecretCmd.AddCommand(certCmd)
+}

--- a/internal/cli/secret/certificate_remote_test.go
+++ b/internal/cli/secret/certificate_remote_test.go
@@ -1,0 +1,35 @@
+package secret
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFetchCertificate(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/secrets/7/certificate" {
+			_, _ = w.Write([]byte(`{"data":{"secret_id":7,"secret_name":"tls-cert","subject":"CN=example.com","issuer":"CN=example.com","serial_number":"4242","not_before":"2025-06-23T00:00:00Z","not_after":"2026-09-21T00:00:00Z","days_until_expiry":90,"is_expired":false,"is_ca":false,"self_signed":true,"dns_names":["example.com"],"signature_algorithm":"ECDSA-SHA256","public_key_algorithm":"ECDSA"}}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	rc, ok := common.NewRemoteClient()
+	require.True(t, ok)
+
+	var v certView
+	require.NoError(t, rc.Get(context.Background(), "/api/v1/secrets/7/certificate", &v))
+	assert.Equal(t, "tls-cert", v.SecretName)
+	assert.Equal(t, "CN=example.com", v.Subject)
+	assert.True(t, v.SelfSigned)
+	assert.Equal(t, 90, v.DaysUntilExpiry)
+	assert.Equal(t, []string{"example.com"}, v.DNSNames)
+}

--- a/internal/core/certificate.go
+++ b/internal/core/certificate.go
@@ -1,0 +1,118 @@
+// certificate.go — certificate inspection (ADR-054). For a secret whose value is an
+// X.509 certificate, InspectCertificate parses it and returns the certificate's
+// PUBLIC metadata (subject, issuer, validity window, SANs, …) so an operator can see
+// PKI hygiene — chiefly when a cert actually expires, independent of any manually-set
+// Expiration field. It never returns the certificate's value or any private key, and
+// it does NOT count against the secret's max_reads (reading public certificate
+// metadata is not value consumption). Each inspection is audited.
+package core
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+)
+
+// EventSecretCertificateInspected is audited when a certificate's metadata is read.
+const EventSecretCertificateInspected = "secret.certificate_inspected" // #nosec G101 -- audit event type, not a credential
+
+// CertificateInfo is the public metadata extracted from an X.509 certificate. It
+// deliberately excludes the certificate value itself and any private key.
+type CertificateInfo struct {
+	SecretID           uint      `json:"secret_id"`
+	SecretName         string    `json:"secret_name"`
+	Subject            string    `json:"subject"`
+	Issuer             string    `json:"issuer"`
+	SerialNumber       string    `json:"serial_number"`
+	NotBefore          time.Time `json:"not_before"`
+	NotAfter           time.Time `json:"not_after"`
+	DaysUntilExpiry    int       `json:"days_until_expiry"` // negative once expired
+	IsExpired          bool      `json:"is_expired"`
+	IsCA               bool      `json:"is_ca"`
+	SelfSigned         bool      `json:"self_signed"`
+	DNSNames           []string  `json:"dns_names,omitempty"`
+	SignatureAlgorithm string    `json:"signature_algorithm"`
+	PublicKeyAlgorithm string    `json:"public_key_algorithm"`
+}
+
+// InspectCertificate decrypts the secret's current value, parses the leaf X.509
+// certificate, and returns its public metadata. actorID is the inspecting principal.
+// Authorization (scoped secrets.read) is enforced at the transport layer, mirroring
+// the other per-secret read endpoints.
+func (c *KeyorixCore) InspectCertificate(ctx context.Context, actorID, secretID uint) (*CertificateInfo, error) {
+	secret, err := c.storage.GetSecret(ctx, secretID)
+	if err != nil {
+		return nil, fmt.Errorf("%s: secret %d not found", i18n.T("ErrorNotFound", nil), secretID)
+	}
+	// A suspended secret is frozen for incident response; don't decrypt it.
+	if secret.Status == SecretStatusSuspended {
+		return nil, fmt.Errorf("secret is suspended")
+	}
+
+	version, err := c.storage.GetLatestSecretVersion(ctx, secretID)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorVersionNotFound", nil), err)
+	}
+
+	// Decrypt WITHOUT touching the max-reads counter — inspecting public certificate
+	// metadata is not a value read. (readVersionValue is the counting path; this is
+	// deliberately the non-counting sibling.)
+	value := version.EncryptedValue
+	if c.encryption != nil {
+		value, err = c.encryption.RetrieveSecret(version.ID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read secret value: %w", err)
+		}
+	}
+
+	cert, err := parseLeafCertificate(value)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "secret value is not a parseable X.509 certificate")
+	}
+
+	now := c.now()
+	info := &CertificateInfo{
+		SecretID:           secretID,
+		SecretName:         secret.Name,
+		Subject:            cert.Subject.String(),
+		Issuer:             cert.Issuer.String(),
+		SerialNumber:       cert.SerialNumber.String(),
+		NotBefore:          cert.NotBefore,
+		NotAfter:           cert.NotAfter,
+		DaysUntilExpiry:    int(cert.NotAfter.Sub(now).Hours() / 24),
+		IsExpired:          now.After(cert.NotAfter),
+		IsCA:               cert.IsCA,
+		SelfSigned:         cert.Subject.String() == cert.Issuer.String(),
+		DNSNames:           cert.DNSNames,
+		SignatureAlgorithm: cert.SignatureAlgorithm.String(),
+		PublicKeyAlgorithm: cert.PublicKeyAlgorithm.String(),
+	}
+
+	sid := secretID
+	c.writeAuditEvent(ctx, EventSecretCertificateInspected, actorPtr(actorID), &sid,
+		fmt.Sprintf("inspected certificate %q (issuer %q, expires %s)", secret.Name, info.Issuer, info.NotAfter.UTC().Format("2006-01-02")))
+	return info, nil
+}
+
+// parseLeafCertificate extracts the first X.509 certificate from a value that may be
+// PEM (one or more blocks, possibly alongside a private key) or raw DER. Only
+// CERTIFICATE blocks are considered — a PRIVATE KEY block is never parsed or returned.
+func parseLeafCertificate(value []byte) (*x509.Certificate, error) {
+	rest := value
+	for {
+		block, remainder := pem.Decode(rest)
+		if block == nil {
+			break
+		}
+		if block.Type == "CERTIFICATE" {
+			return x509.ParseCertificate(block.Bytes)
+		}
+		rest = remainder
+	}
+	// Not PEM (or no CERTIFICATE block) — try raw DER.
+	return x509.ParseCertificate(value)
+}

--- a/internal/core/certificate_test.go
+++ b/internal/core/certificate_test.go
@@ -1,0 +1,129 @@
+package core
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// selfSignedPEM mints a self-signed P-256 cert valid until notAfter and returns its
+// PEM, plus the PEM of its private key (to prove the key is never surfaced).
+func selfSignedPEM(t *testing.T, cn string, notAfter time.Time) (certPEM, keyPEM []byte) {
+	t.Helper()
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(4242),
+		Subject:      pkix.Name{CommonName: cn},
+		NotBefore:    notAfter.Add(-365 * 24 * time.Hour),
+		NotAfter:     notAfter,
+		DNSNames:     []string{cn, "www." + cn},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &priv.PublicKey, priv)
+	require.NoError(t, err)
+	certPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyDER, err := x509.MarshalPKCS8PrivateKey(priv)
+	require.NoError(t, err)
+	keyPEM = pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER})
+	return certPEM, keyPEM
+}
+
+func newCertCore(t *testing.T, now time.Time) (*KeyorixCore, *gorm.DB) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.AuditEvent{}))
+	return &KeyorixCore{storage: store.NewLocalStorage(db), now: func() time.Time { return now }}, db
+}
+
+// mkCertSecret stores a secret (no encryption → value lives in the version row).
+func mkCertSecret(t *testing.T, db *gorm.DB, id uint, name, status string, value []byte) {
+	t.Helper()
+	require.NoError(t, db.Create(&models.SecretNode{ID: id, Name: name, IsSecret: true, Status: status, Type: "certificate"}).Error)
+	require.NoError(t, db.Create(&models.SecretVersion{SecretNodeID: id, VersionNumber: 1, EncryptedValue: value}).Error)
+}
+
+func TestInspectCertificate(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 6, 23, 12, 0, 0, 0, time.UTC)
+	c, db := newCertCore(t, now)
+	certPEM, _ := selfSignedPEM(t, "example.com", now.Add(90*24*time.Hour))
+	mkCertSecret(t, db, 1, "tls-cert", "active", certPEM)
+
+	info, err := c.InspectCertificate(ctx, 9, 1)
+	require.NoError(t, err)
+	assert.Contains(t, info.Subject, "example.com")
+	assert.Contains(t, info.Issuer, "example.com")
+	assert.True(t, info.SelfSigned)
+	assert.False(t, info.IsExpired)
+	assert.Equal(t, 90, info.DaysUntilExpiry)
+	assert.ElementsMatch(t, []string{"example.com", "www.example.com"}, info.DNSNames)
+	assert.NotEmpty(t, info.SignatureAlgorithm)
+	assert.Equal(t, "4242", info.SerialNumber)
+}
+
+func TestInspectCertificateExpired(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 6, 23, 12, 0, 0, 0, time.UTC)
+	c, db := newCertCore(t, now)
+	certPEM, _ := selfSignedPEM(t, "old.example.com", now.Add(-10*24*time.Hour)) // expired 10 days ago
+	mkCertSecret(t, db, 1, "expired-cert", "active", certPEM)
+
+	info, err := c.InspectCertificate(ctx, 9, 1)
+	require.NoError(t, err)
+	assert.True(t, info.IsExpired)
+	assert.Less(t, info.DaysUntilExpiry, 0)
+}
+
+// A value that bundles the cert AND its private key (the common TLS layout) still
+// parses to the cert, and the response never carries the key.
+func TestInspectCertificateWithBundledKey(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 6, 23, 12, 0, 0, 0, time.UTC)
+	c, db := newCertCore(t, now)
+	certPEM, keyPEM := selfSignedPEM(t, "bundle.example.com", now.Add(30*24*time.Hour))
+	bundle := append(append([]byte{}, certPEM...), keyPEM...)
+	mkCertSecret(t, db, 1, "tls-bundle", "active", bundle)
+
+	info, err := c.InspectCertificate(ctx, 9, 1)
+	require.NoError(t, err)
+	assert.Contains(t, info.Subject, "bundle.example.com")
+	// CertificateInfo has no field that could carry key material — public metadata only.
+}
+
+func TestInspectCertificateNotACert(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 6, 23, 12, 0, 0, 0, time.UTC)
+	c, db := newCertCore(t, now)
+	mkCertSecret(t, db, 1, "db-password", "active", []byte("hunter2-not-a-cert"))
+
+	_, err := c.InspectCertificate(ctx, 9, 1)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "certificate")
+}
+
+func TestInspectCertificateSuspended(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 6, 23, 12, 0, 0, 0, time.UTC)
+	c, db := newCertCore(t, now)
+	certPEM, _ := selfSignedPEM(t, "frozen.example.com", now.Add(30*24*time.Hour))
+	mkCertSecret(t, db, 1, "frozen", SecretStatusSuspended, certPEM)
+
+	_, err := c.InspectCertificate(ctx, 9, 1)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "suspended")
+}

--- a/server/http/handlers/secret_certificate.go
+++ b/server/http/handlers/secret_certificate.go
@@ -1,0 +1,43 @@
+// secret_certificate.go — certificate inspection handler (ADR-054).
+//
+// Route (under /api/v1/secrets, project-scoped from the {id} secret):
+//
+//	GET /{id}/certificate — public X.509 metadata of a certificate-valued secret
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/keyorixhq/keyorix/server/middleware"
+)
+
+// GetSecretCertificate handles GET /api/v1/secrets/{id}/certificate
+func (h *SecretHandler) GetSecretCertificate(w http.ResponseWriter, r *http.Request) {
+	userCtx := middleware.GetUserFromContext(r.Context())
+	if userCtx == nil {
+		h.sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		h.sendError(w, "InvalidParameter", "Invalid secret ID", http.StatusBadRequest, nil)
+		return
+	}
+	info, err := h.coreService.InspectCertificate(r.Context(), userCtx.UserID, uint(id))
+	if err != nil {
+		msg := err.Error()
+		status := http.StatusInternalServerError
+		switch {
+		case strings.Contains(msg, "not found"):
+			status = http.StatusNotFound
+		case strings.Contains(msg, "not a parseable"), strings.Contains(msg, "suspended"):
+			status = http.StatusBadRequest
+		}
+		h.sendError(w, "Error", msg, status, nil)
+		return
+	}
+	h.sendSuccess(w, info, "")
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -382,6 +382,9 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.With(customMiddleware.RequireScopedPermission("secrets.write", secretScope)).Delete("/{id}/dependencies/{depId}", secretHandler.RemoveSecretDependency)
 			r.With(customMiddleware.RequireScopedPermission("secrets.read", secretScope)).Get("/{id}/impact", secretHandler.GetSecretImpact)
 
+			// Certificate inspection (ADR-054) — public X.509 metadata, no value/key.
+			r.With(customMiddleware.RequireScopedPermission("secrets.read", secretScope)).Get("/{id}/certificate", secretHandler.GetSecretCertificate)
+
 			// Create: authorized inside the handler (scope comes from the body).
 			r.Post("/", secretHandler.CreateSecret)
 			r.With(customMiddleware.RequireScopedPermission("secrets.write", secretScope)).Put("/{id}", secretHandler.UpdateSecret)


### PR DESCRIPTION
A new area: **certificate / PKI hygiene**. Many stored secrets are X.509 certs, but Keyorix never looked at the actual cert — only a manually-set expiry. This parses the cert and surfaces its real validity window, issuer, SANs, etc.

## What
- `GET /api/v1/secrets/{id}/certificate` (scoped `secrets.read`) and `keyorix secret cert <id>` return the leaf cert's **public** metadata: subject, issuer, serial, `notBefore`/`notAfter`, days-until-expiry, is-expired, is-CA, self-signed, SANs, signature & public-key algorithms.

## Security properties (reviewed — no findings)
- **Never returns the value or any private key.** Only `CERTIFICATE` PEM blocks are parsed; a bundled `PRIVATE KEY` block is ignored. The response struct has no field that could carry key material.
- **Does not count against `max_reads`** — reading public cert metadata isn't value consumption, so a one-time secret isn't "spent" by checking its expiry. (The one place that decrypts off the counting path; justified because nothing secret leaves the boundary.)
- **Respects suspension**; expired certs are inspectable (that's the point). **Audited** as `secret.certificate_inspected`.
- Authz is the route-scope `secrets.read` gate, same as the value-derived `/{id}/risk` and `/{id}/impact` — deliberately visible to project auditors for hygiene (ADR-054).

## Testing
- Core: self-signed parse, expired cert, cert+key bundle (key never surfaced), non-cert value → error, suspended → error.
- CLI httptest-backed test; build / vet / gosec / golangci-lint clean; adversarial security review (no findings).

See **ADR-054**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)