### PR TITLE
test(assurance): close two logged gaps — SCIM deprovision e2e + rotation drift audit

### DIFF
--- a/internal/core/rotation_executor.go
+++ b/internal/core/rotation_executor.go
@@ -204,6 +204,19 @@ func (c *KeyorixCore) RunAutoRotation(ctx context.Context) (int, error) {
 			if _, rerr := c.RotateSecret(ctx, secret.ID, []byte(storeVal), "system:auto-rotation"); rerr != nil {
 				log.Printf("auto-rotation: rotate secret %d: %v", secret.ID, rerr)
 				failed[secret.ID] = fmt.Sprintf("%q: store new version: %v", secret.Name, rerr)
+				sid := secret.ID
+				if secret.RotationBackend != "" {
+					// The upstream credential was rotated but storing the new value failed:
+					// the live credential and Keyorix's record have now DRIFTED. Audit it
+					// distinctly (the backend-apply-failure path above is audited too) so an
+					// operator can reconcile — the live secret may no longer match Keyorix.
+					c.writeAuditEvent(ctx, EventSecretAutoRotated, nil, &sid,
+						fmt.Sprintf("auto-rotation DRIFT for secret %q: backend %q ref %q rotated upstream but storing the new value failed: %v — the live credential may no longer match Keyorix",
+							secret.Name, secret.RotationBackend, secret.RotationRef, rerr))
+				} else {
+					c.writeAuditEvent(ctx, EventSecretAutoRotated, nil, &sid,
+						fmt.Sprintf("auto-rotation FAILED to store new version for secret %q: %v", secret.Name, rerr))
+				}
 				continue
 			}
 			delete(failed, secret.ID) // rotated successfully (e.g. under a later policy)

--- a/internal/core/rotation_executor_test.go
+++ b/internal/core/rotation_executor_test.go
@@ -404,3 +404,39 @@ func TestRunAutoRotation_NoFailuresNoNotify(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, sink.events)
 }
+
+// rotationDriftStore wraps LocalStorage and fails UpdateSecret, so RotateSecret errors AFTER
+// the backend executor has already applied the new credential upstream — the split-brain /
+// drift case.
+type rotationDriftStore struct {
+	*store.LocalStorage
+}
+
+func (s *rotationDriftStore) UpdateSecret(_ context.Context, _ *models.SecretNode) (*models.SecretNode, error) {
+	return nil, errors.New("simulated storage failure after upstream rotation")
+}
+
+// TestRunAutoRotation_BackendSucceedsStoreFails_AuditsDrift pins that the most dangerous
+// rotation outcome — the upstream credential is rotated but storing the new value in Keyorix
+// fails — is audited distinctly. Before the fix this path only logged + reported a generic
+// failure; the live credential could drift from Keyorix's record with no audit trail. The
+// backend-apply-FAILURE path was already audited; this closes the asymmetry.
+func TestRunAutoRotation_BackendSucceedsStoreFails_AuditsDrift(t *testing.T) {
+	fake := &fakeExecutor{name: "pg"}
+	c, db, fixed := backendPolicyCore(t, fake)
+	// Make the post-backend store fail: RotateSecret's final UpdateSecret errors.
+	c.storage = &rotationDriftStore{LocalStorage: c.storage.(*store.LocalStorage)}
+	seedBackendSecret(t, db, 1, "pg", "app_svc", fixed.Add(-60*24*time.Hour))
+
+	n, err := c.RunAutoRotation(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 0, n, "the rotation did not complete — the store failed")
+	require.True(t, fake.called, "the upstream backend WAS rotated (so the credential changed)")
+
+	// Exactly one auto-rotation audit event, and it flags the drift distinctly.
+	var events []models.AuditEvent
+	require.NoError(t, db.Where("event_type = ?", EventSecretAutoRotated).Find(&events).Error)
+	require.Len(t, events, 1)
+	assert.Contains(t, events[0].Description, "DRIFT", "the backend-succeeded-store-failed case must be audited as drift")
+	assert.Contains(t, events[0].Description, "app_svc", "the audit must name the upstream ref to reconcile")
+}

