### PR TITLE
harden: close InviteMember and DeleteProject TOCTOU races (#309/#313)

### DIFF
--- a/internal/core/catalog.go
+++ b/internal/core/catalog.go
@@ -75,21 +75,29 @@ func (c *KeyorixCore) ProjectRequiresMFA(ctx context.Context, projectID uint) (b
 // By default (force=false) it returns an error if the project still contains secrets (ADR-019).
 // Pass force=true to delete the project and all its secrets (cascade).
 func (c *KeyorixCore) DeleteProject(ctx context.Context, id uint, force bool) error {
-	if !force {
-		projectID := id
-		_, total, err := c.storage.ListSecrets(ctx, &storage.SecretFilter{
-			ProjectID: &projectID,
-			Page:      1,
-			PageSize:  1,
-		})
-		if err != nil {
-			return fmt.Errorf("failed to check project secrets: %w", err)
+	// #313: the guard count and the cascade delete used to be two separate top-level
+	// storage calls, with core-layer control flow in between — a secret created in that
+	// window silently got swept into the cascade despite the caller expecting the delete
+	// to be rejected. Run the guard and the delete inside one transaction (a nested
+	// savepoint over LocalStorage.DeleteProject's own transaction) so the count that
+	// gates the reject is the same one the cascade acts on, not a stale read.
+	return c.storage.WithTransaction(ctx, func(tx storage.Storage) error {
+		if !force {
+			projectID := id
+			_, total, err := tx.ListSecrets(ctx, &storage.SecretFilter{
+				ProjectID: &projectID,
+				Page:      1,
+				PageSize:  1,
+			})
+			if err != nil {
+				return fmt.Errorf("failed to check project secrets: %w", err)
+			}
+			if total > 0 {
+				return fmt.Errorf("project has %d secret(s) — delete them first or use --force to cascade", total)
+			}
 		}
-		if total > 0 {
-			return fmt.Errorf("project has %d secret(s) — delete them first or use --force to cascade", total)
-		}
-	}
-	return c.storage.DeleteProject(ctx, id)
+		return tx.DeleteProject(ctx, id)
+	})
 }
 
 // RestoreProject reverses a soft-delete, bringing back the project and the

--- a/internal/core/catalog_delete_project_test.go
+++ b/internal/core/catalog_delete_project_test.go
@@ -1,0 +1,168 @@
+package core_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// --- #313 structural regression -------------------------------------------------
+//
+// DeleteProject's non-force guard (count-then-reject) used to run as a separate
+// top-level storage call, entirely before — not inside — the cascade delete's own
+// transaction. A secret created in that window silently got swept into the cascade
+// despite the caller expecting the delete to be rejected. The fix runs the guard and
+// the cascade inside one storage.WithTransaction call, so the count the guard acts on
+// is read from, and committed alongside, the exact same transaction as the delete.
+//
+// deleteProjectOuterSpy/deleteProjectTxSpy assert that structurally: the outer spy
+// implements only WithTransaction (every other storage.Storage method is left on a
+// nil-embedded interface, so calling one panics on a nil pointer dereference) — so if
+// DeleteProject ever again calls ListSecrets or DeleteProject directly on the
+// non-transactional outer storage instead of the tx-scoped one WithTransaction hands
+// it, this test fails loudly instead of silently passing.
+
+type deleteProjectOuterSpy struct {
+	storage.Storage // left nil: any method besides WithTransaction panics if reached
+	txCalled        bool
+	tx              *deleteProjectTxSpy
+}
+
+func (s *deleteProjectOuterSpy) WithTransaction(ctx context.Context, fn func(storage.Storage) error) error {
+	s.txCalled = true
+	return fn(s.tx)
+}
+
+type deleteProjectTxSpy struct {
+	storage.Storage // left nil: any method besides the two below panics if reached
+	listSecretsTotal int64
+	listSecretsErr   error
+	deleteErr        error
+	callOrder        []string
+}
+
+func (s *deleteProjectTxSpy) ListSecrets(_ context.Context, filter *storage.SecretFilter) ([]*models.SecretNode, int64, error) {
+	s.callOrder = append(s.callOrder, "ListSecrets")
+	if filter.ProjectID == nil || *filter.ProjectID != 7 {
+		return nil, 0, fmt.Errorf("unexpected filter: %+v", filter)
+	}
+	return nil, s.listSecretsTotal, s.listSecretsErr
+}
+
+func (s *deleteProjectTxSpy) DeleteProject(_ context.Context, id uint) error {
+	s.callOrder = append(s.callOrder, "DeleteProject")
+	if id != 7 {
+		return fmt.Errorf("unexpected project id %d", id)
+	}
+	return s.deleteErr
+}
+
+func TestDeleteProject_GuardAndCascadeRunInSameTransaction(t *testing.T) {
+	tx := &deleteProjectTxSpy{listSecretsTotal: 0}
+	outer := &deleteProjectOuterSpy{tx: tx}
+	c := core.NewKeyorixCore(outer)
+
+	require.NoError(t, c.DeleteProject(context.Background(), 7, false))
+	assert.True(t, outer.txCalled, "DeleteProject must run inside storage.WithTransaction")
+	assert.Equal(t, []string{"ListSecrets", "DeleteProject"}, tx.callOrder,
+		"the guard read must happen before the cascade delete, both on the tx-scoped storage")
+}
+
+func TestDeleteProject_RejectsWithinTransactionWhenSecretsExist(t *testing.T) {
+	tx := &deleteProjectTxSpy{listSecretsTotal: 3}
+	outer := &deleteProjectOuterSpy{tx: tx}
+	c := core.NewKeyorixCore(outer)
+
+	err := c.DeleteProject(context.Background(), 7, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "3 secret(s)")
+	assert.True(t, outer.txCalled, "the guard itself must still run inside the transaction")
+	assert.Equal(t, []string{"ListSecrets"}, tx.callOrder,
+		"a rejected guard must short-circuit before reaching the cascade delete")
+}
+
+func TestDeleteProject_ForceSkipsGuardButStaysTransactional(t *testing.T) {
+	tx := &deleteProjectTxSpy{listSecretsTotal: 99} // would reject if the guard ran
+	outer := &deleteProjectOuterSpy{tx: tx}
+	c := core.NewKeyorixCore(outer)
+
+	require.NoError(t, c.DeleteProject(context.Background(), 7, true))
+	assert.True(t, outer.txCalled)
+	assert.Equal(t, []string{"DeleteProject"}, tx.callOrder, "force=true must skip the guard entirely")
+}
+
+// --- #313 real-storage integration (sequential, deterministic) -------------------
+//
+// A live goroutine race against the guard's exact microsecond-wide DB window isn't
+// reproducible deterministically here: SQLite's deferred transactions don't take a
+// write lock until their first write statement, so an external writer can still slip
+// a statement in between the guard's read and the cascade's write — the same
+// inherent limit acknowledged by the finding itself ("just fix the ordering", not
+// eliminate every possible interleaving; the backlog separately calibrates the
+// residual risk as no worse than an explicit force=true). Racing a *second*
+// independent write path (e.g. CreateSecret) additionally entangles this test with
+// that path's own liveness-check timing, which is unrelated to DeleteProject. The
+// structural tests above are the precise regression for the actual fix (guard and
+// cascade co-located in one transaction); these round it out against real storage.
+
+func TestDeleteProject_RealStorage_RejectsWhenSecretsExist(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.Project{}, &models.Environment{}, &models.SecretNode{}, &models.SecretVersion{}))
+	c := core.NewKeyorixCore(store.NewLocalStorage(db))
+	ctx := context.Background()
+
+	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "p"}).Error)
+	require.NoError(t, db.Create(&models.Environment{ID: 1, ProjectID: 1, Name: "env"}).Error)
+	require.NoError(t, db.Create(&models.SecretNode{Name: "s", ProjectID: 1, EnvironmentID: 1, IsSecret: true}).Error)
+
+	err = c.DeleteProject(ctx, 1, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "1 secret(s)")
+
+	var p models.Project
+	require.NoError(t, db.First(&p, 1).Error, "the project must remain live after a rejected delete")
+}
+
+func TestDeleteProject_RealStorage_EmptyProjectSucceeds(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.Project{}, &models.Environment{}, &models.SecretNode{}, &models.SecretVersion{}))
+	c := core.NewKeyorixCore(store.NewLocalStorage(db))
+	ctx := context.Background()
+
+	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "p"}).Error)
+
+	require.NoError(t, c.DeleteProject(ctx, 1, false))
+
+	var p models.Project
+	err = db.First(&p, 1).Error
+	assert.ErrorIs(t, err, gorm.ErrRecordNotFound, "the project must be (soft-)deleted")
+}
+
+func TestDeleteProject_RealStorage_ForceCascadesOverSecrets(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.Project{}, &models.Environment{}, &models.SecretNode{}, &models.SecretVersion{}))
+	c := core.NewKeyorixCore(store.NewLocalStorage(db))
+	ctx := context.Background()
+
+	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "p"}).Error)
+	require.NoError(t, db.Create(&models.Environment{ID: 1, ProjectID: 1, Name: "env"}).Error)
+	require.NoError(t, db.Create(&models.SecretNode{Name: "s", ProjectID: 1, EnvironmentID: 1, IsSecret: true}).Error)
+
+	require.NoError(t, c.DeleteProject(ctx, 1, true))
+
+	var liveSecrets int64
+	require.NoError(t, db.Model(&models.SecretNode{}).Where("project_id = ? AND deleted_at IS NULL", 1).Count(&liveSecrets).Error)
+	assert.Zero(t, liveSecrets, "force=true must cascade-delete the secret along with the project")
+}

