### PR TITLE
harden(auth): enforce the absolute session-lifetime ceiling at validation

### DIFF
--- a/internal/core/auth.go
+++ b/internal/core/auth.go
@@ -179,6 +179,15 @@ func (c *KeyorixCore) ValidateSessionToken(ctx context.Context, token string) (*
 	if session.ExpiresAt != nil && c.now().After(*session.ExpiresAt) {
 		return nil, nil, fmt.Errorf("session expired")
 	}
+	// Enforce the hard absolute-lifetime ceiling at the validation boundary, not only via
+	// the clamp RefreshSession/mintSession apply to ExpiresAt. The clamp makes an expired
+	// ceiling imply an expired access window in normal operation, but the ceiling must not
+	// DEPEND on every issuer having clamped correctly — a session whose access window is
+	// still open yet whose ceiling has passed (a future non-clamping path, or a tampered
+	// row) is rejected here. Self-checking invariant.
+	if session.AbsoluteExpiresAt != nil && c.now().After(*session.AbsoluteExpiresAt) {
+		return nil, nil, fmt.Errorf("session lifetime exceeded")
+	}
 	// Best-effort, throttled last-seen stamp for the My Account sessions view.
 	// Only writes when the stored value is older than sessionTouchInterval, so the
 	// auth hot path is not turned into a write per request. Never fails the request.

--- a/internal/core/session_ttl_test.go
+++ b/internal/core/session_ttl_test.go
@@ -161,3 +161,48 @@ func TestRefreshSession_NoCeilingRefreshesForever(t *testing.T) {
 	require.Equal(t, sessionTestNow.Add(24*time.Hour), *captured.ExpiresAt)
 	require.Nil(t, captured.AbsoluteExpiresAt)
 }
+
+// TestValidateSessionToken_AbsoluteCeilingEnforcedAtBoundary pins that the hard
+// absolute-lifetime ceiling is enforced when a session is VALIDATED, independently of the
+// clamp RefreshSession/mintSession apply to ExpiresAt. The clamp makes an expired ceiling
+// imply an expired access window in normal operation (see the RefreshSession tests above),
+// but the ceiling must not DEPEND on every issuer clamping correctly: a session whose access
+// window is still open yet whose ceiling has passed (a future non-clamping path, or a
+// tampered row) must be rejected at the validation boundary. Self-checking invariant.
+func TestValidateSessionToken_AbsoluteCeilingEnforcedAtBoundary(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("past ceiling is rejected even with an open access window", func(t *testing.T) {
+		store := new(MockStorage)
+		c := newSessionCore(store, time.Hour, 12*time.Hour)
+		accessOpen := sessionTestNow.Add(time.Hour)   // access window still valid
+		ceilingPast := sessionTestNow.Add(-time.Hour) // absolute ceiling already passed
+		store.On("GetSession", ctx, "tok").Return(&models.Session{
+			ID: 7, UserID: 2, ExpiresAt: &accessOpen, AbsoluteExpiresAt: &ceilingPast,
+		}, nil)
+
+		_, _, err := c.ValidateSessionToken(ctx, "tok")
+		require.ErrorContains(t, err, "lifetime exceeded")
+		// Fails fast at the boundary — no last-seen write or user lookup for a dead session.
+		store.AssertNotCalled(t, "TouchSession", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+		store.AssertNotCalled(t, "GetUser", mock.Anything, mock.Anything)
+	})
+
+	t.Run("a future ceiling still validates", func(t *testing.T) {
+		store := new(MockStorage)
+		c := newSessionCore(store, time.Hour, 12*time.Hour)
+		accessOpen := sessionTestNow.Add(time.Hour)
+		ceilingFuture := sessionTestNow.Add(6 * time.Hour)
+		store.On("GetSession", ctx, "tok").Return(&models.Session{
+			ID: 7, UserID: 2, ExpiresAt: &accessOpen, AbsoluteExpiresAt: &ceilingFuture,
+		}, nil)
+		store.On("TouchSession", ctx, uint(7), mock.Anything, mock.Anything).Return(nil)
+		store.On("GetUser", ctx, uint(2)).Return(&models.User{ID: 2, IsActive: true, AccountState: AccountActive}, nil)
+		store.On("GetUserRoles", ctx, uint(2)).Return([]*models.Role{{Name: "viewer"}}, nil)
+
+		user, roles, err := c.ValidateSessionToken(ctx, "tok")
+		require.NoError(t, err)
+		require.Equal(t, uint(2), user.ID)
+		require.Equal(t, []string{"viewer"}, roles)
+	})
+}


### PR DESCRIPTION
## New lane: session-lifecycle assurance — invariant #1

Found via a recon sweep of three candidate lanes (dynamic-secrets leases, SIEM/evidence integrity, session lifecycle). This was the highest-confidence, lowest-risk finding.

### The gap

`ValidateSessionToken` checked only `ExpiresAt` (the refreshable access window), never `AbsoluteExpiresAt` (the hard session-lifetime ceiling set once at login). The ceiling was enforced only **indirectly**: `RefreshSession` and `mintSession` clamp `ExpiresAt` to `AbsoluteExpiresAt`, so in normal operation an expired ceiling also means an expired access window.

That makes the hard ceiling **depend on every session-issuing path clamping correctly**. A future non-clamping issuer, or a tampered session row (open access window + past ceiling), would be accepted past the ceiling because the validator never looked at it.

### The fix

Check `AbsoluteExpiresAt` in `ValidateSessionToken`, right after the `ExpiresAt` check, so the ceiling is **self-enforcing at the validation boundary** rather than reliant on downstream clamp correctness — matching the project's "check the invariant at the boundary, don't rely on a downstream failure" principle. Fails fast (no last-seen write or user lookup for a session past its ceiling).

### Honest scope

This is **not a known live exploit** — the clamp in mint/refresh currently prevents the bypass. It's defense-in-depth that turns the hard ceiling into a self-checking invariant, so it survives a future issuer that forgets to clamp or a tampered row.

### Test

`TestValidateSessionToken_AbsoluteCeilingEnforcedAtBoundary` — a session with an open access window but a past ceiling is rejected (`"lifetime exceeded"`) with **no** `TouchSession`/`GetUser` calls; a future ceiling still validates. Verified the rejection **fails without** the new check.

`go build ./...` ✅ · core pkg ✅ · `golangci-lint ./...` 0 ✅ · `gosec` 0 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)