### PR TITLE
fix: reorder invitation-accept account creation before token consume + audit retention-policy changes (#155, #160)

### DIFF
--- a/internal/core/data_retention.go
+++ b/internal/core/data_retention.go
@@ -14,6 +14,8 @@ import (
 	"context"
 	"fmt"
 	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
 // RetentionPolicy is the resolved set of per-record-type retention windows, in
@@ -54,9 +56,25 @@ func (r RetentionResult) Total() int64 {
 
 // SetRetentionPolicy records the configured per-type retention windows so the
 // compliance posture can report them. The scheduler (main.go) drives the actual
-// purge from config; this setter exists for the read-only posture view.
-func (c *KeyorixCore) SetRetentionPolicy(p RetentionPolicy) {
+// purge from config; this setter exists for the read-only posture view. The
+// server calls it once at startup from keyorix.yaml (#160): an operator with
+// filesystem+restart access who shortens a retention window otherwise leaves no
+// audit trail of the CHANGE itself, only of the resulting purge counts — this
+// records the configured windows every time they're applied, mirroring
+// AuditLicenseState's startup-audit pattern.
+func (c *KeyorixCore) SetRetentionPolicy(ctx context.Context, p RetentionPolicy) {
 	c.retentionPolicy = p
+	ok := true
+	c.emitAudit(ctx, &models.AuditEvent{
+		EventType: "data_retention.policy_configured",
+		Description: fmt.Sprintf(
+			"Data retention policy applied: anomaly_alerts=%dd closed_access_reviews=%dd break_glass=%dd resolved_access_requests=%dd",
+			p.AnomalyAlertsDays, p.ClosedAccessReviewsDays, p.BreakGlassDays, p.ResolvedAccessRequestsDays,
+		),
+		Success:   &ok,
+		ActorType: ActorTypeSystem,
+		EventTime: time.Now(),
+	})
 }
 
 // RetentionPolicy returns the configured retention windows (zero value if unset).

--- a/internal/core/data_retention_test.go
+++ b/internal/core/data_retention_test.go
@@ -73,3 +73,39 @@ func TestRetentionPolicy_Configured(t *testing.T) {
 	require.True(t, RetentionPolicy{AnomalyAlertsDays: 1}.Configured())
 	require.True(t, RetentionPolicy{ResolvedAccessRequestsDays: 90}.Configured())
 }
+
+// #160: applying the retention policy at startup must leave an audit trail of the
+// configured windows, not just of the purge counts it later produces — an operator
+// with filesystem+restart access who shortens a window otherwise leaves no record
+// of the CHANGE itself.
+func TestSetRetentionPolicy_EmitsAuditEvent(t *testing.T) {
+	policy := RetentionPolicy{
+		AnomalyAlertsDays:          30,
+		ClosedAccessReviewsDays:    365,
+		BreakGlassDays:             90,
+		ResolvedAccessRequestsDays: 180,
+	}
+	store := new(MockStorage)
+	var captured *models.AuditEvent
+	store.On("LogAuditEvent", mock.Anything, mock.MatchedBy(func(e *models.AuditEvent) bool {
+		if e.EventType == "data_retention.policy_configured" {
+			captured = e
+			return true
+		}
+		return false
+	})).Return(nil)
+
+	c := NewKeyorixCore(store)
+	c.SetRetentionPolicy(context.Background(), policy)
+
+	require.Equal(t, policy, c.RetentionPolicy())
+	require.NotNil(t, captured, "SetRetentionPolicy must emit an audit event")
+	require.Equal(t, ActorTypeSystem, captured.ActorType)
+	require.NotNil(t, captured.Success)
+	require.True(t, *captured.Success)
+	require.Contains(t, captured.Description, "anomaly_alerts=30d")
+	require.Contains(t, captured.Description, "closed_access_reviews=365d")
+	require.Contains(t, captured.Description, "break_glass=90d")
+	require.Contains(t, captured.Description, "resolved_access_requests=180d")
+	store.AssertExpectations(t)
+}

--- a/internal/core/setup_consume.go
+++ b/internal/core/setup_consume.go
@@ -180,13 +180,15 @@ func (c *KeyorixCore) completeInvitationAccept(ctx context.Context, tok *models.
 		return nil, fmt.Errorf("%w: %v", ErrInvalidSetupPassword, err)
 	}
 
-	// Consume the token (single-use, atomic) before materializing. tok was already
-	// inspected by CompleteSetup, so consume it directly (no re-lookup).
-	if err := c.consumeInspectedToken(ctx, tok, SetupPurposeInvitationAccept); err != nil {
-		return nil, err
-	}
-
 	// Lazily create the account with the chosen password (active — they just set it).
+	// SECURITY (#155): create the account BEFORE consuming the token, not after. If a
+	// concurrent account-creation for the same email (e.g. another invite, an admin
+	// directly adding the address) wins the race, CreateUser fails here and the token
+	// is left untouched, so the legitimate holder can retry the SAME link — at which
+	// point the GetUserByEmail guard above now sees the winning account and returns
+	// the clean "account already exists" message instead of a dead "token already
+	// used" error. Consuming up front (the previous order) permanently burned the
+	// invite link for the loser of that race even though nothing unsafe happened.
 	username, err := c.deriveUsername(ctx, inv.Email)
 	if err != nil {
 		return nil, err
@@ -199,6 +201,12 @@ func (c *KeyorixCore) completeInvitationAccept(ctx context.Context, tok *models.
 	})
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+
+	// Consume the token (single-use, atomic) now that the account exists. tok was
+	// already inspected by CompleteSetup, so consume it directly (no re-lookup).
+	if err := c.consumeInspectedToken(ctx, tok, SetupPurposeInvitationAccept); err != nil {
+		return nil, err
 	}
 
 	// Materialize the invitation's grants under the invite-time validation mode. For a

--- a/server/main.go
+++ b/server/main.go
@@ -633,8 +633,9 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 	}
 
 	// Wire the configured data-retention windows (A.5.33) so the compliance posture
-	// reports them; the scheduler below drives the actual purge.
-	coreService.SetRetentionPolicy(core.RetentionPolicy{
+	// reports them; the scheduler below drives the actual purge. Audited (#160) so a
+	// shortened window is on the record, not just its eventual purge counts.
+	coreService.SetRetentionPolicy(context.Background(), core.RetentionPolicy{
 		AnomalyAlertsDays:          cfg.DataRetention.AnomalyAlertsDays,
 		ClosedAccessReviewsDays:    cfg.DataRetention.ClosedAccessReviewsDays,
 		BreakGlassDays:             cfg.DataRetention.BreakGlassDays,


### PR DESCRIPTION
## Summary

- **#155**: `completeInvitationAccept` consumed the setup token BEFORE calling `CreateUser`. If a concurrent account creation for the same email won the race (another invite, an admin directly adding the address), `CreateUser` failed on the uniqueness constraint but the token was already burned — permanently killing the legitimate invite link with no retry path. Now creates the account first and consumes the token only on success, so a race loser gets a clean "account already exists" on retry instead of a dead "token already used" error. Downgraded from an initial CRITICAL rating in the backlog — this is a denial-of-service on ONE invited user's onboarding link, not a data disclosure or privilege escalation.
- **#160**: `SetRetentionPolicy` (called once at startup from `keyorix.yaml`) now emits a `data_retention.policy_configured` audit event recording the applied per-type windows, mirroring `AuditLicenseState`'s existing startup-audit pattern. An operator with filesystem+restart access who shortens a retention window no longer leaves a forensic gap — previously only the resulting purge counts were recorded, not the policy CHANGE itself.
- **#159** (`connect --password` argv exposure) and **#160(b)** (login timing side-channel) were both already fixed on `main` — verified, no changes needed: `resolveConnectPassword` in `internal/cli/connect/connect.go` already falls back to `KEYORIX_PASSWORD`/a masked prompt with a loud stderr warning on the insecure flag, and `Login` in `internal/core/auth.go` already runs a `dummyBcryptHash` comparison on the not-found/locked paths to equalize timing with the wrong-password path.

## Test plan
- [x] `go build ./...` and `GOWORK=off go build -C operator ./...`
- [x] `go test ./...` (full suite)
- [x] New test: `TestSetRetentionPolicy_EmitsAuditEvent` (asserts the audit event's type, actor, success flag, and that the description encodes all four configured windows)
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues
- [x] `golangci-lint run ./...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)