### PR TITLE
harden(rbac): close admin-rank-ceiling gap on role GRANTING, group last-admin guard, TOCTOU fix

### DIFF
--- a/internal/core/authz.go
+++ b/internal/core/authz.go
@@ -330,6 +330,193 @@ func (c *KeyorixCore) requireEqualOrGreaterAdminAuthority(ctx context.Context, a
 	return nil
 }
 
+// requireGranterHoldsRolePermissions refuses to GRANT roleID at scope unless the
+// actor already holds, at that scope or broader, EVERY permission bundled into the
+// role — the admin-rank-ceiling check on the GRANT step (#93/#107/#141), distinct
+// from and complementary to #169's check on role DEFINITION. #169 only stops a
+// roles.write holder from bundling a permission they don't hold into a role's
+// definition; it does nothing to stop a roles.assign holder from GRANTING an
+// already-defined, already-permission-rich role — including a pre-existing/seeded
+// builtin like "editor" — to a third party (or to themselves) without holding any
+// of its bundled permissions. c.Authorize already includes the admin-role bypass
+// and resolves a broader (e.g. global) grant the actor holds at a narrower target
+// scope, so a genuine admin, or an actor who already holds every bundled
+// permission at an equal-or-broader scope, is unaffected.
+//
+// actorID 0 is the established "system" pseudo-actor for genuinely non-attacker-
+// reachable callers (the local CLI's AssignRoleToUser); skipped exactly like
+// #169's analogous check on AssignPermissionToRole.
+func (c *KeyorixCore) requireGranterHoldsRolePermissions(ctx context.Context, actorID, roleID uint, scope Scope) error {
+	if actorID == 0 {
+		return nil
+	}
+	perms, err := c.storage.GetRolePermissions(ctx, roleID)
+	if err != nil {
+		return fmt.Errorf("failed to resolve role permissions: %w", err)
+	}
+	for _, p := range perms {
+		ok, aerr := c.Authorize(ctx, actorID, p.Name, scope)
+		if aerr != nil {
+			return fmt.Errorf("failed to resolve actor authority: %w", aerr)
+		}
+		if !ok {
+			return fmt.Errorf("cannot grant this role: you do not hold permission %q yourself", p.Name)
+		}
+	}
+	return nil
+}
+
+// groupHoldsGlobalAdminRole reports whether groupID carries a LIVE global-scope
+// (project 0, environment 0) grant of any role in adminIDs, per the pre-fetched
+// assignments — the cheap relevance check every group-path last-admin guard (#107)
+// runs first: a mutation touching a group with no admin-tier grant at all can
+// never strand the install, so there is nothing to compute or refuse.
+func groupHoldsGlobalAdminRole(assignments []storage.RoleAssignment, adminIDs map[uint]bool, groupID uint) bool {
+	for _, a := range assignments {
+		if a.PrincipalType == "group" && a.PrincipalID == groupID && adminIDs[a.RoleID] {
+			return true
+		}
+	}
+	return false
+}
+
+// resolveGlobalAdminHolders expands the given global-scope assignments (both
+// direct user grants and group grants, the latter to their live members) into the
+// set of user IDs who hold admin-tier authority, after applying the optional
+// exclusions. Backs the group-path last-admin guards (#107): unlike
+// guardLastGlobalAdmin's simpler "does another assignment ROW exist" check
+// (sufficient when the removal itself deletes the admin-conferring row), removing
+// a single user from a group leaves the group's own role grant row intact — only
+// that one member's DERIVED authority disappears — so the check must expand group
+// grants to their actual live members, not just count rows.
+//
+//   - excludeAssignment, when non-nil, drops every assignment row it matches:
+//     the one (group, role) grant being removed (RemoveRoleFromGroup), or every
+//     row belonging to a group being deleted (DeleteGroup).
+//   - excludeMember, when non-nil, drops one specific (groupID, userID) member
+//     expansion while leaving the group's grant — and its OTHER members' derived
+//     authority — intact (RemoveUserFromGroup).
+//
+// Any storage error is returned, never swallowed: silently under-counting here
+// only makes the guard MORE likely to refuse (fail closed), but silently mis-
+// resolving a group's membership on a real error could do the opposite.
+func (c *KeyorixCore) resolveGlobalAdminHolders(ctx context.Context, adminIDs map[uint]bool, assignments []storage.RoleAssignment, excludeAssignment func(storage.RoleAssignment) bool, excludeMember func(groupID, userID uint) bool) (map[uint]bool, error) {
+	holders := make(map[uint]bool)
+	for _, a := range assignments {
+		if !adminIDs[a.RoleID] {
+			continue
+		}
+		if excludeAssignment != nil && excludeAssignment(a) {
+			continue
+		}
+		switch a.PrincipalType {
+		case "user":
+			holders[a.PrincipalID] = true
+		case "group":
+			members, merr := c.storage.ListGroupMembers(ctx, a.PrincipalID)
+			if merr != nil {
+				return nil, fmt.Errorf("failed to resolve group %d membership: %w", a.PrincipalID, merr)
+			}
+			for _, m := range members {
+				if excludeMember != nil && excludeMember(a.PrincipalID, m.ID) {
+					continue
+				}
+				holders[m.ID] = true
+			}
+		}
+	}
+	return holders, nil
+}
+
+// guardLastGlobalAdminGroupRole is guardLastGlobalAdmin's group-role-removal
+// counterpart (#107): refuses to remove roleID from groupID at the global scope
+// when doing so would leave the install with zero global admin-tier holders.
+func (c *KeyorixCore) guardLastGlobalAdminGroupRole(ctx context.Context, groupID, roleID uint, scope Scope) error {
+	if scope.ProjectID != 0 || scope.EnvironmentID != 0 {
+		return nil // not the global scope — project admins are recoverable
+	}
+	adminIDs := c.installAdminRoleIDSet(ctx)
+	if !adminIDs[roleID] {
+		return nil // not removing an install-admin role
+	}
+	assignments, err := c.storage.ListProjectRoleAssignments(ctx, 0)
+	if err != nil {
+		return fmt.Errorf("failed to resolve global role assignments: %w", err)
+	}
+	holders, err := c.resolveGlobalAdminHolders(ctx, adminIDs, assignments, func(a storage.RoleAssignment) bool {
+		return a.PrincipalType == "group" && a.PrincipalID == groupID && a.RoleID == roleID
+	}, nil)
+	if err != nil {
+		return err
+	}
+	if len(holders) == 0 {
+		return fmt.Errorf("refusing to remove role %d from group %d: the install would be left with no super_admin/admin/system_admin at the global scope and no one able to manage users, roles, or settings", roleID, groupID)
+	}
+	return nil
+}
+
+// guardLastGlobalAdminGroupDelete is guardLastGlobalAdmin's group-deletion
+// counterpart (#107): refuses to delete groupID when it holds a global admin-tier
+// role and doing so would leave the install with zero admin-tier holders —
+// deleting a group cascades to remove EVERY role grant it holds, not just one. A
+// group with no admin-tier grant at all is never blocked, regardless of the
+// install's overall admin count.
+func (c *KeyorixCore) guardLastGlobalAdminGroupDelete(ctx context.Context, groupID uint) error {
+	adminIDs := c.installAdminRoleIDSet(ctx)
+	if len(adminIDs) == 0 {
+		return nil // no install-admin role seeded — nothing to guard
+	}
+	assignments, err := c.storage.ListProjectRoleAssignments(ctx, 0)
+	if err != nil {
+		return fmt.Errorf("failed to resolve global role assignments: %w", err)
+	}
+	if !groupHoldsGlobalAdminRole(assignments, adminIDs, groupID) {
+		return nil // this group carries no admin-tier grant — irrelevant to the guard
+	}
+	holders, err := c.resolveGlobalAdminHolders(ctx, adminIDs, assignments, func(a storage.RoleAssignment) bool {
+		return a.PrincipalType == "group" && a.PrincipalID == groupID
+	}, nil)
+	if err != nil {
+		return err
+	}
+	if len(holders) == 0 {
+		return fmt.Errorf("refusing to delete group %d: it holds the install's last administrative role grant, and deleting it would leave no super_admin/admin/system_admin at the global scope", groupID)
+	}
+	return nil
+}
+
+// guardLastGlobalAdminMembership is guardLastGlobalAdmin's group-membership-
+// removal counterpart (#107): refuses to remove userID from groupID when the
+// group's admin-tier grant is userID's only remaining route to global admin-tier
+// authority and no other user holds one either. The group's grant row survives
+// this removal, so — unlike the other two guards — this can't be answered by
+// excluding an assignment row; it must exclude just this one member's derived
+// authority via this one group. A group with no admin-tier grant at all is never
+// blocked, regardless of the install's overall admin count.
+func (c *KeyorixCore) guardLastGlobalAdminMembership(ctx context.Context, userID, groupID uint) error {
+	adminIDs := c.installAdminRoleIDSet(ctx)
+	if len(adminIDs) == 0 {
+		return nil // no install-admin role seeded — nothing to guard
+	}
+	assignments, err := c.storage.ListProjectRoleAssignments(ctx, 0)
+	if err != nil {
+		return fmt.Errorf("failed to resolve global role assignments: %w", err)
+	}
+	if !groupHoldsGlobalAdminRole(assignments, adminIDs, groupID) {
+		return nil // this group carries no admin-tier grant — irrelevant to the guard
+	}
+	holders, err := c.resolveGlobalAdminHolders(ctx, adminIDs, assignments, nil, func(gID, uID uint) bool {
+		return gID == groupID && uID == userID
+	})
+	if err != nil {
+		return err
+	}
+	if len(holders) == 0 {
+		return fmt.Errorf("refusing to remove user %d from group %d: they may be the install's last administrator via this group's role grant, and removing them would leave no super_admin/admin/system_admin at the global scope", userID, groupID)
+	}
+	return nil
+}
+
 // dedupeUints returns ids with duplicates removed, preserving first-seen order.
 func dedupeUints(ids []uint) []uint {
 	if len(ids) <= 1 {

--- a/internal/core/concurrency_last_admin_removal_test.go
+++ b/internal/core/concurrency_last_admin_removal_test.go
@@ -1,0 +1,123 @@
+package core_test
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// #340: guardLastGlobalAdmin's prior read-then-conditional-write was a TOCTOU —
+// with exactly two global admins, each concurrently removing the OTHER's role
+// assignment could both observe "another admin still exists" before either write
+// landed, stranding the install with zero admins. This drives the real
+// RemoveUserRole path from two goroutines racing to remove each other's admin
+// grant and asserts the install is NEVER left with zero: exactly one removal must
+// succeed and the other must be refused, however the goroutines interleave.
+// File-backed SQLite (real multi-connection concurrency) run under -race.
+func TestConcurrency_RemoveUserRole_CannotStrandLastTwoAdmins(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	dsn := "file:" + filepath.Join(t.TempDir(), "c.db") + "?_busy_timeout=10000&_journal_mode=WAL&_txlock=immediate"
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.Role{}, &models.Permission{}, &models.RolePermission{}, &models.UserRole{},
+		&models.Group{}, &models.UserGroup{}, &models.GroupRole{},
+		&models.Project{}, &models.Environment{}, &models.AuditEvent{},
+	))
+	require.NoError(t, db.Create(&models.Role{ID: 1, Name: "admin"}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 100, RoleID: 1}).Error) // admin #1, global
+	require.NoError(t, db.Create(&models.UserRole{UserID: 101, RoleID: 1}).Error) // admin #2, global
+
+	c := core.NewKeyorixCore(store.NewLocalStorage(db))
+	ctx := context.Background()
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	results := make(chan error, 2)
+	// Each goroutine removes the OTHER admin's role — the exact race #340 describes.
+	for _, uid := range []uint{100, 101} {
+		wg.Add(1)
+		go func(target uint) {
+			defer wg.Done()
+			<-start
+			results <- c.RemoveUserRole(ctx, 0, target, 1, core.Scope{})
+		}(uid)
+	}
+	close(start)
+	wg.Wait()
+	close(results)
+
+	var succeeded, refused int
+	for e := range results {
+		if e == nil {
+			succeeded++
+		} else {
+			refused++
+		}
+	}
+	assert.Equal(t, 1, succeeded, "exactly one of the two concurrent removals must succeed")
+	assert.Equal(t, 1, refused, "exactly one of the two concurrent removals must be refused")
+
+	// The install must have exactly one admin left standing — never zero.
+	var remaining int64
+	require.NoError(t, db.Model(&models.UserRole{}).Where("role_id = ?", 1).Count(&remaining).Error)
+	assert.Equal(t, int64(1), remaining, "the install must never be left with zero global admins")
+}
+
+// A higher-concurrency variant of the same invariant: N goroutines all racing to
+// remove role grants from a small, fixed set of global admins must never drive the
+// admin count to zero, regardless of scheduling. Repeats several independent
+// two-admin scenarios in the same run to make a would-be race window more likely
+// to be hit than a single pair alone.
+func TestConcurrency_RemoveUserRole_RepeatedPairsNeverStrandInstall(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+
+	const trials = 8
+	for trial := 0; trial < trials; trial++ {
+		trial := trial
+		t.Run(fmt.Sprintf("trial-%d", trial), func(t *testing.T) {
+			dsn := "file:" + filepath.Join(t.TempDir(), "c.db") + "?_busy_timeout=10000&_journal_mode=WAL&_txlock=immediate"
+			db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+			require.NoError(t, err)
+			require.NoError(t, db.AutoMigrate(
+				&models.Role{}, &models.Permission{}, &models.RolePermission{}, &models.UserRole{},
+				&models.Group{}, &models.UserGroup{}, &models.GroupRole{},
+				&models.Project{}, &models.Environment{}, &models.AuditEvent{},
+			))
+			require.NoError(t, db.Create(&models.Role{ID: 1, Name: "admin"}).Error)
+			require.NoError(t, db.Create(&models.UserRole{UserID: 200, RoleID: 1}).Error)
+			require.NoError(t, db.Create(&models.UserRole{UserID: 201, RoleID: 1}).Error)
+
+			c := core.NewKeyorixCore(store.NewLocalStorage(db))
+			ctx := context.Background()
+
+			start := make(chan struct{})
+			var wg sync.WaitGroup
+			for _, uid := range []uint{200, 201} {
+				wg.Add(1)
+				go func(target uint) {
+					defer wg.Done()
+					<-start
+					_ = c.RemoveUserRole(ctx, 0, target, 1, core.Scope{})
+				}(uid)
+			}
+			close(start)
+			wg.Wait()
+
+			var remaining int64
+			require.NoError(t, db.Model(&models.UserRole{}).Where("role_id = ?", 1).Count(&remaining).Error)
+			assert.Equal(t, int64(1), remaining, "the install must never be left with zero global admins")
+		})
+	}
+}

