### PR TITLE
fix(rbac): close admin-rank-ceiling gap on restore/impersonation (#147/#161/#165 HIGH)

### DIFF
--- a/internal/core/authz.go
+++ b/internal/core/authz.go
@@ -11,6 +11,7 @@ package core
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"strings"
 
@@ -269,6 +270,64 @@ func (c *KeyorixCore) roleSetContainsAdmin(ctx context.Context, roleIDs []uint) 
 		}
 	}
 	return false
+}
+
+// requireGlobalAdminToReinstateAdminRoles refuses to reinstate roleIDs unless
+// actorID is themselves a global admin, but ONLY when roleIDs actually contains an
+// admin-tier role — a non-admin role set passes untouched. Restoring a soft-deleted
+// principal (a group, a project, an environment) brings back EVERY role grant it
+// held atomically, in one step, with no per-role choice — unlike a single direct
+// grant (requireAuthorityForRole, invitations.go), the restore may reinstate
+// several roles at once, so the whole SET needs an aggregate ceiling check. Used
+// by group/project/environment restore (#147/#161): a principal holding only the
+// gating permission (roles.assign) — not admin authority itself — must not be able
+// to resurrect an admin-conferring grant that was soft-deleted out from under them
+// (e.g. an incident-response revocation), the same escalation-by-proxy shape
+// requireAuthorityForRole closes for direct grants.
+func (c *KeyorixCore) requireGlobalAdminToReinstateAdminRoles(ctx context.Context, actorID uint, roleIDs []uint, objectDesc string) error {
+	if !c.roleSetContainsAdmin(ctx, roleIDs) {
+		return nil
+	}
+	isAdmin, err := c.IsGlobalAdmin(ctx, actorID)
+	if err != nil {
+		return fmt.Errorf("failed to resolve actor authority: %w", err)
+	}
+	if !isAdmin {
+		return fmt.Errorf("only an administrator can restore a %s holding an administrative role grant", objectDesc)
+	}
+	return nil
+}
+
+// requireEqualOrGreaterAdminAuthority refuses when targetID holds an admin-tier
+// role — global OR project-scoped, direct OR group-inherited — at any scope where
+// actorID does not ALSO hold admin-tier authority. Unlike the single-scope
+// IsGlobalAdmin check, this discovers and checks EVERY scope the target actually
+// holds a grant at (via GetUserRoleScopes), so a target who is a project-scoped
+// project_admin — never itself flagged "global admin" — is still compared
+// correctly. Used by impersonation's admin-rank-ceiling check (#165): the action
+// string only customizes the error message (e.g. "impersonate").
+func (c *KeyorixCore) requireEqualOrGreaterAdminAuthority(ctx context.Context, actorID, targetID uint, action string) error {
+	scopes, err := c.storage.GetUserRoleScopes(ctx, targetID)
+	if err != nil {
+		return fmt.Errorf("failed to resolve target authority: %w", err)
+	}
+	for _, scope := range scopes {
+		targetRoleIDs, err := c.scopedRoleIDs(ctx, targetID, scope)
+		if err != nil {
+			return fmt.Errorf("failed to resolve target authority: %w", err)
+		}
+		if !c.roleSetContainsAdmin(ctx, targetRoleIDs) {
+			continue
+		}
+		actorRoleIDs, err := c.scopedRoleIDs(ctx, actorID, scope)
+		if err != nil {
+			return fmt.Errorf("failed to resolve actor authority: %w", err)
+		}
+		if !c.roleSetContainsAdmin(ctx, actorRoleIDs) {
+			return fmt.Errorf("cannot %s a user holding administrative authority you do not also hold", action)
+		}
+	}
+	return nil
 }
 
 // dedupeUints returns ids with duplicates removed, preserving first-seen order.

--- a/internal/core/catalog.go
+++ b/internal/core/catalog.go
@@ -100,7 +100,15 @@ func (c *KeyorixCore) DeleteProject(ctx context.Context, id uint, force bool) er
 // deletion-timestamp correlation), but the single generic event previously gave no
 // way to tell HOW MANY environments/secrets came back, so a DR-test or accidental
 // delete-then-undo left no forensic trail distinguishing "1 secret" from "200".
