### PR TITLE
feat(anomaly): configurable timezone + off-hours band for the off_hours rule

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1184,6 +1184,21 @@ type AnomalyAlertsConfig struct {
 	// independent of Enabled (which gates alert *push*): ML.Enabled gates whether the
 	// detection scan additionally scores accesses for multivariate outliers.
 	ML AnomalyMLConfig `yaml:"ml"`
+	// BusinessHours configures the timezone and band the off_hours rule uses. Unset =
+	// the legacy UTC 22:00–06:00 default.
+	BusinessHours AnomalyBusinessHoursConfig `yaml:"business_hours"`
+}
+
+// AnomalyBusinessHoursConfig defines when secret access counts as "off hours" for the
+// off_hours detection rule. The hours are evaluated in Timezone, and the off-hours band
+// is [OffHoursStart, OffHoursEnd) wrapping midnight (e.g. 22→6). All fields are optional
+// and default to the legacy behaviour: UTC, 22:00–06:00. Setting Timezone alone is the
+// common case — it stops flagging local business-hours access as off-hours on non-UTC
+// deployments (and vice versa).
+type AnomalyBusinessHoursConfig struct {
+	Timezone      string `yaml:"timezone"`        // IANA name (e.g. "America/New_York"); "" = UTC
+	OffHoursStart int    `yaml:"off_hours_start"` // off-hours band start hour [0,23]; default 22
+	OffHoursEnd   int    `yaml:"off_hours_end"`   // off-hours band end hour [0,23]; default 6
 }
 
 // AnomalyMLConfig configures the Isolation Forest anomaly-detection pass (ADR-050).

