### PR TITLE
feat(compliance): certificate hygiene in the compliance posture (ADR-056)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,16 @@ All notable changes to Keyorix are documented here. This project follows
   single-replica-gated. The scan reads cert values to extract only the expiry — never
   the value or private key, skips suspended secrets, doesn't count against `max_reads`.
   Default off. (ADR-055) ([#419])
+- **Certificate hygiene in the compliance posture** — the control matrix gains a
+  **Certificate expiry hygiene** control (a gap when any certificate is expired; mapped
+  to ISO 27001 / SOC 2 / NIS2 / ENS `op.exp.11`) plus a `certificates` posture figure
+  (expired / expiring-soon / total / not-yet-evaluated). Fed by a cached cert `notAfter`
+  (`SecretNode.cert_not_after`) populated as a side-effect of certificate inspection and
+  the expiry scan — so the posture reports hygiene without decrypting on the dashboard
+  path and without touching the create/rotate path. (ADR-056) ([#421])
 
 [#419]: https://github.com/keyorixhq/keyorix/pull/419
+[#421]: https://github.com/keyorixhq/keyorix/pull/421
 
 ## v0.75.0 — 2026-06-23
 

--- a/docs/adr-056-certificate-hygiene-posture.md
+++ b/docs/adr-056-certificate-hygiene-posture.md
@@ -1,0 +1,56 @@
+# ADR-056: Certificate hygiene in the compliance posture
+
+## Status
+
+Accepted.
+
+## Context
+
+Certificate inspection (ADR-054) and the expiry scan (ADR-055) read a certificate's
+real `notAfter`, but the **compliance posture / control matrix** — the auditor-facing
+view (ISO 27001 / SOC 2 / NIS2 / DORA / ENS) — had no signal for certificate hygiene.
+An expired TLS certificate is both an availability incident and a control gap (ENS
+`op.exp.11`, NIS2 Art.21). The obstacle: the posture is computed on a hot, frequently
+polled path (the compliance dashboard), so it must not decrypt every certificate on
+each view; and threading certificate parsing into the create/rotate write path would be
+a sensitive change with a backfill gap.
+
+## Decision
+
+Add a **Certificate expiry hygiene** control and a `CertificatePosture` figure, fed by a
+**cached** certificate expiry maintained off the read path.
+
+- **Cache.** `SecretNode.CertNotAfter` (additive, nullable column) caches the parsed
+  leaf-certificate `notAfter`. It is populated **as a side-effect** of the two paths
+  that already decrypt and parse a certificate — `InspectCertificate` (ADR-054) and the
+  certificate-expiry scan (ADR-055) — via a targeted single-column update. Nothing else
+  writes it; the create/rotate path is untouched.
+- **Posture.** `certificatePosture` counts certificate-typed secrets by their *cached*
+  `CertNotAfter` (expired / expiring-soon / total / **not-yet-evaluated**) — a plain
+  column read, no decryption. It is wired into `GetCompliancePosture`.
+- **Control.** A `certificate-hygiene` control in the matrix: a **gap** when any
+  certificate is expired, with a detail line that also surfaces expiring-soon and
+  not-yet-evaluated counts. Mapped to ISO 27001 A.5.15/A.8.24, SOC 2 CC6.1, NIS2
+  Art.21(2)(h), ENS `op.exp.11`.
+- **Coverage.** A certificate that has never been inspected or scanned has a nil cache
+  and is reported as **not yet evaluated** (honestly, not silently "healthy"). Full
+  coverage comes from enabling the ADR-055 certificate-expiry scan, which refreshes the
+  cache for every certificate on each run — so a rotated certificate's cache self-heals
+  on the next scan without any write-path coupling.
+
+## Alternatives considered
+
+- **Parse at create/rotate and store the expiry there.** Avoids relying on the scan for
+  coverage, but touches the sensitive write path and still needs a backfill for existing
+  certs. The scan-maintained cache keeps the write path untouched and backfills every
+  certificate on its first run.
+- **Decrypt-and-count on the posture path.** Simple, but decrypting every certificate on
+  each dashboard poll is exactly what the cache avoids.
+- **A separate certificate report instead of a posture control.** The control matrix is
+  where auditors look; a first-class control is higher leverage than a side report.
+
+## Deferred follow-ups
+
+- Invalidate/refresh the cache on rotation immediately (rather than on the next scan).
+- Surface the not-yet-evaluated count in the dashboard with a prompt to enable the scan.
+- Per-environment certificate posture; full-chain (intermediate) expiry.

--- a/internal/core/certificate.go
+++ b/internal/core/certificate.go
@@ -92,6 +92,11 @@ func (c *KeyorixCore) InspectCertificate(ctx context.Context, actorID, secretID 
 		PublicKeyAlgorithm: cert.PublicKeyAlgorithm.String(),
 	}
 
+	// Cache the parsed expiry so the compliance posture can report certificate hygiene
+	// without decrypting on the read path (ADR-056). Best-effort — a cache failure must
+	// not fail the inspection.
+	_ = c.storage.SetSecretCertNotAfter(ctx, secretID, &cert.NotAfter)
+
 	sid := secretID
 	c.writeAuditEvent(ctx, EventSecretCertificateInspected, actorPtr(actorID), &sid,
 		fmt.Sprintf("inspected certificate %q (issuer %q, expires %s)", secret.Name, info.Issuer, info.NotAfter.UTC().Format("2006-01-02")))

--- a/internal/core/certificate_expiry.go
+++ b/internal/core/certificate_expiry.go
@@ -113,6 +113,8 @@ func (c *KeyorixCore) certNotAfter(ctx context.Context, secret *models.SecretNod
 	if err != nil {
 		return time.Time{}, false
 	}
+	// Cache the expiry for the compliance posture (ADR-056); best-effort.
+	_ = c.storage.SetSecretCertNotAfter(ctx, secret.ID, &cert.NotAfter)
 	return cert.NotAfter, true
 }
 
@@ -134,6 +136,30 @@ func (c *KeyorixCore) listCertificateSecrets(ctx context.Context) ([]*models.Sec
 		}
 	}
 	return all, nil
+}
+
+// certificatePosture reports certificate hygiene for the compliance posture (ADR-056)
+// from the cached cert expiry — no decryption on this path. Certificates not yet
+// evaluated (cache nil) are counted separately so the gap is visible.
+func (c *KeyorixCore) certificatePosture(ctx context.Context) CertificatePosture {
+	certs, err := c.listCertificateSecrets(ctx)
+	if err != nil {
+		return CertificatePosture{}
+	}
+	now := c.now()
+	soonCutoff := now.Add(defaultCertExpiryLeadDays * 24 * time.Hour)
+	p := CertificatePosture{TotalCertificates: len(certs)}
+	for _, s := range certs {
+		switch {
+		case s.CertNotAfter == nil:
+			p.NotEvaluated++
+		case s.CertNotAfter.Before(now):
+			p.Expired++
+		case s.CertNotAfter.Before(soonCutoff):
+			p.ExpiringSoon++
+		}
+	}
+	return p
 }
 
 // certificateExpiryMessage renders the per-project digest.

--- a/internal/core/certificate_expiry_test.go
+++ b/internal/core/certificate_expiry_test.go
@@ -112,6 +112,43 @@ func TestScanCertificateExpiry_SuspendedSkipped(t *testing.T) {
 	assert.NotContains(t, notes[0].Message, "expired") // the only expired cert was suspended
 }
 
+func TestCertificatePosture(t *testing.T) {
+	ctx := context.Background()
+	c, db, _ := newCertExpiryCore(t)
+
+	// Before any scan/inspection, no cert has a cached expiry → all "not evaluated".
+	pre := c.certificatePosture(ctx)
+	assert.Equal(t, 4, pre.TotalCertificates)
+	assert.Equal(t, 4, pre.NotEvaluated)
+	assert.Equal(t, 0, pre.Expired)
+
+	// The scan caches notAfter as a side-effect; the posture then reports hygiene with
+	// no decryption. expired(10)+soon(11)+far(12) parse; broken(13) stays unevaluated.
+	_, err := c.ScanCertificateExpiry(ctx, 30)
+	require.NoError(t, err)
+
+	post := c.certificatePosture(ctx)
+	assert.Equal(t, 4, post.TotalCertificates)
+	assert.Equal(t, 1, post.Expired)
+	assert.Equal(t, 1, post.ExpiringSoon)
+	assert.Equal(t, 1, post.NotEvaluated) // only the unparseable "broken" cert
+
+	// The cache was actually written for a parseable cert.
+	var s models.SecretNode
+	require.NoError(t, db.First(&s, 10).Error)
+	require.NotNil(t, s.CertNotAfter)
+}
+
+func TestCertificateHygieneControl(t *testing.T) {
+	// An expired certificate flips the control to a gap; none → pass.
+	gap := findControl(t, EvaluateControls(&CompliancePosture{Certificates: CertificatePosture{TotalCertificates: 2, Expired: 1}}), "certificate-hygiene")
+	assert.Equal(t, ControlStatusGap, gap.Status)
+	assert.NotEmpty(t, gap.Frameworks.ENS)
+
+	ok := findControl(t, EvaluateControls(&CompliancePosture{Certificates: CertificatePosture{TotalCertificates: 2, ExpiringSoon: 1}}), "certificate-hygiene")
+	assert.Equal(t, ControlStatusPass, ok.Status, "expiring-soon is a warning in the detail, not a hard gap")
+}
+
 func TestCertificateExpiryMessage(t *testing.T) {
 	assert.Contains(t, certificateExpiryMessage("p", 2, 3), "2 certificate(s) expired and 3 expiring soon")
 	assert.Contains(t, certificateExpiryMessage("p", 2, 0), "2 certificate(s) have expired")

--- a/internal/core/compliance_posture.go
+++ b/internal/core/compliance_posture.go
@@ -138,6 +138,16 @@ type RiskPosture struct {
 	ExpiringSoon     int `json:"expiring_soon"` // active exceptions expiring within the soon window
 }
 
+// CertificatePosture reports certificate hygiene from the cached cert expiry (ADR-056).
+// NotEvaluated counts certificate-typed secrets whose certificate hasn't been parsed
+// yet (no inspection/scan) — full coverage needs the certificate-expiry scan enabled.
+type CertificatePosture struct {
+	TotalCertificates int `json:"total_certificates"`
+	Expired           int `json:"expired"`
+	ExpiringSoon      int `json:"expiring_soon"` // within the 30-day window
+	NotEvaluated      int `json:"not_evaluated"`
+}
+
 // CompliancePosture is the deployment's control posture at a point in time.
 type CompliancePosture struct {
 	GeneratedAt      time.Time               `json:"generated_at"`
@@ -151,6 +161,7 @@ type CompliancePosture struct {
 	LegalHold        LegalHoldPosture        `json:"legal_hold"`
 	Retention        RetentionPosture        `json:"retention"`
 	Risk             RiskPosture             `json:"risk"`
+	Certificates     CertificatePosture      `json:"certificates"`
 }
 
 // riskExpiringSoonWindow is how far ahead an active exception counts as "expiring
@@ -231,6 +242,9 @@ func (c *KeyorixCore) GetCompliancePosture(ctx context.Context) (*CompliancePost
 	if active, soon, err := c.CountActiveRiskExceptions(ctx, riskExpiringSoonWindow); err == nil {
 		p.Risk = RiskPosture{ActiveExceptions: active, ExpiringSoon: soon}
 	}
+
+	// Certificate hygiene from the cached cert expiry (ADR-056).
+	p.Certificates = c.certificatePosture(ctx)
 
 	// Data-retention windows (A.5.33).
 	rp := c.retentionPolicy

--- a/internal/core/control_framework.go
+++ b/internal/core/control_framework.go
@@ -131,6 +131,12 @@ func EvaluateControls(p *CompliancePosture) []ControlState {
 			Frameworks: FrameworkRefs{ISO27001: []string{"A.5.15", "A.8.24"}, SOC2: []string{"CC6.1"}, NIS2: []string{"Art.21(2)(h)"}, ENS: []string{"op.exp.11"}},
 		},
 		{
+			ID: "certificate-hygiene", Name: "Certificate expiry hygiene", Area: "Cryptography",
+			Status:     gapIf(p.Certificates.Expired > 0),
+			Detail:     fmt.Sprintf("%d expired, %d expiring soon of %d certificate(s) (%d not yet evaluated)", p.Certificates.Expired, p.Certificates.ExpiringSoon, p.Certificates.TotalCertificates, p.Certificates.NotEvaluated),
+			Frameworks: FrameworkRefs{ISO27001: []string{"A.5.15", "A.8.24"}, SOC2: []string{"CC6.1"}, NIS2: []string{"Art.21(2)(h)"}, ENS: []string{"op.exp.11"}},
+		},
+		{
 			ID: "data-classification", Name: "Secret data classification", Area: "Asset management",
 			Status:     gapIf(p.Classification.Unclassified > 0),
 			Detail:     fmt.Sprintf("%d of %d secrets unclassified", p.Classification.Unclassified, p.Classification.TotalSecrets),

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -542,6 +542,10 @@ func (m *MockStorage) GetLatestSecretVersion(ctx context.Context, secretID uint)
 	return args.Get(0).(*models.SecretVersion), args.Error(1)
 }
 
+func (m *MockStorage) SetSecretCertNotAfter(ctx context.Context, secretID uint, notAfter *time.Time) error {
+	return m.Called(ctx, secretID, notAfter).Error(0)
+}
+
 func (m *MockStorage) IncrementSecretReadCount(ctx context.Context, versionID uint) error {
 	args := m.Called(ctx, versionID)
 	return args.Error(0)

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -213,6 +213,9 @@ type Storage interface {
 	GetSecretVersions(ctx context.Context, secretID uint) ([]*models.SecretVersion, error)
 	CreateSecretVersion(ctx context.Context, version *models.SecretVersion) (*models.SecretVersion, error)
 	GetLatestSecretVersion(ctx context.Context, secretID uint) (*models.SecretVersion, error)
+	// SetSecretCertNotAfter caches a certificate-typed secret's parsed leaf expiry
+	// (ADR-056), a targeted column update with no other side effects.
+	SetSecretCertNotAfter(ctx context.Context, secretID uint, notAfter *time.Time) error
 	IncrementSecretReadCount(ctx context.Context, versionID uint) error
 	// TryIncrementSecretReadCount atomically increments a version's read count only
 	// while it is still below maxReads, in a single conditional UPDATE. Returns true

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -170,6 +170,10 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 		if !columnExists(db, "secret_nodes", "rotation_ref") {
 			db.Exec("ALTER TABLE secret_nodes ADD COLUMN rotation_ref TEXT NOT NULL DEFAULT ''")
 		}
+		// ADR-056: cached certificate expiry. Additive (nil = not yet evaluated).
+		if !columnExists(db, "secret_nodes", "cert_not_after") {
+			db.Exec("ALTER TABLE secret_nodes ADD COLUMN cert_not_after TIMESTAMP WITH TIME ZONE")
+		}
 	}
 	// Anomaly alerting: additive `alerted` flag (false = not yet pushed out).
 	if tableExists(db, "anomaly_alerts") && !columnExists(db, "anomaly_alerts", "alerted") {

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -466,6 +466,12 @@ type SecretNode struct {
 	// DB role) before storing it. Empty RotationBackend = regenerate in Keyorix only.
 	RotationBackend string `gorm:"not null;default:''"`
 	RotationRef     string `gorm:"not null;default:''"`
+	// CertNotAfter caches the parsed leaf-certificate expiry for certificate-typed
+	// secrets (ADR-056). Populated as a side-effect of certificate inspection /
+	// expiry scans (which already decrypt + parse the value), so the compliance
+	// posture can report certificate hygiene without decrypting on the read path.
+	// Nil = not yet evaluated (or not a certificate). Metadata only — never the value.
+	CertNotAfter *time.Time `gorm:"index"`
 	// DeletedAt enables soft delete (ADR-033). DELETE stamps it; restore clears
 	// it; the purge scheduler hard-deletes rows past the retention window. GORM
 	// auto-scopes `deleted_at IS NULL` on model-based queries — raw/Table/Joins

--- a/internal/storage/store/local_secrets.go
+++ b/internal/storage/store/local_secrets.go
@@ -13,6 +13,7 @@ package store
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/i18n"
@@ -273,6 +274,16 @@ func (ls *LocalStorage) UpdateSecret(ctx context.Context, secret *models.SecretN
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}
 	return secret, nil
+}
+
+// SetSecretCertNotAfter caches a certificate-typed secret's parsed leaf expiry — a
+// targeted single-column update that touches nothing else (ADR-056).
+func (ls *LocalStorage) SetSecretCertNotAfter(ctx context.Context, secretID uint, notAfter *time.Time) error {
+	if err := ls.db.WithContext(ctx).Model(&models.SecretNode{}).
+		Where("id = ?", secretID).Update("cert_not_after", notAfter).Error; err != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	return nil
 }
 
 // DeleteSecret deletes a secret by ID.

--- a/internal/storage/store/remote_secrets.go
+++ b/internal/storage/store/remote_secrets.go
@@ -257,6 +257,12 @@ func (rs *RemoteStorage) GetSecretVersions(ctx context.Context, secretID uint) (
 }
 
 // GetLatestSecretVersion retrieves the most recent version of a secret via remote API.
+// SetSecretCertNotAfter is a server-side concern (the certificate scan runs on the
+// server); the remote client never invokes it.
+func (rs *RemoteStorage) SetSecretCertNotAfter(_ context.Context, _ uint, _ *time.Time) error {
+	return remoteUnsupported("SetSecretCertNotAfter")
+}
+
 func (rs *RemoteStorage) GetLatestSecretVersion(ctx context.Context, secretID uint) (*models.SecretVersion, error) {
 	path := fmt.Sprintf("/api/v1/secrets/%d/versions/latest", secretID)
 	resp, err := rs.client.Get(ctx, path)


### PR DESCRIPTION
Ties the certificate work (#416 inspection, #419 expiry monitoring) into Keyorix's strongest theme — the auditor-facing compliance control matrix (ISO 27001 / SOC 2 / NIS2 / DORA / ENS).

## What
- A **Certificate expiry hygiene** control in the matrix — a **gap** when any certificate is expired (detail also surfaces expiring-soon and not-yet-evaluated counts). Mapped to ISO A.5.15/A.8.24, SOC 2 CC6.1, NIS2 Art.21(2)(h), ENS `op.exp.11`.
- A `certificates` posture figure: expired / expiring-soon / total / not-yet-evaluated.

## How (the clean part)
The posture must not decrypt every cert on each dashboard poll, and I didn't want to touch the sensitive create/rotate path. So:
- `SecretNode.cert_not_after` (additive, nullable) **caches** the parsed leaf `notAfter`.
- It's populated **as a side-effect** of the two paths that already decrypt + parse a cert — `InspectCertificate` and the expiry scan — via a targeted single-column update.
- The posture reads the cached column (no decryption). A never-evaluated cert is honestly reported as **not yet evaluated**, not silently healthy; enabling the expiry scan (#419) backfills + refreshes all of them (so a rotated cert self-heals on the next scan — no write-path coupling).

## Testing
Real-store tests: posture counts before/after a scan (cache populated), the cache is actually written, and the control flips to a gap on an expired cert / passes otherwise. Migration is additive. build / vet / gosec / golangci-lint clean; full suite green (modulo the known local-only mutating-route test).

See **ADR-056**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)