### PR TITLE
harden(rbac): close deleted_at gap on GetMachineRoleIDsAt (#312 HIGH, #308 LOW)

### DIFF
--- a/internal/core/connect_rbac_test.go
+++ b/internal/core/connect_rbac_test.go
@@ -23,6 +23,7 @@ func connectRBACCore(t *testing.T, conns ...connect.Connector) (*KeyorixCore, *g
 		&models.Role{}, &models.UserRole{}, &models.MachineIdentityRole{},
 		&models.Group{}, &models.UserGroup{}, &models.GroupRole{},
 		&models.ConnectRefGrant{}, &models.AuditEvent{},
+		&models.Project{}, &models.Environment{},
 	))
 	c := &KeyorixCore{storage: store.NewLocalStorage(db)}
 	if len(conns) > 0 {

--- a/internal/storage/store/local_machine_credentials.go
+++ b/internal/storage/store/local_machine_credentials.go
@@ -136,20 +136,44 @@ func (ls *LocalStorage) RemoveMachineRole(ctx context.Context, machineID, roleID
 // GetMachineRoleIDsAt returns the role IDs granted to the machine that apply at
 // the target scope — a grant applies when its project is global or equal AND its
 // environment is global or equal (mirrors GetUserRoleIDsAt).
+//
+// A scoped (non-zero) project_id/environment_id must ALSO NOT resolve to a
+// soft-deleted project/environment row — mirroring the deleted_at join
+// GetUserRoleIDsAt/GetUserGroupRoleIDsAt apply for the same reason (#161/#312).
+// Without it, a machine role bound directly to a project/environment ID keeps
+// authorizing regardless of that project's/environment's own soft-delete state,
+// so deletion doesn't work as an access boundary for machine principals either.
+// The LEFT JOINs (not INNER) are required because project_id/environment_id 0
+// means "global" and has no corresponding row to join against — the "= 0 OR ..."
+// clause short-circuits before the joined columns are consulted in that case; a
+// scoped project_id/environment_id with no matching row at all (the joined column
+// is SQL NULL) is treated as not-deleted, same as every other "unknown" scope ID
+// this query already tolerates.
 func (ls *LocalStorage) GetMachineRoleIDsAt(ctx context.Context, machineID uint, scope storage.Scope) ([]uint, error) {
 	var ids []uint
 	err := ls.db.WithContext(ctx).Model(&models.MachineIdentityRole{}).
-		Where("machine_identity_id = ?", machineID).
-		Where("project_id = 0 OR project_id = ?", scope.ProjectID).
-		Where("environment_id = 0 OR environment_id = ?", scope.EnvironmentID).
-		Distinct().Pluck("role_id", &ids).Error
+		Joins("LEFT JOIN projects ON projects.id = machine_identity_roles.project_id").
+		Joins("LEFT JOIN environments ON environments.id = machine_identity_roles.environment_id").
+		Where("machine_identity_roles.machine_identity_id = ?", machineID).
+		Where("machine_identity_roles.project_id = 0 OR (machine_identity_roles.project_id = ? AND projects.deleted_at IS NULL)", scope.ProjectID).
+		Where("machine_identity_roles.environment_id = 0 OR (machine_identity_roles.environment_id = ? AND environments.deleted_at IS NULL)", scope.EnvironmentID).
+		Distinct().Pluck("machine_identity_roles.role_id", &ids).Error
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
 	}
 	return ids, nil
 }
 
-// GetMachineRoles returns every role granted to the machine (any scope), for display.
+// GetMachineRoles returns every role granted to the machine (any scope), for
+// display only (e.g. rendering a machine's role list in an admin UI/CLI).
+//
+// It is intentionally UNSCOPED — it returns roles across every project/
+// environment flattened into one list, with no deleted_at gate on the scope
+// project/environment (unlike GetMachineRoleIDsAt). Do NOT reuse this result
+// for an authorization decision: pair it with an unscoped role-name check (e.g.
+// RequireRole, see its own warning) on a machine-token-reachable route and a
+// role granted only for a now-soft-deleted or entirely different project would
+// wrongly authorize (#308). Use GetMachineRoleIDsAt for any authorization path.
 func (ls *LocalStorage) GetMachineRoles(ctx context.Context, machineID uint) ([]*models.Role, error) {
 	var roles []*models.Role
 	err := ls.db.WithContext(ctx).Table("roles").

--- a/internal/storage/store/local_machine_credentials_test.go
+++ b/internal/storage/store/local_machine_credentials_test.go
@@ -19,6 +19,7 @@ func newMachineCredTestStore(t *testing.T) *LocalStorage {
 	require.NoError(t, err)
 	require.NoError(t, db.AutoMigrate(
 		&models.MachineIdentityCredential{}, &models.MachineIdentityRole{}, &models.Role{},
+		&models.Project{}, &models.Environment{},
 	))
 	return NewLocalStorage(db)
 }
@@ -140,4 +141,56 @@ func TestMachineRoleGrantScopeResolution_EnvCrossLeak(t *testing.T) {
 	ids, err = ls.GetMachineRoleIDsAt(ctx, machineID, storage.Scope{ProjectID: 2})
 	require.NoError(t, err)
 	assert.Empty(t, ids, "an env-scoped grant does not apply at project-level env 0")
+}
+
+// #312: a machine role bound directly to a project must stop authorizing the
+// moment the project is soft-deleted, and resume once the project is restored —
+// mirroring GetUserRoleIDsAt's #161 fix (PR #568), for the machine-principal
+// path. Before this fix, GetMachineRoleIDsAt had no join against the projects
+// table at all, so a project-scoped machine role kept authorizing regardless of
+// the project's own soft-delete state.
+func TestGetMachineRoleIDsAt_DeletedProjectStopsAuthorizing(t *testing.T) {
+	ls := newMachineCredTestStore(t)
+	ctx := context.Background()
+	const machineID = uint(1)
+	require.NoError(t, ls.db.Create(&models.Project{ID: 5, Name: "proj-5"}).Error)
+	require.NoError(t, ls.AssignMachineRole(ctx, machineID, 20, storage.Scope{ProjectID: 5}))
+
+	ids, err := ls.GetMachineRoleIDsAt(ctx, machineID, storage.Scope{ProjectID: 5})
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []uint{20}, ids, "live project: the project-scoped grant authorizes")
+
+	require.NoError(t, ls.db.Delete(&models.Project{}, 5).Error)
+	ids, err = ls.GetMachineRoleIDsAt(ctx, machineID, storage.Scope{ProjectID: 5})
+	require.NoError(t, err)
+	assert.Empty(t, ids, "soft-deleted project: the grant must stop authorizing")
+
+	require.NoError(t, ls.db.Model(&models.Project{}).Unscoped().Where("id = ?", 5).Update("deleted_at", nil).Error)
+	ids, err = ls.GetMachineRoleIDsAt(ctx, machineID, storage.Scope{ProjectID: 5})
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []uint{20}, ids, "restored project: the grant authorizes again")
+}
+
+// #312: the same deleted_at gate applies to an ENVIRONMENT-scoped machine grant.
+func TestGetMachineRoleIDsAt_DeletedEnvironmentStopsAuthorizing(t *testing.T) {
+	ls := newMachineCredTestStore(t)
+	ctx := context.Background()
+	const machineID = uint(1)
+	require.NoError(t, ls.db.Create(&models.Project{ID: 5, Name: "proj-5"}).Error)
+	require.NoError(t, ls.db.Create(&models.Environment{ID: 9, ProjectID: 5, Name: "prod"}).Error)
+	require.NoError(t, ls.AssignMachineRole(ctx, machineID, 30, storage.Scope{ProjectID: 5, EnvironmentID: 9}))
+
+	ids, err := ls.GetMachineRoleIDsAt(ctx, machineID, storage.Scope{ProjectID: 5, EnvironmentID: 9})
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []uint{30}, ids, "live environment: the env-scoped grant authorizes")
+
+	require.NoError(t, ls.db.Delete(&models.Environment{}, 9).Error)
+	ids, err = ls.GetMachineRoleIDsAt(ctx, machineID, storage.Scope{ProjectID: 5, EnvironmentID: 9})
+	require.NoError(t, err)
+	assert.Empty(t, ids, "soft-deleted environment: the grant must stop authorizing")
+
+	require.NoError(t, ls.db.Model(&models.Environment{}).Unscoped().Where("id = ?", 9).Update("deleted_at", nil).Error)
+	ids, err = ls.GetMachineRoleIDsAt(ctx, machineID, storage.Scope{ProjectID: 5, EnvironmentID: 9})
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []uint{30}, ids, "restored environment: the grant authorizes again")
 }

