### PR TITLE
fix: close systemic compliance-posture fail-open across all sub-checks (#136 HIGH)

### DIFF
--- a/internal/cli/compliance/compliance.go
+++ b/internal/cli/compliance/compliance.go
@@ -90,6 +90,11 @@ type posture struct {
 		BreakGlassDays             int  `json:"break_glass_days"`
 		ResolvedAccessRequestsDays int  `json:"resolved_access_requests_days"`
 	} `json:"retention"`
+	// Degraded/DegradedReasons (#136): true when one or more sub-rollups above could
+	// not be queried this run — their fields hold an UNKNOWN zero value, not a
+	// verified-clean one. Must be surfaced to the operator, not silently dropped.
+	Degraded        bool     `json:"degraded"`
+	DegradedReasons []string `json:"degraded_reasons"`
 }
 
 // retDays renders a retention window: a day count, or "keep" when 0 (disabled).
@@ -121,6 +126,15 @@ var reportCmd = &cobra.Command{
 			return err
 		}
 		fmt.Printf("Compliance posture — %s\n\n", p.GeneratedAt)
+
+		if p.Degraded {
+			fmt.Println("*** DEGRADED SNAPSHOT — one or more controls could not be collected this run ***")
+			fmt.Println("*** Affected fields below hold an UNKNOWN value, NOT a verified-clean one.   ***")
+			for _, reason := range p.DegradedReasons {
+				fmt.Printf("    - %s\n", reason)
+			}
+			fmt.Println()
+		}
 
 		fmt.Println("Audit integrity (ADR-029)")
 		fmt.Printf("  chain verified : %s (%d chained events)\n", yesNo(p.AuditIntegrity.ChainVerified), p.AuditIntegrity.ChainedEvents)
