### PR TITLE
fix: close compliance posture fail-open + share-revoke duplicate gap (#136)

### DIFF
--- a/internal/core/certificate_expiry.go
+++ b/internal/core/certificate_expiry.go
@@ -141,9 +141,10 @@ func (c *KeyorixCore) listCertificateSecrets(ctx context.Context) ([]*models.Sec
 // certificatePosture reports certificate hygiene for the compliance posture (ADR-056)
 // from the cached cert expiry — no decryption on this path. Certificates not yet
 // evaluated (cache nil) are counted separately so the gap is visible.
-func (c *KeyorixCore) certificatePosture(ctx context.Context) CertificatePosture {
+func (c *KeyorixCore) certificatePosture(ctx context.Context, cp *CompliancePosture) CertificatePosture {
 	certs, err := c.listCertificateSecrets(ctx)
 	if err != nil {
+		cp.degrade("certificates", err)
 		return CertificatePosture{}
 	}
 	now := c.now()

--- a/internal/core/certificate_expiry_test.go
+++ b/internal/core/certificate_expiry_test.go
@@ -117,7 +117,7 @@ func TestCertificatePosture(t *testing.T) {
 	c, db, _ := newCertExpiryCore(t)
 
 	// Before any scan/inspection, no cert has a cached expiry → all "not evaluated".
-	pre := c.certificatePosture(ctx)
+	pre := c.certificatePosture(ctx, &CompliancePosture{})
 	assert.Equal(t, 4, pre.TotalCertificates)
 	assert.Equal(t, 4, pre.NotEvaluated)
 	assert.Equal(t, 0, pre.Expired)
@@ -127,7 +127,7 @@ func TestCertificatePosture(t *testing.T) {
 	_, err := c.ScanCertificateExpiry(ctx, 30)
 	require.NoError(t, err)
 
-	post := c.certificatePosture(ctx)
+	post := c.certificatePosture(ctx, &CompliancePosture{})
 	assert.Equal(t, 4, post.TotalCertificates)
 	assert.Equal(t, 1, post.Expired)
 	assert.Equal(t, 1, post.ExpiringSoon)

--- a/internal/core/classify_dynamic_test.go
+++ b/internal/core/classify_dynamic_test.go
@@ -75,7 +75,7 @@ func TestClassificationPosture_CoversDynamicConfigs(t *testing.T) {
 	makeDynConfig(t, c, "c", ClassificationInternal)
 	makeDynConfig(t, c, "d", "") // unclassified
 
-	p := c.classificationPosture(context.Background())
+	p := c.classificationPosture(context.Background(), &CompliancePosture{})
 	assert.Equal(t, 4, p.DynamicConfigs.Total)
 	assert.Equal(t, 2, p.DynamicConfigs.Restricted)
 	assert.Equal(t, 1, p.DynamicConfigs.Internal)

--- a/internal/core/classify_machine_test.go
+++ b/internal/core/classify_machine_test.go
@@ -90,7 +90,7 @@ func TestClassificationPosture_CoversMachineEntities(t *testing.T) {
 	store.On("CountMachineIdentitiesByClassification", mock.Anything).Return(map[string]int{"restricted": 2, "": 1}, nil)
 	store.On("CountMachineIdentityCredentialsByClassification", mock.Anything).Return(map[string]int{"confidential": 3}, nil)
 
-	p := c.classificationPosture(context.Background())
+	p := c.classificationPosture(context.Background(), &CompliancePosture{})
 	assert.Equal(t, 3, p.MachineIdentities.Total)
 	assert.Equal(t, 2, p.MachineIdentities.Restricted)
 	assert.Equal(t, 1, p.MachineIdentities.Unclassified)

--- a/internal/core/compliance_posture.go
+++ b/internal/core/compliance_posture.go
@@ -150,6 +150,13 @@ type CertificatePosture struct {
 }
 
 // CompliancePosture is the deployment's control posture at a point in time.
+//
+// #136: every sub-rollup is queried best-effort so one failing signal doesn't abort
+// the whole snapshot — but a query failure must never read the same as "checked,
+// found clean" (e.g. LegalHold.Active=false on a DB error looks identical to no hold
+// in effect, and this snapshot gets HMAC-signed into evidence packs an auditor
+// trusts). Degraded + DegradedReasons make a partial snapshot detectable instead of
+// indistinguishable from a fully-clean one.
 type CompliancePosture struct {
 	GeneratedAt      time.Time               `json:"generated_at"`
 	AuditIntegrity   AuditIntegrityPosture   `json:"audit_integrity"`
@@ -164,6 +171,20 @@ type CompliancePosture struct {
 	Risk             RiskPosture             `json:"risk"`
 	Certificates     CertificatePosture      `json:"certificates"`
 	SupplyChain      SupplyChainPosture      `json:"supply_chain"`
+	// Degraded is true when one or more sub-rollups below could not be queried — the
+	// zero/clean values they carry are UNKNOWN, not verified-clean. An evidence pack
+	// consumer must treat a degraded snapshot as incomplete, not passing.
+	Degraded bool `json:"degraded"`
+	// DegradedReasons names each failed sub-rollup with its underlying error.
+	DegradedReasons []string `json:"degraded_reasons,omitempty"`
+}
+
+// degrade records that a posture sub-rollup could not be queried: it flips Degraded
+// and appends a human-readable reason, so evidence packs signal "incomplete" instead
+// of silently reading the affected fields as a verified-clean zero value.
+func (p *CompliancePosture) degrade(area string, err error) {
+	p.Degraded = true
+	p.DegradedReasons = append(p.DegradedReasons, fmt.Sprintf("%s: %v", area, err))
 }
 
 // SupplyChainPosture reports software-supply-chain integrity: whether this deployment
@@ -206,11 +227,14 @@ func (c *KeyorixCore) GetCompliancePosture(ctx context.Context) (*CompliancePost
 		}
 	} else if err != nil {
 		p.AuditIntegrity.Reason = err.Error()
+		p.degrade("audit_integrity", err)
 	}
 
 	// Second-factor coverage across active users.
 	if id, err := c.identityPosture(ctx); err == nil {
 		p.Identity = id
+	} else {
+		p.degrade("identity", err)
 	}
 
 	// Rotation hygiene (deployment-wide).
@@ -224,6 +248,8 @@ func (c *KeyorixCore) GetCompliancePosture(ctx context.Context) (*CompliancePost
 				p.Rotation.DueSoon++
 			}
 		}
+	} else {
+		p.degrade("rotation", err)
 	}
 
 	// Access governance + emergency access — per project.
@@ -234,10 +260,12 @@ func (c *KeyorixCore) GetCompliancePosture(ctx context.Context) (*CompliancePost
 	// Separation-of-duties violations (A.5.3).
 	if violations, err := c.DetectSoDViolations(ctx); err == nil {
 		p.AccessGovernance.SoDViolations = len(violations)
+	} else {
+		p.degrade("sod_violations", err)
 	}
 
 	// Data-classification coverage (A.5.12).
-	p.Classification = c.classificationPosture(ctx)
+	p.Classification = c.classificationPosture(ctx, p)
 
 	// Open access anomalies (NIS2 detection).
 	unack := false
@@ -248,21 +276,29 @@ func (c *KeyorixCore) GetCompliancePosture(ctx context.Context) (*CompliancePost
 				p.Anomalies.HighSeverityOpen++
 			}
 		}
+	} else {
+		p.degrade("anomalies", err)
 	}
 
 	// Legal hold (A.5.34).
-	if hold, err := c.storage.GetActiveLegalHold(ctx); err == nil && hold != nil {
-		at := hold.PlacedAt
-		p.LegalHold = LegalHoldPosture{Active: true, PlacedAt: &at, Reason: hold.Reason}
+	if hold, err := c.storage.GetActiveLegalHold(ctx); err == nil {
+		if hold != nil {
+			at := hold.PlacedAt
+			p.LegalHold = LegalHoldPosture{Active: true, PlacedAt: &at, Reason: hold.Reason}
+		}
+	} else {
+		p.degrade("legal_hold", err)
 	}
 
 	// Risk register — governed, time-bound exceptions (A.5.8).
 	if active, soon, err := c.CountActiveRiskExceptions(ctx, riskExpiringSoonWindow); err == nil {
 		p.Risk = RiskPosture{ActiveExceptions: active, ExpiringSoon: soon}
+	} else {
+		p.degrade("risk", err)
 	}
 
 	// Certificate hygiene from the cached cert expiry (ADR-056).
-	p.Certificates = c.certificatePosture(ctx)
+	p.Certificates = c.certificatePosture(ctx, p)
 
 	// Data-retention windows (A.5.33).
 	rp := c.retentionPolicy
@@ -292,7 +328,9 @@ func (c *KeyorixCore) GetCompliancePosture(ctx context.Context) (*CompliancePost
 
 // classificationPosture counts secrets per classification level via cheap count
 // queries (PageSize 1 → only the total), rather than walking every secret row.
-func (c *KeyorixCore) classificationPosture(ctx context.Context) ClassificationPosture {
+// Reports into cp.degrade on any failed count so a query error reads as "unknown",
+// not as a verified-zero count for that classification/entity kind.
+func (c *KeyorixCore) classificationPosture(ctx context.Context, cp *CompliancePosture) ClassificationPosture {
 	count := func(level string) int {
 		f := &storage.SecretFilter{Page: 1, PageSize: 1}
 		if level != "" {
@@ -301,6 +339,7 @@ func (c *KeyorixCore) classificationPosture(ctx context.Context) ClassificationP
 		}
 		_, total, err := c.storage.ListSecrets(ctx, f)
 		if err != nil {
+			cp.degrade("classification:secrets:"+level, err)
 			return 0
 		}
 		return int(total)
@@ -315,12 +354,18 @@ func (c *KeyorixCore) classificationPosture(ctx context.Context) ClassificationP
 	}
 	if m, err := c.storage.CountDynamicSecretConfigsByClassification(ctx); err == nil {
 		p.DynamicConfigs = classificationCountsFromMap(m)
+	} else {
+		cp.degrade("classification:dynamic_configs", err)
 	}
 	if m, err := c.storage.CountMachineIdentitiesByClassification(ctx); err == nil {
 		p.MachineIdentities = classificationCountsFromMap(m)
+	} else {
+		cp.degrade("classification:machine_identities", err)
 	}
 	if m, err := c.storage.CountMachineIdentityCredentialsByClassification(ctx); err == nil {
 		p.MachineCredentials = classificationCountsFromMap(m)
+	} else {
+		cp.degrade("classification:machine_credentials", err)
 	}
 	return p
 }
@@ -387,9 +432,11 @@ func (c *KeyorixCore) accessGovernancePosture(ctx context.Context, p *Compliance
 					p.AccessGovernance.ProjectsOverdue++
 				}
 			}
+		} else {
+			p.degrade(fmt.Sprintf("access_governance:campaigns:project=%d", pid), err)
 		}
 
-		p.AccessGovernance.DormantRoleGrants += c.countDormantRoleGrants(ctx, pid)
+		p.AccessGovernance.DormantRoleGrants += c.countDormantRoleGrants(ctx, pid, p)
 
 		if acts, err := c.ListBreakGlassActivations(ctx, pid); err == nil {
 			p.EmergencyAccess.TotalActivations += len(acts)
@@ -398,6 +445,8 @@ func (c *KeyorixCore) accessGovernancePosture(ctx context.Context, p *Compliance
 					p.EmergencyAccess.ActiveActivations++
 				}
 			}
+		} else {
+			p.degrade(fmt.Sprintf("emergency_access:project=%d", pid), err)
 		}
 	}
 	return nil
@@ -406,13 +455,15 @@ func (c *KeyorixCore) accessGovernancePosture(ctx context.Context, p *Compliance
 // countDormantRoleGrants counts distinct users holding a role grant in the project
 // who have not accessed a secret recently (or ever) — stale standing access. Cheap:
 // the project's role assignments + the last-activity map, no full secret walk.
-func (c *KeyorixCore) countDormantRoleGrants(ctx context.Context, projectID uint) int {
+func (c *KeyorixCore) countDormantRoleGrants(ctx context.Context, projectID uint, cp *CompliancePosture) int {
 	assignments, err := c.storage.ListProjectRoleAssignments(ctx, projectID)
 	if err != nil {
+		cp.degrade(fmt.Sprintf("dormant_role_grants:assignments:project=%d", projectID), err)
 		return 0
 	}
 	activity, err := c.storage.LastUserSecretActivity(ctx, projectID)
 	if err != nil {
+		cp.degrade(fmt.Sprintf("dormant_role_grants:activity:project=%d", projectID), err)
 		return 0
 	}
 	cutoff := c.now().Add(-dormantThreshold)

--- a/internal/core/compliance_posture_test.go
+++ b/internal/core/compliance_posture_test.go
@@ -1,0 +1,66 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// compliancePostureCore builds a bare KeyorixCore against a real (empty) sqlite DB —
+// only models.Project is migrated, since accessGovernancePosture's ListProjects is the
+// one call GetCompliancePosture treats as fatal; every other sub-rollup query errors
+// (e.g. from a missing table) are expected to soft-fail into Degraded, not abort.
+func compliancePostureCore(t *testing.T) *KeyorixCore {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.Project{}))
+	c := &KeyorixCore{storage: store.NewLocalStorage(db)}
+	c.now = func() time.Time { return time.Date(2026, 7, 2, 12, 0, 0, 0, time.UTC) }
+	return c
+}
+
+// failingLegalHoldStore wraps LocalStorage and fails GetActiveLegalHold, simulating a DB
+// error on that one sub-rollup while every other posture query still runs for real.
+type failingLegalHoldStore struct {
+	*store.LocalStorage
+}
+
+func (s *failingLegalHoldStore) GetActiveLegalHold(_ context.Context) (*models.LegalHold, error) {
+	return nil, errors.New("simulated db failure")
+}
+
+// #136: before the fix, a failed legal-hold query left LegalHold.Active=false —
+// byte-identical to "queried, no hold in effect". That's the most dangerous instance of
+// the fail-open pattern: it's the signal purge jobs would otherwise trust to preserve
+// records under hold, and it feeds an HMAC-signed evidence pack an auditor trusts. A query
+// failure must surface as Degraded, not as a silently-clean zero value.
+func TestGetCompliancePosture_DegradedOnLegalHoldQueryError(t *testing.T) {
+	c := compliancePostureCore(t)
+	c.storage = &failingLegalHoldStore{LocalStorage: c.storage.(*store.LocalStorage)}
+
+	p, err := c.GetCompliancePosture(context.Background())
+	require.NoError(t, err, "a single failed sub-rollup must not abort the whole snapshot")
+
+	assert.False(t, p.LegalHold.Active, "the field itself still reads as its zero value")
+	assert.True(t, p.Degraded, "a failed legal-hold query must flip Degraded — the zero value above is UNKNOWN, not verified-clean")
+	assert.True(t, containsSubstring(p.DegradedReasons, "legal_hold"), "expected a legal_hold entry in DegradedReasons, got %v", p.DegradedReasons)
+}
+
+func containsSubstring(ss []string, sub string) bool {
+	for _, s := range ss {
+		if strings.Contains(s, sub) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -630,6 +630,16 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 		}
 	}
 
+	// Close the share-create race (#136): a partial unique index on live rows so two
+	// concurrent CreateShareRecord calls for the same (secret, recipient, is_group)
+	// can no longer both succeed as separate rows. Additive + idempotent; the full
+	// AutoMigrate below covers fresh DBs (which get the index further down too).
+	if tableExists(db, "share_records") {
+		if err := ensureShareRecordUniqueIndex(db); err != nil {
+			return err
+		}
+	}
+
 	// Skip full AutoMigrate if already initialised (projects table present).
 	if projectsExists {
 		return nil
@@ -685,7 +695,24 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 	if err := ensureGroupNameIndex(db); err != nil {
 		return err
 	}
-	return ensureUserNameIndex(db)
+	if err := ensureUserNameIndex(db); err != nil {
+		return err
+	}
+	return ensureShareRecordUniqueIndex(db)
+}
+
+// ensureShareRecordUniqueIndex creates a partial unique index on share_records
+// (secret_id, recipient_id, is_group), scoped to live rows (#136). ShareRecord
+// carried no DB constraint preventing two active share rows for the same
+// (secret, recipient, is_group) tuple: CreateShareRecord's check-then-create is a
+// read-then-write race, and a revoke-by-ID only ever removed one of the resulting
+// duplicates, leaving access live after what looked like a successful single-share
+// revoke. Idempotent; works on SQLite and Postgres.
+func ensureShareRecordUniqueIndex(db *gorm.DB) error {
+	if err := db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS uniq_share_records_active ON share_records (secret_id, recipient_id, is_group) WHERE deleted_at IS NULL").Error; err != nil {
+		return fmt.Errorf("failed to create partial share_records unique index: %w", err)
+	}
+	return nil
 }
 
 // ensureGroupNameIndex replaces any plain unique index on groups.name with a

--- a/internal/storage/store/local_sharing.go
+++ b/internal/storage/store/local_sharing.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/i18n"
@@ -70,9 +71,37 @@ func (ls *LocalStorage) CreateShareRecord(ctx context.Context, share *models.Sha
 	}
 
 	if err := ls.db.Create(share).Error; err != nil {
+		// #136: the SELECT above and this INSERT are not atomic — a concurrent
+		// CreateShareRecord for the same (secret, recipient, is_group) can race between
+		// them, both miss the SELECT, and both attempt the INSERT. The partial unique
+		// index on share_records (see ensureShareRecordUniqueIndex) turns the loser's
+		// INSERT into a constraint violation instead of a second live duplicate row;
+		// treat that specific failure as "someone else just created it" and fall back to
+		// updating the row that won the race, preserving CreateShareRecord's upsert
+		// contract instead of surfacing a raw constraint error to the caller.
+		if isUniqueConstraintErr(err) {
+			if rerr := ls.db.Where("secret_id = ? AND recipient_id = ? AND is_group = ? AND deleted_at IS NULL",
+				share.SecretID, share.RecipientID, share.IsGroup).First(&existing).Error; rerr == nil {
+				existing.Permission = share.Permission
+				existing.UpdatedAt = time.Now()
+				if serr := ls.db.Save(&existing).Error; serr != nil {
+					return nil, fmt.Errorf("%s: %w", i18n.T("ErrorDatabaseOperation", nil), serr)
+				}
+				return &existing, nil
+			}
+		}
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorDatabaseOperation", nil), err)
 	}
 	return share, nil
+}
+
+// isUniqueConstraintErr reports whether err is a unique-constraint violation, across
+// both drivers this storage layer supports (SQLite's modernc/mattn error text and
+// Postgres' SQLSTATE 23505), without importing either driver package here.
+func isUniqueConstraintErr(err error) bool {
+	msg := err.Error()
+	return strings.Contains(msg, "UNIQUE constraint failed") || // SQLite
+		strings.Contains(msg, "23505") || strings.Contains(msg, "duplicate key value") // Postgres
 }
 
 // GetShareRecord retrieves a share record by ID.
@@ -108,13 +137,19 @@ func (ls *LocalStorage) UpdateShareRecord(ctx context.Context, share *models.Sha
 	return existing, nil
 }
 
-// DeleteShareRecord soft-deletes a share record.
+// DeleteShareRecord soft-deletes a share record. #136: a pre-existing duplicate row
+// for the same (secret, recipient, is_group) — from before the unique index in
+// ensureShareRecordUniqueIndex closed the create-race that produced them — would
+// otherwise survive a revoke by ID, leaving access live. Delete every active row for
+// that same tuple, not just shareID, so a revoke is complete regardless of how many
+// duplicates accumulated.
 func (ls *LocalStorage) DeleteShareRecord(ctx context.Context, shareID uint) error {
 	share, err := ls.GetShareRecord(ctx, shareID)
 	if err != nil {
 		return err
 	}
-	if err := ls.db.Delete(share).Error; err != nil {
+	if err := ls.db.Where("secret_id = ? AND recipient_id = ? AND is_group = ? AND deleted_at IS NULL",
+		share.SecretID, share.RecipientID, share.IsGroup).Delete(&models.ShareRecord{}).Error; err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorDatabaseOperation", nil), err)
 	}
 	return nil
@@ -229,7 +264,13 @@ func (ls *LocalStorage) CheckSharePermission(ctx context.Context, secretID, user
 		return "", fmt.Errorf("%s: %w", i18n.T("ErrorDatabaseOperation", nil), err)
 	}
 
-	if secret.OwnerID == userID {
+	// #136: OwnerID==0 means the secret has NO human owner (e.g. machine-created); a
+	// machine actor's userID is also 0, so an unguarded equality would match every
+	// ownerless secret via 0==0 and grant it owner-level "write". The core-layer
+	// secretOwnedBy helper (permissions.go) already carries this guard for its own
+	// callers, but this storage-layer check reimplemented the comparison independently
+	// — closing it here too rather than relying solely on callers validating userID != 0.
+	if secret.OwnerID != 0 && secret.OwnerID == userID {
 		return "write", nil
 	}
 

--- a/internal/storage/store/local_sharing_test.go
+++ b/internal/storage/store/local_sharing_test.go
@@ -1,0 +1,136 @@
+package store
+
+import (
+	"context"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// sharingConcurrentDB opens a temp FILE-backed SQLite (not :memory:) with a busy
+// timeout and WAL, so multiple connections genuinely contend — the only way to test
+// that the create-race fix holds under real concurrency (mirrors concurrentDB in
+// concurrency_max_reads_test.go). It also installs the same partial unique index the
+// real migration does (ensureShareRecordUniqueIndex, internal/storage/factory.go —
+// not importable here without a cycle, so the DDL is mirrored).
+func sharingConcurrentDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	dsn := "file:" + filepath.Join(t.TempDir(), "sharing.db") + "?_busy_timeout=10000&_journal_mode=WAL&_txlock=immediate"
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.User{}, &models.Group{}, &models.UserGroup{}, &models.SecretNode{}, &models.ShareRecord{},
+	))
+	require.NoError(t, db.Exec(
+		"CREATE UNIQUE INDEX IF NOT EXISTS uniq_share_records_active ON share_records (secret_id, recipient_id, is_group) WHERE deleted_at IS NULL",
+	).Error)
+	return db
+}
+
+// #136: two concurrent CreateShareRecord calls for the same (secret, recipient) must
+// not both succeed as separate rows — the partial unique index rejects the loser's
+// INSERT, and CreateShareRecord must turn that into an upsert onto the winner's row
+// rather than surfacing a raw constraint error to the caller.
+func TestCreateShareRecord_ConcurrentGrantsNoDuplicateRow(t *testing.T) {
+	db := sharingConcurrentDB(t)
+	ls := NewLocalStorage(db)
+	ctx := context.Background()
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "owner", Email: "o@x.io"}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 2, Username: "grantee", Email: "g@x.io"}).Error)
+	require.NoError(t, db.Create(&models.SecretNode{
+		ID: 100, Name: "s", ProjectID: 1, EnvironmentID: 1, OwnerID: 1, Status: "active", Type: "password",
+	}).Error)
+
+	const n = 8
+	var wg sync.WaitGroup
+	errs := make([]error, n)
+	var start sync.WaitGroup
+	start.Add(1)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			start.Wait()
+			_, err := ls.CreateShareRecord(ctx, &models.ShareRecord{
+				SecretID: 100, RecipientID: 2, IsGroup: false, OwnerID: 1, Permission: "read",
+			})
+			errs[i] = err
+		}(i)
+	}
+	start.Done() // release all goroutines at once to maximize the race window
+	wg.Wait()
+
+	for i, err := range errs {
+		assert.NoError(t, err, "goroutine %d", i)
+	}
+
+	var count int64
+	require.NoError(t, db.Model(&models.ShareRecord{}).
+		Where("secret_id = ? AND recipient_id = ? AND is_group = ? AND deleted_at IS NULL", 100, 2, false).
+		Count(&count).Error)
+	assert.Equal(t, int64(1), count, "concurrent grants for the same (secret, recipient) must collapse to exactly one active row")
+}
+
+// #136: DeleteShareRecord must remove every active row for the target's
+// (secret, recipient, is_group), not just the row named by shareID — so a
+// pre-existing duplicate (e.g. from before the unique index shipped) doesn't survive
+// a revoke and leave access live.
+func TestDeleteShareRecord_RemovesAllDuplicatesForSameTuple(t *testing.T) {
+	db := sharingConcurrentDB(t)
+	ls := NewLocalStorage(db)
+	ctx := context.Background()
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "owner", Email: "o@x.io"}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 2, Username: "grantee", Email: "g@x.io"}).Error)
+	require.NoError(t, db.Create(&models.SecretNode{
+		ID: 100, Name: "s", ProjectID: 1, EnvironmentID: 1, OwnerID: 1, Status: "active", Type: "password",
+	}).Error)
+
+	// Simulate a pre-existing duplicate from before the unique index existed: insert
+	// directly, bypassing CreateShareRecord (which would now reject/upsert it).
+	share1 := &models.ShareRecord{SecretID: 100, RecipientID: 2, IsGroup: false, OwnerID: 1, Permission: "read"}
+	require.NoError(t, db.Exec("DROP INDEX IF EXISTS uniq_share_records_active").Error)
+	require.NoError(t, db.Create(share1).Error)
+	share2 := &models.ShareRecord{SecretID: 100, RecipientID: 2, IsGroup: false, OwnerID: 1, Permission: "read"}
+	require.NoError(t, db.Create(share2).Error)
+
+	var preCount int64
+	require.NoError(t, db.Model(&models.ShareRecord{}).
+		Where("secret_id = ? AND recipient_id = ? AND is_group = ? AND deleted_at IS NULL", 100, 2, false).
+		Count(&preCount).Error)
+	require.Equal(t, int64(2), preCount, "test setup: two duplicate active rows must exist")
+
+	// Revoke by share1's ID only.
+	require.NoError(t, ls.DeleteShareRecord(ctx, share1.ID))
+
+	perm, err := ls.CheckSharePermission(ctx, 100, 2)
+	require.Error(t, err, "revoking one of the duplicate rows must remove access entirely")
+	assert.Equal(t, "", perm)
+
+	var postCount int64
+	require.NoError(t, db.Model(&models.ShareRecord{}).
+		Where("secret_id = ? AND recipient_id = ? AND is_group = ? AND deleted_at IS NULL", 100, 2, false).
+		Count(&postCount).Error)
+	assert.Equal(t, int64(0), postCount, "both duplicate rows must be removed by a single revoke")
+}
+
+// #136: CheckSharePermission's OwnerID==userID check must not match when both are the
+// zero value. A machine actor's ID is also 0, so an unguarded equality would grant it
+// owner-level "write" on every ownerless (machine-created) secret.
+func TestCheckSharePermission_OwnerZeroGuard(t *testing.T) {
+	db := sharingConcurrentDB(t)
+	ls := NewLocalStorage(db)
+	ctx := context.Background()
+	require.NoError(t, db.Create(&models.SecretNode{
+		ID: 100, Name: "s", ProjectID: 1, EnvironmentID: 1, OwnerID: 0, Status: "active", Type: "password",
+	}).Error)
+
+	perm, err := ls.CheckSharePermission(ctx, 100, 0)
+	require.Error(t, err, "userID=0 must not match an ownerless secret's OwnerID=0")
+	assert.Equal(t, "", perm)
+}


