### PR TITLE
fix: nil-pointer panic in remote-storage client + scheduler crash-hardening (#314-317)

### DIFF
--- a/internal/cli/common/remote_client.go
+++ b/internal/cli/common/remote_client.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"time"
 
 	cliconfig "github.com/keyorixhq/keyorix/internal/cli/config"
 	"github.com/keyorixhq/keyorix/internal/config"
@@ -110,9 +111,19 @@ func NewRemoteClient() (*RemoteClient, bool) {
 	return &RemoteClient{
 		Endpoint: endpoint,
 		Token:    token,
-		hc:       &http.Client{},
+		// #315: the zero-value http.Client has an infinite Timeout. Only 3 CLI
+		// commands (status/connect/offline) wrap their own calls in
+		// context.WithTimeout; the 100+ other call sites across secret/rbac/
+		// machine/rotation/project/dynamic etc. use undecorated contexts — a hung
+		// or misconfigured KEYORIX_SERVER would otherwise hang the CLI forever
+		// with no way out. Mirrors the storage-layer remote client's default.
+		hc: &http.Client{Timeout: defaultRemoteClientTimeout},
 	}, true
 }
+
+// defaultRemoteClientTimeout matches internal/storage/remote's default
+// (Config.GetTimeout's 30s fallback when TimeoutSeconds is unset).
+const defaultRemoteClientTimeout = 30 * time.Second
 
 // Get performs a GET to path, strips the {"data":…} envelope, and decodes into out.
 func (c *RemoteClient) Get(ctx context.Context, path string, out interface{}) error {

--- a/internal/storage/remote/client.go
+++ b/internal/storage/remote/client.go
@@ -5,10 +5,12 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 )
@@ -31,7 +33,11 @@ type HTTPClient struct {
 	retryAttempts int
 	userAgent     string
 
-	// Circuit breaker state
+	// Circuit breaker state. cbMux guards all three fields (#316): HTTPClient is a
+	// long-lived singleton shared by every concurrent request-handling goroutine
+	// when storage.type: remote, and these were read/written with no
+	// synchronization at all — a genuine data race under concurrent use.
+	cbMux           sync.Mutex
 	failureCount    int
 	lastFailureTime time.Time
 	circuitOpen     bool
@@ -96,25 +102,47 @@ type APIError struct {
 	Details string `json:"details,omitempty"`
 }
 
-// Error implements the error interface
+// Error implements the error interface. Nil-safe (#314): every remote_*.go call
+// site does resp.Error.Error() as soon as resp.Success is false, and makeRequest
+// can return Success:false with a nil Error (an upstream 2xx whose JSON body
+// simply omits "error") — without this guard, that call site pattern panics.
 func (e *APIError) Error() string {
+	if e == nil {
+		return "unknown error"
+	}
 	if e.Details != "" {
 		return fmt.Sprintf("%s: %s (%s)", e.Code, e.Message, e.Details)
 	}
 	return fmt.Sprintf("%s: %s", e.Code, e.Message)
 }
 
+// circuitBreakerOpen reports whether the circuit breaker currently refuses
+// requests, closing it first if the 30s cooldown has elapsed (#316: guarded by
+// cbMux instead of being read/written unsynchronized).
+func (c *HTTPClient) circuitBreakerOpen() bool {
+	c.cbMux.Lock()
+	defer c.cbMux.Unlock()
+	if !c.circuitOpen {
+		return false
+	}
+	if time.Since(c.lastFailureTime) > 30*time.Second {
+		c.circuitOpen = false
+		c.failureCount = 0
+		return false
+	}
+	return true
+}
+
+func (c *HTTPClient) resetFailureCount() {
+	c.cbMux.Lock()
+	c.failureCount = 0
+	c.cbMux.Unlock()
+}
+
 // Request makes an HTTP request with retry logic and circuit breaker
 func (c *HTTPClient) Request(ctx context.Context, method, path string, body interface{}) (*APIResponse, error) {
-	// Check circuit breaker
-	if c.circuitOpen {
-		// Check if we should try to close the circuit
-		if time.Since(c.lastFailureTime) > 30*time.Second {
-			c.circuitOpen = false
-			c.failureCount = 0
-		} else {
-			return nil, fmt.Errorf("circuit breaker is open, service unavailable")
-		}
+	if c.circuitBreakerOpen() {
+		return nil, fmt.Errorf("circuit breaker is open, service unavailable")
 	}
 
 	var lastErr error
@@ -143,7 +171,7 @@ func (c *HTTPClient) Request(ctx context.Context, method, path string, body inte
 		}
 
 		// Reset failure count on success
-		c.failureCount = 0
+		c.resetFailureCount()
 		return resp, nil
 	}
 
@@ -153,6 +181,8 @@ func (c *HTTPClient) Request(ctx context.Context, method, path string, body inte
 
 // recordFailure records a failure and potentially opens the circuit breaker
 func (c *HTTPClient) recordFailure() {
+	c.cbMux.Lock()
+	defer c.cbMux.Unlock()
 	c.failureCount++
 	c.lastFailureTime = time.Now()
 
@@ -219,17 +249,63 @@ func (c *HTTPClient) makeRequest(ctx context.Context, method, path string, body 
 				Message: fmt.Sprintf("HTTP %d: %s", resp.StatusCode, resp.Status),
 			}
 		}
-		// Return error for HTTP error status codes to trigger retry logic
-		return nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, resp.Status)
+		// Return a typed status error so isRetryableError can distinguish a
+		// transient server-side failure (worth retrying) from a client error like
+		// 401/403/404 (retrying can never succeed — the request itself is wrong).
+		return nil, &httpStatusError{StatusCode: resp.StatusCode, Status: resp.Status}
+	}
+
+	// #314: a 2xx/3xx upstream response can still carry Success:false with no
+	// "error" field populated (e.g. a proxy/WAF/CDN interstitial, or a degraded
+	// upstream returning "{}") — every remote_*.go call site immediately does
+	// resp.Error.Error() as soon as !resp.Success, which would otherwise panic
+	// on this nil field. Synthesize a generic error so callers always have
+	// something safe to report.
+	if !apiResp.Success && apiResp.Error == nil {
+		apiResp.Error = &APIError{
+			Code:    "UPSTREAM_UNSUCCESSFUL",
+			Message: "upstream returned an unsuccessful response with no error detail",
+		}
 	}
 
 	return &apiResp, nil
 }
 
-// isRetryableError determines if an error is retryable
+// httpStatusError carries the upstream HTTP status so isRetryableError can
+// distinguish a transient server failure from a client error (#317).
+type httpStatusError struct {
+	StatusCode int
+	Status     string
+}
+
+func (e *httpStatusError) Error() string {
+	return fmt.Sprintf("HTTP %d: %s", e.StatusCode, e.Status)
+}
+
+// isRetryableError determines whether a failed request is worth retrying
+// (#317: this previously always returned true regardless of the error,
+// meaning genuinely non-retryable failures — a marshal error, or a 401/403/404
+// — burned the full retry budget with quadratic backoff for no benefit).
+//
+// Retryable: network-level failures (connection refused/reset, DNS, timeout —
+// anything from http.Client.Do or reading the response body) and 5xx/429
+// upstream statuses. Not retryable: request-construction failures (marshal,
+// NewRequest) and 4xx client errors other than 429 — none of these can ever
+// succeed on retry, since the request itself (not the network) is the problem.
 func isRetryableError(err error) bool {
-	// Retry on network errors, timeouts, etc.
-	// This is a simplified implementation
+	if err == nil {
+		return false
+	}
+	var statusErr *httpStatusError
+	if errors.As(err, &statusErr) {
+		return statusErr.StatusCode >= 500 || statusErr.StatusCode == http.StatusTooManyRequests
+	}
+	msg := err.Error()
+	if strings.Contains(msg, "failed to marshal request body") || strings.Contains(msg, "failed to create request") {
+		return false
+	}
+	// Everything else reaching here is a network-level failure (request failed:
+	// ..., failed to read response body: ...) — transient by nature.
 	return true
 }
 

--- a/internal/storage/remote/client_test.go
+++ b/internal/storage/remote/client_test.go
@@ -3,8 +3,10 @@ package remote
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 
@@ -219,6 +221,49 @@ func TestHTTPClient_CircuitBreaker(t *testing.T) {
 	assert.Contains(t, err.Error(), "circuit breaker is open")
 }
 
+// TestHTTPClient_MalformedSuccessResponse_NoPanic pins #314: an upstream that
+// returns a 2xx status with a technically-valid-but-incomplete JSON body (no
+// "error" field set, e.g. a proxy/WAF/CDN interstitial returning `{}`) must not
+// crash makeRequest's caller. Before the fix, this produced Success:false with
+// Error:nil, and every remote_*.go call site's resp.Error.Error() pattern
+// panicked on the nil *APIError receiver — reproduced and confirmed via an
+// earlier version of this test before the fix landed.
+func TestHTTPClient_MalformedSuccessResponse_NoPanic(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	config := &Config{
+		BaseURL:        server.URL,
+		APIKey:         "test-key",
+		TimeoutSeconds: 30,
+		RetryAttempts:  0,
+		TLSVerify:      false,
+	}
+
+	client, err := NewHTTPClient(config)
+	require.NoError(t, err)
+
+	resp, err := client.Get(context.Background(), "/test")
+	require.NoError(t, err)
+	require.False(t, resp.Success)
+	require.NotNil(t, resp.Error, "makeRequest must synthesize a non-nil Error when Success is false")
+	assert.NotPanics(t, func() {
+		_ = resp.Error.Error() // the exact pattern every remote_*.go call site uses
+	})
+}
+
+// TestAPIError_ErrorMethod_NilSafe pins the nil-receiver guard directly: any
+// existing or future caller doing (*APIError)(nil).Error() must not panic.
+func TestAPIError_ErrorMethod_NilSafe(t *testing.T) {
+	var e *APIError
+	assert.NotPanics(t, func() {
+		assert.Equal(t, "unknown error", e.Error())
+	})
+}
+
 func TestHTTPClient_Timeout(t *testing.T) {
 	// Create a test server that delays response
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -245,4 +290,57 @@ func TestHTTPClient_Timeout(t *testing.T) {
 	_, err = client.Get(context.Background(), "/test")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "context deadline exceeded")
+}
+
+// TestIsRetryableError pins #317: a non-retryable failure (marshal error, or a
+// 4xx client error other than 429) must not be retried — the old
+// implementation always returned true, burning the full retry budget with
+// quadratic backoff for failures that could never succeed on retry.
+func TestIsRetryableError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"5xx is retryable", &httpStatusError{StatusCode: http.StatusInternalServerError}, true},
+		{"429 is retryable", &httpStatusError{StatusCode: http.StatusTooManyRequests}, true},
+		{"401 is not retryable", &httpStatusError{StatusCode: http.StatusUnauthorized}, false},
+		{"403 is not retryable", &httpStatusError{StatusCode: http.StatusForbidden}, false},
+		{"404 is not retryable", &httpStatusError{StatusCode: http.StatusNotFound}, false},
+		{"marshal error is not retryable", fmt.Errorf("failed to marshal request body: boom"), false},
+		{"request-construction error is not retryable", fmt.Errorf("failed to create request: boom"), false},
+		{"generic network error is retryable", fmt.Errorf("request failed: connection refused"), true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.want, isRetryableError(c.err))
+		})
+	}
+}
+
+// TestHTTPClient_CircuitBreakerFields_ConcurrentAccess pins #316: the circuit
+// breaker fields must be race-free under concurrent use, since *HTTPClient is
+// a long-lived singleton shared by every concurrent request-handling goroutine
+// when storage.type: remote. Run with -race.
+func TestHTTPClient_CircuitBreakerFields_ConcurrentAccess(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	client, err := NewHTTPClient(&Config{
+		BaseURL: server.URL, APIKey: "test-key", TimeoutSeconds: 5, RetryAttempts: 0, TLSVerify: false,
+	})
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	for range 20 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = client.Get(context.Background(), "/test")
+		}()
+	}
+	wg.Wait()
 }