--- a/internal/core/concurrency_invite_member_test.go
+++ b/internal/core/concurrency_invite_member_test.go
@@ -1,0 +1,88 @@
+package core_test
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// TestConcurrency_InviteMember_NoDuplicateActiveMembership is the (#309) TOCTOU
+// regression: InviteMember's "no active membership" read and its CreateProjectMembership
+// write are two separate calls with no transaction, so concurrent invites for the same
+// (project, user) can both pass the read before either commits, producing two non-revoked
+// ProjectMembership rows. This drives many concurrent invites for the same pair against a
+// real file-backed SQLite (through the same migration path production uses, so the
+// uniq_project_memberships_active partial unique index is actually in place) and asserts
+// exactly one membership row survives, with every loser getting a clean "already has a
+// membership" error rather than a raw constraint-violation message or a silently-orphaned
+// row.
+func TestConcurrency_InviteMember_NoDuplicateActiveMembership(t *testing.T) {
+	dsn := "file:" + filepath.Join(t.TempDir(), "invite.db") + "?_busy_timeout=10000&_journal_mode=WAL"
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.Project{}, &models.Role{}, &models.ProjectMembership{}, &models.AuditEvent{}))
+	// Mirror factory.go's ensureProjectMembershipIndex exactly, so this test exercises the
+	// same DB-level guard production installs get (rather than only the in-process check).
+	require.NoError(t, db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS uniq_project_memberships_active "+
+		"ON project_memberships (project_id, user_id) WHERE state <> 'revoked'").Error)
+
+	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "proj"}).Error)
+	require.NoError(t, db.Create(&models.Role{ID: 6, Name: "project_viewer"}).Error)
+
+	c := core.NewKeyorixCore(store.NewLocalStorage(db))
+	c.SetMembershipValidationMode(core.ValidationModeAllowlist)
+
+	const attackers = 40 // many concurrent invites racing for the same (project, user)
+	start := make(chan struct{})
+	errs := make([]error, attackers)
+	var wg sync.WaitGroup
+	for i := 0; i < attackers; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			_, err := c.InviteMember(context.Background(), 1, 2, "project_viewer", 9, false)
+			errs[i] = err
+		}(i)
+	}
+	close(start) // release every invite at once
+	wg.Wait()
+
+	// Exactly one Create must have won the race.
+	var successes int
+	var duplicateRejections int
+	for _, err := range errs {
+		if err == nil {
+			successes++
+			continue
+		}
+		// The loser of the race gets either the original sequential check's message
+		// ("user already has a <state> membership...") or, when it loses the DB-level
+		// race instead, the translated ErrDuplicateActiveMembership message. Both read
+		// as "already has" + "membership"; neither is a raw constraint-violation string.
+		if strings.Contains(err.Error(), "already has") && strings.Contains(err.Error(), "membership") {
+			duplicateRejections++
+		}
+	}
+	assert.Equal(t, 1, successes, "exactly one concurrent invite must succeed")
+	assert.Equal(t, attackers-1, duplicateRejections,
+		"every other concurrent invite must get a clean 'already has ... membership' error, not a raw DB error")
+
+	// And the DB must hold exactly one non-revoked membership row for the pair — no
+	// orphaned duplicate from a TOCTOU window.
+	var count int64
+	require.NoError(t, db.Model(&models.ProjectMembership{}).
+		Where("project_id = ? AND user_id = ? AND state <> ?", 1, 2, "revoked").
+		Count(&count).Error)
+	assert.Equal(t, int64(1), count, "exactly one active membership row must exist for the pair")
+}

