### PR TITLE
fix(sso): SAML/OIDC type-confusion panic + login-state TOCTOU (#320/#321)

### DIFF
--- a/internal/core/sso.go
+++ b/internal/core/sso.go
@@ -106,12 +106,26 @@ func (c *KeyorixCore) SSOCompleteURL(provider string) (string, bool) {
 	return "", false
 }
 
+// oidcProvider resolves a configured OIDC provider by name. buildSSOProviders
+// (server/main.go) never sets Type for an OIDC provider — it's left as the zero
+// value, "" — so "not saml" is treated as OIDC here, mirroring samlProvider's
+// reciprocal check. This guards the OIDC flow (which dereferences OAuth
+// unconditionally) against being invoked for a provider configured with
+// Type: "saml", whose OAuth field is always nil.
+func (c *KeyorixCore) oidcProvider(name string) (*SSOProvider, error) {
+	p, ok := c.ssoProviders[name]
+	if !ok || p.Type == "saml" || p.OAuth == nil {
+		return nil, fmt.Errorf("unknown SSO provider %q", name)
+	}
+	return p, nil
+}
+
 // BeginSSO creates and stores the CSRF state + nonce and returns the IdP
 // authorization URL to redirect the browser to.
 func (c *KeyorixCore) BeginSSO(ctx context.Context, providerName, returnTo string) (string, error) {
-	p, ok := c.ssoProviders[providerName]
-	if !ok {
-		return "", fmt.Errorf("unknown SSO provider %q", providerName)
+	p, err := c.oidcProvider(providerName)
+	if err != nil {
+		return "", err
 	}
 	state, err := randToken()
 	if err != nil {
@@ -138,8 +152,8 @@ func (c *KeyorixCore) BeginSSO(ctx context.Context, providerName, returnTo strin
 // to a user, and mints a session. Returns the session, the user, and the in-app path
 // to land on (ReturnTo, may be empty).
 func (c *KeyorixCore) CompleteSSO(ctx context.Context, providerName, code, state, userAgent, ip string) (*models.Session, *models.User, string, error) {
-	p, ok := c.ssoProviders[providerName]
-	if !ok {
+	p, err := c.oidcProvider(providerName)
+	if err != nil {
 		return nil, nil, "", fmt.Errorf("unknown SSO provider")
 	}
 	st, err := c.storage.ConsumeSSOLoginState(ctx, state)

--- a/internal/core/sso_test.go
+++ b/internal/core/sso_test.go
@@ -516,6 +516,40 @@ func TestBeginSSO_UnknownProvider(t *testing.T) {
 	require.Error(t, err)
 }
 
+// TestBeginSSO_RejectsSAMLTypedProvider is the #320 regression: a provider configured
+// with Type: "saml" has OAuth == nil (server/main.go only ever sets OAuth for OIDC
+// providers), so the old code — which dereferenced p.OAuth.AuthCodeURL unconditionally
+// — panicked on any GET /auth/sso/{name}/login for a SAML provider name, an
+// unauthenticated, unlimited, automatable crash-and-recover reachable by anyone who'd
+// enumerated the name via GET /auth/sso/providers. BeginSSO must instead return a
+// clean error, and — since the old panic happened AFTER CreateSSOLoginState — must not
+// leave an orphaned SSOLoginState row behind (asserted by AssertNotCalled).
+func TestBeginSSO_RejectsSAMLTypedProvider(t *testing.T) {
+	stub := &stubSAML{redirect: "https://idp.example/sso", requestID: "req-1"}
+	c, store := samlTestCore(stub)
+
+	_, err := c.BeginSSO(context.Background(), "corp", "/secrets")
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "nil pointer", "must be a clean error, not a recovered panic")
+	store.AssertNotCalled(t, "CreateSSOLoginState", mock.Anything, mock.Anything)
+}
+
+// TestCompleteSSO_RejectsSAMLTypedProvider mirrors TestBeginSSO_RejectsSAMLTypedProvider
+// for the callback side (#320): CompleteSSO dereferences p.OAuth.Exchange unconditionally
+// too. Even though a real attacker can't reach this without first obtaining a valid,
+// unexpired SSOLoginState row (the state token is never returned before BeginSSO's old
+// panic), the guard must hold defensively — and must fire BEFORE touching storage, so a
+// type-mismatched callback never even attempts to consume a login state.
+func TestCompleteSSO_RejectsSAMLTypedProvider(t *testing.T) {
+	stub := &stubSAML{redirect: "https://idp.example/sso", requestID: "req-1"}
+	c, store := samlTestCore(stub)
+
+	_, _, _, err := c.CompleteSSO(context.Background(), "corp", "code", "some-state", "ua", "1.2.3.4")
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "nil pointer", "must be a clean error, not a recovered panic")
+	store.AssertNotCalled(t, "ConsumeSSOLoginState", mock.Anything, mock.Anything)
+}
+
 func TestSanitizeReturnTo(t *testing.T) {
 	assert.Equal(t, "/secrets", sanitizeReturnTo("/secrets"))
 	assert.Equal(t, "", sanitizeReturnTo("//evil.com"))

--- a/internal/storage/store/local_sso.go
+++ b/internal/storage/store/local_sso.go
@@ -22,6 +22,16 @@ func (ls *LocalStorage) CreateSSOLoginState(ctx context.Context, s *models.SSOLo
 
 // ConsumeSSOLoginState returns the state row and deletes it (single use), so a
 // callback's state can never be replayed. Returns the not-found error if absent.
+//
+// The delete itself — not the preceding read — is what makes this single-use: two
+// concurrent callers can both pass the initial First() before either deletes (a plain
+// read can't be the guard), so the DELETE is scoped with the same "id = ? AND state =
+// ?" predicate the row was read with and RowsAffected is checked. Only the caller whose
+// DELETE actually matched a row (RowsAffected == 1) gets to proceed; the DB itself
+// (row-level lock on UPDATE/DELETE, re-evaluated after acquiring it, on every gorm
+// driver this project supports) guarantees at most one concurrent DELETE against the
+// same row can ever affect it — the same conditional-write pattern used elsewhere in
+// this campaign (e.g. TryIncrementSecretReadCount, UpdateAccessReviewItem).
 func (ls *LocalStorage) ConsumeSSOLoginState(ctx context.Context, state string) (*models.SSOLoginState, error) {
 	var s models.SSOLoginState
 	err := ls.db.WithContext(ctx).Where("state = ?", state).First(&s).Error
@@ -31,8 +41,16 @@ func (ls *LocalStorage) ConsumeSSOLoginState(ctx context.Context, state string) 
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
 	}
-	if err := ls.db.WithContext(ctx).Delete(&models.SSOLoginState{}, s.ID).Error; err != nil {
-		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	res := ls.db.WithContext(ctx).Where("id = ? AND state = ?", s.ID, state).Delete(&models.SSOLoginState{})
+	if res.Error != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), res.Error)
+	}
+	if res.RowsAffected != 1 {
+		// Lost the race: another caller's concurrent DELETE already consumed this
+		// state. Report it exactly like an unknown/already-used state, not a
+		// distinct error — that distinction isn't observable to a legitimate caller
+		// and shouldn't be to a replaying one either.
+		return nil, fmt.Errorf("%s", i18n.T("ErrorNotFound", nil))
 	}
 	return &s, nil
 }

--- a/internal/storage/store/local_sso_test.go
+++ b/internal/storage/store/local_sso_test.go
@@ -2,6 +2,8 @@ package store
 
 import (
 	"context"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -31,4 +33,55 @@ func TestSSOLoginState_CreateConsumeIsSingleUse(t *testing.T) {
 	// Second consume of the same state fails — it was deleted (no replay).
 	_, err = ls.ConsumeSSOLoginState(ctx, "st-1")
 	require.Error(t, err)
+}
+
+// TestConcurrency_ConsumeSSOLoginState_OnlyOneWins is the #321 regression: two
+// concurrent callback POSTs carrying the SAME state/RelayState must not both pass
+// consumption and each mint a session. The old implementation was an unwrapped
+// SELECT (First) followed by a separate DELETE — both racers could pass the SELECT
+// before either DELETE landed. ConsumeSSOLoginState now scopes its DELETE with the
+// same "id = ? AND state = ?" predicate and only the caller whose DELETE actually
+// affects a row (RowsAffected == 1) may proceed; this drives real concurrent callers
+// (file-backed SQLite, WAL, genuine multi-connection contention — a shared
+// :memory: connection would serialize every statement and mask the race) and
+// asserts exactly one of them ever succeeds.
+func TestConcurrency_ConsumeSSOLoginState_OnlyOneWins(t *testing.T) {
+	db := concurrentDB(t)
+	require.NoError(t, db.AutoMigrate(&models.SSOLoginState{}))
+	ls := NewLocalStorage(db)
+
+	require.NoError(t, ls.CreateSSOLoginState(context.Background(), &models.SSOLoginState{
+		State: "race-state", Nonce: "n-1", Provider: "okta", ExpiresAt: time.Now().Add(10 * time.Minute),
+	}))
+
+	const racers = 32
+	var succeeded atomic.Int64
+	errs := make(chan error, racers)
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < racers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			_, err := ls.ConsumeSSOLoginState(context.Background(), "race-state")
+			if err == nil {
+				succeeded.Add(1)
+				return
+			}
+			errs <- err
+		}()
+	}
+	close(start) // release every racer at once
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.Error(t, err, "every losing racer must get the ordinary not-found/already-consumed error")
+	}
+
+	assert.Equal(t, int64(1), succeeded.Load(), "exactly one concurrent consume may win — never zero, never more than one")
+
+	var count int64
+	require.NoError(t, db.Model(&models.SSOLoginState{}).Where("state = ?", "race-state").Count(&count).Error)
+	assert.Zero(t, count, "the row must be gone after the winning consume, regardless of how many racers competed")
 }


### PR DESCRIPTION
## Summary
- **#320 MEDIUM** — `BeginSSO`/`CompleteSSO` (`internal/core/sso.go`) dereferenced `p.OAuth` unconditionally. A provider configured with `Type: "saml"` always has `p.OAuth == nil` (only `p.SAML` is set, per `server/main.go`), so `oauth2.Config.AuthCodeURL`/`Exchange` panicked on a nil receiver. Since `GET /auth/sso/providers` is unauthenticated and returns every provider name with no type discriminator, any anonymous caller could enumerate a SAML provider's name and trigger the panic (caught by `Recovery()`, degrading to a 500) on demand — and `BeginSSO` created the `SSOLoginState` row *before* the panicking line, orphaning a row on every hit. Added the reciprocal `p.Type == "saml" || p.OAuth == nil` guard (mirroring the existing `samlProvider` check) *before* either function touches storage, so there's no panic and no orphaned row.
- **#321 LOW** — `ConsumeSSOLoginState` (`internal/storage/store/local_sso.go`) was documented as an atomic single-use anti-replay guard but was implemented as an unwrapped `SELECT` followed by a separate `DELETE`, so two concurrent callback requests carrying the same state could both pass the read before either delete landed, minting two sessions from one login state. The delete is now scoped with the same `id + state` predicate the row was read with, and only proceeds when `RowsAffected == 1` — the same conditional-write pattern already used elsewhere in this campaign (`TryIncrementSecretReadCount`, `UpdateAccessReviewItem`).

Both findings re-verified against current `main` before fixing; neither had been independently resolved.

## Test plan
- [x] New regression tests: `TestBeginSSO_RejectsSAMLTypedProvider` / `TestCompleteSSO_RejectsSAMLTypedProvider` prove a clean error (not a panic) for a type-mismatched provider and assert no storage call that would leave an orphaned `SSOLoginState` row
- [x] New concurrency test: `TestConcurrency_ConsumeSSOLoginState_OnlyOneWins` drives 32 real concurrent racers against file-backed SQLite (WAL) and asserts exactly one consume succeeds
- [x] `go build ./...` clean
- [x] `go test ./...` full suite green
- [x] `go test ./internal/core/... ./internal/storage/store/... -race` clean
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues
- [x] `golangci-lint run ./...` — 0 issues
- [x] `GOWORK=off go build -C operator ./...` clean