### PR TITLE
feat(cli): time-bound expiry for secret shares

### DIFF
--- a/internal/cli/share/create.go
+++ b/internal/cli/share/create.go
@@ -15,6 +15,8 @@ var (
 	createRecipientID uint
 	createIsGroup     bool
 	createPermission  string
+	createExpires     string
+	createTTL         string
 )
 
 var createCmd = &cobra.Command{
@@ -28,6 +30,8 @@ func init() {
 	createCmd.Flags().UintVar(&createRecipientID, "recipient-id", 0, "Recipient ID (required)")
 	createCmd.Flags().BoolVar(&createIsGroup, "is-group", false, "Whether the recipient is a group")
 	createCmd.Flags().StringVar(&createPermission, "permission", "read", "Permission level (read or write)")
+	createCmd.Flags().StringVar(&createExpires, "expires", "", "Make the share time-bound: absolute expiry (RFC3339, e.g. 2026-07-01T15:00:00Z)")
+	createCmd.Flags().StringVar(&createTTL, "ttl", "", "Make the share time-bound: lifetime from now (Go duration, e.g. 24h, 30m); mutually exclusive with --expires")
 
 	_ = createCmd.MarkFlagRequired("secret-id")    // #nosec G104
 	_ = createCmd.MarkFlagRequired("recipient-id") // #nosec G104
@@ -37,6 +41,12 @@ func runCreate(cmd *cobra.Command, args []string) error {
 	// Validate permission
 	if createPermission != "read" && createPermission != "write" {
 		return fmt.Errorf("invalid permission: %s (must be 'read' or 'write')", createPermission)
+	}
+
+	// Resolve the optional time-bound expiry (nil = permanent share).
+	expiresAt, err := resolveShareExpiry(createExpires, createTTL)
+	if err != nil {
+		return err
 	}
 
 	// Obtain storage via the factory so the backend honors cfg.Storage.Type (ADR-049).
@@ -59,6 +69,7 @@ func runCreate(cmd *cobra.Command, args []string) error {
 			GroupID:    createRecipientID,
 			Permission: createPermission,
 			SharedBy:   1, // CLI user ID
+			ExpiresAt:  expiresAt,
 		}
 
 		// Call service for group sharing
@@ -74,6 +85,7 @@ func runCreate(cmd *cobra.Command, args []string) error {
 			IsGroup:     false,
 			Permission:  createPermission,
 			SharedBy:    1, // CLI user ID
+			ExpiresAt:   expiresAt,
 		}
 
 		// Call service for user sharing
@@ -92,6 +104,7 @@ func runCreate(cmd *cobra.Command, args []string) error {
 	fmt.Printf("Is Group: %t\n", shareRecord.IsGroup)
 	fmt.Printf("Permission: %s\n", shareRecord.Permission)
 	fmt.Printf("Created At: %s\n", shareRecord.CreatedAt.Format("2006-01-02 15:04:05"))
+	fmt.Printf("Expires At: %s\n", formatShareExpiry(shareRecord.ExpiresAt))
 
 	return nil
 }

--- a/internal/cli/share/expiry.go
+++ b/internal/cli/share/expiry.go
@@ -1,0 +1,51 @@
+package share
+
+import (
+	"fmt"
+	"time"
+)
+
+// resolveShareExpiry turns the --expires (absolute RFC3339) and --ttl (relative Go
+// duration) flags into an absolute expiry instant for a share.
+//
+//   - The two flags are mutually exclusive.
+//   - Both empty → (nil, nil): a permanent share (or, on update, "leave expiry as-is").
+//   - --ttl is resolved against the current wall clock.
+//
+// A past expiry is left for the core layer to reject (it owns the authoritative
+// "must be in the future" check against its own clock); this helper only parses and
+// enforces that --ttl is positive, so the two flags can't silently disagree.
+func resolveShareExpiry(expires, ttl string) (*time.Time, error) {
+	if expires != "" && ttl != "" {
+		return nil, fmt.Errorf("use only one of --expires or --ttl")
+	}
+	switch {
+	case expires != "":
+		t, err := time.Parse(time.RFC3339, expires)
+		if err != nil {
+			return nil, fmt.Errorf("invalid --expires (want RFC3339, e.g. 2026-07-01T15:00:00Z): %w", err)
+		}
+		return &t, nil
+	case ttl != "":
+		d, err := time.ParseDuration(ttl)
+		if err != nil {
+			return nil, fmt.Errorf("invalid --ttl (want a Go duration, e.g. 24h, 30m): %w", err)
+		}
+		if d <= 0 {
+			return nil, fmt.Errorf("--ttl must be a positive duration")
+		}
+		t := time.Now().Add(d)
+		return &t, nil
+	default:
+		return nil, nil
+	}
+}
+
+// formatShareExpiry renders a share's expiry for CLI output: a local timestamp, or
+// "never" for a permanent share.
+func formatShareExpiry(expiresAt *time.Time) string {
+	if expiresAt == nil {
+		return "never"
+	}
+	return expiresAt.Format("2006-01-02 15:04:05")
+}

--- a/internal/cli/share/expiry_test.go
+++ b/internal/cli/share/expiry_test.go
@@ -1,0 +1,95 @@
+package share
+
+import (
+	"testing"
+	"time"
+)
+
+func TestResolveShareExpiry(t *testing.T) {
+	t.Run("both empty is a permanent share", func(t *testing.T) {
+		got, err := resolveShareExpiry("", "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != nil {
+			t.Errorf("got %v, want nil (permanent)", got)
+		}
+	})
+
+	t.Run("absolute RFC3339 expiry", func(t *testing.T) {
+		got, err := resolveShareExpiry("2026-07-01T15:00:00Z", "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := time.Date(2026, 7, 1, 15, 0, 0, 0, time.UTC)
+		if got == nil || !got.Equal(want) {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("relative ttl resolves from now", func(t *testing.T) {
+		before := time.Now()
+		got, err := resolveShareExpiry("", "2h")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got == nil {
+			t.Fatal("got nil, want a time ~2h out")
+		}
+		// Allow a wide window so the test never clock-bombs.
+		delta := got.Sub(before)
+		if delta < 119*time.Minute || delta > 121*time.Minute {
+			t.Errorf("ttl resolved to %v from now, want ~2h", delta)
+		}
+	})
+
+	t.Run("both set is rejected", func(t *testing.T) {
+		if _, err := resolveShareExpiry("2026-07-01T15:00:00Z", "2h"); err == nil {
+			t.Error("expected an error when both --expires and --ttl are set")
+		}
+	})
+
+	t.Run("malformed expires is rejected", func(t *testing.T) {
+		if _, err := resolveShareExpiry("not-a-timestamp", ""); err == nil {
+			t.Error("expected an error for a non-RFC3339 --expires")
+		}
+	})
+
+	t.Run("malformed ttl is rejected", func(t *testing.T) {
+		if _, err := resolveShareExpiry("", "soon"); err == nil {
+			t.Error("expected an error for a non-duration --ttl")
+		}
+	})
+
+	t.Run("non-positive ttl is rejected", func(t *testing.T) {
+		if _, err := resolveShareExpiry("", "0s"); err == nil {
+			t.Error("expected an error for a zero --ttl")
+		}
+		if _, err := resolveShareExpiry("", "-1h"); err == nil {
+			t.Error("expected an error for a negative --ttl")
+		}
+	})
+}
+
+func TestFormatShareExpiry(t *testing.T) {
+	if got := formatShareExpiry(nil); got != "never" {
+		t.Errorf("nil expiry = %q, want %q", got, "never")
+	}
+	at := time.Date(2026, 7, 1, 15, 4, 5, 0, time.UTC)
+	if got := formatShareExpiry(&at); got != "2026-07-01 15:04:05" {
+		t.Errorf("formatted expiry = %q, want %q", got, "2026-07-01 15:04:05")
+	}
+}
+
+func TestCreateAndUpdateExpiryFlagsExist(t *testing.T) {
+	for _, name := range []string{"expires", "ttl"} {
+		if createCmd.Flags().Lookup(name) == nil {
+			t.Errorf("create command missing --%s flag", name)
+		}
+	}
+	for _, name := range []string{"expires", "ttl", "clear-expiry"} {
+		if updateCmd.Flags().Lookup(name) == nil {
+			t.Errorf("update command missing --%s flag", name)
+		}
+	}
+}

--- a/internal/cli/share/list.go
+++ b/internal/cli/share/list.go
@@ -53,9 +53,9 @@ func runList(cmd *cobra.Command, args []string) error {
 
 	// Create a tabwriter for formatted output
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(w, "ID\tSECRET ID\tOWNER ID\tRECIPIENT ID\tIS GROUP\tPERMISSION\tCREATED AT") //nolint:errcheck
+	fmt.Fprintln(w, "ID\tSECRET ID\tOWNER ID\tRECIPIENT ID\tIS GROUP\tPERMISSION\tCREATED AT\tEXPIRES AT") //nolint:errcheck
 	for _, share := range shares {
-		fmt.Fprintf(w, "%d\t%d\t%d\t%d\t%t\t%s\t%s\n", //nolint:errcheck
+		fmt.Fprintf(w, "%d\t%d\t%d\t%d\t%t\t%s\t%s\t%s\n", //nolint:errcheck
 			share.ID,
 			share.SecretID,
 			share.OwnerID,
@@ -63,6 +63,7 @@ func runList(cmd *cobra.Command, args []string) error {
 			share.IsGroup,
 			share.Permission,
 			share.CreatedAt.Format("2006-01-02 15:04:05"),
+			formatShareExpiry(share.ExpiresAt),
 		)
 	}
 	_ = w.Flush() // #nosec G104

--- a/internal/cli/share/remote.go
+++ b/internal/cli/share/remote.go
@@ -31,11 +31,12 @@ func runListRemote(rc *common.RemoteClient, secretID uint) error {
 		return nil
 	}
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(w, "ID\tSECRET ID\tOWNER ID\tRECIPIENT ID\tIS GROUP\tPERMISSION\tCREATED AT") //nolint:errcheck
+	fmt.Fprintln(w, "ID\tSECRET ID\tOWNER ID\tRECIPIENT ID\tIS GROUP\tPERMISSION\tCREATED AT\tEXPIRES AT") //nolint:errcheck
 	for _, share := range resp.Shares {
-		fmt.Fprintf(w, "%d\t%d\t%d\t%d\t%t\t%s\t%s\n", //nolint:errcheck
+		fmt.Fprintf(w, "%d\t%d\t%d\t%d\t%t\t%s\t%s\t%s\n", //nolint:errcheck
 			share.ID, share.SecretID, share.OwnerID, share.RecipientID, share.IsGroup,
-			share.Permission, share.CreatedAt.Format("2006-01-02 15:04:05"))
+			share.Permission, share.CreatedAt.Format("2006-01-02 15:04:05"),
+			formatShareExpiry(share.ExpiresAt))
 	}
 	_ = w.Flush() // #nosec G104
 	return nil

--- a/internal/cli/share/update.go
+++ b/internal/cli/share/update.go
@@ -10,8 +10,11 @@ import (
 )
 
 var (
-	updateShareID    uint
-	updatePermission string
+	updateShareID     uint
+	updatePermission  string
+	updateExpires     string
+	updateTTL         string
+	updateClearExpiry bool
 )
 
 var updateCmd = &cobra.Command{
@@ -23,6 +26,9 @@ var updateCmd = &cobra.Command{
 func init() {
 	updateCmd.Flags().UintVar(&updateShareID, "share-id", 0, "Share ID (required)")
 	updateCmd.Flags().StringVar(&updatePermission, "permission", "", "Permission level (read or write) (required)")
+	updateCmd.Flags().StringVar(&updateExpires, "expires", "", "Set/extend the time-bound expiry: absolute (RFC3339)")
+	updateCmd.Flags().StringVar(&updateTTL, "ttl", "", "Set/extend the time-bound expiry: lifetime from now (Go duration, e.g. 24h); mutually exclusive with --expires")
+	updateCmd.Flags().BoolVar(&updateClearExpiry, "clear-expiry", false, "Make the share permanent (remove its expiry)")
 
 	_ = updateCmd.MarkFlagRequired("share-id")   // #nosec G104
 	_ = updateCmd.MarkFlagRequired("permission") // #nosec G104
@@ -34,6 +40,16 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("invalid permission: %s (must be 'read' or 'write')", updatePermission)
 	}
 
+	// Expiry intent: --clear-expiry (make permanent) is mutually exclusive with setting
+	// a new expiry; leaving all three unset preserves the share's current expiry.
+	if updateClearExpiry && (updateExpires != "" || updateTTL != "") {
+		return fmt.Errorf("--clear-expiry cannot be combined with --expires or --ttl")
+	}
+	expiresAt, err := resolveShareExpiry(updateExpires, updateTTL)
+	if err != nil {
+		return err
+	}
+
 	// Obtain storage via the factory so the backend honors cfg.Storage.Type (ADR-049).
 	st, err := common.InitializeStorage()
 	if err != nil {
@@ -43,9 +59,11 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 
 	// Create update request
 	req := &core.UpdateShareRequest{
-		ShareID:    updateShareID,
-		Permission: updatePermission,
-		UpdatedBy:  1, // CLI user ID
+		ShareID:     updateShareID,
+		Permission:  updatePermission,
+		UpdatedBy:   1, // CLI user ID
+		ExpiresAt:   expiresAt,
+		ClearExpiry: updateClearExpiry,
 	}
 
 	// Call service
@@ -64,6 +82,7 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 	fmt.Printf("Is Group: %t\n", shareRecord.IsGroup)
 	fmt.Printf("Permission: %s\n", shareRecord.Permission)
 	fmt.Printf("Updated At: %s\n", shareRecord.UpdatedAt.Format("2006-01-02 15:04:05"))
+	fmt.Printf("Expires At: %s\n", formatShareExpiry(shareRecord.ExpiresAt))
 
 	return nil
 }


### PR DESCRIPTION
## What

`keyorix share` can now create and manage **time-bound shares** — a share that stops authorizing the instant its expiry passes (and is later swept). This was already supported end-to-end by core + the HTTP API (`ShareSecretRequest.ExpiresAt`, `GroupShareSecretRequest.ExpiresAt`, `UpdateShareRequest.ExpiresAt`/`ClearExpiry`) but had **no CLI surface**, forcing operators to the raw HTTP API for a core JIT-access pattern (temporary onboarding, incident response).

## Changes

- **`share create`** — `--expires` (absolute RFC3339, matching `secret create --expires`) and `--ttl` (lifetime from now, a Go duration, matching `rbac assign-role --ttl`). Mutually exclusive; both optional → permanent. Wired into both the user and group share paths.
- **`share update`** — `--expires`/`--ttl` to set/extend, plus `--clear-expiry` to make a share permanent. `--clear-expiry` can't be combined with setting a new expiry.
- **`share list`** (local + remote) and the create/update output gain an **EXPIRES AT** column (`never` for permanent), so a time-bound share is observable after creation.

Parsing/validation lives in a small shared `resolveShareExpiry` helper; the authoritative "must be in the future" check stays in core (single clock — no duplicated time logic). **Max-reads was deliberately not added** — verified it's a secret-level field, not per-share.

## Tests / gate
- Unit tests: `resolveShareExpiry` (absolute / relative / empty / both-set conflict / malformed / non-positive ttl), `formatShareExpiry`, flag registration.
- `go build ./...` ✅ · `go vet` ✅ · `golangci-lint` 0 ✅ · `gosec` 0 ✅
- Smoke-tested the built CLI: mutual-exclusion, bad-`--expires`, `--clear-expiry`+`--ttl` conflict all error cleanly; `--help` shows the flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)