### PR TITLE
feat(airgap): bundle import — verified, no-downgrade-gated staging (ADR-064 Phase 1b)

### DIFF
--- a/docs/adr-064-air-gap-update-bundles.md
+++ b/docs/adr-064-air-gap-update-bundles.md
@@ -4,8 +4,10 @@
 
 Accepted. Implements the **bundle** half of [ADR-062](adr-062-air-gap-updates.md) Phase 1;
 see [air-gap-updates-design.md](air-gap-updates-design.md) §3. Builds on the Phase 0 trust
-foundation (`internal/trust`). The `import` half (registry load + chart/CRD staging) is a
-follow-up phase (1b).
+foundation (`internal/trust`). Phase 1a added the format + `build`/`verify`; Phase 1b adds
+`import` — verified, no-downgrade-gated, atomic **staging** of the components to a
+directory. Loading images into the internal registry and the Helm upgrade stay the
+operator's own steps by design; CI publication of the bundle is the remaining 1b piece.
 
 ## Context
 
@@ -74,10 +76,13 @@ newer than what is installed, and enforces `min_upgrade_from` (anti-skip). A fir
 - Additive and behaviour-neutral: no caller verifies bundles at runtime yet, and a non-
   release build embeds no keys (every verify fails closed). Producing signed bundles is an
   operational step gated on embedding the production update key.
-- The `import` path (load images into an internal registry, stage charts/CRDs/binaries,
-  enforce `CheckUpgrade` against the live install, emit an audit event) is Phase 1b and
-  reuses `Verify` + `CheckUpgrade` unchanged.
-- CI wiring (`bundle build` as a `release.yml` step publishing the bundle as a release
-  asset) follows once a production update-signing key is embedded.
+- `import` stages verified components to disk through one streaming pass shared with
+  `verify` (`process`), gating no-downgrade *before* any write and writing each component
+  atomically (temp + rename) so a digest failure never leaves a poisoned file. Loading the
+  staged images into an internal registry and the Helm upgrade stay operator-controlled —
+  the CLI prints those steps rather than performing them.
+- Remaining 1b work: CI wiring (`bundle build` as a `release.yml` step publishing the
+  bundle as a release asset) once a production update-signing key is embedded, and an
+  optional server-side audit event when an import runs.
 - Maps to a future "supply-chain integrity" compliance control (NIS2 Art. 21, DORA ICT
   third-party risk, ENS `op.exp.*`).

--- a/docs/air-gap-updates-design.md
+++ b/docs/air-gap-updates-design.md
@@ -189,9 +189,13 @@ behaviour until built.
      `internal/bundle`, and `keyorix bundle build` (sign) + `verify` (offline, fail-closed,
      anti-downgrade) — the cryptographic + structural core, built on the Phase 0 trust
      registry.
-   - **1b:** `keyorix bundle import` (load images into an internal registry, stage
-     charts/CRDs/binaries, enforce no-downgrade against the live install, audit event) and
-     CI wiring (`bundle build` in `release.yml`, bundle published as a release asset).
+   - **1b (staging done, [ADR-064](adr-064-air-gap-update-bundles.md)):** `keyorix bundle
+     import` verifies offline, enforces no-downgrade *before* writing, and stages the
+     verified components to a directory atomically (a digest failure leaves nothing on
+     disk), then prints the operator-controlled rollout steps. Loading images into the
+     internal registry and the Helm upgrade stay the operator's own steps by design.
+   - **1b remaining:** CI wiring (`bundle build` in `release.yml`, bundle published as a
+     release asset) and an optional server-side audit event when an import runs.
 3. **Phase 2 — licensing:** offline license verification, the commercial feature gate
    (fail-safe), `license install|status`, and compliance/audit surfacing.
 4. **Phase 3 — hardening:** HSM-backed signing, key rotation drill, reproducible-bundle

--- a/internal/bundle/bundle.go
+++ b/internal/bundle/bundle.go
@@ -6,9 +6,11 @@
 // pinned chain (the key never travels with the bundle), not a self-described signature.
 //
 // This package is the cryptographic and structural core: build a manifest, sign it, write
