### PR TITLE
feat(server): Cache-Control: no-store on API and SCIM responses

### DIFF
--- a/server/http/no_store_route_test.go
+++ b/server/http/no_store_route_test.go
@@ -1,0 +1,42 @@
+package http
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNoStore_ScopedToAPI confirms every API response carries Cache-Control: no-store
+// (even an unauthenticated 401, since the middleware runs before auth), while non-API
+// paths keep their own caching — secret values must never sit in a browser/proxy cache.
+func TestNoStore_ScopedToAPI(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	router, err := NewRouter(&config.Config{}, newTestCore(t))
+	require.NoError(t, err)
+	srv := httptest.NewServer(router)
+	defer srv.Close()
+	client := &http.Client{}
+
+	cacheCtl := func(path string) (int, string) {
+		resp, err := client.Get(srv.URL + path)
+		require.NoError(t, err)
+		_ = resp.Body.Close()
+		return resp.StatusCode, resp.Header.Get("Cache-Control")
+	}
+
+	// An API response (here a 401 — no auth) is no-store.
+	code, cc := cacheCtl("/api/v1/secrets")
+	assert.Equal(t, http.StatusUnauthorized, code)
+	assert.Equal(t, "no-store", cc, "API responses must be no-store")
+
+	// A non-API path keeps its own cache policy, not no-store (health sets no-cache).
+	_, cc = cacheCtl("/health")
+	assert.NotEqual(t, "no-store", cc, "non-API responses keep their own cache headers")
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -159,6 +159,7 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 	if cfg.SCIM.Enabled {
 		scimHandler := handlers.NewSCIMHandler(coreService)
 		r.Route("/scim/v2", func(r chi.Router) {
+			r.Use(customMiddleware.NoStore)
 			r.Use(customMiddleware.SCIMToken(cfg.SCIM.GetToken()))
 			r.Get("/ServiceProviderConfig", scimHandler.GetServiceProviderConfig)
 			r.Get("/Users", scimHandler.ListUsers)
@@ -177,6 +178,9 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 	}
 
 	r.Route("/api/v1", func(r chi.Router) {
+		// Never let any API response (secret values, tokens, …) be cached by a browser or
+		// proxy. Before auth, so even a 401 carries it.
+		r.Use(customMiddleware.NoStore)
 		// Authentication middleware for API routes
 		r.Use(customMiddleware.Authentication(coreService))
 		// Confine restricted (must-change-password) sessions to the password-change

--- a/server/middleware/no_store.go
+++ b/server/middleware/no_store.go
@@ -1,0 +1,15 @@
+package middleware
+
+import "net/http"
+
+// NoStore sets Cache-Control: no-store on every response it wraps, so browsers, proxies,
+// and any shared cache never store the body. API responses here can carry secret values,
+// tokens, and other sensitive data; without this they have no Cache-Control and are
+// cacheable by default. Apply it to the API groups (before auth, so even a 401 carries
+// it). Static assets keep their own cache headers — this is scoped to the API.
+func NoStore(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Cache-Control", "no-store")
+		next.ServeHTTP(w, r)
+	})
+}

--- a/server/middleware/no_store_test.go
+++ b/server/middleware/no_store_test.go
@@ -1,0 +1,18 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNoStore_SetsHeader(t *testing.T) {
+	h := NoStore(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized) // even an auth failure must carry it
+	}))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/v1/secrets/1", nil))
+	assert.Equal(t, "no-store", rec.Header().Get("Cache-Control"))
+}


### PR DESCRIPTION
Adds a `NoStore` middleware applied to the `/api/v1` and `/scim/v2` route groups (before auth) so secret material and directory data are never written to shared/intermediary caches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)