@@ -228,6 +242,9 @@ type controlMatrix struct {
 		Pass          int `json:"pass"`
 		Gap           int `json:"gap"`
 		NotConfigured int `json:"not_configured"`
+		// Unknown (#136) counts controls whose signal could not be collected this
+		// run — a non-zero value means the matrix is incomplete, not fully passing.
+		Unknown int `json:"unknown"`
 	} `json:"summary"`
 	Controls []struct {
 		Name       string `json:"name"`
@@ -249,6 +266,11 @@ func statusMark(s string) string {
 		return "PASS"
 	case "gap":
 		return "GAP "
+	// #136: "unknown" (collection failed this run) is deliberately distinct from
+	// "not_configured" (the default "n/a ") — an operator must not read a failed
+	// collection as an optional control that simply isn't in use.
+	case "unknown":
+		return "UNK "
 	default:
 		return "n/a "
 	}
@@ -296,7 +318,11 @@ var controlsCmd = &cobra.Command{
 			return err
 		}
 		fmt.Printf("Control matrix — %s\n", m.GeneratedAt)
-		fmt.Printf("  %d controls: %d pass, %d gap, %d not-configured\n\n", m.Summary.Total, m.Summary.Pass, m.Summary.Gap, m.Summary.NotConfigured)
+		fmt.Printf("  %d controls: %d pass, %d gap, %d not-configured, %d unknown\n", m.Summary.Total, m.Summary.Pass, m.Summary.Gap, m.Summary.NotConfigured, m.Summary.Unknown)
+		if m.Summary.Unknown > 0 {
+			fmt.Println("  *** one or more controls could not be collected this run (UNK) — treat this matrix as incomplete, not passing ***")
+		}
+		fmt.Println()
 		for _, ctrl := range m.Controls {
 			fmt.Printf("[%s] %s (%s)\n", statusMark(ctrl.Status), ctrl.Name, ctrl.Area)
 			fmt.Printf("        %s\n", ctrl.Detail)

--- a/internal/core/certificate_expiry.go
+++ b/internal/core/certificate_expiry.go
@@ -141,9 +141,10 @@ func (c *KeyorixCore) listCertificateSecrets(ctx context.Context) ([]*models.Sec
 // certificatePosture reports certificate hygiene for the compliance posture (ADR-056)
 // from the cached cert expiry — no decryption on this path. Certificates not yet
 // evaluated (cache nil) are counted separately so the gap is visible.
-func (c *KeyorixCore) certificatePosture(ctx context.Context) CertificatePosture {
+func (c *KeyorixCore) certificatePosture(ctx context.Context, cp *CompliancePosture) CertificatePosture {
 	certs, err := c.listCertificateSecrets(ctx)
 	if err != nil {
+		cp.degrade("certificates", err)
 		return CertificatePosture{}
 	}
 	now := c.now()

--- a/internal/core/certificate_expiry_test.go
+++ b/internal/core/certificate_expiry_test.go
@@ -117,7 +117,7 @@ func TestCertificatePosture(t *testing.T) {
 	c, db, _ := newCertExpiryCore(t)
 
 	// Before any scan/inspection, no cert has a cached expiry → all "not evaluated".
-	pre := c.certificatePosture(ctx)
+	pre := c.certificatePosture(ctx, &CompliancePosture{})
 	assert.Equal(t, 4, pre.TotalCertificates)
 	assert.Equal(t, 4, pre.NotEvaluated)
 	assert.Equal(t, 0, pre.Expired)
@@ -127,7 +127,7 @@ func TestCertificatePosture(t *testing.T) {
 	_, err := c.ScanCertificateExpiry(ctx, 30)
 	require.NoError(t, err)
 
-	post := c.certificatePosture(ctx)
+	post := c.certificatePosture(ctx, &CompliancePosture{})
 	assert.Equal(t, 4, post.TotalCertificates)
 	assert.Equal(t, 1, post.Expired)
 	assert.Equal(t, 1, post.ExpiringSoon)

--- a/internal/core/classify_dynamic_test.go
+++ b/internal/core/classify_dynamic_test.go
@@ -75,7 +75,7 @@ func TestClassificationPosture_CoversDynamicConfigs(t *testing.T) {
 	makeDynConfig(t, c, "c", ClassificationInternal)
 	makeDynConfig(t, c, "d", "") // unclassified
 
-	p := c.classificationPosture(context.Background())
+	p := c.classificationPosture(context.Background(), &CompliancePosture{})
 	assert.Equal(t, 4, p.DynamicConfigs.Total)
 	assert.Equal(t, 2, p.DynamicConfigs.Restricted)
 	assert.Equal(t, 1, p.DynamicConfigs.Internal)

--- a/internal/core/classify_machine_test.go
+++ b/internal/core/classify_machine_test.go
@@ -90,7 +90,7 @@ func TestClassificationPosture_CoversMachineEntities(t *testing.T) {
 	store.On("CountMachineIdentitiesByClassification", mock.Anything).Return(map[string]int{"restricted": 2, "": 1}, nil)
 	store.On("CountMachineIdentityCredentialsByClassification", mock.Anything).Return(map[string]int{"confidential": 3}, nil)
 
-	p := c.classificationPosture(context.Background())
+	p := c.classificationPosture(context.Background(), &CompliancePosture{})
 	assert.Equal(t, 3, p.MachineIdentities.Total)
 	assert.Equal(t, 2, p.MachineIdentities.Restricted)
 	assert.Equal(t, 1, p.MachineIdentities.Unclassified)

--- a/internal/core/compliance_digest.go
+++ b/internal/core/compliance_digest.go
@@ -30,8 +30,8 @@ func (c *KeyorixCore) BuildComplianceDigest(ctx context.Context) (title, body st
 // formatComplianceDigest renders the digest from a posture snapshot + evaluated
 // controls. Pure (no storage) so it is unit-testable.
 func formatComplianceDigest(p *CompliancePosture, controls []ControlState) (title, body string) {
-	pass, gap := 0, 0
-	var gaps []string
+	pass, gap, unknown := 0, 0, 0
+	var gaps, unknowns []string
 	for _, ctrl := range controls {
 		switch ctrl.Status {
 		case ControlStatusPass:
@@ -39,17 +39,32 @@ func formatComplianceDigest(p *CompliancePosture, controls []ControlState) (titl
 		case ControlStatusGap:
 			gap++
 			gaps = append(gaps, ctrl.Name)
+		case ControlStatusUnknown:
+			unknown++
+			unknowns = append(unknowns, ctrl.Name)
 		}
 	}
 
-	title = fmt.Sprintf("Keyorix compliance digest — %d/%d controls pass", pass, len(controls))
-	if gap > 0 {
+	// #136: a degraded snapshot must be the headline, not a footnote — a collection
+	// failure means this digest is incomplete, and a reader skimming Slack/Teams must
+	// not read "N/N controls pass" as a clean bill of health when it isn't one.
+	switch {
+	case p.Degraded:
+		title = fmt.Sprintf("Keyorix compliance digest — INCOMPLETE (%d control(s) unknown, collection error)", unknown)
+	case gap > 0:
 		title = fmt.Sprintf("Keyorix compliance digest — %d gap%s across %d controls", gap, plural(gap), len(controls))
+	default:
+		title = fmt.Sprintf("Keyorix compliance digest — %d/%d controls pass", pass, len(controls))
 	}
 
 	var b strings.Builder
 	ag := p.AccessGovernance
-	fmt.Fprintf(&b, "Controls: %d pass, %d gap (of %d).\n", pass, gap, len(controls))
+	if p.Degraded {
+		fmt.Fprintf(&b, "WARNING: this snapshot is DEGRADED — %d control(s) could not be collected this run and read as UNKNOWN, not verified-clean: %s.\n",
+			unknown, strings.Join(unknowns, ", "))
+		fmt.Fprintf(&b, "Collection failures: %s.\n", strings.Join(p.DegradedReasons, "; "))
+	}
+	fmt.Fprintf(&b, "Controls: %d pass, %d gap, %d unknown (of %d).\n", pass, gap, unknown, len(controls))
 	if gap > 0 {
 		fmt.Fprintf(&b, "Open gaps: %s.\n", strings.Join(gaps, ", "))
 	}

--- a/internal/core/compliance_evidence.go
+++ b/internal/core/compliance_evidence.go
@@ -81,13 +81,26 @@ func (c *KeyorixCore) GenerateComplianceEvidence(ctx context.Context) (*Complian
 	}
 
 	// Active risk exceptions (the governed-acceptance register).
+	//
+	// #136: each evidence sub-query below is independently re-queried from the posture
+	// rollup (e.g. ListRiskExceptions here vs. CountActiveRiskExceptions in
+	// GetCompliancePosture) and previously had the same no-else fail-open shape: a
+	// query error silently left the evidence-pack slice empty, indistinguishable from
+	// "queried, found none" in the HMAC-signed pack an auditor trusts. Every failure
+	// here now flips the shared posture.Degraded signal via posture.degrade, so a
+	// consumer checking ev.Posture.Degraded catches evidence-pack-level failures too,
+	// not just posture-rollup ones.
 	if exceptions, err := c.ListRiskExceptions(ctx, true); err == nil {
 		ev.RiskExceptions = exceptions
+	} else {
+		posture.degrade("evidence:risk_exceptions", err)
 	}
 
 	// Separation-of-duties violations (the toxic-combination register).
 	if violations, err := c.DetectSoDViolations(ctx); err == nil {
 		ev.SoDViolations = violations
+	} else {
+		posture.degrade("evidence:sod_violations", err)
 	}
 
 	// Audit anchor.
@@ -96,6 +109,8 @@ func (c *KeyorixCore) GenerateComplianceEvidence(ctx context.Context) (*Complian
 			Valid: v.Valid, ChainedEvents: v.ChainedEvents,
 			HeadID: v.HeadID, HeadHash: v.HeadHash, Checkpointed: v.Checkpointed,
 		}
+	} else if err != nil {
+		posture.degrade("evidence:audit_anchor", err)
 	}
 
 	// Overdue rotations (deployment-wide).
@@ -108,6 +123,8 @@ func (c *KeyorixCore) GenerateComplianceEvidence(ctx context.Context) (*Complian
 				})
 			}
 		}
+	} else {
+		posture.degrade("evidence:rotation_overdue", err)
 	}
 
 	// Campaigns + break-glass register, per project.
@@ -126,9 +143,13 @@ func (c *KeyorixCore) GenerateComplianceEvidence(ctx context.Context) (*Complian
 					Revoked: cw.Progress.Revoked, Pending: cw.Progress.Pending,
 				})
 			}
+		} else {
+			posture.degrade(fmt.Sprintf("evidence:campaigns:project=%d", pid), err)
 		}
 		if acts, err := c.ListBreakGlassActivations(ctx, pid); err == nil {
 			ev.BreakGlass = append(ev.BreakGlass, acts...)
+		} else {
+			posture.degrade(fmt.Sprintf("evidence:break_glass:project=%d", pid), err)
 		}
 	}
 	return ev, nil

--- a/internal/core/compliance_posture.go
+++ b/internal/core/compliance_posture.go
@@ -150,6 +150,13 @@ type CertificatePosture struct {
 }
 
 // CompliancePosture is the deployment's control posture at a point in time.
+//
+// #136: every sub-rollup is queried best-effort so one failing signal doesn't abort
+// the whole snapshot — but a query failure must never read the same as "checked,
+// found clean" (e.g. LegalHold.Active=false on a DB error looks identical to no hold
+// in effect, and this snapshot gets HMAC-signed into evidence packs an auditor
+// trusts). Degraded + DegradedReasons make a partial snapshot detectable instead of
+// indistinguishable from a fully-clean one.
 type CompliancePosture struct {
 	GeneratedAt      time.Time               `json:"generated_at"`
 	AuditIntegrity   AuditIntegrityPosture   `json:"audit_integrity"`
@@ -164,6 +171,20 @@ type CompliancePosture struct {
 	Risk             RiskPosture             `json:"risk"`
 	Certificates     CertificatePosture      `json:"certificates"`
 	SupplyChain      SupplyChainPosture      `json:"supply_chain"`
+	// Degraded is true when one or more sub-rollups below could not be queried — the
+	// zero/clean values they carry are UNKNOWN, not verified-clean. An evidence pack
+	// consumer must treat a degraded snapshot as incomplete, not passing.
+	Degraded bool `json:"degraded"`
+	// DegradedReasons names each failed sub-rollup with its underlying error.
+	DegradedReasons []string `json:"degraded_reasons,omitempty"`
+}
+
+// degrade records that a posture sub-rollup could not be queried: it flips Degraded
+// and appends a human-readable reason, so evidence packs signal "incomplete" instead
+// of silently reading the affected fields as a verified-clean zero value.
+func (p *CompliancePosture) degrade(area string, err error) {
+	p.Degraded = true
+	p.DegradedReasons = append(p.DegradedReasons, fmt.Sprintf("%s: %v", area, err))
 }
 
 // SupplyChainPosture reports software-supply-chain integrity: whether this deployment
@@ -206,11 +227,14 @@ func (c *KeyorixCore) GetCompliancePosture(ctx context.Context) (*CompliancePost
 		}
 	} else if err != nil {
 		p.AuditIntegrity.Reason = err.Error()
+		p.degrade("audit_integrity", err)
 	}
 
 	// Second-factor coverage across active users.
 	if id, err := c.identityPosture(ctx); err == nil {
 		p.Identity = id
+	} else {
+		p.degrade("identity", err)
 	}
 
 	// Rotation hygiene (deployment-wide).
@@ -224,6 +248,8 @@ func (c *KeyorixCore) GetCompliancePosture(ctx context.Context) (*CompliancePost
 				p.Rotation.DueSoon++
 			}
 		}
+	} else {
+		p.degrade("rotation", err)
 	}
 
 	// Access governance + emergency access — per project.
@@ -234,10 +260,12 @@ func (c *KeyorixCore) GetCompliancePosture(ctx context.Context) (*CompliancePost
 	// Separation-of-duties violations (A.5.3).
 	if violations, err := c.DetectSoDViolations(ctx); err == nil {
 		p.AccessGovernance.SoDViolations = len(violations)
+	} else {
+		p.degrade("sod_violations", err)
 	}
 
 	// Data-classification coverage (A.5.12).
-	p.Classification = c.classificationPosture(ctx)
+	p.Classification = c.classificationPosture(ctx, p)
 
 	// Open access anomalies (NIS2 detection).
 	unack := false
@@ -248,21 +276,29 @@ func (c *KeyorixCore) GetCompliancePosture(ctx context.Context) (*CompliancePost
 				p.Anomalies.HighSeverityOpen++
 			}
 		}
+	} else {
+		p.degrade("anomalies", err)
 	}
 
 	// Legal hold (A.5.34).
-	if hold, err := c.storage.GetActiveLegalHold(ctx); err == nil && hold != nil {
-		at := hold.PlacedAt
-		p.LegalHold = LegalHoldPosture{Active: true, PlacedAt: &at, Reason: hold.Reason}
+	if hold, err := c.storage.GetActiveLegalHold(ctx); err == nil {
+		if hold != nil {
+			at := hold.PlacedAt
+			p.LegalHold = LegalHoldPosture{Active: true, PlacedAt: &at, Reason: hold.Reason}
+		}
+	} else {
+		p.degrade("legal_hold", err)
 	}
 
 	// Risk register — governed, time-bound exceptions (A.5.8).
 	if active, soon, err := c.CountActiveRiskExceptions(ctx, riskExpiringSoonWindow); err == nil {
 		p.Risk = RiskPosture{ActiveExceptions: active, ExpiringSoon: soon}
+	} else {
+		p.degrade("risk", err)
 	}
 
 	// Certificate hygiene from the cached cert expiry (ADR-056).
-	p.Certificates = c.certificatePosture(ctx)
+	p.Certificates = c.certificatePosture(ctx, p)
 
 	// Data-retention windows (A.5.33).
 	rp := c.retentionPolicy
@@ -292,7 +328,9 @@ func (c *KeyorixCore) GetCompliancePosture(ctx context.Context) (*CompliancePost
 
 // classificationPosture counts secrets per classification level via cheap count
 // queries (PageSize 1 → only the total), rather than walking every secret row.
-func (c *KeyorixCore) classificationPosture(ctx context.Context) ClassificationPosture {
+// Reports into cp.degrade on any failed count so a query error reads as "unknown",
+// not as a verified-zero count for that classification/entity kind.
+func (c *KeyorixCore) classificationPosture(ctx context.Context, cp *CompliancePosture) ClassificationPosture {
 	count := func(level string) int {
 		f := &storage.SecretFilter{Page: 1, PageSize: 1}
 		if level != "" {
@@ -301,6 +339,7 @@ func (c *KeyorixCore) classificationPosture(ctx context.Context) ClassificationP
 		}
 		_, total, err := c.storage.ListSecrets(ctx, f)
 		if err != nil {
+			cp.degrade("classification:secrets:"+level, err)
 			return 0
 		}
 		return int(total)
@@ -315,12 +354,18 @@ func (c *KeyorixCore) classificationPosture(ctx context.Context) ClassificationP
 	}
 	if m, err := c.storage.CountDynamicSecretConfigsByClassification(ctx); err == nil {
 		p.DynamicConfigs = classificationCountsFromMap(m)
+	} else {
+		cp.degrade("classification:dynamic_configs", err)
 	}
 	if m, err := c.storage.CountMachineIdentitiesByClassification(ctx); err == nil {
 		p.MachineIdentities = classificationCountsFromMap(m)
+	} else {
+		cp.degrade("classification:machine_identities", err)
 	}
 	if m, err := c.storage.CountMachineIdentityCredentialsByClassification(ctx); err == nil {
 		p.MachineCredentials = classificationCountsFromMap(m)
+	} else {
+		cp.degrade("classification:machine_credentials", err)
 	}
 	return p
 }
@@ -387,9 +432,11 @@ func (c *KeyorixCore) accessGovernancePosture(ctx context.Context, p *Compliance
 					p.AccessGovernance.ProjectsOverdue++
 				}
 			}
+		} else {
+			p.degrade(fmt.Sprintf("access_governance:campaigns:project=%d", pid), err)
 		}
 
-		p.AccessGovernance.DormantRoleGrants += c.countDormantRoleGrants(ctx, pid)
+		p.AccessGovernance.DormantRoleGrants += c.countDormantRoleGrants(ctx, pid, p)
 
 		if acts, err := c.ListBreakGlassActivations(ctx, pid); err == nil {
 			p.EmergencyAccess.TotalActivations += len(acts)
@@ -398,6 +445,8 @@ func (c *KeyorixCore) accessGovernancePosture(ctx context.Context, p *Compliance
 					p.EmergencyAccess.ActiveActivations++
 				}
 			}
+		} else {
+			p.degrade(fmt.Sprintf("emergency_access:project=%d", pid), err)
 		}
 	}
 	return nil
