### PR TITLE
harden(grpc): validate CreateUser's account_state, fail-closed on unrecognized values (#334)

### DIFF
--- a/internal/core/account_state.go
+++ b/internal/core/account_state.go
@@ -47,14 +47,54 @@ func NormalizeAccountState(state string) string {
 	return state
 }
 
+// validAccountStates is the canonical ADR-025 set a caller may explicitly write.
+// The empty string is separately accepted by IsValidAccountState — it is legacy
+// shorthand for "unset", normalized to active by NormalizeAccountState — but is
+// deliberately not in this map so callers that want the exact persisted set can
+// use it directly.
+var validAccountStates = map[string]bool{
+	AccountActive:                true,
+	AccountPendingFirstLogin:     true,
+	AccountPasswordResetRequired: true,
+	AccountSuspended:             true,
+	AccountDeprovisioned:         true,
+}
+
+// IsValidAccountState reports whether state is the empty string (legacy "unset",
+// normalized to active) or one of the ADR-025 canonical lifecycle values. Any other
+// string (a typo, wrong casing, or arbitrary garbage) is not a value any code path
+// in this codebase ever writes itself, and callers accepting a state as external
+// input (currently: gRPC CreateUser's account_state field) must reject it here
+// rather than persist it verbatim — see #334.
+func IsValidAccountState(state string) bool {
+	return state == "" || validAccountStates[state]
+}
+
 // AccountRestricted reports whether a state forces a password change before the
 // user may use any non-allowlisted endpoint.
+//
+// Fail-CLOSED default: an unrecognized state (default case below) is treated as
+// restricted, not as active/unrestricted. This is the defense-in-depth backstop
+// for #334 — IsValidAccountState now rejects a bad value at the one caller-
+// controlled write path, but this function must still cope with an unrecognized
+// value already sitting in the database (e.g. written before this fix shipped, or
+// by a future path that forgets to validate). Restricting is a safe default here
+// specifically because it is *not* a lockout: a restricted session still
+// authenticates (see AccountLoginBlocked) and self-heals the moment the user next
+// changes their password (clearRestrictionOnPasswordChange resets a restricted
+// state to active), so the failure mode of a garbage value is "forced through the
+// password-change flow", never "silently full access" and never "permanently
+// locked out with no recovery path".
 func AccountRestricted(state string) bool {
 	switch NormalizeAccountState(state) {
+	case AccountActive, AccountSuspended, AccountDeprovisioned:
+		// Suspended/deprovisioned are already refused outright by
+		// AccountLoginBlocked, so "restricted" is moot for them either way.
+		return false
 	case AccountPendingFirstLogin, AccountPasswordResetRequired:
 		return true
 	default:
-		return false
+		return true
 	}
 }
 
