### PR TITLE
release: finalize v0.84.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,33 @@
 All notable changes to Keyorix are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## v0.84.0 — 2026-06-24
+
+The first commercial-licensed feature, plus session-lifetime hardening.
+
+### Added
+- **`bundle import` is the first license-gated commercial feature (`airgap_updates`)** —
+  staging an air-gap update bundle for rollout now requires a valid offline license carrying
+  the `airgap_updates` feature; `bundle verify` stays free. The gate is fail-safe: a
+  missing/expired/invalid license simply means the feature is off and import is refused with
+  an actionable message — it never affects a running deployment. Gating strips nothing from
+  community builds: import already requires the embedded update-signing key that only release
+  builds carry. (ADR-065 Phase 2c, ADR-062) ([#491])
+
+### Security
+- **The absolute session-lifetime ceiling is enforced at validation** — a session is now
+  rejected once it passes its absolute lifetime cap even if the access token itself has not
+  expired, closing a window where a long-lived refresh chain could outlive the configured
+  ceiling. ([#489])
+
+### Internal
+- A regression test pinning that the SIEM-pull audit export carries the ADR-029 hash-chain
+  links (so an external SIEM can independently verify tamper-evidence). ([#490])
+
+[#489]: https://github.com/keyorixhq/keyorix/pull/489
+[#490]: https://github.com/keyorixhq/keyorix/pull/490
+[#491]: https://github.com/keyorixhq/keyorix/pull/491
+
 ## v0.83.0 — 2026-06-24
 
 Offline commercial-license validation — the second air-gap mechanism, fail-safe by design —

--- a/deploy/helm/keyorix-k8s-sync/Chart.yaml
+++ b/deploy/helm/keyorix-k8s-sync/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix-k8s-sync
 description: Keyorix Kubernetes sync agent — materialises Keyorix secrets into native Kubernetes Secrets
 type: application
 # Chart version — tracks the Keyorix release version (published in lockstep).
-version: 0.83.0
+version: 0.84.0
 # The keyorix-k8s-sync image tag this chart deploys by default.
-appVersion: "0.83.0"
+appVersion: "0.84.0"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix

--- a/deploy/helm/keyorix-operator/Chart.yaml
+++ b/deploy/helm/keyorix-operator/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix-operator
 description: Keyorix Kubernetes operator — reconciles KeyorixSecret resources into native Kubernetes Secrets
 type: application
 # Chart version — tracks the Keyorix release version (published in lockstep).
-version: 0.83.0
+version: 0.84.0
 # The keyorix-operator image tag this chart deploys by default.
-appVersion: "0.83.0"
+appVersion: "0.84.0"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix

--- a/deploy/helm/keyorix/Chart.yaml
+++ b/deploy/helm/keyorix/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix
 description: Self-hosted Keyorix secrets manager (API server + web UI + PostgreSQL)
 type: application
 # Chart version — bump on chart changes.
-version: 0.83.0
+version: 0.84.0
 # The Keyorix app version this chart deploys by default (the image tag).
-appVersion: "0.83.0"
+appVersion: "0.84.0"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix


### PR DESCRIPTION
Cuts **v0.84.0**, folding everything merged since v0.83.0 into the changelog and bumping the three Helm charts to 0.84.0.

Headline: the **first license-gated commercial feature** — `airgap_updates` gates `keyorix bundle import` (ADR-065 Phase 2c, #491). Staging an air-gap update for rollout now requires a valid offline license; `bundle verify` stays free, and the gate is fail-safe (a degraded license refuses import with an actionable message, never affecting a running deployment). Gating strips nothing from community builds.

Also: the **absolute session-lifetime ceiling is now enforced at validation** (#489) — a session past its absolute cap is rejected even if the access token hasn't expired.

No code changes — changelog + chart version bumps only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)