### PR TITLE
harden: service-account credential hash-at-rest + lifecycle audit trail (#278/#279)

### DIFF
--- a/internal/core/audit.go
+++ b/internal/core/audit.go
@@ -32,6 +32,18 @@ const (
 	EventGroupMemberRemoved = "group.member_removed"
 )
 
+// Service-account lifecycle event types (#279). A service account is an identity/
+// credential object, not an RBAC grant, so these are NOT part of rbacAuditEventTypes —
+// they land in the general audit log (surfaced by GetActivityFeed / GetAuditLogs),
+// the same family as setup_token.*/machine_identity.* events.
+const (
+	EventServiceAccountCreated = "service_account.created"
+	EventServiceAccountUpdated = "service_account.updated"
+	EventServiceAccountRevoked = "service_account.revoked"
+	EventServiceTokenCreated   = "service_token.created" // #nosec G101 -- audit event type, not a credential
+	EventServiceTokenRevoked   = "service_token.revoked" // #nosec G101 -- audit event type, not a credential
+)
+
 // rbacAuditEventTypes is the set of event types that make up the RBAC audit log.
 var rbacAuditEventTypes = []string{
 	EventRoleAssigned, EventRoleRemoved, EventRoleExpired,
@@ -150,6 +162,55 @@ func (c *KeyorixCore) LogRoleDeleted(ctx context.Context, actorID, roleID uint, 
 func (c *KeyorixCore) logRoleDefinitionChange(ctx context.Context, eventType, verb string, actorID, roleID uint, name string) {
 	desc := fmt.Sprintf("role %q (id %d) %s", name, roleID, verb)
 	c.writeRBACAudit(ctx, eventType, desc, actorID, Scope{}, rbacAuditDetail{RoleID: roleID})
+}
+
+// LogServiceAccountCreated / LogServiceAccountUpdated / LogServiceAccountRevoked
+// record a change to a service-account DEFINITION (create/update/revoke) — same
+// silent-audit-gap family as #233/#234, closed here for service accounts (#279).
+// actorID is the admin who made the change (0 = no authenticated principal, e.g. a
+// local CLI invocation).
+func (c *KeyorixCore) LogServiceAccountCreated(ctx context.Context, actorID uint, clientID, name string) {
+	c.logServiceAccountChange(ctx, EventServiceAccountCreated, "created", actorID, clientID, name)
+}
+
+func (c *KeyorixCore) LogServiceAccountUpdated(ctx context.Context, actorID uint, clientID, name string) {
+	c.logServiceAccountChange(ctx, EventServiceAccountUpdated, "updated", actorID, clientID, name)
+}
+
+func (c *KeyorixCore) LogServiceAccountRevoked(ctx context.Context, actorID uint, clientID, name string) {
+	c.logServiceAccountChange(ctx, EventServiceAccountRevoked, "revoked", actorID, clientID, name)
+}
+
+func (c *KeyorixCore) logServiceAccountChange(ctx context.Context, eventType, verb string, actorID uint, clientID, name string) {
+	desc := fmt.Sprintf("service account %q (%s) %s", name, clientID, verb)
+	var actor *uint
+	if actorID != 0 {
+		a := actorID
+		actor = &a
+	}
+	c.writeAuditEventFull(ctx, eventType, actor, nil, nil, "", desc)
+}
+
+// LogServiceTokenCreated / LogServiceTokenRevoked record a create/revoke change to an
+// API token issued under a service account (#279). clientID is the owning service
+// account's numeric row id (APIClient.ID), available at both call sites without an
+// extra lookup. See LogServiceAccountCreated for actorID semantics.
+func (c *KeyorixCore) LogServiceTokenCreated(ctx context.Context, actorID, tokenID, clientID uint) {
+	c.logServiceTokenChange(ctx, EventServiceTokenCreated, "created", actorID, tokenID, clientID)
+}
+
+func (c *KeyorixCore) LogServiceTokenRevoked(ctx context.Context, actorID, tokenID, clientID uint) {
+	c.logServiceTokenChange(ctx, EventServiceTokenRevoked, "revoked", actorID, tokenID, clientID)
+}
+
+func (c *KeyorixCore) logServiceTokenChange(ctx context.Context, eventType, verb string, actorID, tokenID, clientID uint) {
+	desc := fmt.Sprintf("API token %d for service account %d %s", tokenID, clientID, verb)
+	var actor *uint
+	if actorID != 0 {
+		a := actorID
+		actor = &a
+	}
+	c.writeAuditEventFull(ctx, eventType, actor, nil, nil, "", desc)
 }
 
 // writeRBACAudit is the shared writer for RBAC audit events: actor as UserID,

--- a/internal/core/service_accounts.go
+++ b/internal/core/service_accounts.go
@@ -10,6 +10,27 @@
 //	GET    /{clientId}/tokens           — List tokens for a service account
 //	POST   /{clientId}/tokens           — Create token (returns plain token once)
 //	DELETE /{clientId}/tokens/{tokenId} — Revoke token
+//
+// Credential storage (#278): CreateServiceAccount/CreateServiceToken persist only the
+// SHA-256 hash of the client secret/token (models.APIClient.ClientSecret /
+// models.APIToken.Token), never the plaintext, matching PAT/session/machine-token
+// handling — a DB-only read (backup, replica, injection, insider) yields no usable
+// credential. This column was reused in place rather than routed through
+// AuthEncryption's reversible Encrypted* columns (those are legacy/unused for this
+// model): a one-way hash is strictly stronger, since it stays safe even against an
+// attacker who also holds the DEK. Caveat for deployments that upgraded across this
+// fix: a row's ClientSecret/Token column has always been a 64-hex-char value (the
+// stored secret pre-fix, its hash post-fix) with no schema-level marker distinguishing
+// the two, so a stored value cannot be programmatically classified as "still
+// plaintext" after the fact — hashing an unknown-provenance value risks silently
+// double-hashing an already-safe row. Deployments upgrading from a pre-fix build
+// should revoke and reissue every service-account credential created before the
+// upgrade (compare APIClient.CreatedAt/APIToken.CreatedAt against the upgrade
+// timestamp) rather than rely on an automated in-place migration.
+//
+// Audit trail (#279): every lifecycle transition below (account create/update/revoke,
+// token create/revoke) calls the matching LogServiceAccount*/LogServiceToken*
+// helper (audit.go) so it surfaces in the general audit log.
 package core
 
 import (
@@ -56,8 +77,10 @@ type CreateServiceTokenResult struct {
 }
 
 // CreateServiceAccount generates a new service account with a random client ID and secret.
-// The plain secret is returned only in the result and never stored retrievably.
-func (c *KeyorixCore) CreateServiceAccount(ctx context.Context, req *CreateServiceAccountRequest) (*CreateServiceAccountResult, error) {
+// The plain secret is returned only in the result and never stored retrievably. actorID
+// is the admin creating the account (0 = no authenticated principal, e.g. local CLI);
+// the creation is audited (#279).
+func (c *KeyorixCore) CreateServiceAccount(ctx context.Context, actorID uint, req *CreateServiceAccountRequest) (*CreateServiceAccountResult, error) {
 	clientID, err := generateClientID()
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate client ID: %w", err)
@@ -83,6 +106,7 @@ func (c *KeyorixCore) CreateServiceAccount(ctx context.Context, req *CreateServi
 	if err != nil {
 		return nil, fmt.Errorf("failed to create service account: %w", err)
 	}
+	c.LogServiceAccountCreated(ctx, actorID, created.ClientID, created.Name)
 	return &CreateServiceAccountResult{APIClient: created, PlainClientSecret: secret}, nil
 }
 
@@ -104,8 +128,9 @@ func (c *KeyorixCore) ListServiceAccounts(ctx context.Context) ([]*models.APICli
 	return clients, nil
 }
 
-// UpdateServiceAccount applies name/description/scopes/is_active changes to a service account.
-func (c *KeyorixCore) UpdateServiceAccount(ctx context.Context, clientID string, req *UpdateServiceAccountRequest) (*models.APIClient, error) {
+// UpdateServiceAccount applies name/description/scopes/is_active changes to a service
+// account. actorID is the admin making the change; the update is audited (#279).
+func (c *KeyorixCore) UpdateServiceAccount(ctx context.Context, actorID uint, clientID string, req *UpdateServiceAccountRequest) (*models.APIClient, error) {
 	client, err := c.storage.GetAPIClient(ctx, clientID)
 	if err != nil {
 		return nil, fmt.Errorf("service account not found")
@@ -120,23 +145,28 @@ func (c *KeyorixCore) UpdateServiceAccount(ctx context.Context, clientID string,
 	if err != nil {
 		return nil, fmt.Errorf("failed to update service account: %w", err)
 	}
+	c.LogServiceAccountUpdated(ctx, actorID, updated.ClientID, updated.Name)
 	return updated, nil
 }
 
-// RevokeServiceAccount marks the service account as inactive (soft revoke).
-func (c *KeyorixCore) RevokeServiceAccount(ctx context.Context, clientID string) error {
-	if _, err := c.storage.GetAPIClient(ctx, clientID); err != nil {
+// RevokeServiceAccount marks the service account as inactive (soft revoke). actorID is
+// the admin revoking the account; the revocation is audited (#279).
+func (c *KeyorixCore) RevokeServiceAccount(ctx context.Context, actorID uint, clientID string) error {
+	client, err := c.storage.GetAPIClient(ctx, clientID)
+	if err != nil {
 		return fmt.Errorf("service account not found")
 	}
 	if err := c.storage.RevokeAPIClient(ctx, clientID); err != nil {
 		return fmt.Errorf("failed to revoke service account: %w", err)
 	}
+	c.LogServiceAccountRevoked(ctx, actorID, client.ClientID, client.Name)
 	return nil
 }
 
 // CreateServiceToken generates a new API token for the given service account.
-// The plain token is returned only in the result and never stored retrievably.
-func (c *KeyorixCore) CreateServiceToken(ctx context.Context, clientID string, req *CreateServiceTokenRequest) (*CreateServiceTokenResult, error) {
+// The plain token is returned only in the result and never stored retrievably. actorID
+// is the admin creating the token; the creation is audited (#279).
+func (c *KeyorixCore) CreateServiceToken(ctx context.Context, actorID uint, clientID string, req *CreateServiceTokenRequest) (*CreateServiceTokenResult, error) {
 	client, err := c.storage.GetAPIClient(ctx, clientID)
 	if err != nil {
 		return nil, fmt.Errorf("service account not found")
@@ -165,6 +195,7 @@ func (c *KeyorixCore) CreateServiceToken(ctx context.Context, clientID string, r
 	if err != nil {
 		return nil, fmt.Errorf("failed to create API token: %w", err)
 	}
+	c.LogServiceTokenCreated(ctx, actorID, created.ID, client.ID)
 	return &CreateServiceTokenResult{APIToken: created, PlainToken: plainToken}, nil
 }
 
@@ -190,14 +221,17 @@ func (c *KeyorixCore) ListServiceTokens(ctx context.Context, clientID string) ([
 	return tokens, nil
 }
 
-// RevokeServiceToken marks an API token as revoked.
-func (c *KeyorixCore) RevokeServiceToken(ctx context.Context, id uint) error {
-	if _, err := c.storage.GetAPIToken(ctx, id); err != nil {
+// RevokeServiceToken marks an API token as revoked. actorID is the admin revoking the
+// token; the revocation is audited (#279).
+func (c *KeyorixCore) RevokeServiceToken(ctx context.Context, actorID, id uint) error {
+	tok, err := c.storage.GetAPIToken(ctx, id)
+	if err != nil {
 		return fmt.Errorf("token not found")
 	}
 	if err := c.storage.RevokeAPIToken(ctx, id); err != nil {
 		return fmt.Errorf("failed to revoke token: %w", err)
 	}
+	c.LogServiceTokenRevoked(ctx, actorID, tok.ID, tok.ClientID)
 	return nil
 }
 

--- a/internal/core/service_accounts_external_test.go
+++ b/internal/core/service_accounts_external_test.go
@@ -24,10 +24,10 @@ func sha256Hex(s string) string {
 func TestServiceAccount_CredentialsHashedAtRest(t *testing.T) {
 	h := testhelper.NewRBACTestHelper(t)
 	t.Cleanup(h.Cleanup)
-	require.NoError(t, h.DB.AutoMigrate(&models.APIClient{}, &models.APIToken{}))
+	require.NoError(t, h.DB.AutoMigrate(&models.APIClient{}, &models.APIToken{}, &models.AuditEvent{}))
 	ctx := context.Background()
 
-	acct, err := h.CoreService.CreateServiceAccount(ctx, &core.CreateServiceAccountRequest{Name: "ci-bot"})
+	acct, err := h.CoreService.CreateServiceAccount(ctx, 1, &core.CreateServiceAccountRequest{Name: "ci-bot"})
 	require.NoError(t, err)
 	require.NotEmpty(t, acct.PlainClientSecret, "the plaintext secret is returned once")
 
@@ -37,7 +37,7 @@ func TestServiceAccount_CredentialsHashedAtRest(t *testing.T) {
 	assert.Equal(t, sha256Hex(acct.PlainClientSecret), storedClient.ClientSecret, "the stored secret is its SHA-256 hash")
 	assert.Empty(t, storedClient.EncryptedClientSecret, "no half-encrypted column left behind")
 
-	tok, err := h.CoreService.CreateServiceToken(ctx, acct.ClientID, &core.CreateServiceTokenRequest{Scope: "read"})
+	tok, err := h.CoreService.CreateServiceToken(ctx, 1, acct.ClientID, &core.CreateServiceTokenRequest{Scope: "read"})
 	require.NoError(t, err)
 	require.NotEmpty(t, tok.PlainToken)
 
@@ -45,4 +45,68 @@ func TestServiceAccount_CredentialsHashedAtRest(t *testing.T) {
 	require.NoError(t, h.DB.First(&storedTok, "id = ?", tok.APIToken.ID).Error)
 	assert.NotEqual(t, tok.PlainToken, storedTok.Token, "plaintext token must not be stored")
 	assert.Equal(t, sha256Hex(tok.PlainToken), storedTok.Token, "the stored token is its SHA-256 hash")
+}
+
+// Every service-account/token lifecycle transition (create/update/revoke,
+// token create/revoke) must produce an audit record — same silent-audit-gap family as
+// #233/#234 (#279).
+func TestServiceAccount_LifecycleEventsAudited(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	t.Cleanup(h.Cleanup)
+	require.NoError(t, h.DB.AutoMigrate(&models.APIClient{}, &models.APIToken{}, &models.AuditEvent{}))
+	ctx := context.Background()
+	const actorID = uint(7)
+
+	acct, err := h.CoreService.CreateServiceAccount(ctx, actorID, &core.CreateServiceAccountRequest{Name: "ci-bot"})
+	require.NoError(t, err)
+
+	_, err = h.CoreService.UpdateServiceAccount(ctx, actorID, acct.ClientID, &core.UpdateServiceAccountRequest{
+		Name:     "ci-bot-renamed",
+		IsActive: true,
+	})
+	require.NoError(t, err)
+
+	tok, err := h.CoreService.CreateServiceToken(ctx, actorID, acct.ClientID, &core.CreateServiceTokenRequest{Scope: "read"})
+	require.NoError(t, err)
+
+	require.NoError(t, h.CoreService.RevokeServiceToken(ctx, actorID, tok.APIToken.ID))
+	require.NoError(t, h.CoreService.RevokeServiceAccount(ctx, actorID, acct.ClientID))
+
+	var events []models.AuditEvent
+	require.NoError(t, h.DB.Order("id asc").Find(&events).Error)
+
+	byType := map[string]models.AuditEvent{}
+	for _, e := range events {
+		byType[e.EventType] = e
+	}
+
+	for _, wantType := range []string{
+		"service_account.created",
+		"service_account.updated",
+		"service_account.revoked",
+		"service_token.created",
+		"service_token.revoked",
+	} {
+		e, ok := byType[wantType]
+		require.True(t, ok, "expected an audit event of type %s", wantType)
+		require.NotNil(t, e.UserID, "expected an actor recorded on the %s event", wantType)
+		assert.Equal(t, actorID, *e.UserID)
+	}
+}
+
+// A change made without an authenticated principal (actorID 0, e.g. a local CLI
+// invocation) records no actor on the audit row — same convention as the RBAC audit
+// trail (see TestRBACAuditTrail_SystemActor).
+func TestServiceAccount_LifecycleAuditSystemActor(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	t.Cleanup(h.Cleanup)
+	require.NoError(t, h.DB.AutoMigrate(&models.APIClient{}, &models.APIToken{}, &models.AuditEvent{}))
+	ctx := context.Background()
+
+	_, err := h.CoreService.CreateServiceAccount(ctx, 0, &core.CreateServiceAccountRequest{Name: "cli-bot"})
+	require.NoError(t, err)
+
+	var event models.AuditEvent
+	require.NoError(t, h.DB.Where("event_type = ?", "service_account.created").First(&event).Error)
+	assert.Nil(t, event.UserID, "system/CLI actor should be unset")
 }

--- a/server/http/handlers/service_accounts_handler.go
+++ b/server/http/handlers/service_accounts_handler.go
@@ -151,7 +151,7 @@ func (h *ServiceAccountHandler) CreateServiceAccount(w http.ResponseWriter, r *h
 		return
 	}
 
-	result, err := h.coreService.CreateServiceAccount(r.Context(), &core.CreateServiceAccountRequest{
+	result, err := h.coreService.CreateServiceAccount(r.Context(), userCtx.UserID, &core.CreateServiceAccountRequest{
 		Name:        reqBody.Name,
 		Description: reqBody.Description,
 		Scopes:      reqBody.Scopes,
@@ -233,7 +233,7 @@ func (h *ServiceAccountHandler) UpdateServiceAccount(w http.ResponseWriter, r *h
 		return
 	}
 
-	client, err := h.coreService.UpdateServiceAccount(r.Context(), clientID, &core.UpdateServiceAccountRequest{
+	client, err := h.coreService.UpdateServiceAccount(r.Context(), userCtx.UserID, clientID, &core.UpdateServiceAccountRequest{
 		Name:        reqBody.Name,
 		Description: reqBody.Description,
 		Scopes:      reqBody.Scopes,
@@ -269,7 +269,7 @@ func (h *ServiceAccountHandler) DeactivateServiceAccount(w http.ResponseWriter, 
 	}
 
 	clientID := chi.URLParam(r, "clientId")
-	if err := h.coreService.RevokeServiceAccount(r.Context(), clientID); err != nil {
+	if err := h.coreService.RevokeServiceAccount(r.Context(), userCtx.UserID, clientID); err != nil {
 		if strings.Contains(err.Error(), "not found") {
 			h.sendError(w, "NotFound", "Service account not found", http.StatusNotFound, nil)
 		} else {
@@ -338,7 +338,7 @@ func (h *ServiceAccountHandler) CreateToken(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	result, err := h.coreService.CreateServiceToken(r.Context(), clientID, &core.CreateServiceTokenRequest{
+	result, err := h.coreService.CreateServiceToken(r.Context(), userCtx.UserID, clientID, &core.CreateServiceTokenRequest{
 		Scope:     reqBody.Scope,
 		ExpiresAt: reqBody.ExpiresAt,
 	})
@@ -384,7 +384,7 @@ func (h *ServiceAccountHandler) RevokeToken(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	if err := h.coreService.RevokeServiceToken(r.Context(), uint(tokenID)); err != nil {
+	if err := h.coreService.RevokeServiceToken(r.Context(), userCtx.UserID, uint(tokenID)); err != nil {
 		if strings.Contains(err.Error(), "not found") {
 			h.sendError(w, "NotFound", "Token not found", http.StatusNotFound, nil)
 		} else {


### PR DESCRIPTION
## Summary

- **#278 MEDIUM (already resolved on `main`, verified/documented — no code fix needed here)**: re-checked against current `main` and found `CreateServiceAccount`/`CreateServiceToken` (`internal/core/service_accounts.go`) no longer persist the client secret/API token in plaintext — PR #516 already switched both to store only the SHA-256 hash (`ClientSecret`/`Token` columns), matching PAT/session/machine-token handling. This is a stronger fix than the routed-encryption approach the finding originally recommended: a one-way hash stays safe even against an attacker who also holds the DEK, whereas the `AuthEncryption` `Encrypted*` columns are reversible and are now legacy/unused for this model. Documented this in a file-level comment, along with the residual caveat for deployments that upgraded across the fix: a stored `ClientSecret`/`Token` value has always been a 64-hex-char string in this schema (the plaintext pre-fix, its hash post-fix), so a row's provenance can't be classified after the fact — the safe remediation for any pre-upgrade rows is revoke-and-reissue (compare `CreatedAt` against the upgrade timestamp), not an automated in-place re-hash (which risks silently double-hashing an already-safe row).
- **#279 LOW (fixed)**: service-account/token lifecycle events (create/update/revoke) produced zero audit records — same silent-audit-gap family as #233/#234. Added `LogServiceAccountCreated/Updated/Revoked` and `LogServiceTokenCreated/Revoked` (`internal/core/audit.go`), mirroring the existing `LogRoleCreated/Updated/Deleted` convention, and wired them into every mutating core method (`internal/core/service_accounts.go`) and its HTTP handler call site (`server/http/handlers/service_accounts_handler.go`), threading the caller's `actorID` through.

## Test plan

- [x] New regression tests: `TestServiceAccount_LifecycleEventsAudited` (every lifecycle transition produces the expected audit event with the correct actor) and `TestServiceAccount_LifecycleAuditSystemActor` (actorID 0 records no actor, matching the RBAC audit convention)
- [x] Existing `TestServiceAccount_CredentialsHashedAtRest` still passes, confirming #278's hash-at-rest fix holds
- [x] `go build ./...` clean
- [x] `go test ./...` clean, excluding two **pre-existing, unrelated** failures confirmed present on a clean `origin/main` checkout (not touched by this diff):
  - `TestHTTPJWKSResolver_CapsKeyCount` — local network/httptest flake
  - `TestReconcileRBAC_AddsNewPermissionToBaselineRoles` / `_Idempotent` / `_GrantsAreRBACAudited` — a real regression from PR #557 (#169 CRITICAL fix): `ReconcileRBACPermissions` calls `AssignPermissionToRole(ctx, 0, ...)` for system/CLI-driven catalog reconciliation, but #557's new actor-authority check (`Authorize(ctx, actorID, perm.Name, Scope{})`) can never pass for actor 0 (no `user_roles` rows), so newly-added permissions silently stop propagating to baseline roles on upgrade. Worth filing/fixing separately — flagging here since it surfaced during this PR's full-suite run.
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues
- [x] `golangci-lint run ./...` — 0 issues
- [x] `GOWORK=off go build -C operator ./...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)