### PR TITLE
fix(helm): harden the main keyorix chart's server/web/postgres pods (#137)

### DIFF
--- a/deploy/helm/keyorix/templates/_helpers.tpl
+++ b/deploy/helm/keyorix/templates/_helpers.tpl
@@ -34,5 +34,17 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
 
 {{- define "keyorix.server.image" -}}
+{{- if .Values.server.image.digest -}}
+{{- printf "%s@%s" .Values.server.image.repository .Values.server.image.digest -}}
+{{- else -}}
 {{- printf "%s:%s" .Values.server.image.repository (default .Chart.AppVersion .Values.server.image.tag) -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "keyorix.web.image" -}}
+{{- if .Values.web.image.digest -}}
+{{- printf "%s@%s" .Values.web.image.repository .Values.web.image.digest -}}
+{{- else -}}
+{{- printf "%s:%s" .Values.web.image.repository .Values.web.image.tag -}}
+{{- end -}}
 {{- end -}}

--- a/deploy/helm/keyorix/templates/networkpolicy.yaml
+++ b/deploy/helm/keyorix/templates/networkpolicy.yaml
@@ -1,0 +1,62 @@
+{{/*
+NetworkPolicies scoping the server API and the bundled Postgres to same-namespace
+traffic — without them both are reachable from ANY pod in the cluster that can
+route to their Service (#137). The web UI is deliberately left unrestricted here:
+it's the intended public entry point (often via an Ingress controller whose pod
+labels vary by installation), so locking it down risks breaking legitimate access
+in ways this chart can't predict across every ingress-controller setup.
+*/}}
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "keyorix.server.fullname" . }}
+  labels:
+    {{- include "keyorix.labels" . | nindent 4 }}
+    app.kubernetes.io/component: server
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: server
+  policyTypes:
+    - Ingress
+  ingress:
+    # Same-namespace only: any pod that can route here is currently reachable
+    # cluster-wide (any namespace). This bounds it to the install's own namespace
+    # — typically a single security boundary — while imposing no new dependency
+    # on knowing which specific pods (web, CLI clients, other services) call in.
+    - from:
+        - podSelector: {}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.server.service.port }}
+---
+{{- if .Values.postgresql.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "keyorix.postgresql.fullname" . }}
+  labels:
+    {{- include "keyorix.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgresql
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: postgresql
+  policyTypes:
+    - Ingress
+  ingress:
+    # Only the server needs to reach the bundled Postgres — nothing else in the
+    # cluster (any other namespace, or another pod in this one) should be able to.
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/instance: {{ .Release.Name }}
+              app.kubernetes.io/component: server
+      ports:
+        - protocol: TCP
+          port: 5432
+{{- end }}
+{{- end }}

--- a/deploy/helm/keyorix/templates/postgresql.yaml
+++ b/deploy/helm/keyorix/templates/postgresql.yaml
@@ -59,10 +59,23 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      securityContext:
+        # 999 is the postgres user in the official postgres:*-alpine images; fsGroup
+        # makes the PVC group-writable by it so a fresh (non-root-initialised)
+        # volume doesn't need the entrypoint's root-owned chown step.
+        runAsNonRoot: true
+        runAsUser: 999
+        fsGroup: 999
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: postgresql
           image: "{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}"
           imagePullPolicy: {{ .Values.postgresql.image.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
           ports:
             - name: postgres
               containerPort: 5432

--- a/deploy/helm/keyorix/templates/server-deployment.yaml
+++ b/deploy/helm/keyorix/templates/server-deployment.yaml
@@ -26,10 +26,23 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      securityContext:
+        # matches the server image's "keyorix" user (server/Dockerfile: addgroup/
+        # adduser -u 1001 -g 1001).
+        runAsNonRoot: true
+        runAsUser: 1001
+        runAsGroup: 1001
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: server
           image: {{ include "keyorix.server.image" . }}
           imagePullPolicy: {{ .Values.server.image.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
           ports:
             - name: http
               containerPort: {{ .Values.server.service.port }}
@@ -63,6 +76,8 @@ spec:
               readOnly: true
             - name: keys
               mountPath: /app/keys
+            - name: tmp
+              mountPath: /tmp
           livenessProbe:
             httpGet:
               path: /health
@@ -90,6 +105,8 @@ spec:
           {{- else }}
           emptyDir: {}
           {{- end }}
+        - name: tmp
+          emptyDir: {}
       {{- with .Values.server.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/deploy/helm/keyorix/templates/web-deployment.yaml
+++ b/deploy/helm/keyorix/templates/web-deployment.yaml
@@ -24,10 +24,23 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      securityContext:
+        # A non-root nginx binding port 80 needs CAP_NET_BIND_SERVICE (below,
+        # container-level), not root — UID 101 is nginx's own non-root user in the
+        # standard/alpine nginx images this is built from.
+        runAsNonRoot: true
+        runAsUser: 101
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: web
-          image: "{{ .Values.web.image.repository }}:{{ .Values.web.image.tag }}"
+          image: {{ include "keyorix.web.image" . | quote }}
           imagePullPolicy: {{ .Values.web.image.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              add: ["NET_BIND_SERVICE"]
+              drop: ["ALL"]
           ports:
             - name: http
               containerPort: 80

--- a/deploy/helm/keyorix/values.yaml
+++ b/deploy/helm/keyorix/values.yaml
@@ -21,9 +21,16 @@ auth:
 server:
   image:
     repository: ghcr.io/keyorixhq/keyorix-server
-    # Published GHCR tags today are `latest` / `main` / `sha-<commit>` (no semver
-    # tags yet). Pin to a `sha-*` or a future `vX.Y.Z` tag for reproducibility.
+    # `latest`/`main` are MUTABLE — the exact same tag can point at a different
+    # image tomorrow, defeating "what did I actually deploy" and any image-scan
+    # attestation pinned to this value. Pin to an immutable `sha-<commit>` tag, a
+    # `vX.Y.Z` release tag, or (strongest) a digest via `digest:` below for
+    # production.
     tag: "latest"
+    # digest, when set (e.g. "sha256:abc123..."), pins the exact image content —
+    # immune to a tag being retargeted after the fact — and takes precedence over
+    # tag.
+    digest: ""
     pullPolicy: IfNotPresent
   # The server holds the encryption keys on a single ReadWriteOnce volume and is
   # a single logical instance — do not scale beyond 1 replica.
@@ -37,7 +44,13 @@ server:
     size: 1Gi
     storageClass: ""
     accessMode: ReadWriteOnce
-  resources: {}
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 1
+      memory: 512Mi
   nodeSelector: {}
   tolerations: []
   affinity: {}
@@ -47,13 +60,22 @@ web:
   enabled: true
   image:
     repository: ghcr.io/keyorixhq/keyorix-web
+    # See server.image.tag — the same mutable-tag caveat applies here.
     tag: latest
+    # digest, when set, takes precedence over tag (see server.image.digest).
+    digest: ""
     pullPolicy: IfNotPresent
   replicas: 1
   service:
     type: ClusterIP
     port: 80
-  resources: {}
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 500m
+      memory: 128Mi
 
 # ── Ingress (for the web UI) ──────────────────────────────────────────────────
 ingress:
@@ -82,7 +104,13 @@ postgresql:
     enabled: true
     size: 8Gi
     storageClass: ""
-  resources: {}
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 1
+      memory: 1Gi
 
 # Used when postgresql.enabled is false.
 externalDatabase:
@@ -91,5 +119,13 @@ externalDatabase:
   database: keyorix
   user: keyorix
   sslMode: require
+
+# ── Network policy ────────────────────────────────────────────────────────────
+# Scopes the server API and the bundled Postgres to same-namespace traffic —
+# without this both are reachable from any pod in the cluster that can route to
+# their Service. Disable only if your CNI doesn't support NetworkPolicy, or you
+# have an equivalent policy managed elsewhere.
+networkPolicy:
+  enabled: true
 
 imagePullSecrets: []

--- a/internal/audit/siem/spool.go
+++ b/internal/audit/siem/spool.go
@@ -42,9 +42,16 @@ type spool struct {
 	maxBytes    int64
 	deliverOnce func(context.Context, *models.AuditEvent) error
 
-	mu   sync.Mutex // serializes file mutation (append + replay rewrite); NOT held across delivery
-	stop chan struct{}
-	done chan struct{}
+	mu sync.Mutex // serializes file mutation (append + replay rewrite); NOT held across delivery
+	// replayMu serializes replay() end-to-end (distinct from mu, which is deliberately
+	// released across delivery). Without it, the loop's immediate on-start replay can
+	// race a concurrently-triggered one: both read the same undelivered snapshot before
+	// either rewrites the file, and both attempt delivery — double-delivering the same
+	// backlog to the SIEM. A skipped replay is harmless (the ticker or the next trigger
+	// retries the same backlog), so this blocks rather than drops.
+	replayMu sync.Mutex
+	stop     chan struct{}
+	done     chan struct{}
 }
 
 // newSpool prepares the spool directory and starts the replay loop.
@@ -124,6 +131,8 @@ func (s *spool) loop() {
 // on the audited request path) never blocks behind a SIEM round-trip. Crash-safe: every
 // undelivered line stays on disk until the atomic rewrite at the end.
 func (s *spool) replay() {
+	s.replayMu.Lock()
+	defer s.replayMu.Unlock()
 	// Snapshot under the lock, recording the byte length we read; any add() during the
 	// lock-free delivery below only appends BEYOND this offset (add never rewrites), so the
 	// reconcile can cleanly separate "what we attempted" from "what arrived meanwhile".


### PR DESCRIPTION
## Summary
The operator + `keyorix-k8s-sync` charts were already hardened, but the main chart's server/web/postgres pods shipped with none of it: no `securityContext` (runAsNonRoot, dropped capabilities, seccomp), no `NetworkPolicy` (the API and the bundled Postgres are reachable from any pod in the cluster that can route to their Service), no resource limits, and mutable `latest` image tags.

- **server**: `runAsNonRoot`/`runAsUser 1001` (matches `server/Dockerfile`'s `keyorix` user), `readOnlyRootFilesystem` + a `/tmp` emptyDir, drop ALL capabilities.
- **web**: `runAsNonRoot`/`runAsUser 101` (nginx's own non-root user), drop ALL capabilities except `NET_BIND_SERVICE` (needed to bind port 80 as non-root). `readOnlyRootFilesystem` is **not** set here — nginx's default cache/pid/log paths aren't verified compatible with a read-only root for this specific image (built in a separate repo), so this is left as a documented follow-up rather than risking a startup break.
- **postgresql**: `runAsNonRoot`/`runAsUser 999` (official `postgres:*-alpine` image user) + `fsGroup 999`, drop ALL capabilities. `readOnlyRootFilesystem` is not set — the official image writes broadly beyond PGDATA.
- New **NetworkPolicy** (`networkPolicy.enabled`, default `true`): scopes the server API and the bundled Postgres to same-namespace ingress only, closing the cluster-wide reachability the finding calls out. The web UI is deliberately left unrestricted (it's often the Ingress-controller entry point, whose pod labels vary per installation).
- Resource requests/limits defaults for all three (previously unset).
- `image.digest` (server + web): pins the exact image content, taking precedence over the mutable `tag` default.

**Scope note:** `KEYORIX_MASTER_PASSWORD` via env var (visible via `kubectl exec`/`describe`) and the bundled Postgres's `ssl_mode=disable` are **not** addressed here. The former needs application-side support for a file-based passphrase source (a Go change, not a chart-only fix); the latter is explicitly an "evaluation only" component per its own `values.yaml` comment, with the production path (`externalDatabase.sslMode`) already defaulting to `require`.

From the durable hardening backlog (`docs/security/HARDENING-BACKLOG.md`, finding #137).

## Test plan
- [x] `helm lint deploy/helm/keyorix --strict --set auth.masterPassword=... --set postgresql.auth.password=...` — 0 failures
- [x] `helm template ... | kubeconform -strict -kubernetes-version 1.29.0` for both the bundled-DB and external-DB paths (matching CI's `helm-chart` job exactly) — 0 schema errors across 15/10 rendered resources
- [x] Verified `networkPolicy.enabled=false` and `postgresql.enabled=false` correctly gate/omit the NetworkPolicy resources
- [x] Verified `server.image.digest`/`web.image.digest` override render `repo@sha256:...` correctly, taking precedence over `tag`
- [x] No Go changes in this PR; includes the SIEM spool replay race fix from PR #521 (reapplied — this branch forked from `main` before that one merged) so `build-and-test` stays green