--- a/internal/core/membership_lifecycle.go
+++ b/internal/core/membership_lifecycle.go
@@ -22,6 +22,7 @@ package core
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -139,6 +140,15 @@ func (c *KeyorixCore) inviteMemberWithMode(ctx context.Context, projectID, userI
 	}
 	created, err := c.storage.CreateProjectMembership(ctx, m)
 	if err != nil {
+		// #309: the "no active membership" read above races with a concurrent invite for
+		// the same (project, user) — both can pass it before either commits. The DB-level
+		// partial unique index (uniq_project_memberships_active) catches the loser's Create
+		// and CreateProjectMembership wraps it in ErrDuplicateActiveMembership; surface the
+		// same clean "already has a membership" error the winner's sequential check would
+		// have produced, instead of a raw constraint-violation message or an orphaned row.
+		if errors.Is(err, storage.ErrDuplicateActiveMembership) {
+			return nil, fmt.Errorf("user already has a membership in this project")
+		}
 		return nil, fmt.Errorf("failed to create membership: %w", err)
 	}
 

--- a/internal/core/storage/errors.go
+++ b/internal/core/storage/errors.go
@@ -21,3 +21,11 @@ var ErrRoleNotAssigned = errors.New("role not assigned")
 // from a genuine storage failure; callers should surface it as "already revoked"
 // rather than a generic error.
 var ErrBreakGlassNotActive = errors.New("break-glass activation is not active")
