### PR TITLE
fix(kms): pin Azure Key Vault key version to survive rotation

### DIFF
--- a/docs/adr-041-kms-key-provider.md
+++ b/docs/adr-041-kms-key-provider.md
@@ -102,9 +102,28 @@ but the `Encrypt`/`Decrypt` interface is unchanged. `kms_key_id` holds the Key
 Vault **key identifier URL**
 (`https://{vault}.vault.azure.net/keys/{name}[/{version}]`; an omitted version uses
 the key's current version); credentials come from `DefaultAzureCredential` (env,
-managed identity, workload identity). Like GCP, the operation names the key, so the
-key is inherently pinned — the ciphertext cannot select a different key. Keyorix now
-offers AWS, GCP, **or** Azure for the wrapping key.
+managed identity, workload identity). Keyorix now offers AWS, GCP, **or** Azure for
+the wrapping key.
+
+## Addendum (2026-07-03): Azure key-version pinning (#346)
+
+Unlike AWS/GCP, an Azure Key Vault wrap/unwrap operation targets a specific key
+*version*, and an unversioned `kms_key_id` (the form described above) resolves to
+whatever version is "current" **at call time**. Because `KMSKeyProvider.KEK()`
+calls `Decrypt` with that same unversioned identifier on every server startup,
+routine Key Vault key rotation — no attacker involved — would silently change
+which version "current" resolves to between the wrap (first run) and a later
+unwrap (any subsequent restart), and the new version cannot unwrap ciphertext
+produced by the old one: total, self-inflicted master-DEK-unavailability.
+`internal/crypto/azurekms.Encrypt` now captures the exact key version Key Vault
+actually used (from the response `KID`, which is always fully versioned, even for
+an unversioned request) and embeds it in the returned wrapped-key blob behind a
+package-local magic prefix; `Decrypt` recognizes that prefix and targets the
+pinned version instead of "current", making newly-wrapped KEKs immune to
+rotation. Ciphertext wrapped before this change (no prefix) is unaffected and
+still decrypts via the old "current"/configured-version resolution — a config
+already pinned to an explicit version, or freshly re-wrapped data, is unaffected
+either way.
 
 ## Addendum (2026-06-12): KEK-provider migration tool
 

--- a/internal/crypto/azurekms/azurekms.go
+++ b/internal/crypto/azurekms/azurekms.go
@@ -6,13 +6,26 @@
 //
 // Envelope encryption uses the vault key's wrapKey/unwrapKey operations
 // (RSA-OAEP-256): the 32-byte KEK is wrapped by the vault key and only the wrapped
-// blob is stored on disk. Like GCP KMS, the operation names the key (vault URL +
-// key name + version), so the key is inherently pinned — the ciphertext cannot
-// select a different key.
+// blob is stored on disk.
+//
+// Unlike AWS/GCP KMS, an Azure Key Vault key wrap/unwrap operation targets a
+// specific key VERSION, and an unversioned kms_key_id resolves to whatever
+// version is "current" at call time (docs/adr-041-kms-key-provider.md). Routine
+// key rotation therefore changes what "current" means between the Encrypt call
+// (at first run) and a later Decrypt call (at every subsequent restart) — the new
+// version cannot unwrap ciphertext produced by the old one. To make this immune
+// to rotation, Encrypt captures the exact key version Azure actually used (from
+// the response KID, which is always fully versioned) and embeds it in the
+// returned blob behind a magic prefix; Decrypt recognizes that prefix and targets
+// the pinned version instead of "current". Ciphertext wrapped before this change
+// (no prefix) still decrypts via the old "current"/configured-version resolution
+// — see decodeEnvelope.
 package azurekms
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/url"
 	"strings"
