### PR TITLE
harden: CLI/credential hygiene fixes (#152/#164/#183/#206, MED)

### DIFF
--- a/internal/bundle/bundle.go
+++ b/internal/bundle/bundle.go
@@ -320,7 +320,7 @@ func process(r io.Reader, reg *trust.KeyRegistry, opts *extractOpts) (*Manifest,
 				return nil, err
 			}
 		}
-		if err := os.MkdirAll(opts.destDir, 0o750); err != nil {
+		if err := mkdirAllNoSymlink(opts.destDir, opts.destDir); err != nil {
 			return nil, fmt.Errorf("bundle: create destination: %w", err)
 		}
 	}
@@ -416,7 +416,7 @@ func streamComponent(tr io.Reader, comp Component, destDir string) error {
 			return err
 		}
 		finalPath = final
-		if err := os.MkdirAll(filepath.Dir(finalPath), 0o750); err != nil {
+		if err := mkdirAllNoSymlink(destDir, filepath.Dir(finalPath)); err != nil {
 			return fmt.Errorf("bundle: mkdir for %s: %w", comp.Path, err)
 		}
 		tmp, err = os.CreateTemp(filepath.Dir(finalPath), ".kxbundle-*")
@@ -452,6 +452,63 @@ func streamComponent(tr io.Reader, comp Component, destDir string) error {
 		if err := os.Rename(tmpPath, finalPath); err != nil {
 			cleanup()
 			return fmt.Errorf("bundle: stage %s: %w", comp.Path, err)
+		}
+	}
+	return nil
+}
+
+// mkdirAllNoSymlink creates dir (and any missing parents, down to and including root
+// itself) without ever traversing through an existing symlink. Unlike os.MkdirAll — which
+// happily walks through a symlink at any path component and treats it as "the directory
+// already exists" — this Lstats every component and refuses the moment one is a symlink.
+// That closes the classic insecure-staging-directory attack: a local attacker with write
+// access to the destination path pre-plants a symlink (e.g. "<dest>/images" pointing at
+// "/tmp/evil") before a legitimate operator runs a genuinely-signed bundle import; without
+// this check, extraction would follow the symlink and write trusted bundle contents outside
+// the intended staging tree. root is re-checked on every call (including when root == dir,
+// i.e. staging-root creation itself) so a pre-planted symlink AT the staging root's own path
+// is caught too, not just symlinks nested underneath it.
+func mkdirAllNoSymlink(root, dir string) error {
+	rootAbs, err := filepath.Abs(root)
+	if err != nil {
+		return fmt.Errorf("bundle: resolve staging root: %w", err)
+	}
+	dirAbs, err := filepath.Abs(dir)
+	if err != nil {
+		return fmt.Errorf("bundle: resolve target directory: %w", err)
+	}
+	rel, err := filepath.Rel(rootAbs, dirAbs)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return fmt.Errorf("bundle: refusing to create directory %q outside staging root %q", dir, root)
+	}
+
+	var parts []string
+	if rel != "." {
+		parts = strings.Split(filepath.ToSlash(rel), "/")
+	}
+	// Walk from the staging root's own path down to dir, one component at a time.
+	segments := append([]string{filepath.Base(rootAbs)}, parts...)
+	cur := filepath.Dir(rootAbs)
+	for _, part := range segments {
+		if part == "" {
+			continue
+		}
+		cur = filepath.Join(cur, part)
+		fi, statErr := os.Lstat(cur)
+		switch {
+		case statErr == nil:
+			if fi.Mode()&os.ModeSymlink != 0 {
+				return fmt.Errorf("bundle: refusing to follow pre-existing symlink at %q", cur)
+			}
+			if !fi.IsDir() {
+				return fmt.Errorf("bundle: %q exists and is not a directory", cur)
+			}
+		case os.IsNotExist(statErr):
+			if mkErr := os.Mkdir(cur, 0o750); mkErr != nil {
+				return fmt.Errorf("bundle: mkdir %q: %w", cur, mkErr)
+			}
+		default:
+			return fmt.Errorf("bundle: stat %q: %w", cur, statErr)
 		}
 	}
 	return nil

--- a/internal/bundle/bundle_test.go
+++ b/internal/bundle/bundle_test.go
@@ -394,6 +394,62 @@ func TestExtract_PersistedVersionBlocksDowngrade(t *testing.T) {
 	}
 }
 
