### PR TITLE
feat(airgap): update-bundle format, build & offline verify (ADR-064)

### DIFF
--- a/docs/adr-064-air-gap-update-bundles.md
+++ b/docs/adr-064-air-gap-update-bundles.md
@@ -1,0 +1,83 @@
+# ADR-064: Air-gap update bundles — format, signing & offline verify (ADR-062 Phase 1a)
+
+## Status
+
+Accepted. Implements the **bundle** half of [ADR-062](adr-062-air-gap-updates.md) Phase 1;
+see [air-gap-updates-design.md](air-gap-updates-design.md) §3. Builds on the Phase 0 trust
+foundation (`internal/trust`). The `import` half (registry load + chart/CRD staging) is a
+follow-up phase (1b).
+
+## Context
+
+Air-gapped and highly-regulated deployments — the data-sovereignty segment Keyorix targets
+(defence, finance, government; NIS2/DORA supply-chain integrity) — cannot reach the
+internet to pull GHCR images and GitHub-Release artifacts. They need a single, verifiable
+file they can carry across the gap and check **offline**, with cryptographic provenance and
+anti-downgrade, trusting only a key pinned into the binary — never a key shipped inside the
+artifact.
+
+Phase 0 (ADR-062, #441) already shipped the verify-only foundation: `internal/trust`, a
+purpose-scoped `ed25519` public-key registry that embeds trusted keys at build time via
+`-ldflags` and **fails closed** (a plain `go build` trusts nothing). What was missing is the
+bundle itself: a format, a way to build and sign it, and an offline verifier.
+
+## Decision
+
+Add `internal/bundle` and a `keyorix bundle` CLI with two commands.
+
+**Format.** A bundle is a gzip-compressed tar. The first two entries are `manifest.json`
+(version, `released_at`, `min_upgrade_from`, signing `key_id`, and every component pinned
+by `sha256` + size) and `manifest.sig` (a detached `ed25519` signature over the exact
+`manifest.json` bytes). All remaining entries are the pinned component files (images,
+charts, CRDs, binaries, migrations). Signing the manifest transitively authenticates the
+whole bundle: verify the signature, then verify each file's digest against the manifest.
+
+**Trust.** Verification uses the `key_id` named in the manifest to select a key from the
+**embedded** trust registry (`trust.PurposeUpdate`). It trusts only embedded, pinned keys —
+a forged `key_id` is not in the registry, and an attacker cannot sign with a trusted
+private key (the key never ships). The manifest is signed over its canonical (deterministic,
+sorted-components) bytes, so the same inputs reproduce byte-identical, re-verifiable output.
+
+**Verify is streaming and fail-closed.** It reads the manifest + signature first (size-
+bounded), checks the signature, then streams each component, hashing it against its pinned
+digest with the read bounded to the pinned size (a decompression-bomb guard that also
+rejects an oversized entry). It rejects an unlisted file, a missing component, a digest
+mismatch, an unknown/untrusted key, or an unconfigured purpose — every failure mode returns
+an error and surfaces nothing.
+
+**Anti-downgrade.** `CheckUpgrade(installed)` refuses a bundle whose version is not strictly
+newer than what is installed, and enforces `min_upgrade_from` (anti-skip). A first install
+(empty installed version) passes.
+
+**CLI.**
+- `keyorix bundle build --src <dir> --version vX.Y.Z --key-id <id> --sign-key <pkcs8.pem>
+  [--min-upgrade-from vA.B.C] --out <file>` — the issuance side (Keyorix/CI), signing with
+  the offline private key minted by `keyorix trust keygen`.
+- `keyorix bundle verify <file> [--installed-version vX.Y.Z]` — the air-gapped operator
+  side, verifying offline against the embedded pinned key and reporting version, key-id, and
+  components. Fails closed.
+
+## Alternatives considered
+
+- **Sign each artifact separately (cosign/sigstore).** Strong tooling, but sigstore's
+  default flow is online (transparency log, Fulcio) — the opposite of air-gap — and it
+  fragments provenance across many signatures. A single signed manifest pinning everything
+  is one artifact, one signature, offline by construction.
+- **Detached signature + checksums.txt (the existing release output).** Already SHA-256s
+  the artifacts, but the checksum file is unsigned and the artifacts are many files, not one
+  carriable, anti-downgrade-aware unit.
+- **Buffer the whole bundle to verify.** Simpler, but images make bundles large; streaming
+  + per-entry size bounds keep verification memory-flat and bomb-resistant.
+
+## Consequences
+
+- Additive and behaviour-neutral: no caller verifies bundles at runtime yet, and a non-
+  release build embeds no keys (every verify fails closed). Producing signed bundles is an
+  operational step gated on embedding the production update key.
+- The `import` path (load images into an internal registry, stage charts/CRDs/binaries,
+  enforce `CheckUpgrade` against the live install, emit an audit event) is Phase 1b and
+  reuses `Verify` + `CheckUpgrade` unchanged.
+- CI wiring (`bundle build` as a `release.yml` step publishing the bundle as a release
+  asset) follows once a production update-signing key is embedded.
+- Maps to a future "supply-chain integrity" compliance control (NIS2 Art. 21, DORA ICT
+  third-party risk, ENS `op.exp.*`).

--- a/docs/air-gap-updates-design.md
+++ b/docs/air-gap-updates-design.md
@@ -184,8 +184,14 @@ behaviour until built.
    no callers until Phase 1, and a non-release build trusts no keys. Generating the
    production keypairs and embedding their public keys is an operational step at first
    release of a signed artifact.
-2. **Phase 1 — bundles:** `keyorix bundle build` (CI, extends `release.yml`) +
-   `verify`/`import`; bundle published as a release asset for online customers to relay.
+2. **Phase 1 — bundles:**
+   - **1a (done, [ADR-064](adr-064-air-gap-update-bundles.md)):** the bundle format,
+     `internal/bundle`, and `keyorix bundle build` (sign) + `verify` (offline, fail-closed,
+     anti-downgrade) — the cryptographic + structural core, built on the Phase 0 trust
+     registry.
+   - **1b:** `keyorix bundle import` (load images into an internal registry, stage
+     charts/CRDs/binaries, enforce no-downgrade against the live install, audit event) and
+     CI wiring (`bundle build` in `release.yml`, bundle published as a release asset).
 3. **Phase 2 — licensing:** offline license verification, the commercial feature gate
    (fail-safe), `license install|status`, and compliance/audit surfacing.
 4. **Phase 3 — hardening:** HSM-backed signing, key rotation drill, reproducible-bundle

--- a/internal/bundle/bundle.go
+++ b/internal/bundle/bundle.go
@@ -1,0 +1,437 @@
+// Package bundle implements Keyorix's air-gapped update bundles (ADR-064, ADR-062
+// Phase 1a). A bundle is a single gzip-compressed tar carrying a versioned set of release
+// artifacts (images, charts, CRDs, binaries, migrations) plus a signed manifest that pins
+// every component by sha256. An air-gapped operator carries the file across the gap and
+// verifies it offline against an embedded, pinned ed25519 public key — so trust follows a
+// pinned chain (the key never travels with the bundle), not a self-described signature.
+//
+// This package is the cryptographic and structural core: build a manifest, sign it, write
+// the bundle, and verify a bundle (signature first, then every component digest, fail
+// closed). It deliberately does not load images into a registry or stage charts — that is
+// `bundle import` (Phase 1b), which builds on Verify here.
+package bundle
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"crypto/ed25519"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/hex"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/trust"
+)
+
+// Reserved entry names that carry the manifest and its signature, not bundle components.
+const (
+	manifestName = "manifest.json"
+	sigName      = "manifest.sig"
+)
+
+// maxManifestBytes caps the in-memory manifest/signature reads so a malformed bundle
+// can't exhaust memory before the signature is even checked. A real manifest is a few KiB.
+const maxManifestBytes = 4 << 20 // 4 MiB
+
+var (
+	// ErrNoManifest means the archive did not begin with manifest.json + manifest.sig.
+	ErrNoManifest = errors.New("bundle: manifest.json/manifest.sig missing or out of order")
+	// ErrDigestMismatch means a component's bytes did not match its pinned sha256.
+	ErrDigestMismatch = errors.New("bundle: component digest mismatch")
+	// ErrUnlistedComponent means the archive carried a file not pinned in the manifest.
+	ErrUnlistedComponent = errors.New("bundle: file not listed in manifest")
+	// ErrMissingComponent means the manifest pinned a file the archive did not contain.
+	ErrMissingComponent = errors.New("bundle: manifest component missing from archive")
+	// ErrNotUpgrade means the bundle version is not newer than what is installed.
+	ErrNotUpgrade = errors.New("bundle: version is not an upgrade over the installed version")
+	// ErrUpgradeSkipped means the installed version is older than the bundle's min_upgrade_from.
+	ErrUpgradeSkipped = errors.New("bundle: installed version is below the bundle's minimum upgrade-from")
+)
+
+// Component pins one file in the bundle by its digest and size. Path is a clean,
+// forward-slash, relative path (e.g. "charts/keyorix-0.81.0.tgz").
+type Component struct {
+	Path   string `json:"path"`
+	SHA256 string `json:"sha256"`
+	Size   int64  `json:"size"`
+}
+
+// Manifest describes a bundle: what version it carries, the components it pins, the
+// signing key-id, and the anti-skip floor. Signing the manifest transitively authenticates
+// every component, because each is pinned by sha256.
+type Manifest struct {
+	Version        string      `json:"version"`
+	ReleasedAt     time.Time   `json:"released_at"`
+	MinUpgradeFrom string      `json:"min_upgrade_from,omitempty"`
+	KeyID          string      `json:"key_id"`
+	Components     []Component `json:"components"`
+}
+
+// MarshalCanonical renders the manifest deterministically (components sorted by path,
+// indented) so the same inputs always produce byte-identical manifest.json — the bytes
+// that get signed and, at verify time, re-checked against the signature.
+func (m *Manifest) MarshalCanonical() ([]byte, error) {
+	c := *m
+	c.Components = append([]Component(nil), m.Components...)
+	sort.Slice(c.Components, func(i, j int) bool { return c.Components[i].Path < c.Components[j].Path })
+	return json.MarshalIndent(&c, "", "  ")
+}
+
+// component lookup helper.
+func (m *Manifest) byPath() map[string]Component {
+	idx := make(map[string]Component, len(m.Components))
+	for _, c := range m.Components {
+		idx[c.Path] = c
+	}
+	return idx
+}
+
+// cleanComponentPath validates a component path is relative, normalized, and contained —
+// no absolute paths, no "..", no leading slash. Returned in clean forward-slash form.
+func cleanComponentPath(p string) (string, error) {
+	p = strings.TrimSpace(p)
+	if p == "" {
+		return "", fmt.Errorf("bundle: empty component path")
+	}
+	if path.IsAbs(p) || strings.HasPrefix(p, "/") {
+		return "", fmt.Errorf("bundle: absolute component path %q", p)
+	}
+	clean := path.Clean(filepath.ToSlash(p))
+	if clean == "." || clean == ".." || strings.HasPrefix(clean, "../") {
+		return "", fmt.Errorf("bundle: component path escapes the bundle: %q", p)
+	}
+	if clean == manifestName || clean == sigName {
+		return "", fmt.Errorf("bundle: component path %q collides with a reserved name", p)
+	}
+	return clean, nil
+}
+
+// BuildManifest walks srcDir and pins every regular file (by relative path) with its
+// sha256 and size. It refuses reserved names; manifest.json/manifest.sig are written by
+// WriteBundle, not taken from srcDir.
+func BuildManifest(srcDir, version, keyID, minUpgradeFrom string, releasedAt time.Time) (*Manifest, error) {
+	if strings.TrimSpace(version) == "" {
+		return nil, fmt.Errorf("bundle: version is required")
+	}
+	if _, err := parseVersion(version); err != nil {
+		return nil, fmt.Errorf("bundle: version %q: %w", version, err)
+	}
+	if strings.TrimSpace(keyID) == "" {
+		return nil, fmt.Errorf("bundle: key-id is required")
+	}
+	if minUpgradeFrom != "" {
+		if _, err := parseVersion(minUpgradeFrom); err != nil {
+			return nil, fmt.Errorf("bundle: min-upgrade-from %q: %w", minUpgradeFrom, err)
+		}
+	}
+
+	var components []Component
+	err := filepath.WalkDir(srcDir, func(p string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !d.Type().IsRegular() {
+			return nil
+		}
+		rel, err := filepath.Rel(srcDir, p)
+		if err != nil {
+			return err
+		}
+		clean, err := cleanComponentPath(rel)
+		if err != nil {
+			return err
+		}
+		sum, size, err := hashFile(p)
+		if err != nil {
+			return err
+		}
+		components = append(components, Component{Path: clean, SHA256: sum, Size: size})
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(components) == 0 {
+		return nil, fmt.Errorf("bundle: no files found under %q", srcDir)
+	}
+	sort.Slice(components, func(i, j int) bool { return components[i].Path < components[j].Path })
+	return &Manifest{
+		Version:        strings.TrimSpace(version),
+		ReleasedAt:     releasedAt.UTC(),
+		MinUpgradeFrom: strings.TrimSpace(minUpgradeFrom),
+		KeyID:          strings.TrimSpace(keyID),
+		Components:     components,
+	}, nil
+}
+
+// WriteBundle writes the signed bundle to w: manifest.json first, then manifest.sig, then
+// every component file (sorted by path). sig must be an ed25519 signature over the exact
+// canonical manifest bytes (see Sign).
+func WriteBundle(w io.Writer, srcDir string, m *Manifest, sig []byte) error {
+	manifestBytes, err := m.MarshalCanonical()
+	if err != nil {
+		return err
+	}
+	gz := gzip.NewWriter(w)
+	tw := tar.NewWriter(gz)
+
+	if err := writeTarBytes(tw, manifestName, manifestBytes); err != nil {
+		return err
+	}
+	if err := writeTarBytes(tw, sigName, sig); err != nil {
+		return err
+	}
+	for _, c := range m.Components {
+		full := filepath.Join(srcDir, filepath.FromSlash(c.Path))
+		f, err := os.Open(full) // #nosec G304 -- path validated by cleanComponentPath, rooted at srcDir
+		if err != nil {
+			return err
+		}
+		hdr := &tar.Header{Name: c.Path, Mode: 0o644, Size: c.Size, ModTime: m.ReleasedAt}
+		if err := tw.WriteHeader(hdr); err != nil {
+			_ = f.Close()
+			return err
+		}
+		if _, err := io.Copy(tw, f); err != nil { // #nosec G110 -- size is pinned in the header
+			_ = f.Close()
+			return err
+		}
+		if err := f.Close(); err != nil {
+			return err
+		}
+	}
+	if err := tw.Close(); err != nil {
+		return err
+	}
+	return gz.Close()
+}
+
+// Sign returns an ed25519 signature over the canonical manifest bytes. The private key is
+// the offline signing secret; it never ships with the bundle.
+func Sign(m *Manifest, priv ed25519.PrivateKey) ([]byte, error) {
+	b, err := m.MarshalCanonical()
+	if err != nil {
+		return nil, err
+	}
+	return ed25519.Sign(priv, b), nil
+}
+
+// Verify streams a bundle from r, checking the manifest signature against the trusted,
+// embedded key for its key-id, then every component's digest. It is memory-bounded (it
+// hashes component bytes as they stream; it does not buffer images) and fails closed on
+// any mismatch, unlisted file, or missing component. On success it returns the manifest.
+func Verify(r io.Reader, reg *trust.KeyRegistry) (*Manifest, error) {
+	gz, err := gzip.NewReader(r)
+	if err != nil {
+		return nil, fmt.Errorf("bundle: gzip: %w", err)
+	}
+	defer func() { _ = gz.Close() }()
+	tr := tar.NewReader(gz)
+
+	manifestBytes, err := readNamedEntry(tr, manifestName)
+	if err != nil {
+		return nil, err
+	}
+	sig, err := readNamedEntry(tr, sigName)
+	if err != nil {
+		return nil, err
+	}
+
+	var m Manifest
+	if err := json.Unmarshal(manifestBytes, &m); err != nil {
+		return nil, fmt.Errorf("bundle: parse manifest: %w", err)
+	}
+	if strings.TrimSpace(m.KeyID) == "" {
+		return nil, fmt.Errorf("bundle: manifest has no key-id")
+	}
+	// Verify the signature over the EXACT manifest.json bytes carried in the archive,
+	// against the embedded trusted key named by the manifest's key-id. A forged key-id is
+	// not in the embedded registry, so this fails closed.
+	if err := reg.Verify(trust.PurposeUpdate, m.KeyID, manifestBytes, sig); err != nil {
+		return nil, fmt.Errorf("bundle: manifest signature: %w", err)
+	}
+
+	pinned := m.byPath()
+	seen := make(map[string]bool, len(pinned))
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("bundle: read archive: %w", err)
+		}
+		if hdr.Typeflag != tar.TypeReg {
+			continue
+		}
+		name, err := cleanComponentPath(hdr.Name)
+		if err != nil {
+			return nil, err
+		}
+		comp, ok := pinned[name]
+		if !ok {
+			return nil, fmt.Errorf("%w: %s", ErrUnlistedComponent, name)
+		}
+		// Bound the read to the pinned size (+1 to detect an oversized entry). This both
+		// caps a decompression bomb and rejects any component larger than the manifest
+		// claims, before its digest is even compared.
+		h := sha256.New()
+		n, err := io.Copy(h, io.LimitReader(tr, comp.Size+1))
+		if err != nil {
+			return nil, fmt.Errorf("bundle: hash %s: %w", name, err)
+		}
+		if n != comp.Size {
+			return nil, fmt.Errorf("%w: %s (size %d, want %d)", ErrDigestMismatch, name, n, comp.Size)
+		}
+		if got := hex.EncodeToString(h.Sum(nil)); got != comp.SHA256 {
+			return nil, fmt.Errorf("%w: %s", ErrDigestMismatch, name)
+		}
+		seen[name] = true
+	}
+	for p := range pinned {
+		if !seen[p] {
+			return nil, fmt.Errorf("%w: %s", ErrMissingComponent, p)
+		}
+	}
+	return &m, nil
+}
+
+// CheckUpgrade enforces the no-downgrade and anti-skip rules against the installed
+// version. An empty installed version (a first install) passes. It is the caller's gate
+// before `import` actually stages anything.
+func (m *Manifest) CheckUpgrade(installed string) error {
+	if strings.TrimSpace(installed) == "" {
+		return nil
+	}
+	cmp, err := compareVersions(m.Version, installed)
+	if err != nil {
+		return err
+	}
+	if cmp <= 0 {
+		return fmt.Errorf("%w: bundle %s <= installed %s", ErrNotUpgrade, m.Version, installed)
+	}
+	if m.MinUpgradeFrom != "" {
+		floor, err := compareVersions(installed, m.MinUpgradeFrom)
+		if err != nil {
+			return err
+		}
+		if floor < 0 {
+			return fmt.Errorf("%w: installed %s < required %s", ErrUpgradeSkipped, installed, m.MinUpgradeFrom)
+		}
+	}
+	return nil
+}
+
+// --- helpers ---
+
+func writeTarBytes(tw *tar.Writer, name string, b []byte) error {
+	if err := tw.WriteHeader(&tar.Header{Name: name, Mode: 0o644, Size: int64(len(b))}); err != nil {
+		return err
+	}
+	_, err := tw.Write(b)
+	return err
+}
+
+// readNamedEntry reads the next tar entry, requiring it to be the named regular file, and
+// returns its bytes (bounded by maxManifestBytes).
+func readNamedEntry(tr *tar.Reader, want string) ([]byte, error) {
+	hdr, err := tr.Next()
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrNoManifest, err)
+	}
+	if hdr.Name != want || hdr.Typeflag != tar.TypeReg {
+		return nil, fmt.Errorf("%w: got %q, want %q", ErrNoManifest, hdr.Name, want)
+	}
+	b, err := io.ReadAll(io.LimitReader(tr, maxManifestBytes))
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+func hashFile(p string) (string, int64, error) {
+	f, err := os.Open(p) // #nosec G304 -- caller walks a trusted srcDir
+	if err != nil {
+		return "", 0, err
+	}
+	defer func() { _ = f.Close() }()
+	h := sha256.New()
+	n, err := io.Copy(h, f)
+	if err != nil {
+		return "", 0, err
+	}
+	return hex.EncodeToString(h.Sum(nil)), n, nil
+}
+
+// parseVersion accepts a "vX.Y.Z" (or "X.Y.Z") release version, ignoring any pre-release
+// or build metadata, and returns its numeric components.
+func parseVersion(v string) ([3]int, error) {
+	var out [3]int
+	s := strings.TrimPrefix(strings.TrimSpace(v), "v")
+	if i := strings.IndexAny(s, "-+"); i >= 0 {
+		s = s[:i]
+	}
+	parts := strings.Split(s, ".")
+	if len(parts) != 3 {
+		return out, fmt.Errorf("not a vMAJOR.MINOR.PATCH version")
+	}
+	for i, p := range parts {
+		n, err := strconv.Atoi(p)
+		if err != nil || n < 0 {
+			return out, fmt.Errorf("invalid version component %q", p)
+		}
+		out[i] = n
+	}
+	return out, nil
+}
+
+// compareVersions returns -1, 0, or 1 for a<b, a==b, a>b over vX.Y.Z versions.
+func compareVersions(a, b string) (int, error) {
+	pa, err := parseVersion(a)
+	if err != nil {
+		return 0, err
+	}
+	pb, err := parseVersion(b)
+	if err != nil {
+		return 0, err
+	}
+	for i := 0; i < 3; i++ {
+		if pa[i] != pb[i] {
+			if pa[i] < pb[i] {
+				return -1, nil
+			}
+			return 1, nil
+		}
+	}
+	return 0, nil
+}
+
+// ParsePrivateKeyPEM decodes a PKCS#8 PEM (as written by `keyorix trust keygen`) into an
+// ed25519 private key for signing. It is the only signing-key entry point, shared by the
+// CLI and tests.
+func ParsePrivateKeyPEM(b []byte) (ed25519.PrivateKey, error) {
+	block, _ := pem.Decode(b)
+	if block == nil {
+		return nil, fmt.Errorf("bundle: no PEM block in signing key")
+	}
+	key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("bundle: parse signing key: %w", err)
+	}
+	priv, ok := key.(ed25519.PrivateKey)
+	if !ok {
+		return nil, fmt.Errorf("bundle: signing key is not ed25519 (%T)", key)
+	}
+	return priv, nil
+}

