### PR TITLE
fix(access-request): lock the granted role under multi-party approval

### DIFF
--- a/internal/core/dual_control_external_test.go
+++ b/internal/core/dual_control_external_test.go
@@ -77,6 +77,65 @@ func TestApprove_DualControl(t *testing.T) {
 	assert.Contains(t, ids, uint(3), "editor granted once two approvers signed off")
 }
 
+// Regression: under K-of-N control the threshold-crossing approver must not be able to
+// substitute a higher role than the other approvers consented to — the granted role is
+// locked to the request's suggested_role. Before the fix, only the last approver's
+// granted_role was used, so one approver could escalate after K-1 others signed off.
+func TestApprove_DualControl_RoleLockedToRequest(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(&models.AccessRequest{}, &models.AccessRequestApproval{}, &models.AuditEvent{}))
+
+	ctx := context.Background()
+	h.CreateTestUser(t, "alice", 10)  // requester — asks for "editor"
+	h.CreateTestUser(t, "admin1", 11) // approver 1
+	h.CreateTestUser(t, "admin2", 12) // approver 2 (would-be escalator)
+	h.CoreService.SetDualControlPolicy(2)
+	reqID := seedPendingRequest(t, h, 10) // SuggestedRole "editor"
+
+	// First approver signs off on the request as-stated.
+	_, err := h.CoreService.ApproveAccessRequestWithExpiry(ctx, 2, reqID, 11, "", 0)
+	require.NoError(t, err)
+
+	// The second (threshold-crossing) approver tries to escalate to a higher EXISTING
+	// role ("admin", id 2) than the requested "editor". Without the fix this would
+	// succeed (the last approver's role wins); the request must instead be rejected.
+	_, err = h.CoreService.ApproveAccessRequestWithExpiry(ctx, 2, reqID, 12, "admin", 0)
+	require.Error(t, err, "an approver must not substitute a different role under dual control")
+	ids, _ := h.Storage.GetUserRoleIDsAt(ctx, 10, storage.Scope{ProjectID: 2})
+	assert.NotContains(t, ids, uint(2), "the escalated role (admin) must not be granted")
+
+	// Approving the request as-stated (matching role) grants exactly the requested role.
+	req, err := h.CoreService.ApproveAccessRequestWithExpiry(ctx, 2, reqID, 12, "editor", 0)
+	require.NoError(t, err)
+	assert.Equal(t, "approved", req.State)
+	assert.Equal(t, "editor", req.GrantedRole)
+	ids, _ = h.Storage.GetUserRoleIDsAt(ctx, 10, storage.Scope{ProjectID: 2})
+	assert.Contains(t, ids, uint(3), "the requested role (editor) is granted, not the escalated one")
+}
+
+// A multi-approver request with no role stated at request time is rejected — there is
+// nothing for the approvers to consent to in common.
+func TestApprove_DualControl_RequiresRoleAtRequestTime(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(&models.AccessRequest{}, &models.AccessRequestApproval{}, &models.AuditEvent{}))
+
+	ctx := context.Background()
+	h.CreateTestUser(t, "alice", 10)
+	h.CreateTestUser(t, "admin1", 11)
+	h.CoreService.SetDualControlPolicy(2)
+	req, err := h.Storage.CreateAccessRequest(ctx, &models.AccessRequest{
+		ProjectID: 2, UserID: 10, SuggestedRole: "", State: "pending",
+	})
+	require.NoError(t, err)
+
+	// Even with a role supplied by the approver, multi-party control won't accept a
+	// request that named no role for everyone to review.
+	_, err = h.CoreService.ApproveAccessRequestWithExpiry(ctx, 2, req.ID, 11, "editor", 0)
+	require.Error(t, err)
+}
+
 // The listing annotates a pending request with its M-of-K progress.
 func TestListAccessRequests_AnnotatesProgress(t *testing.T) {
 	h := testhelper.NewRBACTestHelper(t)

--- a/internal/core/invitations.go
+++ b/internal/core/invitations.go
@@ -420,8 +420,24 @@ func (c *KeyorixCore) ApproveAccessRequestWithExpiry(ctx context.Context, projec
 	if approverID == req.UserID {
 		return nil, fmt.Errorf("a requester cannot approve their own access request")
 	}
+	// Determine the role to grant. Under multi-party control (K>1) the role is LOCKED to
+	// the request's suggested_role — the value every approver reviews. A per-approver
+	// override would let the threshold-crossing approver substitute a higher role than
+	// the other K-1 approvers consented to (a dual-control escalation). Single-control
+	// (K=1) keeps the approve-with-a-different-role override, where one approver is the
+	// whole decision anyway.
+	required := c.requiredApprovals()
 	role := grantedRole
 	if role == "" {
+		role = req.SuggestedRole
+	}
+	if required > 1 {
+		if req.SuggestedRole == "" {
+			return nil, fmt.Errorf("a %d-of-N access request must specify the role at request time", required)
+		}
+		if grantedRole != "" && grantedRole != req.SuggestedRole {
+			return nil, fmt.Errorf("under %d-of-N approval the granted role is fixed to the requested role %q and cannot be changed by an approver", required, req.SuggestedRole)
+		}
 		role = req.SuggestedRole
 	}
 	if role == "" {
@@ -445,7 +461,6 @@ func (c *KeyorixCore) ApproveAccessRequestWithExpiry(ctx context.Context, projec
 
 	now := c.now()
 	received := len(approvals) + 1
-	required := c.requiredApprovals()
 
 	// Below the threshold: record the approval, stay pending, notify, return progress.
 	if received < required {


### PR DESCRIPTION
## Summary

`ApproveAccessRequestWithExpiry` took a `granted_role` on every approval call but only
the threshold-crossing (last) approver's value was used. Under K-of-N dual control this
let a single approver escalate: after K-1 others signed off, the final approver could
pass a higher `granted_role` and have THAT granted, beyond what the others consented to.
The maker≠checker and one-vote-per-approver guards were already present, but nothing
pinned the role, so the privilege dimension of dual control was bypassable by one party.

## Fix
Under multi-party control (K>1) the granted role is locked to the request's
`suggested_role` — the value every approver reviews. A per-approver override that differs
from it is rejected, and a multi-approver request that named no role at request time is
refused. Single-party control (K=1) keeps the approve-with-a-different-role override.

## Tests
`TestApprove_DualControl_RoleLockedToRequest` reproduces the escalation (the last
approver substitutes the existing higher "admin" role for the requested "editor") and
asserts it's rejected and ungranted — it fails without the fix. Plus the
no-role-at-request-time guard. gosec clean.
