### PR TITLE
feat(license): airgap_updates is the first commercial feature — gate bundle import (ADR-065 Phase 2c)

### DIFF
--- a/docs/adr-064-air-gap-update-bundles.md
+++ b/docs/adr-064-air-gap-update-bundles.md
@@ -80,7 +80,8 @@ newer than what is installed, and enforces `min_upgrade_from` (anti-skip). A fir
   `verify` (`process`), gating no-downgrade *before* any write and writing each component
   atomically (temp + rename) so a digest failure never leaves a poisoned file. Loading the
   staged images into an internal registry and the Helm upgrade stay operator-controlled —
-  the CLI prints those steps rather than performing them.
+  the CLI prints those steps rather than performing them. `import` is the first
+  license-gated commercial feature (`airgap_updates`, ADR-065 Phase 2c); `verify` is free.
 - Remaining 1b work: CI wiring (`bundle build` as a `release.yml` step publishing the
   bundle as a release asset) once a production update-signing key is embedded, and an
   optional server-side audit event when an import runs.

--- a/docs/adr-065-offline-license-validation.md
+++ b/docs/adr-065-offline-license-validation.md
@@ -5,10 +5,11 @@
 Accepted. Implements the **licensing** mechanism of
 [ADR-062](adr-062-air-gap-updates.md); see [air-gap-updates-design.md](air-gap-updates-design.md)
 §4. Builds on the Phase 0 trust foundation (`internal/trust`, `PurposeLicense`). Phase 2a is
-the token + offline evaluation + CLI; **Phase 2b** (this revision) wires it into the server:
-startup load, a nil-safe fresh-evaluating gate on the core, a startup audit event, and
-`GET /api/v1/license/status`. Gating an actual commercial feature, dashboard surfacing, and
-transition notifications are 2c.
+the token + offline evaluation + CLI; **Phase 2b** wired it into the server (startup load, a
+nil-safe fresh-evaluating gate on the core, a startup audit event, `GET
+/api/v1/license/status`); **Phase 2c** (this revision) designates the **first commercial
+feature** — `airgap_updates`, gating `keyorix bundle import`. Dashboard surfacing and
+transition notifications remain.
 
 ## Context
 
@@ -72,9 +73,14 @@ baseline — and still exits cleanly, never denying.
 
 ## Consequences
 
-- Additive and behaviour-neutral: the server now evaluates the license at startup and serves
-  its status, but no feature is gated on it yet (2c), and a non-release build trusts no
-  license key, so evaluation is always baseline.
+- The first commercial feature is `airgap_updates`, gating `keyorix bundle import` (2c).
+  It was chosen because it strips nothing from community source builds — import already
+  requires the embedded update-signing key only release builds carry — and it is the
+  air-gap tier's flagship by design (ADR-062). `bundle verify` stays free. The gate is
+  fail-safe: a missing/expired/invalid license simply means the feature is off and import
+  is refused with an actionable message; it never touches a running deployment.
+- A non-release build trusts no license key, so evaluation is always baseline; gating is a
+  no-op there (and import is impossible anyway without the embedded update key).
 - The design's "validate on a periodic timer" is realised by the gate evaluating **freshly
   on every call** rather than caching a status and re-checking on a timer — a license that
   lapses while the server runs is observed on the next `Status()`/`HasFeature` call, with no

--- a/docs/air-gap-updates-design.md
+++ b/docs/air-gap-updates-design.md
@@ -207,8 +207,13 @@ behaviour until built.
      restart or a background timer), records the evaluated state as a startup audit event,
      and serves `GET /api/v1/license/status` (admin-gated). `core.HasLicensedFeature` is the
      single gate ready for commercial features.
-   - **2c remaining:** designate the first commercial-only feature and gate it on
-     `HasLicensedFeature`; surface license state in the web dashboard; and emit admin
+   - **2c (first commercial feature done, [ADR-065](adr-065-offline-license-validation.md)):**
+     `airgap_updates` gates `keyorix bundle import` — the first license-gated capability.
+     Chosen because it strips nothing from community builds (import already needs the
+     embedded update key only release builds carry) and is the air-gap tier's flagship;
+     `bundle verify` stays free. The gate is fail-safe (no/degraded license → feature off →
+     import refused, never affecting a running deployment).
+   - **2c remaining:** surface license state in the web dashboard, and emit admin
      notifications on state transitions (expiring-soon / expired).
 4. **Phase 3 — hardening:** HSM-backed signing, key rotation drill, reproducible-bundle
    verification, and a documented operator runbook.

