### PR TITLE
fix(auth): make per-account login-lockout counting atomic under concurrency

### DIFF
--- a/internal/core/concurrency_login_lockout_test.go
+++ b/internal/core/concurrency_login_lockout_test.go
@@ -1,0 +1,83 @@
+package core_test
+
+import (
+	"context"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/bcrypt"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// TestConcurrency_LoginLockout_NoLostIncrements is the per-account lockout invariant under
+// load: the failed-attempt counter must not lose increments when many wrong-password
+// logins race for one account, so the account locks at the threshold and a single burst
+// produces exactly one lockout (not several from a check-then-act re-trip). recordFailedLogin
+// serializes the read-increment-write (process mutex + a Postgres FOR UPDATE row lock via
+// LockUserForUpdate); before that fix two concurrent failures could both read the same count
+// and write back the same value, losing an increment and letting an account exceed its
+// guess budget. This drives many concurrent wrong logins against a real file-backed SQLite
+// and asserts the account ends up locked exactly once.
+func TestConcurrency_LoginLockout_NoLostIncrements(t *testing.T) {
+	dsn := "file:" + filepath.Join(t.TempDir(), "lockout.db") + "?_busy_timeout=10000&_journal_mode=WAL"
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.User{}, &models.Session{}, &models.AuditEvent{}))
+
+	const password = "Secret#Pass123"
+	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.MinCost) // MinCost: keep the race tight
+	require.NoError(t, err)
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "alice", PasswordHash: string(hash), AccountState: core.AccountActive}).Error)
+
+	c := core.NewKeyorixCore(store.NewLocalStorage(db))
+	const maxAttempts = 5
+	c.SetLoginLockoutPolicy(core.LoginLockoutPolicy{
+		Enabled: true, MaxAttempts: maxAttempts,
+		Window: 15 * time.Minute, BaseCooldown: 5 * time.Minute, MaxCooldown: time.Hour,
+	})
+
+	const attackers = 40 // many more than the threshold
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < attackers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			// Wrong password every time → each call reaches recordFailedLogin (unless the
+			// account is already locked, in which case the gate rejects it first).
+			_, _, _ = c.Login(context.Background(), &core.LoginRequest{Username: "alice", Password: "wrong"})
+		}()
+	}
+	close(start) // release all attackers at once
+	wg.Wait()
+
+	// The account must be locked, exactly once — a lost increment would push the lock
+	// later (or, combined with a check-then-act re-trip, lock several times and inflate
+	// the backoff). The counter resets to 0 when the lock trips, and the burst's
+	// stragglers short-circuit on the active lock rather than counting.
+	var u models.User
+	require.NoError(t, db.First(&u, 1).Error)
+	require.NotNil(t, u.LoginLockedUntil, "account must be locked after a burst past the threshold")
+	assert.True(t, time.Now().Before(*u.LoginLockedUntil), "lock must still be active")
+	assert.Equal(t, 1, u.LoginLockoutCount, "a single burst must lock exactly once, not re-trip the backoff")
+	assert.Equal(t, 0, u.FailedLoginAttempts, "the window counter resets when the lock trips")
+
+	// Exactly one account.locked event was written (the lock is audited once).
+	var lockEvents int64
+	require.NoError(t, db.Model(&models.AuditEvent{}).
+		Where("event_type = ?", core.EventAccountLocked).Count(&lockEvents).Error)
+	assert.Equal(t, int64(1), lockEvents, "the lockout must be audited exactly once")
+
+	// And a correct password is now refused while locked (the gate holds).
+	_, _, err = c.Login(context.Background(), &core.LoginRequest{Username: "alice", Password: password})
+	require.ErrorContains(t, err, "locked")
+}

