### PR TITLE
fix(server): serve web-UI static assets on GET/HEAD only

### DIFF
--- a/server/http/router.go
+++ b/server/http/router.go
@@ -670,17 +670,33 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 func registerWebUI(r chi.Router, fsys http.FileSystem) {
 	fileServer := http.FileServer(fsys)
 
-	r.With(setCacheHeaders).Handle("/assets/*", fileServer)
-	r.With(setCacheHeaders).Handle("/static/*", fileServer)
-	r.Handle("/sw.js", fileServer)
-	r.Handle("/manifest.json", fileServer)
-	r.Handle("/favicon.ico", fileServer)
+	// Static assets are read-only: register GET+HEAD only, so a mutating method
+	// (DELETE/PUT/POST/PATCH) on an asset gets a 405 from chi rather than the file
+	// served with a 200 (http.FileServer ignores the method). Cleaner semantics and a
+	// smaller surface for a security product.
+	serveStatic := func(pattern string, mws ...func(http.Handler) http.Handler) {
+		rr := r.With(mws...)
+		rr.Method(http.MethodGet, pattern, fileServer)
+		rr.Method(http.MethodHead, pattern, fileServer)
+	}
+	serveStatic("/assets/*", setCacheHeaders)
+	serveStatic("/static/*", setCacheHeaders)
+	serveStatic("/sw.js")
+	serveStatic("/manifest.json")
+	serveStatic("/favicon.ico")
 
 	// SPA fallback: serve index.html for any non-API route that didn't match a
-	// registered handler, so client-side routes (e.g. /admin/users) resolve.
+	// registered handler, so client-side routes (e.g. /admin/users) resolve. Only for
+	// GET/HEAD — a mutating method to an unmatched path is not a page load.
 	r.NotFound(func(w http.ResponseWriter, req *http.Request) {
+		// An unmatched API path is a 404 regardless of method.
 		if strings.HasPrefix(req.URL.Path, "/api/") {
 			http.NotFound(w, req)
+			return
+		}
+		// A mutating method to a non-API, unmatched path is not a page load.
+		if req.Method != http.MethodGet && req.Method != http.MethodHead {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 			return
 		}
 		f, err := fsys.Open("index.html")

--- a/server/http/static_methods_test.go
+++ b/server/http/static_methods_test.go
@@ -1,0 +1,53 @@
+package http
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStaticAssets_RejectMutatingMethods confirms the web-UI handlers serve only GET/HEAD:
+// a mutating method on a static asset (or an unmatched non-API page path) gets a 405,
+// rather than http.FileServer serving the file with a 200 (it ignores the method).
+func TestStaticAssets_RejectMutatingMethods(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	router, err := NewRouter(&config.Config{}, newTestCore(t))
+	require.NoError(t, err)
+	srv := httptest.NewServer(router)
+	defer srv.Close()
+	client := &http.Client{}
+
+	do := func(method, path string) int {
+		req, err := http.NewRequest(method, srv.URL+path, nil)
+		require.NoError(t, err)
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		_ = resp.Body.Close()
+		return resp.StatusCode
+	}
+
+	for _, asset := range []string{"/sw.js", "/manifest.json", "/favicon.ico", "/assets/x.js", "/static/x.css"} {
+		for _, m := range []string{http.MethodDelete, http.MethodPut, http.MethodPost, http.MethodPatch} {
+			assert.Equal(t, http.StatusMethodNotAllowed, do(m, asset), "%s %s must be 405", m, asset)
+		}
+		assert.NotEqual(t, http.StatusMethodNotAllowed, do(http.MethodGet, asset), "GET %s is allowed", asset)
+	}
+
+	// SPA fallback (unmatched, non-API page path): mutating → 405, GET → served (not 405).
+	assert.Equal(t, http.StatusMethodNotAllowed, do(http.MethodDelete, "/admin/users"))
+	assert.NotEqual(t, http.StatusMethodNotAllowed, do(http.MethodGet, "/admin/users"))
+
+	// API paths are unaffected: they keep their own handling (an unmatched /api/v1 path
+	// goes through the auth middleware → 401; a real route → its own auth), never the
+	// static 405.
+	assert.NotEqual(t, http.StatusMethodNotAllowed, do(http.MethodDelete, "/api/v1/does-not-exist"),
+		"API paths keep their own handling, not the static 405")
+	assert.NotEqual(t, http.StatusMethodNotAllowed, do(http.MethodGet, "/api/v1/secrets"))
+}


### PR DESCRIPTION
`registerWebUI` now serves static assets via a `serveStatic` helper that responds only to GET/HEAD; the SPA NotFound fallback is likewise gated on GET/HEAD. Mutating methods against static paths no longer fall through to the SPA handler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)