@@ -62,6 +102,16 @@ func AccountRestricted(state string) bool {
 // suspension and a SCIM/IdP deactivation block login; every login/session/token path
 // funnels through here, so a deprovisioned account is refused everywhere a suspended
 // one is, with no per-path change.
+//
+// Unlike AccountRestricted, this deliberately keeps a fail-OPEN default (false, not
+// blocked) for an unrecognized state. Blocking login outright has no self-healing
+// path — a fully blocked user can never reach the password-change flow to fix
+// anything — so failing closed here would risk permanently locking out an already-
+// legitimate user over a merely malformed value (e.g. a stale data migration, or a
+// value from a since-removed state) with no recovery short of direct DB/admin
+// intervention. AccountRestricted's fail-closed default already guarantees an
+// unrecognized value can never grant full unrestricted access; that is the correct
+// place for the defense-in-depth backstop, not here.
 func AccountLoginBlocked(state string) bool {
 	switch NormalizeAccountState(state) {
 	case AccountSuspended, AccountDeprovisioned:

--- a/internal/core/account_state_test.go
+++ b/internal/core/account_state_test.go
@@ -31,6 +31,48 @@ func TestAccountStateHelpers(t *testing.T) {
 	assert.Equal(t, AccountActive, clearRestrictionOnPasswordChange(""))
 }
 
+// TestIsValidAccountState proves #334's write-path validation: the empty string
+// and every canonical ADR-025 value are valid, and nothing else is.
+func TestIsValidAccountState(t *testing.T) {
+	for _, s := range []string{"", AccountActive, AccountPendingFirstLogin, AccountPasswordResetRequired, AccountSuspended, AccountDeprovisioned} {
+		assert.True(t, IsValidAccountState(s), "expected %q to be valid", s)
+	}
+	for _, s := range []string{"SUSPENDED", "suspend", "Active", "not-a-real-state", " "} {
+		assert.False(t, IsValidAccountState(s), "expected %q to be invalid", s)
+	}
+}
+
+// TestAccountState_UnrecognizedValueFailsClosed proves #334's defense-in-depth
+// backstop: an unrecognized account_state value (e.g. one persisted before the
+// write-path validation shipped) is treated as restricted — never as fully
+// active/unrestricted — while still not being an outright login block, since a
+// restricted session can self-heal via a password change.
+func TestAccountState_UnrecognizedValueFailsClosed(t *testing.T) {
+	garbage := "not-a-real-state"
+
+	assert.True(t, AccountRestricted(garbage), "unrecognized state must fail closed to restricted")
+	assert.False(t, AccountLoginBlocked(garbage), "unrecognized state must not hard-lock out login (no self-heal path)")
+
+	// An unrecognized-but-restricted state still self-heals to active on the
+	// next password change, exactly like the canonical restricted states.
+	assert.Equal(t, AccountActive, clearRestrictionOnPasswordChange(garbage))
+
+	// The canonical, previously-tested behaviors are unchanged by the new default.
+	assert.True(t, AccountRestricted(AccountPendingFirstLogin))
+	assert.True(t, AccountRestricted(AccountPasswordResetRequired))
+	assert.False(t, AccountRestricted(AccountActive))
+	assert.False(t, AccountRestricted(AccountSuspended))
+	assert.False(t, AccountRestricted(AccountDeprovisioned))
+	assert.False(t, AccountRestricted(""))
+
+	assert.True(t, AccountLoginBlocked(AccountSuspended))
+	assert.True(t, AccountLoginBlocked(AccountDeprovisioned))
+	assert.False(t, AccountLoginBlocked(AccountActive))
+	assert.False(t, AccountLoginBlocked(AccountPendingFirstLogin))
+	assert.False(t, AccountLoginBlocked(AccountPasswordResetRequired))
+	assert.False(t, AccountLoginBlocked(""))
+}
+
 func newAccountCore(store *MockStorage) *KeyorixCore {
 	fixed := time.Date(2026, 6, 5, 12, 0, 0, 0, time.UTC)
 	return &KeyorixCore{storage: store, now: func() time.Time { return fixed }, passwordPolicy: DefaultPasswordPolicy()}

--- a/server/grpc/services/user_service.go
+++ b/server/grpc/services/user_service.go
@@ -86,6 +86,17 @@ func (s *UserGRPCService) CreateUser(ctx context.Context, req *pb.CreateUserRequ
 		IsActive:    req.IsActive,
 	}
 	if as := req.GetAccountState(); as != "" {
+		// account_state is a gRPC-only free-text field with no proto enum/oneof
+		// validation (this repo has no protoc-gen-validate extensions), and has
+		// no HTTP or CLI equivalent to cross-check against. Reject anything that
+		// isn't a canonical ADR-025 value here rather than persist it verbatim —
+		// downstream, AccountRestricted/AccountLoginBlocked would otherwise
+		// treat a typo'd or garbage value inconsistently with the admin's
+		// actual intent. See #334.
+		if !core.IsValidAccountState(as) {
+			return nil, status.Error(codes.InvalidArgument,
+				"account_state must be one of: active, pending_first_login, password_reset_required, suspended, deprovisioned")
+		}
 		coreReq.AccountState = as
 	}
 

--- a/server/grpc/services/user_service_test.go
+++ b/server/grpc/services/user_service_test.go
@@ -161,6 +161,50 @@ func TestUserService_CreateUser_AdminCanGrantRole(t *testing.T) {
 	require.NotNil(t, resp.GetUser())
 }
 
+// TestUserService_CreateUser_RejectsInvalidAccountState proves #334: an
+// unrecognized account_state (typo, wrong casing, or garbage) is rejected with a
+// clear error rather than silently persisted, where it would otherwise be treated
+// as fully active/unrestricted by AccountRestricted/AccountLoginBlocked.
+func TestUserService_CreateUser_RejectsInvalidAccountState(t *testing.T) {
+	svc := newUserService(t)
+	cases := []string{
+		"SUSPENDED",       // wrong case
+		"suspend",         // typo
+		"not-a-real-state",
+		" ",
+	}
+	for _, as := range cases {
+		t.Run(as, func(t *testing.T) {
+			_, err := svc.CreateUser(adminCtx(), &pb.CreateUserRequest{
+				Username: "bad-" + as, Email: "bad-" + as + "@example.com",
+				Password: strPtr("Qr7#Kp2$Lm5@Vn9!"), AccountState: strPtr(as),
+			})
+			require.Error(t, err)
+			assert.Equal(t, codes.InvalidArgument, status.Code(err))
+		})
+	}
+}
+
+// TestUserService_CreateUser_AcceptsValidAccountStates proves the fix does not
+// regress any canonical ADR-025 value: each one is still accepted and persisted
+// as-is.
+func TestUserService_CreateUser_AcceptsValidAccountStates(t *testing.T) {
+	svc := newUserService(t)
+	cases := []string{"active", "pending_first_login", "password_reset_required", "suspended", "deprovisioned"}
+	for i, as := range cases {
+		t.Run(as, func(t *testing.T) {
+			username := "good" + string(rune('a'+i))
+			resp, err := svc.CreateUser(adminCtx(), &pb.CreateUserRequest{
+				Username: username, Email: username + "@example.com",
+				Password: strPtr("Qr7#Kp2$Lm5@Vn9!"), AccountState: strPtr(as),
+			})
+			require.NoError(t, err)
+			require.NotNil(t, resp.GetUser())
+			assert.Equal(t, as, resp.GetUser().GetAccountState())
+		})
+	}
+}
+
 func TestUserService_GetUser(t *testing.T) {
 	svc := newUserService(t)
 	created := svc.mustCreate(t, "dave", "dave@example.com")


### PR DESCRIPTION
## Summary

Fixes #334 (MEDIUM): gRPC `CreateUser`'s `account_state` field (`server/proto/keyorix.proto`, `optional string account_state = 8`) had no enum/pattern validation and was passed through unchecked in `server/grpc/services/user_service.go`. `NormalizeAccountState` only special-cased the empty string; any other value (a typo, wrong casing, or garbage) was persisted verbatim. `AccountRestricted`/`AccountLoginBlocked` — which every login path gates on — `switch`ed on the exact string and defaulted to `false`/unrestricted for anything unrecognized, so an admin-privileged caller issuing e.g. `account_state: "SUSPENDED"` (wrong case) would silently create a fully active, unrestricted user, with no HTTP or CLI equivalent field to cross-check against.

- **Write-path validation:** `CreateUser` now rejects any `account_state` that isn't empty or one of the five canonical ADR-025 values (`active`, `pending_first_login`, `password_reset_required`, `suspended`, `deprovisioned`) with a clear `InvalidArgument` error, via a new `core.IsValidAccountState` helper.
- **Fail-open → fail-closed default, asymmetrically:** `AccountRestricted` now defaults to `true` (restricted) for an unrecognized value already sitting in the DB (e.g. written before this fix shipped) as a defense-in-depth backstop — a restricted session still authenticates and self-heals to `active` on the user's next password change, so this can't turn into a lockout. `AccountLoginBlocked` deliberately keeps its fail-open default: blocking login outright has no self-healing path, so failing closed there would risk permanently locking out a legitimate user over a merely malformed value (e.g. a stale data migration) with no recovery short of direct DB/admin intervention. The reasoning for this asymmetry is documented inline in `internal/core/account_state.go`.

## Test plan
- [x] New test: gRPC `CreateUser` rejects invalid `account_state` values (wrong case, typo, garbage) with `InvalidArgument`.
- [x] New test: gRPC `CreateUser` still accepts all five canonical `account_state` values.
- [x] New test: `AccountRestricted`/`AccountLoginBlocked` fail-closed-default behavior on an unrecognized value, proving no regression on canonical states and self-healing via password change.
- [x] `go build ./...` clean
- [x] `go test ./...` clean (full suite)
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues
- [x] `golangci-lint run ./...` — 0 issues
- [x] `GOWORK=off go build -C operator ./...` clean