### PR TITLE
fix(securefiles): enforce perms on pre-existing files in SecureWriteFile (#296)

### DIFF
--- a/internal/cli/system/init.go
+++ b/internal/cli/system/init.go
@@ -137,7 +137,7 @@ func generateConfigFile() error {
 		return fmt.Errorf("failed to create config directory: %w", err)
 	}
 
-	if err := securefiles.SecureWriteFile(".", configPath, templateData, 0600); err != nil {
+	if err := securefiles.SecureWriteFileSync(".", configPath, templateData, 0600); err != nil {
 		return fmt.Errorf("failed to write config file: %w", err)
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1457,7 +1457,7 @@ func Save(path string, cfg *Config) error {
 		return fmt.Errorf("failed to marshal config: %w", err)
 	}
 
-	if err := securefiles.SecureWriteFile(appRootDir, path, data, 0600); err != nil {
+	if err := securefiles.SecureWriteFileSync(appRootDir, path, data, 0600); err != nil {
 		return fmt.Errorf("failed to write config file %q: %w", path, err)
 	}
 

--- a/internal/config/config_save_test.go
+++ b/internal/config/config_save_test.go
@@ -1,0 +1,28 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSaveEnforcesPermsOnExistingFile pins the #296 fix: Save() must tighten a
+// pre-existing keyorix.yaml's mode to 0600 rather than silently leaving a looser
+// mode in place. appRootDir is "." (the process's working directory), so the
+// test chdirs into a scratch directory to keep the write contained.
+func TestSaveEnforcesPermsOnExistingFile(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	const relPath = "keyorix.yaml"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, relPath), []byte("old: true\n"), 0644))
+
+	require.NoError(t, Save(relPath, &Config{Environment: "test"}))
+
+	info, err := os.Stat(filepath.Join(dir, relPath))
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0600), info.Mode().Perm())
+}