+// TestExtract_RefusesPrePlantedSymlink proves the #152 fix: a symlink pre-planted at a path
+// the extraction process would otherwise write into (before the legitimate operator runs a
+// genuinely-signed bundle import) must be refused, not followed — the trusted bundle content
+// must never land outside the staging root.
+func TestExtract_RefusesPrePlantedSymlink(t *testing.T) {
+	raw, reg, _ := signedBundle(t, map[string]string{"images/keyorix-server.tar": "image-bytes"}, "v1.0.0", "update-2026", "")
+
+	dest := t.TempDir()
+	outside := t.TempDir()
+	// Pre-plant "<dest>/images" as a symlink pointing OUTSIDE the staging root, exactly the
+	// classic insecure-staging-directory precondition: an attacker with local write access to
+	// the destination path plants this before the legitimate import runs.
+	if err := os.Symlink(outside, filepath.Join(dest, "images")); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	if _, err := Extract(bytes.NewReader(raw), reg, dest, ""); err == nil {
+		t.Fatalf("Extract must refuse to follow a pre-planted symlink, got nil error")
+	}
+
+	// Nothing must have been written through the symlink into the outside directory.
+	entries, err := os.ReadDir(outside)
+	if err != nil {
+		t.Fatalf("readdir outside: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("bundle content escaped the staging root into %s: %v", outside, entries)
+	}
+}
+
+// TestExtract_RefusesSymlinkedStagingRoot proves the staging ROOT itself (not just a nested
+// component) is checked: if the operator-supplied --dest path has been pre-planted as a
+// symlink, Extract must refuse rather than stage trusted content through it.
+func TestExtract_RefusesSymlinkedStagingRoot(t *testing.T) {
+	raw, reg, _ := signedBundle(t, map[string]string{"images/a.tar": "x"}, "v1.0.0", "update-2026", "")
+
+	parent := t.TempDir()
+	outside := t.TempDir()
+	dest := filepath.Join(parent, "staging")
+	if err := os.Symlink(outside, dest); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	if _, err := Extract(bytes.NewReader(raw), reg, dest, ""); err == nil {
+		t.Fatalf("Extract must refuse a symlinked staging root, got nil error")
+	}
+
+	entries, err := os.ReadDir(outside)
+	if err != nil {
+		t.Fatalf("readdir outside: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("bundle content escaped through the symlinked root into %s: %v", outside, entries)
+	}
+}
+
 // assertDirEmpty fails if dir contains any regular file (temp files included), proving a
 // fail-closed Extract staged nothing.
 func assertDirEmpty(t *testing.T, dir string) {

--- a/internal/cli/config/cli_config.go
+++ b/internal/cli/config/cli_config.go
@@ -136,9 +136,20 @@ func SaveCLIConfig(config *CLIConfig, configPath string) error {
 		return fmt.Errorf("failed to marshal config: %w", err)
 	}
 
-	// Write file with secure permissions
+	// Write file with secure permissions. os.WriteFile's perm argument only applies when
+	// the file is newly CREATED — if configPath already exists (e.g. restored from a
+	// backup/dotfiles-sync/rsync that reset the mode to a looser umask-default like
+	// 0644, or written by an older client version predating secure-write conventions),
+	// O_TRUNC preserves its existing mode and every subsequent write — including a
+	// deliberate credential rotation — would silently keep writing the fresh plaintext
+	// API key into a loosely-permissioned file (#206). Explicitly Chmod after writing so
+	// the mode is tightened to 0600 regardless of whether the file was newly created or
+	// already existed with looser permissions.
 	if err := os.WriteFile(configPath, data, 0600); err != nil {
 		return fmt.Errorf("failed to write config file: %w", err)
+	}
+	if err := os.Chmod(configPath, 0600); err != nil { // #nosec G302 -- 0600 is the intended secure mode, not a weakening
+		return fmt.Errorf("failed to tighten config file permissions: %w", err)
 	}
 
 	return nil

--- a/internal/cli/config/cli_config_test.go
+++ b/internal/cli/config/cli_config_test.go
@@ -1,0 +1,56 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSaveCLIConfig_TightensExistingLoosePermissions pins the #206 fix: SaveCLIConfig
+// must tighten a pre-existing, loosely-permissioned config file to 0600 on the next save
+// — not just apply the mode on first creation. os.WriteFile's perm argument only applies
+// when the file is newly created (O_CREATE|O_TRUNC on an existing file preserves its
+// current mode bits), so without an explicit Chmod a config file inherited with a looser
+// mode (e.g. restored from a backup/dotfiles-sync/rsync, or written by an older client
+// version) would silently keep accepting writes — including a deliberate API-key
+// rotation — while remaining world/group readable.
+func TestSaveCLIConfig_TightensExistingLoosePermissions(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cli.yaml")
+
+	// Pre-plant the file with loose permissions, as if inherited from before this
+	// codebase adopted secure-write conventions.
+	require.NoError(t, os.WriteFile(path, []byte("mode: embedded\n"), 0644))
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0644), info.Mode().Perm(), "precondition: file starts loosely permissioned")
+
+	cfg := DefaultCLIConfig()
+	cfg.SetClientMode("https://keyorix.example", "rotated-api-key")
+	require.NoError(t, SaveCLIConfig(cfg, path))
+
+	info, err = os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0600), info.Mode().Perm(), "SaveCLIConfig must tighten a pre-existing loosely-permissioned file to 0600")
+
+	// The rotated content was actually written, not just the mode fixed.
+	loaded, err := LoadCLIConfig(path)
+	require.NoError(t, err)
+	assert.Equal(t, "rotated-api-key", loaded.Client.Auth.APIKey)
+}
+
+// TestSaveCLIConfig_NewFileGetsSecureMode confirms the unexceptional case still holds:
+// a brand-new config file is created directly with 0600.
+func TestSaveCLIConfig_NewFileGetsSecureMode(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cli.yaml")
+
+	require.NoError(t, SaveCLIConfig(DefaultCLIConfig(), path))
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0600), info.Mode().Perm())
+}

