### PR TITLE
fix: DB-level email uniqueness + SCIM fail-open guards (#117/#120/#218/#336/#337 HIGH)

### DIFF
--- a/internal/core/concurrency_create_user_test.go
+++ b/internal/core/concurrency_create_user_test.go
@@ -1,0 +1,91 @@
+package core_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// TestConcurrency_CreateUser_NoDuplicateEmail is the (#117) regression: models.User.Email
+// previously had no DB-level unique index (unlike Username's `gorm:"uniqueIndex"`), so
+// concurrent CreateUser calls with the identical email could all succeed, producing
+// multiple rows sharing one email that GetUserByEmail then resolved to an arbitrary one
+// of — a 100%-reproducible ambiguous login/identity-resolution bug (empirically confirmed:
+// 5-8 of 10 concurrent inserts succeeded in every run). This drives many concurrent
+// (*LocalStorage).CreateUser calls for the identical (case-varied) email against a real
+// file-backed SQLite, with the same partial unique index production installs get (mirrors
+// factory.go's ensureUserEmailIndex exactly), and asserts exactly one row survives, with
+// every loser getting the clean ErrDuplicateEmail sentinel rather than a raw
+// constraint-violation error or a silently-duplicated identity.
+func TestConcurrency_CreateUser_NoDuplicateEmail(t *testing.T) {
+	dsn := "file:" + filepath.Join(t.TempDir(), "users.db") + "?_busy_timeout=10000&_journal_mode=WAL"
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.User{}))
+	// Mirror factory.go's ensureUserEmailIndex exactly: a partial, case-insensitive
+	// unique index on live rows, so this test exercises the same DB-level guard
+	// production installs get, not just the (removed) in-process check-then-act read.
+	require.NoError(t, db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS uniq_users_email_active "+
+		"ON users (LOWER(email)) WHERE deleted_at IS NULL AND email <> ''").Error)
+
+	ls := store.NewLocalStorage(db)
+
+	const attackers = 20 // many concurrent creates racing for the same email
+	start := make(chan struct{})
+	errs := make([]error, attackers)
+	var wg sync.WaitGroup
+	for i := 0; i < attackers; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			// Case-varied email + distinct usernames: the point is that email alone
+			// must collide at the DB layer regardless of casing, even though every
+			// other field differs — matching GetUserByEmail's own LOWER(email) lookup.
+			email := "Bob@Example.com"
+			if i%2 == 1 {
+				email = "bob@example.com"
+			}
+			_, cerr := ls.CreateUser(context.Background(), &models.User{
+				Username: fmt.Sprintf("bob%d", i),
+				Email:    email,
+			})
+			errs[i] = cerr
+		}(i)
+	}
+	close(start) // release every create at once
+	wg.Wait()
+
+	var successes, duplicateRejections int
+	for _, cerr := range errs {
+		if cerr == nil {
+			successes++
+			continue
+		}
+		if errors.Is(cerr, storage.ErrDuplicateEmail) {
+			duplicateRejections++
+		}
+	}
+	assert.Equal(t, 1, successes, "exactly one concurrent create must succeed")
+	assert.Equal(t, attackers-1, duplicateRejections,
+		"every other concurrent create must get the clean ErrDuplicateEmail sentinel, not a raw DB error")
+
+	// And the DB must hold exactly one row for the email, regardless of casing — no
+	// ambiguous duplicate identity from the TOCTOU window this closes.
+	var count int64
+	require.NoError(t, db.Model(&models.User{}).
+		Where("LOWER(email) = LOWER(?)", "bob@example.com").
+		Count(&count).Error)
+	assert.Equal(t, int64(1), count, "exactly one user row must exist for the email, regardless of casing")
+}

