### PR TITLE
fix: PAT allowlist cache staleness + local-CLI actor attribution + SCIM session-cleanup propagation (#146, #150, #151)

### DIFF
--- a/internal/cli/common/actor_test.go
+++ b/internal/cli/common/actor_test.go
@@ -1,0 +1,31 @@
+package common
+
+import "testing"
+
+// #150: KEYORIX_CLI_ACTOR lets an operator self-assert their own numeric user ID
+// so local-CLI mutations against a shared backend aren't attributed to actorID=0.
+func TestResolveActorID(t *testing.T) {
+	cases := []struct {
+		name string
+		env  string
+		want uint
+	}{
+		{"unset", "", 0},
+		{"valid", "42", 42},
+		{"zero explicit", "0", 0},
+		{"non-numeric", "not-a-number", 0},
+		{"negative", "-1", 0},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if c.env == "" {
+				t.Setenv(cliActorEnvVar, "")
+			} else {
+				t.Setenv(cliActorEnvVar, c.env)
+			}
+			if got := ResolveActorID(); got != c.want {
+				t.Errorf("ResolveActorID() with %s=%q = %d, want %d", cliActorEnvVar, c.env, got, c.want)
+			}
+		})
+	}
+}

--- a/internal/cli/common/common.go
+++ b/internal/cli/common/common.go
@@ -2,6 +2,8 @@ package common
 
 import (
 	"fmt"
+	"os"
+	"strconv"
 
 	"github.com/keyorixhq/keyorix/internal/config"
 	"github.com/keyorixhq/keyorix/internal/core"
@@ -10,6 +12,33 @@ import (
 	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/storage"
 )
+
+// cliActorEnvVar lets an operator self-assert their own Keyorix user ID for local
+// CLI mutations (#150). Local mode has no authenticated session — every core
+// mutation it drives is otherwise stamped actorID=0 ("no authenticated
+// principal") in the audit trail, including against a SHARED backend
+// (InitializeCoreService honors storage.type=postgres, not just the embedded
+// SQLite default), which weakens accountability in exactly the highest-blast-
+// radius pathway: someone who already holds the deployment's DB credentials.
+// This is self-asserted, not cryptographically verified — local mode already
+// has no authentication layer to verify against — but a self-asserted operator
+// ID beats an anonymous 0 for post-incident forensic reconstruction.
+const cliActorEnvVar = "KEYORIX_CLI_ACTOR"
+
+// ResolveActorID returns the operator-asserted actor ID from KEYORIX_CLI_ACTOR
+// (#150), or 0 (the existing "no authenticated principal" convention) if unset
+// or unparseable.
+func ResolveActorID() uint {
+	raw := os.Getenv(cliActorEnvVar)
+	if raw == "" {
+		return 0
+	}
+	id, err := strconv.ParseUint(raw, 10, 64)
+	if err != nil {
+		return 0
+	}
+	return uint(id)
+}
 
 // InitializeCoreService creates a core service instance using the storage factory
 // This function should be used by all CLI commands instead of directly creating storage
@@ -42,6 +71,15 @@ func InitializeCoreService() (*core.KeyorixCore, error) {
 	storageImpl, err := factory.CreateStorage(cfg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create storage: %w", err)
+	}
+
+	// #150: local mode against a SHARED (non-embedded-SQLite) backend bypasses every
+	// HTTP-layer authz gate AND, without an explicit actor, attributes every
+	// mutation to nobody. Warn loudly rather than silently degrading the audit
+	// trail's accountability for what's already the highest-blast-radius pathway.
+	if cfg.Storage.Type != "" && cfg.Storage.Type != "local" && cfg.Storage.Type != "sqlite" && ResolveActorID() == 0 {
+		fmt.Fprintf(os.Stderr, "WARNING: local CLI mode is writing directly to a shared %q backend with no operator identifier set — audit events for these actions will show actorID=0 (\"no authenticated principal\"). Set %s=<your-keyorix-user-id> to attribute them to yourself.\n",
+			cfg.Storage.Type, cliActorEnvVar)
 	}
 
 	// Create core service and wire credential delivery (ADR-028) so a CLI admin can

--- a/internal/cli/machine/binding.go
+++ b/internal/cli/machine/binding.go
@@ -110,8 +110,9 @@ func runBindingAdd(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to initialize service: %w", err)
 	}
-	// Local mode has no authenticated user; record a system (0) creator.
-	b, err := svc.CreateOIDCBinding(ctx, projectID, m.ID, bindingIssuer, bindingSubject, 0)
+	// Local mode has no authenticated user; #150: record the operator-asserted
+	// KEYORIX_CLI_ACTOR if set, otherwise the existing anonymous (0) creator.
+	b, err := svc.CreateOIDCBinding(ctx, projectID, m.ID, bindingIssuer, bindingSubject, common.ResolveActorID())
 	if err != nil {
 		return fmt.Errorf("failed to create OIDC binding: %w", err)
 	}
@@ -195,7 +196,8 @@ func runBindingRm(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to initialize service: %w", err)
 	}
-	if err := svc.DeleteOIDCBinding(ctx, projectID, m.ID, uint(bindingID), 0); err != nil {
+	// #150: record the operator-asserted KEYORIX_CLI_ACTOR if set.
+	if err := svc.DeleteOIDCBinding(ctx, projectID, m.ID, uint(bindingID), common.ResolveActorID()); err != nil {
 		return fmt.Errorf("failed to remove OIDC binding: %w", err)
 	}
 	fmt.Printf("OIDC binding %d removed from machine %q.\n", bindingID, m.Name)

--- a/internal/core/pat.go
+++ b/internal/core/pat.go
@@ -211,6 +211,28 @@ func DecodePATScopes(raw string) []string {
 	return out
 }
 
+// CurrentPATRestriction re-fetches a PAT's restriction fresh from storage by its
+// raw token, bypassing any cached UserContext snapshot the auth middleware may be
+// holding (#146). The middleware's short-circuit cache holds a validated token's
+// full UserContext — including PATRestriction.AllowedCIDRs — for up to
+// validTokenTTL; on a cache HIT the network-allowlist check would otherwise be
+// enforced against that stale snapshot, not the token's current restriction. This
+// lets the network check re-verify fresh on every request regardless of cache
+// state, at the cost of one extra lightweight lookup per PAT-authenticated
+// request (session/machine tokens carry no such per-request-narrowable
+// restriction and are unaffected). Returns an error on any lookup failure — the
+// caller must NOT treat that as "unrestricted" (that would fail OPEN on the exact
+// check this exists to keep honest); falling back to the last-known (possibly
+// stale, but still a real, previously-enforced) restriction is the correct
+// degraded behavior on a transient storage error.
+func (c *KeyorixCore) CurrentPATRestriction(ctx context.Context, raw string) (*PATRestriction, error) {
+	pat, err := c.storage.GetPersonalAccessTokenByHash(ctx, sha256Hex(raw))
+	if err != nil {
+		return nil, err
+	}
+	return patRestrictionFrom(pat), nil
+}
+
 // patRestrictionFrom builds the request-time restriction for a token, or nil when
 // the token is unrestricted (no scopes and no project confinement).
 func patRestrictionFrom(pat *models.PersonalAccessToken) *PATRestriction {

--- a/internal/core/pat_restriction_refresh_test.go
+++ b/internal/core/pat_restriction_refresh_test.go
@@ -1,0 +1,68 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// #146: CurrentPATRestriction must reflect the CURRENT row, not whatever was true
+// when a caller last cached it — proving the primitive the auth middleware's
+// cache-hit path relies on to avoid enforcing a stale CIDR allowlist.
+func TestCurrentPATRestriction_ReflectsLiveNarrowing(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.User{}, &models.PersonalAccessToken{}))
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "alice", Email: "a@x.io", IsActive: true}).Error)
+
+	const raw = "kx_pat_narrowtest"
+	cidrs, encErr := encodePATCIDRs([]string{"10.0.0.0/8"})
+	require.NoError(t, encErr)
+	pat := &models.PersonalAccessToken{
+		ID: 1, UserID: 1, Name: "ci", TokenHash: sha256Hex(raw), AllowedCIDRs: cidrs,
+	}
+	require.NoError(t, db.Create(pat).Error)
+
+	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
+	ctx := context.Background()
+
+	// Initially permits 10.0.0.0/8.
+	restriction, err := c.CurrentPATRestriction(ctx, raw)
+	require.NoError(t, err)
+	require.NotNil(t, restriction)
+	assert.Contains(t, restriction.AllowedCIDRs, "10.0.0.0/8")
+
+	// An admin narrows the allowlist (simulating a mid-incident restriction change).
+	narrowed, encErr := encodePATCIDRs([]string{"192.0.2.0/24"})
+	require.NoError(t, encErr)
+	pat.AllowedCIDRs = narrowed
+	require.NoError(t, db.Save(pat).Error)
+
+	// The VERY NEXT call — no TTL, no cache — must see the new, narrower allowlist.
+	restriction, err = c.CurrentPATRestriction(ctx, raw)
+	require.NoError(t, err)
+	require.NotNil(t, restriction)
+	assert.NotContains(t, restriction.AllowedCIDRs, "10.0.0.0/8", "the old allowlist must not still be honored")
+	assert.Contains(t, restriction.AllowedCIDRs, "192.0.2.0/24")
+}
+
+// A lookup failure (e.g. the token was revoked/deleted between the caller's cache
+// write and this refresh) must surface as an error, not silently report
+// "unrestricted" — the caller must fail closed / fall back to the prior
+// restriction, never treat a lookup failure as "no restriction."
+func TestCurrentPATRestriction_LookupFailureIsAnError(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.User{}, &models.PersonalAccessToken{}))
+
+	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
+	_, err = c.CurrentPATRestriction(context.Background(), "kx_pat_doesnotexist")
+	require.Error(t, err, "a lookup failure must be a real error, not a silent nil-restriction")
+}

