### PR TITLE
fix(access-review): close the campaign-close-vs-decision race (#343/#237)

### DIFF
--- a/internal/core/access_review_campaign.go
+++ b/internal/core/access_review_campaign.go
@@ -240,19 +240,28 @@ func (c *KeyorixCore) DecideAccessReviewItem(ctx context.Context, actorID, proje
 	item.Reason = reason
 	item.DecidedBy = actorID
 	item.DecidedAt = &now
-	// The pending check above is a plain read, so a concurrent or replayed second
-	// decision on this item can reach here too, having read the same "pending" state
-	// before either write lands. UpdateAccessReviewItem's WHERE-decision='pending'
-	// conditional UPDATE is the actual race-closing guard: ok==false means this call
-	// lost the race (the item was decided out from under it), so surface a clear
-	// "already decided" error rather than a generic storage failure — and, crucially,
-	// don't silently let this decision overwrite the one that won.
+	// Both pre-checks above (item still pending, campaign still open) are plain reads,
+	// so a concurrent/replayed second decision (#319) or a concurrent force-close
+	// (#343) can reach here too, having read the same "pending"/"open" state before
+	// either write lands. UpdateAccessReviewItem's single conditional UPDATE — WHERE
+	// decision='pending' AND the parent campaign's state='open', both checked
+	// atomically in the same statement — is the actual race-closing guard: ok==false
+	// means this call lost the race, either to another decision or to a concurrent
+	// close, so don't silently let this decision overwrite the winner or land into a
+	// campaign whose evidence snapshot was supposed to be frozen at close time.
 	ok, err := c.storage.UpdateAccessReviewItem(ctx, item)
 	if err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}
 	if !ok {
-		return fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "this item has already been decided")
+		// The conditional UPDATE doesn't say WHICH precondition failed, so re-read the
+		// item to shape an accurate error. This re-read is purely cosmetic — the
+		// security decision was already made atomically by the UPDATE above, win or
+		// lose; nothing here re-opens the race.
+		if reloaded, rerr := c.storage.GetAccessReviewItem(ctx, itemID); rerr == nil && reloaded.Decision != ReviewItemPending {
+			return fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "this item has already been decided")
+		}
+		return fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "campaign is closed; decisions can only be made on an open campaign")
 	}
 	return nil
 }