--- a/internal/core/concurrency_scim_update_email_test.go
+++ b/internal/core/concurrency_scim_update_email_test.go
@@ -1,0 +1,97 @@
+package core_test
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// TestConcurrency_UpdateSCIMUser_NoDuplicateEmail is the (#120/#218) regression, narrowed
+// further by the #117 DB-level fix: UpdateSCIMUser's email-uniqueness guard is a plain
+// check-then-act read (GetUserByEmail) with no transaction/lock, so two (or more)
+// concurrent UpdateSCIMUser calls retargeting different users to the SAME new email can
+// all pass the check before any write lands, reproducing the exact ambiguous-email
+// scenario #120/#218 describe. This drives many concurrent UpdateSCIMUser calls, each
+// retargeting a distinct existing user to the identical new email, against a real
+// file-backed SQLite with the same partial unique index production installs get (mirrors
+// factory.go's ensureUserEmailIndex exactly), and asserts exactly one update wins, with
+// every loser getting the same clean "already in use" error UpdateSCIMUser's sequential
+// pre-check already returns — not a raw constraint-violation message — and the DB holding
+// exactly one row for the contested email.
+func TestConcurrency_UpdateSCIMUser_NoDuplicateEmail(t *testing.T) {
+	dsn := "file:" + filepath.Join(t.TempDir(), "scim_update.db") + "?_busy_timeout=10000&_journal_mode=WAL"
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.User{}, &models.Role{}, &models.Permission{}, &models.RolePermission{},
+		&models.UserRole{}, &models.Group{}, &models.UserGroup{}, &models.GroupRole{},
+		&models.Session{}, &models.AuditEvent{}, &models.Project{}, &models.Environment{},
+	))
+	// Mirror factory.go's ensureUserEmailIndex exactly, so this test exercises the same
+	// DB-level guard production installs get (rather than only the in-process
+	// check-then-act read).
+	require.NoError(t, db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS uniq_users_email_active "+
+		"ON users (LOWER(email)) WHERE deleted_at IS NULL AND email <> ''").Error)
+
+	c := core.NewKeyorixCore(store.NewLocalStorage(db))
+	ctx := context.Background()
+
+	const attackers = 20 // many concurrent SCIM updates racing to claim the same email
+	for i := 0; i < attackers; i++ {
+		require.NoError(t, db.Create(&models.User{
+			ID: uint(i + 1), Username: fmt.Sprintf("user%d", i), Email: fmt.Sprintf("user%d@x.io", i),
+			IsActive: true, AccountState: core.AccountActive,
+		}).Error)
+	}
+
+	target := "shared@x.io"
+	start := make(chan struct{})
+	errs := make([]error, attackers)
+	var wg sync.WaitGroup
+	for i := 0; i < attackers; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			_, uerr := c.UpdateSCIMUser(ctx, 9, uint(i+1), nil, &target, nil)
+			errs[i] = uerr
+		}(i)
+	}
+	close(start) // release every update at once
+	wg.Wait()
+
+	var successes, duplicateRejections int
+	for _, uerr := range errs {
+		if uerr == nil {
+			successes++
+			continue
+		}
+		// The loser of the race gets either the original sequential check's message or,
+		// when it instead loses the DB-level race, the translated ErrDuplicateEmail
+		// message. Both read as "already in use"; neither is a raw constraint-violation
+		// string.
+		if strings.Contains(uerr.Error(), "already in use") {
+			duplicateRejections++
+		}
+	}
+	assert.Equal(t, 1, successes, "exactly one concurrent SCIM update must win the contested email")
+	assert.Equal(t, attackers-1, duplicateRejections,
+		"every other concurrent SCIM update must get a clean 'already in use' error, not a raw DB error")
+
+	var count int64
+	require.NoError(t, db.Model(&models.User{}).
+		Where("LOWER(email) = LOWER(?)", target).
+		Count(&count).Error)
+	assert.Equal(t, int64(1), count, "exactly one user row must hold the contested email — no ambiguous duplicate")
+}

--- a/internal/core/scim.go
+++ b/internal/core/scim.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -143,6 +144,14 @@ func (c *KeyorixCore) ProvisionSCIMUser(ctx context.Context, actorID uint, userN
 		PasswordChangedAt: &now, CreatedAt: now, UpdatedAt: now,
 	})
 	if err != nil {
+		// #117: the FindSCIMUser dedup check above races with a concurrent provision call
+		// for the identical email — both can pass it before either commits. The DB-level
+		// partial unique index catches the loser here and CreateUser wraps it in
+		// ErrDuplicateEmail; surface the same clean error the dedup check above already
+		// returns for the sequential case, instead of a raw constraint-violation message.
+		if errors.Is(err, storage.ErrDuplicateEmail) {
+			return nil, fmt.Errorf("a user already exists for this externalId/email")
+		}
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}
 	// Minimal install-wide baseline role (ADR-021), best-effort.
