### PR TITLE
fix(security): sanitize internal errors reflected to HTTP/gRPC clients (#116)

### DIFF
--- a/server/grpc/services/audit_service.go
+++ b/server/grpc/services/audit_service.go
@@ -2,6 +2,8 @@ package services
 
 import (
 	"context"
+	"log"
+	"strings"
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/core"
@@ -151,7 +153,14 @@ func (s *AuditGRPCService) WriteAuditCheckpoint(ctx context.Context, _ *emptypb.
 	if err != nil {
 		// The chain did not verify (broken, or a prior signed checkpoint proves a
 		// truncation) — refuse to notarise it. A precondition failure, not an error.
-		return nil, status.Error(codes.FailedPrecondition, err.Error())
+		// core.WriteAuditCheckpoint also propagates raw storage-layer errors on this
+		// path, which must not reach the client verbatim.
+		msg := err.Error()
+		if !strings.Contains(msg, "refusing to checkpoint") {
+			log.Printf("Error writing audit checkpoint: %v", err)
+			msg = clientSafe(err)
+		}
+		return nil, status.Error(codes.FailedPrecondition, msg)
 	}
 	if !written {
 		return nil, status.Error(codes.FailedPrecondition,

--- a/server/grpc/services/connect_service.go
+++ b/server/grpc/services/connect_service.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"log"
 
 	"github.com/keyorixhq/keyorix/internal/core"
 	pb "github.com/keyorixhq/keyorix/server/proto/pb"
@@ -49,7 +50,14 @@ func (s *ConnectGRPCService) ReadSecret(ctx context.Context, req *pb.ReadFederat
 	}
 	value, err := s.core.ReadFederatedSecret(ctx, actor.ActorKind(), actor.PrincipalID(), req.GetConnector(), req.GetRef())
 	if err != nil {
-		return nil, err
+		msg := err.Error()
+		code := codes.FailedPrecondition
+		if !isSafeConnectError(msg) {
+			log.Printf("Error reading federated secret via connector %q: %v", req.GetConnector(), err)
+			msg = clientSafe(err)
+			code = codes.Internal
+		}
+		return nil, status.Error(code, msg)
 	}
 	return &pb.FederatedSecretValue{
 		Connector: req.GetConnector(),
@@ -70,7 +78,8 @@ func (s *ConnectGRPCService) ListRefGrants(ctx context.Context, _ *emptypb.Empty
 	}
 	grants, err := s.core.ListConnectRefGrants(ctx)
 	if err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
+		log.Printf("Error listing connect ref-grants: %v", err)
+		return nil, status.Error(codes.Internal, clientSafe(err))
 	}
 	out := make([]*pb.ConnectRefGrant, 0, len(grants))
 	for _, g := range grants {
@@ -95,7 +104,14 @@ func (s *ConnectGRPCService) CreateRefGrant(ctx context.Context, req *pb.CreateC
 	}
 	g, err := s.core.CreateConnectRefGrant(ctx, actor.PrincipalID(), uint(req.GetRoleId()), req.GetConnector(), req.GetRefPrefix())
 	if err != nil {
-		return nil, status.Error(codes.InvalidArgument, err.Error())
+		msg := err.Error()
+		code := codes.InvalidArgument
+		if !isSafeConnectError(msg) {
+			log.Printf("Error creating connect ref-grant: %v", err)
+			msg = clientSafe(err)
+			code = codes.Internal
+		}
+		return nil, status.Error(code, msg)
 	}
 	return &pb.ConnectRefGrant{
 		Id:        intToU32(int(g.ID)),
@@ -115,7 +131,8 @@ func (s *ConnectGRPCService) DeleteRefGrant(ctx context.Context, req *pb.DeleteC
 		return nil, err
 	}
 	if err := s.core.DeleteConnectRefGrant(ctx, actor.PrincipalID(), uint(req.GetId())); err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
+		log.Printf("Error deleting connect ref-grant %d: %v", req.GetId(), err)
+		return nil, status.Error(codes.Internal, clientSafe(err))
 	}
 	return &emptypb.Empty{}, nil
 }

--- a/server/grpc/services/conversions.go
+++ b/server/grpc/services/conversions.go
@@ -8,6 +8,7 @@ package services
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/core"
@@ -19,6 +20,43 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
+
+// --- Error sanitization ---
+
+// clientSafe returns a generic, client-safe message in place of err's raw
+// Error() text. The other RPC error-mapping helpers in this package
+// (mapUserError, groupError, etc.) already do this by falling back to a
+// hardcoded message on their unclassified/codes.Internal branch; clientSafe
+// exists for the handful of call sites that don't go through one of those
+// switches and would otherwise reflect a raw error — e.g. a storage/ORM
+// failure or an upstream secret-store connector error (backlog #116) —
+// straight into the gRPC status. The caller MUST still log the original err
+// server-side before calling this.
+func clientSafe(err error) string {
+	if err == nil {
+		return ""
+	}
+	return "an internal error occurred; please try again or contact support if the problem persists"
+}
+
+// isSafeConnectError mirrors the HTTP handlers' connect.go allowlist: it
+// reports whether msg is one of the small set of deliberately-crafted, safe
+// messages core.ReadFederatedSecret / CreateConnectRefGrant /
+// DeleteConnectRefGrant themselves produce. Anything else may originate from
+// storage or an upstream connector (e.g. Vault) and must be sanitized.
+func isSafeConnectError(msg string) bool {
+	for _, marker := range []string{
+		"keyorix connect is not enabled",
+		"unknown connector",
+		"a role is required for a connect ref-grant",
+		"is not permitted for your roles on connector",
+	} {
+		if strings.Contains(msg, marker) {
+			return true
+		}
+	}
+	return false
+}
 
 // --- Identity & authorization ---
 

--- a/server/http/handlers/access_review_campaigns.go
+++ b/server/http/handlers/access_review_campaigns.go
@@ -5,6 +5,7 @@ package handlers
 
 import (
 	"encoding/json"
+	"log"
 	"net/http"
 	"strconv"
 	"strings"
@@ -28,6 +29,21 @@ func campaignStatusForError(msg string) int {
 	}
 }
 
+// sendCampaignError classifies err via campaignStatusForError and writes the
+// response. The message is only echoed back for the recognized, deliberately
+// user-facing outcomes above; the unclassified/500 fallback is assumed to be a
+// raw error from a lower layer (storage, etc.), so it is logged server-side
+// and replaced with a generic client-safe message (backlog #116).
+func sendCampaignError(w http.ResponseWriter, context string, err error) {
+	msg := err.Error()
+	status := campaignStatusForError(msg)
+	if status == http.StatusInternalServerError {
+		log.Printf("Error %s: %v", context, err)
+		msg = clientSafe(err)
+	}
+	sendError(w, "Error", msg, status, nil)
+}
+
 // OpenAccessReviewCampaign handles POST /api/v1/projects/{id}/access-review/campaigns.
 func (h *CatalogHandler) OpenAccessReviewCampaign(w http.ResponseWriter, r *http.Request) {
 	projectID, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
@@ -47,7 +63,7 @@ func (h *CatalogHandler) OpenAccessReviewCampaign(w http.ResponseWriter, r *http
 	_ = json.NewDecoder(r.Body).Decode(&body)
 	result, err := h.coreService.OpenAccessReviewCampaign(r.Context(), userCtx.UserID, uint(projectID), body.Name)
 	if err != nil {
-		sendError(w, "Error", err.Error(), campaignStatusForError(err.Error()), nil)
+		sendCampaignError(w, "opening access-review campaign", err)
 		return
 	}
 	w.WriteHeader(http.StatusCreated)
@@ -63,7 +79,8 @@ func (h *CatalogHandler) ListAccessReviewCampaigns(w http.ResponseWriter, r *htt
 	}
 	campaigns, err := h.coreService.ListAccessReviewCampaigns(r.Context(), uint(projectID))
 	if err != nil {
-		sendError(w, "Error", err.Error(), http.StatusInternalServerError, nil)
+		log.Printf("Error listing access-review campaigns for project %d: %v", projectID, err)
+		sendError(w, "Error", clientSafe(err), http.StatusInternalServerError, nil)
 		return
 	}
 	sendSuccess(w, map[string]interface{}{"campaigns": campaigns, "count": len(campaigns)}, "")
@@ -83,7 +100,7 @@ func (h *CatalogHandler) GetAccessReviewCampaign(w http.ResponseWriter, r *http.
 	}
 	detail, err := h.coreService.GetAccessReviewCampaign(r.Context(), uint(projectID), uint(campaignID))
 	if err != nil {
-		sendError(w, "Error", err.Error(), campaignStatusForError(err.Error()), nil)
+		sendCampaignError(w, "getting access-review campaign", err)
 		return
 	}
 	sendSuccess(w, map[string]interface{}{
@@ -127,7 +144,7 @@ func (h *CatalogHandler) DecideAccessReviewCampaignItem(w http.ResponseWriter, r
 		return
 	}
 	if err := h.coreService.DecideAccessReviewItem(r.Context(), userCtx.UserID, uint(projectID), uint(campaignID), uint(itemID), body.Action, body.Reason); err != nil {
-		sendError(w, "Error", err.Error(), campaignStatusForError(err.Error()), nil)
+		sendCampaignError(w, "deciding access-review campaign item", err)
 		return
 	}
 	sendSuccess(w, nil, "Decision recorded")
@@ -157,7 +174,7 @@ func (h *CatalogHandler) CloseAccessReviewCampaign(w http.ResponseWriter, r *htt
 	_ = json.NewDecoder(r.Body).Decode(&body)
 	result, err := h.coreService.CloseAccessReviewCampaign(r.Context(), userCtx.UserID, uint(projectID), uint(campaignID), body.Force)
 	if err != nil {
-		sendError(w, "Error", err.Error(), campaignStatusForError(err.Error()), nil)
+		sendCampaignError(w, "closing access-review campaign", err)
 		return
 	}
 	sendSuccess(w, map[string]interface{}{"campaign": result.Campaign, "progress": result.Progress}, "Campaign closed")

--- a/server/http/handlers/admin_jobs.go
+++ b/server/http/handlers/admin_jobs.go
@@ -6,6 +6,7 @@
 package handlers
 
 import (
+	"log"
 	"net/http"
 	"strconv"
 
@@ -32,7 +33,8 @@ func (h *AdminJobsHandler) RunAnomalyAlerts(w http.ResponseWriter, r *http.Reque
 	}
 	n, err := h.coreService.AlertNewAnomalies(r.Context())
 	if err != nil {
-		sendError(w, "Error", err.Error(), http.StatusInternalServerError, nil)
+		log.Printf("Error running anomaly alerts job: %v", err)
+		sendError(w, "Error", clientSafe(err), http.StatusInternalServerError, nil)
 		return
 	}
 	sendSuccess(w, map[string]interface{}{"alerted": n}, "")
@@ -47,7 +49,8 @@ func (h *AdminJobsHandler) RunRotationReminders(w http.ResponseWriter, r *http.R
 	}
 	n, err := h.coreService.SendRotationReminders(r.Context())
 	if err != nil {
-		sendError(w, "Error", err.Error(), http.StatusInternalServerError, nil)
+		log.Printf("Error running rotation reminders job: %v", err)
+		sendError(w, "Error", clientSafe(err), http.StatusInternalServerError, nil)
 		return
 	}
 	sendSuccess(w, map[string]interface{}{"sent": n}, "")
@@ -69,7 +72,8 @@ func (h *AdminJobsHandler) RunExpiryReminders(w http.ResponseWriter, r *http.Req
 	}
 	n, err := h.coreService.SendExpiryReminders(r.Context(), leadDays)
 	if err != nil {
-		sendError(w, "Error", err.Error(), http.StatusInternalServerError, nil)
+		log.Printf("Error running expiry reminders job: %v", err)
+		sendError(w, "Error", clientSafe(err), http.StatusInternalServerError, nil)
 		return
 	}
 	sendSuccess(w, map[string]interface{}{"sent": n}, "")
@@ -84,7 +88,8 @@ func (h *AdminJobsHandler) RunComplianceDigest(w http.ResponseWriter, r *http.Re
 	}
 	sent, err := h.coreService.SendComplianceDigest(r.Context())
 	if err != nil {
-		sendError(w, "Error", err.Error(), http.StatusInternalServerError, nil)
+		log.Printf("Error running compliance digest job: %v", err)
+		sendError(w, "Error", clientSafe(err), http.StatusInternalServerError, nil)
 		return
 	}
 	sendSuccess(w, map[string]interface{}{"sent": sent}, "")

--- a/server/http/handlers/audit.go
+++ b/server/http/handlers/audit.go
@@ -5,8 +5,10 @@ package handlers
 
 import (
 	"encoding/json"
+	"log"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/core"
@@ -402,7 +404,14 @@ func (h *AuditHandler) WriteAuditCheckpoint(w http.ResponseWriter, r *http.Reque
 		// The chain did not verify (broken, or a prior signed checkpoint proves a
 		// truncation) — the server refuses to notarise it. Surface the reason so the
 		// operator can investigate; it is a precondition failure, not a server error.
-		sendError(w, "Conflict", err.Error(), http.StatusConflict, nil)
+		// core.WriteAuditCheckpoint also propagates raw storage-layer errors on this
+		// path (e.g. a lookup failure), which must not reach the client verbatim.
+		msg := err.Error()
+		if !strings.Contains(msg, "refusing to checkpoint") {
+			log.Printf("Error writing audit checkpoint: %v", err)
+			msg = clientSafe(err)
+		}
+		sendError(w, "Conflict", msg, http.StatusConflict, nil)
 		return
 	}
 	if !written {

--- a/server/http/handlers/break_glass.go
+++ b/server/http/handlers/break_glass.go
@@ -6,6 +6,7 @@ package handlers
 
 import (
 	"encoding/json"
+	"log"
 	"net/http"
 	"strconv"
 	"strings"
@@ -49,6 +50,9 @@ func (h *CatalogHandler) ActivateBreakGlass(w http.ResponseWriter, r *http.Reque
 		case strings.Contains(msg, "required") || strings.Contains(msg, "ttl must") ||
 			strings.Contains(msg, "no emergency role") || strings.Contains(msg, "not found"):
 			status = http.StatusBadRequest
+		default:
+			log.Printf("Error activating break-glass for project %d: %v", id, err)
+			msg = clientSafe(err)
 		}
 		sendError(w, "Error", msg, status, nil)
 		return
@@ -66,7 +70,8 @@ func (h *CatalogHandler) ListBreakGlassActivations(w http.ResponseWriter, r *htt
 	}
 	activations, err := h.coreService.ListBreakGlassActivations(r.Context(), uint(id))
 	if err != nil {
-		sendError(w, "Error", err.Error(), http.StatusInternalServerError, nil)
+		log.Printf("Error listing break-glass activations for project %d: %v", id, err)
+		sendError(w, "Error", clientSafe(err), http.StatusInternalServerError, nil)
 		return
 	}
 	sendSuccess(w, map[string]interface{}{"activations": activations, "count": len(activations)}, "")
@@ -97,6 +102,9 @@ func (h *CatalogHandler) RevokeBreakGlass(w http.ResponseWriter, r *http.Request
 			status = http.StatusNotFound
 		case strings.Contains(msg, "not active") || strings.Contains(msg, "required"):
 			status = http.StatusBadRequest
+		default:
+			log.Printf("Error revoking break-glass activation %d for project %d: %v", activationID, id, err)
+			msg = clientSafe(err)
 		}
 		sendError(w, "Error", msg, status, nil)
 		return

--- a/server/http/handlers/catalog.go
+++ b/server/http/handlers/catalog.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"encoding/json"
+	"log"
 	"net/http"
 	"strconv"
 	"strings"
@@ -37,7 +38,8 @@ func (h *CatalogHandler) ListProjects(w http.ResponseWriter, r *http.Request) {
 	includeDeleted := r.URL.Query().Get("include_deleted") == "true"
 	projects, err := h.coreService.ListProjectsWithCounts(r.Context(), includeDeleted)
 	if err != nil {
-		sendError(w, "Failed to list projects", err.Error(), http.StatusInternalServerError, nil)
+		log.Printf("Error listing projects: %v", err)
+		sendError(w, "Failed to list projects", clientSafe(err), http.StatusInternalServerError, nil)
 		return
 	}
 	sendSuccess(w, map[string]interface{}{"projects": projects}, "")
@@ -53,10 +55,14 @@ func (h *CatalogHandler) RestoreProject(w http.ResponseWriter, r *http.Request) 
 	}
 	if err := h.coreService.RestoreProject(r.Context(), actorID(r), uint(id)); err != nil {
 		status := http.StatusInternalServerError
-		if strings.Contains(err.Error(), "not found") {
+		msg := err.Error()
+		if strings.Contains(msg, "not found") {
 			status = http.StatusNotFound
+		} else {
+			log.Printf("Error restoring project %d: %v", id, err)
+			msg = clientSafe(err)
 		}
-		sendError(w, "Error", err.Error(), status, nil)
+		sendError(w, "Error", msg, status, nil)
 		return
 	}
 	sendSuccess(w, nil, "Project restored")
@@ -72,7 +78,12 @@ func (h *CatalogHandler) GetProject(w http.ResponseWriter, r *http.Request) {
 	}
 	project, err := h.coreService.GetProject(r.Context(), uint(id))
 	if err != nil {
-		sendError(w, "NotFound", err.Error(), http.StatusNotFound, nil)
+		if strings.Contains(err.Error(), "not found") {
+			sendError(w, "NotFound", err.Error(), http.StatusNotFound, nil)
+			return
+		}
+		log.Printf("Error getting project %d: %v", id, err)
+		sendError(w, "Error", clientSafe(err), http.StatusInternalServerError, nil)
 		return
 	}
 	sendSuccess(w, project, "")
@@ -126,7 +137,8 @@ func (h *CatalogHandler) CreateProject(w http.ResponseWriter, r *http.Request) {
 		project, err = h.coreService.CreateProject(r.Context(), body.Name, body.Description)
 	}
 	if err != nil {
-		sendError(w, "Error", err.Error(), http.StatusInternalServerError, nil)
+		log.Printf("Error creating project: %v", err)
+		sendError(w, "Error", clientSafe(err), http.StatusInternalServerError, nil)
 		return
 	}
 	w.WriteHeader(http.StatusCreated)
@@ -137,7 +149,8 @@ func (h *CatalogHandler) CreateProject(w http.ResponseWriter, r *http.Request) {
 func (h *CatalogHandler) ListEnvironments(w http.ResponseWriter, r *http.Request) {
 	environments, err := h.coreService.ListEnvironments(r.Context())
 	if err != nil {
-		sendError(w, "Failed to list environments", err.Error(), http.StatusInternalServerError, nil)
+		log.Printf("Error listing environments: %v", err)
+		sendError(w, "Failed to list environments", clientSafe(err), http.StatusInternalServerError, nil)
 		return
 	}
 	sendSuccess(w, map[string]interface{}{"environments": environments}, "")
@@ -178,7 +191,16 @@ func (h *CatalogHandler) UpdateProject(w http.ResponseWriter, r *http.Request) {
 	}
 	project, err := h.coreService.UpdateProject(r.Context(), uint(id), body.Name, body.Description, body.RequireMFA)
 	if err != nil {
-		sendError(w, "Error", err.Error(), http.StatusInternalServerError, nil)
+		status := http.StatusInternalServerError
+		msg := err.Error()
+		switch {
+		case strings.Contains(msg, "name is required"), strings.Contains(msg, "exceeds"):
+			status = http.StatusBadRequest
+		default:
+			log.Printf("Error updating project %d: %v", id, err)
+			msg = clientSafe(err)
+		}
+		sendError(w, "Error", msg, status, nil)
 		return
 	}
 	sendSuccess(w, project, "Project updated")
@@ -196,10 +218,14 @@ func (h *CatalogHandler) DeleteProject(w http.ResponseWriter, r *http.Request) {
 	force := r.URL.Query().Get("force") == "true"
 	if err := h.coreService.DeleteProject(r.Context(), uint(id), force); err != nil {
 		status := http.StatusInternalServerError
-		if strings.Contains(err.Error(), "secret(s)") {
+		msg := err.Error()
+		if strings.Contains(msg, "secret(s)") {
 			status = http.StatusConflict
+		} else {
+			log.Printf("Error deleting project %d: %v", id, err)
+			msg = clientSafe(err)
 		}
-		sendError(w, "Error", err.Error(), status, nil)
+		sendError(w, "Error", msg, status, nil)
 		return
 	}
 	sendSuccess(w, nil, "Project deleted")
@@ -237,7 +263,8 @@ func (h *CatalogHandler) CreateProjectEnvironment(w http.ResponseWriter, r *http
 		Name:      body.Name,
 	})
 	if err != nil {
-		sendError(w, "Error", err.Error(), http.StatusInternalServerError, nil)
+		log.Printf("Error creating environment for project %d: %v", id, err)
+		sendError(w, "Error", clientSafe(err), http.StatusInternalServerError, nil)
 		return
 	}
 	w.WriteHeader(http.StatusCreated)
@@ -255,10 +282,14 @@ func (h *CatalogHandler) DeleteEnvironment(w http.ResponseWriter, r *http.Reques
 	if err := h.coreService.DeleteEnvironment(r.Context(), uint(id)); err != nil {
 		msg := err.Error()
 		status := http.StatusInternalServerError
-		if strings.Contains(msg, "active secret") {
+		switch {
+		case strings.Contains(msg, "active secret"):
 			status = http.StatusConflict
-		} else if strings.Contains(msg, "not found") {
+		case strings.Contains(msg, "not found"):
 			status = http.StatusNotFound
+		default:
+			log.Printf("Error deleting environment %d: %v", id, err)
+			msg = clientSafe(err)
 		}
 		sendError(w, "Error", msg, status, nil)
 		return
@@ -282,7 +313,8 @@ func (h *CatalogHandler) ListProjectEnvironments(w http.ResponseWriter, r *http.
 		environments, err = h.coreService.ListEnvironmentsByProject(r.Context(), uint(id))
 	}
 	if err != nil {
-		sendError(w, "Error", err.Error(), http.StatusInternalServerError, nil)
+		log.Printf("Error listing environments for project %d: %v", id, err)
+		sendError(w, "Error", clientSafe(err), http.StatusInternalServerError, nil)
 		return
 	}
 	sendSuccess(w, map[string]interface{}{"environments": environments}, "")
@@ -304,10 +336,14 @@ func (h *CatalogHandler) RestoreEnvironment(w http.ResponseWriter, r *http.Reque
 	}
 	if err := h.coreService.RestoreEnvironment(r.Context(), actorID(r), uint(projectID), uint(id)); err != nil {
 		status := http.StatusInternalServerError
-		if strings.Contains(err.Error(), "not found") {
+		msg := err.Error()
+		if strings.Contains(msg, "not found") {
 			status = http.StatusNotFound
+		} else {
+			log.Printf("Error restoring environment %d in project %d: %v", id, projectID, err)
+			msg = clientSafe(err)
 		}
-		sendError(w, "Error", err.Error(), status, nil)
+		sendError(w, "Error", msg, status, nil)
 		return
 	}
 	sendSuccess(w, nil, "Environment restored")

--- a/server/http/handlers/connect.go
+++ b/server/http/handlers/connect.go
@@ -6,13 +6,37 @@ package handlers
 
 import (
 	"encoding/json"
+	"log"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/keyorixhq/keyorix/server/middleware"
 )
+
+// isSafeConnectError reports whether msg is one of the small set of
+// deliberately-crafted, safe messages core.ReadFederatedSecret /
+// CreateConnectRefGrant / DeleteConnectRefGrant themselves produce (an
+// unknown/disabled connector, a missing role, or a per-reference policy
+// denial). Anything else is assumed to originate from a lower layer —
+// the storage layer or an upstream connector (e.g. Vault) — whose raw
+// error text can leak internal detail and must be sanitized before it
+// reaches the client (backlog #116).
+func isSafeConnectError(msg string) bool {
+	for _, marker := range []string{
+		"keyorix connect is not enabled",
+		"unknown connector",
+		"a role is required for a connect ref-grant",
+		"is not permitted for your roles on connector",
+	} {
+		if strings.Contains(msg, marker) {
+			return true
+		}
+	}
+	return false
+}
 
 // ConnectHandler serves the /connect federation endpoints.
 type ConnectHandler struct {
@@ -49,8 +73,17 @@ func (h *ConnectHandler) GetSecret(w http.ResponseWriter, r *http.Request) {
 	value, err := h.coreService.ReadFederatedSecret(r.Context(), userCtx.ActorKind(), userCtx.PrincipalID(), name, ref)
 	if err != nil {
 		// Unknown connector / disabled is a client error; backend failures surface as
-		// a bad gateway since the upstream store is external.
-		sendError(w, "ConnectError", err.Error(), http.StatusBadGateway, nil)
+		// a bad gateway since the upstream store is external. Either way, the raw error
+		// text may embed the upstream connector's hostname or connection detail (e.g. a
+		// Vault error) — log it server-side and return a generic message to the client
+		// unless it's one of the deliberately-crafted, safe messages core.ReadFederatedSecret
+		// itself produces (backlog #116).
+		msg := err.Error()
+		if !isSafeConnectError(msg) {
+			log.Printf("Error reading federated secret via connector %q: %v", name, err)
+			msg = clientSafe(err)
+		}
+		sendError(w, "ConnectError", msg, http.StatusBadGateway, nil)
 		return
 	}
 	sendSuccess(w, map[string]interface{}{
@@ -68,7 +101,8 @@ func (h *ConnectHandler) ListRefGrants(w http.ResponseWriter, r *http.Request) {
 	}
 	grants, err := h.coreService.ListConnectRefGrants(r.Context())
 	if err != nil {
-		sendError(w, "ConnectError", err.Error(), http.StatusInternalServerError, nil)
+		log.Printf("Error listing connect ref-grants: %v", err)
+		sendError(w, "ConnectError", clientSafe(err), http.StatusInternalServerError, nil)
 		return
 	}
 	out := make([]map[string]interface{}, 0, len(grants))
@@ -102,7 +136,14 @@ func (h *ConnectHandler) CreateRefGrant(w http.ResponseWriter, r *http.Request) 
 	}
 	g, err := h.coreService.CreateConnectRefGrant(r.Context(), userCtx.UserID, body.RoleID, body.Connector, body.RefPrefix)
 	if err != nil {
-		sendError(w, "ConnectError", err.Error(), http.StatusBadRequest, nil)
+		msg := err.Error()
+		status := http.StatusBadRequest
+		if !isSafeConnectError(msg) {
+			log.Printf("Error creating connect ref-grant: %v", err)
+			msg = clientSafe(err)
+			status = http.StatusInternalServerError
+		}
+		sendError(w, "ConnectError", msg, status, nil)
 		return
 	}
 	sendSuccess(w, map[string]interface{}{
@@ -126,7 +167,8 @@ func (h *ConnectHandler) DeleteRefGrant(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	if err := h.coreService.DeleteConnectRefGrant(r.Context(), userCtx.UserID, uint(id)); err != nil {
-		sendError(w, "ConnectError", err.Error(), http.StatusInternalServerError, nil)
+		log.Printf("Error deleting connect ref-grant %d: %v", id, err)
+		sendError(w, "ConnectError", clientSafe(err), http.StatusInternalServerError, nil)
 		return
 	}
 	sendSuccess(w, map[string]interface{}{"id": id}, "Connect ref-grant deleted")

--- a/server/http/handlers/dynamic_secrets.go
+++ b/server/http/handlers/dynamic_secrets.go
@@ -10,12 +10,38 @@ import (
 	"log"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/keyorixhq/keyorix/server/middleware"
 )
+
+// isSafeDynamicSecretError reports whether msg is one of the small set of
+// deliberately-crafted, safe messages core's dynamic-secret lease functions
+// (IssueLease/RevokeLease/RenewLease/RevokeLeasesForConfig) produce without
+// wrapping a lower-layer error. Everything else wraps (via %w) the actual
+// backend operation's error — issuing/revoking a credential against the
+// target database/cloud engine — which can carry connection detail (host,
+// driver wording) that must not reach the client verbatim (backlog #116).
+func isSafeDynamicSecretError(msg string) bool {
+	for _, safe := range []string{
+		"config not found",
+		"lease not found",
+		"lease is not active",
+		"lease has expired; issue a new lease instead",
+		"cannot issue from the",
+		"active-lease limit reached",
+		"mints self-expiring credentials that cannot be renewed",
+		"unsupported backend",
+	} {
+		if strings.Contains(msg, safe) {
+			return true
+		}
+	}
+	return false
+}
 
 // DynamicSecretHandler handles dynamic-secrets HTTP requests.
 type DynamicSecretHandler struct {
@@ -150,7 +176,12 @@ func (h *DynamicSecretHandler) IssueLease(w http.ResponseWriter, r *http.Request
 
 	lease, err := h.coreService.IssueLease(r.Context(), cfg.ID, body.TTLSeconds, userCtx.UserID)
 	if err != nil {
-		sendError(w, "Error", err.Error(), http.StatusBadGateway, nil)
+		msg := err.Error()
+		if !isSafeDynamicSecretError(msg) {
+			log.Printf("Error issuing dynamic-secret lease for config %d: %v", cfg.ID, err)
+			msg = clientSafe(err)
+		}
+		sendError(w, "Error", msg, http.StatusBadGateway, nil)
 		return
 	}
 	sendSuccess(w, lease, "Credential issued — it is shown once and will auto-revoke at expiry.")
@@ -193,7 +224,12 @@ func (h *DynamicSecretHandler) RevokeLease(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	if err := h.coreService.RevokeLease(r.Context(), leaseID, userCtx.UserID, "manual"); err != nil {
-		sendError(w, "Error", err.Error(), http.StatusBadGateway, nil)
+		msg := err.Error()
+		if !isSafeDynamicSecretError(msg) {
+			log.Printf("Error revoking dynamic-secret lease %q: %v", leaseID, err)
+			msg = clientSafe(err)
+		}
+		sendError(w, "Error", msg, http.StatusBadGateway, nil)
 		return
 	}
 	sendSuccess(w, map[string]interface{}{"lease_id": leaseID, "status": "revoked"}, "Lease revoked.")
@@ -222,7 +258,12 @@ func (h *DynamicSecretHandler) RenewLease(w http.ResponseWriter, r *http.Request
 	_ = json.NewDecoder(r.Body).Decode(&body) // body optional; default TTL on absence
 	newExpiry, err := h.coreService.RenewLease(r.Context(), leaseID, body.TTLSeconds, userCtx.UserID)
 	if err != nil {
-		sendError(w, "Error", err.Error(), http.StatusBadGateway, nil)
+		msg := err.Error()
+		if !isSafeDynamicSecretError(msg) {
+			log.Printf("Error renewing dynamic-secret lease %q: %v", leaseID, err)
+			msg = clientSafe(err)
+		}
+		sendError(w, "Error", msg, http.StatusBadGateway, nil)
 		return
 	}
 	sendSuccess(w, map[string]interface{}{"lease_id": leaseID, "expires_at": newExpiry}, "Lease renewed.")
@@ -238,7 +279,12 @@ func (h *DynamicSecretHandler) RevokeAllLeases(w http.ResponseWriter, r *http.Re
 	}
 	revoked, failed, err := h.coreService.RevokeLeasesForConfig(r.Context(), cfg.ID, userCtx.UserID, "bulk")
 	if err != nil {
-		sendError(w, "Error", err.Error(), http.StatusBadGateway, nil)
+		msg := err.Error()
+		if !isSafeDynamicSecretError(msg) {
+			log.Printf("Error revoking all dynamic-secret leases for config %d: %v", cfg.ID, err)
+			msg = clientSafe(err)
+		}
+		sendError(w, "Error", msg, http.StatusBadGateway, nil)
 		return
 	}
 	sendSuccess(w, map[string]interface{}{

--- a/server/http/handlers/error_sanitization_test.go
+++ b/server/http/handlers/error_sanitization_test.go
@@ -1,0 +1,102 @@
+// error_sanitization_test.go — proves the backlog #116 fix: a raw internal
+// (DB-layer) error is sanitized before it reaches the client but the ORIGINAL
+// error still reaches the server-side log for operators to debug.
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// TestClientSafe_NilAndError exercises the helper in isolation: a nil error
+// yields an empty string, and a non-nil error yields a fixed, generic message
+// that never echoes the error's own text.
+func TestClientSafe_NilAndError(t *testing.T) {
+	assert.Equal(t, "", clientSafe(nil))
+
+	raw := errorWithMessage("pq: duplicate key value violates unique constraint \"idx_users_email\"")
+	safe := clientSafe(raw)
+	assert.NotEmpty(t, safe)
+	assert.NotContains(t, safe, "idx_users_email")
+	assert.NotContains(t, safe, "duplicate key")
+	assert.NotEqual(t, raw.Error(), safe)
+}
+
+// errorWithMessage is a tiny error implementation so the test doesn't need to
+// depend on a real driver error type.
+type errorWithMessage string
+
+func (e errorWithMessage) Error() string { return string(e) }
+
+// TestGetProject_DBErrorSanitizedInResponseButLoggedForOperators is the
+// end-to-end property test: force a genuine database-layer failure (NOT a
+// "project not found", which is a deliberately safe message the handler
+// still passes through) and verify BOTH halves of the fix —
+//  1. the HTTP response never contains the raw DB error text, and
+//  2. the raw error still reaches the server-side log.
+func TestGetProject_DBErrorSanitizedInResponseButLoggedForOperators(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.Project{}))
+
+	coreService := core.NewKeyorixCore(store.NewLocalStorage(db))
+	h := NewCatalogHandler(coreService)
+
+	// Force a genuine DB-layer error (not "not found") by closing the
+	// underlying *sql.DB out from under the handler before it queries.
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	require.NoError(t, sqlDB.Close())
+
+	// Capture exactly what core.GetProject raises on a closed connection, so
+	// we can assert the log line carries this same text.
+	_, rawErr := coreService.GetProject(context.Background(), 1)
+	require.Error(t, rawErr)
+	require.NotContains(t, rawErr.Error(), "not found",
+		"test must exercise the sanitize branch, not the deliberate not-found branch")
+
+	var logBuf bytes.Buffer
+	origOutput := log.Writer()
+	origFlags := log.Flags()
+	log.SetOutput(&logBuf)
+	log.SetFlags(0)
+	t.Cleanup(func() {
+		log.SetOutput(origOutput)
+		log.SetFlags(origFlags)
+	})
+
+	req := withUserCtx(httptest.NewRequest(http.MethodGet, "/api/v1/projects/1", nil))
+	req = withChiParam(req, "id", "1")
+	w := httptest.NewRecorder()
+	h.GetProject(w, req)
+
+	// --- Client-facing half: the raw DB error must NOT reach the response. ---
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	msg, _ := resp["message"].(string)
+	assert.NotEmpty(t, msg)
+	assert.NotEqual(t, rawErr.Error(), msg)
+	assert.NotContains(t, w.Body.String(), "sql:")
+	assert.NotContains(t, w.Body.String(), "database is closed")
+	assert.Equal(t, clientSafe(rawErr), msg)
+
+	// --- Server-side half: the ORIGINAL error must still reach the operator log. ---
+	assert.Contains(t, logBuf.String(), rawErr.Error(),
+		"the raw error must still be logged server-side for operators to debug")
+}

--- a/server/http/handlers/helpers.go
+++ b/server/http/handlers/helpers.go
@@ -24,6 +24,23 @@ func sendSuccess(w http.ResponseWriter, data interface{}, message string) {
 	}
 }
 
+// clientSafe returns a generic, client-safe message in place of err's raw
+// Error() text. Use it at the fallback/default branch of an error path once
+// the caller has already carved out the small set of deliberately-crafted,
+// known-safe outcomes (validation messages, "not found", "already exists",
+// etc.) — everything left over is assumed to originate from a lower layer
+// (database/ORM/driver, an upstream secret-store connector, a parser) whose
+// raw text can leak schema, driver, or hostname details that help an
+// attacker fingerprint the backend (backlog #116). The caller MUST still log
+// the original err server-side (e.g. via log.Printf) before calling this —
+// clientSafe only sanitizes the copy that reaches the client.
+func clientSafe(err error) string {
+	if err == nil {
+		return ""
+	}
+	return "an internal error occurred; please try again or contact support if the problem persists"
+}
+
 // sendError sends an error JSON response
 func sendError(w http.ResponseWriter, errorType, message string, statusCode int, details interface{}) {
 	w.Header().Set("Content-Type", "application/json")

--- a/server/http/handlers/invitations.go
+++ b/server/http/handlers/invitations.go
@@ -8,6 +8,7 @@ package handlers
 
 import (
 	"encoding/json"
+	"log"
 	"net/http"
 	"strconv"
 	"strings"
@@ -29,7 +30,8 @@ func (h *CatalogHandler) ListInvitations(w http.ResponseWriter, r *http.Request)
 	}
 	invitations, err := h.coreService.ListProjectInvitations(r.Context(), uint(id))
 	if err != nil {
-		sendError(w, "Error", err.Error(), http.StatusInternalServerError, nil)
+		log.Printf("Error listing invitations for project %d: %v", id, err)
+		sendError(w, "Error", clientSafe(err), http.StatusInternalServerError, nil)
 		return
 	}
 	sendSuccess(w, map[string]interface{}{"invitations": invitations}, "")
@@ -66,10 +68,14 @@ func (h *CatalogHandler) CreateInvitation(w http.ResponseWriter, r *http.Request
 		// base_url unset) — surface that so the admin can fix config and resend.
 		if inv == nil {
 			status := http.StatusInternalServerError
-			if strings.Contains(err.Error(), "unknown role") || strings.Contains(err.Error(), "required") {
+			msg := err.Error()
+			if strings.Contains(msg, "unknown role") || strings.Contains(msg, "required") {
 				status = http.StatusBadRequest
+			} else {
+				log.Printf("Error inviting %q to project %d: %v", body.Email, id, err)
+				msg = clientSafe(err)
 			}
-			sendError(w, "Error", err.Error(), status, nil)
+			sendError(w, "Error", msg, status, nil)
 			return
 		}
 		w.WriteHeader(http.StatusCreated)
@@ -135,10 +141,14 @@ func (h *CatalogHandler) CreateGlobalInvitation(w http.ResponseWriter, r *http.R
 		// base_url unset) — surface that so the admin can fix config and resend.
 		if inv == nil {
 			status := http.StatusInternalServerError
-			if strings.Contains(err.Error(), "unknown") || strings.Contains(err.Error(), "required") || strings.Contains(err.Error(), "needs a") {
+			msg := err.Error()
+			if strings.Contains(msg, "unknown") || strings.Contains(msg, "required") || strings.Contains(msg, "needs a") {
 				status = http.StatusBadRequest
+			} else {
+				log.Printf("Error creating global invitation for %q: %v", body.Email, err)
+				msg = clientSafe(err)
 			}
-			sendError(w, "Error", err.Error(), status, nil)
+			sendError(w, "Error", msg, status, nil)
 			return
 		}
 		w.WriteHeader(http.StatusCreated)
@@ -181,6 +191,9 @@ func (h *CatalogHandler) ResendInvitation(w http.ResponseWriter, r *http.Request
 			status = http.StatusTooManyRequests
 		case strings.Contains(msg, "base_url"):
 			status = http.StatusBadRequest
+		default:
+			log.Printf("Error resending invitation %d for project %d: %v", invID, projectID, err)
+			msg = clientSafe(err)
 		}
 		sendError(w, "Error", msg, status, nil)
 		return
@@ -207,13 +220,17 @@ func (h *CatalogHandler) RevokeInvitation(w http.ResponseWriter, r *http.Request
 	}
 	if err := h.coreService.RevokeInvitation(r.Context(), uint(projectID), uint(invID), actor.UserID); err != nil {
 		status := http.StatusInternalServerError
+		msg := err.Error()
 		switch {
-		case strings.Contains(err.Error(), "not found"):
+		case strings.Contains(msg, "not found"):
 			status = http.StatusNotFound
-		case strings.Contains(err.Error(), "only a pending"):
+		case strings.Contains(msg, "only a pending"):
 			status = http.StatusConflict
+		default:
+			log.Printf("Error revoking invitation %d for project %d: %v", invID, projectID, err)
+			msg = clientSafe(err)
 		}
-		sendError(w, "Error", err.Error(), status, nil)
+		sendError(w, "Error", msg, status, nil)
 		return
 	}
 	sendSuccess(w, nil, "Invitation revoked")
@@ -230,7 +247,8 @@ func (h *CatalogHandler) ListAccessRequests(w http.ResponseWriter, r *http.Reque
 	}
 	requests, err := h.coreService.ListAccessRequests(r.Context(), uint(id))
 	if err != nil {
-		sendError(w, "Error", err.Error(), http.StatusInternalServerError, nil)
+		log.Printf("Error listing access requests for project %d: %v", id, err)
+		sendError(w, "Error", clientSafe(err), http.StatusInternalServerError, nil)
 		return
 	}
 	sendSuccess(w, map[string]interface{}{"access_requests": requests}, "")
@@ -259,10 +277,14 @@ func (h *CatalogHandler) CreateAccessRequest(w http.ResponseWriter, r *http.Requ
 	req, err := h.coreService.RequestProjectAccess(r.Context(), uint(id), actor.UserID, body.SuggestedRole, body.Reason)
 	if err != nil {
 		status := http.StatusInternalServerError
-		if strings.Contains(err.Error(), "unknown role") || strings.Contains(err.Error(), "required") {
+		msg := err.Error()
+		if strings.Contains(msg, "unknown role") || strings.Contains(msg, "required") {
 			status = http.StatusBadRequest
+		} else {
+			log.Printf("Error creating access request for project %d: %v", id, err)
+			msg = clientSafe(err)
 		}
-		sendError(w, "Error", err.Error(), status, nil)
+		sendError(w, "Error", msg, status, nil)
 		return
 	}
 	w.WriteHeader(http.StatusCreated)
@@ -319,13 +341,17 @@ func (h *CatalogHandler) ResolveAccessRequest(w http.ResponseWriter, r *http.Req
 	}
 	if resolveErr != nil {
 		status := http.StatusInternalServerError
+		msg := resolveErr.Error()
 		switch {
-		case strings.Contains(resolveErr.Error(), "not found"):
+		case strings.Contains(msg, "not found"):
 			status = http.StatusNotFound
-		case strings.Contains(resolveErr.Error(), "only a pending"), strings.Contains(resolveErr.Error(), "unknown role"), strings.Contains(resolveErr.Error(), "required"):
+		case strings.Contains(msg, "only a pending"), strings.Contains(msg, "unknown role"), strings.Contains(msg, "required"):
 			status = http.StatusConflict
+		default:
+			log.Printf("Error resolving access request %d for project %d: %v", reqID, projectID, resolveErr)
+			msg = clientSafe(resolveErr)
 		}
-		sendError(w, "Error", resolveErr.Error(), status, nil)
+		sendError(w, "Error", msg, status, nil)
 		return
 	}
 	sendSuccess(w, nil, "Access request "+body.Action+"d")
@@ -345,15 +371,19 @@ func (h *CatalogHandler) WithdrawAccessRequest(w http.ResponseWriter, r *http.Re
 	}
 	if err := h.coreService.WithdrawAccessRequest(r.Context(), uint(reqID), actor.UserID); err != nil {
 		status := http.StatusInternalServerError
+		msg := err.Error()
 		switch {
-		case strings.Contains(err.Error(), "not found"):
+		case strings.Contains(msg, "not found"):
 			status = http.StatusNotFound
-		case strings.Contains(err.Error(), "not your"):
+		case strings.Contains(msg, "not your"):
 			status = http.StatusForbidden
-		case strings.Contains(err.Error(), "only a pending"):
+		case strings.Contains(msg, "only a pending"):
 			status = http.StatusConflict
+		default:
+			log.Printf("Error withdrawing access request %d: %v", reqID, err)
+			msg = clientSafe(err)
 		}
-		sendError(w, "Error", err.Error(), status, nil)
+		sendError(w, "Error", msg, status, nil)
 		return
 	}
 	sendSuccess(w, nil, "Access request withdrawn")

--- a/server/http/handlers/legal_hold.go
+++ b/server/http/handlers/legal_hold.go
@@ -4,6 +4,7 @@ package handlers
 
 import (
 	"encoding/json"
+	"log"
 	"net/http"
 	"strings"
 
@@ -14,7 +15,8 @@ import (
 func (h *DashboardHandler) GetLegalHold(w http.ResponseWriter, r *http.Request) {
 	hold, err := h.coreService.GetActiveLegalHold(r.Context())
 	if err != nil {
-		sendError(w, "Error", err.Error(), http.StatusInternalServerError, nil)
+		log.Printf("Error getting active legal hold: %v", err)
+		sendError(w, "Error", clientSafe(err), http.StatusInternalServerError, nil)
 		return
 	}
 	if hold == nil {
@@ -41,10 +43,14 @@ func (h *DashboardHandler) PlaceLegalHold(w http.ResponseWriter, r *http.Request
 	hold, err := h.coreService.PlaceLegalHold(r.Context(), actor.UserID, body.Reason)
 	if err != nil {
 		status := http.StatusInternalServerError
-		if strings.Contains(err.Error(), "required") || strings.Contains(err.Error(), "already active") {
+		msg := err.Error()
+		if strings.Contains(msg, "required") || strings.Contains(msg, "already active") {
 			status = http.StatusBadRequest
+		} else {
+			log.Printf("Error placing legal hold: %v", err)
+			msg = clientSafe(err)
 		}
-		sendError(w, "Error", err.Error(), status, nil)
+		sendError(w, "Error", msg, status, nil)
 		return
 	}
 	w.WriteHeader(http.StatusCreated)
@@ -60,10 +66,14 @@ func (h *DashboardHandler) LiftLegalHold(w http.ResponseWriter, r *http.Request)
 	}
 	if err := h.coreService.LiftLegalHold(r.Context(), actor.UserID); err != nil {
 		status := http.StatusInternalServerError
-		if strings.Contains(err.Error(), "no legal hold") {
+		msg := err.Error()
+		if strings.Contains(msg, "no legal hold") {
 			status = http.StatusBadRequest
+		} else {
+			log.Printf("Error lifting legal hold: %v", err)
+			msg = clientSafe(err)
 		}
-		sendError(w, "Error", err.Error(), status, nil)
+		sendError(w, "Error", msg, status, nil)
 		return
 	}
 	sendSuccess(w, nil, "Legal hold lifted")

--- a/server/http/handlers/machine_identities.go
+++ b/server/http/handlers/machine_identities.go
@@ -6,6 +6,7 @@ package handlers
 
 import (
 	"encoding/json"
+	"log"
 	"net/http"
 	"strconv"
 	"strings"
@@ -25,7 +26,8 @@ func (h *CatalogHandler) ListMachineIdentities(w http.ResponseWriter, r *http.Re
 	}
 	identities, err := h.coreService.ListMachineIdentities(r.Context(), uint(id))
 	if err != nil {
-		sendError(w, "Error", err.Error(), http.StatusInternalServerError, nil)
+		log.Printf("Error listing machine identities for project %d: %v", id, err)
+		sendError(w, "Error", clientSafe(err), http.StatusInternalServerError, nil)
 		return
 	}
 	sendSuccess(w, map[string]interface{}{"machine_identities": identities}, "")
@@ -50,7 +52,8 @@ func (h *CatalogHandler) ListStaleMachineIdentities(w http.ResponseWriter, r *ht
 	}
 	identities, err := h.coreService.ListStaleMachineIdentities(r.Context(), uint(id), time.Duration(days)*24*time.Hour)
 	if err != nil {
-		sendError(w, "Error", err.Error(), http.StatusInternalServerError, nil)
+		log.Printf("Error listing stale machine identities for project %d: %v", id, err)
+		sendError(w, "Error", clientSafe(err), http.StatusInternalServerError, nil)
 		return
 	}
 	sendSuccess(w, map[string]interface{}{"machine_identities": identities, "total": len(identities)}, "")
@@ -85,10 +88,14 @@ func (h *CatalogHandler) CreateMachineIdentity(w http.ResponseWriter, r *http.Re
 	m, err := h.coreService.CreateMachineIdentity(r.Context(), uint(id), body.Name, body.IdentityType, body.Description, body.Classification, actor.UserID)
 	if err != nil {
 		status := http.StatusInternalServerError
-		if strings.Contains(err.Error(), "invalid identity_type") || strings.Contains(err.Error(), "required") {
+		msg := err.Error()
+		if strings.Contains(msg, "invalid identity_type") || strings.Contains(msg, "required") {
 			status = http.StatusBadRequest
+		} else {
+			log.Printf("Error creating machine identity for project %d: %v", id, err)
+			msg = clientSafe(err)
 		}
-		sendError(w, "Error", err.Error(), status, nil)
+		sendError(w, "Error", msg, status, nil)
 		return
 	}
 	w.WriteHeader(http.StatusCreated)
@@ -130,12 +137,17 @@ func (h *CatalogHandler) MigrateUserToMachine(w http.ResponseWriter, r *http.Req
 	m, err := h.coreService.MigrateUserToMachine(r.Context(), body.Username, uint(id), body.IdentityType, body.Name, actor.UserID, !body.KeepUser)
 	if err != nil {
 		status := http.StatusInternalServerError
-		if strings.Contains(err.Error(), "not found") {
+		msg := err.Error()
+		switch {
+		case strings.Contains(msg, "not found"):
 			status = http.StatusNotFound
-		} else if strings.Contains(err.Error(), "required") || strings.Contains(err.Error(), "invalid identity_type") {
+		case strings.Contains(msg, "required") || strings.Contains(msg, "invalid identity_type"):
 			status = http.StatusBadRequest
+		default:
+			log.Printf("Error migrating user %q to machine identity in project %d: %v", body.Username, id, err)
+			msg = clientSafe(err)
 		}
-		sendError(w, "Error", err.Error(), status, nil)
+		sendError(w, "Error", msg, status, nil)
 		return
 	}
 	w.WriteHeader(http.StatusCreated)
@@ -175,13 +187,17 @@ func (h *CatalogHandler) TransitionMachineIdentity(w http.ResponseWriter, r *htt
 	m, err := h.coreService.TransitionMachineIdentity(r.Context(), uint(projectID), uint(machineID), to, actor.UserID)
 	if err != nil {
 		status := http.StatusInternalServerError
+		msg := err.Error()
 		switch {
-		case strings.Contains(err.Error(), "not found"):
+		case strings.Contains(msg, "not found"):
 			status = http.StatusNotFound
-		case strings.Contains(err.Error(), "cannot transition"):
+		case strings.Contains(msg, "cannot transition"):
 			status = http.StatusConflict
+		default:
+			log.Printf("Error transitioning machine identity %d in project %d: %v", machineID, projectID, err)
+			msg = clientSafe(err)
 		}
-		sendError(w, "Error", err.Error(), status, nil)
+		sendError(w, "Error", msg, status, nil)
 		return
 	}
 	// Suspending or revoking the identity must reject its tokens immediately, not after
@@ -231,13 +247,17 @@ func (h *CatalogHandler) IssueMachineToken(w http.ResponseWriter, r *http.Reques
 	result, err := h.coreService.IssueMachineToken(r.Context(), uint(projectID), uint(machineID), body.Name, expiresAt, body.Classification, actor.UserID)
 	if err != nil {
 		status := http.StatusInternalServerError
+		msg := err.Error()
 		switch {
-		case strings.Contains(err.Error(), "not found"):
+		case strings.Contains(msg, "not found"):
 			status = http.StatusNotFound
-		case strings.Contains(err.Error(), "must be active"):
+		case strings.Contains(msg, "must be active"):
 			status = http.StatusConflict
+		default:
+			log.Printf("Error issuing machine token for machine %d in project %d: %v", machineID, projectID, err)
+			msg = clientSafe(err)
 		}
-		sendError(w, "Error", err.Error(), status, nil)
+		sendError(w, "Error", msg, status, nil)
 		return
 	}
 	w.WriteHeader(http.StatusCreated)
@@ -265,7 +285,8 @@ func (h *CatalogHandler) ListMachineTokens(w http.ResponseWriter, r *http.Reques
 	}
 	creds, err := h.coreService.ListMachineTokens(r.Context(), uint(projectID), uint(machineID))
 	if err != nil {
-		sendError(w, "Error", err.Error(), http.StatusInternalServerError, nil)
+		log.Printf("Error listing machine tokens for machine %d in project %d: %v", machineID, projectID, err)
+		sendError(w, "Error", clientSafe(err), http.StatusInternalServerError, nil)
 		return
 	}
 	out := make([]map[string]interface{}, 0, len(creds))
@@ -309,10 +330,14 @@ func (h *CatalogHandler) RevokeMachineToken(w http.ResponseWriter, r *http.Reque
 	tokenHash, err := h.coreService.RevokeMachineToken(r.Context(), uint(projectID), uint(machineID), uint(tokenID), actor.UserID)
 	if err != nil {
 		status := http.StatusInternalServerError
-		if strings.Contains(err.Error(), "not found") {
+		msg := err.Error()
+		if strings.Contains(msg, "not found") {
 			status = http.StatusNotFound
+		} else {
+			log.Printf("Error revoking machine token %d for machine %d in project %d: %v", tokenID, machineID, projectID, err)
+			msg = clientSafe(err)
 		}
-		sendError(w, "Error", err.Error(), status, nil)
+		sendError(w, "Error", msg, status, nil)
 		return
 	}
 	// Evict the auth cache so the revoked token stops authenticating immediately.
@@ -337,10 +362,18 @@ func (h *CatalogHandler) ClassifyMachineIdentity(w http.ResponseWriter, r *http.
 	m, err := h.coreService.ClassifyMachineIdentity(r.Context(), projectID, machineID, body.Classification, actor.UserID)
 	if err != nil {
 		status := http.StatusBadRequest
-		if strings.Contains(err.Error(), "not found") {
+		msg := err.Error()
+		switch {
+		case strings.Contains(msg, "not found"):
 			status = http.StatusNotFound
+		case strings.Contains(msg, "classification must be"):
+			// keep 400, msg is the deliberate validation message
+		default:
+			status = http.StatusInternalServerError
+			log.Printf("Error classifying machine identity %d in project %d: %v", machineID, projectID, err)
+			msg = clientSafe(err)
 		}
-		sendError(w, "Error", err.Error(), status, nil)
+		sendError(w, "Error", msg, status, nil)
 		return
 	}
 	sendSuccess(w, map[string]interface{}{"machine_identity": m}, "Classification updated")
@@ -368,10 +401,18 @@ func (h *CatalogHandler) ClassifyMachineToken(w http.ResponseWriter, r *http.Req
 	cred, err := h.coreService.ClassifyMachineToken(r.Context(), projectID, machineID, uint(tokenID), body.Classification, actor.UserID)
 	if err != nil {
 		status := http.StatusBadRequest
-		if strings.Contains(err.Error(), "not found") {
+		msg := err.Error()
+		switch {
+		case strings.Contains(msg, "not found"):
 			status = http.StatusNotFound
+		case strings.Contains(msg, "classification must be"):
+			// keep 400, msg is the deliberate validation message
+		default:
+			status = http.StatusInternalServerError
+			log.Printf("Error classifying machine token %d for machine %d in project %d: %v", tokenID, machineID, projectID, err)
+			msg = clientSafe(err)
 		}
-		sendError(w, "Error", err.Error(), status, nil)
+		sendError(w, "Error", msg, status, nil)
 		return
 	}
 	sendSuccess(w, map[string]interface{}{
@@ -434,13 +475,17 @@ func (h *CatalogHandler) changeMachineRole(w http.ResponseWriter, r *http.Reques
 	}
 	if err != nil {
 		status := http.StatusInternalServerError
+		msg := err.Error()
 		switch {
-		case strings.Contains(err.Error(), "not found"):
+		case strings.Contains(msg, "not found"):
 			status = http.StatusNotFound
-		case strings.Contains(err.Error(), "already") || strings.Contains(err.Error(), "not assigned"):
+		case strings.Contains(msg, "already") || strings.Contains(msg, "not assigned"):
 			status = http.StatusConflict
+		default:
+			log.Printf("Error changing machine role for machine %d in project %d: %v", machineID, projectID, err)
+			msg = clientSafe(err)
 		}
-		sendError(w, "Error", err.Error(), status, nil)
+		sendError(w, "Error", msg, status, nil)
 		return
 	}
 	verb := "granted"
@@ -468,15 +513,19 @@ func (h *CatalogHandler) CreateOIDCBinding(w http.ResponseWriter, r *http.Reques
 	b, err := h.coreService.CreateOIDCBinding(r.Context(), projectID, machineID, body.Issuer, body.Subject, actor.UserID)
 	if err != nil {
 		status := http.StatusInternalServerError
+		msg := err.Error()
 		switch {
-		case strings.Contains(err.Error(), "not found"):
+		case strings.Contains(msg, "not found"):
 			status = http.StatusNotFound
-		case strings.Contains(err.Error(), "required"):
+		case strings.Contains(msg, "required"):
 			status = http.StatusBadRequest
-		case strings.Contains(err.Error(), "already bound"):
+		case strings.Contains(msg, "already bound"):
 			status = http.StatusConflict
+		default:
+			log.Printf("Error creating OIDC binding for machine %d in project %d: %v", machineID, projectID, err)
+			msg = clientSafe(err)
 		}
-		sendError(w, "Error", err.Error(), status, nil)
+		sendError(w, "Error", msg, status, nil)
 		return
 	}
 	w.WriteHeader(http.StatusCreated)
@@ -492,10 +541,14 @@ func (h *CatalogHandler) ListOIDCBindings(w http.ResponseWriter, r *http.Request
 	bindings, err := h.coreService.ListOIDCBindings(r.Context(), projectID, machineID)
 	if err != nil {
 		status := http.StatusInternalServerError
-		if strings.Contains(err.Error(), "not found") {
+		msg := err.Error()
+		if strings.Contains(msg, "not found") {
 			status = http.StatusNotFound
+		} else {
+			log.Printf("Error listing OIDC bindings for machine %d in project %d: %v", machineID, projectID, err)
+			msg = clientSafe(err)
 		}
-		sendError(w, "Error", err.Error(), status, nil)
+		sendError(w, "Error", msg, status, nil)
 		return
 	}
 	out := make([]map[string]interface{}, 0, len(bindings))
@@ -518,10 +571,14 @@ func (h *CatalogHandler) DeleteOIDCBinding(w http.ResponseWriter, r *http.Reques
 	}
 	if err := h.coreService.DeleteOIDCBinding(r.Context(), projectID, machineID, uint(bindingID), actor.UserID); err != nil {
 		status := http.StatusInternalServerError
-		if strings.Contains(err.Error(), "not found") {
+		msg := err.Error()
+		if strings.Contains(msg, "not found") {
 			status = http.StatusNotFound
+		} else {
+			log.Printf("Error deleting OIDC binding %d for machine %d in project %d: %v", bindingID, machineID, projectID, err)
+			msg = clientSafe(err)
 		}
-		sendError(w, "Error", err.Error(), status, nil)
+		sendError(w, "Error", msg, status, nil)
 		return
 	}
 	sendSuccess(w, nil, "OIDC binding removed")

--- a/server/http/handlers/project_members.go
+++ b/server/http/handlers/project_members.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"encoding/json"
+	"log"
 	"net/http"
 	"strconv"
 	"strings"
@@ -21,7 +22,8 @@ func (h *CatalogHandler) ListProjectMembers(w http.ResponseWriter, r *http.Reque
 	}
 	members, err := h.coreService.ListProjectMembers(r.Context(), uint(id))
 	if err != nil {
-		sendError(w, "Error", err.Error(), http.StatusInternalServerError, nil)
+		log.Printf("Error listing project %d members: %v", id, err)
+		sendError(w, "Error", clientSafe(err), http.StatusInternalServerError, nil)
 		return
 	}
 	sendSuccess(w, map[string]interface{}{"members": members}, "")
@@ -38,7 +40,8 @@ func (h *CatalogHandler) GetProjectAccessReview(w http.ResponseWriter, r *http.R
 	}
 	entries, err := h.coreService.GenerateProjectAccessReview(r.Context(), uint(id))
 	if err != nil {
-		sendError(w, "Error", err.Error(), http.StatusInternalServerError, nil)
+		log.Printf("Error generating access review for project %d: %v", id, err)
+		sendError(w, "Error", clientSafe(err), http.StatusInternalServerError, nil)
 		return
 	}
 	sendSuccess(w, map[string]interface{}{"entries": entries, "count": len(entries)}, "")
@@ -105,6 +108,9 @@ func (h *CatalogHandler) RevokeProjectAccessReview(w http.ResponseWriter, r *htt
 			status = http.StatusBadRequest
 		case strings.Contains(msg, "no matching share") || strings.Contains(msg, "not found"):
 			status = http.StatusNotFound
+		default:
+			log.Printf("Error revoking access-review grant for project %d: %v", projectID, err)
+			msg = clientSafe(err)
 		}
 		sendError(w, "Error", msg, status, nil)
 		return
@@ -148,12 +154,17 @@ func (h *CatalogHandler) AddProjectMember(w http.ResponseWriter, r *http.Request
 	}
 	if err := h.coreService.AddProjectMember(r.Context(), uint(id), body.UserID, body.Role); err != nil {
 		status := http.StatusInternalServerError
-		if strings.Contains(err.Error(), "already") {
+		msg := err.Error()
+		switch {
+		case strings.Contains(msg, "already"):
 			status = http.StatusConflict
-		} else if strings.Contains(err.Error(), "unknown role") {
+		case strings.Contains(msg, "unknown role"):
 			status = http.StatusBadRequest
+		default:
+			log.Printf("Error adding member to project %d: %v", id, err)
+			msg = clientSafe(err)
 		}
-		sendError(w, "Error", err.Error(), status, nil)
+		sendError(w, "Error", msg, status, nil)
 		return
 	}
 	w.WriteHeader(http.StatusCreated)
@@ -185,10 +196,14 @@ func (h *CatalogHandler) UpdateProjectMember(w http.ResponseWriter, r *http.Requ
 	}
 	if err := h.coreService.SetProjectMemberRole(r.Context(), uint(id), uint(userID), body.Role); err != nil {
 		status := http.StatusInternalServerError
-		if strings.Contains(err.Error(), "unknown role") {
+		msg := err.Error()
+		if strings.Contains(msg, "unknown role") {
 			status = http.StatusBadRequest
+		} else {
+			log.Printf("Error updating role for member %d on project %d: %v", userID, id, err)
+			msg = clientSafe(err)
 		}
-		sendError(w, "Error", err.Error(), status, nil)
+		sendError(w, "Error", msg, status, nil)
 		return
 	}
 	sendSuccess(w, nil, "Member role updated")
@@ -208,10 +223,14 @@ func (h *CatalogHandler) RemoveProjectMember(w http.ResponseWriter, r *http.Requ
 	}
 	if err := h.coreService.RemoveProjectMember(r.Context(), uint(id), uint(userID)); err != nil {
 		status := http.StatusInternalServerError
-		if strings.Contains(err.Error(), "not a member") {
+		msg := err.Error()
+		if strings.Contains(msg, "not a member") {
 			status = http.StatusNotFound
+		} else {
+			log.Printf("Error removing member %d from project %d: %v", userID, id, err)
+			msg = clientSafe(err)
 		}
-		sendError(w, "Error", err.Error(), status, nil)
+		sendError(w, "Error", msg, status, nil)
 		return
 	}
 	sendSuccess(w, nil, "Member removed")

--- a/server/http/handlers/project_memberships.go
+++ b/server/http/handlers/project_memberships.go
@@ -8,6 +8,7 @@ package handlers
 
 import (
 	"encoding/json"
+	"log"
 	"net/http"
 	"strconv"
 	"strings"
@@ -32,7 +33,8 @@ func (h *CatalogHandler) ListProjectMemberships(w http.ResponseWriter, r *http.R
 	if r.URL.Query().Get("stale") == "true" {
 		all, err := h.coreService.StaleInvites(r.Context(), staleInviteThreshold)
 		if err != nil {
-			sendError(w, "Error", err.Error(), http.StatusInternalServerError, nil)
+			log.Printf("Error listing stale invites: %v", err)
+			sendError(w, "Error", clientSafe(err), http.StatusInternalServerError, nil)
 			return
 		}
 		// StaleInvites is install-wide; narrow to this project for the endpoint.
@@ -47,7 +49,8 @@ func (h *CatalogHandler) ListProjectMemberships(w http.ResponseWriter, r *http.R
 	}
 	memberships, err := h.coreService.ListProjectMemberships(r.Context(), uint(id))
 	if err != nil {
-		sendError(w, "Error", err.Error(), http.StatusInternalServerError, nil)
+		log.Printf("Error listing memberships for project %d: %v", id, err)
+		sendError(w, "Error", clientSafe(err), http.StatusInternalServerError, nil)
 		return
 	}
 	sendSuccess(w, map[string]interface{}{"memberships": memberships}, "")
@@ -81,13 +84,17 @@ func (h *CatalogHandler) InviteMember(w http.ResponseWriter, r *http.Request) {
 	m, err := h.coreService.InviteMember(r.Context(), uint(id), body.UserID, body.Role, actor.UserID, body.IDPResolved)
 	if err != nil {
 		status := http.StatusInternalServerError
+		msg := err.Error()
 		switch {
-		case strings.Contains(err.Error(), "already has"):
+		case strings.Contains(msg, "already has"):
 			status = http.StatusConflict
-		case strings.Contains(err.Error(), "unknown role"), strings.Contains(err.Error(), "required"):
+		case strings.Contains(msg, "unknown role"), strings.Contains(msg, "required"):
 			status = http.StatusBadRequest
+		default:
+			log.Printf("Error inviting member to project %d: %v", id, err)
+			msg = clientSafe(err)
 		}
-		sendError(w, "Error", err.Error(), status, nil)
+		sendError(w, "Error", msg, status, nil)
 		return
 	}
 	w.WriteHeader(http.StatusCreated)
@@ -127,13 +134,17 @@ func (h *CatalogHandler) TransitionMembership(w http.ResponseWriter, r *http.Req
 	m, err := h.coreService.TransitionMembership(r.Context(), uint(projectID), uint(membershipID), to, actor.UserID)
 	if err != nil {
 		status := http.StatusInternalServerError
+		msg := err.Error()
 		switch {
-		case strings.Contains(err.Error(), "not found"):
+		case strings.Contains(msg, "not found"):
 			status = http.StatusNotFound
-		case strings.Contains(err.Error(), "cannot transition"):
+		case strings.Contains(msg, "cannot transition"):
 			status = http.StatusConflict
+		default:
+			log.Printf("Error transitioning membership %d for project %d: %v", membershipID, projectID, err)
+			msg = clientSafe(err)
 		}
-		sendError(w, "Error", err.Error(), status, nil)
+		sendError(w, "Error", msg, status, nil)
 		return
 	}
 	sendSuccess(w, map[string]interface{}{"membership": m}, "Membership updated")

--- a/server/http/handlers/risk_exceptions.go
+++ b/server/http/handlers/risk_exceptions.go
@@ -5,6 +5,7 @@ package handlers
 
 import (
 	"encoding/json"
+	"log"
 	"net/http"
 	"strconv"
 	"strings"
@@ -21,7 +22,8 @@ func (h *DashboardHandler) ListRiskExceptions(w http.ResponseWriter, r *http.Req
 	activeOnly := r.URL.Query().Get("all") != "true"
 	exceptions, err := h.coreService.ListRiskExceptions(r.Context(), activeOnly)
 	if err != nil {
-		sendError(w, "Error", err.Error(), http.StatusInternalServerError, nil)
+		log.Printf("Error listing risk exceptions: %v", err)
+		sendError(w, "Error", clientSafe(err), http.StatusInternalServerError, nil)
 		return
 	}
 	sendSuccess(w, map[string]interface{}{"exceptions": exceptions}, "")
@@ -54,10 +56,15 @@ func (h *DashboardHandler) CreateRiskException(w http.ResponseWriter, r *http.Re
 	exc, err := h.coreService.CreateRiskException(r.Context(), actor.UserID, body.Title, body.Category, body.Reference, body.Justification, expiresAt)
 	if err != nil {
 		status := http.StatusInternalServerError
-		if strings.Contains(err.Error(), "required") || strings.Contains(err.Error(), "must be") {
+		msg := err.Error()
+		switch {
+		case strings.Contains(msg, "required") || strings.Contains(msg, "must be"):
 			status = http.StatusBadRequest
+		default:
+			log.Printf("Error creating risk exception: %v", err)
+			msg = clientSafe(err)
 		}
-		sendError(w, "Error", err.Error(), status, nil)
+		sendError(w, "Error", msg, status, nil)
 		return
 	}
 	w.WriteHeader(http.StatusCreated)
@@ -84,6 +91,9 @@ func (h *DashboardHandler) RevokeRiskException(w http.ResponseWriter, r *http.Re
 			status = http.StatusBadRequest
 		case strings.Contains(msg, "not found"):
 			status = http.StatusNotFound
+		default:
+			log.Printf("Error revoking risk exception %d: %v", id, err)
+			msg = clientSafe(err)
 		}
 		sendError(w, "Error", msg, status, nil)
 		return

--- a/server/http/handlers/saml.go
+++ b/server/http/handlers/saml.go
@@ -6,6 +6,7 @@
 package handlers
 
 import (
+	"log"
 	"net/http"
 	"net/url"
 	"time"
@@ -16,9 +17,15 @@ import (
 // SAMLMetadata handles GET /auth/saml/{provider}/metadata — the SP metadata XML the IdP
 // administrator imports to register Keyorix.
 func (h *AuthHandler) SAMLMetadata(w http.ResponseWriter, r *http.Request) {
-	md, err := h.coreService.SAMLMetadata(chi.URLParam(r, "provider"))
+	provider := chi.URLParam(r, "provider")
+	md, err := h.coreService.SAMLMetadata(provider)
 	if err != nil {
-		sendError(w, "SSOError", err.Error(), http.StatusNotFound, nil)
+		msg := err.Error()
+		if !isSafeSSOError(msg) {
+			log.Printf("Error generating SAML metadata for provider %q: %v", provider, err)
+			msg = clientSafe(err)
+		}
+		sendError(w, "SSOError", msg, http.StatusNotFound, nil)
 		return
 	}
 	w.Header().Set("Content-Type", "application/samlmetadata+xml")
@@ -33,7 +40,12 @@ func (h *AuthHandler) BeginSAML(w http.ResponseWriter, r *http.Request) {
 	provider := chi.URLParam(r, "provider")
 	redirectURL, err := h.coreService.BeginSAML(r.Context(), provider, r.URL.Query().Get("return_to"))
 	if err != nil {
-		sendError(w, "SSOError", err.Error(), http.StatusBadRequest, nil)
+		msg := err.Error()
+		if !isSafeSSOError(msg) {
+			log.Printf("Error beginning SAML login via provider %q: %v", provider, err)
+			msg = clientSafe(err)
+		}
+		sendError(w, "SSOError", msg, http.StatusBadRequest, nil)
 		return
 	}
 	// redirectURL is built by core from the provider's operator-configured IdP SSO
@@ -60,7 +72,12 @@ func (h *AuthHandler) CompleteSAML(w http.ResponseWriter, r *http.Request) {
 	session, _, returnTo, err := h.coreService.CompleteSAML(
 		r.Context(), provider, r, relayState, r.Header.Get("User-Agent"), r.RemoteAddr)
 	if err != nil {
-		h.redirectFragment(w, r, completeURL, url.Values{"error": {err.Error()}})
+		msg := err.Error()
+		if !isSafeSSOError(msg) {
+			log.Printf("Error completing SAML login via provider %q: %v", provider, err)
+			msg = clientSafe(err)
+		}
+		h.redirectFragment(w, r, completeURL, url.Values{"error": {msg}})
 		return
 	}
 

--- a/server/http/handlers/scim.go
+++ b/server/http/handlers/scim.go
@@ -8,6 +8,7 @@ package handlers
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
 	"regexp"
 	"strconv"
@@ -141,7 +142,8 @@ func (h *SCIMHandler) ListUsers(w http.ResponseWriter, r *http.Request) {
 		}
 		user, err := h.coreService.FindSCIMUser(r.Context(), "", m[1])
 		if err != nil {
-			scimError(w, http.StatusInternalServerError, err.Error())
+			log.Printf("Error finding SCIM user by filter: %v", err)
+			scimError(w, http.StatusInternalServerError, clientSafe(err))
 			return
 		}
 		resources := []map[string]interface{}{}
@@ -154,7 +156,8 @@ func (h *SCIMHandler) ListUsers(w http.ResponseWriter, r *http.Request) {
 	startIndex, count := scimPaging(r)
 	users, total, err := h.coreService.ListSCIMUsersPage(r.Context(), startIndex, count)
 	if err != nil {
-		scimError(w, http.StatusInternalServerError, err.Error())
+		log.Printf("Error listing SCIM users: %v", err)
+		scimError(w, http.StatusInternalServerError, clientSafe(err))
 		return
 	}
 	resources := make([]map[string]interface{}, 0, len(users))

--- a/server/http/handlers/scim_groups.go
+++ b/server/http/handlers/scim_groups.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
 	"regexp"
 	"strconv"
@@ -76,7 +77,8 @@ var scimGroupNameFilter = regexp.MustCompile(`(?i)displayName\s+eq\s+"([^"]+)"`)
 func (h *SCIMHandler) ListGroups(w http.ResponseWriter, r *http.Request) {
 	groups, err := h.coreService.ListGroups(r.Context())
 	if err != nil {
-		scimError(w, http.StatusInternalServerError, err.Error())
+		log.Printf("Error listing SCIM groups: %v", err)
+		scimError(w, http.StatusInternalServerError, clientSafe(err))
 		return
 	}
 	var wantName string

--- a/server/http/handlers/sod.go
+++ b/server/http/handlers/sod.go
@@ -5,6 +5,7 @@ package handlers
 
 import (
 	"encoding/json"
+	"log"
 	"net/http"
 	"strconv"
 	"strings"
@@ -18,7 +19,8 @@ import (
 func (h *CatalogHandler) ListSoDPolicies(w http.ResponseWriter, r *http.Request) {
 	policies, err := h.coreService.ListSoDPolicies(r.Context())
 	if err != nil {
-		sendError(w, "Error", err.Error(), http.StatusInternalServerError, nil)
+		log.Printf("Error listing SoD policies: %v", err)
+		sendError(w, "Error", clientSafe(err), http.StatusInternalServerError, nil)
 		return
 	}
 	sendSuccess(w, map[string]interface{}{"policies": policies, "count": len(policies)}, "")
@@ -44,10 +46,14 @@ func (h *CatalogHandler) CreateSoDPolicy(w http.ResponseWriter, r *http.Request)
 	policy, err := h.coreService.CreateSoDPolicy(r.Context(), actor.UserID, body.Name, body.Description, body.PermissionA, body.PermissionB)
 	if err != nil {
 		status := http.StatusInternalServerError
-		if strings.Contains(err.Error(), "required") || strings.Contains(err.Error(), "must be different") {
+		msg := err.Error()
+		if strings.Contains(msg, "required") || strings.Contains(msg, "must be different") {
 			status = http.StatusBadRequest
+		} else {
+			log.Printf("Error creating SoD policy: %v", err)
+			msg = clientSafe(err)
 		}
-		sendError(w, "Error", err.Error(), status, nil)
+		sendError(w, "Error", msg, status, nil)
 		return
 	}
 	w.WriteHeader(http.StatusCreated)
@@ -68,10 +74,14 @@ func (h *CatalogHandler) DeleteSoDPolicy(w http.ResponseWriter, r *http.Request)
 	}
 	if err := h.coreService.DeleteSoDPolicy(r.Context(), actor.UserID, uint(id)); err != nil {
 		status := http.StatusInternalServerError
-		if strings.Contains(err.Error(), "not found") {
+		msg := err.Error()
+		if strings.Contains(msg, "not found") {
 			status = http.StatusNotFound
+		} else {
+			log.Printf("Error deleting SoD policy %d: %v", id, err)
+			msg = clientSafe(err)
 		}
-		sendError(w, "Error", err.Error(), status, nil)
+		sendError(w, "Error", msg, status, nil)
 		return
 	}
 	sendSuccess(w, nil, "Policy deleted")
@@ -81,7 +91,8 @@ func (h *CatalogHandler) DeleteSoDPolicy(w http.ResponseWriter, r *http.Request)
 func (h *CatalogHandler) ListSoDViolations(w http.ResponseWriter, r *http.Request) {
 	violations, err := h.coreService.DetectSoDViolations(r.Context())
 	if err != nil {
-		sendError(w, "Error", err.Error(), http.StatusInternalServerError, nil)
+		log.Printf("Error detecting SoD violations: %v", err)
+		sendError(w, "Error", clientSafe(err), http.StatusInternalServerError, nil)
 		return
 	}
 	sendSuccess(w, map[string]interface{}{"violations": violations, "count": len(violations)}, "")

--- a/server/http/handlers/sso.go
+++ b/server/http/handlers/sso.go
@@ -6,12 +6,42 @@
 package handlers
 
 import (
+	"log"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5"
 )
+
+// isSafeSSOError reports whether msg is one of the small set of deliberately-
+// crafted, safe messages core.CompleteSSO itself produces without wrapping a
+// lower-layer error. Everything else — an authorization-code exchange failure,
+// an id_token verification failure, or a storage-layer lookup error — wraps a
+// raw error via %w and can carry internal detail (a library's wording, an
+// upstream IdP response fragment, DB/ORM text). Reflecting that verbatim into
+// the redirect fragment the browser receives would leak it to the client
+// (backlog #116), so anything not on this allowlist is sanitized.
+func isSafeSSOError(msg string) bool {
+	for _, safe := range []string{
+		"unknown SSO provider",
+		"unknown SAML provider",
+		"invalid or expired login state",
+		"login state does not match the callback provider",
+		"login state expired",
+		"the token response carried no id_token",
+		"the assertion carried no subject or email",
+		"no Keyorix account matches this SSO identity",
+		"account suspended",
+		"the IdP returned no email; cannot auto-provision an account",
+	} {
+		if strings.Contains(msg, safe) {
+			return true
+		}
+	}
+	return false
+}
 
 // ListSSOProviders handles GET /auth/sso/providers — the enabled provider names, so
 // the login page can render the right "Sign in with …" buttons.
@@ -25,7 +55,12 @@ func (h *AuthHandler) BeginSSO(w http.ResponseWriter, r *http.Request) {
 	provider := chi.URLParam(r, "provider")
 	authURL, err := h.coreService.BeginSSO(r.Context(), provider, r.URL.Query().Get("return_to"))
 	if err != nil {
-		sendError(w, "SSOError", err.Error(), http.StatusBadRequest, nil)
+		msg := err.Error()
+		if !strings.Contains(msg, "unknown SSO provider") {
+			log.Printf("Error beginning SSO login via provider %q: %v", provider, err)
+			msg = clientSafe(err)
+		}
+		sendError(w, "SSOError", msg, http.StatusBadRequest, nil)
 		return
 	}
 	// authURL is built by core from the provider's operator-configured, discovery-
@@ -57,7 +92,12 @@ func (h *AuthHandler) CompleteSSO(w http.ResponseWriter, r *http.Request) {
 
 	session, _, returnTo, err := h.coreService.CompleteSSO(r.Context(), provider, code, state, r.Header.Get("User-Agent"), r.RemoteAddr)
 	if err != nil {
-		h.redirectFragment(w, r, completeURL, url.Values{"error": {err.Error()}})
+		msg := err.Error()
+		if !isSafeSSOError(msg) {
+			log.Printf("Error completing SSO login via provider %q: %v", provider, err)
+			msg = clientSafe(err)
+		}
+		h.redirectFragment(w, r, completeURL, url.Values{"error": {msg}})
 		return
 	}
 


### PR DESCRIPTION
## Summary

Backlog finding **#116** (LOW, info disclosure): a number of HTTP handlers and gRPC services called `err.Error()` directly when building the client-facing error response. For errors that actually originate from a lower layer (DB/ORM, an upstream secret-store connector, the SSO/SAML libraries) this reflects internal detail — schema/table names, driver wording, upstream hostnames, library internals — straight back to the client, which helps an attacker fingerprint the backend.

Adds a small `clientSafe(err) string` helper (one copy in `server/http/handlers`, one in `server/grpc/services`, since they're separate packages) that returns a fixed, generic message for a client response while the caller logs the original `err` server-side via `log.Printf` — so operators keep full detail, clients get nothing internal. No such helper existed before this change (checked via `grep -rn "clientSafe\|sanitizeError\|safeError"`).

Where a handler already classifies an error into a small, deliberately-crafted set of safe outcomes (validation message, "not found", "already exists", a documented precondition), that classification and message are preserved — `clientSafe` is only applied to the unclassified/fallback branch, which is where a raw internal error was actually able to leak through.

### Named instances (from the finding)
- **Generic/default 500 pattern** — swept `server/http/handlers/` for the `sendError(w, ..., err.Error(), http.StatusInternalServerError, nil)` shape with no classification/logging: `catalog.go`, `risk_exceptions.go`, `project_members.go`, `project_memberships.go`, `break_glass.go`, `access_review_campaigns.go`, `machine_identities.go`, `legal_hold.go`, `admin_jobs.go`, `invitations.go`, `sod.go`.
- **`internal/connect`** — `server/http/handlers/connect.go` (`GetSecret`'s Bad Gateway proxy error, plus `ListRefGrants`/`CreateRefGrant`/`DeleteRefGrant`) and the gRPC mirror `server/grpc/services/connect_service.go` (`ReadSecret`, `ListRefGrants`, `CreateRefGrant`, `DeleteRefGrant`). A per-file `isSafeConnectError` allowlist preserves the deliberate "unknown connector" / "not enabled" / ref-grant-denied messages.
- **SSO callback** — `server/http/handlers/sso.go` (`CompleteSSO`'s redirect-fragment error, plus `BeginSSO`) and the SAML ACS counterpart `server/http/handlers/saml.go` (`CompleteSAML`, `BeginSAML`, `SAMLMetadata`). An `isSafeSSOError` allowlist preserves the handful of deliberate messages core.CompleteSSO/CompleteSAML produce (expired/invalid login state, no matching account, account suspended, etc.); anything else (an OAuth2 exchange failure, an id_token/SAML-assertion verification failure, a storage lookup failure) is sanitized — these all wrap a lower-layer error via `%w` and were the actual leak vector.

### Additional analogous instances found via the same grep sweep
- `server/grpc/services/audit_service.go` `WriteAuditCheckpoint` and its HTTP counterpart `server/http/handlers/audit.go` — both reflected a raw storage-layer error at a "refusing to checkpoint" precondition-failure status; now only the literal "refusing to checkpoint…" message passes through.
- `server/http/handlers/dynamic_secrets.go` (`IssueLease`, `RevokeLease`, `RenewLease`, `RevokeAllLeases`) — these proxy to a real target DB/cloud credential engine using an admin DSN; a raw backend error at Bad Gateway could leak connection detail. An `isSafeDynamicSecretError` allowlist preserves the deliberate lease/config-state messages.
- `server/http/handlers/scim.go` (`ListUsers` filter lookup, paged list) and `server/http/handlers/scim_groups.go` (`ListGroups`) — unconditional 500s reflecting raw storage errors.

### What I deliberately did NOT touch (and why)
- `invitations.go`'s `delivery_error` field (`CreateInvitation`/`CreateGlobalInvitation`) — this is an intentional secondary-error UX feature: the invite itself succeeded, but the setup-link delivery (e.g. mailer/base_url config) failed, and the admin needs the exact reason to fix delivery and resend. Not a DB/ORM leak path.
- `scim.go`'s `CreateUser` (400 default) and `ReplaceUser`/`scim_groups.go` not-found paths — `ProvisionSCIMUser`/`UpdateSCIMUser` can, on a genuine storage failure, surface a wrapped raw error at a 400/404 status that was never explicitly classified (a preexisting status-code smell, not just an info leak). This mirrors the `catalog.go GetProject` bug I did fix as a demonstration of the pattern, but going further down this path across every SCIM/user mutation felt like scope creep for a LOW-severity, cross-cutting finding — flagging as a good candidate for a follow-up pass.
- The remaining `err.Error()` call sites in `server/grpc/services/*.go` (`group_service.go`, `role_service.go`, `user_service.go`, `share_service.go`, `machine_identity_service.go`, `secret_service.go`, `project_service.go`, `dynamic_secret_service.go`, `break_glass_service.go`) — these already route through a `mapXError`-style switch whose `codes.Internal` default returns a **hardcoded** safe string, never `err.Error()`. Already correct; nothing to change.
- The panic-recovery middleware (`server/middleware/recovery.go`, `server/grpc/interceptors/recovery.go`) — already returns a generic message and logs the panic + stack separately; not part of this finding.
- The bulk of ordinary `err.Error()` usage elsewhere in the codebase that reflects a deliberately-crafted, already-safe validation/not-found/conflict message (the majority of call sites) — intentionally left alone per the finding's own scope guidance.

## Test plan
- [x] New test `server/http/handlers/error_sanitization_test.go`:
  - `TestClientSafe_NilAndError` — unit-tests the helper directly (nil → `""`; a raw driver-style error → a generic message that never contains the original text).
  - `TestGetProject_DBErrorSanitizedInResponseButLoggedForOperators` — end-to-end: forces a genuine DB-layer failure (closes the underlying `*sql.DB`, distinct from the deliberate "not found" branch), then asserts **both halves** of the fix: the HTTP response body never contains the raw DB error text, AND the raw error still reaches the server-side log (captured via `log.SetOutput`).
- [x] `go build ./...` — clean.
- [x] `go test ./...` — full suite green.
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues.
- [x] `golangci-lint run ./...` — 0 issues.
- [x] `GOWORK=off go build -C operator ./...` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)