### PR TITLE
harden(audit,secrets): close checkpoint-deletion tamper gap + template-render max_reads double-charge

### DIFF
--- a/internal/audit/siem/spool_test.go
+++ b/internal/audit/siem/spool_test.go
@@ -46,7 +46,14 @@ func TestSpool_PersistsAndReplaysOnRecovery(t *testing.T) {
 	// Long interval so we drive replay() manually and avoid timing flakiness.
 	s, err := newSpool(dir, time.Hour, d.deliver)
 	require.NoError(t, err)
-	t.Cleanup(s.close)
+	// Stop the background replay loop up front so ONLY the controlled replay() calls
+	// below run. Otherwise the loop's own initial drain (loop() calls replay() once,
+	// immediately, on its own goroutine — the long interval only governs the ticker
+	// AFTER that) races the manual calls below on an arbitrary scheduling delay: two
+	// concurrent replay()s can each independently deliver the same still-spooled lines
+	// before either reconciles, double-recording the delivery — this made the test
+	// flaky in CI. close() only stops the goroutine; add()/replay() remain usable.
+	s.close()
 
 	// Spool two events while the SIEM is "down".
 	tr := true

--- a/internal/core/audit_checkpoint.go
+++ b/internal/core/audit_checkpoint.go
@@ -436,18 +436,37 @@ func (c *KeyorixCore) enforceAuditHighWater(ctx context.Context, v *storage.Audi
 	if err != nil {
 		return err
 	}
-	// A persistent mark that is absent or malformed (found=false, tampered=false) is a
-	// rollback attempt WHEN signed checkpoints exist: advanceAuditHighWater writes the
-	// mark with every checkpoint, so a checkpoint without a valid mark means the mark was
-	// deleted or garbled to erase the certified length so a truncation reads clean. (With
-	// no checkpoint we cannot attribute it — a fresh trail legitimately has neither.)
-	if !found && !tampered {
-		if exists, cerr := c.checkpointExists(ctx); cerr != nil {
-			return cerr
-		} else if exists {
+	exists, err := c.checkpointExists(ctx)
+	if err != nil {
+		return err
+	}
+	switch {
+	case !found && !tampered:
+		// A persistent mark that is absent or malformed (found=false, tampered=false) is
+		// a rollback attempt WHEN signed checkpoints exist: advanceAuditHighWater writes
+		// the mark with every checkpoint, so a checkpoint without a valid mark means the
+		// mark was deleted or garbled to erase the certified length so a truncation reads
+		// clean. (With no checkpoint we cannot attribute it — a fresh trail legitimately
+		// has neither.)
+		if exists {
 			tampered = true
 			reason = "audit high-water mark is missing or malformed although signed checkpoints exist — the anti-rollback mark was deleted or tampered with"
 		}
+	case found && !tampered && !exists:
+		// The inverse and equally load-bearing case (#215): a validly-signed mark proves
+		// a checkpoint was written and certified at some point in this install's history
+		// — advanceAuditHighWater only ever persists the mark alongside a successful
+		// checkpoint write, and nothing in this codebase ever prunes checkpoint rows. An
+		// empty audit_checkpoints table alongside a still-valid mark therefore means the
+		// checkpoint row(s) were deleted out from under it. The count-based floor
+		// comparison below cannot catch this alone when the event count wasn't also
+		// reduced — an attacker who tampers content and re-chains the hashes forward from
+		// the tamper point stays self-consistent and doesn't shrink the row count, only
+		// deleting audit_checkpoints defeats the head-hash comparison that would
+		// otherwise catch it. This mark/table cross-check closes that gap independent of
+		// count.
+		tampered = true
+		reason = "signed audit checkpoints existed previously (a valid high-water mark proves it) but the audit_checkpoints table is now empty — the checkpoint row(s) were deleted"
 	}
 	if found || tampered || floor > 0 {
 		v.Checkpointed = true

--- a/internal/core/audit_checkpoint_test.go
+++ b/internal/core/audit_checkpoint_test.go
@@ -542,3 +542,60 @@ func TestAuditCheckpoint_SignDeterministicAndBinding(t *testing.T) {
 		assert.False(t, c.checkpointSignatureValid(cp), "every signed field is bound")
 	}
 }
+
+// #215: a DB-write attacker who deletes every row from audit_checkpoints outright
+// (rather than tampering a checkpoint's content) must not be able to launder that as
+// "no checkpoint ever existed" — the still-valid, still-present high-water mark in
+// system_metadata proves a checkpoint WAS certified, so its absence now is a tamper
+// signal on its own, independent of whether the event count also regressed (a
+// content-tamper that re-chains the hashes forward keeps the row count unchanged).
+func TestAuditCheckpoint_DeletedCheckpointRowsIsTamper(t *testing.T) {
+	ctx := context.Background()
+	c, db := newCheckpointCore(t)
+	logEvents(t, c, 5)
+
+	_, written, err := c.WriteAuditCheckpoint(ctx)
+	require.NoError(t, err)
+	require.True(t, written)
+
+	v, err := c.VerifyAuditChain(ctx)
+	require.NoError(t, err)
+	require.True(t, v.Valid)
+
+	// Attacker deletes every audit_checkpoints row outright. The high-water mark
+	// (a different table) and the audit_events row count are both left untouched,
+	// so neither the old "missing mark" nor the count-regression check alone fires.
+	require.NoError(t, db.Exec("DELETE FROM audit_checkpoints").Error)
+
+	v, err = c.VerifyAuditChain(ctx)
+	require.NoError(t, err)
+	assert.False(t, v.Valid, "deleting all checkpoint rows while a valid high-water mark survives must be flagged as tamper, not read as a fresh install")
+	assert.True(t, v.Checkpointed)
+	assert.Contains(t, v.CheckpointReason, "checkpoint row(s) were deleted")
+
+	// A fresh (restarted) core with no in-memory watermark must catch it too — the
+	// signal comes from the persisted mark, not session state.
+	fresh := &KeyorixCore{storage: store.NewLocalStorage(db)}
+	fresh.SetAuditCheckpointKey(bytes.Repeat([]byte{0x7}, 32), "v1")
+	v, err = fresh.VerifyAuditChain(ctx)
+	require.NoError(t, err)
+	assert.False(t, v.Valid, "the deletion is caught after a restart too, via the persisted mark")
+	assert.Contains(t, v.CheckpointReason, "checkpoint row(s) were deleted")
+}
+
+// A genuinely fresh install — checkpointing available (signing key configured) but no
+// checkpoint has EVER been written, so no high-water mark exists either — must still
+// report clean. This is the legitimate case #215's fix must not break: absence of
+// both a checkpoint row and a high-water mark is normal for a brand-new trail, not
+// evidence of tampering.
+func TestAuditCheckpoint_FreshInstallNeverCheckpointedIsClean(t *testing.T) {
+	ctx := context.Background()
+	c, _ := newCheckpointCore(t)
+	logEvents(t, c, 5) // events flow before checkpointing is ever triggered
+
+	v, err := c.VerifyAuditChain(ctx)
+	require.NoError(t, err)
+	assert.True(t, v.Valid, "no checkpoint ever written is not tampering on a fresh trail")
+	assert.False(t, v.Checkpointed, "nothing has been certified yet")
+	assert.Empty(t, v.CheckpointReason)
+}

--- a/internal/core/secret_render.go
+++ b/internal/core/secret_render.go
@@ -17,10 +17,16 @@ import (
 // RenderSecretTemplate expands ${secret:<environment>/<name>} references in template
 // against the given project, returning the rendered output. A reference to an unknown
 // environment/secret, or one the user cannot read, fails the whole render (no partial
-// output). Values are never logged — but each resolved value IS recorded as a secret read
-// (audit event + access log), so a bulk render can't be used as a covert exfiltration
-// channel invisible to the audit trail and the anomaly detector. username/ip/ua attribute
-// the reads (pass-through from the request); empty is tolerated.
+// output). Values are never logged — but each DISTINCT resolved reference IS recorded as
+// a secret read (audit event + access log), so a bulk render can't be used as a covert
+// exfiltration channel invisible to the audit trail and the anomaly detector.
+// username/ip/ua attribute the reads (pass-through from the request); empty is
+// tolerated. Resolution is memoized per distinct reference within one render: the
+// underlying secrettemplate.Render engine calls the resolver once per OCCURRENCE, so
+// without memoizing here, the same reference repeated N times in one template would
+// both charge TryIncrementSecretReadCount N times (able to exhaust a shared
+// max_reads-limited secret's entire quota in a single request) and emit N audit/
+// access-log rows for what is really one read.
 func (c *KeyorixCore) RenderSecretTemplate(ctx context.Context, template string, projectID, userID uint, username, ip, ua string) (string, error) {
 	if projectID == 0 {
 		return "", fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "project ID is required")
@@ -38,7 +44,11 @@ func (c *KeyorixCore) RenderSecretTemplate(ctx context.Context, template string,
 		envByName[e.Name] = e.ID
 	}
 
+	resolved := make(map[string]string)
 	return secrettemplate.Render(template, func(ref string) (string, error) {
+		if val, ok := resolved[ref]; ok {
+			return val, nil
+		}
 		envName, secretName, err := splitRenderRef(ref)
 		if err != nil {
 			return "", err
@@ -57,9 +67,11 @@ func (c *KeyorixCore) RenderSecretTemplate(ctx context.Context, template string,
 		}
 		// Record the read like the single-secret read path does, so a bulk render is
 		// auditable and visible to the anomaly detector (detached so it survives the
-		// request and never blocks the render).
+		// request and never blocks the render). Only reached once per distinct
+		// reference (see the memoization check above).
 		go c.LogSecretReadWithProject(DetachedAuditContext(ctx), userID, secret.ID, projectID, username, secretName, ip, ua) // #nosec G118
-		return string(val), nil
+		resolved[ref] = string(val)
+		return resolved[ref], nil
 	})
 }
 

--- a/internal/core/secret_render_test.go
+++ b/internal/core/secret_render_test.go
@@ -108,3 +108,93 @@ func TestRenderSecretTemplate_RecordsReads(t *testing.T) {
 	}
 	assert.Positive(t, n, "a resolved render reference must produce a secret access-log row")
 }
+
+// #180 (secondary): referencing the SAME secret twice in one template must resolve and
+// charge max_reads only ONCE — not once per occurrence. A MaxReads=1 secret referenced
+// twice would fail on the second occurrence without memoization; with it, the second
+// occurrence reuses the first resolution's value and never re-decrements the quota.
+func TestRenderSecretTemplate_SameReferenceTwiceChargesMaxReadsOnce(t *testing.T) {
+	ctx := context.Background()
+	c, db, projectID := newRenderFixture(t)
+
+	one := 1
+	require.NoError(t, db.Model(&models.SecretNode{}).Where("name = ?", "db-password").Update("max_reads", &one).Error)
+
+	out, err := c.RenderSecretTemplate(ctx,
+		"A=${secret:production/db-password} B=${secret:production/db-password}",
+		projectID, 1, "owner", "10.0.0.1", "ua")
+	require.NoError(t, err, "a MaxReads=1 secret referenced twice in one template must not exhaust its quota on the second occurrence")
+	assert.Equal(t, "A=s3cr3t B=s3cr3t", out)
+
+	// A third, later render must now be refused — max_reads was charged exactly once,
+	// not twice, by the render above.
+	_, err = c.RenderSecretTemplate(ctx, "${secret:production/db-password}", projectID, 1, "owner", "10.0.0.1", "ua")
+	require.Error(t, err, "the quota was already spent by the single charge in the prior render")
+}
+
+// #180 (secondary): the access-log/audit record for a repeated reference is written only
+// once per distinct reference, not once per occurrence.
+func TestRenderSecretTemplate_SameReferenceTwiceLogsOnce(t *testing.T) {
+	ctx := context.Background()
+	c, db, projectID := newRenderFixture(t)
+
+	_, err := c.RenderSecretTemplate(ctx,
+		"A=${secret:production/db-password} B=${secret:production/db-password} C=${secret:production/db-password}",
+		projectID, 1, "owner", "10.0.0.1", "ua")
+	require.NoError(t, err)
+
+	// Reads are logged in a detached goroutine — poll briefly, then assert the count
+	// settles at exactly one row (not three).
+	var n int64
+	deadline := time.Now().Add(1 * time.Second)
+	for time.Now().Before(deadline) {
+		require.NoError(t, db.Model(&models.SecretAccessLog{}).Where("accessed_by = ?", "owner").Count(&n).Error)
+		if n > 0 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	time.Sleep(50 * time.Millisecond) // let any (incorrect) extra async writes land before asserting
+	require.NoError(t, db.Model(&models.SecretAccessLog{}).Where("accessed_by = ?", "owner").Count(&n).Error)
+	assert.Equal(t, int64(1), n, "the same reference occurring 3 times in one template must log exactly one read")
+}
+
+// Distinct references, by contrast, each produce their own access-log row.
+func TestRenderSecretTemplate_DistinctReferencesEachLogged(t *testing.T) {
+	ctx := context.Background()
+	c, db, projectID := newRenderFixture(t)
+
+	st := store.NewLocalStorage(db)
+	secret2, err := st.CreateSecret(ctx, &models.SecretNode{
+		Name: "api-key", ProjectID: projectID, EnvironmentID: firstEnvID(t, db, projectID), Type: "password",
+		OwnerID: 1, IsSecret: true, CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	})
+	require.NoError(t, err)
+	_, err = st.CreateSecretVersion(ctx, &models.SecretVersion{
+		SecretNodeID: secret2.ID, VersionNumber: 1, EncryptedValue: []byte("k3y"),
+	})
+	require.NoError(t, err)
+
+	_, err = c.RenderSecretTemplate(ctx,
+		"A=${secret:production/db-password} B=${secret:production/api-key}",
+		projectID, 1, "owner", "10.0.0.1", "ua")
+	require.NoError(t, err)
+
+	var n int64
+	deadline := time.Now().Add(1 * time.Second)
+	for time.Now().Before(deadline) {
+		require.NoError(t, db.Model(&models.SecretAccessLog{}).Where("accessed_by = ?", "owner").Count(&n).Error)
+		if n >= 2 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	assert.Equal(t, int64(2), n, "two distinct references must each produce their own access-log row")
+}
+
+func firstEnvID(t *testing.T, db *gorm.DB, projectID uint) uint {
+	t.Helper()
+	var env models.Environment
+	require.NoError(t, db.Where("project_id = ?", projectID).First(&env).Error)
+	return env.ID
+}

--- a/server/middleware/auth_test.go
+++ b/server/middleware/auth_test.go
@@ -569,6 +569,38 @@ func TestAuthentication_PATNetworkAllowlist(t *testing.T) {
 	assert.Equal(t, http.StatusOK, serve("10.9.9.9:443"), "in-range again after a deny")
 }
 
+// #210: a machine token revoked (or its identity suspended/revoked) must be rejected on
+// the VERY NEXT request, even within the 30s positive-cache window — not just once the
+// cache entry naturally expires. This exercises the same eviction primitive
+// (InvalidateTokenCacheByHash) that RevokeMachineToken/TransitionMachineIdentity's HTTP
+// handlers call with the credential's stored hash on revoke/suspend.
+func TestAuthentication_MachineTokenRevokedRejectedWithinCacheWindow(t *testing.T) {
+	mw := newTestAuthMiddleware()
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	serve := func() int {
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req.Header.Set("Authorization", "Bearer kx_machine_validtoken")
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		return w.Code
+	}
+
+	// First request: slow path validates and populates the 30s positive cache entry.
+	require.Equal(t, http.StatusOK, serve(), "a valid machine token authenticates")
+
+	// Revoke (or suspend) the machine token — this is what the HTTP handlers for
+	// RevokeMachineToken / TransitionMachineIdentity(suspended|revoked) do with the
+	// credential's stored SHA-256 hash, which is exactly the cache key.
+	InvalidateTokenCacheByHash(tokenKey("kx_machine_validtoken"))
+
+	// The VERY NEXT request, still well within validTokenTTL, must be rejected — not
+	// served from the now-stale positive cache entry.
+	assert.Equal(t, http.StatusUnauthorized, serve(), "a revoked machine token must be rejected immediately, not after the cache TTL expires")
+}
+
 // A token revoked WHILE a slow-path validation was in flight must not be resurrected by
 // that validation's positive cache write (the revocation-resurrection race).
 func TestCacheSetValidated_DropsResurrectionAfterRevoke(t *testing.T) {


### PR DESCRIPTION
## Summary

Addresses backlog findings #210, #215, #180 (all HIGH, audit/session integrity). Verified each against current code before implementing — two of the three were already substantially fixed by a prior round (PR #518); this PR closes what remained and adds the required regression tests for all three so the fixed behavior is pinned.

- **#210 — Machine-token revocation never invalidates the 30s auth-token cache.** Already fixed on `main` (PR #518, `harden(machine): evict the auth cache on machine-token revoke/suspend`): `RevokeMachineToken` returns the credential's hash and `TransitionMachineIdentity`'s HTTP handler evicts every credential's cache entry on suspend/revoke via `InvalidateTokenCacheByHash`. No further code change needed here — this PR adds the missing end-to-end regression test (populate cache → revoke → assert the very next request is rejected within the cache window), since only unit-level coverage existed before.

- **#215 — DB-write attacker defeats the audit hash-chain by deleting `audit_checkpoints` rows.** The existing high-water-mark mechanism (`system_metadata`, set once on first checkpoint write) already caught count-regression and "mark deleted while a checkpoint row still exists" attacks, but had a real remaining gap: an attacker who tampers `audit_events`, recomputes the forward hash chain to stay self-consistent (so the row count is unchanged), and then deletes **all** `audit_checkpoints` rows evaded detection — the mark (a separate table) survived untouched, so the count-based floor check passed and the deleted-checkpoint case read as "nothing ever certified." `enforceAuditHighWater` now also flags tamper when a valid signed high-water mark proves a checkpoint was written before but the `audit_checkpoints` table is currently empty, independent of whether the row count regressed. A genuinely fresh install (no checkpoint ever written, no mark) is unaffected and still reports clean.

- **#180 (secondary) — template render could exhaust a shared secret's `max_reads` quota in one request.** The primary audit-invisibility issue was already fixed on `main` (PR #518): `RenderSecretTemplate` calls `LogSecretReadWithProject` per resolved reference. The secondary bundled issue remained: `secrettemplate.Render` calls its resolver once per *occurrence*, so referencing the same secret N times in one template both re-charged `TryIncrementSecretReadCount` N times and wrote N redundant access-log rows. The resolver closure in `RenderSecretTemplate` now memoizes per distinct reference, so each is resolved, quota-charged, and audit-logged exactly once regardless of repeat occurrences.

## Test plan

- [x] `internal/core/audit_checkpoint_test.go`: `TestAuditCheckpoint_DeletedCheckpointRowsIsTamper` — write a checkpoint, delete all `audit_checkpoints` rows (mark + event count untouched), assert `VerifyAuditChain` now reports tamper (both same-session and after a simulated restart).
- [x] `internal/core/audit_checkpoint_test.go`: `TestAuditCheckpoint_FreshInstallNeverCheckpointedIsClean` — no checkpoint ever written still reports clean (guards against a false positive on first boot).
- [x] `internal/core/secret_render_test.go`: `TestRenderSecretTemplate_SameReferenceTwiceChargesMaxReadsOnce` — a `max_reads=1` secret referenced twice in one template succeeds (no double-charge) and a subsequent render is then correctly refused (quota was spent exactly once).
- [x] `internal/core/secret_render_test.go`: `TestRenderSecretTemplate_SameReferenceTwiceLogsOnce` / `TestRenderSecretTemplate_DistinctReferencesEachLogged` — one access-log row per distinct reference, not per occurrence.
- [x] `server/middleware/auth_test.go`: `TestAuthentication_MachineTokenRevokedRejectedWithinCacheWindow` — a machine token is rejected on the very next request after revoke, within the 30s cache window.
- [x] `go build ./...` clean
- [x] `go test ./...` full suite clean
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues
- [x] `golangci-lint run ./...` — 0 issues
- [x] `GOWORK=off go build -C operator ./...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)