### PR TITLE
fix(validation): dereference non-nil pointers before rule dispatch (#347 HIGH)

### DIFF
--- a/server/http/handlers/secrets_crud_maxreads_test.go
+++ b/server/http/handlers/secrets_crud_maxreads_test.go
@@ -1,0 +1,168 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/keyorixhq/keyorix/server/middleware"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// TestCreateSecret_MaxReadsValidation is a regression guard for #347 HIGH: a
+// pointer-typed `MaxReads *int validate:"omitempty,min=1"` field must reject
+// max_reads=0/negative, not silently accept it as "unlimited reads" (the
+// opposite of a burn-after-N-reads secret). Confirmed empirically before the
+// fix: both values produced err=nil from the validator.
+func TestCreateSecret_MaxReadsValidation(t *testing.T) {
+	require.NoError(t, i18n.Initialize(&config.Config{Locale: config.LocaleConfig{Language: "en", FallbackLanguage: "en"}}))
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	// A pooled sqlite ":memory:" connection hands out a fresh, empty database
+	// per connection unless pinned to a single connection — pin it so every
+	// query in this test (across subtests) sees the migrated schema.
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	sqlDB.SetMaxOpenConns(1)
+	require.NoError(t, db.AutoMigrate(&models.User{}, &models.Role{}, &models.UserRole{},
+		&models.Permission{}, &models.RolePermission{}, &models.Group{}, &models.GroupRole{},
+		&models.UserGroup{}, &models.Project{}, &models.Environment{}, &models.AuditEvent{},
+		&models.SecretNode{}, &models.SecretVersion{}, &models.SecretAccessLog{}))
+
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "alice", AccountState: "active"}).Error)
+	adminRole := &models.Role{Name: "admin"}
+	require.NoError(t, db.Create(adminRole).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: adminRole.ID}).Error)
+
+	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "proj"}).Error)
+	require.NoError(t, db.Create(&models.Environment{ID: 10, ProjectID: 1, Name: "prod"}).Error)
+
+	coreService := core.NewKeyorixCore(store.NewLocalStorage(db))
+	handler, err := NewSecretHandler(coreService)
+	require.NoError(t, err)
+
+	userCtx := &middleware.UserContext{UserID: 1, Username: "alice", ActorType: core.ActorTypeUser, SessionAuth: true, MFAEnabled: true}
+
+	post := func(name string, maxReads *int) *httptest.ResponseRecorder {
+		body := map[string]interface{}{
+			"name": name, "value": "v", "project_id": uint(1),
+			"environment_id": uint(10), "type": "static",
+		}
+		if maxReads != nil {
+			body["max_reads"] = *maxReads
+		}
+		raw, _ := json.Marshal(body)
+		r := httptest.NewRequest(http.MethodPost, "/api/v1/secrets", bytes.NewReader(raw))
+		r = r.WithContext(context.WithValue(r.Context(), middleware.GetUserContextKey(), userCtx))
+		rr := httptest.NewRecorder()
+		handler.CreateSecret(rr, r)
+		return rr
+	}
+
+	intPtr := func(i int) *int { return &i }
+
+	t.Run("max_reads=0 is rejected", func(t *testing.T) {
+		rr := post("S1", intPtr(0))
+		assert.Equal(t, http.StatusBadRequest, rr.Code)
+		assert.Contains(t, rr.Body.String(), "ValidationError")
+	})
+
+	t.Run("max_reads=-100 is rejected", func(t *testing.T) {
+		rr := post("S2", intPtr(-100))
+		assert.Equal(t, http.StatusBadRequest, rr.Code)
+		assert.Contains(t, rr.Body.String(), "ValidationError")
+	})
+
+	t.Run("max_reads=5 is accepted and creates the secret", func(t *testing.T) {
+		rr := post("S3", intPtr(5))
+		assert.Equal(t, http.StatusCreated, rr.Code, rr.Body.String())
+	})
+
+	t.Run("omitted max_reads is accepted (unlimited reads, unchanged behavior)", func(t *testing.T) {
+		rr := post("S4", nil)
+		assert.Equal(t, http.StatusCreated, rr.Code, rr.Body.String())
+	})
+}
+
+// TestUpdateSecret_MaxReadsValidation exercises the same #347 regression via
+// PUT /api/v1/secrets/{id}, the other declared, wired call site for the
+// pointer-typed MaxReads field.
+func TestUpdateSecret_MaxReadsValidation(t *testing.T) {
+	require.NoError(t, i18n.Initialize(&config.Config{Locale: config.LocaleConfig{Language: "en", FallbackLanguage: "en"}}))
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	// A pooled sqlite ":memory:" connection hands out a fresh, empty database
+	// per connection unless pinned to a single connection — pin it so every
+	// query in this test (across subtests) sees the migrated schema.
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	sqlDB.SetMaxOpenConns(1)
+	require.NoError(t, db.AutoMigrate(&models.User{}, &models.Role{}, &models.UserRole{},
+		&models.Permission{}, &models.RolePermission{}, &models.Group{}, &models.GroupRole{},
+		&models.UserGroup{}, &models.Project{}, &models.Environment{}, &models.AuditEvent{},
+		&models.SecretNode{}, &models.SecretVersion{}, &models.SecretAccessLog{}))
+
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "alice", AccountState: "active"}).Error)
+	adminRole := &models.Role{Name: "admin"}
+	require.NoError(t, db.Create(adminRole).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: adminRole.ID}).Error)
+
+	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "proj"}).Error)
+	require.NoError(t, db.Create(&models.Environment{ID: 10, ProjectID: 1, Name: "prod"}).Error)
+
+	coreService := core.NewKeyorixCore(store.NewLocalStorage(db))
+	handler, err := NewSecretHandler(coreService)
+	require.NoError(t, err)
+
+	created, err := coreService.CreateSecret(context.Background(), &core.CreateSecretRequest{
+		Name: "target", Value: []byte("v"), ProjectID: 1, EnvironmentID: 10, Type: "static",
+		CreatedBy: "alice", OwnerID: 1,
+	})
+	require.NoError(t, err)
+
+	userCtx := &middleware.UserContext{UserID: 1, Username: "alice", ActorType: core.ActorTypeUser, SessionAuth: true, MFAEnabled: true}
+
+	put := func(maxReads int) *httptest.ResponseRecorder {
+		raw, _ := json.Marshal(map[string]interface{}{"max_reads": maxReads})
+		r := httptest.NewRequest(http.MethodPut, "/api/v1/secrets/1", bytes.NewReader(raw))
+		r = r.WithContext(context.WithValue(r.Context(), middleware.GetUserContextKey(), userCtx))
+		rc := chi.NewRouteContext()
+		rc.URLParams.Add("id", strconv.FormatUint(uint64(created.ID), 10))
+		r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rc))
+		rr := httptest.NewRecorder()
+		handler.UpdateSecret(rr, r)
+		return rr
+	}
+
+	t.Run("max_reads=0 is rejected", func(t *testing.T) {
+		rr := put(0)
+		assert.Equal(t, http.StatusBadRequest, rr.Code)
+		assert.Contains(t, rr.Body.String(), "ValidationError")
+	})
+
+	t.Run("max_reads=-100 is rejected", func(t *testing.T) {
+		rr := put(-100)
+		assert.Equal(t, http.StatusBadRequest, rr.Code)
+		assert.Contains(t, rr.Body.String(), "ValidationError")
+	})
+
+	t.Run("max_reads=3 is accepted", func(t *testing.T) {
+		rr := put(3)
+		assert.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+	})
+}

