### PR TITLE
feat(rotation): `keyorix rotation plan --all-projects` — deployment-wide roll-up CLI (ADR-053)

### DIFF
--- a/internal/cli/rotation/plan.go
+++ b/internal/cli/rotation/plan.go
@@ -2,7 +2,8 @@
 // rotation plan — its overdue/due-soon secrets batched into dependency-safe waves and
 // prioritised by urgency, each annotated with why. Talks to
 // GET /api/v1/projects/{id}/rotation-plan (scoped by the caller's secrets.read
-// permission server-side).
+// permission server-side). With --all-projects it prints the deployment-wide roll-up
+// (every project's plan, most pressing first) via GET /api/v1/rotation-plan.
 package rotation
 
 import (
@@ -38,22 +39,56 @@ type rotationPlanView struct {
 	Waves        []rotationWave `json:"waves"`
 }
 
+// deploymentPlanView mirrors core.DeploymentRotationPlan — the install-wide roll-up of
+// every project's plan. Rotation dependencies are per-project, so this is a roll-up of
+// per-project plans (most overdue first), not a single global wave order.
+type deploymentPlanView struct {
+	ProjectsScanned  int                `json:"projects_scanned"`
+	ProjectsWithWork int                `json:"projects_with_work"`
+	TotalSecrets     int                `json:"total_secrets"`
+	OverdueCount     int                `json:"overdue_count"`
+	DueSoonCount     int                `json:"due_soon_count"`
+	Projects         []rotationPlanView `json:"projects"`
+}
+
+var planAllProjects bool
+
 var planCmd = &cobra.Command{
-	Use:   "plan <project-id>",
-	Short: "Print a project's automated rotation plan (dependency-safe waves, by urgency)",
+	Use:   "plan [project-id]",
+	Short: "Print an automated rotation plan (dependency-safe waves, by urgency)",
 	Long: `Print the rotation plan for a project: its overdue and due-soon secrets, batched
 into dependency-safe waves (rotate a wave at a time, top to bottom; within a wave the
-most urgent first) and annotated with why each is due and what it must follow (ADR-053).`,
-	Args:         cobra.ExactArgs(1),
+most urgent first) and annotated with why each is due and what it must follow (ADR-053).
+
+With --all-projects, print the deployment-wide roll-up instead: every project's plan
+aggregated into install-wide totals, most pressing project first. Dependencies are
+per-project, so each project keeps its own wave order.`,
+	Args:         cobra.MaximumNArgs(1),
 	SilenceUsage: true,
 	RunE: func(_ *cobra.Command, args []string) error {
-		projectID, err := strconv.ParseUint(strings.TrimSpace(args[0]), 10, 32)
-		if err != nil || projectID == 0 {
-			return fmt.Errorf("invalid project id %q", args[0])
-		}
 		c, ok := common.NewRemoteClient()
 		if !ok {
 			return fmt.Errorf("not connected to a server — run: keyorix connect <server>")
+		}
+
+		if planAllProjects {
+			if len(args) > 0 {
+				return fmt.Errorf("--all-projects takes no project-id argument")
+			}
+			plan, err := fetchDeploymentRotationPlan(context.Background(), c)
+			if err != nil {
+				return err
+			}
+			printDeploymentPlan(plan)
+			return nil
+		}
+
+		if len(args) != 1 {
+			return fmt.Errorf("provide a project id, or use --all-projects for the deployment-wide plan")
+		}
+		projectID, err := strconv.ParseUint(strings.TrimSpace(args[0]), 10, 32)
+		if err != nil || projectID == 0 {
+			return fmt.Errorf("invalid project id %q", args[0])
 		}
 		plan, err := fetchRotationPlan(context.Background(), c, uint(projectID))
 		if err != nil {
@@ -63,19 +98,41 @@ most urgent first) and annotated with why each is due and what it must follow (A
 			fmt.Println("Nothing to rotate — no policy-covered secret in this project is overdue or due soon.")
 			return nil
 		}
-		fmt.Printf("Rotation plan for project %d — %d to rotate (%d overdue, %d due soon), %d wave(s):\n",
-			plan.ProjectID, plan.TotalSecrets, plan.OverdueCount, plan.DueSoonCount, len(plan.Waves))
-		for _, w := range plan.Waves {
-			fmt.Printf("\nWave %d  (safe to rotate together):\n", w.Index+1)
-			for _, s := range w.Secrets {
-				fmt.Printf("  %-26s %-9s %s%s\n", s.SecretName, statusLabel(s), riskLabel(s.RiskBand), autoRotateLabel(s.AutoRotate))
-				if len(s.Reasons) > 0 {
-					fmt.Printf("      ↳ %s\n", strings.Join(s.Reasons, " · "))
-				}
-			}
-		}
+		printProjectPlan(plan, "")
 		return nil
 	},
+}
+
+// printProjectPlan prints one project's plan: a header line, then its waves. indent is
+// prefixed to every line so the same renderer serves both the single-project view (no
+// indent) and each project block in the deployment-wide view.
+func printProjectPlan(plan *rotationPlanView, indent string) {
+	fmt.Printf("%sRotation plan for project %d — %d to rotate (%d overdue, %d due soon), %d wave(s):\n",
+		indent, plan.ProjectID, plan.TotalSecrets, plan.OverdueCount, plan.DueSoonCount, len(plan.Waves))
+	for _, w := range plan.Waves {
+		fmt.Printf("\n%sWave %d  (safe to rotate together):\n", indent, w.Index+1)
+		for _, s := range w.Secrets {
+			fmt.Printf("%s  %-26s %-9s %s%s\n", indent, s.SecretName, statusLabel(s), riskLabel(s.RiskBand), autoRotateLabel(s.AutoRotate))
+			if len(s.Reasons) > 0 {
+				fmt.Printf("%s      ↳ %s\n", indent, strings.Join(s.Reasons, " · "))
+			}
+		}
+	}
+}
+
+// printDeploymentPlan prints the install-wide roll-up: a summary line then each project's
+// plan, most pressing first.
+func printDeploymentPlan(plan *deploymentPlanView) {
+	if plan.ProjectsWithWork == 0 {
+		fmt.Printf("Nothing to rotate — no policy-covered secret is overdue or due soon across %d project(s).\n", plan.ProjectsScanned)
+		return
+	}
+	fmt.Printf("Deployment rotation plan — %d to rotate (%d overdue, %d due soon) across %d of %d project(s):\n",
+		plan.TotalSecrets, plan.OverdueCount, plan.DueSoonCount, plan.ProjectsWithWork, plan.ProjectsScanned)
+	for i := range plan.Projects {
+		fmt.Println()
+		printProjectPlan(&plan.Projects[i], "  ")
+	}
 }
 
 func statusLabel(s plannedRotation) string {
@@ -108,6 +165,16 @@ func fetchRotationPlan(ctx context.Context, c *common.RemoteClient, projectID ui
 	return &v, nil
 }
 
+// fetchDeploymentRotationPlan is split out for httptest-backed tests.
+func fetchDeploymentRotationPlan(ctx context.Context, c *common.RemoteClient) (*deploymentPlanView, error) {
+	var v deploymentPlanView
+	if err := c.Get(ctx, "/api/v1/rotation-plan", &v); err != nil {
+		return nil, err
+	}
+	return &v, nil
+}
+
 func init() {
+	planCmd.Flags().BoolVar(&planAllProjects, "all-projects", false, "Plan rotation across every project (deployment-wide roll-up)")
 	RotationCmd.AddCommand(planCmd)
 }

--- a/internal/cli/rotation/plan_remote_test.go
+++ b/internal/cli/rotation/plan_remote_test.go
@@ -40,6 +40,40 @@ func TestFetchRotationPlan(t *testing.T) {
 	assert.Contains(t, plan.Waves[1].Secrets[0].Reasons, "rotate after root-ca")
 }
 
+func TestFetchDeploymentRotationPlan(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/rotation-plan" {
+			_, _ = w.Write([]byte(`{"data":{"projects_scanned":3,"projects_with_work":2,"total_secrets":3,"overdue_count":2,"due_soon_count":1,"projects":[
+				{"project_id":7,"total_secrets":2,"overdue_count":2,"due_soon_count":0,"waves":[
+					{"index":0,"secrets":[{"secret_id":12,"secret_name":"root-ca","status":"overdue","days_overdue":110,"risk_band":"high","auto_rotate":false,"reasons":["110 days overdue"]}]}
+				]},
+				{"project_id":2,"total_secrets":1,"overdue_count":0,"due_soon_count":1,"waves":[
+					{"index":0,"secrets":[{"secret_id":4,"secret_name":"app-token","status":"due_soon","days_overdue":-5,"risk_band":"low","auto_rotate":true,"reasons":["due in 5 days"]}]}
+				]}
+			]}}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	rc, ok := common.NewRemoteClient()
+	require.True(t, ok)
+
+	plan, err := fetchDeploymentRotationPlan(context.Background(), rc)
+	require.NoError(t, err)
+	assert.Equal(t, 3, plan.ProjectsScanned)
+	assert.Equal(t, 2, plan.ProjectsWithWork)
+	assert.Equal(t, 3, plan.TotalSecrets)
+	assert.Equal(t, 2, plan.OverdueCount)
+	require.Len(t, plan.Projects, 2)
+	// Most-overdue project first.
+	assert.Equal(t, uint(7), plan.Projects[0].ProjectID)
+	assert.Equal(t, "root-ca", plan.Projects[0].Waves[0].Secrets[0].SecretName)
+	assert.True(t, plan.Projects[1].Waves[0].Secrets[0].AutoRotate)
+}
+
 func TestStatusAndRiskLabels(t *testing.T) {
 	assert.Equal(t, "30d over", statusLabel(plannedRotation{Status: "overdue", DaysOverdue: 30}))
 	assert.Equal(t, "10d left", statusLabel(plannedRotation{Status: "due_soon", DaysOverdue: -10}))


### PR DESCRIPTION
The deployment-wide rotation plan (`GET /api/v1/rotation-plan`, #503) shipped **API-only**. This adds the CLI surface so an operator can see the install-wide rotation picture from the terminal, mirroring the existing per-project `keyorix rotation plan <id>`.

## What
- **`keyorix rotation plan --all-projects`** calls `GET /api/v1/rotation-plan` and prints the roll-up: install-wide totals (secrets to rotate, overdue / due-soon) across *projects-with-work / projects-scanned*, then each project's own dependency-safe waves, **most-overdue project first**.
- The positional `project-id` is now optional (`MaximumNArgs(1)`) and **mutually exclusive** with the flag: `--all-projects` with an id, or no id and no flag, each fail with a clear message.
- The single-project and deployment views share one wave renderer (`printProjectPlan`, indent-prefixed) so output stays consistent.
- `fetchDeploymentRotationPlan` is split out for httptest-backed coverage.

## Why CLI-only here
gRPC needs proto regen (merge-sequentially per the regen-rebase workflow) and the keyorix-web view is a separate surface — both are follow-ups. This PR is the lowest-risk, no-regen, immediately-demoable piece.

## Test
- httptest-backed fetch of the deployment plan asserts install-wide totals + most-overdue ordering.
- Verified end-to-end against a stub server: roll-up renders correctly; both validation guards fire.
- `go build ./...` ✓ · `go test ./internal/cli/rotation/` ✓ · `gosec -severity medium` 0 issues · `golangci-lint` 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)