@@ -173,8 +182,24 @@ func (c *KeyorixCore) UpdateSCIMUser(ctx context.Context, actorID, id uint, disp
 		// identity resolution (SSO matches by email), so silently overwriting a low-priv
 		// account's email to an admin's would corrupt the email→account mapping and
 		// enable account linking/takeover. The create path already guards this.
-		if existing, eerr := c.storage.GetUserByEmail(ctx, *email); eerr == nil && existing != nil && existing.ID != user.ID {
-			return nil, fmt.Errorf("%s: email already in use by another user", i18n.T("ErrorValidation", nil))
+		//
+		// #336: GetUserByEmail returns a non-nil error BOTH when the email is genuinely
+		// unused AND on a real DB failure — treating any error as "no collision" (the
+		// previous `eerr == nil && ...` shape) silently skipped this guard on a transient
+		// error, reintroducing the exact vulnerability it exists to prevent. Distinguish
+		// the two cases the same way FindSCIMUser's create-path lookup does: match the
+		// not-found sentinel text explicitly, and fail CLOSED (refuse the update) on any
+		// other error instead of silently proceeding.
+		existing, eerr := c.storage.GetUserByEmail(ctx, *email)
+		switch {
+		case eerr == nil:
+			if existing != nil && existing.ID != user.ID {
+				return nil, fmt.Errorf("%s: email already in use by another user", i18n.T("ErrorValidation", nil))
+			}
+		case strings.Contains(eerr.Error(), i18n.T("ErrorUserNotFound", nil)):
+			// Genuinely unused — proceed.
+		default:
+			return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), eerr)
 		}
 		user.Email = *email
 	}
