### PR TITLE
release: v0.76.0 (CHANGELOG + Helm charts 0.76.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,11 @@
 All notable changes to Keyorix are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
-## Unreleased
+## v0.76.0 — 2026-06-23
+
+Certificate lifecycle hardening — expiry monitoring and a hygiene control in the
+compliance posture — rotation-plan parity across CLI and gRPC, and per-scheduler
+health metrics for the background jobs.
 
 ### Added
 - **Certificate-expiry monitoring** — an opt-in background scan (`certificate_expiry`)
@@ -29,11 +33,20 @@ All notable changes to Keyorix are documented here. This project follows
 - **gRPC for the rotation plan** — `ProjectService.GetProjectRotationPlan` exposes the
   automated rotation plan (ADR-053) over gRPC (read-only, scoped `secrets.read`),
   completing its surface parity with HTTP / CLI / web. ([#422])
+- **Per-scheduler health metrics** — the ~14 background schedulers (anomaly detection,
+  retention purge, auto-rotation, certificate-expiry scan, audit checkpoints, …) each
+  export their outcome to Prometheus: `keyorix_scheduler_runs_total{scheduler,outcome}`
+  (success / failure / **skipped**), a run-duration histogram, and last-run /
+  last-success timestamp gauges, on the same `/metrics` endpoint. `skipped` (an HA
+  follower not holding the single-writer lock, or a legal-hold stand-down) is tracked
+  distinctly from `failure` so a follower replica never reads as broken — alert on
+  `time() - keyorix_scheduler_last_success_timestamp_seconds{...}`. ([#423])
 
 [#419]: https://github.com/keyorixhq/keyorix/pull/419
 [#420]: https://github.com/keyorixhq/keyorix/pull/420
 [#421]: https://github.com/keyorixhq/keyorix/pull/421
 [#422]: https://github.com/keyorixhq/keyorix/pull/422
+[#423]: https://github.com/keyorixhq/keyorix/pull/423
 
 ## v0.75.0 — 2026-06-23
 

--- a/deploy/helm/keyorix-k8s-sync/Chart.yaml
+++ b/deploy/helm/keyorix-k8s-sync/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix-k8s-sync
 description: Keyorix Kubernetes sync agent — materialises Keyorix secrets into native Kubernetes Secrets
 type: application
 # Chart version — tracks the Keyorix release version (published in lockstep).
-version: 0.75.0
+version: 0.76.0
 # The keyorix-k8s-sync image tag this chart deploys by default.
-appVersion: "0.75.0"
+appVersion: "0.76.0"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix

--- a/deploy/helm/keyorix/Chart.yaml
+++ b/deploy/helm/keyorix/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix
 description: Self-hosted Keyorix secrets manager (API server + web UI + PostgreSQL)
 type: application
 # Chart version — bump on chart changes.
-version: 0.75.0
+version: 0.76.0
 # The Keyorix app version this chart deploys by default (the image tag).
-appVersion: "0.75.0"
+appVersion: "0.76.0"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix


### PR DESCRIPTION
Cuts **v0.76.0**, folding the five feature PRs merged since v0.75.0:

- Certificate-expiry monitoring (#419, ADR-055)
- CLI for the rotation plan (#420, ADR-053)
- Certificate hygiene in the compliance posture (#421, ADR-056)
- gRPC for the rotation plan (#422, ADR-053)
- Per-scheduler health metrics (#423)

## Changes
- `CHANGELOG.md` — Unreleased → `## v0.76.0 — 2026-06-23` with summary, plus the #423 entry.
- `deploy/helm/keyorix/Chart.yaml` + `deploy/helm/keyorix-k8s-sync/Chart.yaml` — `version`/`appVersion` 0.75.0 → 0.76.0.

## After merge
Tag `v0.76.0` on the merge commit and push it. That triggers:
- `docker-publish.yml` — server + web images tagged `v0.76.0`
- `release.yml` — cross-compiled binaries + GitHub Release, and `helm push` of both charts to `oci://ghcr.io/keyorixhq/charts`

Charts lint clean locally (`helm lint`, 0 failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)