### PR TITLE
feat(license): offline license validation — fail-safe entitlement (ADR-065, Phase 2a)

### DIFF
--- a/docs/adr-065-offline-license-validation.md
+++ b/docs/adr-065-offline-license-validation.md
@@ -1,0 +1,80 @@
+# ADR-065: Offline license validation (ADR-062 Phase 2)
+
+## Status
+
+Accepted. Implements the **licensing** mechanism of
+[ADR-062](adr-062-air-gap-updates.md); see [air-gap-updates-design.md](air-gap-updates-design.md)
+§4. Builds on the Phase 0 trust foundation (`internal/trust`, `PurposeLicense`). Phase 2a
+(this) is the token + offline evaluation + CLI; server-startup wiring, the periodic
+re-check, and compliance/admin surfacing are Phase 2b.
+
+## Context
+
+Keyorix is AGPL-3.0 with no commercial entitlement mechanism. A paid tier for air-gapped
+customers (defence/finance/government) needs a license that validates **without phoning
+home** — there is no egress to a license server, and a phone-home would itself be an
+exfiltration channel a regulated buyer would reject.
+
+The Phase 0 trust registry already supports a `license` purpose with an embedded, pinned
+`ed25519` public key (separate keypair from update signing, so the blast radii are
+independent). What was missing is the license token, its offline evaluation, and the CLI.
+
+## Decision
+
+Add `internal/license` and a `keyorix license` CLI (`issue`, `install`, `status`).
+
+**Token.** A compact `base64url(payload).base64url(sig)` token. The payload is JSON:
+`licensee`, `plan`, `features[]`, `issued_at`, `not_after`, optional `deployment_id`,
+optional `max_seats`, and the signing `key_id`. The signature is `ed25519` over the exact
+payload bytes; verification decodes the payload bytes from the token and verifies against
+the **embedded** license key named by `key_id` — trust follows the pinned chain.
+
+**Fail-safe enforcement — the deliberate inverse of update bundles.** Bundles are
+fail-CLOSED (an unverifiable bundle must never be trusted). A license is **fail-SAFE**:
+`Evaluate` never returns an error. Every failure mode — no token, malformed token, bad
+signature, untrusted/absent key, expiry beyond grace, deployment-binding mismatch —
+degrades to the **community baseline** (no commercial features) with a `Reason` the caller
+surfaces as a prominent admin warning and an audit event. It never deletes data, never
+denies access to existing secrets, and never stops the server: for a secrets manager,
+availability *is* a security property, and a license lapse must not brick production.
+Enforcement gates **commercial features only**, through a single `Status.HasFeature` gate.
+
+**States.** `active` (valid, in date) and `expiring_soon` both grant features;
+`expiring_soon` covers the window before `not_after` *and* a configurable post-expiry
+**grace** period (features are retained during grace so the server doesn't lose
+entitlement the moment a license lapses — it warns instead). `expired` (past grace),
+`invalid` (unverifiable / deployment-mismatch), and `none` (no license) all drop to
+baseline.
+
+**Anti-abuse (proportionate).** An optional `deployment_id` binds a license to one
+deployment; a mismatch degrades to baseline with a warning, it does **not** shut down.
+Expiry + signature defeat forgery and replay. No phone-home means no exfiltration channel.
+
+**CLI.** `issue` (Keyorix-internal, signs with the offline license key) prints a token;
+`install` validates a token and stores it at `0600` (refusing to store an unverifiable
+one) for the server to load; `status` reports the locally-evaluated entitlement. A plain
+(non-release) build embeds no license key, so every token evaluates to `invalid` →
+baseline — and still exits cleanly, never denying.
+
+## Alternatives considered
+
+- **A real JWS/JWT library (EdDSA).** Standards-conformant, but pulls a dependency for a
+  format we fully control; the compact `payload.sig` form is a few lines, dependency-free,
+  and consistent with `internal/bundle` and `internal/trust`.
+- **Online license check / floating seats.** Rejected outright — the whole point is no
+  phone-home for air-gapped buyers; seats are informational (`max_seats`), not enforced
+  online.
+- **Fail-closed enforcement (deny on invalid license).** Rejected: bricking a running
+  secrets manager on a license lapse is a worse outcome than running the community
+  baseline. Fail-safe is the explicit ADR-062 posture.
+
+## Consequences
+
+- Additive and behaviour-neutral: nothing in the server reads license state yet (Phase 2b),
+  and a non-release build trusts no license key, so evaluation is always baseline.
+- `Status.HasFeature` is the one gate Phase 2b wires into commercial-feature call sites; the
+  fail-safe semantics live entirely in `Evaluate`, so call sites stay trivial.
+- Issuing real licenses is an operational step gated on embedding the production license
+  public key (and keeping its private key offline), mirroring the update-signing key.
+- Maps onto the compliance posture as an entitlement/record control once Phase 2b surfaces
+  license state in the dashboard + audit log.

