### PR TITLE
harden(connect,rbac): refuse Vault redirects, allow break-glass reactivation after expiry (#98/#263)

### DIFF
--- a/internal/connect/vault.go
+++ b/internal/connect/vault.go
@@ -40,7 +40,19 @@ func NewVaultConnector(name, address, token string, allowedRefs []string) *Vault
 		address:     strings.TrimRight(address, "/"),
 		token:       token,
 		allowedRefs: allowedRefs,
-		client:      &http.Client{Timeout: 15 * time.Second},
+		client: &http.Client{
+			Timeout: 15 * time.Second,
+			// Refuse to follow any redirect. Go's default redirect policy strips
+			// Authorization/Cookie/WWW-Authenticate on a cross-host hop, but
+			// X-Vault-Token is a custom header it does NOT know to strip — so a
+			// compromised or MITM'd Vault endpoint that answers with a 3xx to an
+			// attacker-controlled host would otherwise receive the live Vault
+			// token (#98). Vault's real KV-read API has no legitimate reason to
+			// redirect a GET, so refusing outright is correct, not merely safe.
+			CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		},
 	}
 }
 

--- a/internal/connect/vault_test.go
+++ b/internal/connect/vault_test.go
@@ -174,3 +174,63 @@ func TestVault_GetSecret_LegitimateScopedRefStillWorks(t *testing.T) {
 	require.NoError(t, err)
 	assert.JSONEq(t, `{"password":"p@ss"}`, val)
 }
+
+// TestVault_GetSecret_RefusesCrossHostRedirect proves #98: a compromised/MITM'd Vault
+// endpoint that answers a GET with a 3xx to a different host must NOT cause the live
+// X-Vault-Token to be forwarded there. Go's default redirect policy strips
+// Authorization/Cookie/WWW-Authenticate on a cross-host hop, but NOT the custom
+// X-Vault-Token header — so without an explicit CheckRedirect override, the token
+// would leak to the attacker-controlled host. The connector refuses to follow the
+// redirect at all, so the attacker host must never even receive a request.
+func TestVault_GetSecret_RefusesCrossHostRedirect(t *testing.T) {
+	var attackerHits int
+	var attackerSawToken bool
+	attacker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attackerHits++
+		if r.Header.Get("X-Vault-Token") != "" {
+			attackerSawToken = true
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(attacker.Close)
+
+	vault := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// A "compromised" Vault endpoint redirecting the client to an
+		// attacker-controlled host, on a different origin than vault's own.
+		http.Redirect(w, r, attacker.URL+"/steal", http.StatusFound)
+	}))
+	t.Cleanup(vault.Close)
+
+	c := NewVaultConnector("v", vault.URL, "supersecret-token", nil)
+	_, err := c.GetSecret(context.Background(), "secret/data/myapp")
+
+	require.Error(t, err, "a redirect response must not be treated as a successful read")
+	assert.Contains(t, err.Error(), "HTTP 302", "the redirect status itself surfaces as the (non-200) response")
+	assert.Zero(t, attackerHits, "the connector must never follow the redirect to the attacker-controlled host")
+	assert.False(t, attackerSawToken, "the live Vault token must never reach the attacker-controlled host")
+}
+
+// TestVault_GetSecret_RefusesSameHostRedirect proves the refusal is unconditional
+// (not merely cross-host-aware): even a same-host redirect (e.g. to a path an
+// operator didn't intend to be reachable) is refused rather than followed, since
+// Vault's real KV-read API has no legitimate reason to redirect a GET at all.
+func TestVault_GetSecret_RefusesSameHostRedirect(t *testing.T) {
+	var redirectTargetHits int
+	var mux http.ServeMux
+	srv := httptest.NewServer(&mux)
+	t.Cleanup(srv.Close)
+	mux.HandleFunc("/v1/secret/data/myapp", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, srv.URL+"/v1/secret/data/other", http.StatusMovedPermanently)
+	})
+	mux.HandleFunc("/v1/secret/data/other", func(w http.ResponseWriter, r *http.Request) {
+		redirectTargetHits++
+		_, _ = w.Write([]byte(`{"data":{"data":{"x":"y"},"metadata":{}}}`))
+	})
+
+	c := NewVaultConnector("v", srv.URL, "tok", nil)
+	_, err := c.GetSecret(context.Background(), "secret/data/myapp")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "HTTP 301")
+	assert.Zero(t, redirectTargetHits, "even a same-host redirect target must never be requested")
+}

