### PR TITLE
harden(operator): close residual #184 confused-deputy gap; pin #185 with regression tests

### DIFF
--- a/deploy/helm/keyorix-operator/crds/secrets.keyorix.io_keyorixsecrets.yaml
+++ b/deploy/helm/keyorix-operator/crds/secrets.keyorix.io_keyorixsecrets.yaml
@@ -80,8 +80,11 @@ spec:
                   Defaults to 5m.
                 type: string
               server:
-                description: Server is the Keyorix base URL, e.g. https://keyorix.internal.
-                pattern: ^https?://
+                description: |-
+                  Server is the Keyorix base URL, e.g. https://keyorix.internal. Must be https (the
+                  machine-identity token is sent as a bearer header) AND must match the operator's
+                  --allowed-servers list — the operator rejects any other destination.
+                pattern: ^https://
                 type: string
               target:
                 description: Target is the Kubernetes Secret to create/maintain.
@@ -99,7 +102,12 @@ spec:
                 description: |-
                   TokenSecretRef sources the Keyorix machine-identity token (a least-privilege
                   identity with secrets.read on the referenced secrets). The token is never
-                  inlined in the spec.
+                  inlined in the spec. The referenced Secret MUST carry the label
+                  secrets.keyorix.io/token-secret=true, set by whoever creates it (a principal
+                  with real Secret-write RBAC) — the operator refuses to resolve an unlabeled
+                  Secret, so a namespace-scoped KeyorixSecret author with no core-Secret RBAC of
+                  their own cannot point this at an arbitrary pre-existing Secret and have the
+                  operator ship its bytes to the Keyorix server as a bearer token.
                 properties:
                   key:
                     default: token

--- a/deploy/helm/keyorix-operator/examples/keyorixsecret.yaml
+++ b/deploy/helm/keyorix-operator/examples/keyorixsecret.yaml
@@ -2,8 +2,12 @@
 # db-creds, refreshing every 5m. The Secret is owned by this resource, so deleting the
 # KeyorixSecret removes the Secret too.
 #
-# The machine-identity token is read from an existing Secret (create it out-of-band):
+# The machine-identity token is read from an existing Secret (create it out-of-band).
+# It MUST carry the secrets.keyorix.io/token-secret=true label (only a principal with
+# real Secret-write RBAC can set it) — the operator refuses to resolve an unlabeled
+# Secret as a token source:
 #   kubectl -n app create secret generic keyorix-token --from-literal=token="$TOKEN"
+#   kubectl -n app label secret keyorix-token secrets.keyorix.io/token-secret=true
 apiVersion: secrets.keyorix.io/v1alpha1
 kind: KeyorixSecret
 metadata:

--- a/deploy/helm/keyorix-operator/templates/NOTES.txt
+++ b/deploy/helm/keyorix-operator/templates/NOTES.txt
@@ -3,12 +3,18 @@ keyorix-operator is installed.
 The operator watches KeyorixSecret resources cluster-wide and materialises the
 referenced Keyorix secrets into native Kubernetes Secrets.
 
