### PR TITLE
fix(sso): gate email-fallback account linking behind an explicit opt-in (#89)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -939,6 +939,14 @@ type SSOProviderConfig struct {
 	// (default "system_viewer"). A misconfigured/unknown role grants nothing —
 	// least-privilege on misconfiguration.
 	DefaultRole string `yaml:"default_role"`
+	// TrustEmailForLinking opts this provider into linking its first-login identity
+	// to a PRE-EXISTING account (including a native/password-based one) purely by
+	// asserted email, when no scoped external_id match exists yet. Opt-in (default
+	// off): SAML has no verified-email concept and an OIDC id_token can simply omit
+	// email_verified, so an untrusted/self-service IdP could otherwise hijack an
+	// existing account by asserting its email. Enable only for a provider whose
+	// asserted email you actually trust.
+	TrustEmailForLinking bool `yaml:"trust_email_for_linking"`
 
 	// GroupSync reconciles the user's NATIVE group memberships from the IdP's groups
 	// claim on each login (the IdP becomes the source of truth — membership is added

--- a/internal/core/saml_flow_test.go
+++ b/internal/core/saml_flow_test.go
@@ -145,6 +145,11 @@ func TestCompleteSAML_NoAccountNoProvision(t *testing.T) {
 func TestCompleteSAML_CrossProviderEmailTakeoverRejected(t *testing.T) {
 	stub := &stubSAML{info: &samlpkg.AssertionInfo{Subject: "corp|evil", Email: "admin@x.io", Name: "Mallory"}}
 	c, store := samlTestCore(stub) // provider "corp", AutoProvision: true
+	// This test exercises the cross-provider gate WITHIN the email-fallback path,
+	// which is itself opt-in (TrustEmailForLinking, #89) — enable it here so the
+	// fallback is reached at all, matching an operator who has decided to trust
+	// this provider's asserted email for account linking.
+	c.ssoProviders["corp"].TrustEmailForLinking = true
 	store.On("ConsumeSSOLoginState", mock.Anything, "relay-5").Return(
 		&models.SSOLoginState{Provider: "corp", Nonce: "req-1", ExpiresAt: time.Now().Add(time.Minute)}, nil)
 	// No account under corp's scoped id...
@@ -160,5 +165,36 @@ func TestCompleteSAML_CrossProviderEmailTakeoverRejected(t *testing.T) {
 	assert.Nil(t, session)
 	assert.Nil(t, user)
 	// The takeover must never reach session creation.
+	store.AssertNotCalled(t, "CreateSession", mock.Anything, mock.Anything)
+}
+
+// TestCompleteSAML_NativeAdminTakeoverRejectedByDefault pins the #89 residual gap:
+// even after cross-provider scoping, a SAML assertion could still hijack an
+// existing NATIVE (password-based) admin account — whose external_id is empty,
+// not bound to any provider — merely by asserting its email. SAML has no
+// verified-email concept at all, so this is reachable with no admin-console
+// access: a low-trust/self-service IdP the org configured for JIT SSO just has to
+// assert the victim's address. Without TrustEmailForLinking opted in (the
+// default), the email fallback must not run at all — the login is refused
+// outright (AutoProvision is off here), not silently linked to the native admin.
+func TestCompleteSAML_NativeAdminTakeoverRejectedByDefault(t *testing.T) {
+	stub := &stubSAML{info: &samlpkg.AssertionInfo{Subject: "corp|evil", Email: "admin@company.com", Name: "Mallory"}}
+	c, store := samlTestCore(stub) // provider "corp", TrustEmailForLinking defaults false
+	require.False(t, c.ssoProviders["corp"].TrustEmailForLinking, "precondition: opt-in is off by default")
+	c.ssoProviders["corp"].AutoProvision = false
+	store.On("ConsumeSSOLoginState", mock.Anything, "relay-6").Return(
+		&models.SSOLoginState{Provider: "corp", Nonce: "req-1", ExpiresAt: time.Now().Add(time.Minute)}, nil)
+	store.On("GetUserByExternalID", mock.Anything, "sso:corp:corp|evil").Return((*models.User)(nil), userNotFound())
+
+	session, user, _, err := c.CompleteSAML(context.Background(), "corp",
+		httptest.NewRequest(http.MethodPost, "/auth/saml/corp/acs", nil), "relay-6", "ua", "1.2.3.4")
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "no Keyorix account")
+	assert.Nil(t, session)
+	assert.Nil(t, user)
+	// The native admin's email must never even be looked up — the takeover surface
+	// this closes is that such a lookup existed at all with no independent trust
+	// signal on the asserted email.
+	store.AssertNotCalled(t, "GetUserByEmail", mock.Anything, mock.Anything)
 	store.AssertNotCalled(t, "CreateSession", mock.Anything, mock.Anything)
 }

--- a/internal/core/sso.go
+++ b/internal/core/sso.go
@@ -69,6 +69,20 @@ type SSOProvider struct {
 	AutoProvision bool   // JIT-create an account on first login for an unknown identity
 	DefaultRole   string // baseline role for JIT-provisioned users ("" → system_viewer)
 
+	// TrustEmailForLinking opts this provider into resolveSSOUser's email-fallback
+	// match against a PRE-EXISTING account with no scoped external_id for this
+	// provider yet — including a native/password-based account. Off by default
+	// (fail closed): neither SAML (no verified-email concept at all) nor a
+	// same-provider-scoping fix alone stops a self-service/low-trust IdP from
+	// asserting an arbitrary victim email on first login, so without this flag a
+	// first-time identity that doesn't match a scoped external_id is treated as
+	// unknown (refused, or JIT-provisioned as a NEW account) rather than silently
+	// linked to whichever existing account happens to share that email. Enable
+	// only for a provider whose asserted email you actually trust (e.g. a
+	// corporate IdP you control, or one that reliably sends OIDC
+	// email_verified=true).
+	TrustEmailForLinking bool
+
 	GroupSync   bool   // reconcile native group memberships from the IdP groups claim on login
 	GroupsClaim string // id_token claim carrying group names ("" → "groups")
 
@@ -167,7 +181,7 @@ func (c *KeyorixCore) CompleteSSO(ctx context.Context, providerName, code, state
 		return nil, nil, "", err
 	}
 
-	user, err := c.resolveSSOUser(ctx, p.Name, sub, email)
+	user, err := c.resolveSSOUser(ctx, p, sub, email)
 	if err != nil {
 		return nil, nil, "", err
 	}
@@ -280,7 +294,7 @@ func (c *KeyorixCore) CompleteSAML(ctx context.Context, name string, r *http.Req
 		return nil, nil, "", fmt.Errorf("the assertion carried no subject or email")
 	}
 
-	user, err := c.resolveSSOUser(ctx, p.Name, info.Subject, info.Email)
+	user, err := c.resolveSSOUser(ctx, p, info.Subject, info.Email)
 	if err != nil {
 		return nil, nil, "", err
 	}
@@ -341,24 +355,31 @@ func ssoBoundToOtherProvider(externalID, provider string) bool {
 		!strings.HasPrefix(externalID, ssoExternalID(provider, ""))
 }
 
-// resolveSSOUser maps a verified IdP identity from `provider` to a Keyorix user. It
-// matches this provider's own scoped external_id first, then falls back to email so a
-// pre-existing local or SCIM account can be linked on first SSO login. The email
-// fallback is GATED: it refuses to cross an existing binding to a DIFFERENT provider,
-// so IdP B cannot take over IdP A's account merely by asserting its email address.
-// Returns (nil, nil) when nothing matches — the caller refuses or JIT-provisions.
-func (c *KeyorixCore) resolveSSOUser(ctx context.Context, provider, sub, email string) (*models.User, error) {
+// resolveSSOUser maps a verified IdP identity from provider p to a Keyorix user. It
+// matches this provider's own scoped external_id first, then — only when p opts in
+// via TrustEmailForLinking — falls back to email so a pre-existing local or SCIM
+// account can be linked on first SSO login. Without that opt-in (the default), a
+// first-time identity that matches no scoped external_id is treated as unknown: the
+// email-linking fallback is skipped entirely, closing the residual takeover risk
+// that provider-scoping alone doesn't — SAML has no verified-email concept, and an
+// OIDC id_token can simply omit email_verified, so an untrusted IdP could otherwise
+// still hijack an existing NATIVE (password-based) account, whose external_id is
+// unscoped, by asserting its email. When the opt-in IS set, the fallback remains
+// GATED against crossing an existing binding to a DIFFERENT provider (so IdP B still
+// can't take over IdP A's account). Returns (nil, nil) when nothing matches — the
+// caller refuses or JIT-provisions.
+func (c *KeyorixCore) resolveSSOUser(ctx context.Context, p *SSOProvider, sub, email string) (*models.User, error) {
 	notFound := i18n.T("ErrorUserNotFound", nil)
 	if sub != "" {
-		if u, err := c.storage.GetUserByExternalID(ctx, ssoExternalID(provider, sub)); err == nil {
+		if u, err := c.storage.GetUserByExternalID(ctx, ssoExternalID(p.Name, sub)); err == nil {
 			return u, nil
 		} else if !strings.Contains(err.Error(), notFound) {
 			return nil, err
 		}
 	}
-	if email != "" {
+	if email != "" && p.TrustEmailForLinking {
 		if u, err := c.storage.GetUserByEmail(ctx, email); err == nil {
-			if ssoBoundToOtherProvider(u.ExternalID, provider) {
+			if ssoBoundToOtherProvider(u.ExternalID, p.Name) {
 				return nil, fmt.Errorf("the email %q is already linked to a different SSO provider", email)
 			}
 			return u, nil
@@ -385,7 +406,7 @@ func (c *KeyorixCore) provisionSSOUser(ctx context.Context, p *SSOProvider, sub,
 	// Guard against a race / case where a user materialised between the resolve and
 	// here: reuse it rather than create a duplicate. Re-run the SAME gated resolution so
 	// the race path cannot bypass the cross-provider check.
-	if existing, ferr := c.resolveSSOUser(ctx, p.Name, sub, email); ferr != nil {
+	if existing, ferr := c.resolveSSOUser(ctx, p, sub, email); ferr != nil {
 		return nil, ferr
 	} else if existing != nil {
 		return existing, nil

--- a/internal/core/sso_test.go
+++ b/internal/core/sso_test.go
@@ -134,53 +134,73 @@ func TestResolveSSOUser(t *testing.T) {
 	notFound := func() error { return fmt.Errorf("%s", i18n.T("ErrorUserNotFound", nil)) }
 
 	t.Run("externalId match wins", func(t *testing.T) {
-		c, store, _, _ := ssoTestCore(t)
+		c, store, _, p := ssoTestCore(t)
 		// The subject is looked up under this provider's scoped external_id.
 		store.On("GetUserByExternalID", mock.Anything, "sso:okta:okta|123").Return(&models.User{ID: 7}, nil)
-		u, err := c.resolveSSOUser(context.Background(), "okta", "okta|123", "ada@x.io")
+		u, err := c.resolveSSOUser(context.Background(), p, "okta|123", "ada@x.io")
 		require.NoError(t, err)
 		assert.Equal(t, uint(7), u.ID)
 		store.AssertNotCalled(t, "GetUserByEmail", mock.Anything, mock.Anything)
 	})
 
-	t.Run("falls back to email for an unbound account", func(t *testing.T) {
-		c, store, _, _ := ssoTestCore(t)
+	// #89 residual gap: without the opt-in, an unmatched identity must NOT fall
+	// back to email at all — neither for a native/password-based account nor any
+	// other unbound one. SAML has no verified-email concept and an OIDC id_token
+	// can simply omit email_verified, so trusting an asserted email by default
+	// would let an untrusted/self-service IdP hijack an existing account (up to
+	// and including a native admin) merely by asserting its address.
+	t.Run("email fallback disabled by default — no linking, no lookup at all", func(t *testing.T) {
+		c, store, _, p := ssoTestCore(t)
+		require.False(t, p.TrustEmailForLinking, "default must be off (fail closed)")
+		store.On("GetUserByExternalID", mock.Anything, "sso:okta:okta|123").Return((*models.User)(nil), notFound())
+		u, err := c.resolveSSOUser(context.Background(), p, "okta|123", "ada@x.io")
+		require.NoError(t, err)
+		assert.Nil(t, u, "an unmatched identity must be treated as unknown, not linked by email")
+		store.AssertNotCalled(t, "GetUserByEmail", mock.Anything, mock.Anything)
+	})
+
+	t.Run("email fallback (opt-in) links an unbound account", func(t *testing.T) {
+		c, store, _, p := ssoTestCore(t)
+		p.TrustEmailForLinking = true
 		store.On("GetUserByExternalID", mock.Anything, "sso:okta:okta|123").Return((*models.User)(nil), notFound())
 		// Unbound (empty external_id) local/SCIM account links by email.
 		store.On("GetUserByEmail", mock.Anything, "ada@x.io").Return(&models.User{ID: 9}, nil)
-		u, err := c.resolveSSOUser(context.Background(), "okta", "okta|123", "ada@x.io")
+		u, err := c.resolveSSOUser(context.Background(), p, "okta|123", "ada@x.io")
 		require.NoError(t, err)
 		assert.Equal(t, uint(9), u.ID)
 	})
 
-	t.Run("email fallback refuses an account bound to a different provider", func(t *testing.T) {
-		c, store, _, _ := ssoTestCore(t)
+	t.Run("email fallback (opt-in) refuses an account bound to a different provider", func(t *testing.T) {
+		c, store, _, p := ssoTestCore(t)
+		p.TrustEmailForLinking = true
 		store.On("GetUserByExternalID", mock.Anything, "sso:okta:okta|123").Return((*models.User)(nil), notFound())
 		// This email belongs to an account already bound to IdP "azure". The "okta"
 		// assertion must NOT be able to claim it — that is the takeover this guards.
 		store.On("GetUserByEmail", mock.Anything, "ada@x.io").
 			Return(&models.User{ID: 99, ExternalID: "sso:azure:abc"}, nil)
-		u, err := c.resolveSSOUser(context.Background(), "okta", "okta|123", "ada@x.io")
+		u, err := c.resolveSSOUser(context.Background(), p, "okta|123", "ada@x.io")
 		require.Error(t, err)
 		assert.ErrorContains(t, err, "different SSO provider")
 		assert.Nil(t, u)
 	})
 
-	t.Run("email fallback allows an account bound to the SAME provider", func(t *testing.T) {
-		c, store, _, _ := ssoTestCore(t)
+	t.Run("email fallback (opt-in) allows an account bound to the SAME provider", func(t *testing.T) {
+		c, store, _, p := ssoTestCore(t)
+		p.TrustEmailForLinking = true
 		store.On("GetUserByExternalID", mock.Anything, "sso:okta:okta|123").Return((*models.User)(nil), notFound())
 		store.On("GetUserByEmail", mock.Anything, "ada@x.io").
 			Return(&models.User{ID: 11, ExternalID: "sso:okta:other-sub"}, nil)
-		u, err := c.resolveSSOUser(context.Background(), "okta", "okta|123", "ada@x.io")
+		u, err := c.resolveSSOUser(context.Background(), p, "okta|123", "ada@x.io")
 		require.NoError(t, err)
 		assert.Equal(t, uint(11), u.ID)
 	})
 
-	t.Run("no match returns nil (caller decides)", func(t *testing.T) {
-		c, store, _, _ := ssoTestCore(t)
+	t.Run("no match returns nil (opt-in enabled, caller decides)", func(t *testing.T) {
+		c, store, _, p := ssoTestCore(t)
+		p.TrustEmailForLinking = true
 		store.On("GetUserByExternalID", mock.Anything, "sso:okta:okta|123").Return((*models.User)(nil), notFound())
 		store.On("GetUserByEmail", mock.Anything, "ada@x.io").Return((*models.User)(nil), notFound())
-		u, err := c.resolveSSOUser(context.Background(), "okta", "okta|123", "ada@x.io")
+		u, err := c.resolveSSOUser(context.Background(), p, "okta|123", "ada@x.io")
 		require.NoError(t, err)
 		assert.Nil(t, u)
 	})

--- a/server/main.go
+++ b/server/main.go
@@ -1339,7 +1339,8 @@ func buildSSOProviders(sso config.SSOConfig) (map[string]*core.SSOProvider, core
 			providers[pc.Name] = &core.SSOProvider{
 				Name: pc.Name, Type: "saml", SAML: sp, CompleteURL: completeURL,
 				AutoProvision: pc.AutoProvision, DefaultRole: pc.DefaultRole,
-				GroupSync: pc.GroupSync, GroupRoleMap: pc.GroupRoleMap,
+				TrustEmailForLinking: pc.TrustEmailForLinking,
+				GroupSync:            pc.GroupSync, GroupRoleMap: pc.GroupRoleMap,
 			}
 			continue
 		}
@@ -1372,12 +1373,13 @@ func buildSSOProviders(sso config.SSOConfig) (map[string]*core.SSOProvider, core
 				RedirectURL:  pc.RedirectURL,
 				Scopes:       scopes,
 			},
-			CompleteURL:   completeURL,
-			AutoProvision: pc.AutoProvision,
-			DefaultRole:   pc.DefaultRole,
-			GroupSync:     pc.GroupSync,
-			GroupsClaim:   pc.GroupsClaim,
-			GroupRoleMap:  pc.GroupRoleMap,
+			CompleteURL:          completeURL,
+			AutoProvision:        pc.AutoProvision,
+			DefaultRole:          pc.DefaultRole,
+			TrustEmailForLinking: pc.TrustEmailForLinking,
+			GroupSync:            pc.GroupSync,
+			GroupsClaim:          pc.GroupsClaim,
+			GroupRoleMap:         pc.GroupRoleMap,
 		}
 		jwksURIs[pc.Issuer] = disc.JWKSURI
 	}


### PR DESCRIPTION
## Summary
Stacked on **#517** — targets that branch, not `main`, since it hasn't merged yet and this fix builds directly on its provider-scoping work.

Re-verifying #89 after #517: PR #517 scoped SSO identities to the asserting provider, closing cross-provider takeover — but `resolveSSOUser`'s email fallback still matched **any** account with no scoped `external_id`, including a NATIVE (password-based) one. SAML has no verified-email concept at all, and an OIDC id_token can simply omit `email_verified`, so an untrusted/self-service IdP configured for JIT SSO could still hijack an existing native admin account merely by asserting its email — confirmed via a new regression test (`TestCompleteSAML_NativeAdminTakeoverRejectedByDefault`) that reproduces the exact scenario against #517's code as it stands today.

- Adds `SSOProvider.TrustEmailForLinking` (config: `trust_email_for_linking` on an SSO provider), **off by default**.
- Without it, a first-login identity that doesn't match a scoped `external_id` is treated as unknown — refused, or JIT-provisioned as a NEW account — rather than silently linked to whichever existing account happens to share that email.
- The cross-provider gate (#517) still applies whenever the opt-in IS set and multiple providers are configured.
- Operators enable it only for a provider whose asserted email they actually trust (e.g. a corporate IdP they control, or one that reliably sends `email_verified=true`).

From the durable hardening backlog (`docs/security/HARDENING-BACKLOG.md`, finding #89).

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/core/... ./server/... ./internal/storage/... ./internal/cli/... ./internal/config/...` — all pass
- [x] `GOWORK=off go build -C operator ./...` — operator module unaffected, builds clean
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues
- [x] New regression test `TestCompleteSAML_NativeAdminTakeoverRejectedByDefault` — a SAML assertion self-asserting a native admin's email is refused by default, with `GetUserByEmail` never even called
- [x] Existing `TestResolveSSOUser`/`TestCompleteSAML_CrossProviderEmailTakeoverRejected` updated: email-fallback-dependent cases now explicitly opt in (`TrustEmailForLinking = true`) to keep exercising that behavior, plus a new default-off case