### PR TITLE
release: finalize v0.81.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,49 @@
 All notable changes to Keyorix are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## v0.81.0 — 2026-06-23
+
+A security-hardening release: the HTTP edge gets global security headers, a request
+body-size cap, no panic-internals leakage, and the debug route removed from production;
+per-account login lockout is now atomic under concurrency; and share self-removal works
+end-to-end.
+
+### Added
+- **Share self-removal works end-to-end** — a recipient can now remove themselves from a
+  secret share via `DELETE /api/v1/secrets/{id}/self-share` and the corresponding CLI
+  command. The CLI command previously shipped as a non-functional placeholder; it is now a
+  registered remote-only command backed by a real route, and the operation only removes the
+  caller's own direct share (never a group share, never someone else's). ([#458])
+
+### Security
+- **Global security-headers middleware** — every response now carries `X-Content-Type-Options:
+  nosniff`, `X-Frame-Options: DENY`, `Referrer-Policy: no-referrer`, and HSTS when TLS is
+  enabled. ([#455])
+- **Request body-size cap (DoS mitigation)** — requests are bounded by
+  `http.MaxBytesReader` (10 MiB default, configurable), so an oversized or slow body can't
+  exhaust server memory. ([#456])
+- **Panic internals never reach the client** — the recovery middleware no longer has a
+  development branch that could return the panic value or stack trace in the response; it
+  always responds with a generic 500. ([#453])
+- **Debug `/test-route` removed from the production router** — a leftover debug route is no
+  longer registered. ([#460])
+
+### Fixed
+- **Per-account login lockout is atomic under concurrency** — failed-login counting now uses
+  an atomic update, so concurrent attempts can't race past the lockout threshold. ([#474])
+
+### Internal
+- Group-inherited grant lifecycle boundary tests — expiry and membership transitions for
+  permissions inherited through group shares. ([#475])
+
+[#453]: https://github.com/keyorixhq/keyorix/pull/453
+[#455]: https://github.com/keyorixhq/keyorix/pull/455
+[#456]: https://github.com/keyorixhq/keyorix/pull/456
+[#458]: https://github.com/keyorixhq/keyorix/pull/458
+[#460]: https://github.com/keyorixhq/keyorix/pull/460
+[#474]: https://github.com/keyorixhq/keyorix/pull/474
+[#475]: https://github.com/keyorixhq/keyorix/pull/475
+
 ## v0.80.0 — 2026-06-23
 
 SAML 2.0 single sign-on (Service Provider) lands as a working login path, three more

--- a/deploy/helm/keyorix-k8s-sync/Chart.yaml
+++ b/deploy/helm/keyorix-k8s-sync/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix-k8s-sync
 description: Keyorix Kubernetes sync agent — materialises Keyorix secrets into native Kubernetes Secrets
 type: application
 # Chart version — tracks the Keyorix release version (published in lockstep).
-version: 0.80.0
+version: 0.81.0
 # The keyorix-k8s-sync image tag this chart deploys by default.
-appVersion: "0.80.0"
+appVersion: "0.81.0"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix

--- a/deploy/helm/keyorix-operator/Chart.yaml
+++ b/deploy/helm/keyorix-operator/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix-operator
 description: Keyorix Kubernetes operator — reconciles KeyorixSecret resources into native Kubernetes Secrets
 type: application
 # Chart version — tracks the Keyorix release version (published in lockstep).
-version: 0.80.0
+version: 0.81.0
 # The keyorix-operator image tag this chart deploys by default.
-appVersion: "0.80.0"
+appVersion: "0.81.0"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix

--- a/deploy/helm/keyorix/Chart.yaml
+++ b/deploy/helm/keyorix/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix
 description: Self-hosted Keyorix secrets manager (API server + web UI + PostgreSQL)
 type: application
 # Chart version — bump on chart changes.
-version: 0.80.0
+version: 0.81.0
 # The Keyorix app version this chart deploys by default (the image tag).
-appVersion: "0.80.0"
+appVersion: "0.81.0"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix


### PR DESCRIPTION
Cuts **v0.81.0**, folding everything merged since v0.80.0 into the changelog and bumping the three Helm charts to 0.81.0.

A **security-hardening release**: global security-headers middleware (#455), a request body-size cap / DoS mitigation (#456), the recovery middleware no longer leaking panic internals (#453), and the debug `/test-route` removed from the production router (#460). Plus atomic per-account login lockout under concurrency (#474) and end-to-end share self-removal — route + working CLI (#458).

No code changes — changelog + chart version bumps only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)