### PR TITLE
fix(license): honor configured deployment_id in bundle import (#286)

### DIFF
--- a/internal/cli/bundle/bundle.go
+++ b/internal/cli/bundle/bundle.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	ibundle "github.com/keyorixhq/keyorix/internal/bundle"
+	"github.com/keyorixhq/keyorix/internal/config"
 	ilicense "github.com/keyorixhq/keyorix/internal/license"
 	"github.com/keyorixhq/keyorix/internal/trust"
 	"github.com/spf13/cobra"
@@ -202,7 +203,7 @@ func requireAirgapUpdates(reg *trust.KeyRegistry) error {
 		}
 		token = strings.TrimSpace(string(b))
 	}
-	st := ilicense.Evaluate(token, reg, "", time.Now(), 14*24*time.Hour)
+	st := ilicense.Evaluate(token, reg, configuredDeploymentID(), time.Now(), 14*24*time.Hour)
 	if st.HasFeature(ilicense.FeatureAirgapUpdates) {
 		return nil
 	}
@@ -210,6 +211,21 @@ func requireAirgapUpdates(reg *trust.KeyRegistry) error {
 		"(current state: %s). Install one with `keyorix license install` and pass it via --license, "+
 		"or check `keyorix license status`. `bundle verify` remains available without a license",
 		ilicense.FeatureAirgapUpdates, st.State)
+}
+
+// configuredDeploymentID best-effort loads the local server config and returns the
+// operator's configured license.deployment_id, so `bundle import` honors an anti-copy
+// deployment binding the operator has already set — the same value the server itself
+// passes to license.NewGate (server/main.go) and that `keyorix license install/status`
+// accept via --deployment-id. If no config file is found (or it can't be read), this
+// returns "", matching the previous hardcoded default: an operator who has never
+// configured license.deployment_id sees no change in behavior.
+func configuredDeploymentID() string {
+	cfg, err := config.Load("")
+	if err != nil {
+		return ""
+	}
+	return cfg.License.DeploymentID
 }
 
 func init() {

--- a/internal/cli/bundle/gate_test.go
+++ b/internal/cli/bundle/gate_test.go
@@ -70,3 +70,87 @@ func TestRequireAirgapUpdates_Untrusted_Refused(t *testing.T) {
 		t.Fatal("an untrusted license must be refused")
 	}
 }