--- a/server/scheduler_run.go
+++ b/server/scheduler_run.go
@@ -27,6 +27,21 @@ func runScheduler(ctx context.Context, name string, interval time.Duration, tick
 		defer ticker.Stop()
 		run := func() {
 			start := time.Now()
+			// #314: a scheduler job must never be able to take down the whole
+			// process. This goroutine previously had no recover() at all — any
+			// panic inside tick() (e.g. the remote-storage client's now-fixed nil
+			// *APIError dereference, or a future bug) would crash the entire
+			// server, and would crash again on the next tick after restart if the
+			// underlying condition (a degraded upstream, ordinary operational
+			// noise like an LB/WAF/CDN interstitial) persisted — a repeated-crash
+			// DoS from conditions far short of a deliberate attack. Every other
+			// job on this same ticker keeps running regardless of one job's panic.
+			defer func() {
+				if r := recover(); r != nil {
+					log.Printf("scheduler %q: recovered from panic: %v", name, r)
+					middleware.RecordSchedulerRun(name, middleware.SchedulerFailure, time.Since(start))
+				}
+			}()
 			outcome := tick()
 			middleware.RecordSchedulerRun(name, outcome, time.Since(start))
 		}

--- a/server/scheduler_run_test.go
+++ b/server/scheduler_run_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/server/middleware"
+)
+
+// TestRunScheduler_TickPanicIsRecovered pins #314's defense-in-depth half: a
+// panic inside a scheduler job's tick function must never crash the process.
+// Before this fix, runScheduler's goroutine had no recover() at all, so ANY
+// panic (the now-fixed nil *APIError dereference, or any future bug) would
+// take down the whole server — and would crash again on the next tick after
+// restart if the underlying condition persisted, a repeated-crash DoS from
+// ordinary operational noise.
+func TestRunScheduler_TickPanicIsRecovered(t *testing.T) {
+	var ticks atomic.Int32
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	runScheduler(ctx, "test-panicking-job", 10*time.Millisecond, func() middleware.SchedulerOutcome {
+		n := ticks.Add(1)
+		if n == 1 {
+			panic("simulated tick panic")
+		}
+		return middleware.SchedulerSuccess
+	})
+
+	// The first tick (immediate, on startup) panics. If unrecovered, the whole
+	// test binary would crash here rather than reaching this assertion. Wait for
+	// a second tick (from the ticker) to prove the goroutine survived the panic
+	// and kept running on schedule.
+	deadline := time.Now().Add(2 * time.Second)
+	for ticks.Load() < 2 && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if ticks.Load() < 2 {
+		t.Fatalf("scheduler goroutine did not survive the panic — got %d ticks, want >= 2", ticks.Load())
+	}
+}