--- a/internal/cli/bundle/bundle.go
+++ b/internal/cli/bundle/bundle.go
@@ -1,16 +1,19 @@
-// Package bundle provides `keyorix bundle` — air-gap update-bundle tooling (ADR-064,
-// ADR-062 Phase 1a). `build` assembles and signs a bundle from a directory of release
-// artifacts (the Keyorix/issuance side, with the offline signing key); `verify` checks a
-// bundle offline against the embedded, pinned public key and every component's digest (the
-// air-gapped operator side). `import` (registry/chart staging) is a later phase.
+// Package bundle provides `keyorix bundle` — air-gap update-bundle tooling (ADR-064).
+// `build` assembles and signs a bundle from a directory of release artifacts (the
+// Keyorix/issuance side, with the offline signing key); `verify` checks a bundle offline
+// against the embedded, pinned public key and every component's digest; `import` verifies
+// and stages the artifacts for an air-gapped rollout. `verify` is free; `import` is the
+// first license-gated commercial feature (ADR-065 Phase 2c, the airgap_updates feature).
 package bundle
 
 import (
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	ibundle "github.com/keyorixhq/keyorix/internal/bundle"
+	ilicense "github.com/keyorixhq/keyorix/internal/license"
 	"github.com/keyorixhq/keyorix/internal/trust"
 	"github.com/spf13/cobra"
 )
