### PR TITLE
fix(grpc): mirror HTTP's role Name/Description length bounds (#191)

### DIFF
--- a/internal/core/rbac_audit_test.go
+++ b/internal/core/rbac_audit_test.go
@@ -104,10 +104,15 @@ func TestRBACAuditTrail_PermissionToRole(t *testing.T) {
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
 	require.NoError(t, db.AutoMigrate(
-		&models.AuditEvent{}, &models.Role{}, &models.Permission{}, &models.RolePermission{},
+		&models.AuditEvent{}, &models.Role{}, &models.Permission{}, &models.RolePermission{}, &models.UserRole{},
+		&models.Group{}, &models.UserGroup{}, &models.GroupRole{},
 	))
 	require.NoError(t, db.Create(&models.Role{ID: 2, Name: "editor"}).Error)
 	require.NoError(t, db.Create(&models.Permission{ID: 8, Name: "secrets.write", Resource: "secrets", Action: "write"}).Error)
+	// #169: AssignPermissionToRole now requires the actor already hold the permission
+	// being bundled — make actor 5 a global admin so the bypass applies.
+	require.NoError(t, db.Create(&models.Role{ID: 1, Name: "admin"}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 5, RoleID: 1}).Error)
 	c := NewKeyorixCore(store.NewLocalStorage(db))
 	ctx := context.Background()
 

--- a/internal/core/rbac_management.go
+++ b/internal/core/rbac_management.go
@@ -45,14 +45,33 @@ func (c *KeyorixCore) GetRoleWithPermissions(ctx context.Context, roleID uint) (
 	return role, perms, nil
 }
 
-// AssignPermissionToRole verifies both exist, assigns the permission, and records
-// an RBAC audit event. actorID is the acting principal (0 = none).
+// AssignPermissionToRole verifies both exist, requires the actor already hold the
+// permission being bundled, assigns it, and records an RBAC audit event. actorID is
+// the acting principal (0 = none).
+//
+// #169: CreateRole/UpdateRole are gated only by the narrower "roles.write" — without
+// this check, a roles.write holder could bundle an arbitrary admin-tier permission
+// (system.write, roles.assign, users.impersonate, ...) into a role's DEFINITION with
+// zero check that they hold it themselves, then have that role granted to them
+// through any ordinary (non-admin) grant path — bypassing every admin-rank-ceiling
+// check on the GRANT step (#93/#107/#141/#147/#161/#165 and friends), since none of
+// those fixes touch role-definition time. Roles are global catalog objects (not
+// project/environment-scoped), so the actor must hold the permission at GLOBAL scope
+// — matching how roles.write itself is gated (RequirePermission always resolves to
+// ScopeGlobal). c.Authorize already includes the admin-role bypass, so a genuine
+// global admin is unaffected.
 func (c *KeyorixCore) AssignPermissionToRole(ctx context.Context, actorID, roleID, permissionID uint) error {
 	if _, err := c.storage.GetRole(ctx, roleID); err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorRoleNotFound", nil), err)
 	}
-	if _, err := c.storage.GetPermission(ctx, permissionID); err != nil {
+	perm, err := c.storage.GetPermission(ctx, permissionID)
+	if err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorNotFound", nil), err)
+	}
+	if ok, aerr := c.Authorize(ctx, actorID, perm.Name, Scope{}); aerr != nil {
+		return fmt.Errorf("failed to resolve actor authority: %w", aerr)
+	} else if !ok {
+		return fmt.Errorf("cannot assign permission %q to a role: you do not hold it yourself", perm.Name)
 	}
 	if err := c.storage.AssignPermissionToRole(ctx, roleID, permissionID); err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)