--- a/docs/air-gap-updates-design.md
+++ b/docs/air-gap-updates-design.md
@@ -196,8 +196,13 @@ behaviour until built.
      internal registry and the Helm upgrade stay the operator's own steps by design.
    - **1b remaining:** CI wiring (`bundle build` in `release.yml`, bundle published as a
      release asset) and an optional server-side audit event when an import runs.
-3. **Phase 2 — licensing:** offline license verification, the commercial feature gate
-   (fail-safe), `license install|status`, and compliance/audit surfacing.
+3. **Phase 2 — licensing:**
+   - **2a (done, [ADR-065](adr-065-offline-license-validation.md)):** the signed license
+     token, `internal/license` offline **fail-safe** evaluation (degrade-to-baseline, never
+     deny), the `Status.HasFeature` gate, and `keyorix license issue|install|status`.
+   - **2b:** wire `HasFeature` into commercial-feature call sites, validate at server
+     startup + on a periodic timer, and surface license state in the dashboard, audit log,
+     and admin notifications.
 4. **Phase 3 — hardening:** HSM-backed signing, key rotation drill, reproducible-bundle
    verification, and a documented operator runbook.
 

--- a/internal/cli/license/license.go
+++ b/internal/cli/license/license.go
@@ -1,0 +1,209 @@
+// Package license provides `keyorix license` — offline license tooling (ADR-065, ADR-062
+// Phase 2). `issue` mints a signed license token (Keyorix-internal, with the offline
+// license-signing key); `install` validates and stores a token; `status` reports the
+// locally-evaluated entitlement. Evaluation is fail-safe: a missing/expired/invalid license
+// degrades to the community baseline, it never errors the tool or denies access.
+package license
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	ilicense "github.com/keyorixhq/keyorix/internal/license"
+	"github.com/keyorixhq/keyorix/internal/trust"
+	"github.com/spf13/cobra"
+)
+
+// LicenseCmd is the `keyorix license` command group.
+var LicenseCmd = &cobra.Command{
+	Use:   "license",
+	Short: "Offline license: issue (internal), install, and check status",
+	Long: `Issue, install, and inspect Keyorix offline licenses (ADR-062 Phase 2).
+
+A license is a compact signed token validated locally against the license public key
+embedded in this binary at build time — no phone-home. Enforcement is fail-safe: a missing,
+expired, or invalid license degrades to the community baseline with a warning; it never
+denies access to existing secrets or stops the server.`,
+}
+
+var (
+	issueLicensee   string
+	issuePlan       string
+	issueFeatures   string
+	issueNotAfter   string
+	issueDeployment string
+	issueMaxSeats   int
+	issueKeyID      string
+	issueSignKey    string
+
+	statusFile       string
+	statusDeployment string
+	statusGraceHours int
+
+	installDest       string
+	installDeployment string
+	installGraceHours int
+)
+
+var issueCmd = &cobra.Command{
+	Use:          "issue",
+	Short:        "Mint a signed license token (Keyorix-internal; needs the offline signing key)",
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		notAfter, err := time.Parse(time.RFC3339, issueNotAfter)
+		if err != nil {
+			return fmt.Errorf("--not-after must be RFC3339: %w", err)
+		}
+		keyPEM, err := os.ReadFile(issueSignKey) // #nosec G304 -- operator-supplied key path
+		if err != nil {
+			return fmt.Errorf("read signing key: %w", err)
+		}
+		priv, err := ilicense.ParsePrivateKeyPEM(keyPEM)
+		if err != nil {
+			return err
+		}
+		var features []string
+		for _, f := range strings.Split(issueFeatures, ",") {
+			if f = strings.TrimSpace(f); f != "" {
+				features = append(features, f)
+			}
+		}
+		token, err := ilicense.Issue(ilicense.License{
+			Licensee:     issueLicensee,
+			Plan:         issuePlan,
+			Features:     features,
+			IssuedAt:     time.Now().UTC(),
+			NotAfter:     notAfter.UTC(),
+			DeploymentID: issueDeployment,
+			MaxSeats:     issueMaxSeats,
+			KeyID:        issueKeyID,
+		}, priv)
+		if err != nil {
+			return err
+		}
+		fmt.Println(token)
+		return nil
+	},
+}
+
+var installCmd = &cobra.Command{
+	Use:          "install <token-file>",
+	Short:        "Validate a license token and store it for the server to load",
+	Args:         cobra.ExactArgs(1),
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, args []string) error {
+		if installDest == "" {
+			return fmt.Errorf("--dest is required")
+		}
+		token, err := readToken(args[0])
+		if err != nil {
+			return err
+		}
+		reg, err := trust.DefaultRegistry()
+		if err != nil {
+			return fmt.Errorf("load trusted keys: %w", err)
+		}
+		st := ilicense.Evaluate(token, reg, installDeployment, time.Now().UTC(), graceOf(installGraceHours))
+		// Fail-safe: a degraded license still installs (so a later renewal/clock-fix can
+		// activate it), but we warn loudly and never store an unparseable/forged token.
+		if st.State == ilicense.StateInvalid {
+			return fmt.Errorf("refusing to install an invalid license: %s", st.Reason)
+		}
+		if err := os.WriteFile(installDest, []byte(token+"\n"), 0o600); err != nil {
+			return fmt.Errorf("write license: %w", err)
+		}
+		fmt.Printf("Installed license for %q (plan %s) → %s\n", st.Licensee, st.Plan, installDest)
+		printStatus(st)
+		return nil
+	},
+}
+
+var statusCmd = &cobra.Command{
+	Use:          "status",
+	Short:        "Show the locally-evaluated license entitlement",
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		var token string
+		if statusFile != "" {
+			t, err := readToken(statusFile)
+			if err != nil {
+				return err
+			}
+			token = t
+		}
+		reg, err := trust.DefaultRegistry()
+		if err != nil {
+			return fmt.Errorf("load trusted keys: %w", err)
+		}
+		st := ilicense.Evaluate(token, reg, statusDeployment, time.Now().UTC(), graceOf(statusGraceHours))
+		printStatus(st)
+		return nil
+	},
+}
+
+func printStatus(st ilicense.Status) {
+	fmt.Printf("  state:    %s\n", st.State)
+	if st.Licensee != "" {
+		fmt.Printf("  licensee: %s\n", st.Licensee)
+	}
+	if st.Plan != "" {
+		fmt.Printf("  plan:     %s\n", st.Plan)
+	}
+	if !st.NotAfter.IsZero() {
+		fmt.Printf("  expires:  %s\n", st.NotAfter.UTC().Format(time.RFC3339))
+	}
+	if st.Grants() && len(st.Features) > 0 {
+		fmt.Printf("  features: %s\n", strings.Join(st.Features, ", "))
+	} else {
+		fmt.Printf("  features: (community baseline — no commercial features)\n")
+	}
+	if st.Reason != "" {
+		fmt.Printf("  note:     %s\n", st.Reason)
+	}
+}
+
+func readToken(path string) (string, error) {
+	b, err := os.ReadFile(path) // #nosec G304 -- operator-supplied license path
+	if err != nil {
+		return "", fmt.Errorf("read license token: %w", err)
+	}
+	return strings.TrimSpace(string(b)), nil
+}
+
+// graceOf converts a grace flag (hours) into a duration, defaulting to 14 days when unset.
+func graceOf(hours int) time.Duration {
+	if hours <= 0 {
+		return 14 * 24 * time.Hour
+	}
+	return time.Duration(hours) * time.Hour
+}
+
+func init() {
+	issueCmd.Flags().StringVar(&issueLicensee, "licensee", "", "licensee name (required)")
+	issueCmd.Flags().StringVar(&issuePlan, "plan", "", "plan name, e.g. enterprise-airgap")
+	issueCmd.Flags().StringVar(&issueFeatures, "features", "", "comma-separated commercial feature keys")
+	issueCmd.Flags().StringVar(&issueNotAfter, "not-after", "", "expiry, RFC3339 (required)")
+	issueCmd.Flags().StringVar(&issueDeployment, "deployment-id", "", "optional binding to a deployment id")
+	issueCmd.Flags().IntVar(&issueMaxSeats, "max-seats", 0, "optional informational seat count")
+	issueCmd.Flags().StringVar(&issueKeyID, "key-id", "", "license signing key-id (required)")
+	issueCmd.Flags().StringVar(&issueSignKey, "sign-key", "", "PKCS#8 PEM ed25519 license signing key (required; keep offline)")
+	_ = issueCmd.MarkFlagRequired("licensee")
+	_ = issueCmd.MarkFlagRequired("not-after")
+	_ = issueCmd.MarkFlagRequired("key-id")
+	_ = issueCmd.MarkFlagRequired("sign-key")
+
+	installCmd.Flags().StringVar(&installDest, "dest", "", "path to store the validated license token (required)")
+	installCmd.Flags().StringVar(&installDeployment, "deployment-id", "", "this deployment's id, to check a bound license")
+	installCmd.Flags().IntVar(&installGraceHours, "grace-hours", 0, "post-expiry grace window in hours (default 336 = 14d)")
+	_ = installCmd.MarkFlagRequired("dest")
+
+	statusCmd.Flags().StringVar(&statusFile, "license", "", "license token file to evaluate")
+	statusCmd.Flags().StringVar(&statusDeployment, "deployment-id", "", "this deployment's id, to check a bound license")
+	statusCmd.Flags().IntVar(&statusGraceHours, "grace-hours", 0, "post-expiry grace window in hours (default 336 = 14d)")
+
+	LicenseCmd.AddCommand(issueCmd)
+	LicenseCmd.AddCommand(installCmd)
+	LicenseCmd.AddCommand(statusCmd)
+}

