### PR TITLE
fix: 404 on directory-resolving asset requests and unmatched backend-route paths (#213, #214)

### DIFF
--- a/server/http/router.go
+++ b/server/http/router.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -708,38 +709,86 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 	return r, nil
 }
 
+// backendRoutePrefixes lists every non-SPA route family registered on the router
+// outside registerWebUI (see router.go's setup above /api/v1, plus /api/v1 itself).
+// #214: NotFound previously only special-cased /api/, so a typo'd path under any
+// other backend family (auth, health checks, SCIM, metrics, SAML/SSO endpoints
+// under /auth, the OpenAPI/swagger docs) silently fell through to the SPA shell
+// with a 200 instead of a 404 — not an auth bypass (same static public shell
+// everyone gets at /), but noisy/incorrect status codes confuse health-check
+// tooling and WAF rules that expect a clean 404 on an unknown path.
+var backendRoutePrefixes = []string{
+	"/api/", "/auth/", "/scim/", "/system/init", "/health", "/readyz", "/metrics", "/status", "/swagger/", "/openapi.yaml",
+}
+
+func isBackendRoute(p string) bool {
+	for _, prefix := range backendRoutePrefixes {
+		if strings.HasPrefix(p, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// noDirListing wraps a static file handler so a request that resolves to a
+// directory (no index file inside it) returns 404 instead of falling through to
+// Go's default http.FileServer directory listing (#213). dist/assets has no
+// index.html, so a bare GET /assets/ would otherwise list every bundled filename
+// including .js.map source-map names — low impact (already discoverable via the
+// built JS's own sourceMappingURL comments and index.html's hashed bundle
+// references) but unnecessary and inconsistent with serving no directory index.
+func noDirListing(fsys http.FileSystem, h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		upath := req.URL.Path
+		if !strings.HasPrefix(upath, "/") {
+			upath = "/" + upath
+		}
+		if f, err := fsys.Open(path.Clean(upath)); err == nil {
+			fi, statErr := f.Stat()
+			_ = f.Close()
+			if statErr == nil && fi.IsDir() {
+				http.NotFound(w, req)
+				return
+			}
+		}
+		h.ServeHTTP(w, req)
+	})
+}
+
 // registerWebUI wires the SPA's static assets and the client-side-routing
 // fallback against fsys, which is rooted at the dist directory (so request paths
 // map directly: /assets/x -> dist/assets/x). fsys is either an on-disk build
 // (http.Dir) or the embedded build (webui.HTTPFS()).
 func registerWebUI(r chi.Router, fsys http.FileSystem) {
 	fileServer := http.FileServer(fsys)
+	assetServer := noDirListing(fsys, fileServer)
 
 	// Static assets are read-only: register GET+HEAD only, so a mutating method
 	// (DELETE/PUT/POST/PATCH) on an asset gets a 405 from chi rather than the file
 	// served with a 200 (http.FileServer ignores the method). Cleaner semantics and a
 	// smaller surface for a security product.
-	serveStatic := func(pattern string, mws ...func(http.Handler) http.Handler) {
+	serveStatic := func(pattern string, h http.Handler, mws ...func(http.Handler) http.Handler) {
 		rr := r.With(mws...)
-		rr.Method(http.MethodGet, pattern, fileServer)
-		rr.Method(http.MethodHead, pattern, fileServer)
+		rr.Method(http.MethodGet, pattern, h)
+		rr.Method(http.MethodHead, pattern, h)
 	}
-	serveStatic("/assets/*", setCacheHeaders)
-	serveStatic("/static/*", setCacheHeaders)
-	serveStatic("/sw.js")
-	serveStatic("/manifest.json")
-	serveStatic("/favicon.ico")
+	serveStatic("/assets/*", assetServer, setCacheHeaders)
+	serveStatic("/static/*", assetServer, setCacheHeaders)
+	serveStatic("/sw.js", fileServer)
+	serveStatic("/manifest.json", fileServer)
+	serveStatic("/favicon.ico", fileServer)
 
 	// SPA fallback: serve index.html for any non-API route that didn't match a
 	// registered handler, so client-side routes (e.g. /admin/users) resolve. Only for
 	// GET/HEAD — a mutating method to an unmatched path is not a page load.
 	r.NotFound(func(w http.ResponseWriter, req *http.Request) {
-		// An unmatched API path is a 404 regardless of method.
-		if strings.HasPrefix(req.URL.Path, "/api/") {
+		// An unmatched path under any known backend route family is a 404
+		// regardless of method — never the SPA shell.
+		if isBackendRoute(req.URL.Path) {
 			http.NotFound(w, req)
 			return
 		}
-		// A mutating method to a non-API, unmatched path is not a page load.
+		// A mutating method to a non-backend, unmatched path is not a page load.
 		if req.Method != http.MethodGet && req.Method != http.MethodHead {
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 			return

--- a/server/http/static_hardening_test.go
+++ b/server/http/static_hardening_test.go
@@ -1,0 +1,101 @@
+package http
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newOnDiskWebUIRouter builds a router serving a temp on-disk web build with an
+// /assets directory that has NO index.html inside it — mirroring the real SPA
+// build's layout (dist/assets has no index) — so directory-listing behavior is
+// directly testable, unlike the embedded placeholder build used elsewhere.
+func newOnDiskWebUIRouter(t *testing.T) *httptest.Server {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	t.Cleanup(i18n.ResetForTesting)
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "index.html"), []byte("<html>Keyorix</html>"), 0644))
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "assets"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "assets", "app.js"), []byte("console.log(1)"), 0644))
+
+	cfg := &config.Config{}
+	cfg.Server.HTTP.WebAssetsPath = dir
+	router, err := NewRouter(cfg, newTestCore(t))
+	require.NoError(t, err)
+	srv := httptest.NewServer(router)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// TestAssetDirListing_Returns404NotListing pins #213: a directory-resolving
+// request under /assets/ (no index.html inside it) must 404, not fall through to
+// Go's default http.FileServer directory listing of every bundled filename.
+func TestAssetDirListing_Returns404NotListing(t *testing.T) {
+	srv := newOnDiskWebUIRouter(t)
+	client := &http.Client{}
+
+	// "/assets" (no trailing slash) doesn't match the "/assets/*" wildcard route at
+	// all in chi — it falls straight to the SPA fallback like any other client
+	// route, never reaching http.FileServer, so it is not a listing vector and is
+	// intentionally not asserted here; "/assets/" is the actual listing case.
+	resp, err := client.Get(srv.URL + "/assets/")
+	require.NoError(t, err)
+	_ = resp.Body.Close()
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode, "GET /assets/ must be 404, not a directory listing")
+
+	// A real asset file inside the directory must still be served normally.
+	resp, err = client.Get(srv.URL + "/assets/app.js")
+	require.NoError(t, err)
+	body := readAll(t, resp.Body)
+	_ = resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "console.log(1)", body)
+}
+
+// TestNotFound_BackendRoutePrefixesReturn404 pins #214: an unmatched path under a
+// KNOWN backend route family (not just /api/) must 404, not silently fall through
+// to the SPA shell with a 200.
+func TestNotFound_BackendRoutePrefixesReturn404(t *testing.T) {
+	srv := newOnDiskWebUIRouter(t)
+	client := &http.Client{}
+
+	for _, p := range []string{
+		"/auth/does-not-exist",
+		"/scim/v2/does-not-exist",
+		"/system/init/typo",
+		"/health/nested/typo",
+		"/readyz/typo",
+		"/metrics/typo",
+		"/status/typo",
+		"/swagger/typo",
+		"/openapi.yaml.bak",
+		// /api/v1/does-not-exist is NOT asserted here: an unmatched path inside the
+		// /api/v1 subrouter never reaches this NotFound handler at all — it's caught
+		// by the subrouter's own auth middleware first (401, see
+		// TestStaticAssets_RejectMutatingMethods) — so /api/ coverage here would be
+		// redundant with, not additive to, this handler's own prefix check.
+	} {
+		resp, err := client.Get(srv.URL + p)
+		require.NoError(t, err)
+		_ = resp.Body.Close()
+		assert.Equal(t, http.StatusNotFound, resp.StatusCode, "GET %s must be 404, not the SPA shell", p)
+	}
+
+	// An unmatched path OUTSIDE every known backend family is still a client-side
+	// SPA route and must resolve to index.html (unchanged behavior).
+	resp, err := client.Get(srv.URL + "/admin/users")
+	require.NoError(t, err)
+	body := readAll(t, resp.Body)
+	_ = resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Contains(t, body, "Keyorix")
+}


