### PR TITLE
harden: import size cap, terminal sanitization, scheduler-metrics split, exec provider hygiene (#295/#287/#288)

### DIFF
--- a/internal/cli/secret/import.go
+++ b/internal/cli/secret/import.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"unicode"
 
 	"github.com/keyorixhq/keyorix/internal/cli/common"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
@@ -92,6 +93,24 @@ type secretEntry struct {
 	Value string
 }
 
+// sanitizeForTerminal strips control characters (CR/LF, ANSI/C1 escapes, NUL,
+// etc.) from untrusted import-file content before it's echoed to the operator's
+// terminal in progress/dry-run output. A crafted import file could otherwise
+// embed terminal escape sequences that overwrite or hide the CLI's own status
+// lines during the same run. This only affects what's printed — the value
+// actually stored in the vault is left untouched.
+func sanitizeForTerminal(s string) string {
+	return strings.Map(func(r rune) rune {
+		if r == '\t' {
+			return ' '
+		}
+		if unicode.IsControl(r) {
+			return -1 // drop
+		}
+		return r
+	}, s)
+}
+
 func runImport(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
 
@@ -112,7 +131,7 @@ func runImport(cmd *cobra.Command, args []string) error {
 			if len(preview) > 20 {
 				preview = preview[:20] + "..."
 			}
-			fmt.Printf("  %-30s = %s\n", e.Name, preview)
+			fmt.Printf("  %-30s = %s\n", sanitizeForTerminal(e.Name), sanitizeForTerminal(preview))
 		}
 		fmt.Printf("\nNo changes made (--dry-run).\n")
 		return nil
@@ -201,6 +220,7 @@ func doImport(ctx context.Context, rc *common.RemoteClient, entries []secretEntr
 	imported, skipped, failed := 0, 0, 0
 
 	for _, e := range entries {
+		displayName := sanitizeForTerminal(e.Name)
 		body := map[string]interface{}{
 			"name":           e.Name,
 			"value":          e.Value,
@@ -213,15 +233,15 @@ func doImport(ctx context.Context, rc *common.RemoteClient, entries []secretEntr
 		if err != nil {
 			errStr := err.Error()
 			if importSkipExisting && (strings.Contains(errStr, "409") || strings.Contains(errStr, "already exists")) {
-				fmt.Printf("  - Skipped  %-30s (already exists)\n", e.Name)
+				fmt.Printf("  - Skipped  %-30s (already exists)\n", displayName)
 				skipped++
 				continue
 			}
-			fmt.Printf("  x Failed   %-30s %v\n", e.Name, err)
+			fmt.Printf("  x Failed   %-30s %v\n", displayName, err)
 			failed++
 			continue
 		}
-		fmt.Printf("  + Imported %-30s (id=%d)\n", e.Name, created.ID)
+		fmt.Printf("  + Imported %-30s (id=%d)\n", displayName, created.ID)
 		imported++
 	}
 

--- a/internal/cli/secret/import_parsers.go
+++ b/internal/cli/secret/import_parsers.go
@@ -14,6 +14,27 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// maxImportFileBytes caps how much of an untrusted --file import we'll read into
+// memory in one shot. parseVault and parseJSON both os.ReadFile the whole input
+// (the dotenv parser is already bounded via bufio.Scanner's 64KiB line limit), so
+// without a cap a booby-trapped multi-GB import file can OOM-kill the operator's
+// own CLI process. This only protects the local session; there is no cross-tenant
+// or server-side impact.
+const maxImportFileBytes = 100 << 20 // 100 MiB
+
+// checkImportFileSize stats path and rejects files over maxImportFileBytes before
+// any parser reads the full contents into memory.
+func checkImportFileSize(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+	if info.Size() > maxImportFileBytes {
+		return fmt.Errorf("import file %q is %d bytes, which exceeds the %d byte limit", path, info.Size(), maxImportFileBytes)
+	}
+	return nil
+}
+
 // parseFile dispatches to the correct parser based on format string.
 func parseFile(path, format string) ([]secretEntry, error) {
 	switch strings.ToLower(format) {
@@ -87,6 +108,9 @@ func parseDotenv(path string) ([]secretEntry, error) {
 //
 // Detection: if the block has exactly one key named "value" → Format 1.
 func parseVault(path string) ([]secretEntry, error) {
+	if err := checkImportFileSize(path); err != nil {
+		return nil, err
+	}
 	data, err := os.ReadFile(path) // #nosec G304
 	if err != nil {
 		return nil, err
@@ -132,6 +156,9 @@ func parseVault(path string) ([]secretEntry, error) {
 //
 //	{"DB_PASSWORD": "supersecret123", "API_KEY": "sk_live_abc123"}
 func parseJSON(path string) ([]secretEntry, error) {
+	if err := checkImportFileSize(path); err != nil {
+		return nil, err
+	}
 	data, err := os.ReadFile(path) // #nosec G304
 	if err != nil {
 		return nil, err

--- a/internal/cli/secret/import_parsers_test.go
+++ b/internal/cli/secret/import_parsers_test.go
@@ -1,0 +1,108 @@
+package secret
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ── #295: file-size cap ─────────────────────────────────────────────────────
+
+func TestParseVault_RejectsOversizedFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "big.yaml")
+	require.NoError(t, os.WriteFile(path, []byte("secret/x:\n  value: y\n"), 0o600))
+
+	// Writing a real >100MiB file would be wasteful in CI; the size check runs
+	// via os.Stat before any read, so a sparse (truncated) file that merely
+	// reports a size over the cap is enough to exercise the rejection path.
+	f, err := os.OpenFile(path, os.O_WRONLY, 0o600) // #nosec G304 -- test fixture
+	require.NoError(t, err)
+	require.NoError(t, f.Truncate(maxImportFileBytes+1))
+	require.NoError(t, f.Close())
+
+	_, err = parseVault(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds")
+}
+
+func TestParseJSON_RejectsOversizedFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "big.json")
+	require.NoError(t, os.WriteFile(path, []byte(`{"a":"b"}`), 0o600))
+
+	f, err := os.OpenFile(path, os.O_WRONLY, 0o600) // #nosec G304 -- test fixture
+	require.NoError(t, err)
+	require.NoError(t, f.Truncate(maxImportFileBytes+1))
+	require.NoError(t, f.Close())
+
+	_, err = parseJSON(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds")
+}
+
+func TestParseVault_AllowsFileUnderCap(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "ok.yaml")
+	require.NoError(t, os.WriteFile(path, []byte("secret/production/database-password:\n  value: supersecret123\n"), 0o600))
+
+	entries, err := parseVault(path)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "database-password", entries[0].Name)
+	assert.Equal(t, "supersecret123", entries[0].Value)
+}
+
+func TestParseJSON_AllowsFileUnderCap(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "ok.json")
+	require.NoError(t, os.WriteFile(path, []byte(`{"DB_PASSWORD":"supersecret123"}`), 0o600))
+
+	entries, err := parseJSON(path)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "DB_PASSWORD", entries[0].Name)
+	assert.Equal(t, "supersecret123", entries[0].Value)
+}
+
+func TestCheckImportFileSize_MissingFile(t *testing.T) {
+	err := checkImportFileSize(filepath.Join(t.TempDir(), "does-not-exist.json"))
+	require.Error(t, err)
+}
+
+// ── #295: terminal-escape sanitization ──────────────────────────────────────
+
+func TestSanitizeForTerminal_StripsControlAndANSI(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain", "hello", "hello"},
+		{"ansi_escape", "\x1b[2Khidden\x1b[0m", "[2Khidden[0m"},
+		{"cr_lf", "line1\r\nline2", "line1line2"},
+		{"nul", "a\x00b", "ab"},
+		{"tab_normalized", "a\tb", "a b"},
+		{"bell", "a\x07b", "ab"},
+		{"c1_control", "a\u009bb", "ab"}, // C1 CSI (escape avoids an unprintable byte in the source file)
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, sanitizeForTerminal(tc.in))
+		})
+	}
+}
+
+func TestSanitizeForTerminal_NeutralizesCursorHidingSequence(t *testing.T) {
+	// A crafted value trying to move the cursor up and overwrite the CLI's own
+	// status line: ESC[1A ESC[2K <fake status>. Stripping the ESC byte breaks
+	// the escape sequence into inert printable text.
+	malicious := "\x1b[1A\x1b[2K  + Imported everything (id=999)\n"
+	out := sanitizeForTerminal(malicious)
+	assert.NotContains(t, out, "\x1b")
+	assert.False(t, strings.ContainsRune(out, 0x1b))
+}

--- a/internal/crypto/exec_provider.go
+++ b/internal/crypto/exec_provider.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
 	"time"
 )
@@ -12,6 +13,62 @@ import (
 // fetch is abandoned. Generous enough for a network round-trip to a secret store,
 // short enough that a hung helper fails startup loudly rather than wedging it.
 const execKeyTimeout = 30 * time.Second
+
+// execAllowedEnv is the minimal environment passed through to the resolver
+// process. Go's os/exec inherits the ENTIRE parent environment whenever
+// cmd.Env is left nil, but the resolver is an operator-configured binary
+// (op, sops, vault, or a custom helper) — if it's later compromised via a
+// supply-chain/PATH hijack, or is simply overly permissive or logs its
+// environment, an inherited full environment would hand it every secret the
+// server process holds (KEYORIX_MASTER_PASSWORD, DB credentials, ...), not
+// just what it needs to resolve the KEK. PATH lets the binary and any
+// subprocess it spawns resolve other executables normally; HOME is what most
+// CLI credential helpers (op, sops, vault, aws, gcloud, ...) use to locate
+// their own config/cache/credential files. Extend this list — or make it
+// configurable — if a real resolver genuinely needs more.
+var execAllowedEnv = []string{"PATH", "HOME"}
+
+// execEnv builds the minimal Env slice for the resolver command from
+// execAllowedEnv, passing through only variables that are actually set.
+func execEnv() []string {
+	env := make([]string, 0, len(execAllowedEnv))
+	for _, k := range execAllowedEnv {
+		if v, ok := os.LookupEnv(k); ok {
+			env = append(env, k+"="+v)
+		}
+	}
+	return env
+}
+
+// execMaxStdoutBytes caps how much of the resolver's stdout the exec provider
+// will buffer. Legitimate resolvers here only ever emit a few dozen bytes (raw,
+// hex, or base64 KEK material), so this stays far above any real need while
+// still protecting against a misbehaving or compromised resolver that writes
+// gigabytes to stdout and would otherwise OOM the server process.
+const execMaxStdoutBytes = 1 << 20 // 1 MiB
+
+// limitedBuffer is a bytes.Buffer capped at max bytes. Writes beyond the cap
+// are discarded rather than silently truncated into what becomes the returned
+// key material — exceeded is set so the caller can fail closed with a clear
+// error instead of attempting to decode a truncated/garbage buffer.
+type limitedBuffer struct {
+	buf      bytes.Buffer
+	max      int
+	exceeded bool
+}
+
+func (b *limitedBuffer) Write(p []byte) (int, error) {
+	if b.exceeded {
+		return len(p), nil // already over cap; discard further output
+	}
+	room := b.max - b.buf.Len()
+	if len(p) > room {
+		b.buf.Write(p[:room])
+		b.exceeded = true
+		return len(p), nil
+	}
+	return b.buf.Write(p)
+}
 
 // ExecKeyProvider sources the KEK by running an operator-configured command and
 // reading the key material (raw 32 bytes, or hex/base64 thereof) from its stdout.
@@ -44,7 +101,11 @@ func (p *ExecKeyProvider) KEK() ([]byte, error) {
 	// #nosec G204 -- the argv is operator-configured deployment config (trusted on
 	// the same footing as a file path or env var), run without a shell.
 	cmd := exec.CommandContext(ctx, p.command[0], p.command[1:]...)
-	var stdout, stderr bytes.Buffer
+	// Explicit minimal environment — do NOT inherit the full parent (server)
+	// environment; see execAllowedEnv.
+	cmd.Env = execEnv()
+	stdout := limitedBuffer{max: execMaxStdoutBytes}
+	var stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
@@ -55,9 +116,12 @@ func (p *ExecKeyProvider) KEK() ([]byte, error) {
 		// secret — surface only a trimmed, bounded tail and never the stdout.
 		return nil, fmt.Errorf("exec key provider: command %q failed: %w%s", p.command[0], err, stderrHint(stderr.Bytes()))
 	}
+	if stdout.exceeded {
+		return nil, fmt.Errorf("exec key provider: command %q produced more than %d bytes of output (limit exceeded)", p.command[0], execMaxStdoutBytes)
+	}
 	// Trim a single trailing newline for the encoded forms (helpers usually print
 	// one), but never mangle exactly-32 raw bytes.
-	out := stdout.Bytes()
+	out := stdout.buf.Bytes()
 	if len(out) != KEKSize {
 		out = bytes.TrimRight(out, "\r\n")
 	}

--- a/internal/crypto/exec_provider_test.go
+++ b/internal/crypto/exec_provider_test.go
@@ -1,6 +1,7 @@
 package crypto
 
 import (
+	"bytes"
 	"encoding/base64"
 	"encoding/hex"
 	"os"
@@ -80,6 +81,62 @@ func TestExecKeyProvider_Errors(t *testing.T) {
 		_, err := NewExecKeyProvider([]string{"cat", path}).KEK()
 		require.Error(t, err, "output that does not decode to 32 bytes must be rejected")
 	})
+
+	// ── #288: stdout is bounded ─────────────────────────────────────────────
+	t.Run("oversized stdout rejected", func(t *testing.T) {
+		path := filepath.Join(dir, "toolarge.key")
+		data := bytes.Repeat([]byte("A"), execMaxStdoutBytes+1024)
+		require.NoError(t, os.WriteFile(path, data, 0600))
+		_, err := NewExecKeyProvider([]string{"cat", path}).KEK()
+		require.ErrorContains(t, err, "limit exceeded")
+	})
+}
+
+// ── #288: the resolver only sees a minimal, explicit environment ───────────
+
+func TestExecEnv_MinimalAllowlist(t *testing.T) {
+	t.Setenv("PATH", "/usr/bin:/bin")
+	t.Setenv("HOME", "/home/tester")
+	t.Setenv("KEYORIX_MASTER_PASSWORD", "should-not-leak")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "should-not-leak-either")
+
+	env := execEnv()
+
+	assert.Contains(t, env, "PATH=/usr/bin:/bin")
+	assert.Contains(t, env, "HOME=/home/tester")
+	assert.Len(t, env, 2, "only PATH and HOME should pass through")
+	for _, kv := range env {
+		assert.NotContains(t, kv, "should-not-leak")
+	}
+}
+
+func TestExecEnv_OmitsUnsetAllowedVar(t *testing.T) {
+	t.Setenv("PATH", "/usr/bin")
+	require.NoError(t, os.Unsetenv("HOME"))
+
+	env := execEnv()
+
+	assert.Equal(t, []string{"PATH=/usr/bin"}, env)
+}
+
+func TestExecKeyProvider_ChildDoesNotInheritFullEnvironment(t *testing.T) {
+	t.Setenv("KEYORIX_KEK_TEST_LEAK", "must-not-leak-into-resolver")
+
+	// printenv exits 1 (and prints nothing) when the named variable is unset in
+	// its own environment — regardless of whether it's set in the test process.
+	_, err := NewExecKeyProvider([]string{"printenv", "KEYORIX_KEK_TEST_LEAK"}).KEK()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed", "printenv should exit non-zero because the var is not in the child's restricted env")
+}
+
+func TestExecKeyProvider_ChildStillSeesPath(t *testing.T) {
+	// printenv succeeds (exit 0) for PATH, proving the allowlisted var does reach
+	// the child even though the environment as a whole is minimal. The printed
+	// PATH value isn't valid key material, so KEK() still errors, but on the
+	// decode path rather than "command failed".
+	_, err := NewExecKeyProvider([]string{"printenv", "PATH"}).KEK()
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "failed", "PATH must be visible to the child, so printenv should exit 0")
 }
 
 func TestStderrHint(t *testing.T) {

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -622,6 +622,13 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.Use(customMiddleware.RequirePermission("system.read"))
 			r.Get("/info", handlers.MakeSystemInfoHandler(cfg))
 			r.Get("/metrics", handlers.GetMetrics)
+			// Per-scheduler last-run/last-success timestamps (Prometheus exposition
+			// format), deliberately kept off the public, unauthenticated /metrics
+			// endpoint — see server/middleware/scheduler_metrics.go — since an exact
+			// tick timestamp would let an anonymous caller predict a security-relevant
+			// job's next execution to sub-second precision. Gated behind system.read
+			// like the rest of this group.
+			r.Get("/scheduler-metrics", customMiddleware.SchedulerMetricsHandler().ServeHTTP)
 		})
 
 		// Offline-license status (ADR-065) — the locally-evaluated commercial entitlement.

