### PR TITLE
fix(saml): scope SSO identity to the asserting provider (cross-provider takeover)

### DIFF
--- a/internal/core/saml_flow_test.go
+++ b/internal/core/saml_flow_test.go
@@ -84,7 +84,7 @@ func TestCompleteSAML_ExistingUser(t *testing.T) {
 	c, store := samlTestCore(stub)
 	store.On("ConsumeSSOLoginState", mock.Anything, "relay-1").Return(
 		&models.SSOLoginState{Provider: "corp", Nonce: "req-1", ReturnTo: "/home", ExpiresAt: time.Now().Add(time.Minute)}, nil)
-	store.On("GetUserByExternalID", mock.Anything, "corp|123").Return(&models.User{ID: 7}, nil)
+	store.On("GetUserByExternalID", mock.Anything, "sso:corp:corp|123").Return(&models.User{ID: 7}, nil)
 	store.On("CreateSession", mock.Anything, mock.Anything).Return(&models.Session{ID: 1, UserID: 7, SessionToken: "tok"}, nil)
 	store.On("UpdateLastLogin", mock.Anything, uint(7), mock.Anything).Return(nil)
 	store.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
@@ -129,7 +129,7 @@ func TestCompleteSAML_NoAccountNoProvision(t *testing.T) {
 	c := &KeyorixCore{storage: store, now: time.Now, ssoProviders: map[string]*SSOProvider{"corp": p}}
 	store.On("ConsumeSSOLoginState", mock.Anything, "relay-4").Return(
 		&models.SSOLoginState{Provider: "corp", Nonce: "req-1", ExpiresAt: time.Now().Add(time.Minute)}, nil)
-	store.On("GetUserByExternalID", mock.Anything, "corp|999").Return((*models.User)(nil), userNotFound())
+	store.On("GetUserByExternalID", mock.Anything, "sso:corp:corp|999").Return((*models.User)(nil), userNotFound())
 	store.On("GetUserByEmail", mock.Anything, "noone@x.io").Return((*models.User)(nil), userNotFound())
 
 	_, _, _, err := c.CompleteSAML(context.Background(), "corp",
@@ -153,7 +153,7 @@ func TestCompleteSAML_NativeAdminTakeoverRejectedByDefault(t *testing.T) {
 	c := &KeyorixCore{storage: store, now: time.Now, ssoProviders: map[string]*SSOProvider{"corp": p}}
 	store.On("ConsumeSSOLoginState", mock.Anything, "relay-5").Return(
 		&models.SSOLoginState{Provider: "corp", Nonce: "req-1", ExpiresAt: time.Now().Add(time.Minute)}, nil)
-	store.On("GetUserByExternalID", mock.Anything, "corp|evil").Return((*models.User)(nil), userNotFound())
+	store.On("GetUserByExternalID", mock.Anything, "sso:corp:corp|evil").Return((*models.User)(nil), userNotFound())
 
 	session, user, _, err := c.CompleteSAML(context.Background(), "corp",
 		httptest.NewRequest(http.MethodPost, "/auth/saml/corp/acs", nil), "relay-5", "ua", "1.2.3.4")
@@ -163,6 +163,34 @@ func TestCompleteSAML_NativeAdminTakeoverRejectedByDefault(t *testing.T) {
 	assert.Nil(t, user)
 	// The native admin's email must never even be looked up.
 	store.AssertNotCalled(t, "GetUserByEmail", mock.Anything, mock.Anything)
+	store.AssertNotCalled(t, "CreateSession", mock.Anything, mock.Anything)
+}
+
+// TestCompleteSAML_CrossProviderEmailTakeoverRejected pins the SAML provider-confusion
+// fix: a validly-signed assertion from provider "corp" must NOT be able to take over an
+// account already bound to a different SSO provider ("azure") merely by asserting its
+// email — even with auto-provisioning enabled and TrustAssertedEmail on. The login must
+// fail closed and mint no session.
+func TestCompleteSAML_CrossProviderEmailTakeoverRejected(t *testing.T) {
+	stub := &stubSAML{info: &samlpkg.AssertionInfo{Subject: "corp|evil", Email: "admin@x.io", Name: "Mallory"}}
+	store := new(MockStorage)
+	p := &SSOProvider{Name: "corp", Type: "saml", SAML: stub, AutoProvision: true, TrustAssertedEmail: true}
+	c := &KeyorixCore{storage: store, now: time.Now, ssoProviders: map[string]*SSOProvider{"corp": p}}
+	store.On("ConsumeSSOLoginState", mock.Anything, "relay-6").Return(
+		&models.SSOLoginState{Provider: "corp", Nonce: "req-1", ExpiresAt: time.Now().Add(time.Minute)}, nil)
+	// No account under corp's scoped id...
+	store.On("GetUserByExternalID", mock.Anything, "sso:corp:corp|evil").Return((*models.User)(nil), userNotFound())
+	// ...but the email belongs to an admin bound to provider "azure".
+	store.On("GetUserByEmail", mock.Anything, "admin@x.io").
+		Return(&models.User{ID: 1, Email: "admin@x.io", ExternalID: "sso:azure:admin-sub"}, nil)
+
+	session, user, _, err := c.CompleteSAML(context.Background(), "corp",
+		httptest.NewRequest(http.MethodPost, "/auth/saml/corp/acs", nil), "relay-6", "ua", "1.2.3.4")
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "different SSO provider")
+	assert.Nil(t, session)
+	assert.Nil(t, user)
+	// The takeover must never reach session creation.
 	store.AssertNotCalled(t, "CreateSession", mock.Anything, mock.Anything)
 }
 
@@ -177,11 +205,11 @@ func TestCompleteSAML_TrustAssertedEmailOptInLinksExistingAccount(t *testing.T) 
 	c := &KeyorixCore{storage: store, now: time.Now, ssoProviders: map[string]*SSOProvider{"corp": p}}
 	store.On("ConsumeSSOLoginState", mock.Anything, "relay-7").Return(
 		&models.SSOLoginState{Provider: "corp", Nonce: "req-1", ExpiresAt: time.Now().Add(time.Minute)}, nil)
-	store.On("GetUserByExternalID", mock.Anything, "corp|123").Return((*models.User)(nil), userNotFound())
+	store.On("GetUserByExternalID", mock.Anything, "sso:corp:corp|123").Return((*models.User)(nil), userNotFound())
 	store.On("GetUserByEmail", mock.Anything, "ada@x.io").Return(&models.User{ID: 9, ExternalID: ""}, nil)
 	store.On("UpdateUser", mock.Anything, mock.MatchedBy(func(u *models.User) bool {
-		return u.ID == 9 && u.ExternalID == "corp|123"
-	})).Return(&models.User{ID: 9, ExternalID: "corp|123"}, nil)
+		return u.ID == 9 && u.ExternalID == "sso:corp:corp|123"
+	})).Return(&models.User{ID: 9, ExternalID: "sso:corp:corp|123"}, nil)
 	store.On("CreateSession", mock.Anything, mock.Anything).Return(&models.Session{ID: 1, UserID: 9, SessionToken: "tok"}, nil)
 	store.On("UpdateLastLogin", mock.Anything, uint(9), mock.Anything).Return(nil)
 	store.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)

