### PR TITLE
fix(audit): serialize the audit-checkpoint write path across triggers (#300)

### DIFF
--- a/docs/adr-029-audit-log-tamper-evidence.md
+++ b/docs/adr-029-audit-log-tamper-evidence.md
@@ -122,6 +122,23 @@ double-migration hazard).
     authenticated prior checkpoint, so a truncation is never silently re-baselined
     away. Surfaced as `checkpointed`/`checkpoint_reason` on `/audit/verify` and in
     `keyorix audit verify`.
+  - **Checkpoint-write serialization (#300):** `WriteAuditCheckpoint` is reachable
+    from three unsynchronized triggers — the scheduler tick, the HTTP
+    `POST /api/v1/audit/checkpoint` endpoint, and the gRPC `WriteAuditCheckpoint`
+    RPC — which can land on different replicas (HA). Without serialization, two
+    overlapping calls could interleave the chain-walk + decide + create sequence
+    and commit a checkpoint out of chain-length order: the row with the higher DB
+    `id` could end up certifying FEWER chained events than an earlier-committed
+    row, so `LatestAuditCheckpoint`'s `id DESC` pick would silently miss coverage
+    of events that landed in the interleaving window — a real gap even with a
+    fully-intact, validly-signed chain. `WriteAuditCheckpoint` now runs its whole
+    sequence under `storage.WithAuditCheckpointLock`, mirroring the per-event
+    append serialization above: a process-level mutex for the common single-writer
+    topology and SQLite, extended across processes/replicas on PostgreSQL with a
+    blocking session advisory lock (`pg_advisory_lock`, distinct from the
+    per-append lock key). Unlike the scheduler's own `WithSchedulerLock` (a "try"
+    lock that skips a tick on contention), this blocks until free, so an
+    operator-triggered write racing the scheduler is serialized, not dropped.
   - **DEK rotation:** a checkpoint signed under a superseded DEK cannot be
     re-verified on-box, so after a rotation `verify` fails closed (reports invalid)
     until the next checkpoint write re-baselines under the new key — the scheduler

