### PR TITLE
feat(pat): network (IP/CIDR) allowlist for personal access tokens (ADR-066)

### DIFF
--- a/docs/adr-066-token-ip-allowlist.md
+++ b/docs/adr-066-token-ip-allowlist.md
@@ -1,0 +1,60 @@
+# ADR-066: Network (IP/CIDR) allowlist for personal access tokens
+
+## Status
+
+Accepted. Extends the PAT least-privilege model (ADR-042: scopes + project/environment
+confinement) with a network dimension.
+
+## Context
+
+A personal access token is a bearer credential: whoever holds the string can use it. ADR-042
+narrows *what* a token can do (permission scopes, project/environment confinement), but not
+*from where* it can be used. A token leaked from CI logs, a laptop, or a `.env` file is
+fully usable from anywhere on the internet until it is noticed and revoked. Regulated buyers
+(NIS2 Art. 21 access control, DORA, ENS `op.acc.*`) routinely require that machine
+credentials be usable only from known networks.
+
+## Decision
+
+Add an optional **CIDR allowlist** to a personal access token. When set, a request
+presenting the token is accepted only if its source IP falls within one of the listed CIDR
+blocks; otherwise it is denied with `403`.
+
+- **Storage.** `PersonalAccessToken.AllowedCIDRs` — a JSON `[]string` of CIDRs (a bare IP is
+  normalised to a `/32`/`/128` host route). Empty = no restriction (the back-compat
+  default). CIDRs are validated at creation; an invalid block is rejected.
+- **Enforcement at the auth boundary.** The allowlist rides on the resolved
+  `PATRestriction`, and the authentication middleware checks the request's source IP against
+  it **on every request** — including cache hits, since the same token may arrive from
+  different IPs. It **fails closed**: an undeterminable or unparseable source IP is denied.
+- **The source IP is the TCP peer (`RemoteAddr`), never a client-supplied header**
+  (`X-Forwarded-For` is attacker-controlled and would make the control trivially bypassable).
+  A deployment behind a reverse proxy must therefore terminate so `RemoteAddr` is the real
+  client (e.g. PROXY protocol) for per-client allowlists to apply — documented as an
+  operational requirement.
+- **Surface.** `keyorix pat create --allowed-cidr 10.0.0.0/8` (repeatable), the
+  `allowed_cidrs` field on the create API and token list, and a `from=…` segment in the CLI
+  token-scope summary.
+
+## Alternatives considered
+
+- **Trust `X-Forwarded-For`.** Rejected: a security control keyed on a spoofable header is
+  no control. Trusting it requires explicit trusted-proxy configuration, which is a separate
+  concern; `RemoteAddr` is the safe default.
+- **Enforce inside `ValidatePATToken` (the DB lookup).** Rejected: the result is cached, and
+  the network check must run per-request against the live source IP, so it belongs at the
+  per-request middleware chokepoint, after the (possibly cached) identity is resolved.
+- **A global network policy instead of per-token.** Useful but coarser; per-token matches the
+  ADR-042 least-privilege model and lets one workload's CI token be pinned without
+  constraining interactive admins.
+
+## Consequences
+
+- Additive and behaviour-neutral by default: a token with no allowlist behaves exactly as
+  before. The column is added by AutoMigrate; existing rows decode to "no restriction".
+- Fail-closed: a misconfigured allowlist (or a proxy that hides the client IP) locks the
+  token out rather than failing open — the safe direction for a credential control.
+- Composes with ADR-042: a token can be simultaneously permission-scoped, project/environment
+  confined, and network-restricted.
+- A natural follow-up is the same allowlist on machine-identity tokens (ADR-023), which
+  reuses `IPInCIDRs` and the same enforcement seam.

