### PR TITLE
fix(trust): require --force to overwrite an existing keygen keypair (#355)

### DIFF
--- a/internal/cli/trust/keygen_test.go
+++ b/internal/cli/trust/keygen_test.go
@@ -36,6 +36,44 @@ func TestKeygen_WritesUsableKeypair(t *testing.T) {
 	require.NoError(t, reg.Verify(itrust.PurposeUpdate, "upd-test", msg, ed25519.Sign(priv, msg)))
 }
 
+func TestKeygen_RefusesOverwriteWithoutForce_AllowsWithForce(t *testing.T) {
+	dir := t.TempDir()
+	keygenPurpose, keygenKeyID, keygenDir, keygenForce = "update", "upd-reuse", dir, false
+	require.NoError(t, keygenCmd.RunE(keygenCmd, nil))
+
+	privPath := filepath.Join(dir, "upd-reuse.private.pem")
+	pubPath := filepath.Join(dir, "upd-reuse.public.pem")
+	origPriv, err := os.ReadFile(privPath) //nolint:gosec // test-controlled temp path
+	require.NoError(t, err)
+	origPub, err := os.ReadFile(pubPath) //nolint:gosec // test-controlled temp path
+	require.NoError(t, err)
+
+	// Re-run with the same --dir/--key-id and no --force: must fail cleanly, and
+	// neither file may be touched (not even the one written first on the prior run).
+	err = keygenCmd.RunE(keygenCmd, nil)
+	require.Error(t, err, "a re-run without --force must be refused")
+	assert.Contains(t, err.Error(), "--force")
+
+	stillPriv, err := os.ReadFile(privPath) //nolint:gosec // test-controlled temp path
+	require.NoError(t, err)
+	stillPub, err := os.ReadFile(pubPath) //nolint:gosec // test-controlled temp path
+	require.NoError(t, err)
+	assert.Equal(t, origPriv, stillPriv, "private key must be untouched by the rejected re-run")
+	assert.Equal(t, origPub, stillPub, "public key must be untouched by the rejected re-run")
+
+	// With --force, the overwrite proceeds and produces a fresh (different) keypair.
+	keygenForce = true
+	t.Cleanup(func() { keygenForce = false })
+	require.NoError(t, keygenCmd.RunE(keygenCmd, nil), "--force must allow the overwrite")
+
+	newPriv, err := os.ReadFile(privPath) //nolint:gosec // test-controlled temp path
+	require.NoError(t, err)
+	newPub, err := os.ReadFile(pubPath) //nolint:gosec // test-controlled temp path
+	require.NoError(t, err)
+	assert.NotEqual(t, origPriv, newPriv, "--force must actually overwrite the private key")
+	assert.NotEqual(t, origPub, newPub, "--force must actually overwrite the public key")
+}
+
 func TestKeygen_RejectsBadPurposeAndMissingKeyID(t *testing.T) {
 	keygenPurpose, keygenKeyID, keygenDir = "bogus", "x", t.TempDir()
 	require.Error(t, keygenCmd.RunE(keygenCmd, nil), "an invalid purpose is rejected")

--- a/internal/cli/trust/trust.go
+++ b/internal/cli/trust/trust.go
@@ -29,6 +29,7 @@ var (
 	keygenPurpose string
 	keygenKeyID   string
 	keygenDir     string
+	keygenForce   bool
 )
 
 var keygenCmd = &cobra.Command{
@@ -51,6 +52,22 @@ var keygenCmd = &cobra.Command{
 			return fmt.Errorf("--key-id is required (e.g. %s-2026)", purpose)
 		}
 
+		privPath := filepath.Join(keygenDir, keyID+".private.pem")
+		pubPath := filepath.Join(keygenDir, keyID+".public.pem")
+
+		// Refuse to clobber an existing keypair (in particular the offline private key)
+		// unless --force is passed. Check BOTH paths before writing either one, so a
+		// re-run without --force is a clean no-op rather than a partial overwrite.
+		if !keygenForce {
+			for _, p := range []string{privPath, pubPath} {
+				if _, statErr := os.Stat(p); statErr == nil {
+					return fmt.Errorf("%s already exists — refusing to overwrite an existing signing key; use --force to overwrite", p)
+				} else if !os.IsNotExist(statErr) {
+					return fmt.Errorf("check %s: %w", p, statErr)
+				}
+			}
+		}
+
 		pub, priv, err := itrust.GenerateKey()
 		if err != nil {
 			return fmt.Errorf("generate key: %w", err)
@@ -67,8 +84,6 @@ var keygenCmd = &cobra.Command{
 		privPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privDER})
 		pubPEM := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubDER})
 
-		privPath := filepath.Join(keygenDir, keyID+".private.pem")
-		pubPath := filepath.Join(keygenDir, keyID+".public.pem")
 		// Both at 0600 — the private key is a signing secret; the public key need not be
 		// world-readable here (it is published separately).
 		if err := os.WriteFile(privPath, privPEM, 0o600); err != nil {
@@ -93,5 +108,6 @@ func init() {
 	keygenCmd.Flags().StringVar(&keygenPurpose, "purpose", "", "key purpose: update | license (required)")
 	keygenCmd.Flags().StringVar(&keygenKeyID, "key-id", "", "key identifier, e.g. update-2026 (required)")
 	keygenCmd.Flags().StringVar(&keygenDir, "dir", ".", "directory to write the keypair into")
+	keygenCmd.Flags().BoolVar(&keygenForce, "force", false, "overwrite an existing keypair at the target paths (dangerous)")
 	TrustCmd.AddCommand(keygenCmd)
 }


### PR DESCRIPTION
## Summary
- `keyorix trust keygen`'s private/public PEM writes went straight through bare `os.WriteFile(path, data, 0o600)` with no existence check, so re-running the command with the same `--dir`/`--key-id` (e.g. after a typo or out of habit) silently truncated an existing offline signing key with zero confirmation and no backup.
- Adds an `os.Stat` pre-check for *both* target paths before writing *either* file, and a `--force` flag to opt into an intentional overwrite — mirroring the existing convention in `internal/cli/system/init.go`'s `generateConfigFile`.
- A re-run without `--force` is now a clean no-op (clear error naming the existing path, neither file touched); `--force` still allows the overwrite as before.

Fixes #355 from the security hardening backlog (ROUND 64, MEDIUM).

## Test plan
- [x] New regression test `TestKeygen_RefusesOverwriteWithoutForce_AllowsWithForce`: runs `keygen` twice with the same `--dir`/`--key-id`, asserts the second run without `--force` fails and both PEM files are byte-for-byte unchanged, then asserts `--force` produces a genuinely new keypair.
- [x] `go build ./...`
- [x] `go test ./...` (full suite, clean)
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues
- [x] `golangci-lint run ./...` — 0 issues
- [x] `GOWORK=off go build -C operator ./...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)