### PR TITLE
fix(sso): gate SAML email-fallback linking behind a per-provider opt-in (#89)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -978,6 +978,14 @@ type SSOProviderConfig struct {
 	// (default "system_viewer"). A misconfigured/unknown role grants nothing —
 	// least-privilege on misconfiguration.
 	DefaultRole string `yaml:"default_role"`
+	// TrustAssertedEmail opts a SAML provider (type: saml) into treating its
+	// asserted email as verified for account-linking. SAML has no per-assertion
+	// verified-email signal — the assertion being IdP-signed proves the IdP sent
+	// it, not that the IdP verified the user owns it. Opt-in (default off):
+	// without it, a SAML login can still JIT-provision a NEW account but cannot
+	// claim an EXISTING one by asserting its email. Ignored for OIDC providers
+	// (whose email_verified claim is checked per-login instead).
+	TrustAssertedEmail bool `yaml:"trust_asserted_email"`
 
 	// GroupSync reconciles the user's NATIVE group memberships from the IdP's groups
 	// claim on each login (the IdP becomes the source of truth — membership is added

--- a/internal/core/saml_flow_test.go
+++ b/internal/core/saml_flow_test.go
@@ -136,3 +136,60 @@ func TestCompleteSAML_NoAccountNoProvision(t *testing.T) {
 		httptest.NewRequest(http.MethodPost, "/", nil), "relay-4", "", "")
 	require.ErrorContains(t, err, "no Keyorix account")
 }
+
+// TestCompleteSAML_NativeAdminTakeoverRejectedByDefault pins #89: SAML has no
+// per-assertion equivalent of OIDC's email_verified claim — the assertion being
+// IdP-signed only proves the IdP sent it, not that the IdP verified the user OWNS
+// that address. CompleteSAML previously passed emailVerified=true unconditionally,
+// so a self-service/low-trust SAML IdP could hijack an EXISTING native (password-
+// based) admin account merely by asserting its email. Without the provider opting
+// in via TrustAssertedEmail (off by default), the email fallback must not even
+// query for a match — the login is refused outright (AutoProvision off here).
+func TestCompleteSAML_NativeAdminTakeoverRejectedByDefault(t *testing.T) {
+	stub := &stubSAML{info: &samlpkg.AssertionInfo{Subject: "corp|evil", Email: "admin@company.com", Name: "Mallory"}}
+	store := new(MockStorage)
+	p := &SSOProvider{Name: "corp", Type: "saml", SAML: stub, AutoProvision: false}
+	require.False(t, p.TrustAssertedEmail, "precondition: opt-in is off by default")
+	c := &KeyorixCore{storage: store, now: time.Now, ssoProviders: map[string]*SSOProvider{"corp": p}}
+	store.On("ConsumeSSOLoginState", mock.Anything, "relay-5").Return(
+		&models.SSOLoginState{Provider: "corp", Nonce: "req-1", ExpiresAt: time.Now().Add(time.Minute)}, nil)
+	store.On("GetUserByExternalID", mock.Anything, "corp|evil").Return((*models.User)(nil), userNotFound())
+
+	session, user, _, err := c.CompleteSAML(context.Background(), "corp",
+		httptest.NewRequest(http.MethodPost, "/auth/saml/corp/acs", nil), "relay-5", "ua", "1.2.3.4")
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "no Keyorix account")
+	assert.Nil(t, session)
+	assert.Nil(t, user)
+	// The native admin's email must never even be looked up.
+	store.AssertNotCalled(t, "GetUserByEmail", mock.Anything, mock.Anything)
+	store.AssertNotCalled(t, "CreateSession", mock.Anything, mock.Anything)
+}
+
+// TestCompleteSAML_TrustAssertedEmailOptInLinksExistingAccount is the positive
+// control: an operator who has decided to trust a specific SAML provider's
+// asserted email can still opt in, and the existing (never-federated) account
+// linking behavior works exactly as it does for a verified OIDC email.
+func TestCompleteSAML_TrustAssertedEmailOptInLinksExistingAccount(t *testing.T) {
+	stub := &stubSAML{info: &samlpkg.AssertionInfo{Subject: "corp|123", Email: "ada@x.io", Name: "Ada"}}
+	store := new(MockStorage)
+	p := &SSOProvider{Name: "corp", Type: "saml", SAML: stub, AutoProvision: true, TrustAssertedEmail: true}
+	c := &KeyorixCore{storage: store, now: time.Now, ssoProviders: map[string]*SSOProvider{"corp": p}}
+	store.On("ConsumeSSOLoginState", mock.Anything, "relay-7").Return(
+		&models.SSOLoginState{Provider: "corp", Nonce: "req-1", ExpiresAt: time.Now().Add(time.Minute)}, nil)
+	store.On("GetUserByExternalID", mock.Anything, "corp|123").Return((*models.User)(nil), userNotFound())
+	store.On("GetUserByEmail", mock.Anything, "ada@x.io").Return(&models.User{ID: 9, ExternalID: ""}, nil)
+	store.On("UpdateUser", mock.Anything, mock.MatchedBy(func(u *models.User) bool {
+		return u.ID == 9 && u.ExternalID == "corp|123"
+	})).Return(&models.User{ID: 9, ExternalID: "corp|123"}, nil)
+	store.On("CreateSession", mock.Anything, mock.Anything).Return(&models.Session{ID: 1, UserID: 9, SessionToken: "tok"}, nil)
+	store.On("UpdateLastLogin", mock.Anything, uint(9), mock.Anything).Return(nil)
+	store.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
+
+	session, user, _, err := c.CompleteSAML(context.Background(), "corp",
+		httptest.NewRequest(http.MethodPost, "/auth/saml/corp/acs", nil), "relay-7", "ua", "1.2.3.4")
+	require.NoError(t, err)
+	require.NotNil(t, user)
+	assert.Equal(t, uint(9), user.ID)
+	assert.Equal(t, "tok", session.SessionToken)
+}