@@ -307,8 +316,19 @@ func (c *KeyorixCore) CloseAccessReviewCampaign(ctx context.Context, actorID, pr
 	campaign.State = CampaignStateClosed
 	campaign.ClosedBy = actorID
 	campaign.ClosedAt = &now
-	if err := c.storage.UpdateAccessReviewCampaign(ctx, campaign); err != nil {
+	// The "already closed" check above is a plain read, so two concurrent close calls
+	// (or a close racing another close) can both observe "open" before either write
+	// lands. UpdateAccessReviewCampaign's WHERE-state='open' conditional UPDATE is the
+	// actual race-closing guard: ok==false means this call lost the race (the
+	// campaign was closed out from under it), so surface the same "already closed"
+	// error rather than silently re-closing (and re-stamping ClosedBy/ClosedAt on) an
+	// already-frozen evidence record.
+	ok, err := c.storage.UpdateAccessReviewCampaign(ctx, campaign)
+	if err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	if !ok {
+		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "campaign is already closed")
 	}
 	c.auditProjectScoped(ctx, EventCampaignClosed, actorID, projectID,
 		fmt.Sprintf("closed access-review campaign %d: %d attested, %d revoked, %d pending of %d",

--- a/internal/core/concurrency_access_review_campaign_close_test.go
+++ b/internal/core/concurrency_access_review_campaign_close_test.go
@@ -1,0 +1,129 @@
+package core_test
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// TestConcurrency_DecideAccessReviewItem_RejectsWhenRacingClose drives the FULL
+// DecideAccessReviewItem and CloseAccessReviewCampaign paths (#343, extending #237) —
+// not just the storage layer — with many concurrent reviewers deciding the SAME
+// pending item racing against a concurrent force-close of the campaign. It proves the
+// end-to-end guarantee: a decision can never land in a campaign that has already
+// closed, and a close can never silently coexist with a decision that raced through
+// the same instant undetected. Every outcome must be one of: exactly one decision
+// succeeds (and the close either wins outright or loses to that legitimate decision,
+// in which case it must be retried by a caller), or the close wins and every decision
+// is cleanly rejected as "campaign is closed" — never a silent overwrite, panic, or
+// generic 500.
+func TestConcurrency_DecideAccessReviewItem_RejectsWhenRacingClose(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	dsn := "file:" + filepath.Join(t.TempDir(), "arc-close-race.db") + "?_busy_timeout=10000&_journal_mode=WAL&_txlock=immediate"
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.AccessReviewCampaign{}, &models.AccessReviewItem{}, &models.AuditEvent{}))
+
+	const proj = uint(2)
+	campaign := &models.AccessReviewCampaign{ProjectID: proj, Name: "close-race", State: core.CampaignStateOpen}
+	require.NoError(t, db.Create(campaign).Error)
+	item := &models.AccessReviewItem{CampaignID: campaign.ID, PrincipalType: "role", Source: "role", Decision: core.ReviewItemPending}
+	require.NoError(t, db.Create(item).Error)
+
+	c := core.NewKeyorixCore(store.NewLocalStorage(db))
+	ctx := context.Background()
+
+	const reviewers = 16
+	var decideSucceeded atomic.Int64
+	var decideRejectedDecided atomic.Int64
+	var decideRejectedClosed atomic.Int64
+	var closeSucceeded atomic.Int64
+	var closeRejected atomic.Int64
+	unexpected := make(chan error, reviewers+1)
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+
+	for i := 0; i < reviewers; i++ {
+		wg.Add(1)
+		actorID := uint(100 + i) // distinct attributable human reviewers, none is the item's principal
+		go func(actorID uint) {
+			defer wg.Done()
+			<-start
+			decErr := c.DecideAccessReviewItem(ctx, actorID, proj, campaign.ID, item.ID, "attest", "concurrent review")
+			switch {
+			case decErr == nil:
+				decideSucceeded.Add(1)
+			case strings.Contains(decErr.Error(), "already been decided"):
+				decideRejectedDecided.Add(1)
+			case strings.Contains(decErr.Error(), "campaign is closed"):
+				decideRejectedClosed.Add(1)
+			default:
+				unexpected <- decErr
+			}
+		}(actorID)
+	}
+
+	// One racer force-closes the campaign at the same instant.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		<-start
+		_, closeErr := c.CloseAccessReviewCampaign(ctx, 1, proj, campaign.ID, true)
+		switch {
+		case closeErr == nil:
+			closeSucceeded.Add(1)
+		case strings.Contains(closeErr.Error(), "already closed"):
+			closeRejected.Add(1)
+		default:
+			unexpected <- closeErr
+		}
+	}()
+
+	close(start) // release every racer at once
+	wg.Wait()
+	close(unexpected)
+	for e := range unexpected {
+		require.NoError(t, e, "every rejection must be a clean, expected error — nothing else")
+	}
+
+	// The close is a single-shot operation against a single campaign: it must
+	// succeed exactly once (there's only one closer racer here, but the underlying
+	// guarantee — proven exhaustively by the store-level concurrency test — is that
+	// it can never succeed twice).
+	assert.Equal(t, int64(1), closeSucceeded.Load(), "the force-close must succeed exactly once")
+	assert.Equal(t, int64(0), closeRejected.Load())
+
+	// At most one decision may ever be recorded.
+	assert.LessOrEqual(t, decideSucceeded.Load(), int64(1), "at most one concurrent decision may be recorded")
+	assert.Equal(t, reviewers, int(decideSucceeded.Load()+decideRejectedDecided.Load()+decideRejectedClosed.Load()),
+		"every reviewer call must land in exactly one clean outcome bucket")
+
+	// Final state consistency: the campaign is closed, and the item's decision state
+	// must be exactly consistent with what "closed means frozen" requires — if a
+	// decision won the race, it must have committed before the close (the atomic
+	// UPDATE guarantees this); the campaign closing afterward doesn't retroactively
+	// unfreeze or corrupt it.
+	var gotCampaign models.AccessReviewCampaign
+	require.NoError(t, db.First(&gotCampaign, campaign.ID).Error)
+	assert.Equal(t, core.CampaignStateClosed, gotCampaign.State)
+
+	var gotItem models.AccessReviewItem
+	require.NoError(t, db.First(&gotItem, item.ID).Error)
+	if decideSucceeded.Load() == 1 {
+		assert.Equal(t, core.ReviewItemAttested, gotItem.Decision, "the single winning decision must be the one persisted")
+	} else {
+		assert.Equal(t, core.ReviewItemPending, gotItem.Decision, "no decision won the race — the item must remain untouched, frozen exactly as the close left it")
+	}
+}

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -213,9 +213,9 @@ func (m *MockStorage) ListAccessReviewCampaigns(ctx context.Context, projectID u
 	return args.Get(0).([]*models.AccessReviewCampaign), args.Error(1)
 }
 