+//
+// #161: restoring reinstates every role bound to the project (any environment), so
+// before restoring, this checks that aggregate role SET against the actor's own
+// authority — the same treatment #147 applies to group restore. See
+// requireGlobalAdminToReinstateAdminRoles.
 func (c *KeyorixCore) RestoreProject(ctx context.Context, actorID, id uint) error {
+	if err := c.requireAuthorityToReinstateProjectRoles(ctx, actorID, id, "project"); err != nil {
+		return err
+	}
 	envCount, secretCount, err := c.storage.RestoreProject(ctx, id)
 	if err != nil {
 		return err
@@ -111,6 +119,23 @@ func (c *KeyorixCore) RestoreProject(ctx context.Context, actorID, id uint) erro
 	return nil
 }
 
+// requireAuthorityToReinstateProjectRoles collects every role bound directly to
+// projectID (any environment, user or group grant) and refuses if that set
+// contains an admin-tier role the actor cannot themselves match. Shared by
+// RestoreProject and RestoreEnvironment (an environment's role grants are a
+// subset of its project's).
+func (c *KeyorixCore) requireAuthorityToReinstateProjectRoles(ctx context.Context, actorID, projectID uint, objectDesc string) error {
+	assignments, err := c.storage.ListProjectRoleAssignments(ctx, projectID)
+	if err != nil {
+		return fmt.Errorf("failed to resolve project role grants: %w", err)
+	}
+	roleIDs := make([]uint, 0, len(assignments))
+	for _, a := range assignments {
+		roleIDs = append(roleIDs, a.RoleID)
+	}
+	return c.requireGlobalAdminToReinstateAdminRoles(ctx, actorID, roleIDs, objectDesc)
+}
+
 // DeleteEnvironment deletes an environment by ID.
 func (c *KeyorixCore) DeleteEnvironment(ctx context.Context, id uint) error {
 	return c.storage.DeleteEnvironment(ctx, id)
@@ -119,7 +144,13 @@ func (c *KeyorixCore) DeleteEnvironment(ctx context.Context, id uint) error {
 // RestoreEnvironment clears the soft-delete on an environment, scoped to
 // projectID so a caller authorized for one project cannot restore another's.
 // actorID is the acting admin (0 = none). Audited as environment.restored.
+//
+// #161: see RestoreProject — the same aggregate role-set ceiling check applies,
+// scoped to the owning project (the environment's own grants are a subset of it).
 func (c *KeyorixCore) RestoreEnvironment(ctx context.Context, actorID, projectID, id uint) error {
+	if err := c.requireAuthorityToReinstateProjectRoles(ctx, actorID, projectID, "environment"); err != nil {
+		return err
+	}
 	if err := c.storage.RestoreEnvironment(ctx, projectID, id); err != nil {
 		return err
 	}

--- a/internal/core/connect_rbac_test.go
+++ b/internal/core/connect_rbac_test.go
@@ -23,6 +23,7 @@ func connectRBACCore(t *testing.T, conns ...connect.Connector) (*KeyorixCore, *g
 		&models.Role{}, &models.UserRole{}, &models.MachineIdentityRole{},
 		&models.Group{}, &models.UserGroup{}, &models.GroupRole{},
 		&models.ConnectRefGrant{}, &models.AuditEvent{},
+		&models.Project{}, &models.Environment{},
 	))
 	c := &KeyorixCore{storage: store.NewLocalStorage(db)}
 	if len(conns) > 0 {

--- a/internal/core/groups.go
+++ b/internal/core/groups.go
@@ -93,9 +93,29 @@ func (c *KeyorixCore) DeleteGroup(ctx context.Context, actorID, id uint) error {
 
 // RestoreGroup reverses a soft-delete, bringing the group back with the role grants
 // and memberships it had at deletion. See CreateGroup for actorID semantics.
+//
+// #147: restoring reinstates EVERY role the group held atomically — potentially
+// several at once, including admin-tier ones — so before restoring, this checks the
+// group's whole role SET against the actor's own authority (requireGlobalAdmin
+// ToReinstateAdminRoles), the same ceiling roles.assign/requireAuthorityForRole is
+// meant to enforce on a direct grant. Without it, a principal holding only
+// roles.assign (the router's permission gate) who is themselves a member of an
+// admin-conferring group that was soft-deleted (e.g. an incident-response
+// revocation) could restore it and get their admin access back.
 func (c *KeyorixCore) RestoreGroup(ctx context.Context, actorID, id uint) error {
 	if id == 0 {
 		return fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "group ID is required")
+	}
+	roles, err := c.storage.GetGroupRoles(ctx, id)
+	if err != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	roleIDs := make([]uint, 0, len(roles))
+	for _, r := range roles {
+		roleIDs = append(roleIDs, r.ID)
+	}
+	if err := c.requireGlobalAdminToReinstateAdminRoles(ctx, actorID, roleIDs, "group"); err != nil {
+		return err
 	}
 	if err := c.storage.RestoreGroup(ctx, id); err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)

--- a/internal/core/groups_audit_test.go
+++ b/internal/core/groups_audit_test.go
@@ -23,7 +23,7 @@ func TestGroupCRUDAudit(t *testing.T) {
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
 	require.NoError(t, db.AutoMigrate(
-		&models.Group{}, &models.GroupRole{}, &models.UserGroup{}, &models.AuditEvent{},
+		&models.Group{}, &models.GroupRole{}, &models.UserGroup{}, &models.AuditEvent{}, &models.Role{},
 	))
 	c := &KeyorixCore{storage: store.NewLocalStorage(db)}
 	ctx := context.Background()

--- a/internal/core/impersonation.go
+++ b/internal/core/impersonation.go
@@ -59,15 +59,21 @@ func (c *KeyorixCore) StartImpersonation(ctx context.Context, adminID, targetID 
 	if !target.IsActive || AccountLoginBlocked(target.AccountState) {
 		return nil, nil, fmt.Errorf("cannot impersonate a suspended or inactive user")
 	}
-	// Prevent privilege escalation via impersonation: a caller who is not a global admin
-	// must not impersonate a global admin (which would confer install-wide super-user).
-	// Today users.impersonate is satisfiable only by global admins, so this is a no-op;
-	// it keeps impersonation from escalating if that permission is ever delegated to a
-	// lower-privileged (sub-admin) role.
-	if targetAdmin, _ := c.IsGlobalAdmin(ctx, targetID); targetAdmin {
-		if callerAdmin, _ := c.IsGlobalAdmin(ctx, adminID); !callerAdmin {
-			return nil, nil, fmt.Errorf("cannot impersonate an administrator")
-		}
+	// Admin-rank-ceiling check (#165): the impersonator must already hold authority
+	// equal to or greater than the target's, at EVERY scope the target holds it —
+	// not just the global scope a plain IsGlobalAdmin(target) check would catch.
+	// Without this, a principal holding only users.impersonate (a permission that
+	// by CONVENTION only global admins hold, but nothing enforces that as an
+	// invariant) could impersonate an actual admin — global OR project-scoped,
+	// direct OR group-inherited — then use that session to grant their own real
+	// account admin via the ordinary role-assignment endpoints; the privilege
+	// persists after the impersonation session ends. Today users.impersonate is
+	// satisfiable only by global admins by convention, so for the common case this
+	// check is a no-op; it keeps impersonation from escalating if that permission
+	// is ever delegated to a lower-privileged (sub-admin) role, or if the target is
+	// merely a project-scoped project_admin the older global-only check never saw.
+	if err := c.requireEqualOrGreaterAdminAuthority(ctx, adminID, targetID, "impersonate"); err != nil {
+		return nil, nil, err
 	}
 	token, err := generateSecureToken()
 	if err != nil {

--- a/internal/core/impersonation_test.go
+++ b/internal/core/impersonation_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 func newImpersonationCore(store *MockStorage) *KeyorixCore {
@@ -22,9 +23,9 @@ func TestStartImpersonation_Success(t *testing.T) {
 
 	store.On("GetUser", ctx, uint(1)).Return(&models.User{ID: 1, Username: "admin"}, nil)
 	store.On("GetUser", ctx, uint(2)).Return(&models.User{ID: 2, Username: "alice", IsActive: true}, nil)
-	// The target-rank guard checks whether the target is a global admin (it is not here).
-	store.On("GetUserRoleIDsAt", ctx, uint(2), mock.Anything).Return([]uint{}, nil)
-	store.On("GetUserGroupRoleIDsAt", ctx, uint(2), mock.Anything).Return([]uint{}, nil)
+	// The target-rank guard discovers every scope the target holds a role at (it
+	// holds none here), so no per-scope admin comparison ever runs.
+	store.On("GetUserRoleScopes", ctx, uint(2)).Return([]Scope{}, nil)
 	store.On("CreateSession", ctx, mock.MatchedBy(func(s *models.Session) bool {
 		return s.UserID == 2 && s.ImpersonatedBy != nil && *s.ImpersonatedBy == 1 &&
 			s.ImpersonationStartedAt != nil
@@ -91,15 +92,68 @@ func TestStartImpersonation_RejectsAdminTargetForNonAdminCaller(t *testing.T) {
 	store.On("GetUser", ctx, uint(2)).Return(&models.User{ID: 2, Username: "root", IsActive: true}, nil)
 	// Target (id 2) holds the admin role globally; caller (id 1) holds nothing.
 	store.On("GetRoleByName", ctx, mock.Anything).Return(&models.Role{ID: 7, Name: "admin"}, nil)
+	store.On("GetUserRoleScopes", ctx, uint(2)).Return([]Scope{{}}, nil)
 	store.On("GetUserRoleIDsAt", ctx, uint(2), mock.Anything).Return([]uint{7}, nil)
 	store.On("GetUserGroupRoleIDsAt", ctx, uint(2), mock.Anything).Return([]uint{}, nil)
 	store.On("GetUserRoleIDsAt", ctx, uint(1), mock.Anything).Return([]uint{}, nil)
 	store.On("GetUserGroupRoleIDsAt", ctx, uint(1), mock.Anything).Return([]uint{}, nil)
 	_, _, err := c.StartImpersonation(ctx, 1, 2, "")
-	if err == nil || !strings.Contains(err.Error(), "impersonate an administrator") {
+	if err == nil || !strings.Contains(err.Error(), "administrative authority") {
 		t.Fatalf("expected an admin-target rejection, got %v", err)
 	}
 	store.AssertNotCalled(t, "CreateSession", mock.Anything, mock.Anything)
+}
+
+// A non-admin caller cannot impersonate a target who holds an admin-tier role
+// scoped to a single PROJECT (never itself flagged "global admin") — the
+// scope-aware gap #165 closes beyond the older global-only check.
+func TestStartImpersonation_RejectsProjectScopedAdminTargetForNonAdminCaller(t *testing.T) {
+	store := new(MockStorage)
+	c := newImpersonationCore(store)
+	ctx := context.Background()
+	projScope := Scope{ProjectID: 7}
+	store.On("GetUser", ctx, uint(1)).Return(&models.User{ID: 1, Username: "helpdesk"}, nil)
+	store.On("GetUser", ctx, uint(2)).Return(&models.User{ID: 2, Username: "proj-admin", IsActive: true}, nil)
+	// Target (id 2) holds project_admin at project 7 only; caller (id 1) holds nothing.
+	store.On("GetRoleByName", ctx, mock.Anything).Return(&models.Role{ID: 8, Name: "project_admin"}, nil)
+	store.On("GetUserRoleScopes", ctx, uint(2)).Return([]Scope{projScope}, nil)
+	store.On("GetUserRoleIDsAt", ctx, uint(2), projScope).Return([]uint{8}, nil)
+	store.On("GetUserGroupRoleIDsAt", ctx, uint(2), projScope).Return([]uint{}, nil)
+	store.On("GetUserRoleIDsAt", ctx, uint(1), projScope).Return([]uint{}, nil)
+	store.On("GetUserGroupRoleIDsAt", ctx, uint(1), projScope).Return([]uint{}, nil)
+	_, _, err := c.StartImpersonation(ctx, 1, 2, "")
+	if err == nil || !strings.Contains(err.Error(), "administrative authority") {
+		t.Fatalf("expected a project-scoped admin-target rejection, got %v", err)
+	}
+	store.AssertNotCalled(t, "CreateSession", mock.Anything, mock.Anything)
+}
+
+// A caller who ALSO holds project_admin at the target's exact project scope may
+// impersonate a project-scoped admin target — the ceiling is satisfied, not
+// unconditionally blocked.
+func TestStartImpersonation_AllowsProjectScopedAdminTargetForSameScopeAdminCaller(t *testing.T) {
+	store := new(MockStorage)
+	c := newImpersonationCore(store)
+	ctx := context.Background()
+	projScope := Scope{ProjectID: 7}
+	store.On("GetUser", ctx, uint(1)).Return(&models.User{ID: 1, Username: "other-proj-admin"}, nil)
+	store.On("GetUser", ctx, uint(2)).Return(&models.User{ID: 2, Username: "proj-admin", IsActive: true}, nil)
+	store.On("GetRoleByName", ctx, mock.Anything).Return(&models.Role{ID: 8, Name: "project_admin"}, nil)
+	store.On("GetUserRoleScopes", ctx, uint(2)).Return([]Scope{projScope}, nil)
+	store.On("GetUserRoleIDsAt", ctx, uint(2), projScope).Return([]uint{8}, nil)
+	store.On("GetUserGroupRoleIDsAt", ctx, uint(2), projScope).Return([]uint{}, nil)
+	// Caller also holds project_admin at the SAME project scope.
+	store.On("GetUserRoleIDsAt", ctx, uint(1), projScope).Return([]uint{8}, nil)
+	store.On("GetUserGroupRoleIDsAt", ctx, uint(1), projScope).Return([]uint{}, nil)
+	store.On("CreateSession", ctx, mock.MatchedBy(func(s *models.Session) bool {
+		return s.UserID == 2 && s.ImpersonatedBy != nil && *s.ImpersonatedBy == 1
+	})).Return(&models.Session{ID: 100, UserID: 2, SessionToken: "tok2"}, nil)
+	store.On("LogAuditEvent", ctx, mock.Anything).Return(nil)
+
+	session, target, err := c.StartImpersonation(ctx, 1, 2, "")
+	require.NoError(t, err)
+	require.Equal(t, "tok2", session.SessionToken)
+	require.Equal(t, "proj-admin", target.Username)
 }
 
 func TestEndImpersonation_LogsDurationAndActionCount(t *testing.T) {

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -959,6 +959,14 @@ func (m *MockStorage) GetUserGroupRoleIDsAt(ctx context.Context, userID uint, sc
 	return args.Get(0).([]uint), args.Error(1)
 }
 
+func (m *MockStorage) GetUserRoleScopes(ctx context.Context, userID uint) ([]storage.Scope, error) {
+	args := m.Called(ctx, userID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]storage.Scope), args.Error(1)
+}
+
 func (m *MockStorage) RoleSetHasPermission(ctx context.Context, roleIDs []uint, permission string) (bool, error) {
 	args := m.Called(ctx, roleIDs, permission)
 	return args.Bool(0), args.Error(1)

--- a/internal/core/rbac_audit_test.go
+++ b/internal/core/rbac_audit_test.go
@@ -105,7 +105,7 @@ func TestRBACAuditTrail_PermissionToRole(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, db.AutoMigrate(
 		&models.AuditEvent{}, &models.Role{}, &models.Permission{}, &models.RolePermission{}, &models.UserRole{},
-		&models.Group{}, &models.UserGroup{}, &models.GroupRole{},
+		&models.Group{}, &models.UserGroup{}, &models.GroupRole{}, &models.Project{}, &models.Environment{},
 	))
 	require.NoError(t, db.Create(&models.Role{ID: 2, Name: "editor"}).Error)
 	require.NoError(t, db.Create(&models.Permission{ID: 8, Name: "secrets.write", Resource: "secrets", Action: "write"}).Error)

--- a/internal/core/rbac_management.go
+++ b/internal/core/rbac_management.go
@@ -68,10 +68,18 @@ func (c *KeyorixCore) AssignPermissionToRole(ctx context.Context, actorID, roleI
 	if err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorNotFound", nil), err)
 	}
-	if ok, aerr := c.Authorize(ctx, actorID, perm.Name, Scope{}); aerr != nil {
-		return fmt.Errorf("failed to resolve actor authority: %w", aerr)
-	} else if !ok {
-		return fmt.Errorf("cannot assign permission %q to a role: you do not hold it yourself", perm.Name)
+	// actorID 0 is the established "system" pseudo-actor used by startup/background
+	// processes that are never attacker-reachable (e.g. ReconcileRBACPermissions's
+	// additive, non-clobbering, once-per-boot top-up of newly-added canonical
+	// permissions — #293). Those callers have no role of their own to hold the
+	// permission being bundled, so the #169 self-permission check only applies to a
+	// real (non-zero) actor.
+	if actorID != 0 {
+		if ok, aerr := c.Authorize(ctx, actorID, perm.Name, Scope{}); aerr != nil {
+			return fmt.Errorf("failed to resolve actor authority: %w", aerr)
+		} else if !ok {
+			return fmt.Errorf("cannot assign permission %q to a role: you do not hold it yourself", perm.Name)
+		}
 	}
 	if err := c.storage.AssignPermissionToRole(ctx, roleID, permissionID); err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)

--- a/internal/core/rbac_management_test.go
+++ b/internal/core/rbac_management_test.go
@@ -19,6 +19,7 @@ func newRBACManagementCore(t *testing.T) (*KeyorixCore, *gorm.DB) {
 	require.NoError(t, db.AutoMigrate(
 		&models.AuditEvent{}, &models.Role{}, &models.Permission{}, &models.RolePermission{},
 		&models.UserRole{}, &models.Group{}, &models.UserGroup{}, &models.GroupRole{},
+		&models.Project{}, &models.Environment{},
 	))
 	return NewKeyorixCore(store.NewLocalStorage(db)), db
 }

--- a/internal/core/rbac_reconcile_test.go
+++ b/internal/core/rbac_reconcile_test.go
@@ -16,7 +16,9 @@ func newRBACReconcileCore(t *testing.T) (*KeyorixCore, *gorm.DB) {
 	t.Helper()
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
-	require.NoError(t, db.AutoMigrate(&models.Role{}, &models.Permission{}, &models.RolePermission{}, &models.AuditEvent{}))
+	require.NoError(t, db.AutoMigrate(&models.Role{}, &models.Permission{}, &models.RolePermission{}, &models.AuditEvent{},
+		&models.UserRole{}, &models.Project{}, &models.Environment{},
+		&models.Group{}, &models.UserGroup{}, &models.GroupRole{}))
 	return &KeyorixCore{storage: store.NewLocalStorage(db)}, db
 }
 

--- a/internal/core/restore_admin_ceiling_test.go
+++ b/internal/core/restore_admin_ceiling_test.go
@@ -1,0 +1,162 @@
+// restore_admin_ceiling_test.go — focused regression coverage for the
+// admin-rank-ceiling gap on restore paths (#147 group restore, #161
+// project/environment restore): restoring a soft-deleted principal reinstates
+// every role grant it held atomically, so the actor's own authority must be
+// checked against that whole role SET, not just gated on a permission string.
+package core
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func newRestoreCeilingCore(t *testing.T) (*KeyorixCore, *gorm.DB) {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.User{}, &models.Role{}, &models.Permission{}, &models.RolePermission{},
+		&models.UserRole{}, &models.Group{}, &models.UserGroup{}, &models.GroupRole{},
+		&models.Project{}, &models.Environment{}, &models.AuditEvent{},
+		&models.SecretNode{}, &models.SecretVersion{},
+	))
+	require.NoError(t, db.Create(&models.Role{ID: 1, Name: "admin"}).Error)
+	require.NoError(t, db.Create(&models.Role{ID: 2, Name: "viewer"}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "nonadmin", IsActive: true}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 2, Username: "globaladmin", IsActive: true}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 2, RoleID: 1}).Error) // user 2 = global admin
+	return NewKeyorixCore(store.NewLocalStorage(db)), db
+}
+
+// #147: a principal with no admin authority must be refused restoring a group
+// that holds an admin-tier role — restoring would hand that admin access right
+// back to any member of the group, including the restoring actor themselves.
+func TestRestoreGroup_RefusesNonAdminWhenGroupHoldsAdminRole(t *testing.T) {
+	c, db := newRestoreCeilingCore(t)
+	ctx := context.Background()
+
+	g, err := c.CreateGroup(ctx, 2, &CreateGroupRequest{Name: "platform-admins"})
+	require.NoError(t, err)
+	require.NoError(t, db.Create(&models.GroupRole{GroupID: g.ID, RoleID: 1}).Error) // admin role
+	require.NoError(t, c.DeleteGroup(ctx, 2, g.ID))
+
+	err = c.RestoreGroup(ctx, 1, g.ID) // actor 1 has no roles at all
+	require.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), "administrator"), "got: %v", err)
+
+	// The group must remain soft-deleted — the refusal is not cosmetic.
+	_, getErr := c.GetGroup(ctx, g.ID)
+	assert.Error(t, getErr, "a refused restore must not resurrect the group")
+}
+
+// #147: a global admin CAN restore a group holding an admin-tier role — the
+// ceiling check does not block legitimate administrators.
+func TestRestoreGroup_AllowsGlobalAdmin(t *testing.T) {
+	c, db := newRestoreCeilingCore(t)
+	ctx := context.Background()
+
+	g, err := c.CreateGroup(ctx, 2, &CreateGroupRequest{Name: "platform-admins"})
+	require.NoError(t, err)
+	require.NoError(t, db.Create(&models.GroupRole{GroupID: g.ID, RoleID: 1}).Error)
+	require.NoError(t, c.DeleteGroup(ctx, 2, g.ID))
+
+	require.NoError(t, c.RestoreGroup(ctx, 2, g.ID))
+	restored, err := c.GetGroup(ctx, g.ID)
+	require.NoError(t, err)
+	assert.Equal(t, g.ID, restored.ID)
+}
+
+// #147: a group holding only a NON-admin role needs no elevated authority to
+// restore — the ceiling check must not over-reach into ordinary restores.
+func TestRestoreGroup_AllowsNonAdminWhenGroupHoldsOnlyNonAdminRole(t *testing.T) {
+	c, db := newRestoreCeilingCore(t)
+	ctx := context.Background()
+
+	g, err := c.CreateGroup(ctx, 1, &CreateGroupRequest{Name: "viewers"})
+	require.NoError(t, err)
+	require.NoError(t, db.Create(&models.GroupRole{GroupID: g.ID, RoleID: 2}).Error) // viewer, non-admin
+	require.NoError(t, c.DeleteGroup(ctx, 1, g.ID))
+
+	require.NoError(t, c.RestoreGroup(ctx, 1, g.ID), "a non-admin role set needs no elevated authority to restore")
+}
+
+// #161: a principal with no admin authority must be refused restoring a
+// project that has a directly-bound admin-tier role — restoring reinstates
+// EVERY role bound to the project, potentially handing back admin access.
+func TestRestoreProject_RefusesNonAdminWhenProjectHoldsAdminRole(t *testing.T) {
+	c, db := newRestoreCeilingCore(t)
+	ctx := context.Background()
+
+	p, err := c.CreateProject(ctx, "proj", "")
+	require.NoError(t, err)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 99, RoleID: 1, ProjectID: p.ID}).Error) // admin at project scope
+	require.NoError(t, c.DeleteProject(ctx, p.ID, false))
+
+	err = c.RestoreProject(ctx, 1, p.ID) // actor 1 has no roles at all
+	require.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), "administrator"), "got: %v", err)
+}
+
+// #161: a global admin CAN restore a project holding an admin-tier role grant.
+func TestRestoreProject_AllowsGlobalAdmin(t *testing.T) {
+	c, db := newRestoreCeilingCore(t)
+	ctx := context.Background()
+
+	p, err := c.CreateProject(ctx, "proj", "")
+	require.NoError(t, err)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 99, RoleID: 1, ProjectID: p.ID}).Error)
+	require.NoError(t, c.DeleteProject(ctx, p.ID, false))
+
+	require.NoError(t, c.RestoreProject(ctx, 2, p.ID))
+}
+
+// #161: the same ceiling check applies to environment restore — a non-admin
+// actor is refused when the OWNING PROJECT carries an admin-tier role grant
+// (the environment's grants are a subset of the project's).
+func TestRestoreEnvironment_RefusesNonAdminWhenProjectHoldsAdminRole(t *testing.T) {
+	c, db := newRestoreCeilingCore(t)
+	ctx := context.Background()
+
+	p, err := c.CreateProject(ctx, "proj", "")
+	require.NoError(t, err)
+	// CreateProject seeds default environments; reuse one rather than creating a
+	// colliding duplicate.
+	envs, err := c.ListEnvironmentsByProject(ctx, p.ID)
+	require.NoError(t, err)
+	require.NotEmpty(t, envs)
+	env := envs[0]
+	require.NoError(t, db.Create(&models.UserRole{UserID: 99, RoleID: 1, ProjectID: p.ID}).Error) // admin at project scope
+	require.NoError(t, c.storage.DeleteEnvironment(ctx, env.ID))
+
+	err = c.RestoreEnvironment(ctx, 1, p.ID, env.ID) // actor 1 has no roles at all
+	require.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), "administrator"), "got: %v", err)
+}
+
+// #161: a global admin CAN restore an environment under a project holding an
+// admin-tier role grant.
+func TestRestoreEnvironment_AllowsGlobalAdmin(t *testing.T) {
+	c, db := newRestoreCeilingCore(t)
+	ctx := context.Background()
+
+	p, err := c.CreateProject(ctx, "proj", "")
+	require.NoError(t, err)
+	envs, err := c.ListEnvironmentsByProject(ctx, p.ID)
+	require.NoError(t, err)
+	require.NotEmpty(t, envs)
+	env := envs[0]
+	require.NoError(t, db.Create(&models.UserRole{UserID: 99, RoleID: 1, ProjectID: p.ID}).Error)
+	require.NoError(t, c.storage.DeleteEnvironment(ctx, env.ID))
+
+	require.NoError(t, c.RestoreEnvironment(ctx, 2, p.ID, env.ID))
+}

