### PR TITLE
fix(break-glass): always bound the grant even when MaxTTL is unconfigured

### DIFF
--- a/internal/core/break_glass.go
+++ b/internal/core/break_glass.go
@@ -64,10 +64,11 @@ func (c *KeyorixCore) ActivateBreakGlass(ctx context.Context, projectID, userID 
 		return nil, fmt.Errorf("emergency role %q not found: %w", c.breakGlassPolicy.EmergencyRole, err)
 	}
 
-	ttl := c.breakGlassPolicy.DefaultTTL
-	if ttl <= 0 {
-		ttl = 4 * time.Hour
+	defaultTTL := c.breakGlassPolicy.DefaultTTL
+	if defaultTTL <= 0 {
+		defaultTTL = 4 * time.Hour
 	}
+	ttl := defaultTTL
 	if ttlOverride != "" {
 		d, perr := time.ParseDuration(ttlOverride)
 		if perr != nil || d <= 0 {
@@ -75,8 +76,17 @@ func (c *KeyorixCore) ActivateBreakGlass(ctx context.Context, projectID, userID 
 		}
 		ttl = d
 	}
-	if max := c.breakGlassPolicy.MaxTTL; max > 0 && ttl > max {
-		ttl = max // cap a requested TTL at the configured ceiling
+	// Always bound the grant. When MaxTTL is unconfigured the ceiling falls back to the
+	// default TTL — so an override can only ever SHORTEN the grant, never exceed the
+	// default. The core enforces "break-glass is time-bound" itself rather than trusting
+	// the config layer to have supplied a ceiling; a policy built with MaxTTL=0 (e.g. by
+	// a future or non-startup caller) can't yield an unbounded emergency grant.
+	ceiling := c.breakGlassPolicy.MaxTTL
+	if ceiling <= 0 {
+		ceiling = defaultTTL
+	}
+	if ttl > ceiling {
+		ttl = ceiling // cap a requested TTL at the effective ceiling
 	}
 
 	now := c.now()

--- a/internal/core/break_glass_external_test.go
+++ b/internal/core/break_glass_external_test.go
@@ -68,6 +68,24 @@ func TestActivateBreakGlass_CapsTTL(t *testing.T) {
 	assert.WithinDuration(t, time.Now().Add(1*time.Hour), *act.ExpiresAt, 2*time.Minute, "10h request capped at the 1h max")
 }
 
+// With no MaxTTL configured, a requested TTL is still bounded — to the default TTL,
+// not honored unbounded. The core enforces "break-glass is time-bound" itself rather
+// than relying on the config layer to have supplied a ceiling.
+func TestActivateBreakGlass_UnsetMaxTTLFloorsToDefault(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	migrateBreakGlass(t, h)
+	enableBreakGlass(h, "editor", 4*time.Hour, 0) // MaxTTL unset (0)
+
+	ctx := context.Background()
+	h.CreateTestUser(t, "alice", 10)
+	act, err := h.CoreService.ActivateBreakGlass(ctx, 2, 10, "incident", "720h") // 30-day override
+	require.NoError(t, err)
+	require.NotNil(t, act.ExpiresAt)
+	assert.WithinDuration(t, time.Now().Add(4*time.Hour), *act.ExpiresAt, 2*time.Minute,
+		"with no MaxTTL, an override must be bounded to the default TTL, not honored as 720h")
+}
+
 // Break-glass refuses when disabled, and a justification is mandatory.
 func TestActivateBreakGlass_DisabledAndJustificationRequired(t *testing.T) {
 	h := testhelper.NewRBACTestHelper(t)


### PR DESCRIPTION
## Summary

`ActivateBreakGlass` capped a requested `ttlOverride` at `MaxTTL` only when
`MaxTTL > 0`. A `BreakGlassPolicy` built with `MaxTTL == 0` therefore applied no
ceiling, so a caller could self-grant the emergency role for an arbitrary duration
(e.g. 720h) — an unbounded emergency grant, defeating the time-bound guarantee that is
the core control of break-glass.

The shipping config path is **not** affected (`GetMaxTTL` defaults to 24h); this hardens
the core so it self-enforces its own invariant rather than trusting the config layer to
have supplied a ceiling (a future or non-startup caller constructing the policy directly
would otherwise get no bound).

## Fix
The ceiling falls back to the (already-defaulted) `DefaultTTL` when `MaxTTL <= 0`, so the
grant is always bounded and an override can only ever SHORTEN it below the default in
that case. Behaviour with `MaxTTL` configured is unchanged.

## Tests
`TestActivateBreakGlass_UnsetMaxTTLFloorsToDefault` reproduces the unbounded grant (a
720h override with no MaxTTL) and asserts it's bounded to the default — fails without the
fix. gosec clean.
