### PR TITLE
feat(notifychan): retry + observability for webhook delivery

### DIFF
--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -172,6 +172,21 @@ or, for a job that has never once succeeded since boot,
 `absent(keyorix_scheduler_last_success_timestamp_seconds{scheduler="auto_rotation"})`.
 Only enabled schedulers appear; the gauges are absent until a job first runs.
 
+### Webhook notification delivery
+
+When a webhook notification channel is configured, its delivery health is exported so a
+wedged or failing endpoint is visible rather than buried in logs:
+
+| Metric | Type | Meaning |
+|--------|------|---------|
+| `keyorix_webhook_deliveries_total{outcome}` | counter | Deliveries by terminal outcome: `delivered`, `failed` (a 4xx or retries exhausted), or `dropped` (the bounded queue was full). |
+| `keyorix_webhook_delivery_retries_total` | counter | Retries made after a transient (5xx / 429 / transport) failure. |
+
+Transient failures are retried with exponential backoff; `4xx` responses are treated as
+permanent and not retried. A rising `failed`/`dropped` rate means the endpoint is
+unhealthy or too slow to keep up — alert on
+`rate(keyorix_webhook_deliveries_total{outcome=~"failed|dropped"}[5m]) > 0`.
+
 ## 9. Troubleshooting
 
 | Symptom | Cause / fix |

