### PR TITLE
harden(auth): close login-lockout TOCTOU, verify PAT/suspend cache fix, rate-limit password-reset

### DIFF
--- a/internal/core/auth.go
+++ b/internal/core/auth.go
@@ -65,8 +65,15 @@ func (c *KeyorixCore) Login(ctx context.Context, req *LoginRequest) (*models.Ses
 		c.recordFailedLogin(ctx, user) // increment + lock at the threshold
 		return nil, nil, fmt.Errorf("invalid credentials")
 	}
-	// Correct password — clear any accumulated lockout state.
-	c.clearLoginFailures(ctx, user)
+	// Correct password — but a concurrent burst of failed attempts against this
+	// account may have tripped the lock between the snapshot read at the top of
+	// this function and now (TOCTOU). Re-check the lock state under the same
+	// serialization recordFailedLogin uses (the account's mutex shard + a Postgres
+	// row lock) before minting a session, and only then clear any accumulated
+	// failure state — never trust the stale pre-bcrypt snapshot alone.
+	if err := c.checkLockAndClearLoginFailures(ctx, user); err != nil {
+		return nil, nil, err
+	}
 	// A deactivated account (IsActive=false — e.g. admin deactivation via UpdateUser,
 	// or a SCIM/IdP deactivation) is refused login regardless of account_state. The
 	// state-based gate below does not cover this, so without it a deactivated user who

--- a/internal/core/concurrency_login_lockout_toctou_test.go
+++ b/internal/core/concurrency_login_lockout_toctou_test.go
@@ -1,0 +1,172 @@
+package core_test
+
+import (
+	"context"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/bcrypt"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// raceInjectingStorage wraps a real storage.Storage and, on the FIRST call to
+// GetUserByUsername, simulates a concurrent failed-login burst committing a lock
+// on the same row immediately after the snapshot read returns — exactly the
+// TOCTOU window #247 concerns (Login reads an unlocked snapshot, then a
+// concurrent burst trips the lock before Login reaches bcrypt/mintSession). The
+// returned snapshot is left unmodified (matching what a real concurrent reader
+// would have seen at that instant); the underlying row is locked via a direct
+// write that bypasses the snapshot entirely, so the test is fully deterministic
+// — no goroutine-scheduling luck required — while still exercising the exact
+// interleaving the bug allowed.
+type raceInjectingStorage struct {
+	storage.Storage
+	db        *gorm.DB
+	injected  bool
+	lockUntil time.Time
+}
+
+func (s *raceInjectingStorage) GetUserByUsername(ctx context.Context, username string) (*models.User, error) {
+	user, err := s.Storage.GetUserByUsername(ctx, username)
+	if err != nil {
+		return nil, err
+	}
+	if !s.injected {
+		s.injected = true
+		if err := s.db.Model(&models.User{}).Where("id = ?", user.ID).
+			Updates(map[string]interface{}{
+				"login_locked_until":  s.lockUntil,
+				"login_lockout_count": 1,
+			}).Error; err != nil {
+			panic(err) // test setup invariant — must not silently corrupt the scenario
+		}
+	}
+	return user, nil
+}
+
+// TestLogin_TOCTOU_ConcurrentLockTripBeforeMintIsRefused is the deterministic
+// regression for #247: the login-lockout gate must not trust the pre-bcrypt
+// snapshot read for the WHOLE authorization decision. It simulates a concurrent
+// burst of OTHER failed attempts committing the account's lock in the instant
+// after Login's snapshot read returns unlocked but before Login reaches
+// bcrypt/mintSession — precisely the exploit window the finding describes. On
+// the pre-fix code (which trusted the top-of-function loginLocked snapshot and
+// never rechecked before minting a session) this correct-password login would
+// have succeeded despite the account being locked; the fix re-checks lock state
+// under the same serialization recordFailedLogin uses immediately before
+// minting, so it must now be refused.
+func TestLogin_TOCTOU_ConcurrentLockTripBeforeMintIsRefused(t *testing.T) {
+	dsn := "file:" + filepath.Join(t.TempDir(), "toctou.db") + "?_busy_timeout=10000&_journal_mode=WAL"
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.User{}, &models.Session{}, &models.AuditEvent{}))
+
+	const password = "Correct#Horse9Battery"
+	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.MinCost)
+	require.NoError(t, err)
+	require.NoError(t, db.Create(&models.User{
+		ID: 1, Username: "alice", PasswordHash: string(hash), AccountState: core.AccountActive,
+	}).Error)
+
+	wrapped := &raceInjectingStorage{
+		Storage:   store.NewLocalStorage(db),
+		db:        db,
+		lockUntil: time.Now().Add(time.Hour),
+	}
+	c := core.NewKeyorixCore(wrapped)
+	c.SetLoginLockoutPolicy(core.LoginLockoutPolicy{
+		Enabled: true, MaxAttempts: 5,
+		Window: 15 * time.Minute, BaseCooldown: 5 * time.Minute, MaxCooldown: time.Hour,
+	})
+
+	session, _, err := c.Login(context.Background(), &core.LoginRequest{Username: "alice", Password: password})
+	require.Error(t, err, "a correct password must be refused once a concurrent burst locks the account before the mint")
+	assert.Nil(t, session)
+	assert.Contains(t, err.Error(), "locked")
+
+	// Defense in depth: confirm no session row was actually created.
+	var sessionCount int64
+	require.NoError(t, db.Model(&models.Session{}).Count(&sessionCount).Error)
+	assert.Equal(t, int64(0), sessionCount, "no session may be minted for a login that raced a concurrent lock trip")
+}
+
+// TestConcurrency_LoginLockout_MixedBurstCorrectPasswordAmongLockedNeverMintsExtra
+// is a real (goroutine-scheduled) concurrency stress test, run with -race: a
+// large burst of wrong-password attempts and a single correct-password attempt
+// hit the same, already-nearly-locked account simultaneously. Regardless of
+// scheduling order, at most one session may ever be minted, and the account's
+// final persisted state must be internally consistent (no lost/duplicated
+// lockout transitions from the mixed workload racing the fix's recheck).
+func TestConcurrency_LoginLockout_MixedBurstCorrectPasswordAmongLockedNeverMintsExtra(t *testing.T) {
+	dsn := "file:" + filepath.Join(t.TempDir(), "mixed.db") + "?_busy_timeout=10000&_journal_mode=WAL"
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.User{}, &models.Session{}, &models.AuditEvent{}))
+
+	const password = "Correct#Horse9Battery"
+	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.MinCost)
+	require.NoError(t, err)
+	const maxAttempts = 5
+	// Pre-seed one failure away from tripping, so a single committed wrong
+	// attempt from the burst is enough to lock the account — maximizing the
+	// chance the burst genuinely races the correct-password attempt's recheck.
+	require.NoError(t, db.Create(&models.User{
+		ID: 1, Username: "alice", PasswordHash: string(hash), AccountState: core.AccountActive,
+		FailedLoginAttempts: maxAttempts - 1,
+	}).Error)
+
+	c := core.NewKeyorixCore(store.NewLocalStorage(db))
+	c.SetLoginLockoutPolicy(core.LoginLockoutPolicy{
+		Enabled: true, MaxAttempts: maxAttempts,
+		Window: 15 * time.Minute, BaseCooldown: 5 * time.Minute, MaxCooldown: time.Hour,
+	})
+
+	const wrongAttackers = 60
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	var successCount int32
+	var mu sync.Mutex
+
+	for i := 0; i < wrongAttackers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			_, _, _ = c.Login(context.Background(), &core.LoginRequest{Username: "alice", Password: "wrong"})
+		}()
+	}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		<-start
+		session, _, err := c.Login(context.Background(), &core.LoginRequest{Username: "alice", Password: password})
+		if err == nil {
+			require.NotNil(t, session)
+			mu.Lock()
+			successCount++
+			mu.Unlock()
+		} else {
+			assert.Contains(t, err.Error(), "locked",
+				"the only way the correct password can fail here is the lockout gate")
+		}
+	}()
+	close(start)
+	wg.Wait()
+
+	// At most one session may ever be minted — there's only one correct-password
+	// attempt in the whole burst, so this also guards against any double-mint bug.
+	assert.LessOrEqual(t, successCount, int32(1))
+
+	var sessionCount int64
+	require.NoError(t, db.Model(&models.Session{}).Count(&sessionCount).Error)
+	assert.Equal(t, int64(successCount), sessionCount, "minted-session count must match the observed success count")
+}