@@ -406,13 +455,15 @@ func (c *KeyorixCore) accessGovernancePosture(ctx context.Context, p *Compliance
 // countDormantRoleGrants counts distinct users holding a role grant in the project
 // who have not accessed a secret recently (or ever) — stale standing access. Cheap:
 // the project's role assignments + the last-activity map, no full secret walk.
-func (c *KeyorixCore) countDormantRoleGrants(ctx context.Context, projectID uint) int {
+func (c *KeyorixCore) countDormantRoleGrants(ctx context.Context, projectID uint, cp *CompliancePosture) int {
 	assignments, err := c.storage.ListProjectRoleAssignments(ctx, projectID)
 	if err != nil {
+		cp.degrade(fmt.Sprintf("dormant_role_grants:assignments:project=%d", projectID), err)
 		return 0
 	}
 	activity, err := c.storage.LastUserSecretActivity(ctx, projectID)
 	if err != nil {
+		cp.degrade(fmt.Sprintf("dormant_role_grants:activity:project=%d", projectID), err)
 		return 0
 	}
 	cutoff := c.now().Add(-dormantThreshold)

--- a/internal/core/compliance_posture.go
+++ b/internal/core/compliance_posture.go
@@ -9,6 +9,7 @@ package core
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/core/storage"
@@ -185,6 +186,22 @@ type CompliancePosture struct {
 func (p *CompliancePosture) degrade(area string, err error) {
 	p.Degraded = true
 	p.DegradedReasons = append(p.DegradedReasons, fmt.Sprintf("%s: %v", area, err))
+}
+
+// DegradedArea reports whether any recorded DegradedReasons entry names an area
+// starting with one of the given prefixes — i.e. whether the specific signal a
+// consumer (e.g. the control-framework matrix) depends on failed to collect this
+// run. Used so a downstream "pass/gap" evaluation derived from a degraded field
+// can surface as unknown rather than silently trusting the field's zero value.
+func (p *CompliancePosture) DegradedArea(prefixes ...string) bool {
+	for _, reason := range p.DegradedReasons {
+		for _, prefix := range prefixes {
+			if strings.HasPrefix(reason, prefix) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // SupplyChainPosture reports software-supply-chain integrity: whether this deployment

--- a/internal/core/compliance_posture_test.go
+++ b/internal/core/compliance_posture_test.go
@@ -54,6 +54,66 @@ func TestGetCompliancePosture_DegradedOnLegalHoldQueryError(t *testing.T) {
 	assert.False(t, p.LegalHold.Active, "the field itself still reads as its zero value")
 	assert.True(t, p.Degraded, "a failed legal-hold query must flip Degraded — the zero value above is UNKNOWN, not verified-clean")
 	assert.True(t, containsSubstring(p.DegradedReasons, "legal_hold"), "expected a legal_hold entry in DegradedReasons, got %v", p.DegradedReasons)
+
+	controls, err := c.GetComplianceControls(context.Background())
+	require.NoError(t, err)
+	lh := findControl(t, controls.Controls, "legal-hold")
+	assert.Equal(t, ControlStatusUnknown, lh.Status, "the legal-hold CONTROL must surface as unknown, not silently pass, when its posture signal is degraded")
+}
+
+// failingRiskExceptionsStore wraps LocalStorage and fails ListRiskExceptions, simulating
+// a DB error on the risk-exception sub-rollup.
+type failingRiskExceptionsStore struct {
+	*store.LocalStorage
+}
+
+func (s *failingRiskExceptionsStore) ListRiskExceptions(_ context.Context, _ bool) ([]*models.RiskException, error) {
+	return nil, errors.New("simulated db failure")
+}
+
+// #136: empirically, dropping the risk_exceptions table flipped a real active exception
+// from count=1 to count=0 — a query failure must surface as Degraded, not a silently-clean
+// zero count.
+func TestGetCompliancePosture_DegradedOnRiskExceptionQueryError(t *testing.T) {
+	c := compliancePostureCore(t)
+	c.storage = &failingRiskExceptionsStore{LocalStorage: c.storage.(*store.LocalStorage)}
+
+	p, err := c.GetCompliancePosture(context.Background())
+	require.NoError(t, err, "a single failed sub-rollup must not abort the whole snapshot")
+
+	assert.Equal(t, 0, p.Risk.ActiveExceptions, "the field itself still reads as its zero value")
+	assert.True(t, p.Degraded, "a failed risk-exception query must flip Degraded")
+	assert.True(t, containsSubstring(p.DegradedReasons, "risk"), "expected a risk entry in DegradedReasons, got %v", p.DegradedReasons)
+}
+
+// failingSoDPoliciesStore wraps LocalStorage and fails ListSoDPolicies, simulating a DB
+// error on the SoD sub-rollup.
+type failingSoDPoliciesStore struct {
+	*store.LocalStorage
+}
+
+func (s *failingSoDPoliciesStore) ListSoDPolicies(_ context.Context) ([]*models.SoDPolicy, error) {
+	return nil, errors.New("simulated db failure")
+}
+
+// #136: empirically, dropping the sod_policies table flipped a real toxic-combination
+// violation from count>=1 to count=0 — a query failure must surface as Degraded, not a
+// silently-clean zero count.
+func TestGetCompliancePosture_DegradedOnSoDPoliciesQueryError(t *testing.T) {
+	c := compliancePostureCore(t)
+	c.storage = &failingSoDPoliciesStore{LocalStorage: c.storage.(*store.LocalStorage)}
+
+	p, err := c.GetCompliancePosture(context.Background())
+	require.NoError(t, err, "a single failed sub-rollup must not abort the whole snapshot")
+
+	assert.Equal(t, 0, p.AccessGovernance.SoDViolations, "the field itself still reads as its zero value")
+	assert.True(t, p.Degraded, "a failed SoD-policy query must flip Degraded")
+	assert.True(t, containsSubstring(p.DegradedReasons, "sod_violations"), "expected a sod_violations entry in DegradedReasons, got %v", p.DegradedReasons)
+
+	controls, err := c.GetComplianceControls(context.Background())
+	require.NoError(t, err)
+	sod := findControl(t, controls.Controls, "separation-of-duties")
+	assert.Equal(t, ControlStatusUnknown, sod.Status, "the SoD CONTROL must surface as unknown, not silently pass, when its posture signal is degraded")
 }
 
 func containsSubstring(ss []string, sub string) bool {

--- a/internal/core/compliance_posture_test.go
+++ b/internal/core/compliance_posture_test.go
@@ -1,0 +1,66 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// compliancePostureCore builds a bare KeyorixCore against a real (empty) sqlite DB —
+// only models.Project is migrated, since accessGovernancePosture's ListProjects is the
+// one call GetCompliancePosture treats as fatal; every other sub-rollup query errors
+// (e.g. from a missing table) are expected to soft-fail into Degraded, not abort.
+func compliancePostureCore(t *testing.T) *KeyorixCore {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.Project{}))
+	c := &KeyorixCore{storage: store.NewLocalStorage(db)}
+	c.now = func() time.Time { return time.Date(2026, 7, 2, 12, 0, 0, 0, time.UTC) }
+	return c
+}
+
+// failingLegalHoldStore wraps LocalStorage and fails GetActiveLegalHold, simulating a DB
+// error on that one sub-rollup while every other posture query still runs for real.
+type failingLegalHoldStore struct {
+	*store.LocalStorage
+}
+
+func (s *failingLegalHoldStore) GetActiveLegalHold(_ context.Context) (*models.LegalHold, error) {
+	return nil, errors.New("simulated db failure")
+}
+
+// #136: before the fix, a failed legal-hold query left LegalHold.Active=false —
+// byte-identical to "queried, no hold in effect". That's the most dangerous instance of
+// the fail-open pattern: it's the signal purge jobs would otherwise trust to preserve
+// records under hold, and it feeds an HMAC-signed evidence pack an auditor trusts. A query
+// failure must surface as Degraded, not as a silently-clean zero value.
+func TestGetCompliancePosture_DegradedOnLegalHoldQueryError(t *testing.T) {
+	c := compliancePostureCore(t)
+	c.storage = &failingLegalHoldStore{LocalStorage: c.storage.(*store.LocalStorage)}
+
+	p, err := c.GetCompliancePosture(context.Background())
+	require.NoError(t, err, "a single failed sub-rollup must not abort the whole snapshot")
+
+	assert.False(t, p.LegalHold.Active, "the field itself still reads as its zero value")
+	assert.True(t, p.Degraded, "a failed legal-hold query must flip Degraded — the zero value above is UNKNOWN, not verified-clean")
+	assert.True(t, containsSubstring(p.DegradedReasons, "legal_hold"), "expected a legal_hold entry in DegradedReasons, got %v", p.DegradedReasons)
+}
+
+func containsSubstring(ss []string, sub string) bool {
+	for _, s := range ss {
+		if strings.Contains(s, sub) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/core/control_framework.go
+++ b/internal/core/control_framework.go
@@ -19,6 +19,13 @@ const (
 	ControlStatusPass          ControlStatus = "pass"
 	ControlStatusGap           ControlStatus = "gap"
 	ControlStatusNotConfigured ControlStatus = "not_configured"
+	// ControlStatusUnknown marks a control whose underlying signal could not be
+	// collected this run (its posture sub-rollup query failed — see
+	// CompliancePosture.Degraded). #136: a failed collection must never silently
+	// read as "pass" just because the zero-value field it's evaluated from looks
+	// clean — an auditor relying on this matrix needs to see "unknown", not a false
+	// "pass".
+	ControlStatusUnknown ControlStatus = "unknown"
 )
 
 // FrameworkRefs maps a control to clauses across the regimes Keyorix targets.
@@ -49,6 +56,9 @@ type ControlsSummary struct {
 	Pass          int `json:"pass"`
 	Gap           int `json:"gap"`
 	NotConfigured int `json:"not_configured"`
+	// Unknown counts controls whose signal could not be collected this run (#136) —
+	// a non-zero value here means the matrix is incomplete, not fully passing.
+	Unknown int `json:"unknown"`
 }
 
 // ComplianceControls is the evaluated control matrix at a point in time.
@@ -75,9 +85,22 @@ func (c *KeyorixCore) GetComplianceControls(ctx context.Context) (*ComplianceCon
 			out.Summary.Gap++
 		case ControlStatusNotConfigured:
 			out.Summary.NotConfigured++
+		case ControlStatusUnknown:
+			out.Summary.Unknown++
 		}
 	}
 	return out, nil
+}
+
+// controlStatus evaluates a control's status, but overrides to ControlStatusUnknown
+// whenever `degraded` is true — i.e. whenever the posture sub-rollup(s) this control
+// depends on failed to collect this run (#136). `bad` (the ordinary gapIf input) is
+// only trusted when the underlying signal is known-good.
+func controlStatus(degraded, bad bool) ControlStatus {
+	if degraded {
+		return ControlStatusUnknown
+	}
+	return gapIf(bad)
 }
 
 // gapIf returns Gap when bad is true, else Pass — the common two-state evaluation.
@@ -96,61 +119,63 @@ func EvaluateControls(p *CompliancePosture) []ControlState {
 	return []ControlState{
 		{
 			ID: "audit-trail-integrity", Name: "Tamper-evident audit trail", Area: "Audit & accountability",
-			Status:     gapIf(!p.AuditIntegrity.ChainVerified),
+			Status:     controlStatus(p.DegradedArea("audit_integrity"), !p.AuditIntegrity.ChainVerified),
 			Detail:     fmt.Sprintf("chain verified=%t, checkpointed=%t, %d events", p.AuditIntegrity.ChainVerified, p.AuditIntegrity.Checkpointed, p.AuditIntegrity.ChainedEvents),
 			Frameworks: FrameworkRefs{ISO27001: []string{"A.5.28", "A.8.15"}, SOC2: []string{"CC7.2", "CC4.1"}, NIS2: []string{"Art.21(2)(i)"}, DORA: []string{"Art.9"}, ENS: []string{"op.exp.8", "op.exp.10"}},
 		},
 		{
 			ID: "access-recertification", Name: "Access recertification at planned intervals", Area: "Access governance",
-			Status:     gapIf(ag.ProjectsOverdue > 0 || ag.ProjectsNeverReviewed > 0),
+			Status:     controlStatus(p.DegradedArea("access_governance:campaigns:"), ag.ProjectsOverdue > 0 || ag.ProjectsNeverReviewed > 0),
 			Detail:     fmt.Sprintf("%d overdue, %d never reviewed, %d pending items", ag.ProjectsOverdue, ag.ProjectsNeverReviewed, ag.PendingItems),
 			Frameworks: FrameworkRefs{ISO27001: []string{"A.5.18"}, SOC2: []string{"CC6.2", "CC6.3"}, NIS2: []string{"Art.21(2)(i)"}, DORA: []string{"Art.9"}, ENS: []string{"op.acc.4"}},
 		},
 		{
 			ID: "dormant-access", Name: "No dormant standing access", Area: "Access governance",
-			Status:     gapIf(ag.DormantRoleGrants > 0),
+			Status:     controlStatus(p.DegradedArea("dormant_role_grants:"), ag.DormantRoleGrants > 0),
 			Detail:     fmt.Sprintf("%d dormant role grant(s)", ag.DormantRoleGrants),
 			Frameworks: FrameworkRefs{ISO27001: []string{"A.5.18", "A.8.2"}, SOC2: []string{"CC6.1"}, ENS: []string{"op.acc.2", "op.acc.4"}},
 		},
 		{
 			ID: "separation-of-duties", Name: "Separation of duties (no toxic combinations)", Area: "Access governance",
-			Status:     gapIf(ag.SoDViolations > 0),
+			Status:     controlStatus(p.DegradedArea("sod_violations", "evidence:sod_violations"), ag.SoDViolations > 0),
 			Detail:     fmt.Sprintf("%d SoD violation(s)", ag.SoDViolations),
 			Frameworks: FrameworkRefs{ISO27001: []string{"A.5.3"}, SOC2: []string{"CC5.1"}, DORA: []string{"Art.5"}, ENS: []string{"op.acc.3"}},
 		},
 		{
 			ID: "second-factor", Name: "Second-factor coverage", Area: "Identity",
-			Status:     gapIf(p.Identity.SecondFactorPercent < 100),
+			Status:     controlStatus(p.DegradedArea("identity"), p.Identity.SecondFactorPercent < 100),
 			Detail:     fmt.Sprintf("%d%% of active users have a second factor", p.Identity.SecondFactorPercent),
 			Frameworks: FrameworkRefs{ISO27001: []string{"A.5.17", "A.8.5"}, SOC2: []string{"CC6.1"}, NIS2: []string{"Art.21(2)(j)"}, DORA: []string{"Art.9"}, ENS: []string{"op.acc.5", "op.acc.6"}},
 		},
 		{
 			ID: "secret-rotation", Name: "Secret-rotation hygiene", Area: "Cryptography",
-			Status:     gapIf(p.Rotation.Overdue > 0),
+			Status:     controlStatus(p.DegradedArea("rotation", "evidence:rotation_overdue"), p.Rotation.Overdue > 0),
 			Detail:     fmt.Sprintf("%d overdue, %d due soon of %d covered", p.Rotation.Overdue, p.Rotation.DueSoon, p.Rotation.CoveredSecrets),
 			Frameworks: FrameworkRefs{ISO27001: []string{"A.5.15", "A.8.24"}, SOC2: []string{"CC6.1"}, NIS2: []string{"Art.21(2)(h)"}, ENS: []string{"op.exp.11"}},
 		},
 		{
 			ID: "certificate-hygiene", Name: "Certificate expiry hygiene", Area: "Cryptography",
-			Status:     gapIf(p.Certificates.Expired > 0),
+			Status:     controlStatus(p.DegradedArea("certificates"), p.Certificates.Expired > 0),
 			Detail:     fmt.Sprintf("%d expired, %d expiring soon of %d certificate(s) (%d not yet evaluated)", p.Certificates.Expired, p.Certificates.ExpiringSoon, p.Certificates.TotalCertificates, p.Certificates.NotEvaluated),
 			Frameworks: FrameworkRefs{ISO27001: []string{"A.5.15", "A.8.24"}, SOC2: []string{"CC6.1"}, NIS2: []string{"Art.21(2)(h)"}, ENS: []string{"op.exp.11"}},
 		},
 		{
 			ID: "data-classification", Name: "Secret data classification", Area: "Asset management",
-			Status:     gapIf(p.Classification.Unclassified > 0),
+			Status:     controlStatus(p.DegradedArea("classification:"), p.Classification.Unclassified > 0),
 			Detail:     fmt.Sprintf("%d of %d secrets unclassified", p.Classification.Unclassified, p.Classification.TotalSecrets),
 			Frameworks: FrameworkRefs{ISO27001: []string{"A.5.12", "A.5.13"}, SOC2: []string{"CC3.2"}, ENS: []string{"mp.info.2"}},
 		},
 		{
 			ID: "anomaly-detection", Name: "Access-anomaly detection & response", Area: "Detection",
-			Status:     gapIf(p.Anomalies.HighSeverityOpen > 0),
+			Status:     controlStatus(p.DegradedArea("anomalies"), p.Anomalies.HighSeverityOpen > 0),
 			Detail:     fmt.Sprintf("%d open anomalies (%d high severity)", p.Anomalies.Unacknowledged, p.Anomalies.HighSeverityOpen),
 			Frameworks: FrameworkRefs{ISO27001: []string{"A.8.16"}, SOC2: []string{"CC7.2", "CC7.3"}, NIS2: []string{"Art.21(2)(b)"}, DORA: []string{"Art.10"}, ENS: []string{"op.mon.1", "op.exp.7"}},
 		},
 		{
 			ID: "emergency-access", Name: "Governed emergency (break-glass) access", Area: "Access governance",
-			Status:     ControlStatusPass, // presence of the register is the control; usage is informational
+			// presence of the register is the control; usage is informational — but a
+			// failed collection still needs to surface as unknown, not a default Pass.
+			Status:     controlStatus(p.DegradedArea("emergency_access:", "evidence:break_glass:"), false),
 			Detail:     fmt.Sprintf("%d active, %d total activations (all audited)", p.EmergencyAccess.ActiveActivations, p.EmergencyAccess.TotalActivations),
 			Frameworks: FrameworkRefs{ISO27001: []string{"A.5.15"}, SOC2: []string{"CC6.1"}, DORA: []string{"Art.9"}, ENS: []string{"op.acc.4", "op.exp.7"}},
 		},
@@ -162,8 +187,11 @@ func EvaluateControls(p *CompliancePosture) []ControlState {
 		},
 		{
 			ID: "legal-hold", Name: "Litigation/investigation legal hold", Area: "Data governance",
-			Status:     ControlStatusPass, // capability present; active state is informational
-			Detail:     legalHoldDetail(p.LegalHold),
+			// capability present; active state is informational — but #136's worst
+			// instance is exactly here: a failed query previously read byte-identical
+			// to "no hold", so a degraded collection must surface as unknown instead.
+			Status:     controlStatus(p.DegradedArea("legal_hold"), false),
+			Detail:     legalHoldDetail(p, p.DegradedArea("legal_hold")),
 			Frameworks: FrameworkRefs{ISO27001: []string{"A.5.34"}, DORA: []string{"Art.12"}, ENS: []string{"mp.info.6"}},
 		},
 		{
@@ -207,9 +235,16 @@ func retentionDetail(r RetentionPosture) string {
 		r.AnomalyAlertsDays, r.ClosedAccessReviewsDays, r.BreakGlassDays, r.ResolvedAccessRequestsDays)
 }
 
-func legalHoldDetail(h LegalHoldPosture) string {
-	if h.Active {
-		return fmt.Sprintf("ACTIVE — purges blocked (%s)", h.Reason)
+// legalHoldDetail describes the legal-hold state. When degraded is true, the
+// underlying query failed this run — #136: LegalHold.Active=false is then the
+// query's zero-value fallback, NOT a verified "no hold in effect", so the detail
+// must say so explicitly rather than implying "none currently active".
+func legalHoldDetail(p *CompliancePosture, degraded bool) string {
+	if degraded {
+		return "UNKNOWN — legal-hold status could not be verified this run (query failed); do not treat as inactive"
+	}
+	if p.LegalHold.Active {
+		return fmt.Sprintf("ACTIVE — purges blocked (%s)", p.LegalHold.Reason)
 	}
 	return "available; none currently active"
 }

--- a/internal/core/control_framework_test.go
+++ b/internal/core/control_framework_test.go
@@ -97,7 +97,7 @@ func TestGetComplianceControls_SummaryTallies(t *testing.T) {
 	got, err := c.GetComplianceControls(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, len(got.Controls), got.Summary.Total)
-	assert.Equal(t, got.Summary.Total, got.Summary.Pass+got.Summary.Gap+got.Summary.NotConfigured)
+	assert.Equal(t, got.Summary.Total, got.Summary.Pass+got.Summary.Gap+got.Summary.NotConfigured+got.Summary.Unknown)
 	assert.False(t, got.GeneratedAt.IsZero())
 }
 

--- a/internal/core/evidence_export.go
+++ b/internal/core/evidence_export.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/keyorixhq/keyorix/internal/securefiles"
 )
@@ -43,6 +44,11 @@ type EvidenceExportResult struct {
 	Bytes   int      `json:"bytes"`
 	Targets []string `json:"targets"` // where the pack was delivered (e.g. "file:/path", "webhook")
 	Signed  bool     `json:"signed"`  // whether a detached HMAC signature was produced
+	// Degraded/DegradedReasons (#136): surfaced from the exported pack's posture so a
+	// caller (the scheduler's log line, or an operator inspecting the result) sees a
+	// partial-collection export without having to open and parse the archived file.
+	Degraded        bool     `json:"degraded"`
+	DegradedReasons []string `json:"degraded_reasons,omitempty"`
 }
 
 // ExportComplianceEvidence generates the evidence pack and delivers it to every
@@ -71,7 +77,12 @@ func (c *KeyorixCore) ExportComplianceEvidence(ctx context.Context, outputDir st
 	// pack's authenticity is provable later. signature is "" when unavailable.
 	signature, signed := c.signEvidence(data)
 
-	res := &EvidenceExportResult{Bytes: len(data), Signed: signed}
+	res := &EvidenceExportResult{
+		Bytes:           len(data),
+		Signed:          signed,
+		Degraded:        ev.Posture != nil && ev.Posture.Degraded,
+		DegradedReasons: postureDegradedReasons(ev.Posture),
+	}
 
 	// The pack's canonical name — used both as the local filename and the off-box
 	// object key, so a file and an object-store copy of the same run line up.
@@ -107,10 +118,26 @@ func (c *KeyorixCore) ExportComplianceEvidence(ctx context.Context, outputDir st
 		}
 	}
 
+	// #136: a degraded export must be visible in the audit trail itself, not just in
+	// the archived file — an auditor or admin scanning the log/SIEM for delivery
+	// confirmations should not read "exported" as "complete and clean".
+	degradedNote := ""
+	if res.Degraded {
+		degradedNote = fmt.Sprintf("; DEGRADED (%d collection failure(s)): %s", len(res.DegradedReasons), strings.Join(res.DegradedReasons, "; "))
+	}
+
 	sysCtx := WithActorType(ctx, ActorTypeSystem)
 	c.writeAuditEvent(sysCtx, "compliance.evidence_exported", nil, nil,
-		fmt.Sprintf("compliance evidence pack exported to %v (%d bytes, signed=%t; %d campaigns, %d break-glass activations, %d overdue rotations, %d SoD violations)%s",
-			res.Targets, len(data), signed, len(ev.Campaigns), len(ev.BreakGlass), len(ev.RotationOverdue), len(ev.SoDViolations), forwardNote))
+		fmt.Sprintf("compliance evidence pack exported to %v (%d bytes, signed=%t; %d campaigns, %d break-glass activations, %d overdue rotations, %d SoD violations)%s%s",
+			res.Targets, len(data), signed, len(ev.Campaigns), len(ev.BreakGlass), len(ev.RotationOverdue), len(ev.SoDViolations), forwardNote, degradedNote))
 
 	return res, nil
+}
+
+// postureDegradedReasons safely extracts DegradedReasons from a possibly-nil posture.
+func postureDegradedReasons(p *CompliancePosture) []string {
+	if p == nil {
+		return nil
+	}
+	return p.DegradedReasons
 }

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -644,6 +644,16 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 		}
 	}
 
+	// Close the share-create race (#136): a partial unique index on live rows so two
+	// concurrent CreateShareRecord calls for the same (secret, recipient, is_group)
+	// can no longer both succeed as separate rows. Additive + idempotent; the full
+	// AutoMigrate below covers fresh DBs (which get the index further down too).
+	if tableExists(db, "share_records") {
+		if err := ensureShareRecordUniqueIndex(db); err != nil {
+			return err
+		}
+	}
+
 	// Skip full AutoMigrate if already initialised (projects table present).
 	if projectsExists {
 		return nil
@@ -699,7 +709,24 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 	if err := ensureGroupNameIndex(db); err != nil {
 		return err
 	}
-	return ensureUserNameIndex(db)
+	if err := ensureUserNameIndex(db); err != nil {
+		return err
+	}
+	return ensureShareRecordUniqueIndex(db)
+}
+
+// ensureShareRecordUniqueIndex creates a partial unique index on share_records
+// (secret_id, recipient_id, is_group), scoped to live rows (#136). ShareRecord
+// carried no DB constraint preventing two active share rows for the same
+// (secret, recipient, is_group) tuple: CreateShareRecord's check-then-create is a
+// read-then-write race, and a revoke-by-ID only ever removed one of the resulting
+// duplicates, leaving access live after what looked like a successful single-share
+// revoke. Idempotent; works on SQLite and Postgres.
+func ensureShareRecordUniqueIndex(db *gorm.DB) error {
+	if err := db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS uniq_share_records_active ON share_records (secret_id, recipient_id, is_group) WHERE deleted_at IS NULL").Error; err != nil {
+		return fmt.Errorf("failed to create partial share_records unique index: %w", err)
+	}
+	return nil
 }
 
 // ensureGroupNameIndex replaces any plain unique index on groups.name with a

--- a/internal/storage/store/local_legal_hold.go
+++ b/internal/storage/store/local_legal_hold.go
@@ -36,11 +36,11 @@ func (ls *LocalStorage) CreateLegalHold(ctx context.Context, h *models.LegalHold
 // SQLite or Postgres driver. GORM only maps driver errors to gorm.ErrDuplicatedKey
 // when opened with TranslateError (this app does not set that), so the driver's raw
 // message is matched instead: mattn/go-sqlite3 says "UNIQUE constraint failed";
-// pgx/lib/pq say "duplicate key value violates unique constraint".
+// pgx/lib/pq say "duplicate key value violates unique constraint" (SQLSTATE 23505).
 func isUniqueConstraintErr(err error) bool {
 	msg := err.Error()
-	return strings.Contains(msg, "UNIQUE constraint failed") ||
-		strings.Contains(msg, "duplicate key value violates unique constraint")
+	return strings.Contains(msg, "UNIQUE constraint failed") || // SQLite
+		strings.Contains(msg, "23505") || strings.Contains(msg, "duplicate key value") // Postgres
 }
 
 // GetActiveLegalHold returns the current un-released hold, or (nil, nil) when none

--- a/internal/storage/store/local_sharing.go
+++ b/internal/storage/store/local_sharing.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/i18n"
@@ -75,9 +76,37 @@ func (ls *LocalStorage) CreateShareRecord(ctx context.Context, share *models.Sha
 	}
 
 	if err := ls.db.Create(share).Error; err != nil {
+		// #136: the SELECT above and this INSERT are not atomic — a concurrent
+		// CreateShareRecord for the same (secret, recipient, is_group) can race between
+		// them, both miss the SELECT, and both attempt the INSERT. The partial unique
+		// index on share_records (see ensureShareRecordUniqueIndex) turns the loser's
+		// INSERT into a constraint violation instead of a second live duplicate row;
+		// treat that specific failure as "someone else just created it" and fall back to
+		// updating the row that won the race, preserving CreateShareRecord's upsert
+		// contract instead of surfacing a raw constraint error to the caller.
+		if isUniqueConstraintErr(err) {
+			if rerr := ls.db.Where("secret_id = ? AND recipient_id = ? AND is_group = ? AND deleted_at IS NULL",
+				share.SecretID, share.RecipientID, share.IsGroup).First(&existing).Error; rerr == nil {
+				existing.Permission = share.Permission
+				existing.UpdatedAt = time.Now()
+				if serr := ls.db.Save(&existing).Error; serr != nil {
+					return nil, fmt.Errorf("%s: %w", i18n.T("ErrorDatabaseOperation", nil), serr)
+				}
+				return &existing, nil
+			}
+		}
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorDatabaseOperation", nil), err)
 	}
 	return share, nil
+}
+
+// isUniqueConstraintErr reports whether err is a unique-constraint violation, across
+// both drivers this storage layer supports (SQLite's modernc/mattn error text and
+// Postgres' SQLSTATE 23505), without importing either driver package here.
+func isUniqueConstraintErr(err error) bool {
+	msg := err.Error()
+	return strings.Contains(msg, "UNIQUE constraint failed") || // SQLite
+		strings.Contains(msg, "23505") || strings.Contains(msg, "duplicate key value") // Postgres
 }
 
 // GetShareRecord retrieves a share record by ID.
@@ -113,13 +142,19 @@ func (ls *LocalStorage) UpdateShareRecord(ctx context.Context, share *models.Sha
 	return existing, nil
 }
 
-// DeleteShareRecord soft-deletes a share record.
+// DeleteShareRecord soft-deletes a share record. #136: a pre-existing duplicate row
+// for the same (secret, recipient, is_group) — from before the unique index in
+// ensureShareRecordUniqueIndex closed the create-race that produced them — would
+// otherwise survive a revoke by ID, leaving access live. Delete every active row for
+// that same tuple, not just shareID, so a revoke is complete regardless of how many
+// duplicates accumulated.
 func (ls *LocalStorage) DeleteShareRecord(ctx context.Context, shareID uint) error {
 	share, err := ls.GetShareRecord(ctx, shareID)
 	if err != nil {
 		return err
 	}
-	if err := ls.db.Delete(share).Error; err != nil {
+	if err := ls.db.Where("secret_id = ? AND recipient_id = ? AND is_group = ? AND deleted_at IS NULL",
+		share.SecretID, share.RecipientID, share.IsGroup).Delete(&models.ShareRecord{}).Error; err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorDatabaseOperation", nil), err)
 	}
 	return nil
@@ -234,7 +269,13 @@ func (ls *LocalStorage) CheckSharePermission(ctx context.Context, secretID, user
 		return "", fmt.Errorf("%s: %w", i18n.T("ErrorDatabaseOperation", nil), err)
 	}
 
-	if secret.OwnerID == userID {
+	// #136: OwnerID==0 means the secret has NO human owner (e.g. machine-created); a
+	// machine actor's userID is also 0, so an unguarded equality would match every
+	// ownerless secret via 0==0 and grant it owner-level "write". The core-layer
+	// secretOwnedBy helper (permissions.go) already carries this guard for its own
+	// callers, but this storage-layer check reimplemented the comparison independently
+	// — closing it here too rather than relying solely on callers validating userID != 0.
+	if secret.OwnerID != 0 && secret.OwnerID == userID {
 		return "write", nil
 	}
 

--- a/internal/storage/store/local_sharing.go
+++ b/internal/storage/store/local_sharing.go
@@ -14,7 +14,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/i18n"
@@ -98,15 +97,6 @@ func (ls *LocalStorage) CreateShareRecord(ctx context.Context, share *models.Sha
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorDatabaseOperation", nil), err)
 	}
 	return share, nil
-}
-
-// isUniqueConstraintErr reports whether err is a unique-constraint violation, across
-// both drivers this storage layer supports (SQLite's modernc/mattn error text and
-// Postgres' SQLSTATE 23505), without importing either driver package here.
-func isUniqueConstraintErr(err error) bool {
-	msg := err.Error()
-	return strings.Contains(msg, "UNIQUE constraint failed") || // SQLite
-		strings.Contains(msg, "23505") || strings.Contains(msg, "duplicate key value") // Postgres
 }
 
 // GetShareRecord retrieves a share record by ID.

--- a/internal/storage/store/local_sharing_test.go
+++ b/internal/storage/store/local_sharing_test.go
@@ -1,0 +1,136 @@
+package store
+
+import (
+	"context"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// sharingConcurrentDB opens a temp FILE-backed SQLite (not :memory:) with a busy
+// timeout and WAL, so multiple connections genuinely contend — the only way to test
+// that the create-race fix holds under real concurrency (mirrors concurrentDB in
+// concurrency_max_reads_test.go). It also installs the same partial unique index the
+// real migration does (ensureShareRecordUniqueIndex, internal/storage/factory.go —
+// not importable here without a cycle, so the DDL is mirrored).
+func sharingConcurrentDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	dsn := "file:" + filepath.Join(t.TempDir(), "sharing.db") + "?_busy_timeout=10000&_journal_mode=WAL&_txlock=immediate"
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.User{}, &models.Group{}, &models.UserGroup{}, &models.SecretNode{}, &models.ShareRecord{},
+	))
+	require.NoError(t, db.Exec(
+		"CREATE UNIQUE INDEX IF NOT EXISTS uniq_share_records_active ON share_records (secret_id, recipient_id, is_group) WHERE deleted_at IS NULL",
+	).Error)
+	return db
+}
+
+// #136: two concurrent CreateShareRecord calls for the same (secret, recipient) must
+// not both succeed as separate rows — the partial unique index rejects the loser's
+// INSERT, and CreateShareRecord must turn that into an upsert onto the winner's row
+// rather than surfacing a raw constraint error to the caller.
+func TestCreateShareRecord_ConcurrentGrantsNoDuplicateRow(t *testing.T) {
+	db := sharingConcurrentDB(t)
+	ls := NewLocalStorage(db)
+	ctx := context.Background()
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "owner", Email: "o@x.io"}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 2, Username: "grantee", Email: "g@x.io"}).Error)
+	require.NoError(t, db.Create(&models.SecretNode{
+		ID: 100, Name: "s", ProjectID: 1, EnvironmentID: 1, OwnerID: 1, Status: "active", Type: "password",
+	}).Error)
+
+	const n = 8
+	var wg sync.WaitGroup
+	errs := make([]error, n)
+	var start sync.WaitGroup
+	start.Add(1)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			start.Wait()
+			_, err := ls.CreateShareRecord(ctx, &models.ShareRecord{
+				SecretID: 100, RecipientID: 2, IsGroup: false, OwnerID: 1, Permission: "read",
+			})
+			errs[i] = err
+		}(i)
+	}
+	start.Done() // release all goroutines at once to maximize the race window
+	wg.Wait()
+
+	for i, err := range errs {
+		assert.NoError(t, err, "goroutine %d", i)
+	}
+
+	var count int64
+	require.NoError(t, db.Model(&models.ShareRecord{}).
+		Where("secret_id = ? AND recipient_id = ? AND is_group = ? AND deleted_at IS NULL", 100, 2, false).
+		Count(&count).Error)
+	assert.Equal(t, int64(1), count, "concurrent grants for the same (secret, recipient) must collapse to exactly one active row")
+}
+
+// #136: DeleteShareRecord must remove every active row for the target's
+// (secret, recipient, is_group), not just the row named by shareID — so a
+// pre-existing duplicate (e.g. from before the unique index shipped) doesn't survive
+// a revoke and leave access live.
+func TestDeleteShareRecord_RemovesAllDuplicatesForSameTuple(t *testing.T) {
+	db := sharingConcurrentDB(t)
+	ls := NewLocalStorage(db)
+	ctx := context.Background()
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "owner", Email: "o@x.io"}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 2, Username: "grantee", Email: "g@x.io"}).Error)
+	require.NoError(t, db.Create(&models.SecretNode{
+		ID: 100, Name: "s", ProjectID: 1, EnvironmentID: 1, OwnerID: 1, Status: "active", Type: "password",
+	}).Error)
+
+	// Simulate a pre-existing duplicate from before the unique index existed: insert
+	// directly, bypassing CreateShareRecord (which would now reject/upsert it).
+	share1 := &models.ShareRecord{SecretID: 100, RecipientID: 2, IsGroup: false, OwnerID: 1, Permission: "read"}
+	require.NoError(t, db.Exec("DROP INDEX IF EXISTS uniq_share_records_active").Error)
+	require.NoError(t, db.Create(share1).Error)
+	share2 := &models.ShareRecord{SecretID: 100, RecipientID: 2, IsGroup: false, OwnerID: 1, Permission: "read"}
+	require.NoError(t, db.Create(share2).Error)
+
+	var preCount int64
+	require.NoError(t, db.Model(&models.ShareRecord{}).
+		Where("secret_id = ? AND recipient_id = ? AND is_group = ? AND deleted_at IS NULL", 100, 2, false).
+		Count(&preCount).Error)
+	require.Equal(t, int64(2), preCount, "test setup: two duplicate active rows must exist")
+
+	// Revoke by share1's ID only.
+	require.NoError(t, ls.DeleteShareRecord(ctx, share1.ID))
+
+	perm, err := ls.CheckSharePermission(ctx, 100, 2)
+	require.Error(t, err, "revoking one of the duplicate rows must remove access entirely")
+	assert.Equal(t, "", perm)
+
+	var postCount int64
+	require.NoError(t, db.Model(&models.ShareRecord{}).
+		Where("secret_id = ? AND recipient_id = ? AND is_group = ? AND deleted_at IS NULL", 100, 2, false).
+		Count(&postCount).Error)
+	assert.Equal(t, int64(0), postCount, "both duplicate rows must be removed by a single revoke")
+}
+
+// #136: CheckSharePermission's OwnerID==userID check must not match when both are the
+// zero value. A machine actor's ID is also 0, so an unguarded equality would grant it
+// owner-level "write" on every ownerless (machine-created) secret.
+func TestCheckSharePermission_OwnerZeroGuard(t *testing.T) {
+	db := sharingConcurrentDB(t)
+	ls := NewLocalStorage(db)
+	ctx := context.Background()
+	require.NoError(t, db.Create(&models.SecretNode{
+		ID: 100, Name: "s", ProjectID: 1, EnvironmentID: 1, OwnerID: 0, Status: "active", Type: "password",
+	}).Error)
+
+	perm, err := ls.CheckSharePermission(ctx, 100, 0)
+	require.Error(t, err, "userID=0 must not match an ownerless secret's OwnerID=0")
+	assert.Equal(t, "", perm)
+}

