### PR TITLE
harden(recovery): never return panic internals to the client

### DIFF
--- a/internal/core/webauthn.go
+++ b/internal/core/webauthn.go
@@ -38,8 +38,8 @@ func (u *webauthnUser) WebAuthnID() []byte {
 	binary.BigEndian.PutUint64(b, uint64(u.user.ID))
 	return b
 }
-func (u *webauthnUser) WebAuthnName() string                   { return u.user.Username }
-func (u *webauthnUser) WebAuthnDisplayName() string            { return u.user.Username }
+func (u *webauthnUser) WebAuthnName() string                       { return u.user.Username }
+func (u *webauthnUser) WebAuthnDisplayName() string                { return u.user.Username }
 func (u *webauthnUser) WebAuthnCredentials() []webauthn.Credential { return u.creds }
 
 func (c *KeyorixCore) loadWebAuthnUser(ctx context.Context, userID uint) (*webauthnUser, error) {

--- a/server/middleware/recovery.go
+++ b/server/middleware/recovery.go
@@ -32,7 +32,12 @@ func Recovery() func(next http.Handler) http.Handler {
 					log.Printf("PANIC CONTEXT: RequestID=%s, User=%s, Method=%s, Path=%s, RemoteAddr=%s", // #nosec G706
 						requestID, userInfo, r.Method, r.URL.Path, r.RemoteAddr)
 
-					// Send error response
+					// Send a generic error response. We deliberately NEVER return the
+					// panic value, stack trace, or other internals to the client — this
+					// is a secrets manager, and a panic value can carry sensitive data;
+					// leaking internals (even gated behind a "dev mode" flag) is a foot-
+					// gun one config toggle away from production. Operators get the full
+					// panic + stack from the logs above; clients get only an opaque 500.
 					w.Header().Set("Content-Type", "application/json")
 					w.WriteHeader(http.StatusInternalServerError)
 
@@ -40,16 +45,6 @@ func Recovery() func(next http.Handler) http.Handler {
 						"error":   "InternalServerError",
 						"message": "An internal server error occurred",
 						"code":    http.StatusInternalServerError,
-					}
-
-					// In development mode, include more details
-					// TODO: Check if in development mode from config
-					if isDevelopmentMode() {
-						response["details"] = map[string]interface{}{
-							"panic":      err,
-							"stack":      string(debug.Stack()),
-							"request_id": requestID,
-						}
 					}
 
 					if encodeErr := json.NewEncoder(w).Encode(response); encodeErr != nil {
@@ -62,12 +57,4 @@ func Recovery() func(next http.Handler) http.Handler {
 			next.ServeHTTP(w, r)
 		})
 	}
-}
-
-// isDevelopmentMode checks if the application is running in development mode
-// TODO: Implement proper environment detection
-func isDevelopmentMode() bool {
-	// For now, return false to avoid exposing sensitive information
-	// In a real implementation, this would check environment variables or config
-	return false
 }

--- a/server/middleware/recovery_test.go
+++ b/server/middleware/recovery_test.go
@@ -1,0 +1,52 @@
+package middleware
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRecovery_DoesNotLeakInternals is the security invariant: a panic returns an opaque
+// 500 and the response body never carries the panic value, a stack trace, or other
+// internals to the client (this is a secrets manager — operators read the logs instead).
+func TestRecovery_DoesNotLeakInternals(t *testing.T) {
+	const sensitive = "super-secret-token-do-not-leak"
+	panicking := http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		panic("boom: " + sensitive)
+	})
+
+	rec := httptest.NewRecorder()
+	Recovery()(panicking).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/v1/secrets/1", nil))
+
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+	assert.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+
+	body := rec.Body.String()
+	assert.NotContains(t, body, sensitive, "the panic value must never reach the client")
+	for _, leak := range []string{"stack", "goroutine", "runtime.", ".go:", "boom"} {
+		assert.NotContains(t, body, leak, "response must not leak internals (%q)", leak)
+	}
+
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "InternalServerError", resp["error"])
+	assert.NotContains(t, resp, "details", "no details field is ever returned")
+}
+
+// TestRecovery_PassesThroughNonPanic confirms the middleware is transparent on the happy
+// path.
+func TestRecovery_PassesThroughNonPanic(t *testing.T) {
+	ok := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+	rec := httptest.NewRecorder()
+	Recovery()(ok).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/health", nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "ok", strings.TrimSpace(rec.Body.String()))
+}


### PR DESCRIPTION
A small, self-contained security hardening (independent of the SAML branch).

## Problem
The panic-recovery middleware had a dead but **leak-prone** branch: `isDevelopmentMode()` (which always returns `false`) gated returning the **panic value + full stack trace + request id** to the client. For a secrets manager that's a foot-gun one config toggle away from leaking sensitive data — a panic value can carry secret material, and stack traces expose internal paths — to any API caller.

## Change
- Remove the dead branch and the `isDevelopmentMode()` stub. Clients **always** get an opaque `500 InternalServerError`; operators get the full panic + stack from the logs (unchanged — they already do).
- Add `recovery_test.go` locking in the invariant: a panic carrying a sensitive value returns a generic 500 whose body contains **none** of the panic value, stack, `goroutine`, `.go:`, or a `details` field — plus a happy-path pass-through test.
- Drive-by: `gofmt internal/core/webauthn.go` (CI doesn't gate gofmt, so it had drifted).

## Verification
gofmt / vet / golangci-lint (0) / gosec (0) clean; new tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)