--- a/internal/cli/pat/pat.go
+++ b/internal/cli/pat/pat.go
@@ -31,6 +31,7 @@ var (
 	flagScopes  []string
 	flagProject int
 	flagEnv     int
+	flagCIDRs   []string
 )
 
 func init() {
@@ -39,6 +40,7 @@ func init() {
 	createCmd.Flags().StringArrayVar(&flagScopes, "scope", nil, "Least-privilege permission (repeatable; e.g. --scope secrets.read). Omit = inherit all your permissions")
 	createCmd.Flags().IntVar(&flagProject, "project-id", 0, "Confine the token to a single project (0 = any)")
 	createCmd.Flags().IntVar(&flagEnv, "environment-id", 0, "Confine the token to a single environment (0 = any; only with --project-id)")
+	createCmd.Flags().StringArrayVar(&flagCIDRs, "allowed-cidr", nil, "Restrict the token to source IPs in this CIDR (repeatable; e.g. --allowed-cidr 10.0.0.0/8). Omit = no network restriction")
 	PATCmd.AddCommand(createCmd, listCmd, revokeCmd)
 }
 
@@ -61,6 +63,7 @@ type patView struct {
 	Scopes           []string `json:"scopes"`
 	ProjectScope     uint     `json:"project_scope"`
 	EnvironmentScope uint     `json:"environment_scope"`
+	AllowedCIDRs     []string `json:"allowed_cidrs"`
 }
 
 var createCmd = &cobra.Command{
@@ -83,6 +86,9 @@ var createCmd = &cobra.Command{
 		}
 		if len(flagScopes) > 0 {
 			body["scopes"] = flagScopes
+		}
+		if len(flagCIDRs) > 0 {
+			body["allowed_cidrs"] = flagCIDRs
 		}
 		if flagProject > 0 {
 			body["project_scope"] = flagProject
@@ -189,10 +195,10 @@ func normalizeExpiry(v string) (string, error) {
 
 // describeScope renders a one-line summary of a token's least-privilege restriction.
 func describeScope(t patView) string {
-	if len(t.Scopes) == 0 && t.ProjectScope == 0 && t.EnvironmentScope == 0 {
+	if len(t.Scopes) == 0 && t.ProjectScope == 0 && t.EnvironmentScope == 0 && len(t.AllowedCIDRs) == 0 {
 		return "full access"
 	}
-	parts := make([]string, 0, 3)
+	parts := make([]string, 0, 4)
 	if t.ProjectScope > 0 {
 		parts = append(parts, fmt.Sprintf("project=%d", t.ProjectScope))
 	}
@@ -201,6 +207,9 @@ func describeScope(t patView) string {
 	}
 	if len(t.Scopes) > 0 {
 		parts = append(parts, strings.Join(t.Scopes, ","))
+	}
+	if len(t.AllowedCIDRs) > 0 {
+		parts = append(parts, "from="+strings.Join(t.AllowedCIDRs, ","))
 	}
 	return strings.Join(parts, " ")
 }

--- a/internal/core/authz.go
+++ b/internal/core/authz.go
@@ -11,6 +11,7 @@ package core
 
 import (
 	"context"
+	"net"
 	"strings"
 
 	"github.com/keyorixhq/keyorix/internal/core/storage"
@@ -41,6 +42,31 @@ type PATRestriction struct {
 	// environment-scoped token — correct least privilege for, e.g., a staging-only
 	// CI credential.)
 	EnvironmentID uint
+	// AllowedCIDRs, when non-empty, restricts the token to requests whose source IP falls
+	// within one of the listed CIDR blocks. Enforced at the auth boundary (fail-closed: an
+	// undeterminable/unparseable source IP is denied). Empty = no network restriction.
+	AllowedCIDRs []string
+}
+
+// IPInCIDRs reports whether ip (a bare host like "203.0.113.7") falls within any of the
+// given CIDR blocks. It is the network gate for IP-allowlisted tokens and fails CLOSED:
+// an unparseable ip, an empty cidr list passed as a gate, or a malformed CIDR yields false
+// (callers only invoke it when the token actually carries an allowlist).
+func IPInCIDRs(ip string, cidrs []string) bool {
+	addr := net.ParseIP(strings.TrimSpace(ip))
+	if addr == nil {
+		return false
+	}
+	for _, c := range cidrs {
+		_, network, err := net.ParseCIDR(strings.TrimSpace(c))
+		if err != nil {
+			continue
+		}
+		if network.Contains(addr) {
+			return true
+		}
+	}
+	return false
 }
 
 // Allows reports whether this restriction permits exercising permission at scope.

--- a/internal/core/pat.go
+++ b/internal/core/pat.go
@@ -17,6 +17,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"net"
 	"strings"
 	"time"
 
@@ -45,7 +46,7 @@ type CreatePATResult struct {
 // token below its owner — they are enforced at request time as a filter
 // intersected with the owner's live permissions, so a token can never grant more
 // than its owner currently holds.
-func (c *KeyorixCore) CreateOwnPAT(ctx context.Context, userID uint, name string, expiresAt *time.Time, scopes []string, projectScope, environmentScope uint) (*CreatePATResult, error) {
+func (c *KeyorixCore) CreateOwnPAT(ctx context.Context, userID uint, name string, expiresAt *time.Time, scopes []string, projectScope, environmentScope uint, allowedCIDRs []string) (*CreatePATResult, error) {
 	if userID == 0 {
 		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "user ID is required")
 	}
@@ -54,6 +55,11 @@ func (c *KeyorixCore) CreateOwnPAT(ctx context.Context, userID uint, name string
 	}
 
 	scopesJSON, err := encodePATScopes(scopes)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorValidation", nil), err)
+	}
+
+	cidrsJSON, err := encodePATCIDRs(allowedCIDRs)
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorValidation", nil), err)
 	}
@@ -72,6 +78,7 @@ func (c *KeyorixCore) CreateOwnPAT(ctx context.Context, userID uint, name string
 		Scopes:           scopesJSON,
 		ProjectScope:     projectScope,
 		EnvironmentScope: environmentScope,
+		AllowedCIDRs:     cidrsJSON,
 		ExpiresAt:        expiresAt,
 		CreatedAt:        c.now(),
 	}
@@ -202,8 +209,63 @@ func DecodePATScopes(raw string) []string {
 // the token is unrestricted (no scopes and no project confinement).
 func patRestrictionFrom(pat *models.PersonalAccessToken) *PATRestriction {
 	scopes := DecodePATScopes(pat.Scopes)
-	if len(scopes) == 0 && pat.ProjectScope == 0 && pat.EnvironmentScope == 0 {
+	cidrs := DecodePATCIDRs(pat.AllowedCIDRs)
+	if len(scopes) == 0 && pat.ProjectScope == 0 && pat.EnvironmentScope == 0 && len(cidrs) == 0 {
 		return nil
 	}
-	return &PATRestriction{Permissions: scopes, ProjectID: pat.ProjectScope, EnvironmentID: pat.EnvironmentScope}
+	return &PATRestriction{Permissions: scopes, ProjectID: pat.ProjectScope, EnvironmentID: pat.EnvironmentScope, AllowedCIDRs: cidrs}
+}
+
+// encodePATCIDRs validates and JSON-encodes a CIDR allowlist for storage. Each entry must
+// be a parseable CIDR (e.g. "10.0.0.0/8"); a bare IP is accepted and normalised to a /32
+// or /128 host route. Blanks are dropped and duplicates removed; an empty result encodes to
+// "" (no network restriction, the back-compat default).
+func encodePATCIDRs(cidrs []string) (string, error) {
+	cleaned := make([]string, 0, len(cidrs))
+	seen := make(map[string]struct{}, len(cidrs))
+	for _, c := range cidrs {
+		c = strings.TrimSpace(c)
+		if c == "" {
+			continue
+		}
+		// Accept a bare IP by promoting it to a host route.
+		if !strings.Contains(c, "/") {
+			if ip := net.ParseIP(c); ip != nil {
+				if ip.To4() != nil {
+					c += "/32"
+				} else {
+					c += "/128"
+				}
+			}
+		}
+		if _, _, err := net.ParseCIDR(c); err != nil {
+			return "", fmt.Errorf("invalid CIDR %q", c)
+		}
+		if _, dup := seen[c]; dup {
+			continue
+		}
+		seen[c] = struct{}{}
+		cleaned = append(cleaned, c)
+	}
+	if len(cleaned) == 0 {
+		return "", nil
+	}
+	b, err := json.Marshal(cleaned)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+// DecodePATCIDRs parses a stored CIDR allowlist back into a slice. An empty/invalid column
+// yields nil (no restriction).
+func DecodePATCIDRs(raw string) []string {
+	if strings.TrimSpace(raw) == "" {
+		return nil
+	}
+	var out []string
+	if err := json.Unmarshal([]byte(raw), &out); err != nil {
+		return nil
+	}
+	return out
 }

--- a/internal/core/pat_cidr_test.go
+++ b/internal/core/pat_cidr_test.go
@@ -1,0 +1,62 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIPInCIDRs(t *testing.T) {
+	cidrs := []string{"10.0.0.0/8", "192.0.2.4/32", "2001:db8::/32"}
+	cases := []struct {
+		ip   string
+		want bool
+	}{
+		{"10.1.2.3", true},      // inside 10/8
+		{"192.0.2.4", true},     // exact /32
+		{"192.0.2.5", false},    // adjacent to the /32
+		{"203.0.113.9", false},  // outside all
+		{"2001:db8::1", true},   // inside the v6 block
+		{"2001:dead::1", false}, // outside the v6 block
+		{"not-an-ip", false},    // unparseable → fail closed
+		{"", false},             // empty → fail closed
+	}
+	for _, c := range cases {
+		assert.Equalf(t, c.want, IPInCIDRs(c.ip, cidrs), "ip=%s", c.ip)
+	}
+	// An empty allowlist passed as a gate denies (fail closed); callers only invoke it
+	// when the token actually carries an allowlist.
+	assert.False(t, IPInCIDRs("10.1.2.3", nil))
+	// A malformed CIDR in the list is skipped, not fatal.
+	assert.True(t, IPInCIDRs("10.1.2.3", []string{"garbage", "10.0.0.0/8"}))
+}
+
+func TestEncodePATCIDRs(t *testing.T) {
+	// Valid CIDRs + a bare IP (promoted to a host route), deduped.
+	enc, err := encodePATCIDRs([]string{"10.0.0.0/8", " 192.0.2.4 ", "10.0.0.0/8", ""})
+	assert.NoError(t, err)
+	got := DecodePATCIDRs(enc)
+	assert.ElementsMatch(t, []string{"10.0.0.0/8", "192.0.2.4/32"}, got)
+
+	// All-blank encodes to "" (no restriction).
+	enc, err = encodePATCIDRs([]string{"", "  "})
+	assert.NoError(t, err)
+	assert.Equal(t, "", enc)
+	assert.Nil(t, DecodePATCIDRs(enc))
+
+	// An invalid CIDR is rejected at creation.
+	_, err = encodePATCIDRs([]string{"10.0.0.0/8", "not-a-cidr"})
+	assert.Error(t, err)
+}
+
+func TestPATRestrictionFrom_IncludesCIDRs(t *testing.T) {
+	// A token with ONLY a CIDR allowlist (no scope/project) still yields a restriction.
+	enc, _ := encodePATCIDRs([]string{"10.0.0.0/8"})
+	r := patRestrictionFrom(&models.PersonalAccessToken{AllowedCIDRs: enc})
+	if assert.NotNil(t, r) {
+		assert.Equal(t, []string{"10.0.0.0/8"}, r.AllowedCIDRs)
+	}
+	// A fully-unrestricted token yields nil.
+	assert.Nil(t, patRestrictionFrom(&models.PersonalAccessToken{}))
+}

--- a/internal/core/pat_scoping_e2e_test.go
+++ b/internal/core/pat_scoping_e2e_test.go
@@ -55,7 +55,7 @@ func TestPATScoping_EndToEnd_RealRBAC(t *testing.T) {
 	})
 
 	t.Run("permission-scoped PAT bounds the admin to read-only", func(t *testing.T) {
-		res, err := c.CreateOwnPAT(ctx, admin.ID, "ci-read", nil, []string{"secrets.read"}, 0, 0)
+		res, err := c.CreateOwnPAT(ctx, admin.ID, "ci-read", nil, []string{"secrets.read"}, 0, 0, nil)
 		require.NoError(t, err)
 
 		user, _, restriction, err := c.ValidatePATToken(ctx, res.PlainToken)
@@ -74,7 +74,7 @@ func TestPATScoping_EndToEnd_RealRBAC(t *testing.T) {
 	})
 
 	t.Run("project-scoped PAT is confined to its project", func(t *testing.T) {
-		res, err := c.CreateOwnPAT(ctx, admin.ID, "ci-proj3", nil, nil, 3, 0)
+		res, err := c.CreateOwnPAT(ctx, admin.ID, "ci-proj3", nil, nil, 3, 0, nil)
 		require.NoError(t, err)
 		_, _, restriction, err := c.ValidatePATToken(ctx, res.PlainToken)
 		require.NoError(t, err)
@@ -95,7 +95,7 @@ func TestPATScoping_EndToEnd_RealRBAC(t *testing.T) {
 	})
 
 	t.Run("environment-scoped PAT is confined to its environment", func(t *testing.T) {
-		res, err := c.CreateOwnPAT(ctx, admin.ID, "ci-env7", nil, nil, 0, 7) // env 7 only
+		res, err := c.CreateOwnPAT(ctx, admin.ID, "ci-env7", nil, nil, 0, 7, nil) // env 7 only
 		require.NoError(t, err)
 		_, _, restriction, err := c.ValidatePATToken(ctx, res.PlainToken)
 		require.NoError(t, err)
@@ -117,7 +117,7 @@ func TestPATScoping_EndToEnd_RealRBAC(t *testing.T) {
 	})
 
 	t.Run("unrestricted PAT resolves to no restriction and keeps full inheritance", func(t *testing.T) {
-		res, err := c.CreateOwnPAT(ctx, admin.ID, "ci-full", nil, nil, 0, 0)
+		res, err := c.CreateOwnPAT(ctx, admin.ID, "ci-full", nil, nil, 0, 0, nil)
 		require.NoError(t, err)
 		_, _, restriction, err := c.ValidatePATToken(ctx, res.PlainToken)
 		require.NoError(t, err)

--- a/internal/core/pat_test.go
+++ b/internal/core/pat_test.go
@@ -23,7 +23,7 @@ func TestCreateOwnPAT(t *testing.T) {
 			Run(func(args mock.Arguments) { captured = args.Get(1).(*models.PersonalAccessToken) }).
 			Return(&models.PersonalAccessToken{ID: 1}, nil)
 
-		res, err := c.CreateOwnPAT(ctx, 1, "ci-token", nil, nil, 0, 0)
+		res, err := c.CreateOwnPAT(ctx, 1, "ci-token", nil, nil, 0, 0, nil)
 		require.NoError(t, err)
 		assert.True(t, strings.HasPrefix(res.PlainToken, patPrefix), "raw token carries the kx_pat_ prefix")
 		require.NotNil(t, captured)
@@ -42,7 +42,7 @@ func TestCreateOwnPAT(t *testing.T) {
 			Run(func(args mock.Arguments) { captured = args.Get(1).(*models.PersonalAccessToken) }).
 			Return(&models.PersonalAccessToken{ID: 1}, nil)
 
-		_, err := c.CreateOwnPAT(ctx, 1, "ci-read-only", nil, []string{"secrets.read", "  ", "secrets.read"}, 7, 0)
+		_, err := c.CreateOwnPAT(ctx, 1, "ci-read-only", nil, []string{"secrets.read", "  ", "secrets.read"}, 7, 0, nil)
 		require.NoError(t, err)
 		require.NotNil(t, captured)
 		// Blanks dropped, duplicates removed, encoded as JSON.
@@ -58,7 +58,7 @@ func TestCreateOwnPAT(t *testing.T) {
 	t.Run("rejects an empty name", func(t *testing.T) {
 		ms := new(MockStorage)
 		c := NewKeyorixCore(ms)
-		_, err := c.CreateOwnPAT(ctx, 1, "   ", nil, nil, 0, 0)
+		_, err := c.CreateOwnPAT(ctx, 1, "   ", nil, nil, 0, 0, nil)
 		require.Error(t, err)
 		ms.AssertNotCalled(t, "CreatePersonalAccessToken", mock.Anything, mock.Anything)
 	})

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -631,10 +631,15 @@ type PersonalAccessToken struct {
 	// environment (ADR-042). 0 = any environment. Environment ids are globally
 	// unique, so this also pins the project.
 	EnvironmentScope uint `gorm:"default:0"`
-	LastUsedAt       *time.Time
-	ExpiresAt        *time.Time // nil = never expires
-	Revoked          bool       `gorm:"default:false"`
-	CreatedAt        time.Time
+	// AllowedCIDRs is a JSON-encoded []string of CIDR blocks the token may be used from
+	// (e.g. ["10.0.0.0/8","192.0.2.4/32"]). Empty/null = no network restriction (the
+	// default). When set, a request presenting this token from a source IP outside every
+	// listed CIDR is denied — a stolen token is useless off the allowed network.
+	AllowedCIDRs string `gorm:"type:text"`
+	LastUsedAt   *time.Time
+	ExpiresAt    *time.Time // nil = never expires
+	Revoked      bool       `gorm:"default:false"`
+	CreatedAt    time.Time
 }
 
 // SetupToken is the single-use, hashed-at-rest bearer string that lets a brand-new

--- a/server/grpc/interceptors/auth_test.go
+++ b/server/grpc/interceptors/auth_test.go
@@ -160,7 +160,7 @@ func TestAuthInterceptor_PATAuthenticatesAndEnforcesScope(t *testing.T) {
 	h.AssignUserRole(t, 9100, 3, &proj2) // editor (secrets.read + secrets.write) in project 2
 
 	// A token confined to secrets.read in project 2 only.
-	res, err := h.CoreService.CreateOwnPAT(context.Background(), 9100, "ci", nil, []string{"secrets.read"}, 2, 0)
+	res, err := h.CoreService.CreateOwnPAT(context.Background(), 9100, "ci", nil, []string{"secrets.read"}, 2, 0, nil)
 	require.NoError(t, err)
 	require.True(t, strings.HasPrefix(res.PlainToken, "kx_pat_"))
 

--- a/server/http/handlers/pat_handler.go
+++ b/server/http/handlers/pat_handler.go
@@ -43,6 +43,7 @@ type patResponse struct {
 	Scopes           []string `json:"scopes"`            // empty = inherits the owner's full permissions
 	ProjectScope     uint     `json:"project_scope"`     // 0 = any project the owner can reach
 	EnvironmentScope uint     `json:"environment_scope"` // 0 = any environment
+	AllowedCIDRs     []string `json:"allowed_cidrs"`     // empty = no network restriction
 }
 
 func toPATResponse(t *models.PersonalAccessToken) patResponse {
@@ -55,6 +56,7 @@ func toPATResponse(t *models.PersonalAccessToken) patResponse {
 		Scopes:           core.DecodePATScopes(t.Scopes),
 		ProjectScope:     t.ProjectScope,
 		EnvironmentScope: t.EnvironmentScope,
+		AllowedCIDRs:     core.DecodePATCIDRs(t.AllowedCIDRs),
 	}
 	if t.ExpiresAt != nil {
 		v := t.ExpiresAt.UTC().Format(time.RFC3339)
@@ -141,6 +143,9 @@ type createPATRequestBody struct {
 	ProjectScope uint `json:"project_scope"`
 	// EnvironmentScope optionally confines the token to one environment (0/omit = any).
 	EnvironmentScope uint `json:"environment_scope"`
+	// AllowedCIDRs optionally restricts the token to source IPs within these CIDR blocks
+	// (e.g. ["10.0.0.0/8"]). Omit/empty = no network restriction.
+	AllowedCIDRs []string `json:"allowed_cidrs"`
 }
 
 // CreatePAT handles POST /auth/tokens. The raw token is returned exactly once.
@@ -166,7 +171,7 @@ func (h *PATHandler) CreatePAT(w http.ResponseWriter, r *http.Request) {
 		expiresAt = &t
 	}
 
-	result, err := h.coreService.CreateOwnPAT(r.Context(), userCtx.UserID, body.Name, expiresAt, body.Scopes, body.ProjectScope, body.EnvironmentScope)
+	result, err := h.coreService.CreateOwnPAT(r.Context(), userCtx.UserID, body.Name, expiresAt, body.Scopes, body.ProjectScope, body.EnvironmentScope, body.AllowedCIDRs)
 	if err != nil {
 		sendError(w, "BadRequest", err.Error(), http.StatusBadRequest, nil)
 		return

--- a/server/middleware/auth.go
+++ b/server/middleware/auth.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"strconv"
 	"strings"
@@ -194,6 +195,12 @@ func authenticationWithValidator(validator sessionValidator, coreService *core.K
 					unauthorizedResponse(w, "Invalid or expired token")
 					return
 				}
+				// The network allowlist is per-request (the same token may arrive from a
+				// different IP), so enforce it even on a cache hit.
+				if !tokenNetworkAllowed(r, entry.userCtx) {
+					forbiddenResponse(w, "token not permitted from this network")
+					return
+				}
 				next.ServeHTTP(w, r.WithContext(buildRequestContext(r.Context(), entry.userCtx, coreService)))
 				return
 			}
@@ -217,6 +224,10 @@ func authenticationWithValidator(validator sessionValidator, coreService *core.K
 			// Cache the positive result.
 			cacheSet(key, tokenCacheEntry{userCtx: userCtx, expiresAt: time.Now().Add(validTokenTTL)})
 
+			if !tokenNetworkAllowed(r, userCtx) {
+				forbiddenResponse(w, "token not permitted from this network")
+				return
+			}
 			next.ServeHTTP(w, r.WithContext(buildRequestContext(r.Context(), userCtx, coreService)))
 		})
 	}
@@ -660,6 +671,27 @@ func validateToken(ctx context.Context, validator sessionValidator, token string
 		SessionAuth:    viaSession,
 		PATRestriction: restriction,
 	}, nil
+}
+
+// tokenNetworkAllowed enforces a token's IP allowlist (ADR: PAT network restriction). It
+// returns true when the token has no allowlist; otherwise the request's source IP must fall
+// within one of the allowed CIDRs. It fails CLOSED — an undeterminable/unparseable source
+// IP is denied. The source IP is the TCP peer (r.RemoteAddr), never a client-supplied
+// header, so the control cannot be spoofed; a deployment behind a proxy must terminate so
+// RemoteAddr is the real client (e.g. PROXY protocol) for per-client allowlists to apply.
+func tokenNetworkAllowed(r *http.Request, userCtx *UserContext) bool {
+	if userCtx == nil || userCtx.PATRestriction == nil || len(userCtx.PATRestriction.AllowedCIDRs) == 0 {
+		return true
+	}
+	return core.IPInCIDRs(clientIP(r), userCtx.PATRestriction.AllowedCIDRs)
+}
+
+// clientIP returns the source IP of the request from its TCP peer address.
+func clientIP(r *http.Request) string {
+	if host, _, err := net.SplitHostPort(r.RemoteAddr); err == nil {
+		return host
+	}
+	return r.RemoteAddr // already a bare IP (or empty)
 }
 
 // unauthorizedResponse sends a 401 Unauthorized response

--- a/server/middleware/auth_test.go
+++ b/server/middleware/auth_test.go
@@ -62,6 +62,13 @@ func (fakeValidator) ValidatePATToken(_ context.Context, token string) (*models.
 			&core.PATRestriction{Permissions: []string{"secrets.read"}, ProjectID: 5},
 			nil
 	}
+	if token == "kx_pat_cidrtoken" {
+		// A token restricted to the 10.0.0.0/8 network.
+		return &models.User{ID: 3, Username: "patuser", Email: "pat@example.com"},
+			[]string{"system_viewer"},
+			&core.PATRestriction{AllowedCIDRs: []string{"10.0.0.0/8"}},
+			nil
+	}
 	return nil, nil, nil, fmt.Errorf("invalid token")
 }
 
@@ -535,4 +542,28 @@ func TestAuthenticationConcurrency(t *testing.T) {
 	}
 
 	assert.Equal(t, numGoroutines, successCount)
+}
+
+// A PAT with a CIDR allowlist is honored per-request: accepted from an in-range source IP
+// and denied (403) from outside — and the denial holds on the cached fast path too.
+func TestAuthentication_PATNetworkAllowlist(t *testing.T) {
+	mw := newTestAuthMiddleware()
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	serve := func(remoteAddr string) int {
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req.Header.Set("Authorization", "Bearer kx_pat_cidrtoken")
+		req.RemoteAddr = remoteAddr
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		return w.Code
+	}
+
+	assert.Equal(t, http.StatusOK, serve("10.1.2.3:5555"), "in-range source IP is allowed")
+	// Second request caches the (valid) identity but must still be denied from off-network.
+	assert.Equal(t, http.StatusForbidden, serve("203.0.113.9:5555"), "off-network source IP is forbidden")
+	// And an in-range request after the cached deny still passes (per-request evaluation).
+	assert.Equal(t, http.StatusOK, serve("10.9.9.9:443"), "in-range again after a deny")
 }


### PR DESCRIPTION
A PAT is a bearer credential usable from anywhere until revoked. ADR-042 narrows *what* a token can do (scopes, project/environment confinement); this adds *where it can be used from* — a stolen/leaked token is useless off the allowed network. Regulated buyers (NIS2 Art.21, DORA, ENS op.acc.*) routinely require machine credentials be network-bound.

- **model:** `PersonalAccessToken.AllowedCIDRs` (JSON []string; a bare IP → host route). Empty = no restriction (back-compat default); added by AutoMigrate.
- **core:** `IPInCIDRs` (pure, **fail-closed**) + `AllowedCIDRs` on `PATRestriction`. `CreateOwnPAT` validates + stores CIDRs (an invalid block is rejected at creation); `patRestrictionFrom` yields a restriction when *only* a CIDR allowlist is set.
- **middleware:** enforced at the auth boundary on **every request** (including cache hits — the same token may arrive from different IPs); `403` when off-network. The source IP is the **TCP peer (`RemoteAddr`), never a spoofable `X-Forwarded-For`**; fails closed on an undeterminable IP. (A proxied deployment must surface the real client IP, e.g. PROXY protocol — documented.)
- **surface:** `keyorix pat create --allowed-cidr 10.0.0.0/8` (repeatable); `allowed_cidrs` on the create API + token list; a `from=…` segment in the CLI scope summary.

Tests: `IPInCIDRs` (v4/v6/exact/outside/unparseable), CIDR validation + dedup + bare-IP promotion, restriction wiring, and middleware allow/deny **across the cache boundary**. Composes with ADR-042. Machine-token parity is a natural follow-up reusing the same seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)