### PR TITLE
fix(dynamic-secrets): stop stamping RevokedAt on a failed lease revoke (#323)

### DIFF
--- a/internal/core/dynamic_secrets.go
+++ b/internal/core/dynamic_secrets.go
@@ -289,7 +289,11 @@ func (c *KeyorixCore) RevokeLease(ctx context.Context, leaseID string, userID ui
 	if rerr := engine.Revoke(ctx, adminDSN, lease.RoleName); rerr != nil {
 		lease.Status = "revoke_failed"
 		lease.RevokeError = rerr.Error()
-		lease.RevokedAt = &now
+		// Deliberately NOT stamping RevokedAt here: the target drop failed, so the
+		// credential is still live. Stamping it would make the audit trail / API
+		// falsely claim the role was dropped at this time, even though it wasn't —
+		// and it wasn't dropped at all yet, so there is no "revoked at" moment to
+		// record. RevokedAt is set only on the success path below.
 		_ = c.storage.UpdateDynamicSecretLease(ctx, lease)
 		c.writeAuditEventFull(ctx, "dynamic_lease.revoke_failed", uidPtr, nil, &pid, "",
 			fmt.Sprintf("FAILED to revoke dynamic lease %s (role %s): %v", lease.LeaseID, lease.RoleName, rerr))

--- a/internal/core/dynamic_secrets_test.go
+++ b/internal/core/dynamic_secrets_test.go
@@ -171,7 +171,45 @@ func TestDynamicSecrets_RevokeFailureMarksLease(t *testing.T) {
 	after, _ := c.storage.GetDynamicSecretLease(ctx, issued.LeaseID)
 	assert.Equal(t, "revoke_failed", after.Status, "the lease is flagged for an operator")
 	assert.NotEmpty(t, after.RevokeError)
-	assert.NotNil(t, after.RevokedAt)
+	// RevokedAt must NOT be stamped on a failed attempt: the target drop failed, so the
+	// credential is still live. Stamping it would make the audit trail falsely claim the
+	// role was dropped at this time.
+	assert.Nil(t, after.RevokedAt, "a failed revoke must not be timestamped as revoked")
+
+	// A second attempt that also fails must leave the lease in revoke_failed, not
+	// silently mark it revoked — and still without a RevokedAt timestamp.
+	err = c.RevokeLease(ctx, issued.LeaseID, 7, "retry")
+	require.Error(t, err, "the retry is attempted, not refused, but still fails on target")
+	stillFailed, _ := c.storage.GetDynamicSecretLease(ctx, issued.LeaseID)
+	assert.Equal(t, "revoke_failed", stillFailed.Status, "a second failed attempt stays revoke_failed")
+	assert.Nil(t, stillFailed.RevokedAt)
+}
+
+// A lease stuck in revoke_failed (its credential still live from an earlier failed
+// attempt) must be directly retryable via RevokeLease once the target recovers — not
+// just through the expiry sweep — and only THEN does RevokedAt get stamped.
+func TestDynamicSecrets_RevokeLeaseRetrySucceeds(t *testing.T) {
+	c, _, fake, _ := newDynamicTestCore(t)
+	ctx := context.Background()
+	cfg := mkConfig(t, c, ctx)
+
+	issued, err := c.IssueLease(ctx, cfg.ID, 0, 7)
+	require.NoError(t, err)
+
+	fake.FailRevoke = true
+	require.Error(t, c.RevokeLease(ctx, issued.LeaseID, 7, "manual"))
+	failed, _ := c.storage.GetDynamicSecretLease(ctx, issued.LeaseID)
+	require.Equal(t, "revoke_failed", failed.Status)
+	require.Nil(t, failed.RevokedAt)
+
+	// The target recovers; a direct retry (not the sweep) must be accepted and succeed.
+	fake.FailRevoke = false
+	require.NoError(t, c.RevokeLease(ctx, issued.LeaseID, 7, "retry"))
+
+	after, _ := c.storage.GetDynamicSecretLease(ctx, issued.LeaseID)
+	assert.Equal(t, "revoked", after.Status)
+	assert.NotNil(t, after.RevokedAt, "a genuinely successful revoke IS timestamped")
+	assert.Contains(t, fake.Revoked, issued.Username)
 }
 
 // A revoke_failed lease (its credential still live) must remain retryable — manually and
@@ -311,6 +349,74 @@ func TestDynamicSecrets_RevokeLeasesForConfig(t *testing.T) {
 	revoked2, _, err := c.RevokeLeasesForConfig(ctx, cfg.ID, 7, "incident")
 	require.NoError(t, err)
 	assert.Equal(t, 0, revoked2)
+}
+
+// The bulk incident-response kill switch is the last line of defense for
+// backends with no DB-level native expiry (MySQL/Mongo/Redis): the target
+// drop/dropUser/ACL-DELUSER call is the only enforcement mechanism. A lease already
+// stuck in revoke_failed (its credential still live from an earlier failed attempt)
+// must NOT be silently skipped — it must be retried right alongside the still-active
+// leases, so an operator responding to "this target/config is compromised" actually
+// kills every outstanding credential, not just the ones that happened to revoke
+// cleanly on the first try.
+func TestDynamicSecrets_RevokeLeasesForConfigRetriesRevokeFailed(t *testing.T) {
+	c, _, fake, _ := newDynamicTestCore(t)
+	ctx := context.Background()
+	cfg := mkConfig(t, c, ctx)
+
+	stuck, err := c.IssueLease(ctx, cfg.ID, 0, 7)
+	require.NoError(t, err)
+	stillActive, err := c.IssueLease(ctx, cfg.ID, 0, 7)
+	require.NoError(t, err)
+
+	// The first lease's revoke fails once (transient outage) and is left revoke_failed —
+	// its credential is still live on the target.
+	fake.FailRevoke = true
+	require.Error(t, c.RevokeLease(ctx, stuck.LeaseID, 7, "manual"))
+	before, _ := c.storage.GetDynamicSecretLease(ctx, stuck.LeaseID)
+	require.Equal(t, "revoke_failed", before.Status, "precondition: the lease is stuck")
+	require.Nil(t, before.RevokedAt, "precondition: not falsely timestamped as revoked")
+
+	// The target recovers, and an incident responder now believes the whole config is
+	// compromised and pulls the kill switch.
+	fake.FailRevoke = false
+	revoked, failed, err := c.RevokeLeasesForConfig(ctx, cfg.ID, 7, "incident: compromised target")
+	require.NoError(t, err)
+	assert.Equal(t, 0, failed)
+	assert.Equal(t, 2, revoked, "both the still-active lease AND the previously revoke_failed one must be revoked")
+
+	after, _ := c.storage.GetDynamicSecretLease(ctx, stuck.LeaseID)
+	assert.Equal(t, "revoked", after.Status, "the revoke_failed lease is NOT permanently stuck — the kill switch reaches it")
+	assert.NotNil(t, after.RevokedAt, "the now-successful revoke IS timestamped")
+	assert.Contains(t, fake.Revoked, stuck.Username, "the previously-stranded credential was actually dropped on the target")
+	assert.Contains(t, fake.Revoked, stillActive.Username)
+}
+
+// If the target is still down when the kill switch is pulled, a revoke_failed lease
+// must remain revoke_failed (not be silently marked revoked) and still carry no
+// RevokedAt timestamp — the bulk path must not paper over a persistent failure.
+func TestDynamicSecrets_RevokeLeasesForConfigReportsPersistentFailure(t *testing.T) {
+	c, _, fake, _ := newDynamicTestCore(t)
+	ctx := context.Background()
+	cfg := mkConfig(t, c, ctx)
+
+	stuck, err := c.IssueLease(ctx, cfg.ID, 0, 7)
+	require.NoError(t, err)
+
+	fake.FailRevoke = true
+	require.Error(t, c.RevokeLease(ctx, stuck.LeaseID, 7, "manual"))
+	before, _ := c.storage.GetDynamicSecretLease(ctx, stuck.LeaseID)
+	require.Equal(t, "revoke_failed", before.Status)
+
+	// Target is STILL down when the kill switch is pulled.
+	revoked, failed, err := c.RevokeLeasesForConfig(ctx, cfg.ID, 7, "incident: still down")
+	require.NoError(t, err, "RevokeLeasesForConfig itself never errors — failures are counted")
+	assert.Equal(t, 0, revoked)
+	assert.Equal(t, 1, failed)
+
+	after, _ := c.storage.GetDynamicSecretLease(ctx, stuck.LeaseID)
+	assert.Equal(t, "revoke_failed", after.Status, "still stuck, not silently marked revoked")
+	assert.Nil(t, after.RevokedAt, "not falsely timestamped as revoked")
 }
 
 func TestDynamicSecrets_RenewRejectsInactiveLease(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes the remaining part of backlog #323 HIGH: dynamic-secret lease revoke failures were falsely stamping `RevokedAt`, making the audit trail/API claim a credential was dropped when the target drop actually failed.

Re-verified against current `main` before starting: the primary fixes described in #323 — `RevokeLease` accepting a retry from `revoke_failed`, the bulk incident-response kill switch (`RevokeLeasesForConfig`) sweeping `revoke_failed` leases too, and the auto-revoke sweeper (`ListExpiredActiveLeases`) picking up `revoke_failed` leases past expiry — are **already present and documented on `main`**. Only the secondary correctness bug remained:

- `RevokeLease`'s failure branch set `lease.RevokedAt = &now` even though `engine.Revoke` had just failed and the credential is still live on the target. Now `RevokedAt` is only stamped on the genuinely successful revoke path.

Verified the four backend engines' `Revoke` calls (Postgres `DROP ROLE IF EXISTS`, MySQL `DROP USER IF EXISTS`, MongoDB `dropUser` treating "not found" as success, Redis `ACL DELUSER`) are all idempotent, so retrying a previously-failed revoke (via direct retry, the sweep, or the bulk kill switch) is safe and requires no special-casing.

## Test plan

- [x] New/updated regression tests in `internal/core/dynamic_secrets_test.go`:
  - a failed revoke leaves `RevokedAt` nil (and a second failed retry stays `revoke_failed` with `RevokedAt` still nil)
  - a `revoke_failed` lease is retryable directly via `RevokeLease` and succeeds once the target recovers, stamping `RevokedAt` only then
  - `RevokeLeasesForConfig` (the bulk kill switch) retries and clears a `revoke_failed` lease once the target recovers
  - `RevokeLeasesForConfig` correctly reports a lease as still-failed (not silently revoked) if the target is still down
- [x] `go build ./...` clean
- [x] `go test ./...` full suite clean
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues
- [x] `golangci-lint run ./...` — 0 issues
- [x] `GOWORK=off go build -C operator ./...` clean