--- a/internal/core/login_lockout.go
+++ b/internal/core/login_lockout.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
@@ -53,29 +54,76 @@ func (p LoginLockoutPolicy) cooldownFor(lockoutCount int) time.Duration {
 // the previous failure is older than the window) and locks the account once it
 // reaches MaxAttempts. Best-effort persistence: a storage error must not change the
 // "invalid credentials" outcome the caller returns.
+//
+// The read-increment-write runs inside a transaction over a freshly LockUserForUpdate'd
+// row, under loginFailureMu, so concurrent failures for the same account cannot lose an
+// increment and let an attacker spend more than MaxAttempts guesses before the lock
+// trips: loginFailureMu serializes same-process callers (and so the whole single-process
+// SQLite case), and the FOR UPDATE row lock LockUserForUpdate takes on Postgres
+// serializes across HA replicas. The passed-in user struct was loaded before the lock,
+// so the authoritative current state is re-read inside the transaction.
 func (c *KeyorixCore) recordFailedLogin(ctx context.Context, user *models.User) {
 	if !c.loginLockout.Enabled {
 		return
 	}
+	uid := user.ID
 	now := c.now()
-	// A stale failure (older than the window) starts a fresh count.
-	if user.LastFailedLoginAt != nil && now.Sub(*user.LastFailedLoginAt) > c.loginLockout.Window {
-		user.FailedLoginAttempts = 0
-	}
-	user.FailedLoginAttempts++
-	user.LastFailedLoginAt = &now
 
-	if user.FailedLoginAttempts >= c.loginLockout.MaxAttempts {
-		user.LoginLockoutCount++
-		until := now.Add(c.loginLockout.cooldownFor(user.LoginLockoutCount))
-		user.LoginLockedUntil = &until
-		user.FailedLoginAttempts = 0 // window counter resets; the lock now gates
-		uid := user.ID
+	c.loginFailureMu.Lock()
+	defer c.loginFailureMu.Unlock()
+
+	var locked bool
+	var lockedUntil time.Time
+	var lockoutNum int
+
+	err := c.storage.WithTransaction(ctx, func(tx storage.Storage) error {
+		u, err := tx.LockUserForUpdate(ctx, uid)
+		if err != nil {
+			return err
+		}
+		// Already within an active lockout: don't escalate. The Login gate refuses to
+		// process a password while locked, so reaching here means this caller loaded the
+		// user before the lock was set (a concurrent burst). Counting it would re-trip the
+		// lock with exponential backoff and stretch a single burst into a much longer lock.
+		if u.LoginLockedUntil != nil && now.Before(*u.LoginLockedUntil) {
+			return nil
+		}
+		// A stale failure (older than the window) starts a fresh count.
+		if u.LastFailedLoginAt != nil && now.Sub(*u.LastFailedLoginAt) > c.loginLockout.Window {
+			u.FailedLoginAttempts = 0
+		}
+		u.FailedLoginAttempts++
+		u.LastFailedLoginAt = &now
+
+		if u.FailedLoginAttempts >= c.loginLockout.MaxAttempts {
+			u.LoginLockoutCount++
+			until := now.Add(c.loginLockout.cooldownFor(u.LoginLockoutCount))
+			u.LoginLockedUntil = &until
+			u.FailedLoginAttempts = 0 // window counter resets; the lock now gates
+			locked, lockedUntil, lockoutNum = true, until, u.LoginLockoutCount
+		}
+		if _, err := tx.UpdateUser(ctx, u); err != nil {
+			return err
+		}
+		// Reflect the persisted lockout fields back onto the caller's struct (it was
+		// loaded before the lock), without clobbering preloaded associations.
+		user.FailedLoginAttempts = u.FailedLoginAttempts
+		user.LastFailedLoginAt = u.LastFailedLoginAt
+		user.LoginLockedUntil = u.LoginLockedUntil
+		user.LoginLockoutCount = u.LoginLockoutCount
+		return nil
+	})
+	if err != nil {
+		return // best-effort: a storage error must not change the caller's outcome
+	}
+
+	// Emit the lock audit only after the transaction commits, so a rolled-back lock is
+	// never logged.
+	if locked {
 		c.writeAuditEventFull(ctx, EventAccountLocked, &uid, nil, nil, "",
 			fmt.Sprintf("account %d locked until %s after repeated failed logins (lockout #%d)",
-				user.ID, until.UTC().Format(time.RFC3339), user.LoginLockoutCount))
+				uid, lockedUntil.UTC().Format(time.RFC3339), lockoutNum))
 	}
-	_, _ = c.storage.UpdateUser(ctx, user)
 }
 
 // clearLoginFailures resets the lockout state after a successful authentication.

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -663,6 +663,11 @@ func (m *MockStorage) GetUser(ctx context.Context, id uint) (*models.User, error
 	return args.Get(0).(*models.User), args.Error(1)
 }
 