### PR DESCRIPTION
## Summary
- `GetCompliancePosture` silently read a failed sub-rollup query (legal hold, SoD violations, anomalies, classification counts, dormant role grants, risk exceptions, ...) as a verified-clean zero value — byte-identical to "queried, found nothing." The sharpest instance: a failed legal-hold query read as `LegalHold.Active=false`, the exact signal purge jobs trust to preserve records under hold, and this snapshot is embedded in an HMAC-signed evidence pack an auditor trusts. Adds `Degraded`/`DegradedReasons` fields so a partial snapshot is now detectable instead of silently passing as clean.
- `CreateShareRecord`'s check-then-create was a read-then-write race: two concurrent grants for the same `(secret, recipient)` could both miss the existing-row SELECT and INSERT separate active rows — `ShareRecord` carried no DB uniqueness constraint. `DeleteShareRecord` then only removed the row named by its ID, so revoking one of a duplicate pair left the other's access live after what looked like a successful revoke. Adds a partial unique index on live rows (`WHERE deleted_at IS NULL`), with a graceful upsert-on-conflict fallback in `CreateShareRecord` so a constraint collision doesn't surface as a raw DB error, and widens `DeleteShareRecord` to remove every active row for the same `(secret, recipient, is_group)` tuple.
- `CheckSharePermission`'s ownership check (`secret.OwnerID == userID`) had no zero-guard: a machine actor's ID is also 0, so it would match every ownerless (machine-created) secret's `OwnerID==0` and grant "write". Adds the same guard the core-layer `secretOwnedBy` helper already carries, closing the gap at the storage layer too.

## Test plan
- [x] `go build ./...` and `GOWORK=off go build -C operator ./...`
- [x] `go test ./...` (full suite)
- [x] New tests: `TestGetCompliancePosture_DegradedOnLegalHoldQueryError` proves a failed sub-query flips `Degraded`; `TestCreateShareRecord_ConcurrentGrantsNoDuplicateRow` drives 8 real concurrent goroutines against a file-backed SQLite DB (`-race`) and asserts exactly one active row survives; `TestDeleteShareRecord_RemovesAllDuplicatesForSameTuple` seeds a pre-existing duplicate pair and confirms a single revoke clears both; `TestCheckSharePermission_OwnerZeroGuard` pins the zero-guard
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues
- [x] `golangci-lint run ./...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)