### PR TITLE
feat(grpc): audit chain verify / checkpoint / retention over gRPC

### DIFF
--- a/server/grpc/services/audit_service.go
+++ b/server/grpc/services/audit_service.go
@@ -11,6 +11,7 @@ import (
 	pb "github.com/keyorixhq/keyorix/server/proto/pb"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/emptypb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -103,6 +104,100 @@ func (s *AuditGRPCService) GetRBACAuditLogs(ctx context.Context, req *pb.GetRBAC
 		PageSize:   intToU32(pageSize),
 		TotalPages: intToU32(totalPages(int(total), pageSize)),
 	}, nil
+}
+
+// VerifyAuditChain re-walks the tamper-evidence hash chain (ADR-029) and reports
+// whether the trail is intact. Mirrors GET /api/v1/audit/verify; requires audit.read.
+func (s *AuditGRPCService) VerifyAuditChain(ctx context.Context, _ *emptypb.Empty) (*pb.VerifyAuditChainResponse, error) {
+	actor, err := requireUser(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if err := authorizeGlobal(ctx, s.core, actor, "audit.read"); err != nil {
+		return nil, err
+	}
+	v, err := s.core.VerifyAuditChain(ctx)
+	if err != nil {
+		return nil, status.Error(codes.Internal, "failed to verify audit chain")
+	}
+	resp := &pb.VerifyAuditChainResponse{
+		Valid:            v.Valid,
+		ChainedEvents:    v.ChainedEvents,
+		UnchainedEvents:  v.UnchainedEvents,
+		HeadHash:         v.HeadHash,
+		HeadId:           intToU32(int(v.HeadID)),
+		Checkpointed:     v.Checkpointed,
+		Reason:           v.Reason,
+		CheckpointReason: v.CheckpointReason,
+	}
+	if v.FirstBrokenID != nil {
+		resp.FirstBrokenId = ptrU32(*v.FirstBrokenID)
+	}
+	return resp, nil
+}
+
+// WriteAuditCheckpoint signs a checkpoint of the verified audit-chain head on demand
+// (ADR-029). Mirrors POST /api/v1/audit/checkpoint; privileged (system.write). Returns
+// FailedPrecondition when the chain does not verify or encryption is disabled.
+func (s *AuditGRPCService) WriteAuditCheckpoint(ctx context.Context, _ *emptypb.Empty) (*pb.WriteAuditCheckpointResponse, error) {
+	actor, err := requireUser(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if err := authorizeGlobal(ctx, s.core, actor, "system.write"); err != nil {
+		return nil, err
+	}
+	cp, written, err := s.core.WriteAuditCheckpoint(ctx)
+	if err != nil {
+		// The chain did not verify (broken, or a prior signed checkpoint proves a
+		// truncation) — refuse to notarise it. A precondition failure, not an error.
+		return nil, status.Error(codes.FailedPrecondition, err.Error())
+	}
+	if !written {
+		return nil, status.Error(codes.FailedPrecondition,
+			"signed audit checkpoints require encryption to be enabled (the signing key is derived from the DEK)")
+	}
+	resp := &pb.WriteAuditCheckpointResponse{
+		Id:             intToU32(int(cp.ID)),
+		ChainedEvents:  cp.ChainedEvents,
+		HeadId:         intToU32(int(cp.HeadID)),
+		HeadHash:       cp.HeadHash,
+		KeyVersion:     cp.KeyVersion,
+		AnchorProvider: cp.AnchorProvider,
+	}
+	if cp.AnchoredAt != nil {
+		resp.AnchoredAt = timestamppb.New(*cp.AnchoredAt)
+	}
+	return resp, nil
+}
+
+// GetAuditRetention reports the audit trail's retention coverage (NIS2 12-month).
+// Mirrors GET /api/v1/audit/retention; requires audit.read.
+func (s *AuditGRPCService) GetAuditRetention(ctx context.Context, _ *emptypb.Empty) (*pb.GetAuditRetentionResponse, error) {
+	actor, err := requireUser(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if err := authorizeGlobal(ctx, s.core, actor, "audit.read"); err != nil {
+		return nil, err
+	}
+	cov, err := s.core.AuditRetentionCoverage(ctx)
+	if err != nil {
+		return nil, status.Error(codes.Internal, "failed to compute audit retention coverage")
+	}
+	resp := &pb.GetAuditRetentionResponse{
+		RetentionPolicy:   cov.RetentionPolicy,
+		TotalEvents:       cov.TotalEvents,
+		CoverageDays:      int64(cov.CoverageDays),
+		MeetsNis2_12Month: cov.MeetsNIS2TwelveMonth,
+	}
+	if cov.OldestEvent != nil {
+		resp.OldestEvent = timestamppb.New(*cov.OldestEvent)
+	}
+	if cov.NewestEvent != nil {
+		resp.NewestEvent = timestamppb.New(*cov.NewestEvent)
+	}
+	return resp, nil
 }
 
 func rbacEntryToProto(e *core.RBACAuditEntry) *pb.RBACAuditLog {

--- a/server/grpc/services/audit_service_test.go
+++ b/server/grpc/services/audit_service_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/emptypb"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 )
@@ -66,6 +67,39 @@ func TestAuditService_GetAuditLogs_Unauthenticated(t *testing.T) {
 	_, err := svc.GetAuditLogs(context.Background(), &pb.GetAuditLogsRequest{})
 	require.Error(t, err)
 	assert.Equal(t, codes.Unauthenticated, status.Code(err))
+}
+
+func TestAuditService_VerifyAuditChain(t *testing.T) {
+	svc := newAuditService(t)
+	resp, err := svc.VerifyAuditChain(auditCtx(), &emptypb.Empty{})
+	require.NoError(t, err)
+	// The seeded events are legacy (no hash chain), so the chained suffix is empty
+	// and the trail verifies as intact.
+	assert.True(t, resp.GetValid())
+}
+
+func TestAuditService_VerifyAuditChain_Unauthenticated(t *testing.T) {
+	svc := newAuditService(t)
+	_, err := svc.VerifyAuditChain(context.Background(), &emptypb.Empty{})
+	require.Error(t, err)
+	assert.Equal(t, codes.Unauthenticated, status.Code(err))
+}
+
+func TestAuditService_GetAuditRetention(t *testing.T) {
+	svc := newAuditService(t)
+	resp, err := svc.GetAuditRetention(auditCtx(), &emptypb.Empty{})
+	require.NoError(t, err)
+	assert.Equal(t, "unlimited", resp.GetRetentionPolicy())
+	assert.GreaterOrEqual(t, resp.GetTotalEvents(), int64(1))
+}
+
+func TestAuditService_WriteAuditCheckpoint_RequiresEncryption(t *testing.T) {
+	svc := newAuditService(t)
+	// The test core has no encryption configured, so the DEK-derived signing key is
+	// unavailable and a checkpoint cannot be written — a precondition failure.
+	_, err := svc.WriteAuditCheckpoint(auditCtx(), &emptypb.Empty{})
+	require.Error(t, err)
+	assert.Equal(t, codes.FailedPrecondition, status.Code(err))
 }
 
 func TestAuditService_GetAuditLogs_PermissionDenied(t *testing.T) {

--- a/server/proto/keyorix.proto
+++ b/server/proto/keyorix.proto
@@ -117,6 +117,18 @@ service AuditService {
 
   // Stream audit events as they occur
   rpc StreamAuditLogs(StreamAuditLogsRequest) returns (stream AuditLog);
+
+  // Verify the tamper-evidence hash chain (ADR-029): re-walk the chain and report
+  // whether the trail is intact, naming the first divergent event on failure.
+  rpc VerifyAuditChain(google.protobuf.Empty) returns (VerifyAuditChainResponse);
+
+  // Write a signed checkpoint of the verified audit-chain head on demand (ADR-029).
+  // Requires encryption (the signing key is DEK-derived) and a chain that verifies.
+  rpc WriteAuditCheckpoint(google.protobuf.Empty) returns (WriteAuditCheckpointResponse);
+
+  // Report the audit trail's retention coverage (total events, oldest/newest, and
+  // whether it demonstrably covers the NIS2 12-month window).
+  rpc GetAuditRetention(google.protobuf.Empty) returns (GetAuditRetentionResponse);
 }
 
 // System service for health, info, and metrics
@@ -566,6 +578,42 @@ message StreamAuditLogsRequest {
   // Omit (or 0) to tail only new events from the current head. Lets a disconnected
   // SIEM consumer reconnect from its last-seen id without losing the gap.
   optional uint32 after_id = 4;
+}
+
+// VerifyAuditChainResponse reports the tamper-evidence hash-chain verification
+// (ADR-029). Record (chained_events, head_hash) off-box to detect tail-truncation
+// that an on-box re-walk alone cannot catch.
+message VerifyAuditChainResponse {
+  bool valid = 1;
+  int64 chained_events = 2;
+  int64 unchained_events = 3; // leading legacy rows skipped before the chain begins
+  string head_hash = 4;
+  uint32 head_id = 5;
+  bool checkpointed = 6; // chain also verified against a signed in-DB checkpoint
+  optional uint32 first_broken_id = 7; // set only when !valid
+  string reason = 8; // set only when !valid
+  string checkpoint_reason = 9; // non-fatal notes (e.g. checkpoint under a prior key)
+}
+
+// WriteAuditCheckpointResponse is the signed checkpoint that was written.
+message WriteAuditCheckpointResponse {
+  uint32 id = 1;
+  int64 chained_events = 2;
+  uint32 head_id = 3;
+  string head_hash = 4;
+  string key_version = 5;
+  optional google.protobuf.Timestamp anchored_at = 6; // external-notary anchor, if any
+  string anchor_provider = 7;
+}
+
+// GetAuditRetentionResponse reports the audit trail's retention coverage.
+message GetAuditRetentionResponse {
+  string retention_policy = 1; // always "unlimited" — Keyorix applies no audit cap
+  int64 total_events = 2;
+  optional google.protobuf.Timestamp oldest_event = 3;
+  optional google.protobuf.Timestamp newest_event = 4;
+  int64 coverage_days = 5;
+  bool meets_nis2_12_month = 6;
 }
 
 // ---------------------------------------------------------------------------

--- a/server/proto/pb/keyorix.pb.go
+++ b/server/proto/pb/keyorix.pb.go
@@ -3791,6 +3791,295 @@ func (x *StreamAuditLogsRequest) GetAfterId() uint32 {
 	return 0
 }
 
+// VerifyAuditChainResponse reports the tamper-evidence hash-chain verification
+// (ADR-029). Record (chained_events, head_hash) off-box to detect tail-truncation
+// that an on-box re-walk alone cannot catch.
+type VerifyAuditChainResponse struct {
+	state            protoimpl.MessageState `protogen:"open.v1"`
+	Valid            bool                   `protobuf:"varint,1,opt,name=valid,proto3" json:"valid,omitempty"`
+	ChainedEvents    int64                  `protobuf:"varint,2,opt,name=chained_events,json=chainedEvents,proto3" json:"chained_events,omitempty"`
+	UnchainedEvents  int64                  `protobuf:"varint,3,opt,name=unchained_events,json=unchainedEvents,proto3" json:"unchained_events,omitempty"` // leading legacy rows skipped before the chain begins
+	HeadHash         string                 `protobuf:"bytes,4,opt,name=head_hash,json=headHash,proto3" json:"head_hash,omitempty"`
+	HeadId           uint32                 `protobuf:"varint,5,opt,name=head_id,json=headId,proto3" json:"head_id,omitempty"`
+	Checkpointed     bool                   `protobuf:"varint,6,opt,name=checkpointed,proto3" json:"checkpointed,omitempty"`                                // chain also verified against a signed in-DB checkpoint
+	FirstBrokenId    *uint32                `protobuf:"varint,7,opt,name=first_broken_id,json=firstBrokenId,proto3,oneof" json:"first_broken_id,omitempty"` // set only when !valid
+	Reason           string                 `protobuf:"bytes,8,opt,name=reason,proto3" json:"reason,omitempty"`                                             // set only when !valid
+	CheckpointReason string                 `protobuf:"bytes,9,opt,name=checkpoint_reason,json=checkpointReason,proto3" json:"checkpoint_reason,omitempty"` // non-fatal notes (e.g. checkpoint under a prior key)
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
+}
+
+func (x *VerifyAuditChainResponse) Reset() {
+	*x = VerifyAuditChainResponse{}
+	mi := &file_keyorix_proto_msgTypes[50]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *VerifyAuditChainResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*VerifyAuditChainResponse) ProtoMessage() {}
+
+func (x *VerifyAuditChainResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_keyorix_proto_msgTypes[50]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use VerifyAuditChainResponse.ProtoReflect.Descriptor instead.
+func (*VerifyAuditChainResponse) Descriptor() ([]byte, []int) {
+	return file_keyorix_proto_rawDescGZIP(), []int{50}
+}
+
+func (x *VerifyAuditChainResponse) GetValid() bool {
+	if x != nil {
+		return x.Valid
+	}
+	return false
+}
+
+func (x *VerifyAuditChainResponse) GetChainedEvents() int64 {
+	if x != nil {
+		return x.ChainedEvents
+	}
+	return 0
+}
+
+func (x *VerifyAuditChainResponse) GetUnchainedEvents() int64 {
+	if x != nil {
+		return x.UnchainedEvents
+	}
+	return 0
+}
+
+func (x *VerifyAuditChainResponse) GetHeadHash() string {
+	if x != nil {
+		return x.HeadHash
+	}
+	return ""
+}
+
+func (x *VerifyAuditChainResponse) GetHeadId() uint32 {
+	if x != nil {
+		return x.HeadId
+	}
+	return 0
+}
+
+func (x *VerifyAuditChainResponse) GetCheckpointed() bool {
+	if x != nil {
+		return x.Checkpointed
+	}
+	return false
+}
+
+func (x *VerifyAuditChainResponse) GetFirstBrokenId() uint32 {
+	if x != nil && x.FirstBrokenId != nil {
+		return *x.FirstBrokenId
+	}
+	return 0
+}
+
+func (x *VerifyAuditChainResponse) GetReason() string {
+	if x != nil {
+		return x.Reason
+	}
+	return ""
+}
+
+func (x *VerifyAuditChainResponse) GetCheckpointReason() string {
+	if x != nil {
+		return x.CheckpointReason
+	}
+	return ""
+}
+
+// WriteAuditCheckpointResponse is the signed checkpoint that was written.
+type WriteAuditCheckpointResponse struct {
+	state          protoimpl.MessageState `protogen:"open.v1"`
+	Id             uint32                 `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
+	ChainedEvents  int64                  `protobuf:"varint,2,opt,name=chained_events,json=chainedEvents,proto3" json:"chained_events,omitempty"`
+	HeadId         uint32                 `protobuf:"varint,3,opt,name=head_id,json=headId,proto3" json:"head_id,omitempty"`
+	HeadHash       string                 `protobuf:"bytes,4,opt,name=head_hash,json=headHash,proto3" json:"head_hash,omitempty"`
+	KeyVersion     string                 `protobuf:"bytes,5,opt,name=key_version,json=keyVersion,proto3" json:"key_version,omitempty"`
+	AnchoredAt     *timestamppb.Timestamp `protobuf:"bytes,6,opt,name=anchored_at,json=anchoredAt,proto3,oneof" json:"anchored_at,omitempty"` // external-notary anchor, if any
+	AnchorProvider string                 `protobuf:"bytes,7,opt,name=anchor_provider,json=anchorProvider,proto3" json:"anchor_provider,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *WriteAuditCheckpointResponse) Reset() {
+	*x = WriteAuditCheckpointResponse{}
+	mi := &file_keyorix_proto_msgTypes[51]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *WriteAuditCheckpointResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*WriteAuditCheckpointResponse) ProtoMessage() {}
+
+func (x *WriteAuditCheckpointResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_keyorix_proto_msgTypes[51]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use WriteAuditCheckpointResponse.ProtoReflect.Descriptor instead.
+func (*WriteAuditCheckpointResponse) Descriptor() ([]byte, []int) {
+	return file_keyorix_proto_rawDescGZIP(), []int{51}
+}
+
+func (x *WriteAuditCheckpointResponse) GetId() uint32 {
+	if x != nil {
+		return x.Id
+	}
+	return 0
+}
+
+func (x *WriteAuditCheckpointResponse) GetChainedEvents() int64 {
+	if x != nil {
+		return x.ChainedEvents
+	}
+	return 0
+}
+
+func (x *WriteAuditCheckpointResponse) GetHeadId() uint32 {
+	if x != nil {
+		return x.HeadId
+	}
+	return 0
+}
+
+func (x *WriteAuditCheckpointResponse) GetHeadHash() string {
+	if x != nil {
+		return x.HeadHash
+	}
+	return ""
+}
+
+func (x *WriteAuditCheckpointResponse) GetKeyVersion() string {
+	if x != nil {
+		return x.KeyVersion
+	}
+	return ""
+}
+
+func (x *WriteAuditCheckpointResponse) GetAnchoredAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.AnchoredAt
+	}
+	return nil
+}
+
+func (x *WriteAuditCheckpointResponse) GetAnchorProvider() string {
+	if x != nil {
+		return x.AnchorProvider
+	}
+	return ""
+}
+
+// GetAuditRetentionResponse reports the audit trail's retention coverage.
+type GetAuditRetentionResponse struct {
+	state             protoimpl.MessageState `protogen:"open.v1"`
+	RetentionPolicy   string                 `protobuf:"bytes,1,opt,name=retention_policy,json=retentionPolicy,proto3" json:"retention_policy,omitempty"` // always "unlimited" — Keyorix applies no audit cap
+	TotalEvents       int64                  `protobuf:"varint,2,opt,name=total_events,json=totalEvents,proto3" json:"total_events,omitempty"`
+	OldestEvent       *timestamppb.Timestamp `protobuf:"bytes,3,opt,name=oldest_event,json=oldestEvent,proto3,oneof" json:"oldest_event,omitempty"`
+	NewestEvent       *timestamppb.Timestamp `protobuf:"bytes,4,opt,name=newest_event,json=newestEvent,proto3,oneof" json:"newest_event,omitempty"`
+	CoverageDays      int64                  `protobuf:"varint,5,opt,name=coverage_days,json=coverageDays,proto3" json:"coverage_days,omitempty"`
+	MeetsNis2_12Month bool                   `protobuf:"varint,6,opt,name=meets_nis2_12_month,json=meetsNis212Month,proto3" json:"meets_nis2_12_month,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
+}
+
+func (x *GetAuditRetentionResponse) Reset() {
+	*x = GetAuditRetentionResponse{}
+	mi := &file_keyorix_proto_msgTypes[52]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetAuditRetentionResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetAuditRetentionResponse) ProtoMessage() {}
+
+func (x *GetAuditRetentionResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_keyorix_proto_msgTypes[52]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetAuditRetentionResponse.ProtoReflect.Descriptor instead.
+func (*GetAuditRetentionResponse) Descriptor() ([]byte, []int) {
+	return file_keyorix_proto_rawDescGZIP(), []int{52}
+}
+
+func (x *GetAuditRetentionResponse) GetRetentionPolicy() string {
+	if x != nil {
+		return x.RetentionPolicy
+	}
+	return ""
+}
+
+func (x *GetAuditRetentionResponse) GetTotalEvents() int64 {
+	if x != nil {
+		return x.TotalEvents
+	}
+	return 0
+}
+
+func (x *GetAuditRetentionResponse) GetOldestEvent() *timestamppb.Timestamp {
+	if x != nil {
+		return x.OldestEvent
+	}
+	return nil
+}
+
+func (x *GetAuditRetentionResponse) GetNewestEvent() *timestamppb.Timestamp {
+	if x != nil {
+		return x.NewestEvent
+	}
+	return nil
+}
+
+func (x *GetAuditRetentionResponse) GetCoverageDays() int64 {
+	if x != nil {
+		return x.CoverageDays
+	}
+	return 0
+}
+
+func (x *GetAuditRetentionResponse) GetMeetsNis2_12Month() bool {
+	if x != nil {
+		return x.MeetsNis2_12Month
+	}
+	return false
+}
+
 type ShareRecord struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Id            uint32                 `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
@@ -3807,7 +4096,7 @@ type ShareRecord struct {
 
 func (x *ShareRecord) Reset() {
 	*x = ShareRecord{}
-	mi := &file_keyorix_proto_msgTypes[50]
+	mi := &file_keyorix_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3819,7 +4108,7 @@ func (x *ShareRecord) String() string {
 func (*ShareRecord) ProtoMessage() {}
 
 func (x *ShareRecord) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[50]
+	mi := &file_keyorix_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3832,7 +4121,7 @@ func (x *ShareRecord) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ShareRecord.ProtoReflect.Descriptor instead.
 func (*ShareRecord) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{50}
+	return file_keyorix_proto_rawDescGZIP(), []int{53}
 }
 
 func (x *ShareRecord) GetId() uint32 {
@@ -3903,7 +4192,7 @@ type ShareSecretRequest struct {
 
 func (x *ShareSecretRequest) Reset() {
 	*x = ShareSecretRequest{}
-	mi := &file_keyorix_proto_msgTypes[51]
+	mi := &file_keyorix_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3915,7 +4204,7 @@ func (x *ShareSecretRequest) String() string {
 func (*ShareSecretRequest) ProtoMessage() {}
 
 func (x *ShareSecretRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[51]
+	mi := &file_keyorix_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3928,7 +4217,7 @@ func (x *ShareSecretRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ShareSecretRequest.ProtoReflect.Descriptor instead.
 func (*ShareSecretRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{51}
+	return file_keyorix_proto_rawDescGZIP(), []int{54}
 }
 
 func (x *ShareSecretRequest) GetSecretId() uint32 {
@@ -3968,7 +4257,7 @@ type ListSecretSharesRequest struct {
 
 func (x *ListSecretSharesRequest) Reset() {
 	*x = ListSecretSharesRequest{}
-	mi := &file_keyorix_proto_msgTypes[52]
+	mi := &file_keyorix_proto_msgTypes[55]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3980,7 +4269,7 @@ func (x *ListSecretSharesRequest) String() string {
 func (*ListSecretSharesRequest) ProtoMessage() {}
 
 func (x *ListSecretSharesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[52]
+	mi := &file_keyorix_proto_msgTypes[55]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3993,7 +4282,7 @@ func (x *ListSecretSharesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSecretSharesRequest.ProtoReflect.Descriptor instead.
 func (*ListSecretSharesRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{52}
+	return file_keyorix_proto_rawDescGZIP(), []int{55}
 }
 
 func (x *ListSecretSharesRequest) GetSecretId() uint32 {
@@ -4013,7 +4302,7 @@ type ListUserSharesRequest struct {
 
 func (x *ListUserSharesRequest) Reset() {
 	*x = ListUserSharesRequest{}
-	mi := &file_keyorix_proto_msgTypes[53]
+	mi := &file_keyorix_proto_msgTypes[56]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4025,7 +4314,7 @@ func (x *ListUserSharesRequest) String() string {
 func (*ListUserSharesRequest) ProtoMessage() {}
 
 func (x *ListUserSharesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[53]
+	mi := &file_keyorix_proto_msgTypes[56]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4038,7 +4327,7 @@ func (x *ListUserSharesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListUserSharesRequest.ProtoReflect.Descriptor instead.
 func (*ListUserSharesRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{53}
+	return file_keyorix_proto_rawDescGZIP(), []int{56}
 }
 
 func (x *ListUserSharesRequest) GetPage() uint32 {
@@ -4065,7 +4354,7 @@ type ListSharedSecretsRequest struct {
 
 func (x *ListSharedSecretsRequest) Reset() {
 	*x = ListSharedSecretsRequest{}
-	mi := &file_keyorix_proto_msgTypes[54]
+	mi := &file_keyorix_proto_msgTypes[57]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4077,7 +4366,7 @@ func (x *ListSharedSecretsRequest) String() string {
 func (*ListSharedSecretsRequest) ProtoMessage() {}
 
 func (x *ListSharedSecretsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[54]
+	mi := &file_keyorix_proto_msgTypes[57]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4090,7 +4379,7 @@ func (x *ListSharedSecretsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSharedSecretsRequest.ProtoReflect.Descriptor instead.
 func (*ListSharedSecretsRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{54}
+	return file_keyorix_proto_rawDescGZIP(), []int{57}
 }
 
 func (x *ListSharedSecretsRequest) GetPage() uint32 {
@@ -4120,7 +4409,7 @@ type ListSharesResponse struct {
 
 func (x *ListSharesResponse) Reset() {
 	*x = ListSharesResponse{}
-	mi := &file_keyorix_proto_msgTypes[55]
+	mi := &file_keyorix_proto_msgTypes[58]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4132,7 +4421,7 @@ func (x *ListSharesResponse) String() string {
 func (*ListSharesResponse) ProtoMessage() {}
 
 func (x *ListSharesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[55]
+	mi := &file_keyorix_proto_msgTypes[58]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4145,7 +4434,7 @@ func (x *ListSharesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSharesResponse.ProtoReflect.Descriptor instead.
 func (*ListSharesResponse) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{55}
+	return file_keyorix_proto_rawDescGZIP(), []int{58}
 }
 
 func (x *ListSharesResponse) GetShares() []*ShareRecord {
@@ -4193,7 +4482,7 @@ type UpdateSharePermissionRequest struct {
 
 func (x *UpdateSharePermissionRequest) Reset() {
 	*x = UpdateSharePermissionRequest{}
-	mi := &file_keyorix_proto_msgTypes[56]
+	mi := &file_keyorix_proto_msgTypes[59]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4205,7 +4494,7 @@ func (x *UpdateSharePermissionRequest) String() string {
 func (*UpdateSharePermissionRequest) ProtoMessage() {}
 
 func (x *UpdateSharePermissionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[56]
+	mi := &file_keyorix_proto_msgTypes[59]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4218,7 +4507,7 @@ func (x *UpdateSharePermissionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateSharePermissionRequest.ProtoReflect.Descriptor instead.
 func (*UpdateSharePermissionRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{56}
+	return file_keyorix_proto_rawDescGZIP(), []int{59}
 }
 
 func (x *UpdateSharePermissionRequest) GetShareId() uint32 {
@@ -4244,7 +4533,7 @@ type RevokeShareRequest struct {
 
 func (x *RevokeShareRequest) Reset() {
 	*x = RevokeShareRequest{}
-	mi := &file_keyorix_proto_msgTypes[57]
+	mi := &file_keyorix_proto_msgTypes[60]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4256,7 +4545,7 @@ func (x *RevokeShareRequest) String() string {
 func (*RevokeShareRequest) ProtoMessage() {}
 
 func (x *RevokeShareRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[57]
+	mi := &file_keyorix_proto_msgTypes[60]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4269,7 +4558,7 @@ func (x *RevokeShareRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RevokeShareRequest.ProtoReflect.Descriptor instead.
 func (*RevokeShareRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{57}
+	return file_keyorix_proto_rawDescGZIP(), []int{60}
 }
 
 func (x *RevokeShareRequest) GetShareId() uint32 {
@@ -4291,7 +4580,7 @@ type HealthResponse struct {
 
 func (x *HealthResponse) Reset() {
 	*x = HealthResponse{}
-	mi := &file_keyorix_proto_msgTypes[58]
+	mi := &file_keyorix_proto_msgTypes[61]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4303,7 +4592,7 @@ func (x *HealthResponse) String() string {
 func (*HealthResponse) ProtoMessage() {}
 
 func (x *HealthResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[58]
+	mi := &file_keyorix_proto_msgTypes[61]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4316,7 +4605,7 @@ func (x *HealthResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HealthResponse.ProtoReflect.Descriptor instead.
 func (*HealthResponse) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{58}
+	return file_keyorix_proto_rawDescGZIP(), []int{61}
 }
 
 func (x *HealthResponse) GetStatus() string {
@@ -4364,7 +4653,7 @@ type SystemInfo struct {
 
 func (x *SystemInfo) Reset() {
 	*x = SystemInfo{}
-	mi := &file_keyorix_proto_msgTypes[59]
+	mi := &file_keyorix_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4376,7 +4665,7 @@ func (x *SystemInfo) String() string {
 func (*SystemInfo) ProtoMessage() {}
 
 func (x *SystemInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[59]
+	mi := &file_keyorix_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4389,7 +4678,7 @@ func (x *SystemInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SystemInfo.ProtoReflect.Descriptor instead.
 func (*SystemInfo) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{59}
+	return file_keyorix_proto_rawDescGZIP(), []int{62}
 }
 
 func (x *SystemInfo) GetVersion() string {
@@ -4467,7 +4756,7 @@ type DatabaseInfo struct {
 
 func (x *DatabaseInfo) Reset() {
 	*x = DatabaseInfo{}
-	mi := &file_keyorix_proto_msgTypes[60]
+	mi := &file_keyorix_proto_msgTypes[63]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4479,7 +4768,7 @@ func (x *DatabaseInfo) String() string {
 func (*DatabaseInfo) ProtoMessage() {}
 
 func (x *DatabaseInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[60]
+	mi := &file_keyorix_proto_msgTypes[63]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4492,7 +4781,7 @@ func (x *DatabaseInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DatabaseInfo.ProtoReflect.Descriptor instead.
 func (*DatabaseInfo) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{60}
+	return file_keyorix_proto_rawDescGZIP(), []int{63}
 }
 
 func (x *DatabaseInfo) GetStatus() string {
@@ -4534,7 +4823,7 @@ type EncryptionInfo struct {
 
 func (x *EncryptionInfo) Reset() {
 	*x = EncryptionInfo{}
-	mi := &file_keyorix_proto_msgTypes[61]
+	mi := &file_keyorix_proto_msgTypes[64]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4546,7 +4835,7 @@ func (x *EncryptionInfo) String() string {
 func (*EncryptionInfo) ProtoMessage() {}
 
 func (x *EncryptionInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[61]
+	mi := &file_keyorix_proto_msgTypes[64]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4559,7 +4848,7 @@ func (x *EncryptionInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EncryptionInfo.ProtoReflect.Descriptor instead.
 func (*EncryptionInfo) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{61}
+	return file_keyorix_proto_rawDescGZIP(), []int{64}
 }
 
 func (x *EncryptionInfo) GetStatus() string {
@@ -4596,7 +4885,7 @@ type Metrics struct {
 
 func (x *Metrics) Reset() {
 	*x = Metrics{}
-	mi := &file_keyorix_proto_msgTypes[62]
+	mi := &file_keyorix_proto_msgTypes[65]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4608,7 +4897,7 @@ func (x *Metrics) String() string {
 func (*Metrics) ProtoMessage() {}
 
 func (x *Metrics) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[62]
+	mi := &file_keyorix_proto_msgTypes[65]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4621,7 +4910,7 @@ func (x *Metrics) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Metrics.ProtoReflect.Descriptor instead.
 func (*Metrics) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{62}
+	return file_keyorix_proto_rawDescGZIP(), []int{65}
 }
 
 func (x *Metrics) GetRequests() *RequestMetrics {
@@ -4671,7 +4960,7 @@ type RequestMetrics struct {
 
 func (x *RequestMetrics) Reset() {
 	*x = RequestMetrics{}
-	mi := &file_keyorix_proto_msgTypes[63]
+	mi := &file_keyorix_proto_msgTypes[66]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4683,7 +4972,7 @@ func (x *RequestMetrics) String() string {
 func (*RequestMetrics) ProtoMessage() {}
 
 func (x *RequestMetrics) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[63]
+	mi := &file_keyorix_proto_msgTypes[66]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4696,7 +4985,7 @@ func (x *RequestMetrics) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RequestMetrics.ProtoReflect.Descriptor instead.
 func (*RequestMetrics) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{63}
+	return file_keyorix_proto_rawDescGZIP(), []int{66}
 }
 
 func (x *RequestMetrics) GetTotal() uint64 {
@@ -4739,7 +5028,7 @@ type SecretMetrics struct {
 
 func (x *SecretMetrics) Reset() {
 	*x = SecretMetrics{}
-	mi := &file_keyorix_proto_msgTypes[64]
+	mi := &file_keyorix_proto_msgTypes[67]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4751,7 +5040,7 @@ func (x *SecretMetrics) String() string {
 func (*SecretMetrics) ProtoMessage() {}
 
 func (x *SecretMetrics) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[64]
+	mi := &file_keyorix_proto_msgTypes[67]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4764,7 +5053,7 @@ func (x *SecretMetrics) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SecretMetrics.ProtoReflect.Descriptor instead.
 func (*SecretMetrics) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{64}
+	return file_keyorix_proto_rawDescGZIP(), []int{67}
 }
 
 func (x *SecretMetrics) GetTotal() uint64 {
@@ -4806,7 +5095,7 @@ type UserMetrics struct {
 
 func (x *UserMetrics) Reset() {
 	*x = UserMetrics{}
-	mi := &file_keyorix_proto_msgTypes[65]
+	mi := &file_keyorix_proto_msgTypes[68]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4818,7 +5107,7 @@ func (x *UserMetrics) String() string {
 func (*UserMetrics) ProtoMessage() {}
 
 func (x *UserMetrics) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[65]
+	mi := &file_keyorix_proto_msgTypes[68]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4831,7 +5120,7 @@ func (x *UserMetrics) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UserMetrics.ProtoReflect.Descriptor instead.
 func (*UserMetrics) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{65}
+	return file_keyorix_proto_rawDescGZIP(), []int{68}
 }
 
 func (x *UserMetrics) GetTotal() uint64 {
@@ -4867,7 +5156,7 @@ type PerformanceMetrics struct {
 
 func (x *PerformanceMetrics) Reset() {
 	*x = PerformanceMetrics{}
-	mi := &file_keyorix_proto_msgTypes[66]
+	mi := &file_keyorix_proto_msgTypes[69]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4879,7 +5168,7 @@ func (x *PerformanceMetrics) String() string {
 func (*PerformanceMetrics) ProtoMessage() {}
 
 func (x *PerformanceMetrics) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[66]
+	mi := &file_keyorix_proto_msgTypes[69]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4892,7 +5181,7 @@ func (x *PerformanceMetrics) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PerformanceMetrics.ProtoReflect.Descriptor instead.
 func (*PerformanceMetrics) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{66}
+	return file_keyorix_proto_rawDescGZIP(), []int{69}
 }
 
 func (x *PerformanceMetrics) GetAvgResponseTimeMs() float64 {
@@ -4935,7 +5224,7 @@ type SystemMetrics struct {
 
 func (x *SystemMetrics) Reset() {
 	*x = SystemMetrics{}
-	mi := &file_keyorix_proto_msgTypes[67]
+	mi := &file_keyorix_proto_msgTypes[70]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4947,7 +5236,7 @@ func (x *SystemMetrics) String() string {
 func (*SystemMetrics) ProtoMessage() {}
 
 func (x *SystemMetrics) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[67]
+	mi := &file_keyorix_proto_msgTypes[70]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4960,7 +5249,7 @@ func (x *SystemMetrics) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SystemMetrics.ProtoReflect.Descriptor instead.
 func (*SystemMetrics) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{67}
+	return file_keyorix_proto_rawDescGZIP(), []int{70}
 }
 
 func (x *SystemMetrics) GetCpuUsagePercent() float64 {
@@ -5005,7 +5294,7 @@ type Project struct {
 
 func (x *Project) Reset() {
 	*x = Project{}
-	mi := &file_keyorix_proto_msgTypes[68]
+	mi := &file_keyorix_proto_msgTypes[71]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5017,7 +5306,7 @@ func (x *Project) String() string {
 func (*Project) ProtoMessage() {}
 
 func (x *Project) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[68]
+	mi := &file_keyorix_proto_msgTypes[71]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5030,7 +5319,7 @@ func (x *Project) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Project.ProtoReflect.Descriptor instead.
 func (*Project) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{68}
+	return file_keyorix_proto_rawDescGZIP(), []int{71}
 }
 
 func (x *Project) GetId() uint32 {
@@ -5088,7 +5377,7 @@ type Environment struct {
 
 func (x *Environment) Reset() {
 	*x = Environment{}
-	mi := &file_keyorix_proto_msgTypes[69]
+	mi := &file_keyorix_proto_msgTypes[72]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5100,7 +5389,7 @@ func (x *Environment) String() string {
 func (*Environment) ProtoMessage() {}
 
 func (x *Environment) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[69]
+	mi := &file_keyorix_proto_msgTypes[72]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5113,7 +5402,7 @@ func (x *Environment) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Environment.ProtoReflect.Descriptor instead.
 func (*Environment) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{69}
+	return file_keyorix_proto_rawDescGZIP(), []int{72}
 }
 
 func (x *Environment) GetId() uint32 {
@@ -5160,7 +5449,7 @@ type ListProjectsResponse struct {
 
 func (x *ListProjectsResponse) Reset() {
 	*x = ListProjectsResponse{}
-	mi := &file_keyorix_proto_msgTypes[70]
+	mi := &file_keyorix_proto_msgTypes[73]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5172,7 +5461,7 @@ func (x *ListProjectsResponse) String() string {
 func (*ListProjectsResponse) ProtoMessage() {}
 
 func (x *ListProjectsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[70]
+	mi := &file_keyorix_proto_msgTypes[73]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5185,7 +5474,7 @@ func (x *ListProjectsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListProjectsResponse.ProtoReflect.Descriptor instead.
 func (*ListProjectsResponse) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{70}
+	return file_keyorix_proto_rawDescGZIP(), []int{73}
 }
 
 func (x *ListProjectsResponse) GetProjects() []*Project {
@@ -5204,7 +5493,7 @@ type GetProjectRequest struct {
 
 func (x *GetProjectRequest) Reset() {
 	*x = GetProjectRequest{}
-	mi := &file_keyorix_proto_msgTypes[71]
+	mi := &file_keyorix_proto_msgTypes[74]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5216,7 +5505,7 @@ func (x *GetProjectRequest) String() string {
 func (*GetProjectRequest) ProtoMessage() {}
 
 func (x *GetProjectRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[71]
+	mi := &file_keyorix_proto_msgTypes[74]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5229,7 +5518,7 @@ func (x *GetProjectRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetProjectRequest.ProtoReflect.Descriptor instead.
 func (*GetProjectRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{71}
+	return file_keyorix_proto_rawDescGZIP(), []int{74}
 }
 
 func (x *GetProjectRequest) GetId() uint32 {
@@ -5249,7 +5538,7 @@ type CreateProjectRequest struct {
 
 func (x *CreateProjectRequest) Reset() {
 	*x = CreateProjectRequest{}
-	mi := &file_keyorix_proto_msgTypes[72]
+	mi := &file_keyorix_proto_msgTypes[75]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5261,7 +5550,7 @@ func (x *CreateProjectRequest) String() string {
 func (*CreateProjectRequest) ProtoMessage() {}
 
 func (x *CreateProjectRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[72]
+	mi := &file_keyorix_proto_msgTypes[75]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5274,7 +5563,7 @@ func (x *CreateProjectRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateProjectRequest.ProtoReflect.Descriptor instead.
 func (*CreateProjectRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{72}
+	return file_keyorix_proto_rawDescGZIP(), []int{75}
 }
 
 func (x *CreateProjectRequest) GetName() string {
@@ -5303,7 +5592,7 @@ type UpdateProjectRequest struct {
 
 func (x *UpdateProjectRequest) Reset() {
 	*x = UpdateProjectRequest{}
-	mi := &file_keyorix_proto_msgTypes[73]
+	mi := &file_keyorix_proto_msgTypes[76]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5315,7 +5604,7 @@ func (x *UpdateProjectRequest) String() string {
 func (*UpdateProjectRequest) ProtoMessage() {}
 
 func (x *UpdateProjectRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[73]
+	mi := &file_keyorix_proto_msgTypes[76]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5328,7 +5617,7 @@ func (x *UpdateProjectRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateProjectRequest.ProtoReflect.Descriptor instead.
 func (*UpdateProjectRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{73}
+	return file_keyorix_proto_rawDescGZIP(), []int{76}
 }
 
 func (x *UpdateProjectRequest) GetId() uint32 {
@@ -5369,7 +5658,7 @@ type DeleteProjectRequest struct {
 
 func (x *DeleteProjectRequest) Reset() {
 	*x = DeleteProjectRequest{}
-	mi := &file_keyorix_proto_msgTypes[74]
+	mi := &file_keyorix_proto_msgTypes[77]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5381,7 +5670,7 @@ func (x *DeleteProjectRequest) String() string {
 func (*DeleteProjectRequest) ProtoMessage() {}
 
 func (x *DeleteProjectRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[74]
+	mi := &file_keyorix_proto_msgTypes[77]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5394,7 +5683,7 @@ func (x *DeleteProjectRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteProjectRequest.ProtoReflect.Descriptor instead.
 func (*DeleteProjectRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{74}
+	return file_keyorix_proto_rawDescGZIP(), []int{77}
 }
 
 func (x *DeleteProjectRequest) GetId() uint32 {
@@ -5420,7 +5709,7 @@ type ListEnvironmentsRequest struct {
 
 func (x *ListEnvironmentsRequest) Reset() {
 	*x = ListEnvironmentsRequest{}
-	mi := &file_keyorix_proto_msgTypes[75]
+	mi := &file_keyorix_proto_msgTypes[78]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5432,7 +5721,7 @@ func (x *ListEnvironmentsRequest) String() string {
 func (*ListEnvironmentsRequest) ProtoMessage() {}
 
 func (x *ListEnvironmentsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[75]
+	mi := &file_keyorix_proto_msgTypes[78]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5445,7 +5734,7 @@ func (x *ListEnvironmentsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListEnvironmentsRequest.ProtoReflect.Descriptor instead.
 func (*ListEnvironmentsRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{75}
+	return file_keyorix_proto_rawDescGZIP(), []int{78}
 }
 
 func (x *ListEnvironmentsRequest) GetProjectId() uint32 {
@@ -5464,7 +5753,7 @@ type ListEnvironmentsResponse struct {
 
 func (x *ListEnvironmentsResponse) Reset() {
 	*x = ListEnvironmentsResponse{}
-	mi := &file_keyorix_proto_msgTypes[76]
+	mi := &file_keyorix_proto_msgTypes[79]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5476,7 +5765,7 @@ func (x *ListEnvironmentsResponse) String() string {
 func (*ListEnvironmentsResponse) ProtoMessage() {}
 
 func (x *ListEnvironmentsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[76]
+	mi := &file_keyorix_proto_msgTypes[79]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5489,7 +5778,7 @@ func (x *ListEnvironmentsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListEnvironmentsResponse.ProtoReflect.Descriptor instead.
 func (*ListEnvironmentsResponse) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{76}
+	return file_keyorix_proto_rawDescGZIP(), []int{79}
 }
 
 func (x *ListEnvironmentsResponse) GetEnvironments() []*Environment {
@@ -5519,7 +5808,7 @@ type MachineIdentity struct {
 
 func (x *MachineIdentity) Reset() {
 	*x = MachineIdentity{}
-	mi := &file_keyorix_proto_msgTypes[77]
+	mi := &file_keyorix_proto_msgTypes[80]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5531,7 +5820,7 @@ func (x *MachineIdentity) String() string {
 func (*MachineIdentity) ProtoMessage() {}
 
 func (x *MachineIdentity) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[77]
+	mi := &file_keyorix_proto_msgTypes[80]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5544,7 +5833,7 @@ func (x *MachineIdentity) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MachineIdentity.ProtoReflect.Descriptor instead.
 func (*MachineIdentity) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{77}
+	return file_keyorix_proto_rawDescGZIP(), []int{80}
 }
 
 func (x *MachineIdentity) GetId() uint32 {
@@ -5647,7 +5936,7 @@ type MachineToken struct {
 
 func (x *MachineToken) Reset() {
 	*x = MachineToken{}
-	mi := &file_keyorix_proto_msgTypes[78]
+	mi := &file_keyorix_proto_msgTypes[81]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5659,7 +5948,7 @@ func (x *MachineToken) String() string {
 func (*MachineToken) ProtoMessage() {}
 
 func (x *MachineToken) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[78]
+	mi := &file_keyorix_proto_msgTypes[81]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5672,7 +5961,7 @@ func (x *MachineToken) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MachineToken.ProtoReflect.Descriptor instead.
 func (*MachineToken) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{78}
+	return file_keyorix_proto_rawDescGZIP(), []int{81}
 }
 
 func (x *MachineToken) GetId() uint32 {
@@ -5740,7 +6029,7 @@ type ListMachineIdentitiesRequest struct {
 
 func (x *ListMachineIdentitiesRequest) Reset() {
 	*x = ListMachineIdentitiesRequest{}
-	mi := &file_keyorix_proto_msgTypes[79]
+	mi := &file_keyorix_proto_msgTypes[82]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5752,7 +6041,7 @@ func (x *ListMachineIdentitiesRequest) String() string {
 func (*ListMachineIdentitiesRequest) ProtoMessage() {}
 
 func (x *ListMachineIdentitiesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[79]
+	mi := &file_keyorix_proto_msgTypes[82]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5765,7 +6054,7 @@ func (x *ListMachineIdentitiesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListMachineIdentitiesRequest.ProtoReflect.Descriptor instead.
 func (*ListMachineIdentitiesRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{79}
+	return file_keyorix_proto_rawDescGZIP(), []int{82}
 }
 
 func (x *ListMachineIdentitiesRequest) GetProjectId() uint32 {
@@ -5784,7 +6073,7 @@ type ListMachineIdentitiesResponse struct {
 
 func (x *ListMachineIdentitiesResponse) Reset() {
 	*x = ListMachineIdentitiesResponse{}
-	mi := &file_keyorix_proto_msgTypes[80]
+	mi := &file_keyorix_proto_msgTypes[83]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5796,7 +6085,7 @@ func (x *ListMachineIdentitiesResponse) String() string {
 func (*ListMachineIdentitiesResponse) ProtoMessage() {}
 
 func (x *ListMachineIdentitiesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[80]
+	mi := &file_keyorix_proto_msgTypes[83]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5809,7 +6098,7 @@ func (x *ListMachineIdentitiesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListMachineIdentitiesResponse.ProtoReflect.Descriptor instead.
 func (*ListMachineIdentitiesResponse) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{80}
+	return file_keyorix_proto_rawDescGZIP(), []int{83}
 }
 
 func (x *ListMachineIdentitiesResponse) GetMachineIdentities() []*MachineIdentity {
@@ -5832,7 +6121,7 @@ type CreateMachineIdentityRequest struct {
 
 func (x *CreateMachineIdentityRequest) Reset() {
 	*x = CreateMachineIdentityRequest{}
-	mi := &file_keyorix_proto_msgTypes[81]
+	mi := &file_keyorix_proto_msgTypes[84]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5844,7 +6133,7 @@ func (x *CreateMachineIdentityRequest) String() string {
 func (*CreateMachineIdentityRequest) ProtoMessage() {}
 
 func (x *CreateMachineIdentityRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[81]
+	mi := &file_keyorix_proto_msgTypes[84]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5857,7 +6146,7 @@ func (x *CreateMachineIdentityRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateMachineIdentityRequest.ProtoReflect.Descriptor instead.
 func (*CreateMachineIdentityRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{81}
+	return file_keyorix_proto_rawDescGZIP(), []int{84}
 }
 
 func (x *CreateMachineIdentityRequest) GetProjectId() uint32 {
@@ -5906,7 +6195,7 @@ type TransitionMachineIdentityRequest struct {
 
 func (x *TransitionMachineIdentityRequest) Reset() {
 	*x = TransitionMachineIdentityRequest{}
-	mi := &file_keyorix_proto_msgTypes[82]
+	mi := &file_keyorix_proto_msgTypes[85]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5918,7 +6207,7 @@ func (x *TransitionMachineIdentityRequest) String() string {
 func (*TransitionMachineIdentityRequest) ProtoMessage() {}
 
 func (x *TransitionMachineIdentityRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[82]
+	mi := &file_keyorix_proto_msgTypes[85]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5931,7 +6220,7 @@ func (x *TransitionMachineIdentityRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TransitionMachineIdentityRequest.ProtoReflect.Descriptor instead.
 func (*TransitionMachineIdentityRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{82}
+	return file_keyorix_proto_rawDescGZIP(), []int{85}
 }
 
 func (x *TransitionMachineIdentityRequest) GetProjectId() uint32 {
@@ -5966,7 +6255,7 @@ type ClassifyMachineIdentityRequest struct {
 
 func (x *ClassifyMachineIdentityRequest) Reset() {
 	*x = ClassifyMachineIdentityRequest{}
-	mi := &file_keyorix_proto_msgTypes[83]
+	mi := &file_keyorix_proto_msgTypes[86]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5978,7 +6267,7 @@ func (x *ClassifyMachineIdentityRequest) String() string {
 func (*ClassifyMachineIdentityRequest) ProtoMessage() {}
 
 func (x *ClassifyMachineIdentityRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[83]
+	mi := &file_keyorix_proto_msgTypes[86]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5991,7 +6280,7 @@ func (x *ClassifyMachineIdentityRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ClassifyMachineIdentityRequest.ProtoReflect.Descriptor instead.
 func (*ClassifyMachineIdentityRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{83}
+	return file_keyorix_proto_rawDescGZIP(), []int{86}
 }
 
 func (x *ClassifyMachineIdentityRequest) GetProjectId() uint32 {
@@ -6028,7 +6317,7 @@ type IssueMachineTokenRequest struct {
 
 func (x *IssueMachineTokenRequest) Reset() {
 	*x = IssueMachineTokenRequest{}
-	mi := &file_keyorix_proto_msgTypes[84]
+	mi := &file_keyorix_proto_msgTypes[87]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6040,7 +6329,7 @@ func (x *IssueMachineTokenRequest) String() string {
 func (*IssueMachineTokenRequest) ProtoMessage() {}
 
 func (x *IssueMachineTokenRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[84]
+	mi := &file_keyorix_proto_msgTypes[87]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6053,7 +6342,7 @@ func (x *IssueMachineTokenRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IssueMachineTokenRequest.ProtoReflect.Descriptor instead.
 func (*IssueMachineTokenRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{84}
+	return file_keyorix_proto_rawDescGZIP(), []int{87}
 }
 
 func (x *IssueMachineTokenRequest) GetProjectId() uint32 {
@@ -6104,7 +6393,7 @@ type IssueMachineTokenResponse struct {
 
 func (x *IssueMachineTokenResponse) Reset() {
 	*x = IssueMachineTokenResponse{}
-	mi := &file_keyorix_proto_msgTypes[85]
+	mi := &file_keyorix_proto_msgTypes[88]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6116,7 +6405,7 @@ func (x *IssueMachineTokenResponse) String() string {
 func (*IssueMachineTokenResponse) ProtoMessage() {}
 
 func (x *IssueMachineTokenResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[85]
+	mi := &file_keyorix_proto_msgTypes[88]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6129,7 +6418,7 @@ func (x *IssueMachineTokenResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IssueMachineTokenResponse.ProtoReflect.Descriptor instead.
 func (*IssueMachineTokenResponse) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{85}
+	return file_keyorix_proto_rawDescGZIP(), []int{88}
 }
 
 func (x *IssueMachineTokenResponse) GetToken() string {
@@ -6177,7 +6466,7 @@ type ListMachineTokensRequest struct {
 
 func (x *ListMachineTokensRequest) Reset() {
 	*x = ListMachineTokensRequest{}
-	mi := &file_keyorix_proto_msgTypes[86]
+	mi := &file_keyorix_proto_msgTypes[89]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6189,7 +6478,7 @@ func (x *ListMachineTokensRequest) String() string {
 func (*ListMachineTokensRequest) ProtoMessage() {}
 
 func (x *ListMachineTokensRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[86]
+	mi := &file_keyorix_proto_msgTypes[89]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6202,7 +6491,7 @@ func (x *ListMachineTokensRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListMachineTokensRequest.ProtoReflect.Descriptor instead.
 func (*ListMachineTokensRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{86}
+	return file_keyorix_proto_rawDescGZIP(), []int{89}
 }
 
 func (x *ListMachineTokensRequest) GetProjectId() uint32 {
@@ -6228,7 +6517,7 @@ type ListMachineTokensResponse struct {
 
 func (x *ListMachineTokensResponse) Reset() {
 	*x = ListMachineTokensResponse{}
-	mi := &file_keyorix_proto_msgTypes[87]
+	mi := &file_keyorix_proto_msgTypes[90]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6240,7 +6529,7 @@ func (x *ListMachineTokensResponse) String() string {
 func (*ListMachineTokensResponse) ProtoMessage() {}
 
 func (x *ListMachineTokensResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[87]
+	mi := &file_keyorix_proto_msgTypes[90]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6253,7 +6542,7 @@ func (x *ListMachineTokensResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListMachineTokensResponse.ProtoReflect.Descriptor instead.
 func (*ListMachineTokensResponse) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{87}
+	return file_keyorix_proto_rawDescGZIP(), []int{90}
 }
 
 func (x *ListMachineTokensResponse) GetTokens() []*MachineToken {
@@ -6274,7 +6563,7 @@ type RevokeMachineTokenRequest struct {
 
 func (x *RevokeMachineTokenRequest) Reset() {
 	*x = RevokeMachineTokenRequest{}
-	mi := &file_keyorix_proto_msgTypes[88]
+	mi := &file_keyorix_proto_msgTypes[91]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6286,7 +6575,7 @@ func (x *RevokeMachineTokenRequest) String() string {
 func (*RevokeMachineTokenRequest) ProtoMessage() {}
 
 func (x *RevokeMachineTokenRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[88]
+	mi := &file_keyorix_proto_msgTypes[91]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6299,7 +6588,7 @@ func (x *RevokeMachineTokenRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RevokeMachineTokenRequest.ProtoReflect.Descriptor instead.
 func (*RevokeMachineTokenRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{88}
+	return file_keyorix_proto_rawDescGZIP(), []int{91}
 }
 
 func (x *RevokeMachineTokenRequest) GetProjectId() uint32 {
@@ -6335,7 +6624,7 @@ type ClassifyMachineTokenRequest struct {
 
 func (x *ClassifyMachineTokenRequest) Reset() {
 	*x = ClassifyMachineTokenRequest{}
-	mi := &file_keyorix_proto_msgTypes[89]
+	mi := &file_keyorix_proto_msgTypes[92]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6347,7 +6636,7 @@ func (x *ClassifyMachineTokenRequest) String() string {
 func (*ClassifyMachineTokenRequest) ProtoMessage() {}
 
 func (x *ClassifyMachineTokenRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[89]
+	mi := &file_keyorix_proto_msgTypes[92]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6360,7 +6649,7 @@ func (x *ClassifyMachineTokenRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ClassifyMachineTokenRequest.ProtoReflect.Descriptor instead.
 func (*ClassifyMachineTokenRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{89}
+	return file_keyorix_proto_rawDescGZIP(), []int{92}
 }
 
 func (x *ClassifyMachineTokenRequest) GetProjectId() uint32 {
@@ -6410,7 +6699,7 @@ type DynamicSecretConfig struct {
 
 func (x *DynamicSecretConfig) Reset() {
 	*x = DynamicSecretConfig{}
-	mi := &file_keyorix_proto_msgTypes[90]
+	mi := &file_keyorix_proto_msgTypes[93]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6422,7 +6711,7 @@ func (x *DynamicSecretConfig) String() string {
 func (*DynamicSecretConfig) ProtoMessage() {}
 
 func (x *DynamicSecretConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[90]
+	mi := &file_keyorix_proto_msgTypes[93]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6435,7 +6724,7 @@ func (x *DynamicSecretConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DynamicSecretConfig.ProtoReflect.Descriptor instead.
 func (*DynamicSecretConfig) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{90}
+	return file_keyorix_proto_rawDescGZIP(), []int{93}
 }
 
 func (x *DynamicSecretConfig) GetId() uint32 {
@@ -6532,7 +6821,7 @@ type DynamicSecretLease struct {
 
 func (x *DynamicSecretLease) Reset() {
 	*x = DynamicSecretLease{}
-	mi := &file_keyorix_proto_msgTypes[91]
+	mi := &file_keyorix_proto_msgTypes[94]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6544,7 +6833,7 @@ func (x *DynamicSecretLease) String() string {
 func (*DynamicSecretLease) ProtoMessage() {}
 
 func (x *DynamicSecretLease) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[91]
+	mi := &file_keyorix_proto_msgTypes[94]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6557,7 +6846,7 @@ func (x *DynamicSecretLease) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DynamicSecretLease.ProtoReflect.Descriptor instead.
 func (*DynamicSecretLease) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{91}
+	return file_keyorix_proto_rawDescGZIP(), []int{94}
 }
 
 func (x *DynamicSecretLease) GetLeaseId() string {
@@ -6638,7 +6927,7 @@ type IssuedCredential struct {
 
 func (x *IssuedCredential) Reset() {
 	*x = IssuedCredential{}
-	mi := &file_keyorix_proto_msgTypes[92]
+	mi := &file_keyorix_proto_msgTypes[95]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6650,7 +6939,7 @@ func (x *IssuedCredential) String() string {
 func (*IssuedCredential) ProtoMessage() {}
 
 func (x *IssuedCredential) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[92]
+	mi := &file_keyorix_proto_msgTypes[95]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6663,7 +6952,7 @@ func (x *IssuedCredential) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IssuedCredential.ProtoReflect.Descriptor instead.
 func (*IssuedCredential) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{92}
+	return file_keyorix_proto_rawDescGZIP(), []int{95}
 }
 
 func (x *IssuedCredential) GetLeaseId() string {
@@ -6711,7 +7000,7 @@ type ListDynamicConfigsRequest struct {
 
 func (x *ListDynamicConfigsRequest) Reset() {
 	*x = ListDynamicConfigsRequest{}
-	mi := &file_keyorix_proto_msgTypes[93]
+	mi := &file_keyorix_proto_msgTypes[96]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6723,7 +7012,7 @@ func (x *ListDynamicConfigsRequest) String() string {
 func (*ListDynamicConfigsRequest) ProtoMessage() {}
 
 func (x *ListDynamicConfigsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[93]
+	mi := &file_keyorix_proto_msgTypes[96]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6736,7 +7025,7 @@ func (x *ListDynamicConfigsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListDynamicConfigsRequest.ProtoReflect.Descriptor instead.
 func (*ListDynamicConfigsRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{93}
+	return file_keyorix_proto_rawDescGZIP(), []int{96}
 }
 
 func (x *ListDynamicConfigsRequest) GetProjectId() uint32 {
@@ -6762,7 +7051,7 @@ type ListDynamicConfigsResponse struct {
 
 func (x *ListDynamicConfigsResponse) Reset() {
 	*x = ListDynamicConfigsResponse{}
-	mi := &file_keyorix_proto_msgTypes[94]
+	mi := &file_keyorix_proto_msgTypes[97]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6774,7 +7063,7 @@ func (x *ListDynamicConfigsResponse) String() string {
 func (*ListDynamicConfigsResponse) ProtoMessage() {}
 
 func (x *ListDynamicConfigsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[94]
+	mi := &file_keyorix_proto_msgTypes[97]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6787,7 +7076,7 @@ func (x *ListDynamicConfigsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListDynamicConfigsResponse.ProtoReflect.Descriptor instead.
 func (*ListDynamicConfigsResponse) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{94}
+	return file_keyorix_proto_rawDescGZIP(), []int{97}
 }
 
 func (x *ListDynamicConfigsResponse) GetConfigs() []*DynamicSecretConfig {
@@ -6806,7 +7095,7 @@ type GetDynamicConfigRequest struct {
 
 func (x *GetDynamicConfigRequest) Reset() {
 	*x = GetDynamicConfigRequest{}
-	mi := &file_keyorix_proto_msgTypes[95]
+	mi := &file_keyorix_proto_msgTypes[98]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6818,7 +7107,7 @@ func (x *GetDynamicConfigRequest) String() string {
 func (*GetDynamicConfigRequest) ProtoMessage() {}
 
 func (x *GetDynamicConfigRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[95]
+	mi := &file_keyorix_proto_msgTypes[98]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6831,7 +7120,7 @@ func (x *GetDynamicConfigRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetDynamicConfigRequest.ProtoReflect.Descriptor instead.
 func (*GetDynamicConfigRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{95}
+	return file_keyorix_proto_rawDescGZIP(), []int{98}
 }
 
 func (x *GetDynamicConfigRequest) GetId() uint32 {
@@ -6858,7 +7147,7 @@ type CreateDynamicConfigRequest struct {
 
 func (x *CreateDynamicConfigRequest) Reset() {
 	*x = CreateDynamicConfigRequest{}
-	mi := &file_keyorix_proto_msgTypes[96]
+	mi := &file_keyorix_proto_msgTypes[99]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6870,7 +7159,7 @@ func (x *CreateDynamicConfigRequest) String() string {
 func (*CreateDynamicConfigRequest) ProtoMessage() {}
 
 func (x *CreateDynamicConfigRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[96]
+	mi := &file_keyorix_proto_msgTypes[99]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6883,7 +7172,7 @@ func (x *CreateDynamicConfigRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateDynamicConfigRequest.ProtoReflect.Descriptor instead.
 func (*CreateDynamicConfigRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{96}
+	return file_keyorix_proto_rawDescGZIP(), []int{99}
 }
 
 func (x *CreateDynamicConfigRequest) GetName() string {
@@ -6959,7 +7248,7 @@ type ClassifyDynamicConfigRequest struct {
 
 func (x *ClassifyDynamicConfigRequest) Reset() {
 	*x = ClassifyDynamicConfigRequest{}
-	mi := &file_keyorix_proto_msgTypes[97]
+	mi := &file_keyorix_proto_msgTypes[100]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6971,7 +7260,7 @@ func (x *ClassifyDynamicConfigRequest) String() string {
 func (*ClassifyDynamicConfigRequest) ProtoMessage() {}
 
 func (x *ClassifyDynamicConfigRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[97]
+	mi := &file_keyorix_proto_msgTypes[100]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6984,7 +7273,7 @@ func (x *ClassifyDynamicConfigRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ClassifyDynamicConfigRequest.ProtoReflect.Descriptor instead.
 func (*ClassifyDynamicConfigRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{97}
+	return file_keyorix_proto_rawDescGZIP(), []int{100}
 }
 
 func (x *ClassifyDynamicConfigRequest) GetId() uint32 {
@@ -7011,7 +7300,7 @@ type IssueLeaseRequest struct {
 
 func (x *IssueLeaseRequest) Reset() {
 	*x = IssueLeaseRequest{}
-	mi := &file_keyorix_proto_msgTypes[98]
+	mi := &file_keyorix_proto_msgTypes[101]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7023,7 +7312,7 @@ func (x *IssueLeaseRequest) String() string {
 func (*IssueLeaseRequest) ProtoMessage() {}
 
 func (x *IssueLeaseRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[98]
+	mi := &file_keyorix_proto_msgTypes[101]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7036,7 +7325,7 @@ func (x *IssueLeaseRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IssueLeaseRequest.ProtoReflect.Descriptor instead.
 func (*IssueLeaseRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{98}
+	return file_keyorix_proto_rawDescGZIP(), []int{101}
 }
 
 func (x *IssueLeaseRequest) GetConfigId() uint32 {
@@ -7062,7 +7351,7 @@ type ListLeasesRequest struct {
 
 func (x *ListLeasesRequest) Reset() {
 	*x = ListLeasesRequest{}
-	mi := &file_keyorix_proto_msgTypes[99]
+	mi := &file_keyorix_proto_msgTypes[102]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7074,7 +7363,7 @@ func (x *ListLeasesRequest) String() string {
 func (*ListLeasesRequest) ProtoMessage() {}
 
 func (x *ListLeasesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[99]
+	mi := &file_keyorix_proto_msgTypes[102]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7087,7 +7376,7 @@ func (x *ListLeasesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListLeasesRequest.ProtoReflect.Descriptor instead.
 func (*ListLeasesRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{99}
+	return file_keyorix_proto_rawDescGZIP(), []int{102}
 }
 
 func (x *ListLeasesRequest) GetConfigId() uint32 {
@@ -7106,7 +7395,7 @@ type ListLeasesResponse struct {
 
 func (x *ListLeasesResponse) Reset() {
 	*x = ListLeasesResponse{}
-	mi := &file_keyorix_proto_msgTypes[100]
+	mi := &file_keyorix_proto_msgTypes[103]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7118,7 +7407,7 @@ func (x *ListLeasesResponse) String() string {
 func (*ListLeasesResponse) ProtoMessage() {}
 
 func (x *ListLeasesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[100]
+	mi := &file_keyorix_proto_msgTypes[103]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7131,7 +7420,7 @@ func (x *ListLeasesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListLeasesResponse.ProtoReflect.Descriptor instead.
 func (*ListLeasesResponse) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{100}
+	return file_keyorix_proto_rawDescGZIP(), []int{103}
 }
 
 func (x *ListLeasesResponse) GetLeases() []*DynamicSecretLease {
@@ -7150,7 +7439,7 @@ type RevokeLeaseRequest struct {
 
 func (x *RevokeLeaseRequest) Reset() {
 	*x = RevokeLeaseRequest{}
-	mi := &file_keyorix_proto_msgTypes[101]
+	mi := &file_keyorix_proto_msgTypes[104]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7162,7 +7451,7 @@ func (x *RevokeLeaseRequest) String() string {
 func (*RevokeLeaseRequest) ProtoMessage() {}
 
 func (x *RevokeLeaseRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[101]
+	mi := &file_keyorix_proto_msgTypes[104]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7175,7 +7464,7 @@ func (x *RevokeLeaseRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RevokeLeaseRequest.ProtoReflect.Descriptor instead.
 func (*RevokeLeaseRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{101}
+	return file_keyorix_proto_rawDescGZIP(), []int{104}
 }
 
 func (x *RevokeLeaseRequest) GetLeaseId() string {
@@ -7195,7 +7484,7 @@ type RenewLeaseRequest struct {
 
 func (x *RenewLeaseRequest) Reset() {
 	*x = RenewLeaseRequest{}
-	mi := &file_keyorix_proto_msgTypes[102]
+	mi := &file_keyorix_proto_msgTypes[105]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7207,7 +7496,7 @@ func (x *RenewLeaseRequest) String() string {
 func (*RenewLeaseRequest) ProtoMessage() {}
 
 func (x *RenewLeaseRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[102]
+	mi := &file_keyorix_proto_msgTypes[105]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7220,7 +7509,7 @@ func (x *RenewLeaseRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RenewLeaseRequest.ProtoReflect.Descriptor instead.
 func (*RenewLeaseRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{102}
+	return file_keyorix_proto_rawDescGZIP(), []int{105}
 }
 
 func (x *RenewLeaseRequest) GetLeaseId() string {
@@ -7247,7 +7536,7 @@ type RenewLeaseResponse struct {
 
 func (x *RenewLeaseResponse) Reset() {
 	*x = RenewLeaseResponse{}
-	mi := &file_keyorix_proto_msgTypes[103]
+	mi := &file_keyorix_proto_msgTypes[106]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7259,7 +7548,7 @@ func (x *RenewLeaseResponse) String() string {
 func (*RenewLeaseResponse) ProtoMessage() {}
 
 func (x *RenewLeaseResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[103]
+	mi := &file_keyorix_proto_msgTypes[106]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7272,7 +7561,7 @@ func (x *RenewLeaseResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RenewLeaseResponse.ProtoReflect.Descriptor instead.
 func (*RenewLeaseResponse) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{103}
+	return file_keyorix_proto_rawDescGZIP(), []int{106}
 }
 
 func (x *RenewLeaseResponse) GetLeaseId() string {
@@ -7298,7 +7587,7 @@ type RevokeAllLeasesRequest struct {
 
 func (x *RevokeAllLeasesRequest) Reset() {
 	*x = RevokeAllLeasesRequest{}
-	mi := &file_keyorix_proto_msgTypes[104]
+	mi := &file_keyorix_proto_msgTypes[107]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7310,7 +7599,7 @@ func (x *RevokeAllLeasesRequest) String() string {
 func (*RevokeAllLeasesRequest) ProtoMessage() {}
 
 func (x *RevokeAllLeasesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[104]
+	mi := &file_keyorix_proto_msgTypes[107]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7323,7 +7612,7 @@ func (x *RevokeAllLeasesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RevokeAllLeasesRequest.ProtoReflect.Descriptor instead.
 func (*RevokeAllLeasesRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{104}
+	return file_keyorix_proto_rawDescGZIP(), []int{107}
 }
 
 func (x *RevokeAllLeasesRequest) GetConfigId() uint32 {
@@ -7343,7 +7632,7 @@ type RevokeAllLeasesResponse struct {
 
 func (x *RevokeAllLeasesResponse) Reset() {
 	*x = RevokeAllLeasesResponse{}
-	mi := &file_keyorix_proto_msgTypes[105]
+	mi := &file_keyorix_proto_msgTypes[108]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7355,7 +7644,7 @@ func (x *RevokeAllLeasesResponse) String() string {
 func (*RevokeAllLeasesResponse) ProtoMessage() {}
 
 func (x *RevokeAllLeasesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[105]
+	mi := &file_keyorix_proto_msgTypes[108]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7368,7 +7657,7 @@ func (x *RevokeAllLeasesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RevokeAllLeasesResponse.ProtoReflect.Descriptor instead.
 func (*RevokeAllLeasesResponse) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{105}
+	return file_keyorix_proto_rawDescGZIP(), []int{108}
 }
 
 func (x *RevokeAllLeasesResponse) GetRevoked() uint32 {
@@ -7397,7 +7686,7 @@ type AuditIntegrityPosture struct {
 
 func (x *AuditIntegrityPosture) Reset() {
 	*x = AuditIntegrityPosture{}
-	mi := &file_keyorix_proto_msgTypes[106]
+	mi := &file_keyorix_proto_msgTypes[109]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7409,7 +7698,7 @@ func (x *AuditIntegrityPosture) String() string {
 func (*AuditIntegrityPosture) ProtoMessage() {}
 
 func (x *AuditIntegrityPosture) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[106]
+	mi := &file_keyorix_proto_msgTypes[109]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7422,7 +7711,7 @@ func (x *AuditIntegrityPosture) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AuditIntegrityPosture.ProtoReflect.Descriptor instead.
 func (*AuditIntegrityPosture) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{106}
+	return file_keyorix_proto_rawDescGZIP(), []int{109}
 }
 
 func (x *AuditIntegrityPosture) GetChainVerified() bool {
@@ -7469,7 +7758,7 @@ type AccessGovernancePosture struct {
 
 func (x *AccessGovernancePosture) Reset() {
 	*x = AccessGovernancePosture{}
-	mi := &file_keyorix_proto_msgTypes[107]
+	mi := &file_keyorix_proto_msgTypes[110]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7481,7 +7770,7 @@ func (x *AccessGovernancePosture) String() string {
 func (*AccessGovernancePosture) ProtoMessage() {}
 
 func (x *AccessGovernancePosture) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[107]
+	mi := &file_keyorix_proto_msgTypes[110]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7494,7 +7783,7 @@ func (x *AccessGovernancePosture) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AccessGovernancePosture.ProtoReflect.Descriptor instead.
 func (*AccessGovernancePosture) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{107}
+	return file_keyorix_proto_rawDescGZIP(), []int{110}
 }
 
 func (x *AccessGovernancePosture) GetProjects() int32 {
@@ -7564,7 +7853,7 @@ type RotationPosture struct {
 
 func (x *RotationPosture) Reset() {
 	*x = RotationPosture{}
-	mi := &file_keyorix_proto_msgTypes[108]
+	mi := &file_keyorix_proto_msgTypes[111]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7576,7 +7865,7 @@ func (x *RotationPosture) String() string {
 func (*RotationPosture) ProtoMessage() {}
 
 func (x *RotationPosture) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[108]
+	mi := &file_keyorix_proto_msgTypes[111]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7589,7 +7878,7 @@ func (x *RotationPosture) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RotationPosture.ProtoReflect.Descriptor instead.
 func (*RotationPosture) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{108}
+	return file_keyorix_proto_rawDescGZIP(), []int{111}
 }
 
 func (x *RotationPosture) GetCoveredSecrets() int32 {
@@ -7624,7 +7913,7 @@ type IdentityPosture struct {
 
 func (x *IdentityPosture) Reset() {
 	*x = IdentityPosture{}
-	mi := &file_keyorix_proto_msgTypes[109]
+	mi := &file_keyorix_proto_msgTypes[112]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7636,7 +7925,7 @@ func (x *IdentityPosture) String() string {
 func (*IdentityPosture) ProtoMessage() {}
 
 func (x *IdentityPosture) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[109]
+	mi := &file_keyorix_proto_msgTypes[112]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7649,7 +7938,7 @@ func (x *IdentityPosture) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IdentityPosture.ProtoReflect.Descriptor instead.
 func (*IdentityPosture) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{109}
+	return file_keyorix_proto_rawDescGZIP(), []int{112}
 }
 
 func (x *IdentityPosture) GetActiveUsers() int32 {
@@ -7683,7 +7972,7 @@ type EmergencyAccessPosture struct {
 
 func (x *EmergencyAccessPosture) Reset() {
 	*x = EmergencyAccessPosture{}
-	mi := &file_keyorix_proto_msgTypes[110]
+	mi := &file_keyorix_proto_msgTypes[113]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7695,7 +7984,7 @@ func (x *EmergencyAccessPosture) String() string {
 func (*EmergencyAccessPosture) ProtoMessage() {}
 
 func (x *EmergencyAccessPosture) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[110]
+	mi := &file_keyorix_proto_msgTypes[113]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7708,7 +7997,7 @@ func (x *EmergencyAccessPosture) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EmergencyAccessPosture.ProtoReflect.Descriptor instead.
 func (*EmergencyAccessPosture) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{110}
+	return file_keyorix_proto_rawDescGZIP(), []int{113}
 }
 
 func (x *EmergencyAccessPosture) GetActiveActivations() int32 {
@@ -7739,7 +8028,7 @@ type ClassificationCounts struct {
 
 func (x *ClassificationCounts) Reset() {
 	*x = ClassificationCounts{}
-	mi := &file_keyorix_proto_msgTypes[111]
+	mi := &file_keyorix_proto_msgTypes[114]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7751,7 +8040,7 @@ func (x *ClassificationCounts) String() string {
 func (*ClassificationCounts) ProtoMessage() {}
 
 func (x *ClassificationCounts) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[111]
+	mi := &file_keyorix_proto_msgTypes[114]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7764,7 +8053,7 @@ func (x *ClassificationCounts) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ClassificationCounts.ProtoReflect.Descriptor instead.
 func (*ClassificationCounts) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{111}
+	return file_keyorix_proto_rawDescGZIP(), []int{114}
 }
 
 func (x *ClassificationCounts) GetTotal() int32 {
@@ -7826,7 +8115,7 @@ type ClassificationPosture struct {
 
 func (x *ClassificationPosture) Reset() {
 	*x = ClassificationPosture{}
-	mi := &file_keyorix_proto_msgTypes[112]
+	mi := &file_keyorix_proto_msgTypes[115]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7838,7 +8127,7 @@ func (x *ClassificationPosture) String() string {
 func (*ClassificationPosture) ProtoMessage() {}
 
 func (x *ClassificationPosture) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[112]
+	mi := &file_keyorix_proto_msgTypes[115]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7851,7 +8140,7 @@ func (x *ClassificationPosture) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ClassificationPosture.ProtoReflect.Descriptor instead.
 func (*ClassificationPosture) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{112}
+	return file_keyorix_proto_rawDescGZIP(), []int{115}
 }
 
 func (x *ClassificationPosture) GetTotalSecrets() int32 {
@@ -7927,7 +8216,7 @@ type AnomaliesPosture struct {
 
 func (x *AnomaliesPosture) Reset() {
 	*x = AnomaliesPosture{}
-	mi := &file_keyorix_proto_msgTypes[113]
+	mi := &file_keyorix_proto_msgTypes[116]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7939,7 +8228,7 @@ func (x *AnomaliesPosture) String() string {
 func (*AnomaliesPosture) ProtoMessage() {}
 
 func (x *AnomaliesPosture) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[113]
+	mi := &file_keyorix_proto_msgTypes[116]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7952,7 +8241,7 @@ func (x *AnomaliesPosture) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AnomaliesPosture.ProtoReflect.Descriptor instead.
 func (*AnomaliesPosture) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{113}
+	return file_keyorix_proto_rawDescGZIP(), []int{116}
 }
 
 func (x *AnomaliesPosture) GetUnacknowledged() int32 {
@@ -7980,7 +8269,7 @@ type LegalHoldPosture struct {
 
 func (x *LegalHoldPosture) Reset() {
 	*x = LegalHoldPosture{}
-	mi := &file_keyorix_proto_msgTypes[114]
+	mi := &file_keyorix_proto_msgTypes[117]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7992,7 +8281,7 @@ func (x *LegalHoldPosture) String() string {
 func (*LegalHoldPosture) ProtoMessage() {}
 
 func (x *LegalHoldPosture) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[114]
+	mi := &file_keyorix_proto_msgTypes[117]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8005,7 +8294,7 @@ func (x *LegalHoldPosture) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LegalHoldPosture.ProtoReflect.Descriptor instead.
 func (*LegalHoldPosture) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{114}
+	return file_keyorix_proto_rawDescGZIP(), []int{117}
 }
 
 func (x *LegalHoldPosture) GetActive() bool {
@@ -8042,7 +8331,7 @@ type RetentionPosture struct {
 
 func (x *RetentionPosture) Reset() {
 	*x = RetentionPosture{}
-	mi := &file_keyorix_proto_msgTypes[115]
+	mi := &file_keyorix_proto_msgTypes[118]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8054,7 +8343,7 @@ func (x *RetentionPosture) String() string {
 func (*RetentionPosture) ProtoMessage() {}
 
 func (x *RetentionPosture) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[115]
+	mi := &file_keyorix_proto_msgTypes[118]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8067,7 +8356,7 @@ func (x *RetentionPosture) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RetentionPosture.ProtoReflect.Descriptor instead.
 func (*RetentionPosture) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{115}
+	return file_keyorix_proto_rawDescGZIP(), []int{118}
 }
 
 func (x *RetentionPosture) GetEnabled() bool {
@@ -8115,7 +8404,7 @@ type RiskPosture struct {
 
 func (x *RiskPosture) Reset() {
 	*x = RiskPosture{}
-	mi := &file_keyorix_proto_msgTypes[116]
+	mi := &file_keyorix_proto_msgTypes[119]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8127,7 +8416,7 @@ func (x *RiskPosture) String() string {
 func (*RiskPosture) ProtoMessage() {}
 
 func (x *RiskPosture) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[116]
+	mi := &file_keyorix_proto_msgTypes[119]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8140,7 +8429,7 @@ func (x *RiskPosture) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RiskPosture.ProtoReflect.Descriptor instead.
 func (*RiskPosture) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{116}
+	return file_keyorix_proto_rawDescGZIP(), []int{119}
 }
 
 func (x *RiskPosture) GetActiveExceptions() int32 {
@@ -8176,7 +8465,7 @@ type CompliancePosture struct {
 
 func (x *CompliancePosture) Reset() {
 	*x = CompliancePosture{}
-	mi := &file_keyorix_proto_msgTypes[117]
+	mi := &file_keyorix_proto_msgTypes[120]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8188,7 +8477,7 @@ func (x *CompliancePosture) String() string {
 func (*CompliancePosture) ProtoMessage() {}
 
 func (x *CompliancePosture) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[117]
+	mi := &file_keyorix_proto_msgTypes[120]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8201,7 +8490,7 @@ func (x *CompliancePosture) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CompliancePosture.ProtoReflect.Descriptor instead.
 func (*CompliancePosture) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{117}
+	return file_keyorix_proto_rawDescGZIP(), []int{120}
 }
 
 func (x *CompliancePosture) GetGeneratedAt() *timestamppb.Timestamp {
@@ -8295,7 +8584,7 @@ type FrameworkRefs struct {
 
 func (x *FrameworkRefs) Reset() {
 	*x = FrameworkRefs{}
-	mi := &file_keyorix_proto_msgTypes[118]
+	mi := &file_keyorix_proto_msgTypes[121]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8307,7 +8596,7 @@ func (x *FrameworkRefs) String() string {
 func (*FrameworkRefs) ProtoMessage() {}
 
 func (x *FrameworkRefs) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[118]
+	mi := &file_keyorix_proto_msgTypes[121]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8320,7 +8609,7 @@ func (x *FrameworkRefs) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FrameworkRefs.ProtoReflect.Descriptor instead.
 func (*FrameworkRefs) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{118}
+	return file_keyorix_proto_rawDescGZIP(), []int{121}
 }
 
 func (x *FrameworkRefs) GetIso_27001() []string {
@@ -8372,7 +8661,7 @@ type ControlState struct {
 
 func (x *ControlState) Reset() {
 	*x = ControlState{}
-	mi := &file_keyorix_proto_msgTypes[119]
+	mi := &file_keyorix_proto_msgTypes[122]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8384,7 +8673,7 @@ func (x *ControlState) String() string {
 func (*ControlState) ProtoMessage() {}
 
 func (x *ControlState) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[119]
+	mi := &file_keyorix_proto_msgTypes[122]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8397,7 +8686,7 @@ func (x *ControlState) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ControlState.ProtoReflect.Descriptor instead.
 func (*ControlState) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{119}
+	return file_keyorix_proto_rawDescGZIP(), []int{122}
 }
 
 func (x *ControlState) GetId() string {
@@ -8454,7 +8743,7 @@ type ControlsSummary struct {
 
 func (x *ControlsSummary) Reset() {
 	*x = ControlsSummary{}
-	mi := &file_keyorix_proto_msgTypes[120]
+	mi := &file_keyorix_proto_msgTypes[123]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8466,7 +8755,7 @@ func (x *ControlsSummary) String() string {
 func (*ControlsSummary) ProtoMessage() {}
 
 func (x *ControlsSummary) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[120]
+	mi := &file_keyorix_proto_msgTypes[123]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8479,7 +8768,7 @@ func (x *ControlsSummary) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ControlsSummary.ProtoReflect.Descriptor instead.
 func (*ControlsSummary) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{120}
+	return file_keyorix_proto_rawDescGZIP(), []int{123}
 }
 
 func (x *ControlsSummary) GetTotal() int32 {
@@ -8521,7 +8810,7 @@ type ComplianceControls struct {
 
 func (x *ComplianceControls) Reset() {
 	*x = ComplianceControls{}
-	mi := &file_keyorix_proto_msgTypes[121]
+	mi := &file_keyorix_proto_msgTypes[124]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8533,7 +8822,7 @@ func (x *ComplianceControls) String() string {
 func (*ComplianceControls) ProtoMessage() {}
 
 func (x *ComplianceControls) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[121]
+	mi := &file_keyorix_proto_msgTypes[124]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8546,7 +8835,7 @@ func (x *ComplianceControls) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ComplianceControls.ProtoReflect.Descriptor instead.
 func (*ComplianceControls) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{121}
+	return file_keyorix_proto_rawDescGZIP(), []int{124}
 }
 
 func (x *ComplianceControls) GetGeneratedAt() *timestamppb.Timestamp {
@@ -8579,7 +8868,7 @@ type ConnectorList struct {
 
 func (x *ConnectorList) Reset() {
 	*x = ConnectorList{}
-	mi := &file_keyorix_proto_msgTypes[122]
+	mi := &file_keyorix_proto_msgTypes[125]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8591,7 +8880,7 @@ func (x *ConnectorList) String() string {
 func (*ConnectorList) ProtoMessage() {}
 
 func (x *ConnectorList) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[122]
+	mi := &file_keyorix_proto_msgTypes[125]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8604,7 +8893,7 @@ func (x *ConnectorList) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConnectorList.ProtoReflect.Descriptor instead.
 func (*ConnectorList) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{122}
+	return file_keyorix_proto_rawDescGZIP(), []int{125}
 }
 
 func (x *ConnectorList) GetConnectors() []string {
@@ -8624,7 +8913,7 @@ type ReadFederatedSecretRequest struct {
 
 func (x *ReadFederatedSecretRequest) Reset() {
 	*x = ReadFederatedSecretRequest{}
-	mi := &file_keyorix_proto_msgTypes[123]
+	mi := &file_keyorix_proto_msgTypes[126]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8636,7 +8925,7 @@ func (x *ReadFederatedSecretRequest) String() string {
 func (*ReadFederatedSecretRequest) ProtoMessage() {}
 
 func (x *ReadFederatedSecretRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[123]
+	mi := &file_keyorix_proto_msgTypes[126]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8649,7 +8938,7 @@ func (x *ReadFederatedSecretRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReadFederatedSecretRequest.ProtoReflect.Descriptor instead.
 func (*ReadFederatedSecretRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{123}
+	return file_keyorix_proto_rawDescGZIP(), []int{126}
 }
 
 func (x *ReadFederatedSecretRequest) GetConnector() string {
@@ -8677,7 +8966,7 @@ type FederatedSecretValue struct {
 
 func (x *FederatedSecretValue) Reset() {
 	*x = FederatedSecretValue{}
-	mi := &file_keyorix_proto_msgTypes[124]
+	mi := &file_keyorix_proto_msgTypes[127]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8689,7 +8978,7 @@ func (x *FederatedSecretValue) String() string {
 func (*FederatedSecretValue) ProtoMessage() {}
 
 func (x *FederatedSecretValue) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[124]
+	mi := &file_keyorix_proto_msgTypes[127]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8702,7 +8991,7 @@ func (x *FederatedSecretValue) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FederatedSecretValue.ProtoReflect.Descriptor instead.
 func (*FederatedSecretValue) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{124}
+	return file_keyorix_proto_rawDescGZIP(), []int{127}
 }
 
 func (x *FederatedSecretValue) GetConnector() string {
@@ -8738,7 +9027,7 @@ type ConnectRefGrant struct {
 
 func (x *ConnectRefGrant) Reset() {
 	*x = ConnectRefGrant{}
-	mi := &file_keyorix_proto_msgTypes[125]
+	mi := &file_keyorix_proto_msgTypes[128]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8750,7 +9039,7 @@ func (x *ConnectRefGrant) String() string {
 func (*ConnectRefGrant) ProtoMessage() {}
 
 func (x *ConnectRefGrant) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[125]
+	mi := &file_keyorix_proto_msgTypes[128]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8763,7 +9052,7 @@ func (x *ConnectRefGrant) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConnectRefGrant.ProtoReflect.Descriptor instead.
 func (*ConnectRefGrant) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{125}
+	return file_keyorix_proto_rawDescGZIP(), []int{128}
 }
 
 func (x *ConnectRefGrant) GetId() uint32 {
@@ -8803,7 +9092,7 @@ type ConnectRefGrantList struct {
 
 func (x *ConnectRefGrantList) Reset() {
 	*x = ConnectRefGrantList{}
-	mi := &file_keyorix_proto_msgTypes[126]
+	mi := &file_keyorix_proto_msgTypes[129]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8815,7 +9104,7 @@ func (x *ConnectRefGrantList) String() string {
 func (*ConnectRefGrantList) ProtoMessage() {}
 
 func (x *ConnectRefGrantList) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[126]
+	mi := &file_keyorix_proto_msgTypes[129]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8828,7 +9117,7 @@ func (x *ConnectRefGrantList) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConnectRefGrantList.ProtoReflect.Descriptor instead.
 func (*ConnectRefGrantList) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{126}
+	return file_keyorix_proto_rawDescGZIP(), []int{129}
 }
 
 func (x *ConnectRefGrantList) GetGrants() []*ConnectRefGrant {
@@ -8849,7 +9138,7 @@ type CreateConnectRefGrantRequest struct {
 
 func (x *CreateConnectRefGrantRequest) Reset() {
 	*x = CreateConnectRefGrantRequest{}
-	mi := &file_keyorix_proto_msgTypes[127]
+	mi := &file_keyorix_proto_msgTypes[130]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8861,7 +9150,7 @@ func (x *CreateConnectRefGrantRequest) String() string {
 func (*CreateConnectRefGrantRequest) ProtoMessage() {}
 
 func (x *CreateConnectRefGrantRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[127]
+	mi := &file_keyorix_proto_msgTypes[130]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8874,7 +9163,7 @@ func (x *CreateConnectRefGrantRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateConnectRefGrantRequest.ProtoReflect.Descriptor instead.
 func (*CreateConnectRefGrantRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{127}
+	return file_keyorix_proto_rawDescGZIP(), []int{130}
 }
 
 func (x *CreateConnectRefGrantRequest) GetRoleId() uint32 {
@@ -8907,7 +9196,7 @@ type DeleteConnectRefGrantRequest struct {
 
 func (x *DeleteConnectRefGrantRequest) Reset() {
 	*x = DeleteConnectRefGrantRequest{}
-	mi := &file_keyorix_proto_msgTypes[128]
+	mi := &file_keyorix_proto_msgTypes[131]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8919,7 +9208,7 @@ func (x *DeleteConnectRefGrantRequest) String() string {
 func (*DeleteConnectRefGrantRequest) ProtoMessage() {}
 
 func (x *DeleteConnectRefGrantRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[128]
+	mi := &file_keyorix_proto_msgTypes[131]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8932,7 +9221,7 @@ func (x *DeleteConnectRefGrantRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteConnectRefGrantRequest.ProtoReflect.Descriptor instead.
 func (*DeleteConnectRefGrantRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{128}
+	return file_keyorix_proto_rawDescGZIP(), []int{131}
 }
 
 func (x *DeleteConnectRefGrantRequest) GetId() uint32 {
@@ -9382,7 +9671,38 @@ const file_keyorix_proto_rawDesc = "" +
 	"\n" +
 	"\b_user_idB\r\n" +
 	"\v_project_idB\v\n" +
-	"\t_after_id\"\xa9\x02\n" +
+	"\t_after_id\"\xe2\x02\n" +
+	"\x18VerifyAuditChainResponse\x12\x14\n" +
+	"\x05valid\x18\x01 \x01(\bR\x05valid\x12%\n" +
+	"\x0echained_events\x18\x02 \x01(\x03R\rchainedEvents\x12)\n" +
+	"\x10unchained_events\x18\x03 \x01(\x03R\x0funchainedEvents\x12\x1b\n" +
+	"\thead_hash\x18\x04 \x01(\tR\bheadHash\x12\x17\n" +
+	"\ahead_id\x18\x05 \x01(\rR\x06headId\x12\"\n" +
+	"\fcheckpointed\x18\x06 \x01(\bR\fcheckpointed\x12+\n" +
+	"\x0ffirst_broken_id\x18\a \x01(\rH\x00R\rfirstBrokenId\x88\x01\x01\x12\x16\n" +
+	"\x06reason\x18\b \x01(\tR\x06reason\x12+\n" +
+	"\x11checkpoint_reason\x18\t \x01(\tR\x10checkpointReasonB\x12\n" +
+	"\x10_first_broken_id\"\xa7\x02\n" +
+	"\x1cWriteAuditCheckpointResponse\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\rR\x02id\x12%\n" +
+	"\x0echained_events\x18\x02 \x01(\x03R\rchainedEvents\x12\x17\n" +
+	"\ahead_id\x18\x03 \x01(\rR\x06headId\x12\x1b\n" +
+	"\thead_hash\x18\x04 \x01(\tR\bheadHash\x12\x1f\n" +
+	"\vkey_version\x18\x05 \x01(\tR\n" +
+	"keyVersion\x12@\n" +
+	"\vanchored_at\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampH\x00R\n" +
+	"anchoredAt\x88\x01\x01\x12'\n" +
+	"\x0fanchor_provider\x18\a \x01(\tR\x0eanchorProviderB\x0e\n" +
+	"\f_anchored_at\"\xe7\x02\n" +
+	"\x19GetAuditRetentionResponse\x12)\n" +
+	"\x10retention_policy\x18\x01 \x01(\tR\x0fretentionPolicy\x12!\n" +
+	"\ftotal_events\x18\x02 \x01(\x03R\vtotalEvents\x12B\n" +
+	"\foldest_event\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampH\x00R\voldestEvent\x88\x01\x01\x12B\n" +
+	"\fnewest_event\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampH\x01R\vnewestEvent\x88\x01\x01\x12#\n" +
+	"\rcoverage_days\x18\x05 \x01(\x03R\fcoverageDays\x12-\n" +
+	"\x13meets_nis2_12_month\x18\x06 \x01(\bR\x10meetsNis212MonthB\x0f\n" +
+	"\r_oldest_eventB\x0f\n" +
+	"\r_newest_event\"\xa9\x02\n" +
 	"\vShareRecord\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\rR\x02id\x12\x1b\n" +
 	"\tsecret_id\x18\x02 \x01(\rR\bsecretId\x12\x19\n" +
@@ -9883,11 +10203,14 @@ const file_keyorix_proto_rawDesc = "" +
 	"AssignRole\x12\x1d.keyorix.v1.AssignRoleRequest\x1a\x1a.keyorix.v1.RoleAssignment\x12C\n" +
 	"\n" +
 	"RemoveRole\x12\x1d.keyorix.v1.RemoveRoleRequest\x1a\x16.google.protobuf.Empty\x12Q\n" +
-	"\fGetUserRoles\x12\x1f.keyorix.v1.GetUserRolesRequest\x1a .keyorix.v1.GetUserRolesResponse2\x8f\x02\n" +
+	"\fGetUserRoles\x12\x1f.keyorix.v1.GetUserRolesRequest\x1a .keyorix.v1.GetUserRolesResponse2\x8f\x04\n" +
 	"\fAuditService\x12Q\n" +
 	"\fGetAuditLogs\x12\x1f.keyorix.v1.GetAuditLogsRequest\x1a .keyorix.v1.GetAuditLogsResponse\x12]\n" +
 	"\x10GetRBACAuditLogs\x12#.keyorix.v1.GetRBACAuditLogsRequest\x1a$.keyorix.v1.GetRBACAuditLogsResponse\x12M\n" +
-	"\x0fStreamAuditLogs\x12\".keyorix.v1.StreamAuditLogsRequest\x1a\x14.keyorix.v1.AuditLog0\x012\xce\x01\n" +
+	"\x0fStreamAuditLogs\x12\".keyorix.v1.StreamAuditLogsRequest\x1a\x14.keyorix.v1.AuditLog0\x01\x12P\n" +
+	"\x10VerifyAuditChain\x12\x16.google.protobuf.Empty\x1a$.keyorix.v1.VerifyAuditChainResponse\x12X\n" +
+	"\x14WriteAuditCheckpoint\x12\x16.google.protobuf.Empty\x1a(.keyorix.v1.WriteAuditCheckpointResponse\x12R\n" +
+	"\x11GetAuditRetention\x12\x16.google.protobuf.Empty\x1a%.keyorix.v1.GetAuditRetentionResponse2\xce\x01\n" +
 	"\rSystemService\x12A\n" +
 	"\vHealthCheck\x12\x16.google.protobuf.Empty\x1a\x1a.keyorix.v1.HealthResponse\x12?\n" +
 	"\rGetSystemInfo\x12\x16.google.protobuf.Empty\x1a\x16.keyorix.v1.SystemInfo\x129\n" +
@@ -9948,7 +10271,7 @@ func file_keyorix_proto_rawDescGZIP() []byte {
 	return file_keyorix_proto_rawDescData
 }
 
-var file_keyorix_proto_msgTypes = make([]protoimpl.MessageInfo, 135)
+var file_keyorix_proto_msgTypes = make([]protoimpl.MessageInfo, 138)
 var file_keyorix_proto_goTypes = []any{
 	(*Secret)(nil),                           // 0: keyorix.v1.Secret
 	(*SecretValue)(nil),                      // 1: keyorix.v1.SecretValue
@@ -10000,105 +10323,108 @@ var file_keyorix_proto_goTypes = []any{
 	(*GetRBACAuditLogsRequest)(nil),          // 47: keyorix.v1.GetRBACAuditLogsRequest
 	(*GetRBACAuditLogsResponse)(nil),         // 48: keyorix.v1.GetRBACAuditLogsResponse
 	(*StreamAuditLogsRequest)(nil),           // 49: keyorix.v1.StreamAuditLogsRequest
-	(*ShareRecord)(nil),                      // 50: keyorix.v1.ShareRecord
-	(*ShareSecretRequest)(nil),               // 51: keyorix.v1.ShareSecretRequest
-	(*ListSecretSharesRequest)(nil),          // 52: keyorix.v1.ListSecretSharesRequest
-	(*ListUserSharesRequest)(nil),            // 53: keyorix.v1.ListUserSharesRequest
-	(*ListSharedSecretsRequest)(nil),         // 54: keyorix.v1.ListSharedSecretsRequest
-	(*ListSharesResponse)(nil),               // 55: keyorix.v1.ListSharesResponse
-	(*UpdateSharePermissionRequest)(nil),     // 56: keyorix.v1.UpdateSharePermissionRequest
-	(*RevokeShareRequest)(nil),               // 57: keyorix.v1.RevokeShareRequest
-	(*HealthResponse)(nil),                   // 58: keyorix.v1.HealthResponse
-	(*SystemInfo)(nil),                       // 59: keyorix.v1.SystemInfo
-	(*DatabaseInfo)(nil),                     // 60: keyorix.v1.DatabaseInfo
-	(*EncryptionInfo)(nil),                   // 61: keyorix.v1.EncryptionInfo
-	(*Metrics)(nil),                          // 62: keyorix.v1.Metrics
-	(*RequestMetrics)(nil),                   // 63: keyorix.v1.RequestMetrics
-	(*SecretMetrics)(nil),                    // 64: keyorix.v1.SecretMetrics
-	(*UserMetrics)(nil),                      // 65: keyorix.v1.UserMetrics
-	(*PerformanceMetrics)(nil),               // 66: keyorix.v1.PerformanceMetrics
-	(*SystemMetrics)(nil),                    // 67: keyorix.v1.SystemMetrics
-	(*Project)(nil),                          // 68: keyorix.v1.Project
-	(*Environment)(nil),                      // 69: keyorix.v1.Environment
-	(*ListProjectsResponse)(nil),             // 70: keyorix.v1.ListProjectsResponse
-	(*GetProjectRequest)(nil),                // 71: keyorix.v1.GetProjectRequest
-	(*CreateProjectRequest)(nil),             // 72: keyorix.v1.CreateProjectRequest
-	(*UpdateProjectRequest)(nil),             // 73: keyorix.v1.UpdateProjectRequest
-	(*DeleteProjectRequest)(nil),             // 74: keyorix.v1.DeleteProjectRequest
-	(*ListEnvironmentsRequest)(nil),          // 75: keyorix.v1.ListEnvironmentsRequest
-	(*ListEnvironmentsResponse)(nil),         // 76: keyorix.v1.ListEnvironmentsResponse
-	(*MachineIdentity)(nil),                  // 77: keyorix.v1.MachineIdentity
-	(*MachineToken)(nil),                     // 78: keyorix.v1.MachineToken
-	(*ListMachineIdentitiesRequest)(nil),     // 79: keyorix.v1.ListMachineIdentitiesRequest
-	(*ListMachineIdentitiesResponse)(nil),    // 80: keyorix.v1.ListMachineIdentitiesResponse
-	(*CreateMachineIdentityRequest)(nil),     // 81: keyorix.v1.CreateMachineIdentityRequest
-	(*TransitionMachineIdentityRequest)(nil), // 82: keyorix.v1.TransitionMachineIdentityRequest
-	(*ClassifyMachineIdentityRequest)(nil),   // 83: keyorix.v1.ClassifyMachineIdentityRequest
-	(*IssueMachineTokenRequest)(nil),         // 84: keyorix.v1.IssueMachineTokenRequest
-	(*IssueMachineTokenResponse)(nil),        // 85: keyorix.v1.IssueMachineTokenResponse
-	(*ListMachineTokensRequest)(nil),         // 86: keyorix.v1.ListMachineTokensRequest
-	(*ListMachineTokensResponse)(nil),        // 87: keyorix.v1.ListMachineTokensResponse
-	(*RevokeMachineTokenRequest)(nil),        // 88: keyorix.v1.RevokeMachineTokenRequest
-	(*ClassifyMachineTokenRequest)(nil),      // 89: keyorix.v1.ClassifyMachineTokenRequest
-	(*DynamicSecretConfig)(nil),              // 90: keyorix.v1.DynamicSecretConfig
-	(*DynamicSecretLease)(nil),               // 91: keyorix.v1.DynamicSecretLease
-	(*IssuedCredential)(nil),                 // 92: keyorix.v1.IssuedCredential
-	(*ListDynamicConfigsRequest)(nil),        // 93: keyorix.v1.ListDynamicConfigsRequest
-	(*ListDynamicConfigsResponse)(nil),       // 94: keyorix.v1.ListDynamicConfigsResponse
-	(*GetDynamicConfigRequest)(nil),          // 95: keyorix.v1.GetDynamicConfigRequest
-	(*CreateDynamicConfigRequest)(nil),       // 96: keyorix.v1.CreateDynamicConfigRequest
-	(*ClassifyDynamicConfigRequest)(nil),     // 97: keyorix.v1.ClassifyDynamicConfigRequest
-	(*IssueLeaseRequest)(nil),                // 98: keyorix.v1.IssueLeaseRequest
-	(*ListLeasesRequest)(nil),                // 99: keyorix.v1.ListLeasesRequest
-	(*ListLeasesResponse)(nil),               // 100: keyorix.v1.ListLeasesResponse
-	(*RevokeLeaseRequest)(nil),               // 101: keyorix.v1.RevokeLeaseRequest
-	(*RenewLeaseRequest)(nil),                // 102: keyorix.v1.RenewLeaseRequest
-	(*RenewLeaseResponse)(nil),               // 103: keyorix.v1.RenewLeaseResponse
-	(*RevokeAllLeasesRequest)(nil),           // 104: keyorix.v1.RevokeAllLeasesRequest
-	(*RevokeAllLeasesResponse)(nil),          // 105: keyorix.v1.RevokeAllLeasesResponse
-	(*AuditIntegrityPosture)(nil),            // 106: keyorix.v1.AuditIntegrityPosture
-	(*AccessGovernancePosture)(nil),          // 107: keyorix.v1.AccessGovernancePosture
-	(*RotationPosture)(nil),                  // 108: keyorix.v1.RotationPosture
-	(*IdentityPosture)(nil),                  // 109: keyorix.v1.IdentityPosture
-	(*EmergencyAccessPosture)(nil),           // 110: keyorix.v1.EmergencyAccessPosture
-	(*ClassificationCounts)(nil),             // 111: keyorix.v1.ClassificationCounts
-	(*ClassificationPosture)(nil),            // 112: keyorix.v1.ClassificationPosture
-	(*AnomaliesPosture)(nil),                 // 113: keyorix.v1.AnomaliesPosture
-	(*LegalHoldPosture)(nil),                 // 114: keyorix.v1.LegalHoldPosture
-	(*RetentionPosture)(nil),                 // 115: keyorix.v1.RetentionPosture
-	(*RiskPosture)(nil),                      // 116: keyorix.v1.RiskPosture
-	(*CompliancePosture)(nil),                // 117: keyorix.v1.CompliancePosture
-	(*FrameworkRefs)(nil),                    // 118: keyorix.v1.FrameworkRefs
-	(*ControlState)(nil),                     // 119: keyorix.v1.ControlState
-	(*ControlsSummary)(nil),                  // 120: keyorix.v1.ControlsSummary
-	(*ComplianceControls)(nil),               // 121: keyorix.v1.ComplianceControls
-	(*ConnectorList)(nil),                    // 122: keyorix.v1.ConnectorList
-	(*ReadFederatedSecretRequest)(nil),       // 123: keyorix.v1.ReadFederatedSecretRequest
-	(*FederatedSecretValue)(nil),             // 124: keyorix.v1.FederatedSecretValue
-	(*ConnectRefGrant)(nil),                  // 125: keyorix.v1.ConnectRefGrant
-	(*ConnectRefGrantList)(nil),              // 126: keyorix.v1.ConnectRefGrantList
-	(*CreateConnectRefGrantRequest)(nil),     // 127: keyorix.v1.CreateConnectRefGrantRequest
-	(*DeleteConnectRefGrantRequest)(nil),     // 128: keyorix.v1.DeleteConnectRefGrantRequest
-	nil,                                      // 129: keyorix.v1.Secret.MetadataEntry
-	nil,                                      // 130: keyorix.v1.CreateSecretRequest.MetadataEntry
-	nil,                                      // 131: keyorix.v1.UpdateSecretRequest.MetadataEntry
-	nil,                                      // 132: keyorix.v1.HealthResponse.ServicesEntry
-	nil,                                      // 133: keyorix.v1.SystemInfo.FeaturesEntry
-	nil,                                      // 134: keyorix.v1.IssuedCredential.FieldsEntry
-	(*timestamppb.Timestamp)(nil),            // 135: google.protobuf.Timestamp
-	(*emptypb.Empty)(nil),                    // 136: google.protobuf.Empty
+	(*VerifyAuditChainResponse)(nil),         // 50: keyorix.v1.VerifyAuditChainResponse
+	(*WriteAuditCheckpointResponse)(nil),     // 51: keyorix.v1.WriteAuditCheckpointResponse
+	(*GetAuditRetentionResponse)(nil),        // 52: keyorix.v1.GetAuditRetentionResponse
+	(*ShareRecord)(nil),                      // 53: keyorix.v1.ShareRecord
+	(*ShareSecretRequest)(nil),               // 54: keyorix.v1.ShareSecretRequest
+	(*ListSecretSharesRequest)(nil),          // 55: keyorix.v1.ListSecretSharesRequest
+	(*ListUserSharesRequest)(nil),            // 56: keyorix.v1.ListUserSharesRequest
+	(*ListSharedSecretsRequest)(nil),         // 57: keyorix.v1.ListSharedSecretsRequest
+	(*ListSharesResponse)(nil),               // 58: keyorix.v1.ListSharesResponse
+	(*UpdateSharePermissionRequest)(nil),     // 59: keyorix.v1.UpdateSharePermissionRequest
+	(*RevokeShareRequest)(nil),               // 60: keyorix.v1.RevokeShareRequest
+	(*HealthResponse)(nil),                   // 61: keyorix.v1.HealthResponse
+	(*SystemInfo)(nil),                       // 62: keyorix.v1.SystemInfo
+	(*DatabaseInfo)(nil),                     // 63: keyorix.v1.DatabaseInfo
+	(*EncryptionInfo)(nil),                   // 64: keyorix.v1.EncryptionInfo
+	(*Metrics)(nil),                          // 65: keyorix.v1.Metrics
+	(*RequestMetrics)(nil),                   // 66: keyorix.v1.RequestMetrics
+	(*SecretMetrics)(nil),                    // 67: keyorix.v1.SecretMetrics
+	(*UserMetrics)(nil),                      // 68: keyorix.v1.UserMetrics
+	(*PerformanceMetrics)(nil),               // 69: keyorix.v1.PerformanceMetrics
+	(*SystemMetrics)(nil),                    // 70: keyorix.v1.SystemMetrics
+	(*Project)(nil),                          // 71: keyorix.v1.Project
+	(*Environment)(nil),                      // 72: keyorix.v1.Environment
+	(*ListProjectsResponse)(nil),             // 73: keyorix.v1.ListProjectsResponse
+	(*GetProjectRequest)(nil),                // 74: keyorix.v1.GetProjectRequest
+	(*CreateProjectRequest)(nil),             // 75: keyorix.v1.CreateProjectRequest
+	(*UpdateProjectRequest)(nil),             // 76: keyorix.v1.UpdateProjectRequest
+	(*DeleteProjectRequest)(nil),             // 77: keyorix.v1.DeleteProjectRequest
+	(*ListEnvironmentsRequest)(nil),          // 78: keyorix.v1.ListEnvironmentsRequest
+	(*ListEnvironmentsResponse)(nil),         // 79: keyorix.v1.ListEnvironmentsResponse
+	(*MachineIdentity)(nil),                  // 80: keyorix.v1.MachineIdentity
+	(*MachineToken)(nil),                     // 81: keyorix.v1.MachineToken
+	(*ListMachineIdentitiesRequest)(nil),     // 82: keyorix.v1.ListMachineIdentitiesRequest
+	(*ListMachineIdentitiesResponse)(nil),    // 83: keyorix.v1.ListMachineIdentitiesResponse
+	(*CreateMachineIdentityRequest)(nil),     // 84: keyorix.v1.CreateMachineIdentityRequest
+	(*TransitionMachineIdentityRequest)(nil), // 85: keyorix.v1.TransitionMachineIdentityRequest
+	(*ClassifyMachineIdentityRequest)(nil),   // 86: keyorix.v1.ClassifyMachineIdentityRequest
+	(*IssueMachineTokenRequest)(nil),         // 87: keyorix.v1.IssueMachineTokenRequest
+	(*IssueMachineTokenResponse)(nil),        // 88: keyorix.v1.IssueMachineTokenResponse
+	(*ListMachineTokensRequest)(nil),         // 89: keyorix.v1.ListMachineTokensRequest
+	(*ListMachineTokensResponse)(nil),        // 90: keyorix.v1.ListMachineTokensResponse
+	(*RevokeMachineTokenRequest)(nil),        // 91: keyorix.v1.RevokeMachineTokenRequest
+	(*ClassifyMachineTokenRequest)(nil),      // 92: keyorix.v1.ClassifyMachineTokenRequest
+	(*DynamicSecretConfig)(nil),              // 93: keyorix.v1.DynamicSecretConfig
+	(*DynamicSecretLease)(nil),               // 94: keyorix.v1.DynamicSecretLease
+	(*IssuedCredential)(nil),                 // 95: keyorix.v1.IssuedCredential
+	(*ListDynamicConfigsRequest)(nil),        // 96: keyorix.v1.ListDynamicConfigsRequest
+	(*ListDynamicConfigsResponse)(nil),       // 97: keyorix.v1.ListDynamicConfigsResponse
+	(*GetDynamicConfigRequest)(nil),          // 98: keyorix.v1.GetDynamicConfigRequest
+	(*CreateDynamicConfigRequest)(nil),       // 99: keyorix.v1.CreateDynamicConfigRequest
+	(*ClassifyDynamicConfigRequest)(nil),     // 100: keyorix.v1.ClassifyDynamicConfigRequest
+	(*IssueLeaseRequest)(nil),                // 101: keyorix.v1.IssueLeaseRequest
+	(*ListLeasesRequest)(nil),                // 102: keyorix.v1.ListLeasesRequest
+	(*ListLeasesResponse)(nil),               // 103: keyorix.v1.ListLeasesResponse
+	(*RevokeLeaseRequest)(nil),               // 104: keyorix.v1.RevokeLeaseRequest
+	(*RenewLeaseRequest)(nil),                // 105: keyorix.v1.RenewLeaseRequest
+	(*RenewLeaseResponse)(nil),               // 106: keyorix.v1.RenewLeaseResponse
+	(*RevokeAllLeasesRequest)(nil),           // 107: keyorix.v1.RevokeAllLeasesRequest
+	(*RevokeAllLeasesResponse)(nil),          // 108: keyorix.v1.RevokeAllLeasesResponse
+	(*AuditIntegrityPosture)(nil),            // 109: keyorix.v1.AuditIntegrityPosture
+	(*AccessGovernancePosture)(nil),          // 110: keyorix.v1.AccessGovernancePosture
+	(*RotationPosture)(nil),                  // 111: keyorix.v1.RotationPosture
+	(*IdentityPosture)(nil),                  // 112: keyorix.v1.IdentityPosture
+	(*EmergencyAccessPosture)(nil),           // 113: keyorix.v1.EmergencyAccessPosture
+	(*ClassificationCounts)(nil),             // 114: keyorix.v1.ClassificationCounts
+	(*ClassificationPosture)(nil),            // 115: keyorix.v1.ClassificationPosture
+	(*AnomaliesPosture)(nil),                 // 116: keyorix.v1.AnomaliesPosture
+	(*LegalHoldPosture)(nil),                 // 117: keyorix.v1.LegalHoldPosture
+	(*RetentionPosture)(nil),                 // 118: keyorix.v1.RetentionPosture
+	(*RiskPosture)(nil),                      // 119: keyorix.v1.RiskPosture
+	(*CompliancePosture)(nil),                // 120: keyorix.v1.CompliancePosture
+	(*FrameworkRefs)(nil),                    // 121: keyorix.v1.FrameworkRefs
+	(*ControlState)(nil),                     // 122: keyorix.v1.ControlState
+	(*ControlsSummary)(nil),                  // 123: keyorix.v1.ControlsSummary
+	(*ComplianceControls)(nil),               // 124: keyorix.v1.ComplianceControls
+	(*ConnectorList)(nil),                    // 125: keyorix.v1.ConnectorList
+	(*ReadFederatedSecretRequest)(nil),       // 126: keyorix.v1.ReadFederatedSecretRequest
+	(*FederatedSecretValue)(nil),             // 127: keyorix.v1.FederatedSecretValue
+	(*ConnectRefGrant)(nil),                  // 128: keyorix.v1.ConnectRefGrant
+	(*ConnectRefGrantList)(nil),              // 129: keyorix.v1.ConnectRefGrantList
+	(*CreateConnectRefGrantRequest)(nil),     // 130: keyorix.v1.CreateConnectRefGrantRequest
+	(*DeleteConnectRefGrantRequest)(nil),     // 131: keyorix.v1.DeleteConnectRefGrantRequest
+	nil,                                      // 132: keyorix.v1.Secret.MetadataEntry
+	nil,                                      // 133: keyorix.v1.CreateSecretRequest.MetadataEntry
+	nil,                                      // 134: keyorix.v1.UpdateSecretRequest.MetadataEntry
+	nil,                                      // 135: keyorix.v1.HealthResponse.ServicesEntry
+	nil,                                      // 136: keyorix.v1.SystemInfo.FeaturesEntry
+	nil,                                      // 137: keyorix.v1.IssuedCredential.FieldsEntry
+	(*timestamppb.Timestamp)(nil),            // 138: google.protobuf.Timestamp
+	(*emptypb.Empty)(nil),                    // 139: google.protobuf.Empty
 }
 var file_keyorix_proto_depIdxs = []int32{
-	135, // 0: keyorix.v1.Secret.expiration:type_name -> google.protobuf.Timestamp
-	129, // 1: keyorix.v1.Secret.metadata:type_name -> keyorix.v1.Secret.MetadataEntry
-	135, // 2: keyorix.v1.Secret.created_at:type_name -> google.protobuf.Timestamp
-	135, // 3: keyorix.v1.Secret.updated_at:type_name -> google.protobuf.Timestamp
-	135, // 4: keyorix.v1.CreateSecretRequest.expiration:type_name -> google.protobuf.Timestamp
-	130, // 5: keyorix.v1.CreateSecretRequest.metadata:type_name -> keyorix.v1.CreateSecretRequest.MetadataEntry
-	135, // 6: keyorix.v1.UpdateSecretRequest.expiration:type_name -> google.protobuf.Timestamp
-	131, // 7: keyorix.v1.UpdateSecretRequest.metadata:type_name -> keyorix.v1.UpdateSecretRequest.MetadataEntry
+	138, // 0: keyorix.v1.Secret.expiration:type_name -> google.protobuf.Timestamp
+	132, // 1: keyorix.v1.Secret.metadata:type_name -> keyorix.v1.Secret.MetadataEntry
+	138, // 2: keyorix.v1.Secret.created_at:type_name -> google.protobuf.Timestamp
+	138, // 3: keyorix.v1.Secret.updated_at:type_name -> google.protobuf.Timestamp
+	138, // 4: keyorix.v1.CreateSecretRequest.expiration:type_name -> google.protobuf.Timestamp
+	133, // 5: keyorix.v1.CreateSecretRequest.metadata:type_name -> keyorix.v1.CreateSecretRequest.MetadataEntry
+	138, // 6: keyorix.v1.UpdateSecretRequest.expiration:type_name -> google.protobuf.Timestamp
+	134, // 7: keyorix.v1.UpdateSecretRequest.metadata:type_name -> keyorix.v1.UpdateSecretRequest.MetadataEntry
 	0,   // 8: keyorix.v1.ListSecretsResponse.secrets:type_name -> keyorix.v1.Secret
-	135, // 9: keyorix.v1.SecretVersion.created_at:type_name -> google.protobuf.Timestamp
+	138, // 9: keyorix.v1.SecretVersion.created_at:type_name -> google.protobuf.Timestamp
 	10,  // 10: keyorix.v1.GetSecretVersionsResponse.versions:type_name -> keyorix.v1.SecretVersion
 	12,  // 11: keyorix.v1.SecretDependencies.depends_on:type_name -> keyorix.v1.DependencyEdge
 	12,  // 12: keyorix.v1.SecretDependencies.dependents:type_name -> keyorix.v1.DependencyEdge
@@ -10106,220 +10432,229 @@ var file_keyorix_proto_depIdxs = []int32{
 	16,  // 14: keyorix.v1.RotationOrder.order:type_name -> keyorix.v1.RotationStep
 	18,  // 15: keyorix.v1.RotationWave.secrets:type_name -> keyorix.v1.PlannedRotation
 	19,  // 16: keyorix.v1.RotationPlan.waves:type_name -> keyorix.v1.RotationWave
-	135, // 17: keyorix.v1.User.last_login_at:type_name -> google.protobuf.Timestamp
-	135, // 18: keyorix.v1.User.created_at:type_name -> google.protobuf.Timestamp
-	135, // 19: keyorix.v1.User.updated_at:type_name -> google.protobuf.Timestamp
+	138, // 17: keyorix.v1.User.last_login_at:type_name -> google.protobuf.Timestamp
+	138, // 18: keyorix.v1.User.created_at:type_name -> google.protobuf.Timestamp
+	138, // 19: keyorix.v1.User.updated_at:type_name -> google.protobuf.Timestamp
 	22,  // 20: keyorix.v1.CreateUserRequest.project_assignments:type_name -> keyorix.v1.ProjectAssignment
 	21,  // 21: keyorix.v1.CreateUserResponse.user:type_name -> keyorix.v1.User
 	21,  // 22: keyorix.v1.ListUsersResponse.users:type_name -> keyorix.v1.User
 	30,  // 23: keyorix.v1.Role.permissions:type_name -> keyorix.v1.Permission
-	135, // 24: keyorix.v1.Role.created_at:type_name -> google.protobuf.Timestamp
-	135, // 25: keyorix.v1.Role.updated_at:type_name -> google.protobuf.Timestamp
+	138, // 24: keyorix.v1.Role.created_at:type_name -> google.protobuf.Timestamp
+	138, // 25: keyorix.v1.Role.updated_at:type_name -> google.protobuf.Timestamp
 	31,  // 26: keyorix.v1.ListRolesResponse.roles:type_name -> keyorix.v1.Role
 	31,  // 27: keyorix.v1.GetUserRolesResponse.roles:type_name -> keyorix.v1.Role
-	135, // 28: keyorix.v1.AuditLog.event_time:type_name -> google.protobuf.Timestamp
-	135, // 29: keyorix.v1.GetAuditLogsRequest.start_time:type_name -> google.protobuf.Timestamp
-	135, // 30: keyorix.v1.GetAuditLogsRequest.end_time:type_name -> google.protobuf.Timestamp
+	138, // 28: keyorix.v1.AuditLog.event_time:type_name -> google.protobuf.Timestamp
+	138, // 29: keyorix.v1.GetAuditLogsRequest.start_time:type_name -> google.protobuf.Timestamp
+	138, // 30: keyorix.v1.GetAuditLogsRequest.end_time:type_name -> google.protobuf.Timestamp
 	43,  // 31: keyorix.v1.GetAuditLogsResponse.logs:type_name -> keyorix.v1.AuditLog
-	135, // 32: keyorix.v1.RBACAuditLog.created_at:type_name -> google.protobuf.Timestamp
+	138, // 32: keyorix.v1.RBACAuditLog.created_at:type_name -> google.protobuf.Timestamp
 	46,  // 33: keyorix.v1.GetRBACAuditLogsResponse.logs:type_name -> keyorix.v1.RBACAuditLog
-	135, // 34: keyorix.v1.ShareRecord.created_at:type_name -> google.protobuf.Timestamp
-	135, // 35: keyorix.v1.ShareRecord.updated_at:type_name -> google.protobuf.Timestamp
-	50,  // 36: keyorix.v1.ListSharesResponse.shares:type_name -> keyorix.v1.ShareRecord
-	135, // 37: keyorix.v1.HealthResponse.timestamp:type_name -> google.protobuf.Timestamp
-	132, // 38: keyorix.v1.HealthResponse.services:type_name -> keyorix.v1.HealthResponse.ServicesEntry
-	133, // 39: keyorix.v1.SystemInfo.features:type_name -> keyorix.v1.SystemInfo.FeaturesEntry
-	60,  // 40: keyorix.v1.SystemInfo.database:type_name -> keyorix.v1.DatabaseInfo
-	61,  // 41: keyorix.v1.SystemInfo.encryption:type_name -> keyorix.v1.EncryptionInfo
-	63,  // 42: keyorix.v1.Metrics.requests:type_name -> keyorix.v1.RequestMetrics
-	64,  // 43: keyorix.v1.Metrics.secrets:type_name -> keyorix.v1.SecretMetrics
-	65,  // 44: keyorix.v1.Metrics.users:type_name -> keyorix.v1.UserMetrics
-	66,  // 45: keyorix.v1.Metrics.performance:type_name -> keyorix.v1.PerformanceMetrics
-	67,  // 46: keyorix.v1.Metrics.system:type_name -> keyorix.v1.SystemMetrics
-	135, // 47: keyorix.v1.Project.created_at:type_name -> google.protobuf.Timestamp
-	135, // 48: keyorix.v1.Project.updated_at:type_name -> google.protobuf.Timestamp
-	135, // 49: keyorix.v1.Environment.created_at:type_name -> google.protobuf.Timestamp
-	135, // 50: keyorix.v1.Environment.updated_at:type_name -> google.protobuf.Timestamp
-	68,  // 51: keyorix.v1.ListProjectsResponse.projects:type_name -> keyorix.v1.Project
-	69,  // 52: keyorix.v1.ListEnvironmentsResponse.environments:type_name -> keyorix.v1.Environment
-	135, // 53: keyorix.v1.MachineIdentity.created_at:type_name -> google.protobuf.Timestamp
-	135, // 54: keyorix.v1.MachineIdentity.updated_at:type_name -> google.protobuf.Timestamp
-	135, // 55: keyorix.v1.MachineIdentity.last_seen_at:type_name -> google.protobuf.Timestamp
-	135, // 56: keyorix.v1.MachineIdentity.revoked_at:type_name -> google.protobuf.Timestamp
-	135, // 57: keyorix.v1.MachineToken.last_used_at:type_name -> google.protobuf.Timestamp
-	135, // 58: keyorix.v1.MachineToken.expires_at:type_name -> google.protobuf.Timestamp
-	135, // 59: keyorix.v1.MachineToken.created_at:type_name -> google.protobuf.Timestamp
-	77,  // 60: keyorix.v1.ListMachineIdentitiesResponse.machine_identities:type_name -> keyorix.v1.MachineIdentity
-	135, // 61: keyorix.v1.IssueMachineTokenResponse.expires_at:type_name -> google.protobuf.Timestamp
-	78,  // 62: keyorix.v1.ListMachineTokensResponse.tokens:type_name -> keyorix.v1.MachineToken
-	135, // 63: keyorix.v1.DynamicSecretConfig.created_at:type_name -> google.protobuf.Timestamp
-	135, // 64: keyorix.v1.DynamicSecretLease.issued_at:type_name -> google.protobuf.Timestamp
-	135, // 65: keyorix.v1.DynamicSecretLease.expires_at:type_name -> google.protobuf.Timestamp
-	135, // 66: keyorix.v1.DynamicSecretLease.revoked_at:type_name -> google.protobuf.Timestamp
-	135, // 67: keyorix.v1.IssuedCredential.expires_at:type_name -> google.protobuf.Timestamp
-	134, // 68: keyorix.v1.IssuedCredential.fields:type_name -> keyorix.v1.IssuedCredential.FieldsEntry
-	90,  // 69: keyorix.v1.ListDynamicConfigsResponse.configs:type_name -> keyorix.v1.DynamicSecretConfig
-	91,  // 70: keyorix.v1.ListLeasesResponse.leases:type_name -> keyorix.v1.DynamicSecretLease
-	135, // 71: keyorix.v1.RenewLeaseResponse.expires_at:type_name -> google.protobuf.Timestamp
-	111, // 72: keyorix.v1.ClassificationPosture.dynamic_configs:type_name -> keyorix.v1.ClassificationCounts
-	111, // 73: keyorix.v1.ClassificationPosture.machine_identities:type_name -> keyorix.v1.ClassificationCounts
-	111, // 74: keyorix.v1.ClassificationPosture.machine_credentials:type_name -> keyorix.v1.ClassificationCounts
-	135, // 75: keyorix.v1.LegalHoldPosture.placed_at:type_name -> google.protobuf.Timestamp
-	135, // 76: keyorix.v1.CompliancePosture.generated_at:type_name -> google.protobuf.Timestamp
-	106, // 77: keyorix.v1.CompliancePosture.audit_integrity:type_name -> keyorix.v1.AuditIntegrityPosture
-	107, // 78: keyorix.v1.CompliancePosture.access_governance:type_name -> keyorix.v1.AccessGovernancePosture
-	108, // 79: keyorix.v1.CompliancePosture.rotation:type_name -> keyorix.v1.RotationPosture
-	109, // 80: keyorix.v1.CompliancePosture.identity:type_name -> keyorix.v1.IdentityPosture
-	110, // 81: keyorix.v1.CompliancePosture.emergency_access:type_name -> keyorix.v1.EmergencyAccessPosture
-	112, // 82: keyorix.v1.CompliancePosture.classification:type_name -> keyorix.v1.ClassificationPosture
-	113, // 83: keyorix.v1.CompliancePosture.anomalies:type_name -> keyorix.v1.AnomaliesPosture
-	114, // 84: keyorix.v1.CompliancePosture.legal_hold:type_name -> keyorix.v1.LegalHoldPosture
-	115, // 85: keyorix.v1.CompliancePosture.retention:type_name -> keyorix.v1.RetentionPosture
-	116, // 86: keyorix.v1.CompliancePosture.risk:type_name -> keyorix.v1.RiskPosture
-	118, // 87: keyorix.v1.ControlState.frameworks:type_name -> keyorix.v1.FrameworkRefs
-	135, // 88: keyorix.v1.ComplianceControls.generated_at:type_name -> google.protobuf.Timestamp
-	119, // 89: keyorix.v1.ComplianceControls.controls:type_name -> keyorix.v1.ControlState
-	120, // 90: keyorix.v1.ComplianceControls.summary:type_name -> keyorix.v1.ControlsSummary
-	125, // 91: keyorix.v1.ConnectRefGrantList.grants:type_name -> keyorix.v1.ConnectRefGrant
-	2,   // 92: keyorix.v1.SecretService.CreateSecret:input_type -> keyorix.v1.CreateSecretRequest
-	3,   // 93: keyorix.v1.SecretService.GetSecret:input_type -> keyorix.v1.GetSecretRequest
-	3,   // 94: keyorix.v1.SecretService.GetSecretValue:input_type -> keyorix.v1.GetSecretRequest
-	4,   // 95: keyorix.v1.SecretService.UpdateSecret:input_type -> keyorix.v1.UpdateSecretRequest
-	5,   // 96: keyorix.v1.SecretService.DeleteSecret:input_type -> keyorix.v1.DeleteSecretRequest
-	6,   // 97: keyorix.v1.SecretService.ListSecrets:input_type -> keyorix.v1.ListSecretsRequest
-	8,   // 98: keyorix.v1.SecretService.GetSecretVersions:input_type -> keyorix.v1.GetSecretVersionsRequest
-	9,   // 99: keyorix.v1.SecretService.SetSecretAutoRotate:input_type -> keyorix.v1.SetSecretAutoRotateRequest
-	3,   // 100: keyorix.v1.SecretService.ListSecretDependencies:input_type -> keyorix.v1.GetSecretRequest
-	3,   // 101: keyorix.v1.SecretService.GetSecretImpact:input_type -> keyorix.v1.GetSecretRequest
-	51,  // 102: keyorix.v1.ShareService.ShareSecret:input_type -> keyorix.v1.ShareSecretRequest
-	52,  // 103: keyorix.v1.ShareService.ListSecretShares:input_type -> keyorix.v1.ListSecretSharesRequest
-	53,  // 104: keyorix.v1.ShareService.ListUserShares:input_type -> keyorix.v1.ListUserSharesRequest
-	54,  // 105: keyorix.v1.ShareService.ListSharedSecrets:input_type -> keyorix.v1.ListSharedSecretsRequest
-	56,  // 106: keyorix.v1.ShareService.UpdateSharePermission:input_type -> keyorix.v1.UpdateSharePermissionRequest
-	57,  // 107: keyorix.v1.ShareService.RevokeShare:input_type -> keyorix.v1.RevokeShareRequest
-	23,  // 108: keyorix.v1.UserService.CreateUser:input_type -> keyorix.v1.CreateUserRequest
-	25,  // 109: keyorix.v1.UserService.GetUser:input_type -> keyorix.v1.GetUserRequest
-	26,  // 110: keyorix.v1.UserService.UpdateUser:input_type -> keyorix.v1.UpdateUserRequest
-	27,  // 111: keyorix.v1.UserService.DeleteUser:input_type -> keyorix.v1.DeleteUserRequest
-	28,  // 112: keyorix.v1.UserService.ListUsers:input_type -> keyorix.v1.ListUsersRequest
-	32,  // 113: keyorix.v1.RoleService.CreateRole:input_type -> keyorix.v1.CreateRoleRequest
-	33,  // 114: keyorix.v1.RoleService.GetRole:input_type -> keyorix.v1.GetRoleRequest
-	34,  // 115: keyorix.v1.RoleService.UpdateRole:input_type -> keyorix.v1.UpdateRoleRequest
-	35,  // 116: keyorix.v1.RoleService.DeleteRole:input_type -> keyorix.v1.DeleteRoleRequest
-	36,  // 117: keyorix.v1.RoleService.ListRoles:input_type -> keyorix.v1.ListRolesRequest
-	38,  // 118: keyorix.v1.RoleService.AssignRole:input_type -> keyorix.v1.AssignRoleRequest
-	40,  // 119: keyorix.v1.RoleService.RemoveRole:input_type -> keyorix.v1.RemoveRoleRequest
-	41,  // 120: keyorix.v1.RoleService.GetUserRoles:input_type -> keyorix.v1.GetUserRolesRequest
-	44,  // 121: keyorix.v1.AuditService.GetAuditLogs:input_type -> keyorix.v1.GetAuditLogsRequest
-	47,  // 122: keyorix.v1.AuditService.GetRBACAuditLogs:input_type -> keyorix.v1.GetRBACAuditLogsRequest
-	49,  // 123: keyorix.v1.AuditService.StreamAuditLogs:input_type -> keyorix.v1.StreamAuditLogsRequest
-	136, // 124: keyorix.v1.SystemService.HealthCheck:input_type -> google.protobuf.Empty
-	136, // 125: keyorix.v1.SystemService.GetSystemInfo:input_type -> google.protobuf.Empty
-	136, // 126: keyorix.v1.SystemService.GetMetrics:input_type -> google.protobuf.Empty
-	136, // 127: keyorix.v1.ProjectService.ListProjects:input_type -> google.protobuf.Empty
-	71,  // 128: keyorix.v1.ProjectService.GetProject:input_type -> keyorix.v1.GetProjectRequest
-	72,  // 129: keyorix.v1.ProjectService.CreateProject:input_type -> keyorix.v1.CreateProjectRequest
-	73,  // 130: keyorix.v1.ProjectService.UpdateProject:input_type -> keyorix.v1.UpdateProjectRequest
-	74,  // 131: keyorix.v1.ProjectService.DeleteProject:input_type -> keyorix.v1.DeleteProjectRequest
-	71,  // 132: keyorix.v1.ProjectService.GetProjectRotationOrder:input_type -> keyorix.v1.GetProjectRequest
-	71,  // 133: keyorix.v1.ProjectService.GetProjectRotationPlan:input_type -> keyorix.v1.GetProjectRequest
-	75,  // 134: keyorix.v1.ProjectService.ListEnvironments:input_type -> keyorix.v1.ListEnvironmentsRequest
-	79,  // 135: keyorix.v1.MachineIdentityService.ListMachineIdentities:input_type -> keyorix.v1.ListMachineIdentitiesRequest
-	81,  // 136: keyorix.v1.MachineIdentityService.CreateMachineIdentity:input_type -> keyorix.v1.CreateMachineIdentityRequest
-	82,  // 137: keyorix.v1.MachineIdentityService.TransitionMachineIdentity:input_type -> keyorix.v1.TransitionMachineIdentityRequest
-	83,  // 138: keyorix.v1.MachineIdentityService.ClassifyMachineIdentity:input_type -> keyorix.v1.ClassifyMachineIdentityRequest
-	84,  // 139: keyorix.v1.MachineIdentityService.IssueMachineToken:input_type -> keyorix.v1.IssueMachineTokenRequest
-	86,  // 140: keyorix.v1.MachineIdentityService.ListMachineTokens:input_type -> keyorix.v1.ListMachineTokensRequest
-	88,  // 141: keyorix.v1.MachineIdentityService.RevokeMachineToken:input_type -> keyorix.v1.RevokeMachineTokenRequest
-	89,  // 142: keyorix.v1.MachineIdentityService.ClassifyMachineToken:input_type -> keyorix.v1.ClassifyMachineTokenRequest
-	93,  // 143: keyorix.v1.DynamicSecretService.ListConfigs:input_type -> keyorix.v1.ListDynamicConfigsRequest
-	95,  // 144: keyorix.v1.DynamicSecretService.GetConfig:input_type -> keyorix.v1.GetDynamicConfigRequest
-	96,  // 145: keyorix.v1.DynamicSecretService.CreateConfig:input_type -> keyorix.v1.CreateDynamicConfigRequest
-	97,  // 146: keyorix.v1.DynamicSecretService.ClassifyConfig:input_type -> keyorix.v1.ClassifyDynamicConfigRequest
-	98,  // 147: keyorix.v1.DynamicSecretService.IssueLease:input_type -> keyorix.v1.IssueLeaseRequest
-	99,  // 148: keyorix.v1.DynamicSecretService.ListLeases:input_type -> keyorix.v1.ListLeasesRequest
-	101, // 149: keyorix.v1.DynamicSecretService.RevokeLease:input_type -> keyorix.v1.RevokeLeaseRequest
-	102, // 150: keyorix.v1.DynamicSecretService.RenewLease:input_type -> keyorix.v1.RenewLeaseRequest
-	104, // 151: keyorix.v1.DynamicSecretService.RevokeAllLeases:input_type -> keyorix.v1.RevokeAllLeasesRequest
-	136, // 152: keyorix.v1.ComplianceService.GetCompliancePosture:input_type -> google.protobuf.Empty
-	136, // 153: keyorix.v1.ComplianceService.GetComplianceControls:input_type -> google.protobuf.Empty
-	136, // 154: keyorix.v1.ConnectService.ListConnectors:input_type -> google.protobuf.Empty
-	123, // 155: keyorix.v1.ConnectService.ReadSecret:input_type -> keyorix.v1.ReadFederatedSecretRequest
-	136, // 156: keyorix.v1.ConnectService.ListRefGrants:input_type -> google.protobuf.Empty
-	127, // 157: keyorix.v1.ConnectService.CreateRefGrant:input_type -> keyorix.v1.CreateConnectRefGrantRequest
-	128, // 158: keyorix.v1.ConnectService.DeleteRefGrant:input_type -> keyorix.v1.DeleteConnectRefGrantRequest
-	0,   // 159: keyorix.v1.SecretService.CreateSecret:output_type -> keyorix.v1.Secret
-	0,   // 160: keyorix.v1.SecretService.GetSecret:output_type -> keyorix.v1.Secret
-	1,   // 161: keyorix.v1.SecretService.GetSecretValue:output_type -> keyorix.v1.SecretValue
-	0,   // 162: keyorix.v1.SecretService.UpdateSecret:output_type -> keyorix.v1.Secret
-	136, // 163: keyorix.v1.SecretService.DeleteSecret:output_type -> google.protobuf.Empty
-	7,   // 164: keyorix.v1.SecretService.ListSecrets:output_type -> keyorix.v1.ListSecretsResponse
-	11,  // 165: keyorix.v1.SecretService.GetSecretVersions:output_type -> keyorix.v1.GetSecretVersionsResponse
-	136, // 166: keyorix.v1.SecretService.SetSecretAutoRotate:output_type -> google.protobuf.Empty
-	13,  // 167: keyorix.v1.SecretService.ListSecretDependencies:output_type -> keyorix.v1.SecretDependencies
-	15,  // 168: keyorix.v1.SecretService.GetSecretImpact:output_type -> keyorix.v1.SecretImpact
-	50,  // 169: keyorix.v1.ShareService.ShareSecret:output_type -> keyorix.v1.ShareRecord
-	55,  // 170: keyorix.v1.ShareService.ListSecretShares:output_type -> keyorix.v1.ListSharesResponse
-	55,  // 171: keyorix.v1.ShareService.ListUserShares:output_type -> keyorix.v1.ListSharesResponse
-	7,   // 172: keyorix.v1.ShareService.ListSharedSecrets:output_type -> keyorix.v1.ListSecretsResponse
-	50,  // 173: keyorix.v1.ShareService.UpdateSharePermission:output_type -> keyorix.v1.ShareRecord
-	136, // 174: keyorix.v1.ShareService.RevokeShare:output_type -> google.protobuf.Empty
-	24,  // 175: keyorix.v1.UserService.CreateUser:output_type -> keyorix.v1.CreateUserResponse
-	21,  // 176: keyorix.v1.UserService.GetUser:output_type -> keyorix.v1.User
-	21,  // 177: keyorix.v1.UserService.UpdateUser:output_type -> keyorix.v1.User
-	136, // 178: keyorix.v1.UserService.DeleteUser:output_type -> google.protobuf.Empty
-	29,  // 179: keyorix.v1.UserService.ListUsers:output_type -> keyorix.v1.ListUsersResponse
-	31,  // 180: keyorix.v1.RoleService.CreateRole:output_type -> keyorix.v1.Role
-	31,  // 181: keyorix.v1.RoleService.GetRole:output_type -> keyorix.v1.Role
-	31,  // 182: keyorix.v1.RoleService.UpdateRole:output_type -> keyorix.v1.Role
-	136, // 183: keyorix.v1.RoleService.DeleteRole:output_type -> google.protobuf.Empty
-	37,  // 184: keyorix.v1.RoleService.ListRoles:output_type -> keyorix.v1.ListRolesResponse
-	39,  // 185: keyorix.v1.RoleService.AssignRole:output_type -> keyorix.v1.RoleAssignment
-	136, // 186: keyorix.v1.RoleService.RemoveRole:output_type -> google.protobuf.Empty
-	42,  // 187: keyorix.v1.RoleService.GetUserRoles:output_type -> keyorix.v1.GetUserRolesResponse
-	45,  // 188: keyorix.v1.AuditService.GetAuditLogs:output_type -> keyorix.v1.GetAuditLogsResponse
-	48,  // 189: keyorix.v1.AuditService.GetRBACAuditLogs:output_type -> keyorix.v1.GetRBACAuditLogsResponse
-	43,  // 190: keyorix.v1.AuditService.StreamAuditLogs:output_type -> keyorix.v1.AuditLog
-	58,  // 191: keyorix.v1.SystemService.HealthCheck:output_type -> keyorix.v1.HealthResponse
-	59,  // 192: keyorix.v1.SystemService.GetSystemInfo:output_type -> keyorix.v1.SystemInfo
-	62,  // 193: keyorix.v1.SystemService.GetMetrics:output_type -> keyorix.v1.Metrics
-	70,  // 194: keyorix.v1.ProjectService.ListProjects:output_type -> keyorix.v1.ListProjectsResponse
-	68,  // 195: keyorix.v1.ProjectService.GetProject:output_type -> keyorix.v1.Project
-	68,  // 196: keyorix.v1.ProjectService.CreateProject:output_type -> keyorix.v1.Project
-	68,  // 197: keyorix.v1.ProjectService.UpdateProject:output_type -> keyorix.v1.Project
-	136, // 198: keyorix.v1.ProjectService.DeleteProject:output_type -> google.protobuf.Empty
-	17,  // 199: keyorix.v1.ProjectService.GetProjectRotationOrder:output_type -> keyorix.v1.RotationOrder
-	20,  // 200: keyorix.v1.ProjectService.GetProjectRotationPlan:output_type -> keyorix.v1.RotationPlan
-	76,  // 201: keyorix.v1.ProjectService.ListEnvironments:output_type -> keyorix.v1.ListEnvironmentsResponse
-	80,  // 202: keyorix.v1.MachineIdentityService.ListMachineIdentities:output_type -> keyorix.v1.ListMachineIdentitiesResponse
-	77,  // 203: keyorix.v1.MachineIdentityService.CreateMachineIdentity:output_type -> keyorix.v1.MachineIdentity
-	77,  // 204: keyorix.v1.MachineIdentityService.TransitionMachineIdentity:output_type -> keyorix.v1.MachineIdentity
-	77,  // 205: keyorix.v1.MachineIdentityService.ClassifyMachineIdentity:output_type -> keyorix.v1.MachineIdentity
-	85,  // 206: keyorix.v1.MachineIdentityService.IssueMachineToken:output_type -> keyorix.v1.IssueMachineTokenResponse
-	87,  // 207: keyorix.v1.MachineIdentityService.ListMachineTokens:output_type -> keyorix.v1.ListMachineTokensResponse
-	136, // 208: keyorix.v1.MachineIdentityService.RevokeMachineToken:output_type -> google.protobuf.Empty
-	78,  // 209: keyorix.v1.MachineIdentityService.ClassifyMachineToken:output_type -> keyorix.v1.MachineToken
-	94,  // 210: keyorix.v1.DynamicSecretService.ListConfigs:output_type -> keyorix.v1.ListDynamicConfigsResponse
-	90,  // 211: keyorix.v1.DynamicSecretService.GetConfig:output_type -> keyorix.v1.DynamicSecretConfig
-	90,  // 212: keyorix.v1.DynamicSecretService.CreateConfig:output_type -> keyorix.v1.DynamicSecretConfig
-	90,  // 213: keyorix.v1.DynamicSecretService.ClassifyConfig:output_type -> keyorix.v1.DynamicSecretConfig
-	92,  // 214: keyorix.v1.DynamicSecretService.IssueLease:output_type -> keyorix.v1.IssuedCredential
-	100, // 215: keyorix.v1.DynamicSecretService.ListLeases:output_type -> keyorix.v1.ListLeasesResponse
-	136, // 216: keyorix.v1.DynamicSecretService.RevokeLease:output_type -> google.protobuf.Empty
-	103, // 217: keyorix.v1.DynamicSecretService.RenewLease:output_type -> keyorix.v1.RenewLeaseResponse
-	105, // 218: keyorix.v1.DynamicSecretService.RevokeAllLeases:output_type -> keyorix.v1.RevokeAllLeasesResponse
-	117, // 219: keyorix.v1.ComplianceService.GetCompliancePosture:output_type -> keyorix.v1.CompliancePosture
-	121, // 220: keyorix.v1.ComplianceService.GetComplianceControls:output_type -> keyorix.v1.ComplianceControls
-	122, // 221: keyorix.v1.ConnectService.ListConnectors:output_type -> keyorix.v1.ConnectorList
-	124, // 222: keyorix.v1.ConnectService.ReadSecret:output_type -> keyorix.v1.FederatedSecretValue
-	126, // 223: keyorix.v1.ConnectService.ListRefGrants:output_type -> keyorix.v1.ConnectRefGrantList
-	125, // 224: keyorix.v1.ConnectService.CreateRefGrant:output_type -> keyorix.v1.ConnectRefGrant
-	136, // 225: keyorix.v1.ConnectService.DeleteRefGrant:output_type -> google.protobuf.Empty
-	159, // [159:226] is the sub-list for method output_type
-	92,  // [92:159] is the sub-list for method input_type
-	92,  // [92:92] is the sub-list for extension type_name
-	92,  // [92:92] is the sub-list for extension extendee
-	0,   // [0:92] is the sub-list for field type_name
+	138, // 34: keyorix.v1.WriteAuditCheckpointResponse.anchored_at:type_name -> google.protobuf.Timestamp
+	138, // 35: keyorix.v1.GetAuditRetentionResponse.oldest_event:type_name -> google.protobuf.Timestamp
+	138, // 36: keyorix.v1.GetAuditRetentionResponse.newest_event:type_name -> google.protobuf.Timestamp
+	138, // 37: keyorix.v1.ShareRecord.created_at:type_name -> google.protobuf.Timestamp
+	138, // 38: keyorix.v1.ShareRecord.updated_at:type_name -> google.protobuf.Timestamp
+	53,  // 39: keyorix.v1.ListSharesResponse.shares:type_name -> keyorix.v1.ShareRecord
+	138, // 40: keyorix.v1.HealthResponse.timestamp:type_name -> google.protobuf.Timestamp
+	135, // 41: keyorix.v1.HealthResponse.services:type_name -> keyorix.v1.HealthResponse.ServicesEntry
+	136, // 42: keyorix.v1.SystemInfo.features:type_name -> keyorix.v1.SystemInfo.FeaturesEntry
+	63,  // 43: keyorix.v1.SystemInfo.database:type_name -> keyorix.v1.DatabaseInfo
+	64,  // 44: keyorix.v1.SystemInfo.encryption:type_name -> keyorix.v1.EncryptionInfo
+	66,  // 45: keyorix.v1.Metrics.requests:type_name -> keyorix.v1.RequestMetrics
+	67,  // 46: keyorix.v1.Metrics.secrets:type_name -> keyorix.v1.SecretMetrics
+	68,  // 47: keyorix.v1.Metrics.users:type_name -> keyorix.v1.UserMetrics
+	69,  // 48: keyorix.v1.Metrics.performance:type_name -> keyorix.v1.PerformanceMetrics
+	70,  // 49: keyorix.v1.Metrics.system:type_name -> keyorix.v1.SystemMetrics
+	138, // 50: keyorix.v1.Project.created_at:type_name -> google.protobuf.Timestamp
+	138, // 51: keyorix.v1.Project.updated_at:type_name -> google.protobuf.Timestamp
+	138, // 52: keyorix.v1.Environment.created_at:type_name -> google.protobuf.Timestamp
+	138, // 53: keyorix.v1.Environment.updated_at:type_name -> google.protobuf.Timestamp
+	71,  // 54: keyorix.v1.ListProjectsResponse.projects:type_name -> keyorix.v1.Project
+	72,  // 55: keyorix.v1.ListEnvironmentsResponse.environments:type_name -> keyorix.v1.Environment
+	138, // 56: keyorix.v1.MachineIdentity.created_at:type_name -> google.protobuf.Timestamp
+	138, // 57: keyorix.v1.MachineIdentity.updated_at:type_name -> google.protobuf.Timestamp
+	138, // 58: keyorix.v1.MachineIdentity.last_seen_at:type_name -> google.protobuf.Timestamp
+	138, // 59: keyorix.v1.MachineIdentity.revoked_at:type_name -> google.protobuf.Timestamp
+	138, // 60: keyorix.v1.MachineToken.last_used_at:type_name -> google.protobuf.Timestamp
+	138, // 61: keyorix.v1.MachineToken.expires_at:type_name -> google.protobuf.Timestamp
+	138, // 62: keyorix.v1.MachineToken.created_at:type_name -> google.protobuf.Timestamp
+	80,  // 63: keyorix.v1.ListMachineIdentitiesResponse.machine_identities:type_name -> keyorix.v1.MachineIdentity
+	138, // 64: keyorix.v1.IssueMachineTokenResponse.expires_at:type_name -> google.protobuf.Timestamp
+	81,  // 65: keyorix.v1.ListMachineTokensResponse.tokens:type_name -> keyorix.v1.MachineToken
+	138, // 66: keyorix.v1.DynamicSecretConfig.created_at:type_name -> google.protobuf.Timestamp
+	138, // 67: keyorix.v1.DynamicSecretLease.issued_at:type_name -> google.protobuf.Timestamp
+	138, // 68: keyorix.v1.DynamicSecretLease.expires_at:type_name -> google.protobuf.Timestamp
+	138, // 69: keyorix.v1.DynamicSecretLease.revoked_at:type_name -> google.protobuf.Timestamp
+	138, // 70: keyorix.v1.IssuedCredential.expires_at:type_name -> google.protobuf.Timestamp
+	137, // 71: keyorix.v1.IssuedCredential.fields:type_name -> keyorix.v1.IssuedCredential.FieldsEntry
+	93,  // 72: keyorix.v1.ListDynamicConfigsResponse.configs:type_name -> keyorix.v1.DynamicSecretConfig
+	94,  // 73: keyorix.v1.ListLeasesResponse.leases:type_name -> keyorix.v1.DynamicSecretLease
+	138, // 74: keyorix.v1.RenewLeaseResponse.expires_at:type_name -> google.protobuf.Timestamp
+	114, // 75: keyorix.v1.ClassificationPosture.dynamic_configs:type_name -> keyorix.v1.ClassificationCounts
+	114, // 76: keyorix.v1.ClassificationPosture.machine_identities:type_name -> keyorix.v1.ClassificationCounts
+	114, // 77: keyorix.v1.ClassificationPosture.machine_credentials:type_name -> keyorix.v1.ClassificationCounts
+	138, // 78: keyorix.v1.LegalHoldPosture.placed_at:type_name -> google.protobuf.Timestamp
+	138, // 79: keyorix.v1.CompliancePosture.generated_at:type_name -> google.protobuf.Timestamp
+	109, // 80: keyorix.v1.CompliancePosture.audit_integrity:type_name -> keyorix.v1.AuditIntegrityPosture
+	110, // 81: keyorix.v1.CompliancePosture.access_governance:type_name -> keyorix.v1.AccessGovernancePosture
+	111, // 82: keyorix.v1.CompliancePosture.rotation:type_name -> keyorix.v1.RotationPosture
+	112, // 83: keyorix.v1.CompliancePosture.identity:type_name -> keyorix.v1.IdentityPosture
+	113, // 84: keyorix.v1.CompliancePosture.emergency_access:type_name -> keyorix.v1.EmergencyAccessPosture
+	115, // 85: keyorix.v1.CompliancePosture.classification:type_name -> keyorix.v1.ClassificationPosture
+	116, // 86: keyorix.v1.CompliancePosture.anomalies:type_name -> keyorix.v1.AnomaliesPosture
+	117, // 87: keyorix.v1.CompliancePosture.legal_hold:type_name -> keyorix.v1.LegalHoldPosture
+	118, // 88: keyorix.v1.CompliancePosture.retention:type_name -> keyorix.v1.RetentionPosture
+	119, // 89: keyorix.v1.CompliancePosture.risk:type_name -> keyorix.v1.RiskPosture
+	121, // 90: keyorix.v1.ControlState.frameworks:type_name -> keyorix.v1.FrameworkRefs
+	138, // 91: keyorix.v1.ComplianceControls.generated_at:type_name -> google.protobuf.Timestamp
+	122, // 92: keyorix.v1.ComplianceControls.controls:type_name -> keyorix.v1.ControlState
+	123, // 93: keyorix.v1.ComplianceControls.summary:type_name -> keyorix.v1.ControlsSummary
+	128, // 94: keyorix.v1.ConnectRefGrantList.grants:type_name -> keyorix.v1.ConnectRefGrant
+	2,   // 95: keyorix.v1.SecretService.CreateSecret:input_type -> keyorix.v1.CreateSecretRequest
+	3,   // 96: keyorix.v1.SecretService.GetSecret:input_type -> keyorix.v1.GetSecretRequest
+	3,   // 97: keyorix.v1.SecretService.GetSecretValue:input_type -> keyorix.v1.GetSecretRequest
+	4,   // 98: keyorix.v1.SecretService.UpdateSecret:input_type -> keyorix.v1.UpdateSecretRequest
+	5,   // 99: keyorix.v1.SecretService.DeleteSecret:input_type -> keyorix.v1.DeleteSecretRequest
+	6,   // 100: keyorix.v1.SecretService.ListSecrets:input_type -> keyorix.v1.ListSecretsRequest
+	8,   // 101: keyorix.v1.SecretService.GetSecretVersions:input_type -> keyorix.v1.GetSecretVersionsRequest
+	9,   // 102: keyorix.v1.SecretService.SetSecretAutoRotate:input_type -> keyorix.v1.SetSecretAutoRotateRequest
+	3,   // 103: keyorix.v1.SecretService.ListSecretDependencies:input_type -> keyorix.v1.GetSecretRequest
+	3,   // 104: keyorix.v1.SecretService.GetSecretImpact:input_type -> keyorix.v1.GetSecretRequest
+	54,  // 105: keyorix.v1.ShareService.ShareSecret:input_type -> keyorix.v1.ShareSecretRequest
+	55,  // 106: keyorix.v1.ShareService.ListSecretShares:input_type -> keyorix.v1.ListSecretSharesRequest
+	56,  // 107: keyorix.v1.ShareService.ListUserShares:input_type -> keyorix.v1.ListUserSharesRequest
+	57,  // 108: keyorix.v1.ShareService.ListSharedSecrets:input_type -> keyorix.v1.ListSharedSecretsRequest
+	59,  // 109: keyorix.v1.ShareService.UpdateSharePermission:input_type -> keyorix.v1.UpdateSharePermissionRequest
+	60,  // 110: keyorix.v1.ShareService.RevokeShare:input_type -> keyorix.v1.RevokeShareRequest
+	23,  // 111: keyorix.v1.UserService.CreateUser:input_type -> keyorix.v1.CreateUserRequest
+	25,  // 112: keyorix.v1.UserService.GetUser:input_type -> keyorix.v1.GetUserRequest
+	26,  // 113: keyorix.v1.UserService.UpdateUser:input_type -> keyorix.v1.UpdateUserRequest
+	27,  // 114: keyorix.v1.UserService.DeleteUser:input_type -> keyorix.v1.DeleteUserRequest
+	28,  // 115: keyorix.v1.UserService.ListUsers:input_type -> keyorix.v1.ListUsersRequest
+	32,  // 116: keyorix.v1.RoleService.CreateRole:input_type -> keyorix.v1.CreateRoleRequest
+	33,  // 117: keyorix.v1.RoleService.GetRole:input_type -> keyorix.v1.GetRoleRequest
+	34,  // 118: keyorix.v1.RoleService.UpdateRole:input_type -> keyorix.v1.UpdateRoleRequest
+	35,  // 119: keyorix.v1.RoleService.DeleteRole:input_type -> keyorix.v1.DeleteRoleRequest
+	36,  // 120: keyorix.v1.RoleService.ListRoles:input_type -> keyorix.v1.ListRolesRequest
+	38,  // 121: keyorix.v1.RoleService.AssignRole:input_type -> keyorix.v1.AssignRoleRequest
+	40,  // 122: keyorix.v1.RoleService.RemoveRole:input_type -> keyorix.v1.RemoveRoleRequest
+	41,  // 123: keyorix.v1.RoleService.GetUserRoles:input_type -> keyorix.v1.GetUserRolesRequest
+	44,  // 124: keyorix.v1.AuditService.GetAuditLogs:input_type -> keyorix.v1.GetAuditLogsRequest
+	47,  // 125: keyorix.v1.AuditService.GetRBACAuditLogs:input_type -> keyorix.v1.GetRBACAuditLogsRequest
+	49,  // 126: keyorix.v1.AuditService.StreamAuditLogs:input_type -> keyorix.v1.StreamAuditLogsRequest
+	139, // 127: keyorix.v1.AuditService.VerifyAuditChain:input_type -> google.protobuf.Empty
+	139, // 128: keyorix.v1.AuditService.WriteAuditCheckpoint:input_type -> google.protobuf.Empty
+	139, // 129: keyorix.v1.AuditService.GetAuditRetention:input_type -> google.protobuf.Empty
+	139, // 130: keyorix.v1.SystemService.HealthCheck:input_type -> google.protobuf.Empty
+	139, // 131: keyorix.v1.SystemService.GetSystemInfo:input_type -> google.protobuf.Empty
+	139, // 132: keyorix.v1.SystemService.GetMetrics:input_type -> google.protobuf.Empty
+	139, // 133: keyorix.v1.ProjectService.ListProjects:input_type -> google.protobuf.Empty
+	74,  // 134: keyorix.v1.ProjectService.GetProject:input_type -> keyorix.v1.GetProjectRequest
+	75,  // 135: keyorix.v1.ProjectService.CreateProject:input_type -> keyorix.v1.CreateProjectRequest
+	76,  // 136: keyorix.v1.ProjectService.UpdateProject:input_type -> keyorix.v1.UpdateProjectRequest
+	77,  // 137: keyorix.v1.ProjectService.DeleteProject:input_type -> keyorix.v1.DeleteProjectRequest
+	74,  // 138: keyorix.v1.ProjectService.GetProjectRotationOrder:input_type -> keyorix.v1.GetProjectRequest
+	74,  // 139: keyorix.v1.ProjectService.GetProjectRotationPlan:input_type -> keyorix.v1.GetProjectRequest
+	78,  // 140: keyorix.v1.ProjectService.ListEnvironments:input_type -> keyorix.v1.ListEnvironmentsRequest
+	82,  // 141: keyorix.v1.MachineIdentityService.ListMachineIdentities:input_type -> keyorix.v1.ListMachineIdentitiesRequest
+	84,  // 142: keyorix.v1.MachineIdentityService.CreateMachineIdentity:input_type -> keyorix.v1.CreateMachineIdentityRequest
+	85,  // 143: keyorix.v1.MachineIdentityService.TransitionMachineIdentity:input_type -> keyorix.v1.TransitionMachineIdentityRequest
+	86,  // 144: keyorix.v1.MachineIdentityService.ClassifyMachineIdentity:input_type -> keyorix.v1.ClassifyMachineIdentityRequest
+	87,  // 145: keyorix.v1.MachineIdentityService.IssueMachineToken:input_type -> keyorix.v1.IssueMachineTokenRequest
+	89,  // 146: keyorix.v1.MachineIdentityService.ListMachineTokens:input_type -> keyorix.v1.ListMachineTokensRequest
+	91,  // 147: keyorix.v1.MachineIdentityService.RevokeMachineToken:input_type -> keyorix.v1.RevokeMachineTokenRequest
+	92,  // 148: keyorix.v1.MachineIdentityService.ClassifyMachineToken:input_type -> keyorix.v1.ClassifyMachineTokenRequest
+	96,  // 149: keyorix.v1.DynamicSecretService.ListConfigs:input_type -> keyorix.v1.ListDynamicConfigsRequest
+	98,  // 150: keyorix.v1.DynamicSecretService.GetConfig:input_type -> keyorix.v1.GetDynamicConfigRequest
+	99,  // 151: keyorix.v1.DynamicSecretService.CreateConfig:input_type -> keyorix.v1.CreateDynamicConfigRequest
+	100, // 152: keyorix.v1.DynamicSecretService.ClassifyConfig:input_type -> keyorix.v1.ClassifyDynamicConfigRequest
+	101, // 153: keyorix.v1.DynamicSecretService.IssueLease:input_type -> keyorix.v1.IssueLeaseRequest
+	102, // 154: keyorix.v1.DynamicSecretService.ListLeases:input_type -> keyorix.v1.ListLeasesRequest
+	104, // 155: keyorix.v1.DynamicSecretService.RevokeLease:input_type -> keyorix.v1.RevokeLeaseRequest
+	105, // 156: keyorix.v1.DynamicSecretService.RenewLease:input_type -> keyorix.v1.RenewLeaseRequest
+	107, // 157: keyorix.v1.DynamicSecretService.RevokeAllLeases:input_type -> keyorix.v1.RevokeAllLeasesRequest
+	139, // 158: keyorix.v1.ComplianceService.GetCompliancePosture:input_type -> google.protobuf.Empty
+	139, // 159: keyorix.v1.ComplianceService.GetComplianceControls:input_type -> google.protobuf.Empty
+	139, // 160: keyorix.v1.ConnectService.ListConnectors:input_type -> google.protobuf.Empty
+	126, // 161: keyorix.v1.ConnectService.ReadSecret:input_type -> keyorix.v1.ReadFederatedSecretRequest
+	139, // 162: keyorix.v1.ConnectService.ListRefGrants:input_type -> google.protobuf.Empty
+	130, // 163: keyorix.v1.ConnectService.CreateRefGrant:input_type -> keyorix.v1.CreateConnectRefGrantRequest
+	131, // 164: keyorix.v1.ConnectService.DeleteRefGrant:input_type -> keyorix.v1.DeleteConnectRefGrantRequest
+	0,   // 165: keyorix.v1.SecretService.CreateSecret:output_type -> keyorix.v1.Secret
+	0,   // 166: keyorix.v1.SecretService.GetSecret:output_type -> keyorix.v1.Secret
+	1,   // 167: keyorix.v1.SecretService.GetSecretValue:output_type -> keyorix.v1.SecretValue
+	0,   // 168: keyorix.v1.SecretService.UpdateSecret:output_type -> keyorix.v1.Secret
+	139, // 169: keyorix.v1.SecretService.DeleteSecret:output_type -> google.protobuf.Empty
+	7,   // 170: keyorix.v1.SecretService.ListSecrets:output_type -> keyorix.v1.ListSecretsResponse
+	11,  // 171: keyorix.v1.SecretService.GetSecretVersions:output_type -> keyorix.v1.GetSecretVersionsResponse
+	139, // 172: keyorix.v1.SecretService.SetSecretAutoRotate:output_type -> google.protobuf.Empty
+	13,  // 173: keyorix.v1.SecretService.ListSecretDependencies:output_type -> keyorix.v1.SecretDependencies
+	15,  // 174: keyorix.v1.SecretService.GetSecretImpact:output_type -> keyorix.v1.SecretImpact
+	53,  // 175: keyorix.v1.ShareService.ShareSecret:output_type -> keyorix.v1.ShareRecord
+	58,  // 176: keyorix.v1.ShareService.ListSecretShares:output_type -> keyorix.v1.ListSharesResponse
+	58,  // 177: keyorix.v1.ShareService.ListUserShares:output_type -> keyorix.v1.ListSharesResponse
+	7,   // 178: keyorix.v1.ShareService.ListSharedSecrets:output_type -> keyorix.v1.ListSecretsResponse
+	53,  // 179: keyorix.v1.ShareService.UpdateSharePermission:output_type -> keyorix.v1.ShareRecord
+	139, // 180: keyorix.v1.ShareService.RevokeShare:output_type -> google.protobuf.Empty
+	24,  // 181: keyorix.v1.UserService.CreateUser:output_type -> keyorix.v1.CreateUserResponse
+	21,  // 182: keyorix.v1.UserService.GetUser:output_type -> keyorix.v1.User
+	21,  // 183: keyorix.v1.UserService.UpdateUser:output_type -> keyorix.v1.User
+	139, // 184: keyorix.v1.UserService.DeleteUser:output_type -> google.protobuf.Empty
+	29,  // 185: keyorix.v1.UserService.ListUsers:output_type -> keyorix.v1.ListUsersResponse
+	31,  // 186: keyorix.v1.RoleService.CreateRole:output_type -> keyorix.v1.Role
+	31,  // 187: keyorix.v1.RoleService.GetRole:output_type -> keyorix.v1.Role
+	31,  // 188: keyorix.v1.RoleService.UpdateRole:output_type -> keyorix.v1.Role
+	139, // 189: keyorix.v1.RoleService.DeleteRole:output_type -> google.protobuf.Empty
+	37,  // 190: keyorix.v1.RoleService.ListRoles:output_type -> keyorix.v1.ListRolesResponse
+	39,  // 191: keyorix.v1.RoleService.AssignRole:output_type -> keyorix.v1.RoleAssignment
+	139, // 192: keyorix.v1.RoleService.RemoveRole:output_type -> google.protobuf.Empty
+	42,  // 193: keyorix.v1.RoleService.GetUserRoles:output_type -> keyorix.v1.GetUserRolesResponse
+	45,  // 194: keyorix.v1.AuditService.GetAuditLogs:output_type -> keyorix.v1.GetAuditLogsResponse
+	48,  // 195: keyorix.v1.AuditService.GetRBACAuditLogs:output_type -> keyorix.v1.GetRBACAuditLogsResponse
+	43,  // 196: keyorix.v1.AuditService.StreamAuditLogs:output_type -> keyorix.v1.AuditLog
+	50,  // 197: keyorix.v1.AuditService.VerifyAuditChain:output_type -> keyorix.v1.VerifyAuditChainResponse
+	51,  // 198: keyorix.v1.AuditService.WriteAuditCheckpoint:output_type -> keyorix.v1.WriteAuditCheckpointResponse
+	52,  // 199: keyorix.v1.AuditService.GetAuditRetention:output_type -> keyorix.v1.GetAuditRetentionResponse
+	61,  // 200: keyorix.v1.SystemService.HealthCheck:output_type -> keyorix.v1.HealthResponse
+	62,  // 201: keyorix.v1.SystemService.GetSystemInfo:output_type -> keyorix.v1.SystemInfo
+	65,  // 202: keyorix.v1.SystemService.GetMetrics:output_type -> keyorix.v1.Metrics
+	73,  // 203: keyorix.v1.ProjectService.ListProjects:output_type -> keyorix.v1.ListProjectsResponse
+	71,  // 204: keyorix.v1.ProjectService.GetProject:output_type -> keyorix.v1.Project
+	71,  // 205: keyorix.v1.ProjectService.CreateProject:output_type -> keyorix.v1.Project
+	71,  // 206: keyorix.v1.ProjectService.UpdateProject:output_type -> keyorix.v1.Project
+	139, // 207: keyorix.v1.ProjectService.DeleteProject:output_type -> google.protobuf.Empty
+	17,  // 208: keyorix.v1.ProjectService.GetProjectRotationOrder:output_type -> keyorix.v1.RotationOrder
+	20,  // 209: keyorix.v1.ProjectService.GetProjectRotationPlan:output_type -> keyorix.v1.RotationPlan
+	79,  // 210: keyorix.v1.ProjectService.ListEnvironments:output_type -> keyorix.v1.ListEnvironmentsResponse
+	83,  // 211: keyorix.v1.MachineIdentityService.ListMachineIdentities:output_type -> keyorix.v1.ListMachineIdentitiesResponse
+	80,  // 212: keyorix.v1.MachineIdentityService.CreateMachineIdentity:output_type -> keyorix.v1.MachineIdentity
+	80,  // 213: keyorix.v1.MachineIdentityService.TransitionMachineIdentity:output_type -> keyorix.v1.MachineIdentity
+	80,  // 214: keyorix.v1.MachineIdentityService.ClassifyMachineIdentity:output_type -> keyorix.v1.MachineIdentity
+	88,  // 215: keyorix.v1.MachineIdentityService.IssueMachineToken:output_type -> keyorix.v1.IssueMachineTokenResponse
+	90,  // 216: keyorix.v1.MachineIdentityService.ListMachineTokens:output_type -> keyorix.v1.ListMachineTokensResponse
+	139, // 217: keyorix.v1.MachineIdentityService.RevokeMachineToken:output_type -> google.protobuf.Empty
+	81,  // 218: keyorix.v1.MachineIdentityService.ClassifyMachineToken:output_type -> keyorix.v1.MachineToken
+	97,  // 219: keyorix.v1.DynamicSecretService.ListConfigs:output_type -> keyorix.v1.ListDynamicConfigsResponse
+	93,  // 220: keyorix.v1.DynamicSecretService.GetConfig:output_type -> keyorix.v1.DynamicSecretConfig
+	93,  // 221: keyorix.v1.DynamicSecretService.CreateConfig:output_type -> keyorix.v1.DynamicSecretConfig
+	93,  // 222: keyorix.v1.DynamicSecretService.ClassifyConfig:output_type -> keyorix.v1.DynamicSecretConfig
+	95,  // 223: keyorix.v1.DynamicSecretService.IssueLease:output_type -> keyorix.v1.IssuedCredential
+	103, // 224: keyorix.v1.DynamicSecretService.ListLeases:output_type -> keyorix.v1.ListLeasesResponse
+	139, // 225: keyorix.v1.DynamicSecretService.RevokeLease:output_type -> google.protobuf.Empty
+	106, // 226: keyorix.v1.DynamicSecretService.RenewLease:output_type -> keyorix.v1.RenewLeaseResponse
+	108, // 227: keyorix.v1.DynamicSecretService.RevokeAllLeases:output_type -> keyorix.v1.RevokeAllLeasesResponse
+	120, // 228: keyorix.v1.ComplianceService.GetCompliancePosture:output_type -> keyorix.v1.CompliancePosture
+	124, // 229: keyorix.v1.ComplianceService.GetComplianceControls:output_type -> keyorix.v1.ComplianceControls
+	125, // 230: keyorix.v1.ConnectService.ListConnectors:output_type -> keyorix.v1.ConnectorList
+	127, // 231: keyorix.v1.ConnectService.ReadSecret:output_type -> keyorix.v1.FederatedSecretValue
+	129, // 232: keyorix.v1.ConnectService.ListRefGrants:output_type -> keyorix.v1.ConnectRefGrantList
+	128, // 233: keyorix.v1.ConnectService.CreateRefGrant:output_type -> keyorix.v1.ConnectRefGrant
+	139, // 234: keyorix.v1.ConnectService.DeleteRefGrant:output_type -> google.protobuf.Empty
+	165, // [165:235] is the sub-list for method output_type
+	95,  // [95:165] is the sub-list for method input_type
+	95,  // [95:95] is the sub-list for extension type_name
+	95,  // [95:95] is the sub-list for extension extendee
+	0,   // [0:95] is the sub-list for field type_name
 }
 
 func init() { file_keyorix_proto_init() }
@@ -10344,19 +10679,22 @@ func file_keyorix_proto_init() {
 	file_keyorix_proto_msgTypes[46].OneofWrappers = []any{}
 	file_keyorix_proto_msgTypes[47].OneofWrappers = []any{}
 	file_keyorix_proto_msgTypes[49].OneofWrappers = []any{}
-	file_keyorix_proto_msgTypes[73].OneofWrappers = []any{}
-	file_keyorix_proto_msgTypes[77].OneofWrappers = []any{}
-	file_keyorix_proto_msgTypes[78].OneofWrappers = []any{}
-	file_keyorix_proto_msgTypes[85].OneofWrappers = []any{}
-	file_keyorix_proto_msgTypes[91].OneofWrappers = []any{}
-	file_keyorix_proto_msgTypes[92].OneofWrappers = []any{}
+	file_keyorix_proto_msgTypes[50].OneofWrappers = []any{}
+	file_keyorix_proto_msgTypes[51].OneofWrappers = []any{}
+	file_keyorix_proto_msgTypes[52].OneofWrappers = []any{}
+	file_keyorix_proto_msgTypes[76].OneofWrappers = []any{}
+	file_keyorix_proto_msgTypes[80].OneofWrappers = []any{}
+	file_keyorix_proto_msgTypes[81].OneofWrappers = []any{}
+	file_keyorix_proto_msgTypes[88].OneofWrappers = []any{}
+	file_keyorix_proto_msgTypes[94].OneofWrappers = []any{}
+	file_keyorix_proto_msgTypes[95].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_keyorix_proto_rawDesc), len(file_keyorix_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   135,
+			NumMessages:   138,
 			NumExtensions: 0,
 			NumServices:   11,
 		},

--- a/server/proto/pb/keyorix_grpc.pb.go
+++ b/server/proto/pb/keyorix_grpc.pb.go
@@ -1456,9 +1456,12 @@ var RoleService_ServiceDesc = grpc.ServiceDesc{
 }
 
 const (
-	AuditService_GetAuditLogs_FullMethodName     = "/keyorix.v1.AuditService/GetAuditLogs"
-	AuditService_GetRBACAuditLogs_FullMethodName = "/keyorix.v1.AuditService/GetRBACAuditLogs"
-	AuditService_StreamAuditLogs_FullMethodName  = "/keyorix.v1.AuditService/StreamAuditLogs"
+	AuditService_GetAuditLogs_FullMethodName         = "/keyorix.v1.AuditService/GetAuditLogs"
+	AuditService_GetRBACAuditLogs_FullMethodName     = "/keyorix.v1.AuditService/GetRBACAuditLogs"
+	AuditService_StreamAuditLogs_FullMethodName      = "/keyorix.v1.AuditService/StreamAuditLogs"
+	AuditService_VerifyAuditChain_FullMethodName     = "/keyorix.v1.AuditService/VerifyAuditChain"
+	AuditService_WriteAuditCheckpoint_FullMethodName = "/keyorix.v1.AuditService/WriteAuditCheckpoint"
+	AuditService_GetAuditRetention_FullMethodName    = "/keyorix.v1.AuditService/GetAuditRetention"
 )
 
 // AuditServiceClient is the client API for AuditService service.
@@ -1473,6 +1476,15 @@ type AuditServiceClient interface {
 	GetRBACAuditLogs(ctx context.Context, in *GetRBACAuditLogsRequest, opts ...grpc.CallOption) (*GetRBACAuditLogsResponse, error)
 	// Stream audit events as they occur
 	StreamAuditLogs(ctx context.Context, in *StreamAuditLogsRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[AuditLog], error)
+	// Verify the tamper-evidence hash chain (ADR-029): re-walk the chain and report
+	// whether the trail is intact, naming the first divergent event on failure.
+	VerifyAuditChain(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*VerifyAuditChainResponse, error)
+	// Write a signed checkpoint of the verified audit-chain head on demand (ADR-029).
+	// Requires encryption (the signing key is DEK-derived) and a chain that verifies.
+	WriteAuditCheckpoint(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*WriteAuditCheckpointResponse, error)
+	// Report the audit trail's retention coverage (total events, oldest/newest, and
+	// whether it demonstrably covers the NIS2 12-month window).
+	GetAuditRetention(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*GetAuditRetentionResponse, error)
 }
 
 type auditServiceClient struct {
@@ -1522,6 +1534,36 @@ func (c *auditServiceClient) StreamAuditLogs(ctx context.Context, in *StreamAudi
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type AuditService_StreamAuditLogsClient = grpc.ServerStreamingClient[AuditLog]
 
+func (c *auditServiceClient) VerifyAuditChain(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*VerifyAuditChainResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(VerifyAuditChainResponse)
+	err := c.cc.Invoke(ctx, AuditService_VerifyAuditChain_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *auditServiceClient) WriteAuditCheckpoint(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*WriteAuditCheckpointResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(WriteAuditCheckpointResponse)
+	err := c.cc.Invoke(ctx, AuditService_WriteAuditCheckpoint_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *auditServiceClient) GetAuditRetention(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*GetAuditRetentionResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetAuditRetentionResponse)
+	err := c.cc.Invoke(ctx, AuditService_GetAuditRetention_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // AuditServiceServer is the server API for AuditService service.
 // All implementations must embed UnimplementedAuditServiceServer
 // for forward compatibility.
@@ -1534,6 +1576,15 @@ type AuditServiceServer interface {
 	GetRBACAuditLogs(context.Context, *GetRBACAuditLogsRequest) (*GetRBACAuditLogsResponse, error)
 	// Stream audit events as they occur
 	StreamAuditLogs(*StreamAuditLogsRequest, grpc.ServerStreamingServer[AuditLog]) error
+	// Verify the tamper-evidence hash chain (ADR-029): re-walk the chain and report
+	// whether the trail is intact, naming the first divergent event on failure.
+	VerifyAuditChain(context.Context, *emptypb.Empty) (*VerifyAuditChainResponse, error)
+	// Write a signed checkpoint of the verified audit-chain head on demand (ADR-029).
+	// Requires encryption (the signing key is DEK-derived) and a chain that verifies.
+	WriteAuditCheckpoint(context.Context, *emptypb.Empty) (*WriteAuditCheckpointResponse, error)
+	// Report the audit trail's retention coverage (total events, oldest/newest, and
+	// whether it demonstrably covers the NIS2 12-month window).
+	GetAuditRetention(context.Context, *emptypb.Empty) (*GetAuditRetentionResponse, error)
 	mustEmbedUnimplementedAuditServiceServer()
 }
 
@@ -1552,6 +1603,15 @@ func (UnimplementedAuditServiceServer) GetRBACAuditLogs(context.Context, *GetRBA
 }
 func (UnimplementedAuditServiceServer) StreamAuditLogs(*StreamAuditLogsRequest, grpc.ServerStreamingServer[AuditLog]) error {
 	return status.Error(codes.Unimplemented, "method StreamAuditLogs not implemented")
+}
+func (UnimplementedAuditServiceServer) VerifyAuditChain(context.Context, *emptypb.Empty) (*VerifyAuditChainResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method VerifyAuditChain not implemented")
+}
+func (UnimplementedAuditServiceServer) WriteAuditCheckpoint(context.Context, *emptypb.Empty) (*WriteAuditCheckpointResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method WriteAuditCheckpoint not implemented")
+}
+func (UnimplementedAuditServiceServer) GetAuditRetention(context.Context, *emptypb.Empty) (*GetAuditRetentionResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method GetAuditRetention not implemented")
 }
 func (UnimplementedAuditServiceServer) mustEmbedUnimplementedAuditServiceServer() {}
 func (UnimplementedAuditServiceServer) testEmbeddedByValue()                      {}
@@ -1621,6 +1681,60 @@ func _AuditService_StreamAuditLogs_Handler(srv interface{}, stream grpc.ServerSt
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type AuditService_StreamAuditLogsServer = grpc.ServerStreamingServer[AuditLog]
 
+func _AuditService_VerifyAuditChain_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(emptypb.Empty)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(AuditServiceServer).VerifyAuditChain(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: AuditService_VerifyAuditChain_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(AuditServiceServer).VerifyAuditChain(ctx, req.(*emptypb.Empty))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _AuditService_WriteAuditCheckpoint_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(emptypb.Empty)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(AuditServiceServer).WriteAuditCheckpoint(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: AuditService_WriteAuditCheckpoint_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(AuditServiceServer).WriteAuditCheckpoint(ctx, req.(*emptypb.Empty))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _AuditService_GetAuditRetention_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(emptypb.Empty)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(AuditServiceServer).GetAuditRetention(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: AuditService_GetAuditRetention_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(AuditServiceServer).GetAuditRetention(ctx, req.(*emptypb.Empty))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // AuditService_ServiceDesc is the grpc.ServiceDesc for AuditService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -1635,6 +1749,18 @@ var AuditService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetRBACAuditLogs",
 			Handler:    _AuditService_GetRBACAuditLogs_Handler,
+		},
+		{
+			MethodName: "VerifyAuditChain",
+			Handler:    _AuditService_VerifyAuditChain_Handler,
+		},
+		{
+			MethodName: "WriteAuditCheckpoint",
+			Handler:    _AuditService_WriteAuditCheckpoint_Handler,
+		},
+		{
+			MethodName: "GetAuditRetention",
+			Handler:    _AuditService_GetAuditRetention_Handler,
 		},
 	},
 	Streams: []grpc.StreamDesc{


### PR DESCRIPTION
## What

The gRPC `AuditService` was **read-only** (`GetAuditLogs` / `GetRBACAuditLogs` / `StreamAuditLogs`), while HTTP + CLI also expose the audit-**integrity** surface. Programmatic clients (SIEM / compliance tooling) had no gRPC way to verify the tamper-evidence chain or read retention coverage. This closes the parity gap with three RPCs:

- **`VerifyAuditChain`** — re-walks the ADR-029 hash chain; returns valid / chained / unchained counts, the head (id + hash) for off-box truncation detection, checkpointed state, and the first-broken id + reason on failure. `audit.read`.
- **`WriteAuditCheckpoint`** — signs a checkpoint of the verified head on demand; privileged (`system.write`). Returns `FailedPrecondition` when the chain doesn't verify or encryption is disabled (the signing key is DEK-derived), mirroring the HTTP 409/412.
- **`GetAuditRetention`** — total events, oldest/newest, coverage days, `meets_nis2_12_month`. `audit.read`.

A bulk **Export** RPC was deliberately **not** added — `GetAuditLogs` (paginated) + `StreamAuditLogs` already cover programmatic reads; CSV/NDJSON bulk download is an HTTP-only concern.

## Notes
- Proto regenerated with the **pinned** toolchain (`protoc-gen-go` v1.36.11 / `-grpc` v1.6.2); verified clean `main` regenerates to **zero drift**, so the large `.pb.go` diff is just the serialized-descriptor churn from adding 3 messages.
- `coverage_days` is `int64` (avoids a lossy `int→int32` cast / gosec G115).

## Tests / gate
- verify (intact chain), retention (unlimited + count), checkpoint-requires-encryption precondition, unauthenticated.
- `go build ./...` ✅ · `go vet` ✅ · `golangci-lint` 0 ✅ · `gosec` 0 ✅

First of three gRPC-parity PRs (audit → break-glass → groups).

🤖 Generated with [Claude Code](https://claude.com/claude-code)