### PR TITLE
fix(auth): suspended account must not authenticate via a personal access token

### DIFF
--- a/internal/core/pat.go
+++ b/internal/core/pat.go
@@ -130,6 +130,14 @@ func (c *KeyorixCore) ValidatePATToken(ctx context.Context, raw string) (*models
 	if !user.IsActive {
 		return nil, nil, nil, fmt.Errorf("user inactive")
 	}
+	// A suspended/blocked account must not authenticate via a PAT either. SuspendUser sets
+	// account_state but deliberately leaves is_active untouched (and kills sessions), so
+	// without this an admin's suspend would cut off session access yet leave the user's
+	// personal access tokens fully working. Mirror ValidateSessionToken's account-state
+	// gate so suspension is immediately effective on every credential type.
+	if AccountLoginBlocked(user.AccountState) {
+		return nil, nil, nil, fmt.Errorf("account is not active")
+	}
 
 	// Best-effort, throttled last-used stamp — never fails the request.
 	_ = c.storage.TouchPersonalAccessToken(ctx, pat.ID, c.now(), patTouchInterval)

--- a/internal/core/pat_suspend_test.go
+++ b/internal/core/pat_suspend_test.go
@@ -1,0 +1,50 @@
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// TestValidatePATToken_SuspendRevokesTokenAccess is the end-to-end regression for the
+// suspended-PAT bypass: an admin SuspendUser sets account_state=suspended and kills the
+// user's sessions, but deliberately leaves is_active true. Before the fix the user's
+// personal access token kept working — suspension cut off session access but not token
+// access. This drives the real flow through LocalStorage and asserts the PAT is rejected
+// once the account is suspended.
+func TestValidatePATToken_SuspendRevokesTokenAccess(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.User{}, &models.PersonalAccessToken{}, &models.Session{}, &models.AuditEvent{}))
+
+	ls := store.NewLocalStorage(db)
+	c := NewKeyorixCore(ls)
+	ctx := context.Background()
+
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "alice", IsActive: true, AccountState: AccountActive}).Error)
+	raw := patPrefix + "suspend-regression-token"
+	require.NoError(t, db.Create(&models.PersonalAccessToken{
+		ID: 1, UserID: 1, Name: "ci", TokenHash: sha256Hex(raw), TokenPrefix: "kx",
+	}).Error)
+
+	// Precondition: the PAT validates while the account is active.
+	u, _, _, err := c.ValidatePATToken(ctx, raw)
+	require.NoError(t, err)
+	require.Equal(t, uint(1), u.ID)
+
+	// Admin (id 2) suspends the user.
+	require.NoError(t, c.SuspendUser(ctx, 2, 1))
+
+	// The PAT must now be rejected — suspension revokes token access, not only sessions.
+	_, _, _, err = c.ValidatePATToken(ctx, raw)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not active")
+}

--- a/internal/core/pat_test.go
+++ b/internal/core/pat_test.go
@@ -131,6 +131,21 @@ func TestValidatePATToken(t *testing.T) {
 		assert.Contains(t, err.Error(), "inactive")
 	})
 
+	t.Run("rejects a token for a suspended user (is_active still true)", func(t *testing.T) {
+		// SuspendUser sets account_state=suspended but leaves is_active untouched, so the
+		// is_active check alone would let a suspended user keep using their PAT. The
+		// account-state gate must reject it — mirroring ValidateSessionToken.
+		ms := new(MockStorage)
+		c := NewKeyorixCore(ms)
+		ms.On("GetPersonalAccessTokenByHash", ctx, hash).Return(&models.PersonalAccessToken{ID: 9, UserID: 1}, nil)
+		ms.On("GetUser", ctx, uint(1)).Return(&models.User{ID: 1, IsActive: true, AccountState: AccountSuspended}, nil)
+		_, _, _, err := c.ValidatePATToken(ctx, raw)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not active")
+		// Must reject before stamping last-used — a blocked token is not "used".
+		ms.AssertNotCalled(t, "TouchPersonalAccessToken", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	})
+
 	t.Run("rejects an unknown token", func(t *testing.T) {
 		ms := new(MockStorage)
 		c := NewKeyorixCore(ms)


### PR DESCRIPTION
## Security fix: account suspension didn't revoke PAT access

Found via a recon sweep of three new areas (break-glass, SCIM deprovision, rotation executor). This is a **real access-revocation gap**, confirmed end-to-end.

### The bug

`ValidatePATToken` rejected only inactive users (`!user.IsActive`); it never checked `AccountLoginBlocked(user.AccountState)` the way `ValidateSessionToken` does. But `SuspendUser` (`setAccountState`) sets `account_state = suspended` and kills the user's sessions while **deliberately leaving `is_active` true** (`internal/core/account_state.go:96-105`).

Result: an admin suspending a user — a **compromised or departing account** — cut off their *session* access but left **every one of their personal access tokens fully working**. The auth middleware adds no compensating check (`server/middleware/auth.go:642-662`: a PAT that validates yields a `UserContext` and proceeds). So suspend did not actually revoke API access via tokens.

Severity: a suspended user retains full token-based API access (scoped to their roles) until each PAT is individually revoked or expires.

### The fix

`ValidatePATToken` now also rejects `AccountLoginBlocked(account_state)`, mirroring `ValidateSessionToken`, so suspension is immediately effective on **every** credential type. The existing `!IsActive` branch (and its `"user inactive"` message) is unchanged.

### Tests

- **unit** — `ValidatePATToken` rejects a PAT for a suspended user whose `is_active` is still true, and rejects it *before* stamping last-used.
- **end-to-end** (real `LocalStorage`) — `TestValidatePATToken_SuspendRevokesTokenAccess`: an active user's PAT validates; after `SuspendUser` it is rejected (`"account is not active"`).

**Verified both fail without the fix** (the suspended PAT validated and proceeded to the last-used stamp — the bypass).

`go build ./...` ✅ · core pkg ✅ · `golangci-lint ./...` 0 ✅ · `gosec` 0 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)