### PR TITLE
feat(license): wire offline license into the server — gate, startup eval, status endpoint (ADR-065 Phase 2b)

### DIFF
--- a/docs/adr-065-offline-license-validation.md
+++ b/docs/adr-065-offline-license-validation.md
@@ -4,9 +4,11 @@
 
 Accepted. Implements the **licensing** mechanism of
 [ADR-062](adr-062-air-gap-updates.md); see [air-gap-updates-design.md](air-gap-updates-design.md)
-§4. Builds on the Phase 0 trust foundation (`internal/trust`, `PurposeLicense`). Phase 2a
-(this) is the token + offline evaluation + CLI; server-startup wiring, the periodic
-re-check, and compliance/admin surfacing are Phase 2b.
+§4. Builds on the Phase 0 trust foundation (`internal/trust`, `PurposeLicense`). Phase 2a is
+the token + offline evaluation + CLI; **Phase 2b** (this revision) wires it into the server:
+startup load, a nil-safe fresh-evaluating gate on the core, a startup audit event, and
+`GET /api/v1/license/status`. Gating an actual commercial feature, dashboard surfacing, and
+transition notifications are 2c.
 
 ## Context
 
@@ -70,9 +72,15 @@ baseline — and still exits cleanly, never denying.
 
 ## Consequences
 
-- Additive and behaviour-neutral: nothing in the server reads license state yet (Phase 2b),
-  and a non-release build trusts no license key, so evaluation is always baseline.
-- `Status.HasFeature` is the one gate Phase 2b wires into commercial-feature call sites; the
+- Additive and behaviour-neutral: the server now evaluates the license at startup and serves
+  its status, but no feature is gated on it yet (2c), and a non-release build trusts no
+  license key, so evaluation is always baseline.
+- The design's "validate on a periodic timer" is realised by the gate evaluating **freshly
+  on every call** rather than caching a status and re-checking on a timer — a license that
+  lapses while the server runs is observed on the next `Status()`/`HasFeature` call, with no
+  goroutine to manage. `Evaluate` is cheap (one ed25519 verify), so per-call cost is
+  negligible. A separate transition-notification path (2c) can still watch for state changes.
+- `core.HasLicensedFeature` is the one gate 2c wires into commercial-feature call sites; the
   fail-safe semantics live entirely in `Evaluate`, so call sites stay trivial.
 - Issuing real licenses is an operational step gated on embedding the production license
   public key (and keeping its private key offline), mirroring the update-signing key.

--- a/docs/air-gap-updates-design.md
+++ b/docs/air-gap-updates-design.md
@@ -200,9 +200,16 @@ behaviour until built.
    - **2a (done, [ADR-065](adr-065-offline-license-validation.md)):** the signed license
      token, `internal/license` offline **fail-safe** evaluation (degrade-to-baseline, never
      deny), the `Status.HasFeature` gate, and `keyorix license issue|install|status`.