--- a/internal/notifychan/webhook.go
+++ b/internal/notifychan/webhook.go
@@ -27,6 +27,11 @@ import (
 const (
 	webhookTimeout   = 10 * time.Second
 	webhookQueueSize = 256
+	// A transient failure (5xx/429/transport error) is retried with exponential
+	// backoff so a brief endpoint blip doesn't silently lose an operational alert.
+	// 4 attempts at a 500ms base ≈ 0.5s+1s+2s of backoff before giving up.
+	webhookMaxAttempts = 4
+	webhookBaseBackoff = 500 * time.Millisecond
 )
 
 // WebhookConfig configures the webhook notification channel.
@@ -38,17 +43,26 @@ type WebhookConfig struct {
 
 // WebhookSink delivers notifications to an HTTP endpoint as JSON, asynchronously.
 type WebhookSink struct {
-	cfg     WebhookConfig
-	client  *http.Client
-	queue   chan core.NotificationEvent
-	wg      sync.WaitGroup
-	mu      sync.Mutex
-	dropped int
+	cfg         WebhookConfig
+	client      *http.Client
+	queue       chan core.NotificationEvent
+	baseBackoff time.Duration
+	closing     chan struct{} // closed by Close to abort in-flight retry backoff
+	closeOnce   sync.Once
+	wg          sync.WaitGroup
+	mu          sync.Mutex
+	dropped     int
 }
 
 // NewWebhook builds a webhook sink and starts its delivery worker. The endpoint is
 // required. The returned sink must be Close()d at shutdown to drain in-flight events.
 func NewWebhook(cfg WebhookConfig) (*WebhookSink, error) {
+	return newWebhook(cfg, webhookBaseBackoff)
+}
+
+// newWebhook is the constructor with an injectable retry backoff so tests don't sleep
+// for real seconds. NewWebhook is the production entry point.
+func newWebhook(cfg WebhookConfig, baseBackoff time.Duration) (*WebhookSink, error) {
 	if cfg.Endpoint == "" {
 		return nil, fmt.Errorf("notifychan: webhook endpoint is required")
 	}
@@ -57,9 +71,11 @@ func NewWebhook(cfg WebhookConfig) (*WebhookSink, error) {
 		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} // #nosec G402 -- opt-in for self-signed endpoints
 	}
 	s := &WebhookSink{
-		cfg:    cfg,
-		client: &http.Client{Timeout: webhookTimeout, Transport: transport},
-		queue:  make(chan core.NotificationEvent, webhookQueueSize),
+		cfg:         cfg,
+		client:      &http.Client{Timeout: webhookTimeout, Transport: transport},
+		queue:       make(chan core.NotificationEvent, webhookQueueSize),
+		baseBackoff: baseBackoff,
+		closing:     make(chan struct{}),
 	}
 	s.wg.Add(1)
 	go s.worker()
@@ -80,6 +96,7 @@ func (s *WebhookSink) Deliver(ev core.NotificationEvent) {
 		s.dropped++
 		dropped := s.dropped
 		s.mu.Unlock()
+		webhookDeliveries.WithLabelValues(outcomeDropped).Inc()
 		log.Printf("notifychan: webhook queue full, dropped notification (total dropped: %d)", dropped)
 	}
 }
@@ -87,20 +104,51 @@ func (s *WebhookSink) Deliver(ev core.NotificationEvent) {
 func (s *WebhookSink) worker() {
 	defer s.wg.Done()
 	for ev := range s.queue {
-		if err := s.send(context.Background(), ev); err != nil {
-			log.Printf("notifychan: webhook delivery failed: %v", err)
-		}
+		s.deliver(ev)
 	}
 }
 
-func (s *WebhookSink) send(ctx context.Context, ev core.NotificationEvent) error {
+// deliver POSTs the event, retrying transient failures with exponential backoff up to
+// webhookMaxAttempts. A permanent failure (4xx) is not retried; backoff is abandoned
+// promptly if the sink is closing so shutdown isn't extended by retries. Records the
+// terminal outcome to Prometheus.
+func (s *WebhookSink) deliver(ev core.NotificationEvent) {
+	backoff := s.baseBackoff
+	for attempt := 1; ; attempt++ {
+		retryable, err := s.send(context.Background(), ev)
+		if err == nil {
+			webhookDeliveries.WithLabelValues(outcomeDelivered).Inc()
+			return
+		}
+		if !retryable || attempt >= webhookMaxAttempts {
+			webhookDeliveries.WithLabelValues(outcomeFailed).Inc()
+			log.Printf("notifychan: webhook delivery failed after %d attempt(s): %v", attempt, err)
+			return
+		}
+		webhookRetries.Inc()
+		select {
+		case <-time.After(backoff):
+		case <-s.closing:
+			// Shutting down — don't extend Close() with retry backoff.
+			webhookDeliveries.WithLabelValues(outcomeFailed).Inc()
+			log.Printf("notifychan: webhook delivery abandoned on shutdown after %d attempt(s): %v", attempt, err)
+			return
+		}
+		backoff *= 2
+	}
+}
+
+// send POSTs the event once. retryable reports whether a non-nil err is transient
+// (a 5xx, 429, or transport/timeout error) and therefore worth retrying; a 4xx or a
+// marshalling error is permanent.
+func (s *WebhookSink) send(ctx context.Context, ev core.NotificationEvent) (retryable bool, err error) {
 	body, err := json.Marshal(ev)
 	if err != nil {
-		return fmt.Errorf("marshal notification: %w", err)
+		return false, fmt.Errorf("marshal notification: %w", err)
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.cfg.Endpoint, bytes.NewReader(body))
 	if err != nil {
-		return err
+		return false, err
 	}
 	req.Header.Set("Content-Type", "application/json")
 	if s.cfg.Token != "" {
@@ -108,20 +156,27 @@ func (s *WebhookSink) send(ctx context.Context, ev core.NotificationEvent) error
 	}
 	resp, err := s.client.Do(req)
 	if err != nil {
-		return err
+		return true, err // transport / timeout — transient
 	}
 	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("webhook endpoint returned %s", strings.TrimSpace(resp.Status))
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return false, nil
 	}
-	return nil
+	// 5xx and 429 are transient (endpoint overloaded / down); other 4xx are permanent
+	// (bad request, auth) and won't succeed on retry.
+	retryable = resp.StatusCode >= 500 || resp.StatusCode == http.StatusTooManyRequests
+	return retryable, fmt.Errorf("webhook endpoint returned %s", strings.TrimSpace(resp.Status))
 }
 
-// Close stops the worker after draining queued events.
+// Close stops the worker after draining queued events, abandoning any in-flight retry
+// backoff so shutdown stays bounded. Idempotent.
 func (s *WebhookSink) Close() {
 	if s == nil {
 		return
 	}
-	close(s.queue)
+	s.closeOnce.Do(func() {
+		close(s.closing)
+		close(s.queue)
+	})
 	s.wg.Wait()
 }

--- a/internal/notifychan/webhook_metrics.go
+++ b/internal/notifychan/webhook_metrics.go
@@ -1,0 +1,36 @@
+// webhook_metrics.go — Prometheus instrumentation for the webhook notification sink.
+//
+// Before this, a dropped or failed operational alert (anomaly, break-glass, rotation
+// reminder) left only a log line — there was no series to alert on. These counters
+// land on the default registry the server already exposes at /metrics, so a rising
+// drop/failure rate is visible and alertable.
+package notifychan
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	// webhookDeliveries counts each event by its terminal outcome:
+	//   - delivered: the endpoint accepted it (2xx).
+	//   - failed:    a permanent error (4xx) or retries exhausted / abandoned on shutdown.
+	//   - dropped:   the bounded queue was full (a wedged endpoint) so it was never sent.
+	webhookDeliveries = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "keyorix_webhook_deliveries_total",
+		Help: "Webhook notification deliveries by terminal outcome (delivered|failed|dropped).",
+	}, []string{"outcome"})
+
+	// webhookRetries counts retry attempts made after a transient failure (a 5xx/429 or
+	// a transport error). Distinct from the failed outcome, which is terminal.
+	webhookRetries = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "keyorix_webhook_delivery_retries_total",
+		Help: "Webhook deliveries retried after a transient (5xx/429/transport) failure.",
+	})
+)
+
+const (
+	outcomeDelivered = "delivered"
+	outcomeFailed    = "failed"
+	outcomeDropped   = "dropped"
+)

