### PR TITLE
fix: serialize SIEM spool replay() against concurrent re-entry

### DIFF
--- a/internal/audit/siem/spool.go
+++ b/internal/audit/siem/spool.go
@@ -45,6 +45,15 @@ type spool struct {
 	mu   sync.Mutex // serializes file mutation (append + replay rewrite); NOT held across delivery
 	stop chan struct{}
 	done chan struct{}
+
+	// replayMu serializes replay() itself. In production exactly one goroutine (loop)
+	// ever calls replay(), so this never contends — but replay()'s file mutation lock
+	// (mu) is deliberately released across the network delivery calls, so if replay()
+	// were ever invoked concurrently (e.g. a future manual "flush now" trigger racing
+	// the ticker, or a test driving it directly), two overlapping calls would each
+	// independently snapshot the same undelivered lines and double-deliver them before
+	// either rewrites. This queues concurrent callers instead.
+	replayMu sync.Mutex
 }
 
 // newSpool prepares the spool directory and starts the replay loop.
@@ -124,6 +133,9 @@ func (s *spool) loop() {
 // on the audited request path) never blocks behind a SIEM round-trip. Crash-safe: every
 // undelivered line stays on disk until the atomic rewrite at the end.
 func (s *spool) replay() {
+	s.replayMu.Lock()
+	defer s.replayMu.Unlock()
+
 	// Snapshot under the lock, recording the byte length we read; any add() during the
 	// lock-free delivery below only appends BEYOND this offset (add never rewrites), so the
 	// reconcile can cleanly separate "what we attempted" from "what arrived meanwhile".

--- a/internal/audit/siem/spool_test.go
+++ b/internal/audit/siem/spool_test.go
@@ -166,3 +166,37 @@ func TestSpool_ConcurrentAddDuringReplayNotLost(t *testing.T) {
 	}
 	assert.True(t, deliveredLate || inSpool, "the concurrently-added event must be retained or delivered, never lost")
 }
+
+// replay() must serialize against itself: two overlapping callers (e.g. the background
+// loop's own initial replay racing a manually-triggered one, as happened intermittently
+// in CI for TestSpool_PersistsAndReplaysOnRecovery) must not each independently snapshot
+// and deliver the same undelivered lines, which would double-deliver every event.
+func TestSpool_ConcurrentReplayCallsDoNotDoubleDeliver(t *testing.T) {
+	dir := t.TempDir()
+	tr := true
+	d := &fakeDelivery{}
+	// Slow delivery widens the window in which a second, concurrent replay() could race
+	// the first if replay() weren't serialized against itself.
+	hook := func(ctx context.Context, e *models.AuditEvent) error {
+		time.Sleep(10 * time.Millisecond)
+		return d.deliver(ctx, e)
+	}
+	s, err := newSpool(dir, time.Hour, hook)
+	require.NoError(t, err)
+	s.close() // stop the background loop; drive replay() manually and concurrently below
+
+	s.add(&models.AuditEvent{ID: 1, EventType: "secret.read", Success: &tr})
+	s.add(&models.AuditEvent{ID: 2, EventType: "secret.updated", Success: &tr})
+
+	var wg sync.WaitGroup
+	for range 5 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			s.replay()
+		}()
+	}
+	wg.Wait()
+
+	assert.ElementsMatch(t, []uint{1, 2}, d.delivered, "each event must be delivered exactly once despite concurrent replay() callers")
+}


### PR DESCRIPTION
## Summary

Root-caused a CI flake seen twice this round (`TestSpool_PersistsAndReplaysOnRecovery` failing intermittently on `build-and-test`, unrelated to the diffs of the PRs it was blocking — reproduced reliably by re-running the same commit).

- `spool.replay()`'s file-mutation lock is deliberately released across the (slow, network) delivery calls — by design, so a concurrent `add()` on the audited request path never blocks behind a SIEM round-trip.
- But that also means two **overlapping `replay()` callers** each independently snapshot the same undelivered lines and attempt delivery before either rewrites the file — a double-delivery race.
- In production this never fires today: exactly one goroutine (the background loop) ever calls `replay()`, strictly sequentially (ticker-driven, plus one initial call at startup to drain any backlog left by a prior run). But that SAME initial startup call raced `TestSpool_PersistsAndReplaysOnRecovery`'s own manually-driven `replay()` calls, occasionally double-delivering events 1 and 2 and breaking the test's `ElementsMatch` assertion.
- Fix: a dedicated `replayMu` that serializes `replay()` itself (separate from the file-mutation lock `mu`, so `add()` remains unaffected and the "never blocks behind a SIEM round-trip" property is preserved). This also closes a latent hazard for any future concurrent-trigger path (e.g. a manual "flush now" endpoint racing the ticker), not just the test.

## Test plan
- [x] `go build ./...` and `GOWORK=off go build -C operator ./...`
- [x] `go test ./...` (full suite)
- [x] New regression test: `TestSpool_ConcurrentReplayCallsDoNotDoubleDeliver` — 5 concurrent `replay()` callers against a slow delivery hook, asserts each of 2 spooled events is delivered exactly once
- [x] `go test ./internal/audit/siem/... -race -count=20` — clean, including `TestSpool_PersistsAndReplaysOnRecovery` specifically
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues
- [x] `golangci-lint run ./...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)