### PR TITLE
fix(encryption): wire auth-encryption CLI and harden migrate/rotate/validate (#292)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -191,3 +191,6 @@ certs/
 
 # compiled binary debris (use bin/ via make build)
 /main
+
+# throwaway binaries / test artifacts
+/.scratch/

--- a/internal/cli/auth_encryption_wiring_test.go
+++ b/internal/cli/auth_encryption_wiring_test.go
@@ -1,0 +1,30 @@
+package cli
+
+// auth_encryption_wiring_test.go — regression test for #292: AuthEncryptionCmd
+// was defined but never reached rootCmd, so `keyorix encryption auth-encryption`
+// failed with "unknown command" in the shipped binary even though the
+// implementation existed. Walk the real command tree from rootCmd, exactly as
+// the shipped `keyorix` binary would resolve `keyorix encryption
+// auth-encryption <subcommand>`.
+import "testing"
+
+func TestRootCmd_AuthEncryptionReachable(t *testing.T) {
+	encCmd, _, err := rootCmd.Find([]string{"encryption"})
+	if err != nil {
+		t.Fatalf("rootCmd has no 'encryption' command: %v", err)
+	}
+
+	authCmd, _, err := rootCmd.Find([]string{"encryption", "auth-encryption"})
+	if err != nil {
+		t.Fatalf("'keyorix encryption auth-encryption' is unreachable from rootCmd: %v", err)
+	}
+	if authCmd.Parent() != encCmd {
+		t.Fatalf("auth-encryption resolved but is not a child of the encryption command")
+	}
+
+	for _, sub := range []string{"status", "enable", "rotate", "migrate", "validate"} {
+		if _, _, err := rootCmd.Find([]string{"encryption", "auth-encryption", sub}); err != nil {
+			t.Errorf("'keyorix encryption auth-encryption %s' is unreachable: %v", sub, err)
+		}
+	}
+}

--- a/internal/cli/encryption/auth_encryption_cli_test.go
+++ b/internal/cli/encryption/auth_encryption_cli_test.go
@@ -1,0 +1,198 @@
+package encryption
+
+// auth_encryption_cli_test.go — regression coverage for #292:
+//   - AuthEncryptionCmd must actually be wired into the command tree.
+//   - migrate must clear the plaintext column once the encrypted value is written.
+//   - validate must flag unmigrated (plaintext-only) rows instead of silently
+//     printing an all-clear.
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/encryption"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// TestAuthEncryptionCmd_WiredIntoCommandTree is the regression test for the
+// core #292 defect: AuthEncryptionCmd was defined but never added to
+// EncryptionCmd, so `keyorix encryption auth-encryption` (and every subcommand
+// under it) failed with "unknown command" even though the code existed.
+func TestAuthEncryptionCmd_WiredIntoCommandTree(t *testing.T) {
+	found := false
+	var names []string
+	for _, cmd := range EncryptionCmd.Commands() {
+		names = append(names, cmd.Name())
+		if cmd.Name() == "auth-encryption" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("auth-encryption not found under EncryptionCmd; got subcommands: %v", names)
+	}
+
+	// The five documented subcommands must all be reachable too.
+	want := map[string]bool{"status": false, "enable": false, "rotate": false, "migrate": false, "validate": false}
+	for _, cmd := range AuthEncryptionCmd.Commands() {
+		if _, ok := want[cmd.Name()]; ok {
+			want[cmd.Name()] = true
+		}
+	}
+	for name, ok := range want {
+		if !ok {
+			t.Errorf("auth-encryption subcommand %q not registered", name)
+		}
+	}
+}
+
+// setupMigrateValidateTest opens a real on-disk sqlite DB with encryption
+// enabled (key files generated under t.TempDir()) and returns the AuthEncryption
+// handle plus the raw *gorm.DB, mirroring how the CLI commands construct both.
+func setupMigrateValidateTest(t *testing.T) (*encryption.AuthEncryption, *gorm.DB) {
+	t.Helper()
+	tempDir := t.TempDir()
+
+	dbPath := filepath.Join(tempDir, "test.db")
+	db, err := gorm.Open(sqlite.Open(dbPath), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.APIClient{},
+		&models.Session{},
+		&models.APIToken{},
+		&models.PasswordReset{},
+	))
+
+	cfg := &config.EncryptionConfig{
+		Enabled:  true,
+		DEKPath:  "dek.key",
+		SaltPath: "kek.salt",
+	}
+	authEnc := encryption.NewAuthEncryption(cfg, tempDir, db)
+	require.NoError(t, authEnc.Initialize("migrate-validate-test-passphrase"))
+
+	t.Cleanup(func() {
+		if sqlDB, err := db.DB(); err == nil {
+			_ = sqlDB.Close()
+		}
+	})
+
+	return authEnc, db
+}
+
+// TestMigrateAuthData_ClearsPlaintextColumns is the regression test for latent
+// defect #1: a successful migrate must null out the plaintext column, not just
+// write the encrypted counterpart alongside it.
+func TestMigrateAuthData_ClearsPlaintextColumns(t *testing.T) {
+	authEnc, db := setupMigrateValidateTest(t)
+
+	client := &models.APIClient{Name: "c", ClientID: "client-1", ClientSecret: "plain-client-secret", IsActive: true}
+	require.NoError(t, db.Create(client).Error)
+
+	session := &models.Session{UserID: 1, SessionToken: "plain-session-token"}
+	require.NoError(t, db.Create(session).Error)
+
+	token := &models.APIToken{ClientID: 1, Token: "plain-api-token"}
+	require.NoError(t, db.Create(token).Error)
+
+	reset := &models.PasswordReset{UserID: 1, Token: "plain-reset-token"}
+	require.NoError(t, db.Create(reset).Error)
+
+	require.NoError(t, migrateAPIClients(db, authEnc, false))
+	require.NoError(t, migrateSessions(db, authEnc, false))
+	require.NoError(t, migrateAPITokens(db, authEnc, false))
+	require.NoError(t, migratePasswordResetTokens(db, authEnc, false))
+
+	var gotClient models.APIClient
+	require.NoError(t, db.First(&gotClient, client.ID).Error)
+	require.Empty(t, gotClient.ClientSecret, "plaintext client_secret must be cleared after migration")
+	require.NotEmpty(t, gotClient.EncryptedClientSecret)
+	plain, err := authEnc.DecryptClientSecret(gotClient.EncryptedClientSecret, []byte(gotClient.ClientSecretMetadata))
+	require.NoError(t, err)
+	require.Equal(t, "plain-client-secret", plain)
+
+	var gotSession models.Session
+	require.NoError(t, db.First(&gotSession, session.ID).Error)
+	require.Empty(t, gotSession.SessionToken, "plaintext session_token must be cleared after migration")
+	require.NotEmpty(t, gotSession.EncryptedSessionToken)
+
+	var gotToken models.APIToken
+	require.NoError(t, db.First(&gotToken, token.ID).Error)
+	require.Empty(t, gotToken.Token, "plaintext token must be cleared after migration")
+	require.NotEmpty(t, gotToken.EncryptedToken)
+
+	var gotReset models.PasswordReset
+	require.NoError(t, db.First(&gotReset, reset.ID).Error)
+	require.Empty(t, gotReset.Token, "plaintext reset token must be cleared after migration")
+	require.NotEmpty(t, gotReset.EncryptedToken)
+
+	// A second migrate pass must be a no-op (nothing left matching the
+	// "plaintext present, no encrypted value" query) — and, critically, must not
+	// fail on a unique-constraint collision now that multiple rows share a
+	// cleared (NULL) plaintext column.
+	require.NoError(t, migrateAPIClients(db, authEnc, false))
+	require.NoError(t, migrateSessions(db, authEnc, false))
+	require.NoError(t, migrateAPITokens(db, authEnc, false))
+	require.NoError(t, migratePasswordResetTokens(db, authEnc, false))
+}
+
+// TestMigrateAuthData_ClearsPlaintext_MultipleRowsNoUniqueCollision guards the
+// NULL-not-empty-string choice: session_token/token columns carry a unique
+// index, so clearing two rows to "" would collide on the second UPDATE.
+func TestMigrateAuthData_ClearsPlaintext_MultipleRowsNoUniqueCollision(t *testing.T) {
+	authEnc, db := setupMigrateValidateTest(t)
+
+	s1 := &models.Session{UserID: 1, SessionToken: "session-token-one"}
+	s2 := &models.Session{UserID: 2, SessionToken: "session-token-two"}
+	require.NoError(t, db.Create(s1).Error)
+	require.NoError(t, db.Create(s2).Error)
+
+	require.NoError(t, migrateSessions(db, authEnc, false))
+
+	var got1, got2 models.Session
+	require.NoError(t, db.First(&got1, s1.ID).Error)
+	require.NoError(t, db.First(&got2, s2.ID).Error)
+	require.Empty(t, got1.SessionToken)
+	require.Empty(t, got2.SessionToken)
+	require.NotEmpty(t, got1.EncryptedSessionToken)
+	require.NotEmpty(t, got2.EncryptedSessionToken)
+}
+
+// TestValidateAuthEncryption_FlagsUnmigratedRows is the regression test for
+// latent defect #3: an unmigrated (plaintext-only, no Encrypted* value) row
+// must be reported, not silently invisible to validate.
+func TestValidateAuthEncryption_FlagsUnmigratedRows(t *testing.T) {
+	authEnc, db := setupMigrateValidateTest(t)
+
+	// Unmigrated row: plaintext present, no Encrypted* value at all.
+	unmigrated := &models.APIClient{Name: "u", ClientID: "unmigrated", ClientSecret: "still-plaintext", IsActive: true}
+	require.NoError(t, db.Create(unmigrated).Error)
+
+	// Properly migrated row: should validate clean and not be counted.
+	enc, meta, err := authEnc.EncryptClientSecret("already-encrypted")
+	require.NoError(t, err)
+	migrated := &models.APIClient{Name: "m", ClientID: "migrated", EncryptedClientSecret: enc, ClientSecretMetadata: models.JSON(meta), IsActive: true}
+	require.NoError(t, db.Create(migrated).Error)
+
+	n, err := validateAPIClients(db, authEnc, false)
+	require.NoError(t, err)
+	require.Equal(t, 1, n, "exactly one unmigrated row (plaintext, no Encrypted* value) must be flagged")
+}
+
+// TestValidateAuthEncryption_CleanWhenFullyMigrated confirms the zero-unmigrated
+// case still validates as clean (no false positives once migrate has run).
+func TestValidateAuthEncryption_CleanWhenFullyMigrated(t *testing.T) {
+	authEnc, db := setupMigrateValidateTest(t)
+
+	enc, meta, err := authEnc.EncryptClientSecret("fully-migrated-secret")
+	require.NoError(t, err)
+	client := &models.APIClient{Name: "m", ClientID: "clean", EncryptedClientSecret: enc, ClientSecretMetadata: models.JSON(meta), IsActive: true}
+	require.NoError(t, db.Create(client).Error)
+
+	n, err := validateAPIClients(db, authEnc, false)
+	require.NoError(t, err)
+	require.Zero(t, n)
+}

