### PR TITLE
feat(rotation): refresh the cached certificate expiry on rotation (ADR-056)

### DIFF
--- a/internal/core/certificate.go
+++ b/internal/core/certificate.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
 // EventSecretCertificateInspected is audited when a certificate's metadata is read.
@@ -101,6 +102,28 @@ func (c *KeyorixCore) InspectCertificate(ctx context.Context, actorID, secretID 
 	c.writeAuditEvent(ctx, EventSecretCertificateInspected, actorPtr(actorID), &sid,
 		fmt.Sprintf("inspected certificate %q (issuer %q, expires %s)", secret.Name, info.Issuer, info.NotAfter.UTC().Format("2006-01-02")))
 	return info, nil
+}
+
+// certificateSecretType is the SecretNode.Type that marks a certificate-typed secret,
+// whose leaf-expiry is cached in CertNotAfter for the certificate-hygiene posture (ADR-056).
+const certificateSecretType = "certificate"
+
+// refreshCertNotAfterCache updates the cached leaf-certificate expiry (CertNotAfter,
+// ADR-056) for a certificate-typed secret from a known plaintext value — used after a
+// rotation so the certificate-hygiene posture reflects the new certificate immediately,
+// without waiting for the next expiry scan. A parseable certificate refreshes the cached
+// date; a value that is not a certificate (e.g. the secret was rotated to a non-cert
+// value) clears the now-stale date. A no-op for non-certificate secrets. Best-effort: a
+// cache write failure never fails the caller, mirroring InspectCertificate's cache write.
+func (c *KeyorixCore) refreshCertNotAfterCache(ctx context.Context, secret *models.SecretNode, value []byte) {
+	if secret == nil || secret.Type != certificateSecretType {
+		return
+	}
+	if cert, err := parseLeafCertificate(value); err == nil {
+		_ = c.storage.SetSecretCertNotAfter(ctx, secret.ID, &cert.NotAfter)
+	} else {
+		_ = c.storage.SetSecretCertNotAfter(ctx, secret.ID, nil)
+	}
 }
 
 // parseLeafCertificate extracts the first X.509 certificate from a value that may be