--- a/internal/core/rbac_management_test.go
+++ b/internal/core/rbac_management_test.go
@@ -1,0 +1,111 @@
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func newRBACManagementCore(t *testing.T) (*KeyorixCore, *gorm.DB) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.AuditEvent{}, &models.Role{}, &models.Permission{}, &models.RolePermission{},
+		&models.UserRole{}, &models.Group{}, &models.UserGroup{}, &models.GroupRole{},
+	))
+	return NewKeyorixCore(store.NewLocalStorage(db)), db
+}
+
+// #169: an actor with NO permissions at all — the CVE's own escalation shape (a
+// roles.write holder with nothing else) — must not be able to bundle ANY permission
+// into a role's definition, including a low-privilege one they don't personally hold.
+func TestAssignPermissionToRole_RequiresActorHoldPermission(t *testing.T) {
+	c, db := newRBACManagementCore(t)
+	ctx := context.Background()
+	require.NoError(t, db.Create(&models.Role{ID: 1, Name: "custom"}).Error)
+	require.NoError(t, db.Create(&models.Permission{ID: 1, Name: "system.write", Resource: "system", Action: "write"}).Error)
+
+	const attacker = uint(9) // holds ONLY roles.write in the real exploit scenario, no roles at all here
+	err := c.AssignPermissionToRole(ctx, attacker, 1, 1)
+	require.Error(t, err, "an actor who doesn't hold system.write must not be able to bundle it into a role")
+	assert.Contains(t, err.Error(), "do not hold it yourself")
+
+	var count int64
+	require.NoError(t, db.Model(&models.RolePermission{}).Count(&count).Error)
+	assert.Zero(t, count, "the permission must not have been assigned")
+}
+
+// The escalation path the finding describes: attacker holds roles.write (only)
+// PLUS the target permission at project scope, but not globally — bundling into a
+// role (a global catalog object) must still require GLOBAL authority, not just
+// scoped authority, since the resulting role could be granted anywhere.
+func TestAssignPermissionToRole_ScopedHolderCannotBundleGlobally(t *testing.T) {
+	c, db := newRBACManagementCore(t)
+	ctx := context.Background()
+	require.NoError(t, db.Create(&models.Role{ID: 1, Name: "custom"}).Error)
+	require.NoError(t, db.Create(&models.Role{ID: 2, Name: "scoped-holder"}).Error)
+	require.NoError(t, db.Create(&models.Permission{ID: 1, Name: "system.write", Resource: "system", Action: "write"}).Error)
+	require.NoError(t, db.Create(&models.RolePermission{RoleID: 2, PermissionID: 1}).Error)
+
+	const attacker = uint(9)
+	// attacker holds "system.write" only at project 3, not globally.
+	require.NoError(t, db.Create(&models.UserRole{UserID: attacker, RoleID: 2, ProjectID: 3}).Error)
+
+	err := c.AssignPermissionToRole(ctx, attacker, 1, 1)
+	require.Error(t, err, "a project-scoped holder of system.write must not bundle it into a role, which is a global object")
+}
+
+// An actor who genuinely holds the permission (directly, at global scope) may bundle
+// it into a role — the fix must not block the legitimate case.
+func TestAssignPermissionToRole_HolderMaySelfBundle(t *testing.T) {
+	c, db := newRBACManagementCore(t)
+	ctx := context.Background()
+	require.NoError(t, db.Create(&models.Role{ID: 1, Name: "custom"}).Error)
+	require.NoError(t, db.Create(&models.Role{ID: 2, Name: "holder"}).Error)
+	require.NoError(t, db.Create(&models.Permission{ID: 1, Name: "secrets.read", Resource: "secrets", Action: "read"}).Error)
+	require.NoError(t, db.Create(&models.RolePermission{RoleID: 2, PermissionID: 1}).Error)
+
+	const holder = uint(9)
+	require.NoError(t, db.Create(&models.UserRole{UserID: holder, RoleID: 2}).Error) // global grant
+
+	require.NoError(t, c.AssignPermissionToRole(ctx, holder, 1, 1))
+
+	var count int64
+	require.NoError(t, db.Model(&models.RolePermission{}).Where("role_id = ? AND permission_id = ?", 1, 1).Count(&count).Error)
+	assert.Equal(t, int64(1), count)
+}
+
+// A global admin bypasses the self-permission check (matching every other authz gate
+// in this codebase) — an admin can bundle any permission into any role.
+func TestAssignPermissionToRole_AdminBypasses(t *testing.T) {
+	c, db := newRBACManagementCore(t)
+	ctx := context.Background()
+	require.NoError(t, db.Create(&models.Role{ID: 1, Name: "custom"}).Error)
+	require.NoError(t, db.Create(&models.Role{ID: 2, Name: "admin"}).Error)
+	require.NoError(t, db.Create(&models.Permission{ID: 1, Name: "system.write", Resource: "system", Action: "write"}).Error)
+
+	const admin = uint(9)
+	require.NoError(t, db.Create(&models.UserRole{UserID: admin, RoleID: 2}).Error)
+
+	require.NoError(t, c.AssignPermissionToRole(ctx, admin, 1, 1))
+}
+
+// RemovePermissionFromRole is purely subtractive (weakens a role) — it must NOT
+// require the actor hold the permission being removed, unlike assignment.
+func TestRemovePermissionFromRole_NoSelfPermissionRequired(t *testing.T) {
+	c, db := newRBACManagementCore(t)
+	ctx := context.Background()
+	require.NoError(t, db.Create(&models.Role{ID: 1, Name: "custom"}).Error)
+	require.NoError(t, db.Create(&models.Permission{ID: 1, Name: "system.write", Resource: "system", Action: "write"}).Error)
+	require.NoError(t, db.Create(&models.RolePermission{RoleID: 1, PermissionID: 1}).Error)
+
+	const actor = uint(9) // holds nothing
+	require.NoError(t, c.RemovePermissionFromRole(ctx, actor, 1, 1))
+}

--- a/server/grpc/services/role_service.go
+++ b/server/grpc/services/role_service.go
@@ -41,7 +41,7 @@ func (s *RoleGRPCService) CreateRole(ctx context.Context, req *pb.CreateRoleRequ
 		return nil, status.Error(codes.InvalidArgument, "name, description and at least one permission are required")
 	}
 
