### PR TITLE
harden(http): global security-headers middleware

### DIFF
--- a/server/http/router.go
+++ b/server/http/router.go
@@ -28,6 +28,7 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 	r.Use(middleware.RealIP)
 	r.Use(customMiddleware.Logger())
 	r.Use(customMiddleware.Recovery())
+	r.Use(customMiddleware.SecurityHeaders(cfg.Server.HTTP.TLS.Enabled))
 	r.Use(customMiddleware.PrometheusMiddleware)
 	r.Use(middleware.Timeout(60 * time.Second))
 

--- a/server/middleware/security_headers.go
+++ b/server/middleware/security_headers.go
@@ -1,0 +1,33 @@
+package middleware
+
+import "net/http"
+
+// SecurityHeaders sets standard hardening response headers on every response. For a
+// secrets manager these matter beyond the usual:
+//   - X-Content-Type-Options: nosniff — never let a browser MIME-sniff a response into
+//     something executable.
+//   - X-Frame-Options: DENY — the dashboard must never be framed (clickjacking).
+//   - Referrer-Policy: no-referrer — never leak the request URL via the Referer header;
+//     Keyorix URLs can carry tokens (e.g. the SSO completion fragment), so stripping the
+//     referrer closes a token-leak channel to third-party pages.
+//
+// HSTS is sent only when this process terminates TLS (tlsEnabled); deployments that
+// terminate TLS at a proxy add HSTS there, and sending it over plain HTTP is wrong.
+//
+// Headers are set before the handler runs, so they apply to every response — including
+// errors, panics (the recovery middleware runs after this), and static assets — not just
+// the handlers that set nosniff themselves today.
+func SecurityHeaders(tlsEnabled bool) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			h := w.Header()
+			h.Set("X-Content-Type-Options", "nosniff")
+			h.Set("X-Frame-Options", "DENY")
+			h.Set("Referrer-Policy", "no-referrer")
+			if tlsEnabled {
+				h.Set("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/server/middleware/security_headers_test.go
+++ b/server/middleware/security_headers_test.go
@@ -1,0 +1,33 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func serve(t *testing.T, tlsEnabled bool) http.Header {
+	t.Helper()
+	h := SecurityHeaders(tlsEnabled)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+	return rec.Header()
+}
+
+func TestSecurityHeaders_AlwaysSet(t *testing.T) {
+	hdr := serve(t, false)
+	assert.Equal(t, "nosniff", hdr.Get("X-Content-Type-Options"))
+	assert.Equal(t, "DENY", hdr.Get("X-Frame-Options"))
+	assert.Equal(t, "no-referrer", hdr.Get("Referrer-Policy"))
+	// HSTS is NOT sent over plain HTTP (TLS terminated elsewhere or not at all).
+	assert.Empty(t, hdr.Get("Strict-Transport-Security"))
+}
+
+func TestSecurityHeaders_HSTSOnlyWithTLS(t *testing.T) {
+	hdr := serve(t, true)
+	assert.Equal(t, "max-age=31536000; includeSubDomains", hdr.Get("Strict-Transport-Security"))
+}


### PR DESCRIPTION
A small, self-contained hardening (independent branch → its own CI).

## What
A `SecurityHeaders` middleware applied to **every** response (wired after `Recovery`, so it also covers error/panic/static responses — not just handlers that set `nosniff` themselves today):
- `X-Content-Type-Options: nosniff`
- `X-Frame-Options: DENY` — the dashboard must never be framed (clickjacking).
- `Referrer-Policy: no-referrer` — Keyorix URLs can carry tokens (e.g. the **SSO completion fragment**), so stripping the `Referer` closes a token-leak channel to third-party pages.
- `Strict-Transport-Security` **only when this process terminates TLS** (proxy-terminated deployments add HSTS at the proxy; sending it over plain HTTP is wrong).

## Notes
No route or authorization changes — purely additive response headers. Previously `nosniff` was set ad hoc in individual handlers and the others not at all.

## Verification
gofmt / vet / golangci-lint(0) / gosec(0) clean; new middleware tests (headers always set; HSTS gated on TLS); `server/http` router tests pass (only the documented `TestEveryMutatingRouteDeniesReadOnly` flake fails locally — same 5 routes, unaffected by this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)