### PR TITLE
fix(rbac): full-scope member removal, last-admin guard, itemized restore audit

### DIFF
--- a/internal/core/catalog.go
+++ b/internal/core/catalog.go
@@ -94,13 +94,20 @@ func (c *KeyorixCore) DeleteProject(ctx context.Context, id uint, force bool) er
 
 // RestoreProject reverses a soft-delete, bringing back the project and the
 // environments and secrets that were removed with it. actorID is the acting admin
-// (0 = none). Audited as project.restored.
+// (0 = none). Audited as project.restored, with a per-type count of what the
+// cascade actually resurrected (#311) — the storage layer already refuses to touch
+// children retired independently of the project (see LocalStorage.RestoreProject's
+// deletion-timestamp correlation), but the single generic event previously gave no
+// way to tell HOW MANY environments/secrets came back, so a DR-test or accidental
+// delete-then-undo left no forensic trail distinguishing "1 secret" from "200".
 func (c *KeyorixCore) RestoreProject(ctx context.Context, actorID, id uint) error {
-	if err := c.storage.RestoreProject(ctx, id); err != nil {
+	envCount, secretCount, err := c.storage.RestoreProject(ctx, id)
+	if err != nil {
 		return err
 	}
 	pid := id
-	c.writeAuditEventFull(ctx, "project.restored", actorPtr(actorID), nil, &pid, "", fmt.Sprintf("project %d restored", id))
+	c.writeAuditEventFull(ctx, "project.restored", actorPtr(actorID), nil, &pid, "",
+		fmt.Sprintf("project %d restored (cascade resurrected %d environment(s) and %d secret(s))", id, envCount, secretCount))
 	return nil
 }
 

--- a/internal/core/membership_lifecycle_test.go
+++ b/internal/core/membership_lifecycle_test.go
@@ -164,9 +164,13 @@ func TestTransitionMembership_RevokeRemovesRole(t *testing.T) {
 	})).Return(nil)
 	// RemoveProjectMember resolves and drops the role grant (best-effort). The
 	// role (5) doesn't carry roles.assign, so the last-admin guard (#236) is a
-	// fast no-op and doesn't need ListProjectRoleAssignments mocked.
+	// fast no-op. ListProjectRoleAssignments is still consulted unconditionally
+	// to build the per-grant RBAC audit trail (#234) before the bulk delete.
 	store.On("GetUserRoleIDsExact", ctx, uint(2), storage.Scope{ProjectID: 1}).Return([]uint{5}, nil)
 	store.On("RoleSetHasPermission", ctx, []uint{5}, "roles.assign").Return(false, nil)
+	store.On("ListProjectRoleAssignments", ctx, uint(1)).Return([]storage.RoleAssignment{
+		{PrincipalType: "user", PrincipalID: 2, RoleID: 5, ProjectID: 1},
+	}, nil)
 	store.On("RemoveAllProjectRoleGrants", ctx, uint(2), uint(1)).Return(nil)
 	store.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
 