@@ -27,8 +40,53 @@ import (
 // keys are the common Key Vault case; the same algorithm is used for unwrap.
 var wrapAlgorithm = azkeys.EncryptionAlgorithmRSAOAEP256
 
+// envelopeMagic prefixes a version-pinned wrapped blob (see package doc). Raw
+// Key Vault wrap output is uniformly-random ciphertext bytes, so the chance a
+// legacy (pre-fix) blob collides with this ASCII prefix is negligible — well
+// below the chance of guessing the wrapping key itself.
+const envelopeMagic = "keyorix-azkms-v1:"
+
+// envelope carries the exact key version a KEK was wrapped under, alongside the
+// wrap result, so Decrypt can always target that version rather than "current".
+type envelope struct {
+	Version    string `json:"version"`
+	Ciphertext []byte `json:"ciphertext"`
+}
+
+// encodeEnvelope prepends the magic prefix to a JSON-encoded envelope.
+func encodeEnvelope(version string, ciphertext []byte) ([]byte, error) {
+	body, err := json.Marshal(envelope{Version: version, Ciphertext: ciphertext})
+	if err != nil {
+		return nil, fmt.Errorf("azure-kms: encode envelope: %w", err)
+	}
+	return append([]byte(envelopeMagic), body...), nil
+}
+
+// decodeEnvelope reports whether blob is a version-pinned envelope produced by
+// encodeEnvelope. Blobs without the magic prefix are legacy (or explicitly
+// versioned pre-fix) wrap output and must be decrypted with the client's
+// configured/"current" version instead.
+func decodeEnvelope(blob []byte) (env envelope, ok bool, err error) {
+	if !bytes.HasPrefix(blob, []byte(envelopeMagic)) {
+		return envelope{}, false, nil
+	}
+	if err := json.Unmarshal(blob[len(envelopeMagic):], &env); err != nil {
+		return envelope{}, false, fmt.Errorf("azure-kms: corrupt version-pinned envelope: %w", err)
+	}
+	return env, true, nil
+}
+
+// azureKeysAPI is the slice of the Key Vault keys client this package uses — an
+// interface seam so the SDK stays contained here and version-pinning behavior is
+// unit-testable with a fake that models rotation (a wrap tied to version V fails
+// to unwrap once "current" moves to a different version).
+type azureKeysAPI interface {
+	WrapKey(ctx context.Context, name string, version string, parameters azkeys.KeyOperationParameters, options *azkeys.WrapKeyOptions) (azkeys.WrapKeyResponse, error)
+	UnwrapKey(ctx context.Context, name string, version string, parameters azkeys.KeyOperationParameters, options *azkeys.UnwrapKeyOptions) (azkeys.UnwrapKeyResponse, error)
+}
+
 type client struct {
-	keys       *azkeys.Client
+	keys       azureKeysAPI
 	keyName    string
 	keyVersion string // "" = latest version
 }
@@ -85,13 +143,36 @@ func (c *client) Encrypt(ctx context.Context, plaintext []byte) ([]byte, error) 
 	if err != nil {
 		return nil, err
 	}
-	return res.Result, nil
+	// res.KID is the fully-versioned key identifier Azure actually used, even
+	// when the request (c.keyVersion) was unversioned/"current". Pin it into the
+	// returned blob so a later Decrypt targets this exact version and is immune
+	// to the key being rotated to a new "current" version in the meantime.
+	var version string
+	if res.KID != nil {
+		version = res.KID.Version()
+	}
+	if version == "" {
+		// Unexpected (Key Vault always returns a versioned KID), but fail safe by
+		// falling back to the legacy, unpinned blob rather than erroring out.
+		return res.Result, nil
+	}
+	return encodeEnvelope(version, res.Result)
 }
 
 func (c *client) Decrypt(ctx context.Context, ciphertext []byte) ([]byte, error) {
-	res, err := c.keys.UnwrapKey(ctx, c.keyName, c.keyVersion, azkeys.KeyOperationParameters{
+	version := c.keyVersion
+	wrapped := ciphertext
+	env, pinned, err := decodeEnvelope(ciphertext)
+	if err != nil {
+		return nil, err
+	}
+	if pinned {
+		version = env.Version
+		wrapped = env.Ciphertext
+	}
+	res, err := c.keys.UnwrapKey(ctx, c.keyName, version, azkeys.KeyOperationParameters{
 		Algorithm: to.Ptr(wrapAlgorithm),
-		Value:     ciphertext,
+		Value:     wrapped,
 	}, nil)
 	if err != nil {
 		return nil, err

--- a/internal/crypto/azurekms/azurekms_test.go
+++ b/internal/crypto/azurekms/azurekms_test.go
@@ -1,6 +1,166 @@
 package azurekms
 
-import "testing"
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azkeys"
+)
+
+// fakeKeys models Azure Key Vault's WrapKey/UnwrapKey semantics closely enough
+// to exercise rotation: each version has distinct key material, so a blob
+// wrapped under version A can only be unwrapped by requesting version A
+// specifically — requesting "" (current) or a different version fails once
+// "current" no longer points at A. currentVersion mutates to simulate rotation.
+type fakeKeys struct {
+	currentVersion string
+}
+
+type fakeWrapped struct {
+	Version   string `json:"version"`
+	Plaintext []byte `json:"plaintext"`
+}
+
+func (f *fakeKeys) resolve(version string) string {
+	if version == "" {
+		return f.currentVersion
+	}
+	return version
+}
+
+func (f *fakeKeys) WrapKey(_ context.Context, name string, version string, params azkeys.KeyOperationParameters, _ *azkeys.WrapKeyOptions) (azkeys.WrapKeyResponse, error) {
+	v := f.resolve(version)
+	body, err := json.Marshal(fakeWrapped{Version: v, Plaintext: params.Value})
+	if err != nil {
+		return azkeys.WrapKeyResponse{}, err
+	}
+	kid := azkeys.ID(fmt.Sprintf("https://vault.vault.azure.net/keys/%s/%s", name, v))
+	return azkeys.WrapKeyResponse{KeyOperationResult: azkeys.KeyOperationResult{KID: &kid, Result: body}}, nil
+}
+
+func (f *fakeKeys) UnwrapKey(_ context.Context, _ string, version string, params azkeys.KeyOperationParameters, _ *azkeys.UnwrapKeyOptions) (azkeys.UnwrapKeyResponse, error) {
+	v := f.resolve(version)
+	var w fakeWrapped
+	if err := json.Unmarshal(params.Value, &w); err != nil {
+		return azkeys.UnwrapKeyResponse{}, err
+	}
+	if w.Version != v {
+		return azkeys.UnwrapKeyResponse{}, fmt.Errorf("fake unwrap: blob wrapped under version %q, request targeted %q (key rotated?)", w.Version, v)
+	}
+	return azkeys.UnwrapKeyResponse{KeyOperationResult: azkeys.KeyOperationResult{Result: w.Plaintext}}, nil
+}
+
+func newTestClient(keys *fakeKeys, keyVersion string) *client {
+	return &client{keys: keys, keyName: "kek", keyVersion: keyVersion}
+}
+
+func TestAzureKMS_EncryptPinsVersionAndSurvivesRotation(t *testing.T) {
+	fk := &fakeKeys{currentVersion: "v1"}
+	c := newTestClient(fk, "") // unversioned kms_key_id — the documented default usage
+
+	ct, err := c.Encrypt(context.Background(), []byte("kek-material"))
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+
+	// Simulate Azure's own recommended auto-rotation policy advancing "current"
+	// to a new version between the Encrypt call and the next server restart.
+	fk.currentVersion = "v2"
+
+	pt, err := c.Decrypt(context.Background(), ct)
+	if err != nil {
+		t.Fatalf("decrypt must target the pinned version (v1), survived rotation to v2: %v", err)
+	}
+	if string(pt) != "kek-material" {
+		t.Fatalf("round-trip got %q", pt)
+	}
+}
+
+func TestAzureKMS_WithoutPinningWouldFailAfterRotation(t *testing.T) {
+	// Sanity check that the fake actually models rotation breakage — i.e. that
+	// the previous (unpinned) behavior really would have broken, so the pinning
+	// fix in the test above is meaningfully exercised.
+	fk := &fakeKeys{currentVersion: "v1"}
+	res, err := fk.WrapKey(context.Background(), "kek", "", azkeys.KeyOperationParameters{
+		Algorithm: to.Ptr(wrapAlgorithm),
+		Value:     []byte("kek-material"),
+	}, nil)
+	if err != nil {
+		t.Fatalf("wrap: %v", err)
+	}
+	fk.currentVersion = "v2"
+	if _, err := fk.UnwrapKey(context.Background(), "kek", "", azkeys.KeyOperationParameters{
+		Algorithm: to.Ptr(wrapAlgorithm),
+		Value:     res.Result,
+	}, nil); err == nil {
+		t.Fatal("expected unwrap targeting \"current\" after rotation to fail against a pre-rotation blob")
+	}
+}
+
+func TestAzureKMS_LegacyUnpinnedBlobStillDecrypts(t *testing.T) {
+	// Legacy data: wrapped by the pre-fix Encrypt, which returned the raw wrap
+	// result with no version-pinning envelope. As long as the key has not been
+	// rotated since, it must still decrypt via the old "current"/configured-
+	// version resolution.
+	fk := &fakeKeys{currentVersion: "v1"}
+	legacy, err := fk.WrapKey(context.Background(), "kek", "", azkeys.KeyOperationParameters{
+		Algorithm: to.Ptr(wrapAlgorithm),
+		Value:     []byte("legacy-kek"),
+	}, nil)
+	if err != nil {
+		t.Fatalf("wrap: %v", err)
+	}
+
+	c := newTestClient(fk, "") // unversioned config, matching the legacy deployment
+	pt, err := c.Decrypt(context.Background(), legacy.Result)
+	if err != nil {
+		t.Fatalf("legacy unpinned blob must still decrypt: %v", err)
+	}
+	if string(pt) != "legacy-kek" {
+		t.Fatalf("got %q", pt)
+	}
+}
+
+func TestAzureKMS_LegacyExplicitlyVersionedBlobStillDecrypts(t *testing.T) {
+	// A pre-fix deployment that had already worked around this class of issue by
+	// pinning kms_key_id itself to an explicit version must be unaffected.
+	fk := &fakeKeys{currentVersion: "v3"}
+	legacy, err := fk.WrapKey(context.Background(), "kek", "v3", azkeys.KeyOperationParameters{
+		Algorithm: to.Ptr(wrapAlgorithm),
+		Value:     []byte("legacy-kek"),
+	}, nil)
+	if err != nil {
+		t.Fatalf("wrap: %v", err)
+	}
+
+	c := newTestClient(fk, "v3")
+	pt, err := c.Decrypt(context.Background(), legacy.Result)
+	if err != nil {
+		t.Fatalf("legacy explicitly-versioned blob must still decrypt: %v", err)
+	}
+	if string(pt) != "legacy-kek" {
+		t.Fatalf("got %q", pt)
+	}
+}
+
+func TestAzureKMS_EncryptDecryptRoundTrip(t *testing.T) {
+	fk := &fakeKeys{currentVersion: "v1"}
+	c := newTestClient(fk, "")
+	ct, err := c.Encrypt(context.Background(), []byte("hello"))
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+	pt, err := c.Decrypt(context.Background(), ct)
+	if err != nil {
+		t.Fatalf("decrypt: %v", err)
+	}
+	if string(pt) != "hello" {
+		t.Fatalf("got %q", pt)
+	}
+}
 
 func TestParseKeyID(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Summary

- #346 MEDIUM: an unversioned `kms_key_id` for the Azure KMS wrapper resolves to
  Key Vault's "current" key version at call time. `KMSKeyProvider.KEK()` calls
  `Decrypt` with that same unversioned identifier on every server startup, so
  routine Key Vault key rotation (Azure's own recommended auto-rotation policy,
  no attacker involved) silently changes what "current" resolves to between the
  original wrap and any later restart — the new version cannot unwrap ciphertext
  produced under the old one, and the server loses the master DEK entirely.
  AWS/GCP KMS don't have this failure mode (their decrypt paths are transparent
  to key-material rotation); Azure's version-scoped `unwrapKey` does.
- `Encrypt` (`internal/crypto/azurekms/azurekms.go`) now captures the exact key
  version Key Vault actually used (from the response `KID`, which is always
  fully versioned even for an unversioned request) and embeds it in the returned
  wrapped-key blob behind a package-local magic prefix. `Decrypt` recognizes
  that prefix and targets the pinned version instead of "current", so newly
  wrapped KEKs are immune to rotation.
- Backward compatible: ciphertext wrapped before this change carries no pinning
  marker and keeps decrypting via the old "current"/configured-version
  resolution, so already-deployed installs (with either an unversioned or an
  explicitly-versioned `kms_key_id`) are unaffected either way.
- Updated `docs/adr-041-kms-key-provider.md` with an addendum documenting the
  issue and the fix.

## Test plan

- [x] New regression tests in `internal/crypto/azurekms/azurekms_test.go`
      (fake Key Vault client modeling rotation): encrypt-then-rotate-then-decrypt
      succeeds against the pinned version; a sanity check that the fake really
      would fail post-rotation without pinning; legacy unversioned and legacy
      explicitly-versioned blobs still decrypt; plain round-trip.
- [x] `go build ./...`
- [x] `go test ./...` (full suite, clean)
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues
- [x] `golangci-lint run ./...` — 0 issues
- [x] `GOWORK=off go build -C operator ./...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)