--- a/internal/core/restore_audit_test.go
+++ b/internal/core/restore_audit_test.go
@@ -22,6 +22,7 @@ func TestRestoreOperationsAudit(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, db.AutoMigrate(
 		&models.SecretNode{}, &models.SecretVersion{}, &models.Project{}, &models.Environment{}, &models.AuditEvent{},
+		&models.UserRole{}, &models.GroupRole{}, &models.UserGroup{}, &models.Role{}, &models.Group{},
 	))
 	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
 	ctx := context.Background()

--- a/internal/core/scim_guards_test.go
+++ b/internal/core/scim_guards_test.go
@@ -21,7 +21,7 @@ func newSCIMGuardCore(t *testing.T) (*KeyorixCore, *gorm.DB) {
 	require.NoError(t, db.AutoMigrate(
 		&models.User{}, &models.Role{}, &models.Permission{}, &models.RolePermission{},
 		&models.UserRole{}, &models.Group{}, &models.UserGroup{}, &models.GroupRole{},
-		&models.Session{}, &models.AuditEvent{},
+		&models.Session{}, &models.AuditEvent{}, &models.Project{}, &models.Environment{},
 	))
 	return NewKeyorixCore(store.NewLocalStorage(db)), db
 }

--- a/internal/core/secret_ownership_test.go
+++ b/internal/core/secret_ownership_test.go
@@ -43,7 +43,8 @@ func newOwnershipFixture(t *testing.T) (*KeyorixCore, uint) {
 	sqlDB.SetMaxOpenConns(1)
 	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.User{},
 		&models.Role{}, &models.Permission{}, &models.RolePermission{}, &models.UserRole{},
-		&models.Group{}, &models.UserGroup{}, &models.GroupRole{}))
+		&models.Group{}, &models.UserGroup{}, &models.GroupRole{},
+		&models.Project{}, &models.Environment{}))
 	for _, u := range []models.User{
 		{ID: 1, Username: "owner", Email: "o@test.com"},
 		{ID: 2, Username: "alice", Email: "a@test.com"},

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -368,6 +368,14 @@ type Storage interface {
 	// membership. A global/install-wide role (project_id = 0) does NOT count.
 	IsProjectMember(ctx context.Context, userID, projectID uint) (bool, error)
 	GetUserGroupRoleIDsAt(ctx context.Context, userID uint, scope Scope) ([]uint, error)
+	// GetUserRoleScopes returns the distinct (project, environment) scopes at which
+	// userID holds ANY role, directly or via a live (non-deleted) group. It is the
+	// scope-DISCOVERY step behind a scope-aware admin-rank-ceiling comparison
+	// (impersonation's #165 check): the caller doesn't know in advance which
+	// project a target might hold a project-scoped admin role in, so it must
+	// enumerate every scope the target actually has a grant at, then evaluate
+	// GetUserRoleIDsAt/GetUserGroupRoleIDsAt (via scopedRoleIDs) per scope.
+	GetUserRoleScopes(ctx context.Context, userID uint) ([]Scope, error)
 	RoleSetHasPermission(ctx context.Context, roleIDs []uint, permission string) (bool, error)
 	CheckPermission(ctx context.Context, userID uint, resource, action string) (bool, error)
 	GetUserPermissions(ctx context.Context, userID uint) ([]*Permission, error)

--- a/internal/storage/store/group_soft_delete_test.go
+++ b/internal/storage/store/group_soft_delete_test.go
@@ -22,6 +22,7 @@ func newGroupSoftDeleteStore(t *testing.T) *LocalStorage {
 	require.NoError(t, db.AutoMigrate(
 		&models.Group{}, &models.UserGroup{}, &models.GroupRole{}, &models.Role{},
 		&models.ShareRecord{}, &models.SecretNode{}, &models.User{},
+		&models.Project{}, &models.Environment{},
 	))
 	require.NoError(t, db.Create(&models.User{ID: 1, Username: "u1", Email: "u1@x.io"}).Error)
 	return NewLocalStorage(db)

--- a/internal/storage/store/local_rbac.go
+++ b/internal/storage/store/local_rbac.go
@@ -179,18 +179,79 @@ func (ls *LocalStorage) GetUserRoles(ctx context.Context, userID uint) ([]*model
 // GetUserRoleIDsAt returns the IDs of roles directly assigned to userID that
 // apply at the target scope: a stored assignment applies when its project is
 // global (0) or equal, and its environment is global (0) or equal.
+//
+// A scoped (non-zero) project_id/environment_id must ALSO NOT resolve to a
+// soft-deleted project/environment row — mirroring the groups.deleted_at join
+// GetUserGroupRoleIDsAt already applies for a group's own soft-delete state
+// (#161). Without it, a role bound directly to a project/environment ID keeps
+// authorizing regardless of that project's/environment's own soft-delete state,
+// so deletion doesn't work as an access boundary for directly-bound roles at all.
+// The LEFT JOINs (not INNER) are required because project_id/environment_id 0
+// means "global" and has no corresponding row to join against — the "= 0 OR ..."
+// clause short-circuits before the joined columns are consulted in that case; a
+// scoped project_id/environment_id with no matching row at all (the joined column
+// is SQL NULL) is treated as not-deleted, same as every other "unknown" scope ID
+// this query already tolerates.
 func (ls *LocalStorage) GetUserRoleIDsAt(ctx context.Context, userID uint, scope storage.Scope) ([]uint, error) {
 	var ids []uint
 	err := ls.db.WithContext(ctx).Model(&models.UserRole{}).
-		Where("user_id = ?", userID).
-		Where("project_id = 0 OR project_id = ?", scope.ProjectID).
-		Where("environment_id = 0 OR environment_id = ?", scope.EnvironmentID).
-		Where("expires_at IS NULL OR expires_at > ?", time.Now()).
-		Distinct().Pluck("role_id", &ids).Error
+		Joins("LEFT JOIN projects ON projects.id = user_roles.project_id").
+		Joins("LEFT JOIN environments ON environments.id = user_roles.environment_id").
+		Where("user_roles.user_id = ?", userID).
+		Where("user_roles.project_id = 0 OR (user_roles.project_id = ? AND projects.deleted_at IS NULL)", scope.ProjectID).
+		Where("user_roles.environment_id = 0 OR (user_roles.environment_id = ? AND environments.deleted_at IS NULL)", scope.EnvironmentID).
+		Where("user_roles.expires_at IS NULL OR user_roles.expires_at > ?", time.Now()).
+		Distinct().Pluck("user_roles.role_id", &ids).Error
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
 	}
 	return ids, nil
+}
+
+// GetUserRoleScopes returns the distinct (project, environment) scopes at which
+// userID holds ANY LIVE role, directly (user_roles) or via a live (non-deleted)
+// group (group_roles). See the storage.Storage interface doc for why this exists
+// (#165's scope-aware admin-rank-ceiling check).
+func (ls *LocalStorage) GetUserRoleScopes(ctx context.Context, userID uint) ([]storage.Scope, error) {
+	type scopeRow struct {
+		ProjectID     uint
+		EnvironmentID uint
+	}
+	seen := make(map[storage.Scope]struct{})
+
+	var direct []scopeRow
+	if err := ls.db.WithContext(ctx).Model(&models.UserRole{}).
+		Select("project_id, environment_id").
+		Where("user_id = ?", userID).
+		Where("expires_at IS NULL OR expires_at > ?", time.Now()).
+		Group("project_id, environment_id").
+		Scan(&direct).Error; err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	for _, r := range direct {
+		seen[storage.Scope{ProjectID: r.ProjectID, EnvironmentID: r.EnvironmentID}] = struct{}{}
+	}
+
+	var viaGroups []scopeRow
+	if err := ls.db.WithContext(ctx).Table("group_roles").
+		Select("group_roles.project_id AS project_id, group_roles.environment_id AS environment_id").
+		Joins("JOIN user_groups ON user_groups.group_id = group_roles.group_id").
+		Joins("JOIN groups ON groups.id = group_roles.group_id AND groups.deleted_at IS NULL").
+		Where("user_groups.user_id = ?", userID).
+		Where("group_roles.expires_at IS NULL OR group_roles.expires_at > ?", time.Now()).
+		Group("group_roles.project_id, group_roles.environment_id").
+		Scan(&viaGroups).Error; err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	for _, r := range viaGroups {
+		seen[storage.Scope{ProjectID: r.ProjectID, EnvironmentID: r.EnvironmentID}] = struct{}{}
+	}
+
+	scopes := make([]storage.Scope, 0, len(seen))
+	for s := range seen {
+		scopes = append(scopes, s)
+	}
+	return scopes, nil
 }
 
 // ListProjectRoleAssignments returns every role assignment scoped to the project
@@ -298,6 +359,11 @@ func (ls *LocalStorage) ListProjectMembers(ctx context.Context, projectID uint) 
 // GetUserGroupRoleIDsAt returns the IDs of roles userID inherits via group
 // membership that apply at the target scope (same scope-matching rule as
 // GetUserRoleIDsAt).
+// GetUserGroupRoleIDsAt: like GetUserRoleIDsAt but for group-inherited role
+// grants. A scoped (non-zero) project_id/environment_id must ALSO resolve to a
+// LIVE project/environment row, same as GetUserRoleIDsAt (#161) — a group-bound
+// role scoped to a since-soft-deleted project previously kept authorizing every
+// group member regardless of the project's own soft-delete state.
 func (ls *LocalStorage) GetUserGroupRoleIDsAt(ctx context.Context, userID uint, scope storage.Scope) ([]uint, error) {
 	var ids []uint
 	err := ls.db.WithContext(ctx).Table("group_roles").
@@ -305,9 +371,11 @@ func (ls *LocalStorage) GetUserGroupRoleIDsAt(ctx context.Context, userID uint, 
 		// A soft-deleted group confers no roles, even though its membership/grant rows
 		// are kept for restore — exclude deleted groups from authorization.
 		Joins("JOIN groups ON groups.id = group_roles.group_id AND groups.deleted_at IS NULL").
+		Joins("LEFT JOIN projects ON projects.id = group_roles.project_id").
+		Joins("LEFT JOIN environments ON environments.id = group_roles.environment_id").
 		Where("user_groups.user_id = ?", userID).
-		Where("group_roles.project_id = 0 OR group_roles.project_id = ?", scope.ProjectID).
-		Where("group_roles.environment_id = 0 OR group_roles.environment_id = ?", scope.EnvironmentID).
+		Where("group_roles.project_id = 0 OR (group_roles.project_id = ? AND projects.deleted_at IS NULL)", scope.ProjectID).
+		Where("group_roles.environment_id = 0 OR (group_roles.environment_id = ? AND environments.deleted_at IS NULL)", scope.EnvironmentID).
 		Where("group_roles.expires_at IS NULL OR group_roles.expires_at > ?", time.Now()).
 		Distinct().Pluck("group_roles.role_id", &ids).Error
 	if err != nil {

--- a/internal/storage/store/local_rbac_scope_test.go
+++ b/internal/storage/store/local_rbac_scope_test.go
@@ -27,6 +27,7 @@ func newRBACScopeTestStore(t *testing.T) *LocalStorage {
 	require.NoError(t, err)
 	require.NoError(t, db.AutoMigrate(
 		&models.UserRole{}, &models.GroupRole{}, &models.UserGroup{}, &models.Role{}, &models.Group{},
+		&models.Project{}, &models.Environment{},
 	))
 	return NewLocalStorage(db)
 }
@@ -74,6 +75,82 @@ func TestGetUserRoleIDsAt_ScopeBoundary(t *testing.T) {
 		require.NoError(t, err)
 		assert.Empty(t, got)
 	})
+}
+
+// #161: a role bound directly to a project must stop authorizing the moment the
+// project is soft-deleted, and resume once the project is restored — mirroring
+// how groups.deleted_at already gates group-inherited roles. Before this fix,
+// GetUserRoleIDsAt had no join against the projects table at all, so a
+// project-scoped role kept authorizing regardless of the project's own
+// soft-delete state.
+func TestGetUserRoleIDsAt_DeletedProjectStopsAuthorizing(t *testing.T) {
+	ls := newRBACScopeTestStore(t)
+	ctx := context.Background()
+	require.NoError(t, ls.db.Create(&models.Project{ID: 5, Name: "proj-5"}).Error)
+	require.NoError(t, ls.db.Create(&models.UserRole{UserID: 1, RoleID: 20, ProjectID: 5, EnvironmentID: 0}).Error)
+
+	got, err := ls.GetUserRoleIDsAt(ctx, 1, sc(5, 0))
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []uint{20}, got, "live project: the project-scoped grant authorizes")
+
+	require.NoError(t, ls.db.Delete(&models.Project{}, 5).Error)
+	got, err = ls.GetUserRoleIDsAt(ctx, 1, sc(5, 0))
+	require.NoError(t, err)
+	assert.Empty(t, got, "soft-deleted project: the grant must stop authorizing")
+
+	require.NoError(t, ls.db.Model(&models.Project{}).Unscoped().Where("id = ?", 5).Update("deleted_at", nil).Error)
+	got, err = ls.GetUserRoleIDsAt(ctx, 1, sc(5, 0))
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []uint{20}, got, "restored project: the grant authorizes again")
+}
+
+// #161: the same deleted_at gate applies to an ENVIRONMENT-scoped direct grant.
+func TestGetUserRoleIDsAt_DeletedEnvironmentStopsAuthorizing(t *testing.T) {
+	ls := newRBACScopeTestStore(t)
+	ctx := context.Background()
+	require.NoError(t, ls.db.Create(&models.Project{ID: 5, Name: "proj-5"}).Error)
+	require.NoError(t, ls.db.Create(&models.Environment{ID: 9, ProjectID: 5, Name: "prod"}).Error)
+	require.NoError(t, ls.db.Create(&models.UserRole{UserID: 1, RoleID: 30, ProjectID: 5, EnvironmentID: 9}).Error)
+
+	got, err := ls.GetUserRoleIDsAt(ctx, 1, sc(5, 9))
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []uint{30}, got, "live environment: the env-scoped grant authorizes")
+
+	require.NoError(t, ls.db.Delete(&models.Environment{}, 9).Error)
+	got, err = ls.GetUserRoleIDsAt(ctx, 1, sc(5, 9))
+	require.NoError(t, err)
+	assert.Empty(t, got, "soft-deleted environment: the grant must stop authorizing")
+
+	require.NoError(t, ls.db.Model(&models.Environment{}).Unscoped().Where("id = ?", 9).Update("deleted_at", nil).Error)
+	got, err = ls.GetUserRoleIDsAt(ctx, 1, sc(5, 9))
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []uint{30}, got, "restored environment: the grant authorizes again")
+}
+
+// #161: the missing join was ALSO present on the group-inherited path
+// (GetUserGroupRoleIDsAt) — a group-bound role scoped to a since-soft-deleted
+// project previously kept authorizing every group member.
+func TestGetUserGroupRoleIDsAt_DeletedProjectStopsAuthorizing(t *testing.T) {
+	ls := newRBACScopeTestStore(t)
+	ctx := context.Background()
+	require.NoError(t, ls.db.Create(&models.Project{ID: 5, Name: "proj-5"}).Error)
+	require.NoError(t, ls.db.Create(&models.Group{ID: 100, Name: "g100"}).Error)
+	require.NoError(t, ls.db.Create(&models.UserGroup{UserID: 1, GroupID: 100}).Error)
+	require.NoError(t, ls.db.Create(&models.GroupRole{GroupID: 100, RoleID: 50, ProjectID: 5, EnvironmentID: 0}).Error)
+
+	got, err := ls.GetUserGroupRoleIDsAt(ctx, 1, sc(5, 0))
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []uint{50}, got, "live project: the group's project-scoped grant authorizes")
+
+	require.NoError(t, ls.db.Delete(&models.Project{}, 5).Error)
+	got, err = ls.GetUserGroupRoleIDsAt(ctx, 1, sc(5, 0))
+	require.NoError(t, err)
+	assert.Empty(t, got, "soft-deleted project: the group's grant must stop authorizing")
+
+	require.NoError(t, ls.db.Model(&models.Project{}).Unscoped().Where("id = ?", 5).Update("deleted_at", nil).Error)
+	got, err = ls.GetUserGroupRoleIDsAt(ctx, 1, sc(5, 0))
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []uint{50}, got, "restored project: the group's grant authorizes again")
 }
 
 func TestGetUserRoleIDsExact_NoGlobalMatching(t *testing.T) {

--- a/internal/storage/store/remote_rbac.go
+++ b/internal/storage/store/remote_rbac.go
@@ -376,6 +376,11 @@ func (rs *RemoteStorage) GetUserGroupRoleIDsAt(_ context.Context, _ uint, _ stor
 	return nil, fmt.Errorf("not supported in remote storage")
 }
 
+// GetUserRoleScopes is a server-internal authorization primitive.
+func (rs *RemoteStorage) GetUserRoleScopes(_ context.Context, _ uint) ([]storage.Scope, error) {
+	return nil, fmt.Errorf("not supported in remote storage")
+}
+
 // RoleSetHasPermission is a server-internal authorization primitive.
 func (rs *RemoteStorage) RoleSetHasPermission(_ context.Context, _ []uint, _ string) (bool, error) {
 	return false, fmt.Errorf("not supported in remote storage")

--- a/server/grpc/services/audit_service_test.go
+++ b/server/grpc/services/audit_service_test.go
@@ -31,7 +31,8 @@ func newAuditService(t *testing.T) *AuditGRPCService {
 	require.NoError(t, err)
 	require.NoError(t, db.AutoMigrate(&models.AuditEvent{}, &models.User{},
 		&models.Role{}, &models.Permission{}, &models.RolePermission{}, &models.UserRole{},
-		&models.Group{}, &models.UserGroup{}, &models.GroupRole{}))
+		&models.Group{}, &models.UserGroup{}, &models.GroupRole{},
+		&models.Project{}, &models.Environment{}))
 	require.NoError(t, db.Create(&models.User{ID: 1, Username: "alice", Email: "alice@example.com"}).Error)
 	// User 1 = super_admin (global) so core.Authorize admits the admin-context
 	// tests; the denied test uses an ungranted user id.
@@ -125,7 +126,8 @@ func TestAuditService_GetRBACAuditLogs_ReturnsRoleChanges(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, db.AutoMigrate(&models.AuditEvent{}, &models.UserRole{},
 		&models.Role{}, &models.Permission{}, &models.RolePermission{},
-		&models.Group{}, &models.UserGroup{}, &models.GroupRole{}))
+		&models.Group{}, &models.UserGroup{}, &models.GroupRole{},
+		&models.Project{}, &models.Environment{}))
 	// auditCtx() is user 1 — grant it super_admin (global) so the audit.read check passes.
 	require.NoError(t, db.Create(&models.Role{ID: 1, Name: "super_admin"}).Error)
 	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1, ProjectID: 0}).Error)

