### PR TITLE
fix(legal-hold): close PlaceLegalHold TOCTOU with a partial unique index (#305)

### DIFF
--- a/internal/core/concurrency_legal_hold_test.go
+++ b/internal/core/concurrency_legal_hold_test.go
@@ -1,0 +1,87 @@
+package core_test
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// TestConcurrency_PlaceLegalHold_OnlyOneWins is the TOCTOU regression for #305.
+// PlaceLegalHold's own "no active hold" check and its insert are not atomic, so
+// many concurrent callers can all pass the check before any of them commits. The
+// partial unique index on legal_holds (released) WHERE released = false (created by
+// storage.ensureLegalHoldActiveIndex in production; replicated here per the
+// TestGroupSoftDelete_NameReuse convention) must let exactly one insert win and
+// reject every other one with a client error rather than creating a second,
+// orphaned active-hold row. Uses a file-backed SQLite (real multi-connection
+// concurrency), run under -race.
+func TestConcurrency_PlaceLegalHold_OnlyOneWins(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	dsn := "file:" + filepath.Join(t.TempDir(), "c.db") + "?_busy_timeout=10000&_journal_mode=WAL&_txlock=immediate"
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.LegalHold{}, &models.AuditEvent{}))
+	// The production migration (storage.ensureLegalHoldActiveIndex) creates this;
+	// replicate it for the test DB.
+	require.NoError(t, db.Exec(
+		"CREATE UNIQUE INDEX uniq_legal_holds_active ON legal_holds (released) WHERE released = false",
+	).Error)
+
+	c := core.NewKeyorixCore(store.NewLocalStorage(db))
+	ctx := context.Background()
+
+	const callers = 32
+	var succeeded atomic.Int64
+	unexpected := make(chan error, callers)
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < callers; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			<-start
+			_, perr := c.PlaceLegalHold(ctx, 1, "concurrent litigation hold")
+			if perr == nil {
+				succeeded.Add(1)
+				return
+			}
+			// The only expected failure is "already active" — PlaceLegalHold
+			// returns this same client-facing message whether it came from the
+			// pre-check or from the storage.ErrLegalHoldAlreadyActive mapping.
+			if !strings.Contains(perr.Error(), "already active") {
+				unexpected <- perr
+			}
+		}(i)
+	}
+	close(start) // release all callers simultaneously
+	wg.Wait()
+	close(unexpected)
+	for e := range unexpected {
+		require.NoError(t, e)
+	}
+
+	assert.Equal(t, int64(1), succeeded.Load(), "exactly one concurrent PlaceLegalHold call may succeed")
+
+	// No orphaned duplicate: exactly one row, and it is the active one
+	// GetActiveLegalHold reports.
+	var count int64
+	require.NoError(t, db.Model(&models.LegalHold{}).Where("released = ?", false).Count(&count).Error)
+	assert.Equal(t, int64(1), count, "the DB must contain exactly one active hold row, never a duplicate")
+
+	active, err := c.GetActiveLegalHold(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, active)
+	assert.False(t, active.Released)
+}

