### PR TITLE
test(crypto): DEK rotation must preserve the AAD transplant binding

### DIFF
--- a/internal/encryption/sweep_aad_binding_test.go
+++ b/internal/encryption/sweep_aad_binding_test.go
@@ -1,0 +1,57 @@
+package encryption
+
+import (
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRotateDEKWithSweep_PreservesAADBinding pins that a DEK rotation re-encrypts secret
+// rows WITH their SecretAAD binding intact — not just that they still decrypt. The sweep
+// reads each row with its (secretID, projectID, versionNumber) AAD and must re-seal under
+// the new key with the SAME AAD, so the ciphertext-transplant defense (see the AEAD/AAD
+// tests) survives every rotation.
+//
+// The existing ReEncryptsAllRows test only ever decrypts with the CORRECT AAD, so it would
+// NOT catch a regression that re-encrypted with the plain nil-AAD path: such a row drops to
+// AADVersion="" and the legacy fallback in DecryptSecretWithAAD would still return the
+// plaintext for any AAD — silently voiding transplant-resistance on every key rotation.
+// This test closes that gap by asserting the re-encrypted row is still AAD-marked and
+// rejects a wrong AAD.
+func TestRotateDEKWithSweep_PreservesAADBinding(t *testing.T) {
+	db := newTestDB(t)
+	svc, _ := newTestService(t, "test-passphrase")
+
+	const projectID = uint(1)
+	const versionNumber = 1
+	nodeID := seedSecretNode(t, db, projectID)
+	versionID := seedSecretVersion(t, db, svc, nodeID, projectID, versionNumber, "super-secret-value")
+
+	require.NoError(t, svc.RotateDEKWithSweep("test-passphrase", db))
+
+	var v models.SecretVersion
+	require.NoError(t, db.First(&v, versionID).Error)
+
+	// The re-encrypted row must still be AAD-bound (v2), not downgraded to the legacy path.
+	enc, err := DeserializeEncryptedData(v.EncryptedValue)
+	require.NoError(t, err)
+	require.Equal(t, "v2", enc.Metadata.AADVersion,
+		"rotation must keep the row AAD-bound, not re-encrypt it on the plain nil-AAD path")
+
+	// Round-trips under the correct AAD.
+	correct := SecretAAD(nodeID, projectID, versionNumber)
+	got, err := svc.DecryptSecretWithAAD(v.EncryptedValue, correct)
+	require.NoError(t, err)
+	require.Equal(t, "super-secret-value", string(got))
+
+	// And the transplant defense still holds AFTER rotation: a wrong AAD must fail. If the
+	// sweep had stripped the binding, the legacy fallback would return the plaintext here.
+	_, err = svc.DecryptSecretWithAAD(v.EncryptedValue, SecretAAD(nodeID+1, projectID, versionNumber))
+	assert.Error(t, err, "a different secret ID must not decrypt the re-encrypted row")
+	_, err = svc.DecryptSecretWithAAD(v.EncryptedValue, SecretAAD(nodeID, projectID+1, versionNumber))
+	assert.Error(t, err, "a different project ID must not decrypt the re-encrypted row")
+	_, err = svc.DecryptSecretWithAAD(v.EncryptedValue, SecretAAD(nodeID, projectID, versionNumber+1))
+	assert.Error(t, err, "a different version number must not decrypt the re-encrypted row")
+}


### PR DESCRIPTION
## Cryptographic-integrity lane — invariant #4: rotation preserves the AAD binding

### Recon note (where this came from)

I first reconned the auth-secret path (`auth_encryption.go` — session/API/client/password-reset tokens). **It is not a meaningful transplant surface:** those blobs are AES-GCM at-rest copies, but session validation looks up by the unique `session_token` column (and PATs by hash), not by trusting the decrypted blob — and the threat model that could transplant them (DB write) already owns the `UserID` columns outright. Their round-trip / rotation / disabled-passthrough behaviors are already covered. So I did **not** manufacture a PR there.

The recon did surface a real, adjacent gap on the **secret** path:

### The gap

The DEK-rotation sweep (`sweepSecretVersions`) re-encrypts each secret row under the new key with `EncryptWithAAD(plaintext, newKeyVersion, SecretAAD(...))`, so the ciphertext-transplant defense (AAD bound to `secretID/projectID/versionNumber`, pinned in #480/#481) is meant to **survive every rotation**. Nothing guarded that. The existing `ReEncryptsAllRows` test only ever decrypts with the **correct** AAD — so a regression that re-encrypted on the plain nil-AAD path would slip through: such a row drops to `AADVersion=""`, and `DecryptSecretWithAAD`'s legacy fallback returns the plaintext for **any** AAD — silently voiding transplant-resistance on every key rotation, while that test still passed.

### The test

`TestRotateDEKWithSweep_PreservesAADBinding` — after `RotateDEKWithSweep`, asserts the re-encrypted row is still AAD-marked (`AADVersion=="v2"`), round-trips under the correct AAD, and **rejects a wrong AAD** (different secret ID, project ID, and version number).

**Verified as a real guard:** it fails against a simulated regression that re-encrypts with plain `Encrypt` (the `AADVersion=="v2"` assertion catches the downgrade) and passes with the real `EncryptWithAAD` path.

No production code change. `go build ./...` ✅ · encryption pkg ✅ · `golangci-lint ./...` 0 ✅ · `gosec` 0 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)