--- a/server/grpc/services/audit_stream_test.go
+++ b/server/grpc/services/audit_stream_test.go
@@ -63,7 +63,8 @@ func newStreamCore(t *testing.T) (*AuditGRPCService, *gorm.DB) {
 	sqlDB.SetMaxOpenConns(1)
 	require.NoError(t, db.AutoMigrate(&models.AuditEvent{}, &models.User{},
 		&models.Role{}, &models.Permission{}, &models.RolePermission{}, &models.UserRole{},
-		&models.Group{}, &models.UserGroup{}, &models.GroupRole{}))
+		&models.Group{}, &models.UserGroup{}, &models.GroupRole{},
+		&models.Project{}, &models.Environment{}))
 	require.NoError(t, db.Create(&models.User{ID: 1, Username: "admin"}).Error)
 	// User 1 = super_admin (global) so the audit.read check passes (stream tests
 	// authenticate as user 1); the denied test uses an ungranted user id.

--- a/server/http/handlers/create_user_assignments_test.go
+++ b/server/http/handlers/create_user_assignments_test.go
@@ -27,7 +27,7 @@ func setupCreateUserAssignmentsTest(t *testing.T) (*UserHandler, *gorm.DB) {
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
 	require.NoError(t, db.AutoMigrate(&models.User{}, &models.UserRole{}, &models.Role{}, &models.Project{},
-		&models.Group{}, &models.UserGroup{}, &models.GroupRole{}))
+		&models.Group{}, &models.UserGroup{}, &models.GroupRole{}, &models.Environment{}))
 	require.NoError(t, db.Create(&models.Role{Name: "system_viewer"}).Error)
 	require.NoError(t, db.Create(&models.Role{Name: "project_developer"}).Error)
 	require.NoError(t, db.Create(&models.Project{Name: "default"}).Error)