--- a/internal/core/legal_hold.go
+++ b/internal/core/legal_hold.go
@@ -7,8 +7,10 @@ package core
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
+	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
@@ -54,6 +56,14 @@ func (c *KeyorixCore) legalHoldGuard(ctx context.Context) error {
 
 // PlaceLegalHold activates a deployment-wide legal hold with a reason. Refuses if a
 // hold is already active. actorID is the placing admin.
+//
+// The active check below and the insert in CreateLegalHold are not atomic: two
+// concurrent calls can both observe "no active hold" before either commits (#305).
+// That TOCTOU window fails SAFE, not open — a partial unique index on legal_holds
+// (released) WHERE released = false means only one of the two inserts can succeed,
+// and the loser's CreateLegalHold returns storage.ErrLegalHoldAlreadyActive, which
+// is mapped to the same "already active" client error as the pre-check below rather
+// than a 500.
 func (c *KeyorixCore) PlaceLegalHold(ctx context.Context, actorID uint, reason string) (*models.LegalHold, error) {
 	if reason == "" {
 		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "a reason is required to place a legal hold")
@@ -66,6 +76,9 @@ func (c *KeyorixCore) PlaceLegalHold(ctx context.Context, actorID uint, reason s
 	hold, err := c.storage.CreateLegalHold(ctx, &models.LegalHold{
 		Reason: reason, PlacedBy: actorID, PlacedAt: c.now(), Released: false,
 	})
+	if errors.Is(err, storage.ErrLegalHoldAlreadyActive) {
+		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "a legal hold is already active")
+	}
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -2,10 +2,19 @@ package storage
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
+
+// ErrLegalHoldAlreadyActive is returned by CreateLegalHold when a partial unique
+// index (or equivalent constraint) at the storage layer rejects a second concurrent
+// placement — the backstop for the TOCTOU race in core.PlaceLegalHold's
+// read-then-insert (#305): two concurrent placements can both observe "no active
+// hold" and both attempt to insert one, but only the first commits. Callers should
+// treat this as a client error ("already active"), not a storage failure.
+var ErrLegalHoldAlreadyActive = errors.New("a legal hold is already active")
 
 // Storage defines the unified interface for data persistence operations
 // This interface abstracts away the underlying storage implementation,

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -507,6 +507,15 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 			return fmt.Errorf("failed to migrate legal_holds table: %w", err)
 		}
 	}
+	// At most one legal hold may be active (released = false) at a time — a plain
+	// check-then-insert in core.PlaceLegalHold has a TOCTOU window (#305): two
+	// concurrent placements can both observe "no active hold" and both insert one,
+	// orphaning a row that GetActiveLegalHold's highest-id lookup never surfaces
+	// again, so lifting the hold an operator sees leaves purges permanently blocked.
+	// Close the race at the DB layer regardless of whether the table pre-existed.
+	if err := ensureLegalHoldActiveIndex(db); err != nil {
+		return err
+	}
 
 	// Create the risk-exceptions table if missing (A.5.8 risk treatment, additive).
 	if !riskExceptionExists {
@@ -718,6 +727,20 @@ func ensureUserNameIndex(db *gorm.DB) error {
 	}
 	if err := db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS uniq_users_username_active ON users (username) WHERE deleted_at IS NULL").Error; err != nil {
 		return fmt.Errorf("failed to create partial users username index: %w", err)
+	}
+	return nil
+}
+
+// ensureLegalHoldActiveIndex creates a partial unique index that permits at most one
+// un-released (released = false) row in legal_holds at a time, closing the
+// place-hold TOCTOU race (#305): since every row matching the predicate shares the
+// same released=false value, uniqueness on that column caps the table at one such
+// row, and a second concurrent INSERT is rejected by the DB instead of silently
+// creating an orphaned duplicate hold. Idempotent; works on both SQLite and Postgres
+// (both support partial indexes and IF NOT EXISTS).
+func ensureLegalHoldActiveIndex(db *gorm.DB) error {
+	if err := db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS uniq_legal_holds_active ON legal_holds (released) WHERE released = false").Error; err != nil {
+		return fmt.Errorf("failed to create partial legal_holds active index: %w", err)
 	}
 	return nil
 }

--- a/internal/storage/store/local_legal_hold.go
+++ b/internal/storage/store/local_legal_hold.go
@@ -6,18 +6,41 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"gorm.io/gorm"
 
