### PR TITLE
harden: gate the deployment-wide disclosure family behind audit.read (#255/#272-275/#280-281)

### DIFF
--- a/internal/core/compliance_posture.go
+++ b/internal/core/compliance_posture.go
@@ -3,7 +3,8 @@
 // state of the controls Keyorix already enforces — audit-trail integrity, access
 // recertification coverage, dormant standing access, secret-rotation hygiene,
 // second-factor coverage, and break-glass usage — into one structured object,
-// grouped by control area. Read-only; gated by system.read.
+// grouped by control area. Read-only; gated by audit.read (not the universal
+// system_viewer baseline — see #255/#272 disclosure-family fix in router.go).
 package core
 
 import (

--- a/internal/core/dashboard.go
+++ b/internal/core/dashboard.go
@@ -85,11 +85,20 @@ func (c *KeyorixCore) GetDashboardStats(ctx context.Context, userID uint, userna
 		sharedWithMe = len(incoming)
 	}
 
-	// Recent activity is audit data. Only an auditor (audit.read) may see ALL users'
-	// events — otherwise scope it to the caller's own activity, so the dashboard doesn't
-	// leak secret names / actions from projects the caller can't read.
+	// GetDashboardStats is reachable by any caller holding at least the universal
+	// system_viewer baseline (system.read is enforced in the router) — every regular
+	// user's own home dashboard. Only a genuinely elevated caller (audit.read:
+	// system_admin/system_auditor) may see the DEPLOYMENT-WIDE aggregates mixed into
+	// this same payload (active-user count, audit-event counts, failed-auth count,
+	// inactive-user count): a zero-project-membership baseline account has no
+	// legitimate route to org-wide numbers otherwise (#272). Recent activity gets the
+	// same treatment, scoped to the caller's own events when they lack audit.read, so
+	// the dashboard never leaks secret names/actions from projects the caller can't
+	// read.
+	hasAuditRead, _ := c.Authorize(ctx, userID, "audit.read", Scope{})
+
 	var auditActor *uint
-	if ok, _ := c.Authorize(ctx, userID, "audit.read", Scope{}); !ok {
+	if !hasAuditRead {
 		auditActor = &userID
 	}
 	events, _, _ := c.storage.GetAuditLogs(ctx, &storage.AuditFilter{
@@ -104,53 +113,55 @@ func (c *KeyorixCore) GetDashboardStats(ctx context.Context, userID uint, userna
 
 	expiringSecrets := c.getExpiringSecrets(ctx, username)
 
-	// Active users from storage stats
-	var activeUsers int64
-	if storageStats, err := c.storage.GetStats(ctx); err == nil {
-		activeUsers = storageStats.TotalUsers
+	var activeUsers, auditCount, auditLogins, auditSecretReads, failedAuth24h, inactiveUsers int64
+	if hasAuditRead {
+		// Active users from storage stats.
+		if storageStats, err := c.storage.GetStats(ctx); err == nil {
+			activeUsers = storageStats.TotalUsers
+		}
+
+		// Audit events in the last 30 days — total count only.
+		thirtyDaysAgo := time.Now().UTC().Add(-30 * 24 * time.Hour)
+		_, auditCount, _ = c.storage.GetAuditLogs(ctx, &storage.AuditFilter{
+			StartTime: &thirtyDaysAgo,
+			Page:      1,
+			PageSize:  1,
+		})
+		// Auth events (login/logout) vs secret events in last 30 days.
+		authAction := "auth.login"
+		_, auditLogins, _ = c.storage.GetAuditLogs(ctx, &storage.AuditFilter{
+			StartTime: &thirtyDaysAgo,
+			Action:    &authAction,
+			Page:      1,
+			PageSize:  1,
+		})
+		secretReadAction := "secret.read"
+		_, auditSecretReads, _ = c.storage.GetAuditLogs(ctx, &storage.AuditFilter{
+			StartTime: &thirtyDaysAgo,
+			Action:    &secretReadAction,
+			Page:      1,
+			PageSize:  1,
+		})
+
+		// Failed auth attempts in the last 24 hours (success=false, any action).
+		twentyFourHoursAgo := time.Now().UTC().Add(-24 * time.Hour)
+		successFalse := false
+		_, failedAuth24h, _ = c.storage.GetAuditLogs(ctx, &storage.AuditFilter{
+			StartTime: &twentyFourHoursAgo,
+			Success:   &successFalse,
+			Page:      1,
+			PageSize:  1,
+		})
+
+		// Inactive users: registered users whose last_login_at is null or older than
+		// 30 days. Counted directly off the users table (no audit-log scan).
+		inactiveCutoff := thirtyDaysAgo
+		_, inactiveUsers, _ = c.storage.ListUsers(ctx, &storage.UserFilter{
+			InactiveSince: &inactiveCutoff,
+			Page:          1,
+			PageSize:      1,
+		})
 	}
-
-	// Audit events in the last 30 days — total count only
-	thirtyDaysAgo := time.Now().UTC().Add(-30 * 24 * time.Hour)
-	_, auditCount, _ := c.storage.GetAuditLogs(ctx, &storage.AuditFilter{
-		StartTime: &thirtyDaysAgo,
-		Page:      1,
-		PageSize:  1,
-	})
-	// Auth events (login/logout) vs secret events in last 30 days
-	authAction := "auth.login"
-	_, auditLogins, _ := c.storage.GetAuditLogs(ctx, &storage.AuditFilter{
-		StartTime: &thirtyDaysAgo,
-		Action:    &authAction,
-		Page:      1,
-		PageSize:  1,
-	})
-	secretReadAction := "secret.read"
-	_, auditSecretReads, _ := c.storage.GetAuditLogs(ctx, &storage.AuditFilter{
-		StartTime: &thirtyDaysAgo,
-		Action:    &secretReadAction,
-		Page:      1,
-		PageSize:  1,
-	})
-
-	// Failed auth attempts in the last 24 hours (success=false, any action).
-	twentyFourHoursAgo := time.Now().UTC().Add(-24 * time.Hour)
-	successFalse := false
-	_, failedAuth24h, _ := c.storage.GetAuditLogs(ctx, &storage.AuditFilter{
-		StartTime: &twentyFourHoursAgo,
-		Success:   &successFalse,
-		Page:      1,
-		PageSize:  1,
-	})
-
-	// Inactive users: registered users whose last_login_at is null or older than
-	// 30 days. Counted directly off the users table (no audit-log scan).
-	inactiveCutoff := thirtyDaysAgo
-	_, inactiveUsers, _ := c.storage.ListUsers(ctx, &storage.UserFilter{
-		InactiveSince: &inactiveCutoff,
-		Page:          1,
-		PageSize:      1,
-	})
 
 	stats := &DashboardStats{
 		TotalSecrets:          total,
@@ -189,8 +200,12 @@ func (c *KeyorixCore) GetDashboardStats(ctx context.Context, userID uint, userna
 	return stats, nil
 }
 
-// GetActivityFeed returns a paginated activity feed for the given user.
+// GetActivityFeed returns a paginated, deployment-wide activity feed. userID is
+// unused here (kept for signature symmetry with GetDashboardStats/call sites): the
+// router's audit.read gate on GET /dashboard/activity is what authorizes seeing
+// every user's events, so this function itself applies no per-caller scoping.
 func (c *KeyorixCore) GetActivityFeed(ctx context.Context, userID uint, username string, page, pageSize int) (*ActivityFeed, error) {
+	_ = userID
 	if page <= 0 {
 		page = 1
 	}
@@ -198,8 +213,6 @@ func (c *KeyorixCore) GetActivityFeed(ctx context.Context, userID uint, username
 		pageSize = 10
 	}
 
-	uid := userID
-	_ = uid // admin sees all events
 	events, total, err := c.storage.GetAuditLogs(ctx, &storage.AuditFilter{
 		Page:     page,
 		PageSize: pageSize,

--- a/internal/core/deployment_hygiene.go
+++ b/internal/core/deployment_hygiene.go
@@ -1,10 +1,12 @@
 // deployment_hygiene.go — install-wide hygiene rollup: aggregate every project's
 // hygiene posture (orphaned / unused / expiring secrets, stale machine identities,
 // rotation-overdue) into deployment-wide totals plus a per-project breakdown of the
-// projects that actually carry debt. Counts only — no names or values of secrets —
-// so it is safe to surface to an admin overseeing many projects, and cheap enough to
-// poll for a dashboard. Parallels the deployment-wide PAT ([[pat_hygiene]]) and
-// machine-token hygiene views; built on the per-project [[project_hygiene]] summary.
+// projects that actually carry debt. Counts only — no secret names or values — but
+// the per-project breakdown DOES name every project deployment-wide, which a
+// zero-membership account has no other route to see, so the route requires audit.read
+// (not the universal system_viewer baseline system.read; see #273). Parallels the
+// deployment-wide PAT ([[pat_hygiene]]) and machine-token hygiene views; built on the
+// per-project [[project_hygiene]] summary.
 package core
 
 import (

--- a/internal/core/machine_token_hygiene.go
+++ b/internal/core/machine_token_hygiene.go
@@ -3,7 +3,8 @@
 // revoked, or stale (unused for a long window). The non-human counterpart to PAT
 // hygiene ([[pat_hygiene]]): an abandoned or expired machine token is the same kind of
 // reusable credential an attacker prizes. Read-only; never returns a token hash.
-// Admin-scoped (route-gated).
+// Route-gated on audit.read (not the universal system_viewer baseline; see #274) —
+// discloses credential names/prefixes/expiry deployment-wide.
 package core
 
 import (

--- a/internal/core/pat_hygiene.go
+++ b/internal/core/pat_hygiene.go
@@ -4,7 +4,9 @@
 // long-lived bearer credential that is expired-but-active or abandoned is exactly the
 // kind of token sprawl an attacker reuses, so this gives an admin one place to find
 // and revoke them. Parallels the stale-machine-identity and unused-secret hygiene
-// views. Read-only; never returns a token hash or plaintext. Admin-scoped (route-gated).
+// views. Read-only; never returns a token hash or plaintext. Route-gated on
+// audit.read (not the universal system_viewer baseline; see #275) — discloses every
+// user's PAT names/scopes/CIDRs/owning user ID deployment-wide.
 package core
 
 import (

--- a/internal/core/secret_name_conformance_deployment.go
+++ b/internal/core/secret_name_conformance_deployment.go
@@ -5,7 +5,8 @@
 // project. The per-project view is [[secret_name_conformance]] (SecretNameConformance);
 // this is the admin's all-projects counterpart, parallel to the deployment-wide asset
 // inventory ([[secret_inventory_deployment]]) and hygiene rollup. Never reads a value.
-// Deployment-wide (route-gated system.read).
+// Deployment-wide (route-gated audit.read — it discloses real secret names, so the
+// universal system_viewer baseline is not enough).
 package core
 
 import (

--- a/server/http/deployment_disclosure_family_test.go
+++ b/server/http/deployment_disclosure_family_test.go
@@ -1,0 +1,448 @@
+// deployment_disclosure_family_test.go — proves the fix for the #255/#272-275/#280-281
+// deployment-wide disclosure family: a set of reporting/aggregation endpoints that used
+// to be gated only by the universal, auto-assigned system_viewer baseline (system.read)
+// — or, for #272, by NO permission at all — so any authenticated account (including a
+// brand-new user with zero project memberships) could read sensitive data about other
+// users/projects/secrets deployment-wide. Each route now requires audit.read (the
+// system_admin/system_auditor persona at global scope), which is NOT auto-granted to
+// every account. This file proves, for each affected route: a baseline (system_viewer)
+// caller is denied (403) and an audit.read holder (system_auditor) succeeds (200) with
+// the expected payload shape.
+package http
+
+import (
+	"context"
+	"encoding/csv"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	appstorage "github.com/keyorixhq/keyorix/internal/storage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newFullSchemaTestCore creates a *core.KeyorixCore over a FULLY migrated (production
+// schema) in-memory SQLite DB, via the same StorageFactory the server uses at startup.
+// The minimal newTestCore (above, in integration_test.go) only migrates a handful of
+// tables — not enough for the compliance/hygiene/PAT/machine-credential/risk-register
+// storage this file exercises.
+func newFullSchemaTestCore(t *testing.T) *core.KeyorixCore {
+	t.Helper()
+	cfg := &config.Config{
+		Storage: config.StorageConfig{
+			Type: "local",
+			Database: config.DatabaseConfig{
+				Path: uniqueMemDSN("&_timeout=30000&_journal_mode=WAL"),
+			},
+		},
+	}
+	st, err := appstorage.NewStorageFactory().CreateStorage(cfg)
+	require.NoError(t, err)
+	return core.NewKeyorixCore(st)
+}
+
+// createAuditorToken creates a user holding ONLY the system_auditor role (global scope)
+// — the "genuinely elevated, but not admin-bypass" persona this fix's audit.read gate
+// is meant to admit — and returns a session token.
+func createAuditorToken(t *testing.T, c *core.KeyorixCore) string {
+	t.Helper()
+	ctx := context.Background()
+	_, err := c.CreateUserWithAssignments(ctx, &core.CreateUserRequest{
+		Username: "family_auditor", Email: "family_auditor@example.com", Password: "Qr7#Kp2$Lm5@Vn9!",
+	}, "system_auditor", nil)
+	require.NoError(t, err)
+	sess, _, err := c.Login(ctx, &core.LoginRequest{Username: "family_auditor", Password: "Qr7#Kp2$Lm5@Vn9!"})
+	require.NoError(t, err)
+	return sess.SessionToken
+}
+
+// createNoPermissionToken creates a user, then strips even the auto-assigned
+// system_viewer baseline role — simulating a principal holding NO relevant permission
+// at all (the #272 scenario: today that principal succeeds at GET /dashboard/stats
+// because the route checks no permission whatsoever; after the fix it must be denied).
+func createNoPermissionToken(t *testing.T, c *core.KeyorixCore) string {
+	t.Helper()
+	ctx := context.Background()
+	_, err := c.CreateUser(ctx, &core.CreateUserRequest{
+		Username: "family_noperm", Email: "family_noperm@example.com", Password: "Qr7#Kp2$Lm5@Vn9!",
+	})
+	require.NoError(t, err)
+	require.NoError(t, c.RemoveRoleFromUser(ctx, "family_noperm@example.com", "system_viewer"))
+	sess, _, err := c.Login(ctx, &core.LoginRequest{Username: "family_noperm", Password: "Qr7#Kp2$Lm5@Vn9!"})
+	require.NoError(t, err)
+	return sess.SessionToken
+}
+
+// familyFixtures seeds one row of real, sensitive data behind each endpoint under test
+// (a secret, a PAT, a machine credential, an SoD violation) so the "auditor succeeds
+// with the EXPECTED data" assertions are not vacuously true against an empty deployment.
+type familyFixtures struct {
+	projectID uint
+	envID     uint
+}
+
+func seedFamilyFixtures(t *testing.T, c *core.KeyorixCore) familyFixtures {
+	t.Helper()
+	ctx := context.Background()
+
+	projects, err := c.ListProjects(ctx)
+	require.NoError(t, err)
+	require.NotEmpty(t, projects)
+	project := projects[0]
+
+	envs, err := c.ListEnvironments(ctx)
+	require.NoError(t, err)
+	require.NotEmpty(t, envs)
+	env := envs[0]
+
+	admin, err := c.GetUserByEmail(ctx, "testadmin@example.com")
+	require.NoError(t, err)
+
+	// A live secret, so the deployment-wide inventory CSV (#280) and hygiene rollup
+	// (#273) have a real row to disclose (or correctly withhold from a baseline caller).
+	_, err = c.CreateSecret(ctx, &core.CreateSecretRequest{
+		Name:          "family-disclosure-canary",
+		Value:         []byte("s3cr3t-value"),
+		ProjectID:     project.ID,
+		EnvironmentID: env.ID,
+		Type:          "generic",
+		CreatedBy:     admin.Username,
+		OwnerID:       admin.ID,
+	})
+	require.NoError(t, err)
+
+	// An expired-but-active PAT, so /pat-hygiene (#275) has a flagged entry.
+	pastExpiry := time.Now().Add(-1 * time.Hour)
+	_, err = c.CreateOwnPAT(ctx, admin.ID, "leaked-ci-token", &pastExpiry, nil, 0, 0, nil)
+	require.NoError(t, err)
+
+	// An expired-but-active machine credential, so /machine-token-hygiene (#274) has a
+	// flagged entry.
+	mi, err := c.CreateMachineIdentity(ctx, project.ID, "family-ci-runner", "ci", "", "", admin.ID)
+	require.NoError(t, err)
+	_, err = c.IssueMachineToken(ctx, project.ID, mi.ID, "family-ci-token", &pastExpiry, "", admin.ID)
+	require.NoError(t, err)
+
+	// An SoD policy that the system_auditor role itself violates (system_auditor holds
+	// both system.read and audit.read), so /sod/violations discloses a real violator.
+	_, err = c.CreateSoDPolicy(ctx, admin.ID, "family-test-policy", "", "system.read", "audit.read")
+	require.NoError(t, err)
+
+	// A risk exception with free-text Reference/Justification, so /risk-exceptions
+	// (#255 bundled sub-finding) has a real row to disclose (or correctly withhold).
+	_, err = c.CreateRiskException(ctx, admin.ID, "family risk", "other", "secret:family-disclosure-canary",
+		"accepted pending rotation", time.Now().Add(48*time.Hour))
+	require.NoError(t, err)
+
+	return familyFixtures{projectID: project.ID, envID: env.ID}
+}
+
+// familyRoute describes one GET route in the disclosure family under test.
+type familyRoute struct {
+	name  string
+	path  string
+	check func(t *testing.T, body []byte, contentType string) // asserts the 200 payload shape
+}
+
+func jsonDataField(t *testing.T, body []byte) map[string]interface{} {
+	t.Helper()
+	var env struct {
+		Data json.RawMessage `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(body, &env))
+	var m map[string]interface{}
+	require.NoError(t, json.Unmarshal(env.Data, &m))
+	return m
+}
+
+// TestDeploymentDisclosureFamily_BaselineDeniedAuditorAllowed covers instances
+// #255 (compliance/evidence family incl. posture/controls/controls.csv/digest/
+// legal-hold/risk-exceptions/sod-violations), #273 (hygiene), #274
+// (machine-token-hygiene), #275 (pat-hygiene), #280 (secrets/inventory.csv), and #281
+// (secrets/name-conformance): every route must deny a system_viewer-baseline caller
+// (403) and allow a system_auditor (audit.read) caller (200) with the expected data.
+func TestDeploymentDisclosureFamily_BaselineDeniedAuditorAllowed(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	cfg := &config.Config{}
+	testCore := newFullSchemaTestCore(t)
+	router, err := NewRouter(cfg, testCore)
+	require.NoError(t, err)
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	createTestToken(t, testCore) // bootstrap admin + seed roles/permissions
+	seedFamilyFixtures(t, testCore)
+	baselineToken := createLimitedToken(t, testCore) // system_viewer only (system.read)
+	auditorToken := createAuditorToken(t, testCore)  // system_auditor (audit.read, global)
+
+	// Plant a non-conforming secret BEFORE the naming policy is enabled (naming policy
+	// is only enforced at create time — a policy tightened afterward leaves existing
+	// "straggler" secrets that violate it, which is exactly what #281's deployment-wide
+	// conformance report scans for).
+	ctx := context.Background()
+	admin, err := testCore.GetUserByEmail(ctx, "testadmin@example.com")
+	require.NoError(t, err)
+	projects, err := testCore.ListProjects(ctx)
+	require.NoError(t, err)
+	envs, err := testCore.ListEnvironments(ctx)
+	require.NoError(t, err)
+	_, err = testCore.CreateSecret(ctx, &core.CreateSecretRequest{
+		Name: "Family_NonConforming_Name", Value: []byte("x"), ProjectID: projects[0].ID,
+		EnvironmentID: envs[0].ID, Type: "generic", CreatedBy: admin.Username, OwnerID: admin.ID,
+	})
+	require.NoError(t, err)
+
+	// Enable the naming policy AFTER the straggler secret above was created.
+	require.NoError(t, testCore.SetSecretNamePolicy(core.SecretNamePolicy{
+		Enabled: true, Pattern: `^[a-z0-9]+(-[a-z0-9]+)*$`, MaxLength: 64,
+	}))
+
+	routes := []familyRoute{
+		{
+			name: "#280 deployment secrets inventory CSV",
+			path: "/api/v1/secrets/inventory.csv",
+			check: func(t *testing.T, body []byte, contentType string) {
+				assert.Contains(t, contentType, "text/csv")
+				rows, err := csv.NewReader(strings.NewReader(string(body))).ReadAll()
+				require.NoError(t, err)
+				require.GreaterOrEqual(t, len(rows), 2, "header + at least one secret row")
+				found := false
+				for _, row := range rows[1:] {
+					if len(row) > 2 && row[2] == "family-disclosure-canary" {
+						found = true
+					}
+				}
+				assert.True(t, found, "the canary secret's real name must appear in the CSV for an audit.read holder")
+			},
+		},
+		{
+			name: "#281 deployment secret name-conformance",
+			path: "/api/v1/secrets/name-conformance",
+			check: func(t *testing.T, body []byte, _ string) {
+				m := jsonDataField(t, body)
+				assert.Equal(t, true, m["policy_enabled"])
+				violations, _ := m["violations"].([]interface{})
+				assert.NotEmpty(t, violations, "the non-conformant secret must be reported")
+			},
+		},
+		{
+			name: "#275 pat-hygiene",
+			path: "/api/v1/pat-hygiene",
+			check: func(t *testing.T, body []byte, _ string) {
+				m := jsonDataField(t, body)
+				tokens, _ := m["tokens"].([]interface{})
+				assert.NotEmpty(t, tokens, "the expired PAT must be flagged")
+			},
+		},
+		{
+			name: "#274 machine-token-hygiene",
+			path: "/api/v1/machine-token-hygiene",
+			check: func(t *testing.T, body []byte, _ string) {
+				m := jsonDataField(t, body)
+				creds, ok := m["credentials"].([]interface{})
+				if !ok {
+					creds, _ = m["tokens"].([]interface{})
+				}
+				assert.NotEmpty(t, creds, "the expired machine credential must be flagged")
+			},
+		},
+		{
+			name: "#273 deployment hygiene rollup",
+			path: "/api/v1/hygiene",
+			check: func(t *testing.T, body []byte, _ string) {
+				m := jsonDataField(t, body)
+				assert.Contains(t, m, "totals")
+			},
+		},
+		{
+			name: "#255 compliance posture",
+			path: "/api/v1/compliance/posture",
+			check: func(t *testing.T, body []byte, _ string) {
+				m := jsonDataField(t, body)
+				assert.Contains(t, m, "access_governance")
+			},
+		},
+		{
+			name: "#255 compliance controls",
+			path: "/api/v1/compliance/controls",
+			check: func(t *testing.T, body []byte, _ string) {
+				m := jsonDataField(t, body)
+				assert.Contains(t, m, "controls")
+			},
+		},
+		{
+			name: "#255 compliance controls CSV",
+			path: "/api/v1/compliance/controls.csv",
+			check: func(t *testing.T, body []byte, contentType string) {
+				assert.Contains(t, contentType, "text/csv")
+				assert.NotEmpty(t, body)
+			},
+		},
+		{
+			name: "#255 compliance digest",
+			path: "/api/v1/compliance/digest",
+			check: func(t *testing.T, body []byte, _ string) {
+				m := jsonDataField(t, body)
+				assert.Contains(t, m, "title")
+			},
+		},
+		{
+			name: "#255 legal-hold status",
+			path: "/api/v1/legal-hold",
+			check: func(t *testing.T, body []byte, _ string) {
+				m := jsonDataField(t, body)
+				assert.Contains(t, m, "active")
+			},
+		},
+		{
+			name: "#255 risk-exceptions (bundled MED free-text sub-finding)",
+			path: "/api/v1/risk-exceptions",
+			check: func(t *testing.T, body []byte, _ string) {
+				m := jsonDataField(t, body)
+				exceptions, _ := m["exceptions"].([]interface{})
+				assert.NotEmpty(t, exceptions, "the seeded risk exception must be disclosed to an audit.read holder")
+			},
+		},
+		{
+			name: "#255 sod violations",
+			path: "/api/v1/sod/violations",
+			check: func(t *testing.T, body []byte, _ string) {
+				m := jsonDataField(t, body)
+				violations, _ := m["violations"].([]interface{})
+				assert.NotEmpty(t, violations, "the system_auditor's own system.read+audit.read pair must show up as a violation")
+			},
+		},
+	}
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	for _, rt := range routes {
+		t.Run(rt.name+"/baseline_denied", func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, server.URL+rt.path, nil)
+			require.NoError(t, err)
+			req.Header.Set("Authorization", "Bearer "+baselineToken)
+			resp, err := client.Do(req)
+			require.NoError(t, err)
+			defer func() { _ = resp.Body.Close() }()
+			assert.Equalf(t, http.StatusForbidden, resp.StatusCode,
+				"a system_viewer-baseline (system.read only) caller must be denied at %s", rt.path)
+		})
+
+		t.Run(rt.name+"/auditor_allowed", func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, server.URL+rt.path, nil)
+			require.NoError(t, err)
+			req.Header.Set("Authorization", "Bearer "+auditorToken)
+			resp, err := client.Do(req)
+			require.NoError(t, err)
+			defer func() { _ = resp.Body.Close() }()
+			body := make([]byte, 0, 4096)
+			buf := make([]byte, 4096)
+			for {
+				n, rerr := resp.Body.Read(buf)
+				body = append(body, buf[:n]...)
+				if rerr != nil {
+					break
+				}
+			}
+			require.Equalf(t, http.StatusOK, resp.StatusCode,
+				"a system_auditor (audit.read) caller must succeed at %s (body: %s)", rt.path, string(body))
+			rt.check(t, body, resp.Header.Get("Content-Type"))
+		})
+	}
+}
+
+// TestDashboardStats_PermissionTiers covers #272 — the worst instance of the family:
+// GET /dashboard/stats and GET /dashboard/activity required NO permission at all. It
+// proves: (a) a principal with NO relevant permission whatsoever is now denied
+// (previously it would have succeeded); (b) a baseline system_viewer caller still gets
+// their own personal dashboard (200) but with the deployment-wide aggregate fields
+// zeroed and the activity feed limited to their own events; (c) an audit.read holder
+// gets the full deployment-wide picture.
+func TestDashboardStats_PermissionTiers(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	cfg := &config.Config{}
+	testCore := newFullSchemaTestCore(t)
+	router, err := NewRouter(cfg, testCore)
+	require.NoError(t, err)
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	createTestToken(t, testCore)
+	seedFamilyFixtures(t, testCore)
+	noPermToken := createNoPermissionToken(t, testCore)
+	baselineToken := createLimitedToken(t, testCore)
+	auditorToken := createAuditorToken(t, testCore)
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	get := func(token, path string) (*http.Response, []byte) {
+		req, err := http.NewRequest(http.MethodGet, server.URL+path, nil)
+		require.NoError(t, err)
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+		var body []byte
+		buf := make([]byte, 4096)
+		for {
+			n, rerr := resp.Body.Read(buf)
+			body = append(body, buf[:n]...)
+			if rerr != nil {
+				break
+			}
+		}
+		return resp, body
+	}
+
+	t.Run("no_permission_at_all_denied_stats", func(t *testing.T) {
+		resp, _ := get(noPermToken, "/api/v1/dashboard/stats")
+		assert.Equal(t, http.StatusForbidden, resp.StatusCode,
+			"a principal holding NO permission at all must now be denied — previously this route checked nothing")
+	})
+
+	t.Run("no_permission_at_all_denied_activity", func(t *testing.T) {
+		resp, _ := get(noPermToken, "/api/v1/dashboard/activity")
+		assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+	})
+
+	t.Run("baseline_gets_own_dashboard_with_aggregates_zeroed", func(t *testing.T) {
+		resp, body := get(baselineToken, "/api/v1/dashboard/stats")
+		require.Equal(t, http.StatusOK, resp.StatusCode, "the caller's own home dashboard must still work")
+		m := jsonDataField(t, body)
+		assert.Equal(t, float64(0), m["activeUsers"],
+			"a baseline (non-audit.read) caller must not see the deployment-wide active-user count")
+		assert.Equal(t, float64(0), m["auditEvents30d"])
+		assert.Equal(t, float64(0), m["inactiveUsers"])
+	})
+
+	t.Run("baseline_activity_feed_denied", func(t *testing.T) {
+		resp, _ := get(baselineToken, "/api/v1/dashboard/activity")
+		assert.Equal(t, http.StatusForbidden, resp.StatusCode,
+			"the full org-wide activity feed stays behind audit.read even for a baseline caller")
+	})
+
+	t.Run("auditor_sees_full_deployment_aggregates", func(t *testing.T) {
+		resp, body := get(auditorToken, "/api/v1/dashboard/stats")
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		m := jsonDataField(t, body)
+		activeUsers, _ := m["activeUsers"].(float64)
+		assert.Greater(t, activeUsers, float64(0),
+			"an audit.read holder must see the real deployment-wide active-user count")
+	})
+
+	t.Run("auditor_activity_feed_allowed", func(t *testing.T) {
+		resp, body := get(auditorToken, "/api/v1/dashboard/activity")
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		m := jsonDataField(t, body)
+		assert.Contains(t, m, "items")
+	})
+}

--- a/server/http/handlers/compliance_controls_csv.go
+++ b/server/http/handlers/compliance_controls_csv.go
@@ -15,7 +15,8 @@ import (
 
 // ExportComplianceControlsCSV handles GET /api/v1/compliance/controls.csv — the evaluated
 // control matrix as a CSV attachment (id, name, area, status, detail, and the framework
-// clause refs). Deployment-wide system.read is enforced by the router.
+// clause refs). Deployment-wide audit.read is enforced by the router (not the
+// universal system_viewer baseline — same tier as the JSON endpoint above).
 func (h *DashboardHandler) ExportComplianceControlsCSV(w http.ResponseWriter, r *http.Request) {
 	if middleware.GetUserFromContext(r.Context()) == nil {
 		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)

--- a/server/http/handlers/dashboard.go
+++ b/server/http/handlers/dashboard.go
@@ -20,7 +20,12 @@ func NewDashboardHandler(coreService *core.KeyorixCore) *DashboardHandler {
 	return &DashboardHandler{coreService: coreService}
 }
 
-// GetStats handles GET /api/v1/dashboard/stats
+// GetStats handles GET /api/v1/dashboard/stats — the caller's own home dashboard
+// (their secret/share counts, expiring secrets). Gated by system.read in the router
+// (every real principal must hold at least the baseline); the deployment-wide
+// aggregate fields it also returns are separately scoped to audit.read inside
+// GetDashboardStats, so a baseline caller sees their own numbers with the org-wide
+// aggregates zeroed rather than a 403 on their own home page (#272).
 func (h *DashboardHandler) GetStats(w http.ResponseWriter, r *http.Request) {
 	userCtx := middleware.GetUserFromContext(r.Context())
 	if userCtx == nil {
@@ -38,7 +43,8 @@ func (h *DashboardHandler) GetStats(w http.ResponseWriter, r *http.Request) {
 }
 
 // GetCompliancePosture handles GET /api/v1/compliance/posture — the deployment-wide
-// controls-posture snapshot for auditors (gated by system.read in the router).
+// controls-posture snapshot for auditors (gated by audit.read in the router, not the
+// universal system_viewer baseline).
 func (h *DashboardHandler) GetCompliancePosture(w http.ResponseWriter, r *http.Request) {
 	posture, err := h.coreService.GetCompliancePosture(r.Context())
 	if err != nil {
@@ -51,7 +57,7 @@ func (h *DashboardHandler) GetCompliancePosture(w http.ResponseWriter, r *http.R
 // GetComplianceDigest handles GET /api/v1/compliance/digest — the on-demand,
 // human-readable compliance digest (the same title + body otherwise broadcast on a
 // schedule to the notification channels), so an admin can pull a point-in-time
-// summary without waiting for the scheduled send. Gated by system.read in the router.
+// summary without waiting for the scheduled send. Gated by audit.read in the router.
 func (h *DashboardHandler) GetComplianceDigest(w http.ResponseWriter, r *http.Request) {
 	title, body, err := h.coreService.BuildComplianceDigest(r.Context())
 	if err != nil {
@@ -84,7 +90,7 @@ func (h *DashboardHandler) VerifyComplianceEvidence(w http.ResponseWriter, r *ht
 
 // GetComplianceControls handles GET /api/v1/compliance/controls — the control
 // matrix mapping each enforced control to its ISO 27001 / SOC 2 / NIS2 / DORA
-// references with a live status; gated by system.read in the router.
+// references with a live status; gated by audit.read in the router.
 func (h *DashboardHandler) GetComplianceControls(w http.ResponseWriter, r *http.Request) {
 	controls, err := h.coreService.GetComplianceControls(r.Context())
 	if err != nil {
@@ -95,7 +101,7 @@ func (h *DashboardHandler) GetComplianceControls(w http.ResponseWriter, r *http.
 }
 
 // GetComplianceEvidence handles GET /api/v1/compliance/evidence — the auditor
-// evidence pack (posture + supporting records); gated by system.read in the router.
+// evidence pack (posture + supporting records); gated by audit.read in the router.
 func (h *DashboardHandler) GetComplianceEvidence(w http.ResponseWriter, r *http.Request) {
 	evidence, err := h.coreService.GenerateComplianceEvidence(r.Context())
 	if err != nil {

--- a/server/http/handlers/deployment_hygiene.go
+++ b/server/http/handlers/deployment_hygiene.go
@@ -1,6 +1,7 @@
 // deployment_hygiene.go — DeploymentHygiene handler: the install-wide hygiene rollup
 // (per-project posture summed across every project, plus a breakdown of the projects
-// that carry debt). Counts only. Deployment-wide system.read is enforced by the router.
+// that carry debt). Counts only, but names every project deployment-wide. Deployment-
+// wide audit.read is enforced by the router (not the universal system_viewer baseline).
 package handlers
 
 import (

--- a/server/http/handlers/legal_hold.go
+++ b/server/http/handlers/legal_hold.go
@@ -1,5 +1,7 @@
 // legal_hold.go — deployment-wide legal-hold endpoints (ISO 27001 A.5.34). Status
-// reads need system.read; placing/lifting needs system.write (wired in router.go).
+// reads need audit.read (discloses the free-text hold reason, so the universal
+// system_viewer baseline is not enough); placing/lifting needs system.write (wired in
+// router.go).
 package handlers
 
 import (

--- a/server/http/handlers/machine_token_hygiene.go
+++ b/server/http/handlers/machine_token_hygiene.go
@@ -25,7 +25,8 @@ type machineTokenHygieneEntry struct {
 
 // MachineTokenHygiene handles GET /api/v1/machine-token-hygiene?days=N — the
 // deployment-wide non-revoked machine credentials that are expired-but-active or stale.
-// Global system.read is enforced by the router. days defaults to 90, cap 3650.
+// Global audit.read is enforced by the router, not the universal system_viewer
+// baseline. days defaults to 90, cap 3650.
 func (h *CatalogHandler) MachineTokenHygiene(w http.ResponseWriter, r *http.Request) {
 	if middleware.GetUserFromContext(r.Context()) == nil {
 		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)

--- a/server/http/handlers/openapi.yaml
+++ b/server/http/handlers/openapi.yaml
@@ -2799,6 +2799,14 @@ paths:
     get:
       tags: [Dashboard]
       summary: Dashboard summary statistics
+      description: >-
+        The caller's own home dashboard (secret/share counts, expiring secrets).
+        Requires the universal system.read baseline (every real principal holds it).
+        The deployment-wide aggregate fields (activeUsers, auditEvents30d,
+        auditLogins30d, auditSecretReads30d, failedAuthAttempts24h, inactiveUsers) and
+        the full recentActivity feed are additionally scoped to audit.read — a
+        baseline-only caller gets zeroed aggregates and an activity feed limited to
+        their own events.
       operationId: getDashboardStats
       security: [{bearerAuth: []}]
       responses:
@@ -2811,6 +2819,7 @@ paths:
             expiringSecrets[] (id, name, environment, expiresAt, daysLeft, expired), and
             recentActivity[] (id, type, secretName, timestamp, actor).
         '401': {$ref: '#/components/responses/Error'}
+        '403': {$ref: '#/components/responses/Error'}
   /api/v1/compliance/posture:
     get:
       tags: [Dashboard]
@@ -2828,7 +2837,8 @@ paths:
         counts per sensitivity level + unclassified), anomalies (open /
         high-severity access-anomaly alerts), legal hold (active + reason), and
         data retention (configured per-record-type windows in days; 0 = keep
-        forever — A.5.33 storage-limitation). Requires system.read.
+        forever — A.5.33 storage-limitation). Requires audit.read (not the universal
+        system_viewer baseline).
       operationId: getCompliancePosture
       security: [{bearerAuth: []}]
       responses:
@@ -2847,7 +2857,7 @@ paths:
         references across ISO 27001 Annex A, SOC 2 Trust Services Criteria, NIS2,
         and DORA, with a live status derived from the posture (pass | gap |
         not_configured) and a human-readable detail. Includes a summary tally.
-        Requires system.read.
+        Requires audit.read (not the universal system_viewer baseline).
       operationId: getComplianceControls
       security: [{bearerAuth: []}]
       responses:
@@ -2867,7 +2877,7 @@ paths:
         substantiate it — the audit-chain anchor {valid, chained_events, head_id,
         head_hash, checkpointed}, the access-review campaigns (per project, with
         tallies), the break-glass register, and the overdue rotations. Requires
-        system.read.
+        audit.read (not the universal system_viewer baseline).
       operationId: getComplianceEvidence
       security: [{bearerAuth: []}]
       responses:
@@ -2887,7 +2897,8 @@ paths:
         archived pack was produced by this deployment and is unmodified. The pack is
         base64-encoded in data_b64 so arbitrary JSON can ride in the envelope. A
         signature made under a superseded DEK version (post key-rotation) is reported
-        as unverifiable, distinct from a tamper mismatch. Requires system.read.
+        as unverifiable, distinct from a tamper mismatch. Requires audit.read (not the
+        universal system_viewer baseline).
       operationId: verifyComplianceEvidence
       security: [{bearerAuth: []}]
       requestBody:
@@ -2914,7 +2925,7 @@ paths:
       description: >-
         Whether a deployment-wide litigation/investigation hold is active. While
         active, the background purge jobs are blocked from hard-deleting records.
-        Requires system.read.
+        Requires audit.read (not the universal system_viewer baseline).
       operationId: getLegalHold
       security: [{bearerAuth: []}]
       responses:
@@ -2959,7 +2970,8 @@ paths:
         The risk register: governed acceptances of a known control gap, each with an
         owner, justification, and sunset date. Active only by default; ?all=true
         includes expired exceptions (history). Each carries a computed status
-        (active | expired | revoked). Requires system.read.
+        (active | expired | revoked). Requires audit.read (not the universal
+        system_viewer baseline).
       operationId: listRiskExceptions
       parameters:
         - {name: all, in: query, schema: {type: boolean}, description: "Include expired exceptions."}
@@ -3058,8 +3070,9 @@ paths:
       tags: [Dashboard]
       summary: List separation-of-duties violations
       description: >-
-        Principals whose effective permissions include both sides of a policy.
-        Requires system.read.
+        Principals whose effective permissions include both sides of a policy —
+        discloses violator names/emails deployment-wide. Requires audit.read (not the
+        universal system_viewer baseline).
       operationId: listSoDViolations
       security: [{bearerAuth: []}]
       responses:

--- a/server/http/handlers/pat_handler.go
+++ b/server/http/handlers/pat_handler.go
@@ -99,7 +99,9 @@ type patHygieneResponse struct {
 
 // PATHygiene handles GET /api/v1/pat-hygiene?days=N — the deployment-wide list of
 // non-revoked tokens that are expired-but-active or stale (unused for the window), so
-// an admin can revoke token sprawl. Global system.read is enforced by the router.
+// an admin can revoke token sprawl. Global audit.read is enforced by the router (it
+// discloses every user's PAT scopes/CIDRs/owning user ID deployment-wide, so the
+// universal system_viewer baseline is not enough).
 // days defaults to 90 and is capped at 3650.
 func (h *PATHandler) PATHygiene(w http.ResponseWriter, r *http.Request) {
 	if middleware.GetUserFromContext(r.Context()) == nil {

--- a/server/http/handlers/risk_exceptions.go
+++ b/server/http/handlers/risk_exceptions.go
@@ -1,6 +1,7 @@
 // risk_exceptions.go — the risk register / exceptions endpoints (ISO 27001 A.5.8
-// risk treatment). Listing needs system.read; create/revoke need system.write
-// (wired in router.go).
+// risk treatment). Listing discloses free-text Reference/Justification (which may
+// itself name a secret) deployment-wide, so it needs audit.read, not the universal
+// system_viewer baseline; create/revoke need system.write (wired in router.go).
 package handlers
 
 import (

--- a/server/http/handlers/secrets_inventory_deployment_csv.go
+++ b/server/http/handlers/secrets_inventory_deployment_csv.go
@@ -1,7 +1,9 @@
 // secrets_inventory_deployment_csv.go — DeploymentSecretsInventoryCSV handler: the
 // org-wide secret asset inventory (every project's secrets, metadata only, never
-// values) as a CSV attachment for compliance. Deployment-wide system.read is enforced
-// by the router. Parallels the per-project secrets_inventory_csv handler.
+// values) as a CSV attachment for compliance. Deployment-wide audit.read is enforced
+// by the router (it discloses real secret names/classification/owner deployment-wide,
+// so the universal system_viewer baseline is not enough). Parallels the per-project
+// secrets_inventory_csv handler.
 package handlers
 
 import (

--- a/server/http/handlers/sod.go
+++ b/server/http/handlers/sod.go
@@ -1,6 +1,8 @@
 // sod.go — separation-of-duties endpoints (ISO 27001 A.5.3 / SOX). Deployment-wide:
-// listing policies + violations needs system.read; creating/deleting policies needs
-// system.write (wired in router.go).
+// listing policy DEFINITIONS (name/permission pair, no PII) needs only the universal
+// system_viewer baseline system.read; listing VIOLATIONS discloses violator
+// names/emails deployment-wide, so it needs audit.read; creating/deleting policies
+// needs system.write (wired in router.go).
 package handlers
 
 import (

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -236,7 +236,20 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		r.Post("/notifications/{id}/read", notificationHandler.MarkRead)
 
 		// Dashboard endpoints
-		r.Get("/dashboard/stats", dashboardHandler.GetStats)
+		// GetStats is the caller's OWN home dashboard (their secret/share counts,
+		// their expiring secrets) so it stays reachable by any real principal — but it
+		// previously required NO permission at all, not even the universal system_viewer
+		// baseline, so a principal holding zero permissions in this system (e.g. a
+		// narrowly-scoped machine identity/PAT) could still reach it. Require system.read
+		// to close that: every human user holds it from CreateUser (ADR-021), so this is
+		// a no-op for the product's normal users and only turns away a principal with no
+		// legitimate standing here at all. The deployment-wide aggregate fields the
+		// handler also returns (active users, audit-event counts, failed-auth counts) are
+		// separately scoped to audit.read INSIDE GetDashboardStats (core/dashboard.go),
+		// mirroring the recent-activity scoping already there — a baseline caller gets
+		// their own numbers with the org-wide aggregates zeroed, not a 403 on their own
+		// home page.
+		r.With(customMiddleware.RequirePermission("system.read")).Get("/dashboard/stats", dashboardHandler.GetStats)
 		// The full activity feed is org-wide audit data — gate it behind audit.read.
 		// (Per-user dashboard stats scope their own recent-activity in core.)
 		r.With(customMiddleware.RequirePermission("audit.read")).Get("/dashboard/activity", dashboardHandler.GetActivity)
@@ -385,13 +398,17 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.With(customMiddleware.RequireScopedPermission("secrets.read", customMiddleware.ScopeFromQuery)).Get("/usage/most-accessed", secretHandler.UsageMostAccessed)
 			r.With(customMiddleware.RequireScopedPermission("secrets.read", customMiddleware.ScopeFromQuery)).Get("/usage/unused", secretHandler.UsageUnused)
 			// Org-wide secret asset inventory (ISO 27001 A.5.9) — CSV manifest of every
-			// project's secrets, metadata only (no values). Deployment-wide system.read;
-			// static path, before /{id}.
-			r.With(customMiddleware.RequirePermission("system.read")).Get("/inventory.csv", secretHandler.DeploymentSecretsInventoryCSV)
+			// project's secrets, metadata only (no values), but it DOES disclose every
+			// secret's real NAME/classification/owner deployment-wide, so it is gated on
+			// audit.read (global), NOT the universal system_viewer baseline system.read —
+			// same disclosure-family calibration as /compliance/evidence. Static path,
+			// before /{id}.
+			r.With(customMiddleware.RequirePermission("audit.read")).Get("/inventory.csv", secretHandler.DeploymentSecretsInventoryCSV)
 			// Org-wide naming-policy conformance — every project's secrets whose names
-			// violate the current (global) policy. Deployment-wide system.read; static
+			// violate the current (global) policy; discloses the violating secrets' real
+			// names deployment-wide, so audit.read (global), not the baseline. Static
 			// path, before /{id}.
-			r.With(customMiddleware.RequirePermission("system.read")).Get("/name-conformance", secretHandler.DeploymentSecretNameConformance)
+			r.With(customMiddleware.RequirePermission("audit.read")).Get("/name-conformance", secretHandler.DeploymentSecretNameConformance)
 			// By-reference value read (ESO etc.): resolve project/environment/name → the
 			// secret's value. Scoped to the resolved secret; static path, before /{id}.
 			r.With(customMiddleware.RequireScopedPermission("secrets.read", customMiddleware.ScopeFromRefQuery)).Get("/value", secretHandler.GetSecretValueByRef)
@@ -628,25 +645,37 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		r.With(customMiddleware.RequirePermission("system.read")).Get("/license/status", licenseHandler.GetLicenseStatus)
 
 		// Personal-access-token hygiene — deployment-wide stale / expired-but-active
-		// tokens an admin should revoke (token sprawl).
-		r.With(customMiddleware.RequirePermission("system.read")).Get("/pat-hygiene", patHandler.PATHygiene)
+		// tokens an admin should revoke (token sprawl). Discloses every user's PAT
+		// names/scopes/project-env-scope/AllowedCIDRs/owning user ID deployment-wide, so
+		// gated on audit.read (global), NOT the universal system_viewer baseline
+		// system.read — same disclosure-family calibration as /compliance/evidence.
+		r.With(customMiddleware.RequirePermission("audit.read")).Get("/pat-hygiene", patHandler.PATHygiene)
 		// Machine-token hygiene — deployment-wide stale / expired-but-active machine
-		// credentials an admin should revoke (non-human token sprawl).
-		r.With(customMiddleware.RequirePermission("system.read")).Get("/machine-token-hygiene", catalogHandler.MachineTokenHygiene)
+		// credentials an admin should revoke (non-human token sprawl). Same calibration
+		// as /pat-hygiene: audit.read, not the baseline.
+		r.With(customMiddleware.RequirePermission("audit.read")).Get("/machine-token-hygiene", catalogHandler.MachineTokenHygiene)
 		// Secret-hygiene rollup — deployment-wide totals of every project's posture
-		// (orphaned / unused / expiring / stale-MI / rotation-overdue) + per-project breakdown.
-		r.With(customMiddleware.RequirePermission("system.read")).Get("/hygiene", secretHandler.DeploymentHygiene)
+		// (orphaned / unused / expiring / stale-MI / rotation-overdue) + per-project
+		// breakdown identified by project name. Same calibration: audit.read.
+		r.With(customMiddleware.RequirePermission("audit.read")).Get("/hygiene", secretHandler.DeploymentHygiene)
 
-		// Compliance posture — deployment-wide controls snapshot for auditors.
-		r.With(customMiddleware.RequirePermission("system.read")).Get("/compliance/posture", dashboardHandler.GetCompliancePosture)
+		// Compliance posture — deployment-wide controls snapshot for auditors. Part of
+		// the same disclosure family as /compliance/evidence (SoD-violation counts,
+		// legal-hold reason, risk-register counts): gated on audit.read, not the
+		// universal system_viewer baseline.
+		r.With(customMiddleware.RequirePermission("audit.read")).Get("/compliance/posture", dashboardHandler.GetCompliancePosture)
 		// Compliance control matrix — controls mapped to ISO/SOC2/NIS2/DORA + status.
-		r.With(customMiddleware.RequirePermission("system.read")).Get("/compliance/controls", dashboardHandler.GetComplianceControls)
-		// Control matrix as CSV — the same matrix for an auditor's spreadsheet.
-		r.With(customMiddleware.RequirePermission("system.read")).Get("/compliance/controls.csv", dashboardHandler.ExportComplianceControlsCSV)
-		// Compliance digest — on-demand human-readable summary (the scheduled-broadcast text).
-		r.With(customMiddleware.RequirePermission("system.read")).Get("/compliance/digest", dashboardHandler.GetComplianceDigest)
-		// Legal hold (ISO A.5.34): status reads system.read; place/lift system.write.
-		r.With(customMiddleware.RequirePermission("system.read")).Get("/legal-hold", dashboardHandler.GetLegalHold)
+		r.With(customMiddleware.RequirePermission("audit.read")).Get("/compliance/controls", dashboardHandler.GetComplianceControls)
+		// Control matrix as CSV — the same matrix for an auditor's spreadsheet; same gate
+		// as the JSON endpoint above (a lower-tier CSV export would just be a bypass).
+		r.With(customMiddleware.RequirePermission("audit.read")).Get("/compliance/controls.csv", dashboardHandler.ExportComplianceControlsCSV)
+		// Compliance digest — on-demand human-readable summary (the scheduled-broadcast
+		// text); restates the same posture data, same gate.
+		r.With(customMiddleware.RequirePermission("audit.read")).Get("/compliance/digest", dashboardHandler.GetComplianceDigest)
+		// Legal hold (ISO A.5.34): status discloses the free-text hold reason
+		// deployment-wide, so reads need audit.read; place/lift stay system.write
+		// (an admin action, not a read disclosure).
+		r.With(customMiddleware.RequirePermission("audit.read")).Get("/legal-hold", dashboardHandler.GetLegalHold)
 		r.With(customMiddleware.RequirePermission("system.write")).Post("/legal-hold", dashboardHandler.PlaceLegalHold)
 		r.With(customMiddleware.RequirePermission("system.write")).Delete("/legal-hold", dashboardHandler.LiftLegalHold)
 		// Compliance evidence pack — posture + supporting records, for archival. Gated on
@@ -658,17 +687,21 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		r.With(customMiddleware.RequirePermission("audit.read")).Get("/compliance/evidence", dashboardHandler.GetComplianceEvidence)
 		// Verify a previously-exported evidence pack against its detached signature.
 		r.With(customMiddleware.RequirePermission("audit.read")).Post("/compliance/evidence/verify", dashboardHandler.VerifyComplianceEvidence)
-		// Risk register (ISO A.5.8): list reads system.read; create/revoke system.write.
-		r.With(customMiddleware.RequirePermission("system.read")).Get("/risk-exceptions", dashboardHandler.ListRiskExceptions)
+		// Risk register (ISO A.5.8): list discloses free-text Reference/Justification
+		// (which may itself name a secret) deployment-wide, so reads need audit.read;
+		// create/revoke stay system.write.
+		r.With(customMiddleware.RequirePermission("audit.read")).Get("/risk-exceptions", dashboardHandler.ListRiskExceptions)
 		r.With(customMiddleware.RequirePermission("system.write")).Post("/risk-exceptions", dashboardHandler.CreateRiskException)
 		r.With(customMiddleware.RequirePermission("system.write")).Delete("/risk-exceptions/{id}", dashboardHandler.RevokeRiskException)
 
-		// Separation of duties (ISO A.5.3): list policies/violations (system.read);
-		// create/delete policies (system.write).
+		// Separation of duties (ISO A.5.3): policy definitions (name/permission pair, no
+		// PII) stay at the baseline system.read; the violations list discloses
+		// deployment-wide violator names/emails, so it needs audit.read; create/delete
+		// policies need system.write.
 		r.With(customMiddleware.RequirePermission("system.read")).Get("/sod/policies", catalogHandler.ListSoDPolicies)
 		r.With(customMiddleware.RequirePermission("system.write")).Post("/sod/policies", catalogHandler.CreateSoDPolicy)
 		r.With(customMiddleware.RequirePermission("system.write")).Delete("/sod/policies/{id}", catalogHandler.DeleteSoDPolicy)
-		r.With(customMiddleware.RequirePermission("system.read")).Get("/sod/violations", catalogHandler.ListSoDViolations)
+		r.With(customMiddleware.RequirePermission("audit.read")).Get("/sod/violations", catalogHandler.ListSoDViolations)
 
 		// On-demand triggers for the notification/alert jobs that otherwise run only on
 		// their background schedulers — dispatch immediately after an incident or config


### PR DESCRIPTION
## Summary

Every account is auto-assigned the `system_viewer` role with **zero admin action** — on `CreateUser`, SSO/SCIM JIT-provisioning, and invitations (`internal/core/auth_bootstrap.go`, `internal/core/users.go`, `sso.go`, `scim.go`, `invitations.go`). It carries only `system.read`. Seven deployment-wide reporting/aggregation endpoints were gated on that same universal baseline — or, for #272, on **no permission at all** — so any authenticated account (including a brand-new user with zero project memberships) could read sensitive data about other users/projects/secrets across the entire deployment.

This PR closes all 7 instances with one consistent pattern: require `audit.read` at global scope (the `system_admin`/`system_auditor` persona), which is **not** auto-granted to every account. This is the same convention a prior PR already established for `GET /compliance/evidence` and `GET /dashboard/activity` — both were already fixed before this PR and are unchanged here except for doc-comment cleanup.

## Instances fixed

1. **#272 HIGH** — `GET /dashboard/stats` had **no permission check at all** (the sibling `/dashboard/activity` was already fixed). `GetDashboardStats` now scopes its deployment-wide aggregate fields (active users, audit-event counts, failed-auth count, inactive-user count) to `audit.read`, mirroring the recent-activity scoping already there, while the route itself keeps a `system.read` gate so every normal user's own personal dashboard (their secret/share counts) keeps working — only a principal with no real standing at all (e.g. a narrowly-scoped machine identity/PAT) is now turned away.
2. **#280 HIGH** — `GET /secrets/inventory.csv` (deployment-wide): disclosed every live secret's real name, classification, and owner. Now `audit.read`.
3. **#273 MEDIUM** — `GET /hygiene`: disclosed every project's name deployment-wide plus hygiene counts. Now `audit.read`.
4. **#274 MEDIUM** — `GET /machine-token-hygiene`: disclosed machine-credential names/prefixes/expiry deployment-wide. Now `audit.read`.
5. **#275 MEDIUM** — `GET /pat-hygiene`: disclosed every user's PAT names/scopes/CIDRs/owning user ID deployment-wide — the most reconnaissance-valuable instance (maps which users hold unrestricted PATs). Now `audit.read`.
6. **#281 MEDIUM** — `GET /secrets/name-conformance` (deployment-wide): disclosed every non-conformant secret's real name. Now `audit.read`.
7. **#255 HIGH** — `GET /compliance/evidence` was already fixed in a prior PR (`audit.read`). This PR extends the same fix to the sibling routes the finding explicitly called out: `/compliance/posture`, `/compliance/controls`, `/compliance/controls.csv`, `/compliance/digest`, `/legal-hold` (GET), `/risk-exceptions` (GET), and `/sod/violations`. `/sod/policies` (policy *definitions*, no PII) intentionally stays at the baseline `system.read`.

### #255 bundled MED sub-finding (free text in the evidence pack)

`BreakGlassActivation.Justification` and `RiskException.Reference`/`Justification` are unvalidated free text that flows into the evidence pack and the `/risk-exceptions` list verbatim. Since both routes now require `audit.read` — a genuinely elevated, deliberately-granted compliance/auditor persona, not the universal baseline — I judged the permission fix alone resolves this sub-finding rather than adding separate redaction: the only principals who can now reach this free text are exactly the ones with a legitimate governance need to see it.

## Why `audit.read`

`audit.read` already exists as a distinct, non-baseline permission (`internal/core/auth_bootstrap.go`): granted to `admin`/`system_admin` (bypass roles) and to `system_auditor` (`["secrets.read", "users.read", "roles.read", "audit.read", "system.read"]`), but **not** to `system_viewer` (the auto-assigned baseline, `["system.read"]` only). A prior PR already used it for `/compliance/evidence` and `/dashboard/activity`, so this PR reuses the codebase's own established convention rather than inventing a new permission string.

## Backward compatibility (breaking change, expected)

Any existing deployment whose monitoring/dashboard integration currently authenticates as a plain `system_viewer` (or narrower) principal against these 7 routes will start getting `403`. Such integrations need an `audit.read` grant (`system_admin` or `system_auditor` role) going forward. `GET /dashboard/stats` is the one exception designed to avoid regressing normal end users: it still returns 200 for a baseline caller, just with the deployment-wide aggregate fields zeroed.

## Test plan

- [x] New test `TestDeploymentDisclosureFamily_BaselineDeniedAuditorAllowed` (`server/http/deployment_disclosure_family_test.go`): for all 12 affected GET routes, a `system_viewer`-baseline caller gets 403 and a `system_auditor` (`audit.read`) caller gets 200 with the expected payload (seeded secret/PAT/machine-credential/SoD-violation/risk-exception fixtures).
- [x] New test `TestDashboardStats_PermissionTiers`: proves a principal with **no** relevant permission at all is now denied (previously succeeded), a baseline caller still gets their own dashboard with aggregates zeroed, and an `audit.read` holder sees the full deployment picture.
- [x] `go build ./...`
- [x] `go test ./...` — full suite passes, no regressions
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues
- [x] `golangci-lint run ./...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)