### PR TITLE
fix(anomaly): exclude the live detection window from its own baseline (statistical + ML)

### DIFF
--- a/internal/core/anomaly.go
+++ b/internal/core/anomaly.go
@@ -60,7 +60,7 @@ func (d *AnomalyDetector) RunDetection(ctx context.Context, secrets []models.Sec
 		if len(baselineLogs) == 0 {
 			continue
 		}
-		baseline := buildBaseline(baselineLogs, now)
+		baseline := buildBaseline(baselineLogs, now, window)
 
 		// Get recent accesses (last hour)
 		recentLogs, err := d.storage.ListSecretAccessLogs(ctx, secret.ID, window)
@@ -93,8 +93,14 @@ func (d *AnomalyDetector) RunDetection(ctx context.Context, secrets []models.Sec
 	return nil
 }
 
-// buildBaseline computes statistical baseline from historical access logs.
-func buildBaseline(logs []models.SecretAccessLog, now time.Time) accessBaseline {
+// buildBaseline computes the statistical baseline from historical access logs,
+// EXCLUDING the live detection window [windowStart, now]. The reads being evaluated
+// this pass must not seed their own baseline: the baseline query spans 30 days and
+// therefore contains the last hour too, so without this exclusion a genuinely new IP
+// or user would already appear in knownIPs/knownUsers and the new_ip / new_user rules
+// could never fire. Excluding the window also keeps the volume baseline (dailyAvg)
+// from inflating itself with the very burst a spike check is meant to catch.
+func buildBaseline(logs []models.SecretAccessLog, now, windowStart time.Time) accessBaseline {
 	b := accessBaseline{
 		knownIPs:   make(map[string]bool),
 		knownUsers: make(map[string]bool),
@@ -103,6 +109,10 @@ func buildBaseline(logs []models.SecretAccessLog, now time.Time) accessBaseline 
 	recentCount := 0
 
 	for _, log := range logs {
+		// Skip the live window so this pass's reads don't establish their own baseline.
+		if !log.AccessTime.Before(windowStart) {
+			continue
+		}
 		if log.IPAddress != "" {
 			b.knownIPs[log.IPAddress] = true
 		}

--- a/internal/core/anomaly.go
+++ b/internal/core/anomaly.go
@@ -82,15 +82,32 @@ func (d *AnomalyDetector) RunDetection(ctx context.Context, secrets []models.Sec
 		}
 
 		// ML pass (opt-in): score this window's accesses against an Isolation Forest
-		// trained on the secret's full 30-day baseline, catching multivariate outliers
-		// the single-signal rules above miss.
+		// trained on the secret's prior history, catching multivariate outliers the
+		// single-signal rules above miss. Train only on logs BEFORE the window — for the
+		// same reason buildBaseline excludes it: otherwise the forest learns this window's
+		// reads as normal (and the IP/user frequency features count the burst as
+		// established), so it can't isolate the very accesses it is scoring.
 		if d.ml.Enabled {
-			for _, alert := range mlOutlierAlerts(secret, baselineLogs, recentLogs, d.ml, now) {
+			trainLogs := logsBefore(baselineLogs, window)
+			for _, alert := range mlOutlierAlerts(secret, trainLogs, recentLogs, d.ml, now) {
 				_ = d.storage.CreateAnomalyAlert(ctx, &alert)
 			}
 		}
 	}
 	return nil
+}
+
+// logsBefore returns the access logs that occurred strictly before t, preserving
+// order. Used to exclude the live detection window from the ML training set so this
+// pass's reads don't train the model that is meant to flag them.
+func logsBefore(logs []models.SecretAccessLog, t time.Time) []models.SecretAccessLog {
+	out := make([]models.SecretAccessLog, 0, len(logs))
+	for _, lg := range logs {
+		if lg.AccessTime.Before(t) {
+			out = append(out, lg)
+		}
+	}
+	return out
 }
 
 // buildBaseline computes the statistical baseline from historical access logs,

--- a/internal/core/anomaly_alerting_external_test.go
+++ b/internal/core/anomaly_alerting_external_test.go
@@ -43,6 +43,47 @@ func TestAlertNewAnomalies(t *testing.T) {
 	assert.Equal(t, 0, n)
 }
 
+// Regression: a first-time reader / first-seen IP in the detection window must raise
+// new_user / new_ip. The 30-day baseline query also spans the live 1h window, so before
+// the fix the triggering read seeded its own baseline (knownUsers/knownIPs already
+// contained it) and these two high-severity rules could never fire end-to-end.
+func TestRunDetection_FlagsNewUserAndIPAgainstPriorBaseline(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(&models.SecretNode{}, &models.SecretAccessLog{}, &models.AnomalyAlert{}))
+
+	ctx := context.Background()
+	secret := models.SecretNode{ID: 800, ProjectID: 1, Name: "db-pw", Status: "active", IsSecret: true}
+	require.NoError(t, h.DB.Create(&secret).Error)
+
+	// Established history (outside the 1h detection window): alice from a known IP.
+	for i := 2; i <= 10; i++ {
+		require.NoError(t, h.DB.Create(&models.SecretAccessLog{
+			SecretNodeID: 800, AccessedBy: "alice", Action: "read", IPAddress: "10.0.0.1",
+			AccessTime: time.Now().Add(-time.Duration(i) * 24 * time.Hour),
+		}).Error)
+	}
+	// A brand-new principal from a brand-new IP reads now (inside the detection window).
+	require.NoError(t, h.DB.Create(&models.SecretAccessLog{
+		SecretNodeID: 800, AccessedBy: "mallory", Action: "read", IPAddress: "203.0.113.5",
+		AccessTime: time.Now(),
+	}).Error)
+
+	detector := core.NewAnomalyDetector(h.CoreService.Storage())
+	require.NoError(t, detector.RunDetection(ctx, []models.SecretNode{secret}))
+
+	alerts, err := detector.ListAlerts(ctx, nil)
+	require.NoError(t, err)
+	kinds := map[string]bool{}
+	for _, a := range alerts {
+		if a.SecretNodeID == 800 {
+			kinds[a.AlertType] = true
+		}
+	}
+	assert.True(t, kinds["new_user"], "a first-time reader must raise new_user")
+	assert.True(t, kinds["new_ip"], "a first-seen IP must raise new_ip")
+}
+
 // The compliance posture counts open (unacknowledged) anomalies, with a high-severity tally.
 func TestCompliancePosture_Anomalies(t *testing.T) {
 	h := testhelper.NewRBACTestHelper(t)

--- a/internal/core/anomaly_test.go
+++ b/internal/core/anomaly_test.go
@@ -11,20 +11,25 @@ import (
 
 func TestBuildBaseline(t *testing.T) {
 	now := time.Date(2026, 6, 17, 12, 0, 0, 0, time.UTC)
+	windowStart := now.Add(-1 * time.Hour) // the live detection window — excluded from the baseline
 	logs := []models.SecretAccessLog{
-		{IPAddress: "10.0.0.1", AccessedBy: "alice", AccessTime: now.Add(-1 * time.Hour)},       // in 7d
-		{IPAddress: "10.0.0.2", AccessedBy: "bob", AccessTime: now.Add(-2 * 24 * time.Hour)},    // in 7d
-		{IPAddress: "10.0.0.1", AccessedBy: "alice", AccessTime: now.Add(-20 * 24 * time.Hour)}, // older than 7d
+		{IPAddress: "203.0.113.9", AccessedBy: "mallory", AccessTime: now.Add(-30 * time.Minute)}, // inside window → excluded
+		{IPAddress: "10.0.0.2", AccessedBy: "bob", AccessTime: now.Add(-2 * 24 * time.Hour)},       // in 7d, before window
+		{IPAddress: "10.0.0.1", AccessedBy: "alice", AccessTime: now.Add(-20 * 24 * time.Hour)},    // older than 7d
 	}
-	b := buildBaseline(logs, now)
+	b := buildBaseline(logs, now, windowStart)
+	// The in-window read must NOT seed the baseline, else it would mask its own anomaly.
+	if b.knownIPs["203.0.113.9"] || b.knownUsers["mallory"] {
+		t.Fatalf("in-window read must be excluded from the baseline, got IPs=%v users=%v", b.knownIPs, b.knownUsers)
+	}
 	if !b.knownIPs["10.0.0.1"] || !b.knownIPs["10.0.0.2"] {
-		t.Fatalf("expected both IPs learned, got %v", b.knownIPs)
+		t.Fatalf("expected historical IPs learned, got %v", b.knownIPs)
 	}
 	if !b.knownUsers["alice"] || !b.knownUsers["bob"] {
-		t.Fatalf("expected both users learned, got %v", b.knownUsers)
+		t.Fatalf("expected historical users learned, got %v", b.knownUsers)
 	}
-	// 2 of 3 accesses fall in the last 7 days → dailyAvg = 2/7.
-	if want := 2.0 / 7.0; b.dailyAvg != want {
+	// Of the pre-window reads, only bob's (-2d) is within the last 7 days → dailyAvg = 1/7.
+	if want := 1.0 / 7.0; b.dailyAvg != want {
 		t.Fatalf("dailyAvg = %v, want %v", b.dailyAvg, want)
 	}
 }

--- a/internal/core/anomaly_test.go
+++ b/internal/core/anomaly_test.go
@@ -34,6 +34,20 @@ func TestBuildBaseline(t *testing.T) {
 	}
 }
 
+func TestLogsBefore(t *testing.T) {
+	now := time.Date(2026, 6, 17, 12, 0, 0, 0, time.UTC)
+	cutoff := now.Add(-1 * time.Hour)
+	logs := []models.SecretAccessLog{
+		{AccessedBy: "old", AccessTime: now.Add(-2 * time.Hour)},       // before cutoff → kept
+		{AccessedBy: "edge", AccessTime: cutoff},                       // exactly at cutoff → excluded (strictly before)
+		{AccessedBy: "recent", AccessTime: now.Add(-1 * time.Minute)},  // after cutoff → excluded
+	}
+	got := logsBefore(logs, cutoff)
+	if len(got) != 1 || got[0].AccessedBy != "old" {
+		t.Fatalf("logsBefore should keep only the pre-cutoff log, got %+v", got)
+	}
+}
+
 func TestDetectAnomalies(t *testing.T) {
 	secret := models.SecretNode{ID: 1, Name: "db"}
 	baseline := accessBaseline{


### PR DESCRIPTION
## Summary

`RunDetection` built each secret's 30-day baseline with a window that also spans the
last hour it then evaluates, so `buildBaseline` learned the very reads under
inspection. A brand-new IP or user was already in `knownIPs`/`knownUsers` by the time
the rules checked, so `new_ip` and `new_user` — the two highest-severity
exfiltration signals — could never fire end-to-end. They only passed in unit tests
that build the baseline from a separate hand-built log set. The opt-in ML pass had the
same flaw: it trained the Isolation Forest (and its IP/user frequency features) on
`baselineLogs` that include the window, so a burst trained itself as normal.

## Changes
- `buildBaseline` now excludes the live detection window — this pass's reads no
  longer seed their own baseline.
- The ML pass trains only on history strictly older than the window (`logsBefore`).

## Tests
- `TestRunDetection_FlagsNewUserAndIPAgainstPriorBaseline` — end-to-end, fails
  without the fix.
- `TestBuildBaseline` asserts the in-window exclusion; `TestLogsBefore` covers the ML
  training filter.
- Full `internal/core` suite green, gosec clean.
