### PR TITLE
fix(build): inject the real version into container images

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -40,6 +40,9 @@ jobs:
           context: .
           file: server/Dockerfile
           push: true
+          build-args: |
+            VERSION=${{ github.ref_name }}
+            GIT_COMMIT=${{ github.sha }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
@@ -76,5 +79,8 @@ jobs:
           context: .
           file: cmd/keyorix-k8s-sync/Dockerfile
           push: true
+          build-args: |
+            VERSION=${{ github.ref_name }}
+            GIT_COMMIT=${{ github.sha }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/cmd/keyorix-k8s-sync/Dockerfile
+++ b/cmd/keyorix-k8s-sync/Dockerfile
@@ -5,8 +5,13 @@ WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
+# Injected at build time so the agent reports its real release version (mirrors the
+# Makefile LDFLAGS). Defaults keep ad-hoc `docker build` working; docker-publish
+# passes the git tag + sha.
+ARG VERSION=dev
+ARG GIT_COMMIT=none
 RUN CGO_ENABLED=0 go build \
-    -ldflags "-X github.com/keyorixhq/keyorix/internal/cli.version=dev" \
+    -ldflags "-X github.com/keyorixhq/keyorix/internal/cli.version=${VERSION} -X github.com/keyorixhq/keyorix/internal/version.Version=${VERSION} -X github.com/keyorixhq/keyorix/internal/version.Commit=${GIT_COMMIT}" \
     -trimpath -o /out/keyorix-k8s-sync ./cmd/keyorix-k8s-sync
 
 # Runtime stage — minimal, non-root. ca-certificates lets the agent reach the

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -5,7 +5,12 @@ WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
-RUN go build -ldflags "-X github.com/keyorixhq/keyorix/internal/cli.version=dev" \
+# Injected at build time so the image reports its real release version at runtime
+# (e.g. /health, /system/info). Defaults keep ad-hoc `docker build` working; the
+# docker-publish workflow passes the git tag + sha. Mirrors the Makefile LDFLAGS.
+ARG VERSION=dev
+ARG GIT_COMMIT=none
+RUN go build -ldflags "-X github.com/keyorixhq/keyorix/internal/cli.version=${VERSION} -X github.com/keyorixhq/keyorix/internal/version.Version=${VERSION} -X github.com/keyorixhq/keyorix/internal/version.Commit=${GIT_COMMIT}" \
     -o bin/keyorix-server ./server
 
 # Runtime stage


### PR DESCRIPTION
## Problem

Both `server/Dockerfile` and `cmd/keyorix-k8s-sync/Dockerfile` hardcoded `-X internal/cli.version=dev` and never set `internal/version.Version` — the variable the server's `/health` and `/system/info` read (`server/http/handlers/health.go:24`). So **every published image reports version `dev` at runtime**, regardless of the release tag, even though the GitHub Release *binaries* (built via the Makefile) carry the correct version.

Spotted while cutting v0.76.0 — those images report `dev`.

## Fix

Mirror the Makefile LDFLAGS in both Dockerfiles:
- Add `ARG VERSION=dev` / `ARG GIT_COMMIT=none` (defaults keep ad-hoc `docker build` working).
- Inject into `internal/cli.version`, `internal/version.Version`, **and** `internal/version.Commit`.
- `docker-publish.yml` passes `VERSION=${{ github.ref_name }}` (matching how `release.yml` drives `make release VERSION=${{ github.ref_name }}`) and `GIT_COMMIT=${{ github.sha }}` to both image builds.

## Verified
`docker build -f server/Dockerfile --build-arg VERSION=v9.9.9-test --build-arg GIT_COMMIT=abc1234` → the sentinel lands in `internal/version.Version` (the `/health` source), confirmed via `strings` on the built binary — not just `cli.version`.

Future releases (v0.77.0+) will report their real version; this doesn't retroactively fix the already-published v0.76.0 images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)