-1. Create a machine-identity token Secret in your app namespace:
+1. Create a machine-identity token Secret in your app namespace, and label it as a
+   Keyorix token source (required — the operator refuses to resolve an unlabeled
+   Secret as a tokenSecretRef, so a KeyorixSecret author can't point at an arbitrary
+   pre-existing Secret they don't otherwise have RBAC to read):
 
    kubectl -n <ns> create secret generic keyorix-token \
      --from-literal=token="$KEYORIX_MACHINE_TOKEN"
+   kubectl -n <ns> label secret keyorix-token secrets.keyorix.io/token-secret=true
 
-2. Create a KeyorixSecret (see deploy/helm/keyorix-operator/examples/keyorixsecret.yaml):
+2. Create a KeyorixSecret (see deploy/helm/keyorix-operator/examples/keyorixsecret.yaml).
+   spec.server must be https and match the operator's --allowed-servers /
+   KEYORIX_ALLOWED_SERVERS configuration — the operator rejects every CR until that's set:
 
    apiVersion: secrets.keyorix.io/v1alpha1
    kind: KeyorixSecret

--- a/operator/api/v1alpha1/keyorixsecret_types.go
+++ b/operator/api/v1alpha1/keyorixsecret_types.go
@@ -43,7 +43,12 @@ type KeyorixSecretSpec struct {
 	Server string `json:"server"`
 	// TokenSecretRef sources the Keyorix machine-identity token (a least-privilege
 	// identity with secrets.read on the referenced secrets). The token is never
-	// inlined in the spec.
+	// inlined in the spec. The referenced Secret MUST carry the label
+	// secrets.keyorix.io/token-secret=true, set by whoever creates it (a principal
+	// with real Secret-write RBAC) — the operator refuses to resolve an unlabeled
+	// Secret, so a namespace-scoped KeyorixSecret author with no core-Secret RBAC of
+	// their own cannot point this at an arbitrary pre-existing Secret and have the
+	// operator ship its bytes to the Keyorix server as a bearer token.
 	TokenSecretRef SecretKeySelector `json:"tokenSecretRef"`
 	// RefreshInterval is how often to re-read values from Keyorix. Defaults to 5m.
 	// +optional

--- a/operator/config/crd/bases/secrets.keyorix.io_keyorixsecrets.yaml
+++ b/operator/config/crd/bases/secrets.keyorix.io_keyorixsecrets.yaml
@@ -102,7 +102,12 @@ spec:
                 description: |-
                   TokenSecretRef sources the Keyorix machine-identity token (a least-privilege
                   identity with secrets.read on the referenced secrets). The token is never
-                  inlined in the spec.
+                  inlined in the spec. The referenced Secret MUST carry the label
+                  secrets.keyorix.io/token-secret=true, set by whoever creates it (a principal
+                  with real Secret-write RBAC) — the operator refuses to resolve an unlabeled
+                  Secret, so a namespace-scoped KeyorixSecret author with no core-Secret RBAC of
+                  their own cannot point this at an arbitrary pre-existing Secret and have the
+                  operator ship its bytes to the Keyorix server as a bearer token.
                 properties:
                   key:
                     default: token

--- a/operator/internal/controller/keyorixsecret_controller.go
+++ b/operator/internal/controller/keyorixsecret_controller.go
@@ -137,6 +137,22 @@ func (r *KeyorixSecretReconciler) buildDesired(ctx context.Context, ks *secretsv
 	if err := r.Get(ctx, ref, &tokenSecret); err != nil {
 		return nil, fmt.Errorf("read token secret %s: %w", ref, err)
 	}
+	// A CRD-write-only principal (the CRD's own documented least-privilege deployment
+	// model has no direct core-Secret read/write RBAC) can name ANY pre-existing Secret
+	// in the namespace here — the operator resolves it with its own cluster-wide `get
+	// secrets` RBAC, not the requester's. validateServer above already stops the token
+	// from being shipped to an attacker-controlled destination, but without this gate
+	// the operator would still read an arbitrary Secret's bytes and send them as a
+	// bearer token to the (now-trusted) Keyorix server — a residual probe/abuse
+	// primitive, and exactly the "point at a Secret you don't have RBAC to read" attack
+	// the CRD's threat model is meant to exclude. Require the Secret to already carry a
+	// label only a principal with real Secret-write RBAC could have set (a CRD-write-only
+	// attacker cannot), so an unlabeled pre-existing Secret can never be used as a token
+	// source, however it got created.
+	if tokenSecret.Labels[tokenSecretLabel] != tokenSecretValue {
+		return nil, fmt.Errorf("token secret %s is missing the required label %s=%s (only a Secret explicitly marked as a Keyorix token source may be used as tokenSecretRef)",
+			ref, tokenSecretLabel, tokenSecretValue)
+	}
 	token := string(tokenSecret.Data[tokenKey])
 	if token == "" {
 		return nil, fmt.Errorf("token secret %s has no key %q", ref, tokenKey)
@@ -198,6 +214,15 @@ func (r *KeyorixSecretReconciler) applySecret(ctx context.Context, ks *secretsv1
 const (
 	managedByLabel = "app.kubernetes.io/managed-by"
 	managedByValue = "keyorix-operator"
+)
+
+// tokenSecretLabel/tokenSecretValue gate which Secrets buildDesired will resolve as a
+// TokenSecretRef. Must be set out-of-band (by whoever creates the token Secret — the
+// operator never sets it itself, unlike managedByLabel above) before the controller will
+// read that Secret's data and use it as a bearer token.
+const (
+	tokenSecretLabel = "secrets.keyorix.io/token-secret"
+	tokenSecretValue = "true"
 )
 
 // fail records a SyncError on the Ready condition and requeues with backoff.

--- a/operator/internal/controller/keyorixsecret_controller_test.go
+++ b/operator/internal/controller/keyorixsecret_controller_test.go
@@ -15,6 +15,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	secretsv1alpha1 "github.com/keyorixhq/keyorix/operator/api/v1alpha1"
 )
@@ -79,8 +80,12 @@ func ksFixture() *secretsv1alpha1.KeyorixSecret {
 
 func tokenSecret() *corev1.Secret {
 	return &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{Name: "kx-token", Namespace: "app"},
-		Data:       map[string][]byte{"token": []byte("machine-tok")},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kx-token",
+			Namespace: "app",
+			Labels:    map[string]string{tokenSecretLabel: tokenSecretValue},
+		},
+		Data: map[string][]byte{"token": []byte("machine-tok")},
 	}
 }
 
@@ -272,4 +277,79 @@ func TestReconcile_RejectsUntrustedServer(t *testing.T) {
 	var got corev1.Secret
 	err = c.Get(context.Background(), types.NamespacedName{Name: "db-creds", Namespace: "app"}, &got)
 	require.Error(t, err, "no Secret is created for a rejected server")
+}
+
+// #184 (confused deputy, second half): even with validateServer pinning the
+// destination, a CRD-write-only principal (no core-Secret RBAC of their own) must not
+// be able to point tokenSecretRef at an arbitrary pre-existing Secret and have the
+// operator's cluster-wide Secret-read RBAC ship its bytes to the (trusted) Keyorix
+// server. Only a Secret explicitly labeled as a token source may be resolved.
+func TestReconcile_RejectsUnlabeledTokenSecret(t *testing.T) {
+	unlabeled := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "kx-token", Namespace: "app"}, // no label
+		Data:       map[string][]byte{"token": []byte("some-secret-value")},
+	}
+	r, c := newReconciler(t, &fakeFetcher{}, ksFixture(), unlabeled)
+
+	_, err := reconcile(t, r)
+	require.Error(t, err, "an unlabeled Secret must not be usable as tokenSecretRef")
+	assert.Contains(t, err.Error(), tokenSecretLabel)
+
+	var got corev1.Secret
+	err = c.Get(context.Background(), types.NamespacedName{Name: "db-creds", Namespace: "app"}, &got)
+	require.Error(t, err, "no Secret is created when the token source is unlabeled")
+}
+
+// A Secret carrying an unrelated/incorrect label value (not exactly the required
+// marker) is treated the same as unlabeled — no partial-match bypass.
+func TestReconcile_RejectsTokenSecretWithWrongLabelValue(t *testing.T) {
+	wrongLabel := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kx-token",
+			Namespace: "app",
+			Labels:    map[string]string{tokenSecretLabel: "false"},
+		},
+		Data: map[string][]byte{"token": []byte("some-secret-value")},
+	}
+	r, _ := newReconciler(t, &fakeFetcher{}, ksFixture(), wrongLabel)
+	_, err := reconcile(t, r)
+	require.Error(t, err)
+}
+
+// #185: a same-named Secret already owned (controller ref) by a DIFFERENT KeyorixSecret
+// CR must never be silently re-adopted by this CR, even though it already carries the
+// operator's managed-by label (set by the other CR's earlier reconcile). This is the
+// second line of defense beyond the managed-by label check: SetControllerReference
+// itself refuses to move a controller ref from one owner to another.
+func TestReconcile_RefusesToAdoptSecretOwnedByAnotherCR(t *testing.T) {
+	other := &secretsv1alpha1.KeyorixSecret{
+		ObjectMeta: metav1.ObjectMeta{Name: "other-cr", Namespace: "app", UID: "other-uid"},
+	}
+	owned := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "db-creds",
+			Namespace: "app",
+			Labels:    map[string]string{managedByLabel: managedByValue},
+		},
+		Data: map[string][]byte{"OTHER": []byte("owned-by-other-cr")},
+	}
+	// Give `owned` a real controller owner reference to `other`, mirroring what a prior
+	// reconcile of the other CR would have set.
+	s := testScheme(t)
+	require.NoError(t, controllerutil.SetControllerReference(other, owned, s))
+
+	fetcher := &fakeFetcher{values: map[string][]byte{
+		"app/production/db-password": []byte("p4ss"), "app/production/api-key": []byte("k3y"),
+	}}
+	r, c := newReconciler(t, fetcher, ksFixture(), tokenSecret(), owned)
+
+	_, err := reconcile(t, r)
+	require.Error(t, err, "must refuse to steal ownership of a Secret controlled by a different CR")
+
+	var got corev1.Secret
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "db-creds", Namespace: "app"}, &got))
+	assert.Equal(t, []byte("owned-by-other-cr"), got.Data["OTHER"], "the other CR's Secret data must be untouched")
+	assert.NotContains(t, got.Data, "DB_PASSWORD")
+	require.Len(t, got.OwnerReferences, 1)
+	assert.Equal(t, "other-cr", got.OwnerReferences[0].Name, "ownership must not have moved to the new CR")
 }


