### PR TITLE
release: finalize v0.83.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,40 @@
 All notable changes to Keyorix are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## v0.83.0 — 2026-06-24
+
+Offline commercial-license validation — the second air-gap mechanism, fail-safe by design —
+plus secret-encryption chunk-ordering hardening.
+
+### Added
+- **Offline license validation (`keyorix license issue` / `install` / `status` + server
+  enforcement)** — a paid air-gap tier needs entitlement that validates **with no
+  phone-home**. A license is a compact `ed25519`-signed token (licensee, plan, features,
+  expiry, optional deployment binding) verified locally against a public key embedded at
+  build time. Enforcement is the deliberate **inverse of update bundles**: bundles are
+  fail-closed, a license is **fail-safe** — a missing, expired, or invalid license degrades
+  to the AGPL community baseline (no commercial features) with an admin warning and an audit
+  event; it never denies access to existing secrets or stops the server, because
+  availability is itself a security property for a secrets manager. The server loads the
+  configured license at startup (a bad file never blocks boot), evaluates it freshly on
+  every check, records the state as a startup audit event, and serves `GET
+  /api/v1/license/status`. No shipped feature is gated on it — the gate is ready for future
+  commercial-only capabilities. (ADR-065, ADR-062 Phase 2) ([#485], [#487])
+
+### Security
+- **Chunk position is authenticated in secret-value encryption** — chunked secret values now
+  bind each chunk's position into its AEAD additional data, so a stored ciphertext can't be
+  reordered, spliced, or truncated without detection. ([#484])
+
+### Internal
+- A regression test that DEK rotation preserves the AAD transplant binding (a rewrapped
+  value stays bound to its identity). ([#486])
+
+[#484]: https://github.com/keyorixhq/keyorix/pull/484
+[#485]: https://github.com/keyorixhq/keyorix/pull/485
+[#486]: https://github.com/keyorixhq/keyorix/pull/486
+[#487]: https://github.com/keyorixhq/keyorix/pull/487
+
 ## v0.82.0 — 2026-06-24
 
 Air-gapped, cryptographically-verifiable update bundles — the first build-on of the Phase 0

--- a/deploy/helm/keyorix-k8s-sync/Chart.yaml
+++ b/deploy/helm/keyorix-k8s-sync/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix-k8s-sync
 description: Keyorix Kubernetes sync agent — materialises Keyorix secrets into native Kubernetes Secrets
 type: application
 # Chart version — tracks the Keyorix release version (published in lockstep).
-version: 0.82.0
+version: 0.83.0
 # The keyorix-k8s-sync image tag this chart deploys by default.
-appVersion: "0.82.0"
+appVersion: "0.83.0"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix

--- a/deploy/helm/keyorix-operator/Chart.yaml
+++ b/deploy/helm/keyorix-operator/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix-operator
 description: Keyorix Kubernetes operator — reconciles KeyorixSecret resources into native Kubernetes Secrets
 type: application
 # Chart version — tracks the Keyorix release version (published in lockstep).
-version: 0.82.0
+version: 0.83.0
 # The keyorix-operator image tag this chart deploys by default.
-appVersion: "0.82.0"
+appVersion: "0.83.0"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix

--- a/deploy/helm/keyorix/Chart.yaml
+++ b/deploy/helm/keyorix/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix
 description: Self-hosted Keyorix secrets manager (API server + web UI + PostgreSQL)
 type: application
 # Chart version — bump on chart changes.
-version: 0.82.0
+version: 0.83.0
 # The Keyorix app version this chart deploys by default (the image tag).
-appVersion: "0.82.0"
+appVersion: "0.83.0"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix


### PR DESCRIPTION
Cuts **v0.83.0**, folding everything merged since v0.82.0 into the changelog and bumping the three Helm charts to 0.83.0.

Headline: **offline license validation** — `keyorix license issue / install / status` + server enforcement (ADR-065, ADR-062 Phase 2; #485 + #487). A paid air-gap tier needs entitlement that validates with no phone-home; a license is a compact ed25519-signed token verified locally against an embedded key, with **fail-safe** enforcement (a missing/expired/invalid license degrades to the community baseline, never bricks the server). No shipped feature is gated on it — the gate is ready for future commercial-only capabilities.

Also: secret-encryption **chunk-position authentication** (#484) — a stored ciphertext can't be reordered/spliced/truncated without detection.

No code changes — changelog + chart version bumps only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)