### PR TITLE
fix(connect): close path-traversal gap in allowed_refs/ADR-045 prefix checks (#326)

### DIFF
--- a/internal/connect/connect.go
+++ b/internal/connect/connect.go
@@ -14,10 +14,38 @@ import (
 	"strings"
 )
 
+// RefHasDotSegment reports whether ref contains a "." or ".." path segment, e.g.
+// "secret/data/myapp/../otherapp/secret". strings.HasPrefix (used by prefixAllowed
+// below and core.refMatches for ADR-045 ref-grants) is a purely literal, start-only
+// string comparison: "secret/data/myapp/../otherapp/secret" satisfies
+// HasPrefix(ref, "secret/data/myapp/") even though a downstream HTTP layer (Vault's
+// own API, an intermediating proxy, or any RFC 3986-conformant resolver) collapses
+// the ".." and climbs the request outside the allowed prefix entirely. Rejecting a
+// dot-segment ref here means neither the allowed_refs check nor the ADR-045
+// per-reference RBAC grant can be satisfied by a traversal-shaped ref in the first
+// place, independent of whatever additional defense-in-depth an individual
+// connector's GetSecret applies at its own URL-construction point (e.g. vault.go's
+// sanitizeVaultRef). Unlike azure.go's blanket `/?#%` rejection, this only rejects
+// the traversal segments themselves — a legitimate multi-segment ref (Vault paths,
+// GCP resource names, AWS Secrets Manager friendly names) still contains plain "/".
+func RefHasDotSegment(ref string) bool {
+	for _, seg := range strings.Split(ref, "/") {
+		if seg == "." || seg == ".." {
+			return true
+		}
+	}
+	return false
+}
+
 // prefixAllowed reports whether ref is permitted by an allowlist of prefixes. An
 // empty allowlist permits everything (the backend identity's own scope is then the
-// only bound). Shared by the connectors as a defense-in-depth guardrail (ADR-043).
+// only bound). Shared by the connectors as a defense-in-depth guardrail (ADR-043). A
+// traversal-shaped ref is rejected outright, before the prefix comparison, so it can
+// never be considered "allowed" regardless of the configured allowlist.
 func prefixAllowed(allowed []string, ref string) bool {
+	if RefHasDotSegment(ref) {
+		return false
+	}
 	if len(allowed) == 0 {
 		return true
 	}

--- a/internal/connect/connect_test.go
+++ b/internal/connect/connect_test.go
@@ -1,0 +1,51 @@
+package connect
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRefHasDotSegment(t *testing.T) {
+	cases := []struct {
+		ref  string
+		want bool
+	}{
+		{"secret/data/myapp/config", false},
+		{"secret/data/myapp/", false},
+		{"prod/eu/db", false},
+		{"keyorix/prod-db", false}, // AWS Secrets Manager friendly name, no dot segment
+		{"projects/123/secrets/foo/versions/latest", false},
+		{"", false},
+		{".", true},
+		{"..", true},
+		{"secret/data/myapp/../otherapp/secret", true}, // exact #326 exploit trace
+		{"secret/data/team-a/../../../sys/policies/acl", true},
+		{"../etc/passwd", true},
+		{"secret/./data", true},
+	}
+	for _, tc := range cases {
+		assert.Equalf(t, tc.want, RefHasDotSegment(tc.ref), "RefHasDotSegment(%q)", tc.ref)
+	}
+}
+
+func TestPrefixAllowed(t *testing.T) {
+	t.Run("empty allowlist permits everything for a non-traversal ref", func(t *testing.T) {
+		assert.True(t, prefixAllowed(nil, "anything"))
+	})
+	t.Run("empty allowlist still rejects a traversal-shaped ref", func(t *testing.T) {
+		assert.False(t, prefixAllowed(nil, "secret/data/myapp/../otherapp/secret"))
+	})
+	t.Run("legitimate ref within the granted prefix is allowed", func(t *testing.T) {
+		assert.True(t, prefixAllowed([]string{"secret/data/myapp/"}, "secret/data/myapp/config"))
+	})
+	t.Run("ref outside the granted prefix is denied", func(t *testing.T) {
+		assert.False(t, prefixAllowed([]string{"secret/data/myapp/"}, "secret/data/otherapp/secret"))
+	})
+	t.Run("#326: traversal ref that satisfies the literal HasPrefix check is still denied", func(t *testing.T) {
+		// "secret/data/myapp/../otherapp/secret" literally starts with the allowed
+		// prefix "secret/data/myapp/" — a raw strings.HasPrefix check alone would
+		// have permitted it, even though it resolves outside the grant.
+		assert.False(t, prefixAllowed([]string{"secret/data/myapp/"}, "secret/data/myapp/../otherapp/secret"))
+	})
+}

--- a/internal/connect/vault_test.go
+++ b/internal/connect/vault_test.go
@@ -110,7 +110,10 @@ func TestVault_GetSecret_RejectsTraversalAndInjection(t *testing.T) {
 	t.Run("path traversal is rejected before any request", func(t *testing.T) {
 		_, err := c.GetSecret(context.Background(), "secret/data/team-a/../../../sys/policies/acl")
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "traversal")
+		// prefixAllowed (the allowed_refs layer) now rejects the traversal-shaped
+		// ref outright, before sanitizeVaultRef's own defense-in-depth check even
+		// runs — so the error surfaces as "not permitted" rather than "traversal".
+		assert.Contains(t, err.Error(), "not permitted")
 		assert.Empty(t, hits, "no request should reach Vault for a traversal ref")
 	})
 
@@ -123,4 +126,51 @@ func TestVault_GetSecret_RejectsTraversalAndInjection(t *testing.T) {
 		assert.Empty(t, hits[0].rawQuery, "the injected ?list=true must not become a Vault query parameter")
 		assert.Contains(t, hits[0].rawURI, "%3F", "the ? is percent-escaped into the path")
 	})
+}
+
+// TestVault_GetSecret_CrossTenantTraversalIsRejected proves the exact exploit trace
+// from finding #326: a caller scoped by allowed_refs to "secret/data/myapp/" cannot
+// read "secret/data/otherapp/secret" by requesting the ref
+// "secret/data/myapp/../otherapp/secret". strings.HasPrefix on that ref against the
+// granted prefix "secret/data/myapp/" is true (the literal string starts with the
+// allowed prefix), so without a traversal guard the request would reach Vault, whose
+// HTTP layer resolves the ".." per RFC 3986 to a path outside the granted prefix —
+// a cross-tenant read through one shared connector.
+func TestVault_GetSecret_CrossTenantTraversalIsRejected(t *testing.T) {
+	var hits int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		// Simulate the victim secret actually existing at the path the traversal
+		// resolves to, so a failure to reject would silently succeed.
+		if r.URL.Path == "/v1/secret/data/otherapp/secret" {
+			_, _ = w.Write([]byte(`{"data":{"data":{"password":"victim-secret"},"metadata":{}}}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(srv.Close)
+
+	c := NewVaultConnector("v", srv.URL, "tok", []string{"secret/data/myapp/"})
+
+	_, err := c.GetSecret(context.Background(), "secret/data/myapp/../otherapp/secret")
+	require.Error(t, err, "the cross-tenant traversal ref must be rejected")
+	// Rejected at the allowed_refs layer (prefixAllowed) before sanitizeVaultRef's
+	// defense-in-depth check even runs.
+	assert.Contains(t, err.Error(), "not permitted")
+	assert.Zero(t, hits, "no request should ever reach Vault for a traversal ref")
+}
+
+// TestVault_GetSecret_LegitimateScopedRefStillWorks proves the traversal guard does
+// not collaterally break an ordinary, non-traversal ref within the granted prefix —
+// the same GetSecret code path (prefixAllowed then sanitizeVaultRef) must still let
+// a legitimately scoped caller read their own secret.
+func TestVault_GetSecret_LegitimateScopedRefStillWorks(t *testing.T) {
+	srv := fakeVault(t, "tok", map[string]string{
+		"/v1/secret/data/myapp/config": `{"data":{"data":{"password":"p@ss"},"metadata":{}}}`,
+	})
+	c := NewVaultConnector("v", srv.URL, "tok", []string{"secret/data/myapp/"})
+
+	val, err := c.GetSecret(context.Background(), "secret/data/myapp/config")
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"password":"p@ss"}`, val)
 }

--- a/internal/core/connect.go
+++ b/internal/core/connect.go
@@ -157,7 +157,16 @@ func (c *KeyorixCore) connectRefAllowed(ctx context.Context, actorType string, p
 // shell-style glob via path.Match, where * does not cross '/'. So "metrics/" still
 // grants everything under metrics/, "metrics/*" grants exactly one further path
 // segment, and "prod/*/db" matches prod/<env>/db. A malformed glob matches nothing.
+//
+// A ref containing a "." or ".." path segment (e.g. "myapp/../otherapp") is rejected
+// outright before either comparison: connect.RefHasDotSegment — see its doc comment —
+// covers the same HasPrefix-vs-RFC-3986-resolution gap this per-reference RBAC grant
+// would otherwise be vulnerable to, mirroring the guard on prefixAllowed for the
+// coarser allowed_refs check.
 func refMatches(pattern, ref string) bool {
+	if connect.RefHasDotSegment(ref) {
+		return false
+	}
 	if !strings.ContainsAny(pattern, "*?[") {
 		return strings.HasPrefix(ref, pattern)
 	}

--- a/internal/core/connect_rbac_test.go
+++ b/internal/core/connect_rbac_test.go
@@ -211,10 +211,38 @@ func TestRefMatches(t *testing.T) {
 		{"db?", "db1", true}, // single-char wildcard
 		{"db?", "db", false},
 		{"[", "anything", false}, // malformed glob matches nothing
+		// #326: a traversal-shaped ref must never match, even though a raw
+		// strings.HasPrefix(ref, pattern) would report a literal match.
+		{"secret/data/myapp/", "secret/data/myapp/../otherapp/secret", false},
+		{"secret/data/myapp/", "secret/data/myapp/config", true}, // sibling non-traversal ref still matches
 	}
 	for _, tc := range cases {
 		assert.Equalf(t, tc.want, refMatches(tc.pattern, tc.ref), "refMatches(%q, %q)", tc.pattern, tc.ref)
 	}
+}
+
+// TestConnectRefRBAC_CrossTenantTraversalDenied proves the exact exploit trace from
+// finding #326 at the ADR-045 per-reference RBAC layer: a role granted only
+// "secret/data/myapp/" on the vault connector cannot read
+// "secret/data/otherapp/secret" by requesting the ref
+// "secret/data/myapp/../otherapp/secret". A raw strings.HasPrefix check would treat
+// that ref as matching the grant (the literal string starts with the granted
+// prefix); refMatches must reject it outright.
+func TestConnectRefRBAC_CrossTenantTraversalDenied(t *testing.T) {
+	c, db := connectRBACCore(t, fakeConnector{name: "vault", val: "myapp-secret"})
+	seedRoleForUser(t, db, 1, 5, "myapp-reader")
+	seedGrant(t, c, 5, "vault", "secret/data/myapp/")
+	ctx := context.Background()
+
+	_, err := c.ReadFederatedSecret(ctx, ActorTypeUser, 1, "vault", "secret/data/myapp/../otherapp/secret")
+	require.Error(t, err, "the cross-tenant traversal ref must be denied by the per-reference grant")
+	assert.Contains(t, err.Error(), "not permitted")
+
+	// The legitimate ref within the granted prefix still works through the same
+	// code path (connectRefAllowed -> refMatches -> GetSecret).
+	val, err := c.ReadFederatedSecret(ctx, ActorTypeUser, 1, "vault", "secret/data/myapp/config")
+	require.NoError(t, err)
+	assert.Equal(t, "myapp-secret", val)
 }
 
 func TestConnectRefAllowed_Direct(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes #326 (HIGH): `internal/connect/connect.go`'s `prefixAllowed` (the `allowed_refs`
guardrail) and `internal/core/connect.go`'s `refMatches` (the ADR-045 per-reference RBAC
grant) both gated access with a raw `strings.HasPrefix` comparison against the caller-supplied
`ref`. A ref such as `secret/data/myapp/../otherapp/secret` satisfies
`HasPrefix(ref, "secret/data/myapp/")` — the literal string starts with the granted prefix —
even though it resolves *outside* that prefix once the `..` segment is collapsed by a
downstream HTTP layer (Vault's own API, or any intermediating proxy).

`internal/connect/vault.go`'s `GetSecret` already carries a defense-in-depth guard
(`sanitizeVaultRef`) at its URL-construction point that rejects `..`/`.` segments before
building the Vault request — so on current `main` the concrete cross-tenant read is already
blocked there. But the two RBAC-decision layers that gate the read (`allowed_refs` and the
ADR-045 ref-grant) had no equivalent guard: a traversal-shaped ref was reported as
**allowed** before it ever reached that guard, correct in practice today only because Vault
happens to be the one connector that interpolates `ref` into a URL. Any future connector
sharing these helpers without its own equivalent guard would reintroduce the exact
cross-tenant-read bug the finding describes.

## Fix

- Added `connect.RefHasDotSegment`, which rejects a ref containing a `.` or `..` path
  segment.
- Wired it into `prefixAllowed` (`internal/connect/connect.go`) and `refMatches`
  (`internal/core/connect.go`) so a traversal-shaped ref is denied at the authorization
  layer itself, not just at Vault's URL-construction point.
- Scoped to dot-segments only (not a blanket `/?#%` reject like the `rotation/azure.go`
  precedent) so legitimate multi-segment refs — Vault KV paths, GCP Secret Manager resource
  names, AWS Secrets Manager friendly names — are unaffected; only `AWS`/`GCP`/`Azure`
  connectors' existing tests (which exercise multi-segment `allowed_refs`) were used to
  confirm no regression.

## Test plan

- [x] New regression tests reproduce the exact exploit trace from the finding
      (`secret/data/myapp/../otherapp/secret` against an `allowed_refs`/ADR-045 grant of
      `secret/data/myapp/`) at both the Vault-connector layer
      (`TestVault_GetSecret_CrossTenantTraversalIsRejected`) and the ADR-045 RBAC layer
      (`TestConnectRefRBAC_CrossTenantTraversalDenied`), plus unit coverage for the new
      `RefHasDotSegment`/`prefixAllowed`/`refMatches` behavior.
- [x] New tests confirm legitimate (non-traversal) refs still work through the same code
      path (`TestVault_GetSecret_LegitimateScopedRefStillWorks`, and the "sibling
      non-traversal ref still matches" case in `TestRefMatches`).
- [x] `go build ./...`
- [x] `go test ./...` (full suite green)
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues
- [x] `golangci-lint run ./...` — 0 issues
- [x] `GOWORK=off go build -C operator ./...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)