--- a/internal/core/concurrency_password_reset_throttle_test.go
+++ b/internal/core/concurrency_password_reset_throttle_test.go
@@ -1,0 +1,88 @@
+package core_test
+
+import (
+	"context"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/delivery"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// countingDeliverer is a thread-safe delivery.CredentialDelivery fake that counts
+// how many setup-link "emails" it was asked to send — the direct proxy for the
+// mail-bombing/inbox-flooding harm #249 describes.
+type countingDeliverer struct {
+	sent atomic.Int32
+}
+
+func (d *countingDeliverer) DeliverSetupLink(_ context.Context, _ delivery.SetupLinkRequest) (delivery.DeliveryResult, error) {
+	d.sent.Add(1)
+	return delivery.DeliveryResult{Channel: delivery.ChannelSMTP, Delivered: true}, nil
+}
+
+func (d *countingDeliverer) Name() string { return "counting-fake" }
+
+// TestConcurrency_RequestPasswordReset_BurstIsThrottled is the regression for the
+// check-then-act half of #249: POST /auth/password-reset's abuse control
+// (checkResendThrottle, ADR-028's 60s min-interval + 10/day cap) must not be
+// defeated by a burst of concurrent requests for the same victim email each
+// reading the same pre-burst count and all passing. provisionSetupLinkThrottled
+// already serializes the count-then-issue window per process via setupResendMu
+// (held across the throttle check AND the token write); this drives a real burst
+// — far larger than the daily cap — against genuine SQLite-backed storage and
+// asserts that only ONE reset email is ever actually sent, not one per
+// concurrent request.
+func TestConcurrency_RequestPasswordReset_BurstIsThrottled(t *testing.T) {
+	dsn := "file:" + filepath.Join(t.TempDir(), "pwreset.db") + "?_busy_timeout=10000&_journal_mode=WAL"
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.User{}, &models.SetupToken{}, &models.AuditEvent{}))
+
+	const email = "victim@acme.io"
+	require.NoError(t, db.Create(&models.User{
+		ID: 1, Username: "victim", Email: email, AccountState: core.AccountActive,
+	}).Error)
+
+	c := core.NewKeyorixCore(store.NewLocalStorage(db))
+	fake := &countingDeliverer{}
+	c.SetCredentialDelivery(fake, "https://keyorix.example.internal")
+
+	const burst = 50 // far more than the daily cap (10) and the 60s min interval allows
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < burst; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			// RequestPasswordReset always returns nil (enumeration-safe) regardless of
+			// throttling — the observable effect under test is how many emails went out.
+			_ = c.RequestPasswordReset(context.Background(), email)
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	// The 60s min-interval means at most one reset email can go out per burst that
+	// completes well inside that window — a burst of 50 concurrent requests must
+	// not fan out into 50 emails to the victim's inbox.
+	assert.Equal(t, int32(1), fake.sent.Load(),
+		"a concurrent burst against one email must be throttled to a single delivery, not one per request")
+
+	// Defense in depth: exactly one active setup token exists for this subject —
+	// the DB state agrees with what was actually delivered.
+	var tokenCount int64
+	require.NoError(t, db.Model(&models.SetupToken{}).
+		Where("purpose = ? AND subject_email = ?", core.SetupPurposePasswordResetLink, email).
+		Count(&tokenCount).Error)
+	assert.Equal(t, int64(1), tokenCount, "exactly one setup token should have been issued for the burst")
+}