-// the bundle, and verify a bundle (signature first, then every component digest, fail
-// closed). It deliberately does not load images into a registry or stage charts — that is
-// `bundle import` (Phase 1b), which builds on Verify here.
+// the bundle, verify it (signature first, then every component digest, fail closed), and
+// Extract it — staging the verified components to disk, gated on no-downgrade, atomically.
+// It deliberately stops at staging: loading images into an internal registry and running
+// the Helm upgrade stay the operator's own steps (an air-gap tool must not seize control of
+// the registry), so the CLI prints those next steps rather than performing them.
 package bundle
 
 import (
@@ -231,7 +233,32 @@ func Sign(m *Manifest, priv ed25519.PrivateKey) ([]byte, error) {
 // embedded key for its key-id, then every component's digest. It is memory-bounded (it
 // hashes component bytes as they stream; it does not buffer images) and fails closed on
 // any mismatch, unlisted file, or missing component. On success it returns the manifest.
+// Verify only reads — it stages nothing; see Extract.
 func Verify(r io.Reader, reg *trust.KeyRegistry) (*Manifest, error) {
+	return process(r, reg, nil)
+}
+
+// Extract verifies a bundle (exactly as Verify) and, only after the signature and the
+// no-downgrade gate pass, stages every verified component under destDir — preserving the
+// component's relative path, contained within destDir, written atomically (temp + rename)
+// so a digest failure never leaves a poisoned file in place. installedVersion enforces
+// no-downgrade / min_upgrade_from *before* any component is written. Re-running it
+// overwrites identical verified content, so import is idempotent.
+func Extract(r io.Reader, reg *trust.KeyRegistry, destDir, installedVersion string) (*Manifest, error) {
+	return process(r, reg, &extractOpts{destDir: destDir, installedVersion: installedVersion})
+}
+
+// extractOpts is the staging configuration for process; nil means verify-only.
+type extractOpts struct {
+	destDir          string
+	installedVersion string
+}
+
+// process is the single streaming pass shared by Verify and Extract. It reads the manifest
+// and signature first, verifies the signature against the embedded trusted key, optionally
+// runs the no-downgrade gate, then streams each component — hashing it against its pinned
+// digest and (when staging) writing it atomically. It fails closed on any mismatch.
+func process(r io.Reader, reg *trust.KeyRegistry, opts *extractOpts) (*Manifest, error) {
 	gz, err := gzip.NewReader(r)
 	if err != nil {
 		return nil, fmt.Errorf("bundle: gzip: %w", err)
@@ -262,6 +289,19 @@ func Verify(r io.Reader, reg *trust.KeyRegistry) (*Manifest, error) {
 		return nil, fmt.Errorf("bundle: manifest signature: %w", err)
 	}
 
+	// When staging, gate on no-downgrade BEFORE writing any component, and prepare destDir.
+	if opts != nil {
+		if err := m.CheckUpgrade(opts.installedVersion); err != nil {
+			return nil, err
+		}
+		if strings.TrimSpace(opts.destDir) == "" {
+			return nil, fmt.Errorf("bundle: extract destination is required")
+		}
+		if err := os.MkdirAll(opts.destDir, 0o750); err != nil {
+			return nil, fmt.Errorf("bundle: create destination: %w", err)
+		}
+	}
+
 	pinned := m.byPath()
 	seen := make(map[string]bool, len(pinned))
 	for {
@@ -283,19 +323,8 @@ func Verify(r io.Reader, reg *trust.KeyRegistry) (*Manifest, error) {
 		if !ok {
 			return nil, fmt.Errorf("%w: %s", ErrUnlistedComponent, name)
 		}
-		// Bound the read to the pinned size (+1 to detect an oversized entry). This both
-		// caps a decompression bomb and rejects any component larger than the manifest
-		// claims, before its digest is even compared.
-		h := sha256.New()
-		n, err := io.Copy(h, io.LimitReader(tr, comp.Size+1))
-		if err != nil {
-			return nil, fmt.Errorf("bundle: hash %s: %w", name, err)
-		}
-		if n != comp.Size {
-			return nil, fmt.Errorf("%w: %s (size %d, want %d)", ErrDigestMismatch, name, n, comp.Size)
-		}
-		if got := hex.EncodeToString(h.Sum(nil)); got != comp.SHA256 {
-			return nil, fmt.Errorf("%w: %s", ErrDigestMismatch, name)
+		if err := streamComponent(tr, comp, optsDest(opts)); err != nil {
+			return nil, err
 		}
 		seen[name] = true
 	}
@@ -305,6 +334,93 @@ func Verify(r io.Reader, reg *trust.KeyRegistry) (*Manifest, error) {
 		}
 	}
 	return &m, nil
+}
+
+func optsDest(opts *extractOpts) string {
+	if opts == nil {
+		return ""
+	}
+	return opts.destDir
+}
+
+// streamComponent reads exactly comp.Size bytes of the current tar entry, verifying the
+// sha256 digest. The read is bounded to size+1 (a decompression-bomb guard that also
+// rejects an oversized entry before its digest is compared). If destDir is non-empty the
+// bytes are written atomically to destDir/comp.Path (temp file + rename); on any digest
+// failure the temp file is removed, so a failed component never lands on disk.
+func streamComponent(tr io.Reader, comp Component, destDir string) error {
+	h := sha256.New()
+	dst := io.Writer(h)
+
+	var tmpPath, finalPath string
+	var tmp *os.File
+	if destDir != "" {
+		final, err := safeJoin(destDir, comp.Path)
+		if err != nil {
+			return err
+		}
+		finalPath = final
+		if err := os.MkdirAll(filepath.Dir(finalPath), 0o750); err != nil {
+			return fmt.Errorf("bundle: mkdir for %s: %w", comp.Path, err)
+		}
+		tmp, err = os.CreateTemp(filepath.Dir(finalPath), ".kxbundle-*")
+		if err != nil {
+			return fmt.Errorf("bundle: temp for %s: %w", comp.Path, err)
+		}
+		tmpPath = tmp.Name()
+		dst = io.MultiWriter(h, tmp)
+	}
+
+	n, copyErr := io.Copy(dst, io.LimitReader(tr, comp.Size+1))
+	if tmp != nil {
+		_ = tmp.Close()
+	}
+	cleanup := func() {
+		if tmpPath != "" {
+			_ = os.Remove(tmpPath)
+		}
+	}
+	if copyErr != nil {
+		cleanup()
+		return fmt.Errorf("bundle: read %s: %w", comp.Path, copyErr)
+	}
+	if n != comp.Size {
+		cleanup()
+		return fmt.Errorf("%w: %s (size %d, want %d)", ErrDigestMismatch, comp.Path, n, comp.Size)
+	}
+	if got := hex.EncodeToString(h.Sum(nil)); got != comp.SHA256 {
+		cleanup()
+		return fmt.Errorf("%w: %s", ErrDigestMismatch, comp.Path)
+	}
+	if tmpPath != "" {
+		if err := os.Rename(tmpPath, finalPath); err != nil {
+			cleanup()
+			return fmt.Errorf("bundle: stage %s: %w", comp.Path, err)
+		}
+	}
+	return nil
+}
+
+// safeJoin joins a validated relative component path onto destDir and confirms the result
+// stays within destDir (defence in depth atop cleanComponentPath).
+func safeJoin(destDir, rel string) (string, error) {
+	clean, err := cleanComponentPath(rel)
+	if err != nil {
+		return "", err
+	}
+	joined := filepath.Join(destDir, filepath.FromSlash(clean))
+	rootAbs, err := filepath.Abs(destDir)
+	if err != nil {
+		return "", err
+	}
+	joinedAbs, err := filepath.Abs(joined)
+	if err != nil {
+		return "", err
+	}
+	if joinedAbs != rootAbs && !strings.HasPrefix(joinedAbs, rootAbs+string(os.PathSeparator)) {
+		return "", fmt.Errorf("bundle: component %q escapes destination", rel)
+	}
+	return joined, nil
 }
 
 // CheckUpgrade enforces the no-downgrade and anti-skip rules against the installed

--- a/internal/bundle/bundle_test.go
+++ b/internal/bundle/bundle_test.go
@@ -286,3 +286,105 @@ func TestParsePrivateKeyPEM_RoundTrip(t *testing.T) {
 		t.Fatal("want error for non-PEM input")
 	}
 }
+
+func TestExtract_StagesVerifiedComponents(t *testing.T) {
+	files := map[string]string{
+		"images/keyorix-server.tar":    "image-bytes",
+		"charts/keyorix-0.82.0.tgz":    "chart-bytes",
+		"crds/secrets.keyorix.io.yaml": "crd-bytes",
+	}
+	raw, reg, _ := signedBundle(t, files, "v0.82.0", "update-2026", "v0.80.0")
+
+	dest := t.TempDir()
+	m, err := Extract(bytes.NewReader(raw), reg, dest, "v0.81.0")
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	if m.Version != "v0.82.0" {
+		t.Fatalf("version: %s", m.Version)
+	}
+	for rel, want := range files {
+		got, err := os.ReadFile(filepath.Join(dest, filepath.FromSlash(rel)))
+		if err != nil {
+			t.Fatalf("staged file %s missing: %v", rel, err)
+		}
+		if string(got) != want {
+			t.Fatalf("staged %s = %q, want %q", rel, got, want)
+		}
+	}
+}
+
+func TestExtract_NoDowngrade_StagesNothing(t *testing.T) {
+	raw, reg, _ := signedBundle(t, map[string]string{"images/a.tar": "x"}, "v0.82.0", "update-2026", "")
+	dest := t.TempDir()
+	// Installed is newer than the bundle → must refuse, before writing anything.
+	_, err := Extract(bytes.NewReader(raw), reg, dest, "v0.83.0")
+	if !errors.Is(err, ErrNotUpgrade) {
+		t.Fatalf("want ErrNotUpgrade, got %v", err)
+	}
+	assertDirEmpty(t, dest)
+}
+
+func TestExtract_TamperedComponent_StagesNothing(t *testing.T) {
+	// Same-length tamper as the verify test, but through Extract: the digest mismatch must
+	// abort and leave no poisoned file on disk.
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	dir := srcDirWith(t, map[string]string{"images/a.tar": "AAAA"})
+	m, _ := BuildManifest(dir, "v1.0.0", "update-2026", "", time.Unix(1_700_000_000, 0))
+	sig, _ := Sign(m, priv)
+	manifestBytes, _ := m.MarshalCanonical()
+	raw := writeRawBundle(t, manifestBytes, sig, [][2]string{{"images/a.tar", "BBBB"}})
+
+	reg := trust.NewRegistry()
+	_ = reg.Add(trust.PurposeUpdate, "update-2026", pub)
+	dest := t.TempDir()
+	if _, err := Extract(bytes.NewReader(raw), reg, dest, ""); !errors.Is(err, ErrDigestMismatch) {
+		t.Fatalf("want ErrDigestMismatch, got %v", err)
+	}
+	assertDirEmpty(t, dest)
+}
+
+func TestExtract_FailsClosed_Untrusted_StagesNothing(t *testing.T) {
+	raw, _, _ := signedBundle(t, map[string]string{"images/a.tar": "x"}, "v1.0.0", "update-2026", "")
+	dest := t.TempDir()
+	// Empty registry → fail closed, nothing written.
+	if _, err := Extract(bytes.NewReader(raw), trust.NewRegistry(), dest, ""); !errors.Is(err, trust.ErrNoKeys) {
+		t.Fatalf("want ErrNoKeys, got %v", err)
+	}
+	assertDirEmpty(t, dest)
+}
+
+func TestExtract_Idempotent(t *testing.T) {
+	raw, reg, _ := signedBundle(t, map[string]string{"images/a.tar": "x"}, "v1.0.0", "update-2026", "")
+	dest := t.TempDir()
+	if _, err := Extract(bytes.NewReader(raw), reg, dest, ""); err != nil {
+		t.Fatalf("first extract: %v", err)
+	}
+	// Re-extracting the same bundle overwrites identical verified content and succeeds.
+	if _, err := Extract(bytes.NewReader(raw), reg, dest, ""); err != nil {
+		t.Fatalf("second extract (idempotent): %v", err)
+	}
+	got, _ := os.ReadFile(filepath.Join(dest, "images", "a.tar"))
+	if string(got) != "x" {
+		t.Fatalf("staged content = %q", got)
+	}
+}
+
+// assertDirEmpty fails if dir contains any regular file (temp files included), proving a
+// fail-closed Extract staged nothing.
+func assertDirEmpty(t *testing.T, dir string) {
+	t.Helper()
+	var found []string
+	_ = filepath.WalkDir(dir, func(p string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() {
+			found = append(found, p)
+		}
+		return nil
+	})
+	if len(found) > 0 {
+		t.Fatalf("expected no staged files, found: %v", found)
+	}
+}

--- a/internal/cli/bundle/bundle.go
+++ b/internal/cli/bundle/bundle.go
@@ -36,6 +36,8 @@ var (
 	buildMinFrom    string
 	buildReleased   string
 	verifyInstalled string
+	importDest      string
+	importInstalled string
 )
 
 var buildCmd = &cobra.Command{
@@ -130,6 +132,48 @@ var verifyCmd = &cobra.Command{
 	},
 }
 
+var importCmd = &cobra.Command{
+	Use:          "import <bundle>",
+	Short:        "Verify a bundle offline and stage its artifacts into a directory",
+	Args:         cobra.ExactArgs(1),
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, args []string) error {
+		if importDest == "" {
+			return fmt.Errorf("--dest is required")
+		}
+		reg, err := trust.DefaultRegistry()
+		if err != nil {
+			return fmt.Errorf("load trusted keys: %w", err)
+		}
+
+		f, err := os.Open(args[0]) // #nosec G304 -- operator-supplied bundle path
+		if err != nil {
+			return fmt.Errorf("open bundle: %w", err)
+		}
+		defer func() { _ = f.Close() }()
+
+		// Extract verifies the signature and the no-downgrade gate BEFORE writing anything,
+		// then stages each verified component atomically. It fails closed.
+		m, err := ibundle.Extract(f, reg, importDest, importInstalled)
+		if err != nil {
+			return fmt.Errorf("import failed (fail-closed, nothing staged on a verify failure): %w", err)
+		}
+
+		fmt.Printf("Imported %s ✓ — staged %d verified components under %s\n", m.Version, len(m.Components), importDest)
+		fmt.Printf("  signed by: key-id %s (trusted, embedded)\n", m.KeyID)
+		for _, c := range m.Components {
+			fmt.Printf("    - %s\n", c.Path)
+		}
+		fmt.Printf("\nNext (operator-controlled rollout — Keyorix never pushes to your registry):\n")
+		fmt.Printf("  1. Load images into your internal registry, e.g.:\n")
+		fmt.Printf("       for img in %s/images/*; do docker load -i \"$img\"; done\n", importDest)
+		fmt.Printf("  2. Apply CRDs and run the Helm upgrade from the staged charts:\n")
+		fmt.Printf("       kubectl apply -f %s/crds/   # if present\n", importDest)
+		fmt.Printf("       helm upgrade keyorix %s/charts/keyorix-*.tgz\n", importDest)
+		return nil
+	},
+}
+
 func init() {
 	buildCmd.Flags().StringVar(&buildSrc, "src", "", "directory of release artifacts to bundle (required)")
 	buildCmd.Flags().StringVar(&buildOut, "out", "", "output bundle file (required)")
@@ -146,6 +190,11 @@ func init() {
 
 	verifyCmd.Flags().StringVar(&verifyInstalled, "installed-version", "", "currently-installed version, to enforce no-downgrade / min-upgrade-from")
 
+	importCmd.Flags().StringVar(&importDest, "dest", "", "directory to stage verified artifacts into (required)")
+	importCmd.Flags().StringVar(&importInstalled, "installed-version", "", "currently-installed version, to enforce no-downgrade / min-upgrade-from")
+	_ = importCmd.MarkFlagRequired("dest")
+
 	BundleCmd.AddCommand(buildCmd)
 	BundleCmd.AddCommand(verifyCmd)
+	BundleCmd.AddCommand(importCmd)
 }


### PR DESCRIPTION
Adds `keyorix bundle import`, the air-gap operator's side of [ADR-062](../blob/main/docs/adr-062-air-gap-updates.md) Phase 1b: verify a bundle offline, then stage its verified components to a directory for the rollout.

- **`internal/bundle`:** refactor `Verify` and the new `Extract` onto one streaming pass (`process`). `Extract` checks the manifest signature **and** the no-downgrade gate **before writing anything**, then stages each component atomically (temp + rename) so a digest failure leaves no poisoned file on disk. `safeJoin` contains every write within the destination (defence in depth atop the existing path validation). Idempotent.
- **`keyorix bundle import <file> --dest <dir> [--installed-version X]`:** fail-closed staging, then prints the operator-controlled rollout steps (`docker load`, `kubectl apply`, `helm upgrade`). Loading images into the internal registry and the Helm upgrade stay the operator's own steps **by design** — an air-gap tool must not seize control of the registry.
- **Tests:** staging round-trip, no-downgrade stages nothing, tampered component stages nothing, untrusted key stages nothing, idempotent re-import.

Verified end-to-end with an `-ldflags`-embedded key: a valid upgrade stages 3 verified components; a downgrade is refused with nothing written.

Phase 1b remaining: CI publish of the bundle as a release asset + an optional server-side audit event on import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)