### PR TITLE
feat(saml): working SAML 2.0 SSO — login flow + routes (ADR-063 Phase 1b)

### DIFF
--- a/docs/saml-sso-design.md
+++ b/docs/saml-sso-design.md
@@ -152,9 +152,11 @@ like other secrets, never inlined.
 Each phase its own ADR; nothing changes default behaviour until built (SSO stays
 opt-in/config-driven).
 
-1. **Phase 1 — SP core:** generalise `SSOProvider` with a type; add the SAML provider
-   (crewjam/saml), the metadata/login/ACS routes, signature/audience/time/replay
-   validation, and wire the existing provisioning + group/role mapping. SP-initiated only.
+1. **Phase 1 — SP core (done):** `SSOProvider` generalised with a type; the SAML provider
+   (`internal/saml`, crewjam/saml); the metadata/login/ACS routes; signature/audience/
+   time/`InResponseTo` validation (delegated to the vetted stack); and the existing
+   provisioning + group/role mapping reused. SP-initiated only. Configure per
+   [docs/saml-sso.md](saml-sso.md).
 2. **Phase 2 — hardening/parity:** encrypted assertions, IdP-initiated (opt-in), signed
    AuthnRequests, SP-key rotation, and metadata-URL refresh.
 3. **Phase 3 — ops:** admin UI/CLI to add/test a provider, a "test connection" assertion

--- a/docs/saml-sso.md
+++ b/docs/saml-sso.md
@@ -49,7 +49,8 @@ sso:
 1. Hand your IdP admin the SP metadata (`…/metadata`), or register the SP manually with
    the `sp_entity_id` + `acs_url` above.
 2. Put the IdP's metadata at `idp_metadata_file` (or paste it inline).
-3. Send users to `/auth/saml/corp/login`.
+3. Send users to `/auth/saml/corp/login`. Add `?return_to=<in-app path>` to land them on a
+   specific page after sign-in (the path is carried through as RelayState).
 
 ## Security
 

