### PR TITLE
feat(trust): ed25519 trust foundation + keygen (ADR-062 Phase 0)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,16 @@ BINARY_SERVER=keyorix-server
 BUILD_DIR=./bin
 VERSION?=dev
 GIT_COMMIT?=$(shell git rev-parse --short HEAD 2>/dev/null || echo none)
+# Air-gap trust keys (ADR-062): embed the trusted update/license signing PUBLIC keys at
+# build time, each "keyID=base64pub". Empty by default → a dev build trusts no keys and
+# verification fails closed; release builds set these. `keyorix trust keygen` prints the
+# exact value to use.
+TRUST_UPDATE_KEYS?=
+TRUST_LICENSE_KEYS?=
 # Inject the build identity into both the CLI (internal/cli.version) and the shared
 # internal/version package (read by the server's /health + /system/info). Commit is
 # deterministic per source revision, so release builds stay reproducible (no build date).
-LDFLAGS=-ldflags "-X github.com/keyorixhq/keyorix/internal/cli.version=$(VERSION) -X github.com/keyorixhq/keyorix/internal/version.Version=$(VERSION) -X github.com/keyorixhq/keyorix/internal/version.Commit=$(GIT_COMMIT)"
+LDFLAGS=-ldflags "-X github.com/keyorixhq/keyorix/internal/cli.version=$(VERSION) -X github.com/keyorixhq/keyorix/internal/version.Version=$(VERSION) -X github.com/keyorixhq/keyorix/internal/version.Commit=$(GIT_COMMIT) -X github.com/keyorixhq/keyorix/internal/trust.updateKeysB64=$(TRUST_UPDATE_KEYS) -X github.com/keyorixhq/keyorix/internal/trust.licenseKeysB64=$(TRUST_LICENSE_KEYS)"
 
 .PHONY: build build-cli build-server build-ui install install-cli install-server clean run db-up dev docker-build docker-up docker-down docker-logs proto proto-deps proto-lint release
 

--- a/docs/air-gap-updates-design.md
+++ b/docs/air-gap-updates-design.md
@@ -176,8 +176,14 @@ evidence/audit (different trust model, different purpose).
 Each phase is independently shippable and gets its own ADR; nothing here changes default
 behaviour until built.
 
-1. **Phase 0 (now):** this design + ADR-062. Generate the two `ed25519` keypairs; embed
-   the public keys at build time (`-ldflags`), no behaviour change.
+1. **Phase 0 (done):** this design + ADR-062, plus the verify-only **trust foundation** —
+   `internal/trust` (a purpose-scoped `ed25519` public-key registry that fails closed)
+   wired to embed the trusted public keys at build time via `-ldflags`
+   (`TRUST_UPDATE_KEYS` / `TRUST_LICENSE_KEYS` in the Makefile), and `keyorix trust keygen`
+   to mint a keypair and print the embed snippet. No behaviour change — the registry has
+   no callers until Phase 1, and a non-release build trusts no keys. Generating the
+   production keypairs and embedding their public keys is an operational step at first
+   release of a signed artifact.
 2. **Phase 1 — bundles:** `keyorix bundle build` (CI, extends `release.yml`) +
    `verify`/`import`; bundle published as a release asset for online customers to relay.
 3. **Phase 2 — licensing:** offline license verification, the commercial feature gate

