### PR TITLE
fix(invitations): throttle initial invite-link sends (#345)

### DIFF
--- a/internal/core/invitations.go
+++ b/internal/core/invitations.go
@@ -109,15 +109,25 @@ func (c *KeyorixCore) InviteToProject(ctx context.Context, projectID uint, email
 // InviteToProjectWithLink creates an invitation and provisions its accept link
 // (ADR-028): an invitation_accept setup token bound to the invitation, delivered via
 // the configured channel. Returns the invitation and the delivery outcome. If
-// provisioning fails (e.g. base_url unset), the invitation still exists and is
-// returned with a nil result and the error, so the caller can resend rather than
-// losing the invite.
+// provisioning fails (e.g. base_url unset, or the resend throttle below), the
+// invitation still exists and is returned with a nil result and the error, so the
+// caller can resend rather than losing the invite.
+//
+// The link provisioning is throttled per (purpose, email) via
+// provisionSetupLinkThrottled — the same control ResendInvitationLink uses (#183) —
+// rather than the unthrottled provisionSetupLink an earlier version called directly.
+// Without this, a principal holding only project-scoped roles.assign could loop-call
+// this endpoint for the same target email to fire unbounded real SMTP sends from the
+// operator's mail relay (#345); reusing the existing (purpose, email) key rather than
+// adding an actor or per-invitation dimension keeps initial invites and resends of the
+// same target subject to one combined rate, matching how ResendInvitationLink already
+// treats every pending invite to the same email as one throttled subject.
 func (c *KeyorixCore) InviteToProjectWithLink(ctx context.Context, projectID uint, email, role string, invitedBy uint) (*models.ProjectInvitation, *ProvisionSetupResult, error) {
 	inv, err := c.InviteToProject(ctx, projectID, email, role, invitedBy)
 	if err != nil {
 		return nil, nil, err
 	}
-	prov, err := c.provisionSetupLink(ctx, IssueSetupTokenRequest{
+	prov, err := c.provisionSetupLinkThrottled(ctx, IssueSetupTokenRequest{
 		Purpose:      SetupPurposeInvitationAccept,
 		SubjectEmail: email,
 		InvitationID: &inv.ID,
@@ -201,13 +211,16 @@ func (c *KeyorixCore) InviteGlobal(ctx context.Context, email, systemRole string
 // InviteGlobalWithLink creates a global invitation and provisions its accept link
 // (ADR-028), mirroring InviteToProjectWithLink. A nil result with a non-nil error
 // and a non-nil invitation means the invite exists but the link couldn't be
-// delivered (e.g. base_url unset) — the caller can resend.
+// delivered (e.g. base_url unset, or the resend throttle) — the caller can resend.
+// Throttled per (purpose, email) via provisionSetupLinkThrottled for the same reason
+// as InviteToProjectWithLink (#345): the users.write-gated global-invite endpoint is
+// otherwise an equally loop-callable unbounded-SMTP vector.
 func (c *KeyorixCore) InviteGlobalWithLink(ctx context.Context, email, systemRole string, assignments []ProjectAssignment, invitedBy uint) (*models.ProjectInvitation, *ProvisionSetupResult, error) {
 	inv, err := c.InviteGlobal(ctx, email, systemRole, assignments, invitedBy)
 	if err != nil {
 		return nil, nil, err
 	}
-	prov, err := c.provisionSetupLink(ctx, IssueSetupTokenRequest{
+	prov, err := c.provisionSetupLinkThrottled(ctx, IssueSetupTokenRequest{
 		Purpose:      SetupPurposeInvitationAccept,
 		SubjectEmail: email,
 		InvitationID: &inv.ID,

--- a/internal/core/invitations_test.go
+++ b/internal/core/invitations_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/delivery"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -274,6 +275,87 @@ func TestListProjectInvitations_LazyExpire(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, out, 1)
 	assert.Equal(t, InvitationExpired, out[0].State)
+}
+
+// #345: InviteToProjectWithLink used to call the unthrottled provisionSetupLink
+// directly, so a principal with only project-scoped roles.assign could loop-call the
+// invite endpoint for the same target email to fire unbounded real SMTP sends. It must
+// now hit the same per-(purpose, email) min-interval throttle ResendInvitationLink
+// already enforces (#183).
+func TestInviteToProjectWithLink_ThrottlesRepeatedInitialInvites(t *testing.T) {
+	store := new(MockStorage)
+	c := newInviteCore(store)
+	c.SetCredentialDelivery(&fakeDeliverer{result: delivery.DeliveryResult{Channel: delivery.ChannelSMTP, Delivered: true}}, testBaseURL)
+	ctx := context.Background()
+	fixed := c.now()
+	anyAudit(store)
+
+	store.On("GetRoleByName", ctx, "project_developer").Return(&models.Role{ID: 5}, nil)
+	store.On("CreateProjectInvitation", ctx, mock.AnythingOfType("*models.ProjectInvitation")).
+		Return(&models.ProjectInvitation{ID: 7, State: InvitationPending}, nil)
+	store.On("SupersedeActiveSetupTokens", ctx, SetupPurposeInvitationAccept, "a@b.com").Return(nil)
+	store.On("CreateSetupToken", ctx, mock.AnythingOfType("*models.SetupToken")).Return(&models.SetupToken{ID: 1}, nil)
+
+	// First invite: a zero prior count on both windows, so it succeeds and mints a
+	// token — this is the send that a same-email loop must now be throttled against.
+	store.On("CountSetupTokensSince", ctx, SetupPurposeInvitationAccept, "a@b.com", fixed.Add(-24*time.Hour)).Return(int64(0), nil).Once()
+	store.On("CountSetupTokensSince", ctx, SetupPurposeInvitationAccept, "a@b.com", fixed.Add(-resendMinInterval)).Return(int64(0), nil).Once()
+
+	inv1, prov1, err := c.InviteToProjectWithLink(ctx, 1, "a@b.com", "project_developer", 9)
+	require.NoError(t, err)
+	require.NotNil(t, inv1)
+	require.NotNil(t, prov1)
+	assert.True(t, prov1.Delivered)
+
+	// Second call for the SAME target email, immediately after. Pre-fix this looped
+	// straight through to a second real SMTP send with no check at all.
+	store.On("CountSetupTokensSince", ctx, SetupPurposeInvitationAccept, "a@b.com", fixed.Add(-24*time.Hour)).Return(int64(1), nil).Once()
+	store.On("CountSetupTokensSince", ctx, SetupPurposeInvitationAccept, "a@b.com", fixed.Add(-resendMinInterval)).Return(int64(1), nil).Once()
+
+	inv2, prov2, err := c.InviteToProjectWithLink(ctx, 1, "a@b.com", "project_developer", 9)
+	require.Error(t, err, "the second same-email invite must be throttled, not delivered")
+	assert.Contains(t, err.Error(), "wait")
+	assert.Nil(t, prov2)
+	// The invitation row itself still exists (same contract as a base_url-unset
+	// failure) — only the link/email send is throttled, so the caller can resend once
+	// the window passes rather than losing the invite.
+	require.NotNil(t, inv2)
+	store.AssertNumberOfCalls(t, "CreateSetupToken", 1)
+}
+
+// #345: InviteGlobalWithLink has the same unthrottled-initial-send shape as
+// InviteToProjectWithLink, reachable via the users.write-gated global-invite endpoint.
+func TestInviteGlobalWithLink_ThrottlesRepeatedInitialInvites(t *testing.T) {
+	store := new(MockStorage)
+	c := newInviteCore(store)
+	c.SetCredentialDelivery(&fakeDeliverer{result: delivery.DeliveryResult{Channel: delivery.ChannelSMTP, Delivered: true}}, testBaseURL)
+	ctx := context.Background()
+	fixed := c.now()
+	anyAudit(store)
+
+	store.On("GetRoleByName", ctx, "system_viewer").Return(&models.Role{ID: 2}, nil)
+	store.On("CreateProjectInvitation", ctx, mock.AnythingOfType("*models.ProjectInvitation")).
+		Return(&models.ProjectInvitation{ID: 8, State: InvitationPending}, nil)
+	store.On("SupersedeActiveSetupTokens", ctx, SetupPurposeInvitationAccept, "c@d.com").Return(nil)
+	store.On("CreateSetupToken", ctx, mock.AnythingOfType("*models.SetupToken")).Return(&models.SetupToken{ID: 1}, nil)
+
+	store.On("CountSetupTokensSince", ctx, SetupPurposeInvitationAccept, "c@d.com", fixed.Add(-24*time.Hour)).Return(int64(0), nil).Once()
+	store.On("CountSetupTokensSince", ctx, SetupPurposeInvitationAccept, "c@d.com", fixed.Add(-resendMinInterval)).Return(int64(0), nil).Once()
+
+	inv1, prov1, err := c.InviteGlobalWithLink(ctx, "c@d.com", "", nil, 9)
+	require.NoError(t, err)
+	require.NotNil(t, inv1)
+	require.NotNil(t, prov1)
+
+	store.On("CountSetupTokensSince", ctx, SetupPurposeInvitationAccept, "c@d.com", fixed.Add(-24*time.Hour)).Return(int64(1), nil).Once()
+	store.On("CountSetupTokensSince", ctx, SetupPurposeInvitationAccept, "c@d.com", fixed.Add(-resendMinInterval)).Return(int64(1), nil).Once()
+
+	inv2, prov2, err := c.InviteGlobalWithLink(ctx, "c@d.com", "", nil, 9)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "wait")
+	assert.Nil(t, prov2)
+	require.NotNil(t, inv2)
+	store.AssertNumberOfCalls(t, "CreateSetupToken", 1)
 }
 
 // Access-request approval grants a real role, so both the immediate and TTL-bound

--- a/internal/core/setup_delivery.go
+++ b/internal/core/setup_delivery.go
@@ -74,9 +74,13 @@ func (c *KeyorixCore) provisionSetupLink(ctx context.Context, req IssueSetupToke
 // the cap, so the race defeats the sole mail-bombing control). setupResendMu is held
 // across the check + IssueSetupToken so the count and the write that the next count
 // will see are one critical section. Delivery runs after the lock is released — a
-// slow SMTP send must not block every other resend. Used by every resend path; the
-// initial-provision callers (new account / new invitation) start from a zero count
-// and call provisionSetupLink directly.
+// slow SMTP send must not block every other resend. Used by every resend path and by
+// the invitation initial-send paths (InviteToProjectWithLink / InviteGlobalWithLink,
+// #345) — a loop-called initial invite is otherwise indistinguishable from a
+// loop-called resend as an SMTP-relay abuse vector, so both are held to the same
+// per-(purpose, email) limit. CreateUserWithSetupLink is the one caller that still
+// goes through the unthrottled provisionSetupLink: it runs only once CreateUser has
+// already claimed the (unique) email, so it cannot be looped for the same subject.
 func (c *KeyorixCore) provisionSetupLinkThrottled(ctx context.Context, req IssueSetupTokenRequest, displayName, assignmentSummary string) (*ProvisionSetupResult, error) {
 	if c.setupBaseURL == "" {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorValidation", nil), ErrSetupBaseURLRequired)


### PR DESCRIPTION
## Summary

- `#345 MEDIUM` — `InviteToProjectWithLink` and `InviteGlobalWithLink` (`internal/core/invitations.go`) called the unthrottled `provisionSetupLink` directly, so a principal holding only project-scoped `roles.assign` (`POST /projects/{id}/invitations`) or `users.write` (`POST /invitations`) could loop-call either endpoint for the same target email to fire unbounded real SMTP sends from the operator's own mail relay — the existing resend throttle (`checkResendThrottle`, 60s min-interval + 10/day cap, keyed on purpose+email) protected `ResendAccountSetupLink`/`RequestPasswordReset`/`ResendInvitationLink` but never the initial invite-send path.
- Both entry points now go through `provisionSetupLinkThrottled` — the exact control `ResendInvitationLink` already uses (#183) — reusing its `(purpose, email)` keying rather than adding a parallel mechanism or an actor-scoped dimension, so a same-email invite loop and a same-email resend loop are held to one combined rate.
- On a throttled call the invitation row still exists (same contract as an unset-`base_url` failure) with a nil delivery result and an error, so the caller can retry the link send once the window passes rather than losing the invite.

## Test plan

- [x] New regression tests: `TestInviteToProjectWithLink_ThrottlesRepeatedInitialInvites`, `TestInviteGlobalWithLink_ThrottlesRepeatedInitialInvites` in `internal/core/invitations_test.go` — prove a second same-email call to either endpoint is now blocked exactly like `ResendInvitationLink`'s existing throttle test.
- [x] `go build ./...`
- [x] `go test ./...` (full suite, clean)
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues
- [x] `golangci-lint run ./...` — 0 issues
- [x] `GOWORK=off go build -C operator ./...` — clean