### PR TITLE
feat(cli): keyorix rotation plan — print a project's rotation plan (ADR-053)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,14 @@ All notable changes to Keyorix are documented here. This project follows
   single-replica-gated. The scan reads cert values to extract only the expiry — never
   the value or private key, skips suspended secrets, doesn't count against `max_reads`.
   Default off. (ADR-055) ([#419])
+- **CLI for the rotation plan** — `keyorix rotation plan <project-id>` prints a
+  project's automated rotation plan (ADR-053) in the terminal: overdue/due-soon secrets
+  batched into dependency-safe waves, most urgent first, each annotated with why it's
+  due and what it must rotate after. Thin REST client over the existing endpoint.
+  ([#420])
 
 [#419]: https://github.com/keyorixhq/keyorix/pull/419
+[#420]: https://github.com/keyorixhq/keyorix/pull/420
 
 ## v0.75.0 — 2026-06-23
 

--- a/internal/cli/rotation/plan.go
+++ b/internal/cli/rotation/plan.go
@@ -1,0 +1,113 @@
+// plan.go — the `keyorix rotation plan` CLI (ADR-053): print a project's automated
+// rotation plan — its overdue/due-soon secrets batched into dependency-safe waves and
+// prioritised by urgency, each annotated with why. Talks to
+// GET /api/v1/projects/{id}/rotation-plan (scoped by the caller's secrets.read
+// permission server-side).
+package rotation
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/spf13/cobra"
+)
+
+type plannedRotation struct {
+	SecretID    uint     `json:"secret_id"`
+	SecretName  string   `json:"secret_name"`
+	Status      string   `json:"status"`
+	DaysOverdue int      `json:"days_overdue"`
+	RiskBand    string   `json:"risk_band"`
+	AutoRotate  bool     `json:"auto_rotate"`
+	Reasons     []string `json:"reasons"`
+}
+
+type rotationWave struct {
+	Index   int               `json:"index"`
+	Secrets []plannedRotation `json:"secrets"`
+}
+
+type rotationPlanView struct {
+	ProjectID    uint           `json:"project_id"`
+	TotalSecrets int            `json:"total_secrets"`
+	OverdueCount int            `json:"overdue_count"`
+	DueSoonCount int            `json:"due_soon_count"`
+	Waves        []rotationWave `json:"waves"`
+}
+
+var planCmd = &cobra.Command{
+	Use:   "plan <project-id>",
+	Short: "Print a project's automated rotation plan (dependency-safe waves, by urgency)",
+	Long: `Print the rotation plan for a project: its overdue and due-soon secrets, batched
+into dependency-safe waves (rotate a wave at a time, top to bottom; within a wave the
+most urgent first) and annotated with why each is due and what it must follow (ADR-053).`,
+	Args:         cobra.ExactArgs(1),
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, args []string) error {
+		projectID, err := strconv.ParseUint(strings.TrimSpace(args[0]), 10, 32)
+		if err != nil || projectID == 0 {
+			return fmt.Errorf("invalid project id %q", args[0])
+		}
+		c, ok := common.NewRemoteClient()
+		if !ok {
+			return fmt.Errorf("not connected to a server — run: keyorix connect <server>")
+		}
+		plan, err := fetchRotationPlan(context.Background(), c, uint(projectID))
+		if err != nil {
+			return err
+		}
+		if len(plan.Waves) == 0 {
+			fmt.Println("Nothing to rotate — no policy-covered secret in this project is overdue or due soon.")
+			return nil
+		}
+		fmt.Printf("Rotation plan for project %d — %d to rotate (%d overdue, %d due soon), %d wave(s):\n",
+			plan.ProjectID, plan.TotalSecrets, plan.OverdueCount, plan.DueSoonCount, len(plan.Waves))
+		for _, w := range plan.Waves {
+			fmt.Printf("\nWave %d  (safe to rotate together):\n", w.Index+1)
+			for _, s := range w.Secrets {
+				fmt.Printf("  %-26s %-9s %s%s\n", s.SecretName, statusLabel(s), riskLabel(s.RiskBand), autoRotateLabel(s.AutoRotate))
+				if len(s.Reasons) > 0 {
+					fmt.Printf("      ↳ %s\n", strings.Join(s.Reasons, " · "))
+				}
+			}
+		}
+		return nil
+	},
+}
+
+func statusLabel(s plannedRotation) string {
+	if s.Status == "overdue" {
+		return fmt.Sprintf("%dd over", s.DaysOverdue)
+	}
+	return fmt.Sprintf("%dd left", -s.DaysOverdue)
+}
+
+func riskLabel(band string) string {
+	if band == "" {
+		return ""
+	}
+	return band + " risk"
+}
+
+func autoRotateLabel(auto bool) string {
+	if auto {
+		return "  (self-rotating)"
+	}
+	return ""
+}
+
+// fetchRotationPlan is split out for httptest-backed tests.
+func fetchRotationPlan(ctx context.Context, c *common.RemoteClient, projectID uint) (*rotationPlanView, error) {
+	var v rotationPlanView
+	if err := c.Get(ctx, fmt.Sprintf("/api/v1/projects/%d/rotation-plan", projectID), &v); err != nil {
+		return nil, err
+	}
+	return &v, nil
+}
+
+func init() {
+	RotationCmd.AddCommand(planCmd)
+}

--- a/internal/cli/rotation/plan_remote_test.go
+++ b/internal/cli/rotation/plan_remote_test.go
@@ -1,0 +1,49 @@
+package rotation
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFetchRotationPlan(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/projects/1/rotation-plan" {
+			_, _ = w.Write([]byte(`{"data":{"project_id":1,"total_secrets":2,"overdue_count":1,"due_soon_count":1,"waves":[
+				{"index":0,"secrets":[{"secret_id":12,"secret_name":"root-ca","status":"overdue","days_overdue":110,"risk_band":"high","auto_rotate":false,"reasons":["110 days overdue","high risk (score 78)"]}]},
+				{"index":1,"secrets":[{"secret_id":11,"secret_name":"app-token","status":"due_soon","days_overdue":-10,"risk_band":"low","auto_rotate":true,"reasons":["due in 10 days","rotate after root-ca"]}]}
+			]}}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	rc, ok := common.NewRemoteClient()
+	require.True(t, ok)
+
+	plan, err := fetchRotationPlan(context.Background(), rc, 1)
+	require.NoError(t, err)
+	assert.Equal(t, 2, plan.TotalSecrets)
+	assert.Equal(t, 1, plan.OverdueCount)
+	require.Len(t, plan.Waves, 2)
+	assert.Equal(t, "root-ca", plan.Waves[0].Secrets[0].SecretName)
+	assert.Equal(t, "overdue", plan.Waves[0].Secrets[0].Status)
+	assert.Equal(t, 110, plan.Waves[0].Secrets[0].DaysOverdue)
+	assert.True(t, plan.Waves[1].Secrets[0].AutoRotate)
+	assert.Contains(t, plan.Waves[1].Secrets[0].Reasons, "rotate after root-ca")
+}
+
+func TestStatusAndRiskLabels(t *testing.T) {
+	assert.Equal(t, "30d over", statusLabel(plannedRotation{Status: "overdue", DaysOverdue: 30}))
+	assert.Equal(t, "10d left", statusLabel(plannedRotation{Status: "due_soon", DaysOverdue: -10}))
+	assert.Equal(t, "high risk", riskLabel("high"))
+	assert.Equal(t, "", riskLabel(""))
+	assert.Equal(t, "  (self-rotating)", autoRotateLabel(true))
+}


### PR DESCRIPTION
The automated rotation plan (ADR-053) has an HTTP endpoint and a web tab, but no CLI. For a CLI-first product, this adds `keyorix rotation plan <project-id>` so operators can run (and script) the plan in the terminal.

## What
Prints the project's overdue/due-soon secrets batched into **dependency-safe waves** (rotate a wave at a time, top to bottom; most urgent first within a wave), each annotated with the plan's reasons (`110 days overdue`, `high risk`, `rotate after root-ca`) and a self-rotating marker. Clean "nothing to rotate" state when there's nothing due.

## How
Thin REST client over `GET /api/v1/projects/{id}/rotation-plan` via the standard `common.RemoteClient` (server-side scoped `secrets.read`), with the fetch factored out for testing. Mirrors `keyorix rotation order` / the deps CLI. No server changes.

## Testing
httptest-backed test for `fetchRotationPlan` (waves, status, reasons, auto-rotate) + label helpers; build / vet / gosec / golangci-lint clean; command registration smoke-checked via `--help`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)