--- a/internal/core/audit_checkpoint.go
+++ b/internal/core/audit_checkpoint.go
@@ -143,18 +143,43 @@ func (c *KeyorixCore) VerifyCheckpointAnchor(cp *models.AuditCheckpoint) (anchor
 // error when the chain does not verify — refusing to notarise a tampered state,
 // and refusing to re-baseline over a truncation already flagged by an existing
 // checkpoint (VerifyAuditChain enforces prior checkpoints).
+//
+// The whole chain-walk + decide + create sequence runs under
+// storage.WithAuditCheckpointLock (#300): it is reachable from three
+// unsynchronized triggers — the scheduler tick, the HTTP
+// POST /api/v1/audit/checkpoint endpoint, and the gRPC WriteAuditCheckpoint RPC —
+// which can land on different replicas (ADR-039 HA). Without a lock, two
+// overlapping calls can interleave so the checkpoint that commits with the
+// higher DB id ends up certifying FEWER chained events than an earlier-committed
+// one, reopening the exact truncation-detection gap ADR-029 exists to close.
 func (c *KeyorixCore) WriteAuditCheckpoint(ctx context.Context) (*models.AuditCheckpoint, bool, error) {
 	if !c.AuditCheckpointsAvailable() {
 		return nil, false, nil
 	}
+	var newCP *models.AuditCheckpoint
+	err := c.storage.WithAuditCheckpointLock(ctx, func() error {
+		cp, werr := c.writeAuditCheckpointLocked(ctx)
+		newCP = cp
+		return werr
+	})
+	if err != nil {
+		return nil, false, err
+	}
+	return newCP, true, nil
+}
+
+// writeAuditCheckpointLocked performs the actual chain-walk + decide + create
+// sequence. The caller MUST hold storage.WithAuditCheckpointLock for the
+// duration of this call (see WriteAuditCheckpoint).
+func (c *KeyorixCore) writeAuditCheckpointLocked(ctx context.Context) (*models.AuditCheckpoint, error) {
 	// Verify the raw chain (walk only, no checkpoint enforcement) so we never sign
 	// a head over a broken chain.
 	raw, err := c.storage.VerifyAuditChain(ctx)
 	if err != nil {
-		return nil, false, fmt.Errorf("failed to verify audit chain: %w", err)
+		return nil, fmt.Errorf("failed to verify audit chain: %w", err)
 	}
 	if !raw.Valid {
-		return nil, false, fmt.Errorf("refusing to checkpoint a chain that does not verify: %s", raw.Reason)
+		return nil, fmt.Errorf("refusing to checkpoint a chain that does not verify: %s", raw.Reason)
 	}
 	// Refuse to re-baseline over a truncation that an AUTHENTICATED prior checkpoint
 	// proves — otherwise a scheduled write would silently bless a shortened chain and
@@ -163,14 +188,14 @@ func (c *KeyorixCore) WriteAuditCheckpoint(ctx context.Context) (*models.AuditCh
 	// key rotation.
 	cp, err := c.storage.LatestAuditCheckpoint(ctx)
 	if err != nil {
-		return nil, false, err
+		return nil, err
 	}
 	if cp != nil {
 		if c.checkpointSignatureValid(cp) {
 			if reason, tampered, err := c.checkpointTruncation(ctx, raw.ChainedEvents, cp); err != nil {
-				return nil, false, err
+				return nil, err
 			} else if tampered {
-				return nil, false, fmt.Errorf("refusing to checkpoint: %s", reason)
+				return nil, fmt.Errorf("refusing to checkpoint: %s", reason)
 			}
 		} else if cp.KeyVersion == c.auditCkptKeyVersion {
 			// The prior checkpoint claims the CURRENT signing-key version yet fails its
@@ -180,7 +205,7 @@ func (c *KeyorixCore) WriteAuditCheckpoint(ctx context.Context) (*models.AuditCh
 			// flags this as Valid=false, but a silent re-baseline would write a fresh,
 			// authentic checkpoint over the shortened chain and erase that signal. Fail
 			// closed and leave the tamper signal standing for an operator to investigate.
-			return nil, false, fmt.Errorf("refusing to checkpoint: latest checkpoint #%d fails its signature under the current key version %q — the checkpoint row was tampered with, not rotated", cp.ID, cp.KeyVersion)
+			return nil, fmt.Errorf("refusing to checkpoint: latest checkpoint #%d fails its signature under the current key version %q — the checkpoint row was tampered with, not rotated", cp.ID, cp.KeyVersion)
 		}
 		// else: signature fails AND key_version is superseded → consistent with a DEK
 		// rotation; fall through and re-baseline under the new key (recovery path).
@@ -190,13 +215,13 @@ func (c *KeyorixCore) WriteAuditCheckpoint(ctx context.Context) (*models.AuditCh
 	// checkpoint (and a fresh high-water), erasing the rollback evidence.
 	floor, _, hwTampered, hwReason, err := c.auditHighWaterFloor(ctx)
 	if err != nil {
-		return nil, false, err
+		return nil, err
 	}
 	if hwTampered {
-		return nil, false, fmt.Errorf("refusing to checkpoint: %s", hwReason)
+		return nil, fmt.Errorf("refusing to checkpoint: %s", hwReason)
 	}
 	if raw.ChainedEvents < floor {
-		return nil, false, fmt.Errorf("refusing to checkpoint: the audit trail (%d events) is below the certified high-water mark (%d) — a truncation must be investigated, not re-baselined", raw.ChainedEvents, floor)
+		return nil, fmt.Errorf("refusing to checkpoint: the audit trail (%d events) is below the certified high-water mark (%d) — a truncation must be investigated, not re-baselined", raw.ChainedEvents, floor)
 	}
 	newCP := &models.AuditCheckpoint{
 		ChainedEvents: raw.ChainedEvents,
@@ -206,13 +231,13 @@ func (c *KeyorixCore) WriteAuditCheckpoint(ctx context.Context) (*models.AuditCh
 	}
 	newCP.Signature = c.signCheckpoint(newCP)
 	if err := c.storage.CreateAuditCheckpoint(ctx, newCP); err != nil {
-		return nil, false, fmt.Errorf("failed to write audit checkpoint: %w", err)
+		return nil, fmt.Errorf("failed to write audit checkpoint: %w", err)
 	}
 	// Best-effort external anchor (RFC 3161) — never fails the checkpoint write.
 	c.anchorCheckpoint(ctx, newCP)
 	// Advance the persistent + in-memory high-water mark to this certified length.
 	c.advanceAuditHighWater(ctx, newCP)
-	return newCP, true, nil
+	return newCP, nil
 }
 
 // enforceAuditCheckpoint augments a chain-walk verdict with on-box checkpoint

--- a/internal/core/audit_checkpoint_concurrency_test.go
+++ b/internal/core/audit_checkpoint_concurrency_test.go
@@ -1,0 +1,138 @@
+// audit_checkpoint_concurrency_test.go — regression coverage for #300: the
+// audit-checkpoint write path (ADR-029) must serialize its chain-walk + decide +
+// create-checkpoint sequence across every trigger (scheduler, HTTP, gRPC), so two
+// overlapping WriteAuditCheckpoint calls can never commit an out-of-order chain
+// (a later-committed, higher-id checkpoint certifying FEWER events than an
+// earlier one).
+package core
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// checkpointConcurrentDB opens a temp FILE-backed SQLite with a busy timeout,
+// WAL, and _txlock=immediate. Unlike store.auditConcurrentDB
+// (concurrency_audit_chain_test.go), WriteAuditCheckpoint's chain-walk + decide +
+// create sequence already spans several independent, non-transactional SQL
+// statements (VerifyAuditChain's read, LatestAuditCheckpoint's read,
+// CreateAuditCheckpoint's insert, the high-water read/write) — there is no
+// single SQL transaction whose txlock mode could ever make that multi-statement
+// sequence atomic. So _txlock=immediate here only avoids an unrelated SQLite
+// artifact (concurrent LogAuditEvent inserts and WriteAuditCheckpoint's own
+// writes deadlocking on lock-upgrade under deferred mode); it cannot mask a
+// regression of the Go-level WithAuditCheckpointLock mutex under test.
+func checkpointConcurrentDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	dsn := "file:" + filepath.Join(t.TempDir(), "checkpoint.db") + "?_busy_timeout=10000&_journal_mode=WAL&_txlock=immediate"
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.AuditEvent{}, &models.AuditCheckpoint{}, &models.SystemMetadata{}))
+	return db
+}
+
+// TestConcurrency_AuditCheckpoint_NoOutOfOrderChain drives many goroutines, each
+// appending one audit event and then immediately calling WriteAuditCheckpoint, all
+// released at once to maximize the race window described in #300:
+// WriteAuditCheckpoint's chain-walk (VerifyAuditChain) + read-latest-checkpoint +
+// decide + create-checkpoint sequence has no transaction, row lock, or advisory
+// lock, so two overlapping calls can interleave and commit a checkpoint out of
+// chain-length order — the row with the higher DB id certifying FEWER chained
+// events than an earlier-committed row. That silently reopens the exact
+// tail-truncation-detection gap ADR-029 exists to close: LatestAuditCheckpoint's
+// `id DESC` pick would be a checkpoint that never actually certified an event
+// that landed in the interleaving window.
+//
+// With WithAuditCheckpointLock serializing the whole sequence, every checkpoint
+// commit is strictly ordered against every other: this test asserts that
+// ChainedEvents is monotonically non-decreasing when checkpoints are read back in
+// ascending id order, and that no writer is ever spuriously refused (a correctly
+// serialized writer never races its own high-water floor).
+func TestConcurrency_AuditCheckpoint_NoOutOfOrderChain(t *testing.T) {
+	db := checkpointConcurrentDB(t)
+	c := &KeyorixCore{storage: store.NewLocalStorage(db)}
+	c.SetAuditCheckpointKey(bytes.Repeat([]byte{0x7}, 32), "v1")
+
+	// Seed a small baseline chain so the first checkpoint isn't over an empty trail.
+	logEvents(t, c, 3)
+
+	const writers = 40
+	start := make(chan struct{})
+	errs := make(chan error, writers)
+	var wg sync.WaitGroup
+	base := time.Date(2026, 6, 20, 12, 0, 0, 0, time.UTC)
+	for i := 0; i < writers; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			<-start
+			ctx := context.Background()
+			tr := true
+			// Grow the chain by exactly one event, then immediately race to
+			// checkpoint it — the exact "manual call racing another trigger"
+			// pattern #300 describes, just with many concurrent triggers instead
+			// of the scheduler-vs-HTTP/gRPC pairing in production.
+			if err := c.storage.LogAuditEvent(ctx, &models.AuditEvent{
+				EventType:   "secret.read",
+				Description: fmt.Sprintf("concurrent checkpoint racer %d", n),
+				Success:     &tr,
+				EventTime:   base.Add(time.Duration(n) * time.Millisecond),
+				ActorType:   "user",
+			}); err != nil {
+				errs <- fmt.Errorf("racer %d: log event: %w", n, err)
+				return
+			}
+			if _, written, err := c.WriteAuditCheckpoint(ctx); err != nil {
+				errs <- fmt.Errorf("racer %d: write checkpoint: %w", n, err)
+			} else if !written {
+				errs <- fmt.Errorf("racer %d: checkpoint unexpectedly not written", n)
+			}
+		}(i)
+	}
+	close(start) // release every racer at once
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		// A correctly serialized writer never sees a stale floor/prior-checkpoint
+		// view of its own making, so no racer should ever be refused here. Any
+		// error is either a genuine defect or (pre-fix) the race itself surfacing
+		// as a spurious "below high-water mark" refusal instead of silently
+		// committing an out-of-order chain — both are failures of the invariant
+		// this test protects.
+		assert.NoError(t, err)
+	}
+
+	// The chain-of-record invariant #300 is about: read every checkpoint back in
+	// ascending id (= commit) order and assert ChainedEvents never decreases. A
+	// decrease means a later-committed (higher id) checkpoint certified fewer
+	// events than an earlier one — exactly the out-of-order-chain defect.
+	var cps []models.AuditCheckpoint
+	require.NoError(t, db.Order("id ASC").Find(&cps).Error)
+	require.Len(t, cps, writers, "every racer must have committed exactly one checkpoint")
+	for i := 1; i < len(cps); i++ {
+		assert.GreaterOrEqualf(t, cps[i].ChainedEvents, cps[i-1].ChainedEvents,
+			"checkpoint #%d (committed after #%d) certifies %d events, fewer than #%d's %d — out-of-order chain",
+			cps[i].ID, cps[i-1].ID, cps[i].ChainedEvents, cps[i-1].ID, cps[i-1].ChainedEvents)
+	}
+
+	// Sanity: the final checkpoint certifies the full grown chain (baseline + every
+	// racer's event), and the live chain still verifies clean and checkpointed.
+	assert.Equal(t, int64(3+writers), cps[len(cps)-1].ChainedEvents)
+	v, err := c.VerifyAuditChain(context.Background())
+	require.NoError(t, err)
+	assert.True(t, v.Valid)
+	assert.True(t, v.Checkpointed)
+	assert.Empty(t, v.CheckpointReason)
+}

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -19,6 +19,11 @@ func (m *MockStorage) WithSchedulerLock(_ context.Context, _ int64, fn func() er
 	return true, fn()
 }
 