--- a/internal/cli/main.go
+++ b/internal/cli/main.go
@@ -32,6 +32,7 @@ import (
 	sodcli "github.com/keyorixhq/keyorix/internal/cli/sod"
 	"github.com/keyorixhq/keyorix/internal/cli/status"
 	"github.com/keyorixhq/keyorix/internal/cli/system"
+	trustcli "github.com/keyorixhq/keyorix/internal/cli/trust"
 	"github.com/keyorixhq/keyorix/internal/cli/user"
 	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/spf13/cobra"
@@ -77,6 +78,7 @@ func init() {
 	rootCmd.AddCommand(compliance.ComplianceCmd)
 	rootCmd.AddCommand(sodcli.SoDCmd)
 	rootCmd.AddCommand(hygiene.HygieneCmd)
+	rootCmd.AddCommand(trustcli.TrustCmd)
 }
 
 // Execute runs the root command

--- a/internal/cli/trust/keygen_test.go
+++ b/internal/cli/trust/keygen_test.go
@@ -1,0 +1,67 @@
+package trust
+
+import (
+	"crypto/ed25519"
+	"crypto/x509"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"testing"
+
+	itrust "github.com/keyorixhq/keyorix/internal/trust"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKeygen_WritesUsableKeypair(t *testing.T) {
+	dir := t.TempDir()
+	keygenPurpose, keygenKeyID, keygenDir = "update", "upd-test", dir
+	require.NoError(t, keygenCmd.RunE(keygenCmd, nil))
+
+	privPath := filepath.Join(dir, "upd-test.private.pem")
+	pubPath := filepath.Join(dir, "upd-test.public.pem")
+	for _, p := range []string{privPath, pubPath} {
+		fi, err := os.Stat(p)
+		require.NoError(t, err)
+		assert.Equal(t, os.FileMode(0o600), fi.Mode().Perm(), "%s must be 0600", p)
+	}
+
+	// Load the private key and sign; load the public key into a registry and verify —
+	// proving the generated keypair is usable end-to-end by the trust layer.
+	priv := loadPriv(t, privPath)
+	pub := loadPub(t, pubPath)
+	reg := itrust.NewRegistry()
+	require.NoError(t, reg.Add(itrust.PurposeUpdate, "upd-test", pub))
+	msg := []byte("bundle manifest")
+	require.NoError(t, reg.Verify(itrust.PurposeUpdate, "upd-test", msg, ed25519.Sign(priv, msg)))
+}
+
+func TestKeygen_RejectsBadPurposeAndMissingKeyID(t *testing.T) {
+	keygenPurpose, keygenKeyID, keygenDir = "bogus", "x", t.TempDir()
+	require.Error(t, keygenCmd.RunE(keygenCmd, nil), "an invalid purpose is rejected")
+
+	keygenPurpose, keygenKeyID = "update", ""
+	require.Error(t, keygenCmd.RunE(keygenCmd, nil), "a missing key-id is rejected")
+}
+
+func loadPriv(t *testing.T, path string) ed25519.PrivateKey {
+	t.Helper()
+	raw, err := os.ReadFile(path) //nolint:gosec // test-controlled temp path
+	require.NoError(t, err)
+	block, _ := pem.Decode(raw)
+	require.NotNil(t, block)
+	key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	require.NoError(t, err)
+	return key.(ed25519.PrivateKey)
+}
+
+func loadPub(t *testing.T, path string) ed25519.PublicKey {
+	t.Helper()
+	raw, err := os.ReadFile(path) //nolint:gosec // test-controlled temp path
+	require.NoError(t, err)
+	block, _ := pem.Decode(raw)
+	require.NotNil(t, block)
+	key, err := x509.ParsePKIXPublicKey(block.Bytes)
+	require.NoError(t, err)
+	return key.(ed25519.PublicKey)
+}

--- a/internal/cli/trust/trust.go
+++ b/internal/cli/trust/trust.go
@@ -1,0 +1,97 @@
+// Package trust provides `keyorix trust` — local tooling for Keyorix's air-gap signing
+// keys (ADR-062). `keygen` mints an ed25519 keypair: the private key is the signing
+// secret (kept offline, used by Keyorix to sign update bundles / licenses) and the public
+// key is embedded into release builds so deployments can verify offline.
+package trust
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	itrust "github.com/keyorixhq/keyorix/internal/trust"
+	"github.com/spf13/cobra"
+)
+
+// TrustCmd is the `keyorix trust` command group.
+var TrustCmd = &cobra.Command{
+	Use:   "trust",
+	Short: "Air-gap signing-key tooling (ed25519 keypairs for update bundles / licenses)",
+	Long: `Generate and inspect the asymmetric keys Keyorix uses to sign air-gapped update
+bundles and offline licenses (ADR-062). The private key never ships; its public key is
+embedded into release builds so an air-gapped deployment can verify offline.`,
+}
+
+var (
+	keygenPurpose string
+	keygenKeyID   string
+	keygenDir     string
+)
+
+var keygenCmd = &cobra.Command{
+	Use:          "keygen",
+	Short:        "Generate an ed25519 signing keypair (update or license)",
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		purpose := itrust.Purpose(strings.TrimSpace(keygenPurpose))
+		var ldVar string
+		switch purpose {
+		case itrust.PurposeUpdate:
+			ldVar = "updateKeysB64"
+		case itrust.PurposeLicense:
+			ldVar = "licenseKeysB64"
+		default:
+			return fmt.Errorf("--purpose must be %q or %q", itrust.PurposeUpdate, itrust.PurposeLicense)
+		}
+		keyID := strings.TrimSpace(keygenKeyID)
+		if keyID == "" {
+			return fmt.Errorf("--key-id is required (e.g. %s-2026)", purpose)
+		}
+
+		pub, priv, err := itrust.GenerateKey()
+		if err != nil {
+			return fmt.Errorf("generate key: %w", err)
+		}
+
+		privDER, err := x509.MarshalPKCS8PrivateKey(priv)
+		if err != nil {
+			return fmt.Errorf("marshal private key: %w", err)
+		}
+		pubDER, err := x509.MarshalPKIXPublicKey(pub)
+		if err != nil {
+			return fmt.Errorf("marshal public key: %w", err)
+		}
+		privPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privDER})
+		pubPEM := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubDER})
+
+		privPath := filepath.Join(keygenDir, keyID+".private.pem")
+		pubPath := filepath.Join(keygenDir, keyID+".public.pem")
+		// Both at 0600 — the private key is a signing secret; the public key need not be
+		// world-readable here (it is published separately).
+		if err := os.WriteFile(privPath, privPEM, 0o600); err != nil {
+			return fmt.Errorf("write private key: %w", err)
+		}
+		if err := os.WriteFile(pubPath, pubPEM, 0o600); err != nil {
+			return fmt.Errorf("write public key: %w", err)
+		}
+
+		// The embed snippet: base64 public key keyed by key-id, for the build-time -X var.
+		spec := keyID + "=" + itrust.EncodePublicKeyBase64(pub)
+		fmt.Printf("Generated %s signing keypair %q:\n", purpose, keyID)
+		fmt.Printf("  private key: %s  (KEEP OFFLINE — never commit or ship)\n", privPath)
+		fmt.Printf("  public key:  %s\n\n", pubPath)
+		fmt.Printf("Embed the public key into release builds via:\n")
+		fmt.Printf("  -ldflags \"-X github.com/keyorixhq/keyorix/internal/trust.%s=%s\"\n", ldVar, spec)
+		return nil
+	},
+}
+
+func init() {
+	keygenCmd.Flags().StringVar(&keygenPurpose, "purpose", "", "key purpose: update | license (required)")
+	keygenCmd.Flags().StringVar(&keygenKeyID, "key-id", "", "key identifier, e.g. update-2026 (required)")
+	keygenCmd.Flags().StringVar(&keygenDir, "dir", ".", "directory to write the keypair into")
+	TrustCmd.AddCommand(keygenCmd)
+}

