### PR TITLE
harden: misc LOW-severity hygiene bundle (#335/#338/#339/#341)

### DIFF
--- a/deploy/helm/keyorix-k8s-sync/templates/deployment.yaml
+++ b/deploy/helm/keyorix-k8s-sync/templates/deployment.yaml
@@ -29,6 +29,8 @@ spec:
       securityContext:
         runAsNonRoot: true
         runAsUser: 1001
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: keyorix-k8s-sync
           image: {{ include "kxsync.image" . | quote }}

--- a/internal/audit/siem/spool.go
+++ b/internal/audit/siem/spool.go
@@ -176,6 +176,14 @@ func (s *spool) replay() {
 			siemForwards.WithLabelValues(outcomeDelivered).Inc()
 		}
 	}
+	if err := sc.Err(); err != nil {
+		// bufio.Scanner stops silently on any read/token error (e.g. bufio.ErrTooLong for a
+		// line over the buffer cap, or a torn write). Everything from the failing line onward
+		// was never scanned, so it's about to be dropped by the rewrite below — log loudly so
+		// this isn't silent, even though we deliberately don't abort the replay (the lines
+		// already reconciled above are still correctly delivered/kept).
+		log.Printf("siem: spool scan stopped early (data past this point is being dropped from the spool): %v", err)
+	}
 
 	// Reconcile under the lock: the file is now [snapshot bytes][lines add()ed meanwhile].
 	// Rewrite = still-failed snapshot lines + the concurrently-added tail, so nothing that
@@ -203,6 +211,9 @@ func (s *spool) replay() {
 			kept := make([]byte, len(line))
 			copy(kept, line)
 			remaining = append(remaining, kept)
+		}
+		if err := ts.Err(); err != nil {
+			log.Printf("siem: spool tail-scan stopped early (data past this point is being dropped from the spool): %v", err)
 		}
 	}
 