--- a/server/middleware/scheduler_metrics.go
+++ b/server/middleware/scheduler_metrics.go
@@ -5,8 +5,8 @@
 // previously opaque: a tick that errored only left a log line, so there was no way to
 // alert on "scheduler X has not succeeded in an hour" or "tick failure rate is rising".
 //
-// RecordSchedulerRun folds each tick into the default Prometheus registry, which the
-// server already exposes via MetricsHandler. Three outcomes are tracked per scheduler:
+// RecordSchedulerRun folds each tick into Prometheus. Three outcomes are tracked per
+// scheduler:
 //
 //   - success — the tick ran and completed without error.
 //   - failure — the tick ran and returned an error (or the advisory-lock acquisition
@@ -16,7 +16,14 @@
 //     active legal hold) deliberately stood the job down. A skipped tick is NOT a
 //     failure — a follower replica skips most ticks by design and must not page.
 //
-// Suggested alerts: page when a scheduler stops succeeding —
+// The run-count and duration series live on the default Prometheus registry, which the
+// server exposes unauthenticated via MetricsHandler at GET /metrics — standard for
+// scraping. The two last-run/last-success timestamp gauges are deliberately kept off
+// that public registry (see schedulerTimingRegistry below) and are instead served via
+// SchedulerMetricsHandler, which the router mounts behind an authenticated route.
+//
+// Suggested alerts (against the authenticated scheduler-metrics endpoint): page when a
+// scheduler stops succeeding —
 //
 //	time() - keyorix_scheduler_last_success_timestamp_seconds{scheduler="auto_rotation"} > 3600
 //