--- a/internal/trust/keys.go
+++ b/internal/trust/keys.go
@@ -1,0 +1,37 @@
+package trust
+
+// Build-time-embedded trusted public keys (ADR-062). These are set via -ldflags at
+// release time, each a comma-separated list of "keyID=base64publickey":
+//
+//	go build -ldflags "\
+//	  -X github.com/keyorixhq/keyorix/internal/trust.updateKeysB64=upd-2026=<base64> \
+//	  -X github.com/keyorixhq/keyorix/internal/trust.licenseKeysB64=lic-2026=<base64>"
+//
+// They default to empty, so a plain `go build` trusts no keys and every Verify fails
+// closed. `keyorix trust keygen` prints the exact -ldflags snippet for a generated key.
+// The Makefile wires these from the TRUST_UPDATE_KEYS / TRUST_LICENSE_KEYS variables.
+var (
+	updateKeysB64  string
+	licenseKeysB64 string
+)
+
+// DefaultRegistry builds the registry from the embedded keys. It errors only if an
+// embedded spec is malformed (a build/release misconfiguration), not if it is empty.
+func DefaultRegistry() (*KeyRegistry, error) {
+	r := NewRegistry()
+	for purpose, spec := range map[Purpose]string{
+		PurposeUpdate:  updateKeysB64,
+		PurposeLicense: licenseKeysB64,
+	} {
+		parsed, err := parseKeySpec(spec)
+		if err != nil {
+			return nil, err
+		}
+		for keyID, pub := range parsed {
+			if err := r.Add(purpose, keyID, pub); err != nil {
+				return nil, err
+			}
+		}
+	}
+	return r, nil
+}

