### PR TITLE
feat(mcp): read-only Keyorix MCP server for AI agents (ADR-061)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -121,3 +121,42 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+  # The MCP server image (keyorix-mcp) — read-only Keyorix access for AI agents over
+  # stdio. Published alongside the server.
+  build-and-push-mcp:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Image metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/keyorixhq/keyorix-mcp
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=sha,format=short
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: cmd/keyorix-mcp/Dockerfile
+          push: true
+          build-args: |
+            VERSION=${{ github.ref_name }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/cmd/keyorix-mcp/Dockerfile
+++ b/cmd/keyorix-mcp/Dockerfile
@@ -1,0 +1,20 @@
+# Build stage
+FROM golang:1.26-alpine AS builder
+RUN apk add --no-cache git
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+ARG VERSION=dev
+RUN CGO_ENABLED=0 go build \
+    -ldflags "-X main.version=${VERSION}" \
+    -trimpath -o /out/keyorix-mcp ./cmd/keyorix-mcp
+
+# Runtime stage — minimal, non-root. ca-certificates lets the server reach the Keyorix
+# API over HTTPS. The MCP server speaks JSON-RPC over stdio, so there is no exposed port.
+FROM alpine:latest
+RUN apk add --no-cache ca-certificates tzdata
+RUN addgroup -g 1001 keyorix && adduser -D -s /bin/sh -u 1001 -G keyorix keyorix
+COPY --from=builder /out/keyorix-mcp /usr/local/bin/keyorix-mcp
+USER keyorix
+ENTRYPOINT ["keyorix-mcp"]

--- a/cmd/keyorix-mcp/main.go
+++ b/cmd/keyorix-mcp/main.go
@@ -1,0 +1,46 @@
+/*
+Keyorix MCP server — exposes read-only Keyorix secret access to an AI agent over the
+Model Context Protocol (stdio JSON-RPC 2.0). It is a thin, audited proxy in front of the
+Keyorix API: every read carries a least-privilege machine-identity token and is subject
+to Keyorix's scoped permission, max_reads, suspension, and audit. Secret values are
+never logged.
+
+Configure it in your agent client (e.g. Claude Desktop/Code) as a stdio MCP server with
+KEYORIX_URL and a scoped KEYORIX_TOKEN in the environment.
+
+Copyright (C) 2025 Keyorix Contributors. Licensed under the AGPL-3.0-or-later.
+*/
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/keyorixhq/keyorix/internal/mcp"
+)
+
+// version is overridden at build time via -ldflags.
+var version = "dev"
+
+func main() {
+	// Logs go to stderr so they never corrupt the JSON-RPC stream on stdout.
+	log.SetOutput(os.Stderr)
+	log.SetPrefix("keyorix-mcp: ")
+
+	baseURL := strings.TrimSpace(os.Getenv("KEYORIX_URL"))
+	if baseURL == "" {
+		log.Fatal("KEYORIX_URL is required (the Keyorix server base URL)")
+	}
+	token := strings.TrimSpace(os.Getenv("KEYORIX_TOKEN"))
+	if token == "" {
+		log.Fatal("KEYORIX_TOKEN is required (a least-privilege Keyorix machine-identity token)")
+	}
+
+	server := mcp.NewServer(mcp.NewKeyorixClient(baseURL, token), version)
+	log.Printf("ready (server %s) — read-only Keyorix tools over stdio", version)
+	if err := server.Serve(context.Background(), os.Stdin, os.Stdout); err != nil {
+		log.Fatalf("serve: %v", err)
+	}
+}

