### PR TITLE
harden(operator): scope Secret informer cache to managed Secrets (#327)

### DIFF
--- a/deploy/helm/keyorix-operator/templates/rbac.yaml
+++ b/deploy/helm/keyorix-operator/templates/rbac.yaml
@@ -2,6 +2,21 @@
 The operator needs cluster-wide read on KeyorixSecrets and read/write on the Secrets it
 materialises, plus a namespaced lease for leader election. The Secret verbs match the
 controller's generated RBAC (operator/config/rbac/role.yaml).
+
+NOTE (#327): this ClusterRole/ClusterRoleBinding (rather than a per-namespace Role/
+RoleBinding) reflects the operator's actual deployment model -- a single cluster-wide
+instance watching KeyorixSecret CRs (a namespaced CRD) across every namespace, with no
+--watch-namespaces flag or other dynamic-namespace-discovery mechanism. It genuinely cannot
+predict ahead of time which namespace the next CR (and its TokenSecretRef/target Secret)
+will land in, and Kubernetes RBAC has no way to scope list/watch by resourceNames or to a
+dynamically changing namespace set -- so per-managed-namespace RoleBindings aren't possible
+without also adding namespace-scoping to the operator's deployment model.
+
+To bound the blast radius of this necessarily cluster-wide Secret grant (e.g. if the
+operator process is ever compromised via #184/#240), operator/cmd/main.go scopes the
+manager's Secret informer cache to only Secrets carrying the operator's managed-by label, so
+the operator does not hold an in-memory cache of every Secret in the cluster -- only the
+ones it already owns via this same RBAC.
 */}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/operator/cmd/main.go
+++ b/operator/cmd/main.go
@@ -7,10 +7,14 @@ import (
 	"os"
 	"strings"
 
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
@@ -24,6 +28,47 @@ var scheme = runtime.NewScheme()
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(secretsv1alpha1.AddToScheme(scheme))
+}
+
+// secretCacheOptions scopes the manager's Secret informer to only Secrets the operator
+// itself manages, and routes every other Secret read straight to the API server instead
+// of through that (now-restricted) cache.
+//
+// The operator is deployed as a single cluster-wide instance: it watches KeyorixSecret CRs
+// (a namespaced CRD) across every namespace, with no --watch-namespaces flag or other
+// dynamic-namespace-discovery mechanism, so its ClusterRole necessarily grants Secret
+// get/list/watch/create/update/patch cluster-wide too — the operator genuinely cannot
+// predict which namespace the next CR (and its TokenSecretRef/target Secret) will land in,
+// and Kubernetes RBAC has no way to scope list/watch by resourceNames or to a dynamically
+// changing namespace set. See #327 and operator/config/rbac/role.yaml /
+// deploy/helm/keyorix-operator/templates/rbac.yaml for the fuller writeup.
+//
+// What IS avoidable is controller-runtime's default behavior of caching every Secret in
+// the cluster in the operator's own process memory just because SetupWithManager calls
+// Owns(&corev1.Secret{}) to watch the Secrets it owns. That default cache would hold the
+// full contents of every Secret in the cluster — including ones this operator has no
+// relationship to — turning a compromise of the operator process (e.g. the SSRF/dependency
+// findings #184/#240) into a trivial in-memory dump of the entire cluster's Secrets instead
+// of just the ones it manages. Restricting the informer to controller.ManagedByLabel closes
+// that gap: only Secrets this operator previously created (and therefore already has full
+// read/write RBAC over anyway) are ever resident in its cache.
+//
+// Token Secrets (read via TokenSecretRef) and not-yet-adopted target Secrets never carry
+// that label, so DisableFor routes their reads around the label-restricted cache to a live
+// API call — they stay correctly readable on every reconcile, just uncached.
+func secretCacheOptions() (cache.Options, client.Options) {
+	managedByThisOperator := labels.SelectorFromSet(map[string]string{
+		controller.ManagedByLabel: controller.ManagedByValue,
+	})
+	return cache.Options{
+			ByObject: map[client.Object]cache.ByObject{
+				&corev1.Secret{}: {Label: managedByThisOperator},
+			},
+		}, client.Options{
+			Cache: &client.CacheOptions{
+				DisableFor: []client.Object{&corev1.Secret{}},
+			},
+		}
 }
 
 func main() {
@@ -43,12 +88,18 @@ func main() {
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 	setupLog := ctrl.Log.WithName("setup")
 
+	secretCache, secretClient := secretCacheOptions()
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,
 		Metrics:                metricsserver.Options{BindAddress: metricsAddr},
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "keyorix-operator.secrets.keyorix.io",
+		// Bound the blast radius of the cluster-wide Secret RBAC this operator must hold
+		// (see secretCacheOptions and #327): don't cache every Secret in the cluster, only
+		// ones this operator manages.
+		Cache:  secretCache,
+		Client: secretClient,
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")

--- a/operator/cmd/main_test.go
+++ b/operator/cmd/main_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+
+	"github.com/keyorixhq/keyorix/operator/internal/controller"
+)
+
+// secretByObject finds the corev1.Secret entry in a cache.Options.ByObject map. Map keys
+// there are client.Object interface values (pointers), so a fresh &corev1.Secret{} lookup
+// key never matches by identity — this looks the entry up by dynamic type instead.
+func secretByObject(opts cache.Options) (cache.ByObject, bool) {
+	for obj, byObj := range opts.ByObject {
+		if _, ok := obj.(*corev1.Secret); ok {
+			return byObj, true
+		}
+	}
+	return cache.ByObject{}, false
+}
+
+// secretCacheOptions is the operator's #327 mitigation: without it, the manager's default
+// cache backs Owns(&corev1.Secret{}) by listing/watching/caching EVERY Secret in the
+// cluster in the operator's own process memory, even though the RBAC ClusterRole (required
+// because this is a single cluster-wide operator instance, see cmd/main.go's doc comment)
+// grants access far beyond what any one reconcile touches.
+func TestSecretCacheOptions_ScopesInformerToManagedSecrets(t *testing.T) {
+	cacheOpts, _ := secretCacheOptions()
+
+	byObj, ok := secretByObject(cacheOpts)
+	require.True(t, ok, "the Secret informer must have an explicit ByObject scope, not the cluster-wide default")
+	require.NotNil(t, byObj.Label, "the Secret informer must be restricted by a label selector")
+
+	// Only a Secret carrying the operator's managed-by label is cached...
+	managed := labels.Set{controller.ManagedByLabel: controller.ManagedByValue}
+	assert.True(t, byObj.Label.Matches(managed), "a Secret this operator manages must be cached (Owns() drift-detection depends on it)")
+
+	// ...an arbitrary cluster Secret (e.g. an unrelated workload's Secret, or a
+	// not-yet-adopted target Secret) must NOT be cached.
+	unrelated := labels.Set{"app.kubernetes.io/name": "some-other-app"}
+	assert.False(t, byObj.Label.Matches(unrelated), "a Secret this operator does not manage must not be cached")
+
+	noLabels := labels.Set{}
+	assert.False(t, byObj.Label.Matches(noLabels), "an unlabelled Secret (e.g. a token Secret) must not be cached")
+}
+
+// The label-restricted cache above must not make token Secrets (and not-yet-adopted target
+// Secrets, which never carry the managed-by label) unreadable: direct client reads for
+// Secrets must bypass that cache and go live to the API server instead.
+func TestSecretCacheOptions_DisablesCacheForDirectSecretReads(t *testing.T) {
+	_, clientOpts := secretCacheOptions()
+
+	require.NotNil(t, clientOpts.Cache, "direct Secret reads must be excluded from the label-restricted cache")
+	found := false
+	for _, obj := range clientOpts.Cache.DisableFor {
+		if _, ok := obj.(*corev1.Secret); ok {
+			found = true
+		}
+	}
+	assert.True(t, found, "corev1.Secret must be in Client.Cache.DisableFor so Get/List reads go live, not through the restricted cache")
+}
+
+// Guard against the cache options silently reverting to controller-runtime's cluster-wide
+// default (a nil/empty ByObject map caches everything with no restriction at all).
+func TestSecretCacheOptions_IsNotClusterWideDefault(t *testing.T) {
+	cacheOpts, _ := secretCacheOptions()
+	assert.NotEmpty(t, cacheOpts.ByObject, "cache.Options.ByObject must not be empty, or Secret caching silently reverts to the cluster-wide default")
+}

--- a/operator/config/rbac/role.yaml
+++ b/operator/config/rbac/role.yaml
@@ -1,4 +1,18 @@
 ---
+# NOTE (#327): this is a ClusterRole/ClusterRoleBinding, not a namespaced Role, because the
+# operator is deployed as a single cluster-wide instance that watches KeyorixSecret CRs (a
+# namespaced CRD) across every namespace -- there is no --watch-namespaces flag or other
+# dynamic-namespace-discovery mechanism (see operator/cmd/main.go), so it genuinely cannot
+# predict ahead of time which namespace the next CR (and its TokenSecretRef/target Secret)
+# will land in. Kubernetes RBAC also has no way to scope `list`/`watch` by resourceNames or
+# to a dynamically changing namespace set, so narrowing this to per-namespace RoleBindings
+# isn't possible without also adding namespace-scoping to the operator's deployment model.
+#
+# What operator/cmd/main.go DOES do to bound the blast radius of this necessarily cluster-
+# wide grant: it scopes the manager's Secret informer cache to only Secrets carrying the
+# operator's managed-by label (see secretCacheOptions in operator/cmd/main.go), so a
+# compromised operator process can't trivially dump every cluster Secret straight out of its
+# own in-memory cache -- only ones it already owns via this same RBAC.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/operator/internal/controller/keyorixsecret_controller.go
+++ b/operator/internal/controller/keyorixsecret_controller.go
@@ -176,7 +176,7 @@ func (r *KeyorixSecretReconciler) applySecret(ctx context.Context, ks *secretsv1
 		// or by Helm) and replace its data — letting a CR author clobber another workload's
 		// same-named Secret. A Secret we created carries the managed-by label and is
 		// allowed through.
-		if secret.ResourceVersion != "" && secret.Labels[managedByLabel] != managedByValue {
+		if secret.ResourceVersion != "" && secret.Labels[ManagedByLabel] != ManagedByValue {
 			return fmt.Errorf("refusing to overwrite existing unmanaged Secret %s/%s", ks.Namespace, name)
 		}
 		if err := controllerutil.SetControllerReference(ks, secret, r.Scheme); err != nil {
@@ -185,7 +185,7 @@ func (r *KeyorixSecretReconciler) applySecret(ctx context.Context, ks *secretsv1
 		if secret.Labels == nil {
 			secret.Labels = map[string]string{}
 		}
-		secret.Labels[managedByLabel] = managedByValue
+		secret.Labels[ManagedByLabel] = ManagedByValue
 		secret.Type = secretType
 		secret.Data = data // operator owns the whole data set; removed keys are pruned
 		return nil
@@ -193,11 +193,17 @@ func (r *KeyorixSecretReconciler) applySecret(ctx context.Context, ks *secretsv1
 	return err
 }
 
-// managedByLabel/managedByValue mark a Secret as owned by this operator, so it won't
-// adopt or overwrite a Secret it didn't create.
+// ManagedByLabel/ManagedByValue mark a Secret as owned by this operator, so it won't
+// adopt or overwrite a Secret it didn't create. Exported so cmd/main.go can scope the
+// manager's Secret informer cache to only Secrets carrying this label (see #327): the
+// operator is deployed as a single cluster-wide instance, so its RBAC necessarily grants
+// Secret access in every namespace, but the informer backing Owns(&corev1.Secret{}) has no
+// reason to list/watch/cache Secrets it doesn't manage. Token Secrets and pre-existing
+// unmanaged target Secrets never carry this label, so reads of those are excluded from that
+// cache (they're read live instead) and remain unaffected.
 const (
-	managedByLabel = "app.kubernetes.io/managed-by"
-	managedByValue = "keyorix-operator"
+	ManagedByLabel = "app.kubernetes.io/managed-by"
+	ManagedByValue = "keyorix-operator"
 )
 
 // fail records a SyncError on the Ready condition and requeues with backoff.


### PR DESCRIPTION
## Summary
- The operator's `ClusterRole` grants cluster-wide Secret read/write, bound via a `ClusterRoleBinding` — this reflects its actual deployment model (a single cluster-wide instance watching the namespaced `KeyorixSecret` CRD across every namespace, with no `--watch-namespaces` mechanism, so it genuinely cannot predict which namespace the next CR will land in). The RBAC grant itself stays cluster-wide since narrowing it isn't possible without redesigning the deployment model.
- What **was** avoidable: controller-runtime's default informer cache held every Secret in the cluster in the operator's own process memory, not just ones it manages — turning a future compromise of the operator process (e.g. via the already-filed #184 SSRF or #240 vulnerable dependency) from "confined to Secrets it owns" into "read every Secret cluster-wide straight out of memory."
- `operator/cmd/main.go` now scopes the manager's Secret informer/cache to only Secrets carrying the operator's own managed-by label, routing reads of not-yet-cached objects (e.g. `TokenSecretRef` targets) around the restricted cache to a live, still-fully-authorized API call.

## Test plan
- [x] `GOWORK=off go build -C operator ./...` — clean
- [x] `GOWORK=off go test -C operator ./...` — clean
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go build ./...` / `go test ./...` (main module, unaffected by this change) — clean