### PR TITLE
fix(webauthn): atomic sign-counter update + owner-scoped credential lookup (#306/#307)

### DIFF
--- a/internal/core/concurrency_webauthn_credential_test.go
+++ b/internal/core/concurrency_webauthn_credential_test.go
@@ -1,0 +1,139 @@
+package core
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-webauthn/webauthn/webauthn"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// TestConcurrency_WebAuthnPersistUpdatedCredential_NoStaleCounterRegression is the
+// clone-detection invariant under a race (#306): persistUpdatedCredential must never
+// let a stale (lower) signature counter clobber an already-persisted higher one when
+// two logins for the same credential race — e.g. a cloned authenticator authenticating
+// concurrently with the legitimate device. Before the fix, GetWebAuthnCredentialByCredID
+// + blind Save had no predicate at all: both requests could read the same stale row and
+// the last UPDATE would win regardless of which counter was actually higher, silently
+// regressing the persisted counter and suppressing the webauthn.clone_warning signal on
+// future logins. The fix serializes persistUpdatedCredential (process mutex, mirroring
+// recordFailedLogin's loginFailureMu) and re-reads the row's CURRENT counter inside a
+// transaction (LockWebAuthnCredentialForUpdate takes a Postgres FOR UPDATE lock), only
+// persisting a write whose counter is still greater than that fresh read — so the
+// persisted counter is monotonic regardless of goroutine scheduling. Uses a real
+// file-backed SQLite (not :memory:) so many concurrent connections behave like the
+// production single-process case. Run with -race.
+func TestConcurrency_WebAuthnPersistUpdatedCredential_NoStaleCounterRegression(t *testing.T) {
+	dsn := "file:" + filepath.Join(t.TempDir(), "webauthn.db") + "?_busy_timeout=10000&_journal_mode=WAL"
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.User{}, &models.WebAuthnCredential{}))
+
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "alice", AccountState: "active"}).Error)
+
+	credID := []byte("cred-1")
+	initialBlob, err := json.Marshal(webauthn.Credential{ID: credID, Authenticator: webauthn.Authenticator{SignCount: 0}})
+	require.NoError(t, err)
+	require.NoError(t, db.Create(&models.WebAuthnCredential{
+		UserID: 1, CredentialID: credID, Name: "test key", CredentialBlob: initialBlob,
+	}).Error)
+
+	fixed := time.Now()
+	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: func() time.Time { return fixed }}
+	ctx := context.Background()
+
+	// Repeated trials: each iteration races a "low" (stale/cloned) counter against a
+	// much higher "legitimate" counter, both starting from the current persisted
+	// baseline, and asserts the persisted counter always ends at the max of the two —
+	// i.e. the stale write is rejected regardless of which goroutine's transaction
+	// actually wins the race to run first.
+	const trials = 25
+	baseline := uint32(0)
+	for i := 0; i < trials; i++ {
+		low := baseline + 1
+		high := baseline + 50
+
+		lowCred := &webauthn.Credential{ID: credID, Authenticator: webauthn.Authenticator{SignCount: low}}
+		highCred := &webauthn.Credential{ID: credID, Authenticator: webauthn.Authenticator{SignCount: high}}
+
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			<-start
+			c.persistUpdatedCredential(ctx, 1, lowCred)
+		}()
+		go func() {
+			defer wg.Done()
+			<-start
+			c.persistUpdatedCredential(ctx, 1, highCred)
+		}()
+		close(start)
+		wg.Wait()
+
+		var row models.WebAuthnCredential
+		require.NoError(t, db.Where("credential_id = ?", credID).First(&row).Error)
+		var stored webauthn.Credential
+		require.NoError(t, json.Unmarshal(row.CredentialBlob, &stored))
+		assert.Equal(t, high, stored.Authenticator.SignCount,
+			"trial %d: the higher (legitimate) counter must win regardless of write order — a lost/regressed update would suppress clone detection", i)
+
+		baseline = high
+	}
+}
+
+// TestConcurrency_WebAuthnPersistUpdatedCredential_StaleWriteAfterWinnerIsRejected
+// pins the exact ordering the backlog finding traces: the loser of the race (the
+// stale/lower counter) attempts its write AFTER the winner has already committed a
+// higher counter. Before the fix (blind read-then-Save with no predicate) this stale
+// write would silently clobber the winner's persisted value. After the fix the
+// transaction re-reads the row's current counter and skips the write.
+func TestConcurrency_WebAuthnPersistUpdatedCredential_StaleWriteAfterWinnerIsRejected(t *testing.T) {
+	dsn := "file:" + filepath.Join(t.TempDir(), "webauthn2.db") + "?_busy_timeout=10000&_journal_mode=WAL"
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.User{}, &models.WebAuthnCredential{}))
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "alice", AccountState: "active"}).Error)
+
+	credID := []byte("cred-1")
+	initialBlob, err := json.Marshal(webauthn.Credential{ID: credID, Authenticator: webauthn.Authenticator{SignCount: 0}})
+	require.NoError(t, err)
+	require.NoError(t, db.Create(&models.WebAuthnCredential{
+		UserID: 1, CredentialID: credID, Name: "test key", CredentialBlob: initialBlob,
+	}).Error)
+
+	fixed := time.Now()
+	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: func() time.Time { return fixed }}
+	ctx := context.Background()
+
+	// Winner (legitimate device) commits first: counter advances 0 -> 100.
+	c.persistUpdatedCredential(ctx, 1, &webauthn.Credential{ID: credID, Authenticator: webauthn.Authenticator{SignCount: 100}})
+
+	var afterWinner models.WebAuthnCredential
+	require.NoError(t, db.Where("credential_id = ?", credID).First(&afterWinner).Error)
+	var afterWinnerCred webauthn.Credential
+	require.NoError(t, json.Unmarshal(afterWinner.CredentialBlob, &afterWinnerCred))
+	require.Equal(t, uint32(100), afterWinnerCred.Authenticator.SignCount)
+
+	// Loser (cloned authenticator) had validated its assertion against the stale
+	// baseline (0) and now tries to persist a counter that is higher than that stale
+	// baseline but lower than what's now actually stored.
+	c.persistUpdatedCredential(ctx, 1, &webauthn.Credential{ID: credID, Authenticator: webauthn.Authenticator{SignCount: 5}})
+
+	var final models.WebAuthnCredential
+	require.NoError(t, db.Where("credential_id = ?", credID).First(&final).Error)
+	var finalCred webauthn.Credential
+	require.NoError(t, json.Unmarshal(final.CredentialBlob, &finalCred))
+	assert.Equal(t, uint32(100), finalCred.Authenticator.SignCount,
+		"a stale write below the currently-persisted counter must be rejected, not silently applied")
+}

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -1782,7 +1782,10 @@ func (m *MockStorage) CreateWebAuthnCredential(_ context.Context, _ *models.WebA
 func (m *MockStorage) ListWebAuthnCredentials(_ context.Context, _ uint) ([]*models.WebAuthnCredential, error) {
 	return nil, nil
 }
-func (m *MockStorage) GetWebAuthnCredentialByCredID(_ context.Context, _ []byte) (*models.WebAuthnCredential, error) {
+func (m *MockStorage) GetWebAuthnCredentialByCredID(_ context.Context, _ []byte, _ uint) (*models.WebAuthnCredential, error) {
+	return nil, nil
+}
+func (m *MockStorage) LockWebAuthnCredentialForUpdate(_ context.Context, _ []byte, _ uint) (*models.WebAuthnCredential, error) {
 	return nil, nil
 }
 func (m *MockStorage) UpdateWebAuthnCredential(_ context.Context, _ *models.WebAuthnCredential) error {

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -74,8 +74,15 @@ type KeyorixCore struct {
 	// before either token row exists. Held only across the throttle check and the
 	// token write — link delivery (SMTP) runs after release, so a slow send never
 	// serializes every other resend. Zero value is ready to use. See setup_delivery.go.
-	setupResendMu  sync.Mutex
-	auditForwarder AuditForwarder
+	setupResendMu sync.Mutex
+	// webauthnCredentialMu serializes persistUpdatedCredential's per-credential
+	// read-validate-write of the advanced WebAuthn signature counter, so two
+	// concurrent logins for the same (cloned) authenticator cannot race and let a
+	// stale, lower counter clobber an already-persisted higher one. Combined with the
+	// row lock LockWebAuthnCredentialForUpdate takes on Postgres, the counter stays
+	// monotonic across replicas too. Zero value is ready to use. See webauthn.go.
+	webauthnCredentialMu sync.Mutex
+	auditForwarder       AuditForwarder
 	// auditStream is the in-process pub/sub broker that wakes live audit tails
 	// (gRPC StreamAuditLogs) the instant an event is written, replacing fixed-interval
 	// DB polling. Always non-nil (set in the constructors).

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -537,7 +537,19 @@ type Storage interface {
 	// WebAuthn / passkeys (ADR-036).
 	CreateWebAuthnCredential(ctx context.Context, c *models.WebAuthnCredential) error
 	ListWebAuthnCredentials(ctx context.Context, userID uint) ([]*models.WebAuthnCredential, error)
-	GetWebAuthnCredentialByCredID(ctx context.Context, credentialID []byte) (*models.WebAuthnCredential, error)
+	// GetWebAuthnCredentialByCredID looks up a credential by its (unique) credential
+	// ID, scoped to the claimed owner: the query itself requires user_id = userID, so
+	// correctness does not depend on every caller re-checking ownership after the
+	// fetch (#307).
+	GetWebAuthnCredentialByCredID(ctx context.Context, credentialID []byte, userID uint) (*models.WebAuthnCredential, error)
+	// LockWebAuthnCredentialForUpdate re-reads a WebAuthn credential by (credential_id,
+	// user_id) inside a WithTransaction, taking a row-level write lock on backends that
+	// support one (Postgres: SELECT … FOR UPDATE), so a read-modify-write of the
+	// advanced signature counter serializes against a concurrent write for the same
+	// credential — closing the cloned-authenticator race where two concurrent
+	// authentications both read the stale counter and the last UPDATE silently wins,
+	// suppressing the clone-detection audit signal (#306).
+	LockWebAuthnCredentialForUpdate(ctx context.Context, credentialID []byte, userID uint) (*models.WebAuthnCredential, error)
 	UpdateWebAuthnCredential(ctx context.Context, c *models.WebAuthnCredential) error
 	DeleteWebAuthnCredential(ctx context.Context, userID, id uint) error
 	CountWebAuthnCredentials(ctx context.Context, userID uint) (int64, error)

--- a/internal/core/webauthn.go
+++ b/internal/core/webauthn.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/go-webauthn/webauthn/protocol"
 	"github.com/go-webauthn/webauthn/webauthn"
+	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
@@ -399,19 +400,56 @@ func (c *KeyorixCore) FinishWebAuthnPasswordlessLogin(ctx context.Context, sessi
 // persistUpdatedCredential writes back the credential's advanced signature counter
 // (and clone-warning flag) plus a last-used timestamp. Best-effort: a write error
 // must not fail an otherwise-valid login.
+//
+// Both FinishWebAuthnLogin and FinishWebAuthnPasswordlessLogin call this
+// independently and unsynchronized, so a concurrent cloned-authenticator race can
+// have two requests both load the stored row before either writes back: without a
+// predicate, a blind Save would let the loser's stale (lower) counter overwrite the
+// winner's already-persisted higher one — last UPDATE wins — silently regressing the
+// on-disk counter and suppressing the clone-detection audit signal on subsequent
+// logins (#306). webauthnCredentialMu serializes same-process callers (and so the
+// whole single-process SQLite case); combined with the row lock
+// LockWebAuthnCredentialForUpdate takes on Postgres, the read-validate-write stays
+// correct across replicas too. Inside the transaction the counter check is re-done
+// against the row's CURRENT persisted value (re-read under the lock), not the value
+// `cred` was validated against at the top of Finish*Login, so only a genuinely higher
+// counter is ever persisted.
 func (c *KeyorixCore) persistUpdatedCredential(ctx context.Context, userID uint, cred *webauthn.Credential) {
-	row, err := c.storage.GetWebAuthnCredentialByCredID(ctx, cred.ID)
-	if err != nil || row.UserID != userID {
-		return
-	}
 	blob, err := json.Marshal(cred)
 	if err != nil {
 		return
 	}
 	now := c.now()
-	row.CredentialBlob = blob
-	row.LastUsedAt = &now
-	_ = c.storage.UpdateWebAuthnCredential(ctx, row)
+
+	c.webauthnCredentialMu.Lock()
+	defer c.webauthnCredentialMu.Unlock()
+
+	_ = c.storage.WithTransaction(ctx, func(tx storage.Storage) error {
+		row, err := tx.LockWebAuthnCredentialForUpdate(ctx, cred.ID, userID)
+		if err != nil {
+			return err
+		}
+		var stored webauthn.Credential
+		if err := json.Unmarshal(row.CredentialBlob, &stored); err != nil {
+			return err
+		}
+		// Mirrors go-webauthn's own Authenticator.UpdateCounter gate: many platform
+		// authenticators (Touch ID, Windows Hello, and most passkeys) never implement a
+		// counter and always report 0, so a (0, 0) comparison must NOT be treated as
+		// stale — that would silently stop LastUsedAt/blob updates from ever persisting
+		// again for the common case. Only reject when at least one side is nonzero and
+		// the new value fails to advance past the row's CURRENT stored value.
+		newCount, storedCount := cred.Authenticator.SignCount, stored.Authenticator.SignCount
+		if newCount <= storedCount && (newCount != 0 || storedCount != 0) {
+			// A concurrent request already advanced the stored counter past (or to) this
+			// assertion's value: this write is stale, so skip it rather than regress the
+			// persisted counter.
+			return nil
+		}
+		row.CredentialBlob = blob
+		row.LastUsedAt = &now
+		return tx.UpdateWebAuthnCredential(ctx, row)
+	})
 }
 
 func (c *KeyorixCore) auditWebAuthnFailed(ctx context.Context, userID uint, phase string) {

--- a/internal/core/webauthn_test.go
+++ b/internal/core/webauthn_test.go
@@ -229,6 +229,34 @@ func TestWebAuthn_FinishLoginHonorsAccountLockout(t *testing.T) {
 	assert.Contains(t, err.Error(), "locked")
 }
 
+// Platform authenticators (Touch ID, Windows Hello, and most passkeys) never
+// implement a signature counter and always report SignCount 0. persistUpdatedCredential's
+// #306 stale-write guard must not treat a (0, 0) comparison as "stale" — that would
+// silently stop LastUsedAt/blob from ever persisting again after the very first login
+// for the common case, mirroring go-webauthn's own Authenticator.UpdateCounter gate
+// (which also special-cases 0/0 as never a clone signal).
+func TestWebAuthn_PersistUpdatedCredential_ZeroCounterAuthenticatorAlwaysPersists(t *testing.T) {
+	c, db := newWebAuthnTestCore(t, true)
+	ctx := context.Background()
+	seedCredential(t, c, db, 1, "cred-1")
+
+	var before models.WebAuthnCredential
+	require.NoError(t, db.Where("user_id = ?", 1).First(&before).Error)
+	assert.Nil(t, before.LastUsedAt, "no login yet")
+
+	// Simulate two logins in a row from a zero-counter authenticator.
+	for i := 0; i < 2; i++ {
+		c.now = func() time.Time { return time.Date(2026, 6, 12, 10, i, 0, 0, time.UTC) }
+		c.persistUpdatedCredential(ctx, 1, &webauthn.Credential{ID: []byte("cred-1"), Authenticator: webauthn.Authenticator{SignCount: 0}})
+	}
+
+	var after models.WebAuthnCredential
+	require.NoError(t, db.Where("user_id = ?", 1).First(&after).Error)
+	require.NotNil(t, after.LastUsedAt, "LastUsedAt must still update on every login even when SignCount stays 0")
+	assert.Equal(t, time.Date(2026, 6, 12, 10, 1, 0, 0, time.UTC), after.LastUsedAt.UTC(),
+		"the SECOND login's timestamp must persist too — a (0,0) comparison must not be treated as a stale write")
+}
+
 func TestWebAuthn_FinishLoginRejectsMismatchedSession(t *testing.T) {
 	c, db := newWebAuthnTestCore(t, true)
 	ctx := context.Background()

--- a/internal/storage/store/local_webauthn.go
+++ b/internal/storage/store/local_webauthn.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 func (ls *LocalStorage) CreateWebAuthnCredential(ctx context.Context, c *models.WebAuthnCredential) error {
@@ -23,9 +24,31 @@ func (ls *LocalStorage) ListWebAuthnCredentials(ctx context.Context, userID uint
 	return creds, nil
 }
 
-func (ls *LocalStorage) GetWebAuthnCredentialByCredID(ctx context.Context, credentialID []byte) (*models.WebAuthnCredential, error) {
+// GetWebAuthnCredentialByCredID looks up a credential by credential ID, scoped to
+// the claimed owner (user_id = userID) so a caller cannot fetch another user's
+// credential blob by omitting or forgetting an ownership check (#307).
+func (ls *LocalStorage) GetWebAuthnCredentialByCredID(ctx context.Context, credentialID []byte, userID uint) (*models.WebAuthnCredential, error) {
 	var c models.WebAuthnCredential
-	if err := ls.db.WithContext(ctx).Where("credential_id = ?", credentialID).First(&c).Error; err != nil {
+	if err := ls.db.WithContext(ctx).Where("credential_id = ? AND user_id = ?", credentialID, userID).First(&c).Error; err != nil {
+		return nil, err
+	}
+	return &c, nil
+}
+
+// LockWebAuthnCredentialForUpdate re-reads a credential by (credential_id, user_id),
+// taking a row-level write lock on backends that support one (Postgres: SELECT …
+// FOR UPDATE). Used inside WithTransaction so a read-modify-write of the advanced
+// signature counter serializes against a concurrent write for the same credential
+// (#306). On backends without row locks (SQLite) it is a plain scoped read, and the
+// caller is responsible for its own process-level serialization — mirrors
+// LockUserForUpdate.
+func (ls *LocalStorage) LockWebAuthnCredentialForUpdate(ctx context.Context, credentialID []byte, userID uint) (*models.WebAuthnCredential, error) {
+	q := ls.db.WithContext(ctx)
+	if ls.db.Dialector.Name() == "postgres" {
+		q = q.Clauses(clause.Locking{Strength: "UPDATE"})
+	}
+	var c models.WebAuthnCredential
+	if err := q.Where("credential_id = ? AND user_id = ?", credentialID, userID).First(&c).Error; err != nil {
 		return nil, err
 	}
 	return &c, nil

--- a/internal/storage/store/local_webauthn_scope_test.go
+++ b/internal/storage/store/local_webauthn_scope_test.go
@@ -1,0 +1,76 @@
+package store
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// TestGetWebAuthnCredentialByCredID_ScopedToOwner pins the ownership boundary
+// directly into GetWebAuthnCredentialByCredID's SQL (#307): CredentialID has a
+// DB-level unique index, so today the query is only "safe" because its sole
+// caller (persistUpdatedCredential) immediately re-checks row.UserID != userID
+// after the fetch. A future caller that forgets that manual check would leak
+// another user's credential blob. The fix folds the ownership check into the
+// query itself (AND user_id = ?), so correctness no longer depends on every
+// future caller remembering to re-check.
+func TestGetWebAuthnCredentialByCredID_ScopedToOwner(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.User{}, &models.WebAuthnCredential{}))
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "alice", AccountState: "active"}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 2, Username: "bob", AccountState: "active"}).Error)
+
+	ls := NewLocalStorage(db)
+	ctx := context.Background()
+	credID := []byte("cred-1")
+	require.NoError(t, ls.CreateWebAuthnCredential(ctx, &models.WebAuthnCredential{
+		UserID: 1, CredentialID: credID, Name: "alice's key", CredentialBlob: []byte(`{}`),
+	}))
+
+	// The owner can fetch their own credential by credential ID.
+	got, err := ls.GetWebAuthnCredentialByCredID(ctx, credID, 1)
+	require.NoError(t, err)
+	assert.Equal(t, uint(1), got.UserID)
+
+	// A different user presenting the SAME credential ID (e.g. a caller that
+	// forgot to re-check ownership after the fetch) must get "not found", not
+	// user 1's credential row.
+	_, err = ls.GetWebAuthnCredentialByCredID(ctx, credID, 2)
+	require.Error(t, err, "a non-owner must not be able to fetch another user's credential by credential ID")
+
+	// An unknown credential ID is also "not found".
+	_, err = ls.GetWebAuthnCredentialByCredID(ctx, []byte("no-such-cred"), 1)
+	require.Error(t, err)
+}
+
+// TestLockWebAuthnCredentialForUpdate_ScopedToOwner pins the same ownership
+// boundary on the locking read used by persistUpdatedCredential's atomic
+// counter update (#306): the row lock must never hand back another user's
+// credential.
+func TestLockWebAuthnCredentialForUpdate_ScopedToOwner(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.User{}, &models.WebAuthnCredential{}))
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "alice", AccountState: "active"}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 2, Username: "bob", AccountState: "active"}).Error)
+
+	ls := NewLocalStorage(db)
+	ctx := context.Background()
+	credID := []byte("cred-1")
+	require.NoError(t, ls.CreateWebAuthnCredential(ctx, &models.WebAuthnCredential{
+		UserID: 1, CredentialID: credID, Name: "alice's key", CredentialBlob: []byte(`{}`),
+	}))
+
+	got, err := ls.LockWebAuthnCredentialForUpdate(ctx, credID, 1)
+	require.NoError(t, err)
+	assert.Equal(t, uint(1), got.UserID)
+
+	_, err = ls.LockWebAuthnCredentialForUpdate(ctx, credID, 2)
+	require.Error(t, err, "a non-owner must not be able to lock another user's credential by credential ID")
+}

