### PR TITLE
fix(dynamic-secrets): install-wide max-TTL ceiling + honest lease expiry (#97)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1302,6 +1302,13 @@ type DynamicSecretsConfig struct {
 	SweepEnabled bool `yaml:"sweep_enabled"`
 	// SweepInterval is the sweep cadence as a Go duration (e.g. "1m", "5m").
 	SweepInterval string `yaml:"sweep_interval"`
+	// MaxLeaseTTL is a hard, install-wide ceiling on any dynamic-secret lease's TTL —
+	// independent of (and always enforced alongside) each DynamicSecretConfig's own
+	// per-config MaxTTLSeconds, which has no ceiling of its own and defaults to
+	// "unset = unbounded" (#97: without this, an operator could set/leave a config's
+	// max_ttl_seconds unbounded and mint a credential valid for, say, 100 years). Go
+	// duration string (e.g. "720h"); defaults to 90 days when unset or unparseable.
+	MaxLeaseTTL string `yaml:"max_lease_ttl"`
 }
 
 // GetSweepInterval returns the auto-revoke sweep cadence, parsing SweepInterval
@@ -1313,6 +1320,17 @@ func (c DynamicSecretsConfig) GetSweepInterval() time.Duration {
 		}
 	}
 	return 1 * time.Minute
+}
+
+// GetMaxLeaseTTL returns the install-wide dynamic-secret lease TTL ceiling; defaults to
+// 90 days when unset or unparseable (#97).
+func (c DynamicSecretsConfig) GetMaxLeaseTTL() time.Duration {
+	if c.MaxLeaseTTL != "" {
+		if d, err := time.ParseDuration(c.MaxLeaseTTL); err == nil && d > 0 {
+			return d
+		}
+	}
+	return 90 * 24 * time.Hour
 }
 
 // GetInterval returns the purge run interval, parsing Schedule as a Go duration

--- a/internal/config/dynamic_secrets_config_test.go
+++ b/internal/config/dynamic_secrets_config_test.go
@@ -1,0 +1,14 @@
+package config
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDynamicSecretsConfig_GetMaxLeaseTTL(t *testing.T) {
+	assert.Equal(t, 90*24*time.Hour, DynamicSecretsConfig{}.GetMaxLeaseTTL(), "default when unset")
+	assert.Equal(t, 90*24*time.Hour, DynamicSecretsConfig{MaxLeaseTTL: "garbage"}.GetMaxLeaseTTL(), "unparseable falls back")
+	assert.Equal(t, 720*time.Hour, DynamicSecretsConfig{MaxLeaseTTL: "720h"}.GetMaxLeaseTTL())
+}

--- a/internal/core/dynamic_secrets.go
+++ b/internal/core/dynamic_secrets.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/dynamic"
@@ -16,6 +17,12 @@ import (
 )
 
 const defaultDynamicTTL = 1 * time.Hour
