### PR TITLE
harden: dynamic-lease revoke_failed error leak + manual-rotate backend bypass (#192/#193)

### DIFF
--- a/internal/core/dynamic_secrets.go
+++ b/internal/core/dynamic_secrets.go
@@ -297,6 +297,7 @@ func (c *KeyorixCore) RevokeLease(ctx context.Context, leaseID string, userID ui
 	}
 	lease.Status = "revoked"
 	lease.RevokeReason = reason
+	lease.RevokeError = "" // clear any error from a prior failed attempt — this retry succeeded
 	lease.RevokedAt = &now
 	if err := c.storage.UpdateDynamicSecretLease(ctx, lease); err != nil {
 		return err

--- a/internal/core/dynamic_secrets_test.go
+++ b/internal/core/dynamic_secrets_test.go
@@ -313,6 +313,45 @@ func TestDynamicSecrets_RevokeLeasesForConfig(t *testing.T) {
 	assert.Equal(t, 0, revoked2)
 }
 
+// #192: the bulk incident-response kill switch is the LAST line of defense for
+// MySQL/Mongo/Redis, where the target DROP/dropUser/ACL-DELUSER call is the only
+// enforcement mechanism. A lease already stuck in revoke_failed (its credential still
+// live from an earlier failed attempt) must NOT be silently skipped by
+// RevokeLeasesForConfig — it must be retried right alongside the still-active leases,
+// so an operator responding to "this target/config is compromised" actually kills every
+// outstanding credential, not just the ones that happened to revoke cleanly before.
+func TestDynamicSecrets_RevokeLeasesForConfigRetriesRevokeFailed(t *testing.T) {
+	c, _, fake, _ := newDynamicTestCore(t)
+	ctx := context.Background()
+	cfg := mkConfig(t, c, ctx)
+
+	stuck, err := c.IssueLease(ctx, cfg.ID, 0, 7)
+	require.NoError(t, err)
+	stillActive, err := c.IssueLease(ctx, cfg.ID, 0, 7)
+	require.NoError(t, err)
+
+	// The first lease's revoke fails once (transient outage) and is left revoke_failed —
+	// its credential is still live on the target.
+	fake.FailRevoke = true
+	require.Error(t, c.RevokeLease(ctx, stuck.LeaseID, 7, "manual"))
+	before, _ := c.storage.GetDynamicSecretLease(ctx, stuck.LeaseID)
+	require.Equal(t, "revoke_failed", before.Status, "precondition: the lease is stuck exactly as #192 describes")
+
+	// The target recovers, and an incident responder now believes the whole config is
+	// compromised and pulls the kill switch.
+	fake.FailRevoke = false
+	revoked, failed, err := c.RevokeLeasesForConfig(ctx, cfg.ID, 7, "incident: compromised target")
+	require.NoError(t, err)
+	assert.Equal(t, 0, failed)
+	assert.Equal(t, 2, revoked, "both the still-active lease AND the previously revoke_failed one must be revoked")
+
+	after, _ := c.storage.GetDynamicSecretLease(ctx, stuck.LeaseID)
+	assert.Equal(t, "revoked", after.Status, "the revoke_failed lease is NOT permanently stuck — the kill switch reaches it")
+	assert.Empty(t, after.RevokeError, "a successful retry clears the earlier error")
+	assert.Contains(t, fake.Revoked, stuck.Username, "the previously-stranded credential was actually dropped on the target")
+	assert.Contains(t, fake.Revoked, stillActive.Username)
+}
+
 func TestDynamicSecrets_RenewRejectsInactiveLease(t *testing.T) {
 	c, _, _, _ := newDynamicTestCore(t)
 	ctx := context.Background()

--- a/internal/core/rotation_executor.go
+++ b/internal/core/rotation_executor.go
@@ -24,6 +24,16 @@ import (
 // EventAutoRotationFailures is audited once per run when one or more secrets failed.
 const EventAutoRotationFailures = "rotation.failures_alerted"
 
+// EventSecretRotateFailed and EventSecretRotateIncomplete are audited by
+// RotateSecretOnDemand (#193) when a manual/operator-triggered rotation of a
+// backend-bound secret fails outright, or partially completes (new credential minted
+// but a prior one survived upstream), respectively — distinct from the plain
+// "secret.rotated" success event so an operator can find and act on them.
+const (
+	EventSecretRotateFailed     = "secret.rotate_failed"
+	EventSecretRotateIncomplete = "secret.rotate_incomplete"
+)
+
 // notifyRotationFailures broadcasts a single summary of the run's rotation failures to
 // the configured notification channel (Slack/Teams/webhook) — a silently-failed
 // credential rotation is a security event operators must see. No-op when no sink is
@@ -403,6 +413,65 @@ func (c *KeyorixCore) applyBackendRotation(ctx context.Context, secret *models.S
 		return "", err
 	}
 	return candidate, nil
+}
+
+// RotateSecretOnDemand handles a manual/operator-triggered rotation request (e.g. the
+// POST /secrets/{id}/rotate API) with the same backend awareness as the auto-rotation
+// scheduler (#193): if the secret is bound to a configured rotation backend (ADR-047),
+// the upstream credential is rotated FIRST via applyBackendRotation — the exact machinery
+// rotateOneSecret uses — and the value actually stored in Keyorix is the one the backend
+// produced/confirmed, never an arbitrary caller-supplied value that could silently drift
+// from what's live upstream. Previously this path stored the caller's value verbatim,
+// left the real (possibly suspected-compromised) upstream credential fully untouched, and
+// still reported "rotated successfully" — an actively misleading incident-response tool.
+//
+// newValue is used as the candidate applied upstream for a password-SET backend; for a
+// generate-upstream backend (e.g. a cloud key API) it is ignored — the upstream mints its
+// own value, matching automated-rotation semantics. A secret with no configured backend
+// rotates exactly as before (delegates straight to RotateSecret).
+//
+// If the upstream rotation fails outright, nothing is stored and an error is returned —
+// the caller must never be told "success" while the suspected-compromised credential is
+// still live and untouched. If it only partially completes (a new credential was minted
+// but a prior one could not be removed upstream — rotation.PartialRotationError), the new
+// value is still stored (never orphan a freshly minted credential — a cloud key API often
+// returns key material only once) but an error is still returned, so the HTTP response is
+// never a clean "success" while a leftover credential needs manual operator removal; the
+// audit trail records the partial state distinctly either way.
+func (c *KeyorixCore) RotateSecretOnDemand(ctx context.Context, id uint, newValue []byte, rotatedBy string) (*models.SecretNode, error) {
+	secret, err := c.storage.GetSecret(ctx, id)
+	if err != nil {
+		return nil, fmt.Errorf("secret not found: %w", err)
+	}
+	if secret.RotationBackend == "" {
+		return c.RotateSecret(ctx, id, newValue, rotatedBy)
+	}
+
+	upstreamVal, berr := c.applyBackendRotation(ctx, secret, string(newValue))
+	var partial *rotation.PartialRotationError
+	switch {
+	case errors.As(berr, &partial):
+		// The upstream minted the new credential but a prior, possibly compromised one
+		// could not be removed. Store the new value (discarding it would orphan a live,
+		// untracked credential) but still fail the call — the leftover needs an operator.
+		updated, serr := c.RotateSecret(ctx, id, []byte(partial.Value), rotatedBy)
+		if serr != nil {
+			return nil, serr
+		}
+		sid := id
+		c.writeAuditEvent(ctx, EventSecretRotateIncomplete, nil, &sid,
+			fmt.Sprintf("on-demand rotation INCOMPLETE for secret %q via backend %q ref %q: new credential stored but a prior credential is still live and must be removed manually: %v",
+				secret.Name, secret.RotationBackend, secret.RotationRef, berr))
+		return updated, fmt.Errorf("backend %q rotation for secret %q partially completed: new credential stored but a prior credential is still live upstream and must be removed manually: %w",
+			secret.RotationBackend, secret.Name, berr)
+	case berr != nil:
+		sid := id
+		c.writeAuditEvent(ctx, EventSecretRotateFailed, nil, &sid,
+			fmt.Sprintf("on-demand rotation FAILED for secret %q via backend %q ref %q: %v", secret.Name, secret.RotationBackend, secret.RotationRef, berr))
+		return nil, fmt.Errorf("backend %q rotation failed for secret %q (upstream credential NOT rotated): %w", secret.RotationBackend, secret.Name, berr)
+	default:
+		return c.RotateSecret(ctx, id, []byte(upstreamVal), rotatedBy)
+	}
 }
 
 // knownRotationCharset reports whether name is a recognized charset (or "" = default).

--- a/internal/core/rotation_executor_test.go
+++ b/internal/core/rotation_executor_test.go
@@ -440,3 +440,141 @@ func TestRunAutoRotation_BackendSucceedsStoreFails_AuditsDrift(t *testing.T) {
 	assert.Contains(t, events[0].Description, "DRIFT", "the backend-succeeded-store-failed case must be audited as drift")
 	assert.Contains(t, events[0].Description, "app_svc", "the audit must name the upstream ref to reconcile")
 }
+
+// ── #193: RotateSecretOnDemand — the manual/operator rotation path must actually drive
+// backend rotation for a backend-bound secret, never silently store an arbitrary
+// caller-supplied value while leaving the real upstream credential untouched. ──
+
+// fakePartialGenExecutor is a generate-upstream backend whose GenerateUpstream can
+// return a rotation.PartialRotationError: the new credential is minted upstream but a
+// follow-up cleanup step (deleting the prior one) fails — the new value must still be
+// stored (never orphan a freshly minted, untracked credential).
+type fakePartialGenExecutor struct {
+	name    string
+	value   string
+	partial bool
+	gotRef  string
+}
+
+func (f *fakePartialGenExecutor) Name() string { return f.name }
+func (f *fakePartialGenExecutor) Type() string { return "fakepartial" }
+func (f *fakePartialGenExecutor) Rotate(context.Context, string, string) error {
+	return errors.New("use GenerateUpstream")
+}
+func (f *fakePartialGenExecutor) GenerateUpstream(_ context.Context, ref string) (string, error) {
+	f.gotRef = ref
+	if f.partial {
+		return "", &rotation.PartialRotationError{Value: f.value, Err: errors.New("could not delete prior key")}
+	}
+	return f.value, nil
+}
+
+// A secret with no configured rotation backend rotates exactly as before: the
+// caller-supplied value is stored verbatim.
+func TestRotateSecretOnDemand_NoBackendStoresCallerValue(t *testing.T) {
+	c, db, fixed := rotationExecCore(t)
+	seedRotatableSecret(t, db, 1, "plain", false, fixed.Add(-24*time.Hour))
+
+	updated, err := c.RotateSecretOnDemand(context.Background(), 1, []byte("caller-value"), "alice")
+	require.NoError(t, err)
+	assert.NotNil(t, updated.LastRotatedAt)
+	v := latestVersion(t, db, 1)
+	assert.Equal(t, "caller-value", string(v.EncryptedValue))
+}
+
+// The core #193 regression: a manual on-demand rotate of a backend-bound secret must
+// actually invoke the backend rotation executor (not just overwrite the stored value),
+// and the value stored in Keyorix is the one the backend applied/confirmed.
+func TestRotateSecretOnDemand_AppliesBackend(t *testing.T) {
+	fake := &fakeExecutor{name: "pg"}
+	c, db, fixed := rotationExecCore(t)
+	c.SetRotationManager(rotation.NewManager([]rotation.Executor{fake}))
+	seedBackendSecret(t, db, 1, "pg", "app_svc", fixed.Add(-24*time.Hour))
+
+	updated, err := c.RotateSecretOnDemand(context.Background(), 1, []byte("operator-supplied"), "alice")
+	require.NoError(t, err)
+
+	require.True(t, fake.called, "the manual rotate must actually invoke the backend executor")
+	assert.Equal(t, "app_svc", fake.gotRef)
+	assert.Equal(t, "operator-supplied", fake.gotVal, "the caller's candidate is what gets applied upstream")
+
+	v := latestVersion(t, db, 1)
+	assert.Equal(t, 2, v.VersionNumber)
+	assert.Equal(t, fake.gotVal, string(v.EncryptedValue), "the stored value matches what was actually applied upstream")
+	assert.NotNil(t, updated.LastRotatedAt)
+}
+
+// For a generate-upstream backend the caller's candidate is ignored — the stored value
+// is what the upstream minted, matching automated-rotation semantics.
+func TestRotateSecretOnDemand_GenerateUpstreamIgnoresCandidate(t *testing.T) {
+	fake := &fakePartialGenExecutor{name: "cloud", value: `{"access_key_id":"AKIANEW"}`}
+	c, db, fixed := rotationExecCore(t)
+	c.SetRotationManager(rotation.NewManager([]rotation.Executor{fake}))
+	seedBackendSecret(t, db, 1, "cloud", "svc-app", fixed.Add(-24*time.Hour))
+
+	_, err := c.RotateSecretOnDemand(context.Background(), 1, []byte("ignored-candidate"), "alice")
+	require.NoError(t, err)
+	assert.Equal(t, "svc-app", fake.gotRef)
+	v := latestVersion(t, db, 1)
+	assert.Equal(t, fake.value, string(v.EncryptedValue))
+}
+
+// If the upstream rotation fails outright, nothing is stored — the response must never
+// be a misleading "success" while the suspected-compromised credential is untouched.
+func TestRotateSecretOnDemand_BackendFailureRefused(t *testing.T) {
+	fake := &fakeExecutor{name: "pg", err: errors.New("connection refused")}
+	c, db, fixed := rotationExecCore(t)
+	c.SetRotationManager(rotation.NewManager([]rotation.Executor{fake}))
+	seedBackendSecret(t, db, 1, "pg", "app_svc", fixed.Add(-24*time.Hour))
+
+	_, err := c.RotateSecretOnDemand(context.Background(), 1, []byte("operator-supplied"), "alice")
+	require.Error(t, err, "an upstream rotation failure must never look like success")
+	assert.Contains(t, err.Error(), "backend")
+	assert.Contains(t, err.Error(), "NOT rotated")
+
+	require.True(t, fake.called)
+	v := latestVersion(t, db, 1)
+	assert.Equal(t, 1, v.VersionNumber, "no new value is stored when the upstream apply fails")
+
+	var events []models.AuditEvent
+	require.NoError(t, db.Where("event_type = ?", EventSecretRotateFailed).Find(&events).Error)
+	require.Len(t, events, 1, "the failure is audited distinctly")
+	assert.Contains(t, events[0].Description, "app_svc")
+}
+
+// A partial upstream failure (new credential minted, prior one could not be removed)
+// still stores the new value — discarding it would orphan a live, untracked credential —
+// but the call still returns an error so the caller is never told "success" while a
+// leftover credential needs manual removal.
+func TestRotateSecretOnDemand_PartialFailureStoresButErrors(t *testing.T) {
+	fake := &fakePartialGenExecutor{name: "cloud", value: `{"access_key_id":"AKIANEW"}`, partial: true}
+	c, db, fixed := rotationExecCore(t)
+	c.SetRotationManager(rotation.NewManager([]rotation.Executor{fake}))
+	seedBackendSecret(t, db, 1, "cloud", "svc-app", fixed.Add(-24*time.Hour))
+
+	updated, err := c.RotateSecretOnDemand(context.Background(), 1, []byte("ignored"), "alice")
+	require.Error(t, err, "a partial upstream cleanup failure must not report success")
+	assert.NotNil(t, updated, "the new value is still returned/stored — never orphan a freshly minted credential")
+
+	v := latestVersion(t, db, 1)
+	assert.Equal(t, 2, v.VersionNumber)
+	assert.Equal(t, fake.value, string(v.EncryptedValue), "the newly minted credential is stored despite the partial failure")
+
+	var events []models.AuditEvent
+	require.NoError(t, db.Where("event_type = ?", EventSecretRotateIncomplete).Find(&events).Error)
+	require.Len(t, events, 1, "the partial outcome is audited distinctly from both success and outright failure")
+}
+
+// An unknown backend name (misconfigured after a manager reload) is refused, not
+// silently treated as a plain Keyorix-only rotation.
+func TestRotateSecretOnDemand_UnknownBackendRefused(t *testing.T) {
+	c, db, fixed := rotationExecCore(t)
+	c.SetRotationManager(rotation.NewManager([]rotation.Executor{&fakeExecutor{name: "other"}}))
+	seedBackendSecret(t, db, 1, "pg", "app_svc", fixed.Add(-24*time.Hour))
+
+	_, err := c.RotateSecretOnDemand(context.Background(), 1, []byte("x"), "alice")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown rotation backend")
+	v := latestVersion(t, db, 1)
+	assert.Equal(t, 1, v.VersionNumber, "nothing is stored for an unresolvable backend")
+}

--- a/server/http/handlers/secrets_versions.go
+++ b/server/http/handlers/secrets_versions.go
@@ -82,11 +82,22 @@ func (h *SecretHandler) RotateSecret(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	secret, err := h.coreService.RotateSecret(r.Context(), uint(id), []byte(reqBody.NewValue), userCtx.Username)
+	// RotateSecretOnDemand (#193): for a backend-bound secret this rotates the upstream
+	// credential too (the same machinery the auto-rotation scheduler uses) rather than
+	// just overwriting the stored value — never report success while the real,
+	// potentially compromised credential is still live untouched upstream.
+	secret, err := h.coreService.RotateSecretOnDemand(r.Context(), uint(id), []byte(reqBody.NewValue), userCtx.Username)
 	if err != nil {
-		if strings.Contains(err.Error(), "not found") {
+		switch {
+		case strings.Contains(err.Error(), "not found"):
 			h.sendError(w, "NotFound", "Secret not found", http.StatusNotFound, nil)
-		} else {
+		case strings.Contains(err.Error(), "backend"):
+			// The upstream rotation failed or only partially completed — surfaced
+			// distinctly (502) so the caller never mistakes this for a clean success,
+			// even though a partial attempt may have stored a new value; see the audit
+			// trail (secret.rotate_failed / secret.rotate_incomplete) for the outcome.
+			h.sendError(w, "BackendRotationFailed", err.Error(), http.StatusBadGateway, nil)
+		default:
 			h.sendError(w, "InternalError", "Failed to rotate secret", http.StatusInternalServerError, nil)
 		}
 		return


### PR DESCRIPTION
## Summary

Two HIGH findings from the credential-lifecycle hardening round.

### #192 — dynamic-secret lease `revoke_failed` state-machine gap
On `main`, PR #518 had already fixed the core state-machine bug: `RevokeLease` admits
`revoke_failed` leases for retry, the sweep (`ListExpiredActiveLeases`) picks up
`revoke_failed` leases past expiry, and `RevokeLeasesForConfig` (the incident-response
kill switch) also retries them instead of skipping. Verified this against current
`main` and it holds.

What was still missing, found while writing the required regression test: a
successfully re-revoked lease kept its **stale `RevokeError` string** from the earlier
failed attempt — `RevokeLease` cleared `Status`/`RevokedAt`/`RevokeReason` on success
but never cleared `RevokeError`, so a lease that had fully recovered still looked like
it carried an active error. Fixed by clearing `RevokeError` on a successful (re)revoke.

Added `TestDynamicSecrets_RevokeLeasesForConfigRetriesRevokeFailed`, which pins that
the bulk kill switch — the last line of defense for MySQL/Mongo/Redis, where the
target DROP/dropUser/ACL-DELUSER call is the only enforcement mechanism — actually
reaches a lease already stuck in `revoke_failed`, not just still-active ones, and that
the error is cleared once it succeeds.

### #193 — manual rotate silently bypassed backend rotation
`server/http/handlers/secrets_versions.go` → `core.RotateSecret` never read
`secret.RotationBackend`/`RotationRef` and never called `applyBackendRotation` — only
the scheduler's `rotateOneSecret` did. An operator hitting `POST
/secrets/{id}/rotate` on a backend-bound (e.g. Postgres role) secret got: an
arbitrary caller-supplied value stored in Keyorix, the real upstream credential left
fully live, a "rotated successfully" response, and `LastRotatedAt` bumped (pushing the
real scheduled rotation further out).

Added `core.RotateSecretOnDemand`, which reuses `applyBackendRotation` — the exact
machinery `rotateOneSecret` uses — so a manual rotate of a backend-bound secret
actually rotates the upstream credential:

- **Clean success**: the upstream-applied/minted value is what gets stored in Keyorix.
- **Outright failure**: nothing is stored, a clear error is returned (never a
  misleading "success" while the suspected-compromised credential is untouched).
- **Partial failure** (new credential minted upstream but a prior one couldn't be
  removed — `rotation.PartialRotationError`): the new value is still stored (discarding
  it would orphan a live, untracked credential — some cloud key APIs return key
  material only once), but an error is still returned so the response is never a clean
  "success" while a leftover credential needs manual removal.
- Both failure modes are audited distinctly (`secret.rotate_failed` /
  `secret.rotate_incomplete`), separate from the plain `secret.rotated` success event.
- A secret with no configured backend rotates exactly as before.

The HTTP handler now calls `RotateSecretOnDemand` and surfaces a backend-rotation
problem as `502 BadGateway` (matching the existing convention used by the dynamic-
secrets handlers for upstream failures) instead of a generic 500.

## Test plan
- [x] `internal/core/dynamic_secrets_test.go`: new
      `TestDynamicSecrets_RevokeLeasesForConfigRetriesRevokeFailed` — a lease stuck in
      `revoke_failed` is revoked by the bulk kill switch and its error is cleared.
- [x] `internal/core/rotation_executor_test.go`: new `RotateSecretOnDemand` tests —
      backend actually invoked on success (`fake.called`, applied value stored),
      outright backend failure refused (nothing stored, distinct audit event), partial
      failure still stores the minted value but still errors (distinct audit event),
      generate-upstream backend ignores the caller's candidate, unknown backend
      refused, no-backend secret unaffected.
- [x] `go build ./...` clean
- [x] `go test ./...` clean (full suite)
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues
- [x] `golangci-lint run ./...` — 0 issues
- [x] `GOWORK=off go build -C operator ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)