### PR TITLE
release: finalize v0.82.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,41 @@
 All notable changes to Keyorix are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## v0.82.0 — 2026-06-24
+
+Air-gapped, cryptographically-verifiable update bundles — the first build-on of the Phase 0
+trust foundation — plus a security-test sweep over per-reference RBAC and secret-encryption
+tamper-resistance.
+
+### Added
+- **Air-gap update bundles (`keyorix bundle build` / `verify` / `import`)** — a single,
+  signed, offline-verifiable artifact for carrying a Keyorix release into an air-gapped or
+  regulated environment (defence, finance, government; NIS2/DORA supply-chain integrity). A
+  bundle is a gzip-tar whose `manifest.json` pins every component (images, charts, CRDs,
+  binaries, migrations) by sha256, with a detached `ed25519` `manifest.sig`. `build` signs
+  with an offline key; `verify` and `import` check the signature **offline** against the
+  public key embedded in the binary at build time — trust follows a pinned chain, never a
+  key shipped inside the bundle — then verify every component's digest. `import`
+  additionally enforces **no-downgrade / `min_upgrade_from`** before staging the verified
+  artifacts atomically, and prints the operator-controlled rollout steps (loading images
+  into the internal registry and the Helm upgrade stay the operator's own steps). Everything
+  **fails closed**: a plain (non-release) build embeds no keys, so verification refuses.
+  Reads are size-bounded (decompression-bomb guard). Builds on the Phase 0 trust registry
+  (`internal/trust`). (ADR-064, ADR-062 Phase 1) ([#479], [#482])
+
+### Internal
+- Security-boundary test sweep: Keyorix Connect per-reference RBAC has no admin bypass and
+  no bare-prefix segment-boundary footgun ([#477], [#478], ADR-045); and the secret-
+  encryption AEAD is tamper- and transplant-resistant, with no legacy-AAD downgrade bypass
+  of the transplant binding ([#480], [#481]).
+
+[#477]: https://github.com/keyorixhq/keyorix/pull/477
+[#478]: https://github.com/keyorixhq/keyorix/pull/478
+[#479]: https://github.com/keyorixhq/keyorix/pull/479
+[#480]: https://github.com/keyorixhq/keyorix/pull/480
+[#481]: https://github.com/keyorixhq/keyorix/pull/481
+[#482]: https://github.com/keyorixhq/keyorix/pull/482
+
 ## v0.81.0 — 2026-06-23
 
 A security-hardening release: the HTTP edge gets global security headers, a request

--- a/deploy/helm/keyorix-k8s-sync/Chart.yaml
+++ b/deploy/helm/keyorix-k8s-sync/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix-k8s-sync
 description: Keyorix Kubernetes sync agent — materialises Keyorix secrets into native Kubernetes Secrets
 type: application
 # Chart version — tracks the Keyorix release version (published in lockstep).
-version: 0.81.0
+version: 0.82.0
 # The keyorix-k8s-sync image tag this chart deploys by default.
-appVersion: "0.81.0"
+appVersion: "0.82.0"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix

--- a/deploy/helm/keyorix-operator/Chart.yaml
+++ b/deploy/helm/keyorix-operator/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix-operator
 description: Keyorix Kubernetes operator — reconciles KeyorixSecret resources into native Kubernetes Secrets
 type: application
 # Chart version — tracks the Keyorix release version (published in lockstep).
-version: 0.81.0
+version: 0.82.0
 # The keyorix-operator image tag this chart deploys by default.
-appVersion: "0.81.0"
+appVersion: "0.82.0"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix

--- a/deploy/helm/keyorix/Chart.yaml
+++ b/deploy/helm/keyorix/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix
 description: Self-hosted Keyorix secrets manager (API server + web UI + PostgreSQL)
 type: application
 # Chart version — bump on chart changes.
-version: 0.81.0
+version: 0.82.0
 # The Keyorix app version this chart deploys by default (the image tag).
-appVersion: "0.81.0"
+appVersion: "0.82.0"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix


### PR DESCRIPTION
Cuts **v0.82.0**, folding everything merged since v0.81.0 into the changelog and bumping the three Helm charts to 0.82.0.

Headline: **air-gap update bundles** — `keyorix bundle build / verify / import` (ADR-064, ADR-062 Phase 1, #479 + #482). A single signed, offline-verifiable artifact for carrying a Keyorix release into an air-gapped/regulated environment: the manifest pins every component by sha256 with a detached ed25519 signature, verified offline against the binary's embedded pinned key; `import` enforces no-downgrade before staging atomically. Everything fails closed. Built on the Phase 0 trust registry.

Also a security-boundary test sweep over Keyorix Connect per-reference RBAC (#477, #478) and secret-encryption AEAD tamper/transplant resistance (#480, #481).

No code changes — changelog + chart version bumps only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)