--- a/internal/core/membership_lifecycle_test.go
+++ b/internal/core/membership_lifecycle_test.go
@@ -162,15 +162,18 @@ func TestTransitionMembership_RevokeRemovesRole(t *testing.T) {
 	store.On("UpdateProjectMembership", ctx, mock.MatchedBy(func(x *models.ProjectMembership) bool {
 		return x.State == MembershipRevoked && x.RevokedAt != nil
 	})).Return(nil)
-	// RemoveProjectMember resolves and drops the role grant (best-effort).
+	// RemoveProjectMember resolves and drops the role grant (best-effort). The
+	// role (5) doesn't carry roles.assign, so the last-admin guard (#236) is a
+	// fast no-op and doesn't need ListProjectRoleAssignments mocked.
 	store.On("GetUserRoleIDsExact", ctx, uint(2), storage.Scope{ProjectID: 1}).Return([]uint{5}, nil)
-	store.On("RemoveRole", ctx, uint(2), uint(5), storage.Scope{ProjectID: 1}).Return(nil)
+	store.On("RoleSetHasPermission", ctx, []uint{5}, "roles.assign").Return(false, nil)
+	store.On("RemoveAllProjectRoleGrants", ctx, uint(2), uint(1)).Return(nil)
 	store.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
 
 	out, err := c.TransitionMembership(ctx, 1, 50, MembershipRevoked, 9)
 	require.NoError(t, err)
 	assert.Equal(t, MembershipRevoked, out.State)
-	store.AssertCalled(t, "RemoveRole", ctx, uint(2), uint(5), storage.Scope{ProjectID: 1})
+	store.AssertCalled(t, "RemoveAllProjectRoleGrants", ctx, uint(2), uint(1))
 }
 
 func TestStaleInvites_PassesCutoff(t *testing.T) {

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -73,8 +73,8 @@ func (m *MockStorage) DeleteProject(_ context.Context, _ uint) error {
 	return nil
 }
 
-func (m *MockStorage) RestoreProject(_ context.Context, _ uint) error {
-	return nil
+func (m *MockStorage) RestoreProject(_ context.Context, _ uint) (int, int, error) {
+	return 0, 0, nil
 }
 
 func (m *MockStorage) ListEnvironments(_ context.Context) ([]*models.Environment, error) {
@@ -901,6 +901,11 @@ func (m *MockStorage) AssignRoleWithExpiry(ctx context.Context, userID, roleID u
 
 func (m *MockStorage) RemoveRole(ctx context.Context, userID, roleID uint, scope storage.Scope) error {
 	args := m.Called(ctx, userID, roleID, scope)
+	return args.Error(0)
+}
+
+func (m *MockStorage) RemoveAllProjectRoleGrants(ctx context.Context, userID, projectID uint) error {
+	args := m.Called(ctx, userID, projectID)
 	return args.Error(0)
 }
 

--- a/internal/core/project_members.go
+++ b/internal/core/project_members.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 
 	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/i18n"
 )
 
 // ListProjectMembers returns the users with a role at the project's scope.
@@ -43,6 +44,12 @@ func (c *KeyorixCore) SetProjectMemberRole(ctx context.Context, actorID, project
 	if err != nil {
 		return err
 	}
+	// Refuse a demotion that would leave the project with no roles.assign holder
+	// (#236): after this call the user's only project-scope role is roleName, so
+	// check whether THAT role still carries roles.assign before touching anything.
+	if err := c.guardLastProjectAdmin(ctx, projectID, userID, existing, []uint{role.ID}); err != nil {
+		return err
+	}
 	hasTarget := false
 	for _, rid := range existing {
 		if rid == role.ID {
@@ -59,8 +66,14 @@ func (c *KeyorixCore) SetProjectMemberRole(ctx context.Context, actorID, project
 	return c.AssignUserRole(ctx, actorID, userID, role.ID, scope)
 }
 
-// RemoveProjectMember removes all of the user's roles at the project scope. See
-// AddProjectMember for actorID semantics.
+// RemoveProjectMember removes ALL of the user's role grants scoped to the
+// project — not just the project-level (environment_id = 0) grant the Members
+// UI shows, but any environment-scoped grant (e.g. "prod-only access") in the
+// same project too. A prior version only deleted the exact-scope match, so an
+// environment-scoped grant silently survived an offboarding admin's removal,
+// invisible and uncorrectable by that admin (project-scoped roles.assign
+// cannot see or edit /user-roles grants, which require global scope) (#232).
+// See AddProjectMember for actorID semantics.
 func (c *KeyorixCore) RemoveProjectMember(ctx context.Context, actorID, projectID, userID uint) error {
 	scope := Scope{ProjectID: projectID}
 	existing, err := c.storage.GetUserRoleIDsExact(ctx, userID, scope)
@@ -70,10 +83,87 @@ func (c *KeyorixCore) RemoveProjectMember(ctx context.Context, actorID, projectI
 	if len(existing) == 0 {
 		return fmt.Errorf("user is not a member of this project")
 	}
-	for _, rid := range existing {
-		if err := c.RemoveUserRole(ctx, actorID, userID, rid, scope); err != nil {
-			return err
+	// Refuse to remove the project's last roles.assign holder (#236): the ordinary
+	// member-management API has no other safeguard, so without this the sole
+	// remaining project admin could remove themselves (or be removed by anyone
+	// else holding roles.assign), leaving the project with zero project-scoped
+	// admins. Not a permanent lockout — a GLOBAL admin can always re-add one via
+	// GetUserRoleIDsAt's project_id = 0 OR project_id = ? matching — but still an
+	// availability risk worth refusing outright rather than requiring recovery.
+	if err := c.guardLastProjectAdmin(ctx, projectID, userID, existing, nil); err != nil {
+		return err
+	}
+	// Capture every grant (any environment) this deletes so each can be recorded
+	// in the RBAC audit trail (#234) — RemoveAllProjectRoleGrants is a single
+	// bulk delete, not a per-role RemoveUserRole loop, so it doesn't audit itself.
+	assignments, err := c.storage.ListProjectRoleAssignments(ctx, projectID)
+	if err != nil {
+		return fmt.Errorf("failed to list project role assignments: %w", err)
+	}
+	if err := c.storage.RemoveAllProjectRoleGrants(ctx, userID, projectID); err != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	for _, a := range assignments {
+		if a.PrincipalType != "user" || a.PrincipalID != userID {
+			continue
 		}
+		c.LogRoleRemoved(ctx, actorID, userID, a.RoleID, Scope{ProjectID: projectID, EnvironmentID: a.EnvironmentID})
 	}
 	return nil
+}
+
+// guardLastProjectAdmin refuses an operation that would strip targetID's
+// roles.assign authority at projectID's PROJECT scope (environment_id = 0 — a
+// member removal or role change) unless either (a) targetRoleIDsAfter still
+// carries roles.assign, or (b) some OTHER project-level grant (user or group)
+// already carries it, so governance of the project survives. Only environment_id
+// = 0 grants count: RequireScopedPermission on /projects/{id}/members itself
+// only matches project-level grants (GetUserRoleIDsAt's "environment_id = 0 OR
+// environment_id = ?" against a target scope whose EnvironmentID is 0), so an
+// environment-scoped roles.assign grant could not actually administer this
+// project's membership either — it doesn't count as a survivor. Passing a
+// nil/roles.assign-free targetRoleIDsBefore is a fast no-op (the target wasn't
+// an admin to begin with).
+func (c *KeyorixCore) guardLastProjectAdmin(ctx context.Context, projectID, targetID uint, targetRoleIDsBefore, targetRoleIDsAfter []uint) error {
+	hadAssign, err := c.storage.RoleSetHasPermission(ctx, targetRoleIDsBefore, "roles.assign")
+	if err != nil {
+		return err
+	}
+	if !hadAssign {
+		return nil // target wasn't a project admin — not the last-admin case
+	}
+	willHaveAssign, err := c.storage.RoleSetHasPermission(ctx, targetRoleIDsAfter, "roles.assign")
+	if err != nil {
+		return err
+	}
+	if willHaveAssign {
+		return nil // still an admin afterward — no governance gap
+	}
+	assignments, err := c.storage.ListProjectRoleAssignments(ctx, projectID)
+	if err != nil {
+		return fmt.Errorf("failed to check project administrators: %w", err)
+	}
+	checked := make(map[uint]bool, len(assignments))
+	for _, a := range assignments {
+		if a.EnvironmentID != 0 {
+			continue // not project-level; can't administer /projects/{id}/members
+		}
+		// A grant belonging to the target themselves doesn't count as "another"
+		// admin — only groups and other users can pick up the slack.
+		if a.PrincipalType == "user" && a.PrincipalID == targetID {
+			continue
+		}
+		hasAssign, ok := checked[a.RoleID]
+		if !ok {
+			hasAssign, err = c.storage.RoleSetHasPermission(ctx, []uint{a.RoleID}, "roles.assign")
+			if err != nil {
+				return err
+			}
+			checked[a.RoleID] = hasAssign
+		}
+		if hasAssign {
+			return nil // another admin (user or group) survives the change
+		}
+	}
+	return fmt.Errorf("cannot remove or demote the project's last administrator; assign another project admin first")
 }

--- a/internal/core/project_members_test.go
+++ b/internal/core/project_members_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -107,4 +108,134 @@ func TestProjectMemberGrantIsRBACAudited(t *testing.T) {
 	require.NotNil(t, removed, "expected a role.removed entry for the project-member revoke")
 	require.NotNil(t, removed.ActorUserID)
 	assert.Equal(t, actor, *removed.ActorUserID)
+}
+
+// #232: removing a project member must also revoke any environment-scoped grant
+// (e.g. "prod-only access") the user separately holds in the same project — a
+// prior version only deleted the exact project-level (environment_id = 0) row,
+// leaving the environment-scoped one live and invisible to the offboarding admin.
+func TestRemoveProjectMember_RevokesEnvironmentScopedGrantToo(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	ctx := context.Background()
+	const proj = uint(7)
+	const prodEnv = uint(99)
+
+	u, err := st.CreateUser(ctx, &models.User{Username: "carol", Email: "carol@example.com", IsActive: true})
+	require.NoError(t, err)
+
+	role, err := st.GetRoleByName(ctx, "project_developer")
+	require.NoError(t, err)
+
+	// Project-level membership (what the Members UI shows)...
+	require.NoError(t, c.AddProjectMember(ctx, proj, u.ID, "project_developer"))
+	// ...plus a SEPARATE environment-scoped grant (e.g. "prod-only access"),
+	// created the way POST /user-roles would (gated by GLOBAL roles.assign).
+	require.NoError(t, st.AssignRole(ctx, u.ID, role.ID, storage.Scope{ProjectID: proj, EnvironmentID: prodEnv}))
+
+	// Sanity: both grants are live before removal.
+	projectScoped, err := st.GetUserRoleIDsExact(ctx, u.ID, storage.Scope{ProjectID: proj})
+	require.NoError(t, err)
+	require.Len(t, projectScoped, 1)
+	envScoped, err := st.GetUserRoleIDsExact(ctx, u.ID, storage.Scope{ProjectID: proj, EnvironmentID: prodEnv})
+	require.NoError(t, err)
+	require.Len(t, envScoped, 1)
+
+	require.NoError(t, c.RemoveProjectMember(ctx, proj, u.ID))
+
+	// Neither the project-level NOR the environment-scoped grant survives.
+	projectScoped, err = st.GetUserRoleIDsExact(ctx, u.ID, storage.Scope{ProjectID: proj})
+	require.NoError(t, err)
+	assert.Empty(t, projectScoped, "project-level grant must be revoked")
+	envScoped, err = st.GetUserRoleIDsExact(ctx, u.ID, storage.Scope{ProjectID: proj, EnvironmentID: prodEnv})
+	require.NoError(t, err)
+	assert.Empty(t, envScoped, "environment-scoped grant must be revoked too — the gap #232 closes")
+}
+
+// #236: the sole remaining project admin must not be removable/demotable via the
+// ordinary member-management API — doing so would leave the project with zero
+// project-scoped admins.
+func TestRemoveProjectMember_RefusesLastAdmin(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	ctx := context.Background()
+	const proj = uint(7)
+
+	u, err := st.CreateUser(ctx, &models.User{Username: "dave", Email: "dave@example.com", IsActive: true})
+	require.NoError(t, err)
+	require.NoError(t, c.AddProjectMember(ctx, proj, u.ID, "project_admin"))
+
+	err = c.RemoveProjectMember(ctx, proj, u.ID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "last administrator")
+
+	// The membership is untouched.
+	members, err := c.ListProjectMembers(ctx, proj)
+	require.NoError(t, err)
+	require.Len(t, members, 1)
+	assert.Equal(t, "project_admin", members[0].RoleName)
+}
+
+// #236: demoting the sole remaining project admin to a non-admin role is refused
+// the same way removal is — SetProjectMemberRole must not be a bypass.
+func TestSetProjectMemberRole_RefusesLastAdminDemotion(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	ctx := context.Background()
+	const proj = uint(7)
+
+	u, err := st.CreateUser(ctx, &models.User{Username: "erin", Email: "erin@example.com", IsActive: true})
+	require.NoError(t, err)
+	require.NoError(t, c.AddProjectMember(ctx, proj, u.ID, "project_admin"))
+
+	err = c.SetProjectMemberRole(ctx, proj, u.ID, "project_viewer")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "last administrator")
+
+	members, err := c.ListProjectMembers(ctx, proj)
+	require.NoError(t, err)
+	require.Len(t, members, 1)
+	assert.Equal(t, "project_admin", members[0].RoleName, "role must be unchanged after a refused demotion")
+}
+
+// #236 (negative case): removing a NON-last admin — another project admin still
+// present — must still succeed. The guard must not over-block ordinary removals.
+func TestRemoveProjectMember_AllowsNonLastAdmin(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	ctx := context.Background()
+	const proj = uint(7)
+
+	u1, err := st.CreateUser(ctx, &models.User{Username: "frank", Email: "frank@example.com", IsActive: true})
+	require.NoError(t, err)
+	u2, err := st.CreateUser(ctx, &models.User{Username: "grace", Email: "grace@example.com", IsActive: true})
+	require.NoError(t, err)
+	require.NoError(t, c.AddProjectMember(ctx, proj, u1.ID, "project_admin"))
+	require.NoError(t, c.AddProjectMember(ctx, proj, u2.ID, "project_admin"))
+
+	// Removing one of two admins succeeds — the other keeps the project governed.
+	require.NoError(t, c.RemoveProjectMember(ctx, proj, u1.ID))
+
+	members, err := c.ListProjectMembers(ctx, proj)
+	require.NoError(t, err)
+	require.Len(t, members, 1)
+	assert.Equal(t, "grace", members[0].Username)
+
+	// Now grace IS the last admin — removing her is refused.
+	err = c.RemoveProjectMember(ctx, proj, u2.ID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "last administrator")
+}
+
+// #236 (negative case): a non-admin member (no roles.assign) can always be freely
+// removed — the guard only fires for the LAST roles.assign holder.
+func TestRemoveProjectMember_NonAdminAlwaysRemovable(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	ctx := context.Background()
+	const proj = uint(7)
+
+	u, err := st.CreateUser(ctx, &models.User{Username: "henry", Email: "henry@example.com", IsActive: true})
+	require.NoError(t, err)
+	require.NoError(t, c.AddProjectMember(ctx, proj, u.ID, "project_viewer"))
+
+	require.NoError(t, c.RemoveProjectMember(ctx, proj, u.ID))
+	members, err := c.ListProjectMembers(ctx, proj)
+	require.NoError(t, err)
+	assert.Empty(t, members)
 }

--- a/internal/core/project_members_test.go
+++ b/internal/core/project_members_test.go
@@ -119,6 +119,7 @@ func TestRemoveProjectMember_RevokesEnvironmentScopedGrantToo(t *testing.T) {
 	ctx := context.Background()
 	const proj = uint(7)
 	const prodEnv = uint(99)
+	const actor = uint(55)
 
 	u, err := st.CreateUser(ctx, &models.User{Username: "carol", Email: "carol@example.com", IsActive: true})
 	require.NoError(t, err)
@@ -127,7 +128,7 @@ func TestRemoveProjectMember_RevokesEnvironmentScopedGrantToo(t *testing.T) {
 	require.NoError(t, err)
 
 	// Project-level membership (what the Members UI shows)...
-	require.NoError(t, c.AddProjectMember(ctx, proj, u.ID, "project_developer"))
+	require.NoError(t, c.AddProjectMember(ctx, actor, proj, u.ID, "project_developer"))
 	// ...plus a SEPARATE environment-scoped grant (e.g. "prod-only access"),
 	// created the way POST /user-roles would (gated by GLOBAL roles.assign).
 	require.NoError(t, st.AssignRole(ctx, u.ID, role.ID, storage.Scope{ProjectID: proj, EnvironmentID: prodEnv}))
@@ -140,7 +141,7 @@ func TestRemoveProjectMember_RevokesEnvironmentScopedGrantToo(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, envScoped, 1)
 
-	require.NoError(t, c.RemoveProjectMember(ctx, proj, u.ID))
+	require.NoError(t, c.RemoveProjectMember(ctx, actor, proj, u.ID))
 
 	// Neither the project-level NOR the environment-scoped grant survives.
 	projectScoped, err = st.GetUserRoleIDsExact(ctx, u.ID, storage.Scope{ProjectID: proj})
@@ -158,12 +159,13 @@ func TestRemoveProjectMember_RefusesLastAdmin(t *testing.T) {
 	c, st := newBootstrappedCore(t)
 	ctx := context.Background()
 	const proj = uint(7)
+	const actor = uint(55)
 
 	u, err := st.CreateUser(ctx, &models.User{Username: "dave", Email: "dave@example.com", IsActive: true})
 	require.NoError(t, err)
-	require.NoError(t, c.AddProjectMember(ctx, proj, u.ID, "project_admin"))
+	require.NoError(t, c.AddProjectMember(ctx, actor, proj, u.ID, "project_admin"))
 
-	err = c.RemoveProjectMember(ctx, proj, u.ID)
+	err = c.RemoveProjectMember(ctx, actor, proj, u.ID)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "last administrator")
 
@@ -180,12 +182,13 @@ func TestSetProjectMemberRole_RefusesLastAdminDemotion(t *testing.T) {
 	c, st := newBootstrappedCore(t)
 	ctx := context.Background()
 	const proj = uint(7)
+	const actor = uint(55)
 
 	u, err := st.CreateUser(ctx, &models.User{Username: "erin", Email: "erin@example.com", IsActive: true})
 	require.NoError(t, err)
-	require.NoError(t, c.AddProjectMember(ctx, proj, u.ID, "project_admin"))
+	require.NoError(t, c.AddProjectMember(ctx, actor, proj, u.ID, "project_admin"))
 
-	err = c.SetProjectMemberRole(ctx, proj, u.ID, "project_viewer")
+	err = c.SetProjectMemberRole(ctx, actor, proj, u.ID, "project_viewer")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "last administrator")
 
@@ -201,16 +204,17 @@ func TestRemoveProjectMember_AllowsNonLastAdmin(t *testing.T) {
 	c, st := newBootstrappedCore(t)
 	ctx := context.Background()
 	const proj = uint(7)
+	const actor = uint(55)
 
 	u1, err := st.CreateUser(ctx, &models.User{Username: "frank", Email: "frank@example.com", IsActive: true})
 	require.NoError(t, err)
 	u2, err := st.CreateUser(ctx, &models.User{Username: "grace", Email: "grace@example.com", IsActive: true})
 	require.NoError(t, err)
-	require.NoError(t, c.AddProjectMember(ctx, proj, u1.ID, "project_admin"))
-	require.NoError(t, c.AddProjectMember(ctx, proj, u2.ID, "project_admin"))
+	require.NoError(t, c.AddProjectMember(ctx, actor, proj, u1.ID, "project_admin"))
+	require.NoError(t, c.AddProjectMember(ctx, actor, proj, u2.ID, "project_admin"))
 
 	// Removing one of two admins succeeds — the other keeps the project governed.
-	require.NoError(t, c.RemoveProjectMember(ctx, proj, u1.ID))
+	require.NoError(t, c.RemoveProjectMember(ctx, actor, proj, u1.ID))
 
 	members, err := c.ListProjectMembers(ctx, proj)
 	require.NoError(t, err)
@@ -218,7 +222,7 @@ func TestRemoveProjectMember_AllowsNonLastAdmin(t *testing.T) {
 	assert.Equal(t, "grace", members[0].Username)
 
 	// Now grace IS the last admin — removing her is refused.
-	err = c.RemoveProjectMember(ctx, proj, u2.ID)
+	err = c.RemoveProjectMember(ctx, actor, proj, u2.ID)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "last administrator")
 }
@@ -229,12 +233,13 @@ func TestRemoveProjectMember_NonAdminAlwaysRemovable(t *testing.T) {
 	c, st := newBootstrappedCore(t)
 	ctx := context.Background()
 	const proj = uint(7)
+	const actor = uint(55)
 
 	u, err := st.CreateUser(ctx, &models.User{Username: "henry", Email: "henry@example.com", IsActive: true})
 	require.NoError(t, err)
-	require.NoError(t, c.AddProjectMember(ctx, proj, u.ID, "project_viewer"))
+	require.NoError(t, c.AddProjectMember(ctx, actor, proj, u.ID, "project_viewer"))
 
-	require.NoError(t, c.RemoveProjectMember(ctx, proj, u.ID))
+	require.NoError(t, c.RemoveProjectMember(ctx, actor, proj, u.ID))
 	members, err := c.ListProjectMembers(ctx, proj)
 	require.NoError(t, err)
 	assert.Empty(t, members)

--- a/internal/core/restore_audit_test.go
+++ b/internal/core/restore_audit_test.go
@@ -53,6 +53,62 @@ func TestRestoreOperationsAudit(t *testing.T) {
 		require.NotNil(t, auditActor("project.restored"))
 	})
 
+	// #311: the project.restored event must itemize what the cascade actually
+	// resurrected (a per-type count), and that count must correctly EXCLUDE a
+	// secret that was soft-deleted independently, before (and unrelated to) the
+	// project's own deletion — otherwise a DR-test or accidental delete-then-undo
+	// of a whole project leaves no way to tell "1 secret came back" from "200",
+	// nor whether an unrelated, deliberately-retired secret was among them.
+	//
+	// Correlation-window reasoning: DeleteProject stamps the project and every
+	// then-LIVE child with ONE uniform deleted_at (the "cascade timestamp").
+	// RestoreProject reads that timestamp back off the project row and only
+	// restores children whose deleted_at >= it. A secret already soft-deleted
+	// BEFORE the project (an earlier, independent recycle-bin delete — e.g. an
+	// operator remediating a compromised secret) carries a strictly earlier
+	// deleted_at and is correctly left alone. There is no coherent "deleted AFTER
+	// the project" case to test: DeleteSecret's soft-delete only matches
+	// currently-live rows, and a project's live secrets are exactly what the
+	// cascade already swept up, so nothing stays independently deletable once the
+	// project itself is gone.
+	t.Run("project.restored itemizes the cascade and excludes independent deletes", func(t *testing.T) {
+		p, err := c.storage.CreateProject(ctx, &models.Project{Name: "proj-itemized"})
+		require.NoError(t, err)
+		_, err = c.storage.CreateEnvironment(ctx, &models.Environment{Name: "prod", ProjectID: p.ID})
+		require.NoError(t, err)
+
+		kept, err := c.storage.CreateSecret(ctx, &models.SecretNode{
+			ProjectID: p.ID, EnvironmentID: 1, Name: "kept", IsSecret: true, Type: "text", Status: "active",
+			CreatedAt: time.Now(), UpdatedAt: time.Now(),
+		})
+		require.NoError(t, err)
+		retired, err := c.storage.CreateSecret(ctx, &models.SecretNode{
+			ProjectID: p.ID, EnvironmentID: 1, Name: "retired", IsSecret: true, Type: "text", Status: "active",
+			CreatedAt: time.Now(), UpdatedAt: time.Now(),
+		})
+		require.NoError(t, err)
+
+		// "retired" was deliberately soft-deleted well before the project — an
+		// operator's own remediation, independent of any project-level action.
+		require.NoError(t, db.Unscoped().Model(&models.SecretNode{}).
+			Where("id = ?", retired.ID).Update("deleted_at", time.Now().Add(-time.Hour)).Error)
+
+		require.NoError(t, c.storage.DeleteProject(ctx, p.ID))
+		require.NoError(t, c.RestoreProject(ctx, 42, p.ID))
+
+		// "kept" (swept up by the cascade) is live again; "retired" (independently
+		// deleted earlier) stays in the recycle bin.
+		_, err = c.storage.GetSecret(ctx, kept.ID)
+		require.NoError(t, err)
+		_, err = c.storage.GetSecret(ctx, retired.ID)
+		require.Error(t, err, "an independently-retired secret must not be resurrected")
+
+		var ev models.AuditEvent
+		require.NoError(t, db.Where("event_type = ? AND project_id = ?", "project.restored", p.ID).First(&ev).Error)
+		assert.Contains(t, ev.Description, "1 environment", "the audit trail must itemize the restored environment count")
+		assert.Contains(t, ev.Description, "1 secret", "the audit trail must itemize the restored secret count — excluding the independently-deleted one")
+	})
+
 	t.Run("environment.restored", func(t *testing.T) {
 		p, err := c.storage.CreateProject(ctx, &models.Project{Name: "proj2"})
 		require.NoError(t, err)

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -38,7 +38,12 @@ type Storage interface {
 	GetProject(ctx context.Context, id uint) (*models.Project, error)
 	UpdateProject(ctx context.Context, project *models.Project) (*models.Project, error)
 	DeleteProject(ctx context.Context, id uint) error
-	RestoreProject(ctx context.Context, id uint) error
+	// RestoreProject reverses a project soft-delete and cascades to the environments/
+	// secrets that were removed WITH it (matched by deletion timestamp — independently
+	// retired children stay deleted, see LocalStorage.RestoreProject). It returns the
+	// count of environments and secrets the cascade actually restored, so the caller
+	// can audit what came back (#311), not just that "the project" was restored.
+	RestoreProject(ctx context.Context, id uint) (restoredEnvironments, restoredSecrets int, err error)
 	ListProjects(ctx context.Context) ([]*models.Project, error)
 	ListProjectsWithCounts(ctx context.Context, includeDeleted bool) ([]ProjectWithCounts, error)
 	CreateEnvironment(ctx context.Context, env *models.Environment) (*models.Environment, error)
@@ -347,6 +352,14 @@ type Storage interface {
 	// filter on it) and is later swept by DeleteExpiredRoleGrants.
 	AssignRoleWithExpiry(ctx context.Context, userID, roleID uint, scope Scope, expiresAt time.Time) error
 	RemoveRole(ctx context.Context, userID, roleID uint, scope Scope) error
+	// RemoveAllProjectRoleGrants deletes every user_roles row for (userID, projectID),
+	// across ALL environments — not just the project-level (environment_id = 0) grant
+	// RemoveRole's exact-scope match would touch. RemoveProjectMember uses it so that
+	// offboarding a project member also revokes any environment-scoped grant (e.g.
+	// "prod-only access", created via POST /user-roles) they separately hold in the
+	// same project; otherwise it silently survives project-level removal, invisible to
+	// the project admin who performed the offboarding (#232).
+	RemoveAllProjectRoleGrants(ctx context.Context, userID, projectID uint) error
 	GetUserRoles(ctx context.Context, userID uint) ([]*models.Role, error)
 	GetUserRoleIDsAt(ctx context.Context, userID uint, scope Scope) ([]uint, error)
 	GetUserRoleIDsExact(ctx context.Context, userID uint, scope Scope) ([]uint, error)

--- a/internal/storage/store/local_rbac.go
+++ b/internal/storage/store/local_rbac.go
@@ -146,6 +146,22 @@ func (ls *LocalStorage) RemoveRole(ctx context.Context, userID, roleID uint, sco
 	return nil
 }
 
+// RemoveAllProjectRoleGrants deletes every user_roles row for (userID, projectID),
+// regardless of environment_id — unlike RemoveRole, which only ever deletes an
+// exact-scope match. Used by RemoveProjectMember to fully revoke a departing
+// member's access to a project: without it, an environment-scoped grant (e.g.
+// "prod-only access", project_id = P, environment_id = E) survives project-level
+// removal untouched, because it was never an exact match for
+// Scope{ProjectID: P} (environment_id defaults to 0) (#232).
+func (ls *LocalStorage) RemoveAllProjectRoleGrants(ctx context.Context, userID, projectID uint) error {
+	if err := ls.db.WithContext(ctx).
+		Where("user_id = ? AND project_id = ?", userID, projectID).
+		Delete(&models.UserRole{}).Error; err != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	return nil
+}
+
 // GetUserRoles retrieves all roles assigned to userID via the user_roles join table.
 func (ls *LocalStorage) GetUserRoles(ctx context.Context, userID uint) ([]*models.Role, error) {
 	var roles []*models.Role

--- a/internal/storage/store/local_secrets.go
+++ b/internal/storage/store/local_secrets.go
@@ -154,8 +154,13 @@ func (ls *LocalStorage) DeleteProject(ctx context.Context, id uint) error {
 // environments a user had retired independently earlier carry a different deleted_at
 // and are deliberately left in the recycle bin — restoring the project must not
 // silently resurrect a deliberately-deleted secret (and re-grant its retained shares).
-func (ls *LocalStorage) RestoreProject(ctx context.Context, id uint) error {
-	return ls.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+//
+// Returns the number of environments and secrets the cascade actually brought back, so
+// the caller can emit a per-type-count audit entry alongside the single project.restored
+// event (#311) — otherwise a DR-test or accidental delete-then-undo of a whole project
+// resurrects an unknown number of children with no forensic record of what came back.
+func (ls *LocalStorage) RestoreProject(ctx context.Context, id uint) (restoredEnvironments, restoredSecrets int, err error) {
+	txErr := ls.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		// Read the cascade's deletion timestamp before clearing it.
 		var project models.Project
 		if err := tx.Unscoped().Where("id = ? AND deleted_at IS NOT NULL", id).First(&project).Error; err != nil {
@@ -166,14 +171,20 @@ func (ls *LocalStorage) RestoreProject(ctx context.Context, id uint) error {
 		// Restore only the children whose deleted_at is at or after the cascade timestamp
 		// (those removed by this DeleteProject); earlier, independently-retired rows are
 		// strictly before it and stay deleted.
-		if err := tx.Unscoped().Model(&models.Environment{}).
-			Where("project_id = ? AND deleted_at >= ?", id, cascadeTS).Update("deleted_at", nil).Error; err != nil {
-			return fmt.Errorf("failed to restore project environments: %w", err)
+		envResult := tx.Unscoped().Model(&models.Environment{}).
+			Where("project_id = ? AND deleted_at >= ?", id, cascadeTS).Update("deleted_at", nil)
+		if envResult.Error != nil {
+			return fmt.Errorf("failed to restore project environments: %w", envResult.Error)
 		}
-		if err := tx.Unscoped().Model(&models.SecretNode{}).
-			Where("project_id = ? AND deleted_at >= ?", id, cascadeTS).Update("deleted_at", nil).Error; err != nil {
-			return fmt.Errorf("failed to restore project secrets: %w", err)
+		restoredEnvironments = int(envResult.RowsAffected)
+
+		secResult := tx.Unscoped().Model(&models.SecretNode{}).
+			Where("project_id = ? AND deleted_at >= ?", id, cascadeTS).Update("deleted_at", nil)
+		if secResult.Error != nil {
+			return fmt.Errorf("failed to restore project secrets: %w", secResult.Error)
 		}
+		restoredSecrets = int(secResult.RowsAffected)
+
 		// Clear the project last.
 		if err := tx.Unscoped().Model(&models.Project{}).
 			Where("id = ?", id).Update("deleted_at", nil).Error; err != nil {
@@ -181,6 +192,10 @@ func (ls *LocalStorage) RestoreProject(ctx context.Context, id uint) error {
 		}
 		return nil
 	})
+	if txErr != nil {
+		return 0, 0, txErr
+	}
+	return restoredEnvironments, restoredSecrets, nil
 }
 
 func (ls *LocalStorage) ListEnvironments(ctx context.Context) ([]*models.Environment, error) {

--- a/internal/storage/store/remote_rbac.go
+++ b/internal/storage/store/remote_rbac.go
@@ -178,6 +178,12 @@ func (rs *RemoteStorage) RemoveRole(ctx context.Context, userID, roleID uint, sc
 	return nil
 }
 
+// RemoveAllProjectRoleGrants is a server-internal RBAC primitive (project
+// membership management runs entirely against LocalStorage); unsupported here.
+func (rs *RemoteStorage) RemoveAllProjectRoleGrants(_ context.Context, _, _ uint) error {
+	return remoteUnsupported("RemoveAllProjectRoleGrants")
+}
+
 // GetUserRoles retrieves all roles for a user via remote API.
 func (rs *RemoteStorage) GetUserRoles(ctx context.Context, userID uint) ([]*models.Role, error) {
 	path := fmt.Sprintf("/api/v1/users/%d/roles", userID)
@@ -405,8 +411,8 @@ func (rs *RemoteStorage) DeleteProject(_ context.Context, _ uint) error {
 	return remoteUnsupported("DeleteProject")
 }
 
-func (rs *RemoteStorage) RestoreProject(_ context.Context, _ uint) error {
-	return remoteUnsupported("RestoreProject")
+func (rs *RemoteStorage) RestoreProject(_ context.Context, _ uint) (int, int, error) {
+	return 0, 0, remoteUnsupported("RestoreProject")
 }
 
 func (rs *RemoteStorage) ListEnvironments(_ context.Context) ([]*models.Environment, error) {

--- a/internal/storage/store/restore_test.go
+++ b/internal/storage/store/restore_test.go
@@ -49,7 +49,12 @@ func TestRestoreProjectCascade(t *testing.T) {
 
 	// Restore brings back the project, its environments, AND its secrets —
 	// secrets now soft-delete with the project and restore with it (ADR-033).
-	require.NoError(t, ls.RestoreProject(ctx, proj.ID))
+	// RestoreProject also reports how many of each it actually resurrected (#311),
+	// so the caller can audit the cascade's true blast radius.
+	restoredEnvs, restoredSecrets, err := ls.RestoreProject(ctx, proj.ID)
+	require.NoError(t, err)
+	assert.Equal(t, 1, restoredEnvs)
+	assert.Equal(t, 1, restoredSecrets)
 
 	restored, err := ls.ListProjectsWithCounts(ctx, false)
 	require.NoError(t, err)
@@ -87,7 +92,10 @@ func TestRestoreProject_DoesNotResurrectIndependentlyDeletedSecret(t *testing.T)
 
 	// Delete then restore the whole project.
 	require.NoError(t, ls.DeleteProject(ctx, proj.ID))
-	require.NoError(t, ls.RestoreProject(ctx, proj.ID))
+	restoredEnvs, restoredSecrets, err := ls.RestoreProject(ctx, proj.ID)
+	require.NoError(t, err)
+	assert.Equal(t, 1, restoredEnvs)
+	assert.Equal(t, 1, restoredSecrets, "only the cascade-deleted secret is counted, not the independently-retired one")
 
 	// "kept" (cascade-deleted with the project) is restored.
 	_, err = ls.GetSecret(ctx, kept.ID)
@@ -134,7 +142,8 @@ func TestRestoreChild_RefusedWhileParentProjectDeleted(t *testing.T) {
 	require.Error(t, err)
 
 	// Restoring the project first (cascade) brings the children back — the supported path.
-	require.NoError(t, ls.RestoreProject(ctx, proj.ID))
+	_, _, err = ls.RestoreProject(ctx, proj.ID)
+	require.NoError(t, err)
 	_, err = ls.GetSecret(ctx, sec.ID)
 	require.NoError(t, err, "after the project is restored, its cascade-deleted secret is live again")
 }
@@ -174,7 +183,7 @@ func TestRestoreProjectNotDeleted(t *testing.T) {
 	require.NoError(t, err)
 
 	// Restoring a project that isn't deleted is a no-op error.
-	err = ls.RestoreProject(ctx, proj.ID)
+	_, _, err = ls.RestoreProject(ctx, proj.ID)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not deleted")
 }

--- a/server/http/handlers/project_members.go
+++ b/server/http/handlers/project_members.go
@@ -195,8 +195,11 @@ func (h *CatalogHandler) UpdateProjectMember(w http.ResponseWriter, r *http.Requ
 	}
 	if err := h.coreService.SetProjectMemberRole(r.Context(), userCtx.UserID, uint(id), uint(userID), body.Role); err != nil {
 		status := http.StatusInternalServerError
-		if strings.Contains(err.Error(), "unknown role") {
+		switch {
+		case strings.Contains(err.Error(), "unknown role"):
 			status = http.StatusBadRequest
+		case strings.Contains(err.Error(), "last administrator"):
+			status = http.StatusConflict
 		}
 		sendError(w, "Error", err.Error(), status, nil)
 		return
@@ -223,8 +226,11 @@ func (h *CatalogHandler) RemoveProjectMember(w http.ResponseWriter, r *http.Requ
 	}
 	if err := h.coreService.RemoveProjectMember(r.Context(), userCtx.UserID, uint(id), uint(userID)); err != nil {
 		status := http.StatusInternalServerError
-		if strings.Contains(err.Error(), "not a member") {
+		switch {
+		case strings.Contains(err.Error(), "not a member"):
 			status = http.StatusNotFound
+		case strings.Contains(err.Error(), "last administrator"):
+			status = http.StatusConflict
 		}
 		sendError(w, "Error", err.Error(), status, nil)
 		return


### PR DESCRIPTION
## Summary

Three project-membership correctness findings from the security-hardening backlog, fixed together since they touch the same files.

- **#232 (HIGH)** — `RemoveProjectMember` only deleted the exact project-level (`environment_id = 0`) `user_roles` row. An environment-scoped grant in the same project (e.g. "prod-only access", created via `POST /user-roles`, gated by GLOBAL `roles.assign`) silently survived an offboarding admin's removal — invisible to and uncorrectable by that admin (project-scoped `roles.assign` can't see or edit `/user-roles` grants, which need global scope). `RemoveProjectMember` now deletes every `user_roles` row for `(userID, projectID)`, across all environments, via a new `RemoveAllProjectRoleGrants` storage primitive.
- **#236 (MED)** — Neither `RemoveProjectMember` nor `SetProjectMemberRole` checked whether the target was the project's last `roles.assign` holder, so the sole remaining project admin could remove or demote themselves (or be removed by anyone else holding `roles.assign`), leaving the project with zero project-scoped admins. Both now go through a shared `guardLastProjectAdmin` check and refuse unless another project-level grant (user or group) already carries `roles.assign`. Not a permanent lockout — a GLOBAL admin can always re-add a project admin — but still an availability risk worth refusing outright.
- **#311 (MED)** — `RestoreProject`'s cascade already correlates environment/secret restores to the project's own deletion timestamp (fixed in a prior PR: only children whose `deleted_at >= project.deleted_at` come back, so independently-retired secrets stay deleted). What was still missing: the audit trail was a single generic `project.restored` event with no way to tell *how many* rows the cascade actually resurrected. `RestoreProject` now returns per-type counts (environments, secrets) and the audit description itemizes them, so a DR-test or accidental delete-then-undo of a whole project leaves a forensic record of its actual blast radius.

## Test plan

- [x] New unit tests in `internal/core/project_members_test.go`: environment-scoped grant is revoked alongside the project-level one (#232); last-admin removal/demotion is refused with a clear error while non-last-admin removal still succeeds, and non-admin removal is always allowed (#236).
- [x] New/updated tests in `internal/storage/store/restore_test.go` and `internal/core/restore_audit_test.go`: `RestoreProject` returns and audits accurate per-type counts, correctly excluding an independently-deleted secret from the tally (#311).
- [x] `go build ./...` and `GOWORK=off go build -C operator ./...` — clean.
- [x] `go test ./...` — full suite passes, no regressions.
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues.
- [x] `golangci-lint run ./...` — 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)