### PR TITLE
feat(cli): keyorix secret get --ref project/environment/name (ADR-059)

### DIFF
--- a/internal/cli/secret/get.go
+++ b/internal/cli/secret/get.go
@@ -3,6 +3,7 @@ package secret
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"strings"
 	"time"
 
@@ -15,6 +16,7 @@ import (
 var (
 	getID        uint
 	getName      string
+	getRef       string
 	getShowValue bool
 	getProject   uint
 	getEnv       uint
@@ -23,26 +25,45 @@ var (
 var getCmd = &cobra.Command{
 	Use:   "get",
 	Short: "Get a secret",
-	Long: `Retrieve a secret by ID or name.
+	Long: `Retrieve a secret by ID, by name, or by a project/environment/name reference.
+
+--ref reads the secret's value by a human-readable "project/environment/name"
+reference (ADR-059) — handy for scripts and automation. It always reads the value
+(so it counts toward max_reads and is audited like any value read).
 
 Examples:
   keyorix secret get --id 123
   keyorix secret get --name "db-password" --project 1 --environment 1
-  keyorix secret get --id 123 --show-value  # Show decrypted value`,
+  keyorix secret get --id 123 --show-value          # show decrypted value
+  keyorix secret get --ref app/production/db-password`,
 	RunE: runGet,
 }
 
 func init() {
 	getCmd.Flags().UintVar(&getID, "id", 0, "Secret ID")
 	getCmd.Flags().StringVar(&getName, "name", "", "Secret name")
+	getCmd.Flags().StringVar(&getRef, "ref", "", "Reference: project/environment/name (reads the value)")
 	getCmd.Flags().UintVar(&getProject, "project", 1, "Project ID (required with --name)")
 	getCmd.Flags().UintVar(&getEnv, "environment", 1, "Environment ID (required with --name)")
 	getCmd.Flags().BoolVar(&getShowValue, "show-value", false, "Show decrypted secret value")
 }
 
 func runGet(cmd *cobra.Command, args []string) error {
-	if getID == 0 && getName == "" {
-		return fmt.Errorf("either --id or --name is required")
+	selectors := 0
+	for _, set := range []bool{getID != 0, getName != "", getRef != ""} {
+		if set {
+			selectors++
+		}
+	}
+	if selectors == 0 {
+		return fmt.Errorf("one of --id, --name, or --ref is required")
+	}
+	if selectors > 1 {
+		return fmt.Errorf("--id, --name, and --ref are mutually exclusive")
+	}
+	// A reference read is value-oriented (it resolves to one secret and returns its value).
+	if getRef != "" {
+		getShowValue = true
 	}
 
 	ctx := context.Background()
@@ -58,6 +79,20 @@ func runGet(cmd *cobra.Command, args []string) error {
 func runGetRemote(ctx context.Context, rc *common.RemoteClient) error {
 	var secret *models.SecretNode
 	var value string
+
+	if getRef != "" {
+		q := url.Values{}
+		q.Set("ref", getRef)
+		var body struct {
+			Secret *models.SecretNode `json:"secret"`
+			Value  string             `json:"value"`
+		}
+		if err := rc.Get(ctx, "/api/v1/secrets/value?"+q.Encode(), &body); err != nil {
+			return fmt.Errorf("get secret by ref: %w", err)
+		}
+		displaySecret(body.Secret, body.Value)
+		return nil
+	}
 
 	if getID != 0 {
 		if getShowValue {
@@ -125,6 +160,19 @@ func runGetEmbedded(ctx context.Context) error {
 	service, err := common.InitializeCoreService()
 	if err != nil {
 		return fmt.Errorf("failed to initialize service: %w", err)
+	}
+
+	if getRef != "" {
+		secret, err := service.ResolveSecretRef(ctx, getRef)
+		if err != nil {
+			return fmt.Errorf("resolve ref %q: %w", getRef, err)
+		}
+		val, err := service.GetSecretValue(ctx, secret.ID)
+		if err != nil {
+			return fmt.Errorf("failed to get secret value: %w", err)
+		}
+		displaySecret(secret, string(val))
+		return nil
 	}
 
 	var secret *models.SecretNode

--- a/internal/cli/secret/get_ref_remote_test.go
+++ b/internal/cli/secret/get_ref_remote_test.go
@@ -1,0 +1,48 @@
+package secret
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunGetRemote_ByRef(t *testing.T) {
+	var gotPath, gotRef string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath, gotRef = r.URL.Path, r.URL.Query().Get("ref")
+		if gotPath == "/api/v1/secrets/value" {
+			_, _ = w.Write([]byte(`{"data":{"secret":{},"value":"p4ss"}}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	rc, ok := common.NewRemoteClient()
+	require.True(t, ok)
+
+	getID, getName, getRef, getShowValue = 0, "", "app/production/db", true
+	defer func() { getID, getName, getRef, getShowValue = 0, "", "", false }()
+
+	require.NoError(t, runGetRemote(context.Background(), rc))
+	assert.Equal(t, "/api/v1/secrets/value", gotPath, "--ref uses the by-reference value endpoint (ADR-059)")
+	assert.Equal(t, "app/production/db", gotRef, "the full project/environment/name ref is passed")
+}
+
+func TestRunGet_SelectorValidation(t *testing.T) {
+	reset := func() { getID, getName, getRef, getShowValue = 0, "", "", false }
+	defer reset()
+
+	reset()
+	require.ErrorContains(t, runGet(nil, nil), "one of --id, --name, or --ref")
+
+	reset()
+	getID, getRef = 1, "app/prod/db"
+	require.ErrorContains(t, runGet(nil, nil), "mutually exclusive")
+}


### PR DESCRIPTION
Completes **CLI parity** for the by-reference secret read (ADR-059), which was HTTP-only. A `--ref project/environment/name` selector on `keyorix secret get` lets a human or script read a secret's value by a friendly reference instead of a numeric ID — useful in automation and air-gapped contexts.

## What
- `keyorix secret get --ref app/production/db-password`
- `--ref` is mutually exclusive with `--id` / `--name`, and is **value-oriented**: it resolves to exactly one secret and returns its value (so it counts toward `max_reads` and is audited like any value read).
- **Remote mode** calls the existing `GET /api/v1/secrets/value?ref=` endpoint; **embedded mode** reuses `core.ResolveSecretRef` + `GetSecretValue` — no new server surface, no proto/buf changes.

## Notes
- gRPC by-ref parity is intentionally left out for now (it'd need a proto change + regen for marginal benefit); the CLI is the high-value parity gap.

## Verification
gofmt / vet / golangci-lint (0) / gosec (0) clean. Tests: the remote `--ref` path (hits the value endpoint with the full ref) and selector validation (none set → error; `--id` + `--ref` → mutually exclusive). Full `internal/cli/secret` package passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)