### PR TITLE
harden(crypto): authenticate chunk position to stop reorder/splice/truncation

### DIFF
--- a/internal/encryption/chunk_integrity_test.go
+++ b/internal/encryption/chunk_integrity_test.go
@@ -1,0 +1,123 @@
+package encryption
+
+import (
+	"bytes"
+	"crypto/rand"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// chunkTestData returns an EncryptionService and a plaintext that spans several chunks at
+// the given chunk size.
+func chunkTestData(t *testing.T, chunkSize, total int) (*EncryptionService, []byte) {
+	t.Helper()
+	es := newTestEncryptionService(t)
+	pt := make([]byte, total)
+	_, err := rand.Read(pt)
+	require.NoError(t, err)
+	return es, pt
+}
+
+// TestChunked_RoundTrip is the positive control: untouched chunks reassemble exactly,
+// including when delivered out of slice order (reassembly is by authenticated index).
+func TestChunked_RoundTrip(t *testing.T) {
+	es, pt := chunkTestData(t, 1024, 5*1024) // 5 chunks
+	chunks, err := es.EncryptChunked(pt, 1024, testKeyVersion)
+	require.NoError(t, err)
+	require.Len(t, chunks, 5)
+
+	// Shuffle the slice order — order in the slice must not matter, only the index does.
+	chunks[0], chunks[4] = chunks[4], chunks[0]
+	got, err := es.DecryptChunked(chunks)
+	require.NoError(t, err)
+	assert.True(t, bytes.Equal(pt, got), "untouched chunks must reassemble exactly")
+}
+
+// TestChunked_ReorderFailsClosed pins anti-reorder: swapping two chunks' ciphertext while
+// leaving the index metadata in place must fail, not silently reassemble scrambled
+// plaintext. The chunk index is bound into each chunk's AAD, so a chunk decrypted at the
+// wrong position fails the GCM tag check.
+func TestChunked_ReorderFailsClosed(t *testing.T) {
+	es, pt := chunkTestData(t, 1024, 3*1024)
+	chunks, err := es.EncryptChunked(pt, 1024, testKeyVersion)
+	require.NoError(t, err)
+
+	// Swap the ciphertext (and nonce) of chunks 0 and 1 but keep their index labels: now
+	// the bytes sealed for index 1 sit under index 0's metadata.
+	chunks[0].Data, chunks[1].Data = chunks[1].Data, chunks[0].Data
+	chunks[0].Metadata.Nonce, chunks[1].Metadata.Nonce = chunks[1].Metadata.Nonce, chunks[0].Metadata.Nonce
+
+	_, err = es.DecryptChunked(chunks)
+	require.Error(t, err, "a chunk decrypted at the wrong index must fail the AAD check")
+}
+
+// TestChunked_TruncationFailsClosed pins anti-truncation: dropping the last chunk and
+// editing the (unauthenticated) TotalChunks on the survivors to match must fail. The total
+// is bound into every chunk's AAD, so a shorter claimed total no longer matches what was
+// sealed.
+func TestChunked_TruncationFailsClosed(t *testing.T) {
+	es, pt := chunkTestData(t, 1024, 4*1024) // 4 chunks
+	chunks, err := es.EncryptChunked(pt, 1024, testKeyVersion)
+	require.NoError(t, err)
+	require.Len(t, chunks, 4)
+
+	// Drop the last chunk and rewrite TotalChunks on the rest so the count check passes.
+	truncated := chunks[:3]
+	for _, c := range truncated {
+		c.Metadata.TotalChunks = 3
+	}
+
+	_, err = es.DecryptChunked(truncated)
+	require.Error(t, err, "a truncated chunk set must fail even after editing TotalChunks")
+}
+
+// TestChunked_CrossStreamSpliceFailsClosed pins anti-splice: substituting a chunk from a
+// different chunked secret (a different stream) for one of this secret's chunks must fail —
+// even if the attacker rewrites the spliced chunk's index and stream-id metadata to match,
+// because the stream id is bound into the AAD it was sealed with.
+func TestChunked_CrossStreamSpliceFailsClosed(t *testing.T) {
+	es, ptA := chunkTestData(t, 1024, 3*1024)
+	a, err := es.EncryptChunked(ptA, 1024, testKeyVersion)
+	require.NoError(t, err)
+
+	ptB := make([]byte, 3*1024)
+	_, err = rand.Read(ptB)
+	require.NoError(t, err)
+	b, err := es.EncryptChunked(ptB, 1024, testKeyVersion)
+	require.NoError(t, err)
+
+	// Splice B's chunk 1 into A in place of A's chunk 1.
+	t.Run("naive splice is caught by the stream-id consistency check", func(t *testing.T) {
+		spliced := []*EncryptedData{a[0], b[1], a[2]}
+		_, err := es.DecryptChunked(spliced)
+		require.Error(t, err, "a chunk from another stream must be rejected")
+	})
+
+	t.Run("relabeled splice is caught by the AAD", func(t *testing.T) {
+		// Rewrite B's chunk-1 metadata to impersonate A's chunk 1 (same stream id + index
+		// + total). The metadata now passes the consistency checks, but the chunk was
+		// sealed under B's stream id, so the rebuilt AAD no longer matches.
+		victim := *b[1]
+		victim.Metadata.ChunkStreamID = a[0].Metadata.ChunkStreamID
+		victim.Metadata.ChunkIndex = 1
+		victim.Metadata.TotalChunks = a[0].Metadata.TotalChunks
+		spliced := []*EncryptedData{a[0], &victim, a[2]}
+		_, err := es.DecryptChunked(spliced)
+		require.Error(t, err, "a relabeled foreign chunk must still fail the AAD check")
+	})
+}
+
+// TestChunked_DuplicateIndexFailsClosed pins that a set padded with a duplicated chunk
+// (instead of the real one at another index) is rejected rather than dropping data.
+func TestChunked_DuplicateIndexFailsClosed(t *testing.T) {
+	es, pt := chunkTestData(t, 1024, 3*1024)
+	chunks, err := es.EncryptChunked(pt, 1024, testKeyVersion)
+	require.NoError(t, err)
+
+	// Replace chunk 2 with a second copy of chunk 0 (count still matches TotalChunks).
+	dup := []*EncryptedData{chunks[0], chunks[1], chunks[0]}
+	_, err = es.DecryptChunked(dup)
+	require.Error(t, err, "a duplicated chunk index must be rejected")
+}

--- a/internal/encryption/encryption.go
+++ b/internal/encryption/encryption.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -30,7 +31,12 @@ type EncryptionMetadata struct {
 	Iterations  int       `json:"iterations,omitempty"`
 	ChunkIndex  int       `json:"chunk_index,omitempty"`
 	TotalChunks int       `json:"total_chunks,omitempty"`
-	AADVersion  string    `json:"aad_version,omitempty"` // "v2" = secretID:projectID:versionNumber; absent = legacy (no AAD). ("v1" was the pre-migration secretID:namespaceID:versionNumber scheme; no longer produced.)
+	// ChunkStreamID is a random per-encryption identifier shared by every chunk of one
+	// chunked secret. With ChunkIndex/TotalChunks it is folded into each chunk's AAD
+	// (chunkAAD), so a chunk cannot be reordered, dropped, or spliced in from another
+	// chunked secret without failing the GCM tag check on decryption.
+	ChunkStreamID string `json:"chunk_stream_id,omitempty"`
+	AADVersion    string `json:"aad_version,omitempty"` // "v2" = secretID:projectID:versionNumber; absent = legacy (no AAD). ("v1" was the pre-migration secretID:namespaceID:versionNumber scheme; no longer produced.)
 }
 
 // EncryptedData represents encrypted content with metadata
@@ -178,6 +184,16 @@ func (es *EncryptionService) EncryptChunked(plaintext []byte, chunkSize int, key
 		chunkSize = 64 * 1024 // Default 64KB chunks
 	}
 
+	// A random per-call stream ID binds every chunk to THIS encryption. Together with the
+	// chunk index and total, folded into each chunk's AAD, it makes reorder, truncation,
+	// and cross-stream splice all fail the GCM tag check on decryption — the chunk index
+	// and total in the (unauthenticated) metadata alone could otherwise be edited freely.
+	streamIDBytes := make([]byte, 16)
+	if _, err := io.ReadFull(rand.Reader, streamIDBytes); err != nil {
+		return nil, fmt.Errorf("failed to generate chunk stream id: %w", err)
+	}
+	streamID := hex.EncodeToString(streamIDBytes)
+
 	var chunks []*EncryptedData
 	totalChunks := (len(plaintext) + chunkSize - 1) / chunkSize
 
@@ -187,15 +203,17 @@ func (es *EncryptionService) EncryptChunked(plaintext []byte, chunkSize int, key
 			end = len(plaintext)
 		}
 
-		chunk := plaintext[i:end]
-		encryptedChunk, err := es.Encrypt(chunk, keyVersion)
+		idx := len(chunks)
+		encryptedChunk, err := es.EncryptWithAAD(plaintext[i:end], keyVersion, chunkAAD(streamID, idx, totalChunks))
 		if err != nil {
-			return nil, fmt.Errorf("failed to encrypt chunk %d: %w", len(chunks), err)
+			return nil, fmt.Errorf("failed to encrypt chunk %d: %w", idx, err)
 		}
 
-		// Add chunk metadata
-		encryptedChunk.Metadata.ChunkIndex = len(chunks)
+		// Add chunk metadata. These values are also bound into the AAD above, so any
+		// tampering with them is caught by DecryptWithAAD, not trusted blindly.
+		encryptedChunk.Metadata.ChunkIndex = idx
 		encryptedChunk.Metadata.TotalChunks = totalChunks
+		encryptedChunk.Metadata.ChunkStreamID = streamID
 
 		chunks = append(chunks, encryptedChunk)
 	}