### PR DESCRIPTION
## Summary

- **#213**: `http.FileServer` over the SPA's `dist/assets` (no `index.html` inside it) served Go's default directory listing for a bare `GET /assets/`, revealing the full static-asset filename list including `.js.map` source-map names. Low impact — every revealed filename is already discoverable via the built JS's own `//# sourceMappingURL` comments and `index.html`'s hashed bundle references — but unnecessary. Adds `noDirListing`, wrapping the `/assets/*` and `/static/*` file servers so a request resolving to a directory 404s instead of falling through to the listing.
- **#214**: the SPA-fallback `NotFound` handler only special-cased `/api/`, so a typo'd path under any other backend route family (`/auth`, `/health`, `/readyz`, `/metrics`, `/status`, `/scim`, `/swagger`, `/openapi.yaml`) silently fell through to the static SPA shell with a `200` instead of a `404`. Not an auth bypass (same static public shell everyone gets at `/`) but noisy/incorrect status codes confuse health-check tooling and WAF rules expecting a clean 404. Broadens the guard to a full list of known backend route prefixes; an unmatched path outside all of them still correctly falls through to the SPA (client-side routing is inherently open-ended, so this is a denylist of known backend prefixes, not an allowlist of SPA paths, per the backlog's suggested remediation).

## Test plan
- [x] `go build ./...` and `GOWORK=off go build -C operator ./...`
- [x] `go test ./...` (full suite)
- [x] New tests in `server/http/static_hardening_test.go`: `TestAssetDirListing_Returns404NotListing` (GET `/assets/` → 404, a real asset file still serves normally), `TestNotFound_BackendRoutePrefixesReturn404` (every known backend prefix 404s on an unmatched sub-path; a path outside all of them still resolves to the SPA shell — unchanged behavior)
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues
- [x] `golangci-lint run ./...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)