--- a/internal/cli/run/run.go
+++ b/internal/cli/run/run.go
@@ -17,9 +17,10 @@ import (
 )
 
 var (
-	runEnv     string
-	runProject string
-	runToken   string
+	runEnv      string
+	runProject  string
+	runToken    string
+	runCleanEnv bool
 )
 
 // RunCmd is the top-level 'run' command.
@@ -46,7 +47,16 @@ Authentication:
   • Session tokens written by 'keyorix auth login' are used automatically
     when the CLI is in client mode.
   • For service accounts / CI/CD, set KEYORIX_TOKEN (or --token) and
-    point the CLI at a server with 'keyorix connect' or KEYORIX_SERVER.`,
+    point the CLI at a server with 'keyorix connect' or KEYORIX_SERVER.
+
+Environment isolation:
+  • By default the child process inherits the FULL parent environment plus
+    the injected secrets, matching how most shells/tools behave.
+  • Pass --clean-env to start the child from ONLY the injected secrets
+    (plus a minimal PATH/HOME baseline) instead — use this when you don't
+    want the child to also see whatever else is already exported in the
+    invoking shell (a leftover token from a prior 'keyorix run', an
+    unrelated CI secret, etc.).`,
 	Args: cobra.MinimumNArgs(1),
 	RunE: runRun,
 }
@@ -55,6 +65,7 @@ func init() {
 	RunCmd.Flags().StringVar(&runEnv, "env", "development", "Environment name (e.g. production)")
 	RunCmd.Flags().StringVar(&runProject, "project", "", "Project name (overrides KEYORIX_PROJECT and active project)")
 	RunCmd.Flags().StringVar(&runToken, "token", "", "Service or session token (overrides KEYORIX_TOKEN env var)")
+	RunCmd.Flags().BoolVar(&runCleanEnv, "clean-env", false, "Start the child process with ONLY the injected secrets (plus a minimal PATH/HOME baseline) instead of the full inherited parent environment")
 }
 
 func runRun(cmd *cobra.Command, args []string) error {
@@ -90,7 +101,7 @@ func runRun(cmd *cobra.Command, args []string) error {
 		return fetchErr
 	}
 
-	return execChild(args, envVars)
+	return execChild(args, envVars, runCleanEnv)
 }
 
 // ── Embedded mode ─────────────────────────────────────────────────────────────
@@ -300,12 +311,16 @@ func toEnvKey(name string) string {
 	return b.String()
 }
 