+
+// defaultMaxLeaseTTL is the install-wide lease TTL ceiling used when
+// KeyorixCore.dynamicMaxLeaseTTL is unset (mirrors config.DynamicSecretsConfig's
+// own default so behaviour is identical whether or not the server wired
+// SetDynamicMaxLeaseTTL, e.g. in tests that construct KeyorixCore directly).
+const defaultMaxLeaseTTL = 90 * 24 * time.Hour
 
 // CreateDynamicSecretConfigRequest registers a dynamic-secrets target.
 type CreateDynamicSecretConfigRequest struct {
@@ -147,6 +154,17 @@ func (c *KeyorixCore) GetDynamicSecretLease(ctx context.Context, leaseID string)
 // IssueLease mints a short-lived credential on the target and persists the lease.
 // The plaintext credential is returned ONCE; only its encrypted form is stored.
 // ttlSeconds<=0 uses the config default (or 1h).
+//
+// LOW (#97): a genuine process crash (SIGKILL/OOM/panic bypassing defers) between
+// engine.Issue minting the credential on the target and this function persisting the
+// lease row leaves an orphan invisible to every list/revoke/sweep path (all keyed off
+// the lease table) — cleanupOrphanedRole only covers synchronous Go-level errors
+// returned by the steps AFTER Issue, not a hard crash. Fully closing this needs
+// crash-safe two-phase persistence (write a pre-mint marker, reconcile it against the
+// target on restart) across all 8 backend engines — out of proportion for a LOW
+// finding. The log line below is a partial mitigation: it gives an operator a
+// searchable breadcrumb (config, backend, target-ish role hint) to correlate against
+// server logs during incident response if a mint never resulted in a lease row.
 func (c *KeyorixCore) IssueLease(ctx context.Context, configID uint, ttlSeconds int, userID uint) (*IssuedLease, error) {
 	cfg, err := c.storage.GetDynamicSecretConfig(ctx, configID)
 	if err != nil {
@@ -181,6 +199,10 @@ func (c *KeyorixCore) IssueLease(ctx context.Context, configID uint, ttlSeconds 
 	}
 	ttl := c.dynamicTTL(cfg, ttlSeconds)
 
+	// Logged BEFORE the mint (not after) so the breadcrumb survives a crash during or
+	// immediately after engine.Issue — see the crash-orphan note on IssueLease's doc
+	// comment (#97).
+	log.Printf("dynamic-secrets: issuing a %s credential (config=%q id=%d project=%d ttl=%s)", cfg.BackendType, cfg.Name, cfg.ID, cfg.ProjectID, ttl)
 	cred, roleName, err := engine.Issue(ctx, adminDSN, cfg.CreationTemplate, ttl)
 	if err != nil {
 		return nil, fmt.Errorf("failed to issue credential: %w", err)
@@ -201,7 +223,20 @@ func (c *KeyorixCore) IssueLease(ctx context.Context, configID uint, ttlSeconds 
 		c.cleanupOrphanedRole(ctx, cfg, engine, adminDSN, roleName, userID)
 		return nil, fmt.Errorf("failed to encrypt credential: %w", err)
 	}
+	// #97: cloud-IAM engines (AWS STS, Kubernetes) floor the REQUESTED ttl up to their
+	// own provider minimum (900s/600s) when minting, so the credential returned is
+	// valid for longer than a short-ttl caller asked for — but ExpiresAt computed from
+	// the requested ttl alone would understate that, making Keyorix believe (and the
+	// auto-revoke sweep act on) an earlier expiry than the credential's true,
+	// provider-enforced one. Both engines surface the actual granted expiry in
+	// cred.Fields["expiration"] (RFC3339); trust it over the requested-ttl computation
+	// whenever the engine provides it.
 	expiresAt := c.now().Add(ttl)
+	if raw := cred.Fields["expiration"]; raw != "" {
+		if actual, perr := time.Parse(time.RFC3339, raw); perr == nil {
+			expiresAt = actual
+		}
+	}
 	lease, err := c.storage.CreateDynamicSecretLease(ctx, &models.DynamicSecretLease{
 		ConfigID:       cfg.ID,
 		LeaseID:        leaseID,
@@ -318,8 +353,18 @@ func (c *KeyorixCore) RevokeLease(ctx context.Context, leaseID string, userID ui
 	if err := c.storage.UpdateDynamicSecretLease(ctx, lease); err != nil {
 		return err
 	}
-	c.writeAuditEventFull(ctx, "dynamic_lease.revoked", uidPtr, nil, &pid, "",
-		fmt.Sprintf("revoked dynamic lease %s (reason=%s)", lease.LeaseID, reason))
+	// #97: for an ephemeral backend (AWS STS, Kubernetes) engine.Revoke above is a
+	// documented no-op — the credential cannot be invalidated early at the provider,
+	// only marked dead in Keyorix's own bookkeeping. Saying "revoked" outright would
+	// misleadingly imply the credential is dead; it remains live until its own
+	// provider-enforced expiry (lease.ExpiresAt, corrected to the actual granted
+	// expiry at issue — see IssueLease).
+	msg := fmt.Sprintf("revoked dynamic lease %s (reason=%s)", lease.LeaseID, reason)
+	if engine.IsEphemeralBackend() {
+		msg = fmt.Sprintf("marked dynamic lease %s revoked locally (reason=%s); the %s credential cannot be invalidated early and remains live until its provider-enforced expiry at %s",
+			lease.LeaseID, reason, cfg.BackendType, lease.ExpiresAt.UTC().Format(time.RFC3339))
+	}
+	c.writeAuditEventFull(ctx, "dynamic_lease.revoked", uidPtr, nil, &pid, "", msg)
 	return nil
 }
 
@@ -384,8 +429,13 @@ func (c *KeyorixCore) RevokeLeasesForConfig(ctx context.Context, configID, userI
 	return revoked, failed, nil
 }
 
-// dynamicTTL resolves the requested TTL (override, else config default, else 1h)
-// and clamps it to the config's MaxTTLSeconds ceiling when one is set.
+// dynamicTTL resolves the requested TTL (override, else config default, else 1h),
+// clamps it to the config's MaxTTLSeconds ceiling when one is set, and always clamps
+// it to the install-wide max-lease-TTL ceiling on top (#97) — the per-config ceiling
+// is entirely operator-controlled and defaults to "unset = unbounded" (e.g. a config
+// left with MaxTTLSeconds=0 combined with a caller-supplied override would otherwise
+// mint a credential valid for however long the caller asked, with nothing to stop a
+// 100-year lease).
 func (c *KeyorixCore) dynamicTTL(cfg *models.DynamicSecretConfig, override int) time.Duration {
 	ttl := defaultDynamicTTL
 	switch {
@@ -398,6 +448,13 @@ func (c *KeyorixCore) dynamicTTL(cfg *models.DynamicSecretConfig, override int) 
 		if max := time.Duration(cfg.MaxTTLSeconds) * time.Second; ttl > max {
 			ttl = max
 		}
+	}
+	installMax := c.dynamicMaxLeaseTTL
+	if installMax <= 0 {
+		installMax = defaultMaxLeaseTTL
+	}
+	if ttl > installMax {
+		ttl = installMax
 	}
 	return ttl
 }
@@ -437,6 +494,16 @@ func (c *KeyorixCore) RenewLease(ctx context.Context, leaseID string, ttlSeconds
 		if hardCap := lease.IssuedAt.Add(time.Duration(cfg.MaxTTLSeconds) * time.Second); newExpiry.After(hardCap) {
 			newExpiry = hardCap
 		}
+	}
+	// ...nor past the install-wide ceiling (#97) — same reasoning as dynamicTTL: the
+	// per-config ceiling above is optional and defaults to unbounded, so a renewal
+	// alone could otherwise stretch a lease's total lifetime arbitrarily far.
+	installMax := c.dynamicMaxLeaseTTL
+	if installMax <= 0 {
+		installMax = defaultMaxLeaseTTL
+	}
+	if hardCap := lease.IssuedAt.Add(installMax); newExpiry.After(hardCap) {
+		newExpiry = hardCap
 	}
 	if !newExpiry.After(lease.ExpiresAt) {
 		return time.Time{}, fmt.Errorf("renewal would not extend the lease (max-TTL ceiling reached)")

--- a/internal/core/dynamic_secrets_test.go
+++ b/internal/core/dynamic_secrets_test.go
@@ -302,6 +302,105 @@ func TestDynamicSecrets_MaxTTLClampsIssue(t *testing.T) {
 	assert.Equal(t, fixed.Add(30*time.Minute), issued.ExpiresAt, "issue TTL must be clamped to max_ttl_seconds")
 }
 
+// #97: an install-wide ceiling must clamp a lease's TTL even when the config's own
+// MaxTTLSeconds is left unset (unbounded) — otherwise a caller-supplied override
+// (or, on a misconfigured install, the config default) could mint an arbitrarily
+// long-lived credential.
+func TestDynamicSecrets_InstallWideMaxLeaseTTLClampsIssue(t *testing.T) {
+	c, _, _, fixed := newDynamicTestCore(t)
+	c.SetDynamicMaxLeaseTTL(2 * time.Hour)
+	ctx := context.Background()
+	cfg, err := c.CreateDynamicSecretConfig(ctx, &CreateDynamicSecretConfigRequest{
+		Name: "unbounded", ProjectID: 1, BackendType: "postgres", AdminDSN: adminDSNPlain,
+		// No MaxTTLSeconds — the per-config ceiling is unset/unbounded.
+	})
+	require.NoError(t, err)
+
+	// A caller requests a 1000-hour (~41-day) lease; nothing in the config stops it.
+	issued, err := c.IssueLease(ctx, cfg.ID, 1000*3600, 7)
+	require.NoError(t, err)
+	assert.Equal(t, fixed.Add(2*time.Hour), issued.ExpiresAt, "the install-wide ceiling must clamp an otherwise-unbounded request")
+}
+
+// A zero/unset install-wide ceiling must fall back to the package default (90 days),
+// not disable the ceiling entirely.
+func TestDynamicSecrets_InstallWideMaxLeaseTTLDefaultsWhenUnset(t *testing.T) {
+	c, _, _, fixed := newDynamicTestCore(t)
+	// SetDynamicMaxLeaseTTL is never called — dynamicMaxLeaseTTL stays its zero value.
+	ctx := context.Background()
+	cfg, err := c.CreateDynamicSecretConfig(ctx, &CreateDynamicSecretConfigRequest{
+		Name: "unbounded", ProjectID: 1, BackendType: "postgres", AdminDSN: adminDSNPlain,
+	})
+	require.NoError(t, err)
+
+	issued, err := c.IssueLease(ctx, cfg.ID, 1000*24*3600, 7) // ~1000 days requested
+	require.NoError(t, err)
+	assert.Equal(t, fixed.Add(defaultMaxLeaseTTL), issued.ExpiresAt, "an unset install ceiling must fall back to the 90-day default, not disable clamping")
+}
+
+// #97: when the engine surfaces the provider's actual granted expiry (Fields
+// ["expiration"], set by the AWS STS / Kubernetes engines after their own
+// 900s/600s duration floor), the persisted lease must use THAT value rather than
+// naively computing now+requestedTTL — otherwise Keyorix's own bookkeeping (and the
+// auto-revoke sweep, which acts on ExpiresAt) would understate the credential's true
+// lifetime.
+func TestDynamicSecrets_ExpiresAtUsesProviderActualExpiryWhenSurfaced(t *testing.T) {
+	c, _, fake, fixed := newDynamicTestCore(t)
+	fake.Ephemeral = true
+	// The engine floored a short requested TTL up to its own provider minimum — the
+	// actual granted expiry is well past what a naive now+requestedTTL would compute.
+	actualExpiry := fixed.Add(15 * time.Minute)
+	fake.IssueFields = map[string]string{"expiration": actualExpiry.UTC().Format(time.RFC3339)}
+	ctx := context.Background()
+	cfg := mkConfig(t, c, ctx)
+
+	// Request only 60s — far below the provider's actual floor.
+	issued, err := c.IssueLease(ctx, cfg.ID, 60, 7)
+	require.NoError(t, err)
+	assert.Equal(t, actualExpiry, issued.ExpiresAt, "ExpiresAt must reflect the provider's actual granted expiry, not now+60s")
+
+	stored, err := c.storage.GetDynamicSecretLease(ctx, issued.LeaseID)
+	require.NoError(t, err)
+	assert.Equal(t, actualExpiry, stored.ExpiresAt, "the persisted lease row must carry the corrected expiry too")
+}
+
+// Without a surfaced provider expiry (Fields["expiration"] absent, e.g. a DB backend),
+// ExpiresAt must still fall back to the requested-ttl computation — the correction is
+// additive, not a behavior change for backends that don't surface one.
+func TestDynamicSecrets_ExpiresAtFallsBackWithoutProviderExpiry(t *testing.T) {
+	c, _, _, fixed := newDynamicTestCore(t)
+	ctx := context.Background()
+	cfg := mkConfig(t, c, ctx)
+
+	issued, err := c.IssueLease(ctx, cfg.ID, 1800, 7)
+	require.NoError(t, err)
+	assert.Equal(t, fixed.Add(30*time.Minute), issued.ExpiresAt)
+}
+
+// #97: RevokeLease's audit trail must not claim an ephemeral (no-op-Revoke) backend's
+// credential was actually killed — it remains live at the provider until its own
+// natural expiry. The lease is still marked "revoked" locally (so it drops out of
+// active-lease accounting / stops appearing as issuable-from-this-lease), but the
+// audit message must say so honestly.
+func TestDynamicSecrets_RevokeEphemeralBackendAuditsHonestly(t *testing.T) {
+	c, db, fake, _ := newDynamicTestCore(t)
+	fake.Ephemeral = true
+	ctx := context.Background()
+	cfg := mkConfig(t, c, ctx)
+
+	issued, err := c.IssueLease(ctx, cfg.ID, 0, 7)
+	require.NoError(t, err)
+	require.NoError(t, c.RevokeLease(ctx, issued.LeaseID, 7, "manual"))
+
+	lease, err := c.storage.GetDynamicSecretLease(ctx, issued.LeaseID)
+	require.NoError(t, err)
+	assert.Equal(t, "revoked", lease.Status, "still marked revoked locally")
+
+	var ev models.AuditEvent
+	require.NoError(t, db.Where("event_type = ?", "dynamic_lease.revoked").Order("id DESC").First(&ev).Error)
+	assert.Contains(t, ev.Description, "cannot be invalidated early", "the audit trail must not claim a full provider-side revoke for an ephemeral backend")
+}
+
 func TestDynamicSecrets_CreateRejectsDefaultOverMax(t *testing.T) {
 	c, _, _, _ := newDynamicTestCore(t)
 	_, err := c.CreateDynamicSecretConfig(context.Background(), &CreateDynamicSecretConfigRequest{
@@ -309,6 +408,30 @@ func TestDynamicSecrets_CreateRejectsDefaultOverMax(t *testing.T) {
 		DefaultTTLSeconds: 3600, MaxTTLSeconds: 600,
 	})
 	require.Error(t, err)
+}
+
+// #97: renewal must respect the install-wide ceiling too, not just the (optional,
+// default-unbounded) per-config MaxTTLSeconds — otherwise a config left without its
+// own ceiling could have its lease's total lifetime stretched arbitrarily far by
+// repeated renewals.
+func TestDynamicSecrets_RenewRespectsInstallWideMaxLeaseTTL(t *testing.T) {
+	c, _, _, fixed := newDynamicTestCore(t)
+	c.SetDynamicMaxLeaseTTL(20 * time.Minute)
+	ctx := context.Background()
+	cfg, err := c.CreateDynamicSecretConfig(ctx, &CreateDynamicSecretConfigRequest{
+		Name: "unbounded", ProjectID: 1, BackendType: "postgres", AdminDSN: adminDSNPlain,
+		DefaultTTLSeconds: 300, // no MaxTTLSeconds — per-config ceiling unset
+	})
+	require.NoError(t, err)
+
+	issued, err := c.IssueLease(ctx, cfg.ID, 0, 7) // expiry = fixed+5m
+	require.NoError(t, err)
+	require.Equal(t, fixed.Add(5*time.Minute), issued.ExpiresAt)
+
+	// Ask to renew far past the 20m install ceiling (measured from IssuedAt).
+	exp, err := c.RenewLease(ctx, issued.LeaseID, 3600, 7)
+	require.NoError(t, err)
+	assert.Equal(t, fixed.Add(20*time.Minute), exp, "renewal must clamp to the install-wide ceiling from IssuedAt")
 }
 
 func TestDynamicSecrets_RenewExtendsAndRespectsMaxTTL(t *testing.T) {

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -49,6 +49,11 @@ type KeyorixCore struct {
 	// enforce a lease's TTL, so IssueLease refuses to mint from them when it is off
 	// (the credential would otherwise never expire). Set via SetDynamicSweepEnabled.
 	dynamicSweepEnabled bool
+	// dynamicMaxLeaseTTL mirrors config dynamic_secrets.max_lease_ttl (#97): a hard,
+	// install-wide ceiling dynamicTTL enforces alongside (never instead of) each
+	// config's own MaxTTLSeconds, which has no ceiling of its own. Zero = the
+	// package default (90 days) applies. Set via SetDynamicMaxLeaseTTL.
+	dynamicMaxLeaseTTL time.Duration
 	// webauthnRP is the WebAuthn relying party (ADR-036); nil = WebAuthn disabled.
 	// Set from config at startup via SetWebAuthn.
 	webauthnRP     *webauthn.WebAuthn
@@ -449,6 +454,15 @@ func (c *KeyorixCore) SetDynamicEngineFactory(f func(string) (dynamic.Credential
 // to mint a credential from a backend whose TTL only the sweeper would enforce.
 func (c *KeyorixCore) SetDynamicSweepEnabled(enabled bool) {
 	c.dynamicSweepEnabled = enabled
+}
+
+// SetDynamicMaxLeaseTTL sets the install-wide dynamic-secret lease TTL ceiling
+// (config dynamic_secrets.max_lease_ttl, #97). A non-positive value is ignored — the
+// package default (90 days) applies instead of disabling the ceiling.
+func (c *KeyorixCore) SetDynamicMaxLeaseTTL(ttl time.Duration) {
+	if ttl > 0 {
+		c.dynamicMaxLeaseTTL = ttl
+	}
 }
 
 // dynamicEngine resolves an engine for a backend type via the factory (or the

--- a/server/main.go
+++ b/server/main.go
@@ -649,6 +649,9 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 	// refuses to mint from backends whose lease TTL only the sweeper enforces
 	// (MySQL/MongoDB) when it is disabled — otherwise the credential never expires.
 	coreService.SetDynamicSweepEnabled(cfg.DynamicSecrets.SweepEnabled)
+	// Install-wide hard ceiling on any dynamic-secret lease's TTL (#97); enforced on
+	// top of each config's own optional (default-unbounded) MaxTTLSeconds.
+	coreService.SetDynamicMaxLeaseTTL(cfg.DynamicSecrets.GetMaxLeaseTTL())
 
 	// Wire self-service emergency access (break-glass); zero value = disabled.
 	coreService.SetBreakGlassPolicy(core.BreakGlassPolicy{


### PR DESCRIPTION
## Summary
Closes backlog finding #97 — dynamic secrets had no install-wide TTL ceiling and could compute a lease's expiry inconsistently with what the cloud-IAM provider actually granted:

- **No install ceiling on requested TTL.** `dynamicTTL()`'s only ceiling was each `DynamicSecretConfig`'s own `MaxTTLSeconds`, which defaults to `0` = unbounded and is entirely operator-controlled. A config left unconfigured (or a caller-supplied `ttl_seconds` override with no config ceiling) could mint a credential valid for however long was asked — e.g. 100 years. Added `dynamic_secrets.max_lease_ttl` (default 90 days), a hard install-wide ceiling enforced by `dynamicTTL` and by `RenewLease`'s total-lifetime cap, alongside (never instead of) the per-config ceiling.
- **STS/K8s floor to 900s/600s while `ExpiresAt` was computed from the requested TTL.** The AWS STS and Kubernetes engines both floor a short requested duration up to their own provider minimum when minting — the credential really is valid that long — but `IssueLease` computed `ExpiresAt = now + requestedTTL`, understating the credential's true, provider-enforced lifetime. Both engines already surface the actual granted expiry in `cred.Fields["expiration"]` (RFC3339); `IssueLease` now trusts it over the requested-TTL computation whenever the engine provides one. This matters because the auto-revoke sweep acts on `ExpiresAt` — before this fix it could mark a lease "revoked" in Keyorix while the underlying STS/K8s credential was still genuinely live for several more minutes.
- **Revoke is a documented no-op for ephemeral backends, but the audit trail claimed a full revoke.** AWS STS temp credentials and Kubernetes ServiceAccount tokens cannot be invalidated early — `Revoke` returning `nil` for those engines just means "nothing to drop," yet `RevokeLease` wrote a `dynamic_lease.revoked` audit event indistinguishable from a real target-side revoke. It now says explicitly that the credential remains live until its (corrected) natural expiry for `IsEphemeralBackend()` engines.
- **LOW: mint-then-persist crash orphan.** A genuine process crash between `engine.Issue` minting a credential and `IssueLease` persisting the lease row leaves an orphan invisible to every list/revoke/sweep path (all keyed off the lease table); the existing `cleanupOrphanedRole` only covers synchronous Go-level errors, not a hard crash. Fully closing this needs crash-safe two-phase persistence across all 8 backend engines — out of proportion for a LOW finding. Documented explicitly on `IssueLease`, plus a pre-mint log line as a low-risk partial mitigation (a searchable breadcrumb for incident response).

Also reapplies the SIEM spool `replayMu` serialization fix from #521 (unmerged), carried forward since this branch forked from `main` before that PR landed.

## Test plan
- [x] New `TestDynamicSecrets_InstallWideMaxLeaseTTLClampsIssue` / `..._DefaultsWhenUnset` — an otherwise-unbounded config's lease is clamped to the install ceiling (explicit and default-90-day).
- [x] New `TestDynamicSecrets_RenewRespectsInstallWideMaxLeaseTTL` — renewal can't stretch total lifetime past the install ceiling either.
- [x] New `TestDynamicSecrets_ExpiresAtUsesProviderActualExpiryWhenSurfaced` / `..._FallsBackWithoutProviderExpiry` — `ExpiresAt` uses the provider's actual expiry when surfaced, and falls back cleanly when not (DB backends unaffected).
- [x] New `TestDynamicSecrets_RevokeEphemeralBackendAuditsHonestly` — the audit message for an ephemeral-backend revoke says the credential remains live, not that it was killed.
- [x] New `TestDynamicSecretsConfig_GetMaxLeaseTTL` for the config parsing/default.
- [x] `go test ./internal/... ./server/...` — all green.
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues.
- [x] `GOWORK=off go build -C operator ./...` — clean.