+// LockUserForUpdate has no row lock in the mock; it reuses the GetUser expectation.
+func (m *MockStorage) LockUserForUpdate(ctx context.Context, id uint) (*models.User, error) {
+	return m.GetUser(ctx, id)
+}
+
 func (m *MockStorage) GetUserByEmail(ctx context.Context, email string) (*models.User, error) {
 	args := m.Called(ctx, email)
 	if args.Get(0) == nil {

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -5,6 +5,7 @@ import (
 	"crypto/x509"
 	"fmt"
 	"regexp"
+	"sync"
 	"time"
 
 	"github.com/go-webauthn/webauthn/webauthn"
@@ -54,7 +55,12 @@ type KeyorixCore struct {
 	secretNamePolicy  SecretNamePolicy   // optional naming convention for secrets (off by default)
 	secretNameRe      *regexp.Regexp     // compiled secretNamePolicy.Pattern (nil = no regex check)
 	loginLockout      LoginLockoutPolicy // per-account login lockout (disabled by default)
-	auditForwarder    AuditForwarder
+	// loginFailureMu serializes the per-account failed-login read-increment-write in
+	// recordFailedLogin so concurrent failures can't lose an increment. Combined with
+	// the row lock LockUserForUpdate takes on Postgres, the lockout counter stays
+	// correct across replicas. Zero value is ready to use. See login_lockout.go.
+	loginFailureMu sync.Mutex
+	auditForwarder AuditForwarder
 	// auditStream is the in-process pub/sub broker that wakes live audit tails
 	// (gRPC StreamAuditLogs) the instant an event is written, replacing fixed-interval
 	// DB polling. Always non-nil (set in the constructors).

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -256,6 +256,15 @@ type Storage interface {
 	// persisted.
 	CreateUserWithRoleGrants(ctx context.Context, user *models.User, grants []RoleGrant) (*models.User, error)
 	GetUser(ctx context.Context, id uint) (*models.User, error)
+	// LockUserForUpdate re-reads a user by ID inside a WithTransaction, taking a
+	// row-level write lock on backends that support one (Postgres: SELECT … FOR
+	// UPDATE) so a read-modify-write on the row serializes against concurrent writers
+	// across replicas. On backends without row locks (SQLite) it is a plain read, and
+	// the caller is responsible for its own process-level serialization. Returns the
+	// typed ErrUserNotFound when the user is absent. Use this — not GetUser — whenever
+	// a transaction increments or conditionally mutates per-user counters (e.g. the
+	// login-lockout failed-attempt count) that must not lose updates under concurrency.
+	LockUserForUpdate(ctx context.Context, id uint) (*models.User, error)
 	GetUserByEmail(ctx context.Context, email string) (*models.User, error)
 	UpdateUser(ctx context.Context, user *models.User) (*models.User, error)
 	// UpdateLastLogin stamps the user's last_login_at column without touching any

--- a/internal/storage/store/local_users.go
+++ b/internal/storage/store/local_users.go
@@ -19,6 +19,7 @@ import (
 	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 // --- Users ---
@@ -63,6 +64,26 @@ func (ls *LocalStorage) GetUser(ctx context.Context, id uint) (*models.User, err
 		if err == gorm.ErrRecordNotFound {
 			// Wrap the typed sentinel so callers can distinguish "absent" from a
 			// transient failure (e.g. ownership-transfer recovery must fail closed).
+			return nil, fmt.Errorf("%s: %w", i18n.T("ErrorUserNotFound", nil), storage.ErrUserNotFound)
+		}
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	return &user, nil
+}
+
+// LockUserForUpdate re-reads a user, adding SELECT … FOR UPDATE on Postgres so a
+// read-modify-write inside a transaction serializes against concurrent writers of the
+// same row (the login-lockout failed-attempt counter relies on this — see
+// recordFailedLogin). SQLite has no row-level lock, so the clause is omitted there and
+// the caller serializes in-process; SQLite is always single-process, so that suffices.
+func (ls *LocalStorage) LockUserForUpdate(ctx context.Context, id uint) (*models.User, error) {
+	q := ls.db.WithContext(ctx)
+	if ls.db.Dialector.Name() == "postgres" {
+		q = q.Clauses(clause.Locking{Strength: "UPDATE"})
+	}
+	var user models.User
+	if err := q.First(&user, id).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
 			return nil, fmt.Errorf("%s: %w", i18n.T("ErrorUserNotFound", nil), storage.ErrUserNotFound)
 		}
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)

--- a/internal/storage/store/remote_users.go
+++ b/internal/storage/store/remote_users.go
@@ -55,6 +55,13 @@ func (rs *RemoteStorage) GetUser(ctx context.Context, id uint) (*models.User, er
 	return &result, nil
 }
 
+// LockUserForUpdate has no row lock to take over HTTP — each remote API call is already
+// atomic server-side, and the server's own LocalStorage takes the real FOR UPDATE lock
+// when it runs the lockout accounting. So this is a plain read.
+func (rs *RemoteStorage) LockUserForUpdate(ctx context.Context, id uint) (*models.User, error) {
+	return rs.GetUser(ctx, id)
+}
+
 // GetUserByEmail retrieves a user by email via remote API.
 func (rs *RemoteStorage) GetUserByEmail(ctx context.Context, email string) (*models.User, error) {
 	path := fmt.Sprintf("/api/v1/users/by-email/%s", email)


### PR DESCRIPTION
## The bug

The per-account login lockout (`login_lockout.go`) incremented `user.FailedLoginAttempts` on the in-memory `User` struct each `Login` loaded *for itself*, then wrote the whole row back — a classic **read-modify-write lost-update race**. Concurrent failed logins for one account each read the same count and wrote back the same value, losing increments. An attacker racing parallel requests could spend well past `MaxAttempts` guesses before the lock tripped (and with the lock gate also reading a stale user, a burst could fail to lock at all). This is the race I flagged while building the concurrency-assurance test lane (#465/#466/#472) rather than papering over with a test that asserted behavior it didn't have.

## The fix

Do the read-increment-write inside `c.storage.WithTransaction` over a freshly re-read, **row-locked** user, under a process mutex — mirroring the audit-chain precedent (process mutex + DB-level lock):

- **`LockUserForUpdate(ctx, id)`** — new storage primitive: re-reads the user adding `SELECT … FOR UPDATE` on Postgres (clause omitted on SQLite), so same-account updates serialize **across HA replicas**. Implemented on Local + Remote storage and the test mock; interface-documented as the read to use for any per-user counter that must not lose updates.
- **`KeyorixCore.loginFailureMu`** — serializes same-process callers, covering the whole single-process SQLite case (SQLite has no row lock).
- **`recordFailedLogin`** — re-reads authoritative state inside the txn, applies the existing window-reset / increment / threshold-lock / exponential-backoff policy **unchanged**, and emits the `account.locked` audit only *after* commit (a rolled-back lock is never logged).
- **Burst de-dup** — while an account is already within an active lockout, a straggler from a concurrent burst short-circuits instead of counting. The Login gate already refuses to process a password while locked, so this just makes a single burst lock **exactly once** instead of re-tripping the exponential backoff and stretching the lock.

## Test

`TestConcurrency_LoginLockout_NoLostIncrements` — 40 concurrent wrong-password logins against a file-backed SQLite lock the account **exactly once** (`LoginLockoutCount==1`, one `account.locked` audit event), then a correct password is refused.

**Verified as a real guard:** the test **FAILS** against the old in-place implementation (lost updates keep the count below the threshold, so the account never locks) and **PASSES** with the fix — `-race` ×3. All existing login-lockout tests are unchanged and green.

`go build ./...` ✅ · `golangci-lint ./...` 0 ✅ · `gosec` 0 ✅ · server handler tests ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)