### PR TITLE
feat(evidencesink): retry transient failures on evidence-pack webhook delivery

### DIFF
--- a/internal/evidencesink/webhook.go
+++ b/internal/evidencesink/webhook.go
@@ -14,7 +14,13 @@ import (
 	"time"
 )
 
-const webhookTimeout = 30 * time.Second // the evidence pack can be large
+const (
+	webhookTimeout = 30 * time.Second // the evidence pack can be large
+	// A transient failure (5xx/429/transport) is retried with exponential backoff so a
+	// brief receiver outage doesn't lose a day's evidence pack until the next run.
+	maxAttempts        = 4
+	defaultBaseBackoff = 1 * time.Second
+)
 
 // WebhookConfig configures the evidence webhook target.
 type WebhookConfig struct {
@@ -24,14 +30,22 @@ type WebhookConfig struct {
 }
 
 // Webhook POSTs the evidence pack JSON to an HTTP endpoint. Delivery is synchronous
-// — it is only called from the once-a-day evidence scheduler, never a hot path.
+// — it is only called from the once-a-day evidence scheduler, never a hot path — so it
+// retries transient failures in-call rather than queueing.
 type Webhook struct {
-	cfg    WebhookConfig
-	client *http.Client
+	cfg         WebhookConfig
+	client      *http.Client
+	baseBackoff time.Duration
 }
 
 // NewWebhook builds an evidence webhook target. The endpoint is required.
 func NewWebhook(cfg WebhookConfig) (*Webhook, error) {
+	return newWebhook(cfg, defaultBaseBackoff)
+}
+
+// newWebhook is the constructor with an injectable retry backoff so tests don't sleep
+// for real seconds. NewWebhook is the production entry point.
+func newWebhook(cfg WebhookConfig, baseBackoff time.Duration) (*Webhook, error) {
 	if cfg.Endpoint == "" {
 		return nil, fmt.Errorf("evidencesink: webhook endpoint is required")
 	}
@@ -39,17 +53,42 @@ func NewWebhook(cfg WebhookConfig) (*Webhook, error) {
 	if cfg.InsecureSkipVerify {
 		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} // #nosec G402 -- opt-in for self-signed endpoints
 	}
-	return &Webhook{cfg: cfg, client: &http.Client{Timeout: webhookTimeout, Transport: transport}}, nil
+	return &Webhook{cfg: cfg, client: &http.Client{Timeout: webhookTimeout, Transport: transport}, baseBackoff: baseBackoff}, nil
 }
 
 // ForwardEvidence POSTs the marshalled evidence pack as application/json. The pack's
 // canonical name rides in X-Keyorix-Evidence-Filename, and when the pack is signed
 // the detached HMAC signature is sent in X-Keyorix-Evidence-Signature so the receiver
 // can record both for later verification.
+//
+// Transient failures (5xx, 429, transport/timeout) are retried with exponential
+// backoff up to maxAttempts; a 4xx is permanent and returned immediately. Backoff
+// respects ctx cancellation so a shutdown isn't extended.
 func (w *Webhook) ForwardEvidence(ctx context.Context, name string, data []byte, signature string) error {
+	backoff := w.baseBackoff
+	for attempt := 1; ; attempt++ {
+		retryable, err := w.post(ctx, name, data, signature)
+		if err == nil {
+			return nil
+		}
+		if !retryable || attempt >= maxAttempts {
+			return err
+		}
+		select {
+		case <-time.After(backoff):
+		case <-ctx.Done():
+			return fmt.Errorf("evidence webhook delivery cancelled after %d attempt(s): %w", attempt, ctx.Err())
+		}
+		backoff *= 2
+	}
+}
+
+// post sends the pack once. retryable reports whether a non-nil err is transient
+// (a 5xx, 429, or transport/timeout error) versus permanent (a 4xx or build error).
+func (w *Webhook) post(ctx context.Context, name string, data []byte, signature string) (retryable bool, err error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, w.cfg.Endpoint, bytes.NewReader(data))
 	if err != nil {
-		return err
+		return false, err
 	}
 	req.Header.Set("Content-Type", "application/json")
 	if name != "" {
@@ -63,13 +102,14 @@ func (w *Webhook) ForwardEvidence(ctx context.Context, name string, data []byte,
 	}
 	resp, err := w.client.Do(req)
 	if err != nil {
-		return err
+		return true, err // transport / timeout — transient
 	}
 	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("evidence webhook endpoint returned %s", strings.TrimSpace(resp.Status))
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return false, nil
 	}
-	return nil
+	retryable = resp.StatusCode >= 500 || resp.StatusCode == http.StatusTooManyRequests
+	return retryable, fmt.Errorf("evidence webhook endpoint returned %s", strings.TrimSpace(resp.Status))
 }
 
 // Target labels this forwarder in the export result.

