### PR TITLE
test(authz): pin connect ref-grant bare-prefix segment-boundary footgun (ADR-045)

### DIFF
--- a/internal/core/connect_ref_prefix_boundary_test.go
+++ b/internal/core/connect_ref_prefix_boundary_test.go
@@ -1,0 +1,68 @@
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRefMatches_BarePrefixIsNotASegmentBoundary pins the documented prefix semantics of a
+// ConnectRefGrant whose RefPrefix has no glob metacharacters (ADR-045): it is matched with
+// strings.HasPrefix — a substring prefix, NOT a path-segment boundary. So a bare prefix
+// "prod" also authorizes the SIBLING namespace "production/...". The safe, segment-scoped
+// form is the trailing slash, "prod/". This is a real operator footgun (an unintentionally
+// over-broad grant), the same class of start-only prefix bug as the rotation-ref URL
+// injection note — so pin both the sharp edge and the safe pattern, and force any change to
+// the matching semantics to be a deliberate, reviewed decision.
+func TestRefMatches_BarePrefixIsNotASegmentBoundary(t *testing.T) {
+	// A bare prefix matches its own namespace — and also leaks into a sibling one.
+	assert.True(t, refMatches("prod", "prod/db"), "bare prefix matches within its own namespace")
+	assert.True(t, refMatches("prod", "production/db"),
+		"FOOTGUN: a bare prefix also matches the sibling namespace 'production/' (HasPrefix, not a path boundary)")
+
+	// A trailing slash scopes the grant to the segment — the safe form.
+	assert.True(t, refMatches("prod/", "prod/db"), "trailing-slash prefix matches within the namespace")
+	assert.False(t, refMatches("prod/", "production/db"),
+		"a trailing-slash prefix does NOT leak into the sibling namespace 'production/'")
+}
+
+// TestConnectRefRBAC_BarePrefixOverMatchesSiblingNamespace shows the same edge through the
+// real enforcement path: a grant written with a bare prefix authorizes a sibling namespace
+// the operator likely did not intend, whereas the trailing-slash grant confines the read.
+// Pinning the end-to-end behavior keeps the footgun visible and the fix (write prefixes
+// with a trailing slash) discoverable.
+func TestConnectRefRBAC_BarePrefixOverMatchesSiblingNamespace(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("bare prefix leaks into the sibling namespace", func(t *testing.T) {
+		c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v"})
+		seedRoleForUser(t, db, 1, 5, "prod-reader")
+		seedGrant(t, c, 5, "aws", "prod") // bare prefix — NO trailing slash
+
+		val, err := c.ReadFederatedSecret(ctx, ActorTypeUser, 1, "aws", "prod/db")
+		require.NoError(t, err)
+		assert.Equal(t, "v", val, "the intended namespace is allowed")
+
+		val, err = c.ReadFederatedSecret(ctx, ActorTypeUser, 1, "aws", "production/db")
+		require.NoError(t, err)
+		assert.Equal(t, "v", val,
+			"FOOTGUN: the bare-prefix grant also authorizes the sibling namespace 'production/'")
+	})
+
+	t.Run("trailing-slash prefix confines the grant", func(t *testing.T) {
+		c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v"})
+		seedRoleForUser(t, db, 1, 5, "prod-reader")
+		seedGrant(t, c, 5, "aws", "prod/") // safe form — trailing slash
+
+		val, err := c.ReadFederatedSecret(ctx, ActorTypeUser, 1, "aws", "prod/db")
+		require.NoError(t, err)
+		assert.Equal(t, "v", val, "the intended namespace is allowed")
+
+		_, err = c.ReadFederatedSecret(ctx, ActorTypeUser, 1, "aws", "production/db")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not permitted",
+			"the trailing-slash grant denies the sibling namespace 'production/'")
+	})
+}


### PR DESCRIPTION
## Authorization-boundary lane — closing the connect ref-grant thin spots

Final pass over the thin spots flagged after #477. Two turned out to be **already covered**, so this PR pins only the one real gap (noted below for the record).

## What this pins

A `ConnectRefGrant` `RefPrefix` with no glob metacharacters is matched with `strings.HasPrefix` (ADR-045, backward compatible) — a **substring** prefix, **not** a path-segment boundary. So a bare prefix `"prod"` also authorizes the **sibling namespace** `"production/..."`, an unintentionally over-broad grant. The safe, segment-scoped form is the trailing slash `"prod/"`. The existing `TestRefMatches` only exercises trailing-slash prefixes, so this sharp edge was unpinned.

Pinned at both levels:
- **unit** — `refMatches("prod","production/db")==true` vs `refMatches("prod/","production/db")==false`;
- **end-to-end** — through `ReadFederatedSecret`: a bare-prefix grant lets a role read `production/db`, while the trailing-slash grant denies it (`"not permitted"`).

This is **documented behavior, not a change** — pinning keeps the footgun visible and forces any future change to the matching semantics to be a deliberate, reviewed decision. Same class as the rotation-ref start-only prefix bug.

## Thin spots that were already covered (no test added)

- **PAT / share expiry** — `TestShareExpiry_Enforcement` already pins share expiry in the authorization path, and `TestValidatePATToken` already covers the **revoked / expired / inactive-user** reject paths. Expiry is a pure time-read (no race), so the "under concurrency" framing didn't apply.
- **Suspended / soft-deleted user** — `account_state_test.go` (`TestLogin_BlocksSuspended`, `TestValidateSessionToken_RejectsBlockedOrInactive`) already gate account state at the session layer; the `Authorize` RBAC path deliberately doesn't.

No production code change. `go build ./...` ✅ · connect tests ✅ · `golangci-lint ./...` 0 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)