--- a/internal/notifychan/webhook_test.go
+++ b/internal/notifychan/webhook_test.go
@@ -6,9 +6,12 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -81,4 +84,79 @@ func TestWebhookSink_NoTokenOmitsAuthHeader(t *testing.T) {
 func TestNewWebhook_RequiresEndpoint(t *testing.T) {
 	_, err := NewWebhook(WebhookConfig{})
 	require.Error(t, err)
+}
+
+func TestWebhookSink_RetriesTransientThenSucceeds(t *testing.T) {
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if hits.Add(1) < 3 {
+			w.WriteHeader(http.StatusServiceUnavailable) // transient — should be retried
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	delivBefore := testutil.ToFloat64(webhookDeliveries.WithLabelValues(outcomeDelivered))
+	retryBefore := testutil.ToFloat64(webhookRetries)
+
+	sink, err := newWebhook(WebhookConfig{Endpoint: srv.URL}, time.Millisecond)
+	require.NoError(t, err)
+	defer sink.Close()
+	sink.Deliver(core.NotificationEvent{UserID: 1, Type: "x"})
+
+	// Wait for the terminal "delivered" outcome before asserting — Close() would
+	// abort an in-flight retry, so we must not race it against the backoff.
+	require.Eventually(t, func() bool {
+		return testutil.ToFloat64(webhookDeliveries.WithLabelValues(outcomeDelivered))-delivBefore == 1
+	}, 2*time.Second, 5*time.Millisecond)
+
+	assert.Equal(t, int32(3), hits.Load(), "should have taken 2 retries (3 attempts)")
+	assert.Equal(t, 2.0, testutil.ToFloat64(webhookRetries)-retryBefore)
+}
+
+func TestWebhookSink_PermanentErrorNotRetried(t *testing.T) {
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusBadRequest) // 4xx — permanent, must not retry
+	}))
+	defer srv.Close()
+
+	failedBefore := testutil.ToFloat64(webhookDeliveries.WithLabelValues(outcomeFailed))
+	retryBefore := testutil.ToFloat64(webhookRetries)
+
+	sink, err := newWebhook(WebhookConfig{Endpoint: srv.URL}, time.Millisecond)
+	require.NoError(t, err)
+	sink.Deliver(core.NotificationEvent{UserID: 1, Type: "x"})
+	sink.Close() // no retry backoff for a permanent error, so Close cleanly drains it
+
+	assert.Equal(t, int32(1), hits.Load(), "a 4xx must not be retried")
+	assert.Equal(t, 1.0, testutil.ToFloat64(webhookDeliveries.WithLabelValues(outcomeFailed))-failedBefore)
+	assert.Equal(t, 0.0, testutil.ToFloat64(webhookRetries)-retryBefore)
+}
+
+func TestWebhookSink_DropsAndCountsWhenQueueFull(t *testing.T) {
+	release := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		<-release // wedge the worker so the queue backs up
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	droppedBefore := testutil.ToFloat64(webhookDeliveries.WithLabelValues(outcomeDropped))
+
+	sink, err := newWebhook(WebhookConfig{Endpoint: srv.URL}, time.Millisecond)
+	require.NoError(t, err)
+
+	// One event wedges the worker; the buffered queue holds webhookQueueSize more;
+	// everything past that is dropped (and counted) rather than blocking the caller.
+	for i := 0; i < webhookQueueSize+5; i++ {
+		sink.Deliver(core.NotificationEvent{UserID: 1, Type: "x"})
+	}
+	dropped := testutil.ToFloat64(webhookDeliveries.WithLabelValues(outcomeDropped)) - droppedBefore
+	assert.GreaterOrEqual(t, dropped, 1.0, "events past the queue capacity should be dropped and counted")
+
+	close(release)
+	sink.Close()
 }


### PR DESCRIPTION
## Problem

The webhook notification sink (ISO 27001 A.5.5 operational alerting — anomalies, break-glass, rotation/recert reminders) sent each event **exactly once**, and on a full queue **dropped it with only a log line**. A brief endpoint blip silently lost the alert, and drops/failures had no metric to alert on — fire-and-forget for compliance-relevant notifications.

## Changes

- **Retry with backoff** — transient failures (`5xx`, `429`, transport/timeout) are retried with exponential backoff up to `webhookMaxAttempts` (4). A `4xx` is treated as permanent and **not** retried. Backoff aborts promptly when the sink is closing, so shutdown stays bounded.
- **Observability** — `keyorix_webhook_deliveries_total{outcome=delivered|failed|dropped}` and `keyorix_webhook_delivery_retries_total` on the default `/metrics` registry (consistent with the scheduler/HTTP metrics). Documented in `SELF_HOSTING.md` with a suggested alert.
- **Idempotent `Close`** (`sync.Once`) that abandons in-flight retry backoff.

A **persistent on-disk/DB dead-letter queue is intentionally out of scope** — this is in-memory bounded retry + drop-counting, not durable replay (that'd be a much larger change). `send()` now reports whether a failure is retryable; a test-only constructor injects a tiny backoff so tests don't sleep for real seconds.

## Tests / gate
- `-race`: retry-transient-then-succeed (asserts 2 retries → delivered), permanent-`4xx`-not-retried, drop-counted-when-queue-full.
- `go build ./...` ✅ · `go vet` ✅ · `golangci-lint` 0 ✅ · `gosec` 0 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)