### PR TITLE
harden: route every privilege-grant path through the audited RBAC choke point (#233/#234/#297/#298/#299/#293)

### DIFF
--- a/internal/cli/group/add-member.go
+++ b/internal/cli/group/add-member.go
@@ -34,7 +34,7 @@ func runAddMember(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to initialize service: %w", err)
 	}
 	ctx := context.Background()
-	if err := service.AddUserToGroup(ctx, addMemberUserID, addMemberGroupID); err != nil {
+	if err := service.AddUserToGroup(ctx, 0, addMemberUserID, addMemberGroupID); err != nil {
 		return fmt.Errorf("failed to add member: %w", err)
 	}
 	fmt.Printf("User %d added to group %d.\n", addMemberUserID, addMemberGroupID)

--- a/internal/cli/group/remove-member.go
+++ b/internal/cli/group/remove-member.go
@@ -34,7 +34,7 @@ func runRemoveMember(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to initialize service: %w", err)
 	}
 	ctx := context.Background()
-	if err := service.RemoveUserFromGroup(ctx, removeMemberUserID, removeMemberGroupID); err != nil {
+	if err := service.RemoveUserFromGroup(ctx, 0, removeMemberUserID, removeMemberGroupID); err != nil {
 		return fmt.Errorf("failed to remove member: %w", err)
 	}
 	fmt.Printf("User %d removed from group %d.\n", removeMemberUserID, removeMemberGroupID)

--- a/internal/core/audit.go
+++ b/internal/core/audit.go
@@ -25,6 +25,11 @@ const (
 	EventRoleCreated = "role.created"
 	EventRoleUpdated = "role.updated"
 	EventRoleDeleted = "role.deleted"
+	// Group membership: adding/removing a member confers/revokes every role the
+	// group holds — the same blast radius as a direct role grant/removal, so these
+	// land in the RBAC audit trail alongside role.assigned/role.removed (#233).
+	EventGroupMemberAdded   = "group.member_added"
+	EventGroupMemberRemoved = "group.member_removed"
 )
 
 // rbacAuditEventTypes is the set of event types that make up the RBAC audit log.
@@ -33,6 +38,7 @@ var rbacAuditEventTypes = []string{
 	EventRoleGroupAssigned, EventRoleGroupRemoved,
 	EventPermissionAdded, EventPermissionRemoved,
 	EventRoleCreated, EventRoleUpdated, EventRoleDeleted,
+	EventGroupMemberAdded, EventGroupMemberRemoved,
 }
 
 // rbacAuditDetail is the structured payload stored in an RBAC event's Diff field,
@@ -84,6 +90,26 @@ func (c *KeyorixCore) logGroupRoleChange(ctx context.Context, eventType, verb st
 		RoleID:        roleID,
 		ProjectID:     scope.ProjectID,
 		EnvironmentID: scope.EnvironmentID,
+	})
+}
+
+// LogGroupMemberAdded / LogGroupMemberRemoved record a user being added to / removed
+// from a group. Because membership confers every role the group holds, this is a
+// role-grant-equivalent action and lands in the RBAC audit trail (#233). See
+// LogRoleAssigned for actorID semantics.
+func (c *KeyorixCore) LogGroupMemberAdded(ctx context.Context, actorID, userID, groupID uint) {
+	c.logGroupMemberChange(ctx, EventGroupMemberAdded, "added to group", actorID, userID, groupID)
+}
+
+func (c *KeyorixCore) LogGroupMemberRemoved(ctx context.Context, actorID, userID, groupID uint) {
+	c.logGroupMemberChange(ctx, EventGroupMemberRemoved, "removed from group", actorID, userID, groupID)
+}
+
+func (c *KeyorixCore) logGroupMemberChange(ctx context.Context, eventType, verb string, actorID, userID, groupID uint) {
+	desc := fmt.Sprintf("user %d %s %d", userID, verb, groupID)
+	c.writeRBACAudit(ctx, eventType, desc, actorID, Scope{}, rbacAuditDetail{
+		TargetUserID: userID,
+		GroupID:      groupID,
 	})
 }
 

--- a/internal/core/auth_bootstrap_rbac_test.go
+++ b/internal/core/auth_bootstrap_rbac_test.go
@@ -28,7 +28,8 @@ func newBootstrappedCore(t *testing.T) (*KeyorixCore, *store.LocalStorage) {
 	require.NoError(t, db.AutoMigrate(
 		&models.User{}, &models.Role{}, &models.Permission{}, &models.RolePermission{},
 		&models.UserRole{}, &models.Group{}, &models.UserGroup{}, &models.GroupRole{},
-		&models.Project{}, &models.Environment{},
+		&models.Project{}, &models.Environment{}, &models.AuditEvent{},
+		&models.AccessRequest{}, &models.AccessRequestApproval{}, &models.ProjectMembership{},
 	))
 
 	st := store.NewLocalStorage(db)

--- a/internal/core/groups.go
+++ b/internal/core/groups.go
@@ -113,25 +113,30 @@ func (c *KeyorixCore) ListGroups(ctx context.Context) ([]*models.Group, error) {
 	return groups, nil
 }
 
-// AddUserToGroup adds a user to a group.
-func (c *KeyorixCore) AddUserToGroup(ctx context.Context, userID, groupID uint) error {
+// AddUserToGroup adds a user to a group. actorID is the admin performing it (0 = no
+// authenticated principal, e.g. a local CLI invocation). Membership confers every
+// role the group holds, so this is recorded in the RBAC audit trail (#233).
+func (c *KeyorixCore) AddUserToGroup(ctx context.Context, actorID, userID, groupID uint) error {
 	if userID == 0 || groupID == 0 {
 		return fmt.Errorf("%s: user ID and group ID are required", i18n.T("ErrorValidation", nil))
 	}
 	if err := c.storage.AddUserToGroup(ctx, userID, groupID); err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}
+	c.LogGroupMemberAdded(ctx, actorID, userID, groupID)
 	return nil
 }
 
-// RemoveUserFromGroup removes a user from a group.
-func (c *KeyorixCore) RemoveUserFromGroup(ctx context.Context, userID, groupID uint) error {
+// RemoveUserFromGroup removes a user from a group. See AddUserToGroup for actorID
+// semantics.
+func (c *KeyorixCore) RemoveUserFromGroup(ctx context.Context, actorID, userID, groupID uint) error {
 	if userID == 0 || groupID == 0 {
 		return fmt.Errorf("%s: user ID and group ID are required", i18n.T("ErrorValidation", nil))
 	}
 	if err := c.storage.RemoveUserFromGroup(ctx, userID, groupID); err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}
+	c.LogGroupMemberRemoved(ctx, actorID, userID, groupID)
 	return nil
 }
 

--- a/internal/core/groups_audit_test.go
+++ b/internal/core/groups_audit_test.go
@@ -63,6 +63,57 @@ func TestGroupCRUDAudit(t *testing.T) {
 	assert.Equal(t, g.ID, restored.ID)
 }
 
+// Group membership (add/remove) is role-grant-equivalent — a member inherits every
+// role the group holds — so it must land in the RBAC audit trail (#233), the same
+// as a direct /user-roles grant.
+func TestGroupMembershipAudit(t *testing.T) {
+	require.NoError(t, i18n.Initialize(&config.Config{
+		Locale: config.LocaleConfig{Language: "en", FallbackLanguage: "en"},
+	}))
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.Group{}, &models.User{}, &models.UserGroup{}, &models.AuditEvent{},
+	))
+	require.NoError(t, db.Create(&models.Group{ID: 7, Name: "platform"}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 11, Username: "alice", Email: "alice@example.com"}).Error)
+	c := &KeyorixCore{storage: store.NewLocalStorage(db)}
+	ctx := context.Background()
+
+	require.NoError(t, c.AddUserToGroup(ctx, 42, 11, 7))
+
+	entries, total, err := c.ListRBACAuditLogs(ctx, 1, 50)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), total)
+	require.Len(t, entries, 1)
+	assert.Equal(t, EventGroupMemberAdded, entries[0].Action)
+	require.NotNil(t, entries[0].ActorUserID)
+	assert.Equal(t, uint(42), *entries[0].ActorUserID)
+	require.NotNil(t, entries[0].TargetUserID)
+	assert.Equal(t, uint(11), *entries[0].TargetUserID)
+	require.NotNil(t, entries[0].GroupID)
+	assert.Equal(t, uint(7), *entries[0].GroupID)
+
+	require.NoError(t, c.RemoveUserFromGroup(ctx, 42, 11, 7))
+
+	entries, total, err = c.ListRBACAuditLogs(ctx, 1, 50)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), total)
+	var removed *RBACAuditEntry
+	for _, e := range entries {
+		if e.Action == EventGroupMemberRemoved {
+			removed = e
+		}
+	}
+	require.NotNil(t, removed, "expected a group.member_removed entry")
+	require.NotNil(t, removed.ActorUserID)
+	assert.Equal(t, uint(42), *removed.ActorUserID)
+	require.NotNil(t, removed.TargetUserID)
+	assert.Equal(t, uint(11), *removed.TargetUserID)
+	require.NotNil(t, removed.GroupID)
+	assert.Equal(t, uint(7), *removed.GroupID)
+}
+
 // A CLI invocation (actorID 0) still audits, with no actor recorded.
 func TestGroupCreateAudit_UnauthenticatedActor(t *testing.T) {
 	require.NoError(t, i18n.Initialize(&config.Config{

--- a/internal/core/invitation_global_test.go
+++ b/internal/core/invitation_global_test.go
@@ -137,3 +137,38 @@ func TestApplyInvitationGrants_GlobalInvite(t *testing.T) {
 	require.NoError(t, err)
 	store.AssertExpectations(t)
 }
+
+// The system-role grant on global-invitation acceptance is the moment of privilege
+// (up to and including super_admin) — it must land in the RBAC audit trail like every
+// other grant path, not vanish with zero trace (#299). Uses real storage so
+// ListRBACAuditLogs is exercised end to end.
+func TestApplyInvitationGrants_SystemRoleIsRBACAudited(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	ctx := context.Background()
+
+	inviter, err := st.CreateUser(ctx, &models.User{Username: "admin-inviter", Email: "inviter@example.com", IsActive: true})
+	require.NoError(t, err)
+	invitee, err := st.CreateUser(ctx, &models.User{Username: "carol", Email: "carol@example.com", IsActive: true})
+	require.NoError(t, err)
+
+	inv := &models.ProjectInvitation{
+		ID: 1, ProjectID: 0, Email: invitee.Email, InvitedBy: inviter.ID,
+		SystemRole: "system_auditor",
+	}
+
+	require.NoError(t, c.applyInvitationGrants(ctx, inv, invitee.ID))
+
+	entries, _, err := c.ListRBACAuditLogs(ctx, 1, 50)
+	require.NoError(t, err)
+	var assigned *RBACAuditEntry
+	for _, e := range entries {
+		if e.Action == EventRoleAssigned {
+			assigned = e
+		}
+	}
+	require.NotNil(t, assigned, "global-invitation system-role grant must appear in the RBAC audit trail")
+	require.NotNil(t, assigned.ActorUserID)
+	assert.Equal(t, inviter.ID, *assigned.ActorUserID)
+	require.NotNil(t, assigned.TargetUserID)
+	assert.Equal(t, invitee.ID, *assigned.TargetUserID)
+}

--- a/internal/core/invitations.go
+++ b/internal/core/invitations.go
@@ -232,7 +232,11 @@ func (c *KeyorixCore) applyInvitationGrants(ctx context.Context, inv *models.Pro
 			if err != nil {
 				return fmt.Errorf("unknown system role %q: %w", inv.SystemRole, err)
 			}
-			if err := c.storage.AssignRole(ctx, userID, role.ID, storage.Scope{ProjectID: 0}); err != nil {
+			// Routed through the audited wrapper — this is the moment of privilege
+			// grant for a global invitation (up to and including super_admin), which
+			// previously left zero trace of any kind (#299). Attributed to the inviter,
+			// consistent with the per-project assignment grants below.
+			if err := c.AssignUserRole(ctx, inv.InvitedBy, userID, role.ID, Scope{ProjectID: 0}); err != nil {
 				return fmt.Errorf("failed to grant system role: %w", err)
 			}
 		}
@@ -521,12 +525,15 @@ func (c *KeyorixCore) ApproveAccessRequestWithExpiry(ctx context.Context, projec
 	grantDesc := role
 	if grantTTL > 0 {
 		expiresAt := now.Add(grantTTL)
-		if err := c.storage.AssignRoleWithExpiry(ctx, req.UserID, roleModel.ID, scope, expiresAt); err != nil {
+		// Routed through the audited wrapper so this grant lands in the RBAC audit
+		// trail with a structured RoleID, alongside the generic access_request.approved
+		// event below (#298).
+		if err := c.AssignUserRoleWithExpiry(ctx, approverID, req.UserID, roleModel.ID, scope, expiresAt); err != nil {
 			return nil, fmt.Errorf("failed to grant role: %w", err)
 		}
 		grantDesc = fmt.Sprintf("%s until %s (TTL %s)", role, expiresAt.UTC().Format(time.RFC3339), grantTTL)
 	} else {
-		if err := c.storage.AssignRole(ctx, req.UserID, roleModel.ID, scope); err != nil {
+		if err := c.AssignUserRole(ctx, approverID, req.UserID, roleModel.ID, scope); err != nil {
 			return nil, fmt.Errorf("failed to grant role: %w", err)
 		}
 	}

--- a/internal/core/invitations_test.go
+++ b/internal/core/invitations_test.go
@@ -77,6 +77,11 @@ func TestApproveAccessRequest_GrantsRole(t *testing.T) {
 	store.On("LogAuditEvent", ctx, mock.MatchedBy(func(e *models.AuditEvent) bool {
 		return e.EventType == "access_request.approved"
 	})).Return(nil)
+	// The grant now also routes through the audited RBAC choke point (#298), which
+	// records its own structured role.assigned event alongside the generic one above.
+	store.On("LogAuditEvent", ctx, mock.MatchedBy(func(e *models.AuditEvent) bool {
+		return e.EventType == EventRoleAssigned
+	})).Return(nil)
 	store.On("ListAccessRequestApprovals", ctx, uint(3)).Return([]*models.AccessRequestApproval{}, nil)
 	store.On("CreateAccessRequestApproval", ctx, mock.Anything).Return(nil)
 
@@ -85,6 +90,9 @@ func TestApproveAccessRequest_GrantsRole(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, AccessRequestApproved, out.State)
 	store.AssertCalled(t, "AssignRole", ctx, uint(2), uint(5), storage.Scope{ProjectID: 1})
+	store.AssertCalled(t, "LogAuditEvent", ctx, mock.MatchedBy(func(e *models.AuditEvent) bool {
+		return e.EventType == EventRoleAssigned
+	}))
 }
 
 func TestApproveAccessRequest_FallsBackToSuggestedRole(t *testing.T) {
@@ -266,4 +274,57 @@ func TestListProjectInvitations_LazyExpire(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, out, 1)
 	assert.Equal(t, InvitationExpired, out[0].State)
+}
+
+// Access-request approval grants a real role, so both the immediate and TTL-bound
+// grant branches must land in the RBAC audit trail with a structured RoleID — not
+// just the generic access_request.approved event (#298). Uses real storage so
+// ListRBACAuditLogs is exercised end to end.
+func TestApproveAccessRequestWithExpiry_IsRBACAudited(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	ctx := context.Background()
+
+	approver, err := st.CreateUser(ctx, &models.User{Username: "approver", Email: "approver@example.com", IsActive: true})
+	require.NoError(t, err)
+	requester, err := st.CreateUser(ctx, &models.User{Username: "requester", Email: "requester@example.com", IsActive: true})
+	require.NoError(t, err)
+	req, err := st.CreateAccessRequest(ctx, &models.AccessRequest{
+		ProjectID: 1, UserID: requester.ID, SuggestedRole: "project_viewer", State: AccessRequestPending,
+	})
+	require.NoError(t, err)
+
+	_, err = c.ApproveAccessRequestWithExpiry(ctx, 1, req.ID, approver.ID, "", 0)
+	require.NoError(t, err)
+
+	entries, _, err := c.ListRBACAuditLogs(ctx, 1, 50)
+	require.NoError(t, err)
+	var assigned *RBACAuditEntry
+	for _, e := range entries {
+		if e.Action == EventRoleAssigned {
+			assigned = e
+		}
+	}
+	require.NotNil(t, assigned, "access-request approval grant must appear in the RBAC audit trail")
+	require.NotNil(t, assigned.ActorUserID)
+	assert.Equal(t, approver.ID, *assigned.ActorUserID)
+	require.NotNil(t, assigned.TargetUserID)
+	assert.Equal(t, requester.ID, *assigned.TargetUserID)
+
+	// Time-bound (TTL) grant branch is audited the same way.
+	req2, err := st.CreateAccessRequest(ctx, &models.AccessRequest{
+		ProjectID: 1, UserID: requester.ID, SuggestedRole: "project_developer", State: AccessRequestPending,
+	})
+	require.NoError(t, err)
+	_, err = c.ApproveAccessRequestWithExpiry(ctx, 1, req2.ID, approver.ID, "", time.Hour)
+	require.NoError(t, err)
+
+	entries, _, err = c.ListRBACAuditLogs(ctx, 1, 50)
+	require.NoError(t, err)
+	var count int
+	for _, e := range entries {
+		if e.Action == EventRoleAssigned && e.TargetUserID != nil && *e.TargetUserID == requester.ID {
+			count++
+		}
+	}
+	assert.Equal(t, 2, count, "both the immediate and TTL-bound grants are RBAC-audited")
 }

--- a/internal/core/membership_lifecycle.go
+++ b/internal/core/membership_lifecycle.go
@@ -144,7 +144,7 @@ func (c *KeyorixCore) inviteMemberWithMode(ctx context.Context, projectID, userI
 
 	// If the mode put us straight into active, grant the role now.
 	if created.State == MembershipActive {
-		if err := c.AddProjectMember(ctx, projectID, userID, role); err != nil {
+		if err := c.AddProjectMember(ctx, invitedBy, projectID, userID, role); err != nil {
 			return nil, fmt.Errorf("failed to grant role on activation: %w", err)
 		}
 	}
@@ -213,12 +213,12 @@ func (c *KeyorixCore) TransitionMembership(ctx context.Context, projectID, membe
 	// Side effects on the role grant.
 	switch to {
 	case MembershipActive:
-		if err := c.AddProjectMember(ctx, m.ProjectID, m.UserID, m.Role); err != nil {
+		if err := c.AddProjectMember(ctx, actorID, m.ProjectID, m.UserID, m.Role); err != nil {
 			return nil, fmt.Errorf("failed to grant role on activation: %w", err)
 		}
 	case MembershipRevoked:
 		// Best-effort: the membership is already revoked; a missing grant is fine.
-		_ = c.RemoveProjectMember(ctx, m.ProjectID, m.UserID)
+		_ = c.RemoveProjectMember(ctx, actorID, m.ProjectID, m.UserID)
 	}
 
 	c.logMembershipEvent(ctx, "membership."+transitionVerb(to), m, actorID)

--- a/internal/core/project_members.go
+++ b/internal/core/project_members.go
@@ -1,9 +1,10 @@
 // project_members.go — project-scoped membership (ADR-021 two-tier model).
 //
 // A "project member" is a user holding a role at the project's scope
-// (project_id = P, environment_id = 0). These helpers sit on top of the generic
-// scoped role assignment (AssignRole/RemoveRole) to give the Members tab a
-// membership-shaped API.
+// (project_id = P, environment_id = 0). These helpers sit on top of the audited
+// RBAC choke point (AssignUserRole/RemoveUserRole, see rbac_management.go) to give
+// the Members tab a membership-shaped API — the same underlying grant as
+// /user-roles, so it must be audited identically (#234).
 package core
 
 import (
@@ -18,23 +19,26 @@ func (c *KeyorixCore) ListProjectMembers(ctx context.Context, projectID uint) ([
 	return c.storage.ListProjectMembers(ctx, projectID)
 }
 
-// AddProjectMember assigns roleName to userID at the project scope.
-func (c *KeyorixCore) AddProjectMember(ctx context.Context, projectID, userID uint, roleName string) error {
+// AddProjectMember assigns roleName to userID at the project scope. actorID is the
+// acting principal (0 = no authenticated principal, e.g. a system-driven onboarding
+// transition); see AssignUserRole for actorID semantics.
+func (c *KeyorixCore) AddProjectMember(ctx context.Context, actorID, projectID, userID uint, roleName string) error {
 	role, err := c.storage.GetRoleByName(ctx, roleName)
 	if err != nil {
 		return fmt.Errorf("unknown role %q: %w", roleName, err)
 	}
-	return c.storage.AssignRole(ctx, userID, role.ID, storage.Scope{ProjectID: projectID})
+	return c.AssignUserRole(ctx, actorID, userID, role.ID, Scope{ProjectID: projectID})
 }
 
 // SetProjectMemberRole replaces the user's role(s) at the project scope with
-// roleName, adding the member if they had none.
-func (c *KeyorixCore) SetProjectMemberRole(ctx context.Context, projectID, userID uint, roleName string) error {
+// roleName, adding the member if they had none. See AddProjectMember for actorID
+// semantics.
+func (c *KeyorixCore) SetProjectMemberRole(ctx context.Context, actorID, projectID, userID uint, roleName string) error {
 	role, err := c.storage.GetRoleByName(ctx, roleName)
 	if err != nil {
 		return fmt.Errorf("unknown role %q: %w", roleName, err)
 	}
-	scope := storage.Scope{ProjectID: projectID}
+	scope := Scope{ProjectID: projectID}
 	existing, err := c.storage.GetUserRoleIDsExact(ctx, userID, scope)
 	if err != nil {
 		return err
@@ -45,19 +49,20 @@ func (c *KeyorixCore) SetProjectMemberRole(ctx context.Context, projectID, userI
 			hasTarget = true
 			continue
 		}
-		if err := c.storage.RemoveRole(ctx, userID, rid, scope); err != nil {
+		if err := c.RemoveUserRole(ctx, actorID, userID, rid, scope); err != nil {
 			return err
 		}
 	}
 	if hasTarget {
 		return nil
 	}
-	return c.storage.AssignRole(ctx, userID, role.ID, scope)
+	return c.AssignUserRole(ctx, actorID, userID, role.ID, scope)
 }
 
-// RemoveProjectMember removes all of the user's roles at the project scope.
-func (c *KeyorixCore) RemoveProjectMember(ctx context.Context, projectID, userID uint) error {
-	scope := storage.Scope{ProjectID: projectID}
+// RemoveProjectMember removes all of the user's roles at the project scope. See
+// AddProjectMember for actorID semantics.
+func (c *KeyorixCore) RemoveProjectMember(ctx context.Context, actorID, projectID, userID uint) error {
+	scope := Scope{ProjectID: projectID}
 	existing, err := c.storage.GetUserRoleIDsExact(ctx, userID, scope)
 	if err != nil {
 		return err
@@ -66,7 +71,7 @@ func (c *KeyorixCore) RemoveProjectMember(ctx context.Context, projectID, userID
 		return fmt.Errorf("user is not a member of this project")
 	}
 	for _, rid := range existing {
-		if err := c.storage.RemoveRole(ctx, userID, rid, scope); err != nil {
+		if err := c.RemoveUserRole(ctx, actorID, userID, rid, scope); err != nil {
 			return err
 		}
 	}

--- a/internal/core/project_members_test.go
+++ b/internal/core/project_members_test.go
@@ -22,8 +22,10 @@ func TestProjectMemberLifecycle(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, members)
 
+	const actor = uint(99)
+
 	// Add as project_viewer.
-	require.NoError(t, c.AddProjectMember(ctx, proj, u.ID, "project_viewer"))
+	require.NoError(t, c.AddProjectMember(ctx, actor, proj, u.ID, "project_viewer"))
 	members, err = c.ListProjectMembers(ctx, proj)
 	require.NoError(t, err)
 	require.Len(t, members, 1)
@@ -31,10 +33,10 @@ func TestProjectMemberLifecycle(t *testing.T) {
 	assert.Equal(t, "project_viewer", members[0].RoleName)
 
 	// Adding the same role again is a conflict.
-	require.Error(t, c.AddProjectMember(ctx, proj, u.ID, "project_viewer"))
+	require.Error(t, c.AddProjectMember(ctx, actor, proj, u.ID, "project_viewer"))
 
 	// Change role to project_developer — replaces, doesn't accumulate.
-	require.NoError(t, c.SetProjectMemberRole(ctx, proj, u.ID, "project_developer"))
+	require.NoError(t, c.SetProjectMemberRole(ctx, actor, proj, u.ID, "project_developer"))
 	members, err = c.ListProjectMembers(ctx, proj)
 	require.NoError(t, err)
 	require.Len(t, members, 1, "member should have exactly one project role after change")
@@ -46,13 +48,13 @@ func TestProjectMemberLifecycle(t *testing.T) {
 	assert.Empty(t, other)
 
 	// Remove.
-	require.NoError(t, c.RemoveProjectMember(ctx, proj, u.ID))
+	require.NoError(t, c.RemoveProjectMember(ctx, actor, proj, u.ID))
 	members, err = c.ListProjectMembers(ctx, proj)
 	require.NoError(t, err)
 	assert.Empty(t, members)
 
 	// Removing a non-member errors.
-	require.Error(t, c.RemoveProjectMember(ctx, proj, u.ID))
+	require.Error(t, c.RemoveProjectMember(ctx, actor, proj, u.ID))
 }
 
 func TestAddProjectMemberUnknownRole(t *testing.T) {
@@ -60,5 +62,49 @@ func TestAddProjectMemberUnknownRole(t *testing.T) {
 	ctx := context.Background()
 	u, err := st.CreateUser(ctx, &models.User{Username: "bob", Email: "bob@example.com", IsActive: true})
 	require.NoError(t, err)
-	require.Error(t, c.AddProjectMember(ctx, 1, u.ID, "no_such_role"))
+	require.Error(t, c.AddProjectMember(ctx, 99, 1, u.ID, "no_such_role"))
+}
+
+// AddProjectMember/SetProjectMemberRole/RemoveProjectMember grant/revoke the same
+// underlying role assignment as /user-roles, so they must land in the RBAC audit
+// trail identically (#234) — previously these bypassed AssignUserRole/RemoveUserRole
+// and wrote nothing.
+func TestProjectMemberGrantIsRBACAudited(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	ctx := context.Background()
+	const proj = uint(9)
+	const actor = uint(55)
+
+	u, err := st.CreateUser(ctx, &models.User{Username: "carol", Email: "carol@example.com", IsActive: true})
+	require.NoError(t, err)
+
+	require.NoError(t, c.AddProjectMember(ctx, actor, proj, u.ID, "project_viewer"))
+
+	entries, _, err := c.ListRBACAuditLogs(ctx, 1, 50)
+	require.NoError(t, err)
+	var assigned *RBACAuditEntry
+	for _, e := range entries {
+		if e.Action == EventRoleAssigned && e.TargetUserID != nil && *e.TargetUserID == u.ID {
+			assigned = e
+		}
+	}
+	require.NotNil(t, assigned, "expected a role.assigned entry for the project-member grant")
+	require.NotNil(t, assigned.ActorUserID)
+	assert.Equal(t, actor, *assigned.ActorUserID)
+	require.NotNil(t, assigned.ProjectID)
+	assert.Equal(t, proj, *assigned.ProjectID)
+
+	require.NoError(t, c.RemoveProjectMember(ctx, actor, proj, u.ID))
+
+	entries, _, err = c.ListRBACAuditLogs(ctx, 1, 50)
+	require.NoError(t, err)
+	var removed *RBACAuditEntry
+	for _, e := range entries {
+		if e.Action == EventRoleRemoved && e.TargetUserID != nil && *e.TargetUserID == u.ID {
+			removed = e
+		}
+	}
+	require.NotNil(t, removed, "expected a role.removed entry for the project-member revoke")
+	require.NotNil(t, removed.ActorUserID)
+	assert.Equal(t, actor, *removed.ActorUserID)
 }

--- a/internal/core/rbac_audit.go
+++ b/internal/core/rbac_audit.go
@@ -19,7 +19,7 @@ import (
 // whom, at what scope, and when.
 type RBACAuditEntry struct {
 	ID           uint
-	Action       string // role.assigned | role.removed | role.group_assigned | role.group_removed
+	Action       string // role.assigned | role.removed | role.group_assigned | role.group_removed | group.member_added | group.member_removed
 	ActorUserID  *uint  // the principal who made the change (nil for system/CLI)
 	TargetUserID *uint  // set for user-role events
 	GroupID      *uint  // set for group-role events

--- a/internal/core/rbac_reconcile.go
+++ b/internal/core/rbac_reconcile.go
@@ -75,7 +75,11 @@ func (c *KeyorixCore) ReconcileRBACPermissions(ctx context.Context) error {
 			if !isNew || held[permName] {
 				continue
 			}
-			if err := c.storage.AssignPermissionToRole(ctx, role.ID, id); err != nil {
+			// Routed through the audited core wrapper (actor 0 = system, the same
+			// convention every other system-initiated grant uses) so this startup
+			// top-up emits permission.assigned like every other permission grant
+			// path, instead of leaving the tamper-evident audit chain silent (#293).
+			if err := c.AssignPermissionToRole(ctx, 0, role.ID, id); err != nil {
 				log.Printf("rbac reconcile: grant %s to role %s: %v", permName, rdef.Name, err)
 			}
 		}

--- a/internal/core/rbac_reconcile_test.go
+++ b/internal/core/rbac_reconcile_test.go
@@ -16,7 +16,7 @@ func newRBACReconcileCore(t *testing.T) (*KeyorixCore, *gorm.DB) {
 	t.Helper()
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
-	require.NoError(t, db.AutoMigrate(&models.Role{}, &models.Permission{}, &models.RolePermission{}))
+	require.NoError(t, db.AutoMigrate(&models.Role{}, &models.Permission{}, &models.RolePermission{}, &models.AuditEvent{}))
 	return &KeyorixCore{storage: store.NewLocalStorage(db)}, db
 }
 
@@ -122,4 +122,36 @@ func TestReconcileRBAC_Idempotent(t *testing.T) {
 	require.NoError(t, db.Model(&models.Permission{}).Select("id").Where("name = ?", "connect.read").First(&connectID).Error)
 	require.NoError(t, db.Model(&models.RolePermission{}).Where("role_id = ? AND permission_id = ?", r.ID, connectID).Count(&n).Error)
 	assert.Equal(t, int64(1), n, "no duplicate grant on a second reconcile")
+}
+
+// Startup reconciliation grants must land in the RBAC audit trail like every other
+// permission grant, attributed to the system actor (0), not vanish silently (#293).
+func TestReconcileRBAC_GrantsAreRBACAudited(t *testing.T) {
+	c, db := newRBACReconcileCore(t)
+	seedOldCatalog(t, c, db)
+	ctx := context.Background()
+
+	require.NoError(t, c.ReconcileRBACPermissions(ctx))
+
+	entries, _, err := c.ListRBACAuditLogs(ctx, 1, 100)
+	require.NoError(t, err)
+
+	var found *RBACAuditEntry
+	for _, e := range entries {
+		if e.Action == EventPermissionAdded && e.ActorUserID == nil {
+			// Match the connect.read grant to the admin role specifically.
+			r, rerr := c.storage.GetRoleByName(ctx, "admin")
+			require.NoError(t, rerr)
+			if e.RoleID != nil && *e.RoleID == r.ID {
+				found = e
+			}
+		}
+	}
+	require.NotNil(t, found, "reconciliation's permission grant must appear in the RBAC audit trail")
+	assert.Nil(t, found.ActorUserID, "system-initiated reconciliation records no actor")
+	require.NotNil(t, found.PermissionID)
+
+	var connectID uint
+	require.NoError(t, db.Model(&models.Permission{}).Select("id").Where("name = ?", "connect.read").First(&connectID).Error)
+	assert.Equal(t, connectID, *found.PermissionID)
 }

--- a/internal/core/sso.go
+++ b/internal/core/sso.go
@@ -571,6 +571,12 @@ func (c *KeyorixCore) reconcileSSORoles(ctx context.Context, p *SSOProvider, use
 		currentSet[r.Name] = true
 	}
 
+	// Route through the audited RBAC choke point (AssignUserRole/RemoveUserRole) so
+	// each individual role change lands in the RBAC audit trail with a structured
+	// RoleID, not just the coarse aggregate-count event below (#297). The acting
+	// principal is the logging-in user themself — the same attribution the
+	// aggregate auth.sso_roles_synced event below already used — since the grant is
+	// driven by their own IdP-asserted groups against the admin-configured map.
 	added, removed := 0, 0
 	for role := range managedRoles {
 		r, rerr := c.storage.GetRoleByName(ctx, role)
@@ -579,11 +585,11 @@ func (c *KeyorixCore) reconcileSSORoles(ctx context.Context, p *SSOProvider, use
 		}
 		switch {
 		case desiredRoles[role] && !currentSet[role]:
-			if c.storage.AssignRole(ctx, userID, r.ID, Scope{}) == nil {
+			if c.AssignUserRole(ctx, userID, userID, r.ID, Scope{}) == nil {
 				added++
 			}
 		case !desiredRoles[role] && currentSet[role]:
-			if c.storage.RemoveRole(ctx, userID, r.ID, Scope{}) == nil {
+			if c.RemoveUserRole(ctx, userID, userID, r.ID, Scope{}) == nil {
 				removed++
 			}
 		}

--- a/internal/core/sso_test.go
+++ b/internal/core/sso_test.go
@@ -401,6 +401,10 @@ func TestSyncSSORoles(t *testing.T) {
 		}, nil)
 		store.On("GetRoleByName", mock.Anything, "system_admin").Return(&models.Role{ID: 10, Name: "system_admin"}, nil)
 		store.On("GetRoleByName", mock.Anything, "system_auditor").Return(&models.Role{ID: 20, Name: "system_auditor"}, nil)
+		// RemoveUserRole's last-global-admin guard (unrelated to this test's role, but
+		// exercised on every removal) looks up the other install-admin role names too.
+		store.On("GetRoleByName", mock.Anything, "super_admin").Return(nil, assert.AnError)
+		store.On("GetRoleByName", mock.Anything, "admin").Return(nil, assert.AnError)
 		store.On("AssignRole", mock.Anything, uint(7), uint(10), mock.Anything).Return(nil)
 		store.On("RemoveRole", mock.Anything, uint(7), uint(20), mock.Anything).Return(nil)
 		store.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
@@ -432,6 +436,58 @@ func TestSyncSSORoles(t *testing.T) {
 		c.syncSSORoles(context.Background(), p, 7, raw)
 		store.AssertNotCalled(t, "AssignRole", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 	})
+}
+
+// SSO login-time role reconciliation grants/revokes a real role, so it must land in
+// the RBAC audit trail with a structured RoleID like every other grant path — not
+// just the coarse aggregate auth.sso_roles_synced count (#297). Uses real storage so
+// ListRBACAuditLogs (reading the actual persisted rows) is exercised end to end.
+func TestReconcileSSORoles_IsRBACAudited(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.User{}, &models.Role{}, &models.UserRole{}, &models.AuditEvent{}))
+	ls := store.NewLocalStorage(db)
+	c := NewKeyorixCore(ls)
+	ctx := context.Background()
+
+	require.NoError(t, db.Create(&models.User{ID: 7, Username: "alice"}).Error)
+	require.NoError(t, db.Create(&models.Role{ID: 10, Name: "system_auditor"}).Error)
+	p := &SSOProvider{Name: "okta", GroupRoleMap: map[string]string{"keyorix-auditors": "system_auditor"}}
+
+	// IdP asserts keyorix-auditors → system_auditor should be granted.
+	c.reconcileSSORoles(ctx, p, 7, []string{"keyorix-auditors"})
+
+	entries, _, err := c.ListRBACAuditLogs(ctx, 1, 50)
+	require.NoError(t, err)
+	var assigned *RBACAuditEntry
+	for _, e := range entries {
+		if e.Action == EventRoleAssigned {
+			assigned = e
+		}
+	}
+	require.NotNil(t, assigned, "SSO-driven role grant must appear in the RBAC audit trail")
+	require.NotNil(t, assigned.TargetUserID)
+	assert.Equal(t, uint(7), *assigned.TargetUserID)
+	require.NotNil(t, assigned.RoleID)
+	assert.Equal(t, uint(10), *assigned.RoleID)
+
+	// A later login with no group asserted must revoke system_admin, also audited.
+	c.reconcileSSORoles(ctx, p, 7, nil)
+
+	entries, _, err = c.ListRBACAuditLogs(ctx, 1, 50)
+	require.NoError(t, err)
+	var removed *RBACAuditEntry
+	for _, e := range entries {
+		if e.Action == EventRoleRemoved {
+			removed = e
+		}
+	}
+	require.NotNil(t, removed, "SSO-driven role revoke must appear in the RBAC audit trail")
+	require.NotNil(t, removed.TargetUserID)
+	assert.Equal(t, uint(7), *removed.TargetUserID)
+	require.NotNil(t, removed.RoleID)
+	assert.Equal(t, uint(10), *removed.RoleID)
 }
 
 func TestBeginSSO_BuildsAuthURLWithStateAndNonce(t *testing.T) {

--- a/server/grpc/services/group_service.go
+++ b/server/grpc/services/group_service.go
@@ -156,7 +156,7 @@ func (s *GroupGRPCService) AddGroupMember(ctx context.Context, req *pb.GroupMemb
 	if err := authorizeGlobal(ctx, s.core, actor, "roles.assign"); err != nil {
 		return nil, err
 	}
-	if err := s.core.AddUserToGroup(ctx, uint(req.GetUserId()), uint(req.GetGroupId())); err != nil {
+	if err := s.core.AddUserToGroup(ctx, actor.UserID, uint(req.GetUserId()), uint(req.GetGroupId())); err != nil {
 		return nil, groupError(err)
 	}
 	return &emptypb.Empty{}, nil
@@ -170,7 +170,7 @@ func (s *GroupGRPCService) RemoveGroupMember(ctx context.Context, req *pb.GroupM
 	if err := authorizeGlobal(ctx, s.core, actor, "roles.assign"); err != nil {
 		return nil, err
 	}
-	if err := s.core.RemoveUserFromGroup(ctx, uint(req.GetUserId()), uint(req.GetGroupId())); err != nil {
+	if err := s.core.RemoveUserFromGroup(ctx, actor.UserID, uint(req.GetUserId()), uint(req.GetGroupId())); err != nil {
 		return nil, groupError(err)
 	}
 	return &emptypb.Empty{}, nil

--- a/server/http/handlers/groups_members.go
+++ b/server/http/handlers/groups_members.go
@@ -70,7 +70,7 @@ func (h *GroupHandler) AddGroupMember(w http.ResponseWriter, r *http.Request) {
 		sendError(w, "ValidationError", "user_id is required", http.StatusBadRequest, nil)
 		return
 	}
-	if err := h.coreService.AddUserToGroup(r.Context(), body.UserID, uint(groupID)); err != nil {
+	if err := h.coreService.AddUserToGroup(r.Context(), userCtx.UserID, body.UserID, uint(groupID)); err != nil {
 		log.Printf("Error adding group member: %v", err)
 		if strings.Contains(err.Error(), "not found") {
 			sendError(w, "NotFound", "User or group not found", http.StatusNotFound, nil)
@@ -99,7 +99,7 @@ func (h *GroupHandler) RemoveGroupMember(w http.ResponseWriter, r *http.Request)
 		sendError(w, "InvalidParameter", "Invalid user ID", http.StatusBadRequest, nil)
 		return
 	}
-	if err := h.coreService.RemoveUserFromGroup(r.Context(), uint(userID), uint(groupID)); err != nil {
+	if err := h.coreService.RemoveUserFromGroup(r.Context(), userCtx.UserID, uint(userID), uint(groupID)); err != nil {
 		log.Printf("Error removing group member: %v", err)
 		sendError(w, "InternalError", "Failed to remove group member", http.StatusInternalServerError, nil)
 		return

--- a/server/http/handlers/project_members.go
+++ b/server/http/handlers/project_members.go
@@ -134,6 +134,11 @@ func (h *CatalogHandler) AddProjectMember(w http.ResponseWriter, r *http.Request
 		sendError(w, "InvalidParameter", "Invalid project ID", http.StatusBadRequest, nil)
 		return
 	}
+	userCtx := middleware.GetUserFromContext(r.Context())
+	if userCtx == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
 	var body struct {
 		UserID uint   `json:"user_id"`
 		Role   string `json:"role"`
@@ -146,7 +151,7 @@ func (h *CatalogHandler) AddProjectMember(w http.ResponseWriter, r *http.Request
 		sendError(w, "ValidationError", "user_id and role are required", http.StatusBadRequest, nil)
 		return
 	}
-	if err := h.coreService.AddProjectMember(r.Context(), uint(id), body.UserID, body.Role); err != nil {
+	if err := h.coreService.AddProjectMember(r.Context(), userCtx.UserID, uint(id), body.UserID, body.Role); err != nil {
 		status := http.StatusInternalServerError
 		if strings.Contains(err.Error(), "already") {
 			status = http.StatusConflict
@@ -172,6 +177,11 @@ func (h *CatalogHandler) UpdateProjectMember(w http.ResponseWriter, r *http.Requ
 		sendError(w, "InvalidParameter", "Invalid user ID", http.StatusBadRequest, nil)
 		return
 	}
+	userCtx := middleware.GetUserFromContext(r.Context())
+	if userCtx == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
 	var body struct {
 		Role string `json:"role"`
 	}
@@ -183,7 +193,7 @@ func (h *CatalogHandler) UpdateProjectMember(w http.ResponseWriter, r *http.Requ
 		sendError(w, "ValidationError", "role is required", http.StatusBadRequest, nil)
 		return
 	}
-	if err := h.coreService.SetProjectMemberRole(r.Context(), uint(id), uint(userID), body.Role); err != nil {
+	if err := h.coreService.SetProjectMemberRole(r.Context(), userCtx.UserID, uint(id), uint(userID), body.Role); err != nil {
 		status := http.StatusInternalServerError
 		if strings.Contains(err.Error(), "unknown role") {
 			status = http.StatusBadRequest
@@ -206,7 +216,12 @@ func (h *CatalogHandler) RemoveProjectMember(w http.ResponseWriter, r *http.Requ
 		sendError(w, "InvalidParameter", "Invalid user ID", http.StatusBadRequest, nil)
 		return
 	}
-	if err := h.coreService.RemoveProjectMember(r.Context(), uint(id), uint(userID)); err != nil {
+	userCtx := middleware.GetUserFromContext(r.Context())
+	if userCtx == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	if err := h.coreService.RemoveProjectMember(r.Context(), userCtx.UserID, uint(id), uint(userID)); err != nil {
 		status := http.StatusInternalServerError
 		if strings.Contains(err.Error(), "not a member") {
 			status = http.StatusNotFound


### PR DESCRIPTION
## Summary

`AssignUserRole`/`RemoveUserRole` (`internal/core/rbac_management.go`) is the ONLY
place that calls `LogRoleAssigned`/`LogRoleRemoved` and lands a grant in the
tamper-evident RBAC audit trail queryable via `ListRBACAuditLogs`. Six other code
paths granted or revoked functionally-identical privilege by calling
`storage.AssignRole`/`RemoveRole` (or equivalent) directly, leaving zero forensic
trail for a grant indistinguishable in effect from an audited `/user-roles` call.

Fixed, heaviest first:

- **#233 (HIGH)** — `AddUserToGroup`/`RemoveUserFromGroup` (`internal/core/groups.go`)
  took no `actorID` and emitted no audit event at all, despite membership conferring
  every role a group holds — the same blast radius as a role grant. Added `actorID`,
  new `group.member_added`/`group.member_removed` RBAC-audit events (mirroring
  `LogGroupRoleAssigned`'s shape), and threaded the actor through the HTTP, gRPC, and
  CLI call sites. Live, attacker-triggerable-on-demand via `roles.assign`.

- **#234 (HIGH)** — `AddProjectMember`/`SetProjectMemberRole`/`RemoveProjectMember`
  (`internal/core/project_members.go`) bypassed `AssignUserRole`/`RemoveUserRole`
  despite the file's own header comment claiming otherwise, and the three HTTP
  handlers never read the caller's identity at all. Routed through the audited
  wrappers and threaded `middleware.GetUserFromContext` into the handlers, matching
  sibling handlers in the same package. Same `roles.assign` permission as the
  fully-audited `/user-roles` path for an identical effect.

- **#297 (MEDIUM)** — SSO login-time role reconciliation (`reconcileSSORoles`,
  `internal/core/sso.go`) grants IdP-mapped roles via direct storage calls on every
  login; the existing `auth.sso_roles_synced` event is a coarse aggregate count
  outside the RBAC-audit allowlist. Routed through `AssignUserRole`/`RemoveUserRole`
  so each individual change is visible to RBAC audit review.

- **#298 (MEDIUM)** — Access-request approval (`ApproveAccessRequestWithExpiry`,
  `internal/core/invitations.go`) granted roles via direct storage calls on a live,
  self-service dual-control path; only a free-text `access_request.approved` event
  existed. Routed both the immediate and TTL-bound grant branches through
  `AssignUserRole`/`AssignUserRoleWithExpiry`.

- **#299 (MEDIUM)** — Global-invitation acceptance (`applyInvitationGrants`,
  `internal/core/invitations.go`) granted the invite's `SystemRole` — which can be
  `super_admin` — via a direct storage call with ZERO adjacent audit event of any
  kind. Routed through `AssignUserRole`, attributed to the inviter.

- **#293 (LOW)** — Startup RBAC permission reconciliation
  (`internal/core/rbac_reconcile.go`, ADR-044) called the storage layer directly
  instead of the core `AssignPermissionToRole` wrapper. Routed through the wrapper
  with actor 0 ("system"), consistent with every other system-initiated audit event.
  Lowest priority: fires once per process start granting only pre-baked permissions
  to pre-baked roles — no attacker-controlled timing or content.

Each instance has a dedicated test proving the audit trail now records the grant
(actor, target, role) via `ListRBACAuditLogs`, where none existed before or the
existing event was too coarse to attribute.

## Test plan

- [x] `go build ./...`
- [x] `GOWORK=off go build -C operator ./...`
- [x] `go test ./...` (full suite passes; one known unrelated flake in
      `internal/audit/siem` `TestSpool_PersistsAndReplaysOnRecovery` — passes in
      isolation)
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues
- [x] `golangci-lint run ./...` — 0 issues
- [x] New/updated tests per instance:
  - `TestGroupMembershipAudit` (#233)
  - `TestProjectMemberGrantIsRBACAudited` (#234)
  - `TestReconcileSSORoles_IsRBACAudited` (#297)
  - `TestApproveAccessRequestWithExpiry_IsRBACAudited` (#298)
  - `TestApplyInvitationGrants_SystemRoleIsRBACAudited` (#299)
  - `TestReconcileRBAC_GrantsAreRBACAudited` (#293)

🤖 Generated with [Claude Code](https://claude.com/claude-code)