### PR TITLE
fix(auth): evict the old token from the auth cache on token refresh

### DIFF
--- a/server/http/auth_refresh_cache_test.go
+++ b/server/http/auth_refresh_cache_test.go
@@ -1,0 +1,75 @@
+package http
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRefreshToken_EvictsOldTokenFromAuthCache is a regression test for the
+// token-rotation cache bug: RefreshToken rotates the session (deleting the old one),
+// but if it does not evict the old token from the middleware's positive auth cache,
+// the rotated-away token keeps passing auth (a cache hit skips the DB) for up to
+// validTokenTTL. The fix mirrors Logout/ChangePassword (middleware.InvalidateTokenCache).
+func TestRefreshToken_EvictsOldTokenFromAuthCache(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			HTTP: config.ServerInstanceConfig{Enabled: true, Port: "8080"},
+		},
+	}
+	c := newTestCore(t)
+	router, err := NewRouter(cfg, c)
+	require.NoError(t, err)
+	server := httptest.NewServer(router)
+	defer server.Close()
+	client := server.Client()
+
+	oldToken := createTestToken(t, c)
+
+	authedProfileStatus := func(token string) int {
+		req, _ := http.NewRequest("GET", server.URL+"/api/v1/auth/profile", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		_ = resp.Body.Close()
+		return resp.StatusCode
+	}
+
+	// 1. An authed request validates the old token and caches it (positive entry).
+	require.Equal(t, http.StatusOK, authedProfileStatus(oldToken), "token should authenticate before refresh")
+
+	// 2. Refresh rotates the token — the old session row is deleted.
+	req, _ := http.NewRequest("POST", server.URL+"/auth/refresh", nil)
+	req.Header.Set("Authorization", "Bearer "+oldToken)
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	body, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode, "refresh should succeed: %s", body)
+
+	var refreshed struct {
+		Data struct {
+			Token string `json:"token"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(body, &refreshed))
+	require.NotEmpty(t, refreshed.Data.Token)
+	require.NotEqual(t, oldToken, refreshed.Data.Token, "refresh must issue a new token")
+
+	// 3. The OLD token must be rejected immediately: refresh evicted it from the cache,
+	//    so the middleware hits the DB and finds no session. Before the fix, the cached
+	//    positive entry kept it valid for up to validTokenTTL.
+	assert.Equal(t, http.StatusUnauthorized, authedProfileStatus(oldToken),
+		"rotated-away token must be rejected, not served from a stale cache entry")
+
+	// 4. The NEW token authenticates.
+	assert.Equal(t, http.StatusOK, authedProfileStatus(refreshed.Data.Token), "new token should authenticate")
+}

--- a/server/http/handlers/auth.go
+++ b/server/http/handlers/auth.go
@@ -116,9 +116,9 @@ func (h *AuthHandler) Login(w http.ResponseWriter, r *http.Request) {
 			// Tell the client which second factors this account can complete, so it
 			// can offer the right step (TOTP code entry vs. a passkey prompt).
 			sendSuccess(w, map[string]interface{}{
-				"mfa_required":      true,
-				"mfa_challenge":     challenge,
-				"totp_available":    user.MFAEnabled,
+				"mfa_required":       true,
+				"mfa_challenge":      challenge,
+				"totp_available":     user.MFAEnabled,
 				"webauthn_available": user.WebAuthnEnabled,
 			}, "MFA required")
 			return
@@ -285,6 +285,13 @@ func (h *AuthHandler) RefreshToken(w http.ResponseWriter, r *http.Request) {
 		sendError(w, "Unauthorized", "Session not found or expired", http.StatusUnauthorized, nil)
 		return
 	}
+
+	// Token rotation: evict the OLD token from the auth cache immediately, like Logout
+	// and ChangePassword. Without this, the just-validated old token lingers in the 30s
+	// positive cache and keeps passing auth (a cache hit skips the DB) even though its
+	// session row was deleted — so it stays usable for up to validTokenTTL after being
+	// rotated away.
+	middleware.InvalidateTokenCache(token)
 
 	resp := map[string]interface{}{
 		"token": session.SessionToken,


### PR DESCRIPTION
## Bug (confirmed)

The auth middleware caches a validated session token for `validTokenTTL` (30s) so repeat requests skip the DB (`server/middleware/auth.go`). `Logout` and `ChangePassword` evict the token via `middleware.InvalidateTokenCache`; **`RefreshToken` did not.**

So after a refresh rotated the session — `RefreshSession` creates a new session and deletes the old row (`internal/core/auth.go`) — the **old token kept passing authentication** from its cached positive entry for up to 30s. And because the old-session delete is best-effort (`_ = c.storage.DeleteSession(...)`), if that delete fails the old token stays valid **indefinitely** via the DB too. Capturing a token then forcing a refresh should not leave the old token usable.

## Fix

Call `middleware.InvalidateTokenCache(token)` after a successful `RefreshSession`, mirroring `Logout`/`ChangePassword`. The rotated-away token is then rejected on the next request (the middleware falls through to the DB and finds no session).

## Test

End-to-end regression test through the real router + auth middleware (`server/http/auth_refresh_cache_test.go`): an authed request caches the token → refresh → the **old token now gets 401** while the new token works. **Verified the test fails without the fix** (temporarily neutralized the line → step 3 fails).

## Notes
- Also realigns one pre-existing gofmt-dirty map literal in the same file (incidental, 3 lines).
- The best-effort old-session delete in `RefreshSession` (a deeper, rare edge if the DB delete fails) is **not** changed here — this PR fixes the common, exposed cache-window bug; the delete-failure hardening (transaction / surface the error) would be a separate change.

`go build ./...` ✅ · `go vet` ✅ · `golangci-lint ./...` 0 ✅ · `gosec` 0 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)