### PR TITLE
feat(secrets): certificate-expiry monitoring (ADR-055)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to Keyorix are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## Unreleased
+
+### Added
+- **Certificate-expiry monitoring** — an opt-in background scan (`certificate_expiry`)
+  that parses certificate-typed secrets and notifies project admins of certificates
+  **expired or expiring** within the lead window, using the certificate's *real*
+  `notAfter` (ADR-054 parser) rather than the manual `expiration` field. Prevents the
+  classic silent cert lapse / outage. One de-duplicated standing reminder per project,
+  single-replica-gated. The scan reads cert values to extract only the expiry — never
+  the value or private key, skips suspended secrets, doesn't count against `max_reads`.
+  Default off. (ADR-055) ([#419])
+
+[#419]: https://github.com/keyorixhq/keyorix/pull/419
+
 ## v0.75.0 — 2026-06-23
 
 A large security release: anomaly-detection ML, ENS compliance mapping, the full

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -618,6 +618,23 @@ rotation_reminders:
   schedule: "24h"         # Go duration between reminder runs (default 24h)
 ```
 
+## certificate_expiry
+
+An opt-in background scan (ADR-055) that parses **certificate-typed** secrets and
+notifies project admins (in-app) of certificates that are **expired or expiring**
+within `lead_days`, using the certificate's *real* `notAfter` (not the manually-set
+`expiration` field, which cert secrets usually leave unset). One standing reminder per
+project per admin, de-duplicated like the rotation reminder; single-replica-gated
+(ADR-039). The scan reads certificate values to extract the expiry only — it never
+exposes the value or any private key, and skips suspended secrets. Opt-in (default off).
+
+```yaml
+certificate_expiry:
+  enabled: true
+  schedule: "24h"         # Go duration between scans (default 24h)
+  lead_days: 30           # warn this many days before notAfter (default 30)
+```
+
 ## audit_checkpoints
 
 An opt-in background scheduler that signs the audit hash-chain head (ADR-029) so

--- a/docs/adr-055-certificate-expiry-monitoring.md
+++ b/docs/adr-055-certificate-expiry-monitoring.md
@@ -1,0 +1,58 @@
+# ADR-055: Certificate-expiry monitoring
+
+## Status
+
+Accepted.
+
+## Context
+
+Certificate inspection (ADR-054) lets an operator *ask* for a certificate's real
+`notAfter`, but answering "which of my certificates are about to expire?" still required
+checking each one by hand. An expired TLS certificate that nobody noticed is a classic
+cause of production outages, and certificate hygiene is an availability/continuity
+control under NIS2 and ENS. Keyorix already has a secret-expiry reminder scheduler, but
+it keys off the manually-set `Expiration` field — which certificate secrets usually
+leave unset, relying on the cert's own validity window. So certs fell through the gap.
+
+## Decision
+
+Add an opt-in **certificate-expiry scan** that proactively notifies project admins of
+certificates that are expired or expiring within a lead window, using the certificate's
+*real* `notAfter`.
+
+- **Scan.** `ScanCertificateExpiry(leadDays)` lists certificate-typed secrets, parses
+  each leaf certificate (reusing the ADR-054 parser), and for those whose `notAfter` is
+  before `now + leadDays` tallies expired vs. expiring-soon per project. It sends ONE
+  standing digest notification (`secret.certificate_expiry`) to each affected project's
+  approver-role members, de-duplicated against an existing unread reminder — exactly the
+  mechanism the secret-expiry reminder uses.
+- **Scheduler.** Opt-in `certificate_expiry` config block (`enabled`, `schedule`,
+  `lead_days`; default off, 24h interval, 30-day lead — wider than generic secrets since
+  certs take longer to re-issue). Runs in the single-replica-gated scheduler (ADR-039).
+- **Value handling.** The scan decrypts certificate-typed secret values to read
+  `notAfter`. It reads off the **non-`max_reads`-counting** path (a system scan is not a
+  user value read), respects suspension (a suspended secret is skipped), and never
+  returns or exposes the value or any private key — only the expiry time is used, and
+  only the per-project counts reach the notification. An unparseable value is skipped,
+  not an error.
+
+## Alternatives considered
+
+- **Extend the existing secret-expiry reminder to be cert-aware.** Cleaner (no new
+  scheduler) but changes the behaviour of an already-shipped opt-in feature and couples
+  cert decryption into it. A separate, independently opt-in scan keeps the concern
+  isolated and the change additive.
+- **Cache the parsed `notAfter` at write/inspect time and scan the cache (no repeated
+  decrypt).** Architecturally tidy and avoids decrypting on every tick, but only covers
+  certs created/rotated/inspected after the change (a backfill gap) and adds persisted
+  state. Deferred — the scan-and-parse approach works for every certificate immediately;
+  caching is a reasonable later optimisation if scan cost becomes a concern at scale.
+- **On-demand fleet report instead of a scheduler.** Useful, but it still requires an
+  operator to look; proactive notification is the point (prevent the silent lapse).
+
+## Deferred follow-ups
+
+- Cache `notAfter` (and issuer) on the secret to avoid per-scan decryption at scale, and
+  surface it in the expiry/rotation posture and dashboards.
+- Full-chain expiry (intermediates), and per-environment / deployment-wide scopes.
+- External delivery (email/webhook) of the digest via the existing notifications fan-out.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,6 +28,10 @@ type Config struct {
 	// ExpiryReminders configures the opt-in background scheduler that notifies project
 	// admins of secrets that have expired or are approaching their expiration.
 	ExpiryReminders ExpiryRemindersConfig `yaml:"expiry_reminders"`
+	// CertificateExpiry configures the opt-in background scan (ADR-055) that parses
+	// certificate-typed secrets and notifies project admins of certificates expired or
+	// expiring within the lead window (using the real cert notAfter).
+	CertificateExpiry CertificateExpiryConfig `yaml:"certificate_expiry"`
 	// AutoRotation configures the opt-in background scheduler that actually rotates
 	// auto-rotate-enabled secrets overdue under a policy (ADR-046), regenerating their
 	// value. Distinct from rotation_reminders, which only notifies.
@@ -918,6 +922,26 @@ type ExpiryRemindersConfig struct {
 	Enabled  bool   `yaml:"enabled"`
 	Schedule string `yaml:"schedule"`
 	LeadDays int    `yaml:"lead_days"` // notify this many days before expiry (0 = default 14)
+}
+
+// CertificateExpiryConfig configures the opt-in certificate-expiry monitoring scan
+// (ADR-055). It parses certificate-typed secrets and notifies project admins of certs
+// expired or expiring within LeadDays (using the certificate's real notAfter).
+type CertificateExpiryConfig struct {
+	Enabled  bool   `yaml:"enabled"`
+	Schedule string `yaml:"schedule"`
+	LeadDays int    `yaml:"lead_days"` // notify this many days before notAfter (0 = default 30)
+}
+
+// GetInterval returns the certificate-expiry scan interval (Go duration, e.g. "24h");
+// defaults to 24h when unset or unparseable.
+func (c CertificateExpiryConfig) GetInterval() time.Duration {
+	if c.Schedule != "" {
+		if d, err := time.ParseDuration(c.Schedule); err == nil && d > 0 {
+			return d
+		}
+	}
+	return 24 * time.Hour
 }
 
 // GetInterval returns the expiry-reminder run interval (Go duration, e.g. "24h");

--- a/internal/core/certificate_expiry.go
+++ b/internal/core/certificate_expiry.go
@@ -1,0 +1,164 @@
+// certificate_expiry.go — proactive certificate-expiry monitoring (ADR-055). An
+// opt-in background scan (see main.go) parses certificate-typed secrets, reads each
+// certificate's real notAfter, and notifies project admins of certs that are expired
+// or expiring within the lead window — so a certificate never silently lapses and
+// takes down its consumers. Builds on the certificate parser (ADR-054); mirrors the
+// secret-expiry reminder scheduler (notify project approvers once, de-duplicated).
+//
+// The scan decrypts certificate-typed secret values to read notAfter; it never
+// returns or exposes the value or any private key, and it is opt-in/off by default.
+package core
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// NotificationCertificateExpiry marks an in-app certificate-expiry reminder.
+const NotificationCertificateExpiry = "secret.certificate_expiry"
+
+const (
+	// defaultCertExpiryLeadDays — certificates usually need more lead time to
+	// re-issue than a generic secret, so the default window is wider.
+	defaultCertExpiryLeadDays = 30
+	certExpiryPageSize        = 500
+)
+
+// ScanCertificateExpiry finds certificate-typed secrets whose certificate is expired
+// or expires within leadDays, and sends ONE standing digest notification to each
+// affected project's approvers (de-duplicated, like the secret-expiry reminder).
+// leadDays <= 0 falls back to the default. Returns the number of notifications created.
+func (c *KeyorixCore) ScanCertificateExpiry(ctx context.Context, leadDays int) (int, error) {
+	if leadDays <= 0 {
+		leadDays = defaultCertExpiryLeadDays
+	}
+	now := c.now()
+	cutoff := now.Add(time.Duration(leadDays) * 24 * time.Hour)
+
+	certs, err := c.listCertificateSecrets(ctx)
+	if err != nil {
+		return 0, err
+	}
+
+	type counts struct{ expired, soon int }
+	byProject := map[uint]*counts{}
+	for _, s := range certs {
+		notAfter, ok := c.certNotAfter(ctx, s)
+		if !ok || notAfter.After(cutoff) {
+			continue // not a parseable cert, or not expiring within the window
+		}
+		ct := byProject[s.ProjectID]
+		if ct == nil {
+			ct = &counts{}
+			byProject[s.ProjectID] = ct
+		}
+		if notAfter.Before(now) {
+			ct.expired++
+		} else {
+			ct.soon++
+		}
+	}
+
+	sent := 0
+	for projectID, ct := range byProject {
+		if projectID == 0 || (ct.expired == 0 && ct.soon == 0) {
+			continue
+		}
+		members, err := c.storage.ListProjectMembers(ctx, projectID)
+		if err != nil {
+			continue
+		}
+		pid := projectID
+		msg := certificateExpiryMessage(c.projectLabel(ctx, projectID), ct.expired, ct.soon)
+		for _, mbr := range members {
+			if !isApproverRole(mbr.RoleName) {
+				continue
+			}
+			if c.hasUnreadCertificateExpiry(ctx, mbr.UserID, projectID) {
+				continue // a standing reminder already exists — don't pile up
+			}
+			c.notify(ctx, mbr.UserID, NotificationCertificateExpiry,
+				"Certificates expiring", msg, &pid, "/secrets")
+			sent++
+		}
+	}
+	return sent, nil
+}
+
+// certNotAfter decrypts a certificate-typed secret's current value and returns the
+// leaf certificate's notAfter. ok is false when the secret is suspended, has no
+// version, or its value is not a parseable certificate. Reads the value off the
+// max-reads-counting path (this is a system scan, not a user value read) and never
+// surfaces the value or key — only the expiry time.
+func (c *KeyorixCore) certNotAfter(ctx context.Context, secret *models.SecretNode) (time.Time, bool) {
+	if secret.Status == SecretStatusSuspended {
+		return time.Time{}, false
+	}
+	version, err := c.storage.GetLatestSecretVersion(ctx, secret.ID)
+	if err != nil {
+		return time.Time{}, false
+	}
+	value := version.EncryptedValue
+	if c.encryption != nil {
+		value, err = c.encryption.RetrieveSecret(version.ID)
+		if err != nil {
+			return time.Time{}, false
+		}
+	}
+	cert, err := parseLeafCertificate(value)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return cert.NotAfter, true
+}
+
+// listCertificateSecrets returns every certificate-typed secret across all projects,
+// paging through all of them (expiry evaluation must not silently cap).
+func (c *KeyorixCore) listCertificateSecrets(ctx context.Context) ([]*models.SecretNode, error) {
+	certType := "certificate"
+	var all []*models.SecretNode
+	for page := 1; ; page++ {
+		secrets, total, err := c.storage.ListSecrets(ctx, &storage.SecretFilter{
+			Page: page, PageSize: certExpiryPageSize, Type: &certType,
+		})
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, secrets...)
+		if len(secrets) < certExpiryPageSize || int64(len(all)) >= total {
+			break
+		}
+	}
+	return all, nil
+}
+
+// certificateExpiryMessage renders the per-project digest.
+func certificateExpiryMessage(project string, expired, soon int) string {
+	switch {
+	case expired > 0 && soon > 0:
+		return fmt.Sprintf("%s: %d certificate(s) expired and %d expiring soon — review and re-issue.", project, expired, soon)
+	case expired > 0:
+		return fmt.Sprintf("%s: %d certificate(s) have expired — re-issue them.", project, expired)
+	default:
+		return fmt.Sprintf("%s: %d certificate(s) expiring soon — plan re-issuance.", project, soon)
+	}
+}
+
+// hasUnreadCertificateExpiry reports whether the user already has an unread
+// certificate-expiry reminder for the project (de-duplication).
+func (c *KeyorixCore) hasUnreadCertificateExpiry(ctx context.Context, userID, projectID uint) bool {
+	notes, err := c.storage.ListNotifications(ctx, userID, true, 100)
+	if err != nil {
+		return false // on a read error, prefer notifying over silently skipping
+	}
+	for _, n := range notes {
+		if n.Type == NotificationCertificateExpiry && n.ProjectID != nil && *n.ProjectID == projectID {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/core/certificate_expiry_test.go
+++ b/internal/core/certificate_expiry_test.go
@@ -1,0 +1,119 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// newCertExpiryCore sets up a real-SQLite core with one project, a project_admin
+// (user 5) and a viewer (user 6), and certificate-typed secrets in various expiry
+// states (each backed by a real self-signed cert in its version row).
+func newCertExpiryCore(t *testing.T) (*KeyorixCore, *gorm.DB, time.Time) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.User{}, &models.Role{}, &models.UserRole{}, &models.Project{},
+		&models.Environment{}, &models.SecretNode{}, &models.SecretVersion{}, &models.Notification{},
+	))
+
+	now := time.Date(2026, 6, 23, 10, 0, 0, 0, time.UTC)
+	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "payments"}).Error)
+	require.NoError(t, db.Create(&models.Environment{ID: 2, Name: "production", ProjectID: 1}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 5, Username: "ada", Email: "ada@x.io", IsActive: true}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 6, Username: "viewer", Email: "v@x.io", IsActive: true}).Error)
+	require.NoError(t, db.Create(&models.Role{ID: 1, Name: "project_admin"}).Error)
+	require.NoError(t, db.Create(&models.Role{ID: 2, Name: "project_viewer"}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 5, RoleID: 1, ProjectID: 1}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 6, RoleID: 2, ProjectID: 1}).Error)
+
+	mkCert := func(id uint, name string, notAfter time.Time) {
+		pem, _ := selfSignedPEM(t, name+".example.com", notAfter)
+		require.NoError(t, db.Create(&models.SecretNode{
+			ID: id, Name: name, ProjectID: 1, EnvironmentID: 2, Type: "certificate", IsSecret: true, Status: "active", CreatedAt: now,
+		}).Error)
+		require.NoError(t, db.Create(&models.SecretVersion{SecretNodeID: id, VersionNumber: 1, EncryptedValue: pem}).Error)
+	}
+	mkCert(10, "expired", now.AddDate(0, 0, -5)) // expired 5 days ago
+	mkCert(11, "soon", now.AddDate(0, 0, 10))    // within the 30-day lead window
+	mkCert(12, "far", now.AddDate(0, 0, 200))    // outside the lead window
+	// A certificate-typed secret whose value isn't a cert — must be skipped, not error.
+	require.NoError(t, db.Create(&models.SecretNode{ID: 13, Name: "broken", ProjectID: 1, EnvironmentID: 2, Type: "certificate", IsSecret: true, Status: "active"}).Error)
+	require.NoError(t, db.Create(&models.SecretVersion{SecretNodeID: 13, VersionNumber: 1, EncryptedValue: []byte("not a cert")}).Error)
+
+	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: func() time.Time { return now }}
+	return c, db, now
+}
+
+func TestScanCertificateExpiry(t *testing.T) {
+	ctx := context.Background()
+	c, db, _ := newCertExpiryCore(t)
+
+	// First run: the project_admin (user 5) is notified for the expired + soon certs;
+	// the viewer (6) is not; far-future and unparseable certs don't count.
+	sent, err := c.ScanCertificateExpiry(ctx, 30)
+	require.NoError(t, err)
+	assert.Equal(t, 1, sent, "only the project admin is notified")
+
+	var notes []models.Notification
+	require.NoError(t, db.Where("type = ?", NotificationCertificateExpiry).Find(&notes).Error)
+	require.Len(t, notes, 1)
+	assert.Equal(t, uint(5), notes[0].UserID)
+	require.NotNil(t, notes[0].ProjectID)
+	assert.Equal(t, uint(1), *notes[0].ProjectID)
+	assert.Contains(t, notes[0].Message, "expired")
+	assert.Contains(t, notes[0].Message, "expiring soon")
+	assert.Contains(t, notes[0].Message, "payments")
+
+	// Second run while unread: deduped.
+	sent, err = c.ScanCertificateExpiry(ctx, 30)
+	require.NoError(t, err)
+	assert.Equal(t, 0, sent, "a standing unread reminder is not duplicated")
+
+	// After reading, still-expiring certs nudge again.
+	require.NoError(t, db.Model(&models.Notification{}).Where("id = ?", notes[0].ID).Update("is_read", true).Error)
+	sent, err = c.ScanCertificateExpiry(ctx, 30)
+	require.NoError(t, err)
+	assert.Equal(t, 1, sent)
+}
+
+func TestScanCertificateExpiry_NothingDue(t *testing.T) {
+	ctx := context.Background()
+	c, db, _ := newCertExpiryCore(t)
+	// Remove the expired + soon certs; only the far-future and broken ones remain.
+	require.NoError(t, db.Where("id IN ?", []uint{10, 11}).Delete(&models.SecretNode{}).Error)
+
+	sent, err := c.ScanCertificateExpiry(ctx, 30)
+	require.NoError(t, err)
+	assert.Equal(t, 0, sent)
+}
+
+func TestScanCertificateExpiry_SuspendedSkipped(t *testing.T) {
+	ctx := context.Background()
+	c, db, _ := newCertExpiryCore(t)
+	// Suspend the expired cert; only the "soon" cert should remain countable.
+	require.NoError(t, db.Model(&models.SecretNode{}).Where("id = ?", 10).Update("status", SecretStatusSuspended).Error)
+
+	sent, err := c.ScanCertificateExpiry(ctx, 30)
+	require.NoError(t, err)
+	assert.Equal(t, 1, sent)
+	var notes []models.Notification
+	require.NoError(t, db.Where("type = ?", NotificationCertificateExpiry).Find(&notes).Error)
+	require.Len(t, notes, 1)
+	assert.Contains(t, notes[0].Message, "expiring soon")
+	assert.NotContains(t, notes[0].Message, "expired") // the only expired cert was suspended
+}
+
+func TestCertificateExpiryMessage(t *testing.T) {
+	assert.Contains(t, certificateExpiryMessage("p", 2, 3), "2 certificate(s) expired and 3 expiring soon")
+	assert.Contains(t, certificateExpiryMessage("p", 2, 0), "2 certificate(s) have expired")
+	assert.Contains(t, certificateExpiryMessage("p", 0, 4), "4 certificate(s) expiring soon")
+}

--- a/server/main.go
+++ b/server/main.go
@@ -149,6 +149,7 @@ const (
 	schedLockLoginPrune   int64 = 0x4B455953_4C474E50 // "KEYSLGNP"
 	schedLockRotationRmdr int64 = 0x4B455953_524F5452 // "KEYSROTR"
 	schedLockExpiryRmdr   int64 = 0x4B455953_45585052 // "KEYSEXPR"
+	schedLockCertExpiry   int64 = 0x4B455953_43455254 // "KEYSCERT"
 	schedLockAutoRotate   int64 = 0x4B455953_4155544F // "KEYSAUTO"
 	schedLockAuditCkpt    int64 = 0x4B455953_41434B50 // "KEYSACKP"
 	schedLockJITExpiry    int64 = 0x4B455953_4A495445 // "KEYSJITE"
@@ -911,6 +912,43 @@ func startHTTPServer(ctx context.Context, cfg *config.Config) error {
 				select {
 				case <-ticker.C:
 					runExpiry()
+				case <-ctx.Done():
+					return
+				}
+			}
+		}()
+	}
+
+	// Start the certificate-expiry scan — opt-in (ADR-055). Parses certificate-typed
+	// secrets and notifies project admins of certs expired/expiring within the window.
+	// Single-replica-gated (ADR-039).
+	if cfg.CertificateExpiry.Enabled {
+		interval := cfg.CertificateExpiry.GetInterval()
+		leadDays := cfg.CertificateExpiry.LeadDays
+		log.Printf("Certificate-expiry scan enabled: every %s (lead %dd)", interval, leadDays)
+		go func() {
+			ticker := time.NewTicker(interval)
+			defer ticker.Stop()
+			runCertScan := func() {
+				if _, err := coreService.Storage().WithSchedulerLock(ctx, schedLockCertExpiry, func() error {
+					n, rerr := coreService.ScanCertificateExpiry(ctx, leadDays)
+					if rerr != nil {
+						log.Printf("Certificate-expiry scan error: %v", rerr)
+						return rerr
+					}
+					if n > 0 {
+						log.Printf("Certificate-expiry scan: sent %d notification(s)", n)
+					}
+					return nil
+				}); err != nil {
+					log.Printf("Certificate-expiry scheduler error: %v", err)
+				}
+			}
+			runCertScan() // run once on startup
+			for {
+				select {
+				case <-ticker.C:
+					runCertScan()
 				case <-ctx.Done():
 					return
 				}


### PR DESCRIPTION
Turns the passive certificate inspection (#416 / ADR-054) into **proactive alerting** — preventing the classic "expired cert took down prod because nobody checked".

## What
An opt-in background scan (`certificate_expiry`) that parses **certificate-typed** secrets and notifies project admins (in-app) of certificates **expired or expiring** within `lead_days`, using the certificate's *real* `notAfter` — not the manually-set `expiration` field, which cert secrets usually leave unset.

- One de-duplicated standing reminder per project to its approver-role members (mirrors the secret-expiry reminder), single-replica-gated (ADR-039).
- Config `certificate_expiry: { enabled, schedule (24h), lead_days (30) }`, default off.

## Security
The scan decrypts certificate-typed secret values to read `notAfter` only — it **never** returns or exposes the value or any private key (only per-project counts reach the notification), reads off the **non-`max_reads`-counting** path (a system scan isn't a user value read), skips **suspended** secrets, and skips unparseable values rather than erroring.

## Testing
Real-store tests: expired/soon/far + unparseable + suspended; notification targeting (admin yes, viewer no), message content, **dedup**, re-notify after read. gofmt / build / vet / gosec / golangci-lint clean.

See **ADR-055**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)