-   - **2b:** wire `HasFeature` into commercial-feature call sites, validate at server
-     startup + on a periodic timer, and surface license state in the dashboard, audit log,
-     and admin notifications.
+   - **2b (server wiring done, [ADR-065](adr-065-offline-license-validation.md)):** the
+     server loads the configured license at startup (fail-safe — a missing/unreadable/
+     invalid file degrades to baseline, never blocks boot), builds a nil-safe `license.Gate`
+     on the core that evaluates **freshly on every call** (so a lapse is observed without a
+     restart or a background timer), records the evaluated state as a startup audit event,
+     and serves `GET /api/v1/license/status` (admin-gated). `core.HasLicensedFeature` is the
+     single gate ready for commercial features.
+   - **2c remaining:** designate the first commercial-only feature and gate it on
+     `HasLicensedFeature`; surface license state in the web dashboard; and emit admin
+     notifications on state transitions (expiring-soon / expired).
 4. **Phase 3 — hardening:** HSM-backed signing, key rotation drill, reproducible-bundle
    verification, and a documented operator runbook.
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -112,6 +112,33 @@ type Config struct {
 	// external secret stores. Disabled (zero value) = the /connect endpoints are not
 	// served.
 	Connect ConnectConfig `yaml:"connect"`
+
+	// License configures offline commercial-license validation (ADR-065). Absent (zero
+	// value) = no license installed → the community baseline (no commercial features).
+	// Enforcement is fail-safe: a missing/expired/invalid license never denies access or
+	// stops the server; it degrades to the baseline with an admin warning + audit event.
+	License LicenseConfig `yaml:"license"`
+}
+
+// LicenseConfig points at an installed offline license token and tunes its evaluation
+// (ADR-065). All fields are optional; an empty Path means no license is installed.
+type LicenseConfig struct {
+	// Path is the file holding the license token (as written by `keyorix license install`).
+	Path string `yaml:"path"`
+	// DeploymentID, when set, is checked against a license bound to a deployment; a
+	// mismatch degrades to the baseline (it never shuts the server down).
+	DeploymentID string `yaml:"deployment_id"`
+	// GraceHours is the post-expiry tolerance window during which features are retained
+	// (with a loud warning) so a lapse doesn't instantly drop entitlement. Default 336 (14d).
+	GraceHours int `yaml:"grace_hours"`
+}
+
+// LicenseGrace returns the configured post-expiry grace window, defaulting to 14 days.
+func (c *Config) LicenseGrace() time.Duration {
+	if c.License.GraceHours <= 0 {
+		return 14 * 24 * time.Hour
+	}
+	return time.Duration(c.License.GraceHours) * time.Hour
 }
 
 // ConnectConfig configures read-through federation to external secret stores

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -14,6 +14,7 @@ import (
 	"github.com/keyorixhq/keyorix/internal/delivery"
 	"github.com/keyorixhq/keyorix/internal/dynamic"
 	"github.com/keyorixhq/keyorix/internal/encryption"
+	"github.com/keyorixhq/keyorix/internal/license"
 	"github.com/keyorixhq/keyorix/internal/notary"
 	"github.com/keyorixhq/keyorix/internal/rotation"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
@@ -138,6 +139,10 @@ type KeyorixCore struct {
 	// nil = signing unavailable (encryption disabled). Set via SetEvidenceSignKey.
 	evidenceSignKey        []byte
 	evidenceSignKeyVersion string
+	// licenseGate evaluates the installed offline commercial license (ADR-065). nil =
+	// no license configured → the community baseline. Evaluation is fail-safe (it never
+	// denies access or stops the server) and fresh on every call. Set via SetLicenseGate.
+	licenseGate *license.Gate
 }
 
 // AuditForwarder ships persisted audit events to an external sink (e.g. a SIEM).
@@ -152,6 +157,44 @@ type AuditForwarder interface {
 // when the install configures an audit.siem block. nil disables forwarding.
 func (c *KeyorixCore) SetAuditForwarder(f AuditForwarder) {
 	c.auditForwarder = f
+}
+
+// SetLicenseGate wires the offline-license feature gate built at startup from the
+// installed token. nil = no license (community baseline). Safe to leave unset.
+func (c *KeyorixCore) SetLicenseGate(g *license.Gate) {
+	c.licenseGate = g
+}
+
+// LicenseStatus returns the freshly-evaluated license entitlement. It never errors; an
+// unset gate or a degraded license reports the community baseline with a reason. The gate
+// is nil-safe, so this is valid even when no license is configured.
+func (c *KeyorixCore) LicenseStatus() license.Status {
+	return c.licenseGate.Status()
+}
+
+// HasLicensedFeature reports whether commercial feature f is currently granted. This is the
+// single gate a future commercial-only capability checks; it is false under any degraded,
+// expired, missing, or unconfigured license.
+func (c *KeyorixCore) HasLicensedFeature(f string) bool {
+	return c.licenseGate.HasFeature(f)
+}
+
+// AuditLicenseState records the current license state as an audit event. The server calls
+// it once at startup so the evaluated entitlement (and any degrade reason) is on the record.
+func (c *KeyorixCore) AuditLicenseState(ctx context.Context) {
+	st := c.LicenseStatus()
+	desc := "License evaluated at startup: " + string(st.State)
+	if st.Reason != "" {
+		desc += " — " + st.Reason
+	}
+	ok := true
+	c.emitAudit(ctx, &models.AuditEvent{
+		EventType:   "license.evaluated",
+		Description: desc,
+		Success:     &ok,
+		ActorType:   "system",
+		EventTime:   time.Now(),
+	})
 }
 
 // emitAudit persists an audit event and forwards it to the configured sink.

--- a/internal/license/gate.go
+++ b/internal/license/gate.go
@@ -1,0 +1,55 @@
+package license
+
+import (
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/trust"
+)
+
+// Gate is the server-side feature gate built from an installed license token. It evaluates
+// the token freshly on every call (Evaluate is cheap — one ed25519 verify), so the reported
+// state always reflects the current time without any cached-state or background-timer
+// lifecycle: a license that lapses while the server runs is observed on the next call.
+//
+// A nil *Gate is valid and behaves as "no license installed" (community baseline) — so a
+// server with no license configured needs no special-casing at call sites.
+type Gate struct {
+	token        string
+	reg          *trust.KeyRegistry
+	deploymentID string
+	grace        time.Duration
+	now          func() time.Time // injectable for tests; defaults to time.Now
+}
+
+// NewGate builds a gate over an installed token. A nil registry or empty token still yields
+// a usable gate that simply evaluates to the baseline (fail-safe).
+func NewGate(token string, reg *trust.KeyRegistry, deploymentID string, grace time.Duration) *Gate {
+	if grace <= 0 {
+		grace = 14 * 24 * time.Hour
+	}
+	return &Gate{token: token, reg: reg, deploymentID: deploymentID, grace: grace, now: time.Now}
+}
+
+// Status evaluates the license against the current time. It never errors — a degraded
+// license returns a baseline Status with a Reason. A nil gate reports StateNone.
+func (g *Gate) Status() Status {
+	if g == nil {
+		return Status{State: StateNone, Reason: "no license configured — running the community baseline"}
+	}
+	reg := g.reg
+	if reg == nil {
+		reg = trust.NewRegistry()
+	}
+	now := time.Now
+	if g.now != nil {
+		now = g.now
+	}
+	return Evaluate(g.token, reg, g.deploymentID, now(), g.grace)
+}
+
+// HasFeature reports whether commercial feature f is currently granted. This is the single
+// gate the rest of the server calls before enabling a commercial-only capability; it is
+// false for every feature under a degraded, expired, missing, or unconfigured license.
+func (g *Gate) HasFeature(f string) bool {
+	return g.Status().HasFeature(f)
+}

--- a/internal/license/gate_test.go
+++ b/internal/license/gate_test.go
@@ -1,0 +1,88 @@
+package license
+
+import (
+	"crypto/ed25519"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/trust"
+)
+
+func TestGate_Nil_IsBaseline(t *testing.T) {
+	var g *Gate // a server with no license configured
+	st := g.Status()
+	if st.State != StateNone {
+		t.Fatalf("nil gate state = %s, want none", st.State)
+	}
+	if g.HasFeature("airgap_updates") {
+		t.Fatal("nil gate must grant nothing")
+	}
+}
+
+func TestGate_EmptyToken_IsBaseline(t *testing.T) {
+	g := NewGate("", trust.NewRegistry(), "", 0)
+	if g.Status().State != StateNone || g.HasFeature("x") {
+		t.Fatalf("empty token must be baseline: %+v", g.Status())
+	}
+}
+
+func TestGate_ActiveToken_Grants(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	reg := trust.NewRegistry()
+	_ = reg.Add(trust.PurposeLicense, "license-2026", pub)
+
+	// not_after well in the future so the gate's real-clock Status() is active.
+	token, err := Issue(License{
+		Licensee: "ACME", Plan: "enterprise", Features: []string{"airgap_updates"},
+		IssuedAt: time.Now().Add(-time.Hour), NotAfter: time.Now().Add(365 * 24 * time.Hour),
+		KeyID: "license-2026",
+	}, priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	g := NewGate(token, reg, "", 0)
+	if !g.HasFeature("airgap_updates") {
+		t.Fatalf("expected feature granted: %+v", g.Status())
+	}
+	if g.HasFeature("nope") {
+		t.Fatal("ungranted feature reported present")
+	}
+}
+
+func TestGate_FreshEvaluation_AcrossExpiry(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	reg := trust.NewRegistry()
+	_ = reg.Add(trust.PurposeLicense, "license-2026", pub)
+
+	base := time.Unix(1_700_000_000, 0).UTC()
+	notAfter := base.Add(100 * 24 * time.Hour) // 100d out — beyond the 30d expiring-soon window
+	token, _ := Issue(License{
+		Licensee: "ACME", Features: []string{"x"},
+		IssuedAt: base.Add(-24 * time.Hour), NotAfter: notAfter,
+		KeyID: "license-2026",
+	}, priv)
+
+	g := NewGate(token, reg, "", time.Minute) // tiny grace
+	// Drive the gate's clock to prove it re-evaluates each call rather than caching.
+	g.now = func() time.Time { return base } // 100d before expiry → active
+	if g.Status().State != StateActive {
+		t.Fatalf("pre-expiry: %s", g.Status().State)
+	}
+	g.now = func() time.Time { return notAfter.Add(10 * time.Minute) } // past expiry+grace → expired
+	if st := g.Status(); st.State != StateExpired || st.Grants() {
+		t.Fatalf("post-expiry: %s grants=%v (expected expired, no grant)", st.State, st.Grants())
+	}
+}
+
+func TestGate_NilRegistry_Degrades(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	_ = pub
+	token, _ := Issue(License{Licensee: "ACME", NotAfter: time.Now().Add(time.Hour), Features: []string{"x"}, KeyID: "k"}, priv)
+	// A gate with no registry (e.g. trust.DefaultRegistry failed) must not panic and must
+	// degrade to baseline.
+	g := NewGate(token, nil, "", 0)
+	if g.Status().Grants() {
+		t.Fatal("no registry must not grant features")
+	}
+}

--- a/server/http/handlers/license.go
+++ b/server/http/handlers/license.go
@@ -1,0 +1,60 @@
+// license.go — GetLicenseStatus: the locally-evaluated offline-license entitlement
+// (ADR-065). Read-only; the server never phones home and the evaluation is fail-safe.
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/server/middleware"
+)
+
+// LicenseHandler serves the offline-license status.
+type LicenseHandler struct {
+	coreService *core.KeyorixCore
+}
+
+// NewLicenseHandler constructs a LicenseHandler.
+func NewLicenseHandler(coreService *core.KeyorixCore) *LicenseHandler {
+	return &LicenseHandler{coreService: coreService}
+}
+
+// licenseStatusResponse is the read-only view of the evaluated entitlement.
+type licenseStatusResponse struct {
+	State     string   `json:"state"`
+	Licensee  string   `json:"licensee,omitempty"`
+	Plan      string   `json:"plan,omitempty"`
+	Features  []string `json:"features"`
+	Grants    bool     `json:"grants"`
+	ExpiresAt string   `json:"expires_at,omitempty"`
+	MaxSeats  int      `json:"max_seats,omitempty"`
+	Reason    string   `json:"reason,omitempty"`
+}
+
+// GetLicenseStatus returns the freshly-evaluated license status. It never fails on license
+// state — a degraded/absent license reports the community baseline, consistent with the
+// fail-safe enforcement posture.
+func (h *LicenseHandler) GetLicenseStatus(w http.ResponseWriter, r *http.Request) {
+	if middleware.GetUserFromContext(r.Context()) == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+
+	st := h.coreService.LicenseStatus()
+	resp := licenseStatusResponse{
+		State:    string(st.State),
+		Licensee: st.Licensee,
+		Plan:     st.Plan,
+		Features: st.Features,
+		Grants:   st.Grants(),
+		MaxSeats: st.MaxSeats,
+		Reason:   st.Reason,
+	}
+	if resp.Features == nil {
+		resp.Features = []string{}
+	}
+	if !st.NotAfter.IsZero() {
+		resp.ExpiresAt = st.NotAfter.UTC().Format("2006-01-02T15:04:05Z07:00")
+	}
+	sendSuccess(w, resp, "")
+}

--- a/server/http/handlers/license_handler_test.go
+++ b/server/http/handlers/license_handler_test.go
@@ -1,0 +1,73 @@
+package handlers
+
+import (
+	"crypto/ed25519"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/license"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/keyorixhq/keyorix/internal/trust"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLicenseHandler_RequiresUserContext(t *testing.T) {
+	db := openTestDB(t)
+	h := NewLicenseHandler(core.NewKeyorixCore(store.NewLocalStorage(db)))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/license/status", nil)
+	w := httptest.NewRecorder()
+	h.GetLicenseStatus(w, req)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestLicenseHandler_NoLicense_ReportsBaseline(t *testing.T) {
+	db := openTestDB(t)
+	// No gate set → community baseline (the nil-gate is valid).
+	h := NewLicenseHandler(core.NewKeyorixCore(store.NewLocalStorage(db)))
+
+	req := withUserCtx(httptest.NewRequest(http.MethodGet, "/api/v1/license/status", nil))
+	w := httptest.NewRecorder()
+	h.GetLicenseStatus(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	assert.Contains(t, body, `"state":"none"`)
+	assert.Contains(t, body, `"grants":false`)
+}
+
+func TestLicenseHandler_ActiveLicense_ReportsFeatures(t *testing.T) {
+	db := openTestDB(t)
+	c := core.NewKeyorixCore(store.NewLocalStorage(db))
+
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	reg := trust.NewRegistry()
+	_ = reg.Add(trust.PurposeLicense, "license-2026", pub)
+	token, err := license.Issue(license.License{
+		Licensee: "ACME GmbH", Plan: "enterprise-airgap",
+		Features: []string{"airgap_updates"},
+		IssuedAt: time.Now().Add(-time.Hour), NotAfter: time.Now().Add(365 * 24 * time.Hour),
+		KeyID: "license-2026",
+	}, priv)
+	assert.NoError(t, err)
+	c.SetLicenseGate(license.NewGate(token, reg, "", 0))
+
+	h := NewLicenseHandler(c)
+	req := withUserCtx(httptest.NewRequest(http.MethodGet, "/api/v1/license/status", nil))
+	w := httptest.NewRecorder()
+	h.GetLicenseStatus(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	assert.Contains(t, body, `"state":"active"`)
+	assert.Contains(t, body, `"grants":true`)
+	assert.Contains(t, body, "airgap_updates")
+	assert.Contains(t, body, "ACME GmbH")
+	// The plaintext token must never appear in the status response.
+	assert.False(t, strings.Contains(body, token), "license token must not be echoed in status")
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -66,6 +66,7 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 	catalogHandler := handlers.NewCatalogHandler(coreService)
 	dashboardHandler := handlers.NewDashboardHandler(coreService)
 	auditHandler := handlers.NewAuditHandler(coreService)
+	licenseHandler := handlers.NewLicenseHandler(coreService)
 	rotationPolicyHandler := handlers.NewRotationPolicyHandler(coreService)
 	dynamicSecretHandler := handlers.NewDynamicSecretHandler(coreService)
 	rbacHandler := handlers.NewRBACHandler(coreService)
@@ -595,6 +596,9 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.Get("/info", handlers.MakeSystemInfoHandler(cfg))
 			r.Get("/metrics", handlers.GetMetrics)
 		})
+
+		// Offline-license status (ADR-065) — the locally-evaluated commercial entitlement.
+		r.With(customMiddleware.RequirePermission("system.read")).Get("/license/status", licenseHandler.GetLicenseStatus)
 
 		// Personal-access-token hygiene — deployment-wide stale / expired-but-active
 		// tokens an admin should revoke (token sprawl).

--- a/server/main.go
+++ b/server/main.go
@@ -45,11 +45,13 @@ import (
 	"github.com/keyorixhq/keyorix/internal/encryption"
 	"github.com/keyorixhq/keyorix/internal/evidencesink"
 	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/license"
 	"github.com/keyorixhq/keyorix/internal/notary"
 	"github.com/keyorixhq/keyorix/internal/notifychan"
 	"github.com/keyorixhq/keyorix/internal/rotation"
 	samlpkg "github.com/keyorixhq/keyorix/internal/saml"
 	appstorage "github.com/keyorixhq/keyorix/internal/storage"
+	"github.com/keyorixhq/keyorix/internal/trust"
 	"github.com/keyorixhq/keyorix/server/grpc"
 	httpServer "github.com/keyorixhq/keyorix/server/http"
 	"github.com/keyorixhq/keyorix/server/middleware"
@@ -654,6 +656,35 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 		log.Printf("WebAuthn enabled (RP ID %q, %d origin(s))", wa.RPID, len(wa.RPOrigins))
 	}
 
+	// Wire the offline-license feature gate (ADR-065). Fail-safe throughout: a missing,
+	// unreadable, or invalid license never blocks startup — the gate degrades to the
+	// community baseline. A non-release build embeds no license key, so any token evaluates
+	// to the baseline anyway. The gate evaluates the token freshly on every call.
+	reg, terr := trust.DefaultRegistry()
+	if terr != nil {
+		// A malformed embedded key spec is a build/release misconfiguration; surface it,
+		// but still run (no trusted keys → baseline).
+		log.Printf("WARNING: trusted-key registry: %v (running community baseline)", terr)
+		reg = nil
+	}
+	var token string
+	if p := strings.TrimSpace(cfg.License.Path); p != "" {
+		b, rerr := os.ReadFile(p) // #nosec G304 -- operator-configured license path
+		if rerr != nil {
+			log.Printf("WARNING: license file %q unreadable: %v (running community baseline)", p, rerr)
+		} else {
+			token = strings.TrimSpace(string(b))
+		}
+	}
+	gate := license.NewGate(token, reg, cfg.License.DeploymentID, cfg.LicenseGrace())
+	coreService.SetLicenseGate(gate)
+	st := gate.Status()
+	if st.Grants() {
+		log.Printf("License: %s (%s) — state %s", st.Licensee, st.Plan, st.State)
+	} else {
+		log.Printf("License: community baseline (state %s)", st.State)
+	}
+
 	return coreService, encSvc, nil
 }
 
@@ -676,6 +707,10 @@ func startHTTPServer(ctx context.Context, cfg *config.Config) error {
 	if encSvc != nil {
 		defer encSvc.Shutdown()
 	}
+
+	// Record the evaluated license state once at startup (ADR-065), so the entitlement
+	// (and any degrade reason) is on the audit record.
+	coreService.AuditLicenseState(ctx)
 
 	// Create HTTP router
 	router, err := httpServer.NewRouter(cfg, coreService)


### PR DESCRIPTION
Makes the Phase 2a license core (#485) live in the server — **fail-safe throughout**.

- **`internal/license.Gate`:** a nil-safe feature gate that evaluates the installed token **freshly on every call** (Evaluate is one ed25519 verify), so a lapse is observed without a restart or a background timer. A nil gate = community baseline, so call sites need no special-casing.
- **config:** a `License` block (path, deployment_id, grace_hours) + `LicenseGrace()`; absent = no license = baseline.
- **core:** `licenseGate` field + `SetLicenseGate` / `LicenseStatus` / `HasLicensedFeature` (the single gate a future commercial feature checks) + `AuditLicenseState` (startup record).
- **`server/main.go`:** loads the configured token at startup — a missing/unreadable/invalid file **degrades to baseline with a warning, never blocks boot** (availability is a security property) — builds the gate from `trust.DefaultRegistry()`, emits the startup audit event.
- **`GET /api/v1/license/status`** (`system.read`): the locally-evaluated entitlement; never echoes the token.

**Deliberately does NOT retro-gate any shipped feature** — that would strip capabilities from existing AGPL community deployments. `HasLicensedFeature` is ready for the first commercial-only feature (2c), alongside dashboard surfacing + transition notifications.

Tests: gate nil-safety + fresh re-evaluation across expiry; handler baseline/active/no-context + a token-never-echoed leak check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)