--- a/internal/evidencesink/webhook_test.go
+++ b/internal/evidencesink/webhook_test.go
@@ -6,7 +6,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -45,14 +47,46 @@ func TestWebhook_PostsEvidenceWithAuth(t *testing.T) {
 	assert.Equal(t, "webhook", wh.Target())
 }
 
-func TestWebhook_ErrorsOnNon2xx(t *testing.T) {
+func TestWebhook_ErrorsOnNon2xxAfterRetries(t *testing.T) {
+	var hits atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusInternalServerError)
+		hits.Add(1)
+		w.WriteHeader(http.StatusInternalServerError) // transient — retried, then surfaced
 	}))
 	defer srv.Close()
-	wh, err := NewWebhook(WebhookConfig{Endpoint: srv.URL})
+	wh, err := newWebhook(WebhookConfig{Endpoint: srv.URL}, time.Millisecond)
 	require.NoError(t, err)
 	require.Error(t, wh.ForwardEvidence(context.Background(), "pack.json", []byte(`{}`), ""))
+	assert.Equal(t, int32(maxAttempts), hits.Load(), "a 5xx should be retried up to maxAttempts")
+}
+
+func TestWebhook_RetriesTransientThenSucceeds(t *testing.T) {
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if hits.Add(1) < 3 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+	wh, err := newWebhook(WebhookConfig{Endpoint: srv.URL}, time.Millisecond)
+	require.NoError(t, err)
+	require.NoError(t, wh.ForwardEvidence(context.Background(), "pack.json", []byte(`{}`), ""))
+	assert.Equal(t, int32(3), hits.Load(), "should retry the two 503s then succeed")
+}
+
+func TestWebhook_PermanentErrorNotRetried(t *testing.T) {
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusBadRequest) // 4xx — permanent
+	}))
+	defer srv.Close()
+	wh, err := newWebhook(WebhookConfig{Endpoint: srv.URL}, time.Millisecond)
+	require.NoError(t, err)
+	require.Error(t, wh.ForwardEvidence(context.Background(), "pack.json", []byte(`{}`), ""))
+	assert.Equal(t, int32(1), hits.Load(), "a 4xx must not be retried")
 }
 
 func TestNewWebhook_RequiresEndpoint(t *testing.T) {


### PR DESCRIPTION
## Problem

The compliance evidence-pack webhook (ISO 27001 / SOC 2 continuous evidence) POSTed **once** and returned the error on any failure. A brief receiver outage during the daily evidence run lost that day's pack until the next run — a gap in the "continuous evidence" guarantee auditors rely on.

## Fix

Unlike the notification/SIEM sinks (async queues), this target is **synchronous** and only called from the once-a-day scheduler, so the right fix is **in-call retry**, not a queue:
- Transient failures (`5xx`, `429`, transport/timeout) retry with exponential backoff up to `maxAttempts`; a `4xx` is permanent and returned immediately.
- Backoff respects `ctx` cancellation so shutdown isn't extended.

Delivery health is **already observable** via the `evidence_delivery` scheduler metrics (#423) — a post-retry failure still fails the tick and stalls its `last_success` — so no new metric is added here. `send` split into a retryable-classifying `post()`; a test-only constructor injects a tiny backoff.

## Tests / gate
- `-race`: retry-transient-then-succeed, permanent-`4xx`-not-retried, `5xx`-retried-then-surfaced (asserts `maxAttempts` hits).
- `go build ./...` ✅ · `go vet` ✅ · `golangci-lint` 0 ✅ · `gosec` 0 ✅

Second of three from the latest recon (OIDC CLI #438 → **evidence-pack durability** → PAT list timestamps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)