### PR TITLE
harden: reject oversized RSA JWKS keys + gate MFA disable/regen behind lockout (#100/#125)

### DIFF
--- a/internal/core/mfa.go
+++ b/internal/core/mfa.go
@@ -108,6 +108,15 @@ func (c *KeyorixCore) DisableMFA(ctx context.Context, userID uint, codeOrPasswor
 	if !user.MFAEnabled {
 		return fmt.Errorf("MFA is not enabled")
 	}
+	// Per-account lockout gates this self-service re-auth the same way it gates the
+	// second login factor (VerifyMFALogin): a stolen session lets an attacker submit
+	// TOTP guesses without ever having the password, so without this the code check
+	// above is the ONLY throttle on disabling MFA — and it had none. Keyed by user
+	// (not IP), since this is an authenticated-session endpoint, not the pre-auth
+	// login path.
+	if c.loginLocked(user) {
+		return fmt.Errorf("account temporarily locked due to repeated failed logins; try again later")
+	}
 	ok := false
 	if secret, err := c.loadTOTPSecret(ctx, userID); err == nil && c.validateTOTP(secret, codeOrPassword) {
 		ok = true
@@ -117,8 +126,10 @@ func (c *KeyorixCore) DisableMFA(ctx context.Context, userID uint, codeOrPasswor
 	}
 	if !ok {
 		c.auditMFAFailed(ctx, userID, "disable")
+		c.recordFailedLogin(ctx, user) // count the failed re-auth attempt toward the lockout
 		return fmt.Errorf("invalid code or password")
 	}
+	c.clearLoginFailures(ctx, user)
 	if err := c.storage.SetUserMFAEnabled(ctx, userID, false); err != nil {
 		return err
 	}
@@ -143,6 +154,12 @@ func (c *KeyorixCore) RegenerateMFARecoveryCodes(ctx context.Context, userID uin
 	if !user.MFAEnabled {
 		return nil, fmt.Errorf("MFA is not enabled")
 	}
+	// Same account-level lockout gate as DisableMFA (see comment there): a stolen
+	// session with no lockout gating here would let an attacker brute-force the TOTP
+	// code to regenerate (and so invalidate) the legitimate recovery codes.
+	if c.loginLocked(user) {
+		return nil, fmt.Errorf("account temporarily locked due to repeated failed logins; try again later")
+	}
 	ok := false
 	if secret, err := c.loadTOTPSecret(ctx, userID); err == nil && c.validateTOTP(secret, codeOrPassword) {
 		ok = true
@@ -152,8 +169,10 @@ func (c *KeyorixCore) RegenerateMFARecoveryCodes(ctx context.Context, userID uin
 	}
 	if !ok {
 		c.auditMFAFailed(ctx, userID, "regenerate_recovery_codes")
+		c.recordFailedLogin(ctx, user) // count the failed re-auth attempt toward the lockout
 		return nil, fmt.Errorf("invalid code or password")
 	}
+	c.clearLoginFailures(ctx, user)
 	codes, hashes, err := generateRecoveryCodes(mfaRecoveryCodeCount)
 	if err != nil {
 		return nil, err

--- a/internal/core/mfa_test.go
+++ b/internal/core/mfa_test.go
@@ -315,3 +315,98 @@ func TestVerifyMFALogin_FailedCodesFeedAccountLockout(t *testing.T) {
 	assert.Contains(t, err.Error(), "locked")
 	assert.Nil(t, sess)
 }
+
+// DisableMFA is an authenticated-session self-service endpoint: a stolen session
+// with no TOTP secret must not be able to brute-force the current code unbounded.
+// Repeated wrong codes must feed the same per-account lockout VerifyMFALogin uses,
+// and once locked even a VALID code must be refused.
+func TestDisableMFA_FailedCodesFeedAccountLockout(t *testing.T) {
+	c, db, fixed := newMFATestCore(t)
+	c.loginLockout = LoginLockoutPolicy{Enabled: true, MaxAttempts: 3, Window: time.Hour, BaseCooldown: 15 * time.Minute, MaxCooldown: time.Hour}
+	ctx := context.Background()
+	secret, _ := activateMFAForTest(t, c, fixed)
+
+	for i := 0; i < 3; i++ {
+		err := c.DisableMFA(ctx, 1, "000000")
+		require.Error(t, err)
+	}
+
+	var locked models.User
+	require.NoError(t, db.First(&locked, 1).Error)
+	require.NotNil(t, locked.LoginLockedUntil, "account must be locked after MaxAttempts failed disable attempts")
+	assert.True(t, locked.LoginLockedUntil.After(fixed))
+
+	// Even a VALID TOTP code is now refused while the lock is active.
+	good, err := totp.GenerateCode(secret, fixed)
+	require.NoError(t, err)
+	err = c.DisableMFA(ctx, 1, good)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "locked")
+
+	// MFA must still be enabled — the lock blocked the disable, correct code or not.
+	var u models.User
+	require.NoError(t, db.First(&u, 1).Error)
+	assert.True(t, u.MFAEnabled)
+}
+
+// A successful DisableMFA (correct code/password) must clear any accrued lockout
+// state, mirroring the happy-path reset on a successful login.
+func TestDisableMFA_SuccessClearsLoginFailures(t *testing.T) {
+	c, db, fixed := newMFATestCore(t)
+	c.loginLockout = LoginLockoutPolicy{Enabled: true, MaxAttempts: 5, Window: time.Hour, BaseCooldown: 15 * time.Minute, MaxCooldown: time.Hour}
+	ctx := context.Background()
+	activateMFAForTest(t, c, fixed)
+
+	// Two wrong attempts accrue failures but don't yet reach the lockout threshold.
+	for i := 0; i < 2; i++ {
+		require.Error(t, c.DisableMFA(ctx, 1, "000000"))
+	}
+	var mid models.User
+	require.NoError(t, db.First(&mid, 1).Error)
+	assert.Equal(t, 2, mid.FailedLoginAttempts)
+
+	// A correct password succeeds and resets the accrued failures.
+	require.NoError(t, c.DisableMFA(ctx, 1, mfaTestPassword))
+	var after models.User
+	require.NoError(t, db.First(&after, 1).Error)
+	assert.Zero(t, after.FailedLoginAttempts)
+	assert.Nil(t, after.LoginLockedUntil)
+}
+
+// RegenerateMFARecoveryCodes is the second AUTHENTICATED-SESSION self-service
+// endpoint #125 names: repeated wrong-code attempts must feed the same per-account
+// lockout, and once locked even a valid code must be refused.
+func TestRegenerateMFARecoveryCodes_FailedCodesFeedAccountLockout(t *testing.T) {
+	c, db, fixed := newMFATestCore(t)
+	c.loginLockout = LoginLockoutPolicy{Enabled: true, MaxAttempts: 3, Window: time.Hour, BaseCooldown: 15 * time.Minute, MaxCooldown: time.Hour}
+	ctx := context.Background()
+	secret, original := activateMFAForTest(t, c, fixed)
+
+	for i := 0; i < 3; i++ {
+		_, err := c.RegenerateMFARecoveryCodes(ctx, 1, "000000")
+		require.Error(t, err)
+	}
+
+	var locked models.User
+	require.NoError(t, db.First(&locked, 1).Error)
+	require.NotNil(t, locked.LoginLockedUntil, "account must be locked after MaxAttempts failed regenerate attempts")
+	assert.True(t, locked.LoginLockedUntil.After(fixed))
+
+	// Even a VALID TOTP code is now refused while the lock is active.
+	good, err := totp.GenerateCode(secret, fixed)
+	require.NoError(t, err)
+	fresh, err := c.RegenerateMFARecoveryCodes(ctx, 1, good)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "locked")
+	assert.Nil(t, fresh)
+
+	// The original recovery codes must still be intact — the lock blocked the
+	// regenerate entirely.
+	ch, err := c.CreateMFAChallenge(ctx, 1)
+	require.NoError(t, err)
+	// Unlock first (the login-lockout also blocks VerifyMFALogin's second factor) so
+	// we can confirm the ORIGINAL codes, not a replacement set, are what remain.
+	require.NoError(t, db.Model(&models.User{}).Where("id = ?", 1).Update("login_locked_until", nil).Error)
+	_, _, err = c.VerifyMFALogin(ctx, ch, original[0], "ua", "1.2.3.4")
+	require.NoError(t, err, "original recovery code must still work; regenerate was blocked by the lock")
+}

--- a/internal/core/oidc_jwks.go
+++ b/internal/core/oidc_jwks.go
@@ -48,6 +48,18 @@ const maxJWKSBytes = 1 << 20 // 1 MiB
 // growth from a pathological key set.
 const maxJWKSKeys = 50
 
+// maxRSABits caps the modulus size of an RSA key accepted from a JWKS. Without
+// this, a compromised/malicious OIDC provider can serve an RSA key with an
+// absurdly large modulus (tens of thousands of bits); modular exponentiation
+// cost grows roughly cubically with modulus size, so a single oversized key
+// makes every signature verification against it expensive. Worse, the key is
+// cached for up to jwksCacheTTL and reused for every verification in that
+// window, so the cost is paid repeatedly per request, not just once at fetch —
+// a sustained DoS. 8192 bits comfortably exceeds any real-world RSA key size in
+// production use (2048/3072/4096 are standard; NIST's own long-term guidance
+// tops out at 15360) while still rejecting a maliciously oversized modulus.
+const maxRSABits = 8192
+
 // jwksStaleGrace bounds how far PAST the TTL a cached key set may still be served
 // as a fallback when a JWKS refetch fails transiently. Without a bound, a key the
 // issuer rotated out — e.g. because its private key was compromised — would keep
@@ -273,6 +285,9 @@ func parseJWK(k jwk) (interface{}, error) {
 		n, err := b64uBigInt(k.N)
 		if err != nil {
 			return nil, err
+		}
+		if n.BitLen() > maxRSABits {
+			return nil, fmt.Errorf("rsa modulus too large: %d bits exceeds %d-bit limit", n.BitLen(), maxRSABits)
 		}
 		eBytes, err := base64.RawURLEncoding.DecodeString(k.E)
 		if err != nil {

--- a/internal/core/oidc_jwks_test.go
+++ b/internal/core/oidc_jwks_test.go
@@ -158,6 +158,61 @@ func TestHTTPJWKSResolver_CapsKeyCount(t *testing.T) {
 	assert.LessOrEqual(t, n, maxJWKSKeys, "retained key count is capped")
 }
 
+// parseJWK must reject an RSA key whose modulus exceeds maxRSABits, rather than
+// constructing an rsa.PublicKey from it. Without this check an oversized modulus
+// from a malicious/compromised OIDC provider gets cached for up to jwksCacheTTL and
+// its expensive modular-exponentiation cost is paid on every verification in that
+// window — a sustained DoS, not just a one-time cost at fetch.
+func TestParseJWK_RejectsOversizedRSAModulus(t *testing.T) {
+	// Construct a JWK whose modulus is artificially larger than maxRSABits, without
+	// paying the cost of actually generating an RSA key that size: fill N with random
+	// bytes sized just over the limit.
+	nBytes := make([]byte, (maxRSABits/8)+16)
+	nBytes[0] = 0xFF // ensure the top byte is set so BitLen reflects the full length
+	_, err := rand.Read(nBytes)
+	require.NoError(t, err)
+	nBytes[0] |= 0x80
+
+	k := jwk{
+		Kty: "RSA",
+		Kid: "oversized",
+		N:   base64.RawURLEncoding.EncodeToString(nBytes),
+		E:   base64.RawURLEncoding.EncodeToString(big.NewInt(65537).Bytes()),
+	}
+	got, err := parseJWK(k)
+	require.Error(t, err, "an oversized RSA modulus must be rejected")
+	assert.Nil(t, got)
+	assert.Contains(t, err.Error(), "too large")
+}
+
+// A JWKS response containing an oversized RSA key must not be cached or served: the
+// key is skipped (parseJWK errors, and fetch continues past unparsable keys), so a
+// lookup for that kid fails rather than yielding the oversized key.
+func TestHTTPJWKSResolver_RejectsOversizedRSAKeyInJWKS(t *testing.T) {
+	nBytes := make([]byte, (maxRSABits/8)+16)
+	_, err := rand.Read(nBytes)
+	require.NoError(t, err)
+	nBytes[0] |= 0x80
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"keys": []map[string]string{{
+				"kty": "RSA", "kid": "oversized", "use": "sig",
+				"n": base64.RawURLEncoding.EncodeToString(nBytes),
+				"e": base64.RawURLEncoding.EncodeToString(big.NewInt(65537).Bytes()),
+			}},
+		})
+	}))
+	defer srv.Close()
+
+	r, err := NewHTTPJWKSResolver(map[string]string{"https://iss": srv.URL})
+	require.NoError(t, err)
+
+	_, err = r.Key(context.Background(), "https://iss", "oversized")
+	require.Error(t, err, "an oversized RSA key must never be cached or returned")
+	assert.Contains(t, err.Error(), "no usable signing keys")
+}
+
 func TestNewHTTPJWKSResolver_RejectsInsecureScheme(t *testing.T) {
 	// Plaintext http to a non-loopback host is refused (signing-key MITM).
 	_, err := NewHTTPJWKSResolver(map[string]string{"https://iss": "http://idp.example.com/jwks"})


### PR DESCRIPTION
## Summary

Two unrelated, previously-open findings from the security-hardening backlog:

**#100 (OIDC JWKS RSA-modulus DoS).** `parseJWK` (`internal/core/oidc_jwks.go`) had real hardening around it (redirect protection, response-size cap, key-count cap, refetch-storm guard) but no bound on the RSA modulus size itself. An attacker-controlled or compromised OIDC provider could serve a key with an absurdly large modulus; the key gets cached for up to `jwksCacheTTL` (1h) and its expensive modular-exponentiation cost is then paid on *every* signature verification in that window, not just once at fetch — a sustained DoS. `parseJWK` now rejects any RSA key whose modulus exceeds a new `maxRSABits` (8192) ceiling before constructing the `rsa.PublicKey`, with a clear error. 8192 bits comfortably exceeds any real-world RSA key size in production use (2048/3072/4096 are standard) while still bounding the attack.

**#125 (MFA disable/regen brute force).** A previous fix added account-lockout gating and TOTP anti-replay to `VerifyMFALogin` (the login-challenge completion path), but `DisableMFA` and `RegenerateMFARecoveryCodes` (`internal/core/mfa.go`) — the authenticated-session self-service endpoints the finding actually names — had no attempt-limiting at all, at either the core layer or the router layer. A stolen-session attacker could brute-force the current TOTP code against either endpoint (up to ~3e5 attempts within a session's lifetime) with zero throttling. Both endpoints now gate on the same per-account lockout `VerifyMFALogin` uses (`loginLocked` / `recordFailedLogin` / `clearLoginFailures`), keyed per-user since these are authenticated-session endpoints, not per-IP like the login path.

## Test plan
- [x] New regression test `TestParseJWK_RejectsOversizedRSAModulus` — an artificially oversized RSA modulus is rejected with a clear "too large" error.
- [x] New regression test `TestHTTPJWKSResolver_RejectsOversizedRSAKeyInJWKS` — an oversized key in a fetched JWKS is never cached or served.
- [x] New regression tests `TestDisableMFA_FailedCodesFeedAccountLockout` / `TestDisableMFA_SuccessClearsLoginFailures` — repeated wrong-code attempts against `DisableMFA` trip the same account lockout as login, and a valid re-auth clears accrued failures.
- [x] New regression test `TestRegenerateMFARecoveryCodes_FailedCodesFeedAccountLockout` — same coverage for `RegenerateMFARecoveryCodes`.
- [x] `go build ./...` clean.
- [x] `go test ./...` clean (two known unrelated flakes — `TestSpool_PersistsAndReplaysOnRecovery` in `internal/audit/siem` and `TestHTTPJWKSResolver_CapsKeyCount` in `internal/core` — both confirmed to pass when their package is run in isolation).
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues.
- [x] `golangci-lint run ./...` — 0 issues.
- [x] `GOWORK=off go build -C operator ./...` — clean.