--- a/internal/cli/main.go
+++ b/internal/cli/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/keyorixhq/keyorix/internal/cli/hygiene"
 	"github.com/keyorixhq/keyorix/internal/cli/invite"
 	"github.com/keyorixhq/keyorix/internal/cli/legalhold"
+	licensecli "github.com/keyorixhq/keyorix/internal/cli/license"
 	"github.com/keyorixhq/keyorix/internal/cli/machine"
 	"github.com/keyorixhq/keyorix/internal/cli/migrate"
 	"github.com/keyorixhq/keyorix/internal/cli/pat"
@@ -81,6 +82,7 @@ func init() {
 	rootCmd.AddCommand(hygiene.HygieneCmd)
 	rootCmd.AddCommand(trustcli.TrustCmd)
 	rootCmd.AddCommand(bundlecli.BundleCmd)
+	rootCmd.AddCommand(licensecli.LicenseCmd)
 }
 
 // Execute runs the root command

--- a/internal/license/license.go
+++ b/internal/license/license.go
@@ -1,0 +1,214 @@
+// Package license implements Keyorix's offline license validation (ADR-065, ADR-062
+// Phase 2). A license is a compact, signed token — base64url(payload).base64url(sig) — that
+// a deployment validates locally against an ed25519 public key embedded at build time
+// (trust.PurposeLicense). There is no phone-home.
+//
+// The enforcement posture is deliberately the INVERSE of update bundles. Bundles are
+// fail-CLOSED: an unverifiable bundle must never be trusted. A license is fail-SAFE: a
+// missing, expired, or invalid license must never deny access to existing secrets or stop
+// the server — availability is itself a security property for a secrets manager, and a
+// license lapse must not brick production. So `Evaluate` never errors out; it degrades to
+// the community baseline (no commercial features) with a reason the caller surfaces as an
+// admin warning + audit event. Enforcement gates commercial features only.
+package license
+
+import (
+	"crypto/ed25519"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/trust"
+)
+
+// expiringSoonWindow is how long before not_after a still-valid license is flagged
+// "expiring soon" so operators can renew ahead of a lapse.
+const expiringSoonWindow = 30 * 24 * time.Hour
+
+// License is the signed payload. Features are commercial-feature keys this license grants.
+type License struct {
+	Licensee     string    `json:"licensee"`
+	Plan         string    `json:"plan"`
+	Features     []string  `json:"features"`
+	IssuedAt     time.Time `json:"issued_at"`
+	NotAfter     time.Time `json:"not_after"`
+	DeploymentID string    `json:"deployment_id,omitempty"`
+	MaxSeats     int       `json:"max_seats,omitempty"`
+	KeyID        string    `json:"key_id"`
+}
+
+// State is the evaluated license state. Only Active and ExpiringSoon grant features.
+type State string
+
+const (
+	StateActive       State = "active"        // valid, in date
+	StateExpiringSoon State = "expiring_soon" // valid and feature-granting, but near/just past expiry (within grace)
+	StateExpired      State = "expired"       // past not_after + grace → baseline
+	StateInvalid      State = "invalid"       // unparseable / bad signature / deployment mismatch → baseline
+	StateNone         State = "none"          // no license installed → baseline
+)
+
+// Status is the result of evaluating a token. Features is the EFFECTIVE feature set —
+// empty (community baseline) whenever the state is not feature-granting.
+type Status struct {
+	State        State
+	Licensee     string
+	Plan         string
+	Features     []string
+	NotAfter     time.Time
+	DeploymentID string
+	MaxSeats     int
+	Reason       string // why degraded (for admin warning + audit); empty when Active
+}
+
+// Grants reports whether the license currently grants commercial features.
+func (s Status) Grants() bool {
+	return s.State == StateActive || s.State == StateExpiringSoon
+}
+
+// HasFeature reports whether feature f is granted right now. It is the single gate the rest
+// of the server should call; it is false for every feature under a degraded license.
+func (s Status) HasFeature(f string) bool {
+	if !s.Grants() {
+		return false
+	}
+	for _, x := range s.Features {
+		if x == f {
+			return true
+		}
+	}
+	return false
+}
+
+// Issue marshals and signs a license into a compact token. Issuance-side only (the private
+// key is the offline license-signing secret; it never ships).
+func Issue(lic License, priv ed25519.PrivateKey) (string, error) {
+	if strings.TrimSpace(lic.KeyID) == "" {
+		return "", fmt.Errorf("license: key-id is required")
+	}
+	if strings.TrimSpace(lic.Licensee) == "" {
+		return "", fmt.Errorf("license: licensee is required")
+	}
+	if lic.NotAfter.IsZero() {
+		return "", fmt.Errorf("license: not_after is required")
+	}
+	payload, err := json.Marshal(&lic)
+	if err != nil {
+		return "", err
+	}
+	sig := ed25519.Sign(priv, payload)
+	return enc(payload) + "." + enc(sig), nil
+}
+
+// parseToken splits and decodes a token into its raw payload bytes, signature, and the
+// parsed License. It does not verify the signature.
+func parseToken(token string) (payload, sig []byte, lic *License, err error) {
+	token = strings.TrimSpace(token)
+	parts := strings.Split(token, ".")
+	if len(parts) != 2 {
+		return nil, nil, nil, fmt.Errorf("license: malformed token (want payload.sig)")
+	}
+	payload, err = dec(parts[0])
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("license: decode payload: %w", err)
+	}
+	sig, err = dec(parts[1])
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("license: decode signature: %w", err)
+	}
+	var l License
+	if err := json.Unmarshal(payload, &l); err != nil {
+		return nil, nil, nil, fmt.Errorf("license: parse payload: %w", err)
+	}
+	return payload, sig, &l, nil
+}
+
+// Evaluate validates a token offline and returns the effective Status. It NEVER returns an
+// error: every failure mode (no token, bad signature, expiry, deployment mismatch) degrades
+// to the community baseline with a Reason — the caller surfaces that as an admin warning and
+// an audit event, but the server keeps running. deploymentID, when non-empty on both sides,
+// must match (anti-copy binding). grace is the post-expiry tolerance window.
+func Evaluate(token string, reg *trust.KeyRegistry, deploymentID string, now time.Time, grace time.Duration) Status {
+	if strings.TrimSpace(token) == "" {
+		return Status{State: StateNone, Reason: "no license installed — running the community baseline"}
+	}
+	payload, sig, lic, err := parseToken(token)
+	if err != nil {
+		return Status{State: StateInvalid, Reason: err.Error()}
+	}
+	if strings.TrimSpace(lic.KeyID) == "" {
+		return Status{State: StateInvalid, Reason: "license has no key-id"}
+	}
+	// Verify against the embedded, pinned license key for this key-id. A forged key-id is
+	// not in the registry, so this fails — and degrades, not denies.
+	if err := reg.Verify(trust.PurposeLicense, lic.KeyID, payload, sig); err != nil {
+		return Status{State: StateInvalid, Reason: "signature: " + err.Error()}
+	}
+
+	base := Status{
+		Licensee:     lic.Licensee,
+		Plan:         lic.Plan,
+		NotAfter:     lic.NotAfter,
+		DeploymentID: lic.DeploymentID,
+		MaxSeats:     lic.MaxSeats,
+	}
+
+	// Anti-copy binding: a license bound to a deployment must not grant features on another.
+	// Mismatch degrades (warn + audit), it does not shut anything down.
+	if lic.DeploymentID != "" && deploymentID != "" && lic.DeploymentID != deploymentID {
+		base.State = StateInvalid
+		base.Reason = fmt.Sprintf("license is bound to deployment %q, not this deployment", lic.DeploymentID)
+		return base
+	}
+
+	switch {
+	case now.After(lic.NotAfter.Add(grace)):
+		base.State = StateExpired
+		base.Reason = fmt.Sprintf("license expired on %s — running the community baseline", lic.NotAfter.UTC().Format(time.RFC3339))
+		return base
+	case now.After(lic.NotAfter):
+		// Past expiry but within grace: keep features (fail-safe) and warn loudly.
+		base.State = StateExpiringSoon
+		base.Features = lic.Features
+		base.Reason = fmt.Sprintf("license expired on %s and is in its grace period — renew now", lic.NotAfter.UTC().Format(time.RFC3339))
+		return base
+	case now.After(lic.NotAfter.Add(-expiringSoonWindow)):
+		base.State = StateExpiringSoon
+		base.Features = lic.Features
+		base.Reason = fmt.Sprintf("license expires on %s — renew soon", lic.NotAfter.UTC().Format(time.RFC3339))
+		return base
+	default:
+		base.State = StateActive
+		base.Features = lic.Features
+		return base
+	}
+}
+
+// --- helpers ---
+
+func enc(b []byte) string { return base64.RawURLEncoding.EncodeToString(b) }
+func dec(s string) ([]byte, error) {
+	return base64.RawURLEncoding.DecodeString(strings.TrimSpace(s))
+}
+
+// ParsePrivateKeyPEM decodes a PKCS#8 PEM (as written by `keyorix trust keygen`) into an
+// ed25519 license-signing key.
+func ParsePrivateKeyPEM(b []byte) (ed25519.PrivateKey, error) {
+	block, _ := pem.Decode(b)
+	if block == nil {
+		return nil, fmt.Errorf("license: no PEM block in signing key")
+	}
+	key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("license: parse signing key: %w", err)
+	}
+	priv, ok := key.(ed25519.PrivateKey)
+	if !ok {
+		return nil, fmt.Errorf("license: signing key is not ed25519 (%T)", key)
+	}
+	return priv, nil
+}

