### PR TITLE
fix(core): exclude expired time-bound shares from ListUserPermissions

### DIFF
--- a/internal/cli/share/expiry_test.go
+++ b/internal/cli/share/expiry_test.go
@@ -35,6 +35,7 @@ func TestResolveShareExpiry(t *testing.T) {
 		}
 		if got == nil {
 			t.Fatal("got nil, want a time ~2h out")
+			return // unreachable after Fatal, but tells staticcheck got is non-nil below
 		}
 		// Allow a wide window so the test never clock-bombs.
 		delta := got.Sub(before)

--- a/internal/core/list_user_permissions_test.go
+++ b/internal/core/list_user_permissions_test.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/stretchr/testify/assert"
@@ -47,6 +48,44 @@ func TestListUserPermissions_IncludesGroupShares(t *testing.T) {
 	assert.Equal(t, uint(5), *g.GroupID)
 	require.NotNil(t, g.ShareID)
 	assert.Equal(t, uint(30), *g.ShareID)
+}
+
+func TestListUserPermissions_ExcludesExpiredShares(t *testing.T) {
+	ctx := context.Background()
+	const userID = uint(9)
+	ms := new(MockStorage)
+	c := NewKeyorixCore(ms)
+
+	past := time.Now().Add(-1 * time.Hour)
+	future := time.Now().Add(1 * time.Hour)
+
+	ms.On("ListSecrets", ctx, mock.AnythingOfType("*storage.SecretFilter")).
+		Return([]*models.SecretNode{}, int64(0), nil)
+	// One active direct share (#2) and one expired direct share (#3).
+	ms.On("ListSharesByUser", ctx, userID).
+		Return([]*models.ShareRecord{
+			{ID: 20, SecretID: 2, Permission: "read"},
+			{ID: 21, SecretID: 3, Permission: "read", ExpiresAt: &past},
+		}, nil)
+	// Group #5: one active group share (#4) and one expired (#5).
+	ms.On("GetUserGroups", ctx, userID).Return([]*models.Group{{ID: 5}}, nil)
+	ms.On("ListSharesByGroup", ctx, uint(5)).
+		Return([]*models.ShareRecord{
+			{ID: 30, SecretID: 4, Permission: "write", IsGroup: true, RecipientID: 5, ExpiresAt: &future},
+			{ID: 31, SecretID: 5, Permission: "write", IsGroup: true, RecipientID: 5, ExpiresAt: &past},
+		}, nil)
+
+	perms, err := c.ListUserPermissions(ctx, userID)
+	require.NoError(t, err)
+
+	secrets := map[uint]bool{}
+	for _, p := range perms {
+		secrets[p.SecretID] = true
+	}
+	assert.True(t, secrets[2], "active direct share should be listed")
+	assert.True(t, secrets[4], "non-expired group share should be listed")
+	assert.False(t, secrets[3], "expired direct share must NOT be listed")
+	assert.False(t, secrets[5], "expired group share must NOT be listed")
 }
 
 func TestListUserPermissions_NoGroups(t *testing.T) {

--- a/internal/core/permissions.go
+++ b/internal/core/permissions.go
@@ -242,11 +242,19 @@ func (c *KeyorixCore) ListUserPermissions(ctx context.Context, userID uint) ([]*
 		})
 	}
 
+	// A time-bound share stops granting access the instant it expires, so it must
+	// not appear in the access listing either — same filter the read-path
+	// authorization (CheckSecretPermission via activeShares) applies.
+	now := c.now()
+
 	directShares, err := c.storage.ListSharesByUser(ctx, userID)
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
 	}
 	for _, share := range directShares {
+		if !shareActive(share, now) {
+			continue
+		}
 		permissions = append(permissions, &models.UserSecretPermission{
 			SecretID:   share.SecretID,
 			UserID:     userID,
@@ -267,6 +275,9 @@ func (c *KeyorixCore) ListUserPermissions(ctx context.Context, userID uint) ([]*
 			return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
 		}
 		for _, share := range groupShares {
+			if !shareActive(share, now) {
+				continue
+			}
 			groupID := group.ID
 			permissions = append(permissions, &models.UserSecretPermission{
 				SecretID:   share.SecretID,


### PR DESCRIPTION
## Bug

`ListUserPermissions` ("all secrets a user has access to") iterated direct and group shares **without filtering expired time-bound shares**, while the read-path authorization (`CheckSecretPermission` → `activeShares`) and storage `ListSharedSecrets` both drop them (`internal/core/permissions.go`). So an expired share — which grants **zero** access — still appeared in the access listing, inconsistent with enforcement.

Confirmed by reading the code: `CheckSecretPermission` applies `activeShares(shares, c.now())` (permissions.go:92); `ListUserPermissions` did not.

## Fix

Filter both the direct-share and group-share loops with `shareActive(share, c.now())` — the same predicate the read path uses.

## Impact (honest)

**Low / latent.** This method is **not currently wired to any HTTP/CLI surface** — the exposed `/users/{id}/permissions` endpoint returns RBAC permissions via a different method (`GetUserPermissionsByID`). But `ListUserPermissions` is a maintained, tested API (it has its own test file) and should be correct for when it's surfaced — and consistent with the rest of the codebase, which filters expired shares everywhere else.

## Tests / gate
- New test: an expired direct share and an expired group share are excluded while the active ones remain. Existing tests still pass.
- `go build ./...` ✅ · `go vet` ✅ · `golangci-lint` 0 ✅ · `gosec` 0 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)