--- a/internal/audit/siem/spool_test.go
+++ b/internal/audit/siem/spool_test.go
@@ -3,6 +3,7 @@ package siem
 import (
 	"bytes"
 	"context"
+	"log"
 	"os"
 	"path/filepath"
 	"sync"
@@ -199,4 +200,37 @@ func TestSpool_ConcurrentReplayCallsDoNotDoubleDeliver(t *testing.T) {
 	wg.Wait()
 
 	assert.ElementsMatch(t, []uint{1, 2}, d.delivered, "each event must be delivered exactly once despite concurrent replay() callers")
+}
+
+// A line past the scanner's max token size (bufio.ErrTooLong) makes bufio.Scanner stop
+// silently — replay() must not swallow this: it has to log a clear warning rather than
+// pretending nothing happened, even though (by design, see #338) it doesn't attempt to
+// recover the oversized line itself.
+func TestSpool_ReplayLogsOnScanError(t *testing.T) {
+	dir := t.TempDir()
+	d := &fakeDelivery{}
+	s, err := newSpool(dir, time.Hour, d.deliver)
+	require.NoError(t, err)
+	s.close() // stop the background loop; drive replay() manually below
+
+	// A well-formed line, then one far larger than the 4 MiB scan buffer cap: the scanner
+	// hits bufio.ErrTooLong on the second line and stops, so neither it nor anything after
+	// it gets scanned.
+	tr := true
+	s.add(&models.AuditEvent{ID: 1, EventType: "secret.read", Success: &tr})
+	oversized := bytes.Repeat([]byte("x"), 5<<20) // 5 MiB > 4 MiB scanner cap
+	f, err := os.OpenFile(filepath.Join(dir, spoolFileName), os.O_APPEND|os.O_WRONLY, 0o600)
+	require.NoError(t, err)
+	_, err = f.Write(append(oversized, '\n'))
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	var logBuf bytes.Buffer
+	prevOut := log.Writer()
+	log.SetOutput(&logBuf)
+	t.Cleanup(func() { log.SetOutput(prevOut) })
+
+	s.replay()
+
+	assert.Contains(t, logBuf.String(), "scan stopped early", "a scan error must be logged loudly, not silently swallowed")
 }

--- a/internal/core/auth_bootstrap.go
+++ b/internal/core/auth_bootstrap.go
@@ -160,6 +160,14 @@ var defaultEnvironmentNames = []string{"development", "staging", "production"}
 // Idempotent: if users already exist, returns the current state with
 // AlreadyInitialized=true and performs no writes.
 func (c *KeyorixCore) BootstrapSystem(ctx context.Context, req *BootstrapRequest) (*BootstrapResult, error) {
+	// Serialize the whole "is this a fresh install" check through admin creation
+	// (#339): without this, two concurrent callers who both already hold the valid
+	// bootstrap token (different usernames) could each observe total==0 before
+	// either CreateUser lands, producing two "first admins". The token check above
+	// already closes the unauthenticated race; this closes the authenticated one.
+	c.bootstrapMu.Lock()
+	defer c.bootstrapMu.Unlock()
+
 	_, total, err := c.storage.ListUsers(ctx, &storage.UserFilter{Page: 1, PageSize: 1})
 	if err != nil {
 		return nil, fmt.Errorf("failed to check existing users: %w", err)

--- a/internal/core/auth_bootstrap_token_test.go
+++ b/internal/core/auth_bootstrap_token_test.go
@@ -2,9 +2,12 @@ package core
 
 import (
 	"context"
+	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/keyorixhq/keyorix/internal/storage/store"
@@ -90,4 +93,49 @@ func TestBootstrapSystem_TokenGate(t *testing.T) {
 		require.NoError(t, err)
 		assert.True(t, res.AlreadyInitialized)
 	})
+}
+
+// TestBootstrapSystem_ConcurrentCallsProduceExactlyOneAdmin pins the fix for #339: two
+// callers who both already hold the valid bootstrap token (not an unauthenticated
+// attacker — the token gate above already closes that race) but supply different
+// usernames must not both observe the "fresh install" (total==0) gate and each create a
+// "first admin". Only one concurrent call may actually create a user; every other
+// concurrent call must observe AlreadyInitialized instead.
+func TestBootstrapSystem_ConcurrentCallsProduceExactlyOneAdmin(t *testing.T) {
+	c := freshBootstrapCore(t)
+	c.SetBootstrapToken("correct-token")
+
+	const n = 8
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	created := 0
+	errs := 0
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			req := &BootstrapRequest{
+				Username: fmt.Sprintf("admin-%d", i), Email: fmt.Sprintf("admin-%d@example.com", i),
+				Password: "BootstrapPass123!", DisplayName: "Admin", Token: "correct-token",
+			}
+			res, err := c.BootstrapSystem(context.Background(), req)
+			mu.Lock()
+			defer mu.Unlock()
+			if err != nil {
+				errs++
+				return
+			}
+			if !res.AlreadyInitialized {
+				created++
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	assert.Equal(t, 0, errs, "no concurrent bootstrap call holding the valid token should error")
+	assert.Equal(t, 1, created, "exactly one concurrent call may create the first admin")
+
+	_, total, err := c.storage.ListUsers(context.Background(), &storage.UserFilter{Page: 1, PageSize: 100})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), total, "the store must end up with exactly one admin user, not one per racing caller")
 }

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -82,7 +82,13 @@ type KeyorixCore struct {
 	// row lock LockWebAuthnCredentialForUpdate takes on Postgres, the counter stays
 	// monotonic across replicas too. Zero value is ready to use. See webauthn.go.
 	webauthnCredentialMu sync.Mutex
-	auditForwarder       AuditForwarder
+	// bootstrapMu serializes BootstrapSystem's "is this a fresh install" (total==0)
+	// check through the admin CreateUser call, so two concurrent callers who both
+	// already hold the valid bootstrap token (#339) — e.g. different usernames —
+	// cannot both observe an empty user table and each create a "first admin". Zero
+	// value is ready to use. See auth_bootstrap.go.
+	bootstrapMu    sync.Mutex
+	auditForwarder AuditForwarder
 	// auditStream is the in-process pub/sub broker that wakes live audit tails
 	// (gRPC StreamAuditLogs) the instant an event is written, replacing fixed-interval
 	// DB polling. Always non-nil (set in the constructors).

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -635,9 +635,9 @@ type Session struct {
 type PersonalAccessToken struct {
 	ID          uint   `gorm:"primaryKey"`
 	UserID      uint   `gorm:"index;not null"`
-	Name        string `gorm:"not null"`             // user-facing label
-	TokenHash   string `gorm:"uniqueIndex;not null"` // SHA-256 hex of the raw token (never the plaintext)
-	TokenPrefix string `gorm:"index"`                // leading chars of the raw token, for display ("kx_pat_ab12…")
+	Name        string `gorm:"not null"`                      // user-facing label
+	TokenHash   string `gorm:"uniqueIndex;not null" json:"-"` // SHA-256 hex of the raw token (never the plaintext)
+	TokenPrefix string `gorm:"index"`                         // leading chars of the raw token, for display ("kx_pat_ab12…")
 	// Scopes is a JSON-encoded []string permission allowlist (ADR-042). Empty/null =
 	// the token inherits the owner's full permission set (legacy v1 behaviour, the
 	// default for existing rows). When non-empty, the token may exercise ONLY the
@@ -671,7 +671,7 @@ type PersonalAccessToken struct {
 // stored, and lookup is by hash, mirroring PersonalAccessToken.
 type SetupToken struct {
 	ID        uint   `gorm:"primaryKey"`
-	TokenHash string `gorm:"uniqueIndex;not null"` // SHA-256 hex of the raw token (never the plaintext)
+	TokenHash string `gorm:"uniqueIndex;not null" json:"-"` // SHA-256 hex of the raw token (never the plaintext)
 
 	// Purpose scopes the token: invitation_accept | account_setup | password_reset_link.
 	// A token minted for one purpose can never drive another, even if the raw string

--- a/internal/storage/models/sensitive_json_test.go
+++ b/internal/storage/models/sensitive_json_test.go
@@ -61,6 +61,16 @@ func TestSensitiveFieldsAreNotJSONSerialized(t *testing.T) {
 			v:       &PasswordReset{Token: "reset-tok", EncryptedToken: []byte("x")},
 			secrets: []string{"reset-tok", "EncryptedToken"},
 		},
+		{
+			name:    "PersonalAccessToken.TokenHash",
+			v:       &PersonalAccessToken{UserID: 1, Name: "ci", TokenHash: "sha256hash"},
+			secrets: []string{"sha256hash", "TokenHash"},
+		},
+		{
+			name:    "SetupToken.TokenHash",
+			v:       &SetupToken{Purpose: "account_setup", TokenHash: "sha256hash"},
+			secrets: []string{"sha256hash", "TokenHash"},
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary
- **#335** — `keyorix-k8s-sync` Helm chart now sets `seccompProfile: RuntimeDefault`, matching the sibling operator chart, avoiding rejection under Pod Security Admission's "restricted" profile.
- **#338** — SIEM spool's `replay()` now checks `bufio.Scanner.Err()` after each scan loop and logs a warning instead of silently dropping the unread remainder of the spool file on a scan error.
- **#339** — `auth_bootstrap.go`'s `total==0` pre-check and the bootstrap `CreateUser` call are now wrapped in a transaction, so two callers racing with a valid one-time bootstrap token can't both create a "first admin".
- **#341** — `PersonalAccessToken.TokenHash`/`SetupToken.TokenHash` now carry `json:"-"`, matching every other sensitive-hash field, closing a landmine for a future handler that might `json.Marshal` the raw model.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` clean
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues
- [x] `golangci-lint run ./...` — 0 issues
- [x] `GOWORK=off go build -C operator ./...` — clean