### PR TITLE
feat(rotation): deployment-wide rotation plan across all projects (ADR-053)

### DIFF
--- a/internal/core/rotation_planner.go
+++ b/internal/core/rotation_planner.go
@@ -129,6 +129,57 @@ func (c *KeyorixCore) GenerateRotationPlan(ctx context.Context, projectID uint) 
 	return plan, nil
 }
 
+// DeploymentRotationPlan aggregates every project's rotation plan into the install-wide
+// rotation picture (ADR-053 deferred follow-up): the roll-up totals a security lead needs at
+// a glance, plus each project's own plan. Rotation dependencies are per-project (ADR-052
+// edges never cross a project boundary), so this is a roll-up of per-project plans rather
+// than a single global wave ordering. Only projects with something to rotate are listed.
+type DeploymentRotationPlan struct {
+	ProjectsScanned  int            `json:"projects_scanned"`   // projects examined
+	ProjectsWithWork int            `json:"projects_with_work"` // projects with at least one secret to rotate
+	TotalSecrets     int            `json:"total_secrets"`      // secrets needing rotation, deployment-wide
+	OverdueCount     int            `json:"overdue_count"`
+	DueSoonCount     int            `json:"due_soon_count"`
+	Projects         []RotationPlan `json:"projects"` // most-overdue project first; only projects with work
+}
+
+// GenerateDeploymentRotationPlan builds the deployment-wide rotation plan by aggregating
+// every project's plan (ADR-053). Projects with nothing to rotate are omitted from the
+// list but still counted in ProjectsScanned. Projects are ordered most-overdue first so the
+// install's most pressing rotation work surfaces at the top.
+func (c *KeyorixCore) GenerateDeploymentRotationPlan(ctx context.Context) (*DeploymentRotationPlan, error) {
+	projects, err := c.storage.ListProjects(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	dp := &DeploymentRotationPlan{Projects: []RotationPlan{}}
+	for _, p := range projects {
+		dp.ProjectsScanned++
+		plan, err := c.GenerateRotationPlan(ctx, p.ID)
+		if err != nil {
+			return nil, fmt.Errorf("project %d: %w", p.ID, err)
+		}
+		if plan.TotalSecrets == 0 {
+			continue // nothing to rotate here — keep the deployment view focused
+		}
+		dp.ProjectsWithWork++
+		dp.TotalSecrets += plan.TotalSecrets
+		dp.OverdueCount += plan.OverdueCount
+		dp.DueSoonCount += plan.DueSoonCount
+		dp.Projects = append(dp.Projects, *plan)
+	}
+
+	// Most overdue projects first; project id breaks ties for a deterministic order.
+	sort.Slice(dp.Projects, func(i, j int) bool {
+		if dp.Projects[i].OverdueCount != dp.Projects[j].OverdueCount {
+			return dp.Projects[i].OverdueCount > dp.Projects[j].OverdueCount
+		}
+		return dp.Projects[i].ProjectID < dp.Projects[j].ProjectID
+	})
+	return dp, nil
+}
+
 // planSecret turns a candidate entry into a PlannedRotation with urgency and reasons.
 func (c *KeyorixCore) planSecret(ctx context.Context, e *RotationStatusEntry, deps []uint, candidates map[uint]*RotationStatusEntry) PlannedRotation {
 	riskScore, riskBand := 0, ""

--- a/internal/core/rotation_planner_test.go
+++ b/internal/core/rotation_planner_test.go
@@ -163,3 +163,81 @@ func joinReasons(rs []string) string {
 	}
 	return out
 }
+
+func TestGenerateDeploymentRotationPlan(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 6, 22, 12, 0, 0, 0, time.UTC)
+	c, db := newPlannerCore(t, now)
+	daysAgo := func(d int) *time.Time { tt := now.Add(-time.Duration(d) * 24 * time.Hour); return &tt }
+
+	mkProject := func(id uint, name string) {
+		require.NoError(t, db.Create(&models.Project{ID: id, Name: name}).Error)
+		require.NoError(t, db.Create(&models.Environment{ID: id, ProjectID: id, Name: name + "-env"}).Error)
+		pid := id
+		require.NoError(t, db.Create(&models.RotationPolicy{
+			Name: name + "-90d", Scope: "project", ProjectID: &pid, IntervalDays: 90, AlertDaysBefore: 14, IsActive: true,
+		}).Error)
+	}
+	mkSecret := func(id, projID, envID uint, name string, last *time.Time) {
+		require.NoError(t, db.Create(&models.SecretNode{
+			ID: id, Name: name, ProjectID: projID, EnvironmentID: envID, IsSecret: true, Status: "active",
+			OwnerID: 1, LastRotatedAt: last,
+		}).Error)
+	}
+
+	mkProject(1, "prod")
+	mkSecret(1, 1, 1, "prod-db", daysAgo(200))  // 110 days overdue
+	mkSecret(2, 1, 1, "prod-app", daysAgo(120)) // 30 days overdue
+
+	mkProject(2, "staging")
+	mkSecret(3, 2, 2, "stg-key", daysAgo(80)) // 10 days remaining → due_soon
+
+	mkProject(3, "sandbox")
+	mkSecret(4, 3, 3, "sbx-healthy", daysAgo(5)) // ok → no work
+
+	dp, err := c.GenerateDeploymentRotationPlan(ctx)
+	require.NoError(t, err)
+
+	assert.Equal(t, 3, dp.ProjectsScanned)
+	assert.Equal(t, 2, dp.ProjectsWithWork, "sandbox has nothing due → excluded from the list")
+	assert.Equal(t, 3, dp.TotalSecrets, "2 in prod + 1 in staging")
+	assert.Equal(t, 2, dp.OverdueCount)
+	assert.Equal(t, 1, dp.DueSoonCount)
+
+	// Only projects with work are listed, most-overdue first: prod (2 overdue) before staging (0).
+	require.Len(t, dp.Projects, 2)
+	assert.Equal(t, uint(1), dp.Projects[0].ProjectID)
+	assert.Equal(t, 2, dp.Projects[0].OverdueCount)
+	assert.Equal(t, uint(2), dp.Projects[1].ProjectID)
+	assert.Equal(t, 0, dp.Projects[1].OverdueCount)
+	assert.Equal(t, 1, dp.Projects[1].DueSoonCount)
+}
+
+func TestGenerateDeploymentRotationPlan_NothingDueAnywhere(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 6, 22, 12, 0, 0, 0, time.UTC)
+	c, db := newPlannerCore(t, now)
+	healthy := now.Add(-5 * 24 * time.Hour)
+
+	for _, p := range []struct {
+		id   uint
+		name string
+	}{{1, "alpha"}, {2, "beta"}} {
+		require.NoError(t, db.Create(&models.Project{ID: p.id, Name: p.name}).Error)
+		require.NoError(t, db.Create(&models.Environment{ID: p.id, ProjectID: p.id, Name: p.name + "-env"}).Error)
+		pid := p.id
+		require.NoError(t, db.Create(&models.RotationPolicy{
+			Name: "90d-" + p.name, Scope: "project", ProjectID: &pid, IntervalDays: 90, AlertDaysBefore: 14, IsActive: true,
+		}).Error)
+		require.NoError(t, db.Create(&models.SecretNode{
+			ID: p.id, Name: "healthy-" + p.name, ProjectID: p.id, EnvironmentID: p.id, IsSecret: true, Status: "active", OwnerID: 1, LastRotatedAt: &healthy,
+		}).Error)
+	}
+
+	dp, err := c.GenerateDeploymentRotationPlan(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 2, dp.ProjectsScanned)
+	assert.Equal(t, 0, dp.ProjectsWithWork)
+	assert.Equal(t, 0, dp.TotalSecrets)
+	assert.Empty(t, dp.Projects)
+}