+	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
+// CreateLegalHold inserts a hold row. A partial unique index on legal_holds
+// (released) WHERE released = false (see storage.ensureLegalHoldActiveIndex) allows
+// at most one un-released row at a time, so a second concurrent placement — which
+// core.PlaceLegalHold's own read-then-insert check cannot fully exclude (#305) —
+// fails here with a UNIQUE-constraint violation instead of creating a duplicate
+// active row. That violation is surfaced as storage.ErrLegalHoldAlreadyActive so
+// the caller can map it to a client error rather than a 500.
 func (ls *LocalStorage) CreateLegalHold(ctx context.Context, h *models.LegalHold) (*models.LegalHold, error) {
 	if err := ls.db.WithContext(ctx).Create(h).Error; err != nil {
+		if isUniqueConstraintErr(err) {
+			return nil, storage.ErrLegalHoldAlreadyActive
+		}
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}
 	return h, nil
+}
+
+// isUniqueConstraintErr reports whether err is a UNIQUE-constraint violation from the
+// SQLite or Postgres driver. GORM only maps driver errors to gorm.ErrDuplicatedKey
+// when opened with TranslateError (this app does not set that), so the driver's raw
+// message is matched instead: mattn/go-sqlite3 says "UNIQUE constraint failed";
+// pgx/lib/pq say "duplicate key value violates unique constraint".
+func isUniqueConstraintErr(err error) bool {
+	msg := err.Error()
+	return strings.Contains(msg, "UNIQUE constraint failed") ||
+		strings.Contains(msg, "duplicate key value violates unique constraint")
 }
 
 // GetActiveLegalHold returns the current un-released hold, or (nil, nil) when none

--- a/internal/storage/store/local_legal_hold_test.go
+++ b/internal/storage/store/local_legal_hold_test.go
@@ -1,0 +1,108 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	corestorage "github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newLegalHoldStore(t *testing.T) *LocalStorage {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	db := concurrentDB(t)
+	require.NoError(t, db.AutoMigrate(&models.LegalHold{}))
+	// The production migration (storage.ensureLegalHoldActiveIndex) creates this;
+	// replicate it for the test DB, per the TestGroupSoftDelete_NameReuse convention.
+	require.NoError(t, db.Exec(
+		"CREATE UNIQUE INDEX uniq_legal_holds_active ON legal_holds (released) WHERE released = false",
+	).Error)
+	return NewLocalStorage(db)
+}
+
+// The partial unique index rejects a second concurrent un-released row (#305), and
+// the rejection surfaces as the ErrLegalHoldAlreadyActive sentinel — not a generic
+// storage error — so callers can map it to a client error.
+func TestLegalHold_ActiveIndexRejectsDuplicate(t *testing.T) {
+	ls := newLegalHoldStore(t)
+	ctx := context.Background()
+
+	_, err := ls.CreateLegalHold(ctx, &models.LegalHold{Reason: "first", PlacedBy: 1})
+	require.NoError(t, err)
+
+	_, err = ls.CreateLegalHold(ctx, &models.LegalHold{Reason: "second", PlacedBy: 2})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, corestorage.ErrLegalHoldAlreadyActive),
+		"a duplicate active hold must surface as ErrLegalHoldAlreadyActive, not a generic storage error")
+
+	var count int64
+	require.NoError(t, ls.db.Model(&models.LegalHold{}).Where("released = ?", false).Count(&count).Error)
+	assert.Equal(t, int64(1), count, "the DB must contain exactly one active hold row")
+}
+
+// A released hold does not block a new one — the index only constrains released =
+// false rows.
+func TestLegalHold_ActiveIndexAllowsNewHoldAfterRelease(t *testing.T) {
+	ls := newLegalHoldStore(t)
+	ctx := context.Background()
+
+	first, err := ls.CreateLegalHold(ctx, &models.LegalHold{Reason: "first", PlacedBy: 1})
+	require.NoError(t, err)
+
+	first.Released = true
+	require.NoError(t, ls.UpdateLegalHold(ctx, first))
+
+	_, err = ls.CreateLegalHold(ctx, &models.LegalHold{Reason: "second", PlacedBy: 1})
+	require.NoError(t, err, "a new hold is allowed once the prior one is released")
+}
+
+// TestConcurrency_CreateLegalHold_OnlyOneWins drives many concurrent CreateLegalHold
+// calls at the raw storage layer (bypassing core.PlaceLegalHold's own pre-check
+// entirely) and asserts the DB-level unique index still allows exactly one to
+// succeed. This is the storage-layer backstop for the TOCTOU race in
+// core.PlaceLegalHold (#305): even if the application-level check-then-insert races,
+// the constraint here is what actually prevents two active rows from existing.
+func TestConcurrency_CreateLegalHold_OnlyOneWins(t *testing.T) {
+	ls := newLegalHoldStore(t)
+	ctx := context.Background()
+
+	const callers = 32
+	var succeeded atomic.Int64
+	unexpected := make(chan error, callers)
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < callers; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			<-start
+			_, cerr := ls.CreateLegalHold(ctx, &models.LegalHold{Reason: "concurrent", PlacedBy: uint(n)})
+			if cerr == nil {
+				succeeded.Add(1)
+				return
+			}
+			if !errors.Is(cerr, corestorage.ErrLegalHoldAlreadyActive) {
+				unexpected <- cerr
+			}
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+	close(unexpected)
+	for e := range unexpected {
+		require.NoError(t, e)
+	}
+
+	assert.Equal(t, int64(1), succeeded.Load(), "exactly one concurrent CreateLegalHold call may succeed")
+
+	var count int64
+	require.NoError(t, ls.db.Model(&models.LegalHold{}).Where("released = ?", false).Count(&count).Error)
+	assert.Equal(t, int64(1), count, "the DB must contain exactly one active hold row, never a duplicate")
+}


