### PR TITLE
harden(audit): fix sharing-audit impersonation gap, diff omissions, revoke ordering

### DIFF
--- a/internal/core/audit_diff.go
+++ b/internal/core/audit_diff.go
@@ -2,11 +2,13 @@
 //
 // SECURITY: a diff must never carry a plaintext secret value. For the value
 // field we record only {"changed": true}; all other fields are non-sensitive
-// metadata (name, type, max_reads, expiration) whose before/after is safe to log.
+// metadata (name, type, max_reads, expiration, metadata) whose before/after is
+// safe to log.
 package core
 
 import (
 	"encoding/json"
+	"reflect"
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/storage/models"
@@ -38,8 +40,19 @@ func BuildSecretUpdateDiff(old *models.SecretNode, req *UpdateSecretRequest, val
 	if req.MaxReads != nil && !eqIntPtr(old.MaxReads, req.MaxReads) {
 		diff["max_reads"] = fieldChange{Before: intPtrVal(old.MaxReads), After: intPtrVal(req.MaxReads)}
 	}
-	if req.Expiration != nil && !eqTimePtr(old.Expiration, req.Expiration) {
+	switch {
+	case req.ClearExpiration:
+		// ClearExpiration explicitly transitions an expiring secret to non-expiring —
+		// record it even though the "after" side is nil, so the clear itself is
+		// visible in the trail (#285).
+		if old.Expiration != nil {
+			diff["expiration"] = fieldChange{Before: timePtrVal(old.Expiration), After: nil}
+		}
+	case req.Expiration != nil && !eqTimePtr(old.Expiration, req.Expiration):
 		diff["expiration"] = fieldChange{Before: timePtrVal(old.Expiration), After: timePtrVal(req.Expiration)}
+	}
+	if req.Metadata != nil && !eqMetadata(old.Metadata, req.Metadata) {
+		diff["metadata"] = fieldChange{Before: metadataVal(old.Metadata), After: req.Metadata}
 	}
 
 	if len(diff) == 0 {
@@ -78,4 +91,27 @@ func timePtrVal(p *time.Time) interface{} {
 		return nil
 	}
 	return p.UTC().Format(time.RFC3339)
+}
+
+// eqMetadata reports whether old (the persisted models.SecretNode.Metadata JSON
+// blob) is equivalent to new (the requested replacement map). An unparsable or
+// empty old value is treated as an empty map, so setting metadata on a secret
+// that previously had none still registers as a change.
+func eqMetadata(old models.JSON, new map[string]string) bool {
+	return reflect.DeepEqual(metadataMap(old), new)
+}
+
+// metadataMap decodes a models.SecretNode.Metadata JSON blob into a map,
+// treating anything unparsable/empty as an empty (non-nil) map.
+func metadataMap(old models.JSON) map[string]string {
+	m := map[string]string{}
+	if len(old) > 0 {
+		_ = json.Unmarshal(old, &m)
+	}
+	return m
+}
+
+// metadataVal returns the "before" side of a metadata diff entry.
+func metadataVal(old models.JSON) interface{} {
+	return metadataMap(old)
 }

--- a/internal/core/audit_diff_test.go
+++ b/internal/core/audit_diff_test.go
@@ -75,6 +75,107 @@ func TestBuildSecretUpdateDiff_ExpirationChange(t *testing.T) {
 	}
 }
 
+// TestBuildSecretUpdateDiff_ClearExpiration locks in #285: UpdateSecret clears
+// secret.Expiration when req.ClearExpiration is true even though req.Expiration
+// is nil, and the diff must record that transition explicitly rather than
+// silently omitting it (the old code only ever checked req.Expiration != nil).
+func TestBuildSecretUpdateDiff_ClearExpiration(t *testing.T) {
+	exp := time.Date(2027, 1, 2, 3, 4, 5, 0, time.UTC)
+	old := &models.SecretNode{Expiration: &exp}
+	req := &UpdateSecretRequest{ClearExpiration: true}
+	diff := BuildSecretUpdateDiff(old, req, false)
+	if diff == "" {
+		t.Fatal("expected a diff for a cleared expiration")
+	}
+	var parsed map[string]map[string]any
+	if err := json.Unmarshal([]byte(diff), &parsed); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	e, ok := parsed["expiration"]
+	if !ok {
+		t.Fatalf("expected an expiration entry, got %q", diff)
+	}
+	if e["before"] != "2027-01-02T03:04:05Z" {
+		t.Errorf("expected before=2027-01-02T03:04:05Z, got %v", e["before"])
+	}
+	if _, hasAfter := e["after"]; hasAfter {
+		t.Errorf("expected after to be omitted (nil) for a cleared expiration, got %v", e["after"])
+	}
+}
+
+// TestBuildSecretUpdateDiff_ClearExpiration_NoOpWhenAlreadyUnset confirms that
+// clearing an already-nil expiration produces no diff entry (nothing changed).
+func TestBuildSecretUpdateDiff_ClearExpiration_NoOpWhenAlreadyUnset(t *testing.T) {
+	old := &models.SecretNode{}
+	req := &UpdateSecretRequest{ClearExpiration: true}
+	if diff := BuildSecretUpdateDiff(old, req, false); diff != "" {
+		t.Errorf("expected empty diff, got %q", diff)
+	}
+}
+
+// TestBuildSecretUpdateDiff_MetadataChange locks in #285: UpdateSecret
+// unconditionally applies req.Metadata when non-nil, but the diff builder
+// previously never inspected it at all.
+func TestBuildSecretUpdateDiff_MetadataChange(t *testing.T) {
+	old := &models.SecretNode{Metadata: models.JSON(`{"env":"staging"}`)}
+	req := &UpdateSecretRequest{Metadata: map[string]string{"env": "production"}}
+	diff := BuildSecretUpdateDiff(old, req, false)
+	if diff == "" {
+		t.Fatal("expected a diff for a metadata change")
+	}
+	var parsed map[string]map[string]any
+	if err := json.Unmarshal([]byte(diff), &parsed); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	m, ok := parsed["metadata"]
+	if !ok {
+		t.Fatalf("expected a metadata entry, got %q", diff)
+	}
+	before, _ := m["before"].(map[string]any)
+	after, _ := m["after"].(map[string]any)
+	if before["env"] != "staging" {
+		t.Errorf("expected before.env=staging, got %v", m["before"])
+	}
+	if after["env"] != "production" {
+		t.Errorf("expected after.env=production, got %v", m["after"])
+	}
+}
+
+// TestBuildSecretUpdateDiff_MetadataUnchanged confirms setting metadata to the
+// same value produces no diff entry.
+func TestBuildSecretUpdateDiff_MetadataUnchanged(t *testing.T) {
+	old := &models.SecretNode{Metadata: models.JSON(`{"env":"staging"}`)}
+	req := &UpdateSecretRequest{Metadata: map[string]string{"env": "staging"}}
+	if diff := BuildSecretUpdateDiff(old, req, false); diff != "" {
+		t.Errorf("expected empty diff, got %q", diff)
+	}
+}
+
+// TestBuildSecretUpdateDiff_MetadataFromEmpty confirms setting metadata on a
+// secret that previously had none registers as a change.
+func TestBuildSecretUpdateDiff_MetadataFromEmpty(t *testing.T) {
+	old := &models.SecretNode{}
+	req := &UpdateSecretRequest{Metadata: map[string]string{"env": "production"}}
+	diff := BuildSecretUpdateDiff(old, req, false)
+	if diff == "" {
+		t.Fatal("expected a diff when metadata is set from empty")
+	}
+}
+
+// TestBuildSecretUpdateDiff_TagsStillNotDiffed documents (and locks in) that Tags
+// is intentionally out of scope for #285: UpdateSecret never applies req.Tags to
+// the stored secret (dead/no-op on both sides — see secrets.go UpdateSecret), so
+// the diff builder correctly never emits a "tags" entry either. If UpdateSecret
+// ever starts applying Tags, this test should be revisited alongside wiring a
+// real diff for it.
+func TestBuildSecretUpdateDiff_TagsStillNotDiffed(t *testing.T) {
+	old := &models.SecretNode{}
+	req := &UpdateSecretRequest{Tags: []string{"prod", "db"}}
+	if diff := BuildSecretUpdateDiff(old, req, false); diff != "" {
+		t.Errorf("Tags is out of scope for #285 and must not appear in the diff, got %q", diff)
+	}
+}
+
 func TestBuildSecretUpdateDiff_NilSafe(t *testing.T) {
 	if got := BuildSecretUpdateDiff(nil, nil, true); got != "" {
 		t.Errorf("nil inputs must yield empty diff, got %q", got)

--- a/internal/core/self_removal_test.go
+++ b/internal/core/self_removal_test.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -56,6 +57,50 @@ func TestRemoveSelfFromShare_Success(t *testing.T) {
 
 	// Assert
 	assert.NoError(t, err)
+	mockStorage.AssertExpectations(t)
+}
+
+// TestRemoveSelfFromShare_NoPhantomAuditOnDeleteFailure locks in #283: when the
+// storage delete fails, RemoveSelfFromShare must NOT have already logged a
+// "share_self_removed" audit event — otherwise the trail would permanently assert
+// a removal happened even though the share is still live.
+func TestRemoveSelfFromShare_NoPhantomAuditOnDeleteFailure(t *testing.T) {
+	err := i18n.InitializeForTesting()
+	require.NoError(t, err)
+
+	mockStorage := new(MockStorage)
+	core := &KeyorixCore{
+		storage: mockStorage,
+	}
+
+	ctx := context.Background()
+	secretID := uint(1)
+	userID := uint(2)
+
+	shares := []*models.ShareRecord{
+		{
+			ID:          1,
+			SecretID:    1,
+			RecipientID: 2,
+			IsGroup:     false,
+			Permission:  "read",
+			CreatedAt:   time.Now(),
+		},
+	}
+	secret := &models.SecretNode{
+		ID:      1,
+		Name:    "test-secret",
+		OwnerID: 3,
+	}
+
+	mockStorage.On("ListSharesBySecret", ctx, secretID).Return(shares, nil)
+	mockStorage.On("GetSecret", ctx, secretID).Return(secret, nil)
+	mockStorage.On("DeleteShareRecord", ctx, uint(1)).Return(errors.New("storage unavailable"))
+
+	err = core.RemoveSelfFromShare(ctx, secretID, userID)
+
+	require.Error(t, err)
+	mockStorage.AssertNotCalled(t, "LogAuditEvent", mock.Anything, mock.Anything)
 	mockStorage.AssertExpectations(t)
 }
 

--- a/internal/core/sharing.go
+++ b/internal/core/sharing.go
@@ -166,6 +166,13 @@ func (c *KeyorixCore) RevokeShare(ctx context.Context, shareID uint, revokedBy u
 		return fmt.Errorf("%s", i18n.T("ErrorPermissionDenied", nil))
 	}
 
+	if err := c.storage.DeleteShareRecord(ctx, shareID); err != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+
+	// Only log the revocation once the storage mutation has actually succeeded —
+	// logging first would leave a phantom "revoked" audit record if the delete
+	// failed and the share stayed live (#283).
 	auditCtx := &ShareAuditContext{
 		ActorID:     revokedBy,
 		SecretID:    shareRecord.SecretID,
@@ -177,10 +184,6 @@ func (c *KeyorixCore) RevokeShare(ctx context.Context, shareID uint, revokedBy u
 		c.LogGroupShareRevoked(ctx, auditCtx)
 	} else {
 		c.LogShareRevoked(ctx, auditCtx)
-	}
-
-	if err := c.storage.DeleteShareRecord(ctx, shareID); err != nil {
-		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}
 	// Tell the affected user(s) their access was revoked. Best-effort.
 	if shareRecord.IsGroup {
@@ -220,6 +223,12 @@ func (c *KeyorixCore) RemoveSelfFromShare(ctx context.Context, secretID, userID 
 		return fmt.Errorf("%s: %w", i18n.T("ErrorSecretNotFound", nil), err)
 	}
 
+	if err := c.storage.DeleteShareRecord(ctx, shareToRemove.ID); err != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+
+	// Only log the removal once the storage mutation has actually succeeded — see
+	// RevokeShare for why (#283).
 	c.LogSelfRemovalFromShare(ctx, &ShareAuditContext{
 		ActorID:     userID,
 		SecretID:    secretID,
@@ -227,9 +236,5 @@ func (c *KeyorixCore) RemoveSelfFromShare(ctx context.Context, secretID, userID 
 		IsGroup:     false,
 		Permission:  shareToRemove.Permission,
 	})
-
-	if err := c.storage.DeleteShareRecord(ctx, shareToRemove.ID); err != nil {
-		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
-	}
 	return nil
 }

--- a/internal/core/sharing_audit.go
+++ b/internal/core/sharing_audit.go
@@ -3,9 +3,6 @@ package core
 import (
 	"context"
 	"fmt"
-	"time"
-
-	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
 // ShareAuditEvent represents different types of sharing audit events
@@ -54,16 +51,10 @@ func (c *KeyorixCore) LogShareCreated(ctx context.Context, auditCtx *ShareAuditC
 		recipientType = "group"
 	}
 
-	event := &models.AuditEvent{
-		EventType:    string(ShareAuditEventCreated),
-		UserID:       &auditCtx.ActorID,
-		SecretNodeID: &auditCtx.SecretID,
-		Description:  fmt.Sprintf("Shared with %s %d (permission: %s)", recipientType, auditCtx.RecipientID, auditCtx.Permission),
-		EventTime:    time.Now(),
-	}
-
-	// Log the event (ignore errors to not block the main operation)
-	c.emitAudit(ctx, event)
+	desc := fmt.Sprintf("Shared with %s %d (permission: %s)", recipientType, auditCtx.RecipientID, auditCtx.Permission)
+	// Route through the shared choke point so impersonation context
+	// (ActorType/ImpersonatedBy/ActingAs/Impersonation) gets stamped consistently (#284).
+	c.writeAuditEvent(ctx, string(ShareAuditEventCreated), &auditCtx.ActorID, &auditCtx.SecretID, desc)
 }
 
 // LogShareUpdated logs a share permission update event
@@ -73,17 +64,9 @@ func (c *KeyorixCore) LogShareUpdated(ctx context.Context, auditCtx *ShareAuditC
 		recipientType = "group"
 	}
 
-	event := &models.AuditEvent{
-		EventType:    string(ShareAuditEventUpdated),
-		UserID:       &auditCtx.ActorID,
-		SecretNodeID: &auditCtx.SecretID,
-		Description: fmt.Sprintf("Updated share permission for %s %d (from %s to %s)",
-			recipientType, auditCtx.RecipientID, auditCtx.OldPermission, auditCtx.Permission),
-		EventTime: time.Now(),
-	}
-
-	// Log the event (ignore errors to not block the main operation)
-	c.emitAudit(ctx, event)
+	desc := fmt.Sprintf("Updated share permission for %s %d (from %s to %s)",
+		recipientType, auditCtx.RecipientID, auditCtx.OldPermission, auditCtx.Permission)
+	c.writeAuditEvent(ctx, string(ShareAuditEventUpdated), &auditCtx.ActorID, &auditCtx.SecretID, desc)
 }
 
 // LogShareRevoked logs a share revocation event
@@ -93,85 +76,37 @@ func (c *KeyorixCore) LogShareRevoked(ctx context.Context, auditCtx *ShareAuditC
 		recipientType = "group"
 	}
 
-	event := &models.AuditEvent{
-		EventType:    string(ShareAuditEventRevoked),
-		UserID:       &auditCtx.ActorID,
-		SecretNodeID: &auditCtx.SecretID,
-		Description:  fmt.Sprintf("Revoked share for %s %d", recipientType, auditCtx.RecipientID),
-		EventTime:    time.Now(),
-	}
-
-	// Log the event (ignore errors to not block the main operation)
-	c.emitAudit(ctx, event)
+	desc := fmt.Sprintf("Revoked share for %s %d", recipientType, auditCtx.RecipientID)
+	c.writeAuditEvent(ctx, string(ShareAuditEventRevoked), &auditCtx.ActorID, &auditCtx.SecretID, desc)
 }
 
 // LogSharedSecretAccessed logs when a user accesses a shared secret
 func (c *KeyorixCore) LogSharedSecretAccessed(ctx context.Context, auditCtx *ShareAuditContext) {
-	event := &models.AuditEvent{
-		EventType:    string(ShareAuditEventAccessed),
-		UserID:       &auditCtx.ActorID,
-		SecretNodeID: &auditCtx.SecretID,
-		Description:  fmt.Sprintf("Accessed shared secret (permission: %s)", auditCtx.Permission),
-		EventTime:    time.Now(),
-	}
-
-	// Log the event (ignore errors to not block the main operation)
-	c.emitAudit(ctx, event)
+	desc := fmt.Sprintf("Accessed shared secret (permission: %s)", auditCtx.Permission)
+	c.writeAuditEvent(ctx, string(ShareAuditEventAccessed), &auditCtx.ActorID, &auditCtx.SecretID, desc)
 }
 
 // LogGroupShareCreated logs a group share creation event
 func (c *KeyorixCore) LogGroupShareCreated(ctx context.Context, auditCtx *ShareAuditContext) {
-	event := &models.AuditEvent{
-		EventType:    string(ShareAuditEventGroupCreated),
-		UserID:       &auditCtx.ActorID,
-		SecretNodeID: &auditCtx.SecretID,
-		Description:  fmt.Sprintf("Shared with group %d (permission: %s)", auditCtx.RecipientID, auditCtx.Permission),
-		EventTime:    time.Now(),
-	}
-
-	// Log the event (ignore errors to not block the main operation)
-	c.emitAudit(ctx, event)
+	desc := fmt.Sprintf("Shared with group %d (permission: %s)", auditCtx.RecipientID, auditCtx.Permission)
+	c.writeAuditEvent(ctx, string(ShareAuditEventGroupCreated), &auditCtx.ActorID, &auditCtx.SecretID, desc)
 }
 
 // LogGroupShareUpdated logs a group share permission update event
 func (c *KeyorixCore) LogGroupShareUpdated(ctx context.Context, auditCtx *ShareAuditContext) {
-	event := &models.AuditEvent{
-		EventType:    string(ShareAuditEventGroupUpdated),
-		UserID:       &auditCtx.ActorID,
-		SecretNodeID: &auditCtx.SecretID,
-		Description: fmt.Sprintf("Updated group share permission for group %d (from %s to %s)",
-			auditCtx.RecipientID, auditCtx.OldPermission, auditCtx.Permission),
-		EventTime: time.Now(),
-	}
-
-	// Log the event (ignore errors to not block the main operation)
-	c.emitAudit(ctx, event)
+	desc := fmt.Sprintf("Updated group share permission for group %d (from %s to %s)",
+		auditCtx.RecipientID, auditCtx.OldPermission, auditCtx.Permission)
+	c.writeAuditEvent(ctx, string(ShareAuditEventGroupUpdated), &auditCtx.ActorID, &auditCtx.SecretID, desc)
 }
 
 // LogGroupShareRevoked logs a group share revocation event
 func (c *KeyorixCore) LogGroupShareRevoked(ctx context.Context, auditCtx *ShareAuditContext) {
-	event := &models.AuditEvent{
-		EventType:    string(ShareAuditEventGroupRevoked),
-		UserID:       &auditCtx.ActorID,
-		SecretNodeID: &auditCtx.SecretID,
-		Description:  fmt.Sprintf("Revoked group share for group %d", auditCtx.RecipientID),
-		EventTime:    time.Now(),
-	}
-
-	// Log the event (ignore errors to not block the main operation)
-	c.emitAudit(ctx, event)
+	desc := fmt.Sprintf("Revoked group share for group %d", auditCtx.RecipientID)
+	c.writeAuditEvent(ctx, string(ShareAuditEventGroupRevoked), &auditCtx.ActorID, &auditCtx.SecretID, desc)
 }
 
 // LogSelfRemovalFromShare logs when a user removes themselves from a shared secret
 func (c *KeyorixCore) LogSelfRemovalFromShare(ctx context.Context, auditCtx *ShareAuditContext) {
-	event := &models.AuditEvent{
-		EventType:    string(ShareAuditEventSelfRemoved),
-		UserID:       &auditCtx.ActorID,
-		SecretNodeID: &auditCtx.SecretID,
-		Description:  fmt.Sprintf("User removed themselves from shared secret (permission: %s)", auditCtx.Permission),
-		EventTime:    time.Now(),
-	}
-
-	// Log the event (ignore errors to not block the main operation)
-	c.emitAudit(ctx, event)
+	desc := fmt.Sprintf("User removed themselves from shared secret (permission: %s)", auditCtx.Permission)
+	c.writeAuditEvent(ctx, string(ShareAuditEventSelfRemoved), &auditCtx.ActorID, &auditCtx.SecretID, desc)
 }

--- a/internal/core/sharing_audit_test.go
+++ b/internal/core/sharing_audit_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 func TestKeyorixCore_LogShareCreated(t *testing.T) {
@@ -251,6 +252,82 @@ func TestKeyorixCore_LogGroupShareRevoked(t *testing.T) {
 
 	// Assert
 	mockStorage.AssertExpectations(t)
+}
+
+// TestShareAudit_StampsImpersonationContext locks in #284: every sharing-related
+// audit writer must route through the shared writeAuditEvent choke point so an
+// action taken during an impersonation session is stamped with
+// ImpersonatedBy/ActingAs/Impersonation=true — mirroring how secret CRUD and RBAC
+// writers (audit.go) already behave. Exploit trace from the finding: an admin (id
+// 99) impersonates target user T (id 2) and shares a secret as T; the resulting
+// audit row must NOT be indistinguishable from T's own genuine action.
+func TestShareAudit_StampsImpersonationContext(t *testing.T) {
+	mockStorage := new(MockStorage)
+	core := &KeyorixCore{
+		storage: mockStorage,
+		now:     time.Now,
+	}
+	ctx := WithImpersonation(context.Background(), 99) // admin 99 impersonating target 2
+
+	writers := map[string]func(){
+		string(ShareAuditEventCreated):      func() { core.LogShareCreated(ctx, &ShareAuditContext{ActorID: 2, SecretID: 1, RecipientID: 3, Permission: "read"}) },
+		string(ShareAuditEventUpdated):      func() { core.LogShareUpdated(ctx, &ShareAuditContext{ActorID: 2, SecretID: 1, RecipientID: 3, Permission: "write", OldPermission: "read"}) },
+		string(ShareAuditEventRevoked):      func() { core.LogShareRevoked(ctx, &ShareAuditContext{ActorID: 2, SecretID: 1, RecipientID: 3}) },
+		string(ShareAuditEventAccessed):     func() { core.LogSharedSecretAccessed(ctx, &ShareAuditContext{ActorID: 2, SecretID: 1, Permission: "read"}) },
+		string(ShareAuditEventGroupCreated): func() { core.LogGroupShareCreated(ctx, &ShareAuditContext{ActorID: 2, SecretID: 1, RecipientID: 4, IsGroup: true, Permission: "read"}) },
+		string(ShareAuditEventGroupUpdated): func() {
+			core.LogGroupShareUpdated(ctx, &ShareAuditContext{ActorID: 2, SecretID: 1, RecipientID: 4, IsGroup: true, Permission: "write", OldPermission: "read"})
+		},
+		string(ShareAuditEventGroupRevoked): func() { core.LogGroupShareRevoked(ctx, &ShareAuditContext{ActorID: 2, SecretID: 1, RecipientID: 4, IsGroup: true}) },
+		string(ShareAuditEventSelfRemoved):  func() { core.LogSelfRemovalFromShare(ctx, &ShareAuditContext{ActorID: 2, SecretID: 1, RecipientID: 2}) },
+	}
+
+	for eventType, write := range writers {
+		t.Run(eventType, func(t *testing.T) {
+			mockStorage.ExpectedCalls = nil
+			mockStorage.Calls = nil
+			var captured *models.AuditEvent
+			mockStorage.On("LogAuditEvent", ctx, mock.MatchedBy(func(e *models.AuditEvent) bool {
+				captured = e
+				return e.EventType == eventType
+			})).Return(nil)
+
+			write()
+
+			require.NotNil(t, captured, "expected an audit event to be written")
+			assert.True(t, captured.Impersonation, "Impersonation must be true")
+			require.NotNil(t, captured.ImpersonatedBy, "ImpersonatedBy must be stamped")
+			assert.Equal(t, uint(99), *captured.ImpersonatedBy)
+			require.NotNil(t, captured.ActingAs, "ActingAs must be stamped")
+			assert.Equal(t, uint(2), *captured.ActingAs)
+			assert.Equal(t, ActorTypeUser, captured.ActorType)
+		})
+	}
+}
+
+// TestShareAudit_NoImpersonationOutsideSession confirms a non-impersonation
+// context leaves Impersonation/ImpersonatedBy/ActingAs unset, so the fix does not
+// spuriously tag ordinary sharing actions.
+func TestShareAudit_NoImpersonationOutsideSession(t *testing.T) {
+	mockStorage := new(MockStorage)
+	core := &KeyorixCore{
+		storage: mockStorage,
+		now:     time.Now,
+	}
+	ctx := context.Background()
+
+	var captured *models.AuditEvent
+	mockStorage.On("LogAuditEvent", ctx, mock.MatchedBy(func(e *models.AuditEvent) bool {
+		captured = e
+		return true
+	})).Return(nil)
+
+	core.LogShareCreated(ctx, &ShareAuditContext{ActorID: 2, SecretID: 1, RecipientID: 3, Permission: "read"})
+
+	require.NotNil(t, captured)
+	assert.False(t, captured.Impersonation)
+	assert.Nil(t, captured.ImpersonatedBy)
+	assert.Nil(t, captured.ActingAs)
 }
 
 func TestShareAuditContext_Validation(t *testing.T) {

--- a/internal/core/sharing_test.go
+++ b/internal/core/sharing_test.go
@@ -267,6 +267,44 @@ func TestKeyorixCore_RevokeShare(t *testing.T) {
 	mockStorage.AssertExpectations(t)
 }
 
+// TestKeyorixCore_RevokeShare_NoPhantomAuditOnDeleteFailure locks in #283: when
+// storage.DeleteShareRecord fails, RevokeShare must return the error to the
+// caller and must NOT have already written a "share_revoked" audit event — a
+// phantom revoke record while the share stays live is worse than no record.
+func TestKeyorixCore_RevokeShare_NoPhantomAuditOnDeleteFailure(t *testing.T) {
+	mockStorage := new(MockStorage)
+	core := &KeyorixCore{
+		storage: mockStorage,
+		now:     time.Now,
+	}
+	ctx := context.Background()
+
+	secret := &models.SecretNode{
+		ID:      1,
+		Name:    "test-secret",
+		OwnerID: 1,
+	}
+	shareRecord := &models.ShareRecord{
+		ID:          1,
+		SecretID:    1,
+		OwnerID:     1,
+		RecipientID: 2,
+		IsGroup:     false,
+		Permission:  "read",
+	}
+
+	mockStorage.On("GetShareRecord", ctx, uint(1)).Return(shareRecord, nil)
+	mockStorage.On("GetSecret", ctx, uint(1)).Return(secret, nil)
+	mockStorage.On("DeleteShareRecord", ctx, uint(1)).Return(errors.New("storage unavailable"))
+
+	err := core.RevokeShare(ctx, 1, 1)
+
+	require.Error(t, err)
+	mockStorage.AssertNotCalled(t, "LogAuditEvent", mock.Anything, mock.Anything)
+	mockStorage.AssertNotCalled(t, "CreateNotification", mock.Anything, mock.Anything)
+	mockStorage.AssertExpectations(t)
+}
+
 func TestKeyorixCore_ListSharedSecrets(t *testing.T) {
 	// Setup
 	mockStorage := new(MockStorage)


### PR DESCRIPTION
## Summary

Fixes three findings from the security-hardening backlog in the sharing/audit subsystem:

- **#284 MEDIUM** — every sharing-related audit writer (share/group-share create/update/revoke/access, self-removal) built `models.AuditEvent` directly and called `emitAudit`, bypassing the shared impersonation-context choke point (`writeAuditEvent`/`writeAuditEventDiff` in `internal/core/audit.go`). An admin acting as an impersonated user while sharing a secret produced an audit row indistinguishable from the target's own action (no `ImpersonatedBy`/`ActingAs`/`Impersonation=true`), and the action was silently dropped from `EndImpersonation`'s derived `action_count`. Fixed by routing all 8 writers in `internal/core/sharing_audit.go` through `writeAuditEvent`.
- **#285 MEDIUM** — `BuildSecretUpdateDiff` (`internal/core/audit_diff.go`) silently omitted two real, applied changes from the structured update diff: metadata updates and clearing an expiration date (`ClearExpiration`). Extended the diff builder to cover both. `Tags` remains intentionally undiffed — confirmed `UpdateSecret` still never applies `req.Tags`, so wiring a diff for it would be out of scope/misleading.
- **#283 LOW** — `RevokeShare`/`RemoveSelfFromShare` (`internal/core/sharing.go`) logged the "revoked"/"self-removed" audit event *before* the storage delete. A `DeleteShareRecord` failure left a phantom audit record asserting a revoke happened while the share stayed live. Reordered both to log only after a successful delete, matching the existing pattern in `ShareSecret`/`UpdateSharePermission`/`RevokeAccessReviewGrant`.

## Test plan
- [x] New regression tests: impersonation-context stamping across all 8 sharing audit writers (`TestShareAudit_StampsImpersonationContext`) plus a non-impersonation control (`TestShareAudit_NoImpersonationOutsideSession`)
- [x] New diff tests: metadata change/no-op/from-empty, expiration-clear/no-op, and a lock-in test confirming `Tags` remains out of scope
- [x] New "no phantom audit on delete failure" tests for both `RevokeShare` and `RemoveSelfFromShare`
- [x] `go build ./...` clean
- [x] `go test ./...` clean (full suite, including `internal/audit/siem`)
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues
- [x] `golangci-lint run ./...` — 0 issues
- [x] `GOWORK=off go build -C operator ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)