--- a/docs/adr-061-mcp-server.md
+++ b/docs/adr-061-mcp-server.md
@@ -1,0 +1,71 @@
+# ADR-061: Model Context Protocol (MCP) server
+
+## Status
+
+Accepted.
+
+## Context
+
+AI agents (Claude Desktop/Code, IDE assistants, automation) increasingly need access to
+secrets to do real work — call an API, connect to a database — but the usual paths are
+bad: paste a secret into a prompt, bake it into the agent's environment, or give the
+agent a broad token. The Model Context Protocol (MCP) is the emerging standard for giving
+an agent scoped, declarative access to external capabilities via **tools**.
+
+Keyorix already has the right primitives for a safe answer: least-privilege
+**machine-identity tokens** (ADR-030), a **by-reference value read** endpoint (ADR-059),
+and per-read **scoped permission / `max_reads` / suspension / audit** enforcement. What's
+missing is an MCP front door so an agent can read a secret *through* Keyorix —
+authenticated, least-privilege, and audited — instead of around it.
+
+## Decision
+
+Add a small **MCP server** (`keyorix-mcp`) that exposes read-only Keyorix access to an
+agent over stdio.
+
+- **Transport: stdio JSON-RPC 2.0.** The standard for locally-launched MCP servers; the
+  agent's client spawns the binary and speaks newline-delimited JSON over stdin/stdout.
+  No network listener, no inbound attack surface.
+- **Dependency-minimal, hand-rolled.** The protocol surface is small (`initialize`,
+  `tools/list`, `tools/call`); it is implemented over the standard library rather than
+  pulling an MCP SDK, mirroring how `keyorix-k8s-sync` hand-rolls a thin REST client
+  instead of importing `client-go`. Logic lives in `internal/mcp`; the binary is
+  `cmd/keyorix-mcp`.
+- **Auth.** The server reads `KEYORIX_URL` and `KEYORIX_TOKEN` (a least-privilege machine
+  identity) from the environment — never from a tool argument, so a token can't be
+  coaxed out of the model. Every Keyorix call carries that bearer token.
+- **Read-only tools.**
+  - `keyorix_get_secret({ ref })` — returns a secret's value, resolved by a
+    `project/environment/name` reference through the by-reference endpoint (ADR-059).
+  - `keyorix_list_secrets({ environment })` — lists secret references in an environment
+    (metadata only, **no values**) for discovery.
+  There are deliberately **no** write/rotate/delete tools: handing an agent the ability
+  to mutate secrets is a different, higher-risk decision, out of scope for v1.
+- **Enforcement is server-side and unchanged.** Each tool call is an ordinary authorized
+  Keyorix API request: the machine identity's scoped `secrets.read`, `max_reads`,
+  suspension, and audit logging all apply. The MCP server adds no new trust — it is a
+  thin, audited proxy. It never logs secret values.
+
+## Alternatives considered
+
+- **Use an MCP SDK** (official Go SDK / community libraries). Rejected for v1: adds a
+  dependency and supply-chain surface for a three-method protocol the standard library
+  handles cleanly; the hand-rolled server is small and matches house style. Revisit if we
+  need resources/prompts/sampling or streaming transports.
+- **HTTP/SSE transport.** Rejected for v1: stdio is what local agent clients expect and
+  has no inbound surface. A remote transport can be added later behind the same tool
+  layer.
+- **Expose write tools** (set/rotate). Rejected for v1: read access is the high-value,
+  low-risk starting point; mutation by an agent warrants its own approval/guardrail
+  design.
+- **Embed MCP in the server process.** Rejected: an agent client launches a local stdio
+  process; a separate tiny binary is the right packaging (and keeps the server free of
+  MCP concerns).
+
+## Consequences
+
+- A new `keyorix-mcp` binary (and image) ships alongside the CLI/agent. Users add it to
+  their agent client config with a `KEYORIX_URL` + a scoped `KEYORIX_TOKEN`.
+- Agent secret access becomes least-privilege and audited by construction: revoke the
+  machine identity to cut the agent off; read it back in the audit log.
+- v1 is read-only; write tools and non-stdio transports are deliberate future decisions.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,0 +1,92 @@
+# Keyorix MCP server
+
+`keyorix-mcp` gives an AI agent **read-only, least-privilege, audited** access to Keyorix
+secrets over the [Model Context Protocol](https://modelcontextprotocol.io/) (MCP). Instead
+of pasting a secret into a prompt or baking a broad token into an agent's environment, the
+agent calls a tool and Keyorix serves the value *through* its normal controls — scoped
+`secrets.read`, `max_reads`, suspension, and audit logging all apply (ADR-061).
+
+It speaks MCP over **stdio** (JSON-RPC 2.0): the agent client spawns the binary and talks
+to it over stdin/stdout. There is no network listener and no inbound surface.
+
+## Tools
+
+| Tool | Arguments | Returns |
+|---|---|---|
+| `keyorix_get_secret` | `ref` — `project/environment/name` | The secret's current value (text). |
+| `keyorix_list_secrets` | `environment` *(optional)* | The references the token can see (metadata only, **no values**). |
+
+There are deliberately **no** write/rotate/delete tools — handing an agent the ability to
+mutate secrets is out of scope for v1.
+
+## Configure
+
+The server needs two environment variables:
+
+- `KEYORIX_URL` — the Keyorix server base URL (e.g. `https://keyorix.internal`).
+- `KEYORIX_TOKEN` — a **least-privilege machine-identity token** (ADR-030) with
+  `secrets.read` only for the secrets the agent should reach. Create one with
+  `keyorix machine create …`. The token is read from the environment, never from a tool
+  argument, so the model can't coax it out.
+
+### Claude Desktop / Claude Code
+
+Add it as an MCP server (e.g. in `claude_desktop_config.json`, or via
+`claude mcp add` for Claude Code):
+
+```json
+{
+  "mcpServers": {
+    "keyorix": {
+      "command": "keyorix-mcp",
+      "env": {
+        "KEYORIX_URL": "https://keyorix.internal",
+        "KEYORIX_TOKEN": "kx_machine_…"
+      }
+    }
+  }
+}
+```
+
+Then ask the agent to e.g. *"list the production secrets in Keyorix"* or *"read
+`app/production/db-password`"* — it will call the tools and Keyorix will authorize and
+audit each read.
+
+### Run from an image
+
+```sh
+docker run --rm -i \
+  -e KEYORIX_URL=https://keyorix.internal \
+  -e KEYORIX_TOKEN=kx_machine_… \
+  ghcr.io/keyorixhq/keyorix-mcp:latest
+```
+
+(`-i` keeps stdin open for the stdio protocol; point the agent client's `command` at this
+`docker run` invocation.)
+
+## Security
+
+- **Least-privilege by construction.** The agent can only reach what its
+  `KEYORIX_TOKEN`'s machine identity is allowed to read. Revoke the identity to cut the
+  agent off immediately.
+- **Every read is audited.** Each `keyorix_get_secret` is an ordinary authorized Keyorix
+  read — it appears in the audit log with the machine identity as actor, and counts
+  against any `max_reads` cap.
+- **No values are logged.** The server writes only diagnostics (to stderr); values flow
+  solely into the tool result the agent requested.
+- **No inbound surface.** stdio only — the binary is launched by the agent client, not a
+  network service.
+- **Read-only.** v1 exposes no mutating tools.
+
+> Treat a secret returned to an agent as disclosed to that agent (and any model context it
+> shares). Scope the token tightly and prefer secrets with a sensible `max_reads`.
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---|---|
+| Server exits immediately | `KEYORIX_URL` or `KEYORIX_TOKEN` unset (it logs which to stderr). |
+| `not authorized (HTTP 403)` from a tool | The token's identity lacks `secrets.read` for that secret. |
+| `not found` from `keyorix_get_secret` | No such `project/environment/name` (check `keyorix_list_secrets`). |
+| `invalid request …` | `ref` is not a three-part `project/environment/name`. |
+| Agent client shows no tools | The client didn't complete `initialize`/`tools/list` — check its MCP logs and that `command` points at the binary. |

--- a/internal/mcp/keyorix.go
+++ b/internal/mcp/keyorix.go
@@ -1,0 +1,121 @@
+// Package mcp implements a Model Context Protocol (MCP) server that exposes read-only
+// Keyorix secret access to an AI agent over stdio (ADR-061). It is a thin, audited proxy
+// in front of the Keyorix API: every call carries a least-privilege machine-identity
+// token and is subject to Keyorix's scoped permission, max_reads, suspension, and audit.
+// Secret values are never logged.
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// KeyorixClient reads secrets from a Keyorix server with a bearer (machine-identity)
+// token. It satisfies SecretReader.
+type KeyorixClient struct {
+	baseURL string
+	token   string
+	hc      *http.Client
+}
+
+// NewKeyorixClient builds a client for the given Keyorix base URL and bearer token.
+func NewKeyorixClient(baseURL, token string) *KeyorixClient {
+	return &KeyorixClient{
+		baseURL: strings.TrimRight(baseURL, "/"),
+		token:   token,
+		hc:      &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+// SecretInfo is a discovery entry: a usable reference plus minimal metadata (no value).
+type SecretInfo struct {
+	Ref  string `json:"ref"`
+	Type string `json:"type,omitempty"`
+}
+
+// GetSecret returns the value of the secret referenced by "project/environment/name"
+// via the by-reference read endpoint (ADR-059).
+func (c *KeyorixClient) GetSecret(ctx context.Context, ref string) (string, error) {
+	q := url.Values{}
+	q.Set("ref", ref)
+	var body struct {
+		Value string `json:"value"`
+	}
+	if err := c.getJSON(ctx, "/api/v1/secrets/value?"+q.Encode(), &body); err != nil {
+		return "", err
+	}
+	return body.Value, nil
+}
+
+// ListSecrets returns the references the token can see, optionally filtered to one
+// environment. Metadata only — no values are read. Capped at one page (100).
+func (c *KeyorixClient) ListSecrets(ctx context.Context, environment string) ([]SecretInfo, error) {
+	var body struct {
+		Secrets []struct {
+			Name            string `json:"Name"`
+			Type            string `json:"Type"`
+			ProjectName     string `json:"project_name"`
+			EnvironmentName string `json:"environment_name"`
+		} `json:"secrets"`
+	}
+	if err := c.getJSON(ctx, "/api/v1/secrets?page_size=100", &body); err != nil {
+		return nil, err
+	}
+	out := make([]SecretInfo, 0, len(body.Secrets))
+	for _, s := range body.Secrets {
+		if environment != "" && !strings.EqualFold(s.EnvironmentName, environment) {
+			continue
+		}
+		if s.ProjectName == "" || s.EnvironmentName == "" || s.Name == "" {
+			continue // can't form an unambiguous ref without all three parts
+		}
+		out = append(out, SecretInfo{
+			Ref:  s.ProjectName + "/" + s.EnvironmentName + "/" + s.Name,
+			Type: s.Type,
+		})
+	}
+	return out, nil
+}
+
+// getJSON performs an authenticated GET and decodes the {"data": …} envelope into out.
+func (c *KeyorixClient) getJSON(ctx context.Context, path string, out interface{}) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+path, nil)
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.hc.Do(req)
+	if err != nil {
+		return fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	switch {
+	case resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden:
+		return fmt.Errorf("not authorized (HTTP %d) — check the token and its secrets.read permission", resp.StatusCode)
+	case resp.StatusCode == http.StatusNotFound:
+		return fmt.Errorf("not found")
+	case resp.StatusCode == http.StatusBadRequest:
+		return fmt.Errorf("invalid request (want a project/environment/name reference)")
+	case resp.StatusCode >= 400:
+		return fmt.Errorf("server returned HTTP %d", resp.StatusCode)
+	}
+
+	var env struct {
+		Data json.RawMessage `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&env); err != nil {
+		return fmt.Errorf("decode response: %w", err)
+	}
+	if env.Data == nil {
+		return fmt.Errorf("empty data in response")
+	}
+	return json.Unmarshal(env.Data, out)
+}

--- a/internal/mcp/keyorix_test.go
+++ b/internal/mcp/keyorix_test.go
@@ -1,0 +1,74 @@
+package mcp
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKeyorixClient_GetSecret(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v1/secrets/value", r.URL.Path)
+		assert.Equal(t, "app/prod/db", r.URL.Query().Get("ref"))
+		assert.Equal(t, "Bearer tok", r.Header.Get("Authorization"))
+		_, _ = w.Write([]byte(`{"data":{"secret":{"Name":"db"},"value":"p4ss"}}`))
+	}))
+	defer srv.Close()
+
+	v, err := NewKeyorixClient(srv.URL, "tok").GetSecret(context.Background(), "app/prod/db")
+	require.NoError(t, err)
+	assert.Equal(t, "p4ss", v)
+}
+
+func TestKeyorixClient_GetSecretErrors(t *testing.T) {
+	cases := map[int]string{
+		http.StatusUnauthorized: "not authorized",
+		http.StatusForbidden:    "not authorized",
+		http.StatusNotFound:     "not found",
+		http.StatusBadRequest:   "invalid request",
+		http.StatusBadGateway:   "HTTP 502",
+	}
+	for status, want := range cases {
+		t.Run(want, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(status)
+			}))
+			defer srv.Close()
+			_, err := NewKeyorixClient(srv.URL, "tok").GetSecret(context.Background(), "a/b/c")
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), want)
+		})
+	}
+}
+
+func TestKeyorixClient_ListSecretsBuildsRefsAndFilters(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v1/secrets", r.URL.Path)
+		assert.Equal(t, "100", r.URL.Query().Get("page_size"))
+		_, _ = w.Write([]byte(`{"data":{"secrets":[
+			{"Name":"db","Type":"password","project_name":"app","environment_name":"production"},
+			{"Name":"api","Type":"api_key","project_name":"app","environment_name":"staging"},
+			{"Name":"orphan","project_name":"app"}
+		]}}`))
+	}))
+	defer srv.Close()
+
+	// No filter: the two complete entries map to refs; the entry missing an environment
+	// is dropped (can't form an unambiguous ref).
+	all, err := NewKeyorixClient(srv.URL, "tok").ListSecrets(context.Background(), "")
+	require.NoError(t, err)
+	require.Len(t, all, 2)
+	assert.Equal(t, "app/production/db", all[0].Ref)
+	assert.Equal(t, "password", all[0].Type)
+	assert.Equal(t, "app/staging/api", all[1].Ref)
+
+	// Environment filter (case-insensitive) narrows to one.
+	prod, err := NewKeyorixClient(srv.URL, "tok").ListSecrets(context.Background(), "Production")
+	require.NoError(t, err)
+	require.Len(t, prod, 1)
+	assert.Equal(t, "app/production/db", prod[0].Ref)
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1,0 +1,138 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+)
+
+// protocolVersion is the MCP revision the server speaks if a client does not request a
+// specific one. When the client sends a protocolVersion in initialize, the server echoes
+// it back (maximising interop) since the surface used here is stable across revisions.
+const defaultProtocolVersion = "2024-11-05"
+
+// jsonrpcVersion is the only JSON-RPC version MCP uses.
+const jsonrpcVersion = "2.0"
+
+// SecretReader is the slice of Keyorix the MCP tools need — a seam so the server is
+// unit-tested without HTTP. Satisfied by *KeyorixClient.
+type SecretReader interface {
+	GetSecret(ctx context.Context, ref string) (string, error)
+	ListSecrets(ctx context.Context, environment string) ([]SecretInfo, error)
+}
+
+// Server speaks MCP over a JSON-RPC 2.0 stream (stdio). It exposes read-only Keyorix
+// tools and holds no state between messages.
+type Server struct {
+	reader  SecretReader
+	version string
+}
+
+// NewServer builds a server over the given reader; version is reported in serverInfo.
+func NewServer(reader SecretReader, version string) *Server {
+	if version == "" {
+		version = "dev"
+	}
+	return &Server{reader: reader, version: version}
+}
+
+type rpcRequest struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"` // absent ⇒ notification (no reply)
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+type rpcResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id"`
+	Result  interface{}     `json:"result,omitempty"`
+	Error   *rpcError       `json:"error,omitempty"`
+}
+
+type rpcError struct {
+	Code    int         `json:"code"`
+	Message string      `json:"message"`
+	Data    interface{} `json:"data,omitempty"`
+}
+
+// JSON-RPC standard error codes used here.
+const (
+	codeParseError     = -32700
+	codeInvalidRequest = -32600
+	codeMethodNotFound = -32601
+	codeInvalidParams  = -32602
+)
+
+// Serve reads JSON-RPC messages from r and writes responses to w until EOF. It returns
+// nil on a clean EOF. Diagnostics must go to stderr (never to w); values are never
+// written anywhere but a tool result requested by the client.
+func (s *Server) Serve(ctx context.Context, r io.Reader, w io.Writer) error {
+	dec := json.NewDecoder(r)
+	enc := json.NewEncoder(w)
+	for {
+		var req rpcRequest
+		if err := dec.Decode(&req); err != nil {
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+			// The stream is no longer parseable; report once and stop (id unknown).
+			_ = enc.Encode(rpcResponse{JSONRPC: jsonrpcVersion, ID: json.RawMessage("null"),
+				Error: &rpcError{Code: codeParseError, Message: "parse error"}})
+			return err
+		}
+		// A notification (no id) gets no reply — e.g. notifications/initialized.
+		if len(req.ID) == 0 {
+			continue
+		}
+		if err := enc.Encode(s.handle(ctx, &req)); err != nil {
+			return err
+		}
+	}
+}
+
+func (s *Server) handle(ctx context.Context, req *rpcRequest) rpcResponse {
+	resp := rpcResponse{JSONRPC: jsonrpcVersion, ID: req.ID}
+	if req.JSONRPC != jsonrpcVersion {
+		resp.Error = &rpcError{Code: codeInvalidRequest, Message: "jsonrpc must be \"2.0\""}
+		return resp
+	}
+	switch req.Method {
+	case "initialize":
+		resp.Result = s.initialize(req.Params)
+	case "ping":
+		resp.Result = map[string]interface{}{}
+	case "tools/list":
+		resp.Result = map[string]interface{}{"tools": toolDefinitions()}
+	case "tools/call":
+		result, err := s.callTool(ctx, req.Params)
+		if err != nil {
+			resp.Error = err
+			return resp
+		}
+		resp.Result = result
+	default:
+		resp.Error = &rpcError{Code: codeMethodNotFound, Message: "method not found: " + req.Method}
+	}
+	return resp
+}
+
+// initialize negotiates the protocol version (echoing the client's when present) and
+// advertises the tools capability.
+func (s *Server) initialize(params json.RawMessage) map[string]interface{} {
+	version := defaultProtocolVersion
+	if len(params) > 0 {
+		var p struct {
+			ProtocolVersion string `json:"protocolVersion"`
+		}
+		if json.Unmarshal(params, &p) == nil && p.ProtocolVersion != "" {
+			version = p.ProtocolVersion
+		}
+	}
+	return map[string]interface{}{
+		"protocolVersion": version,
+		"capabilities":    map[string]interface{}{"tools": map[string]interface{}{}},
+		"serverInfo":      map[string]interface{}{"name": "keyorix-mcp", "version": s.version},
+	}
+}

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -1,0 +1,163 @@
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeReader struct {
+	value   string
+	getErr  error
+	list    []SecretInfo
+	listErr error
+
+	gotRef string
+	gotEnv string
+}
+
+func (f *fakeReader) GetSecret(_ context.Context, ref string) (string, error) {
+	f.gotRef = ref
+	if f.getErr != nil {
+		return "", f.getErr
+	}
+	return f.value, nil
+}
+
+func (f *fakeReader) ListSecrets(_ context.Context, env string) ([]SecretInfo, error) {
+	f.gotEnv = env
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	return f.list, nil
+}
+
+// run feeds the given JSON-RPC messages through Serve and returns the decoded responses.
+func run(t *testing.T, s *Server, msgs ...string) []rpcResponse {
+	t.Helper()
+	var out bytes.Buffer
+	require.NoError(t, s.Serve(context.Background(), strings.NewReader(strings.Join(msgs, "\n")), &out))
+	dec := json.NewDecoder(&out)
+	var resps []rpcResponse
+	for {
+		var r rpcResponse
+		if err := dec.Decode(&r); err != nil {
+			break
+		}
+		resps = append(resps, r)
+	}
+	return resps
+}
+
+// resultMap re-decodes a response's Result into a map for assertions.
+func resultMap(t *testing.T, r rpcResponse) map[string]interface{} {
+	t.Helper()
+	b, err := json.Marshal(r.Result)
+	require.NoError(t, err)
+	var m map[string]interface{}
+	require.NoError(t, json.Unmarshal(b, &m))
+	return m
+}
+
+func TestServe_Initialize(t *testing.T) {
+	s := NewServer(&fakeReader{}, "1.2.3")
+	resps := run(t, s, `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18"}}`)
+	require.Len(t, resps, 1)
+	res := resultMap(t, resps[0])
+	assert.Equal(t, "2025-06-18", res["protocolVersion"], "server echoes the client's protocol version")
+	info := res["serverInfo"].(map[string]interface{})
+	assert.Equal(t, "keyorix-mcp", info["name"])
+	assert.Equal(t, "1.2.3", info["version"])
+	assert.Contains(t, res["capabilities"].(map[string]interface{}), "tools")
+}
+
+func TestServe_NotificationGetsNoReply(t *testing.T) {
+	s := NewServer(&fakeReader{}, "")
+	resps := run(t, s,
+		`{"jsonrpc":"2.0","id":1,"method":"ping"}`,
+		`{"jsonrpc":"2.0","method":"notifications/initialized"}`, // no id ⇒ no reply
+		`{"jsonrpc":"2.0","id":2,"method":"ping"}`,
+	)
+	require.Len(t, resps, 2, "the notification produces no response")
+}
+
+func TestServe_ToolsList(t *testing.T) {
+	s := NewServer(&fakeReader{}, "")
+	resps := run(t, s, `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`)
+	require.Len(t, resps, 1)
+	tools := resultMap(t, resps[0])["tools"].([]interface{})
+	names := map[string]bool{}
+	for _, tl := range tools {
+		names[tl.(map[string]interface{})["name"].(string)] = true
+	}
+	assert.True(t, names["keyorix_get_secret"])
+	assert.True(t, names["keyorix_list_secrets"])
+}
+
+func TestServe_GetSecretSuccess(t *testing.T) {
+	fr := &fakeReader{value: "p4ss"}
+	resps := run(t, NewServer(fr, ""),
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"keyorix_get_secret","arguments":{"ref":"app/prod/db"}}}`)
+	require.Len(t, resps, 1)
+	assert.Equal(t, "app/prod/db", fr.gotRef)
+	res := resultMap(t, resps[0])
+	assert.NotEqual(t, true, res["isError"])
+	content := res["content"].([]interface{})[0].(map[string]interface{})
+	assert.Equal(t, "p4ss", content["text"])
+}
+
+func TestServe_GetSecretErrorIsInBand(t *testing.T) {
+	fr := &fakeReader{getErr: errors.New("not authorized (HTTP 403)")}
+	resps := run(t, NewServer(fr, ""),
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"keyorix_get_secret","arguments":{"ref":"app/prod/db"}}}`)
+	require.Len(t, resps, 1)
+	assert.Nil(t, resps[0].Error, "a tool failure is in-band, not a JSON-RPC error")
+	res := resultMap(t, resps[0])
+	assert.Equal(t, true, res["isError"])
+	text := res["content"].([]interface{})[0].(map[string]interface{})["text"].(string)
+	assert.Contains(t, text, "not authorized")
+}
+
+func TestServe_GetSecretRequiresRef(t *testing.T) {
+	resps := run(t, NewServer(&fakeReader{}, ""),
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"keyorix_get_secret","arguments":{}}}`)
+	res := resultMap(t, resps[0])
+	assert.Equal(t, true, res["isError"])
+	assert.Contains(t, res["content"].([]interface{})[0].(map[string]interface{})["text"], "ref is required")
+}
+
+func TestServe_ListSecrets(t *testing.T) {
+	fr := &fakeReader{list: []SecretInfo{{Ref: "app/prod/db", Type: "password"}, {Ref: "app/prod/api"}}}
+	resps := run(t, NewServer(fr, ""),
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"keyorix_list_secrets","arguments":{"environment":"prod"}}}`)
+	assert.Equal(t, "prod", fr.gotEnv)
+	text := resultMap(t, resps[0])["content"].([]interface{})[0].(map[string]interface{})["text"].(string)
+	assert.Contains(t, text, "app/prod/db")
+	assert.Contains(t, text, "(password)")
+	assert.Contains(t, text, "app/prod/api")
+}
+
+func TestServe_UnknownMethodAndTool(t *testing.T) {
+	s := NewServer(&fakeReader{}, "")
+	resps := run(t, s,
+		`{"jsonrpc":"2.0","id":1,"method":"does/not/exist"}`,
+		`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"keyorix_delete","arguments":{}}}`)
+	require.Len(t, resps, 2)
+	require.NotNil(t, resps[0].Error)
+	assert.Equal(t, codeMethodNotFound, resps[0].Error.Code)
+	require.NotNil(t, resps[1].Error)
+	assert.Contains(t, resps[1].Error.Message, "unknown tool")
+}
+
+func TestServe_RejectsBadJSONRPCVersion(t *testing.T) {
+	resps := run(t, NewServer(&fakeReader{}, ""), `{"jsonrpc":"1.0","id":1,"method":"ping"}`)
+	require.Len(t, resps, 1)
+	require.NotNil(t, resps[0].Error)
+	assert.Equal(t, codeInvalidRequest, resps[0].Error.Code)
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1,0 +1,121 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// toolDefinitions is the static tool catalogue advertised via tools/list. Read-only by
+// design (ADR-061): no write/rotate/delete tools.
+func toolDefinitions() []map[string]interface{} {
+	return []map[string]interface{}{
+		{
+			"name": "keyorix_get_secret",
+			"description": "Read a secret's current value from Keyorix by a " +
+				"\"project/environment/name\" reference (e.g. \"app/production/db-password\"). " +
+				"The value is returned as text. Access is least-privilege and every read is audited.",
+			"inputSchema": map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"ref": map[string]interface{}{
+						"type":        "string",
+						"description": "The secret reference: project/environment/name.",
+					},
+				},
+				"required": []string{"ref"},
+			},
+		},
+		{
+			"name": "keyorix_list_secrets",
+			"description": "List the secret references the configured token can see " +
+				"(metadata only — no values), optionally filtered to one environment. Use the " +
+				"returned refs with keyorix_get_secret.",
+			"inputSchema": map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"environment": map[string]interface{}{
+						"type":        "string",
+						"description": "Optional environment name to filter by (e.g. \"production\").",
+					},
+				},
+			},
+		},
+	}
+}
+
+// callTool dispatches a tools/call request. A bad request shape is a JSON-RPC error; a
+// tool execution failure is returned in-band as an isError result (per MCP), so the
+// agent can read the reason without the call itself failing.
+func (s *Server) callTool(ctx context.Context, params json.RawMessage) (map[string]interface{}, *rpcError) {
+	var p struct {
+		Name      string          `json:"name"`
+		Arguments json.RawMessage `json:"arguments"`
+	}
+	if len(params) == 0 || json.Unmarshal(params, &p) != nil {
+		return nil, &rpcError{Code: codeInvalidParams, Message: "invalid tools/call params"}
+	}
+
+	switch p.Name {
+	case "keyorix_get_secret":
+		return s.toolGetSecret(ctx, p.Arguments), nil
+	case "keyorix_list_secrets":
+		return s.toolListSecrets(ctx, p.Arguments), nil
+	default:
+		return nil, &rpcError{Code: codeMethodNotFound, Message: "unknown tool: " + p.Name}
+	}
+}
+
+func (s *Server) toolGetSecret(ctx context.Context, args json.RawMessage) map[string]interface{} {
+	var a struct {
+		Ref string `json:"ref"`
+	}
+	_ = json.Unmarshal(args, &a)
+	if strings.TrimSpace(a.Ref) == "" {
+		return errorResult("ref is required (project/environment/name)")
+	}
+	value, err := s.reader.GetSecret(ctx, a.Ref)
+	if err != nil {
+		return errorResult(fmt.Sprintf("could not read %q: %v", a.Ref, err))
+	}
+	return textResult(value)
+}
+
+func (s *Server) toolListSecrets(ctx context.Context, args json.RawMessage) map[string]interface{} {
+	var a struct {
+		Environment string `json:"environment"`
+	}
+	_ = json.Unmarshal(args, &a)
+	infos, err := s.reader.ListSecrets(ctx, a.Environment)
+	if err != nil {
+		return errorResult(fmt.Sprintf("could not list secrets: %v", err))
+	}
+	if len(infos) == 0 {
+		return textResult("(no secrets visible to this token)")
+	}
+	var b strings.Builder
+	for _, info := range infos {
+		b.WriteString(info.Ref)
+		if info.Type != "" {
+			b.WriteString("  (" + info.Type + ")")
+		}
+		b.WriteByte('\n')
+	}
+	return textResult(strings.TrimRight(b.String(), "\n"))
+}
+
+// textResult / errorResult build the MCP tool-result envelope (content blocks). A tool
+// failure is signalled in-band with isError, not as a JSON-RPC error.
+func textResult(text string) map[string]interface{} {
+	return map[string]interface{}{
+		"content": []map[string]interface{}{{"type": "text", "text": text}},
+	}
+}
+
+func errorResult(msg string) map[string]interface{} {
+	return map[string]interface{}{
+		"content": []map[string]interface{}{{"type": "text", "text": msg}},
+		"isError": true,
+	}
+}


