### PR TITLE
test(core): permission-granularity authorization tests

### DIFF
--- a/internal/core/authz_permission_granularity_test.go
+++ b/internal/core/authz_permission_granularity_test.go
@@ -1,0 +1,65 @@
+package core_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/testhelper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// roleAuditor is the seeded auditor role (audit.read/admin, system.read, users.read,
+// roles.read — but NOT roles.assign or any secrets permission). It is a non-admin role,
+// so authorization resolves it through the granular permission check, not the admin
+// bypass.
+const roleAuditor = uint(5)
+
+// TestPermissionGranularity_DistinctPermissionsEnforced pins that each permission in the
+// lattice (read vs write vs delete, and read vs assign across resources) is enforced
+// independently — a holder of one must not get an adjacent one. A regression here is a
+// privilege-escalation vector (e.g. a read-only auditor granting itself roles). Uses
+// NON-admin roles only; super_admin/admin bypass granular checks by design.
+func TestPermissionGranularity_DistinctPermissionsEnforced(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+
+	viewer := h.CreateTestUser(t, "gran-viewer", 300) // secrets.read, users.read
+	h.AssignUserRole(t, viewer.ID, roleViewer, ptr(1))
+	editor := h.CreateTestUser(t, "gran-editor", 301) // + secrets.write
+	h.AssignUserRole(t, editor.ID, roleEditor, ptr(1))
+	auditor := h.CreateTestUser(t, "gran-auditor", 302) // audit.read, roles.read, users.read, system.read
+	h.AssignUserRole(t, auditor.ID, roleAuditor, ptr(1))
+
+	cases := []struct {
+		name       string
+		userID     uint
+		permission string
+		want       bool
+	}{
+		// viewer — read only on secrets, nothing on writes/deletes/users.
+		{"viewer reads secrets", viewer.ID, "secrets.read", true},
+		{"viewer cannot write secrets", viewer.ID, "secrets.write", false},
+		{"viewer cannot delete secrets", viewer.ID, "secrets.delete", false},
+		{"viewer cannot write users", viewer.ID, "users.write", false},
+		// editor — read + write, but write must not imply delete.
+		{"editor writes secrets", editor.ID, "secrets.write", true},
+		{"editor cannot delete secrets", editor.ID, "secrets.delete", false},
+		// auditor — roles.read must not imply roles.assign (the escalation guard),
+		// and an auditor has no secrets access at all.
+		{"auditor reads roles", auditor.ID, "roles.read", true},
+		{"auditor cannot assign roles", auditor.ID, "roles.assign", false},
+		{"auditor cannot read secrets", auditor.ID, "secrets.read", false},
+	}
+
+	ctx := context.Background()
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			ok, err := h.CoreService.Authorize(ctx, tc.userID, tc.permission, core.Scope{ProjectID: 1})
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, ok)
+		})
+	}
+}


### PR DESCRIPTION
## Why

Second PR in the **authorization-boundary assurance** lane (after #457 cross-tenant). The permission *lattice* — read vs write vs delete vs assign, across resources — is least-privilege's core. A regression that makes one permission imply an adjacent one is a privilege-escalation vector. This pins each permission as independently enforced.

## What

Table-driven test using **non-admin** seeded roles only (super_admin/admin bypass granular checks by design):

- **viewer** (`secrets.read`) → denied `secrets.write`, `secrets.delete`, `users.write`.
- **editor** (`secrets.read`+`secrets.write`) → write must **not** imply delete (`secrets.delete` denied).
- **auditor** (`roles.read`, no `roles.assign`) → `roles.read` must **not** imply `roles.assign` — the escalation guard: a read-only auditor can't grant itself roles. Also has no secrets access at all.

No code change — the lattice is correct today; this guards it against a future role/permission wiring change.

`go build ./...` ✅ · `go vet` ✅ · `golangci-lint` 0 ✅ · `gosec` 0 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)