--- a/internal/core/dual_control_external_test.go
+++ b/internal/core/dual_control_external_test.go
@@ -28,6 +28,10 @@ func TestApprove_SingleControlDefault(t *testing.T) {
 	ctx := context.Background()
 	h.CreateTestUser(t, "alice", 10)  // requester
 	h.CreateTestUser(t, "admin1", 11) // approver
+	// #93/#107/#141: the approver must themselves hold every permission of the
+	// role being granted (editor: secrets.read/write, users.read) — grant them
+	// "admin" globally so the ceiling check's admin bypass applies.
+	h.AssignUserRole(t, 11, 2, nil)
 	reqID := seedPendingRequest(t, h, 10)
 
 	req, err := h.CoreService.ApproveAccessRequestWithExpiry(ctx, 2, reqID, 11, "", 0)
@@ -50,6 +54,11 @@ func TestApprove_DualControl(t *testing.T) {
 	h.CreateTestUser(t, "alice", 10)  // requester
 	h.CreateTestUser(t, "admin1", 11) // approver 1
 	h.CreateTestUser(t, "admin2", 12) // approver 2
+	// #93/#107/#141: the threshold-crossing approver must themselves hold every
+	// permission of the role being granted — grant both "admin" globally so the
+	// ceiling check's admin bypass applies regardless of which one crosses it.
+	h.AssignUserRole(t, 11, 2, nil)
+	h.AssignUserRole(t, 12, 2, nil)
 	h.CoreService.SetDualControlPolicy(2)
 	reqID := seedPendingRequest(t, h, 10)
 
@@ -90,6 +99,12 @@ func TestApprove_DualControl_RoleLockedToRequest(t *testing.T) {
 	h.CreateTestUser(t, "alice", 10)  // requester — asks for "editor"
 	h.CreateTestUser(t, "admin1", 11) // approver 1
 	h.CreateTestUser(t, "admin2", 12) // approver 2 (would-be escalator)
+	// #93/#107/#141: the threshold-crossing approver must themselves hold every
+	// permission of the role being granted — grant both "admin" globally so the
+	// ceiling check's admin bypass applies (independent of the dual-control
+	// role-lock this test actually exercises).
+	h.AssignUserRole(t, 11, 2, nil)
+	h.AssignUserRole(t, 12, 2, nil)
 	h.CoreService.SetDualControlPolicy(2)
 	reqID := seedPendingRequest(t, h, 10) // SuggestedRole "editor"
 

--- a/internal/core/group_admin_guard_test.go
+++ b/internal/core/group_admin_guard_test.go
@@ -1,0 +1,175 @@
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// #107 (group-path variant): RemoveRoleFromGroup, DeleteGroup, and
+// RemoveUserFromGroup must each refuse an operation that would strand the install
+// with zero global (project 0) admin-tier holders — mirroring the direct
+// user-role-removal guard (guardLastGlobalAdmin), which they previously had zero
+// call to.
+
+// RemoveRoleFromGroup: removing the group's global admin role must be refused when
+// no other admin route (user or group) survives.
+func TestRemoveRoleFromGroup_RefusesLastGlobalAdmin(t *testing.T) {
+	c, db := newRBACManagementCore(t)
+	ctx := context.Background()
+	require.NoError(t, db.Create(&models.Role{ID: 1, Name: "admin"}).Error)
+	require.NoError(t, db.Create(&models.Group{ID: 1, Name: "ops"}).Error)
+	require.NoError(t, db.Create(&models.GroupRole{GroupID: 1, RoleID: 1}).Error) // global admin grant
+
+	err := c.RemoveRoleFromGroup(ctx, 0, 1, 1, Scope{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no super_admin/admin/system_admin at the global scope")
+
+	// The grant is untouched.
+	var count int64
+	require.NoError(t, db.Model(&models.GroupRole{}).Count(&count).Error)
+	assert.Equal(t, int64(1), count)
+}
+
+// RemoveRoleFromGroup: succeeds once another admin route (a direct user grant)
+// exists — the guard must not over-block.
+func TestRemoveRoleFromGroup_AllowsWhenAnotherAdminExists(t *testing.T) {
+	c, db := newRBACManagementCore(t)
+	ctx := context.Background()
+	require.NoError(t, db.Create(&models.Role{ID: 1, Name: "admin"}).Error)
+	require.NoError(t, db.Create(&models.Group{ID: 1, Name: "ops"}).Error)
+	require.NoError(t, db.Create(&models.GroupRole{GroupID: 1, RoleID: 1}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 42, RoleID: 1}).Error) // another global admin
+
+	require.NoError(t, c.RemoveRoleFromGroup(ctx, 0, 1, 1, Scope{}))
+}
+
+// RemoveRoleFromGroup: a non-admin role grant is never blocked, regardless of the
+// install's admin count.
+func TestRemoveRoleFromGroup_NonAdminRoleAlwaysRemovable(t *testing.T) {
+	c, db := newRBACManagementCore(t)
+	ctx := context.Background()
+	require.NoError(t, db.Create(&models.Role{ID: 3, Name: "editor"}).Error)
+	require.NoError(t, db.Create(&models.Group{ID: 1, Name: "ops"}).Error)
+	require.NoError(t, db.Create(&models.GroupRole{GroupID: 1, RoleID: 3}).Error)
+
+	require.NoError(t, c.RemoveRoleFromGroup(ctx, 0, 1, 3, Scope{}))
+}
+
+// DeleteGroup: deleting a group holding the install's last global admin grant
+// must be refused — deleting the group cascades to remove EVERY role it holds.
+func TestDeleteGroup_RefusesWhenHoldsLastGlobalAdminRole(t *testing.T) {
+	c, db := newRBACManagementCore(t)
+	ctx := context.Background()
+	require.NoError(t, db.Create(&models.Role{ID: 1, Name: "admin"}).Error)
+	require.NoError(t, db.Create(&models.Group{ID: 1, Name: "ops"}).Error)
+	require.NoError(t, db.Create(&models.GroupRole{GroupID: 1, RoleID: 1}).Error)
+
+	err := c.DeleteGroup(ctx, 0, 1)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "last administrative role grant")
+
+	// The group must still exist.
+	g, gerr := c.GetGroup(ctx, 1)
+	require.NoError(t, gerr)
+	assert.Equal(t, uint(1), g.ID)
+}
+
+// DeleteGroup: succeeds once another admin route survives.
+func TestDeleteGroup_AllowsWhenAnotherAdminExists(t *testing.T) {
+	c, db := newRBACManagementCore(t)
+	ctx := context.Background()
+	require.NoError(t, db.Create(&models.Role{ID: 1, Name: "admin"}).Error)
+	require.NoError(t, db.Create(&models.Group{ID: 1, Name: "ops"}).Error)
+	require.NoError(t, db.Create(&models.GroupRole{GroupID: 1, RoleID: 1}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 42, RoleID: 1}).Error)
+
+	require.NoError(t, c.DeleteGroup(ctx, 0, 1))
+}
+
+// DeleteGroup: a group with no admin-tier grant is always deletable, regardless of
+// the install's overall admin count (must not over-block unrelated groups).
+func TestDeleteGroup_NonAdminGroupAlwaysDeletable(t *testing.T) {
+	c, db := newRBACManagementCore(t)
+	ctx := context.Background()
+	require.NoError(t, db.Create(&models.Role{ID: 3, Name: "editor"}).Error)
+	require.NoError(t, db.Create(&models.Group{ID: 1, Name: "ops-team"}).Error)
+	require.NoError(t, db.Create(&models.GroupRole{GroupID: 1, RoleID: 3}).Error)
+
+	require.NoError(t, c.DeleteGroup(ctx, 0, 1))
+}
+
+// RemoveUserFromGroup: the group's role grant row SURVIVES membership removal —
+// this is the case a simple "does another assignment row exist" check cannot
+// catch. Removing the sole member of an admin-conferring group must be refused
+// when no other admin route exists.
+func TestRemoveUserFromGroup_RefusesLastAdminMember(t *testing.T) {
+	c, db := newRBACManagementCore(t)
+	ctx := context.Background()
+	require.NoError(t, db.AutoMigrate(&models.User{}))
+	require.NoError(t, db.Create(&models.Role{ID: 1, Name: "admin"}).Error)
+	require.NoError(t, db.Create(&models.Group{ID: 1, Name: "ops"}).Error)
+	require.NoError(t, db.Create(&models.GroupRole{GroupID: 1, RoleID: 1}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 42, Username: "sole-admin", Email: "sole@example.com"}).Error)
+	require.NoError(t, db.Create(&models.UserGroup{UserID: 42, GroupID: 1}).Error)
+
+	err := c.RemoveUserFromGroup(ctx, 0, 42, 1)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "last administrator")
+
+	// The membership is untouched.
+	var count int64
+	require.NoError(t, db.Model(&models.UserGroup{}).Count(&count).Error)
+	assert.Equal(t, int64(1), count)
+}
+
+// RemoveUserFromGroup: succeeds once another member of the SAME group would still
+// carry the admin authority forward.
+func TestRemoveUserFromGroup_AllowsWhenAnotherGroupMemberRemains(t *testing.T) {
+	c, db := newRBACManagementCore(t)
+	ctx := context.Background()
+	require.NoError(t, db.AutoMigrate(&models.User{}))
+	require.NoError(t, db.Create(&models.Role{ID: 1, Name: "admin"}).Error)
+	require.NoError(t, db.Create(&models.Group{ID: 1, Name: "ops"}).Error)
+	require.NoError(t, db.Create(&models.GroupRole{GroupID: 1, RoleID: 1}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 42, Username: "admin1", Email: "a1@example.com"}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 43, Username: "admin2", Email: "a2@example.com"}).Error)
+	require.NoError(t, db.Create(&models.UserGroup{UserID: 42, GroupID: 1}).Error)
+	require.NoError(t, db.Create(&models.UserGroup{UserID: 43, GroupID: 1}).Error)
+
+	require.NoError(t, c.RemoveUserFromGroup(ctx, 0, 42, 1))
+}
+
+// RemoveUserFromGroup: succeeds once another admin route survives (a direct grant
+// on a different user), even with only one member in the admin-conferring group.
+func TestRemoveUserFromGroup_AllowsWhenDirectAdminExists(t *testing.T) {
+	c, db := newRBACManagementCore(t)
+	ctx := context.Background()
+	require.NoError(t, db.AutoMigrate(&models.User{}))
+	require.NoError(t, db.Create(&models.Role{ID: 1, Name: "admin"}).Error)
+	require.NoError(t, db.Create(&models.Group{ID: 1, Name: "ops"}).Error)
+	require.NoError(t, db.Create(&models.GroupRole{GroupID: 1, RoleID: 1}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 42, Username: "sole-member", Email: "sm@example.com"}).Error)
+	require.NoError(t, db.Create(&models.UserGroup{UserID: 42, GroupID: 1}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 99, RoleID: 1}).Error) // direct global admin
+
+	require.NoError(t, c.RemoveUserFromGroup(ctx, 0, 42, 1))
+}
+
+// RemoveUserFromGroup: membership in a group with no admin-tier grant is always
+// removable, regardless of the install's overall admin count.
+func TestRemoveUserFromGroup_NonAdminGroupAlwaysRemovable(t *testing.T) {
+	c, db := newRBACManagementCore(t)
+	ctx := context.Background()
+	require.NoError(t, db.AutoMigrate(&models.User{}))
+	require.NoError(t, db.Create(&models.Role{ID: 3, Name: "editor"}).Error)
+	require.NoError(t, db.Create(&models.Group{ID: 1, Name: "ops-team"}).Error)
+	require.NoError(t, db.Create(&models.GroupRole{GroupID: 1, RoleID: 3}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 42, Username: "alice", Email: "alice@example.com"}).Error)
+	require.NoError(t, db.Create(&models.UserGroup{UserID: 42, GroupID: 1}).Error)
+
+	require.NoError(t, c.RemoveUserFromGroup(ctx, 0, 42, 1))
+}