+
+// ErrDuplicateActiveMembership is returned (wrapped) by CreateProjectMembership when the
+// insert collides with the partial unique index on (project_id, user_id) scoped to
+// non-revoked rows. InviteMember's own "no active membership" check races with a
+// concurrent invite for the same pair (#309 TOCTOU); this lets the loser of that race
+// be told cleanly that the membership already exists, rather than surfacing a raw
+// constraint-violation error or silently leaving an orphaned row.
+var ErrDuplicateActiveMembership = errors.New("an active membership already exists for this project and user")

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -588,6 +588,11 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 			return fmt.Errorf("failed to migrate project_memberships table: %w", err)
 		}
 	}
+	if tableExists(db, "project_memberships") {
+		if err := ensureProjectMembershipIndex(db); err != nil {
+			return err
+		}
+	}
 
 	// Create setup_tokens if missing (ADR-028 credential delivery, additive).
 	if !setupTokenExists {
@@ -708,6 +713,23 @@ func ensureGroupNameIndex(db *gorm.DB) error {
 	}
 	if err := db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS uniq_groups_name_active ON groups (name) WHERE deleted_at IS NULL").Error; err != nil {
 		return fmt.Errorf("failed to create partial groups name index: %w", err)
+	}
+	return nil
+}
+
+// ensureProjectMembershipIndex creates a partial unique index enforcing at most one
+// non-revoked ProjectMembership per (project, user) at the DB layer. InviteMember's
+// own check-then-create ("one active onboarding per (project, user)") is a TOCTOU:
+// two concurrent invites for the same pair can both pass the "no active membership"
+// read before either commits its Create, producing two non-revoked rows (#309). The
+// index makes the second concurrent Create fail with a constraint violation instead,
+// which CreateProjectMembership/InviteMember translate into the same clean
+// "already has a membership" error a sequential caller would get. Idempotent; mirrors
+// ensureGroupNameIndex/ensureUserNameIndex (partial unique index, live rows only).
+func ensureProjectMembershipIndex(db *gorm.DB) error {
+	if err := db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS uniq_project_memberships_active " +
+		"ON project_memberships (project_id, user_id) WHERE state <> 'revoked'").Error; err != nil {
+		return fmt.Errorf("failed to create partial project_memberships index: %w", err)
 	}
 	return nil
 }