--- a/internal/core/sso.go
+++ b/internal/core/sso.go
@@ -68,6 +68,17 @@ type SSOProvider struct {
 	AutoProvision bool   // JIT-create an account on first login for an unknown identity
 	DefaultRole   string // baseline role for JIT-provisioned users ("" → system_viewer)
 
+	// TrustAssertedEmail opts a SAML provider into treating its asserted email as
+	// verified for resolveSSOUser's email-fallback account linking. SAML carries no
+	// per-assertion equivalent of OIDC's email_verified claim — the assertion being
+	// IdP-signed only proves the IdP sent it, not that the IdP itself verified
+	// ownership of that address (a self-service/low-trust IdP could let a user set
+	// any email). Off by default: without it, CompleteSAML's email fallback can
+	// still seed a brand-new JIT account (nothing to take over) but cannot claim an
+	// EXISTING one — closing a SAML-specific account-takeover path (#89) that
+	// OIDC's real email_verified claim already closes. Ignored for OIDC providers.
+	TrustAssertedEmail bool
+
 	GroupSync   bool   // reconcile native group memberships from the IdP groups claim on login
 	GroupsClaim string // id_token claim carrying group names ("" → "groups")
 
@@ -279,9 +290,13 @@ func (c *KeyorixCore) CompleteSAML(ctx context.Context, name string, r *http.Req
 		return nil, nil, "", fmt.Errorf("the assertion carried no subject or email")
 	}
 
-	// A SAML assertion's attributes (incl. email) are carried inside the IdP-signed,
-	// library-verified assertion, so the email is treated as verified here.
-	user, err := c.resolveSSOUser(ctx, info.Subject, info.Email, true)
+	// The assertion being IdP-signed proves the IdP sent this email, not that the
+	// IdP verified the user OWNS it — SAML has no per-assertion equivalent of
+	// OIDC's email_verified claim. Trusting it unconditionally let a self-service/
+	// low-trust SAML IdP claim an EXISTING account (up to a native admin) merely
+	// by asserting its address (#89). Gate on the provider's explicit opt-in
+	// instead; see SSOProvider.TrustAssertedEmail.
+	user, err := c.resolveSSOUser(ctx, info.Subject, info.Email, p.TrustAssertedEmail)
 	if err != nil {
 		return nil, nil, "", err
 	}

--- a/server/main.go
+++ b/server/main.go
@@ -1542,7 +1542,8 @@ func buildSSOProviders(sso config.SSOConfig) (map[string]*core.SSOProvider, core
 			providers[pc.Name] = &core.SSOProvider{
 				Name: pc.Name, Type: "saml", SAML: sp, CompleteURL: completeURL,
 				AutoProvision: pc.AutoProvision, DefaultRole: pc.DefaultRole,
-				GroupSync: pc.GroupSync, GroupRoleMap: pc.GroupRoleMap,
+				TrustAssertedEmail: pc.TrustAssertedEmail,
+				GroupSync:          pc.GroupSync, GroupRoleMap: pc.GroupRoleMap,
 			}
 			continue
 		}


### PR DESCRIPTION
## Summary

Re-verifies and correctly fixes #89 against `main`'s actual, current SSO mechanism (PR #518, already merged) — supersedes the approach in PR #528, which was built against a stale/divergent branch (#517) that predates #518's merge and duplicates work already shipped there.

- `CompleteSAML` passed `emailVerified=true` unconditionally into `resolveSSOUser`, defeating the `emailVerified`-gated email-fallback protection that `resolveSSOUser` already correctly enforces for OIDC (derived from the real `email_verified` id_token claim).
- SAML has no per-assertion equivalent of `email_verified` — an assertion being IdP-signed proves the IdP sent it, not that the IdP verified the user owns that address. A self-service/low-trust SAML IdP could hijack an **existing account** (including a native, password-based admin) merely by asserting its email.
- Adds `SSOProvider.TrustAssertedEmail` (config: `trust_asserted_email`), an explicit per-provider opt-in mirroring the existing `AutoProvision`/`GroupSync` pattern — **off by default**. With it off, a SAML login can still JIT-provision a brand-new account (nothing to take over) but cannot claim an existing one.
- OIDC providers are unaffected — their `emailVerified` is already derived per-login from the real claim.

## Test plan
- [x] New regression test `TestCompleteSAML_NativeAdminTakeoverRejectedByDefault`: a SAML login asserting a native admin's email is refused outright by default; `GetUserByEmail`/`CreateSession` are never even called.
- [x] New regression test `TestCompleteSAML_TrustAssertedEmailOptInLinksExistingAccount`: opting a provider in restores the existing-account linking behavior already verified for OIDC.
- [x] Full existing SSO/SAML suite passes unchanged (`go test ./internal/core/... -run "SSO|SAML"`).
- [x] `go build ./...`
- [x] `go test ./internal/... ./server/...` — all green.
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues.
- [x] `GOWORK=off go build -C operator ./...` — operator module unaffected, builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)