### PR TITLE
fix(anomaly): close 5 detector blind spots (#101)

### DIFF
--- a/internal/config/anomaly_config_test.go
+++ b/internal/config/anomaly_config_test.go
@@ -1,0 +1,17 @@
+package config
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAnomalyAlertsConfig_GetBaselineQuarantine(t *testing.T) {
+	assert.Equal(t, 24*time.Hour, AnomalyAlertsConfig{}.GetBaselineQuarantine(), "default when unset")
+	assert.Equal(t, 24*time.Hour, AnomalyAlertsConfig{BaselineQuarantine: "garbage"}.GetBaselineQuarantine(), "unparseable falls back")
+	assert.Equal(t, 6*time.Hour, AnomalyAlertsConfig{BaselineQuarantine: "6h"}.GetBaselineQuarantine())
+	// "0"/"0s" is an explicit opt-out, not "unset" — must NOT fall back to the default.
+	assert.Equal(t, time.Duration(0), AnomalyAlertsConfig{BaselineQuarantine: "0"}.GetBaselineQuarantine())
+	assert.Equal(t, time.Duration(0), AnomalyAlertsConfig{BaselineQuarantine: "0s"}.GetBaselineQuarantine())
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1240,6 +1240,24 @@ type AnomalyAlertsConfig struct {
 	// BusinessHours configures the timezone and band the off_hours rule uses. Unset =
 	// the legacy UTC 22:00–06:00 default.
 	BusinessHours AnomalyBusinessHoursConfig `yaml:"business_hours"`
+	// BaselineQuarantine is how long an IP/user must be observed before the live scan
+	// window before it is trusted as "known" baseline (#101) — see
+	// AnomalyDetector.SetBaselineQuarantine. Go duration string (e.g. "24h"); unset
+	// keeps the 24h default. An explicit "0" or "0s" disables quarantine.
+	BaselineQuarantine string `yaml:"baseline_quarantine"`
+}
+
+// GetBaselineQuarantine returns the parsed BaselineQuarantine duration; defaults to 24h.
+// A configured zero duration ("0", "0s") is honored as an explicit opt-out rather than
+// falling back to the default, since Go's ParseDuration("0") succeeds with d == 0.
+func (c AnomalyAlertsConfig) GetBaselineQuarantine() time.Duration {
+	if c.BaselineQuarantine == "" {
+		return 24 * time.Hour
+	}
+	if d, err := time.ParseDuration(c.BaselineQuarantine); err == nil && d >= 0 {
+		return d
+	}
+	return 24 * time.Hour
 }
 
 // AnomalyBusinessHoursConfig defines when secret access counts as "off hours" for the
@@ -1264,7 +1282,11 @@ type AnomalyMLConfig struct {
 	Threshold  float64 `yaml:"threshold"`   // anomaly-score cutoff (0.5,1.0); default 0.60
 	NumTrees   int     `yaml:"num_trees"`   // ensemble size; default 100
 	SampleSize int     `yaml:"sample_size"` // per-tree subsample (psi); default 256
-	Seed       int64   `yaml:"seed"`        // RNG seed for reproducible scoring; default 1
+	// Seed, if set, pins the Isolation Forest's RNG for reproducible scoring (e.g. to
+	// diff forest behavior across a config change). Unset (0) draws a fresh
+	// crypto/rand-sourced seed per process instead of a fixed constant, so the forest
+	// structure isn't predictable from source (#101).
+	Seed int64 `yaml:"seed"`
 }
 
 // GetInterval returns the anomaly scan/alert interval (Go duration); defaults to 1h.

--- a/internal/core/anomaly.go
+++ b/internal/core/anomaly.go
@@ -21,14 +21,28 @@ type AnomalyDetector struct {
 	// — a coverage blind spot when the operator sets a scan cadence longer than the
 	// default. Defaults to 1h; SetLookback raises it to match the configured interval.
 	lookback time.Duration
+	// quarantine is how long an IP/user must have been observed before the live window
+	// before buildBaseline trusts it as "known" (#101). Without this, an attacker's IP
+	// ages into the baseline after just one lookback interval (as little as 1h) — the
+	// very next pass sees it as historical and the new_ip/new_user rules go silent.
+	// Requiring sustained presence for `quarantine` before promotion raises the cost of
+	// that evasion from one pass to a sustained, repeatedly-observed presence.
+	quarantine time.Duration
 }
 
 // minDetectionLookback is the floor for the per-pass scan window.
 const minDetectionLookback = time.Hour
 
+// defaultBaselineQuarantine is how long a newly observed IP/user must have been present
+// before buildBaseline promotes it to "known" — see AnomalyDetector.quarantine.
+const defaultBaselineQuarantine = 24 * time.Hour
+
 // StorageInterface is satisfied by *storage.LocalStorage and *storage.RemoteStorage.
 type StorageInterface = interface {
 	ListSecretAccessLogs(ctx context.Context, secretID uint, since time.Time) ([]models.SecretAccessLog, error)
+	// PrincipalSecretFirstSeen backs the per-principal breadth-exfiltration pass
+	// (#101): see internal/core/storage.Storage's doc comment for the full rationale.
+	PrincipalSecretFirstSeen(ctx context.Context, since time.Time) (map[string]map[uint]time.Time, error)
 	CreateAnomalyAlert(ctx context.Context, alert *models.AnomalyAlert) error
 	ListAnomalyAlerts(ctx context.Context, acknowledged *bool) ([]models.AnomalyAlert, error)
 	AcknowledgeAnomalyAlert(ctx context.Context, id uint) error
@@ -45,10 +59,24 @@ func (d *AnomalyDetector) SetLookback(window time.Duration) {
 	d.lookback = window
 }
 
-// NewAnomalyDetector creates a new AnomalyDetector with the ML pass disabled and the
-// off-hours window at its UTC 22:00–06:00 default.
+// SetBaselineQuarantine overrides how long an IP/user must be observed before the live
+// window before it is trusted as "known" baseline (see AnomalyDetector.quarantine). A
+// non-positive value disables quarantine (only the live window itself is excluded,
+// the pre-#101 behaviour) — accepted as an explicit opt-out, not silently floored.
+func (d *AnomalyDetector) SetBaselineQuarantine(window time.Duration) {
+	d.quarantine = window
+}
+
+// NewAnomalyDetector creates a new AnomalyDetector with the ML pass disabled, the
+// off-hours window at its UTC 22:00–06:00 default, and the baseline quarantine at its
+// 24h default.
 func NewAnomalyDetector(storage StorageInterface) *AnomalyDetector {
-	return &AnomalyDetector{storage: storage, offHours: defaultOffHoursPolicy(), lookback: minDetectionLookback}
+	return &AnomalyDetector{
+		storage:    storage,
+		offHours:   defaultOffHoursPolicy(),
+		lookback:   minDetectionLookback,
+		quarantine: defaultBaselineQuarantine,
+	}
 }
 
 // SetMLConfig enables (or reconfigures) the Isolation Forest pass. Defaults are
@@ -142,7 +170,13 @@ func (d *AnomalyDetector) RunDetection(ctx context.Context, secrets []models.Sec
 
 	var failures int
 	for _, secret := range secrets {
-		// Build 30-day baseline
+		// Build 30-day baseline. A secret with NO baseline history (brand new, or
+		// unread in 30 days) used to be skipped entirely here — off_hours and
+		// frequency_spike included — which is exactly the blind spot an attacker
+		// deliberately targeting a freshly-provisioned, never-accessed secret would
+		// exploit. Proceed with an empty baseline instead; detectAnomalies still
+		// flags off-hours access, and now also flags first-ever new_ip/new_user
+		// (see detectAnomalies for how severity is scaled down for that case).
 		baselineLogs, err := d.storage.ListSecretAccessLogs(ctx, secret.ID, baselineWindow)
 		if err != nil {
 			// #365: the aggregate failure count below already surfaces a non-nil error to
@@ -154,10 +188,7 @@ func (d *AnomalyDetector) RunDetection(ctx context.Context, secrets []models.Sec
 			failures++
 			continue
 		}
-		if len(baselineLogs) == 0 {
-			continue
-		}
-		baseline := buildBaseline(baselineLogs, now, window)
+		baseline := buildBaseline(baselineLogs, now, window, d.quarantine)
 
 		// Get recent accesses over the lookback window.
 		recentLogs, err := d.storage.ListSecretAccessLogs(ctx, secret.ID, window)
@@ -199,10 +230,78 @@ func (d *AnomalyDetector) RunDetection(ctx context.Context, secrets []models.Sec
 			}
 		}
 	}
+
+	// Per-principal aggregate (#101): a principal reading many DIFFERENT secrets it has
+	// never touched before is invisible to every rule above — each is scoped to a single
+	// secret's own baseline, so the same breadth-exfiltrating principal looks merely
+	// "new" to N separate secrets rather than triggering one aggregate signal. Runs once
+	// per pass across all secrets, not per secret.
+	breadthAlerts, err := detectPrincipalBreadth(ctx, d.storage, now, window, baselineWindow)
+	if err != nil {
+		failures++
+	}
+	for _, alert := range breadthAlerts {
+		if err := d.storage.CreateAnomalyAlert(ctx, &alert); err != nil {
+			failures++
+		}
+	}
+
 	if failures > 0 {
 		return fmt.Errorf("anomaly detection completed with %d storage failure(s) — some alerts may not have been recorded", failures)
 	}
 	return nil
+}
+
+const (
+	// principalBreadthMinNewSecrets is the minimum count of distinct secrets a
+	// principal must access in the live window — NONE of which it touched during the
+	// 30-day baseline — before a principal_breadth alert fires. Catches breadth
+	// exfiltration (many different secrets each read once) that the per-secret rules
+	// structurally cannot see.
+	principalBreadthMinNewSecrets = 5
+	// principalBreadthHighMultiplier: at or above principalBreadthMinNewSecrets times
+	// this multiplier, the alert is "high" severity rather than "medium".
+	principalBreadthHighMultiplier = 2
+)
+
+// detectPrincipalBreadth aggregates access logs by principal (not by secret) over the
+// 30-day baseline and flags a principal whose EARLIEST-ever access to an unusually high
+// number of secrets falls inside the live scan window — the per-secret rules never see
+// this, since each secret only observes "one access from a possibly-new actor." The
+// live-window boundary is applied here in Go against a real time.Time, not pushed into
+// the storage query's SQL bound — see PrincipalSecretFirstSeen's doc comment for why.
+func detectPrincipalBreadth(ctx context.Context, s StorageInterface, now, windowStart, baselineWindow time.Time) ([]models.AnomalyAlert, error) {
+	firstSeen, err := s.PrincipalSecretFirstSeen(ctx, baselineWindow)
+	if err != nil {
+		return nil, err
+	}
+
+	var alerts []models.AnomalyAlert
+	for principal, secrets := range firstSeen {
+		newCount := 0
+		for _, t := range secrets {
+			if !t.Before(windowStart) { // first ever access to this secret falls in the live window
+				newCount++
+			}
+		}
+		if newCount < principalBreadthMinNewSecrets {
+			continue
+		}
+		severity := "medium"
+		if newCount >= principalBreadthMinNewSecrets*principalBreadthHighMultiplier {
+			severity = "high"
+		}
+		alerts = append(alerts, models.AnomalyAlert{
+			AlertType: "principal_breadth",
+			Severity:  severity,
+			Description: fmt.Sprintf(
+				"%s accessed %d distinct secrets with no prior access history in the last scan window — possible breadth exfiltration",
+				principal, newCount),
+			AccessedBy: principal,
+			DetectedAt: now,
+		})
+	}
+	return alerts, nil
 }
 
 // logsBefore returns the access logs that occurred strictly before t, preserving
@@ -225,12 +324,22 @@ func logsBefore(logs []models.SecretAccessLog, t time.Time) []models.SecretAcces
 // or user would already appear in knownIPs/knownUsers and the new_ip / new_user rules
 // could never fire. Excluding the window also keeps the volume baseline (dailyAvg)
 // from inflating itself with the very burst a spike check is meant to catch.
-func buildBaseline(logs []models.SecretAccessLog, now, windowStart time.Time) accessBaseline {
+//
+// quarantine additionally withholds knownIPs/knownUsers promotion for accesses that,
+// while before the live window, are still more recent than `quarantine` (#101): without
+// this, an IP/user first observed in pass N is already "known" by pass N+1 — as little
+// as one lookback interval later — so an attacker's IP self-poisons the baseline and
+// stops triggering new_ip/new_user after a single successful access. Requiring an
+// access to predate `windowStart - quarantine`, not just `windowStart`, means an IP/user
+// must be observed continuously for the full quarantine period before it is trusted.
+// dailyAvg is unaffected by quarantine — it measures volume trend, not identity trust.
+func buildBaseline(logs []models.SecretAccessLog, now, windowStart time.Time, quarantine time.Duration) accessBaseline {
 	b := accessBaseline{
 		knownIPs:   make(map[string]bool),
 		knownUsers: make(map[string]bool),
 	}
 	sevenDaysAgo := now.Add(-7 * 24 * time.Hour)
+	trustCutoff := windowStart.Add(-quarantine)
 	recentCount := 0
 
 	for _, log := range logs {
@@ -238,14 +347,17 @@ func buildBaseline(logs []models.SecretAccessLog, now, windowStart time.Time) ac
 		if !log.AccessTime.Before(windowStart) {
 			continue
 		}
+		if log.AccessTime.After(sevenDaysAgo) {
+			recentCount++
+		}
+		if !log.AccessTime.Before(trustCutoff) {
+			continue // observed too recently to be trusted yet — still in quarantine
+		}
 		if log.IPAddress != "" {
 			b.knownIPs[log.IPAddress] = true
 		}
 		if log.AccessedBy != "" {
 			b.knownUsers[log.AccessedBy] = true
-		}
-		if log.AccessTime.After(sevenDaysAgo) {
-			recentCount++
 		}
 	}
 	b.dailyAvg = float64(recentCount) / 7.0
@@ -271,28 +383,48 @@ func detectAnomalies(secret models.SecretNode, log models.SecretAccessLog, basel
 		})
 	}
 
-	// Rule 2: Access from unknown IP
-	if log.IPAddress != "" && !baseline.knownIPs[log.IPAddress] && len(baseline.knownIPs) > 0 {
+	// Rule 2: Access from unknown IP. An empty baseline (no prior history at all —
+	// bootstrap, or a brand-new secret) used to suppress this rule entirely (#101): a
+	// first-ever access from ANY IP was silently waved through with zero novelty
+	// signal, which is exactly what an attacker deliberately targeting a
+	// freshly-provisioned, never-accessed secret would rely on. It still fires, but at
+	// "low" severity when there is no established baseline to violate — an established
+	// pattern being violated (baseline non-empty) is a stronger signal than a secret's
+	// first-ever access being from some IP, which is unremarkable on its own but now at
+	// least visible and auditable rather than invisible.
+	if log.IPAddress != "" && !baseline.knownIPs[log.IPAddress] {
+		severity := "high"
+		desc := fmt.Sprintf("Secret accessed from unrecognised IP address: %s", log.IPAddress)
+		if len(baseline.knownIPs) == 0 {
+			severity = "low"
+			desc = fmt.Sprintf("Secret's first observed access is from IP address %s (no prior baseline to compare against)", log.IPAddress)
+		}
 		alerts = append(alerts, models.AnomalyAlert{
 			SecretNodeID: secret.ID,
 			SecretName:   secret.Name,
 			AlertType:    "new_ip",
-			Severity:     "high",
-			Description:  fmt.Sprintf("Secret accessed from unrecognised IP address: %s", log.IPAddress),
+			Severity:     severity,
+			Description:  desc,
 			AccessedBy:   log.AccessedBy,
 			IPAddress:    log.IPAddress,
 			DetectedAt:   now,
 		})
 	}
 
-	// Rule 3: Access by unknown user
-	if log.AccessedBy != "" && !baseline.knownUsers[log.AccessedBy] && len(baseline.knownUsers) > 0 {
+	// Rule 3: Access by unknown user — same empty-baseline reasoning as Rule 2.
+	if log.AccessedBy != "" && !baseline.knownUsers[log.AccessedBy] {
+		severity := "high"
+		desc := fmt.Sprintf("Secret accessed by user with no prior access history: %s", log.AccessedBy)
+		if len(baseline.knownUsers) == 0 {
+			severity = "low"
+			desc = fmt.Sprintf("Secret's first observed access is by user %s (no prior baseline to compare against)", log.AccessedBy)
+		}
 		alerts = append(alerts, models.AnomalyAlert{
 			SecretNodeID: secret.ID,
 			SecretName:   secret.Name,
 			AlertType:    "new_user",
-			Severity:     "high",
-			Description:  fmt.Sprintf("Secret accessed by user with no prior access history: %s", log.AccessedBy),
+			Severity:     severity,
+			Description:  desc,
 			AccessedBy:   log.AccessedBy,
 			IPAddress:    log.IPAddress,
 			DetectedAt:   now,
@@ -349,7 +481,8 @@ func (d *AnomalyDetector) ListAlerts(ctx context.Context, acknowledged *bool) ([
 }
 
 // FilterAlerts narrows a set of alerts to those matching the given severity
-// (low/medium/high) and/or alert type (off_hours/new_ip/new_user/frequency_spike).
+// (low/medium/high) and/or alert type (off_hours/new_ip/new_user/frequency_spike/
+// ml_outlier/principal_breadth).
 // An empty string for either is "no constraint", so FilterAlerts(a, "", "") == a.
 func FilterAlerts(alerts []models.AnomalyAlert, severity, alertType string) []models.AnomalyAlert {
 	if severity == "" && alertType == "" {

--- a/internal/core/anomaly_alerting_external_test.go
+++ b/internal/core/anomaly_alerting_external_test.go
@@ -166,6 +166,53 @@ func TestRunDetection_FlagsNewUserAndIPAgainstPriorBaseline(t *testing.T) {
 	assert.True(t, kinds["new_ip"], "a first-seen IP must raise new_ip")
 }
 
+// Regression (#101): a principal that reads many DIFFERENT secrets it has never
+// touched before — breadth exfiltration — must raise a principal_breadth alert, even
+// though each individual secret only sees one unremarkable access from that principal
+// (never crossing any single-secret threshold on its own).
+func TestRunDetection_DetectsPrincipalBreadthAcrossSecrets(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(&models.SecretNode{}, &models.SecretAccessLog{}, &models.AnomalyAlert{}))
+
+	ctx := context.Background()
+	var secrets []models.SecretNode
+	for i := uint(900); i < 906; i++ { // 6 secrets — above principalBreadthMinNewSecrets (5)
+		s := models.SecretNode{ID: i, ProjectID: 1, Name: "s", Status: "active", IsSecret: true}
+		require.NoError(t, h.DB.Create(&s).Error)
+		secrets = append(secrets, s)
+
+		// Established baseline for each secret: alice, well outside the quarantine window,
+		// so per-secret new_user does not also fire for alice and confound the assertion.
+		require.NoError(t, h.DB.Create(&models.SecretAccessLog{
+			SecretNodeID: s.ID, AccessedBy: "alice", Action: "read", IPAddress: "10.0.0.1",
+			AccessTime: time.Now().Add(-10 * 24 * time.Hour),
+		}).Error)
+	}
+
+	// mallory reads all 6 secrets ONCE each, right now — never touched any of them before.
+	for _, s := range secrets {
+		require.NoError(t, h.DB.Create(&models.SecretAccessLog{
+			SecretNodeID: s.ID, AccessedBy: "mallory", Action: "read", IPAddress: "203.0.113.5",
+			AccessTime: time.Now(),
+		}).Error)
+	}
+
+	detector := core.NewAnomalyDetector(h.CoreService.Storage())
+	require.NoError(t, detector.RunDetection(ctx, secrets))
+
+	alerts, err := detector.ListAlerts(ctx, nil)
+	require.NoError(t, err)
+	var breadth *models.AnomalyAlert
+	for i, a := range alerts {
+		if a.AlertType == "principal_breadth" && a.AccessedBy == "mallory" {
+			breadth = &alerts[i]
+		}
+	}
+	require.NotNil(t, breadth, "a principal reading 6 never-before-touched secrets must raise principal_breadth")
+	assert.Equal(t, "medium", breadth.Severity, "6 new secrets is below the high-severity multiplier (2x threshold = 10)")
+}
+
 // The compliance posture counts open (unacknowledged) anomalies, with a high-severity tally.
 func TestCompliancePosture_Anomalies(t *testing.T) {
 	h := testhelper.NewRBACTestHelper(t)

--- a/internal/core/anomaly_ml.go
+++ b/internal/core/anomaly_ml.go
@@ -1,9 +1,11 @@
 package core
 
 import (
+	"crypto/rand"
+	"encoding/binary"
 	"fmt"
 	"math"
-	"math/rand"
+	mathrand "math/rand"
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/storage/models"
@@ -53,8 +55,15 @@ type MLConfig struct {
 // tuned to this feature set's score distribution: with the low-dimensional access
 // features, normal accesses cluster near 0.5 and the genuinely rare tail reaches
 // ~0.65–0.8, so 0.60 cleanly separates them while staying clear of the noise floor.
-// A non-positive seed becomes a fixed constant so scoring stays deterministic across
-// restarts rather than drifting with wall-clock entropy.
+//
+// A non-positive seed is drawn from crypto/rand, not a fixed constant (#101): every
+// default deployment used to run an IDENTICAL, publicly-known-from-source forest
+// structure (seed=1), so an attacker who knew (or could infer) the training data could
+// precompute which subsamples/splits an access would land in and craft one that the
+// forest isolates poorly — i.e. tune an access to score low on purpose. An operator who
+// genuinely wants reproducible scoring (e.g. to diff forest behavior across a config
+// change) can still set Seed explicitly; only the *unset* default stops being a known
+// constant.
 func (c MLConfig) withDefaults() MLConfig {
 	if c.Threshold <= 0.5 || c.Threshold >= 1.0 {
 		c.Threshold = 0.60
@@ -66,9 +75,24 @@ func (c MLConfig) withDefaults() MLConfig {
 		c.SampleSize = 256
 	}
 	if c.Seed <= 0 {
-		c.Seed = 1
+		c.Seed = randomSeed()
 	}
 	return c
+}
+
+// randomSeed draws a positive int64 from crypto/rand for MLConfig's default seed. Falls
+// back to a time-based seed only if the OS CSPRNG is unavailable — vanishingly rare, and
+// still per-process-unique rather than a hardcoded constant.
+func randomSeed() int64 {
+	var buf [8]byte
+	if _, err := rand.Read(buf[:]); err != nil {
+		return time.Now().UnixNano()
+	}
+	v := int64(binary.BigEndian.Uint64(buf[:]) >> 1) // clear sign bit: always positive
+	if v <= 0 {
+		v = 1
+	}
+	return v
 }
 
 // accessFeatures turns one access-log entry into the feature vector the forest splits
@@ -123,7 +147,11 @@ func mlOutlierAlerts(secret models.SecretNode, baselineLogs, recentLogs []models
 		train[i] = accessFeatures(lg, ipFreq, userFreq)
 	}
 
-	rng := rand.New(rand.NewSource(cfg.Seed)) // #nosec G404 -- model sampling must be reproducible, not unpredictable; no security decision rides on this RNG
+	// #nosec G404 -- math/rand, seeded from cfg.Seed, drives tree-building sampling only;
+	// the seed itself is crypto/rand-sourced by default (see randomSeed), so an attacker
+	// cannot predict the forest structure. An explicitly configured seed opts back into
+	// deterministic-for-reproducibility behavior on purpose.
+	rng := mathrand.New(mathrand.NewSource(cfg.Seed))
 	forest := newIsolationForest(train, cfg.NumTrees, cfg.SampleSize, rng)
 	if forest == nil {
 		return nil

--- a/internal/core/anomaly_ml_test.go
+++ b/internal/core/anomaly_ml_test.go
@@ -8,13 +8,20 @@ import (
 )
 
 func TestMLConfigWithDefaults(t *testing.T) {
+	// #101: an unset seed is drawn from crypto/rand, not the fixed constant 1 — assert
+	// it's positive and non-deterministic across calls, not a specific value.
 	got := MLConfig{Enabled: true}.withDefaults()
-	if got.Threshold != 0.60 || got.NumTrees != 100 || got.SampleSize != 256 || got.Seed != 1 {
+	if got.Threshold != 0.60 || got.NumTrees != 100 || got.SampleSize != 256 || got.Seed <= 0 {
 		t.Fatalf("defaults not applied: %+v", got)
 	}
+	got2 := MLConfig{Enabled: true}.withDefaults()
+	if got.Seed == got2.Seed {
+		t.Fatalf("two unset-seed defaults collided (seed=%d) — the seed must not be a fixed constant", got.Seed)
+	}
+
 	// Out-of-range values are corrected; valid ones are kept.
 	got = MLConfig{Enabled: true, Threshold: 1.5, NumTrees: -3, SampleSize: 0, Seed: -1}.withDefaults()
-	if got.Threshold != 0.60 || got.NumTrees != 100 || got.SampleSize != 256 || got.Seed != 1 {
+	if got.Threshold != 0.60 || got.NumTrees != 100 || got.SampleSize != 256 || got.Seed <= 0 {
 		t.Fatalf("out-of-range not corrected: %+v", got)
 	}
 	got = MLConfig{Enabled: true, Threshold: 0.8, NumTrees: 50, SampleSize: 128, Seed: 9}.withDefaults()

--- a/internal/core/anomaly_test.go
+++ b/internal/core/anomaly_test.go
@@ -37,6 +37,9 @@ func (c *captureStore) ListAnomalyAlerts(_ context.Context, _ *bool) ([]models.A
 	return nil, nil
 }
 func (c *captureStore) AcknowledgeAnomalyAlert(_ context.Context, _ uint) error { return nil }
+func (c *captureStore) PrincipalSecretFirstSeen(_ context.Context, _ time.Time) (map[string]map[uint]time.Time, error) {
+	return nil, nil
+}
 
 // The recent-access scan window must honor the configured lookback (so a longer scan
 // cadence scans a proportionally longer window), and be floored at one hour.
@@ -127,7 +130,10 @@ func TestBuildBaseline(t *testing.T) {
 		{IPAddress: "10.0.0.2", AccessedBy: "bob", AccessTime: now.Add(-2 * 24 * time.Hour)},      // in 7d, before window
 		{IPAddress: "10.0.0.1", AccessedBy: "alice", AccessTime: now.Add(-20 * 24 * time.Hour)},   // older than 7d
 	}
-	b := buildBaseline(logs, now, windowStart)
+	// quarantine=0: isolates this test to the live-window exclusion behavior; the
+	// quarantine-specific promotion delay is covered separately by
+	// TestBuildBaseline_QuarantineWithholdsRecentlySeenIdentities.
+	b := buildBaseline(logs, now, windowStart, 0)
 	// The in-window read must NOT seed the baseline, else it would mask its own anomaly.
 	if b.knownIPs["203.0.113.9"] || b.knownUsers["mallory"] {
 		t.Fatalf("in-window read must be excluded from the baseline, got IPs=%v users=%v", b.knownIPs, b.knownUsers)
@@ -141,6 +147,29 @@ func TestBuildBaseline(t *testing.T) {
 	// Of the pre-window reads, only bob's (-2d) is within the last 7 days → dailyAvg = 1/7.
 	if want := 1.0 / 7.0; b.dailyAvg != want {
 		t.Fatalf("dailyAvg = %v, want %v", b.dailyAvg, want)
+	}
+}
+
+// #101: an IP/user must have been observed for at least `quarantine` before the live
+// window, not merely before it, to be trusted as baseline — otherwise a single access
+// one lookback interval ago (e.g. 1h) is enough to poison the baseline and silence
+// new_ip/new_user for that identity on the very next pass.
+func TestBuildBaseline_QuarantineWithholdsRecentlySeenIdentities(t *testing.T) {
+	now := time.Date(2026, 6, 17, 12, 0, 0, 0, time.UTC)
+	windowStart := now.Add(-1 * time.Hour)
+	quarantine := 24 * time.Hour
+	logs := []models.SecretAccessLog{
+		// First seen 2h before the live window — well short of the 24h quarantine.
+		{IPAddress: "203.0.113.9", AccessedBy: "mallory", AccessTime: windowStart.Add(-2 * time.Hour)},
+		// First seen 48h before the live window — clears the 24h quarantine.
+		{IPAddress: "10.0.0.1", AccessedBy: "alice", AccessTime: windowStart.Add(-48 * time.Hour)},
+	}
+	b := buildBaseline(logs, now, windowStart, quarantine)
+	if b.knownIPs["203.0.113.9"] || b.knownUsers["mallory"] {
+		t.Fatalf("a recently-first-seen identity must stay quarantined, got IPs=%v users=%v", b.knownIPs, b.knownUsers)
+	}
+	if !b.knownIPs["10.0.0.1"] || !b.knownUsers["alice"] {
+		t.Fatalf("an identity first seen before the quarantine cutoff must be trusted, got IPs=%v users=%v", b.knownIPs, b.knownUsers)
 	}
 }
 
@@ -191,17 +220,30 @@ func TestDetectAnomalies(t *testing.T) {
 		}
 	})
 
-	t.Run("empty baseline suppresses new-ip/new-user", func(t *testing.T) {
-		// Bootstrapping: with no history, an unknown IP/user must not flag (only off-hours,
-		// which is time-based, can fire). Use a business-hours time so nothing fires.
+	t.Run("empty baseline still flags first-ever access, at low severity (#101)", func(t *testing.T) {
+		// A brand-new secret's first-ever access used to be silently waved through with
+		// zero novelty signal — exactly the blind spot an attacker deliberately
+		// targeting a freshly-provisioned, never-accessed secret would rely on. It must
+		// now still surface (auditable), but at "low" severity since there's no
+		// established pattern being violated, only an absence of history. Business-hours
+		// time so only new_ip/new_user are in play.
 		lg := models.SecretAccessLog{
 			IPAddress:  "8.8.8.8",
 			AccessedBy: "mallory",
 			AccessTime: time.Date(2026, 6, 17, 14, 0, 0, 0, time.UTC),
 		}
 		empty := accessBaseline{knownIPs: map[string]bool{}, knownUsers: map[string]bool{}}
-		if alerts := detectAnomalies(secret, lg, empty, defaultOffHoursPolicy()); len(alerts) != 0 {
-			t.Fatalf("expected no alerts against an empty baseline, got %v", kindsOf(alerts))
+		alerts := detectAnomalies(secret, lg, empty, defaultOffHoursPolicy())
+		got := kindsOf(alerts)
+		for _, want := range []string{"new_ip", "new_user"} {
+			if !got[want] {
+				t.Errorf("expected %s alert against an empty baseline, got %v", want, got)
+			}
+		}
+		for _, a := range alerts {
+			if a.Severity != "low" {
+				t.Errorf("expected low severity for a first-ever access with no baseline, got %s alert at %s", a.AlertType, a.Severity)
+			}
 		}
 	})
 }

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -1060,6 +1060,14 @@ func (m *MockStorage) ListSecretAccessLogs(ctx context.Context, secretID uint, s
 	return args.Get(0).([]models.SecretAccessLog), args.Error(1)
 }
 
+func (m *MockStorage) PrincipalSecretFirstSeen(ctx context.Context, since time.Time) (map[string]map[uint]time.Time, error) {
+	args := m.Called(ctx, since)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(map[string]map[uint]time.Time), args.Error(1)
+}
+
 func (m *MockStorage) MostAccessedSecrets(ctx context.Context, projectID *uint, since time.Time, limit int) ([]storage.SecretUsageStat, error) {
 	args := m.Called(ctx, projectID, since, limit)
 	if args.Get(0) == nil {

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -510,6 +510,17 @@ type Storage interface {
 	LogAuditEvent(ctx context.Context, event *models.AuditEvent) error
 	CreateSecretAccessLog(ctx context.Context, log *models.SecretAccessLog) error
 	ListSecretAccessLogs(ctx context.Context, secretID uint, since time.Time) ([]models.SecretAccessLog, error)
+	// PrincipalSecretFirstSeen returns, for every non-empty accessed_by with at least
+	// one access log row at or after `since`, the earliest access time per secret it
+	// touched in that range — aggregated in SQL (GROUP BY + MIN), not loaded as full
+	// log rows, so this stays cheap regardless of per-secret read volume. Backs the
+	// anomaly detector's per-principal breadth-exfiltration pass (#101): a principal
+	// reading many DIFFERENT secrets it has never touched before is invisible to the
+	// per-secret rules (each secret only sees one unremarkable access), so this
+	// aggregates across secrets by principal instead. See the LocalStorage
+	// implementation's doc comment for why `since` must stay a coarse (date-scale)
+	// bound rather than a narrow live-window one.
+	PrincipalSecretFirstSeen(ctx context.Context, since time.Time) (map[string]map[uint]time.Time, error)
 	// MostAccessedSecrets returns the most-read secrets (optionally scoped to a
 	// project) in the window since `since`, ordered by read count descending,
 	// capped at `limit`. Backs the usage-analytics dashboard.

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -953,7 +953,7 @@ type AnomalyAlert struct {
 	ID           uint `gorm:"primaryKey"`
 	SecretNodeID uint `gorm:"index"`
 	SecretName   string
-	AlertType    string // off_hours, new_ip, frequency_spike, new_user, ml_outlier
+	AlertType    string // off_hours, new_ip, frequency_spike, new_user, ml_outlier, principal_breadth
 	Severity     string // low, medium, high
 	Description  string
 	AccessedBy   string

--- a/internal/storage/store/anomaly_test.go
+++ b/internal/storage/store/anomaly_test.go
@@ -102,3 +102,72 @@ func TestListAnomalyAlerts_AcknowledgedFilter(t *testing.T) {
 	require.Len(t, unacked, 1)
 	assert.Equal(t, a2.ID, unacked[0].ID)
 }
+
+// PrincipalSecretFirstSeen must return the EARLIEST access time per (principal, secret)
+// pair, not the latest — repeat reads must not reset "first seen" forward, or a
+// principal's long-standing access to a secret would look newly-first-seen on every
+// pass (#101).
+func TestPrincipalSecretFirstSeen_ReturnsEarliestPerPair(t *testing.T) {
+	ctx := context.Background()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.SecretAccessLog{}))
+	ls := NewLocalStorage(db)
+
+	now := time.Now().UTC()
+	first := now.Add(-10 * 24 * time.Hour)
+	// Three reads of the same (alice, secret 1) pair; the middle two are later than
+	// `first` and must not overwrite it as the earliest.
+	for _, offset := range []time.Duration{0, 2 * time.Hour, 5 * 24 * time.Hour} {
+		require.NoError(t, db.Create(&models.SecretAccessLog{
+			SecretNodeID: 1, AccessedBy: "alice", Action: "read", IPAddress: "10.0.0.1",
+			AccessTime: first.Add(offset),
+		}).Error)
+	}
+	// A second, unrelated pair.
+	require.NoError(t, db.Create(&models.SecretAccessLog{
+		SecretNodeID: 2, AccessedBy: "bob", Action: "read", IPAddress: "10.0.0.2",
+		AccessTime: now.Add(-1 * time.Hour),
+	}).Error)
+
+	got, err := ls.PrincipalSecretFirstSeen(ctx, now.Add(-30*24*time.Hour))
+	require.NoError(t, err)
+	require.Contains(t, got, "alice")
+	require.Contains(t, got["alice"], uint(1))
+	assert.WithinDuration(t, first, got["alice"][1], time.Second, "must return the earliest access, not the latest")
+	require.Contains(t, got, "bob")
+	require.Contains(t, got["bob"], uint(2))
+
+	// The `since` bound excludes pairs whose only activity predates it entirely.
+	got, err = ls.PrincipalSecretFirstSeen(ctx, now.Add(-1*time.Minute))
+	require.NoError(t, err)
+	assert.NotContains(t, got, "alice", "alice's only reads are older than `since`")
+	assert.NotContains(t, got, "bob", "bob's only read is older than `since`")
+}
+
+// ListSecretAccessLogs must cap the number of rows returned (#101) — otherwise a
+// secret read continuously over the query window (a busy CI pipeline, or an attacker
+// deliberately hammering reads to bloat the log) makes the anomaly detector, which
+// calls this per secret per pass, load an unbounded result set into memory.
+func TestListSecretAccessLogs_CapsRowCount(t *testing.T) {
+	ctx := context.Background()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.SecretAccessLog{}))
+	ls := NewLocalStorage(db)
+
+	now := time.Now().UTC()
+	const overCap = maxSecretAccessLogRows + 50
+	rows := make([]models.SecretAccessLog, overCap)
+	for i := range rows {
+		rows[i] = models.SecretAccessLog{
+			SecretNodeID: 1, AccessedBy: "svc", Action: "read", IPAddress: "10.0.0.1",
+			AccessTime: now.Add(-time.Duration(overCap-i) * time.Millisecond),
+		}
+	}
+	require.NoError(t, db.CreateInBatches(rows, 1000).Error)
+
+	got, err := ls.ListSecretAccessLogs(ctx, 1, now.Add(-time.Hour))
+	require.NoError(t, err)
+	assert.Len(t, got, maxSecretAccessLogRows, "result must be capped, not the full over-cap row count")
+}

--- a/internal/storage/store/local_audit.go
+++ b/internal/storage/store/local_audit.go
@@ -23,12 +23,67 @@ func (ls *LocalStorage) CreateSecretAccessLog(ctx context.Context, log *models.S
 	return ls.db.WithContext(ctx).Create(log).Error
 }
 
+// maxSecretAccessLogRows caps how many rows a single ListSecretAccessLogs call can
+// return (#101). Without a cap, a secret read continuously over a long window (a busy
+// CI pipeline, or an attacker deliberately hammering reads to bloat the log) makes the
+// anomaly detector — which calls this per secret, per pass, over a 30-day window —
+// load an unbounded result set into memory, a self-inflicted latency/OOM vector.
+// Ordered newest-first so a capped result keeps the most recent (most relevant) rows.
+const maxSecretAccessLogRows = 50_000
+
 func (ls *LocalStorage) ListSecretAccessLogs(ctx context.Context, secretID uint, since time.Time) ([]models.SecretAccessLog, error) {
 	var logs []models.SecretAccessLog
 	result := ls.db.WithContext(ctx).
 		Where("secret_node_id = ? AND access_time >= ?", secretID, since).
+		Order("access_time DESC").
+		Limit(maxSecretAccessLogRows).
 		Find(&logs)
 	return logs, result.Error
+}
+
+// PrincipalSecretFirstSeen returns, for every (principal, secret) pair with at least one
+// access log row at or after `since`, the EARLIEST access time in that range —
+// aggregated in SQL (GROUP BY + MIN), not loaded as full log rows, so this stays cheap
+// regardless of per-secret read volume (#101).
+//
+// The `since` SQL boundary is deliberately coarse (the 30-day baseline window, not the
+// live scan window): a stored AccessTime preserves its writer's local UTC offset as
+// text (e.g. "...+02:00"), rather than being normalised to a single format, so a SQL
+// WHERE boundary that's narrow relative to "now" (same-day/same-hour) compares that text
+// lexicographically against a differently-offset-formatted bound parameter and can
+// silently misclassify rows near the boundary — a real-but-latent issue across this
+// codebase's time-range queries, only ever safe today because every other WHERE
+// boundary here is date-scale (7d/30d), never hour-scale. Callers needing the
+// hour-scale "is this within the live window" distinction must make it in Go against
+// the returned time.Time (which is location-independent to compare), not by pushing a
+// second, narrower bound into this query.
+func (ls *LocalStorage) PrincipalSecretFirstSeen(ctx context.Context, since time.Time) (map[string]map[uint]time.Time, error) {
+	type row struct {
+		AccessedBy   string
+		SecretNodeID uint
+		FirstSeen    scanTime
+	}
+	var rows []row
+	err := ls.db.WithContext(ctx).
+		Model(&models.SecretAccessLog{}).
+		Select("accessed_by, secret_node_id, MIN(access_time) AS first_seen").
+		Where("access_time >= ? AND accessed_by != ''", since).
+		Group("accessed_by, secret_node_id").
+		Scan(&rows).Error
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[string]map[uint]time.Time, len(rows))
+	for _, r := range rows {
+		if r.FirstSeen.t == nil {
+			continue
+		}
+		if out[r.AccessedBy] == nil {
+			out[r.AccessedBy] = make(map[uint]time.Time)
+		}
+		out[r.AccessedBy][r.SecretNodeID] = *r.FirstSeen.t
+	}
+	return out, nil
 }
 
 // scanTime portably scans a SQL timestamp that some drivers return as time.Time

--- a/internal/storage/store/remote_audit.go
+++ b/internal/storage/store/remote_audit.go
@@ -124,6 +124,11 @@ func (rs *RemoteStorage) ListSecretAccessLogs(_ context.Context, _ uint, _ time.
 	return nil, fmt.Errorf("ListSecretAccessLogs not available in remote mode")
 }
 
+// PrincipalSecretFirstSeen is not available in remote mode; anomaly detection is server-side.
+func (rs *RemoteStorage) PrincipalSecretFirstSeen(_ context.Context, _ time.Time) (map[string]map[uint]time.Time, error) {
+	return nil, fmt.Errorf("PrincipalSecretFirstSeen not available in remote mode")
+}
+
 // MostAccessedSecrets is not available in remote mode; usage analytics aggregate server-side.
 func (rs *RemoteStorage) MostAccessedSecrets(_ context.Context, _ *uint, _ time.Time, _ int) ([]storage.SecretUsageStat, error) {
 	return nil, fmt.Errorf("MostAccessedSecrets not available in remote mode")

--- a/server/http/handlers/audit_anomaly.go
+++ b/server/http/handlers/audit_anomaly.go
@@ -36,8 +36,8 @@ func ListAnomalyAlerts(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Optional ?severity=low|medium|high and ?alertType=off_hours|new_ip|new_user|
-	// frequency_spike|ml_outlier narrow the list server-side (an empty value is no
-	// constraint).
+	// frequency_spike|ml_outlier|principal_breadth narrow the list server-side (an
+	// empty value is no constraint).
 	alerts = core.FilterAlerts(alerts, r.URL.Query().Get("severity"), r.URL.Query().Get("alertType"))
 	sendSuccess(w, map[string]interface{}{"alerts": alerts, "total": len(alerts)}, "")
 }

--- a/server/main.go
+++ b/server/main.go
@@ -833,6 +833,7 @@ func startHTTPServer(ctx context.Context, cfg *config.Config) error {
 		// Scan a window at least as long as the cadence, so a longer schedule doesn't
 		// leave the time between passes unexamined (floored at 1h inside SetLookback).
 		detector.SetLookback(interval)
+		detector.SetBaselineQuarantine(cfg.AnomalyAlerts.GetBaselineQuarantine())
 		if alertsEnabled {
 			log.Printf("Anomaly alerting enabled: scan + alert every %s", interval)
 		}


### PR DESCRIPTION
## Summary
Closes backlog finding #101 — the anomaly detector had five distinct blind spots:

- **No per-principal fanout.** Every rule is scoped to a single secret's own baseline, so a principal reading many DIFFERENT secrets it has never touched before (breadth exfiltration) was invisible — each secret only ever saw "one unremarkable access from a possibly-new actor." New `PrincipalSecretFirstSeen` storage query (aggregated in SQL via `GROUP BY + MIN`, not full log rows) + `detectPrincipalBreadth` raises a `principal_breadth` alert when a principal's first-ever access to ≥5 secrets falls in the live scan window.
- **Baseline self-poisoning.** An IP/user aged into "known" after just one lookback interval (as little as 1h) — the very next pass treated it as historical and `new_ip`/`new_user` went silent. `buildBaseline` now requires an identity to have been observed for a configurable quarantine period (default 24h; `AnomalyDetector.SetBaselineQuarantine`, wired from the new `anomaly_alerts.baseline_quarantine` config) before it's trusted.
- **Empty-baseline suppressed novelty.** A secret's first-ever access from any IP/user was silently waved through with zero signal — exactly what an attacker deliberately targeting a freshly-provisioned, never-accessed secret would rely on. It now still flags, at "low" severity (no established pattern is being violated, just an absence of history), and a secret with zero baseline history no longer skips off_hours/frequency_spike checks either.
- **Unbounded log load.** `ListSecretAccessLogs` had no row cap; a secret read continuously over the 30-day scan window (a busy CI pipeline, or an attacker deliberately hammering reads to bloat the log) made the detector — which calls this per secret, per pass — load an unbounded result set into memory. Capped at 50k rows, newest-first.
- **Fixed RNG seed.** The Isolation Forest's default seed was the hardcoded constant `1` — every default deployment ran an identical, publicly-known-from-source forest structure, letting an attacker precompute which accesses the forest would isolate poorly. An unset seed now draws from `crypto/rand` per process; an explicit `seed` config value still opts into deterministic-for-reproducibility scoring.

A narrow-time-window SQL comparison bug surfaced while building the per-principal test: SQLite stores `time.Time` as TEXT preserving the writer's own UTC offset (not normalized), so a WHERE boundary narrow relative to "now" (same-hour) can misclassify rows when compared lexicographically against a differently-offset-formatted bound parameter — safe everywhere else in this codebase only because every other time boundary here is date-scale (7d/30d). `PrincipalSecretFirstSeen` avoids it by keeping its SQL bound coarse (the 30-day baseline) and doing the live-window split in Go against a real `time.Time`.

Also reapplies the SIEM spool `replayMu` serialization fix from #521 (unmerged), carried forward since this branch forked from `main` before that PR landed.

## Test plan
- [x] New `TestRunDetection_DetectsPrincipalBreadthAcrossSecrets` — a principal reading 6 never-before-touched secrets raises `principal_breadth`.
- [x] New `TestBuildBaseline_QuarantineWithholdsRecentlySeenIdentities` — an identity first seen inside the quarantine window is withheld from "known".
- [x] `TestDetectAnomalies` updated — an empty baseline now flags `new_ip`/`new_user` at low severity instead of suppressing them.
- [x] New `TestPrincipalSecretFirstSeen_ReturnsEarliestPerPair` and `TestListSecretAccessLogs_CapsRowCount` at the storage layer.
- [x] New `TestMLConfigWithDefaults` assertion that two unset-seed defaults never collide.
- [x] New `TestAnomalyAlertsConfig_GetBaselineQuarantine` for the zero-duration explicit-opt-out semantics.
- [x] `go test ./internal/... ./server/...` — all green.
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues.
- [x] `GOWORK=off go build -C operator ./...` — clean.