### PR TITLE
All security fixes: gRPC parity + bug-hunt + SoD + break-glass

### DIFF
--- a/internal/core/access_review_campaign.go
+++ b/internal/core/access_review_campaign.go
@@ -185,6 +185,18 @@ func (c *KeyorixCore) DecideAccessReviewItem(ctx context.Context, actorID, proje
 	if item.CampaignID != campaignID {
 		return fmt.Errorf("%s", i18n.T("ErrorNotFound", nil))
 	}
+	// Decide once: an already-attested/revoked item must not be flipped. A revoke
+	// removes the real grant, so re-deciding it (revoke→attest) would record
+	// "attested" for access that no longer exists — false certification evidence.
+	if item.Decision != ReviewItemPending {
+		return fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "this item has already been decided")
+	}
+	// Independence (ISO 27001 A.5.18): a reviewer must not certify their OWN access.
+	// Self-certification defeats the control, so a user can't decide a user-scoped
+	// item that is themselves — an independent reviewer is required.
+	if item.PrincipalType == "user" && item.PrincipalID == actorID {
+		return fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "you cannot review your own access; an independent reviewer is required")
+	}
 
 	decision := AccessReviewDecision{
 		Source:        item.Source,

--- a/internal/core/access_review_campaign_external_test.go
+++ b/internal/core/access_review_campaign_external_test.go
@@ -92,6 +92,62 @@ func TestDecideAccessReviewItem_AttestAndRevoke(t *testing.T) {
 	assert.NotContains(t, names, "bob")
 }
 
+// A reviewer must not certify their OWN access (ISO 27001 A.5.18 independence).
+func TestDecideAccessReviewItem_RejectsSelfCertification(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	migrateCampaignTables(t, h)
+
+	const proj = uint(2)
+	ctx := context.Background()
+	h.CreateTestUser(t, "alice", 10)
+	h.AssignUserRole(t, 10, 3, uptr(proj))
+
+	res, err := h.CoreService.OpenAccessReviewCampaign(ctx, 1, proj, "review")
+	require.NoError(t, err)
+	detail, err := h.CoreService.GetAccessReviewCampaign(ctx, proj, res.Campaign.ID)
+	require.NoError(t, err)
+	require.Len(t, detail.Items, 1)
+	item := detail.Items[0].ID
+
+	// Alice (user 10) deciding her own item is rejected...
+	err = h.CoreService.DecideAccessReviewItem(ctx, 10, proj, res.Campaign.ID, item, "attest", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "your own access")
+
+	// ...but an independent reviewer can.
+	require.NoError(t, h.CoreService.DecideAccessReviewItem(ctx, 1, proj, res.Campaign.ID, item, "attest", ""))
+}
+
+// An item is decided once: a decided item can't be flipped, so the recorded decision
+// can't drift from the real grant state (false certification evidence).
+func TestDecideAccessReviewItem_RejectsDoubleDecision(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	migrateCampaignTables(t, h)
+
+	const proj = uint(2)
+	ctx := context.Background()
+	h.CreateTestUser(t, "alice", 10)
+	h.AssignUserRole(t, 10, 3, uptr(proj))
+
+	res, err := h.CoreService.OpenAccessReviewCampaign(ctx, 1, proj, "review")
+	require.NoError(t, err)
+	detail, err := h.CoreService.GetAccessReviewCampaign(ctx, proj, res.Campaign.ID)
+	require.NoError(t, err)
+	item := detail.Items[0].ID
+
+	require.NoError(t, h.CoreService.DecideAccessReviewItem(ctx, 1, proj, res.Campaign.ID, item, "attest", ""))
+	// A second decision (flip to revoke) is rejected, and the original stands.
+	err = h.CoreService.DecideAccessReviewItem(ctx, 1, proj, res.Campaign.ID, item, "revoke", "flip")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already been decided")
+
+	after, err := h.CoreService.GetAccessReviewCampaign(ctx, proj, res.Campaign.ID)
+	require.NoError(t, err)
+	assert.Equal(t, core.ReviewItemAttested, after.Items[0].Decision, "the original decision is preserved")
+}
+
 // Closing refuses while items are pending unless forced; a closed campaign rejects
 // further decisions.
 func TestCloseAccessReviewCampaign_PendingGuardAndForce(t *testing.T) {

--- a/internal/core/account_state.go
+++ b/internal/core/account_state.go
@@ -6,7 +6,11 @@
 //	pending_first_login       — provisioned by an admin; must set a password
 //	                            before doing anything else (restricted session).
 //	password_reset_required   — admin forced a reset; restricted until changed.
-//	suspended                 — login is refused entirely.
+//	suspended                 — login is refused entirely (admin security action).
+//	deprovisioned             — login is refused; set by SCIM/IdP deactivation. Kept
+//	                            distinct from `suspended` so an IdP reactivation clears
+//	                            only its own deactivation and can never undo an admin's
+//	                            security suspension (incident response wins).
 //
 // A "restricted" session (pending_first_login / password_reset_required)
 // authenticates but the auth middleware blocks every endpoint except the
@@ -29,6 +33,10 @@ const (
 	AccountPendingFirstLogin     = "pending_first_login"
 	AccountPasswordResetRequired = "password_reset_required"
 	AccountSuspended             = "suspended"
+	// AccountDeprovisioned is set by SCIM/IdP deactivation. It blocks login exactly
+	// like AccountSuspended, but is a separate value so SCIM reactivation can clear it
+	// without clearing an admin's (stronger, sticky) AccountSuspended. See UpdateSCIMUser.
+	AccountDeprovisioned = "deprovisioned"
 )
 
 // NormalizeAccountState maps the empty legacy value to active.
@@ -50,9 +58,17 @@ func AccountRestricted(state string) bool {
 	}
 }
 
-// AccountLoginBlocked reports whether a state refuses login outright.
+// AccountLoginBlocked reports whether a state refuses login outright. Both an admin
+// suspension and a SCIM/IdP deactivation block login; every login/session/token path
+// funnels through here, so a deprovisioned account is refused everywhere a suspended
+// one is, with no per-path change.
 func AccountLoginBlocked(state string) bool {
-	return NormalizeAccountState(state) == AccountSuspended
+	switch NormalizeAccountState(state) {
+	case AccountSuspended, AccountDeprovisioned:
+		return true
+	default:
+		return false
+	}
 }
 
 // StaleAccounts returns users that have sat in the given account_state longer

--- a/internal/core/account_state_test.go
+++ b/internal/core/account_state_test.go
@@ -104,13 +104,16 @@ func TestValidateSessionToken_RejectsBlockedOrInactive(t *testing.T) {
 			c := newAccountCore(store)
 			ctx := context.Background()
 			store.On("GetSession", ctx, "tok").Return(&models.Session{ID: 7, UserID: 2, ExpiresAt: &future}, nil)
-			store.On("TouchSession", ctx, uint(7), mock.Anything, mock.Anything).Return(nil)
 			store.On("GetUser", ctx, uint(2)).Return(tc.user, nil)
 
 			_, _, err := c.ValidateSessionToken(ctx, "tok")
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), "not active")
 			store.AssertNotCalled(t, "GetUserRoles", mock.Anything, mock.Anything)
+			// Must reject before stamping last-seen — a blocked/inactive account's
+			// request is not "used" and must not refresh the sessions view (matching
+			// ValidatePATToken's touch-after-gate ordering).
+			store.AssertNotCalled(t, "TouchSession", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 		})
 	}
 }

--- a/internal/core/anomaly_alerting_external_test.go
+++ b/internal/core/anomaly_alerting_external_test.go
@@ -43,6 +43,56 @@ func TestAlertNewAnomalies(t *testing.T) {
 	assert.Equal(t, 0, n)
 }
 