--- a/internal/license/license_test.go
+++ b/internal/license/license_test.go
@@ -1,0 +1,186 @@
+package license
+
+import (
+	"crypto/ed25519"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/trust"
+)
+
+// signed mints a license + a registry that trusts its key under keyID.
+func signed(t *testing.T, lic License) (string, *trust.KeyRegistry) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("genkey: %v", err)
+	}
+	if lic.KeyID == "" {
+		lic.KeyID = "license-2026"
+	}
+	token, err := Issue(lic, priv)
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+	reg := trust.NewRegistry()
+	if err := reg.Add(trust.PurposeLicense, lic.KeyID, pub); err != nil {
+		t.Fatalf("reg.Add: %v", err)
+	}
+	return token, reg
+}
+
+func TestEvaluate_Active(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0).UTC()
+	token, reg := signed(t, License{
+		Licensee: "ACME GmbH", Plan: "enterprise-airgap",
+		Features: []string{"airgap_updates", "premium_connectors"},
+		IssuedAt: now, NotAfter: now.Add(365 * 24 * time.Hour),
+	})
+	st := Evaluate(token, reg, "", now, 14*24*time.Hour)
+	if st.State != StateActive {
+		t.Fatalf("state = %s, want active (%s)", st.State, st.Reason)
+	}
+	if !st.HasFeature("airgap_updates") || !st.HasFeature("premium_connectors") {
+		t.Fatalf("expected features granted: %+v", st)
+	}
+	if st.HasFeature("not_a_feature") {
+		t.Fatal("ungranted feature reported as present")
+	}
+}
+
+func TestEvaluate_NoLicense_DegradesToBaseline(t *testing.T) {
+	st := Evaluate("", trust.NewRegistry(), "", time.Now(), time.Hour)
+	if st.State != StateNone {
+		t.Fatalf("state = %s, want none", st.State)
+	}
+	if st.Grants() || st.HasFeature("airgap_updates") {
+		t.Fatal("no license must grant nothing")
+	}
+	if st.Reason == "" {
+		t.Fatal("expected a reason to surface to the admin")
+	}
+}
+
+func TestEvaluate_BadSignature_DegradesNotDenies(t *testing.T) {
+	now := time.Now().UTC()
+	token, _ := signed(t, License{Licensee: "ACME", NotAfter: now.Add(time.Hour), Features: []string{"x"}})
+	// A registry that trusts a DIFFERENT key under the same id — signature won't verify.
+	otherPub, _, _ := ed25519.GenerateKey(nil)
+	reg := trust.NewRegistry()
+	_ = reg.Add(trust.PurposeLicense, "license-2026", otherPub)
+
+	st := Evaluate(token, reg, "", now, time.Hour)
+	// Fail-SAFE: invalid signature degrades to baseline, it does NOT error or deny.
+	if st.State != StateInvalid {
+		t.Fatalf("state = %s, want invalid", st.State)
+	}
+	if st.Grants() {
+		t.Fatal("an unverifiable license must not grant features")
+	}
+}
+
+func TestEvaluate_UntrustedRegistry_Degrades(t *testing.T) {
+	now := time.Now().UTC()
+	token, _ := signed(t, License{Licensee: "ACME", NotAfter: now.Add(time.Hour), Features: []string{"x"}})
+	// Empty registry (a plain non-release build) — no license keys at all.
+	st := Evaluate(token, trust.NewRegistry(), "", now, time.Hour)
+	if st.State != StateInvalid || st.Grants() {
+		t.Fatalf("want invalid+no-grant, got %s grants=%v", st.State, st.Grants())
+	}
+}
+
+func TestEvaluate_Expired_BeyondGrace_Baseline(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0).UTC()
+	token, reg := signed(t, License{
+		Licensee: "ACME", Features: []string{"airgap_updates"},
+		IssuedAt: now.Add(-400 * 24 * time.Hour), NotAfter: now.Add(-30 * 24 * time.Hour),
+	})
+	st := Evaluate(token, reg, "", now, 14*24*time.Hour) // expired 30d ago, grace 14d → expired
+	if st.State != StateExpired {
+		t.Fatalf("state = %s, want expired", st.State)
+	}
+	if st.Grants() || st.HasFeature("airgap_updates") {
+		t.Fatal("a fully-expired license must drop to baseline")
+	}
+}
+
+func TestEvaluate_Expired_WithinGrace_StillGrants(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0).UTC()
+	// Expired 3 days ago, grace 14 days → still grants (fail-safe), flagged expiring_soon.
+	token, reg := signed(t, License{
+		Licensee: "ACME", Features: []string{"airgap_updates"},
+		IssuedAt: now.Add(-100 * 24 * time.Hour), NotAfter: now.Add(-3 * 24 * time.Hour),
+	})
+	st := Evaluate(token, reg, "", now, 14*24*time.Hour)
+	if st.State != StateExpiringSoon {
+		t.Fatalf("state = %s, want expiring_soon (in grace)", st.State)
+	}
+	if !st.HasFeature("airgap_updates") {
+		t.Fatal("within grace, features must still be granted (availability is a security property)")
+	}
+	if st.Reason == "" {
+		t.Fatal("grace period must warn")
+	}
+}
+
+func TestEvaluate_ExpiringSoon_BeforeExpiry(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0).UTC()
+	// Expires in 10 days (< 30d window) → expiring_soon, still grants.
+	token, reg := signed(t, License{
+		Licensee: "ACME", Features: []string{"airgap_updates"},
+		IssuedAt: now.Add(-355 * 24 * time.Hour), NotAfter: now.Add(10 * 24 * time.Hour),
+	})
+	st := Evaluate(token, reg, "", now, 14*24*time.Hour)
+	if st.State != StateExpiringSoon || !st.HasFeature("airgap_updates") {
+		t.Fatalf("want expiring_soon + granted, got %s grants=%v", st.State, st.Grants())
+	}
+}
+
+func TestEvaluate_DeploymentBinding(t *testing.T) {
+	now := time.Now().UTC()
+	token, reg := signed(t, License{
+		Licensee: "ACME", Features: []string{"x"},
+		NotAfter: now.Add(time.Hour), DeploymentID: "kx-7f3a",
+	})
+	// Matching deployment → granted.
+	if st := Evaluate(token, reg, "kx-7f3a", now, time.Hour); !st.HasFeature("x") {
+		t.Fatalf("matching deployment should grant: %+v", st)
+	}
+	// Mismatched deployment → degrade (warn + audit), NOT shutdown.
+	st := Evaluate(token, reg, "kx-other", now, time.Hour)
+	if st.State != StateInvalid || st.Grants() {
+		t.Fatalf("mismatch must degrade: %s grants=%v", st.State, st.Grants())
+	}
+	// No local deployment id supplied → binding not enforced (still grants).
+	if st := Evaluate(token, reg, "", now, time.Hour); !st.HasFeature("x") {
+		t.Fatal("unbound check should still grant")
+	}
+}
+
+func TestEvaluate_MalformedToken_Degrades(t *testing.T) {
+	for _, bad := range []string{"garbage", "only-one-part", "a.b.c", "!!.??"} {
+		st := Evaluate(bad, trust.NewRegistry(), "", time.Now(), time.Hour)
+		if st.State != StateInvalid || st.Grants() {
+			t.Fatalf("token %q: want invalid+no-grant, got %s", bad, st.State)
+		}
+	}
+}
+
+func TestIssue_Validates(t *testing.T) {
+	_, priv, _ := ed25519.GenerateKey(nil)
+	if _, err := Issue(License{NotAfter: time.Now(), KeyID: "k"}, priv); err == nil {
+		t.Fatal("want error for missing licensee")
+	}
+	if _, err := Issue(License{Licensee: "x", KeyID: "k"}, priv); err == nil {
+		t.Fatal("want error for missing not_after")
+	}
+	if _, err := Issue(License{Licensee: "x", NotAfter: time.Now()}, priv); err == nil {
+		t.Fatal("want error for missing key-id")
+	}
+}
+
+func TestParsePrivateKeyPEM_Rejects(t *testing.T) {
+	if _, err := ParsePrivateKeyPEM([]byte("not a pem")); err == nil {
+		t.Fatal("want error for non-PEM input")
+	}
+}