--- a/server/http/handlers/global_invitation_test.go
+++ b/server/http/handlers/global_invitation_test.go
@@ -28,7 +28,7 @@ func setupGlobalInvitationTest(t *testing.T) (*CatalogHandler, *gorm.DB) {
 		&models.User{}, &models.UserRole{}, &models.Role{}, &models.Project{},
 		&models.ProjectInvitation{}, &models.SetupToken{}, &models.AuditEvent{},
 		// AuthorizePrincipal (the invite ceiling) resolves group-inherited roles too.
-		&models.Group{}, &models.UserGroup{}, &models.GroupRole{},
+		&models.Group{}, &models.UserGroup{}, &models.GroupRole{}, &models.Environment{},
 	))
 	require.NoError(t, db.Create(&models.Role{Name: "system_viewer"}).Error)
 	require.NoError(t, db.Create(&models.Role{Name: "system_auditor"}).Error)

--- a/server/http/handlers/groups_restore_test.go
+++ b/server/http/handlers/groups_restore_test.go
@@ -20,7 +20,7 @@ func TestRestoreGroupHandler(t *testing.T) {
 	require.NoError(t, i18n.InitializeForTesting())
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
-	require.NoError(t, db.AutoMigrate(&models.Group{}, &models.UserGroup{}, &models.GroupRole{}, &models.AuditEvent{}))
+	require.NoError(t, db.AutoMigrate(&models.Group{}, &models.UserGroup{}, &models.GroupRole{}, &models.AuditEvent{}, &models.Role{}))
 	c := core.NewKeyorixCore(store.NewLocalStorage(db))
 	h, err := NewGroupHandler(c)
 	require.NoError(t, err)

--- a/server/http/handlers/rbac_real_test.go
+++ b/server/http/handlers/rbac_real_test.go
@@ -60,6 +60,8 @@ func openTestDB(t *testing.T) *gorm.DB {
 		&models.UserGroup{},
 		&models.GroupRole{},
 		&models.User{},
+		&models.Project{},
+		&models.Environment{},
 	))
 	// A distinct name from any role individual tests create via mustCreateRole (some
 	// create their own role literally named "admin" for unrelated purposes) — Role.Name

