### PR TITLE
chore(http): remove debug /test-route from the production router

### DIFF
--- a/server/http/router.go
+++ b/server/http/router.go
@@ -136,12 +136,6 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		handlers.HealthCheck(w, r)
 	})
 
-	// Test route
-	r.Get("/test-route", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "text/plain")
-		_, _ = w.Write([]byte("Test route working")) // #nosec G104
-	})
-
 	// Spanish status page endpoint
 	r.Get("/status-es", func(w http.ResponseWriter, r *http.Request) {
 		webDir := getWebAssetsPath(cfg)


### PR DESCRIPTION
Small hygiene cleanup (independent branch → its own CI).

`/test-route` returned a plaintext `Test route working` and was wired into the **live** router with **no references anywhere** — a leftover debug endpoint. Removing it drops needless attack surface and unprofessional cruft from a security product's production HTTP surface.

No tests or clients reference it; `server/http` tests pass (only the documented `TestEveryMutatingRouteDeniesReadOnly` flake fails locally, unaffected). vet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)