--- a/internal/core/groups.go
+++ b/internal/core/groups.go
@@ -74,7 +74,10 @@ func (c *KeyorixCore) UpdateGroup(ctx context.Context, actorID uint, req *Update
 	return updated, nil
 }
 
-// DeleteGroup deletes a group by ID. See CreateGroup for actorID semantics.
+// DeleteGroup deletes a group by ID. See CreateGroup for actorID semantics. It
+// refuses to delete a group holding the install's last global-admin-conferring
+// role grant (#107; see guardLastGlobalAdminGroupDelete) — deleting a group
+// cascades to remove every role grant it holds.
 func (c *KeyorixCore) DeleteGroup(ctx context.Context, actorID, id uint) error {
 	if id == 0 {
 		return fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "group ID is required")
@@ -82,6 +85,9 @@ func (c *KeyorixCore) DeleteGroup(ctx context.Context, actorID, id uint) error {
 	group, err := c.storage.GetGroup(ctx, id)
 	if err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	if err := c.guardLastGlobalAdminGroupDelete(ctx, id); err != nil {
+		return err
 	}
 	if err := c.storage.DeleteGroup(ctx, id); err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
@@ -148,10 +154,15 @@ func (c *KeyorixCore) AddUserToGroup(ctx context.Context, actorID, userID, group
 }
 
 // RemoveUserFromGroup removes a user from a group. See AddUserToGroup for actorID
-// semantics.
+// semantics. It refuses to remove a user whose global admin-tier authority comes
+// solely from this group's role grant when no other admin route remains (#107;
+// see guardLastGlobalAdminMembership).
 func (c *KeyorixCore) RemoveUserFromGroup(ctx context.Context, actorID, userID, groupID uint) error {
 	if userID == 0 || groupID == 0 {
 		return fmt.Errorf("%s: user ID and group ID are required", i18n.T("ErrorValidation", nil))
+	}
+	if err := c.guardLastGlobalAdminMembership(ctx, userID, groupID); err != nil {
+		return err
 	}
 	if err := c.storage.RemoveUserFromGroup(ctx, userID, groupID); err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)

--- a/internal/core/groups_audit_test.go
+++ b/internal/core/groups_audit_test.go
@@ -24,6 +24,7 @@ func TestGroupCRUDAudit(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, db.AutoMigrate(
 		&models.Group{}, &models.GroupRole{}, &models.UserGroup{}, &models.AuditEvent{}, &models.Role{},
+		&models.UserRole{},
 	))
 	c := &KeyorixCore{storage: store.NewLocalStorage(db)}
 	ctx := context.Background()
@@ -74,6 +75,7 @@ func TestGroupMembershipAudit(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, db.AutoMigrate(
 		&models.Group{}, &models.User{}, &models.UserGroup{}, &models.AuditEvent{},
+		&models.Role{}, &models.UserRole{}, &models.GroupRole{},
 	))
 	require.NoError(t, db.Create(&models.Group{ID: 7, Name: "platform"}).Error)
 	require.NoError(t, db.Create(&models.User{ID: 11, Username: "alice", Email: "alice@example.com"}).Error)

--- a/internal/core/invitation_global_test.go
+++ b/internal/core/invitation_global_test.go
@@ -146,13 +146,16 @@ func TestApplyInvitationGrants_SystemRoleIsRBACAudited(t *testing.T) {
 	c, st := newBootstrappedCore(t)
 	ctx := context.Background()
 
-	inviter, err := st.CreateUser(ctx, &models.User{Username: "admin-inviter", Email: "inviter@example.com", IsActive: true})
-	require.NoError(t, err)
+	// #93/#107/#141: the inviter must themselves hold every permission of the
+	// role they're granting (system_auditor here) — give them "admin" so the
+	// ceiling check's admin bypass applies, same as a real install where only an
+	// admin can invite someone into a system_auditor-or-richer role.
+	inviterID := seedUserWithRole(t, st, "admin-inviter", "admin", storage.Scope{})
 	invitee, err := st.CreateUser(ctx, &models.User{Username: "carol", Email: "carol@example.com", IsActive: true})
 	require.NoError(t, err)
 
 	inv := &models.ProjectInvitation{
-		ID: 1, ProjectID: 0, Email: invitee.Email, InvitedBy: inviter.ID,
+		ID: 1, ProjectID: 0, Email: invitee.Email, InvitedBy: inviterID,
 		SystemRole: "system_auditor",
 	}
 
@@ -168,7 +171,7 @@ func TestApplyInvitationGrants_SystemRoleIsRBACAudited(t *testing.T) {
 	}
 	require.NotNil(t, assigned, "global-invitation system-role grant must appear in the RBAC audit trail")
 	require.NotNil(t, assigned.ActorUserID)
-	assert.Equal(t, inviter.ID, *assigned.ActorUserID)
+	assert.Equal(t, inviterID, *assigned.ActorUserID)
 	require.NotNil(t, assigned.TargetUserID)
 	assert.Equal(t, invitee.ID, *assigned.TargetUserID)
 }

--- a/internal/core/invitations_test.go
+++ b/internal/core/invitations_test.go
@@ -286,6 +286,12 @@ func TestApproveAccessRequestWithExpiry_IsRBACAudited(t *testing.T) {
 
 	approver, err := st.CreateUser(ctx, &models.User{Username: "approver", Email: "approver@example.com", IsActive: true})
 	require.NoError(t, err)
+	// #93/#107/#141: the approver must themselves hold every permission of the
+	// role being granted — grant "admin" globally so the ceiling check's admin
+	// bypass applies.
+	adminRole, err := st.GetRoleByName(ctx, "admin")
+	require.NoError(t, err)
+	require.NoError(t, st.AssignRole(ctx, approver.ID, adminRole.ID, storage.Scope{}))
 	requester, err := st.CreateUser(ctx, &models.User{Username: "requester", Email: "requester@example.com", IsActive: true})
 	require.NoError(t, err)
 	req, err := st.CreateAccessRequest(ctx, &models.AccessRequest{

--- a/internal/core/jit_access.go
+++ b/internal/core/jit_access.go
@@ -16,6 +16,18 @@ import (
 // AssignUserRoleWithExpiry assigns a time-bound role to a user at scope (the grant
 // stops authorizing once expiresAt passes) and records the assignment. actorID is
 // the granting principal (0 = unauthenticated/system).
+//
+// KNOWN GAP (tracked, not fixed here): unlike AssignUserRole, this does NOT run
+// requireGranterHoldsRolePermissions (#93/#107/#141) — it writes directly via
+// storage, bypassing the grant-ceiling check entirely. The HTTP JIT-assign-with-
+// expiry path (POST /user-roles with expires_at) and the access-request TTL-grant
+// path (invitations.go) both reach this unguarded, so a roles.assign holder can
+// currently bundle-grant a time-bound role with a permission they don't hold. Left
+// unfixed in this change deliberately: break_glass.go's self-service emergency
+// grant also calls this, and legitimately MUST elevate a user beyond their current
+// permissions (that's break-glass's entire purpose) — closing this gap needs a
+// break-glass-aware carve-out, which is its own follow-up, not a mechanical mirror
+// of AssignUserRole's fix.
 func (c *KeyorixCore) AssignUserRoleWithExpiry(ctx context.Context, actorID, userID, roleID uint, scope Scope, expiresAt time.Time) error {
 	if err := c.storage.AssignRoleWithExpiry(ctx, userID, roleID, scope, expiresAt); err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)

--- a/internal/core/jit_access_external_test.go
+++ b/internal/core/jit_access_external_test.go
@@ -145,6 +145,10 @@ func TestApproveAccessRequest_PermanentByDefault(t *testing.T) {
 	const proj = uint(2)
 	ctx := context.Background()
 	h.CreateTestUser(t, "alice", 10)
+	// #93/#107/#141: the approver must themselves hold every permission of the
+	// role being granted — grant "admin" globally so the ceiling check's admin
+	// bypass applies.
+	h.AssignUserRole(t, 1, 2, nil)
 
 	created, err := h.Storage.CreateAccessRequest(ctx, &models.AccessRequest{
 		ProjectID: proj, UserID: 10, SuggestedRole: "editor", State: core.AccessRequestPending,

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -118,6 +118,14 @@ func (m *MockStorage) ListProjectRoleAssignments(ctx context.Context, projectID 
 	return args.Get(0).([]storage.RoleAssignment), args.Error(1)
 }
 
+// ListGlobalAdminAssignmentsForUpdate is unused by the tests that construct a
+// MockStorage directly (they don't exercise RemoveUserRole's last-admin guard);
+// returns empty so the guard treats "no other admin" as the default in the rare
+// case something reaches it.
+func (m *MockStorage) ListGlobalAdminAssignmentsForUpdate(_ context.Context, _ []uint) ([]storage.RoleAssignment, error) {
+	return nil, nil
+}
+
 func (m *MockStorage) CreateProjectInvitation(ctx context.Context, inv *models.ProjectInvitation) (*models.ProjectInvitation, error) {
 	args := m.Called(ctx, inv)
 	if args.Get(0) == nil {

--- a/internal/core/project_members_test.go
+++ b/internal/core/project_members_test.go
@@ -6,9 +6,27 @@ import (
 
 	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// grantGlobalAdmin gives actorID the "admin" role at the global scope, so it
+// satisfies the #93/#107/#141 grant-ceiling check (AssignUserRole requires the
+// granting actor already hold every permission bundled into the role being
+// granted; the admin bypass in Authorize covers that trivially) for these
+// project-member tests, which weren't otherwise concerned with the actor's own
+// authority. A GLOBAL grant doesn't show up in a per-project assignment listing
+// (ListProjectRoleAssignments filters on the exact project ID), so it also does
+// NOT get counted as "another project admin" by guardLastProjectAdmin — the
+// last-project-admin scenarios these tests exercise are unaffected.
+func grantGlobalAdmin(t *testing.T, st *store.LocalStorage, actorID uint) {
+	t.Helper()
+	ctx := context.Background()
+	role, err := st.GetRoleByName(ctx, "admin")
+	require.NoError(t, err)
+	require.NoError(t, st.AssignRole(ctx, actorID, role.ID, storage.Scope{}))
+}
 
 func TestProjectMemberLifecycle(t *testing.T) {
 	c, st := newBootstrappedCore(t)
@@ -24,6 +42,7 @@ func TestProjectMemberLifecycle(t *testing.T) {
 	assert.Empty(t, members)
 
 	const actor = uint(99)
+	grantGlobalAdmin(t, st, actor)
 
 	// Add as project_viewer.
 	require.NoError(t, c.AddProjectMember(ctx, actor, proj, u.ID, "project_viewer"))
@@ -75,6 +94,7 @@ func TestProjectMemberGrantIsRBACAudited(t *testing.T) {
 	ctx := context.Background()
 	const proj = uint(9)
 	const actor = uint(55)
+	grantGlobalAdmin(t, st, actor)
 
 	u, err := st.CreateUser(ctx, &models.User{Username: "carol", Email: "carol@example.com", IsActive: true})
 	require.NoError(t, err)
@@ -120,6 +140,7 @@ func TestRemoveProjectMember_RevokesEnvironmentScopedGrantToo(t *testing.T) {
 	const proj = uint(7)
 	const prodEnv = uint(99)
 	const actor = uint(55)
+	grantGlobalAdmin(t, st, actor)
 
 	u, err := st.CreateUser(ctx, &models.User{Username: "carol", Email: "carol@example.com", IsActive: true})
 	require.NoError(t, err)
@@ -160,6 +181,7 @@ func TestRemoveProjectMember_RefusesLastAdmin(t *testing.T) {
 	ctx := context.Background()
 	const proj = uint(7)
 	const actor = uint(55)
+	grantGlobalAdmin(t, st, actor)
 
 	u, err := st.CreateUser(ctx, &models.User{Username: "dave", Email: "dave@example.com", IsActive: true})
 	require.NoError(t, err)
@@ -183,6 +205,7 @@ func TestSetProjectMemberRole_RefusesLastAdminDemotion(t *testing.T) {
 	ctx := context.Background()
 	const proj = uint(7)
 	const actor = uint(55)
+	grantGlobalAdmin(t, st, actor)
 
 	u, err := st.CreateUser(ctx, &models.User{Username: "erin", Email: "erin@example.com", IsActive: true})
 	require.NoError(t, err)
@@ -205,6 +228,7 @@ func TestRemoveProjectMember_AllowsNonLastAdmin(t *testing.T) {
 	ctx := context.Background()
 	const proj = uint(7)
 	const actor = uint(55)
+	grantGlobalAdmin(t, st, actor)
 
 	u1, err := st.CreateUser(ctx, &models.User{Username: "frank", Email: "frank@example.com", IsActive: true})
 	require.NoError(t, err)
@@ -234,6 +258,7 @@ func TestRemoveProjectMember_NonAdminAlwaysRemovable(t *testing.T) {
 	ctx := context.Background()
 	const proj = uint(7)
 	const actor = uint(55)
+	grantGlobalAdmin(t, st, actor)
 
 	u, err := st.CreateUser(ctx, &models.User{Username: "henry", Email: "henry@example.com", IsActive: true})
 	require.NoError(t, err)

--- a/internal/core/rbac_audit_test.go
+++ b/internal/core/rbac_audit_test.go
@@ -16,7 +16,11 @@ func newRBACAuditCore(t *testing.T) *KeyorixCore {
 	t.Helper()
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
-	require.NoError(t, db.AutoMigrate(&models.AuditEvent{}, &models.UserRole{}))
+	require.NoError(t, db.AutoMigrate(
+		&models.AuditEvent{}, &models.UserRole{}, &models.Role{}, &models.Permission{},
+		&models.RolePermission{}, &models.Group{}, &models.UserGroup{}, &models.GroupRole{},
+		&models.Project{}, &models.Environment{},
+	))
 	return NewKeyorixCore(store.NewLocalStorage(db))
 }
 

--- a/internal/core/rbac_grant_ceiling_test.go
+++ b/internal/core/rbac_grant_ceiling_test.go
@@ -1,0 +1,158 @@
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// #93/#107/#141: a roles.assign holder with no other authority must not be able to
+// GRANT a role bundling a permission they don't hold themselves — the "grant"
+// counterpart to #169's "definition" fix (TestAssignPermissionToRole_*, above).
+// "editor" here stands in for any pre-existing/seeded permission-rich role: the
+// attacker never touched its definition, only its grant.
+func TestAssignUserRole_RequiresActorHoldRolePermissions(t *testing.T) {
+	c, db := newRBACManagementCore(t)
+	ctx := context.Background()
+	require.NoError(t, db.Create(&models.Role{ID: 2, Name: "editor"}).Error)
+	require.NoError(t, db.Create(&models.Permission{ID: 1, Name: "secrets.delete", Resource: "secrets", Action: "delete"}).Error)
+	require.NoError(t, db.Create(&models.RolePermission{RoleID: 2, PermissionID: 1}).Error)
+
+	const attacker = uint(9) // holds roles.assign in the real exploit (irrelevant here — no roles at all)
+	const target = uint(10)
+	err := c.AssignUserRole(ctx, attacker, target, 2, Scope{ProjectID: 3})
+	require.Error(t, err, "a roles.assign holder must not grant a role bundling a permission they don't hold themselves")
+	assert.Contains(t, err.Error(), "do not hold permission")
+
+	var count int64
+	require.NoError(t, db.Model(&models.UserRole{}).Count(&count).Error)
+	assert.Zero(t, count, "the grant must not have been persisted")
+}
+
+// The same escalation-by-proxy shape works against a THIRD party too, not just a
+// self-grant — a roles.assign holder must not be able to hand a permission-rich
+// role to anyone else either.
+func TestAssignUserRole_CannotGrantToThirdPartyEither(t *testing.T) {
+	c, db := newRBACManagementCore(t)
+	ctx := context.Background()
+	require.NoError(t, db.Create(&models.Role{ID: 2, Name: "editor"}).Error)
+	require.NoError(t, db.Create(&models.Permission{ID: 1, Name: "secrets.delete", Resource: "secrets", Action: "delete"}).Error)
+	require.NoError(t, db.Create(&models.RolePermission{RoleID: 2, PermissionID: 1}).Error)
+	// attacker DOES hold roles.assign at the project (the gate every grant path
+	// already enforces at the router/handler layer) — but not secrets.delete.
+	require.NoError(t, db.Create(&models.Permission{ID: 2, Name: "roles.assign", Resource: "roles", Action: "assign"}).Error)
+	require.NoError(t, db.Create(&models.Role{ID: 3, Name: "role-manager"}).Error)
+	require.NoError(t, db.Create(&models.RolePermission{RoleID: 3, PermissionID: 2}).Error)
+
+	const attacker = uint(9)
+	const victim = uint(20) // a third party, not the attacker themselves
+	require.NoError(t, db.Create(&models.UserRole{UserID: attacker, RoleID: 3, ProjectID: 3}).Error)
+
+	err := c.AssignUserRole(ctx, attacker, victim, 2, Scope{ProjectID: 3})
+	require.Error(t, err, "holding roles.assign alone must not be enough to grant a role bundling secrets.delete")
+	assert.Contains(t, err.Error(), "do not hold permission")
+}
+
+// A project-scoped holder of the bundled permission cannot use it to grant the
+// role at a BROADER (global) scope than they hold it at — the ceiling check
+// resolves the actor's authority AT THE TARGET SCOPE, not anywhere.
+func TestAssignUserRole_ScopedHolderCannotGrantAtBroaderScope(t *testing.T) {
+	c, db := newRBACManagementCore(t)
+	ctx := context.Background()
+	require.NoError(t, db.Create(&models.Role{ID: 2, Name: "editor"}).Error)
+	require.NoError(t, db.Create(&models.Permission{ID: 1, Name: "secrets.delete", Resource: "secrets", Action: "delete"}).Error)
+	require.NoError(t, db.Create(&models.RolePermission{RoleID: 2, PermissionID: 1}).Error)
+	require.NoError(t, db.Create(&models.Role{ID: 3, Name: "holder"}).Error)
+	require.NoError(t, db.Create(&models.RolePermission{RoleID: 3, PermissionID: 1}).Error)
+
+	const attacker = uint(9)
+	const target = uint(10)
+	// attacker holds secrets.delete only at project 3, not globally.
+	require.NoError(t, db.Create(&models.UserRole{UserID: attacker, RoleID: 3, ProjectID: 3}).Error)
+
+	err := c.AssignUserRole(ctx, attacker, target, 2, Scope{}) // global grant attempt
+	require.Error(t, err, "a project-scoped holder must not grant the role globally")
+	assert.Contains(t, err.Error(), "do not hold permission")
+
+	// The SAME grant at the project scope they actually hold the permission at succeeds.
+	require.NoError(t, c.AssignUserRole(ctx, attacker, target, 2, Scope{ProjectID: 3}))
+}
+
+// An actor who genuinely holds every bundled permission (directly, at an
+// equal-or-broader scope) may grant the role — the fix must not block the
+// legitimate case.
+func TestAssignUserRole_HolderMayGrantRoleTheyQualifyFor(t *testing.T) {
+	c, db := newRBACManagementCore(t)
+	ctx := context.Background()
+	require.NoError(t, db.Create(&models.Role{ID: 2, Name: "editor"}).Error)
+	require.NoError(t, db.Create(&models.Permission{ID: 1, Name: "secrets.read", Resource: "secrets", Action: "read"}).Error)
+	require.NoError(t, db.Create(&models.Permission{ID: 2, Name: "secrets.write", Resource: "secrets", Action: "write"}).Error)
+	require.NoError(t, db.Create(&models.RolePermission{RoleID: 2, PermissionID: 1}).Error)
+	require.NoError(t, db.Create(&models.RolePermission{RoleID: 2, PermissionID: 2}).Error)
+	require.NoError(t, db.Create(&models.Role{ID: 3, Name: "holder"}).Error)
+	require.NoError(t, db.Create(&models.RolePermission{RoleID: 3, PermissionID: 1}).Error)
+	require.NoError(t, db.Create(&models.RolePermission{RoleID: 3, PermissionID: 2}).Error)
+
+	const holder = uint(9)
+	const target = uint(10)
+	require.NoError(t, db.Create(&models.UserRole{UserID: holder, RoleID: 3}).Error) // global grant
+
+	require.NoError(t, c.AssignUserRole(ctx, holder, target, 2, Scope{ProjectID: 3}))
+
+	var count int64
+	require.NoError(t, db.Model(&models.UserRole{}).Where("user_id = ? AND role_id = ?", target, 2).Count(&count).Error)
+	assert.Equal(t, int64(1), count)
+}
+
+// A global admin bypasses the grant-ceiling check (matching every other authz gate
+// in this codebase, and #169's analogous bypass) — an admin can grant any role,
+// including one bundling a permission they don't explicitly hold by name (the
+// admin bypass in Authorize covers it).
+func TestAssignUserRole_AdminBypassesCeiling(t *testing.T) {
+	c, db := newRBACManagementCore(t)
+	ctx := context.Background()
+	require.NoError(t, db.Create(&models.Role{ID: 1, Name: "admin"}).Error)
+	require.NoError(t, db.Create(&models.Role{ID: 2, Name: "editor"}).Error)
+	require.NoError(t, db.Create(&models.Permission{ID: 1, Name: "secrets.delete", Resource: "secrets", Action: "delete"}).Error)
+	require.NoError(t, db.Create(&models.RolePermission{RoleID: 2, PermissionID: 1}).Error)
+
+	const admin = uint(9)
+	const target = uint(10)
+	require.NoError(t, db.Create(&models.UserRole{UserID: admin, RoleID: 1}).Error)
+
+	require.NoError(t, c.AssignUserRole(ctx, admin, target, 2, Scope{ProjectID: 3}))
+}
+
+// actorID 0 is the established "system" pseudo-actor for genuinely non-attacker-
+// reachable callers (the local CLI's AssignRoleToUser) — it must still bypass the
+// grant-ceiling check exactly like it bypasses #169's AssignPermissionToRole check,
+// so local/system-driven role assignment at bootstrap keeps working.
+func TestAssignUserRole_SystemActorBypassesCeiling(t *testing.T) {
+	c, db := newRBACManagementCore(t)
+	ctx := context.Background()
+	require.NoError(t, db.Create(&models.Role{ID: 2, Name: "editor"}).Error)
+	require.NoError(t, db.Create(&models.Permission{ID: 1, Name: "secrets.delete", Resource: "secrets", Action: "delete"}).Error)
+	require.NoError(t, db.Create(&models.RolePermission{RoleID: 2, PermissionID: 1}).Error)
+
+	const target = uint(10)
+	require.NoError(t, c.AssignUserRole(ctx, 0, target, 2, Scope{ProjectID: 3}))
+
+	var count int64
+	require.NoError(t, db.Model(&models.UserRole{}).Where("user_id = ? AND role_id = ?", target, 2).Count(&count).Error)
+	assert.Equal(t, int64(1), count)
+}
+
+// A role with NO bundled permissions at all (an empty/placeholder role) is always
+// grantable — there is nothing to ceiling-check.
+func TestAssignUserRole_EmptyRoleAlwaysGrantable(t *testing.T) {
+	c, db := newRBACManagementCore(t)
+	ctx := context.Background()
+	require.NoError(t, db.Create(&models.Role{ID: 2, Name: "empty-role"}).Error)
+
+	const actor = uint(9) // holds nothing
+	const target = uint(10)
+	require.NoError(t, c.AssignUserRole(ctx, actor, target, 2, Scope{ProjectID: 3}))
+}

--- a/internal/core/rbac_management.go
+++ b/internal/core/rbac_management.go
@@ -137,10 +137,15 @@ func (c *KeyorixCore) AssignRoleToGroup(ctx context.Context, actorID, groupID, r
 }
 
 // RemoveRoleFromGroup verifies the group exists then removes the role at scope
-// and records an RBAC audit event. actorID is the acting principal (0 = none).
+// and records an RBAC audit event. actorID is the acting principal (0 = none). It
+// refuses to remove the install's last global-admin-conferring group grant (#107;
+// see guardLastGlobalAdminGroupRole).
 func (c *KeyorixCore) RemoveRoleFromGroup(ctx context.Context, actorID, groupID, roleID uint, scope Scope) error {
 	if _, err := c.storage.GetGroup(ctx, groupID); err != nil {
 		return fmt.Errorf("group not found: %w", err)
+	}
+	if err := c.guardLastGlobalAdminGroupRole(ctx, groupID, roleID, scope); err != nil {
+		return err
 	}
 	if err := c.storage.RemoveRoleFromGroup(ctx, groupID, roleID, scope); err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
@@ -245,8 +250,36 @@ func (c *KeyorixCore) SetUserRoles(ctx context.Context, actorID, userID uint, ro
 // AssignUserRole assigns a role to a user at the given scope and records an RBAC
 // audit event. actorID is the acting principal (0 when unauthenticated, e.g. a
 // local CLI invocation). This is the audited choke point all role-assignment
-// paths funnel through.
+// paths funnel through. See requireGranterHoldsRolePermissions for the
+// admin-rank-ceiling check on the grant (#93/#107/#141).
 func (c *KeyorixCore) AssignUserRole(ctx context.Context, actorID, userID, roleID uint, scope Scope) error {
+	if err := c.requireGranterHoldsRolePermissions(ctx, actorID, roleID, scope); err != nil {
+		return err
+	}
+	if err := c.storage.AssignRole(ctx, userID, roleID, scope); err != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	c.LogRoleAssigned(ctx, actorID, userID, roleID, scope)
+	return nil
+}
+
+// assignUserRoleSystemGrant performs the same audited grant as AssignUserRole but
+// deliberately SKIPS the #93/#107/#141 grant-ceiling check. Use it ONLY where the
+// authorization root for the grant is not the acting principal's own
+// roles.assign-derived authority, but an independently validated, admin-
+// configured trust mapping — today that is exactly one caller: SSO group-role
+// reconciliation (sso.go), where an install admin (not the logging-in user)
+// decided which IdP groups map to which roles ahead of time, and the login itself
+// was verified against the IdP's signed id_token. Requiring the logging-in user to
+// already hold the very role they're being auto-provisioned would defeat the
+// feature's whole purpose — this mirrors the actorID-0 "system pseudo-actor"
+// bypass AssignPermissionToRole uses for #169, but keyed on the call site instead
+// of the actor ID, since SSO reconciliation attributes the grant to the real
+// logging-in user (actorID = userID) for audit purposes, not to actor 0.
+// actorID is still recorded as the audit actor. Never call this from a path
+// reachable by an ordinary authenticated request exercising roles.assign — that
+// path must go through AssignUserRole so the ceiling check applies.
+func (c *KeyorixCore) assignUserRoleSystemGrant(ctx context.Context, actorID, userID, roleID uint, scope Scope) error {
 	if err := c.storage.AssignRole(ctx, userID, roleID, scope); err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}
@@ -258,12 +291,30 @@ func (c *KeyorixCore) AssignUserRole(ctx context.Context, actorID, userID, roleI
 // RBAC audit event. See AssignUserRole for actorID semantics. It refuses to remove
 // the last install administrator (see guardLastGlobalAdmin). This is the choke point
 // SetUserRoles and the HTTP/gRPC role-removal handlers funnel through.
+//
+// The last-admin check and the removal itself run inside a single storage
+// transaction, held under globalAdminGuardMu for its whole duration (#340):
+// without this, two concurrent removals of two different admins' role
+// assignments could each observe "another admin still exists" before either
+// write commits, stranding the install with zero admins. The transaction's
+// ListGlobalAdminAssignmentsForUpdate read takes a row-level lock on every
+// candidate admin-conferring assignment on backends that support one (Postgres),
+// serializing HA replicas; globalAdminGuardMu serializes same-process callers —
+// the same two-layer pattern login_lockout.go's recordFailedLogin uses.
 func (c *KeyorixCore) RemoveUserRole(ctx context.Context, actorID, userID, roleID uint, scope Scope) error {
-	if err := c.guardLastGlobalAdmin(ctx, userID, roleID, scope); err != nil {
+	c.globalAdminGuardMu.Lock()
+	defer c.globalAdminGuardMu.Unlock()
+	err := c.storage.WithTransaction(ctx, func(tx storage.Storage) error {
+		if err := c.guardLastGlobalAdmin(ctx, tx, userID, roleID, scope); err != nil {
+			return err
+		}
+		if err := tx.RemoveRole(ctx, userID, roleID, scope); err != nil {
+			return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+		}
+		return nil
+	})
+	if err != nil {
 		return err
-	}
-	if err := c.storage.RemoveRole(ctx, userID, roleID, scope); err != nil {
-		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}
 	c.LogRoleRemoved(ctx, actorID, userID, roleID, scope)
 	return nil
@@ -277,9 +328,20 @@ var installAdminRoleNames = []string{"super_admin", "admin", "system_admin"}
 // installAdminRoleIDSet resolves installAdminRoleNames to their role IDs (skipping
 // any that a given install did not seed).
 func (c *KeyorixCore) installAdminRoleIDSet(ctx context.Context) map[uint]bool {
+	return c.installAdminRoleIDSetFrom(ctx, c.storage)
+}
+
+// installAdminRoleIDSetFrom is installAdminRoleIDSet against an explicit Storage
+// handle. Callers running inside a WithTransaction callback (guardLastGlobalAdmin,
+// #340) MUST pass the transaction-scoped Storage they were handed, not c.storage:
+// on the local (DB) backend, a read issued through c.storage while a transaction
+// is still open checks out a SEPARATE pooled connection — for SQLite ":memory:"
+// specifically, a distinct, empty database — silently missing the very rows the
+// transaction just wrote or is checking.
+func (c *KeyorixCore) installAdminRoleIDSetFrom(ctx context.Context, s storage.Storage) map[uint]bool {
 	set := make(map[uint]bool, len(installAdminRoleNames))
 	for _, name := range installAdminRoleNames {
-		if role, err := c.storage.GetRoleByName(ctx, name); err == nil && role != nil {
+		if role, err := s.GetRoleByName(ctx, name); err == nil && role != nil {
 			set[role.ID] = true
 		}
 	}
@@ -291,22 +353,28 @@ func (c *KeyorixCore) installAdminRoleIDSet(ctx context.Context) map[uint]bool {
 // self-inflicted or malicious-insider lockout that strands the install with no
 // administrator (and no recovery short of DB surgery). Only the global scope is
 // guarded: a project-scoped admin can always be restored by a global admin.
-func (c *KeyorixCore) guardLastGlobalAdmin(ctx context.Context, userID, roleID uint, scope Scope) error {
+//
+// tx is the transaction-scoped Storage the caller (RemoveUserRole) is running
+// inside (#340): the read MUST go through it, not c.storage, so the row lock
+// ListGlobalAdminAssignmentsForUpdate takes is actually held for the lifetime of
+// this decision rather than released before the caller's own write runs.
+func (c *KeyorixCore) guardLastGlobalAdmin(ctx context.Context, tx storage.Storage, userID, roleID uint, scope Scope) error {
 	if scope.ProjectID != 0 || scope.EnvironmentID != 0 {
 		return nil // not the global scope — project admins are recoverable
 	}
-	adminIDs := c.installAdminRoleIDSet(ctx)
+	adminIDs := c.installAdminRoleIDSetFrom(ctx, tx)
 	if !adminIDs[roleID] {
 		return nil // not removing an install-admin role
 	}
-	assignments, err := c.storage.ListProjectRoleAssignments(ctx, 0)
+	ids := make([]uint, 0, len(adminIDs))
+	for id := range adminIDs {
+		ids = append(ids, id)
+	}
+	assignments, err := tx.ListGlobalAdminAssignmentsForUpdate(ctx, ids)
 	if err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
 	}
 	for _, a := range assignments {
-		if !adminIDs[a.RoleID] {
-			continue
-		}
 		// Ignore the exact assignment being removed; any OTHER global admin grant
 		// (held by another user, or by a group) means governance survives.
 		if a.PrincipalType == "user" && a.PrincipalID == userID && a.RoleID == roleID {

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -68,6 +68,14 @@ type KeyorixCore struct {
 	// the row lock LockUserForUpdate takes on Postgres, the lockout counter stays
 	// correct across replicas. Zero value is ready to use. See login_lockout.go.
 	loginFailureMu sync.Mutex
+	// globalAdminGuardMu serializes RemoveUserRole's last-global-admin check and the
+	// removal it guards (guardLastGlobalAdmin) into one atomic unit, so two admins
+	// concurrently removing each other's role assignment cannot both observe
+	// "another admin still exists" before either write lands (#340). Combined with
+	// the row lock ListGlobalAdminAssignmentsForUpdate takes on Postgres, the guard
+	// stays correct across HA replicas too. Zero value is ready to use. See
+	// rbac_management.go.
+	globalAdminGuardMu sync.Mutex
 	// setupResendMu serializes the count-then-issue window of the setup-link resend
 	// throttle (checkResendThrottle + IssueSetupToken) so two concurrent resends for
 	// the same (purpose, email) cannot both clear the per-day cap / min-interval

--- a/internal/core/sso.go
+++ b/internal/core/sso.go
@@ -585,12 +585,19 @@ func (c *KeyorixCore) reconcileSSORoles(ctx context.Context, p *SSOProvider, use
 		currentSet[r.Name] = true
 	}
 
-	// Route through the audited RBAC choke point (AssignUserRole/RemoveUserRole) so
-	// each individual role change lands in the RBAC audit trail with a structured
-	// RoleID, not just the coarse aggregate-count event below (#297). The acting
-	// principal is the logging-in user themself — the same attribution the
-	// aggregate auth.sso_roles_synced event below already used — since the grant is
-	// driven by their own IdP-asserted groups against the admin-configured map.
+	// Route through the audited RBAC choke point (assignUserRoleSystemGrant/
+	// RemoveUserRole) so each individual role change lands in the RBAC audit trail
+	// with a structured RoleID, not just the coarse aggregate-count event below
+	// (#297). The acting principal is the logging-in user themself — the same
+	// attribution the aggregate auth.sso_roles_synced event below already used —
+	// since the grant is driven by their own IdP-asserted groups against the
+	// admin-configured map. The grant deliberately uses assignUserRoleSystemGrant,
+	// not AssignUserRole: the #93/#107/#141 grant-ceiling check would require the
+	// logging-in user to already hold every permission of the role they're being
+	// auto-provisioned — impossible for their FIRST SSO-driven grant, and beside
+	// the point, since authorization here is rooted in the admin-configured
+	// GroupRoleMap and the verified IdP assertion, not in the user's own
+	// roles.assign-derived authority.
 	added, removed := 0, 0
 	for role := range managedRoles {
 		r, rerr := c.storage.GetRoleByName(ctx, role)
@@ -599,7 +606,7 @@ func (c *KeyorixCore) reconcileSSORoles(ctx context.Context, p *SSOProvider, use
 		}
 		switch {
 		case desiredRoles[role] && !currentSet[role]:
-			if c.AssignUserRole(ctx, userID, userID, r.ID, Scope{}) == nil {
+			if c.assignUserRoleSystemGrant(ctx, userID, userID, r.ID, Scope{}) == nil {
 				added++
 			}
 		case !desiredRoles[role] && currentSet[role]:

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -81,6 +81,17 @@ type Storage interface {
 	// rows for a project access review. Global (project 0) grants are excluded:
 	// those are install-level, reviewed separately.
 	ListProjectRoleAssignments(ctx context.Context, projectID uint) ([]RoleAssignment, error)
+	// ListGlobalAdminAssignmentsForUpdate returns every global-scope (project 0,
+	// environment 0) direct user and group role grant whose role is in
+	// adminRoleIDs, taking a row-level write lock on backends that support one
+	// (Postgres: SELECT ... FOR UPDATE) so a concurrent racing removal serializes
+	// against this read. This is the atomicity fix for #340: guardLastGlobalAdmin's
+	// prior read-then-conditional-write let two admins racing to remove each
+	// other's role assignment both observe "another admin still exists" before
+	// either write landed, stranding the install. On SQLite this is a plain read;
+	// the caller's own process-level mutex serializes same-process callers,
+	// mirroring LockUserForUpdate/LockWebAuthnCredentialForUpdate.
+	ListGlobalAdminAssignmentsForUpdate(ctx context.Context, adminRoleIDs []uint) ([]RoleAssignment, error)
 	// LastUserSecretActivity returns, per user, the most recent secret-access time
 	// in the project (from the audit trail). Backs dormant-access detection in the
 	// access review — a grant whose principal has no recent activity is stale

--- a/internal/storage/store/local_rbac.go
+++ b/internal/storage/store/local_rbac.go
@@ -18,6 +18,7 @@ import (
 	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 // --- Permissions ---
@@ -275,6 +276,55 @@ func (ls *LocalStorage) ListProjectRoleAssignments(ctx context.Context, projectI
 
 	var groupRows []models.GroupRole
 	if err := ls.db.WithContext(ctx).Where("project_id = ?", projectID).Find(&groupRows).Error; err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	for _, r := range groupRows {
+		out = append(out, storage.RoleAssignment{
+			PrincipalType: "group", PrincipalID: r.GroupID, RoleID: r.RoleID,
+			ProjectID: r.ProjectID, EnvironmentID: r.EnvironmentID,
+		})
+	}
+	return out, nil
+}
+
+// ListGlobalAdminAssignmentsForUpdate returns every global-scope (project 0,
+// environment 0) direct user and group role grant whose role is in adminRoleIDs,
+// taking a row-level write lock on backends that support one (Postgres FOR
+// UPDATE), mirroring LockUserForUpdate/LockWebAuthnCredentialForUpdate. See the
+// Storage interface doc (#340) for why this exists: a concurrent racing removal
+// must serialize against this read on Postgres/HA; the caller's own process
+// mutex covers SQLite (single instance, no cross-process concern).
+func (ls *LocalStorage) ListGlobalAdminAssignmentsForUpdate(ctx context.Context, adminRoleIDs []uint) ([]storage.RoleAssignment, error) {
+	if len(adminRoleIDs) == 0 {
+		return nil, nil
+	}
+	locked := ls.db.Dialector.Name() == "postgres"
+
+	var out []storage.RoleAssignment
+
+	userQ := ls.db.WithContext(ctx)
+	if locked {
+		userQ = userQ.Clauses(clause.Locking{Strength: "UPDATE"})
+	}
+	var userRows []models.UserRole
+	if err := userQ.Where("project_id = 0 AND environment_id = 0 AND role_id IN ?", adminRoleIDs).
+		Find(&userRows).Error; err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	for _, r := range userRows {
+		out = append(out, storage.RoleAssignment{
+			PrincipalType: "user", PrincipalID: r.UserID, RoleID: r.RoleID,
+			ProjectID: r.ProjectID, EnvironmentID: r.EnvironmentID,
+		})
+	}
+
+	groupQ := ls.db.WithContext(ctx)
+	if locked {
+		groupQ = groupQ.Clauses(clause.Locking{Strength: "UPDATE"})
+	}
+	var groupRows []models.GroupRole
+	if err := groupQ.Where("project_id = 0 AND environment_id = 0 AND role_id IN ?", adminRoleIDs).
+		Find(&groupRows).Error; err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
 	}
 	for _, r := range groupRows {

--- a/internal/storage/store/remote_rbac.go
+++ b/internal/storage/store/remote_rbac.go
@@ -440,6 +440,14 @@ func (rs *RemoteStorage) ListProjectRoleAssignments(_ context.Context, _ uint) (
 	return nil, remoteUnsupported("ListProjectRoleAssignments")
 }
 
+// ListGlobalAdminAssignmentsForUpdate is a server-internal RBAC primitive backing
+// the last-admin-removal guard's atomicity fix (#340); like
+// ListProjectRoleAssignments, RBAC admin-removal guarding runs entirely against
+// LocalStorage server-side, so this is unsupported here.
+func (rs *RemoteStorage) ListGlobalAdminAssignmentsForUpdate(_ context.Context, _ []uint) ([]storage.RoleAssignment, error) {
+	return nil, remoteUnsupported("ListGlobalAdminAssignmentsForUpdate")
+}
+
 func (rs *RemoteStorage) GetEnvironment(_ context.Context, _ uint) (*models.Environment, error) {
 	return nil, remoteUnsupported("GetEnvironment")
 }


### PR DESCRIPTION
## Summary

- **#93/#107/#141 HIGH** — `AssignUserRole` audited a role grant but never checked that the granting actor already held the permissions bundled into the role being granted. A project-scoped `roles.assign` holder could grant a role bundling `secrets.delete` (or `system.write`, or a pre-existing/seeded builtin like `editor`) to anyone in scope — including themselves — without holding it. `#169` only closed the analogous gap on role *definition*; this closes the *grant* vector via a new `requireGranterHoldsRolePermissions` check, mirroring #169's pattern: the actor must hold every bundled permission at an equal-or-broader scope, `Authorize`'s admin bypass covers genuine admins, and `actorID 0` (the established local-CLI system pseudo-actor) is exempt exactly like #169's analogous check. SSO group-role reconciliation gets its own `assignUserRoleSystemGrant` bypass, since its authorization root is an admin-configured `GroupRoleMap` + a verified IdP assertion, not the logging-in user's own `roles.assign` chain — requiring the user to already hold the role they're being auto-provisioned would defeat the feature.
- **#107 group-path variant** — `RemoveRoleFromGroup`, `DeleteGroup`, and `RemoveUserFromGroup` had zero call to any last-global-admin guard, so deleting or emptying a group holding the install's last admin-conferring role could strand it with zero admins. Three new guards (`guardLastGlobalAdminGroupRole`/`GroupDelete`/`Membership`) cover each shape, including the trickiest one — membership removal, where the group's own grant row *survives* and only one member's derived authority disappears, which a simple "does another assignment row exist" check can't catch.
- **#340 LOW** — `guardLastGlobalAdmin`'s direct-removal check was a read-then-conditional-write TOCTOU: two admins concurrently removing each other's role could both observe "another admin still exists" before either write landed. `RemoveUserRole` now runs the check-and-remove inside one storage transaction, serialized by a new `globalAdminGuardMu` plus a row-locking read (`ListGlobalAdminAssignmentsForUpdate`, `SELECT ... FOR UPDATE` on Postgres) — the same two-layer pattern `login_lockout.go`'s failed-login counter already uses.

A known, deliberately out-of-scope gap: `AssignUserRoleWithExpiry` (the JIT/TTL-grant sibling) still bypasses the ceiling check entirely, since `break_glass.go`'s self-service emergency grant also routes through it and legitimately needs to elevate a user beyond their current permissions. Flagged with a code comment for a dedicated follow-up rather than a mechanical (and break-glass-breaking) mirror of this fix.

## Test plan
- [x] New regression tests: `rbac_grant_ceiling_test.go` (ceiling holds/blocks a direct grant, a third-party grant, a broader-scope grant, admin bypass, actor-0 system bypass, empty-role no-op)
- [x] New regression tests: `group_admin_guard_test.go` (last-admin guard blocks/allows `RemoveRoleFromGroup`, `DeleteGroup`, `RemoveUserFromGroup`, including the survives-the-grant-row membership case)
- [x] New regression tests: `concurrency_last_admin_removal_test.go` (`-race`, file-backed SQLite, two admins racing to remove each other never reach zero)
- [x] `go build ./...` and `go test ./...` clean
- [x] `go test -race ./internal/core/... ./internal/storage/... ./server/...` clean
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues
- [x] `golangci-lint run ./...` — 0 issues
- [x] `GOWORK=off go build -C operator ./...` — clean