### PR TITLE
test(audit): pin that the SIEM-pull export carries the ADR-029 chain links

### DIFF
--- a/server/http/handlers/audit_export_chain_test.go
+++ b/server/http/handlers/audit_export_chain_test.go
@@ -1,0 +1,73 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// TestExportAuditLogs_CarriesChainLinks pins the ADR-029 off-box anchor: the SIEM-pull JSON
+// export (GET /api/v1/audit/export) must carry each event's prev_hash AND entry_hash, so an
+// off-box observer can reconstruct the tamper-evidence hash chain and detect on-box
+// tampering — including tail-truncation, which on-box re-verification cannot catch. The
+// handler includes these fields, but nothing guarded that they stay: a struct cleanup that
+// dropped them would silently void the documented anchor with no other test failing. (The
+// async SIEM push forwarder deliberately omits them — it is a best-effort, lossy stream and
+// cannot anchor a chain; the pull export is the authoritative, ordered channel.)
+func TestExportAuditLogs_CarriesChainLinks(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.AuditEvent{}, &models.User{}))
+
+	ls := store.NewLocalStorage(db)
+	ctx := context.Background()
+	tru := true
+	// Seed a real chain via LogAuditEvent so prev_hash/entry_hash are computed and linked.
+	for i, desc := range []string{"first", "second", "third"} {
+		require.NoError(t, ls.LogAuditEvent(ctx, &models.AuditEvent{
+			EventType: "secret.read", Description: desc, Success: &tru,
+			EventTime: time.Now().Add(time.Duration(i) * time.Second), ActorType: "user",
+		}))
+	}
+
+	h := NewAuditHandler(core.NewKeyorixCore(ls))
+	req := withUserCtx(httptest.NewRequest(http.MethodGet, "/api/v1/audit/export", nil))
+	w := httptest.NewRecorder()
+	h.ExportAuditLogs(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp struct {
+		Data struct {
+			Events []struct {
+				ID        uint   `json:"id"`
+				PrevHash  string `json:"prev_hash"`
+				EntryHash string `json:"entry_hash"`
+			} `json:"events"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Len(t, resp.Data.Events, 3)
+
+	// Every exported event must carry both chain links — the anchor is useless without them.
+	for i, e := range resp.Data.Events {
+		assert.NotEmpty(t, e.EntryHash, "event %d must export its entry_hash", i)
+		assert.NotEmpty(t, e.PrevHash, "event %d must export its prev_hash", i)
+	}
+	// And the links must actually chain (export is ascending by id): each event's prev_hash
+	// equals the previous event's entry_hash, so the off-box observer can verify end-to-end.
+	assert.Equal(t, resp.Data.Events[0].EntryHash, resp.Data.Events[1].PrevHash,
+		"event 2's prev_hash must link to event 1's entry_hash")
+	assert.Equal(t, resp.Data.Events[1].EntryHash, resp.Data.Events[2].PrevHash,
+		"event 3's prev_hash must link to event 2's entry_hash")
+}


### PR DESCRIPTION
## Recon outcome: the SIEM "chain links" finding — corrected and pinned

A recon pass flagged that the async SIEM forwarder omits `prev_hash`/`entry_hash`, suggesting ADR-029's off-box anchor was undelivered. **Verifying against the code + ADR, that's a misread:** ADR-029 (lines 100-102) scopes the off-box anchor to the **pull export** (`GET /api/v1/audit/export`), and that handler **does** carry the chain links (`server/http/handlers/audit.go:241-242`). The async **push** forwarder deliberately omits them — it is a best-effort, lossy stream (drops on backpressure) and cannot anchor a chain, so the pull export is the authoritative, ordered channel by design.

So there's no bug — but the *actual* ADR-029 deliverable (export carries the links) had **no test**. A struct cleanup that dropped those fields would silently void the documented off-box tamper-evidence anchor. This pins it.

## Test

`TestExportAuditLogs_CarriesChainLinks` — seeds a real 3-event chain via `LogAuditEvent` (so `prev_hash`/`entry_hash` are computed and linked), calls `ExportAuditLogs`, and asserts:
- every exported event carries a **non-empty** `prev_hash` **and** `entry_hash`;
- the links **actually chain** — each event's `prev_hash` equals the previous event's `entry_hash`, so an off-box observer can verify the chain end-to-end.

**Verified as a real guard:** it fails if the export drops the hash fields.

No production code change. `go build ./...` ✅ · handlers pkg ✅ · `golangci-lint ./...` 0 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)