### PR TITLE
feat(cli): compliance & inventory CSV export

### DIFF
--- a/internal/cli/common/remote_client.go
+++ b/internal/cli/common/remote_client.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 
@@ -94,6 +95,33 @@ func (c *RemoteClient) Get(ctx context.Context, path string, out interface{}) er
 		return fmt.Errorf("server returned HTTP %d for %s", resp.StatusCode, path)
 	}
 	return decodeEnvelope(resp, out, path)
+}
+
+// GetRaw performs a GET and returns the raw, un-enveloped response body. Used for
+// endpoints that serve a non-JSON artifact directly (e.g. the text/csv compliance and
+// inventory exports), where the dashboard downloads the same bytes.
+func (c *RemoteClient) GetRaw(ctx context.Context, path string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.Endpoint+path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.Token)
+	req.Header.Set("Accept", "text/csv, */*")
+
+	resp, err := c.hc.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("server returned HTTP %d for %s", resp.StatusCode, path)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response from %s: %w", path, err)
+	}
+	return body, nil
 }
 
 // Post serialises body as JSON, POSTs to path, strips the envelope, and decodes into out.

--- a/internal/cli/common/remote_client_test.go
+++ b/internal/cli/common/remote_client_test.go
@@ -1,0 +1,41 @@
+package common
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestGetRaw(t *testing.T) {
+	const body = "name,project,type\napi-key,1,static\n"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer tok" {
+			t.Errorf("Authorization = %q, want %q", got, "Bearer tok")
+		}
+		if r.URL.Path == "/ok" {
+			w.Header().Set("Content-Type", "text/csv")
+			_, _ = w.Write([]byte(body))
+			return
+		}
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer srv.Close()
+	c := &RemoteClient{Endpoint: srv.URL, Token: "tok", hc: srv.Client()}
+
+	t.Run("returns the raw body verbatim", func(t *testing.T) {
+		got, err := c.GetRaw(context.Background(), "/ok")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if string(got) != body {
+			t.Errorf("body = %q, want %q", got, body)
+		}
+	})
+
+	t.Run("surfaces an HTTP error", func(t *testing.T) {
+		if _, err := c.GetRaw(context.Background(), "/denied"); err == nil {
+			t.Error("expected an error for a 403 response")
+		}
+	})
+}

--- a/internal/cli/compliance/compliance.go
+++ b/internal/cli/compliance/compliance.go
@@ -269,6 +269,11 @@ func joinRefs(refs ...[]string) string {
 	return out
 }
 