--- a/internal/core/sso.go
+++ b/internal/core/sso.go
@@ -1,8 +1,9 @@
 // sso.go — human single-sign-on via OIDC (authorization-code flow). A user clicks
 // "Sign in with SSO", is redirected to their IdP, and on callback Keyorix verifies
 // the id_token (signature via the issuer's JWKS, issuer, audience=client_id, expiry,
-// and the nonce it issued), maps the identity to a Keyorix user (the SCIM externalId
-// first, then email), and mints the SAME session a password login would — so an
+// and the nonce it issued), maps the identity to a Keyorix user (this provider's
+// scoped externalId first, then a provider-gated email fallback), and mints the SAME
+// session a password login would — so an
 // IdP-provisioned (passwordless) user can actually sign in. SSO logins bypass
 // Keyorix-local MFA: the IdP is the trusted authenticator.
 //
@@ -194,7 +195,7 @@ func (c *KeyorixCore) CompleteSSO(ctx context.Context, providerName, code, state
 		return nil, nil, "", err
 	}
 
-	user, err := c.resolveSSOUser(ctx, sub, email, emailVerified)
+	user, err := c.resolveSSOUser(ctx, p.Name, sub, email, emailVerified)
 	if err != nil {
 		return nil, nil, "", err
 	}
@@ -313,7 +314,7 @@ func (c *KeyorixCore) CompleteSAML(ctx context.Context, name string, r *http.Req
 	// low-trust SAML IdP claim an EXISTING account (up to a native admin) merely
 	// by asserting its address (#89). Gate on the provider's explicit opt-in
 	// instead; see SSOProvider.TrustAssertedEmail.
-	user, err := c.resolveSSOUser(ctx, info.Subject, info.Email, p.TrustAssertedEmail)
+	user, err := c.resolveSSOUser(ctx, p.Name, info.Subject, info.Email, p.TrustAssertedEmail)
 	if err != nil {
 		return nil, nil, "", err
 	}
@@ -351,29 +352,48 @@ func (c *KeyorixCore) CompleteSAML(ctx context.Context, name string, r *http.Req
 	return session, user, st.ReturnTo, nil
 }
 
-// resolveSSOUser maps the IdP identity to a Keyorix user: the SCIM externalId
-// (subject) first, then email. Returns (nil, nil) when neither matches — the caller
-// decides whether to refuse the login or JIT-provision the account.
+// ssoExternalIDScheme namespaces an SSO-provider-managed identity inside the shared
+// external_id column. A scoped value "sso:<provider>:<subject>" binds the account to
+// exactly ONE SSO provider, so a second IdP that asserts the same subject — or the same
+// email — cannot claim it (see resolveSSOUser). Bare external_ids (SCIM externalId,
+// RFC 7644) and empty values (local accounts) are deliberately left unscoped so they
+// stay interoperable; only JIT-provisioned SSO accounts carry the scheme.
+const ssoExternalIDScheme = "sso:"
+
+// ssoExternalID builds the provider-scoped external_id for an SSO identity. Provider
+// names are configuration keys (no ':'), so the scheme + provider form a stable prefix.
+func ssoExternalID(provider, subject string) string {
+	return ssoExternalIDScheme + provider + ":" + subject
+}
+
+// ssoBoundToOtherProvider reports whether externalID is an SSO-scoped identity owned by
+// a provider OTHER than `provider`. An account in that state must never be linked to
+// `provider`'s assertion — doing so is exactly the cross-provider account takeover this
+// guards against. Bare/empty external_ids are not provider-bound and return false.
+func ssoBoundToOtherProvider(externalID, provider string) bool {
+	return strings.HasPrefix(externalID, ssoExternalIDScheme) &&
+		!strings.HasPrefix(externalID, ssoExternalID(provider, ""))
+}
+
+// resolveSSOUser maps a verified IdP identity from `provider` to a Keyorix user: this
+// provider's own scoped external_id first, then email. Returns (nil, nil) when neither
+// matches — the caller decides whether to refuse the login or JIT-provision the account.
 //
 // The email fallback carries two guards that close a cross-provider account-takeover
 // vector when more than one SSO provider is trusted (e.g. a corporate IdP plus a
 // weaker/partner IdP). (1) The email must be EXPLICITLY verified: an IdP that lets a
 // user self-assert an address — or merely omits email_verified — cannot use it to
 // claim an EXISTING account (a brand-new JIT account is still provisionable, since
-// there is nothing to take over). (2) The matched account must not already be bound
-// to a DIFFERENT federated identity; otherwise a second IdP asserting the same email
-// could take over an account owned by the first. A never-federated (native or
-// SCIM-by-email) account is claimed by this subject on first link, so a later
-// provider can't re-link it by asserting the same address.
-//
-// Residual (documented): a malicious provider that can choose its subjects could still
-// forge a sub equal to a victim's externalId and match via the subject branch. Fully
-// closing that requires binding each federated identity to its issuer (as the machine
-// OIDC path does) — a schema change tracked separately.
-func (c *KeyorixCore) resolveSSOUser(ctx context.Context, sub, email string, emailVerified bool) (*models.User, error) {
+// there is nothing to take over). (2) The matched account must not already be bound to
+// a scoped identity owned by a DIFFERENT provider (see ssoBoundToOtherProvider);
+// otherwise a second IdP asserting the same email could take over an account owned by
+// the first. A never-federated (native or SCIM-by-email) account is claimed for THIS
+// provider+subject on first link, so a later provider can't re-link it by asserting the
+// same address.
+func (c *KeyorixCore) resolveSSOUser(ctx context.Context, provider, sub, email string, emailVerified bool) (*models.User, error) {
 	notFound := i18n.T("ErrorUserNotFound", nil)
 	if sub != "" {
-		if u, err := c.storage.GetUserByExternalID(ctx, sub); err == nil {
+		if u, err := c.storage.GetUserByExternalID(ctx, ssoExternalID(provider, sub)); err == nil {
 			return u, nil
 		} else if !strings.Contains(err.Error(), notFound) {
 			return nil, err
@@ -389,14 +409,14 @@ func (c *KeyorixCore) resolveSSOUser(ctx context.Context, sub, email string, ema
 		}
 		return nil, err
 	}
-	if u.ExternalID != "" && u.ExternalID != sub {
-		return nil, fmt.Errorf("this email is already linked to a different SSO identity")
+	if ssoBoundToOtherProvider(u.ExternalID, provider) {
+		return nil, fmt.Errorf("the email %q is already linked to a different SSO provider", email)
 	}
 	if u.ExternalID == "" && sub != "" {
-		// Claim this never-federated account for the verifying subject so a later
-		// provider can't re-link it by asserting the same email. Best-effort: a failed
-		// update just means we re-link on the next login.
-		u.ExternalID = sub
+		// Claim this never-federated account for the verifying provider+subject so a
+		// later provider can't re-link it by asserting the same email. Best-effort: a
+		// failed update just means we re-link on the next login.
+		u.ExternalID = ssoExternalID(provider, sub)
 		if updated, uerr := c.storage.UpdateUser(ctx, u); uerr == nil {
 			u = updated
 		}
@@ -421,11 +441,9 @@ func (c *KeyorixCore) provisionSSOUser(ctx context.Context, p *SSOProvider, sub,
 	// reuse it rather than create a duplicate. This MUST go through resolveSSOUser (not a
 	// raw email lookup), so the same guards apply — an EXISTING account is reused via an
 	// email match ONLY when the email is verified, and never when it is bound to a
-	// different federated identity. A raw FindSCIMUser(sub, email) here re-introduced the
-	// unverified-email account-takeover that resolveSSOUser exists to prevent: an IdP that
-	// omits email_verified could assert a victim's email and have the JIT path "reuse"
-	// (i.e. log in as) the victim's existing account.
-	if existing, ferr := c.resolveSSOUser(ctx, sub, email, emailVerified); ferr != nil {
+	// different provider's federated identity. Re-running the SAME gated resolution
+	// means the race path cannot bypass either check.
+	if existing, ferr := c.resolveSSOUser(ctx, p.Name, sub, email, emailVerified); ferr != nil {
 		return nil, ferr
 	} else if existing != nil {
 		return existing, nil
@@ -445,7 +463,7 @@ func (c *KeyorixCore) provisionSSOUser(ctx context.Context, p *SSOProvider, sub,
 	now := c.now()
 	created, err := c.storage.CreateUser(ctx, &models.User{
 		Username: username, Email: email, DisplayName: displayName,
-		PasswordHash: hash, IsActive: true, AccountState: AccountActive, ExternalID: sub,
+		PasswordHash: hash, IsActive: true, AccountState: AccountActive, ExternalID: ssoExternalID(p.Name, sub),
 		PasswordChangedAt: &now, CreatedAt: now, UpdatedAt: now,
 	})
 	if err != nil {

--- a/internal/core/sso_test.go
+++ b/internal/core/sso_test.go
@@ -138,8 +138,9 @@ func TestResolveSSOUser(t *testing.T) {
 
 	t.Run("externalId match wins", func(t *testing.T) {
 		c, store, _, _ := ssoTestCore(t)
-		store.On("GetUserByExternalID", mock.Anything, "okta|123").Return(&models.User{ID: 7}, nil)
-		u, err := c.resolveSSOUser(context.Background(), "okta|123", "ada@x.io", true)
+		// The subject is looked up under this provider's scoped external_id.
+		store.On("GetUserByExternalID", mock.Anything, "sso:okta:okta|123").Return(&models.User{ID: 7}, nil)
+		u, err := c.resolveSSOUser(context.Background(), "okta", "okta|123", "ada@x.io", true)
 		require.NoError(t, err)
 		assert.Equal(t, uint(7), u.ID)
 		store.AssertNotCalled(t, "GetUserByEmail", mock.Anything, mock.Anything)
@@ -147,13 +148,14 @@ func TestResolveSSOUser(t *testing.T) {
 
 	t.Run("verified email links a never-federated account and claims it", func(t *testing.T) {
 		c, store, _, _ := ssoTestCore(t)
-		store.On("GetUserByExternalID", mock.Anything, "okta|123").Return((*models.User)(nil), notFound())
+		store.On("GetUserByExternalID", mock.Anything, "sso:okta:okta|123").Return((*models.User)(nil), notFound())
 		store.On("GetUserByEmail", mock.Anything, "ada@x.io").Return(&models.User{ID: 9, ExternalID: ""}, nil)
-		// First link claims the account for this subject (so a later provider can't re-link it).
+		// First link claims the account for this provider+subject (so a later provider
+		// can't re-link it).
 		store.On("UpdateUser", mock.Anything, mock.MatchedBy(func(u *models.User) bool {
-			return u.ID == 9 && u.ExternalID == "okta|123"
-		})).Return(&models.User{ID: 9, ExternalID: "okta|123"}, nil)
-		u, err := c.resolveSSOUser(context.Background(), "okta|123", "ada@x.io", true)
+			return u.ID == 9 && u.ExternalID == "sso:okta:okta|123"
+		})).Return(&models.User{ID: 9, ExternalID: "sso:okta:okta|123"}, nil)
+		u, err := c.resolveSSOUser(context.Background(), "okta", "okta|123", "ada@x.io", true)
 		require.NoError(t, err)
 		assert.Equal(t, uint(9), u.ID)
 		store.AssertCalled(t, "UpdateUser", mock.Anything, mock.Anything)
@@ -161,31 +163,43 @@ func TestResolveSSOUser(t *testing.T) {
 
 	t.Run("unverified email does NOT match an existing account (no takeover)", func(t *testing.T) {
 		c, store, _, _ := ssoTestCore(t)
-		store.On("GetUserByExternalID", mock.Anything, "okta|123").Return((*models.User)(nil), notFound())
+		store.On("GetUserByExternalID", mock.Anything, "sso:okta:okta|123").Return((*models.User)(nil), notFound())
 		// emailVerified=false: the email fallback is skipped entirely — an IdP that merely
 		// asserts (or omits email_verified for) an address can't claim an existing account.
-		u, err := c.resolveSSOUser(context.Background(), "okta|123", "ada@x.io", false)
+		u, err := c.resolveSSOUser(context.Background(), "okta", "okta|123", "ada@x.io", false)
 		require.NoError(t, err)
 		assert.Nil(t, u)
 		store.AssertNotCalled(t, "GetUserByEmail", mock.Anything, mock.Anything)
 	})
 
-	t.Run("email match to an account bound to a DIFFERENT identity is refused", func(t *testing.T) {
+	t.Run("email fallback refuses an account bound to a different provider", func(t *testing.T) {
 		c, store, _, _ := ssoTestCore(t)
-		store.On("GetUserByExternalID", mock.Anything, "partner|999").Return((*models.User)(nil), notFound())
-		// The corp account is already federated to a different subject — a second provider
-		// asserting the same email must not take it over.
-		store.On("GetUserByEmail", mock.Anything, "ada@x.io").Return(&models.User{ID: 9, ExternalID: "okta|123"}, nil)
-		_, err := c.resolveSSOUser(context.Background(), "partner|999", "ada@x.io", true)
-		require.ErrorContains(t, err, "already linked to a different SSO identity")
-		store.AssertNotCalled(t, "UpdateUser", mock.Anything, mock.Anything)
+		store.On("GetUserByExternalID", mock.Anything, "sso:okta:okta|123").Return((*models.User)(nil), notFound())
+		// This email belongs to an account already bound to IdP "azure". The "okta"
+		// assertion must NOT be able to claim it — that is the takeover this guards.
+		store.On("GetUserByEmail", mock.Anything, "ada@x.io").
+			Return(&models.User{ID: 99, ExternalID: "sso:azure:abc"}, nil)
+		u, err := c.resolveSSOUser(context.Background(), "okta", "okta|123", "ada@x.io", true)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "different SSO provider")
+		assert.Nil(t, u)
+	})
+
+	t.Run("email fallback allows an account bound to the SAME provider", func(t *testing.T) {
+		c, store, _, _ := ssoTestCore(t)
+		store.On("GetUserByExternalID", mock.Anything, "sso:okta:okta|123").Return((*models.User)(nil), notFound())
+		store.On("GetUserByEmail", mock.Anything, "ada@x.io").
+			Return(&models.User{ID: 11, ExternalID: "sso:okta:other-sub"}, nil)
+		u, err := c.resolveSSOUser(context.Background(), "okta", "okta|123", "ada@x.io", true)
+		require.NoError(t, err)
+		assert.Equal(t, uint(11), u.ID)
 	})
 
 	t.Run("no match returns nil (caller decides)", func(t *testing.T) {
 		c, store, _, _ := ssoTestCore(t)
-		store.On("GetUserByExternalID", mock.Anything, "okta|123").Return((*models.User)(nil), notFound())
+		store.On("GetUserByExternalID", mock.Anything, "sso:okta:okta|123").Return((*models.User)(nil), notFound())
 		store.On("GetUserByEmail", mock.Anything, "ada@x.io").Return((*models.User)(nil), notFound())
-		u, err := c.resolveSSOUser(context.Background(), "okta|123", "ada@x.io", true)
+		u, err := c.resolveSSOUser(context.Background(), "okta", "okta|123", "ada@x.io", true)
 		require.NoError(t, err)
 		assert.Nil(t, u)
 	})
@@ -196,8 +210,8 @@ func TestProvisionSSOUser(t *testing.T) {
 
 	t.Run("JIT-creates an active passwordless user with the default role", func(t *testing.T) {
 		c, store, _, p := ssoTestCore(t)
-		// No existing match (FindSCIMUser re-check), unique username derivation.
-		store.On("GetUserByExternalID", mock.Anything, "okta|123").Return((*models.User)(nil), notFound())
+		// No existing match (gated resolve re-check), unique username derivation.
+		store.On("GetUserByExternalID", mock.Anything, "sso:okta:okta|123").Return((*models.User)(nil), notFound())
 		store.On("GetUserByEmail", mock.Anything, "ada@x.io").Return((*models.User)(nil), notFound())
 		store.On("GetUserByUsername", mock.Anything, "ada").Return((*models.User)(nil), notFound())
 		var created *models.User
@@ -216,7 +230,7 @@ func TestProvisionSSOUser(t *testing.T) {
 		// restricted password-change-only session), externalId pinned, real display name.
 		assert.Equal(t, AccountActive, created.AccountState)
 		assert.True(t, created.IsActive)
-		assert.Equal(t, "okta|123", created.ExternalID)
+		assert.Equal(t, "sso:okta:okta|123", created.ExternalID, "JIT account is bound to the asserting provider")
 		assert.Equal(t, "ada@x.io", created.Email)
 		assert.Equal(t, "Ada Lovelace", created.DisplayName)
 		assert.NotEmpty(t, created.PasswordHash) // unusable random hash, not blank
@@ -258,7 +272,7 @@ func TestProvisionSSOUser(t *testing.T) {
 
 	t.Run("reuses an existing user instead of duplicating", func(t *testing.T) {
 		c, store, _, p := ssoTestCore(t)
-		store.On("GetUserByExternalID", mock.Anything, "okta|123").Return(&models.User{ID: 5}, nil)
+		store.On("GetUserByExternalID", mock.Anything, "sso:okta:okta|123").Return(&models.User{ID: 5}, nil)
 		u, err := c.provisionSSOUser(context.Background(), p, "okta|123", "ada@x.io", true, "Ada")
 		require.NoError(t, err)
 		assert.Equal(t, uint(5), u.ID)
@@ -268,7 +282,7 @@ func TestProvisionSSOUser(t *testing.T) {
 	t.Run("honours a configured default_role", func(t *testing.T) {
 		c, store, _, p := ssoTestCore(t)
 		p.DefaultRole = "project_admin"
-		store.On("GetUserByExternalID", mock.Anything, "okta|123").Return((*models.User)(nil), notFound())
+		store.On("GetUserByExternalID", mock.Anything, "sso:okta:okta|123").Return((*models.User)(nil), notFound())
 		store.On("GetUserByEmail", mock.Anything, "ada@x.io").Return((*models.User)(nil), notFound())
 		store.On("GetUserByUsername", mock.Anything, "ada").Return((*models.User)(nil), notFound())
 		store.On("CreateUser", mock.Anything, mock.Anything).Return(&models.User{ID: 7}, nil)
@@ -284,7 +298,7 @@ func TestProvisionSSOUser(t *testing.T) {
 	t.Run("an unknown default_role grants nothing but still provisions", func(t *testing.T) {
 		c, store, _, p := ssoTestCore(t)
 		p.DefaultRole = "does_not_exist"
-		store.On("GetUserByExternalID", mock.Anything, "okta|123").Return((*models.User)(nil), notFound())
+		store.On("GetUserByExternalID", mock.Anything, "sso:okta:okta|123").Return((*models.User)(nil), notFound())
 		store.On("GetUserByEmail", mock.Anything, "ada@x.io").Return((*models.User)(nil), notFound())
 		store.On("GetUserByUsername", mock.Anything, "ada").Return((*models.User)(nil), notFound())
 		store.On("CreateUser", mock.Anything, mock.Anything).Return(&models.User{ID: 8}, nil)

--- a/internal/core/sso_test.go
+++ b/internal/core/sso_test.go
@@ -250,8 +250,8 @@ func TestProvisionSSOUser(t *testing.T) {
 	t.Run("does NOT reuse an existing account on an unverified email", func(t *testing.T) {
 		c, store, _, p := ssoTestCore(t)
 		// sub does not match; an existing victim account DOES match the email.
-		store.On("GetUserByExternalID", mock.Anything, "evil|999").Return((*models.User)(nil), notFound())
-		victim := &models.User{ID: 7, Username: "victim", Email: "victim@corp.com", ExternalID: "okta|legit"}
+		store.On("GetUserByExternalID", mock.Anything, "sso:okta:evil|999").Return((*models.User)(nil), notFound())
+		victim := &models.User{ID: 7, Username: "victim", Email: "victim@corp.com", ExternalID: "sso:okta:legit"}
 		store.On("GetUserByEmail", mock.Anything, "victim@corp.com").Return(victim, nil)
 		// A fresh account is provisioned instead of reusing the victim.
 		store.On("GetUserByUsername", mock.Anything, "victim").Return((*models.User)(nil), notFound())
@@ -266,7 +266,7 @@ func TestProvisionSSOUser(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, uint(99), u.ID, "must be the fresh account, not the victim (id 7)")
 		require.NotNil(t, created)
-		assert.Equal(t, "evil|999", created.ExternalID, "fresh account bound to the asserting subject, not the victim")
+		assert.Equal(t, "sso:okta:evil|999", created.ExternalID, "fresh account bound to the asserting provider+subject, not the victim")
 		store.AssertNotCalled(t, "UpdateUser", mock.Anything, mock.Anything) // victim not claimed/reused
 	})
 


### PR DESCRIPTION
## Summary

Fixes a cross-provider account-takeover in SSO identity resolution. `resolveSSOUser` matched users by **global** `external_id` and email, so a validly-signed assertion from one configured SSO provider could be linked to an account belonging to a **different** provider (or a local/SCIM account) merely by asserting its email — seizing that account.

With two providers configured (e.g. a trusted corporate IdP plus a lower-trust one), an attacker controlling the second IdP could claim a privileged account by setting its email/NameID.

## Changes

- SSO-managed accounts now carry a **provider-scoped** `external_id` (`sso:<provider>:<subject>`). Bare SCIM `external_id`s and empty local ids stay unscoped and interoperable.
- `resolveSSOUser` matches this provider's scoped id first, then a **gated** email fallback that refuses to cross an existing binding to a different provider.
- JIT provisioning stores the scoped id; the race-dedup guard reuses the same gated resolution.

## Testing

- New regression tests cover cross-provider rejection end-to-end (SAML `CompleteSAML`), plus the unbound/same-provider allow cases.
- `go build ./...`, `go test ./internal/core/`, `go vet`, `gofmt`, `gosec` all green.

## Known residual (follow-up)

Pre-existing SSO accounts (bare `external_id`) and SCIM-managed accounts remain email-linkable by the first asserting provider until re-bound; fully closing that needs a dedicated `sso_provider` column (SCIM can't supply provenance via the shared `external_id`).
