### PR TITLE
release: finalize v0.85.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,28 @@
 All notable changes to Keyorix are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## v0.85.0 — 2026-06-24
+
+A proactive license-expiry reminder, plus break-glass and federated-auth boundary tests.
+
+### Added
+- **Background license-expiry reminder** — an opt-in scheduler (`license_expiry`) that
+  notifies install-wide admins when the offline commercial license is within its lead window
+  of expiry or has already expired, so a silent lapse (which degrades commercial features to
+  the community baseline) doesn't go unnoticed. It targets install-wide admins only
+  (`super_admin` / `admin` / `system_admin`, not project-scoped admins), is deduped so it
+  doesn't repeat on every tick, and is single-replica-gated in HA (ADR-039). The fail-safe
+  gate and `GET /api/v1/license/status` are unaffected. (ADR-065 Phase 2c) ([#496])
+
+### Internal
+- Security-boundary tests: an expired break-glass emergency grant denies authorization end
+  to end ([#494]), and federated machine-identity auth keeps cross-issuer bindings isolated
+  (a token from one issuer can't satisfy a binding for another) ([#495], ADR-031).
+
+[#494]: https://github.com/keyorixhq/keyorix/pull/494
+[#495]: https://github.com/keyorixhq/keyorix/pull/495
+[#496]: https://github.com/keyorixhq/keyorix/pull/496
+
 ## v0.84.0 — 2026-06-24
 
 The first commercial-licensed feature, plus session-lifetime hardening.

--- a/deploy/helm/keyorix-k8s-sync/Chart.yaml
+++ b/deploy/helm/keyorix-k8s-sync/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix-k8s-sync
 description: Keyorix Kubernetes sync agent — materialises Keyorix secrets into native Kubernetes Secrets
 type: application
 # Chart version — tracks the Keyorix release version (published in lockstep).
-version: 0.84.0
+version: 0.85.0
 # The keyorix-k8s-sync image tag this chart deploys by default.
-appVersion: "0.84.0"
+appVersion: "0.85.0"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix

--- a/deploy/helm/keyorix-operator/Chart.yaml
+++ b/deploy/helm/keyorix-operator/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix-operator
 description: Keyorix Kubernetes operator — reconciles KeyorixSecret resources into native Kubernetes Secrets
 type: application
 # Chart version — tracks the Keyorix release version (published in lockstep).
-version: 0.84.0
+version: 0.85.0
 # The keyorix-operator image tag this chart deploys by default.
-appVersion: "0.84.0"
+appVersion: "0.85.0"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix

--- a/deploy/helm/keyorix/Chart.yaml
+++ b/deploy/helm/keyorix/Chart.yaml
@@ -3,9 +3,9 @@ name: keyorix
 description: Self-hosted Keyorix secrets manager (API server + web UI + PostgreSQL)
 type: application
 # Chart version — bump on chart changes.
-version: 0.84.0
+version: 0.85.0
 # The Keyorix app version this chart deploys by default (the image tag).
-appVersion: "0.84.0"
+appVersion: "0.85.0"
 home: https://github.com/keyorixhq/keyorix
 sources:
   - https://github.com/keyorixhq/keyorix


### PR DESCRIPTION
Cuts **v0.85.0**, folding everything merged since v0.84.0 into the changelog and bumping the three Helm charts to 0.85.0.

Headline: a **background license-expiry reminder** (ADR-065 Phase 2c, #496) — an opt-in scheduler that notifies install-wide admins before/after the offline license lapses, so a silent expiry (which degrades commercial features to the community baseline) doesn't go unnoticed. Deduped, single-replica-gated, install-wide-admins only.

Also: break-glass and federated machine-auth boundary tests (#494, #495).

No code changes — changelog + chart version bumps only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)