### PR TITLE
harden(identity): DB uniqueness on email/external_id + async reset delivery — #117

### DIFF
--- a/internal/core/auth.go
+++ b/internal/core/auth.go
@@ -365,6 +365,15 @@ func (c *KeyorixCore) ValidateSessionToken(ctx context.Context, token string) (*
 // account (enumeration-safe), so unknown addresses, suspended accounts, throttled
 // repeats, and delivery/config failures are all swallowed. The attempt itself is
 // audited inside provisionSetupLink.
+//
+// #117: the known-account path used to synchronously dial-and-send the email
+// (SMTP delivery blocks on the real network round-trip) before returning, while
+// an unknown/blocked/SSO-managed address returned after a single fast DB lookup
+// — a measurable timing side-channel an attacker can use to enumerate valid
+// accounts without ever seeing a different response body. The issue+deliver
+// step now runs detached in the background (DetachedAuditContext, the same
+// fire-and-forget pattern used elsewhere for post-response audit work) so this
+// function returns at the same speed regardless of whether the email exists.
 func (c *KeyorixCore) RequestPasswordReset(ctx context.Context, email string) error {
 	user, err := c.storage.GetUserByEmail(ctx, email)
 	if err != nil {
@@ -382,12 +391,18 @@ func (c *KeyorixCore) RequestPasswordReset(ctx context.Context, email string) er
 	}
 	// Throttle abusive repeats to a victim address (same control as resend). A
 	// throttled repeat returns an error here, swallowed below to stay enumeration-safe.
-	_, _ = c.provisionSetupLinkThrottled(ctx, IssueSetupTokenRequest{
-		Purpose:       SetupPurposePasswordResetLink,
-		SubjectEmail:  user.Email,
-		SubjectUserID: &user.ID,
-		CreatedBy:     0, // self-service (no issuing admin)
-	}, user.DisplayName, "")
+	// Detached from the request context: the HTTP handler returns immediately after
+	// this call, which would cancel a request-scoped ctx before the SMTP send (or
+	// even the throttle check) completes.
+	detached := DetachedAuditContext(ctx)
+	go func() {
+		_, _ = c.provisionSetupLinkThrottled(detached, IssueSetupTokenRequest{
+			Purpose:       SetupPurposePasswordResetLink,
+			SubjectEmail:  user.Email,
+			SubjectUserID: &user.ID,
+			CreatedBy:     0, // self-service (no issuing admin)
+		}, user.DisplayName, "")
+	}()
 	return nil
 }
 

--- a/internal/core/password_reset_test.go
+++ b/internal/core/password_reset_test.go
@@ -29,7 +29,12 @@ func TestRequestPasswordReset(t *testing.T) {
 	activeUser := &models.User{ID: 9, Email: email, DisplayName: "Rhea", AccountState: AccountActive}
 
 	t.Run("active account: issues a password_reset_link and delivers it", func(t *testing.T) {
-		fake := &fakeDeliverer{echoLink: true, result: delivery.DeliveryResult{Channel: delivery.ChannelSMTP, Delivered: true}}
+		// #117: issue+deliver now runs detached in a background goroutine so the
+		// call returns at the same speed regardless of whether the email exists
+		// (closing the SMTP-send timing oracle) — done synchronizes this
+		// assertion with that async work instead of racing it.
+		done := make(chan struct{})
+		fake := &fakeDeliverer{echoLink: true, result: delivery.DeliveryResult{Channel: delivery.ChannelSMTP, Delivered: true}, done: done}
 		c, ms := newCore(fake)
 		ms.On("GetUserByEmail", ctx, email).Return(activeUser, nil)
 		ms.On("CountSetupTokensSince", ctx, SetupPurposePasswordResetLink, email, fixed.Add(-24*time.Hour)).Return(int64(0), nil)
@@ -38,6 +43,11 @@ func TestRequestPasswordReset(t *testing.T) {
 		ms.On("CreateSetupToken", ctx, mock.AnythingOfType("*models.SetupToken")).Return(&models.SetupToken{ID: 1}, nil)
 
 		require.NoError(t, c.RequestPasswordReset(ctx, email))
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for the background delivery")
+		}
 		assert.True(t, fake.called, "the reset link should be delivered")
 		assert.Equal(t, SetupPurposePasswordResetLink, fake.lastReq.Purpose)
 		assert.Equal(t, email, fake.lastReq.RecipientEmail)
@@ -76,4 +86,57 @@ func TestRequestPasswordReset(t *testing.T) {
 		assert.False(t, fake.called)
 		ms.AssertNotCalled(t, "CreateSetupToken", mock.Anything, mock.Anything)
 	})
+
+	// TestRequestPasswordReset_KnownEmailReturnsWithoutWaitingForDelivery pins
+	// #117: the known-account path used to synchronously dial-and-send the
+	// email before returning, while an unknown address returned after a single
+	// fast DB lookup — a measurable timing side-channel. RequestPasswordReset
+	// must now return promptly for a KNOWN email even when delivery is slow,
+	// proving delivery no longer blocks the response.
+	t.Run("known email returns without waiting for a slow delivery", func(t *testing.T) {
+		deliveryStarted := make(chan struct{})
+		releaseDelivery := make(chan struct{})
+		slow := &slowFakeDeliverer{started: deliveryStarted, release: releaseDelivery}
+		c, ms := newCore(slow)
+		ms.On("GetUserByEmail", ctx, email).Return(activeUser, nil)
+		ms.On("CountSetupTokensSince", ctx, SetupPurposePasswordResetLink, email, fixed.Add(-24*time.Hour)).Return(int64(0), nil)
+		ms.On("CountSetupTokensSince", ctx, SetupPurposePasswordResetLink, email, fixed.Add(-resendMinInterval)).Return(int64(0), nil)
+		ms.On("SupersedeActiveSetupTokens", ctx, SetupPurposePasswordResetLink, email).Return(nil)
+		ms.On("CreateSetupToken", ctx, mock.AnythingOfType("*models.SetupToken")).Return(&models.SetupToken{ID: 1}, nil)
+		defer close(releaseDelivery) // don't leak the goroutine if the test fails early
+
+		done := make(chan struct{})
+		go func() {
+			require.NoError(t, c.RequestPasswordReset(ctx, email))
+			close(done)
+		}()
+
+		select {
+		case <-done:
+			// RequestPasswordReset returned — good, it did not wait for delivery.
+		case <-time.After(2 * time.Second):
+			t.Fatal("RequestPasswordReset blocked on delivery instead of returning immediately")
+		}
+		// The delivery genuinely started (proves the goroutine wasn't just skipped).
+		select {
+		case <-deliveryStarted:
+		case <-time.After(2 * time.Second):
+			t.Fatal("background delivery never started")
+		}
+	})
 }
+
+// slowFakeDeliverer blocks inside DeliverSetupLink until release is closed, so a
+// test can prove a caller does NOT wait for it.
+type slowFakeDeliverer struct {
+	started chan struct{}
+	release chan struct{}
+}
+
+func (s *slowFakeDeliverer) DeliverSetupLink(_ context.Context, _ delivery.SetupLinkRequest) (delivery.DeliveryResult, error) {
+	close(s.started)
+	<-s.release
+	return delivery.DeliveryResult{Channel: delivery.ChannelSMTP, Delivered: true}, nil
+}
+
+func (s *slowFakeDeliverer) Name() string { return "slow-fake" }

--- a/internal/core/setup_delivery_test.go
+++ b/internal/core/setup_delivery_test.go
@@ -24,6 +24,11 @@ type fakeDeliverer struct {
 	result   delivery.DeliveryResult
 	echoLink bool
 	err      error
+	// done, when non-nil, is closed after DeliverSetupLink returns — lets a test
+	// whose caller dispatches delivery in a background goroutine (e.g.
+	// RequestPasswordReset, #117) synchronize an assertion with the async work
+	// instead of racing it.
+	done chan struct{}
 }
 
 func (f *fakeDeliverer) DeliverSetupLink(_ context.Context, req delivery.SetupLinkRequest) (delivery.DeliveryResult, error) {
@@ -32,6 +37,9 @@ func (f *fakeDeliverer) DeliverSetupLink(_ context.Context, req delivery.SetupLi
 	res := f.result
 	if f.echoLink {
 		res.LinkForAdmin = req.Link
+	}
+	if f.done != nil {
+		defer close(f.done)
 	}
 	return res, f.err
 }

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -651,6 +651,14 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 		if err := ensureUserEmailIndex(db); err != nil {
 			return err
 		}
+		// Same DB-level protection for users.external_id (#117): the SCIM/IdP-asserted
+		// identifier was indexed but NOT unique, so two different users could share the
+		// same non-empty external_id — an ambiguity GetUserByExternalID (SSO/SCIM login
+		// resolution) must not tolerate. Additive + idempotent; the full AutoMigrate
+		// below covers fresh DBs.
+		if err := ensureUserExternalIDIndex(db); err != nil {
+			return err
+		}
 	}
 
 	// Close the share-create race (#136): a partial unique index on live rows so two
@@ -745,6 +753,9 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 		return err
 	}
 	if err := ensureUserEmailIndex(db); err != nil {
+		return err
+	}
+	if err := ensureUserExternalIDIndex(db); err != nil {
 		return err
 	}
 	if err := ensureProjectNameIndex(db); err != nil {
@@ -846,13 +857,29 @@ func ensureUserNameIndex(db *gorm.DB) error {
 // case-insensitive lookup (`LOWER(email) = LOWER(?)`) — an exact-match index would let
 // the race slip through on a case variant (Bob@x vs bob@x). Scoped to
 // `deleted_at IS NULL` so a soft-deleted (e.g. SCIM-deprovisioned) user's email is freed
-// for reuse on re-provisioning, mirroring ensureUserNameIndex; `email <> ''` so any
+// for reuse on re-provisioning, mirroring ensureUserNameIndex; `email <> ”` so any
 // legacy rows with no email recorded don't collide with each other. Idempotent; works on
 // both SQLite and Postgres (both support expression indexes, partial indexes, and
 // IF [NOT] EXISTS).
 func ensureUserEmailIndex(db *gorm.DB) error {
 	if err := db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS uniq_users_email_active ON users (LOWER(email)) WHERE deleted_at IS NULL AND email <> ''").Error; err != nil {
 		return fmt.Errorf("failed to create partial users email index: %w", err)
+	}
+	return nil
+}
+
+// ensureUserExternalIDIndex creates a partial unique index on users.external_id,
+// scoped to live rows with a non-empty external_id (#117). external_id (the
+// SCIM/IdP-asserted identifier) was indexed but NOT unique, explicitly
+// documented as allowing "legacy/blank rows [to] coexist" — but two DIFFERENT
+// users sharing the same non-empty external_id is exactly the ambiguity SSO/
+// SCIM identity resolution (GetUserByExternalID) must not tolerate: which one
+// does a federated login authenticate as? Empty external_id (every locally-
+// created account) is excluded so native users never collide with each other.
+// Idempotent; works on SQLite and Postgres.
+func ensureUserExternalIDIndex(db *gorm.DB) error {
+	if err := db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS uniq_users_external_id_active ON users (external_id) WHERE deleted_at IS NULL AND external_id != ''").Error; err != nil {
+		return fmt.Errorf("failed to create partial users external_id index: %w", err)
 	}
 	return nil
 }
@@ -870,7 +897,7 @@ func ensureUserEmailIndex(db *gorm.DB) error {
 // ensureUserEmailIndex's treatment of users.email (#117) for the identical
 // shadow-identity class of bug. Scoped to `deleted_at IS NULL` so a soft-deleted
 // project's name is freed for reuse on re-creation, mirroring ensureGroupNameIndex/
-// ensureUserNameIndex; `name <> ''` so any legacy rows with no name recorded don't
+// ensureUserNameIndex; `name <> ”` so any legacy rows with no name recorded don't
 // collide with each other. Idempotent; works on both SQLite and Postgres.
 //
 // Known residual limitation: this closes the case-folding gap but not the

--- a/internal/storage/factory_identity_index_test.go
+++ b/internal/storage/factory_identity_index_test.go
@@ -1,0 +1,83 @@
+package storage
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEmailPartialUniqueIndex pins #117: users.email carried no DB constraint at
+// all — two concurrent CreateUser calls with the same address could both
+// succeed, leaving duplicate-email accounts with ambiguous SSO/SCIM/password-
+// reset targeting. The partial unique index rejects a second LIVE user with the
+// same email, while still allowing a soft-deleted user's email to be reused
+// (matching the username precedent) and allowing multiple users with NO email
+// (empty is excluded from the constraint).
+func TestEmailPartialUniqueIndex(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	cfg := &config.Config{}
+	cfg.Storage.Type = "local"
+	cfg.Storage.Database.Path = filepath.Join(t.TempDir(), "email-index.db")
+
+	st, err := NewStorageFactory().CreateStorage(cfg)
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	alice, err := st.CreateUser(ctx, &models.User{Username: "alice", Email: "alice@x.io", IsActive: true})
+	require.NoError(t, err)
+
+	// A second LIVE user with the same email is rejected.
+	_, err = st.CreateUser(ctx, &models.User{Username: "alice2", Email: "alice@x.io", IsActive: true})
+	require.Error(t, err, "two live users may not share an email")
+
+	// Soft-deleting alice frees her email for reuse.
+	require.NoError(t, st.DeleteUser(ctx, alice.ID))
+	reAlice, err := st.CreateUser(ctx, &models.User{Username: "alice-again", Email: "alice@x.io", IsActive: true})
+	require.NoError(t, err, "a soft-deleted user's email must be reusable on re-provisioning")
+	assert.NotEqual(t, alice.ID, reAlice.ID)
+
+	// Multiple LIVE users with NO email at all is allowed (empty is excluded).
+	_, err = st.CreateUser(ctx, &models.User{Username: "svc-1", Email: "", IsActive: true})
+	require.NoError(t, err)
+	_, err = st.CreateUser(ctx, &models.User{Username: "svc-2", Email: "", IsActive: true})
+	require.NoError(t, err, "multiple users with no email must not collide with each other")
+}
+
+// TestExternalIDPartialUniqueIndex pins #117: external_id was indexed but not
+// unique — two DIFFERENT users sharing the same non-empty external_id makes SSO/
+// SCIM identity resolution (GetUserByExternalID) ambiguous. Native (local)
+// accounts, which always have an empty external_id, must not collide with each
+// other.
+func TestExternalIDPartialUniqueIndex(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	cfg := &config.Config{}
+	cfg.Storage.Type = "local"
+	cfg.Storage.Database.Path = filepath.Join(t.TempDir(), "external-id-index.db")
+
+	st, err := NewStorageFactory().CreateStorage(cfg)
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	_, err = st.CreateUser(ctx, &models.User{Username: "bob", Email: "bob@x.io", ExternalID: "okta|bob", IsActive: true})
+	require.NoError(t, err)
+
+	// A second LIVE user claiming the same external_id is rejected.
+	_, err = st.CreateUser(ctx, &models.User{Username: "bob2", Email: "bob2@x.io", ExternalID: "okta|bob", IsActive: true})
+	require.Error(t, err, "two live users may not share a non-empty external_id")
+
+	// Multiple native (local) users with an empty external_id must not collide.
+	_, err = st.CreateUser(ctx, &models.User{Username: "native-1", Email: "n1@x.io", ExternalID: "", IsActive: true})
+	require.NoError(t, err)
+	_, err = st.CreateUser(ctx, &models.User{Username: "native-2", Email: "n2@x.io", ExternalID: "", IsActive: true})
+	require.NoError(t, err, "multiple native users with no external_id must not collide with each other")
+}

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -233,7 +233,13 @@ type User struct {
 	// deleted_at IS NULL), created in migrateDatabase — not the plain `uniqueIndex`
 	// tag — so a soft-deleted (e.g. SCIM-deprovisioned) user's username is freed for
 	// reuse on re-provisioning while the old row stays restorable for audit.
-	Username     string `gorm:"not null"`
+	Username string `gorm:"not null"`
+	// Email uniqueness (among live, non-empty rows) is enforced by a PARTIAL
+	// unique index (email WHERE deleted_at IS NULL AND email != ''), created in
+	// migrateDatabase — mirrors the Username precedent. Without this, two
+	// concurrent CreateUser calls with the same address could both succeed,
+	// leaving duplicate-email accounts with ambiguous SSO/SCIM/password-reset
+	// targeting.
 	Email        string
 	DisplayName  string
 	PasswordHash string     `json:"-"`
@@ -253,8 +259,11 @@ type User struct {
 	// a WebAuthn assertion as the second factor (see WebAuthnCredential).
 	WebAuthnEnabled bool `gorm:"default:false"`
 	// ExternalID is the IdP's stable identifier for a SCIM-provisioned user (SCIM
-	// externalId, RFC 7644). Empty for locally-created users. Indexed for the SCIM
-	// reconciliation lookup; not unique (legacy/blank rows coexist).
+	// externalId, RFC 7644). Empty for locally-created users. Uniqueness (among
+	// live, non-empty rows) is enforced by a PARTIAL unique index, created in
+	// migrateDatabase — two different users sharing a non-empty external_id would
+	// make SSO/SCIM identity resolution (GetUserByExternalID) ambiguous. Blank
+	// rows (every local account) coexist freely.
 	ExternalID string `gorm:"index"`
 	// Per-account login lockout (brute-force protection). FailedLoginAttempts counts
 	// consecutive failed password logins within the configured window;
@@ -477,7 +486,7 @@ type SecretNode struct {
 	// carries forward across both.
 	ReadCount  int
 	Expiration *time.Time
-	Metadata    JSON
+	Metadata   JSON
 	// Classification is the data sensitivity label (ISO 27001 A.5.12/A.5.13):
 	// "" = unclassified, else one of public|internal|confidential|restricted. Drives
 	// the classification posture and lets a review find high-sensitivity secrets.


### PR DESCRIPTION
## Summary

One MEDIUM-severity finding covering two sub-issues in user identity handling.

- **No DB uniqueness on email/external_id.** Neither field carried any DB constraint. Two concurrent `CreateUser` calls with the same email (or the same SCIM/IdP `externalId`) could both succeed, leaving duplicate-account rows with ambiguous SSO/SCIM/password-reset targeting. Added `ensureUserEmailIndex`/`ensureUserExternalIDIndex`, mirroring the existing `ensureUserNameIndex`/`ensureGroupNameIndex` precedent exactly: a partial unique index scoped to live, non-empty rows — not a plain gorm `uniqueIndex` tag, since `AutoMigrate` creating a unique index directly on an existing, potentially-already-duplicate table is the exact failure mode this repo's established pattern avoids.

- **Password-reset timing oracle.** The known-account path synchronously dialed and sent the SMTP email (a real network round-trip) before returning, while an unknown/blocked/SSO-managed address returned after a single fast DB lookup — response bodies were already identical, but the latency difference let an attacker enumerate valid accounts. The issue+deliver step now runs detached in the background (`DetachedAuditContext`, the same fire-and-forget pattern already used elsewhere for post-response audit work), so the function returns at the same speed regardless of whether the email exists.

**Scope note:** if an install already has live duplicate emails/external_ids, the `CREATE UNIQUE INDEX` statement fails loud at migration time rather than silently leaving the gap open — matching this repo's existing username/group-name migrations' behavior for the same pre-existing-duplicate risk class.

## Test plan
- [x] New regression test: a partial unique index rejects a second live user sharing an email; a soft-deleted user's email is reusable; multiple live users with no email don't collide.
- [x] New regression test: same for `external_id` (SCIM/IdP identifier).
- [x] New regression test: `RequestPasswordReset` returns promptly for a known email even when delivery is deliberately slow (a blocking fake deliverer), proving delivery no longer blocks the response.
- [x] Existing `TestRequestPasswordReset` suite updated to synchronize with the now-async delivery (was racing before) and passes under `-race -count=5`.
- [x] Full test suite: `go test ./internal/... ./server/...` — all green; `go test ./internal/core/... -race` — clean.
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues.
- [x] `GOWORK=off go build -C operator ./...` — operator module unaffected, builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)