### PR TITLE
fix(share): complete share self-removal (route + correct CLI)

### DIFF
--- a/internal/cli/share/self_remove.go
+++ b/internal/cli/share/self_remove.go
@@ -5,56 +5,31 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/keyorixhq/keyorix/internal/core"
-	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/cli/common"
 	"github.com/spf13/cobra"
 )
 
-// NewSelfRemoveCommand creates a new command for removing self from shared secrets
-func NewSelfRemoveCommand(coreService *core.KeyorixCore) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "self-remove <secret-id>",
-		Short: i18n.T("CLISelfRemoveShort", nil),
-		Long:  i18n.T("CLISelfRemoveLong", nil),
-		Args:  cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return runSelfRemove(cmd.Context(), coreService, args[0])
-		},
-	}
-
-	return cmd
-}
-
-func runSelfRemove(ctx context.Context, coreService *core.KeyorixCore, secretIDStr string) error {
-	// Parse secret ID
-	secretID, err := strconv.ParseUint(secretIDStr, 10, 32)
-	if err != nil {
-		return fmt.Errorf("%s: %s", i18n.T("ErrorInvalidSecretID", nil), err.Error())
-	}
-
-	// Get current user ID (this would need to be implemented based on your auth system)
-	// For now, we'll use a placeholder
-	userID := getCurrentUserID()
-	if userID == 0 {
-		return fmt.Errorf("%s", i18n.T("ErrorUserNotAuthenticated", nil))
-	}
-
-	// Remove self from share
-	err = coreService.RemoveSelfFromShare(ctx, uint(secretID), userID)
-	if err != nil {
-		return fmt.Errorf("%s: %w", i18n.T("ErrorSelfRemovalFailed", nil), err)
-	}
-
-	fmt.Printf("%s\n", i18n.T("SuccessSelfRemoved", map[string]interface{}{
-		"SecretID": secretID,
-	}))
-
-	return nil
-}
-
-// getCurrentUserID returns the current user's ID
-// This is a placeholder - implement based on your authentication system
-func getCurrentUserID() uint {
-	// TODO: Implement proper user ID retrieval from context/session
-	return 1 // Placeholder
+// selfRemoveCmd lets the signed-in user remove THEMSELVES from a secret that was shared
+// with them. The server identifies "self" from the caller's token, so this is remote-only
+// — there is no authenticated user in embedded (direct-storage) mode.
+var selfRemoveCmd = &cobra.Command{
+	Use:          "self-remove <secret-id>",
+	Short:        "Remove yourself from a secret shared with you",
+	Args:         cobra.ExactArgs(1),
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		secretID, err := strconv.ParseUint(args[0], 10, 32)
+		if err != nil {
+			return fmt.Errorf("invalid secret ID %q: %w", args[0], err)
+		}
+		rc, ok := common.NewRemoteClient()
+		if !ok {
+			return fmt.Errorf("self-remove requires a server connection — run: keyorix connect <server>")
+		}
+		if err := rc.Delete(context.Background(), fmt.Sprintf("/api/v1/secrets/%d/self-share", secretID)); err != nil {
+			return fmt.Errorf("remove self from share: %w", err)
+		}
+		fmt.Printf("Removed yourself from secret %d.\n", secretID)
+		return nil
+	},
 }

--- a/internal/cli/share/self_remove_test.go
+++ b/internal/cli/share/self_remove_test.go
@@ -1,0 +1,48 @@
+package share
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSelfRemove_CallsSelfShareEndpoint(t *testing.T) {
+	var gotMethod, gotPath, gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod, gotPath, gotAuth = r.Method, r.URL.Path, r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+
+	require.NoError(t, selfRemoveCmd.RunE(selfRemoveCmd, []string{"7"}))
+	assert.Equal(t, http.MethodDelete, gotMethod)
+	assert.Equal(t, "/api/v1/secrets/7/self-share", gotPath, "the server identifies the caller; no user id is sent")
+	assert.Equal(t, "Bearer tok", gotAuth)
+}
+
+func TestSelfRemove_InvalidID(t *testing.T) {
+	t.Setenv("KEYORIX_SERVER", "http://example.invalid")
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	require.ErrorContains(t, selfRemoveCmd.RunE(selfRemoveCmd, []string{"not-a-number"}), "invalid secret ID")
+}
+
+func TestSelfRemove_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound) // no such share for this caller
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	require.Error(t, selfRemoveCmd.RunE(selfRemoveCmd, []string{"7"}))
+}
+
+func TestSelfRemove_RequiresServerConnection(t *testing.T) {
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	require.ErrorContains(t, selfRemoveCmd.RunE(selfRemoveCmd, []string{"7"}), "server connection")
+}

--- a/internal/cli/share/share.go
+++ b/internal/cli/share/share.go
@@ -18,4 +18,5 @@ func init() {
 	ShareCmd.AddCommand(updateCmd)
 	ShareCmd.AddCommand(revokeCmd)
 	ShareCmd.AddCommand(sharedSecretsCmd)
+	ShareCmd.AddCommand(selfRemoveCmd)
 }

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -412,6 +412,10 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.With(customMiddleware.RequireScopedPermission("secrets.write", secretScope)).Post("/{id}/suspend", secretHandler.SuspendSecret)
 			r.With(customMiddleware.RequireScopedPermission("secrets.write", secretScope)).Post("/{id}/resume", secretHandler.ResumeSecret)
 			r.With(customMiddleware.RequireScopedPermission("secrets.write", secretScope)).Post("/{id}/share", shareHandler.ShareSecret)
+			// Self-service: a recipient removes their OWN direct share. No scoped
+			// permission — the action is on the caller's own grant (core only removes a
+			// share whose RecipientID == the caller), so it needs just authentication.
+			r.Delete("/{id}/self-share", shareHandler.RemoveSelfFromShare)
 
 			r.With(customMiddleware.RequireScopedPermission("secrets.delete", secretScope)).Delete("/{id}", secretHandler.DeleteSecret)
 			// Restore resolves scope from the (soft-deleted) secret via the unscoped resolver.


### PR DESCRIPTION
Completes a half-built feature and fixes a latent correctness bug — independent branch, its own CI.

## The gap
"Remove myself from a secret shared with me" was only partly wired:
- ✅ core `RemoveSelfFromShare` + ✅ HTTP handler existed,
- ❌ the **route was never registered**, and
- ❌ the CLI command was **dead code** (never added to `ShareCmd`) with a placeholder `getCurrentUserID()` hardcoded to `1` — had it been wired, it would always remove **user 1 (the admin)** from the share, not the caller.

## Fix
- **Register** `DELETE /api/v1/secrets/{id}/self-share` → `RemoveSelfFromShare`. **Self-service, no scoped permission**: the core only deletes a share whose `RecipientID == the authenticated caller`, so a user can only remove themselves — it needs just authentication, not `secrets.write` (requiring write would wrongly block a recipient who isn't an owner).
- **Rewrite the CLI** as a registered, **remote-only** command that calls that endpoint. The server identifies "self" from the token, so the CLI never guesses a user id. Embedded mode returns a clear "connect to a server" error.

## Verification
gofmt / vet / golangci-lint(0) / gosec(0) clean. CLI tests: hits `DELETE …/self-share` with the bearer; invalid-id / server-error / no-connection paths. Confirmed the route returns **404 for a non-recipient** (a read-only persona can't abuse it) — `TestEveryMutatingRouteDeniesReadOnly` unaffected (same known 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)