### PR TITLE
harden: bootstrap admin-claim (HIGH), gRPC PAT scope, KMS binding, audit/k8ssync/webhook/PAT hardening

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,6 +41,7 @@ require (
 	go.mongodb.org/mongo-driver v1.17.9
 	golang.org/x/crypto v0.52.0
 	golang.org/x/oauth2 v0.36.0
+	golang.org/x/sync v0.21.0
 	golang.org/x/term v0.43.0
 	golang.org/x/text v0.37.0
 	google.golang.org/api v0.274.0
@@ -134,7 +135,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.43.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	golang.org/x/net v0.55.0 // indirect
-	golang.org/x/sync v0.21.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 	google.golang.org/genproto v0.0.0-20260319201613-d00831a3d3e7 // indirect

--- a/internal/audit/siem/forwarder.go
+++ b/internal/audit/siem/forwarder.go
@@ -26,6 +26,25 @@ import (
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
+// refuseRedirect blocks a redirect to a different host or an https->http downgrade.
+// The SIEM auth rides in custom headers (DD-API-KEY, Splunk token) that Go does NOT
+// strip on a cross-host redirect, so a compromised/misconfigured intake endpoint
+// returning a 30x could otherwise bounce the credential-bearing request to an
+// attacker-controlled or internal host (token exfil / SSRF).
+func refuseRedirect(req *http.Request, via []*http.Request) error {
+	if len(via) == 0 {
+		return nil
+	}
+	prev := via[len(via)-1]
+	if req.URL.Host != prev.URL.Host {
+		return fmt.Errorf("siem: refusing cross-host redirect to %q", req.URL.Host)
+	}
+	if prev.URL.Scheme == "https" && req.URL.Scheme != "https" {
+		return fmt.Errorf("siem: refusing https->%s redirect", req.URL.Scheme)
+	}
+	return nil
+}
+
 // Provider identifies the destination SIEM format.
 type Provider string
 
@@ -103,7 +122,7 @@ func newForwarder(cfg Config, baseBackoff time.Duration) (*Forwarder, error) {
 	}
 	f := &Forwarder{
 		cfg:         cfg,
-		client:      &http.Client{Timeout: httpTimeout, Transport: transport},
+		client:      &http.Client{Timeout: httpTimeout, Transport: transport, CheckRedirect: refuseRedirect},
 		queue:       make(chan *models.AuditEvent, queueSize),
 		baseBackoff: baseBackoff,
 		closing:     make(chan struct{}),

--- a/internal/audit/siem/forwarder.go
+++ b/internal/audit/siem/forwarder.go
@@ -42,6 +42,11 @@ type Config struct {
 	Endpoint           string // full destination URL (e.g. Splunk HEC collector URL)
 	Token              string // HEC token / DD-API-KEY / bearer token
 	InsecureSkipVerify bool   // skip TLS verification (self-signed SIEM endpoints)
+	// SpoolDir, when set, enables a durable on-disk backlog: an event that would
+	// otherwise be dropped (full queue) or fail after retries is persisted here and
+	// replayed until the SIEM accepts it, so a sustained outage no longer silently
+	// loses the off-box copy. Empty = best-effort only (the prior behaviour).
+	SpoolDir string
 }
 
 // queueSize bounds in-flight events; httpTimeout bounds a single delivery.
@@ -64,6 +69,7 @@ type Forwarder struct {
 	closing     chan struct{} // closed by Close to abort in-flight retry backoff
 	closeOnce   sync.Once
 	wg          sync.WaitGroup
+	spool       *spool // nil unless Config.SpoolDir is set
 
 	mu      sync.Mutex
 	dropped int64
@@ -102,6 +108,16 @@ func newForwarder(cfg Config, baseBackoff time.Duration) (*Forwarder, error) {
 		baseBackoff: baseBackoff,
 		closing:     make(chan struct{}),
 	}
+	if cfg.SpoolDir != "" {
+		sp, serr := newSpool(cfg.SpoolDir, defaultReplayInterval, func(ctx context.Context, e *models.AuditEvent) error {
+			_, err := f.send(ctx, e)
+			return err
+		})
+		if serr != nil {
+			return nil, serr
+		}
+		f.spool = sp
+	}
 	f.wg.Add(1)
 	go f.worker()
 	return f, nil
@@ -116,6 +132,12 @@ func (f *Forwarder) Forward(event *models.AuditEvent) {
 	select {
 	case f.queue <- event:
 	default:
+		// Queue full (a wedged/slow SIEM). Persist to the durable spool if configured so
+		// the event is replayed later; otherwise fall back to a counted, logged drop.
+		if f.spool != nil {
+			f.spool.add(event)
+			return
+		}
 		f.mu.Lock()
 		f.dropped++
 		dropped := f.dropped
@@ -146,6 +168,7 @@ func (f *Forwarder) Close() {
 		close(f.queue)
 	})
 	f.wg.Wait()
+	f.spool.close() // nil-safe; stops the replay loop
 }
 
 func (f *Forwarder) worker() {
@@ -169,6 +192,11 @@ func (f *Forwarder) deliver(event *models.AuditEvent) {
 		if !retryable || attempt >= maxAttempts {
 			siemForwards.WithLabelValues(outcomeFailed).Inc()
 			log.Printf("siem: failed to forward audit event %d after %d attempt(s): %v", event.ID, attempt, err)
+			// Persist to the durable spool (if configured) so the off-box copy survives
+			// a SIEM outage longer than the in-memory retry budget.
+			if f.spool != nil {
+				f.spool.add(event)
+			}
 			return
 		}
 		siemRetries.Inc()
@@ -177,6 +205,9 @@ func (f *Forwarder) deliver(event *models.AuditEvent) {
 		case <-f.closing:
 			siemForwards.WithLabelValues(outcomeFailed).Inc()
 			log.Printf("siem: forward of audit event %d abandoned on shutdown after %d attempt(s): %v", event.ID, attempt, err)
+			if f.spool != nil {
+				f.spool.add(event)
+			}
 			return
 		}
 		backoff *= 2

--- a/internal/audit/siem/forwarder.go
+++ b/internal/audit/siem/forwarder.go
@@ -200,6 +200,11 @@ type eventPayload struct {
 	Impersonation  bool            `json:"impersonation,omitempty"`
 	ImpersonatedBy *uint           `json:"impersonated_by,omitempty"`
 	ActingAs       *uint           `json:"acting_as,omitempty"`
+	// Tamper-evidence chain links (ADR-029). Exporting them lets a downstream SIEM
+	// re-link the chain and detect a dropped/forged/reordered event — without them an
+	// export consumer cannot tell a gap (a lost event) from a contiguous stream.
+	EntryHash string `json:"entry_hash,omitempty"`
+	PrevHash  string `json:"prev_hash,omitempty"`
 }
 
 func toPayload(e *models.AuditEvent) eventPayload {
@@ -221,6 +226,8 @@ func toPayload(e *models.AuditEvent) eventPayload {
 		Impersonation:  e.Impersonation,
 		ImpersonatedBy: e.ImpersonatedBy,
 		ActingAs:       e.ActingAs,
+		EntryHash:      e.EntryHash,
+		PrevHash:       e.PrevHash,
 	}
 	if e.Diff != "" {
 		p.Diff = json.RawMessage(e.Diff)

--- a/internal/audit/siem/forwarder_test.go
+++ b/internal/audit/siem/forwarder_test.go
@@ -151,6 +151,35 @@ func TestSend_WebhookBearer(t *testing.T) {
 	}
 }
 
+// A cross-host redirect from the configured SIEM endpoint must be refused, so the
+// custom auth header (DD-API-KEY) — which Go does NOT strip across hosts — can't be
+// exfiltrated to an attacker-controlled redirect target.
+func TestSend_RefusesCrossHostRedirect(t *testing.T) {
+	evil, evilCap := newCaptureServer(t, http.StatusOK)
+	// Primary endpoint 302-redirects to the evil host.
+	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Redirect(w, nil, evil.URL, http.StatusFound)
+	}))
+	t.Cleanup(primary.Close)
+
+	f, _ := New(Config{Enabled: true, Provider: ProviderDatadog, Endpoint: primary.URL, Token: "dd-key"})
+	t.Cleanup(f.Close)
+
+	_, err := f.send(context.Background(), sampleEvent())
+	if err == nil {
+		t.Fatal("expected an error when the endpoint redirects cross-host")
+	}
+	evilCap.mu.Lock()
+	hits, leaked := evilCap.hits, evilCap.headers.Get("DD-API-KEY")
+	evilCap.mu.Unlock()
+	if hits != 0 {
+		t.Errorf("redirect target was reached %d time(s); it must not be followed", hits)
+	}
+	if leaked != "" {
+		t.Errorf("DD-API-KEY leaked to redirect target: %q", leaked)
+	}
+}
+
 func TestSend_Non2xxIsError(t *testing.T) {
 	srv, _ := newCaptureServer(t, http.StatusInternalServerError)
 	f, _ := New(Config{Enabled: true, Provider: ProviderWebhook, Endpoint: srv.URL})

--- a/internal/audit/siem/forwarder_test.go
+++ b/internal/audit/siem/forwarder_test.go
@@ -37,7 +37,9 @@ func sampleEvent() *models.AuditEvent {
 		ID: 42, EventType: "secret.updated", UserID: &uid, ProjectID: &pid,
 		Description: "User alice updated secret db-password", IPAddress: "10.0.0.5",
 		Success: &t, EventTime: time.Date(2026, 6, 4, 10, 0, 0, 0, time.UTC),
-		Diff: `{"value":{"changed":true}}`,
+		Diff:      `{"value":{"changed":true}}`,
+		PrevHash:  "prevhash-abc",
+		EntryHash: "entryhash-xyz",
 	}
 }
 
@@ -141,6 +143,11 @@ func TestSend_WebhookBearer(t *testing.T) {
 	}
 	if p.ID != 42 || p.EventType != "secret.updated" {
 		t.Errorf("unexpected payload: %+v", p)
+	}
+	// The chain links must be exported so a downstream SIEM can detect a dropped or
+	// forged event (a gap shows as a prev_hash that doesn't match the prior entry_hash).
+	if p.EntryHash != "entryhash-xyz" || p.PrevHash != "prevhash-abc" {
+		t.Errorf("missing tamper-evidence chain links: entry=%q prev=%q", p.EntryHash, p.PrevHash)
 	}
 }
 

--- a/internal/audit/siem/metrics.go
+++ b/internal/audit/siem/metrics.go
@@ -32,4 +32,7 @@ const (
 	outcomeDelivered = "delivered"
 	outcomeFailed    = "failed"
 	outcomeDropped   = "dropped"
+	// spooled: persisted to the on-disk durable spool for later replay instead of being
+	// dropped (only when Config.SpoolDir is set).
+	outcomeSpooled = "spooled"
 )

--- a/internal/audit/siem/spool.go
+++ b/internal/audit/siem/spool.go
@@ -27,6 +27,11 @@ import (
 const (
 	spoolFileName         = "siem-spool.jsonl"
 	defaultReplayInterval = 30 * time.Second
+	// defaultSpoolMaxBytes caps the on-disk backlog so an indefinite SIEM outage (the
+	// spool's whole purpose) can't fill the volume and take the server down — the local
+	// audit chain remains the durable system of record regardless. Beyond the cap, new
+	// events are dropped (counted) rather than appended.
+	defaultSpoolMaxBytes int64 = 100 << 20 // 100 MiB
 )
 
 // spool persists undelivered events and replays them on an interval. deliverOnce
@@ -34,9 +39,10 @@ const (
 type spool struct {
 	path        string
 	interval    time.Duration
+	maxBytes    int64
 	deliverOnce func(context.Context, *models.AuditEvent) error
 
-	mu   sync.Mutex // serializes all file access (append + replay rewrite)
+	mu   sync.Mutex // serializes file mutation (append + replay rewrite); NOT held across delivery
 	stop chan struct{}
 	done chan struct{}
 }
@@ -46,12 +52,19 @@ func newSpool(dir string, interval time.Duration, deliverOnce func(context.Conte
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return nil, fmt.Errorf("siem: create spool dir: %w", err)
 	}
+	// MkdirAll leaves a pre-existing directory's mode untouched, so tighten it: the spool
+	// holds audit events (secret names, usernames, IPs, justifications) that must not be
+	// group/world-readable.
+	if err := os.Chmod(dir, 0o700); err != nil { // #nosec G302 -- a directory needs the owner execute bit to be traversable; 0700 is the tightest valid dir mode
+		return nil, fmt.Errorf("siem: tighten spool dir perms: %w", err)
+	}
 	if interval <= 0 {
 		interval = defaultReplayInterval
 	}
 	s := &spool{
 		path:        filepath.Join(dir, spoolFileName),
 		interval:    interval,
+		maxBytes:    defaultSpoolMaxBytes,
 		deliverOnce: deliverOnce,
 		stop:        make(chan struct{}),
 		done:        make(chan struct{}),
@@ -60,7 +73,8 @@ func newSpool(dir string, interval time.Duration, deliverOnce func(context.Conte
 	return s, nil
 }
 
-// add appends an event to the spool for later replay.
+// add appends an event to the spool for later replay, unless the backlog is already at its
+// size cap (in which case the event is dropped + counted, bounding disk use).
 func (s *spool) add(event *models.AuditEvent) {
 	line, err := json.Marshal(event)
 	if err != nil {
@@ -69,6 +83,13 @@ func (s *spool) add(event *models.AuditEvent) {
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if s.maxBytes > 0 {
+		if info, serr := os.Stat(s.path); serr == nil && info.Size() >= s.maxBytes {
+			log.Printf("siem: spool at cap (%d bytes); dropping audit event %d off-box copy (local audit chain retains it)", s.maxBytes, event.ID)
+			siemForwards.WithLabelValues(outcomeDropped).Inc()
+			return
+		}
+	}
 	f, err := os.OpenFile(s.path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
 	if err != nil {
 		log.Printf("siem: open spool to persist audit event %d failed: %v", event.ID, err)
@@ -98,12 +119,18 @@ func (s *spool) loop() {
 }
 
 // replay re-attempts delivery of every spooled event, then rewrites the file with only
-// those that still failed. Held under the lock so a concurrent add can't be lost.
+// those that still failed. The lock is NOT held across the (slow, network) deliveries —
+// only across the snapshot read and the final reconcile — so a concurrent add() (which is
+// on the audited request path) never blocks behind a SIEM round-trip. Crash-safe: every
+// undelivered line stays on disk until the atomic rewrite at the end.
 func (s *spool) replay() {
+	// Snapshot under the lock, recording the byte length we read; any add() during the
+	// lock-free delivery below only appends BEYOND this offset (add never rewrites), so the
+	// reconcile can cleanly separate "what we attempted" from "what arrived meanwhile".
 	s.mu.Lock()
-	defer s.mu.Unlock()
-
 	data, err := os.ReadFile(s.path)
+	snapshotLen := int64(len(data))
+	s.mu.Unlock()
 	if err != nil {
 		if !os.IsNotExist(err) {
 			log.Printf("siem: read spool failed: %v", err)
@@ -127,7 +154,7 @@ func (s *spool) replay() {
 			continue
 		}
 		ctx, cancel := context.WithTimeout(context.Background(), httpTimeout)
-		derr := s.deliverOnce(ctx, &event)
+		derr := s.deliverOnce(ctx, &event) // network I/O — deliberately NOT under s.mu
 		cancel()
 		if derr != nil {
 			kept := make([]byte, len(line))
@@ -135,6 +162,35 @@ func (s *spool) replay() {
 			remaining = append(remaining, kept)
 		} else {
 			siemForwards.WithLabelValues(outcomeDelivered).Inc()
+		}
+	}
+
+	// Reconcile under the lock: the file is now [snapshot bytes][lines add()ed meanwhile].
+	// Rewrite = still-failed snapshot lines + the concurrently-added tail, so nothing that
+	// arrived during delivery is lost and nothing delivered is re-sent.
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cur, rerr := os.ReadFile(s.path)
+	if rerr != nil {
+		if !os.IsNotExist(rerr) {
+			log.Printf("siem: re-read spool failed: %v", rerr)
+		}
+		if len(remaining) > 0 {
+			s.rewrite(remaining) // file vanished unexpectedly — re-persist the failed lines
+		}
+		return
+	}
+	if int64(len(cur)) > snapshotLen {
+		ts := bufio.NewScanner(data2reader(cur[snapshotLen:]))
+		ts.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+		for ts.Scan() {
+			line := ts.Bytes()
+			if len(bytes.TrimSpace(line)) == 0 {
+				continue
+			}
+			kept := make([]byte, len(line))
+			copy(kept, line)
+			remaining = append(remaining, kept)
 		}
 	}
 

--- a/internal/audit/siem/spool.go
+++ b/internal/audit/siem/spool.go
@@ -1,0 +1,186 @@
+// spool.go — an opt-in, durable on-disk backlog for audit events that could not be
+// delivered to the SIEM (a full queue, or retries exhausted). Without it, a SIEM
+// outage longer than the in-memory retry budget silently loses the off-box copy of
+// those events. When Config.SpoolDir is set, such events are appended to a JSONL file
+// and a background loop replays them until the SIEM accepts them.
+//
+// The local audit chain remains the durable system of record either way; the spool
+// only protects the off-box mirror. It is best-effort: a crash mid-rewrite may at
+// worst re-deliver an event (SIEMs dedupe on the event id), never silently drop one.
+package siem
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+const (
+	spoolFileName         = "siem-spool.jsonl"
+	defaultReplayInterval = 30 * time.Second
+)
+
+// spool persists undelivered events and replays them on an interval. deliverOnce
+// attempts a single delivery and returns nil on success.
+type spool struct {
+	path        string
+	interval    time.Duration
+	deliverOnce func(context.Context, *models.AuditEvent) error
+
+	mu   sync.Mutex // serializes all file access (append + replay rewrite)
+	stop chan struct{}
+	done chan struct{}
+}
+
+// newSpool prepares the spool directory and starts the replay loop.
+func newSpool(dir string, interval time.Duration, deliverOnce func(context.Context, *models.AuditEvent) error) (*spool, error) {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return nil, fmt.Errorf("siem: create spool dir: %w", err)
+	}
+	if interval <= 0 {
+		interval = defaultReplayInterval
+	}
+	s := &spool{
+		path:        filepath.Join(dir, spoolFileName),
+		interval:    interval,
+		deliverOnce: deliverOnce,
+		stop:        make(chan struct{}),
+		done:        make(chan struct{}),
+	}
+	go s.loop()
+	return s, nil
+}
+
+// add appends an event to the spool for later replay.
+func (s *spool) add(event *models.AuditEvent) {
+	line, err := json.Marshal(event)
+	if err != nil {
+		log.Printf("siem: spool marshal of audit event %d failed: %v", event.ID, err)
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	f, err := os.OpenFile(s.path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		log.Printf("siem: open spool to persist audit event %d failed: %v", event.ID, err)
+		return
+	}
+	defer func() { _ = f.Close() }()
+	if _, err := f.Write(append(line, '\n')); err != nil {
+		log.Printf("siem: write spool for audit event %d failed: %v", event.ID, err)
+		return
+	}
+	siemForwards.WithLabelValues(outcomeSpooled).Inc()
+}
+
+func (s *spool) loop() {
+	defer close(s.done)
+	t := time.NewTicker(s.interval)
+	defer t.Stop()
+	s.replay() // drain any backlog left by a prior run immediately on start
+	for {
+		select {
+		case <-s.stop:
+			return
+		case <-t.C:
+			s.replay()
+		}
+	}
+}
+
+// replay re-attempts delivery of every spooled event, then rewrites the file with only
+// those that still failed. Held under the lock so a concurrent add can't be lost.
+func (s *spool) replay() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	data, err := os.ReadFile(s.path)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			log.Printf("siem: read spool failed: %v", err)
+		}
+		return
+	}
+
+	var remaining [][]byte
+	sc := bufio.NewScanner(data2reader(data))
+	sc.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	for sc.Scan() {
+		line := sc.Bytes()
+		if len(bytes.TrimSpace(line)) == 0 {
+			continue
+		}
+		var event models.AuditEvent
+		if err := json.Unmarshal(line, &event); err != nil {
+			// A corrupt line can never be delivered; drop it loudly rather than wedging
+			// the whole spool on it forever.
+			log.Printf("siem: discarding unparseable spool line: %v", err)
+			continue
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), httpTimeout)
+		derr := s.deliverOnce(ctx, &event)
+		cancel()
+		if derr != nil {
+			kept := make([]byte, len(line))
+			copy(kept, line)
+			remaining = append(remaining, kept)
+		} else {
+			siemForwards.WithLabelValues(outcomeDelivered).Inc()
+		}
+	}
+
+	if len(remaining) == 0 {
+		_ = os.Remove(s.path)
+		return
+	}
+	s.rewrite(remaining)
+}
+
+// rewrite atomically replaces the spool file with the given lines.
+func (s *spool) rewrite(lines [][]byte) {
+	tmp, err := os.CreateTemp(filepath.Dir(s.path), "siem-spool-*.tmp")
+	if err != nil {
+		log.Printf("siem: rewrite spool (tempfile) failed: %v", err)
+		return
+	}
+	tmpName := tmp.Name()
+	for _, l := range lines {
+		if _, err := tmp.Write(append(l, '\n')); err != nil {
+			_ = tmp.Close()
+			_ = os.Remove(tmpName)
+			log.Printf("siem: rewrite spool (write) failed: %v", err)
+			return
+		}
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpName)
+		log.Printf("siem: rewrite spool (close) failed: %v", err)
+		return
+	}
+	if err := os.Rename(tmpName, s.path); err != nil {
+		_ = os.Remove(tmpName)
+		log.Printf("siem: rewrite spool (rename) failed: %v", err)
+	}
+}
+
+// close stops the replay loop and waits for it to exit.
+func (s *spool) close() {
+	if s == nil {
+		return
+	}
+	close(s.stop)
+	<-s.done
+}
+
+// data2reader wraps a byte slice as an io.Reader for the scanner without pulling in
+// bytes.NewReader at every call site.
+func data2reader(b []byte) *bytes.Reader { return bytes.NewReader(b) }

--- a/internal/audit/siem/spool_test.go
+++ b/internal/audit/siem/spool_test.go
@@ -1,0 +1,85 @@
+package siem
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeDelivery records delivered event IDs and can be toggled to fail.
+type fakeDelivery struct {
+	mu        sync.Mutex
+	failing   bool
+	delivered []uint
+}
+
+func (d *fakeDelivery) deliver(_ context.Context, e *models.AuditEvent) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.failing {
+		return assertErr
+	}
+	d.delivered = append(d.delivered, e.ID)
+	return nil
+}
+
+func (d *fakeDelivery) setFailing(v bool) { d.mu.Lock(); d.failing = v; d.mu.Unlock() }
+func (d *fakeDelivery) count() int        { d.mu.Lock(); defer d.mu.Unlock(); return len(d.delivered) }
+
+var assertErr = &deliveryError{}
+
+type deliveryError struct{}
+
+func (*deliveryError) Error() string { return "siem down" }
+
+func TestSpool_PersistsAndReplaysOnRecovery(t *testing.T) {
+	dir := t.TempDir()
+	d := &fakeDelivery{failing: true}
+	// Long interval so we drive replay() manually and avoid timing flakiness.
+	s, err := newSpool(dir, time.Hour, d.deliver)
+	require.NoError(t, err)
+	t.Cleanup(s.close)
+
+	// Spool two events while the SIEM is "down".
+	tr := true
+	s.add(&models.AuditEvent{ID: 1, EventType: "secret.read", Success: &tr})
+	s.add(&models.AuditEvent{ID: 2, EventType: "secret.updated", Success: &tr})
+
+	spoolPath := filepath.Join(dir, spoolFileName)
+	_, statErr := os.Stat(spoolPath)
+	require.NoError(t, statErr, "events must be persisted to the spool file")
+
+	// A replay while still failing must keep both events (nothing delivered).
+	s.replay()
+	assert.Equal(t, 0, d.count())
+	_, statErr = os.Stat(spoolPath)
+	require.NoError(t, statErr, "a failed replay must retain the backlog")
+
+	// SIEM recovers — the next replay drains the backlog and removes the file.
+	d.setFailing(false)
+	s.replay()
+	assert.ElementsMatch(t, []uint{1, 2}, d.delivered)
+	_, statErr = os.Stat(spoolPath)
+	assert.True(t, os.IsNotExist(statErr), "a fully-drained spool must delete its file")
+}
+
+func TestSpool_DiscardsUnparseableLine(t *testing.T) {
+	dir := t.TempDir()
+	d := &fakeDelivery{}
+	s, err := newSpool(dir, time.Hour, d.deliver)
+	require.NoError(t, err)
+	t.Cleanup(s.close)
+
+	// A corrupt line must not wedge the spool forever.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, spoolFileName), []byte("not json\n"), 0o600))
+	s.replay()
+	_, statErr := os.Stat(filepath.Join(dir, spoolFileName))
+	assert.True(t, os.IsNotExist(statErr), "an unparseable backlog must be cleared, not retried forever")
+}

--- a/internal/audit/siem/spool_test.go
+++ b/internal/audit/siem/spool_test.go
@@ -138,7 +138,11 @@ func TestSpool_ConcurrentAddDuringReplayNotLost(t *testing.T) {
 	s, err := newSpool(dir, time.Hour, hook)
 	require.NoError(t, err)
 	sp = s
-	t.Cleanup(s.close)
+	// Stop the background replay loop up front so ONLY the controlled replay below runs.
+	// Otherwise the loop's periodic/initial replay races the manual one — two concurrent
+	// deliveries appending to d2.delivered and a TOCTOU on the spool file — which made this
+	// test flaky in CI. close() only stops the goroutine; add()/replay() remain usable.
+	s.close()
 
 	s.add(&models.AuditEvent{ID: 1, EventType: "secret.read", Success: &tr})
 	s.replay() // delivers ID 1; ID 99 is add()ed mid-delivery and must not be lost

--- a/internal/audit/siem/spool_test.go
+++ b/internal/audit/siem/spool_test.go
@@ -1,6 +1,7 @@
 package siem
 
 import (
+	"bytes"
 	"context"
 	"os"
 	"path/filepath"
@@ -82,4 +83,82 @@ func TestSpool_DiscardsUnparseableLine(t *testing.T) {
 	s.replay()
 	_, statErr := os.Stat(filepath.Join(dir, spoolFileName))
 	assert.True(t, os.IsNotExist(statErr), "an unparseable backlog must be cleared, not retried forever")
+}
+
+// The spool is bounded: once at its size cap, further adds are dropped (counted) rather
+// than growing the file unbounded during a sustained SIEM outage.
+func TestSpool_CapBoundsGrowth(t *testing.T) {
+	dir := t.TempDir()
+	d := &fakeDelivery{failing: true}
+	s, err := newSpool(dir, time.Hour, d.deliver)
+	require.NoError(t, err)
+	t.Cleanup(s.close)
+	s.maxBytes = 200 // tiny cap for the test
+
+	tr := true
+	for i := 0; i < 50; i++ {
+		s.add(&models.AuditEvent{ID: uint(i + 1), EventType: "secret.read", Success: &tr})
+	}
+	info, statErr := os.Stat(filepath.Join(dir, spoolFileName))
+	require.NoError(t, statErr)
+	// The cap is checked before each append, so the file can exceed it by at most one line.
+	assert.Less(t, info.Size(), int64(600), "spool must not grow unbounded past its cap")
+}
+
+// A SIEM dir mode is tightened even if it pre-exists with looser perms.
+func TestSpool_TightensExistingDirPerms(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "spool")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	require.NoError(t, os.Chmod(dir, 0o755)) // defeat umask
+	d := &fakeDelivery{}
+	s, err := newSpool(dir, time.Hour, d.deliver)
+	require.NoError(t, err)
+	t.Cleanup(s.close)
+	info, statErr := os.Stat(dir)
+	require.NoError(t, statErr)
+	assert.Equal(t, os.FileMode(0o700), info.Mode().Perm(), "spool dir must be tightened to 0700")
+}
+
+// replay must not lose an event add()ed concurrently during a (slow) delivery: the
+// reconcile preserves lines appended after the snapshot. Here delivery of the snapshot
+// succeeds (file would be removed) while a new event is added mid-replay; it must survive.
+func TestSpool_ConcurrentAddDuringReplayNotLost(t *testing.T) {
+	dir := t.TempDir()
+	tr := true
+	d := &fakeDelivery{}
+	// deliver hook adds a second event the first time it runs, simulating a concurrent
+	// add() arriving while the snapshot is being delivered.
+	var once sync.Once
+	var sp *spool
+	d2 := &fakeDelivery{}
+	hook := func(ctx context.Context, e *models.AuditEvent) error {
+		once.Do(func() { sp.add(&models.AuditEvent{ID: 99, EventType: "late", Success: &tr}) })
+		return d2.deliver(ctx, e)
+	}
+	s, err := newSpool(dir, time.Hour, hook)
+	require.NoError(t, err)
+	sp = s
+	t.Cleanup(s.close)
+
+	s.add(&models.AuditEvent{ID: 1, EventType: "secret.read", Success: &tr})
+	s.replay() // delivers ID 1; ID 99 is add()ed mid-delivery and must not be lost
+
+	_ = d
+	// The invariant: the event added concurrently during a delivery is never LOST — it is
+	// either still in the spool (retained for the next replay) or already delivered by a
+	// subsequent replay. (newSpool's background loop makes the exact split nondeterministic;
+	// the guarantee is no-loss.) Before the lock-free reconcile, an add() during replay
+	// would also have DEADLOCKED on the held mutex — reaching this point at all proves the
+	// lock isn't held across delivery.
+	deliveredLate := false
+	for _, id := range d2.delivered {
+		if id == 99 {
+			deliveredLate = true
+		}
+	}
+	inSpool := false
+	if data, rerr := os.ReadFile(filepath.Join(dir, spoolFileName)); rerr == nil {
+		inSpool = bytes.Contains(data, []byte("\"late\""))
+	}
+	assert.True(t, deliveredLate || inSpool, "the concurrently-added event must be retained or delivered, never lost")
 }

--- a/internal/bundle/bundle.go
+++ b/internal/bundle/bundle.go
@@ -291,11 +291,34 @@ func process(r io.Reader, reg *trust.KeyRegistry, opts *extractOpts) (*Manifest,
 
 	// When staging, gate on no-downgrade BEFORE writing any component, and prepare destDir.
 	if opts != nil {
-		if err := m.CheckUpgrade(opts.installedVersion); err != nil {
-			return nil, err
-		}
 		if strings.TrimSpace(opts.destDir) == "" {
 			return nil, fmt.Errorf("bundle: extract destination is required")
+		}
+		// The PERSISTED installed version (written at the dest by the previous import) is
+		// authoritative over the operator-supplied flag, so the no-downgrade gate enforces
+		// itself on every re-import without relying on the operator passing the right
+		// --installed-version. A present-but-unreadable marker fails closed.
+		installed := strings.TrimSpace(opts.installedVersion)
+		fromMarker := false
+		if marker, ok, merr := readInstalledVersion(opts.destDir); merr != nil {
+			return nil, merr
+		} else if ok {
+			installed, fromMarker = marker, true
+		}
+		// Re-importing the EXACT same version recorded by the marker is an idempotent
+		// re-stage of identical (signature-verified) content — allow it. CheckUpgrade
+		// rejects equal as a non-upgrade, which is right for the operator-asserted flag
+		// (an upgrade check) but would break idempotent re-import against the marker.
+		idempotent := false
+		if fromMarker && installed != "" {
+			if cmp, cerr := compareVersions(m.Version, installed); cerr == nil && cmp == 0 {
+				idempotent = true
+			}
+		}
+		if !idempotent {
+			if err := m.CheckUpgrade(installed); err != nil {
+				return nil, err
+			}
 		}
 		if err := os.MkdirAll(opts.destDir, 0o750); err != nil {
 			return nil, fmt.Errorf("bundle: create destination: %w", err)
@@ -333,7 +356,40 @@ func process(r io.Reader, reg *trust.KeyRegistry, opts *extractOpts) (*Manifest,
 			return nil, fmt.Errorf("%w: %s", ErrMissingComponent, p)
 		}
 	}
+	// Record the just-staged version so a subsequent import enforces no-downgrade against
+	// reality without the operator having to pass --installed-version.
+	if opts != nil {
+		if err := writeInstalledVersion(opts.destDir, m.Version); err != nil {
+			return nil, err
+		}
+	}
 	return &m, nil
+}
+
+// installedVersionMarker is the file at the staging destination recording the version of
+// the last successfully-imported bundle — the authoritative input to the no-downgrade gate.
+const installedVersionMarker = ".keyorix-installed-version"
+
+// readInstalledVersion returns the persisted installed version at destDir. ok is false
+// when no marker exists (a first install); a present-but-unreadable marker is an error
+// (fail closed — don't silently treat a tampered/locked marker as "first install").
+func readInstalledVersion(destDir string) (string, bool, error) {
+	b, err := os.ReadFile(filepath.Join(destDir, installedVersionMarker)) // #nosec G304 -- destDir is operator-configured, marker name is a constant
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", false, nil
+		}
+		return "", false, fmt.Errorf("bundle: read installed-version marker: %w", err)
+	}
+	return strings.TrimSpace(string(b)), true, nil
+}
+
+// writeInstalledVersion persists version as the installed-version marker at destDir.
+func writeInstalledVersion(destDir, version string) error {
+	if err := os.WriteFile(filepath.Join(destDir, installedVersionMarker), []byte(version+"\n"), 0o600); err != nil {
+		return fmt.Errorf("bundle: write installed-version marker: %w", err)
+	}
+	return nil
 }
 
 func optsDest(opts *extractOpts) string {

--- a/internal/bundle/bundle_test.go
+++ b/internal/bundle/bundle_test.go
@@ -370,6 +370,30 @@ func TestExtract_Idempotent(t *testing.T) {
 	}
 }
 
+// After an import, the no-downgrade gate enforces itself against the PERSISTED installed
+// version (the marker written at the dest), so re-importing an OLDER bundle is refused
+// even when the operator passes no --installed-version.
+func TestExtract_PersistedVersionBlocksDowngrade(t *testing.T) {
+	dest := t.TempDir()
+
+	// Install v1.2.0 (no flag → first install, allowed).
+	newRaw, newReg, _ := signedBundle(t, map[string]string{"images/a.tar": "new"}, "v1.2.0", "update-2026", "")
+	if _, err := Extract(bytes.NewReader(newRaw), newReg, dest, ""); err != nil {
+		t.Fatalf("install v1.2.0: %v", err)
+	}
+
+	// Attempt to import an OLDER v1.0.0 with no flag — must be refused via the marker.
+	oldRaw, oldReg, _ := signedBundle(t, map[string]string{"images/a.tar": "old"}, "v1.0.0", "update-2026", "")
+	if _, err := Extract(bytes.NewReader(oldRaw), oldReg, dest, ""); !errors.Is(err, ErrNotUpgrade) {
+		t.Fatalf("downgrade must be refused via the persisted marker, got %v", err)
+	}
+	// The older content must not have overwritten the installed component.
+	got, _ := os.ReadFile(filepath.Join(dest, "images", "a.tar"))
+	if string(got) != "new" {
+		t.Fatalf("downgrade staged content = %q, want the installed 'new'", got)
+	}
+}
+
 // assertDirEmpty fails if dir contains any regular file (temp files included), proving a
 // fail-closed Extract staged nothing.
 func assertDirEmpty(t *testing.T, dir string) {

--- a/internal/cli/common/remote_client.go
+++ b/internal/cli/common/remote_client.go
@@ -6,8 +6,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"net/url"
 	"os"
+	"strings"
 
 	cliconfig "github.com/keyorixhq/keyorix/internal/cli/config"
 	"github.com/keyorixhq/keyorix/internal/config"
@@ -35,21 +38,56 @@ func ResolveRemote() (endpoint, token string, ok bool) {
 		}
 	}
 
-	// Main config (keyorix.yaml — written by 'keyorix auth login --server')
+	// Main config (keyorix.yaml — written by 'keyorix auth login --server'). config.Load
+	// resolves a CWD-relative ./keyorix.yaml, so a type:remote config planted in the
+	// working directory could silently redirect the CLI to an attacker server. Warn when
+	// the remote endpoint/token is sourced from it (env and ~/.keyorix/cli.yaml above are
+	// the trusted sources).
 	if endpoint == "" || token == "" {
 		if mainCfg, err := config.Load(""); err == nil &&
 			mainCfg.Storage.Type == "remote" && mainCfg.Storage.Remote != nil {
-			if endpoint == "" {
+			fromMain := false
+			if endpoint == "" && mainCfg.Storage.Remote.BaseURL != "" {
 				endpoint = mainCfg.Storage.Remote.BaseURL
+				fromMain = true
 			}
-			if token == "" {
+			if token == "" && mainCfg.Storage.Remote.GetAPIKey() != "" {
 				token = mainCfg.Storage.Remote.GetAPIKey()
+				fromMain = true
+			}
+			if fromMain {
+				fmt.Fprintf(os.Stderr, "⚠️  Using a remote server config from ./keyorix.yaml in the current directory. If you did not place it here, a malicious file could be redirecting the CLI — prefer KEYORIX_SERVER/KEYORIX_TOKEN or 'keyorix connect'.\n")
 			}
 		}
 	}
 
+	// A non-HTTPS endpoint sends the bearer token in cleartext — warn loudly (a loopback
+	// target for local testing is fine).
+	if endpoint != "" && !endpointIsSecure(endpoint) {
+		fmt.Fprintf(os.Stderr, "⚠️  Remote endpoint %q is not HTTPS — the access token is sent in cleartext and is MITM-capturable.\n", endpoint)
+	}
+
 	ok = endpoint != "" && token != ""
 	return
+}
+
+// endpointIsSecure reports whether the endpoint is https or a loopback target.
+func endpointIsSecure(endpoint string) bool {
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return false
+	}
+	if u.Scheme == "https" {
+		return true
+	}
+	host := u.Hostname()
+	if host == "localhost" || strings.HasPrefix(host, "127.") || host == "::1" {
+		return true
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return ip.IsLoopback()
+	}
+	return false
 }
 
 // RemoteClient makes authenticated requests to the Keyorix HTTP API.

--- a/internal/cli/connect/connect.go
+++ b/internal/cli/connect/connect.go
@@ -6,11 +6,17 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"syscall"
 	"time"
 
 	cliconfig "github.com/keyorixhq/keyorix/internal/cli/config"
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 )
 
 // ConnectCmd represents the connect command
@@ -36,12 +42,15 @@ var statusCmd = &cobra.Command{
 }
 
 func init() {
-	// Add flags for connect command
-	ConnectCmd.Flags().String("api-key", "", "API key for authentication")
-	ConnectCmd.Flags().String("username", "", "Username for authentication (obtains token automatically)")
-	ConnectCmd.Flags().String("password", "", "Password for authentication (obtains token automatically)")
+	// Add flags for connect command. Secrets default to the secure path (env var /
+	// interactive no-echo prompt); passing them as literal flags is insecure (visible
+	// via ps and saved in shell history) and warned about at runtime.
+	ConnectCmd.Flags().String("api-key", "", "API key (INSECURE on the command line — prefer KEYORIX_API_KEY env var)")
+	ConnectCmd.Flags().String("username", "", "Username for authentication (prompts for the password, or reads KEYORIX_PASSWORD)")
+	ConnectCmd.Flags().String("password", "", "Password (INSECURE on the command line — omit to be prompted, or set KEYORIX_PASSWORD)")
 	ConnectCmd.Flags().String("timeout", "30s", "Request timeout")
 	ConnectCmd.Flags().Bool("test", true, "Test connection before saving")
+	ConnectCmd.Flags().Bool("insecure", false, "Allow a non-HTTPS (cleartext) endpoint — credentials and tokens would be sent unencrypted")
 
 	// Add subcommands
 	ConnectCmd.AddCommand(disconnectCmd)
@@ -50,11 +59,20 @@ func init() {
 
 func runConnect(cmd *cobra.Command, args []string) error {
 	endpoint := args[0]
-	apiKey, _ := cmd.Flags().GetString("api-key")
 	username, _ := cmd.Flags().GetString("username")
-	password, _ := cmd.Flags().GetString("password")
 	timeoutStr, _ := cmd.Flags().GetString("timeout")
 	testConnection, _ := cmd.Flags().GetBool("test")
+
+	// Resolve the API key without ever requiring it on the command line.
+	apiKey := resolveAPIKey(cmd)
+
+	// Refuse to send credentials/tokens over a cleartext (non-HTTPS) endpoint, where a
+	// network attacker could capture them, unless --insecure is explicitly given (and a
+	// loopback target, used for local testing, is always allowed).
+	insecure, _ := cmd.Flags().GetBool("insecure")
+	if err := requireSecureEndpoint(endpoint, insecure); err != nil {
+		return err
+	}
 
 	// Parse timeout
 	timeout, err := time.ParseDuration(timeoutStr)
@@ -64,8 +82,16 @@ func runConnect(cmd *cobra.Command, args []string) error {
 
 	fmt.Printf("🔗 Connecting to %s...\n", endpoint)
 
-	// If username/password provided, log in and get token
-	if username != "" && password != "" {
+	// If a username is provided, log in for a token — resolving the password securely
+	// (interactive no-echo prompt or KEYORIX_PASSWORD), never requiring it on argv.
+	if username != "" {
+		password, perr := resolveConnectPassword(cmd, username)
+		if perr != nil {
+			return perr
+		}
+		if password == "" {
+			return fmt.Errorf("a password is required to log in as %s", username)
+		}
 		fmt.Printf("🔑 Logging in as %s...\n", username)
 		token, err := loginWithCredentials(endpoint, username, password, timeout)
 		if err != nil {
@@ -102,10 +128,76 @@ func runConnect(cmd *cobra.Command, args []string) error {
 	fmt.Printf("🌐 CLI is now in client mode\n")
 
 	if apiKey == "" {
-		fmt.Printf("💡 Tip: Use --api-key flag if the server requires authentication\n")
+		fmt.Printf("💡 Tip: set KEYORIX_API_KEY (preferred over --api-key, which leaks via ps/history)\n")
 	}
 
 	return nil
+}
+
+// requireSecureEndpoint rejects a non-HTTPS endpoint (over which the password/token
+// would travel in cleartext, MITM-capturable) unless the caller opted in with --insecure.
+// A loopback target is always allowed (local development). An https endpoint is fine.
+func requireSecureEndpoint(endpoint string, insecure bool) error {
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return fmt.Errorf("invalid endpoint %q: %w", endpoint, err)
+	}
+	if u.Scheme == "https" {
+		return nil
+	}
+	if isLoopbackHost(u.Hostname()) {
+		return nil
+	}
+	if insecure {
+		fmt.Fprintf(os.Stderr, "⚠️  Connecting to %q over cleartext (%s) — credentials and tokens are sent UNENCRYPTED.\n", endpoint, u.Scheme)
+		return nil
+	}
+	return fmt.Errorf("refusing to connect to a non-HTTPS endpoint %q: credentials/tokens would be sent in cleartext. Use an https:// URL, or pass --insecure to override (not recommended)", endpoint)
+}
+
+// isLoopbackHost reports whether host is localhost or a loopback IP.
+func isLoopbackHost(host string) bool {
+	if host == "localhost" {
+		return true
+	}
+	if strings.HasPrefix(host, "127.") || host == "::1" {
+		return true
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return ip.IsLoopback()
+	}
+	return false
+}
+
+// resolveAPIKey returns the API key from the (insecure, warned) --api-key flag if set,
+// else from the KEYORIX_API_KEY env var. A literal flag value is visible via ps and the
+// shell history, so its use is flagged.
+func resolveAPIKey(cmd *cobra.Command) string {
+	if k, _ := cmd.Flags().GetString("api-key"); k != "" {
+		fmt.Fprintln(os.Stderr, "⚠️  Passing --api-key on the command line is insecure (visible via ps/proc and saved in shell history); prefer the KEYORIX_API_KEY environment variable.")
+		return k
+	}
+	return os.Getenv("KEYORIX_API_KEY")
+}
+
+// resolveConnectPassword obtains the login password without ever requiring it on argv:
+// the (insecure, warned) --password flag if set, else KEYORIX_PASSWORD, else an
+// interactive no-echo prompt (mirroring `keyorix auth login`).
+func resolveConnectPassword(cmd *cobra.Command, username string) (string, error) {
+	if pw, _ := cmd.Flags().GetString("password"); pw != "" {
+		fmt.Fprintln(os.Stderr, "⚠️  Passing --password on the command line is insecure (visible via ps/proc and saved in shell history); omit it to be prompted, or set KEYORIX_PASSWORD.")
+		return pw, nil
+	}
+	if pw := os.Getenv("KEYORIX_PASSWORD"); pw != "" {
+		return pw, nil
+	}
+	fmt.Fprintf(os.Stderr, "Password for %s: ", username)
+	b, err := term.ReadPassword(int(syscall.Stdin))
+	fmt.Fprintln(os.Stderr)
+	if err != nil {
+		return "", fmt.Errorf("failed to read password: %w", err)
+	}
+	return string(b), nil
 }
 
 func runDisconnect(cmd *cobra.Command, args []string) error {

--- a/internal/cli/connect/connect_test.go
+++ b/internal/cli/connect/connect_test.go
@@ -1,0 +1,30 @@
+package connect
+
+import "testing"
+
+func TestRequireSecureEndpoint(t *testing.T) {
+	cases := []struct {
+		name     string
+		endpoint string
+		insecure bool
+		wantErr  bool
+	}{
+		{"https allowed", "https://keyorix.example.com", false, false},
+		{"http loopback allowed", "http://localhost:8080", false, false},
+		{"http 127.0.0.1 allowed", "http://127.0.0.1:8080", false, false},
+		{"http remote refused", "http://server.example.com", false, true},
+		{"http remote allowed with --insecure", "http://server.example.com", true, false},
+		{"garbage endpoint refused", "://nope", false, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := requireSecureEndpoint(tc.endpoint, tc.insecure)
+			if tc.wantErr && err == nil {
+				t.Errorf("requireSecureEndpoint(%q, %v) = nil; want error", tc.endpoint, tc.insecure)
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("requireSecureEndpoint(%q, %v) = %v; want nil", tc.endpoint, tc.insecure, err)
+			}
+		})
+	}
+}

--- a/internal/cli/dynamic/config_create.go
+++ b/internal/cli/dynamic/config_create.go
@@ -17,13 +17,14 @@ import (
 const adminDSNEnv = "KEYORIX_DYNAMIC_ADMIN_DSN"
 
 var (
-	cfgName       string
-	cfgProjectID  int
-	cfgEnvID      int
-	cfgBackend    string
-	cfgTemplate   string
-	cfgDefaultTTL int
-	cfgMaxTTL     int
+	cfgName           string
+	cfgProjectID      int
+	cfgEnvID          int
+	cfgBackend        string
+	cfgTemplate       string
+	cfgDefaultTTL     int
+	cfgMaxTTL         int
+	cfgMaxActiveLease int
 )
 
 var createConfigCmd = &cobra.Command{
@@ -80,6 +81,7 @@ Examples:
 			"creation_template":   cfgTemplate,
 			"default_ttl_seconds": cfgDefaultTTL,
 			"max_ttl_seconds":     cfgMaxTTL,
+			"max_active_leases":   cfgMaxActiveLease,
 		}
 		var out configView
 		if err := c.Post(context.Background(), "/api/v1/dynamic-secrets/configs", body, &out); err != nil {
@@ -119,5 +121,6 @@ func init() {
 	f.StringVar(&cfgTemplate, "creation-template", "", "Backend-specific grant/role/ACL template ({{name}} for SQL)")
 	f.IntVar(&cfgDefaultTTL, "default-ttl", 0, "Default lease TTL in seconds (0 = server default)")
 	f.IntVar(&cfgMaxTTL, "max-ttl", 0, "Max lease TTL ceiling in seconds (0 = no ceiling)")
+	f.IntVar(&cfgMaxActiveLease, "max-active-leases", 0, "Max concurrent active leases from this config (0 = no ceiling)")
 	DynamicSecretCmd.AddCommand(createConfigCmd)
 }

--- a/internal/cli/run/run.go
+++ b/internal/cli/run/run.go
@@ -72,9 +72,11 @@ func runRun(cmd *cobra.Command, args []string) error {
 		fetchErr error
 	)
 
-	// --token flag overrides the token resolved by ResolveRemote.
+	// --token flag overrides the token resolved by ResolveRemote. Passing it literally is
+	// insecure (visible via ps/proc and saved in shell history) — prefer KEYORIX_TOKEN.
 	endpoint, tok, remoteOK := common.ResolveRemote()
 	if runToken != "" {
+		fmt.Fprintln(os.Stderr, "⚠️  Passing --token on the command line is insecure (visible via ps/proc and saved in shell history); prefer the KEYORIX_TOKEN environment variable.")
 		tok = runToken
 		remoteOK = endpoint != ""
 	}

--- a/internal/cli/system/init.go
+++ b/internal/cli/system/init.go
@@ -26,10 +26,11 @@ var (
 	force          bool
 
 	// Remote bootstrap flags (--server triggers a different code path).
-	initServer        string
-	initAdminUsername string
-	initAdminPassword string
-	initAdminEmail    string
+	initServer         string
+	initAdminUsername  string
+	initAdminPassword  string
+	initAdminEmail     string
+	initBootstrapToken string
 )
 
 var InitCmd = &cobra.Command{
@@ -68,6 +69,7 @@ func init() {
 	InitCmd.Flags().StringVar(&initAdminUsername, "admin-username", "admin", "Admin username to create")
 	InitCmd.Flags().StringVar(&initAdminPassword, "admin-password", "admin", "Admin password (change after first login)")
 	InitCmd.Flags().StringVar(&initAdminEmail, "admin-email", "admin@localhost", "Admin email address")
+	InitCmd.Flags().StringVar(&initBootstrapToken, "bootstrap-token", "", "Bootstrap token authorizing first-admin creation (or env KEYORIX_BOOTSTRAP_TOKEN; printed in the server log on first boot)")
 }
 
 func runInit(cmd *cobra.Command, args []string) error {
@@ -222,11 +224,16 @@ func runRemoteInit() error {
 	server := strings.TrimRight(initServer, "/")
 	url := server + "/system/init"
 
+	token := initBootstrapToken
+	if token == "" {
+		token = strings.TrimSpace(os.Getenv("KEYORIX_BOOTSTRAP_TOKEN"))
+	}
 	payload := map[string]string{
-		"username":     initAdminUsername,
-		"email":        initAdminEmail,
-		"password":     initAdminPassword,
-		"display_name": "Administrator",
+		"username":        initAdminUsername,
+		"email":           initAdminEmail,
+		"password":        initAdminPassword,
+		"display_name":    "Administrator",
+		"bootstrap_token": token,
 	}
 	body, err := json.Marshal(payload)
 	if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -554,6 +554,11 @@ type SIEMConfig struct {
 	Endpoint           string `yaml:"endpoint"`
 	Token              string `yaml:"token"` // use KEYORIX_SIEM_TOKEN env var instead
 	InsecureSkipVerify bool   `yaml:"insecure_skip_verify"`
+	// SpoolDir enables a durable on-disk backlog: events that can't be delivered
+	// (full queue / retries exhausted) are persisted here and replayed until the SIEM
+	// accepts them, so a sustained outage doesn't silently lose the off-box copy.
+	// Empty = best-effort only.
+	SpoolDir string `yaml:"spool_dir"`
 }
 
 // GetToken returns the resolved SIEM token, preferring the environment variable.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -467,6 +467,12 @@ type SecurityConfig struct {
 	// for an exponentially-backing-off cooldown. Distinct from the per-IP rate
 	// limiter (ADR-040). Opt-in (default off).
 	LoginLockout LoginLockoutConfig `yaml:"login_lockout"`
+	// RequireTransportTLS, when true, refuses to start an enabled HTTP/gRPC listener
+	// that has no TLS configured — failing closed so bearer tokens and secret values are
+	// never served in cleartext. Default false (a TLS-terminating proxy in front is a
+	// common, supported deployment), but when off the server logs a prominent warning if
+	// it serves cleartext, so the exposure is never silent.
+	RequireTransportTLS bool `yaml:"require_transport_tls"`
 }
 
 // parseDurationDefault parses a Go duration string, returning def when empty or
@@ -1383,10 +1389,14 @@ func (c *Config) Validate() error {
 	}
 
 	if c.Server.GRPC.TLS.Enabled {
-		if !c.Server.GRPC.TLS.AutoCert {
-			if c.Server.GRPC.TLS.CertFile == "" || c.Server.GRPC.TLS.KeyFile == "" {
-				return fmt.Errorf("gRPC TLS is enabled but cert_file or key_file is missing")
-			}
+		// gRPC has no ACME integration: auto_cert would build a TLS config with no
+		// certificate, so every handshake fails (a silent outage). Reject it explicitly
+		// rather than start a server that cannot serve.
+		if c.Server.GRPC.TLS.AutoCert {
+			return fmt.Errorf("gRPC TLS auto_cert is not supported; provide cert_file and key_file")
+		}
+		if c.Server.GRPC.TLS.CertFile == "" || c.Server.GRPC.TLS.KeyFile == "" {
+			return fmt.Errorf("gRPC TLS is enabled but cert_file or key_file is missing")
 		}
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -223,6 +223,13 @@ type ServerInstanceConfig struct {
 	// JSON request); a negative value disables the cap (for endpoints that legitimately
 	// accept very large bodies).
 	MaxRequestBodyBytes int64 `yaml:"max_request_body_bytes,omitempty"`
+	// TrustedProxies is the set of reverse-proxy/load-balancer source addresses (CIDRs
+	// or bare IPs) whose X-Forwarded-For / X-Real-IP header is honored when deriving the
+	// client IP. When empty, those headers are IGNORED and the real TCP peer is used —
+	// so a client cannot spoof its source IP (which would otherwise defeat the per-IP
+	// login/MFA rate limiter) unless it actually connects from a trusted proxy. Set this
+	// to your ingress/LB CIDR(s) when running behind a proxy. (HTTP only.)
+	TrustedProxies []string `yaml:"trusted_proxies,omitempty"`
 	// Web dashboard specific settings (HTTP only)
 	WebAssetsPath  string   `yaml:"web_assets_path,omitempty"`
 	AllowedOrigins []string `yaml:"allowed_origins,omitempty"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -406,6 +406,14 @@ type KeyProviderConfig struct {
 	// WrappedKeyPath is where the KMS-wrapped KEK blob lives (aws-kms / gcp-kms /
 	// azure-kms).
 	WrappedKeyPath string `yaml:"wrapped_key_path"`
+	// KMSEncryptionContext binds the wrapped KEK to this install (aws-kms /gcp-kms):
+	// it's passed as the AWS EncryptionContext / GCP AdditionalAuthenticatedData on
+	// wrap+unwrap, so a different install sharing the same CMK cannot unwrap this
+	// install's KEK. Set a value unique to the install, e.g. {keyorix-install: <id>}.
+	// Empty = no binding (the prior behaviour). Not supported by azure-kms (RSA wrap
+	// has no AAD). Existing wrapped blobs decrypt via a no-context fallback, so this
+	// can be enabled on a running install (it binds on the next KEK re-wrap).
+	KMSEncryptionContext map[string]string `yaml:"kms_encryption_context"`
 	// ExecCommand is the argv for type "exec": the resolver command (argv[0] is the
 	// binary, the rest are arguments) whose stdout supplies the KEK as raw 32 bytes
 	// or a hex/base64 encoding thereof. Run directly without a shell. Lets a

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -899,11 +899,19 @@ type NotificationWebhookConfig struct {
 	Endpoint           string `yaml:"endpoint"`
 	Token              string `yaml:"token"` // use KEYORIX_NOTIFY_WEBHOOK_TOKEN env var instead
 	InsecureSkipVerify bool   `yaml:"insecure_skip_verify"`
+	// SigningSecret HMAC-signs each payload (X-Keyorix-Signature) so the receiver can
+	// verify authenticity. Use KEYORIX_NOTIFY_WEBHOOK_SIGNING_SECRET instead of the file.
+	SigningSecret string `yaml:"signing_secret"`
 }
 
 // GetToken returns the resolved webhook token, preferring the environment variable.
 func (c *NotificationWebhookConfig) GetToken() string {
 	return resolveSecret("KEYORIX_NOTIFY_WEBHOOK_TOKEN", c.Token)
+}
+
+// GetSigningSecret returns the resolved webhook signing secret, preferring the env var.
+func (c *NotificationWebhookConfig) GetSigningSecret() string {
+	return resolveSecret("KEYORIX_NOTIFY_WEBHOOK_SIGNING_SECRET", c.SigningSecret)
 }
 
 // SCIMConfig configures SCIM 2.0 provisioning (RFC 7644). When Enabled, the

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1137,10 +1137,17 @@ func (c RotationRemindersConfig) GetInterval() time.Duration {
 }
 
 // AuditCheckpointsConfig configures the audit-checkpoint scheduler: a background
-// job that signs the audit hash-chain head (ADR-029) so tail-truncation / re-seed
-// is detectable on-box. Opt-in (default off); requires encryption enabled.
+// job that signs the audit hash-chain head (ADR-029) so tampering, tail-truncation,
+// and genesis re-seed are detectable. This is the audit trail's forgery-resistance
+// layer — the per-row hash chain alone is unkeyed and a database-write attacker can
+// recompute it, so without signed checkpoints the trail is only tamper-EVIDENT, not
+// forgery-resistant. It is therefore enabled BY DEFAULT whenever a signing key is
+// available (encryption configured). Set Disabled to opt out (a loud warning is
+// logged). Enabled is retained for backward compatibility and is now redundant with
+// the default-on behavior.
 type AuditCheckpointsConfig struct {
 	Enabled  bool   `yaml:"enabled"`
+	Disabled bool   `yaml:"disabled"`
 	Schedule string `yaml:"schedule"`
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -464,8 +464,10 @@ type SecurityConfig struct {
 	RequireMFA bool `yaml:"require_mfa"`
 	// LoginLockout configures per-account login lockout (brute-force protection):
 	// after MaxAttempts failed password logins within Window, the account is locked
-	// for an exponentially-backing-off cooldown. Distinct from the per-IP rate
-	// limiter (ADR-040). Opt-in (default off).
+	// for an exponentially-backing-off cooldown. Distinct from (and complementary to)
+	// the per-IP rate limiter, which a distributed/botnet guess against one account can
+	// evade. It is ENABLED BY DEFAULT — a secrets-manager login must resist online
+	// guessing out of the box. Set login_lockout.disabled to opt out.
 	LoginLockout LoginLockoutConfig `yaml:"login_lockout"`
 	// RequireTransportTLS, when true, refuses to start an enabled HTTP/gRPC listener
 	// that has no TLS configured — failing closed so bearer tokens and secret values are
@@ -487,9 +489,12 @@ func parseDurationDefault(raw string, def time.Duration) time.Duration {
 	return def
 }
 
-// LoginLockoutConfig configures per-account login lockout.
+// LoginLockoutConfig configures per-account login lockout. Lockout is enabled by
+// default; Disabled is the explicit opt-out. Enabled is retained for backward
+// compatibility and is now redundant with the default-on behavior.
 type LoginLockoutConfig struct {
 	Enabled      bool   `yaml:"enabled"`
+	Disabled     bool   `yaml:"disabled"`      // explicit opt-out (lockout is on by default)
 	MaxAttempts  int    `yaml:"max_attempts"`  // failures within the window before locking (default 5)
 	Window       string `yaml:"window"`        // Go duration; consecutive-failure window (default 15m)
 	BaseCooldown string `yaml:"base_cooldown"` // lock duration for the first lockout (default 1m)

--- a/internal/config/config_load_test.go
+++ b/internal/config/config_load_test.go
@@ -98,3 +98,14 @@ func yamlUnmarshalForTest(t *testing.T, y string, c *Config) error {
 	*c = *loaded
 	return nil
 }
+
+// gRPC TLS auto_cert has no ACME backing (it would build a certless config and fail every
+// handshake), so Validate must reject it rather than start a server that cannot serve.
+func TestValidate_RejectsGRPCAutoCert(t *testing.T) {
+	c := &Config{}
+	c.Server.GRPC.TLS.Enabled = true
+	c.Server.GRPC.TLS.AutoCert = true
+	err := c.Validate()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "auto_cert")
+}

--- a/internal/core/access_review_campaign.go
+++ b/internal/core/access_review_campaign.go
@@ -71,6 +71,10 @@ func tallyProgress(items []*models.AccessReviewItem) CampaignProgress {
 // campaign's items (each pending) and returns the campaign with its (all-pending)
 // progress. actorID is the opener.
 func (c *KeyorixCore) OpenAccessReviewCampaign(ctx context.Context, actorID, projectID uint, name string) (*CampaignWithProgress, error) {
+	// Note: opening is NOT gated on a human actor — the scheduler legitimately auto-opens
+	// overdue campaigns as a system action (actorID==0). Opening only generates review
+	// items; the attributable-human requirement is enforced on the DECISION (attest/
+	// revoke) in DecideAccessReviewItem, which is the actual recertification control.
 	if projectID == 0 {
 		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "project ID is required")
 	}
@@ -171,6 +175,14 @@ func (c *KeyorixCore) GetAccessReviewCampaign(ctx context.Context, projectID, ca
 // campaign: "attest" keeps the grant (evidence only), "revoke" removes the
 // underlying grant via RevokeAccessReviewGrant. actorID is the reviewer.
 func (c *KeyorixCore) DecideAccessReviewItem(ctx context.Context, actorID, projectID, campaignID, itemID uint, action, reason string) error {
+	// A recertification decision must come from an attributable HUMAN reviewer. A
+	// machine identity authenticates with UserID==0 (authz uses its PrincipalID), so a
+	// non-zero actorID is required — otherwise an automation token holding roles.assign
+	// could rubber-stamp a campaign with the evidence recording reviewer "0"/nil, and the
+	// self-review independence check below (keyed on actorID) would be a no-op for it.
+	if err := requireHumanReviewer(actorID); err != nil {
+		return err
+	}
 	campaign, err := c.loadScopedCampaign(ctx, projectID, campaignID)
 	if err != nil {
 		return err
@@ -230,6 +242,17 @@ func (c *KeyorixCore) DecideAccessReviewItem(ctx context.Context, actorID, proje
 	item.DecidedAt = &now
 	if err := c.storage.UpdateAccessReviewItem(ctx, item); err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	return nil
+}
+
+// requireHumanReviewer rejects a recertification action by a non-human / unattributable
+// actor. A machine identity authenticates with UserID==0 (it authorizes via PrincipalID),
+// and actorID==0 also denotes an unauthenticated local invocation — neither is an
+// attributable, independent human reviewer, which the SOC2/ISO/NIS2 control requires.
+func requireHumanReviewer(actorID uint) error {
+	if actorID == 0 {
+		return fmt.Errorf("%s: %s", i18n.T("ErrorPermissionDenied", nil), "access reviews require an attributable human reviewer (a machine identity cannot act as a reviewer)")
 	}
 	return nil
 }

--- a/internal/core/access_review_campaign.go
+++ b/internal/core/access_review_campaign.go
@@ -191,11 +191,15 @@ func (c *KeyorixCore) DecideAccessReviewItem(ctx context.Context, actorID, proje
 	if item.Decision != ReviewItemPending {
 		return fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "this item has already been decided")
 	}
-	// Independence (ISO 27001 A.5.18): a reviewer must not certify their OWN access.
-	// Self-certification defeats the control, so a user can't decide a user-scoped
-	// item that is themselves — an independent reviewer is required.
+	// Independence (ISO 27001 A.5.18): a reviewer must not certify their OWN access —
+	// directly (a user-scoped item that is themselves) OR indirectly (a group-scoped item
+	// for a group they belong to). Self-certification, including via a group grant,
+	// defeats the control; an independent reviewer is required.
 	if item.PrincipalType == "user" && item.PrincipalID == actorID {
 		return fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "you cannot review your own access; an independent reviewer is required")
+	}
+	if item.PrincipalType == "group" && c.userInGroup(ctx, actorID, item.PrincipalID) {
+		return fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "you cannot review access for a group you belong to; an independent reviewer is required")
 	}
 
 	decision := AccessReviewDecision{
@@ -228,6 +232,22 @@ func (c *KeyorixCore) DecideAccessReviewItem(ctx context.Context, actorID, proje
 		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}
 	return nil
+}
+
+// userInGroup reports whether userID is a member of groupID. It fails CLOSED — a
+// lookup error returns true — because it backs the recertification independence check:
+// if we can't prove the reviewer is NOT in the group, we must not let them certify it.
+func (c *KeyorixCore) userInGroup(ctx context.Context, userID, groupID uint) bool {
+	groups, err := c.storage.GetUserGroups(ctx, userID)
+	if err != nil {
+		return true
+	}
+	for _, g := range groups {
+		if g.ID == groupID {
+			return true
+		}
+	}
+	return false
 }
 
 // CloseAccessReviewCampaign freezes a campaign as the evidence record. It refuses

--- a/internal/core/access_review_campaign_external_test.go
+++ b/internal/core/access_review_campaign_external_test.go
@@ -119,6 +119,38 @@ func TestDecideAccessReviewItem_RejectsSelfCertification(t *testing.T) {
 	require.NoError(t, h.CoreService.DecideAccessReviewItem(ctx, 1, proj, res.Campaign.ID, item, "attest", ""))
 }
 
+// A recertification decision requires an attributable HUMAN reviewer. A machine identity
+// authenticates with UserID==0, so actorID==0 is refused — otherwise an automation token
+// could rubber-stamp a campaign with the evidence recording reviewer "0"/nil, and the
+// self-review independence check (keyed on actorID) would be inert for it.
+func TestDecideAccessReviewItem_RejectsNonHumanReviewer(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	migrateCampaignTables(t, h)
+
+	const proj = uint(2)
+	ctx := context.Background()
+	h.CreateTestUser(t, "alice", 10)
+	h.AssignUserRole(t, 10, 3, uptr(proj))
+
+	res, err := h.CoreService.OpenAccessReviewCampaign(ctx, 1, proj, "review")
+	require.NoError(t, err)
+	detail, err := h.CoreService.GetAccessReviewCampaign(ctx, proj, res.Campaign.ID)
+	require.NoError(t, err)
+	require.Len(t, detail.Items, 1)
+	item := detail.Items[0].ID
+
+	// actorID 0 (machine identity / unattributable) cannot decide.
+	err = h.CoreService.DecideAccessReviewItem(ctx, 0, proj, res.Campaign.ID, item, "attest", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "attributable human reviewer")
+
+	// The item is untouched — still pending, not silently attested.
+	detail, err = h.CoreService.GetAccessReviewCampaign(ctx, proj, res.Campaign.ID)
+	require.NoError(t, err)
+	assert.Equal(t, core.ReviewItemPending, detail.Items[0].Decision)
+}
+
 // Independence extends to GROUP-conferred access: a reviewer who belongs to a group
 // must not certify that group's review item (self-certification via a group grant).
 func TestDecideAccessReviewItem_RejectsGroupSelfCertification(t *testing.T) {

--- a/internal/core/access_review_campaign_external_test.go
+++ b/internal/core/access_review_campaign_external_test.go
@@ -119,6 +119,42 @@ func TestDecideAccessReviewItem_RejectsSelfCertification(t *testing.T) {
 	require.NoError(t, h.CoreService.DecideAccessReviewItem(ctx, 1, proj, res.Campaign.ID, item, "attest", ""))
 }
 
+// Independence extends to GROUP-conferred access: a reviewer who belongs to a group
+// must not certify that group's review item (self-certification via a group grant).
+func TestDecideAccessReviewItem_RejectsGroupSelfCertification(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	migrateCampaignTables(t, h)
+
+	const proj = uint(2)
+	ctx := context.Background()
+	h.CreateTestUser(t, "carol", 20)
+	g := h.CreateTestGroup(t, "team", "", 5)
+	h.AssignGroupRole(t, g.ID, 3, uptr(proj)) // the group holds a role in the project
+	h.AssignUserToGroup(t, 20, g.ID)          // carol is a member
+
+	res, err := h.CoreService.OpenAccessReviewCampaign(ctx, 1, proj, "review")
+	require.NoError(t, err)
+	detail, err := h.CoreService.GetAccessReviewCampaign(ctx, proj, res.Campaign.ID)
+	require.NoError(t, err)
+
+	var groupItem uint
+	for _, it := range detail.Items {
+		if it.PrincipalType == "group" && it.PrincipalID == g.ID {
+			groupItem = it.ID
+		}
+	}
+	require.NotZero(t, groupItem, "expected a group-source review item")
+
+	// Carol (a member of the group) cannot self-certify the group's access...
+	err = h.CoreService.DecideAccessReviewItem(ctx, 20, proj, res.Campaign.ID, groupItem, "attest", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "group you belong to")
+
+	// ...but an independent reviewer (not a member) can.
+	require.NoError(t, h.CoreService.DecideAccessReviewItem(ctx, 1, proj, res.Campaign.ID, groupItem, "attest", ""))
+}
+
 // An item is decided once: a decided item can't be flipped, so the recorded decision
 // can't drift from the real grant state (false certification evidence).
 func TestDecideAccessReviewItem_RejectsDoubleDecision(t *testing.T) {

--- a/internal/core/account.go
+++ b/internal/core/account.go
@@ -56,14 +56,18 @@ func (c *KeyorixCore) ChangePassword(ctx context.Context, userID uint, current, 
 		return err
 	}
 
-	// Drop other sessions. Best-effort: the password change itself has succeeded.
+	// Drop OTHER sessions and evict them from the auth cache, so a thief holding a
+	// stolen session is locked out immediately on the next request — not after the
+	// cache TTL. Best-effort: the password change itself has succeeded.
 	var keepID uint
+	var keepHash string
 	if keepSessionToken != "" {
 		if s, serr := c.storage.GetSession(ctx, keepSessionToken); serr == nil {
 			keepID = s.ID
+			keepHash = s.SessionToken
 		}
 	}
-	_ = c.storage.DeleteSessionsForUserExcept(ctx, userID, keepID)
+	_ = c.deleteSessionsForUserAndEvict(ctx, userID, keepID, keepHash)
 	return nil
 }
 
@@ -84,6 +88,23 @@ func (c *KeyorixCore) invalidateTokenCache(hashes ...string) {
 			c.tokenCacheInvalidator(h)
 		}
 	}
+}
+
+// deleteSessionsForUserAndEvict deletes all of the user's sessions except keepID and
+// evicts the deleted sessions from the HTTP auth cache, so a revoked session stops
+// authenticating on the very NEXT request rather than lingering for the positive-cache
+// TTL. The stored session_token IS the SHA-256 cache key. keepHash (the kept session's
+// stored hash, or "") is never evicted, so the caller's own session is not disturbed.
+// Best-effort: the session deletion is the durable control; eviction is the immediacy.
+func (c *KeyorixCore) deleteSessionsForUserAndEvict(ctx context.Context, userID, keepID uint, keepHash string) error {
+	hashes, _ := c.storage.ListSessionTokenHashesForUser(ctx, userID)
+	err := c.storage.DeleteSessionsForUserExcept(ctx, userID, keepID)
+	for _, h := range hashes {
+		if h != "" && h != keepHash {
+			c.invalidateTokenCache(h)
+		}
+	}
+	return err
 }
 
 // validateNewPassword checks a candidate password against the configured policy and
@@ -209,5 +230,11 @@ func (c *KeyorixCore) RevokeOwnSession(ctx context.Context, userID, sessionID ui
 	if err != nil || session.UserID != userID {
 		return fmt.Errorf("%s: session not found", i18n.T("ErrorNotFound", nil))
 	}
-	return c.storage.DeleteSession(ctx, sessionID)
+	if err := c.storage.DeleteSession(ctx, sessionID); err != nil {
+		return err
+	}
+	// Evict the revoked session from the auth cache so the device is logged out on its
+	// next request, not after the positive-cache TTL. session_token is the cache key.
+	c.invalidateTokenCache(session.SessionToken)
+	return nil
 }

--- a/internal/core/account.go
+++ b/internal/core/account.go
@@ -67,6 +67,25 @@ func (c *KeyorixCore) ChangePassword(ctx context.Context, userID uint, current, 
 	return nil
 }
 
+// SetTokenCacheInvalidator wires the HTTP auth-cache eviction function (by token hash)
+// so core token-revocation paths can evict immediately. Called once at startup.
+func (c *KeyorixCore) SetTokenCacheInvalidator(fn func(hash string)) {
+	c.tokenCacheInvalidator = fn
+}
+
+// invalidateTokenCache evicts the given token hashes from the auth cache when an
+// invalidator is wired (a no-op otherwise — e.g. tests, where the cache doesn't exist).
+func (c *KeyorixCore) invalidateTokenCache(hashes ...string) {
+	if c.tokenCacheInvalidator == nil {
+		return
+	}
+	for _, h := range hashes {
+		if h != "" {
+			c.tokenCacheInvalidator(h)
+		}
+	}
+}
+
 // validateNewPassword checks a candidate password against the configured policy and
 // the password-history rule, without mutating anything. Split from applyNewPassword
 // so callers (e.g. the setup-token consume flow) can reject a weak password BEFORE
@@ -105,6 +124,14 @@ func (c *KeyorixCore) applyNewPassword(ctx context.Context, user *models.User, n
 	if c.passwordPolicy.HistoryCount > 0 {
 		_ = c.storage.AddPasswordHistory(ctx, user.ID, string(hash), now)
 		_ = c.storage.PrunePasswordHistory(ctx, user.ID, c.passwordPolicy.HistoryCount)
+	}
+
+	// Revoke the user's PATs too. A credential change must invalidate EVERY bearer class,
+	// not just sessions — otherwise a thief who minted a (possibly non-expiring) PAT from a
+	// stolen session survives the victim's reset. Best-effort; evict each from the auth
+	// cache immediately so a revoked PAT can't keep authenticating for the cache TTL.
+	if hashes, herr := c.storage.RevokeAllPersonalAccessTokensForUser(ctx, user.ID); herr == nil {
+		c.invalidateTokenCache(hashes...)
 	}
 	return nil
 }

--- a/internal/core/account_sessions.go
+++ b/internal/core/account_sessions.go
@@ -35,6 +35,13 @@ func (c *KeyorixCore) RevokeUserSessions(ctx context.Context, adminID, userID ui
 	if err := c.storage.DeleteSessionsForUserExcept(ctx, userID, 0); err != nil {
 		return 0, fmt.Errorf("failed to revoke sessions: %w", err)
 	}
+	// Evict every revoked session from the HTTP auth cache so a compromised token stops
+	// authenticating on the NEXT request instead of lingering for the positive-cache TTL
+	// — this is the incident-response control, so the residual window matters. The stored
+	// session_token IS the SHA-256 cache key.
+	for _, s := range sessions {
+		c.invalidateTokenCache(s.SessionToken)
+	}
 
 	aid := adminID
 	c.writeAuditEventFull(ctx, EventUserSessionsRevoked, &aid, nil, nil, "",

--- a/internal/core/account_sessions_test.go
+++ b/internal/core/account_sessions_test.go
@@ -35,6 +35,11 @@ func TestRevokeUserSessions(t *testing.T) {
 	mkSession(11, 2, "t-b") // target's
 	mkSession(12, 3, "b-a") // bystander's — must survive
 
+	// Capture auth-cache evictions so we can prove the revoked sessions are evicted (so a
+	// compromised token can't keep authenticating on the cache fast path for the TTL).
+	var evicted []string
+	c.SetTokenCacheInvalidator(func(h string) { evicted = append(evicted, h) })
+
 	t.Run("revokes all of the target's sessions, leaves others", func(t *testing.T) {
 		n, err := c.RevokeUserSessions(ctx, 1, 2)
 		require.NoError(t, err)
@@ -47,6 +52,11 @@ func TestRevokeUserSessions(t *testing.T) {
 		other, err := c.storage.ListSessionsByUser(ctx, 3)
 		require.NoError(t, err)
 		assert.Len(t, other, 1, "bystander's session untouched")
+
+		// Both of the target's session hashes were evicted from the auth cache;
+		// the bystander's was not.
+		assert.ElementsMatch(t, []string{"t-a", "t-b"}, evicted)
+		assert.NotContains(t, evicted, "b-a")
 	})
 
 	t.Run("the account state is unchanged (force-logout, not suspend)", func(t *testing.T) {

--- a/internal/core/account_state.go
+++ b/internal/core/account_state.go
@@ -109,17 +109,31 @@ func (c *KeyorixCore) setAccountState(ctx context.Context, adminID, userID uint,
 	if err != nil {
 		return fmt.Errorf("user not found: %w", err)
 	}
+	// Capture the user's current session-token HASHES BEFORE mutating so we can evict their
+	// auth-cache entries. The HTTP auth cache fast path serves a frozen identity without
+	// re-reading the DB, so without eviction a suspend/deactivate/restrict would not take
+	// effect until the positive-cache TTL — a window where a blocked user keeps full access.
+	// The stored session_token IS the SHA-256 hash, which is exactly the cache key.
+	sessionHashes, _ := c.storage.ListSessionTokenHashesForUser(ctx, userID)
+
 	user.AccountState = state
 	user.UpdatedAt = c.now()
 	if _, err := c.storage.UpdateUser(ctx, user); err != nil {
 		return fmt.Errorf("failed to update account state: %w", err)
 	}
-	// A state that blocks login must also terminate the user's existing sessions,
-	// so suspension is effective immediately instead of lingering until the token
-	// expires. ValidateSessionToken also rejects blocked accounts as a backstop.
+	// A state that blocks login must also terminate the user's existing sessions AND PATs,
+	// so suspension is effective immediately instead of lingering until the token expires.
+	// ValidateSessionToken/ValidatePATToken also reject blocked accounts as a slow-path
+	// backstop, but the cache fast path bypasses it — so evict here too.
 	if AccountLoginBlocked(state) {
 		_ = c.storage.DeleteSessionsForUserExcept(ctx, userID, 0)
+		if hashes, herr := c.storage.RevokeAllPersonalAccessTokensForUser(ctx, userID); herr == nil {
+			c.invalidateTokenCache(hashes...)
+		}
 	}
+	// Evict the captured session-token hashes from the auth cache so the new state (blocked,
+	// or merely restricted) is reflected on the very next request, not after the cache TTL.
+	c.invalidateTokenCache(sessionHashes...)
 	aid := adminID
 	c.writeAuditEventFull(ctx, eventType, &aid, nil, nil, "",
 		fmt.Sprintf("user %d account state set to %s", userID, state))

--- a/internal/core/account_state_test.go
+++ b/internal/core/account_state_test.go
@@ -188,6 +188,7 @@ func TestChangePassword_ClearsRestriction(t *testing.T) {
 	store.On("PrunePasswordHistory", ctx, uint(1), 5).Return(nil)
 	store.On("GetSession", ctx, "tok").Return(&models.Session{ID: 7, UserID: 1}, nil)
 	store.On("DeleteSessionsForUserExcept", ctx, uint(1), uint(7)).Return(nil)
+	store.On("RevokeAllPersonalAccessTokensForUser", mock.Anything, mock.Anything).Return(nil, nil)
 
 	err := c.ChangePassword(ctx, 1, "oldpassword", "Brandnew#Passw0rd!", "tok")
 	require.NoError(t, err)

--- a/internal/core/account_state_test.go
+++ b/internal/core/account_state_test.go
@@ -190,6 +190,7 @@ func TestChangePassword_ClearsRestriction(t *testing.T) {
 	store.On("AddPasswordHistory", ctx, uint(1), mock.AnythingOfType("string"), mock.Anything).Return(nil)
 	store.On("PrunePasswordHistory", ctx, uint(1), 5).Return(nil)
 	store.On("GetSession", ctx, "tok").Return(&models.Session{ID: 7, UserID: 1}, nil)
+	store.On("ListSessionTokenHashesForUser", ctx, uint(1)).Return([]string{}, nil)
 	store.On("DeleteSessionsForUserExcept", ctx, uint(1), uint(7)).Return(nil)
 	store.On("RevokeAllPersonalAccessTokensForUser", mock.Anything, mock.Anything).Return(nil, nil)
 

--- a/internal/core/account_state_test.go
+++ b/internal/core/account_state_test.go
@@ -59,9 +59,12 @@ func TestAdminAccountTransitions(t *testing.T) {
 			store.On("LogAuditEvent", ctx, mock.MatchedBy(func(e *models.AuditEvent) bool {
 				return e.EventType == tc.event
 			})).Return(nil)
-			// A login-blocking transition (suspend) must purge the user's sessions.
+			// Every state change evicts the user's cached session tokens from the auth cache.
+			store.On("ListSessionTokenHashesForUser", ctx, uint(2)).Return([]string{}, nil)
+			// A login-blocking transition (suspend) must purge the user's sessions AND PATs.
 			if AccountLoginBlocked(tc.wantState) {
 				store.On("DeleteSessionsForUserExcept", ctx, uint(2), uint(0)).Return(nil)
+				store.On("RevokeAllPersonalAccessTokensForUser", ctx, uint(2)).Return([]string{}, nil)
 			}
 
 			require.NoError(t, tc.call(c, ctx))

--- a/internal/core/account_test.go
+++ b/internal/core/account_test.go
@@ -61,6 +61,7 @@ func TestChangePassword(t *testing.T) {
 		ms.On("GetUser", ctx, uint(1)).Return(user, nil)
 		ms.On("UpdateUser", ctx, mock.AnythingOfType("*models.User")).Return(user, nil)
 		ms.On("GetSession", ctx, "current-token").Return(&models.Session{ID: 7, UserID: 1}, nil)
+		ms.On("ListSessionTokenHashesForUser", ctx, uint(1)).Return([]string{}, nil)
 		ms.On("DeleteSessionsForUserExcept", ctx, uint(1), uint(7)).Return(nil)
 		ms.On("RevokeAllPersonalAccessTokensForUser", mock.Anything, mock.Anything).Return(nil, nil)
 		// History rule (default HistoryCount=5): no prior hashes, then record + prune.
@@ -87,6 +88,7 @@ func TestChangePassword(t *testing.T) {
 		ms.On("GetUser", ctx, uint(1)).Return(user, nil)
 		ms.On("UpdateUser", ctx, mock.AnythingOfType("*models.User")).Return(user, nil)
 		ms.On("GetSession", ctx, "current-token").Return(&models.Session{ID: 7, UserID: 1}, nil)
+		ms.On("ListSessionTokenHashesForUser", ctx, uint(1)).Return([]string{}, nil)
 		ms.On("DeleteSessionsForUserExcept", ctx, uint(1), uint(7)).Return(nil)
 		// Two active PATs are revoked and their hashes returned for cache eviction.
 		ms.On("RevokeAllPersonalAccessTokensForUser", ctx, uint(1)).Return([]string{"hash-a", "hash-b"}, nil)

--- a/internal/core/account_test.go
+++ b/internal/core/account_test.go
@@ -62,6 +62,7 @@ func TestChangePassword(t *testing.T) {
 		ms.On("UpdateUser", ctx, mock.AnythingOfType("*models.User")).Return(user, nil)
 		ms.On("GetSession", ctx, "current-token").Return(&models.Session{ID: 7, UserID: 1}, nil)
 		ms.On("DeleteSessionsForUserExcept", ctx, uint(1), uint(7)).Return(nil)
+		ms.On("RevokeAllPersonalAccessTokensForUser", mock.Anything, mock.Anything).Return(nil, nil)
 		// History rule (default HistoryCount=5): no prior hashes, then record + prune.
 		ms.On("RecentPasswordHashes", ctx, uint(1), 5).Return([]string{}, nil)
 		ms.On("AddPasswordHistory", ctx, uint(1), mock.AnythingOfType("string"), mock.Anything).Return(nil)
@@ -74,6 +75,28 @@ func TestChangePassword(t *testing.T) {
 		assert.NoError(t, bcrypt.CompareHashAndPassword([]byte(user.PasswordHash), []byte(newPw)))
 		ms.AssertCalled(t, "DeleteSessionsForUserExcept", ctx, uint(1), uint(7))
 		ms.AssertCalled(t, "AddPasswordHistory", ctx, uint(1), mock.AnythingOfType("string"), mock.Anything)
+	})
+
+	t.Run("revokes the user's PATs and evicts them from the auth cache", func(t *testing.T) {
+		ms := new(MockStorage)
+		c := NewKeyorixCore(ms)
+		var evicted []string
+		c.SetTokenCacheInvalidator(func(h string) { evicted = append(evicted, h) })
+		user := &models.User{ID: 1, Username: acctTestUser, PasswordHash: string(oldHash)}
+
+		ms.On("GetUser", ctx, uint(1)).Return(user, nil)
+		ms.On("UpdateUser", ctx, mock.AnythingOfType("*models.User")).Return(user, nil)
+		ms.On("GetSession", ctx, "current-token").Return(&models.Session{ID: 7, UserID: 1}, nil)
+		ms.On("DeleteSessionsForUserExcept", ctx, uint(1), uint(7)).Return(nil)
+		// Two active PATs are revoked and their hashes returned for cache eviction.
+		ms.On("RevokeAllPersonalAccessTokensForUser", ctx, uint(1)).Return([]string{"hash-a", "hash-b"}, nil)
+		ms.On("RecentPasswordHashes", ctx, uint(1), 5).Return([]string{}, nil)
+		ms.On("AddPasswordHistory", ctx, uint(1), mock.AnythingOfType("string"), mock.Anything).Return(nil)
+		ms.On("PrunePasswordHistory", ctx, uint(1), 5).Return(nil)
+
+		require.NoError(t, c.ChangePassword(ctx, 1, "oldpassword", "Brandnew#Passw0rd!", "current-token"))
+		ms.AssertCalled(t, "RevokeAllPersonalAccessTokensForUser", ctx, uint(1))
+		assert.ElementsMatch(t, []string{"hash-a", "hash-b"}, evicted, "revoked PAT hashes are evicted from the auth cache")
 	})
 
 	t.Run("rejects reuse of a recent password", func(t *testing.T) {

--- a/internal/core/anomaly.go
+++ b/internal/core/anomaly.go
@@ -15,7 +15,15 @@ type AnomalyDetector struct {
 	storage  StorageInterface
 	ml       MLConfig       // ML pass; disabled by default (see SetMLConfig)
 	offHours offHoursPolicy // off_hours rule window; defaults to UTC 22:00–06:00
+	// lookback is how far back each pass scans. It must be >= the scheduler interval, or
+	// the access logs between (now-lookback) and the prior run go unexamined by any rule
+	// — a coverage blind spot when the operator sets a scan cadence longer than the
+	// default. Defaults to 1h; SetLookback raises it to match the configured interval.
+	lookback time.Duration
 }
+
+// minDetectionLookback is the floor for the per-pass scan window.
+const minDetectionLookback = time.Hour
 
 // StorageInterface is satisfied by *storage.LocalStorage and *storage.RemoteStorage.
 type StorageInterface = interface {
@@ -25,10 +33,21 @@ type StorageInterface = interface {
 	AcknowledgeAnomalyAlert(ctx context.Context, id uint) error
 }
 
+// SetLookback sets how far back each detection pass scans, flooring it at one hour. The
+// scheduler should set this to its scan interval so consecutive passes cover a
+// contiguous timeline (a longer cadence must scan a proportionally longer window, else
+// the gap between passes is never analysed).
+func (d *AnomalyDetector) SetLookback(window time.Duration) {
+	if window < minDetectionLookback {
+		window = minDetectionLookback
+	}
+	d.lookback = window
+}
+
 // NewAnomalyDetector creates a new AnomalyDetector with the ML pass disabled and the
 // off-hours window at its UTC 22:00–06:00 default.
 func NewAnomalyDetector(storage StorageInterface) *AnomalyDetector {
-	return &AnomalyDetector{storage: storage, offHours: defaultOffHoursPolicy()}
+	return &AnomalyDetector{storage: storage, offHours: defaultOffHoursPolicy(), lookback: minDetectionLookback}
 }
 
 // SetMLConfig enables (or reconfigures) the Isolation Forest pass. Defaults are
@@ -106,17 +125,26 @@ type accessBaseline struct {
 	dailyAvg   float64 // average accesses per day over last 7 days
 }
 
-// RunDetection analyses SecretAccessLog for the past hour and emits AnomalyAlert rows.
-// Safe to call on a schedule — idempotent per detection window.
+// RunDetection analyses SecretAccessLog over the configured lookback window and emits
+// AnomalyAlert rows. Safe to call on a schedule — idempotent per detection window (the
+// dedup window absorbs the overlap between passes). It is best-effort per secret but
+// returns a non-nil error if any storage operation failed, so the scheduler outcome
+// reflects a partial failure rather than silently reporting success.
 func (d *AnomalyDetector) RunDetection(ctx context.Context, secrets []models.SecretNode) error {
 	now := time.Now().UTC()
-	window := now.Add(-1 * time.Hour)
+	lookback := d.lookback
+	if lookback < minDetectionLookback {
+		lookback = minDetectionLookback
+	}
+	window := now.Add(-lookback)
 	baselineWindow := now.Add(-30 * 24 * time.Hour)
 
+	var failures int
 	for _, secret := range secrets {
 		// Build 30-day baseline
 		baselineLogs, err := d.storage.ListSecretAccessLogs(ctx, secret.ID, baselineWindow)
 		if err != nil {
+			failures++
 			continue
 		}
 		if len(baselineLogs) == 0 {
@@ -124,23 +152,28 @@ func (d *AnomalyDetector) RunDetection(ctx context.Context, secrets []models.Sec
 		}
 		baseline := buildBaseline(baselineLogs, now, window)
 
-		// Get recent accesses (last hour)
+		// Get recent accesses over the lookback window.
 		recentLogs, err := d.storage.ListSecretAccessLogs(ctx, secret.ID, window)
 		if err != nil {
+			failures++
 			continue
 		}
 
 		for _, accessLog := range recentLogs {
 			alerts := detectAnomalies(secret, accessLog, baseline, d.offHours)
 			for _, alert := range alerts {
-				_ = d.storage.CreateAnomalyAlert(ctx, &alert)
+				if err := d.storage.CreateAnomalyAlert(ctx, &alert); err != nil {
+					failures++
+				}
 			}
 		}
 
 		// Per-secret aggregate: a read-volume spike for the window versus the learned
 		// baseline (one alert per secret per pass, not per access).
 		if alert := volumeSpikeAlert(secret, len(recentLogs), baseline, now); alert != nil {
-			_ = d.storage.CreateAnomalyAlert(ctx, alert)
+			if err := d.storage.CreateAnomalyAlert(ctx, alert); err != nil {
+				failures++
+			}
 		}
 
 		// ML pass (opt-in): score this window's accesses against an Isolation Forest
@@ -152,9 +185,14 @@ func (d *AnomalyDetector) RunDetection(ctx context.Context, secrets []models.Sec
 		if d.ml.Enabled {
 			trainLogs := logsBefore(baselineLogs, window)
 			for _, alert := range mlOutlierAlerts(secret, trainLogs, recentLogs, d.ml, now) {
-				_ = d.storage.CreateAnomalyAlert(ctx, &alert)
+				if err := d.storage.CreateAnomalyAlert(ctx, &alert); err != nil {
+					failures++
+				}
 			}
 		}
+	}
+	if failures > 0 {
+		return fmt.Errorf("anomaly detection completed with %d storage failure(s) — some alerts may not have been recorded", failures)
 	}
 	return nil
 }

--- a/internal/core/anomaly_alerting.go
+++ b/internal/core/anomaly_alerting.go
@@ -17,6 +17,29 @@ import (
 // it flows through the SIEM forwarder like any audit event.
 const EventAnomalyDetected = "security.anomaly_detected" // #nosec G101 -- audit event type, not a credential
 
+// EventAnomalyAcknowledged audits an operator dismissing an anomaly alert — a mutation
+// of a security-detection record, so WHO dismissed WHICH alert must land on the
+// append-only trail (otherwise an attacker could quietly bury an alert about their own
+// activity).
+const EventAnomalyAcknowledged = "security.anomaly_acknowledged" // #nosec G101 -- audit event type, not a credential
+
+// AcknowledgeAnomalyAlert marks an anomaly alert acknowledged and records who did it on
+// the audit trail. actorID is the operator performing the dismissal. The acknowledge is
+// gated at the transport by a write-level permission (it mutates a detection record).
+func (c *KeyorixCore) AcknowledgeAnomalyAlert(ctx context.Context, actorID, alertID uint) error {
+	if err := c.storage.AcknowledgeAnomalyAlert(ctx, alertID); err != nil {
+		return err
+	}
+	var aid *uint
+	if actorID != 0 {
+		a := actorID
+		aid = &a
+	}
+	c.writeAuditEventFull(ctx, EventAnomalyAcknowledged, aid, nil, nil, "",
+		fmt.Sprintf("anomaly alert %d acknowledged (dismissed) by user %d", alertID, actorID))
+	return nil
+}
+
 // AlertNewAnomalies pushes every not-yet-alerted anomaly to the project's admins
 // and the audit/SIEM pipeline, marking each alerted. Returns the number announced.
 // Idempotent: an already-alerted anomaly is skipped.

--- a/internal/core/anomaly_alerting_external_test.go
+++ b/internal/core/anomaly_alerting_external_test.go
@@ -43,6 +43,38 @@ func TestAlertNewAnomalies(t *testing.T) {
 	assert.Equal(t, 0, n)
 }
 
+// Acknowledging (dismissing) an anomaly alert flips its flag, records WHO dismissed it
+// on the audit trail (so the dismissal can't quietly bury an alert), and reports a
+// missing alert id as not-found rather than a silent success.
+func TestAcknowledgeAnomalyAlert_AuditsAndChecksExistence(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(&models.AnomalyAlert{}, &models.AuditEvent{}))
+	ctx := context.Background()
+
+	alert := models.AnomalyAlert{
+		SecretNodeID: 500, SecretName: "db-pw", AlertType: "new_ip", Severity: "high",
+		Description: "access from a new IP", AccessedBy: "mallory", IPAddress: "203.0.113.9",
+		DetectedAt: time.Now(),
+	}
+	require.NoError(t, h.DB.Create(&alert).Error)
+
+	// Acknowledge as user 7 → flag set + an audit event attributing the dismissal.
+	require.NoError(t, h.CoreService.AcknowledgeAnomalyAlert(ctx, 7, alert.ID))
+
+	var got models.AnomalyAlert
+	require.NoError(t, h.DB.First(&got, alert.ID).Error)
+	assert.True(t, got.Acknowledged, "the alert is marked acknowledged")
+
+	var ev models.AuditEvent
+	require.NoError(t, h.DB.Where("event_type = ?", core.EventAnomalyAcknowledged).First(&ev).Error)
+	require.NotNil(t, ev.UserID)
+	assert.Equal(t, uint(7), *ev.UserID, "the dismissal is attributed to the acting operator")
+
+	// A non-existent alert id is reported as an error, not a silent success.
+	require.Error(t, h.CoreService.AcknowledgeAnomalyAlert(ctx, 7, 999999))
+}
+
 // A secret read recorded through the real production logging path
 // (LogSecretReadWithProject → writeAccessLog → CreateSecretAccessLog) must be
 // visible to anomaly detection. Both the HTTP reveal handler and the gRPC

--- a/internal/core/anomaly_test.go
+++ b/internal/core/anomaly_test.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -9,13 +10,84 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// captureStore records the `since` lower bound of every ListSecretAccessLogs call so a
+// test can assert the detection window honors the configured lookback. It returns one
+// baseline log so RunDetection proceeds past the empty-history skip.
+type captureStore struct {
+	sinces       []time.Time
+	createErr    error
+	createdCount int
+}
+
+func (c *captureStore) ListSecretAccessLogs(_ context.Context, _ uint, since time.Time) ([]models.SecretAccessLog, error) {
+	c.sinces = append(c.sinces, since)
+	// A known user/IP (so new_user/new_ip never fire) at a deterministic OFF-HOURS time
+	// (23:00 UTC ∈ the default 22:00–06:00 window), so detectAnomalies always yields
+	// exactly one off_hours alert — making the storage-failure path deterministic.
+	return []models.SecretAccessLog{{
+		AccessedBy: "alice", IPAddress: "10.0.0.1",
+		AccessTime: time.Date(2026, 6, 20, 23, 0, 0, 0, time.UTC),
+	}}, nil
+}
+func (c *captureStore) CreateAnomalyAlert(_ context.Context, _ *models.AnomalyAlert) error {
+	c.createdCount++
+	return c.createErr
+}
+func (c *captureStore) ListAnomalyAlerts(_ context.Context, _ *bool) ([]models.AnomalyAlert, error) {
+	return nil, nil
+}
+func (c *captureStore) AcknowledgeAnomalyAlert(_ context.Context, _ uint) error { return nil }
+
+// The recent-access scan window must honor the configured lookback (so a longer scan
+// cadence scans a proportionally longer window), and be floored at one hour.
+func TestRunDetection_ScanWindowHonorsLookback(t *testing.T) {
+	t.Run("longer lookback widens the window", func(t *testing.T) {
+		store := &captureStore{}
+		d := NewAnomalyDetector(store)
+		d.SetLookback(6 * time.Hour)
+		require.NoError(t, d.RunDetection(context.Background(), []models.SecretNode{{ID: 1}}))
+
+		require.Len(t, store.sinces, 2, "one baseline query + one recent-window query")
+		recentSince := store.sinces[1] // the second call uses the lookback window
+		gap := time.Now().UTC().Sub(recentSince)
+		assert.InDelta(t, (6 * time.Hour).Seconds(), gap.Seconds(), 60, "recent window must span the 6h lookback")
+	})
+
+	t.Run("sub-hour lookback is floored at 1h", func(t *testing.T) {
+		store := &captureStore{}
+		d := NewAnomalyDetector(store)
+		d.SetLookback(5 * time.Minute) // below the floor
+		require.NoError(t, d.RunDetection(context.Background(), []models.SecretNode{{ID: 1}}))
+
+		gap := time.Now().UTC().Sub(store.sinces[1])
+		assert.InDelta(t, time.Hour.Seconds(), gap.Seconds(), 60, "the window floors at 1h")
+	})
+}
+
+// A storage failure during detection must surface as a non-nil error so the scheduler
+// records a partial failure rather than reporting a clean pass.
+func TestRunDetection_SurfacesStorageFailure(t *testing.T) {
+	store := &captureStore{createErr: assertAnErr}
+	d := NewAnomalyDetector(store)
+	// The store always yields one off_hours alert, whose insert fails → a surfaced error.
+	err := d.RunDetection(context.Background(), []models.SecretNode{{ID: 1, Name: "s"}})
+	require.Positive(t, store.createdCount, "the off_hours access must produce an alert to persist")
+	require.Error(t, err, "a failed alert insert must surface as a pass error")
+}
+
+var assertAnErr = &detectionTestErr{}
+
+type detectionTestErr struct{}
+
+func (*detectionTestErr) Error() string { return "boom" }
+
 func TestBuildBaseline(t *testing.T) {
 	now := time.Date(2026, 6, 17, 12, 0, 0, 0, time.UTC)
 	windowStart := now.Add(-1 * time.Hour) // the live detection window — excluded from the baseline
 	logs := []models.SecretAccessLog{
 		{IPAddress: "203.0.113.9", AccessedBy: "mallory", AccessTime: now.Add(-30 * time.Minute)}, // inside window → excluded
-		{IPAddress: "10.0.0.2", AccessedBy: "bob", AccessTime: now.Add(-2 * 24 * time.Hour)},       // in 7d, before window
-		{IPAddress: "10.0.0.1", AccessedBy: "alice", AccessTime: now.Add(-20 * 24 * time.Hour)},    // older than 7d
+		{IPAddress: "10.0.0.2", AccessedBy: "bob", AccessTime: now.Add(-2 * 24 * time.Hour)},      // in 7d, before window
+		{IPAddress: "10.0.0.1", AccessedBy: "alice", AccessTime: now.Add(-20 * 24 * time.Hour)},   // older than 7d
 	}
 	b := buildBaseline(logs, now, windowStart)
 	// The in-window read must NOT seed the baseline, else it would mask its own anomaly.
@@ -38,9 +110,9 @@ func TestLogsBefore(t *testing.T) {
 	now := time.Date(2026, 6, 17, 12, 0, 0, 0, time.UTC)
 	cutoff := now.Add(-1 * time.Hour)
 	logs := []models.SecretAccessLog{
-		{AccessedBy: "old", AccessTime: now.Add(-2 * time.Hour)},       // before cutoff → kept
-		{AccessedBy: "edge", AccessTime: cutoff},                       // exactly at cutoff → excluded (strictly before)
-		{AccessedBy: "recent", AccessTime: now.Add(-1 * time.Minute)},  // after cutoff → excluded
+		{AccessedBy: "old", AccessTime: now.Add(-2 * time.Hour)},      // before cutoff → kept
+		{AccessedBy: "edge", AccessTime: cutoff},                      // exactly at cutoff → excluded (strictly before)
+		{AccessedBy: "recent", AccessTime: now.Add(-1 * time.Minute)}, // after cutoff → excluded
 	}
 	got := logsBefore(logs, cutoff)
 	if len(got) != 1 || got[0].AccessedBy != "old" {

--- a/internal/core/audit.go
+++ b/internal/core/audit.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
+	"unicode"
 
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
@@ -163,7 +165,7 @@ func (c *KeyorixCore) writeAuditEventDiff(ctx context.Context, eventType string,
 		SecretNodeID: secretID,
 		ProjectID:    projectID,
 		IPAddress:    ip,
-		Description:  description,
+		Description:  sanitizeAuditText(description),
 		Success:      &t,
 		EventTime:    time.Now(),
 		Diff:         diff,
@@ -185,12 +187,29 @@ func (c *KeyorixCore) writeAuditEventFailed(ctx context.Context, eventType strin
 		EventType:   eventType,
 		UserID:      userID,
 		IPAddress:   ip,
-		Description: description,
+		Description: sanitizeAuditText(description),
 		Success:     &f,
 		EventTime:   time.Now(),
 		ActorType:   actorTypeFromContext(ctx),
 	}
 	c.emitAudit(ctx, event)
+}
+
+// sanitizeAuditText strips control characters (CR/LF, ANSI/C1 escapes, NUL, etc.) from a
+// string headed for an audit Description, so a crafted secret name or username can't inject
+// a forged audit line or smuggle terminal-control sequences into a CLI audit viewer. The
+// audit chain hashes the Description, so cleaning it also keeps the persisted, tamper-
+// evident content faithful. A tab is normalized to a space; other controls are dropped.
+func sanitizeAuditText(s string) string {
+	return strings.Map(func(r rune) rune {
+		if r == '\t' {
+			return ' '
+		}
+		if unicode.IsControl(r) {
+			return -1 // drop
+		}
+		return r
+	}, s)
 }
 
 // writeAccessLog persists a secret_access_logs row.

--- a/internal/core/audit_checkpoint.go
+++ b/internal/core/audit_checkpoint.go
@@ -53,6 +53,37 @@ func (c *KeyorixCore) AuditCheckpointsAvailable() bool {
 	return len(c.auditCkptKey) > 0
 }
 
+// SeedAuditWatermark loads the persisted high-water mark into the in-memory watermark
+// at startup, so anti-rollback survives a process restart. Without this the in-memory
+// watermark resets to 0 on every restart, and an attacker who deleted/garbled the
+// persistent mark before a restart could then truncate the trail undetected (the
+// restart erases the only remaining proof of the certified length). Best-effort: a read
+// error or absent/invalid mark leaves the watermark at 0 (and a missing mark while
+// checkpoints exist is separately flagged as tamper by enforceAuditHighWater).
+func (c *KeyorixCore) SeedAuditWatermark(ctx context.Context) {
+	if !c.AuditCheckpointsAvailable() {
+		return
+	}
+	floor, _, _, _, err := c.auditHighWaterFloor(ctx)
+	if err != nil {
+		log.Printf("audit high-water: failed to seed in-memory watermark at startup: %v", err)
+		return
+	}
+	c.bumpWatermark(floor)
+}
+
+// checkpointExists reports whether any signed checkpoint row exists — i.e. whether
+// checkpointing has ever been initialized for this trail. Once it has, the persistent
+// high-water mark must exist too (advanceAuditHighWater writes it with every
+// checkpoint), so a missing/malformed mark alongside an existing checkpoint is tampering.
+func (c *KeyorixCore) checkpointExists(ctx context.Context) (bool, error) {
+	cp, err := c.storage.LatestAuditCheckpoint(ctx)
+	if err != nil {
+		return false, err
+	}
+	return cp != nil, nil
+}
+
 // SetCheckpointNotary wires an external notary (RFC 3161 TSA) that anchors each
 // freshly-written checkpoint for a forge-proof proof-of-existence (ADR-029).
 // Called at startup when audit.checkpoint_notary is enabled; left unset, no
@@ -405,7 +436,20 @@ func (c *KeyorixCore) enforceAuditHighWater(ctx context.Context, v *storage.Audi
 	if err != nil {
 		return err
 	}
-	if found || floor > 0 {
+	// A persistent mark that is absent or malformed (found=false, tampered=false) is a
+	// rollback attempt WHEN signed checkpoints exist: advanceAuditHighWater writes the
+	// mark with every checkpoint, so a checkpoint without a valid mark means the mark was
+	// deleted or garbled to erase the certified length so a truncation reads clean. (With
+	// no checkpoint we cannot attribute it — a fresh trail legitimately has neither.)
+	if !found && !tampered {
+		if exists, cerr := c.checkpointExists(ctx); cerr != nil {
+			return cerr
+		} else if exists {
+			tampered = true
+			reason = "audit high-water mark is missing or malformed although signed checkpoints exist — the anti-rollback mark was deleted or tampered with"
+		}
+	}
+	if found || tampered || floor > 0 {
 		v.Checkpointed = true
 	}
 	switch {

--- a/internal/core/audit_checkpoint.go
+++ b/internal/core/audit_checkpoint.go
@@ -20,12 +20,23 @@ import (
 	"encoding/hex"
 	"fmt"
 	"log"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/notary"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
+
+// auditHighWaterKey is the system_metadata key holding the signed audit high-water
+// mark — the greatest chained-events count ever certified. Unlike the append-only
+// checkpoint rows, this is a SINGLE overwritten row, so an attacker cannot "delete the
+// newer ones" to surface an older authentic checkpoint: the high-water always attests
+// the maximum reached. Lowering it requires the signing key (forgery-proof); leaving it
+// while truncating the chain is caught as a regression; deleting it mid-run is caught by
+// the in-memory watermark. See ADR-029.
+const auditHighWaterKey = "audit_checkpoint_highwater" // #nosec G101 -- metadata key name, not a credential
 
 // SetAuditCheckpointKey wires the DEK-derived HMAC key (and the DEK key version
 // it was derived from) used to sign and verify audit checkpoints. Called at
@@ -143,6 +154,19 @@ func (c *KeyorixCore) WriteAuditCheckpoint(ctx context.Context) (*models.AuditCh
 		// else: signature fails AND key_version is superseded → consistent with a DEK
 		// rotation; fall through and re-baseline under the new key (recovery path).
 	}
+	// Refuse to checkpoint a chain that sits below the certified high-water mark —
+	// otherwise a scheduled write would launder a truncation into a fresh, authentic
+	// checkpoint (and a fresh high-water), erasing the rollback evidence.
+	floor, _, hwTampered, hwReason, err := c.auditHighWaterFloor(ctx)
+	if err != nil {
+		return nil, false, err
+	}
+	if hwTampered {
+		return nil, false, fmt.Errorf("refusing to checkpoint: %s", hwReason)
+	}
+	if raw.ChainedEvents < floor {
+		return nil, false, fmt.Errorf("refusing to checkpoint: the audit trail (%d events) is below the certified high-water mark (%d) — a truncation must be investigated, not re-baselined", raw.ChainedEvents, floor)
+	}
 	newCP := &models.AuditCheckpoint{
 		ChainedEvents: raw.ChainedEvents,
 		HeadID:        raw.HeadID,
@@ -155,6 +179,8 @@ func (c *KeyorixCore) WriteAuditCheckpoint(ctx context.Context) (*models.AuditCh
 	}
 	// Best-effort external anchor (RFC 3161) — never fails the checkpoint write.
 	c.anchorCheckpoint(ctx, newCP)
+	// Advance the persistent + in-memory high-water mark to this certified length.
+	c.advanceAuditHighWater(ctx, newCP)
 	return newCP, true, nil
 }
 
@@ -177,12 +203,19 @@ func (c *KeyorixCore) enforceAuditCheckpoint(ctx context.Context, v *storage.Aud
 	if !c.AuditCheckpointsAvailable() {
 		return nil
 	}
+	// Anti-rollback: check the live chain against the certified high-water mark first.
+	// This runs even when every checkpoint row has been deleted (the high-water is a
+	// separate, single, signed row), so deleting newer checkpoints to surface an older
+	// authentic one no longer hides a tail-truncation.
+	if err := c.enforceAuditHighWater(ctx, v); err != nil {
+		return err
+	}
 	cp, err := c.storage.LatestAuditCheckpoint(ctx)
 	if err != nil {
 		return err
 	}
 	if cp == nil {
-		return nil // none written yet
+		return nil // no checkpoint row; the high-water check above still applied
 	}
 
 	v.Checkpointed = true
@@ -203,6 +236,17 @@ func (c *KeyorixCore) enforceAuditCheckpoint(ctx context.Context, v *storage.Aud
 			brokenID = &id
 		}
 		c.failCheckpoint(v, brokenID, reason)
+	}
+	// When an external-notary trust root is configured and the latest checkpoint carries
+	// an anchor, re-verify the RFC 3161 receipt binds this exact checkpoint. Without this
+	// the anchor was written but never checked on the read path — a forged/invalid token
+	// would go unnoticed. Only enforced when roots are configured (opt-in); an anchor that
+	// fails to verify against a configured root is a tamper signal.
+	if c.checkpointAnchorRoots != nil && len(cp.AnchorToken) > 0 {
+		if _, _, aerr := c.VerifyCheckpointAnchor(cp); aerr != nil {
+			c.failCheckpoint(v, nil,
+				fmt.Sprintf("audit checkpoint #%d external anchor failed verification against the configured trust root: %v", cp.ID, aerr))
+		}
 	}
 	return nil
 }
@@ -261,5 +305,133 @@ func (c *KeyorixCore) signCheckpoint(cp *models.AuditCheckpoint) string {
 }
 
 func (c *KeyorixCore) checkpointSignatureValid(cp *models.AuditCheckpoint) bool {
-	return hmac.Equal([]byte(c.signCheckpoint(cp)), []byte(cp.Signature))
+	return c.checkpointSigMatches(cp, cp.Signature)
+}
+
+// checkpointSigMatches reports whether sig is the valid HMAC over cp's canonical bytes.
+// Used for both a checkpoint row (sig == cp.Signature) and the high-water mark (where
+// the signature is stored alongside the canonical fields, not on the cp struct).
+func (c *KeyorixCore) checkpointSigMatches(cp *models.AuditCheckpoint, sig string) bool {
+	return hmac.Equal([]byte(c.signCheckpoint(cp)), []byte(sig))
+}
+
+// --- audit high-water mark (anti-rollback for checkpoints) ---------------------
+
+// bumpWatermark raises the in-memory monotonic high-water mark to n (never lowers it).
+func (c *KeyorixCore) bumpWatermark(n int64) {
+	c.auditWatermarkMu.Lock()
+	if n > c.auditMaxCertified {
+		c.auditMaxCertified = n
+	}
+	c.auditWatermarkMu.Unlock()
+}
+
+// watermark returns the in-memory monotonic high-water mark.
+func (c *KeyorixCore) watermark() int64 {
+	c.auditWatermarkMu.Lock()
+	defer c.auditWatermarkMu.Unlock()
+	return c.auditMaxCertified
+}
+
+// auditHighWaterValue serializes a high-water mark: the checkpoint canonical bytes
+// (chained_events, head_id, head_hash, key_version) plus the HMAC signature, all
+// null-separated so the fields cannot be ambiguously re-split.
+func auditHighWaterValue(cp *models.AuditCheckpoint, sig string) string {
+	return checkpointCanonical(cp) + "\x00" + sig
+}
+
+// parseAuditHighWater parses a stored high-water value back into a checkpoint snapshot
+// and its signature. ok is false on any malformed value (treated as "no mark").
+func parseAuditHighWater(val string) (cp *models.AuditCheckpoint, sig string, ok bool) {
+	parts := strings.Split(val, "\x00")
+	if len(parts) != 6 || parts[0] != "v1" {
+		return nil, "", false
+	}
+	chained, err1 := strconv.ParseInt(parts[1], 10, 64)
+	headID, err2 := strconv.ParseUint(parts[2], 10, 64)
+	if err1 != nil || err2 != nil {
+		return nil, "", false
+	}
+	return &models.AuditCheckpoint{
+		ChainedEvents: chained,
+		HeadID:        uint(headID),
+		HeadHash:      parts[3],
+		KeyVersion:    parts[4],
+	}, parts[5], true
+}
+
+// auditHighWaterFloor returns the greatest chained-events count this server can prove
+// the trail previously reached: the max of the in-memory watermark and a signature-valid
+// persistent high-water under the current key. found reports whether a persistent mark
+// exists; tampered/reason flag a persistent mark that fails its signature under the
+// CURRENT key version (a superseded version is treated as a DEK rotation and ignored, so
+// the system can recover after a key rotation — symmetric with checkpoint enforcement).
+func (c *KeyorixCore) auditHighWaterFloor(ctx context.Context) (floor int64, found, tampered bool, reason string, err error) {
+	floor = c.watermark()
+	val, ok, err := c.storage.GetSystemMetadata(ctx, auditHighWaterKey)
+	if err != nil {
+		return 0, false, false, "", err
+	}
+	if !ok {
+		return floor, false, false, "", nil
+	}
+	cp, sig, parsed := parseAuditHighWater(val)
+	if !parsed {
+		// A malformed mark under a configured key is itself suspicious, but we cannot
+		// attribute it; treat as absent rather than asserting a specific floor.
+		return floor, false, false, "", nil
+	}
+	if c.checkpointSigMatches(cp, sig) {
+		if cp.ChainedEvents > floor {
+			floor = cp.ChainedEvents
+		}
+		return floor, true, false, "", nil
+	}
+	if cp.KeyVersion == c.auditCkptKeyVersion {
+		return floor, true, true,
+			fmt.Sprintf("audit high-water mark fails its signature under the current key version %q — the high-water row was tampered with", cp.KeyVersion), nil
+	}
+	// Signature fails AND key_version is superseded → consistent with a DEK rotation;
+	// ignore the stale mark (the next checkpoint write re-establishes it under the new key).
+	return floor, true, false, "", nil
+}
+
+// enforceAuditHighWater flags the verdict if the live chain has regressed below the
+// certified high-water mark (the anti-rollback check that catches deletion of newer
+// checkpoints + tail-truncation, which the latest-checkpoint comparison alone misses),
+// then raises the in-memory watermark to the just-verified length.
+func (c *KeyorixCore) enforceAuditHighWater(ctx context.Context, v *storage.AuditChainVerification) error {
+	floor, found, tampered, reason, err := c.auditHighWaterFloor(ctx)
+	if err != nil {
+		return err
+	}
+	if found || floor > 0 {
+		v.Checkpointed = true
+	}
+	switch {
+	case tampered:
+		c.failCheckpoint(v, nil, reason)
+	case v.ChainedEvents < floor:
+		c.failCheckpoint(v, nil,
+			fmt.Sprintf("audit trail truncated below the certified high-water mark: %d events were previously certified, only %d remain", floor, v.ChainedEvents))
+	}
+	c.bumpWatermark(v.ChainedEvents)
+	return nil
+}
+
+// advanceAuditHighWater persists (and bumps the in-memory) high-water mark to cp after a
+// checkpoint write. The mark only ever advances; it is signed with the current key.
+func (c *KeyorixCore) advanceAuditHighWater(ctx context.Context, cp *models.AuditCheckpoint) {
+	floor, _, _, _, err := c.auditHighWaterFloor(ctx)
+	if err == nil && cp.ChainedEvents < floor {
+		// Never lower the mark (a legitimate grow only raises it). Should not happen —
+		// WriteAuditCheckpoint refuses to checkpoint below the floor — but be defensive.
+		c.bumpWatermark(floor)
+		return
+	}
+	val := auditHighWaterValue(cp, c.signCheckpoint(cp))
+	if err := c.storage.SetSystemMetadata(ctx, auditHighWaterKey, val); err != nil {
+		log.Printf("audit high-water: failed to persist mark at %d events: %v", cp.ChainedEvents, err)
+	}
+	c.bumpWatermark(cp.ChainedEvents)
 }

--- a/internal/core/audit_checkpoint_test.go
+++ b/internal/core/audit_checkpoint_test.go
@@ -67,6 +67,80 @@ func TestAuditCheckpoint_HappyPath(t *testing.T) {
 	assert.Empty(t, v.CheckpointReason)
 }
 
+// Deleting or garbling the persistent high-water mark while a signed checkpoint still
+// exists is a rollback attempt (the mark is written with every checkpoint, so its
+// absence/corruption alongside a checkpoint means it was tampered with). This also
+// simulates the restart case: the in-memory watermark is cleared, so detection must
+// come from the persistent-mark/checkpoint cross-check, not the in-memory floor.
+func TestAuditCheckpoint_MissingHighWaterWithCheckpointIsTamper(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("deleted mark", func(t *testing.T) {
+		c, db := newCheckpointCore(t)
+		logEvents(t, c, 5)
+		_, written, err := c.WriteAuditCheckpoint(ctx)
+		require.NoError(t, err)
+		require.True(t, written)
+
+		v, err := c.VerifyAuditChain(ctx)
+		require.NoError(t, err)
+		require.True(t, v.Valid)
+
+		// Attacker deletes the anti-rollback mark; simulate a restart losing the watermark.
+		require.NoError(t, db.Exec("DELETE FROM system_metadata WHERE key = ?", auditHighWaterKey).Error)
+		c.auditMaxCertified = 0
+
+		v, err = c.VerifyAuditChain(ctx)
+		require.NoError(t, err)
+		assert.False(t, v.Valid, "a missing high-water mark while a checkpoint exists is tamper")
+		assert.Contains(t, v.CheckpointReason, "anti-rollback mark")
+	})
+
+	t.Run("garbled mark", func(t *testing.T) {
+		c, _ := newCheckpointCore(t)
+		logEvents(t, c, 5)
+		_, written, err := c.WriteAuditCheckpoint(ctx)
+		require.NoError(t, err)
+		require.True(t, written)
+
+		// Overwrite the mark with an unparseable value; simulate a restart.
+		require.NoError(t, c.storage.SetSystemMetadata(ctx, auditHighWaterKey, "not-a-valid-mark"))
+		c.auditMaxCertified = 0
+
+		v, err := c.VerifyAuditChain(ctx)
+		require.NoError(t, err)
+		assert.False(t, v.Valid, "a malformed high-water mark while a checkpoint exists is tamper")
+		assert.Contains(t, v.CheckpointReason, "anti-rollback mark")
+	})
+}
+
+// SeedAuditWatermark restores the in-memory watermark from the persisted mark, so a
+// restart followed by a truncation (with the mark intact at seed time) is still caught.
+func TestSeedAuditWatermark_RestoresFloorAfterRestart(t *testing.T) {
+	ctx := context.Background()
+	c, db := newCheckpointCore(t)
+	logEvents(t, c, 5)
+	_, _, err := c.WriteAuditCheckpoint(ctx)
+	require.NoError(t, err)
+
+	// Simulate a restart: a fresh core over the same DB with the same key (in-memory
+	// watermark starts at 0), then seed from the persisted mark.
+	c2 := &KeyorixCore{storage: store.NewLocalStorage(db)}
+	c2.SetAuditCheckpointKey(bytes.Repeat([]byte{0x7}, 32), "v1")
+	c2.SeedAuditWatermark(ctx)
+	assert.Equal(t, int64(5), c2.watermark(), "watermark restored from persisted high-water")
+
+	// Truncate the checkpoint rows AND the mark, leaving a self-consistent shorter chain;
+	// the restored in-memory watermark still catches the regression.
+	require.NoError(t, db.Exec("DELETE FROM audit_checkpoints").Error)
+	require.NoError(t, db.Exec("DELETE FROM system_metadata WHERE key = ?", auditHighWaterKey).Error)
+	require.NoError(t, db.Exec("DELETE FROM audit_events WHERE id > (SELECT MIN(id) FROM audit_events)").Error)
+
+	v, err := c2.VerifyAuditChain(ctx)
+	require.NoError(t, err)
+	assert.False(t, v.Valid, "truncation below the restored watermark is detected after restart")
+}
+
 // fakeNotary is a stand-in external authority for the anchoring wiring tests
 // (the real RFC 3161 verify path is covered by the notary package round-trip).
 type fakeNotary struct {

--- a/internal/core/audit_checkpoint_test.go
+++ b/internal/core/audit_checkpoint_test.go
@@ -3,6 +3,7 @@ package core
 import (
 	"bytes"
 	"context"
+	"crypto/x509"
 	"fmt"
 	"testing"
 	"time"
@@ -21,7 +22,7 @@ func newCheckpointCore(t *testing.T) (*KeyorixCore, *gorm.DB) {
 	t.Helper()
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
-	require.NoError(t, db.AutoMigrate(&models.AuditEvent{}, &models.AuditCheckpoint{}))
+	require.NoError(t, db.AutoMigrate(&models.AuditEvent{}, &models.AuditCheckpoint{}, &models.SystemMetadata{}))
 	c := &KeyorixCore{storage: store.NewLocalStorage(db)}
 	c.SetAuditCheckpointKey(bytes.Repeat([]byte{0x7}, 32), "v1")
 	return c, db
@@ -340,6 +341,108 @@ func TestAuditCheckpoint_NoRebaselineOverCorruptedSignature(t *testing.T) {
 	v, err := c.VerifyAuditChain(ctx)
 	require.NoError(t, err)
 	assert.False(t, v.Valid)
+}
+
+// The headline rollback attack: an attacker with DB write deletes the newer
+// checkpoint(s) and truncates the trail back to an OLDER but still-authentic
+// checkpoint's head. The latest-checkpoint comparison alone is satisfied (the older
+// checkpoint verifies and matches the shortened chain), but the signed high-water mark
+// — a single overwritten row attesting the MAX certified length — still records the
+// longer length, so verification must flag the rollback. A FRESH core (no in-memory
+// watermark — i.e. a server restart) must catch it purely from the persistent mark.
+func TestAuditCheckpoint_DetectsRollbackToOlderCheckpoint(t *testing.T) {
+	ctx := context.Background()
+	c, db := newCheckpointCore(t)
+
+	logEvents(t, c, 5)
+	_, _, err := c.WriteAuditCheckpoint(ctx) // checkpoint #1 certifies 5; high-water = 5
+	require.NoError(t, err)
+	logEvents(t, c, 5)                      // 10 total
+	_, _, err = c.WriteAuditCheckpoint(ctx) // checkpoint #2 certifies 10; high-water = 10
+	require.NoError(t, err)
+
+	// Attack: truncate the trail back to 5 events AND delete the newer checkpoint so the
+	// authentic older checkpoint (certifying 5) becomes the latest.
+	require.NoError(t, db.Exec("DELETE FROM audit_events WHERE id > 5").Error)
+	require.NoError(t, db.Exec("DELETE FROM audit_checkpoints WHERE chained_events = 10").Error)
+
+	// Sanity: the latest-checkpoint comparison alone is now satisfied — the surviving
+	// checkpoint certifies 5 and exactly 5 self-consistent events remain.
+	raw, err := c.storage.VerifyAuditChain(ctx)
+	require.NoError(t, err)
+	assert.True(t, raw.Valid, "the bare walk passes")
+
+	// A FRESH core (server restart: in-memory watermark starts at 0) still catches the
+	// rollback via the persistent signed high-water mark.
+	fresh := &KeyorixCore{storage: store.NewLocalStorage(db)}
+	fresh.SetAuditCheckpointKey(bytes.Repeat([]byte{0x7}, 32), "v1")
+	v, err := fresh.VerifyAuditChain(ctx)
+	require.NoError(t, err)
+	assert.False(t, v.Valid, "the high-water mark catches the rollback to an older checkpoint")
+	assert.True(t, v.Checkpointed)
+	assert.Contains(t, v.CheckpointReason, "high-water mark")
+}
+
+// Deleting the high-water row mid-run does not help an online attacker: the in-memory
+// watermark remembers the max length certified this session.
+func TestAuditCheckpoint_InMemoryWatermarkSurvivesHighWaterDeletion(t *testing.T) {
+	ctx := context.Background()
+	c, db := newCheckpointCore(t)
+	logEvents(t, c, 8)
+	_, _, err := c.WriteAuditCheckpoint(ctx) // high-water = 8 (persistent + in-memory)
+	require.NoError(t, err)
+
+	// Attacker truncates and wipes BOTH the checkpoint rows and the persistent mark.
+	require.NoError(t, db.Exec("DELETE FROM audit_events WHERE id > 3").Error)
+	require.NoError(t, db.Exec("DELETE FROM audit_checkpoints").Error)
+	require.NoError(t, db.Exec("DELETE FROM system_metadata").Error)
+
+	// The SAME running core still flags it from its in-memory watermark.
+	v, err := c.VerifyAuditChain(ctx)
+	require.NoError(t, err)
+	assert.False(t, v.Valid, "the in-memory watermark catches truncation after the mark is wiped")
+	assert.Contains(t, v.CheckpointReason, "high-water mark")
+}
+
+// Editing the persistent high-water row under the current key is detected (the HMAC
+// won't recompute) and is reported as tampering, not silently trusted.
+func TestAuditCheckpoint_TamperedHighWaterDetected(t *testing.T) {
+	ctx := context.Background()
+	c, db := newCheckpointCore(t)
+	logEvents(t, c, 6)
+	_, _, err := c.WriteAuditCheckpoint(ctx)
+	require.NoError(t, err)
+
+	// Lower the high-water's claimed length to mask a planned truncation; the signature
+	// no longer matches. Use a fresh core so only the persistent mark is consulted.
+	require.NoError(t, db.Exec("UPDATE system_metadata SET value = ? WHERE key = ?",
+		"v1\x002\x002\x00deadbeef\x00v1\x00bogussig", auditHighWaterKey).Error)
+
+	fresh := &KeyorixCore{storage: store.NewLocalStorage(db)}
+	fresh.SetAuditCheckpointKey(bytes.Repeat([]byte{0x7}, 32), "v1")
+	v, err := fresh.VerifyAuditChain(ctx)
+	require.NoError(t, err)
+	assert.False(t, v.Valid)
+	assert.Contains(t, v.CheckpointReason, "high-water mark")
+}
+
+// When an external-notary trust root is configured, the latest checkpoint's stored
+// anchor is re-verified on the read path: a token that doesn't verify against the
+// configured root is flagged (previously the anchor was written but never checked).
+func TestAuditCheckpoint_VerifiesAnchorWhenRootsConfigured(t *testing.T) {
+	ctx := context.Background()
+	c, _ := newCheckpointCore(t)
+	logEvents(t, c, 3)
+	fn := &fakeNotary{token: []byte("not-a-real-rfc3161-token"), at: time.Date(2026, 6, 15, 9, 0, 0, 0, time.UTC)}
+	c.SetCheckpointNotary(fn)
+	c.SetCheckpointAnchorRoots(x509.NewCertPool()) // roots configured → anchor verified on read
+	_, _, err := c.WriteAuditCheckpoint(ctx)
+	require.NoError(t, err)
+
+	v, err := c.VerifyAuditChain(ctx)
+	require.NoError(t, err)
+	assert.False(t, v.Valid, "a checkpoint anchor that doesn't verify against the configured root is flagged")
+	assert.Contains(t, v.CheckpointReason, "external anchor failed verification")
 }
 
 func TestAuditCheckpoint_SignDeterministicAndBinding(t *testing.T) {

--- a/internal/core/audit_sanitize_test.go
+++ b/internal/core/audit_sanitize_test.go
@@ -1,0 +1,23 @@
+package core
+
+import "testing"
+
+// Control characters in a user-controlled name/string must be stripped from an audit
+// Description so a crafted secret name can't inject a forged audit line or smuggle ANSI
+// escapes into a CLI audit viewer.
+func TestSanitizeAuditText(t *testing.T) {
+	cases := map[string]string{
+		"plain secret name":                 "plain secret name",
+		"line1\nline2":                      "line1line2", // newline dropped (no forged line)
+		"a\r\nFAKE secret.deleted by admin": "aFAKE secret.deleted by admin",
+		"esc\x1b[31mred":                    "esc[31mred", // ANSI escape byte dropped
+		"nul\x00byte":                       "nulbyte",
+		"tab\tcol":                          "tab col",        // tab normalized to space
+		"unicode-café-✓":                    "unicode-café-✓", // printable unicode preserved
+	}
+	for in, want := range cases {
+		if got := sanitizeAuditText(in); got != want {
+			t.Errorf("sanitizeAuditText(%q) = %q; want %q", in, got, want)
+		}
+	}
+}

--- a/internal/core/auth.go
+++ b/internal/core/auth.go
@@ -38,10 +38,18 @@ type LoginRequest struct {
 	IPAddress string
 }
 
+// dummyBcryptHash is a fixed bcrypt hash (DefaultCost) used to equalize the timing of
+// the user-not-found login path with the wrong-password path, so /auth/login can't be
+// used as a username-existence oracle. Computed once at package load.
+var dummyBcryptHash, _ = bcrypt.GenerateFromPassword([]byte("keyorix-login-timing-equalizer"), bcrypt.DefaultCost)
+
 // Login validates credentials, creates a session, and returns (session, user, error).
 func (c *KeyorixCore) Login(ctx context.Context, req *LoginRequest) (*models.Session, *models.User, error) {
 	user, err := c.storage.GetUserByUsername(ctx, req.Username)
 	if err != nil {
+		// Spend an equivalent bcrypt comparison so a missing username doesn't return
+		// faster than a wrong password (account-enumeration timing side-channel).
+		_ = bcrypt.CompareHashAndPassword(dummyBcryptHash, []byte(req.Password))
 		return nil, nil, fmt.Errorf("invalid credentials")
 	}
 	// Per-account lockout gate: while locked, refuse regardless of the password (and

--- a/internal/core/auth.go
+++ b/internal/core/auth.go
@@ -124,8 +124,15 @@ func (c *KeyorixCore) mintSession(ctx context.Context, userID uint, userAgent, i
 	if err != nil {
 		return nil, fmt.Errorf("failed to create session: %w", err)
 	}
+	// Bound concurrent sessions per user so unbounded logins can't grow the table or
+	// enlarge the credential-theft blast radius. Best-effort — never fail a login on it.
+	_ = c.storage.EnforceSessionLimit(ctx, userID, maxSessionsPerUser)
 	return created, nil
 }
+
+// maxSessionsPerUser caps a user's concurrent sessions; the oldest beyond this are
+// reaped on each new login (see EnforceSessionLimit).
+const maxSessionsPerUser = 25
 
 // RecordLogin stamps the user's last_login_at to the current time. Best-effort:
 // the login handler calls this in a goroutine after a successful authentication,

--- a/internal/core/auth.go
+++ b/internal/core/auth.go
@@ -278,6 +278,12 @@ func (c *KeyorixCore) RequestPasswordReset(ctx context.Context, email string) er
 	if AccountLoginBlocked(user.AccountState) {
 		return nil
 	}
+	// Refuse for externally-managed identities (SSO/SCIM): issuing a local password
+	// would create a backdoor that authenticates at /auth/login and bypasses the IdP's
+	// MFA / conditional access / deprovisioning. Swallowed to stay enumeration-safe.
+	if user.ExternalID != "" {
+		return nil
+	}
 	// Throttle abusive repeats to a victim address (same control as resend). A
 	// throttled repeat returns an error here, swallowed below to stay enumeration-safe.
 	_, _ = c.provisionSetupLinkThrottled(ctx, IssueSetupTokenRequest{

--- a/internal/core/auth.go
+++ b/internal/core/auth.go
@@ -152,6 +152,15 @@ func (c *KeyorixCore) RefreshSession(ctx context.Context, token string) (*models
 		_ = c.storage.DeleteSession(ctx, old.ID)
 		return nil, fmt.Errorf("session lifetime exceeded; re-authentication required")
 	}
+	// An impersonation session must not be refreshable. /auth/refresh is public (any
+	// bearer token), and refresh rebuilds the session without the impersonation fields —
+	// so refreshing an impersonation token would mint a fresh, full-TTL session for the
+	// target with the impersonated_by attribution stripped, laundering a bounded, audited
+	// support session into unbounded, unattributed account access. The admin keeps their
+	// own session and swaps back via "Return to Admin".
+	if old.ImpersonatedBy != nil {
+		return nil, fmt.Errorf("impersonation sessions cannot be refreshed")
+	}
 	// Re-check account state before rotating the token. ValidateSessionToken applies
 	// this gate on every request, but refresh is a distinct, unauthenticated-by-token
 	// entry point: without re-checking here, an account deactivated (IsActive=false)

--- a/internal/core/auth.go
+++ b/internal/core/auth.go
@@ -52,9 +52,13 @@ func (c *KeyorixCore) Login(ctx context.Context, req *LoginRequest) (*models.Ses
 		_ = bcrypt.CompareHashAndPassword(dummyBcryptHash, []byte(req.Password))
 		return nil, nil, fmt.Errorf("invalid credentials")
 	}
-	// Per-account lockout gate: while locked, refuse regardless of the password (and
-	// before spending a bcrypt comparison), so repeated guessing can't progress.
+	// Per-account lockout gate: while locked, refuse regardless of the password, so
+	// repeated guessing can't progress. Spend an equivalent bcrypt comparison first so the
+	// locked path's latency matches the unknown-user and wrong-password paths — otherwise a
+	// fast (no-bcrypt) response on a locked account is a username-existence oracle (the
+	// attacker first forces the lockout, then probes by timing).
 	if c.loginLocked(user) {
+		_ = bcrypt.CompareHashAndPassword(dummyBcryptHash, []byte(req.Password))
 		return nil, nil, fmt.Errorf("account temporarily locked due to repeated failed logins; try again later")
 	}
 	if err := bcrypt.CompareHashAndPassword([]byte(user.PasswordHash), []byte(req.Password)); err != nil {

--- a/internal/core/auth_bootstrap.go
+++ b/internal/core/auth_bootstrap.go
@@ -7,18 +7,24 @@ package core
 
 import (
 	"context"
+	"crypto/subtle"
 	"fmt"
 
 	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
 // BootstrapRequest holds credentials and display name for the initial bootstrap.
+// Token is the caller-supplied bootstrap token, matched against the server's
+// configured token (see KeyorixCore.SetBootstrapToken) to authorize the first-admin
+// claim.
 type BootstrapRequest struct {
 	Username    string
 	Email       string
 	Password    string
 	DisplayName string
+	Token       string
 }
 
 // BootstrapResult is returned after a bootstrap call (first-time or idempotent repeat).
@@ -162,6 +168,21 @@ func (c *KeyorixCore) BootstrapSystem(ctx context.Context, req *BootstrapRequest
 		return c.currentBootstrapState(ctx)
 	}
 
+	// Authorize the first-admin claim. Without this gate the bootstrap is an
+	// unauthenticated, first-caller-wins admin seizure on any fresh, network-reachable
+	// instance. An unset server token disables API bootstrap entirely (fail closed).
+	if c.bootstrapToken == "" {
+		return nil, fmt.Errorf("system initialisation over the API is disabled: no bootstrap token is configured")
+	}
+	if subtle.ConstantTimeCompare([]byte(req.Token), []byte(c.bootstrapToken)) != 1 {
+		return nil, fmt.Errorf("invalid bootstrap token")
+	}
+	// The initial admin is the most privileged account; enforce the password policy
+	// here too (plain CreateUser does not), so it can't be seeded with a weak password.
+	if err := c.passwordPolicy.Validate(req.Password, nil); err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorValidation", nil), err)
+	}
+
 	displayName := req.DisplayName
 	if displayName == "" {
 		displayName = req.Username
@@ -263,4 +284,22 @@ func (c *KeyorixCore) currentBootstrapState(ctx context.Context) (*BootstrapResu
 		Project:            project,
 		Environments:       envs,
 	}, nil
+}
+
+// SystemNeedsBootstrap reports whether the install has no users yet (i.e. POST
+// /system/init would seed the first admin). The server uses this at startup to decide
+// whether to surface the bootstrap token to the operator.
+func (c *KeyorixCore) SystemNeedsBootstrap(ctx context.Context) (bool, error) {
+	_, total, err := c.storage.ListUsers(ctx, &storage.UserFilter{Page: 1, PageSize: 1})
+	if err != nil {
+		return false, err
+	}
+	return total == 0, nil
+}
+
+// GenerateBootstrapToken returns a fresh, high-entropy bootstrap token. The server
+// uses it when no KEYORIX_BOOTSTRAP_TOKEN is configured, logging the value so the
+// operator can initialise the (still-empty) install.
+func GenerateBootstrapToken() (string, error) {
+	return randToken()
 }

--- a/internal/core/auth_bootstrap_rbac_test.go
+++ b/internal/core/auth_bootstrap_rbac_test.go
@@ -33,8 +33,10 @@ func newBootstrappedCore(t *testing.T) (*KeyorixCore, *store.LocalStorage) {
 
 	st := store.NewLocalStorage(db)
 	c := NewKeyorixCore(st)
+	c.SetBootstrapToken("test-bootstrap-token")
 	_, err = c.BootstrapSystem(context.Background(), &BootstrapRequest{
-		Username: "admin", Email: "admin@example.com", Password: "password12345", DisplayName: "Admin",
+		Username: "admin", Email: "admin@example.com", Password: "BootstrapPass123!", DisplayName: "Admin",
+		Token: "test-bootstrap-token",
 	})
 	require.NoError(t, err)
 	return c, st

--- a/internal/core/auth_bootstrap_token_test.go
+++ b/internal/core/auth_bootstrap_token_test.go
@@ -1,0 +1,93 @@
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// freshBootstrapCore returns a non-bootstrapped core over an in-memory store.
+func freshBootstrapCore(t *testing.T) *KeyorixCore {
+	t.Helper()
+	require.NoError(t, i18n.Initialize(&config.Config{
+		Locale: config.LocaleConfig{Language: "en", FallbackLanguage: "en"},
+	}))
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.User{}, &models.Role{}, &models.Permission{}, &models.RolePermission{},
+		&models.UserRole{}, &models.Group{}, &models.UserGroup{}, &models.GroupRole{},
+		&models.Project{}, &models.Environment{},
+	))
+	return NewKeyorixCore(store.NewLocalStorage(db))
+}
+
+func strongBootstrapReq(token string) *BootstrapRequest {
+	return &BootstrapRequest{
+		Username: "admin", Email: "admin@example.com",
+		Password: "BootstrapPass123!", DisplayName: "Admin", Token: token,
+	}
+}
+
+// TestBootstrapSystem_TokenGate pins the fix for the unauthenticated first-admin-claim
+// race: /system/init must refuse unless the caller presents the configured token.
+func TestBootstrapSystem_TokenGate(t *testing.T) {
+	t.Run("refuses when no server token is configured (fail closed)", func(t *testing.T) {
+		c := freshBootstrapCore(t) // no SetBootstrapToken
+		_, err := c.BootstrapSystem(context.Background(), strongBootstrapReq("anything"))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "disabled")
+		// Nothing was seeded.
+		needs, nerr := c.SystemNeedsBootstrap(context.Background())
+		require.NoError(t, nerr)
+		assert.True(t, needs, "no admin should exist after a refused bootstrap")
+	})
+
+	t.Run("refuses a wrong token", func(t *testing.T) {
+		c := freshBootstrapCore(t)
+		c.SetBootstrapToken("correct-token")
+		_, err := c.BootstrapSystem(context.Background(), strongBootstrapReq("wrong-token"))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid bootstrap token")
+		needs, _ := c.SystemNeedsBootstrap(context.Background())
+		assert.True(t, needs)
+	})
+
+	t.Run("refuses a weak admin password even with the right token", func(t *testing.T) {
+		c := freshBootstrapCore(t)
+		c.SetBootstrapToken("correct-token")
+		req := strongBootstrapReq("correct-token")
+		req.Password = "admin" // below the default policy floor
+		_, err := c.BootstrapSystem(context.Background(), req)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "password must")
+	})
+
+	t.Run("succeeds with the right token and a strong password", func(t *testing.T) {
+		c := freshBootstrapCore(t)
+		c.SetBootstrapToken("correct-token")
+		res, err := c.BootstrapSystem(context.Background(), strongBootstrapReq("correct-token"))
+		require.NoError(t, err)
+		require.NotNil(t, res.User)
+		assert.False(t, res.AlreadyInitialized)
+	})
+
+	t.Run("idempotent repeat needs no token once initialised", func(t *testing.T) {
+		c := freshBootstrapCore(t)
+		c.SetBootstrapToken("correct-token")
+		_, err := c.BootstrapSystem(context.Background(), strongBootstrapReq("correct-token"))
+		require.NoError(t, err)
+		// A second call with no token returns the existing state, not an error.
+		res, err := c.BootstrapSystem(context.Background(), &BootstrapRequest{})
+		require.NoError(t, err)
+		assert.True(t, res.AlreadyInitialized)
+	})
+}

--- a/internal/core/authz.go
+++ b/internal/core/authz.go
@@ -133,6 +133,18 @@ type Scope = storage.Scope
 // expected to be assigned at a project scope (bypasses within that project).
 var adminRoleNames = []string{"super_admin", "admin", "system_admin", "project_admin"}
 
+// isAdminRoleName reports whether roleName is one of the admin (permission-bypass)
+// roles — a pure-string check requiring no storage lookup, for guards that already
+// hold the role name.
+func isAdminRoleName(roleName string) bool {
+	for _, n := range adminRoleNames {
+		if n == roleName {
+			return true
+		}
+	}
+	return false
+}
+
 // AuthorizePrincipal reports whether a principal — a human user or a machine
 // identity (ADR-030) — may exercise permission against the target scope. It is
 // the actor-aware entrypoint the auth gates use; Authorize is the user-only

--- a/internal/core/authz.go
+++ b/internal/core/authz.go
@@ -186,6 +186,24 @@ func (c *KeyorixCore) Authorize(ctx context.Context, userID uint, permission str
 	return c.storage.RoleSetHasPermission(ctx, roleIDs, permission)
 }
 
+// principalHasScopedPermission reports whether userID's OWN roles grant permission at
+// scope, independent of any PAT restriction on the context (which belongs to the
+// requesting actor, not this user). Use it to vet a THIRD party — e.g. a prospective
+// secret owner — without the caller's token narrowing the result. Fails closed.
+func (c *KeyorixCore) principalHasScopedPermission(ctx context.Context, userID uint, permission string, scope Scope) (bool, error) {
+	roleIDs, err := c.scopedRoleIDs(ctx, userID, scope)
+	if err != nil {
+		return false, err
+	}
+	if len(roleIDs) == 0 {
+		return false, nil
+	}
+	if c.roleSetContainsAdmin(ctx, roleIDs) {
+		return true, nil
+	}
+	return c.storage.RoleSetHasPermission(ctx, roleIDs, permission)
+}
+
 // IsGlobalAdmin reports whether userID holds an admin role assigned globally
 // (project 0, environment 0). Used to short-circuit scope-filtered listing.
 //

--- a/internal/core/break_glass.go
+++ b/internal/core/break_glass.go
@@ -5,7 +5,10 @@
 // project's admins, and is recorded as a queryable BreakGlassActivation for
 // post-hoc review (NIS2/DORA incident response). Deliberately un-gated by RBAC —
 // the whole point is access the user does NOT already have — so the controls are:
-// it must be enabled, every use is justified + audited + alerted, and it expires.
+// it must be enabled, the activator must be a member of the project (a project-scoped
+// role, not merely the global baseline), the emergency role must be contained (it may
+// not carry roles.assign, so an auto-expiring grant cannot mint permanent access),
+// every use is justified + audited + alerted, and it expires.
 package core
 
 import (
@@ -56,17 +59,18 @@ func (c *KeyorixCore) ActivateBreakGlass(ctx context.Context, projectID, userID 
 	if justification == "" {
 		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "a justification is required for emergency access")
 	}
-	// Only a user already affiliated with the project may break-glass it. Without this,
-	// any authenticated user could self-grant the emergency role on ANY project — break-
-	// glass is for a project you're responsible for but lack a specific power on, not for
-	// arbitrary projects. Eligibility = holding any role that applies at the project scope
-	// (a project-scoped grant, or a global/install-wide role that applies everywhere); a
-	// user scoped only to a DIFFERENT project resolves an empty set and is refused.
-	affiliated, merr := c.storage.GetUserRoleIDsAt(ctx, userID, storage.Scope{ProjectID: projectID})
+	// Only a user already affiliated with the project may break-glass it. Eligibility
+	// must require a role scoped to THIS project (project_id = P), directly or via a
+	// group — NOT merely a global/install-wide role. The previous check used
+	// GetUserRoleIDsAt, which matches project_id = 0 OR P, so the install baseline
+	// (system_viewer, granted globally to every SSO/JIT user) counted as membership and
+	// let any authenticated user self-grant the emergency role on ANY project. IsProjectMember
+	// excludes global roles, so a user scoped only globally (or to a different project) is refused.
+	affiliated, merr := c.storage.IsProjectMember(ctx, userID, projectID)
 	if merr != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), merr)
 	}
-	if len(affiliated) == 0 {
+	if !affiliated {
 		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorPermissionDenied", nil), "break-glass is available only to members of the project")
 	}
 	// Refuse a new activation while the user already holds an active, unexpired one on
@@ -89,10 +93,21 @@ func (c *KeyorixCore) ActivateBreakGlass(ctx context.Context, projectID, userID 
 		return nil, fmt.Errorf("emergency role %q not found: %w", c.breakGlassPolicy.EmergencyRole, err)
 	}
 	// Refuse an install-wide admin role as the emergency role: break-glass grants at a
-	// project scope and must not be a vehicle for install-wide super-user. project_admin
-	// (a project role) is the intended emergency role and is allowed.
+	// project scope and must not be a vehicle for install-wide super-user.
 	if c.installAdminRoleIDSet(ctx)[role.ID] {
 		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "the configured emergency role grants install-wide administration and cannot be used for break-glass")
+	}
+	// Refuse an emergency role that can ASSIGN ROLES or issue credentials. The whole
+	// security model of break-glass is "it auto-expires", but a time-bound role carrying
+	// roles.assign lets the holder mint a PERMANENT grant (or a long-lived machine token)
+	// during the window that outlives it — defeating expiry entirely. The emergency role
+	// must be powerful-but-contained (e.g. project_developer: read/write/delete secrets,
+	// no role administration), NOT project_admin. roles.assign also gates machine-token
+	// issuance, so this one check closes both persistence vectors.
+	if hasAssign, perr := c.storage.RoleSetHasPermission(ctx, []uint{role.ID}, "roles.assign"); perr != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), perr)
+	} else if hasAssign {
+		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "the configured emergency role can assign roles or issue credentials and cannot be used for break-glass (it would let an emergency grant create permanent access); configure a contained role such as project_developer")
 	}
 
 	defaultTTL := c.breakGlassPolicy.DefaultTTL

--- a/internal/core/break_glass.go
+++ b/internal/core/break_glass.go
@@ -56,12 +56,48 @@ func (c *KeyorixCore) ActivateBreakGlass(ctx context.Context, projectID, userID 
 	if justification == "" {
 		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "a justification is required for emergency access")
 	}
+	// Only a user already affiliated with the project may break-glass it. Without this,
+	// any authenticated user could self-grant the emergency role on ANY project — break-
+	// glass is for a project you're responsible for but lack a specific power on, not for
+	// arbitrary projects.
+	members, merr := c.storage.ListProjectMembers(ctx, projectID)
+	if merr != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), merr)
+	}
+	isMember := false
+	for _, m := range members {
+		if m.UserID == userID {
+			isMember = true
+			break
+		}
+	}
+	if !isMember {
+		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorPermissionDenied", nil), "break-glass is available only to members of the project")
+	}
+	// Refuse a new activation while the user already holds an active, unexpired one on
+	// this project — otherwise the time-bound grant becomes indefinitely renewable.
+	bgNow := c.now()
+	existing, lerr := c.storage.ListBreakGlassActivations(ctx, projectID)
+	if lerr != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), lerr)
+	}
+	for _, a := range existing {
+		if a.UserID == userID && a.State == BreakGlassActive && a.ExpiresAt != nil && a.ExpiresAt.After(bgNow) {
+			return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "you already have an active break-glass grant on this project; revoke it before activating again")
+		}
+	}
 	if c.breakGlassPolicy.EmergencyRole == "" {
 		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "no emergency role is configured")
 	}
 	role, err := c.storage.GetRoleByName(ctx, c.breakGlassPolicy.EmergencyRole)
 	if err != nil {
 		return nil, fmt.Errorf("emergency role %q not found: %w", c.breakGlassPolicy.EmergencyRole, err)
+	}
+	// Refuse an install-wide admin role as the emergency role: break-glass grants at a
+	// project scope and must not be a vehicle for install-wide super-user. project_admin
+	// (a project role) is the intended emergency role and is allowed.
+	if c.installAdminRoleIDSet(ctx)[role.ID] {
+		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "the configured emergency role grants install-wide administration and cannot be used for break-glass")
 	}
 
 	defaultTTL := c.breakGlassPolicy.DefaultTTL

--- a/internal/core/break_glass.go
+++ b/internal/core/break_glass.go
@@ -59,19 +59,14 @@ func (c *KeyorixCore) ActivateBreakGlass(ctx context.Context, projectID, userID 
 	// Only a user already affiliated with the project may break-glass it. Without this,
 	// any authenticated user could self-grant the emergency role on ANY project — break-
 	// glass is for a project you're responsible for but lack a specific power on, not for
-	// arbitrary projects.
-	members, merr := c.storage.ListProjectMembers(ctx, projectID)
+	// arbitrary projects. Eligibility = holding any role that applies at the project scope
+	// (a project-scoped grant, or a global/install-wide role that applies everywhere); a
+	// user scoped only to a DIFFERENT project resolves an empty set and is refused.
+	affiliated, merr := c.storage.GetUserRoleIDsAt(ctx, userID, storage.Scope{ProjectID: projectID})
 	if merr != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), merr)
 	}
-	isMember := false
-	for _, m := range members {
-		if m.UserID == userID {
-			isMember = true
-			break
-		}
-	}
-	if !isMember {
+	if len(affiliated) == 0 {
 		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorPermissionDenied", nil), "break-glass is available only to members of the project")
 	}
 	// Refuse a new activation while the user already holds an active, unexpired one on

--- a/internal/core/break_glass_external_test.go
+++ b/internal/core/break_glass_external_test.go
@@ -260,9 +260,58 @@ func TestActivateBreakGlass_RejectsConcurrentReactivation(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// A user affiliated with the project ONLY via a global/install-wide role (e.g. the
+// system_viewer baseline every SSO user receives) is NOT a project member and must be
+// refused — otherwise any authenticated user could break-glass any project.
+func TestActivateBreakGlass_RejectsGlobalOnlyAffiliation(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	migrateBreakGlass(t, h)
+	enableBreakGlass(h, "editor", 4*time.Hour, 24*time.Hour)
+
+	ctx := context.Background()
+	h.CreateTestUser(t, "ssouser", 10)
+	h.AssignUserRole(t, 10, 4, nil) // viewer at GLOBAL scope (project_id = 0), not project-scoped
+
+	_, err := h.CoreService.ActivateBreakGlass(ctx, 2, 10, "incident", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "members of the project")
+}
+
+// The emergency role must not carry roles.assign: a time-bound role that can assign
+// roles (or issue credentials) could be used during the window to mint a PERMANENT
+// grant that outlives break-glass, defeating auto-expiry. A (non-admin) role carrying
+// roles.assign is refused; a contained role (editor — no roles.assign) is fine.
+func TestActivateBreakGlass_RejectsRoleAssignEmergencyRole(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	migrateBreakGlass(t, h)
+
+	const proj = uint(2)
+	ctx := context.Background()
+	h.CreateTestUser(t, "alice", 10)
+	makeProjectMember(t, h, 10, proj)
+
+	// A delegated, NON-admin role that nonetheless carries roles.assign (perm id 13).
+	h.ExecuteRawSQL(t, "INSERT OR IGNORE INTO roles (id, name, description) VALUES (?, ?, ?)",
+		50, "delegated_approver", "non-admin role that can assign roles")
+	h.ExecuteRawSQL(t, "INSERT OR IGNORE INTO role_permissions (role_id, permission_id) VALUES (?, ?)", 50, 13)
+
+	enableBreakGlass(h, "delegated_approver", 4*time.Hour, 24*time.Hour)
+	_, err := h.CoreService.ActivateBreakGlass(ctx, proj, 10, "incident", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "assign roles")
+
+	// editor is contained (no roles.assign) → allowed.
+	enableBreakGlass(h, "editor", 4*time.Hour, 24*time.Hour)
+	act, err := h.CoreService.ActivateBreakGlass(ctx, proj, 10, "incident", "")
+	require.NoError(t, err)
+	assert.Equal(t, core.BreakGlassActive, act.State)
+}
+
 // An install-wide admin role (super_admin/admin/system_admin) must not be usable as the
 // emergency role: break-glass grants at a project scope and must not become a vehicle
-// for install-wide super-user. (project_admin — a project role — remains valid.)
+// for install-wide super-user.
 func TestActivateBreakGlass_RejectsInstallAdminEmergencyRole(t *testing.T) {
 	h := testhelper.NewRBACTestHelper(t)
 	defer h.Cleanup()

--- a/internal/core/break_glass_external_test.go
+++ b/internal/core/break_glass_external_test.go
@@ -23,6 +23,14 @@ func migrateBreakGlass(t *testing.T, h *testhelper.RBACTestHelper) {
 	require.NoError(t, h.DB.AutoMigrate(&models.BreakGlassActivation{}, &models.AuditEvent{}))
 }
 
+// makeProjectMember gives the user a baseline (viewer) role at the project so they
+// satisfy break-glass's project-eligibility gate — the realistic scenario is a member
+// who lacks the specific emergency power, not an unaffiliated outsider.
+func makeProjectMember(t *testing.T, h *testhelper.RBACTestHelper, userID, projectID uint) {
+	pid := projectID
+	h.AssignUserRole(t, userID, 4, &pid) // role 4 = viewer
+}
+
 // Activating break-glass time-bound-grants the configured emergency role to the
 // caller and records the justified activation.
 func TestActivateBreakGlass_GrantsTimeBoundRole(t *testing.T) {
@@ -34,6 +42,7 @@ func TestActivateBreakGlass_GrantsTimeBoundRole(t *testing.T) {
 	const proj = uint(2)
 	ctx := context.Background()
 	h.CreateTestUser(t, "alice", 10)
+	makeProjectMember(t, h, 10, proj)
 
 	act, err := h.CoreService.ActivateBreakGlass(ctx, proj, 10, "prod incident #42", "")
 	require.NoError(t, err)
@@ -62,6 +71,7 @@ func TestActivateBreakGlass_CapsTTL(t *testing.T) {
 
 	ctx := context.Background()
 	h.CreateTestUser(t, "alice", 10)
+	makeProjectMember(t, h, 10, 2)
 	act, err := h.CoreService.ActivateBreakGlass(ctx, 2, 10, "incident", "10h")
 	require.NoError(t, err)
 	require.NotNil(t, act.ExpiresAt)
@@ -79,6 +89,7 @@ func TestActivateBreakGlass_UnsetMaxTTLFloorsToDefault(t *testing.T) {
 
 	ctx := context.Background()
 	h.CreateTestUser(t, "alice", 10)
+	makeProjectMember(t, h, 10, 2)
 	act, err := h.CoreService.ActivateBreakGlass(ctx, 2, 10, "incident", "720h") // 30-day override
 	require.NoError(t, err)
 	require.NotNil(t, act.ExpiresAt)
@@ -115,6 +126,7 @@ func TestRevokeBreakGlass_RemovesGrant(t *testing.T) {
 	const proj = uint(2)
 	ctx := context.Background()
 	h.CreateTestUser(t, "alice", 10)
+	makeProjectMember(t, h, 10, proj)
 
 	act, err := h.CoreService.ActivateBreakGlass(ctx, proj, 10, "incident", "")
 	require.NoError(t, err)
@@ -168,6 +180,7 @@ func TestBreakGlass_ExpiredGrantDeniesAuthorization(t *testing.T) {
 	const proj = uint(2)
 	ctx := context.Background()
 	h.CreateTestUser(t, "alice", 10)
+	makeProjectMember(t, h, 10, proj)
 
 	_, err := h.CoreService.ActivateBreakGlass(ctx, proj, 10, "prod incident", "")
 	require.NoError(t, err)
@@ -192,4 +205,76 @@ func TestBreakGlass_ExpiredGrantDeniesAuthorization(t *testing.T) {
 	ok, err = h.CoreService.Authorize(ctx, 10, "secrets.write", core.Scope{ProjectID: proj})
 	require.NoError(t, err)
 	assert.False(t, ok, "an expired break-glass grant must confer no access at the authorization boundary")
+}
+
+// A user with no affiliation to the project cannot break-glass it — otherwise any
+// authenticated user could self-grant the emergency role on an arbitrary project.
+func TestActivateBreakGlass_RejectsNonMember(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	migrateBreakGlass(t, h)
+	enableBreakGlass(h, "editor", 4*time.Hour, 24*time.Hour)
+
+	ctx := context.Background()
+	h.CreateTestUser(t, "outsider", 10) // created, but NOT a member of project 2
+
+	_, err := h.CoreService.ActivateBreakGlass(ctx, 2, 10, "incident", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "members of the project")
+
+	// And no activation was recorded for the rejected attempt.
+	list, err := h.CoreService.ListBreakGlassActivations(ctx, 2)
+	require.NoError(t, err)
+	assert.Empty(t, list)
+}
+
+// A second activation is refused while the user already holds an active, unexpired
+// grant — so a time-bound emergency grant can't be silently renewed into permanence.
+func TestActivateBreakGlass_RejectsConcurrentReactivation(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	migrateBreakGlass(t, h)
+	enableBreakGlass(h, "editor", 4*time.Hour, 24*time.Hour)
+
+	const proj = uint(2)
+	ctx := context.Background()
+	h.CreateTestUser(t, "alice", 10)
+	makeProjectMember(t, h, 10, proj)
+
+	_, err := h.CoreService.ActivateBreakGlass(ctx, proj, 10, "first incident", "")
+	require.NoError(t, err)
+
+	// Second activation while the first is still active → refused.
+	_, err = h.CoreService.ActivateBreakGlass(ctx, proj, 10, "again", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already have an active break-glass grant")
+
+	// Exactly one activation exists.
+	list, err := h.CoreService.ListBreakGlassActivations(ctx, proj)
+	require.NoError(t, err)
+	require.Len(t, list, 1)
+
+	// Once the first is revoked, a fresh activation is allowed again.
+	require.NoError(t, h.CoreService.RevokeBreakGlass(ctx, 1, proj, list[0].ID))
+	_, err = h.CoreService.ActivateBreakGlass(ctx, proj, 10, "new incident", "")
+	require.NoError(t, err)
+}
+
+// An install-wide admin role (super_admin/admin/system_admin) must not be usable as the
+// emergency role: break-glass grants at a project scope and must not become a vehicle
+// for install-wide super-user. (project_admin — a project role — remains valid.)
+func TestActivateBreakGlass_RejectsInstallAdminEmergencyRole(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	migrateBreakGlass(t, h)
+	enableBreakGlass(h, "admin", 4*time.Hour, 24*time.Hour) // admin is an install-wide role
+
+	const proj = uint(2)
+	ctx := context.Background()
+	h.CreateTestUser(t, "alice", 10)
+	makeProjectMember(t, h, 10, proj)
+
+	_, err := h.CoreService.ActivateBreakGlass(ctx, proj, 10, "incident", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "install-wide administration")
 }

--- a/internal/core/certificate.go
+++ b/internal/core/certificate.go
@@ -126,21 +126,74 @@ func (c *KeyorixCore) refreshCertNotAfterCache(ctx context.Context, secret *mode
 	}
 }
 
-// parseLeafCertificate extracts the first X.509 certificate from a value that may be
+// maxCertBlocks bounds how many CERTIFICATE blocks we parse from a single value, so a
+// pathological PEM (the body is already capped at MaxBodyBytes) can't burn CPU.
+const maxCertBlocks = 64
+
+// parseLeafCertificate extracts the leaf X.509 certificate from a value that may be
 // PEM (one or more blocks, possibly alongside a private key) or raw DER. Only
 // CERTIFICATE blocks are considered — a PRIVATE KEY block is never parsed or returned.
+//
+// It does NOT trust block order. PEM chains are routinely stored leaf-last (a CA
+// bundle, or a root/intermediate pasted ahead of the serving cert), so returning the
+// FIRST block would let a long-lived CA's NotAfter mask a short-lived leaf and
+// silently defeat the ADR-055/056 expiry monitor; an unparseable first block would
+// likewise hide a valid leaf behind it. Instead it parses every CERTIFICATE block,
+// skips the ones that don't parse, and selects the leaf via selectLeafCertificate.
 func parseLeafCertificate(value []byte) (*x509.Certificate, error) {
+	var certs []*x509.Certificate
 	rest := value
-	for {
+	sawPEMBlock := false
+	for len(certs) < maxCertBlocks {
 		block, remainder := pem.Decode(rest)
 		if block == nil {
 			break
 		}
-		if block.Type == "CERTIFICATE" {
-			return x509.ParseCertificate(block.Bytes)
-		}
+		sawPEMBlock = true
 		rest = remainder
+		if block.Type != "CERTIFICATE" {
+			continue
+		}
+		// Skip an unparseable CERTIFICATE block rather than aborting — a corrupt block
+		// must not hide a valid (possibly soon-expiring) leaf elsewhere in the value.
+		if cert, err := x509.ParseCertificate(block.Bytes); err == nil {
+			certs = append(certs, cert)
+		}
 	}
-	// Not PEM (or no CERTIFICATE block) — try raw DER.
-	return x509.ParseCertificate(value)
+	if !sawPEMBlock {
+		// Not PEM — try raw DER (a single certificate).
+		return x509.ParseCertificate(value)
+	}
+	if len(certs) == 0 {
+		return nil, fmt.Errorf("no parseable X.509 certificate found")
+	}
+	return selectLeafCertificate(certs), nil
+}
+
+// selectLeafCertificate picks the certificate the expiry/hygiene control should key
+// off: the soonest-expiring END-ENTITY (non-CA) certificate, so a chain that stores a
+// long-lived CA/intermediate ahead of a short-lived leaf can't hide the leaf's
+// expiry. Falls back to the soonest-expiring certificate overall when every block is a
+// CA. Order-independent by construction.
+func selectLeafCertificate(certs []*x509.Certificate) *x509.Certificate {
+	var chosen *x509.Certificate
+	for _, cert := range certs {
+		if cert.IsCA {
+			continue
+		}
+		if chosen == nil || cert.NotAfter.Before(chosen.NotAfter) {
+			chosen = cert
+		}
+	}
+	if chosen != nil {
+		return chosen
+	}
+	// All blocks are CAs — still pick the soonest-expiring so the control fails safe.
+	chosen = certs[0]
+	for _, cert := range certs[1:] {
+		if cert.NotAfter.Before(chosen.NotAfter) {
+			chosen = cert
+		}
+	}
+	return chosen
 }

--- a/internal/core/certificate_test.go
+++ b/internal/core/certificate_test.go
@@ -42,6 +42,60 @@ func selfSignedPEM(t *testing.T, cn string, notAfter time.Time) (certPEM, keyPEM
 	return certPEM, keyPEM
 }
 
+// caCertPEM mints a self-signed CA certificate valid until notAfter (IsCA=true),
+// used to build leaf-last / CA-first chains.
+func caCertPEM(t *testing.T, cn string, notAfter time.Time) []byte {
+	t.Helper()
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(9999),
+		Subject:               pkix.Name{CommonName: cn},
+		NotBefore:             notAfter.Add(-3650 * 24 * time.Hour),
+		NotAfter:              notAfter,
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &priv.PublicKey, priv)
+	require.NoError(t, err)
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+}
+
+// TestParseLeafCertificate_OrderIndependent proves the expiry monitor can't be
+// defeated by chain ordering or a corrupt leading block: parseLeafCertificate always
+// surfaces the soonest-expiring end-entity (non-CA) leaf regardless of position.
+func TestParseLeafCertificate_OrderIndependent(t *testing.T) {
+	base := time.Date(2026, 6, 23, 12, 0, 0, 0, time.UTC)
+	leafPEM, _ := selfSignedPEM(t, "leaf.example.com", base.Add(30*24*time.Hour)) // short-lived leaf
+	caPEM := caCertPEM(t, "Root CA", base.Add(3650*24*time.Hour))                 // long-lived CA
+	leafNotAfter := base.Add(30 * 24 * time.Hour)
+
+	t.Run("CA-first bundle still yields the leaf's expiry", func(t *testing.T) {
+		bundle := append(append([]byte{}, caPEM...), leafPEM...)
+		cert, err := parseLeafCertificate(bundle)
+		require.NoError(t, err)
+		assert.False(t, cert.IsCA, "must select the end-entity leaf, not the CA")
+		assert.WithinDuration(t, leafNotAfter, cert.NotAfter, time.Second)
+	})
+
+	t.Run("corrupt leading CERTIFICATE block does not hide the valid leaf", func(t *testing.T) {
+		garbage := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: []byte("not a real der cert")})
+		bundle := append(append([]byte{}, garbage...), leafPEM...)
+		cert, err := parseLeafCertificate(bundle)
+		require.NoError(t, err)
+		assert.WithinDuration(t, leafNotAfter, cert.NotAfter, time.Second)
+	})
+
+	t.Run("all-CA bundle falls back to soonest-expiring CA", func(t *testing.T) {
+		soonCA := caCertPEM(t, "Intermediate", base.Add(100*24*time.Hour))
+		bundle := append(append([]byte{}, caPEM...), soonCA...)
+		cert, err := parseLeafCertificate(bundle)
+		require.NoError(t, err)
+		assert.WithinDuration(t, base.Add(100*24*time.Hour), cert.NotAfter, time.Second)
+	})
+}
+
 func newCertCore(t *testing.T, now time.Time) (*KeyorixCore, *gorm.DB) {
 	t.Helper()
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})

--- a/internal/core/compliance_evidence.go
+++ b/internal/core/compliance_evidence.go
@@ -99,7 +99,7 @@ func (c *KeyorixCore) GenerateComplianceEvidence(ctx context.Context) (*Complian
 	}
 
 	// Overdue rotations (deployment-wide).
-	if statuses, err := c.GetRotationStatus(ctx, nil); err == nil {
+	if statuses, err := c.GetRotationStatus(ctx, nil, nil); err == nil {
 		for _, s := range statuses {
 			if s.Status == RotationStatusOverdue {
 				ev.RotationOverdue = append(ev.RotationOverdue, EvidenceRotation{

--- a/internal/core/compliance_posture.go
+++ b/internal/core/compliance_posture.go
@@ -214,7 +214,7 @@ func (c *KeyorixCore) GetCompliancePosture(ctx context.Context) (*CompliancePost
 	}
 
 	// Rotation hygiene (deployment-wide).
-	if statuses, err := c.GetRotationStatus(ctx, nil); err == nil {
+	if statuses, err := c.GetRotationStatus(ctx, nil, nil); err == nil {
 		p.Rotation.CoveredSecrets = len(statuses)
 		for _, s := range statuses {
 			switch s.Status {

--- a/internal/core/dashboard.go
+++ b/internal/core/dashboard.go
@@ -85,9 +85,15 @@ func (c *KeyorixCore) GetDashboardStats(ctx context.Context, userID uint, userna
 		sharedWithMe = len(incoming)
 	}
 
-	uid := userID
-	_ = uid // recent activity shows all users' events
+	// Recent activity is audit data. Only an auditor (audit.read) may see ALL users'
+	// events — otherwise scope it to the caller's own activity, so the dashboard doesn't
+	// leak secret names / actions from projects the caller can't read.
+	var auditActor *uint
+	if ok, _ := c.Authorize(ctx, userID, "audit.read", Scope{}); !ok {
+		auditActor = &userID
+	}
 	events, _, _ := c.storage.GetAuditLogs(ctx, &storage.AuditFilter{
+		UserID:   auditActor,
 		Page:     1,
 		PageSize: 5,
 	})

--- a/internal/core/data_retention.go
+++ b/internal/core/data_retention.go
@@ -73,6 +73,12 @@ func (c *KeyorixCore) RetentionPolicy() RetentionPolicy {
 // CALLERS MUST gate this on legal-hold status (the scheduler does): an active hold
 // must preserve all records, so this is not invoked while a hold is in effect.
 func (c *KeyorixCore) PurgeExpiredComplianceRecords(ctx context.Context, now time.Time, policy RetentionPolicy) (*RetentionResult, error) {
+	// Authoritative legal-hold re-check inside the locked purge (see PurgeExpiredSoftDeletes):
+	// closes the TOCTOU where a hold placed after the scheduler's pre-lock check would not
+	// stop the in-flight deletion of compliance records. Fails SAFE.
+	if err := c.legalHoldGuard(ctx); err != nil {
+		return &RetentionResult{}, err
+	}
 	res := &RetentionResult{}
 	var firstErr error
 	rec := func(err error) {

--- a/internal/core/data_retention_test.go
+++ b/internal/core/data_retention_test.go
@@ -19,6 +19,7 @@ func TestPurgeExpiredComplianceRecords_CountsCutoffsAndAudits(t *testing.T) {
 		ResolvedAccessRequestsDays: 180,
 	}
 	store := new(MockStorage)
+	store.On("GetActiveLegalHold", mock.Anything).Return(nil, nil) // no active legal hold
 	store.On("DeleteAnomalyAlertsBefore", mock.Anything, now.AddDate(0, 0, -30)).Return(int64(5), nil)
 	store.On("DeleteClosedAccessReviewsBefore", mock.Anything, now.AddDate(0, 0, -365)).Return(int64(2), int64(7), nil)
 	store.On("DeleteExpiredBreakGlassBefore", mock.Anything, now.AddDate(0, 0, -90)).Return(int64(1), nil)
@@ -52,6 +53,7 @@ func TestPurgeExpiredComplianceRecords_ZeroWindowsSkipped(t *testing.T) {
 	// Only break-glass has a window; every other type is keep-forever (0).
 	policy := RetentionPolicy{BreakGlassDays: 45}
 	store := new(MockStorage)
+	store.On("GetActiveLegalHold", mock.Anything).Return(nil, nil) // no active legal hold
 	store.On("DeleteExpiredBreakGlassBefore", mock.Anything, mock.Anything).Return(int64(0), nil)
 
 	c := NewKeyorixCore(store)

--- a/internal/core/dynamic_secrets.go
+++ b/internal/core/dynamic_secrets.go
@@ -262,7 +262,10 @@ func (c *KeyorixCore) RevokeLease(ctx context.Context, leaseID string, userID ui
 	if err != nil {
 		return fmt.Errorf("lease not found")
 	}
-	if lease.Status != "active" {
+	// Admit revoke_failed too: a prior revoke whose target drop failed left the underlying
+	// credential LIVE, so it must remain retryable (manually or via the sweep). Only an
+	// already-revoked/expired lease is a no-op.
+	if lease.Status != "active" && lease.Status != "revoke_failed" {
 		return fmt.Errorf("lease is not active (status %s)", lease.Status)
 	}
 	cfg, err := c.storage.GetDynamicSecretConfig(ctx, lease.ConfigID)
@@ -303,18 +306,25 @@ func (c *KeyorixCore) RevokeLease(ctx context.Context, leaseID string, userID ui
 	return nil
 }
 
-// RevokeExpiredLeases is the auto-revoke sweep: it revokes every active lease
-// past its expiry (system-actored). Returns the count revoked.
+// RevokeExpiredLeases is the auto-revoke sweep: it revokes every active (or previously
+// revoke_failed) lease past its expiry (system-actored). Returns the count revoked and a
+// non-nil error if any revoke failed, so the scheduler records the partial failure rather
+// than reporting a clean sweep while credentials remain live past their TTL.
 func (c *KeyorixCore) RevokeExpiredLeases(ctx context.Context, before time.Time) (int, error) {
 	expired, err := c.storage.ListExpiredActiveLeases(ctx, before)
 	if err != nil {
 		return 0, err
 	}
-	revoked := 0
+	revoked, failed := 0, 0
 	for _, l := range expired {
 		if err := c.RevokeLease(ctx, l.LeaseID, 0, "expired"); err == nil {
 			revoked++
+		} else {
+			failed++
 		}
+	}
+	if failed > 0 {
+		return revoked, fmt.Errorf("dynamic-secrets sweep: %d of %d expired lease(s) failed to revoke — those credentials remain live past their TTL", failed, len(expired))
 	}
 	return revoked, nil
 }
@@ -330,7 +340,8 @@ func (c *KeyorixCore) RevokeLeasesForConfig(ctx context.Context, configID, userI
 		return 0, 0, err
 	}
 	for _, l := range leases {
-		if l.Status != "active" {
+		// Retry a previously-failed revoke too — its credential is still live.
+		if l.Status != "active" && l.Status != "revoke_failed" {
 			continue
 		}
 		if rerr := c.RevokeLease(ctx, l.LeaseID, userID, reason); rerr != nil {

--- a/internal/core/dynamic_secrets.go
+++ b/internal/core/dynamic_secrets.go
@@ -26,6 +26,7 @@ type CreateDynamicSecretConfigRequest struct {
 	CreationTemplate  string
 	DefaultTTLSeconds int
 	MaxTTLSeconds     int
+	MaxActiveLeases   int
 	CreatedBy         string
 	// Classification is an optional data-sensitivity label (A.5.12) for the
 	// credentials this config mints: "" or one of public|internal|confidential|restricted.
@@ -72,6 +73,7 @@ func (c *KeyorixCore) CreateDynamicSecretConfig(ctx context.Context, req *Create
 		CreationTemplate:  req.CreationTemplate,
 		DefaultTTLSeconds: req.DefaultTTLSeconds,
 		MaxTTLSeconds:     req.MaxTTLSeconds,
+		MaxActiveLeases:   req.MaxActiveLeases,
 		Classification:    req.Classification,
 		CreatedBy:         req.CreatedBy,
 		CreatedAt:         c.now(),
@@ -150,6 +152,18 @@ func (c *KeyorixCore) IssueLease(ctx context.Context, configID uint, ttlSeconds 
 	// enforced — a false promise — so refuse and point the operator at the fix.
 	if !engine.SupportsNativeExpiry() && !c.dynamicSweepEnabled {
 		return nil, fmt.Errorf("cannot issue from the %s backend while the auto-revoke sweeper is disabled: its lease TTL is enforced only by the sweeper, so the credential would never expire — enable dynamic_secrets.sweep_enabled", cfg.BackendType)
+	}
+	// Enforce the config's active-lease ceiling so a caller can't mint unbounded real DB
+	// roles/users (resource exhaustion on the target). A small race under concurrency is
+	// acceptable for a soft resource cap.
+	if cfg.MaxActiveLeases > 0 {
+		active, cerr := c.storage.CountActiveLeases(ctx, configID)
+		if cerr != nil {
+			return nil, fmt.Errorf("failed to check active lease count: %w", cerr)
+		}
+		if active >= int64(cfg.MaxActiveLeases) {
+			return nil, fmt.Errorf("active-lease limit reached for this config (%d); revoke a lease before issuing another", cfg.MaxActiveLeases)
+		}
 	}
 	adminDSN, err := c.decryptAuthSecret(cfg.AdminDSNEnc, cfg.AdminDSNMeta)
 	if err != nil {

--- a/internal/core/dynamic_secrets.go
+++ b/internal/core/dynamic_secrets.go
@@ -403,6 +403,12 @@ func (c *KeyorixCore) RenewLease(ctx context.Context, leaseID string, ttlSeconds
 	if err != nil {
 		return time.Time{}, err
 	}
+	// A backend with no DB-level expiry relies entirely on the sweeper to enforce a
+	// lease's TTL. With the sweeper disabled, a renewal would extend a credential nothing
+	// will ever revoke — mirror IssueLease's fail-closed refusal.
+	if !engine.SupportsNativeExpiry() && !c.dynamicSweepEnabled {
+		return time.Time{}, fmt.Errorf("renewal is unavailable for the %s backend while the lease sweeper is disabled (its TTL would be unenforced)", cfg.BackendType)
+	}
 	adminDSN, err := c.decryptAuthSecret(cfg.AdminDSNEnc, cfg.AdminDSNMeta)
 	if err != nil {
 		return time.Time{}, fmt.Errorf("failed to decrypt admin DSN: %w", err)

--- a/internal/core/dynamic_secrets_test.go
+++ b/internal/core/dynamic_secrets_test.go
@@ -68,6 +68,34 @@ func TestDynamicSecrets_ConfigEncryptsAdminDSN(t *testing.T) {
 	assert.NotEqual(t, adminDSNPlain, string(stored.AdminDSNEnc))
 }
 
+func TestDynamicSecrets_MaxActiveLeasesCeiling(t *testing.T) {
+	c, _, _, _ := newDynamicTestCore(t)
+	ctx := context.Background()
+	cfg, err := c.CreateDynamicSecretConfig(ctx, &CreateDynamicSecretConfigRequest{
+		Name: "capped", ProjectID: 1, EnvironmentID: 2, BackendType: "postgres",
+		AdminDSN: adminDSNPlain, CreationTemplate: "GRANT SELECT TO {{name}};",
+		DefaultTTLSeconds: 3600, MaxActiveLeases: 2, CreatedBy: "alice",
+	})
+	require.NoError(t, err)
+
+	// Two leases are allowed...
+	_, err = c.IssueLease(ctx, cfg.ID, 0, 7)
+	require.NoError(t, err)
+	_, err = c.IssueLease(ctx, cfg.ID, 0, 7)
+	require.NoError(t, err)
+	// ...the third exceeds the ceiling.
+	_, err = c.IssueLease(ctx, cfg.ID, 0, 7)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "active-lease limit")
+
+	// Revoking one frees a slot.
+	leases, err := c.ListDynamicSecretLeases(ctx, cfg.ID)
+	require.NoError(t, err)
+	require.NoError(t, c.RevokeLease(ctx, leases[0].LeaseID, 7, "manual"))
+	_, err = c.IssueLease(ctx, cfg.ID, 0, 7)
+	require.NoError(t, err, "a slot opens after a revoke")
+}
+
 func TestDynamicSecrets_IssueListRevoke(t *testing.T) {
 	c, db, fake, _ := newDynamicTestCore(t)
 	ctx := context.Background()

--- a/internal/core/dynamic_secrets_test.go
+++ b/internal/core/dynamic_secrets_test.go
@@ -174,6 +174,44 @@ func TestDynamicSecrets_RevokeFailureMarksLease(t *testing.T) {
 	assert.NotNil(t, after.RevokedAt)
 }
 
+// A revoke_failed lease (its credential still live) must remain retryable — manually and
+// via the sweep — not be a terminal dead-end. The sweep also surfaces a persistent
+// failure as an error so a mass TTL-enforcement outage isn't reported as a clean pass.
+func TestDynamicSecrets_RevokeFailedIsRetryable(t *testing.T) {
+	c, _, fake, fixed := newDynamicTestCore(t)
+	ctx := context.Background()
+	cfg := mkConfig(t, c, ctx)
+
+	issued, err := c.IssueLease(ctx, cfg.ID, 0, 7)
+	require.NoError(t, err)
+
+	// First revoke fails on the target → revoke_failed (the credential is still live).
+	fake.FailRevoke = true
+	require.Error(t, c.RevokeLease(ctx, issued.LeaseID, 7, "manual"))
+	failed, _ := c.storage.GetDynamicSecretLease(ctx, issued.LeaseID)
+	require.Equal(t, "revoke_failed", failed.Status)
+
+	// A manual retry must be ACCEPTED (not rejected as "not active"). While the target is
+	// still down it fails again — but the lease stays retryable.
+	require.Error(t, c.RevokeLease(ctx, issued.LeaseID, 7, "retry"), "retry is attempted, not refused")
+
+	// Backdate past expiry: the sweep must pick up the revoke_failed lease and, while the
+	// target is still down, surface the persistent failure as a non-nil error.
+	failed.ExpiresAt = fixed.Add(-time.Hour)
+	require.NoError(t, c.storage.UpdateDynamicSecretLease(ctx, failed))
+	_, serr := c.RevokeExpiredLeases(ctx, fixed)
+	require.Error(t, serr, "the sweep surfaces a still-failing revoke")
+
+	// The target recovers — the sweep now drops the credential and the lease is revoked.
+	fake.FailRevoke = false
+	n, err := c.RevokeExpiredLeases(ctx, fixed)
+	require.NoError(t, err)
+	assert.Equal(t, 1, n)
+	done, _ := c.storage.GetDynamicSecretLease(ctx, issued.LeaseID)
+	assert.Equal(t, "revoked", done.Status)
+	assert.Contains(t, fake.Revoked, issued.Username)
+}
+
 func TestDynamicSecrets_IssueRejectsUnknownConfig(t *testing.T) {
 	c, _, _, _ := newDynamicTestCore(t)
 	ctx := context.Background()

--- a/internal/core/impersonation.go
+++ b/internal/core/impersonation.go
@@ -37,6 +37,14 @@ func (c *KeyorixCore) StartImpersonation(ctx context.Context, adminID, targetID 
 	if adminID == targetID {
 		return nil, nil, fmt.Errorf("cannot impersonate yourself")
 	}
+	// A request authenticated with a least-privilege PAT (ADR-042) must not LAUNDER that
+	// restriction through impersonation: the impersonation session is a plain session
+	// carrying no restriction, so it would act as the target with the target's FULL
+	// permissions — escaping the bound the PAT deliberately imposed. Refuse, mirroring
+	// IsGlobalAdmin's fail-closed convention for the PAT restriction.
+	if patRestrictionFromContext(ctx) != nil {
+		return nil, nil, fmt.Errorf("a restricted access token may not start impersonation")
+	}
 	admin, err := c.storage.GetUser(ctx, adminID)
 	if err != nil {
 		return nil, nil, fmt.Errorf("admin not found")
@@ -44,6 +52,22 @@ func (c *KeyorixCore) StartImpersonation(ctx context.Context, adminID, targetID 
 	target, err := c.storage.GetUser(ctx, targetID)
 	if err != nil {
 		return nil, nil, fmt.Errorf("target user not found")
+	}
+	// Don't mint a session for a target who cannot log in: it would be dead on arrival
+	// (ValidateSessionToken rejects blocked/inactive accounts on every request) and would
+	// only produce a misleading impersonation.start audit event.
+	if !target.IsActive || AccountLoginBlocked(target.AccountState) {
+		return nil, nil, fmt.Errorf("cannot impersonate a suspended or inactive user")
+	}
+	// Prevent privilege escalation via impersonation: a caller who is not a global admin
+	// must not impersonate a global admin (which would confer install-wide super-user).
+	// Today users.impersonate is satisfiable only by global admins, so this is a no-op;
+	// it keeps impersonation from escalating if that permission is ever delegated to a
+	// lower-privileged (sub-admin) role.
+	if targetAdmin, _ := c.IsGlobalAdmin(ctx, targetID); targetAdmin {
+		if callerAdmin, _ := c.IsGlobalAdmin(ctx, adminID); !callerAdmin {
+			return nil, nil, fmt.Errorf("cannot impersonate an administrator")
+		}
 	}
 	token, err := generateSecureToken()
 	if err != nil {

--- a/internal/core/impersonation_test.go
+++ b/internal/core/impersonation_test.go
@@ -21,7 +21,10 @@ func TestStartImpersonation_Success(t *testing.T) {
 	ctx := context.Background()
 
 	store.On("GetUser", ctx, uint(1)).Return(&models.User{ID: 1, Username: "admin"}, nil)
-	store.On("GetUser", ctx, uint(2)).Return(&models.User{ID: 2, Username: "alice"}, nil)
+	store.On("GetUser", ctx, uint(2)).Return(&models.User{ID: 2, Username: "alice", IsActive: true}, nil)
+	// The target-rank guard checks whether the target is a global admin (it is not here).
+	store.On("GetUserRoleIDsAt", ctx, uint(2), mock.Anything).Return([]uint{}, nil)
+	store.On("GetUserGroupRoleIDsAt", ctx, uint(2), mock.Anything).Return([]uint{}, nil)
 	store.On("CreateSession", ctx, mock.MatchedBy(func(s *models.Session) bool {
 		return s.UserID == 2 && s.ImpersonatedBy != nil && *s.ImpersonatedBy == 1 &&
 			s.ImpersonationStartedAt != nil
@@ -48,6 +51,55 @@ func TestStartImpersonation_RejectsSelf(t *testing.T) {
 	if _, _, err := c.StartImpersonation(context.Background(), 5, 5, ""); err == nil {
 		t.Fatal("expected an error impersonating yourself")
 	}
+}
+
+// A request carrying a least-privilege PAT restriction may not start impersonation —
+// otherwise the impersonation session (which carries no restriction) would launder the
+// PAT's bound and act as the target with full permissions.
+func TestStartImpersonation_RejectsRestrictedPAT(t *testing.T) {
+	store := new(MockStorage)
+	c := newImpersonationCore(store)
+	ctx := WithPATRestriction(context.Background(), &PATRestriction{Permissions: []string{"users.*"}})
+	_, _, err := c.StartImpersonation(ctx, 1, 2, "")
+	if err == nil || !strings.Contains(err.Error(), "restricted access token") {
+		t.Fatalf("expected a restricted-token rejection, got %v", err)
+	}
+	store.AssertNotCalled(t, "CreateSession", mock.Anything, mock.Anything)
+}
+
+// A suspended/inactive target cannot be impersonated (the session would be dead on
+// arrival and only emit a misleading audit event).
+func TestStartImpersonation_RejectsInactiveTarget(t *testing.T) {
+	store := new(MockStorage)
+	c := newImpersonationCore(store)
+	ctx := context.Background()
+	store.On("GetUser", ctx, uint(1)).Return(&models.User{ID: 1, Username: "admin"}, nil)
+	store.On("GetUser", ctx, uint(2)).Return(&models.User{ID: 2, Username: "alice", IsActive: false}, nil)
+	_, _, err := c.StartImpersonation(ctx, 1, 2, "")
+	if err == nil || !strings.Contains(err.Error(), "suspended or inactive") {
+		t.Fatalf("expected an inactive-target rejection, got %v", err)
+	}
+	store.AssertNotCalled(t, "CreateSession", mock.Anything, mock.Anything)
+}
+
+// A non-admin caller cannot impersonate a global admin (privilege escalation guard).
+func TestStartImpersonation_RejectsAdminTargetForNonAdminCaller(t *testing.T) {
+	store := new(MockStorage)
+	c := newImpersonationCore(store)
+	ctx := context.Background()
+	store.On("GetUser", ctx, uint(1)).Return(&models.User{ID: 1, Username: "helpdesk"}, nil)
+	store.On("GetUser", ctx, uint(2)).Return(&models.User{ID: 2, Username: "root", IsActive: true}, nil)
+	// Target (id 2) holds the admin role globally; caller (id 1) holds nothing.
+	store.On("GetRoleByName", ctx, mock.Anything).Return(&models.Role{ID: 7, Name: "admin"}, nil)
+	store.On("GetUserRoleIDsAt", ctx, uint(2), mock.Anything).Return([]uint{7}, nil)
+	store.On("GetUserGroupRoleIDsAt", ctx, uint(2), mock.Anything).Return([]uint{}, nil)
+	store.On("GetUserRoleIDsAt", ctx, uint(1), mock.Anything).Return([]uint{}, nil)
+	store.On("GetUserGroupRoleIDsAt", ctx, uint(1), mock.Anything).Return([]uint{}, nil)
+	_, _, err := c.StartImpersonation(ctx, 1, 2, "")
+	if err == nil || !strings.Contains(err.Error(), "impersonate an administrator") {
+		t.Fatalf("expected an admin-target rejection, got %v", err)
+	}
+	store.AssertNotCalled(t, "CreateSession", mock.Anything, mock.Anything)
 }
 
 func TestEndImpersonation_LogsDurationAndActionCount(t *testing.T) {

--- a/internal/core/invitations.go
+++ b/internal/core/invitations.go
@@ -410,6 +410,15 @@ func (c *KeyorixCore) ApproveAccessRequestWithExpiry(ctx context.Context, projec
 	if req.State != AccessRequestPending {
 		return nil, fmt.Errorf("only a pending request can be approved (state is %s)", req.State)
 	}
+	// Enforce the request's own TTL here, not only on the list path. GetAccessRequest
+	// returns the stored record verbatim, so a request whose expiry has passed is still
+	// State==pending until something reconciles it — approving it would grant access on a
+	// stale request that should have lapsed. Expire it lazily and refuse.
+	if req.ExpiresAt != nil && c.now().After(*req.ExpiresAt) {
+		req.State = AccessRequestExpired
+		_ = c.storage.UpdateAccessRequest(ctx, req)
+		return nil, fmt.Errorf("access request has expired")
+	}
 	if grantTTL < 0 {
 		return nil, fmt.Errorf("grant TTL must not be negative")
 	}
@@ -443,6 +452,21 @@ func (c *KeyorixCore) ApproveAccessRequestWithExpiry(ctx context.Context, projec
 	roleModel, err := c.storage.GetRoleByName(ctx, role)
 	if err != nil {
 		return nil, fmt.Errorf("unknown role %q: %w", role, err)
+	}
+
+	// Privilege ceiling: an approver may not grant an admin role unless they themselves
+	// hold admin authority at this project. The route gate only proves the approver has
+	// roles.assign here — without this an ordinary approver could sign off a request for
+	// `admin`/`project_admin` and mint a principal more powerful than the approver, an
+	// escalation-by-proxy. Mirrors scimGroupConfersAdmin's "can't add to an admin group".
+	if isAdminRoleName(role) {
+		approverRoleIDs, rerr := c.storage.GetUserRoleIDsAt(ctx, approverID, storage.Scope{ProjectID: req.ProjectID})
+		if rerr != nil {
+			return nil, fmt.Errorf("failed to resolve approver authority: %w", rerr)
+		}
+		if !c.roleSetContainsAdmin(ctx, approverRoleIDs) {
+			return nil, fmt.Errorf("only an administrator can approve a request that grants the administrative role %q", role)
+		}
 	}
 
 	// One sign-off per distinct approver.

--- a/internal/core/invitations.go
+++ b/internal/core/invitations.go
@@ -48,6 +48,27 @@ const (
 
 // ── Invitations ────────────────────────────────────────────────────────────
 
+// requireAuthorityForRole refuses to GRANT an admin role (super_admin/admin/system_admin/
+// project_admin) unless the actor holds admin authority at the project scope. The various
+// grant entry points (access-request approval, project invite, membership activation) are
+// gated by roles.assign, but that alone would let a non-admin roles.assign holder mint a
+// principal more powerful than themselves — escalation-by-proxy. Non-admin roles pass (the
+// roles.assign gate covers them). actorID==0 (a system/unauthenticated path) cannot grant
+// an admin role through these flows.
+func (c *KeyorixCore) requireAuthorityForRole(ctx context.Context, actorID, projectID uint, role string) error {
+	if !isAdminRoleName(role) {
+		return nil
+	}
+	ids, err := c.storage.GetUserRoleIDsAt(ctx, actorID, storage.Scope{ProjectID: projectID})
+	if err != nil {
+		return fmt.Errorf("failed to resolve granter authority: %w", err)
+	}
+	if !c.roleSetContainsAdmin(ctx, ids) {
+		return fmt.Errorf("only an administrator can grant the administrative role %q", role)
+	}
+	return nil
+}
+
 // InviteToProject creates a pending invitation for an email to a project with an
 // intended role. It snapshots the current validation mode and sets a 14-day TTL.
 func (c *KeyorixCore) InviteToProject(ctx context.Context, projectID uint, email, role string, invitedBy uint) (*models.ProjectInvitation, error) {
@@ -56,6 +77,11 @@ func (c *KeyorixCore) InviteToProject(ctx context.Context, projectID uint, email
 	}
 	if _, err := c.storage.GetRoleByName(ctx, role); err != nil {
 		return nil, fmt.Errorf("unknown role %q: %w", role, err)
+	}
+	// Escalation-by-proxy guard: inviting someone as an admin role requires the inviter
+	// to hold admin authority at the project (parallel to the access-request ceiling).
+	if err := c.requireAuthorityForRole(ctx, invitedBy, projectID, role); err != nil {
+		return nil, err
 	}
 	now := c.now()
 	expires := now.Add(invitationTTL)
@@ -455,18 +481,9 @@ func (c *KeyorixCore) ApproveAccessRequestWithExpiry(ctx context.Context, projec
 	}
 
 	// Privilege ceiling: an approver may not grant an admin role unless they themselves
-	// hold admin authority at this project. The route gate only proves the approver has
-	// roles.assign here — without this an ordinary approver could sign off a request for
-	// `admin`/`project_admin` and mint a principal more powerful than the approver, an
-	// escalation-by-proxy. Mirrors scimGroupConfersAdmin's "can't add to an admin group".
-	if isAdminRoleName(role) {
-		approverRoleIDs, rerr := c.storage.GetUserRoleIDsAt(ctx, approverID, storage.Scope{ProjectID: req.ProjectID})
-		if rerr != nil {
-			return nil, fmt.Errorf("failed to resolve approver authority: %w", rerr)
-		}
-		if !c.roleSetContainsAdmin(ctx, approverRoleIDs) {
-			return nil, fmt.Errorf("only an administrator can approve a request that grants the administrative role %q", role)
-		}
+	// hold admin authority at this project (escalation-by-proxy guard).
+	if err := c.requireAuthorityForRole(ctx, approverID, req.ProjectID, role); err != nil {
+		return nil, err
 	}
 
 	// One sign-off per distinct approver.

--- a/internal/core/invitations_test.go
+++ b/internal/core/invitations_test.go
@@ -108,6 +108,80 @@ func TestApproveAccessRequest_FallsBackToSuggestedRole(t *testing.T) {
 	assert.Equal(t, "project_viewer", out.GrantedRole)
 }
 
+// stubAdminRoleLookups registers the admin role names so roleSetContainsAdmin can
+// resolve them; super_admin=1, admin=2, system_admin=3, project_admin=4.
+func stubAdminRoleLookups(store *MockStorage, ctx context.Context) {
+	store.On("GetRoleByName", ctx, "super_admin").Return(&models.Role{ID: 1}, nil)
+	store.On("GetRoleByName", ctx, "admin").Return(&models.Role{ID: 2}, nil)
+	store.On("GetRoleByName", ctx, "system_admin").Return(&models.Role{ID: 3}, nil)
+	store.On("GetRoleByName", ctx, "project_admin").Return(&models.Role{ID: 4}, nil)
+}
+
+// Privilege ceiling: a non-admin approver cannot sign off a request that grants an
+// admin role — that would mint a principal more powerful than the approver.
+func TestApproveAccessRequest_RejectsAdminGrantByNonAdmin(t *testing.T) {
+	store := new(MockStorage)
+	c := newInviteCore(store)
+	ctx := context.Background()
+	store.On("GetAccessRequest", ctx, uint(3)).Return(&models.AccessRequest{
+		ID: 3, ProjectID: 1, UserID: 2, SuggestedRole: "admin", State: AccessRequestPending,
+	}, nil)
+	stubAdminRoleLookups(store, ctx)
+	// Approver 9 holds only a non-admin role (id 6) at the project.
+	store.On("GetUserRoleIDsAt", ctx, uint(9), storage.Scope{ProjectID: 1}).Return([]uint{6}, nil)
+
+	_, err := c.ApproveAccessRequest(ctx, 1, 3, 9, "admin")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "only an administrator can approve")
+	// The grant was refused before any role assignment or approval record.
+	store.AssertNotCalled(t, "AssignRole", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	store.AssertNotCalled(t, "CreateAccessRequestApproval", mock.Anything, mock.Anything)
+}
+
+// An admin approver may grant an admin role — the ceiling permits an equal-or-higher
+// authority to sign off.
+func TestApproveAccessRequest_AdminApproverMayGrantAdmin(t *testing.T) {
+	store := new(MockStorage)
+	c := newInviteCore(store)
+	ctx := context.Background()
+	store.On("GetAccessRequest", ctx, uint(3)).Return(&models.AccessRequest{
+		ID: 3, ProjectID: 1, UserID: 2, SuggestedRole: "admin", State: AccessRequestPending,
+	}, nil)
+	stubAdminRoleLookups(store, ctx)
+	// Approver 9 holds the admin role (id 2) at the project.
+	store.On("GetUserRoleIDsAt", ctx, uint(9), storage.Scope{ProjectID: 1}).Return([]uint{2}, nil)
+	store.On("AssignRole", ctx, uint(2), uint(2), storage.Scope{ProjectID: 1}).Return(nil)
+	store.On("UpdateAccessRequest", ctx, mock.Anything).Return(nil)
+	store.On("LogAuditEvent", ctx, mock.Anything).Return(nil)
+	store.On("ListAccessRequestApprovals", ctx, uint(3)).Return([]*models.AccessRequestApproval{}, nil)
+	store.On("CreateAccessRequestApproval", ctx, mock.Anything).Return(nil)
+	allowNotifications(store)
+
+	out, err := c.ApproveAccessRequest(ctx, 1, 3, 9, "admin")
+	require.NoError(t, err)
+	assert.Equal(t, AccessRequestApproved, out.State)
+}
+
+// A request whose TTL has elapsed is refused on the approve path (lazy expiry), not
+// only on the list path — GetAccessRequest returns the stored record verbatim.
+func TestApproveAccessRequest_RejectsExpired(t *testing.T) {
+	store := new(MockStorage)
+	c := newInviteCore(store)
+	ctx := context.Background()
+	past := time.Date(2026, 6, 5, 11, 0, 0, 0, time.UTC) // before the fixed clock (12:00)
+	store.On("GetAccessRequest", ctx, uint(3)).Return(&models.AccessRequest{
+		ID: 3, ProjectID: 1, UserID: 2, SuggestedRole: "project_viewer", State: AccessRequestPending, ExpiresAt: &past,
+	}, nil)
+	store.On("UpdateAccessRequest", ctx, mock.MatchedBy(func(r *models.AccessRequest) bool {
+		return r.State == AccessRequestExpired
+	})).Return(nil)
+
+	_, err := c.ApproveAccessRequest(ctx, 1, 3, 9, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "expired")
+	store.AssertNotCalled(t, "AssignRole", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+}
+
 func TestApproveAccessRequest_RejectsNonPending(t *testing.T) {
 	store := new(MockStorage)
 	c := newInviteCore(store)

--- a/internal/core/invitations_test.go
+++ b/internal/core/invitations_test.go
@@ -117,6 +117,31 @@ func stubAdminRoleLookups(store *MockStorage, ctx context.Context) {
 	store.On("GetRoleByName", ctx, "project_admin").Return(&models.Role{ID: 4}, nil)
 }
 
+// The same admin-role ceiling applies to project invitations: a non-admin inviter
+// (roles.assign but not admin) cannot invite someone as an admin role — escalation-by-
+// proxy. A non-admin role invite still works.
+func TestInviteToProject_EnforcesAdminCeiling(t *testing.T) {
+	store := new(MockStorage)
+	c := newInviteCore(store)
+	ctx := context.Background()
+	stubAdminRoleLookups(store, ctx)
+	// Inviter 9 holds only a non-admin role (id 6) at the project.
+	store.On("GetUserRoleIDsAt", ctx, uint(9), storage.Scope{ProjectID: 1}).Return([]uint{6}, nil)
+
+	// Inviting as project_admin → refused before any invitation is created.
+	_, err := c.InviteToProject(ctx, 1, "a@b.io", "project_admin", 9)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "only an administrator can grant")
+	store.AssertNotCalled(t, "CreateProjectInvitation", mock.Anything, mock.Anything)
+
+	// Inviting as a non-admin role is allowed (isAdminRoleName false → no ceiling).
+	store.On("GetRoleByName", ctx, "project_developer").Return(&models.Role{ID: 6, Name: "project_developer"}, nil)
+	store.On("CreateProjectInvitation", ctx, mock.Anything).Return(&models.ProjectInvitation{ID: 1}, nil)
+	store.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
+	_, err = c.InviteToProject(ctx, 1, "c@d.io", "project_developer", 9)
+	require.NoError(t, err)
+}
+
 // Privilege ceiling: a non-admin approver cannot sign off a request that grants an
 // admin role — that would mint a principal more powerful than the approver.
 func TestApproveAccessRequest_RejectsAdminGrantByNonAdmin(t *testing.T) {
@@ -132,7 +157,7 @@ func TestApproveAccessRequest_RejectsAdminGrantByNonAdmin(t *testing.T) {
 
 	_, err := c.ApproveAccessRequest(ctx, 1, 3, 9, "admin")
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "only an administrator can approve")
+	assert.Contains(t, err.Error(), "only an administrator can grant")
 	// The grant was refused before any role assignment or approval record.
 	store.AssertNotCalled(t, "AssignRole", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 	store.AssertNotCalled(t, "CreateAccessRequestApproval", mock.Anything, mock.Anything)

--- a/internal/core/legal_hold.go
+++ b/internal/core/legal_hold.go
@@ -36,6 +36,22 @@ func (c *KeyorixCore) IsLegalHoldActive(ctx context.Context) (bool, error) {
 	return hold != nil, nil
 }
 
+// legalHoldGuard returns a non-nil error when a deployment-wide legal hold is active OR
+// its status cannot be confirmed — fail SAFE. The hard-delete purges call this at their
+// top (inside the scheduler lock, immediately before the deletes) so a hold placed after
+// the scheduler's pre-lock check still aborts the in-flight purge, never destroying
+// records that may be under hold.
+func (c *KeyorixCore) legalHoldGuard(ctx context.Context) error {
+	held, err := c.IsLegalHoldActive(ctx)
+	if err != nil {
+		return fmt.Errorf("refusing to purge: could not confirm legal-hold status: %w", err)
+	}
+	if held {
+		return fmt.Errorf("refusing to purge: a deployment-wide legal hold is active")
+	}
+	return nil
+}
+
 // PlaceLegalHold activates a deployment-wide legal hold with a reason. Refuses if a
 // hold is already active. actorID is the placing admin.
 func (c *KeyorixCore) PlaceLegalHold(ctx context.Context, actorID uint, reason string) (*models.LegalHold, error) {

--- a/internal/core/machine_token.go
+++ b/internal/core/machine_token.go
@@ -96,21 +96,41 @@ func (c *KeyorixCore) ListMachineTokens(ctx context.Context, projectID, machineI
 }
 
 // RevokeMachineToken revokes one credential after verifying the machine belongs
-// to the project and the credential belongs to the machine.
-func (c *KeyorixCore) RevokeMachineToken(ctx context.Context, projectID, machineID, credentialID, actorID uint) error {
+// to the project and the credential belongs to the machine. It returns the revoked
+// token's hash so the caller can evict it from the auth cache immediately (the HTTP
+// token cache is keyed by SHA-256(raw) == TokenHash); without that a revoked machine
+// token keeps authenticating until the positive-cache TTL.
+func (c *KeyorixCore) RevokeMachineToken(ctx context.Context, projectID, machineID, credentialID, actorID uint) (tokenHash string, err error) {
 	m, err := c.machineInProject(ctx, projectID, machineID)
 	if err != nil {
-		return err
+		return "", err
 	}
 	cred, err := c.storage.GetMachineIdentityCredentialByID(ctx, credentialID)
 	if err != nil || cred.MachineIdentityID != machineID {
-		return fmt.Errorf("token not found")
+		return "", fmt.Errorf("token not found")
 	}
 	if err := c.storage.RevokeMachineIdentityCredential(ctx, credentialID); err != nil {
-		return err
+		return "", err
 	}
 	c.logMachineEvent(ctx, "machine_identity.token_revoked", m, actorID)
-	return nil
+	return cred.TokenHash, nil
+}
+
+// MachineTokenHashes returns the hashes of all of a machine identity's credentials,
+// so the caller can evict them from the auth cache when the identity is suspended or
+// revoked (which must reject its tokens immediately, not after the cache TTL).
+func (c *KeyorixCore) MachineTokenHashes(ctx context.Context, machineID uint) ([]string, error) {
+	creds, err := c.storage.ListMachineIdentityCredentials(ctx, machineID)
+	if err != nil {
+		return nil, err
+	}
+	hashes := make([]string, 0, len(creds))
+	for _, cr := range creds {
+		if cr.TokenHash != "" {
+			hashes = append(hashes, cr.TokenHash)
+		}
+	}
+	return hashes, nil
 }
 
 // ClassifyMachineToken sets (or clears, with "") the data-classification label on a

--- a/internal/core/machine_token_test.go
+++ b/internal/core/machine_token_test.go
@@ -51,6 +51,22 @@ func TestIssueMachineToken_ActiveOnly(t *testing.T) {
 	require.Equal(t, sha256Hex(res.PlainToken), created.TokenHash)
 }
 
+// RevokeMachineToken must return the revoked credential's hash so the HTTP handler can
+// evict it from the auth cache immediately (otherwise it keeps authenticating ≤30s).
+func TestRevokeMachineToken_ReturnsHashForCacheEviction(t *testing.T) {
+	store := new(MockStorage)
+	c := NewKeyorixCore(store)
+	store.On("GetMachineIdentity", mock.Anything, uint(1)).Return(&models.MachineIdentity{ID: 1, ProjectID: 2, State: MachineActive}, nil)
+	store.On("GetMachineIdentityCredentialByID", mock.Anything, uint(5)).
+		Return(&models.MachineIdentityCredential{ID: 5, MachineIdentityID: 1, TokenHash: "hash-5"}, nil)
+	store.On("RevokeMachineIdentityCredential", mock.Anything, uint(5)).Return(nil)
+	store.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
+
+	hash, err := c.RevokeMachineToken(context.Background(), 2, 1, 5, 9)
+	require.NoError(t, err)
+	require.Equal(t, "hash-5", hash)
+}
+
 func TestValidateMachineToken(t *testing.T) {
 	fixed := time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)
 	raw := "kx_machine_abc"

--- a/internal/core/max_reads_enforce_test.go
+++ b/internal/core/max_reads_enforce_test.go
@@ -90,3 +90,19 @@ func TestMaxReads_ConcurrentNeverExceedsCap(t *testing.T) {
 	require.NoError(t, db.Where("secret_node_id = ?", id).First(&v).Error)
 	assert.LessOrEqual(t, v.ReadCount, cap, "read_count must not exceed the cap")
 }
+
+// A by-version read enforces the same max-reads cap as the latest-version read —
+// the by-version path must not be a bypass for the read ceiling.
+func TestMaxReads_ByVersionStopsAtCap(t *testing.T) {
+	c, _ := newMaxReadsCore(t)
+	id := seedMaxReadsSecret(t, c, 2)
+	ctx := context.Background()
+
+	for i := 0; i < 2; i++ {
+		_, err := c.GetSecretValueByVersion(ctx, id, 1)
+		require.NoError(t, err, "by-version read %d should be within the cap", i+1)
+	}
+	_, err := c.GetSecretValueByVersion(ctx, id, 1)
+	require.Error(t, err, "the 3rd by-version read must be denied")
+	assert.Contains(t, err.Error(), i18n.T("ErrorMaxReadsExceeded", nil))
+}

--- a/internal/core/membership_lifecycle.go
+++ b/internal/core/membership_lifecycle.go
@@ -103,6 +103,20 @@ func (c *KeyorixCore) inviteMemberWithMode(ctx context.Context, projectID, userI
 	if _, err := c.storage.GetRoleByName(ctx, role); err != nil {
 		return nil, fmt.Errorf("unknown role %q: %w", role, err)
 	}
+	// The parent project must be live. GetProject is soft-delete-scoped, so this refuses
+	// onboarding into a soft-deleted project — otherwise accepting an invitation that was
+	// outstanding when the project was deleted would re-establish a membership/role grant
+	// that silently resurrects on a later RestoreProject (the restore-into-deleted-parent
+	// class). It also covers the per-assignment grants applied at invite-accept.
+	if _, err := c.storage.GetProject(ctx, projectID); err != nil {
+		return nil, fmt.Errorf("project %d not found or deleted", projectID)
+	}
+	// Escalation-by-proxy guard: onboarding a member as an admin role requires the
+	// inviter to hold admin authority at the project (parallel to the access-request
+	// approval ceiling). idpResolved invites still pass through here.
+	if err := c.requireAuthorityForRole(ctx, invitedBy, projectID, role); err != nil {
+		return nil, err
+	}
 	// One active onboarding per (project, user).
 	if existing, err := c.storage.GetActiveProjectMembership(ctx, projectID, userID); err == nil && existing != nil {
 		return nil, fmt.Errorf("user already has a %s membership in this project", existing.State)
@@ -172,6 +186,15 @@ func (c *KeyorixCore) TransitionMembership(ctx context.Context, projectID, membe
 	}
 	if !canTransition(m.State, to) {
 		return nil, fmt.Errorf("cannot transition membership from %s to %s", m.State, to)
+	}
+	// Activating a membership grants its role, so the same escalation-by-proxy ceiling
+	// applies: the actor must hold admin authority at the project to activate a membership
+	// carrying an admin role. (Revocation/other transitions remove or don't grant, so
+	// they're unaffected.)
+	if to == MembershipActive {
+		if err := c.requireAuthorityForRole(ctx, actorID, m.ProjectID, m.Role); err != nil {
+			return nil, err
+		}
 	}
 
 	now := c.now()

--- a/internal/core/mfa.go
+++ b/internal/core/mfa.go
@@ -221,6 +221,14 @@ func (c *KeyorixCore) VerifyMFALogin(ctx context.Context, challenge, code, userA
 	if !user.IsActive || AccountLoginBlocked(user.AccountState) {
 		return nil, nil, fmt.Errorf("account is not active")
 	}
+	// Per-account lockout also gates the second factor. The per-IP rate limiter is
+	// spoofable behind a misconfigured proxy, and it is otherwise the ONLY online
+	// throttle on TOTP/recovery-code guessing — binding failures to the account (keyed
+	// by ch.UserID, which the attacker does not control) makes second-factor brute force
+	// cost the same lockout as password brute force.
+	if c.loginLocked(user) {
+		return nil, nil, fmt.Errorf("account temporarily locked due to repeated failed logins; try again later")
+	}
 	verified, usedRecovery := false, false
 	if secret, err := c.loadTOTPSecret(ctx, ch.UserID); err == nil {
 		if step, ok := c.validateTOTPStep(secret, code); ok {
@@ -240,8 +248,11 @@ func (c *KeyorixCore) VerifyMFALogin(ctx context.Context, challenge, code, userA
 	}
 	if !verified {
 		c.auditMFAFailed(ctx, ch.UserID, "login")
+		c.recordFailedLogin(ctx, user) // count the failed second factor toward the lockout
 		return nil, nil, fmt.Errorf("invalid code")
 	}
+	// Cleared the second factor — reset any lockout state accrued from failed codes.
+	c.clearLoginFailures(ctx, user)
 	session, err := c.mintSession(ctx, ch.UserID, userAgent, ip)
 	if err != nil {
 		return nil, nil, err

--- a/internal/core/mfa.go
+++ b/internal/core/mfa.go
@@ -81,10 +81,11 @@ func (c *KeyorixCore) ActivateMFA(ctx context.Context, userID uint, code string)
 	if err := c.storage.SetUserMFAEnabled(ctx, userID, true); err != nil {
 		return nil, fmt.Errorf("failed to enable MFA: %w", err)
 	}
-	// Invalidate any sessions minted before MFA was enabled, so a pre-enrolment
-	// session cannot outlive the security upgrade (same hygiene as password change
-	// / suspend). Best-effort: enrolment must not fail on a session-cleanup error.
-	_ = c.storage.DeleteSessionsForUserExcept(ctx, userID, 0)
+	// Invalidate any sessions minted before MFA was enabled (and evict them from the auth
+	// cache), so a pre-enrolment session cannot outlive the security upgrade — even for
+	// the cache TTL (same hygiene as password change / suspend). Best-effort: enrolment
+	// must not fail on a session-cleanup error.
+	_ = c.deleteSessionsForUserAndEvict(ctx, userID, 0, "")
 	codes, hashes, err := generateRecoveryCodes(mfaRecoveryCodeCount)
 	if err != nil {
 		return nil, err

--- a/internal/core/mfa.go
+++ b/internal/core/mfa.go
@@ -7,6 +7,7 @@ package core
 import (
 	"context"
 	"crypto/rand"
+	"crypto/subtle"
 	"errors"
 	"fmt"
 	"strings"
@@ -221,10 +222,21 @@ func (c *KeyorixCore) VerifyMFALogin(ctx context.Context, challenge, code, userA
 		return nil, nil, fmt.Errorf("account is not active")
 	}
 	verified, usedRecovery := false, false
-	if secret, err := c.loadTOTPSecret(ctx, ch.UserID); err == nil && c.validateTOTP(secret, code) {
-		verified = true
-	} else if consumed, err := c.storage.ConsumeMFARecoveryCode(ctx, ch.UserID, sha256Hex(normalizeRecoveryCode(code)), c.now()); err == nil && consumed {
-		verified, usedRecovery = true, true
+	if secret, err := c.loadTOTPSecret(ctx, ch.UserID); err == nil {
+		if step, ok := c.validateTOTPStep(secret, code); ok {
+			// Single-use within the validity window: atomically advance the last-used
+			// step. A code already accepted at this (or a later) step is a replay and
+			// MarkTOTPStepUsed returns false, so it is rejected — closing the ~90s
+			// replay window the bare totp validation left open.
+			if fresh, ferr := c.storage.MarkTOTPStepUsed(ctx, ch.UserID, step); ferr == nil && fresh {
+				verified = true
+			}
+		}
+	}
+	if !verified {
+		if consumed, err := c.storage.ConsumeMFARecoveryCode(ctx, ch.UserID, sha256Hex(normalizeRecoveryCode(code)), c.now()); err == nil && consumed {
+			verified, usedRecovery = true, true
+		}
 	}
 	if !verified {
 		c.auditMFAFailed(ctx, ch.UserID, "login")
@@ -262,6 +274,30 @@ func (c *KeyorixCore) validateTOTP(secret, code string) bool {
 		Period: 30, Skew: 1, Digits: otp.DigitsSix, Algorithm: otp.AlgorithmSHA1,
 	})
 	return valid
+}
+
+// totpPeriod is the TOTP step length in seconds.
+const totpPeriod = 30
+
+// validateTOTPStep verifies code against the current step and ±1 skew and, on a match,
+// returns the matched time-step (unix/period) so the caller can enforce single-use
+// (anti-replay). Unlike validateTOTP it identifies WHICH step matched.
+func (c *KeyorixCore) validateTOTPStep(secret, code string) (int64, bool) {
+	code = strings.TrimSpace(code)
+	if code == "" {
+		return 0, false
+	}
+	now := c.now().UTC()
+	for _, delta := range []int64{0, -1, 1} {
+		t := now.Add(time.Duration(delta*totpPeriod) * time.Second)
+		expected, err := totp.GenerateCodeCustom(secret, t, totp.ValidateOpts{
+			Period: totpPeriod, Skew: 0, Digits: otp.DigitsSix, Algorithm: otp.AlgorithmSHA1,
+		})
+		if err == nil && subtle.ConstantTimeCompare([]byte(code), []byte(expected)) == 1 {
+			return t.Unix() / totpPeriod, true
+		}
+	}
+	return 0, false
 }
 
 func (c *KeyorixCore) auditMFAFailed(ctx context.Context, userID uint, phase string) {

--- a/internal/core/mfa_test.go
+++ b/internal/core/mfa_test.go
@@ -243,3 +243,35 @@ func TestMFA_RegenerateRequiresMFAEnabled(t *testing.T) {
 	_, err := c.RegenerateMFARecoveryCodes(context.Background(), 1, mfaTestPassword)
 	require.Error(t, err, "regenerate requires MFA to be enabled")
 }
+
+// A TOTP code must be single-use: replaying the same code within its validity window
+// (with a fresh challenge) must be rejected, not mint a second session.
+func TestVerifyMFALogin_RejectsReplayedTOTPCode(t *testing.T) {
+	c, _, fixed := newMFATestCore(t)
+	ctx := context.Background()
+
+	_, secret, err := c.BeginMFAEnrollment(ctx, 1)
+	require.NoError(t, err)
+	actCode, err := totp.GenerateCode(secret, fixed)
+	require.NoError(t, err)
+	_, err = c.ActivateMFA(ctx, 1, actCode)
+	require.NoError(t, err)
+
+	code, err := totp.GenerateCode(secret, fixed)
+	require.NoError(t, err)
+
+	// First use succeeds.
+	ch1, err := c.CreateMFAChallenge(ctx, 1)
+	require.NoError(t, err)
+	sess, _, err := c.VerifyMFALogin(ctx, ch1, code, "ua", "1.2.3.4")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+
+	// Replay of the same code (fresh challenge, same time-step) is refused.
+	ch2, err := c.CreateMFAChallenge(ctx, 1)
+	require.NoError(t, err)
+	sess2, _, err := c.VerifyMFALogin(ctx, ch2, code, "ua", "1.2.3.4")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid code")
+	assert.Nil(t, sess2)
+}

--- a/internal/core/mfa_test.go
+++ b/internal/core/mfa_test.go
@@ -275,3 +275,43 @@ func TestVerifyMFALogin_RejectsReplayedTOTPCode(t *testing.T) {
 	assert.Contains(t, err.Error(), "invalid code")
 	assert.Nil(t, sess2)
 }
+
+// Failed second-factor attempts feed the per-account lockout, so TOTP/recovery-code
+// guessing is throttled even when the per-IP limiter is bypassed (e.g. a spoofed proxy
+// header). After MaxAttempts bad codes the account locks and refuses further attempts.
+func TestVerifyMFALogin_FailedCodesFeedAccountLockout(t *testing.T) {
+	c, db, fixed := newMFATestCore(t)
+	c.loginLockout = LoginLockoutPolicy{Enabled: true, MaxAttempts: 3, Window: time.Hour, BaseCooldown: 15 * time.Minute, MaxCooldown: time.Hour}
+	ctx := context.Background()
+
+	_, secret, err := c.BeginMFAEnrollment(ctx, 1)
+	require.NoError(t, err)
+	actCode, err := totp.GenerateCode(secret, fixed)
+	require.NoError(t, err)
+	_, err = c.ActivateMFA(ctx, 1, actCode)
+	require.NoError(t, err)
+
+	// Three wrong codes → the account locks.
+	for i := 0; i < 3; i++ {
+		ch, cerr := c.CreateMFAChallenge(ctx, 1)
+		require.NoError(t, cerr)
+		_, _, verr := c.VerifyMFALogin(ctx, ch, "000000", "ua", "9.9.9.9")
+		require.Error(t, verr)
+	}
+
+	var locked models.User
+	require.NoError(t, db.First(&locked, 1).Error)
+	require.NotNil(t, locked.LoginLockedUntil, "account must be locked after MaxAttempts failed second factors")
+	assert.True(t, locked.LoginLockedUntil.After(fixed))
+
+	// Even a VALID code is now refused while the lock is active — second-factor guessing
+	// cannot continue past the lockout.
+	good, err := totp.GenerateCode(secret, fixed)
+	require.NoError(t, err)
+	ch, err := c.CreateMFAChallenge(ctx, 1)
+	require.NoError(t, err)
+	sess, _, err := c.VerifyMFALogin(ctx, ch, good, "ua", "9.9.9.9")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "locked")
+	assert.Nil(t, sess)
+}

--- a/internal/core/migrate_user_to_machine_test.go
+++ b/internal/core/migrate_user_to_machine_test.go
@@ -30,6 +30,9 @@ func TestMigrateUserToMachine(t *testing.T) {
 			return u.ID == 7 && u.AccountState == AccountSuspended
 		})).Return(&models.User{ID: 7, AccountState: AccountSuspended}, nil)
 		store.On("DeleteSessionsForUserExcept", ctx, uint(7), uint(0)).Return(nil)
+		// Suspension also evicts the user's cached session tokens and revokes their PATs.
+		store.On("ListSessionTokenHashesForUser", ctx, uint(7)).Return([]string{}, nil)
+		store.On("RevokeAllPersonalAccessTokensForUser", ctx, uint(7)).Return([]string{}, nil)
 
 		seen := map[string]bool{}
 		store.On("LogAuditEvent", ctx, mock.MatchedBy(func(e *models.AuditEvent) bool {

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -1210,6 +1210,14 @@ func (m *MockStorage) RevokePersonalAccessToken(ctx context.Context, id uint) er
 	return args.Error(0)
 }
 
+func (m *MockStorage) RevokeAllPersonalAccessTokensForUser(ctx context.Context, userID uint) ([]string, error) {
+	args := m.Called(ctx, userID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]string), args.Error(1)
+}
+
 func (m *MockStorage) TouchPersonalAccessToken(ctx context.Context, id uint, usedAt time.Time, staleness time.Duration) error {
 	args := m.Called(ctx, id, usedAt, staleness)
 	return args.Error(0)

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -1718,6 +1718,9 @@ func (m *MockStorage) GetDynamicSecretLease(_ context.Context, _ string) (*model
 func (m *MockStorage) ListDynamicSecretLeases(_ context.Context, _ uint) ([]*models.DynamicSecretLease, error) {
 	return nil, nil
 }
+func (m *MockStorage) CountActiveLeases(_ context.Context, _ uint) (int64, error) {
+	return 0, nil
+}
 func (m *MockStorage) UpdateDynamicSecretLease(_ context.Context, _ *models.DynamicSecretLease) error {
 	return nil
 }

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -941,6 +941,11 @@ func (m *MockStorage) GetUserRoleIDsExact(ctx context.Context, userID uint, scop
 	return args.Get(0).([]uint), args.Error(1)
 }
 
+func (m *MockStorage) IsProjectMember(ctx context.Context, userID, projectID uint) (bool, error) {
+	args := m.Called(ctx, userID, projectID)
+	return args.Bool(0), args.Error(1)
+}
+
 func (m *MockStorage) GetUserGroupRoleIDsAt(ctx context.Context, userID uint, scope storage.Scope) ([]uint, error) {
 	args := m.Called(ctx, userID, scope)
 	if args.Get(0) == nil {

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -1462,6 +1462,14 @@ func (m *MockStorage) ListMachineIdentities(ctx context.Context, projectID uint)
 	return args.Get(0).([]*models.MachineIdentity), args.Error(1)
 }
 
+func (m *MockStorage) ListAllMachineIdentities(ctx context.Context) ([]*models.MachineIdentity, error) {
+	args := m.Called(ctx)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*models.MachineIdentity), args.Error(1)
+}
+
 func (m *MockStorage) CountMachineIdentitiesByClassification(ctx context.Context) (map[string]int, error) {
 	args := m.Called(ctx)
 	if args.Get(0) == nil {

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -1669,7 +1669,10 @@ func (m *MockStorage) UpsertMFASecret(_ context.Context, _ *models.MFASecret) er
 func (m *MockStorage) GetMFASecret(_ context.Context, _ uint) (*models.MFASecret, error) {
 	return nil, nil
 }
-func (m *MockStorage) ActivateMFASecret(_ context.Context, _ uint) error         { return nil }
+func (m *MockStorage) ActivateMFASecret(_ context.Context, _ uint) error { return nil }
+func (m *MockStorage) MarkTOTPStepUsed(_ context.Context, _ uint, _ int64) (bool, error) {
+	return true, nil
+}
 func (m *MockStorage) DeleteMFAForUser(_ context.Context, _ uint) error          { return nil }
 func (m *MockStorage) SetUserMFAEnabled(_ context.Context, _ uint, _ bool) error { return nil }
 func (m *MockStorage) CreateMFARecoveryCodes(_ context.Context, _ uint, _ []string) error {

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -1141,6 +1141,8 @@ func (m *MockStorage) ListSessionsByUser(ctx context.Context, userID uint) ([]*m
 	return args.Get(0).([]*models.Session), args.Error(1)
 }
 
+func (m *MockStorage) EnforceSessionLimit(_ context.Context, _ uint, _ int) error { return nil }
+
 func (m *MockStorage) DeleteSessionsForUserExcept(ctx context.Context, userID, exceptID uint) error {
 	args := m.Called(ctx, userID, exceptID)
 	return args.Error(0)

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -1042,6 +1042,16 @@ func (m *MockStorage) AuditEntryHashByID(ctx context.Context, id uint) (string, 
 	return args.String(0), args.Bool(1), args.Error(2)
 }
 
+func (m *MockStorage) GetSystemMetadata(ctx context.Context, key string) (string, bool, error) {
+	args := m.Called(ctx, key)
+	return args.String(0), args.Bool(1), args.Error(2)
+}
+
+func (m *MockStorage) SetSystemMetadata(ctx context.Context, key, value string) error {
+	args := m.Called(ctx, key, value)
+	return args.Error(0)
+}
+
 func (m *MockStorage) UnusedSecrets(ctx context.Context, projectID *uint, notReadSince time.Time) ([]storage.UnusedSecretStat, error) {
 	args := m.Called(ctx, projectID, notReadSince)
 	if args.Get(0) == nil {

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -1158,6 +1158,14 @@ func (m *MockStorage) DeleteSessionsForUserExcept(ctx context.Context, userID, e
 	return args.Error(0)
 }
 
+func (m *MockStorage) ListSessionTokenHashesForUser(ctx context.Context, userID uint) ([]string, error) {
+	args := m.Called(ctx, userID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]string), args.Error(1)
+}
+
 func (m *MockStorage) TouchSession(ctx context.Context, id uint, seenAt time.Time, staleness time.Duration) error {
 	args := m.Called(ctx, id, seenAt, staleness)
 	return args.Error(0)

--- a/internal/core/oidc_jwks.go
+++ b/internal/core/oidc_jwks.go
@@ -14,16 +14,39 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
 	"math/big"
 	"net"
 	"net/http"
 	"net/url"
+	"strings"
 	"sync"
 	"time"
+
+	"golang.org/x/sync/singleflight"
 )
 
 // jwksCacheTTL bounds how long a fetched key set is trusted before a refetch.
 const jwksCacheTTL = 1 * time.Hour
+
+// jwksMinRefetchInterval bounds how often an *unknown kid* on an otherwise-fresh
+// cache may trigger a rotation refetch, per issuer. The keyfunc runs during JWT
+// parse — BEFORE the signature is verified — and only requires that the token's
+// iss name a trusted issuer (a public, guessable value). Without this gate an
+// unauthenticated attacker could stream tokens bearing a trusted iss and a fresh
+// random kid, forcing one outbound JWKS GET each: a request storm that makes the
+// IdP rate-limit/ban Keyorix (breaking real federation) and drains our outbound
+// budget. With it, a bogus-kid flood costs at most one refetch per interval.
+const jwksMinRefetchInterval = 1 * time.Minute
+
+// maxJWKSBytes caps the JWKS response body we will read into memory. A compromised
+// or MITM'd issuer (or one reached over a downgraded connection) could otherwise
+// return an arbitrarily large body that we decode whole.
+const maxJWKSBytes = 1 << 20 // 1 MiB
+
+// maxJWKSKeys caps how many keys we retain from a single JWKS, bounding cache
+// growth from a pathological key set.
+const maxJWKSKeys = 50
 
 // jwksStaleGrace bounds how far PAST the TTL a cached key set may still be served
 // as a fallback when a JWKS refetch fails transiently. Without a bound, a key the
@@ -37,6 +60,11 @@ const jwksStaleGrace = 10 * time.Minute
 type HTTPJWKSResolver struct {
 	jwksURIs map[string]string // issuer -> jwks_uri (operator-configured)
 	client   *http.Client
+
+	// group collapses concurrent fetches for the same issuer into one outbound
+	// request, so a burst of unknown-kid tokens (see jwksMinRefetchInterval) can't
+	// fan out into a thundering herd against the IdP.
+	group singleflight.Group
 
 	mu    sync.Mutex
 	cache map[string]*jwksEntry // issuer -> cached keys
@@ -59,9 +87,31 @@ func NewHTTPJWKSResolver(jwksURIs map[string]string) (*HTTPJWKSResolver, error) 
 	}
 	return &HTTPJWKSResolver{
 		jwksURIs: jwksURIs,
-		client:   &http.Client{Timeout: 10 * time.Second},
-		cache:    map[string]*jwksEntry{},
+		client: &http.Client{
+			Timeout:       10 * time.Second,
+			CheckRedirect: noCrossOriginRedirect,
+		},
+		cache: map[string]*jwksEntry{},
 	}, nil
+}
+
+// noCrossOriginRedirect rejects a redirect that changes host or downgrades the
+// scheme. validateJWKSScheme only vets the *configured* jwks_uri; without this a
+// trusted https jwks_uri that 302s (open redirect on the IdP, or a compromised
+// IdP) to http://attacker/ would be followed and attacker keys fetched, which
+// would then validate forged tokens. Same-origin redirects are still allowed.
+func noCrossOriginRedirect(req *http.Request, via []*http.Request) error {
+	if len(via) == 0 {
+		return nil
+	}
+	prev := via[len(via)-1].URL
+	if !strings.EqualFold(req.URL.Hostname(), prev.Hostname()) {
+		return fmt.Errorf("jwks fetch: refusing cross-host redirect to %q", req.URL.Host)
+	}
+	if prev.Scheme == "https" && req.URL.Scheme != "https" {
+		return fmt.Errorf("jwks fetch: refusing scheme downgrade to %q", req.URL.Scheme)
+	}
+	return nil
 }
 
 // validateJWKSScheme requires https for a jwks_uri (http only for loopback).
@@ -110,10 +160,17 @@ func (r *HTTPJWKSResolver) Key(ctx context.Context, issuer, kid string) (interfa
 		if k, ok := entry.keys[kid]; ok {
 			return k, nil
 		}
-		// Unknown kid on a fresh cache: the key may have just rotated — refetch once.
+		// Unknown kid on a fresh cache: the key may have just rotated. Refetch — but
+		// not more than once per jwksMinRefetchInterval per issuer, so a flood of
+		// tokens bearing a trusted iss and random kids can't amplify into a refetch
+		// storm against the IdP. (A legitimate rotation is picked up on the next
+		// refetch the interval allows; the cache TTL still bounds staleness.)
+		if time.Since(entry.fetchedAt) < jwksMinRefetchInterval {
+			return nil, fmt.Errorf("no signing key with kid %q at issuer %q", kid, issuer)
+		}
 	}
 
-	keys, err := r.fetch(ctx, jwksURI)
+	keys, err := r.fetchAndCache(ctx, issuer, jwksURI)
 	if err != nil {
 		// Fall back to a recently-cached key set on a transient fetch error — but
 		// ONLY within a bounded grace window past the TTL, so a rotated-out (possibly
@@ -127,14 +184,29 @@ func (r *HTTPJWKSResolver) Key(ctx context.Context, issuer, kid string) (interfa
 		return nil, err
 	}
 
-	r.mu.Lock()
-	r.cache[issuer] = &jwksEntry{keys: keys, fetchedAt: time.Now()}
-	r.mu.Unlock()
-
 	if k, ok := keys[kid]; ok {
 		return k, nil
 	}
 	return nil, fmt.Errorf("no signing key with kid %q at issuer %q", kid, issuer)
+}
+
+// fetchAndCache fetches the issuer's JWKS and stores it, collapsing concurrent
+// callers for the same issuer into a single outbound request via singleflight.
+func (r *HTTPJWKSResolver) fetchAndCache(ctx context.Context, issuer, jwksURI string) (map[string]interface{}, error) {
+	v, err, _ := r.group.Do(issuer, func() (interface{}, error) {
+		keys, err := r.fetch(ctx, jwksURI)
+		if err != nil {
+			return nil, err
+		}
+		r.mu.Lock()
+		r.cache[issuer] = &jwksEntry{keys: keys, fetchedAt: time.Now()}
+		r.mu.Unlock()
+		return keys, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return v.(map[string]interface{}), nil
 }
 
 // jwk is one JSON Web Key (the subset of fields we verify with).
@@ -166,12 +238,17 @@ func (r *HTTPJWKSResolver) fetch(ctx context.Context, jwksURI string) (map[strin
 	var doc struct {
 		Keys []jwk `json:"keys"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&doc); err != nil {
+	// Bound the body we read so a compromised/MITM'd issuer can't OOM us with a huge
+	// response; the LimitReader yields a decode error past the cap rather than reading on.
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxJWKSBytes)).Decode(&doc); err != nil {
 		return nil, fmt.Errorf("jwks decode: %w", err)
 	}
 
 	out := make(map[string]interface{}, len(doc.Keys))
 	for _, k := range doc.Keys {
+		if len(out) >= maxJWKSKeys {
+			break // cap retained keys so a pathological JWKS can't bloat the cache
+		}
 		if k.Use != "" && k.Use != "sig" {
 			continue // not a signing key
 		}

--- a/internal/core/oidc_jwks_test.go
+++ b/internal/core/oidc_jwks_test.go
@@ -9,6 +9,7 @@ import (
 	"math/big"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 	"time"
 
@@ -88,6 +89,73 @@ func TestHTTPJWKSResolver_StaleFallbackBounded(t *testing.T) {
 	seedCache(jwksCacheTTL + jwksStaleGrace + time.Minute)
 	_, err = r.Key(context.Background(), "https://iss", "k1")
 	require.Error(t, err)
+}
+
+// An unknown kid on a fresh cache triggers at most one refetch per
+// jwksMinRefetchInterval per issuer, so a flood of tokens bearing a trusted issuer
+// and random kids can't amplify into a JWKS-fetch storm against the IdP.
+func TestHTTPJWKSResolver_UnknownKidRefetchRateLimited(t *testing.T) {
+	key, _ := rsa.GenerateKey(rand.Reader, 2048)
+	pub := &key.PublicKey
+	var hits int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits++
+		eBytes := big.NewInt(int64(pub.E)).Bytes()
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"keys": []map[string]string{{
+				"kty": "RSA", "kid": "k1", "use": "sig",
+				"n": base64.RawURLEncoding.EncodeToString(pub.N.Bytes()),
+				"e": base64.RawURLEncoding.EncodeToString(eBytes),
+			}},
+		})
+	}))
+	defer srv.Close()
+	r, err := NewHTTPJWKSResolver(map[string]string{"https://iss": srv.URL})
+	require.NoError(t, err)
+
+	// Prime the cache (1 fetch).
+	_, err = r.Key(context.Background(), "https://iss", "k1")
+	require.NoError(t, err)
+	require.Equal(t, 1, hits)
+
+	// A flood of distinct unknown kids on the now-fresh cache: the first one is
+	// allowed to refetch (rotation), the rest within the interval are rejected
+	// without any outbound fetch.
+	for i := 0; i < 50; i++ {
+		_, _ = r.Key(context.Background(), "https://iss", "bogus-kid")
+	}
+	assert.LessOrEqual(t, hits, 2, "bogus-kid flood must not amplify into a fetch storm")
+
+	// The legitimate kid is still served from cache throughout.
+	_, err = r.Key(context.Background(), "https://iss", "k1")
+	require.NoError(t, err)
+}
+
+// A JWKS with more keys than maxJWKSKeys is capped so a pathological key set can't
+// bloat the cache.
+func TestHTTPJWKSResolver_CapsKeyCount(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		keys := make([]map[string]string, 0, maxJWKSKeys+20)
+		for i := 0; i < maxJWKSKeys+20; i++ {
+			k, _ := rsa.GenerateKey(rand.Reader, 2048)
+			pub := &k.PublicKey
+			keys = append(keys, map[string]string{
+				"kty": "RSA", "kid": "k" + strconv.Itoa(i), "use": "sig",
+				"n": base64.RawURLEncoding.EncodeToString(pub.N.Bytes()),
+				"e": base64.RawURLEncoding.EncodeToString(big.NewInt(int64(pub.E)).Bytes()),
+			})
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"keys": keys})
+	}))
+	defer srv.Close()
+	r, err := NewHTTPJWKSResolver(map[string]string{"https://iss": srv.URL})
+	require.NoError(t, err)
+
+	_, _ = r.Key(context.Background(), "https://iss", "k0")
+	r.mu.Lock()
+	n := len(r.cache["https://iss"].keys)
+	r.mu.Unlock()
+	assert.LessOrEqual(t, n, maxJWKSKeys, "retained key count is capped")
 }
 
 func TestNewHTTPJWKSResolver_RejectsInsecureScheme(t *testing.T) {

--- a/internal/core/pat.go
+++ b/internal/core/pat.go
@@ -98,16 +98,22 @@ func (c *KeyorixCore) ListOwnPATs(ctx context.Context, userID uint) ([]*models.P
 }
 
 // RevokeOwnPAT revokes one of the caller's tokens after verifying ownership. A token
-// owned by another user is reported as not found to prevent ID enumeration.
-func (c *KeyorixCore) RevokeOwnPAT(ctx context.Context, userID, tokenID uint) error {
+// owned by another user is reported as not found to prevent ID enumeration. On success
+// it returns the token's hash so the caller can evict the auth cache immediately: the
+// HTTP token cache is keyed by SHA-256(raw token), which equals the stored TokenHash,
+// so without eviction a revoked PAT would keep authenticating until the cache TTL.
+func (c *KeyorixCore) RevokeOwnPAT(ctx context.Context, userID, tokenID uint) (tokenHash string, err error) {
 	if userID == 0 || tokenID == 0 {
-		return fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "user and token IDs are required")
+		return "", fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "user and token IDs are required")
 	}
 	pat, err := c.storage.GetPersonalAccessTokenByID(ctx, tokenID)
 	if err != nil || pat.UserID != userID {
-		return fmt.Errorf("%s: token not found", i18n.T("ErrorNotFound", nil))
+		return "", fmt.Errorf("%s: token not found", i18n.T("ErrorNotFound", nil))
 	}
-	return c.storage.RevokePersonalAccessToken(ctx, tokenID)
+	if err := c.storage.RevokePersonalAccessToken(ctx, tokenID); err != nil {
+		return "", err
+	}
+	return pat.TokenHash, nil
 }
 
 // ValidatePATToken resolves a raw PAT to its owning user, role names, and any

--- a/internal/core/pat_scoping_e2e_test.go
+++ b/internal/core/pat_scoping_e2e_test.go
@@ -30,8 +30,10 @@ func newPATScopingCore(t *testing.T) (*KeyorixCore, *store.LocalStorage) {
 	))
 	st := store.NewLocalStorage(db)
 	c := NewKeyorixCore(st)
+	c.SetBootstrapToken("test-bootstrap-token")
 	_, err = c.BootstrapSystem(context.Background(), &BootstrapRequest{
-		Username: "admin", Email: "admin@example.com", Password: "password12345", DisplayName: "Admin",
+		Username: "admin", Email: "admin@example.com", Password: "BootstrapPass123!", DisplayName: "Admin",
+		Token: "test-bootstrap-token",
 	})
 	require.NoError(t, err)
 	return c, st

--- a/internal/core/pat_suspend_test.go
+++ b/internal/core/pat_suspend_test.go
@@ -43,8 +43,14 @@ func TestValidatePATToken_SuspendRevokesTokenAccess(t *testing.T) {
 	// Admin (id 2) suspends the user.
 	require.NoError(t, c.SuspendUser(ctx, 2, 1))
 
-	// The PAT must now be rejected — suspension revokes token access, not only sessions.
+	// The PAT must now be rejected — suspension actively revokes the user's PATs (not just
+	// blocking them via account state), so the token is reported revoked.
 	_, _, _, err = c.ValidatePATToken(ctx, raw)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "not active")
+	assert.Contains(t, err.Error(), "revoked")
+
+	// Confirm the revocation is persisted (defence-in-depth, independent of the auth cache).
+	var pat models.PersonalAccessToken
+	require.NoError(t, db.First(&pat, 1).Error)
+	assert.True(t, pat.Revoked, "suspension must revoke the user's PATs")
 }

--- a/internal/core/pat_test.go
+++ b/internal/core/pat_test.go
@@ -169,9 +169,11 @@ func TestRevokeOwnPAT(t *testing.T) {
 	t.Run("revokes a token the caller owns", func(t *testing.T) {
 		ms := new(MockStorage)
 		c := NewKeyorixCore(ms)
-		ms.On("GetPersonalAccessTokenByID", ctx, uint(3)).Return(&models.PersonalAccessToken{ID: 3, UserID: 1}, nil)
+		ms.On("GetPersonalAccessTokenByID", ctx, uint(3)).Return(&models.PersonalAccessToken{ID: 3, UserID: 1, TokenHash: "hash-3"}, nil)
 		ms.On("RevokePersonalAccessToken", ctx, uint(3)).Return(nil)
-		require.NoError(t, c.RevokeOwnPAT(ctx, 1, 3))
+		hash, rerr := c.RevokeOwnPAT(ctx, 1, 3)
+		require.NoError(t, rerr)
+		assert.Equal(t, "hash-3", hash, "revoke returns the token hash for cache eviction")
 		ms.AssertCalled(t, "RevokePersonalAccessToken", ctx, uint(3))
 	})
 
@@ -179,7 +181,7 @@ func TestRevokeOwnPAT(t *testing.T) {
 		ms := new(MockStorage)
 		c := NewKeyorixCore(ms)
 		ms.On("GetPersonalAccessTokenByID", ctx, uint(3)).Return(&models.PersonalAccessToken{ID: 3, UserID: 2}, nil)
-		err := c.RevokeOwnPAT(ctx, 1, 3)
+		_, err := c.RevokeOwnPAT(ctx, 1, 3)
 		require.Error(t, err)
 		ms.AssertNotCalled(t, "RevokePersonalAccessToken", mock.Anything, mock.Anything)
 	})

--- a/internal/core/project_hygiene.go
+++ b/internal/core/project_hygiene.go
@@ -78,7 +78,7 @@ func (c *KeyorixCore) ProjectHygieneSummary(ctx context.Context, projectID uint,
 	out.StaleMachineIdentities = len(staleMI)
 
 	// Secrets past their rotation policy's interval (reuses the rotation-status eval).
-	statuses, err := c.GetRotationStatus(ctx, &projectID)
+	statuses, err := c.GetRotationStatus(ctx, &projectID, nil)
 	if err != nil {
 		return nil, fmt.Errorf("rotation status: %w", err)
 	}

--- a/internal/core/purge.go
+++ b/internal/core/purge.go
@@ -28,6 +28,15 @@ func (r PurgeResult) Total() int64 {
 // it emits one system-actored `data.purged` audit event with the counts. Errors on
 // individual entities are collected but do not abort the others.
 func (c *KeyorixCore) PurgeExpiredSoftDeletes(ctx context.Context, before time.Time) (*PurgeResult, error) {
+	// Re-check the legal hold HERE — inside the purge, under the scheduler lock and
+	// immediately before the deletes — not only in the scheduler closure before the lock
+	// is taken. Otherwise a hold placed after the pre-lock check (PlaceLegalHold doesn't
+	// take the lock) would not stop an in-flight purge from hard-deleting records that are
+	// now under hold (irreversible spoliation, ISO A.5.34). Fails SAFE: an unconfirmable
+	// hold status aborts the purge.
+	if err := c.legalHoldGuard(ctx); err != nil {
+		return &PurgeResult{}, err
+	}
 	res := &PurgeResult{}
 	var firstErr error
 	record := func(n int64, err error) int64 {

--- a/internal/core/purge_test.go
+++ b/internal/core/purge_test.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -13,6 +14,7 @@ import (
 func TestPurgeExpiredSoftDeletes_CountsAndAudits(t *testing.T) {
 	before := time.Date(2026, 6, 10, 0, 0, 0, 0, time.UTC)
 	store := new(MockStorage)
+	store.On("GetActiveLegalHold", mock.Anything).Return(nil, nil) // no active legal hold
 	store.On("PurgeDeletedUsersBefore", mock.Anything, before).Return(int64(2), nil)
 	store.On("PurgeDeletedProjectsBefore", mock.Anything, before).Return(int64(1), nil)
 	store.On("PurgeDeletedEnvironmentsBefore", mock.Anything, before).Return(int64(3), nil)
@@ -42,6 +44,7 @@ func TestPurgeExpiredSoftDeletes_CountsAndAudits(t *testing.T) {
 func TestPurgeExpiredSoftDeletes_NoAuditWhenNothingPurged(t *testing.T) {
 	before := time.Now()
 	store := new(MockStorage)
+	store.On("GetActiveLegalHold", mock.Anything).Return(nil, nil) // no active legal hold
 	store.On("PurgeDeletedUsersBefore", mock.Anything, before).Return(int64(0), nil)
 	store.On("PurgeDeletedProjectsBefore", mock.Anything, before).Return(int64(0), nil)
 	store.On("PurgeDeletedEnvironmentsBefore", mock.Anything, before).Return(int64(0), nil)
@@ -53,4 +56,34 @@ func TestPurgeExpiredSoftDeletes_NoAuditWhenNothingPurged(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, int64(0), res.Total())
 	store.AssertNotCalled(t, "LogAuditEvent", mock.Anything, mock.Anything)
+}
+
+// The purge re-checks the legal hold itself (not just the scheduler), so a hold active
+// when the purge runs aborts it before ANY delete — closing the TOCTOU where a hold
+// placed after the scheduler's pre-lock check would let an in-flight purge destroy
+// records now under hold.
+func TestPurgeExpiredSoftDeletes_AbortsUnderActiveLegalHold(t *testing.T) {
+	before := time.Now()
+	store := new(MockStorage)
+	store.On("GetActiveLegalHold", mock.Anything).Return(&models.LegalHold{ID: 1, Reason: "litigation"}, nil)
+
+	c := NewKeyorixCore(store)
+	_, err := c.PurgeExpiredSoftDeletes(context.Background(), before)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "legal hold")
+	// No delete was attempted.
+	store.AssertNotCalled(t, "PurgeDeletedUsersBefore", mock.Anything, mock.Anything)
+	store.AssertNotCalled(t, "PurgeDeletedSecretsBefore", mock.Anything, mock.Anything)
+}
+
+// Fail SAFE: if the legal-hold status can't be confirmed, the purge aborts rather than
+// risk destroying data that may be under hold.
+func TestPurgeExpiredSoftDeletes_AbortsWhenHoldStatusUnknown(t *testing.T) {
+	store := new(MockStorage)
+	store.On("GetActiveLegalHold", mock.Anything).Return(nil, fmt.Errorf("db down"))
+
+	c := NewKeyorixCore(store)
+	_, err := c.PurgeExpiredSoftDeletes(context.Background(), time.Now())
+	require.Error(t, err)
+	store.AssertNotCalled(t, "PurgeDeletedUsersBefore", mock.Anything, mock.Anything)
 }

--- a/internal/core/restore_audit_test.go
+++ b/internal/core/restore_audit_test.go
@@ -33,6 +33,10 @@ func TestRestoreOperationsAudit(t *testing.T) {
 	}
 
 	t.Run("secret.restored", func(t *testing.T) {
+		// A live parent project + environment: RestoreSecret refuses to restore into a
+		// soft-deleted parent, so the audit test needs them present and live.
+		require.NoError(t, db.Create(&models.Project{ID: 1, Name: "p1"}).Error)
+		require.NoError(t, db.Create(&models.Environment{ID: 999, ProjectID: 1, Name: "env"}).Error)
 		s, err := c.storage.CreateSecret(ctx, &models.SecretNode{Name: "k", ProjectID: 1, EnvironmentID: 999, IsSecret: true, CreatedAt: time.Now(), UpdatedAt: time.Now()})
 		require.NoError(t, err)
 		require.NoError(t, c.storage.DeleteSecret(ctx, s.ID))

--- a/internal/core/risk_exceptions.go
+++ b/internal/core/risk_exceptions.go
@@ -48,6 +48,10 @@ func exceptionStatus(e *models.RiskException, now time.Time) string {
 	return ExceptionStatusActive
 }
 
+// maxRiskExceptionDuration caps how far out a risk exception may be set to expire — an
+// exception must sunset and be re-reviewed, not become a permanent waiver.
+const maxRiskExceptionDuration = 365 * 24 * time.Hour
+
 // CreateRiskException records a governed, time-bound acceptance of a control gap.
 // actorID is the accepting owner; expiresAt must be in the future.
 func (c *KeyorixCore) CreateRiskException(ctx context.Context, actorID uint, title, category, reference, justification string, expiresAt time.Time) (*models.RiskException, error) {
@@ -59,6 +63,11 @@ func (c *KeyorixCore) CreateRiskException(ctx context.Context, actorID uint, tit
 	}
 	if !expiresAt.After(c.now()) {
 		return nil, fmt.Errorf("expires_at must be in the future (exceptions are time-bound)")
+	}
+	// A risk exception MUST sunset — bound the duration so it can't be set effectively
+	// forever (e.g. year 9999), defeating the "accepted with a sunset" governance intent.
+	if expiresAt.After(c.now().Add(maxRiskExceptionDuration)) {
+		return nil, fmt.Errorf("expires_at must be within %d days (exceptions must sunset and be re-reviewed)", int(maxRiskExceptionDuration/(24*time.Hour)))
 	}
 	created, err := c.storage.CreateRiskException(ctx, &models.RiskException{
 		Title: title, Category: category, Reference: reference, Justification: justification,

--- a/internal/core/risk_exceptions_test.go
+++ b/internal/core/risk_exceptions_test.go
@@ -48,6 +48,12 @@ func TestCreateRiskException_Rejects(t *testing.T) {
 
 	_, err = c.CreateRiskException(context.Background(), 1, "t", "sod", "", "j", now.Add(-time.Hour))
 	require.Error(t, err, "expiry must be in the future")
+
+	// Must sunset: an expiry beyond the max duration is refused (no effectively-forever
+	// waiver).
+	_, err = c.CreateRiskException(context.Background(), 1, "t", "sod", "", "j", now.AddDate(5, 0, 0))
+	require.Error(t, err, "expiry beyond the cap is rejected")
+	require.Contains(t, err.Error(), "must be within")
 }
 
 func TestListRiskExceptions_ComputesStatusAndFilters(t *testing.T) {

--- a/internal/core/rotation_eval_cap_test.go
+++ b/internal/core/rotation_eval_cap_test.go
@@ -45,11 +45,11 @@ func TestEvaluateRotationPolicies_NoSilentCap(t *testing.T) {
 	}
 	require.NoError(t, db.CreateInBatches(secrets, 200).Error)
 
-	evals, err := c.EvaluateRotationPolicies(context.Background(), nil)
+	evals, err := c.EvaluateRotationPolicies(context.Background(), nil, nil)
 	require.NoError(t, err)
 	assert.Len(t, evals, n, "every overdue secret is evaluated, not capped at one page")
 
-	status, err := c.GetRotationStatus(context.Background(), nil)
+	status, err := c.GetRotationStatus(context.Background(), nil, nil)
 	require.NoError(t, err)
 	assert.Len(t, status, n, "status covers every secret too, not capped at one page")
 }

--- a/internal/core/rotation_executor.go
+++ b/internal/core/rotation_executor.go
@@ -174,7 +174,7 @@ func (c *KeyorixCore) RunAutoRotation(ctx context.Context) (int, error) {
 		if !policy.IsActive {
 			continue
 		}
-		secrets, err := c.scopedPolicySecrets(ctx, policy)
+		secrets, err := c.scopedPolicySecrets(ctx, policy, nil)
 		if err != nil {
 			continue
 		}

--- a/internal/core/rotation_planner.go
+++ b/internal/core/rotation_planner.go
@@ -59,7 +59,7 @@ type RotationPlan struct {
 // prioritised by urgency within each wave. Returns an empty plan (no waves) when
 // nothing needs rotation.
 func (c *KeyorixCore) GenerateRotationPlan(ctx context.Context, projectID uint) (*RotationPlan, error) {
-	status, err := c.GetRotationStatus(ctx, &projectID)
+	status, err := c.GetRotationStatus(ctx, &projectID, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/core/rotation_policies.go
+++ b/internal/core/rotation_policies.go
@@ -186,11 +186,16 @@ type RotationStatusEntry struct {
 // environment) with more than one page of secrets would otherwise have the
 // secrets past the cap never checked for rotation — so overdue ones would be
 // missed by both the reminder scheduler and the status/evaluate views.
-func (c *KeyorixCore) scopedPolicySecrets(ctx context.Context, policy *models.RotationPolicy) ([]*models.SecretNode, error) {
+func (c *KeyorixCore) scopedPolicySecrets(ctx context.Context, policy *models.RotationPolicy, reqEnvID *uint) ([]*models.SecretNode, error) {
 	const pageSize = 500
 	var projectID, environmentID *uint
 	if policy.Scope == "project" {
 		projectID = policy.ProjectID
+		// When the caller restricted the view to a specific environment, confine a
+		// PROJECT-scoped policy's secret enumeration to that environment too — otherwise
+		// an environment-scoped reader would see secret metadata (name, last-rotated,
+		// overdue status, backend) for every environment of the project. nil = all envs.
+		environmentID = reqEnvID
 	} else {
 		environmentID = policy.EnvironmentID
 	}
@@ -211,7 +216,20 @@ func (c *KeyorixCore) scopedPolicySecrets(ctx context.Context, policy *models.Ro
 	return all, nil
 }
 
-func (c *KeyorixCore) GetRotationStatus(ctx context.Context, projectID *uint) ([]*RotationStatusEntry, error) {
+// policyAppliesToEnv reports whether a policy should be included when the caller
+// restricted the view to reqEnvID. A nil reqEnvID (project-wide / internal callers)
+// includes everything. A project-scoped policy always applies (its secrets are then
+// confined to reqEnvID by scopedPolicySecrets); an environment-scoped policy applies
+// only when it targets reqEnvID, so a reader scoped to one environment can't see
+// another environment's policy posture.
+func policyAppliesToEnv(policy *models.RotationPolicy, reqEnvID *uint) bool {
+	if reqEnvID == nil || policy.Scope == "project" {
+		return true
+	}
+	return policy.EnvironmentID != nil && *policy.EnvironmentID == *reqEnvID
+}
+
+func (c *KeyorixCore) GetRotationStatus(ctx context.Context, projectID, environmentID *uint) ([]*RotationStatusEntry, error) {
 	policies, err := c.storage.ListRotationPolicies(ctx, projectID, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list rotation policies: %w", err)
@@ -221,11 +239,11 @@ func (c *KeyorixCore) GetRotationStatus(ctx context.Context, projectID *uint) ([
 	now := c.now()
 
 	for _, policy := range policies {
-		if !policy.IsActive {
+		if !policy.IsActive || !policyAppliesToEnv(policy, environmentID) {
 			continue
 		}
 
-		secrets, err := c.scopedPolicySecrets(ctx, policy)
+		secrets, err := c.scopedPolicySecrets(ctx, policy, environmentID)
 		if err != nil {
 			continue
 		}
@@ -267,7 +285,7 @@ func (c *KeyorixCore) GetRotationStatus(ctx context.Context, projectID *uint) ([
 	return entries, nil
 }
 
-func (c *KeyorixCore) EvaluateRotationPolicies(ctx context.Context, projectID *uint) ([]*RotationPolicyEvaluation, error) {
+func (c *KeyorixCore) EvaluateRotationPolicies(ctx context.Context, projectID, environmentID *uint) ([]*RotationPolicyEvaluation, error) {
 	policies, err := c.storage.ListRotationPolicies(ctx, projectID, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list rotation policies: %w", err)
@@ -277,11 +295,11 @@ func (c *KeyorixCore) EvaluateRotationPolicies(ctx context.Context, projectID *u
 	now := c.now()
 
 	for _, policy := range policies {
-		if !policy.IsActive {
+		if !policy.IsActive || !policyAppliesToEnv(policy, environmentID) {
 			continue
 		}
 
-		secrets, err := c.scopedPolicySecrets(ctx, policy)
+		secrets, err := c.scopedPolicySecrets(ctx, policy, environmentID)
 		if err != nil {
 			continue
 		}

--- a/internal/core/rotation_reminders.go
+++ b/internal/core/rotation_reminders.go
@@ -18,7 +18,7 @@ const NotificationRotationDue = "rotation.reminder"
 // reminders don't pile up — once they read it (and the secret is still overdue) the
 // next run nudges them again. Returns the number of notifications created.
 func (c *KeyorixCore) SendRotationReminders(ctx context.Context) (int, error) {
-	evals, err := c.EvaluateRotationPolicies(ctx, nil)
+	evals, err := c.EvaluateRotationPolicies(ctx, nil, nil)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/core/rotation_status_test.go
+++ b/internal/core/rotation_status_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -36,10 +37,10 @@ func TestGetRotationStatus_Classification(t *testing.T) {
 	inactive := &models.RotationPolicy{ID: 8, Name: "off", Scope: "project", ProjectID: &projectID, IntervalDays: 30, IsActive: false}
 
 	secrets := []*models.SecretNode{
-		{ID: 1, Name: "overdue-key", EnvironmentID: 2, LastRotatedAt: daysAgo(120)}, // 120 > 90 → overdue
+		{ID: 1, Name: "overdue-key", EnvironmentID: 2, LastRotatedAt: daysAgo(120)},                                               // 120 > 90 → overdue
 		{ID: 2, Name: "due-soon-key", EnvironmentID: 2, LastRotatedAt: daysAgo(80), AutoRotate: true, RotationBackend: "prod-pg"}, // 90-80=10 <= 14 → due_soon
-		{ID: 3, Name: "healthy-key", EnvironmentID: 2, LastRotatedAt: daysAgo(10)},  // 90-10=80 > 14 → ok
-		{ID: 4, Name: "never-rotated", EnvironmentID: 2, CreatedAt: *daysAgo(200)},  // falls back to CreatedAt → overdue
+		{ID: 3, Name: "healthy-key", EnvironmentID: 2, LastRotatedAt: daysAgo(10)},                                                // 90-10=80 > 14 → ok
+		{ID: 4, Name: "never-rotated", EnvironmentID: 2, CreatedAt: *daysAgo(200)},                                                // falls back to CreatedAt → overdue
 	}
 
 	store.On("ListRotationPolicies", mock.Anything, &projectID, (*uint)(nil)).Return([]*models.RotationPolicy{policy, inactive}, nil)
@@ -48,7 +49,7 @@ func TestGetRotationStatus_Classification(t *testing.T) {
 	c := NewKeyorixCore(store)
 	c.now = func() time.Time { return fixed }
 
-	entries, err := c.GetRotationStatus(context.Background(), &projectID)
+	entries, err := c.GetRotationStatus(context.Background(), &projectID, nil)
 	require.NoError(t, err)
 	require.Len(t, entries, 4, "all covered secrets returned, inactive policy skipped")
 
@@ -68,4 +69,36 @@ func TestGetRotationStatus_Classification(t *testing.T) {
 	require.True(t, byID[2].AutoRotate)
 	require.Equal(t, "prod-pg", byID[2].RotationBackend)
 	require.False(t, byID[1].AutoRotate, "reminder-only secret is not auto-rotate")
+}
+
+// When the caller restricts to a specific environment, a project-scoped policy's
+// secret enumeration is confined to that environment, and an environment-scoped policy
+// for a DIFFERENT environment is skipped entirely — so an environment-scoped reader
+// can't see another environment's rotation posture.
+func TestGetRotationStatus_ConfinedToEnvironment(t *testing.T) {
+	fixed := time.Date(2026, 6, 8, 12, 0, 0, 0, time.UTC)
+	store := new(MockStorage)
+	projectID := uint(1)
+	envID := uint(2)
+	otherEnv := uint(9)
+
+	projPolicy := &models.RotationPolicy{ID: 1, Name: "proj", Scope: "project", ProjectID: &projectID, IntervalDays: 90, IsActive: true}
+	otherEnvPolicy := &models.RotationPolicy{ID: 2, Name: "env9", Scope: "environment", EnvironmentID: &otherEnv, IntervalDays: 90, IsActive: true}
+
+	store.On("ListRotationPolicies", mock.Anything, &projectID, (*uint)(nil)).
+		Return([]*models.RotationPolicy{projPolicy, otherEnvPolicy}, nil)
+	// The project-scoped policy's secret listing must be confined to env 2; the env-9
+	// policy must never reach ListSecrets (it's skipped before enumeration).
+	store.On("ListSecrets", mock.Anything, mock.MatchedBy(func(f *storage.SecretFilter) bool {
+		return f.EnvironmentID != nil && *f.EnvironmentID == envID
+	})).Return([]*models.SecretNode{{ID: 1, Name: "k", EnvironmentID: envID, LastRotatedAt: &fixed}}, int64(1), nil)
+
+	c := NewKeyorixCore(store)
+	c.now = func() time.Time { return fixed }
+
+	entries, err := c.GetRotationStatus(context.Background(), &projectID, &envID)
+	require.NoError(t, err)
+	require.Len(t, entries, 1, "only the project policy's env-2 secret; the env-9 policy is skipped")
+	require.Equal(t, uint(1), entries[0].SecretID)
+	store.AssertExpectations(t)
 }

--- a/internal/core/scim.go
+++ b/internal/core/scim.go
@@ -161,10 +161,23 @@ func (c *KeyorixCore) UpdateSCIMUser(ctx context.Context, actorID, id uint, disp
 		user.DisplayName = *displayName
 	}
 	if email != nil && *email != "" {
+		// Refuse an email that collides with a DIFFERENT user. SCIM email is trusted by
+		// identity resolution (SSO matches by email), so silently overwriting a low-priv
+		// account's email to an admin's would corrupt the email→account mapping and
+		// enable account linking/takeover. The create path already guards this.
+		if existing, eerr := c.storage.GetUserByEmail(ctx, *email); eerr == nil && existing != nil && existing.ID != user.ID {
+			return nil, fmt.Errorf("%s: email already in use by another user", i18n.T("ErrorValidation", nil))
+		}
 		user.Email = *email
 	}
 	deactivated := false
 	if active != nil {
+		if !*active {
+			// Don't let a routine (or hostile) SCIM sync deactivate the only admin.
+			if err := c.guardLastAdminDeactivation(ctx, id); err != nil {
+				return nil, err
+			}
+		}
 		user.IsActive = *active
 		if *active {
 			// Reactivation clears only a SCIM/IdP deactivation. An admin security
@@ -202,6 +215,33 @@ func (c *KeyorixCore) UpdateSCIMUser(ctx context.Context, actorID, id uint, disp
 	return updated, nil
 }
 
+// guardLastAdminDeactivation refuses an operation that would deactivate/deprovision the
+// only remaining install administrator, so a routine or hostile SCIM push can't lock
+// everyone out. Mirrors guardLastGlobalAdmin's assignment scan but keyed on the target.
+func (c *KeyorixCore) guardLastAdminDeactivation(ctx context.Context, targetID uint) error {
+	isAdmin, err := c.IsGlobalAdmin(ctx, targetID)
+	if err != nil || !isAdmin {
+		return nil // not an admin (or can't tell) — not the last-admin case
+	}
+	adminIDs := c.installAdminRoleIDSet(ctx)
+	assignments, err := c.storage.ListProjectRoleAssignments(ctx, 0)
+	if err != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	for _, a := range assignments {
+		if !adminIDs[a.RoleID] {
+			continue
+		}
+		// Any OTHER global-admin grant (a different user, or a group) means governance
+		// survives the target's removal.
+		if a.PrincipalType == "user" && a.PrincipalID == targetID {
+			continue
+		}
+		return nil
+	}
+	return fmt.Errorf("refusing to deactivate the last install administrator via SCIM")
+}
+
 // DeprovisionSCIMUser handles a SCIM DELETE: it deprovisions the user (blocks login,
 // terminates sessions) and soft-deletes the record, so the account is recoverable
 // within the retention window rather than hard-destroyed.
@@ -209,6 +249,10 @@ func (c *KeyorixCore) DeprovisionSCIMUser(ctx context.Context, actorID, id uint)
 	user, err := c.storage.GetUser(ctx, id)
 	if err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorUserNotFound", nil), err)
+	}
+	// Don't let a SCIM DELETE deprovision the only admin and lock the install out.
+	if err := c.guardLastAdminDeactivation(ctx, id); err != nil {
+		return err
 	}
 	user.IsActive = false
 	// Mark as SCIM-deprovisioned rather than admin-suspended, but never downgrade an

--- a/internal/core/scim.go
+++ b/internal/core/scim.go
@@ -110,7 +110,15 @@ func (c *KeyorixCore) ProvisionSCIMUser(ctx context.Context, actorID uint, userN
 	if email == "" {
 		email = userName // SCIM userName is conventionally the email
 	}
-	if existing, _ := c.FindSCIMUser(ctx, externalID, email); existing != nil {
+	// Fail CLOSED on a lookup error: swallowing it would let a transient DB error during
+	// the dedup check fall through to CreateUser and mint a SECOND identity with the same
+	// email (there is no DB-level email uniqueness), and SSO/SCIM resolve email via
+	// first-match — so which physical account a login binds to would become ambiguous.
+	existing, ferr := c.FindSCIMUser(ctx, externalID, email)
+	if ferr != nil {
+		return nil, fmt.Errorf("failed to check for an existing user: %w", ferr)
+	}
+	if existing != nil {
 		return nil, fmt.Errorf("a user already exists for this externalId/email")
 	}
 	username, err := c.deriveSCIMUsername(ctx, userName)

--- a/internal/core/scim.go
+++ b/internal/core/scim.go
@@ -215,8 +215,10 @@ func (c *KeyorixCore) UpdateSCIMUser(ctx context.Context, actorID, id uint, disp
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}
 	if deactivated {
-		// Suspension must be effective immediately, not lingering until tokens expire.
-		_ = c.storage.DeleteSessionsForUserExcept(ctx, id, 0)
+		// Suspension must be effective immediately, not lingering until tokens expire —
+		// terminate sessions AND evict them from the auth cache (the fast path bypasses the
+		// DB, so without eviction an offboarded user keeps access for the cache TTL).
+		_ = c.deleteSessionsForUserAndEvict(ctx, id, 0, "")
 	}
 	c.writeAuditEvent(ctx, EventSCIMUserUpdated, actorPtr(actorID), nil,
 		fmt.Sprintf("SCIM updated user %d", id))
@@ -270,6 +272,9 @@ func (c *KeyorixCore) DeprovisionSCIMUser(ctx context.Context, actorID, id uint)
 		user.AccountState = AccountDeprovisioned
 	}
 	user.UpdatedAt = c.now()
+	// Capture the user's session-token hashes BEFORE the transaction so they can be
+	// evicted from the auth cache after commit (the stored token is the SHA-256 cache key).
+	sessionHashes, _ := c.storage.ListSessionTokenHashesForUser(ctx, id)
 	// Suspend + terminate sessions + soft-delete atomically: a SCIM DELETE either fully
 	// deprovisions or leaves the account untouched, so a mid-way storage failure can't
 	// leave it half-deprovisioned (suspended but not deleted), which would make retries
@@ -283,6 +288,10 @@ func (c *KeyorixCore) DeprovisionSCIMUser(ctx context.Context, actorID, id uint)
 	}); err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}
+	// Evict the terminated sessions from the auth cache AFTER commit, so a deprovisioned
+	// (offboarded) user's live session stops authenticating immediately instead of
+	// lingering for the cache TTL.
+	c.invalidateTokenCache(sessionHashes...)
 	c.writeAuditEvent(ctx, EventSCIMUserDeprovisioned, actorPtr(actorID), nil,
 		fmt.Sprintf("SCIM deprovisioned user %d (%s)", id, user.Username))
 	return nil

--- a/internal/core/scim.go
+++ b/internal/core/scim.go
@@ -297,6 +297,41 @@ func (c *KeyorixCore) DeprovisionSCIMUser(ctx context.Context, actorID, id uint)
 	return nil
 }
 
+// SCIMMaxPageSize bounds how many resources a single SCIM list page returns — the
+// value advertised in ServiceProviderConfig (filter.maxResults). A larger requested
+// count is clamped to it so an unfiltered list can't drain the whole directory into one
+// response (memory + DB amplification).
+const SCIMMaxPageSize = 200
+
+// ListSCIMUsersPage returns one page of users for a SCIM list and the total count.
+// startIndex is 1-based (SCIM convention); count is clamped to [0, SCIMMaxPageSize]
+// (count==0 returns no resources, just the total).
+func (c *KeyorixCore) ListSCIMUsersPage(ctx context.Context, startIndex, count int) ([]*models.User, int, error) {
+	if startIndex < 1 {
+		startIndex = 1
+	}
+	if count < 0 {
+		count = 0
+	}
+	if count > SCIMMaxPageSize {
+		count = SCIMMaxPageSize
+	}
+	if count == 0 {
+		// SCIM count=0 → return totalResults only. Use PageSize=1 to get an accurate
+		// total without a separate count API; the single fetched row is discarded.
+		_, total, err := c.storage.ListUsers(ctx, &storage.UserFilter{Page: 1, PageSize: 1})
+		if err != nil {
+			return nil, 0, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+		}
+		return []*models.User{}, int(total), nil
+	}
+	users, total, err := c.storage.ListUsers(ctx, &storage.UserFilter{Offset: startIndex - 1, PageSize: count})
+	if err != nil {
+		return nil, 0, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	return users, int(total), nil
+}
+
 // ListSCIMUsers returns users for a SCIM list, paging through all of them.
 func (c *KeyorixCore) ListSCIMUsers(ctx context.Context) ([]*models.User, error) {
 	const pageSize = 200

--- a/internal/core/scim_groups.go
+++ b/internal/core/scim_groups.go
@@ -66,14 +66,25 @@ func (c *KeyorixCore) ReplaceSCIMGroup(ctx context.Context, actorID, groupID uin
 	have := make(map[uint]bool, len(current))
 	for _, u := range current {
 		have[u.ID] = true
+	}
+	toAdd := make([]uint, 0)
+	for id := range want {
+		if !have[id] {
+			toAdd = append(toAdd, id)
+		}
+	}
+	// SCIM must not be able to grant administrative access by adding members to a group
+	// that carries an admin role. Block the add (de-escalating removals are still fine).
+	if len(toAdd) > 0 && c.scimGroupConfersAdmin(ctx, groupID) {
+		return nil, fmt.Errorf("%s: SCIM cannot add members to a group that grants administrative roles", i18n.T("ErrorNotAuthorized", nil))
+	}
+	for _, u := range current {
 		if !want[u.ID] {
 			_ = c.storage.RemoveUserFromGroup(ctx, u.ID, groupID)
 		}
 	}
-	for id := range want {
-		if !have[id] {
-			_ = c.storage.AddUserToGroup(ctx, id, groupID)
-		}
+	for _, id := range toAdd {
+		_ = c.storage.AddUserToGroup(ctx, id, groupID)
 	}
 	c.writeAuditEvent(ctx, EventSCIMGroupUpdated, actorPtr(actorID), nil,
 		fmt.Sprintf("SCIM replaced group %d (members=%d)", groupID, len(want)))
@@ -93,6 +104,16 @@ func (c *KeyorixCore) PatchSCIMGroup(ctx context.Context, actorID, groupID uint,
 			return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 		}
 	}
+	hasAdds := false
+	for _, id := range addIDs {
+		if id != 0 {
+			hasAdds = true
+			break
+		}
+	}
+	if hasAdds && c.scimGroupConfersAdmin(ctx, groupID) {
+		return nil, fmt.Errorf("%s: SCIM cannot add members to a group that grants administrative roles", i18n.T("ErrorNotAuthorized", nil))
+	}
 	for _, id := range addIDs {
 		if id != 0 {
 			_ = c.storage.AddUserToGroup(ctx, id, groupID)
@@ -106,6 +127,22 @@ func (c *KeyorixCore) PatchSCIMGroup(ctx context.Context, actorID, groupID uint,
 	c.writeAuditEvent(ctx, EventSCIMGroupUpdated, actorPtr(actorID), nil,
 		fmt.Sprintf("SCIM patched group %d (+%d/-%d members)", groupID, len(addIDs), len(removeIDs)))
 	return c.storage.GetGroup(ctx, groupID)
+}
+
+// scimGroupConfersAdmin reports whether membership in groupID grants an admin role, so
+// the SCIM group-sync paths can refuse to add members to it. Fails CLOSED (treats the
+// group as admin-bearing) on a lookup error, so an inability to verify never opens the
+// privilege grant.
+func (c *KeyorixCore) scimGroupConfersAdmin(ctx context.Context, groupID uint) bool {
+	roles, err := c.storage.GetGroupRoles(ctx, groupID)
+	if err != nil {
+		return true
+	}
+	ids := make([]uint, 0, len(roles))
+	for _, r := range roles {
+		ids = append(ids, r.ID)
+	}
+	return c.roleSetContainsAdmin(ctx, ids)
 }
 
 // DeprovisionSCIMGroup handles a SCIM DELETE — removes the group (membership links

--- a/internal/core/scim_guards_test.go
+++ b/internal/core/scim_guards_test.go
@@ -1,0 +1,80 @@
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func newSCIMGuardCore(t *testing.T) (*KeyorixCore, *gorm.DB) {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.User{}, &models.Role{}, &models.Permission{}, &models.RolePermission{},
+		&models.UserRole{}, &models.Group{}, &models.UserGroup{}, &models.GroupRole{},
+		&models.Session{}, &models.AuditEvent{},
+	))
+	return NewKeyorixCore(store.NewLocalStorage(db)), db
+}
+
+func TestUpdateSCIMUser_RejectsEmailCollision(t *testing.T) {
+	c, db := newSCIMGuardCore(t)
+	ctx := context.Background()
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "admin", Email: "admin@x.io", IsActive: true, AccountState: AccountActive}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 2, Username: "bob", Email: "bob@x.io", IsActive: true, AccountState: AccountActive}).Error)
+
+	adminEmail := "admin@x.io"
+	_, err := c.UpdateSCIMUser(ctx, 9, 2, nil, &adminEmail, nil)
+	require.Error(t, err, "SCIM must not overwrite user 2's email to collide with the admin's")
+	assert.Contains(t, err.Error(), "already in use")
+}
+
+func TestUpdateSCIMUser_RefusesLastAdminDeactivation(t *testing.T) {
+	c, db := newSCIMGuardCore(t)
+	ctx := context.Background()
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "root", IsActive: true, AccountState: AccountActive}).Error)
+	require.NoError(t, db.Create(&models.Role{ID: 10, Name: "admin"}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 10}).Error) // global admin
+
+	no := false
+	_, err := c.UpdateSCIMUser(ctx, 9, 1, nil, nil, &no)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "last install administrator")
+}
+
+func TestUpdateSCIMUser_AllowsAdminDeactivationWhenAnotherExists(t *testing.T) {
+	c, db := newSCIMGuardCore(t)
+	ctx := context.Background()
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "root", IsActive: true, AccountState: AccountActive}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 2, Username: "root2", IsActive: true, AccountState: AccountActive}).Error)
+	require.NoError(t, db.Create(&models.Role{ID: 10, Name: "admin"}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 10}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 2, RoleID: 10}).Error)
+
+	no := false
+	off, err := c.UpdateSCIMUser(ctx, 9, 1, nil, nil, &no)
+	require.NoError(t, err, "deactivating one of two admins is allowed")
+	assert.False(t, off.IsActive)
+}
+
+func TestPatchSCIMGroup_RefusesAddingMemberToAdminGroup(t *testing.T) {
+	c, db := newSCIMGuardCore(t)
+	ctx := context.Background()
+	require.NoError(t, db.Create(&models.User{ID: 2, Username: "bob", IsActive: true, AccountState: AccountActive}).Error)
+	require.NoError(t, db.Create(&models.Role{ID: 10, Name: "admin"}).Error)
+	require.NoError(t, db.Create(&models.Group{ID: 5, Name: "Keyorix-Admins"}).Error)
+	require.NoError(t, db.Create(&models.GroupRole{GroupID: 5, RoleID: 10}).Error) // group confers admin
+
+	_, err := c.PatchSCIMGroup(ctx, 9, 5, nil, []uint{2}, nil)
+	require.Error(t, err, "SCIM must not add a member to an admin-bearing group")
+	assert.Contains(t, err.Error(), "administrative roles")
+}

--- a/internal/core/scim_paging_test.go
+++ b/internal/core/scim_paging_test.go
@@ -1,0 +1,55 @@
+package core
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// ListSCIMUsersPage returns a bounded window (clamped to SCIMMaxPageSize) plus the true
+// total, honouring the 1-based startIndex — so an unfiltered SCIM list can't drain the
+// whole directory into one response.
+func TestListSCIMUsersPage(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.User{}))
+	c := NewKeyorixCore(store.NewLocalStorage(db))
+	ctx := context.Background()
+
+	const n = 25
+	for i := 1; i <= n; i++ {
+		require.NoError(t, db.Create(&models.User{ID: uint(i), Username: fmt.Sprintf("u%02d", i), Email: fmt.Sprintf("u%02d@x.io", i)}).Error)
+	}
+
+	t.Run("count is clamped to the max page size", func(t *testing.T) {
+		users, total, err := c.ListSCIMUsersPage(ctx, 1, 10_000)
+		require.NoError(t, err)
+		assert.Equal(t, n, total, "total reflects the whole directory")
+		assert.LessOrEqual(t, len(users), SCIMMaxPageSize, "returned window is clamped")
+		assert.Len(t, users, n) // n < max, so all returned in this case
+	})
+
+	t.Run("startIndex + count select a window", func(t *testing.T) {
+		users, total, err := c.ListSCIMUsersPage(ctx, 11, 5)
+		require.NoError(t, err)
+		assert.Equal(t, n, total)
+		require.Len(t, users, 5)
+		assert.Equal(t, "u11", users[0].Username, "1-based startIndex 11 → 11th user")
+	})
+
+	t.Run("count zero returns the total only", func(t *testing.T) {
+		users, total, err := c.ListSCIMUsersPage(ctx, 1, 0)
+		require.NoError(t, err)
+		assert.Equal(t, n, total)
+		assert.Empty(t, users)
+	})
+}

--- a/internal/core/secret_bulk_rename.go
+++ b/internal/core/secret_bulk_rename.go
@@ -94,6 +94,14 @@ func (c *KeyorixCore) BulkRenameSecrets(ctx context.Context, projectID uint, ren
 			skip(rn.ID, secret.Name, newName, "secret does not belong to this project")
 			continue
 		}
+		// Re-check per-secret write authorization (owner/share). The project-wide
+		// secrets.write route gate is not sufficient on its own — the single-secret PUT
+		// path enforces this, so the bulk op must not let a caller rename a secret they
+		// can't update individually.
+		if _, perr := c.EnforceSecretWritePermission(ctx, secret.ID, actorID); perr != nil {
+			skip(rn.ID, secret.Name, newName, "not authorized to rename this secret")
+			continue
+		}
 		if !secret.IsSecret {
 			skip(rn.ID, secret.Name, newName, "not a secret (folder nodes have no governed name)")
 			continue

--- a/internal/core/secret_bulk_rename_test.go
+++ b/internal/core/secret_bulk_rename_test.go
@@ -68,6 +68,18 @@ func TestBulkRenameSecrets(t *testing.T) {
 		require.Error(t, err)
 	})
 
+	t.Run("a non-owner is skipped (per-secret write ACL)", func(t *testing.T) {
+		mine := mk("non-conf-x", p.ID, true) // owned by user 1
+		// User 2 holds no ownership/share on it — even with project secrets.write it must
+		// not be renamable via the bulk op (parity with the single-secret PUT gate).
+		rep, err := c.BulkRenameSecrets(ctx, p.ID, []SecretRename{{ID: mine, NewName: "MINE_X"}}, false, "intruder", 2, "", "")
+		require.NoError(t, err)
+		assert.Equal(t, 0, rep.Renamed)
+		require.Len(t, rep.Outcomes, 1)
+		assert.Equal(t, renameStatusSkipped, rep.Outcomes[0].Status)
+		assert.Contains(t, rep.Outcomes[0].Reason, "not authorized")
+	})
+
 	t.Run("dry run validates but changes nothing", func(t *testing.T) {
 		rep, err := c.BulkRenameSecrets(ctx, p.ID, []SecretRename{{ID: bad, NewName: "DB_PASSWORD"}}, true, "alice", 1, "", "")
 		require.NoError(t, err)

--- a/internal/core/secret_dependencies.go
+++ b/internal/core/secret_dependencies.go
@@ -77,20 +77,18 @@ func (c *KeyorixCore) AddSecretDependency(ctx context.Context, actorID, dependen
 	}
 	dependent, err := c.requireSecret(ctx, dependentID)
 	if err != nil {
-		return nil, err
+		return nil, err // the caller is authorized on the path secret, so its status may differ
 	}
-	dependsOn, err := c.requireSecret(ctx, dependsOnID)
-	if err != nil {
-		return nil, err
-	}
-	// Both endpoints must be in the same project AND environment. Authorization is
-	// environment-granular (a grant is scoped to {project, environment}), and the HTTP
-	// layer only authorizes the caller on the path secret's environment — so confining
-	// the edge to that one environment is what makes the path-secret authorization also
-	// cover the dependency secret. A cross-environment edge would let a caller scoped to
-	// one environment reference (and later read the name of) a secret in another.
-	if dependent.ProjectID != dependsOn.ProjectID || dependent.EnvironmentID != dependsOn.EnvironmentID {
-		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "both secrets must be in the same project and environment")
+	// Resolve the dependency target, but DON'T distinguish "not found" / "is a folder" /
+	// "in another project or environment" — the caller is only authorized on the path
+	// (dependent) secret's scope, so a differentiated error here is a cross-scope
+	// existence-and-type oracle (probe arbitrary IDs by 404-vs-400). Collapse them into a
+	// single opaque error. Confining the edge to the same project AND environment is also
+	// what makes the path-secret authorization cover the dependency secret (authorization
+	// is environment-granular and the HTTP layer authorizes only the path secret's env).
+	dependsOn, derr := c.requireSecret(ctx, dependsOnID)
+	if derr != nil || dependsOn.ProjectID != dependent.ProjectID || dependsOn.EnvironmentID != dependent.EnvironmentID {
+		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "the dependency target must be a secret in the same project and environment")
 	}
 
 	edges, err := c.storage.ListSecretDependenciesForProject(ctx, dependent.ProjectID)

--- a/internal/core/secret_dependencies_test.go
+++ b/internal/core/secret_dependencies_test.go
@@ -71,7 +71,12 @@ func newDepCore(t *testing.T) (*KeyorixCore, *gorm.DB) {
 	t.Helper()
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
-	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretDependency{}, &models.AuditEvent{}))
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretDependency{}, &models.AuditEvent{}, &models.Project{}, &models.Environment{}))
+	// Live parent projects (1, 2) + environment (1): RestoreSecret refuses to restore a
+	// secret into a soft-deleted parent, so the dependency-cascade tests need them present.
+	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "p1"}).Error)
+	require.NoError(t, db.Create(&models.Project{ID: 2, Name: "p2"}).Error)
+	require.NoError(t, db.Create(&models.Environment{ID: 1, ProjectID: 1, Name: "env1"}).Error)
 	now := time.Date(2026, 6, 22, 9, 0, 0, 0, time.UTC)
 	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: func() time.Time { return now }}
 	return c, db

--- a/internal/core/secret_dependencies_test.go
+++ b/internal/core/secret_dependencies_test.go
@@ -130,10 +130,13 @@ func TestAddSecretDependency_Validation(t *testing.T) {
 		assert.Contains(t, err.Error(), "cycle")
 	})
 
-	t.Run("missing secret rejected", func(t *testing.T) {
+	t.Run("missing dependency target rejected with an opaque error (no existence oracle)", func(t *testing.T) {
 		_, err := c.AddSecretDependency(ctx, 10, appTok, 9999, "")
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "9999")
+		// Must NOT reveal whether 9999 exists / what it is — same message as a cross-scope
+		// target, so the caller can't enumerate secret IDs across scopes.
+		assert.NotContains(t, err.Error(), "9999")
+		assert.Contains(t, err.Error(), "same project and environment")
 	})
 }
 

--- a/internal/core/secret_extend_expiring.go
+++ b/internal/core/secret_extend_expiring.go
@@ -39,6 +39,13 @@ func (c *KeyorixCore) ExtendExpiringSecrets(ctx context.Context, projectID uint,
 
 	extended := 0
 	for _, s := range secrets {
+		// Re-check per-secret write authorization (owner/share). The project-wide
+		// secrets.write route gate is not sufficient on its own — the single-secret PUT
+		// path enforces this too, so a caller who can't update a secret individually must
+		// not be able to via the bulk op. Skip (don't abort) on denial.
+		if _, err := c.EnforceSecretWritePermission(ctx, s.ID, actorID); err != nil {
+			continue
+		}
 		// Only push expiry out, never in — skip a secret already dated past the new window.
 		if s.Expiration != nil && !s.Expiration.Before(newExpiry) {
 			continue

--- a/internal/core/secret_ownership.go
+++ b/internal/core/secret_ownership.go
@@ -59,6 +59,17 @@ func (c *KeyorixCore) transferOwnership(ctx context.Context, secretID, newOwnerI
 		return nil, fmt.Errorf("%s: only the current owner can transfer this secret", i18n.T("ErrorPermissionDenied", nil))
 	}
 
+	// The NEW owner must already have access to the secret's scope. Ownership grants
+	// full control (incl. re-share), so without this an authorized writer could hand a
+	// secret to a user with no role in its project — granting access out of band.
+	// Evaluate the new owner's OWN roles, not gated by the actor's PAT restriction.
+	if ok, perr := c.principalHasScopedPermission(ctx, newOwnerID, "secrets.read",
+		Scope{ProjectID: secret.ProjectID, EnvironmentID: secret.EnvironmentID}); perr != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), perr)
+	} else if !ok {
+		return nil, fmt.Errorf("%s: the new owner has no access to this secret's project/environment", i18n.T("ErrorPermissionDenied", nil))
+	}
+
 	oldOwner := secret.OwnerID
 	secret.OwnerID = newOwnerID
 	updated, err := c.storage.UpdateSecret(ctx, secret)

--- a/internal/core/secret_ownership_test.go
+++ b/internal/core/secret_ownership_test.go
@@ -41,14 +41,24 @@ func newOwnershipFixture(t *testing.T) (*KeyorixCore, uint) {
 	sqlDB, err := db.DB()
 	require.NoError(t, err)
 	sqlDB.SetMaxOpenConns(1)
-	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.User{}))
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.User{},
+		&models.Role{}, &models.Permission{}, &models.RolePermission{}, &models.UserRole{},
+		&models.Group{}, &models.UserGroup{}, &models.GroupRole{}))
 	for _, u := range []models.User{
 		{ID: 1, Username: "owner", Email: "o@test.com"},
 		{ID: 2, Username: "alice", Email: "a@test.com"},
 		{ID: 3, Username: "bob", Email: "b@test.com"},
+		{ID: 4, Username: "carol", Email: "c@test.com"}, // no role — a transfer target with no project access
 	} {
 		require.NoError(t, db.Create(&u).Error)
 	}
+	// A reader role with secrets.read, granted to users 2 and 3 in project 1 (the
+	// secret's scope) so they're eligible to become the owner; user 4 holds nothing.
+	require.NoError(t, db.Create(&models.Role{ID: 1, Name: "reader"}).Error)
+	require.NoError(t, db.Create(&models.Permission{ID: 1, Name: "secrets.read", Resource: "secrets", Action: "read"}).Error)
+	require.NoError(t, db.Create(&models.RolePermission{RoleID: 1, PermissionID: 1}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 2, RoleID: 1, ProjectID: 1}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 3, RoleID: 1, ProjectID: 1}).Error)
 	st := store.NewLocalStorage(db)
 	c := &KeyorixCore{storage: st, now: time.Now}
 	secret, err := st.CreateSecret(context.Background(), &models.SecretNode{
@@ -88,6 +98,14 @@ func TestTransferSecretOwnership(t *testing.T) {
 		updated, err := c.TransferSecretOwnership(ctx, id, 2, 3) // actor 3, owner gone
 		require.NoError(t, err)
 		assert.EqualValues(t, 2, updated.OwnerID)
+	})
+
+	t.Run("rejects a new owner with no access to the secret's scope", func(t *testing.T) {
+		c, id := newOwnershipFixture(t)
+		// User 4 holds no role in project 1, so it must not be handed ownership.
+		_, err := c.TransferSecretOwnership(ctx, id, 4, 1)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no access")
 	})
 
 	t.Run("rejects a non-existent new owner", func(t *testing.T) {

--- a/internal/core/secret_reassign_owner_test.go
+++ b/internal/core/secret_reassign_owner_test.go
@@ -20,7 +20,8 @@ func TestReassignOwnedSecrets(t *testing.T) {
 	require.NoError(t, err)
 	sqlDB, _ := db.DB()
 	sqlDB.SetMaxOpenConns(1)
-	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.User{}, &models.AuditEvent{}, &models.Project{}, &models.Environment{}))
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.User{}, &models.AuditEvent{}, &models.Project{}, &models.Environment{},
+		&models.Role{}, &models.Permission{}, &models.RolePermission{}, &models.UserRole{}, &models.Group{}, &models.UserGroup{}, &models.GroupRole{}))
 	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
 	ctx := context.Background()
 
@@ -37,6 +38,12 @@ func TestReassignOwnedSecrets(t *testing.T) {
 	require.NoError(t, err)
 	e2, err := c.storage.CreateEnvironment(ctx, &models.Environment{Name: "production", ProjectID: p2.ID})
 	require.NoError(t, err)
+
+	// The heir must have access to the secrets' scope to become their owner.
+	require.NoError(t, db.Create(&models.Role{ID: 1, Name: "reader"}).Error)
+	require.NoError(t, db.Create(&models.Permission{ID: 1, Name: "secrets.read", Resource: "secrets", Action: "read"}).Error)
+	require.NoError(t, db.Create(&models.RolePermission{RoleID: 1, PermissionID: 1}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 3, RoleID: 1, ProjectID: p1.ID}).Error)
 
 	mk := func(name string, projectID, envID, ownerID uint) uint {
 		s, err := c.storage.CreateSecret(ctx, &models.SecretNode{

--- a/internal/core/secret_render.go
+++ b/internal/core/secret_render.go
@@ -17,8 +17,11 @@ import (
 // RenderSecretTemplate expands ${secret:<environment>/<name>} references in template
 // against the given project, returning the rendered output. A reference to an unknown
 // environment/secret, or one the user cannot read, fails the whole render (no partial
-// output). Values are never logged.
-func (c *KeyorixCore) RenderSecretTemplate(ctx context.Context, template string, projectID, userID uint) (string, error) {
+// output). Values are never logged — but each resolved value IS recorded as a secret read
+// (audit event + access log), so a bulk render can't be used as a covert exfiltration
+// channel invisible to the audit trail and the anomaly detector. username/ip/ua attribute
+// the reads (pass-through from the request); empty is tolerated.
+func (c *KeyorixCore) RenderSecretTemplate(ctx context.Context, template string, projectID, userID uint, username, ip, ua string) (string, error) {
 	if projectID == 0 {
 		return "", fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "project ID is required")
 	}
@@ -52,6 +55,10 @@ func (c *KeyorixCore) RenderSecretTemplate(ctx context.Context, template string,
 		if err != nil {
 			return "", err
 		}
+		// Record the read like the single-secret read path does, so a bulk render is
+		// auditable and visible to the anomaly detector (detached so it survives the
+		// request and never blocks the render).
+		go c.LogSecretReadWithProject(DetachedAuditContext(ctx), userID, secret.ID, projectID, username, secretName, ip, ua) // #nosec G118
 		return string(val), nil
 	})
 }

--- a/internal/core/secret_render_test.go
+++ b/internal/core/secret_render_test.go
@@ -16,7 +16,7 @@ import (
 
 // newRenderFixture builds an in-memory core with a project, a "production"
 // environment, and a secret "db-password"=s3cr3t owned by user 1.
-func newRenderFixture(t *testing.T) (*KeyorixCore, uint) {
+func newRenderFixture(t *testing.T) (*KeyorixCore, *gorm.DB, uint) {
 	t.Helper()
 	require.NoError(t, i18n.InitializeForTesting())
 
@@ -27,7 +27,7 @@ func newRenderFixture(t *testing.T) (*KeyorixCore, uint) {
 	sqlDB.SetMaxOpenConns(1)
 	require.NoError(t, db.AutoMigrate(
 		&models.SecretNode{}, &models.SecretVersion{}, &models.User{},
-		&models.Project{}, &models.Environment{},
+		&models.Project{}, &models.Environment{}, &models.SecretAccessLog{}, &models.AuditEvent{},
 	))
 	require.NoError(t, db.Create(&models.User{ID: 1, Username: "owner", Email: "o@test.com"}).Error)
 
@@ -48,41 +48,63 @@ func newRenderFixture(t *testing.T) (*KeyorixCore, uint) {
 		SecretNodeID: secret.ID, VersionNumber: 1, EncryptedValue: []byte("s3cr3t"),
 	})
 	require.NoError(t, err)
-	return c, proj.ID
+	return c, db, proj.ID
 }
 
 func TestRenderSecretTemplate(t *testing.T) {
 	ctx := context.Background()
-	c, projectID := newRenderFixture(t)
+	c, _, projectID := newRenderFixture(t)
 
 	t.Run("expands a known reference", func(t *testing.T) {
-		out, err := c.RenderSecretTemplate(ctx, "DB=${secret:production/db-password}", projectID, 1)
+		out, err := c.RenderSecretTemplate(ctx, "DB=${secret:production/db-password}", projectID, 1, "owner", "10.0.0.1", "ua")
 		require.NoError(t, err)
 		assert.Equal(t, "DB=s3cr3t", out)
 	})
 
 	t.Run("unknown environment fails", func(t *testing.T) {
-		_, err := c.RenderSecretTemplate(ctx, "${secret:staging/db-password}", projectID, 1)
+		_, err := c.RenderSecretTemplate(ctx, "${secret:staging/db-password}", projectID, 1, "owner", "10.0.0.1", "ua")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "environment")
 	})
 
 	t.Run("unknown secret fails", func(t *testing.T) {
-		_, err := c.RenderSecretTemplate(ctx, "${secret:production/nope}", projectID, 1)
+		_, err := c.RenderSecretTemplate(ctx, "${secret:production/nope}", projectID, 1, "owner", "10.0.0.1", "ua")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "not found")
 	})
 
 	t.Run("non-reader cannot resolve", func(t *testing.T) {
 		// User 2 owns nothing and has no share → the per-secret read check denies.
-		_, err := c.RenderSecretTemplate(ctx, "${secret:production/db-password}", projectID, 2)
+		_, err := c.RenderSecretTemplate(ctx, "${secret:production/db-password}", projectID, 2, "owner", "10.0.0.1", "ua")
 		require.Error(t, err)
 	})
 
 	t.Run("requires project + user", func(t *testing.T) {
-		_, err := c.RenderSecretTemplate(ctx, "x", 0, 1)
+		_, err := c.RenderSecretTemplate(ctx, "x", 0, 1, "owner", "10.0.0.1", "ua")
 		require.Error(t, err)
-		_, err = c.RenderSecretTemplate(ctx, "x", projectID, 0)
+		_, err = c.RenderSecretTemplate(ctx, "x", projectID, 0, "owner", "10.0.0.1", "ua")
 		require.Error(t, err)
 	})
+}
+
+// A render records a secret read (access log) for each resolved reference, so a bulk
+// render can't be a covert exfiltration channel invisible to the audit trail and the
+// anomaly detector (which feeds on SecretAccessLog).
+func TestRenderSecretTemplate_RecordsReads(t *testing.T) {
+	ctx := context.Background()
+	c, db, projectID := newRenderFixture(t)
+
+	_, err := c.RenderSecretTemplate(ctx, "DB=${secret:production/db-password}", projectID, 1, "owner", "10.0.0.1", "ua")
+	require.NoError(t, err)
+
+	// The read is logged in a detached goroutine — poll briefly for the access-log row.
+	var n int64
+	for i := 0; i < 200; i++ {
+		require.NoError(t, db.Model(&models.SecretAccessLog{}).Where("accessed_by = ?", "owner").Count(&n).Error)
+		if n > 0 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	assert.Positive(t, n, "a resolved render reference must produce a secret access-log row")
 }

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/x509"
 	"fmt"
+	"log"
 	"regexp"
 	"sync"
 	"time"
@@ -213,7 +214,14 @@ func (c *KeyorixCore) AuditLicenseState(ctx context.Context) {
 // emitAudit persists an audit event and forwards it to the configured sink.
 // All core audit writers funnel through here so SIEM forwarding is uniform.
 func (c *KeyorixCore) emitAudit(ctx context.Context, event *models.AuditEvent) {
-	_ = c.storage.LogAuditEvent(ctx, event)
+	if err := c.storage.LogAuditEvent(ctx, event); err != nil {
+		// A failed chain-write is an audit gap that VerifyAuditChain cannot detect — a
+		// never-written event leaves no hole. Surface it loudly instead of swallowing,
+		// and do NOT forward a phantom event (ID 0, no chain position) to the SIEM: the
+		// off-box mirror must reflect the durable chain, not events that never landed.
+		log.Printf("SECURITY: failed to persist audit event %q (success=%v): %v", event.EventType, event.Success, err)
+		return
+	}
 	if c.auditForwarder != nil {
 		c.auditForwarder.Forward(event)
 	}

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -140,6 +140,13 @@ type KeyorixCore struct {
 	// enforced after a DEK rotation.
 	auditCkptKey        []byte
 	auditCkptKeyVersion string
+	// auditMaxCertified is an in-memory monotonic high-water mark of the greatest
+	// chained-events count this process has ever certified or verified. It backstops
+	// the persistent signed high-water (SystemMetadata) against an online attacker who
+	// deletes the high-water row mid-run: the chain can never be observed to regress
+	// below a length we already saw this lifetime. Guarded by auditWatermarkMu.
+	auditMaxCertified int64
+	auditWatermarkMu  sync.Mutex
 	// checkpointNotary, when set, anchors each freshly-written audit checkpoint to
 	// an external authority (RFC 3161 TSA) for a forge-proof proof-of-existence
 	// (ADR-029). nil = no external anchoring. Set at startup via SetCheckpointNotary.

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -49,9 +49,15 @@ type KeyorixCore struct {
 	dynamicSweepEnabled bool
 	// webauthnRP is the WebAuthn relying party (ADR-036); nil = WebAuthn disabled.
 	// Set from config at startup via SetWebAuthn.
-	webauthnRP        *webauthn.WebAuthn
-	now               func() time.Time // For testability
-	passwordPolicy    PasswordPolicy
+	webauthnRP     *webauthn.WebAuthn
+	now            func() time.Time // For testability
+	passwordPolicy PasswordPolicy
+	// bootstrapToken gates POST /system/init (BootstrapSystem). The first-boot admin
+	// claim is otherwise unauthenticated, so a fresh, network-reachable instance could
+	// be seized by whoever calls /system/init first. The server sets this at startup
+	// (from KEYORIX_BOOTSTRAP_TOKEN, or a random value logged for the operator while the
+	// system is uninitialised); init refuses unless the caller presents a matching token.
+	bootstrapToken    string
 	secretValuePolicy SecretValuePolicy  // optional quality gate on secret values (off by default)
 	secretNamePolicy  SecretNamePolicy   // optional naming convention for secrets (off by default)
 	secretNameRe      *regexp.Regexp     // compiled secretNamePolicy.Pattern (nil = no regex check)
@@ -330,6 +336,13 @@ func (c *KeyorixCore) WebAuthnEnabled() bool { return c.webauthnRP != nil }
 // configures a password_policy block.
 func (c *KeyorixCore) SetPasswordPolicy(p PasswordPolicy) {
 	c.passwordPolicy = p
+}
+
+// SetBootstrapToken sets the token that POST /system/init must present to seed the
+// first admin. An empty token disables API bootstrap entirely (fail closed). The
+// server wires this at startup; see BootstrapSystem.
+func (c *KeyorixCore) SetBootstrapToken(token string) {
+	c.bootstrapToken = token
 }
 
 // SetSecretValuePolicy enables/configures the secret-value quality gate (off by

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -140,6 +140,12 @@ type KeyorixCore struct {
 	// enforced after a DEK rotation.
 	auditCkptKey        []byte
 	auditCkptKeyVersion string
+	// tokenCacheInvalidator evicts a bearer token from the HTTP auth cache by its hash.
+	// Wired at startup (SetTokenCacheInvalidator) to the middleware cache; nil in tests/
+	// remote mode (the cache lives in the HTTP server). Lets core paths that revoke a
+	// token (e.g. revoking PATs on a password change) take effect immediately rather than
+	// after the positive-cache TTL. core cannot import the middleware directly (cycle).
+	tokenCacheInvalidator func(hash string)
 	// auditMaxCertified is an in-memory monotonic high-water mark of the greatest
 	// chained-events count this process has ever certified or verified. It backstops
 	// the persistent signed high-water (SystemMetadata) against an online attacker who

--- a/internal/core/session_ttl_test.go
+++ b/internal/core/session_ttl_test.go
@@ -148,6 +148,23 @@ func TestRefreshSession_RefusedPastCeiling(t *testing.T) {
 	store.AssertCalled(t, "DeleteSession", mock.Anything, uint(7))
 }
 
+// An impersonation session must not be refreshable — otherwise /auth/refresh would
+// mint a fresh, full-TTL session for the target with the impersonation attribution
+// stripped (laundering).
+func TestRefreshSession_RefusesImpersonationSession(t *testing.T) {
+	store := new(MockStorage)
+	c := newSessionCore(store, 30*time.Minute, 12*time.Hour)
+
+	admin := uint(9)
+	old := &models.Session{ID: 7, UserID: 1, SessionToken: "imp", ImpersonatedBy: &admin}
+	store.On("GetSession", mock.Anything, "imp").Return(old, nil)
+
+	_, err := c.RefreshSession(context.Background(), "imp")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "impersonation")
+	store.AssertNotCalled(t, "CreateSession", mock.Anything, mock.Anything)
+}
+
 // With no ceiling (legacy behaviour) a session refreshes indefinitely.
 func TestRefreshSession_NoCeilingRefreshesForever(t *testing.T) {
 	store := new(MockStorage)

--- a/internal/core/setup_consume.go
+++ b/internal/core/setup_consume.go
@@ -97,6 +97,13 @@ func (c *KeyorixCore) completePasswordSetup(ctx context.Context, tok *models.Set
 	if AccountLoginBlocked(user.AccountState) {
 		return nil, fmt.Errorf("account suspended")
 	}
+	// Externally-managed identities (SSO/SCIM) must not get a local password: it would
+	// be a backdoor that authenticates at /auth/login and bypasses the IdP entirely.
+	// This is the critical gate — even if a link was somehow issued, consuming it for a
+	// federated account is refused.
+	if user.ExternalID != "" {
+		return nil, fmt.Errorf("%s: this account is managed by an external identity provider; set a password through your IdP", i18n.T("ErrorValidation", nil))
+	}
 
 	// Validate the password BEFORE consuming the token, so a policy rejection lets
 	// the user retry with the same link instead of dead-ending on a spent token.

--- a/internal/core/setup_consume.go
+++ b/internal/core/setup_consume.go
@@ -124,11 +124,12 @@ func (c *KeyorixCore) completePasswordSetup(ctx context.Context, tok *models.Set
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}
-	// Evict every other session for this account, keeping only the one just minted.
-	// A self-service password reset must lock out anyone holding a stolen session
-	// (and a re-provision must drop stale ones) — matching ChangePassword's
-	// invalidate-other-devices invariant, which this path previously skipped.
-	_ = c.storage.DeleteSessionsForUserExcept(ctx, user.ID, session.ID)
+	// Evict every other session for this account, keeping only the one just minted, and
+	// drop those sessions from the auth cache so a stolen session is locked out on its
+	// next request, not after the cache TTL. A self-service password reset must lock out
+	// anyone holding a stolen session (and a re-provision must drop stale ones) — matching
+	// ChangePassword's invalidate-other-devices invariant, which this path previously skipped.
+	_ = c.deleteSessionsForUserAndEvict(ctx, user.ID, session.ID, session.SessionToken)
 
 	c.writeAuditEventFull(ctx, "account.setup_completed", &user.ID, nil, nil, ip,
 		fmt.Sprintf("account setup completed via %s", tok.Purpose))

--- a/internal/core/setup_consume_test.go
+++ b/internal/core/setup_consume_test.go
@@ -101,6 +101,22 @@ func TestCompleteSetup(t *testing.T) {
 		ms.AssertCalled(t, "DeleteSessionsForUserExcept", ctx, uid, uint(1))
 	})
 
+	t.Run("an externally-managed (SSO/SCIM) account is refused a local password", func(t *testing.T) {
+		ms := new(MockStorage)
+		c := NewKeyorixCore(ms)
+		anyAudit(ms)
+		user := &models.User{ID: uid, Username: "dana", AccountState: AccountActive, ExternalID: "okta|123"}
+		ms.On("GetSetupTokenByHash", ctx, hash).Return(activeAccountSetup(c), nil)
+		ms.On("GetUser", ctx, uid).Return(user, nil)
+
+		_, err := c.CompleteSetup(ctx, raw, strongPw, "ua", "1.2.3.4")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "external identity provider")
+		// The token must NOT be consumed and no session minted.
+		ms.AssertNotCalled(t, "MarkSetupTokenConsumed", mock.Anything, mock.Anything, mock.Anything)
+		ms.AssertNotCalled(t, "CreateSession", mock.Anything, mock.Anything)
+	})
+
 	t.Run("a weak password is rejected WITHOUT consuming the token", func(t *testing.T) {
 		ms := new(MockStorage)
 		c := NewKeyorixCore(ms)

--- a/internal/core/setup_consume_test.go
+++ b/internal/core/setup_consume_test.go
@@ -89,6 +89,7 @@ func TestCompleteSetup(t *testing.T) {
 			Return(&models.Session{ID: 1, UserID: uid, SessionToken: "sess-abc"}, nil)
 		// Completing setup must evict the subject's other sessions (keeping the new
 		// one) so a stolen session can't survive a self-service password reset.
+		ms.On("ListSessionTokenHashesForUser", ctx, uid).Return([]string{}, nil)
 		ms.On("DeleteSessionsForUserExcept", ctx, uid, uint(1)).Return(nil)
 		ms.On("RevokeAllPersonalAccessTokensForUser", mock.Anything, mock.Anything).Return(nil, nil)
 

--- a/internal/core/setup_consume_test.go
+++ b/internal/core/setup_consume_test.go
@@ -90,6 +90,7 @@ func TestCompleteSetup(t *testing.T) {
 		// Completing setup must evict the subject's other sessions (keeping the new
 		// one) so a stolen session can't survive a self-service password reset.
 		ms.On("DeleteSessionsForUserExcept", ctx, uid, uint(1)).Return(nil)
+		ms.On("RevokeAllPersonalAccessTokensForUser", mock.Anything, mock.Anything).Return(nil, nil)
 
 		res, err := c.CompleteSetup(ctx, raw, strongPw, "ua", "1.2.3.4")
 		require.NoError(t, err)

--- a/internal/core/setup_delivery.go
+++ b/internal/core/setup_delivery.go
@@ -11,7 +11,6 @@ package core
 import (
 	"context"
 	"crypto/rand"
-	"encoding/base64"
 	"errors"
 	"fmt"
 	"math/big"
@@ -273,11 +272,12 @@ func (c *KeyorixCore) checkResendThrottle(ctx context.Context, purpose, email st
 // password of a setup-link account. It is never disclosed, so no one can log in
 // until the user sets a real password via the link.
 func randomUnusablePassword() (string, error) {
-	b := make([]byte, 32)
-	if _, err := rand.Read(b); err != nil {
-		return "", fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
-	}
-	return base64.RawURLEncoding.EncodeToString(b), nil
+	// This password is a throwaway placeholder — it is never returned, and the account is
+	// confined to pending_first_login until the real password is set on setup-link consume.
+	// But it still flows through CreateUser's password-policy check, so it must satisfy the
+	// policy (a raw base64 draw can randomly lack a required character class). Reuse the
+	// policy-compliant one-time-password generator (all four classes guaranteed).
+	return generateOneTimePassword()
 }
 
 // One-time-password character classes (ADR-028 Part E). Visually ambiguous characters

--- a/internal/core/sod.go
+++ b/internal/core/sod.go
@@ -22,16 +22,22 @@ const (
 	EventSoDPolicyDeleted = "sod.policy_deleted" // #nosec G101 -- audit event type, not a credential
 )
 
-// SoDViolation is one user who effectively holds both permissions a policy forbids
-// together.
+// SoDViolation is one principal (human user or machine identity) that effectively
+// holds both permissions a policy forbids together.
 type SoDViolation struct {
-	PolicyID    uint   `json:"policy_id"`
-	PolicyName  string `json:"policy_name"`
-	UserID      uint   `json:"user_id"`
-	Username    string `json:"username"`
-	Email       string `json:"email,omitempty"`
-	PermissionA string `json:"permission_a"`
-	PermissionB string `json:"permission_b"`
+	PolicyID   uint   `json:"policy_id"`
+	PolicyName string `json:"policy_name"`
+	// PrincipalType is "user" or "machine". UserID/Username carry the principal's id
+	// and label for either kind (the JSON keys stay user_* for backward compatibility).
+	PrincipalType string `json:"principal_type"`
+	UserID        uint   `json:"user_id"`
+	Username      string `json:"username"`
+	Email         string `json:"email,omitempty"`
+	PermissionA   string `json:"permission_a"`
+	PermissionB   string `json:"permission_b"`
+	// Detail explains a non-obvious basis for the violation, e.g. that the principal
+	// holds both sides only by virtue of an admin permission-bypass role.
+	Detail string `json:"detail,omitempty"`
 }
 
 // CreateSoDPolicy defines a toxic-combination rule. The two permissions must be
@@ -80,9 +86,11 @@ func (c *KeyorixCore) DeleteSoDPolicy(ctx context.Context, actorID, id uint) err
 	return nil
 }
 
-// DetectSoDViolations evaluates every policy against every active user's effective
-// permissions and returns each principal that holds both sides of a policy. Empty
-// when there are no policies. It pages through all users (no silent cap).
+// DetectSoDViolations evaluates every policy against every active principal's
+// effective permissions and returns each that holds both sides of a policy. Empty
+// when there are no policies. It covers BOTH human users (paged, no silent cap) and
+// machine identities — automation principals hold roles and are authorized too, so
+// omitting them would leave the control blind to a whole class of actor.
 func (c *KeyorixCore) DetectSoDViolations(ctx context.Context) ([]SoDViolation, error) {
 	policies, err := c.storage.ListSoDPolicies(ctx)
 	if err != nil {
@@ -103,40 +111,124 @@ func (c *KeyorixCore) DetectSoDViolations(ctx context.Context) ([]SoDViolation, 
 			if !u.IsActive {
 				continue
 			}
-			perms, err := c.storage.GetUserPermissions(ctx, u.ID)
-			if err != nil {
-				continue // best-effort; a user whose permissions can't be read is skipped
-			}
-			// A toxic combination is just as real when one (or both) of the conflicting
-			// permissions reaches the user through GROUP membership — Authorize unions
-			// direct and group-inherited roles, so the SoD scan must too, or a conflict
-			// satisfied via a group grant goes silently undetected (false-negative).
-			groupPerms, err := c.storage.GetUserGroupPermissions(ctx, u.ID)
-			if err != nil {
-				continue // best-effort; skip a user whose group permissions can't be read
-			}
-			held := make(map[string]bool, len(perms)+len(groupPerms))
-			for _, p := range perms {
-				held[p.Name] = true
-			}
-			for _, p := range groupPerms {
-				held[p.Name] = true
-			}
-			for _, pol := range policies {
-				if held[pol.PermissionA] && held[pol.PermissionB] {
-					violations = append(violations, SoDViolation{
-						PolicyID: pol.ID, PolicyName: pol.Name,
-						UserID: u.ID, Username: u.Username, Email: u.Email,
-						PermissionA: pol.PermissionA, PermissionB: pol.PermissionB,
-					})
-				}
-			}
+			violations = append(violations, c.userSoDViolations(ctx, u, policies)...)
 		}
 		if len(users) < pageSize || int64(page*pageSize) >= total {
 			break
 		}
 	}
+
+	violations = append(violations, c.machineSoDViolations(ctx, policies)...)
 	return violations, nil
+}
+
+// userSoDViolations returns the policy violations a single user holds. A user whose
+// role set includes an admin permission-bypass role effectively holds EVERY
+// permission — Authorize short-circuits on it before ever consulting role_permissions
+// — so such a user violates every policy, even though their explicit role_permissions
+// rows may name only one side (or neither). Missing that made the SoD control blind to
+// exactly the most-privileged principals it exists to police. For a non-admin, the
+// held-set unions direct and group-inherited permissions (mirroring Authorize).
+func (c *KeyorixCore) userSoDViolations(ctx context.Context, u *models.User, policies []*models.SoDPolicy) []SoDViolation {
+	if adminRole := c.adminRoleName(ctx, u.ID); adminRole != "" {
+		out := make([]SoDViolation, 0, len(policies))
+		detail := fmt.Sprintf("holds all permissions via admin role %q", adminRole)
+		for _, pol := range policies {
+			out = append(out, SoDViolation{
+				PolicyID: pol.ID, PolicyName: pol.Name,
+				PrincipalType: "user", UserID: u.ID, Username: u.Username, Email: u.Email,
+				PermissionA: pol.PermissionA, PermissionB: pol.PermissionB,
+				Detail: detail,
+			})
+		}
+		return out
+	}
+
+	perms, err := c.storage.GetUserPermissions(ctx, u.ID)
+	if err != nil {
+		return nil // best-effort; a user whose permissions can't be read is skipped
+	}
+	groupPerms, err := c.storage.GetUserGroupPermissions(ctx, u.ID)
+	if err != nil {
+		return nil // best-effort; skip a user whose group permissions can't be read
+	}
+	held := make(map[string]bool, len(perms)+len(groupPerms))
+	for _, p := range perms {
+		held[p.Name] = true
+	}
+	for _, p := range groupPerms {
+		held[p.Name] = true
+	}
+	var out []SoDViolation
+	for _, pol := range policies {
+		if held[pol.PermissionA] && held[pol.PermissionB] {
+			out = append(out, SoDViolation{
+				PolicyID: pol.ID, PolicyName: pol.Name,
+				PrincipalType: "user", UserID: u.ID, Username: u.Username, Email: u.Email,
+				PermissionA: pol.PermissionA, PermissionB: pol.PermissionB,
+			})
+		}
+	}
+	return out
+}
+
+// machineSoDViolations scans active machine identities. Machines resolve permissions
+// from machine_identity_roles and receive NO admin-role bypass (a leaked machine token
+// is bounded to its explicit grants), so the held-set is just the union of its roles'
+// permissions. Best-effort: if machine identities can't be listed (e.g. the table
+// isn't provisioned in this deployment), machine scanning is skipped rather than
+// failing the whole detection.
+func (c *KeyorixCore) machineSoDViolations(ctx context.Context, policies []*models.SoDPolicy) []SoDViolation {
+	machines, err := c.storage.ListAllMachineIdentities(ctx)
+	if err != nil {
+		return nil
+	}
+	var out []SoDViolation
+	for _, m := range machines {
+		if m.State != "active" {
+			continue
+		}
+		roles, err := c.storage.GetMachineRoles(ctx, m.ID)
+		if err != nil || len(roles) == 0 {
+			continue
+		}
+		roleIDs := make([]uint, 0, len(roles))
+		for _, r := range roles {
+			roleIDs = append(roleIDs, r.ID)
+		}
+		for _, pol := range policies {
+			hasA, err := c.storage.RoleSetHasPermission(ctx, roleIDs, pol.PermissionA)
+			if err != nil || !hasA {
+				continue
+			}
+			hasB, err := c.storage.RoleSetHasPermission(ctx, roleIDs, pol.PermissionB)
+			if err != nil || !hasB {
+				continue
+			}
+			out = append(out, SoDViolation{
+				PolicyID: pol.ID, PolicyName: pol.Name,
+				PrincipalType: "machine", UserID: m.ID, Username: m.Name,
+				PermissionA: pol.PermissionA, PermissionB: pol.PermissionB,
+			})
+		}
+	}
+	return out
+}
+
+// adminRoleName returns the name of an admin (permission-bypass) role the user holds
+// in ANY scope, or "" if none. The SoD scan is scope-agnostic (it unions a user's
+// permissions across scopes), so it checks admin membership the same way.
+func (c *KeyorixCore) adminRoleName(ctx context.Context, userID uint) string {
+	roles, err := c.storage.GetUserRoles(ctx, userID)
+	if err != nil {
+		return ""
+	}
+	for _, r := range roles {
+		if isAdminRoleName(r.Name) {
+			return r.Name
+		}
+	}
+	return ""
 }
 
 // actorPtr returns a *uint for an actor id (nil when 0/unauthenticated).

--- a/internal/core/sod_external_test.go
+++ b/internal/core/sod_external_test.go
@@ -76,6 +76,86 @@ func TestDetectSoDViolations_GroupInheritedPermission(t *testing.T) {
 	assert.NotContains(t, users, "dave", "dave holds only secrets.read")
 }
 
+// A user holding an admin permission-bypass role effectively holds BOTH sides of
+// every policy — Authorize short-circuits on the admin role before consulting
+// role_permissions, so the SoD scan must flag the admin even when their explicit
+// role_permissions name only one side (or neither). Before the fix this most-
+// privileged principal was invisible to the control.
+func TestDetectSoDViolations_AdminBypass(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(&models.SoDPolicy{}, &models.AuditEvent{}))
+	ctx := context.Background()
+
+	// erin holds the admin role (role 2) — a permission-bypass role.
+	h.CreateTestUser(t, "erin", 14)
+	h.AssignUserRole(t, 14, 2, nil)
+	// frank is a plain viewer (role 4) — holds neither side, the negative control.
+	h.CreateTestUser(t, "frank", 15)
+	h.AssignUserRole(t, 15, 4, nil)
+
+	// A policy over two permissions the admin role does NOT explicitly enumerate.
+	_, err := h.CoreService.CreateSoDPolicy(ctx, 1, "approve-vs-admin", "", "access_requests.approve", "system.write")
+	require.NoError(t, err)
+
+	violations, err := h.CoreService.DetectSoDViolations(ctx)
+	require.NoError(t, err)
+
+	var erinV *struct {
+		detail   string
+		username string
+	}
+	for _, v := range violations {
+		if v.Username == "erin" {
+			erinV = &struct {
+				detail   string
+				username string
+			}{v.Detail, v.Username}
+			assert.Equal(t, "user", v.PrincipalType)
+		}
+		assert.NotEqual(t, "frank", v.Username, "a plain viewer must not be flagged")
+	}
+	require.NotNil(t, erinV, "the admin must be flagged for the policy via bypass")
+	assert.Contains(t, erinV.detail, "admin role")
+}
+
+// Machine identities hold roles and are authorized too, so a machine that holds both
+// sides of a policy via its roles is a real violation. Before the fix the scan only
+// iterated human users and never examined automation principals.
+func TestDetectSoDViolations_MachinePrincipal(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(&models.SoDPolicy{}, &models.AuditEvent{},
+		&models.MachineIdentity{}, &models.MachineIdentityRole{}))
+	ctx := context.Background()
+
+	// A CI machine that holds editor (role 3 → secrets.write) AND auditor (role 5 →
+	// audit.read), a toxic write+audit combination.
+	require.NoError(t, h.DB.Create(&models.MachineIdentity{ID: 70, Name: "ci-bot", State: "active", ProjectID: 1}).Error)
+	require.NoError(t, h.DB.Create(&models.MachineIdentityRole{MachineIdentityID: 70, RoleID: 3}).Error)
+	require.NoError(t, h.DB.Create(&models.MachineIdentityRole{MachineIdentityID: 70, RoleID: 5}).Error)
+	// A suspended machine with the same grants must be ignored.
+	require.NoError(t, h.DB.Create(&models.MachineIdentity{ID: 71, Name: "old-bot", State: "suspended", ProjectID: 1}).Error)
+	require.NoError(t, h.DB.Create(&models.MachineIdentityRole{MachineIdentityID: 71, RoleID: 3}).Error)
+	require.NoError(t, h.DB.Create(&models.MachineIdentityRole{MachineIdentityID: 71, RoleID: 5}).Error)
+
+	_, err := h.CoreService.CreateSoDPolicy(ctx, 1, "write-vs-audit", "", "secrets.write", "audit.read")
+	require.NoError(t, err)
+
+	violations, err := h.CoreService.DetectSoDViolations(ctx)
+	require.NoError(t, err)
+
+	var found bool
+	for _, v := range violations {
+		if v.PrincipalType == "machine" && v.Username == "ci-bot" {
+			found = true
+			assert.Equal(t, uint(70), v.UserID)
+		}
+		assert.NotEqual(t, "old-bot", v.Username, "a suspended machine must not be flagged")
+	}
+	assert.True(t, found, "the active CI machine holding both sides must be flagged")
+}
+
 // With no policies, there are no violations.
 func TestDetectSoDViolations_NoPolicies(t *testing.T) {
 	h := testhelper.NewRBACTestHelper(t)

--- a/internal/core/sso.go
+++ b/internal/core/sso.go
@@ -446,14 +446,26 @@ func (c *KeyorixCore) reconcileSSOGroups(ctx context.Context, p *SSOProvider, us
 		currentSet[g.ID] = true
 	}
 
-	added, removed := 0, 0
+	added, removed, blocked := 0, 0, 0
 	for id := range desired {
-		if !currentSet[id] {
-			if err := c.storage.AddUserToGroup(ctx, userID, id); err == nil {
-				added++
-			}
+		if currentSet[id] {
+			continue
+		}
+		// Refuse to ESCALATE into an admin-conferring group via an IdP group assertion —
+		// the same guard SCIM applies (scimGroupConfersAdmin; the predicate is not
+		// SCIM-specific). IdP group membership/names are often self-service or governed by
+		// people who are not Keyorix admins, so silently inheriting an admin role from a
+		// name match would be a privilege escalation. scimGroupConfersAdmin fails CLOSED on
+		// a lookup error, so an unverifiable group is treated as admin-bearing and skipped.
+		if c.scimGroupConfersAdmin(ctx, id) {
+			blocked++
+			continue
+		}
+		if err := c.storage.AddUserToGroup(ctx, userID, id); err == nil {
+			added++
 		}
 	}
+	// De-escalating removals are unconditional (dropping a group only reduces privilege).
 	for id := range currentSet {
 		if !desired[id] {
 			if err := c.storage.RemoveUserFromGroup(ctx, userID, id); err == nil {
@@ -461,9 +473,12 @@ func (c *KeyorixCore) reconcileSSOGroups(ctx context.Context, p *SSOProvider, us
 			}
 		}
 	}
-	if added > 0 || removed > 0 {
-		c.writeAuditEvent(ctx, EventSSOGroupsSynced, actorPtr(userID), nil,
-			fmt.Sprintf("SSO group sync via %s: user %d (+%d/-%d native group memberships)", p.Name, userID, added, removed))
+	if added > 0 || removed > 0 || blocked > 0 {
+		msg := fmt.Sprintf("SSO group sync via %s: user %d (+%d/-%d native group memberships)", p.Name, userID, added, removed)
+		if blocked > 0 {
+			msg += fmt.Sprintf("; %d admin-conferring group(s) refused (IdP assertion cannot grant admin)", blocked)
+		}
+		c.writeAuditEvent(ctx, EventSSOGroupsSynced, actorPtr(userID), nil, msg)
 	}
 }
 

--- a/internal/core/sso.go
+++ b/internal/core/sso.go
@@ -161,12 +161,12 @@ func (c *KeyorixCore) CompleteSSO(ctx context.Context, providerName, code, state
 	if rawID == "" {
 		return nil, nil, "", fmt.Errorf("the token response carried no id_token")
 	}
-	sub, email, name, err := c.verifyIDToken(ctx, p, st.Nonce, rawID)
+	sub, email, name, emailVerified, err := c.verifyIDToken(ctx, p, st.Nonce, rawID)
 	if err != nil {
 		return nil, nil, "", err
 	}
 
-	user, err := c.resolveSSOUser(ctx, sub, email)
+	user, err := c.resolveSSOUser(ctx, sub, email, emailVerified)
 	if err != nil {
 		return nil, nil, "", err
 	}
@@ -279,7 +279,9 @@ func (c *KeyorixCore) CompleteSAML(ctx context.Context, name string, r *http.Req
 		return nil, nil, "", fmt.Errorf("the assertion carried no subject or email")
 	}
 
-	user, err := c.resolveSSOUser(ctx, info.Subject, info.Email)
+	// A SAML assertion's attributes (incl. email) are carried inside the IdP-signed,
+	// library-verified assertion, so the email is treated as verified here.
+	user, err := c.resolveSSOUser(ctx, info.Subject, info.Email, true)
 	if err != nil {
 		return nil, nil, "", err
 	}
@@ -320,7 +322,23 @@ func (c *KeyorixCore) CompleteSAML(ctx context.Context, name string, r *http.Req
 // resolveSSOUser maps the IdP identity to a Keyorix user: the SCIM externalId
 // (subject) first, then email. Returns (nil, nil) when neither matches — the caller
 // decides whether to refuse the login or JIT-provision the account.
-func (c *KeyorixCore) resolveSSOUser(ctx context.Context, sub, email string) (*models.User, error) {
+//
+// The email fallback carries two guards that close a cross-provider account-takeover
+// vector when more than one SSO provider is trusted (e.g. a corporate IdP plus a
+// weaker/partner IdP). (1) The email must be EXPLICITLY verified: an IdP that lets a
+// user self-assert an address — or merely omits email_verified — cannot use it to
+// claim an EXISTING account (a brand-new JIT account is still provisionable, since
+// there is nothing to take over). (2) The matched account must not already be bound
+// to a DIFFERENT federated identity; otherwise a second IdP asserting the same email
+// could take over an account owned by the first. A never-federated (native or
+// SCIM-by-email) account is claimed by this subject on first link, so a later
+// provider can't re-link it by asserting the same address.
+//
+// Residual (documented): a malicious provider that can choose its subjects could still
+// forge a sub equal to a victim's externalId and match via the subject branch. Fully
+// closing that requires binding each federated identity to its issuer (as the machine
+// OIDC path does) — a schema change tracked separately.
+func (c *KeyorixCore) resolveSSOUser(ctx context.Context, sub, email string, emailVerified bool) (*models.User, error) {
 	notFound := i18n.T("ErrorUserNotFound", nil)
 	if sub != "" {
 		if u, err := c.storage.GetUserByExternalID(ctx, sub); err == nil {
@@ -329,14 +347,29 @@ func (c *KeyorixCore) resolveSSOUser(ctx context.Context, sub, email string) (*m
 			return nil, err
 		}
 	}
-	if email != "" {
-		if u, err := c.storage.GetUserByEmail(ctx, email); err == nil {
-			return u, nil
-		} else if !strings.Contains(err.Error(), notFound) {
-			return nil, err
+	if email == "" || !emailVerified {
+		return nil, nil
+	}
+	u, err := c.storage.GetUserByEmail(ctx, email)
+	if err != nil {
+		if strings.Contains(err.Error(), notFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if u.ExternalID != "" && u.ExternalID != sub {
+		return nil, fmt.Errorf("this email is already linked to a different SSO identity")
+	}
+	if u.ExternalID == "" && sub != "" {
+		// Claim this never-federated account for the verifying subject so a later
+		// provider can't re-link it by asserting the same email. Best-effort: a failed
+		// update just means we re-link on the next login.
+		u.ExternalID = sub
+		if updated, uerr := c.storage.UpdateUser(ctx, u); uerr == nil {
+			u = updated
 		}
 	}
-	return nil, nil
+	return u, nil
 }
 
 // provisionSSOUser JIT-creates a Keyorix account for a verified SSO identity that
@@ -618,13 +651,13 @@ func (b *ssoBool) UnmarshalJSON(data []byte) error {
 
 // verifyIDToken validates the id_token's signature (asymmetric only), issuer,
 // audience (= the provider's client_id), expiry, and the nonce, returning the
-// subject, email, and (best-effort) name claims. The email is returned only when the
-// IdP has not explicitly marked it unverified (email_verified: false) — so an IdP
-// that lets a user self-assert an arbitrary, unverified address cannot use it to
-// match an existing account or seed a JIT-provisioned one. An absent email_verified
-// claim is treated as trusted: it is OPTIONAL in OIDC and common enterprise IdPs
-// (e.g. Entra ID) omit it for a configured, trusted issuer.
-func (c *KeyorixCore) verifyIDToken(ctx context.Context, p *SSOProvider, expectedNonce, raw string) (sub, email, name string, err error) {
+// subject, email, (best-effort) name, and whether the email was EXPLICITLY verified.
+// The email is dropped only when the IdP explicitly marks it unverified
+// (email_verified: false). An absent email_verified claim is treated as trusted for
+// JIT-provisioning — it is OPTIONAL in OIDC and common enterprise IdPs (e.g. Entra ID)
+// omit it — but emailVerified is reported true only when the claim is present and true,
+// so resolveSSOUser can refuse to MATCH AN EXISTING account on a merely-asserted email.
+func (c *KeyorixCore) verifyIDToken(ctx context.Context, p *SSOProvider, expectedNonce, raw string) (sub, email, name string, emailVerified bool, err error) {
 	var claims struct {
 		jwt.RegisteredClaims
 		Email         string   `json:"email"`
@@ -647,10 +680,10 @@ func (c *KeyorixCore) verifyIDToken(ctx context.Context, p *SSOProvider, expecte
 	}
 	token, err := parser.ParseWithClaims(raw, &claims, keyfn)
 	if err != nil {
-		return "", "", "", fmt.Errorf("id_token verification failed: %w", err)
+		return "", "", "", false, fmt.Errorf("id_token verification failed: %w", err)
 	}
 	if !token.Valid || claims.Issuer != p.Issuer {
-		return "", "", "", fmt.Errorf("id_token invalid")
+		return "", "", "", false, fmt.Errorf("id_token invalid")
 	}
 	audOK := false
 	for _, a := range claims.Audience {
@@ -660,13 +693,13 @@ func (c *KeyorixCore) verifyIDToken(ctx context.Context, p *SSOProvider, expecte
 		}
 	}
 	if !audOK {
-		return "", "", "", fmt.Errorf("id_token audience does not match the client id")
+		return "", "", "", false, fmt.Errorf("id_token audience does not match the client id")
 	}
 	if expectedNonce == "" || claims.Nonce != expectedNonce {
-		return "", "", "", fmt.Errorf("id_token nonce mismatch")
+		return "", "", "", false, fmt.Errorf("id_token nonce mismatch")
 	}
 	if strings.TrimSpace(claims.Subject) == "" {
-		return "", "", "", fmt.Errorf("id_token has no subject")
+		return "", "", "", false, fmt.Errorf("id_token has no subject")
 	}
 	email = claims.Email
 	if email != "" && claims.EmailVerified != nil && !bool(*claims.EmailVerified) {
@@ -675,7 +708,8 @@ func (c *KeyorixCore) verifyIDToken(ctx context.Context, p *SSOProvider, expecte
 		// fallback / JIT-provisioning lose this untrusted address.
 		email = ""
 	}
-	return claims.Subject, email, claims.Name, nil
+	emailVerified = claims.EmailVerified != nil && bool(*claims.EmailVerified)
+	return claims.Subject, email, claims.Name, emailVerified, nil
 }
 
 func randToken() (string, error) {

--- a/internal/core/sso_test.go
+++ b/internal/core/sso_test.go
@@ -14,9 +14,12 @@ import (
 
 	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
 )
 
 func ssoTestCore(t *testing.T) (*KeyorixCore, *MockStorage, *rsa.PrivateKey, *SSOProvider) {
@@ -322,6 +325,41 @@ func TestSyncSSOGroups(t *testing.T) {
 		store.AssertNotCalled(t, "ListGroups", mock.Anything)
 		store.AssertNotCalled(t, "RemoveUserFromGroup", mock.Anything, mock.Anything, mock.Anything)
 	})
+
+}
+
+// An IdP group assertion must NOT add the user to an admin-conferring native group (the
+// SCIM admin-group guard applied to the SSO path), while a non-admin group still syncs.
+// Uses real storage so the GetGroupRoles → roleSetContainsAdmin predicate is exercised.
+func TestReconcileSSOGroups_RefusesAdminGroupEscalation(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.User{}, &models.Group{}, &models.UserGroup{},
+		&models.GroupRole{}, &models.Role{}, &models.AuditEvent{}))
+	ls := store.NewLocalStorage(db)
+	c := NewKeyorixCore(ls)
+	ctx := context.Background()
+
+	require.NoError(t, db.Create(&models.User{ID: 7, Username: "alice"}).Error)
+	require.NoError(t, db.Create(&models.Role{ID: 2, Name: "admin"}).Error)  // an admin-bypass role
+	require.NoError(t, db.Create(&models.Role{ID: 9, Name: "viewer"}).Error) // non-admin
+	require.NoError(t, db.Create(&models.Group{ID: 1, Name: "keyorix-admins"}).Error)
+	require.NoError(t, db.Create(&models.Group{ID: 2, Name: "engineers"}).Error)
+	require.NoError(t, db.Create(&models.GroupRole{GroupID: 1, RoleID: 2}).Error) // group 1 confers admin
+	require.NoError(t, db.Create(&models.GroupRole{GroupID: 2, RoleID: 9}).Error) // group 2 is benign
+
+	// The IdP asserts BOTH group names.
+	c.reconcileSSOGroups(ctx, &SSOProvider{Name: "okta"}, 7, []string{"keyorix-admins", "engineers"})
+
+	groups, err := ls.GetUserGroups(ctx, 7)
+	require.NoError(t, err)
+	ids := map[uint]bool{}
+	for _, g := range groups {
+		ids[g.ID] = true
+	}
+	assert.False(t, ids[1], "must NOT be added to the admin-conferring group via an IdP assertion")
+	assert.True(t, ids[2], "the benign group still syncs")
 }
 
 func TestSyncSSORoles(t *testing.T) {

--- a/internal/core/sso_test.go
+++ b/internal/core/sso_test.go
@@ -58,7 +58,7 @@ func TestVerifyIDToken(t *testing.T) {
 
 	b := base()
 	b["name"] = "Ada Lovelace"
-	sub, email, name, err := c.verifyIDToken(ctx, p, "N1", signToken(t, key, "kid-1", b))
+	sub, email, name, _, err := c.verifyIDToken(ctx, p, "N1", signToken(t, key, "kid-1", b))
 	require.NoError(t, err)
 	assert.Equal(t, "okta|123", sub)
 	assert.Equal(t, "ada@x.io", email)
@@ -67,23 +67,23 @@ func TestVerifyIDToken(t *testing.T) {
 	// Wrong audience → rejected.
 	bad := base()
 	bad["aud"] = "someone-else"
-	_, _, _, err = c.verifyIDToken(ctx, p, "N1", signToken(t, key, "kid-1", bad))
+	_, _, _, _, err = c.verifyIDToken(ctx, p, "N1", signToken(t, key, "kid-1", bad))
 	require.Error(t, err)
 
 	// Nonce mismatch → rejected (replay / mix-up protection).
-	_, _, _, err = c.verifyIDToken(ctx, p, "WRONG", signToken(t, key, "kid-1", base()))
+	_, _, _, _, err = c.verifyIDToken(ctx, p, "WRONG", signToken(t, key, "kid-1", base()))
 	require.Error(t, err)
 
 	// Expired → rejected.
 	exp := base()
 	exp["exp"] = time.Now().Add(-time.Hour).Unix()
-	_, _, _, err = c.verifyIDToken(ctx, p, "N1", signToken(t, key, "kid-1", exp))
+	_, _, _, _, err = c.verifyIDToken(ctx, p, "N1", signToken(t, key, "kid-1", exp))
 	require.Error(t, err)
 
 	// Wrong issuer → rejected (keyfn refuses it).
 	iss := base()
 	iss["iss"] = "https://evil.test"
-	_, _, _, err = c.verifyIDToken(ctx, p, "N1", signToken(t, key, "kid-1", iss))
+	_, _, _, _, err = c.verifyIDToken(ctx, p, "N1", signToken(t, key, "kid-1", iss))
 	require.Error(t, err)
 }
 
@@ -98,14 +98,14 @@ func TestVerifyIDToken_EmailVerified(t *testing.T) {
 	}
 
 	// email_verified absent → email is trusted (OIDC-optional; Entra omits it).
-	_, email, _, err := c.verifyIDToken(ctx, p, "N1", signToken(t, key, "kid-1", base()))
+	_, email, _, _, err := c.verifyIDToken(ctx, p, "N1", signToken(t, key, "kid-1", base()))
 	require.NoError(t, err)
 	assert.Equal(t, "ada@x.io", email)
 
 	// email_verified: true → email trusted.
 	ok := base()
 	ok["email_verified"] = true
-	_, email, _, err = c.verifyIDToken(ctx, p, "N1", signToken(t, key, "kid-1", ok))
+	_, email, _, _, err = c.verifyIDToken(ctx, p, "N1", signToken(t, key, "kid-1", ok))
 	require.NoError(t, err)
 	assert.Equal(t, "ada@x.io", email)
 
@@ -113,7 +113,7 @@ func TestVerifyIDToken_EmailVerified(t *testing.T) {
 	// and the subject is unaffected.
 	no := base()
 	no["email_verified"] = false
-	sub, email, _, err := c.verifyIDToken(ctx, p, "N1", signToken(t, key, "kid-1", no))
+	sub, email, _, _, err := c.verifyIDToken(ctx, p, "N1", signToken(t, key, "kid-1", no))
 	require.NoError(t, err)
 	assert.Equal(t, "okta|123", sub)
 	assert.Empty(t, email)
@@ -121,14 +121,14 @@ func TestVerifyIDToken_EmailVerified(t *testing.T) {
 	// email_verified sent as the string "false" → also dropped (no parse failure).
 	noStr := base()
 	noStr["email_verified"] = "false"
-	_, email, _, err = c.verifyIDToken(ctx, p, "N1", signToken(t, key, "kid-1", noStr))
+	_, email, _, _, err = c.verifyIDToken(ctx, p, "N1", signToken(t, key, "kid-1", noStr))
 	require.NoError(t, err)
 	assert.Empty(t, email)
 
 	// email_verified sent as the string "true" → trusted.
 	okStr := base()
 	okStr["email_verified"] = "true"
-	_, email, _, err = c.verifyIDToken(ctx, p, "N1", signToken(t, key, "kid-1", okStr))
+	_, email, _, _, err = c.verifyIDToken(ctx, p, "N1", signToken(t, key, "kid-1", okStr))
 	require.NoError(t, err)
 	assert.Equal(t, "ada@x.io", email)
 }
@@ -139,26 +139,53 @@ func TestResolveSSOUser(t *testing.T) {
 	t.Run("externalId match wins", func(t *testing.T) {
 		c, store, _, _ := ssoTestCore(t)
 		store.On("GetUserByExternalID", mock.Anything, "okta|123").Return(&models.User{ID: 7}, nil)
-		u, err := c.resolveSSOUser(context.Background(), "okta|123", "ada@x.io")
+		u, err := c.resolveSSOUser(context.Background(), "okta|123", "ada@x.io", true)
 		require.NoError(t, err)
 		assert.Equal(t, uint(7), u.ID)
 		store.AssertNotCalled(t, "GetUserByEmail", mock.Anything, mock.Anything)
 	})
 
-	t.Run("falls back to email", func(t *testing.T) {
+	t.Run("verified email links a never-federated account and claims it", func(t *testing.T) {
 		c, store, _, _ := ssoTestCore(t)
 		store.On("GetUserByExternalID", mock.Anything, "okta|123").Return((*models.User)(nil), notFound())
-		store.On("GetUserByEmail", mock.Anything, "ada@x.io").Return(&models.User{ID: 9}, nil)
-		u, err := c.resolveSSOUser(context.Background(), "okta|123", "ada@x.io")
+		store.On("GetUserByEmail", mock.Anything, "ada@x.io").Return(&models.User{ID: 9, ExternalID: ""}, nil)
+		// First link claims the account for this subject (so a later provider can't re-link it).
+		store.On("UpdateUser", mock.Anything, mock.MatchedBy(func(u *models.User) bool {
+			return u.ID == 9 && u.ExternalID == "okta|123"
+		})).Return(&models.User{ID: 9, ExternalID: "okta|123"}, nil)
+		u, err := c.resolveSSOUser(context.Background(), "okta|123", "ada@x.io", true)
 		require.NoError(t, err)
 		assert.Equal(t, uint(9), u.ID)
+		store.AssertCalled(t, "UpdateUser", mock.Anything, mock.Anything)
+	})
+
+	t.Run("unverified email does NOT match an existing account (no takeover)", func(t *testing.T) {
+		c, store, _, _ := ssoTestCore(t)
+		store.On("GetUserByExternalID", mock.Anything, "okta|123").Return((*models.User)(nil), notFound())
+		// emailVerified=false: the email fallback is skipped entirely — an IdP that merely
+		// asserts (or omits email_verified for) an address can't claim an existing account.
+		u, err := c.resolveSSOUser(context.Background(), "okta|123", "ada@x.io", false)
+		require.NoError(t, err)
+		assert.Nil(t, u)
+		store.AssertNotCalled(t, "GetUserByEmail", mock.Anything, mock.Anything)
+	})
+
+	t.Run("email match to an account bound to a DIFFERENT identity is refused", func(t *testing.T) {
+		c, store, _, _ := ssoTestCore(t)
+		store.On("GetUserByExternalID", mock.Anything, "partner|999").Return((*models.User)(nil), notFound())
+		// The corp account is already federated to a different subject — a second provider
+		// asserting the same email must not take it over.
+		store.On("GetUserByEmail", mock.Anything, "ada@x.io").Return(&models.User{ID: 9, ExternalID: "okta|123"}, nil)
+		_, err := c.resolveSSOUser(context.Background(), "partner|999", "ada@x.io", true)
+		require.ErrorContains(t, err, "already linked to a different SSO identity")
+		store.AssertNotCalled(t, "UpdateUser", mock.Anything, mock.Anything)
 	})
 
 	t.Run("no match returns nil (caller decides)", func(t *testing.T) {
 		c, store, _, _ := ssoTestCore(t)
 		store.On("GetUserByExternalID", mock.Anything, "okta|123").Return((*models.User)(nil), notFound())
 		store.On("GetUserByEmail", mock.Anything, "ada@x.io").Return((*models.User)(nil), notFound())
-		u, err := c.resolveSSOUser(context.Background(), "okta|123", "ada@x.io")
+		u, err := c.resolveSSOUser(context.Background(), "okta|123", "ada@x.io", true)
 		require.NoError(t, err)
 		assert.Nil(t, u)
 	})

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -438,6 +438,11 @@ type Storage interface {
 	// AuditEntryHashByID returns the entry_hash of the audit row with the given
 	// id; found is false when no such row exists (e.g. it was truncated away).
 	AuditEntryHashByID(ctx context.Context, id uint) (hash string, found bool, err error)
+	// GetSystemMetadata returns the value stored for key; found is false when the key
+	// has never been set. A small singleton key/value store for server-managed state.
+	GetSystemMetadata(ctx context.Context, key string) (value string, found bool, err error)
+	// SetSystemMetadata upserts a system-metadata key/value (last write wins).
+	SetSystemMetadata(ctx context.Context, key, value string) error
 	GetDistinctActiveUserIDs(ctx context.Context, since time.Time) ([]uint, error)
 	// CountImpersonatedActions returns the number of impersonated audit events
 	// recorded for actingAs by impersonator since `since`, excluding the

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -646,6 +646,10 @@ type UserFilter struct {
 	IncludeDeleted bool // when true, also return soft-deleted users
 	Page           int
 	PageSize       int
+	// Offset, when > 0, sets the row offset directly (overriding the Page-derived
+	// offset). Used for SCIM startIndex paging, where the window is an arbitrary 1-based
+	// item offset that need not align to a Page boundary.
+	Offset int
 }
 
 // MembershipCounts holds a user's project-membership tallies: Active counts

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -350,6 +350,10 @@ type Storage interface {
 	GetUserRoles(ctx context.Context, userID uint) ([]*models.Role, error)
 	GetUserRoleIDsAt(ctx context.Context, userID uint, scope Scope) ([]uint, error)
 	GetUserRoleIDsExact(ctx context.Context, userID uint, scope Scope) ([]uint, error)
+	// IsProjectMember reports whether the user holds a LIVE role grant scoped to the
+	// project itself (project_id = projectID), directly or via a group — i.e. real
+	// membership. A global/install-wide role (project_id = 0) does NOT count.
+	IsProjectMember(ctx context.Context, userID, projectID uint) (bool, error)
 	GetUserGroupRoleIDsAt(ctx context.Context, userID uint, scope Scope) ([]uint, error)
 	RoleSetHasPermission(ctx context.Context, roleIDs []uint, permission string) (bool, error)
 	CheckPermission(ctx context.Context, userID uint, resource, action string) (bool, error)

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -490,6 +490,9 @@ type Storage interface {
 	CreateDynamicSecretLease(ctx context.Context, l *models.DynamicSecretLease) (*models.DynamicSecretLease, error)
 	GetDynamicSecretLease(ctx context.Context, leaseID string) (*models.DynamicSecretLease, error)
 	ListDynamicSecretLeases(ctx context.Context, configID uint) ([]*models.DynamicSecretLease, error)
+	// CountActiveLeases returns how many leases from configID are currently active —
+	// used to enforce the config's MaxActiveLeases ceiling.
+	CountActiveLeases(ctx context.Context, configID uint) (int64, error)
 	UpdateDynamicSecretLease(ctx context.Context, l *models.DynamicSecretLease) error
 	ListExpiredActiveLeases(ctx context.Context, before time.Time) ([]*models.DynamicSecretLease, error)
 

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -463,6 +463,10 @@ type Storage interface {
 	UpsertMFASecret(ctx context.Context, s *models.MFASecret) error
 	GetMFASecret(ctx context.Context, userID uint) (*models.MFASecret, error)
 	ActivateMFASecret(ctx context.Context, userID uint) error
+	// MarkTOTPStepUsed atomically records that the given TOTP time-step was accepted for
+	// userID, returning true only if it was newly consumed (step strictly greater than
+	// the stored last-used step). A false return means the code is a replay.
+	MarkTOTPStepUsed(ctx context.Context, userID uint, step int64) (bool, error)
 	DeleteMFAForUser(ctx context.Context, userID uint) error // clears secret + recovery codes
 	SetUserMFAEnabled(ctx context.Context, userID uint, enabled bool) error
 	CreateMFARecoveryCodes(ctx context.Context, userID uint, codeHashes []string) error

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -450,6 +450,9 @@ type Storage interface {
 	GetSession(ctx context.Context, token string) (*models.Session, error)
 	GetSessionByID(ctx context.Context, id uint) (*models.Session, error)
 	ListSessionsByUser(ctx context.Context, userID uint) ([]*models.Session, error)
+	// EnforceSessionLimit deletes a user's oldest sessions beyond the `keep` most-recent
+	// (by created_at), bounding concurrent sessions per user. No-op when under the cap.
+	EnforceSessionLimit(ctx context.Context, userID uint, keep int) error
 	DeleteSession(ctx context.Context, id uint) error
 	// DeleteSessionsForUserExcept removes every session owned by userID except the
 	// one with id exceptID. Used to drop other sessions on a password change.

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -131,6 +131,9 @@ type Storage interface {
 	GetMachineIdentity(ctx context.Context, id uint) (*models.MachineIdentity, error)
 	UpdateMachineIdentity(ctx context.Context, m *models.MachineIdentity) error
 	ListMachineIdentities(ctx context.Context, projectID uint) ([]*models.MachineIdentity, error)
+	// ListAllMachineIdentities returns every machine identity across all projects —
+	// for install-wide sweeps such as SoD conflict detection over non-human principals.
+	ListAllMachineIdentities(ctx context.Context) ([]*models.MachineIdentity, error)
 	// CountMachineIdentitiesByClassification returns install-wide counts keyed by
 	// classification label ("" = unclassified) for the compliance posture.
 	CountMachineIdentitiesByClassification(ctx context.Context) (map[string]int, error)

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -462,6 +462,10 @@ type Storage interface {
 	// DeleteSessionsForUserExcept removes every session owned by userID except the
 	// one with id exceptID. Used to drop other sessions on a password change.
 	DeleteSessionsForUserExcept(ctx context.Context, userID, exceptID uint) error
+	// ListSessionTokenHashesForUser returns the stored session_token values (SHA-256
+	// hashes — equal to the auth-cache key) for every session owned by or impersonating
+	// userID, so a state change can evict them from the auth cache immediately.
+	ListSessionTokenHashesForUser(ctx context.Context, userID uint) ([]string, error)
 	// TouchSession bumps last_seen_at only when it is older than the given staleness
 	// window (no-op otherwise) so the auth hot path is not turned into a write per request.
 	TouchSession(ctx context.Context, id uint, seenAt time.Time, staleness time.Duration) error

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -532,6 +532,10 @@ type Storage interface {
 	GetPersonalAccessTokenByID(ctx context.Context, id uint) (*models.PersonalAccessToken, error)
 	GetPersonalAccessTokenByHash(ctx context.Context, hash string) (*models.PersonalAccessToken, error)
 	RevokePersonalAccessToken(ctx context.Context, id uint) error
+	// RevokeAllPersonalAccessTokensForUser revokes every active PAT for a user and returns
+	// their token hashes (for immediate auth-cache eviction). Used on a password change/
+	// reset so PATs die with the password.
+	RevokeAllPersonalAccessTokensForUser(ctx context.Context, userID uint) ([]string, error)
 	TouchPersonalAccessToken(ctx context.Context, id uint, usedAt time.Time, staleness time.Duration) error
 
 	// Setup Token Management (ADR-028) — single-use, hashed-at-rest credential-delivery tokens.

--- a/internal/core/users.go
+++ b/internal/core/users.go
@@ -34,6 +34,16 @@ func (c *KeyorixCore) buildUserForCreate(ctx context.Context, req *CreateUserReq
 		displayName = req.Username
 	}
 
+	// Enforce the configured password policy on the admin-supplied password — the same
+	// policy BootstrapSystem and ChangePassword apply. Without this, the admin "classic"
+	// create path (the one path where a human picks the credential) silently accepted a
+	// weak password, which is then exposed to online guessing. The policy's user context
+	// also catches username/email-in-password. ADR-025.
+	policyUser := &models.User{Username: req.Username, Email: req.Email, DisplayName: displayName}
+	if err := c.passwordPolicy.Validate(req.Password, policyUser); err != nil {
+		return nil, "", fmt.Errorf("%s: %w", i18n.T("ErrorValidation", nil), err)
+	}
+
 	hash, err := bcrypt.GenerateFromPassword([]byte(req.Password), bcrypt.DefaultCost)
 	if err != nil {
 		return nil, "", fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)

--- a/internal/core/users_password_policy_test.go
+++ b/internal/core/users_password_policy_test.go
@@ -1,0 +1,42 @@
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// CreateUser must enforce the configured password policy on the admin-supplied
+// password — the one path where a human picks the credential. Before the fix this
+// path accepted any non-empty password, so an admin could seed a weak account.
+func TestCreateUser_EnforcesPasswordPolicy(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	ctx := context.Background()
+
+	t.Run("a weak password is rejected before any storage write", func(t *testing.T) {
+		ms := new(MockStorage)
+		c := NewKeyorixCore(ms)
+		_, err := c.CreateUser(ctx, &CreateUserRequest{
+			Username: "svc", Email: "svc@example.com", Password: "weak",
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "password must")
+		ms.AssertNotCalled(t, "CreateUser", mock.Anything, mock.Anything)
+	})
+
+	t.Run("a password containing the username is rejected", func(t *testing.T) {
+		ms := new(MockStorage)
+		c := NewKeyorixCore(ms)
+		// 16+ chars with all classes, but embeds the username.
+		_, err := c.CreateUser(ctx, &CreateUserRequest{
+			Username: "alice", Email: "alice@example.com", Password: "Alice#Passw0rd99!",
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "password must")
+		ms.AssertNotCalled(t, "CreateUser", mock.Anything, mock.Anything)
+	})
+}

--- a/internal/core/versions.go
+++ b/internal/core/versions.go
@@ -149,10 +149,10 @@ func (c *KeyorixCore) GetSecretValueByVersion(ctx context.Context, secretID uint
 	if err != nil {
 		return nil, err
 	}
-	if c.encryption != nil {
-		return c.encryption.RetrieveSecret(version.ID)
-	}
-	return version.EncryptedValue, nil
+	// Route through the shared enforcement path so a by-version read is subject to the
+	// same atomic max-reads cap as the latest-version read — defense-in-depth against a
+	// future caller that uses the by-version path to bypass the read ceiling.
+	return c.readVersionValue(ctx, secret, version)
 }
 
 // EventSecretRolledBack is audited when a secret is restored to a prior version.

--- a/internal/core/webauthn.go
+++ b/internal/core/webauthn.go
@@ -266,11 +266,21 @@ func (c *KeyorixCore) FinishWebAuthnLogin(ctx context.Context, challenge, sessio
 	if !wu.user.IsActive || AccountLoginBlocked(wu.user.AccountState) {
 		return nil, nil, fmt.Errorf("account is not active")
 	}
+	// Per-account lockout also gates the WebAuthn second factor (parity with the TOTP
+	// path in VerifyMFALogin): the per-IP limiter is spoofable behind a proxy and fails
+	// open, so bind assertion failures to the account. ch.UserID comes from the
+	// password-gated challenge (not an attacker-chosen handle), so this cannot be abused
+	// to lock out an arbitrary victim.
+	if c.loginLocked(wu.user) {
+		return nil, nil, fmt.Errorf("account temporarily locked due to repeated failed logins; try again later")
+	}
 	cred, err := c.webauthnRP.ValidateLogin(wu, sd, parsed)
 	if err != nil {
 		c.auditWebAuthnFailed(ctx, ch.UserID, "login")
+		c.recordFailedLogin(ctx, wu.user) // count the failed second factor toward the lockout
 		return nil, nil, fmt.Errorf("assertion verification failed: %w", err)
 	}
+	c.clearLoginFailures(ctx, wu.user)
 	c.persistUpdatedCredential(ctx, ch.UserID, cred)
 
 	session, err := c.mintSession(ctx, ch.UserID, userAgent, ip)
@@ -358,6 +368,16 @@ func (c *KeyorixCore) FinishWebAuthnPasswordlessLogin(ctx context.Context, sessi
 	if !resolved.IsActive || AccountLoginBlocked(resolved.AccountState) {
 		return nil, nil, fmt.Errorf("account is not active")
 	}
+	// Honor an active per-account lockout even for a valid passkey (defense in depth —
+	// e.g. the account was locked via the password path). We deliberately do NOT feed
+	// failures into the lockout here: a discoverable login resolves the user from an
+	// attacker-chosen user handle, so counting failed assertions would let an attacker
+	// lock out an arbitrary victim. The unforgeable assertion signature is the real
+	// throttle, backed by the per-IP limiter.
+	if c.loginLocked(resolved) {
+		return nil, nil, fmt.Errorf("account temporarily locked due to repeated failed logins; try again later")
+	}
+	c.clearLoginFailures(ctx, resolved)
 	c.persistUpdatedCredential(ctx, resolved.ID, cred)
 
 	session, err := c.mintSession(ctx, resolved.ID, userAgent, ip)

--- a/internal/core/webauthn.go
+++ b/internal/core/webauthn.go
@@ -350,10 +350,13 @@ func (c *KeyorixCore) FinishWebAuthnPasswordlessLogin(ctx context.Context, sessi
 		c.writeAuditEventFull(ctx, "webauthn.failed", nil, nil, nil, ip, "failed passwordless WebAuthn login")
 		return nil, nil, fmt.Errorf("assertion verification failed: %w", err)
 	}
-	// A passwordless login is still a login: a suspended/blocked account is refused
-	// (the password path's AccountLoginBlocked gate has no equivalent here).
-	if AccountLoginBlocked(resolved.AccountState) {
-		return nil, nil, fmt.Errorf("account suspended")
+	// A passwordless login is still a login: a deactivated or suspended/blocked account
+	// is refused. IsActive is an independent gate from AccountState — an admin
+	// deactivation (is_active=false) leaves AccountState="active", so checking only
+	// AccountLoginBlocked would let a disabled account in. Mirrors the 2FA and password
+	// gates.
+	if !resolved.IsActive || AccountLoginBlocked(resolved.AccountState) {
+		return nil, nil, fmt.Errorf("account is not active")
 	}
 	c.persistUpdatedCredential(ctx, resolved.ID, cred)
 

--- a/internal/core/webauthn.go
+++ b/internal/core/webauthn.go
@@ -168,7 +168,9 @@ func (c *KeyorixCore) FinishWebAuthnRegistration(ctx context.Context, userID uin
 		return nil, err
 	}
 	if firstEnrol {
-		_ = c.storage.DeleteSessionsForUserExcept(ctx, userID, 0)
+		// Purge pre-enrolment sessions AND evict them from the auth cache, so a session
+		// minted before the security upgrade cannot outlive it even for the cache TTL.
+		_ = c.deleteSessionsForUserAndEvict(ctx, userID, 0, "")
 	}
 	uid := userID
 	c.writeAuditEventFull(ctx, "webauthn.registered", &uid, nil, nil, "",

--- a/internal/core/webauthn_test.go
+++ b/internal/core/webauthn_test.go
@@ -206,6 +206,29 @@ func TestWebAuthn_FinishLoginRejectsSuspendedAccount(t *testing.T) {
 	assert.Contains(t, err.Error(), "not active")
 }
 
+// A per-account lockout (e.g. from password brute force) also bars the WebAuthn second
+// factor: the gate fires before the assertion is validated, so a locked account is
+// refused even with an otherwise-valid ceremony. Parity with the TOTP path.
+func TestWebAuthn_FinishLoginHonorsAccountLockout(t *testing.T) {
+	c, db := newWebAuthnTestCore(t, true)
+	c.loginLockout = LoginLockoutPolicy{Enabled: true, MaxAttempts: 3, Window: time.Hour, BaseCooldown: 15 * time.Minute, MaxCooldown: time.Hour}
+	ctx := context.Background()
+	seedCredential(t, c, db, 1, "cred-1")
+
+	// The account is locked (e.g. via the password path).
+	until := c.now().Add(30 * time.Minute)
+	require.NoError(t, db.Model(&models.User{}).Where("id = ?", 1).Update("login_locked_until", until).Error)
+
+	ch, err := c.CreateMFAChallenge(ctx, 1)
+	require.NoError(t, err)
+	token, err := c.storeWebAuthnSession(ctx, 1, "login", &webauthn.SessionData{Challenge: "x"})
+	require.NoError(t, err)
+
+	_, _, err = c.FinishWebAuthnLogin(ctx, ch, token, "ua", "1.2.3.4", nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "locked")
+}
+
 func TestWebAuthn_FinishLoginRejectsMismatchedSession(t *testing.T) {
 	c, db := newWebAuthnTestCore(t, true)
 	ctx := context.Background()

--- a/internal/crypto/awskms/awskms.go
+++ b/internal/crypto/awskms/awskms.go
@@ -13,15 +13,24 @@ import (
 	keyorixcrypto "github.com/keyorixhq/keyorix/internal/crypto"
 )
 
+// awsKMSAPI is the slice of the KMS client the provider uses — an interface seam so
+// the SDK stays contained here and the encryption-context fallback is unit-testable.
+type awsKMSAPI interface {
+	Encrypt(ctx context.Context, in *kms.EncryptInput, optFns ...func(*kms.Options)) (*kms.EncryptOutput, error)
+	Decrypt(ctx context.Context, in *kms.DecryptInput, optFns ...func(*kms.Options)) (*kms.DecryptOutput, error)
+}
+
 type client struct {
-	kms   *kms.Client
-	keyID string
+	kms    awsKMSAPI
+	keyID  string
+	encCtx map[string]string // AWS EncryptionContext bound to the wrapped KEK (may be empty)
 }
 
 // New builds an AWS-KMS-backed crypto.KMSClient for the given key (ID, ARN, or
 // alias). It loads the default AWS config; the caller's environment supplies the
-// region and credentials.
-func New(ctx context.Context, keyID string) (keyorixcrypto.KMSClient, error) {
+// region and credentials. encContext, when non-empty, is bound to the wrapped KEK so
+// a different install sharing the same CMK cannot unwrap it.
+func New(ctx context.Context, keyID string, encContext map[string]string) (keyorixcrypto.KMSClient, error) {
 	if keyID == "" {
 		return nil, fmt.Errorf("aws-kms: kms_key_id is required")
 	}
@@ -29,11 +38,15 @@ func New(ctx context.Context, keyID string) (keyorixcrypto.KMSClient, error) {
 	if err != nil {
 		return nil, fmt.Errorf("aws-kms: load AWS config: %w", err)
 	}
-	return &client{kms: kms.NewFromConfig(cfg), keyID: keyID}, nil
+	return &client{kms: kms.NewFromConfig(cfg), keyID: keyID, encCtx: encContext}, nil
 }
 
 func (c *client) Encrypt(ctx context.Context, plaintext []byte) ([]byte, error) {
-	out, err := c.kms.Encrypt(ctx, &kms.EncryptInput{KeyId: &c.keyID, Plaintext: plaintext})
+	in := &kms.EncryptInput{KeyId: &c.keyID, Plaintext: plaintext}
+	if len(c.encCtx) > 0 {
+		in.EncryptionContext = c.encCtx
+	}
+	out, err := c.kms.Encrypt(ctx, in)
 	if err != nil {
 		return nil, err
 	}
@@ -42,7 +55,19 @@ func (c *client) Encrypt(ctx context.Context, plaintext []byte) ([]byte, error) 
 
 func (c *client) Decrypt(ctx context.Context, ciphertext []byte) ([]byte, error) {
 	// Pin KeyId so the blob is only decryptable by the expected CMK.
-	out, err := c.kms.Decrypt(ctx, &kms.DecryptInput{CiphertextBlob: ciphertext, KeyId: &c.keyID})
+	in := &kms.DecryptInput{CiphertextBlob: ciphertext, KeyId: &c.keyID}
+	if len(c.encCtx) > 0 {
+		in.EncryptionContext = c.encCtx
+	}
+	out, err := c.kms.Decrypt(ctx, in)
+	if err != nil && len(c.encCtx) > 0 {
+		// Legacy blob wrapped before the encryption context was configured: retry once
+		// without it, so enabling the binding on a running install doesn't lock out the
+		// already-wrapped KEK (it rebinds on the next KEK re-wrap). A blob bound to a
+		// DIFFERENT install's context still fails both attempts — the security property
+		// holds.
+		out, err = c.kms.Decrypt(ctx, &kms.DecryptInput{CiphertextBlob: ciphertext, KeyId: &c.keyID})
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/internal/crypto/awskms/awskms_test.go
+++ b/internal/crypto/awskms/awskms_test.go
@@ -1,0 +1,89 @@
+package awskms
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/kms"
+)
+
+// fakeKMS models AWS KMS EncryptionContext semantics: a blob decrypts only with the
+// exact context it was encrypted under. The context is embedded in the blob so the
+// fake is stateless.
+type fakeKMS struct{}
+
+type fakeBlob struct {
+	Plaintext []byte            `json:"p"`
+	Context   map[string]string `json:"c"`
+}
+
+func (fakeKMS) Encrypt(_ context.Context, in *kms.EncryptInput, _ ...func(*kms.Options)) (*kms.EncryptOutput, error) {
+	b, _ := json.Marshal(fakeBlob{Plaintext: in.Plaintext, Context: in.EncryptionContext})
+	return &kms.EncryptOutput{CiphertextBlob: b}, nil
+}
+
+func (fakeKMS) Decrypt(_ context.Context, in *kms.DecryptInput, _ ...func(*kms.Options)) (*kms.DecryptOutput, error) {
+	var b fakeBlob
+	if err := json.Unmarshal(in.CiphertextBlob, &b); err != nil {
+		return nil, err
+	}
+	if !contextEqual(b.Context, in.EncryptionContext) {
+		return nil, errors.New("InvalidCiphertextException: encryption context mismatch")
+	}
+	return &kms.DecryptOutput{Plaintext: b.Plaintext}, nil
+}
+
+func contextEqual(a, b map[string]string) bool {
+	if len(a) == 0 && len(b) == 0 {
+		return true
+	}
+	return reflect.DeepEqual(a, b)
+}
+
+func newTestClient(encCtx map[string]string) *client {
+	return &client{kms: fakeKMS{}, keyID: "test-key", encCtx: encCtx}
+}
+
+func TestAWSKMS_RoundTripWithContext(t *testing.T) {
+	c := newTestClient(map[string]string{"keyorix-install": "inst-1"})
+	ct, err := c.Encrypt(context.Background(), []byte("kek-material"))
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+	pt, err := c.Decrypt(context.Background(), ct)
+	if err != nil {
+		t.Fatalf("decrypt: %v", err)
+	}
+	if string(pt) != "kek-material" {
+		t.Fatalf("round-trip got %q", pt)
+	}
+}
+
+func TestAWSKMS_LegacyBlobDecryptsViaFallback(t *testing.T) {
+	// A KEK wrapped before any context was configured (no EncryptionContext).
+	legacy := newTestClient(nil)
+	ct, _ := legacy.Encrypt(context.Background(), []byte("kek"))
+	// Enabling the binding on a running install must not lock out that legacy blob.
+	bound := newTestClient(map[string]string{"keyorix-install": "inst-1"})
+	pt, err := bound.Decrypt(context.Background(), ct)
+	if err != nil {
+		t.Fatalf("legacy blob must decrypt via the no-context fallback: %v", err)
+	}
+	if string(pt) != "kek" {
+		t.Fatalf("got %q", pt)
+	}
+}
+
+func TestAWSKMS_CrossInstallDenied(t *testing.T) {
+	a := newTestClient(map[string]string{"keyorix-install": "inst-A"})
+	ct, _ := a.Encrypt(context.Background(), []byte("kek-A"))
+	// A different install sharing the CMK must NOT be able to unwrap A's KEK — neither
+	// with its own context nor via the no-context fallback.
+	b := newTestClient(map[string]string{"keyorix-install": "inst-B"})
+	if _, err := b.Decrypt(context.Background(), ct); err == nil {
+		t.Fatal("install B must not unwrap install A's context-bound KEK")
+	}
+}

--- a/internal/crypto/gcpkms/gcpkms.go
+++ b/internal/crypto/gcpkms/gcpkms.go
@@ -9,20 +9,33 @@ package gcpkms
 import (
 	"context"
 	"fmt"
+	"sort"
+	"strings"
 
 	kms "cloud.google.com/go/kms/apiv1"
 	"cloud.google.com/go/kms/apiv1/kmspb"
+	gax "github.com/googleapis/gax-go/v2"
 	keyorixcrypto "github.com/keyorixhq/keyorix/internal/crypto"
 )
 
+// gcpKMSAPI is the slice of the KMS client the provider uses — an interface seam so
+// the SDK stays contained here and the AAD fallback is unit-testable.
+type gcpKMSAPI interface {
+	Encrypt(ctx context.Context, req *kmspb.EncryptRequest, opts ...gax.CallOption) (*kmspb.EncryptResponse, error)
+	Decrypt(ctx context.Context, req *kmspb.DecryptRequest, opts ...gax.CallOption) (*kmspb.DecryptResponse, error)
+}
+
 type client struct {
-	kms     *kms.KeyManagementClient
+	kms     gcpKMSAPI
 	keyName string // projects/P/locations/L/keyRings/R/cryptoKeys/K
+	aad     []byte // AdditionalAuthenticatedData binding the wrapped KEK (nil = none)
 }
 
 // New builds a GCP-KMS-backed crypto.KMSClient for the given crypto-key resource
-// name (projects/.../cryptoKeys/...).
-func New(ctx context.Context, keyName string) (keyorixcrypto.KMSClient, error) {
+// name (projects/.../cryptoKeys/...). encContext, when non-empty, is bound to the
+// wrapped KEK as AdditionalAuthenticatedData so a different install sharing the same
+// key cannot unwrap it.
+func New(ctx context.Context, keyName string, encContext map[string]string) (keyorixcrypto.KMSClient, error) {
 	if keyName == "" {
 		return nil, fmt.Errorf("gcp-kms: kms_key_id (crypto key resource name) is required")
 	}
@@ -30,11 +43,37 @@ func New(ctx context.Context, keyName string) (keyorixcrypto.KMSClient, error) {
 	if err != nil {
 		return nil, fmt.Errorf("gcp-kms: create client: %w", err)
 	}
-	return &client{kms: c, keyName: keyName}, nil
+	return &client{kms: c, keyName: keyName, aad: encContextAAD(encContext)}, nil
+}
+
+// encContextAAD canonicalises an encryption-context map into deterministic bytes
+// (sorted key=value lines) for use as GCP AdditionalAuthenticatedData. Returns nil for
+// an empty map so the no-binding path is byte-identical to the prior behaviour.
+func encContextAAD(m map[string]string) []byte {
+	if len(m) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var b strings.Builder
+	for _, k := range keys {
+		b.WriteString(k)
+		b.WriteByte('=')
+		b.WriteString(m[k])
+		b.WriteByte('\n')
+	}
+	return []byte(b.String())
 }
 
 func (c *client) Encrypt(ctx context.Context, plaintext []byte) ([]byte, error) {
-	resp, err := c.kms.Encrypt(ctx, &kmspb.EncryptRequest{Name: c.keyName, Plaintext: plaintext})
+	req := &kmspb.EncryptRequest{Name: c.keyName, Plaintext: plaintext}
+	if len(c.aad) > 0 {
+		req.AdditionalAuthenticatedData = c.aad
+	}
+	resp, err := c.kms.Encrypt(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -42,7 +81,18 @@ func (c *client) Encrypt(ctx context.Context, plaintext []byte) ([]byte, error) 
 }
 
 func (c *client) Decrypt(ctx context.Context, ciphertext []byte) ([]byte, error) {
-	resp, err := c.kms.Decrypt(ctx, &kmspb.DecryptRequest{Name: c.keyName, Ciphertext: ciphertext})
+	req := &kmspb.DecryptRequest{Name: c.keyName, Ciphertext: ciphertext}
+	if len(c.aad) > 0 {
+		req.AdditionalAuthenticatedData = c.aad
+	}
+	resp, err := c.kms.Decrypt(ctx, req)
+	if err != nil && len(c.aad) > 0 {
+		// Legacy blob wrapped before the AAD was configured: retry once without it, so
+		// enabling the binding on a running install doesn't lock out the already-wrapped
+		// KEK (it rebinds on the next KEK re-wrap). A blob bound to a DIFFERENT install's
+		// AAD still fails both attempts — the security property holds.
+		resp, err = c.kms.Decrypt(ctx, &kmspb.DecryptRequest{Name: c.keyName, Ciphertext: ciphertext})
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/internal/crypto/gcpkms/gcpkms_test.go
+++ b/internal/crypto/gcpkms/gcpkms_test.go
@@ -1,0 +1,90 @@
+package gcpkms
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"cloud.google.com/go/kms/apiv1/kmspb"
+	gax "github.com/googleapis/gax-go/v2"
+)
+
+// fakeKMS models GCP KMS AAD semantics: a blob decrypts only with the exact
+// AdditionalAuthenticatedData it was encrypted under. The AAD is embedded in the
+// ciphertext so the fake is stateless.
+type fakeKMS struct{}
+
+type fakeBlob struct {
+	Plaintext []byte `json:"p"`
+	AAD       []byte `json:"a"`
+}
+
+func (fakeKMS) Encrypt(_ context.Context, req *kmspb.EncryptRequest, _ ...gax.CallOption) (*kmspb.EncryptResponse, error) {
+	b, _ := json.Marshal(fakeBlob{Plaintext: req.Plaintext, AAD: req.AdditionalAuthenticatedData})
+	return &kmspb.EncryptResponse{Ciphertext: b}, nil
+}
+
+func (fakeKMS) Decrypt(_ context.Context, req *kmspb.DecryptRequest, _ ...gax.CallOption) (*kmspb.DecryptResponse, error) {
+	var b fakeBlob
+	if err := json.Unmarshal(req.Ciphertext, &b); err != nil {
+		return nil, err
+	}
+	if !bytes.Equal(b.AAD, req.AdditionalAuthenticatedData) {
+		return nil, errors.New("decryption failed: AAD mismatch")
+	}
+	return &kmspb.DecryptResponse{Plaintext: b.Plaintext}, nil
+}
+
+func newTestClient(encCtx map[string]string) *client {
+	return &client{kms: fakeKMS{}, keyName: "projects/p/locations/l/keyRings/r/cryptoKeys/k", aad: encContextAAD(encCtx)}
+}
+
+func TestGCPKMS_RoundTripWithContext(t *testing.T) {
+	c := newTestClient(map[string]string{"keyorix-install": "inst-1"})
+	ct, err := c.Encrypt(context.Background(), []byte("kek-material"))
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+	pt, err := c.Decrypt(context.Background(), ct)
+	if err != nil {
+		t.Fatalf("decrypt: %v", err)
+	}
+	if string(pt) != "kek-material" {
+		t.Fatalf("round-trip got %q", pt)
+	}
+}
+
+func TestGCPKMS_LegacyBlobDecryptsViaFallback(t *testing.T) {
+	legacy := newTestClient(nil)
+	ct, _ := legacy.Encrypt(context.Background(), []byte("kek"))
+	bound := newTestClient(map[string]string{"keyorix-install": "inst-1"})
+	pt, err := bound.Decrypt(context.Background(), ct)
+	if err != nil {
+		t.Fatalf("legacy blob must decrypt via the no-AAD fallback: %v", err)
+	}
+	if string(pt) != "kek" {
+		t.Fatalf("got %q", pt)
+	}
+}
+
+func TestGCPKMS_CrossInstallDenied(t *testing.T) {
+	a := newTestClient(map[string]string{"keyorix-install": "inst-A"})
+	ct, _ := a.Encrypt(context.Background(), []byte("kek-A"))
+	b := newTestClient(map[string]string{"keyorix-install": "inst-B"})
+	if _, err := b.Decrypt(context.Background(), ct); err == nil {
+		t.Fatal("install B must not unwrap install A's AAD-bound KEK")
+	}
+}
+
+func TestEncContextAAD_DeterministicAndEmpty(t *testing.T) {
+	if encContextAAD(nil) != nil || encContextAAD(map[string]string{}) != nil {
+		t.Fatal("empty context must produce nil AAD (byte-identical to no binding)")
+	}
+	a := encContextAAD(map[string]string{"b": "2", "a": "1"})
+	b := encContextAAD(map[string]string{"a": "1", "b": "2"})
+	if !bytes.Equal(a, b) {
+		t.Fatal("AAD must be deterministic regardless of map iteration order")
+	}
+}

--- a/internal/crypto/keyprovider.go
+++ b/internal/crypto/keyprovider.go
@@ -26,11 +26,21 @@ type KeyProvider interface {
 	Name() string
 }
 
-// validateKEK ensures key material is exactly KEKSize bytes — a shared guard so
-// every provider rejects a mis-sized key with the same clear error.
+// validateKEK ensures key material is exactly KEKSize bytes and is not the all-zero
+// key — a shared guard so every provider rejects bad material with the same clear
+// error. An all-zero KEK is a plausible empty-state (a zeroed/placeholder mounted
+// secret, an unset env var read as zeros) and must never be accepted as real AES-256
+// key material on a secrets product.
 func validateKEK(key []byte, providerName string) ([]byte, error) {
 	if len(key) != KEKSize {
 		return nil, fmt.Errorf("%s key provider: KEK must be %d bytes, got %d", providerName, KEKSize, len(key))
+	}
+	var anySet byte
+	for _, b := range key {
+		anySet |= b
+	}
+	if anySet == 0 {
+		return nil, fmt.Errorf("%s key provider: KEK is all-zero bytes — refusing placeholder/zeroed key material", providerName)
 	}
 	return key, nil
 }

--- a/internal/crypto/keyprovider_test.go
+++ b/internal/crypto/keyprovider_test.go
@@ -95,6 +95,22 @@ func TestFileKeyProvider_Errors(t *testing.T) {
 		require.Error(t, err, "a zeroed/placeholder KEK must be rejected")
 		assert.Contains(t, err.Error(), "all-zero")
 	})
+	// The all-zero guard must not be skippable by supplying the zeroed KEK in an
+	// encoded form — a placeholder/un-rendered mounted secret can arrive hex- or
+	// base64-encoded just as easily as raw bytes.
+	zero := make([]byte, KEKSize)
+	for name, encoded := range map[string][]byte{
+		"all-zero hex":    []byte(hex.EncodeToString(zero)),
+		"all-zero base64": []byte(base64.StdEncoding.EncodeToString(zero)),
+	} {
+		t.Run(name+" rejected", func(t *testing.T) {
+			path := filepath.Join(dir, "zero-enc.key")
+			require.NoError(t, os.WriteFile(path, encoded, 0600))
+			_, err := NewFileKeyProvider(path).KEK()
+			require.Error(t, err, "an encoded all-zero KEK must be rejected")
+			assert.Contains(t, err.Error(), "all-zero")
+		})
+	}
 }
 
 func TestEnvKeyProvider(t *testing.T) {

--- a/internal/crypto/keyprovider_test.go
+++ b/internal/crypto/keyprovider_test.go
@@ -88,6 +88,13 @@ func TestFileKeyProvider_Errors(t *testing.T) {
 		_, err := NewFileKeyProvider(path).KEK()
 		require.Error(t, err, "a key that doesn't decode to 32 bytes must be rejected")
 	})
+	t.Run("all-zero key rejected", func(t *testing.T) {
+		path := filepath.Join(dir, "zero.key")
+		require.NoError(t, os.WriteFile(path, make([]byte, KEKSize), 0600))
+		_, err := NewFileKeyProvider(path).KEK()
+		require.Error(t, err, "a zeroed/placeholder KEK must be rejected")
+		assert.Contains(t, err.Error(), "all-zero")
+	})
 }
 
 func TestEnvKeyProvider(t *testing.T) {

--- a/internal/crypto/raw_providers.go
+++ b/internal/crypto/raw_providers.go
@@ -18,14 +18,17 @@ func decodeKeyMaterial(material []byte, providerName string) ([]byte, error) {
 		return validateKEK(material, providerName)
 	}
 	s := strings.TrimSpace(string(material))
-	// Hex (64 chars for 32 bytes).
+	// Hex (64 chars for 32 bytes). Decoded key material is validated (e.g. all-zero
+	// rejected) exactly like the raw branch — the guard must not be skippable by
+	// supplying the KEK in an encoded form (a zeroed/placeholder mounted secret can
+	// arrive hex- or base64-encoded just as easily as raw).
 	if b, err := hex.DecodeString(s); err == nil && len(b) == KEKSize {
-		return b, nil
+		return validateKEK(b, providerName)
 	}
 	// Base64 — try standard then raw (unpadded), both URL-safe-tolerant.
 	for _, enc := range []*base64.Encoding{base64.StdEncoding, base64.RawStdEncoding, base64.URLEncoding, base64.RawURLEncoding} {
 		if b, err := enc.DecodeString(s); err == nil && len(b) == KEKSize {
-			return b, nil
+			return validateKEK(b, providerName)
 		}
 	}
 	return nil, fmt.Errorf("%s key provider: key material must be 32 raw bytes, or hex/base64 encoding thereof (got %d bytes that did not decode to %d)", providerName, len(material), KEKSize)

--- a/internal/encryption/auth_encryption.go
+++ b/internal/encryption/auth_encryption.go
@@ -3,6 +3,15 @@
 // Thin typed wrappers over Service.EncryptSecret/DecryptSecret for each auth token category.
 // For DB store/retrieve operations see auth_encryption_store.go.
 // For rotation see auth_encryption_rotate.go.
+//
+// SECURITY NOTE (tracked hardening): unlike secret VALUES (which bind their ciphertext to
+// the owning row via SecretAAD), these auth-token blobs are encrypted without AAD, so a
+// database-WRITE attacker could transplant an encrypted token blob between rows. The
+// plaintext stays confidential under the DEK (an integrity/confused-deputy gap, not a
+// decryption or auth bypass), which is why it is not closed inline: binding AAD requires
+// threading each token's owning identity (userID/tokenID) through every encrypt/decrypt
+// call site AND a versioned-AAD migration for existing blobs (mirroring the secret-value
+// AADVersion fallback). Track as a dedicated change.
 package encryption
 
 import (

--- a/internal/encryption/encryption.go
+++ b/internal/encryption/encryption.go
@@ -116,6 +116,12 @@ func (es *EncryptionService) Decrypt(encryptedData *EncryptedData) ([]byte, erro
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode nonce: %w", err)
 	}
+	// gcm.Open PANICS on a wrong-length nonce rather than returning an error. The nonce
+	// comes from stored metadata, so a corrupt/tampered row would otherwise crash the
+	// request goroutine (caught by recovery middleware as a 500); guard it as an error.
+	if len(nonce) != es.gcm.NonceSize() {
+		return nil, fmt.Errorf("invalid nonce length %d", len(nonce))
+	}
 
 	plaintext, err := es.gcm.Open(nil, nonce, encryptedData.Data, nil)
 	if err != nil {
@@ -168,6 +174,10 @@ func (es *EncryptionService) DecryptWithAAD(encryptedData *EncryptedData, aad []
 	nonce, err := base64.StdEncoding.DecodeString(encryptedData.Metadata.Nonce)
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode nonce: %w", err)
+	}
+	// gcm.Open panics on a wrong-length nonce; treat a corrupt stored nonce as an error.
+	if len(nonce) != es.gcm.NonceSize() {
+		return nil, fmt.Errorf("invalid nonce length %d", len(nonce))
 	}
 
 	plaintext, err := es.gcm.Open(nil, nonce, encryptedData.Data, aad)

--- a/internal/encryption/encryption_test.go
+++ b/internal/encryption/encryption_test.go
@@ -3,6 +3,7 @@ package encryption
 import (
 	"bytes"
 	"crypto/rand"
+	"encoding/base64"
 	"testing"
 )
 
@@ -70,6 +71,40 @@ func TestEncryptionService(t *testing.T) {
 	// Verify decrypted data matches original
 	if !bytes.Equal(plaintext, decrypted) {
 		t.Errorf("Decrypted data doesn't match original.\nOriginal: %s\nDecrypted: %s", plaintext, decrypted)
+	}
+}
+
+// A corrupt/wrong-length stored nonce must yield an ERROR, not a panic (gcm.Open panics
+// on a wrong-length nonce; the guard converts that to a clean error).
+func TestDecrypt_RejectsBadNonceLengthWithoutPanic(t *testing.T) {
+	kek, err := GenerateRandomKey(32)
+	if err != nil {
+		t.Fatalf("Failed to generate KEK: %v", err)
+	}
+	service, err := NewEncryptionService(kek)
+	if err != nil {
+		t.Fatalf("Failed to create encryption service: %v", err)
+	}
+	enc, err := service.Encrypt([]byte("secret"), testKeyVersion)
+	if err != nil {
+		t.Fatalf("Failed to encrypt: %v", err)
+	}
+	// Corrupt the nonce to a too-short value (base64 of 4 bytes).
+	enc.Metadata.Nonce = base64.StdEncoding.EncodeToString([]byte{1, 2, 3, 4})
+
+	_, err = service.Decrypt(enc) // must not panic
+	if err == nil {
+		t.Fatal("expected an error for a wrong-length nonce")
+	}
+
+	// Same guard on the AAD path.
+	encAAD, err := service.EncryptWithAAD([]byte("secret"), testKeyVersion, []byte("aad"))
+	if err != nil {
+		t.Fatalf("Failed to encrypt with AAD: %v", err)
+	}
+	encAAD.Metadata.Nonce = base64.StdEncoding.EncodeToString([]byte{1, 2, 3, 4})
+	if _, err := service.DecryptWithAAD(encAAD, []byte("aad")); err == nil {
+		t.Fatal("expected an error for a wrong-length nonce on the AAD path")
 	}
 }
 

--- a/internal/encryption/service.go
+++ b/internal/encryption/service.go
@@ -106,18 +106,23 @@ func NewKeyProviderFromConfig(cfg *config.EncryptionConfig, baseDir, passphrase 
 	case "tpm":
 		return crypto.NewTPMKeyProvider(kp.TPMDevice, baseDir, kp.WrappedKeyPath), nil
 	case "aws-kms":
-		kmsClient, err := awskms.New(context.Background(), kp.KMSKeyID)
+		kmsClient, err := awskms.New(context.Background(), kp.KMSKeyID, kp.KMSEncryptionContext)
 		if err != nil {
 			return nil, err
 		}
 		return crypto.NewKMSKeyProvider(kmsClient, "aws-kms", baseDir, kp.WrappedKeyPath), nil
 	case "gcp-kms":
-		kmsClient, err := gcpkms.New(context.Background(), kp.KMSKeyID)
+		kmsClient, err := gcpkms.New(context.Background(), kp.KMSKeyID, kp.KMSEncryptionContext)
 		if err != nil {
 			return nil, err
 		}
 		return crypto.NewKMSKeyProvider(kmsClient, "gcp-kms", baseDir, kp.WrappedKeyPath), nil
 	case "azure-kms":
+		if len(kp.KMSEncryptionContext) > 0 {
+			// Azure Key Vault wraps with RSA-OAEP, which has no additional-authenticated-
+			// data input, so the wrapped KEK cannot be bound to an install this way.
+			log.Printf("azure-kms: kms_encryption_context is set but unsupported (RSA wrap has no AAD); ignoring — use a per-install key to avoid shared-key unwrap")
+		}
 		kmsClient, err := azurekms.New(context.Background(), kp.KMSKeyID)
 		if err != nil {
 			return nil, err

--- a/internal/evidencesink/webhook.go
+++ b/internal/evidencesink/webhook.go
@@ -53,7 +53,26 @@ func newWebhook(cfg WebhookConfig, baseBackoff time.Duration) (*Webhook, error) 
 	if cfg.InsecureSkipVerify {
 		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} // #nosec G402 -- opt-in for self-signed endpoints
 	}
-	return &Webhook{cfg: cfg, client: &http.Client{Timeout: webhookTimeout, Transport: transport}, baseBackoff: baseBackoff}, nil
+	return &Webhook{cfg: cfg, client: &http.Client{Timeout: webhookTimeout, Transport: transport, CheckRedirect: refuseRedirect}, baseBackoff: baseBackoff}, nil
+}
+
+// refuseRedirect blocks a redirect to a different host or an https->http downgrade, so
+// a compromised/misconfigured receiver returning a 30x cannot bounce the bearer-token-
+// bearing evidence POST to an internal or cleartext target (SSRF / token exfil). The
+// Authorization header is stripped by Go on a cross-host redirect, but the evidence pack
+// itself (and a same-host downgrade) still warrant refusing the bounce outright.
+func refuseRedirect(req *http.Request, via []*http.Request) error {
+	if len(via) == 0 {
+		return nil
+	}
+	prev := via[len(via)-1]
+	if req.URL.Host != prev.URL.Host {
+		return fmt.Errorf("evidencesink: refusing cross-host redirect to %q", req.URL.Host)
+	}
+	if prev.URL.Scheme == "https" && req.URL.Scheme != "https" {
+		return fmt.Errorf("evidencesink: refusing https->%s redirect", req.URL.Scheme)
+	}
+	return nil
 }
 
 // ForwardEvidence POSTs the marshalled evidence pack as application/json. The pack's

--- a/internal/evidencesink/webhook.go
+++ b/internal/evidencesink/webhook.go
@@ -9,7 +9,9 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"net"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 )
@@ -49,11 +51,64 @@ func newWebhook(cfg WebhookConfig, baseBackoff time.Duration) (*Webhook, error) 
 	if cfg.Endpoint == "" {
 		return nil, fmt.Errorf("evidencesink: webhook endpoint is required")
 	}
+	// Refuse a non-https (or internal-target) endpoint up front. Unlike the notification
+	// webhook, this path previously sent the bearer token + the FULL compliance evidence
+	// pack to whatever URL was configured — an http:// endpoint shipped both in cleartext
+	// on every POST, and refuseRedirect only guards bounces, not the initial request.
+	if err := validateEndpoint(cfg.Endpoint, cfg.InsecureSkipVerify); err != nil {
+		return nil, err
+	}
 	transport := &http.Transport{}
 	if cfg.InsecureSkipVerify {
 		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} // #nosec G402 -- opt-in for self-signed endpoints
 	}
 	return &Webhook{cfg: cfg, client: &http.Client{Timeout: webhookTimeout, Transport: transport, CheckRedirect: refuseRedirect}, baseBackoff: baseBackoff}, nil
+}
+
+// validateEndpoint rejects a non-https evidence endpoint (which would send the bearer
+// token and the full compliance pack in cleartext), allowing http only for an explicit
+// insecure opt-in or a loopback target. It also refuses a literal private/link-local IP
+// destination unless the insecure opt-in is set (SSRF/exfil hardening: an evidence pack
+// must not be POSTed to cloud metadata or an internal host).
+func validateEndpoint(raw string, allowInsecure bool) error {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("evidencesink: invalid endpoint %q: %w", raw, err)
+	}
+	switch u.Scheme {
+	case "https":
+		// scheme OK; fall through to the destination-IP check
+	case "http":
+		if !allowInsecure && !isLoopbackHost(u.Hostname()) {
+			return fmt.Errorf("evidencesink: endpoint %q must use https (set insecure_skip_verify only for a trusted self-signed or loopback target)", raw)
+		}
+	default:
+		return fmt.Errorf("evidencesink: endpoint %q must use https", raw)
+	}
+	if !allowInsecure && isDisallowedIPHost(u.Hostname()) {
+		return fmt.Errorf("evidencesink: endpoint %q targets a private/link-local address; refusing to send evidence to an internal host", raw)
+	}
+	return nil
+}
+
+func isLoopbackHost(host string) bool {
+	if host == "localhost" {
+		return true
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return ip.IsLoopback()
+	}
+	return false
+}
+
+// isDisallowedIPHost reports whether host is a literal private or link-local IP (loopback
+// permitted). Hostnames are not resolved here, so this catches the literal-IP SSRF cases.
+func isDisallowedIPHost(host string) bool {
+	ip := net.ParseIP(host)
+	if ip == nil || ip.IsLoopback() {
+		return false
+	}
+	return ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast()
 }
 
 // refuseRedirect blocks a redirect to a different host or an https->http downgrade, so

--- a/internal/evidencesink/webhook_test.go
+++ b/internal/evidencesink/webhook_test.go
@@ -14,6 +14,27 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// The evidence webhook must refuse a cleartext (non-loopback http) endpoint and an
+// internal-target destination at construction, so the bearer token + compliance pack
+// are never shipped in cleartext or to an internal host.
+func TestWebhook_RejectsInsecureEndpoints(t *testing.T) {
+	// Cleartext http to a non-loopback host → rejected.
+	_, err := NewWebhook(WebhookConfig{Endpoint: "http://collector.example.com/evidence", Token: "ev-tok"})
+	require.ErrorContains(t, err, "must use https")
+
+	// https to the cloud-metadata link-local address → rejected (SSRF/exfil).
+	_, err = NewWebhook(WebhookConfig{Endpoint: "https://169.254.169.254/evidence"})
+	require.ErrorContains(t, err, "private/link-local")
+
+	// https to a normal host → accepted.
+	_, err = NewWebhook(WebhookConfig{Endpoint: "https://collector.example.com/evidence"})
+	require.NoError(t, err)
+
+	// The insecure opt-in permits http (trusted self-signed / lab).
+	_, err = NewWebhook(WebhookConfig{Endpoint: "http://collector.example.com/evidence", InsecureSkipVerify: true})
+	require.NoError(t, err)
+}
+
 func TestWebhook_PostsEvidenceWithAuth(t *testing.T) {
 	var (
 		mu       sync.Mutex

--- a/internal/evidencesink/webhook_test.go
+++ b/internal/evidencesink/webhook_test.go
@@ -47,6 +47,27 @@ func TestWebhook_PostsEvidenceWithAuth(t *testing.T) {
 	assert.Equal(t, "webhook", wh.Target())
 }
 
+// A cross-host redirect from the configured evidence endpoint must be refused, so the
+// evidence pack (and its bearer token) can't be bounced to an attacker-controlled host.
+func TestWebhook_RefusesCrossHostRedirect(t *testing.T) {
+	var evilHits int32
+	evil := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&evilHits, 1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer evil.Close()
+	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Redirect(w, nil, evil.URL, http.StatusFound)
+	}))
+	defer primary.Close()
+
+	wh, err := newWebhook(WebhookConfig{Endpoint: primary.URL, Token: "ev-tok"}, time.Millisecond)
+	require.NoError(t, err)
+	err = wh.ForwardEvidence(context.Background(), "pack.json", []byte(`{"x":1}`), "")
+	require.Error(t, err, "a cross-host redirect must not be followed")
+	assert.Equal(t, int32(0), atomic.LoadInt32(&evilHits), "redirect target must never be reached")
+}
+
 func TestWebhook_ErrorsOnNon2xxAfterRetries(t *testing.T) {
 	var hits atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/internal/k8ssync/config.go
+++ b/internal/k8ssync/config.go
@@ -2,6 +2,8 @@ package k8ssync
 
 import (
 	"fmt"
+	"net"
+	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -43,6 +45,13 @@ func (c *Config) validate() error {
 	if strings.TrimSpace(c.KeyorixURL) == "" {
 		return fmt.Errorf("keyorix_url is required")
 	}
+	// The agent sends the machine-identity token (KEYORIX_TOKEN) as a Bearer header on
+	// every request, so keyorix_url MUST be https (http only for loopback in dev) — an
+	// http endpoint would ship a secrets-read-capable token in cleartext over the cluster
+	// network. The operator (CRD) path already requires https; this matches it.
+	if err := requireHTTPSURL(c.KeyorixURL); err != nil {
+		return err
+	}
 	if len(c.Mappings) == 0 {
 		return fmt.Errorf("at least one mapping is required")
 	}
@@ -57,6 +66,30 @@ func (c *Config) validate() error {
 		}
 	}
 	return nil
+}
+
+// requireHTTPSURL rejects a keyorix_url that is not https (http is allowed only for a
+// loopback host, for local development/testing).
+func requireHTTPSURL(raw string) error {
+	u, err := url.Parse(raw)
+	if err != nil || u.Host == "" {
+		return fmt.Errorf("invalid keyorix_url %q", raw)
+	}
+	switch u.Scheme {
+	case "https":
+		return nil
+	case "http":
+		host := u.Hostname()
+		if host == "localhost" {
+			return nil
+		}
+		if ip := net.ParseIP(host); ip != nil && ip.IsLoopback() {
+			return nil
+		}
+		return fmt.Errorf("keyorix_url %q must use https (http is allowed only for localhost); sending the bearer token over plaintext would expose it", raw)
+	default:
+		return fmt.Errorf("keyorix_url %q must use https", raw)
+	}
 }
 
 // GetInterval returns the reconcile interval, defaulting to 5m when unset.

--- a/internal/k8ssync/config_test.go
+++ b/internal/k8ssync/config_test.go
@@ -73,6 +73,11 @@ interval: "soon"
 mappings:
   - {ref: e/n, namespace: ns, name: s, key: K}
 `,
+		"cleartext url": `
+keyorix_url: http://keyorix.internal
+mappings:
+  - {ref: e/n, namespace: ns, name: s, key: K}
+`,
 	}
 	for name, body := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/internal/k8ssync/rest_sink.go
+++ b/internal/k8ssync/rest_sink.go
@@ -189,10 +189,30 @@ func (s *RESTSink) List(ctx context.Context, namespace string) ([]string, error)
 	return names, nil
 }
 
-// Delete removes the named Secret. A 404 is treated as success — the goal state (gone)
-// is already met, so a concurrent delete or an already-reaped Secret is not an error.
+// Delete removes the named Secret, but only while it still belongs to this agent. It
+// re-verifies the managed-by label and pins the exact (uid, resourceVersion) it saw,
+// so a Secret that lost the label or was replaced between the orphan listing and here
+// is left untouched — closing the list→delete TOCTOU on a destructive action. A 404 is
+// success (already gone); a 409 means it changed under us (uid/resourceVersion no
+// longer match), so we skip rather than delete a different object.
 func (s *RESTSink) Delete(ctx context.Context, namespace, name string) error {
-	req, err := s.newRequest(ctx, http.MethodDelete, s.secretPath(namespace, name), "", nil)
+	uid, rv, owned, err := s.getOwnedMeta(ctx, namespace, name)
+	if err != nil {
+		return err
+	}
+	if !owned {
+		return nil // gone, or no longer ours — must not delete
+	}
+	opts := map[string]interface{}{
+		"apiVersion":    "v1",
+		"kind":          "DeleteOptions",
+		"preconditions": map[string]string{"uid": uid, "resourceVersion": rv},
+	}
+	raw, err := json.Marshal(opts)
+	if err != nil {
+		return fmt.Errorf("marshal delete options %s/%s: %w", namespace, name, err)
+	}
+	req, err := s.newRequest(ctx, http.MethodDelete, s.secretPath(namespace, name), "application/json", bytes.NewReader(raw))
 	if err != nil {
 		return err
 	}
@@ -201,13 +221,47 @@ func (s *RESTSink) Delete(ctx context.Context, namespace, name string) error {
 		return fmt.Errorf("request failed: %w", err)
 	}
 	defer resp.Body.Close() //nolint:errcheck
-	if resp.StatusCode == http.StatusNotFound {
+	switch {
+	case resp.StatusCode == http.StatusNotFound, resp.StatusCode == http.StatusConflict:
+		// 404: already gone. 409: the object changed since our owner-check (precondition
+		// mismatch) — the Secret we verified is no longer the one on the server, so skip.
 		return nil
-	}
-	if resp.StatusCode >= 400 {
+	case resp.StatusCode >= 400:
 		return fmt.Errorf("delete secret %s/%s: HTTP %d", namespace, name, resp.StatusCode)
 	}
 	return nil
+}
+
+// getOwnedMeta fetches the Secret's uid + resourceVersion and reports whether it still
+// carries this agent's managed-by label. owned is false when the Secret is absent.
+func (s *RESTSink) getOwnedMeta(ctx context.Context, namespace, name string) (uid, resourceVersion string, owned bool, err error) {
+	req, err := s.newRequest(ctx, http.MethodGet, s.secretPath(namespace, name), "", nil)
+	if err != nil {
+		return "", "", false, err
+	}
+	resp, err := s.hc.Do(req)
+	if err != nil {
+		return "", "", false, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode == http.StatusNotFound {
+		return "", "", false, nil
+	}
+	if resp.StatusCode >= 400 {
+		return "", "", false, fmt.Errorf("get secret %s/%s: HTTP %d", namespace, name, resp.StatusCode)
+	}
+	var body struct {
+		Metadata struct {
+			UID             string            `json:"uid"`
+			ResourceVersion string            `json:"resourceVersion"`
+			Labels          map[string]string `json:"labels"`
+		} `json:"metadata"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return "", "", false, fmt.Errorf("decode secret %s/%s: %w", namespace, name, err)
+	}
+	owned = body.Metadata.Labels[managedByLabel] == managedByValue
+	return body.Metadata.UID, body.Metadata.ResourceVersion, owned, nil
 }
 
 func (s *RESTSink) secretPath(namespace, name string) string {

--- a/internal/k8ssync/rest_sink_test.go
+++ b/internal/k8ssync/rest_sink_test.go
@@ -88,19 +88,47 @@ func TestRESTSink_ListOwnedScopesByLabel(t *testing.T) {
 	assert.ElementsMatch(t, []string{"creds", "stale"}, names)
 }
 
-func TestRESTSink_DeleteHitsDeleteVerb(t *testing.T) {
-	var gotMethod, gotPath string
+func TestRESTSink_DeleteOwnerConditional(t *testing.T) {
+	var methods []string
+	var deleteBody, deletePath string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotMethod = r.Method
-		gotPath = r.URL.Path
-		_, _ = w.Write([]byte(`{"kind":"Status"}`))
+		methods = append(methods, r.Method)
+		switch r.Method {
+		case http.MethodGet:
+			// An owned Secret with a known uid/resourceVersion.
+			_, _ = w.Write([]byte(`{"metadata":{"uid":"u-1","resourceVersion":"rv-9","labels":{"app.kubernetes.io/managed-by":"keyorix-sync"}}}`))
+		case http.MethodDelete:
+			b, _ := io.ReadAll(r.Body)
+			deleteBody, deletePath = string(b), r.URL.Path
+			_, _ = w.Write([]byte(`{"kind":"Status"}`))
+		}
 	}))
 	defer srv.Close()
 
 	err := testSink(srv).Delete(context.Background(), "app", "stale")
 	require.NoError(t, err)
-	assert.Equal(t, http.MethodDelete, gotMethod)
-	assert.Equal(t, "/api/v1/namespaces/app/secrets/stale", gotPath)
+	assert.Equal(t, []string{http.MethodGet, http.MethodDelete}, methods, "the owner re-check (GET) must precede the DELETE")
+	assert.Equal(t, "/api/v1/namespaces/app/secrets/stale", deletePath)
+	// The delete is pinned to the exact object we verified (closes the TOCTOU).
+	assert.Contains(t, deleteBody, `"uid":"u-1"`)
+	assert.Contains(t, deleteBody, `"resourceVersion":"rv-9"`)
+}
+
+func TestRESTSink_DeleteSkipsUnownedSecret(t *testing.T) {
+	var sawDelete bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete {
+			sawDelete = true
+		}
+		// The Secret no longer carries our managed-by label (e.g. label stripped and the
+		// name reused by an unrelated object between listing and delete).
+		_, _ = w.Write([]byte(`{"metadata":{"uid":"u-2","resourceVersion":"rv-1","labels":{"app":"other"}}}`))
+	}))
+	defer srv.Close()
+
+	err := testSink(srv).Delete(context.Background(), "app", "not-ours")
+	require.NoError(t, err)
+	assert.False(t, sawDelete, "a Secret without our managed-by label must never be deleted")
 }
 
 func TestRESTSink_DeleteAbsentIsNotAnError(t *testing.T) {

--- a/internal/k8ssync/sync.go
+++ b/internal/k8ssync/sync.go
@@ -13,9 +13,21 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"regexp"
 	"sort"
 	"strings"
 )
+
+// Kubernetes object-name constraints. A namespace is an RFC1123 DNS label; a Secret
+// name is an RFC1123 DNS subdomain. Validating these before they reach the API path
+// keeps a malformed (or hostile) config mapping from targeting an unintended object.
+var (
+	dns1123Label     = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`)
+	dns1123Subdomain = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`)
+)
+
+func isDNS1123Label(s string) bool     { return len(s) <= 63 && dns1123Label.MatchString(s) }
+func isDNS1123Subdomain(s string) bool { return len(s) <= 253 && dns1123Subdomain.MatchString(s) }
 
 // SecretMapping maps one Keyorix secret reference to a key inside a target
 // Kubernetes Secret. Several mappings may target the same Secret with different keys.
@@ -270,6 +282,10 @@ func validateMapping(m SecretMapping) error {
 		return fmt.Errorf("name is required")
 	case strings.TrimSpace(m.Key) == "":
 		return fmt.Errorf("key is required")
+	case !isDNS1123Label(m.Namespace):
+		return fmt.Errorf("namespace %q is not a valid RFC1123 label", m.Namespace)
+	case !isDNS1123Subdomain(m.Name):
+		return fmt.Errorf("name %q is not a valid Kubernetes Secret name (RFC1123 subdomain)", m.Name)
 	}
 	return nil
 }

--- a/internal/license/license.go
+++ b/internal/license/license.go
@@ -158,11 +158,21 @@ func Evaluate(token string, reg *trust.KeyRegistry, deploymentID string, now tim
 	}
 
 	// Anti-copy binding: a license bound to a deployment must not grant features on another.
-	// Mismatch degrades (warn + audit), it does not shut anything down.
-	if lic.DeploymentID != "" && deploymentID != "" && lic.DeploymentID != deploymentID {
-		base.State = StateInvalid
-		base.Reason = fmt.Sprintf("license is bound to deployment %q, not this deployment", lic.DeploymentID)
-		return base
+	// Mismatch degrades (warn + audit), it does not shut anything down. Crucially, a
+	// deployment-bound license on a host with NO deployment_id configured must ALSO fail
+	// (closed): otherwise the binding is trivially bypassed by simply leaving deployment_id
+	// empty — copying the license to any host that doesn't set it.
+	if lic.DeploymentID != "" {
+		if deploymentID == "" {
+			base.State = StateInvalid
+			base.Reason = "license is bound to a specific deployment but this deployment has no deployment_id configured"
+			return base
+		}
+		if lic.DeploymentID != deploymentID {
+			base.State = StateInvalid
+			base.Reason = fmt.Sprintf("license is bound to deployment %q, not this deployment", lic.DeploymentID)
+			return base
+		}
 	}
 
 	switch {

--- a/internal/license/license_test.go
+++ b/internal/license/license_test.go
@@ -151,9 +151,19 @@ func TestEvaluate_DeploymentBinding(t *testing.T) {
 	if st.State != StateInvalid || st.Grants() {
 		t.Fatalf("mismatch must degrade: %s grants=%v", st.State, st.Grants())
 	}
-	// No local deployment id supplied → binding not enforced (still grants).
-	if st := Evaluate(token, reg, "", now, time.Hour); !st.HasFeature("x") {
-		t.Fatal("unbound check should still grant")
+	// A deployment-BOUND license on a host with NO deployment_id configured must FAIL
+	// CLOSED — otherwise the anti-copy binding is bypassed by simply leaving deployment_id
+	// empty (copy the license to any host that doesn't set it).
+	if st := Evaluate(token, reg, "", now, time.Hour); st.State != StateInvalid || st.Grants() {
+		t.Fatalf("a bound license with no local deployment id must degrade, not grant: %s grants=%v", st.State, st.Grants())
+	}
+
+	// An UNBOUND license (no DeploymentID) still grants regardless of the local id.
+	unboundTok, unboundReg := signed(t, License{
+		Licensee: "ACME", Features: []string{"x"}, NotAfter: now.Add(time.Hour),
+	})
+	if st := Evaluate(unboundTok, unboundReg, "", now, time.Hour); !st.HasFeature("x") {
+		t.Fatal("an unbound license should grant when no deployment id is configured")
 	}
 }
 

--- a/internal/notifychan/chat.go
+++ b/internal/notifychan/chat.go
@@ -60,9 +60,12 @@ func newChat(cfg ChatConfig, baseBackoff time.Duration) (*ChatSink, error) {
 	if cfg.WebhookURL == "" {
 		return nil, fmt.Errorf("notifychan: chat webhook_url is required")
 	}
+	if err := validateEndpoint(cfg.WebhookURL, false); err != nil {
+		return nil, err
+	}
 	s := &ChatSink{
 		cfg:    cfg,
-		client: &http.Client{Timeout: chatTimeout},
+		client: &http.Client{Timeout: chatTimeout, CheckRedirect: refuseRedirectDowngrade},
 	}
 	s.d = newDeliverer(string(cfg.Kind), chatQueueSize, baseBackoff, s.send)
 	return s, nil

--- a/internal/notifychan/secure_transport.go
+++ b/internal/notifychan/secure_transport.go
@@ -1,0 +1,54 @@
+package notifychan
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+)
+
+// validateEndpoint rejects a non-https notification endpoint — which would send the
+// bearer token and payload in cleartext — allowing http only for an explicit insecure
+// opt-in or a loopback target (local testing).
+func validateEndpoint(raw string, allowInsecure bool) error {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("notifychan: invalid endpoint %q: %w", raw, err)
+	}
+	switch u.Scheme {
+	case "https":
+		return nil
+	case "http":
+		if allowInsecure || isLoopbackHost(u.Hostname()) {
+			return nil
+		}
+	}
+	return fmt.Errorf("notifychan: endpoint %q must use https (set insecure_skip_verify only for a trusted self-signed or loopback target)", raw)
+}
+
+func isLoopbackHost(host string) bool {
+	if host == "localhost" {
+		return true
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return ip.IsLoopback()
+	}
+	return false
+}
+
+// refuseRedirectDowngrade blocks a redirect to a different host or a downgrade from
+// https to http, so a compromised/misbehaving endpoint cannot bounce the signed,
+// token-bearing request to an internal or cleartext target (SSRF/exfil hardening).
+func refuseRedirectDowngrade(req *http.Request, via []*http.Request) error {
+	if len(via) == 0 {
+		return nil
+	}
+	prev := via[len(via)-1]
+	if req.URL.Host != prev.URL.Host {
+		return fmt.Errorf("notifychan: refusing cross-host redirect to %q", req.URL.Host)
+	}
+	if prev.URL.Scheme == "https" && req.URL.Scheme != "https" {
+		return fmt.Errorf("notifychan: refusing https->%s redirect", req.URL.Scheme)
+	}
+	return nil
+}

--- a/internal/notifychan/secure_transport.go
+++ b/internal/notifychan/secure_transport.go
@@ -9,7 +9,9 @@ import (
 
 // validateEndpoint rejects a non-https notification endpoint — which would send the
 // bearer token and payload in cleartext — allowing http only for an explicit insecure
-// opt-in or a loopback target (local testing).
+// opt-in or a loopback target (local testing). It also refuses a literal private /
+// link-local destination IP (e.g. cloud metadata 169.254.169.254 or an internal host)
+// unless the insecure opt-in is set — SSRF/exfil hardening.
 func validateEndpoint(raw string, allowInsecure bool) error {
 	u, err := url.Parse(raw)
 	if err != nil {
@@ -17,13 +19,18 @@ func validateEndpoint(raw string, allowInsecure bool) error {
 	}
 	switch u.Scheme {
 	case "https":
-		return nil
+		// scheme OK; fall through to the destination-IP check
 	case "http":
-		if allowInsecure || isLoopbackHost(u.Hostname()) {
-			return nil
+		if !allowInsecure && !isLoopbackHost(u.Hostname()) {
+			return fmt.Errorf("notifychan: endpoint %q must use https (set insecure_skip_verify only for a trusted self-signed or loopback target)", raw)
 		}
+	default:
+		return fmt.Errorf("notifychan: endpoint %q must use https", raw)
 	}
-	return fmt.Errorf("notifychan: endpoint %q must use https (set insecure_skip_verify only for a trusted self-signed or loopback target)", raw)
+	if !allowInsecure && isDisallowedIPHost(u.Hostname()) {
+		return fmt.Errorf("notifychan: endpoint %q targets a private/link-local address; refusing to send to an internal host", raw)
+	}
+	return nil
 }
 
 func isLoopbackHost(host string) bool {
@@ -34,6 +41,17 @@ func isLoopbackHost(host string) bool {
 		return ip.IsLoopback()
 	}
 	return false
+}
+
+// isDisallowedIPHost reports whether host is a literal private or link-local IP (loopback
+// is permitted as a dev target). Hostnames are not resolved here (no DNS at config time),
+// so this catches the literal-IP SSRF cases without a resolution side effect.
+func isDisallowedIPHost(host string) bool {
+	ip := net.ParseIP(host)
+	if ip == nil || ip.IsLoopback() {
+		return false
+	}
+	return ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast()
 }
 
 // refuseRedirectDowngrade blocks a redirect to a different host or a downgrade from

--- a/internal/notifychan/webhook.go
+++ b/internal/notifychan/webhook.go
@@ -13,7 +13,10 @@ package notifychan
 import (
 	"bytes"
 	"context"
+	"crypto/hmac"
+	"crypto/sha256"
 	"crypto/tls"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -33,6 +36,9 @@ type WebhookConfig struct {
 	Endpoint           string // full destination URL (POST target)
 	Token              string // optional bearer token (Authorization: Bearer <token>)
 	InsecureSkipVerify bool   // skip TLS verification (test/self-signed only)
+	// SigningSecret, when set, signs each payload with HMAC-SHA256 so the receiver can
+	// verify it came from Keyorix: header X-Keyorix-Signature: sha256=<hex(hmac(body))>.
+	SigningSecret string
 }
 
 // WebhookSink delivers notifications to an HTTP endpoint as JSON, asynchronously.
@@ -54,13 +60,16 @@ func newWebhook(cfg WebhookConfig, baseBackoff time.Duration) (*WebhookSink, err
 	if cfg.Endpoint == "" {
 		return nil, fmt.Errorf("notifychan: webhook endpoint is required")
 	}
+	if err := validateEndpoint(cfg.Endpoint, cfg.InsecureSkipVerify); err != nil {
+		return nil, err
+	}
 	transport := &http.Transport{}
 	if cfg.InsecureSkipVerify {
 		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} // #nosec G402 -- opt-in for self-signed endpoints
 	}
 	s := &WebhookSink{
 		cfg:    cfg,
-		client: &http.Client{Timeout: webhookTimeout, Transport: transport},
+		client: &http.Client{Timeout: webhookTimeout, Transport: transport, CheckRedirect: refuseRedirectDowngrade},
 	}
 	s.d = newDeliverer("webhook", webhookQueueSize, baseBackoff, s.send)
 	return s, nil
@@ -90,6 +99,11 @@ func (s *WebhookSink) send(ctx context.Context, ev core.NotificationEvent) (retr
 	req.Header.Set("Content-Type", "application/json")
 	if s.cfg.Token != "" {
 		req.Header.Set("Authorization", "Bearer "+s.cfg.Token)
+	}
+	if s.cfg.SigningSecret != "" {
+		mac := hmac.New(sha256.New, []byte(s.cfg.SigningSecret))
+		mac.Write(body)
+		req.Header.Set("X-Keyorix-Signature", "sha256="+hex.EncodeToString(mac.Sum(nil)))
 	}
 	resp, err := s.client.Do(req)
 	if err != nil {

--- a/internal/notifychan/webhook_test.go
+++ b/internal/notifychan/webhook_test.go
@@ -1,6 +1,9 @@
 package notifychan
 
 import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -159,4 +162,44 @@ func TestWebhookSink_DropsAndCountsWhenQueueFull(t *testing.T) {
 
 	close(release)
 	sink.Close()
+}
+
+func TestWebhookSink_SignsPayloadWhenSecretSet(t *testing.T) {
+	var (
+		mu   sync.Mutex
+		body []byte
+		sig  string
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		body, sig = b, r.Header.Get("X-Keyorix-Signature")
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	sink, err := NewWebhook(WebhookConfig{Endpoint: srv.URL, SigningSecret: "shh"})
+	require.NoError(t, err)
+	sink.Deliver(core.NotificationEvent{UserID: 1, Type: "x"})
+	sink.Close()
+
+	mu.Lock()
+	defer mu.Unlock()
+	mac := hmac.New(sha256.New, []byte("shh"))
+	mac.Write(body)
+	want := "sha256=" + hex.EncodeToString(mac.Sum(nil))
+	assert.Equal(t, want, sig, "payload must be HMAC-signed so the receiver can verify it")
+}
+
+func TestNewWebhook_RejectsNonHTTPSEndpoint(t *testing.T) {
+	_, err := NewWebhook(WebhookConfig{Endpoint: "http://siem.example.com/hook"})
+	require.Error(t, err, "a non-loopback http endpoint must be rejected (cleartext token)")
+	assert.Contains(t, err.Error(), "https")
+
+	// Loopback http is allowed (local testing), and explicit insecure opt-in too.
+	_, err = NewWebhook(WebhookConfig{Endpoint: "http://127.0.0.1:9000/hook"})
+	require.NoError(t, err)
+	_, err = NewWebhook(WebhookConfig{Endpoint: "http://siem.example.com/hook", InsecureSkipVerify: true})
+	require.NoError(t, err)
 }

--- a/internal/rotation/awsiam.go
+++ b/internal/rotation/awsiam.go
@@ -9,10 +9,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 )
 
 // iamAPI is the slice of the IAM client the executor uses — an interface seam so the
@@ -94,12 +96,28 @@ func (e *AWSIAMExecutor) GenerateUpstream(ctx context.Context, ref string) (stri
 			prior = append(prior, *k.AccessKeyId)
 		}
 	}
-	// IAM caps a user at two access keys; free a slot before creating the new one.
+	// IAM caps a user at two access keys. Only when both slots are full must we delete
+	// one BEFORE creating the new key (the create would otherwise fail) — that is the one
+	// unavoidable "revoke-before-mint" window. Minimise its blast radius by evicting the
+	// safest victim: an Inactive key if present, else the oldest by CreateDate, so we
+	// don't revoke a freshly-active credential and keep the most-likely-in-use key live
+	// until the new one is minted. Below the cap we skip this and create first, then
+	// delete priors (no window at all).
 	if len(prior) >= 2 {
-		if err := e.deleteKey(ctx, cl, ref, prior[0]); err != nil {
+		victim := evictableAccessKey(list.AccessKeyMetadata)
+		if victim == "" {
+			victim = prior[0]
+		}
+		if err := e.deleteKey(ctx, cl, ref, victim); err != nil {
 			return "", err
 		}
-		prior = prior[1:]
+		filtered := prior[:0]
+		for _, id := range prior {
+			if id != victim {
+				filtered = append(filtered, id)
+			}
+		}
+		prior = filtered
 	}
 
 	created, err := cl.CreateAccessKey(ctx, &iam.CreateAccessKeyInput{UserName: aws.String(ref)})
@@ -142,6 +160,27 @@ func (e *AWSIAMExecutor) GenerateUpstream(ctx context.Context, ref string) (stri
 		}
 	}
 	return string(out), nil
+}
+
+// evictableAccessKey picks the safest key to remove when freeing a slot at the IAM
+// two-key cap: an Inactive key if any (returned as soon as one is seen, regardless of
+// order), otherwise the oldest by CreateDate. Returns "" when no candidate has an ID.
+func evictableAccessKey(keys []iamtypes.AccessKeyMetadata) string {
+	victim := ""
+	var oldest *time.Time
+	for _, k := range keys {
+		if k.AccessKeyId == nil {
+			continue
+		}
+		if k.Status == iamtypes.StatusTypeInactive {
+			return *k.AccessKeyId
+		}
+		if oldest == nil || (k.CreateDate != nil && k.CreateDate.Before(*oldest)) {
+			victim = *k.AccessKeyId
+			oldest = k.CreateDate
+		}
+	}
+	return victim
 }
 
 func (e *AWSIAMExecutor) deleteKey(ctx context.Context, cl iamAPI, user, keyID string) error {

--- a/internal/securefiles/securefiles.go
+++ b/internal/securefiles/securefiles.go
@@ -23,19 +23,46 @@ type FilePermSpec struct {
 	Mode os.FileMode // e.g., 0600
 }
 
-// isPathInsideBase ensures that targetPath is inside baseDir
+// isPathInsideBase ensures that targetPath is inside baseDir. It resolves symlinks on
+// both sides before comparing, so a symlink planted inside baseDir cannot redirect the
+// read/write to a location outside it (a purely lexical filepath.Clean check would miss
+// that). The target file itself may not exist yet (writes), so its longest existing
+// ancestor is resolved and the unresolved tail re-attached.
 func isPathInsideBase(baseDir, targetPath string) (bool, error) {
 	absBase, err := filepath.Abs(baseDir)
 	if err != nil {
 		return false, err
 	}
+	if resolved, rerr := filepath.EvalSymlinks(absBase); rerr == nil {
+		absBase = resolved
+	} else if !os.IsNotExist(rerr) {
+		return false, rerr
+	}
+
 	absTarget, err := filepath.Abs(targetPath)
 	if err != nil {
 		return false, err
 	}
+	absTarget = resolveExistingAncestor(absTarget)
 
 	baseWithSlash := absBase + string(os.PathSeparator)
 	return absTarget == absBase || strings.HasPrefix(absTarget, baseWithSlash), nil
+}
+
+// resolveExistingAncestor returns p with its longest existing prefix run through
+// filepath.EvalSymlinks (collapsing any symlink in the real path) and the remaining
+// non-existent suffix re-appended unchanged. This lets the containment check resolve
+// symlinks even when the final target does not exist yet.
+func resolveExistingAncestor(p string) string {
+	if resolved, err := filepath.EvalSymlinks(p); err == nil {
+		return resolved
+	}
+	dir, file := filepath.Split(p)
+	dir = filepath.Clean(dir)
+	if dir == p { // reached the filesystem root; nothing left to resolve
+		return p
+	}
+	return filepath.Join(resolveExistingAncestor(dir), file)
 }
 
 // SafeReadFile reads a file at filepath.Join(baseDir, filePath), validating

--- a/internal/securefiles/securefiles.go
+++ b/internal/securefiles/securefiles.go
@@ -164,13 +164,15 @@ func FixFilePerms(files []FilePermSpec, autofix bool) error {
 	}
 	currentUID, _ := strconv.Atoi(currentUser.Uid)
 
-	hasWarnings := false
+	hasWarnings := false // a mismatch was found (fixed or not)
+	unresolved := false  // a problem REMAINS — stat/chmod/chown failed, so autofix didn't help
 
 	for _, f := range files {
 		info, err := os.Stat(f.Path)
 		if err != nil {
 			fmt.Printf("[WARN] Cannot stat file %s: %v\n", f.Path, err)
 			hasWarnings = true
+			unresolved = true
 			continue
 		}
 
@@ -178,16 +180,16 @@ func FixFilePerms(files []FilePermSpec, autofix bool) error {
 		actualMode := info.Mode().Perm()
 		if actualMode != f.Mode {
 			msg := fmt.Sprintf("File %s has mode %o but expected %o", f.Path, actualMode, f.Mode)
+			hasWarnings = true
 			if autofix {
 				if err := os.Chmod(f.Path, f.Mode); err != nil {
 					fmt.Printf("[ERROR] Failed to chmod %s: %v\n", f.Path, err)
-					hasWarnings = true
+					unresolved = true
 				} else {
 					fmt.Printf("[FIXED] %s\n", msg)
 				}
 			} else {
 				fmt.Printf("[WARN] %s\n", msg)
-				hasWarnings = true
 			}
 		}
 
@@ -196,28 +198,33 @@ func FixFilePerms(files []FilePermSpec, autofix bool) error {
 		if !ok {
 			fmt.Printf("[WARN] Cannot get stat_t for %s\n", f.Path)
 			hasWarnings = true
+			unresolved = true
 			continue
 		}
 
 		fileUID := int(stat.Uid)
 		if fileUID != currentUID {
 			msg := fmt.Sprintf("File %s is owned by uid %d, expected uid %d", f.Path, fileUID, currentUID)
+			hasWarnings = true
 			if autofix {
 				if err := os.Chown(f.Path, currentUID, int(stat.Gid)); err != nil {
 					fmt.Printf("[ERROR] Failed to chown %s: %v\n", f.Path, err)
-					hasWarnings = true
+					unresolved = true
 				} else {
 					fmt.Printf("[FIXED] %s\n", msg)
 				}
 			} else {
 				fmt.Printf("[WARN] %s\n", msg)
-				hasWarnings = true
 			}
 		}
 	}
 
-	if hasWarnings && !autofix {
-		return fmt.Errorf("permissions or ownership audit found warnings")
+	// Fail closed when a problem remains: either autofix was off and a mismatch exists,
+	// or autofix was on but a chmod/chown/stat FAILED (so the insecure state persists).
+	// The previous `hasWarnings && !autofix` form silently returned nil when autofix
+	// couldn't actually lock a world-readable key file down.
+	if unresolved || (hasWarnings && !autofix) {
+		return fmt.Errorf("permissions or ownership audit found unresolved issues")
 	}
 
 	return nil

--- a/internal/securefiles/securefiles.go
+++ b/internal/securefiles/securefiles.go
@@ -103,7 +103,19 @@ func SecureWriteFile(baseDir, path string, data []byte, perm os.FileMode) error 
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(cleanPath, data, perm)
+	// O_NOFOLLOW refuses to write THROUGH a final-component symlink. The containment
+	// check resolves EXISTING symlinks, but a DANGLING final symlink (its target not yet
+	// existing) slips past it — os.WriteFile would then follow it and create a file
+	// outside baseDir. With O_NOFOLLOW the open fails (ELOOP) instead of following it.
+	f, err := os.OpenFile(cleanPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC|syscall.O_NOFOLLOW, perm) // #nosec G304 -- cleanPath validated inside baseDir by resolveInside
+	if err != nil {
+		return err
+	}
+	if _, werr := f.Write(data); werr != nil {
+		_ = f.Close()
+		return werr
+	}
+	return f.Close()
 }
 
 // SecureWriteFileSync writes data like SecureWriteFile but fsyncs the file before
@@ -118,7 +130,7 @@ func SecureWriteFileSync(baseDir, path string, data []byte, perm os.FileMode) er
 	if err != nil {
 		return err
 	}
-	f, err := os.OpenFile(cleanPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, perm) // #nosec G304 -- cleanPath validated inside baseDir by resolveInside
+	f, err := os.OpenFile(cleanPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC|syscall.O_NOFOLLOW, perm) // #nosec G304 -- cleanPath validated inside baseDir by resolveInside; O_NOFOLLOW refuses a final-component symlink
 	if err != nil {
 		return err
 	}
@@ -168,9 +180,19 @@ func FixFilePerms(files []FilePermSpec, autofix bool) error {
 	unresolved := false  // a problem REMAINS — stat/chmod/chown failed, so autofix didn't help
 
 	for _, f := range files {
-		info, err := os.Stat(f.Path)
+		// Lstat (not Stat) so a symlink is detected rather than dereferenced: os.Chmod /
+		// os.Chown FOLLOW symlinks, so a symlink planted in the key directory would
+		// otherwise redirect the perm/owner fix to an arbitrary target (an arbitrary chown
+		// when running as root). Refuse to "fix" a symlinked path.
+		info, err := os.Lstat(f.Path)
 		if err != nil {
 			fmt.Printf("[WARN] Cannot stat file %s: %v\n", f.Path, err)
+			hasWarnings = true
+			unresolved = true
+			continue
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			fmt.Printf("[WARN] Refusing to fix %s: it is a symlink (won't follow it to an arbitrary target)\n", f.Path)
 			hasWarnings = true
 			unresolved = true
 			continue

--- a/internal/securefiles/securefiles_test.go
+++ b/internal/securefiles/securefiles_test.go
@@ -85,6 +85,42 @@ func TestSecureWriteFileSyncRejectsTraversal(t *testing.T) {
 	assert.True(t, os.IsNotExist(statErr))
 }
 
+// A DANGLING final-component symlink inside the base must not be followed: the write
+// must fail (O_NOFOLLOW) rather than create the symlink's target outside the base.
+func TestSecureWriteRefusesDanglingSymlink(t *testing.T) {
+	base := t.TempDir()
+	outside := filepath.Join(filepath.Dir(base), "escape.key")
+	// A symlink "link.key" inside base pointing at a not-yet-existing file outside base.
+	require.NoError(t, os.Symlink(outside, filepath.Join(base, "link.key")))
+
+	err := SecureWriteFile(base, "link.key", []byte("secret"), 0600)
+	require.Error(t, err, "writing through a final-component symlink must be refused")
+	_, statErr := os.Stat(outside)
+	assert.True(t, os.IsNotExist(statErr), "the symlink target outside base must not have been created")
+
+	err = SecureWriteFileSync(base, "link.key", []byte("secret"), 0600)
+	require.Error(t, err)
+	_, statErr = os.Stat(outside)
+	assert.True(t, os.IsNotExist(statErr))
+}
+
+// FixFilePerms must refuse to follow a symlink — otherwise it would chmod/chown the
+// symlink's target (an arbitrary file when running as root).
+func TestFixFilePerms_RefusesSymlink(t *testing.T) {
+	base := t.TempDir()
+	target := filepath.Join(base, "real.txt")
+	require.NoError(t, os.WriteFile(target, []byte("x"), 0644))
+	link := filepath.Join(base, "link.key")
+	require.NoError(t, os.Symlink(target, link))
+
+	err := FixFilePerms([]FilePermSpec{{Path: link, Mode: 0600}}, true)
+	require.Error(t, err, "autofix must report an unresolved issue for a symlinked path")
+	// The target's mode must be untouched (the symlink was not followed).
+	info, statErr := os.Stat(target)
+	require.NoError(t, statErr)
+	assert.Equal(t, os.FileMode(0644), info.Mode().Perm(), "the symlink target's mode must be unchanged")
+}
+
 func TestSyncDir(t *testing.T) {
 	base := t.TempDir()
 	// A real directory syncs without error.

--- a/internal/securefiles/securefiles_test.go
+++ b/internal/securefiles/securefiles_test.go
@@ -153,3 +153,28 @@ func TestFixFilePermsMissingFileWarns(t *testing.T) {
 	err := FixFilePerms([]FilePermSpec{{Path: filepath.Join(t.TempDir(), "absent"), Mode: 0600}}, false)
 	require.Error(t, err)
 }
+
+// TestContainmentRejectsSymlinkEscape pins the symlink-containment fix: a symlink
+// planted inside baseDir that points outside it must not let a read or write escape.
+func TestContainmentRejectsSymlinkEscape(t *testing.T) {
+	base := t.TempDir()
+	outside := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(outside, "secret.txt"), []byte("top secret"), 0o600))
+
+	// A symlink inside baseDir that resolves to the outside directory.
+	require.NoError(t, os.Symlink(outside, filepath.Join(base, "link")))
+
+	// Reading through the symlink must be denied (the resolved path is outside base).
+	_, err := SafeReadFile(base, "link/secret.txt")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "outside")
+
+	// Writing through the symlink (target does not exist yet) must also be denied.
+	err = SecureWriteFile(base, "link/planted.txt", []byte("x"), 0o600)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "outside")
+
+	// The outside directory must be untouched by the rejected write.
+	_, statErr := os.Stat(filepath.Join(outside, "planted.txt"))
+	assert.True(t, os.IsNotExist(statErr), "rejected write must not create a file outside base")
+}

--- a/internal/securefiles/securefiles_test.go
+++ b/internal/securefiles/securefiles_test.go
@@ -128,6 +128,16 @@ func TestFixFilePermsAuditReportsWrongMode(t *testing.T) {
 	assert.Equal(t, os.FileMode(0644), info.Mode().Perm(), "audit must not modify the file")
 }
 
+// Fail closed: when autofix is on but the fix can't actually be applied (here, the file
+// doesn't exist so stat fails), FixFilePerms must return an error rather than silently
+// reporting success — the previous `hasWarnings && !autofix` form returned nil, hiding an
+// unlocked-down key file.
+func TestFixFilePermsAutofixFailsClosedOnUnresolvable(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "nope.key")
+	err := FixFilePerms([]FilePermSpec{{Path: missing, Mode: 0600}}, true)
+	require.Error(t, err, "an unresolvable problem must fail even under autofix")
+}
+
 func TestFixFilePermsAutofixCorrectsMode(t *testing.T) {
 	dir := t.TempDir()
 	p := filepath.Join(dir, "loose.key")

--- a/internal/startup/validation.go
+++ b/internal/startup/validation.go
@@ -44,7 +44,7 @@ func ValidateStartup(configPath string) (*ValidationResult, error) {
 	result.ConfigValid = true
 
 	if cfg.Security.EnableFilePermissionCheck {
-		if err := validateFilePermissions(cfg, result); err != nil {
+		if err := validateFilePermissions(cfg, configPath, result); err != nil {
 			if !cfg.Security.AllowUnsafeFilePermissions {
 				return result, fmt.Errorf("file permission validation failed: %w", err)
 			}
@@ -77,13 +77,15 @@ func ValidateStartup(configPath string) (*ValidationResult, error) {
 	return result, nil
 }
 
-func validateFilePermissions(cfg *config.Config, result *ValidationResult) error {
+func validateFilePermissions(cfg *config.Config, configPath string, result *ValidationResult) error {
 	var files []securefiles.FilePermSpec
 
-	files = append(files, securefiles.FilePermSpec{
-		Path: filepath.Clean("keyorix.yaml"),
-		Mode: 0600,
-	})
+	// Check the config file that was actually loaded, not a hardcoded "keyorix.yaml":
+	// the loader resolves KEYORIX_CONFIG_PATH / an absolute path, so a fixed relative
+	// name would silently stat a non-existent file and pass. Skip only when truly unknown.
+	if cfgFile := strings.TrimSpace(configPath); cfgFile != "" {
+		files = append(files, securefiles.FilePermSpec{Path: filepath.Clean(cfgFile), Mode: 0600})
+	}
 
 	if cfg.Storage.Encryption.Enabled {
 		// The KEK is passphrase-derived and never on disk (ADR-004); the salt and

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -14,6 +14,11 @@ import (
 	"gorm.io/gorm"
 )
 
+// defaultMaxOpenConns bounds the DB connection pool when the operator hasn't set
+// max_open_conns — Go's own default is unlimited, which lets a request flood exhaust the
+// backing database's connection limit. A conservative cap is safer out of the box.
+const defaultMaxOpenConns = 25
+
 // StorageFactory creates storage instances based on configuration
 type StorageFactory interface {
 	CreateStorage(config *config.Config) (storage.Storage, error)
@@ -91,8 +96,13 @@ func applyPoolSettings(db *gorm.DB, dbCfg *config.DatabaseConfig) error {
 	if err != nil {
 		return fmt.Errorf("failed to get underlying sql.DB: %w", err)
 	}
+	// Always cap open connections. Go's default is UNLIMITED, so without a cap a flood of
+	// concurrent requests (even unauthenticated ones like /readyz, which pings the DB) can
+	// open connections without bound and exhaust the backing database's max_connections.
 	if dbCfg.MaxOpenConns > 0 {
 		sqlDB.SetMaxOpenConns(dbCfg.MaxOpenConns)
+	} else {
+		sqlDB.SetMaxOpenConns(defaultMaxOpenConns)
 	}
 	if dbCfg.MaxIdleConns > 0 {
 		sqlDB.SetMaxIdleConns(dbCfg.MaxIdleConns)

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -611,6 +611,15 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 		}
 	}
 
+	// Swap the plain unique index on users.username for a partial one (live rows only),
+	// so a SCIM-deprovisioned username can be re-provisioned. Additive + idempotent; the
+	// full AutoMigrate below covers fresh DBs.
+	if tableExists(db, "users") {
+		if err := ensureUserNameIndex(db); err != nil {
+			return err
+		}
+	}
+
 	// Skip full AutoMigrate if already initialised (projects table present).
 	if projectsExists {
 		return nil
@@ -660,9 +669,13 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 	); err != nil {
 		return err
 	}
-	// The Group model carries no plain unique tag on name; enforce uniqueness only
-	// among live groups via a partial index (so a soft-deleted name can be reused).
-	return ensureGroupNameIndex(db)
+	// The Group and User models carry no plain unique tag on name/username; enforce
+	// uniqueness only among live rows via partial indexes (so a soft-deleted name or
+	// username can be reused, e.g. on SCIM re-provisioning).
+	if err := ensureGroupNameIndex(db); err != nil {
+		return err
+	}
+	return ensureUserNameIndex(db)
 }
 
 // ensureGroupNameIndex replaces any plain unique index on groups.name with a
@@ -676,6 +689,25 @@ func ensureGroupNameIndex(db *gorm.DB) error {
 	}
 	if err := db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS uniq_groups_name_active ON groups (name) WHERE deleted_at IS NULL").Error; err != nil {
 		return fmt.Errorf("failed to create partial groups name index: %w", err)
+	}
+	return nil
+}
+
+// ensureUserNameIndex replaces the plain unique index on users.username (from the old
+// `uniqueIndex` tag) with a partial unique index scoped to non-deleted rows. Without
+// this a SCIM-deprovisioned (soft-deleted) user keeps occupying the username in the
+// unique index, so re-provisioning the same userName collides on INSERT and the IdP's
+// provisioning run errors indefinitely. Idempotent; works on SQLite and Postgres.
+func ensureUserNameIndex(db *gorm.DB) error {
+	// Drop the legacy plain unique index. GORM's `uniqueIndex` tag names it
+	// idx_users_username; the older `unique` tag would be uni_users_username. Drop both.
+	for _, idx := range []string{"idx_users_username", "uni_users_username"} {
+		if err := db.Exec("DROP INDEX IF EXISTS " + idx).Error; err != nil {
+			return fmt.Errorf("failed to drop legacy users username index %q: %w", idx, err)
+		}
+	}
+	if err := db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS uniq_users_username_active ON users (username) WHERE deleted_at IS NULL").Error; err != nil {
+		return fmt.Errorf("failed to create partial users username index: %w", err)
 	}
 	return nil
 }

--- a/internal/storage/factory_username_index_test.go
+++ b/internal/storage/factory_username_index_test.go
@@ -1,0 +1,43 @@
+package storage
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A soft-deleted (e.g. SCIM-deprovisioned) username must be reusable — the partial
+// unique index scopes uniqueness to live rows, so re-provisioning the same userName
+// no longer collides on INSERT. Two LIVE users with the same username must still fail.
+func TestUsernamePartialUniqueIndex_ReuseAfterSoftDelete(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	cfg := &config.Config{}
+	cfg.Storage.Type = "local"
+	cfg.Storage.Database.Path = filepath.Join(t.TempDir(), "username-index.db")
+
+	st, err := NewStorageFactory().CreateStorage(cfg)
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	// Provision "alice".
+	alice, err := st.CreateUser(ctx, &models.User{Username: "alice", Email: "alice@x.io", IsActive: true})
+	require.NoError(t, err)
+
+	// A second LIVE "alice" is rejected (live uniqueness still holds).
+	_, err = st.CreateUser(ctx, &models.User{Username: "alice", Email: "alice2@x.io", IsActive: true})
+	require.Error(t, err, "two live users may not share a username")
+
+	// Deprovision alice (soft delete), then re-provision the same userName — must succeed.
+	require.NoError(t, st.DeleteUser(ctx, alice.ID))
+	reAlice, err := st.CreateUser(ctx, &models.User{Username: "alice", Email: "alice@x.io", IsActive: true})
+	require.NoError(t, err, "a soft-deleted username must be reusable on re-provisioning")
+	assert.NotEqual(t, alice.ID, reAlice.ID, "re-provisioning creates a fresh row")
+}

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -225,7 +225,7 @@ type User struct {
 	Username     string `gorm:"uniqueIndex;not null"`
 	Email        string
 	DisplayName  string
-	PasswordHash string `json:"-"`
+	PasswordHash string     `json:"-"`
 	IsActive     bool       `gorm:"default:true"`
 	LastLoginAt  *time.Time // stamped on each successful auth.login; nil = never logged in
 	// PasswordChangedAt is when the current password was set. Drives max-age
@@ -268,7 +268,11 @@ type MFASecret struct {
 	SecretEnc  []byte `json:"-"` // encrypted TOTP secret (passthrough plaintext when encryption is disabled)
 	SecretMeta []byte `json:"-"` // encryption metadata (key version etc.)
 	Activated  bool   `gorm:"default:false"`
-	CreatedAt  time.Time
+	// LastUsedStep is the TOTP time-step (unix/period) of the most recently accepted
+	// login code. A code at or below it is a replay within its validity window and is
+	// rejected (anti-replay). nil on legacy rows = no code accepted yet.
+	LastUsedStep *int64 `json:"-"`
+	CreatedAt    time.Time
 }
 
 // MFARecoveryCode is a single-use backup code (SHA-256 hashed). UsedAt is stamped
@@ -338,8 +342,8 @@ type WebAuthnSession struct {
 // forbid reuse of the last N passwords (ADR-025 history_count). Only bcrypt
 // hashes are stored — never plaintext.
 type PasswordHistory struct {
-	ID           uint `gorm:"primaryKey"`
-	UserID       uint `gorm:"index"`
+	ID           uint   `gorm:"primaryKey"`
+	UserID       uint   `gorm:"index"`
 	PasswordHash string `json:"-"`
 	CreatedAt    time.Time
 }
@@ -587,9 +591,9 @@ type SecretMetadataHistory struct {
 type Session struct {
 	ID                    uint `gorm:"primaryKey"`
 	UserID                uint
-	SessionToken          string `gorm:"unique" json:"-"` // SHA-256 hash of the session token (never plaintext)
-	EncryptedSessionToken []byte `json:"-"`
-	SessionTokenMetadata  JSON   `json:"-"`
+	SessionToken          string     `gorm:"unique" json:"-"` // SHA-256 hash of the session token (never plaintext)
+	EncryptedSessionToken []byte     `json:"-"`
+	SessionTokenMetadata  JSON       `json:"-"`
 	UserAgent             string     // captured at login, for the My Account "active sessions" view
 	IPAddress             string     // captured at login
 	LastSeenAt            *time.Time // throttled — updated at most once per validTokenTTL on the auth slow path
@@ -830,7 +834,7 @@ type APIToken struct {
 	ClientID       uint
 	UserID         *uint
 	Token          string `gorm:"unique" json:"-"` // SHA-256 hash of the token (never plaintext); the token is shown once at creation
-	EncryptedToken []byte `json:"-"` // legacy/unused encrypt-at-rest column; creation now hashes into Token
+	EncryptedToken []byte `json:"-"`               // legacy/unused encrypt-at-rest column; creation now hashes into Token
 	TokenMetadata  JSON   `json:"-"`
 	Scope          string
 	Revoked        bool

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -221,8 +221,12 @@ type AccessReviewItem struct {
 }
 
 type User struct {
-	ID           uint   `gorm:"primaryKey"`
-	Username     string `gorm:"uniqueIndex;not null"`
+	ID uint `gorm:"primaryKey"`
+	// Username uniqueness is enforced by a PARTIAL unique index (username WHERE
+	// deleted_at IS NULL), created in migrateDatabase — not the plain `uniqueIndex`
+	// tag — so a soft-deleted (e.g. SCIM-deprovisioned) user's username is freed for
+	// reuse on re-provisioning while the old row stays restorable for audit.
+	Username     string `gorm:"not null"`
 	Email        string
 	DisplayName  string
 	PasswordHash string     `json:"-"`

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -306,9 +306,13 @@ type MFAChallenge struct {
 // the limit holds in HA. Rows past the window are pruned by a maintenance sweep
 // and are never read after that. The composite index serves the windowed count.
 type LoginAttempt struct {
-	ID          uint      `gorm:"primaryKey"`
-	IP          string    `gorm:"index:idx_login_attempt_ip_time,priority:1"`
-	AttemptedAt time.Time `gorm:"index:idx_login_attempt_ip_time,priority:2"`
+	ID uint   `gorm:"primaryKey"`
+	IP string `gorm:"index:idx_login_attempt_ip_time,priority:1"`
+	// AttemptedAt carries two indexes: the composite (ip, attempted_at) serves the
+	// per-IP windowed count, and a standalone index serves the prune's
+	// `WHERE attempted_at < ?` (the composite's leading ip column can't), keeping the
+	// hourly cleanup an index range delete rather than a full-table scan.
+	AttemptedAt time.Time `gorm:"index:idx_login_attempt_ip_time,priority:2;index:idx_login_attempt_time"`
 }
 
 // WebAuthnCredential is a registered passkey / FIDO2 authenticator (ADR-036).

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -538,6 +538,10 @@ type DynamicSecretConfig struct {
 	// MaxTTLSeconds caps the lifetime of any lease from this config (issue + all
 	// renewals), regardless of the TTL a caller requests. 0 = no ceiling.
 	MaxTTLSeconds int
+	// MaxActiveLeases caps how many leases from this config may be active at once, so a
+	// caller can't mint unbounded real DB roles/users (resource exhaustion on the target).
+	// 0 = no ceiling.
+	MaxActiveLeases int
 	// Classification is the data-sensitivity label of the credentials this config
 	// mints (ISO 27001 A.5.12/A.5.13): "" = unclassified, else one of
 	// public|internal|confidential|restricted. Folds into the classification posture

--- a/internal/storage/remote/client.go
+++ b/internal/storage/remote/client.go
@@ -13,6 +13,9 @@ import (
 	"time"
 )
 
+// maxResponseBytes caps a single API response body to bound client memory use.
+const maxResponseBytes = 64 << 20 // 64 MiB
+
 // cacheEntry represents a cached response
 type cacheEntry struct {
 	response  *APIResponse
@@ -44,9 +47,17 @@ func NewHTTPClient(config *Config) (*HTTPClient, error) {
 		return nil, fmt.Errorf("invalid config: %w", err)
 	}
 
-	// Create HTTP client with timeout
+	// Create HTTP client with timeout. Refuse a redirect to a different host so a
+	// compromised/misbehaving server can't bounce the token-bearing request elsewhere
+	// (Go already strips the Authorization header cross-host, but don't follow at all).
 	httpClient := &http.Client{
 		Timeout: config.GetTimeout(),
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) > 0 && req.URL.Host != via[0].URL.Host {
+				return fmt.Errorf("remote: refusing redirect to a different host %q", req.URL.Host)
+			}
+			return nil
+		},
 	}
 
 	// Configure TLS if needed
@@ -181,7 +192,8 @@ func (c *HTTPClient) makeRequest(ctx context.Context, method, path string, body 
 	}
 	defer resp.Body.Close() //nolint:errcheck
 
-	respBody, err := io.ReadAll(resp.Body)
+	// Bound the response so a malicious/MITM server can't OOM the client.
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response body: %w", err)
 	}

--- a/internal/storage/remote/config.go
+++ b/internal/storage/remote/config.go
@@ -2,6 +2,8 @@ package remote
 
 import (
 	"fmt"
+	"net"
+	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -30,6 +32,17 @@ func (c *Config) Validate() error {
 	c.APIKey = expandEnvVars(c.APIKey)
 	c.BaseURL = expandEnvVars(c.BaseURL)
 
+	// The API key is sent as a bearer token on every request, so refuse a cleartext
+	// base URL — it would leak the token in transit. Allow http only for a loopback
+	// target (local dev).
+	u, perr := url.Parse(c.BaseURL)
+	if perr != nil {
+		return fmt.Errorf("invalid base_url %q: %w", c.BaseURL, perr)
+	}
+	if u.Scheme != "https" && !isLoopbackHost(u.Hostname()) {
+		return fmt.Errorf("base_url must use https (got scheme %q) so the API key is not sent in cleartext", u.Scheme)
+	}
+
 	// Set defaults
 	if c.TimeoutSeconds <= 0 {
 		c.TimeoutSeconds = 30
@@ -45,6 +58,17 @@ func (c *Config) Validate() error {
 // GetTimeout returns the timeout duration
 func (c *Config) GetTimeout() time.Duration {
 	return time.Duration(c.TimeoutSeconds) * time.Second
+}
+
+// isLoopbackHost reports whether host is localhost or a loopback IP.
+func isLoopbackHost(host string) bool {
+	if host == "localhost" {
+		return true
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return ip.IsLoopback()
+	}
+	return false
 }
 
 // expandEnvVars expands environment variables in the format ${VAR_NAME}

--- a/internal/storage/remote/config_https_test.go
+++ b/internal/storage/remote/config_https_test.go
@@ -1,0 +1,16 @@
+package remote
+
+import "testing"
+
+// TestConfig_Validate_RequiresHTTPS pins that the bearer-token-bearing base URL must
+// be https (loopback http allowed for dev).
+func TestConfig_Validate_RequiresHTTPS(t *testing.T) {
+	if err := (&Config{BaseURL: "http://siem.example.com", APIKey: "k"}).Validate(); err == nil {
+		t.Fatal("cleartext http base_url must be rejected")
+	}
+	for _, u := range []string{"https://x.example.com", "http://localhost:8080", "http://127.0.0.1:9000"} {
+		if err := (&Config{BaseURL: u, APIKey: "k"}).Validate(); err != nil {
+			t.Fatalf("%s should be allowed: %v", u, err)
+		}
+	}
+}

--- a/internal/storage/store/group_softdelete_test.go
+++ b/internal/storage/store/group_softdelete_test.go
@@ -1,0 +1,71 @@
+package store
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// TestGroupShare_SoftDeletedMemberExcluded pins that a soft-deleted user no longer
+// inherits group shares and no longer appears as a group member.
+func TestGroupShare_SoftDeletedMemberExcluded(t *testing.T) {
+	ctx := context.Background()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.User{}, &models.Group{}, &models.UserGroup{},
+		&models.ShareRecord{}, &models.SecretNode{},
+	))
+	ls := NewLocalStorage(db)
+
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "alive", Email: "a@x.io"}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 2, Username: "gone", Email: "g@x.io"}).Error)
+	require.NoError(t, db.Create(&models.Group{ID: 10, Name: "team"}).Error)
+	require.NoError(t, db.Create(&models.UserGroup{UserID: 1, GroupID: 10}).Error)
+	require.NoError(t, db.Create(&models.UserGroup{UserID: 2, GroupID: 10}).Error)
+	require.NoError(t, db.Create(&models.SecretNode{
+		ID: 100, Name: "s", ProjectID: 1, EnvironmentID: 1, OwnerID: 9, Status: "active", Type: "password",
+	}).Error)
+	// Share the secret with the group.
+	require.NoError(t, db.Create(&models.ShareRecord{
+		SecretID: 100, RecipientID: 10, IsGroup: true, Permission: "read",
+	}).Error)
+
+	// Both members see the group share and have permission.
+	for _, uid := range []uint{1, 2} {
+		secrets, lerr := ls.ListSharedSecrets(ctx, uid)
+		require.NoError(t, lerr)
+		assert.Len(t, secrets, 1, "user %d should see the group share", uid)
+		perm, perr := ls.CheckSharePermission(ctx, 100, uid)
+		require.NoError(t, perr)
+		assert.Equal(t, "read", perm, "user %d permission", uid)
+	}
+	members, merr := ls.ListGroupMembers(ctx, 10)
+	require.NoError(t, merr)
+	assert.Len(t, members, 2)
+
+	// Soft-delete user 2.
+	require.NoError(t, db.Delete(&models.User{}, 2).Error)
+
+	// User 2 no longer inherits the group share, has no permission, and is not listed.
+	secrets, lerr := ls.ListSharedSecrets(ctx, 2)
+	require.NoError(t, lerr)
+	assert.Empty(t, secrets, "a soft-deleted user must not inherit group shares")
+	perm, perr := ls.CheckSharePermission(ctx, 100, 2)
+	require.Error(t, perr, "a soft-deleted user must have no group-share permission")
+	assert.Equal(t, "", perm)
+	members, merr = ls.ListGroupMembers(ctx, 10)
+	require.NoError(t, merr)
+	require.Len(t, members, 1, "a soft-deleted user must not appear in the member list")
+	assert.Equal(t, uint(1), members[0].ID)
+
+	// The live member is unaffected.
+	secrets, lerr = ls.ListSharedSecrets(ctx, 1)
+	require.NoError(t, lerr)
+	assert.Len(t, secrets, 1)
+}

--- a/internal/storage/store/list_project_members_test.go
+++ b/internal/storage/store/list_project_members_test.go
@@ -1,0 +1,48 @@
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// An EXPIRED (but not-yet-swept) time-bound grant must NOT appear as a project member —
+// otherwise a lapsed break-glass admin keeps receiving approver notifications after authz
+// has already cut off their access. Live and never-expiring grants still appear.
+func TestListProjectMembers_ExcludesExpiredGrants(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.User{}, &models.Role{}, &models.UserRole{}))
+	ls := NewLocalStorage(db)
+	ctx := context.Background()
+
+	const proj = uint(2)
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "alice"}).Error) // permanent admin
+	require.NoError(t, db.Create(&models.User{ID: 2, Username: "bob"}).Error)   // live break-glass
+	require.NoError(t, db.Create(&models.User{ID: 3, Username: "carol"}).Error) // EXPIRED break-glass
+	require.NoError(t, db.Create(&models.Role{ID: 9, Name: "project_admin"}).Error)
+
+	future := time.Now().Add(time.Hour)
+	past := time.Now().Add(-time.Hour)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 9, ProjectID: proj}).Error)                     // no expiry
+	require.NoError(t, db.Create(&models.UserRole{UserID: 2, RoleID: 9, ProjectID: proj, ExpiresAt: &future}).Error) // live
+	require.NoError(t, db.Create(&models.UserRole{UserID: 3, RoleID: 9, ProjectID: proj, ExpiresAt: &past}).Error)   // expired
+
+	members, err := ls.ListProjectMembers(ctx, proj)
+	require.NoError(t, err)
+	got := map[string]bool{}
+	for _, m := range members {
+		got[m.Username] = true
+	}
+	assert.True(t, got["alice"], "a permanent grant is a member")
+	assert.True(t, got["bob"], "a live time-bound grant is a member")
+	assert.False(t, got["carol"], "an expired (unswept) grant must NOT be a member")
+}

--- a/internal/storage/store/local_audit.go
+++ b/internal/storage/store/local_audit.go
@@ -309,7 +309,14 @@ func (ls *LocalStorage) ListAnomalyAlerts(ctx context.Context, acknowledged *boo
 }
 
 func (ls *LocalStorage) AcknowledgeAnomalyAlert(ctx context.Context, id uint) error {
-	return ls.db.WithContext(ctx).Model(&models.AnomalyAlert{}).Where("id = ?", id).Update("acknowledged", true).Error
+	res := ls.db.WithContext(ctx).Model(&models.AnomalyAlert{}).Where("id = ?", id).Update("acknowledged", true)
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return fmt.Errorf("anomaly alert not found")
+	}
+	return nil
 }
 
 func (ls *LocalStorage) ListUnalertedAnomalyAlerts(ctx context.Context) ([]models.AnomalyAlert, error) {

--- a/internal/storage/store/local_auth.go
+++ b/internal/storage/store/local_auth.go
@@ -121,6 +121,18 @@ func (ls *LocalStorage) DeleteSessionsForUserExcept(ctx context.Context, userID,
 	return nil
 }
 
+// ListSessionTokenHashesForUser returns the stored session_token hashes for every session
+// the user owns or is impersonated through, for auth-cache eviction on a state change.
+func (ls *LocalStorage) ListSessionTokenHashesForUser(ctx context.Context, userID uint) ([]string, error) {
+	var hashes []string
+	if err := ls.db.WithContext(ctx).Model(&models.Session{}).
+		Where("user_id = ? OR impersonated_by = ?", userID, userID).
+		Pluck("session_token", &hashes).Error; err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	return hashes, nil
+}
+
 // TouchSession bumps last_seen_at only if the stored value is older than staleness
 // (or NULL), keeping the auth hot path from writing on every request.
 func (ls *LocalStorage) TouchSession(ctx context.Context, id uint, seenAt time.Time, staleness time.Duration) error {

--- a/internal/storage/store/local_auth.go
+++ b/internal/storage/store/local_auth.go
@@ -82,6 +82,30 @@ func (ls *LocalStorage) DeleteSession(ctx context.Context, id uint) error {
 	return nil
 }
 
+// EnforceSessionLimit keeps only the `keep` most-recent sessions for a user and deletes
+// the rest, so unbounded logins can't grow the table or enlarge the credential-theft
+// blast radius. No-op when the user is at or under the cap.
+func (ls *LocalStorage) EnforceSessionLimit(ctx context.Context, userID uint, keep int) error {
+	if keep <= 0 {
+		return nil
+	}
+	var keepIDs []uint
+	if err := ls.db.WithContext(ctx).Model(&models.Session{}).
+		Where("user_id = ?", userID).
+		Order("created_at DESC").Limit(keep).Pluck("id", &keepIDs).Error; err != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	if len(keepIDs) < keep {
+		return nil // under the cap — nothing to prune
+	}
+	if err := ls.db.WithContext(ctx).
+		Where("user_id = ? AND id NOT IN ?", userID, keepIDs).
+		Delete(&models.Session{}).Error; err != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	return nil
+}
+
 // DeleteSessionsForUserExcept removes all of the user's sessions except exceptID.
 // It also removes impersonation sessions the user STARTED (impersonated_by = userID):
 // an impersonation session is keyed to the target's user_id, so without this clause a

--- a/internal/storage/store/local_auth.go
+++ b/internal/storage/store/local_auth.go
@@ -291,6 +291,29 @@ func (ls *LocalStorage) RevokePersonalAccessToken(ctx context.Context, id uint) 
 	return nil
 }
 
+// RevokeAllPersonalAccessTokensForUser revokes every not-already-revoked PAT belonging to
+// the user and returns the revoked tokens' hashes so the caller can evict them from the
+// auth cache immediately. Used on a password change/reset: a PAT is a parallel, longer-
+// lived credential that must die with the password, or a thief who minted one from a
+// stolen session would survive the reset.
+func (ls *LocalStorage) RevokeAllPersonalAccessTokensForUser(ctx context.Context, userID uint) ([]string, error) {
+	var hashes []string
+	if err := ls.db.WithContext(ctx).Model(&models.PersonalAccessToken{}).
+		Where("user_id = ? AND revoked = ?", userID, false).
+		Pluck("token_hash", &hashes).Error; err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	if len(hashes) == 0 {
+		return nil, nil
+	}
+	if err := ls.db.WithContext(ctx).Model(&models.PersonalAccessToken{}).
+		Where("user_id = ? AND revoked = ?", userID, false).
+		Update("revoked", true).Error; err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	return hashes, nil
+}
+
 // TouchPersonalAccessToken bumps last_used_at only when older than staleness (or NULL),
 // keeping the auth hot path from writing on every request (mirrors TouchSession).
 func (ls *LocalStorage) TouchPersonalAccessToken(ctx context.Context, id uint, usedAt time.Time, staleness time.Duration) error {

--- a/internal/storage/store/local_dynamic.go
+++ b/internal/storage/store/local_dynamic.go
@@ -81,12 +81,15 @@ func (ls *LocalStorage) CountActiveLeases(ctx context.Context, configID uint) (i
 	return n, err
 }
 
-// ListExpiredActiveLeases returns active leases whose ExpiresAt is past `before`,
-// ordered by id (stable) for the revoke sweep.
+// ListExpiredActiveLeases returns leases whose ExpiresAt is past `before` that still need
+// their target credential dropped — active leases AND revoke_failed ones (whose earlier
+// revoke failed, so their credential is still live). Ordered by id (stable) for the sweep.
+// Without the revoke_failed inclusion such a credential would stay live past TTL forever,
+// excluded from both the sweep and a manual retry.
 func (ls *LocalStorage) ListExpiredActiveLeases(ctx context.Context, before time.Time) ([]*models.DynamicSecretLease, error) {
 	var leases []*models.DynamicSecretLease
 	if err := ls.db.WithContext(ctx).
-		Where("status = ? AND expires_at < ?", "active", before).
+		Where("status IN ? AND expires_at < ?", []string{"active", "revoke_failed"}, before).
 		Order("id").Find(&leases).Error; err != nil {
 		return nil, err
 	}

--- a/internal/storage/store/local_dynamic.go
+++ b/internal/storage/store/local_dynamic.go
@@ -73,6 +73,14 @@ func (ls *LocalStorage) UpdateDynamicSecretLease(ctx context.Context, l *models.
 	return ls.db.WithContext(ctx).Save(l).Error
 }
 
+// CountActiveLeases returns the number of active leases for a config.
+func (ls *LocalStorage) CountActiveLeases(ctx context.Context, configID uint) (int64, error) {
+	var n int64
+	err := ls.db.WithContext(ctx).Model(&models.DynamicSecretLease{}).
+		Where("config_id = ? AND status = ?", configID, "active").Count(&n).Error
+	return n, err
+}
+
 // ListExpiredActiveLeases returns active leases whose ExpiresAt is past `before`,
 // ordered by id (stable) for the revoke sweep.
 func (ls *LocalStorage) ListExpiredActiveLeases(ctx context.Context, before time.Time) ([]*models.DynamicSecretLease, error) {

--- a/internal/storage/store/local_machine_identities.go
+++ b/internal/storage/store/local_machine_identities.go
@@ -45,6 +45,16 @@ func (ls *LocalStorage) ListMachineIdentities(ctx context.Context, projectID uin
 	return rows, nil
 }
 
+// ListAllMachineIdentities returns every machine identity across all projects.
+func (ls *LocalStorage) ListAllMachineIdentities(ctx context.Context) ([]*models.MachineIdentity, error) {
+	var rows []*models.MachineIdentity
+	err := ls.db.WithContext(ctx).Order("created_at DESC").Find(&rows).Error
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	return rows, nil
+}
+
 func (ls *LocalStorage) CountMachineIdentitiesByClassification(ctx context.Context) (map[string]int, error) {
 	return countByClassification(ctx, ls.db, &models.MachineIdentity{})
 }

--- a/internal/storage/store/local_mfa.go
+++ b/internal/storage/store/local_mfa.go
@@ -33,6 +33,20 @@ func (ls *LocalStorage) ActivateMFASecret(ctx context.Context, userID uint) erro
 		Where("user_id = ?", userID).Update("activated", true).Error
 }
 
+// MarkTOTPStepUsed atomically advances the user's last-used TOTP step. The single
+// conditional UPDATE (guard in the WHERE clause + RowsAffected check) makes accept and
+// advance race-free: a code at or below the stored step matches zero rows and is
+// rejected as a replay.
+func (ls *LocalStorage) MarkTOTPStepUsed(ctx context.Context, userID uint, step int64) (bool, error) {
+	res := ls.db.WithContext(ctx).Model(&models.MFASecret{}).
+		Where("user_id = ? AND (last_used_step IS NULL OR last_used_step < ?)", userID, step).
+		Update("last_used_step", step)
+	if res.Error != nil {
+		return false, res.Error
+	}
+	return res.RowsAffected == 1, nil
+}
+
 // DeleteMFAForUser removes the secret and all recovery codes for a user.
 func (ls *LocalStorage) DeleteMFAForUser(ctx context.Context, userID uint) error {
 	return ls.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {

--- a/internal/storage/store/local_rbac.go
+++ b/internal/storage/store/local_rbac.go
@@ -224,9 +224,13 @@ func (ls *LocalStorage) GetUserRoleIDsExact(ctx context.Context, userID uint, sc
 	return ids, nil
 }
 
-// ListProjectMembers returns the users holding a role at the project's scope
-// (project_id = projectID, environment_id = 0 — project-level membership per
-// ADR-021). Soft-deleted users are excluded.
+// ListProjectMembers returns the users holding a LIVE role at the project's scope
+// (project_id = projectID, environment_id = 0 — project-level membership per ADR-021).
+// Soft-deleted users AND expired time-bound grants are excluded — the same expires_at
+// filter every authorization query applies, so a lapsed (but not-yet-swept) grant (e.g.
+// an expired break-glass project_admin) confers neither access NOR membership/notification
+// eligibility. Without it, sensitive approver notifications would keep reaching a user
+// whose grant has already lapsed.
 func (ls *LocalStorage) ListProjectMembers(ctx context.Context, projectID uint) ([]storage.ProjectMember, error) {
 	var members []storage.ProjectMember
 	err := ls.db.WithContext(ctx).Table("user_roles ur").
@@ -234,6 +238,7 @@ func (ls *LocalStorage) ListProjectMembers(ctx context.Context, projectID uint) 
 		Joins("JOIN users u ON u.id = ur.user_id").
 		Joins("JOIN roles r ON r.id = ur.role_id").
 		Where("ur.project_id = ? AND ur.environment_id = 0", projectID).
+		Where("ur.expires_at IS NULL OR ur.expires_at > ?", time.Now()).
 		Where("u.deleted_at IS NULL").
 		Order("u.username").
 		Scan(&members).Error

--- a/internal/storage/store/local_rbac.go
+++ b/internal/storage/store/local_rbac.go
@@ -224,6 +224,37 @@ func (ls *LocalStorage) GetUserRoleIDsExact(ctx context.Context, userID uint, sc
 	return ids, nil
 }
 
+// IsProjectMember reports whether the user holds a LIVE role grant scoped to the
+// project itself (project_id = projectID), directly or via a group. A global/install-
+// wide role (project_id = 0) does NOT count — break-glass and similar controls must
+// distinguish a project member from any user who merely holds the install baseline.
+func (ls *LocalStorage) IsProjectMember(ctx context.Context, userID, projectID uint) (bool, error) {
+	if projectID == 0 {
+		return false, nil
+	}
+	now := time.Now()
+	var direct int64
+	if err := ls.db.WithContext(ctx).Model(&models.UserRole{}).
+		Where("user_id = ? AND project_id = ?", userID, projectID).
+		Where("expires_at IS NULL OR expires_at > ?", now).
+		Count(&direct).Error; err != nil {
+		return false, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	if direct > 0 {
+		return true, nil
+	}
+	var viaGroup int64
+	if err := ls.db.WithContext(ctx).Table("group_roles").
+		Joins("JOIN user_groups ON user_groups.group_id = group_roles.group_id").
+		Joins("JOIN groups ON groups.id = group_roles.group_id AND groups.deleted_at IS NULL").
+		Where("user_groups.user_id = ? AND group_roles.project_id = ?", userID, projectID).
+		Where("group_roles.expires_at IS NULL OR group_roles.expires_at > ?", now).
+		Count(&viaGroup).Error; err != nil {
+		return false, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	return viaGroup > 0, nil
+}
+
 // ListProjectMembers returns the users holding a LIVE role at the project's scope
 // (project_id = projectID, environment_id = 0 — project-level membership per ADR-021).
 // Soft-deleted users AND expired time-bound grants are excluded — the same expires_at

--- a/internal/storage/store/local_secrets.go
+++ b/internal/storage/store/local_secrets.go
@@ -233,8 +233,15 @@ func (ls *LocalStorage) DeleteEnvironment(ctx context.Context, id uint) error {
 	return nil
 }
 
-// RestoreEnvironment clears deleted_at on a soft-deleted environment.
+// RestoreEnvironment clears deleted_at on a soft-deleted environment, but refuses to
+// restore one whose parent project is still soft-deleted — otherwise a holder of a
+// still-extant project-scoped grant (a soft-deleted project does NOT revoke its role
+// grants) could resurrect a usable, readable scope under a project an admin deleted to
+// revoke access. Mirrors the parent-liveness guard on CreateProjectEnvironment.
 func (ls *LocalStorage) RestoreEnvironment(ctx context.Context, projectID, id uint) error {
+	if err := ls.requireLiveProject(ctx, projectID); err != nil {
+		return err
+	}
 	result := ls.db.WithContext(ctx).Unscoped().Model(&models.Environment{}).
 		Where("id = ? AND project_id = ? AND deleted_at IS NOT NULL", id, projectID).Update("deleted_at", nil)
 	if result.Error != nil {
@@ -323,9 +330,26 @@ func (ls *LocalStorage) GetSecretIncludingDeleted(ctx context.Context, id uint) 
 	return &secret, nil
 }
 
-// RestoreSecret clears a soft-deleted secret's deleted_at (ADR-033). Uses
-// Unscoped to reach the soft-deleted row, which GORM hides by default.
+// RestoreSecret clears a soft-deleted secret's deleted_at (ADR-033). Uses Unscoped to
+// reach the soft-deleted row, which GORM hides by default. It refuses to restore a
+// secret whose parent project or environment is still soft-deleted — otherwise a holder
+// of a still-extant project-scoped grant could resurrect a live, readable secret inside
+// a project an admin deleted to revoke access (the project delete does not revoke role
+// grants). To bring such a secret back, restore the parent project first (which
+// cascade-restores its children).
 func (ls *LocalStorage) RestoreSecret(ctx context.Context, id uint) error {
+	var secret models.SecretNode
+	if err := ls.db.WithContext(ctx).Unscoped().Select("id", "project_id", "environment_id").First(&secret, id).Error; err != nil {
+		return fmt.Errorf("%s", i18n.T("ErrorSecretNotFound", nil))
+	}
+	if err := ls.requireLiveProject(ctx, secret.ProjectID); err != nil {
+		return err
+	}
+	if secret.EnvironmentID != 0 {
+		if err := ls.requireLiveEnvironment(ctx, secret.EnvironmentID); err != nil {
+			return err
+		}
+	}
 	result := ls.db.WithContext(ctx).Unscoped().Model(&models.SecretNode{}).
 		Where("id = ? AND deleted_at IS NOT NULL", id).Update("deleted_at", nil)
 	if result.Error != nil {
@@ -333,6 +357,32 @@ func (ls *LocalStorage) RestoreSecret(ctx context.Context, id uint) error {
 	}
 	if result.RowsAffected == 0 {
 		return fmt.Errorf("%s", i18n.T("ErrorSecretNotFound", nil))
+	}
+	return nil
+}
+
+// requireLiveProject returns an error when the project is missing or soft-deleted.
+func (ls *LocalStorage) requireLiveProject(ctx context.Context, projectID uint) error {
+	var n int64
+	if err := ls.db.WithContext(ctx).Model(&models.Project{}).
+		Where("id = ? AND deleted_at IS NULL", projectID).Count(&n).Error; err != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	if n == 0 {
+		return fmt.Errorf("cannot restore: the parent project is deleted — restore the project first")
+	}
+	return nil
+}
+
+// requireLiveEnvironment returns an error when the environment is missing or soft-deleted.
+func (ls *LocalStorage) requireLiveEnvironment(ctx context.Context, environmentID uint) error {
+	var n int64
+	if err := ls.db.WithContext(ctx).Model(&models.Environment{}).
+		Where("id = ? AND deleted_at IS NULL", environmentID).Count(&n).Error; err != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	if n == 0 {
+		return fmt.Errorf("cannot restore: the parent environment is deleted — restore the environment first")
 	}
 	return nil
 }

--- a/internal/storage/store/local_sharing.go
+++ b/internal/storage/store/local_sharing.go
@@ -206,6 +206,7 @@ func (ls *LocalStorage) ListSharedSecrets(ctx context.Context, userID uint) ([]*
 		JOIN share_records sr ON s.id = sr.secret_id
 		JOIN user_groups ug ON sr.recipient_id = ug.group_id
 		JOIN groups g ON g.id = ug.group_id AND g.deleted_at IS NULL
+		JOIN users u ON u.id = ug.user_id AND u.deleted_at IS NULL
 		WHERE ug.user_id = ? AND sr.is_group = ? AND sr.deleted_at IS NULL AND s.deleted_at IS NULL
 		  AND (sr.expires_at IS NULL OR sr.expires_at > ?)
 	`
@@ -250,6 +251,7 @@ func (ls *LocalStorage) CheckSharePermission(ctx context.Context, secretID, user
 		SELECT sr.* FROM share_records sr
 		JOIN user_groups ug ON sr.recipient_id = ug.group_id
 		JOIN groups g ON g.id = ug.group_id AND g.deleted_at IS NULL
+		JOIN users u ON u.id = ug.user_id AND u.deleted_at IS NULL
 		WHERE sr.secret_id = ? AND ug.user_id = ? AND sr.is_group = ? AND sr.deleted_at IS NULL
 		  AND (sr.expires_at IS NULL OR sr.expires_at > ?)
 		LIMIT 1

--- a/internal/storage/store/local_system_metadata.go
+++ b/internal/storage/store/local_system_metadata.go
@@ -1,0 +1,36 @@
+// local_system_metadata.go — a small singleton key/value store for server-managed
+// state (e.g. the audit-checkpoint high-water mark, ADR-029). Backed by the
+// system_metadata table.
+package store
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// GetSystemMetadata returns the value stored for key; found is false when the key
+// has never been set.
+func (ls *LocalStorage) GetSystemMetadata(ctx context.Context, key string) (string, bool, error) {
+	var m models.SystemMetadata
+	err := ls.db.WithContext(ctx).Where("key = ?", key).Take(&m).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, err
+	}
+	return m.Value, true, nil
+}
+
+// SetSystemMetadata upserts a system-metadata key/value (last write wins).
+func (ls *LocalStorage) SetSystemMetadata(ctx context.Context, key, value string) error {
+	return ls.db.WithContext(ctx).Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "key"}},
+		DoUpdates: clause.AssignmentColumns([]string{"value", "updated_at"}),
+	}).Create(&models.SystemMetadata{Key: key, Value: value, UpdatedAt: time.Now()}).Error
+}

--- a/internal/storage/store/local_users.go
+++ b/internal/storage/store/local_users.go
@@ -226,6 +226,9 @@ func (ls *LocalStorage) ListUsers(ctx context.Context, filter *storage.UserFilte
 	}
 
 	offset := (filter.Page - 1) * filter.PageSize
+	if filter.Offset > 0 {
+		offset = filter.Offset
+	}
 	query = query.Offset(offset).Limit(filter.PageSize)
 
 	var users []*models.User

--- a/internal/storage/store/local_users.go
+++ b/internal/storage/store/local_users.go
@@ -13,6 +13,7 @@ package store
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/core/storage"
@@ -21,6 +22,14 @@ import (
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 )
+
+// likeEscaper escapes the LIKE/ILIKE metacharacters so a user-supplied search term is
+// matched literally, not as a wildcard. Paired with an explicit ESCAPE '\' clause.
+var likeEscaper = strings.NewReplacer(`\`, `\\`, "%", `\%`, "_", `\_`)
+
+// escapeLike neutralizes %, _, and \ in a user search string so `?q=%` can't turn the
+// filter into a match-all / full-table scan.
+func escapeLike(s string) string { return likeEscaper.Replace(s) }
 
 // --- Users ---
 
@@ -192,14 +201,14 @@ func (ls *LocalStorage) ListUsers(ctx context.Context, filter *storage.UserFilte
 	}
 
 	if filter.Search != nil {
-		pattern := "%" + *filter.Search + "%"
-		query = query.Where("username ILIKE ? OR email ILIKE ? OR display_name ILIKE ?", pattern, pattern, pattern)
+		pattern := "%" + escapeLike(*filter.Search) + "%"
+		query = query.Where("username ILIKE ? ESCAPE '\\' OR email ILIKE ? ESCAPE '\\' OR display_name ILIKE ? ESCAPE '\\'", pattern, pattern, pattern)
 	}
 	if filter.Username != nil {
-		query = query.Where("username LIKE ?", "%"+*filter.Username+"%")
+		query = query.Where("username LIKE ? ESCAPE '\\'", "%"+escapeLike(*filter.Username)+"%")
 	}
 	if filter.Email != nil {
-		query = query.Where("email LIKE ?", "%"+*filter.Email+"%")
+		query = query.Where("email LIKE ? ESCAPE '\\'", "%"+escapeLike(*filter.Email)+"%")
 	}
 	if filter.IsActive != nil {
 		query = query.Where("is_active = ?", *filter.IsActive)

--- a/internal/storage/store/query.go
+++ b/internal/storage/store/query.go
@@ -7,6 +7,7 @@ package store
 
 import (
 	"fmt"
+	"net/url"
 	"strings"
 	"time"
 )
@@ -21,7 +22,9 @@ func newQueryBuilder() *queryBuilder {
 }
 
 func (q *queryBuilder) add(key, value string) {
-	q.params = append(q.params, key+"="+value)
+	// Escape both sides: user-controlled filter values (names, tags, search, resource/
+	// action) must not be able to inject extra query params or truncate the query.
+	q.params = append(q.params, url.QueryEscape(key)+"="+url.QueryEscape(value))
 }
 
 func (q *queryBuilder) addUint(key string, v *uint) {

--- a/internal/storage/store/query_escape_test.go
+++ b/internal/storage/store/query_escape_test.go
@@ -1,0 +1,24 @@
+package store
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestQueryBuilder_EscapesInjection pins that user-controlled filter values can't
+// inject extra query params or truncate the query.
+func TestQueryBuilder_EscapesInjection(t *testing.T) {
+	q := newQueryBuilder()
+	q.add("type", "1&owner_id=999")
+	q.add("search", "a#b")
+	out := q.String()
+	if strings.Contains(out, "owner_id=999") {
+		t.Fatalf("'&' injection not escaped: %s", out)
+	}
+	if strings.Contains(out, "#") {
+		t.Fatalf("'#' not escaped: %s", out)
+	}
+	if !strings.Contains(out, "1%26owner_id%3D999") {
+		t.Fatalf("value not percent-encoded: %s", out)
+	}
+}

--- a/internal/storage/store/remote_audit.go
+++ b/internal/storage/store/remote_audit.go
@@ -164,6 +164,16 @@ func (rs *RemoteStorage) AuditEntryHashByID(_ context.Context, _ uint) (string, 
 	return "", false, fmt.Errorf("AuditEntryHashByID not available in remote mode")
 }
 
+// GetSystemMetadata is not available in remote mode; server-managed state is server-side.
+func (rs *RemoteStorage) GetSystemMetadata(_ context.Context, _ string) (string, bool, error) {
+	return "", false, fmt.Errorf("GetSystemMetadata not available in remote mode")
+}
+
+// SetSystemMetadata is not available in remote mode; server-managed state is server-side.
+func (rs *RemoteStorage) SetSystemMetadata(_ context.Context, _, _ string) error {
+	return fmt.Errorf("SetSystemMetadata not available in remote mode")
+}
+
 // CreateAnomalyAlert is not available in remote mode; anomaly detection is server-side.
 func (rs *RemoteStorage) CreateAnomalyAlert(_ context.Context, _ *models.AnomalyAlert) error {
 	return fmt.Errorf("CreateAnomalyAlert not available in remote mode")

--- a/internal/storage/store/remote_auth.go
+++ b/internal/storage/store/remote_auth.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/storage/models"
@@ -37,7 +38,7 @@ func (rs *RemoteStorage) CreateSession(ctx context.Context, session *models.Sess
 
 // GetSession retrieves a session by token via remote API.
 func (rs *RemoteStorage) GetSession(ctx context.Context, token string) (*models.Session, error) {
-	path := fmt.Sprintf("/api/v1/sessions/%s", token)
+	path := fmt.Sprintf("/api/v1/sessions/%s", url.PathEscape(token))
 	resp, err := rs.client.Get(ctx, path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get session: %w", err)
@@ -97,7 +98,7 @@ func (rs *RemoteStorage) CreateAPIClient(ctx context.Context, client *models.API
 
 // GetAPIClient retrieves an API client by client ID via remote API.
 func (rs *RemoteStorage) GetAPIClient(ctx context.Context, clientID string) (*models.APIClient, error) {
-	path := fmt.Sprintf("/api/v1/api-clients/%s", clientID)
+	path := fmt.Sprintf("/api/v1/api-clients/%s", url.PathEscape(clientID))
 	resp, err := rs.client.Get(ctx, path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get API client: %w", err)
@@ -114,7 +115,7 @@ func (rs *RemoteStorage) GetAPIClient(ctx context.Context, clientID string) (*mo
 
 // RevokeAPIClient revokes an API client via remote API.
 func (rs *RemoteStorage) RevokeAPIClient(ctx context.Context, clientID string) error {
-	path := fmt.Sprintf("/api/v1/api-clients/%s/revoke", clientID)
+	path := fmt.Sprintf("/api/v1/api-clients/%s/revoke", url.PathEscape(clientID))
 	resp, err := rs.client.Post(ctx, path, nil)
 	if err != nil {
 		return fmt.Errorf("failed to revoke API client: %w", err)
@@ -143,7 +144,7 @@ func (rs *RemoteStorage) ListAPIClients(ctx context.Context) ([]*models.APIClien
 
 // UpdateAPIClient updates an API client via remote API.
 func (rs *RemoteStorage) UpdateAPIClient(ctx context.Context, client *models.APIClient) (*models.APIClient, error) {
-	path := fmt.Sprintf("/api/v1/service-accounts/%s", client.ClientID)
+	path := fmt.Sprintf("/api/v1/service-accounts/%s", url.PathEscape(client.ClientID))
 	resp, err := rs.client.Put(ctx, path, client)
 	if err != nil {
 		return nil, fmt.Errorf("failed to update API client: %w", err)

--- a/internal/storage/store/remote_auth.go
+++ b/internal/storage/store/remote_auth.go
@@ -281,6 +281,10 @@ func (rs *RemoteStorage) RevokePersonalAccessToken(_ context.Context, _ uint) er
 	return errUnsupportedRemote
 }
 
+func (rs *RemoteStorage) RevokeAllPersonalAccessTokensForUser(_ context.Context, _ uint) ([]string, error) {
+	return nil, errUnsupportedRemote
+}
+
 func (rs *RemoteStorage) TouchPersonalAccessToken(_ context.Context, _ uint, _ time.Time, _ time.Duration) error {
 	return nil // best-effort; no-op on remote storage
 }

--- a/internal/storage/store/remote_auth.go
+++ b/internal/storage/store/remote_auth.go
@@ -249,6 +249,10 @@ func (rs *RemoteStorage) DeleteSessionsForUserExcept(_ context.Context, _, _ uin
 	return errUnsupportedRemote
 }
 
+func (rs *RemoteStorage) ListSessionTokenHashesForUser(_ context.Context, _ uint) ([]string, error) {
+	return nil, errUnsupportedRemote
+}
+
 func (rs *RemoteStorage) EnforceSessionLimit(_ context.Context, _ uint, _ int) error {
 	return errUnsupportedRemote
 }

--- a/internal/storage/store/remote_auth.go
+++ b/internal/storage/store/remote_auth.go
@@ -249,6 +249,10 @@ func (rs *RemoteStorage) DeleteSessionsForUserExcept(_ context.Context, _, _ uin
 	return errUnsupportedRemote
 }
 
+func (rs *RemoteStorage) EnforceSessionLimit(_ context.Context, _ uint, _ int) error {
+	return errUnsupportedRemote
+}
+
 func (rs *RemoteStorage) TouchSession(_ context.Context, _ uint, _ time.Time, _ time.Duration) error {
 	return nil // best-effort; no-op on remote storage
 }

--- a/internal/storage/store/remote_dynamic.go
+++ b/internal/storage/store/remote_dynamic.go
@@ -33,6 +33,9 @@ func (rs *RemoteStorage) GetDynamicSecretLease(_ context.Context, _ string) (*mo
 func (rs *RemoteStorage) ListDynamicSecretLeases(_ context.Context, _ uint) ([]*models.DynamicSecretLease, error) {
 	return nil, remoteUnsupported("ListDynamicSecretLeases")
 }
+func (rs *RemoteStorage) CountActiveLeases(_ context.Context, _ uint) (int64, error) {
+	return 0, remoteUnsupported("CountActiveLeases")
+}
 func (rs *RemoteStorage) UpdateDynamicSecretLease(_ context.Context, _ *models.DynamicSecretLease) error {
 	return remoteUnsupported("UpdateDynamicSecretLease")
 }

--- a/internal/storage/store/remote_machine_identities.go
+++ b/internal/storage/store/remote_machine_identities.go
@@ -28,6 +28,10 @@ func (rs *RemoteStorage) ListMachineIdentities(_ context.Context, _ uint) ([]*mo
 	return nil, remoteUnsupported("ListMachineIdentities")
 }
 
+func (rs *RemoteStorage) ListAllMachineIdentities(_ context.Context) ([]*models.MachineIdentity, error) {
+	return nil, remoteUnsupported("ListAllMachineIdentities")
+}
+
 func (rs *RemoteStorage) CountMachineIdentitiesByClassification(_ context.Context) (map[string]int, error) {
 	return nil, remoteUnsupported("CountMachineIdentitiesByClassification")
 }

--- a/internal/storage/store/remote_mfa.go
+++ b/internal/storage/store/remote_mfa.go
@@ -21,6 +21,10 @@ func (rs *RemoteStorage) ActivateMFASecret(_ context.Context, _ uint) error {
 	return remoteUnsupported("ActivateMFASecret")
 }
 
+func (rs *RemoteStorage) MarkTOTPStepUsed(_ context.Context, _ uint, _ int64) (bool, error) {
+	return false, remoteUnsupported("MarkTOTPStepUsed")
+}
+
 func (rs *RemoteStorage) DeleteMFAForUser(_ context.Context, _ uint) error {
 	return remoteUnsupported("DeleteMFAForUser")
 }

--- a/internal/storage/store/remote_rbac.go
+++ b/internal/storage/store/remote_rbac.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/core/storage"
@@ -56,7 +57,7 @@ func (rs *RemoteStorage) GetRole(ctx context.Context, id uint) (*models.Role, er
 
 // GetRoleByName retrieves a role by name via remote API.
 func (rs *RemoteStorage) GetRoleByName(ctx context.Context, name string) (*models.Role, error) {
-	path := fmt.Sprintf("/api/v1/roles/by-name/%s", name)
+	path := fmt.Sprintf("/api/v1/roles/by-name/%s", url.PathEscape(name))
 	resp, err := rs.client.Get(ctx, path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get role by name: %w", err)
@@ -196,7 +197,7 @@ func (rs *RemoteStorage) GetUserRoles(ctx context.Context, userID uint) ([]*mode
 
 // CheckPermission checks if a user has a specific resource/action permission via remote API.
 func (rs *RemoteStorage) CheckPermission(ctx context.Context, userID uint, resource, action string) (bool, error) {
-	path := fmt.Sprintf("/api/v1/rbac/check-permission?user_id=%d&resource=%s&action=%s", userID, resource, action)
+	path := fmt.Sprintf("/api/v1/rbac/check-permission?user_id=%d&resource=%s&action=%s", userID, url.QueryEscape(resource), url.QueryEscape(action))
 	resp, err := rs.client.Get(ctx, path)
 	if err != nil {
 		return false, fmt.Errorf("failed to check permission: %w", err)

--- a/internal/storage/store/remote_rbac.go
+++ b/internal/storage/store/remote_rbac.go
@@ -361,6 +361,10 @@ func (rs *RemoteStorage) GetUserRoleIDsExact(_ context.Context, _ uint, _ storag
 	return nil, fmt.Errorf("not supported in remote storage")
 }
 
+func (rs *RemoteStorage) IsProjectMember(_ context.Context, _ uint, _ uint) (bool, error) {
+	return false, fmt.Errorf("not supported in remote storage")
+}
+
 // GetUserGroupRoleIDsAt is a server-internal authorization primitive.
 func (rs *RemoteStorage) GetUserGroupRoleIDsAt(_ context.Context, _ uint, _ storage.Scope) ([]uint, error) {
 	return nil, fmt.Errorf("not supported in remote storage")

--- a/internal/storage/store/remote_secrets.go
+++ b/internal/storage/store/remote_secrets.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/core/storage"
@@ -55,7 +56,7 @@ func (rs *RemoteStorage) GetSecret(ctx context.Context, id uint) (*models.Secret
 // GetSecretByName retrieves a secret by name and scope context via remote API.
 func (rs *RemoteStorage) GetSecretByName(ctx context.Context, name string, projectID, environmentID uint) (*models.SecretNode, error) {
 	path := fmt.Sprintf("/api/v1/secrets/by-name/%s?project_id=%d&environment_id=%d",
-		name, projectID, environmentID)
+		url.PathEscape(name), projectID, environmentID)
 	resp, err := rs.client.Get(ctx, path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get secret by name: %w", err)

--- a/internal/storage/store/remote_users.go
+++ b/internal/storage/store/remote_users.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/core/storage"
@@ -64,7 +65,7 @@ func (rs *RemoteStorage) LockUserForUpdate(ctx context.Context, id uint) (*model
 
 // GetUserByEmail retrieves a user by email via remote API.
 func (rs *RemoteStorage) GetUserByEmail(ctx context.Context, email string) (*models.User, error) {
-	path := fmt.Sprintf("/api/v1/users/by-email/%s", email)
+	path := fmt.Sprintf("/api/v1/users/by-email/%s", url.PathEscape(email))
 	resp, err := rs.client.Get(ctx, path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get user by email: %w", err)

--- a/internal/storage/store/restore_test.go
+++ b/internal/storage/store/restore_test.go
@@ -101,6 +101,72 @@ func TestRestoreProject_DoesNotResurrectIndependentlyDeletedSecret(t *testing.T)
 	assert.True(t, stillDeleted.DeletedAt.Valid, "retired secret remains soft-deleted")
 }
 
+// An individual environment or secret must NOT be restorable while its parent project
+// is still soft-deleted — otherwise a holder of a still-extant project-scoped grant (a
+// soft-deleted project does not revoke its role grants) could resurrect a live, readable
+// scope under a project an admin deleted to revoke access.
+func TestRestoreChild_RefusedWhileParentProjectDeleted(t *testing.T) {
+	ctx := context.Background()
+	ls := newRestoreTestStore(t)
+
+	proj, err := ls.CreateProject(ctx, &models.Project{Name: "app"})
+	require.NoError(t, err)
+	env, err := ls.CreateEnvironment(ctx, &models.Environment{Name: "prod", ProjectID: proj.ID})
+	require.NoError(t, err)
+	sec, err := ls.CreateSecret(ctx, &models.SecretNode{ProjectID: proj.ID, EnvironmentID: env.ID, Name: "db-pw", IsSecret: true, Type: "text", Status: "active"})
+	require.NoError(t, err)
+
+	// Soft-delete the whole project (cascades to env + secret).
+	require.NoError(t, ls.DeleteProject(ctx, proj.ID))
+
+	// Individually restoring the secret is refused — the parent project is deleted.
+	err = ls.RestoreSecret(ctx, sec.ID)
+	require.Error(t, err, "a secret must not be restorable under a soft-deleted project")
+	assert.Contains(t, err.Error(), "parent project is deleted")
+
+	// Likewise the environment.
+	err = ls.RestoreEnvironment(ctx, proj.ID, env.ID)
+	require.Error(t, err, "an environment must not be restorable under a soft-deleted project")
+	assert.Contains(t, err.Error(), "parent project is deleted")
+
+	// The secret stays in the recycle bin (still soft-deleted, not readable).
+	_, err = ls.GetSecret(ctx, sec.ID)
+	require.Error(t, err)
+
+	// Restoring the project first (cascade) brings the children back — the supported path.
+	require.NoError(t, ls.RestoreProject(ctx, proj.ID))
+	_, err = ls.GetSecret(ctx, sec.ID)
+	require.NoError(t, err, "after the project is restored, its cascade-deleted secret is live again")
+}
+
+// A secret whose parent ENVIRONMENT is still soft-deleted (but project live) is also
+// refused, so a child can never outlive a deleted parent scope.
+func TestRestoreSecret_RefusedWhileParentEnvironmentDeleted(t *testing.T) {
+	ctx := context.Background()
+	ls := newRestoreTestStore(t)
+
+	proj, err := ls.CreateProject(ctx, &models.Project{Name: "app"})
+	require.NoError(t, err)
+	env, err := ls.CreateEnvironment(ctx, &models.Environment{Name: "prod", ProjectID: proj.ID})
+	require.NoError(t, err)
+	sec, err := ls.CreateSecret(ctx, &models.SecretNode{ProjectID: proj.ID, EnvironmentID: env.ID, Name: "db-pw", IsSecret: true, Type: "text", Status: "active"})
+	require.NoError(t, err)
+
+	// Delete the secret, then the environment (project stays live).
+	require.NoError(t, ls.DeleteSecret(ctx, sec.ID))
+	require.NoError(t, ls.DeleteEnvironment(ctx, env.ID))
+
+	err = ls.RestoreSecret(ctx, sec.ID)
+	require.Error(t, err, "a secret must not be restorable under a soft-deleted environment")
+	assert.Contains(t, err.Error(), "parent environment is deleted")
+
+	// With the environment restored, the secret can be restored.
+	require.NoError(t, ls.RestoreEnvironment(ctx, proj.ID, env.ID))
+	require.NoError(t, ls.RestoreSecret(ctx, sec.ID))
+	_, err = ls.GetSecret(ctx, sec.ID)
+	require.NoError(t, err)
+}
+
 func TestRestoreProjectNotDeleted(t *testing.T) {
 	ctx := context.Background()
 	ls := newRestoreTestStore(t)

--- a/internal/storage/store/secret_soft_delete_test.go
+++ b/internal/storage/store/secret_soft_delete_test.go
@@ -17,7 +17,7 @@ func newSoftDeleteTestStore(t *testing.T) *LocalStorage {
 	t.Helper()
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
-	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.Environment{}, &models.SecretDependency{}))
+	require.NoError(t, db.AutoMigrate(&models.Project{}, &models.SecretNode{}, &models.SecretVersion{}, &models.Environment{}, &models.SecretDependency{}))
 	return NewLocalStorage(db)
 }
 
@@ -26,6 +26,9 @@ func TestSecretSoftDeleteLifecycle(t *testing.T) {
 	ctx := context.Background()
 	const projectID = uint(1)
 
+	// A live parent project + environment — RestoreSecret refuses to restore into a
+	// soft-deleted parent, so the lifecycle test needs them present and live.
+	require.NoError(t, ls.db.Create(&models.Project{ID: projectID, Name: "proj"}).Error)
 	require.NoError(t, ls.db.Create(&models.Environment{ID: 10, ProjectID: projectID, Name: "dev"}).Error)
 	s, err := ls.CreateSecret(ctx, &models.SecretNode{ProjectID: projectID, EnvironmentID: 10, Name: "API_KEY", IsSecret: true, Type: "api_key", Status: "active"})
 	require.NoError(t, err)

--- a/internal/storage/store/session_limit_test.go
+++ b/internal/storage/store/session_limit_test.go
@@ -1,0 +1,53 @@
+package store
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestEnforceSessionLimit(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.Session{}))
+	ls := NewLocalStorage(db)
+
+	base := time.Now()
+	for i := 0; i < 30; i++ {
+		require.NoError(t, db.Create(&models.Session{
+			UserID: 1, SessionToken: fmt.Sprintf("t%d", i),
+			CreatedAt: base.Add(time.Duration(i) * time.Minute),
+		}).Error)
+	}
+	require.NoError(t, db.Create(&models.Session{UserID: 2, SessionToken: "other"}).Error)
+
+	require.NoError(t, ls.EnforceSessionLimit(context.Background(), 1, 25))
+
+	var count int64
+	db.Model(&models.Session{}).Where("user_id = ?", 1).Count(&count)
+	assert.EqualValues(t, 25, count, "keeps exactly the cap")
+
+	// The 5 oldest are reaped; the newest survives.
+	var oldest, newest int64
+	db.Model(&models.Session{}).Where("session_token = ?", "t0").Count(&oldest)
+	db.Model(&models.Session{}).Where("session_token = ?", "t29").Count(&newest)
+	assert.EqualValues(t, 0, oldest, "oldest session reaped")
+	assert.EqualValues(t, 1, newest, "most-recent session retained")
+
+	// Another user's sessions are untouched.
+	var u2 int64
+	db.Model(&models.Session{}).Where("user_id = ?", 2).Count(&u2)
+	assert.EqualValues(t, 1, u2)
+
+	// Under the cap is a no-op.
+	require.NoError(t, ls.EnforceSessionLimit(context.Background(), 2, 25))
+	db.Model(&models.Session{}).Where("user_id = ?", 2).Count(&u2)
+	assert.EqualValues(t, 1, u2)
+}

--- a/operator/api/v1alpha1/keyorixsecret_types.go
+++ b/operator/api/v1alpha1/keyorixsecret_types.go
@@ -36,8 +36,10 @@ type KeyorixSecretTarget struct {
 
 // KeyorixSecretSpec defines which Keyorix secrets to sync and where.
 type KeyorixSecretSpec struct {
-	// Server is the Keyorix base URL, e.g. https://keyorix.internal.
-	// +kubebuilder:validation:Pattern=`^https?://`
+	// Server is the Keyorix base URL, e.g. https://keyorix.internal. Must be https (the
+	// machine-identity token is sent as a bearer header) AND must match the operator's
+	// --allowed-servers list — the operator rejects any other destination.
+	// +kubebuilder:validation:Pattern=`^https://`
 	Server string `json:"server"`
 	// TokenSecretRef sources the Keyorix machine-identity token (a least-privilege
 	// identity with secrets.read on the referenced secrets). The token is never

--- a/operator/cmd/main.go
+++ b/operator/cmd/main.go
@@ -5,6 +5,7 @@ package main
 import (
 	"flag"
 	"os"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -26,12 +27,15 @@ func init() {
 }
 
 func main() {
-	var metricsAddr, probeAddr string
+	var metricsAddr, probeAddr, allowedServers string
 	var enableLeaderElection bool
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "address the metric endpoint binds to")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "address the probe endpoint binds to")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"enable leader election for controller manager (run a single active replica)")
+	flag.StringVar(&allowedServers, "allowed-servers", os.Getenv("KEYORIX_ALLOWED_SERVERS"),
+		"comma-separated list of trusted Keyorix base URLs (https://host) a KeyorixSecret's spec.server must match. "+
+			"REQUIRED: without it every CR is rejected, so the operator never sends a token to a CR-chosen destination.")
 	opts := zap.Options{Development: false}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
@@ -51,9 +55,19 @@ func main() {
 		os.Exit(1)
 	}
 
+	var allowed []string
+	for _, s := range strings.Split(allowedServers, ",") {
+		if s = strings.TrimSpace(s); s != "" {
+			allowed = append(allowed, s)
+		}
+	}
+	if len(allowed) == 0 {
+		setupLog.Info("WARNING: --allowed-servers is not set; every KeyorixSecret will be REJECTED until you configure the trusted Keyorix server URL(s)")
+	}
 	if err := (&controller.KeyorixSecretReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:         mgr.GetClient(),
+		Scheme:         mgr.GetScheme(),
+		AllowedServers: allowed,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "KeyorixSecret")
 		os.Exit(1)

--- a/operator/config/crd/bases/secrets.keyorix.io_keyorixsecrets.yaml
+++ b/operator/config/crd/bases/secrets.keyorix.io_keyorixsecrets.yaml
@@ -80,8 +80,11 @@ spec:
                   Defaults to 5m.
                 type: string
               server:
-                description: Server is the Keyorix base URL, e.g. https://keyorix.internal.
-                pattern: ^https?://
+                description: |-
+                  Server is the Keyorix base URL, e.g. https://keyorix.internal. Must be https (the
+                  machine-identity token is sent as a bearer header) AND must match the operator's
+                  --allowed-servers list — the operator rejects any other destination.
+                pattern: ^https://
                 type: string
               target:
                 description: Target is the Kubernetes Secret to create/maintain.

--- a/operator/internal/controller/keyorixsecret_controller.go
+++ b/operator/internal/controller/keyorixsecret_controller.go
@@ -132,15 +132,35 @@ func (r *KeyorixSecretReconciler) applySecret(ctx context.Context, ks *secretsv1
 		secretType = corev1.SecretTypeOpaque
 	}
 	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, secret, func() error {
+		// Refuse to adopt-and-overwrite a pre-existing Secret we don't manage. A non-empty
+		// ResourceVersion means the object already existed; without a managed-by guard,
+		// SetControllerReference would adopt an UNOWNED Secret (e.g. one created manually
+		// or by Helm) and replace its data — letting a CR author clobber another workload's
+		// same-named Secret. A Secret we created carries the managed-by label and is
+		// allowed through.
+		if secret.ResourceVersion != "" && secret.Labels[managedByLabel] != managedByValue {
+			return fmt.Errorf("refusing to overwrite existing unmanaged Secret %s/%s", ks.Namespace, name)
+		}
 		if err := controllerutil.SetControllerReference(ks, secret, r.Scheme); err != nil {
 			return err
 		}
+		if secret.Labels == nil {
+			secret.Labels = map[string]string{}
+		}
+		secret.Labels[managedByLabel] = managedByValue
 		secret.Type = secretType
 		secret.Data = data // operator owns the whole data set; removed keys are pruned
 		return nil
 	})
 	return err
 }
+
+// managedByLabel/managedByValue mark a Secret as owned by this operator, so it won't
+// adopt or overwrite a Secret it didn't create.
+const (
+	managedByLabel = "app.kubernetes.io/managed-by"
+	managedByValue = "keyorix-operator"
+)
 
 // fail records a SyncError on the Ready condition and requeues with backoff.
 func (r *KeyorixSecretReconciler) fail(ctx context.Context, ks *secretsv1alpha1.KeyorixSecret, cause error) (ctrl.Result, error) {

--- a/operator/internal/controller/keyorixsecret_controller.go
+++ b/operator/internal/controller/keyorixsecret_controller.go
@@ -8,7 +8,9 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"net/url"
 	"sort"
+	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -33,9 +35,40 @@ const (
 type KeyorixSecretReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
+	// AllowedServers is the set of trusted Keyorix base URLs (scheme://host) the operator
+	// will send tokens to. A CR's spec.server MUST match one of these. Without it the
+	// operator is a confused deputy: it holds cluster-wide Secret read and would ship a
+	// CR-named Secret's value (the "token") to a CR-chosen server — letting a tenant who
+	// can only create a CR exfiltrate any namespace Secret to an attacker. Empty = reject
+	// every CR (fail closed); configured at startup from --allowed-servers.
+	AllowedServers []string
 	// newClient builds a value fetcher for a server/token; nil uses the real HTTP client.
 	// Overridden in tests.
 	newClient func(server, token string) valueFetcher
+}
+
+// validateServer rejects a CR-supplied server that is not https or not in the operator's
+// configured allow-list. This is the control that stops the confused-deputy exfiltration:
+// the token (a possibly-arbitrary namespace Secret value) only ever travels to a trusted,
+// TLS-protected destination the operator was explicitly configured to trust.
+func (r *KeyorixSecretReconciler) validateServer(server string) error {
+	u, err := url.Parse(server)
+	if err != nil || u.Host == "" {
+		return fmt.Errorf("invalid server URL %q", server)
+	}
+	if u.Scheme != "https" {
+		return fmt.Errorf("refusing server %q: only https is allowed (the bearer token must not travel in cleartext)", server)
+	}
+	if len(r.AllowedServers) == 0 {
+		return fmt.Errorf("refusing CR-specified server %q: the operator has no allowed-servers configured and will not send a token to an arbitrary destination — set --allowed-servers to the trusted Keyorix URL(s)", server)
+	}
+	target := u.Scheme + "://" + u.Host
+	for _, a := range r.AllowedServers {
+		if au, perr := url.Parse(strings.TrimRight(strings.TrimSpace(a), "/")); perr == nil && au.Scheme+"://"+au.Host == target {
+			return nil
+		}
+	}
+	return fmt.Errorf("server %q is not in the operator's allowed-servers list", server)
 }
 
 // valueFetcher is the slice of the Keyorix client the reconciler needs (a seam for tests).
@@ -90,6 +123,11 @@ func (r *KeyorixSecretReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 // Secret's data. Any failure fails the whole reconcile so a Secret is never written with
 // a partially-fetched set of keys.
 func (r *KeyorixSecretReconciler) buildDesired(ctx context.Context, ks *secretsv1alpha1.KeyorixSecret) (map[string][]byte, error) {
+	// Validate the destination BEFORE reading the token Secret, so a CR pointing at an
+	// untrusted server can't even cause the operator to read (let alone transmit) a Secret.
+	if err := r.validateServer(ks.Spec.Server); err != nil {
+		return nil, err
+	}
 	tokenKey := ks.Spec.TokenSecretRef.Key
 	if tokenKey == "" {
 		tokenKey = "token"

--- a/operator/internal/controller/keyorixsecret_controller_test.go
+++ b/operator/internal/controller/keyorixsecret_controller_test.go
@@ -123,6 +123,27 @@ func TestReconcile_CreatesTargetSecretOwnedByCR(t *testing.T) {
 	assert.Equal(t, int64(1), ks.Status.ObservedGeneration)
 }
 
+func TestReconcile_RefusesToOverwriteUnmanagedSecret(t *testing.T) {
+	// A pre-existing Secret with the target name that the operator did NOT create.
+	foreign := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "db-creds", Namespace: "app"},
+		Data:       map[string][]byte{"OTHER": []byte("do-not-clobber")},
+	}
+	fetcher := &fakeFetcher{values: map[string][]byte{
+		"app/production/db-password": []byte("p4ss"), "app/production/api-key": []byte("k3y"),
+	}}
+	r, c := newReconciler(t, fetcher, ksFixture(), tokenSecret(), foreign)
+
+	_, err := reconcile(t, r)
+	require.Error(t, err, "must refuse to adopt/overwrite an unmanaged Secret")
+
+	// The foreign Secret's data is untouched — not clobbered with the synced keys.
+	var got corev1.Secret
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "db-creds", Namespace: "app"}, &got))
+	assert.Equal(t, []byte("do-not-clobber"), got.Data["OTHER"])
+	assert.NotContains(t, got.Data, "DB_PASSWORD")
+}
+
 func TestReconcile_DefaultsTargetNameToCR(t *testing.T) {
 	ks := ksFixture()
 	ks.Spec.Target.Name = "" // unset → defaults to the CR name "db"

--- a/operator/internal/controller/keyorixsecret_controller_test.go
+++ b/operator/internal/controller/keyorixsecret_controller_test.go
@@ -53,9 +53,12 @@ func newReconciler(t *testing.T, fetcher valueFetcher, objs ...client.Object) (*
 		WithObjects(objs...).
 		Build()
 	return &KeyorixSecretReconciler{
-		Client:    c,
-		Scheme:    s,
-		newClient: func(_, _ string) valueFetcher { return fetcher },
+		Client: c,
+		Scheme: s,
+		// Trust the fixture's server so the (now fail-closed) allow-list passes; the
+		// server-validation behavior itself is covered by TestValidateServer.
+		AllowedServers: []string{"https://keyorix.internal"},
+		newClient:      func(_, _ string) valueFetcher { return fetcher },
 	}, c
 }
 
@@ -222,4 +225,51 @@ func TestHashData_StableAndSensitive(t *testing.T) {
 	b := map[string][]byte{"y": []byte("2"), "x": []byte("1")}
 	assert.Equal(t, hashData(a), hashData(b), "hash is independent of map iteration order")
 	assert.NotEqual(t, hashData(a), hashData(map[string][]byte{"x": []byte("1"), "y": []byte("3")}))
+}
+
+// validateServer is the confused-deputy guard: the operator must only ever send a token
+// to an https destination it was explicitly configured to trust, so a tenant who can
+// create a CR cannot redirect a (possibly arbitrary) namespace Secret's value to an
+// attacker server.
+func TestValidateServer(t *testing.T) {
+	allow := &KeyorixSecretReconciler{AllowedServers: []string{"https://keyorix.internal", "https://kx.example.com/"}}
+	cases := []struct {
+		name    string
+		r       *KeyorixSecretReconciler
+		server  string
+		wantErr bool
+	}{
+		{"allowed host", allow, "https://keyorix.internal", false},
+		{"allowed host trailing-slash config", allow, "https://kx.example.com", false},
+		{"http rejected", allow, "http://keyorix.internal", true},
+		{"not in allow-list rejected", allow, "https://attacker.example", true},
+		{"empty allow-list rejects everything (fail closed)", &KeyorixSecretReconciler{}, "https://keyorix.internal", true},
+		{"garbage rejected", allow, "::nope", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.r.validateServer(tc.server)
+			if tc.wantErr && err == nil {
+				t.Errorf("validateServer(%q) = nil; want error", tc.server)
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("validateServer(%q) = %v; want nil", tc.server, err)
+			}
+		})
+	}
+}
+
+// A CR pointing at an untrusted server is rejected BEFORE the operator reads the token
+// Secret — so it cannot be used to exfiltrate a namespace Secret to an attacker.
+func TestReconcile_RejectsUntrustedServer(t *testing.T) {
+	ks := ksFixture()
+	ks.Spec.Server = "https://attacker.example"
+	r, c := newReconciler(t, &fakeFetcher{}, ks, tokenSecret())
+	_, err := reconcile(t, r)
+	require.Error(t, err, "a CR with a non-allowlisted server must fail the reconcile")
+
+	// No target Secret was written.
+	var got corev1.Secret
+	err = c.Get(context.Background(), types.NamespacedName{Name: "db-creds", Namespace: "app"}, &got)
+	require.Error(t, err, "no Secret is created for a rejected server")
 }

--- a/server/grpc/interceptors/auth.go
+++ b/server/grpc/interceptors/auth.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
+	pb "github.com/keyorixhq/keyorix/server/proto/pb"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
@@ -91,6 +92,13 @@ func AuthInterceptor(coreService *core.KeyorixCore, requireMFA bool) grpc.UnaryS
 			return nil, err
 		}
 
+		// Mirror the HTTP BlockWhenImpersonating guard: an admin acting through an
+		// impersonation session must not mint a durable credential that would outlive the
+		// bounded, audited session.
+		if blockedUnderImpersonation(info.FullMethod) && userCtx.ImpersonatedBy != nil {
+			return nil, status.Error(codes.PermissionDenied, "this action is not permitted while impersonating")
+		}
+
 		// Add user context to request context
 		newCtx := context.WithValue(ctx, userContextKey, userCtx)
 		newCtx = withAuditAttribution(newCtx, userCtx)
@@ -119,6 +127,10 @@ func StreamAuthInterceptor(coreService *core.KeyorixCore, requireMFA bool) grpc.
 			return err
 		}
 
+		if blockedUnderImpersonation(info.FullMethod) && userCtx.ImpersonatedBy != nil {
+			return status.Error(codes.PermissionDenied, "this action is not permitted while impersonating")
+		}
+
 		// Create a new stream with user context (+ audit attribution / PAT restriction).
 		streamCtx := context.WithValue(stream.Context(), userContextKey, userCtx)
 		streamCtx = withAuditAttribution(streamCtx, userCtx)
@@ -132,6 +144,21 @@ func StreamAuthInterceptor(coreService *core.KeyorixCore, requireMFA bool) grpc.
 
 		return handler(srv, wrappedStream)
 	}
+}
+
+// credentialMintingMethods are the RPCs that issue a durable credential and so must be
+// refused while impersonating (parity with the HTTP BlockWhenImpersonating routes). A
+// token minted here would outlive the bounded, audited impersonation session with no
+// impersonation attribution. Keep in sync with the HTTP routes wrapped in
+// BlockWhenImpersonating. (Service-account token issuance has no gRPC surface today.)
+var credentialMintingMethods = map[string]bool{
+	pb.MachineIdentityService_IssueMachineToken_FullMethodName: true,
+}
+
+// blockedUnderImpersonation reports whether fullMethod mints a durable credential that
+// must not be created while impersonating.
+func blockedUnderImpersonation(fullMethod string) bool {
+	return credentialMintingMethods[fullMethod]
 }
 
 // wrappedServerStream wraps grpc.ServerStream to override context

--- a/server/grpc/interceptors/auth_test.go
+++ b/server/grpc/interceptors/auth_test.go
@@ -59,6 +59,46 @@ func mintSessionForTest(t *testing.T, h *testhelper.RBACTestHelper, userID uint,
 	require.NoError(t, err)
 }
 
+// An impersonation session must not be able to mint a durable machine token over gRPC:
+// the credential would outlive the bounded, audited impersonation session. Parity with
+// the HTTP BlockWhenImpersonating guard. A benign RPC under the same session still works.
+func TestAuthInterceptor_BlocksMachineTokenIssuanceWhileImpersonating(t *testing.T) {
+	h := setupAuthHelper(t)
+	defer h.Cleanup()
+	admin := uint(7000)
+	target := uint(7001)
+	h.CreateTestUser(t, "imp-admin", admin)
+	h.CreateTestUser(t, "imp-target", target)
+	expiry := time.Now().Add(time.Hour)
+	_, err := h.Storage.CreateSession(context.Background(), &models.Session{
+		UserID: target, SessionToken: "imp-token", ExpiresAt: &expiry, ImpersonatedBy: &admin,
+	})
+	require.NoError(t, err)
+
+	interceptor := AuthInterceptor(h.CoreService, false)
+	const machineIssue = "/keyorix.v1.MachineIdentityService/IssueMachineToken"
+
+	// Credential-minting RPC under impersonation → refused.
+	_, err = interceptor(bearerCtx("imp-token"), nil,
+		&grpc.UnaryServerInfo{FullMethod: machineIssue}, okHandler(nil))
+	require.Error(t, err)
+	assert.Equal(t, codes.PermissionDenied, status.Code(err))
+
+	// A non-credential-minting RPC under the same impersonation session still proceeds.
+	resp, err := interceptor(bearerCtx("imp-token"), nil,
+		&grpc.UnaryServerInfo{FullMethod: secretMethod}, okHandler(nil))
+	require.NoError(t, err)
+	assert.Equal(t, "ok", resp)
+}
+
+// The predicate is the single source of truth for which gRPC methods are blocked while
+// impersonating; keep it aligned with the HTTP BlockWhenImpersonating routes.
+func TestBlockedUnderImpersonation(t *testing.T) {
+	assert.True(t, blockedUnderImpersonation("/keyorix.v1.MachineIdentityService/IssueMachineToken"))
+	assert.False(t, blockedUnderImpersonation(secretMethod))
+	assert.False(t, blockedUnderImpersonation("/keyorix.v1.MachineIdentityService/ListMachineTokens"))
+}
+
 func TestAuthInterceptor_ValidSessionPopulatesUserContext(t *testing.T) {
 	h := setupAuthHelper(t)
 	defer h.Cleanup()

--- a/server/grpc/services/break_glass_service_test.go
+++ b/server/grpc/services/break_glass_service_test.go
@@ -22,6 +22,10 @@ func newBreakGlassService(t *testing.T) *BreakGlassGRPCService {
 	require.NoError(t, h.DB.AutoMigrate(&models.BreakGlassActivation{}, &models.AuditEvent{}))
 	// user 1 = super_admin (global), so the scoped roles.read/roles.assign checks pass.
 	h.AssignUserRole(t, 1, 1, nil)
+	// Break-glass eligibility now requires a PROJECT-scoped membership (a global role no
+	// longer counts), so give user 1 a project-scoped role on project 1.
+	proj := uint(1)
+	h.AssignUserRole(t, 1, 4, &proj) // viewer at project 1
 	// Configure self-service emergency access with an emergency role that exists.
 	h.CreateTestRole(t, "emergency", "break-glass role", 90)
 	h.CoreService.SetBreakGlassPolicy(core.BreakGlassPolicy{

--- a/server/grpc/services/conversions.go
+++ b/server/grpc/services/conversions.go
@@ -30,20 +30,6 @@ func requireUser(ctx context.Context) (*interceptors.UserContext, error) {
 	return user, nil
 }
 
-// hasPermission reports flat membership in the caller's permission union. Use it
-// ONLY for self-scoped reads (a caller listing their OWN shares), where the result
-// set is already filtered to the caller and no cross-tenant access is possible. For
-// anything that reads or mutates another tenant's / global state, use
-// authorizeScoped / authorizeGlobal instead (see the bug-class note below).
-func hasPermission(permissions []string, required string) bool {
-	for _, p := range permissions {
-		if p == required {
-			return true
-		}
-	}
-	return false
-}
-
 // authorizeScoped enforces perm at the given scope via core.Authorize — the same
 // scope-aware path HTTP uses. This is the ONLY authorization primitive the services
 // use: an earlier flat `hasPermission(user.Permissions, …)` check treated a

--- a/server/grpc/services/machine_identity_service.go
+++ b/server/grpc/services/machine_identity_service.go
@@ -201,7 +201,9 @@ func (s *MachineIdentityGRPCService) RevokeMachineToken(ctx context.Context, req
 	if err := authorizeScoped(ctx, s.core, user, "roles.assign", core.Scope{ProjectID: uint(req.GetProjectId())}); err != nil {
 		return nil, err
 	}
-	if err := s.core.RevokeMachineToken(ctx, uint(req.GetProjectId()), uint(req.GetMachineId()), uint(req.GetTokenId()), user.UserID); err != nil {
+	// gRPC has no auth cache (the interceptor validates every request), so the returned
+	// hash needs no eviction here.
+	if _, err := s.core.RevokeMachineToken(ctx, uint(req.GetProjectId()), uint(req.GetMachineId()), uint(req.GetTokenId()), user.UserID); err != nil {
 		return nil, mapMachineError(err)
 	}
 	return &emptypb.Empty{}, nil

--- a/server/grpc/services/project_service.go
+++ b/server/grpc/services/project_service.go
@@ -152,6 +152,12 @@ func (s *ProjectGRPCService) UpdateProject(ctx context.Context, req *pb.UpdatePr
 	if req.RequireMfa != nil {
 		v := req.GetRequireMfa()
 		requireMFA = &v
+		// require_mfa is a per-project security-policy control: changing it additionally
+		// requires roles.assign at the project (parity with the HTTP handler), so a
+		// non-admin secrets.write holder can't silently disable MFA enforcement.
+		if err := authorizeScoped(ctx, s.core, user, "roles.assign", core.Scope{ProjectID: uint(req.GetId())}); err != nil {
+			return nil, err
+		}
 	}
 	project, err := s.core.UpdateProject(ctx, uint(req.GetId()), req.GetName(), req.GetDescription(), requireMFA)
 	if err != nil {

--- a/server/grpc/services/project_service_test.go
+++ b/server/grpc/services/project_service_test.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"testing"
 
+	"github.com/keyorixhq/keyorix/internal/storage/models"
 	pb "github.com/keyorixhq/keyorix/server/proto/pb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
+	"gorm.io/gorm"
 )
 
 // newProjectTestRig reuses the secret rig's seeded core (project 1 "default" +
@@ -19,6 +21,14 @@ func newProjectTestRig(t *testing.T) *ProjectGRPCService {
 	t.Helper()
 	r := newSecretTestRig(t)
 	return NewProjectService(r.svc.core)
+}
+
+// newProjectTestRigWithDB also returns the rig's DB so a test can seed extra grants
+// (e.g. roles.assign for the require_mfa policy gate).
+func newProjectTestRigWithDB(t *testing.T) (*ProjectGRPCService, *gorm.DB) {
+	t.Helper()
+	r := newSecretTestRig(t)
+	return NewProjectService(r.svc.core), r.db
 }
 
 func TestProjectService_CRUDAndList(t *testing.T) {
@@ -40,14 +50,13 @@ func TestProjectService_CRUDAndList(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "billing", got.GetName())
 
-	// Update name + require_mfa.
-	mfa := true
+	// Update name/description on the writer's secrets.write gate (require_mfa is a
+	// security-policy field with its own roles.assign gate, exercised separately).
 	upd, err := svc.UpdateProject(ctx, &pb.UpdateProjectRequest{
-		Id: created.GetId(), Name: "billing-prod", Description: "money", RequireMfa: &mfa,
+		Id: created.GetId(), Name: "billing-prod", Description: "money",
 	})
 	require.NoError(t, err)
 	assert.Equal(t, "billing-prod", upd.GetName())
-	assert.True(t, upd.GetRequireMfa())
 
 	// List environments of the seeded project.
 	envs, err := svc.ListEnvironments(ctx, &pb.ListEnvironmentsRequest{ProjectId: 1})
@@ -58,6 +67,27 @@ func TestProjectService_CRUDAndList(t *testing.T) {
 	// Delete the created project.
 	_, err = svc.DeleteProject(ctx, &pb.DeleteProjectRequest{Id: created.GetId()})
 	require.NoError(t, err)
+}
+
+// Changing require_mfa (a per-project security control) requires roles.assign at the
+// project — a plain secrets.write holder (the writer/editor persona) is refused, so a
+// developer cannot silently disable the project's MFA enforcement.
+func TestProjectService_UpdateRequireMFANeedsRolesAssign(t *testing.T) {
+	svc, db := newProjectTestRigWithDB(t)
+	ctx := authCtx(1, "owner") // user 1 = global writer (secrets.read/write/delete only)
+	mfa := false
+
+	// Writer (no roles.assign) → denied on the require_mfa toggle.
+	_, err := svc.UpdateProject(ctx, &pb.UpdateProjectRequest{Id: 1, Name: "default", RequireMfa: &mfa})
+	require.Error(t, err)
+	assert.Equal(t, codes.PermissionDenied, status.Code(err))
+
+	// Grant the writer role roles.assign, and now the toggle is allowed.
+	require.NoError(t, db.Create(&models.Permission{ID: 13, Name: "roles.assign", Resource: "roles", Action: "assign"}).Error)
+	require.NoError(t, db.Create(&models.RolePermission{RoleID: writerRoleID, PermissionID: 13}).Error)
+	upd, err := svc.UpdateProject(ctx, &pb.UpdateProjectRequest{Id: 1, Name: "default", RequireMfa: &mfa})
+	require.NoError(t, err)
+	assert.False(t, upd.GetRequireMfa())
 }
 
 func TestProjectService_Unauthenticated(t *testing.T) {

--- a/server/grpc/services/share_service.go
+++ b/server/grpc/services/share_service.go
@@ -97,10 +97,13 @@ func (s *ShareGRPCService) ListUserShares(ctx context.Context, req *pb.ListUserS
 	if err != nil {
 		return nil, err
 	}
-	// Self-scoped: returns only the caller's own shares, so a flat secrets.read
-	// check is sufficient (no cross-tenant access — see hasPermission's note).
-	if !hasPermission(user.Permissions, "secrets.read") {
-		return nil, status.Error(codes.PermissionDenied, "insufficient permissions")
+	// Authorize through the scope/actor-aware primitive (global secrets.read), matching
+	// the HTTP GET /shares gate. A flat hasPermission check ignored a PAT's scope
+	// restriction, so a project-scoped (or non-read) token could list shares over gRPC
+	// while HTTP correctly denied it — the #53/#54-class transport divergence, also the
+	// IP-allowlist divergence ADR-066 closed.
+	if err := authorizeGlobal(ctx, s.core, user, "secrets.read"); err != nil {
+		return nil, err
 	}
 
 	shares, err := s.core.ListSharesByUser(ctx, user.UserID)
@@ -117,9 +120,11 @@ func (s *ShareGRPCService) ListSharedSecrets(ctx context.Context, req *pb.ListSh
 	if err != nil {
 		return nil, err
 	}
-	// Self-scoped (caller's own shared-with-me secrets) — flat check is sufficient.
-	if !hasPermission(user.Permissions, "secrets.read") {
-		return nil, status.Error(codes.PermissionDenied, "insufficient permissions")
+	// Authorize through the scope/actor-aware primitive (global secrets.read), matching
+	// the HTTP GET /shared-secrets gate — a flat check let a PAT exceed its scope
+	// restriction over gRPC (transport divergence; see ListUserShares).
+	if err := authorizeGlobal(ctx, s.core, user, "secrets.read"); err != nil {
+		return nil, err
 	}
 
 	secrets, err := s.core.ListSharedSecrets(ctx, user.UserID)

--- a/server/grpc/services/share_service_test.go
+++ b/server/grpc/services/share_service_test.go
@@ -197,12 +197,36 @@ func TestShareService_ListSharedSecrets(t *testing.T) {
 	r := newShareTestRig(t)
 	r.share(t, "read")
 
+	// The recipient needs a REAL global secrets.read grant (parity with the HTTP
+	// GET /shared-secrets gate), not just a flat permission string in the token.
+	require.NoError(t, r.db.Create(&models.UserRole{UserID: 2, RoleID: writerRoleID}).Error)
+
 	// Listed from the recipient's perspective (user 2).
 	ctx := authCtx(2, "recipient", "secrets.read")
 	resp, err := r.svc.ListSharedSecrets(ctx, &pb.ListSharedSecretsRequest{})
 	require.NoError(t, err)
 	require.GreaterOrEqual(t, len(resp.GetSecrets()), 1)
 	assert.Equal(t, "shared-secret", resp.GetSecrets()[0].GetName())
+}
+
+// Regression (security review): ListUserShares / ListSharedSecrets must authorize
+// through the scope/actor-aware path, not a flat permission check — otherwise a PAT
+// restricted below global secrets.read could list shares over gRPC while HTTP denies
+// it. A caller whose token carries the "secrets.read" string but who holds no real
+// global grant must be denied.
+func TestShareService_ListShares_FlatPermissionDenied(t *testing.T) {
+	r := newShareTestRig(t)
+	r.share(t, "read")
+	// User 2 has NO role grant; the flat permission string must no longer be enough.
+	ctx := authCtx(2, "recipient", "secrets.read")
+
+	_, err := r.svc.ListSharedSecrets(ctx, &pb.ListSharedSecretsRequest{})
+	require.Error(t, err)
+	assert.Equal(t, codes.PermissionDenied, status.Code(err), "ListSharedSecrets flat-perm")
+
+	_, err = r.svc.ListUserShares(ctx, &pb.ListUserSharesRequest{})
+	require.Error(t, err)
+	assert.Equal(t, codes.PermissionDenied, status.Code(err), "ListUserShares flat-perm")
 }
 
 // Regression (security review): listing a secret's shares is owner-only on the

--- a/server/grpc/services/user_service_test.go
+++ b/server/grpc/services/user_service_test.go
@@ -31,7 +31,7 @@ func adminCtx() context.Context {
 func (svc *UserGRPCService) mustCreate(t *testing.T, username, email string) *pb.User {
 	t.Helper()
 	resp, err := svc.CreateUser(adminCtx(), &pb.CreateUserRequest{
-		Username: username, Email: email, Password: strPtr("password123"),
+		Username: username, Email: email, Password: strPtr("Qr7#Kp2$Lm5@Vn9!"),
 	})
 	require.NoError(t, err)
 	require.NotNil(t, resp.GetUser())
@@ -50,7 +50,7 @@ func TestUserService_CreateUser_Password(t *testing.T) {
 func TestUserService_CreateUser_Unauthenticated(t *testing.T) {
 	svc := newUserService(t)
 	_, err := svc.CreateUser(context.Background(), &pb.CreateUserRequest{
-		Username: "x", Email: "x@example.com", Password: strPtr("password123"),
+		Username: "x", Email: "x@example.com", Password: strPtr("Qr7#Kp2$Lm5@Vn9!"),
 	})
 	require.Error(t, err)
 	assert.Equal(t, codes.Unauthenticated, status.Code(err))
@@ -60,7 +60,7 @@ func TestUserService_CreateUser_PermissionDenied(t *testing.T) {
 	svc := newUserService(t)
 	ctx := authCtx(7, "reader") // ungranted user → denied
 	_, err := svc.CreateUser(ctx, &pb.CreateUserRequest{
-		Username: "x", Email: "x@example.com", Password: strPtr("password123"),
+		Username: "x", Email: "x@example.com", Password: strPtr("Qr7#Kp2$Lm5@Vn9!"),
 	})
 	require.Error(t, err)
 	assert.Equal(t, codes.PermissionDenied, status.Code(err))
@@ -126,14 +126,14 @@ func TestUserService_CreateUser_RoleGrantRequiresAssign(t *testing.T) {
 
 	// Plain user creation (no grant) is still allowed by users.write alone.
 	resp, err := svc.CreateUser(ctx, &pb.CreateUserRequest{
-		Username: "plain", Email: "plain@example.com", Password: strPtr("password123"),
+		Username: "plain", Email: "plain@example.com", Password: strPtr("Qr7#Kp2$Lm5@Vn9!"),
 	})
 	require.NoError(t, err)
 	require.NotNil(t, resp.GetUser())
 
 	// Handing out a system role is denied — this is the privilege-escalation gate.
 	_, err = svc.CreateUser(ctx, &pb.CreateUserRequest{
-		Username: "esc", Email: "esc@example.com", Password: strPtr("password123"),
+		Username: "esc", Email: "esc@example.com", Password: strPtr("Qr7#Kp2$Lm5@Vn9!"),
 		Role: strPtr("super_admin"),
 	})
 	require.Error(t, err)
@@ -141,7 +141,7 @@ func TestUserService_CreateUser_RoleGrantRequiresAssign(t *testing.T) {
 
 	// Handing out a project role is likewise denied.
 	_, err = svc.CreateUser(ctx, &pb.CreateUserRequest{
-		Username: "esc2", Email: "esc2@example.com", Password: strPtr("password123"),
+		Username: "esc2", Email: "esc2@example.com", Password: strPtr("Qr7#Kp2$Lm5@Vn9!"),
 		ProjectAssignments: []*pb.ProjectAssignment{{ProjectId: 1, Role: "editor"}},
 	})
 	require.Error(t, err)
@@ -154,7 +154,7 @@ func TestUserService_CreateUser_RoleGrantRequiresAssign(t *testing.T) {
 func TestUserService_CreateUser_AdminCanGrantRole(t *testing.T) {
 	svc := newUserService(t)
 	resp, err := svc.CreateUser(adminCtx(), &pb.CreateUserRequest{
-		Username: "withrole", Email: "withrole@example.com", Password: strPtr("password123"),
+		Username: "withrole", Email: "withrole@example.com", Password: strPtr("Qr7#Kp2$Lm5@Vn9!"),
 		Role: strPtr("system_viewer"),
 	})
 	require.NoError(t, err)

--- a/server/http/authz_http_grpc_parity_test.go
+++ b/server/http/authz_http_grpc_parity_test.go
@@ -48,8 +48,9 @@ func TestAuthzParity_HTTPvsGRPC_Secrets(t *testing.T) {
 
 	// Bootstrap seeds the admin, the standard roles (incl. "viewer" = secrets.read) +
 	// permissions, and project 1 with its environments.
+	c.SetBootstrapToken("test-bootstrap-token")
 	_, err = c.BootstrapSystem(ctx, &core.BootstrapRequest{
-		Username: "admin", Email: "admin@example.com", Password: "AdminPass123!",
+		Username: "admin", Email: "admin@example.com", Password: "AdminPassphrase123!", Token: "test-bootstrap-token",
 	})
 	require.NoError(t, err)
 	var admin models.User

--- a/server/http/authz_http_grpc_parity_test.go
+++ b/server/http/authz_http_grpc_parity_test.go
@@ -50,7 +50,7 @@ func TestAuthzParity_HTTPvsGRPC_Secrets(t *testing.T) {
 	// permissions, and project 1 with its environments.
 	c.SetBootstrapToken("test-bootstrap-token")
 	_, err = c.BootstrapSystem(ctx, &core.BootstrapRequest{
-		Username: "admin", Email: "admin@example.com", Password: "AdminPassphrase123!", Token: "test-bootstrap-token",
+		Username: "admin", Email: "admin@example.com", Password: "Qr7#Kp2$Lm5@Vn9!", Token: "test-bootstrap-token",
 	})
 	require.NoError(t, err)
 	var admin models.User
@@ -60,12 +60,12 @@ func TestAuthzParity_HTTPvsGRPC_Secrets(t *testing.T) {
 	require.NoError(t, db.Create(&models.Environment{ID: 9, ProjectID: 2, Name: "prod"}).Error)
 
 	// A viewer (secrets.read) scoped to project 1 ONLY.
-	vu, err := c.CreateUser(ctx, &core.CreateUserRequest{Username: "viewer", Email: "viewer@example.com", Password: "ViewerPass123!"})
+	vu, err := c.CreateUser(ctx, &core.CreateUserRequest{Username: "viewer", Email: "viewer@example.com", Password: "Qr7#Kp2$Lm5@Vn9!"})
 	require.NoError(t, err)
 	var viewerRole models.Role
 	require.NoError(t, db.Where("name = ?", "viewer").First(&viewerRole).Error)
 	require.NoError(t, db.Create(&models.UserRole{UserID: vu.ID, RoleID: viewerRole.ID, ProjectID: 1}).Error)
-	session, _, err := c.Login(ctx, &core.LoginRequest{Username: "viewer", Password: "ViewerPass123!"})
+	session, _, err := c.Login(ctx, &core.LoginRequest{Username: "viewer", Password: "Qr7#Kp2$Lm5@Vn9!"})
 	require.NoError(t, err)
 	token := session.SessionToken
 

--- a/server/http/authz_share_parity_test.go
+++ b/server/http/authz_share_parity_test.go
@@ -47,7 +47,7 @@ func TestAuthzParity_HTTPvsGRPC_ShareCreate(t *testing.T) {
 
 	c.SetBootstrapToken("test-bootstrap-token")
 	_, err = c.BootstrapSystem(ctx, &core.BootstrapRequest{
-		Username: "admin", Email: "admin@example.com", Password: "AdminPassphrase123!", Token: "test-bootstrap-token",
+		Username: "admin", Email: "admin@example.com", Password: "Qr7#Kp2$Lm5@Vn9!", Token: "test-bootstrap-token",
 	})
 	require.NoError(t, err)
 
@@ -61,16 +61,16 @@ func TestAuthzParity_HTTPvsGRPC_ShareCreate(t *testing.T) {
 	}
 
 	// owner — has secrets.write on p1 AND owns the secret (can share).
-	owner, err := c.CreateUser(ctx, &core.CreateUserRequest{Username: "owner", Email: "owner@example.com", Password: "OwnerPass123!"})
+	owner, err := c.CreateUser(ctx, &core.CreateUserRequest{Username: "owner", Email: "owner@example.com", Password: "Qr7#Kp2$Lm5@Vn9!"})
 	require.NoError(t, err)
 	require.NoError(t, db.Create(&models.UserRole{UserID: owner.ID, RoleID: editorRole.ID, ProjectID: 1}).Error)
-	ownerToken := login("owner", "OwnerPass123!")
+	ownerToken := login("owner", "Qr7#Kp2$Lm5@Vn9!")
 
 	// writer — has secrets.write on p1 but does NOT own the secret (must not re-share).
-	writer, err := c.CreateUser(ctx, &core.CreateUserRequest{Username: "writer", Email: "writer@example.com", Password: "WriterPass123!"})
+	writer, err := c.CreateUser(ctx, &core.CreateUserRequest{Username: "writer", Email: "writer@example.com", Password: "Qr7#Kp2$Lm5@Vn9!"})
 	require.NoError(t, err)
 	require.NoError(t, db.Create(&models.UserRole{UserID: writer.ID, RoleID: editorRole.ID, ProjectID: 1}).Error)
-	writerToken := login("writer", "WriterPass123!")
+	writerToken := login("writer", "Qr7#Kp2$Lm5@Vn9!")
 
 	// Recipients just need to exist. Distinct ones for the allow case so the HTTP and
 	// gRPC shares don't collide as duplicates.

--- a/server/http/authz_share_parity_test.go
+++ b/server/http/authz_share_parity_test.go
@@ -45,8 +45,9 @@ func TestAuthzParity_HTTPvsGRPC_ShareCreate(t *testing.T) {
 	c := core.NewKeyorixCore(store.NewLocalStorage(db))
 	ctx := context.Background()
 
+	c.SetBootstrapToken("test-bootstrap-token")
 	_, err = c.BootstrapSystem(ctx, &core.BootstrapRequest{
-		Username: "admin", Email: "admin@example.com", Password: "AdminPass123!",
+		Username: "admin", Email: "admin@example.com", Password: "AdminPassphrase123!", Token: "test-bootstrap-token",
 	})
 	require.NoError(t, err)
 

--- a/server/http/handlers/audit_anomaly.go
+++ b/server/http/handlers/audit_anomaly.go
@@ -55,9 +55,14 @@ func AcknowledgeAnomalyAlert(w http.ResponseWriter, r *http.Request) {
 		sendError(w, "BadRequest", "Invalid alert ID", http.StatusBadRequest, nil)
 		return
 	}
-	detector := core.NewAnomalyDetector(coreService.Storage())
-	if err := detector.AcknowledgeAlert(r.Context(), uint(id)); err != nil {
-		sendError(w, "InternalError", "Failed to acknowledge alert", http.StatusInternalServerError, nil)
+	var actorID uint
+	if u := middleware.GetUserFromContext(r.Context()); u != nil {
+		actorID = u.UserID
+	}
+	// Routed through the core (not the bare detector) so the dismissal is audited with
+	// the acting operator and a missing alert id is reported as not-found, not a silent ok.
+	if err := coreService.AcknowledgeAnomalyAlert(r.Context(), actorID, uint(id)); err != nil {
+		sendError(w, "NotFound", "Anomaly alert not found", http.StatusNotFound, nil)
 		return
 	}
 	sendSuccess(w, map[string]interface{}{"acknowledged": true}, "")

--- a/server/http/handlers/audit_export_csv.go
+++ b/server/http/handlers/audit_export_csv.go
@@ -90,15 +90,15 @@ func (h *AuditHandler) ExportAuditLogsCSV(w http.ResponseWriter, r *http.Request
 		_ = cw.Write([]string{
 			strconv.FormatUint(uint64(e.ID), 10),
 			e.EventTime.UTC().Format(time.RFC3339),
-			e.EventType,
-			name(e.UserID),
+			csvSafe(e.EventType),
+			csvSafe(name(e.UserID)),
 			actorTypeOrDefault(e.ActorType),
 			uintStr(e.UserID),
 			uintStr(e.ProjectID),
 			uintStr(e.SecretNodeID),
-			e.IPAddress,
+			csvSafe(e.IPAddress),
 			success,
-			e.Description,
+			csvSafe(e.Description),
 		})
 	}
 }

--- a/server/http/handlers/auth.go
+++ b/server/http/handlers/auth.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/keyorixhq/keyorix/server/middleware"
 )
@@ -75,6 +76,7 @@ type initSystemRequestBody struct {
 	Email       string `json:"email"`
 	Password    string `json:"password"`
 	DisplayName string `json:"display_name"`
+	Token       string `json:"bootstrap_token"`
 }
 
 // ── Handlers ──────────────────────────────────────────────────────────────────
@@ -530,14 +532,26 @@ func (h *AuthHandler) InitSystem(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// The bootstrap token authorizes the first-admin claim. Accept it from a header
+	// (preferred) or the request body so the CLI and automation can supply it.
+	token := r.Header.Get("X-Keyorix-Bootstrap-Token")
+	if token == "" {
+		token = body.Token
+	}
 	result, err := h.coreService.BootstrapSystem(r.Context(), &core.BootstrapRequest{
 		Username:    body.Username,
 		Email:       body.Email,
 		Password:    body.Password,
 		DisplayName: body.DisplayName,
+		Token:       token,
 	})
 	if err != nil {
-		sendError(w, "Error", err.Error(), http.StatusInternalServerError, nil)
+		// A bad/missing token or a weak password is a client error, not a 500.
+		status := http.StatusInternalServerError
+		if strings.Contains(err.Error(), "bootstrap token") || strings.Contains(err.Error(), i18n.T("ErrorValidation", nil)) {
+			status = http.StatusForbidden
+		}
+		sendError(w, "Error", err.Error(), status, nil)
 		return
 	}
 

--- a/server/http/handlers/auth.go
+++ b/server/http/handlers/auth.go
@@ -555,6 +555,15 @@ func (h *AuthHandler) InitSystem(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// On an already-initialized system this endpoint is reachable UNAUTHENTICATED (the
+	// bootstrap token only gates the create path). Returning the admin's username/email
+	// and the project/environment topology here would be a pre-auth identity/topology
+	// oracle, so the idempotent response carries only the initialized flag.
+	if result.AlreadyInitialized {
+		sendSuccess(w, map[string]interface{}{"already_initialized": true}, "System already initialised")
+		return
+	}
+
 	envNames := make([]string, 0, len(result.Environments))
 	for _, e := range result.Environments {
 		envNames = append(envNames, e.Name)
@@ -575,11 +584,7 @@ func (h *AuthHandler) InitSystem(w http.ResponseWriter, r *http.Request) {
 		resp["project"] = result.Project.Name
 	}
 
-	msg := "System initialised successfully"
-	if result.AlreadyInitialized {
-		msg = "System already initialised"
-	}
-	sendSuccess(w, resp, msg)
+	sendSuccess(w, resp, "System initialised successfully")
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────

--- a/server/http/handlers/catalog.go
+++ b/server/http/handlers/catalog.go
@@ -208,6 +208,14 @@ func (h *CatalogHandler) CreateProjectEnvironment(w http.ResponseWriter, r *http
 		sendError(w, "ValidationError", "Environment name is required", http.StatusBadRequest, nil)
 		return
 	}
+	// The scope check resolves the project id from the URL without verifying it exists,
+	// so confirm the parent project is live before creating an environment under it —
+	// otherwise a caller who held write on a since-deleted project could re-establish a
+	// usable scope under it (GetProject excludes soft-deleted projects).
+	if _, perr := h.coreService.Storage().GetProject(r.Context(), uint(id)); perr != nil {
+		sendError(w, "NotFound", "Project not found", http.StatusNotFound, nil)
+		return
+	}
 	env, err := h.coreService.Storage().CreateEnvironment(r.Context(), &models.Environment{
 		ProjectID: uint(id),
 		Name:      body.Name,

--- a/server/http/handlers/catalog.go
+++ b/server/http/handlers/catalog.go
@@ -160,6 +160,22 @@ func (h *CatalogHandler) UpdateProject(w http.ResponseWriter, r *http.Request) {
 		sendError(w, "InvalidJSON", "Invalid request body", http.StatusBadRequest, nil)
 		return
 	}
+	// require_mfa is a per-project SECURITY-POLICY control (ADR-037), not ordinary content.
+	// The route gate only proves secrets.write — held by the non-admin editor persona — so
+	// changing it must additionally require roles.assign at the project (the admin/membership
+	// tier), otherwise a developer could silently disable the project's MFA enforcement.
+	// name/description stay on the secrets.write gate.
+	if body.RequireMFA != nil {
+		actor := middleware.GetUserFromContext(r.Context())
+		if actor == nil {
+			sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+			return
+		}
+		if ok, aerr := h.coreService.AuthorizePrincipal(r.Context(), actor.ActorKind(), actor.PrincipalID(), "roles.assign", core.Scope{ProjectID: uint(id)}); aerr != nil || !ok {
+			sendError(w, "Forbidden", "changing a project's MFA requirement requires the roles.assign permission", http.StatusForbidden, nil)
+			return
+		}
+	}
 	project, err := h.coreService.UpdateProject(r.Context(), uint(id), body.Name, body.Description, body.RequireMFA)
 	if err != nil {
 		sendError(w, "Error", err.Error(), http.StatusInternalServerError, nil)

--- a/server/http/handlers/csv_safe.go
+++ b/server/http/handlers/csv_safe.go
@@ -1,0 +1,17 @@
+package handlers
+
+// csvSafe neutralizes spreadsheet formula injection (CWE-1236): a CSV cell beginning
+// with =, +, -, @, TAB, or CR is prefixed with a single quote so Excel / LibreOffice /
+// Sheets treat it as text rather than executing it as a formula. Apply it to any
+// user-controlled field (secret names, usernames, descriptions) written to a CSV
+// export an auditor may open.
+func csvSafe(s string) string {
+	if s == "" {
+		return s
+	}
+	switch s[0] {
+	case '=', '+', '-', '@', '\t', '\r':
+		return "'" + s
+	}
+	return s
+}

--- a/server/http/handlers/csv_safe_test.go
+++ b/server/http/handlers/csv_safe_test.go
@@ -1,0 +1,21 @@
+package handlers
+
+import "testing"
+
+func TestCSVSafe(t *testing.T) {
+	cases := map[string]string{
+		"":                         "",
+		"db-password":              "db-password",
+		"=HYPERLINK(\"http://x\")": "'=HYPERLINK(\"http://x\")",
+		"+1+1":                     "'+1+1",
+		"-2+3":                     "'-2+3",
+		"@SUM(A1)":                 "'@SUM(A1)",
+		"\tlead-tab":               "'\tlead-tab",
+		"normal=mid":               "normal=mid", // only a LEADING formula char is defanged
+	}
+	for in, want := range cases {
+		if got := csvSafe(in); got != want {
+			t.Errorf("csvSafe(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/server/http/handlers/dynamic_secrets.go
+++ b/server/http/handlers/dynamic_secrets.go
@@ -70,6 +70,7 @@ func (h *DynamicSecretHandler) CreateConfig(w http.ResponseWriter, r *http.Reque
 		CreationTemplate  string `json:"creation_template"`
 		DefaultTTLSeconds int    `json:"default_ttl_seconds"`
 		MaxTTLSeconds     int    `json:"max_ttl_seconds"`
+		MaxActiveLeases   int    `json:"max_active_leases"`
 		Classification    string `json:"classification"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
@@ -90,6 +91,7 @@ func (h *DynamicSecretHandler) CreateConfig(w http.ResponseWriter, r *http.Reque
 		CreationTemplate:  body.CreationTemplate,
 		DefaultTTLSeconds: body.DefaultTTLSeconds,
 		MaxTTLSeconds:     body.MaxTTLSeconds,
+		MaxActiveLeases:   body.MaxActiveLeases,
 		Classification:    body.Classification,
 		CreatedBy:         userCtx.Username,
 	})
@@ -300,6 +302,7 @@ func sanitizeConfig(c *models.DynamicSecretConfig) map[string]interface{} {
 		"creation_template":   c.CreationTemplate,
 		"default_ttl_seconds": c.DefaultTTLSeconds,
 		"max_ttl_seconds":     c.MaxTTLSeconds,
+		"max_active_leases":   c.MaxActiveLeases,
 		"classification":      c.Classification,
 		"created_by":          c.CreatedBy,
 		"created_at":          c.CreatedAt,

--- a/server/http/handlers/global_invitation_test.go
+++ b/server/http/handlers/global_invitation_test.go
@@ -27,11 +27,19 @@ func setupGlobalInvitationTest(t *testing.T) (*CatalogHandler, *gorm.DB) {
 	require.NoError(t, db.AutoMigrate(
 		&models.User{}, &models.UserRole{}, &models.Role{}, &models.Project{},
 		&models.ProjectInvitation{}, &models.SetupToken{}, &models.AuditEvent{},
+		// AuthorizePrincipal (the invite ceiling) resolves group-inherited roles too.
+		&models.Group{}, &models.UserGroup{}, &models.GroupRole{},
 	))
 	require.NoError(t, db.Create(&models.Role{Name: "system_viewer"}).Error)
 	require.NoError(t, db.Create(&models.Role{Name: "system_auditor"}).Error)
 	require.NoError(t, db.Create(&models.Role{Name: "project_developer"}).Error)
 	require.NoError(t, db.Create(&models.Project{Name: "default"}).Error)
+	// The acting user (withUserCtx → UserID 1) is a global super_admin, so it holds
+	// roles.assign everywhere and passes the invite privilege ceiling. A non-admin actor
+	// is exercised separately in the ceiling test below.
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "testuser", Email: "testuser@example.com"}).Error)
+	require.NoError(t, db.Create(&models.Role{ID: 100, Name: "super_admin"}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 100, ProjectID: 0}).Error)
 	return NewCatalogHandler(core.NewKeyorixCore(store.NewLocalStorage(db))), db
 }
 
@@ -80,5 +88,39 @@ func TestCreateGlobalInvitation(t *testing.T) {
 		body := `{"email":"z@y.io","project_assignments":[{"project_id":` + itoa(proj.ID) + `,"role":"bogus"}]}`
 		w := postGlobalInvite(t, h, body)
 		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+}
+
+// The invite privilege ceiling: a non-admin actor (holds users.write via the route gate
+// but NOT roles.assign) cannot invite with a system role or a project role — otherwise
+// an onboarding manager could invite themselves as system_admin and own the install.
+func TestCreateGlobalInvitation_EnforcesAssignCeiling(t *testing.T) {
+	h, db := setupGlobalInvitationTest(t)
+	var proj models.Project
+	require.NoError(t, db.Where("name = ?", "default").First(&proj).Error)
+	require.NoError(t, db.Create(&models.Role{Name: "system_admin"}).Error)
+
+	// Strip the actor's admin authority — user 1 now holds no role-granting power.
+	require.NoError(t, db.Where("user_id = ?", 1).Delete(&models.UserRole{}).Error)
+
+	t.Run("inviting a system role without roles.assign → 403", func(t *testing.T) {
+		w := postGlobalInvite(t, h, `{"email":"a@b.io","role":"system_admin"}`)
+		assert.Equal(t, http.StatusForbidden, w.Code)
+		var n int64
+		require.NoError(t, db.Model(&models.ProjectInvitation{}).Where("email = ?", "a@b.io").Count(&n).Error)
+		assert.Equal(t, int64(0), n, "no invitation is created when the ceiling refuses")
+	})
+
+	t.Run("inviting a project role without roles.assign in that project → 403", func(t *testing.T) {
+		body := `{"email":"c@d.io","project_assignments":[{"project_id":` + itoa(proj.ID) + `,"role":"project_developer"}]}`
+		w := postGlobalInvite(t, h, body)
+		assert.Equal(t, http.StatusForbidden, w.Code)
+	})
+
+	t.Run("inviting the default baseline (no role) is still allowed", func(t *testing.T) {
+		// An empty role defaults to system_viewer (the minimal baseline), which is not a
+		// privilege grant, so users.write alone suffices — mirrors CreateUser.
+		w := postGlobalInvite(t, h, `{"email":"e@f.io"}`)
+		assert.Equal(t, http.StatusCreated, w.Code)
 	})
 }

--- a/server/http/handlers/health.go
+++ b/server/http/handlers/health.go
@@ -4,8 +4,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"time"
-
-	"github.com/keyorixhq/keyorix/internal/version"
 )
 
 // processStart is captured when the package loads (≈ server start) so /health can report
@@ -17,12 +15,13 @@ var processStart = time.Now()
 // dependencies (that is /readyz's job) — a transient dependency outage should not cause
 // the liveness probe to fail and restart the pod.
 func HealthCheck(w http.ResponseWriter, r *http.Request) {
+	// Deliberately omit version/commit: /health is unauthenticated, and disclosing the
+	// exact build aids CVE targeting. The precise version is available on the
+	// system.read-gated /api/v1/system/info instead.
 	health := map[string]interface{}{
 		"status":    "healthy",
 		"timestamp": time.Now().UTC(),
 		"uptime":    time.Since(processStart).String(),
-		"version":   version.Version,
-		"commit":    version.Commit,
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/server/http/handlers/health_test.go
+++ b/server/http/handlers/health_test.go
@@ -24,7 +24,10 @@ func TestHealthCheck(t *testing.T) {
 	assert.Equal(t, "healthy", body["status"])
 	assert.Contains(t, body, "timestamp")
 	assert.Contains(t, body, "uptime")
-	assert.Contains(t, body, "version")
+	// version/commit are deliberately NOT disclosed on the unauthenticated /health
+	// (CVE-targeting); they live on the system.read-gated /api/v1/system/info.
+	assert.NotContains(t, body, "version")
+	assert.NotContains(t, body, "commit")
 
 	// The old handler fabricated dependency health (always "healthy" db/storage/
 	// encryption) — that lie is gone. Liveness must not claim DB health (see /readyz).

--- a/server/http/handlers/invitations.go
+++ b/server/http/handlers/invitations.go
@@ -107,6 +107,23 @@ func (h *CatalogHandler) CreateGlobalInvitation(w http.ResponseWriter, r *http.R
 		sendError(w, "ValidationError", "email is required", http.StatusBadRequest, nil)
 		return
 	}
+	// Privilege ceiling (mirrors CreateUser): the route gate proves users.write, but a
+	// users.write holder must not be able to GRANT a role they themselves lack authority
+	// to assign — otherwise an onboarding manager without roles.assign could invite an
+	// account (their own email) as system_admin and own the install on accept. Require
+	// roles.assign at the relevant scope for the system role and each project assignment.
+	if body.Role != "" {
+		if ok, aerr := h.coreService.AuthorizePrincipal(r.Context(), actor.ActorKind(), actor.PrincipalID(), "roles.assign", core.Scope{}); aerr != nil || !ok {
+			sendError(w, "Forbidden", "You may not invite with a system role you cannot assign", http.StatusForbidden, nil)
+			return
+		}
+	}
+	for _, a := range body.ProjectAssignments {
+		if ok, aerr := h.coreService.AuthorizePrincipal(r.Context(), actor.ActorKind(), actor.PrincipalID(), "roles.assign", core.Scope{ProjectID: a.ProjectID}); aerr != nil || !ok {
+			sendError(w, "Forbidden", "You may not invite with roles in a project where you cannot assign roles", http.StatusForbidden, nil)
+			return
+		}
+	}
 	assignments := make([]core.ProjectAssignment, 0, len(body.ProjectAssignments))
 	for _, a := range body.ProjectAssignments {
 		assignments = append(assignments, core.ProjectAssignment{ProjectID: a.ProjectID, Role: a.Role})

--- a/server/http/handlers/machine_identities.go
+++ b/server/http/handlers/machine_identities.go
@@ -184,6 +184,15 @@ func (h *CatalogHandler) TransitionMachineIdentity(w http.ResponseWriter, r *htt
 		sendError(w, "Error", err.Error(), status, nil)
 		return
 	}
+	// Suspending or revoking the identity must reject its tokens immediately, not after
+	// the auth-cache TTL — evict every credential's cache entry.
+	if to == core.MachineSuspended || to == core.MachineRevoked {
+		if hashes, herr := h.coreService.MachineTokenHashes(r.Context(), uint(machineID)); herr == nil {
+			for _, hsh := range hashes {
+				middleware.InvalidateTokenCacheByHash(hsh)
+			}
+		}
+	}
 	sendSuccess(w, map[string]interface{}{"machine_identity": m}, "Machine identity updated")
 }
 
@@ -297,7 +306,8 @@ func (h *CatalogHandler) RevokeMachineToken(w http.ResponseWriter, r *http.Reque
 		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
 		return
 	}
-	if err := h.coreService.RevokeMachineToken(r.Context(), uint(projectID), uint(machineID), uint(tokenID), actor.UserID); err != nil {
+	tokenHash, err := h.coreService.RevokeMachineToken(r.Context(), uint(projectID), uint(machineID), uint(tokenID), actor.UserID)
+	if err != nil {
 		status := http.StatusInternalServerError
 		if strings.Contains(err.Error(), "not found") {
 			status = http.StatusNotFound
@@ -305,6 +315,8 @@ func (h *CatalogHandler) RevokeMachineToken(w http.ResponseWriter, r *http.Reque
 		sendError(w, "Error", err.Error(), status, nil)
 		return
 	}
+	// Evict the auth cache so the revoked token stops authenticating immediately.
+	middleware.InvalidateTokenCacheByHash(tokenHash)
 	sendSuccess(w, nil, "Machine token revoked")
 }
 

--- a/server/http/handlers/pat_handler.go
+++ b/server/http/handlers/pat_handler.go
@@ -198,9 +198,13 @@ func (h *PATHandler) RevokePAT(w http.ResponseWriter, r *http.Request) {
 		sendError(w, "BadRequest", "Invalid token ID", http.StatusBadRequest, nil)
 		return
 	}
-	if err := h.coreService.RevokeOwnPAT(r.Context(), userCtx.UserID, uint(id)); err != nil {
+	tokenHash, err := h.coreService.RevokeOwnPAT(r.Context(), userCtx.UserID, uint(id))
+	if err != nil {
 		sendError(w, "NotFound", "Token not found", http.StatusNotFound, nil)
 		return
 	}
+	// Evict the auth cache so the revoked token stops authenticating immediately rather
+	// than lingering for the positive-cache TTL.
+	middleware.InvalidateTokenCacheByHash(tokenHash)
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/server/http/handlers/rotation_policies_handler.go
+++ b/server/http/handlers/rotation_policies_handler.go
@@ -290,6 +290,21 @@ func (h *RotationPolicyHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
+// parseOptionalUintQuery parses an optional uint query parameter; returns (nil, nil)
+// when absent and (nil, err) when present but not a valid uint.
+func parseOptionalUintQuery(r *http.Request, key string) (*uint, error) {
+	v := r.URL.Query().Get(key)
+	if v == "" {
+		return nil, nil
+	}
+	id, err := strconv.ParseUint(v, 10, 32)
+	if err != nil {
+		return nil, err
+	}
+	uid := uint(id)
+	return &uid, nil
+}
+
 // Evaluate handles GET /api/v1/rotation-policies/evaluate
 func (h *RotationPolicyHandler) Evaluate(w http.ResponseWriter, r *http.Request) {
 	userCtx := middleware.GetUserFromContext(r.Context())
@@ -309,7 +324,16 @@ func (h *RotationPolicyHandler) Evaluate(w http.ResponseWriter, r *http.Request)
 		projectID = &uid
 	}
 
-	evaluations, err := h.coreService.EvaluateRotationPolicies(r.Context(), projectID)
+	// Honour environment_id so an environment-scoped reader's view is confined to their
+	// environment (the route gate authorizes at {project, environment} via ScopeFromQuery,
+	// but the core previously ignored the env and returned the whole project's posture).
+	environmentID, perr := parseOptionalUintQuery(r, "environment_id")
+	if perr != nil {
+		h.sendError(w, "InvalidParameter", "Invalid environment_id", http.StatusBadRequest, nil)
+		return
+	}
+
+	evaluations, err := h.coreService.EvaluateRotationPolicies(r.Context(), projectID, environmentID)
 	if err != nil {
 		log.Printf("Error evaluating rotation policies: %v", err)
 		h.sendError(w, "InternalError", "Failed to evaluate rotation policies", http.StatusInternalServerError, nil)
@@ -341,7 +365,15 @@ func (h *RotationPolicyHandler) Status(w http.ResponseWriter, r *http.Request) {
 		projectID = &uid
 	}
 
-	entries, err := h.coreService.GetRotationStatus(r.Context(), projectID)
+	// Honour environment_id so an environment-scoped reader's view is confined to their
+	// environment (see Evaluate).
+	environmentID, perr := parseOptionalUintQuery(r, "environment_id")
+	if perr != nil {
+		h.sendError(w, "InvalidParameter", "Invalid environment_id", http.StatusBadRequest, nil)
+		return
+	}
+
+	entries, err := h.coreService.GetRotationStatus(r.Context(), projectID, environmentID)
 	if err != nil {
 		log.Printf("Error getting rotation status: %v", err)
 		h.sendError(w, "InternalError", "Failed to get rotation status", http.StatusInternalServerError, nil)

--- a/server/http/handlers/scim.go
+++ b/server/http/handlers/scim.go
@@ -151,7 +151,8 @@ func (h *SCIMHandler) ListUsers(w http.ResponseWriter, r *http.Request) {
 		writeSCIM(w, http.StatusOK, listResponse(resources))
 		return
 	}
-	users, err := h.coreService.ListSCIMUsers(r.Context())
+	startIndex, count := scimPaging(r)
+	users, total, err := h.coreService.ListSCIMUsersPage(r.Context(), startIndex, count)
 	if err != nil {
 		scimError(w, http.StatusInternalServerError, err.Error())
 		return
@@ -160,14 +161,40 @@ func (h *SCIMHandler) ListUsers(w http.ResponseWriter, r *http.Request) {
 	for _, u := range users {
 		resources = append(resources, toSCIMUser(u))
 	}
-	writeSCIM(w, http.StatusOK, listResponse(resources))
+	writeSCIM(w, http.StatusOK, listResponsePaged(resources, total, startIndex))
+}
+
+// scimPaging parses the SCIM startIndex (1-based, default 1) and count (default and
+// max SCIMMaxPageSize) query parameters, clamping count so an unfiltered list cannot
+// drain the whole directory into a single response.
+func scimPaging(r *http.Request) (startIndex, count int) {
+	startIndex = 1
+	if v := r.URL.Query().Get("startIndex"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			startIndex = n
+		}
+	}
+	count = core.SCIMMaxPageSize
+	if v := r.URL.Query().Get("count"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+			count = n
+		}
+	}
+	if count > core.SCIMMaxPageSize {
+		count = core.SCIMMaxPageSize
+	}
+	return startIndex, count
 }
 
 func listResponse(resources []map[string]interface{}) map[string]interface{} {
+	return listResponsePaged(resources, len(resources), 1)
+}
+
+func listResponsePaged(resources []map[string]interface{}, total, startIndex int) map[string]interface{} {
 	return map[string]interface{}{
 		"schemas":      []string{scimListSchema},
-		"totalResults": len(resources),
-		"startIndex":   1,
+		"totalResults": total,
+		"startIndex":   startIndex,
 		"itemsPerPage": len(resources),
 		"Resources":    resources,
 	}

--- a/server/http/handlers/scim_groups.go
+++ b/server/http/handlers/scim_groups.go
@@ -18,6 +18,15 @@ import (
 
 const scimGroupSchema = "urn:ietf:params:scim:schemas:core:2.0:Group"
 
+// SCIM group-mutation bounds: a single request may not carry more than these many
+// member entries or patch operations, so a multi-MiB members[] / Operations[] array
+// can't fan out into hundreds of thousands of per-member DB writes (the body is already
+// capped at 10 MiB, but that still permits a very large small-object array).
+const (
+	scimMaxMembersPerRequest = 5000
+	scimMaxPatchOps          = 1000
+)
+
 func toSCIMGroup(g *models.Group, members []*models.User) map[string]interface{} {
 	mem := make([]map[string]interface{}, 0, len(members))
 	for _, u := range members {
@@ -79,15 +88,43 @@ func (h *SCIMHandler) ListGroups(w http.ResponseWriter, r *http.Request) {
 		}
 		wantName = m[1]
 	}
-	resources := make([]map[string]interface{}, 0, len(groups))
+
+	// Apply the name filter first, then a bounded page. Members are fetched ONLY for the
+	// groups on the returned page, so the per-group GetGroupMembers query (an N+1) is
+	// capped at the page size instead of running across the whole directory.
+	matched := groups[:0]
 	for _, g := range groups {
-		if wantName != "" && g.Name != wantName {
-			continue
+		if wantName == "" || g.Name == wantName {
+			matched = append(matched, g)
 		}
+	}
+	total := len(matched)
+	startIndex, count := scimPaging(r)
+	page := pageSlice(matched, startIndex, count)
+
+	resources := make([]map[string]interface{}, 0, len(page))
+	for _, g := range page {
 		members, _ := h.coreService.GetGroupMembers(r.Context(), g.ID)
 		resources = append(resources, toSCIMGroup(g, members))
 	}
-	writeSCIM(w, http.StatusOK, listResponse(resources))
+	writeSCIM(w, http.StatusOK, listResponsePaged(resources, total, startIndex))
+}
+
+// pageSlice returns the [startIndex, startIndex+count) window of items (startIndex is
+// 1-based), clamped to the slice bounds.
+func pageSlice[T any](items []T, startIndex, count int) []T {
+	lo := startIndex - 1
+	if lo < 0 {
+		lo = 0
+	}
+	if lo >= len(items) || count <= 0 {
+		return nil
+	}
+	hi := lo + count
+	if hi > len(items) {
+		hi = len(items)
+	}
+	return items[lo:hi]
 }
 
 // GetGroup handles GET /scim/v2/Groups/{id}.
@@ -115,6 +152,10 @@ func (h *SCIMHandler) CreateGroup(w http.ResponseWriter, r *http.Request) {
 		scimError(w, http.StatusBadRequest, "displayName is required")
 		return
 	}
+	if len(p.Members) > scimMaxMembersPerRequest {
+		scimError(w, http.StatusRequestEntityTooLarge, "too many members in one request")
+		return
+	}
 	g, err := h.coreService.ProvisionSCIMGroup(r.Context(), 0, p.DisplayName, p.memberIDs())
 	if err != nil {
 		status := http.StatusBadRequest
@@ -138,6 +179,10 @@ func (h *SCIMHandler) ReplaceGroup(w http.ResponseWriter, r *http.Request) {
 		scimError(w, http.StatusBadRequest, "invalid SCIM payload")
 		return
 	}
+	if len(p.Members) > scimMaxMembersPerRequest {
+		scimError(w, http.StatusRequestEntityTooLarge, "too many members in one request")
+		return
+	}
 	g, err := h.coreService.ReplaceSCIMGroup(r.Context(), 0, id, p.DisplayName, p.memberIDs())
 	if err != nil {
 		scimError(w, http.StatusNotFound, err.Error())
@@ -159,6 +204,10 @@ func (h *SCIMHandler) PatchGroup(w http.ResponseWriter, r *http.Request) {
 	var patch scimPatch
 	if err := json.NewDecoder(r.Body).Decode(&patch); err != nil {
 		scimError(w, http.StatusBadRequest, "invalid SCIM patch")
+		return
+	}
+	if len(patch.Operations) > scimMaxPatchOps {
+		scimError(w, http.StatusRequestEntityTooLarge, "too many patch operations in one request")
 		return
 	}
 
@@ -207,6 +256,11 @@ func (h *SCIMHandler) PatchGroup(w http.ResponseWriter, r *http.Request) {
 			replaceAll = true
 			replaceMembers = parseValueMembers(op.Value)
 		}
+	}
+
+	if len(addIDs)+len(removeIDs)+len(replaceMembers) > scimMaxMembersPerRequest {
+		scimError(w, http.StatusRequestEntityTooLarge, "too many members in one request")
+		return
 	}
 
 	var g *models.Group

--- a/server/http/handlers/secrets_inventory_csv.go
+++ b/server/http/handlers/secrets_inventory_csv.go
@@ -53,11 +53,11 @@ func (h *SecretHandler) SecretsInventoryCSV(w http.ResponseWriter, r *http.Reque
 	for _, it := range items {
 		_ = cw.Write([]string{
 			strconv.FormatUint(uint64(it.ID), 10),
-			it.Name,
-			it.EnvironmentName,
-			it.Type,
-			it.Classification,
-			it.OwnerUsername,
+			csvSafe(it.Name),
+			csvSafe(it.EnvironmentName),
+			csvSafe(it.Type),
+			csvSafe(it.Classification),
+			csvSafe(it.OwnerUsername),
 			it.CreatedAt.UTC().Format(time.RFC3339),
 			tstr(it.Expiration),
 			tstr(it.LastRotatedAt),

--- a/server/http/handlers/secrets_inventory_deployment_csv.go
+++ b/server/http/handlers/secrets_inventory_deployment_csv.go
@@ -47,13 +47,13 @@ func (h *SecretHandler) DeploymentSecretsInventoryCSV(w http.ResponseWriter, r *
 	})
 	for _, it := range items {
 		_ = cw.Write([]string{
-			it.ProjectName,
+			csvSafe(it.ProjectName),
 			strconv.FormatUint(uint64(it.ID), 10),
-			it.Name,
-			it.EnvironmentName,
-			it.Type,
-			it.Classification,
-			it.OwnerUsername,
+			csvSafe(it.Name),
+			csvSafe(it.EnvironmentName),
+			csvSafe(it.Type),
+			csvSafe(it.Classification),
+			csvSafe(it.OwnerUsername),
 			it.CreatedAt.UTC().Format(time.RFC3339),
 			tstr(it.Expiration),
 			tstr(it.LastRotatedAt),

--- a/server/http/handlers/secrets_list.go
+++ b/server/http/handlers/secrets_list.go
@@ -33,6 +33,11 @@ func (h *SecretHandler) ListSecrets(w http.ResponseWriter, r *http.Request) {
 
 	if pageStr := r.URL.Query().Get("page"); pageStr != "" {
 		if p, err := strconv.Atoi(pageStr); err == nil && p > 0 {
+			// Clamp the page so a very large value can't force a huge OFFSET scan over the
+			// whole table on every request (deep-pagination DoS).
+			if p > maxListPage {
+				p = maxListPage
+			}
 			page = p
 		}
 	}

--- a/server/http/handlers/secrets_render.go
+++ b/server/http/handlers/secrets_render.go
@@ -35,7 +35,7 @@ func (h *SecretHandler) RenderTemplate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	rendered, err := h.coreService.RenderSecretTemplate(r.Context(), reqBody.Template, uint(id), userCtx.UserID)
+	rendered, err := h.coreService.RenderSecretTemplate(r.Context(), reqBody.Template, uint(id), userCtx.UserID, userCtx.Username, r.RemoteAddr, r.Header.Get("User-Agent"))
 	if err != nil {
 		switch {
 		case strings.Contains(err.Error(), "not found"):

--- a/server/http/handlers/users_list.go
+++ b/server/http/handlers/users_list.go
@@ -21,6 +21,10 @@ import (
 // Matches the dashboard's 30-day inactive-users signal.
 const inactiveUserWindow = 30 * 24 * time.Hour
 
+// maxListPage caps the page number on offset-paginated list endpoints, so a very large
+// page can't force an enormous OFFSET table scan on each request (deep-pagination DoS).
+const maxListPage = 10000
+
 // ListUsers serves user list from core.
 func (h *UserHandler) ListUsers(w http.ResponseWriter, r *http.Request) {
 	userCtx := middleware.GetUserFromContext(r.Context())
@@ -33,6 +37,10 @@ func (h *UserHandler) ListUsers(w http.ResponseWriter, r *http.Request) {
 	pageSize := 20
 	if pageStr := r.URL.Query().Get("page"); pageStr != "" {
 		if p, err := strconv.Atoi(pageStr); err == nil && p > 0 {
+			// Clamp the page so a very large value can't force a huge OFFSET scan (DoS).
+			if p > maxListPage {
+				p = maxListPage
+			}
 			page = p
 		}
 	}

--- a/server/http/integration_test.go
+++ b/server/http/integration_test.go
@@ -100,14 +100,14 @@ func createLimitedToken(t *testing.T, c *core.KeyorixCore) string {
 	_, err := c.CreateUser(ctx, &core.CreateUserRequest{
 		Username: "limiteduser",
 		Email:    "limited@example.com",
-		Password: "LimitedPass123!",
+		Password: "Qr7#Kp2$Lm5@Vn9!",
 	})
 	if err != nil {
 		t.Fatalf("createLimitedToken: create user failed: %v", err)
 	}
 	session, _, err := c.Login(ctx, &core.LoginRequest{
 		Username: "limiteduser",
-		Password: "LimitedPass123!",
+		Password: "Qr7#Kp2$Lm5@Vn9!",
 	})
 	if err != nil {
 		t.Fatalf("createLimitedToken: login failed: %v", err)
@@ -383,7 +383,7 @@ func TestHTTPServerIntegration(t *testing.T) {
 				"username":     "integration-user",
 				"email":        "integration@test.com",
 				"display_name": "Integration Test User",
-				"password":     "securepassword123",
+				"password":     "Qr7#Kp2$Lm5@Vn9!",
 			}
 
 			body, err := json.Marshal(userData)
@@ -763,10 +763,10 @@ func TestPrivescRoutesRequireWrite(t *testing.T) {
 	// users get system_viewer, which holds users.read but not users.write.
 	ctx := context.Background()
 	_, err = testCore.CreateUser(ctx, &core.CreateUserRequest{
-		Username: "privesc_ro", Email: "privesc_ro@example.com", Password: "LimitedPass123!",
+		Username: "privesc_ro", Email: "privesc_ro@example.com", Password: "Qr7#Kp2$Lm5@Vn9!",
 	})
 	require.NoError(t, err)
-	sess, _, err := testCore.Login(ctx, &core.LoginRequest{Username: "privesc_ro", Password: "LimitedPass123!"})
+	sess, _, err := testCore.Login(ctx, &core.LoginRequest{Username: "privesc_ro", Password: "Qr7#Kp2$Lm5@Vn9!"})
 	require.NoError(t, err)
 	limited := sess.SessionToken
 
@@ -819,10 +819,10 @@ func TestEveryMutatingRouteDeniesReadOnly(t *testing.T) {
 	// read-only persona that must not be able to mutate anything.
 	ctx := context.Background()
 	_, err = testCore.CreateUser(ctx, &core.CreateUserRequest{
-		Username: "ro_guard", Email: "ro_guard@example.com", Password: "LimitedPass123!",
+		Username: "ro_guard", Email: "ro_guard@example.com", Password: "Qr7#Kp2$Lm5@Vn9!",
 	})
 	require.NoError(t, err)
-	sess, _, err := testCore.Login(ctx, &core.LoginRequest{Username: "ro_guard", Password: "LimitedPass123!"})
+	sess, _, err := testCore.Login(ctx, &core.LoginRequest{Username: "ro_guard", Password: "Qr7#Kp2$Lm5@Vn9!"})
 	require.NoError(t, err)
 	roToken := sess.SessionToken
 

--- a/server/http/integration_test.go
+++ b/server/http/integration_test.go
@@ -835,16 +835,17 @@ func TestEveryMutatingRouteDeniesReadOnly(t *testing.T) {
 	}
 	// Self-service (own account) and public routes a read-only/unauthenticated
 	// caller may legitimately reach; everything else mutating must be denied.
-	// /secrets/render and /compliance/evidence/verify are READ operations behind a POST
-	// (they only carry a payload; they mutate nothing and are gated on a *.read
-	// permission) — legitimately reachable by a read-only persona, like /system/init.
-	// /sw.js is the SPA service-worker static asset, served by the web handler for any
-	// method; serving the file for DELETE/PUT/etc. changes no state, so it's not an API
-	// mutation. These are the only exemptions; any other mutating route MUST be denied.
+	// /secrets/render is a READ operation behind a POST (it only carries a payload; it
+	// mutates nothing and is gated on a *.read permission) — legitimately reachable by a
+	// read-only persona, like /system/init. (/compliance/evidence/verify is a POST too,
+	// but it is gated on audit.read which system_viewer lacks, so it is correctly DENIED
+	// and not exempted here.) /sw.js is the SPA service-worker static asset, served by the
+	// web handler for any method; serving the file for DELETE/PUT/etc. changes no state,
+	// so it's not an API mutation. These are the only exemptions; any other mutating route
+	// MUST be denied.
 	allowExact := map[string]bool{
 		"/system/init": true, "/health": true, "/metrics": true,
 		"/api/v1/projects/{id}/secrets/render": true,
-		"/api/v1/compliance/evidence/verify":   true, // read-only signature verify (system.read)
 		"/sw.js":                               true, // static service-worker asset, not an API route
 	}
 	allowPrefix := []string{"/auth/", "/api/v1/auth/", "/notifications", "/api/v1/notifications"}

--- a/server/http/integration_test.go
+++ b/server/http/integration_test.go
@@ -72,10 +72,12 @@ func createTestToken(t *testing.T, c *core.KeyorixCore) string {
 	t.Helper()
 	ctx := context.Background()
 	// SeedSystem creates admin user, roles, permissions, project, environments
+	c.SetBootstrapToken("test-bootstrap-token")
 	_, err := c.BootstrapSystem(ctx, &core.BootstrapRequest{
 		Username: "testadmin",
 		Email:    "testadmin@example.com",
 		Password: "TestPassword123!",
+		Token:    "test-bootstrap-token",
 	})
 	if err != nil {
 		t.Logf("BootstrapSystem: %v (may already be initialised)", err)

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -327,8 +327,11 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		r.With(customMiddleware.RequireScopedPermission("roles.assign", projectScope)).Put("/projects/{id}/machine-identities/{machineId}", catalogHandler.TransitionMachineIdentity)
 		r.With(customMiddleware.RequireScopedPermission("roles.assign", projectScope)).Patch("/projects/{id}/machine-identities/{machineId}/classification", catalogHandler.ClassifyMachineIdentity)
 		r.With(customMiddleware.RequireScopedPermission("roles.assign", projectScope)).Patch("/projects/{id}/machine-identities/{machineId}/tokens/{tokenId}/classification", catalogHandler.ClassifyMachineToken)
-		// Machine-token credentials + role grants (ADR-030).
-		r.With(customMiddleware.RequireScopedPermission("roles.assign", projectScope)).Post("/projects/{id}/machine-identities/{machineId}/tokens", catalogHandler.IssueMachineToken)
+		// Machine-token credentials + role grants (ADR-030). Issuing a token is blocked
+		// while impersonating — like PAT creation — so an admin acting as another user
+		// cannot plant a durable (potentially non-expiring) credential that outlives the
+		// bounded, audited impersonation session.
+		r.With(customMiddleware.BlockWhenImpersonating, customMiddleware.RequireScopedPermission("roles.assign", projectScope)).Post("/projects/{id}/machine-identities/{machineId}/tokens", catalogHandler.IssueMachineToken)
 		r.With(customMiddleware.RequireScopedPermission("users.read", projectScope)).Get("/projects/{id}/machine-identities/{machineId}/tokens", catalogHandler.ListMachineTokens)
 		r.With(customMiddleware.RequireScopedPermission("roles.assign", projectScope)).Delete("/projects/{id}/machine-identities/{machineId}/tokens/{tokenId}", catalogHandler.RevokeMachineToken)
 		r.With(customMiddleware.RequireScopedPermission("roles.assign", projectScope)).Post("/projects/{id}/machine-identities/{machineId}/roles", catalogHandler.GrantMachineRole)
@@ -575,7 +578,9 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.With(customMiddleware.RequirePermission("users.write")).
 				Delete("/{clientId}", saHandler.DeactivateServiceAccount)
 			r.Get("/{clientId}/tokens", saHandler.ListTokens)
-			r.With(customMiddleware.RequirePermission("users.write")).
+			// Blocked while impersonating: a service-account token is a durable credential
+			// that must not be mintable under a bounded impersonation session.
+			r.With(customMiddleware.BlockWhenImpersonating, customMiddleware.RequirePermission("users.write")).
 				Post("/{clientId}/tokens", saHandler.CreateToken)
 			r.With(customMiddleware.RequirePermission("users.write")).
 				Delete("/{clientId}/tokens/{tokenId}", saHandler.RevokeToken)

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -198,21 +198,26 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		r.Get("/auth/profile", authHandler.Profile)
 		r.Put("/auth/profile", authHandler.UpdateProfile)
 		r.Post("/auth/change-password", authHandler.ChangePassword)
-		// MFA self-service (acts on the authenticated caller's own account).
-		r.Post("/auth/mfa/enroll", authHandler.EnrollMFA)
-		r.Post("/auth/mfa/activate", authHandler.ActivateMFA)
-		r.Post("/auth/mfa/disable", authHandler.DisableMFA)
+		// MFA self-service (acts on the authenticated caller's own account). The
+		// authenticator-lifecycle routes are blocked under impersonation so an admin
+		// acting as a user cannot alter the user's MFA / plant a durable credential that
+		// outlives the impersonation session.
+		r.With(customMiddleware.BlockWhenImpersonating).Post("/auth/mfa/enroll", authHandler.EnrollMFA)
+		r.With(customMiddleware.BlockWhenImpersonating).Post("/auth/mfa/activate", authHandler.ActivateMFA)
+		r.With(customMiddleware.BlockWhenImpersonating).Post("/auth/mfa/disable", authHandler.DisableMFA)
 		r.Get("/auth/mfa/recovery-codes", authHandler.RecoveryCodesStatus)
-		r.Post("/auth/mfa/recovery-codes/regenerate", authHandler.RegenerateRecoveryCodes)
+		r.With(customMiddleware.BlockWhenImpersonating).Post("/auth/mfa/recovery-codes/regenerate", authHandler.RegenerateRecoveryCodes)
 		// WebAuthn / passkey self-service (acts on the authenticated caller's account).
-		r.Post("/auth/webauthn/register/begin", authHandler.BeginWebAuthnRegistration)
-		r.Post("/auth/webauthn/register/finish", authHandler.FinishWebAuthnRegistration)
+		r.With(customMiddleware.BlockWhenImpersonating).Post("/auth/webauthn/register/begin", authHandler.BeginWebAuthnRegistration)
+		r.With(customMiddleware.BlockWhenImpersonating).Post("/auth/webauthn/register/finish", authHandler.FinishWebAuthnRegistration)
 		r.Get("/auth/webauthn/credentials", authHandler.ListWebAuthnCredentials)
 		r.Delete("/auth/webauthn/credentials/{id}", authHandler.DeleteWebAuthnCredential)
 		r.Get("/auth/sessions", authHandler.ListSessions)
 		r.Delete("/auth/sessions/{id}", authHandler.RevokeSession)
 		r.Get("/auth/tokens", patHandler.ListPATs)
-		r.Post("/auth/tokens", patHandler.CreatePAT)
+		// Minting a PAT under impersonation would create a durable token owned by the
+		// target that outlives the session — block it.
+		r.With(customMiddleware.BlockWhenImpersonating).Post("/auth/tokens", patHandler.CreatePAT)
 		r.Delete("/auth/tokens/{id}", patHandler.RevokePAT)
 		// Self-scoped: end the current impersonation session (no permission gate).
 		r.Post("/auth/end-impersonation", impersonationHandler.End)

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -229,7 +229,9 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 
 		// Dashboard endpoints
 		r.Get("/dashboard/stats", dashboardHandler.GetStats)
-		r.Get("/dashboard/activity", dashboardHandler.GetActivity)
+		// The full activity feed is org-wide audit data — gate it behind audit.read.
+		// (Per-user dashboard stats scope their own recent-activity in core.)
+		r.With(customMiddleware.RequirePermission("audit.read")).Get("/dashboard/activity", dashboardHandler.GetActivity)
 
 		// Catalog endpoints (projects, environments).
 		// List endpoints need global read (browse everything); accessing a

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -215,7 +215,11 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		r.With(customMiddleware.BlockWhenImpersonating).Post("/auth/webauthn/register/begin", authHandler.BeginWebAuthnRegistration)
 		r.With(customMiddleware.BlockWhenImpersonating).Post("/auth/webauthn/register/finish", authHandler.FinishWebAuthnRegistration)
 		r.Get("/auth/webauthn/credentials", authHandler.ListWebAuthnCredentials)
-		r.Delete("/auth/webauthn/credentials/{id}", authHandler.DeleteWebAuthnCredential)
+		// Deleting a passkey disables WebAuthn when it removes the last one — the same
+		// durable MFA-downgrade that /auth/mfa/disable is blocked from doing under
+		// impersonation. There is no admin API to remove another user's passkey, so without
+		// this guard impersonation would be the one path to weaken a user's second factor.
+		r.With(customMiddleware.BlockWhenImpersonating).Delete("/auth/webauthn/credentials/{id}", authHandler.DeleteWebAuthnCredential)
 		r.Get("/auth/sessions", authHandler.ListSessions)
 		r.Delete("/auth/sessions/{id}", authHandler.RevokeSession)
 		r.Get("/auth/tokens", patHandler.ListPATs)

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -25,7 +25,11 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 
 	// Apply middleware
 	r.Use(middleware.RequestID)
-	r.Use(middleware.RealIP)
+	// Trusted-proxy-aware client IP: honor X-Forwarded-For / X-Real-IP ONLY when the TCP
+	// peer is a configured trusted proxy, otherwise use the real peer. chi's RealIP trusts
+	// the header unconditionally, which lets any client spoof its source IP and defeat the
+	// per-IP login/MFA brute-force rate limiter.
+	r.Use(customMiddleware.ClientIP(cfg.Server.HTTP.TrustedProxies))
 	r.Use(customMiddleware.Logger())
 	r.Use(customMiddleware.Recovery())
 	r.Use(customMiddleware.SecurityHeaders(cfg.Server.HTTP.TLS.Enabled))

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -645,10 +645,15 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		r.With(customMiddleware.RequirePermission("system.read")).Get("/legal-hold", dashboardHandler.GetLegalHold)
 		r.With(customMiddleware.RequirePermission("system.write")).Post("/legal-hold", dashboardHandler.PlaceLegalHold)
 		r.With(customMiddleware.RequirePermission("system.write")).Delete("/legal-hold", dashboardHandler.LiftLegalHold)
-		// Compliance evidence pack — posture + supporting records, for archival.
-		r.With(customMiddleware.RequirePermission("system.read")).Get("/compliance/evidence", dashboardHandler.GetComplianceEvidence)
+		// Compliance evidence pack — posture + supporting records, for archival. Gated on
+		// audit.read (global), NOT system.read: the deployment-wide pack enumerates
+		// cross-project secret NAMES and break-glass JUSTIFICATIONS, which the minimal
+		// system_viewer baseline (system.read only) must not be able to export. audit.read
+		// is the compliance/auditor persona (system_auditor/system_admin) at global scope;
+		// a project-scoped audit.read holder is correctly excluded from the org-wide pack.
+		r.With(customMiddleware.RequirePermission("audit.read")).Get("/compliance/evidence", dashboardHandler.GetComplianceEvidence)
 		// Verify a previously-exported evidence pack against its detached signature.
-		r.With(customMiddleware.RequirePermission("system.read")).Post("/compliance/evidence/verify", dashboardHandler.VerifyComplianceEvidence)
+		r.With(customMiddleware.RequirePermission("audit.read")).Post("/compliance/evidence/verify", dashboardHandler.VerifyComplianceEvidence)
 		// Risk register (ISO A.5.8): list reads system.read; create/revoke system.write.
 		r.With(customMiddleware.RequirePermission("system.read")).Get("/risk-exceptions", dashboardHandler.ListRiskExceptions)
 		r.With(customMiddleware.RequirePermission("system.write")).Post("/risk-exceptions", dashboardHandler.CreateRiskException)

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -607,7 +607,10 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			// above the group's audit.read with system.write (admin-level).
 			r.With(customMiddleware.RequirePermission("system.write")).Post("/checkpoint", auditHandler.WriteAuditCheckpoint)
 			r.Get("/anomalies", handlers.ListAnomalyAlerts)
-			r.Post("/anomalies/{id}/acknowledge", handlers.AcknowledgeAnomalyAlert)
+			// Acknowledging (dismissing) an alert mutates a security-detection record, so
+			// gate it above the group's audit.read with system.write — like /checkpoint —
+			// rather than letting any read-only auditor silently bury alerts.
+			r.With(customMiddleware.RequirePermission("system.write")).Post("/anomalies/{id}/acknowledge", handlers.AcknowledgeAnomalyAlert)
 		})
 
 		// System endpoints

--- a/server/main.go
+++ b/server/main.go
@@ -96,6 +96,11 @@ func main() {
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
 
+	// Refuse (or loudly warn about) serving bearer tokens + secret values in cleartext.
+	if err := checkTransportTLSPosture(cfg); err != nil {
+		log.Fatalf("transport security: %v", err)
+	}
+
 	var wg sync.WaitGroup
 
 	// Start HTTP server
@@ -251,6 +256,9 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 		}
 	}
 	coreService.SetBootstrapToken(bootstrapToken)
+	// Let core token-revocation paths (e.g. revoking PATs on a password change) evict the
+	// HTTP auth cache immediately, rather than waiting out the positive-cache TTL.
+	coreService.SetTokenCacheInvalidator(middleware.InvalidateTokenCacheByHash)
 	if needs, berr := coreService.SystemNeedsBootstrap(context.Background()); berr == nil && needs && bootstrapToken != "" {
 		if bootstrapTokenGenerated {
 			log.Printf("system not initialised — run `keyorix system init` with this one-time bootstrap token (set KEYORIX_BOOTSTRAP_TOKEN to pin your own):\n    BOOTSTRAP TOKEN: %s", bootstrapToken)
@@ -1228,6 +1236,38 @@ func startHTTPServer(ctx context.Context, cfg *config.Config) error {
 
 	log.Println("Shutting down HTTP server...")
 	return server.Shutdown(shutdownCtx)
+}
+
+// checkTransportTLSPosture guards against silently serving credentials/secret values in
+// cleartext. For each enabled listener without TLS it either fails closed (when
+// security.require_transport_tls is set) or logs a prominent warning. It also warns when
+// the allowed_ciphers / protocol_versions tuning is set, since those fields are not
+// currently honored (the suite list + TLS 1.2 minimum are fixed) and would otherwise give
+// a false sense of control.
+func checkTransportTLSPosture(cfg *config.Config) error {
+	require := cfg.Security.RequireTransportTLS
+	check := func(name string, inst config.ServerInstanceConfig) error {
+		if !inst.Enabled {
+			return nil
+		}
+		// The tuning fields are not wired into the TLS builders — warn whenever they are
+		// set (TLS on or off) so an operator isn't misled into thinking they took effect.
+		if len(inst.TLS.AllowedCiphers) > 0 || len(inst.ProtocolVersions) > 0 {
+			log.Printf("WARNING: %s tls.allowed_ciphers / protocol_versions are set but NOT honored — the cipher suite list and TLS 1.2 minimum are fixed in code.", name)
+		}
+		if inst.TLS.Enabled {
+			return nil
+		}
+		if require {
+			return fmt.Errorf("%s listener has no TLS but security.require_transport_tls is set: refusing to serve credentials/secrets in cleartext (enable tls or front it with a TLS-terminating proxy and unset the requirement)", name)
+		}
+		log.Printf("WARNING: %s listener is serving CLEARTEXT (no TLS) — bearer tokens and secret values are unencrypted. Front it with a TLS-terminating proxy, enable tls, or set security.require_transport_tls to fail closed.", name)
+		return nil
+	}
+	if err := check("HTTP", cfg.Server.HTTP); err != nil {
+		return err
+	}
+	return check("gRPC", cfg.Server.GRPC)
 }
 
 func startGRPCServer(ctx context.Context, cfg *config.Config) error {

--- a/server/main.go
+++ b/server/main.go
@@ -24,6 +24,7 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"net"
 	"net/http"
@@ -1398,16 +1399,37 @@ func resolveOutboundIP() string {
 
 // oidcDiscovery is the subset of an OIDC discovery document we need.
 type oidcDiscovery struct {
+	Issuer                string `json:"issuer"`
 	AuthorizationEndpoint string `json:"authorization_endpoint"`
 	TokenEndpoint         string `json:"token_endpoint"`
 	JWKSURI               string `json:"jwks_uri"`
 }
 
-// discoverOIDC fetches an issuer's /.well-known/openid-configuration.
+// maxDiscoveryBytes caps the discovery document we read into memory.
+const maxDiscoveryBytes = 1 << 20 // 1 MiB
+
+// discoverOIDC fetches an issuer's /.well-known/openid-configuration and validates
+// it. The issuer must use https (http only for loopback) so the document — which
+// names the jwks_uri that ultimately supplies the token-signing keys — is not
+// fetched over plaintext where a MITM could redirect key fetching to attacker keys.
+// Per the OIDC spec the document's own issuer must equal the configured issuer, and
+// the jwks_uri it advertises must live on the issuer's host, so a tampered/hostile
+// discovery doc can't point key fetching at an unrelated host.
 func discoverOIDC(issuer string) (*oidcDiscovery, error) {
+	iss, err := url.Parse(strings.TrimRight(issuer, "/"))
+	if err != nil || iss.Host == "" {
+		return nil, fmt.Errorf("invalid issuer %q", issuer)
+	}
+	if err := requireSecureOrLoopback(iss, "issuer"); err != nil {
+		return nil, err
+	}
+
 	u := strings.TrimRight(issuer, "/") + "/.well-known/openid-configuration"
-	client := &http.Client{Timeout: 10 * time.Second}
-	resp, err := client.Get(u) // #nosec G107 -- issuer is operator-configured, not user input
+	client := &http.Client{
+		Timeout:       10 * time.Second,
+		CheckRedirect: noDiscoveryCrossOriginRedirect,
+	}
+	resp, err := client.Get(u) // #nosec G107 -- issuer is operator-configured and https-validated above
 	if err != nil {
 		return nil, err
 	}
@@ -1416,13 +1438,60 @@ func discoverOIDC(issuer string) (*oidcDiscovery, error) {
 		return nil, fmt.Errorf("discovery returned %s", resp.Status)
 	}
 	var d oidcDiscovery
-	if err := json.NewDecoder(resp.Body).Decode(&d); err != nil {
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxDiscoveryBytes)).Decode(&d); err != nil {
 		return nil, err
 	}
 	if d.AuthorizationEndpoint == "" || d.TokenEndpoint == "" || d.JWKSURI == "" {
 		return nil, fmt.Errorf("discovery document is missing required endpoints")
 	}
+	if d.Issuer != "" && strings.TrimRight(d.Issuer, "/") != strings.TrimRight(issuer, "/") {
+		return nil, fmt.Errorf("discovery issuer %q does not match configured issuer %q", d.Issuer, issuer)
+	}
+	jwksURL, err := url.Parse(d.JWKSURI)
+	if err != nil || jwksURL.Host == "" {
+		return nil, fmt.Errorf("discovery jwks_uri %q is invalid", d.JWKSURI)
+	}
+	if !strings.EqualFold(jwksURL.Hostname(), iss.Hostname()) {
+		return nil, fmt.Errorf("discovery jwks_uri host %q does not match issuer host %q", jwksURL.Hostname(), iss.Hostname())
+	}
 	return &d, nil
+}
+
+// requireSecureOrLoopback rejects a non-https URL unless its host is loopback.
+func requireSecureOrLoopback(u *url.URL, label string) error {
+	if u.Scheme == "https" {
+		return nil
+	}
+	if u.Scheme == "http" && isLoopbackHostname(u.Hostname()) {
+		return nil
+	}
+	return fmt.Errorf("%s %q must use https (http is allowed only for localhost)", label, u.Redacted())
+}
+
+func isLoopbackHostname(host string) bool {
+	if host == "localhost" {
+		return true
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return ip.IsLoopback()
+	}
+	return false
+}
+
+// noDiscoveryCrossOriginRedirect rejects a discovery redirect that changes host or
+// downgrades the scheme, so a redirect can't pull the document from an unexpected host.
+func noDiscoveryCrossOriginRedirect(req *http.Request, via []*http.Request) error {
+	if len(via) == 0 {
+		return nil
+	}
+	prev := via[len(via)-1].URL
+	if !strings.EqualFold(req.URL.Hostname(), prev.Hostname()) {
+		return fmt.Errorf("discovery: refusing cross-host redirect to %q", req.URL.Host)
+	}
+	if prev.Scheme == "https" && req.URL.Scheme != "https" {
+		return fmt.Errorf("discovery: refusing scheme downgrade to %q", req.URL.Scheme)
+	}
+	return nil
 }
 
 // ssoCompleteURL derives the SPA completion URL (<redirect origin>/auth/sso/complete)

--- a/server/main.go
+++ b/server/main.go
@@ -774,6 +774,9 @@ func startHTTPServer(ctx context.Context, cfg *config.Config) error {
 		}
 		alertsEnabled := cfg.AnomalyAlerts.Enabled
 		interval := cfg.AnomalyAlerts.GetInterval()
+		// Scan a window at least as long as the cadence, so a longer schedule doesn't
+		// leave the time between passes unexamined (floored at 1h inside SetLookback).
+		detector.SetLookback(interval)
 		if alertsEnabled {
 			log.Printf("Anomaly alerting enabled: scan + alert every %s", interval)
 		}

--- a/server/main.go
+++ b/server/main.go
@@ -356,9 +356,11 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 		log.Printf("Secret-name policy enabled (pattern=%q, max_length=%d)", snp.Pattern, snp.MaxLength)
 	}
 
-	// Apply per-account login lockout if enabled (brute-force protection, distinct
-	// from the per-IP rate limiter).
-	if ll := cfg.Security.LoginLockout; ll.Enabled {
+	// Apply per-account login lockout (brute-force protection, distinct from and
+	// complementary to the per-IP rate limiter, which distributed guessing can evade).
+	// Enabled BY DEFAULT — a secrets-manager login must resist online guessing out of
+	// the box; set login_lockout.disabled to opt out.
+	if ll := cfg.Security.LoginLockout; !ll.Disabled {
 		coreService.SetLoginLockoutPolicy(core.LoginLockoutPolicy{
 			Enabled:      true,
 			MaxAttempts:  ll.GetMaxAttempts(),
@@ -368,6 +370,8 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 		})
 		log.Printf("Per-account login lockout enabled (max_attempts=%d, window=%s, base_cooldown=%s, max_cooldown=%s)",
 			ll.GetMaxAttempts(), ll.GetWindow(), ll.GetBaseCooldown(), ll.GetMaxCooldown())
+	} else {
+		log.Printf("WARNING: per-account login lockout is DISABLED — only the per-IP rate limiter throttles password guessing, which distributed/botnet guessing against a single account can evade")
 	}
 
 	// Wire native SIEM audit forwarding if configured. New returns (nil, nil)

--- a/server/main.go
+++ b/server/main.go
@@ -1160,13 +1160,13 @@ func startHTTPServer(ctx context.Context, cfg *config.Config) error {
 		})
 	}
 
-	// Prune expired login-attempt records hourly (ADR-040). Single-replica-gated;
-	// always on (the limiter table needs bounded growth regardless of the purge
-	// scheduler). Rows past the rate-limit window are never read again.
-	runScheduler(ctx, "login_attempt_prune", 1*time.Hour, func() middleware.SchedulerOutcome {
-		if legalHoldBlocks("Login-attempt prune") {
-			return middleware.SchedulerSkipped
-		}
+	// Prune expired login-attempt records every 15 minutes (ADR-040). Single-replica-
+	// gated and ALWAYS run — login_attempts are ephemeral rate-limit data (never legal
+	// evidence), so this is deliberately NOT subject to legalHoldBlocks: a long-running
+	// legal hold must not stop the prune, or the table grows unbounded (an attacker
+	// failing logins from rotating IPs would exhaust disk). The rate-limit window is
+	// 15 minutes, so a 15-minute cadence keeps the table at roughly one window of rows.
+	runScheduler(ctx, "login_attempt_prune", 15*time.Minute, func() middleware.SchedulerOutcome {
 		return lockedRun(ctx, coreService.Storage(), schedLockLoginPrune, "Login-attempt prune", func() error {
 			_, perr := coreService.PruneLoginAttempts(ctx)
 			return perr

--- a/server/main.go
+++ b/server/main.go
@@ -380,6 +380,7 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 			Endpoint:           wc.Endpoint,
 			Token:              wc.GetToken(),
 			InsecureSkipVerify: wc.InsecureSkipVerify,
+			SigningSecret:      wc.GetSigningSecret(),
 		})
 		if werr != nil {
 			return nil, nil, fmt.Errorf("failed to init notification webhook channel: %w", werr)

--- a/server/main.go
+++ b/server/main.go
@@ -236,6 +236,29 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 		log.Printf("RBAC permission reconciliation: %v (continuing)", err)
 	}
 
+	// Wire the bootstrap token that gates POST /system/init. Prefer an operator-set
+	// KEYORIX_BOOTSTRAP_TOKEN (for automation); otherwise generate one and, while the
+	// install is still empty, log it so the operator can complete first-boot init. This
+	// closes the unauthenticated, first-caller-wins admin-claim race on a fresh, reachable
+	// instance.
+	bootstrapToken := strings.TrimSpace(os.Getenv("KEYORIX_BOOTSTRAP_TOKEN"))
+	bootstrapTokenGenerated := false
+	if bootstrapToken == "" {
+		if t, gerr := core.GenerateBootstrapToken(); gerr == nil {
+			bootstrapToken, bootstrapTokenGenerated = t, true
+		} else {
+			log.Printf("failed to generate a bootstrap token: %v (API system-init will be disabled)", gerr)
+		}
+	}
+	coreService.SetBootstrapToken(bootstrapToken)
+	if needs, berr := coreService.SystemNeedsBootstrap(context.Background()); berr == nil && needs && bootstrapToken != "" {
+		if bootstrapTokenGenerated {
+			log.Printf("system not initialised — run `keyorix system init` with this one-time bootstrap token (set KEYORIX_BOOTSTRAP_TOKEN to pin your own):\n    BOOTSTRAP TOKEN: %s", bootstrapToken)
+		} else {
+			log.Printf("system not initialised — run `keyorix system init` with the configured KEYORIX_BOOTSTRAP_TOKEN")
+		}
+	}
+
 	if encSvc != nil {
 		// Wire the initialised encryption service for reversibly-encrypted auth
 		// secrets (the TOTP MFA secret, which cannot be hashed).

--- a/server/main.go
+++ b/server/main.go
@@ -362,6 +362,7 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 			Endpoint:           sc.Endpoint,
 			Token:              sc.GetToken(),
 			InsecureSkipVerify: sc.InsecureSkipVerify,
+			SpoolDir:           sc.SpoolDir,
 		})
 		if ferr != nil {
 			return nil, nil, fmt.Errorf("failed to init SIEM audit forwarder: %w", ferr)

--- a/server/main.go
+++ b/server/main.go
@@ -101,6 +101,11 @@ func main() {
 		log.Fatalf("transport security: %v", err)
 	}
 
+	// Refuse (or warn) when key material on disk is readable beyond its owner.
+	if err := enforceKeyFilePermissions(cfg); err != nil {
+		log.Fatalf("key file security: %v", err)
+	}
+
 	var wg sync.WaitGroup
 
 	// Start HTTP server
@@ -1268,6 +1273,56 @@ func checkTransportTLSPosture(cfg *config.Config) error {
 		return err
 	}
 	return check("gRPC", cfg.Server.GRPC)
+}
+
+// enforceKeyFilePermissions refuses to start (or, by default, loudly warns) when sensitive
+// key material on disk — the wrapped DEK, the KEK salt, and TLS private keys — is readable
+// by group or other. Key writes are already 0600, but a file restored from a backup with a
+// bad umask, or one left 0644 by an operator, would otherwise expose the wrapped DEK / TLS
+// key to any local user with no signal. Fails closed only when
+// security.enable_file_permission_check is set (and not overridden by
+// allow_unsafe_file_permissions); otherwise it warns. A not-yet-created key file (first
+// boot) is skipped — it is created at 0600.
+func enforceKeyFilePermissions(cfg *config.Config) error {
+	resolve := func(p string) string {
+		if p == "" || filepath.IsAbs(p) {
+			return p
+		}
+		return filepath.Join(".", p)
+	}
+	var paths []string
+	if cfg.Storage.Encryption.Enabled {
+		paths = append(paths, resolve(cfg.Storage.Encryption.DEKPath), resolve(cfg.Storage.Encryption.SaltPath))
+	}
+	if cfg.Server.HTTP.TLS.Enabled {
+		paths = append(paths, cfg.Server.HTTP.TLS.KeyFile)
+	}
+	if cfg.Server.GRPC.TLS.Enabled {
+		paths = append(paths, cfg.Server.GRPC.TLS.KeyFile)
+	}
+
+	var insecure []string
+	for _, p := range paths {
+		if p == "" {
+			continue
+		}
+		info, err := os.Stat(p)
+		if err != nil {
+			continue // absent (e.g. created at 0600 on first boot) — nothing to check yet
+		}
+		if info.Mode().Perm()&0o077 != 0 {
+			insecure = append(insecure, fmt.Sprintf("%s (mode %o)", p, info.Mode().Perm()))
+		}
+	}
+	if len(insecure) == 0 {
+		return nil
+	}
+	msg := fmt.Sprintf("key material is readable beyond its owner: %s", strings.Join(insecure, ", "))
+	if cfg.Security.EnableFilePermissionCheck && !cfg.Security.AllowUnsafeFilePermissions {
+		return fmt.Errorf("%s — refusing to start (chmod to 0600, or set security.allow_unsafe_file_permissions to override)", msg)
+	}
+	log.Printf("WARNING: %s — restrict to 0600. Set security.enable_file_permission_check to fail closed instead of warning.", msg)
+	return nil
 }
 
 func startGRPCServer(ctx context.Context, cfg *config.Config) error {

--- a/server/main.go
+++ b/server/main.go
@@ -282,6 +282,9 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 		// when encryption is off (no DEK).
 		if key, keyVer, ok := encSvc.AuditCheckpointKey(); ok {
 			coreService.SetAuditCheckpointKey(key, keyVer)
+			// Restore the in-memory anti-rollback watermark from the persisted high-water
+			// mark so a process restart cannot reset it to zero (ADR-029).
+			coreService.SeedAuditWatermark(context.Background())
 		}
 		// Derive the evidence-pack signing key from the DEK so scheduled evidence
 		// exports are signed (and verifiable). Unavailable when encryption is off.
@@ -1079,30 +1082,34 @@ func startHTTPServer(ctx context.Context, cfg *config.Config) error {
 		}
 	}
 
-	// Start the audit-checkpoint scheduler (ADR-029) — opt-in. Periodically signs
-	// the verified audit-chain head so tail-truncation / genesis re-seed becomes
-	// detectable on-box. HA-gated so one replica writes per tick. Requires
-	// encryption (the signing key is DEK-derived); skipped with a warning if not.
-	if cfg.AuditCheckpoints.Enabled {
-		if !coreService.AuditCheckpointsAvailable() {
-			log.Printf("Audit-checkpoint scheduler requested but encryption is disabled (no signing key); skipping")
-		} else {
-			interval := cfg.AuditCheckpoints.GetInterval()
-			log.Printf("Audit-checkpoint scheduler enabled: every %s", interval)
-			runScheduler(ctx, "audit_checkpoint", interval, func() middleware.SchedulerOutcome {
-				return lockedRun(ctx, coreService.Storage(), schedLockAuditCkpt, "Audit-checkpoint", func() error {
-					cp, written, werr := coreService.WriteAuditCheckpoint(ctx)
-					if werr != nil {
-						log.Printf("Audit-checkpoint error: %v", werr)
-						return werr
-					}
-					if written {
-						log.Printf("Audit checkpoint written: #%d head=%d events=%d", cp.ID, cp.HeadID, cp.ChainedEvents)
-					}
-					return nil
-				})
+	// Start the audit-checkpoint scheduler (ADR-029). Periodically signs the verified
+	// audit-chain head so tampering, tail-truncation, and genesis re-seed are
+	// detectable. This is the trail's FORGERY-RESISTANCE layer: the per-row hash chain
+	// is unkeyed, so a database-write attacker could otherwise edit/delete/reorder rows
+	// and recompute a self-consistent chain undetected. It is therefore enabled BY
+	// DEFAULT whenever a signing key is available (the key is DEK-derived → encryption
+	// must be configured). HA-gated so one replica writes per tick.
+	switch {
+	case cfg.AuditCheckpoints.Disabled:
+		log.Printf("WARNING: audit-checkpoint forgery-resistance is explicitly DISABLED; the audit trail is tamper-evident but a database-write attacker can recompute the hash chain undetected")
+	case !coreService.AuditCheckpointsAvailable():
+		log.Printf("WARNING: audit checkpointing is UNAVAILABLE (encryption/signing key not configured) — the audit trail is tamper-EVIDENT only, NOT forgery-resistant: a database-write attacker can edit/delete/reorder audit rows and recompute the chain. Enable encryption to activate forgery resistance.")
+	default:
+		interval := cfg.AuditCheckpoints.GetInterval()
+		log.Printf("Audit-checkpoint scheduler enabled (forgery resistance active): every %s", interval)
+		runScheduler(ctx, "audit_checkpoint", interval, func() middleware.SchedulerOutcome {
+			return lockedRun(ctx, coreService.Storage(), schedLockAuditCkpt, "Audit-checkpoint", func() error {
+				cp, written, werr := coreService.WriteAuditCheckpoint(ctx)
+				if werr != nil {
+					log.Printf("Audit-checkpoint error: %v", werr)
+					return werr
+				}
+				if written {
+					log.Printf("Audit checkpoint written: #%d head=%d events=%d", cp.ID, cp.HeadID, cp.ChainedEvents)
+				}
+				return nil
 			})
-		}
+		})
 	}
 
 	// Start the JIT access-expiry sweeper — opt-in. Removes time-bound role grants

--- a/server/middleware/auth.go
+++ b/server/middleware/auth.go
@@ -102,12 +102,21 @@ const (
 	// TTL for negative cache entries (stale/invalid tokens — MCP storm fix).
 	// Short enough that a legitimately re-issued token works after ~10s.
 	invalidTokenTTL = 10 * time.Second
+	// maxTokenCacheEntries caps the cache so an unauthenticated flood of distinct garbage
+	// bearer tokens (each negative-cached) cannot grow the map without bound and exhaust
+	// process memory. Beyond the cap, arbitrary entries are evicted; a cache miss just
+	// falls back to the DB.
+	maxTokenCacheEntries = 50_000
 )
 
 // tokenCacheEntry holds a cached auth result.
 type tokenCacheEntry struct {
 	userCtx   *UserContext // nil for negative entries
 	expiresAt time.Time
+	// revokedAt marks a tombstone written by an explicit eviction (revoke/logout/suspend).
+	// It lets a positive write that was already in flight when the revoke landed know it
+	// must NOT resurrect the entry (see cacheSetValidated).
+	revokedAt time.Time
 }
 
 // tokenCache is a process-wide cache keyed by SHA-256(token).
@@ -144,15 +153,44 @@ func cacheSet(key string, entry tokenCacheEntry) {
 	tokenCacheMu.Lock()
 	defer tokenCacheMu.Unlock()
 	tokenCache[key] = entry
-	// Periodic O(n) purge — runs at most once per minute.
+	pruneLocked()
+}
+
+// cacheSetValidated stores a POSITIVE entry from the slow path, but refuses to resurrect a
+// token that was revoked WHILE this validation was in flight: if a tombstone for the key
+// was written after validatedAt (the moment the slow path began, before its DB read), the
+// revoke wins and the positive entry is dropped. Closes the revocation-resurrection race.
+func cacheSetValidated(key string, userCtx *UserContext, validatedAt time.Time, expiresAt time.Time) {
+	tokenCacheMu.Lock()
+	defer tokenCacheMu.Unlock()
+	if existing, ok := tokenCache[key]; ok && existing.revokedAt.After(validatedAt) {
+		return // revoked during our validation — do not re-cache the now-stale positive
+	}
+	tokenCache[key] = tokenCacheEntry{userCtx: userCtx, expiresAt: expiresAt}
+	pruneLocked()
+}
+
+// pruneLocked drops expired entries (at most once per minute) and hard-caps the cache so
+// a flood of distinct bearers can't grow it unbounded. Caller MUST hold tokenCacheMu.
+func pruneLocked() {
+	now := time.Now()
 	if time.Since(lastPurge) > time.Minute {
-		now := time.Now()
 		for k, v := range tokenCache {
 			if now.After(v.expiresAt) {
 				delete(tokenCache, k)
 			}
 		}
 		lastPurge = now
+	}
+	// Hard cap independent of the timed purge: evict arbitrary entries (map iteration is
+	// randomized) until back under the cap. A dropped entry is just a future cache miss.
+	for len(tokenCache) > maxTokenCacheEntries {
+		for k := range tokenCache {
+			delete(tokenCache, k)
+			if len(tokenCache) <= maxTokenCacheEntries {
+				break
+			}
+		}
 	}
 }
 
@@ -205,7 +243,10 @@ func authenticationWithValidator(validator sessionValidator, coreService *core.K
 				return
 			}
 
-			// Slow path: DB lookup.
+			// Slow path: DB lookup. Capture the start time BEFORE the DB read so a
+			// concurrent revoke landing during validation is recognized as "after" us and
+			// can't be resurrected by our positive cache write (see cacheSetValidated).
+			validatedAt := time.Now()
 			userCtx, err := validateToken(r.Context(), validator, token)
 			if err != nil {
 				// Cache the negative result so subsequent retries skip the DB.
@@ -221,8 +262,8 @@ func authenticationWithValidator(validator sessionValidator, coreService *core.K
 				userCtx.ImpersonatedBy = coreService.SessionImpersonator(r.Context(), token)
 			}
 
-			// Cache the positive result.
-			cacheSet(key, tokenCacheEntry{userCtx: userCtx, expiresAt: time.Now().Add(validTokenTTL)})
+			// Cache the positive result (race-safe: dropped if revoked mid-validation).
+			cacheSetValidated(key, userCtx, validatedAt, time.Now().Add(validTokenTTL))
 
 			if !tokenNetworkAllowed(r, userCtx) {
 				forbiddenResponse(w, "token not permitted from this network")
@@ -807,6 +848,11 @@ func InvalidateTokenCache(token string) {
 // rather than waiting out the positive-cache TTL.
 func InvalidateTokenCacheByHash(hash string) {
 	tokenCacheMu.Lock()
-	delete(tokenCache, hash)
+	// Write a short-lived tombstone rather than a plain delete: a positive validation that
+	// was already in flight (read the DB before this revoke) would otherwise re-add the
+	// entry right after our delete. The tombstone's revokedAt lets cacheSetValidated drop
+	// that stale write, and negative-caches the revoked token for invalidTokenTTL.
+	now := time.Now()
+	tokenCache[hash] = tokenCacheEntry{userCtx: nil, expiresAt: now.Add(invalidTokenTTL), revokedAt: now}
 	tokenCacheMu.Unlock()
 }

--- a/server/middleware/auth.go
+++ b/server/middleware/auth.go
@@ -703,6 +703,22 @@ func unauthorizedResponse(w http.ResponseWriter, message string) {
 	})
 }
 
+// BlockWhenImpersonating refuses a request made under an impersonation session. It
+// guards the target's credential-issuing / authenticator-lifecycle self-service routes
+// (mint a PAT, enroll/disable MFA, register a passkey) so an admin impersonating a user
+// cannot plant a durable credential that outlives the bounded, audited impersonation
+// session. Impersonation is for acting AS the user for support, not administering their
+// long-lived credentials.
+func BlockWhenImpersonating(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if u := GetUserFromContext(r.Context()); u != nil && u.ImpersonatedBy != nil {
+			forbiddenResponse(w, "this action is not permitted while impersonating")
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
 // forbiddenResponse sends a 403 Forbidden response
 func forbiddenResponse(w http.ResponseWriter, message string) {
 	w.Header().Set("Content-Type", "application/json")

--- a/server/middleware/auth.go
+++ b/server/middleware/auth.go
@@ -782,8 +782,15 @@ func GetCoreServiceFromContext(ctx context.Context) *core.KeyorixCore {
 // InvalidateTokenCache removes a specific token from the auth cache.
 // Call this on logout to ensure the token is rejected immediately.
 func InvalidateTokenCache(token string) {
-	key := tokenKey(token)
+	InvalidateTokenCacheByHash(tokenKey(token))
+}
+
+// InvalidateTokenCacheByHash evicts the entry keyed by the token's SHA-256 hash (hex).
+// PAT revocation works by token ID and never sees the raw token, but a PAT's stored
+// TokenHash equals this cache key, so revoke-by-id can purge the entry immediately
+// rather than waiting out the positive-cache TTL.
+func InvalidateTokenCacheByHash(hash string) {
 	tokenCacheMu.Lock()
-	delete(tokenCache, key)
+	delete(tokenCache, hash)
 	tokenCacheMu.Unlock()
 }

--- a/server/middleware/auth_test.go
+++ b/server/middleware/auth_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
@@ -566,4 +567,68 @@ func TestAuthentication_PATNetworkAllowlist(t *testing.T) {
 	assert.Equal(t, http.StatusForbidden, serve("203.0.113.9:5555"), "off-network source IP is forbidden")
 	// And an in-range request after the cached deny still passes (per-request evaluation).
 	assert.Equal(t, http.StatusOK, serve("10.9.9.9:443"), "in-range again after a deny")
+}
+
+// A token revoked WHILE a slow-path validation was in flight must not be resurrected by
+// that validation's positive cache write (the revocation-resurrection race).
+func TestCacheSetValidated_DropsResurrectionAfterRevoke(t *testing.T) {
+	key := tokenKey("race-token")
+	tokenCacheMu.Lock()
+	delete(tokenCache, key)
+	tokenCacheMu.Unlock()
+
+	validatedAt := time.Now()        // slow path began (before its DB read)
+	time.Sleep(2 * time.Millisecond) //
+	InvalidateTokenCacheByHash(key)  // token revoked during validation
+	// The in-flight positive write must be refused (revoke is newer than validatedAt).
+	cacheSetValidated(key, &UserContext{UserID: 1}, validatedAt, time.Now().Add(validTokenTTL))
+
+	entry, ok := cacheGet(key)
+	if !ok {
+		return // tombstone may have already expired in CI; the key point is no positive entry
+	}
+	if entry.userCtx != nil {
+		t.Error("a token revoked mid-validation must NOT be resurrected as a positive cache entry")
+	}
+}
+
+// A positive write with no intervening revoke is cached normally.
+func TestCacheSetValidated_CachesWhenNotRevoked(t *testing.T) {
+	key := tokenKey("ok-token")
+	tokenCacheMu.Lock()
+	delete(tokenCache, key)
+	tokenCacheMu.Unlock()
+
+	cacheSetValidated(key, &UserContext{UserID: 7}, time.Now(), time.Now().Add(validTokenTTL))
+	entry, ok := cacheGet(key)
+	if !ok || entry.userCtx == nil || entry.userCtx.UserID != 7 {
+		t.Errorf("a non-revoked validation must be cached; got ok=%v entry=%+v", ok, entry)
+	}
+}
+
+// pruneLocked hard-caps the cache so a flood of distinct tokens can't grow it unbounded.
+func TestPruneLocked_EnforcesSizeCap(t *testing.T) {
+	// Clear the shared cache before and after so the bulk insert doesn't bleed into other
+	// tests that share the process-wide map.
+	t.Cleanup(func() {
+		tokenCacheMu.Lock()
+		for k := range tokenCache {
+			delete(tokenCache, k)
+		}
+		tokenCacheMu.Unlock()
+	})
+	tokenCacheMu.Lock()
+	for k := range tokenCache {
+		delete(tokenCache, k)
+	}
+	far := time.Now().Add(time.Hour)
+	for i := 0; i < maxTokenCacheEntries+1000; i++ {
+		tokenCache[tokenKey(string(rune(i))+"-x-"+time.Now().String()+string(rune(i)))] = tokenCacheEntry{expiresAt: far}
+	}
+	pruneLocked()
+	n := len(tokenCache)
+	tokenCacheMu.Unlock()
+	if n > maxTokenCacheEntries {
+		t.Errorf("cache size %d exceeds cap %d after prune", n, maxTokenCacheEntries)
+	}
 }

--- a/server/middleware/client_ip.go
+++ b/server/middleware/client_ip.go
@@ -6,10 +6,9 @@ import (
 	"strings"
 )
 
-// trueClientIPHeaders are the forwarding headers a trusted proxy may set, in order of
-// preference. X-Forwarded-For is a comma-separated client→proxy chain (leftmost is the
-// originating client); X-Real-IP is a single address.
-var trueClientIPHeaders = []string{"X-Forwarded-For", "X-Real-IP"}
+// The forwarding headers a trusted proxy may set, in order of preference, are
+// X-Forwarded-For (a comma-separated client→proxy chain; leftmost is the originating
+// client) and X-Real-IP (a single address) — both read directly in clientIPFromRequest.
 
 // ClientIP returns a middleware that derives the real client IP and rewrites
 // r.RemoteAddr, but ONLY honors forwarding headers when the immediate TCP peer is a

--- a/server/middleware/client_ip.go
+++ b/server/middleware/client_ip.go
@@ -1,0 +1,115 @@
+package middleware
+
+import (
+	"net"
+	"net/http"
+	"strings"
+)
+
+// trueClientIPHeaders are the forwarding headers a trusted proxy may set, in order of
+// preference. X-Forwarded-For is a comma-separated client→proxy chain (leftmost is the
+// originating client); X-Real-IP is a single address.
+var trueClientIPHeaders = []string{"X-Forwarded-For", "X-Real-IP"}
+
+// ClientIP returns a middleware that derives the real client IP and rewrites
+// r.RemoteAddr, but ONLY honors forwarding headers when the immediate TCP peer is a
+// configured trusted proxy. This replaces chi's middleware.RealIP, which trusts the
+// header unconditionally — letting any client spoof its source IP and so defeat the
+// per-IP login/MFA brute-force rate limiter that keys on r.RemoteAddr.
+//
+// trustedProxies is a list of CIDRs or bare IPs (the ingress/load-balancer addresses).
+// When it is empty, forwarding headers are ignored entirely and the real TCP peer is
+// always used — the safe default for a directly-exposed server. When the peer is NOT a
+// trusted proxy, headers are likewise ignored. Only when the peer IS trusted do we walk
+// the X-Forwarded-For chain from the right and take the first hop that is not itself a
+// trusted proxy (the address the trusted edge actually saw), so an attacker cannot
+// prepend a spoofed entry to claim an arbitrary client IP.
+func ClientIP(trustedProxies []string) func(http.Handler) http.Handler {
+	nets := parseCIDRs(trustedProxies)
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if ip := clientIPFromRequest(r, nets); ip != "" {
+				r.RemoteAddr = ip
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// clientIPFromRequest returns the IP to attribute the request to, or "" to leave
+// r.RemoteAddr unchanged. It trusts forwarding headers only when the peer is trusted.
+func clientIPFromRequest(r *http.Request, trusted []*net.IPNet) string {
+	peer := hostOnly(r.RemoteAddr)
+	if len(trusted) == 0 || !ipInAny(peer, trusted) {
+		return "" // no trusted proxy in front (or none configured) → keep the TCP peer
+	}
+	// X-Real-IP, if a trusted proxy set it, is a single already-resolved client address.
+	if xri := strings.TrimSpace(r.Header.Get("X-Real-IP")); xri != "" {
+		if net.ParseIP(xri) != nil {
+			return xri
+		}
+	}
+	// Walk X-Forwarded-For right→left and return the first address that is NOT a trusted
+	// proxy — the client as seen by the trusted edge. A spoofed leftmost entry is ignored
+	// because we stop at the first untrusted hop from the right.
+	xff := r.Header.Get("X-Forwarded-For")
+	if xff == "" {
+		return ""
+	}
+	parts := strings.Split(xff, ",")
+	for i := len(parts) - 1; i >= 0; i-- {
+		hop := strings.TrimSpace(parts[i])
+		if hop == "" || net.ParseIP(hop) == nil {
+			continue
+		}
+		if !ipInAny(hop, trusted) {
+			return hop
+		}
+	}
+	return ""
+}
+
+func parseCIDRs(entries []string) []*net.IPNet {
+	nets := make([]*net.IPNet, 0, len(entries))
+	for _, e := range entries {
+		e = strings.TrimSpace(e)
+		if e == "" {
+			continue
+		}
+		if !strings.Contains(e, "/") {
+			// A bare IP — treat as a /32 (v4) or /128 (v6).
+			if ip := net.ParseIP(e); ip != nil {
+				if ip.To4() != nil {
+					e += "/32"
+				} else {
+					e += "/128"
+				}
+			}
+		}
+		if _, n, err := net.ParseCIDR(e); err == nil {
+			nets = append(nets, n)
+		}
+	}
+	return nets
+}
+
+func ipInAny(ipStr string, nets []*net.IPNet) bool {
+	ip := net.ParseIP(ipStr)
+	if ip == nil {
+		return false
+	}
+	for _, n := range nets {
+		if n.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+// hostOnly strips the :port from a host:port (or returns the input if there's no port).
+func hostOnly(addr string) string {
+	if host, _, err := net.SplitHostPort(addr); err == nil {
+		return host
+	}
+	return addr
+}

--- a/server/middleware/client_ip.go
+++ b/server/middleware/client_ip.go
@@ -43,28 +43,29 @@ func clientIPFromRequest(r *http.Request, trusted []*net.IPNet) string {
 	if len(trusted) == 0 || !ipInAny(peer, trusted) {
 		return "" // no trusted proxy in front (or none configured) → keep the TCP peer
 	}
-	// X-Real-IP, if a trusted proxy set it, is a single already-resolved client address.
-	if xri := strings.TrimSpace(r.Header.Get("X-Real-IP")); xri != "" {
-		if net.ParseIP(xri) != nil {
-			return xri
+	// Prefer X-Forwarded-For: walk it right→left and return the first address that is NOT
+	// a trusted proxy — the client as seen by the trusted edge. Stopping at the first
+	// untrusted hop from the right means a spoofed leftmost (client-prepended) entry is
+	// ignored, so the client cannot claim an arbitrary source IP.
+	if xff := strings.TrimSpace(r.Header.Get("X-Forwarded-For")); xff != "" {
+		parts := strings.Split(xff, ",")
+		for i := len(parts) - 1; i >= 0; i-- {
+			hop := strings.TrimSpace(parts[i])
+			if hop == "" || net.ParseIP(hop) == nil {
+				continue
+			}
+			if !ipInAny(hop, trusted) {
+				return hop
+			}
 		}
+		return "" // XFF present but only trusted hops — nothing client-attributable
 	}
-	// Walk X-Forwarded-For right→left and return the first address that is NOT a trusted
-	// proxy — the client as seen by the trusted edge. A spoofed leftmost entry is ignored
-	// because we stop at the first untrusted hop from the right.
-	xff := r.Header.Get("X-Forwarded-For")
-	if xff == "" {
-		return ""
-	}
-	parts := strings.Split(xff, ",")
-	for i := len(parts) - 1; i >= 0; i-- {
-		hop := strings.TrimSpace(parts[i])
-		if hop == "" || net.ParseIP(hop) == nil {
-			continue
-		}
-		if !ipInAny(hop, trusted) {
-			return hop
-		}
+	// Only when X-Forwarded-For is absent do we fall back to X-Real-IP. X-Real-IP carries
+	// no chain, so its anti-spoof guarantee depends entirely on the trusted proxy
+	// OVERWRITING it (not passing a client-supplied value through). Preferring the XFF
+	// walk above avoids trusting a possibly-passed-through X-Real-IP whenever XFF exists.
+	if xri := strings.TrimSpace(r.Header.Get("X-Real-IP")); xri != "" && net.ParseIP(xri) != nil {
+		return xri
 	}
 	return ""
 }

--- a/server/middleware/client_ip_test.go
+++ b/server/middleware/client_ip_test.go
@@ -1,0 +1,76 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// serveAndCaptureRemoteAddr runs the ClientIP middleware over a request and returns the
+// r.RemoteAddr the downstream handler observes.
+func serveAndCaptureRemoteAddr(trusted []string, remoteAddr string, headers map[string]string) string {
+	var seen string
+	h := ClientIP(trusted)(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		seen = r.RemoteAddr
+	}))
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = remoteAddr
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	h.ServeHTTP(httptest.NewRecorder(), req)
+	return seen
+}
+
+func TestClientIP_IgnoresHeaderWhenNoTrustedProxies(t *testing.T) {
+	// No trusted proxies configured → a spoofed X-Forwarded-For must be ignored and the
+	// real TCP peer kept (so the rate limiter keys on the attacker's real IP).
+	got := serveAndCaptureRemoteAddr(nil, "203.0.113.7:5555", map[string]string{
+		"X-Forwarded-For": "1.2.3.4",
+		"X-Real-IP":       "5.6.7.8",
+	})
+	if got != "203.0.113.7:5555" {
+		t.Errorf("RemoteAddr = %q; want the unmodified TCP peer", got)
+	}
+}
+
+func TestClientIP_IgnoresHeaderWhenPeerNotTrusted(t *testing.T) {
+	// A trusted proxy IS configured, but this request comes straight from an untrusted
+	// peer → its spoofed header must not be honored.
+	got := serveAndCaptureRemoteAddr([]string{"10.0.0.0/8"}, "203.0.113.7:5555", map[string]string{
+		"X-Forwarded-For": "1.2.3.4",
+	})
+	if got != "203.0.113.7:5555" {
+		t.Errorf("RemoteAddr = %q; want the unmodified TCP peer", got)
+	}
+}
+
+func TestClientIP_HonorsHeaderFromTrustedProxy(t *testing.T) {
+	// The peer is the trusted proxy → the forwarded client IP is taken.
+	got := serveAndCaptureRemoteAddr([]string{"10.0.0.0/8"}, "10.1.2.3:443", map[string]string{
+		"X-Forwarded-For": "203.0.113.9",
+	})
+	if got != "203.0.113.9" {
+		t.Errorf("RemoteAddr = %q; want the forwarded client IP", got)
+	}
+}
+
+func TestClientIP_StopsAtFirstUntrustedHopFromRight(t *testing.T) {
+	// XFF chain: spoofed, real-client, trusted-proxy. Walking from the right, the first
+	// untrusted hop is the real client — a prepended spoofed entry is ignored.
+	got := serveAndCaptureRemoteAddr([]string{"10.0.0.0/8"}, "10.1.2.3:443", map[string]string{
+		"X-Forwarded-For": "9.9.9.9, 203.0.113.9, 10.4.5.6",
+	})
+	if got != "203.0.113.9" {
+		t.Errorf("RemoteAddr = %q; want the first untrusted hop from the right", got)
+	}
+}
+
+func TestClientIP_BareIPTrustedProxy(t *testing.T) {
+	got := serveAndCaptureRemoteAddr([]string{"192.168.1.10"}, "192.168.1.10:8080", map[string]string{
+		"X-Real-IP": "198.51.100.2",
+	})
+	if got != "198.51.100.2" {
+		t.Errorf("RemoteAddr = %q; want the X-Real-IP from the trusted proxy", got)
+	}
+}

--- a/server/middleware/client_ip_test.go
+++ b/server/middleware/client_ip_test.go
@@ -66,6 +66,28 @@ func TestClientIP_StopsAtFirstUntrustedHopFromRight(t *testing.T) {
 	}
 }
 
+func TestClientIP_XForwardedForTakesPrecedenceOverRealIP(t *testing.T) {
+	// When both headers are present, the spoof-resistant XFF walk wins over X-Real-IP,
+	// so a client-supplied (possibly proxy-passed-through) X-Real-IP can't override it.
+	got := serveAndCaptureRemoteAddr([]string{"10.0.0.0/8"}, "10.1.2.3:443", map[string]string{
+		"X-Forwarded-For": "203.0.113.9",
+		"X-Real-IP":       "6.6.6.6", // attacker-set; must be ignored in favor of XFF
+	})
+	if got != "203.0.113.9" {
+		t.Errorf("RemoteAddr = %q; want the X-Forwarded-For client, not the X-Real-IP", got)
+	}
+}
+
+func TestClientIP_RealIPOnlyWhenNoXForwardedFor(t *testing.T) {
+	// X-Real-IP is honored only as a fallback when XFF is absent (and the peer is trusted).
+	got := serveAndCaptureRemoteAddr([]string{"10.0.0.0/8"}, "10.1.2.3:443", map[string]string{
+		"X-Real-IP": "198.51.100.7",
+	})
+	if got != "198.51.100.7" {
+		t.Errorf("RemoteAddr = %q; want the X-Real-IP fallback", got)
+	}
+}
+
 func TestClientIP_BareIPTrustedProxy(t *testing.T) {
 	got := serveAndCaptureRemoteAddr([]string{"192.168.1.10"}, "192.168.1.10:8080", map[string]string{
 		"X-Real-IP": "198.51.100.2",

--- a/server/middleware/metrics.go
+++ b/server/middleware/metrics.go
@@ -51,9 +51,28 @@ func PrometheusMiddleware(next http.Handler) http.Handler {
 		if status == 0 {
 			status = http.StatusOK // handler returned without an explicit WriteHeader
 		}
-		httpRequestsTotal.WithLabelValues(r.Method, route, strconv.Itoa(status)).Inc()
-		httpRequestDuration.WithLabelValues(r.Method, route).Observe(time.Since(start).Seconds())
+		method := normalizeMethod(r.Method)
+		httpRequestsTotal.WithLabelValues(method, route, strconv.Itoa(status)).Inc()
+		httpRequestDuration.WithLabelValues(method, route).Observe(time.Since(start).Seconds())
 	})
+}
+
+// knownMethods bounds the `method` metric label. net/http accepts any RFC-7230 token
+// as a request method, so labelling series with the raw method would let an
+// unauthenticated caller spawn unbounded time series (one per distinct method, ×buckets
+// in the histogram) and exhaust the registry — a memory-exhaustion DoS. Anything outside
+// this allow-list collapses to "other".
+var knownMethods = map[string]bool{
+	http.MethodGet: true, http.MethodPost: true, http.MethodPut: true, http.MethodPatch: true,
+	http.MethodDelete: true, http.MethodHead: true, http.MethodOptions: true,
+	http.MethodConnect: true, http.MethodTrace: true,
+}
+
+func normalizeMethod(m string) string {
+	if knownMethods[m] {
+		return m
+	}
+	return "other"
 }
 
 // MetricsHandler serves the Prometheus exposition endpoint (default registry:

--- a/server/middleware/metrics_test.go
+++ b/server/middleware/metrics_test.go
@@ -1,0 +1,24 @@
+package middleware
+
+import (
+	"net/http"
+	"testing"
+)
+
+// The method label must be bounded to a fixed allow-list so an attacker sending arbitrary
+// RFC-7230 method tokens cannot spawn unbounded Prometheus time series (memory DoS).
+func TestNormalizeMethod(t *testing.T) {
+	for _, m := range []string{
+		http.MethodGet, http.MethodPost, http.MethodPut, http.MethodPatch,
+		http.MethodDelete, http.MethodHead, http.MethodOptions, http.MethodConnect, http.MethodTrace,
+	} {
+		if got := normalizeMethod(m); got != m {
+			t.Errorf("normalizeMethod(%q) = %q; want %q", m, got, m)
+		}
+	}
+	for _, m := range []string{"AAAA", "BBBB", "lowercaseget", "FOOBAR", ""} {
+		if got := normalizeMethod(m); got != "other" {
+			t.Errorf("normalizeMethod(%q) = %q; want %q", m, got, "other")
+		}
+	}
+}

--- a/server/middleware/recovery.go
+++ b/server/middleware/recovery.go
@@ -5,7 +5,21 @@ import (
 	"log"
 	"net/http"
 	"runtime/debug"
+	"strings"
+	"unicode"
 )
+
+// stripControl removes control characters (CR/LF, ANSI/C1 escapes, NUL, etc.) from a
+// string before it is written to a log line, preventing log-injection / terminal-control
+// smuggling via attacker-influenceable values (request headers, usernames).
+func stripControl(s string) string {
+	return strings.Map(func(r rune) rune {
+		if unicode.IsControl(r) {
+			return -1
+		}
+		return r
+	}, s)
+}
 
 // Recovery returns a middleware that recovers from panics and returns a proper error response
 func Recovery() func(next http.Handler) http.Handler {
@@ -17,19 +31,23 @@ func Recovery() func(next http.Handler) http.Handler {
 					log.Printf("PANIC: %v\n%s", err, debug.Stack())
 
 					// Get request context for logging
-					requestID := r.Header.Get("X-Request-ID")
+					// Strip control characters from the attacker-influenceable X-Request-ID
+					// header and the username before logging, so neither can inject a forged
+					// log line or smuggle terminal-control sequences into a log viewer
+					// (net/http already drops CR/LF in headers, but not other C0/C1 controls).
+					requestID := stripControl(r.Header.Get("X-Request-ID"))
 					if requestID == "" {
 						requestID = "unknown"
 					}
 
 					var userInfo string
 					if userCtx := GetUserFromContext(r.Context()); userCtx != nil {
-						userInfo = userCtx.Username
+						userInfo = stripControl(userCtx.Username)
 					} else {
 						userInfo = "anonymous"
 					}
 
-					log.Printf("PANIC CONTEXT: RequestID=%s, User=%s, Method=%s, Path=%s, RemoteAddr=%s", // #nosec G706
+					log.Printf("PANIC CONTEXT: RequestID=%s, User=%s, Method=%s, Path=%s, RemoteAddr=%s",
 						requestID, userInfo, r.Method, r.URL.Path, r.RemoteAddr)
 
 					// Send a generic error response. We deliberately NEVER return the

--- a/server/transport_tls_test.go
+++ b/server/transport_tls_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+)
+
+func cfgWith(httpEnabled, httpTLS, grpcEnabled, grpcTLS, require bool) *config.Config {
+	c := &config.Config{}
+	c.Server.HTTP.Enabled = httpEnabled
+	c.Server.HTTP.TLS.Enabled = httpTLS
+	c.Server.GRPC.Enabled = grpcEnabled
+	c.Server.GRPC.TLS.Enabled = grpcTLS
+	c.Security.RequireTransportTLS = require
+	return c
+}
+
+func TestCheckTransportTLSPosture(t *testing.T) {
+	// require_transport_tls + a cleartext enabled listener → fail closed.
+	if err := checkTransportTLSPosture(cfgWith(true, false, false, false, true)); err == nil {
+		t.Error("expected failure: HTTP cleartext with require_transport_tls set")
+	}
+	if err := checkTransportTLSPosture(cfgWith(false, false, true, false, true)); err == nil {
+		t.Error("expected failure: gRPC cleartext with require_transport_tls set")
+	}
+	// require set but both listeners have TLS → ok.
+	if err := checkTransportTLSPosture(cfgWith(true, true, true, true, true)); err != nil {
+		t.Errorf("TLS on both listeners must pass even with require set: %v", err)
+	}
+	// require OFF + cleartext → no error (warns only).
+	if err := checkTransportTLSPosture(cfgWith(true, false, true, false, false)); err != nil {
+		t.Errorf("cleartext without require must not fail: %v", err)
+	}
+	// a disabled listener is ignored even under require.
+	if err := checkTransportTLSPosture(cfgWith(false, false, false, false, true)); err != nil {
+		t.Errorf("no enabled listeners must pass: %v", err)
+	}
+}

--- a/server/transport_tls_test.go
+++ b/server/transport_tls_test.go
@@ -1,10 +1,65 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/keyorixhq/keyorix/internal/config"
 )
+
+// A group/world-readable key file must fail closed when the permission check is enabled,
+// warn (no error) by default, and be allowed when explicitly overridden. A 0600 file or a
+// missing file (first boot) passes.
+func TestEnforceKeyFilePermissions(t *testing.T) {
+	dir := t.TempDir()
+	dek := filepath.Join(dir, "dek.key")
+	salt := filepath.Join(dir, "kek.salt")
+	mk := func(p string, mode os.FileMode) {
+		if err := os.WriteFile(p, []byte("x"), mode); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chmod(p, mode); err != nil { // defeat umask
+			t.Fatal(err)
+		}
+	}
+
+	base := func() *config.Config {
+		c := &config.Config{}
+		c.Storage.Encryption.Enabled = true
+		c.Storage.Encryption.DEKPath = dek
+		c.Storage.Encryption.SaltPath = salt
+		return c
+	}
+
+	// 0600 files → ok regardless of the flag.
+	mk(dek, 0600)
+	mk(salt, 0600)
+	if err := enforceKeyFilePermissions(base()); err != nil {
+		t.Errorf("0600 key files must pass: %v", err)
+	}
+
+	// World-readable DEK + strict check → fail closed.
+	mk(dek, 0644)
+	strict := base()
+	strict.Security.EnableFilePermissionCheck = true
+	if err := enforceKeyFilePermissions(strict); err == nil {
+		t.Error("world-readable key with enable_file_permission_check must fail closed")
+	}
+
+	// Same file, default (no strict flag) → warn only, no error.
+	if err := enforceKeyFilePermissions(base()); err != nil {
+		t.Errorf("default mode must warn, not fail: %v", err)
+	}
+
+	// Strict but explicitly overridden → allowed.
+	override := base()
+	override.Security.EnableFilePermissionCheck = true
+	override.Security.AllowUnsafeFilePermissions = true
+	if err := enforceKeyFilePermissions(override); err != nil {
+		t.Errorf("allow_unsafe_file_permissions must override: %v", err)
+	}
+}
 
 func cfgWith(httpEnabled, httpTLS, grpcEnabled, grpcTLS, require bool) *config.Config {
 	c := &config.Config{}


### PR DESCRIPTION
## Summary

A multi-subsystem security-hardening batch from an adversarial bug-hunt across previously-unaudited veins. One HIGH, one MEDIUM, plus several lower-severity fixes — each a focused commit with regression tests. Reviewable commit-by-commit.

## Fixes (by severity)

**HIGH**
- `harden(bootstrap)` — `POST /system/init` was unauthenticated and gated only by a "no users yet" check, so a fresh, network-reachable instance could be seized (first caller becomes global admin). Now requires a bootstrap token (constant-time; auto-generated and logged on first boot, or `KEYORIX_BOOTSTRAP_TOKEN`) and enforces the password policy on the seeded admin. `keyorix system init` gains `--bootstrap-token`.

**MEDIUM**
- `fix(grpc)` — `ShareService.ListUserShares`/`ListSharedSecrets` authorized with a flat permission check that ignored a PAT's scope restriction (the HTTP routes enforce it); a PAT scoped below global `secrets.read` could list shares over gRPC. Now routes through `authorizeGlobal` → `AuthorizePrincipal` (ADR-066 transport-divergence class).
- `harden(crypto)` — bind the wrapped KEK to the install via KMS encryption context (AWS `EncryptionContext` / GCP AAD) so installs sharing one CMK can't unwrap each other's KEK. Opt-in/default-empty (identical to prior behaviour), legacy-blob decrypt fallback. **Azure unsupported** (RSA-OAEP has no AAD). *Validated against fakes modelling KMS context semantics — validate against live AWS/GCP KMS before enabling in production.*
- `feat(audit)` — durable opt-in on-disk SIEM spool with replay, so a sustained SIEM outage no longer silently drops the off-box copy.
- `harden(audit)` — `emitAudit` no longer swallows the persist error and won't forward a phantom event; SIEM payload now carries `entry_hash`/`prev_hash` for downstream gap/forgery detection.

**LOW / hardening**
- `harden(k8ssync)` — owner-conditional orphan delete (re-verify label + pin uid/resourceVersion; 409→skip) + RFC1123 namespace/name validation.
- `harden(securefiles,rotation)` — symlink-safe containment (EvalSymlinks) + safest-victim AWS IAM key eviction.
- `harden(crypto)` — reject an all-zero file/env KEK.
- `harden(notifychan)` — HMAC-sign webhook payloads + require https endpoints (refuse cross-host/downgrade redirects).
- `harden(storage)` — exclude soft-deleted users from the raw group-share queries.
- `harden(pat)` — evict the auth cache on PAT revoke so a revoked token stops working immediately (was lingering ≤30s).

## Testing

Every fix carries regression tests. `go build ./...`, the full `go test ./internal/... ./server/... ./cmd/...` suite, `go vet`, `gofmt`, and `gosec -severity medium` are all green.

## Notes for the reviewer

- The KMS encryption-context binding is the only change touching the catastrophic KEK-unwrap path; it is opt-in and default-equivalent, but please validate against live KMS before enabling `key_provider.kms_encryption_context`.
- Several deferred items were completed within this batch (durable SIEM spool, KMS binding). The batch is large but each commit is independently scoped — happy to split into smaller PRs if preferred.