--- a/internal/core/scim.go
+++ b/internal/core/scim.go
@@ -283,7 +283,9 @@ func (c *KeyorixCore) DeprovisionSCIMUser(ctx context.Context, actorID, id uint)
 		if _, err := tx.UpdateUser(ctx, user); err != nil {
 			return err
 		}
-		_ = tx.DeleteSessionsForUserExcept(ctx, id, 0)
+		if err := tx.DeleteSessionsForUserExcept(ctx, id, 0); err != nil {
+			return err
+		}
 		return tx.DeleteUser(ctx, id)
 	}); err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)

--- a/server/middleware/auth.go
+++ b/server/middleware/auth.go
@@ -72,6 +72,17 @@ type UserContext struct {
 	PATRestriction *core.PATRestriction `json:"-"`
 }
 
+// cloneUserContextWithRestriction returns a shallow copy of base with
+// PATRestriction replaced (#146) — used on a cache hit to apply a freshly
+// re-fetched restriction without mutating the shared cached entry (other
+// concurrent requests hitting the same cache entry must not see this one
+// request's snapshot).
+func cloneUserContextWithRestriction(base *UserContext, restriction *core.PATRestriction) *UserContext {
+	clone := *base
+	clone.PATRestriction = restriction
+	return &clone
+}
+
 // ActorKind returns the principal's actor type ("user" or "machine_identity"),
 // defaulting to user for legacy/empty contexts.
 func (u *UserContext) ActorKind() string {
@@ -234,12 +245,23 @@ func authenticationWithValidator(validator sessionValidator, coreService *core.K
 					return
 				}
 				// The network allowlist is per-request (the same token may arrive from a
-				// different IP), so enforce it even on a cache hit.
-				if !tokenNetworkAllowed(r, entry.userCtx) {
+				// different IP), so enforce it even on a cache hit. For a PAT specifically,
+				// the ALLOWLIST ITSELF (not just the request's IP) can change between cache
+				// writes (#146: an admin narrowing a compromised PAT's allowlist mid-incident
+				// must take effect immediately, not up to validTokenTTL later) — re-fetch it
+				// fresh rather than trusting entry.userCtx's cached snapshot. A refresh
+				// failure falls back to the cached restriction (degraded, not fail-open).
+				effective := entry.userCtx
+				if coreService != nil && strings.HasPrefix(token, patTokenPrefix) {
+					if fresh, err := coreService.CurrentPATRestriction(r.Context(), token); err == nil {
+						effective = cloneUserContextWithRestriction(entry.userCtx, fresh)
+					}
+				}
+				if !tokenNetworkAllowed(r, effective) {
 					forbiddenResponse(w, "token not permitted from this network")
 					return
 				}
-				next.ServeHTTP(w, r.WithContext(buildRequestContext(r.Context(), entry.userCtx, coreService)))
+				next.ServeHTTP(w, r.WithContext(buildRequestContext(r.Context(), effective, coreService)))
 				return
 			}
 

--- a/server/middleware/auth_test.go
+++ b/server/middleware/auth_test.go
@@ -2,6 +2,8 @@ package middleware
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -10,8 +12,11 @@ import (
 
 	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
 )
 
 const (
@@ -567,6 +572,53 @@ func TestAuthentication_PATNetworkAllowlist(t *testing.T) {
 	assert.Equal(t, http.StatusForbidden, serve("203.0.113.9:5555"), "off-network source IP is forbidden")
 	// And an in-range request after the cached deny still passes (per-request evaluation).
 	assert.Equal(t, http.StatusOK, serve("10.9.9.9:443"), "in-range again after a deny")
+}
+
+// #146: a PAT's CIDR allowlist narrowed AFTER the first request (which cached the
+// identity) must be enforced on the very next request — a cache HIT must not keep
+// permitting a source IP the allowlist no longer allows, even within validTokenTTL.
+func TestAuthentication_PATNetworkAllowlist_RefreshesOnCacheHit(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.User{}, &models.PersonalAccessToken{}))
+	require.NoError(t, db.Create(&models.User{ID: 3, Username: "patuser", Email: "pat@example.com", IsActive: true}).Error)
+
+	const raw = "kx_pat_cidrtoken"
+	sum := sha256.Sum256([]byte(raw))
+	hash := hex.EncodeToString(sum[:])
+	cidrsJSON := `["10.0.0.0/8"]`
+	pat := &models.PersonalAccessToken{ID: 1, UserID: 3, Name: "ci", TokenHash: hash, AllowedCIDRs: cidrsJSON}
+	require.NoError(t, db.Create(pat).Error)
+
+	coreService := core.NewKeyorixCore(store.NewLocalStorage(db))
+	mw := authenticationWithValidator(fakeValidator{}, coreService)
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	serve := func(remoteAddr string) int {
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req.Header.Set("Authorization", "Bearer "+raw)
+		req.RemoteAddr = remoteAddr
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		return w.Code
+	}
+
+	// First request (slow path, via fakeValidator): in-range, cached.
+	require.Equal(t, http.StatusOK, serve("10.1.2.3:5555"))
+
+	// An admin narrows the allowlist directly in storage — simulating a live
+	// mid-incident restriction change on the SAME token the cache already holds.
+	pat.AllowedCIDRs = `["192.0.2.0/24"]`
+	require.NoError(t, db.Save(pat).Error)
+
+	// The SAME source IP that was allowed a moment ago must now be denied — on the
+	// cache-HIT path, not after the 30s TTL expires.
+	assert.Equal(t, http.StatusForbidden, serve("10.1.2.3:5555"),
+		"a narrowed allowlist must take effect on the very next request, not after the cache TTL")
+	// And the newly-allowed network is now honored, also on a cache hit.
+	assert.Equal(t, http.StatusOK, serve("192.0.2.7:5555"))
 }
 
 // A token revoked WHILE a slow-path validation was in flight must not be resurrected by


