### PR TITLE
fix(mfa): throttle DisableMFA/RegenerateMFARecoveryCodes (#125)

### DIFF
--- a/internal/audit/siem/spool.go
+++ b/internal/audit/siem/spool.go
@@ -42,9 +42,16 @@ type spool struct {
 	maxBytes    int64
 	deliverOnce func(context.Context, *models.AuditEvent) error
 
-	mu   sync.Mutex // serializes file mutation (append + replay rewrite); NOT held across delivery
-	stop chan struct{}
-	done chan struct{}
+	mu sync.Mutex // serializes file mutation (append + replay rewrite); NOT held across delivery
+	// replayMu serializes replay() end-to-end (distinct from mu, which is deliberately
+	// released across delivery). Without it, the loop's immediate on-start replay can
+	// race a concurrently-triggered one: both read the same undelivered snapshot before
+	// either rewrites the file, and both attempt delivery — double-delivering the same
+	// backlog to the SIEM. A skipped replay is harmless (the ticker or the next trigger
+	// retries the same backlog), so this blocks rather than drops.
+	replayMu sync.Mutex
+	stop     chan struct{}
+	done     chan struct{}
 }
 
 // newSpool prepares the spool directory and starts the replay loop.
@@ -124,6 +131,8 @@ func (s *spool) loop() {
 // on the audited request path) never blocks behind a SIEM round-trip. Crash-safe: every
 // undelivered line stays on disk until the atomic rewrite at the end.
 func (s *spool) replay() {
+	s.replayMu.Lock()
+	defer s.replayMu.Unlock()
 	// Snapshot under the lock, recording the byte length we read; any add() during the
 	// lock-free delivery below only appends BEYOND this offset (add never rewrites), so the
 	// reconcile can cleanly separate "what we attempted" from "what arrived meanwhile".

--- a/internal/core/mfa.go
+++ b/internal/core/mfa.go
@@ -108,6 +108,16 @@ func (c *KeyorixCore) DisableMFA(ctx context.Context, userID uint, codeOrPasswor
 	if !user.MFAEnabled {
 		return fmt.Errorf("MFA is not enabled")
 	}
+	// #125: this proof-of-possession check accepted either a TOTP code or the account
+	// password with NO throttle — a caller holding a stolen SESSION (which by itself
+	// doesn't require re-proving the second factor) could brute-force the 6-digit TOTP
+	// here with unlimited attempts and turn MFA off outright, defeating it entirely.
+	// Route through the same per-account lockout VerifyMFALogin already applies to the
+	// login-time second factor, so guessing here costs the same lockout as guessing at
+	// login — a no-op when login_lockout is disabled, matching that gate's behavior.
+	if c.loginLocked(user) {
+		return fmt.Errorf("account temporarily locked due to repeated failed logins; try again later")
+	}
 	ok := false
 	if secret, err := c.loadTOTPSecret(ctx, userID); err == nil && c.validateTOTP(secret, codeOrPassword) {
 		ok = true
@@ -117,8 +127,10 @@ func (c *KeyorixCore) DisableMFA(ctx context.Context, userID uint, codeOrPasswor
 	}
 	if !ok {
 		c.auditMFAFailed(ctx, userID, "disable")
+		c.recordFailedLogin(ctx, user)
 		return fmt.Errorf("invalid code or password")
 	}
+	c.clearLoginFailures(ctx, user)
 	if err := c.storage.SetUserMFAEnabled(ctx, userID, false); err != nil {
 		return err
 	}
@@ -143,6 +155,11 @@ func (c *KeyorixCore) RegenerateMFARecoveryCodes(ctx context.Context, userID uin
 	if !user.MFAEnabled {
 		return nil, fmt.Errorf("MFA is not enabled")
 	}
+	// #125: same unthrottled-brute-force gap as DisableMFA — see its comment. A stolen
+	// SESSION could otherwise be used to guess the TOTP code here with no rate limit.
+	if c.loginLocked(user) {
+		return nil, fmt.Errorf("account temporarily locked due to repeated failed logins; try again later")
+	}
 	ok := false
 	if secret, err := c.loadTOTPSecret(ctx, userID); err == nil && c.validateTOTP(secret, codeOrPassword) {
 		ok = true
@@ -152,8 +169,10 @@ func (c *KeyorixCore) RegenerateMFARecoveryCodes(ctx context.Context, userID uin
 	}
 	if !ok {
 		c.auditMFAFailed(ctx, userID, "regenerate_recovery_codes")
+		c.recordFailedLogin(ctx, user)
 		return nil, fmt.Errorf("invalid code or password")
 	}
+	c.clearLoginFailures(ctx, user)
 	codes, hashes, err := generateRecoveryCodes(mfaRecoveryCodeCount)
 	if err != nil {
 		return nil, err

--- a/internal/core/mfa_test.go
+++ b/internal/core/mfa_test.go
@@ -315,3 +315,96 @@ func TestVerifyMFALogin_FailedCodesFeedAccountLockout(t *testing.T) {
 	assert.Contains(t, err.Error(), "locked")
 	assert.Nil(t, sess)
 }
+
+// #125: DisableMFA accepted a TOTP-code-or-password proof with NO throttle — a caller
+// holding a stolen SESSION (which doesn't itself require re-proving the second factor)
+// could brute-force the 6-digit TOTP with unlimited attempts and turn MFA off
+// outright. This pins that failed attempts now feed the SAME per-account lockout
+// VerifyMFALogin already uses, and that even a subsequently-correct code is refused
+// once locked.
+func TestDisableMFA_FailedCodesFeedAccountLockout(t *testing.T) {
+	c, db, fixed := newMFATestCore(t)
+	c.loginLockout = LoginLockoutPolicy{Enabled: true, MaxAttempts: 3, Window: time.Hour, BaseCooldown: 15 * time.Minute, MaxCooldown: time.Hour}
+	ctx := context.Background()
+
+	_, secret, err := c.BeginMFAEnrollment(ctx, 1)
+	require.NoError(t, err)
+	actCode, err := totp.GenerateCode(secret, fixed)
+	require.NoError(t, err)
+	_, err = c.ActivateMFA(ctx, 1, actCode)
+	require.NoError(t, err)
+
+	// Three wrong disable attempts (neither a valid TOTP code nor the password) → locked.
+	for i := 0; i < 3; i++ {
+		require.Error(t, c.DisableMFA(ctx, 1, "000000"))
+	}
+
+	var locked models.User
+	require.NoError(t, db.First(&locked, 1).Error)
+	require.NotNil(t, locked.LoginLockedUntil, "account must be locked after MaxAttempts failed disable attempts")
+
+	// Even the CORRECT password is now refused while the lock is active.
+	err = c.DisableMFA(ctx, 1, mfaTestPassword)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "locked")
+
+	var still models.User
+	require.NoError(t, db.First(&still, 1).Error)
+	assert.True(t, still.MFAEnabled, "MFA must remain enabled while the account is locked, even with the correct password")
+}
+
+// A successful disable (correct password, before any lockout) must still clear
+// whatever failure count had accrued — the same convention VerifyMFALogin follows on
+// a successful second factor.
+func TestDisableMFA_SuccessClearsAccruedFailures(t *testing.T) {
+	c, db, fixed := newMFATestCore(t)
+	c.loginLockout = LoginLockoutPolicy{Enabled: true, MaxAttempts: 5, Window: time.Hour, BaseCooldown: 15 * time.Minute, MaxCooldown: time.Hour}
+	ctx := context.Background()
+
+	_, secret, err := c.BeginMFAEnrollment(ctx, 1)
+	require.NoError(t, err)
+	actCode, err := totp.GenerateCode(secret, fixed)
+	require.NoError(t, err)
+	_, err = c.ActivateMFA(ctx, 1, actCode)
+	require.NoError(t, err)
+
+	require.Error(t, c.DisableMFA(ctx, 1, "000000"))
+	require.Error(t, c.DisableMFA(ctx, 1, "111111"))
+
+	var mid models.User
+	require.NoError(t, db.First(&mid, 1).Error)
+	assert.Equal(t, 2, mid.FailedLoginAttempts, "the two wrong attempts must be recorded")
+
+	require.NoError(t, c.DisableMFA(ctx, 1, mfaTestPassword))
+
+	var after models.User
+	require.NoError(t, db.First(&after, 1).Error)
+	assert.Zero(t, after.FailedLoginAttempts, "a successful disable must clear accrued failures")
+}
+
+// #125: same unthrottled-brute-force gap, same fix, for RegenerateMFARecoveryCodes.
+func TestRegenerateMFARecoveryCodes_FailedCodesFeedAccountLockout(t *testing.T) {
+	c, db, fixed := newMFATestCore(t)
+	c.loginLockout = LoginLockoutPolicy{Enabled: true, MaxAttempts: 3, Window: time.Hour, BaseCooldown: 15 * time.Minute, MaxCooldown: time.Hour}
+	ctx := context.Background()
+
+	_, secret, err := c.BeginMFAEnrollment(ctx, 1)
+	require.NoError(t, err)
+	actCode, err := totp.GenerateCode(secret, fixed)
+	require.NoError(t, err)
+	_, err = c.ActivateMFA(ctx, 1, actCode)
+	require.NoError(t, err)
+
+	for i := 0; i < 3; i++ {
+		_, err := c.RegenerateMFARecoveryCodes(ctx, 1, "000000")
+		require.Error(t, err)
+	}
+
+	var locked models.User
+	require.NoError(t, db.First(&locked, 1).Error)
+	require.NotNil(t, locked.LoginLockedUntil, "account must be locked after MaxAttempts failed regenerate attempts")
+
+	_, err = c.RegenerateMFARecoveryCodes(ctx, 1, mfaTestPassword)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "locked")
+}


### PR DESCRIPTION
## Summary
Closes backlog finding #125 — `DisableMFA` and `RegenerateMFARecoveryCodes` accepted a TOTP-code-or-password proof of possession with **no rate limit at all**.

A caller holding a stolen SESSION (which by itself doesn't require re-proving the second factor for most actions) could brute-force the 6-digit TOTP against `/auth/mfa/disable` with unlimited attempts (~3×10⁵ on average) and turn MFA off outright — defeating the whole protection. The account's actual password is never needed if the TOTP guess lands first, and the endpoint offered no throttle on that guessing.

Both now route through the **same per-account lockout** `VerifyMFALogin` already applies to the login-time second factor:
- `c.loginLocked(user)` refuses before attempting verification.
- A failed attempt calls `c.recordFailedLogin` (same exponential-backoff lockout as password/login-MFA brute force).
- A successful one calls `c.clearLoginFailures`, matching the existing convention.
- A no-op when `login_lockout` is disabled — identical behavior to every other gate that uses this mechanism.

This is also the established pattern in this codebase: there is **no separate per-IP rate-limit middleware** on any `/auth/*` route (confirmed via `router.go`) — per-account lockout is the only online brute-force defense `/auth/login` itself relies on. Extending it here (rather than introducing a new middleware layer) keeps the MFA-downgrade paths consistent with how every other credential-guessing surface in Keyorix is throttled, and reuses well-tested, already-concurrency-safe machinery (`loginFailureMu` + `LockUserForUpdate` inside a transaction) rather than adding a second, parallel counter.

Also reapplies the SIEM spool `replayMu` serialization fix from #521 (unmerged), carried forward since this branch forked from `main` before that PR landed.

## Test plan
- [x] New `TestDisableMFA_FailedCodesFeedAccountLockout` — 3 wrong disable attempts lock the account; even the *correct* password is then refused while locked, and MFA stays enabled.
- [x] New `TestDisableMFA_SuccessClearsAccruedFailures` — 2 wrong attempts accrue a failure count, then a correct disable clears it.
- [x] New `TestRegenerateMFARecoveryCodes_FailedCodesFeedAccountLockout` — same lockout behavior for the regenerate path.
- [x] Existing `TestVerifyMFALogin_FailedCodesFeedAccountLockout` and the rest of the MFA suite still pass unchanged.
- [x] `go test ./internal/... ./server/...` — all 62 packages green.
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues.
- [x] `GOWORK=off go build -C operator ./...` — clean.