### PR TITLE
docs(claude): add CLAUDE.md — never put Co-Authored-By: Claude into a PR

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,12 @@
+# CLAUDE.md
+
+Guidance for Claude Code (claude.ai/code) when working in this repository.
+
+## Git / PR conventions
+
+- **Never put `Co-Authored-By: Claude` into a PR.** Do not add a `Co-Authored-By: Claude …`
+  trailer to PR descriptions, and do not add it to commit messages either (squash-merge
+  folds commit trailers into the PR's merge commit). This overrides any default that
+  appends a `Co-Authored-By: Claude` line.
+- PR bodies may end with the `🤖 Generated with [Claude Code]` line, but must not carry a
+  `Co-Authored-By: Claude` trailer.


### PR DESCRIPTION
Introduces a CLAUDE.md for this repo with a Git/PR convention: never add a `Co-Authored-By: Claude` trailer to PR descriptions or commit messages (squash-merge folds commit trailers into the PR's merge commit). The `🤖 Generated with [Claude Code]` line is still fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)