-func (m *MockStorage) UpdateAccessReviewCampaign(ctx context.Context, c *models.AccessReviewCampaign) error {
+func (m *MockStorage) UpdateAccessReviewCampaign(ctx context.Context, c *models.AccessReviewCampaign) (bool, error) {
 	args := m.Called(ctx, c)
-	return args.Error(0)
+	return args.Bool(0), args.Error(1)
 }
 
 func (m *MockStorage) CreateAccessReviewItems(ctx context.Context, items []*models.AccessReviewItem) error {

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -108,15 +108,21 @@ type Storage interface {
 	CreateAccessReviewCampaign(ctx context.Context, c *models.AccessReviewCampaign) (*models.AccessReviewCampaign, error)
 	GetAccessReviewCampaign(ctx context.Context, id uint) (*models.AccessReviewCampaign, error)
 	ListAccessReviewCampaigns(ctx context.Context, projectID uint) ([]*models.AccessReviewCampaign, error)
-	UpdateAccessReviewCampaign(ctx context.Context, c *models.AccessReviewCampaign) error
+	// UpdateAccessReviewCampaign persists a campaign state transition with a
+	// conditional UPDATE (only a campaign whose CURRENT stored state is still "open"
+	// may be transitioned). The bool reports whether the row matched and was updated;
+	// false means the campaign was already closed (by a prior or racing call) and
+	// this write was rejected, not silently applied.
+	UpdateAccessReviewCampaign(ctx context.Context, c *models.AccessReviewCampaign) (bool, error)
 	CreateAccessReviewItems(ctx context.Context, items []*models.AccessReviewItem) error
 	ListAccessReviewItems(ctx context.Context, campaignID uint) ([]*models.AccessReviewItem, error)
 	GetAccessReviewItem(ctx context.Context, id uint) (*models.AccessReviewItem, error)
 	// UpdateAccessReviewItem persists a decision with a conditional UPDATE (only an
-	// item whose CURRENT stored decision is still "pending" may be transitioned). The
-	// bool reports whether the row matched and was updated; false means the item was
-	// already decided (by a prior or racing call) and this write was rejected, not
-	// silently applied.
+	// item whose CURRENT stored decision is still "pending", in a campaign whose
+	// CURRENT stored state is still "open", may be transitioned). The bool reports
+	// whether the row matched and was updated; false means either the item was
+	// already decided or the parent campaign was closed (by a prior or racing call)
+	// and this write was rejected, not silently applied.
 	UpdateAccessReviewItem(ctx context.Context, item *models.AccessReviewItem) (bool, error)
 
 	// Separation-of-duties policies (ISO 27001 A.5.3 / SOX) — toxic permission pairs.

--- a/internal/storage/store/concurrency_access_review_campaign_close_test.go
+++ b/internal/storage/store/concurrency_access_review_campaign_close_test.go
@@ -1,0 +1,127 @@
+// concurrency_access_review_campaign_close_test.go — regression coverage for #343
+// (extends the still-unfixed #237): a campaign force-close racing a concurrent item
+// decision must not land a fresh decision into a campaign whose evidence snapshot was
+// supposed to be frozen at close time, and the close transition itself must be atomic.
+package store
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestUpdateAccessReviewItem_RejectsWhenCampaignClosedConcurrently deterministically
+// reproduces the #343 exploit trace at the layer where the guarantee actually lives:
+// DecideAccessReviewItem's own pre-check (item pending, campaign open) is a plain
+// read, so a concurrent force-close can land BETWEEN that read and the persist. This
+// simulates exactly that window — the campaign closes after the "read" but before the
+// persist — and asserts the persist itself (not the earlier in-memory pre-check)
+// rejects it: the campaign is the frozen source of truth, so "closed" wins over a
+// decision racing through the same instant.
+func TestUpdateAccessReviewItem_RejectsWhenCampaignClosedConcurrently(t *testing.T) {
+	db := concurrentDB(t)
+	require.NoError(t, db.AutoMigrate(&models.AccessReviewCampaign{}, &models.AccessReviewItem{}))
+	ls := NewLocalStorage(db)
+	ctx := context.Background()
+
+	campaign := &models.AccessReviewCampaign{ProjectID: 1, Name: "race", State: accessReviewCampaignOpen}
+	require.NoError(t, db.Create(campaign).Error)
+	item := &models.AccessReviewItem{CampaignID: campaign.ID, PrincipalType: "role", Source: "role", Decision: accessReviewItemPending}
+	require.NoError(t, db.Create(item).Error)
+
+	// A reviewer's DecideAccessReviewItem call has already read the item (pending)
+	// and the campaign (open) at this point, and is about to persist an "attest".
+
+	// A concurrent force-close lands first and commits.
+	require.NoError(t, db.Model(&models.AccessReviewCampaign{}).
+		Where("id = ?", campaign.ID).
+		Update("state", "closed").Error)
+
+	// The reviewer's decision, computed against the now-stale "open" read, attempts
+	// to persist. It must be rejected — not silently applied to a frozen campaign.
+	decided := &models.AccessReviewItem{ID: item.ID, CampaignID: campaign.ID, PrincipalType: "role", Source: "role", Decision: "attested"}
+	ok, err := ls.UpdateAccessReviewItem(ctx, decided)
+	require.NoError(t, err, "a lost race is reported via the bool, not an error")
+	assert.False(t, ok, "a decision racing a concurrent close must be rejected — closed means frozen")
+
+	var got models.AccessReviewItem
+	require.NoError(t, db.First(&got, item.ID).Error)
+	assert.Equal(t, accessReviewItemPending, got.Decision, "the item must remain untouched — no decision lands into a closed campaign")
+}
+
+// TestUpdateAccessReviewItem_SucceedsWhileCampaignOpen is the control case: with no
+// racing close, a decision on a pending item in an open campaign still persists
+// normally (the new campaign-open condition must not be a false-positive block).
+func TestUpdateAccessReviewItem_SucceedsWhileCampaignOpen(t *testing.T) {
+	db := concurrentDB(t)
+	require.NoError(t, db.AutoMigrate(&models.AccessReviewCampaign{}, &models.AccessReviewItem{}))
+	ls := NewLocalStorage(db)
+	ctx := context.Background()
+
+	campaign := &models.AccessReviewCampaign{ProjectID: 1, Name: "no-race", State: accessReviewCampaignOpen}
+	require.NoError(t, db.Create(campaign).Error)
+	item := &models.AccessReviewItem{CampaignID: campaign.ID, PrincipalType: "role", Source: "role", Decision: accessReviewItemPending}
+	require.NoError(t, db.Create(item).Error)
+
+	decided := &models.AccessReviewItem{ID: item.ID, CampaignID: campaign.ID, PrincipalType: "role", Source: "role", Decision: "attested"}
+	ok, err := ls.UpdateAccessReviewItem(ctx, decided)
+	require.NoError(t, err)
+	assert.True(t, ok, "a decision against a still-open campaign must succeed")
+
+	var got models.AccessReviewItem
+	require.NoError(t, db.First(&got, item.ID).Error)
+	assert.Equal(t, "attested", got.Decision)
+}
+
+// TestConcurrency_UpdateAccessReviewCampaign_OnlyOneCloseWins drives real concurrent
+// close attempts (file-backed SQLite, WAL, genuine multi-connection contention)
+// against the SAME open campaign and asserts the conditional UPDATE lets exactly one
+// win — the close-transition analogue of #319's item-level guarantee.
+func TestConcurrency_UpdateAccessReviewCampaign_OnlyOneCloseWins(t *testing.T) {
+	db := concurrentDB(t)
+	require.NoError(t, db.AutoMigrate(&models.AccessReviewCampaign{}, &models.AccessReviewItem{}))
+	ls := NewLocalStorage(db)
+
+	campaign := &models.AccessReviewCampaign{ProjectID: 1, Name: "double-close", State: accessReviewCampaignOpen}
+	require.NoError(t, db.Create(campaign).Error)
+
+	const racers = 32
+	var succeeded atomic.Int64
+	errs := make(chan error, racers)
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < racers; i++ {
+		wg.Add(1)
+		closerID := uint(200 + i)
+		go func(closerID uint) {
+			defer wg.Done()
+			<-start
+			candidate := &models.AccessReviewCampaign{ID: campaign.ID, ProjectID: 1, Name: "double-close", State: "closed", ClosedBy: closerID}
+			ok, err := ls.UpdateAccessReviewCampaign(context.Background(), candidate)
+			if err != nil {
+				errs <- err
+				return
+			}
+			if ok {
+				succeeded.Add(1)
+			}
+		}(closerID)
+	}
+	close(start) // release every racer at once
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+
+	assert.Equal(t, int64(1), succeeded.Load(), "exactly one concurrent close may win — never zero, never more than one")
+
+	var got models.AccessReviewCampaign
+	require.NoError(t, db.First(&got, campaign.ID).Error)
+	assert.Equal(t, "closed", got.State, "the winning close must have been persisted")
+}

--- a/internal/storage/store/concurrency_access_review_redecide_test.go
+++ b/internal/storage/store/concurrency_access_review_redecide_test.go
@@ -22,7 +22,9 @@ func TestUpdateAccessReviewItem_RejectsSecondDecision(t *testing.T) {
 	ls := NewLocalStorage(db)
 	ctx := context.Background()
 
-	item := &models.AccessReviewItem{CampaignID: 1, PrincipalType: "role", Source: "role", Decision: "pending"}
+	campaign := &models.AccessReviewCampaign{State: accessReviewCampaignOpen}
+	require.NoError(t, db.Create(campaign).Error)
+	item := &models.AccessReviewItem{CampaignID: campaign.ID, PrincipalType: "role", Source: "role", Decision: "pending"}
 	require.NoError(t, db.Create(item).Error)
 
 	// Call 1: revoke really "wins" the decision.
@@ -32,7 +34,7 @@ func TestUpdateAccessReviewItem_RejectsSecondDecision(t *testing.T) {
 	assert.True(t, ok, "the first decision on a pending item must succeed")
 
 	// Call 2: a later/racing attest must NOT silently overwrite the persisted revoke.
-	overwrite := &models.AccessReviewItem{ID: item.ID, CampaignID: 1, PrincipalType: "role", Source: "role", Decision: "attested"}
+	overwrite := &models.AccessReviewItem{ID: item.ID, CampaignID: campaign.ID, PrincipalType: "role", Source: "role", Decision: "attested"}
 	ok, err = ls.UpdateAccessReviewItem(ctx, overwrite)
 	require.NoError(t, err, "a lost race is reported via the bool, not an error")
 	assert.False(t, ok, "a second decision on an already-decided item must be rejected")
@@ -53,7 +55,9 @@ func TestConcurrency_AccessReviewItem_OnlyOneDecisionWins(t *testing.T) {
 	require.NoError(t, db.AutoMigrate(&models.AccessReviewCampaign{}, &models.AccessReviewItem{}))
 	ls := NewLocalStorage(db)
 
-	item := &models.AccessReviewItem{CampaignID: 1, PrincipalType: "role", Source: "role", Decision: "pending"}
+	campaign := &models.AccessReviewCampaign{State: accessReviewCampaignOpen}
+	require.NoError(t, db.Create(campaign).Error)
+	item := &models.AccessReviewItem{CampaignID: campaign.ID, PrincipalType: "role", Source: "role", Decision: "pending"}
 	require.NoError(t, db.Create(item).Error)
 
 	const racers = 32
@@ -70,7 +74,7 @@ func TestConcurrency_AccessReviewItem_OnlyOneDecisionWins(t *testing.T) {
 		go func(decision string) {
 			defer wg.Done()
 			<-start
-			candidate := &models.AccessReviewItem{ID: item.ID, CampaignID: 1, PrincipalType: "role", Source: "role", Decision: decision}
+			candidate := &models.AccessReviewItem{ID: item.ID, CampaignID: campaign.ID, PrincipalType: "role", Source: "role", Decision: decision}
 			ok, err := ls.UpdateAccessReviewItem(context.Background(), candidate)
 			if err != nil {
 				errs <- err

--- a/internal/storage/store/local_access_review_campaigns.go
+++ b/internal/storage/store/local_access_review_campaigns.go
@@ -40,11 +40,30 @@ func (ls *LocalStorage) ListAccessReviewCampaigns(ctx context.Context, projectID
 	return rows, nil
 }
 
-func (ls *LocalStorage) UpdateAccessReviewCampaign(ctx context.Context, c *models.AccessReviewCampaign) error {
-	if err := ls.db.WithContext(ctx).Save(c).Error; err != nil {
-		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+// accessReviewCampaignOpen mirrors core.CampaignStateOpen (the store package cannot
+// import core: core already imports storage/store). Both sides of this state
+// machine — core's pre-check and this conditional UPDATE — must agree on the same
+// "still open" sentinel string.
+const accessReviewCampaignOpen = "open"
+
+// UpdateAccessReviewCampaign persists a campaign state transition with a conditional
+// UPDATE (`WHERE id = ? AND state = 'open'`), not the prior unconditional Save. The
+// only mutation path today is CloseAccessReviewCampaign (open -> closed): a plain
+// read-then-write left a window for two concurrent close calls — or a close racing a
+// concurrent decision that read the campaign while it was still "open" — to both pass
+// their in-memory precondition before either write lands. Making the persist itself
+// the single conditional statement closes that race the same way #319 closed it at
+// the item layer: whichever call's UPDATE lands first wins (RowsAffected==1); the
+// loser is told so instead of silently re-closing (or clobbering) the winner's record.
+func (ls *LocalStorage) UpdateAccessReviewCampaign(ctx context.Context, c *models.AccessReviewCampaign) (bool, error) {
+	res := ls.db.WithContext(ctx).Model(&models.AccessReviewCampaign{}).
+		Where("id = ? AND state = ?", c.ID, accessReviewCampaignOpen).
+		Select("*").
+		Updates(c)
+	if res.Error != nil {
+		return false, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), res.Error)
 	}
-	return nil
+	return res.RowsAffected == 1, nil
 }
 
 // --- Items ---
@@ -86,19 +105,27 @@ func (ls *LocalStorage) GetAccessReviewItem(ctx context.Context, id uint) (*mode
 const accessReviewItemPending = "pending"
 
 // UpdateAccessReviewItem persists a recertification decision with a conditional
-// UPDATE (`WHERE id = ? AND decision = 'pending'`), not an unconditional Save. A
-// decision is a one-way transition (pending -> attested|revoked): DecideAccessReviewItem
-// reads the item, checks it's still pending, then acts and persists — a plain
+// UPDATE (`WHERE id = ? AND decision = 'pending' AND campaign_id IN (SELECT id FROM
+// access_review_campaigns WHERE id = ? AND state = 'open')`), not an unconditional
+// Save. A decision is a one-way transition (pending -> attested|revoked):
+// DecideAccessReviewItem reads the item AND the campaign, checks the item is still
+// pending and the campaign is still open, then acts and persists — a plain
 // read-then-write with a gap in between (the action itself, plus everything else in
 // the request) wide enough for two concurrent/replayed decisions to both pass the
-// pending check before either writes. Making the persist itself the single
-// conditional statement closes that race: whichever call's UPDATE lands first wins
-// (RowsAffected==1); the loser's UPDATE matches zero rows and is told so, instead of
-// silently overwriting the winner's decision and corrupting the compliance evidence
-// trail.
+// pending check before either writes (#319), or for a decision to observe the
+// campaign as "open" immediately before a concurrent force-close freezes it (#343).
+// Making the persist itself a single conditional statement that verifies BOTH
+// preconditions atomically closes both races in one shot: whichever write lands
+// first wins (RowsAffected==1); the loser's UPDATE matches zero rows and is told so,
+// instead of silently overwriting the winner's decision (#319) or landing a fresh
+// decision into a campaign whose evidence snapshot was supposed to be frozen at
+// close time (#343).
 func (ls *LocalStorage) UpdateAccessReviewItem(ctx context.Context, item *models.AccessReviewItem) (bool, error) {
+	openCampaign := ls.db.Model(&models.AccessReviewCampaign{}).
+		Select("id").
+		Where("id = ? AND state = ?", item.CampaignID, accessReviewCampaignOpen)
 	res := ls.db.WithContext(ctx).Model(&models.AccessReviewItem{}).
-		Where("id = ? AND decision = ?", item.ID, accessReviewItemPending).
+		Where("id = ? AND decision = ? AND campaign_id IN (?)", item.ID, accessReviewItemPending, openCampaign).
 		Select("*").
 		Updates(item)
 	if res.Error != nil {

--- a/internal/storage/store/remote_access_review_campaigns.go
+++ b/internal/storage/store/remote_access_review_campaigns.go
@@ -21,8 +21,8 @@ func (rs *RemoteStorage) ListAccessReviewCampaigns(_ context.Context, _ uint) ([
 	return nil, remoteUnsupported("ListAccessReviewCampaigns")
 }
 
-func (rs *RemoteStorage) UpdateAccessReviewCampaign(_ context.Context, _ *models.AccessReviewCampaign) error {
-	return remoteUnsupported("UpdateAccessReviewCampaign")
+func (rs *RemoteStorage) UpdateAccessReviewCampaign(_ context.Context, _ *models.AccessReviewCampaign) (bool, error) {
+	return false, remoteUnsupported("UpdateAccessReviewCampaign")
 }
 
 func (rs *RemoteStorage) CreateAccessReviewItems(_ context.Context, _ []*models.AccessReviewItem) error {


### PR DESCRIPTION
## Summary

- **#343 MEDIUM / #237** — `DecideAccessReviewItem` checked `campaign.State != CampaignStateOpen` via a plain, unguarded read before persisting a decision, and `CloseAccessReviewCampaign` had no DB-level guard on the campaign's state transition (`UpdateAccessReviewCampaign` was a plain `.Save(c)`). A decision's own read of `campaign.State` could observe `open` immediately before a concurrent force-close wrote `closed`; the decision would then persist via the (already atomic, per #319) item-level `WHERE decision='pending'` update, which had no awareness of the campaign's state — landing a fresh attest/revoke into a campaign whose evidence snapshot was supposed to be frozen at close time. Same bug family #319 fixed for item-vs-item races, one layer up at the campaign-close transition.
- `UpdateAccessReviewCampaign` is now a conditional `UPDATE ... WHERE id = ? AND state = 'open'`, reporting via a bool whether the close actually landed — two concurrent closes now resolve to exactly one winner, matching #319's own established convention.
- `UpdateAccessReviewItem`'s conditional update now also requires the parent campaign's `state = 'open'` (via a subquery on `access_review_campaigns`), so the item persist and the campaign-open check happen as a single atomic statement instead of two separate reads with a gap between them. **Ordering guarantee chosen: a decision racing a concurrent close loses cleanly** (surfaced as `"campaign is closed; decisions can only be made on an open campaign"`) — "closed means frozen" is the stronger invariant for an evidence record, so close wins over a same-instant decision.
- Verified the adjacent low-confidence note from the same backlog round: `CloseAccessReviewCampaign`'s "refuse to close while pending items remain" guard is still purely an in-memory tally (`ListAccessReviewItems` + `tallyProgress`), with no DB-level backstop. Left as-is — it's a workflow nicety around force vs. non-force close, not the security boundary this fix addresses (which is now enforced atomically regardless of how close is reached), and closing it properly would need a materially bigger transactional change than this fix's scope.

## Test plan

- [x] New regression tests:
  - `internal/storage/store/concurrency_access_review_campaign_close_test.go` — deterministic reproduction of the #343 race at the storage layer (`TestUpdateAccessReviewItem_RejectsWhenCampaignClosedConcurrently`), a control case (`TestUpdateAccessReviewItem_SucceedsWhileCampaignOpen`), and a real-concurrency proof that the close transition itself is atomic (`TestConcurrency_UpdateAccessReviewCampaign_OnlyOneCloseWins`, 32 racers, exactly one wins).
  - `internal/core/concurrency_access_review_campaign_close_test.go` — end-to-end concurrency test driving `DecideAccessReviewItem` and `CloseAccessReviewCampaign` against the same campaign/item, asserting no silent overwrite and full outcome-bucket consistency (`TestConcurrency_DecideAccessReviewItem_RejectsWhenRacingClose`).
  - Updated the pre-existing #319 item-vs-item concurrency tests to create a real open campaign row (the new campaign-open subquery condition requires it).
- [x] `go build ./...` clean
- [x] `go test ./...` full suite clean (no failures, including the known unrelated flakes `TestSpool_PersistsAndReplaysOnRecovery` and `TestHTTPJWKSResolver_CapsKeyCount`, which did not trigger this run)
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues
- [x] `golangci-lint run ./...` — 0 issues
- [x] `GOWORK=off go build -C operator ./...` — clean build