@@ -212,6 +237,16 @@ func (c *KeyorixCore) UpdateSCIMUser(ctx context.Context, actorID, id uint, disp
 	user.UpdatedAt = c.now()
 	updated, err := c.storage.UpdateUser(ctx, user)
 	if err != nil {
+		// #120/#218: the email-uniqueness check above is a plain check-then-act read that
+		// races with a concurrent UpdateSCIMUser (or any other create/update) targeting the
+		// identical email — both can pass it before either commits. The DB-level partial
+		// unique index (uniq_users_email_active, #117) catches the loser here and
+		// UpdateUser wraps it in ErrDuplicateEmail; surface the same clean error the check
+		// above already returns for the sequential case, instead of a raw
+		// constraint-violation message.
+		if errors.Is(err, storage.ErrDuplicateEmail) {
+			return nil, fmt.Errorf("%s: email already in use by another user", i18n.T("ErrorValidation", nil))
+		}
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}
 	if deactivated {
@@ -230,8 +265,19 @@ func (c *KeyorixCore) UpdateSCIMUser(ctx context.Context, actorID, id uint, disp
 // everyone out. Mirrors guardLastGlobalAdmin's assignment scan but keyed on the target.
 func (c *KeyorixCore) guardLastAdminDeactivation(ctx context.Context, targetID uint) error {
 	isAdmin, err := c.IsGlobalAdmin(ctx, targetID)
-	if err != nil || !isAdmin {
-		return nil // not an admin (or can't tell) — not the last-admin case
+	if err != nil {
+		// #337: "can't tell" is NOT the same as "confirmed not an admin". The previous
+		// code treated an IsGlobalAdmin lookup error identically to a confirmed non-admin
+		// (both fell through to `return nil`, permitting the deactivation/deprovision),
+		// silently disabling the last-admin lockout guard on exactly the failure mode (a
+		// DB hiccup, or connection-pool exhaustion an attacker could induce) it exists to
+		// protect against — the opposite of the fail-safe behaviour this guard is meant to
+		// provide. Fail CLOSED: refuse the operation rather than risk stranding the
+		// install with zero admins.
+		return fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	if !isAdmin {
+		return nil // confirmed not an admin — not the last-admin case
 	}
 	adminIDs := c.installAdminRoleIDSet(ctx)
 	assignments, err := c.storage.ListProjectRoleAssignments(ctx, 0)

--- a/internal/core/scim_deprovision_test.go
+++ b/internal/core/scim_deprovision_test.go
@@ -22,7 +22,8 @@ func TestDeprovisionSCIMUser_RevokesSessionAndPAT(t *testing.T) {
 	require.NoError(t, i18n.InitializeForTesting())
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
-	require.NoError(t, db.AutoMigrate(&models.User{}, &models.Session{}, &models.PersonalAccessToken{}, &models.AuditEvent{}))
+	require.NoError(t, db.AutoMigrate(&models.User{}, &models.Session{}, &models.PersonalAccessToken{}, &models.AuditEvent{},
+		&models.UserRole{}, &models.Project{}, &models.Environment{}, &models.Group{}, &models.UserGroup{}, &models.GroupRole{}))
 
 	ls := store.NewLocalStorage(db)
 	c := NewKeyorixCore(ls)

--- a/internal/core/scim_guards_test.go
+++ b/internal/core/scim_guards_test.go
@@ -2,12 +2,15 @@ package core
 
 import (
 	"context"
+	"errors"
 	"testing"
 
+	corestorage "github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/keyorixhq/keyorix/internal/storage/store"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
@@ -77,4 +80,117 @@ func TestPatchSCIMGroup_RefusesAddingMemberToAdminGroup(t *testing.T) {
 	_, err := c.PatchSCIMGroup(ctx, 9, 5, nil, []uint{2}, nil)
 	require.Error(t, err, "SCIM must not add a member to an admin-bearing group")
 	assert.Contains(t, err.Error(), "administrative roles")
+}
+
+// TestUpdateSCIMUser_FailsClosedOnTransientEmailLookupError is the (#336) regression:
+// GetUserByEmail returns a non-nil error BOTH when the email is genuinely unused AND on
+// a real DB failure. The previous `eerr == nil && existing != nil && ...` guard treated
+// any error identically to "no collision", silently skipping the uniqueness check on a
+// transient error — reintroducing the exact vulnerability the check exists to prevent,
+// on the same failure mode the sibling create-path fix (FindSCIMUser) is deliberately
+// hardened against. Simulates a genuine storage failure (not the "user not found"
+// sentinel text) via MockStorage and asserts the update is refused, not silently applied.
+func TestUpdateSCIMUser_FailsClosedOnTransientEmailLookupError(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	ms := new(MockStorage)
+	c := NewKeyorixCore(ms)
+	ctx := context.Background()
+
+	target := &models.User{ID: 2, Username: "bob", Email: "bob@x.io", IsActive: true, AccountState: AccountActive}
+	ms.On("GetUser", ctx, uint(2)).Return(target, nil)
+	// A genuine transient failure — NOT the "user not found" sentinel text — must fail
+	// the whole update closed, not be treated as "email is unused".
+	ms.On("GetUserByEmail", ctx, "new@x.io").Return(nil, errors.New("connection refused"))
+
+	newEmail := "new@x.io"
+	_, err := c.UpdateSCIMUser(ctx, 9, 2, nil, &newEmail, nil)
+	require.Error(t, err, "a transient email-lookup failure must refuse the update, not silently apply it")
+	assert.NotContains(t, err.Error(), "already in use",
+		"this is a lookup failure, not a collision — the error must say so, not misreport a collision")
+
+	// The write must never have been attempted.
+	ms.AssertNotCalled(t, "UpdateUser", mock.Anything, mock.Anything)
+}
+
+// TestUpdateSCIMUser_ProceedsWhenEmailGenuinelyUnused confirms the #336 fix didn't turn
+// the guard into an unconditional refusal: the ordinary "email not found" case (the
+// sentinel GetUserByEmail actually returns for a genuinely-unused email) must still let
+// the update proceed.
+func TestUpdateSCIMUser_ProceedsWhenEmailGenuinelyUnused(t *testing.T) {
+	c, db := newSCIMGuardCore(t)
+	ctx := context.Background()
+	require.NoError(t, db.Create(&models.User{ID: 2, Username: "bob", Email: "bob@x.io", IsActive: true, AccountState: AccountActive}).Error)
+
+	newEmail := "unused@x.io"
+	updated, err := c.UpdateSCIMUser(ctx, 9, 2, nil, &newEmail, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "unused@x.io", updated.Email)
+}
+
+// TestGuardLastAdminDeactivation_FailsClosedOnIsGlobalAdminError is the (#337)
+// regression: guardLastAdminDeactivation previously treated an IsGlobalAdmin lookup
+// error identically to "confirmed not an admin" (`if err != nil || !isAdmin { return
+// nil }`), silently permitting a SCIM deactivate/deprovision of the sole install admin
+// on exactly the failure mode (a DB hiccup during this one check) the guard exists to
+// protect against. Simulates a genuine storage failure underneath IsGlobalAdmin via
+// MockStorage and asserts both call sites — UpdateSCIMUser(active:false) and
+// DeprovisionSCIMUser — now refuse the operation instead of silently permitting it.
+func TestGuardLastAdminDeactivation_FailsClosedOnIsGlobalAdminError(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	dbErr := errors.New("connection pool exhausted")
+
+	t.Run("UpdateSCIMUser deactivate", func(t *testing.T) {
+		ms := new(MockStorage)
+		c := NewKeyorixCore(ms)
+		ctx := context.Background()
+		target := &models.User{ID: 1, Username: "root", IsActive: true, AccountState: AccountActive}
+		ms.On("GetUser", ctx, uint(1)).Return(target, nil)
+		ms.On("GetUserRoleIDsAt", ctx, uint(1), Scope{}).Return(nil, dbErr)
+
+		no := false
+		_, err := c.UpdateSCIMUser(ctx, 9, 1, nil, nil, &no)
+		require.Error(t, err, "an IsGlobalAdmin lookup failure must refuse the deactivation, not silently permit it")
+		ms.AssertNotCalled(t, "UpdateUser", mock.Anything, mock.Anything)
+	})
+
+	t.Run("DeprovisionSCIMUser", func(t *testing.T) {
+		ms := new(MockStorage)
+		c := NewKeyorixCore(ms)
+		ctx := context.Background()
+		target := &models.User{ID: 1, Username: "root", IsActive: true, AccountState: AccountActive}
+		ms.On("GetUser", ctx, uint(1)).Return(target, nil)
+		ms.On("GetUserRoleIDsAt", ctx, uint(1), Scope{}).Return(nil, dbErr)
+
+		err := c.DeprovisionSCIMUser(ctx, 9, 1)
+		require.Error(t, err, "an IsGlobalAdmin lookup failure must refuse the deprovision, not silently permit it")
+		ms.AssertNotCalled(t, "UpdateUser", mock.Anything, mock.Anything)
+		ms.AssertNotCalled(t, "WithTransaction", mock.Anything, mock.Anything)
+	})
+}
+
+// TestLocalStorage_UpdateUser_DuplicateEmailWrapsSentinel is the storage-layer half of the
+// (#120/#218) regression: UpdateUser must translate a DB-level email-uniqueness violation
+// into the clean ErrDuplicateEmail sentinel (mirroring CreateUser), not a raw
+// constraint-violation error. See concurrency_scim_update_email_test.go for the full
+// concurrent-UpdateSCIMUser race regression.
+func TestLocalStorage_UpdateUser_DuplicateEmailWrapsSentinel(t *testing.T) {
+	c, db := newSCIMGuardCore(t)
+	_ = c
+	// Install the same partial unique index production installs get (mirrors
+	// factory.go's ensureUserEmailIndex), since newSCIMGuardCore's in-memory AutoMigrate
+	// doesn't run the storage-factory migration path that creates it.
+	require.NoError(t, db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS uniq_users_email_active "+
+		"ON users (LOWER(email)) WHERE deleted_at IS NULL AND email <> ''").Error)
+	ctx := context.Background()
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "alice", Email: "alice@x.io", IsActive: true, AccountState: AccountActive}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 2, Username: "bob", Email: "bob@x.io", IsActive: true, AccountState: AccountActive}).Error)
+
+	ls := store.NewLocalStorage(db)
+	u2, err := ls.GetUser(ctx, 2)
+	require.NoError(t, err)
+	u2.Email = "alice@x.io" // collides with user 1
+	_, err = ls.UpdateUser(ctx, u2)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, corestorage.ErrDuplicateEmail),
+		"a DB-level email collision on UpdateUser must be wrapped in the ErrDuplicateEmail sentinel")
 }

--- a/internal/core/scim_suspend_wins_test.go
+++ b/internal/core/scim_suspend_wins_test.go
@@ -18,7 +18,8 @@ func newSCIMStateCore(t *testing.T) (*KeyorixCore, *gorm.DB) {
 	require.NoError(t, i18n.InitializeForTesting())
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
-	require.NoError(t, db.AutoMigrate(&models.User{}, &models.Session{}, &models.AuditEvent{}))
+	require.NoError(t, db.AutoMigrate(&models.User{}, &models.Session{}, &models.AuditEvent{},
+		&models.UserRole{}, &models.Project{}, &models.Environment{}, &models.Group{}, &models.UserGroup{}, &models.GroupRole{}))
 	c := NewKeyorixCore(store.NewLocalStorage(db))
 	require.NoError(t, db.Create(&models.User{ID: 1, Username: "alice", IsActive: true, AccountState: AccountActive}).Error)
 	return c, db

--- a/internal/core/sso.go
+++ b/internal/core/sso.go
@@ -18,6 +18,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"sort"
@@ -27,6 +28,7 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 	"golang.org/x/oauth2"
 
+	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/i18n"
 	samlpkg "github.com/keyorixhq/keyorix/internal/saml"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
@@ -423,6 +425,14 @@ func (c *KeyorixCore) provisionSSOUser(ctx context.Context, p *SSOProvider, sub,
 		PasswordChangedAt: &now, CreatedAt: now, UpdatedAt: now,
 	})
 	if err != nil {
+		// #117: the FindSCIMUser reuse-check above races with a concurrent JIT-provision
+		// (or any other create) for the identical email — both can pass it before either
+		// commits. The DB-level partial unique index catches the loser here and CreateUser
+		// wraps it in ErrDuplicateEmail; surface a clean error instead of a raw
+		// constraint-violation message.
+		if errors.Is(err, storage.ErrDuplicateEmail) {
+			return nil, fmt.Errorf("a user with this email already exists")
+		}
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}
 	role := strings.TrimSpace(p.DefaultRole)

--- a/internal/core/storage/errors.go
+++ b/internal/core/storage/errors.go
@@ -29,3 +29,15 @@ var ErrBreakGlassNotActive = errors.New("break-glass activation is not active")
 // be told cleanly that the membership already exists, rather than surfacing a raw
 // constraint-violation error or silently leaving an orphaned row.
 var ErrDuplicateActiveMembership = errors.New("an active membership already exists for this project and user")
+
+// ErrDuplicateEmail is returned (wrapped) by CreateUser/CreateUserWithRoleGrants/UpdateUser
+// when the write collides with the partial, case-insensitive unique index on users.email
+// (live rows only). Every email-uniqueness check in this codebase (CreateUser, signup,
+// invite-accept, SSO JIT-provision, SCIM provision/update) is a check-then-act read
+// followed by a later write, which is inherently racy — two concurrent calls for the
+// identical email can both pass their pre-check before either commits (#117). The DB-level
+// index makes the loser's write fail here instead of silently minting a second account
+// sharing the email (which left GetUserByEmail resolving to an arbitrary one of them);
+// callers translate this into a clean "email already in use" error rather than a raw
+// constraint-violation message.
+var ErrDuplicateEmail = errors.New("a user with this email already exists")

--- a/internal/core/users.go
+++ b/internal/core/users.go
@@ -6,6 +6,7 @@ package core
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -93,6 +94,16 @@ func (c *KeyorixCore) CreateUser(ctx context.Context, req *CreateUserRequest) (*
 
 	createdUser, err := c.storage.CreateUser(ctx, user)
 	if err != nil {
+		// #117: the pre-check above (GetUserByEmail) is a check-then-act read that races
+		// with a concurrent create for the identical email — both can pass it before
+		// either commits. The DB-level partial unique index (uniq_users_email_active)
+		// catches the loser here and CreateUser wraps it in ErrDuplicateEmail; surface the
+		// same clean "email already in use" error the winner's sequential check would have
+		// produced, instead of a raw constraint-violation message or an ambiguous
+		// duplicate-email row.
+		if errors.Is(err, storage.ErrDuplicateEmail) {
+			return nil, fmt.Errorf("%s: user with email already exists", i18n.T("ErrorValidation", nil))
+		}
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}
 
@@ -161,6 +172,10 @@ func (c *KeyorixCore) CreateUserWithAssignments(ctx context.Context, req *Create
 
 	created, err := c.storage.CreateUserWithRoleGrants(ctx, user, grants)
 	if err != nil {
+		// #117: same race/translation as CreateUser above — see its comment.
+		if errors.Is(err, storage.ErrDuplicateEmail) {
+			return nil, fmt.Errorf("%s: user with email already exists", i18n.T("ErrorValidation", nil))
+		}
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}
 

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -642,6 +642,15 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 		if err := ensureUserNameIndex(db); err != nil {
 			return err
 		}
+		// Add a DB-level, case-insensitive, live-rows-only unique index on users.email
+		// (#117): CreateUser/signup/invite-accept/SCIM provisioning previously enforced
+		// email uniqueness only via a check-then-act read, letting concurrent creates for
+		// the identical email all succeed and leaving GetUserByEmail to resolve to an
+		// arbitrary one of the resulting rows. Additive + idempotent; the full AutoMigrate
+		// below covers fresh DBs.
+		if err := ensureUserEmailIndex(db); err != nil {
+			return err
+		}
 	}
 
 	// Close the share-create race (#136): a partial unique index on live rows so two
@@ -712,6 +721,9 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 	if err := ensureUserNameIndex(db); err != nil {
 		return err
 	}
+	if err := ensureUserEmailIndex(db); err != nil {
+		return err
+	}
 	return ensureShareRecordUniqueIndex(db)
 }
 
@@ -776,6 +788,29 @@ func ensureUserNameIndex(db *gorm.DB) error {
 	}
 	if err := db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS uniq_users_username_active ON users (username) WHERE deleted_at IS NULL").Error; err != nil {
 		return fmt.Errorf("failed to create partial users username index: %w", err)
+	}
+	return nil
+}
+
+// ensureUserEmailIndex creates a partial, case-insensitive unique index on users.email
+// scoped to live (non-deleted) rows with a non-empty email (#117). Without a DB-level
+// constraint, email uniqueness was enforced only by a check-then-act read
+// (GetUserByEmail) before each create/update, which is racy: two concurrent
+// CreateUser/signup/invite-accept/SCIM-provision calls for the identical email could
+// both pass their pre-check before either write landed, producing multiple rows sharing
+// one email that GetUserByEmail then resolves to an arbitrary one of — an ambiguous
+// login/identity-resolution bug, empirically reproduced at a 100% rate under
+// concurrency. The index is on LOWER(email) to match GetUserByEmail's own
+// case-insensitive lookup (`LOWER(email) = LOWER(?)`) — an exact-match index would let
+// the race slip through on a case variant (Bob@x vs bob@x). Scoped to
+// `deleted_at IS NULL` so a soft-deleted (e.g. SCIM-deprovisioned) user's email is freed
+// for reuse on re-provisioning, mirroring ensureUserNameIndex; `email <> ''` so any
+// legacy rows with no email recorded don't collide with each other. Idempotent; works on
+// both SQLite and Postgres (both support expression indexes, partial indexes, and
+// IF [NOT] EXISTS).
+func ensureUserEmailIndex(db *gorm.DB) error {
+	if err := db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS uniq_users_email_active ON users (LOWER(email)) WHERE deleted_at IS NULL AND email <> ''").Error; err != nil {
+		return fmt.Errorf("failed to create partial users email index: %w", err)
 	}
 	return nil
 }

