### PR TITLE
test(evidence): a wrong-key signature with the right version label is rejected

### DIFF
--- a/internal/core/evidence_signing_test.go
+++ b/internal/core/evidence_signing_test.go
@@ -37,6 +37,33 @@ func TestEvidenceSignature_RoundTrip(t *testing.T) {
 	assert.False(t, c.VerifyEvidenceSignature(data, "garbage").Valid)
 }
 
+// TestEvidenceSignature_WrongKeySameVersionRejected pins that the key-version label is NOT a
+// credential: a signature carrying the right version prefix but produced by a DIFFERENT key
+// (another deployment) must be rejected as a mismatch, not accepted. The HMAC's secret key is
+// what proves authenticity; the version label is public. A regression that only compared the
+// version string (skipping the constant-time HMAC check) would pass every other test but make
+// evidence signatures trivially forgeable — this catches it.
+func TestEvidenceSignature_WrongKeySameVersionRejected(t *testing.T) {
+	data := []byte(`{"generated_at":"2026-06-15T00:00:00Z"}`)
+
+	// A different deployment signs the same data with ITS OWN key, under the same "v1" label.
+	other := &KeyorixCore{}
+	other.SetEvidenceSignKey([]byte("ffffffffffffffffffffffffffffffff"), "v1")
+	foreignSig, ok := other.signEvidence(data)
+	require.True(t, ok)
+	require.True(t, strings.HasPrefix(foreignSig, "v1:"))
+
+	// This deployment has a DIFFERENT key under the same version label. The version matches
+	// (so we reach the HMAC check, not the superseded-version early-return), but the key
+	// differs, so verification must report a mismatch.
+	c := &KeyorixCore{}
+	c.SetEvidenceSignKey([]byte("0123456789abcdef0123456789abcdef"), "v1")
+	res := c.VerifyEvidenceSignature(data, foreignSig)
+	assert.False(t, res.Valid, "a signature from a different deployment's key must not verify")
+	assert.Contains(t, res.Reason, "does not match")
+	assert.NotContains(t, res.Reason, "superseded", "the version matched — the HMAC check, not version handling, must reject it")
+}
+
 func TestEvidenceSignature_UnavailableWithoutKey(t *testing.T) {
 	c := &KeyorixCore{}
 	assert.False(t, c.EvidenceSigningAvailable())


### PR DESCRIPTION
## Evidence-signature unforgeability: the version label is not a credential

From a recon of the outbound-signing surface (webhook/delivery, evidence packs, audit checkpoints). The signing primitives are sound — notification webhooks use Bearer auth (by design), evidence packs carry a detached HMAC signature with constant-time verification and key-version pinning. This pins the one security property in the evidence-signing verifier that was unguarded.

### The invariant

An evidence signature is `"<keyVersion>:<hmac-hex>"`. The `keyVersion` label is **public** (it travels with the pack); the **secret HMAC key** is what proves authenticity. The existing tests cover valid round-trip, tampered data, a superseded version (reported distinctly), malformed input, and unavailable signing — but **not** the cross-deployment forgery case: a signature carrying the right version prefix but produced by a *different key* must be rejected.

### The test

`TestEvidenceSignature_WrongKeySameVersionRejected` — another deployment signs the same data with its own key under the same `"v1"` label; this deployment (different key, same label) must report **`does not match`**, and crucially **not** `superseded` — so we know the **HMAC check** (not the version early-return) is what rejected it. A regression that compared only the version string would pass every other test yet make evidence signatures trivially forgeable; this catches it.

No production code change. `go build ./...` ✅ · core pkg ✅ · `golangci-lint ./...` 0 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)