--- a/server/http/handlers/secrets_ownership.go
+++ b/server/http/handlers/secrets_ownership.go
@@ -27,6 +27,9 @@ func (h *SecretHandler) TransferOwnership(w http.ResponseWriter, r *http.Request
 		return
 	}
 	var reqBody struct {
+		// The `validate:"required"` tag here is decorative: this handler never
+		// calls h.validator.Validate, relying instead on the manual == 0
+		// check below (see the same note in secrets_versions.go, #347).
 		NewOwnerID uint `json:"new_owner_id" validate:"required"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {

--- a/server/http/handlers/secrets_versions.go
+++ b/server/http/handlers/secrets_versions.go
@@ -71,6 +71,11 @@ func (h *SecretHandler) RotateSecret(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var reqBody struct {
+		// The `validate:"required"` tag here is decorative: this handler never
+		// calls h.validator.Validate, relying instead on the manual == ""
+		// check below. Harmless today (the manual check covers the same
+		// case), but the tag would silently fail to protect a future rule
+		// added to the tag without a matching manual check (see #347).
 		NewValue string `json:"new_value" validate:"required"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
@@ -114,6 +119,9 @@ func (h *SecretHandler) RollbackSecret(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var reqBody struct {
+		// The `validate:"required"` tag here is decorative: this handler never
+		// calls h.validator.Validate, relying instead on the manual <= 0
+		// check below. See the same note on RotateSecret's NewValue above.
 		Version int `json:"version" validate:"required"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {

--- a/server/http/handlers/users_crud_pointerfield_test.go
+++ b/server/http/handlers/users_crud_pointerfield_test.go
@@ -1,0 +1,65 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/server/middleware"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestUpdateUser_PointerFieldValidation is a regression guard for #347 HIGH's
+// secondary instance: UpdateUser's Email/Username/DisplayName are all
+// pointer-typed (*string) so a caller can distinguish "not provided" (nil,
+// leave unchanged) from "explicitly set" (non-nil). Before the fix, the
+// validator's Kind()-based rule dispatch (validateEmail/validateMin/
+// validateMax) silently no-op'd for any pointer Kind, so a malformed email,
+// too-short username, or too-long display_name all passed clean.
+func TestUpdateUser_PointerFieldValidation(t *testing.T) {
+	require.NoError(t, i18n.Initialize(&config.Config{Locale: config.LocaleConfig{Language: "en", FallbackLanguage: "en"}}))
+
+	handler, err := NewUserHandler(nil)
+	require.NoError(t, err)
+
+	userCtx := &middleware.UserContext{UserID: 1, Username: "alice", ActorType: core.ActorTypeUser, SessionAuth: true}
+
+	put := func(body map[string]interface{}) *httptest.ResponseRecorder {
+		raw, _ := json.Marshal(body)
+		r := httptest.NewRequest(http.MethodPut, "/api/v1/users/2", bytes.NewReader(raw))
+		r = r.WithContext(context.WithValue(r.Context(), middleware.GetUserContextKey(), userCtx))
+		rc := chi.NewRouteContext()
+		rc.URLParams.Add("id", "2")
+		r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rc))
+		rr := httptest.NewRecorder()
+		handler.UpdateUser(rr, r)
+		return rr
+	}
+
+	t.Run("malformed email is rejected", func(t *testing.T) {
+		rr := put(map[string]interface{}{"email": "not-an-email <script>"})
+		assert.Equal(t, http.StatusBadRequest, rr.Code)
+		assert.Contains(t, rr.Body.String(), "ValidationError")
+	})
+
+	t.Run("too-short username is rejected", func(t *testing.T) {
+		rr := put(map[string]interface{}{"username": "ab"})
+		assert.Equal(t, http.StatusBadRequest, rr.Code)
+		assert.Contains(t, rr.Body.String(), "ValidationError")
+	})
+
+	t.Run("too-long display_name is rejected", func(t *testing.T) {
+		rr := put(map[string]interface{}{"display_name": strings.Repeat("a", 101)})
+		assert.Equal(t, http.StatusBadRequest, rr.Code)
+		assert.Contains(t, rr.Body.String(), "ValidationError")
+	})
+}

--- a/server/validation/validator.go
+++ b/server/validation/validator.go
@@ -160,7 +160,15 @@ func (v *Validator) applyRule(fieldName string, field reflect.Value, ruleName, p
 	return nil
 }
 
-// isEmpty checks if a field is empty
+// isEmpty checks if a field is empty. A nil pointer/interface is empty (and
+// `omitempty` short-circuits the remaining rules for it). A NON-nil pointer
+// is deliberately NOT treated as empty even when it points at a zero value
+// (e.g. a non-nil *int pointing at 0, or a non-nil *string pointing at "").
+// Pointer-typed request fields exist precisely so a caller can distinguish
+// "not provided" (nil — skip validation, leave any existing value alone)
+// from "explicitly set to the zero value" (non-nil — must still satisfy
+// every other rule, e.g. reject a `max_reads: 0` that a `min=1` tag forbids,
+// rather than silently letting the zero value pass as if it were absent).
 func (v *Validator) isEmpty(field reflect.Value) bool {
 	switch field.Kind() {
 	case reflect.String:
@@ -181,8 +189,31 @@ func (v *Validator) isEmpty(field reflect.Value) bool {
 	return false
 }
 
+// derefForRule resolves field to the value that the Kind()-based validation
+// rules (min/max/email/url/alpha/alphanum/numeric/oneof) should inspect: a
+// non-pointer field is returned unchanged; a non-nil pointer is dereferenced
+// so it's validated against the same rules as its non-pointer equivalent; a
+// nil pointer has nothing to validate (ok=false) — the rule should pass,
+// exactly as it does today for an absent value (omitempty, if present, has
+// already short-circuited via isEmpty; `required` is enforced separately).
+func derefForRule(field reflect.Value) (resolved reflect.Value, ok bool) {
+	if field.Kind() == reflect.Pointer {
+		if field.IsNil() {
+			return reflect.Value{}, false
+		}
+		return field.Elem(), true
+	}
+	return field, true
+}
+
 // validateMin validates minimum length/value
 func (v *Validator) validateMin(field reflect.Value, param string) error {
+	resolved, ok := derefForRule(field)
+	if !ok {
+		return nil
+	}
+	field = resolved
+
 	var min int
 	_, _ = fmt.Sscanf(param, "%d", &min)
 
@@ -214,6 +245,12 @@ func (v *Validator) validateMin(field reflect.Value, param string) error {
 
 // validateMax validates maximum length/value
 func (v *Validator) validateMax(field reflect.Value, param string) error {
+	resolved, ok := derefForRule(field)
+	if !ok {
+		return nil
+	}
+	field = resolved
+
 	var max int
 	_, _ = fmt.Sscanf(param, "%d", &max)
 
@@ -245,6 +282,11 @@ func (v *Validator) validateMax(field reflect.Value, param string) error {
 
 // validateEmail validates email format
 func (v *Validator) validateEmail(field reflect.Value) error {
+	resolved, ok := derefForRule(field)
+	if !ok {
+		return nil
+	}
+	field = resolved
 	if field.Kind() != reflect.String {
 		return nil
 	}
@@ -264,6 +306,11 @@ func (v *Validator) validateEmail(field reflect.Value) error {
 
 // validateURL validates URL format
 func (v *Validator) validateURL(field reflect.Value) error {
+	resolved, ok := derefForRule(field)
+	if !ok {
+		return nil
+	}
+	field = resolved
 	if field.Kind() != reflect.String {
 		return nil
 	}
@@ -283,6 +330,11 @@ func (v *Validator) validateURL(field reflect.Value) error {
 
 // validateAlpha validates alphabetic characters only
 func (v *Validator) validateAlpha(field reflect.Value) error {
+	resolved, ok := derefForRule(field)
+	if !ok {
+		return nil
+	}
+	field = resolved
 	if field.Kind() != reflect.String {
 		return nil
 	}
@@ -302,6 +354,11 @@ func (v *Validator) validateAlpha(field reflect.Value) error {
 
 // validateAlphaNum validates alphanumeric characters only
 func (v *Validator) validateAlphaNum(field reflect.Value) error {
+	resolved, ok := derefForRule(field)
+	if !ok {
+		return nil
+	}
+	field = resolved
 	if field.Kind() != reflect.String {
 		return nil
 	}
@@ -321,6 +378,11 @@ func (v *Validator) validateAlphaNum(field reflect.Value) error {
 
 // validateNumeric validates numeric characters only
 func (v *Validator) validateNumeric(field reflect.Value) error {
+	resolved, ok := derefForRule(field)
+	if !ok {
+		return nil
+	}
+	field = resolved
 	if field.Kind() != reflect.String {
 		return nil
 	}
@@ -340,6 +402,11 @@ func (v *Validator) validateNumeric(field reflect.Value) error {
 
 // validateOneOf validates that value is one of allowed values
 func (v *Validator) validateOneOf(field reflect.Value, param string) error {
+	resolved, ok := derefForRule(field)
+	if !ok {
+		return nil
+	}
+	field = resolved
 	if field.Kind() != reflect.String {
 		return nil
 	}

--- a/server/validation/validator_test.go
+++ b/server/validation/validator_test.go
@@ -2,6 +2,7 @@ package validation
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/keyorixhq/keyorix/internal/i18n"
@@ -177,6 +178,134 @@ func TestValidationErrors_ErrorString(t *testing.T) {
 	assert.Contains(t, got, "name: is required")
 	assert.Contains(t, got, "age: must be at least 18")
 	assert.Contains(t, got, "; ")
+}
+
+// --- Pointer-typed field regression tests (#347) ---
+//
+// Pointer-typed fields (*int, *string, *[]string) must be validated against
+// the SAME rules as their non-pointer equivalent once the pointer is known
+// to be non-nil. A nil pointer with `omitempty` must still pass, exactly as
+// before.
+
+func intPtr(i int) *int                { return &i }
+func strPtr(s string) *string          { return &s }
+func sliceStrPtr(s []string) *[]string { return &s }
+
+func TestValidate_PointerMin_NonNilBelowMin_Errors(t *testing.T) {
+	type payload struct {
+		MaxReads *int `json:"max_reads" validate:"omitempty,min=1"`
+	}
+	v := NewValidator()
+
+	// The primary #347 regression: max_reads=0 and max_reads=-100 must be
+	// rejected, not silently pass as "unlimited reads".
+	require.Error(t, v.Validate(payload{MaxReads: intPtr(0)}), "max_reads=0 must be rejected")
+	require.Error(t, v.Validate(payload{MaxReads: intPtr(-100)}), "max_reads=-100 must be rejected")
+}
+
+func TestValidate_PointerMin_NonNilAtOrAboveMin_Passes(t *testing.T) {
+	type payload struct {
+		MaxReads *int `json:"max_reads" validate:"omitempty,min=1"`
+	}
+	v := NewValidator()
+
+	require.NoError(t, v.Validate(payload{MaxReads: intPtr(1)}))
+	require.NoError(t, v.Validate(payload{MaxReads: intPtr(100)}))
+}
+
+func TestValidate_PointerOmitempty_NilPointerPasses(t *testing.T) {
+	type payload struct {
+		MaxReads *int `json:"max_reads" validate:"omitempty,min=1"`
+	}
+	v := NewValidator()
+
+	// A nil pointer must still be treated as "absent" and pass omitempty,
+	// exactly like before this fix.
+	require.NoError(t, v.Validate(payload{MaxReads: nil}))
+}
+
+func TestValidate_PointerString_MinMax(t *testing.T) {
+	type payload struct {
+		Username *string `json:"username" validate:"omitempty,min=3,max=50"`
+	}
+	v := NewValidator()
+
+	require.NoError(t, v.Validate(payload{Username: nil}), "nil pointer passes via omitempty")
+	require.NoError(t, v.Validate(payload{Username: strPtr("abc")}))
+	require.Error(t, v.Validate(payload{Username: strPtr("ab")}), "below min")
+	require.Error(t, v.Validate(payload{Username: strPtr(strings.Repeat("a", 51))}), "above max")
+}
+
+func TestValidate_PointerString_Email(t *testing.T) {
+	type payload struct {
+		Email *string `json:"email" validate:"omitempty,email"`
+	}
+	v := NewValidator()
+
+	require.NoError(t, v.Validate(payload{Email: nil}), "nil pointer passes via omitempty")
+	require.NoError(t, v.Validate(payload{Email: strPtr("a@b.co")}))
+	require.Error(t, v.Validate(payload{Email: strPtr("not-an-email <script>")}), "malformed email must be rejected")
+}
+
+func TestValidate_PointerString_NonNilZeroValueIsNotOmitted(t *testing.T) {
+	// A non-nil pointer to a zero value ("") must NOT be short-circuited by
+	// omitempty — only a nil pointer means "not provided". A caller who
+	// explicitly sends an empty string must still hit min=1 and be rejected;
+	// this is the whole reason MaxReads/DisplayName/etc. use pointer types
+	// instead of plain int/string (to distinguish "omitted" from "explicit
+	// zero value").
+	type payload struct {
+		DisplayName *string `json:"display_name" validate:"omitempty,min=1,max=100"`
+	}
+	v := NewValidator()
+
+	empty := ""
+	require.Error(t, v.Validate(payload{DisplayName: &empty}), "non-nil pointer to empty string must still be validated, not treated as absent")
+	require.NoError(t, v.Validate(payload{DisplayName: nil}), "nil pointer is absent, correctly skipped")
+}
+
+func TestValidate_PointerSlice_MinMax(t *testing.T) {
+	type payload struct {
+		Permissions *[]string `json:"permissions" validate:"omitempty,min=1"`
+	}
+	v := NewValidator()
+
+	require.NoError(t, v.Validate(payload{Permissions: nil}), "nil pointer passes via omitempty")
+	require.NoError(t, v.Validate(payload{Permissions: sliceStrPtr([]string{"secrets.read"})}))
+	require.Error(t, v.Validate(payload{Permissions: sliceStrPtr([]string{})}), "empty slice behind non-nil pointer must fail min=1")
+}
+
+func TestValidate_PointerAndNonPointer_IdenticalRuleOutcome(t *testing.T) {
+	// A *string field and its non-pointer equivalent must reach the same
+	// pass/fail verdict for the same underlying value and rule set.
+	type withPtr struct {
+		Value *string `json:"value" validate:"omitempty,min=3,max=5,alphanum"`
+	}
+	type withoutPtr struct {
+		Value string `json:"value" validate:"omitempty,min=3,max=5,alphanum"`
+	}
+	v := NewValidator()
+
+	cases := []struct {
+		val     string
+		wantErr bool
+	}{
+		{"ab", true},     // below min
+		{"abc12", false}, // ok
+		{"abcdef", true}, // above max
+		{"abc-1", true},  // alphanum rejects dash (within min/max range)
+	}
+	for _, c := range cases {
+		ptrErr := v.Validate(withPtr{Value: strPtr(c.val)})
+		plainErr := v.Validate(withoutPtr{Value: c.val})
+		if c.wantErr {
+			require.Error(t, ptrErr, "pointer case: %q", c.val)
+			require.Error(t, plainErr, "non-pointer case: %q", c.val)
+		} else {
+			require.NoError(t, ptrErr, "pointer case: %q", c.val)
+			require.NoError(t, plainErr, "non-pointer case: %q", c.val)
+		}
+	}
 }
 
 func TestValidate_UsesJSONNameForErrorField(t *testing.T) {


### PR DESCRIPTION
## Summary
- `server/validation`'s `validateMin`/`validateMax`/`validateEmail`/`validateURL`/`validateAlpha`/`validateAlphaNum`/`validateNumeric`/`validateOneOf` all switch on `reflect.Kind()` with no `Pointer` case, so any `*int`/`*string`/`*[]string` field silently skipped every rule beyond the nil-check.
- Primary, empirically-confirmed instance: `CreateSecret`/`UpdateSecret`'s `MaxReads *int validate:"omitempty,min=1"` accepted `max_reads=0`/`max_reads=-100` with `err=nil`, which `internal/core/versions.go`'s read-count gate (`if secret.MaxReads != nil && *secret.MaxReads > 0`) treats as **unlimited reads** — the opposite of a burn-after-N-reads control.
- Same root cause silently no-op'd `UpdateUser`'s `Email`/`Username`/`DisplayName` (malformed email passed clean) and RBAC's `UpdateRoleRequest.Description`/`Permissions`.
- Fix: dereference a non-nil pointer before applying the `Kind()`-based rules so a pointer field is validated identically to its non-pointer equivalent. `isEmpty`'s pointer case stays a plain nil-check (not deref-and-recurse) so `omitempty` only short-circuits a truly absent value, not an explicit zero — otherwise `max_reads: 0` would again be treated as "omitted" and never reach `min=1`.
- Noted (not fixed, decorative only): `secrets_versions.go`/`secrets_ownership.go` declare `validate:"required"` tags but never call the validator, relying on manual equivalent checks — commented for future maintainers.

## Test plan
- [x] New validator-package unit tests proving pointer-typed fields (`*int`/`*string`/`*[]string`) are validated identically to their non-pointer equivalents, including the `omitempty` + nil-pointer pass-through case and the non-nil-pointer-to-zero-value case.
- [x] New handler tests: `CreateSecret`/`UpdateSecret` reject `max_reads=0` and `max_reads=-100`, accept a valid positive value and an omitted value.
- [x] New handler test: `UpdateUser` rejects a malformed email, a too-short username, and a too-long display name.
- [x] `go build ./...` clean.
- [x] `go test ./...` full suite green (no pre-existing test relied on the buggy pass-through).
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues.
- [x] `golangci-lint run ./...` — 0 issues.
- [x] `GOWORK=off go build -C operator ./...` — clean (separate module).