+
+// licenseTokBoundTo issues a license bound to the given deployment id (anti-copy binding),
+// mirroring licenseTok above.
+func licenseTokBoundTo(t *testing.T, deploymentID string, features []string) (string, *trust.KeyRegistry) {
+	t.Helper()
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	token, err := ilicense.Issue(ilicense.License{
+		Licensee: "ACME", Plan: "enterprise-airgap", Features: features,
+		IssuedAt: time.Now().Add(-time.Hour), NotAfter: time.Now().Add(365 * 24 * time.Hour),
+		DeploymentID: deploymentID,
+		KeyID:        "license-2026",
+	}, priv)
+	if err != nil {
+		t.Fatalf("issue: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "license.tok")
+	if err := os.WriteFile(path, []byte(token), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	reg := trust.NewRegistry()
+	_ = reg.Add(trust.PurposeLicense, "license-2026", pub)
+	return path, reg
+}
+
+// writeConfigWithDeploymentID writes a minimal keyorix.yaml configuring
+// license.deployment_id and points KEYORIX_CONFIG_PATH at it for the duration of the test.
+func writeConfigWithDeploymentID(t *testing.T, deploymentID string) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "keyorix.yaml")
+	yaml := "license:\n  deployment_id: \"" + deploymentID + "\"\n"
+	if err := os.WriteFile(path, []byte(yaml), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	t.Setenv("KEYORIX_CONFIG_PATH", path)
+}
+
+// Regression test for #286: `bundle import` used to hardcode Evaluate(token, reg, "", ...),
+// so it never enforced an operator's own configured license.deployment_id anti-copy binding.
+// It must now pass the configured value through.
+func TestRequireAirgapUpdates_ConfiguredDeploymentID_PassedThrough(t *testing.T) {
+	writeConfigWithDeploymentID(t, "deployment-a")
+
+	// A license bound to the SAME deployment the operator configured must be granted.
+	matchPath, matchReg := licenseTokBoundTo(t, "deployment-a", []string{ilicense.FeatureAirgapUpdates})
+	importLicense = matchPath
+	if err := requireAirgapUpdates(matchReg); err != nil {
+		t.Fatalf("license bound to the configured deployment id should pass: %v", err)
+	}
+
+	// A license bound to a DIFFERENT deployment (e.g. copied from another customer) must now
+	// be refused — this only happens if the configured deployment id actually reaches Evaluate.
+	mismatchPath, mismatchReg := licenseTokBoundTo(t, "deployment-b", []string{ilicense.FeatureAirgapUpdates})
+	importLicense = mismatchPath
+	t.Cleanup(func() { importLicense = "" })
+	err := requireAirgapUpdates(mismatchReg)
+	if err == nil {
+		t.Fatal("a license bound to a different deployment must be refused once deployment_id is configured")
+	}
+}
+
+// Regression test for #286: with NO configured license.deployment_id (the default, unopted-in
+// posture), behavior must be exactly what it was before the fix — Evaluate still receives "".
+func TestRequireAirgapUpdates_UnconfiguredDeploymentID_BehaviorUnchanged(t *testing.T) {
+	// Point at a config path that does not exist, so configuredDeploymentID() falls back to
+	// "" exactly as the old hardcoded call site did, regardless of the host's real environment.
+	t.Setenv("KEYORIX_CONFIG_PATH", filepath.Join(t.TempDir(), "does-not-exist.yaml"))
+
+	// An unbound license (no deployment_id on the token) still passes — unaffected either way.
+	unboundPath, unboundReg := licenseTok(t, []string{ilicense.FeatureAirgapUpdates})
+	importLicense = unboundPath
+	if err := requireAirgapUpdates(unboundReg); err != nil {
+		t.Fatalf("an unbound license must still pass with no deployment configured: %v", err)
+	}
+
+	// A license bound to a specific deployment is refused when this deployment has no
+	// deployment_id configured — same fail-closed anti-bypass behavior as before the fix
+	// (internal/license/license.go's Evaluate: "no deployment_id configured" degrades).
+	boundPath, boundReg := licenseTokBoundTo(t, "deployment-a", []string{ilicense.FeatureAirgapUpdates})
+	importLicense = boundPath
+	t.Cleanup(func() { importLicense = "" })
+	if err := requireAirgapUpdates(boundReg); err == nil {
+		t.Fatal("a deployment-bound license must still be refused when no deployment_id is configured")
+	}
+}


### PR DESCRIPTION
## Summary
- Fixes #286 LOW: `bundle import`'s license gate (`requireAirgapUpdates` in `internal/cli/bundle/bundle.go`) hardcoded `Evaluate(token, reg, "", ...)`, so it never enforced an operator's own configured `license.deployment_id` anti-copy binding — no `--deployment-id`-equivalent flag existed, and the command silently ignored a configured value.
- Adds `configuredDeploymentID()`, which best-effort loads the local server config (same `config.Load("")` used elsewhere) and passes `cfg.License.DeploymentID` through to `Evaluate`, mirroring the pattern already used by `server/main.go` (`license.NewGate`) and `keyorix license install/status`.
- This is purely additive: when `license.deployment_id` is unconfigured (the default), `configuredDeploymentID()` still returns `""`, so `Evaluate` receives the same empty value it always did — no change to default/unconfigured behavior. The opt-in anti-copy binding design itself (checked only when configured) is intentional and untouched.

## Test plan
- [x] New regression tests in `internal/cli/bundle/gate_test.go`:
  - `TestRequireAirgapUpdates_ConfiguredDeploymentID_PassedThrough` — with `license.deployment_id` configured, a license bound to the *same* deployment passes and one bound to a *different* deployment is now refused (only possible if the configured value actually reaches `Evaluate`).
  - `TestRequireAirgapUpdates_UnconfiguredDeploymentID_BehaviorUnchanged` — with no config file present, behavior matches the pre-fix hardcoded `""` exactly (unbound licenses still pass; deployment-bound licenses are still refused when nothing is configured).
- [x] `go build ./...` clean
- [x] `go test ./...` clean (full suite, including `internal/audit/siem`)
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues
- [x] `golangci-lint run ./...` — 0 issues
- [x] `GOWORK=off go build -C operator ./...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)