### PR TITLE
fix(build): build the ./server package, not ./server/main.go

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ build-cli:
 	go build $(LDFLAGS) -o $(BUILD_DIR)/$(BINARY_CLI) .
 
 build-server:
-	go build $(LDFLAGS) -o $(BUILD_DIR)/$(BINARY_SERVER) ./server/main.go
+	go build $(LDFLAGS) -o $(BUILD_DIR)/$(BINARY_SERVER) ./server
 
 # Path to the keyorix-web checkout (override: make build-ui KEYORIX_WEB_DIR=/path).
 KEYORIX_WEB_DIR ?= ../keyorix-web
@@ -51,7 +51,7 @@ build-ui:
 	rm -rf server/webui/dist
 	mkdir -p server/webui/dist
 	cp -R "$(KEYORIX_WEB_DIR)"/dist/. server/webui/dist/
-	go build $(LDFLAGS) -o $(BUILD_DIR)/$(BINARY_SERVER) ./server/main.go
+	go build $(LDFLAGS) -o $(BUILD_DIR)/$(BINARY_SERVER) ./server
 	@git checkout -- server/webui/dist/index.html 2>/dev/null || true
 	@echo "Built $(BUILD_DIR)/$(BINARY_SERVER) with the web UI embedded."
 
@@ -66,7 +66,7 @@ install: install-cli install-server
 # Run the server locally against the docker-compose Postgres, using the
 # committed dev config. `db-up` ensures Postgres is running first.
 run: db-up
-	KEYORIX_CONFIG_PATH=configs/dev.yaml KEYORIX_DB_PASSWORD=keyorix123 KEYORIX_MASTER_PASSWORD=keyorix123 go run server/main.go
+	KEYORIX_CONFIG_PATH=configs/dev.yaml KEYORIX_DB_PASSWORD=keyorix123 KEYORIX_MASTER_PASSWORD=keyorix123 go run ./server
 
 # Start only the Postgres service (not the full stack — `make run` runs the
 # server on :8080 itself, so we don't want the compose server container too).
@@ -88,10 +88,10 @@ release:
 	GOOS=linux  GOARCH=arm64  CGO_ENABLED=0 go build $(LDFLAGS) -trimpath -o dist/$(BINARY_CLI)_linux_arm64    .
 	GOOS=darwin GOARCH=amd64  CGO_ENABLED=0 go build $(LDFLAGS) -trimpath -o dist/$(BINARY_CLI)_darwin_amd64   .
 	GOOS=darwin GOARCH=arm64  CGO_ENABLED=0 go build $(LDFLAGS) -trimpath -o dist/$(BINARY_CLI)_darwin_arm64   .
-	GOOS=linux  GOARCH=amd64  CGO_ENABLED=0 go build $(LDFLAGS) -trimpath -o dist/$(BINARY_SERVER)_linux_amd64  ./server/main.go
-	GOOS=linux  GOARCH=arm64  CGO_ENABLED=0 go build $(LDFLAGS) -trimpath -o dist/$(BINARY_SERVER)_linux_arm64  ./server/main.go
-	GOOS=darwin GOARCH=amd64  CGO_ENABLED=0 go build $(LDFLAGS) -trimpath -o dist/$(BINARY_SERVER)_darwin_amd64 ./server/main.go
-	GOOS=darwin GOARCH=arm64  CGO_ENABLED=0 go build $(LDFLAGS) -trimpath -o dist/$(BINARY_SERVER)_darwin_arm64 ./server/main.go
+	GOOS=linux  GOARCH=amd64  CGO_ENABLED=0 go build $(LDFLAGS) -trimpath -o dist/$(BINARY_SERVER)_linux_amd64  ./server
+	GOOS=linux  GOARCH=arm64  CGO_ENABLED=0 go build $(LDFLAGS) -trimpath -o dist/$(BINARY_SERVER)_linux_arm64  ./server
+	GOOS=darwin GOARCH=amd64  CGO_ENABLED=0 go build $(LDFLAGS) -trimpath -o dist/$(BINARY_SERVER)_darwin_amd64 ./server
+	GOOS=darwin GOARCH=arm64  CGO_ENABLED=0 go build $(LDFLAGS) -trimpath -o dist/$(BINARY_SERVER)_darwin_arm64 ./server
 	@cd dist && (sha256sum * > checksums.txt 2>/dev/null || shasum -a 256 * > checksums.txt)
 	@echo "✅ Release binaries in dist/"
 

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -33,7 +33,7 @@ for platform in "${PLATFORMS[@]}"; do
     GOOS="$os" GOARCH="$arch" go build \
         -ldflags="${LDFLAGS}" \
         -o "${DIST_DIR}/keyorix-server_${os}_${arch}" \
-        ./server/main.go
+        ./server
 done
 
 # Checksums

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -6,7 +6,7 @@ COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
 RUN go build -ldflags "-X github.com/keyorixhq/keyorix/internal/cli.version=dev" \
-    -o bin/keyorix-server ./server/main.go
+    -o bin/keyorix-server ./server
 
 # Runtime stage
 FROM alpine:latest


### PR DESCRIPTION
## Problem

`server/main.go` is `package main` with sibling files (e.g. `server/scheduler_run.go`, added in #423). Building the **single file** `./server/main.go` only compiles that one file, so it can't see symbols defined in the package's other files. The moment `main.go` was split, the server image and release binaries broke:

```
server/main.go:707:11: undefined: lockedRun
server/main.go:746:3: undefined: runScheduler
```

CI's `build-and-test` uses package-aware `go build ./...`, so it stayed green — the breakage only surfaced in **`docker-publish`** and the **tag release builds** (`make release`), which run on `main`/tags rather than PRs. This is why the v0.76.0 `docker-publish` and `release` runs failed.

## Fix

Build the package path `./server` everywhere instead of the single file:
- `server/Dockerfile`
- `Makefile` — `build-server`, `install-server`, `run`, `release`
- `scripts/build-release.sh`

Building a package compiles all its `.go` files, so future additions to `package main` won't reintroduce this.

## Verified
- `make build-server` ✅
- `docker build -f server/Dockerfile .` ✅ (the exact build that failed in CI)

After merge I'll re-point the `v0.76.0` tag here — it published nothing usable (failed image, no binaries, no GitHub Release), so it's a clean re-tag rather than a v0.76.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)