### PR TITLE
feat(cli): show created/last-used/expiry in keyorix pat list

### DIFF
--- a/internal/cli/pat/pat.go
+++ b/internal/cli/pat/pat.go
@@ -8,8 +8,10 @@ package pat
 import (
 	"context"
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
+	"text/tabwriter"
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/cli/common"
@@ -53,6 +55,7 @@ type patView struct {
 	Name             string   `json:"name"`
 	TokenPrefix      string   `json:"token_prefix"`
 	Revoked          bool     `json:"revoked"`
+	CreatedAt        string   `json:"created_at"`
 	ExpiresAt        *string  `json:"expires_at"`
 	LastUsedAt       *string  `json:"last_used_at"`
 	Scopes           []string `json:"scopes"`
@@ -122,12 +125,29 @@ var listCmd = &cobra.Command{
 			fmt.Println("You have no personal access tokens.")
 			return nil
 		}
-		fmt.Printf("%-5s %-22s %-14s %-9s %s\n", "ID", "NAME", "PREFIX", "REVOKED", "SCOPE")
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(w, "ID\tNAME\tPREFIX\tCREATED\tLAST USED\tEXPIRES\tREVOKED\tSCOPE") //nolint:errcheck
 		for _, t := range tokens {
-			fmt.Printf("%-5d %-22s %-14s %-9t %s\n", t.ID, t.Name, t.TokenPrefix+"…", t.Revoked, describeScope(t))
+			fmt.Fprintf(w, "%d\t%s\t%s\t%s\t%s\t%s\t%t\t%s\n", //nolint:errcheck
+				t.ID, t.Name, t.TokenPrefix+"…",
+				patDate(&t.CreatedAt), patDate(t.LastUsedAt), patDate(t.ExpiresAt),
+				t.Revoked, describeScope(t))
 		}
+		_ = w.Flush() // #nosec G104
 		return nil
 	},
+}
+
+// patDate renders an optional RFC3339 timestamp as a compact date for the list, or
+// "never" when absent (a token never used / non-expiring).
+func patDate(s *string) string {
+	if s == nil || *s == "" {
+		return "never"
+	}
+	if t, err := time.Parse(time.RFC3339, *s); err == nil {
+		return t.Format("2006-01-02")
+	}
+	return *s
 }
 
 var revokeCmd = &cobra.Command{

--- a/internal/cli/pat/pat_test.go
+++ b/internal/cli/pat/pat_test.go
@@ -101,3 +101,13 @@ func TestDescribeScope(t *testing.T) {
 	assert.Equal(t, "secrets.read,secrets.write",
 		describeScope(patView{Scopes: []string{"secrets.read", "secrets.write"}}))
 }
+
+func TestPatDate(t *testing.T) {
+	assert.Equal(t, "never", patDate(nil), "absent timestamp")
+	empty := ""
+	assert.Equal(t, "never", patDate(&empty), "empty timestamp")
+	ts := "2026-06-20T10:30:00Z"
+	assert.Equal(t, "2026-06-20", patDate(&ts), "RFC3339 rendered as a compact date")
+	bad := "not-a-time"
+	assert.Equal(t, "not-a-time", patDate(&bad), "unparseable value passed through")
+}


### PR DESCRIPTION
## What

The tokens API returns `created_at`, `last_used_at`, and `expires_at`, but `keyorix pat list` showed only ID/NAME/PREFIX/REVOKED/SCOPE — so answering a basic hygiene question ("which of my tokens are stale or about to expire?") meant dropping to the web UI or raw API. The `patView` struct already parsed `expires_at`/`last_used_at`; they just weren't displayed (and `created_at` wasn't requested).

## Change

- Add `CreatedAt` to `patView`.
- Render the list via a `tabwriter` with **CREATED / LAST USED / EXPIRES** columns (compact dates; `never` for an unused or non-expiring token). A `patDate` helper formats the optional RFC3339 timestamps.

## Tests / gate
- `patDate` (absent / empty / RFC3339 / unparseable).
- `go build ./...` ✅ · `go vet` ✅ · `golangci-lint` 0 ✅ · `gosec` 0 ✅

Third of three from the latest recon (OIDC CLI #438 → evidence-pack durability #439 → **PAT list timestamps**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)