--- a/internal/cli/encryption/auth_encryption_migrate.go
+++ b/internal/cli/encryption/auth_encryption_migrate.go
@@ -71,9 +71,17 @@ func migrateAPIClients(db *gorm.DB, authEnc *encryption.AuthEncryption, dryRun b
 		if err != nil {
 			return fmt.Errorf("failed to encrypt client secret for client %s: %w", client.ClientID, err)
 		}
+		// Clear the plaintext column in the same update that writes the encrypted
+		// value — leaving it populated after a "successful" migration defeats the
+		// point: the #278 compromise surface (a readable plaintext column) would
+		// still be sitting right next to its encrypted replacement. NULL, not "",
+		// since a second migrated row with "" would collide with any unique index
+		// on the column; NULL is exempt from uniqueness checks on every backend
+		// this CLI targets (sqlite/postgres).
 		if err := db.Model(&client).Updates(map[string]interface{}{
 			"encrypted_client_secret": enc,
 			"client_secret_metadata":  meta,
+			"client_secret":           nil,
 		}).Error; err != nil {
 			return fmt.Errorf("failed to update client %s: %w", client.ClientID, err)
 		}
@@ -95,9 +103,12 @@ func migrateSessions(db *gorm.DB, authEnc *encryption.AuthEncryption, dryRun boo
 		if err != nil {
 			return fmt.Errorf("failed to encrypt session token for session %d: %w", session.ID, err)
 		}
+		// See migrateAPIClients for why the plaintext column is cleared (set to
+		// NULL, not "") in the same update as the encrypted write.
 		if err := db.Model(&session).Updates(map[string]interface{}{
 			"encrypted_session_token": enc,
 			"session_token_metadata":  meta,
+			"session_token":           nil,
 		}).Error; err != nil {
 			return fmt.Errorf("failed to update session %d: %w", session.ID, err)
 		}
@@ -119,9 +130,12 @@ func migrateAPITokens(db *gorm.DB, authEnc *encryption.AuthEncryption, dryRun bo
 		if err != nil {
 			return fmt.Errorf("failed to encrypt API token %d: %w", token.ID, err)
 		}
+		// See migrateAPIClients for why the plaintext column is cleared (set to
+		// NULL, not "") in the same update as the encrypted write.
 		if err := db.Model(&token).Updates(map[string]interface{}{
 			"encrypted_token": enc,
 			"token_metadata":  meta,
+			"token":           nil,
 		}).Error; err != nil {
 			return fmt.Errorf("failed to update API token %d: %w", token.ID, err)
 		}
@@ -143,9 +157,12 @@ func migratePasswordResetTokens(db *gorm.DB, authEnc *encryption.AuthEncryption,
 		if err != nil {
 			return fmt.Errorf("failed to encrypt password reset token %d: %w", reset.ID, err)
 		}
+		// See migrateAPIClients for why the plaintext column is cleared (set to
+		// NULL, not "") in the same update as the encrypted write.
 		if err := db.Model(&reset).Updates(map[string]interface{}{
 			"encrypted_token": enc,
 			"token_metadata":  meta,
+			"token":           nil,
 		}).Error; err != nil {
 			return fmt.Errorf("failed to update password reset token %d: %w", reset.ID, err)
 		}

--- a/internal/cli/encryption/auth_encryption_validate.go
+++ b/internal/cli/encryption/auth_encryption_validate.go
@@ -1,6 +1,8 @@
 // auth_encryption_validate.go — runValidateAuthEncryption and per-table validate helpers.
 //
-// Decrypts every encrypted auth row to confirm keys are working.
+// Decrypts every encrypted auth row to confirm keys are working, and separately
+// flags any row that still holds a plaintext value with no corresponding
+// Encrypted* value (i.e. one 'auth-encryption migrate' hasn't reached yet).
 // For migration see auth_encryption_migrate.go.
 package encryption
 
@@ -32,95 +34,157 @@ func runValidateAuthEncryption(cmd *cobra.Command, args []string) error {
 
 	fmt.Println("🔍 Validating authentication encryption...")
 
-	if err := validateAPIClients(db, authEnc, verbose); err != nil {
+	var unmigrated int
+
+	n, err := validateAPIClients(db, authEnc, verbose)
+	if err != nil {
 		return fmt.Errorf("API client validation failed: %w", err)
 	}
-	if err := validateSessions(db, authEnc, verbose); err != nil {
+	unmigrated += n
+
+	n, err = validateSessions(db, authEnc, verbose)
+	if err != nil {
 		return fmt.Errorf("session validation failed: %w", err)
 	}
-	if err := validateAPITokens(db, authEnc, verbose); err != nil {
+	unmigrated += n
+
+	n, err = validateAPITokens(db, authEnc, verbose)
+	if err != nil {
 		return fmt.Errorf("API token validation failed: %w", err)
 	}
-	if err := validatePasswordResetTokens(db, authEnc, verbose); err != nil {
+	unmigrated += n
+
+	n, err = validatePasswordResetTokens(db, authEnc, verbose)
+	if err != nil {
 		return fmt.Errorf("password reset token validation failed: %w", err)
+	}
+	unmigrated += n
+
+	// #292: previously this printed the all-clear message unconditionally,
+	// regardless of how many rows had a plaintext value with no Encrypted*
+	// counterpart at all (invisible to the decrypt-only checks above, since those
+	// only ever query "Encrypted* IS NOT NULL") — the same false-clean shape as
+	// the posture-fails-open family (#136/#145/#149). Fail loud instead: a
+	// non-zero unmigrated count is reported per-row above and turns this into a
+	// non-zero exit rather than a silent pass.
+	if unmigrated > 0 {
+		fmt.Printf("❌ %d authentication row(s) still hold a plaintext value with no encrypted counterpart — run 'keyorix encryption auth-encryption migrate'\n", unmigrated)
+		return fmt.Errorf("%d authentication row(s) need migration to encrypted storage", unmigrated)
 	}
 
 	fmt.Println("✅ All authentication encryption validation checks passed")
 	return nil
 }
 
-func validateAPIClients(db *gorm.DB, authEnc *encryption.AuthEncryption, verbose bool) error {
+// validateAPIClients decrypts every already-encrypted API client row (proving
+// the current keys work), then separately reports and counts rows that still
+// hold a plaintext client_secret with no Encrypted* counterpart — those are
+// invisible to the decrypt check above since it only ever queries
+// "encrypted_client_secret IS NOT NULL".
+func validateAPIClients(db *gorm.DB, authEnc *encryption.AuthEncryption, verbose bool) (int, error) {
 	var clients []models.APIClient
 	if err := db.Where("encrypted_client_secret IS NOT NULL").Find(&clients).Error; err != nil {
-		return err
+		return 0, err
 	}
 	if verbose {
 		fmt.Printf("🔑 Validating %d encrypted API clients...\n", len(clients))
 	}
 	for _, client := range clients {
 		if _, err := authEnc.DecryptClientSecret(client.EncryptedClientSecret, []byte(client.ClientSecretMetadata)); err != nil {
-			return fmt.Errorf("failed to decrypt client secret for client %s: %w", client.ClientID, err)
+			return 0, fmt.Errorf("failed to decrypt client secret for client %s: %w", client.ClientID, err)
 		}
 		if verbose {
 			fmt.Printf("  ✅ Client %s: OK\n", client.ClientID)
 		}
 	}
-	return nil
+
+	var unmigrated []models.APIClient
+	if err := db.Where("client_secret != '' AND client_secret IS NOT NULL AND encrypted_client_secret IS NULL").Find(&unmigrated).Error; err != nil {
+		return 0, err
+	}
+	for _, client := range unmigrated {
+		fmt.Printf("  ⚠️  Client %s: plaintext client_secret with no encrypted counterpart — needs migration\n", client.ClientID)
+	}
+	return len(unmigrated), nil
 }
 
-func validateSessions(db *gorm.DB, authEnc *encryption.AuthEncryption, verbose bool) error {
+func validateSessions(db *gorm.DB, authEnc *encryption.AuthEncryption, verbose bool) (int, error) {
 	var sessions []models.Session
 	if err := db.Where("encrypted_session_token IS NOT NULL").Find(&sessions).Error; err != nil {
-		return err
+		return 0, err
 	}
 	if verbose {
 		fmt.Printf("🎫 Validating %d encrypted sessions...\n", len(sessions))
 	}
 	for _, session := range sessions {
 		if _, err := authEnc.DecryptSessionToken(session.EncryptedSessionToken, []byte(session.SessionTokenMetadata)); err != nil {
-			return fmt.Errorf("failed to decrypt session token for session %d: %w", session.ID, err)
+			return 0, fmt.Errorf("failed to decrypt session token for session %d: %w", session.ID, err)
 		}
 		if verbose {
 			fmt.Printf("  ✅ Session %d: OK\n", session.ID)
 		}
 	}
-	return nil
+
+	var unmigrated []models.Session
+	if err := db.Where("session_token != '' AND session_token IS NOT NULL AND encrypted_session_token IS NULL").Find(&unmigrated).Error; err != nil {
+		return 0, err
+	}
+	for _, session := range unmigrated {
+		fmt.Printf("  ⚠️  Session %d: plaintext session_token with no encrypted counterpart — needs migration\n", session.ID)
+	}
+	return len(unmigrated), nil
 }
 
-func validateAPITokens(db *gorm.DB, authEnc *encryption.AuthEncryption, verbose bool) error {
+func validateAPITokens(db *gorm.DB, authEnc *encryption.AuthEncryption, verbose bool) (int, error) {
 	var tokens []models.APIToken
 	if err := db.Where("encrypted_token IS NOT NULL").Find(&tokens).Error; err != nil {
-		return err
+		return 0, err
 	}
 	if verbose {
 		fmt.Printf("🎟️  Validating %d encrypted API tokens...\n", len(tokens))
 	}
 	for _, token := range tokens {
 		if _, err := authEnc.DecryptAPIToken(token.EncryptedToken, []byte(token.TokenMetadata)); err != nil {
-			return fmt.Errorf("failed to decrypt API token %d: %w", token.ID, err)
+			return 0, fmt.Errorf("failed to decrypt API token %d: %w", token.ID, err)
 		}
 		if verbose {
 			fmt.Printf("  ✅ API Token %d: OK\n", token.ID)
 		}
 	}
-	return nil
+
+	var unmigrated []models.APIToken
+	if err := db.Where("token != '' AND token IS NOT NULL AND encrypted_token IS NULL").Find(&unmigrated).Error; err != nil {
+		return 0, err
+	}
+	for _, token := range unmigrated {
+		fmt.Printf("  ⚠️  API Token %d: plaintext token with no encrypted counterpart — needs migration\n", token.ID)
+	}
+	return len(unmigrated), nil
 }
 
-func validatePasswordResetTokens(db *gorm.DB, authEnc *encryption.AuthEncryption, verbose bool) error {
+func validatePasswordResetTokens(db *gorm.DB, authEnc *encryption.AuthEncryption, verbose bool) (int, error) {
 	var resets []models.PasswordReset
 	if err := db.Where("encrypted_token IS NOT NULL").Find(&resets).Error; err != nil {
-		return err
+		return 0, err
 	}
 	if verbose {
 		fmt.Printf("🔄 Validating %d encrypted password reset tokens...\n", len(resets))
 	}
 	for _, reset := range resets {
 		if _, err := authEnc.DecryptPasswordResetToken(reset.EncryptedToken, []byte(reset.TokenMetadata)); err != nil {
-			return fmt.Errorf("failed to decrypt password reset token %d: %w", reset.ID, err)
+			return 0, fmt.Errorf("failed to decrypt password reset token %d: %w", reset.ID, err)
 		}
 		if verbose {
 			fmt.Printf("  ✅ Reset Token %d: OK\n", reset.ID)
 		}
 	}
-	return nil
+
+	var unmigrated []models.PasswordReset
+	if err := db.Where("token != '' AND token IS NOT NULL AND encrypted_token IS NULL").Find(&unmigrated).Error; err != nil {
+		return 0, err
+	}
+	for _, reset := range unmigrated {
+		fmt.Printf("  ⚠️  Reset Token %d: plaintext token with no encrypted counterpart — needs migration\n", reset.ID)
+	}
+	return len(unmigrated), nil
 }

--- a/internal/cli/encryption/encryption.go
+++ b/internal/cli/encryption/encryption.go
@@ -66,6 +66,13 @@ func init() {
 	EncryptionCmd.AddCommand(rotateCmd)
 	EncryptionCmd.AddCommand(validateCmd)
 	EncryptionCmd.AddCommand(fixPermsCmd)
+	// AuthEncryptionCmd (status/enable/rotate/migrate/validate for the
+	// authentication-data encryption subsystem — API client secrets, session
+	// tokens, API tokens, password reset tokens) is defined in auth_encryption.go
+	// but was never wired into the tree, leaving it dead code (#292). It is
+	// distinct from the DEK-rotation `rotate`/`validate` above, which operate on
+	// secret VALUES, not auth credentials.
+	EncryptionCmd.AddCommand(AuthEncryptionCmd)
 
 	rotateCmd.Flags().BoolVar(&rotateConfirm, "confirm", false,
 		"required acknowledgement that the database will be write-locked during the sweep")

--- a/internal/encryption/auth_encryption_rotate.go
+++ b/internal/encryption/auth_encryption_rotate.go
@@ -1,6 +1,7 @@
 // auth_encryption_rotate.go — RotateAuthEncryption and per-type rotation helpers.
 //
-// RotateAuthEncryption, rotateAPIClientSecrets, rotateSessionTokens, rotateAPITokens.
+// RotateAuthEncryption, rotateAPIClientSecrets, rotateSessionTokens, rotateAPITokens,
+// rotatePasswordResetTokens.
 // For encrypt/decrypt see auth_encryption.go. For DB store/retrieve see auth_encryption_store.go.
 package encryption
 
@@ -8,31 +9,68 @@ import (
 	"fmt"
 
 	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"gorm.io/gorm"
 )
 
-// RotateAuthEncryption re-encrypts all authentication data (API clients, sessions, API tokens).
+// RotateAuthEncryption re-encrypts all authentication data (API clients, sessions,
+// API tokens, password reset tokens) with the current key.
+//
+// The whole sweep runs inside a single DB transaction — committed only if every
+// row rotates cleanly, rolled back on any failure — mirroring the live
+// RotateDEKWithSweep→SweepAllTables pattern (internal/encryption/service_rotation.go,
+// sweep.go) so a mid-loop failure can never leave a permanent partial-rotation
+// state (some rows under the new key, the rest stuck under the old one).
 func (ae *AuthEncryption) RotateAuthEncryption() error {
 	if !ae.service.IsEnabled() {
 		return fmt.Errorf("encryption is disabled")
 	}
-	if err := ae.rotateAPIClientSecrets(); err != nil {
+
+	tx := ae.db.Begin()
+	if tx.Error != nil {
+		return fmt.Errorf("failed to begin rotation transaction: %w", tx.Error)
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			tx.Rollback()
+			panic(r)
+		}
+	}()
+
+	if err := ae.rotateAPIClientSecrets(tx); err != nil {
+		tx.Rollback()
 		return fmt.Errorf("failed to rotate API client secrets: %w", err)
 	}
-	if err := ae.rotateSessionTokens(); err != nil {
+	if err := ae.rotateSessionTokens(tx); err != nil {
+		tx.Rollback()
 		return fmt.Errorf("failed to rotate session tokens: %w", err)
 	}
-	if err := ae.rotateAPITokens(); err != nil {
+	if err := ae.rotateAPITokens(tx); err != nil {
+		tx.Rollback()
 		return fmt.Errorf("failed to rotate API tokens: %w", err)
+	}
+	if err := ae.rotatePasswordResetTokens(tx); err != nil {
+		tx.Rollback()
+		return fmt.Errorf("failed to rotate password reset tokens: %w", err)
+	}
+
+	if err := tx.Commit().Error; err != nil {
+		return fmt.Errorf("failed to commit rotation transaction: %w", err)
 	}
 	return nil
 }
 
-func (ae *AuthEncryption) rotateAPIClientSecrets() error {
+func (ae *AuthEncryption) rotateAPIClientSecrets(tx *gorm.DB) error {
 	var clients []models.APIClient
-	if err := ae.db.Find(&clients).Error; err != nil {
+	if err := tx.Find(&clients).Error; err != nil {
 		return fmt.Errorf("failed to retrieve API clients: %w", err)
 	}
 	for _, client := range clients {
+		if len(client.EncryptedClientSecret) == 0 {
+			// #278: row has no Encrypted* value yet (still plaintext-only, or never
+			// populated) — nothing to rotate. Skip rather than abort the whole loop;
+			// run 'auth-encryption migrate' first to bring it under encryption.
+			continue
+		}
 		plain, err := ae.DecryptClientSecret(client.EncryptedClientSecret, []byte(client.ClientSecretMetadata))
 		if err != nil {
 			return fmt.Errorf("failed to decrypt client secret for rotation: %w", err)
@@ -41,7 +79,7 @@ func (ae *AuthEncryption) rotateAPIClientSecrets() error {
 		if err != nil {
 			return fmt.Errorf("failed to re-encrypt client secret: %w", err)
 		}
-		if err := ae.db.Model(&client).Updates(map[string]interface{}{
+		if err := tx.Model(&client).Updates(map[string]interface{}{
 			"encrypted_client_secret": enc,
 			"client_secret_metadata":  models.JSON(meta),
 		}).Error; err != nil {
@@ -51,12 +89,15 @@ func (ae *AuthEncryption) rotateAPIClientSecrets() error {
 	return nil
 }
 
-func (ae *AuthEncryption) rotateSessionTokens() error {
+func (ae *AuthEncryption) rotateSessionTokens(tx *gorm.DB) error {
 	var sessions []models.Session
-	if err := ae.db.Find(&sessions).Error; err != nil {
+	if err := tx.Find(&sessions).Error; err != nil {
 		return fmt.Errorf("failed to retrieve sessions: %w", err)
 	}
 	for _, session := range sessions {
+		if len(session.EncryptedSessionToken) == 0 {
+			continue // #278: unmigrated row — nothing to rotate.
+		}
 		plain, err := ae.DecryptSessionToken(session.EncryptedSessionToken, []byte(session.SessionTokenMetadata))
 		if err != nil {
 			return fmt.Errorf("failed to decrypt session token for rotation: %w", err)
@@ -65,7 +106,7 @@ func (ae *AuthEncryption) rotateSessionTokens() error {
 		if err != nil {
 			return fmt.Errorf("failed to re-encrypt session token: %w", err)
 		}
-		if err := ae.db.Model(&session).Updates(map[string]interface{}{
+		if err := tx.Model(&session).Updates(map[string]interface{}{
 			"encrypted_session_token": enc,
 			"session_token_metadata":  models.JSON(meta),
 		}).Error; err != nil {
@@ -75,12 +116,15 @@ func (ae *AuthEncryption) rotateSessionTokens() error {
 	return nil
 }
 
-func (ae *AuthEncryption) rotateAPITokens() error {
+func (ae *AuthEncryption) rotateAPITokens(tx *gorm.DB) error {
 	var tokens []models.APIToken
-	if err := ae.db.Find(&tokens).Error; err != nil {
+	if err := tx.Find(&tokens).Error; err != nil {
 		return fmt.Errorf("failed to retrieve API tokens: %w", err)
 	}
 	for _, token := range tokens {
+		if len(token.EncryptedToken) == 0 {
+			continue // #278: unmigrated row — nothing to rotate.
+		}
 		plain, err := ae.DecryptAPIToken(token.EncryptedToken, []byte(token.TokenMetadata))
 		if err != nil {
 			return fmt.Errorf("failed to decrypt API token for rotation: %w", err)
@@ -89,11 +133,44 @@ func (ae *AuthEncryption) rotateAPITokens() error {
 		if err != nil {
 			return fmt.Errorf("failed to re-encrypt API token: %w", err)
 		}
-		if err := ae.db.Model(&token).Updates(map[string]interface{}{
+		if err := tx.Model(&token).Updates(map[string]interface{}{
 			"encrypted_token": enc,
 			"token_metadata":  models.JSON(meta),
 		}).Error; err != nil {
 			return fmt.Errorf("failed to update rotated API token: %w", err)
+		}
+	}
+	return nil
+}
+
+// rotatePasswordResetTokens re-encrypts password reset tokens. It was missing
+// entirely despite RotateAuthEncryption's callers (the CLI Long help text, and
+// AuthEncryptionCmd's own package doc) claiming to rotate "all" authentication
+// data including password reset tokens (#292) — added here to match migrate's
+// and validate's existing password-reset-token coverage rather than narrowing
+// the documented claim.
+func (ae *AuthEncryption) rotatePasswordResetTokens(tx *gorm.DB) error {
+	var resets []models.PasswordReset
+	if err := tx.Find(&resets).Error; err != nil {
+		return fmt.Errorf("failed to retrieve password reset tokens: %w", err)
+	}
+	for _, reset := range resets {
+		if len(reset.EncryptedToken) == 0 {
+			continue // #278: unmigrated row — nothing to rotate.
+		}
+		plain, err := ae.DecryptPasswordResetToken(reset.EncryptedToken, []byte(reset.TokenMetadata))
+		if err != nil {
+			return fmt.Errorf("failed to decrypt password reset token for rotation: %w", err)
+		}
+		enc, meta, err := ae.EncryptPasswordResetToken(plain)
+		if err != nil {
+			return fmt.Errorf("failed to re-encrypt password reset token: %w", err)
+		}
+		if err := tx.Model(&reset).Updates(map[string]interface{}{
+			"encrypted_token": enc,
+			"token_metadata":  models.JSON(meta),
+		}).Error; err != nil {
+			return fmt.Errorf("failed to update rotated password reset token: %w", err)
 		}
 	}
 	return nil

--- a/internal/encryption/auth_encryption_rotate_test.go
+++ b/internal/encryption/auth_encryption_rotate_test.go
@@ -1,0 +1,135 @@
+package encryption
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// setupEnabledAuthEncryptionTest is like setupAuthEncryptionTest but with real
+// encryption ENABLED (key files generated on disk), needed to exercise
+// RotateAuthEncryption — with encryption disabled, EncryptClientSecret etc. are
+// no-ops and there is nothing to rotate.
+func setupEnabledAuthEncryptionTest(t *testing.T) (*AuthEncryption, *gorm.DB) {
+	t.Helper()
+	tempDir := t.TempDir()
+
+	dbPath := filepath.Join(tempDir, "test.db")
+	db, err := gorm.Open(sqlite.Open(dbPath), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.APIClient{},
+		&models.Session{},
+		&models.APIToken{},
+		&models.PasswordReset{},
+	))
+
+	cfg := &config.EncryptionConfig{
+		Enabled:  true,
+		DEKPath:  "dek.key",
+		SaltPath: "kek.salt",
+	}
+	authEnc := NewAuthEncryption(cfg, tempDir, db)
+	require.NoError(t, authEnc.Initialize("rotate-test-passphrase-correct-horse"))
+
+	t.Cleanup(func() {
+		if sqlDB, err := db.DB(); err == nil {
+			_ = sqlDB.Close()
+		}
+		_ = os.RemoveAll(tempDir)
+	})
+
+	return authEnc, db
+}
+
+// TestRotateAuthEncryption_SkipsUnmigratedRows verifies that a row with no
+// Encrypted* value (an unmigrated, #278-affected plaintext-only row) does not
+// abort the rotation loop — it is skipped, and every properly-encrypted row
+// still rotates successfully.
+func TestRotateAuthEncryption_SkipsUnmigratedRows(t *testing.T) {
+	authEnc, db := setupEnabledAuthEncryptionTest(t)
+
+	// Unmigrated row: plaintext-only, no Encrypted* value at all. Before the fix,
+	// RotateAuthEncryption would call DecryptClientSecret on the empty
+	// EncryptedClientSecret and abort the whole rotation with an error.
+	unmigrated := &models.APIClient{Name: "unmigrated", ClientID: "unmigrated-client", ClientSecret: "plain-secret-never-encrypted", IsActive: true}
+	require.NoError(t, db.Create(unmigrated).Error)
+
+	// Properly-migrated row: has an Encrypted* value, should rotate cleanly.
+	enc, meta, err := authEnc.EncryptClientSecret("secret-to-rotate")
+	require.NoError(t, err)
+	migrated := &models.APIClient{Name: "migrated", ClientID: "migrated-client", EncryptedClientSecret: enc, ClientSecretMetadata: models.JSON(meta), IsActive: true}
+	require.NoError(t, db.Create(migrated).Error)
+
+	require.NoError(t, authEnc.RotateAuthEncryption())
+
+	// Unmigrated row untouched — still no Encrypted* value, plaintext intact.
+	var gotUnmigrated models.APIClient
+	require.NoError(t, db.Where("client_id = ?", "unmigrated-client").First(&gotUnmigrated).Error)
+	require.Empty(t, gotUnmigrated.EncryptedClientSecret)
+	require.Equal(t, "plain-secret-never-encrypted", gotUnmigrated.ClientSecret)
+
+	// Migrated row rotated: still decrypts to the same plaintext.
+	var gotMigrated models.APIClient
+	require.NoError(t, db.Where("client_id = ?", "migrated-client").First(&gotMigrated).Error)
+	plain, err := authEnc.DecryptClientSecret(gotMigrated.EncryptedClientSecret, []byte(gotMigrated.ClientSecretMetadata))
+	require.NoError(t, err)
+	require.Equal(t, "secret-to-rotate", plain)
+}
+
+// TestRotateAuthEncryption_RollsBackOnError verifies that a mid-loop failure
+// rolls back the entire rotation transaction — no row is left partially
+// rotated (some under the new key, the rest under the old one).
+func TestRotateAuthEncryption_RollsBackOnError(t *testing.T) {
+	authEnc, db := setupEnabledAuthEncryptionTest(t)
+
+	// A row that rotates fine on its own — api_clients rotate before sessions, so
+	// this row's re-encryption would already have been written to the DB by the
+	// time the session below fails, if rotation weren't transactional.
+	enc, meta, err := authEnc.EncryptClientSecret("secret-should-not-change")
+	require.NoError(t, err)
+	client := &models.APIClient{Name: "rollback-client", ClientID: "rollback-client-id", EncryptedClientSecret: enc, ClientSecretMetadata: models.JSON(meta), IsActive: true}
+	require.NoError(t, db.Create(client).Error)
+	originalCiphertext := append([]byte(nil), client.EncryptedClientSecret...)
+
+	// A corrupt session row: EncryptedSessionToken is not valid serialized
+	// encrypted data, so decrypting it during rotation fails deterministically.
+	badSession := &models.Session{UserID: 1, EncryptedSessionToken: []byte("not-a-valid-encrypted-blob"), SessionTokenMetadata: models.JSON(`{}`)}
+	require.NoError(t, db.Create(badSession).Error)
+
+	err = authEnc.RotateAuthEncryption()
+	require.Error(t, err)
+
+	// Roll back means the earlier, individually-successful client re-encryption
+	// must NOT have been persisted either.
+	var gotClient models.APIClient
+	require.NoError(t, db.Where("client_id = ?", "rollback-client-id").First(&gotClient).Error)
+	require.Equal(t, originalCiphertext, gotClient.EncryptedClientSecret, "rotation must roll back ALL writes, not just the failing row, on mid-loop error")
+}
+
+// TestRotateAuthEncryption_RotatesPasswordResetTokens verifies rotate covers
+// password reset tokens too — RotateAuthEncryption's doc/CLI help text claims
+// to re-encrypt "all" authentication data, and migrate/validate already cover
+// this table, so rotate must not silently skip it (#292).
+func TestRotateAuthEncryption_RotatesPasswordResetTokens(t *testing.T) {
+	authEnc, db := setupEnabledAuthEncryptionTest(t)
+
+	enc, meta, err := authEnc.EncryptPasswordResetToken("reset-token-to-rotate")
+	require.NoError(t, err)
+	reset := &models.PasswordReset{UserID: 1, EncryptedToken: enc, TokenMetadata: models.JSON(meta)}
+	require.NoError(t, db.Create(reset).Error)
+
+	require.NoError(t, authEnc.RotateAuthEncryption())
+
+	var got models.PasswordReset
+	require.NoError(t, db.First(&got, reset.ID).Error)
+	plain, err := authEnc.DecryptPasswordResetToken(got.EncryptedToken, []byte(got.TokenMetadata))
+	require.NoError(t, err)
+	require.Equal(t, "reset-token-to-rotate", plain)
+}


### PR DESCRIPTION
## Summary

- `AuthEncryptionCmd` (`status`/`enable`/`rotate`/`migrate`/`validate`) was fully implemented in `internal/cli/encryption/auth_encryption.go` but never added to `EncryptionCmd` — `keyorix encryption auth-encryption` failed with "unknown command" in the shipped binary. This was the only remediation path for the already-filed **#278** (plaintext service-account credentials), so #278 had zero available fix path. Wired it into the tree.
- Fixed three latent defects in the previously-unreachable implementation that would have made it unsafe even once wired in:
  - **migrate**: the four migrate helpers wrote the new `Encrypted*` value but never cleared the old plaintext column. Now clears it (`NULL`, not `""` — several of these columns carry a unique index, and `NULL` is exempt from uniqueness checks on both sqlite and postgres) in the same update.
  - **rotate**: `RotateAuthEncryption` had no empty-field skip guard (an unmigrated #278-affected row aborted the whole loop on `DecryptClientSecret` error) and wasn't wrapped in a DB transaction, unlike the live `RotateDEKWithSweep`/`SweepAllTables` path, which begins a tx and rolls back atomically on error. Added the skip guard and wrapped the full rotation in a transaction with rollback on any failure, so a mid-loop failure can't leave a permanent partial-rotation state. Also added the missing `rotatePasswordResetTokens` helper — the function claimed to re-encrypt "all" authentication data (matching migrate's and validate's existing password-reset-token coverage) but had no such helper at all.
  - **validate**: only queried rows where `encrypted_*  IS NOT NULL`, so plaintext-only rows with no encrypted counterpart were invisible to it entirely, and it printed an unconditional "✅ All authentication encryption validation checks passed" regardless — the same false-clean shape as the already-known posture-fails-open family (#136/#145/#149). Now separately queries for and flags those rows, and returns a non-nil error instead of printing the all-clear message when any are found.

Every one of these commands already requires operator-equivalent trust (local filesystem + DB + KEK-material access) to invoke, so this is a remediation-tooling-availability fix, not a new access-control boundary — no new authorization checks were added.

Also verified while investigating: on current `main`, `CreateServiceAccount`/`CreateServiceToken` (`internal/core/service_accounts.go`) already store only a SHA-256 hash of the client secret/token, not plaintext — so #278's specific storage exposure for those two tables appears independently mitigated by an earlier, unrelated commit. That doesn't change anything about this fix (the CLI tree wiring bug and the three latent defects are all still real and independently worth fixing, and `password_resets` still benefits from this tooling), but it's worth noting for prioritization of #278 itself.

## Test plan

- [x] New regression tests: CLI wiring (`internal/cli/auth_encryption_wiring_test.go`, `internal/cli/encryption/auth_encryption_cli_test.go`), migrate-clears-plaintext (incl. a multi-row unique-index-collision guard), rotate-skips-empty-and-rolls-back-on-error (`internal/encryption/auth_encryption_rotate_test.go`), validate-flags-unmigrated-rows.
- [x] `go build ./...` clean.
- [x] `go test ./...` — full suite green. `TestSpool_PersistsAndReplaysOnRecovery` re-run 5x in isolation to confirm the known unrelated flake didn't fire.
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues.
- [x] `golangci-lint run ./...` — 0 issues.
- [x] `GOWORK=off go build -C operator ./...` — clean build.