@@ -26,10 +33,12 @@
 package middleware
 
 import (
+	"net/http"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 // SchedulerOutcome is the result of a single scheduler tick. Its string value is used
@@ -54,12 +63,23 @@ var (
 		Buckets: prometheus.DefBuckets,
 	}, []string{"scheduler"})
 
-	schedulerLastRun = promauto.NewGaugeVec(prometheus.GaugeOpts{
+	// schedulerTimingRegistry is a separate, non-default Prometheus registry for the
+	// two gauges below. GET /metrics is unauthenticated by design (standard for
+	// scraping), and an exact "last run"/"last success" Unix timestamp per scheduler
+	// lets any anonymous caller predict a security-relevant job's next tick to
+	// sub-second precision. schedulerRunsTotal and schedulerRunDuration (coarse
+	// counters/durations, not exact timestamps) stay on the default registry and
+	// remain visible at /metrics; these two gauges are served only via
+	// SchedulerMetricsHandler, which server/http/router.go wires behind an
+	// authenticated, permissioned route instead.
+	schedulerTimingRegistry = prometheus.NewRegistry()
+
+	schedulerLastRun = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "keyorix_scheduler_last_run_timestamp_seconds",
 		Help: "Unix time of the last tick that actually ran (success or failure; not a skip), by scheduler name.",
 	}, []string{"scheduler"})
 