+// WithAuditCheckpointLock runs fn directly in tests (single instance, no DB lock).
+func (m *MockStorage) WithAuditCheckpointLock(_ context.Context, fn func() error) error {
+	return fn()
+}
+
 // WithTransaction runs fn directly against the mock (no real transaction in tests).
 func (m *MockStorage) WithTransaction(_ context.Context, fn func(storage.Storage) error) error {
 	return fn(m)

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -24,6 +24,17 @@ type Storage interface {
 	// when another replica holds the lock — the caller should simply skip this tick.
 	WithSchedulerLock(ctx context.Context, key int64, fn func() error) (ran bool, err error)
 
+	// WithAuditCheckpointLock serializes the audit-checkpoint chain-walk + decide +
+	// create-checkpoint sequence (ADR-029) across every trigger — the scheduler tick,
+	// the HTTP POST /api/v1/audit/checkpoint endpoint, and the gRPC
+	// WriteAuditCheckpoint RPC — even when they land on different replicas (ADR-039
+	// HA). Unlike WithSchedulerLock, this BLOCKS until the lock is free rather than
+	// skipping on contention: every caller must actually run its checkpoint decision
+	// against a consistent, serialized view, not silently no-op (#300). On PostgreSQL
+	// it holds a session advisory lock (pg_advisory_lock) for the duration of fn; on
+	// SQLite (single instance, no cross-process concern) a process mutex is enough.
+	WithAuditCheckpointLock(ctx context.Context, fn func() error) error
+
 	// WithTransaction runs fn inside a single storage transaction: every mutation fn
 	// performs through the provided Storage commits together, or rolls back together if
 	// fn returns an error. The backing store decides the semantics — the local (DB)

--- a/internal/storage/store/entry.go
+++ b/internal/storage/store/entry.go
@@ -80,9 +80,15 @@ type LocalStorage struct {
 	// SAME mutex as its parent — otherwise an audit append inside a transaction would
 	// not serialize against concurrent appends on the base store.
 	auditChainMu *sync.Mutex
+	// auditCheckpointMu serializes WriteAuditCheckpoint's chain-walk + decide +
+	// create-checkpoint sequence within this process (ADR-029/#300). The PostgreSQL
+	// advisory lock in WithAuditCheckpointLock extends this across processes/replicas
+	// (ADR-039 HA). A pointer for the same reason as auditChainMu — a transaction-scoped
+	// LocalStorage must share its parent's mutex.
+	auditCheckpointMu *sync.Mutex
 }
 
 // NewLocalStorage creates a LocalStorage backed by the given *gorm.DB.
 func NewLocalStorage(db *gorm.DB) *LocalStorage {
-	return &LocalStorage{db: db, auditChainMu: &sync.Mutex{}}
+	return &LocalStorage{db: db, auditChainMu: &sync.Mutex{}, auditCheckpointMu: &sync.Mutex{}}
 }

--- a/internal/storage/store/local_audit_checkpoint_lock.go
+++ b/internal/storage/store/local_audit_checkpoint_lock.go
@@ -1,0 +1,62 @@
+// local_audit_checkpoint_lock.go — serializes the audit-checkpoint write path
+// (ADR-029) across every trigger and replica.
+//
+// WriteAuditCheckpoint's chain-walk + decide + create-checkpoint sequence is
+// reachable from three unsynchronized triggers: the background scheduler tick,
+// an operator's POST /api/v1/audit/checkpoint call, and the gRPC
+// WriteAuditCheckpoint RPC. With no lock, two overlapping calls — including two
+// landing on different replicas under ADR-039 HA — can interleave and commit a
+// checkpoint out of chain-length order: the row with the higher DB id can end
+// up certifying FEWER chained events than an earlier-committed row, silently
+// reopening the truncation-detection gap ADR-029 exists to close (#300).
+package store
+
+import (
+	"context"
+	"fmt"
+)
+
+// auditCheckpointAdvisoryLockKey is the Postgres advisory-lock key guarding
+// WriteAuditCheckpoint's chain-walk + decide + create sequence across processes.
+// Distinct from auditAdvisoryLockKey (local_audit_chain.go), which guards
+// per-event chain appends — the two critical sections are independent and must
+// not contend with each other.
+const auditCheckpointAdvisoryLockKey = 0x4B455941_43484B50 // "KEYACHKP"
+
+// WithAuditCheckpointLock runs fn with the audit-checkpoint write path
+// serialized: a process-level mutex covers the common single-writer self-host
+// topology and SQLite (inherently single-instance — there is no DB-level
+// advisory lock to take); a PostgreSQL session-scoped advisory lock
+// (pg_advisory_lock) extends that across processes/replicas (ADR-039 HA).
+//
+// Unlike WithSchedulerLock, this BLOCKS until the lock is acquired rather than
+// skipping on contention — the scheduler, HTTP, and gRPC triggers must each
+// actually run their checkpoint decision against state left by the previous
+// writer, not silently no-op, or an operator-triggered write racing the
+// scheduler would just be dropped instead of serialized.
+func (ls *LocalStorage) WithAuditCheckpointLock(ctx context.Context, fn func() error) error {
+	ls.auditCheckpointMu.Lock()
+	defer ls.auditCheckpointMu.Unlock()
+
+	if ls.db.Dialector.Name() != "postgres" {
+		return fn()
+	}
+
+	sqlDB, err := ls.db.DB()
+	if err != nil {
+		return err
+	}
+	conn, err := sqlDB.Conn(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = conn.Close() }() // returns the conn to the pool (after the unlock below)
+
+	if _, err := conn.ExecContext(ctx, "SELECT pg_advisory_lock($1)", int64(auditCheckpointAdvisoryLockKey)); err != nil {
+		return fmt.Errorf("failed to acquire audit-checkpoint advisory lock: %w", err)
+	}
+	// Release before the deferred Close so the pooled connection carries no lock.
+	defer func() { _, _ = conn.ExecContext(ctx, "SELECT pg_advisory_unlock($1)", int64(auditCheckpointAdvisoryLockKey)) }()
+
+	return fn()
+}

--- a/internal/storage/store/local_transaction.go
+++ b/internal/storage/store/local_transaction.go
@@ -11,10 +11,11 @@ import (
 // WithTransaction runs fn inside a single GORM transaction. fn receives a
 // transaction-scoped LocalStorage: every mutation it makes is committed together when
 // fn returns nil, and rolled back together if fn returns an error (or panics). The
-// transaction-scoped store shares the parent's audit-chain mutex so an audit append
-// inside the transaction still serializes correctly (ADR-029).
+// transaction-scoped store shares the parent's audit-chain and audit-checkpoint mutexes
+// so an audit append or checkpoint write inside the transaction still serializes
+// correctly (ADR-029).
 func (ls *LocalStorage) WithTransaction(ctx context.Context, fn func(storage.Storage) error) error {
 	return ls.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		return fn(&LocalStorage{db: tx, auditChainMu: ls.auditChainMu})
+		return fn(&LocalStorage{db: tx, auditChainMu: ls.auditChainMu, auditCheckpointMu: ls.auditCheckpointMu})
 	})
 }

--- a/internal/storage/store/remote_audit_checkpoint_lock.go
+++ b/internal/storage/store/remote_audit_checkpoint_lock.go
@@ -1,0 +1,14 @@
+package store
+
+import "context"
+
+// WithAuditCheckpointLock is server-side only — WriteAuditCheckpoint (and its
+// three triggers: scheduler, HTTP, gRPC) always runs against LocalStorage inside
+// the server process; the CLI's `keyorix audit checkpoint` goes through the HTTP
+// endpoint rather than calling the core method directly against RemoteStorage. A
+// remote caller reaching this would get no real cross-process guarantee anyway
+// (there is no shared advisory lock to take over HTTP), so this fails closed
+// rather than silently running fn unserialized.
+func (rs *RemoteStorage) WithAuditCheckpointLock(_ context.Context, _ func() error) error {
+	return remoteUnsupported("WithAuditCheckpointLock")
+}


### PR DESCRIPTION
## Summary
- `WriteAuditCheckpoint` (ADR-029) had no transaction, row lock, or advisory lock guarding its chain-walk + decide + create-checkpoint sequence, and is reachable from three unsynchronized triggers: the scheduler tick, the HTTP `POST /api/v1/audit/checkpoint` endpoint, and the gRPC `WriteAuditCheckpoint` RPC.
- Two overlapping calls — including two landing on different replicas under HA — could interleave and commit a checkpoint out of chain-length order: the row with the higher DB `id` could end up certifying FEWER chained events than an earlier-committed row, so `LatestAuditCheckpoint`'s `id DESC` pick would silently miss coverage of events that landed in the interleaving window. That reopens the tail-truncation-detection gap ADR-029 exists to close, even with a fully-intact, validly-signed checkpoint chain.
- Fix: added `storage.WithAuditCheckpointLock`, mirroring the existing per-event chain-append serialization (`LogAuditEvent`'s `auditChainMu` + `pg_advisory_xact_lock` pattern) — a process-level mutex for the common single-writer/SQLite topology, extended across processes/replicas on PostgreSQL with a blocking session advisory lock (distinct key from the per-append lock). Unlike the scheduler's own `WithSchedulerLock` (a "try" lock that skips on contention), this blocks until free, so an operator-triggered write racing the scheduler is serialized, not silently dropped. `WriteAuditCheckpoint`'s whole read-decide-write sequence now runs under this lock.

## Test plan
- [x] New concurrency regression test (`TestConcurrency_AuditCheckpoint_NoOutOfOrderChain`, `-race`) drives many goroutines each appending an audit event and racing to checkpoint it, then asserts checkpoints read back in ascending `id` order never regress in `chained_events`. Verified it reliably reproduces the out-of-order commit (5/5 runs) when the lock is temporarily removed, and passes reliably (5/5) with the fix.
- [x] `go build ./...` clean
- [x] `go test ./...` clean (full suite, including `internal/audit/siem`)
- [x] `go test ./internal/core/... ./internal/storage/store/... -race` clean
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues
- [x] `golangci-lint run ./...` — 0 issues
- [x] `GOWORK=off go build -C operator ./...` clean

Note: `go test ./server/http/... -race` occasionally flakes on `TestSharingHTTPConcurrency` (a pre-existing, unrelated data race in `server/validation.Validator` shared across concurrent `ShareSecret` requests) — confirmed unrelated to this diff (none of the changed files touch sharing/validation code) and reproduces identically on `main`.