### PR TITLE
harden(validation): CSV formula injection, mrkdwn escaping, blank-name bypass, name-length parity

### DIFF
--- a/internal/core/groups.go
+++ b/internal/core/groups.go
@@ -153,12 +153,18 @@ func (c *KeyorixCore) validateCreateGroupRequest(req *CreateGroupRequest) error 
 	if req.Name == "" {
 		return fmt.Errorf("group name is required")
 	}
+	if err := validateNameLength("group name", req.Name); err != nil {
+		return err
+	}
 	return validateDescription(req.Description)
 }
 
 func (c *KeyorixCore) validateUpdateGroupRequest(req *UpdateGroupRequest) error {
 	if req.ID == 0 {
 		return fmt.Errorf("group ID is required")
+	}
+	if err := validateNameLength("group name", req.Name); err != nil {
+		return err
 	}
 	return validateDescription(req.Description)
 }

--- a/internal/core/secret_description.go
+++ b/internal/core/secret_description.go
@@ -26,6 +26,24 @@ func validateDescription(description string) error {
 	return nil
 }
 
+// maxResourceNameLen bounds a resource Name (group, secret) at the core layer,
+// matching the HTTP-side `validate:"...,max=255"` cap (server/http/handlers/
+// groups_handler.go, secrets_crud.go). HTTP's byte-length semantics
+// (server/validation.Validator's `max` rule uses len(string), not rune count) are
+// mirrored here with len(name) so the two transports agree exactly. gRPC never runs
+// the HTTP validator, so without this the core layer was the only enforcement point
+// gRPC could inherit from — this closes that HTTP/gRPC parity gap (backlog #190).
+const maxResourceNameLen = 255
+
+// validateNameLength bounds a resource Name to maxResourceNameLen bytes, matching
+// HTTP's cap exactly. kind labels the error ("group name", "secret name", ...).
+func validateNameLength(kind, name string) error {
+	if len(name) > maxResourceNameLen {
+		return fmt.Errorf("%s exceeds %d characters", kind, maxResourceNameLen)
+	}
+	return nil
+}
+
 // SetSecretDescription sets (or clears, with "") the secret's description. The actor
 // must be able to write the secret. The note is trimmed and length-bounded. Audited.
 func (c *KeyorixCore) SetSecretDescription(ctx context.Context, actorID, secretID uint, description string) (*models.SecretNode, error) {

--- a/internal/core/secrets_validation.go
+++ b/internal/core/secrets_validation.go
@@ -13,6 +13,9 @@ func (c *KeyorixCore) validateCreateSecretRequest(req *CreateSecretRequest) erro
 	if req.Name == "" {
 		return fmt.Errorf("%s", i18n.T("LabelName", nil))
 	}
+	if err := validateNameLength("secret name", req.Name); err != nil {
+		return err
+	}
 	if len(req.Value) == 0 {
 		return fmt.Errorf("%s", i18n.T("LabelValue", nil))
 	}

--- a/internal/notifychan/chat.go
+++ b/internal/notifychan/chat.go
@@ -103,14 +103,29 @@ func (s *ChatSink) send(ctx context.Context, ev core.NotificationEvent) (retryab
 	return retryable, fmt.Errorf("%s webhook returned %s", s.cfg.Kind, strings.TrimSpace(resp.Status))
 }
 
+// mrkdwnEscaper neutralizes Slack/Teams mrkdwn control syntax before a user-
+// controllable string (secret name, project name, etc.) is interpolated into a chat
+// payload. Slack's incoming-webhook `text` field parses `<...>` as a link/mention
+// token (`<!channel>`, `<@USERID>`, `<https://evil.com|label>`) by default; escaping
+// `<`/`>` (and `&`, so the escape sequences themselves can't be re-interpreted) turns
+// any such sequence back into inert literal text. Teams' MessageCard fields share the
+// same HTML-ish escaping convention, so the same replacer is safe for both platforms.
+var mrkdwnEscaper = strings.NewReplacer("&", "&amp;", "<", "&lt;", ">", "&gt;")
+
+// escapeMrkdwn applies mrkdwnEscaper to a single string.
+func escapeMrkdwn(s string) string {
+	return mrkdwnEscaper.Replace(s)
+}
+
 // chatText renders the notification as a single plain-text message (no remote
-// resources), shared by both platforms.
+// resources), shared by both platforms. Title/Message may embed user-controllable
+// values (secret/project names), so both are mrkdwn-escaped before interpolation.
 func chatText(ev core.NotificationEvent) string {
 	var b strings.Builder
 	if ev.Title != "" {
-		fmt.Fprintf(&b, "*%s*\n", ev.Title)
+		fmt.Fprintf(&b, "*%s*\n", escapeMrkdwn(ev.Title))
 	}
-	b.WriteString(ev.Message)
+	b.WriteString(escapeMrkdwn(ev.Message))
 	if ev.Link != "" {
 		fmt.Fprintf(&b, "\n%s", ev.Link)
 	}
@@ -118,7 +133,9 @@ func chatText(ev core.NotificationEvent) string {
 }
 
 // chatPayload builds the platform-specific JSON body. Slack incoming webhooks take
-// {text}; Teams connectors take a MessageCard.
+// {text}; Teams connectors take a MessageCard. Every field sourced from
+// user-controllable data (Title, Message) is mrkdwn-escaped before it reaches either
+// payload shape.
 func chatPayload(kind ChatKind, ev core.NotificationEvent) interface{} {
 	text := chatText(ev)
 	if kind == ChatTeams {
@@ -129,9 +146,9 @@ func chatPayload(kind ChatKind, ev core.NotificationEvent) interface{} {
 		return map[string]interface{}{
 			"@type":    "MessageCard",
 			"@context": "https://schema.org/extensions",
-			"summary":  title,
-			"title":    title,
-			"text":     ev.Message,
+			"summary":  escapeMrkdwn(title),
+			"title":    escapeMrkdwn(title),
+			"text":     escapeMrkdwn(ev.Message),
 		}
 	}
 	return map[string]string{"text": text}

--- a/internal/notifychan/chat_test.go
+++ b/internal/notifychan/chat_test.go
@@ -64,6 +64,44 @@ func TestChatSink_TeamsPayload(t *testing.T) {
 	assert.Equal(t, "off-hours access by ada.", card["text"])
 }
 
+func TestChatSink_EscapesMrkdwnControlSequences(t *testing.T) {
+	// A secret/project name crafted to trigger a Slack mention-ping or a spoofed link
+	// must reach the payload as inert literal text, not live mrkdwn control syntax.
+	malicious := `<!channel> your secret <@U12345> was shared, click <https://evil.example/phish|here>`
+
+	t.Run("slack", func(t *testing.T) {
+		srv, get := captureChatServer(t)
+		sink, err := NewChat(ChatConfig{Kind: ChatSlack, WebhookURL: srv.URL})
+		require.NoError(t, err)
+		sink.Deliver(core.NotificationEvent{Title: "Secret shared with you", Message: malicious})
+		sink.Close()
+
+		var payload map[string]string
+		require.NoError(t, json.Unmarshal(get(), &payload))
+		assert.NotContains(t, payload["text"], "<!channel>", "must not carry a live @channel mention token")
+		assert.NotContains(t, payload["text"], "<@U12345>", "must not carry a live user-mention token")
+		assert.NotContains(t, payload["text"], "<https://evil.example/phish|here>", "must not carry a live spoofed-link token")
+		assert.Contains(t, payload["text"], "&lt;!channel&gt;")
+		assert.Contains(t, payload["text"], "&lt;@U12345&gt;")
+		assert.Contains(t, payload["text"], "&lt;https://evil.example/phish|here&gt;")
+	})
+
+	t.Run("teams", func(t *testing.T) {
+		srv, get := captureChatServer(t)
+		sink, err := NewChat(ChatConfig{Kind: ChatTeams, WebhookURL: srv.URL})
+		require.NoError(t, err)
+		sink.Deliver(core.NotificationEvent{Title: "Secret shared with you", Message: malicious})
+		sink.Close()
+
+		var card map[string]interface{}
+		require.NoError(t, json.Unmarshal(get(), &card))
+		text, _ := card["text"].(string)
+		assert.NotContains(t, text, "<!channel>")
+		assert.NotContains(t, text, "<@U12345>")
+		assert.Contains(t, text, "&lt;!channel&gt;")
+	})
+}
+
 func TestNewChat_Validation(t *testing.T) {
 	_, err := NewChat(ChatConfig{Kind: "irc", WebhookURL: "https://x"})
 	require.Error(t, err)

--- a/server/grpc/services/group_service.go
+++ b/server/grpc/services/group_service.go
@@ -204,7 +204,7 @@ func groupError(err error) error {
 		return status.Error(codes.NotFound, err.Error())
 	case strings.Contains(msg, "already exists") || strings.Contains(msg, "duplicate") || strings.Contains(msg, "in use"):
 		return status.Error(codes.AlreadyExists, err.Error())
-	case strings.Contains(msg, "required") || strings.Contains(msg, "invalid"):
+	case strings.Contains(msg, "required") || strings.Contains(msg, "invalid") || strings.Contains(msg, "exceeds"):
 		return status.Error(codes.InvalidArgument, err.Error())
 	case strings.Contains(msg, "permission") || strings.Contains(msg, "denied"):
 		return status.Error(codes.PermissionDenied, "access denied")

--- a/server/grpc/services/group_service_test.go
+++ b/server/grpc/services/group_service_test.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/keyorixhq/keyorix/internal/testhelper"
@@ -73,6 +74,26 @@ func TestGroupService_Members(t *testing.T) {
 	members, err = svc.GetGroupMembers(groupCtx(), &pb.GetGroupMembersRequest{Id: g.GetId()})
 	require.NoError(t, err)
 	assert.Empty(t, members.GetMembers())
+}
+
+// TestGroupService_NameLengthMatchesHTTP verifies gRPC rejects an over-255-char Name
+// with the same limit HTTP's `validate:"...,max=255"` tag enforces (backlog #190) —
+// the core-layer CreateGroup/UpdateGroup validation both transports call must reject
+// it, not just the (gRPC-bypassed) HTTP validator.
+func TestGroupService_NameLengthMatchesHTTP(t *testing.T) {
+	svc, _ := newGroupService(t)
+	tooLong := strings.Repeat("a", 256)
+
+	_, err := svc.CreateGroup(groupCtx(), &pb.CreateGroupRequest{Name: tooLong})
+	require.Error(t, err, "a 256-char group name must be rejected over gRPC, matching HTTP's 255-char cap")
+
+	// A name at exactly the limit is still accepted.
+	g, err := svc.CreateGroup(groupCtx(), &pb.CreateGroupRequest{Name: strings.Repeat("a", 255)})
+	require.NoError(t, err)
+
+	// UpdateGroup enforces the same cap.
+	_, err = svc.UpdateGroup(groupCtx(), &pb.UpdateGroupRequest{Id: g.GetId(), Name: tooLong})
+	require.Error(t, err, "a 256-char rename must be rejected over gRPC, matching HTTP's 255-char cap")
 }
 
 func TestGroupService_Unauthenticated(t *testing.T) {

--- a/server/grpc/services/secret_service.go
+++ b/server/grpc/services/secret_service.go
@@ -370,7 +370,7 @@ func mapSecretError(err error) error {
 		return status.Error(codes.AlreadyExists, "secret with this name already exists")
 	case strings.Contains(msg, "unknown rotation charset"), strings.Contains(msg, "out of range"),
 		strings.Contains(msg, "must be set together"), strings.Contains(msg, "unknown rotation backend"),
-		strings.Contains(msg, "no rotation backends"):
+		strings.Contains(msg, "no rotation backends"), strings.Contains(msg, "exceeds"):
 		return status.Error(codes.InvalidArgument, msg)
 	default:
 		return status.Error(codes.Internal, "secret operation failed")

--- a/server/grpc/services/secret_service_test.go
+++ b/server/grpc/services/secret_service_test.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -274,6 +275,27 @@ func TestSecretService_CreateSecret_Validation(t *testing.T) {
 	})
 	require.Error(t, err)
 	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
+// TestSecretService_CreateSecret_NameLengthMatchesHTTP verifies gRPC rejects an
+// over-255-char secret Name with the same limit HTTP's `validate:"...,max=255"` tag
+// enforces (backlog #190) — internal/core.CreateSecret, which both transports call,
+// must reject it rather than only the (gRPC-bypassed) HTTP validator.
+func TestSecretService_CreateSecret_NameLengthMatchesHTTP(t *testing.T) {
+	r := newSecretTestRig(t)
+	ctx := authCtx(1, "writer", "secrets.write", "secrets.read")
+
+	_, err := r.svc.CreateSecret(ctx, &pb.CreateSecretRequest{
+		Name: strings.Repeat("a", 256), Value: "v", ProjectId: 1, EnvironmentId: 1, Type: "password",
+	})
+	require.Error(t, err, "a 256-char secret name must be rejected over gRPC, matching HTTP's 255-char cap")
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+
+	// A name at exactly the limit is still accepted.
+	_, err = r.svc.CreateSecret(ctx, &pb.CreateSecretRequest{
+		Name: strings.Repeat("a", 255), Value: "v", ProjectId: 1, EnvironmentId: 1, Type: "password",
+	})
+	require.NoError(t, err)
 }
 
 func TestSecretService_GetSecret(t *testing.T) {

--- a/server/http/handlers/access_review_campaign_export_csv.go
+++ b/server/http/handlers/access_review_campaign_export_csv.go
@@ -72,18 +72,18 @@ func (h *CatalogHandler) ExportAccessReviewCampaignCSV(w http.ResponseWriter, r 
 	})
 	for _, it := range detail.Items {
 		_ = cw.Write([]string{
-			it.PrincipalType,
-			it.PrincipalName,
-			it.Email,
-			it.Source,
-			it.RoleName,
-			it.AccessLevel,
+			csvSafe(it.PrincipalType),
+			csvSafe(it.PrincipalName),
+			csvSafe(it.Email),
+			csvSafe(it.Source),
+			csvSafe(it.RoleName),
+			csvSafe(it.AccessLevel),
 			strconv.FormatUint(uint64(it.EnvironmentID), 10),
-			it.SecretName,
+			csvSafe(it.SecretName),
 			tstr(it.LastUsedAt),
-			it.Decision,
-			it.Reason,
-			deciderName[it.DecidedBy],
+			csvSafe(it.Decision),
+			csvSafe(it.Reason),
+			csvSafe(deciderName[it.DecidedBy]),
 			tstr(it.DecidedAt),
 		})
 	}

--- a/server/http/handlers/access_review_campaign_export_csv_test.go
+++ b/server/http/handlers/access_review_campaign_export_csv_test.go
@@ -40,6 +40,11 @@ func TestExportAccessReviewCampaignCSV(t *testing.T) {
 		Source: "role", RoleName: "viewer", AccessLevel: "read", EnvironmentID: 2,
 		Decision: "revoked", Reason: "left team", DecidedBy: 1, DecidedAt: &decided,
 	}).Error)
+	require.NoError(t, db.Create(&models.AccessReviewItem{
+		ID: 3, CampaignID: 5, PrincipalType: "user", PrincipalID: 12, PrincipalName: `=cmd|'/c calc'!A1`,
+		Source: "role", RoleName: "viewer", AccessLevel: "read", EnvironmentID: 2,
+		Decision: "attested", DecidedBy: 1, DecidedAt: &decided,
+	}).Error)
 
 	h := NewCatalogHandler(core.NewKeyorixCore(store.NewLocalStorage(db)))
 
@@ -56,7 +61,7 @@ func TestExportAccessReviewCampaignCSV(t *testing.T) {
 
 		body := w.Body.String()
 		lines := strings.Split(strings.TrimSpace(body), "\n")
-		require.Len(t, lines, 3, "header + two items")
+		require.Len(t, lines, 4, "header + three items")
 		assert.Equal(t, "principal_type,principal,email,source,role,access_level,environment_id,secret,last_used_at,decision,reason,decided_by,decided_at", strings.TrimSpace(lines[0]))
 		assert.Contains(t, body, "alice")
 		assert.Contains(t, body, "attested")
@@ -64,6 +69,21 @@ func TestExportAccessReviewCampaignCSV(t *testing.T) {
 		assert.Contains(t, body, "revoked")
 		assert.Contains(t, body, "left team")
 		assert.Contains(t, body, "auditor", "decider username is resolved")
+	})
+
+	t.Run("neutralizes a formula-injection payload in a user-controlled field", func(t *testing.T) {
+		req := withChiParams(withUserCtx(httptest.NewRequest(http.MethodGet,
+			"/api/v1/projects/1/access-review/campaigns/5/export.csv", nil)),
+			map[string]string{"id": "1", "campaignId": "5"})
+		w := httptest.NewRecorder()
+		h.ExportAccessReviewCampaignCSV(w, req)
+
+		require.Equal(t, http.StatusOK, w.Code)
+		body := w.Body.String()
+		// "bob"'s reason cell starts with plain text; verify the injected principal name
+		// carries a leading formula-trigger character defanged with a leading single quote.
+		assert.NotContains(t, body, "\n=cmd|'/c calc'!A1", "a raw leading-= cell must never reach the CSV body")
+		assert.Contains(t, body, "'=cmd|'/c calc'!A1", "formula-trigger prefix must be neutralized with a leading quote")
 	})
 
 	t.Run("requires a user context", func(t *testing.T) {

--- a/server/validation/validator.go
+++ b/server/validation/validator.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"regexp"
 	"strings"
+	"unicode"
 
 	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/utils/safeconv"
@@ -155,16 +156,32 @@ func (v *Validator) applyRule(fieldName string, field reflect.Value, ruleName, p
 		return v.validateNumeric(field)
 	case "oneof":
 		return v.validateOneOf(field, param)
+	case "identifier":
+		return v.validateIdentifier(field)
 	}
 
 	return nil
+}
+
+// isBlank reports whether s has no visible content once ordinary whitespace and
+// Unicode zero-width/format (Cf) and control (Cc) characters (e.g. U+200B ZERO WIDTH
+// SPACE) are disregarded. Used by isEmpty so a whitespace-only or zero-width-only
+// string doesn't pass a `required` check.
+func isBlank(s string) bool {
+	for _, r := range s {
+		if unicode.IsSpace(r) || unicode.Is(unicode.Cf, r) || unicode.Is(unicode.Cc, r) {
+			continue
+		}
+		return false
+	}
+	return true
 }
 
 // isEmpty checks if a field is empty
 func (v *Validator) isEmpty(field reflect.Value) bool {
 	switch field.Kind() {
 	case reflect.String:
-		return field.String() == ""
+		return isBlank(field.String())
 	case reflect.Slice, reflect.Map, reflect.Array:
 		return field.Len() == 0
 	case reflect.Pointer, reflect.Interface:
@@ -333,6 +350,35 @@ func (v *Validator) validateNumeric(field reflect.Value) error {
 	numericRegex := regexp.MustCompile(`^[0-9]+$`)
 	if !numericRegex.MatchString(str) {
 		return fmt.Errorf("%s: must contain only numeric characters", i18n.T("ErrorValidation", nil))
+	}
+
+	return nil
+}
+
+// identifierRegex matches a safe resource-identifier charset: letters, digits,
+// spaces, `-`, and `_`. Deliberately excludes punctuation with special meaning
+// elsewhere (CSV-formula triggers, path separators, shell/URL metacharacters) and
+// any character outside this allowlist, so it also rejects zero-width/homograph
+// characters that could otherwise render a name blank or visually deceptive.
+var identifierRegex = regexp.MustCompile(`^[a-zA-Z0-9 _-]+$`)
+
+// validateIdentifier validates that a string is a safe resource identifier: letters,
+// digits, spaces, `-`, `_` only (see identifierRegex). Opt-in via `validate:"identifier"`
+// for Name-like fields that should be restricted to a safe, unambiguous charset — not
+// applied globally, since some fields (e.g. free-form secret names) intentionally allow
+// a broader charset.
+func (v *Validator) validateIdentifier(field reflect.Value) error {
+	if field.Kind() != reflect.String {
+		return nil
+	}
+
+	str := field.String()
+	if str == "" {
+		return nil
+	}
+
+	if !identifierRegex.MatchString(str) {
+		return fmt.Errorf("%s: must contain only letters, digits, spaces, - or _", i18n.T("ErrorValidation", nil))
 	}
 
 	return nil

--- a/server/validation/validator_test.go
+++ b/server/validation/validator_test.go
@@ -45,6 +45,47 @@ func TestValidate_Required(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestValidate_Required_RejectsWhitespaceAndZeroWidthOnly(t *testing.T) {
+	type payload struct {
+		Name string `json:"name" validate:"required"`
+	}
+	v := NewValidator()
+
+	// Positive case: real content still passes.
+	require.NoError(t, v.Validate(payload{Name: "Payments"}))
+
+	for name, bad := range map[string]string{
+		"pure whitespace":      "   \t\n  ",
+		"zero-width space":     "\u200b\u200b",
+		"zero-width + spaces":  "  \u200b \u200b  ",
+		"non-breaking + ZWNBS": "\u00a0\ufeff",
+	} {
+		err := v.Validate(payload{Name: bad})
+		require.Error(t, err, name)
+	}
+}
+
+func TestValidate_Identifier(t *testing.T) {
+	type payload struct {
+		Name string `json:"name" validate:"omitempty,identifier"`
+	}
+	v := NewValidator()
+
+	for _, good := range []string{"", "Payments", "prod-db_01", "team 42"} {
+		require.NoError(t, v.Validate(payload{Name: good}), good)
+	}
+	zwsp := string(rune(0x200B)) // ZERO WIDTH SPACE
+	for _, bad := range []string{
+		"=cmd|'/c calc'!A1",
+		"name" + zwsp + "with" + zwsp + "zero" + zwsp + "width",
+		"path/traversal",
+		"<script>",
+		"semicolon;here",
+	} {
+		require.Error(t, v.Validate(payload{Name: bad}), bad)
+	}
+}
+
 func TestValidate_Omitempty_SkipsRemainingRules(t *testing.T) {
 	type payload struct {
 		Nickname string `json:"nickname" validate:"omitempty,min=3"`


### PR DESCRIPTION
## Summary

Fixes 4 MEDIUM backlog findings in the "input validation & injection hardening" bundle.

- **#148 — CSV formula injection in exports.** `SecretsInventoryCSV` already escaped its fields (fixed in a prior PR via the `csvSafe` helper). `AccessReviewCampaignExportCSV` did not — principal name, email, secret name, decision reason, etc. were written to the CSV with no leading-character escaping. A crafted value like `=cmd|'/c calc'!A1` would execute as a formula/macro when an admin later opened the export in Excel/Sheets/LibreOffice. Now every user-controllable field in that export runs through the existing `csvSafe` prefix-escaping helper.

- **#158 — Slack/Teams mrkdwn control-sequence injection.** `internal/notifychan/chat.go` interpolated `Title`/`Message` (which can carry a user-controlled secret/project name) directly into the Slack `text` field and the Teams `MessageCard`. Since Slack parses `<...>` as a mention/link token by default, a crafted name like `<!channel>` or `<https://evil.example/phish|here>` would render as a live channel-wide ping or a spoofed link in a message the recipient trusts as system-generated. Added an `escapeMrkdwn` helper (escapes `&`, `<`, `>`) applied to `Title`/`Message` before either payload is built.

- **#189 — `required` validator accepts whitespace-only / zero-width-only strings.** `server/validation.Validator`'s `required`/`isEmpty` check only tested `s == ""`, so a name made entirely of spaces or U+200B (zero-width space) passed as "provided." `isEmpty` now trims ordinary whitespace and strips Unicode zero-width/format (Cf) and control (Cc) runes before checking for content. Also added a reusable, **opt-in** `identifier` validation rule (`validate:"identifier"`) for Name-like fields that should be restricted to a safe charset (letters/digits/space/`-`/`_`) — available for future use, not force-applied to existing free-form Name fields (secret/group names intentionally allow a broader charset by default, per `DefaultSecretNamePolicy`).

- **#190 — HTTP enforces a 255-char Name cap; gRPC did not.** HTTP's `validate:"...,max=255"` tag on Group/Secret `Name` runs through `server/validation.Validator`, which gRPC never invokes. `internal/core.CreateGroup`/`UpdateGroup`/`CreateSecret` — the shared business-logic layer both transports call — had no length check at all, so a gRPC caller could create an effectively unbounded-length name. Added a `maxResourceNameLen` (255, byte-length, matching HTTP's semantics exactly) enforced in `internal/core`, which both transports now inherit. Also fixed `groupError`/`mapSecretError` (the gRPC error-code mappers) to surface this validation failure — and the pre-existing description/tag-length validation failures, which had the same latent gap — as `codes.InvalidArgument` instead of falling through to `codes.Internal`.

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./...` — clean (two unrelated pre-existing flakes reproduced in isolation against a clean tree and confirmed pre-existing/unrelated: `TestHTTPJWKSResolver_CapsKeyCount` in `internal/core`, and a cross-test-pollution flake in `internal/audit/siem`)
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues
- [x] `golangci-lint run ./...` — 0 issues
- [x] `GOWORK=off go build -C operator ./...` — clean
- [x] New/updated tests:
  - `TestExportAccessReviewCampaignCSV/neutralizes_a_formula-injection_payload...` (#148)
  - `TestChatSink_EscapesMrkdwnControlSequences` (#158)
  - `TestValidate_Required_RejectsWhitespaceAndZeroWidthOnly`, `TestValidate_Identifier` (#189)
  - `TestGroupService_NameLengthMatchesHTTP`, `TestSecretService_CreateSecret_NameLengthMatchesHTTP` (#190, request-level gRPC handler tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)