-	schedulerLastSuccess = promauto.NewGaugeVec(prometheus.GaugeOpts{
+	schedulerLastSuccess = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "keyorix_scheduler_last_success_timestamp_seconds",
 		Help: "Unix time of the last successful tick, by scheduler name.",
 	}, []string{"scheduler"})
@@ -67,6 +87,10 @@ var (
 	// nowUnix is overridable in tests; production uses the wall clock.
 	nowUnix = func() int64 { return time.Now().Unix() }
 )
+
+func init() {
+	schedulerTimingRegistry.MustRegister(schedulerLastRun, schedulerLastSuccess)
+}
 
 // RegisterScheduler initialises a scheduler's counter series to zero so dashboards and
 // `rate()` queries see an explicit 0 rather than "no data" before the first tick. Call
@@ -77,6 +101,14 @@ func RegisterScheduler(name string) {
 	for _, outcome := range []SchedulerOutcome{SchedulerSuccess, SchedulerFailure, SchedulerSkipped} {
 		schedulerRunsTotal.WithLabelValues(name, string(outcome))
 	}
+}
+
+// SchedulerMetricsHandler serves the per-scheduler last-run/last-success timestamp
+// gauges from schedulerTimingRegistry — kept off the public, unauthenticated /metrics
+// endpoint (see the doc comment on schedulerTimingRegistry) and wired instead behind
+// an authenticated route for operators who legitimately need this visibility.
+func SchedulerMetricsHandler() http.Handler {
+	return promhttp.HandlerFor(schedulerTimingRegistry, promhttp.HandlerOpts{})
 }
 
 // RecordSchedulerRun records the outcome and (for ticks that ran) the duration of a

