### PR TITLE
fix(break-glass): fail closed on revoke role-removal errors, atomic state transition

### DIFF
--- a/internal/core/break_glass.go
+++ b/internal/core/break_glass.go
@@ -13,6 +13,7 @@ package core
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -201,16 +202,28 @@ func (c *KeyorixCore) RevokeBreakGlass(ctx context.Context, actorID, projectID, 
 	if activation.State != BreakGlassActive {
 		return fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "activation is not active")
 	}
-	// Remove the grant early. If it already auto-expired the row is gone — ignore
-	// that error and still reconcile the record.
+	// Remove the grant early. A benign "the row is already gone" case (it already
+	// auto-expired, or a racing revoke already removed it — see the conditional
+	// state transition below) is not an error: proceed to reconcile the record. A
+	// genuine storage failure, however, must abort the revoke here — proceeding to
+	// mark the record "revoked" while the removal itself failed would leave the
+	// emergency role grant LIVE in user_roles (the table RBAC actually reads) but
+	// reported as revoked everywhere else (API response, audit trail).
 	scope := storage.Scope{ProjectID: projectID}
-	_ = c.RemoveUserRole(ctx, actorID, activation.UserID, activation.RoleID, scope)
+	if err := c.RemoveUserRole(ctx, actorID, activation.UserID, activation.RoleID, scope); err != nil && !errors.Is(err, storage.ErrRoleNotAssigned) {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
 
+	// Conditional UPDATE (WHERE state = active), not a read-modify-write: the initial
+	// state check above is only a fast-path convenience, not the enforcement — two
+	// concurrent revokes of the same activation can both pass it. Only the first
+	// concurrent caller's conditional update actually transitions state; the second
+	// gets ErrBreakGlassNotActive instead of silently overwriting RevokedBy/RevokedAt.
 	now := c.now()
-	activation.State = BreakGlassRevoked
-	activation.RevokedBy = actorID
-	activation.RevokedAt = &now
-	if err := c.storage.UpdateBreakGlassActivation(ctx, activation); err != nil {
+	if err := c.storage.RevokeBreakGlassActivation(ctx, activation.ID, actorID, now); err != nil {
+		if errors.Is(err, storage.ErrBreakGlassNotActive) {
+			return fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "activation is not active")
+		}
 		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}
 	c.auditProjectScoped(ctx, EventBreakGlassRevoked, actorID, projectID,

--- a/internal/core/break_glass_external_test.go
+++ b/internal/core/break_glass_external_test.go
@@ -2,6 +2,7 @@ package core_test
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -144,6 +145,92 @@ func TestRevokeBreakGlass_RemovesGrant(t *testing.T) {
 	require.Len(t, list, 1)
 	assert.Equal(t, core.BreakGlassRevoked, list[0].State)
 	require.Error(t, h.CoreService.RevokeBreakGlass(ctx, 1, proj, act.ID))
+}
+
+// #304: the storage-layer state transition is a single conditional UPDATE
+// (WHERE state = active), not a read-modify-write. Revoking the same activation
+// twice in a row must let only the first call actually transition state — the
+// second must fail cleanly with storage.ErrBreakGlassNotActive, and the first
+// revoker's attribution (RevokedBy/RevokedAt) must survive untouched rather than
+// being silently overwritten by the second attempt.
+func TestRevokeBreakGlassActivation_ConditionalUpdateOnlyFirstAttemptWins(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	migrateBreakGlass(t, h)
+	enableBreakGlass(h, "editor", 4*time.Hour, 24*time.Hour)
+
+	const proj = uint(2)
+	ctx := context.Background()
+	h.CreateTestUser(t, "alice", 10)
+	makeProjectMember(t, h, 10, proj)
+
+	act, err := h.CoreService.ActivateBreakGlass(ctx, proj, 10, "incident", "")
+	require.NoError(t, err)
+
+	firstRevokeAt := time.Now().Add(-time.Minute).UTC().Truncate(time.Second)
+	require.NoError(t, h.Storage.RevokeBreakGlassActivation(ctx, act.ID, 100, firstRevokeAt))
+
+	secondRevokeAt := time.Now().UTC().Truncate(time.Second)
+	err = h.Storage.RevokeBreakGlassActivation(ctx, act.ID, 200, secondRevokeAt)
+	require.Error(t, err, "a second conditional revoke of an already-revoked activation must fail")
+	assert.ErrorIs(t, err, storage.ErrBreakGlassNotActive)
+
+	got, err := h.Storage.GetBreakGlassActivation(ctx, act.ID)
+	require.NoError(t, err)
+	assert.Equal(t, core.BreakGlassRevoked, got.State)
+	assert.Equal(t, uint(100), got.RevokedBy, "the first revoker's attribution must survive a racing second attempt")
+	require.NotNil(t, got.RevokedAt)
+	assert.WithinDuration(t, firstRevokeAt, *got.RevokedAt, time.Second)
+}
+
+// #304 end to end: two admins racing to revoke the same activation concurrently
+// must not both succeed and must not corrupt RevokedBy/RevokedAt attribution —
+// exactly one RevokeBreakGlass call wins, the other gets a clean "not active" error.
+func TestRevokeBreakGlass_ConcurrentRevokesOnlyOneWins(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	migrateBreakGlass(t, h)
+	enableBreakGlass(h, "editor", 4*time.Hour, 24*time.Hour)
+	// A single shared connection so both goroutines' conditional UPDATEs interleave
+	// through the same in-memory SQLite database rather than each opening its own
+	// independent (and differently-seeded) :memory: connection.
+	h.SqlDB.SetMaxOpenConns(1)
+
+	const proj = uint(2)
+	ctx := context.Background()
+	h.CreateTestUser(t, "alice", 10)
+	makeProjectMember(t, h, 10, proj)
+
+	act, err := h.CoreService.ActivateBreakGlass(ctx, proj, 10, "incident", "")
+	require.NoError(t, err)
+
+	admins := []uint{100, 200}
+	errs := make([]error, len(admins))
+	var wg sync.WaitGroup
+	for i, admin := range admins {
+		wg.Add(1)
+		go func(i int, admin uint) {
+			defer wg.Done()
+			errs[i] = h.CoreService.RevokeBreakGlass(ctx, admin, proj, act.ID)
+		}(i, admin)
+	}
+	wg.Wait()
+
+	successCount := 0
+	var winner uint
+	for i, e := range errs {
+		if e == nil {
+			successCount++
+			winner = admins[i]
+		}
+	}
+	assert.Equal(t, 1, successCount, "exactly one concurrent revoke must win")
+
+	list, err := h.CoreService.ListBreakGlassActivations(ctx, proj)
+	require.NoError(t, err)
+	require.Len(t, list, 1)
+	assert.Equal(t, core.BreakGlassRevoked, list[0].State)
+	assert.Equal(t, winner, list[0].RevokedBy, "attribution must belong to whichever admin's conditional update actually won")
 }
 
 // List reports an active record past its expiry as expired (lazy reconciliation).

--- a/internal/core/break_glass_revoke_test.go
+++ b/internal/core/break_glass_revoke_test.go
@@ -1,0 +1,79 @@
+// break_glass_revoke_test.go — regression tests for RevokeBreakGlass's handling of
+// RemoveUserRole failures (#303): a genuine storage failure removing the emergency
+// role assignment must abort the revoke rather than silently proceeding to mark the
+// activation "revoked" while the live grant survives in user_roles. The companion
+// "row already gone" case (already auto-expired, or already removed) must still be
+// treated as success.
+package core
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestActivation() *models.BreakGlassActivation {
+	expiresAt := time.Date(2026, 7, 1, 13, 0, 0, 0, time.UTC)
+	return &models.BreakGlassActivation{
+		ID: 7, ProjectID: 2, UserID: 10, RoleID: 3, RoleName: "editor",
+		State: BreakGlassActive, ExpiresAt: &expiresAt,
+	}
+}
+
+// TestRevokeBreakGlass_GenuineRoleRemovalFailureAbortsRevoke reproduces #303: a
+// genuine storage error (NOT "row not assigned") from RemoveUserRole must propagate
+// out of RevokeBreakGlass, and the function must NOT go on to persist the activation
+// as revoked. Before the fix, the error was discarded (`_ = c.RemoveUserRole(...)`)
+// and the function proceeded unconditionally, leaving the emergency role grant LIVE
+// in user_roles while the activation, API response, and audit trail all reported it
+// as revoked.
+func TestRevokeBreakGlass_GenuineRoleRemovalFailureAbortsRevoke(t *testing.T) {
+	mockStorage := new(MockStorage)
+	now := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	c := &KeyorixCore{storage: mockStorage, now: func() time.Time { return now }}
+	ctx := context.Background()
+
+	activation := newTestActivation()
+	mockStorage.On("GetBreakGlassActivation", mock.Anything, uint(7)).Return(activation, nil)
+
+	dbErr := errors.New("connection reset by peer")
+	mockStorage.On("RemoveRole", mock.Anything, uint(10), uint(3), storage.Scope{ProjectID: 2}).Return(dbErr)
+
+	err := c.RevokeBreakGlass(ctx, 1, 2, 7)
+	require.Error(t, err, "a genuine RemoveUserRole failure must abort the revoke")
+
+	// The conditional state transition (and the audit write that follows it) must
+	// never be reached: no expectation was set for either, so RevokeBreakGlassActivation
+	// or LogAuditEvent being called would fail this test (mock panics on an
+	// unexpected call, or AssertExpectations below would report an extra call).
+	mockStorage.AssertNotCalled(t, "RevokeBreakGlassActivation", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	mockStorage.AssertExpectations(t)
+}
+
+// TestRevokeBreakGlass_AlreadyGoneRoleRemovalIsNotAFailure is the companion half of
+// #303: RemoveUserRole's own "row not found" case (the grant already auto-expired,
+// or a racing revoke already removed it) must still be treated as success, not a
+// hard failure that blocks the revoke.
+func TestRevokeBreakGlass_AlreadyGoneRoleRemovalIsNotAFailure(t *testing.T) {
+	mockStorage := new(MockStorage)
+	now := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	c := &KeyorixCore{storage: mockStorage, now: func() time.Time { return now }}
+	ctx := context.Background()
+
+	activation := newTestActivation()
+	mockStorage.On("GetBreakGlassActivation", mock.Anything, uint(7)).Return(activation, nil)
+	mockStorage.On("RemoveRole", mock.Anything, uint(10), uint(3), storage.Scope{ProjectID: 2}).
+		Return(storage.ErrRoleNotAssigned)
+	mockStorage.On("RevokeBreakGlassActivation", mock.Anything, uint(7), uint(1), now).Return(nil)
+	mockStorage.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
+
+	err := c.RevokeBreakGlass(ctx, 1, 2, 7)
+	require.NoError(t, err, "an already-removed role assignment must not block the revoke")
+	mockStorage.AssertExpectations(t)
+}

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -397,6 +397,11 @@ func (m *MockStorage) UpdateBreakGlassActivation(ctx context.Context, a *models.
 	return args.Error(0)
 }
 
+func (m *MockStorage) RevokeBreakGlassActivation(ctx context.Context, id, revokedBy uint, revokedAt time.Time) error {
+	args := m.Called(ctx, id, revokedBy, revokedAt)
+	return args.Error(0)
+}
+
 func (m *MockStorage) GetEnvironment(_ context.Context, id uint) (*models.Environment, error) {
 	return &models.Environment{ID: id, ProjectID: 1, Name: "test"}, nil
 }

--- a/internal/core/storage/errors.go
+++ b/internal/core/storage/errors.go
@@ -7,3 +7,17 @@ import "errors"
 // closed on uncertainty — e.g. authorization decisions keyed on "is this account
 // gone?" — should match it with errors.Is rather than treating any error as absence.
 var ErrUserNotFound = errors.New("user not found")
+
+// ErrRoleNotAssigned is returned (wrapped) by RemoveRole when the (user, role, scope)
+// row positively does not exist — e.g. it already auto-expired or was already
+// removed — as distinct from a genuine storage failure. Callers for whom "already
+// gone" is an acceptable outcome (idempotent removal) should match it with
+// errors.Is rather than swallowing every error identically.
+var ErrRoleNotAssigned = errors.New("role not assigned")
+
+// ErrBreakGlassNotActive is returned (wrapped) when a conditional break-glass state
+// transition (e.g. revoke) finds the activation is no longer in the expected prior
+// state — most often because a concurrent revoke already won the race. Distinct
+// from a genuine storage failure; callers should surface it as "already revoked"
+// rather than a generic error.
+var ErrBreakGlassNotActive = errors.New("break-glass activation is not active")

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -126,6 +126,13 @@ type Storage interface {
 	GetBreakGlassActivation(ctx context.Context, id uint) (*models.BreakGlassActivation, error)
 	ListBreakGlassActivations(ctx context.Context, projectID uint) ([]*models.BreakGlassActivation, error)
 	UpdateBreakGlassActivation(ctx context.Context, a *models.BreakGlassActivation) error
+	// RevokeBreakGlassActivation atomically transitions activation id from active to
+	// revoked, recording who revoked it and when, via a single conditional UPDATE
+	// (WHERE state = active) rather than a read-modify-write — so two concurrent
+	// revokes of the same activation cannot both "win": only the first transitions
+	// state, and the second gets ErrBreakGlassNotActive rather than silently
+	// overwriting the first revoker's attribution.
+	RevokeBreakGlassActivation(ctx context.Context, id, revokedBy uint, revokedAt time.Time) error
 	// Machine identities (ADR-023) — non-human project members.
 	CreateMachineIdentity(ctx context.Context, m *models.MachineIdentity) (*models.MachineIdentity, error)
 	GetMachineIdentity(ctx context.Context, id uint) (*models.MachineIdentity, error)

--- a/internal/storage/store/local_break_glass.go
+++ b/internal/storage/store/local_break_glass.go
@@ -5,9 +5,19 @@ package store
 import (
 	"context"
 	"fmt"
+	"time"
 
+	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// breakGlassActiveState / breakGlassRevokedState mirror core.BreakGlassActive /
+// core.BreakGlassRevoked. Duplicated here (rather than imported) because this
+// package is imported BY internal/core — importing core back would cycle.
+const (
+	breakGlassActiveState  = "active"
+	breakGlassRevokedState = "revoked"
 )
 
 func (ls *LocalStorage) CreateBreakGlassActivation(ctx context.Context, a *models.BreakGlassActivation) (*models.BreakGlassActivation, error) {
@@ -40,6 +50,28 @@ func (ls *LocalStorage) ListBreakGlassActivations(ctx context.Context, projectID
 func (ls *LocalStorage) UpdateBreakGlassActivation(ctx context.Context, a *models.BreakGlassActivation) error {
 	if err := ls.db.WithContext(ctx).Save(a).Error; err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	return nil
+}
+
+// RevokeBreakGlassActivation conditionally transitions activation id from active to
+// revoked in a single UPDATE ... WHERE state = 'active' — not a read-then-write —
+// so a concurrent revoke of the same activation cannot silently overwrite this
+// one's RevokedBy/RevokedAt. Returns storage.ErrBreakGlassNotActive (wrapped) if
+// the row was not active (already revoked, or absent).
+func (ls *LocalStorage) RevokeBreakGlassActivation(ctx context.Context, id, revokedBy uint, revokedAt time.Time) error {
+	result := ls.db.WithContext(ctx).Model(&models.BreakGlassActivation{}).
+		Where("id = ? AND state = ?", id, breakGlassActiveState).
+		Updates(map[string]interface{}{
+			"state":      breakGlassRevokedState,
+			"revoked_by": revokedBy,
+			"revoked_at": revokedAt,
+		})
+	if result.Error != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), result.Error)
+	}
+	if result.RowsAffected == 0 {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorValidation", nil), storage.ErrBreakGlassNotActive)
 	}
 	return nil
 }

--- a/internal/storage/store/local_rbac.go
+++ b/internal/storage/store/local_rbac.go
@@ -141,7 +141,7 @@ func (ls *LocalStorage) RemoveRole(ctx context.Context, userID, roleID uint, sco
 		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), result.Error)
 	}
 	if result.RowsAffected == 0 {
-		return fmt.Errorf("%s", i18n.T("ErrorRoleNotAssigned", nil))
+		return fmt.Errorf("%s: %w", i18n.T("ErrorRoleNotAssigned", nil), storage.ErrRoleNotAssigned)
 	}
 	return nil
 }

--- a/internal/storage/store/remote_break_glass.go
+++ b/internal/storage/store/remote_break_glass.go
@@ -4,6 +4,7 @@ package store
 
 import (
 	"context"
+	"time"
 
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
@@ -22,4 +23,8 @@ func (rs *RemoteStorage) ListBreakGlassActivations(_ context.Context, _ uint) ([
 
 func (rs *RemoteStorage) UpdateBreakGlassActivation(_ context.Context, _ *models.BreakGlassActivation) error {
 	return remoteUnsupported("UpdateBreakGlassActivation")
+}
+
+func (rs *RemoteStorage) RevokeBreakGlassActivation(_ context.Context, _, _ uint, _ time.Time) error {
+	return remoteUnsupported("RevokeBreakGlassActivation")
 }


### PR DESCRIPTION
## Summary
- **#303 MEDIUM**: `RevokeBreakGlass` discarded the `RemoveUserRole` error unconditionally (`_ = c.RemoveUserRole(...)`), so a genuine storage failure removing the emergency role assignment was indistinguishable from the benign "row already gone" (auto-expired) case. On a real failure, the emergency role grant stayed LIVE in `user_roles` — the table RBAC actually reads — while the activation, API response, and `break_glass.revoked` audit event all reported it as revoked. Fixed: only `storage.ErrRoleNotAssigned` (the row genuinely no longer exists) is tolerated; any other error now aborts the revoke.
- **#304 LOW**: the subsequent state transition was a non-atomic check-then-act (`GetBreakGlassActivation` → state check → `Save`), so two concurrent revokes (e.g. two admins) could both pass the check and the later `Save` would silently overwrite the earlier one's `RevokedBy`/`RevokedAt`. Replaced with a single conditional `UPDATE ... WHERE state = 'active'` (new `RevokeBreakGlassActivation` storage method, checking `RowsAffected`) so only the first concurrent revoke transitions state; the second now gets a clean "activation is not active" error instead of corrupting attribution.

## Test plan
- [x] New regression tests: `TestRevokeBreakGlass_GenuineRoleRemovalFailureAbortsRevoke` / `TestRevokeBreakGlass_AlreadyGoneRoleRemovalIsNotAFailure` (mocked storage, #303) and `TestRevokeBreakGlassActivation_ConditionalUpdateOnlyFirstAttemptWins` / `TestRevokeBreakGlass_ConcurrentRevokesOnlyOneWins` (real SQLite, goroutine race, #304)
- [x] `go build ./...`
- [x] `go test ./...` (full suite green; pre-existing `TestHTTPJWKSResolver_CapsKeyCount` flake confirmed unrelated — reproduces the same way on unmodified `main`)
- [x] `go test ./internal/core/... -race -run BreakGlass`
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues
- [x] `golangci-lint run ./...` — 0 issues
- [x] `GOWORK=off go build -C operator ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)