--- a/internal/core/break_glass_external_test.go
+++ b/internal/core/break_glass_external_test.go
@@ -347,6 +347,51 @@ func TestActivateBreakGlass_RejectsConcurrentReactivation(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// #263: a second, real-incident break-glass activation for the same user/role/project
+// must succeed once the FIRST activation's grant has naturally EXPIRED — not fail with
+// "already assigned" against a stale, un-reaped user_roles row. The existing
+// revoke-then-reactivate coverage above (TestActivateBreakGlass_RejectsConcurrentReactivation)
+// doesn't exercise this: an explicit revoke deletes the row outright, but a natural
+// expiry leaves it in place with expires_at in the past, which the assignment's
+// existence check must treat as absent.
+func TestActivateBreakGlass_ReactivatesAfterNaturalExpiry(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	migrateBreakGlass(t, h)
+	enableBreakGlass(h, "editor", 4*time.Hour, 24*time.Hour) // editor = role 3
+
+	const proj = uint(2)
+	ctx := context.Background()
+	h.CreateTestUser(t, "alice", 10)
+	makeProjectMember(t, h, 10, proj)
+
+	first, err := h.CoreService.ActivateBreakGlass(ctx, proj, 10, "first incident", "")
+	require.NoError(t, err)
+
+	// Simulate the first grant's TTL naturally elapsing: push both the underlying
+	// user_roles row's expiry AND the activation record's expiry into the past — the
+	// same effect a real elapsed TTL has, without waiting hours in the test. Critically,
+	// unlike RevokeBreakGlass, this does NOT delete the user_roles row.
+	past := time.Now().Add(-time.Minute)
+	require.NoError(t, h.DB.Model(&models.UserRole{}).
+		Where("user_id = ? AND role_id = ?", 10, 3).
+		Update("expires_at", past).Error)
+	require.NoError(t, h.DB.Model(&models.BreakGlassActivation{}).
+		Where("id = ?", first.ID).
+		Update("expires_at", past).Error)
+
+	// A second, real-incident activation for the same user/role/project must now
+	// succeed — the first grant is expired, not live.
+	second, err := h.CoreService.ActivateBreakGlass(ctx, proj, 10, "second incident", "")
+	require.NoError(t, err, "reactivation after natural expiry must succeed, not fail with 'already assigned'")
+	assert.Equal(t, core.BreakGlassActive, second.State)
+
+	// The fresh grant is live and authorizing.
+	ids, err := h.Storage.GetUserRoleIDsAt(ctx, 10, storage.Scope{ProjectID: proj})
+	require.NoError(t, err)
+	assert.Contains(t, ids, uint(3), "the fresh reactivation grant is live")
+}
+
 // A user affiliated with the project ONLY via a global/install-wide role (e.g. the
 // system_viewer baseline every SSO user receives) is NOT a project member and must be
 // refused — otherwise any authenticated user could break-glass any project.

--- a/internal/storage/store/local_rbac.go
+++ b/internal/storage/store/local_rbac.go
@@ -113,10 +113,30 @@ func (ls *LocalStorage) assignUserRole(ctx context.Context, userID, roleID uint,
 	err := ls.db.WithContext(ctx).
 		Where("user_id = ? AND role_id = ? AND project_id = ? AND environment_id = ?",
 			userID, roleID, scope.ProjectID, scope.EnvironmentID).First(&existing).Error
-	if err == nil {
-		return fmt.Errorf("%s", i18n.T("ErrorRoleAlreadyAssigned", nil))
-	}
-	if err != gorm.ErrRecordNotFound {
+	switch err {
+	case nil:
+		// A row already exists at this exact (user, role, project, environment) key. A
+		// still-live grant (no expiry, or an expiry still in the future) genuinely blocks
+		// a duplicate assignment. But an EXPIRED grant is a stale, un-reaped row — e.g. a
+		// prior break-glass activation whose time-bound grant naturally lapsed — and must
+		// be treated as ABSENT for this check, or a second real-incident activation for
+		// the same user/role/scope is permanently refused with "already assigned" even
+		// though nothing live is actually being duplicated (#263). Delete the stale row
+		// so the composite primary key (user_id, role_id, project_id, environment_id) is
+		// free for the fresh Create below, mirroring how live-authorization queries
+		// elsewhere (e.g. GetUserRoles) already exclude expired grants.
+		if existing.ExpiresAt == nil || existing.ExpiresAt.After(time.Now()) {
+			return fmt.Errorf("%s", i18n.T("ErrorRoleAlreadyAssigned", nil))
+		}
+		if derr := ls.db.WithContext(ctx).
+			Where("user_id = ? AND role_id = ? AND project_id = ? AND environment_id = ?",
+				userID, roleID, scope.ProjectID, scope.EnvironmentID).
+			Delete(&models.UserRole{}).Error; derr != nil {
+			return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), derr)
+		}
+	case gorm.ErrRecordNotFound:
+		// no existing row for this key — proceed to create.
+	default:
 		return fmt.Errorf("%s: %w", i18n.T("ErrorInternalServer", nil), err)
 	}
 	userRole := models.UserRole{

--- a/internal/storage/store/local_rbac_test.go
+++ b/internal/storage/store/local_rbac_test.go
@@ -1,0 +1,75 @@
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// #263: assignUserRole's existence check must treat an EXPIRED grant as absent, so a
+// second real-incident activation (e.g. break-glass) for the same (user, role,
+// project, environment) key succeeds instead of permanently failing with "already
+// assigned" against a stale, un-reaped row. A genuinely still-live grant (no expiry,
+// or an expiry still in the future) must continue to correctly block a duplicate.
+
+// A permanent (non-expiring) grant still blocks a duplicate AssignRole.
+func TestAssignRole_BlocksDuplicateOfLiveGrant(t *testing.T) {
+	ls := newRBACScopeTestStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, ls.AssignRole(ctx, 1, 10, sc(5, 0)))
+	err := ls.AssignRole(ctx, 1, 10, sc(5, 0))
+	require.Error(t, err, "a duplicate assignment of a permanent, still-live grant must be refused")
+}
+
+// A grant that has not yet expired still blocks a duplicate AssignRoleWithExpiry.
+func TestAssignRoleWithExpiry_BlocksDuplicateOfLiveGrant(t *testing.T) {
+	ls := newRBACScopeTestStore(t)
+	ctx := context.Background()
+
+	future := time.Now().Add(time.Hour)
+	require.NoError(t, ls.AssignRoleWithExpiry(ctx, 1, 10, sc(5, 0), future))
+
+	err := ls.AssignRoleWithExpiry(ctx, 1, 10, sc(5, 0), time.Now().Add(2*time.Hour))
+	require.Error(t, err, "a duplicate assignment while the first grant is still live must be refused")
+}
+
+// The core of #263: once the FIRST grant's expires_at has naturally passed, a SECOND
+// activation for the exact same (user, role, project, environment) key must succeed —
+// not fail with "already assigned" against the stale, un-reaped row.
+func TestAssignRoleWithExpiry_ReactivatesAfterNaturalExpiry(t *testing.T) {
+	ls := newRBACScopeTestStore(t)
+	ctx := context.Background()
+
+	past := time.Now().Add(-time.Hour)
+	require.NoError(t, ls.AssignRoleWithExpiry(ctx, 1, 10, sc(5, 0), past),
+		"seed a grant that is already expired at creation, simulating natural expiry")
+
+	newExpiry := time.Now().Add(time.Hour)
+	err := ls.AssignRoleWithExpiry(ctx, 1, 10, sc(5, 0), newExpiry)
+	require.NoError(t, err, "a second activation after the first grant naturally expired must succeed")
+
+	ids, err := ls.GetUserRoleIDsAt(ctx, 1, sc(5, 0))
+	require.NoError(t, err)
+	assert.Contains(t, ids, uint(10), "the fresh grant must be live and authorizing")
+}
+
+// Same as above but via the permanent AssignRole path re-granting after a PRIOR
+// time-bound grant (e.g. AssignRoleWithExpiry) at the same key expired.
+func TestAssignRole_SucceedsAfterPriorTimeBoundGrantExpired(t *testing.T) {
+	ls := newRBACScopeTestStore(t)
+	ctx := context.Background()
+
+	past := time.Now().Add(-time.Hour)
+	require.NoError(t, ls.AssignRoleWithExpiry(ctx, 1, 10, sc(5, 0), past))
+
+	err := ls.AssignRole(ctx, 1, 10, sc(5, 0))
+	require.NoError(t, err, "a permanent re-grant after the prior time-bound grant expired must succeed")
+
+	ids, err := ls.GetUserRoleIDsAt(ctx, 1, sc(5, 0))
+	require.NoError(t, err)
+	assert.Contains(t, ids, uint(10))
+}


### PR DESCRIPTION
## Summary

Two unrelated, still-fully-open HARDENING-BACKLOG findings, reconfirmed against `origin/main` before fixing:

- **#98** — `internal/connect/vault.go`'s `http.Client` had no `CheckRedirect` override, so Go's default redirect policy applied. `X-Vault-Token` is a custom header that Go's default handling does NOT strip on a cross-host redirect (only `Authorization`/`Cookie`/`WWW-Authenticate` are). A compromised or MITM'd Vault endpoint answering a GET with a 3xx to an attacker-controlled host would still receive the live Vault token. Fixed by setting `CheckRedirect` to refuse every redirect outright — Vault's real KV-read API has no legitimate reason to redirect a GET, so this is the correct behavior, not merely the cautious one.

- **#263** — `assignUserRole` (`internal/storage/store/local_rbac.go`), the shared existence check behind `AssignRole`/`AssignRoleWithExpiry` (and therefore behind break-glass's `ActivateBreakGlass` → `AssignUserRoleWithExpiry` path), matched on `(user_id, role_id, project_id, environment_id)` with no `expires_at` filter. A stale, un-reaped `user_roles` row left behind by a naturally-expired grant (as opposed to an explicit revoke, which deletes the row) permanently blocked a second real-incident break-glass activation with "already assigned". The check now treats an expired grant as absent — deleting the stale row before the fresh insert — while still correctly refusing a duplicate of a grant that is genuinely still live.

## Test plan

- [x] New regression tests in `internal/connect/vault_test.go`: cross-host redirect (proves the attacker host is never contacted and never sees the token) and same-host redirect (proves the refusal is unconditional, not just cross-host-aware)
- [x] New regression tests in `internal/storage/store/local_rbac_test.go`: a live permanent/time-bound grant still blocks a duplicate; a grant that naturally expired no longer blocks reactivation (both via `AssignRole` and `AssignRoleWithExpiry`)
- [x] New end-to-end regression test in `internal/core/break_glass_external_test.go`: `TestActivateBreakGlass_ReactivatesAfterNaturalExpiry` — simulates a real elapsed TTL (not a revoke) and proves a second activation for the same user/role/project succeeds
- [x] `go build ./...` clean
- [x] `go test ./...` full suite clean (no flakes hit)
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues
- [x] `golangci-lint run ./...` — 0 issues
- [x] `GOWORK=off go build -C operator ./...` — clean (separate module)

🤖 Generated with [Claude Code](https://claude.com/claude-code)