--- a/server/middleware/scheduler_metrics_test.go
+++ b/server/middleware/scheduler_metrics_test.go
@@ -1,6 +1,8 @@
 package middleware
 
 import (
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -106,5 +108,75 @@ func TestRecordSchedulerRunSkippedTouchesOnlyCounter(t *testing.T) {
 	}
 	if got := gauge(t, schedulerLastSuccess, name); got != 0 {
 		t.Errorf("last_success = %v, want 0 (a skip must not set it)", got)
+	}
+}
+
+// ── #287: timestamp gauges must not appear on the public /metrics registry ───
+
+func TestSchedulerTimestampGaugesAbsentFromDefaultRegistry(t *testing.T) {
+	const name = "test_public_metrics_split"
+	RecordSchedulerRun(name, SchedulerSuccess, time.Millisecond)
+
+	families, err := prometheus.DefaultGatherer.Gather()
+	if err != nil {
+		t.Fatalf("gather default registry: %v", err)
+	}
+	for _, mf := range families {
+		switch mf.GetName() {
+		case "keyorix_scheduler_last_run_timestamp_seconds", "keyorix_scheduler_last_success_timestamp_seconds":
+			t.Fatalf("timestamp gauge %q must not be registered on the default (public /metrics) registry", mf.GetName())
+		}
+	}
+}
+
+func TestSchedulerRunsTotalStillOnDefaultRegistry(t *testing.T) {
+	// The coarse run-count/duration series are intentionally still public — only the
+	// exact-timestamp gauges moved off the default registry.
+	const name = "test_public_metrics_present"
+	RecordSchedulerRun(name, SchedulerSuccess, time.Millisecond)
+
+	families, err := prometheus.DefaultGatherer.Gather()
+	if err != nil {
+		t.Fatalf("gather default registry: %v", err)
+	}
+	var sawRunsTotal, sawDuration bool
+	for _, mf := range families {
+		switch mf.GetName() {
+		case "keyorix_scheduler_runs_total":
+			sawRunsTotal = true
+		case "keyorix_scheduler_run_duration_seconds":
+			sawDuration = true
+		}
+	}
+	if !sawRunsTotal {
+		t.Error("keyorix_scheduler_runs_total should remain on the default registry")
+	}
+	if !sawDuration {
+		t.Error("keyorix_scheduler_run_duration_seconds should remain on the default registry")
+	}
+}
+
+func TestSchedulerMetricsHandlerServesTimestampGauges(t *testing.T) {
+	const name = "test_scheduler_metrics_handler"
+	nowUnix = func() int64 { return 4242 }
+	t.Cleanup(func() { nowUnix = func() int64 { return time.Now().Unix() } })
+	RecordSchedulerRun(name, SchedulerSuccess, time.Millisecond)
+
+	req := httptest.NewRequest("GET", "/api/v1/system/scheduler-metrics", nil)
+	rec := httptest.NewRecorder()
+	SchedulerMetricsHandler().ServeHTTP(rec, req)
+
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	body := rec.Body.String()
+	for _, want := range []string{
+		"keyorix_scheduler_last_run_timestamp_seconds",
+		"keyorix_scheduler_last_success_timestamp_seconds",
+		name,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("scheduler-metrics response missing %q: %s", want, body)
+		}
 	}
 }