--- a/server/http/handlers/rbac_role_audit_test.go
+++ b/server/http/handlers/rbac_role_audit_test.go
@@ -29,6 +29,7 @@ func TestRBACRoleDefinitionAudit(t *testing.T) {
 	require.NoError(t, db.AutoMigrate(
 		&models.Role{}, &models.Permission{}, &models.RolePermission{}, &models.AuditEvent{},
 		&models.UserRole{}, &models.Group{}, &models.UserGroup{}, &models.GroupRole{},
+		&models.Project{}, &models.Environment{},
 	))
 	handler := NewRBACHandler(core.NewKeyorixCore(store.NewLocalStorage(db)))
 	// CreateRole requires at least one (resolvable) permission name.

--- a/server/http/handlers/rbac_role_escalation_test.go
+++ b/server/http/handlers/rbac_role_escalation_test.go
@@ -35,6 +35,7 @@ func TestCreateRole_RolesWriteHolderCannotBundleSystemWrite(t *testing.T) {
 	require.NoError(t, db.AutoMigrate(
 		&models.Role{}, &models.Permission{}, &models.RolePermission{}, &models.UserRole{},
 		&models.Group{}, &models.UserGroup{}, &models.GroupRole{}, &models.AuditEvent{},
+		&models.Project{}, &models.Environment{},
 	))
 
 	rolesWritePerm := &models.Permission{Name: "roles.write", Resource: "roles", Action: "write"}
@@ -91,6 +92,7 @@ func TestUpdateRole_RolesWriteHolderCannotAddSystemWrite(t *testing.T) {
 	require.NoError(t, db.AutoMigrate(
 		&models.Role{}, &models.Permission{}, &models.RolePermission{}, &models.UserRole{},
 		&models.Group{}, &models.UserGroup{}, &models.GroupRole{}, &models.AuditEvent{},
+		&models.Project{}, &models.Environment{},
 	))
 
 	rolesWritePerm := &models.Permission{Name: "roles.write", Resource: "roles", Action: "write"}
@@ -154,6 +156,7 @@ func TestCreateRole_CannotClaimReservedAdminBypassName(t *testing.T) {
 	require.NoError(t, db.AutoMigrate(
 		&models.Role{}, &models.Permission{}, &models.RolePermission{}, &models.UserRole{},
 		&models.Group{}, &models.UserGroup{}, &models.GroupRole{}, &models.AuditEvent{},
+		&models.Project{}, &models.Environment{},
 	))
 
 	rolesWritePerm := &models.Permission{Name: "roles.write", Resource: "roles", Action: "write"}

--- a/server/http/rbac_route_authz_test.go
+++ b/server/http/rbac_route_authz_test.go
@@ -31,7 +31,7 @@ func TestUpdateUserRolesRequiresRolesAssign(t *testing.T) {
 	require.NoError(t, db.AutoMigrate(
 		&models.User{}, &models.Role{}, &models.Permission{}, &models.RolePermission{},
 		&models.UserRole{}, &models.Group{}, &models.UserGroup{}, &models.GroupRole{},
-		&models.AuditEvent{}, &models.Session{},
+		&models.AuditEvent{}, &models.Session{}, &models.Project{}, &models.Environment{},
 	))
 	now := time.Now()
 	require.NoError(t, db.Create(&models.User{ID: 1, Username: "admin", Email: "a@t.com", IsActive: true, CreatedAt: now, UpdatedAt: now}).Error)

--- a/server/http/restore_route_authz_test.go
+++ b/server/http/restore_route_authz_test.go
@@ -1,0 +1,151 @@
+package http
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// Regression (#147 HIGH): POST /api/v1/groups/{id}/restore reinstates every role
+// grant the group carried at deletion — the same blast radius as a role grant —
+// so it must require roles.assign, not the group-wide users.write. Previously a
+// users.write holder (without roles.assign) could restore a soft-deleted,
+// admin-conferring group and get their own admin access back.
+func TestRestoreGroupRouteRequiresRolesAssign(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+	ctx := context.Background()
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.User{}, &models.Role{}, &models.Permission{}, &models.RolePermission{},
+		&models.UserRole{}, &models.Group{}, &models.UserGroup{}, &models.GroupRole{},
+		&models.AuditEvent{}, &models.Session{}, &models.Project{}, &models.Environment{},
+	))
+	now := time.Now()
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "admin", Email: "a@t.com", IsActive: true, CreatedAt: now, UpdatedAt: now}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 2, Username: "usermgr", Email: "u@t.com", IsActive: true, CreatedAt: now, UpdatedAt: now}).Error)
+	require.NoError(t, db.Create(&models.Role{ID: 1, Name: "admin"}).Error)
+	require.NoError(t, db.Create(&models.Role{ID: 2, Name: "usermgr"}).Error)
+	require.NoError(t, db.Create(&models.Permission{ID: 1, Name: "users.write", Resource: "users", Action: "write"}).Error)
+	require.NoError(t, db.Create(&models.RolePermission{RoleID: 2, PermissionID: 1}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 2, RoleID: 2}).Error)
+	seedSession(t, db, 1, "admin-tok")
+	seedSession(t, db, 2, "usermgr-tok")
+
+	c := core.NewKeyorixCore(store.NewLocalStorage(db))
+	g, err := c.CreateGroup(ctx, 1, &core.CreateGroupRequest{Name: "ops"})
+	require.NoError(t, err)
+	require.NoError(t, c.DeleteGroup(ctx, 1, g.ID))
+
+	router, err := NewRouter(&config.Config{}, c)
+	require.NoError(t, err)
+	server := httptest.NewServer(router)
+	defer server.Close()
+	client := &http.Client{Timeout: 5 * time.Second}
+
+	restore := func(token string) int {
+		req, err := http.NewRequest("POST", fmt.Sprintf("%s/api/v1/groups/%d/restore", server.URL, g.ID), nil)
+		require.NoError(t, err)
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+		return resp.StatusCode
+	}
+
+	// The fix: users.write alone (no roles.assign) is rejected.
+	assert.Equal(t, http.StatusForbidden, restore("usermgr-tok"),
+		"users.write holder without roles.assign must NOT restore a group")
+	// An admin (privilege-bypass, holds roles.assign) passes the gate.
+	assert.NotEqual(t, http.StatusForbidden, restore("admin-tok"),
+		"admin should be allowed past the roles.assign gate")
+}
+
+// Regression (#161 HIGH): POST /api/v1/projects/{id}/restore and
+// POST /api/v1/projects/{projectId}/environments/{id}/restore reinstate every role
+// grant bound to the project/environment — so they must require roles.assign, not
+// secrets.write. Previously a secrets.write-only principal could restore a
+// soft-deleted project/environment and get back every role grant it carried.
+func TestRestoreProjectAndEnvironmentRoutesRequireRolesAssign(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+	ctx := context.Background()
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.User{}, &models.Role{}, &models.Permission{}, &models.RolePermission{},
+		&models.UserRole{}, &models.Group{}, &models.UserGroup{}, &models.GroupRole{},
+		&models.AuditEvent{}, &models.Session{}, &models.Project{}, &models.Environment{},
+		&models.SecretNode{}, &models.SecretVersion{},
+	))
+	now := time.Now()
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "admin", Email: "a@t.com", IsActive: true, CreatedAt: now, UpdatedAt: now}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 2, Username: "writer", Email: "w@t.com", IsActive: true, CreatedAt: now, UpdatedAt: now}).Error)
+	require.NoError(t, db.Create(&models.Role{ID: 1, Name: "admin"}).Error)
+	require.NoError(t, db.Create(&models.Role{ID: 2, Name: "secretwriter"}).Error)
+	require.NoError(t, db.Create(&models.Permission{ID: 1, Name: "secrets.write", Resource: "secrets", Action: "write"}).Error)
+	require.NoError(t, db.Create(&models.RolePermission{RoleID: 2, PermissionID: 1}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1}).Error)
+
+	c := core.NewKeyorixCore(store.NewLocalStorage(db))
+	p, err := c.CreateProject(ctx, "proj", "")
+	require.NoError(t, err)
+	// The writer's secrets.write is scoped to the project created above.
+	require.NoError(t, db.Create(&models.UserRole{UserID: 2, RoleID: 2, ProjectID: p.ID}).Error)
+	seedSession(t, db, 1, "admin-tok")
+	seedSession(t, db, 2, "writer-tok")
+
+	// CreateProject seeds default environments; reuse one rather than creating a
+	// colliding duplicate.
+	envs, err := c.ListEnvironmentsByProject(ctx, p.ID)
+	require.NoError(t, err)
+	require.NotEmpty(t, envs)
+	env := envs[0]
+	require.NoError(t, c.Storage().DeleteEnvironment(ctx, env.ID))
+	require.NoError(t, c.DeleteProject(ctx, p.ID, true))
+
+	router, err := NewRouter(&config.Config{}, c)
+	require.NoError(t, err)
+	server := httptest.NewServer(router)
+	defer server.Close()
+	client := &http.Client{Timeout: 5 * time.Second}
+
+	post := func(token, path string) int {
+		req, err := http.NewRequest("POST", server.URL+path, nil)
+		require.NoError(t, err)
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+		return resp.StatusCode
+	}
+
+	projectRestorePath := fmt.Sprintf("/api/v1/projects/%d/restore", p.ID)
+	assert.Equal(t, http.StatusForbidden, post("writer-tok", projectRestorePath),
+		"secrets.write holder without roles.assign must NOT restore a project")
+	assert.NotEqual(t, http.StatusForbidden, post("admin-tok", projectRestorePath),
+		"admin should be allowed past the roles.assign gate on project restore")
+
+	envRestorePath := fmt.Sprintf("/api/v1/projects/%d/environments/%d/restore", p.ID, env.ID)
+	assert.Equal(t, http.StatusForbidden, post("writer-tok", envRestorePath),
+		"secrets.write holder without roles.assign must NOT restore an environment")
+	assert.NotEqual(t, http.StatusForbidden, post("admin-tok", envRestorePath),
+		"admin should be allowed past the roles.assign gate on environment restore")
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -262,7 +262,10 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		r.With(customMiddleware.RequirePermission("secrets.write")).Post("/projects", catalogHandler.CreateProject)
 		r.With(customMiddleware.RequireScopedPermission("secrets.write", projectScope)).Put("/projects/{id}", catalogHandler.UpdateProject)
 		r.With(customMiddleware.RequireScopedPermission("secrets.delete", projectScope)).Delete("/projects/{id}", catalogHandler.DeleteProject)
