### PR TITLE
harden: CLI credential-exposure and delivery-insecure-toggle bundle (LOW #103/#142)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -492,7 +492,7 @@ notifications:
     username: "keyorix"
     password: ""                 # prefer the KEYORIX_NOTIFY_SMTP_PASSWORD env var
     from: "keyorix@example.com"
-    tls: "starttls"              # starttls | implicit | none(dev-only)
+    tls: "starttls"              # starttls | implicit | none(dev-only) — none requires KEYORIX_ALLOW_INSECURE_SMTP=true
   slack:
     enabled: true
     webhook_url: ""              # prefer the KEYORIX_NOTIFY_SLACK_WEBHOOK env var
@@ -964,6 +964,15 @@ credential_delivery:
 `out_of_band` / `log` return or log the link instead of emailing it (useful when no
 mail relay is available). A link-producing mode with an empty `base_url` is a
 misconfiguration — link minting refuses it rather than emitting a relative link.
+
+`mode: log` writes a live, usable setup link to the application log (dev/test only) and
+`smtp.tls: none` sends mail — and any relay credentials — in cleartext. Both are refused
+at startup unless the operator explicitly opts in by setting
+`KEYORIX_ALLOW_INSECURE_LOG_DELIVERY=true` (for `mode: log`) or
+`KEYORIX_ALLOW_INSECURE_SMTP=true` (for `smtp.tls: none`), mirroring how other insecure
+toggles in this codebase require an explicit acknowledgement rather than defaulting on.
+The same `KEYORIX_ALLOW_INSECURE_SMTP` gate also applies to `notify.smtp.tls: none` for
+the notification-email channel.
 
 ## connect
 

--- a/docs/adr-028-credential-delivery.md
+++ b/docs/adr-028-credential-delivery.md
@@ -86,7 +86,7 @@ Three implementations:
 
 1. **`SMTPDelivery`** — sends a minimal email via a vetted SMTP library (**`wneessen/go-mail`**, chosen over stdlib `net/smtp` for correct implicit-TLS on 465, STARTTLS, and auth negotiation — TLS correctness is not something to hand-roll in a security product). Connection is operator-configured. Email content (Part D) is plaintext + minimal inline HTML, **no remote resources, no tracking pixels**.
 2. **`OutOfBandDelivery`** — sends nothing; returns the link in `DeliveryResult.LinkForAdmin` so the create-user / invite API response carries it back to the admin UI/CLI, which displays it once with a copy button. Also covers the "admin out-of-band display" of a one-time password (Part E).
-3. **`LogDelivery`** — dev/test only; writes the link to the server log with a loud warning. Never selected when `enabled` and `mode != log`.
+3. **`LogDelivery`** — dev/test only; writes the link to the server log with a loud warning. Never selected when `enabled` and `mode != log`. Because this puts a live, usable credential in the logs, `mode: log` additionally refuses to activate unless the operator explicitly opts in with `KEYORIX_ALLOW_INSECURE_LOG_DELIVERY=true` (the same explicit-opt-in convention as other insecure toggles, e.g. `insecure_skip_verify`). `smtp.tls: none` (cleartext SMTP) is gated the same way, behind `KEYORIX_ALLOW_INSECURE_SMTP=true`.
 
 Selection is by `credential_delivery.mode`:
 - `smtp` — use SMTP; error at send time if SMTP is unreachable (the admin sees "couldn't send; here's the link to relay manually" — i.e. graceful degradation to out-of-band).

--- a/internal/cli/auth/auth.go
+++ b/internal/cli/auth/auth.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"syscall"
 
+	"github.com/keyorixhq/keyorix/internal/cli/common"
 	"github.com/keyorixhq/keyorix/internal/config"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
@@ -51,6 +52,8 @@ func init() {
 func runLogin(cmd *cobra.Command, args []string) error {
 	apiKey, _ := cmd.Flags().GetString("api-key")
 	server, _ := cmd.Flags().GetString("server")
+
+	common.WarnInsecureFlag(cmd, "api-key", "omit the flag to be prompted instead, or set KEYORIX_REMOTE_API_KEY.")
 
 	// Load current configuration
 	cfg, err := config.Load("keyorix.yaml")

--- a/internal/cli/auth/login_flag_warning_test.go
+++ b/internal/cli/auth/login_flag_warning_test.go
@@ -1,0 +1,49 @@
+// login_flag_warning_test.go — verifies 'auth login --api-key' warns on stderr about
+// ps/proc + shell-history exposure when the flag is explicitly passed on the command
+// line, and stays silent when the caller is prompted for it instead.
+package auth
+
+import (
+	"io"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stderr
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stderr = w
+	defer func() { os.Stderr = orig }()
+
+	fn()
+
+	require.NoError(t, w.Close())
+	out, err := io.ReadAll(r)
+	require.NoError(t, err)
+	return string(out)
+}
+
+func TestRunLogin_APIKeyFlagWarnsWhenExplicitlySet(t *testing.T) {
+	t.Chdir(t.TempDir()) // runLogin writes keyorix.yaml relative to cwd
+
+	require.NoError(t, loginCmd.Flags().Set("api-key", "kx_api_secret"))
+	require.NoError(t, loginCmd.Flags().Set("server", "https://keyorix.example.com"))
+	t.Cleanup(func() {
+		_ = loginCmd.Flags().Set("api-key", "")
+		_ = loginCmd.Flags().Set("server", "")
+		loginCmd.Flags().Lookup("api-key").Changed = false
+		loginCmd.Flags().Lookup("server").Changed = false
+	})
+
+	out := captureStderr(t, func() {
+		require.NoError(t, runLogin(loginCmd, nil))
+	})
+	assert.Contains(t, out, "--api-key")
+	assert.Contains(t, out, "ps/proc")
+	assert.Contains(t, out, "shell history")
+}

--- a/internal/cli/common/warn.go
+++ b/internal/cli/common/warn.go
@@ -1,0 +1,20 @@
+package common
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// WarnInsecureFlag prints a loud stderr warning when the named flag was explicitly
+// set on the command line. Command-line arguments are visible to any other local user
+// via `ps`/`/proc/<pid>/cmdline` and are typically saved in shell history, so a secret
+// value, password, API key, or token should never be passed this way if there is a
+// safer alternative (an interactive prompt, --from-file, or an environment variable).
+// It is a no-op when the flag was left at its default (nothing insecure happened).
+func WarnInsecureFlag(cmd *cobra.Command, flagName, advice string) {
+	if cmd.Flags().Changed(flagName) {
+		fmt.Fprintf(os.Stderr, "⚠️  Passing --%s on the command line is insecure (visible to other local users via ps/proc, and saved in shell history); %s\n", flagName, advice)
+	}
+}

--- a/internal/cli/common/warn_test.go
+++ b/internal/cli/common/warn_test.go
@@ -1,0 +1,59 @@
+package common
+
+import (
+	"io"
+	"os"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// captureStderr redirects os.Stderr for the duration of fn and returns everything
+// written to it.
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stderr
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stderr = w
+	defer func() { os.Stderr = orig }()
+
+	fn()
+
+	require.NoError(t, w.Close())
+	out, err := io.ReadAll(r)
+	require.NoError(t, err)
+	return string(out)
+}
+
+func newCmdWithFlag(flagName, value string, changed bool) *cobra.Command {
+	cmd := &cobra.Command{Use: "x"}
+	cmd.Flags().String(flagName, "", "")
+	if changed {
+		_ = cmd.Flags().Set(flagName, value)
+	}
+	return cmd
+}
+
+func TestWarnInsecureFlag(t *testing.T) {
+	t.Run("warns when the flag was explicitly set on the command line", func(t *testing.T) {
+		cmd := newCmdWithFlag("value", "s3cr3t", true)
+		out := captureStderr(t, func() {
+			WarnInsecureFlag(cmd, "value", "use --interactive instead.")
+		})
+		assert.Contains(t, out, "--value")
+		assert.Contains(t, out, "ps/proc")
+		assert.Contains(t, out, "shell history")
+		assert.Contains(t, out, "use --interactive instead.")
+	})
+
+	t.Run("stays silent when the flag was left at its default", func(t *testing.T) {
+		cmd := newCmdWithFlag("value", "", false)
+		out := captureStderr(t, func() {
+			WarnInsecureFlag(cmd, "value", "use --interactive instead.")
+		})
+		assert.Empty(t, out, "no warning should be printed when the insecure flag was never used")
+	})
+}

--- a/internal/cli/config/cli_config.go
+++ b/internal/cli/config/cli_config.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/keyorixhq/keyorix/internal/securefiles"
 	"gopkg.in/yaml.v3"
 )
 
@@ -136,8 +137,11 @@ func SaveCLIConfig(config *CLIConfig, configPath string) error {
 		return fmt.Errorf("failed to marshal config: %w", err)
 	}
 
-	// Write file with secure permissions
-	if err := os.WriteFile(configPath, data, 0600); err != nil {
+	// Write with 0600 perms via the hardened writer (matches internal/config.Save):
+	// O_NOFOLLOW refuses to write through a symlink planted at configPath, so a local
+	// attacker who can plant a dangling symlink at the CLI config path cannot redirect
+	// this write (which may contain an API key) to an arbitrary file.
+	if err := securefiles.SecureWriteFile(dir, filepath.Base(configPath), data, 0600); err != nil {
 		return fmt.Errorf("failed to write config file: %w", err)
 	}
 

--- a/internal/cli/config/cli_config_test.go
+++ b/internal/cli/config/cli_config_test.go
@@ -1,0 +1,49 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSaveCLIConfig_RoundTripAndPerms(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cli.yaml")
+
+	cfg := DefaultCLIConfig()
+	cfg.SetClientMode("https://keyorix.example.com", "kx_api_secret")
+
+	require.NoError(t, SaveCLIConfig(cfg, path))
+
+	// The file must be written with 0600 perms — it can hold an API key — not the
+	// world/group-readable 0644 a plain os.WriteFile-without-perm-enforcement risks.
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0600), info.Mode().Perm())
+
+	loaded, err := LoadCLIConfig(path)
+	require.NoError(t, err)
+	assert.Equal(t, "client", loaded.Mode)
+	assert.Equal(t, "https://keyorix.example.com", loaded.Client.Endpoint)
+	assert.Equal(t, "kx_api_secret", loaded.Client.Auth.APIKey)
+}
+
+// A dangling final-component symlink at the config path must not be followed: writing
+// through it would let a local attacker who can plant a symlink redirect a config
+// write (containing an API key) to an arbitrary file outside the intended directory.
+func TestSaveCLIConfig_RefusesDanglingSymlink(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cli.yaml")
+	outside := filepath.Join(filepath.Dir(dir), "escape-cli.yaml")
+	require.NoError(t, os.Symlink(outside, path))
+
+	cfg := DefaultCLIConfig()
+	err := SaveCLIConfig(cfg, path)
+	require.Error(t, err, "writing through a symlink must be refused")
+
+	_, statErr := os.Stat(outside)
+	assert.True(t, os.IsNotExist(statErr), "the symlink target outside the config dir must not have been created")
+}

--- a/internal/cli/group/delete.go
+++ b/internal/cli/group/delete.go
@@ -1,15 +1,21 @@
 package group
 
 import (
+	"bufio"
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"strings"
 
 	"github.com/keyorixhq/keyorix/internal/cli/common"
 	"github.com/spf13/cobra"
 )
 
-var deleteGroupID uint
+var (
+	deleteGroupID uint
+	deleteForce   bool
+)
 
 var deleteCmd = &cobra.Command{
 	Use:   "delete",
@@ -19,6 +25,7 @@ var deleteCmd = &cobra.Command{
 
 func init() {
 	deleteCmd.Flags().UintVar(&deleteGroupID, "id", 0, "Group ID (required)")
+	deleteCmd.Flags().BoolVar(&deleteForce, "force", false, "Skip the confirmation prompt")
 }
 
 func runDelete(cmd *cobra.Command, args []string) error {
@@ -30,9 +37,34 @@ func runDelete(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to initialize service: %w", err)
 	}
 	ctx := context.Background()
+
+	// Deleting a group is irreversible, so require an explicit confirmation unless
+	// the caller opted out with --force (e.g. for scripted/CI use).
+	if !deleteForce {
+		label := fmt.Sprintf("group %d", deleteGroupID)
+		if g, gerr := service.GetGroup(ctx, deleteGroupID); gerr == nil {
+			label = fmt.Sprintf("group %d (%s)", g.ID, g.Name)
+		}
+		if !confirmYesNo(fmt.Sprintf("Delete %s? This cannot be undone.", label)) {
+			fmt.Println("❌ Deletion cancelled")
+			return nil
+		}
+	}
+
 	if err := service.DeleteGroup(ctx, 0, deleteGroupID); err != nil { // actorID 0: local/unauthenticated CLI
 		return fmt.Errorf("failed to delete group: %w", err)
 	}
 	fmt.Printf("Group %d deleted.\n", deleteGroupID)
 	return nil
+}
+
+// confirmYesNo prompts on stdin and reports whether the operator typed "y"/"yes"
+// (case-insensitive). Anything else — including a blank line — is treated as "no", so
+// an accidental Enter never confirms a destructive action.
+func confirmYesNo(prompt string) bool {
+	reader := bufio.NewReader(os.Stdin)
+	fmt.Printf("%s (yes/no): ", prompt)
+	input, _ := reader.ReadString('\n')
+	input = strings.TrimSpace(strings.ToLower(input))
+	return input == "yes" || input == "y"
 }

--- a/internal/cli/group/delete_test.go
+++ b/internal/cli/group/delete_test.go
@@ -1,0 +1,59 @@
+package group
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// withStdin redirects os.Stdin to a pipe pre-loaded with input for the duration of fn.
+func withStdin(t *testing.T, input string, fn func()) {
+	t.Helper()
+	orig := os.Stdin
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdin = r
+	defer func() { os.Stdin = orig }()
+
+	go func() {
+		_, _ = w.WriteString(input)
+		_ = w.Close()
+	}()
+
+	fn()
+}
+
+func TestConfirmYesNo(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{"explicit yes", "yes\n", true},
+		{"short y", "y\n", true},
+		{"explicit no", "no\n", false},
+		{"short n", "n\n", false},
+		// A destructive prompt must fail CLOSED: a blank line (accidental Enter) or any
+		// unrecognized input must never be treated as confirmation.
+		{"blank line does not confirm", "\n", false},
+		{"garbage does not confirm", "sure whatever\n", false},
+		{"mixed case yes still confirms", "YES\n", true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var got bool
+			withStdin(t, c.input, func() {
+				got = confirmYesNo("Delete group 42?")
+			})
+			assert.Equal(t, c.want, got)
+		})
+	}
+}
+
+func TestDeleteCmd_HasForceBypassFlag(t *testing.T) {
+	f := deleteCmd.Flags().Lookup("force")
+	require.NotNil(t, f, "delete must expose --force to bypass the confirmation prompt for scripted use")
+	assert.Equal(t, "false", f.DefValue, "confirmation must be required by default")
+}

--- a/internal/cli/run/run.go
+++ b/internal/cli/run/run.go
@@ -300,9 +300,47 @@ func toEnvKey(name string) string {
 	return b.String()
 }
 
+// sensitiveEnvSuffixes mark a KEYORIX_-prefixed env var as this CLI invocation's own
+// credential (an auth token, password, API key, secret, or DB DSN) rather than
+// something a launched command needs.
+var sensitiveEnvSuffixes = []string{"_TOKEN", "_PASSWORD", "_SECRET", "_API_KEY", "_DSN", "_KEK"}
+
+// filterSensitiveEnv drops Keyorix's own credential env vars (e.g. KEYORIX_TOKEN, the
+// token this invocation used to authenticate) from the environment inherited by the
+// child process. 'keyorix run' still inherits the rest of the parent environment
+// unchanged (PATH, HOME, and any other var) — that inheritance is the point of `run`,
+// matching how a plain subshell behaves — but the child (and anything it in turn
+// spawns) has no legitimate need for the credentials THIS CLI invocation used to reach
+// Keyorix, so those are withheld rather than handed down by default.
+func filterSensitiveEnv(env []string) []string {
+	out := make([]string, 0, len(env))
+	for _, kv := range env {
+		key, _, _ := strings.Cut(kv, "=")
+		if isSensitiveKeyorixEnv(key) {
+			continue
+		}
+		out = append(out, kv)
+	}
+	return out
+}
+
+// isSensitiveKeyorixEnv reports whether key is a Keyorix-internal credential variable
+// (KEYORIX_ prefix plus a token/password/secret/key/DSN suffix).
+func isSensitiveKeyorixEnv(key string) bool {
+	if !strings.HasPrefix(key, "KEYORIX_") {
+		return false
+	}
+	for _, suf := range sensitiveEnvSuffixes {
+		if strings.HasSuffix(key, suf) {
+			return true
+		}
+	}
+	return false
+}
+
 // execChild builds the child environment and executes the command.
 func execChild(args []string, extraEnv map[string]string) error {
-	childEnv := os.Environ()
+	childEnv := filterSensitiveEnv(os.Environ())
 	for k, v := range extraEnv {
 		childEnv = append(childEnv, k+"="+v)
 	}

--- a/internal/cli/run/run_test.go
+++ b/internal/cli/run/run_test.go
@@ -1,0 +1,71 @@
+package run
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFilterSensitiveEnv(t *testing.T) {
+	in := []string{
+		"PATH=/usr/bin",
+		"HOME=/home/dev",
+		"KEYORIX_TOKEN=super-secret-token",
+		"KEYORIX_API_KEY=kx_api_abc",
+		"KEYORIX_REMOTE_API_KEY=kx_remote_abc",
+		"KEYORIX_BOOTSTRAP_TOKEN=boot-tok",
+		"KEYORIX_PASSWORD=hunter2",
+		"KEYORIX_MASTER_PASSWORD=hunter3",
+		"KEYORIX_TARGET_KEK=base64kek",
+		"KEYORIX_DYNAMIC_ADMIN_DSN=postgres://u:p@h/db",
+		"KEYORIX_PROJECT=payments", // not a credential — must survive
+		"KEYORIX_SERVER=https://x", // not a credential — must survive
+		"KEYORIX_ENV=production",   // not a credential — must survive
+	}
+
+	out := filterSensitiveEnv(in)
+
+	t.Run("strips every Keyorix credential var", func(t *testing.T) {
+		for _, sensitive := range []string{
+			"KEYORIX_TOKEN=super-secret-token",
+			"KEYORIX_API_KEY=kx_api_abc",
+			"KEYORIX_REMOTE_API_KEY=kx_remote_abc",
+			"KEYORIX_BOOTSTRAP_TOKEN=boot-tok",
+			"KEYORIX_PASSWORD=hunter2",
+			"KEYORIX_MASTER_PASSWORD=hunter3",
+			"KEYORIX_TARGET_KEK=base64kek",
+			"KEYORIX_DYNAMIC_ADMIN_DSN=postgres://u:p@h/db",
+		} {
+			assert.NotContains(t, out, sensitive, "%s must not leak into the child environment", sensitive)
+		}
+	})
+
+	t.Run("keeps ordinary and non-credential Keyorix vars intact", func(t *testing.T) {
+		for _, keep := range []string{
+			"PATH=/usr/bin",
+			"HOME=/home/dev",
+			"KEYORIX_PROJECT=payments",
+			"KEYORIX_SERVER=https://x",
+			"KEYORIX_ENV=production",
+		} {
+			assert.Contains(t, out, keep, "%s should still be passed to the child", keep)
+		}
+	})
+}
+
+func TestIsSensitiveKeyorixEnv(t *testing.T) {
+	cases := map[string]bool{
+		"KEYORIX_TOKEN":         true,
+		"KEYORIX_API_KEY":       true,
+		"KEYORIX_SIEM_TOKEN":    true,
+		"KEYORIX_SMTP_PASSWORD": true,
+		"KEYORIX_TARGET_KEK":    true,
+		"KEYORIX_PROJECT":       false,
+		"KEYORIX_SERVER":        false,
+		"PATH":                  false,
+		"SOME_OTHER_APP_TOKEN":  false, // not KEYORIX_-prefixed
+	}
+	for key, want := range cases {
+		assert.Equal(t, want, isSensitiveKeyorixEnv(key), "key=%s", key)
+	}
+}

--- a/internal/cli/secret/create.go
+++ b/internal/cli/secret/create.go
@@ -53,6 +53,8 @@ func init() {
 }
 
 func runCreate(cmd *cobra.Command, args []string) error {
+	common.WarnInsecureFlag(cmd, "value", "use --interactive or --from-file instead.")
+
 	var (
 		req *core.CreateSecretRequest
 		err error

--- a/internal/cli/secret/rotate.go
+++ b/internal/cli/secret/rotate.go
@@ -5,9 +5,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"syscall"
 
+	"github.com/keyorixhq/keyorix/internal/cli/common"
 	cliconfig "github.com/keyorixhq/keyorix/internal/cli/config"
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 )
 
 var rotateCmd = &cobra.Command{
@@ -21,14 +24,27 @@ var rotateValue string
 var rotateEnv string
 
 func init() {
-	rotateCmd.Flags().StringVarP(&rotateValue, "value", "v", "", "New secret value (required)")
+	rotateCmd.Flags().StringVarP(&rotateValue, "value", "v", "", "New secret value (omit to be prompted interactively)")
 	rotateCmd.Flags().StringVarP(&rotateEnv, "env", "e", "production", "Environment name")
-	_ = rotateCmd.MarkFlagRequired("value") // #nosec G104
 	SecretCmd.AddCommand(rotateCmd)
 }
 
 func runRotate(cmd *cobra.Command, args []string) error {
 	name := args[0]
+
+	common.WarnInsecureFlag(cmd, "value", "omit the flag to be prompted instead.")
+	if !cmd.Flags().Changed("value") {
+		fmt.Print("New secret value (hidden): ")
+		valueBytes, perr := term.ReadPassword(int(syscall.Stdin))
+		fmt.Println()
+		if perr != nil {
+			return fmt.Errorf("failed to read secret value: %w", perr)
+		}
+		if len(valueBytes) == 0 {
+			return fmt.Errorf("secret value is required (use --value or enter it at the prompt)")
+		}
+		rotateValue = string(valueBytes)
+	}
 
 	cfg, err := cliconfig.LoadCLIConfig("")
 	if err != nil {

--- a/internal/cli/secret/rotate_test.go
+++ b/internal/cli/secret/rotate_test.go
@@ -1,0 +1,78 @@
+package secret
+
+import (
+	"io"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// isolateCLIConfig points the CLI config lookup at an empty temp dir so
+// cliconfig.LoadCLIConfig("") deterministically returns the zero-value default
+// (Client.Endpoint == "") regardless of what the host running the tests has on disk.
+func isolateCLIConfig(t *testing.T) {
+	t.Helper()
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+}
+
+// resetRotateFlags restores rotateCmd's flag values/Changed state after a test
+// mutates them directly.
+func resetRotateFlags(t *testing.T) {
+	t.Helper()
+	origValue, origEnv := rotateValue, rotateEnv
+	t.Cleanup(func() {
+		rotateValue, rotateEnv = origValue, origEnv
+		_ = rotateCmd.Flags().Set("value", "")
+		rotateCmd.Flags().Lookup("value").Changed = false
+	})
+}
+
+func TestRunRotate_ValueFlagWarnsOnCommandLine(t *testing.T) {
+	isolateCLIConfig(t)
+	resetRotateFlags(t)
+	require.NoError(t, rotateCmd.Flags().Set("value", "s3cr3t-on-argv"))
+
+	origStderr := os.Stderr
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stderr = w
+	// runRotate will go on to fail on the network call (no server configured); that's
+	// fine — we only care that the warning was printed before it gets there.
+	_ = runRotate(rotateCmd, []string{"some-secret"})
+	os.Stderr = origStderr
+	require.NoError(t, w.Close())
+	out, err := io.ReadAll(r)
+	require.NoError(t, err)
+
+	assert.Contains(t, string(out), "--value")
+	assert.Contains(t, string(out), "ps/proc")
+}
+
+// When --value is omitted, rotate must not silently proceed with an empty secret: it
+// falls back to an interactive masked prompt, and if that prompt cannot be read (e.g.
+// stdin is not a terminal, as in this test), the command must fail closed rather than
+// send an empty rotation value to the server.
+func TestRunRotate_MissingValueFailsClosedWithoutATerminal(t *testing.T) {
+	isolateCLIConfig(t)
+	resetRotateFlags(t)
+
+	origStdin := os.Stdin
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdin = r
+	defer func() { os.Stdin = origStdin }()
+	_ = w.Close() // EOF immediately — simulates a non-interactive/non-tty stdin
+
+	err = runRotate(rotateCmd, []string{"some-secret"})
+	require.Error(t, err, "must not proceed with an empty/unread secret value")
+}
+
+func TestRotateCmd_ValueFlagIsNotRequired(t *testing.T) {
+	f := rotateCmd.Flags().Lookup("value")
+	require.NotNil(t, f)
+	assert.Empty(t, f.Annotations[requiredFlagAnnotation], "--value must be optional now that omitting it prompts interactively")
+}
+
+const requiredFlagAnnotation = "cobra_annotation_bash_completion_one_required_flag"

--- a/internal/cli/secret/scan.go
+++ b/internal/cli/secret/scan.go
@@ -125,6 +125,18 @@ func runScan(cmd *cobra.Command, args []string) error {
 	}
 
 	if scanCommit != "" {
+		// scanCommit is a user-controlled --commit value passed straight to git as a
+		// revision argument. A value starting with "-" (e.g. "--upload-pack=...")
+		// would otherwise be parsed as a git flag rather than a revision — arg
+		// injection, not full shell injection (no shell is involved), but still lets a
+		// crafted value smuggle extra git arguments. A literal "--" separator does NOT
+		// fix this for diff-tree: git treats everything after "--" as a pathspec, not a
+		// revision, so it would just break every legitimate --commit value. Reject a
+		// leading "-" instead — no genuine git revision (branch, tag, SHA, HEAD~N, …)
+		// ever starts with one.
+		if strings.HasPrefix(scanCommit, "-") {
+			return fmt.Errorf("invalid --commit value %q: must not start with '-'", scanCommit)
+		}
 		out, err := exec.Command("git", "-C", absPath, "diff-tree", "--no-commit-id", "-r", "--name-only", scanCommit).Output() // #nosec G204
 		if err == nil && len(out) > 0 {
 			stagedFiles = map[string]bool{}

--- a/internal/cli/secret/scan_git_test.go
+++ b/internal/cli/secret/scan_git_test.go
@@ -1,0 +1,60 @@
+package secret
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// resetScanFlags restores the scan command's package-level flag state after a test
+// mutates it directly (the flags are cobra package vars, not per-call state).
+func resetScanFlags(t *testing.T) {
+	t.Helper()
+	origCommit, origStaged, origImport, origReport, origSeverity := scanCommit, scanStaged, scanImport, scanReport, scanSeverity
+	t.Cleanup(func() {
+		scanCommit, scanStaged, scanImport, scanReport, scanSeverity = origCommit, origStaged, origImport, origReport, origSeverity
+	})
+}
+
+func TestRunScan_CommitFlagRejectsLeadingDash(t *testing.T) {
+	resetScanFlags(t)
+	dir := t.TempDir()
+
+	// A --commit value starting with "-" would otherwise be parsed by git as a flag
+	// (e.g. "--upload-pack=/some/evil") instead of a revision — arg injection. It must
+	// be rejected before a git subprocess is ever spawned.
+	scanCommit = "--upload-pack=/bin/sh"
+
+	err := runScan(scanCmd, []string{dir})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid --commit value")
+}
+
+func TestRunScan_CommitFlagAcceptsARealRevision(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	resetScanFlags(t)
+	dir := t.TempDir()
+
+	runGit := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", append([]string{"-C", dir}, args...)...) // #nosec G204 -- test-controlled args
+		cmd.Env = append(os.Environ(), "GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t.io", "GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t.io")
+		out, err := cmd.CombinedOutput()
+		require.NoErrorf(t, err, "git %v: %s", args, out)
+	}
+
+	runGit("init", "-q")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "config.yaml"), []byte("api_key: AKIAABCDEFGHIJKLMNOP\n"), 0600))
+	runGit("add", "config.yaml")
+	runGit("commit", "-q", "-m", "add config")
+
+	scanCommit = "HEAD"
+	err := runScan(scanCmd, []string{dir})
+	require.NoError(t, err, "a real revision must still work after the arg-injection fix")
+}

--- a/internal/cli/secret/update.go
+++ b/internal/cli/secret/update.go
@@ -59,6 +59,8 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 		return errors.New("secret ID is required (use --id)")
 	}
 
+	common.WarnInsecureFlag(cmd, "value", "use --interactive or --from-file instead.")
+
 	if rc, ok := common.NewRemoteClient(); ok {
 		return runUpdateRemote(rc)
 	}

--- a/internal/cli/secret/value_flag_warning_test.go
+++ b/internal/cli/secret/value_flag_warning_test.go
@@ -1,0 +1,85 @@
+// value_flag_warning_test.go — verifies that 'secret create' and 'secret update'
+// warn on stderr when a secret value is passed via --value (ps/proc + shell-history
+// exposure), matching the same property already covered for 'secret rotate' in
+// rotate_test.go.
+package secret
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// captureStderr redirects os.Stderr for the duration of fn and returns everything
+// written to it.
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stderr
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stderr = w
+	defer func() { os.Stderr = orig }()
+
+	fn()
+
+	require.NoError(t, w.Close())
+	out, err := io.ReadAll(r)
+	require.NoError(t, err)
+	return string(out)
+}
+
+func TestRunCreate_ValueFlagWarnsOnCommandLine(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"id":1,"name":"x","type":"generic","project_id":1,"environment_id":1}}`))
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+
+	origName, origValue, origInteractive := createName, createValue, createInteractive
+	t.Cleanup(func() { createName, createValue, createInteractive = origName, origValue, origInteractive })
+	createInteractive = false
+	require.NoError(t, createCmd.Flags().Set("name", "my-secret"))
+	require.NoError(t, createCmd.Flags().Set("value", "s3cr3t-on-argv"))
+	t.Cleanup(func() {
+		_ = createCmd.Flags().Set("value", "")
+		createCmd.Flags().Lookup("value").Changed = false
+		createCmd.Flags().Lookup("name").Changed = false
+	})
+
+	out := captureStderr(t, func() {
+		_ = runCreate(createCmd, nil)
+	})
+	assert.Contains(t, out, "--value")
+	assert.Contains(t, out, "ps/proc")
+}
+
+func TestRunUpdate_ValueFlagWarnsOnCommandLine(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"id":1,"name":"x","type":"generic","project_id":1,"environment_id":1}}`))
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+
+	origID, origValue, origInteractive := updateID, updateValue, updateInteractive
+	t.Cleanup(func() { updateID, updateValue, updateInteractive = origID, origValue, origInteractive })
+	updateID = 1
+	updateInteractive = false
+	require.NoError(t, updateCmd.Flags().Set("value", "s3cr3t-on-argv"))
+	t.Cleanup(func() {
+		_ = updateCmd.Flags().Set("value", "")
+		updateCmd.Flags().Lookup("value").Changed = false
+	})
+
+	out := captureStderr(t, func() {
+		_ = runUpdate(updateCmd, nil)
+	})
+	assert.Contains(t, out, "--value")
+	assert.Contains(t, out, "ps/proc")
+}