### PR DESCRIPTION
## Summary

Note: the agent originally assigned this vein hit an account-level session limit partway through (completed `#151` cleanly, hadn't started `#146`/`#150`). I picked it up directly, verified `#151`'s existing fix, and implemented `#146`/`#150` myself.

- **#146**: `authenticationWithValidator`'s cache-hit fast path enforced a PAT's network allowlist against the CACHED `UserContext` snapshot, not the token's current restriction — narrowing a compromised PAT's allowlist mid-incident wouldn't take effect for up to `validTokenTTL` (30s). Adds `KeyorixCore.CurrentPATRestriction`, which re-fetches the restriction fresh by token hash; the middleware now calls it on every cache hit for a PAT-prefixed token and uses the fresh result — falling back to the cached restriction on a lookup error (never treating a fetch failure as "unrestricted," which would fail open on exactly the check this exists to keep honest).
- **#150**: local CLI mode calls `internal/core` functions directly with `actorID=0`, and `InitializeCoreService` honors `storage.type=postgres`, not just embedded SQLite — so a local CLI operator against a SHARED backend attributes every mutation to "no authenticated principal" in the audit trail. Adds a `KEYORIX_CLI_ACTOR` env var an operator can set to their own numeric Keyorix user ID (self-asserted, not cryptographically verified — local mode has no auth layer to verify against, but beats an anonymous 0 for forensic reconstruction); `InitializeCoreService` warns loudly on stderr when local mode targets a non-SQLite backend with no actor set. Wired into the concrete named instance (`keyorix machine binding add/rm`).
- **#151**: `DeprovisionSCIMUser` silently discarded a session-cleanup error inside its own transaction (`_ = tx.DeleteSessionsForUserExcept(...)`), so a genuine storage failure would still commit the deprovision with stale session rows left behind. Now propagates the error, so a failure rolls back the whole transaction cleanly instead of partially completing. (This part was already correctly implemented before the session limit hit.)

## Test plan
- [x] `go build ./...` and `GOWORK=off go build -C operator ./...`
- [x] `go test ./...` (full suite)
- [x] New tests: `TestCurrentPATRestriction_ReflectsLiveNarrowing`/`_LookupFailureIsAnError` (core-level, proving the fresh-lookup primitive and its fail-safe error behavior), `TestAuthentication_PATNetworkAllowlist_RefreshesOnCacheHit` (middleware-level, real `KeyorixCore`+sqlite: narrows a PAT's CIDR mid-test and proves the very next request — a cache hit — is denied, not the 30s-stale allow), `TestResolveActorID` (env-var parsing edge cases)
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues
- [x] `golangci-lint run ./...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)