### PR DESCRIPTION
Implements **ADR-062 Phase 2a** — offline license validation, the second mechanism after air-gap bundles, built on the Phase 0 trust registry (`PurposeLicense`).

A paid air-gap tier (defence/finance/government) needs entitlement that validates **with no phone-home** — there's no egress, and a phone-home is itself an exfiltration channel regulated buyers reject.

- **`internal/license`:** a compact `base64url(payload).base64url(sig)` token (licensee, plan, features, issued_at, not_after, optional deployment_id/max_seats, key_id), signed ed25519 over the payload bytes and verified against the **embedded** license key.
- **`Evaluate` is the deliberate INVERSE of bundle verify — fail-SAFE, never errors.** No token / malformed / bad signature / untrusted key / expiry-beyond-grace / deployment mismatch all degrade to the **community baseline** (no commercial features) with a `Reason` for the admin warning + audit — it never denies access to existing secrets or stops the server. Availability *is* a security property; a license lapse must not brick a secrets manager. `Status.HasFeature` is the single gate Phase 2b wires into call sites. A `grace` window keeps features for a period past `not_after`.
- **`keyorix license issue`** (offline-signed) **`| install`** (validate + store `0600`, refuse a forged token) **`| status`** (locally-evaluated entitlement).

Additive and behaviour-neutral — nothing in the server reads license state yet (**Phase 2b**: wire `HasFeature` into commercial features, validate at startup + periodic timer, surface in dashboard/audit).

Verified end-to-end with an `-ldflags`-embedded key: active grants features; a plain binary degrades (exit 0, never denies); `install` refuses a garbage token; deployment-binding, grace, and expiry all behave per the fail-safe posture. Tests lock in every degrade path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)