+var (
+	controlsCSV    bool
+	controlsOutput string
+)
+
 var controlsCmd = &cobra.Command{
 	Use:          "controls",
 	Short:        "Control matrix — controls mapped to ISO 27001 / SOC 2 / NIS2 / DORA with status",
@@ -277,6 +282,14 @@ var controlsCmd = &cobra.Command{
 		c, ok := common.NewRemoteClient()
 		if !ok {
 			return fmt.Errorf("not connected to a server — run: keyorix connect <server>")
+		}
+		// --csv downloads the server's canonical controls.csv (the same artifact the
+		// dashboard exports); the default prints the human-readable matrix.
+		if controlsCSV {
+			return emitCSV(c, "/api/v1/compliance/controls.csv", controlsOutput, "Control matrix CSV")
+		}
+		if controlsOutput != "" {
+			return fmt.Errorf("--output is only valid together with --csv")
 		}
 		var m controlMatrix
 		if err := c.Get(context.Background(), "/api/v1/compliance/controls", &m); err != nil {
@@ -352,6 +365,8 @@ not been modified. Requires server-side encryption (the signing key is DEK-deriv
 
 func init() {
 	exportCmd.Flags().StringVar(&exportOutput, "output", "", "Write the evidence pack to a file instead of stdout")
+	controlsCmd.Flags().BoolVar(&controlsCSV, "csv", false, "Download the control matrix as CSV instead of the text report")
+	controlsCmd.Flags().StringVar(&controlsOutput, "output", "", "With --csv, write to a file instead of stdout")
 	verifyCmd.Flags().StringVar(&verifyFile, "file", "", "Path to the evidence pack JSON to verify (required)")
 	verifyCmd.Flags().StringVar(&verifySig, "sig", "", "Path to the signature file (default <file>.sig)")
 	ComplianceCmd.AddCommand(reportCmd, controlsCmd, exportCmd, verifyCmd)

--- a/internal/cli/compliance/csv_export.go
+++ b/internal/cli/compliance/csv_export.go
@@ -1,0 +1,65 @@
+// csv_export.go — `keyorix compliance inventory` plus the emitCSV helper shared with
+// `compliance controls --csv`. These download the server's canonical CSV artifacts
+// (the same bytes the dashboard exports) for an auditor hand-off, rather than
+// re-deriving them client-side. Remote-only, like the rest of the compliance group.
+package compliance
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/spf13/cobra"
+)
+
+var (
+	inventoryProject uint
+	inventoryOutput  string
+)
+
+var inventoryCmd = &cobra.Command{
+	Use:   "inventory",
+	Short: "Export the secret asset inventory as CSV (deployment-wide, or one project)",
+	Long: `Download the secret asset-inventory as CSV for an auditor hand-off — secrets
+listed by name, project, environment, type, classification, owner, and lifecycle
+status, with no secret values. Deployment-wide by default (needs system.read);
+--project <id> scopes it to a single project (needs secrets.read on that project).
+Writes to stdout, or to --output FILE.`,
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		c, ok := common.NewRemoteClient()
+		if !ok {
+			return fmt.Errorf("not connected to a server — run: keyorix connect <server>")
+		}
+		path := "/api/v1/secrets/inventory.csv"
+		if inventoryProject != 0 {
+			path = fmt.Sprintf("/api/v1/projects/%d/secrets/inventory.csv", inventoryProject)
+		}
+		return emitCSV(c, path, inventoryOutput, "Secret inventory CSV")
+	},
+}
+
+// emitCSV downloads the CSV artifact at path and writes it to outputPath (0600) or, if
+// empty, to stdout. label names the artifact in the file-written confirmation line.
+func emitCSV(rc *common.RemoteClient, path, outputPath, label string) error {
+	data, err := rc.GetRaw(context.Background(), path)
+	if err != nil {
+		return err
+	}
+	if outputPath != "" {
+		if err := os.WriteFile(outputPath, data, 0o600); err != nil {
+			return fmt.Errorf("failed to write %s: %w", outputPath, err)
+		}
+		fmt.Printf("%s written to %s.\n", label, outputPath)
+		return nil
+	}
+	_, _ = os.Stdout.Write(data)
+	return nil
+}
+
+func init() {
+	inventoryCmd.Flags().UintVar(&inventoryProject, "project", 0, "Scope to one project by ID (default: deployment-wide)")
+	inventoryCmd.Flags().StringVar(&inventoryOutput, "output", "", "Write the CSV to a file instead of stdout")
+	ComplianceCmd.AddCommand(inventoryCmd)
+}

--- a/internal/cli/compliance/csv_export_test.go
+++ b/internal/cli/compliance/csv_export_test.go
@@ -1,0 +1,25 @@
+package compliance
+
+import "testing"
+
+func TestComplianceCSVCommandsRegistered(t *testing.T) {
+	inv, _, err := ComplianceCmd.Find([]string{"inventory"})
+	if err != nil || inv.Name() != "inventory" {
+		t.Fatalf("inventory command not registered: %v", err)
+	}
+	for _, f := range []string{"project", "output"} {
+		if inv.Flags().Lookup(f) == nil {
+			t.Errorf("inventory missing --%s flag", f)
+		}
+	}
+
+	ctrls, _, err := ComplianceCmd.Find([]string{"controls"})
+	if err != nil {
+		t.Fatalf("controls command missing: %v", err)
+	}
+	for _, f := range []string{"csv", "output"} {
+		if ctrls.Flags().Lookup(f) == nil {
+			t.Errorf("controls missing --%s flag", f)
+		}
+	}
+}


### PR DESCRIPTION
## What

Auditors had to fall back to the raw HTTP API to pull the CSV manifests the dashboard serves — there was no CLI parity for an air-gapped hand-off. This adds CSV download to the auditor-facing `keyorix compliance` group:

- **`compliance controls --csv [--output FILE]`** — the control matrix as CSV (the default still prints the human-readable matrix; `--output` requires `--csv`).
- **`compliance inventory [--project <id>] [--output FILE]`** — the secret asset inventory as CSV, deployment-wide (`system.read`) or scoped to one project (`secrets.read`). No secret values.

## How

Both **download the server's canonical CSV** (the exact bytes the dashboard exports: `/api/v1/compliance/controls.csv`, `/api/v1/secrets/inventory.csv`, `/api/v1/projects/{id}/secrets/inventory.csv`) rather than re-deriving it client-side — so the CLI artifact is byte-identical to the UI one. New `RemoteClient.GetRaw` returns the un-enveloped response body (the existing `Get` strips a JSON `{data}` envelope). Remote-only, matching the rest of the compliance group.

## Tests / gate
- `GetRaw` against `httptest` (raw body verbatim, auth header, HTTP-error surfaced); command + flag registration.
- `go build ./...` ✅ · `go vet` ✅ · `golangci-lint` 0 ✅ · `gosec` 0 ✅ · smoke-tested help + not-connected error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)