--- a/internal/core/certificate_expiry.go
+++ b/internal/core/certificate_expiry.go
@@ -121,7 +121,7 @@ func (c *KeyorixCore) certNotAfter(ctx context.Context, secret *models.SecretNod
 // listCertificateSecrets returns every certificate-typed secret across all projects,
 // paging through all of them (expiry evaluation must not silently cap).
 func (c *KeyorixCore) listCertificateSecrets(ctx context.Context) ([]*models.SecretNode, error) {
-	certType := "certificate"
+	certType := certificateSecretType
 	var all []*models.SecretNode
 	for page := 1; ; page++ {
 		secrets, total, err := c.storage.ListSecrets(ctx, &storage.SecretFilter{

--- a/internal/core/certificate_rotation_test.go
+++ b/internal/core/certificate_rotation_test.go
@@ -1,0 +1,79 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Rotating a certificate-typed secret refreshes the cached leaf-expiry (CertNotAfter,
+// ADR-056) immediately, so the certificate-hygiene posture reflects the new certificate
+// without waiting for the next expiry scan.
+func TestRotateSecret_RefreshesCertNotAfterCache(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 6, 23, 12, 0, 0, 0, time.UTC)
+	c, db := newCertCore(t, now)
+
+	oldExpiry := now.Add(30 * 24 * time.Hour)
+	cert1, _ := selfSignedPEM(t, "a.example.com", oldExpiry)
+	mkCertSecret(t, db, 1, "tls-cert", "active", cert1)
+
+	// Prime the cache to the old certificate's expiry (as a scan / inspection would).
+	_, err := c.InspectCertificate(ctx, 9, 1)
+	require.NoError(t, err)
+	primed, err := c.storage.GetSecret(ctx, 1)
+	require.NoError(t, err)
+	require.NotNil(t, primed.CertNotAfter)
+	assert.WithinDuration(t, oldExpiry, *primed.CertNotAfter, time.Second)
+
+	// Rotate to a renewed certificate with a later expiry.
+	newExpiry := now.Add(90 * 24 * time.Hour)
+	cert2, _ := selfSignedPEM(t, "a.example.com", newExpiry)
+	_, err = c.RotateSecret(ctx, 1, cert2, "tester")
+	require.NoError(t, err)
+
+	got, err := c.storage.GetSecret(ctx, 1)
+	require.NoError(t, err)
+	require.NotNil(t, got.CertNotAfter, "the cached expiry is refreshed on rotation")
+	assert.WithinDuration(t, newExpiry, *got.CertNotAfter, time.Second,
+		"CertNotAfter reflects the rotated certificate, not the old one")
+}
+
+// Rotating a non-certificate secret does not touch CertNotAfter (it stays nil).
+func TestRotateSecret_NonCertSecretLeavesCertNotAfterNil(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 6, 23, 12, 0, 0, 0, time.UTC)
+	c, db := newCertCore(t, now)
+	require.NoError(t, db.Create(&models.SecretNode{ID: 1, Name: "api-key", IsSecret: true, Status: "active", Type: "api_key"}).Error)
+	require.NoError(t, db.Create(&models.SecretVersion{SecretNodeID: 1, VersionNumber: 1, EncryptedValue: []byte("old-value")}).Error)
+
+	_, err := c.RotateSecret(ctx, 1, []byte("new-random-value"), "tester")
+	require.NoError(t, err)
+
+	got, err := c.storage.GetSecret(ctx, 1)
+	require.NoError(t, err)
+	assert.Nil(t, got.CertNotAfter, "a non-certificate secret never gets a cached cert expiry")
+}
+
+// A certificate-typed secret rotated to a value that is not a certificate clears the now-
+// stale cached expiry, rather than leaving the old certificate's date in place.
+func TestRotateSecret_CertRotatedToNonCertClearsCache(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 6, 23, 12, 0, 0, 0, time.UTC)
+	c, db := newCertCore(t, now)
+	cert1, _ := selfSignedPEM(t, "a.example.com", now.Add(30*24*time.Hour))
+	mkCertSecret(t, db, 1, "tls-cert", "active", cert1)
+	_, err := c.InspectCertificate(ctx, 9, 1) // prime the cache
+	require.NoError(t, err)
+
+	_, err = c.RotateSecret(ctx, 1, []byte("no-longer-a-certificate"), "tester")
+	require.NoError(t, err)
+
+	got, err := c.storage.GetSecret(ctx, 1)
+	require.NoError(t, err)
+	assert.Nil(t, got.CertNotAfter, "the stale cached expiry is cleared when the value is no longer a certificate")
+}

--- a/internal/core/secrets.go
+++ b/internal/core/secrets.go
@@ -227,6 +227,11 @@ func (c *KeyorixCore) RotateSecret(ctx context.Context, id uint, newValue []byte
 	if err != nil {
 		return nil, fmt.Errorf("failed to update rotation timestamp: %w", err)
 	}
+	// Refresh the cached certificate expiry immediately for a certificate-typed secret
+	// (ADR-056) so the certificate-hygiene posture reflects the rotated certificate
+	// without waiting for the next expiry scan. The plaintext is already in hand, so no
+	// re-decryption is needed; a no-op for non-certificate secrets.
+	c.refreshCertNotAfterCache(ctx, secret, newValue)
 	return updatedSecret, nil
 }
 


### PR DESCRIPTION
## What

A certificate-typed secret caches its leaf-certificate expiry in `CertNotAfter` so
the **certificate-hygiene posture** (ADR-056) can report expiry without decrypting on
the read path. That cache was populated only by `InspectCertificate` and the daily
expiry scan — `RotateSecret` stored a new version and bumped `LastRotatedAt` but
**never refreshed `CertNotAfter`**. So after rotating (renewing) a certificate, the
posture kept reporting the **old** certificate's expiry until the next scan (up to
~24h stale).

## Change

`RotateSecret` now refreshes the cache immediately for a certificate-typed secret —
the rotated plaintext is already in hand, so it parses the new leaf certificate and
updates `CertNotAfter`, or **clears** it if the secret was rotated to a non-certificate
value (so a stale date is never left behind). A no-op for non-certificate secrets, and
best-effort — a cache write failure never fails the rotation, mirroring
`InspectCertificate`'s cache write.

Also adds the `certificateSecretType` constant (replacing the `"certificate"` string
literal the expiry scan used) and the `refreshCertNotAfterCache` helper.

## Tests

- rotating a certificate refreshes `CertNotAfter` to the new expiry,
- a non-certificate secret is untouched (stays nil),
- a certificate rotated to a non-certificate value clears the cache.

`gosec` 0 / `golangci-lint` 0 / `go vet` / `gofmt` clean; full `internal/core` suite passes.