### PR DESCRIPTION
## Summary

Backlog findings **#184** and **#185** (HIGH, operator's KeyorixSecret controller), verified against current code before implementing (per this campaign's convention — the backlog can lag shipped fixes).

### #184 — Operator KeyorixSecret CRD is a confused deputy

Half of this finding was already closed by an earlier commit (`fix(operator): pin the destination server to close confused-deputy exfiltration`, #518): `spec.server` must now be `https` and match the operator's `--allowed-servers` allow-list (fail-closed when unset), so a CR author can no longer redirect the bearer token to an attacker-controlled destination.

The **remaining gap**, explicitly flagged as a follow-up in that commit's message, is fixed here: `buildDesired` still resolved `spec.tokenSecretRef` against **any** Secret in the CR's namespace, using the operator's own cluster-wide `get secrets` RBAC rather than the requester's. A principal who can only create `KeyorixSecret` CRs (the CRD's documented least-privilege deployment model grants no core-Secret RBAC) could point `tokenSecretRef` at an arbitrary pre-existing Secret they have no RBAC to read, and have its bytes shipped as a bearer token to the (now-trusted) Keyorix server.

Fix: the referenced Secret must now carry the label `secrets.keyorix.io/token-secret=true` — settable only by a principal with real Secret-write RBAC, which a CRD-write-only attacker lacks — before the controller will resolve it. Missing/incorrect label fails the reconcile closed with a `SyncError` condition, matching the existing failure pattern (not a silent skip).

Docs updated to match: CRD field doc-comment, the generated CRD schema (hand-synced — `controller-gen`/`make manifests` needs a module-proxy network fetch the sandbox couldn't reach; the schema-only description-text edit is low-risk to hand-sync), the Helm chart's CRD copy (**was already stale** even before this change — still had the pre-#518 `^https?://` pattern, now resynced), `NOTES.txt`, and the example manifest.

**Deliberately left out of scope:** a full validating admission webhook (bigger lift than either finding needs — noted in the backlog itself as optional), and moving `spec.server` out of the per-CR spec into operator-level config entirely. The `--allowed-servers` allow-list (already shipped) closes the SSRF-to-attacker-server vector without the larger API/deployment-model change a config move would require.

### #185 — applySecret has no "managed-by" ownership guard

Verified against current code: **already fixed**, in the same earlier commit (`harden(operator): refuse to overwrite a Secret the operator doesn't manage`) — mirrors the sibling k8ssync/#139 fix's exact label scheme (`app.kubernetes.io/managed-by=keyorix-operator`). A pre-existing same-named Secret without that label is refused (error surfaced via the `Ready`/`SyncError` status condition, not silently skipped), and `controllerutil.SetControllerReference`'s own ownership-conflict check provides a second line of defense against a different CR silently stealing a Secret it doesn't already own.

Added a regression test (`TestReconcile_RefusesToAdoptSecretOwnedByAnotherCR`) closing the one coverage gap: a same-named Secret already owned by a **different** `KeyorixSecret` CR (so it already carries the managed-by label from that CR's prior reconcile) must not be silently re-adopted by this CR.

## Test plan

- [x] `GOWORK=off go build -C operator ./...` clean
- [x] `GOWORK=off go test -race -timeout 120s -C operator ./...` clean (includes 4 new tests: unlabeled token secret, wrong-value-labeled token secret, cross-CR ownership adoption refusal, plus the updated fixture covering the happy path)
- [x] `go build ./...` from repo root clean (no main-module files touched)
- [x] `cd operator && GOWORK=off gosec -severity medium -exclude-generated ./...` — 0 issues
- [x] `cd operator && GOWORK=off golangci-lint run ./...` — 0 issues
- [x] `gofmt -l` clean on changed files
- [x] `helm lint deploy/helm/keyorix-operator` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)