--- a/server/grpc/services/compliance_service.go
+++ b/server/grpc/services/compliance_service.go
@@ -124,6 +124,11 @@ func compliancePostureToProto(p *core.CompliancePosture) *pb.CompliancePosture {
 			ActiveExceptions: intToI32(p.Risk.ActiveExceptions),
 			ExpiringSoon:     intToI32(p.Risk.ExpiringSoon),
 		},
+		// #136: Degraded/DegradedReasons must reach every consumer, gRPC included —
+		// silently dropping them here would leave gRPC callers unable to distinguish
+		// a genuinely clean snapshot from one where a sub-rollup query failed.
+		Degraded:        p.Degraded,
+		DegradedReasons: p.DegradedReasons,
 	}
 	if p.LegalHold.PlacedAt != nil {
 		out.LegalHold.PlacedAt = timestamppb.New(*p.LegalHold.PlacedAt)
@@ -172,6 +177,7 @@ func complianceControlsToProto(c *core.ComplianceControls) *pb.ComplianceControl
 			Pass:          intToI32(c.Summary.Pass),
 			Gap:           intToI32(c.Summary.Gap),
 			NotConfigured: intToI32(c.Summary.NotConfigured),
+			Unknown:       intToI32(c.Summary.Unknown),
 		},
 	}
 }

