### PR TITLE
fix(access-review): make item decisions a conditional update (#319)

### DIFF
--- a/internal/core/access_review_campaign.go
+++ b/internal/core/access_review_campaign.go
@@ -240,8 +240,19 @@ func (c *KeyorixCore) DecideAccessReviewItem(ctx context.Context, actorID, proje
 	item.Reason = reason
 	item.DecidedBy = actorID
 	item.DecidedAt = &now
-	if err := c.storage.UpdateAccessReviewItem(ctx, item); err != nil {
+	// The pending check above is a plain read, so a concurrent or replayed second
+	// decision on this item can reach here too, having read the same "pending" state
+	// before either write lands. UpdateAccessReviewItem's WHERE-decision='pending'
+	// conditional UPDATE is the actual race-closing guard: ok==false means this call
+	// lost the race (the item was decided out from under it), so surface a clear
+	// "already decided" error rather than a generic storage failure — and, crucially,
+	// don't silently let this decision overwrite the one that won.
+	ok, err := c.storage.UpdateAccessReviewItem(ctx, item)
+	if err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	if !ok {
+		return fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "this item has already been decided")
 	}
 	return nil
 }

--- a/internal/core/concurrency_access_review_redecide_test.go
+++ b/internal/core/concurrency_access_review_redecide_test.go
@@ -1,0 +1,85 @@
+package core_test
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// TestConcurrency_DecideAccessReviewItem_OnlyOneDecisionWins drives the FULL
+// DecideAccessReviewItem path (#319) — not just the storage layer — from many
+// concurrent reviewers deciding the SAME pending item. DecideAccessReviewItem's own
+// pending pre-check is a plain read, wide open to a race between the read and the
+// eventual persist (the decision action itself runs in between); the guarantee this
+// asserts is the one that actually matters end-to-end: exactly one decision is ever
+// recorded and every other caller gets a clear rejection — never a silently
+// overwritten compliance record, and never a panic or generic 500.
+func TestConcurrency_DecideAccessReviewItem_OnlyOneDecisionWins(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	dsn := "file:" + filepath.Join(t.TempDir(), "arc.db") + "?_busy_timeout=10000&_journal_mode=WAL&_txlock=immediate"
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.AccessReviewCampaign{}, &models.AccessReviewItem{}, &models.AuditEvent{}))
+
+	const proj = uint(2)
+	campaign := &models.AccessReviewCampaign{ProjectID: proj, Name: "race", State: core.CampaignStateOpen}
+	require.NoError(t, db.Create(campaign).Error)
+	// PrincipalType "role" (neither "user" nor "group") sidesteps the self-certification
+	// checks, which aren't what this test is about; Source "role" satisfies
+	// AttestAccessReviewGrant's only precondition (a non-empty source) without needing a
+	// real role/share grant to exist.
+	item := &models.AccessReviewItem{CampaignID: campaign.ID, PrincipalType: "role", Source: "role", Decision: core.ReviewItemPending}
+	require.NoError(t, db.Create(item).Error)
+
+	c := core.NewKeyorixCore(store.NewLocalStorage(db))
+	ctx := context.Background()
+
+	const reviewers = 24
+	var succeeded atomic.Int64
+	var rejected atomic.Int64
+	unexpected := make(chan error, reviewers)
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < reviewers; i++ {
+		wg.Add(1)
+		actorID := uint(100 + i) // distinct attributable human reviewers, none is the item's principal
+		go func(actorID uint) {
+			defer wg.Done()
+			<-start
+			decErr := c.DecideAccessReviewItem(ctx, actorID, proj, campaign.ID, item.ID, "attest", "concurrent review")
+			switch {
+			case decErr == nil:
+				succeeded.Add(1)
+			case strings.Contains(decErr.Error(), "already been decided"):
+				rejected.Add(1)
+			default:
+				unexpected <- decErr
+			}
+		}(actorID)
+	}
+	close(start) // release every reviewer at once
+	wg.Wait()
+	close(unexpected)
+	for e := range unexpected {
+		require.NoError(t, e, "every losing decision must fail with the clear 'already decided' error, nothing else")
+	}
+
+	assert.Equal(t, int64(1), succeeded.Load(), "exactly one concurrent decision may be recorded")
+	assert.Equal(t, int64(reviewers-1), rejected.Load(), "every other concurrent decision must be rejected, not silently applied")
+
+	var got models.AccessReviewItem
+	require.NoError(t, db.First(&got, item.ID).Error)
+	assert.Equal(t, core.ReviewItemAttested, got.Decision, "the single winning decision must be the one persisted")
+}

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -234,9 +234,9 @@ func (m *MockStorage) GetAccessReviewItem(ctx context.Context, id uint) (*models
 	return args.Get(0).(*models.AccessReviewItem), args.Error(1)
 }
 