--- a/internal/core/anomaly.go
+++ b/internal/core/anomaly.go
@@ -12,8 +12,9 @@ import (
 // and, when enabled, an Isolation Forest (ADR-050). Operates on metadata only — secret
 // values are never examined.
 type AnomalyDetector struct {
-	storage StorageInterface
-	ml      MLConfig // ML pass; disabled by default (see SetMLConfig)
+	storage  StorageInterface
+	ml       MLConfig       // ML pass; disabled by default (see SetMLConfig)
+	offHours offHoursPolicy // off_hours rule window; defaults to UTC 22:00–06:00
 }
 
 // StorageInterface is satisfied by *storage.LocalStorage and *storage.RemoteStorage.
@@ -24,9 +25,10 @@ type StorageInterface = interface {
 	AcknowledgeAnomalyAlert(ctx context.Context, id uint) error
 }
 
-// NewAnomalyDetector creates a new AnomalyDetector with the ML pass disabled.
+// NewAnomalyDetector creates a new AnomalyDetector with the ML pass disabled and the
+// off-hours window at its UTC 22:00–06:00 default.
 func NewAnomalyDetector(storage StorageInterface) *AnomalyDetector {
-	return &AnomalyDetector{storage: storage}
+	return &AnomalyDetector{storage: storage, offHours: defaultOffHoursPolicy()}
 }
 
 // SetMLConfig enables (or reconfigures) the Isolation Forest pass. Defaults are
@@ -35,6 +37,66 @@ func NewAnomalyDetector(storage StorageInterface) *AnomalyDetector {
 // rules run.
 func (d *AnomalyDetector) SetMLConfig(cfg MLConfig) {
 	d.ml = cfg
+}
+
+// offHoursPolicy defines the "off hours" band for the off_hours rule. Hours are
+// evaluated in loc, and the band is [start, end) wrapping midnight (e.g. 22→6 means
+// 22:00–23:59 plus 00:00–05:59).
+type offHoursPolicy struct {
+	loc   *time.Location
+	start int // off-hours band start hour [0,23]
+	end   int // off-hours band end hour [0,23], exclusive
+}
+
+// defaultOffHoursPolicy is the legacy hardcoded behaviour: UTC, 22:00–06:00.
+func defaultOffHoursPolicy() offHoursPolicy {
+	return offHoursPolicy{loc: time.UTC, start: 22, end: 6}
+}
+
+// isOffHours reports whether t falls in the off-hours band, evaluated in the policy's
+// timezone. A band with start <= end is a normal interval [start, end); start > end is
+// a band that wraps midnight.
+func (p offHoursPolicy) isOffHours(t time.Time) bool {
+	loc := p.loc
+	if loc == nil { // zero-value policy → treat as UTC rather than panic in t.In
+		loc = time.UTC
+	}
+	h := t.In(loc).Hour()
+	if p.start <= p.end {
+		return h >= p.start && h < p.end
+	}
+	return h >= p.start || h < p.end
+}
+
+// validHour reports whether h is a valid clock hour [0,23].
+func validHour(h int) bool { return h >= 0 && h <= 23 }
+
+// SetBusinessHours configures the off_hours rule's timezone and band. tz is an IANA
+// name ("" = UTC); the off-hours band is [startHour, endHour) wrapping midnight, in
+// that timezone. A blank tz keeps UTC, and the band defaults to 22:00–06:00 unless
+// overridden. Because 0 is the config zero value AND a valid hour, both hours being 0
+// is treated as "unset" (a 0–0 band would be empty) — set the timezone alone and the
+// default band is kept. Returns an error only for an unparseable timezone, leaving the
+// prior policy unchanged.
+func (d *AnomalyDetector) SetBusinessHours(tz string, startHour, endHour int) error {
+	p := defaultOffHoursPolicy()
+	if tz != "" {
+		loc, err := time.LoadLocation(tz)
+		if err != nil {
+			return fmt.Errorf("anomaly business_hours timezone %q: %w", tz, err)
+		}
+		p.loc = loc
+	}
+	if startHour != 0 || endHour != 0 { // both zero = unset → keep the default band
+		if validHour(startHour) {
+			p.start = startHour
+		}
+		if validHour(endHour) {
+			p.end = endHour
+		}
+	}
+	d.offHours = p
+	return nil
 }
 
 // accessBaseline holds statistical baseline for a secret's access patterns.
@@ -69,7 +131,7 @@ func (d *AnomalyDetector) RunDetection(ctx context.Context, secrets []models.Sec
 		}
 
 		for _, accessLog := range recentLogs {
-			alerts := detectAnomalies(secret, accessLog, baseline)
+			alerts := detectAnomalies(secret, accessLog, baseline, d.offHours)
 			for _, alert := range alerts {
 				_ = d.storage.CreateAnomalyAlert(ctx, &alert)
 			}
@@ -118,19 +180,18 @@ func buildBaseline(logs []models.SecretAccessLog, now time.Time) accessBaseline 
 }
 
 // detectAnomalies checks a single access log entry against the baseline.
-func detectAnomalies(secret models.SecretNode, log models.SecretAccessLog, baseline accessBaseline) []models.AnomalyAlert {
+func detectAnomalies(secret models.SecretNode, log models.SecretAccessLog, baseline accessBaseline, offHours offHoursPolicy) []models.AnomalyAlert {
 	var alerts []models.AnomalyAlert
 	now := time.Now().UTC()
 
-	// Rule 1: Off-hours access (22:00 - 06:00 UTC)
-	hour := log.AccessTime.UTC().Hour()
-	if hour >= 22 || hour < 6 {
+	// Rule 1: Off-hours access (configurable band + timezone; default 22:00–06:00 UTC).
+	if offHours.isOffHours(log.AccessTime) {
 		alerts = append(alerts, models.AnomalyAlert{
 			SecretNodeID: secret.ID,
 			SecretName:   secret.Name,
 			AlertType:    "off_hours",
 			Severity:     "medium",
-			Description:  fmt.Sprintf("Secret accessed outside business hours at %s UTC", log.AccessTime.UTC().Format("15:04")),
+			Description:  fmt.Sprintf("Secret accessed outside business hours at %s", log.AccessTime.In(offHours.loc).Format("15:04 MST")),
 			AccessedBy:   log.AccessedBy,
 			IPAddress:    log.IPAddress,
 			DetectedAt:   now,

--- a/internal/core/anomaly_test.go
+++ b/internal/core/anomaly_test.go
@@ -43,7 +43,7 @@ func TestDetectAnomalies(t *testing.T) {
 			AccessedBy: "mallory",
 			AccessTime: time.Date(2026, 6, 17, 3, 0, 0, 0, time.UTC),
 		}
-		got := kindsOf(detectAnomalies(secret, lg, baseline))
+		got := kindsOf(detectAnomalies(secret, lg, baseline, defaultOffHoursPolicy()))
 		for _, want := range []string{"off_hours", "new_ip", "new_user"} {
 			if !got[want] {
 				t.Errorf("expected %s alert, got %v", want, got)
@@ -57,7 +57,7 @@ func TestDetectAnomalies(t *testing.T) {
 			AccessedBy: "alice",
 			AccessTime: time.Date(2026, 6, 17, 14, 0, 0, 0, time.UTC),
 		}
-		if alerts := detectAnomalies(secret, lg, baseline); len(alerts) != 0 {
+		if alerts := detectAnomalies(secret, lg, baseline, defaultOffHoursPolicy()); len(alerts) != 0 {
 			t.Fatalf("expected no alerts, got %v", kindsOf(alerts))
 		}
 	})
@@ -71,10 +71,58 @@ func TestDetectAnomalies(t *testing.T) {
 			AccessTime: time.Date(2026, 6, 17, 14, 0, 0, 0, time.UTC),
 		}
 		empty := accessBaseline{knownIPs: map[string]bool{}, knownUsers: map[string]bool{}}
-		if alerts := detectAnomalies(secret, lg, empty); len(alerts) != 0 {
+		if alerts := detectAnomalies(secret, lg, empty, defaultOffHoursPolicy()); len(alerts) != 0 {
 			t.Fatalf("expected no alerts against an empty baseline, got %v", kindsOf(alerts))
 		}
 	})
+}
+
+// The off-hours decision must be evaluated in the configured timezone: the same
+// instant can be off-hours in UTC but business hours elsewhere. This is the bug the
+// hardcoded-UTC rule had on non-UTC deployments.
+func TestOffHoursPolicy(t *testing.T) {
+	la, err := time.LoadLocation("America/Los_Angeles")
+	require.NoError(t, err)
+
+	// 2026-06-17 01:00 UTC == 2026-06-16 18:00 PDT (UTC-7 in summer).
+	instant := time.Date(2026, 6, 17, 1, 0, 0, 0, time.UTC)
+
+	if !defaultOffHoursPolicy().isOffHours(instant) {
+		t.Errorf("01:00 UTC must be off-hours under the UTC 22–6 default")
+	}
+	pacific := offHoursPolicy{loc: la, start: 22, end: 6}
+	if pacific.isOffHours(instant) {
+		t.Errorf("18:00 PDT (same instant) must NOT be off-hours under a Pacific 22–6 band")
+	}
+
+	// A non-wrapping band [9,17) is a normal interval.
+	day := offHoursPolicy{loc: time.UTC, start: 9, end: 17}
+	if !day.isOffHours(time.Date(2026, 6, 17, 12, 0, 0, 0, time.UTC)) {
+		t.Errorf("12:00 must fall inside a non-wrapping [9,17) band")
+	}
+	if day.isOffHours(time.Date(2026, 6, 17, 20, 0, 0, 0, time.UTC)) {
+		t.Errorf("20:00 must fall outside a non-wrapping [9,17) band")
+	}
+}
+
+func TestSetBusinessHours(t *testing.T) {
+	d := NewAnomalyDetector(nil)
+
+	// Timezone only: the default 22–6 band is kept (both hours 0 = unset).
+	require.NoError(t, d.SetBusinessHours("America/New_York", 0, 0))
+	assert.Equal(t, "America/New_York", d.offHours.loc.String())
+	assert.Equal(t, 22, d.offHours.start)
+	assert.Equal(t, 6, d.offHours.end)
+
+	// Custom band applied.
+	require.NoError(t, d.SetBusinessHours("UTC", 20, 7))
+	assert.Equal(t, 20, d.offHours.start)
+	assert.Equal(t, 7, d.offHours.end)
+
+	// Invalid timezone: error, and the prior policy is left unchanged.
+	before := d.offHours
+	require.Error(t, d.SetBusinessHours("Not/AZone", 1, 2))
+	assert.Equal(t, before, d.offHours, "an invalid timezone must not mutate the policy")
 }
 
 func TestVolumeSpike(t *testing.T) {

--- a/server/main.go
+++ b/server/main.go
@@ -725,6 +725,18 @@ func startHTTPServer(ctx context.Context, cfg *config.Config) error {
 	// anomalies to project admins + the audit/SIEM pipeline.
 	{
 		detector := core.NewAnomalyDetector(coreService.Storage())
+		if bh := cfg.AnomalyAlerts.BusinessHours; bh.Timezone != "" || bh.OffHoursStart != 0 || bh.OffHoursEnd != 0 {
+			tzLabel := bh.Timezone
+			if tzLabel == "" {
+				tzLabel = "UTC"
+			}
+			if err := detector.SetBusinessHours(bh.Timezone, bh.OffHoursStart, bh.OffHoursEnd); err != nil {
+				// Misconfigured timezone: keep the safe UTC default rather than fail startup.
+				log.Printf("Anomaly off-hours config ignored (%v); using UTC 22:00–06:00", err)
+			} else {
+				log.Printf("Anomaly off-hours rule configured (timezone %s)", tzLabel)
+			}
+		}
 		if mlc := cfg.AnomalyAlerts.ML; mlc.Enabled {
 			detector.SetMLConfig(core.MLConfig{
 				Enabled:    true,


### PR DESCRIPTION
## Summary

The `off_hours` rule hardcoded the off-hours window to 22:00–06:00 UTC, so on any
non-UTC deployment it was wrong in both directions: a read during local business hours
(e.g. 5pm US-Pacific = 01:00 UTC) was flagged off-hours, while a genuine local-night
read (2am Pacific = 09:00 UTC) was not.

## Changes
The off-hours window is now configurable under `anomaly_alerts.business_hours`:

```yaml
anomaly_alerts:
  business_hours:
    timezone: "America/New_York"   # IANA name; "" = UTC
    off_hours_start: 20            # band start hour [0,23]; default 22
    off_hours_end: 7               # band end hour [0,23]; default 6
```

The band `[start, end)` is evaluated in the configured timezone and may wrap midnight.
All fields are optional and default to the legacy UTC 22:00–06:00, so existing
deployments are unchanged. An unparseable timezone is logged and the UTC default
retained rather than failing startup. The alert description now reports the time in the
configured zone (e.g. "14:32 EDT").

## Tests
`TestOffHoursPolicy` (timezone-aware, wrapping + non-wrapping bands) and
`TestSetBusinessHours` (tz-only keeps the default band, invalid tz leaves the policy
unchanged). Full `internal/core` + `config` suites green, gosec clean.

## Merge order
Both this branch and #510 edit `anomaly.go` / `anomaly_test.go`. Merge #510
(baseline-pollution) first, then rebase this and resolve the mechanical conflict
(different rules in the same functions).
