### PR TITLE
fix: add seccompProfile to k8s-sync chart + wire real DEK rotation + shred migrate-provider backups (#187, #197, #198)

### DIFF
--- a/deploy/helm/keyorix-k8s-sync/templates/deployment.yaml
+++ b/deploy/helm/keyorix-k8s-sync/templates/deployment.yaml
@@ -29,6 +29,8 @@ spec:
       securityContext:
         runAsNonRoot: true
         runAsUser: 1001
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: keyorix-k8s-sync
           image: {{ include "kxsync.image" . | quote }}

--- a/internal/cli/encryption/auth_encryption.go
+++ b/internal/cli/encryption/auth_encryption.go
@@ -159,7 +159,7 @@ func runRotateAuthEncryption(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to initialize auth encryption: %w", err)
 	}
 	fmt.Println("🔄 Starting authentication encryption key rotation...")
-	if err := authEnc.RotateAuthEncryption(); err != nil {
+	if err := authEnc.RotateAuthEncryption(passphrase); err != nil {
 		return fmt.Errorf("failed to rotate auth encryption keys: %w", err)
 	}
 	fmt.Println("✅ Authentication encryption key rotation completed successfully")

--- a/internal/cli/encryption/migrate_provider.go
+++ b/internal/cli/encryption/migrate_provider.go
@@ -14,6 +14,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/config"
@@ -39,6 +41,9 @@ var (
 	mpToTPMDevice      string
 	mpToSaltPath       string
 	mpConfirm          bool
+
+	mpCleanupConfirm bool
+	mpCleanupDryRun  bool
 )
 
 var migrateProviderCmd = &cobra.Command{
@@ -63,6 +68,28 @@ restart — the printed summary shows the exact block.`,
 	RunE: runMigrateProvider,
 }
 
+// migrateProviderCleanupCmd securely deletes leftover `<dekPath>.migrate-backup.*`
+// files (#198). migrate-provider retains its pre-migration wrapped-DEK backup
+// indefinitely by design (so a failed verification can restore it) — but since a
+// rewrap never changes the DEK's VALUE, only its wrapping, the backup's
+// plaintext-after-unwrap stays byte-identical to the DEK still in active use. A
+// weak/compromised OLD KEK can unwrap it forever unless an operator deletes it, and
+// the only prior guidance was a printed "remove once confident" — no tooling.
+var migrateProviderCleanupCmd = &cobra.Command{
+	Use:   "cleanup",
+	Short: "Securely delete leftover pre-migration wrapped-DEK backups",
+	Long: `Find and securely delete every "<dek_path>.migrate-backup.*" file left behind by
+a previous 'migrate-provider' run. Each backup's plaintext-after-unwrap is
+byte-identical to the DEK still in active use (only the wrapping changed), so a
+weak/compromised OLD key-encryption key can still unwrap it indefinitely — deleting
+these once you've confirmed the new provider works removes that exposure window.
+
+Files are overwritten (random pass, then zero pass, each fsynced) before being
+unlinked — a best-effort "shred", not a guarantee on copy-on-write filesystems, SSDs,
+or replicated/snapshotted storage. Requires --confirm; use --dry-run to preview first.`,
+	RunE: runMigrateProviderCleanup,
+}
+
 func init() {
 	EncryptionCmd.AddCommand(migrateProviderCmd)
 	f := migrateProviderCmd.Flags()
@@ -77,6 +104,86 @@ func init() {
 	f.StringVar(&mpToTPMDevice, "to-tpm-device", "", "TPM 2.0 device path (tpm type; default /dev/tpmrm0)")
 	f.StringVar(&mpToSaltPath, "to-salt-path", "", "salt path for the target password provider (default: current salt_path)")
 	f.BoolVar(&mpConfirm, "confirm", false, "required acknowledgement before re-wrapping the DEK")
+
+	migrateProviderCmd.AddCommand(migrateProviderCleanupCmd)
+	cf := migrateProviderCleanupCmd.Flags()
+	cf.BoolVar(&mpCleanupConfirm, "confirm", false, "required acknowledgement before deleting backup files")
+	cf.BoolVar(&mpCleanupDryRun, "dry-run", false, "list matching backup files without deleting them")
+}
+
+// runMigrateProviderCleanup finds and (unless --dry-run) securely deletes every
+// migrate-backup file for the configured DEK path. Matching is by filename prefix
+// "<base>.migrate-backup." directly under the DEK's directory — the same layout
+// migrateProviderWithConfig writes (backupRel is relative to baseDir, sibling to
+// enc.DEKPath).
+func runMigrateProviderCleanup(cmd *cobra.Command, args []string) error {
+	cfg, err := loadConfig()
+	if err != nil {
+		return err
+	}
+	baseDir, _ := os.Getwd()
+	return migrateProviderCleanupWithConfig(cfg, baseDir, mpCleanupDryRun, mpCleanupConfirm)
+}
+
+// migrateProviderCleanupWithConfig is the testable core of the cleanup subcommand:
+// no flag parsing, an explicit baseDir instead of os.Getwd().
+func migrateProviderCleanupWithConfig(cfg *config.Config, baseDir string, dryRun, confirm bool) error {
+	if !cfg.Storage.Encryption.Enabled {
+		return fmt.Errorf("encryption is disabled in configuration")
+	}
+	matches, err := findMigrateBackups(baseDir, cfg.Storage.Encryption.DEKPath)
+	if err != nil {
+		return fmt.Errorf("failed to scan for migrate-backup files: %w", err)
+	}
+	if len(matches) == 0 {
+		fmt.Println("✅ No migrate-backup files found — nothing to clean up.")
+		return nil
+	}
+	fmt.Printf("Found %d migrate-backup file(s):\n", len(matches))
+	for _, m := range matches {
+		fmt.Printf("  %s\n", m)
+	}
+	if dryRun {
+		fmt.Println("\n(--dry-run: no files deleted)")
+		return nil
+	}
+	if !confirm {
+		return fmt.Errorf("this permanently and irreversibly shreds the listed backup file(s). Re-run with --confirm (or --dry-run to only list them)")
+	}
+	for _, m := range matches {
+		if err := securefiles.SecureDeleteFile(filepath.Join(baseDir, m)); err != nil {
+			return fmt.Errorf("failed to securely delete %s: %w", m, err)
+		}
+	}
+	fmt.Printf("✅ Securely deleted %d migrate-backup file(s).\n", len(matches))
+	return nil
+}
+
+// findMigrateBackups lists filenames (relative to baseDir) matching
+// "<base>.migrate-backup.*" for the given DEK path, sorted for stable output.
+func findMigrateBackups(baseDir, dekPath string) ([]string, error) {
+	dir := filepath.Dir(filepath.Join(baseDir, dekPath))
+	prefix := filepath.Base(dekPath) + ".migrate-backup."
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var matches []string
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasPrefix(e.Name(), prefix) {
+			continue
+		}
+		rel, rerr := filepath.Rel(baseDir, filepath.Join(dir, e.Name()))
+		if rerr != nil {
+			continue
+		}
+		matches = append(matches, rel)
+	}
+	sort.Strings(matches)
+	return matches, nil
 }
 
 // migrateOpts is the target-provider description, mirroring the --to-* flags so the
@@ -320,7 +427,11 @@ func providerLabel(t string) string {
 func printMigrateSummary(tgt config.EncryptionConfig, backupRel string) {
 	kp := tgt.KeyProvider
 	fmt.Println("✅ DEK re-wrapped and verified under the new provider.")
-	fmt.Printf("🗄️  Previous wrapped DEK backed up at %s (remove once confident).\n", backupRel)
+	fmt.Printf("🗄️  Previous wrapped DEK backed up at %s.\n", backupRel)
+	fmt.Println("   Its plaintext-after-unwrap is byte-identical to the DEK still in active use —")
+	fmt.Println("   only the wrapping changed. Once you've confirmed the new provider works, run")
+	fmt.Println("   `keyorix encryption migrate-provider cleanup --confirm` to securely delete it")
+	fmt.Println("   (and any other leftover migrate-backup files) rather than a plain rm.")
 	fmt.Println()
 	fmt.Println("⚠️  Update storage.encryption.key_provider in your config to match BEFORE the next restart:")
 	fmt.Println()

--- a/internal/cli/encryption/migrate_provider_test.go
+++ b/internal/cli/encryption/migrate_provider_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"io"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -102,6 +103,73 @@ func TestMigrateProvider_EndToEnd_PasswordToEnv(t *testing.T) {
 	matches, _ := filepath.Glob(filepath.Join(dir, "dek.key.migrate-backup.*"))
 	if len(matches) == 0 {
 		t.Fatalf("expected a dek.key.migrate-backup.* file")
+	}
+}
+
+// TestMigrateProviderCleanup_EndToEnd runs a real migration (leaving a backup file
+// behind), then confirms cleanup finds it, dry-run leaves it in place, and a
+// confirmed run securely deletes it (#198).
+func TestMigrateProviderCleanup_EndToEnd(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	t.Setenv("KEYORIX_MASTER_PASSWORD", "Sup3r-Secret-Passphrase!")
+	raw := make([]byte, 32)
+	if _, err := io.ReadFull(rand.Reader, raw); err != nil {
+		t.Fatalf("gen kek: %v", err)
+	}
+	t.Setenv("KEYORIX_TARGET_KEK", hex.EncodeToString(raw))
+
+	cfg := enabledLocalCfg()
+	cfg.Storage.Encryption.DEKPath = "dek.key"
+	cfg.Storage.Encryption.SaltPath = "kek.salt"
+
+	if err := migrateProviderWithConfig(cfg, migrateOpts{toType: "env", toEnvVar: "KEYORIX_TARGET_KEK"}, true); err != nil {
+		t.Fatalf("migrate password -> env: %v", err)
+	}
+
+	matches, _ := filepath.Glob(filepath.Join(dir, "dek.key.migrate-backup.*"))
+	if len(matches) != 1 {
+		t.Fatalf("expected exactly one migrate-backup file, got %v", matches)
+	}
+	backupPath := matches[0]
+
+	// Dry-run must list it but not delete it.
+	if err := migrateProviderCleanupWithConfig(cfg, dir, true, false); err != nil {
+		t.Fatalf("dry-run cleanup: %v", err)
+	}
+	if _, err := os.Stat(backupPath); err != nil {
+		t.Fatalf("dry-run must not delete the backup file: %v", err)
+	}
+
+	// Without --confirm (and not --dry-run), it must refuse.
+	if err := migrateProviderCleanupWithConfig(cfg, dir, false, false); err == nil || !strings.Contains(err.Error(), "--confirm") {
+		t.Fatalf("expected --confirm gate, got: %v", err)
+	}
+	if _, err := os.Stat(backupPath); err != nil {
+		t.Fatalf("unconfirmed cleanup must not delete the backup file: %v", err)
+	}
+
+	// Confirmed cleanup deletes it.
+	if err := migrateProviderCleanupWithConfig(cfg, dir, false, true); err != nil {
+		t.Fatalf("confirmed cleanup: %v", err)
+	}
+	if _, err := os.Stat(backupPath); !os.IsNotExist(err) {
+		t.Fatalf("expected backup file to be deleted, stat err = %v", err)
+	}
+
+	// A second run finds nothing left to clean up.
+	if err := migrateProviderCleanupWithConfig(cfg, dir, false, true); err != nil {
+		t.Fatalf("cleanup on empty state should be a no-op success: %v", err)
+	}
+}
+
+func TestMigrateProviderCleanup_RejectsDisabledEncryption(t *testing.T) {
+	cfg := enabledLocalCfg()
+	cfg.Storage.Encryption.Enabled = false
+	err := migrateProviderCleanupWithConfig(cfg, t.TempDir(), false, true)
+	if err == nil || !strings.Contains(err.Error(), "disabled") {
+		t.Fatalf("expected disabled-encryption rejection, got: %v", err)
 	}
 }
 

--- a/internal/encryption/auth_encryption_rotate.go
+++ b/internal/encryption/auth_encryption_rotate.go
@@ -1,100 +1,24 @@
-// auth_encryption_rotate.go — RotateAuthEncryption and per-type rotation helpers.
+// auth_encryption_rotate.go — RotateAuthEncryption, delegating to the real DEK rotation.
 //
-// RotateAuthEncryption, rotateAPIClientSecrets, rotateSessionTokens, rotateAPITokens.
 // For encrypt/decrypt see auth_encryption.go. For DB store/retrieve see auth_encryption_store.go.
 package encryption
 
-import (
-	"fmt"
+import "fmt"
 
-	"github.com/keyorixhq/keyorix/internal/storage/models"
-)
-
-// RotateAuthEncryption re-encrypts all authentication data (API clients, sessions, API tokens).
-func (ae *AuthEncryption) RotateAuthEncryption() error {
+// RotateAuthEncryption performs a true DEK rotation (ADR-010): a new DEK is generated and
+// every DEK-encrypted row — including API client secrets, session tokens, and API tokens —
+// is re-encrypted under it in one atomic sweep, delegating to Service.RotateDEKWithSweep.
+//
+// #197: this previously unwrapped the EXISTING on-disk DEK and re-encrypted rows under that
+// SAME unchanged key — no new key material was ever generated, despite the command's help
+// text and success message claiming otherwise. passphrase is forwarded to the key manager
+// for KEK derivation to re-wrap the new DEK — never stored.
+func (ae *AuthEncryption) RotateAuthEncryption(passphrase string) error {
 	if !ae.service.IsEnabled() {
 		return fmt.Errorf("encryption is disabled")
 	}
-	if err := ae.rotateAPIClientSecrets(); err != nil {
-		return fmt.Errorf("failed to rotate API client secrets: %w", err)
-	}
-	if err := ae.rotateSessionTokens(); err != nil {
-		return fmt.Errorf("failed to rotate session tokens: %w", err)
-	}
-	if err := ae.rotateAPITokens(); err != nil {
-		return fmt.Errorf("failed to rotate API tokens: %w", err)
-	}
-	return nil
-}
-
-func (ae *AuthEncryption) rotateAPIClientSecrets() error {
-	var clients []models.APIClient
-	if err := ae.db.Find(&clients).Error; err != nil {
-		return fmt.Errorf("failed to retrieve API clients: %w", err)
-	}
-	for _, client := range clients {
-		plain, err := ae.DecryptClientSecret(client.EncryptedClientSecret, []byte(client.ClientSecretMetadata))
-		if err != nil {
-			return fmt.Errorf("failed to decrypt client secret for rotation: %w", err)
-		}
-		enc, meta, err := ae.EncryptClientSecret(plain)
-		if err != nil {
-			return fmt.Errorf("failed to re-encrypt client secret: %w", err)
-		}
-		if err := ae.db.Model(&client).Updates(map[string]interface{}{
-			"encrypted_client_secret": enc,
-			"client_secret_metadata":  models.JSON(meta),
-		}).Error; err != nil {
-			return fmt.Errorf("failed to update rotated client secret: %w", err)
-		}
-	}
-	return nil
-}
-
-func (ae *AuthEncryption) rotateSessionTokens() error {
-	var sessions []models.Session
-	if err := ae.db.Find(&sessions).Error; err != nil {
-		return fmt.Errorf("failed to retrieve sessions: %w", err)
-	}
-	for _, session := range sessions {
-		plain, err := ae.DecryptSessionToken(session.EncryptedSessionToken, []byte(session.SessionTokenMetadata))
-		if err != nil {
-			return fmt.Errorf("failed to decrypt session token for rotation: %w", err)
-		}
-		enc, meta, err := ae.EncryptSessionToken(plain)
-		if err != nil {
-			return fmt.Errorf("failed to re-encrypt session token: %w", err)
-		}
-		if err := ae.db.Model(&session).Updates(map[string]interface{}{
-			"encrypted_session_token": enc,
-			"session_token_metadata":  models.JSON(meta),
-		}).Error; err != nil {
-			return fmt.Errorf("failed to update rotated session token: %w", err)
-		}
-	}
-	return nil
-}
-
-func (ae *AuthEncryption) rotateAPITokens() error {
-	var tokens []models.APIToken
-	if err := ae.db.Find(&tokens).Error; err != nil {
-		return fmt.Errorf("failed to retrieve API tokens: %w", err)
-	}
-	for _, token := range tokens {
-		plain, err := ae.DecryptAPIToken(token.EncryptedToken, []byte(token.TokenMetadata))
-		if err != nil {
-			return fmt.Errorf("failed to decrypt API token for rotation: %w", err)
-		}
-		enc, meta, err := ae.EncryptAPIToken(plain)
-		if err != nil {
-			return fmt.Errorf("failed to re-encrypt API token: %w", err)
-		}
-		if err := ae.db.Model(&token).Updates(map[string]interface{}{
-			"encrypted_token": enc,
-			"token_metadata":  models.JSON(meta),
-		}).Error; err != nil {
-			return fmt.Errorf("failed to update rotated API token: %w", err)
-		}
+	if err := ae.service.RotateDEKWithSweep(passphrase, ae.db); err != nil {
+		return fmt.Errorf("failed to rotate auth encryption keys: %w", err)
 	}
 	return nil
 }

--- a/internal/encryption/auth_encryption_test.go
+++ b/internal/encryption/auth_encryption_test.go
@@ -291,11 +291,27 @@ func TestAuthEncryption_DisabledEncryption(t *testing.T) {
 	assert.Equal(t, clientSecret, decryptedSecret)
 }
 
+// TestAuthEncryption_KeyRotation exercises the REAL rotation path (#197): unlike the rest of
+// this file, encryption must be enabled with real on-disk key material, since a true DEK
+// rotation (new key generated, old key wiped) is meaningless against the pass-through
+// no-op encryption setupAuthEncryptionTest otherwise uses.
 func TestAuthEncryption_KeyRotation(t *testing.T) {
-	authEnc, _, cleanup := setupAuthEncryptionTest(t)
-	defer cleanup()
+	dir := t.TempDir()
+	db, err := gorm.Open(sqlite.Open(filepath.Join(dir, "test.db")), &gorm.Config{})
+	require.NoError(t, err)
+	// RotateAuthEncryption delegates to RotateDEKWithSweep, which sweeps every
+	// DEK-encrypted table (see SweepAllTables), not just the auth-specific ones.
+	require.NoError(t, db.AutoMigrate(
+		&models.SecretNode{}, &models.SecretVersion{},
+		&models.APIClient{}, &models.Session{}, &models.APIToken{}, &models.PasswordReset{},
+		&models.MFASecret{}, &models.DynamicSecretConfig{}, &models.DynamicSecretLease{},
+	))
 
-	// Create test data
+	const passphrase = "test-passphrase-for-key-rotation"
+	cfg := &config.EncryptionConfig{Enabled: true, DEKPath: "dek.key", SaltPath: "kek.salt"}
+	authEnc := NewAuthEncryption(cfg, dir, db)
+	require.NoError(t, authEnc.Initialize(passphrase))
+
 	client := &models.APIClient{
 		Name:      "Test Client",
 		ClientID:  "test-client-rotation",
@@ -303,27 +319,21 @@ func TestAuthEncryption_KeyRotation(t *testing.T) {
 		IsActive:  true,
 		CreatedAt: time.Now(),
 	}
-
 	clientSecret := "secret-for-rotation"
-	err := authEnc.StoreEncryptedAPIClient(client, clientSecret)
-	require.NoError(t, err)
+	require.NoError(t, authEnc.StoreEncryptedAPIClient(client, clientSecret))
 
-	// Verify original secret works
 	retrievedSecret, err := authEnc.RetrieveAPIClientSecret("test-client-rotation")
 	require.NoError(t, err)
 	assert.Equal(t, clientSecret, retrievedSecret)
 
-	// Skip key rotation test when encryption is disabled
-	if !authEnc.service.IsEnabled() {
-		t.Skip("Skipping key rotation test when encryption is disabled")
-	}
+	keyVersionBefore := authEnc.service.GetKeyVersion()
 
-	// Rotate keys (this would normally involve key manager rotation)
-	// For this test, we'll simulate by re-encrypting with the same key
-	err = authEnc.RotateAuthEncryption()
-	require.NoError(t, err)
+	require.NoError(t, authEnc.RotateAuthEncryption(passphrase))
 
-	// Verify secret still works after rotation
+	// A real rotation must produce a NEW key version, not silently keep the old one.
+	assert.NotEqual(t, keyVersionBefore, authEnc.service.GetKeyVersion(), "RotateAuthEncryption must generate new key material, not just re-encrypt under the same key")
+
+	// The secret, re-encrypted under the new DEK by the sweep, must still decrypt correctly.
 	retrievedSecret, err = authEnc.RetrieveAPIClientSecret("test-client-rotation")
 	require.NoError(t, err)
 	assert.Equal(t, clientSecret, retrievedSecret)

--- a/internal/securefiles/securefiles.go
+++ b/internal/securefiles/securefiles.go
@@ -1,6 +1,7 @@
 package securefiles
 
 import (
+	"crypto/rand"
 	"fmt"
 	"os"
 	"os/user"
@@ -165,6 +166,55 @@ func SyncDir(dirPath string) error {
 		return serr
 	}
 	return d.Close()
+}
+
+// SecureDeleteFile overwrites path with random bytes, then zeros, fsyncing after each
+// pass, before unlinking it — a best-effort "shred" for key-material backups that
+// should not linger recoverable on disk (e.g. a pre-migration wrapped-DEK backup, whose
+// plaintext-after-unwrap is byte-identical to the DEK still in active use). This is NOT
+// a guarantee on copy-on-write filesystems, SSDs with wear-leveling, or any snapshotted/
+// replicated storage — those may retain the original blocks regardless of what gets
+// written to the logical file — but it's strictly better than a plain unlink, and is the
+// same caveat any shred(1)-style tool carries.
+func SecureDeleteFile(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	size := info.Size()
+
+	f, err := os.OpenFile(path, os.O_WRONLY, 0) // #nosec G304 -- caller-controlled key-backup path, not network input
+	if err != nil {
+		return err
+	}
+	overwrite := func(pattern func([]byte) error) error {
+		buf := make([]byte, size)
+		if err := pattern(buf); err != nil {
+			return err
+		}
+		if _, err := f.WriteAt(buf, 0); err != nil {
+			return err
+		}
+		return f.Sync()
+	}
+	if err := overwrite(func(b []byte) error { _, err := rand.Read(b); return err }); err != nil {
+		_ = f.Close()
+		return fmt.Errorf("shred pass (random) failed: %w", err)
+	}
+	if err := overwrite(func(b []byte) error { return nil /* buf is already zero-valued */ }); err != nil {
+		_ = f.Close()
+		return fmt.Errorf("shred pass (zero) failed: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		return err
+	}
+	if err := os.Remove(path); err != nil {
+		return err
+	}
+	return SyncDir(filepath.Dir(path))
 }
 
 // FixFilePerms verifies file permissions and ownership.

--- a/internal/securefiles/securefiles_test.go
+++ b/internal/securefiles/securefiles_test.go
@@ -224,3 +224,19 @@ func TestContainmentRejectsSymlinkEscape(t *testing.T) {
 	_, statErr := os.Stat(filepath.Join(outside, "planted.txt"))
 	assert.True(t, os.IsNotExist(statErr), "rejected write must not create a file outside base")
 }
+
+func TestSecureDeleteFile_OverwritesAndRemoves(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "dek.key.migrate-backup.123")
+	original := []byte("sensitive-wrapped-dek-bytes-not-random")
+	require.NoError(t, os.WriteFile(path, original, 0600))
+
+	require.NoError(t, SecureDeleteFile(path))
+
+	_, err := os.Stat(path)
+	assert.True(t, os.IsNotExist(err), "file must be removed")
+}
+
+func TestSecureDeleteFile_MissingFileIsNotAnError(t *testing.T) {
+	require.NoError(t, SecureDeleteFile(filepath.Join(t.TempDir(), "does-not-exist")))
+}


### PR DESCRIPTION
## Summary

- **#187**: `keyorix-k8s-sync` chart's pod `securityContext` was missing `seccompProfile: RuntimeDefault`, inconsistent with the `keyorix-operator` chart which already sets it. Under the Kubernetes "restricted" Pod Security Standard this chart as written would fail admission or run without an explicit seccomp profile.
- **#197**: `keyorix encryption auth-encryption rotate` — unreachable today (never wired to the CLI root), but a landmine if ever exposed — only unwrapped the EXISTING on-disk DEK and re-encrypted rows under that SAME unchanged key. No new key material was ever generated despite the command's help text and success message actively claiming otherwise. `RotateAuthEncryption` now delegates to `Service.RotateDEKWithSweep`, which performs a REAL DEK rotation with a full re-encryption sweep across every DEK-encrypted table (sessions, API tokens, API clients, password resets, secret versions, MFA secrets, dynamic-secret configs/leases) — strictly more correct and complete than the three hand-rolled per-type rotators it replaces (removed as dead code).
- **#198**: `migrate-provider`'s pre-migration DEK backup was retained indefinitely with only a printed "remove once confident" — no tooling, no auto-cleanup. Since a rewrap never changes the DEK's VALUE, only its wrapping, the backup's plaintext-after-unwrap stays byte-identical to the DEK still in active use, so a weak/compromised OLD KEK could unwrap it forever. Adds `migrate-provider cleanup [--dry-run] --confirm`, which finds every `<dek_path>.migrate-backup.*` file and securely deletes it via a new `securefiles.SecureDeleteFile` (random pass, then zero pass, each fsynced, then unlink — best-effort, not a guarantee on copy-on-write/SSD/replicated storage, same caveat as `shred(1)`). The post-migration summary now points operators at it instead of a plain `rm`.

## Test plan
- [x] `go build ./...` and `GOWORK=off go build -C operator ./...`
- [x] `go test ./...` (full suite)
- [x] New/updated tests: `TestAuthEncryption_KeyRotation` (rewritten to actually enable encryption and assert the key VERSION changes, not just that the old no-op path still round-trips), `TestMigrateProviderCleanup_EndToEnd` (real migration → dry-run leaves the backup → unconfirmed refuses → confirmed deletes → idempotent no-op on empty state), `TestMigrateProviderCleanup_RejectsDisabledEncryption`, `TestSecureDeleteFile_OverwritesAndRemoves`, `TestSecureDeleteFile_MissingFileIsNotAnError`
- [x] `helm template deploy/helm/keyorix-k8s-sync --set keyorix.url=... --set keyorix.tokenSecret.name=...` — confirms `seccompProfile: RuntimeDefault` renders
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues
- [x] `golangci-lint run ./...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)