### PR TITLE
fix: wire startup/schema validation into the live boot path (#330/#331/#332 HIGH)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1336,6 +1336,22 @@ func resolveSecret(envVar string, fallback string) string {
 
 const appRootDir = "."
 
+// ResolvedPath returns the config file path Load(path) would read, without
+// actually reading it: an explicit non-empty path wins, otherwise
+// KEYORIX_CONFIG_PATH, otherwise "keyorix.yaml" in the application root.
+// Callers that need to know exactly which file was (or will be) loaded — e.g.
+// startup validation checking that file's permissions — should resolve
+// through this helper rather than re-deriving the fallback chain themselves.
+func ResolvedPath(path string) string {
+	if path == "" {
+		path = resolveSecret("KEYORIX_CONFIG_PATH", "")
+	}
+	if path == "" {
+		path = filepath.Join(appRootDir, "keyorix.yaml")
+	}
+	return path
+}
+
 // Load loads the YAML configuration file.
 //
 // Path resolution when path is empty (the default / LoadConfig case):
@@ -1347,12 +1363,7 @@ const appRootDir = "."
 // with the safe-read rooted at the file's own directory, so the traversal guard
 // still applies; relative paths remain rooted at the application directory.
 func Load(path string) (*Config, error) {
-	if path == "" {
-		path = resolveSecret("KEYORIX_CONFIG_PATH", "")
-	}
-	if path == "" {
-		path = filepath.Join(appRootDir, "keyorix.yaml")
-	}
+	path = ResolvedPath(path)
 
 	baseDir, readPath := appRootDir, path
 	if filepath.IsAbs(path) {

--- a/internal/startup/validation.go
+++ b/internal/startup/validation.go
@@ -41,6 +41,10 @@ func ValidateStartup(configPath string) (*ValidationResult, error) {
 		result.Errors = append(result.Errors, fmt.Sprintf("Failed to load config: %v", err))
 		return result, fmt.Errorf("configuration validation failed: %w", err)
 	}
+	if err := cfg.Validate(); err != nil {
+		result.Errors = append(result.Errors, fmt.Sprintf("Config schema validation failed: %v", err))
+		return result, fmt.Errorf("configuration validation failed: %w", err)
+	}
 	result.ConfigValid = true
 
 	if cfg.Security.EnableFilePermissionCheck {
@@ -96,10 +100,22 @@ func validateFilePermissions(cfg *config.Config, configPath string, result *Vali
 		)
 	}
 
-	files = append(files, securefiles.FilePermSpec{
-		Path: filepath.Clean(cfg.Storage.Database.Path),
-		Mode: 0600,
-	})
+	// Mirror Config.Validate()'s switch on Storage.Type: only "local"/"" storage has a
+	// local database FILE to lock down. postgres/remote connect over the network (DSN or
+	// host/name/user, or the remote client's own auth) and legitimately have an empty
+	// Database.Path — appending it unconditionally would stat/chmod the current directory
+	// (filepath.Clean("") == ".") instead of skipping the check.
+	switch cfg.Storage.Type {
+	case "remote", "postgres", "postgresql":
+		// no local database file to check
+	default: // "local", ""
+		if cfg.Storage.Database.Path != "" {
+			files = append(files, securefiles.FilePermSpec{
+				Path: filepath.Clean(cfg.Storage.Database.Path),
+				Mode: 0600,
+			})
+		}
+	}
 
 	if cfg.Server.HTTP.TLS.Enabled {
 		files = append(files,
@@ -171,6 +187,18 @@ func resolveKeyPath(p string) string {
 }
 
 func validateDatabase(cfg *config.Config, result *ValidationResult) error {
+	// Mirror Config.Validate()'s switch on Storage.Type: only "local"/"" storage is a
+	// local SQLite file reachable by stat/open. postgres/remote reach their backing store
+	// over the network and are out of scope for a local-file reachability check here.
+	switch cfg.Storage.Type {
+	case "remote":
+		result.Warnings = append(result.Warnings, "Database reachability check skipped: storage.type is \"remote\" (network client, not a local file)")
+		return nil
+	case "postgres", "postgresql":
+		result.Warnings = append(result.Warnings, "Database reachability check skipped: storage.type is \"postgres\" (network connection, not a local file)")
+		return nil
+	}
+
 	dbPath := filepath.Clean(cfg.Storage.Database.Path)
 
 	if strings.Contains(dbPath, "..") || !filepath.IsAbs(dbPath) {

--- a/internal/startup/validation_test.go
+++ b/internal/startup/validation_test.go
@@ -76,3 +76,63 @@ func TestResolveKeyPath(t *testing.T) {
 		t.Errorf("relative path resolved unexpectedly: %q", got)
 	}
 }
+
+// #331 regression: validateFilePermissions must check the config file that was
+// actually passed in (and loaded via config.Load), not a hardcoded "keyorix.yaml" in
+// the process's working directory. A 0600 file at an arbitrary custom path must pass;
+// if the old hardcoded-name bug were still present, it would try to Lstat a
+// "keyorix.yaml" that doesn't exist in this package's test directory and fail instead.
+func TestValidateFilePermissions_UsesActualConfigPath(t *testing.T) {
+	if _, err := os.Lstat("keyorix.yaml"); err == nil {
+		t.Skip("a keyorix.yaml exists in the test working directory; this test cannot distinguish the bug from the fix")
+	}
+
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "custom-config-name.yml")
+	if err := os.WriteFile(configPath, []byte("x"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Config{} // no encryption/DB path configured — isolates the config-file check
+	if err := validateFilePermissions(cfg, configPath, &ValidationResult{}); err != nil {
+		t.Fatalf("expected the real 0600 config path to pass, got: %v", err)
+	}
+}
+
+// #332 regression: validateFilePermissions must not treat a postgres/remote deployment's
+// (legitimately empty) Storage.Database.Path as a local file to lock down — that would
+// resolve to "." (the current directory) and either warn on or attempt to chmod it.
+func TestValidateFilePermissions_SkipsDatabasePathForNonLocalStorage(t *testing.T) {
+	for _, typ := range []string{"postgres", "postgresql", "remote"} {
+		cfg := &config.Config{}
+		cfg.Storage.Type = typ
+		// Database.Path intentionally left empty, as it legitimately is for these types.
+		if err := validateFilePermissions(cfg, "", &ValidationResult{}); err != nil {
+			t.Errorf("storage.type=%q must not check a local database file, got: %v", typ, err)
+		}
+	}
+}
+
+// #332 regression: validateDatabase must mirror Config.Validate()'s switch on
+// Storage.Type — postgres/remote deployments reach their store over the network and
+// must not be false-failed by a local-file reachability check.
+func TestValidateDatabase_SkipsLocalCheckForNonLocalStorage(t *testing.T) {
+	for _, typ := range []string{"postgres", "postgresql", "remote"} {
+		cfg := &config.Config{}
+		cfg.Storage.Type = typ
+		result := &ValidationResult{}
+		if err := validateDatabase(cfg, result); err != nil {
+			t.Errorf("storage.type=%q must not require a local database file, got: %v", typ, err)
+		}
+	}
+}
+
+// Local/sqlite storage is unaffected by the #332 fix: an unsafe (relative) path is
+// still rejected.
+func TestValidateDatabase_LocalStorageStillValidatesPath(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Storage.Database.Path = "relative.db"
+	if err := validateDatabase(cfg, &ValidationResult{}); err == nil {
+		t.Fatal("expected error for a relative local database path")
+	}
+}

--- a/server/main.go
+++ b/server/main.go
@@ -52,6 +52,7 @@ import (
 	"github.com/keyorixhq/keyorix/internal/rotation"
 	samlpkg "github.com/keyorixhq/keyorix/internal/saml"
 	appstorage "github.com/keyorixhq/keyorix/internal/storage"
+	"github.com/keyorixhq/keyorix/internal/startup"
 	"github.com/keyorixhq/keyorix/internal/trust"
 	"github.com/keyorixhq/keyorix/server/grpc"
 	httpServer "github.com/keyorixhq/keyorix/server/http"
@@ -65,6 +66,20 @@ func main() {
 	cfg, err := config.LoadConfig()
 	if err != nil {
 		log.Fatalf("Failed to load configuration: %v", err)
+	}
+
+	// Schema/sanity validation (ports, TLS cert/key presence, storage DSN/path) — always
+	// enforced, independent of any security flag: a malformed config should never boot.
+	if err := cfg.Validate(); err != nil {
+		log.Fatalf("Configuration is invalid: %v", err)
+	}
+
+	// Run the file-permission / encryption-key / database-reachability checks that were
+	// previously reachable ONLY via the manual `keyorix system validate` CLI subcommand
+	// (#330), despite official docs and that command's own help text claiming they run
+	// automatically on every boot.
+	if err := runStartupValidation(cfg); err != nil {
+		log.Fatalf("startup validation: %v", err)
 	}
 
 	// Initialize i18n system
@@ -1285,6 +1300,44 @@ func checkTransportTLSPosture(cfg *config.Config) error {
 		return err
 	}
 	return check("gRPC", cfg.Server.GRPC)
+}
+
+// runStartupValidation runs internal/startup.ValidateStartup — the file-permission,
+// encryption-key (DEK/salt existence + size), and database-reachability checks that were
+// previously reachable ONLY via the manual `keyorix system validate` CLI subcommand,
+// despite that command's own help text and SYSTEM_SETUP.md/docs/CONFIGURATION.md claiming
+// they run automatically on every boot (#330).
+//
+// Gated behind security.enable_file_permission_check — the flag these checks are
+// documented under and the one production.yaml/web-enabled.yaml explicitly turn on — so a
+// deployment that hasn't opted in (the default: the flag defaults to false) is completely
+// unaffected by wiring this in; enforceKeyFilePermissions below still runs unconditionally
+// as the lighter-weight, always-on permission check it always was. When the flag is set,
+// ValidateStartup itself decides warn-vs-fail-closed for a bad permission via
+// allow_unsafe_file_permissions, and auto-fixes bad permissions when
+// auto_fix_file_permissions is set (run first, before enforceKeyFilePermissions, so an
+// auto-fix takes effect before that check re-inspects the same files) — any other failure
+// (missing/undersized DEK or salt, unreachable local database) refuses to start, matching
+// this being "the sole automated backstop for a world-readable master-key-material file."
+func runStartupValidation(cfg *config.Config) error {
+	if !cfg.Security.EnableFilePermissionCheck {
+		return nil
+	}
+	configPath := config.ResolvedPath("")
+	result, err := startup.ValidateStartup(configPath)
+	if result != nil {
+		for _, w := range result.Warnings {
+			log.Printf("startup validation warning: %s", w)
+		}
+		for _, e := range result.Errors {
+			log.Printf("startup validation error: %s", e)
+		}
+	}
+	if err != nil {
+		return err
+	}
+	log.Printf("Startup validation passed (config, file permissions, encryption keys, database).")
+	return nil
 }
 
 // enforceKeyFilePermissions refuses to start (or, by default, loudly warns) when sensitive

--- a/server/startup_validation_test.go
+++ b/server/startup_validation_test.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+)
+
+// writeStartupTestConfig writes a self-consistent local-storage + encryption config
+// (a config file, a wrapped DEK, a KEK salt, and a SQLite DB file) to dir and returns
+// its path. The permission modes of each file, and whether the permission check is
+// turned on, are parameterized so callers can exercise both the "clean" and
+// "world-readable key material" cases end to end (config file on disk -> config.Load
+// -> runStartupValidation), exactly as server/main.go's real startup sequence does.
+func writeStartupTestConfig(t *testing.T, dir string, enableCheck bool, dekMode, saltMode, dbMode os.FileMode) string {
+	t.Helper()
+
+	dek := filepath.Join(dir, "dek.key")
+	salt := filepath.Join(dir, "kek.salt")
+	dbPath := filepath.Join(dir, "keyorix.db")
+
+	must := func(err error) {
+		t.Helper()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	must(os.WriteFile(dek, make([]byte, 60), dekMode))    // wrapped DEK: 12+32+16 bytes
+	must(os.WriteFile(salt, make([]byte, 32), saltMode))  // KEK salt: 32 bytes
+	must(os.WriteFile(dbPath, []byte("sqlite"), dbMode))
+
+	configPath := filepath.Join(dir, "keyorix.yaml")
+	yamlContent := fmt.Sprintf(`
+storage:
+  type: local
+  database:
+    path: %q
+  encryption:
+    enabled: true
+    dek_path: %q
+    salt_path: %q
+security:
+  enable_file_permission_check: %v
+  allow_unsafe_file_permissions: false
+`, dbPath, dek, salt, enableCheck)
+	must(os.WriteFile(configPath, []byte(yamlContent), 0600))
+	return configPath
+}
+
+// loadStartupTestConfig points KEYORIX_CONFIG_PATH at configPath (mirroring how
+// config.LoadConfig/config.ResolvedPath resolve the default path in server/main.go)
+// and loads it, so runStartupValidation's internal re-load via
+// startup.ValidateStartup sees the exact same file.
+func loadStartupTestConfig(t *testing.T, configPath string) *config.Config {
+	t.Helper()
+	t.Setenv("KEYORIX_CONFIG_PATH", configPath)
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		t.Fatalf("failed to load test config: %v", err)
+	}
+	return cfg
+}
+
+// #330: with security.enable_file_permission_check set (as the documented production
+// template does), a world-readable DEK must refuse to start — this is meant to be the
+// sole automated backstop for exactly this condition, and must not silently no-op.
+func TestRunStartupValidation_EnabledCatchesWorldReadableDEK(t *testing.T) {
+	dir := t.TempDir()
+	configPath := writeStartupTestConfig(t, dir, true, 0644, 0600, 0600)
+	cfg := loadStartupTestConfig(t, configPath)
+
+	if err := runStartupValidation(cfg); err == nil {
+		t.Fatal("expected startup validation to refuse to start with a world-readable DEK")
+	}
+}
+
+// The same world-readable DEK must NOT block startup when the check is left at its
+// default (disabled) — confirming this wiring cannot regress an existing deployment
+// that hasn't opted in to the flag.
+func TestRunStartupValidation_DisabledIsANoOp(t *testing.T) {
+	dir := t.TempDir()
+	configPath := writeStartupTestConfig(t, dir, false, 0644, 0644, 0644)
+	cfg := loadStartupTestConfig(t, configPath)
+
+	if err := runStartupValidation(cfg); err != nil {
+		t.Fatalf("startup validation must be a no-op when the flag is disabled: %v", err)
+	}
+}
+
+// A correctly-permissioned setup with the check enabled must pass cleanly.
+func TestRunStartupValidation_EnabledPassesOnCleanSetup(t *testing.T) {
+	dir := t.TempDir()
+	configPath := writeStartupTestConfig(t, dir, true, 0600, 0600, 0600)
+	cfg := loadStartupTestConfig(t, configPath)
+
+	if err := runStartupValidation(cfg); err != nil {
+		t.Fatalf("expected a clean 0600 setup to pass: %v", err)
+	}
+}
+
+// A completely zero-value config (the shape most local/dev/CI configs take: the flag
+// defaults to false in Go/YAML) must never touch the filesystem or fail, regardless of
+// what encryption/database paths would otherwise be configured — the safety property
+// this wiring relies on to avoid regressing normal server startup.
+func TestRunStartupValidation_ZeroValueConfigIsANoOp(t *testing.T) {
+	if err := runStartupValidation(&config.Config{}); err != nil {
+		t.Fatalf("zero-value config must not fail startup validation: %v", err)
+	}
+}

--- a/server/transport_tls_test.go
+++ b/server/transport_tls_test.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"bytes"
+	"log"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/keyorixhq/keyorix/internal/config"
@@ -90,5 +93,26 @@ func TestCheckTransportTLSPosture(t *testing.T) {
 	// a disabled listener is ignored even under require.
 	if err := checkTransportTLSPosture(cfgWith(false, false, false, false, true)); err != nil {
 		t.Errorf("no enabled listeners must pass: %v", err)
+	}
+}
+
+// #333: TLSConfig.AllowedCiphers is parsed but never wired into the hardcoded
+// AEAD-only CipherSuites list (server/main.go, server/grpc/server.go). An operator who
+// sets it must get a clear warning, not silent no-op — never a hard failure, since the
+// hardcoded list it can't affect is already AEAD-only.
+func TestCheckTransportTLSPosture_WarnsOnDeadAllowedCiphers(t *testing.T) {
+	c := cfgWith(true, true, false, false, false)
+	c.Server.HTTP.TLS.AllowedCiphers = []string{"TLS_AES_128_GCM_SHA256"}
+
+	var buf bytes.Buffer
+	orig := log.Writer()
+	log.SetOutput(&buf)
+	defer log.SetOutput(orig)
+
+	if err := checkTransportTLSPosture(c); err != nil {
+		t.Fatalf("a dead allowed_ciphers setting must warn, not fail: %v", err)
+	}
+	if !strings.Contains(buf.String(), "tls.allowed_ciphers") {
+		t.Errorf("expected a warning mentioning tls.allowed_ciphers, got log output: %q", buf.String())
 	}
 }


### PR DESCRIPTION
## Summary
- `internal/startup.ValidateStartup`/`config.Config.Validate()` were never called from `server/main.go`, despite official docs and the `keyorix system validate` CLI's own help text claiming this validation runs automatically on every boot. An operator following the documented production template with `enable_file_permission_check: true` and a world-readable DEK/salt file got zero warning at startup.
- `cfg.Validate()` now always runs on boot (schema/port/TLS/DSN checks — a malformed config should never start).
- `ValidateStartup` (file-permission/DEK-salt/DB-reachability checks) now runs on boot when `security.enable_file_permission_check` is set, matching the flag it's documented under — unaffected when unset (the default), so no existing deployment's boot behavior changes unless it already opted in.
- **#331**: fixed a hardcoded `"keyorix.yaml"` path instead of the resolved config path (spurious failure on any `KEYORIX_CONFIG_PATH`/non-default-path deployment) via a new `config.ResolvedPath()` helper.
- **#332**: fixed startup validation unconditionally requiring `Storage.Database.Path` (false-failing postgres/remote deployments) — now switches on `Storage.Type` like `Config.Validate()` already correctly does.
- **#333** turned out already addressed by a pre-existing check (`checkTransportTLSPosture`, from an earlier round) that already warns on every boot when `allowed_ciphers`/`protocol_versions` are set but unhonored — no further change needed.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` clean
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues
- [x] `golangci-lint run ./...` — 0 issues
- [x] `GOWORK=off go build -C operator ./...` — clean
- [x] New regression tests covering: the config-path fix, the storage-type-aware validation fix, and an integration-style test proving `server/main.go`'s startup sequence now actually calls validation.