--- a/internal/storage/store/remote_mfa.go
+++ b/internal/storage/store/remote_mfa.go
@@ -69,8 +69,11 @@ func (rs *RemoteStorage) CreateWebAuthnCredential(_ context.Context, _ *models.W
 func (rs *RemoteStorage) ListWebAuthnCredentials(_ context.Context, _ uint) ([]*models.WebAuthnCredential, error) {
 	return nil, remoteUnsupported("ListWebAuthnCredentials")
 }
-func (rs *RemoteStorage) GetWebAuthnCredentialByCredID(_ context.Context, _ []byte) (*models.WebAuthnCredential, error) {
+func (rs *RemoteStorage) GetWebAuthnCredentialByCredID(_ context.Context, _ []byte, _ uint) (*models.WebAuthnCredential, error) {
 	return nil, remoteUnsupported("GetWebAuthnCredentialByCredID")
+}
+func (rs *RemoteStorage) LockWebAuthnCredentialForUpdate(_ context.Context, _ []byte, _ uint) (*models.WebAuthnCredential, error) {
+	return nil, remoteUnsupported("LockWebAuthnCredentialForUpdate")
 }
 func (rs *RemoteStorage) UpdateWebAuthnCredential(_ context.Context, _ *models.WebAuthnCredential) error {
 	return remoteUnsupported("UpdateWebAuthnCredential")


### PR DESCRIPTION
## Summary

- **#306 MEDIUM** — `persistUpdatedCredential`'s WebAuthn sign-counter read-validate-write was unsynchronized between `FinishWebAuthnLogin` and `FinishWebAuthnPasswordlessLogin`: two concurrent authentications for the same credential (e.g. a cloned authenticator racing the legitimate device) could both read the stale stored counter before either wrote back, and the last blind `Save` would silently clobber an already-persisted higher counter — suppressing the `webauthn.clone_warning` audit signal. Fixed by serializing the read-modify-write with a process mutex (`webauthnCredentialMu`, mirroring the existing `loginFailureMu` pattern) plus a transaction that re-checks the row's *current* counter via a new `LockWebAuthnCredentialForUpdate` (Postgres `FOR UPDATE` row lock), only persisting a genuine advance. The staleness check mirrors go-webauthn's own `Authenticator.UpdateCounter` (0,0) exception so platform authenticators that never implement a counter (Touch ID, Windows Hello, most passkeys — always report `SignCount 0`) still get `LastUsedAt` updated on every login instead of being permanently treated as "stale."
- **#307 LOW** — `GetWebAuthnCredentialByCredID` had no `user_id` predicate in its own SQL; safe today only because its sole caller (`persistUpdatedCredential`) immediately re-checked `row.UserID != userID` after the fetch. The query itself now requires `user_id = ?`, so correctness no longer depends on every future caller remembering that check. Threaded the new `userID` parameter through the interface, local/remote storage implementations, and the mock.

Both findings re-verified against current `origin/main` before fixing — neither was already resolved.

## Test plan
- [x] New regression test `TestConcurrency_WebAuthnPersistUpdatedCredential_NoStaleCounterRegression` — repeated concurrent low/high-counter races over a real file-backed SQLite DB, asserting the persisted counter is always the max regardless of goroutine scheduling.
- [x] New regression test `TestConcurrency_WebAuthnPersistUpdatedCredential_StaleWriteAfterWinnerIsRejected` — pins the exact ordering from the finding (stale write arrives after the winner commits) and asserts it's rejected, not silently applied.
- [x] New regression test `TestWebAuthn_PersistUpdatedCredential_ZeroCounterAuthenticatorAlwaysPersists` — guards the platform-authenticator (SignCount always 0) edge case discovered while fixing #306.
- [x] New scoping tests `TestGetWebAuthnCredentialByCredID_ScopedToOwner` / `TestLockWebAuthnCredentialForUpdate_ScopedToOwner` in `internal/storage/store` pin the `user_id` predicate directly in the SQL.
- [x] `go build ./...` clean
- [x] `go test ./...` full suite clean (one pre-existing, unrelated flake confirmed independent of this change: `TestHTTPJWKSResolver_CapsKeyCount` fails identically on a clean `origin/main` checkout — not touched by this PR)
- [x] `go test ./internal/core/... -race -run 'WebAuthn'` and `go test ./internal/storage/store/... -race -run 'WebAuthn'` clean
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues
- [x] `golangci-lint run ./...` — 0 issues
- [x] `GOWORK=off go build -C operator ./...` — clean (separate module)