### PR DESCRIPTION
## Summary
Three independent LOW-severity findings from `docs/security/HARDENING-BACKLOG.md`, all re-verified against current `main` before fixing.

- **#295** — `internal/cli/secret/import_parsers.go`: `parseVault`/`parseJSON` now `os.Stat` the input file and reject anything over 100MB before reading it fully into memory (matches the existing `io.LimitReader`/size-cap convention used elsewhere, e.g. `internal/bundle/bundle.go`'s `maxManifestBytes`). The dotenv parser was already bounded via `bufio.Scanner`'s 64KiB line limit and is untouched. Separately, `import.go`'s dry-run/progress output now sanitizes parsed keys/values (strips control chars and ANSI/C1 escape sequences, mirroring the existing `sanitizeAuditText`/`stripControl` pattern in `internal/core/audit.go` and `server/middleware/recovery.go`) before printing them, so a crafted import file can no longer hide or overwrite the CLI's own status lines. The value actually stored in the vault is unchanged — this only affects what's echoed to the terminal.

- **#287** — `server/middleware/scheduler_metrics.go`: the per-scheduler `keyorix_scheduler_last_run_timestamp_seconds` / `..._last_success_timestamp_seconds` gauges (which let an anonymous caller predict a scheduler's next tick to sub-second precision) move off the default Prometheus registry served unauthenticated at `GET /metrics`, onto a private registry served instead via a new authenticated route `GET /api/v1/system/scheduler-metrics` (gated on `system.read`, same tier as the existing `/api/v1/system/metrics`). The coarse `keyorix_scheduler_runs_total` counter and `keyorix_scheduler_run_duration_seconds` histogram stay on the public registry — only the exact-timestamp gauges moved.

