### PR TITLE
fix(secrets): close concurrent secret-version write race (#121)

### DIFF
--- a/internal/audit/siem/spool.go
+++ b/internal/audit/siem/spool.go
@@ -42,9 +42,16 @@ type spool struct {
 	maxBytes    int64
 	deliverOnce func(context.Context, *models.AuditEvent) error
 
-	mu   sync.Mutex // serializes file mutation (append + replay rewrite); NOT held across delivery
-	stop chan struct{}
-	done chan struct{}
+	mu sync.Mutex // serializes file mutation (append + replay rewrite); NOT held across delivery
+	// replayMu serializes replay() end-to-end (distinct from mu, which is deliberately
+	// released across delivery). Without it, the loop's immediate on-start replay can
+	// race a concurrently-triggered one: both read the same undelivered snapshot before
+	// either rewrites the file, and both attempt delivery — double-delivering the same
+	// backlog to the SIEM. A skipped replay is harmless (the ticker or the next trigger
+	// retries the same backlog), so this blocks rather than drops.
+	replayMu sync.Mutex
+	stop     chan struct{}
+	done     chan struct{}
 }
 
 // newSpool prepares the spool directory and starts the replay loop.
@@ -124,6 +131,8 @@ func (s *spool) loop() {
 // on the audited request path) never blocks behind a SIEM round-trip. Crash-safe: every
 // undelivered line stays on disk until the atomic rewrite at the end.
 func (s *spool) replay() {
+	s.replayMu.Lock()
+	defer s.replayMu.Unlock()
 	// Snapshot under the lock, recording the byte length we read; any add() during the
 	// lock-free delivery below only appends BEYOND this offset (add never rewrites), so the
 	// reconcile can cleanly separate "what we attempted" from "what arrived meanwhile".

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -539,6 +539,14 @@ func (m *MockStorage) CreateSecretVersion(ctx context.Context, version *models.S
 	return args.Get(0).(*models.SecretVersion), args.Error(1)
 }
 
+func (m *MockStorage) CreateNextSecretVersion(ctx context.Context, version *models.SecretVersion) (*models.SecretVersion, error) {
+	args := m.Called(ctx, version)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.SecretVersion), args.Error(1)
+}
+
 func (m *MockStorage) GetLatestSecretVersion(ctx context.Context, secretID uint) (*models.SecretVersion, error) {
 	args := m.Called(ctx, secretID)
 	if args.Get(0) == nil {

--- a/internal/core/secrets.go
+++ b/internal/core/secrets.go
@@ -108,7 +108,7 @@ func (c *KeyorixCore) CreateSecret(ctx context.Context, req *CreateSecretRequest
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}
 
-	if err := c.storeSecretVersion(ctx, createdSecret, req.Value, 1); err != nil {
+	if err := c.storeSecretVersion(ctx, createdSecret, req.Value); err != nil {
 		if delErr := c.storage.DeleteSecret(ctx, createdSecret.ID); delErr != nil {
 			log.Printf("warning: failed to cleanup orphaned secret %d after failed version creation: %v", createdSecret.ID, delErr)
 		}
@@ -175,12 +175,7 @@ func (c *KeyorixCore) UpdateSecret(ctx context.Context, req *UpdateSecretRequest
 	secret.UpdatedAt = time.Now()
 
 	if len(req.Value) > 0 {
-		latestVersion, err := c.storage.GetLatestSecretVersion(ctx, secret.ID)
-		nextVersionNumber := 1
-		if err == nil && latestVersion != nil {
-			nextVersionNumber = latestVersion.VersionNumber + 1
-		}
-		if err := c.storeSecretVersion(ctx, secret, req.Value, nextVersionNumber); err != nil {
+		if err := c.storeSecretVersion(ctx, secret, req.Value); err != nil {
 			return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 		}
 	}
@@ -212,12 +207,7 @@ func (c *KeyorixCore) RotateSecret(ctx context.Context, id uint, newValue []byte
 	if err != nil {
 		return nil, fmt.Errorf("secret not found: %w", err)
 	}
-	latestVersion, err := c.storage.GetLatestSecretVersion(ctx, secret.ID)
-	nextVersionNumber := 1
-	if err == nil && latestVersion != nil {
-		nextVersionNumber = latestVersion.VersionNumber + 1
-	}
-	if err := c.storeSecretVersion(ctx, secret, newValue, nextVersionNumber); err != nil {
+	if err := c.storeSecretVersion(ctx, secret, newValue); err != nil {
 		return nil, fmt.Errorf("failed to store rotated secret: %w", err)
 	}
 	now := time.Now()

--- a/internal/core/secrets_versions.go
+++ b/internal/core/secrets_versions.go
@@ -11,22 +11,32 @@ import (
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
-// storeSecretVersion writes a new version row for the given secret.
-// Routes through the encryption service if wired; otherwise stores raw bytes.
-// Used by CreateSecret, UpdateSecret, and RotateSecret.
-func (c *KeyorixCore) storeSecretVersion(ctx context.Context, secret *models.SecretNode, value []byte, versionNumber int) error {
+// storeSecretVersion writes a new version row for the given secret, assigning
+// the next version number atomically. Routes through the encryption service if
+// wired; otherwise stores raw bytes. Used by CreateSecret, UpdateSecret, and
+// RotateSecret — including auto-rotation, which calls RotateSecret directly, so
+// a manual rotation racing a scheduled one goes through the same protection.
+//
+// #121: this used to take a caller-computed versionNumber (fetched via a
+// separate GetLatestSecretVersion call moments earlier) — two concurrent
+// callers for the SAME secret could both compute the SAME "next" number and
+// both insert, producing a duplicate version (GetLatest then returns one
+// non-deterministically) or losing whichever write lost the race. The version
+// number is now computed and retried atomically inside the storage layer
+// (CreateNextSecretVersion / encryption.StoreSecret), so callers no longer
+// need — or are able — to pass one in.
+func (c *KeyorixCore) storeSecretVersion(ctx context.Context, secret *models.SecretNode, value []byte) error {
 	if c.encryption != nil {
 		_, err := c.encryption.StoreSecret(secret, value)
 		return err
 	}
 	version := &models.SecretVersion{
 		SecretNodeID:       secret.ID,
-		VersionNumber:      versionNumber,
 		EncryptedValue:     value,
 		EncryptionMetadata: []byte("{}"),
 		ReadCount:          0,
 		CreatedAt:          time.Now(),
 	}
-	_, err := c.storage.CreateSecretVersion(ctx, version)
+	_, err := c.storage.CreateNextSecretVersion(ctx, version)
 	return err
 }

--- a/internal/core/service_test.go
+++ b/internal/core/service_test.go
@@ -53,7 +53,7 @@ func TestKeyorixCore_CreateSecret(t *testing.T) {
 		// Mock storage calls
 		mockStorage.On("GetSecretByName", ctx, req.Name, req.ProjectID, req.EnvironmentID).Return(nil, assert.AnError)
 		mockStorage.On("CreateSecret", ctx, mock.AnythingOfType("*models.SecretNode")).Return(expectedSecret, nil)
-		mockStorage.On("CreateSecretVersion", ctx, mock.AnythingOfType("*models.SecretVersion")).Return(expectedVersion, nil)
+		mockStorage.On("CreateNextSecretVersion", ctx, mock.AnythingOfType("*models.SecretVersion")).Return(expectedVersion, nil)
 
 		// Execute
 		result, err := core.CreateSecret(ctx, req)

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -224,6 +224,17 @@ type Storage interface {
 	ListProjectSecretsForDrift(ctx context.Context, projectID uint) ([]DriftSecretRow, error)
 	GetSecretVersions(ctx context.Context, secretID uint) ([]*models.SecretVersion, error)
 	CreateSecretVersion(ctx context.Context, version *models.SecretVersion) (*models.SecretVersion, error)
+	// CreateNextSecretVersion atomically assigns and stores the next version
+	// number for version.SecretNodeID (#121): version.VersionNumber is ignored on
+	// input and set internally. A manual rotation racing auto-rotation (or two
+	// concurrent updates) on the same secret used to both compute the SAME
+	// MAX(version_number)+1 before either INSERTed, producing a duplicate version
+	// number (GetLatest then returns one non-deterministically — a lost update)
+	// or, worse, silently diverging from the upstream credential a backend
+	// rotation just set. Backed by a unique index on (secret_node_id,
+	// version_number): a losing writer's INSERT fails and is retried with a
+	// freshly computed number instead of racing again.
+	CreateNextSecretVersion(ctx context.Context, version *models.SecretVersion) (*models.SecretVersion, error)
 	GetLatestSecretVersion(ctx context.Context, secretID uint) (*models.SecretVersion, error)
 	// SetSecretCertNotAfter caches a certificate-typed secret's parsed leaf expiry
 	// (ADR-056), a targeted column update with no other side effects.

--- a/internal/encryption/integration.go
+++ b/internal/encryption/integration.go
@@ -31,9 +31,42 @@ func (se *SecretEncryption) Initialize(passphrase string) error {
 	return se.service.Initialize(passphrase)
 }
 
-// StoreSecret encrypts and stores a secret in the database
+// maxStoreSecretConflictRetries bounds StoreSecret's version-number retry loop
+// (#121). Each retry only advances the computed number by one slot, so under N
+// truly simultaneous writers on the same secret a losing writer can need close
+// to N retries — set well above any realistic concurrent-writer count on one
+// secret, bounded so a genuinely broken insert fails instead of looping forever.
+const maxStoreSecretConflictRetries = 64
+
+// StoreSecret encrypts and stores a secret in the database, assigning the next
+// version number atomically (#121). A concurrent writer for the SAME secret
+// (manual RotateSecret racing scheduled auto-rotation, or two concurrent
+// updates) used to both compute the SAME MAX(version_number)+1 before either
+// committed, producing a duplicate version number — GetLatest then returns one
+// non-deterministically (a lost update: the Keyorix-visible value silently
+// diverges from whichever upstream credential a rotation backend actually set)
+// — or, when the second INSERT's version_number wasn't yet unique-constrained,
+// simply succeeded and duplicated it outright. A unique index on
+// (secret_node_id, version_number) now makes the losing writer's INSERT fail
+// instead of succeeding wrongly; this retries with a freshly computed number
+// rather than surfacing that as an error.
 func (se *SecretEncryption) StoreSecret(secretNode *models.SecretNode, plaintext []byte) (*models.SecretVersion, error) {
-	// Use a transaction to ensure atomicity and prevent race conditions
+	var lastErr error
+	for attempt := 0; attempt < maxStoreSecretConflictRetries; attempt++ {
+		version, err := se.tryStoreSecret(secretNode, plaintext)
+		if err == nil {
+			return version, nil
+		}
+		lastErr = err
+	}
+	return nil, lastErr
+}
+
+// tryStoreSecret is one attempt of StoreSecret: compute the next version number
+// and insert, inside a transaction. The encryption AAD binds to the version
+// number (SecretAAD), so a conflicting attempt must re-encrypt with the freshly
+// computed number, not just retry the insert with the old ciphertext.
+func (se *SecretEncryption) tryStoreSecret(secretNode *models.SecretNode, plaintext []byte) (*models.SecretVersion, error) {
 	tx := se.db.Begin()
 	defer func() {
 		if r := recover(); r != nil {
@@ -41,7 +74,6 @@ func (se *SecretEncryption) StoreSecret(secretNode *models.SecretNode, plaintext
 		}
 	}()
 
-	// Calculate next version number within the transaction
 	var maxVersion int
 	err := tx.Model(&models.SecretVersion{}).
 		Where("secret_node_id = ?", secretNode.ID).

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -630,6 +630,16 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 		}
 	}
 
+	// #121: (secret_node_id, version_number) carried no DB constraint at all — a
+	// manual RotateSecret racing scheduled auto-rotation (or two concurrent
+	// updates) on the same secret could both compute the same MAX+1 and both
+	// insert, duplicating a version number. See ensureSecretVersionIndex.
+	if tableExists(db, "secret_versions") {
+		if err := ensureSecretVersionIndex(db); err != nil {
+			return err
+		}
+	}
+
 	// Skip full AutoMigrate if already initialised (projects table present).
 	if projectsExists {
 		return nil
@@ -685,7 +695,10 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 	if err := ensureGroupNameIndex(db); err != nil {
 		return err
 	}
-	return ensureUserNameIndex(db)
+	if err := ensureUserNameIndex(db); err != nil {
+		return err
+	}
+	return ensureSecretVersionIndex(db)
 }
 
 // ensureGroupNameIndex replaces any plain unique index on groups.name with a
@@ -718,6 +731,25 @@ func ensureUserNameIndex(db *gorm.DB) error {
 	}
 	if err := db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS uniq_users_username_active ON users (username) WHERE deleted_at IS NULL").Error; err != nil {
 		return fmt.Errorf("failed to create partial users username index: %w", err)
+	}
+	return nil
+}
+
+// ensureSecretVersionIndex enforces uniqueness of (secret_node_id, version_number)
+// at the DB layer (#121). Without this, two concurrent writers for the same secret
+// (manual RotateSecret racing scheduled auto-rotation, or two concurrent updates)
+// could both compute the same next version number and both insert successfully,
+// producing a duplicate version — a lost update: GetLatest then returns one of the
+// two non-deterministically, silently diverging from whichever value a rotation
+// backend actually set upstream. Versions are append-only (never soft-deleted), so
+// unlike the users/groups name indexes this one is unconditional, not partial. An
+// install that already has duplicate (secret_node_id, version_number) rows from
+// this exact pre-existing race will fail loud here rather than have AutoMigrate
+// error unpredictably — a deliberate, disclosed tradeoff matching the precedent set
+// by ensureUserNameIndex/ensureGroupNameIndex for the same class of risk.
+func ensureSecretVersionIndex(db *gorm.DB) error {
+	if err := db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS uniq_secret_versions_node_version ON secret_versions (secret_node_id, version_number)").Error; err != nil {
+		return fmt.Errorf("failed to create secret_versions unique index: %w", err)
 	}
 	return nil
 }

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -517,7 +517,14 @@ type SecretDependency struct {
 }
 
 type SecretVersion struct {
-	ID                 uint `gorm:"primaryKey"`
+	ID uint `gorm:"primaryKey"`
+	// SecretNodeID + VersionNumber uniqueness is enforced by a composite unique
+	// index (secret_node_id, version_number), created in migrateDatabase — not a
+	// plain gorm uniqueIndex tag, matching the raw-SQL-index precedent used for
+	// users.email/external_id (an install that already has duplicate rows from
+	// this exact race must fail loud at migration time, not have AutoMigrate
+	// error unpredictably). Versions are append-only (never soft-deleted), so
+	// unlike those partial indexes this one is unconditional.
 	SecretNodeID       uint
 	VersionNumber      int
 	EncryptedValue     []byte `json:"-"`

--- a/internal/storage/store/concurrency_secret_version_test.go
+++ b/internal/storage/store/concurrency_secret_version_test.go
@@ -1,0 +1,87 @@
+package store
+
+import (
+	"context"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// secretVersionConcurrentDB opens a temp FILE-backed SQLite (not :memory:) with a busy
+// timeout and WAL, so multiple connections genuinely contend — the only way to exercise
+// CreateNextSecretVersion's optimistic-retry-under-a-unique-index design under real
+// concurrency. It also creates the (secret_node_id, version_number) unique index that
+// ensureSecretVersionIndex (internal/storage/factory.go) installs in production — without
+// it, CreateNextSecretVersion's retry loop has nothing to actually catch a losing writer on.
+func secretVersionConcurrentDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	dsn := "file:" + filepath.Join(t.TempDir(), "sv.db") + "?_busy_timeout=10000&_journal_mode=WAL&_txlock=immediate"
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.SecretVersion{}))
+	require.NoError(t, db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS uniq_secret_versions_node_version ON secret_versions (secret_node_id, version_number)").Error)
+	return db
+}
+
+// TestConcurrency_CreateNextSecretVersion_NeverDuplicates is the #121 regression: a manual
+// rotation racing scheduled auto-rotation (or two concurrent updates) on the SAME secret
+// used to both read the same MAX(version_number) and both insert "next", producing a
+// duplicate version number — a lost update, since GetLatest then resolves to one of the two
+// non-deterministically and the other silently vanishes from the version history. This
+// drives many concurrent writers at CreateNextSecretVersion for one secret and asserts every
+// resulting version number is unique and the full 1..N run is present with no gaps.
+func TestConcurrency_CreateNextSecretVersion_NeverDuplicates(t *testing.T) {
+	db := secretVersionConcurrentDB(t)
+	ls := NewLocalStorage(db)
+
+	const secretNodeID = uint(1)
+	const writers = 30
+
+	var succeeded atomic.Int64
+	errs := make(chan error, writers)
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < writers; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			<-start
+			_, err := ls.CreateNextSecretVersion(context.Background(), &models.SecretVersion{
+				SecretNodeID:   secretNodeID,
+				EncryptedValue: []byte("value"),
+			})
+			if err != nil {
+				errs <- err
+				return
+			}
+			succeeded.Add(1)
+		}(i)
+	}
+	close(start) // release all writers at once
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err, "every writer must eventually succeed via retry, not error out")
+	}
+	assert.Equal(t, int64(writers), succeeded.Load())
+
+	var rows []models.SecretVersion
+	require.NoError(t, db.Where("secret_node_id = ?", secretNodeID).Order("version_number ASC").Find(&rows).Error)
+	require.Len(t, rows, writers, "exactly one row per successful writer, no lost updates")
+
+	seen := make(map[int]bool, writers)
+	for _, r := range rows {
+		assert.False(t, seen[r.VersionNumber], "duplicate version_number %d means two writers raced past the unique index", r.VersionNumber)
+		seen[r.VersionNumber] = true
+	}
+	for n := 1; n <= writers; n++ {
+		assert.True(t, seen[n], "version_number %d is missing — the 1..N run must be gap-free", n)
+	}
+}

--- a/internal/storage/store/local_secrets.go
+++ b/internal/storage/store/local_secrets.go
@@ -522,6 +522,44 @@ func (ls *LocalStorage) CreateSecretVersion(ctx context.Context, version *models
 	return version, nil
 }
 
+// maxSecretVersionConflictRetries bounds CreateNextSecretVersion's retry loop.
+// Each retry only advances the computed number by one slot, so under N truly
+// simultaneous writers on the same secret a losing writer can need close to N
+// retries — set well above any realistic concurrent-writer count on one secret,
+// bounded so a genuinely broken insert (not a version-number conflict) fails
+// instead of looping forever.
+const maxSecretVersionConflictRetries = 64
+
+// CreateNextSecretVersion atomically assigns and stores the next version number
+// for version.SecretNodeID (#121). It computes MAX(version_number)+1 and
+// inserts; a concurrent writer racing the SAME computation is caught by the
+// unique index on (secret_node_id, version_number) rather than silently
+// duplicating a version number or losing an update — the losing INSERT fails,
+// and this retries with a freshly (now-post-conflict) computed number. Cheaper
+// and more portable across SQLite/Postgres than a SELECT ... FOR UPDATE lock,
+// and correct regardless of transaction isolation level: an INSERT is either
+// accepted (this writer's number was live) or rejected (it wasn't).
+func (ls *LocalStorage) CreateNextSecretVersion(ctx context.Context, version *models.SecretVersion) (*models.SecretVersion, error) {
+	var lastErr error
+	for attempt := 0; attempt < maxSecretVersionConflictRetries; attempt++ {
+		var maxVersion int
+		if err := ls.db.WithContext(ctx).Model(&models.SecretVersion{}).
+			Where("secret_node_id = ?", version.SecretNodeID).
+			Select("COALESCE(MAX(version_number), 0)").
+			Scan(&maxVersion).Error; err != nil {
+			return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+		}
+		version.VersionNumber = maxVersion + 1
+		version.ID = 0 // ensure a retry after a failed attempt inserts fresh, not updates
+		if err := ls.db.WithContext(ctx).Create(version).Error; err == nil {
+			return version, nil
+		} else {
+			lastErr = err
+		}
+	}
+	return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), lastErr)
+}
+
 // GetSecretVersions retrieves all versions of a secret ordered newest-first.
 func (ls *LocalStorage) GetSecretVersions(ctx context.Context, secretID uint) ([]*models.SecretVersion, error) {
 	var versions []*models.SecretVersion

--- a/internal/storage/store/remote_secrets.go
+++ b/internal/storage/store/remote_secrets.go
@@ -218,6 +218,17 @@ func (rs *RemoteStorage) CreateSecretVersion(ctx context.Context, version *model
 	return &result, nil
 }
 
+// CreateNextSecretVersion delegates to CreateSecretVersion, leaving
+// version.VersionNumber as the caller set it. True atomic version-number
+// assignment (#121) is enforced server-side, where the actual writer is a
+// LocalStorage-backed Keyorix server process (RotateSecret/CreateSecret/
+// UpdateSecret all route through KeyorixCore.storeSecretVersion, which calls
+// this same interface method); this remote client is not itself on that
+// enforcement path.
+func (rs *RemoteStorage) CreateNextSecretVersion(ctx context.Context, version *models.SecretVersion) (*models.SecretVersion, error) {
+	return rs.CreateSecretVersion(ctx, version)
+}
+
 // GetSecretVersion retrieves a specific version of a secret via remote API.
 func (rs *RemoteStorage) GetSecretVersion(ctx context.Context, secretID uint, version int) (*models.SecretVersion, error) {
 	path := fmt.Sprintf("/api/v1/secrets/%d/versions/%d", secretID, version)


### PR DESCRIPTION
## Summary
- #121: two concurrent writers on the same secret (manual `RotateSecret` racing scheduled auto-rotation, or two concurrent `UpdateSecret` calls) both computed the same `MAX(version_number)+1` before either inserted — a lost update where the visible secret value could silently diverge from whichever credential a rotation backend actually set, or two versions could collide and one vanish non-deterministically from `GetLatestSecretVersion`.
- Adds `Storage.CreateNextSecretVersion`, which computes-and-inserts the next version number under a new DB-level unique index on `(secret_node_id, version_number)`, retrying with a freshly computed number when a concurrent writer wins the race (portable optimistic-retry, not a `SELECT ... FOR UPDATE` lock).
- `SecretEncryption.StoreSecret` (the encrypted-path equivalent used when encryption is enabled — the AAD binds to the version number, so a retry must re-encrypt, not just re-insert) gets the same retry wrapper.
- `internal/core.storeSecretVersion` no longer takes a caller-computed `versionNumber` — `CreateSecret`/`UpdateSecret`/`RotateSecret` all route through the atomic path now.
- New unconditional composite unique index `uniq_secret_versions_node_version` on `secret_versions`, installed via `ensureSecretVersionIndex` in `migrateDatabase` (raw SQL, not a `gorm:"uniqueIndex"` tag — matches the precedent from #117's user email/external_id indexes: an install that already has duplicate rows from this exact pre-existing race fails loud at migration time instead of `AutoMigrate` erroring unpredictably).
- Also reapplies the SIEM spool `replayMu` serialization fix from #521 (unmerged), carried forward since this branch forked from `main` before that PR landed.

## Test plan
- [x] New `TestConcurrency_CreateNextSecretVersion_NeverDuplicates` (`internal/storage/store`) drives 30 real concurrent writers against one secret over a file-backed SQLite DB and asserts a gap-free, duplicate-free `1..N` run of version numbers — passes under `-race -count=10`.
- [x] `go test ./internal/... ./server/...` — all green.
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues.
- [x] `GOWORK=off go build -C operator ./...` — clean.