### PR TITLE
fix(encryption): close AAD-transplant exposure for MFA/dynamic-secret ciphertext (#94)

### DIFF
--- a/internal/cli/encryption/encryption.go
+++ b/internal/cli/encryption/encryption.go
@@ -58,12 +58,29 @@ running. Requires --confirm.`,
 	RunE: runRotate,
 }
 
+var upgradeAADCmd = &cobra.Command{
+	Use:   "upgrade-aad",
+	Short: "Bind legacy auth-secret rows to per-row AAD, without rotating the DEK",
+	Long: `Re-encrypt every legacy (pre-#94), no-AAD row in mfa_secrets,
+dynamic_secret_configs, and dynamic_secret_leases under the CURRENT DEK, binding
+each to Additional Authenticated Data derived from its own identity (user id / config
+id / lease id). This closes a ciphertext-transplant exposure — without AAD, a
+DB-write attacker could copy an encrypted blob from one row to another and have it
+decrypt successfully under the wrong identity.
+
+Unlike "rotate", this does NOT change the DEK — it is safe to run repeatedly and
+does not require --confirm, though it does hold a write lock on these three tables
+for the duration of the sweep (typically brief; they are not high-row-count tables).`,
+	RunE: runUpgradeAAD,
+}
+
 var rotateConfirm bool
 
 func init() {
 	EncryptionCmd.AddCommand(initCmd)
 	EncryptionCmd.AddCommand(statusCmd)
 	EncryptionCmd.AddCommand(rotateCmd)
+	EncryptionCmd.AddCommand(upgradeAADCmd)
 	EncryptionCmd.AddCommand(validateCmd)
 	EncryptionCmd.AddCommand(fixPermsCmd)
 	// AuthEncryptionCmd (status/enable/rotate/migrate/validate for the
@@ -222,6 +239,56 @@ func rotateWithConfig(cfg *config.Config, confirm bool) error {
 
 	fmt.Println("✅ DEK rotated successfully")
 	fmt.Printf("📋 New key version: %s\n", service.GetKeyVersion())
+	return nil
+}
+
+func runUpgradeAAD(cmd *cobra.Command, args []string) error {
+	cfg, err := loadConfig()
+	if err != nil {
+		return err
+	}
+	return upgradeAADWithConfig(cfg)
+}
+
+// upgradeAADWithConfig is the testable core of runUpgradeAAD — no config loading, no
+// flag parsing. Returns early (before any DB or encryption work) when encryption is
+// disabled or storage is remote, so tests don't need a real database or key files.
+func upgradeAADWithConfig(cfg *config.Config) error {
+	if !cfg.Storage.Encryption.Enabled {
+		return fmt.Errorf("encryption is disabled in configuration")
+	}
+	if cfg.Storage.Type == "remote" {
+		return fmt.Errorf("AAD upgrade must run on the server host. Current storage type is 'remote' — connect to the server and run this command there")
+	}
+
+	baseDir, _ := os.Getwd()
+	service := encryption.NewService(&cfg.Storage.Encryption, baseDir)
+
+	passphrase, err := masterPassphrase(cfg)
+	if err != nil {
+		return err
+	}
+	service.CleanPendingDEK()
+	if err := service.Initialize(passphrase); err != nil {
+		return fmt.Errorf("failed to initialize encryption: %w", err)
+	}
+	defer service.Shutdown()
+
+	db, err := storage.OpenGormDB(cfg)
+	if err != nil {
+		return fmt.Errorf("failed to open database for AAD upgrade: %w", err)
+	}
+	defer closeDB(db)
+
+	fmt.Println("🔄 Upgrading legacy auth-secret rows to per-row AAD...")
+	result, err := service.UpgradeAuthAAD(db)
+	if err != nil {
+		return fmt.Errorf("AAD upgrade failed: %w", err)
+	}
+
+	fmt.Println("✅ AAD upgrade complete")
+	fmt.Printf("📋 mfa_secrets: %d, dynamic_secret_configs: %d, dynamic_secret_leases: %d (legacy rows upgraded: %d)\n",
+		result.MFASecretsSwept, result.DynamicSecretConfigsSwept, result.DynamicSecretLeasesSwept, result.LegacyAADUpgraded)
 	return nil
 }
 

--- a/internal/core/dynamic_secrets.go
+++ b/internal/core/dynamic_secrets.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/dynamic"
+	"github.com/keyorixhq/keyorix/internal/encryption"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
@@ -59,17 +60,17 @@ func (c *KeyorixCore) CreateDynamicSecretConfig(ctx context.Context, req *Create
 	if !IsValidClassification(req.Classification) {
 		return nil, fmt.Errorf("classification must be one of public, internal, confidential, restricted (or empty)")
 	}
-	dsnEnc, dsnMeta, err := c.encryptAuthSecret(req.AdminDSN)
-	if err != nil {
-		return nil, fmt.Errorf("failed to encrypt admin DSN: %w", err)
-	}
+	// #94: the admin DSN is encrypted bound to DynamicSecretConfigAAD(cfg.ID, ...), so
+	// it must be encrypted AFTER the row exists (cfg.ID is an auto-increment PK, not
+	// known beforehand) — insert first with the DSN columns empty, then encrypt and
+	// persist them in a second write. The gap between the two writes is invisible to
+	// any other caller: cfg.ID isn't returned to the requester until this function
+	// returns, so nothing else can observe or race the momentarily-DSN-less row.
 	cfg, err := c.storage.CreateDynamicSecretConfig(ctx, &models.DynamicSecretConfig{
 		Name:              req.Name,
 		ProjectID:         req.ProjectID,
 		EnvironmentID:     req.EnvironmentID,
 		BackendType:       req.BackendType,
-		AdminDSNEnc:       dsnEnc,
-		AdminDSNMeta:      dsnMeta,
 		CreationTemplate:  req.CreationTemplate,
 		DefaultTTLSeconds: req.DefaultTTLSeconds,
 		MaxTTLSeconds:     req.MaxTTLSeconds,
@@ -81,6 +82,15 @@ func (c *KeyorixCore) CreateDynamicSecretConfig(ctx context.Context, req *Create
 	})
 	if err != nil {
 		return nil, err
+	}
+	dsnEnc, dsnMeta, err := c.encryptAuthSecret(req.AdminDSN, encryption.DynamicSecretConfigAAD(cfg.ID, cfg.ProjectID, cfg.EnvironmentID))
+	if err != nil {
+		return nil, fmt.Errorf("failed to encrypt admin DSN: %w", err)
+	}
+	cfg.AdminDSNEnc = dsnEnc
+	cfg.AdminDSNMeta = dsnMeta
+	if err := c.storage.UpdateDynamicSecretConfig(ctx, cfg); err != nil {
+		return nil, fmt.Errorf("failed to persist encrypted admin DSN: %w", err)
 	}
 	pid := cfg.ProjectID
 	c.writeAuditEventFull(ctx, "dynamic_secret.config_created", nil, nil, &pid, "",
@@ -165,7 +175,7 @@ func (c *KeyorixCore) IssueLease(ctx context.Context, configID uint, ttlSeconds 
 			return nil, fmt.Errorf("active-lease limit reached for this config (%d); revoke a lease before issuing another", cfg.MaxActiveLeases)
 		}
 	}
-	adminDSN, err := c.decryptAuthSecret(cfg.AdminDSNEnc, cfg.AdminDSNMeta)
+	adminDSN, err := c.decryptAuthSecret(cfg.AdminDSNEnc, cfg.AdminDSNMeta, encryption.DynamicSecretConfigAAD(cfg.ID, cfg.ProjectID, cfg.EnvironmentID))
 	if err != nil {
 		return nil, fmt.Errorf("failed to decrypt admin DSN: %w", err)
 	}
@@ -175,18 +185,21 @@ func (c *KeyorixCore) IssueLease(ctx context.Context, configID uint, ttlSeconds 
 	if err != nil {
 		return nil, fmt.Errorf("failed to issue credential: %w", err)
 	}
-	credJSON, _ := json.Marshal(cred) // #nosec G117 -- intentional: serialized only to be immediately encrypted at rest below, never persisted or logged in cleartext
-	credEnc, credMeta, err := c.encryptAuthSecret(string(credJSON))
-	if err != nil {
-		// The role exists on the target — revoke it so we don't leak it.
-		c.cleanupOrphanedRole(ctx, cfg, engine, adminDSN, roleName, userID)
-		return nil, fmt.Errorf("failed to encrypt credential: %w", err)
-	}
-
+	// leaseID is generated BEFORE encryption (not after, as in the pre-#94 order) so
+	// DynamicSecretLeaseAAD can bind the credential's ciphertext to it — leaseID is a
+	// random token assigned by us, not an auto-increment PK, so it's available without
+	// a two-phase insert-then-update (contrast CreateDynamicSecretConfig above).
 	leaseID, err := generateSecureToken()
 	if err != nil {
 		c.cleanupOrphanedRole(ctx, cfg, engine, adminDSN, roleName, userID)
 		return nil, err
+	}
+	credJSON, _ := json.Marshal(cred) // #nosec G117 -- intentional: serialized only to be immediately encrypted at rest below, never persisted or logged in cleartext
+	credEnc, credMeta, err := c.encryptAuthSecret(string(credJSON), encryption.DynamicSecretLeaseAAD(leaseID, cfg.ID))
+	if err != nil {
+		// The role exists on the target — revoke it so we don't leak it.
+		c.cleanupOrphanedRole(ctx, cfg, engine, adminDSN, roleName, userID)
+		return nil, fmt.Errorf("failed to encrypt credential: %w", err)
 	}
 	expiresAt := c.now().Add(ttl)
 	lease, err := c.storage.CreateDynamicSecretLease(ctx, &models.DynamicSecretLease{
@@ -276,7 +289,7 @@ func (c *KeyorixCore) RevokeLease(ctx context.Context, leaseID string, userID ui
 	if err != nil {
 		return err
 	}
-	adminDSN, err := c.decryptAuthSecret(cfg.AdminDSNEnc, cfg.AdminDSNMeta)
+	adminDSN, err := c.decryptAuthSecret(cfg.AdminDSNEnc, cfg.AdminDSNMeta, encryption.DynamicSecretConfigAAD(cfg.ID, cfg.ProjectID, cfg.EnvironmentID))
 	if err != nil {
 		return fmt.Errorf("failed to decrypt admin DSN: %w", err)
 	}
@@ -438,7 +451,7 @@ func (c *KeyorixCore) RenewLease(ctx context.Context, leaseID string, ttlSeconds
 	if !engine.SupportsNativeExpiry() && !c.dynamicSweepEnabled {
 		return time.Time{}, fmt.Errorf("renewal is unavailable for the %s backend while the lease sweeper is disabled (its TTL would be unenforced)", cfg.BackendType)
 	}
-	adminDSN, err := c.decryptAuthSecret(cfg.AdminDSNEnc, cfg.AdminDSNMeta)
+	adminDSN, err := c.decryptAuthSecret(cfg.AdminDSNEnc, cfg.AdminDSNMeta, encryption.DynamicSecretConfigAAD(cfg.ID, cfg.ProjectID, cfg.EnvironmentID))
 	if err != nil {
 		return time.Time{}, fmt.Errorf("failed to decrypt admin DSN: %w", err)
 	}

--- a/internal/core/dynamic_secrets_test.go
+++ b/internal/core/dynamic_secrets_test.go
@@ -68,6 +68,36 @@ func TestDynamicSecrets_ConfigEncryptsAdminDSN(t *testing.T) {
 	assert.NotEqual(t, adminDSNPlain, string(stored.AdminDSNEnc))
 }
 
+// #94: a DB-write attacker who copies one config's encrypted admin DSN onto a
+// DIFFERENT config's row must NOT have it decrypt successfully — that would let
+// Keyorix connect to (and potentially reveal error/behavioral detail about) a
+// target it was never configured to reach for that config, using credentials
+// scoped to a different backend entirely. This exercises the live IssueLease
+// (decryptAuthSecret) path end-to-end, not just the low-level AEAD primitive.
+func TestDynamicSecrets_AdminDSNTransplantBetweenConfigsFailsToDecrypt(t *testing.T) {
+	c, db, _, _ := newDynamicTestCore(t)
+	ctx := context.Background()
+	cfgA := mkConfig(t, c, ctx)
+	cfgB, err := c.CreateDynamicSecretConfig(ctx, &CreateDynamicSecretConfigRequest{
+		Name: "other-db", ProjectID: 1, BackendType: "postgres",
+		AdminDSN: "postgres://admin:different@other-db.internal:5432/app",
+		DefaultTTLSeconds: 3600,
+	})
+	require.NoError(t, err)
+
+	// Simulate a DB-write attacker: copy config A's encrypted admin DSN onto B's row.
+	rowA, err := c.storage.GetDynamicSecretConfig(ctx, cfgA.ID)
+	require.NoError(t, err)
+	require.NoError(t, db.Model(&models.DynamicSecretConfig{}).Where("id = ?", cfgB.ID).Updates(map[string]interface{}{
+		"admin_dsn_enc":  rowA.AdminDSNEnc,
+		"admin_dsn_meta": rowA.AdminDSNMeta,
+	}).Error)
+
+	_, err = c.IssueLease(ctx, cfgB.ID, 0, 7)
+	require.Error(t, err, "an admin DSN transplanted from a different config must fail to decrypt, not silently succeed")
+	assert.Contains(t, err.Error(), "decrypt admin DSN")
+}
+
 func TestDynamicSecrets_MaxActiveLeasesCeiling(t *testing.T) {
 	c, _, _, _ := newDynamicTestCore(t)
 	ctx := context.Background()

--- a/internal/core/mfa.go
+++ b/internal/core/mfa.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/keyorixhq/keyorix/internal/encryption"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/pquerna/otp"
 	"github.com/pquerna/otp/totp"
@@ -46,7 +47,7 @@ func (c *KeyorixCore) BeginMFAEnrollment(ctx context.Context, userID uint) (otpa
 	if err != nil {
 		return "", "", fmt.Errorf("failed to generate TOTP secret: %w", err)
 	}
-	ct, meta, err := c.encryptAuthSecret(key.Secret())
+	ct, meta, err := c.encryptAuthSecret(key.Secret(), encryption.MFASecretAAD(userID))
 	if err != nil {
 		return "", "", fmt.Errorf("failed to encrypt TOTP secret: %w", err)
 	}
@@ -292,7 +293,7 @@ func (c *KeyorixCore) loadTOTPSecret(ctx context.Context, userID uint) (string, 
 	if err != nil {
 		return "", err
 	}
-	return c.decryptAuthSecret(row.SecretEnc, row.SecretMeta)
+	return c.decryptAuthSecret(row.SecretEnc, row.SecretMeta, encryption.MFASecretAAD(userID))
 }
 
 func (c *KeyorixCore) validateTOTP(secret, code string) bool {

--- a/internal/core/mfa_test.go
+++ b/internal/core/mfa_test.go
@@ -410,3 +410,37 @@ func TestRegenerateMFARecoveryCodes_FailedCodesFeedAccountLockout(t *testing.T) 
 	_, _, err = c.VerifyMFALogin(ctx, ch, original[0], "ua", "1.2.3.4")
 	require.NoError(t, err, "original recovery code must still work; regenerate was blocked by the lock")
 }
+
+// #94: a DB-write attacker who copies one user's encrypted TOTP seed onto another
+// user's mfa_secrets row must NOT have it decrypt successfully — that would let
+// bob's account accept codes generated from alice's TOTP seed, a stealthy MFA
+// bypass that survives even if alice regenerates her own codes. This directly
+// exercises the live decryptAuthSecret/loadTOTPSecret path (not just the low-level
+// AEAD primitive), proving the AAD wiring — not merely its existence — is correct.
+func TestMFA_TOTPSecretTransplantBetweenUsersFailsToDecrypt(t *testing.T) {
+	c, db, fixed := newMFATestCore(t)
+	ctx := context.Background()
+	require.NoError(t, db.Create(&models.User{ID: 2, Username: "bob", Email: "b@b.com",
+		PasswordHash: "x", AccountState: "active"}).Error)
+
+	_, aliceSecret, err := c.BeginMFAEnrollment(ctx, 1)
+	require.NoError(t, err)
+	aliceCode, err := totp.GenerateCode(aliceSecret, fixed)
+	require.NoError(t, err)
+	_, err = c.ActivateMFA(ctx, 1, aliceCode)
+	require.NoError(t, err)
+
+	_, _, err = c.BeginMFAEnrollment(ctx, 2)
+	require.NoError(t, err)
+
+	// Simulate a DB-write attacker: copy alice's encrypted TOTP row onto bob's.
+	aliceRow, err := c.storage.GetMFASecret(ctx, 1)
+	require.NoError(t, err)
+	require.NoError(t, db.Model(&models.MFASecret{}).Where("user_id = ?", 2).Updates(map[string]interface{}{
+		"secret_enc":  aliceRow.SecretEnc,
+		"secret_meta": aliceRow.SecretMeta,
+	}).Error)
+
+	_, err = c.loadTOTPSecret(ctx, 2)
+	require.Error(t, err, "a TOTP secret transplanted from another user's row must fail to decrypt, not silently succeed")
+}

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -402,20 +402,28 @@ func (c *KeyorixCore) SetAuthEncryptor(s *encryption.Service) {
 	c.authEncryptor = s
 }
 
-// encryptAuthSecret reversibly encrypts plain; passthrough when encryption is off.
-func (c *KeyorixCore) encryptAuthSecret(plain string) (ct, meta []byte, err error) {
+// encryptAuthSecret reversibly encrypts plain, bound to aad (#94: MFASecretAAD /
+// DynamicSecretConfigAAD / DynamicSecretLeaseAAD — never nil for a live caller, so a
+// DB-write attacker cannot transplant one row's ciphertext onto another's identity and
+// have it decrypt). Passthrough when encryption is off.
+func (c *KeyorixCore) encryptAuthSecret(plain string, aad []byte) (ct, meta []byte, err error) {
 	if c.authEncryptor == nil || !c.authEncryptor.IsEnabled() {
 		return []byte(plain), nil, nil
 	}
-	return c.authEncryptor.EncryptSecret([]byte(plain))
+	return c.authEncryptor.EncryptSecretWithAAD([]byte(plain), aad)
 }
 
-// decryptAuthSecret reverses encryptAuthSecret; passthrough when encryption is off.
-func (c *KeyorixCore) decryptAuthSecret(ct, _ []byte) (string, error) {
+// decryptAuthSecret reverses encryptAuthSecret. aad must be reconstructed from the
+// row's own identity, identically to how it was encrypted. Falls back to a legacy
+// nil-AAD decrypt for rows encrypted before #94 (Service.DecryptSecretWithAAD's own
+// AADVersion branch — see SecretEncryption for the same pattern on secret values);
+// the sweep upgrades those rows to AAD-bound in place. Passthrough when encryption is
+// off.
+func (c *KeyorixCore) decryptAuthSecret(ct, _ []byte, aad []byte) (string, error) {
 	if c.authEncryptor == nil || !c.authEncryptor.IsEnabled() {
 		return string(ct), nil
 	}
-	plain, err := c.authEncryptor.DecryptSecret(ct)
+	plain, err := c.authEncryptor.DecryptSecretWithAAD(ct, aad)
 	if err != nil {
 		return "", err
 	}

--- a/internal/encryption/aad_auth_transplant_test.go
+++ b/internal/encryption/aad_auth_transplant_test.go
@@ -1,0 +1,81 @@
+package encryption
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAEAD_MFASecretAADBindsCiphertextToOwningUser pins the #94 fix for TOTP shared
+// secrets: a ciphertext sealed with MFASecretAAD(userID) cannot be decrypted under a
+// different user's identity. Without this, a DB-write attacker could copy user A's
+// encrypted TOTP seed into user B's mfa_secrets row — B's login would then accept
+// codes generated from A's seed (a stealthy, persistent MFA bypass).
+func TestAEAD_MFASecretAADBindsCiphertextToOwningUser(t *testing.T) {
+	es := newTestEncryptionService(t)
+	plaintext := []byte("JBSWY3DPEHPK3PXP") // a base32 TOTP seed shape
+
+	aadA := MFASecretAAD(42)
+	enc, err := es.EncryptWithAAD(plaintext, testKeyVersion, aadA)
+	require.NoError(t, err)
+
+	got, err := es.DecryptWithAAD(enc, aadA)
+	require.NoError(t, err)
+	assert.True(t, bytes.Equal(plaintext, got), "the binding AAD must round-trip")
+
+	_, err = es.DecryptWithAAD(enc, MFASecretAAD(43))
+	require.Error(t, err, "a TOTP seed ciphertext transplanted onto a different user's row must not decrypt")
+}
+
+// TestAEAD_DynamicSecretConfigAADBindsCiphertextToOwningConfig pins the #94 fix for
+// dynamic-secret admin DSNs: a ciphertext sealed with
+// DynamicSecretConfigAAD(id, projectID, environmentID) cannot be decrypted under a
+// different config's identity, project, or environment. Without this, an attacker
+// could transplant one target's encrypted admin credential onto a DIFFERENT config
+// row and have Keyorix connect to the wrong (attacker's own, or another tenant's)
+// database using credentials it was never authorized to use for that config.
+func TestAEAD_DynamicSecretConfigAADBindsCiphertextToOwningConfig(t *testing.T) {
+	es := newTestEncryptionService(t)
+	plaintext := []byte("postgres://admin:s3cr3t@db.internal:5432/app")
+
+	aadA := DynamicSecretConfigAAD(10, 1, 2)
+	enc, err := es.EncryptWithAAD(plaintext, testKeyVersion, aadA)
+	require.NoError(t, err)
+
+	got, err := es.DecryptWithAAD(enc, aadA)
+	require.NoError(t, err)
+	assert.True(t, bytes.Equal(plaintext, got), "the binding AAD must round-trip")
+
+	_, err = es.DecryptWithAAD(enc, DynamicSecretConfigAAD(11, 1, 2))
+	require.Error(t, err, "an admin DSN transplanted onto a different config ID must not decrypt")
+	_, err = es.DecryptWithAAD(enc, DynamicSecretConfigAAD(10, 3, 2))
+	require.Error(t, err, "an admin DSN relabeled to a different project must not decrypt")
+	_, err = es.DecryptWithAAD(enc, DynamicSecretConfigAAD(10, 1, 5))
+	require.Error(t, err, "an admin DSN relabeled to a different environment must not decrypt")
+}
+
+// TestAEAD_DynamicSecretLeaseAADBindsCiphertextToOwningLease pins the #94 fix for
+// issued dynamic-secret credentials: a ciphertext sealed with
+// DynamicSecretLeaseAAD(leaseID, configID) cannot be decrypted under a different
+// lease or a different owning config. Without this, an attacker could transplant one
+// principal's issued credential (returned once, on issue) onto another lease row and
+// have RevokeLease/RenewLease act on it under the wrong identity.
+func TestAEAD_DynamicSecretLeaseAADBindsCiphertextToOwningLease(t *testing.T) {
+	es := newTestEncryptionService(t)
+	plaintext := []byte(`{"username":"kx_role_abc","password":"hunter2"}`)
+
+	aadA := DynamicSecretLeaseAAD("lease-aaa", 5)
+	enc, err := es.EncryptWithAAD(plaintext, testKeyVersion, aadA)
+	require.NoError(t, err)
+
+	got, err := es.DecryptWithAAD(enc, aadA)
+	require.NoError(t, err)
+	assert.True(t, bytes.Equal(plaintext, got), "the binding AAD must round-trip")
+
+	_, err = es.DecryptWithAAD(enc, DynamicSecretLeaseAAD("lease-bbb", 5))
+	require.Error(t, err, "a credential transplanted onto a different lease ID must not decrypt")
+	_, err = es.DecryptWithAAD(enc, DynamicSecretLeaseAAD("lease-aaa", 6))
+	require.Error(t, err, "a credential relabeled to a different owning config must not decrypt")
+}

--- a/internal/encryption/encryption.go
+++ b/internal/encryption/encryption.go
@@ -139,6 +139,36 @@ func SecretAAD(secretID, projectID uint, versionNumber int) []byte {
 	return []byte(fmt.Sprintf("keyorix:v2:%d:%d:%d", secretID, projectID, versionNumber))
 }
 
+// MFASecretAAD returns the AAD for a user's encrypted TOTP shared secret (#94),
+// binding the ciphertext to the owning user so a DB-write attacker cannot transplant
+// one user's encrypted TOTP seed onto another user's row. MFASecret is keyed 1:1 on
+// UserID (a uniqueIndex, never reassigned), so this alone is a stable, sufficient
+// owning identity. Domain-separated from SecretAAD's "keyorix:v2:" prefix so a
+// transplant across CATEGORIES (e.g. a SecretVersion blob pasted into an MFASecret
+// row) also fails, not just a transplant within the same category.
+func MFASecretAAD(userID uint) []byte {
+	return []byte(fmt.Sprintf("keyorix:mfa:v1:%d", userID))
+}
+
+// DynamicSecretConfigAAD returns the AAD for a dynamic-secret config's encrypted admin
+// DSN (#94), binding the ciphertext to the config's identity and project/environment
+// scope. None of configID/projectID/environmentID are reassigned after creation (see
+// DynamicSecretConfig — only Classification is ever updated).
+func DynamicSecretConfigAAD(configID, projectID, environmentID uint) []byte {
+	return []byte(fmt.Sprintf("keyorix:dynsecret-config:v1:%d:%d:%d", configID, projectID, environmentID))
+}
+
+// DynamicSecretLeaseAAD returns the AAD for an issued dynamic-secret lease's encrypted
+// credential (#94), binding the ciphertext to the lease's identity and owning config —
+// leases are issue-once (revoke/expire only), never reassigned to a different config.
+// Takes the lease's external string LeaseID (a random token, gorm:"uniqueIndex"), not
+// its numeric primary key — LeaseID is generated before the row is inserted, so the
+// caller can bind and encrypt the credential in one pass rather than needing a
+// two-phase insert-then-update to learn an auto-increment ID first.
+func DynamicSecretLeaseAAD(leaseID string, configID uint) []byte {
+	return []byte(fmt.Sprintf("keyorix:dynsecret-lease:v1:%s:%d", leaseID, configID))
+}
+
 // EncryptWithAAD encrypts data using AES-GCM with Additional Authenticated Data.
 // The AAD is mixed into the GCM authentication tag — it is not stored in the
 // ciphertext but must be supplied identically on decryption.

--- a/internal/encryption/service_rotation.go
+++ b/internal/encryption/service_rotation.go
@@ -68,6 +68,73 @@ func (s *Service) RotateDEKWithSweep(passphrase string, db *gorm.DB) error {
 	return nil
 }
 
+// UpgradeAuthAAD re-encrypts every legacy (pre-#94), no-AAD row in the AAD-bound auth
+// tables (mfa_secrets, dynamic_secret_configs, dynamic_secret_leases) UNDER THE
+// CURRENT DEK — no key rotation involved. Rows already AAD-bound are re-encrypted
+// too (a fresh nonce, same AAD), so the sweep is idempotent and safe to re-run.
+//
+// This exists so closing the #94 AAD-transplant exposure for these tables doesn't
+// require an operator to perform a full, write-locking DEK rotation (RotateDEKWithSweep)
+// — a live install can run this on its own schedule (or a one-off CLI invocation)
+// while the DEK stays exactly as it was. secret_versions rows are NOT touched here:
+// they've been AAD-bound since the M2 migration and are only ever upgraded as a
+// side effect of a real DEK rotation's sweep.
+//
+// The DB transaction is owned here, matching RotateDEKWithSweep: committed on
+// success, rolled back on any failure.
+func (s *Service) UpgradeAuthAAD(db *gorm.DB) (*SweepResult, error) {
+	s.mu.RLock()
+	if !s.initialized {
+		s.mu.RUnlock()
+		return nil, fmt.Errorf("encryption service not initialized")
+	}
+	svc := s.encryptionService
+	keyVersion := s.keyManager.GetKeyVersion()
+	s.mu.RUnlock()
+
+	tx := db.Begin()
+	if tx.Error != nil {
+		return nil, fmt.Errorf("failed to begin transaction: %w", tx.Error)
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			tx.Rollback()
+		}
+	}()
+
+	result := &SweepResult{}
+	sweptMFA, legacyMFA, err := sweepMFASecrets(tx, svc, svc, keyVersion)
+	if err != nil {
+		tx.Rollback()
+		return nil, fmt.Errorf("mfa_secrets AAD upgrade failed: %w", err)
+	}
+	result.MFASecretsSwept = sweptMFA
+	result.LegacyAADUpgraded += legacyMFA
+
+	sweptDynConfigs, legacyDynConfigs, err := sweepDynamicSecretConfigs(tx, svc, svc, keyVersion)
+	if err != nil {
+		tx.Rollback()
+		return nil, fmt.Errorf("dynamic_secret_configs AAD upgrade failed: %w", err)
+	}
+	result.DynamicSecretConfigsSwept = sweptDynConfigs
+	result.LegacyAADUpgraded += legacyDynConfigs
+
+	sweptDynLeases, legacyDynLeases, err := sweepDynamicSecretLeases(tx, svc, svc, keyVersion)
+	if err != nil {
+		tx.Rollback()
+		return nil, fmt.Errorf("dynamic_secret_leases AAD upgrade failed: %w", err)
+	}
+	result.DynamicSecretLeasesSwept = sweptDynLeases
+	result.LegacyAADUpgraded += legacyDynLeases
+
+	if err := tx.Commit().Error; err != nil {
+		return nil, fmt.Errorf("failed to commit AAD upgrade transaction: %w", err)
+	}
+	log.Printf("✅ AAD upgrade committed: %d mfa_secrets, %d dynamic_secret_configs, %d dynamic_secret_leases re-encrypted (%d legacy AAD upgraded)",
+		result.MFASecretsSwept, result.DynamicSecretConfigsSwept, result.DynamicSecretLeasesSwept, result.LegacyAADUpgraded)
+	return result, nil
+}
+
 // RotateDEK rotates the DEK without re-encrypting existing secrets.
 // DEPRECATED: Use RotateDEKWithSweep instead. See ADR-010.
 func (s *Service) RotateDEK(passphrase string) error {

--- a/internal/encryption/sweep.go
+++ b/internal/encryption/sweep.go
@@ -73,27 +73,32 @@ func SweepAllTables(tx *gorm.DB, oldSvc *EncryptionService, newSvc *EncryptionSe
 	}
 	result.PasswordResetsSwept = sweptResets
 
-	// These three tables are also DEK-encrypted (via Service.EncryptSecret) but were
-	// previously omitted from the sweep — so a DEK rotation orphaned their ciphertext
-	// under the wiped old key (TOTP secrets, dynamic-secret admin DSNs and lease
-	// credentials), breaking MFA login and dynamic-secret access irrecoverably.
-	sweptMFA, err := sweepMFASecrets(tx, oldSvc, newSvc, newKeyVersion)
+	// These three tables are also DEK-encrypted but were previously omitted from the
+	// sweep entirely — so a DEK rotation orphaned their ciphertext under the wiped old
+	// key (TOTP secrets, dynamic-secret admin DSNs and lease credentials), breaking
+	// MFA login and dynamic-secret access irrecoverably. They are also AAD-bound
+	// (#94) as of this fix, so — like sweepSecretVersions — each also upgrades any
+	// still-legacy (no-AAD) row it encounters, contributing to LegacyAADUpgraded.
+	sweptMFA, legacyMFA, err := sweepMFASecrets(tx, oldSvc, newSvc, newKeyVersion)
 	if err != nil {
 		return nil, fmt.Errorf("mfa_secrets sweep failed: %w", err)
 	}
 	result.MFASecretsSwept = sweptMFA
+	result.LegacyAADUpgraded += legacyMFA
 
-	sweptDynConfigs, err := sweepDynamicSecretConfigs(tx, oldSvc, newSvc, newKeyVersion)
+	sweptDynConfigs, legacyDynConfigs, err := sweepDynamicSecretConfigs(tx, oldSvc, newSvc, newKeyVersion)
 	if err != nil {
 		return nil, fmt.Errorf("dynamic_secret_configs sweep failed: %w", err)
 	}
 	result.DynamicSecretConfigsSwept = sweptDynConfigs
+	result.LegacyAADUpgraded += legacyDynConfigs
 
-	sweptDynLeases, err := sweepDynamicSecretLeases(tx, oldSvc, newSvc, newKeyVersion)
+	sweptDynLeases, legacyDynLeases, err := sweepDynamicSecretLeases(tx, oldSvc, newSvc, newKeyVersion)
 	if err != nil {
 		return nil, fmt.Errorf("dynamic_secret_leases sweep failed: %w", err)
 	}
 	result.DynamicSecretLeasesSwept = sweptDynLeases
+	result.LegacyAADUpgraded += legacyDynLeases
 
 	return result, nil
 }

--- a/internal/encryption/sweep_auth.go
+++ b/internal/encryption/sweep_auth.go
@@ -1,8 +1,16 @@
-// sweep_auth.go — Re-encryption sweep for auth tables (sessions, API tokens, clients, password resets).
+// sweep_auth.go — Re-encryption sweep for auth tables (sessions, API tokens, clients,
+// password resets, MFA secrets, dynamic-secret configs/leases).
 //
-// These four sweepers follow an identical pattern: fetch all rows, decrypt with
-// oldSvc, re-encrypt with newSvc, write back. No AAD required (auth tokens are
-// not AAD-bound). See sweep.go for the AAD-aware secret_versions sweep.
+// sweepSessions/sweepAPITokens/sweepAPIClients/sweepPasswordResets follow an identical
+// pattern: fetch all rows, decrypt with oldSvc, re-encrypt with newSvc, write back. No
+// AAD (these 4 tables' encrypted columns are unpopulated by any live write path today
+// — see #129 — so they carry no AAD-transplant exposure to close).
+//
+// sweepMFASecrets/sweepDynamicSecretConfigs/sweepDynamicSecretLeases (#94) ARE
+// live-path AAD-bound categories: they reconstruct each row's AAD from its own
+// identity (mirroring sweepSecretVersions in sweep.go) and, like it, decrypt via
+// either the legacy no-AAD path or the AAD-aware path depending on the row's stored
+// AADVersion, then ALWAYS re-encrypt with AAD — upgrading legacy rows in place.
 package encryption
 
 import (
@@ -139,141 +147,180 @@ func sweepAPIClients(tx *gorm.DB, oldSvc *EncryptionService, newSvc *EncryptionS
 	return swept, nil
 }
 
-// sweepMFASecrets re-encrypts TOTP secrets (mfa_secrets.secret_enc). These are
-// written via Service.EncryptSecret (no AAD), the same serialization as the auth
-// tokens above. Missing this sweeper meant a DEK rotation left every enrolled TOTP
-// secret encrypted under the wiped old DEK — permanently breaking MFA login.
-func sweepMFASecrets(tx *gorm.DB, oldSvc *EncryptionService, newSvc *EncryptionService, newKeyVersion string) (int, error) {
+// sweepMFASecrets re-encrypts TOTP secrets (mfa_secrets.secret_enc), bound to
+// MFASecretAAD(UserID) (#94). Legacy (pre-#94) rows are decrypted via the no-AAD
+// path and always re-encrypted WITH AAD, upgrading them in place — mirrors
+// sweepSecretVersions's legacy-branch pattern. Missing this sweeper's re-encryption
+// step entirely (the original gap, ADR-010) meant a DEK rotation left every enrolled
+// TOTP secret encrypted under the wiped old DEK — permanently breaking MFA login.
+// Returns (rowsSwept, legacyRowsUpgraded, error).
+func sweepMFASecrets(tx *gorm.DB, oldSvc *EncryptionService, newSvc *EncryptionService, newKeyVersion string) (int, int, error) {
 	var rows []models.MFASecret
 	if err := tx.Find(&rows).Error; err != nil {
-		return 0, fmt.Errorf("failed to fetch mfa_secrets: %w", err)
+		return 0, 0, fmt.Errorf("failed to fetch mfa_secrets: %w", err)
 	}
-	swept := 0
+	swept, legacyUpgraded := 0, 0
 	for _, row := range rows {
 		if len(row.SecretEnc) == 0 {
 			continue
 		}
 		encrypted, err := DeserializeEncryptedData(row.SecretEnc)
 		if err != nil {
-			return swept, fmt.Errorf("failed to deserialize mfa_secret id=%d: %w", row.ID, err)
+			return swept, legacyUpgraded, fmt.Errorf("failed to deserialize mfa_secret id=%d: %w", row.ID, err)
 		}
-		plaintext, err := oldSvc.Decrypt(encrypted)
+		aad := MFASecretAAD(row.UserID)
+		isLegacy := encrypted.Metadata.AADVersion == ""
+		var plaintext []byte
+		if isLegacy {
+			plaintext, err = oldSvc.Decrypt(encrypted)
+		} else {
+			plaintext, err = oldSvc.DecryptWithAAD(encrypted, aad)
+		}
 		if err != nil {
-			return swept, fmt.Errorf("failed to decrypt mfa_secret id=%d: %w", row.ID, err)
+			return swept, legacyUpgraded, fmt.Errorf("failed to decrypt mfa_secret id=%d: %w", row.ID, err)
 		}
-		newEncrypted, err := newSvc.Encrypt(plaintext, newKeyVersion)
+		newEncrypted, err := newSvc.EncryptWithAAD(plaintext, newKeyVersion, aad)
 		wipeBytes(plaintext)
 		if err != nil {
-			return swept, fmt.Errorf("failed to re-encrypt mfa_secret id=%d: %w", row.ID, err)
+			return swept, legacyUpgraded, fmt.Errorf("failed to re-encrypt mfa_secret id=%d: %w", row.ID, err)
 		}
 		newBytes, err := SerializeEncryptedData(newEncrypted)
 		if err != nil {
-			return swept, fmt.Errorf("failed to serialize mfa_secret id=%d: %w", row.ID, err)
+			return swept, legacyUpgraded, fmt.Errorf("failed to serialize mfa_secret id=%d: %w", row.ID, err)
 		}
 		metaBytes, err := json.Marshal(newEncrypted.Metadata)
 		if err != nil {
-			return swept, fmt.Errorf("failed to marshal mfa_secret metadata id=%d: %w", row.ID, err)
+			return swept, legacyUpgraded, fmt.Errorf("failed to marshal mfa_secret metadata id=%d: %w", row.ID, err)
 		}
 		if err := tx.Model(&models.MFASecret{}).Where("id = ?", row.ID).Updates(map[string]interface{}{
 			"secret_enc":  newBytes,
 			"secret_meta": metaBytes,
 		}).Error; err != nil {
-			return swept, fmt.Errorf("failed to update mfa_secret id=%d: %w", row.ID, err)
+			return swept, legacyUpgraded, fmt.Errorf("failed to update mfa_secret id=%d: %w", row.ID, err)
 		}
 		swept++
+		if isLegacy {
+			legacyUpgraded++
+		}
 	}
-	return swept, nil
+	return swept, legacyUpgraded, nil
 }
 
 // sweepDynamicSecretConfigs re-encrypts dynamic-secret admin DSNs
-// (dynamic_secret_configs.admin_dsn_enc). Missing this left the admin connection
-// string undecryptable after rotation — the backend could no longer be reached or
-// its leases revoked.
-func sweepDynamicSecretConfigs(tx *gorm.DB, oldSvc *EncryptionService, newSvc *EncryptionService, newKeyVersion string) (int, error) {
+// (dynamic_secret_configs.admin_dsn_enc), bound to
+// DynamicSecretConfigAAD(ID, ProjectID, EnvironmentID) (#94). Legacy rows are
+// upgraded to AAD in place — see sweepMFASecrets. Missing this sweeper's
+// re-encryption step entirely (the original gap, ADR-010) left the admin connection
+// string undecryptable after a DEK rotation — the backend could no longer be reached
+// or its leases revoked. Returns (rowsSwept, legacyRowsUpgraded, error).
+func sweepDynamicSecretConfigs(tx *gorm.DB, oldSvc *EncryptionService, newSvc *EncryptionService, newKeyVersion string) (int, int, error) {
 	var rows []models.DynamicSecretConfig
 	if err := tx.Find(&rows).Error; err != nil {
-		return 0, fmt.Errorf("failed to fetch dynamic_secret_configs: %w", err)
+		return 0, 0, fmt.Errorf("failed to fetch dynamic_secret_configs: %w", err)
 	}
-	swept := 0
+	swept, legacyUpgraded := 0, 0
 	for _, row := range rows {
 		if len(row.AdminDSNEnc) == 0 {
 			continue
 		}
 		encrypted, err := DeserializeEncryptedData(row.AdminDSNEnc)
 		if err != nil {
-			return swept, fmt.Errorf("failed to deserialize dynamic_secret_config id=%d: %w", row.ID, err)
+			return swept, legacyUpgraded, fmt.Errorf("failed to deserialize dynamic_secret_config id=%d: %w", row.ID, err)
 		}
-		plaintext, err := oldSvc.Decrypt(encrypted)
+		aad := DynamicSecretConfigAAD(row.ID, row.ProjectID, row.EnvironmentID)
+		isLegacy := encrypted.Metadata.AADVersion == ""
+		var plaintext []byte
+		if isLegacy {
+			plaintext, err = oldSvc.Decrypt(encrypted)
+		} else {
+			plaintext, err = oldSvc.DecryptWithAAD(encrypted, aad)
+		}
 		if err != nil {
-			return swept, fmt.Errorf("failed to decrypt dynamic_secret_config id=%d: %w", row.ID, err)
+			return swept, legacyUpgraded, fmt.Errorf("failed to decrypt dynamic_secret_config id=%d: %w", row.ID, err)
 		}
-		newEncrypted, err := newSvc.Encrypt(plaintext, newKeyVersion)
+		newEncrypted, err := newSvc.EncryptWithAAD(plaintext, newKeyVersion, aad)
 		wipeBytes(plaintext)
 		if err != nil {
-			return swept, fmt.Errorf("failed to re-encrypt dynamic_secret_config id=%d: %w", row.ID, err)
+			return swept, legacyUpgraded, fmt.Errorf("failed to re-encrypt dynamic_secret_config id=%d: %w", row.ID, err)
 		}
 		newBytes, err := SerializeEncryptedData(newEncrypted)
 		if err != nil {
-			return swept, fmt.Errorf("failed to serialize dynamic_secret_config id=%d: %w", row.ID, err)
+			return swept, legacyUpgraded, fmt.Errorf("failed to serialize dynamic_secret_config id=%d: %w", row.ID, err)
 		}
 		metaBytes, err := json.Marshal(newEncrypted.Metadata)
 		if err != nil {
-			return swept, fmt.Errorf("failed to marshal dynamic_secret_config metadata id=%d: %w", row.ID, err)
+			return swept, legacyUpgraded, fmt.Errorf("failed to marshal dynamic_secret_config metadata id=%d: %w", row.ID, err)
 		}
 		if err := tx.Model(&models.DynamicSecretConfig{}).Where("id = ?", row.ID).Updates(map[string]interface{}{
 			"admin_dsn_enc":  newBytes,
 			"admin_dsn_meta": metaBytes,
 		}).Error; err != nil {
-			return swept, fmt.Errorf("failed to update dynamic_secret_config id=%d: %w", row.ID, err)
+			return swept, legacyUpgraded, fmt.Errorf("failed to update dynamic_secret_config id=%d: %w", row.ID, err)
 		}
 		swept++
+		if isLegacy {
+			legacyUpgraded++
+		}
 	}
-	return swept, nil
+	return swept, legacyUpgraded, nil
 }
 
 // sweepDynamicSecretLeases re-encrypts issued dynamic-secret credentials
-// (dynamic_secret_leases.credential_enc). Missing this left active lease
-// credentials undecryptable after rotation.
-func sweepDynamicSecretLeases(tx *gorm.DB, oldSvc *EncryptionService, newSvc *EncryptionService, newKeyVersion string) (int, error) {
+// (dynamic_secret_leases.credential_enc), bound to
+// DynamicSecretLeaseAAD(LeaseID, ConfigID) (#94). Legacy rows are upgraded to AAD in
+// place — see sweepMFASecrets. Missing this sweeper's re-encryption step entirely
+// (the original gap, ADR-010) left active lease credentials undecryptable after a DEK
+// rotation. Returns (rowsSwept, legacyRowsUpgraded, error).
+func sweepDynamicSecretLeases(tx *gorm.DB, oldSvc *EncryptionService, newSvc *EncryptionService, newKeyVersion string) (int, int, error) {
 	var rows []models.DynamicSecretLease
 	if err := tx.Find(&rows).Error; err != nil {
-		return 0, fmt.Errorf("failed to fetch dynamic_secret_leases: %w", err)
+		return 0, 0, fmt.Errorf("failed to fetch dynamic_secret_leases: %w", err)
 	}
-	swept := 0
+	swept, legacyUpgraded := 0, 0
 	for _, row := range rows {
 		if len(row.CredentialEnc) == 0 {
 			continue
 		}
 		encrypted, err := DeserializeEncryptedData(row.CredentialEnc)
 		if err != nil {
-			return swept, fmt.Errorf("failed to deserialize dynamic_secret_lease id=%d: %w", row.ID, err)
+			return swept, legacyUpgraded, fmt.Errorf("failed to deserialize dynamic_secret_lease id=%d: %w", row.ID, err)
 		}
-		plaintext, err := oldSvc.Decrypt(encrypted)
+		aad := DynamicSecretLeaseAAD(row.LeaseID, row.ConfigID)
+		isLegacy := encrypted.Metadata.AADVersion == ""
+		var plaintext []byte
+		if isLegacy {
+			plaintext, err = oldSvc.Decrypt(encrypted)
+		} else {
+			plaintext, err = oldSvc.DecryptWithAAD(encrypted, aad)
+		}
 		if err != nil {
-			return swept, fmt.Errorf("failed to decrypt dynamic_secret_lease id=%d: %w", row.ID, err)
+			return swept, legacyUpgraded, fmt.Errorf("failed to decrypt dynamic_secret_lease id=%d: %w", row.ID, err)
 		}
-		newEncrypted, err := newSvc.Encrypt(plaintext, newKeyVersion)
+		newEncrypted, err := newSvc.EncryptWithAAD(plaintext, newKeyVersion, aad)
 		wipeBytes(plaintext)
 		if err != nil {
-			return swept, fmt.Errorf("failed to re-encrypt dynamic_secret_lease id=%d: %w", row.ID, err)
+			return swept, legacyUpgraded, fmt.Errorf("failed to re-encrypt dynamic_secret_lease id=%d: %w", row.ID, err)
 		}
 		newBytes, err := SerializeEncryptedData(newEncrypted)
 		if err != nil {
-			return swept, fmt.Errorf("failed to serialize dynamic_secret_lease id=%d: %w", row.ID, err)
+			return swept, legacyUpgraded, fmt.Errorf("failed to serialize dynamic_secret_lease id=%d: %w", row.ID, err)
 		}
 		metaBytes, err := json.Marshal(newEncrypted.Metadata)
 		if err != nil {
-			return swept, fmt.Errorf("failed to marshal dynamic_secret_lease metadata id=%d: %w", row.ID, err)
+			return swept, legacyUpgraded, fmt.Errorf("failed to marshal dynamic_secret_lease metadata id=%d: %w", row.ID, err)
 		}
 		if err := tx.Model(&models.DynamicSecretLease{}).Where("id = ?", row.ID).Updates(map[string]interface{}{
 			"credential_enc":  newBytes,
 			"credential_meta": metaBytes,
 		}).Error; err != nil {
-			return swept, fmt.Errorf("failed to update dynamic_secret_lease id=%d: %w", row.ID, err)
+			return swept, legacyUpgraded, fmt.Errorf("failed to update dynamic_secret_lease id=%d: %w", row.ID, err)
 		}
 		swept++
+		if isLegacy {
+			legacyUpgraded++
+		}
 	}
-	return swept, nil
+	return swept, legacyUpgraded, nil
 }
 
 func sweepPasswordResets(tx *gorm.DB, oldSvc *EncryptionService, newSvc *EncryptionService, newKeyVersion string) (int, error) {

--- a/internal/encryption/sweep_test.go
+++ b/internal/encryption/sweep_test.go
@@ -246,7 +246,11 @@ func TestRotateDEKWithSweep_MultipleBatches(t *testing.T) {
 // DEK-encrypted auth-secret tables previously omitted from the sweep — TOTP
 // secrets, dynamic-secret admin DSNs, and lease credentials — are re-encrypted
 // under the new DEK. Before the fix a rotation orphaned them under the wiped old
-// key, breaking MFA login and dynamic-secret access irrecoverably.
+// key, breaking MFA login and dynamic-secret access irrecoverably. These three
+// tables are also AAD-bound as of #94, so the rows here are seeded legacy
+// (no-AAD, EncryptSecret) and the rotation's sweep must upgrade them to
+// AAD-bound in the same pass — proven via DecryptSecretWithAAD, not the plain
+// no-AAD DecryptSecret (which would now fail: AAD is baked into the GCM tag).
 func TestRotateDEKWithSweep_ReEncryptsAuthSecretTables(t *testing.T) {
 	db := newTestDB(t)
 	svc, _ := newTestService(t, "test-passphrase")
@@ -262,9 +266,9 @@ func TestRotateDEKWithSweep_ReEncryptsAuthSecretTables(t *testing.T) {
 	totpEnc, totpMeta := encSecret("TOTP-SEED-XYZ")
 	require.NoError(t, db.Create(&models.MFASecret{UserID: 1, SecretEnc: totpEnc, SecretMeta: totpMeta}).Error)
 	dsnEnc, dsnMeta := encSecret("postgres://admin:pw@db/app")
-	require.NoError(t, db.Create(&models.DynamicSecretConfig{Name: "pg", ProjectID: 1, AdminDSNEnc: dsnEnc, AdminDSNMeta: dsnMeta}).Error)
+	require.NoError(t, db.Create(&models.DynamicSecretConfig{Name: "pg", ProjectID: 1, EnvironmentID: 2, AdminDSNEnc: dsnEnc, AdminDSNMeta: dsnMeta}).Error)
 	credEnc, credMeta := encSecret(`{"user":"x","pass":"y"}`)
-	require.NoError(t, db.Create(&models.DynamicSecretLease{LeaseID: "l-1", CredentialEnc: credEnc, CredentialMeta: credMeta}).Error)
+	require.NoError(t, db.Create(&models.DynamicSecretLease{LeaseID: "l-1", ConfigID: 9, CredentialEnc: credEnc, CredentialMeta: credMeta}).Error)
 
 	oldDEK := captureCurrentDEK(t, svc)
 	if err := svc.RotateDEKWithSweep("test-passphrase", db); err != nil {
@@ -273,29 +277,29 @@ func TestRotateDEKWithSweep_ReEncryptsAuthSecretTables(t *testing.T) {
 	oldEncSvc, err := NewEncryptionService(oldDEK)
 	require.NoError(t, err)
 
-	check := func(name string, enc []byte, want string) {
-		// Decrypts under the new DEK (the current service)...
-		got, derr := svc.DecryptSecret(enc)
-		require.NoErrorf(t, derr, "%s: must decrypt under the new DEK after rotation", name)
+	check := func(name string, enc []byte, aad []byte, want string) {
+		// Decrypts under the new DEK, WITH the correct AAD, after rotation...
+		got, derr := svc.DecryptSecretWithAAD(enc, aad)
+		require.NoErrorf(t, derr, "%s: must decrypt under the new DEK+AAD after rotation", name)
 		require.Equal(t, want, string(got), name)
 		// ...and NOT under the old, rotated-out DEK.
 		parsed, perr := DeserializeEncryptedData(enc)
 		require.NoError(t, perr)
-		_, oerr := oldEncSvc.Decrypt(parsed)
+		_, oerr := oldEncSvc.DecryptWithAAD(parsed, aad)
 		require.Errorf(t, oerr, "%s: must NOT decrypt under the old DEK", name)
 	}
 
 	var mfa models.MFASecret
 	require.NoError(t, db.First(&mfa, "user_id = ?", 1).Error)
-	check("mfa_secret", mfa.SecretEnc, "TOTP-SEED-XYZ")
+	check("mfa_secret", mfa.SecretEnc, MFASecretAAD(1), "TOTP-SEED-XYZ")
 
 	var cfg models.DynamicSecretConfig
 	require.NoError(t, db.First(&cfg, "name = ?", "pg").Error)
-	check("dynamic_secret_config", cfg.AdminDSNEnc, "postgres://admin:pw@db/app")
+	check("dynamic_secret_config", cfg.AdminDSNEnc, DynamicSecretConfigAAD(cfg.ID, 1, 2), "postgres://admin:pw@db/app")
 
 	var lease models.DynamicSecretLease
 	require.NoError(t, db.First(&lease, "lease_id = ?", "l-1").Error)
-	check("dynamic_secret_lease", lease.CredentialEnc, `{"user":"x","pass":"y"}`)
+	check("dynamic_secret_lease", lease.CredentialEnc, DynamicSecretLeaseAAD("l-1", 9), `{"user":"x","pass":"y"}`)
 }
 
 // TestRotateDEKWithSweep_SoftDeletedSecretDoesNotBlock verifies a secret in the

--- a/internal/encryption/upgrade_auth_aad_test.go
+++ b/internal/encryption/upgrade_auth_aad_test.go
@@ -1,0 +1,93 @@
+package encryption
+
+import (
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestUpgradeAuthAAD_BindsLegacyRowsWithoutRotatingDEK proves the #94 standalone
+// upgrade path: legacy (no-AAD) rows in mfa_secrets, dynamic_secret_configs, and
+// dynamic_secret_leases are re-encrypted with per-row AAD UNDER THE SAME DEK — no
+// key rotation. This is the mechanism an operator uses to close the AAD-transplant
+// exposure without the disruption of a full, write-locking DEK rotation.
+func TestUpgradeAuthAAD_BindsLegacyRowsWithoutRotatingDEK(t *testing.T) {
+	db := newTestDB(t)
+	svc, _ := newTestService(t, "test-passphrase")
+
+	encSecret := func(v string) ([]byte, []byte) {
+		enc, meta, err := svc.EncryptSecret([]byte(v))
+		require.NoError(t, err)
+		return enc, meta
+	}
+
+	totpEnc, totpMeta := encSecret("TOTP-SEED-XYZ")
+	require.NoError(t, db.Create(&models.MFASecret{UserID: 1, SecretEnc: totpEnc, SecretMeta: totpMeta}).Error)
+	dsnEnc, dsnMeta := encSecret("postgres://admin:pw@db/app")
+	require.NoError(t, db.Create(&models.DynamicSecretConfig{Name: "pg", ProjectID: 1, EnvironmentID: 2, AdminDSNEnc: dsnEnc, AdminDSNMeta: dsnMeta}).Error)
+	credEnc, credMeta := encSecret(`{"user":"x","pass":"y"}`)
+	require.NoError(t, db.Create(&models.DynamicSecretLease{LeaseID: "l-1", ConfigID: 9, CredentialEnc: credEnc, CredentialMeta: credMeta}).Error)
+
+	keyVersionBefore := svc.GetKeyVersion()
+
+	result, err := svc.UpgradeAuthAAD(db)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.MFASecretsSwept)
+	assert.Equal(t, 1, result.DynamicSecretConfigsSwept)
+	assert.Equal(t, 1, result.DynamicSecretLeasesSwept)
+	assert.Equal(t, 3, result.LegacyAADUpgraded, "all 3 seeded rows were legacy (no-AAD)")
+
+	// The DEK/key version is unchanged — this is not a rotation.
+	assert.Equal(t, keyVersionBefore, svc.GetKeyVersion(), "UpgradeAuthAAD must not rotate the DEK")
+
+	// Each row now decrypts correctly WITH its reconstructed AAD...
+	var mfa models.MFASecret
+	require.NoError(t, db.First(&mfa, "user_id = ?", 1).Error)
+	got, err := svc.DecryptSecretWithAAD(mfa.SecretEnc, MFASecretAAD(1))
+	require.NoError(t, err)
+	assert.Equal(t, "TOTP-SEED-XYZ", string(got))
+
+	var cfg models.DynamicSecretConfig
+	require.NoError(t, db.First(&cfg, "name = ?", "pg").Error)
+	got, err = svc.DecryptSecretWithAAD(cfg.AdminDSNEnc, DynamicSecretConfigAAD(cfg.ID, 1, 2))
+	require.NoError(t, err)
+	assert.Equal(t, "postgres://admin:pw@db/app", string(got))
+
+	var lease models.DynamicSecretLease
+	require.NoError(t, db.First(&lease, "lease_id = ?", "l-1").Error)
+	got, err = svc.DecryptSecretWithAAD(lease.CredentialEnc, DynamicSecretLeaseAAD("l-1", 9))
+	require.NoError(t, err)
+	assert.Equal(t, `{"user":"x","pass":"y"}`, string(got))
+
+	// ...and no longer transplants: a ciphertext from a DIFFERENT row's AAD must fail.
+	_, err = svc.DecryptSecretWithAAD(mfa.SecretEnc, MFASecretAAD(2))
+	require.Error(t, err, "post-upgrade, the mfa_secret ciphertext must be AAD-bound to its true owner")
+}
+
+// TestUpgradeAuthAAD_IsIdempotent proves a second run over already-AAD-bound rows is
+// safe (fresh nonce, same AAD, no error) — an operator should be able to re-run this
+// on a schedule without needing to track which rows were already upgraded.
+func TestUpgradeAuthAAD_IsIdempotent(t *testing.T) {
+	db := newTestDB(t)
+	svc, _ := newTestService(t, "test-passphrase")
+
+	enc, meta, err := svc.EncryptSecret([]byte("TOTP-SEED"))
+	require.NoError(t, err)
+	require.NoError(t, db.Create(&models.MFASecret{UserID: 5, SecretEnc: enc, SecretMeta: meta}).Error)
+
+	_, err = svc.UpgradeAuthAAD(db)
+	require.NoError(t, err)
+
+	result, err := svc.UpgradeAuthAAD(db)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.MFASecretsSwept)
+	assert.Equal(t, 0, result.LegacyAADUpgraded, "the second pass finds nothing legacy left to upgrade")
+
+	var mfa models.MFASecret
+	require.NoError(t, db.First(&mfa, "user_id = ?", 5).Error)
+	got, err := svc.DecryptSecretWithAAD(mfa.SecretEnc, MFASecretAAD(5))
+	require.NoError(t, err)
+	assert.Equal(t, "TOTP-SEED", string(got))
+}


### PR DESCRIPTION
## Summary
Closes backlog finding #94 (HIGH) — a ciphertext-transplant exposure spanning every live category encrypted through the shared auth-secret helper.

Secret values have been AAD-bound (`SecretAAD`: `secretID:projectID:versionNumber`) since the M2 migration, but three other live categories, all routed through `internal/core`'s single `encryptAuthSecret`/`decryptAuthSecret` helper, carried **no AAD at all**:
- TOTP shared secrets (`mfa_secrets.secret_enc`)
- Dynamic-secret admin DSNs (`dynamic_secret_configs.admin_dsn_enc`)
- Issued dynamic-secret credentials (`dynamic_secret_leases.credential_enc`)

Without AAD, AES-GCM authenticates a ciphertext's integrity but not *which row it belongs to* — a DB-write attacker (a different vuln, an insider with DB access, or a compromised backup/replica) could copy an encrypted blob from one row to another and have it decrypt successfully under the wrong identity. Concretely: copy user A's encrypted TOTP seed onto user B's `mfa_secrets` row, and B's login now accepts codes generated from A's seed — a stealthy, persistent MFA bypass. Or copy one dynamic-secret config's admin DSN onto a different config, and Keyorix connects to (and issues credentials scoped to) the wrong backend.

**Scoped out** (see the research that grounded this fix): `Session`/`APIToken`/`APIClient`/`PasswordReset` also have encrypted-at-rest columns, but none are populated by any live write path today — those tables authenticate via hashing instead, and the encrypted columns are legacy/unused. Tracked separately under #129 (dead-code cleanup) rather than folded into this fix, since adding AAD to columns nothing writes to would be security theater.

## What changed
- New `MFASecretAAD`/`DynamicSecretConfigAAD`/`DynamicSecretLeaseAAD` (`internal/encryption/encryption.go`), each domain-separated from `SecretAAD`'s `"keyorix:v2:"` prefix so a cross-*category* transplant (e.g. a `SecretVersion` blob pasted into an `MFASecret` row) fails too, not just a same-category one.
- `encryptAuthSecret`/`decryptAuthSecret` (`internal/core/service.go`) now require an `aad []byte` parameter and route through `Service`'s existing `EncryptSecretWithAAD`/`DecryptSecretWithAAD` — the same AAD-aware primitives secret values already use. `DecryptSecretWithAAD`'s built-in legacy-row fallback (checks the stored `AADVersion`) means existing no-AAD rows keep decrypting without a forced migration.
- `CreateDynamicSecretConfig` now does a two-phase create-then-encrypt-then-update: the admin DSN's AAD binds to the config's auto-increment `ID`, which isn't known before the row is inserted. `IssueLease` generates the lease's random string `LeaseID` *before* encrypting the credential (previously after) so its AAD is available without needing the same two-phase dance — `LeaseID` is caller-generated and `uniqueIndex`-constrained, so it's available up front.
- `sweepMFASecrets`/`sweepDynamicSecretConfigs`/`sweepDynamicSecretLeases` (run during a DEK rotation) are now AAD-aware, mirroring `sweepSecretVersions`'s legacy-branch pattern — previously even a full DEK rotation left these three tables permanently AAD-less.
- New `Service.UpgradeAuthAAD` + `keyorix encryption upgrade-aad` CLI command: upgrades legacy rows in these three tables **under the current DEK, no key rotation involved** — closing the exposure on a live install doesn't require the disruption of a full, write-locking DEK rotation.

## Test plan
- [x] New `TestAEAD_MFASecretAADBindsCiphertextToOwningUser` / `..._DynamicSecretConfigAAD...` / `..._DynamicSecretLeaseAAD...` — low-level AEAD transplant-rejection proofs, mirroring the existing `SecretAAD` coverage.
- [x] New `TestMFA_TOTPSecretTransplantBetweenUsersFailsToDecrypt` and `TestDynamicSecrets_AdminDSNTransplantBetweenConfigsFailsToDecrypt` — end-to-end proofs through the real `KeyorixCore` flow (not just the primitive), simulating a DB-write attacker and asserting decryption fails.
- [x] New `TestUpgradeAuthAAD_BindsLegacyRowsWithoutRotatingDEK` and `..._IsIdempotent` — the standalone same-key upgrade path.
- [x] `TestRotateDEKWithSweep_ReEncryptsAuthSecretTables` updated to assert via `DecryptSecretWithAAD` (the sweep now upgrades these rows to AAD-bound, so the old no-AAD assertion no longer applies).
- [x] `go test ./internal/... ./server/...` — all green.
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues.
- [x] `GOWORK=off go build -C operator ./...` — clean.