### PR TITLE
feat(rotation): order auto-rotation by the secret dependency graph (ADR-052/053)

### DIFF
--- a/internal/core/rotation_executor.go
+++ b/internal/core/rotation_executor.go
@@ -138,23 +138,37 @@ func generateRotatedValueSpec(length int, charset string) (string, error) {
 	return string(b), nil
 }
 
+// dueRotation is a secret that is due for auto-rotation this run, with the policy it is
+// due under (for the audit trail).
+type dueRotation struct {
+	secret *models.SecretNode
+	policy *models.RotationPolicy
+}
+
 // RunAutoRotation rotates every auto-rotate-enabled secret that is overdue under an
 // active rotation policy, regenerating its value (a new version) and auditing each
-// rotation. Best-effort per secret: a generate/rotate failure is logged and skipped,
-// never aborting the run. A secret covered by multiple policies is rotated at most once
-// per run. Returns the number of secrets rotated.
+// rotation. A secret covered by multiple policies is rotated at most once per run.
+//
+// Rotations are ordered by the secret dependency graph (ADR-052): within a project a
+// secret rotates only after the secrets it depends on, mirroring the dependency-safe
+// waves the rotation planner computes (ADR-053). When a dependency does NOT rotate this
+// run — it failed, or was itself deferred — the dependent is DEFERRED rather than
+// rotated against a now-stale dependency (dependency-first auto-rotation), and audited
+// so an operator can act. Otherwise best-effort per secret: a generate/rotate failure is
+// logged and skipped, never aborting the run. Returns the number of secrets rotated.
 func (c *KeyorixCore) RunAutoRotation(ctx context.Context) (int, error) {
 	policies, err := c.storage.ListRotationPolicies(ctx, nil, nil)
 	if err != nil {
 		return 0, fmt.Errorf("auto-rotation: list policies: %w", err)
 	}
 	now := c.now()
-	rotated := 0
-	done := make(map[uint]bool)
-	// failed records the last failure per secret id; a secret that later rotates under
-	// another covering policy is removed, so only genuine end-of-run failures remain.
-	failed := make(map[uint]string)
 
+	// Phase 1 — gather the secrets due for auto-rotation, deduped per secret. A secret
+	// covered by several policies is rotated at most once, under the first active policy
+	// it is due under (preserves the prior first-policy-wins behaviour). dueOrder keeps
+	// discovery order so project grouping below is deterministic.
+	due := map[uint]*dueRotation{}
+	dueOrder := []uint{}
 	for _, policy := range policies {
 		if !policy.IsActive {
 			continue
@@ -164,75 +178,180 @@ func (c *KeyorixCore) RunAutoRotation(ctx context.Context) (int, error) {
 			continue
 		}
 		for _, secret := range secrets {
-			if !secret.AutoRotate || done[secret.ID] {
+			if !secret.AutoRotate {
 				continue
+			}
+			if _, seen := due[secret.ID]; seen {
+				continue // already due under an earlier policy
 			}
 			lastRotated := secret.CreatedAt
 			if secret.LastRotatedAt != nil {
 				lastRotated = *secret.LastRotatedAt
 			}
-			daysSince := int(now.Sub(lastRotated).Hours() / 24)
-			if daysSince < policy.IntervalDays {
+			if int(now.Sub(lastRotated).Hours()/24) < policy.IntervalDays {
 				continue // not yet due under this policy
 			}
-
-			val, gerr := generateRotatedValueSpec(secret.RotationLength, secret.RotationCharset)
-			if gerr != nil {
-				log.Printf("auto-rotation: generate value for secret %d: %v", secret.ID, gerr)
-				failed[secret.ID] = fmt.Sprintf("%q: generate value: %v", secret.Name, gerr)
-				continue
-			}
-			// Backend rotation (ADR-047): if the secret names a configured executor,
-			// rotate the credential UPSTREAM first and store the resulting value only on
-			// success, so the two never drift. For a generate-upstream backend (e.g. a
-			// cloud key API) the stored value is what the upstream minted; for a
-			// password-set backend it is the candidate we generated. A backend that is
-			// unconfigured/unknown or whose upstream apply fails is skipped (audited).
-			storeVal := val
-			if secret.RotationBackend != "" {
-				upstreamVal, err := c.applyBackendRotation(ctx, secret, val)
-				if err != nil {
-					sid := secret.ID
-					c.writeAuditEvent(ctx, EventSecretAutoRotated, nil, &sid,
-						fmt.Sprintf("auto-rotation FAILED for secret %q via backend %q ref %q: %v", secret.Name, secret.RotationBackend, secret.RotationRef, err))
-					log.Printf("auto-rotation: backend rotate secret %d: %v", secret.ID, err)
-					failed[secret.ID] = fmt.Sprintf("%q via backend %q ref %q: %v", secret.Name, secret.RotationBackend, secret.RotationRef, err)
-					continue
-				}
-				storeVal = upstreamVal
-			}
-			if _, rerr := c.RotateSecret(ctx, secret.ID, []byte(storeVal), "system:auto-rotation"); rerr != nil {
-				log.Printf("auto-rotation: rotate secret %d: %v", secret.ID, rerr)
-				failed[secret.ID] = fmt.Sprintf("%q: store new version: %v", secret.Name, rerr)
-				sid := secret.ID
-				if secret.RotationBackend != "" {
-					// The upstream credential was rotated but storing the new value failed:
-					// the live credential and Keyorix's record have now DRIFTED. Audit it
-					// distinctly (the backend-apply-failure path above is audited too) so an
-					// operator can reconcile — the live secret may no longer match Keyorix.
-					c.writeAuditEvent(ctx, EventSecretAutoRotated, nil, &sid,
-						fmt.Sprintf("auto-rotation DRIFT for secret %q: backend %q ref %q rotated upstream but storing the new value failed: %v — the live credential may no longer match Keyorix",
-							secret.Name, secret.RotationBackend, secret.RotationRef, rerr))
-				} else {
-					c.writeAuditEvent(ctx, EventSecretAutoRotated, nil, &sid,
-						fmt.Sprintf("auto-rotation FAILED to store new version for secret %q: %v", secret.Name, rerr))
-				}
-				continue
-			}
-			delete(failed, secret.ID) // rotated successfully (e.g. under a later policy)
-			done[secret.ID] = true
-			rotated++
-			sid := secret.ID
-			via := ""
-			if secret.RotationBackend != "" {
-				via = fmt.Sprintf(" via backend %q ref %q", secret.RotationBackend, secret.RotationRef)
-			}
-			c.writeAuditEvent(ctx, EventSecretAutoRotated, nil, &sid,
-				fmt.Sprintf("auto-rotated secret %q (policy %q, interval %dd)%s", secret.Name, policy.Name, policy.IntervalDays, via))
+			due[secret.ID] = &dueRotation{secret: secret, policy: policy}
+			dueOrder = append(dueOrder, secret.ID)
 		}
 	}
+	if len(due) == 0 {
+		return 0, nil
+	}
+
+	// Phase 2 — group the due secrets by project. Rotation dependencies are per-project
+	// (ADR-052 edges never cross a project boundary), so ordering is computed per project.
+	byProject := map[uint][]uint{}
+	projectOrder := []uint{}
+	for _, id := range dueOrder {
+		pid := due[id].secret.ProjectID
+		if _, ok := byProject[pid]; !ok {
+			projectOrder = append(projectOrder, pid)
+		}
+		byProject[pid] = append(byProject[pid], id)
+	}
+
+	// Phase 3 — rotate each project's due secrets in dependency-safe wave order.
+	rotated := 0
+	// failed records why each non-rotated secret did not rotate (a genuine failure or a
+	// dependency-driven deferral); surfaced to operators via notifyRotationFailures.
+	failed := map[uint]string{}
+	for _, pid := range projectOrder {
+		ids := byProject[pid]
+		candidateSet := make(map[uint]bool, len(ids))
+		for _, id := range ids {
+			candidateSet[id] = true
+		}
+
+		edges, eerr := c.storage.ListSecretDependenciesForProject(ctx, pid)
+		if eerr != nil {
+			// Can't determine the dependency order; degrade to a flat best-effort pass for
+			// this project (no deferral) rather than skip its rotations entirely.
+			log.Printf("auto-rotation: list dependencies for project %d: %v — rotating without dependency ordering", pid, eerr)
+			edges = nil
+		}
+		waves, ok := rotationWaves(edges, candidateSet)
+		if !ok {
+			// A cycle should not occur (the graph is kept acyclic at add, ADR-052). Fall
+			// back to a single flat wave with deferral disabled so a malformed graph never
+			// blocks rotation.
+			log.Printf("auto-rotation: dependency graph for project %d has a cycle — rotating without dependency ordering", pid)
+			flat := append([]uint(nil), ids...)
+			sort.Slice(flat, func(i, j int) bool { return flat[i] < flat[j] })
+			waves = [][]uint{flat}
+			edges = nil
+		}
+
+		// In-run dependencies per secret (edges to other due secrets in this project).
+		dependsOnInRun := map[uint][]uint{}
+		for _, e := range edges {
+			if candidateSet[e.DependentSecretID] && candidateSet[e.DependsOnSecretID] {
+				dependsOnInRun[e.DependentSecretID] = append(dependsOnInRun[e.DependentSecretID], e.DependsOnSecretID)
+			}
+		}
+
+		blocked := map[uint]bool{} // due secrets that did not rotate this run (failed or deferred)
+		for _, wave := range waves {
+			for _, id := range wave {
+				dr := due[id]
+				// A dependency processed earlier (dependency-safe order guarantees it) did
+				// not rotate — defer rather than rotate against a stale dependency.
+				if depID, isBlocked := lowestBlockedDep(dependsOnInRun[id], blocked); isBlocked {
+					blocked[id] = true
+					depName := ""
+					if d, ok := due[depID]; ok {
+						depName = d.secret.Name
+					}
+					sid := id
+					c.writeAuditEvent(ctx, EventSecretAutoRotated, nil, &sid,
+						fmt.Sprintf("auto-rotation DEFERRED for secret %q: it depends on %q which did not rotate this run", dr.secret.Name, depName))
+					failed[id] = fmt.Sprintf("%q: deferred — depends on %q which did not rotate this run", dr.secret.Name, depName)
+					continue
+				}
+				if c.rotateOneSecret(ctx, dr.secret, dr.policy, failed) {
+					rotated++
+				} else {
+					blocked[id] = true
+				}
+			}
+		}
+	}
+
 	c.notifyRotationFailures(ctx, failed)
 	return rotated, nil
+}
+
+// lowestBlockedDep returns the lowest-id dependency that is in blocked (and true), or
+// 0/false if none of deps is blocked. Lowest-id makes the chosen dependency — and thus
+// the deferral audit message — deterministic when several dependencies are blocked.
+func lowestBlockedDep(deps []uint, blocked map[uint]bool) (uint, bool) {
+	found := false
+	var lowest uint
+	for _, d := range deps {
+		if blocked[d] && (!found || d < lowest) {
+			found, lowest = true, d
+		}
+	}
+	return lowest, found
+}
+
+// rotateOneSecret performs the actual rotation of a single due secret: generate a new
+// value, optionally apply it to the configured backend (ADR-047) before storing so the
+// two never drift, store the new version, and audit the outcome. Any failure is recorded
+// in failed and logged; it returns true only when the secret was rotated and stored
+// successfully. Best-effort: it never returns an error or aborts the run.
+func (c *KeyorixCore) rotateOneSecret(ctx context.Context, secret *models.SecretNode, policy *models.RotationPolicy, failed map[uint]string) bool {
+	val, gerr := generateRotatedValueSpec(secret.RotationLength, secret.RotationCharset)
+	if gerr != nil {
+		log.Printf("auto-rotation: generate value for secret %d: %v", secret.ID, gerr)
+		failed[secret.ID] = fmt.Sprintf("%q: generate value: %v", secret.Name, gerr)
+		return false
+	}
+	// Backend rotation (ADR-047): if the secret names a configured executor, rotate the
+	// credential UPSTREAM first and store the resulting value only on success. For a
+	// generate-upstream backend (e.g. a cloud key API) the stored value is what the
+	// upstream minted; for a password-set backend it is the candidate we generated. A
+	// backend that is unconfigured/unknown or whose upstream apply fails is skipped.
+	storeVal := val
+	if secret.RotationBackend != "" {
+		upstreamVal, err := c.applyBackendRotation(ctx, secret, val)
+		if err != nil {
+			sid := secret.ID
+			c.writeAuditEvent(ctx, EventSecretAutoRotated, nil, &sid,
+				fmt.Sprintf("auto-rotation FAILED for secret %q via backend %q ref %q: %v", secret.Name, secret.RotationBackend, secret.RotationRef, err))
+			log.Printf("auto-rotation: backend rotate secret %d: %v", secret.ID, err)
+			failed[secret.ID] = fmt.Sprintf("%q via backend %q ref %q: %v", secret.Name, secret.RotationBackend, secret.RotationRef, err)
+			return false
+		}
+		storeVal = upstreamVal
+	}
+	if _, rerr := c.RotateSecret(ctx, secret.ID, []byte(storeVal), "system:auto-rotation"); rerr != nil {
+		log.Printf("auto-rotation: rotate secret %d: %v", secret.ID, rerr)
+		failed[secret.ID] = fmt.Sprintf("%q: store new version: %v", secret.Name, rerr)
+		sid := secret.ID
+		if secret.RotationBackend != "" {
+			// The upstream credential was rotated but storing the new value failed: the
+			// live credential and Keyorix's record have now DRIFTED. Audit it distinctly
+			// (the backend-apply-failure path above is audited too) so an operator can
+			// reconcile — the live secret may no longer match Keyorix.
+			c.writeAuditEvent(ctx, EventSecretAutoRotated, nil, &sid,
+				fmt.Sprintf("auto-rotation DRIFT for secret %q: backend %q ref %q rotated upstream but storing the new value failed: %v — the live credential may no longer match Keyorix",
+					secret.Name, secret.RotationBackend, secret.RotationRef, rerr))
+		} else {
+			c.writeAuditEvent(ctx, EventSecretAutoRotated, nil, &sid,
+				fmt.Sprintf("auto-rotation FAILED to store new version for secret %q: %v", secret.Name, rerr))
+		}
+		return false
+	}
+	delete(failed, secret.ID)
+	sid := secret.ID
+	via := ""
+	if secret.RotationBackend != "" {
+		via = fmt.Sprintf(" via backend %q ref %q", secret.RotationBackend, secret.RotationRef)
+	}
+	c.writeAuditEvent(ctx, EventSecretAutoRotated, nil, &sid,
+		fmt.Sprintf("auto-rotated secret %q (policy %q, interval %dd)%s", secret.Name, policy.Name, policy.IntervalDays, via))
+	return true
 }
 
 // applyBackendRotation resolves the secret's named rotation executor and rotates the

--- a/internal/core/rotation_executor_deps_test.go
+++ b/internal/core/rotation_executor_deps_test.go
@@ -1,0 +1,140 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/rotation"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+// depExecCore is rotationExecCore plus the secret-dependency table and a single active
+// 30-day project policy, so auto-rotation has a dependency graph to order by (ADR-052/053).
+func depExecCore(t *testing.T) (*KeyorixCore, *gorm.DB, time.Time) {
+	t.Helper()
+	c, db, fixed := rotationExecCore(t)
+	require.NoError(t, db.AutoMigrate(&models.SecretDependency{}))
+	pid := uint(1)
+	require.NoError(t, db.Create(&models.RotationPolicy{
+		ID: 1, Name: "30-day", Scope: "project", ProjectID: &pid, IntervalDays: 30, IsActive: true, CreatedBy: "admin",
+	}).Error)
+	return c, db, fixed
+}
+
+// seedDependency inserts a directed edge "dependent depends on dependsOn" in project 1.
+func seedDependency(t *testing.T, db *gorm.DB, dependent, dependsOn uint) {
+	t.Helper()
+	require.NoError(t, db.Create(&models.SecretDependency{
+		ProjectID: 1, DependentSecretID: dependent, DependsOnSecretID: dependsOn,
+	}).Error)
+}
+
+// autoRotateEventDescriptions returns the auto-rotation audit event descriptions in write
+// order (event id ascending) — i.e. the order the executor rotated/deferred secrets.
+func autoRotateEventDescriptions(t *testing.T, db *gorm.DB) []string {
+	t.Helper()
+	var events []models.AuditEvent
+	require.NoError(t, db.Where("event_type = ?", EventSecretAutoRotated).Order("id ASC").Find(&events).Error)
+	descs := make([]string, len(events))
+	for i, e := range events {
+		descs[i] = e.Description
+	}
+	return descs
+}
+
+// A dependent rotates only AFTER the secret it depends on. The dependency is given a
+// HIGHER id than its dependent so a naive id-ordered pass would rotate them in the wrong
+// order — proving the ordering comes from the dependency graph, not the scan order.
+func TestRunAutoRotation_RotatesInDependencyOrder(t *testing.T) {
+	c, db, fixed := depExecCore(t)
+	overdue := fixed.Add(-60 * 24 * time.Hour)
+	// secret 1 (app-token) depends on secret 2 (db-password): db-password must rotate first.
+	seedRotatableSecret(t, db, 1, "app-token", true, overdue)
+	seedRotatableSecret(t, db, 2, "db-password", true, overdue)
+	seedDependency(t, db, 1, 2) // dependent=app-token depends on db-password
+
+	n, err := c.RunAutoRotation(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 2, n, "both overdue secrets rotate")
+	assert.Equal(t, 2, latestVersion(t, db, 1).VersionNumber)
+	assert.Equal(t, 2, latestVersion(t, db, 2).VersionNumber)
+
+	descs := autoRotateEventDescriptions(t, db)
+	require.Len(t, descs, 2)
+	assert.Contains(t, descs[0], "db-password", "the dependency rotates first")
+	assert.Contains(t, descs[1], "app-token", "the dependent rotates second")
+}
+
+// When a dependency fails to rotate, the dependent is DEFERRED rather than rotated
+// against a now-stale dependency — and the deferral propagates transitively down the
+// chain (A fails → B deferred → C deferred).
+func TestRunAutoRotation_DefersDependentsOfFailedDependency(t *testing.T) {
+	fake := &fakeExecutor{name: "pg", err: errors.New("connection refused")}
+	c, db, fixed := depExecCore(t)
+	c.SetRotationManager(rotation.NewManager([]rotation.Executor{fake}))
+	overdue := fixed.Add(-60 * 24 * time.Hour)
+
+	// Chain: app-token (3) depends on db-app (2) depends on db-root (1, a backend secret
+	// that fails to rotate upstream).
+	seedBackendSecret(t, db, 1, "pg", "db_root", overdue) // name "upstream-cred"; fails
+	seedRotatableSecret(t, db, 2, "db-app", true, overdue)
+	seedRotatableSecret(t, db, 3, "app-token", true, overdue)
+	seedDependency(t, db, 2, 1) // db-app depends on db-root
+	seedDependency(t, db, 3, 2) // app-token depends on db-app
+
+	n, err := c.RunAutoRotation(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 0, n, "the dependency failed, so neither dependent rotates")
+
+	// Nothing downstream got a new version.
+	assert.Equal(t, 1, latestVersion(t, db, 1).VersionNumber, "failed dependency unchanged")
+	assert.Equal(t, 1, latestVersion(t, db, 2).VersionNumber, "deferred dependent unchanged")
+	assert.Equal(t, 1, latestVersion(t, db, 3).VersionNumber, "transitively-deferred dependent unchanged")
+
+	descs := autoRotateEventDescriptions(t, db)
+	joined := strings.Join(descs, "\n")
+	assert.Contains(t, joined, "FAILED", "the dependency's failure is audited")
+	// db-app deferred because db-root (the backend secret, named "upstream-cred") didn't rotate.
+	assert.Contains(t, joined, `DEFERRED for secret "db-app"`)
+	// app-token deferred because db-app didn't rotate this run (transitive propagation).
+	assert.Contains(t, joined, `DEFERRED for secret "app-token": it depends on "db-app"`)
+}
+
+// A sibling dependent of a SUCCESSFUL dependency still rotates — deferral is scoped to the
+// dependents of secrets that did not rotate, not a blanket stand-down.
+func TestRunAutoRotation_SuccessfulDependencyDoesNotDeferDependent(t *testing.T) {
+	c, db, fixed := depExecCore(t)
+	overdue := fixed.Add(-60 * 24 * time.Hour)
+	seedRotatableSecret(t, db, 1, "db-password", true, overdue) // generated → succeeds
+	seedRotatableSecret(t, db, 2, "app-token", true, overdue)
+	seedDependency(t, db, 2, 1)
+
+	n, err := c.RunAutoRotation(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 2, n, "dependency succeeds, so the dependent rotates too")
+	assert.Equal(t, 2, latestVersion(t, db, 2).VersionNumber)
+}
+
+// A cyclic graph (which the add path normally rejects, ADR-052) must never block
+// rotation: the executor falls back to a flat best-effort pass and still rotates.
+func TestRunAutoRotation_CyclicGraphFallsBackToFlatRotation(t *testing.T) {
+	c, db, fixed := depExecCore(t)
+	overdue := fixed.Add(-60 * 24 * time.Hour)
+	seedRotatableSecret(t, db, 1, "a", true, overdue)
+	seedRotatableSecret(t, db, 2, "b", true, overdue)
+	// Insert a cycle directly, bypassing the acyclic-at-create guard.
+	seedDependency(t, db, 1, 2)
+	seedDependency(t, db, 2, 1)
+
+	n, err := c.RunAutoRotation(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 2, n, "a cyclic graph falls back to flat order and still rotates both")
+	assert.Equal(t, 2, latestVersion(t, db, 1).VersionNumber)
+	assert.Equal(t, 2, latestVersion(t, db, 2).VersionNumber)
+}


### PR DESCRIPTION
## What

`RunAutoRotation` rotated overdue auto-rotate secrets in arbitrary policy/scan
order, ignoring the ADR-052 dependency graph the rotation *planner* already turns
into dependency-safe waves (ADR-053) — so it could rotate a dependent secret
before the dependency it derives from (e.g. an app token before the database
password it embeds).

## Change

- Within each project (dependency edges never cross a project boundary), due
  secrets now rotate in **dependency-safe wave order** via the existing
  cycle-safe `rotationWaves` topological sort.
- **Dependency-first:** when a dependency does not rotate this run (it failed, or
  was itself deferred), the dependent is **deferred** rather than rotated against
  a now-stale dependency — propagated transitively down the chain and audited
  distinctly so an operator can act.
- **Fallback:** a cyclic graph (rejected at add, but defended here) or an
  edge-fetch error degrades to a flat best-effort pass, so a malformed graph
  never blocks rotation.
- Per-secret rotation extracted into `rotateOneSecret`; existing
  audit/backend/drift behaviour is unchanged.

## Tests

New `rotation_executor_deps_test.go`:
- dependency ordering (the dependency is given a *higher* id to prove ordering is
  graph-driven, not scan-order),
- transitive deferral when a dependency fails,
- a sibling of a *successful* dependency still rotates,
- cyclic-graph fallback.

All prior auto-rotation tests still pass. `gosec` 0 / `golangci-lint` 0 / `go vet` / `gofmt` clean.
