### PR TITLE
test(concurrency): login rate-limiter count integrity under concurrent attempts

### DIFF
--- a/internal/core/concurrency_rate_limit_test.go
+++ b/internal/core/concurrency_rate_limit_test.go
@@ -1,0 +1,61 @@
+package core_test
+
+import (
+	"context"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// TestConcurrency_LoginRateLimit_TripsAndStaysTripped drives the real per-IP brute-force
+// path — RecordFailedLogin → IsLoginRateLimited (ADR-040) — from many concurrent attempts
+// and asserts the end-to-end invariant: once the failed-attempt budget is reached, the IP
+// is rate-limited and stays that way, with every attempt counted. The limiter is a
+// fail-open backstop (the check is intentionally separate from the record, so it does NOT
+// promise "at most N attempts ever pass" under a race) — the guarantee it MUST keep is
+// that concurrent attempts can't deflate the count and slip the IP back under budget.
+func TestConcurrency_LoginRateLimit_TripsAndStaysTripped(t *testing.T) {
+	dsn := "file:" + filepath.Join(t.TempDir(), "rl.db") + "?_busy_timeout=10000&_journal_mode=WAL&_txlock=immediate"
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.LoginAttempt{}))
+	c := core.NewKeyorixCore(store.NewLocalStorage(db))
+	ctx := context.Background()
+
+	const ip = "203.0.113.42"
+	// Fire well past the budget concurrently.
+	const attempts = 100
+	require.Greater(t, attempts, core.LoginMaxAttempts)
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < attempts; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			c.RecordFailedLogin(ctx, ip)
+		}()
+	}
+	close(start) // release all attempts at once
+	wg.Wait()
+
+	// Every concurrent attempt was recorded, so the IP is over budget and stays limited
+	// across repeated checks (the count is monotonic within the window).
+	assert.True(t, c.IsLoginRateLimited(ctx, ip), "IP must be rate-limited once the budget is exceeded")
+	assert.True(t, c.IsLoginRateLimited(ctx, ip), "rate-limit verdict must be stable, not flap")
+
+	// A fresh IP with no attempts is not limited — the budget is per-IP, not global.
+	assert.False(t, c.IsLoginRateLimited(ctx, "198.51.100.9"), "an unrelated IP must not be limited")
+
+	// An empty IP fails open (never limited) by design.
+	assert.False(t, c.IsLoginRateLimited(ctx, ""), "empty IP must fail open")
+}

--- a/internal/storage/store/concurrency_rate_limit_test.go
+++ b/internal/storage/store/concurrency_rate_limit_test.go
@@ -1,0 +1,63 @@
+package store
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestConcurrency_LoginAttempts_NoLostRecords is the rate-limiter count-integrity
+// invariant (ADR-040). The per-IP login limiter is a windowed COUNT over independent
+// attempt rows; each failed login is its own INSERT (not an increment of a shared
+// counter), so the count cannot be deflated by a lost-update race. This drives many
+// concurrent RecordLoginAttempt calls for one IP and asserts every single one is durably
+// counted — if a future change turned the record path into a non-atomic upsert/increment,
+// concurrent attempts would lose writes, the window count would under-report, and the
+// brute-force budget would be silently inflated. That regression is what this guards.
+func TestConcurrency_LoginAttempts_NoLostRecords(t *testing.T) {
+	db := concurrentDB(t)
+	require.NoError(t, db.AutoMigrate(&models.LoginAttempt{}))
+	ls := NewLocalStorage(db)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	const attempts = 100
+	const ip = "203.0.113.7"
+
+	errs := make(chan error, attempts)
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < attempts; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			<-start
+			// Spread timestamps within the window so each row is distinct, but all newer
+			// than `since` below.
+			if err := ls.RecordLoginAttempt(ctx, ip, now.Add(time.Duration(n)*time.Millisecond)); err != nil {
+				errs <- err
+			}
+		}(i)
+	}
+	close(start) // release all writers at once
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+
+	// Every concurrent attempt must be counted — no lost inserts under contention.
+	n, err := ls.CountRecentLoginAttempts(ctx, ip, now.Add(-time.Minute))
+	require.NoError(t, err)
+	assert.Equal(t, int64(attempts), n, "every concurrent login attempt must be durably counted")
+
+	// A different IP shares none of those attempts (the WHERE ip = ? scoping holds).
+	other, err := ls.CountRecentLoginAttempts(ctx, "198.51.100.1", now.Add(-time.Minute))
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), other, "attempts must not leak across IPs")
+}


### PR DESCRIPTION
## Concurrency-invariant assurance lane — invariant #3: login rate-limiter (ADR-040)

Completes the lane over the three security-critical counters: **max-reads** ✓ (#465), **audit hash-chain** ✓ (#466), **rate-limiter** ✓ (here).

The per-IP brute-force limiter is a windowed `COUNT` over independent attempt rows — each failed login is its own `INSERT`, *not* an increment of a shared counter — so the count can't be deflated by a lost-update race. These tests pin that property.

## What

- **storage layer** — 100 concurrent `RecordLoginAttempt` for one IP → `CountRecentLoginAttempts` returns exactly **100** (no lost inserts under contention); a different IP sees **0** (the `WHERE ip = ?` scoping holds). If the record path ever became a non-atomic upsert/increment, concurrent attempts would lose writes and the budget would silently inflate — this catches that.
- **full path** — 100 concurrent `RecordFailedLogin` → `IsLoginRateLimited` is **true and stable** across repeated checks (count is monotonic within the window); a fresh IP is **not** limited (per-IP, not global) and an empty IP **fails open**.

## Honest scope

The limiter is a **fail-open backstop** with the check intentionally separate from the record, so it does **not** promise "at most N attempts ever pass" under a race — asserting that would be a false claim, and these tests don't. The property it *must* keep, and that these pin, is that concurrent attempts can't deflate the count and slip an IP back under budget.

No production code change. `go build ./...` ✅ · `golangci-lint ./...` 0 ✅ · `gosec` 0 ✅ · `-race` ×3 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)