### PR DESCRIPTION
## Summary

- Fixes **#305 LOW** from the security-hardening backlog: `PlaceLegalHold`'s check-then-insert (`internal/core/legal_hold.go`) has a TOCTOU window — two concurrent callers can both observe "no active hold" and both insert a `released=false` row. `GetActiveLegalHold` always returns the highest-id unreleased row, so lifting what an operator believes is "the" hold can leave an earlier orphaned row active and purges permanently blocked. This fails SAFE (over-blocks), not open — it's a correctness bug, not a bypass.
- Adds a partial unique index `uniq_legal_holds_active` on `legal_holds (released) WHERE released = false` (via `ensureLegalHoldActiveIndex` in `internal/storage/factory.go`, following the same pattern as the existing `ensureGroupNameIndex`/`ensureUserNameIndex` partial indexes), so a second concurrent placement is rejected at the DB layer instead of creating a duplicate active row.
- `CreateLegalHold` now detects the UNIQUE-constraint violation and returns the new `storage.ErrLegalHoldAlreadyActive` sentinel; `PlaceLegalHold` maps it to the same "already active" client-facing error its own pre-check already returns, so the caller gets a clear non-500 error instead of a generic storage failure.

## Test plan

- [x] New regression tests prove the race is closed:
  - `internal/storage/store/local_legal_hold_test.go`: `TestConcurrency_CreateLegalHold_OnlyOneWins` drives 32 concurrent `CreateLegalHold` calls against a file-backed SQLite DB (real multi-connection concurrency) and asserts exactly one succeeds and the DB never holds more than one active row; plus `TestLegalHold_ActiveIndexRejectsDuplicate` and `TestLegalHold_ActiveIndexAllowsNewHoldAfterRelease`.
  - `internal/core/concurrency_legal_hold_test.go`: `TestConcurrency_PlaceLegalHold_OnlyOneWins` drives 32 concurrent `core.PlaceLegalHold` calls end-to-end and asserts exactly one wins.
- [x] `go build ./...` clean
- [x] `go test ./...` clean (full suite, including `-race` on the new concurrency tests)
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues
- [x] `golangci-lint run ./...` — 0 issues
- [x] `GOWORK=off go build -C operator ./...` — clean (separate module)

🤖 Generated with [Claude Code](https://claude.com/claude-code)