+// A secret read recorded through the real production logging path
+// (LogSecretReadWithProject → writeAccessLog → CreateSecretAccessLog) must be
+// visible to anomaly detection. Both the HTTP reveal handler and the gRPC
+// GetSecretValue fire that exact call, so this guards the end-to-end pipeline:
+// the existing detector tests hand-build SecretAccessLog rows, which would not
+// catch the writer drifting (action string, field mapping) and silently
+// re-blinding detection to real reads.
+func TestLogSecretRead_FeedsAnomalyDetection(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(
+		&models.SecretNode{}, &models.SecretAccessLog{}, &models.AnomalyAlert{}, &models.AuditEvent{}))
+
+	ctx := context.Background()
+	secret := models.SecretNode{ID: 700, ProjectID: 1, Name: "api-key", Status: "active", IsSecret: true}
+	require.NoError(t, h.DB.Create(&secret).Error)
+
+	// A quiet baseline so the detector has history to compare against (a couple of reads
+	// >7 days ago — far below the spike threshold). Seeded directly because the
+	// production writer always stamps AccessTime=now, so history can't go through it.
+	for i := 8; i <= 10; i++ {
+		require.NoError(t, h.DB.Create(&models.SecretAccessLog{
+			SecretNodeID: 700, AccessedBy: "alice", Action: "read", IPAddress: "10.0.0.1",
+			AccessTime: time.Now().Add(-time.Duration(i) * 24 * time.Hour),
+		}).Error)
+	}
+
+	// A burst of reads in the detection window, each recorded through the SAME call HTTP
+	// and gRPC use (LogSecretReadWithProject → writeAccessLog → CreateSecretAccessLog).
+	for i := 0; i < 12; i++ {
+		h.CoreService.LogSecretReadWithProject(ctx, 999, 700, 1, "mallory", "api-key", "203.0.113.5", "grpc-go/1.80")
+	}
+
+	// Detection must flag the burst as a frequency spike — proving the real logging path
+	// lands in secret_access_logs and is counted by the detector, not just hand-built rows.
+	detector := core.NewAnomalyDetector(h.CoreService.Storage())
+	require.NoError(t, detector.RunDetection(ctx, []models.SecretNode{secret}))
+
+	alerts, err := detector.ListAlerts(ctx, nil)
+	require.NoError(t, err)
+	var sawSpike bool
+	for _, a := range alerts {
+		if a.AlertType == "frequency_spike" && a.SecretNodeID == 700 {
+			sawSpike = true
+		}
+	}
+	assert.True(t, sawSpike,
+		"reads via LogSecretReadWithProject must be visible to anomaly detection")
+}
+
 // The compliance posture counts open (unacknowledged) anomalies, with a high-severity tally.
 func TestCompliancePosture_Anomalies(t *testing.T) {
 	h := testhelper.NewRBACTestHelper(t)

--- a/internal/core/auth.go
+++ b/internal/core/auth.go
@@ -188,10 +188,6 @@ func (c *KeyorixCore) ValidateSessionToken(ctx context.Context, token string) (*
 	if session.AbsoluteExpiresAt != nil && c.now().After(*session.AbsoluteExpiresAt) {
 		return nil, nil, fmt.Errorf("session lifetime exceeded")
 	}
-	// Best-effort, throttled last-seen stamp for the My Account sessions view.
-	// Only writes when the stored value is older than sessionTouchInterval, so the
-	// auth hot path is not turned into a write per request. Never fails the request.
-	_ = c.storage.TouchSession(ctx, session.ID, c.now(), sessionTouchInterval)
 	user, err := c.storage.GetUser(ctx, session.UserID)
 	if err != nil {
 		return nil, nil, fmt.Errorf("user not found")
@@ -202,6 +198,13 @@ func (c *KeyorixCore) ValidateSessionToken(ctx context.Context, token string) (*
 	if !user.IsActive || AccountLoginBlocked(user.AccountState) {
 		return nil, nil, fmt.Errorf("account is not active")
 	}
+	// Best-effort, throttled last-seen stamp for the My Account sessions view.
+	// Only writes when the stored value is older than sessionTouchInterval, so the
+	// auth hot path is not turned into a write per request. Never fails the request.
+	// Stamped only AFTER the account-state gate, so a rejected request from a
+	// suspended/deactivated account is not "used" — it must not refresh last-seen
+	// (matching ValidatePATToken, which touches only after the same gate).
+	_ = c.storage.TouchSession(ctx, session.ID, c.now(), sessionTouchInterval)
 	roles, err := c.storage.GetUserRoles(ctx, user.ID)
 	if err != nil {
 		return user, []string{}, nil

--- a/internal/core/auth.go
+++ b/internal/core/auth.go
@@ -234,11 +234,9 @@ func (c *KeyorixCore) RequestPasswordReset(ctx context.Context, email string) er
 	if AccountLoginBlocked(user.AccountState) {
 		return nil
 	}
-	// Throttle abusive repeats to a victim address (same control as resend).
-	if err := c.checkResendThrottle(ctx, SetupPurposePasswordResetLink, user.Email); err != nil {
-		return nil
-	}
-	_, _ = c.provisionSetupLink(ctx, IssueSetupTokenRequest{
+	// Throttle abusive repeats to a victim address (same control as resend). A
+	// throttled repeat returns an error here, swallowed below to stay enumeration-safe.
+	_, _ = c.provisionSetupLinkThrottled(ctx, IssueSetupTokenRequest{
 		Purpose:       SetupPurposePasswordResetLink,
 		SubjectEmail:  user.Email,
 		SubjectUserID: &user.ID,

--- a/internal/core/break_glass.go
+++ b/internal/core/break_glass.go
@@ -64,10 +64,11 @@ func (c *KeyorixCore) ActivateBreakGlass(ctx context.Context, projectID, userID 
 		return nil, fmt.Errorf("emergency role %q not found: %w", c.breakGlassPolicy.EmergencyRole, err)
 	}
 
-	ttl := c.breakGlassPolicy.DefaultTTL
-	if ttl <= 0 {
-		ttl = 4 * time.Hour
+	defaultTTL := c.breakGlassPolicy.DefaultTTL
+	if defaultTTL <= 0 {
+		defaultTTL = 4 * time.Hour
 	}
+	ttl := defaultTTL
 	if ttlOverride != "" {
 		d, perr := time.ParseDuration(ttlOverride)
 		if perr != nil || d <= 0 {
@@ -75,8 +76,17 @@ func (c *KeyorixCore) ActivateBreakGlass(ctx context.Context, projectID, userID 
 		}
 		ttl = d
 	}
-	if max := c.breakGlassPolicy.MaxTTL; max > 0 && ttl > max {
-		ttl = max // cap a requested TTL at the configured ceiling
+	// Always bound the grant. When MaxTTL is unconfigured the ceiling falls back to the
+	// default TTL — so an override can only ever SHORTEN the grant, never exceed the
+	// default. The core enforces "break-glass is time-bound" itself rather than trusting
+	// the config layer to have supplied a ceiling; a policy built with MaxTTL=0 (e.g. by
+	// a future or non-startup caller) can't yield an unbounded emergency grant.
+	ceiling := c.breakGlassPolicy.MaxTTL
+	if ceiling <= 0 {
+		ceiling = defaultTTL
+	}
+	if ttl > ceiling {
+		ttl = ceiling // cap a requested TTL at the effective ceiling
 	}
 
 	now := c.now()

--- a/internal/core/break_glass_external_test.go
+++ b/internal/core/break_glass_external_test.go
@@ -68,6 +68,24 @@ func TestActivateBreakGlass_CapsTTL(t *testing.T) {
 	assert.WithinDuration(t, time.Now().Add(1*time.Hour), *act.ExpiresAt, 2*time.Minute, "10h request capped at the 1h max")
 }
 
+// With no MaxTTL configured, a requested TTL is still bounded — to the default TTL,
+// not honored unbounded. The core enforces "break-glass is time-bound" itself rather
+// than relying on the config layer to have supplied a ceiling.
+func TestActivateBreakGlass_UnsetMaxTTLFloorsToDefault(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	migrateBreakGlass(t, h)
+	enableBreakGlass(h, "editor", 4*time.Hour, 0) // MaxTTL unset (0)
+
+	ctx := context.Background()
+	h.CreateTestUser(t, "alice", 10)
+	act, err := h.CoreService.ActivateBreakGlass(ctx, 2, 10, "incident", "720h") // 30-day override
+	require.NoError(t, err)
+	require.NotNil(t, act.ExpiresAt)
+	assert.WithinDuration(t, time.Now().Add(4*time.Hour), *act.ExpiresAt, 2*time.Minute,
+		"with no MaxTTL, an override must be bounded to the default TTL, not honored as 720h")
+}
+
 // Break-glass refuses when disabled, and a justification is mandatory.
 func TestActivateBreakGlass_DisabledAndJustificationRequired(t *testing.T) {
 	h := testhelper.NewRBACTestHelper(t)

--- a/internal/core/dynamic_secrets.go
+++ b/internal/core/dynamic_secrets.go
@@ -372,6 +372,14 @@ func (c *KeyorixCore) RenewLease(ctx context.Context, leaseID string, ttlSeconds
 	if lease.Status != "active" {
 		return time.Time{}, fmt.Errorf("lease is not active (status %s)", lease.Status)
 	}
+	// A lease whose expiry has already passed is logically dead even if the sweeper
+	// has not yet flipped its status (sweep disabled, or not run yet). Renewing it
+	// would push the backend credential's lifetime forward — resurrecting a
+	// credential that should be gone, violating the promised TTL — and would race the
+	// sweep that is about to revoke it. Refuse; the caller must issue a new lease.
+	if !c.now().Before(lease.ExpiresAt) {
+		return time.Time{}, fmt.Errorf("lease has expired; issue a new lease instead")
+	}
 	cfg, err := c.storage.GetDynamicSecretConfig(ctx, lease.ConfigID)
 	if err != nil {
 		return time.Time{}, fmt.Errorf("config not found")

--- a/internal/core/dynamic_secrets_test.go
+++ b/internal/core/dynamic_secrets_test.go
@@ -258,6 +258,31 @@ func TestDynamicSecrets_RenewRejectsInactiveLease(t *testing.T) {
 	require.Error(t, err, "a revoked lease cannot be renewed")
 }
 
+// A lease whose expiry has already passed must not be renewable even while its status
+// is still "active" (the sweeper has not flipped it yet, or is disabled). Renewing it
+// would push the backend credential's lifetime forward and resurrect a credential that
+// should be dead, so RenewLease must refuse and must NOT call the engine.
+func TestDynamicSecrets_RenewRejectsExpiredLease(t *testing.T) {
+	c, _, fake, fixed := newDynamicTestCore(t)
+	ctx := context.Background()
+	cfg := mkConfig(t, c, ctx)
+
+	issued, err := c.IssueLease(ctx, cfg.ID, 0, 7)
+	require.NoError(t, err)
+
+	// Backdate the lease past its expiry while leaving status "active" (pre-sweep).
+	lease, err := c.storage.GetDynamicSecretLease(ctx, issued.LeaseID)
+	require.NoError(t, err)
+	lease.ExpiresAt = fixed.Add(-time.Minute)
+	require.NoError(t, c.storage.UpdateDynamicSecretLease(ctx, lease))
+	require.Equal(t, "active", lease.Status)
+
+	_, err = c.RenewLease(ctx, issued.LeaseID, 1200, 7)
+	require.Error(t, err, "an expired lease cannot be renewed")
+	assert.Contains(t, err.Error(), "expired")
+	assert.NotContains(t, fake.Renewed, issued.Username, "the engine must not renew a dead credential")
+}
+
 // TestDynamicSecrets_RealFactoryValidatesBackend checks the real engine factory
 // (no fake): config creation accepts the supported backends and rejects others.
 func TestDynamicSecrets_RealFactoryValidatesBackend(t *testing.T) {

--- a/internal/core/invitations.go
+++ b/internal/core/invitations.go
@@ -248,10 +248,7 @@ func (c *KeyorixCore) ResendInvitationLink(ctx context.Context, projectID, invit
 	if inv.State != InvitationPending {
 		return nil, fmt.Errorf("only a pending invitation can be resent (state is %s)", inv.State)
 	}
-	if err := c.checkResendThrottle(ctx, SetupPurposeInvitationAccept, inv.Email); err != nil {
-		return nil, err
-	}
-	return c.provisionSetupLink(ctx, IssueSetupTokenRequest{
+	return c.provisionSetupLinkThrottled(ctx, IssueSetupTokenRequest{
 		Purpose:      SetupPurposeInvitationAccept,
 		SubjectEmail: inv.Email,
 		InvitationID: &inv.ID,

--- a/internal/core/mfa.go
+++ b/internal/core/mfa.go
@@ -212,6 +212,14 @@ func (c *KeyorixCore) VerifyMFALogin(ctx context.Context, challenge, code, userA
 	if err != nil {
 		return nil, nil, fmt.Errorf("user not found")
 	}
+	// Completing a second factor still mints a login session, so a suspended or
+	// deactivated account must be refused here too — the challenge may have been
+	// issued (password step passed) just before an admin suspended the account, and
+	// nothing rechecks the state between the two steps. Mirrors the password,
+	// session, PAT, and passwordless-WebAuthn gates.
+	if !user.IsActive || AccountLoginBlocked(user.AccountState) {
+		return nil, nil, fmt.Errorf("account is not active")
+	}
 	verified, usedRecovery := false, false
 	if secret, err := c.loadTOTPSecret(ctx, ch.UserID); err == nil && c.validateTOTP(secret, code) {
 		verified = true

--- a/internal/core/mfa_test.go
+++ b/internal/core/mfa_test.go
@@ -41,6 +41,35 @@ func newMFATestCore(t *testing.T) (*KeyorixCore, *gorm.DB, time.Time) {
 	return c, db, fixed
 }
 
+// A suspended account must not complete a second factor: the challenge can be
+// issued (password step passed) just before an admin suspends the account, and the
+// MFA-completion path must refuse it rather than mint a session.
+func TestVerifyMFALogin_RejectsSuspendedAccount(t *testing.T) {
+	c, db, fixed := newMFATestCore(t)
+	ctx := context.Background()
+
+	// Enrol + activate MFA for alice.
+	_, secret, err := c.BeginMFAEnrollment(ctx, 1)
+	require.NoError(t, err)
+	actCode, err := totp.GenerateCode(secret, fixed)
+	require.NoError(t, err)
+	_, err = c.ActivateMFA(ctx, 1, actCode)
+	require.NoError(t, err)
+
+	// A login is in flight (valid challenge), then the admin suspends the account.
+	ch, err := c.CreateMFAChallenge(ctx, 1)
+	require.NoError(t, err)
+	require.NoError(t, db.Model(&models.User{}).Where("id = ?", 1).Update("account_state", AccountSuspended).Error)
+
+	// Even a correct TOTP code must not yield a session for the suspended account.
+	code, err := totp.GenerateCode(secret, fixed)
+	require.NoError(t, err)
+	sess, _, err := c.VerifyMFALogin(ctx, ch, code, "ua", "1.2.3.4")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not active")
+	assert.Nil(t, sess)
+}
+
 func TestMFA_FullFlow(t *testing.T) {
 	c, db, fixed := newMFATestCore(t)
 	ctx := context.Background()

--- a/internal/core/scim.go
+++ b/internal/core/scim.go
@@ -127,7 +127,7 @@ func (c *KeyorixCore) ProvisionSCIMUser(ctx context.Context, actorID uint, userN
 	now := c.now()
 	state := AccountPendingFirstLogin
 	if !active {
-		state = AccountSuspended
+		state = AccountDeprovisioned
 	}
 	created, err := c.storage.CreateUser(ctx, &models.User{
 		Username: username, Email: email, DisplayName: displayName,
@@ -147,8 +147,11 @@ func (c *KeyorixCore) ProvisionSCIMUser(ctx context.Context, actorID uint, userN
 }
 
 // UpdateSCIMUser applies a SCIM Replace/PATCH to a user: displayName, email, and the
-// active flag (deactivation suspends the account and terminates sessions; activation
-// returns it to active). nil fields are left unchanged.
+// active flag. Deactivation marks the account deprovisioned (blocks login, terminates
+// sessions); activation clears only a prior SCIM deactivation. An admin security
+// suspension is sticky and survives IdP sync — only an admin can clear it
+// (ReactivateUser), so routine SCIM traffic can't undo an incident-response lockout.
+// nil fields are left unchanged.
 func (c *KeyorixCore) UpdateSCIMUser(ctx context.Context, actorID, id uint, displayName, email *string, active *bool) (*models.User, error) {
 	user, err := c.storage.GetUser(ctx, id)
 	if err != nil {
@@ -164,11 +167,20 @@ func (c *KeyorixCore) UpdateSCIMUser(ctx context.Context, actorID, id uint, disp
 	if active != nil {
 		user.IsActive = *active
 		if *active {
-			if AccountLoginBlocked(user.AccountState) {
+			// Reactivation clears only a SCIM/IdP deactivation. An admin security
+			// suspension (AccountSuspended) is sticky: routine IdP sync, which re-sends
+			// active=true for every active user, must not undo an incident-response
+			// lockout — only an admin clears that, via ReactivateUser.
+			if NormalizeAccountState(user.AccountState) == AccountDeprovisioned {
 				user.AccountState = AccountActive
 			}
 		} else {
-			user.AccountState = AccountSuspended
+			// Mark the SCIM/IdP deactivation distinctly so a later reactivation can tell
+			// it from an admin suspension. Never downgrade an admin AccountSuspended — it
+			// is the stronger, sticky state (both block login either way).
+			if NormalizeAccountState(user.AccountState) != AccountSuspended {
+				user.AccountState = AccountDeprovisioned
+			}
 			deactivated = true
 		}
 	}
@@ -186,7 +198,7 @@ func (c *KeyorixCore) UpdateSCIMUser(ctx context.Context, actorID, id uint, disp
 	return updated, nil
 }
 
-// DeprovisionSCIMUser handles a SCIM DELETE: it suspends the user (blocks login,
+// DeprovisionSCIMUser handles a SCIM DELETE: it deprovisions the user (blocks login,
 // terminates sessions) and soft-deletes the record, so the account is recoverable
 // within the retention window rather than hard-destroyed.
 func (c *KeyorixCore) DeprovisionSCIMUser(ctx context.Context, actorID, id uint) error {
@@ -195,7 +207,12 @@ func (c *KeyorixCore) DeprovisionSCIMUser(ctx context.Context, actorID, id uint)
 		return fmt.Errorf("%s: %w", i18n.T("ErrorUserNotFound", nil), err)
 	}
 	user.IsActive = false
-	user.AccountState = AccountSuspended
+	// Mark as SCIM-deprovisioned rather than admin-suspended, but never downgrade an
+	// existing admin security suspension. The user is soft-deleted below regardless,
+	// so this only affects the state on the recoverable record.
+	if NormalizeAccountState(user.AccountState) != AccountSuspended {
+		user.AccountState = AccountDeprovisioned
+	}
 	user.UpdatedAt = c.now()
 	// Suspend + terminate sessions + soft-delete atomically: a SCIM DELETE either fully
 	// deprovisions or leaves the account untouched, so a mid-way storage failure can't

--- a/internal/core/scim_deprovision_test.go
+++ b/internal/core/scim_deprovision_test.go
@@ -30,7 +30,10 @@ func TestDeprovisionSCIMUser_RevokesSessionAndPAT(t *testing.T) {
 
 	require.NoError(t, db.Create(&models.User{ID: 1, Username: "alice", IsActive: true, AccountState: AccountActive}).Error)
 	expiry := time.Now().Add(time.Hour)
-	require.NoError(t, db.Create(&models.Session{ID: 1, UserID: 1, SessionToken: "sess-tok", ExpiresAt: &expiry}).Error)
+	// Create through the storage layer so the session token is hashed at rest (raw
+	// db.Create would store the plaintext, which GetSession's hashed lookup won't match).
+	_, err = ls.CreateSession(ctx, &models.Session{UserID: 1, SessionToken: "sess-tok", ExpiresAt: &expiry})
+	require.NoError(t, err)
 	raw := patPrefix + "deprovision-regression-token"
 	require.NoError(t, db.Create(&models.PersonalAccessToken{ID: 1, UserID: 1, Name: "ci", TokenHash: sha256Hex(raw)}).Error)
 

--- a/internal/core/scim_suspend_wins_test.go
+++ b/internal/core/scim_suspend_wins_test.go
@@ -1,0 +1,78 @@
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func newSCIMStateCore(t *testing.T) (*KeyorixCore, *gorm.DB) {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.User{}, &models.Session{}, &models.AuditEvent{}))
+	c := NewKeyorixCore(store.NewLocalStorage(db))
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "alice", IsActive: true, AccountState: AccountActive}).Error)
+	return c, db
+}
+
+// An admin security suspension must survive routine SCIM activation. The IdP re-sends
+// active=true for every active user, so without a distinct deprovisioned state that
+// sync would silently undo an incident-response lockout.
+func TestUpdateSCIMUser_AdminSuspensionSurvivesReactivation(t *testing.T) {
+	c, _ := newSCIMStateCore(t)
+	ctx := context.Background()
+	yes := true
+
+	require.NoError(t, c.SuspendUser(ctx, 99, 1)) // admin incident response
+
+	updated, err := c.UpdateSCIMUser(ctx, 2, 1, nil, nil, &yes) // IdP sync
+	require.NoError(t, err)
+	assert.Equal(t, AccountSuspended, updated.AccountState, "SCIM activation must not clear an admin suspension")
+	assert.True(t, AccountLoginBlocked(updated.AccountState), "the account stays login-blocked")
+}
+
+// The legitimate SCIM lifecycle still works: deactivation blocks login (deprovisioned),
+// and a later reactivation restores access.
+func TestUpdateSCIMUser_DeactivateThenReactivate(t *testing.T) {
+	c, _ := newSCIMStateCore(t)
+	ctx := context.Background()
+	yes, no := true, false
+
+	off, err := c.UpdateSCIMUser(ctx, 2, 1, nil, nil, &no)
+	require.NoError(t, err)
+	assert.Equal(t, AccountDeprovisioned, off.AccountState)
+	assert.False(t, off.IsActive)
+	assert.True(t, AccountLoginBlocked(off.AccountState), "a SCIM-deactivated account is login-blocked")
+
+	on, err := c.UpdateSCIMUser(ctx, 2, 1, nil, nil, &yes)
+	require.NoError(t, err)
+	assert.Equal(t, AccountActive, on.AccountState, "reactivation clears its own deactivation")
+	assert.True(t, on.IsActive)
+	assert.False(t, AccountLoginBlocked(on.AccountState))
+}
+
+// Deactivating an already admin-suspended user must not downgrade the suspension to a
+// deprovisioned state (which a later reactivation could then clear).
+func TestUpdateSCIMUser_DeactivateKeepsAdminSuspension(t *testing.T) {
+	c, _ := newSCIMStateCore(t)
+	ctx := context.Background()
+	yes, no := true, false
+	require.NoError(t, c.SuspendUser(ctx, 99, 1))
+
+	off, err := c.UpdateSCIMUser(ctx, 2, 1, nil, nil, &no)
+	require.NoError(t, err)
+	assert.Equal(t, AccountSuspended, off.AccountState, "an admin suspension is not downgraded by SCIM deactivation")
+
+	on, err := c.UpdateSCIMUser(ctx, 2, 1, nil, nil, &yes)
+	require.NoError(t, err)
+	assert.Equal(t, AccountSuspended, on.AccountState, "and reactivation still cannot revive it")
+}

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -61,6 +61,13 @@ type KeyorixCore struct {
 	// the row lock LockUserForUpdate takes on Postgres, the lockout counter stays
 	// correct across replicas. Zero value is ready to use. See login_lockout.go.
 	loginFailureMu sync.Mutex
+	// setupResendMu serializes the count-then-issue window of the setup-link resend
+	// throttle (checkResendThrottle + IssueSetupToken) so two concurrent resends for
+	// the same (purpose, email) cannot both clear the per-day cap / min-interval
+	// before either token row exists. Held only across the throttle check and the
+	// token write — link delivery (SMTP) runs after release, so a slow send never
+	// serializes every other resend. Zero value is ready to use. See setup_delivery.go.
+	setupResendMu  sync.Mutex
 	auditForwarder AuditForwarder
 	// auditStream is the in-process pub/sub broker that wakes live audit tails
 	// (gRPC StreamAuditLogs) the instant an event is written, replacing fixed-interval

--- a/internal/core/setup_delivery.go
+++ b/internal/core/setup_delivery.go
@@ -64,10 +64,47 @@ func (c *KeyorixCore) provisionSetupLink(ctx context.Context, req IssueSetupToke
 	if err != nil {
 		return nil, err
 	}
+	return c.deliverSetupLink(ctx, issued, req, displayName, assignmentSummary)
+}
+
+// provisionSetupLinkThrottled is provisionSetupLink with the per-subject resend
+// throttle (ADR-028 abuse section) applied atomically. The throttle check counts
+// recent tokens and then a new token is minted; without serialization two concurrent
+// resends for the same (purpose, email) both see a sub-cap count and both mint,
+// exceeding the daily cap / min-interval (the count-then-act is the only way past
+// the cap, so the race defeats the sole mail-bombing control). setupResendMu is held
+// across the check + IssueSetupToken so the count and the write that the next count
+// will see are one critical section. Delivery runs after the lock is released — a
+// slow SMTP send must not block every other resend. Used by every resend path; the
+// initial-provision callers (new account / new invitation) start from a zero count
+// and call provisionSetupLink directly.
+func (c *KeyorixCore) provisionSetupLinkThrottled(ctx context.Context, req IssueSetupTokenRequest, displayName, assignmentSummary string) (*ProvisionSetupResult, error) {
+	if c.setupBaseURL == "" {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorValidation", nil), ErrSetupBaseURLRequired)
+	}
+	c.setupResendMu.Lock()
+	if err := c.checkResendThrottle(ctx, req.Purpose, req.SubjectEmail); err != nil {
+		c.setupResendMu.Unlock()
+		return nil, err
+	}
+	issued, err := c.IssueSetupToken(ctx, req)
+	c.setupResendMu.Unlock()
+	if err != nil {
+		return nil, err
+	}
+	return c.deliverSetupLink(ctx, issued, req, displayName, assignmentSummary)
+}
+
+// deliverSetupLink builds the absolute setup link from a freshly issued token and
+// delivers it via the configured channel (or hands it back out-of-band), auditing
+// the delivery. Split from provisionSetupLink so the slow delivery step runs outside
+// the resend-throttle lock.
+func (c *KeyorixCore) deliverSetupLink(ctx context.Context, issued *IssueSetupTokenResult, req IssueSetupTokenRequest, displayName, assignmentSummary string) (*ProvisionSetupResult, error) {
 	link := c.setupBaseURL + "/auth/setup/" + issued.PlainToken
 
 	var result delivery.DeliveryResult
 	if c.credentialDelivery != nil {
+		var err error
 		result, err = c.credentialDelivery.DeliverSetupLink(ctx, delivery.SetupLinkRequest{
 			RecipientEmail:    req.SubjectEmail,
 			DisplayName:       displayName,
@@ -197,10 +234,7 @@ func (c *KeyorixCore) ResendAccountSetupLink(ctx context.Context, userID, create
 	if AccountLoginBlocked(user.AccountState) {
 		return nil, fmt.Errorf("account suspended")
 	}
-	if err := c.checkResendThrottle(ctx, SetupPurposeAccountSetup, user.Email); err != nil {
-		return nil, err
-	}
-	return c.provisionSetupLink(ctx, IssueSetupTokenRequest{
+	return c.provisionSetupLinkThrottled(ctx, IssueSetupTokenRequest{
 		Purpose:       SetupPurposeAccountSetup,
 		SubjectEmail:  user.Email,
 		SubjectUserID: &user.ID,

--- a/internal/core/setup_resend_concurrency_test.go
+++ b/internal/core/setup_resend_concurrency_test.go
@@ -1,0 +1,74 @@
+package core_test
+
+import (
+	"context"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// TestConcurrency_SetupLinkResendThrottle drives the real setup-link resend path
+// (ResendAccountSetupLink → checkResendThrottle → IssueSetupToken) from many
+// concurrent goroutines for the SAME subject and asserts the abuse-control invariant:
+// the count-then-issue window is serialized, so a simultaneous burst cannot all clear
+// the throttle before any token row exists.
+//
+// With a real clock every resend lands inside the 60s min-interval window, so once the
+// first resend mints a token the rest must observe it and back off — exactly one token
+// may be created. Before setupResendMu, concurrent callers counted zero in parallel and
+// all minted, exceeding the cap; this test fails (many tokens) without the lock.
+func TestConcurrency_SetupLinkResendThrottle(t *testing.T) {
+	dsn := "file:" + filepath.Join(t.TempDir(), "resend.db") + "?_busy_timeout=10000&_journal_mode=WAL&_txlock=immediate"
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.User{}, &models.SetupToken{}, &models.AuditEvent{}))
+
+	st := store.NewLocalStorage(db)
+	c := core.NewKeyorixCore(st)
+	c.SetCredentialDelivery(nil, "https://keyorix.test") // nil channel → out-of-band, no SMTP
+	ctx := context.Background()
+
+	const uid = uint(1)
+	require.NoError(t, db.Create(&models.User{
+		ID:           uid,
+		Username:     "dana",
+		Email:        "dana@acme.io",
+		DisplayName:  "Dana",
+		AccountState: core.AccountPendingFirstLogin,
+	}).Error)
+
+	const callers = 32
+	var ok int64
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < callers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			if _, err := c.ResendAccountSetupLink(ctx, uid, 7); err == nil {
+				atomic.AddInt64(&ok, 1)
+			}
+		}()
+	}
+	close(start) // release the whole burst at once
+	wg.Wait()
+
+	var tokens int64
+	require.NoError(t, db.Model(&models.SetupToken{}).Count(&tokens).Error)
+
+	// The min-interval admits exactly one issue from a same-window burst; the race
+	// would let several through. Token rows are the ground truth (each successful
+	// resend mints one), and successes must match.
+	assert.Equal(t, int64(1), tokens, "a concurrent burst must mint exactly one setup token, not race past the throttle")
+	assert.Equal(t, int64(1), atomic.LoadInt64(&ok), "exactly one resend may succeed; the rest are throttled")
+}

--- a/internal/core/sod_external_test.go
+++ b/internal/core/sod_external_test.go
@@ -40,6 +40,37 @@ func TestDetectSoDViolations(t *testing.T) {
 	assert.NotContains(t, users, "bob", "bob (viewer) lacks secrets.write")
 }
 
+// A toxic pair held with one permission DIRECT and the other inherited via a GROUP is a
+// real SoD violation and must be flagged — effective permissions include group-inherited
+// roles, not just directly-assigned ones.
+func TestDetectSoDViolations_GroupInheritedPermission(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(&models.SoDPolicy{}, &models.AuditEvent{}))
+	ctx := context.Background()
+
+	// carol holds users.read directly (viewer, role 4) and secrets.write ONLY via a group
+	// (editor, role 3). Neither side alone is a violation; together they are.
+	h.CreateTestUser(t, "carol", 12)
+	h.AssignUserRole(t, 12, 4, nil) // viewer (direct) → users.read (+ secrets.read)
+	h.CreateTestGroup(t, "writers", "", 5)
+	h.AssignGroupRole(t, 5, 3, nil) // editor on the group → secrets.write
+	h.AssignUserToGroup(t, 12, 5)   // carol joins → inherits secrets.write
+
+	_, err := h.CoreService.CreateSoDPolicy(ctx, 1, "write-vs-useradmin", "", "secrets.write", "users.read")
+	require.NoError(t, err)
+
+	violations, err := h.CoreService.DetectSoDViolations(ctx)
+	require.NoError(t, err)
+
+	var users []string
+	for _, v := range violations {
+		users = append(users, v.Username)
+	}
+	assert.Contains(t, users, "carol",
+		"carol holds users.read directly and secrets.write via a group — a group-inherited SoD violation")
+}
+
 // With no policies, there are no violations.
 func TestDetectSoDViolations_NoPolicies(t *testing.T) {
 	h := testhelper.NewRBACTestHelper(t)

--- a/internal/core/webauthn.go
+++ b/internal/core/webauthn.go
@@ -259,6 +259,13 @@ func (c *KeyorixCore) FinishWebAuthnLogin(ctx context.Context, challenge, sessio
 	if err != nil {
 		return nil, nil, err
 	}
+	// A second-factor WebAuthn login still mints a session, so a suspended or
+	// deactivated account must be refused — the challenge may have been issued just
+	// before suspension, with nothing rechecking state between steps. Mirrors the
+	// passwordless path's AccountLoginBlocked gate (and the password/session gates).
+	if !wu.user.IsActive || AccountLoginBlocked(wu.user.AccountState) {
+		return nil, nil, fmt.Errorf("account is not active")
+	}
 	cred, err := c.webauthnRP.ValidateLogin(wu, sd, parsed)
 	if err != nil {
 		c.auditWebAuthnFailed(ctx, ch.UserID, "login")

--- a/internal/core/webauthn_test.go
+++ b/internal/core/webauthn_test.go
@@ -184,6 +184,28 @@ func TestWebAuthn_PasswordlessFinishRejectsWrongPurposeSession(t *testing.T) {
 	require.Error(t, err)
 }
 
+// A suspended account must not complete WebAuthn second-factor login. The gate fires
+// after the user is loaded but before the assertion is validated, so a suspended
+// account is refused even with an otherwise-valid ceremony (nil assertion is never
+// reached). Mirrors the passwordless path's existing AccountLoginBlocked gate.
+func TestWebAuthn_FinishLoginRejectsSuspendedAccount(t *testing.T) {
+	c, db := newWebAuthnTestCore(t, true)
+	ctx := context.Background()
+	seedCredential(t, c, db, 1, "cred-1")
+
+	ch, err := c.CreateMFAChallenge(ctx, 1)
+	require.NoError(t, err)
+	token, err := c.storeWebAuthnSession(ctx, 1, "login", &webauthn.SessionData{Challenge: "x"})
+	require.NoError(t, err)
+
+	// Admin suspends the account after the ceremony began (challenge + session exist).
+	require.NoError(t, db.Model(&models.User{}).Where("id = ?", 1).Update("account_state", AccountSuspended).Error)
+
+	_, _, err = c.FinishWebAuthnLogin(ctx, ch, token, "ua", "1.2.3.4", nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not active")
+}
+
 func TestWebAuthn_FinishLoginRejectsMismatchedSession(t *testing.T) {
 	c, db := newWebAuthnTestCore(t, true)
 	ctx := context.Background()

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -78,9 +78,14 @@ type AccessRequest struct {
 // N-of-M dual control (ISO 27001 A.5.3 / SOX): a request grants the role only once
 // RequiredApprovals distinct approvers (none of them the requester) have approved.
 type AccessRequestApproval struct {
-	ID         uint `gorm:"primaryKey"`
-	RequestID  uint `gorm:"index;not null"`
-	ApproverID uint `gorm:"not null"`
+	ID uint `gorm:"primaryKey"`
+	// (RequestID, ApproverID) is unique: one sign-off per distinct approver. The
+	// constraint is the race backstop for the M-of-K dual-control count — without it,
+	// concurrent approvals from the same approver could insert multiple rows and the
+	// row-count threshold would treat one person as several, defeating dual control.
+	// The composite index also covers RequestID lookups (leftmost column).
+	RequestID  uint `gorm:"not null;uniqueIndex:ux_access_request_approver"`
+	ApproverID uint `gorm:"not null;uniqueIndex:ux_access_request_approver"`
 	CreatedAt  time.Time
 }
 

--- a/internal/storage/store/access_request_approval_test.go
+++ b/internal/storage/store/access_request_approval_test.go
@@ -1,0 +1,37 @@
+package store
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// A duplicate (request_id, approver_id) approval must collapse to a single row: the
+// composite unique index plus OnConflict-DoNothing keep the M-of-K dual-control count
+// honest, so a racing same-approver double-submit can't be counted as two sign-offs.
+func TestCreateAccessRequestApproval_DedupsSameApprover(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.AccessRequestApproval{}))
+	ls := NewLocalStorage(db)
+	ctx := context.Background()
+
+	require.NoError(t, ls.CreateAccessRequestApproval(ctx, &models.AccessRequestApproval{RequestID: 1, ApproverID: 11}))
+	// Same request + approver again — a benign no-op, not a second sign-off.
+	require.NoError(t, ls.CreateAccessRequestApproval(ctx, &models.AccessRequestApproval{RequestID: 1, ApproverID: 11}))
+
+	rows, err := ls.ListAccessRequestApprovals(ctx, 1)
+	require.NoError(t, err)
+	assert.Len(t, rows, 1, "the same approver must yield exactly one approval row")
+
+	// A distinct approver is a separate sign-off.
+	require.NoError(t, ls.CreateAccessRequestApproval(ctx, &models.AccessRequestApproval{RequestID: 1, ApproverID: 12}))
+	rows, err = ls.ListAccessRequestApprovals(ctx, 1)
+	require.NoError(t, err)
+	assert.Len(t, rows, 2)
+}

--- a/internal/storage/store/local_audit_chain.go
+++ b/internal/storage/store/local_audit_chain.go
@@ -83,6 +83,17 @@ func (ls *LocalStorage) LogAuditEvent(ctx context.Context, event *models.AuditEv
 	// µs-precision; an un-truncated nanosecond time would not round-trip).
 	event.EventTime = event.EventTime.Truncate(time.Microsecond)
 
+	// Normalize ActorType to the column default ("user", see models.AuditEvent)
+	// BEFORE hashing. The hash covers ActorType, but the row is stored via GORM,
+	// whose `default:user` tag rewrites an empty value to "user" at insert. Without
+	// this, a caller that leaves ActorType unset (e.g. the sharing/impersonation
+	// audit helpers) hashes over "" yet persists "user", so VerifyAuditChain later
+	// recomputes over the stored "user" and false-fails an untampered chain. Pinning
+	// the value here keeps the hashed and stored ActorType identical for every caller.
+	if event.ActorType == "" {
+		event.ActorType = "user"
+	}
+
 	ls.auditChainMu.Lock()
 	defer ls.auditChainMu.Unlock()
 

--- a/internal/storage/store/local_audit_chain_test.go
+++ b/internal/storage/store/local_audit_chain_test.go
@@ -188,6 +188,40 @@ func TestLogAuditEvent_ConcurrentAppendsStayChained(t *testing.T) {
 	assert.Equal(t, int64(writers*perWriter), v.ChainedEvents)
 }
 
+// An event written with ActorType left empty (as the sharing/impersonation audit
+// helpers do) must still verify: LogAuditEvent normalizes it to the column default
+// ("user") BEFORE hashing, so the hashed value matches the row GORM persists. Without
+// that normalization the hash is taken over "" while the stored row holds "user", and
+// VerifyAuditChain false-fails an untampered chain at the first such event.
+func TestLogAuditEvent_EmptyActorTypeStillVerifies(t *testing.T) {
+	ls := newAuditChainTestStore(t)
+	base := time.Now().UTC()
+	tr := true
+
+	// A normal event, then one with ActorType deliberately unset (the share path).
+	require.NoError(t, ls.LogAuditEvent(context.Background(), &models.AuditEvent{
+		EventType: "auth.login", Description: "first", Success: &tr, EventTime: base, ActorType: "user",
+	}))
+	shareEvt := &models.AuditEvent{
+		EventType: "share_created", Description: "shared with user 2",
+		Success: &tr, EventTime: base.Add(time.Second), // ActorType intentionally empty
+	}
+	require.NoError(t, ls.LogAuditEvent(context.Background(), shareEvt))
+
+	// The persisted row carries the column default, and the in-memory event was
+	// pinned to the same value so its hash matches.
+	assert.Equal(t, "user", shareEvt.ActorType, "empty ActorType is normalized to the stored default before hashing")
+	var stored models.AuditEvent
+	require.NoError(t, ls.db.First(&stored, shareEvt.ID).Error)
+	assert.Equal(t, "user", stored.ActorType)
+
+	v, err := ls.VerifyAuditChain(context.Background())
+	require.NoError(t, err)
+	assert.True(t, v.Valid, "chain with an empty-ActorType event must verify: %s", v.Reason)
+	assert.Equal(t, int64(2), v.ChainedEvents)
+	assert.Nil(t, v.FirstBrokenID)
+}
+
 func TestComputeAuditEntryHash_Deterministic(t *testing.T) {
 	at := time.Unix(1_700_000_000, 123000).UTC() // 123µs exactly
 	uid := uint(7)

--- a/internal/storage/store/local_auth.go
+++ b/internal/storage/store/local_auth.go
@@ -11,6 +11,8 @@ package store
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"time"
 
@@ -21,16 +23,32 @@ import (
 
 // --- Sessions ---
 
+// hashSessionToken is the at-rest representation of a session token. Sessions, like
+// PATs / machine / setup tokens, are stored only as a SHA-256 hash so a database read
+// (backup, replica, injection, insider) never yields a live, replayable token. The
+// plaintext lives only in the client's possession.
+func hashSessionToken(token string) string {
+	sum := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(sum[:])
+}
+
 func (ls *LocalStorage) CreateSession(ctx context.Context, session *models.Session) (*models.Session, error) {
-	if err := ls.db.WithContext(ctx).Create(session).Error; err != nil {
+	// Persist the hash, not the plaintext token. Hand the plaintext back to the caller
+	// (it must reach the client) but keep it out of the row; the column holds the hash.
+	plaintext := session.SessionToken
+	session.SessionToken = hashSessionToken(plaintext)
+	err := ls.db.WithContext(ctx).Create(session).Error
+	session.SessionToken = plaintext // restore for the caller (transient, never re-stored)
+	if err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}
 	return session, nil
 }
 
 func (ls *LocalStorage) GetSession(ctx context.Context, token string) (*models.Session, error) {
+	// Look up by the hash of the presented token — the row stores only the hash.
 	var session models.Session
-	if err := ls.db.WithContext(ctx).Where("session_token = ?", token).First(&session).Error; err != nil {
+	if err := ls.db.WithContext(ctx).Where("session_token = ?", hashSessionToken(token)).First(&session).Error; err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorNotFound", nil), err)
 	}
 	return &session, nil

--- a/internal/storage/store/local_invitations.go
+++ b/internal/storage/store/local_invitations.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"gorm.io/gorm/clause"
 )
 
 // --- Project invitations ---
@@ -84,7 +85,12 @@ func (ls *LocalStorage) ListAccessRequests(ctx context.Context, projectID uint) 
 }
 
 func (ls *LocalStorage) CreateAccessRequestApproval(ctx context.Context, a *models.AccessRequestApproval) error {
-	if err := ls.db.WithContext(ctx).Create(a).Error; err != nil {
+	// DoNothing on conflict so a duplicate (request_id, approver_id) — e.g. two
+	// concurrent approvals from the same approver racing past the app-level dedup —
+	// is a benign no-op rather than a unique-violation error. The unique index keeps
+	// the dual-control count honest (one row per distinct approver); this just makes
+	// the losing racer idempotent. Driver-agnostic (SQLite + Postgres).
+	if err := ls.db.WithContext(ctx).Clauses(clause.OnConflict{DoNothing: true}).Create(a).Error; err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}
 	return nil

--- a/internal/storage/store/local_rbac.go
+++ b/internal/storage/store/local_rbac.go
@@ -469,15 +469,35 @@ func (ls *LocalStorage) RemoveRoleFromGroup(ctx context.Context, groupID, roleID
 	return nil
 }
 
-// GetUserPermissions retrieves all distinct permissions for userID via role membership.
+// GetUserPermissions retrieves a user's EFFECTIVE distinct permissions — the union of
+// permissions granted by their directly-assigned roles AND roles inherited through group
+// membership. Both grant paths are what Authorize honours (direct + group role ids), so
+// the "what can this user do" view (dashboards, access reviews, SoD detection) must count
+// both; a direct-only set silently under-reports — and would miss a separation-of-duties
+// violation whose two permissions are held one directly and one via a group. Expired
+// grants and soft-deleted groups are excluded, matching the role-resolution path.
 func (ls *LocalStorage) GetUserPermissions(ctx context.Context, userID uint) ([]*storage.Permission, error) {
+	now := time.Now()
+	// Role ids granted directly to the user (unexpired).
+	directRoleIDs := ls.db.Table("user_roles").
+		Select("role_id").
+		Where("user_id = ?", userID).
+		Where("expires_at IS NULL OR expires_at > ?", now)
+	// Role ids inherited via group membership (active groups, unexpired grants) —
+	// mirrors GetUserGroupRoleIDsAt's join, minus the scope filter (this set is the
+	// user's permissions anywhere, like the direct set above).
+	groupRoleIDs := ls.db.Table("group_roles").
+		Select("group_roles.role_id").
+		Joins("JOIN user_groups ON user_groups.group_id = group_roles.group_id").
+		Joins("JOIN groups ON groups.id = group_roles.group_id AND groups.deleted_at IS NULL").
+		Where("user_groups.user_id = ?", userID).
+		Where("group_roles.expires_at IS NULL OR group_roles.expires_at > ?", now)
+
 	var permissions []*storage.Permission
 	err := ls.db.WithContext(ctx).Table("permissions").
 		Select("permissions.id, permissions.name, permissions.description, permissions.resource, permissions.action").
 		Joins("JOIN role_permissions ON permissions.id = role_permissions.permission_id").
-		Joins("JOIN user_roles ON role_permissions.role_id = user_roles.role_id").
-		Where("user_roles.user_id = ?", userID).
-		Where("user_roles.expires_at IS NULL OR user_roles.expires_at > ?", time.Now()).
+		Where("role_permissions.role_id IN (?) OR role_permissions.role_id IN (?)", directRoleIDs, groupRoleIDs).
 		Group("permissions.id").
 		Find(&permissions).Error
 	if err != nil {

--- a/internal/storage/store/local_retention_test.go
+++ b/internal/storage/store/local_retention_test.go
@@ -96,10 +96,10 @@ func TestDeleteResolvedAccessRequestsBefore_CascadesAndSkipsPending(t *testing.T
 	now := time.Now()
 	oldResolved := now.AddDate(0, 0, -200)
 
-	// Resolved request with 2 approvals — purged with its approvals.
+	// Resolved request with 2 approvals (from 2 distinct approvers) — purged with them.
 	require.NoError(t, ls.db.Create(&models.AccessRequest{ID: 1, State: "approved", ResolvedAt: &oldResolved}).Error)
-	require.NoError(t, ls.db.Create(&models.AccessRequestApproval{ID: 100, RequestID: 1}).Error)
-	require.NoError(t, ls.db.Create(&models.AccessRequestApproval{ID: 101, RequestID: 1}).Error)
+	require.NoError(t, ls.db.Create(&models.AccessRequestApproval{ID: 100, RequestID: 1, ApproverID: 11}).Error)
+	require.NoError(t, ls.db.Create(&models.AccessRequestApproval{ID: 101, RequestID: 1, ApproverID: 12}).Error)
 	// Pending request (resolved_at NULL) created long ago — never purged.
 	require.NoError(t, ls.db.Create(&models.AccessRequest{ID: 2, State: "pending", CreatedAt: oldResolved}).Error)
 

--- a/internal/storage/store/session_hash_test.go
+++ b/internal/storage/store/session_hash_test.go
@@ -1,0 +1,44 @@
+package store
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// Session tokens must be stored hashed (like PATs/setup tokens), so a database read
+// never yields a live, replayable token — while the plaintext still round-trips to the
+// caller and validates on lookup.
+func TestSession_StoredHashedNotPlaintext(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.Session{}))
+	ls := NewLocalStorage(db)
+	ctx := context.Background()
+
+	const raw = "kx-session-plaintext-xyz"
+	created, err := ls.CreateSession(ctx, &models.Session{UserID: 1, SessionToken: raw})
+	require.NoError(t, err)
+	// The caller still receives the plaintext to hand to the client.
+	assert.Equal(t, raw, created.SessionToken)
+
+	// The row stores only the hash.
+	var row models.Session
+	require.NoError(t, db.First(&row, created.ID).Error)
+	assert.NotEqual(t, raw, row.SessionToken, "session token must not be persisted in plaintext")
+	assert.Equal(t, hashSessionToken(raw), row.SessionToken)
+
+	// Lookup by the plaintext token works (hashed internally on the way in).
+	got, err := ls.GetSession(ctx, raw)
+	require.NoError(t, err)
+	assert.Equal(t, created.ID, got.ID)
+
+	// A token equal to the stored hash (as if lifted from a DB dump) must NOT validate.
+	_, err = ls.GetSession(ctx, hashSessionToken(raw))
+	require.Error(t, err, "the stored hash is not itself a usable session token")
+}

--- a/server/grpc/interceptors/auth.go
+++ b/server/grpc/interceptors/auth.go
@@ -62,8 +62,10 @@ const (
 )
 
 // AuthInterceptor returns a unary server interceptor that authenticates each
-// request against a real session token via the core service.
-func AuthInterceptor(coreService *core.KeyorixCore) grpc.UnaryServerInterceptor {
+// request against a real session token via the core service. requireMFA mirrors
+// the deployment-wide security.require_mfa policy so the gRPC transport enforces
+// the same MFA-enrolment gate as the HTTP API.
+func AuthInterceptor(coreService *core.KeyorixCore, requireMFA bool) grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 		// Skip authentication for certain methods
 		if isPublicMethod(info.FullMethod) {
@@ -71,7 +73,7 @@ func AuthInterceptor(coreService *core.KeyorixCore) grpc.UnaryServerInterceptor 
 		}
 
 		// Extract and validate token
-		userCtx, restriction, err := authenticateRequest(ctx, coreService)
+		userCtx, restriction, err := authenticateRequest(ctx, coreService, requireMFA)
 		if err != nil {
 			return nil, err
 		}
@@ -88,8 +90,9 @@ func AuthInterceptor(coreService *core.KeyorixCore) grpc.UnaryServerInterceptor 
 }
 
 // StreamAuthInterceptor returns a stream server interceptor that authenticates
-// each stream against a real session token via the core service.
-func StreamAuthInterceptor(coreService *core.KeyorixCore) grpc.StreamServerInterceptor {
+// each stream against a real session token via the core service. requireMFA
+// mirrors the deployment-wide security.require_mfa policy (see AuthInterceptor).
+func StreamAuthInterceptor(coreService *core.KeyorixCore, requireMFA bool) grpc.StreamServerInterceptor {
 	return func(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 		// Skip authentication for certain methods
 		if isPublicMethod(info.FullMethod) {
@@ -97,7 +100,7 @@ func StreamAuthInterceptor(coreService *core.KeyorixCore) grpc.StreamServerInter
 		}
 
 		// Extract and validate token
-		userCtx, restriction, err := authenticateRequest(stream.Context(), coreService)
+		userCtx, restriction, err := authenticateRequest(stream.Context(), coreService, requireMFA)
 		if err != nil {
 			return err
 		}
@@ -133,7 +136,7 @@ func (w *wrappedServerStream) Context() context.Context {
 // token. On success it returns the authenticated user's context (id, identity,
 // roles, permissions) and the PAT restriction (nil for sessions) for downstream
 // authorization.
-func authenticateRequest(ctx context.Context, coreService *core.KeyorixCore) (*UserContext, *core.PATRestriction, error) {
+func authenticateRequest(ctx context.Context, coreService *core.KeyorixCore, requireMFA bool) (*UserContext, *core.PATRestriction, error) {
 	if coreService == nil {
 		// Fail closed: a server wired without a core service must not authenticate.
 		return nil, nil, status.Errorf(codes.Internal, "authentication unavailable")
@@ -199,6 +202,27 @@ func authenticateRequest(ctx context.Context, coreService *core.KeyorixCore) (*U
 		if !core.IPInCIDRs(grpcPeerIP(ctx), restriction.AllowedCIDRs) {
 			return nil, nil, status.Errorf(codes.PermissionDenied, "token not permitted from this network")
 		}
+	}
+
+	// Mirror the HTTP authed-group gates over gRPC so neither is bypassable by switching
+	// transport (the same class of gap ADR-066 closed for the IP allowlist):
+	//
+	//   - Account restriction (ADR-025): a pending_first_login / password_reset_required
+	//     account must change its password first. On HTTP it is confined to the
+	//     change-password allowlist; gRPC has no such endpoint, so it is denied outright.
+	//   - MFA enrolment (ADR-037): when the deployment mandates MFA, an interactive
+	//     session without MFA is confined to the enrolment endpoints on HTTP; again gRPC
+	//     has none, so deny. PATs and machine tokens are non-interactive and exempt,
+	//     exactly as on HTTP — automation must not break.
+	//
+	// Both fail closed. viaSession is true for a session token (machine tokens already
+	// returned above; a PAT carries the patTokenPrefix).
+	if core.AccountRestricted(user.AccountState) {
+		return nil, nil, status.Errorf(codes.PermissionDenied, "password change required before access")
+	}
+	viaSession := !strings.HasPrefix(token, patTokenPrefix)
+	if requireMFA && viaSession && !(user.MFAEnabled || user.WebAuthnEnabled) {
+		return nil, nil, status.Errorf(codes.PermissionDenied, "multi-factor authentication enrolment required")
 	}
 
 	// Resolve roles + permissions for downstream per-method authorization.

--- a/server/grpc/interceptors/auth.go
+++ b/server/grpc/interceptors/auth.go
@@ -248,7 +248,7 @@ func authenticateRequest(ctx context.Context, coreService *core.KeyorixCore, req
 	// restriction is not bypassable by switching from HTTP to gRPC. Fail-closed: an
 	// undeterminable peer IP outside the allowlist is denied.
 	if restriction != nil && len(restriction.AllowedCIDRs) > 0 {
-		if !core.IPInCIDRs(grpcPeerIP(ctx), restriction.AllowedCIDRs) {
+		if !core.IPInCIDRs(PeerIP(ctx), restriction.AllowedCIDRs) {
 			return nil, nil, status.Errorf(codes.PermissionDenied, "token not permitted from this network")
 		}
 	}
@@ -297,9 +297,10 @@ func authenticateRequest(ctx context.Context, coreService *core.KeyorixCore, req
 	}, restriction, nil
 }
 
-// grpcPeerIP returns the source IP of the gRPC call from its peer (TCP) address, or "" if
-// it cannot be determined (which the fail-closed allowlist check then denies).
-func grpcPeerIP(ctx context.Context) string {
+// PeerIP returns the source IP of the gRPC call from its peer (TCP) address, or "" if
+// it cannot be determined (which the fail-closed allowlist check then denies). Exported
+// so the service layer can stamp it on secret-access logs, matching the HTTP path.
+func PeerIP(ctx context.Context) string {
 	p, ok := peer.FromContext(ctx)
 	if !ok || p.Addr == nil {
 		return ""
@@ -308,6 +309,19 @@ func grpcPeerIP(ctx context.Context) string {
 		return host
 	}
 	return p.Addr.String()
+}
+
+// ClientUserAgent returns the gRPC client's user-agent from request metadata, or ""
+// when absent. Recorded on secret-access logs alongside the peer IP, as on HTTP.
+func ClientUserAgent(ctx context.Context) string {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return ""
+	}
+	if ua := md.Get("user-agent"); len(ua) > 0 {
+		return ua[0]
+	}
+	return ""
 }
 
 // isPublicMethod checks if a gRPC method is public (doesn't require authentication)

--- a/server/grpc/interceptors/auth.go
+++ b/server/grpc/interceptors/auth.go
@@ -34,6 +34,12 @@ type UserContext struct {
 	// (treated as a user). MachineIdentityID is the machine's id for that case.
 	ActorType         string `json:"actor_type,omitempty"`
 	MachineIdentityID uint   `json:"machine_identity_id,omitempty"`
+	// ImpersonatedBy is the initiating admin's id when this is an impersonation
+	// session (nil otherwise). Resolved once in authenticateRequest and tagged onto
+	// the request context by the interceptors (core.WithImpersonation) so audit
+	// events written over gRPC carry the same accountability HTTP records — the
+	// same definition HTTP's UserContext uses.
+	ImpersonatedBy *uint `json:"impersonated_by,omitempty"`
 	// SessionAuth is true only for an interactive session token — false for PATs and
 	// machine tokens, which are non-interactive. MFAEnabled is true when the user has
 	// any second factor (TOTP or a passkey). Together they let the service layer apply
@@ -87,6 +93,7 @@ func AuthInterceptor(coreService *core.KeyorixCore, requireMFA bool) grpc.UnaryS
 
 		// Add user context to request context
 		newCtx := context.WithValue(ctx, userContextKey, userCtx)
+		newCtx = withAuditAttribution(newCtx, userCtx)
 		// Carry a PAT's least-privilege restriction (ADR-042) so core.Authorize
 		// enforces it on every authorization check this RPC makes.
 		if restriction != nil {
@@ -112,8 +119,9 @@ func StreamAuthInterceptor(coreService *core.KeyorixCore, requireMFA bool) grpc.
 			return err
 		}
 
-		// Create a new stream with user context (+ PAT restriction when present).
+		// Create a new stream with user context (+ audit attribution / PAT restriction).
 		streamCtx := context.WithValue(stream.Context(), userContextKey, userCtx)
+		streamCtx = withAuditAttribution(streamCtx, userCtx)
 		if restriction != nil {
 			streamCtx = core.WithPATRestriction(streamCtx, restriction)
 		}
@@ -134,6 +142,30 @@ type wrappedServerStream struct {
 
 func (w *wrappedServerStream) Context() context.Context {
 	return w.ctx
+}
+
+// withAuditAttribution tags ctx so audit events written downstream over gRPC carry
+// the same actor accountability the HTTP path records in buildRequestContext:
+//
+//   - a machine-identity request is actored as a machine (ADR-023/030) rather than
+//     defaulting to "user";
+//   - an impersonation session records the initiating admin (ImpersonatedBy /
+//     Impersonation=true), so an admin acting through impersonation stays
+//     attributable over gRPC just as on HTTP.
+//
+// Without this, switching transport to gRPC silently dropped both tags — machine
+// actions were logged as user actions and impersonated actions lost the admin.
+func withAuditAttribution(ctx context.Context, userCtx *UserContext) context.Context {
+	if userCtx == nil {
+		return ctx
+	}
+	if userCtx.ActorType == core.ActorTypeMachine {
+		ctx = core.WithActorType(ctx, core.ActorTypeMachine)
+	}
+	if userCtx.ImpersonatedBy != nil {
+		ctx = core.WithImpersonation(ctx, *userCtx.ImpersonatedBy)
+	}
+	return ctx
 }
 
 // authenticateRequest extracts the bearer token from the request metadata and
@@ -193,13 +225,23 @@ func authenticateRequest(ctx context.Context, coreService *core.KeyorixCore, req
 		restriction *core.PATRestriction
 		err         error
 	)
-	if strings.HasPrefix(token, patTokenPrefix) {
+	viaPAT := strings.HasPrefix(token, patTokenPrefix)
+	if viaPAT {
 		user, _, restriction, err = coreService.ValidatePATToken(ctx, token)
 	} else {
 		user, _, err = coreService.ValidateSessionToken(ctx, token)
 	}
 	if err != nil {
 		return nil, nil, status.Errorf(codes.Unauthenticated, "Invalid or expired token")
+	}
+
+	// Resolve impersonation for a real session token (a PAT is never an
+	// impersonation session). On HTTP the auth middleware tags the context so audit
+	// events record the initiating admin; mirror it here so that accountability is
+	// not lost by switching transport. A non-impersonation session returns nil.
+	var impersonatedBy *uint
+	if !viaPAT {
+		impersonatedBy = coreService.SessionImpersonator(ctx, token)
 	}
 
 	// Enforce a PAT's network allowlist on the gRPC transport too (ADR-066), so the IP
@@ -227,7 +269,7 @@ func authenticateRequest(ctx context.Context, coreService *core.KeyorixCore, req
 	if core.AccountRestricted(user.AccountState) {
 		return nil, nil, status.Errorf(codes.PermissionDenied, "password change required before access")
 	}
-	viaSession := !strings.HasPrefix(token, patTokenPrefix)
+	viaSession := !viaPAT
 	if requireMFA && viaSession && !(user.MFAEnabled || user.WebAuthnEnabled) {
 		return nil, nil, status.Errorf(codes.PermissionDenied, "multi-factor authentication enrolment required")
 	}
@@ -249,6 +291,9 @@ func authenticateRequest(ctx context.Context, coreService *core.KeyorixCore, req
 		// stays exempt — exactly as the deployment-wide gate above and HTTP treat it.
 		SessionAuth: viaSession,
 		MFAEnabled:  user.MFAEnabled || user.WebAuthnEnabled,
+		// Carry the impersonation attribution so the interceptor can tag the request
+		// context (core.WithImpersonation) — audit parity with HTTP.
+		ImpersonatedBy: impersonatedBy,
 	}, restriction, nil
 }
 

--- a/server/grpc/interceptors/auth.go
+++ b/server/grpc/interceptors/auth.go
@@ -34,6 +34,13 @@ type UserContext struct {
 	// (treated as a user). MachineIdentityID is the machine's id for that case.
 	ActorType         string `json:"actor_type,omitempty"`
 	MachineIdentityID uint   `json:"machine_identity_id,omitempty"`
+	// SessionAuth is true only for an interactive session token — false for PATs and
+	// machine tokens, which are non-interactive. MFAEnabled is true when the user has
+	// any second factor (TOTP or a passkey). Together they let the service layer apply
+	// the per-project MFA policy (ADR-037) the same way the HTTP ProjectMFABlocked gate
+	// does, so it is not bypassable by switching transport.
+	SessionAuth bool `json:"-"`
+	MFAEnabled  bool `json:"-"`
 }
 
 // ActorKind returns the principal's actor type ("user" or "machine_identity"),
@@ -237,6 +244,11 @@ func authenticateRequest(ctx context.Context, coreService *core.KeyorixCore, req
 		Email:       user.Email,
 		Roles:       identity.Roles,
 		Permissions: identity.Permissions,
+		// Carry the interactive-session and second-factor facts so the service layer can
+		// apply the per-project MFA policy (ADR-037). viaSession is false for a PAT, which
+		// stays exempt — exactly as the deployment-wide gate above and HTTP treat it.
+		SessionAuth: viaSession,
+		MFAEnabled:  user.MFAEnabled || user.WebAuthnEnabled,
 	}, restriction, nil
 }
 

--- a/server/grpc/interceptors/auth_test.go
+++ b/server/grpc/interceptors/auth_test.go
@@ -65,7 +65,7 @@ func TestAuthInterceptor_ValidSessionPopulatesUserContext(t *testing.T) {
 	mintSessionForTest(t, h, 9001, "grpc-alice", "live-token", time.Now().Add(time.Hour))
 
 	var captured context.Context
-	interceptor := AuthInterceptor(h.CoreService)
+	interceptor := AuthInterceptor(h.CoreService, false)
 	resp, err := interceptor(bearerCtx("live-token"), nil,
 		&grpc.UnaryServerInfo{FullMethod: secretMethod}, okHandler(&captured))
 
@@ -84,7 +84,7 @@ func TestAuthInterceptor_LegacyBackdoorTokenRejected(t *testing.T) {
 	h := setupAuthHelper(t)
 	defer h.Cleanup()
 
-	interceptor := AuthInterceptor(h.CoreService)
+	interceptor := AuthInterceptor(h.CoreService, false)
 	for _, tok := range []string{"valid-token", "test-token"} {
 		_, err := interceptor(bearerCtx(tok), nil,
 			&grpc.UnaryServerInfo{FullMethod: secretMethod}, okHandler(nil))
@@ -98,7 +98,7 @@ func TestAuthInterceptor_ExpiredSessionRejected(t *testing.T) {
 	defer h.Cleanup()
 	mintSessionForTest(t, h, 9002, "grpc-bob", "stale-token", time.Now().Add(-time.Minute))
 
-	interceptor := AuthInterceptor(h.CoreService)
+	interceptor := AuthInterceptor(h.CoreService, false)
 	_, err := interceptor(bearerCtx("stale-token"), nil,
 		&grpc.UnaryServerInfo{FullMethod: secretMethod}, okHandler(nil))
 	require.Error(t, err)
@@ -108,7 +108,7 @@ func TestAuthInterceptor_ExpiredSessionRejected(t *testing.T) {
 func TestAuthInterceptor_MissingAndMalformedCredentials(t *testing.T) {
 	h := setupAuthHelper(t)
 	defer h.Cleanup()
-	interceptor := AuthInterceptor(h.CoreService)
+	interceptor := AuthInterceptor(h.CoreService, false)
 	info := &grpc.UnaryServerInfo{FullMethod: secretMethod}
 
 	cases := map[string]context.Context{
@@ -129,7 +129,7 @@ func TestAuthInterceptor_MissingAndMalformedCredentials(t *testing.T) {
 
 // A nil core service must fail closed (never authenticate) rather than panic.
 func TestAuthInterceptor_NilCoreFailsClosed(t *testing.T) {
-	interceptor := AuthInterceptor(nil)
+	interceptor := AuthInterceptor(nil, false)
 	_, err := interceptor(bearerCtx("whatever"), nil,
 		&grpc.UnaryServerInfo{FullMethod: secretMethod}, okHandler(nil))
 	require.Error(t, err)
@@ -138,7 +138,7 @@ func TestAuthInterceptor_NilCoreFailsClosed(t *testing.T) {
 
 // Public methods (health, reflection) bypass authentication entirely.
 func TestAuthInterceptor_PublicMethodBypassesAuth(t *testing.T) {
-	interceptor := AuthInterceptor(nil) // never consulted for public methods
+	interceptor := AuthInterceptor(nil, false) // never consulted for public methods
 	var captured context.Context
 	resp, err := interceptor(context.Background(), nil,
 		&grpc.UnaryServerInfo{FullMethod: "/grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo"},
@@ -167,7 +167,7 @@ func TestAuthInterceptor_PATAuthenticatesAndEnforcesScope(t *testing.T) {
 	require.True(t, strings.HasPrefix(res.PlainToken, "kx_pat_"))
 
 	var captured context.Context
-	interceptor := AuthInterceptor(h.CoreService)
+	interceptor := AuthInterceptor(h.CoreService, false)
 	resp, err := interceptor(bearerCtx(res.PlainToken), nil,
 		&grpc.UnaryServerInfo{FullMethod: secretMethod}, okHandler(&captured))
 	require.NoError(t, err, "a kx_pat_ token must now authenticate over gRPC")
@@ -208,7 +208,7 @@ func TestAuthInterceptor_MachineTokenAuthenticatesAndUsesMachineRBAC(t *testing.
 	require.NoError(t, h.CoreService.AssignMachineRole(context.Background(), m.ID, 4, core.Scope{ProjectID: 2}, 1))
 
 	var captured context.Context
-	interceptor := AuthInterceptor(h.CoreService)
+	interceptor := AuthInterceptor(h.CoreService, false)
 	_, err = interceptor(bearerCtx(tok.PlainToken), nil,
 		&grpc.UnaryServerInfo{FullMethod: secretMethod}, okHandler(&captured))
 	require.NoError(t, err, "a kx_machine_ token must authenticate over gRPC")
@@ -242,7 +242,7 @@ func TestAuthInterceptor_InvalidPATRejected(t *testing.T) {
 	defer h.Cleanup()
 	require.NoError(t, h.DB.AutoMigrate(&models.PersonalAccessToken{}))
 
-	interceptor := AuthInterceptor(h.CoreService)
+	interceptor := AuthInterceptor(h.CoreService, false)
 	_, err := interceptor(bearerCtx("kx_pat_bogus"), nil,
 		&grpc.UnaryServerInfo{FullMethod: secretMethod}, okHandler(nil))
 	require.Error(t, err)
@@ -272,7 +272,7 @@ func TestAuthInterceptor_PATNetworkAllowlistOverGRPC(t *testing.T) {
 	res, err := h.CoreService.CreateOwnPAT(context.Background(), 9200, "ci-cidr", nil, nil, 0, 0, []string{"10.0.0.0/8"})
 	require.NoError(t, err)
 
-	interceptor := AuthInterceptor(h.CoreService)
+	interceptor := AuthInterceptor(h.CoreService, false)
 
 	_, err = interceptor(bearerCtxFromIP(res.PlainToken, "10.1.2.3"), nil,
 		&grpc.UnaryServerInfo{FullMethod: secretMethod}, okHandler(nil))
@@ -282,4 +282,67 @@ func TestAuthInterceptor_PATNetworkAllowlistOverGRPC(t *testing.T) {
 		&grpc.UnaryServerInfo{FullMethod: secretMethod}, okHandler(nil))
 	require.Error(t, err, "off-network source IP must be denied over gRPC")
 	assert.Equal(t, codes.PermissionDenied, status.Code(err))
+}
+
+// setUserFields fetches a user by id, applies mutate, and persists — used to put a
+// test user into a restricted account state or flip its MFA flag.
+func setUserFields(t *testing.T, h *testhelper.RBACTestHelper, userID uint, mutate func(*models.User)) {
+	t.Helper()
+	var u models.User
+	require.NoError(t, h.DB.First(&u, userID).Error)
+	mutate(&u)
+	require.NoError(t, h.DB.Save(&u).Error)
+}
+
+// A restricted account (ADR-025 password_reset_required / pending_first_login) must
+// change its password first. HTTP confines it to the change-password allowlist; gRPC
+// has no such endpoint, so it is denied outright — otherwise the restriction would be
+// bypassable by switching transports.
+func TestAuthInterceptor_RestrictedAccountDeniedOverGRPC(t *testing.T) {
+	h := setupAuthHelper(t)
+	defer h.Cleanup()
+	mintSessionForTest(t, h, 9300, "grpc-reset", "reset-token", time.Now().Add(time.Hour))
+	setUserFields(t, h, 9300, func(u *models.User) { u.AccountState = core.AccountPasswordResetRequired })
+
+	interceptor := AuthInterceptor(h.CoreService, false)
+	_, err := interceptor(bearerCtx("reset-token"), nil,
+		&grpc.UnaryServerInfo{FullMethod: secretMethod}, okHandler(nil))
+	require.Error(t, err, "a restricted account must not access RPCs over gRPC")
+	assert.Equal(t, codes.PermissionDenied, status.Code(err))
+}
+
+// When the deployment mandates MFA (security.require_mfa), an interactive session
+// without MFA is confined to the enrolment endpoints on HTTP; gRPC has none, so it is
+// denied. A session with MFA is allowed, and a PAT is exempt (non-interactive) — both
+// matching the HTTP EnforceMFAEnrollment policy.
+func TestAuthInterceptor_MFAEnrolmentGateOverGRPC(t *testing.T) {
+	h := setupAuthHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(&models.PersonalAccessToken{}))
+
+	mintSessionForTest(t, h, 9400, "grpc-nomfa", "nomfa-token", time.Now().Add(time.Hour))
+	mintSessionForTest(t, h, 9401, "grpc-mfa", "mfa-token", time.Now().Add(time.Hour))
+	setUserFields(t, h, 9401, func(u *models.User) { u.MFAEnabled = true })
+
+	// A PAT owned by a user without MFA — non-interactive, so exempt from the gate.
+	h.CreateTestUser(t, "grpc-pat-nomfa", 9402)
+	res, err := h.CoreService.CreateOwnPAT(context.Background(), 9402, "ci", nil, nil, 0, 0, nil)
+	require.NoError(t, err)
+
+	mfaRequired := AuthInterceptor(h.CoreService, true)
+	info := &grpc.UnaryServerInfo{FullMethod: secretMethod}
+
+	_, err = mfaRequired(bearerCtx("nomfa-token"), nil, info, okHandler(nil))
+	require.Error(t, err, "session without MFA must be denied when the deployment requires MFA")
+	assert.Equal(t, codes.PermissionDenied, status.Code(err))
+
+	_, err = mfaRequired(bearerCtx("mfa-token"), nil, info, okHandler(nil))
+	require.NoError(t, err, "session with MFA is allowed")
+
+	_, err = mfaRequired(bearerCtx(res.PlainToken), nil, info, okHandler(nil))
+	require.NoError(t, err, "a PAT is non-interactive and exempt from the MFA-enrolment gate")
+
+	// With the policy off, the same un-enrolled session authenticates fine.
+	_, err = AuthInterceptor(h.CoreService, false)(bearerCtx("nomfa-token"), nil, info, okHandler(nil))
+	require.NoError(t, err, "no MFA gate when the deployment does not require MFA")
 }

--- a/server/grpc/interceptors/auth_test.go
+++ b/server/grpc/interceptors/auth_test.go
@@ -346,3 +346,86 @@ func TestAuthInterceptor_MFAEnrolmentGateOverGRPC(t *testing.T) {
 	_, err = AuthInterceptor(h.CoreService, false)(bearerCtx("nomfa-token"), nil, info, okHandler(nil))
 	require.NoError(t, err, "no MFA gate when the deployment does not require MFA")
 }
+
+// A machine-identity request over gRPC must produce audit events actored as a
+// machine (ADR-023/030), not silently defaulted to "user" — parity with HTTP's
+// buildRequestContext, which tags the request context the same way. Without the
+// interceptor tagging the context, switching transport to gRPC would mislabel
+// every machine action as a user action in the audit trail.
+func TestAuthInterceptor_MachineRequestStampsMachineActorInAudit(t *testing.T) {
+	h := setupAuthHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(
+		&models.MachineIdentity{}, &models.MachineIdentityCredential{}, &models.MachineIdentityRole{}, &models.AuditEvent{}))
+
+	m, err := h.CoreService.CreateMachineIdentity(context.Background(), 2, "ci-bot", "service", "", "", 1)
+	require.NoError(t, err)
+	tok, err := h.CoreService.IssueMachineToken(context.Background(), 2, m.ID, "tok", nil, "", 1)
+	require.NoError(t, err)
+
+	var captured context.Context
+	interceptor := AuthInterceptor(h.CoreService, false)
+	_, err = interceptor(bearerCtx(tok.PlainToken), nil,
+		&grpc.UnaryServerInfo{FullMethod: secretMethod}, okHandler(&captured))
+	require.NoError(t, err)
+
+	// An audit event written downstream with the handler's context must be machine-actored.
+	h.CoreService.LogRoleAssigned(captured, 0, 1, 4, core.Scope{ProjectID: 2})
+	var ev models.AuditEvent
+	require.NoError(t, h.DB.Order("id desc").First(&ev).Error)
+	assert.Equal(t, core.ActorTypeMachine, ev.ActorType,
+		"a machine request over gRPC must stamp ActorType=machine_identity in audit")
+}
+
+// An impersonation session used over gRPC must keep the initiating admin
+// attributable: every audit event it writes records ImpersonatedBy and
+// Impersonation=true, exactly as on HTTP. Without resolving SessionImpersonator
+// and tagging the context, an admin acting through impersonation over gRPC would
+// be invisible in the audit trail — an accountability bypass by transport.
+func TestAuthInterceptor_ImpersonationSessionStampsAdminInAudit(t *testing.T) {
+	h := setupAuthHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(&models.AuditEvent{}))
+
+	const adminID, targetID uint = 7001, 7002
+	h.CreateTestUser(t, "imp-target", targetID)
+	exp := time.Now().Add(time.Hour)
+	admin := adminID
+	_, err := h.Storage.CreateSession(context.Background(), &models.Session{
+		UserID:         targetID,
+		SessionToken:   "imp-token",
+		ExpiresAt:      &exp,
+		ImpersonatedBy: &admin,
+	})
+	require.NoError(t, err)
+
+	var captured context.Context
+	interceptor := AuthInterceptor(h.CoreService, false)
+	_, err = interceptor(bearerCtx("imp-token"), nil,
+		&grpc.UnaryServerInfo{FullMethod: secretMethod}, okHandler(&captured))
+	require.NoError(t, err)
+
+	// The token authenticates as the impersonated target, carrying the admin's id.
+	user := GetUserFromGRPCContext(captured)
+	require.NotNil(t, user)
+	assert.Equal(t, targetID, user.UserID)
+	require.NotNil(t, user.ImpersonatedBy, "impersonation must be resolved over gRPC")
+	assert.Equal(t, adminID, *user.ImpersonatedBy)
+
+	// An audit event written downstream records the initiating admin and the flag.
+	h.CoreService.LogRoleAssigned(captured, targetID, 1, 4, core.Scope{ProjectID: 2})
+	var ev models.AuditEvent
+	require.NoError(t, h.DB.Order("id desc").First(&ev).Error)
+	require.NotNil(t, ev.ImpersonatedBy, "audit over gRPC must record the impersonating admin")
+	assert.Equal(t, adminID, *ev.ImpersonatedBy)
+	assert.True(t, ev.Impersonation, "audit over gRPC must mark the event as impersonated")
+
+	// A non-impersonation session leaves the tag unset (no false positives).
+	mintSessionForTest(t, h, 7003, "plain-user", "plain-token", time.Now().Add(time.Hour))
+	var plainCtx context.Context
+	_, err = interceptor(bearerCtx("plain-token"), nil,
+		&grpc.UnaryServerInfo{FullMethod: secretMethod}, okHandler(&plainCtx))
+	require.NoError(t, err)
+	assert.Nil(t, GetUserFromGRPCContext(plainCtx).ImpersonatedBy,
+		"an ordinary session must not be tagged as impersonation")
+}

--- a/server/grpc/interceptors/timeout.go
+++ b/server/grpc/interceptors/timeout.go
@@ -1,0 +1,27 @@
+package interceptors
+
+import (
+	"context"
+	"time"
+
+	"google.golang.org/grpc"
+)
+
+// TimeoutInterceptor returns a unary server interceptor that caps each RPC's
+// duration at d, mirroring the HTTP API's request-timeout middleware
+// (middleware.Timeout) so a slow or hung handler cannot tie up server resources
+// indefinitely over gRPC when it would be bounded over HTTP.
+//
+// It is unary-only by design: streaming RPCs (e.g. StreamAuditLogs) are
+// legitimately long-lived and must not be cut off, so the stream chain carries no
+// timeout. context.WithTimeout only ever shortens the deadline, so a client that
+// already set a tighter deadline keeps it; one that set none (or a longer one) is
+// capped at d. On expiry the handler's context is cancelled and the RPC returns
+// DeadlineExceeded.
+func TimeoutInterceptor(d time.Duration) grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		ctx, cancel := context.WithTimeout(ctx, d)
+		defer cancel()
+		return handler(ctx, req)
+	}
+}

--- a/server/grpc/interceptors/timeout_test.go
+++ b/server/grpc/interceptors/timeout_test.go
@@ -1,0 +1,62 @@
+package interceptors
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+// A slow unary handler is cut off at the configured deadline: the interceptor
+// injects a timeout into the context, and a handler that outlives it gets
+// DeadlineExceeded — the gRPC analogue of the HTTP request-timeout middleware.
+func TestTimeoutInterceptor_CapsSlowHandler(t *testing.T) {
+	interceptor := TimeoutInterceptor(50 * time.Millisecond)
+
+	_, err := interceptor(context.Background(), nil,
+		&grpc.UnaryServerInfo{FullMethod: "/keyorix.v1.SecretService/GetSecret"},
+		func(ctx context.Context, _ interface{}) (interface{}, error) {
+			_, ok := ctx.Deadline()
+			require.True(t, ok, "the handler's context must carry the injected deadline")
+			<-ctx.Done() // simulate a hung handler
+			return nil, ctx.Err()
+		})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+// A handler that returns before the deadline is unaffected — the timeout only
+// bounds the worst case, it does not add latency to normal calls.
+func TestTimeoutInterceptor_FastHandlerUnaffected(t *testing.T) {
+	interceptor := TimeoutInterceptor(time.Hour)
+
+	resp, err := interceptor(context.Background(), nil,
+		&grpc.UnaryServerInfo{FullMethod: "/keyorix.v1.SecretService/GetSecret"},
+		func(context.Context, interface{}) (interface{}, error) { return "ok", nil })
+
+	require.NoError(t, err)
+	assert.Equal(t, "ok", resp)
+}
+
+// A client deadline tighter than the cap is preserved — context.WithTimeout only
+// ever shortens, so the interceptor never extends a caller's own deadline.
+func TestTimeoutInterceptor_PreservesShorterClientDeadline(t *testing.T) {
+	interceptor := TimeoutInterceptor(time.Hour)
+	clientCtx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
+
+	var handlerDeadline time.Time
+	_, _ = interceptor(clientCtx, nil,
+		&grpc.UnaryServerInfo{FullMethod: "/keyorix.v1.SecretService/GetSecret"},
+		func(ctx context.Context, _ interface{}) (interface{}, error) {
+			handlerDeadline, _ = ctx.Deadline()
+			return "ok", nil
+		})
+
+	assert.WithinDuration(t, time.Now().Add(30*time.Millisecond), handlerDeadline, 25*time.Millisecond,
+		"the tighter client deadline must win over the 1h cap")
+}

--- a/server/grpc/server.go
+++ b/server/grpc/server.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"math"
+	"time"
 
 	"github.com/keyorixhq/keyorix/internal/config"
 	"github.com/keyorixhq/keyorix/internal/core"
@@ -15,6 +16,11 @@ import (
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/reflection"
 )
+
+// grpcUnaryTimeout caps each unary RPC's duration, matching the HTTP API's 60s
+// request-timeout middleware (server/http/router.go) so the bound is the same on
+// both transports. Streaming RPCs are exempt (see TimeoutInterceptor).
+const grpcUnaryTimeout = 60 * time.Second
 
 // NewServer creates a new gRPC server. The auth interceptor validates session
 // tokens against the shared core service. Service registration is wired in a
@@ -28,6 +34,11 @@ func NewServer(cfg *config.Config, coreService *core.KeyorixCore) (*grpc.Server,
 		grpc.ChainUnaryInterceptor(
 			interceptors.LoggingInterceptor(),
 			interceptors.RecoveryInterceptor(),
+			// Cap each unary RPC at the same 60s the HTTP API's Timeout middleware
+			// enforces, so a hung handler can't tie up resources over gRPC when it would
+			// be bounded over HTTP. Streams are intentionally exempt (StreamAuditLogs is
+			// long-lived), so the stream chain carries no timeout.
+			interceptors.TimeoutInterceptor(grpcUnaryTimeout),
 			interceptors.AuthInterceptor(coreService, cfg.Security.RequireMFA),
 			interceptors.MetricsInterceptor(),
 		),

--- a/server/grpc/server.go
+++ b/server/grpc/server.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"log"
+	"math"
 
 	"github.com/keyorixhq/keyorix/internal/config"
 	"github.com/keyorixhq/keyorix/internal/core"
@@ -36,6 +37,18 @@ func NewServer(cfg *config.Config, coreService *core.KeyorixCore) (*grpc.Server,
 			interceptors.StreamAuthInterceptor(coreService, cfg.Security.RequireMFA),
 		),
 	}
+
+	// Honor the configured request-size cap on gRPC too. HTTP enforces it via the
+	// MaxBodyBytes middleware (max_request_body_bytes) to mitigate memory-exhaustion
+	// DoS; without this gRPC silently kept grpc-go's own 4 MiB default and ignored the
+	// operator's server.grpc setting, so the cap was bypassable by switching transport.
+	// Bounds the inbound message; clamp to MaxInt32 so the int64→int conversion is safe
+	// on every platform (a >2 GiB request cap is nonsensical anyway).
+	maxMsg := cfg.Server.GRPC.EffectiveMaxRequestBodyBytes()
+	if maxMsg > math.MaxInt32 {
+		maxMsg = math.MaxInt32
+	}
+	opts = append(opts, grpc.MaxRecvMsgSize(int(maxMsg)))
 
 	// Add TLS if enabled
 	if cfg.Server.GRPC.TLS.Enabled {

--- a/server/grpc/server.go
+++ b/server/grpc/server.go
@@ -27,13 +27,13 @@ func NewServer(cfg *config.Config, coreService *core.KeyorixCore) (*grpc.Server,
 		grpc.ChainUnaryInterceptor(
 			interceptors.LoggingInterceptor(),
 			interceptors.RecoveryInterceptor(),
-			interceptors.AuthInterceptor(coreService),
+			interceptors.AuthInterceptor(coreService, cfg.Security.RequireMFA),
 			interceptors.MetricsInterceptor(),
 		),
 		grpc.ChainStreamInterceptor(
 			interceptors.StreamLoggingInterceptor(),
 			interceptors.StreamRecoveryInterceptor(),
-			interceptors.StreamAuthInterceptor(coreService),
+			interceptors.StreamAuthInterceptor(coreService, cfg.Security.RequireMFA),
 		),
 	}
 

--- a/server/grpc/server_integration_test.go
+++ b/server/grpc/server_integration_test.go
@@ -33,7 +33,13 @@ func TestGRPCServer_EndToEnd(t *testing.T) {
 	// Real core with a fully seeded RBAC schema (super_admin has all perms).
 	h := testhelper.NewRBACTestHelper(t)
 	t.Cleanup(h.Cleanup)
-	require.NoError(t, h.DB.AutoMigrate(&models.Session{}, &models.SecretVersion{}))
+	require.NoError(t, h.DB.AutoMigrate(&models.Session{}, &models.SecretVersion{}, &models.AuditEvent{}, &models.SecretAccessLog{}))
+	// The services fire their audit/access-log writes in detached goroutines (as on
+	// HTTP), so serialize the in-memory DB to one connection to avoid SQLite
+	// "database is locked" races between those writes and the test's own RPCs.
+	sqlDB, sqlErr := h.DB.DB()
+	require.NoError(t, sqlErr)
+	sqlDB.SetMaxOpenConns(1)
 	// Environments that belong to the seeded projects 1 and 2 (seeded envs have none).
 	require.NoError(t, h.DB.Create(&models.Environment{ID: 10, ProjectID: 1, Name: "dev"}).Error)
 	require.NoError(t, h.DB.Create(&models.Environment{ID: 20, ProjectID: 2, Name: "dev"}).Error)

--- a/server/grpc/server_integration_test.go
+++ b/server/grpc/server_integration_test.go
@@ -3,6 +3,7 @@ package grpc_test
 import (
 	"context"
 	"net"
+	"strings"
 	"testing"
 	"time"
 
@@ -143,4 +144,54 @@ func TestGRPCServer_EndToEnd(t *testing.T) {
 		assert.Equal(t, codes.PermissionDenied, status.Code(err),
 			"a project-1-scoped writer must not create secrets in project 2 over gRPC")
 	})
+}
+
+// TestGRPCServer_HonorsConfiguredMaxRecvMsgSize proves the gRPC server enforces the
+// configured request-size cap (server.grpc.max_request_body_bytes) the way the HTTP
+// MaxBodyBytes middleware does — a memory-exhaustion DoS control that must not be
+// bypassable by switching transport. Before the fix, NewServer ignored the setting
+// and kept grpc-go's 4 MiB default.
+func TestGRPCServer_HonorsConfiguredMaxRecvMsgSize(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	t.Cleanup(h.Cleanup)
+
+	cfg := &config.Config{}
+	cfg.Server.GRPC.MaxRequestBodyBytes = 4096 // 4 KiB — far below grpc-go's 4 MiB default
+
+	srv, err := keyorixgrpc.NewServer(cfg, h.CoreService)
+	require.NoError(t, err)
+	lis := bufconn.Listen(1024 * 1024)
+	go func() { _ = srv.Serve(lis) }()
+	t.Cleanup(srv.Stop)
+
+	conn, err := grpc.NewClient(
+		"passthrough:///bufnet",
+		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) { return lis.Dial() }),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	authed := metadata.NewOutgoingContext(ctx, metadata.Pairs("authorization", "Bearer bogus"))
+	secrets := pb.NewSecretServiceClient(conn)
+
+	// A request over the cap is refused at the transport layer with ResourceExhausted —
+	// before the auth interceptor even runs.
+	_, err = secrets.CreateSecret(authed, &pb.CreateSecretRequest{
+		Name: "big", Value: strings.Repeat("A", 8192), ProjectId: 1, EnvironmentId: 1, Type: "password",
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.ResourceExhausted, status.Code(err),
+		"a request over the configured gRPC body cap must be rejected with ResourceExhausted")
+
+	// A small request clears the size check and reaches auth (rejected as Unauthenticated
+	// for the bogus token), proving the prior failure was the size cap and not auth.
+	_, err = secrets.CreateSecret(authed, &pb.CreateSecretRequest{
+		Name: "small", Value: "tiny", ProjectId: 1, EnvironmentId: 1, Type: "password",
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.Unauthenticated, status.Code(err),
+		"a small request clears the size cap and is then rejected by auth")
 }

--- a/server/grpc/services/conversions.go
+++ b/server/grpc/services/conversions.go
@@ -59,6 +59,28 @@ func authorizeScoped(ctx context.Context, cs *core.KeyorixCore, actor *intercept
 	if allowed, err := cs.AuthorizePrincipal(ctx, actor.ActorKind(), actor.PrincipalID(), perm, scope); err != nil || !allowed {
 		return status.Error(codes.PermissionDenied, "insufficient permissions")
 	}
+	return enforceProjectMFA(ctx, cs, actor, scope.ProjectID)
+}
+
+// enforceProjectMFA applies the per-project MFA policy (ADR-037) over gRPC: an
+// interactive session WITHOUT a second factor is denied access to a project that
+// requires MFA. It mirrors the HTTP ProjectMFABlocked gate so the policy is not
+// bypassable by switching transport. Non-interactive callers (PAT / machine) are
+// exempt — SessionAuth is false for them — and a global-scoped operation (project
+// 0) is never gated. Called after the permission check at every project-scoped
+// authorization chokepoint. Fails closed only on a positive requirement; a lookup
+// error leaves the prior permission decision in force (matching HTTP).
+func enforceProjectMFA(ctx context.Context, cs *core.KeyorixCore, actor *interceptors.UserContext, projectID uint) error {
+	if projectID == 0 || cs == nil || actor == nil {
+		return nil
+	}
+	if !actor.SessionAuth || actor.MFAEnabled {
+		return nil
+	}
+	if required, err := cs.ProjectRequiresMFA(ctx, projectID); err == nil && required {
+		return status.Error(codes.PermissionDenied,
+			"this project requires multi-factor authentication; enrol a second factor to access it")
+	}
 	return nil
 }
 

--- a/server/grpc/services/role_service.go
+++ b/server/grpc/services/role_service.go
@@ -55,6 +55,10 @@ func (s *RoleGRPCService) CreateRole(ctx context.Context, req *pb.CreateRoleRequ
 			return nil, status.Error(codes.Internal, "failed to assign permissions to role")
 		}
 	}
+	// Audit the role creation, mirroring the HTTP handler — Storage().CreateRole does
+	// not audit internally, so without this a role created over gRPC left no trail.
+	// (Permission grants are audited by AssignPermissionToRole itself.)
+	s.core.LogRoleCreated(ctx, actor.UserID, role.ID, role.Name)
 	return s.roleByID(ctx, role.ID)
 }
 
@@ -113,6 +117,9 @@ func (s *RoleGRPCService) UpdateRole(ctx context.Context, req *pb.UpdateRoleRequ
 		}
 	}
 
+	// Audit the role update, mirroring the HTTP handler — Storage().UpdateRole and the
+	// permission swap above do not emit a role.updated event on their own.
+	s.core.LogRoleUpdated(ctx, actor.UserID, role.ID, role.Name)
 	return s.roleByID(ctx, role.ID)
 }
 
@@ -128,9 +135,16 @@ func (s *RoleGRPCService) DeleteRole(ctx context.Context, req *pb.DeleteRoleRequ
 	if req.GetId() == 0 {
 		return nil, status.Error(codes.InvalidArgument, "id is required")
 	}
+	// Resolve the name for the audit log before the row is gone (mirrors HTTP).
+	role, _, err := s.core.GetRoleWithPermissions(ctx, uint(req.GetId()))
+	if err != nil {
+		return nil, mapRoleError(err)
+	}
 	if err := s.core.Storage().DeleteRole(ctx, uint(req.GetId())); err != nil {
 		return nil, mapRoleError(err)
 	}
+	// Audit the deletion — Storage().DeleteRole does not audit internally.
+	s.core.LogRoleDeleted(ctx, actor.UserID, role.ID, role.Name)
 	return &emptypb.Empty{}, nil
 }
 

--- a/server/grpc/services/role_service_test.go
+++ b/server/grpc/services/role_service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/keyorixhq/keyorix/internal/testhelper"
 	pb "github.com/keyorixhq/keyorix/server/proto/pb"
 	"github.com/stretchr/testify/assert"
@@ -123,6 +124,37 @@ func TestRoleService_DeleteRole(t *testing.T) {
 	_, err = svc.GetRole(roleAdminCtx(), &pb.GetRoleRequest{Id: created.GetId()})
 	require.Error(t, err)
 	assert.Equal(t, codes.NotFound, status.Code(err))
+}
+
+// Role create/update/delete over gRPC must each leave an audit event, exactly as on
+// HTTP — the underlying Storage() calls do not audit internally, so without the
+// service firing LogRole* these lifecycle changes were invisible in the audit trail
+// when driven over gRPC. The writes are synchronous, so assert directly.
+func TestRoleService_LifecycleAuditedOverGRPC(t *testing.T) {
+	svc, h := newRoleService(t)
+	require.NoError(t, h.DB.AutoMigrate(&models.AuditEvent{}))
+	perm := somePermission(t, h)
+
+	created, err := svc.CreateRole(roleAdminCtx(), &pb.CreateRoleRequest{
+		Name: "lifecycle-role", Description: "d", Permissions: []string{perm},
+	})
+	require.NoError(t, err)
+	_, err = svc.UpdateRole(roleAdminCtx(), &pb.UpdateRoleRequest{
+		Id: created.GetId(), Description: strPtr("new"),
+	})
+	require.NoError(t, err)
+	_, err = svc.DeleteRole(roleAdminCtx(), &pb.DeleteRoleRequest{Id: created.GetId()})
+	require.NoError(t, err)
+
+	count := func(evType string) int64 {
+		var n int64
+		require.NoError(t, h.DB.Model(&models.AuditEvent{}).
+			Where("event_type = ? AND user_id = ?", evType, 1).Count(&n).Error)
+		return n
+	}
+	assert.Equal(t, int64(1), count("role.created"), "CreateRole over gRPC must be audited")
+	assert.Equal(t, int64(1), count("role.updated"), "UpdateRole over gRPC must be audited")
+	assert.Equal(t, int64(1), count("role.deleted"), "DeleteRole over gRPC must be audited")
 }
 
 func TestRoleService_ListRoles(t *testing.T) {

--- a/server/grpc/services/secret_service.go
+++ b/server/grpc/services/secret_service.go
@@ -46,6 +46,9 @@ func (s *SecretGRPCService) CreateSecret(ctx context.Context, req *pb.CreateSecr
 	if allowed, err := s.core.AuthorizePrincipal(ctx, user.ActorKind(), user.PrincipalID(), "secrets.write", scope); err != nil || !allowed {
 		return nil, status.Error(codes.PermissionDenied, "insufficient permissions to create secrets in this project")
 	}
+	if err := enforceProjectMFA(ctx, s.core, user, scope.ProjectID); err != nil {
+		return nil, err
+	}
 
 	secret, err := s.core.CreateSecret(ctx, &core.CreateSecretRequest{
 		Name:          req.GetName(),
@@ -229,6 +232,9 @@ func (s *SecretGRPCService) ListSecrets(ctx context.Context, req *pb.ListSecrets
 	if allowed, err := s.core.AuthorizePrincipal(ctx, user.ActorKind(), user.PrincipalID(), "secrets.read", listScope); err != nil || !allowed {
 		return nil, status.Error(codes.PermissionDenied, "insufficient permissions to list secrets")
 	}
+	if err := enforceProjectMFA(ctx, s.core, user, listScope.ProjectID); err != nil {
+		return nil, err
+	}
 
 	page := int(req.GetPage())
 	if page < 1 {
@@ -317,7 +323,7 @@ func authorizeSecretScoped(ctx context.Context, cs *core.KeyorixCore, actor *int
 	if allowed, err := cs.AuthorizePrincipal(ctx, actor.ActorKind(), actor.PrincipalID(), perm, scope); err != nil || !allowed {
 		return status.Error(codes.PermissionDenied, "insufficient permissions for this secret")
 	}
-	return nil
+	return enforceProjectMFA(ctx, cs, actor, scope.ProjectID)
 }
 
 // mapSecretError translates core errors into gRPC status codes.

--- a/server/grpc/services/secret_service.go
+++ b/server/grpc/services/secret_service.go
@@ -139,6 +139,14 @@ func (s *SecretGRPCService) GetSecretValue(ctx context.Context, req *pb.GetSecre
 	if err != nil {
 		return nil, mapSecretError(err)
 	}
+	// Record the read in the audit trail and secret-access log — the same call the
+	// HTTP reveal handler fires. Without it, a secret read over gRPC left no
+	// secret.read event and no access-log row, so the anomaly detector never saw it:
+	// secrets could be exfiltrated over gRPC invisibly to both the audit trail and
+	// anomaly detection. Detached + async like HTTP, so it neither blocks the RPC nor
+	// dies on its cancellation; DetachedAuditContext preserves the actor-type and
+	// impersonation tags the interceptor set.
+	go s.core.LogSecretReadWithProject(core.DetachedAuditContext(ctx), user.UserID, uint(req.GetId()), secret.ProjectID, user.Username, secret.Name, interceptors.PeerIP(ctx), interceptors.ClientUserAgent(ctx)) // #nosec G118
 	return &pb.SecretValue{
 		Id:    req.GetId(),
 		Name:  secret.Name,

--- a/server/grpc/services/secret_service.go
+++ b/server/grpc/services/secret_service.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/keyorixhq/keyorix/internal/core"
@@ -66,6 +67,10 @@ func (s *SecretGRPCService) CreateSecret(ctx context.Context, req *pb.CreateSecr
 	if err != nil {
 		return nil, mapSecretError(err)
 	}
+	// Audit the create the same way the HTTP handler does — the core method does not
+	// audit internally, so without this a secret created over gRPC left no audit
+	// trail. Detached + async (see GetSecretValue).
+	go s.core.LogSecretCreatedWithProject(core.DetachedAuditContext(ctx), user.UserID, secret.ID, secret.ProjectID, user.Username, secret.Name, interceptors.PeerIP(ctx), interceptors.ClientUserAgent(ctx)) // #nosec G118
 	return secretNodeToProto(secret), nil
 }
 
@@ -180,10 +185,18 @@ func (s *SecretGRPCService) UpdateSecret(ctx context.Context, req *pb.UpdateSecr
 		updateReq.Value = []byte(v)
 	}
 
+	// Capture pre-update metadata for the audit diff (raw fetch, no read-count side
+	// effect). Best-effort: a miss just yields an empty diff — same as the HTTP path.
+	oldSecret, _ := s.core.Storage().GetSecret(ctx, uint(req.GetId()))
+
 	secret, err := s.core.UpdateSecretWithPermissionCheck(ctx, updateReq)
 	if err != nil {
 		return nil, mapSecretError(err)
 	}
+	// Audit the update with a before/after diff, mirroring the HTTP handler — the
+	// core method does not audit internally. Detached + async (see GetSecretValue).
+	diff := core.BuildSecretUpdateDiff(oldSecret, updateReq, req.GetValue() != "")
+	go s.core.LogSecretUpdatedWithDiff(core.DetachedAuditContext(ctx), user.UserID, uint(req.GetId()), secret.ProjectID, user.Username, secret.Name, interceptors.PeerIP(ctx), interceptors.ClientUserAgent(ctx), diff) // #nosec G118
 	return secretNodeToProto(secret), nil
 }
 
@@ -199,9 +212,20 @@ func (s *SecretGRPCService) DeleteSecret(ctx context.Context, req *pb.DeleteSecr
 	if err := authorizeSecretScoped(ctx, s.core, user, uint(req.GetId()), "secrets.delete"); err != nil {
 		return nil, err
 	}
+	// Pre-fetch name + project for the audit log before the record is gone, mirroring
+	// the HTTP handler. Best-effort: a miss falls back to the id.
+	secretName := fmt.Sprintf("id=%d", req.GetId())
+	var secretProjectID uint
+	if sec, err := s.core.GetSecretWithPermissionCheck(ctx, uint(req.GetId()), user.UserID); err == nil {
+		secretName = sec.Name
+		secretProjectID = sec.ProjectID
+	}
 	if err := s.core.DeleteSecretWithPermissionCheck(ctx, uint(req.GetId()), user.UserID); err != nil {
 		return nil, mapSecretError(err)
 	}
+	// Audit the delete the same way the HTTP handler does — the core method does not
+	// audit internally. Detached + async (see GetSecretValue).
+	go s.core.LogSecretDeletedWithProject(core.DetachedAuditContext(ctx), user.UserID, uint(req.GetId()), secretProjectID, user.Username, secretName, interceptors.PeerIP(ctx), interceptors.ClientUserAgent(ctx)) // #nosec G118
 	return &emptypb.Empty{}, nil
 }
 

--- a/server/grpc/services/secret_service_test.go
+++ b/server/grpc/services/secret_service_test.go
@@ -35,6 +35,12 @@ func newSecretTestRig(t *testing.T) *secretTestRig {
 
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
+	// Serialize access to the in-memory DB: the audit logging the service fires runs
+	// in a detached goroutine (as on HTTP), so a single connection avoids SQLite
+	// "database is locked" races between it and the test's own queries.
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	sqlDB.SetMaxOpenConns(1)
 	require.NoError(t, db.AutoMigrate(
 		&models.Project{}, &models.Environment{}, &models.SecretNode{},
 		&models.SecretVersion{}, &models.User{}, &models.Role{}, &models.ShareRecord{},
@@ -329,6 +335,42 @@ func TestSecretService_GetSecretValue_RecordsAccessLogAndAudit(t *testing.T) {
 	require.NoError(t, r.db.Where("secret_node_id = ?", created.GetId()).First(&alog).Error)
 	assert.Equal(t, "owner", alog.AccessedBy)
 	assert.Equal(t, uint(created.GetId()), alog.SecretNodeID)
+}
+
+// Secret create/update/delete over gRPC must be audited exactly as on HTTP — the
+// core methods do not audit internally, the handler does. Without this, the entire
+// secret lifecycle was invisible in the audit trail when driven over gRPC.
+func TestSecretService_WriteOps_AuditedOverGRPC(t *testing.T) {
+	r := newSecretTestRig(t)
+	require.NoError(t, r.db.AutoMigrate(&models.AuditEvent{}))
+	ctx := authCtx(1, "owner", "secrets.write", "secrets.read", "secrets.delete")
+
+	created := r.createSecret(t, ctx, "lifecycle", "v1")
+
+	_, err := r.svc.UpdateSecret(ctx, &pb.UpdateSecretRequest{Id: created.GetId(), Value: strPtr("v2")})
+	require.NoError(t, err)
+
+	_, err = r.svc.DeleteSecret(ctx, &pb.DeleteSecretRequest{Id: created.GetId()})
+	require.NoError(t, err)
+
+	// Each op writes its audit event asynchronously; poll until all three landed.
+	countEvent := func(evType string) int64 {
+		var n int64
+		r.db.Model(&models.AuditEvent{}).
+			Where("event_type = ? AND secret_node_id = ?", evType, created.GetId()).Count(&n)
+		return n
+	}
+	require.Eventually(t, func() bool {
+		return countEvent("secret.created") == 1 &&
+			countEvent("secret.updated") == 1 &&
+			countEvent("secret.deleted") == 1
+	}, 2*time.Second, 10*time.Millisecond,
+		"create/update/delete over gRPC must each write one audit event")
+
+	// The update event carries a before/after diff (it records what changed).
+	var upd models.AuditEvent
+	require.NoError(t, r.db.Where("event_type = ? AND secret_node_id = ?", "secret.updated", created.GetId()).First(&upd).Error)
+	assert.NotEmpty(t, upd.Diff, "an update over gRPC must record a diff, like HTTP")
 }
 
 func TestSecretService_UpdateSecret(t *testing.T) {

--- a/server/grpc/services/secret_service_test.go
+++ b/server/grpc/services/secret_service_test.go
@@ -3,6 +3,7 @@ package services
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/keyorixhq/keyorix/internal/config"
 	"github.com/keyorixhq/keyorix/internal/core"
@@ -297,6 +298,37 @@ func TestSecretService_GetSecretValue(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "the-value", val.GetValue())
 	assert.Equal(t, "token", val.GetName())
+}
+
+// A secret read over gRPC must land in the audit trail and the secret-access log,
+// exactly as the HTTP reveal handler records it. Without it, the anomaly detector
+// (which feeds on secret_access_logs) is blind to reads that arrive over gRPC, so
+// secrets could be exfiltrated over gRPC invisibly. The write is detached/async,
+// so poll for it.
+func TestSecretService_GetSecretValue_RecordsAccessLogAndAudit(t *testing.T) {
+	r := newSecretTestRig(t)
+	require.NoError(t, r.db.AutoMigrate(&models.AuditEvent{}, &models.SecretAccessLog{}))
+	ctx := authCtx(1, "owner", "secrets.write", "secrets.read")
+	created := r.createSecret(t, ctx, "token", "the-value")
+
+	_, err := r.svc.GetSecretValue(ctx, &pb.GetSecretRequest{Id: created.GetId()})
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		var audits, logs int64
+		r.db.Model(&models.AuditEvent{}).
+			Where("event_type = ? AND secret_node_id = ?", "secret.read", created.GetId()).Count(&audits)
+		r.db.Model(&models.SecretAccessLog{}).
+			Where("secret_node_id = ? AND action = ?", created.GetId(), "read").Count(&logs)
+		return audits == 1 && logs == 1
+	}, 2*time.Second, 10*time.Millisecond,
+		"a gRPC secret read must write one secret.read audit event and one access-log row")
+
+	// The access-log row attributes the read to the caller, for forensics / anomaly.
+	var alog models.SecretAccessLog
+	require.NoError(t, r.db.Where("secret_node_id = ?", created.GetId()).First(&alog).Error)
+	assert.Equal(t, "owner", alog.AccessedBy)
+	assert.Equal(t, uint(created.GetId()), alog.SecretNodeID)
 }
 
 func TestSecretService_UpdateSecret(t *testing.T) {

--- a/server/grpc/services/secret_service_test.go
+++ b/server/grpc/services/secret_service_test.go
@@ -116,6 +116,61 @@ func TestSecretService_CreateSecret_PermissionDenied(t *testing.T) {
 	assert.Equal(t, codes.PermissionDenied, status.Code(err))
 }
 
+// sessionCtx returns a context for an interactive session-authenticated user (as
+// the auth interceptor populates after validating a session token), with the
+// second-factor flag set explicitly. SessionAuth gates the per-project MFA policy.
+func sessionCtx(userID uint, username string, mfaEnabled bool, perms ...string) context.Context {
+	return context.WithValue(context.Background(), interceptors.GetUserContextKey(),
+		&interceptors.UserContext{
+			UserID: userID, Username: username, Permissions: perms,
+			SessionAuth: true, MFAEnabled: mfaEnabled,
+		})
+}
+
+// Per-project MFA policy (ADR-037) over gRPC: a project that requires MFA must
+// deny an interactive session WITHOUT a second factor, mirroring the HTTP
+// ProjectMFABlocked gate so the policy is not bypassable by switching transport.
+// A session WITH MFA is allowed; a PAT (non-interactive, SessionAuth=false) is
+// exempt; and a project that does not require MFA gates nobody.
+func TestSecretService_PerProjectMFAGateOverGRPC(t *testing.T) {
+	r := newSecretTestRig(t)
+	// Project 1 (seeded) now mandates a second factor; project 2 does not.
+	require.NoError(t, r.db.Model(&models.Project{}).Where("id = ?", 1).Update("require_mfa", true).Error)
+	require.NoError(t, r.db.Create(&models.Project{ID: 2, Name: "open"}).Error)
+	require.NoError(t, r.db.Create(&models.Environment{ID: 2, ProjectID: 2, Name: "development"}).Error)
+
+	create := func(ctx context.Context, name string, projectID, envID uint32) error {
+		_, err := r.svc.CreateSecret(ctx, &pb.CreateSecretRequest{
+			Name: name, Value: "v", ProjectId: projectID, EnvironmentId: envID, Type: "password",
+		})
+		return err
+	}
+
+	// Interactive session without MFA → denied on the MFA-required project, for both a
+	// mutation and a read (ListSecrets shares the gate).
+	noMFA := sessionCtx(1, "owner", false, "secrets.write", "secrets.read")
+	err := create(noMFA, "k1", 1, 1)
+	require.Error(t, err, "session without MFA must be denied on an MFA-required project")
+	assert.Equal(t, codes.PermissionDenied, status.Code(err))
+
+	_, err = r.svc.ListSecrets(noMFA, &pb.ListSecretsRequest{ProjectId: ptrU32(1), EnvironmentId: ptrU32(1)})
+	require.Error(t, err, "ListSecrets is gated by the per-project MFA policy too")
+	assert.Equal(t, codes.PermissionDenied, status.Code(err))
+
+	// Same session, but the project does not require MFA → allowed.
+	require.NoError(t, r.db.Create(&models.UserRole{UserID: 1, RoleID: writerRoleID, ProjectID: 2}).Error)
+	require.NoError(t, create(noMFA, "k2", 2, 2), "a project without an MFA requirement gates nobody")
+
+	// A session WITH a second factor is allowed on the MFA-required project.
+	withMFA := sessionCtx(1, "owner", true, "secrets.write", "secrets.read")
+	require.NoError(t, create(withMFA, "k3", 1, 1), "session with MFA is allowed")
+
+	// A PAT is non-interactive (SessionAuth=false) and exempt — automation must not
+	// break on an MFA-required project. authCtx leaves SessionAuth false.
+	pat := authCtx(1, "owner", "secrets.write", "secrets.read")
+	require.NoError(t, create(pat, "k4", 1, 1), "a PAT is exempt from the per-project MFA gate")
+}
+
 // Regression (gRPC scoped-authz hardening): CreateSecret must authorize
 // secrets.write at the TARGET project/environment, not against the flat global
 // permission set. A user whose secrets.write is granted only in project 1 must

--- a/server/grpc/services/share_service.go
+++ b/server/grpc/services/share_service.go
@@ -208,7 +208,7 @@ func (s *ShareGRPCService) authorizeShareScoped(ctx context.Context, actor *inte
 	if allowed, err := s.core.AuthorizePrincipal(ctx, actor.ActorKind(), actor.PrincipalID(), perm, scope); err != nil || !allowed {
 		return status.Error(codes.PermissionDenied, "insufficient permissions for this share")
 	}
-	return nil
+	return enforceProjectMFA(ctx, s.core, actor, scope.ProjectID)
 }
 
 // mapShareError translates core sharing errors into gRPC status codes.

--- a/server/http/handlers/rbac_real_test.go
+++ b/server/http/handlers/rbac_real_test.go
@@ -55,6 +55,7 @@ func openTestDB(t *testing.T) *gorm.DB {
 		&models.UserRole{},
 		&models.Group{},
 		&models.GroupRole{},
+		&models.UserGroup{},
 		&models.User{},
 	))
 	return db

--- a/server/http/handlers/scim_test.go
+++ b/server/http/handlers/scim_test.go
@@ -84,7 +84,9 @@ func TestSCIM_ProvisionGetListDeactivateDelete(t *testing.T) {
 	list := decodeSCIM(t, w)
 	assert.Equal(t, float64(1), list["totalResults"])
 
-	// PATCH active=false → suspended.
+	// PATCH active=false → deprovisioned (a SCIM/IdP deactivation, distinct from an
+	// admin security suspension so it can be reversed by SCIM without clearing a
+	// suspension; both block login).
 	patch := `{"schemas":["urn:ietf:params:scim:api:messages:2.0:PatchOp"],"Operations":[{"op":"replace","path":"active","value":false}]}`
 	w = httptest.NewRecorder()
 	h.PatchUser(w, withID(httptest.NewRequest(http.MethodPatch, "/scim/v2/Users/"+id, bytes.NewReader([]byte(patch))), id))
@@ -93,7 +95,8 @@ func TestSCIM_ProvisionGetListDeactivateDelete(t *testing.T) {
 
 	var suspended models.User
 	require.NoError(t, db.Where("external_id = ?", "okta-123").First(&suspended).Error)
-	assert.Equal(t, core.AccountSuspended, suspended.AccountState)
+	assert.Equal(t, core.AccountDeprovisioned, suspended.AccountState)
+	assert.True(t, core.AccountLoginBlocked(suspended.AccountState), "a deprovisioned account is login-blocked")
 
 	// DELETE → 204 and the user is soft-deleted.
 	w = httptest.NewRecorder()

--- a/server/http/rbac_route_authz_test.go
+++ b/server/http/rbac_route_authz_test.go
@@ -43,8 +43,8 @@ func TestUpdateUserRolesRequiresRolesAssign(t *testing.T) {
 	require.NoError(t, db.Create(&models.RolePermission{RoleID: 2, PermissionID: 1}).Error)
 	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1}).Error)
 	require.NoError(t, db.Create(&models.UserRole{UserID: 2, RoleID: 2}).Error)
-	require.NoError(t, db.Create(&models.Session{UserID: 1, SessionToken: "admin-tok"}).Error)
-	require.NoError(t, db.Create(&models.Session{UserID: 2, SessionToken: "mgr-tok"}).Error)
+	seedSession(t, db, 1, "admin-tok")
+	seedSession(t, db, 2, "mgr-tok")
 
 	router, err := NewRouter(&config.Config{}, core.NewKeyorixCore(store.NewLocalStorage(db)))
 	require.NoError(t, err)

--- a/server/http/scoped_rbac_integration_test.go
+++ b/server/http/scoped_rbac_integration_test.go
@@ -56,8 +56,8 @@ func setupScopedRBACCore(t *testing.T) *core.KeyorixCore {
 	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1}).Error)
 	require.NoError(t, db.Create(&models.UserRole{UserID: 2, RoleID: 2, ProjectID: 1}).Error)
 
-	require.NoError(t, db.Create(&models.Session{UserID: 1, SessionToken: "admin-tok"}).Error)
-	require.NoError(t, db.Create(&models.Session{UserID: 2, SessionToken: "viewerA-tok"}).Error)
+	seedSession(t, db, 1, "admin-tok")
+	seedSession(t, db, 2, "viewerA-tok")
 
 	return core.NewKeyorixCore(store.NewLocalStorage(db))
 }

--- a/server/http/secret_value_by_ref_scope_test.go
+++ b/server/http/secret_value_by_ref_scope_test.go
@@ -62,8 +62,8 @@ func setupByRefScopeCore(t *testing.T) *core.KeyorixCore {
 	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1}).Error)                 // admin: global
 	require.NoError(t, db.Create(&models.UserRole{UserID: 2, RoleID: 2, ProjectID: 1}).Error)   // viewerA: project A only
 
-	require.NoError(t, db.Create(&models.Session{UserID: 1, SessionToken: "admin-tok"}).Error)
-	require.NoError(t, db.Create(&models.Session{UserID: 2, SessionToken: "viewerA-tok"}).Error)
+	seedSession(t, db, 1, "admin-tok")
+	seedSession(t, db, 2, "viewerA-tok")
 
 	return core.NewKeyorixCore(store.NewLocalStorage(db))
 }

--- a/server/http/session_seed_test.go
+++ b/server/http/session_seed_test.go
@@ -1,0 +1,20 @@
+package http
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+// seedSession inserts a session through the storage layer, so its token is stored
+// hashed exactly as production does. A raw db.Create of a plaintext SessionToken no
+// longer authenticates — GetSession looks the presented token up by its hash.
+func seedSession(t *testing.T, db *gorm.DB, userID uint, token string) {
+	t.Helper()
+	_, err := store.NewLocalStorage(db).CreateSession(context.Background(), &models.Session{UserID: userID, SessionToken: token})
+	require.NoError(t, err)
+}

--- a/server/http/sharing_integration_test.go
+++ b/server/http/sharing_integration_test.go
@@ -104,9 +104,9 @@ func newSharingTestCore(t *testing.T) *core.KeyorixCore {
 	require.NoError(t, db.Create(&models.UserRole{UserID: 2, RoleID: 2}).Error)
 
 	// Seed sessions for "valid-token" and "owner-token" (user 1, admin), "recipient-token" (user 2, reader).
-	require.NoError(t, db.Create(&models.Session{UserID: 1, SessionToken: "valid-token"}).Error)
-	require.NoError(t, db.Create(&models.Session{UserID: 1, SessionToken: "owner-token"}).Error)
-	require.NoError(t, db.Create(&models.Session{UserID: 2, SessionToken: "recipient-token"}).Error)
+	seedSession(t, db, 1, "valid-token")
+	seedSession(t, db, 1, "owner-token")
+	seedSession(t, db, 2, "recipient-token")
 
 	return core.NewKeyorixCore(store.NewLocalStorage(db))
 }


### PR DESCRIPTION
# integration/all-fixes-merged — consolidated work from all worktrees

One branch off `main` combining every active worktree's work. Builds clean; the full
`go test ./...` suite passes.

## What's included (23 commits)

- **gRPC↔HTTP parity** (10 commits, `b243a24..f785844`) — account-restriction/MFA gates,
  per-project MFA, audit context, secret/role CRUD audit, request-size cap, RPC timeout,
  anomaly-path test. *(was on `fix/grpc-account-restriction-mfa-parity`, already on origin)*
- **9 security bug-hunt fixes** (`8bb0911..696ed1b`) — audit-chain ActorType false-failure,
  dynamic-lease expired-renew, session touch ordering, setup-link resend race, MFA/WebAuthn
  2FA account-state gate, SCIM admin-suspension override, dual-control approval race,
  plaintext session tokens, access-review self-cert + double-decision.
- **SoD group-inherited permissions fix** (`edc0379`, merged) — *parallel session*.
- **break-glass MaxTTL floor fix** (`3184ba7`, merged) — *parallel session*.
- **test(rbac) completion** (`9b8dcab`) — migrate `user_groups` so the SoD join works in
  `TestRBACReal_GetUserPermissionsForUser`. The textual merge was conflict-free; this
  semantic gap only surfaced running the full suite together. **Apply this on
  `fix/sod-group-inherited-permissions` too — the same test fails there.**

## Heads-up before merging to main

This branch contains commits that also live on their own origin branches/PRs:
`fix/sod-group-inherited-permissions`, `fix/break-glass-maxttl-floor`, and the gRPC-parity
work on `fix/grpc-account-restriction-mfa-parity`. If you merge **this** consolidated branch
to main, close/supersede those separate PRs to avoid duplicate-commit churn — or instead
merge each PR independently and drop this branch. Your call.

## Redundant local refs (safe to delete)

- `integration/all-fixes` — intermediate, superseded by `-merged`.
- `worktree-security-bug-hunt-fixes` — the 8-fix subset, now contained here.