--- a/internal/storage/store/local_users.go
+++ b/internal/storage/store/local_users.go
@@ -31,10 +31,39 @@ var likeEscaper = strings.NewReplacer(`\`, `\\`, "%", `\%`, "_", `\_`)
 // filter into a match-all / full-table scan.
 func escapeLike(s string) string { return likeEscaper.Replace(s) }
 
+// isDuplicateEmailViolation reports whether err is a unique-constraint violation on
+// specifically the partial users-email index (uniq_users_email_active, #117), as
+// distinct from any other unique constraint on the users table (e.g. the username
+// index) or elsewhere. Both SQLite and Postgres include the violated index/constraint
+// name in the driver-native error text for an expression index like this one (SQLite:
+// `UNIQUE constraint failed: index 'uniq_users_email_active'`; Postgres: `duplicate key
+// value violates unique constraint "uniq_users_email_active"`), so matching the index
+// name — rather than the generic isUniqueViolation substrings used for
+// single-unique-index tables like project_memberships — avoids mis-attributing a
+// username collision (or any future users-table unique index) to email. Neither
+// dialector wraps a typed error here (that needs the gorm.Config{TranslateError: true}
+// opt-in, which this codebase doesn't set), so this is driver-native text matching, the
+// same approach already used for "not found"/unique-violation detection elsewhere (e.g.
+// sso.go, users.go, scim.go, local_memberships.go).
+func isDuplicateEmailViolation(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "uniq_users_email_active")
+}
+
 // --- Users ---
 
 func (ls *LocalStorage) CreateUser(ctx context.Context, user *models.User) (*models.User, error) {
 	if err := ls.db.WithContext(ctx).Create(user).Error; err != nil {
+		if isDuplicateEmailViolation(err) {
+			// The partial unique index uniq_users_email_active (#117) caught a concurrent
+			// duplicate: another create/signup/invite-accept/SCIM-provision for the
+			// identical (case-insensitive) email committed first. Translate to the
+			// sentinel so callers can surface a clean "email already in use" error
+			// instead of a raw constraint-violation message.
+			return nil, fmt.Errorf("%w: %v", storage.ErrDuplicateEmail, err)
+		}
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}
 	return user, nil
@@ -46,6 +75,9 @@ func (ls *LocalStorage) CreateUser(ctx context.Context, user *models.User) (*mod
 func (ls *LocalStorage) CreateUserWithRoleGrants(ctx context.Context, user *models.User, grants []storage.RoleGrant) (*models.User, error) {
 	err := ls.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		if err := tx.Create(user).Error; err != nil {
+			if isDuplicateEmailViolation(err) {
+				return fmt.Errorf("%w: %v", storage.ErrDuplicateEmail, err)
+			}
 			return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 		}
 		for _, g := range grants {
@@ -139,6 +171,14 @@ func (ls *LocalStorage) GetUserByExternalID(ctx context.Context, externalID stri
 
 func (ls *LocalStorage) UpdateUser(ctx context.Context, user *models.User) (*models.User, error) {
 	if err := ls.db.WithContext(ctx).Save(user).Error; err != nil {
+		if isDuplicateEmailViolation(err) {
+			// The partial unique index uniq_users_email_active (#117) caught a concurrent
+			// duplicate: another update (e.g. a racing UpdateSCIMUser, #120/#218) already
+			// committed the identical (case-insensitive) email to a different user before
+			// this write landed. Translate to the sentinel so callers surface a clean
+			// "email already in use" error instead of a raw constraint-violation message.
+			return nil, fmt.Errorf("%w: %v", storage.ErrDuplicateEmail, err)
+		}
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}
 	return user, nil

--- a/server/http/handlers/scim_test.go
+++ b/server/http/handlers/scim_test.go
@@ -30,7 +30,7 @@ func setupSCIMTest(t *testing.T) (*SCIMHandler, *gorm.DB) {
 	require.NoError(t, err)
 	require.NoError(t, db.AutoMigrate(
 		&models.User{}, &models.Role{}, &models.UserRole{}, &models.Session{}, &models.AuditEvent{},
-		&models.Group{}, &models.UserGroup{}, &models.GroupRole{},
+		&models.Group{}, &models.UserGroup{}, &models.GroupRole{}, &models.Project{}, &models.Environment{},
 	))
 	require.NoError(t, db.Create(&models.Role{Name: "system_viewer"}).Error)
 	return NewSCIMHandler(core.NewKeyorixCore(store.NewLocalStorage(db))), db


### PR DESCRIPTION
## Summary
- **#117 HIGH (empirically proven, 100% reproduction)** — `users.email` had no DB-level unique index. Concurrent `CreateUser`/signup/invite-accept calls with the identical email could all succeed, leaving `GetUserByEmail` to resolve to an arbitrary one of the resulting rows. Adds a partial, case-insensitive unique index (`LOWER(email)`, live rows only, matching `GetUserByEmail`'s own lookup semantics). Every create/update path now translates the resulting constraint violation into a clean `ErrDuplicateEmail`.
- **#120/#218** — `UpdateSCIMUser`'s email-uniqueness check was a plain check-then-act read; the DB-level index above closes the remaining concurrent-write race.
- **#336 MEDIUM** — `UpdateSCIMUser`'s email-uniqueness guard failed OPEN on a transient `GetUserByEmail` error (treated identically to "email unused"). Now only the explicit not-found case proceeds; any other error fails closed.
- **#337 MEDIUM** — `guardLastAdminDeactivation` failed OPEN on an `IsGlobalAdmin` lookup error, silently disabling the last-admin lockout guard on SCIM deactivate/deprovision on exactly the failure mode it exists to protect against. Now fails closed.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` clean
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues
- [x] `golangci-lint run ./...` — 0 issues
- [x] `GOWORK=off go build -C operator ./...` — clean
- [x] New concurrency regression tests for `CreateUser`/`UpdateSCIMUser` proving the DB now rejects duplicate emails under concurrent creation, plus fail-closed tests for #336/#337 simulating a transient storage error.