-// execChild builds the child environment and executes the command.
-func execChild(args []string, extraEnv map[string]string) error {
-	childEnv := os.Environ()
-	for k, v := range extraEnv {
-		childEnv = append(childEnv, k+"="+v)
-	}
+// execChild builds the child environment and executes the command. By default (cleanEnv
+// false) the child inherits the FULL parent environment plus the injected secrets — the
+// long-standing, backward-compatible behavior. With cleanEnv true (--clean-env), the child
+// starts from ONLY the injected secrets plus a minimal PATH/HOME baseline so it can still
+// locate binaries and its home directory; every other variable already present in the
+// invoking shell (a leftover token from a prior `keyorix run`, an unrelated CI secret, etc.)
+// is NOT inherited. This is opt-in hardening for #164 — the root cause underlying the
+// already-fixed #103 KEYORIX_TOKEN-specific leak, broader than that one variable.
+func execChild(args []string, extraEnv map[string]string, cleanEnv bool) error {
+	childEnv := buildChildEnv(extraEnv, cleanEnv)
 
 	c := exec.Command(args[0], args[1:]...) // #nosec G204
 	c.Stdin = os.Stdin
@@ -321,4 +336,27 @@ func execChild(args []string, extraEnv map[string]string) error {
 		return fmt.Errorf("command failed: %w", err)
 	}
 	return nil
+}
+
+// buildChildEnv computes the environment slice passed to the child process. By default
+// (cleanEnv false) it starts from the FULL parent environment (os.Environ()) — the
+// long-standing, backward-compatible behavior. With cleanEnv true it starts from ONLY a
+// minimal PATH/HOME baseline (so the child can still locate binaries and its home
+// directory), NOT the rest of the parent environment. In both cases extraEnv (the injected
+// secrets) is appended last.
+func buildChildEnv(extraEnv map[string]string, cleanEnv bool) []string {
+	var childEnv []string
+	if cleanEnv {
+		for _, k := range []string{"PATH", "HOME"} {
+			if v, ok := os.LookupEnv(k); ok {
+				childEnv = append(childEnv, k+"="+v)
+			}
+		}
+	} else {
+		childEnv = os.Environ()
+	}
+	for k, v := range extraEnv {
+		childEnv = append(childEnv, k+"="+v)
+	}
+	return childEnv
 }

--- a/internal/cli/run/run_test.go
+++ b/internal/cli/run/run_test.go
@@ -1,0 +1,75 @@
+package run
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestBuildChildEnv_Default_InheritsFullParentEnv proves the long-standing, backward-
+// compatible default: with cleanEnv=false, the child gets the ENTIRE parent environment
+// (including variables unrelated to the injected secrets) plus the injected secrets.
+func TestBuildChildEnv_Default_InheritsFullParentEnv(t *testing.T) {
+	t.Setenv("KEYORIX_RUN_TEST_UNRELATED", "leftover-from-shell")
+
+	got := buildChildEnv(map[string]string{"DB_PASSWORD": "s3cr3t"}, false)
+
+	if !containsEnv(got, "KEYORIX_RUN_TEST_UNRELATED", "leftover-from-shell") {
+		t.Fatalf("default (no --clean-env) must still inherit unrelated parent vars, got: %v", got)
+	}
+	if !containsEnv(got, "DB_PASSWORD", "s3cr3t") {
+		t.Fatalf("injected secret missing from child env: %v", got)
+	}
+}
+
+// TestBuildChildEnv_CleanEnv_OnlyInjectedSecretsAndBaseline proves the #164 fix: with
+// cleanEnv=true (--clean-env), the child must NOT inherit unrelated parent environment
+// variables — only the explicitly injected secrets plus the minimal PATH/HOME baseline.
+func TestBuildChildEnv_CleanEnv_OnlyInjectedSecretsAndBaseline(t *testing.T) {
+	t.Setenv("KEYORIX_RUN_TEST_UNRELATED", "leftover-from-shell")
+	t.Setenv("KEYORIX_TOKEN", "should-not-leak-into-clean-child")
+
+	got := buildChildEnv(map[string]string{"DB_PASSWORD": "s3cr3t"}, true)
+
+	if containsEnv(got, "KEYORIX_RUN_TEST_UNRELATED", "leftover-from-shell") {
+		t.Fatalf("--clean-env must NOT inherit unrelated parent vars, got: %v", got)
+	}
+	if containsEnv(got, "KEYORIX_TOKEN", "should-not-leak-into-clean-child") {
+		t.Fatalf("--clean-env must NOT leak the parent's KEYORIX_TOKEN, got: %v", got)
+	}
+	if !containsEnv(got, "DB_PASSWORD", "s3cr3t") {
+		t.Fatalf("injected secret missing from clean child env: %v", got)
+	}
+
+	// Only PATH/HOME (if set) plus the one injected secret should be present.
+	for _, kv := range got {
+		key := strings.SplitN(kv, "=", 2)[0]
+		if key != "PATH" && key != "HOME" && key != "DB_PASSWORD" {
+			t.Fatalf("--clean-env leaked unexpected variable %q into child env: %v", key, got)
+		}
+	}
+}
+
+// TestBuildChildEnv_CleanEnv_BaselineMatchesParent confirms the minimal PATH/HOME baseline
+// is actually populated from the parent when clean-env is requested, so the child can still
+// locate binaries and its home directory.
+func TestBuildChildEnv_CleanEnv_BaselineMatchesParent(t *testing.T) {
+	wantPath, ok := os.LookupEnv("PATH")
+	if !ok {
+		t.Skip("PATH not set in test environment")
+	}
+	got := buildChildEnv(nil, true)
+	if !containsEnv(got, "PATH", wantPath) {
+		t.Fatalf("--clean-env must carry over the parent PATH baseline, got: %v", got)
+	}
+}
+
+func containsEnv(env []string, key, val string) bool {
+	target := key + "=" + val
+	for _, kv := range env {
+		if kv == target {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/core/setup_delivery.go
+++ b/internal/core/setup_delivery.go
@@ -55,29 +55,20 @@ type ProvisionSetupResult struct {
 // provisionSetupLink issues a setup token for the request's subject and delivers it
 // via the configured channel, returning the outcome. Requires a configured base URL
 // (a relative link is a misconfiguration, not a fallback).
+//
+// Always enforces the per-subject resend throttle (ADR-028 abuse section,
+// checkResendThrottle) — including on what looks like an "initial" provision, not just
+// explicit resends. Without this, a create→soft-delete→recreate loop against the same
+// email would bypass the throttle entirely: DeleteUser is an unconditional soft delete
+// and GetUserByEmail excludes soft-deleted rows, so the same address becomes immediately
+// reusable for another "initial" CreateUserWithSetupLink, each one an unthrottled SMTP
+// send against the org's own mail relay (#183). checkResendThrottle is keyed on the raw
+// email address in the setup-token store, independent of the (deletable/recreatable) user
+// row, so the count survives the delete. The count-then-act window (check, then
+// IssueSetupToken) is serialized under setupResendMu so a concurrent burst for the same
+// (purpose, email) can't all observe a sub-cap count before any of them writes the token
+// that would push the next check over the cap.
 func (c *KeyorixCore) provisionSetupLink(ctx context.Context, req IssueSetupTokenRequest, displayName, assignmentSummary string) (*ProvisionSetupResult, error) {
-	if c.setupBaseURL == "" {
-		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorValidation", nil), ErrSetupBaseURLRequired)
-	}
-	issued, err := c.IssueSetupToken(ctx, req)
-	if err != nil {
-		return nil, err
-	}
-	return c.deliverSetupLink(ctx, issued, req, displayName, assignmentSummary)
-}
-
-// provisionSetupLinkThrottled is provisionSetupLink with the per-subject resend
-// throttle (ADR-028 abuse section) applied atomically. The throttle check counts
-// recent tokens and then a new token is minted; without serialization two concurrent
-// resends for the same (purpose, email) both see a sub-cap count and both mint,
-// exceeding the daily cap / min-interval (the count-then-act is the only way past
-// the cap, so the race defeats the sole mail-bombing control). setupResendMu is held
-// across the check + IssueSetupToken so the count and the write that the next count
-// will see are one critical section. Delivery runs after the lock is released — a
-// slow SMTP send must not block every other resend. Used by every resend path; the
-// initial-provision callers (new account / new invitation) start from a zero count
-// and call provisionSetupLink directly.
-func (c *KeyorixCore) provisionSetupLinkThrottled(ctx context.Context, req IssueSetupTokenRequest, displayName, assignmentSummary string) (*ProvisionSetupResult, error) {
 	if c.setupBaseURL == "" {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorValidation", nil), ErrSetupBaseURLRequired)
 	}
@@ -92,6 +83,14 @@ func (c *KeyorixCore) provisionSetupLinkThrottled(ctx context.Context, req Issue
 		return nil, err
 	}
 	return c.deliverSetupLink(ctx, issued, req, displayName, assignmentSummary)
+}
+
+// provisionSetupLinkThrottled is now a thin alias for provisionSetupLink, kept as an
+// explicitly-named entry point at resend/reset call sites where the throttle is the whole
+// point — provisionSetupLink itself always enforces checkResendThrottle (see above), so
+// there is no longer a distinct unthrottled variant to be paired with.
+func (c *KeyorixCore) provisionSetupLinkThrottled(ctx context.Context, req IssueSetupTokenRequest, displayName, assignmentSummary string) (*ProvisionSetupResult, error) {
+	return c.provisionSetupLink(ctx, req, displayName, assignmentSummary)
 }
 
 // deliverSetupLink builds the absolute setup link from a freshly issued token and

--- a/internal/core/setup_delivery_test.go
+++ b/internal/core/setup_delivery_test.go
@@ -147,6 +147,8 @@ func TestCreateUserWithSetupLink(t *testing.T) {
 	ctx := context.Background()
 	ms := new(MockStorage)
 	c := NewKeyorixCore(ms)
+	fixed := time.Date(2026, 6, 5, 12, 0, 0, 0, time.UTC)
+	c.now = func() time.Time { return fixed }
 	c.SetCredentialDelivery(&fakeDeliverer{echoLink: true, result: delivery.DeliveryResult{Channel: delivery.ChannelOutOfBand}}, testBaseURL)
 	anyAudit(ms)
 
@@ -162,6 +164,10 @@ func TestCreateUserWithSetupLink(t *testing.T) {
 	})).Return(created, nil)
 	ms.On("AddPasswordHistory", ctx, uint(9), mock.AnythingOfType("string"), mock.Anything).Return(nil)
 	ms.On("GetRoleByName", ctx, "system_viewer").Return(nil, notFound())
+	// The initial provision is throttle-checked too (#183) — a fresh email with no
+	// prior tokens clears both checks.
+	ms.On("CountSetupTokensSince", ctx, SetupPurposeAccountSetup, "dana@acme.io", fixed.Add(-24*time.Hour)).Return(int64(0), nil)
+	ms.On("CountSetupTokensSince", ctx, SetupPurposeAccountSetup, "dana@acme.io", fixed.Add(-resendMinInterval)).Return(int64(0), nil)
 	ms.On("SupersedeActiveSetupTokens", ctx, SetupPurposeAccountSetup, "dana@acme.io").Return(nil)
 	ms.On("CreateSetupToken", ctx, mock.AnythingOfType("*models.SetupToken")).Return(&models.SetupToken{ID: 1}, nil)
 
@@ -173,6 +179,65 @@ func TestCreateUserWithSetupLink(t *testing.T) {
 	ms.AssertNotCalled(t, "UpdateUser", mock.Anything, mock.Anything)
 	require.NotNil(t, prov)
 	assert.True(t, strings.HasPrefix(prov.LinkForAdmin, testBaseURL+"/auth/setup/"+setupPrefix))
+}
+
+// TestCreateUserWithSetupLink_ThrottlesCreateDeleteRecreateLoop proves the #183 fix: a
+// create→soft-delete→recreate loop against the SAME email must be throttled on the Nth
+// attempt within the cooldown window, exactly like an explicit resend — because
+// DeleteUser is an unconditional soft delete and GetUserByEmail excludes soft-deleted
+// rows, the email is immediately reusable for another CreateUserWithSetupLink call, and
+// without this fix each such "recreate" would look like a fresh, unthrottled initial
+// provision and send another email with no cooldown and no daily cap.
+func TestCreateUserWithSetupLink_ThrottlesCreateDeleteRecreateLoop(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	ctx := context.Background()
+	ms := new(MockStorage)
+	c := NewKeyorixCore(ms)
+	fixed := time.Date(2026, 6, 5, 12, 0, 0, 0, time.UTC)
+	c.now = func() time.Time { return fixed }
+	c.SetCredentialDelivery(&fakeDeliverer{echoLink: true, result: delivery.DeliveryResult{Channel: delivery.ChannelOutOfBand}}, testBaseURL)
+	anyAudit(ms)
+
+	notFound := func() error { return assertNotFoundErr() }
+	req := &CreateUserRequest{Username: "dana", Email: "dana@acme.io", DisplayName: "Dana"}
+
+	// First create→provision succeeds (the recreated user gets a fresh row/ID after the
+	// prior one was soft-deleted, but the email — and so the throttle key — is the same).
+	ms.On("GetUserByUsername", ctx, "dana").Return(nil, notFound())
+	ms.On("GetUserByEmail", ctx, "dana@acme.io").Return(nil, notFound())
+	ms.On("CreateUser", ctx, mock.MatchedBy(func(u *models.User) bool {
+		return u.AccountState == AccountPendingFirstLogin
+	})).Return(&models.User{ID: 20, Username: "dana", Email: "dana@acme.io", AccountState: AccountPendingFirstLogin}, nil).Once()
+	ms.On("AddPasswordHistory", ctx, uint(20), mock.AnythingOfType("string"), mock.Anything).Return(nil).Once()
+	ms.On("GetRoleByName", ctx, "system_viewer").Return(nil, notFound())
+	ms.On("CountSetupTokensSince", ctx, SetupPurposeAccountSetup, "dana@acme.io", fixed.Add(-24*time.Hour)).Return(int64(0), nil).Once()
+	ms.On("CountSetupTokensSince", ctx, SetupPurposeAccountSetup, "dana@acme.io", fixed.Add(-resendMinInterval)).Return(int64(0), nil).Once()
+	ms.On("SupersedeActiveSetupTokens", ctx, SetupPurposeAccountSetup, "dana@acme.io").Return(nil).Once()
+	ms.On("CreateSetupToken", ctx, mock.AnythingOfType("*models.SetupToken")).Return(&models.SetupToken{ID: 1}, nil).Once()
+
+	_, prov1, err := c.CreateUserWithSetupLink(ctx, req, 7)
+	require.NoError(t, err)
+	require.NotNil(t, prov1)
+
+	// Simulate the soft-delete: the recreated account is a "new" user again as far as
+	// CreateUser's own checks are concerned (GetUserByUsername/Email miss again), but the
+	// setup-token store — keyed on the raw email, independent of the user row — now
+	// reflects the one token just issued, so the throttle must fire on this second attempt.
+	ms.On("GetUserByUsername", ctx, "dana").Return(nil, notFound())
+	ms.On("GetUserByEmail", ctx, "dana@acme.io").Return(nil, notFound())
+	ms.On("CreateUser", ctx, mock.MatchedBy(func(u *models.User) bool {
+		return u.AccountState == AccountPendingFirstLogin
+	})).Return(&models.User{ID: 21, Username: "dana", Email: "dana@acme.io", AccountState: AccountPendingFirstLogin}, nil).Once()
+	ms.On("AddPasswordHistory", ctx, uint(21), mock.AnythingOfType("string"), mock.Anything).Return(nil).Once()
+	ms.On("CountSetupTokensSince", ctx, SetupPurposeAccountSetup, "dana@acme.io", fixed.Add(-24*time.Hour)).Return(int64(1), nil).Once()
+	ms.On("CountSetupTokensSince", ctx, SetupPurposeAccountSetup, "dana@acme.io", fixed.Add(-resendMinInterval)).Return(int64(1), nil).Once()
+
+	_, prov2, err := c.CreateUserWithSetupLink(ctx, req, 7)
+	require.Error(t, err, "the recreate must be throttled by the still-live min-interval window")
+	assert.Contains(t, err.Error(), "wait")
+	assert.Nil(t, prov2)
+	// Throttled means no second setup token was minted and no second email sent.
+	ms.AssertNumberOfCalls(t, "CreateSetupToken", 1)
 }
 
 func TestCreateUserWithOneTimePassword(t *testing.T) {

--- a/internal/securefiles/securefiles.go
+++ b/internal/securefiles/securefiles.go
@@ -97,7 +97,12 @@ func resolveInside(baseDir, path string) (string, error) {
 }
 
 // SecureWriteFile writes data to filepath.Join(baseDir, path), validating
-// that the resolved path remains inside baseDir.
+// that the resolved path remains inside baseDir. The file mode is enforced even if the
+// file pre-existed with a looser mode (#206): OpenFile's perm argument only applies to
+// NEW files (a Go/POSIX gotcha — O_CREATE|O_TRUNC on an EXISTING file preserves its
+// current mode bits), so a file restored from a backup/dotfiles-sync/rsync with a loose
+// mode (e.g. umask-default 0644) would otherwise silently keep accepting secure writes
+// without ever being tightened. An explicit Chmod after open closes that gap.
 func SecureWriteFile(baseDir, path string, data []byte, perm os.FileMode) error {
 	cleanPath, err := resolveInside(baseDir, path)
 	if err != nil {
@@ -110,6 +115,11 @@ func SecureWriteFile(baseDir, path string, data []byte, perm os.FileMode) error 
 	f, err := os.OpenFile(cleanPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC|syscall.O_NOFOLLOW, perm) // #nosec G304 -- cleanPath validated inside baseDir by resolveInside
 	if err != nil {
 		return err
+	}
+	// O_TRUNC keeps a pre-existing file's mode; force the intended perms (see doc comment).
+	if cerr := f.Chmod(perm); cerr != nil {
+		_ = f.Close()
+		return cerr
 	}
 	if _, werr := f.Write(data); werr != nil {
 		_ = f.Close()

--- a/internal/securefiles/securefiles_test.go
+++ b/internal/securefiles/securefiles_test.go
@@ -61,6 +61,24 @@ func TestSecureWriteFileSyncRoundTripAndPerms(t *testing.T) {
 	assert.Equal(t, want, got)
 }
 
+// TestSecureWriteFileEnforcesPermsOnExistingFile pins the #206 fix: a pre-existing file
+// with looser perms (e.g. inherited from a backup/dotfiles-sync/rsync, or an older client
+// version predating secure-write conventions) must be tightened to the requested mode on
+// the next SecureWriteFile call — O_TRUNC alone preserves the old mode; the explicit
+// Chmod fixes it, mirroring SecureWriteFileSync's already-correct pattern.
+func TestSecureWriteFileEnforcesPermsOnExistingFile(t *testing.T) {
+	base := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(base, "cfg.yaml"), []byte("old"), 0644))
+	require.NoError(t, SecureWriteFile(base, "cfg.yaml", []byte("new"), 0600))
+
+	info, err := os.Stat(filepath.Join(base, "cfg.yaml"))
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0600), info.Mode().Perm())
+	got, err := SafeReadFile(base, "cfg.yaml")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("new"), got)
+}
+
 func TestSecureWriteFileSyncEnforcesPermsOnExistingFile(t *testing.T) {
 	base := t.TempDir()
 	// A pre-existing file with looser perms must be tightened to the requested mode


### PR DESCRIPTION
## Summary

Fixes five MED-severity findings from the ongoing adversarial security-hardening campaign (backlog: `docs/security/HARDENING-BACKLOG.md` on `security/hardening-backlog`), grouped as "CLI/credential hygiene":

- **#152 — Bundle extraction follows a pre-planted symlink in the staging directory.** `internal/bundle/bundle.go`'s `process`/`streamComponent` used `os.MkdirAll` to create staging directories, which happily walks through an existing symlink. A local attacker with write access to the destination path could pre-plant a symlink (e.g. `<dest>/images -> /tmp/evil`) before a legitimate `bundle import`, redirecting trusted, signature-verified content outside the staging tree. Added `mkdirAllNoSymlink`, which `os.Lstat`s every path component (including the staging root itself) and refuses to create through/over an existing symlink.

- **#164 — `keyorix run` injects secrets into the FULL inherited parent environment.** `internal/cli/run/run.go` built the child environment from `os.Environ()` plus the injected secrets, so the child also inherited every other sensitive variable already present in the invoking shell (root cause underlying the already-fixed #103 `KEYORIX_TOKEN`-specific leak). Added an opt-in `--clean-env` flag that starts the child from only the injected secrets plus a minimal PATH/HOME baseline. Default behavior (full inheritance) is unchanged.

- **#171 — Admin-created users bypass password-policy validation.** Verified against current code: already fixed on `main` by PR #518 (`buildUserForCreate` now calls `c.passwordPolicy.Validate` before hashing, with a regression test in `internal/core/users_password_policy_test.go`). No further change needed.

- **#183 — Unthrottled SMTP-send loop via create→soft-delete→recreate bypasses the ADR-028 resend throttle.** `CreateUserWithSetupLink` never called `checkResendThrottle`, so a `users.write` holder could `POST /users` → `DELETE /users/{id}` → `POST /users` in a loop against the same email with no cooldown or daily cap (soft-delete + `GetUserByEmail`'s `First()` exclusion make the email immediately reusable). Moved the throttle check into the shared `provisionSetupLink` helper (used by both the initial-provision and resend/reset paths), keyed on the raw email address independent of the deletable user row.

- **#206 — `SaveCLIConfig`'s plaintext store never tightens permissions on a pre-existing loosely-permissioned file.** Confirmed the gap: `os.WriteFile`'s `perm` argument only applies on file *creation* — an existing file (e.g. inherited from a backup/dotfiles-sync/rsync with a looser umask-default mode, or written by an older client) keeps its old mode across subsequent writes, including a deliberate API-key rotation. Added an explicit `Chmod` after write in both `SaveCLIConfig` (`internal/cli/config/cli_config.go`) and `securefiles.SecureWriteFile` (the shared helper `internal/config.Save` also relies on), mirroring the already-correct pattern in `SecureWriteFileSync`.

## Test plan

- [x] `internal/bundle`: new tests planting a symlink at a nested staging path and at the staging root itself — both refused, nothing written outside the root.
- [x] `internal/cli/run`: new tests proving `--clean-env` carries only the injected secrets (+ PATH/HOME baseline), while the default still inherits the full parent environment unchanged.
- [x] `internal/core`: existing `TestCreateUser_EnforcesPasswordPolicy` (#171, pre-existing) still passes; new `TestCreateUserWithSetupLink_ThrottlesCreateDeleteRecreateLoop` proves a create→delete→recreate attempt against the same email is throttled on the second call within the cooldown window.
- [x] `internal/securefiles` + `internal/cli/config`: new tests proving a pre-existing 0644 file is tightened to 0600 by `SecureWriteFile` and by `SaveCLIConfig`.
- [x] `go build ./...` clean
- [x] `go test ./...` clean (full suite)
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues
- [x] `golangci-lint run ./...` — 0 issues
- [x] `GOWORK=off go build -C operator ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)