@@ -38,6 +41,7 @@ var (
 	verifyInstalled string
 	importDest      string
 	importInstalled string
+	importLicense   string
 )
 
 var buildCmd = &cobra.Command{
@@ -146,6 +150,16 @@ var importCmd = &cobra.Command{
 			return fmt.Errorf("load trusted keys: %w", err)
 		}
 
+		// Commercial gate (ADR-065 Phase 2c): `bundle import` — staging an update for an
+		// air-gapped rollout — is the first license-gated feature. `bundle verify` stays
+		// free. Fail-safe: a missing/expired/invalid license simply means the feature is
+		// off, so import is refused with a clear message (it never affects a running
+		// deployment). Gating strips nothing from community source builds, which can't
+		// import anyway (no embedded update key).
+		if err := requireAirgapUpdates(reg); err != nil {
+			return err
+		}
+
 		f, err := os.Open(args[0]) // #nosec G304 -- operator-supplied bundle path
 		if err != nil {
 			return fmt.Errorf("open bundle: %w", err)
@@ -174,6 +188,30 @@ var importCmd = &cobra.Command{
 	},
 }
 
+// requireAirgapUpdates enforces the commercial license gate for `bundle import`. It reads
+// the installed license token (if --license was given), evaluates it offline against the
+// embedded license key, and requires the airgap_updates feature. Fail-safe: any
+// missing/degraded license means the feature is simply off, and import is refused with a
+// clear, actionable message — it never affects a running deployment.
+func requireAirgapUpdates(reg *trust.KeyRegistry) error {
+	var token string
+	if importLicense != "" {
+		b, err := os.ReadFile(importLicense) // #nosec G304 -- operator-supplied license path
+		if err != nil {
+			return fmt.Errorf("read license: %w", err)
+		}
+		token = strings.TrimSpace(string(b))
+	}
+	st := ilicense.Evaluate(token, reg, "", time.Now(), 14*24*time.Hour)
+	if st.HasFeature(ilicense.FeatureAirgapUpdates) {
+		return nil
+	}
+	return fmt.Errorf("`bundle import` is a commercial feature (%q) and requires a valid license "+
+		"(current state: %s). Install one with `keyorix license install` and pass it via --license, "+
+		"or check `keyorix license status`. `bundle verify` remains available without a license",
+		ilicense.FeatureAirgapUpdates, st.State)
+}
+
 func init() {
 	buildCmd.Flags().StringVar(&buildSrc, "src", "", "directory of release artifacts to bundle (required)")
 	buildCmd.Flags().StringVar(&buildOut, "out", "", "output bundle file (required)")
@@ -192,6 +230,7 @@ func init() {
 
 	importCmd.Flags().StringVar(&importDest, "dest", "", "directory to stage verified artifacts into (required)")
 	importCmd.Flags().StringVar(&importInstalled, "installed-version", "", "currently-installed version, to enforce no-downgrade / min-upgrade-from")
+	importCmd.Flags().StringVar(&importLicense, "license", "", "path to the installed license token (bundle import is a commercial feature)")
 	_ = importCmd.MarkFlagRequired("dest")
 
 	BundleCmd.AddCommand(buildCmd)

--- a/internal/cli/bundle/gate_test.go
+++ b/internal/cli/bundle/gate_test.go
@@ -1,0 +1,72 @@
+package bundle
+
+import (
+	"crypto/ed25519"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	ilicense "github.com/keyorixhq/keyorix/internal/license"
+	"github.com/keyorixhq/keyorix/internal/trust"
+)
+
+// licenseTok issues a license with the given features and writes it to a temp file,
+// returning the path and a registry that trusts its key.
+func licenseTok(t *testing.T, features []string) (string, *trust.KeyRegistry) {
+	t.Helper()
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	token, err := ilicense.Issue(ilicense.License{
+		Licensee: "ACME", Plan: "enterprise-airgap", Features: features,
+		IssuedAt: time.Now().Add(-time.Hour), NotAfter: time.Now().Add(365 * 24 * time.Hour),
+		KeyID: "license-2026",
+	}, priv)
+	if err != nil {
+		t.Fatalf("issue: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "license.tok")
+	if err := os.WriteFile(path, []byte(token), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	reg := trust.NewRegistry()
+	_ = reg.Add(trust.PurposeLicense, "license-2026", pub)
+	return path, reg
+}
+
+func TestRequireAirgapUpdates_Licensed(t *testing.T) {
+	path, reg := licenseTok(t, []string{ilicense.FeatureAirgapUpdates})
+	importLicense = path
+	t.Cleanup(func() { importLicense = "" })
+	if err := requireAirgapUpdates(reg); err != nil {
+		t.Fatalf("a license with airgap_updates should pass: %v", err)
+	}
+}
+
+func TestRequireAirgapUpdates_WrongFeature_Refused(t *testing.T) {
+	path, reg := licenseTok(t, []string{"some_other_feature"})
+	importLicense = path
+	t.Cleanup(func() { importLicense = "" })
+	err := requireAirgapUpdates(reg)
+	if err == nil || !strings.Contains(err.Error(), "commercial feature") {
+		t.Fatalf("a license without airgap_updates must be refused, got: %v", err)
+	}
+}
+
+func TestRequireAirgapUpdates_NoLicense_Refused(t *testing.T) {
+	importLicense = "" // no --license supplied
+	err := requireAirgapUpdates(trust.NewRegistry())
+	if err == nil {
+		t.Fatal("no license must refuse import (fail-safe: feature off)")
+	}
+}
+
+func TestRequireAirgapUpdates_Untrusted_Refused(t *testing.T) {
+	// A valid token, but evaluated against a registry that doesn't trust its key.
+	path, _ := licenseTok(t, []string{ilicense.FeatureAirgapUpdates})
+	importLicense = path
+	t.Cleanup(func() { importLicense = "" })
+	if err := requireAirgapUpdates(trust.NewRegistry()); err == nil {
+		t.Fatal("an untrusted license must be refused")
+	}
+}

--- a/internal/license/features.go
+++ b/internal/license/features.go
@@ -1,0 +1,14 @@
+package license
+
+// Commercial feature keys gated by an offline license. These are the canonical strings that
+// appear in a license's Features list and in HasFeature / HasLicensedFeature checks — use
+// the constants, never bare strings, so the gated set stays discoverable in one place.
+const (
+	// FeatureAirgapUpdates gates `keyorix bundle import` — staging a signed update bundle
+	// for an air-gapped rollout (ADR-064). Bundle *verification* is always free; only the
+	// import (delivery) action is commercial. This is the first designated commercial
+	// feature (ADR-065 Phase 2c). Gating it strips nothing from community source builds:
+	// import already requires the embedded update-signing key that only release builds
+	// carry, so a plain `go build` cannot import regardless.
+	FeatureAirgapUpdates = "airgap_updates"
+)


### PR DESCRIPTION
Designates the **first license-gated capability**: `keyorix bundle import` now requires a valid license carrying the `airgap_updates` feature. **`bundle verify` stays free.**

**Why this feature first:**
- **Strips nothing from community builds** — import already requires the embedded update-signing key that only release builds carry, so a plain `go build` can't import regardless. The license gate formalizes what's already intrinsically a release/enterprise capability.
- **It's the air-gap tier's flagship by design** (ADR-062) — the same regulated buyer who needs offline updates needs the offline license.
- **Fail-safe** — a missing/expired/invalid license means the feature is simply off, so import is refused with an actionable message; it never touches a running deployment (availability preserved).

Ruled out: `extended_retention` (audit retention is deliberately *not* paywalled — NIS2 positioning); SSO / SIEM / connectors (already shipped community, so gating them would strip features).

- `internal/license/features.go`: `FeatureAirgapUpdates` constant (canonical key).
- `bundle import`: a `--license` flag; `requireAirgapUpdates` evaluates the token offline against the embedded license key and requires the feature before any work.
- Tests: licensed passes; wrong-feature / no-license / untrusted all refused.

Verified end-to-end with a binary embedding both update + license keys: verify is free; import is refused without a license, refused with a license lacking the feature, and succeeds only with a valid `airgap_updates` license — each refusal stages nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)