### PR TITLE
harden: SCIM group membership guard, GHA env-var injection, scan symlink follow

### DIFF
--- a/integrations/github-action/README.md
+++ b/integrations/github-action/README.md
@@ -29,7 +29,9 @@ your workflow as **masked environment variables**.
 
 How it works: installs the Keyorix CLI (via the official installer, or a pinned
 `version`), runs `keyorix secret export --format json`, masks each value with
-`::add-mask::`, and writes them to `$GITHUB_ENV`. Secret names are injected
-verbatim — name them as valid env identifiers (e.g. `STRIPE_KEY`).
+`::add-mask::`, and writes them to `$GITHUB_ENV`. Secret names must be valid env
+identifiers (e.g. `STRIPE_KEY`, matching `^[A-Za-z_][A-Za-z0-9_]*$`) — the action
+refuses and fails the step if any secret name doesn't match, rather than writing it
+to `$GITHUB_ENV` unsanitized.
 
 See [docs/CI_CD.md](../../docs/CI_CD.md) for GitLab CI and CircleCI examples.

--- a/integrations/github-action/entrypoint.sh
+++ b/integrations/github-action/entrypoint.sh
@@ -48,6 +48,20 @@ install_cli() {
   keyorix --version
 }
 
+# validate_secret_name checks that a Keyorix secret NAME is safe to write verbatim
+# into $GITHUB_ENV. Keyorix only validates secret name LENGTH server-side (min=1,
+# max=255) with no charset restriction, so a principal holding only project-scoped
+# secrets.write could name a secret e.g. "FOO\nGITHUB_TOKEN=<attacker-value>\nBAR".
+# $GITHUB_ENV is a plain line-based text format the runner parses after this action
+# exits; an embedded newline (or other metacharacter) in the "name" field lets that
+# single entry masquerade as an extra NAME=VALUE assignment line, overriding env vars
+# trusted by later, more-privileged steps in the same job (#174). Requiring a plain
+# identifier closes this off entirely: no newline, `=`, or other special character
+# can ever reach the file.
+validate_secret_name() {
+  [[ "$1" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]
+}
+
 inject_env() {
   local json key val delim count
   json="$(keyorix secret export --project "$PROJECT" --env "$ENVIRONMENT" --format json)"
@@ -60,6 +74,12 @@ inject_env() {
   count=0
   while IFS= read -r key; do
     [ -n "$key" ] || continue
+    # Reject any secret name that isn't a safe identifier BEFORE it ever reaches
+    # $GITHUB_ENV — see validate_secret_name above (#174).
+    if ! validate_secret_name "$key"; then
+      echo "error: secret name '${key}' is not a valid identifier (must match ^[A-Za-z_][A-Za-z0-9_]*\$) — refusing to export it to \$GITHUB_ENV" >&2
+      exit 1
+    fi
     val="$(printf '%s' "$json" | jq -r --arg k "$key" '.[$k]')"
     # Mask the value everywhere it might appear in the logs.
     echo "::add-mask::$val"
@@ -78,14 +98,19 @@ inject_env() {
   echo "Loaded ${count} secret(s) from project '${PROJECT}' environment '${ENVIRONMENT}'."
 }
 
-install_cli
+# Only run the action's main flow when this script is executed directly, not when
+# it's sourced (e.g. by a test harness that wants validate_secret_name/inject_env
+# without performing a real CLI install + secret export).
+if [[ "${BASH_SOURCE[0]:-$0}" == "${0}" ]]; then
+  install_cli
 
-if [ "$EXPORT_TO_ENV" = "true" ]; then
-  inject_env
-fi
+  if [ "$EXPORT_TO_ENV" = "true" ]; then
+    inject_env
+  fi
 
-if [ -n "$OUTPUT_FILE" ]; then
-  # Reuse the CLI's dotenv writer (handles quoting) for the file form.
-  keyorix secret export --project "$PROJECT" --env "$ENVIRONMENT" --format dotenv --output "$OUTPUT_FILE"
-  echo "Wrote secrets to ${OUTPUT_FILE}"
+  if [ -n "$OUTPUT_FILE" ]; then
+    # Reuse the CLI's dotenv writer (handles quoting) for the file form.
+    keyorix secret export --project "$PROJECT" --env "$ENVIRONMENT" --format dotenv --output "$OUTPUT_FILE"
+    echo "Wrote secrets to ${OUTPUT_FILE}"
+  fi
 fi

--- a/integrations/github-action/entrypoint_test.sh
+++ b/integrations/github-action/entrypoint_test.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# entrypoint_test.sh — minimal regression test for entrypoint.sh's secret-name
+# validation (#174: attacker-controllable secret NAMES written unsanitized into
+# $GITHUB_ENV could inject a bogus extra NAME=VALUE assignment line, overriding env
+# vars trusted by later, more-privileged steps in the same job).
+#
+# Run directly: ./entrypoint_test.sh
+#
+# Sources entrypoint.sh to get access to validate_secret_name without performing a
+# real CLI install or secret export — entrypoint.sh only runs its top-level
+# install/export flow when executed directly (see the BASH_SOURCE guard at the
+# bottom of that file), so sourcing it here is side-effect-free.
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Satisfy entrypoint.sh's required-input checks (`: "${KEYORIX_SERVER:?...}"` etc.)
+# before sourcing; these values are never used since we don't invoke install_cli or
+# inject_env, only validate_secret_name directly.
+KEYORIX_SERVER="https://example.invalid"
+KEYORIX_TOKEN="test-token"
+export KEYORIX_SERVER KEYORIX_TOKEN
+
+# shellcheck source=entrypoint.sh disable=SC1091
+source "${script_dir}/entrypoint.sh"
+
+fail=0
+
+assert_valid() {
+  if validate_secret_name "$1"; then
+    echo "ok   - accepted: '$1'"
+  else
+    echo "FAIL - should have been accepted: '$1'"
+    fail=1
+  fi
+}
+
+assert_invalid() {
+  if validate_secret_name "$1"; then
+    echo "FAIL - should have been rejected: '$1'"
+    fail=1
+  else
+    echo "ok   - rejected: '$1'"
+  fi
+}
+
+# --- Legitimate identifiers must be accepted. ---
+assert_valid "STRIPE_KEY"
+assert_valid "_LEADING_UNDERSCORE"
+assert_valid "A"
+assert_valid "MixedCase123"
+
+# --- The #174 exploit primitive: a secret name embedding a newline, crafted to
+# look like a second $GITHUB_ENV assignment line once written out verbatim. ---
+assert_invalid "$(printf 'FOO\nGITHUB_TOKEN=evil\nBAR')"
+
+# --- Other unsafe characters that must never reach $GITHUB_ENV unsanitized. ---
+assert_invalid "FOO=BAR"
+assert_invalid "FOO BAR"
+assert_invalid "1LEADING_DIGIT"
+assert_invalid ""
+assert_invalid "FOO<<EOF"
+# The literal, unexpanded '$(...)' text is the point of this case.
+# shellcheck disable=SC2016
+assert_invalid 'FOO$(whoami)'
+
+if [ "$fail" -ne 0 ]; then
+  echo
+  echo "entrypoint_test.sh: FAILED"
+  exit 1
+fi
+
+echo
+echo "entrypoint_test.sh: all checks passed"

--- a/internal/cli/secret/scan.go
+++ b/internal/cli/secret/scan.go
@@ -144,6 +144,18 @@ func runScan(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return nil
 		}
+		// Never follow symlinks (#153). filepath.Walk reports a symlink's own Lstat
+		// info (info.Mode()&os.ModeSymlink is set) and doesn't itself descend into a
+		// symlinked directory — but a symlinked *file* still reaches this callback,
+		// and the per-type scanners below open the path with os.ReadFile, which DOES
+		// follow symlinks. A malicious repo could commit one pointing outside the
+		// scanned tree (e.g. at the scanning user's own ~/.aws/credentials or
+		// /etc/shadow); reading through it would leak the SCANNING USER's own files
+		// into the report. Skip every symlink encountered rather than trying to
+		// validate where it resolves to.
+		if info.Mode()&os.ModeSymlink != 0 {
+			return nil
+		}
 		if info.IsDir() {
 			if skipDirs[info.Name()] {
 				return filepath.SkipDir

--- a/internal/cli/secret/scan_symlink_test.go
+++ b/internal/cli/secret/scan_symlink_test.go
@@ -1,0 +1,67 @@
+// scan_symlink_test.go — regression test for #153: `secret scan` must not follow
+// symlinks. A malicious repo could commit a symlink pointing outside the scanned
+// tree at a file the scanning user has read access to (e.g. ~/.aws/credentials or
+// /etc/shadow); if followed, its content would be pattern-matched and written into
+// the scan report, leaking the SCANNING USER's own files.
+package secret
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunScan_DoesNotFollowSymlinksOutOfScanRoot(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires elevated privileges on windows")
+	}
+
+	root := t.TempDir()
+	outside := t.TempDir()
+
+	// A regular, in-tree file: must still be found — the symlink fix must not
+	// regress ordinary scanning.
+	inTreeValue := strings.Repeat("A", 40)
+	inTreeContent := "AWS_SECRET_ACCESS_KEY=" + inTreeValue + "\n"
+	require.NoError(t, os.WriteFile(filepath.Join(root, "config.env"), []byte(inTreeContent), 0600))
+
+	// A file OUTSIDE the scan root, standing in for a sensitive file the scanning
+	// user can read (e.g. ~/.aws/credentials) that a malicious repo has no business
+	// exposing.
+	outsideValue := strings.Repeat("Z", 40)
+	outsideContent := "AWS_SECRET_ACCESS_KEY=" + outsideValue + "\n"
+	outsideFile := filepath.Join(outside, "credentials.env")
+	require.NoError(t, os.WriteFile(outsideFile, []byte(outsideContent), 0600))
+
+	// A symlink INSIDE the scan root pointing at the outside file — the attack
+	// primitive: a malicious repo commits this symlink, and the scanning user's
+	// clone+scan would otherwise transparently follow it.
+	require.NoError(t, os.Symlink(outsideFile, filepath.Join(root, "linked.env")))
+
+	reportPath := filepath.Join(t.TempDir(), "report.json")
+	origReport, origSeverity, origStaged, origCommit := scanReport, scanSeverity, scanStaged, scanCommit
+	scanReport, scanSeverity, scanStaged, scanCommit = reportPath, "", false, ""
+	t.Cleanup(func() {
+		scanReport, scanSeverity, scanStaged, scanCommit = origReport, origSeverity, origStaged, origCommit
+	})
+
+	require.NoError(t, runScan(scanCmd, []string{root}))
+
+	data, err := os.ReadFile(reportPath)
+	require.NoError(t, err)
+	var report ScanReport
+	require.NoError(t, json.Unmarshal(data, &report))
+
+	values := make([]string, 0, len(report.Findings))
+	for _, f := range report.Findings {
+		values = append(values, f.Value)
+	}
+	assert.Contains(t, values, inTreeValue, "a regular file inside the scan root must still be scanned")
+	assert.NotContains(t, values, outsideValue, "the scanner must not follow a symlink to read a file outside the scan root")
+}

--- a/internal/core/scim_groups.go
+++ b/internal/core/scim_groups.go
@@ -19,10 +19,53 @@ const (
 	EventSCIMGroupDeprovisioned = "scim.group_deprovisioned"
 )
 
+// scimManagedMember reports whether uid identifies a SCIM-managed account (carries a
+// stored ExternalID — only SCIM user-provisioning sets one; a native/local account
+// never does). SCIM group membership mutations (Create/Replace/PATCH) must refuse any
+// target that isn't: those endpoints take arbitrary numeric member ids straight off
+// the SCIM payload with no check that the id belongs to an account SCIM actually owns,
+// so a valid (e.g. group-provisioning-only) SCIM bearer token could otherwise add ANY
+// native user — including one the attacker already controls — into a group. If that
+// group carries an admin-conferring role (a common "IdP group X = Keyorix admins"
+// integration pattern), membership alone grants the role immediately, with no SSO
+// step required (#167 — the group-membership sibling of #120's user-level guard).
+// Fails CLOSED (treats a lookup error as not-managed) so an inability to verify never
+// opens the add.
+func (c *KeyorixCore) scimManagedMember(ctx context.Context, uid uint) bool {
+	user, err := c.storage.GetUser(ctx, uid)
+	if err != nil {
+		return false
+	}
+	return user.ExternalID != ""
+}
+
+// filterSCIMManaged splits ids into (allowed, rejected) member ids based on
+// scimManagedMember, so callers can add only the SCIM-managed subset and report the
+// rest as refused rather than silently dropping them.
+func (c *KeyorixCore) filterSCIMManaged(ctx context.Context, ids []uint) (allowed, rejected []uint) {
+	for _, id := range ids {
+		if id == 0 {
+			continue
+		}
+		if c.scimManagedMember(ctx, id) {
+			allowed = append(allowed, id)
+		} else {
+			rejected = append(rejected, id)
+		}
+	}
+	return allowed, rejected
+}
+
 // ProvisionSCIMGroup creates a group from a SCIM Create and adds its initial members.
+// Only SCIM-managed members may be added (scimManagedMember, #167); a non-SCIM-managed
+// id in memberIDs is refused.
 func (c *KeyorixCore) ProvisionSCIMGroup(ctx context.Context, actorID uint, displayName string, memberIDs []uint) (*models.Group, error) {
 	if displayName == "" {
 		return nil, fmt.Errorf("displayName is required")
+	}
+	allowed, rejected := c.filterSCIMManaged(ctx, memberIDs)
+	if len(rejected) > 0 {
+		return nil, fmt.Errorf("%s: SCIM can only add SCIM-managed users to a group (rejected member id(s): %v)", i18n.T("ErrorNotAuthorized", nil), rejected)
 	}
 	// Storage-direct: the SCIM path emits its own scim.group_provisioned event below,
 	// so it must not also fire the generic group.created from CreateGroup.
@@ -30,13 +73,11 @@ func (c *KeyorixCore) ProvisionSCIMGroup(ctx context.Context, actorID uint, disp
 	if err != nil {
 		return nil, err
 	}
-	for _, uid := range memberIDs {
-		if uid != 0 {
-			_ = c.storage.AddUserToGroup(ctx, uid, group.ID)
-		}
+	for _, uid := range allowed {
+		_ = c.storage.AddUserToGroup(ctx, uid, group.ID)
 	}
 	c.writeAuditEvent(ctx, EventSCIMGroupProvisioned, actorPtr(actorID), nil,
-		fmt.Sprintf("SCIM provisioned group %d (%q) with %d member(s)", group.ID, displayName, len(memberIDs)))
+		fmt.Sprintf("SCIM provisioned group %d (%q) with %d member(s)", group.ID, displayName, len(allowed)))
 	return group, nil
 }
 
@@ -78,6 +119,11 @@ func (c *KeyorixCore) ReplaceSCIMGroup(ctx context.Context, actorID, groupID uin
 	if len(toAdd) > 0 && c.scimGroupConfersAdmin(ctx, groupID) {
 		return nil, fmt.Errorf("%s: SCIM cannot add members to a group that grants administrative roles", i18n.T("ErrorNotAuthorized", nil))
 	}
+	// Every add must target a SCIM-managed account (#167); a native/non-SCIM id in the
+	// requested member set is refused outright rather than silently skipped.
+	if _, rejected := c.filterSCIMManaged(ctx, toAdd); len(rejected) > 0 {
+		return nil, fmt.Errorf("%s: SCIM can only add SCIM-managed users to a group (rejected member id(s): %v)", i18n.T("ErrorNotAuthorized", nil), rejected)
+	}
 	for _, u := range current {
 		if !want[u.ID] {
 			_ = c.storage.RemoveUserFromGroup(ctx, u.ID, groupID)
@@ -114,10 +160,14 @@ func (c *KeyorixCore) PatchSCIMGroup(ctx context.Context, actorID, groupID uint,
 	if hasAdds && c.scimGroupConfersAdmin(ctx, groupID) {
 		return nil, fmt.Errorf("%s: SCIM cannot add members to a group that grants administrative roles", i18n.T("ErrorNotAuthorized", nil))
 	}
-	for _, id := range addIDs {
-		if id != 0 {
-			_ = c.storage.AddUserToGroup(ctx, id, groupID)
-		}
+	// Every add must target a SCIM-managed account (#167); a native/non-SCIM id in the
+	// requested add set is refused outright rather than silently skipped.
+	allowedAdds, rejected := c.filterSCIMManaged(ctx, addIDs)
+	if len(rejected) > 0 {
+		return nil, fmt.Errorf("%s: SCIM can only add SCIM-managed users to a group (rejected member id(s): %v)", i18n.T("ErrorNotAuthorized", nil), rejected)
+	}
+	for _, id := range allowedAdds {
+		_ = c.storage.AddUserToGroup(ctx, id, groupID)
 	}
 	for _, id := range removeIDs {
 		if id != 0 {

--- a/internal/core/scim_guards_test.go
+++ b/internal/core/scim_guards_test.go
@@ -69,7 +69,7 @@ func TestUpdateSCIMUser_AllowsAdminDeactivationWhenAnotherExists(t *testing.T) {
 func TestPatchSCIMGroup_RefusesAddingMemberToAdminGroup(t *testing.T) {
 	c, db := newSCIMGuardCore(t)
 	ctx := context.Background()
-	require.NoError(t, db.Create(&models.User{ID: 2, Username: "bob", IsActive: true, AccountState: AccountActive}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 2, Username: "bob", IsActive: true, AccountState: AccountActive, ExternalID: "okta|bob"}).Error)
 	require.NoError(t, db.Create(&models.Role{ID: 10, Name: "admin"}).Error)
 	require.NoError(t, db.Create(&models.Group{ID: 5, Name: "Keyorix-Admins"}).Error)
 	require.NoError(t, db.Create(&models.GroupRole{GroupID: 5, RoleID: 10}).Error) // group confers admin
@@ -77,4 +77,103 @@ func TestPatchSCIMGroup_RefusesAddingMemberToAdminGroup(t *testing.T) {
 	_, err := c.PatchSCIMGroup(ctx, 9, 5, nil, []uint{2}, nil)
 	require.Error(t, err, "SCIM must not add a member to an admin-bearing group")
 	assert.Contains(t, err.Error(), "administrative roles")
+}
+
+// --- #167: SCIM group membership mutations must refuse non-SCIM-managed targets ---
+//
+// None of ProvisionSCIMGroup/ReplaceSCIMGroup/PatchSCIMGroup checked the target
+// member's ExternalID before AddUserToGroup, so a valid SCIM group-provisioning
+// token could add ANY native user — including one the attacker already controls —
+// into a group. If that group carries an admin-conferring role, membership alone
+// grants the role immediately. Each function below is exercised with both a
+// SCIM-managed target (positive control — must succeed) and a non-SCIM-managed
+// native target (negative control — must be refused, and membership must not
+// take effect).
+
+func TestProvisionSCIMGroup_AllowsSCIMManagedMember(t *testing.T) {
+	c, db := newSCIMGuardCore(t)
+	ctx := context.Background()
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "alice", IsActive: true, AccountState: AccountActive, ExternalID: "okta|alice"}).Error)
+
+	group, err := c.ProvisionSCIMGroup(ctx, 9, "Engineering", []uint{1})
+	require.NoError(t, err)
+	members, err := c.storage.ListGroupMembers(ctx, group.ID)
+	require.NoError(t, err)
+	require.Len(t, members, 1)
+	assert.Equal(t, uint(1), members[0].ID)
+}
+
+func TestProvisionSCIMGroup_RefusesNonSCIMManagedMember(t *testing.T) {
+	c, db := newSCIMGuardCore(t)
+	ctx := context.Background()
+	// Native user: no ExternalID — never SCIM-provisioned.
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "native", IsActive: true, AccountState: AccountActive}).Error)
+
+	group, err := c.ProvisionSCIMGroup(ctx, 9, "Engineering", []uint{1})
+	require.Error(t, err, "SCIM must not add a non-SCIM-managed native user at group creation")
+	assert.Contains(t, err.Error(), "SCIM-managed")
+	assert.Nil(t, group)
+
+	// No group should have been left dangling with the rejected membership.
+	var count int64
+	require.NoError(t, db.Model(&models.Group{}).Where("name = ?", "Engineering").Count(&count).Error)
+	assert.Zero(t, count, "the group must not be created when the member set is refused")
+}
+
+func TestReplaceSCIMGroup_AllowsSCIMManagedMember(t *testing.T) {
+	c, db := newSCIMGuardCore(t)
+	ctx := context.Background()
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "alice", IsActive: true, AccountState: AccountActive, ExternalID: "okta|alice"}).Error)
+	require.NoError(t, db.Create(&models.Group{ID: 5, Name: "Engineering"}).Error)
+
+	_, err := c.ReplaceSCIMGroup(ctx, 9, 5, "", []uint{1})
+	require.NoError(t, err)
+	members, err := c.storage.ListGroupMembers(ctx, 5)
+	require.NoError(t, err)
+	require.Len(t, members, 1)
+	assert.Equal(t, uint(1), members[0].ID)
+}
+
+func TestReplaceSCIMGroup_RefusesNonSCIMManagedMember(t *testing.T) {
+	c, db := newSCIMGuardCore(t)
+	ctx := context.Background()
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "native", IsActive: true, AccountState: AccountActive}).Error)
+	require.NoError(t, db.Create(&models.Group{ID: 5, Name: "Engineering"}).Error)
+
+	_, err := c.ReplaceSCIMGroup(ctx, 9, 5, "", []uint{1})
+	require.Error(t, err, "SCIM must not add a non-SCIM-managed native user via PUT")
+	assert.Contains(t, err.Error(), "SCIM-managed")
+
+	members, err := c.storage.ListGroupMembers(ctx, 5)
+	require.NoError(t, err)
+	assert.Empty(t, members, "the refused member must not have been added")
+}
+
+func TestPatchSCIMGroup_AllowsSCIMManagedMember(t *testing.T) {
+	c, db := newSCIMGuardCore(t)
+	ctx := context.Background()
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "alice", IsActive: true, AccountState: AccountActive, ExternalID: "okta|alice"}).Error)
+	require.NoError(t, db.Create(&models.Group{ID: 5, Name: "Engineering"}).Error)
+
+	_, err := c.PatchSCIMGroup(ctx, 9, 5, nil, []uint{1}, nil)
+	require.NoError(t, err)
+	members, err := c.storage.ListGroupMembers(ctx, 5)
+	require.NoError(t, err)
+	require.Len(t, members, 1)
+	assert.Equal(t, uint(1), members[0].ID)
+}
+
+func TestPatchSCIMGroup_RefusesNonSCIMManagedMember(t *testing.T) {
+	c, db := newSCIMGuardCore(t)
+	ctx := context.Background()
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "native", IsActive: true, AccountState: AccountActive}).Error)
+	require.NoError(t, db.Create(&models.Group{ID: 5, Name: "Engineering"}).Error)
+
+	_, err := c.PatchSCIMGroup(ctx, 9, 5, nil, []uint{1}, nil)
+	require.Error(t, err, "SCIM must not add a non-SCIM-managed native user via PATCH")
+	assert.Contains(t, err.Error(), "SCIM-managed")
+
+	members, err := c.storage.ListGroupMembers(ctx, 5)
+	require.NoError(t, err)
+	assert.Empty(t, members, "the refused member must not have been added")
 }