-	permIDs, err := s.resolvePermissionIDs(ctx, req.GetPermissions())
+	permIDs, err := s.resolvePermissionIDs(ctx, actor.UserID, req.GetPermissions())
 	if err != nil {
 		return nil, err
 	}
@@ -101,7 +101,7 @@ func (s *RoleGRPCService) UpdateRole(ctx context.Context, req *pb.UpdateRoleRequ
 
 	// A provided permission list replaces the entire set.
 	if len(req.GetPermissions()) > 0 {
-		permIDs, err := s.resolvePermissionIDs(ctx, req.GetPermissions())
+		permIDs, err := s.resolvePermissionIDs(ctx, actor.UserID, req.GetPermissions())
 		if err != nil {
 			return nil, err
 		}
@@ -278,8 +278,15 @@ func (s *RoleGRPCService) roleByID(ctx context.Context, id uint) (*pb.Role, erro
 	return roleToProto(role, perms), nil
 }
 
-// resolvePermissionIDs maps permission names to IDs, rejecting unknown names.
-func (s *RoleGRPCService) resolvePermissionIDs(ctx context.Context, names []string) ([]uint, error) {
+// resolvePermissionIDs maps permission names to IDs, rejecting unknown names, and
+// requires actorID already hold every named permission (#169: CreateRole/UpdateRole
+// are gated only by the narrower "roles.write" — without this, a roles.write holder
+// could bundle an arbitrary admin-tier permission into a role's DEFINITION with no
+// check they hold it themselves, mirroring the same check the HTTP handler applies).
+// Checked at global scope, matching how roles.write itself is gated. Validating here
+// — before the caller creates/mutates anything — means a request naming even one
+// unauthorized permission is rejected atomically, not partially applied.
+func (s *RoleGRPCService) resolvePermissionIDs(ctx context.Context, actorID uint, names []string) ([]uint, error) {
 	perms, err := s.core.Storage().ListPermissions(ctx)
 	if err != nil {
 		return nil, status.Error(codes.Internal, "failed to resolve permissions")
@@ -293,6 +300,13 @@ func (s *RoleGRPCService) resolvePermissionIDs(ctx context.Context, names []stri
 		id, ok := byName[n]
 		if !ok {
 			return nil, status.Errorf(codes.InvalidArgument, "unknown permission %q", n)
+		}
+		authorized, aerr := s.core.Authorize(ctx, actorID, n, core.Scope{})
+		if aerr != nil {
+			return nil, status.Error(codes.Internal, "failed to resolve actor authority")
+		}
+		if !authorized {
+			return nil, status.Errorf(codes.PermissionDenied, "cannot bundle permission %q into a role: you do not hold it yourself", n)
 		}
 		ids = append(ids, id)
 	}

--- a/server/grpc/services/role_service.go
+++ b/server/grpc/services/role_service.go
@@ -12,6 +12,18 @@ import (
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
+// Role Name/Description length bounds. gRPC has no shared internal/core
+// validation layer to inherit these from (unlike other resources), so they
+// are mirrored here exactly from the HTTP-side struct tags in
+// server/http/handlers/rbac.go (CreateRoleRequest/UpdateRoleRequest) to keep
+// the two transports' accepted input identical (#191).
+const (
+	roleNameMinLen        = 3
+	roleNameMaxLen        = 50
+	roleDescriptionMinLen = 1
+	roleDescriptionMaxLen = 200
+)
+
 // RoleGRPCService implements pb.RoleServiceServer, backing each RPC with the
 // shared core service (role CRUD + permission wiring via storage, reads via the
 // core RBAC helpers).
@@ -37,8 +49,14 @@ func (s *RoleGRPCService) CreateRole(ctx context.Context, req *pb.CreateRoleRequ
 	if err := authorizeGlobal(ctx, s.core, actor, "roles.write"); err != nil {
 		return nil, err
 	}
-	if req.GetName() == "" || req.GetDescription() == "" || len(req.GetPermissions()) == 0 {
-		return nil, status.Error(codes.InvalidArgument, "name, description and at least one permission are required")
+	if len(req.GetPermissions()) == 0 {
+		return nil, status.Error(codes.InvalidArgument, "at least one permission is required")
+	}
+	if err := validateRoleName(req.GetName()); err != nil {
+		return nil, err
+	}
+	if err := validateRoleDescription(req.GetDescription()); err != nil {
+		return nil, err
 	}
 
 	permIDs, err := s.resolvePermissionIDs(ctx, actor.UserID, req.GetPermissions())
@@ -85,6 +103,11 @@ func (s *RoleGRPCService) UpdateRole(ctx context.Context, req *pb.UpdateRoleRequ
 	}
 	if req.GetId() == 0 {
 		return nil, status.Error(codes.InvalidArgument, "id is required")
+	}
+	if req.Description != nil {
+		if err := validateRoleDescription(req.GetDescription()); err != nil {
+			return nil, err
+		}
 	}
 
 	role, current, err := s.core.GetRoleWithPermissions(ctx, uint(req.GetId()))
@@ -333,6 +356,25 @@ func permissionToProto(p *models.Permission) *pb.Permission {
 		Resource:    p.Resource,
 		Action:      p.Action,
 	}
+}
+
+// validateRoleName mirrors HTTP's CreateRoleRequest.Name `min=3,max=50` bound
+// (server/http/handlers/rbac.go) so a role name accepted over gRPC is never
+// shorter/longer than one accepted over HTTP (#191).
+func validateRoleName(name string) error {
+	if len(name) < roleNameMinLen || len(name) > roleNameMaxLen {
+		return status.Errorf(codes.InvalidArgument, "name must be between %d and %d characters", roleNameMinLen, roleNameMaxLen)
+	}
+	return nil
+}
+
+// validateRoleDescription mirrors HTTP's Role Description `min=1,max=200`
+// bound (server/http/handlers/rbac.go) for the same reason (#191).
+func validateRoleDescription(description string) error {
+	if len(description) < roleDescriptionMinLen || len(description) > roleDescriptionMaxLen {
+		return status.Errorf(codes.InvalidArgument, "description must be between %d and %d characters", roleDescriptionMinLen, roleDescriptionMaxLen)
+	}
+	return nil
 }
 
 // mapRoleError translates core/storage role errors into gRPC status codes.

--- a/server/grpc/services/role_service_test.go
+++ b/server/grpc/services/role_service_test.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/keyorixhq/keyorix/internal/storage/models"
@@ -76,10 +77,57 @@ func TestRoleService_CreateRole_MissingFields(t *testing.T) {
 	assert.Equal(t, codes.InvalidArgument, status.Code(err))
 }
 
+// TestRoleService_CreateRole_NameTooShort mirrors HTTP's CreateRoleRequest.Name
+// `min=3` bound (server/http/handlers/rbac.go) — gRPC must reject the same
+// input HTTP would (#191).
+func TestRoleService_CreateRole_NameTooShort(t *testing.T) {
+	svc, h := newRoleService(t)
+	_, err := svc.CreateRole(roleAdminCtx(), &pb.CreateRoleRequest{
+		Name: "ab", Description: "a valid description", Permissions: []string{somePermission(t, h)},
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
+// TestRoleService_CreateRole_NameTooLong mirrors HTTP's `max=50` bound (#191).
+func TestRoleService_CreateRole_NameTooLong(t *testing.T) {
+	svc, h := newRoleService(t)
+	_, err := svc.CreateRole(roleAdminCtx(), &pb.CreateRoleRequest{
+		Name: strings.Repeat("a", 51), Description: "a valid description", Permissions: []string{somePermission(t, h)},
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
+// TestRoleService_CreateRole_DescriptionTooLong mirrors HTTP's
+// `max=200` bound on Description (#191).
+func TestRoleService_CreateRole_DescriptionTooLong(t *testing.T) {
+	svc, h := newRoleService(t)
+	_, err := svc.CreateRole(roleAdminCtx(), &pb.CreateRoleRequest{
+		Name: "valid-role-name", Description: strings.Repeat("d", 201), Permissions: []string{somePermission(t, h)},
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
+func TestRoleService_UpdateRole_DescriptionTooLong(t *testing.T) {
+	svc, h := newRoleService(t)
+	created, err := svc.CreateRole(roleAdminCtx(), &pb.CreateRoleRequest{
+		Name: "u-role-len", Description: "old", Permissions: []string{somePermission(t, h)},
+	})
+	require.NoError(t, err)
+
+	_, err = svc.UpdateRole(roleAdminCtx(), &pb.UpdateRoleRequest{
+		Id: created.GetId(), Description: strPtr(strings.Repeat("d", 201)),
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
 func TestRoleService_CreateRole_UnknownPermission(t *testing.T) {
 	svc, _ := newRoleService(t)
 	_, err := svc.CreateRole(roleAdminCtx(), &pb.CreateRoleRequest{
-		Name: "x", Description: "y", Permissions: []string{"does.not.exist"},
+		Name: "unknown-perm-role", Description: "y", Permissions: []string{"does.not.exist"},
 	})
 	require.Error(t, err)
 	assert.Equal(t, codes.InvalidArgument, status.Code(err))

--- a/server/grpc/services/role_service_test.go
+++ b/server/grpc/services/role_service_test.go
@@ -230,6 +230,57 @@ func TestRoleService_AssignRole_ScopedCrossProjectDenied(t *testing.T) {
 	assert.Equal(t, codes.PermissionDenied, status.Code(err))
 }
 
+// #169: the gRPC path closes the same escalation as HTTP — an actor holding ONLY
+// roles.write (no system.write, no admin role) must not be able to bundle
+// system.write into a role's definition, whether creating a new role or updating an
+// existing one they already hold.
+func TestRoleService_CreateRole_RolesWriteHolderCannotBundleSystemWrite(t *testing.T) {
+	svc, h := newRoleService(t)
+	roleEditor := h.CreateTestRole(t, "role-editor", "can edit roles only", 100)
+	require.NoError(t, h.DB.Exec(
+		"INSERT INTO role_permissions (role_id, permission_id) SELECT ?, id FROM permissions WHERE name = 'roles.write'",
+		roleEditor.ID).Error)
+	h.CreateTestUser(t, "attacker", 700)
+	h.AssignUserRole(t, 700, roleEditor.ID, nil)
+
+	ctx := authCtx(700, "attacker")
+	_, err := svc.CreateRole(ctx, &pb.CreateRoleRequest{
+		Name: "self-promote", Description: "escalation attempt", Permissions: []string{"system.write"},
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.PermissionDenied, status.Code(err))
+
+	var roleCount int64
+	require.NoError(t, h.DB.Model(&models.Role{}).Where("name = ?", "self-promote").Count(&roleCount).Error)
+	assert.Zero(t, roleCount, "no role must be created when a bundled permission is refused")
+}
+
+func TestRoleService_UpdateRole_RolesWriteHolderCannotAddSystemWrite(t *testing.T) {
+	svc, h := newRoleService(t)
+	roleEditor := h.CreateTestRole(t, "role-editor", "can edit roles only", 100)
+	require.NoError(t, h.DB.Exec(
+		"INSERT INTO role_permissions (role_id, permission_id) SELECT ?, id FROM permissions WHERE name = 'roles.write'",
+		roleEditor.ID).Error)
+	target := h.CreateTestRole(t, "target", "a role the attacker already holds", 101)
+	require.NoError(t, h.DB.Exec(
+		"INSERT INTO role_permissions (role_id, permission_id) SELECT ?, id FROM permissions WHERE name = 'roles.write'",
+		target.ID).Error)
+	h.CreateTestUser(t, "attacker2", 701)
+	h.AssignUserRole(t, 701, roleEditor.ID, nil)
+	h.AssignUserRole(t, 701, target.ID, nil)
+
+	ctx := authCtx(701, "attacker2")
+	_, err := svc.UpdateRole(ctx, &pb.UpdateRoleRequest{
+		Id: uint32(target.ID), Permissions: []string{"roles.write", "system.write"},
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.PermissionDenied, status.Code(err))
+
+	var permCount int64
+	require.NoError(t, h.DB.Table("role_permissions").Where("role_id = ?", target.ID).Count(&permCount).Error)
+	assert.Equal(t, int64(1), permCount, "the role's permission set must be unchanged")
+}
+
 func TestRoleService_RemoveRole(t *testing.T) {
 	svc, h := newRoleService(t)
 	user := h.CreateTestUser(t, "removee", 501)

--- a/server/http/handlers/rbac.go
+++ b/server/http/handlers/rbac.go
@@ -138,6 +138,30 @@ func (h *RBACHandler) CreateRole(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// #169: resolve + authorize every requested permission BEFORE creating anything,
+	// so a request naming even one permission the actor doesn't hold fails the whole
+	// creation loudly (403) instead of silently creating a role missing just that
+	// permission — which would let the actor believe they got what they asked for.
+	// Unknown permission names are still skipped (not a security boundary), but an
+	// authorization failure on a KNOWN permission is fatal to the request.
+	toAssign := make([]*models.Permission, 0, len(req.Permissions))
+	for _, permName := range req.Permissions {
+		perm, err := h.findPermissionByName(r.Context(), permName)
+		if err != nil {
+			continue // skip unknown permission names
+		}
+		ok, aerr := h.coreService.Authorize(r.Context(), userCtx.UserID, perm.Name, core.Scope{})
+		if aerr != nil {
+			sendError(w, "InternalError", "Failed to resolve actor authority", http.StatusInternalServerError, nil)
+			return
+		}
+		if !ok {
+			sendError(w, "Forbidden", fmt.Sprintf("cannot bundle permission %q into a role: you do not hold it yourself", permName), http.StatusForbidden, nil)
+			return
+		}
+		toAssign = append(toAssign, perm)
+	}
+
 	role, err := h.coreService.Storage().CreateRole(r.Context(), &models.Role{Name: req.Name, Description: req.Description})
 	if err != nil {
 		log.Printf("Error creating role: %v", err)
@@ -149,15 +173,12 @@ func (h *RBACHandler) CreateRole(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Assign named permissions by looking up each permission by name.
 	var assignedPerms []*models.Permission
-	for _, permName := range req.Permissions {
-		perm, err := h.findPermissionByName(r.Context(), permName)
-		if err != nil {
-			continue // skip unknown permission names
-		}
+	for _, perm := range toAssign {
 		if err := h.coreService.AssignPermissionToRole(r.Context(), userCtx.UserID, role.ID, perm.ID); err != nil {
-			log.Printf("Warning: could not assign permission %q to role %d: %v", permName, role.ID, err)
+			// Already authorized above; only a race (permission deleted concurrently) or
+			// storage error reaches here — log it, the role still exists with the rest.
+			log.Printf("Warning: could not assign permission %q to role %d: %v", perm.Name, role.ID, err)
 		} else {
 			assignedPerms = append(assignedPerms, perm)
 		}
@@ -229,6 +250,34 @@ func (h *RBACHandler) UpdateRole(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// #169: resolve + authorize every requested permission BEFORE touching the
+	// role's existing permission set — otherwise a request naming even one
+	// permission the actor doesn't hold would strip the role's current permissions
+	// (RemovePermissionFromRole runs unconditionally below) and then fail partway
+	// through re-adding them, leaving the role broken. An authorization failure on a
+	// KNOWN permission must abort before any mutation. Unknown names are still
+	// skipped later, matching CreateRole's convention.
+	var toAssign []*models.Permission
+	if req.Permissions != nil {
+		toAssign = make([]*models.Permission, 0, len(*req.Permissions))
+		for _, permName := range *req.Permissions {
+			perm, err := h.findPermissionByName(r.Context(), permName)
+			if err != nil {
+				continue
+			}
+			ok, aerr := h.coreService.Authorize(r.Context(), userCtx.UserID, perm.Name, core.Scope{})
+			if aerr != nil {
+				sendError(w, "InternalError", "Failed to resolve actor authority", http.StatusInternalServerError, nil)
+				return
+			}
+			if !ok {
+				sendError(w, "Forbidden", fmt.Sprintf("cannot bundle permission %q into a role: you do not hold it yourself", permName), http.StatusForbidden, nil)
+				return
+			}
+			toAssign = append(toAssign, perm)
+		}
+	}
+
 	if req.Description != nil {
 		role.Description = *req.Description
 	}
@@ -245,12 +294,10 @@ func (h *RBACHandler) UpdateRole(w http.ResponseWriter, r *http.Request) {
 		for _, ep := range existing {
 			_ = h.coreService.RemovePermissionFromRole(r.Context(), userCtx.UserID, id, ep.ID)
 		}
-		for _, permName := range *req.Permissions {
-			perm, err := h.findPermissionByName(r.Context(), permName)
-			if err != nil {
-				continue
+		for _, perm := range toAssign {
+			if err := h.coreService.AssignPermissionToRole(r.Context(), userCtx.UserID, id, perm.ID); err != nil {
+				log.Printf("Warning: could not assign permission %q to role %d: %v", perm.Name, id, err)
 			}
-			_ = h.coreService.AssignPermissionToRole(r.Context(), userCtx.UserID, id, perm.ID)
 		}
 	}
 
@@ -500,9 +547,13 @@ func (h *RBACHandler) AssignPermissionToRole(w http.ResponseWriter, r *http.Requ
 
 	if err := h.coreService.AssignPermissionToRole(r.Context(), userCtx.UserID, roleID, body.PermissionID); err != nil {
 		log.Printf("Error assigning permission to role: %v", err)
-		if strings.Contains(err.Error(), "not found") {
+		switch {
+		case strings.Contains(err.Error(), "not found"):
 			sendError(w, "NotFound", err.Error(), http.StatusNotFound, nil)
-		} else {
+		case strings.Contains(err.Error(), "do not hold it yourself"):
+			// #169: the actor doesn't hold the permission being bundled — 403, not 500.
+			sendError(w, "Forbidden", err.Error(), http.StatusForbidden, nil)
+		default:
 			sendError(w, "InternalError", "Failed to assign permission", http.StatusInternalServerError, nil)
 		}
 		return

--- a/server/http/handlers/rbac_real_test.go
+++ b/server/http/handlers/rbac_real_test.go
@@ -43,7 +43,10 @@ func mustCreateGroup(t *testing.T, db *gorm.DB, name string) *models.Group {
 	return group
 }
 
-// openTestDB opens a fresh in-memory SQLite DB and auto-migrates RBAC tables.
+// openTestDB opens a fresh in-memory SQLite DB and auto-migrates RBAC tables. Makes
+// the test user (withUserCtx's UserID 1) a global admin so AssignPermissionToRole's
+// #169 self-permission check (via the admin bypass) doesn't block these RBAC-plumbing
+// tests, which aren't testing that authorization boundary themselves.
 func openTestDB(t *testing.T) *gorm.DB {
 	t.Helper()
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
@@ -54,9 +57,16 @@ func openTestDB(t *testing.T) *gorm.DB {
 		&models.RolePermission{},
 		&models.UserRole{},
 		&models.Group{},
+		&models.UserGroup{},
 		&models.GroupRole{},
 		&models.User{},
 	))
+	// A distinct name from any role individual tests create via mustCreateRole (some
+	// create their own role literally named "admin" for unrelated purposes) — Role.Name
+	// is unique, so this must not collide with those.
+	adminRole := &models.Role{Name: "system_admin", Description: "Administrator"}
+	require.NoError(t, db.Create(adminRole).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: adminRole.ID}).Error)
 	return db
 }
 
@@ -347,7 +357,9 @@ func TestRBACReal_AssignRole_PastExpiry_400(t *testing.T) {
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 	var n int64
-	require.NoError(t, db.Model(&models.UserRole{}).Count(&n).Error)
+	// Scoped to the specific (user, role) under test, not a bare table count — openTestDB
+	// itself seeds a UserRole granting the test actor admin authority (#169).
+	require.NoError(t, db.Model(&models.UserRole{}).Where("user_id = ? AND role_id = ?", user.ID, role.ID).Count(&n).Error)
 	assert.Zero(t, n, "no grant should be written when the expiry is rejected")
 }
 

--- a/server/http/handlers/rbac_role_audit_test.go
+++ b/server/http/handlers/rbac_role_audit_test.go
@@ -28,10 +28,18 @@ func TestRBACRoleDefinitionAudit(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, db.AutoMigrate(
 		&models.Role{}, &models.Permission{}, &models.RolePermission{}, &models.AuditEvent{},
+		&models.UserRole{}, &models.Group{}, &models.UserGroup{}, &models.GroupRole{},
 	))
 	handler := NewRBACHandler(core.NewKeyorixCore(store.NewLocalStorage(db)))
 	// CreateRole requires at least one (resolvable) permission name.
 	require.NoError(t, db.Create(&models.Permission{Name: "secrets.read", Resource: "secrets", Action: "read"}).Error)
+	// #169: CreateRole/UpdateRole now require the actor already hold every permission
+	// being bundled — make withUserCtx's actor (UserID 1) a global admin so the bypass
+	// applies. Named distinctly from the literal "admin" role a later subtest creates
+	// (Role.Name is unique).
+	adminRole := &models.Role{Name: "system_admin", Description: "Administrator"}
+	require.NoError(t, db.Create(adminRole).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: adminRole.ID}).Error)
 
 	countEvents := func(eventType string) int64 {
 		var n int64

--- a/server/http/handlers/rbac_role_escalation_test.go
+++ b/server/http/handlers/rbac_role_escalation_test.go
@@ -1,0 +1,135 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	customMiddleware "github.com/keyorixhq/keyorix/server/middleware"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// #169: the exact escalation the finding describes — an actor holding ONLY
+// "roles.write" (a narrower permission that, by name, sounds like "can edit what a
+// role contains," not "can hand out admin") must not be able to bundle an
+// admin-tier permission like "system.write" into a role's DEFINITION, since that
+// role could then be granted to them (or already IS) through an ordinary
+// non-admin grant path — bypassing every admin-rank-ceiling check on the GRANT step.
+func TestCreateRole_RolesWriteHolderCannotBundleSystemWrite(t *testing.T) {
+	require.NoError(t, i18n.Initialize(&config.Config{
+		Locale: config.LocaleConfig{Language: "en", FallbackLanguage: "en"},
+	}))
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.Role{}, &models.Permission{}, &models.RolePermission{}, &models.UserRole{},
+		&models.Group{}, &models.UserGroup{}, &models.GroupRole{}, &models.AuditEvent{},
+	))
+
+	rolesWritePerm := &models.Permission{Name: "roles.write", Resource: "roles", Action: "write"}
+	systemWritePerm := &models.Permission{Name: "system.write", Resource: "system", Action: "write"}
+	require.NoError(t, db.Create(rolesWritePerm).Error)
+	require.NoError(t, db.Create(systemWritePerm).Error)
+
+	// The attacker's role: ONLY roles.write, nothing else — no system.write, no admin.
+	attackerRole := &models.Role{Name: "role-editor"}
+	require.NoError(t, db.Create(attackerRole).Error)
+	require.NoError(t, db.Create(&models.RolePermission{RoleID: attackerRole.ID, PermissionID: rolesWritePerm.ID}).Error)
+
+	const attackerID = uint(42)
+	require.NoError(t, db.Create(&models.UserRole{UserID: attackerID, RoleID: attackerRole.ID}).Error)
+
+	coreService := core.NewKeyorixCore(store.NewLocalStorage(db))
+	handler := NewRBACHandler(coreService)
+
+	attackerCtx := &customMiddleware.UserContext{UserID: attackerID, Username: "attacker", Email: "a@x.io"}
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/roles",
+		bytes.NewBufferString(`{"name":"self-promote","description":"escalation attempt","permissions":["system.write"]}`))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(context.WithValue(req.Context(), customMiddleware.GetUserContextKey(), attackerCtx))
+	w := httptest.NewRecorder()
+
+	handler.CreateRole(w, req)
+
+	assert.Equal(t, http.StatusForbidden, w.Code, "a roles.write-only actor must not be able to bundle system.write into a role")
+
+	var roleCount int64
+	require.NoError(t, db.Model(&models.Role{}).Where("name = ?", "self-promote").Count(&roleCount).Error)
+	assert.Zero(t, roleCount, "no role must be created when a bundled permission is refused")
+
+	// Sanity: the SAME actor CAN create a role bundling a permission they DO hold.
+	req2 := httptest.NewRequest(http.MethodPost, "/api/v1/roles",
+		bytes.NewBufferString(`{"name":"role-editor-clone","description":"legit","permissions":["roles.write"]}`))
+	req2.Header.Set("Content-Type", "application/json")
+	req2 = req2.WithContext(context.WithValue(req2.Context(), customMiddleware.GetUserContextKey(), attackerCtx))
+	w2 := httptest.NewRecorder()
+	handler.CreateRole(w2, req2)
+	assert.Equal(t, http.StatusCreated, w2.Code, "bundling a permission the actor genuinely holds must still succeed")
+}
+
+// The UpdateRole path closes the same gap for an ALREADY-EXISTING role: an actor
+// must not be able to retroactively add an admin-tier permission to a role's
+// definition (which would grant it to every current holder, including themselves)
+// without holding that permission.
+func TestUpdateRole_RolesWriteHolderCannotAddSystemWrite(t *testing.T) {
+	require.NoError(t, i18n.Initialize(&config.Config{
+		Locale: config.LocaleConfig{Language: "en", FallbackLanguage: "en"},
+	}))
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.Role{}, &models.Permission{}, &models.RolePermission{}, &models.UserRole{},
+		&models.Group{}, &models.UserGroup{}, &models.GroupRole{}, &models.AuditEvent{},
+	))
+
+	rolesWritePerm := &models.Permission{Name: "roles.write", Resource: "roles", Action: "write"}
+	systemWritePerm := &models.Permission{Name: "system.write", Resource: "system", Action: "write"}
+	require.NoError(t, db.Create(rolesWritePerm).Error)
+	require.NoError(t, db.Create(systemWritePerm).Error)
+
+	attackerRole := &models.Role{Name: "role-editor"}
+	require.NoError(t, db.Create(attackerRole).Error)
+	require.NoError(t, db.Create(&models.RolePermission{RoleID: attackerRole.ID, PermissionID: rolesWritePerm.ID}).Error)
+
+	// The role the attacker will try to retroactively upgrade — one they already hold.
+	targetRole := &models.Role{Name: "target"}
+	require.NoError(t, db.Create(targetRole).Error)
+	require.NoError(t, db.Create(&models.RolePermission{RoleID: targetRole.ID, PermissionID: rolesWritePerm.ID}).Error)
+
+	const attackerID = uint(42)
+	require.NoError(t, db.Create(&models.UserRole{UserID: attackerID, RoleID: attackerRole.ID}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: attackerID, RoleID: targetRole.ID}).Error)
+
+	coreService := core.NewKeyorixCore(store.NewLocalStorage(db))
+	handler := NewRBACHandler(coreService)
+
+	attackerCtx := &customMiddleware.UserContext{UserID: attackerID, Username: "attacker", Email: "a@x.io"}
+	req := httptest.NewRequest(http.MethodPut, fmt.Sprintf("/api/v1/roles/%d", targetRole.ID),
+		bytes.NewBufferString(`{"permissions":["roles.write","system.write"]}`))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(context.WithValue(req.Context(), customMiddleware.GetUserContextKey(), attackerCtx))
+	req = withChiParam(req, "id", fmt.Sprintf("%d", targetRole.ID))
+	w := httptest.NewRecorder()
+
+	handler.UpdateRole(w, req)
+
+	assert.Equal(t, http.StatusForbidden, w.Code, "adding system.write to an existing role must be refused")
+
+	var perms []models.Permission
+	require.NoError(t, db.Model(&models.Permission{}).
+		Joins("JOIN role_permissions ON role_permissions.permission_id = permissions.id").
+		Where("role_permissions.role_id = ?", targetRole.ID).Find(&perms).Error)
+	require.Len(t, perms, 1, "the role's permission set must be unchanged — still just roles.write")
+	assert.Equal(t, "roles.write", perms[0].Name)
+}


### PR DESCRIPTION
## Summary

Note: this branch is based on `harden/round-critical-role-permission-self-check` (PR #557, not yet merged) since that PR substantially refactored `server/grpc/services/role_service.go`'s `CreateRole`/`UpdateRole`/`resolvePermissionIDs` for finding #169, and this fix touches the exact same functions — building on top avoids duplicating that refactor. This PR targets `main` directly, so its diff includes #557's changes until #557 merges; that's expected.

gRPC's `CreateRole`/`UpdateRole` call `s.core.Storage().CreateRole(...)` directly with no `core.CreateRole` business-logic wrapper to inherit validation from (unlike other resources), so they only checked non-empty — a 1-character name or an unbounded description was accepted over gRPC while HTTP's `CreateRoleRequest`/`UpdateRoleRequest` validator tags (`min=3,max=50` / `min=1,max=200`) reject the same input. Requires `roles.write` (already privileged) — naming-convention/consistency and minor storage-bloat impact only, not an authority-escalation gap (that's #169, already fixed on the base branch).

Mirrors the exact HTTP-side bounds in the gRPC handler via `validateRoleName`/`validateRoleDescription`.

## Test plan
- [x] `go build ./...` and `GOWORK=off go build -C operator ./...`
- [x] `go test ./...` (full suite)
- [x] New tests: too-short name, too-long name, too-long description on `CreateRole`; too-long description on `UpdateRole` — each asserts `codes.InvalidArgument`, matching HTTP's rejection of the same input
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues
- [x] `golangci-lint run ./...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)