### PR TITLE
harden(secrets): lifecycle audit/value-egress bundle — #126, #132, #133

### DIFF
--- a/internal/audit/siem/spool.go
+++ b/internal/audit/siem/spool.go
@@ -45,6 +45,13 @@ type spool struct {
 	mu   sync.Mutex // serializes file mutation (append + replay rewrite); NOT held across delivery
 	stop chan struct{}
 	done chan struct{}
+
+	// replayMu serializes the whole replay() call end-to-end (distinct from mu,
+	// which is deliberately released across delivery). Without it, the loop's
+	// immediate on-start replay() and a concurrently-fired ticker/manual replay()
+	// could both read the same undelivered snapshot before either finishes its
+	// reconcile-and-rewrite, double-delivering every event still in the backlog.
+	replayMu sync.Mutex
 }
 
 // newSpool prepares the spool directory and starts the replay loop.
@@ -124,6 +131,8 @@ func (s *spool) loop() {
 // on the audited request path) never blocks behind a SIEM round-trip. Crash-safe: every
 // undelivered line stays on disk until the atomic rewrite at the end.
 func (s *spool) replay() {
+	s.replayMu.Lock()
+	defer s.replayMu.Unlock()
 	// Snapshot under the lock, recording the byte length we read; any add() during the
 	// lock-free delivery below only appends BEYOND this offset (add never rewrites), so the
 	// reconcile can cleanly separate "what we attempted" from "what arrived meanwhile".

--- a/internal/core/max_reads_enforce_test.go
+++ b/internal/core/max_reads_enforce_test.go
@@ -23,7 +23,7 @@ func newMaxReadsCore(t *testing.T) (*KeyorixCore, *gorm.DB) {
 	require.NoError(t, err)
 	sqlDB, _ := db.DB()
 	sqlDB.SetMaxOpenConns(1) // sqlite: serialize connections (statements stay atomic)
-	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}))
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.AuditEvent{}))
 	return &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}, db
 }
 
@@ -104,5 +104,37 @@ func TestMaxReads_ByVersionStopsAtCap(t *testing.T) {
 	}
 	_, err := c.GetSecretValueByVersion(ctx, id, 1)
 	require.Error(t, err, "the 3rd by-version read must be denied")
+	assert.Contains(t, err.Error(), i18n.T("ErrorMaxReadsExceeded", nil))
+}
+
+// TestMaxReads_SurvivesRotateAndRollback pins #133: the max-reads counter used
+// to be keyed on the VERSION, which starts at zero for every new version — so a
+// burn-after-N-read secret became re-readable simply by rotating (or rolling
+// back, which also creates a new version) it, resetting the budget. The cap
+// must be enforced against the secret's lifetime read count, surviving both.
+func TestMaxReads_SurvivesRotateAndRollback(t *testing.T) {
+	c, _ := newMaxReadsCore(t)
+	id := seedMaxReadsSecret(t, c, 1)
+	ctx := context.Background()
+
+	// Burn the one allowed read.
+	_, err := c.GetSecretValue(ctx, id)
+	require.NoError(t, err)
+	_, err = c.GetSecretValue(ctx, id)
+	require.Error(t, err, "the budget is exhausted")
+
+	// Rotating creates a brand-new version (read_count reset to 0 on THAT row) —
+	// the secret-level counter must still refuse the next read.
+	_, err = c.RotateSecret(ctx, id, []byte("v2"), "actor")
+	require.NoError(t, err)
+	_, err = c.GetSecretValue(ctx, id)
+	require.Error(t, err, "rotating must not grant a fresh read budget")
+	assert.Contains(t, err.Error(), i18n.T("ErrorMaxReadsExceeded", nil))
+
+	// Rolling back to version 1 also creates a new version — same requirement.
+	_, err = c.RollbackSecret(ctx, id, 1, 1, "actor")
+	require.NoError(t, err)
+	_, err = c.GetSecretValue(ctx, id)
+	require.Error(t, err, "rolling back must not grant a fresh read budget either")
 	assert.Contains(t, err.Error(), i18n.T("ErrorMaxReadsExceeded", nil))
 }

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -561,6 +561,11 @@ func (m *MockStorage) TryIncrementSecretReadCount(ctx context.Context, versionID
 	return args.Bool(0), args.Error(1)
 }
 