### PR DESCRIPTION
A `keyorix-mcp` server that gives an AI agent **read-only, least-privilege, audited** access to Keyorix secrets over the [Model Context Protocol](https://modelcontextprotocol.io/) — the next not-started roadmap item (P2 #3). *"Secrets for AI agents: on-prem, least-privilege, fully audited."*

## What
A thin, audited proxy in front of the Keyorix API, speaking MCP over **stdio** (JSON-RPC 2.0). No network listener, no inbound surface. Auth is `KEYORIX_URL` + a scoped `KEYORIX_TOKEN` from the environment (never a tool argument).

**Tools (read-only — no write/rotate/delete):**
- `keyorix_get_secret(ref)` — value by `project/environment/name`, via the by-ref endpoint (ADR-059)
- `keyorix_list_secrets(environment?)` — references the token can see (metadata only, no values)

Every read is an ordinary authorized Keyorix request: scoped `secrets.read`, `max_reads`, suspension, and audit all apply. The MCP server adds no new trust — revoke the machine identity to cut the agent off. Values are never logged.

## Design
- **Hand-rolled over the standard library** (no MCP SDK) — mirrors how `keyorix-k8s-sync` avoids heavy deps. Logic in `internal/mcp`, binary in `cmd/keyorix-mcp`.
- Ships a Dockerfile + a `docker-publish` job (`ghcr.io/keyorixhq/keyorix-mcp`) and `docs/mcp.md` (Claude Desktop/Code config, security, troubleshooting).

## Verification
gofmt / vet / golangci-lint (0) / gosec (0) clean. Unit tests drive the JSON-RPC protocol end-to-end (initialize, tools/list, tools/call, notifications, error paths) + the Keyorix client. Also verified with a **live stdio smoke test** against a fake Keyorix server: initialize → tools/list → get_secret → list_secrets all correct. (ADR-061)

🤖 Generated with [Claude Code](https://claude.com/claude-code)