### PR TITLE
test(authz): connect per-reference RBAC has no admin bypass (ADR-045)

### DIFF
--- a/internal/core/connect_rbac_admin_test.go
+++ b/internal/core/connect_rbac_admin_test.go
@@ -1,0 +1,50 @@
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestConnectRefRBAC_NoAdminBypass pins a deliberate asymmetry: the connect per-reference
+// RBAC (ADR-045) has NO admin bypass, unlike core RBAC where an admin role short-circuits
+// every permission check (Authorize → roleSetContainsAdmin). connectRefAllowed resolves
+// only role-set membership against the grants, so once a connector is ref-scoped even a
+// global super_admin is bounded by the grants — federated reads are deny-by-default for
+// any role without a matching grant. This matters because a leaked or over-broad admin
+// must not silently widen which external secrets can be pulled through a connector, and it
+// is easy to regress by "helpfully" adding an admin shortcut to the federated-read path.
+func TestConnectRefRBAC_NoAdminBypass(t *testing.T) {
+	c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v"})
+
+	// User 1 is a GLOBAL super_admin — the role that bypasses core RBAC.
+	seedRoleForUser(t, db, 1, 1, "super_admin")
+	// The connector is ref-scoped, but only for a DIFFERENT role (reader = role 2).
+	require.NoError(t, db.Create(&models.Role{ID: 2, Name: "reader"}).Error)
+	seedGrant(t, c, 2, "aws", "metrics/")
+
+	ctx := context.Background()
+
+	// Precondition: the super_admin DOES bypass core RBAC — no connect.read permission is
+	// seeded, yet Authorize returns true via the admin-name bypass.
+	ok, err := c.Authorize(ctx, 1, "connect.read", Scope{})
+	require.NoError(t, err)
+	require.True(t, ok, "precondition: super_admin bypasses core RBAC")
+
+	// But the per-reference policy still denies the admin: their role holds no matching
+	// connect ref-grant on this scoped connector.
+	_, err = c.ReadFederatedSecret(ctx, ActorTypeUser, 1, "aws", "metrics/qps")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not permitted", "the connect per-ref policy must not honor an admin bypass")
+
+	// And it is an ordinary-role policy, not a hard block on admins: granting the admin
+	// role itself a matching prefix lets the read through — proving the earlier denial was
+	// policy-driven, not a special-case rejection of admins.
+	seedGrant(t, c, 1, "aws", "metrics/")
+	val, err := c.ReadFederatedSecret(ctx, ActorTypeUser, 1, "aws", "metrics/qps")
+	require.NoError(t, err)
+	assert.Equal(t, "v", val, "an explicit grant on the admin role authorizes the read")
+}


### PR DESCRIPTION
## Authorization-boundary lane — federated-read (Keyorix Connect) per-ref policy

Continues the lane (#457/#459/#462/#463/#464/#475). The connect per-reference RBAC suite already covers prefix/glob scoping, role mismatch, empty-prefix-all, multi-role union, machine identities, and group-derived roles — but **not** the admin asymmetry, which is the highest-value unpinned property here.

## The property

Core RBAC lets an admin role **short-circuit** every permission check (`Authorize` → `roleSetContainsAdmin`). The connect per-reference policy (`connectRefAllowed`) resolves **only role-set membership** against the ref-grants — it has **no admin bypass**. So once a connector is ref-scoped, even a global `super_admin` is bounded by the grants: a federated read is deny-by-default for any role without a matching grant.

This is deliberate and worth guarding: a leaked or over-broad admin must **not** silently widen which external secrets can be pulled through a connector. It is also easy to regress by "helpfully" adding an admin shortcut to `ReadFederatedSecret`.

## Test

`TestConnectRefRBAC_NoAdminBypass`:
- a global `super_admin` **bypasses core RBAC** — `Authorize("connect.read")` is true with no permission seeded (precondition);
- yet is **denied** a federated read on a connector ref-scoped only for a different role (`"not permitted"`);
- and once the **admin role itself** is granted a matching prefix, the read **succeeds** — proving the denial was policy-driven, not a special-case rejection of admins (so the assertion isn't a tautology).

Drives the real enforcement path (`ReadFederatedSecret` → `connectRefAllowed`) through a live SQLite store. No production code change.

`go build ./...` ✅ · all connect tests ✅ · `golangci-lint ./...` 0 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)