--- a/internal/trust/trust.go
+++ b/internal/trust/trust.go
@@ -1,0 +1,130 @@
+// Package trust holds the asymmetric (ed25519) verification foundation for Keyorix's
+// air-gapped update bundles and offline licenses (ADR-062, Phase 0). It is deliberately
+// verify-only: it knows a set of *trusted public keys*, pinned at build time, and never
+// holds a private key. Keyorix signs bundles/licenses out-of-band with the matching
+// private keys (which never ship); a deployment verifies against the embedded public key
+// for the signature's key-id — so trust follows a pinned chain, not a self-described
+// signature.
+//
+// This package has no callers in the running server/CLI paths yet; the bundle/license
+// phases (ADR-062 Phases 1–2) build on it.
+package trust
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Purpose scopes a key to one use, so an update-signing key can never validate a license
+// (independent blast radii).
+type Purpose string
+
+const (
+	PurposeUpdate  Purpose = "update"
+	PurposeLicense Purpose = "license"
+)
+
+var (
+	// ErrNoKeys means no trusted key is configured for the purpose — a release build
+	// embeds them; a plain `go build` has none, so verification fails closed.
+	ErrNoKeys = errors.New("trust: no trusted keys configured for purpose")
+	// ErrUnknownKey means the signature names a key-id not in the trusted set.
+	ErrUnknownKey = errors.New("trust: no trusted key for key-id")
+	// ErrBadSignature means the signature did not verify against the trusted key.
+	ErrBadSignature = errors.New("trust: signature verification failed")
+)
+
+// KeyRegistry holds trusted public keys keyed by purpose and key-id.
+type KeyRegistry struct {
+	keys map[Purpose]map[string]ed25519.PublicKey
+}
+
+// NewRegistry returns an empty registry.
+func NewRegistry() *KeyRegistry {
+	return &KeyRegistry{keys: make(map[Purpose]map[string]ed25519.PublicKey)}
+}
+
+// Add trusts pub for (purpose, keyID). It rejects a key of the wrong size.
+func (r *KeyRegistry) Add(purpose Purpose, keyID string, pub ed25519.PublicKey) error {
+	if len(pub) != ed25519.PublicKeySize {
+		return fmt.Errorf("trust: bad public key size %d (want %d)", len(pub), ed25519.PublicKeySize)
+	}
+	if strings.TrimSpace(keyID) == "" {
+		return fmt.Errorf("trust: key-id is required")
+	}
+	if r.keys[purpose] == nil {
+		r.keys[purpose] = make(map[string]ed25519.PublicKey)
+	}
+	r.keys[purpose][keyID] = pub
+	return nil
+}
+
+// Verify checks that sig is a valid ed25519 signature over message by the trusted key
+// for (purpose, keyID). It fails closed: an unconfigured purpose, an unknown key-id, or a
+// bad signature all return an error.
+func (r *KeyRegistry) Verify(purpose Purpose, keyID string, message, sig []byte) error {
+	m := r.keys[purpose]
+	if len(m) == 0 {
+		return fmt.Errorf("%w (%s)", ErrNoKeys, purpose)
+	}
+	pub, ok := m[keyID]
+	if !ok {
+		return fmt.Errorf("%w (%s/%s)", ErrUnknownKey, purpose, keyID)
+	}
+	if !ed25519.Verify(pub, message, sig) {
+		return ErrBadSignature
+	}
+	return nil
+}
+
+// KeyIDs lists the trusted key-ids for a purpose, sorted (for logging/diagnostics).
+func (r *KeyRegistry) KeyIDs(purpose Purpose) []string {
+	ids := make([]string, 0, len(r.keys[purpose]))
+	for id := range r.keys[purpose] {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+// GenerateKey mints a fresh ed25519 keypair (used by `keyorix trust keygen`). The private
+// key is the signing secret — it must be stored offline and never shipped.
+func GenerateKey() (ed25519.PublicKey, ed25519.PrivateKey, error) {
+	return ed25519.GenerateKey(rand.Reader)
+}
+
+// EncodePublicKeyBase64 renders a public key as standard base64 — the form embedded at
+// build time (see keys.go) and printed by keygen.
+func EncodePublicKeyBase64(pub ed25519.PublicKey) string {
+	return base64.StdEncoding.EncodeToString(pub)
+}
+
+// parseKeySpec parses a comma-separated "keyID=base64pub" spec (the build-time embedding
+// format) into a key-id → public-key map. An empty spec yields an empty map (no trust).
+func parseKeySpec(spec string) (map[string]ed25519.PublicKey, error) {
+	out := make(map[string]ed25519.PublicKey)
+	for _, part := range strings.Split(spec, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		kv := strings.SplitN(part, "=", 2)
+		if len(kv) != 2 || strings.TrimSpace(kv[0]) == "" {
+			return nil, fmt.Errorf("trust: bad key spec %q (want keyID=base64)", part)
+		}
+		raw, err := base64.StdEncoding.DecodeString(strings.TrimSpace(kv[1]))
+		if err != nil {
+			return nil, fmt.Errorf("trust: key %q: decode: %w", kv[0], err)
+		}
+		if len(raw) != ed25519.PublicKeySize {
+			return nil, fmt.Errorf("trust: key %q: bad size %d", kv[0], len(raw))
+		}
+		out[strings.TrimSpace(kv[0])] = ed25519.PublicKey(raw)
+	}
+	return out, nil
+}

--- a/internal/trust/trust_test.go
+++ b/internal/trust/trust_test.go
@@ -1,0 +1,89 @@
+package trust
+
+import (
+	"crypto/ed25519"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegistry_VerifyRoundTrip(t *testing.T) {
+	pub, priv, err := GenerateKey()
+	require.NoError(t, err)
+
+	r := NewRegistry()
+	require.NoError(t, r.Add(PurposeUpdate, "upd-1", pub))
+
+	msg := []byte("manifest bytes")
+	sig := ed25519.Sign(priv, msg)
+	require.NoError(t, r.Verify(PurposeUpdate, "upd-1", msg, sig))
+}
+
+func TestRegistry_FailsClosed(t *testing.T) {
+	pub, priv, err := GenerateKey()
+	require.NoError(t, err)
+	r := NewRegistry()
+	require.NoError(t, r.Add(PurposeUpdate, "upd-1", pub))
+	msg := []byte("payload")
+	sig := ed25519.Sign(priv, msg)
+
+	// No keys for the license purpose at all.
+	assert.ErrorIs(t, r.Verify(PurposeLicense, "upd-1", msg, sig), ErrNoKeys)
+	// Right purpose, unknown key-id.
+	assert.ErrorIs(t, r.Verify(PurposeUpdate, "nope", msg, sig), ErrUnknownKey)
+	// Right key, tampered message.
+	assert.ErrorIs(t, r.Verify(PurposeUpdate, "upd-1", []byte("tampered"), sig), ErrBadSignature)
+
+	// A different key's signature must not verify against the trusted key.
+	_, otherPriv, _ := GenerateKey()
+	assert.ErrorIs(t, r.Verify(PurposeUpdate, "upd-1", msg, ed25519.Sign(otherPriv, msg)), ErrBadSignature)
+}
+
+func TestRegistry_AddRejectsBadKey(t *testing.T) {
+	r := NewRegistry()
+	assert.Error(t, r.Add(PurposeUpdate, "k", ed25519.PublicKey([]byte("too short"))))
+	pub, _, _ := GenerateKey()
+	assert.Error(t, r.Add(PurposeUpdate, "", pub), "empty key-id is rejected")
+}
+
+func TestRegistry_KeyIDsSorted(t *testing.T) {
+	pub, _, _ := GenerateKey()
+	r := NewRegistry()
+	require.NoError(t, r.Add(PurposeUpdate, "b", pub))
+	require.NoError(t, r.Add(PurposeUpdate, "a", pub))
+	assert.Equal(t, []string{"a", "b"}, r.KeyIDs(PurposeUpdate))
+	assert.Empty(t, r.KeyIDs(PurposeLicense))
+}
+
+func TestParseKeySpec(t *testing.T) {
+	pub, _, _ := GenerateKey()
+	spec := "k1=" + EncodePublicKeyBase64(pub)
+
+	parsed, err := parseKeySpec(spec)
+	require.NoError(t, err)
+	require.Contains(t, parsed, "k1")
+	assert.Equal(t, []byte(pub), []byte(parsed["k1"]))
+
+	// Empty spec → empty map (no trust), not an error.
+	empty, err := parseKeySpec("")
+	require.NoError(t, err)
+	assert.Empty(t, empty)
+
+	// Malformed specs are rejected.
+	_, err = parseKeySpec("no-equals-sign")
+	assert.Error(t, err)
+	_, err = parseKeySpec("k=not-base64!!")
+	assert.Error(t, err)
+	_, err = parseKeySpec("k=YWJj") // valid base64 but wrong key size
+	assert.Error(t, err)
+}
+
+func TestDefaultRegistry_EmptyByDefaultFailsClosed(t *testing.T) {
+	// With no keys embedded (the default in a non-release build), the registry trusts
+	// nothing and verification fails closed.
+	r, err := DefaultRegistry()
+	require.NoError(t, err)
+	assert.ErrorIs(t, r.Verify(PurposeUpdate, "any", []byte("m"), []byte("s")), ErrNoKeys)
+	assert.ErrorIs(t, r.Verify(PurposeLicense, "any", []byte("m"), []byte("s")), ErrNoKeys)
+}


### PR DESCRIPTION
Phase 0 of the air-gap design ([ADR-062](../blob/main/docs/adr-062-air-gap-updates.md)) — the **verify-only trust foundation** every later phase (signed update bundles, offline licenses) builds on. **No behaviour change**: the registry has no callers yet, and a non-release build trusts no keys (fails closed).

## What
- **`internal/trust`** — a purpose-scoped (`update` | `license`) `ed25519` **public-key registry** with `Verify` primitives that fail closed (`ErrNoKeys` / `ErrUnknownKey` / `ErrBadSignature`). Trusted public keys are **embedded at build time** via `-ldflags` (`updateKeysB64` / `licenseKeysB64`), wired from `TRUST_UPDATE_KEYS` / `TRUST_LICENSE_KEYS` in the Makefile; **empty by default**.
- **`keyorix trust keygen --purpose <update|license> --key-id <id>`** — mints an `ed25519` keypair (private `0600`, kept offline; public PEM) and prints the exact `-ldflags` snippet to embed the public key.

## Why this shape
Verify-only by design: the private signing key **never ships**. A deployment verifies a bundle/license against the **embedded pinned key** for the signature's key-id — trust follows a pinned chain, not a self-described signature. Generating the production keypairs + embedding their public keys is an operational step at first release of a signed artifact.

## Verification
gofmt / vet / golangci-lint (0) / gosec (0) clean. Tests: sign↔verify round trip, every fail-closed path (no keys / unknown key-id / tampered message / foreign key), key-spec parsing, and `keygen` end-to-end (files at 0600, valid PEM, keypair round-trips through the registry). Verified the binary: `keyorix trust keygen` produces a valid keypair + correct embed snippet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)