--- a/server/main.go
+++ b/server/main.go
@@ -1079,7 +1079,15 @@ func startHTTPServer(ctx context.Context, cfg *config.Config) error {
 						log.Printf("Evidence-delivery error: %v", err)
 						return err
 					}
-					log.Printf("Evidence pack exported: %d bytes → %v", res.Bytes, res.Targets)
+					if res.Degraded {
+						// #136: a degraded pack must be loud in the operator-facing log, not
+						// just embedded in the archived JSON — a collection failure means
+						// this export is incomplete, not a clean point-in-time snapshot.
+						log.Printf("Evidence pack exported DEGRADED (%d collection failure(s)): %d bytes -> %v; reasons: %s",
+							len(res.DegradedReasons), res.Bytes, res.Targets, strings.Join(res.DegradedReasons, "; "))
+					} else {
+						log.Printf("Evidence pack exported: %d bytes -> %v", res.Bytes, res.Targets)
+					}
 					return nil
 				})
 			})

--- a/server/proto/keyorix.proto
+++ b/server/proto/keyorix.proto
@@ -1320,6 +1320,12 @@ message CompliancePosture {
   LegalHoldPosture legal_hold = 9;
   RetentionPosture retention = 10;
   RiskPosture risk = 11;
+  // degraded is true when one or more sub-rollups above could not be queried this
+  // run (#136) — the zero/clean values they carry are UNKNOWN, not verified-clean.
+  // A consumer must treat a degraded snapshot as incomplete, not passing.
+  bool degraded = 12;
+  // degraded_reasons names each failed sub-rollup with its underlying error.
+  repeated string degraded_reasons = 13;
 }
 
 message FrameworkRefs {
@@ -1345,6 +1351,9 @@ message ControlsSummary {
   int32 pass = 2;
   int32 gap = 3;
   int32 not_configured = 4;
+  // unknown (#136) counts controls whose signal could not be collected this run —
+  // a non-zero value means the matrix is incomplete, not fully passing.
+  int32 unknown = 5;
 }
 
 message ComplianceControls {

--- a/server/proto/pb/keyorix.pb.go
+++ b/server/proto/pb/keyorix.pb.go
@@ -9368,8 +9368,14 @@ type CompliancePosture struct {
 	LegalHold        *LegalHoldPosture        `protobuf:"bytes,9,opt,name=legal_hold,json=legalHold,proto3" json:"legal_hold,omitempty"`
 	Retention        *RetentionPosture        `protobuf:"bytes,10,opt,name=retention,proto3" json:"retention,omitempty"`
 	Risk             *RiskPosture             `protobuf:"bytes,11,opt,name=risk,proto3" json:"risk,omitempty"`
-	unknownFields    protoimpl.UnknownFields
-	sizeCache        protoimpl.SizeCache
+	// degraded is true when one or more sub-rollups above could not be queried this
+	// run (#136) — the zero/clean values they carry are UNKNOWN, not verified-clean.
+	// A consumer must treat a degraded snapshot as incomplete, not passing.
+	Degraded bool `protobuf:"varint,12,opt,name=degraded,proto3" json:"degraded,omitempty"`
+	// degraded_reasons names each failed sub-rollup with its underlying error.
+	DegradedReasons []string `protobuf:"bytes,13,rep,name=degraded_reasons,json=degradedReasons,proto3" json:"degraded_reasons,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
 }
 
 func (x *CompliancePosture) Reset() {
@@ -9475,6 +9481,20 @@ func (x *CompliancePosture) GetRetention() *RetentionPosture {
 func (x *CompliancePosture) GetRisk() *RiskPosture {
 	if x != nil {
 		return x.Risk
+	}
+	return nil
+}
+
+func (x *CompliancePosture) GetDegraded() bool {
+	if x != nil {
+		return x.Degraded
+	}
+	return false
+}
+
+func (x *CompliancePosture) GetDegradedReasons() []string {
+	if x != nil {
+		return x.DegradedReasons
 	}
 	return nil
 }
@@ -9646,6 +9666,9 @@ type ControlsSummary struct {
 	Pass          int32                  `protobuf:"varint,2,opt,name=pass,proto3" json:"pass,omitempty"`
 	Gap           int32                  `protobuf:"varint,3,opt,name=gap,proto3" json:"gap,omitempty"`
 	NotConfigured int32                  `protobuf:"varint,4,opt,name=not_configured,json=notConfigured,proto3" json:"not_configured,omitempty"`
+	// unknown (#136) counts controls whose signal could not be collected this run —
+	// a non-zero value means the matrix is incomplete, not fully passing.
+	Unknown       int32 `protobuf:"varint,5,opt,name=unknown,proto3" json:"unknown,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -9704,6 +9727,13 @@ func (x *ControlsSummary) GetGap() int32 {
 func (x *ControlsSummary) GetNotConfigured() int32 {
 	if x != nil {
 		return x.NotConfigured
+	}
+	return 0
+}
+
+func (x *ControlsSummary) GetUnknown() int32 {
+	if x != nil {
+		return x.Unknown
 	}
 	return 0
 }
@@ -11078,7 +11108,7 @@ const file_keyorix_proto_rawDesc = "" +
 	"\x1dresolved_access_requests_days\x18\x05 \x01(\x05R\x1aresolvedAccessRequestsDays\"_\n" +
 	"\vRiskPosture\x12+\n" +
 	"\x11active_exceptions\x18\x01 \x01(\x05R\x10activeExceptions\x12#\n" +
-	"\rexpiring_soon\x18\x02 \x01(\x05R\fexpiringSoon\"\xde\x05\n" +
+	"\rexpiring_soon\x18\x02 \x01(\x05R\fexpiringSoon\"\xa5\x06\n" +
 	"\x11CompliancePosture\x12=\n" +
 	"\fgenerated_at\x18\x01 \x01(\v2\x1a.google.protobuf.TimestampR\vgeneratedAt\x12J\n" +
 	"\x0faudit_integrity\x18\x02 \x01(\v2!.keyorix.v1.AuditIntegrityPostureR\x0eauditIntegrity\x12P\n" +
@@ -11092,7 +11122,9 @@ const file_keyorix_proto_rawDesc = "" +
 	"legal_hold\x18\t \x01(\v2\x1c.keyorix.v1.LegalHoldPostureR\tlegalHold\x12:\n" +
 	"\tretention\x18\n" +
 	" \x01(\v2\x1c.keyorix.v1.RetentionPostureR\tretention\x12+\n" +
-	"\x04risk\x18\v \x01(\v2\x17.keyorix.v1.RiskPostureR\x04risk\"z\n" +
+	"\x04risk\x18\v \x01(\v2\x17.keyorix.v1.RiskPostureR\x04risk\x12\x1a\n" +
+	"\bdegraded\x18\f \x01(\bR\bdegraded\x12)\n" +
+	"\x10degraded_reasons\x18\r \x03(\tR\x0fdegradedReasons\"z\n" +
 	"\rFrameworkRefs\x12\x1b\n" +
 	"\tiso_27001\x18\x01 \x03(\tR\biso27001\x12\x12\n" +
 	"\x04soc2\x18\x02 \x03(\tR\x04soc2\x12\x12\n" +
@@ -11107,12 +11139,13 @@ const file_keyorix_proto_rawDesc = "" +
 	"\x06detail\x18\x05 \x01(\tR\x06detail\x129\n" +
 	"\n" +
 	"frameworks\x18\x06 \x01(\v2\x19.keyorix.v1.FrameworkRefsR\n" +
-	"frameworks\"t\n" +
+	"frameworks\"\x8e\x01\n" +
 	"\x0fControlsSummary\x12\x14\n" +
 	"\x05total\x18\x01 \x01(\x05R\x05total\x12\x12\n" +
 	"\x04pass\x18\x02 \x01(\x05R\x04pass\x12\x10\n" +
 	"\x03gap\x18\x03 \x01(\x05R\x03gap\x12%\n" +
-	"\x0enot_configured\x18\x04 \x01(\x05R\rnotConfigured\"\xc0\x01\n" +
+	"\x0enot_configured\x18\x04 \x01(\x05R\rnotConfigured\x12\x18\n" +
+	"\aunknown\x18\x05 \x01(\x05R\aunknown\"\xc0\x01\n" +
 	"\x12ComplianceControls\x12=\n" +
 	"\fgenerated_at\x18\x01 \x01(\v2\x1a.google.protobuf.TimestampR\vgeneratedAt\x124\n" +
 	"\bcontrols\x18\x02 \x03(\v2\x18.keyorix.v1.ControlStateR\bcontrols\x125\n" +


### PR DESCRIPTION
## Summary
- `GetCompliancePosture` had a systemic `if err == nil { p.Field = x }` no-`else` pattern: a transient sub-query failure (legal hold, risk exceptions, SoD violations, and others) silently left the zero-value ("all clear") in place instead of surfacing as unknown/degraded.
- Empirically proven (round 60 of the security-hardening campaign): dropping the `legal_holds`/`risk_exceptions`/`sod_policies` table mid-query flipped a real adverse state (active hold, active exception, real SoD violation) back to "0/false" — exactly the signal purge jobs and the HMAC-signed evidence pack both trust.
- Adds `CompliancePosture.DegradedArea(prefixes...)` so any downstream pass/gap evaluation derived from a degraded field can defer to an explicit `ControlStatusUnknown` instead of trusting the zero value, wired through every control in `EvaluateControls`, the evidence pack, the `keyorix compliance` CLI output, and the gRPC compliance service response.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` (full suite, clean)
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues
- [x] `golangci-lint run ./...` — 0 issues
- [x] `GOWORK=off go build -C operator ./...` — clean
- [x] New regression tests reproducing the empirical scenario for legal-hold, risk-exceptions, and SoD-policy query failures, each asserting `Degraded=true` and the corresponding control surfacing `ControlStatusUnknown` rather than a false pass.