--- a/internal/core/scim_deprovision_test.go
+++ b/internal/core/scim_deprovision_test.go
@@ -1,0 +1,57 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// TestDeprovisionSCIMUser_RevokesSessionAndPAT is the end-to-end deprovision invariant: once
+// an IdP deprovisions a user (SCIM DELETE), that user must be unable to authenticate via ANY
+// credential — neither a live session token nor a personal access token. DeprovisionSCIMUser
+// suspends the account, kills its sessions, and soft-deletes the user atomically; this drives
+// the real flow through LocalStorage and asserts both auth paths reject the user afterward.
+func TestDeprovisionSCIMUser_RevokesSessionAndPAT(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.User{}, &models.Session{}, &models.PersonalAccessToken{}, &models.AuditEvent{}))
+
+	ls := store.NewLocalStorage(db)
+	c := NewKeyorixCore(ls)
+	ctx := context.Background()
+
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "alice", IsActive: true, AccountState: AccountActive}).Error)
+	expiry := time.Now().Add(time.Hour)
+	require.NoError(t, db.Create(&models.Session{ID: 1, UserID: 1, SessionToken: "sess-tok", ExpiresAt: &expiry}).Error)
+	raw := patPrefix + "deprovision-regression-token"
+	require.NoError(t, db.Create(&models.PersonalAccessToken{ID: 1, UserID: 1, Name: "ci", TokenHash: sha256Hex(raw)}).Error)
+
+	// Preconditions: while active, both the session and the PAT validate.
+	su, _, err := c.ValidateSessionToken(ctx, "sess-tok")
+	require.NoError(t, err)
+	require.Equal(t, uint(1), su.ID)
+	pu, _, _, err := c.ValidatePATToken(ctx, raw)
+	require.NoError(t, err)
+	require.Equal(t, uint(1), pu.ID)
+
+	// IdP deprovisions the user (actor id 2).
+	require.NoError(t, c.DeprovisionSCIMUser(ctx, 2, 1))
+
+	// Neither credential may authenticate the deprovisioned user any longer.
+	_, _, err = c.ValidateSessionToken(ctx, "sess-tok")
+	require.Error(t, err, "a deprovisioned user's session must not validate")
+	_, _, _, err = c.ValidatePATToken(ctx, raw)
+	require.Error(t, err, "a deprovisioned user's PAT must not validate")
+
+	// And the user is soft-deleted — no longer resolvable.
+	_, err = ls.GetUser(ctx, 1)
+	require.Error(t, err, "a deprovisioned user must be soft-deleted")
+}


### PR DESCRIPTION
## Assurance mop-up: the two remaining logged gaps

Closes out the assurance pass by pinning the last two logged items.

### 1. SCIM deprovision — end-to-end (test only)

`TestDeprovisionSCIMUser_RevokesSessionAndPAT` drives the real `DeprovisionSCIMUser` flow through `LocalStorage` and asserts that once a user is deprovisioned (SCIM DELETE), **neither a held session token nor a personal access token still validates**, and the user is soft-deleted. Complements #492 (suspend → PAT denied) by pinning the full deprovision lifecycle.

### 2. Rotation drift — distinct audit (fix + test)

Auto-rotation's **most dangerous outcome** — the upstream credential is rotated but storing the new value in Keyorix fails, so the live credential and Keyorix's record **drift** — was only logged + reported in the failure summary, **never audited**. Yet the backend-apply-*failure* path right above it *was* audited. That asymmetry meant the one case where an operator most needs an audit trail (the live secret may no longer match Keyorix) had none.

`RunAutoRotation` now writes a distinct **`DRIFT`** audit event when a backend rotation succeeded but the store failed (and a plain store-failure audit when no backend was involved), so every rotation outcome is now auditable.

`TestRunAutoRotation_BackendSucceedsStoreFails_AuditsDrift` wraps storage to fail `RotateSecret`'s final `UpdateSecret` *after* the fake backend applies upstream, then asserts exactly one `DRIFT` audit naming the ref. **Verified it fails without the fix** (no audit event was written).

`go build ./...` ✅ · core pkg ✅ · `golangci-lint ./...` 0 ✅ · `gosec` 0 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)