### PR TITLE
fix(cli): secret fix's applyFix resolves against --path, not CWD (#352 HIGH)

### DIFF
--- a/internal/cli/secret/fix.go
+++ b/internal/cli/secret/fix.go
@@ -100,7 +100,7 @@ func runFix(cmd *cobra.Command, args []string) error {
 
 	// Apply fixes
 	for _, plan := range plans {
-		if err := applyFix(plan); err != nil {
+		if err := applyFix(absPath, plan); err != nil {
 			fmt.Printf("Error fixing %s: %v\n", plan.File, err)
 			continue
 		}
@@ -180,8 +180,13 @@ func findAndPlanFix(basePath, envVarName string) ([]fixPlan, error) {
 	return plans, err
 }
 
-func applyFix(plan fixPlan) error {
-	content, err := os.ReadFile(filepath.Clean(plan.File)) // #nosec G304 G122 -- path sourced from filepath.Walk within operator-controlled basePath
+func applyFix(basePath string, plan fixPlan) error {
+	// plan.File was recorded by findAndPlanFix relative to basePath (the same
+	// --path the plan was built from), so it must be resolved against that
+	// same basePath here — not the process's CWD — or the fix reads/writes
+	// an unrelated file that merely shares the same relative path.
+	fullPath := filepath.Join(basePath, plan.File)
+	content, err := os.ReadFile(filepath.Clean(fullPath)) // #nosec G304 G122 -- fullPath is basePath (operator-supplied --path) joined with a relative path from filepath.Walk rooted at that same basePath
 	if err != nil {
 		return err
 	}
@@ -190,5 +195,5 @@ func applyFix(plan fixPlan) error {
 		return fmt.Errorf("line %d out of range", plan.Line)
 	}
 	lines[plan.Line-1] = plan.NewLine
-	return os.WriteFile(plan.File, []byte(strings.Join(lines, "\n")), 0600) // #nosec G703 -- plan.File is a relative path from filepath.Walk within operator-supplied basePath; path traversal not a realistic threat for this local CLI tool
+	return os.WriteFile(fullPath, []byte(strings.Join(lines, "\n")), 0600) // #nosec G703 -- fullPath is basePath (operator-supplied --path) joined with a relative path from filepath.Walk rooted at that same basePath; path traversal not a realistic threat for this local CLI tool
 }

--- a/internal/cli/secret/fix_test.go
+++ b/internal/cli/secret/fix_test.go
@@ -1,0 +1,85 @@
+package secret
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestFix_ResolvesAgainstPathNotCWD reproduces the exact scenario from
+// HARDENING-BACKLOG #352: `findAndPlanFix` records plan.File relative to
+// --path, but applyFix used to resolve that same relative path against the
+// process's CWD instead. Running `keyorix secret fix --path <elsewhere>`
+// from a directory that happens to contain a file at the same relative path
+// as the real target must:
+//   - actually fix the real target under --path, and
+//   - leave the CWD-relative decoy file (which merely shares that relative
+//     path) completely untouched.
+func TestFix_ResolvesAgainstPathNotCWD(t *testing.T) {
+	root := t.TempDir()
+
+	projectDir := filepath.Join(root, "project")
+	decoyDir := filepath.Join(root, "decoy")
+
+	realFile := filepath.Join(projectDir, "sub", "config.py")
+	decoyFile := filepath.Join(decoyDir, "sub", "config.py")
+
+	if err := os.MkdirAll(filepath.Dir(realFile), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(decoyFile), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	realContent := "DB_PASSWORD = \"supersecretvalue123\"\n"
+	decoyContent := "# unrelated file at the same relative path — must not be touched\nDB_PASSWORD = \"supersecretvalue123\"\n"
+
+	if err := os.WriteFile(realFile, []byte(realContent), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(decoyFile, []byte(decoyContent), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Run from decoyDir with --path pointing at ../project, exactly as in
+	// the empirically-reproduced finding (invoked from an unrelated `decoy/`
+	// directory that happens to share a same-relative-path file).
+	t.Chdir(decoyDir)
+
+	origPath, origDryRun, origInteractive, origEnvFile := fixPath, fixDryRun, fixInteractive, fixEnvFile
+	t.Cleanup(func() {
+		fixPath, fixDryRun, fixInteractive, fixEnvFile = origPath, origDryRun, origInteractive, origEnvFile
+	})
+
+	fixPath = "../project"
+	fixDryRun = false
+	fixInteractive = false
+	fixEnvFile = ".env"
+
+	if err := runFix(fixCmd, []string{"DB_PASSWORD"}); err != nil {
+		t.Fatalf("runFix returned error: %v", err)
+	}
+
+	// The decoy file (which would only be touched if resolution incorrectly
+	// used the CWD instead of --path) must be completely untouched.
+	gotDecoy, err := os.ReadFile(decoyFile)
+	if err != nil {
+		t.Fatalf("decoy file vanished: %v", err)
+	}
+	if string(gotDecoy) != decoyContent {
+		t.Fatalf("decoy file (unrelated to --path) was modified; got %q, want unchanged %q", gotDecoy, decoyContent)
+	}
+
+	// The real target file under --path must actually have been fixed.
+	gotReal, err := os.ReadFile(realFile)
+	if err != nil {
+		t.Fatalf("real target file vanished: %v", err)
+	}
+	if strings.Contains(string(gotReal), "supersecretvalue123") {
+		t.Fatalf("real target file still contains the hardcoded secret (false remediation): %q", gotReal)
+	}
+	if !strings.Contains(string(gotReal), `os.getenv("DB_PASSWORD")`) {
+		t.Fatalf("real target file was not fixed as expected: %q", gotReal)
+	}
+}


### PR DESCRIPTION
## Summary
- `findAndPlanFix` (`internal/cli/secret/fix.go`) records `plan.File` relative to `--path` (via `filepath.Rel(basePath, path)`), but `applyFix` resolved that same relative path against the process's CWD instead of `--path` when reading/writing it.
- Whenever `--path` differed from the invoking CWD, and a file happened to exist at the same relative path under the CWD, `keyorix secret fix ... --path <elsewhere> --dry-run=false` would silently overwrite that unrelated CWD-relative file with the fix's replacement text while printing "Fixed ..." (false success) — leaving the real hardcoded secret under `--path` untouched.
- Fix: `applyFix` now takes the same absolute base path (`absPath`) that `findAndPlanFix` used to build `plan.File`, and joins it with `plan.File` before reading/writing — matching the already-correct handling of the companion `.env`-append path in the same function.

## Test plan
- [x] Added `TestFix_ResolvesAgainstPathNotCWD` reproducing the exact finding: invokes `fix` from a decoy CWD with `--path` pointing at a different directory containing a same-relative-path file; asserts the decoy file is untouched and the real target under `--path` is actually fixed. Verified it fails against the pre-fix code and passes against the fix.
- [x] `go build ./...`
- [x] `go test ./...` (full suite)
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues
- [x] `golangci-lint run ./...` — 0 issues
- [x] `GOWORK=off go build -C operator ./...`