@@ -203,35 +221,55 @@ func (es *EncryptionService) EncryptChunked(plaintext []byte, chunkSize int, key
 	return chunks, nil
 }
 
-// DecryptChunked decrypts chunked data and reassembles it
+// chunkAAD binds a chunk to its stream, position, and count. Reconstructed identically on
+// decryption from the chunk's claimed metadata, so a reordered, truncated, or spliced-in
+// chunk yields a different AAD than it was sealed with and fails the AES-GCM tag check.
+func chunkAAD(streamID string, index, total int) []byte {
+	return []byte(fmt.Sprintf("keyorix:chunk:v1:%s:%d:%d", streamID, index, total))
+}
+
+// DecryptChunked decrypts chunked data and reassembles it. Every chunk must belong to the
+// same stream and agree on the total; the per-chunk AAD (stream+index+total) is the
+// cryptographic backstop, so reorder, truncation, duplication, and cross-secret splice all
+// fail closed rather than reassembling an attacker-chosen plaintext.
 func (es *EncryptionService) DecryptChunked(chunks []*EncryptedData) ([]byte, error) {
 	if len(chunks) == 0 {
 		return nil, fmt.Errorf("no chunks provided")
 	}
 
-	// Verify chunk integrity
 	totalChunks := chunks[0].Metadata.TotalChunks
+	streamID := chunks[0].Metadata.ChunkStreamID
 	if len(chunks) != totalChunks {
 		return nil, fmt.Errorf("expected %d chunks, got %d", totalChunks, len(chunks))
 	}
 
-	// Sort chunks by index (in case they're out of order)
+	// Sort chunks by index (they may arrive out of order), rejecting any inconsistency
+	// before decryption; the AAD check below re-verifies the same facts cryptographically.
 	sortedChunks := make([]*EncryptedData, totalChunks)
 	for _, chunk := range chunks {
-		if chunk.Metadata.ChunkIndex >= totalChunks {
+		if chunk.Metadata.ChunkStreamID != streamID {
+			return nil, fmt.Errorf("chunk stream id mismatch (chunk spliced from another secret?)")
+		}
+		if chunk.Metadata.TotalChunks != totalChunks {
+			return nil, fmt.Errorf("inconsistent total chunks across the set")
+		}
+		if chunk.Metadata.ChunkIndex < 0 || chunk.Metadata.ChunkIndex >= totalChunks {
 			return nil, fmt.Errorf("invalid chunk index %d", chunk.Metadata.ChunkIndex)
+		}
+		if sortedChunks[chunk.Metadata.ChunkIndex] != nil {
+			return nil, fmt.Errorf("duplicate chunk index %d", chunk.Metadata.ChunkIndex)
 		}
 		sortedChunks[chunk.Metadata.ChunkIndex] = chunk
 	}
 
-	// Decrypt and reassemble
+	// Decrypt and reassemble, binding each chunk to its position via the AAD.
 	var result []byte
 	for i, chunk := range sortedChunks {
 		if chunk == nil {
 			return nil, fmt.Errorf("missing chunk at index %d", i)
 		}
 
-		decrypted, err := es.Decrypt(chunk)
+		decrypted, err := es.DecryptWithAAD(chunk, chunkAAD(streamID, i, totalChunks))
 		if err != nil {
 			return nil, fmt.Errorf("failed to decrypt chunk %d: %w", i, err)
 		}


### PR DESCRIPTION
## Cryptographic-integrity lane — invariant #3 (a real hardening, not just a test)

### The gap

`EncryptChunked` sealed each chunk with plain `Encrypt` (**nil AAD**) and stored `ChunkIndex` / `TotalChunks` in **unauthenticated metadata**. `DecryptChunked` then *trusted* that metadata to order and bound the set. An attacker with write access to the stored chunks could:

- **reorder** chunks (swap ciphertext, keep the index labels),
- **truncate** the set (drop a chunk and edit `TotalChunks` to match),
- **splice in** a chunk from another chunked secret,

…each reassembling an attacker-influenced plaintext **while every individual GCM tag still verified**. This is the classic AEAD-composition gap: the parts were authenticated, their composition was not.

The large-secret chunked path (`EncryptLargeSecret`/`DecryptLargeSecret` → `StoreLargeSecret`/`RetrieveLargeSecret`) currently has **no callers**, so this hardens it *before* it is ever wired in — **zero migration risk** (no chunked rows exist).

### The fix

Bind each chunk's position into its AAD. `EncryptChunked` generates a random per-call `ChunkStreamID` and seals chunk *i* with AAD `keyorix:chunk:v1:<stream>:<i>:<total>` via `EncryptWithAAD`. `DecryptChunked` re-derives that AAD from each chunk's claimed metadata and verifies it with `DecryptWithAAD`, and first rejects any stream-id/total inconsistency or duplicate index. So reorder, truncation, duplication, and cross-secret splice all **fail the tag check** (or the consistency check) instead of decrypting — the metadata is now *asserted context*, not trusted input.

### Tests (`chunk_integrity_test.go`)

- round-trip, including out-of-slice-order delivery (reassembly is by authenticated index);
- **reorder** fails closed;
- **truncation** (with `TotalChunks` edited to match) fails closed;
- **cross-stream splice** fails closed — both the naive case *and* the case where the attacker relabels the foreign chunk's stream-id/index/total metadata (caught by the AAD);
- **duplicate index** fails closed.

Existing `TestChunkedEncryption` and the large-secret round-trip still pass.

`go build ./...` ✅ · encryption pkg `-race` ✅ · `golangci-lint ./...` 0 ✅ · `gosec` 0 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)