### PR TITLE
feat(rotation): cascade secret soft-delete/restore/purge through the dependency graph (ADR-052/053)

### DIFF
--- a/internal/core/secret_dependencies.go
+++ b/internal/core/secret_dependencies.go
@@ -208,14 +208,18 @@ func (c *KeyorixCore) GetProjectRotationOrder(ctx context.Context, projectID uin
 	if err != nil {
 		return nil, err
 	}
+	// Rotation order is project-wide (authorized by a project-scoped grant that spans
+	// all environments), so no per-environment filter here — but a soft-deleted secret
+	// (ADR-033) must not appear in the order. Resolve names first, then drop any edge
+	// incident to a secret that no longer resolves, so the graph follows the secret's
+	// soft-delete/restore lifecycle (the env-scoped views filter the same way).
+	info := c.resolveSecretInfo(ctx, edges)
+	edges = edgesBetweenLiveSecrets(edges, info)
 	order, ok := topologicalRotationOrder(edges)
 	if !ok {
 		// Defensive: cycles are rejected at add, so a remaining cycle is a data fault.
 		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorInternal", nil), "the dependency graph contains a cycle")
 	}
-	// Rotation order is project-wide (authorized by a project-scoped grant that spans
-	// all environments), so no per-environment filter here.
-	info := c.resolveSecretInfo(ctx, edges)
 	out := &RotationOrder{ProjectID: projectID, Order: make([]SecretRef, 0, len(order))}
 	for _, id := range order {
 		out.Order = append(out.Order, SecretRef{SecretID: id, SecretName: info[id].name})
@@ -273,6 +277,24 @@ func edgesWithinEnvironment(edges []*models.SecretDependency, info map[uint]secr
 	out := make([]*models.SecretDependency, 0, len(edges))
 	for _, e := range edges {
 		if info[e.DependentSecretID].env == environmentID && info[e.DependsOnSecretID].env == environmentID {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// edgesBetweenLiveSecrets keeps only edges whose BOTH endpoints resolved to a live
+// secret (present in info). A soft-deleted endpoint does not resolve — GetSecret hides it
+// (ADR-033) — so it is absent from info, dropping every edge incident to it. The edge
+// rows are never mutated, so restoring the secret brings its edges back into the graph
+// automatically. Used by the project-wide rotation order, which (unlike the env-scoped
+// views) has no environment filter to exclude a deleted endpoint for it.
+func edgesBetweenLiveSecrets(edges []*models.SecretDependency, info map[uint]secretInfo) []*models.SecretDependency {
+	out := make([]*models.SecretDependency, 0, len(edges))
+	for _, e := range edges {
+		_, dependentLive := info[e.DependentSecretID]
+		_, dependsOnLive := info[e.DependsOnSecretID]
+		if dependentLive && dependsOnLive {
 			out = append(out, e)
 		}
 	}

--- a/internal/core/secret_dependencies_cascade_test.go
+++ b/internal/core/secret_dependencies_cascade_test.go
@@ -1,0 +1,85 @@
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// rotationOrderNames returns the secret names in a project's rotation order, and asserts
+// none is blank — a blank name means an edge to an unresolved (e.g. soft-deleted) secret
+// leaked into the order.
+func rotationOrderNames(t *testing.T, c *KeyorixCore, projectID uint) []string {
+	t.Helper()
+	ro, err := c.GetProjectRotationOrder(context.Background(), projectID)
+	require.NoError(t, err)
+	names := make([]string, len(ro.Order))
+	for i, r := range ro.Order {
+		require.NotEmpty(t, r.SecretName, "rotation order must not contain an unresolved (soft-deleted) secret")
+		names[i] = r.SecretName
+	}
+	return names
+}
+
+// A soft-deleted secret drops out of the project rotation order (it must not surface as a
+// phantom, blank-named node), the rest of the graph is unaffected, and restoring it brings
+// it — and its edges, which were never removed — straight back.
+func TestGetProjectRotationOrder_CascadesSoftDeleteAndRestore(t *testing.T) {
+	ctx := context.Background()
+	c, db := newDepCore(t)
+	dbPass := mkSecret(t, db, 1, "db-password")
+	appTok := mkSecret(t, db, 1, "app-token")
+	cacheKey := mkSecret(t, db, 1, "cache-key")
+	// app-token and cache-key both depend on db-password.
+	_, err := c.AddSecretDependency(ctx, 10, appTok, dbPass, "")
+	require.NoError(t, err)
+	_, err = c.AddSecretDependency(ctx, 10, cacheKey, dbPass, "")
+	require.NoError(t, err)
+
+	// Baseline: dependency first, then its two dependents (sorted by id).
+	assert.Equal(t, []string{"db-password", "app-token", "cache-key"}, rotationOrderNames(t, c, 1))
+
+	// Soft-delete one dependent: it leaves the order; db-password and cache-key remain.
+	require.NoError(t, c.DeleteSecret(ctx, appTok))
+	assert.Equal(t, []string{"db-password", "cache-key"}, rotationOrderNames(t, c, 1),
+		"the soft-deleted secret is gone from the order, with no blank-named phantom")
+
+	// Restore it: the edge row was never removed, so it reappears in full.
+	require.NoError(t, c.RestoreSecret(ctx, 0, appTok))
+	assert.Equal(t, []string{"db-password", "app-token", "cache-key"}, rotationOrderNames(t, c, 1),
+		"restoring the secret brings it and its dependency edge back")
+}
+
+// Impact analysis (the blast radius of rotating a secret) excludes a soft-deleted
+// dependent and includes it again after restore.
+func TestGetSecretImpact_CascadesSoftDeleteAndRestore(t *testing.T) {
+	ctx := context.Background()
+	c, db := newDepCore(t)
+	dbPass := mkSecret(t, db, 1, "db-password")
+	appTok := mkSecret(t, db, 1, "app-token")
+	cacheKey := mkSecret(t, db, 1, "cache-key")
+	_, err := c.AddSecretDependency(ctx, 10, appTok, dbPass, "")
+	require.NoError(t, err)
+	_, err = c.AddSecretDependency(ctx, 10, cacheKey, dbPass, "")
+	require.NoError(t, err)
+
+	impactNames := func() []string {
+		si, err := c.GetSecretImpact(ctx, dbPass)
+		require.NoError(t, err)
+		names := make([]string, len(si.Affected))
+		for i, a := range si.Affected {
+			names[i] = a.SecretName
+		}
+		return names
+	}
+
+	assert.ElementsMatch(t, []string{"app-token", "cache-key"}, impactNames())
+
+	require.NoError(t, c.DeleteSecret(ctx, appTok))
+	assert.ElementsMatch(t, []string{"cache-key"}, impactNames(), "soft-deleted dependent drops from the blast radius")
+
+	require.NoError(t, c.RestoreSecret(ctx, 0, appTok))
+	assert.ElementsMatch(t, []string{"app-token", "cache-key"}, impactNames(), "restore brings it back")
+}

--- a/internal/storage/store/local_purge.go
+++ b/internal/storage/store/local_purge.go
@@ -39,8 +39,38 @@ func (ls *LocalStorage) PurgeDeletedEnvironmentsBefore(ctx context.Context, befo
 	return ls.purgeDeletedBefore(ctx, &models.Environment{}, before)
 }
 
+// PurgeDeletedSecretsBefore hard-deletes soft-deleted secrets past the cutoff together
+// with the dependency-graph edges incident to them, in one transaction. A SecretDependency
+// edge has no soft-delete of its own (ADR-052) — it lives and dies with its endpoints — so
+// purging a secret without removing its edges would leave rows referencing a hard-deleted
+// secret. Returns the number of secrets purged (edge rows are not counted).
 func (ls *LocalStorage) PurgeDeletedSecretsBefore(ctx context.Context, before time.Time) (int64, error) {
-	return ls.purgeDeletedBefore(ctx, &models.SecretNode{}, before)
+	var purged int64
+	err := ls.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var ids []uint
+		if e := tx.Unscoped().Model(&models.SecretNode{}).
+			Where("deleted_at IS NOT NULL AND deleted_at < ?", before).
+			Pluck("id", &ids).Error; e != nil {
+			return e
+		}
+		if len(ids) == 0 {
+			return nil
+		}
+		if e := tx.Where("dependent_secret_id IN ? OR depends_on_secret_id IN ?", ids, ids).
+			Delete(&models.SecretDependency{}).Error; e != nil {
+			return e
+		}
+		r := tx.Unscoped().Where("id IN ?", ids).Delete(&models.SecretNode{})
+		if r.Error != nil {
+			return r.Error
+		}
+		purged = r.RowsAffected
+		return nil
+	})
+	if err != nil {
+		return 0, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	return purged, nil
 }
 
 // --- Data-retention purges (ISO A.5.33 / GDPR storage-limitation) ---

--- a/internal/storage/store/secret_soft_delete_test.go
+++ b/internal/storage/store/secret_soft_delete_test.go
@@ -17,7 +17,7 @@ func newSoftDeleteTestStore(t *testing.T) *LocalStorage {
 	t.Helper()
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
-	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.Environment{}))
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.Environment{}, &models.SecretDependency{}))
 	return NewLocalStorage(db)
 }
 
@@ -78,6 +78,28 @@ func TestPurgeDeletedSecretsBefore(t *testing.T) {
 	var remaining int64
 	require.NoError(t, ls.db.Unscoped().Model(&models.SecretNode{}).Where("name = ?", "old").Count(&remaining).Error)
 	assert.Equal(t, int64(0), remaining, "purged row hard-deleted")
+}
+
+// Purging a soft-deleted secret also removes the dependency-graph edges incident to it,
+// so the graph is never left with rows pointing at a hard-deleted secret (ADR-052).
+func TestPurgeDeletedSecretsBefore_CascadesDependencyEdges(t *testing.T) {
+	ls := newSoftDeleteTestStore(t)
+	ctx := context.Background()
+
+	// Two secrets with an edge between them; one survives, one is purged.
+	require.NoError(t, ls.db.Create(&models.SecretNode{ID: 1, ProjectID: 1, EnvironmentID: 10, Name: "db-password", IsSecret: true}).Error)
+	require.NoError(t, ls.db.Create(&models.SecretNode{ID: 2, ProjectID: 1, EnvironmentID: 10, Name: "app-token", IsSecret: true}).Error)
+	require.NoError(t, ls.db.Create(&models.SecretDependency{ProjectID: 1, DependentSecretID: 2, DependsOnSecretID: 1}).Error)
+	// Soft-delete db-password 40 days ago; it is past a 30-day retention cutoff.
+	require.NoError(t, ls.db.Unscoped().Model(&models.SecretNode{}).Where("id = ?", 1).Update("deleted_at", time.Now().AddDate(0, 0, -40)).Error)
+
+	n, err := ls.PurgeDeletedSecretsBefore(ctx, time.Now().AddDate(0, 0, -30))
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), n)
+
+	var edges int64
+	require.NoError(t, ls.db.Model(&models.SecretDependency{}).Count(&edges).Error)
+	assert.Equal(t, int64(0), edges, "the edge incident to the purged secret is removed (no orphan)")
 }
 
 func ptr[T any](v T) *T { return &v }


