### PR TITLE
harden(audit): close incomplete-fix gaps in anti-rollback and bundle integrity — #110, #111

### DIFF
--- a/internal/audit/siem/spool.go
+++ b/internal/audit/siem/spool.go
@@ -45,6 +45,13 @@ type spool struct {
 	mu   sync.Mutex // serializes file mutation (append + replay rewrite); NOT held across delivery
 	stop chan struct{}
 	done chan struct{}
+
+	// replayMu serializes the whole replay() call end-to-end (distinct from mu,
+	// which is deliberately released across delivery). Without it, the loop's
+	// immediate on-start replay() and a concurrently-fired ticker/manual replay()
+	// could both read the same undelivered snapshot before either finishes its
+	// reconcile-and-rewrite, double-delivering every event still in the backlog.
+	replayMu sync.Mutex
 }
 
 // newSpool prepares the spool directory and starts the replay loop.
@@ -124,6 +131,8 @@ func (s *spool) loop() {
 // on the audited request path) never blocks behind a SIEM round-trip. Crash-safe: every
 // undelivered line stays on disk until the atomic rewrite at the end.
 func (s *spool) replay() {
+	s.replayMu.Lock()
+	defer s.replayMu.Unlock()
 	// Snapshot under the lock, recording the byte length we read; any add() during the
 	// lock-free delivery below only appends BEYOND this offset (add never rewrites), so the
 	// reconcile can cleanly separate "what we attempted" from "what arrived meanwhile".

--- a/internal/bundle/bundle.go
+++ b/internal/bundle/bundle.go
@@ -373,15 +373,47 @@ const installedVersionMarker = ".keyorix-installed-version"
 // readInstalledVersion returns the persisted installed version at destDir. ok is false
 // when no marker exists (a first install); a present-but-unreadable marker is an error
 // (fail closed — don't silently treat a tampered/locked marker as "first install").
+//
+// #111: a missing marker in an OTHERWISE NON-EMPTY destDir is refused rather than
+// treated as a first install. The marker is a plaintext file in the same operator-
+// writable staging directory the import itself writes into — an import-capable
+// adversary can freely rm/edit it, and a bare "absent = first install" gate let them
+// delete the marker to re-stage an older signed release over an existing, populated
+// install (the no-downgrade check never fires with no marker to compare against). A
+// directory already holding staged component files but no marker is inconsistent
+// with a genuine first install (which starts from an empty/nonexistent directory) —
+// it means either a marker was deleted, or a prior import failed partway through
+// (before the marker write at the very end); both cases are ambiguous enough to
+// refuse rather than silently proceed unguarded.
 func readInstalledVersion(destDir string) (string, bool, error) {
 	b, err := os.ReadFile(filepath.Join(destDir, installedVersionMarker)) // #nosec G304 -- destDir is operator-configured, marker name is a constant
 	if err != nil {
 		if os.IsNotExist(err) {
+			hasContent, derr := destDirHasContent(destDir)
+			if derr != nil {
+				return "", false, fmt.Errorf("bundle: check destination for existing content: %w", derr)
+			}
+			if hasContent {
+				return "", false, fmt.Errorf("bundle: destination %q already contains staged content but no installed-version marker — refusing to treat this as a first install (the marker may have been removed, or a prior import failed partway through); clear the destination first if this is intentional", destDir)
+			}
 			return "", false, nil
 		}
 		return "", false, fmt.Errorf("bundle: read installed-version marker: %w", err)
 	}
 	return strings.TrimSpace(string(b)), true, nil
+}
+
+// destDirHasContent reports whether destDir contains any entry at all. A
+// nonexistent directory counts as empty (nothing has ever been staged there).
+func destDirHasContent(destDir string) (bool, error) {
+	entries, err := os.ReadDir(destDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return len(entries) > 0, nil
 }
 
 // writeInstalledVersion persists version as the installed-version marker at destDir.

--- a/internal/bundle/bundle_test.go
+++ b/internal/bundle/bundle_test.go
@@ -394,6 +394,50 @@ func TestExtract_PersistedVersionBlocksDowngrade(t *testing.T) {
 	}
 }
 
+// TestExtract_MissingMarkerInNonEmptyDestRefused pins #111: the installed-version
+// marker is a plaintext file in the SAME operator-writable staging directory the
+// import itself writes into — an import-capable adversary who deletes it (to fake
+// a "first install") must not be able to re-stage an OLDER signed release over an
+// existing, populated install just because there's no marker left to compare
+// against. A destDir that already holds staged content but no marker is refused,
+// not silently treated as a first install.
+func TestExtract_MissingMarkerInNonEmptyDestRefused(t *testing.T) {
+	dest := t.TempDir()
+
+	newRaw, newReg, _ := signedBundle(t, map[string]string{"images/a.tar": "new"}, "v1.2.0", "update-2026", "")
+	if _, err := Extract(bytes.NewReader(newRaw), newReg, dest, ""); err != nil {
+		t.Fatalf("install v1.2.0: %v", err)
+	}
+
+	// Attacker: delete the marker to erase the evidence of what's installed.
+	if err := os.Remove(filepath.Join(dest, installedVersionMarker)); err != nil {
+		t.Fatalf("remove marker: %v", err)
+	}
+
+	// Attempt to re-stage an OLDER v1.0.0 with no flag — must be refused because the
+	// destination already has staged content, not silently accepted as "first install".
+	oldRaw, oldReg, _ := signedBundle(t, map[string]string{"images/a.tar": "old"}, "v1.0.0", "update-2026", "")
+	if _, err := Extract(bytes.NewReader(oldRaw), oldReg, dest, ""); err == nil {
+		t.Fatalf("expected the downgrade to be refused, but Extract succeeded")
+	}
+
+	// The older content must not have overwritten the installed component.
+	got, _ := os.ReadFile(filepath.Join(dest, "images", "a.tar"))
+	if string(got) != "new" {
+		t.Fatalf("downgrade staged content = %q, want the installed 'new'", got)
+	}
+}
+
+// A genuinely first install (empty/nonexistent destDir, no marker) is still allowed
+// — the fix must not break the legitimate case.
+func TestExtract_FirstInstallOnEmptyDestStillAllowed(t *testing.T) {
+	dest := t.TempDir()
+	raw, reg, _ := signedBundle(t, map[string]string{"images/a.tar": "x"}, "v1.0.0", "update-2026", "")
+	if _, err := Extract(bytes.NewReader(raw), reg, dest, ""); err != nil {
+		t.Fatalf("first install on an empty destination must succeed: %v", err)
+	}
+}
+
 // assertDirEmpty fails if dir contains any regular file (temp files included), proving a
 // fail-closed Extract staged nothing.
 func assertDirEmpty(t *testing.T, dir string) {

--- a/internal/core/audit_checkpoint.go
+++ b/internal/core/audit_checkpoint.go
@@ -64,7 +64,7 @@ func (c *KeyorixCore) SeedAuditWatermark(ctx context.Context) {
 	if !c.AuditCheckpointsAvailable() {
 		return
 	}
-	floor, _, _, _, err := c.auditHighWaterFloor(ctx)
+	floor, _, _, _, err := c.auditHighWaterFloor(ctx, false)
 	if err != nil {
 		log.Printf("audit high-water: failed to seed in-memory watermark at startup: %v", err)
 		return
@@ -188,7 +188,7 @@ func (c *KeyorixCore) WriteAuditCheckpoint(ctx context.Context) (*models.AuditCh
 	// Refuse to checkpoint a chain that sits below the certified high-water mark —
 	// otherwise a scheduled write would launder a truncation into a fresh, authentic
 	// checkpoint (and a fresh high-water), erasing the rollback evidence.
-	floor, _, hwTampered, hwReason, err := c.auditHighWaterFloor(ctx)
+	floor, _, hwTampered, hwReason, err := c.auditHighWaterFloor(ctx, false)
 	if err != nil {
 		return nil, false, err
 	}
@@ -394,10 +394,28 @@ func parseAuditHighWater(val string) (cp *models.AuditCheckpoint, sig string, ok
 // auditHighWaterFloor returns the greatest chained-events count this server can prove
 // the trail previously reached: the max of the in-memory watermark and a signature-valid
 // persistent high-water under the current key. found reports whether a persistent mark
-// exists; tampered/reason flag a persistent mark that fails its signature under the
-// CURRENT key version (a superseded version is treated as a DEK rotation and ignored, so
-// the system can recover after a key rotation — symmetric with checkpoint enforcement).
-func (c *KeyorixCore) auditHighWaterFloor(ctx context.Context) (floor int64, found, tampered bool, reason string, err error) {
+// exists; tampered/reason flag a persistent mark that fails its signature.
+//
+// strict controls how an unverifiable mark (signature fails) is treated when its
+// key_version does NOT match the current signing key:
+//   - strict=true (the READ path, enforceAuditHighWater): ALWAYS tamper once any
+//     checkpoint exists. The mark's key_version field is attacker-controlled and
+//     unauthenticated — a FAILED signature means it cannot be trusted either. #110:
+//     the prior version excused any sig failure whose key_version merely differed
+//     from the current one, so an attacker could forge the mark with a fabricated
+//     key_version + garbage signature and have it accepted as "just an old key" —
+//     bypassing the anti-rollback floor entirely (found=true routed around the
+//     missing-mark tamper check, and the floor silently stayed at 0 after a
+//     restart). This matches the checkpoint ROW's read-path behavior
+//     (enforceAuditCheckpoint), which has never had a superseded-key exception.
+//   - strict=false (the WRITE/recovery path, WriteAuditCheckpoint, and the
+//     non-enforcing SeedAuditWatermark/advanceAuditHighWater callers): a sig
+//     failure under a claimed-superseded key_version is treated as a genuine DEK
+//     rotation and ignored, so the system can still self-heal by writing a fresh,
+//     correctly-signed checkpoint under the new key. This does not reopen #110:
+//     the very next VerifyAuditChain call uses strict=true and will flag the
+//     stale/unverifiable mark until that fresh write actually happens.
+func (c *KeyorixCore) auditHighWaterFloor(ctx context.Context, strict bool) (floor int64, found, tampered bool, reason string, err error) {
 	floor = c.watermark()
 	val, ok, err := c.storage.GetSystemMetadata(ctx, auditHighWaterKey)
 	if err != nil {
@@ -422,8 +440,17 @@ func (c *KeyorixCore) auditHighWaterFloor(ctx context.Context) (floor int64, fou
 		return floor, true, true,
 			fmt.Sprintf("audit high-water mark fails its signature under the current key version %q — the high-water row was tampered with", cp.KeyVersion), nil
 	}
-	// Signature fails AND key_version is superseded → consistent with a DEK rotation;
-	// ignore the stale mark (the next checkpoint write re-establishes it under the new key).
+	if strict {
+		if exists, cerr := c.checkpointExists(ctx); cerr != nil {
+			return 0, false, false, "", cerr
+		} else if exists {
+			return floor, true, true,
+				fmt.Sprintf("audit high-water mark fails its signature (claiming key version %q) while signed checkpoints exist — an unverifiable key_version claim is not trusted as proof of a DEK rotation", cp.KeyVersion), nil
+		}
+	}
+	// Lenient path, or no checkpoint exists yet to protect: signature fails and
+	// key_version is (claimed) superseded → consistent with a DEK rotation; ignore
+	// the stale mark (the next checkpoint write re-establishes it under the new key).
 	return floor, true, false, "", nil
 }
 
@@ -432,7 +459,11 @@ func (c *KeyorixCore) auditHighWaterFloor(ctx context.Context) (floor int64, fou
 // checkpoints + tail-truncation, which the latest-checkpoint comparison alone misses),
 // then raises the in-memory watermark to the just-verified length.
 func (c *KeyorixCore) enforceAuditHighWater(ctx context.Context, v *storage.AuditChainVerification) error {
-	floor, found, tampered, reason, err := c.auditHighWaterFloor(ctx)
+	// strict=true (#110): the read path must not excuse an unverifiable mark just
+	// because it CLAIMS a superseded key_version — that field is unauthenticated
+	// once the signature fails, so trusting it lets a forged mark bypass the
+	// anti-rollback floor entirely. See auditHighWaterFloor's doc comment.
+	floor, found, tampered, reason, err := c.auditHighWaterFloor(ctx, true)
 	if err != nil {
 		return err
 	}
@@ -466,7 +497,7 @@ func (c *KeyorixCore) enforceAuditHighWater(ctx context.Context, v *storage.Audi
 // advanceAuditHighWater persists (and bumps the in-memory) high-water mark to cp after a
 // checkpoint write. The mark only ever advances; it is signed with the current key.
 func (c *KeyorixCore) advanceAuditHighWater(ctx context.Context, cp *models.AuditCheckpoint) {
-	floor, _, _, _, err := c.auditHighWaterFloor(ctx)
+	floor, _, _, _, err := c.auditHighWaterFloor(ctx, false)
 	if err == nil && cp.ChainedEvents < floor {
 		// Never lower the mark (a legitimate grow only raises it). Should not happen —
 		// WriteAuditCheckpoint refuses to checkpoint below the floor — but be defensive.

--- a/internal/core/audit_checkpoint_test.go
+++ b/internal/core/audit_checkpoint_test.go
@@ -500,6 +500,51 @@ func TestAuditCheckpoint_TamperedHighWaterDetected(t *testing.T) {
 	assert.Contains(t, v.CheckpointReason, "high-water mark")
 }
 
+// TestAuditCheckpoint_ForgedKeyVersionHighWaterDetected pins #110 — the exact
+// exploit the prior fix missed: a forged high-water mark whose key_version is
+// simply set to something OTHER than the current one was excused as "consistent
+// with a DEK rotation" and its found=true routed around the missing-mark tamper
+// check entirely, silently resetting the anti-rollback floor. Combined with
+// deleting the newest checkpoint (keeping an older authentic one) and truncating
+// events between them, VerifyAuditChain reported Valid=true over a rolled-back
+// trail. The read path must not trust an unauthenticated key_version claim on a
+// signature that fails to verify.
+func TestAuditCheckpoint_ForgedKeyVersionHighWaterDetected(t *testing.T) {
+	ctx := context.Background()
+	c, db := newCheckpointCore(t)
+
+	// Establish an older, authentic checkpoint (the kept "#50" in the exploit
+	// narrative) and a newer one (the "#100" the attacker will delete).
+	logEvents(t, c, 5)
+	_, written, err := c.WriteAuditCheckpoint(ctx)
+	require.NoError(t, err)
+	require.True(t, written)
+	logEvents(t, c, 5) // now 10 events total
+	_, written, err = c.WriteAuditCheckpoint(ctx)
+	require.NoError(t, err)
+	require.True(t, written)
+
+	// Attacker: forge the high-water mark with a FABRICATED key_version (not the
+	// real current "v1", and not a genuinely-ever-used version either) and a
+	// garbage signature — this is the exact shape that was previously excused.
+	require.NoError(t, db.Exec("UPDATE system_metadata SET value = ? WHERE key = ?",
+		"v1\x001\x001\x00deadbeef\x00fabricated-v99\x00bogussig", auditHighWaterKey).Error)
+	// Attacker: delete the newer checkpoint, keeping the older authentic one.
+	require.NoError(t, db.Exec("DELETE FROM audit_checkpoints WHERE chained_events = 10").Error)
+	// Attacker: truncate events below what the deleted checkpoint certified, but
+	// still at/above what the surviving older checkpoint certified.
+	require.NoError(t, db.Exec("DELETE FROM audit_events WHERE id > 7").Error)
+
+	// Simulate a restart: fresh core, in-memory watermark reset.
+	fresh := &KeyorixCore{storage: store.NewLocalStorage(db)}
+	fresh.SetAuditCheckpointKey(bytes.Repeat([]byte{0x7}, 32), "v1")
+
+	v, err := fresh.VerifyAuditChain(ctx)
+	require.NoError(t, err)
+	assert.False(t, v.Valid, "a forged high-water mark claiming an arbitrary key_version must not bypass anti-rollback")
+	assert.Contains(t, v.CheckpointReason, "high-water mark")
+}
+
 // When an external-notary trust root is configured, the latest checkpoint's stored
 // anchor is re-verified on the read path: a token that doesn't verify against the
 // configured root is flagged (previously the anchor was written but never checked).


### PR DESCRIPTION
## Summary

Two "INCOMPLETE FIX" findings — each references an earlier fix (#79, #81) that only partially closed the original vulnerability.

- **#110 — forged parseable high-water mark bypasses audit anti-rollback (incomplete fix of #79).** `auditHighWaterFloor` excused ANY high-water-mark signature failure whose `key_version` merely differed from the current signing key as "consistent with a DEK rotation" — but once the signature fails, `key_version` is unauthenticated. An attacker could forge the mark with a fabricated `key_version` + garbage signature and have it accepted as benign, silently resetting the anti-rollback floor (surviving a restart, since `SeedAuditWatermark` hit the same excuse). Combined with deleting the newest checkpoint (keeping an older authentic one) and truncating events between them, `VerifyAuditChain` reported `Valid=true` over a rolled-back trail.

  Fix splits `auditHighWaterFloor` on a `strict` parameter: the READ path (`VerifyAuditChain`) is now unconditionally strict — any signature failure is tamper once any checkpoint exists, regardless of the claimed `key_version` — matching the checkpoint ROW's read-path check, which has never had this exception. The WRITE/recovery path (`WriteAuditCheckpoint`) keeps the lenient exception so a **genuine** DEK rotation still self-heals on the next checkpoint write (verified: `TestAuditCheckpoint_RotationRebaselines` still passes unchanged).

- **#111 — bundle no-downgrade marker is unsigned + deletable (incomplete fix of #81).** `.keyorix-installed-version` is a plaintext file in the SAME operator-writable staging directory the import itself writes into. A missing marker was treated unconditionally as "first install" (no downgrade check) — an import-capable adversary could delete it to re-stage an older signed release over an existing, populated install.

  Fix: a destination that already holds staged component files but no marker is now refused, not silently treated as first install. **Scope note:** a DB-backed or signed marker (the original suggested fix) isn't architecturally available here — `internal/bundle` is deliberately storage-agnostic so it can run air-gapped, before any Keyorix server/DB exists. Wiring one in is a larger change left for a dedicated follow-up.

Also reapplies the `siem/spool.go` `replayMu` fix (originally PR #521, still unmerged) since this branch forks from a pre-#521 `main`.

## Test plan
- [x] New regression test: a forged high-water mark with a fabricated `key_version`, a deleted newer checkpoint, and truncated events between them is now detected after a simulated restart (previously silently `Valid=true`).
- [x] New regression test: a deleted marker in a non-empty destination refuses a downgrade re-stage (previously accepted); a genuinely empty destination still allows a first install.
- [x] Existing `TestAuditCheckpoint_RotationRebaselines` (genuine key-rotation recovery) still passes unchanged.
- [x] Full existing `audit_checkpoint_test.go` and `bundle_test.go` suites pass unchanged.
- [x] Full test suite: `go test ./internal/... ./server/...` — all green.
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues.
- [x] `GOWORK=off go build -C operator ./...` — operator module unaffected, builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)