-func (m *MockStorage) UpdateAccessReviewItem(ctx context.Context, item *models.AccessReviewItem) error {
+func (m *MockStorage) UpdateAccessReviewItem(ctx context.Context, item *models.AccessReviewItem) (bool, error) {
 	args := m.Called(ctx, item)
-	return args.Error(0)
+	return args.Bool(0), args.Error(1)
 }
 
 func (m *MockStorage) LastUserSecretActivity(ctx context.Context, projectID uint) (map[uint]time.Time, error) {

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -87,7 +87,12 @@ type Storage interface {
 	CreateAccessReviewItems(ctx context.Context, items []*models.AccessReviewItem) error
 	ListAccessReviewItems(ctx context.Context, campaignID uint) ([]*models.AccessReviewItem, error)
 	GetAccessReviewItem(ctx context.Context, id uint) (*models.AccessReviewItem, error)
-	UpdateAccessReviewItem(ctx context.Context, item *models.AccessReviewItem) error
+	// UpdateAccessReviewItem persists a decision with a conditional UPDATE (only an
+	// item whose CURRENT stored decision is still "pending" may be transitioned). The
+	// bool reports whether the row matched and was updated; false means the item was
+	// already decided (by a prior or racing call) and this write was rejected, not
+	// silently applied.
+	UpdateAccessReviewItem(ctx context.Context, item *models.AccessReviewItem) (bool, error)
 
 	// Separation-of-duties policies (ISO 27001 A.5.3 / SOX) — toxic permission pairs.
 	CreateSoDPolicy(ctx context.Context, p *models.SoDPolicy) (*models.SoDPolicy, error)

--- a/internal/storage/store/concurrency_access_review_redecide_test.go
+++ b/internal/storage/store/concurrency_access_review_redecide_test.go
@@ -1,0 +1,96 @@
+package store
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestUpdateAccessReviewItem_RejectsSecondDecision proves UpdateAccessReviewItem is a
+// conditional UPDATE (`WHERE decision = 'pending'`), not the prior unconditional Save:
+// once an item has been decided, a second call attempting a DIFFERENT decision must be
+// rejected (ok == false, item unchanged) rather than silently overwriting it — the
+// exact "revoke persisted, then attest overwrites it" corruption in #319.
+func TestUpdateAccessReviewItem_RejectsSecondDecision(t *testing.T) {
+	db := concurrentDB(t)
+	require.NoError(t, db.AutoMigrate(&models.AccessReviewCampaign{}, &models.AccessReviewItem{}))
+	ls := NewLocalStorage(db)
+	ctx := context.Background()
+
+	item := &models.AccessReviewItem{CampaignID: 1, PrincipalType: "role", Source: "role", Decision: "pending"}
+	require.NoError(t, db.Create(item).Error)
+
+	// Call 1: revoke really "wins" the decision.
+	item.Decision = "revoked"
+	ok, err := ls.UpdateAccessReviewItem(ctx, item)
+	require.NoError(t, err)
+	assert.True(t, ok, "the first decision on a pending item must succeed")
+
+	// Call 2: a later/racing attest must NOT silently overwrite the persisted revoke.
+	overwrite := &models.AccessReviewItem{ID: item.ID, CampaignID: 1, PrincipalType: "role", Source: "role", Decision: "attested"}
+	ok, err = ls.UpdateAccessReviewItem(ctx, overwrite)
+	require.NoError(t, err, "a lost race is reported via the bool, not an error")
+	assert.False(t, ok, "a second decision on an already-decided item must be rejected")
+
+	var got models.AccessReviewItem
+	require.NoError(t, db.First(&got, item.ID).Error)
+	assert.Equal(t, "revoked", got.Decision, "the original decision must survive untouched — no silent overwrite")
+}
+
+// TestConcurrency_AccessReviewItem_OnlyOneDecisionWins drives real concurrent decisions
+// (file-backed SQLite, WAL, genuine multi-connection contention) against the SAME
+// pending item and asserts the conditional UPDATE lets exactly one of them win — never
+// zero (a would-be deadlock/starvation bug) and never more than one (the #319
+// corruption: two decisions both "succeeding" and the later silently clobbering the
+// earlier one).
+func TestConcurrency_AccessReviewItem_OnlyOneDecisionWins(t *testing.T) {
+	db := concurrentDB(t)
+	require.NoError(t, db.AutoMigrate(&models.AccessReviewCampaign{}, &models.AccessReviewItem{}))
+	ls := NewLocalStorage(db)
+
+	item := &models.AccessReviewItem{CampaignID: 1, PrincipalType: "role", Source: "role", Decision: "pending"}
+	require.NoError(t, db.Create(item).Error)
+
+	const racers = 32
+	var succeeded atomic.Int64
+	errs := make(chan error, racers)
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < racers; i++ {
+		wg.Add(1)
+		decision := "attested"
+		if i%2 == 0 {
+			decision = "revoked"
+		}
+		go func(decision string) {
+			defer wg.Done()
+			<-start
+			candidate := &models.AccessReviewItem{ID: item.ID, CampaignID: 1, PrincipalType: "role", Source: "role", Decision: decision}
+			ok, err := ls.UpdateAccessReviewItem(context.Background(), candidate)
+			if err != nil {
+				errs <- err
+				return
+			}
+			if ok {
+				succeeded.Add(1)
+			}
+		}(decision)
+	}
+	close(start) // release every racer at once
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+
+	assert.Equal(t, int64(1), succeeded.Load(), "exactly one concurrent decision may win — never zero, never more than one")
+
+	var got models.AccessReviewItem
+	require.NoError(t, db.First(&got, item.ID).Error)
+	assert.NotEqual(t, "pending", got.Decision, "the winning decision must have been persisted")
+}

--- a/internal/storage/store/local_access_review_campaigns.go
+++ b/internal/storage/store/local_access_review_campaigns.go
@@ -79,9 +79,30 @@ func (ls *LocalStorage) GetAccessReviewItem(ctx context.Context, id uint) (*mode
 	return &item, nil
 }
 
-func (ls *LocalStorage) UpdateAccessReviewItem(ctx context.Context, item *models.AccessReviewItem) error {
-	if err := ls.db.WithContext(ctx).Save(item).Error; err != nil {
-		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+// accessReviewItemPending mirrors core.ReviewItemPending (the store package cannot
+// import core: core already imports storage/store). Both sides of this decision
+// state machine — core's pre-check and this conditional UPDATE — must agree on the
+// same "undecided" sentinel string.
+const accessReviewItemPending = "pending"
+
+// UpdateAccessReviewItem persists a recertification decision with a conditional
+// UPDATE (`WHERE id = ? AND decision = 'pending'`), not an unconditional Save. A
+// decision is a one-way transition (pending -> attested|revoked): DecideAccessReviewItem
+// reads the item, checks it's still pending, then acts and persists — a plain
+// read-then-write with a gap in between (the action itself, plus everything else in
+// the request) wide enough for two concurrent/replayed decisions to both pass the
+// pending check before either writes. Making the persist itself the single
+// conditional statement closes that race: whichever call's UPDATE lands first wins
+// (RowsAffected==1); the loser's UPDATE matches zero rows and is told so, instead of
+// silently overwriting the winner's decision and corrupting the compliance evidence
+// trail.
+func (ls *LocalStorage) UpdateAccessReviewItem(ctx context.Context, item *models.AccessReviewItem) (bool, error) {
+	res := ls.db.WithContext(ctx).Model(&models.AccessReviewItem{}).
+		Where("id = ? AND decision = ?", item.ID, accessReviewItemPending).
+		Select("*").
+		Updates(item)
+	if res.Error != nil {
+		return false, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), res.Error)
 	}
-	return nil
+	return res.RowsAffected == 1, nil
 }

--- a/internal/storage/store/remote_access_review_campaigns.go
+++ b/internal/storage/store/remote_access_review_campaigns.go
@@ -37,6 +37,6 @@ func (rs *RemoteStorage) GetAccessReviewItem(_ context.Context, _ uint) (*models
 	return nil, remoteUnsupported("GetAccessReviewItem")
 }
 
-func (rs *RemoteStorage) UpdateAccessReviewItem(_ context.Context, _ *models.AccessReviewItem) error {
-	return remoteUnsupported("UpdateAccessReviewItem")
+func (rs *RemoteStorage) UpdateAccessReviewItem(_ context.Context, _ *models.AccessReviewItem) (bool, error) {
+	return false, remoteUnsupported("UpdateAccessReviewItem")
 }


### PR DESCRIPTION
## Summary

- `UpdateAccessReviewItem` (`internal/storage/store/local_access_review_campaigns.go`) was an unconditional full-row `Save(item)` — no `WHERE decision = 'pending'` predicate, no version column. `DecideAccessReviewItem`'s own pending pre-check is a plain read-then-write with the entire decision action (a real grant revoke, or an audit-log write for attest) executing in the gap, so a concurrent, racing, or replayed second decision on the same item could still pass the pre-check and silently overwrite an earlier decision — e.g. a real `revoke` persists, then a later no-op `attest` clobbers the item to `"attested"`, with no error, no conflict signal, corrupting the ISO 27001 A.5.18 compliance evidence trail.
- `UpdateAccessReviewItem` is now a single conditional `UPDATE ... WHERE id = ? AND decision = 'pending'`, reporting via a `bool` whether the write actually matched a row (`RowsAffected == 1`).
- `DecideAccessReviewItem` now surfaces a clear "this item has already been decided" validation error when the conditional update reports zero rows, instead of returning success for a decision that was silently discarded.

## Test plan

- [x] New regression test `TestUpdateAccessReviewItem_RejectsSecondDecision` (storage layer): a second decision on an already-decided item is rejected and the original decision is left untouched.
- [x] New regression test `TestConcurrency_AccessReviewItem_OnlyOneDecisionWins` (storage layer, real file-backed SQLite + WAL, genuine concurrent connections): 32 concurrent decisions on the same pending item — exactly one wins, never zero, never more than one.
- [x] New regression test `TestConcurrency_DecideAccessReviewItem_OnlyOneDecisionWins` (core layer, full `DecideAccessReviewItem` path): 24 concurrent reviewers deciding the same item — exactly one decision is recorded, every other caller gets the clear "already been decided" error, never a panic or generic failure.
- [x] Existing `TestDecideAccessReviewItem_RejectsDoubleDecision` (sequential double-decide) still passes.
- [x] `go build ./...` clean.
- [x] `go test ./...` clean, except the pre-existing, unrelated `TestHTTPJWKSResolver_CapsKeyCount` flake (reproduces identically on unmodified `origin/main`, unrelated to this change — OIDC JWKS resolver httptest teardown). `internal/audit/siem`'s `TestSpool_PersistsAndReplaysOnRecovery` passes cleanly (already fixed on `main`).
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues.
- [x] `golangci-lint run ./...` — 0 issues.
- [x] `GOWORK=off go build -C operator ./...` — clean build.