### PR TITLE
test(concurrency): max-reads burn-after-read invariant under -race

### DIFF
--- a/internal/core/concurrency_max_reads_test.go
+++ b/internal/core/concurrency_max_reads_test.go
@@ -1,0 +1,79 @@
+package core_test
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// TestConcurrency_MaxReads_FullReadPathEnforcesCap drives the real burn-after-read
+// path — GetSecretValue → readVersionValue → TryIncrementSecretReadCount — from many
+// concurrent readers against a max_reads-capped secret, and asserts the value is handed
+// out EXACTLY max_reads times. This is the user-facing invariant an attacker races: a
+// secret meant to be read N times must never be read N+1 times, even under contention.
+// Uses a file-backed SQLite (real multi-connection concurrency), run under -race.
+func TestConcurrency_MaxReads_FullReadPathEnforcesCap(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	dsn := "file:" + filepath.Join(t.TempDir(), "c.db") + "?_busy_timeout=10000&_journal_mode=WAL&_txlock=immediate"
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.Project{}, &models.Environment{}, &models.SecretNode{}, &models.SecretVersion{}))
+	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "p1"}).Error)
+	require.NoError(t, db.Create(&models.Environment{ID: 1, ProjectID: 1, Name: "dev"}).Error)
+	c := core.NewKeyorixCore(store.NewLocalStorage(db))
+	ctx := context.Background()
+
+	maxReads := 3
+	sec, err := c.CreateSecret(ctx, &core.CreateSecretRequest{
+		Name: "burn-after-read", Value: []byte("topsecret"), ProjectID: 1, EnvironmentID: 1,
+		Type: "password", Classification: "internal", MaxReads: &maxReads, OwnerID: 1, CreatedBy: "owner",
+	})
+	require.NoError(t, err)
+
+	const readers = 40
+	var succeeded atomic.Int64
+	unexpected := make(chan error, readers)
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < readers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			val, gerr := c.GetSecretValue(ctx, sec.ID)
+			if gerr != nil {
+				// The only expected failure is the cap being hit (max-reads exceeded).
+				return
+			}
+			if string(val) != "topsecret" {
+				unexpected <- fmt.Errorf("read returned the wrong value: %q", val)
+				return
+			}
+			succeeded.Add(1)
+		}()
+	}
+	close(start) // release all readers simultaneously
+	wg.Wait()
+	close(unexpected)
+	for e := range unexpected {
+		require.NoError(t, e)
+	}
+
+	assert.Equal(t, int64(maxReads), succeeded.Load(), "the value must be served exactly max_reads times, never more")
+
+	var got models.SecretVersion
+	require.NoError(t, db.Where("secret_node_id = ?", sec.ID).First(&got).Error)
+	assert.Equal(t, maxReads, got.ReadCount, "the persisted read_count must settle exactly at the cap")
+}

--- a/internal/storage/store/concurrency_max_reads_test.go
+++ b/internal/storage/store/concurrency_max_reads_test.go
@@ -1,0 +1,76 @@
+package store
+
+import (
+	"context"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// concurrentDB opens a temp FILE-backed SQLite (not :memory:) with a busy timeout and
+// WAL, so multiple connections genuinely contend — the only way to test that an atomic
+// check-and-increment holds under real concurrency. A single shared in-memory
+// connection would serialize every statement and mask a check-then-act race.
+func concurrentDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	dsn := "file:" + filepath.Join(t.TempDir(), "c.db") + "?_busy_timeout=10000&_journal_mode=WAL&_txlock=immediate"
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	require.NoError(t, err)
+	return db
+}
+
+// TestConcurrency_MaxReads_NeverExceedsCap is the burn-after-read invariant: a secret
+// version with read_count capped at maxReads must let through EXACTLY maxReads reads,
+// no matter how many readers race. TryIncrementSecretReadCount is a single conditional
+// UPDATE (read_count < maxReads), so concurrent callers can't collectively over-read;
+// this drives many readers at once and asserts exactly maxReads succeed.
+func TestConcurrency_MaxReads_NeverExceedsCap(t *testing.T) {
+	db := concurrentDB(t)
+	require.NoError(t, db.AutoMigrate(&models.SecretVersion{}))
+	ls := NewLocalStorage(db)
+
+	v := &models.SecretVersion{SecretNodeID: 1, VersionNumber: 1, ReadCount: 0}
+	require.NoError(t, db.Create(v).Error)
+
+	const maxReads = 5
+	const readers = 64
+
+	var succeeded atomic.Int64
+	errs := make(chan error, readers)
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < readers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			ok, err := ls.TryIncrementSecretReadCount(context.Background(), v.ID, maxReads)
+			if err != nil {
+				errs <- err
+				return
+			}
+			if ok {
+				succeeded.Add(1)
+			}
+		}()
+	}
+	close(start) // release all readers at once
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+
+	assert.Equal(t, int64(maxReads), succeeded.Load(), "exactly maxReads reads may succeed, never more")
+
+	var got models.SecretVersion
+	require.NoError(t, db.First(&got, v.ID).Error)
+	assert.Equal(t, maxReads, got.ReadCount, "the stored read_count must settle exactly at the cap")
+}


### PR DESCRIPTION
## New lane: concurrency-invariant assurance

The authorization-boundary lane is well-covered; this opens a new assurance lane — proving the **security-critical counters** hold under parallel load with `-race`. First up: `max_reads`. A secret capped at N reads must be served **exactly N times**, no matter how many readers race — over-reading a burn-after-read secret is a direct confidentiality break.

## What

Two complementary tests, run under `-race` against a **file-backed** SQLite (real multi-connection contention — a single shared in-memory connection would serialize every statement and mask a check-then-act race):

- **storage layer** — 64 readers hit `TryIncrementSecretReadCount(versionID, 5)` simultaneously → exactly **5** succeed, persisted `read_count` settles at 5. Proves the conditional `UPDATE ... WHERE read_count < maxReads` is atomic, not check-then-act.
- **full read path** — 40 concurrent `GetSecretValue` calls on a `max_reads=3` secret → the value is served exactly **3** times; the rest get max-reads-exceeded.

No code change — the invariant holds (atomic conditional UPDATE); these guard it against a regression to a non-atomic check-then-act, which would let concurrent readers over-read. Verified `-race` ×3.

`go build ./...` ✅ · `golangci-lint ./...` 0 ✅ · `gosec` 0 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)