### PR TITLE
fix(sharing): copy ExpiresAt in the CreateShareRecord upsert path (#282)

### DIFF
--- a/internal/core/shares_expiry_test.go
+++ b/internal/core/shares_expiry_test.go
@@ -189,6 +189,87 @@ func TestUpdateShareExpiry(t *testing.T) {
 	})
 }
 
+// TestReShareTightensExpiry is the regression test for #282: re-sharing an
+// already-shared secret (the CreateShareRecord upsert path, reached from both
+// ShareSecret and ShareSecretWithGroup) must persist a newly-requested ExpiresAt
+// onto the existing row — not silently drop it — so an owner can time-bound or
+// shorten an existing indefinite grant. Uses the real sqlite-backed LocalStorage
+// fixture (no mocks) so the assertions exercise the actual upsert SQL, not a
+// hand-rolled double.
+func TestReShareTightensExpiry(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("direct share: re-sharing a permanent grant with an expiry persists it", func(t *testing.T) {
+		c, secretID, now, _ := newSharesExpiryFixture(t)
+		rec, err := c.ShareSecret(ctx, &ShareSecretRequest{
+			SecretID: secretID, RecipientID: 2, Permission: "read", SharedBy: 1,
+		})
+		require.NoError(t, err)
+		require.Nil(t, rec.ExpiresAt, "initial share must be permanent")
+
+		exp := now.Add(time.Hour)
+		reshared, err := c.ShareSecret(ctx, &ShareSecretRequest{
+			SecretID: secretID, RecipientID: 2, Permission: "read", SharedBy: 1, ExpiresAt: &exp,
+		})
+		require.NoError(t, err)
+		require.Equal(t, rec.ID, reshared.ID, "re-share must upsert onto the same row, not create a duplicate")
+		require.NotNil(t, reshared.ExpiresAt, "re-share must tighten the returned record's expiry")
+		assert.True(t, reshared.ExpiresAt.Equal(exp))
+
+		// Re-fetch independently from storage to prove the tightened expiry was
+		// actually persisted, not just reflected on the in-memory return value.
+		persisted, err := c.storage.GetShareRecord(ctx, rec.ID)
+		require.NoError(t, err)
+		require.NotNil(t, persisted.ExpiresAt, "persisted row must carry the tightened expiry")
+		assert.True(t, persisted.ExpiresAt.Equal(exp))
+	})
+
+	t.Run("direct share: re-sharing without an expiry clears a prior one back to permanent", func(t *testing.T) {
+		c, secretID, now, _ := newSharesExpiryFixture(t)
+		exp := now.Add(time.Hour)
+		rec, err := c.ShareSecret(ctx, &ShareSecretRequest{
+			SecretID: secretID, RecipientID: 2, Permission: "read", SharedBy: 1, ExpiresAt: &exp,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, rec.ExpiresAt)
+
+		reshared, err := c.ShareSecret(ctx, &ShareSecretRequest{
+			SecretID: secretID, RecipientID: 2, Permission: "read", SharedBy: 1,
+		})
+		require.NoError(t, err)
+		assert.Nil(t, reshared.ExpiresAt, "re-share with no ExpiresAt must clear it back to permanent")
+
+		persisted, err := c.storage.GetShareRecord(ctx, rec.ID)
+		require.NoError(t, err)
+		assert.Nil(t, persisted.ExpiresAt, "persisted row must reflect the cleared expiry")
+	})
+
+	t.Run("group share: re-sharing a permanent grant with an expiry persists it", func(t *testing.T) {
+		c, secretID, now, db := newSharesExpiryFixture(t)
+		require.NoError(t, db.Create(&models.Group{ID: 10, Name: "eng"}).Error)
+
+		rec, err := c.ShareSecretWithGroup(ctx, &GroupShareSecretRequest{
+			SecretID: secretID, GroupID: 10, Permission: "read", SharedBy: 1,
+		})
+		require.NoError(t, err)
+		require.Nil(t, rec.ExpiresAt, "initial group share must be permanent")
+
+		exp := now.Add(time.Hour)
+		reshared, err := c.ShareSecretWithGroup(ctx, &GroupShareSecretRequest{
+			SecretID: secretID, GroupID: 10, Permission: "read", SharedBy: 1, ExpiresAt: &exp,
+		})
+		require.NoError(t, err)
+		require.Equal(t, rec.ID, reshared.ID, "re-share must upsert onto the same row, not create a duplicate")
+		require.NotNil(t, reshared.ExpiresAt, "re-share must tighten the returned record's expiry")
+		assert.True(t, reshared.ExpiresAt.Equal(exp))
+
+		persisted, err := c.storage.GetShareRecord(ctx, rec.ID)
+		require.NoError(t, err)
+		require.NotNil(t, persisted.ExpiresAt, "persisted row must carry the tightened expiry")
+		assert.True(t, persisted.ExpiresAt.Equal(exp))
+	})
+}
+
 func TestListUserShareViews(t *testing.T) {
 	ctx := context.Background()
 	c, secretID, now, _ := newSharesExpiryFixture(t)

--- a/internal/storage/store/local_sharing.go
+++ b/internal/storage/store/local_sharing.go
@@ -60,6 +60,11 @@ func (ls *LocalStorage) CreateShareRecord(ctx context.Context, share *models.Sha
 
 	if result.Error == nil {
 		existing.Permission = share.Permission
+		// ExpiresAt reflects the caller's requested value verbatim (nil = permanent,
+		// non-nil = time-bound), mirroring UpdateShareRecord's behaviour — a re-share
+		// must be able to tighten (or clear) an existing grant's expiry, not just its
+		// permission. Save writes nil as NULL.
+		existing.ExpiresAt = share.ExpiresAt
 		existing.UpdatedAt = time.Now()
 		if err := ls.db.Save(&existing).Error; err != nil {
 			return nil, fmt.Errorf("%s: %w", i18n.T("ErrorDatabaseOperation", nil), err)


### PR DESCRIPTION
## Summary

- Fixes #282 (MEDIUM): re-sharing an already-shared secret via `ShareSecret` or `ShareSecretWithGroup` went through `LocalStorage.CreateShareRecord`'s upsert branch, which copied only `Permission` onto the existing row and silently dropped the caller's requested `ExpiresAt`. An owner trying to time-bound or shorten an existing indefinite grant had no effect — and no error.
- The ID-based `UpdateSharePermission` -> `storage.UpdateShareRecord` path already copied `ExpiresAt` correctly; the upsert path in `CreateShareRecord` is now brought in line with it, copying `share.ExpiresAt` (including `nil`, to clear back to permanent) onto `existing`.

## Test plan

- [x] New regression test `TestReShareTightensExpiry` in `internal/core/shares_expiry_test.go`, using a real sqlite-backed `LocalStorage` harness (no mocks): covers re-sharing to set/tighten an expiry and to clear one back to permanent, via both the direct-share (`ShareSecret`) and group-share (`ShareSecretWithGroup`) paths. Confirmed the test fails without the fix and passes with it.
- [x] `go build ./...` clean
- [x] `go test ./...` full suite clean (including `internal/audit/siem`, no flake observed)
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues
- [x] `golangci-lint run ./...` — 0 issues
- [x] `GOWORK=off go build -C operator ./...` — clean build

🤖 Generated with [Claude Code](https://claude.com/claude-code)