--- a/server/middleware/auth.go
+++ b/server/middleware/auth.go
@@ -577,6 +577,15 @@ func derefUint(p *uint) uint {
 // which a deliberately-scoped token must not satisfy. This keeps PAT scoping
 // honoured on this role-based gate, which does not funnel through core.Authorize
 // (where the restriction is otherwise enforced). Fail-closed.
+//
+// WARNING (#308): this match is UNSCOPED — it checks only the role name against
+// userCtx.Roles, with no project/environment scope check at all. It currently has
+// no production route caller (only exercised by auth_test.go). Do NOT wire this
+// onto a machine-token-reachable route: combined with a machine identity's
+// unscoped role list (e.g. store.GetMachineRoles, itself for-display only, see
+// its own warning), it would bypass project/environment scoping entirely for
+// machine principals. If a role-based gate is ever needed on a scoped route, use
+// a scope-aware check (core.Authorize / the RBAC choke point) instead.
 func RequireRole(role string) func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
- #312 HIGH: `GetMachineRoleIDsAt` (`internal/storage/store/local_machine_credentials.go`) had the identical missing-`deleted_at`-join gap as #161, but sat outside that finding's stated fix scope (PR #568 fixed only `GetUserRoleIDsAt`/`GetUserGroupRoleIDsAt`). A machine identity (ADR-030) bound directly to a project/environment ID kept being authorized by `AuthorizePrincipal` on any project-scoped route a machine token can reach, even after that project/environment was soft-deleted. Fixed by adding the same `LEFT JOIN projects` / `LEFT JOIN environments` + `deleted_at IS NULL` gate PR #568 applied to the user/group variants.
- #308 LOW (doc-only, no behavior change): `RequireRole` middleware (`server/middleware/auth.go`) is an unscoped role-name match with zero production route callers today, and `GetMachineRoles` (`local_machine_credentials.go`) is an intentionally-unscoped "for display" query. Together, if either were ever wired into a real machine-token-reachable route, project/environment scoping would be bypassed. Added warning doc comments on both functions; no live bug today.

## Dependency on #568
PR #568 (`harden/round-high-admin-rank-ceiling-trio`) was still open (not merged) when this branch was cut, so this PR is based on current `main` rather than on #568's branch, and mirrors the join pattern from #568 directly (`git show origin/harden/round-high-admin-rank-ceiling-trio:internal/storage/store/local_rbac.go`) rather than depending on it landing first.

## Test plan
- [x] New regression tests in `internal/storage/store/local_machine_credentials_test.go`: `TestGetMachineRoleIDsAt_DeletedProjectStopsAuthorizing`, `TestGetMachineRoleIDsAt_DeletedEnvironmentStopsAuthorizing` — mirror the #161/#568 user-scope tests, for the machine-principal path (delete → grant stops authorizing → restore → grant authorizes again).
- [x] `go build ./...` clean
- [x] `go test ./...` full suite clean (including `internal/audit/siem`, no flake observed)
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues
- [x] `golangci-lint run ./...` — 0 issues
- [x] `GOWORK=off go build -C operator ./...` — clean