### PR TITLE
feat(siem): retry + observability for audit-event forwarding

### DIFF
--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -187,6 +187,21 @@ permanent and not retried. A rising `failed`/`dropped` rate means the endpoint i
 unhealthy or too slow to keep up — alert on
 `rate(keyorix_webhook_deliveries_total{outcome=~"failed|dropped"}[5m]) > 0`.
 
+### SIEM audit forwarding
+
+When SIEM forwarding is enabled, the audit-event forwarder (Splunk HEC / Datadog /
+webhook) exports the same delivery health — losing audit events silently is a SOC 2 /
+ISO 27001 finding, so a wedged or failing SIEM should page:
+
+| Metric | Type | Meaning |
+|--------|------|---------|
+| `keyorix_siem_forwards_total{outcome}` | counter | Forwards by terminal outcome: `delivered`, `failed` (a 4xx or retries exhausted), or `dropped` (the bounded queue was full). |
+| `keyorix_siem_forward_retries_total` | counter | Forwards retried after a transient (5xx / 429 / transport) failure. |
+
+Transient failures retry with exponential backoff; `4xx` is permanent. Alert on
+`rate(keyorix_siem_forwards_total{outcome=~"failed|dropped"}[5m]) > 0` — a SIEM that is
+dropping or failing audit events is a compliance gap.
+
 ## 9. Troubleshooting
 
 | Symptom | Cause / fix |

