### PR TITLE
test(oidc): pin cross-issuer binding isolation for federated machine auth

### DIFF
--- a/internal/core/oidc_cross_issuer_test.go
+++ b/internal/core/oidc_cross_issuer_test.go
@@ -1,0 +1,83 @@
+package core
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/require"
+)
+
+// issuerKeyResolver returns a distinct signing key per issuer — i.e. each trusted issuer's
+// own JWKS. The verifier picks the key by the token's (configured) issuer, so a token can
+// only ever be validated against its own issuer's key.
+type issuerKeyResolver map[string]interface{}
+
+func (r issuerKeyResolver) Key(_ context.Context, issuer, _ string) (interface{}, error) {
+	if k, ok := r[issuer]; ok {
+		return k, nil
+	}
+	return nil, errTestNoKey
+}
+
+// TestValidateOIDCToken_CrossIssuerBindingIsolation pins the federated-auth trust property
+// (ADR-031): an OIDC machine binding is keyed by (issuer, subject) JOINTLY. A token validly
+// signed by ONE trusted issuer must not authenticate as a machine bound to a DIFFERENT
+// trusted issuer, even when the subject is identical. This is the multi-tenant / confused-
+// deputy defense: a second trusted issuer (another K8s cluster or CI provider) must not be
+// able to impersonate a machine bound to the first just by reusing the subject string.
+// Verify() pins the signing key to the token's configured issuer, and the binding lookup is
+// scoped by issuer, so a (issuer-B, subject) token resolves no (issuer-A, subject) binding.
+func TestValidateOIDCToken_CrossIssuerBindingIsolation(t *testing.T) {
+	keyA, _ := rsa.GenerateKey(rand.Reader, 2048)
+	keyB, _ := rsa.GenerateKey(rand.Reader, 2048)
+	const issA = "https://cluster-a.local"
+	const issB = "https://cluster-b.local"
+	const subject = "system:serviceaccount:ci:deployer"
+
+	v, err := NewOIDCVerifier(
+		[]OIDCTrustedIssuer{
+			{Issuer: issA, Audiences: []string{"keyorix"}},
+			{Issuer: issB, Audiences: []string{"keyorix"}},
+		},
+		issuerKeyResolver{issA: &keyA.PublicKey, issB: &keyB.PublicKey},
+	)
+	require.NoError(t, err)
+
+	store := new(MockStorage)
+	c := NewKeyorixCore(store)
+	c.SetOIDCVerifier(v)
+	ctx := context.Background()
+
+	// A machine is bound to (issuer A, subject) only — that exact tuple resolves; the same
+	// subject under issuer B resolves nothing.
+	machine := &models.MachineIdentity{ID: 7, State: MachineActive}
+	store.On("GetMachineByOIDCSubject", ctx, issA, subject).Return(machine, nil)
+	store.On("GetMachineByOIDCSubject", ctx, issB, subject).Return(nil, errTestNoKey)
+	store.On("GetMachineRoles", ctx, uint(7)).Return([]*models.Role{{Name: "ci-deployer"}}, nil)
+
+	claims := func(iss string) jwt.MapClaims {
+		return jwt.MapClaims{
+			"iss": iss, "sub": subject, "aud": []string{"keyorix"},
+			"exp": time.Now().Add(time.Hour).Unix(),
+		}
+	}
+
+	// Control: the genuine token from issuer A authenticates as the bound machine.
+	m, roles, err := c.ValidateOIDCToken(ctx, signToken(t, keyA, "kid-1", claims(issA)))
+	require.NoError(t, err)
+	require.Equal(t, uint(7), m.ID)
+	require.Equal(t, []string{"ci-deployer"}, roles)
+
+	// Attack: a VALID token from the OTHER trusted issuer, same subject, must NOT
+	// authenticate as machine 7 — no binding exists for (issuer B, subject).
+	_, _, err = c.ValidateOIDCToken(ctx, signToken(t, keyB, "kid-1", claims(issB)))
+	require.Error(t, err, "a token from a different trusted issuer must not resolve another issuer's binding")
+	require.Contains(t, err.Error(), "no machine identity bound")
+	// The lookup was scoped by the TOKEN's issuer (B), not the bound issuer (A).
+	store.AssertCalled(t, "GetMachineByOIDCSubject", ctx, issB, subject)
+}


### PR DESCRIPTION
## Federated machine-auth assurance: cross-issuer binding isolation

From a recon sweep of new areas (OIDC binding trust + secret-share redemption limits). Both came back **no bug** — the OIDC trust chain is correctly implemented (issuer pinned to config, JWKS fetched from config not the token, audience + expiry checked, binding scoped by issuer). This pins the one security-critical invariant that was **unguarded**.

### The invariant

An OIDC machine binding (ADR-031) is keyed by `(issuer, subject)` **jointly**: `Verify()` pins the signing key to the token's *configured* issuer, and `GetMachineByOIDCSubject` scopes the lookup by issuer — so a token from one trusted issuer cannot resolve a binding made for another. The existing OIDC tests cover untrusted-issuer / wrong-audience / expiry / bad-signature / bad-kid rejections, but **none** pinned cross-issuer **isolation among multiple trusted issuers** — the multi-tenant / confused-deputy case where a *second legitimately-trusted* issuer (another K8s cluster or CI provider) must not impersonate a machine bound to the first by reusing the subject string.

### The test

`TestValidateOIDCToken_CrossIssuerBindingIsolation` — two trusted issuers A and B with distinct signing keys, a machine bound to `(A, subject)`:
- **control** — the genuine token from A authenticates as the bound machine;
- **attack** — a **valid** token from trusted issuer B with the **same** subject is denied (`"no machine identity bound"`), and the binding lookup is asserted to have used the token's *own* issuer (B), not the bound issuer (A).

A regression that resolved bindings by subject alone, or dropped the issuer check from `Verify`, would fail this. Mirrors the `verify-trust-chain-not-just-signature` principle.

No production code change. `go build ./...` ✅ · core pkg ✅ · `golangci-lint ./...` 0 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)