--- a/docs/saml-sso.md
+++ b/docs/saml-sso.md
@@ -1,0 +1,66 @@
+# SAML 2.0 SSO (configuring a provider)
+
+Keyorix is a SAML 2.0 **Service Provider**: users sign in through your IdP (ADFS,
+Shibboleth, Okta, Azure AD, …) and Keyorix maps the assertion to an account — the same
+session, JIT provisioning, and group→role mapping as [OIDC SSO](#), just driven by a
+signed SAML assertion. Design + rationale: [ADR-063](adr-063-saml-sso.md) /
+[saml-sso-design.md](saml-sso-design.md).
+
+SAML is a provider **type** under the existing `sso` config block. It is opt-in: with no
+SAML provider configured, nothing changes.
+
+## Endpoints
+
+For a provider named `corp`, Keyorix exposes:
+
+| Endpoint | Purpose |
+|---|---|
+| `GET /auth/saml/corp/metadata` | SP metadata XML — import into your IdP to register Keyorix. |
+| `GET /auth/saml/corp/login` | Start login (redirects to the IdP with an AuthnRequest). |
+| `POST /auth/saml/corp/acs` | Assertion Consumer Service — your IdP posts the signed response here. |
+
+## Configure
+
+```yaml
+sso:
+  enabled: true
+  providers:
+    - name: corp                      # URL slug: /auth/saml/corp/*
+      type: saml
+      saml:
+        # The IdP's SAML metadata (entityID, SSO URL, signing cert) — inline or a file:
+        idp_metadata_file: /etc/keyorix/corp-idp-metadata.xml
+        # idp_metadata_xml: "<EntityDescriptor …>…</EntityDescriptor>"
+        sp_entity_id: https://keyorix.internal/auth/saml/corp/metadata
+        acs_url:      https://keyorix.internal/auth/saml/corp/acs
+        allow_idp_initiated: false     # keep off unless your IdP requires it
+        # Attribute names to read (defaults suit Azure AD / ADFS):
+        email_attribute:  http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress
+        name_attribute:   http://schemas.xmlsoap.org/ws/2005/05/identity/claims/displayname
+        groups_attribute: http://schemas.xmlsoap.org/claims/Group
+      # Shared provisioning controls (same as OIDC):
+      auto_provision: true             # JIT-create an account on first login
+      default_role: system_viewer
+      group_sync: true                 # reconcile native group memberships from the assertion
+      group_role_map:                  # map asserted groups → Keyorix system roles
+        Keyorix-Admins: system_admin
+```
+
+1. Hand your IdP admin the SP metadata (`…/metadata`), or register the SP manually with
+   the `sp_entity_id` + `acs_url` above.
+2. Put the IdP's metadata at `idp_metadata_file` (or paste it inline).
+3. Send users to `/auth/saml/corp/login`.
+
+## Security
+
+- The assertion's signature is verified against the **pinned IdP certificate** from its
+  metadata (never a cert in the response); audience (`sp_entity_id`), recipient
+  (`acs_url`), the validity window, and `InResponseTo` are all enforced — by the vetted
+  `crewjam/saml` + `goxmldsig` stack (ADR-063), not a bespoke implementation.
+- **IdP-initiated SSO is off by default** (it loses `InResponseTo` CSRF/replay
+  protection); enable per-provider only when required.
+- A SAML login yields the same session, audit (`auth.sso_login`), JIT provisioning, and
+  per-project MFA as OIDC. Group→role mapping is additive and non-clobbering — manual role
+  grants survive; the IdP only drives the roles named in `group_role_map`.
+- Group/role reconciliation runs only when the assertion actually carries groups, so an
+  IdP that omits the groups attribute never strips a user's memberships or roles.

--- a/internal/cli/share/expiry_test.go
+++ b/internal/cli/share/expiry_test.go
@@ -35,6 +35,7 @@ func TestResolveShareExpiry(t *testing.T) {
 		}
 		if got == nil {
 			t.Fatal("got nil, want a time ~2h out")
+			return // unreachable, but makes the non-nil invariant explicit for staticcheck
 		}
 		// Allow a wide window so the test never clock-bombs.
 		delta := got.Sub(before)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -869,7 +869,12 @@ type SSOConfig struct {
 // the issuer's /.well-known/openid-configuration at startup, so only the issuer +
 // client credentials + redirect URL are required.
 type SSOProviderConfig struct {
-	Name         string   `yaml:"name"`          // operator label + URL slug (e.g. "okta")
+	Name string `yaml:"name"` // operator label + URL slug (e.g. "okta")
+	// Type is "oidc" (default) or "saml"; it selects which block below is used.
+	Type string `yaml:"type"`
+	// SAML config (when type=saml). OIDC fields below are ignored for SAML providers.
+	SAML *SAMLProviderConfig `yaml:"saml"`
+
 	Issuer       string   `yaml:"issuer"`        // OIDC issuer URL
 	ClientID     string   `yaml:"client_id"`     // the OAuth client id registered at the IdP
 	ClientSecret string   `yaml:"client_secret"` // prefer KEYORIX_SSO_<NAME>_CLIENT_SECRET
@@ -907,6 +912,23 @@ type SSOProviderConfig struct {
 // env var KEYORIX_SSO_<NAME>_CLIENT_SECRET (name upper-cased).
 func (p *SSOProviderConfig) GetClientSecret() string {
 	return resolveSecret("KEYORIX_SSO_"+strings.ToUpper(p.Name)+"_CLIENT_SECRET", p.ClientSecret)
+}
+
+// SAMLProviderConfig is one configured SAML 2.0 IdP (when the provider's type=saml).
+// The IdP metadata supplies the entityID, SSO URL, and signing certificate; provide it
+// inline (idp_metadata_xml) or as a file path (idp_metadata_file).
+type SAMLProviderConfig struct {
+	IDPMetadataXML  string `yaml:"idp_metadata_xml"`
+	IDPMetadataFile string `yaml:"idp_metadata_file"`
+	SPEntityID      string `yaml:"sp_entity_id"` // our SP entity ID (conventionally the metadata URL)
+	ACSURL          string `yaml:"acs_url"`      // <public-host>/auth/saml/<name>/acs
+	// AllowIDPInitiated permits responses with no InResponseTo (loses CSRF/replay
+	// protection). Off by default — enable only for IdPs that require it.
+	AllowIDPInitiated bool `yaml:"allow_idp_initiated"`
+	// Attribute names to read from the assertion (empty → common Azure AD/ADFS defaults).
+	EmailAttribute  string `yaml:"email_attribute"`
+	NameAttribute   string `yaml:"name_attribute"`
+	GroupsAttribute string `yaml:"groups_attribute"`
 }
 
 // RotationRemindersConfig configures the rotation-reminder scheduler: a background

--- a/internal/core/saml_flow_test.go
+++ b/internal/core/saml_flow_test.go
@@ -1,0 +1,138 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	samlpkg "github.com/keyorixhq/keyorix/internal/saml"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// userNotFound mirrors the storage "not found" error that resolveSSOUser treats as
+// "no matching account" (rather than a hard error), so the mock matches the real path.
+func userNotFound() error { return fmt.Errorf("%s", i18n.T("ErrorUserNotFound", nil)) }
+
+// stubSAML is a SAMLAuthn whose ParseResponse returns a canned assertion — so the SAML
+// login flow is tested without a live IdP or a signed response.
+type stubSAML struct {
+	redirect, requestID string
+	info                *samlpkg.AssertionInfo
+	parseErr            error
+
+	gotRelayState string
+	gotRequestIDs []string
+}
+
+func (s *stubSAML) AuthnRequest(relayState string) (string, string, error) {
+	s.gotRelayState = relayState
+	return s.redirect, s.requestID, nil
+}
+
+func (s *stubSAML) ParseResponse(_ *http.Request, ids []string) (*samlpkg.AssertionInfo, error) {
+	s.gotRequestIDs = ids
+	if s.parseErr != nil {
+		return nil, s.parseErr
+	}
+	return s.info, nil
+}
+
+func (s *stubSAML) Metadata() ([]byte, error) { return []byte("<EntityDescriptor/>"), nil }
+
+func samlTestCore(stub *stubSAML) (*KeyorixCore, *MockStorage) {
+	store := new(MockStorage)
+	p := &SSOProvider{Name: "corp", Type: "saml", SAML: stub, AutoProvision: true, DefaultRole: "system_viewer"}
+	c := &KeyorixCore{storage: store, now: time.Now, ssoProviders: map[string]*SSOProvider{"corp": p}}
+	return c, store
+}
+
+func TestBeginSAML(t *testing.T) {
+	stub := &stubSAML{redirect: "https://idp.example/sso?SAMLRequest=x", requestID: "req-1"}
+	c, store := samlTestCore(stub)
+	var stored *models.SSOLoginState
+	store.On("CreateSSOLoginState", mock.Anything, mock.MatchedBy(func(s *models.SSOLoginState) bool {
+		stored = s
+		return true
+	})).Return(nil)
+
+	url, err := c.BeginSAML(context.Background(), "corp", "/home")
+	require.NoError(t, err)
+	assert.Equal(t, "https://idp.example/sso?SAMLRequest=x", url)
+	require.NotNil(t, stored)
+	assert.Equal(t, "corp", stored.Provider)
+	assert.Equal(t, "req-1", stored.Nonce, "the AuthnRequest ID is stored for InResponseTo")
+	assert.NotEmpty(t, stored.State)
+	assert.Equal(t, stored.State, stub.gotRelayState, "RelayState is the login-state key")
+}
+
+func TestBeginSAML_UnknownProvider(t *testing.T) {
+	c, _ := samlTestCore(&stubSAML{})
+	_, err := c.BeginSAML(context.Background(), "ghost", "")
+	require.Error(t, err)
+}
+
+func TestCompleteSAML_ExistingUser(t *testing.T) {
+	stub := &stubSAML{info: &samlpkg.AssertionInfo{Subject: "corp|123", Email: "ada@x.io", Name: "Ada"}}
+	c, store := samlTestCore(stub)
+	store.On("ConsumeSSOLoginState", mock.Anything, "relay-1").Return(
+		&models.SSOLoginState{Provider: "corp", Nonce: "req-1", ReturnTo: "/home", ExpiresAt: time.Now().Add(time.Minute)}, nil)
+	store.On("GetUserByExternalID", mock.Anything, "corp|123").Return(&models.User{ID: 7}, nil)
+	store.On("CreateSession", mock.Anything, mock.Anything).Return(&models.Session{ID: 1, UserID: 7, SessionToken: "tok"}, nil)
+	store.On("UpdateLastLogin", mock.Anything, uint(7), mock.Anything).Return(nil)
+	store.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
+
+	req := httptest.NewRequest(http.MethodPost, "/auth/saml/corp/acs", nil)
+	session, user, returnTo, err := c.CompleteSAML(context.Background(), "corp", req, "relay-1", "ua", "1.2.3.4")
+	require.NoError(t, err)
+	require.NotNil(t, user)
+	assert.Equal(t, uint(7), user.ID)
+	assert.Equal(t, "tok", session.SessionToken)
+	assert.Equal(t, "/home", returnTo)
+	assert.Equal(t, []string{"req-1"}, stub.gotRequestIDs, "InResponseTo is matched against the stored request ID")
+}
+
+func TestCompleteSAML_InvalidResponseRejected(t *testing.T) {
+	stub := &stubSAML{parseErr: errors.New("signature verification failed")}
+	c, store := samlTestCore(stub)
+	store.On("ConsumeSSOLoginState", mock.Anything, "relay-2").Return(
+		&models.SSOLoginState{Provider: "corp", Nonce: "req-1", ExpiresAt: time.Now().Add(time.Minute)}, nil)
+
+	_, _, _, err := c.CompleteSAML(context.Background(), "corp",
+		httptest.NewRequest(http.MethodPost, "/", nil), "relay-2", "", "")
+	require.ErrorContains(t, err, "signature verification failed")
+}
+
+func TestCompleteSAML_NoSubjectOrEmail(t *testing.T) {
+	stub := &stubSAML{info: &samlpkg.AssertionInfo{}}
+	c, store := samlTestCore(stub)
+	store.On("ConsumeSSOLoginState", mock.Anything, "relay-3").Return(
+		&models.SSOLoginState{Provider: "corp", Nonce: "req-1", ExpiresAt: time.Now().Add(time.Minute)}, nil)
+
+	_, _, _, err := c.CompleteSAML(context.Background(), "corp",
+		httptest.NewRequest(http.MethodPost, "/", nil), "relay-3", "", "")
+	require.ErrorContains(t, err, "no subject or email")
+}
+
+func TestCompleteSAML_NoAccountNoProvision(t *testing.T) {
+	stub := &stubSAML{info: &samlpkg.AssertionInfo{Subject: "corp|999", Email: "noone@x.io"}}
+	store := new(MockStorage)
+	// AutoProvision off → an unmatched identity is refused.
+	p := &SSOProvider{Name: "corp", Type: "saml", SAML: stub, AutoProvision: false}
+	c := &KeyorixCore{storage: store, now: time.Now, ssoProviders: map[string]*SSOProvider{"corp": p}}
+	store.On("ConsumeSSOLoginState", mock.Anything, "relay-4").Return(
+		&models.SSOLoginState{Provider: "corp", Nonce: "req-1", ExpiresAt: time.Now().Add(time.Minute)}, nil)
+	store.On("GetUserByExternalID", mock.Anything, "corp|999").Return((*models.User)(nil), userNotFound())
+	store.On("GetUserByEmail", mock.Anything, "noone@x.io").Return((*models.User)(nil), userNotFound())
+
+	_, _, _, err := c.CompleteSAML(context.Background(), "corp",
+		httptest.NewRequest(http.MethodPost, "/", nil), "relay-4", "", "")
+	require.ErrorContains(t, err, "no Keyorix account")
+}

--- a/internal/core/sso.go
+++ b/internal/core/sso.go
@@ -19,6 +19,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"sort"
 	"strings"
 	"time"
@@ -27,6 +28,7 @@ import (
 	"golang.org/x/oauth2"
 
 	"github.com/keyorixhq/keyorix/internal/i18n"
+	samlpkg "github.com/keyorixhq/keyorix/internal/saml"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
@@ -42,13 +44,26 @@ const (
 	ssoDefaultGroupClaim = "groups"
 )
 
-// SSOProvider is a resolved OIDC provider whose endpoints have been discovered.
+// SAMLAuthn is the slice of a SAML Service Provider the SSO flow needs (satisfied by
+// *saml.Provider). It is an interface so the SAML login path is unit-tested without a
+// live IdP or a signed response.
+type SAMLAuthn interface {
+	AuthnRequest(relayState string) (redirectURL, requestID string, err error)
+	ParseResponse(r *http.Request, possibleRequestIDs []string) (*samlpkg.AssertionInfo, error)
+	Metadata() ([]byte, error)
+}
+
+// SSOProvider is a resolved SSO provider. Type is "oidc" (the default) or "saml"; the
+// type-specific fields (OAuth/JWKS for OIDC, SAML for SAML) are set accordingly, while
+// the provisioning + group/role-mapping fields below are shared by both.
 type SSOProvider struct {
 	Name        string
+	Type        string // "oidc" (default) | "saml"
 	Issuer      string
 	ClientID    string
-	OAuth       *oauth2.Config // ClientID/Secret + discovered Auth/Token endpoints + redirect
+	OAuth       *oauth2.Config // OIDC: ClientID/Secret + discovered Auth/Token endpoints + redirect
 	CompleteURL string         // <redirect origin>/auth/sso/complete — where the browser lands
+	SAML        SAMLAuthn      // SAML: the Service Provider (nil for OIDC providers)
 
 	AutoProvision bool   // JIT-create an account on first login for an unknown identity
 	DefaultRole   string // baseline role for JIT-provisioned users ("" → system_viewer)
@@ -188,6 +203,120 @@ func (c *KeyorixCore) CompleteSSO(ctx context.Context, providerName, code, state
 	return session, user, st.ReturnTo, nil
 }
 
+// samlProvider resolves a configured SAML provider by name.
+func (c *KeyorixCore) samlProvider(name string) (*SSOProvider, error) {
+	p, ok := c.ssoProviders[name]
+	if !ok || p.Type != "saml" || p.SAML == nil {
+		return nil, fmt.Errorf("unknown SAML provider")
+	}
+	return p, nil
+}
+
+// SAMLMetadata returns the SP metadata XML for a provider (served at the metadata route).
+func (c *KeyorixCore) SAMLMetadata(name string) ([]byte, error) {
+	p, err := c.samlProvider(name)
+	if err != nil {
+		return nil, err
+	}
+	return p.SAML.Metadata()
+}
+
+// BeginSAML starts an SP-initiated login: it builds a signed-or-unsigned AuthnRequest,
+// stores the login state (RelayState key + the request ID for InResponseTo matching),
+// and returns the IdP redirect URL. Mirrors BeginSSO for OIDC.
+func (c *KeyorixCore) BeginSAML(ctx context.Context, name, returnTo string) (string, error) {
+	p, err := c.samlProvider(name)
+	if err != nil {
+		return "", err
+	}
+	relayState, err := randToken()
+	if err != nil {
+		return "", err
+	}
+	redirectURL, requestID, err := p.SAML.AuthnRequest(relayState)
+	if err != nil {
+		return "", fmt.Errorf("build SAML request: %w", err)
+	}
+	// Reuse the SSO login-state row: State is the RelayState lookup key, Nonce carries
+	// the AuthnRequest ID (matched against InResponseTo at the ACS).
+	if err := c.storage.CreateSSOLoginState(ctx, &models.SSOLoginState{
+		State:     relayState,
+		Nonce:     requestID,
+		Provider:  name,
+		ReturnTo:  sanitizeReturnTo(returnTo),
+		ExpiresAt: c.now().Add(ssoStateTTL),
+		CreatedAt: c.now(),
+	}); err != nil {
+		return "", err
+	}
+	return redirectURL, nil
+}
+
+// CompleteSAML consumes the RelayState, validates the SAMLResponse on r (signature,
+// audience, recipient, time, InResponseTo — via the vetted library), maps the assertion
+// to a user, reconciles groups/roles, and mints a session. Mirrors CompleteSSO.
+func (c *KeyorixCore) CompleteSAML(ctx context.Context, name string, r *http.Request, relayState, userAgent, ip string) (*models.Session, *models.User, string, error) {
+	p, err := c.samlProvider(name)
+	if err != nil {
+		return nil, nil, "", err
+	}
+	st, err := c.storage.ConsumeSSOLoginState(ctx, relayState)
+	if err != nil {
+		return nil, nil, "", fmt.Errorf("invalid or expired login state")
+	}
+	if st.Provider != name {
+		return nil, nil, "", fmt.Errorf("login state does not match the callback provider")
+	}
+	if c.now().After(st.ExpiresAt) {
+		return nil, nil, "", fmt.Errorf("login state expired")
+	}
+
+	info, err := p.SAML.ParseResponse(r, []string{st.Nonce})
+	if err != nil {
+		return nil, nil, "", err
+	}
+	if strings.TrimSpace(info.Subject) == "" && strings.TrimSpace(info.Email) == "" {
+		return nil, nil, "", fmt.Errorf("the assertion carried no subject or email")
+	}
+
+	user, err := c.resolveSSOUser(ctx, info.Subject, info.Email)
+	if err != nil {
+		return nil, nil, "", err
+	}
+	if user == nil {
+		if !p.AutoProvision {
+			return nil, nil, "", fmt.Errorf("no Keyorix account matches this SSO identity")
+		}
+		if user, err = c.provisionSSOUser(ctx, p, info.Subject, info.Email, info.Name); err != nil {
+			return nil, nil, "", err
+		}
+	}
+	if AccountLoginBlocked(user.AccountState) {
+		return nil, nil, "", fmt.Errorf("account suspended")
+	}
+
+	// Reconcile only when the assertion actually carried groups — an IdP that omits the
+	// groups attribute must not strip a user's memberships/roles (matches the OIDC
+	// absent-claim no-op).
+	if len(info.Groups) > 0 {
+		if p.GroupSync {
+			c.reconcileSSOGroups(ctx, p, user.ID, info.Groups)
+		}
+		if len(p.GroupRoleMap) > 0 {
+			c.reconcileSSORoles(ctx, p, user.ID, info.Groups)
+		}
+	}
+
+	session, err := c.mintSession(ctx, user.ID, userAgent, ip)
+	if err != nil {
+		return nil, nil, "", err
+	}
+	_ = c.RecordLogin(ctx, user.ID) // best-effort last-login stamp
+	c.writeAuditEvent(ctx, EventSSOLogin, actorPtr(user.ID), nil,
+		fmt.Sprintf("SAML login via %s (subject=%s)", name, info.Subject))
+	return session, user, st.ReturnTo, nil
+}
+
 // resolveSSOUser maps the IdP identity to a Keyorix user: the SCIM externalId
 // (subject) first, then email. Returns (nil, nil) when neither matches — the caller
 // decides whether to refuse the login or JIT-provision the account.
@@ -284,6 +413,12 @@ func (c *KeyorixCore) syncSSOGroups(ctx context.Context, p *SSOProvider, userID 
 	if !present {
 		return // IdP did not assert groups in the id_token — leave memberships untouched.
 	}
+	c.reconcileSSOGroups(ctx, p, userID, asserted)
+}
+
+// reconcileSSOGroups reconciles native group memberships to match the asserted group
+// names — shared by the OIDC (id_token claim) and SAML (assertion attribute) paths.
+func (c *KeyorixCore) reconcileSSOGroups(ctx context.Context, p *SSOProvider, userID uint, asserted []string) {
 	assertedSet := make(map[string]bool, len(asserted))
 	for _, g := range asserted {
 		if g = strings.TrimSpace(g); g != "" {
@@ -349,6 +484,13 @@ func (c *KeyorixCore) syncSSORoles(ctx context.Context, p *SSOProvider, userID u
 	if !present {
 		return // IdP did not assert groups in the id_token — leave roles untouched.
 	}
+	c.reconcileSSORoles(ctx, p, userID, asserted)
+}
+
+// reconcileSSORoles reconciles the user's grants of the MAPPED roles to match the roles
+// their asserted groups map to — shared by the OIDC and SAML paths. Authoritative only
+// over roles named in GroupRoleMap (manual grants survive).
+func (c *KeyorixCore) reconcileSSORoles(ctx context.Context, p *SSOProvider, userID uint, asserted []string) {
 	assertedSet := make(map[string]bool, len(asserted))
 	for _, g := range asserted {
 		if g = strings.TrimSpace(g); g != "" {

--- a/server/http/handlers/saml.go
+++ b/server/http/handlers/saml.go
@@ -1,0 +1,78 @@
+// saml.go — human SSO login endpoints for the SAML 2.0 binding (ADR-063). Like the OIDC
+// endpoints they are unauthenticated (mounted outside the session middleware): the SP
+// metadata, the login redirect (AuthnRequest), and the Assertion Consumer Service (ACS)
+// that consumes the IdP's signed response. On success the ACS hands the SPA its session
+// the same way the OIDC callback does — token in the URL fragment.
+package handlers
+
+import (
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// SAMLMetadata handles GET /auth/saml/{provider}/metadata — the SP metadata XML the IdP
+// administrator imports to register Keyorix.
+func (h *AuthHandler) SAMLMetadata(w http.ResponseWriter, r *http.Request) {
+	md, err := h.coreService.SAMLMetadata(chi.URLParam(r, "provider"))
+	if err != nil {
+		sendError(w, "SSOError", err.Error(), http.StatusNotFound, nil)
+		return
+	}
+	w.Header().Set("Content-Type", "application/samlmetadata+xml")
+	// md is server-generated SP metadata XML (from operator config, no request input)
+	// served as non-HTML — not an XSS vector.
+	_, _ = w.Write(md) // #nosec G705 -- server-generated SAML metadata, non-HTML content type
+}
+
+// BeginSAML handles GET /auth/saml/{provider}/login — redirects the browser to the IdP
+// SSO endpoint with a fresh AuthnRequest.
+func (h *AuthHandler) BeginSAML(w http.ResponseWriter, r *http.Request) {
+	provider := chi.URLParam(r, "provider")
+	redirectURL, err := h.coreService.BeginSAML(r.Context(), provider, r.URL.Query().Get("return_to"))
+	if err != nil {
+		sendError(w, "SSOError", err.Error(), http.StatusBadRequest, nil)
+		return
+	}
+	// redirectURL is built by core from the provider's operator-configured IdP SSO
+	// endpoint (from the IdP metadata) plus our AuthnRequest — never user input.
+	http.Redirect(w, r, redirectURL, http.StatusFound) // #nosec G710 -- operator-configured IdP endpoint, not user-controlled
+}
+
+// CompleteSAML handles POST /auth/saml/{provider}/acs — the Assertion Consumer Service.
+// It validates the SAMLResponse (via core/the vetted library), mints a session, and
+// redirects to the SPA completion page with the token in the fragment.
+func (h *AuthHandler) CompleteSAML(w http.ResponseWriter, r *http.Request) {
+	provider := chi.URLParam(r, "provider")
+	completeURL, ok := h.coreService.SSOCompleteURL(provider)
+	if !ok {
+		sendError(w, "SSOError", "unknown SSO provider", http.StatusBadRequest, nil)
+		return
+	}
+	if err := r.ParseForm(); err != nil {
+		h.redirectFragment(w, r, completeURL, url.Values{"error": {"invalid ACS request"}})
+		return
+	}
+	relayState := r.PostFormValue("RelayState")
+
+	session, _, returnTo, err := h.coreService.CompleteSAML(
+		r.Context(), provider, r, relayState, r.Header.Get("User-Agent"), r.RemoteAddr)
+	if err != nil {
+		h.redirectFragment(w, r, completeURL, url.Values{"error": {err.Error()}})
+		return
+	}
+
+	frag := url.Values{"token": {session.SessionToken}}
+	if session.ExpiresAt != nil {
+		frag.Set("expires_at", session.ExpiresAt.Format(time.RFC3339))
+	}
+	if session.AbsoluteExpiresAt != nil {
+		frag.Set("absolute_expires_at", session.AbsoluteExpiresAt.Format(time.RFC3339))
+	}
+	if returnTo != "" {
+		frag.Set("return_to", returnTo)
+	}
+	h.redirectFragment(w, r, completeURL, frag)
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -102,6 +102,11 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 	r.Get("/auth/sso/providers", authHandler.ListSSOProviders)
 	r.Get("/auth/sso/{provider}/login", authHandler.BeginSSO)
 	r.Get("/auth/sso/{provider}/callback", authHandler.CompleteSSO)
+	// SAML 2.0 SP endpoints (ADR-063): metadata for the IdP admin, the login redirect
+	// (AuthnRequest), and the Assertion Consumer Service. Unauthenticated, like OIDC.
+	r.Get("/auth/saml/{provider}/metadata", authHandler.SAMLMetadata)
+	r.Get("/auth/saml/{provider}/login", authHandler.BeginSAML)
+	r.Post("/auth/saml/{provider}/acs", authHandler.CompleteSAML)
 
 	// Health check endpoint — lightweight liveness signal (does not touch the DB, so a
 	// transient DB outage won't get the pod restarted).

--- a/server/main.go
+++ b/server/main.go
@@ -48,6 +48,7 @@ import (
 	"github.com/keyorixhq/keyorix/internal/notary"
 	"github.com/keyorixhq/keyorix/internal/notifychan"
 	"github.com/keyorixhq/keyorix/internal/rotation"
+	samlpkg "github.com/keyorixhq/keyorix/internal/saml"
 	appstorage "github.com/keyorixhq/keyorix/internal/storage"
 	"github.com/keyorixhq/keyorix/server/grpc"
 	httpServer "github.com/keyorixhq/keyorix/server/http"
@@ -1248,8 +1249,31 @@ func buildSSOProviders(sso config.SSOConfig) (map[string]*core.SSOProvider, core
 	jwksURIs := map[string]string{}
 	for i := range sso.Providers {
 		pc := sso.Providers[i]
-		if pc.Name == "" || pc.Issuer == "" || pc.ClientID == "" || pc.RedirectURL == "" {
-			log.Printf("SSO provider %q misconfigured (name/issuer/client_id/redirect_url required); skipping", pc.Name)
+		if pc.Name == "" {
+			log.Printf("SSO provider with no name; skipping")
+			continue
+		}
+		// SAML providers are built from their own block (no OIDC discovery).
+		if strings.EqualFold(pc.Type, "saml") {
+			sp, err := buildSAMLProvider(pc)
+			if err != nil {
+				log.Printf("SSO provider %q (saml) misconfigured: %v; skipping", pc.Name, err)
+				continue
+			}
+			completeURL, err := ssoCompleteURL(pc.SAML.ACSURL)
+			if err != nil {
+				log.Printf("SSO provider %q (saml): %v; skipping", pc.Name, err)
+				continue
+			}
+			providers[pc.Name] = &core.SSOProvider{
+				Name: pc.Name, Type: "saml", SAML: sp, CompleteURL: completeURL,
+				AutoProvision: pc.AutoProvision, DefaultRole: pc.DefaultRole,
+				GroupSync: pc.GroupSync, GroupRoleMap: pc.GroupRoleMap,
+			}
+			continue
+		}
+		if pc.Issuer == "" || pc.ClientID == "" || pc.RedirectURL == "" {
+			log.Printf("SSO provider %q misconfigured (issuer/client_id/redirect_url required); skipping", pc.Name)
 			continue
 		}
 		disc, err := discoverOIDC(pc.Issuer)
@@ -1289,10 +1313,40 @@ func buildSSOProviders(sso config.SSOConfig) (map[string]*core.SSOProvider, core
 	if len(providers) == 0 {
 		return nil, nil, 0
 	}
+	// A JWKS resolver is only needed for OIDC providers; a SAML-only deployment has none.
+	if len(jwksURIs) == 0 {
+		return providers, nil, len(providers)
+	}
 	resolver, err := core.NewHTTPJWKSResolver(jwksURIs)
 	if err != nil {
 		log.Printf("SSO disabled: jwks resolver init failed: %v", err)
 		return nil, nil, 0
 	}
 	return providers, resolver, len(providers)
+}
+
+// buildSAMLProvider constructs a SAML Service Provider from its config block, reading
+// the IdP metadata inline or from a file.
+func buildSAMLProvider(pc config.SSOProviderConfig) (*samlpkg.Provider, error) {
+	if pc.SAML == nil {
+		return nil, fmt.Errorf("missing saml config block")
+	}
+	metaXML := []byte(pc.SAML.IDPMetadataXML)
+	if len(metaXML) == 0 && pc.SAML.IDPMetadataFile != "" {
+		b, err := os.ReadFile(pc.SAML.IDPMetadataFile) // #nosec G304 -- operator-provided metadata path
+		if err != nil {
+			return nil, fmt.Errorf("read idp_metadata_file: %w", err)
+		}
+		metaXML = b
+	}
+	return samlpkg.NewProvider(samlpkg.Config{
+		Name:              pc.Name,
+		IDPMetadataXML:    metaXML,
+		SPEntityID:        pc.SAML.SPEntityID,
+		ACSURL:            pc.SAML.ACSURL,
+		AllowIDPInitiated: pc.SAML.AllowIDPInitiated,
+		EmailAttr:         pc.SAML.EmailAttribute,
+		NameAttr:          pc.SAML.NameAttribute,
+		GroupsAttr:        pc.SAML.GroupsAttribute,
+	})
 }


### PR DESCRIPTION
Turns the SAML SP core (#447) into a **working login**. Builds on the vetted `crewjam/saml` + `goxmldsig` stack ([ADR-063](../blob/main/docs/adr-063-saml-sso.md)). **Opt-in** — no behaviour change with no SAML provider configured.

## What
- **Provider generalization** — `SSOProvider` gains a `Type` (`oidc`|`saml`) + a `SAMLAuthn` interface (satisfied by `*saml.Provider`); the shared provisioning + group/role-mapping fields are reused.
- **Core flow** — `BeginSAML` (AuthnRequest + store login state, reusing `SSOLoginState`'s `Nonce` for `InResponseTo` — no migration) and `CompleteSAML` (validate via the library → map assertion → `resolveSSOUser`/`provisionSSOUser` → reconcile groups/roles → mint the **same session** as OIDC).
- **Reconcile refactor** — split `reconcileSSOGroups`/`reconcileSSORoles` out of the OIDC sync so both the id_token (OIDC) and assertion-attribute (SAML) paths share it. SAML reconciles **only when groups were asserted** (never strips on absent).
- **Routes/config/startup** — `/auth/saml/{provider}/{metadata,login,acs}` (unauthenticated, like OIDC), `SSOProviderConfig.Type` + a `saml` block, and `buildSSOProviders` builds a `saml.Provider` for `type: saml` (SAML-only deployments need no JWKS resolver). Operator guide: `docs/saml-sso.md`.

## Safety
Signature verified against the **pinned IdP cert** (never one from the response); audience/recipient/time/`InResponseTo` enforced by the vetted stack. IdP-initiated off by default. Same session/audit/JIT/per-project-MFA as OIDC; group→role mapping additive/non-clobbering.

## Verification
gofmt/vet/golangci-lint(0)/gosec(0)/**govulncheck clean**. The **full `internal/core` test package passes** (OIDC refactor is safe); new SAML flow tests cover begin/complete, invalid-response rejection, no-subject, refuse-when-no-provision. Router/config tests pass; the only failing local test is the documented `TestEveryMutatingRouteDeniesReadOnly` flake (`/sw.js` + `/compliance/evidence/verify`) — my `POST /acs` is not flagged.

Phase 2 (encrypted assertions, opt-in IdP-initiated, signed AuthnRequests) is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)