### PR TITLE
fix(grpc): enforce PAT IP allowlist over gRPC too — close the transport bypass (ADR-066)

### DIFF
--- a/docs/adr-066-token-ip-allowlist.md
+++ b/docs/adr-066-token-ip-allowlist.md
@@ -23,10 +23,13 @@ blocks; otherwise it is denied with `403`.
 - **Storage.** `PersonalAccessToken.AllowedCIDRs` — a JSON `[]string` of CIDRs (a bare IP is
   normalised to a `/32`/`/128` host route). Empty = no restriction (the back-compat
   default). CIDRs are validated at creation; an invalid block is rejected.
-- **Enforcement at the auth boundary.** The allowlist rides on the resolved
-  `PATRestriction`, and the authentication middleware checks the request's source IP against
-  it **on every request** — including cache hits, since the same token may arrive from
-  different IPs. It **fails closed**: an undeterminable or unparseable source IP is denied.
+- **Enforcement at the auth boundary, on every transport.** The allowlist rides on the
+  resolved `PATRestriction`, and the source IP is checked against it **on every request** —
+  including HTTP cache hits, since the same token may arrive from different IPs. Both
+  transports enforce it: the HTTP authentication middleware (`RemoteAddr`) and the gRPC
+  auth interceptor (the gRPC peer address) — so the restriction cannot be bypassed by
+  switching from HTTP to gRPC. It **fails closed**: an undeterminable or unparseable source
+  IP is denied.
 - **The source IP is the TCP peer (`RemoteAddr`), never a client-supplied header**
   (`X-Forwarded-For` is attacker-controlled and would make the control trivially bypassable).
   A deployment behind a reverse proxy must therefore terminate so `RemoteAddr` is the real

--- a/server/grpc/interceptors/auth.go
+++ b/server/grpc/interceptors/auth.go
@@ -2,6 +2,7 @@ package interceptors
 
 import (
 	"context"
+	"net"
 	"strings"
 
 	"github.com/keyorixhq/keyorix/internal/core"
@@ -9,6 +10,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
 )
 
@@ -190,6 +192,15 @@ func authenticateRequest(ctx context.Context, coreService *core.KeyorixCore) (*U
 		return nil, nil, status.Errorf(codes.Unauthenticated, "Invalid or expired token")
 	}
 
+	// Enforce a PAT's network allowlist on the gRPC transport too (ADR-066), so the IP
+	// restriction is not bypassable by switching from HTTP to gRPC. Fail-closed: an
+	// undeterminable peer IP outside the allowlist is denied.
+	if restriction != nil && len(restriction.AllowedCIDRs) > 0 {
+		if !core.IPInCIDRs(grpcPeerIP(ctx), restriction.AllowedCIDRs) {
+			return nil, nil, status.Errorf(codes.PermissionDenied, "token not permitted from this network")
+		}
+	}
+
 	// Resolve roles + permissions for downstream per-method authorization.
 	identity, err := coreService.GetUserIdentity(ctx, user.ID)
 	if err != nil {
@@ -203,6 +214,19 @@ func authenticateRequest(ctx context.Context, coreService *core.KeyorixCore) (*U
 		Roles:       identity.Roles,
 		Permissions: identity.Permissions,
 	}, restriction, nil
+}
+
+// grpcPeerIP returns the source IP of the gRPC call from its peer (TCP) address, or "" if
+// it cannot be determined (which the fail-closed allowlist check then denies).
+func grpcPeerIP(ctx context.Context) string {
+	p, ok := peer.FromContext(ctx)
+	if !ok || p.Addr == nil {
+		return ""
+	}
+	if host, _, err := net.SplitHostPort(p.Addr.String()); err == nil {
+		return host
+	}
+	return p.Addr.String()
 }
 
 // isPublicMethod checks if a gRPC method is public (doesn't require authentication)

--- a/server/grpc/interceptors/auth_test.go
+++ b/server/grpc/interceptors/auth_test.go
@@ -2,6 +2,7 @@ package interceptors
 
 import (
 	"context"
+	"net"
 	"strings"
 	"testing"
 	"time"
@@ -14,6 +15,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
 )
 
@@ -245,4 +247,39 @@ func TestAuthInterceptor_InvalidPATRejected(t *testing.T) {
 		&grpc.UnaryServerInfo{FullMethod: secretMethod}, okHandler(nil))
 	require.Error(t, err)
 	assert.Equal(t, codes.Unauthenticated, status.Code(err))
+}
+
+// bearerCtxFromIP is bearerCtx plus a gRPC peer with the given source IP.
+func bearerCtxFromIP(token, ip string) context.Context {
+	md := metadata.Pairs("authorization", "Bearer "+token)
+	ctx := metadata.NewIncomingContext(context.Background(), md)
+	return peer.NewContext(ctx, &peer.Peer{Addr: &net.TCPAddr{IP: net.ParseIP(ip), Port: 5555}})
+}
+
+// A PAT's IP allowlist (ADR-066) is enforced over gRPC too — otherwise the restriction
+// would be bypassable by switching transports. In-range peer is allowed; off-network is
+// PermissionDenied.
+func TestAuthInterceptor_PATNetworkAllowlistOverGRPC(t *testing.T) {
+	h := setupAuthHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(&models.PersonalAccessToken{}))
+
+	h.CreateTestUser(t, "grpc-cidr", 9200)
+	proj2 := uint(2)
+	h.AssignUserRole(t, 9200, 3, &proj2)
+
+	// A token restricted to 10.0.0.0/8 (no permission/project scoping).
+	res, err := h.CoreService.CreateOwnPAT(context.Background(), 9200, "ci-cidr", nil, nil, 0, 0, []string{"10.0.0.0/8"})
+	require.NoError(t, err)
+
+	interceptor := AuthInterceptor(h.CoreService)
+
+	_, err = interceptor(bearerCtxFromIP(res.PlainToken, "10.1.2.3"), nil,
+		&grpc.UnaryServerInfo{FullMethod: secretMethod}, okHandler(nil))
+	require.NoError(t, err, "in-range source IP is allowed over gRPC")
+
+	_, err = interceptor(bearerCtxFromIP(res.PlainToken, "203.0.113.9"), nil,
+		&grpc.UnaryServerInfo{FullMethod: secretMethod}, okHandler(nil))
+	require.Error(t, err, "off-network source IP must be denied over gRPC")
+	assert.Equal(t, codes.PermissionDenied, status.Code(err))
 }


### PR DESCRIPTION
The PAT network allowlist (ADR-066, #502) was enforced **only in the HTTP middleware**. The gRPC auth interceptor validates PATs as well, so a token with an IP allowlist could be used over gRPC from **any** source IP — a bypass of the control.

- **gRPC auth interceptor:** after resolving a PAT's restriction, enforce its `AllowedCIDRs` against the gRPC peer IP (`grpcPeerIP` via `peer.FromContext`). **Fail-closed:** an off-network or undeterminable peer IP → `codes.PermissionDenied`.
- **ADR-066:** record that both transports (HTTP `RemoteAddr` + gRPC peer) enforce the allowlist.

Test: a CIDR-restricted PAT is allowed from an in-range gRPC peer and denied (`PermissionDenied`) from off-network.

🤖 Generated with [Claude Code](https://claude.com/claude-code)