### PR TITLE
harden(handlers): close CSV formula injection in access-review and compliance exports (#148)

### DIFF
--- a/server/http/handlers/access_review_campaign_export_csv.go
+++ b/server/http/handlers/access_review_campaign_export_csv.go
@@ -72,18 +72,18 @@ func (h *CatalogHandler) ExportAccessReviewCampaignCSV(w http.ResponseWriter, r 
 	})
 	for _, it := range detail.Items {
 		_ = cw.Write([]string{
-			it.PrincipalType,
-			it.PrincipalName,
-			it.Email,
-			it.Source,
-			it.RoleName,
-			it.AccessLevel,
+			csvSafe(it.PrincipalType),
+			csvSafe(it.PrincipalName),
+			csvSafe(it.Email),
+			csvSafe(it.Source),
+			csvSafe(it.RoleName),
+			csvSafe(it.AccessLevel),
 			strconv.FormatUint(uint64(it.EnvironmentID), 10),
-			it.SecretName,
+			csvSafe(it.SecretName),
 			tstr(it.LastUsedAt),
-			it.Decision,
-			it.Reason,
-			deciderName[it.DecidedBy],
+			csvSafe(it.Decision),
+			csvSafe(it.Reason),
+			csvSafe(deciderName[it.DecidedBy]),
 			tstr(it.DecidedAt),
 		})
 	}

--- a/server/http/handlers/access_review_campaign_export_csv_test.go
+++ b/server/http/handlers/access_review_campaign_export_csv_test.go
@@ -66,6 +66,36 @@ func TestExportAccessReviewCampaignCSV(t *testing.T) {
 		assert.Contains(t, body, "auditor", "decider username is resolved")
 	})
 