-		r.With(customMiddleware.RequireScopedPermission("secrets.write", projectScope)).Post("/projects/{id}/restore", catalogHandler.RestoreProject)
+		// Restore reinstates every role grant the project carried at deletion — the
+		// same blast radius as a role grant — so gate on roles.assign (#161), not
+		// secrets.write, mirroring the direct-grant paths (matching #147's group fix).
+		r.With(customMiddleware.RequireScopedPermission("roles.assign", projectScope)).Post("/projects/{id}/restore", catalogHandler.RestoreProject)
 		r.With(customMiddleware.RequireScopedPermission("secrets.read", projectScope)).Get("/projects/{id}/drift", catalogHandler.GetProjectDrift)
 		r.With(customMiddleware.RequireScopedPermission("secrets.read", projectScope)).Get("/projects/{id}/rotation-order", secretHandler.GetProjectRotationOrder)
 		r.With(customMiddleware.RequireScopedPermission("secrets.read", projectScope)).Get("/projects/{id}/rotation-plan", secretHandler.GetProjectRotationPlan)
@@ -367,7 +370,9 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		r.With(customMiddleware.RequireScopedPermission("secrets.write", projectScope)).Post("/projects/{id}/environments", catalogHandler.CreateProjectEnvironment)
 		// Environment restore is nested under the project so the scope resolves
 		// from the (live) project ID — the env row is soft-deleted and unloadable.