--- a/internal/bundle/bundle_test.go
+++ b/internal/bundle/bundle_test.go
@@ -1,0 +1,288 @@
+package bundle
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"crypto/ed25519"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/trust"
+)
+
+// --- helpers ---
+
+// srcDirWith writes files (path → content) into a fresh temp dir and returns it.
+func srcDirWith(t *testing.T, files map[string]string) string {
+	t.Helper()
+	dir := t.TempDir()
+	for rel, content := range files {
+		full := filepath.Join(dir, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+			t.Fatalf("write %s: %v", rel, err)
+		}
+	}
+	return dir
+}
+
+// signedBundle builds + signs a bundle from files and returns its bytes plus a registry
+// that trusts the signing key under keyID.
+func signedBundle(t *testing.T, files map[string]string, version, keyID, minFrom string) ([]byte, *trust.KeyRegistry, ed25519.PrivateKey) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("genkey: %v", err)
+	}
+	dir := srcDirWith(t, files)
+	m, err := BuildManifest(dir, version, keyID, minFrom, time.Unix(1_700_000_000, 0))
+	if err != nil {
+		t.Fatalf("BuildManifest: %v", err)
+	}
+	sig, err := Sign(m, priv)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	var buf bytes.Buffer
+	if err := WriteBundle(&buf, dir, m, sig); err != nil {
+		t.Fatalf("WriteBundle: %v", err)
+	}
+	reg := trust.NewRegistry()
+	if err := reg.Add(trust.PurposeUpdate, keyID, pub); err != nil {
+		t.Fatalf("reg.Add: %v", err)
+	}
+	return buf.Bytes(), reg, priv
+}
+
+// writeRawBundle assembles a tar.gz from explicit ordered parts, for crafting adversarial
+// bundles the normal build path would never produce.
+func writeRawBundle(t *testing.T, manifest, sig []byte, files [][2]string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	put := func(name string, b []byte) {
+		if err := tw.WriteHeader(&tar.Header{Name: name, Mode: 0o644, Size: int64(len(b)), Typeflag: tar.TypeReg}); err != nil {
+			t.Fatalf("hdr %s: %v", name, err)
+		}
+		if _, err := tw.Write(b); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	if manifest != nil {
+		put(manifestName, manifest)
+	}
+	if sig != nil {
+		put(sigName, sig)
+	}
+	for _, f := range files {
+		put(f[0], []byte(f[1]))
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("tw close: %v", err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatalf("gz close: %v", err)
+	}
+	return buf.Bytes()
+}
+
+// --- tests ---
+
+func TestVerify_RoundTrip(t *testing.T) {
+	files := map[string]string{
+		"bin/keyorix":               "fake-binary-bytes",
+		"charts/keyorix-0.82.0.tgz": "fake-chart",
+		"crds/secrets.yaml":         "apiVersion: v1",
+	}
+	raw, reg, _ := signedBundle(t, files, "v0.82.0", "update-2026", "v0.80.0")
+
+	m, err := Verify(bytes.NewReader(raw), reg)
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if m.Version != "v0.82.0" || m.KeyID != "update-2026" || m.MinUpgradeFrom != "v0.80.0" {
+		t.Fatalf("manifest fields wrong: %+v", m)
+	}
+	if len(m.Components) != 3 {
+		t.Fatalf("want 3 components, got %d", len(m.Components))
+	}
+	// Components are canonically sorted by path.
+	if m.Components[0].Path != "bin/keyorix" {
+		t.Fatalf("components not sorted: %+v", m.Components)
+	}
+}
+
+func TestVerify_FailsClosed_NoTrustedKeys(t *testing.T) {
+	raw, _, _ := signedBundle(t, map[string]string{"a": "x"}, "v1.0.0", "update-2026", "")
+	// An empty registry (a plain non-release build) trusts nothing.
+	if _, err := Verify(bytes.NewReader(raw), trust.NewRegistry()); !errors.Is(err, trust.ErrNoKeys) {
+		t.Fatalf("want ErrNoKeys, got %v", err)
+	}
+}
+
+func TestVerify_FailsClosed_UnknownKeyID(t *testing.T) {
+	raw, _, _ := signedBundle(t, map[string]string{"a": "x"}, "v1.0.0", "update-2026", "")
+	// Registry trusts a different key-id than the manifest names.
+	pub, _, _ := ed25519.GenerateKey(nil)
+	reg := trust.NewRegistry()
+	_ = reg.Add(trust.PurposeUpdate, "some-other-id", pub)
+	if _, err := Verify(bytes.NewReader(raw), reg); !errors.Is(err, trust.ErrUnknownKey) {
+		t.Fatalf("want ErrUnknownKey, got %v", err)
+	}
+}
+
+func TestVerify_FailsClosed_WrongKey(t *testing.T) {
+	raw, _, _ := signedBundle(t, map[string]string{"a": "x"}, "v1.0.0", "update-2026", "")
+	// Same key-id, but an attacker's public key — signature won't verify.
+	otherPub, _, _ := ed25519.GenerateKey(nil)
+	reg := trust.NewRegistry()
+	_ = reg.Add(trust.PurposeUpdate, "update-2026", otherPub)
+	if _, err := Verify(bytes.NewReader(raw), reg); !errors.Is(err, trust.ErrBadSignature) {
+		t.Fatalf("want ErrBadSignature, got %v", err)
+	}
+}
+
+func TestVerify_TamperedComponent(t *testing.T) {
+	// Build a legitimate manifest, then ship a component whose bytes differ from its
+	// pinned digest (same length, so only the hash — not the size — catches it).
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	dir := srcDirWith(t, map[string]string{"bin/keyorix": "AAAA"})
+	m, err := BuildManifest(dir, "v1.0.0", "update-2026", "", time.Unix(1_700_000_000, 0))
+	if err != nil {
+		t.Fatal(err)
+	}
+	sig, _ := Sign(m, priv)
+	manifestBytes, _ := m.MarshalCanonical()
+	// "BBBB" has the same length as "AAAA" but a different digest.
+	raw := writeRawBundle(t, manifestBytes, sig, [][2]string{{"bin/keyorix", "BBBB"}})
+
+	reg := trust.NewRegistry()
+	_ = reg.Add(trust.PurposeUpdate, "update-2026", pub)
+	if _, err := Verify(bytes.NewReader(raw), reg); !errors.Is(err, ErrDigestMismatch) {
+		t.Fatalf("want ErrDigestMismatch, got %v", err)
+	}
+}
+
+func TestVerify_TamperedManifest(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	dir := srcDirWith(t, map[string]string{"a": "x"})
+	m, _ := BuildManifest(dir, "v1.0.0", "update-2026", "", time.Unix(1_700_000_000, 0))
+	sig, _ := Sign(m, priv)
+
+	// Tamper: bump the version in the manifest bytes but keep the old signature.
+	m.Version = "v9.9.9"
+	tampered, _ := m.MarshalCanonical()
+	raw := writeRawBundle(t, tampered, sig, [][2]string{{"a", "x"}})
+
+	reg := trust.NewRegistry()
+	_ = reg.Add(trust.PurposeUpdate, "update-2026", pub)
+	if _, err := Verify(bytes.NewReader(raw), reg); !errors.Is(err, trust.ErrBadSignature) {
+		t.Fatalf("want ErrBadSignature, got %v", err)
+	}
+}
+
+func TestVerify_UnlistedComponent(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	dir := srcDirWith(t, map[string]string{"a": "x"})
+	m, _ := BuildManifest(dir, "v1.0.0", "update-2026", "", time.Unix(1_700_000_000, 0))
+	sig, _ := Sign(m, priv)
+	manifestBytes, _ := m.MarshalCanonical()
+	// Archive carries an extra file the manifest never pinned.
+	raw := writeRawBundle(t, manifestBytes, sig, [][2]string{{"a", "x"}, {"evil.sh", "rm -rf"}})
+
+	reg := trust.NewRegistry()
+	_ = reg.Add(trust.PurposeUpdate, "update-2026", pub)
+	if _, err := Verify(bytes.NewReader(raw), reg); !errors.Is(err, ErrUnlistedComponent) {
+		t.Fatalf("want ErrUnlistedComponent, got %v", err)
+	}
+}
+
+func TestVerify_MissingComponent(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	dir := srcDirWith(t, map[string]string{"a": "x", "b": "y"})
+	m, _ := BuildManifest(dir, "v1.0.0", "update-2026", "", time.Unix(1_700_000_000, 0))
+	sig, _ := Sign(m, priv)
+	manifestBytes, _ := m.MarshalCanonical()
+	// Archive omits component "b".
+	raw := writeRawBundle(t, manifestBytes, sig, [][2]string{{"a", "x"}})
+
+	reg := trust.NewRegistry()
+	_ = reg.Add(trust.PurposeUpdate, "update-2026", pub)
+	if _, err := Verify(bytes.NewReader(raw), reg); !errors.Is(err, ErrMissingComponent) {
+		t.Fatalf("want ErrMissingComponent, got %v", err)
+	}
+}
+
+func TestVerify_NoManifest(t *testing.T) {
+	pub, _, _ := ed25519.GenerateKey(nil)
+	reg := trust.NewRegistry()
+	_ = reg.Add(trust.PurposeUpdate, "update-2026", pub)
+	// First entry is not manifest.json.
+	raw := writeRawBundle(t, nil, nil, [][2]string{{"a", "x"}})
+	if _, err := Verify(bytes.NewReader(raw), reg); !errors.Is(err, ErrNoManifest) {
+		t.Fatalf("want ErrNoManifest, got %v", err)
+	}
+}
+
+func TestCheckUpgrade(t *testing.T) {
+	cases := []struct {
+		name      string
+		version   string
+		minFrom   string
+		installed string
+		wantErr   error
+	}{
+		{"first install passes", "v1.0.0", "", "", nil},
+		{"newer is ok", "v1.2.0", "", "v1.1.0", nil},
+		{"equal is not an upgrade", "v1.1.0", "", "v1.1.0", ErrNotUpgrade},
+		{"older is not an upgrade", "v1.0.0", "", "v1.1.0", ErrNotUpgrade},
+		{"meets min-upgrade-from", "v2.0.0", "v1.5.0", "v1.6.0", nil},
+		{"below min-upgrade-from is skipped", "v2.0.0", "v1.5.0", "v1.0.0", ErrUpgradeSkipped},
+		{"patch bump ok", "v1.1.2", "", "v1.1.1", nil},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			m := &Manifest{Version: c.version, MinUpgradeFrom: c.minFrom}
+			err := m.CheckUpgrade(c.installed)
+			if c.wantErr == nil && err != nil {
+				t.Fatalf("want nil, got %v", err)
+			}
+			if c.wantErr != nil && !errors.Is(err, c.wantErr) {
+				t.Fatalf("want %v, got %v", c.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestBuildManifest_Rejects(t *testing.T) {
+	dir := srcDirWith(t, map[string]string{"a": "x"})
+	if _, err := BuildManifest(dir, "", "k", "", time.Now()); err == nil {
+		t.Fatal("want error for empty version")
+	}
+	if _, err := BuildManifest(dir, "not-semver", "k", "", time.Now()); err == nil {
+		t.Fatal("want error for bad version")
+	}
+	if _, err := BuildManifest(dir, "v1.0.0", "", "", time.Now()); err == nil {
+		t.Fatal("want error for empty key-id")
+	}
+	if _, err := BuildManifest(dir, "v1.0.0", "k", "bad", time.Now()); err == nil {
+		t.Fatal("want error for bad min-upgrade-from")
+	}
+	if _, err := BuildManifest(t.TempDir(), "v1.0.0", "k", "", time.Now()); err == nil {
+		t.Fatal("want error for empty source dir")
+	}
+}
+
+func TestParsePrivateKeyPEM_RoundTrip(t *testing.T) {
+	// A garbage PEM must be rejected.
+	if _, err := ParsePrivateKeyPEM([]byte("not a pem")); err == nil {
+		t.Fatal("want error for non-PEM input")
+	}
+}

--- a/internal/cli/bundle/bundle.go
+++ b/internal/cli/bundle/bundle.go
@@ -1,0 +1,151 @@
+// Package bundle provides `keyorix bundle` — air-gap update-bundle tooling (ADR-064,
+// ADR-062 Phase 1a). `build` assembles and signs a bundle from a directory of release
+// artifacts (the Keyorix/issuance side, with the offline signing key); `verify` checks a
+// bundle offline against the embedded, pinned public key and every component's digest (the
+// air-gapped operator side). `import` (registry/chart staging) is a later phase.
+package bundle
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	ibundle "github.com/keyorixhq/keyorix/internal/bundle"
+	"github.com/keyorixhq/keyorix/internal/trust"
+	"github.com/spf13/cobra"
+)
+
+// BundleCmd is the `keyorix bundle` command group.
+var BundleCmd = &cobra.Command{
+	Use:   "bundle",
+	Short: "Air-gap update bundles: build (signed) and verify offline",
+	Long: `Build and verify Keyorix air-gap update bundles (ADR-062 Phase 1).
+
+A bundle is a single signed tarball carrying a release's artifacts, pinned by sha256 in a
+manifest that is signed with an offline ed25519 key. An air-gapped operator carries the
+file across the gap and verifies it offline against the public key embedded in this binary
+at build time — trust follows a pinned chain, never a key shipped inside the bundle.`,
+}
+
+var (
+	buildSrc        string
+	buildOut        string
+	buildVersion    string
+	buildKeyID      string
+	buildSignKey    string
+	buildMinFrom    string
+	buildReleased   string
+	verifyInstalled string
+)
+
+var buildCmd = &cobra.Command{
+	Use:          "build",
+	Short:        "Assemble and sign an update bundle from a directory of release artifacts",
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		if buildSrc == "" || buildOut == "" {
+			return fmt.Errorf("--src and --out are required")
+		}
+		releasedAt := time.Now().UTC()
+		if buildReleased != "" {
+			t, err := time.Parse(time.RFC3339, buildReleased)
+			if err != nil {
+				return fmt.Errorf("--released-at must be RFC3339: %w", err)
+			}
+			releasedAt = t.UTC()
+		}
+
+		keyPEM, err := os.ReadFile(buildSignKey) // #nosec G304 -- operator-supplied key path
+		if err != nil {
+			return fmt.Errorf("read signing key: %w", err)
+		}
+		priv, err := ibundle.ParsePrivateKeyPEM(keyPEM)
+		if err != nil {
+			return err
+		}
+
+		m, err := ibundle.BuildManifest(buildSrc, buildVersion, buildKeyID, buildMinFrom, releasedAt)
+		if err != nil {
+			return err
+		}
+		sig, err := ibundle.Sign(m, priv)
+		if err != nil {
+			return err
+		}
+
+		out, err := os.Create(buildOut) // #nosec G304 -- operator-supplied output path
+		if err != nil {
+			return fmt.Errorf("create bundle: %w", err)
+		}
+		if err := ibundle.WriteBundle(out, buildSrc, m, sig); err != nil {
+			_ = out.Close()
+			return fmt.Errorf("write bundle: %w", err)
+		}
+		if err := out.Close(); err != nil {
+			return err
+		}
+		fmt.Printf("Built %s (%s, %d components, key-id %s) → %s\n",
+			buildOut, m.Version, len(m.Components), m.KeyID, buildOut)
+		return nil
+	},
+}
+
+var verifyCmd = &cobra.Command{
+	Use:          "verify <bundle>",
+	Short:        "Verify a bundle offline against the embedded pinned key and component digests",
+	Args:         cobra.ExactArgs(1),
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, args []string) error {
+		reg, err := trust.DefaultRegistry()
+		if err != nil {
+			return fmt.Errorf("load trusted keys: %w", err)
+		}
+
+		f, err := os.Open(args[0]) // #nosec G304 -- operator-supplied bundle path
+		if err != nil {
+			return fmt.Errorf("open bundle: %w", err)
+		}
+		defer func() { _ = f.Close() }()
+
+		m, err := ibundle.Verify(f, reg)
+		if err != nil {
+			return fmt.Errorf("verification failed (fail-closed): %w", err)
+		}
+		if err := m.CheckUpgrade(verifyInstalled); err != nil {
+			return err
+		}
+
+		fmt.Printf("Bundle verified ✓\n")
+		fmt.Printf("  version:    %s\n", m.Version)
+		fmt.Printf("  signed by:  key-id %s (trusted, embedded)\n", m.KeyID)
+		fmt.Printf("  released:   %s\n", m.ReleasedAt.Format(time.RFC3339))
+		if m.MinUpgradeFrom != "" {
+			fmt.Printf("  min from:   %s\n", m.MinUpgradeFrom)
+		}
+		fmt.Printf("  components: %d (all digests match)\n", len(m.Components))
+		for _, c := range m.Components {
+			fmt.Printf("    - %s\n", c.Path)
+		}
+		return nil
+	},
+}
+
+func init() {
+	buildCmd.Flags().StringVar(&buildSrc, "src", "", "directory of release artifacts to bundle (required)")
+	buildCmd.Flags().StringVar(&buildOut, "out", "", "output bundle file (required)")
+	buildCmd.Flags().StringVar(&buildVersion, "version", "", "bundle version, e.g. v0.82.0 (required)")
+	buildCmd.Flags().StringVar(&buildKeyID, "key-id", "", "signing key-id, must match the embedded trusted key (required)")
+	buildCmd.Flags().StringVar(&buildSignKey, "sign-key", "", "PKCS#8 PEM ed25519 private signing key (required; keep offline)")
+	buildCmd.Flags().StringVar(&buildMinFrom, "min-upgrade-from", "", "minimum installed version this bundle may upgrade from (anti-skip)")
+	buildCmd.Flags().StringVar(&buildReleased, "released-at", "", "release timestamp (RFC3339; default now)")
+	_ = buildCmd.MarkFlagRequired("src")
+	_ = buildCmd.MarkFlagRequired("out")
+	_ = buildCmd.MarkFlagRequired("version")
+	_ = buildCmd.MarkFlagRequired("key-id")
+	_ = buildCmd.MarkFlagRequired("sign-key")
+
+	verifyCmd.Flags().StringVar(&verifyInstalled, "installed-version", "", "currently-installed version, to enforce no-downgrade / min-upgrade-from")
+
+	BundleCmd.AddCommand(buildCmd)
+	BundleCmd.AddCommand(verifyCmd)
+}

--- a/internal/cli/main.go
+++ b/internal/cli/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/keyorixhq/keyorix/internal/cli/audit"
 	"github.com/keyorixhq/keyorix/internal/cli/auth"
 	"github.com/keyorixhq/keyorix/internal/cli/breakglass"
+	bundlecli "github.com/keyorixhq/keyorix/internal/cli/bundle"
 	"github.com/keyorixhq/keyorix/internal/cli/compliance"
 	"github.com/keyorixhq/keyorix/internal/cli/config"
 	"github.com/keyorixhq/keyorix/internal/cli/connect"
@@ -79,6 +80,7 @@ func init() {
 	rootCmd.AddCommand(sodcli.SoDCmd)
 	rootCmd.AddCommand(hygiene.HygieneCmd)
 	rootCmd.AddCommand(trustcli.TrustCmd)
+	rootCmd.AddCommand(bundlecli.BundleCmd)
 }
 
 // Execute runs the root command


### PR DESCRIPTION
Implements **ADR-062 Phase 1a** — the cryptographic + structural core of air-gap update bundles, built on the Phase 0 trust registry (`internal/trust`, #441).

Air-gapped deployments (defence/finance/government; NIS2/DORA supply-chain integrity) can't pull GHCR images. This gives them a single, verifiable file to carry across the gap and check **offline**, trusting only a key pinned into the binary — never a key shipped inside the bundle.

**`internal/bundle`** — a gzip-tar whose first two entries are `manifest.json` (version, `released_at`, `min_upgrade_from`, `key_id`, every component pinned by sha256+size) and `manifest.sig` (detached ed25519 over the canonical manifest bytes). `Verify` streams the archive, checks the signature against the **embedded** pinned key named by the manifest's `key_id`, then every component digest — **fail-closed** on unknown/untrusted key, digest mismatch, unlisted or missing component. Reads are size-bounded (decompression-bomb guard). `CheckUpgrade` enforces no-downgrade + `min_upgrade_from`.

**`keyorix bundle build`** (sign with the offline key) **+ `verify`** (offline, against the embedded key). A plain build embeds no keys → verify fails closed.

Additive and behaviour-neutral — no runtime caller verifies bundles yet. `import` (registry/chart staging) is Phase 1b and reuses `Verify`/`CheckUpgrade` unchanged.

Verified end-to-end: keygen → build a binary with the pubkey embedded via `-ldflags` → `bundle build` → `verify` passes; plain binary fails closed; no-downgrade refuses an older version. Package tests cover the round-trip and every fail-closed path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)