+	t.Run("neutralizes formula-injection payloads in attacker/reviewer-controlled fields", func(t *testing.T) {
+		require.NoError(t, db.Create(&models.AccessReviewCampaign{
+			ID: 6, ProjectID: 1, Name: "Q1 2027", State: "closed", CreatedBy: 1, CreatedAt: time.Now(),
+		}).Error)
+		require.NoError(t, db.Create(&models.AccessReviewItem{
+			ID: 3, CampaignID: 6, PrincipalType: "user", PrincipalID: 12,
+			PrincipalName: "=1+1", Email: "+cmd|calc!A0",
+			Source: "role", RoleName: "@SUM(A1:A9)", AccessLevel: "-2+3", EnvironmentID: 2,
+			SecretName: "=HYPERLINK(http://evil)", Decision: "revoked",
+			Reason: "+cmd|calc!A0", DecidedBy: 1, DecidedAt: &decided,
+		}).Error)
+
+		req := withChiParams(withUserCtx(httptest.NewRequest(http.MethodGet,
+			"/api/v1/projects/1/access-review/campaigns/6/export.csv", nil)),
+			map[string]string{"id": "1", "campaignId": "6"})
+		w := httptest.NewRecorder()
+		h.ExportAccessReviewCampaignCSV(w, req)
+
+		require.Equal(t, http.StatusOK, w.Code)
+		body := w.Body.String()
+		assert.Contains(t, body, "'=1+1")
+		assert.Contains(t, body, "'+cmd|calc!A0")
+		assert.Contains(t, body, "'@SUM(A1:A9)")
+		assert.Contains(t, body, "'-2+3")
+		assert.Contains(t, body, "'=HYPERLINK(http://evil)")
+		// Every raw (unescaped) payload must not appear on its own — only prefixed.
+		assert.NotContains(t, body, "\n=1+1")
+		assert.NotContains(t, body, ",=1+1")
+	})
+
 	t.Run("requires a user context", func(t *testing.T) {
 		req := withChiParams(httptest.NewRequest(http.MethodGet,
 			"/api/v1/projects/1/access-review/campaigns/5/export.csv", nil),

--- a/server/http/handlers/compliance_controls_csv.go
+++ b/server/http/handlers/compliance_controls_csv.go
@@ -37,16 +37,16 @@ func (h *DashboardHandler) ExportComplianceControlsCSV(w http.ResponseWriter, r 
 	_ = cw.Write([]string{"id", "name", "area", "status", "detail", "iso_27001", "soc2", "nis2", "dora", "ens"})
 	for _, ctrl := range matrix.Controls {
 		_ = cw.Write([]string{
-			ctrl.ID,
-			ctrl.Name,
-			ctrl.Area,
-			string(ctrl.Status),
-			ctrl.Detail,
-			strings.Join(ctrl.Frameworks.ISO27001, "; "),
-			strings.Join(ctrl.Frameworks.SOC2, "; "),
-			strings.Join(ctrl.Frameworks.NIS2, "; "),
-			strings.Join(ctrl.Frameworks.DORA, "; "),
-			strings.Join(ctrl.Frameworks.ENS, "; "),
+			csvSafe(ctrl.ID),
+			csvSafe(ctrl.Name),
+			csvSafe(ctrl.Area),
+			csvSafe(string(ctrl.Status)),
+			csvSafe(ctrl.Detail),
+			csvSafe(strings.Join(ctrl.Frameworks.ISO27001, "; ")),
+			csvSafe(strings.Join(ctrl.Frameworks.SOC2, "; ")),
+			csvSafe(strings.Join(ctrl.Frameworks.NIS2, "; ")),
+			csvSafe(strings.Join(ctrl.Frameworks.DORA, "; ")),
+			csvSafe(strings.Join(ctrl.Frameworks.ENS, "; ")),
 		})
 	}
 }

--- a/server/http/handlers/compliance_controls_csv_test.go
+++ b/server/http/handlers/compliance_controls_csv_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/keyorixhq/keyorix/internal/i18n"
@@ -53,5 +54,26 @@ func TestExportComplianceControlsCSV(t *testing.T) {
 		w := httptest.NewRecorder()
 		h.ExportComplianceControlsCSV(w, req)
 		assert.Equal(t, http.StatusUnauthorized, w.Code)
+	})
+
+	t.Run("every cell is written through csvSafe even though none currently starts with attacker content", func(t *testing.T) {
+		// The only operator/free-text field reachable in this otherwise system-
+		// generated export is LegalHoldPosture.Reason, but legalHoldDetail always
+		// embeds it after a fixed "ACTIVE — purges blocked (" prefix, so it can never
+		// land as the leading character of the "detail" cell — a formula-injection
+		// payload here is inert today. Every string cell is still routed through
+		// csvSafe (matching the audit / inventory export handlers) as defense in
+		// depth against a future Detail-builder that puts free text first.
+		require.NoError(t, db.Create(&models.LegalHold{
+			Reason: "=1+1", PlacedBy: 1, PlacedAt: time.Now(), Released: false,
+		}).Error)
+
+		req := withUserCtx(httptest.NewRequest(http.MethodGet, "/api/v1/compliance/controls.csv", nil))
+		w := httptest.NewRecorder()
+		h.ExportComplianceControlsCSV(w, req)
+
+		require.Equal(t, http.StatusOK, w.Code)
+		body := w.Body.String()
+		assert.Contains(t, body, "ACTIVE — purges blocked (=1+1)", "embedded mid-cell: correctly left unescaped")
 	})
 }


### PR DESCRIPTION
## Summary
- `ExportAccessReviewCampaignCSV` — the second export path #148 explicitly named as still open — wrote `PrincipalName`/`Email`/`RoleName`/`SecretName` and reviewer-entered free-text `Reason` straight into unescaped CSV cells. Every user/attacker-influenced field is now wrapped with the existing `csvSafe` helper (`server/http/handlers/csv_safe.go`), matching how it's already applied in `SecretsInventoryCSV`, `DeploymentSecretsInventoryCSV`, and `ExportAuditLogsCSV`.
- `ExportComplianceControlsCSV` gets the same wrapping for consistency with the rest of the CSV-export family. Its fields are currently fully system-generated behind a fixed literal prefix (e.g. `"ACTIVE — purges blocked (%s)"`), so a user-entered value (legal-hold `Reason`) can never land as the leading character of a cell today — this is defense in depth against a future `Detail`-builder that puts free text first, not a fix for a currently reachable exploit.
- Swept `server/http/handlers/` for any other `csv.NewWriter` export handler beyond the two named in the backlog entry; found none — the full set is these two plus the three already-fixed handlers.

## Test plan
- [x] New regression test in `access_review_campaign_export_csv_test.go` seeds an item with `=1+1` / `+cmd|calc!A0` / `@SUM(...)` / `-2+3` / `=HYPERLINK(...)` payloads across `PrincipalName`, `Email`, `RoleName`, `AccessLevel`, `SecretName`, and `Reason`, and asserts every payload is single-quote-prefixed in the exported CSV.
- [x] New test in `compliance_controls_csv_test.go` places a legal hold with a formula-like `Reason` and documents why it's inert (embedded mid-cell, not cell-leading) while confirming the export still renders correctly.
- [x] `go build ./...` clean.
- [x] `go test ./...` — full suite green.
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues.
- [x] `golangci-lint run ./...` — 0 issues.
- [x] `GOWORK=off go build -C operator ./...` — clean (separate module).