### PR TITLE
harden(notify): Slack/Teams mrkdwn escaping + webhook-URL log redaction (#328/#329)

### DIFF
--- a/internal/notifychan/chat.go
+++ b/internal/notifychan/chat.go
@@ -103,14 +103,38 @@ func (s *ChatSink) send(ctx context.Context, ev core.NotificationEvent) (retryab
 	return retryable, fmt.Errorf("%s webhook returned %s", s.cfg.Kind, strings.TrimSpace(resp.Status))
 }
 
+// mrkdwnEscaper neutralizes Slack/Teams mrkdwn control syntax before a
+// user-controllable string (secret name, project name, or anything else that
+// ultimately traces back to a Title/Message an ordinary, non-admin user can choose —
+// e.g. by naming a secret they own and sharing it, ADR-024) is interpolated into a
+// chat payload. Slack's incoming-webhook `text` field is rendered as mrkdwn by
+// default, where `<...>` is parsed as a link/mention token: `<!channel>`/`<!here>`/
+// `<!everyone>` trigger a mass ping, `<@USERID>` mentions a specific user, and
+// `<https://evil.example|label>` renders as a clickable link with an
+// attacker-chosen label. Escaping `<`/`>` (per Slack's own escaping rules, along
+// with `&` so the escape sequences themselves can't be re-interpreted) turns any
+// such sequence back into inert literal text — this is Slack's documented escaping
+// convention, and Teams' MessageCard fields share the same HTML-ish convention, so
+// the same replacer is safe for both platforms.
+var mrkdwnEscaper = strings.NewReplacer("&", "&amp;", "<", "&lt;", ">", "&gt;")
+
+// escapeMrkdwn applies mrkdwnEscaper to a single string.
+func escapeMrkdwn(s string) string {
+	return mrkdwnEscaper.Replace(s)
+}
+
 // chatText renders the notification as a single plain-text message (no remote
-// resources), shared by both platforms.
+// resources), shared by both platforms. Title/Message may embed user-controllable
+// values (secret/project names), so both are mrkdwn-escaped before interpolation —
+// this is the single choke point every caller's text passes through, so escaping
+// here (rather than at each notification call site) covers every current and
+// future producer of a NotificationEvent.
 func chatText(ev core.NotificationEvent) string {
 	var b strings.Builder
 	if ev.Title != "" {
-		fmt.Fprintf(&b, "*%s*\n", ev.Title)
+		fmt.Fprintf(&b, "*%s*\n", escapeMrkdwn(ev.Title))
 	}
-	b.WriteString(ev.Message)
+	b.WriteString(escapeMrkdwn(ev.Message))
 	if ev.Link != "" {
 		fmt.Fprintf(&b, "\n%s", ev.Link)
 	}
@@ -118,7 +142,10 @@ func chatText(ev core.NotificationEvent) string {
 }
 
 // chatPayload builds the platform-specific JSON body. Slack incoming webhooks take
-// {text}; Teams connectors take a MessageCard.
+// {text}; Teams connectors take a MessageCard. Every field sourced from
+// user-controllable data (Title, Message) is mrkdwn-escaped (via chatText/
+// escapeMrkdwn) before it reaches either payload shape — Link is excluded because it
+// is always a server-generated path (e.g. "/secrets/%d"), never user input.
 func chatPayload(kind ChatKind, ev core.NotificationEvent) interface{} {
 	text := chatText(ev)
 	if kind == ChatTeams {
@@ -129,9 +156,9 @@ func chatPayload(kind ChatKind, ev core.NotificationEvent) interface{} {
 		return map[string]interface{}{
 			"@type":    "MessageCard",
 			"@context": "https://schema.org/extensions",
-			"summary":  title,
-			"title":    title,
-			"text":     ev.Message,
+			"summary":  escapeMrkdwn(title),
+			"title":    escapeMrkdwn(title),
+			"text":     escapeMrkdwn(ev.Message),
 		}
 	}
 	return map[string]string{"text": text}

--- a/internal/notifychan/chat_test.go
+++ b/internal/notifychan/chat_test.go
@@ -64,6 +64,69 @@ func TestChatSink_TeamsPayload(t *testing.T) {
 	assert.Equal(t, "off-hours access by ada.", card["text"])
 }
 
+// TestChatSink_EscapesMrkdwnInjectionFromSecretName proves the #328 exploit trace
+// (an ordinary secret owner names a secret with Slack mrkdwn control syntax and
+// shares it — no admin privilege required) is neutralized before it reaches either
+// platform's JSON payload: no live `<!channel>` mass-ping token, no live
+// `<url|label>` spoofed-link token, in the actual bytes posted to the destination.
+func TestChatSink_EscapesMrkdwnInjectionFromSecretName(t *testing.T) {
+	// Exactly the exploit trace from #328: a secret name crafted to trigger a
+	// Slack mass-ping and a spoofed clickable link, delivered via the ordinary
+	// "secret shared with you" notification (notifySecretShared in
+	// internal/core/notifications.go embeds secret.Name verbatim into ev.Message).
+	secretName := `<!channel> Password reset required: <https://evil.example/login|Reset Now>`
+	message := `You were granted read access to secret "` + secretName + `".`
+
+	t.Run("slack", func(t *testing.T) {
+		srv, get := captureChatServer(t)
+		sink, err := NewChat(ChatConfig{Kind: ChatSlack, WebhookURL: srv.URL})
+		require.NoError(t, err)
+		sink.Deliver(core.NotificationEvent{Title: "Secret shared with you", Message: message})
+		sink.Close()
+
+		var payload map[string]string
+		require.NoError(t, json.Unmarshal(get(), &payload))
+		text := payload["text"]
+		assert.NotContains(t, text, "<!channel>", "must not carry a live @channel mass-ping token")
+		assert.NotContains(t, text, "<https://evil.example/login|Reset Now>", "must not carry a live spoofed-link token")
+		// The content must still be present, just inert — nothing was silently dropped.
+		assert.Contains(t, text, "&lt;!channel&gt;")
+		assert.Contains(t, text, "&lt;https://evil.example/login|Reset Now&gt;")
+	})
+
+	t.Run("teams", func(t *testing.T) {
+		srv, get := captureChatServer(t)
+		sink, err := NewChat(ChatConfig{Kind: ChatTeams, WebhookURL: srv.URL})
+		require.NoError(t, err)
+		sink.Deliver(core.NotificationEvent{Title: "Secret shared with you", Message: message})
+		sink.Close()
+
+		var card map[string]interface{}
+		require.NoError(t, json.Unmarshal(get(), &card))
+		text, _ := card["text"].(string)
+		assert.NotContains(t, text, "<!channel>", "must not carry a live @channel mass-ping token")
+		assert.NotContains(t, text, "<https://evil.example/login|Reset Now>", "must not carry a live spoofed-link token")
+		assert.Contains(t, text, "&lt;!channel&gt;")
+		assert.Contains(t, text, "&lt;https://evil.example/login|Reset Now&gt;")
+	})
+}
+
+// TestChatSink_EscapesMrkdwnInjectionInTitle covers the Title field (used verbatim
+// by other admin/system-triggered notification paths, e.g. compliance_digest.go,
+// rotation_executor.go) through the same choke point.
+func TestChatSink_EscapesMrkdwnInjectionInTitle(t *testing.T) {
+	srv, get := captureChatServer(t)
+	sink, err := NewChat(ChatConfig{Kind: ChatSlack, WebhookURL: srv.URL})
+	require.NoError(t, err)
+	sink.Deliver(core.NotificationEvent{Title: `<!here> urgent`, Message: "ok"})
+	sink.Close()
+
+	var payload map[string]string
+	require.NoError(t, json.Unmarshal(get(), &payload))
+	assert.NotContains(t, payload["text"], "<!here>")
+	assert.Contains(t, payload["text"], "&lt;!here&gt;")
+}
+
 func TestNewChat_Validation(t *testing.T) {
 	_, err := NewChat(ChatConfig{Kind: "irc", WebhookURL: "https://x"})
 	require.Error(t, err)

--- a/internal/notifychan/delivery.go
+++ b/internal/notifychan/delivery.go
@@ -11,6 +11,8 @@ package notifychan
 import (
 	"context"
 	"log"
+	"net/url"
+	"regexp"
 	"sync"
 	"time"
 
@@ -27,6 +29,38 @@ const (
 // sendFunc delivers one event. retryable reports whether a non-nil err is transient
 // (worth retrying) rather than permanent.
 type sendFunc func(ctx context.Context, ev core.NotificationEvent) (retryable bool, err error)
+
+// embeddedURLPattern matches an absolute http(s) URL appearing anywhere in an
+// error's text form. A webhook/chat destination URL (chat.go, webhook.go) IS the
+// bearer credential for a Slack/Teams incoming webhook — the token lives in the URL
+// path, not a header — and Go's *url.Error.Error() (returned by http.Client on any
+// transport-level failure: dial/timeout/TLS) embeds the full request URL verbatim,
+// e.g. `Post "https://hooks.slack.com/services/T000/B000/<token>": dial tcp: ...`.
+var embeddedURLPattern = regexp.MustCompile(`https?://[^\s"]+`)
+
+// redactURLHost renders rawURL as just its scheme and host, dropping the
+// path/query — and with it any bearer token embedded there — while keeping enough
+// context (which destination failed) to be useful for diagnosis. Falls back to a
+// fixed placeholder when rawURL doesn't parse into a URL with a host.
+func redactURLHost(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil || u.Host == "" {
+		return "[redacted-url]"
+	}
+	return u.Scheme + "://" + u.Host
+}
+
+// sanitizeDeliveryError renders err for logging with any embedded destination URL
+// cut down to scheme+host, so an ordinary transient delivery failure (the routine
+// case this exists to handle — a network hiccup, a DNS blip, a closed connection)
+// never writes a live webhook token to the log stream, which is typically shipped
+// to a broader-access SIEM/log platform than whoever administers the channel config.
+func sanitizeDeliveryError(err error) string {
+	if err == nil {
+		return ""
+	}
+	return embeddedURLPattern.ReplaceAllStringFunc(err.Error(), redactURLHost)
+}
 
 // deliverer is the shared queue+worker+retry engine. Sinks embed one.
 type deliverer struct {
@@ -91,7 +125,7 @@ func (d *deliverer) deliver(ev core.NotificationEvent) {
 		}
 		if !retryable || attempt >= deliveryMaxAttempts {
 			notifyDeliveries.WithLabelValues(d.channel, outcomeFailed).Inc()
-			log.Printf("notifychan: %s delivery failed after %d attempt(s): %v", d.channel, attempt, err)
+			log.Printf("notifychan: %s delivery failed after %d attempt(s): %s", d.channel, attempt, sanitizeDeliveryError(err))
 			return
 		}
 		notifyRetries.WithLabelValues(d.channel).Inc()
@@ -99,7 +133,7 @@ func (d *deliverer) deliver(ev core.NotificationEvent) {
 		case <-time.After(backoff):
 		case <-d.closing:
 			notifyDeliveries.WithLabelValues(d.channel, outcomeFailed).Inc()
-			log.Printf("notifychan: %s delivery abandoned on shutdown after %d attempt(s): %v", d.channel, attempt, err)
+			log.Printf("notifychan: %s delivery abandoned on shutdown after %d attempt(s): %s", d.channel, attempt, sanitizeDeliveryError(err))
 			return
 		}
 		backoff *= 2

--- a/internal/notifychan/delivery_test.go
+++ b/internal/notifychan/delivery_test.go
@@ -1,0 +1,70 @@
+package notifychan
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSanitizeDeliveryError_StripsTokenFromTransportError proves the #329 fix at
+// the unit level: Go's *url.Error.Error() — exactly what http.Client returns on a
+// transport-level failure (dial/timeout/TLS), the routine case a delivery-failure
+// log line exists to report — embeds the full request URL, including a Slack/Teams
+// incoming-webhook's bearer token (a URL path segment, not a header). The sanitized
+// rendering must drop the token and path while keeping the host for diagnostics.
+func TestSanitizeDeliveryError_StripsTokenFromTransportError(t *testing.T) {
+	tokenURL := "https://hooks.slack.com/services/T000/B000/xoxb-super-secret-token"
+	transportErr := &url.Error{Op: "Post", URL: tokenURL, Err: fmt.Errorf("dial tcp: connection refused")}
+
+	got := sanitizeDeliveryError(transportErr)
+
+	assert.NotContains(t, got, "xoxb-super-secret-token")
+	assert.NotContains(t, got, "/services/T000/B000")
+	assert.Contains(t, got, "hooks.slack.com", "host should be kept for diagnostic value")
+	assert.Contains(t, got, "connection refused")
+}
+
+// TestSanitizeDeliveryError_PassesThroughURLFreeError proves the sanitizer is a
+// no-op for an error that carries no embedded URL, so ordinary (non-webhook-URL)
+// failure messages are unaffected.
+func TestSanitizeDeliveryError_PassesThroughURLFreeError(t *testing.T) {
+	err := fmt.Errorf("teams webhook returned 503 Service Unavailable")
+	assert.Equal(t, err.Error(), sanitizeDeliveryError(err))
+}
+
+func TestSanitizeDeliveryError_NilErrReturnsEmptyString(t *testing.T) {
+	assert.Equal(t, "", sanitizeDeliveryError(nil))
+}
+
+// TestChatSink_DeliveryFailureLogDoesNotLeakWebhookToken is the end-to-end
+// regression for #329: a real transport failure (connection refused against a
+// closed loopback port — no mocking of *url.Error) against a webhook URL carrying
+// an embedded token must produce a log line that contains no trace of the token.
+func TestChatSink_DeliveryFailureLogDoesNotLeakWebhookToken(t *testing.T) {
+	const token = "xoxb-topsecret-1234567890"
+	// Loopback http is allowed without insecure_skip_verify (see validateEndpoint);
+	// port 1 is not listening, so every attempt fails fast with a genuine *url.Error.
+	badURL := "http://127.0.0.1:1/services/T000/B000/" + token
+
+	var buf bytes.Buffer
+	orig := log.Writer()
+	log.SetOutput(&buf)
+	defer log.SetOutput(orig)
+
+	sink, err := newChat(ChatConfig{Kind: ChatSlack, WebhookURL: badURL}, time.Millisecond)
+	require.NoError(t, err)
+	sink.Deliver(core.NotificationEvent{Title: "x", Message: "y"})
+	sink.Close() // blocks until the worker (incl. its log.Printf calls) has finished
+
+	logged := buf.String()
+	assert.Contains(t, logged, "notifychan:", "sanity: the failure path should still log something")
+	assert.NotContains(t, logged, token, "the webhook's embedded bearer token must never reach the log stream")
+	assert.NotContains(t, logged, "services/T000/B000", "the webhook's path (which carries the token) must never reach the log stream")
+}


### PR DESCRIPTION
## Summary
- **#328 HIGH** — `internal/notifychan/chat.go` interpolated `ev.Title`/`ev.Message` into the Slack `text`/Teams `MessageCard.text` fields with zero markdown escaping. Any ordinary, non-admin secret **owner** can name a secret with Slack mrkdwn control syntax (`<!channel>`, `<@USERID>`, `<url|label>`) and `ShareSecret` it with any project member — `notifySecretShared` embeds the secret's raw name verbatim, so the crafted name reaches the org's own trusted Slack/Teams integration as live markup (mass-ping + spoofed clickable link). Fixed at the single choke point (`chatText`/`chatPayload`) rather than per call site, so it also covers the lower-severity admin/system-triggered paths (`compliance_digest.go`, `rotation_executor.go`) for free — and along the way fixes a pre-existing bug where Teams' `text` field bypassed `chatText` entirely (no title/link formatting, and no escaping).
- **#329 MEDIUM** — a Slack/Teams incoming-webhook URL *is* the bearer credential (token is a path segment, not a header). On a transient transport failure, Go's `*url.Error.Error()` embeds the full request URL, and `delivery.go` logged it unmodified — an ordinary network hiccup wrote the live webhook token to the log stream. `sanitizeDeliveryError` now redacts any embedded `http(s)` URL down to scheme+host before either delivery-failure log line, keeping enough context (which host failed) without leaking the credential.

Verified against current `origin/main`: neither fix was present (an earlier, related mrkdwn-escaping fix for #158 exists but is still an *open*, unmerged PR — #565 — so main was fully unescaped at HEAD).

## Test plan
- [x] New regression tests: `TestChatSink_EscapesMrkdwnInjectionFromSecretName` (Slack + Teams, using the exact #328 exploit trace against a captured HTTP payload), `TestChatSink_EscapesMrkdwnInjectionInTitle`, `TestSanitizeDeliveryError_StripsTokenFromTransportError`, `TestChatSink_DeliveryFailureLogDoesNotLeakWebhookToken` (real transport failure against a token-bearing URL, asserts the captured log output).
- [x] `go build ./...` clean
- [x] `go test ./...` clean (one known unrelated flake, `TestHTTPJWKSResolver_CapsKeyCount` in `internal/core`, confirmed passing in isolation)
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues
- [x] `golangci-lint run ./...` — 0 issues
- [x] `GOWORK=off go build -C operator ./...` — clean