- **#288** — `internal/crypto/exec_provider.go`: the exec-based KMS key provider now sets `cmd.Env` to an explicit minimal allowlist (`PATH`, `HOME`) instead of leaving it nil (which inherits the *entire* server process environment per Go's `os/exec` semantics — including things like `KEYORIX_MASTER_PASSWORD` and DB credentials). Its stdout is now capped at 1MiB via a bounded writer (`limitedBuffer`) instead of an unbounded `bytes.Buffer`, failing closed with a clear "limit exceeded" error rather than risking an OOM from a misbehaving/compromised resolver binary.

## Test plan
- [x] New regression tests: file-size-cap rejection (`TestParseVault_RejectsOversizedFile`, `TestParseJSON_RejectsOversizedFile`), terminal-escape sanitization (`TestSanitizeForTerminal_*`), scheduler-metrics public/private registry split (`TestSchedulerTimestampGaugesAbsentFromDefaultRegistry`, `TestSchedulerRunsTotalStillOnDefaultRegistry`, `TestSchedulerMetricsHandlerServesTimestampGauges`), exec-provider env allowlist + stdout cap (`TestExecEnv_MinimalAllowlist`, `TestExecKeyProvider_ChildDoesNotInheritFullEnvironment`, `TestExecKeyProvider_ChildStillSeesPath`, oversized-stdout case in `TestExecKeyProvider_Errors`).
- [x] `go build ./...` clean
- [x] `go test ./...` clean (full suite, including `internal/audit/siem`'s `TestSpool_PersistsAndReplaysOnRecovery`)
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues
- [x] `golangci-lint run ./...` — 0 issues
- [x] `GOWORK=off go build ./...` from `operator/` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)