--- a/internal/cli/system/init.go
+++ b/internal/cli/system/init.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/keyorixhq/keyorix/internal/cli/common"
 	"github.com/keyorixhq/keyorix/internal/config"
 	"github.com/keyorixhq/keyorix/internal/securefiles"
 	"github.com/spf13/cobra"
@@ -74,6 +75,7 @@ func init() {
 
 func runInit(cmd *cobra.Command, args []string) error {
 	if initServer != "" {
+		common.WarnInsecureFlag(cmd, "admin-password", "consider leaving it unset and changing the password after first login instead.")
 		return runRemoteInit()
 	}
 

--- a/internal/cli/system/init_flag_warning_test.go
+++ b/internal/cli/system/init_flag_warning_test.go
@@ -1,0 +1,75 @@
+// init_flag_warning_test.go — verifies 'system init --server ... --admin-password'
+// warns on stderr about ps/proc + shell-history exposure when the flag is explicitly
+// passed on the command line, and stays silent when it is left at its default.
+package system
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stderr
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stderr = w
+	defer func() { os.Stderr = orig }()
+
+	fn()
+
+	require.NoError(t, w.Close())
+	out, err := io.ReadAll(r)
+	require.NoError(t, err)
+	return string(out)
+}
+
+func remoteInitStub(t *testing.T) string {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"success":true,"data":{"already_initialized":true}}`))
+	}))
+	t.Cleanup(srv.Close)
+	return srv.URL
+}
+
+func resetInitFlags(t *testing.T) {
+	t.Helper()
+	origServer, origPassword := initServer, initAdminPassword
+	t.Cleanup(func() {
+		initServer, initAdminPassword = origServer, origPassword
+		InitCmd.Flags().Lookup("admin-password").Changed = false
+		InitCmd.Flags().Lookup("server").Changed = false
+	})
+}
+
+func TestRunInit_AdminPasswordFlagWarnsWhenExplicitlySet(t *testing.T) {
+	resetInitFlags(t)
+	url := remoteInitStub(t)
+	require.NoError(t, InitCmd.Flags().Set("server", url))
+	require.NoError(t, InitCmd.Flags().Set("admin-password", "correct-horse-battery-staple"))
+
+	out := captureStderr(t, func() {
+		require.NoError(t, runInit(InitCmd, nil))
+	})
+	assert.Contains(t, out, "--admin-password")
+	assert.Contains(t, out, "ps/proc")
+}
+
+func TestRunInit_AdminPasswordFlagSilentWhenLeftAtDefault(t *testing.T) {
+	resetInitFlags(t)
+	url := remoteInitStub(t)
+	require.NoError(t, InitCmd.Flags().Set("server", url))
+	// admin-password left untouched (default "admin").
+
+	out := captureStderr(t, func() {
+		require.NoError(t, runInit(InitCmd, nil))
+	})
+	assert.NotContains(t, out, "--admin-password")
+}

--- a/internal/cli/user/delete.go
+++ b/internal/cli/user/delete.go
@@ -1,15 +1,21 @@
 package user
 
 import (
+	"bufio"
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"strings"
 
 	"github.com/keyorixhq/keyorix/internal/cli/common"
 	"github.com/spf13/cobra"
 )
 
-var deleteUserID uint
+var (
+	deleteUserID uint
+	deleteForce  bool
+)
 
 var deleteCmd = &cobra.Command{
 	Use:   "delete",
@@ -19,6 +25,7 @@ var deleteCmd = &cobra.Command{
 
 func init() {
 	deleteCmd.Flags().UintVar(&deleteUserID, "id", 0, "User ID (required)")
+	deleteCmd.Flags().BoolVar(&deleteForce, "force", false, "Skip the confirmation prompt")
 }
 
 func runDelete(cmd *cobra.Command, args []string) error {
@@ -32,9 +39,33 @@ func runDelete(cmd *cobra.Command, args []string) error {
 	}
 	ctx := context.Background()
 
+	// Deleting a user is irreversible, so require an explicit confirmation unless
+	// the caller opted out with --force (e.g. for scripted/CI use).
+	if !deleteForce {
+		label := fmt.Sprintf("user %d", deleteUserID)
+		if u, gerr := service.GetUser(ctx, deleteUserID); gerr == nil {
+			label = fmt.Sprintf("user %d (%s)", u.ID, u.Email)
+		}
+		if !confirmYesNo(fmt.Sprintf("Delete %s? This cannot be undone.", label)) {
+			fmt.Println("❌ Deletion cancelled")
+			return nil
+		}
+	}
+
 	if err := service.DeleteUser(ctx, deleteUserID); err != nil {
 		return fmt.Errorf("failed to delete user: %w", err)
 	}
 	fmt.Printf("User %d deleted.\n", deleteUserID)
 	return nil
+}
+
+// confirmYesNo prompts on stdin and reports whether the operator typed "y"/"yes"
+// (case-insensitive). Anything else — including a blank line — is treated as "no", so
+// an accidental Enter never confirms a destructive action.
+func confirmYesNo(prompt string) bool {
+	reader := bufio.NewReader(os.Stdin)
+	fmt.Printf("%s (yes/no): ", prompt)
+	input, _ := reader.ReadString('\n')
+	input = strings.TrimSpace(strings.ToLower(input))
+	return input == "yes" || input == "y"
 }

--- a/internal/cli/user/delete_test.go
+++ b/internal/cli/user/delete_test.go
@@ -1,0 +1,59 @@
+package user
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// withStdin redirects os.Stdin to a pipe pre-loaded with input for the duration of fn.
+func withStdin(t *testing.T, input string, fn func()) {
+	t.Helper()
+	orig := os.Stdin
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdin = r
+	defer func() { os.Stdin = orig }()
+
+	go func() {
+		_, _ = w.WriteString(input)
+		_ = w.Close()
+	}()
+
+	fn()
+}
+
+func TestConfirmYesNo(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{"explicit yes", "yes\n", true},
+		{"short y", "y\n", true},
+		{"explicit no", "no\n", false},
+		{"short n", "n\n", false},
+		// A destructive prompt must fail CLOSED: a blank line (accidental Enter) or any
+		// unrecognized input must never be treated as confirmation.
+		{"blank line does not confirm", "\n", false},
+		{"garbage does not confirm", "sure whatever\n", false},
+		{"mixed case yes still confirms", "YES\n", true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var got bool
+			withStdin(t, c.input, func() {
+				got = confirmYesNo("Delete user 42?")
+			})
+			assert.Equal(t, c.want, got)
+		})
+	}
+}
+
+func TestDeleteCmd_HasForceBypassFlag(t *testing.T) {
+	f := deleteCmd.Flags().Lookup("force")
+	require.NotNil(t, f, "delete must expose --force to bypass the confirmation prompt for scripted use")
+	assert.Equal(t, "false", f.DefValue, "confirmation must be required by default")
+}

--- a/internal/delivery/delivery.go
+++ b/internal/delivery/delivery.go
@@ -14,7 +14,30 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"os"
+	"strconv"
 )
+
+// EnvAllowInsecureLogDelivery gates credential_delivery.mode=log (ADR-028). Writing a
+// live, usable password-reset / setup link to the application log is a real credential
+// disclosure — anyone with log read access gets a working account-takeover link. Unlike
+// the other delivery modes it is dev/test-only, so — mirroring how other insecure
+// toggles in this codebase (e.g. insecure_skip_verify) require an explicit operator
+// opt-in rather than defaulting on — mode=log refuses to activate unless this env var is
+// set to a truthy value.
+const EnvAllowInsecureLogDelivery = "KEYORIX_ALLOW_INSECURE_LOG_DELIVERY"
+
+// envFlagEnabled reports whether the named environment variable is set to a truthy
+// value (accepts anything strconv.ParseBool accepts: "1", "t", "true", etc., case
+// sensitive per ParseBool). Unset or unparsable = false (fail closed).
+func envFlagEnabled(name string) bool {
+	v, ok := os.LookupEnv(name)
+	if !ok {
+		return false
+	}
+	b, err := strconv.ParseBool(v)
+	return err == nil && b
+}
 
 // Delivery modes (credential_delivery.mode).
 const (
@@ -105,6 +128,10 @@ func New(cfg Config) (CredentialDelivery, error) {
 	case ModeOutOfBand:
 		return &OutOfBandDelivery{}, nil
 	case ModeLog:
+		if !envFlagEnabled(EnvAllowInsecureLogDelivery) {
+			return nil, fmt.Errorf("delivery: credential_delivery.mode=log writes a live, usable setup link to the log; refusing unless the operator explicitly opts in by setting %s=true", EnvAllowInsecureLogDelivery)
+		}
+		log.Printf("delivery: WARNING credential_delivery.mode=log is ACTIVE — setup links (live, usable credentials) will be written to the application log; dev/test only, never use in production")
 		return &LogDelivery{}, nil
 	case ModeSMTP:
 		return newSMTPDelivery(cfg.SMTP)

--- a/internal/delivery/delivery_test.go
+++ b/internal/delivery/delivery_test.go
@@ -21,7 +21,14 @@ func TestNew(t *testing.T) {
 		assert.IsType(t, &OutOfBandDelivery{}, d)
 	})
 
-	t.Run("log selects LogDelivery", func(t *testing.T) {
+	t.Run("log refuses to activate without the explicit opt-in env var", func(t *testing.T) {
+		t.Setenv(EnvAllowInsecureLogDelivery, "")
+		_, err := New(Config{Mode: ModeLog})
+		require.Error(t, err, "mode=log discloses a live setup link into the log; it must fail closed by default")
+	})
+
+	t.Run("log selects LogDelivery once the operator opts in", func(t *testing.T) {
+		t.Setenv(EnvAllowInsecureLogDelivery, "true")
 		d, err := New(Config{Mode: ModeLog})
 		require.NoError(t, err)
 		assert.IsType(t, &LogDelivery{}, d)

--- a/internal/delivery/smtp.go
+++ b/internal/delivery/smtp.go
@@ -37,6 +37,13 @@ const (
 	smtpTLSNone     = "none"
 )
 
+// EnvAllowInsecureSMTP gates credential_delivery.smtp.tls=none. Cleartext SMTP sends
+// the setup-link email (and, if the relay requires auth, the relay credentials) over
+// the wire unencrypted — mirroring the explicit-opt-in convention used for other
+// insecure toggles in this codebase (e.g. insecure_skip_verify), tls=none refuses to
+// activate unless this env var is set to a truthy value.
+const EnvAllowInsecureSMTP = "KEYORIX_ALLOW_INSECURE_SMTP"
+
 // SMTPDelivery sends setup links via the operator's configured SMTP relay.
 type SMTPDelivery struct {
 	cfg SMTPSettings
@@ -52,7 +59,12 @@ func newSMTPDelivery(cfg SMTPSettings) (*SMTPDelivery, error) {
 		return nil, fmt.Errorf("delivery: smtp from address is required")
 	}
 	switch strings.ToLower(cfg.TLS) {
-	case "", smtpTLSStartTLS, smtpTLSImplicit, smtpTLSNone:
+	case "", smtpTLSStartTLS, smtpTLSImplicit:
+	case smtpTLSNone:
+		if !envFlagEnabled(EnvAllowInsecureSMTP) {
+			return nil, fmt.Errorf("delivery: smtp.tls=none sends mail (and any relay credentials) in cleartext; refusing unless the operator explicitly opts in by setting %s=true", EnvAllowInsecureSMTP)
+		}
+		log.Printf("delivery: WARNING smtp.tls=none is ACTIVE — setup-link email will be sent over CLEARTEXT SMTP; dev/test only, never use in production")
 	default:
 		return nil, fmt.Errorf("delivery: unknown smtp tls mode %q (want starttls|implicit|none)", cfg.TLS)
 	}

--- a/internal/delivery/smtp_test.go
+++ b/internal/delivery/smtp_test.go
@@ -23,10 +23,23 @@ func TestNewSMTPDelivery(t *testing.T) {
 	})
 
 	t.Run("accepts the documented tls modes", func(t *testing.T) {
+		t.Setenv(EnvAllowInsecureSMTP, "true")
 		for _, m := range []string{"", "starttls", "implicit", "none", "STARTTLS"} {
 			_, err := newSMTPDelivery(SMTPSettings{Host: "smtp.acme.io", From: "k@acme.io", TLS: m})
 			require.NoError(t, err, "tls=%q", m)
 		}
+	})
+
+	t.Run("tls=none refuses to activate without the explicit opt-in env var", func(t *testing.T) {
+		t.Setenv(EnvAllowInsecureSMTP, "")
+		_, err := newSMTPDelivery(SMTPSettings{Host: "smtp.acme.io", From: "k@acme.io", TLS: "none"})
+		require.Error(t, err, "cleartext SMTP must fail closed by default")
+	})
+
+	t.Run("tls=none succeeds once the operator opts in", func(t *testing.T) {
+		t.Setenv(EnvAllowInsecureSMTP, "true")
+		_, err := newSMTPDelivery(SMTPSettings{Host: "smtp.acme.io", From: "k@acme.io", TLS: "none"})
+		require.NoError(t, err)
 	})
 }
 
@@ -88,6 +101,7 @@ func TestSubjectFor(t *testing.T) {
 func TestSMTPDeliverDegradesOnSendFailure(t *testing.T) {
 	// Point at a closed port on localhost: the dial fails fast (connection refused),
 	// and delivery must degrade to manual relay rather than returning an error.
+	t.Setenv(EnvAllowInsecureSMTP, "true")
 	d, err := newSMTPDelivery(SMTPSettings{Host: "127.0.0.1", Port: 1, From: "k@acme.io", TLS: "none"})
 	require.NoError(t, err)
 

--- a/internal/notifychan/email.go
+++ b/internal/notifychan/email.go
@@ -7,6 +7,9 @@ package notifychan
 import (
 	"context"
 	"fmt"
+	"log"
+	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -19,6 +22,23 @@ const (
 	emailTimeout   = 10 * time.Second
 	emailQueueSize = 256
 )
+
+// envAllowInsecureSMTP gates tls=none for the notification-email channel, mirroring
+// the same opt-in required for credential-delivery SMTP (internal/delivery) and the
+// explicit-opt-in convention used for other insecure toggles in this codebase (e.g.
+// insecure_skip_verify): cleartext SMTP is never enabled by default.
+const envAllowInsecureSMTP = "KEYORIX_ALLOW_INSECURE_SMTP"
+
+// envFlagEnabled reports whether the named environment variable is set to a truthy
+// value. Unset or unparsable = false (fail closed).
+func envFlagEnabled(name string) bool {
+	v, ok := os.LookupEnv(name)
+	if !ok {
+		return false
+	}
+	b, err := strconv.ParseBool(v)
+	return err == nil && b
+}
 
 // EmailConfig configures the SMTP notification channel.
 type EmailConfig struct {
@@ -51,7 +71,12 @@ func newEmail(cfg EmailConfig, baseBackoff time.Duration) (*EmailSink, error) {
 		return nil, fmt.Errorf("notifychan: email smtp from address is required")
 	}
 	switch strings.ToLower(cfg.TLS) {
-	case "", "starttls", "implicit", "none":
+	case "", "starttls", "implicit":
+	case "none":
+		if !envFlagEnabled(envAllowInsecureSMTP) {
+			return nil, fmt.Errorf("notifychan: email smtp tls=none sends mail (and any relay credentials) in cleartext; refusing unless the operator explicitly opts in by setting %s=true", envAllowInsecureSMTP)
+		}
+		log.Printf("notifychan: WARNING email smtp tls=none is ACTIVE — notification email will be sent over CLEARTEXT SMTP; dev/test only, never use in production")
 	default:
 		return nil, fmt.Errorf("notifychan: unknown smtp tls mode %q (want starttls|implicit|none)", cfg.TLS)
 	}

--- a/internal/notifychan/email_test.go
+++ b/internal/notifychan/email_test.go
@@ -50,7 +50,19 @@ func TestNewEmail_Validation(t *testing.T) {
 	s.Close()
 }
 
+func TestNewEmail_TLSNoneRequiresExplicitOptIn(t *testing.T) {
+	t.Setenv(envAllowInsecureSMTP, "")
+	_, err := NewEmail(EmailConfig{Host: "smtp.x.io", From: "ops@x.io", TLS: "none"})
+	require.Error(t, err, "cleartext SMTP must fail closed by default")
+
+	t.Setenv(envAllowInsecureSMTP, "true")
+	s, err := NewEmail(EmailConfig{Host: "smtp.x.io", From: "ops@x.io", TLS: "none"})
+	require.NoError(t, err, "tls=none must succeed once the operator opts in")
+	s.Close()
+}
+
 func TestEmailSink_SkipsEventsWithoutRecipient(t *testing.T) {
+	t.Setenv(envAllowInsecureSMTP, "true")
 	before := emailOutcomeTotal(t)
 	sink, err := NewEmail(EmailConfig{Host: "smtp.invalid", From: "ops@x.io", TLS: "none"})
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

Fixes backlog findings **#103** (CLI hardening bundle) and **#142** (round-24 LOW
bundle) — both LOW severity, both scoped to `internal/cli/**` plus the two shared
insecure-toggle gaps the backlog flagged in `internal/delivery` / `internal/notifychan`.

### #103 — CLI hardening bundle
- `system init --admin-password` / `auth login --api-key`: warn on stderr when the
  flag is passed explicitly (argv is visible to other local users via `ps`/`/proc`, and
  lands in shell history). New shared `common.WarnInsecureFlag` helper.
- `keyorix run`: strip Keyorix's own credential env vars (`KEYORIX_TOKEN` and any other
  `KEYORIX_*_TOKEN`/`_PASSWORD`/`_SECRET`/`_API_KEY`/`_DSN`/`_KEK`) from the launched
  child's environment instead of forwarding the full parent environment verbatim.
  Everything else (`PATH`, `HOME`, `KEYORIX_PROJECT`, …) still passes through unchanged
  — that's the whole point of `run`.
- `SaveCLIConfig`: now writes through `securefiles.SecureWriteFile` (0600, `O_NOFOLLOW`)
  instead of a bare `os.WriteFile`, matching the pattern `internal/config.Save` already
  uses.
- `secret scan --commit`: rejects a leading `-` in the user-supplied revision before it
  reaches `git diff-tree` (arg injection). Note: a literal `--` separator does **not**
  work here — `git diff-tree` treats everything after `--` as a pathspec, not a
  revision, so that "fix" silently breaks every legitimate `--commit` value (verified
  empirically); rejecting a leading `-` is the correct minimal mitigation.

### #142 — round-24 LOW bundle
- `secret create/update/rotate --value`: warn via the same `WarnInsecureFlag` helper.
  `rotate --value` is no longer a required flag — omitting it now falls back to a
  masked interactive prompt (matching `create`/`update`'s existing `--interactive`
  pattern). `secret import` has no `--value` flag to begin with — it's already
  file/live-source based, so nothing to change there.
- `user delete` / `group delete`: now require a yes/no confirmation prompt before the
  irreversible delete, bypassable with `--force` (mirrors the `--force` convention
  already used by `secret delete`).
- `credential_delivery.mode=log` (writes a live, usable password-reset/setup link to
  the application log) and `smtp.tls=none` (cleartext SMTP — both `credential_delivery`
  and the separate `notifychan` notification-email channel) now refuse to activate
  unless the operator explicitly opts in via `KEYORIX_ALLOW_INSECURE_LOG_DELIVERY` /
  `KEYORIX_ALLOW_INSECURE_SMTP`, and log a loud warning when active — mirroring this
  codebase's `insecure_skip_verify` explicit-opt-in convention. Documented in
  `docs/CONFIGURATION.md` and `docs/adr-028-credential-delivery.md`.
- Email header-injection/host-poisoning/XSS: already confirmed CLOSED per the backlog;
  not re-touched here.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` (full suite)
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues
- [x] `golangci-lint run ./...` — 0 issues
- [x] `GOWORK=off go build -C operator ./...`
- [x] New focused tests per fix: `common.WarnInsecureFlag` (warn/silent), `run.filterSensitiveEnv`/`isSensitiveKeyorixEnv` (credential vars stripped, everything else kept), `secret scan --commit` (rejects leading `-`, still works for a real revision against a throwaway git repo), `SaveCLIConfig` (0600 perms + round-trip + refuses a dangling symlink), `secret create/update/rotate --value` (warns; rotate fails closed without a readable prompt), `user`/`group` `confirmYesNo` (fail-closed on blank/garbage input; `--force` flag present), `system init --admin-password` and `auth login --api-key` (warn only when explicitly set), `delivery`/`notifychan` SMTP `tls=none` and `credential_delivery.mode=log` (refuse without the env opt-in, succeed with it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)