-		r.With(customMiddleware.RequireScopedPermission("secrets.write", customMiddleware.ScopeFromProjectParam("projectId"))).Post("/projects/{projectId}/environments/{id}/restore", catalogHandler.RestoreEnvironment)
+		// Restore reinstates the environment's role grants, so gate on roles.assign
+		// (#161), not secrets.write — same shape as the project-restore fix above.
+		r.With(customMiddleware.RequireScopedPermission("roles.assign", customMiddleware.ScopeFromProjectParam("projectId"))).Post("/projects/{projectId}/environments/{id}/restore", catalogHandler.RestoreEnvironment)
 		r.With(customMiddleware.RequireScopedPermission("secrets.delete", customMiddleware.ScopeFromEnvParam("id"))).Delete("/environments/{id}", catalogHandler.DeleteEnvironment)
 		r.With(customMiddleware.RequirePermission("secrets.read")).Get("/environments", catalogHandler.ListEnvironments)
 
@@ -536,7 +541,10 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.Get("/{id}", groupHandler.GetGroup)
 			r.With(customMiddleware.RequirePermission("users.write")).Put("/{id}", groupHandler.UpdateGroup)
 			r.With(customMiddleware.RequirePermission("users.write")).Delete("/{id}", groupHandler.DeleteGroup)
-			r.With(customMiddleware.RequirePermission("users.write")).Post("/{id}/restore", groupHandler.RestoreGroup)
+			// Restore reinstates every role grant the group carried at deletion — the
+			// same blast radius as a role grant — so gate on roles.assign (#147), not
+			// users.write, mirroring the direct role-grant path below.
+			r.With(customMiddleware.RequirePermission("roles.assign")).Post("/{id}/restore", groupHandler.RestoreGroup)
 			r.Get("/{id}/members", groupHandler.GetGroupMembers)
 			// Secrets a group can reach via shares — reveals secret names, so it needs
 			// secrets.read on top of the group-level users.read above.


### PR DESCRIPTION
## Summary

Fixes three HIGH-severity findings from the ongoing security-hardening campaign, all instances of the recurring **admin-rank-ceiling gap**: a restore or impersonation path reinstates/grants admin-level access without checking the actor's own authority against what they're granting (same root as #93/#107/#141).

### #147 — Group restore reinstates role grants with no ceiling check
- `POST /groups/{id}/restore` now requires `roles.assign` (was `users.write`), matching the direct role-grant path.
- `RestoreGroup` collects the group's full role set and refuses to reinstate it when it contains an admin-tier role unless the actor is a global admin (`requireGlobalAdminToReinstateAdminRoles`) — a group can hold multiple roles at once, so this is an aggregate check, not a single-role check.

### #161 — Project/environment restore + missing deleted_at join
- `POST /projects/{id}/restore` and `POST /projects/{projectId}/environments/{id}/restore` now require `roles.assign` (was `secrets.write`), with the same aggregate role-set ceiling check as #147 (`requireAuthorityToReinstateProjectRoles`).
- Deeper fix: `GetUserRoleIDsAt` and `GetUserGroupRoleIDsAt` had **no join at all** against `projects`/`environments`, so a role bound directly to a project/environment ID kept authorizing regardless of that project's/environment's own soft-delete state — deletion wasn't an access boundary for directly-bound roles. Both queries now `LEFT JOIN` projects/environments and require `deleted_at IS NULL` for a scoped match, mirroring the existing `groups.deleted_at` check `GetUserGroupRoleIDsAt` already had for the group's own state.

### #165 — Admin impersonation has no admin-rank-ceiling check
- `StartImpersonation` previously only compared the target against a literal global-admin flag (`IsGlobalAdmin`), missing a target who is a project-scoped `project_admin` (or admin-tier via group membership) — never itself flagged "global admin".
- Added `GetUserRoleScopes` (new storage primitive) to discover every scope the target holds a role at, then `requireEqualOrGreaterAdminAuthority` compares the impersonator's authority against the target's at each scope — a scope-aware ceiling instead of a single global check.

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./...` clean (full suite, including fixed pre-existing test DB setups that omitted the `projects`/`environments` tables now required by the join)
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues
- [x] `golangci-lint run ./...` — 0 issues
- [x] `GOWORK=off go build -C operator ./...` clean
- [x] New focused tests:
  - `internal/core/restore_admin_ceiling_test.go` — #147/#161 core-layer ceiling checks (refuse non-admin when group/project holds an admin-tier role; allow global admin; don't over-reach on non-admin role sets)
  - `internal/storage/store/local_rbac_scope_test.go` — #161 storage-layer proof that a role bound to a soft-deleted project/environment stops authorizing and resumes after restore (both direct and group-inherited paths)
  - `server/http/restore_route_authz_test.go` — #147/#161 HTTP route-gate proof (`roles.assign` required, not `users.write`/`secrets.write`)
  - `internal/core/impersonation_test.go` — #165 scope-aware ceiling (project-scoped admin target refused for a non-admin caller, allowed for a same-scope admin caller)

🤖 Generated with [Claude Code](https://claude.com/claude-code)