### PR DESCRIPTION
## Summary

- **#314 HIGH — empirically verified (reproduced the exact PoC before fixing)**: an upstream 2xx response whose JSON body simply omits the `error` field (a proxy/WAF/CDN interstitial, a degraded upstream) made `makeRequest` return `Success:false` with `Error:nil`. Every `remote_*.go` storage stub (~65 call sites) does `resp.Error.Error()` as soon as `!resp.Success`, which panics on a nil `*APIError` receiver. Fixed three ways:
  1. `APIError.Error()` is now nil-safe.
  2. `makeRequest` synthesizes a generic non-nil `Error` whenever `Success` is false but the JSON didn't populate one.
  3. `runScheduler`'s ticker goroutine — which drives every periodic job (auto-rotation, retention-purge, cert/license-expiry, dynamic-secret-sweep, login-attempt-prune) and previously had **no `recover()` at all** — now recovers a panicking tick and records it as a failed run instead of crashing the whole server process. Without (3), this would have been a repeated-crash DoS from ordinary operational noise (the server can run with `storage.type: remote` against another Keyorix node) — the process crashes on the next scheduler tick after every restart for as long as the upstream stays degraded.
- **#315 MEDIUM**: the CLI-facing `RemoteClient` had NO request timeout (zero-value `http.Client`, infinite). Only 3 of 100+ call sites wrapped their own `context.WithTimeout`. A hung/misconfigured `KEYORIX_SERVER` hung the CLI forever. Now defaults to the same 30s the storage-layer client uses.
- **#316 LOW**: the circuit breaker's `failureCount`/`lastFailureTime`/`circuitOpen` were read/written with no synchronization on a singleton shared by every concurrent request goroutine — a genuine data race. Added a dedicated mutex; verified race-free under `-race -count=5`.
- **#317 LOW**: `isRetryableError` always returned `true`, so non-retryable failures (marshal errors, 401/403/404) burned the full retry budget with quadratic backoff. Introduced a typed `httpStatusError` so the retry decision can actually inspect the failure: network errors and 5xx/429 retry, marshal/request-construction errors and other 4xx don't.
- **#318**: verified already fixed (`url.PathEscape` already applied at every cited call site in `remote_users.go`/`remote_secrets.go`/`remote_rbac.go`/`remote_auth.go`); no changes needed.

## Test plan
- [x] `go build ./...` and `GOWORK=off go build -C operator ./...`
- [x] `go test ./...` (full suite, no regressions)
- [x] `TestHTTPClient_MalformedSuccessResponse_NoPanic` — the exact #314 reproduction, confirms no panic + a synthesized error post-fix
- [x] `TestAPIError_ErrorMethod_NilSafe` — direct nil-receiver guard
- [x] `TestRunScheduler_TickPanicIsRecovered` — a panicking tick function, proves the scheduler goroutine survives and keeps running on schedule
- [x] `TestIsRetryableError` — table test covering 5xx/429 (retry), 401/403/404/marshal/construction errors (don't retry)
- [x] `TestHTTPClient_CircuitBreakerFields_ConcurrentAccess` + `go test ./internal/storage/remote/... -race -count=5` — clean
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues
- [x] `golangci-lint run ./...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)