+func (m *MockStorage) TryIncrementSecretNodeReadCount(ctx context.Context, secretID uint, maxReads int) (bool, error) {
+	args := m.Called(ctx, secretID, maxReads)
+	return args.Bool(0), args.Error(1)
+}
+
 // Secret Sharing Management
 
 func (m *MockStorage) CreateShareRecord(ctx context.Context, share *models.ShareRecord) (*models.ShareRecord, error) {

--- a/internal/core/secret_copy.go
+++ b/internal/core/secret_copy.go
@@ -20,7 +20,13 @@ import (
 // when empty. The actor must be able to read the source (enforced here) and — checked
 // by the transport — to create in the target environment. The target environment must
 // belong to the same project as the source.
-func (c *KeyorixCore) CopySecret(ctx context.Context, sourceID, targetEnvID uint, newName, actorUsername string, actorID uint) (*models.SecretNode, error) {
+//
+// Decrypting the source and writing a new secret are audited explicitly (secret.read
+// + secret.created, #126): CreateSecret alone leaves no trace that a copy also read
+// the source value, and GetSecretValueWithPermissionCheck's max-reads accounting is
+// not an audit event — without this, a copy was a covert exfil channel invisible to
+// the anomaly detector (which keys off SecretAccessLog rows the Log* helpers write).
+func (c *KeyorixCore) CopySecret(ctx context.Context, sourceID, targetEnvID uint, newName, actorUsername string, actorID uint, ip, ua string) (*models.SecretNode, error) {
 	if sourceID == 0 || targetEnvID == 0 {
 		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "source secret ID and target environment ID are required")
 	}
@@ -45,6 +51,7 @@ func (c *KeyorixCore) CopySecret(ctx context.Context, sourceID, targetEnvID uint
 	if err != nil {
 		return nil, err
 	}
+	c.LogSecretReadWithProject(ctx, actorID, source.ID, source.ProjectID, actorUsername, source.Name, ip, ua)
 
 	name := strings.TrimSpace(newName)
 	if name == "" {
@@ -53,7 +60,7 @@ func (c *KeyorixCore) CopySecret(ctx context.Context, sourceID, targetEnvID uint
 
 	// CreateSecret re-validates the value policy, the env↔project link, and name
 	// uniqueness within the target environment.
-	return c.CreateSecret(ctx, &CreateSecretRequest{
+	created, err := c.CreateSecret(ctx, &CreateSecretRequest{
 		Name:           name,
 		Value:          value,
 		ProjectID:      source.ProjectID,
@@ -64,4 +71,9 @@ func (c *KeyorixCore) CopySecret(ctx context.Context, sourceID, targetEnvID uint
 		CreatedBy:      actorUsername,
 		OwnerID:        actorID,
 	})
+	if err != nil {
+		return nil, err
+	}
+	c.LogSecretCreatedWithProject(ctx, actorID, created.ID, source.ProjectID, actorUsername, created.Name, ip, ua)
+	return created, nil
 }

--- a/internal/core/secret_copy_environment.go
+++ b/internal/core/secret_copy_environment.go
@@ -20,7 +20,7 @@ const copyEnvPageSize = 500
 // project), returning how many were copied and how many were skipped (a name already
 // present in the target, or a per-secret failure). The two environments must belong to
 // the same project.
-func (c *KeyorixCore) CopyEnvironmentSecrets(ctx context.Context, projectID, sourceEnvID, targetEnvID uint, actorUsername string, actorID uint) (copied, skipped int, err error) {
+func (c *KeyorixCore) CopyEnvironmentSecrets(ctx context.Context, projectID, sourceEnvID, targetEnvID uint, actorUsername string, actorID uint, ip, ua string) (copied, skipped int, err error) {
 	if projectID == 0 || sourceEnvID == 0 || targetEnvID == 0 {
 		return 0, 0, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "project, source and target environment IDs are required")
 	}
@@ -51,7 +51,7 @@ func (c *KeyorixCore) CopyEnvironmentSecrets(ctx context.Context, projectID, sou
 			return copied, skipped, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), lerr)
 		}
 		for _, s := range secrets {
-			if _, cerr := c.CopySecret(ctx, s.ID, targetEnvID, "", actorUsername, actorID); cerr != nil {
+			if _, cerr := c.CopySecret(ctx, s.ID, targetEnvID, "", actorUsername, actorID, ip, ua); cerr != nil {
 				// A name that already exists in the target is the common case — skip it
 				// (never clobber); other per-secret failures are skipped too, best-effort.
 				skipped++

--- a/internal/core/secret_copy_environment_test.go
+++ b/internal/core/secret_copy_environment_test.go
@@ -41,7 +41,7 @@ func TestCopyEnvironmentSecrets(t *testing.T) {
 	mk(prod.ID, "db") // pre-existing in target → name clash, should be skipped
 
 	t.Run("copies new secrets, skips name clashes", func(t *testing.T) {
-		copied, skipped, err := c.CopyEnvironmentSecrets(ctx, p.ID, staging.ID, prod.ID, "owner", 1)
+		copied, skipped, err := c.CopyEnvironmentSecrets(ctx, p.ID, staging.ID, prod.ID, "owner", 1, "", "")
 		require.NoError(t, err)
 		assert.Equal(t, 1, copied, "only 'api' is new in prod")
 		assert.Equal(t, 1, skipped, "'db' already exists in prod")
@@ -57,17 +57,17 @@ func TestCopyEnvironmentSecrets(t *testing.T) {
 	})
 
 	t.Run("a cross-project target is rejected", func(t *testing.T) {
-		_, _, err := c.CopyEnvironmentSecrets(ctx, p.ID, staging.ID, otherEnv.ID, "owner", 1)
+		_, _, err := c.CopyEnvironmentSecrets(ctx, p.ID, staging.ID, otherEnv.ID, "owner", 1, "", "")
 		require.Error(t, err)
 	})
 
 	t.Run("source == target is rejected", func(t *testing.T) {
-		_, _, err := c.CopyEnvironmentSecrets(ctx, p.ID, staging.ID, staging.ID, "owner", 1)
+		_, _, err := c.CopyEnvironmentSecrets(ctx, p.ID, staging.ID, staging.ID, "owner", 1, "", "")
 		require.Error(t, err)
 	})
 
 	t.Run("required IDs are validated", func(t *testing.T) {
-		_, _, err := c.CopyEnvironmentSecrets(ctx, 0, staging.ID, prod.ID, "owner", 1)
+		_, _, err := c.CopyEnvironmentSecrets(ctx, 0, staging.ID, prod.ID, "owner", 1, "", "")
 		require.Error(t, err)
 	})
 }

--- a/internal/core/secret_copy_test.go
+++ b/internal/core/secret_copy_test.go
@@ -20,7 +20,7 @@ func TestCopySecret(t *testing.T) {
 	require.NoError(t, err)
 	sqlDB, _ := db.DB()
 	sqlDB.SetMaxOpenConns(1)
-	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.User{}, &models.Project{}, &models.Environment{}, &models.AuditEvent{}))
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.User{}, &models.Project{}, &models.Environment{}, &models.AuditEvent{}, &models.SecretAccessLog{}))
 	require.NoError(t, db.Create(&models.User{ID: 1, Username: "owner", Email: "o@t.com"}).Error)
 
 	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
@@ -39,7 +39,7 @@ func TestCopySecret(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("copies value + metadata into the target environment", func(t *testing.T) {
-		copied, err := c.CopySecret(ctx, src.ID, prod.ID, "", "owner", 1)
+		copied, err := c.CopySecret(ctx, src.ID, prod.ID, "", "owner", 1, "", "")
 		require.NoError(t, err)
 		assert.NotEqual(t, src.ID, copied.ID, "a distinct new secret")
 		assert.Equal(t, "db-url", copied.Name)
@@ -55,27 +55,47 @@ func TestCopySecret(t *testing.T) {
 		assert.Equal(t, "postgres://secret", string(val))
 	})
 
+	// TestCopySecret/audits_both_the_source_read_and_the_destination_create pins
+	// #126: CopySecret decrypts the source and writes a new secret with no audit
+	// trail — a covert exfil channel invisible to the anomaly detector, which
+	// keys off SecretAccessLog rows. A copy must leave both a "read" row for the
+	// source and a "create" row for the destination.
+	t.Run("audits both the source read and the destination create", func(t *testing.T) {
+		copied, err := c.CopySecret(ctx, src.ID, prod.ID, "audit-check", "owner", 1, "", "")
+		require.NoError(t, err)
+
+		var readLog models.SecretAccessLog
+		require.NoError(t, db.Where("secret_node_id = ? AND action = ?", src.ID, "read").
+			Order("id DESC").First(&readLog).Error, "the source read must be audited")
+		assert.Equal(t, "owner", readLog.AccessedBy)
+
+		var createLog models.SecretAccessLog
+		require.NoError(t, db.Where("secret_node_id = ? AND action = ?", copied.ID, "create").
+			First(&createLog).Error, "the destination create must be audited")
+		assert.Equal(t, "owner", createLog.AccessedBy)
+	})
+
 	t.Run("a new name can be given", func(t *testing.T) {
-		copied, err := c.CopySecret(ctx, src.ID, prod.ID, "db-url-renamed", "owner", 1)
+		copied, err := c.CopySecret(ctx, src.ID, prod.ID, "db-url-renamed", "owner", 1, "", "")
 		require.NoError(t, err)
 		assert.Equal(t, "db-url-renamed", copied.Name)
 	})
 
 	t.Run("copying to an environment in another project is rejected", func(t *testing.T) {
-		_, err := c.CopySecret(ctx, src.ID, otherEnv.ID, "", "owner", 1)
+		_, err := c.CopySecret(ctx, src.ID, otherEnv.ID, "", "owner", 1, "", "")
 		require.Error(t, err)
 	})
 
 	t.Run("a duplicate name in the target environment is rejected", func(t *testing.T) {
 		// "db-url" already copied into prod above.
-		_, err := c.CopySecret(ctx, src.ID, prod.ID, "", "owner", 1)
+		_, err := c.CopySecret(ctx, src.ID, prod.ID, "", "owner", 1, "", "")
 		require.Error(t, err)
 	})
 
 	t.Run("required IDs are validated", func(t *testing.T) {
-		_, err := c.CopySecret(ctx, 0, prod.ID, "", "owner", 1)
+		_, err := c.CopySecret(ctx, 0, prod.ID, "", "owner", 1, "", "")
 		require.Error(t, err)
-		_, err = c.CopySecret(ctx, src.ID, 0, "", "owner", 1)
+		_, err = c.CopySecret(ctx, src.ID, 0, "", "owner", 1, "", "")
 		require.Error(t, err)
 	})
 }

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -235,6 +235,14 @@ type Storage interface {
 	// already reached (or the version is gone). This is the race-free gate for
 	// max-reads enforcement: concurrent reads can never collectively exceed the cap.
 	TryIncrementSecretReadCount(ctx context.Context, versionID uint, maxReads int) (bool, error)
+	// TryIncrementSecretNodeReadCount is TryIncrementSecretReadCount's secret-level
+	// twin (#133): keyed on the SECRET, not a version, so the count carries forward
+	// across rotate/rollback creating a new version — a per-version counter resets
+	// to zero on every new version, letting a burn-after-N-reads secret become
+	// re-readable simply by rolling back. This is the authoritative max-reads gate;
+	// TryIncrementSecretReadCount remains for the per-version read_count DISPLAY
+	// field only.
+	TryIncrementSecretNodeReadCount(ctx context.Context, secretID uint, maxReads int) (bool, error)
 
 	// Secret Sharing Management
 	CreateShareRecord(ctx context.Context, share *models.ShareRecord) (*models.ShareRecord, error)

--- a/internal/core/versions.go
+++ b/internal/core/versions.go
@@ -207,16 +207,24 @@ func (c *KeyorixCore) GetSecretValueByVersionWithPermissionCheck(ctx context.Con
 // Shared by GetSecretValue and GetSecretValueWithPermissionCheck.
 func (c *KeyorixCore) readVersionValue(ctx context.Context, secret *models.SecretNode, version *models.SecretVersion) ([]byte, error) {
 	if secret.MaxReads != nil && *secret.MaxReads > 0 {
-		// Atomic check-and-increment: the conditional UPDATE serializes concurrent
-		// reads on the row, so they can never collectively exceed the cap. Fail closed
-		// — if enforcement can't be confirmed, don't hand back the value.
-		ok, err := c.storage.TryIncrementSecretReadCount(ctx, version.ID, *secret.MaxReads)
+		// Atomic check-and-increment against the SECRET (not the version, #133): the
+		// conditional UPDATE serializes concurrent reads on the row, so they can never
+		// collectively exceed the cap, and the count carries forward across rotate/
+		// rollback creating a new version — a per-version counter would reset to zero
+		// on every new version, letting a burn-after-N-reads secret become re-readable
+		// simply by rolling back. Fail closed — if enforcement can't be confirmed,
+		// don't hand back the value.
+		ok, err := c.storage.TryIncrementSecretNodeReadCount(ctx, secret.ID, *secret.MaxReads)
 		if err != nil {
 			return nil, fmt.Errorf("max-reads enforcement failed: %w", err)
 		}
 		if !ok {
 			return nil, fmt.Errorf("%s", i18n.T("ErrorMaxReadsExceeded", nil))
 		}
+		// Best-effort per-version read_count (CLI/gRPC display only, not the
+		// enforcement mechanism above): a failure here must not block an already-
+		// authorized read.
+		_, _ = c.storage.TryIncrementSecretReadCount(ctx, version.ID, *secret.MaxReads)
 	}
 	if c.encryption != nil {
 		return c.encryption.RetrieveSecret(version.ID)

--- a/internal/rotation/mysql.go
+++ b/internal/rotation/mysql.go
@@ -87,7 +87,11 @@ func (e *MySQLExecutor) Rotate(ctx context.Context, ref, newValue string) error 
 	q := fmt.Sprintf("ALTER USER %s@%s IDENTIFIED BY %s",
 		quoteMySQLString(user), quoteMySQLString(host), quoteMySQLString(newValue))
 	if err := c.Exec(ctx, q); err != nil {
-		return fmt.Errorf("mysql: rotate account %q: %w", ref, err)
+		// The new password is a quoted literal in q; a driver error can echo the
+		// failing statement verbatim. Redact before wrapping so the live credential
+		// never egresses via the rotation-failure SIEM audit / notification
+		// broadcast (#132).
+		return redactSQLError("mysql", ref, err)
 	}
 	return nil
 }

--- a/internal/rotation/mysql_test.go
+++ b/internal/rotation/mysql_test.go
@@ -82,4 +82,13 @@ func TestMySQL_RotateErrors(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "access denied")
 	})
+	// #132: mirrors the postgres redaction test — a driver error echoing the
+	// failing statement must not leak the new password literal.
+	t.Run("backend error echoing the statement is redacted", func(t *testing.T) {
+		fake := &fakeMySQL{err: errors.New(`Error 1064: syntax error near 'S3cr3t-Live-Value!'`)}
+		err := myWith(fake, "app_").Rotate(context.Background(), "app_svc", "S3cr3t-Live-Value!")
+		require.Error(t, err)
+		assert.NotContains(t, err.Error(), "S3cr3t-Live-Value!", "the live credential must never appear in the returned error")
+		assert.Contains(t, err.Error(), "app_svc")
+	})
 }

--- a/internal/rotation/postgres.go
+++ b/internal/rotation/postgres.go
@@ -79,7 +79,11 @@ func (e *PostgresExecutor) Rotate(ctx context.Context, ref, newValue string) err
 	// can escape the statement.
 	sql := fmt.Sprintf("ALTER ROLE %s WITH PASSWORD %s", quoteIdentifier(ref), quoteLiteral(newValue))
 	if err := c.Exec(ctx, sql); err != nil {
-		return fmt.Errorf("postgresql: rotate role %q: %w", ref, err)
+		// The new password is a quoted literal in sql; a driver error can echo the
+		// failing statement (e.g. a syntax error near the literal) verbatim. Redact
+		// before wrapping so the live credential never egresses via the rotation-
+		// failure SIEM audit / notification broadcast (#132).
+		return redactSQLError("postgresql", ref, err)
 	}
 	return nil
 }

--- a/internal/rotation/postgres_test.go
+++ b/internal/rotation/postgres_test.go
@@ -94,4 +94,16 @@ func TestPostgres_RotateErrors(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "permission denied")
 	})
+	// #132: a driver error that echoes the failing statement (containing the new
+	// password as a quoted literal) must not leak that literal into the returned
+	// error — it flows unsanitized into the SIEM audit Description and the
+	// rotation-failure Slack/webhook broadcast.
+	t.Run("backend error echoing the statement is redacted", func(t *testing.T) {
+		fake := &fakePG{err: errors.New(`syntax error at or near "WITH" — statement: ALTER ROLE "app_svc" WITH PASSWORD 'S3cr3t-Live-Value!'`)}
+		err := pgWith(fake, "app_").Rotate(context.Background(), "app_svc", "S3cr3t-Live-Value!")
+		require.Error(t, err)
+		assert.NotContains(t, err.Error(), "S3cr3t-Live-Value!", "the live credential must never appear in the returned error")
+		assert.Contains(t, err.Error(), "app_svc", "the ref is still useful diagnostic context")
+		assert.Contains(t, err.Error(), `'***'`, "the redacted literal is replaced with a placeholder, not silently dropped")
+	})
 }

--- a/internal/rotation/rotation.go
+++ b/internal/rotation/rotation.go
@@ -8,6 +8,8 @@ package rotation
 
 import (
 	"context"
+	"fmt"
+	"regexp"
 	"strings"
 )
 
@@ -95,4 +97,24 @@ func prefixAllowed(allowed []string, ref string) bool {
 		}
 	}
 	return false
+}
+
+// sqlStringLiteral matches a single-quoted SQL string literal, including the
+// standard ''-doubling escape for an embedded quote (used by both PostgreSQL
+// and MySQL's default ANSI_QUOTES-off mode).
+var sqlStringLiteral = regexp.MustCompile(`'(?:[^']|'')*'`)
+
+// redactSQLError wraps err with a value-free message: the SQL rotation backends
+// (postgres.go, mysql.go) inline the new password into an ALTER ROLE/USER
+// statement as a quoted literal, and a driver error can echo the failing
+// statement or its position back verbatim (e.g. a syntax error near the
+// literal) — %w/%v-wrapping that raw error let the LIVE credential egress into
+// the rotation-failure SIEM audit Description and the Slack/webhook broadcast
+// on a statement-echoing failure (#132). Any single-quoted literal in the
+// error text is replaced with a placeholder before the error is ever wrapped,
+// so the operator still gets the backend name, ref, and whatever non-literal
+// diagnostic context (error class, position) the driver returned.
+func redactSQLError(backend, ref string, err error) error {
+	redacted := sqlStringLiteral.ReplaceAllString(err.Error(), "'***'")
+	return fmt.Errorf("%s: rotate %q: %s", backend, ref, redacted)
 }

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -453,7 +453,13 @@ type SecretNode struct {
 	// upstream it belongs to, who to contact. Metadata only; never the value.
 	Description string
 	MaxReads    *int
-	Expiration  *time.Time
+	// ReadCount is the secret's LIFETIME read count against MaxReads — deliberately
+	// secret-level, not per-version (#133). A per-version counter resets to zero on
+	// every new version, so a burn-after-N-reads secret became re-readable simply
+	// by rotating or rolling back (which creates a fresh version); this counter
+	// carries forward across both.
+	ReadCount  int
+	Expiration *time.Time
 	Metadata    JSON
 	// Classification is the data sensitivity label (ISO 27001 A.5.12/A.5.13):
 	// "" = unclassified, else one of public|internal|confidential|restricted. Drives

--- a/internal/storage/store/concurrency_max_reads_test.go
+++ b/internal/storage/store/concurrency_max_reads_test.go
@@ -74,3 +74,51 @@ func TestConcurrency_MaxReads_NeverExceedsCap(t *testing.T) {
 	require.NoError(t, db.First(&got, v.ID).Error)
 	assert.Equal(t, maxReads, got.ReadCount, "the stored read_count must settle exactly at the cap")
 }
+
+// TestConcurrency_MaxReadsSecretLevel_NeverExceedsCap mirrors the version-level
+// test above for TryIncrementSecretNodeReadCount (#133): the secret-level
+// counter that survives rotate/rollback must have the SAME race-free guarantee
+// as the version-level one it supersedes for enforcement.
+func TestConcurrency_MaxReadsSecretLevel_NeverExceedsCap(t *testing.T) {
+	db := concurrentDB(t)
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}))
+	ls := NewLocalStorage(db)
+
+	s := &models.SecretNode{Name: "n", ProjectID: 1, EnvironmentID: 1, ReadCount: 0}
+	require.NoError(t, db.Create(s).Error)
+
+	const maxReads = 5
+	const readers = 64
+
+	var succeeded atomic.Int64
+	errs := make(chan error, readers)
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < readers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			ok, err := ls.TryIncrementSecretNodeReadCount(context.Background(), s.ID, maxReads)
+			if err != nil {
+				errs <- err
+				return
+			}
+			if ok {
+				succeeded.Add(1)
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+
+	assert.Equal(t, int64(maxReads), succeeded.Load(), "exactly maxReads reads may succeed, never more")
+
+	var got models.SecretNode
+	require.NoError(t, db.First(&got, s.ID).Error)
+	assert.Equal(t, maxReads, got.ReadCount, "the stored read_count must settle exactly at the cap")
+}

--- a/internal/storage/store/local_secrets.go
+++ b/internal/storage/store/local_secrets.go
@@ -566,3 +566,17 @@ func (ls *LocalStorage) TryIncrementSecretReadCount(ctx context.Context, version
 	}
 	return res.RowsAffected == 1, nil
 }
+
+// TryIncrementSecretNodeReadCount is TryIncrementSecretReadCount's secret-level
+// twin (#133): the same atomic conditional-UPDATE pattern, keyed on the secret
+// (secret_nodes.read_count) instead of a version, so the cap survives rotate/
+// rollback creating a new version.
+func (ls *LocalStorage) TryIncrementSecretNodeReadCount(ctx context.Context, secretID uint, maxReads int) (bool, error) {
+	res := ls.db.WithContext(ctx).Model(&models.SecretNode{}).
+		Where("id = ? AND read_count < ?", secretID, maxReads).
+		UpdateColumn("read_count", gorm.Expr("read_count + 1"))
+	if res.Error != nil {
+		return false, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), res.Error)
+	}
+	return res.RowsAffected == 1, nil
+}

