### PR TITLE
feat(storage): WithTransaction primitive; make SCIM deprovision atomic

### DIFF
--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -19,6 +19,11 @@ func (m *MockStorage) WithSchedulerLock(_ context.Context, _ int64, fn func() er
 	return true, fn()
 }
 
+// WithTransaction runs fn directly against the mock (no real transaction in tests).
+func (m *MockStorage) WithTransaction(_ context.Context, fn func(storage.Storage) error) error {
+	return fn(m)
+}
+
 // Login rate-limiting stubs (core rate-limit logic is tested against real SQLite).
 func (m *MockStorage) RecordLoginAttempt(_ context.Context, _ string, _ time.Time) error { return nil }
 func (m *MockStorage) CountRecentLoginAttempts(_ context.Context, _ string, _ time.Time) (int64, error) {

--- a/internal/core/scim.go
+++ b/internal/core/scim.go
@@ -197,11 +197,17 @@ func (c *KeyorixCore) DeprovisionSCIMUser(ctx context.Context, actorID, id uint)
 	user.IsActive = false
 	user.AccountState = AccountSuspended
 	user.UpdatedAt = c.now()
-	if _, err := c.storage.UpdateUser(ctx, user); err != nil {
-		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
-	}
-	_ = c.storage.DeleteSessionsForUserExcept(ctx, id, 0)
-	if err := c.storage.DeleteUser(ctx, id); err != nil {
+	// Suspend + terminate sessions + soft-delete atomically: a SCIM DELETE either fully
+	// deprovisions or leaves the account untouched, so a mid-way storage failure can't
+	// leave it half-deprovisioned (suspended but not deleted), which would make retries
+	// non-idempotent.
+	if err := c.storage.WithTransaction(ctx, func(tx storage.Storage) error {
+		if _, err := tx.UpdateUser(ctx, user); err != nil {
+			return err
+		}
+		_ = tx.DeleteSessionsForUserExcept(ctx, id, 0)
+		return tx.DeleteUser(ctx, id)
+	}); err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}
 	c.writeAuditEvent(ctx, EventSCIMUserDeprovisioned, actorPtr(actorID), nil,

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -24,6 +24,15 @@ type Storage interface {
 	// when another replica holds the lock — the caller should simply skip this tick.
 	WithSchedulerLock(ctx context.Context, key int64, fn func() error) (ran bool, err error)
 
+	// WithTransaction runs fn inside a single storage transaction: every mutation fn
+	// performs through the provided Storage commits together, or rolls back together if
+	// fn returns an error. The backing store decides the semantics — the local (DB)
+	// store opens a real transaction and hands fn a transaction-scoped Storage; the
+	// remote store runs fn directly against itself (each remote call is already atomic
+	// server-side, so there is no client-side transaction to open). Use it for
+	// multi-step mutations that must not half-apply (e.g. a suspend + delete pair).
+	WithTransaction(ctx context.Context, fn func(Storage) error) error
+
 	// Project / Environment management
 	CreateProject(ctx context.Context, project *models.Project) (*models.Project, error)
 	GetProject(ctx context.Context, id uint) (*models.Project, error)

--- a/internal/storage/store/entry.go
+++ b/internal/storage/store/entry.go
@@ -76,10 +76,13 @@ type LocalStorage struct {
 	// auditChainMu serializes audit-event appends so the read-chain-head +
 	// insert critical section is atomic within this process (ADR-029). The
 	// PostgreSQL advisory lock in LogAuditEvent extends this across processes.
-	auditChainMu sync.Mutex
+	// A pointer so a transaction-scoped LocalStorage (see WithTransaction) shares the
+	// SAME mutex as its parent — otherwise an audit append inside a transaction would
+	// not serialize against concurrent appends on the base store.
+	auditChainMu *sync.Mutex
 }
 
 // NewLocalStorage creates a LocalStorage backed by the given *gorm.DB.
 func NewLocalStorage(db *gorm.DB) *LocalStorage {
-	return &LocalStorage{db: db}
+	return &LocalStorage{db: db, auditChainMu: &sync.Mutex{}}
 }

--- a/internal/storage/store/local_transaction.go
+++ b/internal/storage/store/local_transaction.go
@@ -1,0 +1,20 @@
+// local_transaction.go — WithTransaction for the local (DB-backed) store.
+package store
+
+import (
+	"context"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"gorm.io/gorm"
+)
+
+// WithTransaction runs fn inside a single GORM transaction. fn receives a
+// transaction-scoped LocalStorage: every mutation it makes is committed together when
+// fn returns nil, and rolled back together if fn returns an error (or panics). The
+// transaction-scoped store shares the parent's audit-chain mutex so an audit append
+// inside the transaction still serializes correctly (ADR-029).
+func (ls *LocalStorage) WithTransaction(ctx context.Context, fn func(storage.Storage) error) error {
+	return ls.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		return fn(&LocalStorage{db: tx, auditChainMu: ls.auditChainMu})
+	})
+}

--- a/internal/storage/store/local_transaction_test.go
+++ b/internal/storage/store/local_transaction_test.go
@@ -1,0 +1,59 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func newTxStore(t *testing.T) *LocalStorage {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	// One connection so the tx commit and the follow-up read share the same in-memory DB.
+	sqlDB.SetMaxOpenConns(1)
+	require.NoError(t, db.AutoMigrate(&models.User{}))
+	return NewLocalStorage(db)
+}
+
+func TestLocalStorage_WithTransaction_CommitsOnSuccess(t *testing.T) {
+	ls := newTxStore(t)
+	ctx := context.Background()
+
+	err := ls.WithTransaction(ctx, func(tx storage.Storage) error {
+		_, e := tx.CreateUser(ctx, &models.User{Username: "alice", Email: "a@x.io"})
+		return e
+	})
+	require.NoError(t, err)
+
+	got, err := ls.GetUserByUsername(ctx, "alice")
+	require.NoError(t, err)
+	assert.Equal(t, "alice", got.Username)
+}
+
+func TestLocalStorage_WithTransaction_RollsBackOnError(t *testing.T) {
+	ls := newTxStore(t)
+	ctx := context.Background()
+	sentinel := errors.New("boom")
+
+	err := ls.WithTransaction(ctx, func(tx storage.Storage) error {
+		if _, e := tx.CreateUser(ctx, &models.User{Username: "bob", Email: "b@x.io"}); e != nil {
+			return e
+		}
+		// The insert above must be rolled back when fn returns an error.
+		return sentinel
+	})
+	require.ErrorIs(t, err, sentinel)
+
+	_, err = ls.GetUserByUsername(ctx, "bob")
+	require.Error(t, err, "bob must not exist after a rolled-back transaction")
+}

--- a/internal/storage/store/remote_transaction.go
+++ b/internal/storage/store/remote_transaction.go
@@ -1,0 +1,17 @@
+// remote_transaction.go — WithTransaction for the remote (HTTP-backed) store.
+package store
+
+import (
+	"context"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+)
+
+// WithTransaction runs fn directly against this store. There is no client-side
+// transaction to open over HTTP — each remote API call is already atomic server-side,
+// and the server applies its own transaction for any multi-step mutation behind a
+// single endpoint. fn therefore sees the same (non-transactional) store; callers that
+// need a true multi-statement transaction must drive the local store.
+func (rs *RemoteStorage) WithTransaction(ctx context.Context, fn func(storage.Storage) error) error {
+	return fn(rs)
+}


### PR DESCRIPTION
## What

Adds a transaction primitive to the storage layer for multi-step mutations that must not half-apply:

```go
WithTransaction(ctx context.Context, fn func(Storage) error) error
```

- **LocalStorage** opens a real GORM transaction and hands `fn` a transaction-scoped store (sharing the parent's audit-chain mutex so ADR-029 audit appends still serialize).
- **RemoteStorage** runs `fn` directly — each remote API call is already atomic server-side, so there's no client-side transaction to open.
- **MockStorage** (tests) runs `fn` directly.

`auditChainMu` becomes a `*sync.Mutex` (init in `NewLocalStorage`) so the tx-scoped store shares it — a fresh mutex on the tx copy wouldn't serialize against the base store.

## First use: atomic SCIM deprovision

`DeprovisionSCIMUser` wraps suspend + terminate-sessions + soft-delete in `WithTransaction`, so a SCIM `DELETE` either **fully deprovisions or leaves the account untouched** — no half-deprovisioned (suspended-but-not-deleted) state that makes retries non-idempotent.

## Deliberately NOT addressed

Atomic **secret create+version**. When encryption is on, the version write goes through `encryption.SecretEncryption` (its **own** `*gorm.DB` + transaction), not `c.storage` — so a storage-only transaction can't cover it. Making that atomic would require threading a shared tx through the security-critical encryption write path; out of scope here (and flagged as a bad risk/reward).

## Tests / gate
- `WithTransaction` commits on success / rolls back on `fn` error (real SQLite, single connection).
- `go build ./...` ✅ · `go vet` ✅ · `golangci-lint ./...` 0 ✅ · `gosec` 0 ✅ · `-race` ✅ · core + store suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)