--- a/server/http/handlers/secret_dependencies.go
+++ b/server/http/handlers/secret_dependencies.go
@@ -174,3 +174,20 @@ func (h *SecretHandler) GetProjectRotationPlan(w http.ResponseWriter, r *http.Re
 	}
 	h.sendSuccess(w, plan, "")
 }
+
+// GetDeploymentRotationPlan handles GET /api/v1/rotation-plan (ADR-053): the install-wide
+// rotation plan — every project's overdue/due-soon secrets aggregated into a roll-up, most
+// pressing project first. Gated by GLOBAL secrets.read at the route (the same access level
+// as listing all projects), so it never reveals a project the caller cannot already see.
+func (h *SecretHandler) GetDeploymentRotationPlan(w http.ResponseWriter, r *http.Request) {
+	if middleware.GetUserFromContext(r.Context()) == nil {
+		h.sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	plan, err := h.coreService.GenerateDeploymentRotationPlan(r.Context())
+	if err != nil {
+		h.sendError(w, "Error", err.Error(), dependencyErrorStatus(err.Error()), nil)
+		return
+	}
+	h.sendSuccess(w, plan, "")
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -251,6 +251,10 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		r.With(customMiddleware.RequireScopedPermission("secrets.read", projectScope)).Get("/projects/{id}/drift", catalogHandler.GetProjectDrift)
 		r.With(customMiddleware.RequireScopedPermission("secrets.read", projectScope)).Get("/projects/{id}/rotation-order", secretHandler.GetProjectRotationOrder)
 		r.With(customMiddleware.RequireScopedPermission("secrets.read", projectScope)).Get("/projects/{id}/rotation-plan", secretHandler.GetProjectRotationPlan)
+		// Deployment-wide rotation plan (ADR-053): aggregates every project. Gated by
+		// GLOBAL secrets.read — the same access level as listing all projects — so it
+		// reveals no project the caller cannot already see.
+		r.With(customMiddleware.RequirePermission("secrets.read")).Get("/rotation-plan", secretHandler.GetDeploymentRotationPlan)
 		// Project membership (ADR-021 two-tier model). Read = project members may
 		// view the roster; mutations require roles.assign at the project scope, so
 		// a project_admin can manage their own project's members.


### PR DESCRIPTION
## Deployment-wide rotation plan (ADR-053 deferred follow-up)

The automated rotation plan is currently per-project (`GET /projects/{id}/rotation-plan`). A security lead also needs the **whole-deployment picture** — which projects have the most pressing rotation work — without querying each project one at a time. ADR-053 lists "a deployment-wide plan (all projects)" as a deferred follow-up; this builds it, API-first (matching how the per-project plan shipped — "the API is the first vertical").

## What

- **core** — `GenerateDeploymentRotationPlan` aggregates every project's `GenerateRotationPlan` into a `DeploymentRotationPlan`: deployment-wide roll-up totals (projects scanned / with work, total secrets needing rotation, overdue, due-soon) plus each project's own plan. Rotation dependencies are per-project (ADR-052 edges never cross a project boundary), so this is a **roll-up of per-project plans**, not a single global wave ordering. Projects with nothing to rotate are omitted from the list but still counted; listed projects are ordered **most-overdue first**.
- **HTTP** — `GET /api/v1/rotation-plan` → `GetDeploymentRotationPlan`, gated by **global `secrets.read`** — the same access level as `GET /projects` (listing all projects) — so it never reveals a project the caller can't already see. gRPC + CLI surfaces are a follow-up.

## Tests

- multi-project aggregation: roll-up totals, most-overdue-first ordering, and an empty project counted-but-omitted;
- the nothing-due-anywhere case (all projects scanned, none listed).

`go build ./...` ✅ · core + server/http tests ✅ · `golangci-lint` 0 ✅ · `gosec` 0 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)