--- a/internal/core/evidence_export.go
+++ b/internal/core/evidence_export.go
@@ -81,7 +81,7 @@ func (c *KeyorixCore) ExportComplianceEvidence(ctx context.Context, outputDir st
 		if err := os.MkdirAll(outputDir, 0o700); err != nil {
 			return nil, fmt.Errorf("evidence export: create output dir: %w", err)
 		}
-		if err := securefiles.SecureWriteFile(outputDir, name, data, 0o600); err != nil {
+		if err := securefiles.SecureWriteFileSync(outputDir, name, data, 0o600); err != nil {
 			return nil, fmt.Errorf("evidence export: write: %w", err)
 		}
 		res.Path = filepath.Join(outputDir, name)
@@ -89,7 +89,7 @@ func (c *KeyorixCore) ExportComplianceEvidence(ctx context.Context, outputDir st
 		// Write the detached signature alongside the pack (verify with `keyorix
 		// compliance verify`). Best-effort: a sig-write failure must not lose the pack.
 		if signed {
-			_ = securefiles.SecureWriteFile(outputDir, name+".sig", []byte(signature), 0o600)
+			_ = securefiles.SecureWriteFileSync(outputDir, name+".sig", []byte(signature), 0o600)
 		}
 	}
 

--- a/internal/core/evidence_export_test.go
+++ b/internal/core/evidence_export_test.go
@@ -64,6 +64,33 @@ func TestExportComplianceEvidence_WritesFileAndAudits(t *testing.T) {
 	assert.Equal(t, int64(1), n)
 }
 
+// TestExportComplianceEvidence_EnforcesPermsOnExistingFile pins the #296 fix: a
+// pre-existing evidence pack (and its detached signature) at the export's target
+// path must have its mode tightened to 0600, not left at whatever looser mode a
+// prior file happened to have.
+func TestExportComplianceEvidence_EnforcesPermsOnExistingFile(t *testing.T) {
+	ctx := context.Background()
+	c, _, now := newEvidenceExportCore(t)
+	c.SetEvidenceSignKey([]byte("0123456789abcdef0123456789abcdef"), "v1")
+	dir := t.TempDir()
+
+	wantName := "keyorix-evidence-" + now.UTC().Format(evidenceFileTimeLayout) + ".json"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, wantName), []byte("stale"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, wantName+".sig"), []byte("stale-sig"), 0644))
+
+	res, err := c.ExportComplianceEvidence(ctx, dir)
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(dir, wantName), res.Path)
+
+	info, err := os.Stat(res.Path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0600), info.Mode().Perm(), "the evidence pack's mode must be tightened even though a looser-mode file pre-existed")
+
+	sigInfo, err := os.Stat(res.Path + ".sig")
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0600), sigInfo.Mode().Perm(), "the detached signature's mode must be tightened too")
+}
+
 func TestExportComplianceEvidence_SignsAndVerifies(t *testing.T) {
 	c, _, _ := newEvidenceExportCore(t)
 	c.SetEvidenceSignKey([]byte("0123456789abcdef0123456789abcdef"), "v1")

--- a/internal/securefiles/securefiles.go
+++ b/internal/securefiles/securefiles.go
@@ -97,7 +97,12 @@ func resolveInside(baseDir, path string) (string, error) {
 }
 
 // SecureWriteFile writes data to filepath.Join(baseDir, path), validating
-// that the resolved path remains inside baseDir.
+// that the resolved path remains inside baseDir. The file mode is enforced
+// even if the file pre-existed with a looser mode (O_CREATE|O_TRUNC alone
+// only applies perm at creation time and leaves an existing file's mode
+// untouched, so this Chmods explicitly after open — mirroring
+// SecureWriteFileSync, minus the fsync). Callers writing durability-critical
+// key material should prefer SecureWriteFileSync instead.
 func SecureWriteFile(baseDir, path string, data []byte, perm os.FileMode) error {
 	cleanPath, err := resolveInside(baseDir, path)
 	if err != nil {
@@ -110,6 +115,11 @@ func SecureWriteFile(baseDir, path string, data []byte, perm os.FileMode) error 
 	f, err := os.OpenFile(cleanPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC|syscall.O_NOFOLLOW, perm) // #nosec G304 -- cleanPath validated inside baseDir by resolveInside
 	if err != nil {
 		return err
+	}
+	// O_TRUNC keeps a pre-existing file's mode; force the intended perms.
+	if cerr := f.Chmod(perm); cerr != nil {
+		_ = f.Close()
+		return cerr
 	}
 	if _, werr := f.Write(data); werr != nil {
 		_ = f.Close()

--- a/internal/securefiles/securefiles_test.go
+++ b/internal/securefiles/securefiles_test.go
@@ -47,6 +47,22 @@ func TestSecureWriteAndReadRoundTrip(t *testing.T) {
 	assert.Equal(t, want, got)
 }
 
+func TestSecureWriteFileEnforcesPermsOnExistingFile(t *testing.T) {
+	base := t.TempDir()
+	// A pre-existing file with looser perms must be tightened to the requested mode
+	// (O_TRUNC alone keeps the old mode; the explicit Chmod fixes it) — same guarantee
+	// as SecureWriteFileSync, just without the fsync.
+	require.NoError(t, os.WriteFile(filepath.Join(base, "config.yaml"), []byte("old"), 0644))
+	require.NoError(t, SecureWriteFile(base, "config.yaml", []byte("new"), 0600))
+
+	info, err := os.Stat(filepath.Join(base, "config.yaml"))
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0600), info.Mode().Perm())
+	got, err := SafeReadFile(base, "config.yaml")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("new"), got)
+}
+
 func TestSecureWriteFileSyncRoundTripAndPerms(t *testing.T) {
 	base := t.TempDir()
 	want := []byte("durable-key-bytes")


### PR DESCRIPTION
## Summary

Fixes #296 MEDIUM: `securefiles.SecureWriteFile` (the non-`Sync` variant) never enforced the requested file permission on a **pre-existing** file at the target path — `O_CREATE` only applies the `perm` argument at creation time, so a looser mode already on disk (restored from backup, rsync, umask drift, etc.) silently survived every subsequent write, including config saves and evidence-pack exports. This is exactly the "permission-only-on-creation" bug class this campaign hunts, present in the shared "safe" write helper itself.

`SecureWriteFileSync` (same file) already closed this with an explicit `f.Chmod(perm)` after open, proven by `TestSecureWriteFileSyncEnforcesPermsOnExistingFile` — `SecureWriteFile` had no such guarantee or test.

## Changes

- **Root-cause fix**: `SecureWriteFile` now does the same `f.Chmod(perm)` after open as its `Sync` sibling (keeping the lack of `fsync`, which is `Sync`'s distinguishing durability guarantee, not a permission one) — so the guarantee holds regardless of which variant a future caller picks.
- **Confirmed callers switched to `SecureWriteFileSync`** (both for the permission fix and the durability bonus, since none of these are hot paths):
  - `internal/config/config.go` (`Save()`, writes `keyorix.yaml`, mode 0600)
  - `internal/core/evidence_export.go` (compliance evidence pack + detached signature, two call sites)
  - `internal/cli/system/init.go` (initial config template)
- Grepped the whole repo for remaining `securefiles.SecureWriteFile(` (non-`Sync`) callers outside the package — none left.

## Regression tests

- `internal/securefiles/securefiles_test.go`: `TestSecureWriteFileEnforcesPermsOnExistingFile` — mirrors the existing `...Sync` test, proves `SecureWriteFile` now tightens a pre-existing 0644 file to 0600.
- `internal/config/config_save_test.go` (new): `TestSaveEnforcesPermsOnExistingFile` — `config.Save()` now tightens a pre-existing looser-mode `keyorix.yaml`.
- `internal/core/evidence_export_test.go`: `TestExportComplianceEvidence_EnforcesPermsOnExistingFile` — a pre-existing loose-mode evidence pack + detached `.sig` are both tightened to 0600 on export.

## Backlog hygiene (informational only — not touched in this PR)

Per the task, grepped `docs/security/HARDENING-BACKLOG.md` (from `origin/security/hardening-backlog`) for any earlier finding that names bare `securefiles.SecureWriteFile` (not `...Sync`) as *its own recommended fix* for a raw-`os.WriteFile` permission bug:

- No such finding exists. The two literal matches for "just call `securefiles.SecureWriteFile`" are self-referential text inside #296's own write-up/round-54 summary, not a mistake in an earlier entry.
- **#206 MED** (earlier, predates #296) independently identified this same `SecureWriteFile` gap and correctly recommended the root-cause `Chmod` fix (not "just switch to the bare helper") — this PR fulfills that recommendation. #206 also named `internal/cli/config/config.go` (`auth login`/`config set-remote`/`config use-local`) as an affected caller; that's indirect via `config.Save()`, which this PR now hardens, so that sub-case is resolved. #206 separately flags `SaveCLIConfig` (`internal/cli/config/cli_config.go:140`, a raw `os.WriteFile` that never goes through `securefiles` at all) as still open — out of scope here since it's not a `securefiles.SecureWriteFile` caller.
- **#269 LOW** (Shamir CLI share writer) correctly recommends `SecureWriteFileSync`, not the bare variant — no correction needed.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` full suite green (including `internal/audit/siem`, the known-flaky package — passed on this run)
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues
- [x] `golangci-lint run ./...` — 0 issues
- [x] `GOWORK=off go build -C operator ./...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)