--- a/internal/storage/store/local_memberships.go
+++ b/internal/storage/store/local_memberships.go
@@ -7,6 +7,7 @@ package store
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/core/storage"
@@ -16,9 +17,32 @@ import (
 
 func (ls *LocalStorage) CreateProjectMembership(ctx context.Context, m *models.ProjectMembership) (*models.ProjectMembership, error) {
 	if err := ls.db.WithContext(ctx).Create(m).Error; err != nil {
+		if isUniqueViolation(err) {
+			// The partial unique index uniq_project_memberships_active (#309) caught a
+			// concurrent duplicate: another invite for the same (project, user) committed
+			// first. Translate to the sentinel so callers (InviteMember) can surface the
+			// same clean "already has a membership" error a sequential caller would get,
+			// instead of a raw constraint-violation message.
+			return nil, fmt.Errorf("%w: %v", storage.ErrDuplicateActiveMembership, err)
+		}
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}
 	return m, nil
+}
+
+// isUniqueViolation reports whether err looks like a unique-constraint violation from
+// either backing DB driver. Neither SQLite's nor Postgres's default GORM dialector
+// wraps a typed error here (that needs the gorm.Config{TranslateError: true} opt-in,
+// which this codebase doesn't set), so this matches the driver-native message text —
+// the same approach already used for "not found" detection elsewhere (e.g. sso.go,
+// users.go, scim.go).
+func isUniqueViolation(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "UNIQUE constraint failed") || // SQLite
+		strings.Contains(msg, "duplicate key value violates unique constraint") // Postgres
 }
 
 func (ls *LocalStorage) GetProjectMembership(ctx context.Context, id uint) (*models.ProjectMembership, error) {


### PR DESCRIPTION
## Summary

- **#309 LOW** — `InviteMember`'s "no active membership" check and `CreateProjectMembership` were two separate storage calls with no transaction and no DB constraint, so two concurrent invites for the same `(project, user)` could both pass the check before either committed, leaving an orphaned duplicate `ProjectMembership` row (the actual RBAC grant was never doubled). Fix: add a partial unique index `uniq_project_memberships_active` (non-revoked rows only), mirroring the existing `uniq_groups_name_active`/`uniq_users_username_active` convention in `factory.go`. `CreateProjectMembership` now translates the resulting constraint violation into `storage.ErrDuplicateActiveMembership`, and `InviteMember` surfaces the same clean "already has a membership" error a sequential caller would get, instead of a raw DB error or a silent orphaned row.
- **#310 LOW** — already fixed on `main` (PR #518, commit `6dd9e55`): `queryBuilder.add` in `internal/storage/store/query.go` already calls `url.QueryEscape` on both key and value. Verified against current code; no action taken.
- **#313 LOW** — `DeleteProject`'s non-force secret-count guard ran as a separate top-level call *before*, not inside, the cascade delete's own transaction, so a secret created in that window could get silently swept into the cascade despite the caller expecting the delete to be rejected. Fix: wrap the guard and the cascade delete in one `storage.WithTransaction` call (a nested savepoint over `LocalStorage.DeleteProject`'s own transaction), narrowing the check-then-act window from an application-level round trip down to a single DB transaction.

## Test plan

- [x] `internal/core/concurrency_invite_member_test.go` — 40 concurrent `InviteMember` calls for the same `(project, user)` against a real file-backed SQLite (with the production partial unique index applied); asserts exactly one membership row survives and every other caller gets a clean "already has ... membership" error.
- [x] `internal/core/catalog_delete_project_test.go` — structural spy tests proving the guard and the cascade delete run inside one `WithTransaction` call, in the correct order, and that `force=true` skips the guard entirely; plus real-SQLite integration tests for reject/succeed/force-cascade behavior. (A true race-window test isn't reproducible deterministically against SQLite's deferred-transaction locking without conflating it with an unrelated `CreateSecret` liveness-check race — see the in-file comment for why the structural tests are the precise regression here.)
- [x] `go build ./...` clean
- [x] `go test ./...` clean (known unrelated flake `TestSpool_PersistsAndReplaysOnRecovery` in `internal/audit/siem` passes 5/5 in isolation)
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues
- [x] `golangci-lint run ./...` — 0 issues
- [x] `GOWORK=off go build -C operator ./...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)