### PR DESCRIPTION
## What

A soft-deleted secret (ADR-033) left its dependency-graph edges (ADR-052) behind,
and nothing filtered them out of the **project rotation order** — so a deleted
secret surfaced as a **phantom, blank-named node** in `GetProjectRotationOrder`.
(The env-scoped views — `ListSecretDependencies`, `GetSecretImpact` — already
dropped it via the same-environment filter; the project-wide rotation order had no
equivalent.) And the eventual hard purge left **orphan edge rows** pointing at a
gone secret.

## Change

- **`GetProjectRotationOrder`** resolves names first, then drops every edge
  incident to a secret that no longer resolves (`edgesBetweenLiveSecrets`), so a
  soft-deleted secret leaves the order cleanly. Edge rows are never mutated, so
  **restoring** the secret brings it — and its edges — straight back; the graph
  follows the secret's soft-delete/restore lifecycle for free.
- **`PurgeDeletedSecretsBefore`** (ADR-032) now removes the dependency edges
  incident to a purged secret in the **same transaction**, mirroring the
  access-review / access-request purge cascades — no orphan edge row remains.

## Tests

- rotation order excludes a soft-deleted secret (asserts **no blank-named
  phantom**) and restores it,
- impact analysis cascades the same way,
- purge removes incident edges (no orphan).

Existing purge/soft-delete tests now migrate the dependency table to match
production `AutoMigrate`. `gosec` 0 / `golangci-lint` 0 / `go vet` / `gofmt` clean;
full `internal/core` + `internal/storage/store` suites pass.