--- a/internal/core/login_lockout.go
+++ b/internal/core/login_lockout.go
@@ -11,6 +11,7 @@ package core
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/core/storage"
@@ -31,6 +32,19 @@ const (
 	EventAccountLocked   = "account.locked"
 	EventAccountUnlocked = "account.unlocked"
 )
+
+// loginFailureMuShards is the shard count for loginFailureMu (see service.go):
+// enough to make same-shard collisions between two unrelated accounts rare under
+// realistic concurrency, without the memory/complexity of a per-user sync.Map.
+const loginFailureMuShards = 64
+
+// loginFailureLock returns the shard of loginFailureMu serializing this user's
+// failed-login accounting. Sharding by userID means a flood against one (even
+// already-locked) account no longer blocks every other account's accounting
+// behind a single process-wide lock.
+func (c *KeyorixCore) loginFailureLock(userID uint) *sync.Mutex {
+	return &c.loginFailureMu[userID%loginFailureMuShards]
+}
 
 // loginLocked reports whether the user is currently within an active lockout window.
 func (c *KeyorixCore) loginLocked(user *models.User) bool {
@@ -56,12 +70,13 @@ func (p LoginLockoutPolicy) cooldownFor(lockoutCount int) time.Duration {
 // "invalid credentials" outcome the caller returns.
 //
 // The read-increment-write runs inside a transaction over a freshly LockUserForUpdate'd
-// row, under loginFailureMu, so concurrent failures for the same account cannot lose an
-// increment and let an attacker spend more than MaxAttempts guesses before the lock
-// trips: loginFailureMu serializes same-process callers (and so the whole single-process
-// SQLite case), and the FOR UPDATE row lock LockUserForUpdate takes on Postgres
-// serializes across HA replicas. The passed-in user struct was loaded before the lock,
-// so the authoritative current state is re-read inside the transaction.
+// row, under the user's loginFailureMu shard, so concurrent failures for the same
+// account cannot lose an increment and let an attacker spend more than MaxAttempts
+// guesses before the lock trips: the shard mutex serializes same-process callers for
+// that account (and so the whole single-process SQLite case), and the FOR UPDATE row
+// lock LockUserForUpdate takes on Postgres serializes across HA replicas. The
+// passed-in user struct was loaded before the lock, so the authoritative current
+// state is re-read inside the transaction.
 func (c *KeyorixCore) recordFailedLogin(ctx context.Context, user *models.User) {
 	if !c.loginLockout.Enabled {
 		return
@@ -69,8 +84,9 @@ func (c *KeyorixCore) recordFailedLogin(ctx context.Context, user *models.User) 
 	uid := user.ID
 	now := c.now()
 
-	c.loginFailureMu.Lock()
-	defer c.loginFailureMu.Unlock()
+	mu := c.loginFailureLock(uid)
+	mu.Lock()
+	defer mu.Unlock()
 
 	var locked bool
 	var lockedUntil time.Time
@@ -124,6 +140,79 @@ func (c *KeyorixCore) recordFailedLogin(ctx context.Context, user *models.User) 
 			fmt.Sprintf("account %d locked until %s after repeated failed logins (lockout #%d)",
 				uid, lockedUntil.UTC().Format(time.RFC3339), lockoutNum))
 	}
+}
+
+// checkLockAndClearLoginFailures re-checks the account's lock state and, if not
+// locked, clears any accumulated failure state — both under the SAME
+// serialization (the user's loginFailureMu shard, plus the Postgres FOR UPDATE
+// row lock LockUserForUpdate takes) that recordFailedLogin uses. This closes the
+// TOCTOU gap between a caller's pre-verification snapshot check (loginLocked,
+// evaluated against a user row read before the slow credential check — bcrypt, a
+// TOTP/recovery-code check, or a WebAuthn assertion) and minting a session:
+// without re-checking here, a concurrent burst of failed attempts against the
+// same account could trip the lock AFTER a request already passed the snapshot
+// check but BEFORE it mints a session, letting that request's otherwise-valid
+// credential succeed against an account that should already be locked.
+//
+// Returns an error (the same "account temporarily locked" message the snapshot
+// check uses) when the account is found to be locked; the caller MUST refuse the
+// login rather than mint a session. Also returns an error — failing closed — if
+// the lock state cannot be verified (a storage error), rather than falling back
+// to the caller's stale snapshot. When the lockout feature is disabled this is
+// equivalent to clearLoginFailures. Shared by every login path that reaches a
+// session mint after passing the lockout gate: password (Login), TOTP/recovery
+// (VerifyMFALogin), and WebAuthn (FinishWebAuthnLogin /
+// FinishWebAuthnPasswordlessLogin) — recordFailedLogin feeds the same counter
+// from all of them, so the recheck must cover all of them too.
+func (c *KeyorixCore) checkLockAndClearLoginFailures(ctx context.Context, user *models.User) error {
+	if !c.loginLockout.Enabled {
+		c.clearLoginFailures(ctx, user)
+		return nil
+	}
+	uid := user.ID
+
+	mu := c.loginFailureLock(uid)
+	mu.Lock()
+	defer mu.Unlock()
+
+	var lockErr error
+	err := c.storage.WithTransaction(ctx, func(tx storage.Storage) error {
+		u, err := tx.LockUserForUpdate(ctx, uid)
+		if err != nil {
+			return err
+		}
+		if u.LoginLockedUntil != nil && c.now().Before(*u.LoginLockedUntil) {
+			// A concurrent burst tripped the lock after our caller's pre-verification
+			// snapshot but before we reached here — reflect the authoritative state
+			// back onto the caller's struct and refuse.
+			user.LoginLockedUntil = u.LoginLockedUntil
+			user.LoginLockoutCount = u.LoginLockoutCount
+			lockErr = fmt.Errorf("account temporarily locked due to repeated failed logins; try again later")
+			return nil
+		}
+		if u.FailedLoginAttempts == 0 && u.LoginLockedUntil == nil && u.LoginLockoutCount == 0 {
+			return nil // nothing to clear
+		}
+		u.FailedLoginAttempts = 0
+		u.LastFailedLoginAt = nil
+		u.LoginLockedUntil = nil
+		u.LoginLockoutCount = 0
+		if _, err := tx.UpdateUser(ctx, u); err != nil {
+			return err
+		}
+		user.FailedLoginAttempts = 0
+		user.LastFailedLoginAt = nil
+		user.LoginLockedUntil = nil
+		user.LoginLockoutCount = 0
+		return nil
+	})
+	if err != nil {
+		// Unable to verify the current lock state — fail closed. Silently falling
+		// back to "not locked" here would reopen exactly the snapshot-trust gap
+		// this function exists to close.
+		return fmt.Errorf("unable to verify account lock state, please try again")
+	}
+	return lockErr
 }
 
 // clearLoginFailures resets the lockout state after a successful authentication.

--- a/internal/core/mfa.go
+++ b/internal/core/mfa.go
@@ -252,8 +252,13 @@ func (c *KeyorixCore) VerifyMFALogin(ctx context.Context, challenge, code, userA
 		c.recordFailedLogin(ctx, user) // count the failed second factor toward the lockout
 		return nil, nil, fmt.Errorf("invalid code")
 	}
-	// Cleared the second factor — reset any lockout state accrued from failed codes.
-	c.clearLoginFailures(ctx, user)
+	// Cleared the second factor — but a concurrent burst of failed second-factor
+	// attempts against this account may have tripped the lock since the
+	// pre-verification snapshot check above (TOCTOU). Re-check under the same
+	// serialization recordFailedLogin uses before minting a session.
+	if err := c.checkLockAndClearLoginFailures(ctx, user); err != nil {
+		return nil, nil, err
+	}
 	session, err := c.mintSession(ctx, ch.UserID, userAgent, ip)
 	if err != nil {
 		return nil, nil, err

--- a/internal/core/rate_limit.go
+++ b/internal/core/rate_limit.go
@@ -44,3 +44,51 @@ func (c *KeyorixCore) RecordFailedLogin(ctx context.Context, ip string) {
 func (c *KeyorixCore) PruneLoginAttempts(ctx context.Context) (int64, error) {
 	return c.storage.PruneLoginAttempts(ctx, c.now().Add(-LoginWindow))
 }
+
+// passwordResetRateLimitPrefix namespaces password-reset attempts within the
+// SAME LoginAttempt table the login rate limiter uses (ADR-040), so a
+// password-reset flood budget is tracked per-IP separately from — but reuses
+// the identical cluster-wide, DB-backed limiter as — failed login attempts.
+// POST /auth/password-reset (#249) is fully unauthenticated and had zero
+// rate-limiting of any kind before this; composing the key this way (rather
+// than a second table/migration) matches the codebase's existing convention
+// for "per-IP request budget" and needs no schema change.
+const passwordResetRateLimitPrefix = "pwreset:"
+
+const (
+	// PasswordResetMaxAttempts is the request budget per IP within
+	// PasswordResetWindow. Deliberately tighter than LoginMaxAttempts: each
+	// request potentially triggers a real outbound email, so the budget is a
+	// mail-bombing defense, not just a guess-throttle.
+	PasswordResetMaxAttempts = 5
+	// PasswordResetWindow is the sliding window over which attempts are counted.
+	PasswordResetWindow = 15 * time.Minute
+)
+
+// IsPasswordResetRateLimited reports whether an IP has reached the
+// password-reset request budget within the window. Fails open (false) on an
+// empty IP or a storage error — this is a defense-in-depth backstop on top of
+// the per-email checkResendThrottle (ADR-028), not the sole abuse control.
+func (c *KeyorixCore) IsPasswordResetRateLimited(ctx context.Context, ip string) bool {
+	if ip == "" {
+		return false
+	}
+	n, err := c.storage.CountRecentLoginAttempts(ctx, passwordResetRateLimitPrefix+ip, c.now().Add(-PasswordResetWindow))
+	if err != nil {
+		return false
+	}
+	return n >= PasswordResetMaxAttempts
+}
+
+// RecordPasswordResetAttempt records a password-reset request from an IP.
+// Unlike RecordFailedLogin (recorded only on a WRONG password), this is
+// recorded on EVERY request regardless of outcome: the endpoint always returns
+// success (enumeration-safe) and never signals which email is registered, so
+// the request itself — not a distinguishable "failure" — is the abuse signal
+// to budget against. Best-effort: a storage error does not block the response.
+func (c *KeyorixCore) RecordPasswordResetAttempt(ctx context.Context, ip string) {
+	if ip == "" {
+		return
+	}
+	_ = c.storage.RecordLoginAttempt(ctx, passwordResetRateLimitPrefix+ip, c.now())
+}

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -64,10 +64,16 @@ type KeyorixCore struct {
 	secretNameRe      *regexp.Regexp     // compiled secretNamePolicy.Pattern (nil = no regex check)
 	loginLockout      LoginLockoutPolicy // per-account login lockout (disabled by default)
 	// loginFailureMu serializes the per-account failed-login read-increment-write in
-	// recordFailedLogin so concurrent failures can't lose an increment. Combined with
-	// the row lock LockUserForUpdate takes on Postgres, the lockout counter stays
-	// correct across replicas. Zero value is ready to use. See login_lockout.go.
-	loginFailureMu sync.Mutex
+	// recordFailedLogin (and the pre-session-mint recheck in
+	// checkLockAndClearLoginFailures) so concurrent failures can't lose an increment.
+	// Combined with the row lock LockUserForUpdate takes on Postgres, the lockout
+	// counter stays correct across replicas. Sharded by userID (see
+	// loginFailureLock) so a flood against one account cannot serialize every OTHER
+	// account's failed-login accounting behind a single process-wide lock — a
+	// noisy-neighbour/availability concern distinct from the correctness the
+	// per-shard lock + row lock still provide. Zero value is ready to use (each
+	// shard is its own zero-value sync.Mutex). See login_lockout.go.
+	loginFailureMu [loginFailureMuShards]sync.Mutex
 	// setupResendMu serializes the count-then-issue window of the setup-link resend
 	// throttle (checkResendThrottle + IssueSetupToken) so two concurrent resends for
 	// the same (purpose, email) cannot both clear the per-day cap / min-interval

--- a/internal/core/webauthn.go
+++ b/internal/core/webauthn.go
@@ -282,7 +282,13 @@ func (c *KeyorixCore) FinishWebAuthnLogin(ctx context.Context, challenge, sessio
 		c.recordFailedLogin(ctx, wu.user) // count the failed second factor toward the lockout
 		return nil, nil, fmt.Errorf("assertion verification failed: %w", err)
 	}
-	c.clearLoginFailures(ctx, wu.user)
+	// A concurrent burst of failed second-factor attempts against this account may
+	// have tripped the lock since the pre-verification snapshot check above
+	// (TOCTOU). Re-check under the same serialization recordFailedLogin uses
+	// before minting a session.
+	if err := c.checkLockAndClearLoginFailures(ctx, wu.user); err != nil {
+		return nil, nil, err
+	}
 	c.persistUpdatedCredential(ctx, ch.UserID, cred)
 
 	session, err := c.mintSession(ctx, ch.UserID, userAgent, ip)
@@ -379,7 +385,14 @@ func (c *KeyorixCore) FinishWebAuthnPasswordlessLogin(ctx context.Context, sessi
 	if c.loginLocked(resolved) {
 		return nil, nil, fmt.Errorf("account temporarily locked due to repeated failed logins; try again later")
 	}
-	c.clearLoginFailures(ctx, resolved)
+	// Re-check the lock state under the same serialization recordFailedLogin uses
+	// before minting a session — the passwordless path does not feed failures into
+	// the lockout itself (see above), but the account could still have been locked
+	// concurrently via the password/2FA path between the snapshot check above and
+	// here (TOCTOU).
+	if err := c.checkLockAndClearLoginFailures(ctx, resolved); err != nil {
+		return nil, nil, err
+	}
 	c.persistUpdatedCredential(ctx, resolved.ID, cred)
 
 	session, err := c.mintSession(ctx, resolved.ID, userAgent, ip)

--- a/server/http/handlers/auth.go
+++ b/server/http/handlers/auth.go
@@ -503,7 +503,28 @@ func (h *AuthHandler) RevokeSession(w http.ResponseWriter, r *http.Request) {
 
 // PasswordReset handles POST /auth/password-reset.
 // Always returns success to prevent email enumeration.
+//
+// This route is intentionally unauthenticated (anyone must be able to request a
+// reset for their own account), which also makes it reachable by anyone for ANY
+// target email — with no compensating auth barrier the way the admin-triggered
+// resend flows have (users.write / roles.assign). checkResendThrottle
+// (ADR-028, per-email 10/day + 60s min-interval, already serialized per-process
+// via setupResendMu) is the primary abuse control, but as a defense-in-depth
+// backstop specific to this unauthenticated entry point, an IP-based budget
+// (ADR-040's existing cluster-wide, DB-backed limiter, reused here) caps how
+// many reset requests — and therefore how many outbound emails — a single
+// source can trigger, independent of which email(s) it targets (#249).
 func (h *AuthHandler) PasswordReset(w http.ResponseWriter, r *http.Request) {
+	ip := r.RemoteAddr
+	if idx := strings.LastIndex(ip, ":"); idx != -1 {
+		ip = ip[:idx]
+	}
+	if h.coreService.IsPasswordResetRateLimited(r.Context(), ip) {
+		sendError(w, "TooManyRequests", "Too many password reset requests. Try again later.", http.StatusTooManyRequests, nil)
+		return
+	}
+	h.coreService.RecordPasswordResetAttempt(r.Context(), ip)
+
 	var body passwordResetRequestBody
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		sendError(w, "BadRequest", "Invalid request body", http.StatusBadRequest, nil)

--- a/server/http/handlers/auth_cache_invalidation_test.go
+++ b/server/http/handlers/auth_cache_invalidation_test.go
@@ -1,0 +1,132 @@
+// auth_cache_invalidation_test.go — regression coverage for #248 (the PAT/
+// suspend leg of the sessions/machine-token/PAT cache-invalidation family): a
+// revoked PAT or a suspended account must stop authenticating on the very NEXT
+// request, not linger in the middleware's 30s positive auth cache. Both fixes
+// were already present in the tree (RevokeOwnPAT returns the token hash for the
+// handler to evict; setAccountState evicts session + PAT hashes on any
+// login-blocking transition) but lacked an end-to-end test that actually drives
+// the real middleware.Authentication cache — this locks that behaviour in.
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/keyorixhq/keyorix/server/middleware"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// newCacheTestCore builds a real KeyorixCore over an in-memory SQLite DB, wired
+// with the same HTTP-auth-cache invalidator server/main.go wires at startup
+// (SetTokenCacheInvalidator -> middleware.InvalidateTokenCacheByHash). Without
+// this wiring, core-layer revocation (PAT revoke, suspend/reactivate) cannot
+// evict the middleware's positive cache — mirroring production exactly is the
+// point of these tests.
+func newCacheTestCore(t *testing.T) *core.KeyorixCore {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.User{}, &models.PersonalAccessToken{}, &models.Session{}, &models.AuditEvent{},
+	))
+	c := core.NewKeyorixCore(store.NewLocalStorage(db))
+	c.SetTokenCacheInvalidator(middleware.InvalidateTokenCacheByHash)
+	return c
+}
+
+// authProbe drives a bearer-token request through the REAL Authentication
+// middleware (a genuine *core.KeyorixCore, not a fake validator), so the test
+// exercises the exact cache-hit/miss/eviction logic production traffic uses.
+func authProbe(c *core.KeyorixCore, token string) int {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/probe", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	h := middleware.Authentication(c)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	h.ServeHTTP(rec, req)
+	return rec.Code
+}
+
+// TestRevokePAT_EvictsFromAuthCacheImmediately drives the real RevokePAT HTTP
+// handler (not a mock), so the exact production call — RevokeOwnPAT returning
+// the token hash, then middleware.InvalidateTokenCacheByHash(tokenHash) — is
+// what's under test. Before either half of that existed, a revoked PAT kept
+// authenticating from the positive cache for up to validTokenTTL (30s).
+func TestRevokePAT_EvictsFromAuthCacheImmediately(t *testing.T) {
+	c := newCacheTestCore(t)
+	ctx := context.Background()
+
+	user, err := c.CreateUser(ctx, &core.CreateUserRequest{
+		Username: "alice", Email: "alice@example.com", DisplayName: "Alice", Password: "Sup3r$ecretPassw0rd!",
+	})
+	require.NoError(t, err)
+
+	result, err := c.CreateOwnPAT(ctx, user.ID, "ci", nil, nil, 0, 0, nil)
+	require.NoError(t, err)
+
+	// Populate the positive cache with a real request.
+	require.Equal(t, http.StatusOK, authProbe(c, result.PlainToken), "PAT should authenticate before revocation")
+
+	// Revoke via the real HTTP handler — the exact code path #248 concerned.
+	h := NewPATHandler(c)
+	idStr := strconv.FormatUint(uint64(result.Token.ID), 10)
+	req := httptest.NewRequest(http.MethodDelete, "/auth/tokens/"+idStr, nil)
+	req = req.WithContext(context.WithValue(req.Context(), middleware.GetUserContextKey(), &middleware.UserContext{UserID: user.ID}))
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", idStr)
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+	rec := httptest.NewRecorder()
+	h.RevokePAT(rec, req)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+
+	// Immediately (no sleep, no 30s wait): the cache must reject it, not serve
+	// the stale positive entry.
+	assert.Equal(t, http.StatusUnauthorized, authProbe(c, result.PlainToken),
+		"revoked PAT must be rejected immediately, not served from the positive auth cache")
+}
+
+// TestSuspendUser_EvictsCachedSessionAndPATImmediately is the end-to-end
+// regression for the setAccountState leg of #248: suspending a user must evict
+// BOTH their session and their PAT from the shared positive auth cache, so a
+// suspended user's already-cached credentials stop working on the very next
+// request rather than lingering for the cache TTL.
+func TestSuspendUser_EvictsCachedSessionAndPATImmediately(t *testing.T) {
+	c := newCacheTestCore(t)
+	ctx := context.Background()
+
+	user, err := c.CreateUser(ctx, &core.CreateUserRequest{
+		Username: "bob", Email: "bob@example.com", DisplayName: "Bob", Password: "Sup3r$ecretPassw0rd!",
+	})
+	require.NoError(t, err)
+
+	session, _, err := c.Login(ctx, &core.LoginRequest{Username: "bob", Password: "Sup3r$ecretPassw0rd!"})
+	require.NoError(t, err)
+
+	pat, err := c.CreateOwnPAT(ctx, user.ID, "ci", nil, nil, 0, 0, nil)
+	require.NoError(t, err)
+
+	// Populate the positive cache for both credential kinds with real requests.
+	require.Equal(t, http.StatusOK, authProbe(c, session.SessionToken), "session should authenticate before suspension")
+	require.Equal(t, http.StatusOK, authProbe(c, pat.PlainToken), "PAT should authenticate before suspension")
+
+	require.NoError(t, c.SuspendUser(ctx, 1 /* admin */, user.ID))
+
+	// Immediately (no 30s wait): both must be rejected, not served from cache.
+	assert.Equal(t, http.StatusUnauthorized, authProbe(c, session.SessionToken),
+		"session token must be rejected immediately after suspension, not served from cache")
+	assert.Equal(t, http.StatusUnauthorized, authProbe(c, pat.PlainToken),
+		"PAT must be rejected immediately after suspension, not served from cache")
+}

--- a/server/http/handlers/password_reset_rate_limit_test.go
+++ b/server/http/handlers/password_reset_rate_limit_test.go
@@ -1,0 +1,86 @@
+// password_reset_rate_limit_test.go — regression coverage for #249: before this
+// fix, POST /auth/password-reset had zero rate-limiting of any kind (no auth,
+// no per-IP budget), so an unauthenticated caller could mail-bomb any
+// registered address without limit. This exercises the real HTTP handler.
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/delivery"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// noopDeliverer discards every setup-link delivery; only used so
+// RequestPasswordReset's base-URL/channel requirements are satisfied.
+type noopDeliverer struct{}
+
+func (noopDeliverer) DeliverSetupLink(_ context.Context, _ delivery.SetupLinkRequest) (delivery.DeliveryResult, error) {
+	return delivery.DeliveryResult{Channel: delivery.ChannelSMTP, Delivered: true}, nil
+}
+func (noopDeliverer) Name() string { return "noop" }
+
+func newPasswordResetTestCore(t *testing.T) *core.KeyorixCore {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.User{}, &models.SetupToken{}, &models.AuditEvent{}, &models.LoginAttempt{},
+	))
+	c := core.NewKeyorixCore(store.NewLocalStorage(db))
+	c.SetCredentialDelivery(noopDeliverer{}, "https://keyorix.example.internal")
+	return c
+}
+
+func doPasswordReset(h *AuthHandler, ip string) int {
+	rec := httptest.NewRecorder()
+	body := strings.NewReader(`{"email":"someone@example.com"}`)
+	req := httptest.NewRequest(http.MethodPost, "/auth/password-reset", body)
+	req.RemoteAddr = ip + ":54321"
+	h.PasswordReset(rec, req)
+	return rec.Code
+}
+
+// TestPasswordReset_RateLimitedByIP proves POST /auth/password-reset now has a
+// per-IP request budget: before core.PasswordResetMaxAttempts requests from one
+// IP within the window all succeed (200, the enumeration-safe generic
+// response); the next one is rejected with 429 rather than triggering another
+// throttle-check + potential email send.
+func TestPasswordReset_RateLimitedByIP(t *testing.T) {
+	c := newPasswordResetTestCore(t)
+	h := NewAuthHandler(c)
+	const ip = "203.0.113.7"
+
+	for i := 0; i < core.PasswordResetMaxAttempts; i++ {
+		assert.Equal(t, http.StatusOK, doPasswordReset(h, ip), "request %d should be under the IP budget", i+1)
+	}
+	assert.Equal(t, http.StatusTooManyRequests, doPasswordReset(h, ip),
+		"the request beyond the IP budget must be rate-limited")
+}
+
+// TestPasswordReset_RateLimitIsPerIP confirms the budget is scoped per source
+// IP, not global — a different caller is unaffected by another IP's burst.
+func TestPasswordReset_RateLimitIsPerIP(t *testing.T) {
+	c := newPasswordResetTestCore(t)
+	h := NewAuthHandler(c)
+
+	for i := 0; i < core.PasswordResetMaxAttempts; i++ {
+		assert.Equal(t, http.StatusOK, doPasswordReset(h, "203.0.113.7"))
+	}
+	assert.Equal(t, http.StatusTooManyRequests, doPasswordReset(h, "203.0.113.7"))
+
+	// A different IP still gets through.
+	assert.Equal(t, http.StatusOK, doPasswordReset(h, "198.51.100.9"))
+}


### PR DESCRIPTION
## Summary

Three HIGH findings from `docs/security/HARDENING-BACKLOG.md` (#247/#248/#249).

**#247 — Login-lockout gate was check-then-act across the whole authorization decision, not just the counter.**
`Login` read the user row, checked `loginLocked()` against that pre-bcrypt snapshot, then ran bcrypt and minted a session unconditionally on success — nothing re-checked lock state between the snapshot and the mint. A concurrent burst of failed attempts against the same account could trip the lock *after* the snapshot but *before* the mint, letting a correct password succeed against an account that should already be locked.

Fix: `checkLockAndClearLoginFailures` re-checks lock state immediately before minting a session, under the *same* serialization (`recordFailedLogin`'s per-account mutex shard + a Postgres `FOR UPDATE` row lock via `LockUserForUpdate`) already used for the counter. Applied to every login path that reaches a mint after the lockout gate — password (`Login`), TOTP/recovery (`VerifyMFALogin`), and WebAuthn 2FA/passwordless (`webauthn.go`) — since `recordFailedLogin` feeds the same counter from all of them, so the TOCTOU window existed identically in each.

Also bundled: `loginFailureMu` was a single process-wide `sync.Mutex` shared by every account's failed-login accounting, including the already-locked early-return path. Sharded it (64-way, keyed by `userID % N`) so flooding one (even already-locked) account no longer serializes every *other* account's accounting behind the same lock.

**#248 — PAT revocation / suspend cache invalidation.** Audited against current code and found **already fixed**: `RevokeOwnPAT` returns the token hash and the HTTP handler calls `middleware.InvalidateTokenCacheByHash`; `setAccountState` evicts both session and PAT cache entries (and revokes the underlying PAT rows outright) on any login-blocking transition, wired via `SetTokenCacheInvalidator` from `server/main.go`. No code changes needed. Added end-to-end regression tests that drive the real handler + the real `middleware.Authentication` cache (not mocks) — that specific path had no test coverage before.

**#249 — `POST /auth/password-reset` unauthenticated with zero rate-limiting.** `checkResendThrottle`'s count-then-insert is already serialized per-process via `setupResendMu` (`provisionSetupLinkThrottled`, which this password-reset path already uses) — that closes the exact concurrent-burst race described, for single-instance deployments. What was genuinely still missing: *any* IP-based budget on the unauthenticated route itself (confirmed by reading the handler — it never calls a rate limiter at all, unlike `/auth/login`). Added `IsPasswordResetRateLimited` / `RecordPasswordResetAttempt`, reusing the existing ADR-040 cluster-wide (DB-backed, HA-safe) per-IP limiter under a namespaced key rather than standing up a new subsystem, wired into the handler ahead of the throttle check.

## Test plan

- [x] New deterministic (non-flaky) regression test for #247 that injects a concurrent lock-trip via a storage decorator between the snapshot read and the recheck — confirmed it **fails** on the pre-fix code and **passes** post-fix.
- [x] New goroutine-based concurrency tests (`-race` clean) for the mixed wrong/correct-password burst (#247) and the password-reset throttle burst (#249).
- [x] New end-to-end cache-invalidation tests for PAT revoke / account suspend driving the real HTTP handler + real auth-cache middleware (#248).
- [x] New handler-level tests proving the password-reset IP rate limit trips and is scoped per-IP (#249).
- [x] `go build ./...` and `GOWORK=off go build -C operator ./...`
- [x] `go test ./...` (full suite, no regressions)
- [x] `go test ./internal/core/... ./server/http/... ./server/middleware/... -race`
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues
- [x] `golangci-lint run ./...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)