--- a/internal/audit/siem/forwarder.go
+++ b/internal/audit/siem/forwarder.go
@@ -48,14 +48,22 @@ type Config struct {
 const (
 	queueSize   = 1024
 	httpTimeout = 5 * time.Second
+	// A transient failure (5xx/429/transport) is retried with exponential backoff so a
+	// brief SIEM outage doesn't silently lose an audit event. 4 attempts at a 500ms
+	// base ≈ 0.5s+1s+2s of backoff before giving up.
+	maxAttempts        = 4
+	defaultBaseBackoff = 500 * time.Millisecond
 )
 
 // Forwarder ships audit events to a configured SIEM asynchronously.
 type Forwarder struct {
-	cfg    Config
-	client *http.Client
-	queue  chan *models.AuditEvent
-	wg     sync.WaitGroup
+	cfg         Config
+	client      *http.Client
+	queue       chan *models.AuditEvent
+	baseBackoff time.Duration
+	closing     chan struct{} // closed by Close to abort in-flight retry backoff
+	closeOnce   sync.Once
+	wg          sync.WaitGroup
 
 	mu      sync.Mutex
 	dropped int64
@@ -68,6 +76,12 @@ func New(cfg Config) (*Forwarder, error) {
 	if !cfg.Enabled {
 		return nil, nil
 	}
+	return newForwarder(cfg, defaultBaseBackoff)
+}
+
+// newForwarder is the constructor with an injectable retry backoff so tests don't
+// sleep for real seconds. New is the production entry point.
+func newForwarder(cfg Config, baseBackoff time.Duration) (*Forwarder, error) {
 	if cfg.Endpoint == "" {
 		return nil, fmt.Errorf("siem: endpoint is required when enabled")
 	}
@@ -82,9 +96,11 @@ func New(cfg Config) (*Forwarder, error) {
 		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} // #nosec G402 — operator opt-in for self-signed SIEM
 	}
 	f := &Forwarder{
-		cfg:    cfg,
-		client: &http.Client{Timeout: httpTimeout, Transport: transport},
-		queue:  make(chan *models.AuditEvent, queueSize),
+		cfg:         cfg,
+		client:      &http.Client{Timeout: httpTimeout, Transport: transport},
+		queue:       make(chan *models.AuditEvent, queueSize),
+		baseBackoff: baseBackoff,
+		closing:     make(chan struct{}),
 	}
 	f.wg.Add(1)
 	go f.worker()
@@ -104,6 +120,7 @@ func (f *Forwarder) Forward(event *models.AuditEvent) {
 		f.dropped++
 		dropped := f.dropped
 		f.mu.Unlock()
+		siemForwards.WithLabelValues(outcomeDropped).Inc()
 		log.Printf("siem: audit forward queue full, dropped event (total dropped: %d)", dropped)
 	}
 }
@@ -118,21 +135,51 @@ func (f *Forwarder) Dropped() int64 {
 	return f.dropped
 }
 
-// Close stops accepting events and waits for the in-flight queue to drain.
+// Close stops accepting events and waits for the in-flight queue to drain, abandoning
+// any in-flight retry backoff so shutdown stays bounded. Idempotent.
 func (f *Forwarder) Close() {
 	if f == nil {
 		return
 	}
-	close(f.queue)
+	f.closeOnce.Do(func() {
+		close(f.closing)
+		close(f.queue)
+	})
 	f.wg.Wait()
 }
 
 func (f *Forwarder) worker() {
 	defer f.wg.Done()
 	for event := range f.queue {
-		if err := f.send(context.Background(), event); err != nil {
-			log.Printf("siem: failed to forward audit event %d: %v", event.ID, err)
+		f.deliver(event)
+	}
+}
+
+// deliver forwards one event, retrying transient failures with exponential backoff up
+// to maxAttempts and recording the terminal outcome. A permanent failure (4xx) is not
+// retried; backoff is abandoned promptly when closing so shutdown stays bounded.
+func (f *Forwarder) deliver(event *models.AuditEvent) {
+	backoff := f.baseBackoff
+	for attempt := 1; ; attempt++ {
+		retryable, err := f.send(context.Background(), event)
+		if err == nil {
+			siemForwards.WithLabelValues(outcomeDelivered).Inc()
+			return
 		}
+		if !retryable || attempt >= maxAttempts {
+			siemForwards.WithLabelValues(outcomeFailed).Inc()
+			log.Printf("siem: failed to forward audit event %d after %d attempt(s): %v", event.ID, attempt, err)
+			return
+		}
+		siemRetries.Inc()
+		select {
+		case <-time.After(backoff):
+		case <-f.closing:
+			siemForwards.WithLabelValues(outcomeFailed).Inc()
+			log.Printf("siem: forward of audit event %d abandoned on shutdown after %d attempt(s): %v", event.ID, attempt, err)
+			return
+		}
+		backoff *= 2
 	}
 }
 
@@ -227,18 +274,22 @@ func (f *Forwarder) buildRequest(ctx context.Context, e *models.AuditEvent) (*ht
 	return req, nil
 }
 
-func (f *Forwarder) send(ctx context.Context, e *models.AuditEvent) error {
+// send forwards the event once. retryable reports whether a non-nil err is transient
+// (a 5xx, 429, or transport/timeout error) and worth retrying; a 4xx or a payload-build
+// error is permanent.
+func (f *Forwarder) send(ctx context.Context, e *models.AuditEvent) (retryable bool, err error) {
 	req, err := f.buildRequest(ctx, e)
 	if err != nil {
-		return err
+		return false, err
 	}
 	resp, err := f.client.Do(req)
 	if err != nil {
-		return err
+		return true, err // transport / timeout — transient
 	}
 	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("siem endpoint returned %s", strings.TrimSpace(resp.Status))
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return false, nil
 	}
-	return nil
+	retryable = resp.StatusCode >= 500 || resp.StatusCode == http.StatusTooManyRequests
+	return retryable, fmt.Errorf("siem endpoint returned %s", strings.TrimSpace(resp.Status))
 }

--- a/internal/audit/siem/forwarder_test.go
+++ b/internal/audit/siem/forwarder_test.go
@@ -8,11 +8,27 @@ import (
 	"net/http/httptest"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 )
+
+// eventually polls cond until true or a deadline, for asserting on async delivery
+// without racing the retry backoff.
+func eventually(t *testing.T, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("condition not met within deadline")
+}
 
 func sampleEvent() *models.AuditEvent {
 	t := true
@@ -73,7 +89,7 @@ func TestSend_SplunkFormat(t *testing.T) {
 	}
 	t.Cleanup(f.Close)
 
-	if err := f.send(context.Background(), sampleEvent()); err != nil {
+	if _, err := f.send(context.Background(), sampleEvent()); err != nil {
 		t.Fatalf("send: %v", err)
 	}
 	if got := cap.headers.Get("Authorization"); got != "Splunk hec-tok" {
@@ -100,7 +116,7 @@ func TestSend_DatadogHeader(t *testing.T) {
 	f, _ := New(Config{Enabled: true, Provider: ProviderDatadog, Endpoint: srv.URL, Token: "dd-key"})
 	t.Cleanup(f.Close)
 
-	if err := f.send(context.Background(), sampleEvent()); err != nil {
+	if _, err := f.send(context.Background(), sampleEvent()); err != nil {
 		t.Fatalf("send: %v", err)
 	}
 	if got := cap.headers.Get("DD-API-KEY"); got != "dd-key" {
@@ -113,7 +129,7 @@ func TestSend_WebhookBearer(t *testing.T) {
 	f, _ := New(Config{Enabled: true, Provider: ProviderWebhook, Endpoint: srv.URL, Token: "bear"})
 	t.Cleanup(f.Close)
 
-	if err := f.send(context.Background(), sampleEvent()); err != nil {
+	if _, err := f.send(context.Background(), sampleEvent()); err != nil {
 		t.Fatalf("send: %v", err)
 	}
 	if got := cap.headers.Get("Authorization"); got != "Bearer bear" {
@@ -132,7 +148,7 @@ func TestSend_Non2xxIsError(t *testing.T) {
 	srv, _ := newCaptureServer(t, http.StatusInternalServerError)
 	f, _ := New(Config{Enabled: true, Provider: ProviderWebhook, Endpoint: srv.URL})
 	t.Cleanup(f.Close)
-	if err := f.send(context.Background(), sampleEvent()); err == nil {
+	if _, err := f.send(context.Background(), sampleEvent()); err == nil {
 		t.Error("expected an error on a 500 response")
 	}
 }
@@ -151,6 +167,85 @@ func TestForward_AsyncDeliversThenClose(t *testing.T) {
 	if hits != 2 {
 		t.Errorf("expected 2 delivered events, got %d", hits)
 	}
+}
+
+func TestForward_RetriesTransientThenSucceeds(t *testing.T) {
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if hits.Add(1) < 3 {
+			w.WriteHeader(http.StatusServiceUnavailable) // transient — retried
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	delivBefore := testutil.ToFloat64(siemForwards.WithLabelValues(outcomeDelivered))
+	retryBefore := testutil.ToFloat64(siemRetries)
+
+	f, err := newForwarder(Config{Enabled: true, Provider: ProviderWebhook, Endpoint: srv.URL}, time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	f.Forward(sampleEvent())
+
+	eventually(t, func() bool {
+		return testutil.ToFloat64(siemForwards.WithLabelValues(outcomeDelivered))-delivBefore == 1
+	})
+	if got := hits.Load(); got != 3 {
+		t.Errorf("hits = %d, want 3 (two retries then success)", got)
+	}
+	if got := testutil.ToFloat64(siemRetries) - retryBefore; got != 2 {
+		t.Errorf("retries = %v, want 2", got)
+	}
+}
+
+func TestForward_PermanentErrorNotRetried(t *testing.T) {
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusBadRequest) // 4xx — permanent
+	}))
+	defer srv.Close()
+
+	failedBefore := testutil.ToFloat64(siemForwards.WithLabelValues(outcomeFailed))
+	f, err := newForwarder(Config{Enabled: true, Provider: ProviderWebhook, Endpoint: srv.URL}, time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.Forward(sampleEvent())
+	f.Close() // no retry backoff for a permanent error, so Close cleanly drains it
+
+	if got := hits.Load(); got != 1 {
+		t.Errorf("hits = %d, want 1 (a 4xx must not be retried)", got)
+	}
+	if got := testutil.ToFloat64(siemForwards.WithLabelValues(outcomeFailed)) - failedBefore; got != 1 {
+		t.Errorf("failed delta = %v, want 1", got)
+	}
+}
+
+func TestForward_DropsAndCountsWhenQueueFull(t *testing.T) {
+	release := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		<-release // wedge the worker so the queue backs up
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	droppedBefore := testutil.ToFloat64(siemForwards.WithLabelValues(outcomeDropped))
+	f, err := newForwarder(Config{Enabled: true, Provider: ProviderWebhook, Endpoint: srv.URL}, time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < queueSize+5; i++ {
+		f.Forward(sampleEvent())
+	}
+	if got := testutil.ToFloat64(siemForwards.WithLabelValues(outcomeDropped)) - droppedBefore; got < 1 {
+		t.Errorf("dropped delta = %v, want >= 1 (events past queue capacity are dropped)", got)
+	}
+	close(release)
+	f.Close()
 }
 
 // containsValueLeak reports whether the JSON appears to carry a plaintext value

--- a/internal/audit/siem/metrics.go
+++ b/internal/audit/siem/metrics.go
@@ -1,0 +1,35 @@
+// metrics.go — Prometheus instrumentation for SIEM audit forwarding.
+//
+// A dropped or failed audit forward used to leave only a log line. Because audit
+// events are security/compliance evidence (SOC 2 / ISO 27001), a SIEM that is silently
+// losing them is a finding — so the forwarder's delivery health is exported on the
+// default registry the server serves at /metrics.
+package siem
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	// siemForwards counts each audit event by terminal outcome:
+	//   - delivered: the SIEM accepted it (2xx).
+	//   - failed:    a permanent error (4xx) or retries exhausted / abandoned on shutdown.
+	//   - dropped:   the bounded queue was full (a wedged SIEM) so it was never sent.
+	siemForwards = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "keyorix_siem_forwards_total",
+		Help: "SIEM audit-event forwards by terminal outcome (delivered|failed|dropped).",
+	}, []string{"outcome"})
+
+	// siemRetries counts forwards retried after a transient (5xx/429/transport) failure.
+	siemRetries = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "keyorix_siem_forward_retries_total",
+		Help: "SIEM audit-event forwards retried after a transient failure.",
+	})
+)
+
+const (
+	outcomeDelivered = "delivered"
+	outcomeFailed    = "failed"
+	outcomeDropped   = "dropped"
+)


### PR DESCRIPTION
## Problem

The SIEM forwarder (Splunk HEC / Datadog / generic webhook) sent each audit event **exactly once** and, on a full queue, **dropped it with only a log line**. A brief SIEM outage or a wedged endpoint silently lost security/compliance audit events — a SOC 2 / ISO 27001 problem — with no metric to alert on. This applies the durability pattern the notification webhook got in #432 to the audit path.

## Changes

- **Retry with backoff** — transient failures (`5xx`, `429`, transport/timeout) are retried with exponential backoff up to `maxAttempts` (4); `4xx` is permanent and not retried. Backoff aborts promptly on shutdown so `Close` stays bounded.
- **Observability** — `keyorix_siem_forwards_total{outcome=delivered|failed|dropped}` + `keyorix_siem_forward_retries_total` on the default `/metrics` registry. Documented in `SELF_HOSTING.md` with an alert.
- **Idempotent `Close`** (`sync.Once`) that abandons in-flight retry backoff.

`send()` now reports whether a failure is retryable; a test-only constructor injects a tiny backoff so tests don't sleep.

## Tests / gate
- `-race`: retry-transient-then-succeed (2 retries), permanent-`4xx`-not-retried, drop-counted-when-queue-full. Existing provider/format/no-leak tests carried over (send call-sites updated to the new signature).
- `go build ./...` ✅ · `go vet` ✅ · `golangci-lint` 0 ✅ · `gosec` 0 ✅

Companion to #434 (notification sinks). Both target the same fire-and-forget gap; this one is the audit/compliance path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)