--- a/server/http/handlers/scim_groups_test.go
+++ b/server/http/handlers/scim_groups_test.go
@@ -10,10 +10,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// provisionUser creates a SCIM user and returns its SCIM id.
+// provisionUser creates a SCIM user (with a real externalId, so it's SCIM-managed
+// per #167/#120's convention — scimManaged only looks at a stored ExternalID, which
+// ProvisionSCIMUser only sets from the payload's own externalId field) and returns
+// its SCIM id.
 func provisionUser(t *testing.T, h *SCIMHandler, userName string) string {
 	t.Helper()
-	body := `{"userName":"` + userName + `"}`
+	body := `{"userName":"` + userName + `","externalId":"idp-` + userName + `"}`
 	w := httptest.NewRecorder()
 	h.CreateUser(w, httptest.NewRequest(http.MethodPost, "/scim/v2/Users", bytes.NewReader([]byte(body))))
 	require.Equal(t, http.StatusCreated, w.Code, w.Body.String())


### PR DESCRIPTION
## Summary

Three standalone HIGH-severity findings from the durable hardening backlog
(`docs/security/HARDENING-BACKLOG.md`, branch `security/hardening-backlog`), bundled
because each is small and touches a disjoint part of the codebase.

### #167 HIGH — SCIM group provisioning had no restriction to SCIM-managed users
None of `ProvisionSCIMGroup`/`ReplaceSCIMGroup`/`PatchSCIMGroup`
(`internal/core/scim_groups.go`) checked the target member's `ExternalID` before
calling `AddUserToGroup` — any user id, native or IdP-provisioned, could be added to
a group via a SCIM PATCH/PUT/POST. This is the group-membership sibling of #120
(user-level SCIM operations, still unmerged as PR #523) — reimplemented the same
`ExternalID != ""` "SCIM-managed" convention independently here so this fix stands
on its own against `main`. If a SCIM-managed group carries an admin-conferring role
(a common "IdP group X = Keyorix admins" pattern), a compromised/over-scoped SCIM
group-provisioning token could previously add any native user — including one the
attacker controls — directly into that group and inherit the role immediately, with
no SSO-claim step required. All three mutation paths now refuse the add outright
(and report which member id(s) were rejected) rather than silently dropping them.

### #174 HIGH — GitHub Action `entrypoint.sh` wrote secret names unsanitized into `$GITHUB_ENV`
Keyorix only validates secret name length server-side (1–255 chars), no charset
restriction. `inject_env` in `integrations/github-action/entrypoint.sh` wrote the
secret *name* verbatim into a `$GITHUB_ENV` heredoc line, so a principal holding
only project-scoped `secrets.write` could name a secret to smuggle an extra
`NAME=VALUE` assignment line into `$GITHUB_ENV`, overriding env vars trusted by
later, more-privileged steps in the same job. `entrypoint.sh` now rejects any secret
name that isn't a plain identifier (`^[A-Za-z_][A-Za-z0-9_]*$`) before it ever
reaches `$GITHUB_ENV`, failing the action step loudly.

### #153 HIGH — `secret scan` followed symlinks, letting a malicious repo exfiltrate the scanning user's own files
`filepath.Walk` in `internal/cli/secret/scan.go` reported a symlink's own info
(doesn't itself descend into symlinked directories), but symlinked *files* still
reached the per-type scanners, which read them with `os.ReadFile` — following the
symlink transparently. A malicious repo could commit a symlink pointing outside the
scanned tree (e.g. at the scanning user's own `~/.aws/credentials`); running
`keyorix secret scan .` against it would read that file with the scanning user's own
privileges and could surface matched content in the scan report. The walk now skips
every symlink it encounters, full stop — no partial "stays inside the root" logic.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` — full suite passes (including an existing SCIM-groups
      integration test updated to give its fixture users a realistic `externalId`,
      matching the same-convention fixture update #523 made for user-level tests)
- [x] `GOWORK=off go build -C operator ./...`
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues
- [x] `golangci-lint run ./...` — 0 issues
- [x] `shellcheck integrations/github-action/entrypoint.sh` and
      `entrypoint_test.sh` — clean
- [x] New tests: `internal/core/scim_guards_test.go` — positive (SCIM-managed
      target succeeds) and negative (non-SCIM-managed native target refused) cases
      for `ProvisionSCIMGroup`/`ReplaceSCIMGroup`/`PatchSCIMGroup`
- [x] New test: `internal/cli/secret/scan_symlink_test.go` — plants a symlink
      pointing outside the scan root and confirms the scanner does not read through
      it, while still correctly scanning regular in-tree files
- [x] New test: `integrations/github-action/entrypoint_test.sh` — a minimal bash
      harness (none existed before) that sources `entrypoint.sh` and exercises
      `validate_secret_name` directly against legitimate identifiers and the
      newline-injection exploit primitive

🤖 Generated with [Claude Code](https://claude.com/claude-code)