--- a/internal/storage/store/remote_secrets.go
+++ b/internal/storage/store/remote_secrets.go
@@ -304,3 +304,12 @@ func (rs *RemoteStorage) TryIncrementSecretReadCount(ctx context.Context, versio
 	}
 	return true, nil
 }
+
+// TryIncrementSecretNodeReadCount mirrors TryIncrementSecretReadCount: the
+// authoritative enforcement runs server-side against local storage, so a remote
+// client is never on the enforcement hot path. Not expected to be called from a
+// CLI/remote context (KeyorixCore always runs against LocalStorage server-side);
+// fails loud rather than silently reporting success if it ever is.
+func (rs *RemoteStorage) TryIncrementSecretNodeReadCount(ctx context.Context, secretID uint, maxReads int) (bool, error) {
+	return false, fmt.Errorf("remote storage: max-reads enforcement is server-side only")
+}

--- a/server/http/handlers/secrets_copy.go
+++ b/server/http/handlers/secrets_copy.go
@@ -53,7 +53,7 @@ func (h *SecretHandler) CopySecret(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	created, err := h.coreService.CopySecret(r.Context(), uint(id), reqBody.EnvironmentID, reqBody.Name, userCtx.Username, userCtx.UserID)
+	created, err := h.coreService.CopySecret(r.Context(), uint(id), reqBody.EnvironmentID, reqBody.Name, userCtx.Username, userCtx.UserID, r.RemoteAddr, r.Header.Get("User-Agent"))
 	if err != nil {
 		msg := err.Error()
 		status := http.StatusInternalServerError

--- a/server/http/handlers/secrets_copy_environment.go
+++ b/server/http/handlers/secrets_copy_environment.go
@@ -44,7 +44,7 @@ func (h *SecretHandler) CopyEnvironmentSecrets(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	copied, skipped, err := h.coreService.CopyEnvironmentSecrets(r.Context(), uint(projectID), uint(sourceEnvID), reqBody.TargetEnvironmentID, userCtx.Username, userCtx.UserID)
+	copied, skipped, err := h.coreService.CopyEnvironmentSecrets(r.Context(), uint(projectID), uint(sourceEnvID), reqBody.TargetEnvironmentID, userCtx.Username, userCtx.UserID, r.RemoteAddr, r.Header.Get("User-Agent"))
 	if err != nil {
 		status := http.StatusInternalServerError
 		msg := err.Error()


### PR DESCRIPTION
## Summary

Three MEDIUM-severity findings around secret lifecycle auditing and value egress.

- **#126 — CopySecret/CopyEnvironmentSecrets decrypt+propagate with no audit.** A copy decrypted the source and wrote a new secret with no audit trail for either — a covert exfil channel invisible to the anomaly detector (which keys off `SecretAccessLog` rows). Now emits a detached `secret.read` (source) + `secret.created` (destination) audit event, with actor ip/ua threaded from the HTTP handler.
- **#132 — Secret VALUE egress via rotation-backend error → SIEM + notification.** The Postgres/MySQL rotation executors inline the new password into the SQL as a quoted literal; a driver error can echo the failing statement verbatim. That raw error flowed unsanitized into the rotation-failure SIEM audit Description and the Slack/webhook broadcast. Added a shared `redactSQLError` helper that strips any quoted SQL literal before the error is wrapped, applied to both backends.
- **#133 — max_reads is per-version → rotate/rollback resets the read budget.** The atomic max-reads counter was keyed on the version, which starts fresh at zero for every new version — a burn-after-N-read secret became re-readable simply by rotating or rolling it back. Added `SecretNode.ReadCount` (secret-level, lifetime) and `TryIncrementSecretNodeReadCount` — the same atomic conditional-UPDATE pattern, re-targeted at the secret so the cap survives both. The existing per-version counter is kept (best-effort) purely for its CLI/gRPC display field.

**Scope note:** upgrading an install with an already-exhausted pre-existing burn-after-N secret resets that secret's budget once at migration time (the new column defaults to 0) — a narrow, one-time edge case, disclosed here rather than adding a data-backfill sweep.

Also reapplies the `siem/spool.go` `replayMu` fix (originally PR #521, still unmerged) since this branch forks from a pre-#521 `main`.

## Test plan
- [x] New regression test: `CopySecret` writes both a `secret.read` and a `secret.created` `SecretAccessLog` row (verified via direct DB query, not just no-error).
- [x] New regression tests (Postgres + MySQL): a driver error echoing the failing statement's password literal is redacted before it's returned; the ref/backend context is preserved.
- [x] New regression test: a burn-after-1-read secret refuses a second read; **after rotating**, still refuses; **after rolling back**, still refuses (the core exploit this PR closes).
- [x] New concurrency test: 64 concurrent readers against a secret-level `max_reads=5` cap yield exactly 5 successes (mirrors the existing version-level race test).
- [x] Full test suite: `go test ./internal/... ./server/...` — all green.
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues.
- [x] `GOWORK=off go build -C operator ./...` — operator module unaffected, builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)