### PR TITLE
fix: close account-suspension lost-update race vs SCIM sync (#344 HIGH)

### DIFF
--- a/internal/core/account_state.go
+++ b/internal/core/account_state.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
@@ -151,38 +152,62 @@ func (c *KeyorixCore) RequirePasswordReset(ctx context.Context, adminID, userID 
 }
 
 // setAccountState persists a new account state and writes an audit event.
+//
+// #344: this read-modify-write races with UpdateSCIMUser's — a routine SCIM/IdP
+// resync's GetUser can read the row before an admin's SuspendUser here commits, and
+// whichever caller's full-row Save lands last would otherwise win outright, silently
+// reverting the other's change with no error to either side. accountStateMu (held for
+// the whole read-modify-write, not just the DB write) serializes this against
+// UpdateSCIMUser in-process, and LockUserForUpdate's row lock (Postgres: SELECT ...
+// FOR UPDATE) does the same across replicas — the identical pattern recordFailedLogin
+// uses for the login-lockout counter (see login_lockout.go).
 func (c *KeyorixCore) setAccountState(ctx context.Context, adminID, userID uint, state, eventType string) error {
 	if userID == 0 {
 		return fmt.Errorf("user ID is required")
 	}
-	user, err := c.storage.GetUser(ctx, userID)
-	if err != nil {
-		return fmt.Errorf("user not found: %w", err)
-	}
-	// Capture the user's current session-token HASHES BEFORE mutating so we can evict their
-	// auth-cache entries. The HTTP auth cache fast path serves a frozen identity without
-	// re-reading the DB, so without eviction a suspend/deactivate/restrict would not take
-	// effect until the positive-cache TTL — a window where a blocked user keeps full access.
-	// The stored session_token IS the SHA-256 hash, which is exactly the cache key.
-	sessionHashes, _ := c.storage.ListSessionTokenHashesForUser(ctx, userID)
+	c.accountStateMu.Lock()
+	defer c.accountStateMu.Unlock()
 
-	user.AccountState = state
-	user.UpdatedAt = c.now()
-	if _, err := c.storage.UpdateUser(ctx, user); err != nil {
+	var sessionHashes []string
+	err := c.storage.WithTransaction(ctx, func(tx storage.Storage) error {
+		user, err := tx.LockUserForUpdate(ctx, userID)
+		if err != nil {
+			return err
+		}
+		// Capture the user's current session-token HASHES BEFORE mutating so we can evict
+		// their auth-cache entries after commit. The HTTP auth cache fast path serves a
+		// frozen identity without re-reading the DB, so without eviction a
+		// suspend/deactivate/restrict would not take effect until the positive-cache TTL —
+		// a window where a blocked user keeps full access. The stored session_token IS the
+		// SHA-256 hash, which is exactly the cache key.
+		sessionHashes, _ = tx.ListSessionTokenHashesForUser(ctx, userID)
+
+		user.AccountState = state
+		user.UpdatedAt = c.now()
+		if _, err := tx.UpdateUser(ctx, user); err != nil {
+			return err
+		}
+		// A state that blocks login must also terminate the user's existing sessions AND
+		// PATs, so suspension is effective immediately instead of lingering until the
+		// token expires. ValidateSessionToken/ValidatePATToken also reject blocked
+		// accounts as a slow-path backstop, but the cache fast path bypasses it — so
+		// evict here too. Revoked PAT hashes are folded into sessionHashes so they're
+		// evicted from the auth cache alongside the session hashes after commit.
+		if AccountLoginBlocked(state) {
+			_ = tx.DeleteSessionsForUserExcept(ctx, userID, 0)
+			if hashes, herr := tx.RevokeAllPersonalAccessTokensForUser(ctx, userID); herr == nil {
+				sessionHashes = append(sessionHashes, hashes...)
+			}
+		}
+		return nil
+	})
+	if err != nil {
 		return fmt.Errorf("failed to update account state: %w", err)
 	}
-	// A state that blocks login must also terminate the user's existing sessions AND PATs,
-	// so suspension is effective immediately instead of lingering until the token expires.
-	// ValidateSessionToken/ValidatePATToken also reject blocked accounts as a slow-path
-	// backstop, but the cache fast path bypasses it — so evict here too.
-	if AccountLoginBlocked(state) {
-		_ = c.storage.DeleteSessionsForUserExcept(ctx, userID, 0)
-		if hashes, herr := c.storage.RevokeAllPersonalAccessTokensForUser(ctx, userID); herr == nil {
-			c.invalidateTokenCache(hashes...)
-		}
-	}
-	// Evict the captured session-token hashes from the auth cache so the new state (blocked,
-	// or merely restricted) is reflected on the very next request, not after the cache TTL.
+	// Evict the captured session/PAT-token hashes from the auth cache — AFTER commit,
+	// so a rolled-back transaction never evicts a still-valid cache entry — so the new
+	// state (blocked, or merely restricted) is reflected on the very next request, not
+	// after the cache TTL.
 	c.invalidateTokenCache(sessionHashes...)
 	aid := adminID
 	c.writeAuditEventFull(ctx, eventType, &aid, nil, nil, "",

--- a/internal/core/concurrency_account_suspension_scim_test.go
+++ b/internal/core/concurrency_account_suspension_scim_test.go
@@ -1,0 +1,158 @@
+package core_test
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// TestConcurrency_SuspendUser_SurvivesConcurrentSCIMResync is the #344 regression: an
+// admin's incident-response SuspendUser and a routine SCIM/IdP resync's UpdateSCIMUser
+// (active=true — the ordinary "this user is still active in the directory" payload,
+// not even an attack) racing for the SAME user. Both used to be a plain
+// read-modify-full-row-Save with no transaction, row lock, or mutex: the SCIM call's
+// GetUser could read the row before the suspend committed, and if its Save then landed
+// AFTER the suspend's, the suspension was silently reverted back to active, with no
+// error to either caller and no audit signal distinguishing "still suspended" from
+// "un-suspended by a race".
+//
+// Mirrors TestConcurrency_SetupLinkResendThrottle's / TestConcurrency_
+// UpdateSCIMUser_NoDuplicateEmail's rigor for the analogous cross-call races those
+// regressions cover: many distinct users, each with its own SuspendUser/UpdateSCIMUser
+// pair, ALL released from a single start barrier at once — maximizing genuine
+// goroutine-scheduling contention on the shared, real, file-backed SQLite DB, so the
+// interleaving that the #344 finding describes actually has a chance to occur (a
+// single isolated pair rarely races on a mostly-idle machine; hundreds racing at once
+// reliably do). Before accountStateMu + LockUserForUpdate, a meaningful fraction of
+// users end up silently reactivated by the race; with the fix, the admin suspension
+// wins every single trial, regardless of which call's read happened to observe the
+// stale state first.
+func TestConcurrency_SuspendUser_SurvivesConcurrentSCIMResync(t *testing.T) {
+	dsn := "file:" + filepath.Join(t.TempDir(), "suspend_scim_race.db") + "?_busy_timeout=10000&_journal_mode=WAL&_txlock=immediate"
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.User{}, &models.Session{}, &models.AuditEvent{}, &models.PersonalAccessToken{},
+		&models.Role{}, &models.UserRole{}, &models.Project{}, &models.Environment{},
+	))
+
+	c := core.NewKeyorixCore(store.NewLocalStorage(db))
+	ctx := context.Background()
+
+	const users = 200 // many concurrent (suspend, SCIM-resync) pairs racing at once
+	for i := 0; i < users; i++ {
+		require.NoError(t, db.Create(&models.User{
+			ID: uint(i + 1), Username: fmt.Sprintf("user%d", i), Email: fmt.Sprintf("user%d@x.io", i),
+			IsActive: true, AccountState: core.AccountActive,
+		}).Error)
+	}
+
+	yes := true
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < users; i++ {
+		uid := uint(i + 1)
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			<-start
+			_ = c.SuspendUser(ctx, 99, uid) // admin incident response
+		}()
+		go func() {
+			defer wg.Done()
+			<-start
+			_, _ = c.UpdateSCIMUser(ctx, 2, uid, nil, nil, &yes) // routine IdP resync
+		}()
+	}
+	close(start) // release every pair at once
+	wg.Wait()
+
+	var reverted []uint
+	for i := 0; i < users; i++ {
+		uid := uint(i + 1)
+		var got models.User
+		require.NoError(t, db.First(&got, uid).Error)
+		if got.AccountState != core.AccountSuspended {
+			reverted = append(reverted, uid)
+		}
+	}
+	assert.Empty(t, reverted,
+		"an admin suspension must survive a concurrent SCIM resync regardless of interleaving; "+
+			"these users were silently un-suspended by the race: %v", reverted)
+}
+
+// TestConcurrency_SuspendUser_SurvivesConcurrentSCIMDeactivateReactivate is the same
+// #344 race, but against UpdateSCIMUser's deactivate→reactivate path (active=false then
+// active=true) instead of a single active=true resync — the other call shape
+// setAccountState races against per the backlog finding. setAccountState
+// unconditionally sets AccountSuspended, and UpdateSCIMUser's reactivation only ever
+// clears AccountDeprovisioned (never AccountSuspended — see UpdateSCIMUser's doc
+// comment), so every possible total ordering of {suspend, deactivate, reactivate} ends
+// in AccountSuspended once accountStateMu enforces one call at a time: the final state
+// is not just "some login-blocked value" but deterministically the suspension itself.
+func TestConcurrency_SuspendUser_SurvivesConcurrentSCIMDeactivateReactivate(t *testing.T) {
+	dsn := "file:" + filepath.Join(t.TempDir(), "suspend_scim_deact_race.db") + "?_busy_timeout=10000&_journal_mode=WAL&_txlock=immediate"
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.User{}, &models.Session{}, &models.AuditEvent{}, &models.PersonalAccessToken{},
+		&models.Role{}, &models.UserRole{}, &models.Project{}, &models.Environment{},
+	))
+
+	c := core.NewKeyorixCore(store.NewLocalStorage(db))
+	ctx := context.Background()
+
+	const users = 200
+	for i := 0; i < users; i++ {
+		require.NoError(t, db.Create(&models.User{
+			ID: uint(i + 1), Username: fmt.Sprintf("user%d", i), Email: fmt.Sprintf("user%d@x.io", i),
+			IsActive: true, AccountState: core.AccountActive,
+		}).Error)
+	}
+
+	no, yes := false, true
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < users; i++ {
+		uid := uint(i + 1)
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			<-start
+			_ = c.SuspendUser(ctx, 99, uid) // admin incident response
+		}()
+		go func() {
+			defer wg.Done()
+			<-start
+			// A routine SCIM deactivate immediately followed by a reactivate (e.g. a
+			// bounce during directory sync), racing the admin's suspend.
+			_, _ = c.UpdateSCIMUser(ctx, 2, uid, nil, nil, &no)
+			_, _ = c.UpdateSCIMUser(ctx, 2, uid, nil, nil, &yes)
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	var reverted []uint
+	for i := 0; i < users; i++ {
+		uid := uint(i + 1)
+		var got models.User
+		require.NoError(t, db.First(&got, uid).Error)
+		if got.AccountState != core.AccountSuspended {
+			reverted = append(reverted, uid)
+		}
+	}
+	assert.Empty(t, reverted,
+		"the admin suspension must be the terminal state after racing a SCIM deactivate/reactivate "+
+			"cycle, under every possible interleaving; these users were not: %v", reverted)
+}

--- a/internal/core/scim.go
+++ b/internal/core/scim.go
@@ -169,19 +169,26 @@ func (c *KeyorixCore) ProvisionSCIMUser(ctx context.Context, actorID uint, userN
 // suspension is sticky and survives IdP sync — only an admin can clear it
 // (ReactivateUser), so routine SCIM traffic can't undo an incident-response lockout.
 // nil fields are left unchanged.
+//
+// #344: the account_state/is_active mutation below races with setAccountState's (the
+// admin SuspendUser/ReactivateUser/RequirePasswordReset actions) — a routine SCIM/IdP
+// resync's read of the row can land before an admin's incident-response suspend
+// commits, and this function's Save would otherwise silently overwrite it back with no
+// error to either caller. It is serialized against setAccountState the same way
+// setAccountState is: accountStateMu (whole read-modify-write, in-process) + a fresh
+// LockUserForUpdate row lock (across replicas, Postgres only). See accountStateMu's doc
+// comment in service.go and setAccountState in account_state.go.
 func (c *KeyorixCore) UpdateSCIMUser(ctx context.Context, actorID, id uint, displayName, email *string, active *bool) (*models.User, error) {
-	user, err := c.storage.GetUser(ctx, id)
-	if err != nil {
-		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorUserNotFound", nil), err)
-	}
-	if displayName != nil {
-		user.DisplayName = *displayName
-	}
 	if email != nil && *email != "" {
 		// Refuse an email that collides with a DIFFERENT user. SCIM email is trusted by
 		// identity resolution (SSO matches by email), so silently overwriting a low-priv
 		// account's email to an admin's would corrupt the email→account mapping and
-		// enable account linking/takeover. The create path already guards this.
+		// enable account linking/takeover. The create path already guards this. Checked
+		// up front (against `id`, not a pre-fetched user struct) since it targets a
+		// DIFFERENT user's row and doesn't need the account-state lock below; the DB-level
+		// partial unique index (uniq_users_email_active, #117) remains the authoritative
+		// backstop against the residual check-then-act race on this specific check (see
+		// the ErrDuplicateEmail handling below).
 		//
 		// #336: GetUserByEmail returns a non-nil error BOTH when the email is genuinely
 		// unused AND on a real DB failure — treating any error as "no collision" (the
@@ -193,7 +200,7 @@ func (c *KeyorixCore) UpdateSCIMUser(ctx context.Context, actorID, id uint, disp
 		existing, eerr := c.storage.GetUserByEmail(ctx, *email)
 		switch {
 		case eerr == nil:
-			if existing != nil && existing.ID != user.ID {
+			if existing != nil && existing.ID != id {
 				return nil, fmt.Errorf("%s: email already in use by another user", i18n.T("ErrorValidation", nil))
 			}
 		case strings.Contains(eerr.Error(), i18n.T("ErrorUserNotFound", nil)):
@@ -201,42 +208,71 @@ func (c *KeyorixCore) UpdateSCIMUser(ctx context.Context, actorID, id uint, disp
 		default:
 			return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), eerr)
 		}
-		user.Email = *email
 	}
+	if active != nil && !*active {
+		// Don't let a routine (or hostile) SCIM sync deactivate the only admin.
+		if err := c.guardLastAdminDeactivation(ctx, id); err != nil {
+			return nil, err
+		}
+	}
+
+	c.accountStateMu.Lock()
+	defer c.accountStateMu.Unlock()
+
 	deactivated := false
-	if active != nil {
-		if !*active {
-			// Don't let a routine (or hostile) SCIM sync deactivate the only admin.
-			if err := c.guardLastAdminDeactivation(ctx, id); err != nil {
-				return nil, err
+	var updated *models.User
+	txErr := c.storage.WithTransaction(ctx, func(tx storage.Storage) error {
+		// A fresh, lock-guarded read: never reuse a struct fetched before the lock above
+		// was taken, or a concurrent setAccountState commit made between that read and
+		// this write would be silently clobbered by this Save (the exact #344 race).
+		user, err := tx.LockUserForUpdate(ctx, id)
+		if err != nil {
+			return err
+		}
+		if displayName != nil {
+			user.DisplayName = *displayName
+		}
+		if email != nil && *email != "" {
+			user.Email = *email
+		}
+		if active != nil {
+			user.IsActive = *active
+			if *active {
+				// Reactivation clears only a SCIM/IdP deactivation. An admin security
+				// suspension (AccountSuspended) is sticky: routine IdP sync, which
+				// re-sends active=true for every active user, must not undo an
+				// incident-response lockout — only an admin clears that, via
+				// ReactivateUser.
+				if NormalizeAccountState(user.AccountState) == AccountDeprovisioned {
+					user.AccountState = AccountActive
+				}
+			} else {
+				// Mark the SCIM/IdP deactivation distinctly so a later reactivation can
+				// tell it from an admin-set state. Only an 'active' account moves to
+				// deprovisioned: any admin-set state (suspended, AND the restricted
+				// password_reset_required / pending_first_login states) is preserved, so
+				// a routine IdP deactivate→reactivate cycle cannot silently clear a
+				// forced-credential-reset or a first-login requirement. Login is blocked
+				// meanwhile by IsActive=false (set above) regardless of which state is
+				// retained.
+				if NormalizeAccountState(user.AccountState) == AccountActive {
+					user.AccountState = AccountDeprovisioned
+				}
+				deactivated = true
 			}
 		}
-		user.IsActive = *active
-		if *active {
-			// Reactivation clears only a SCIM/IdP deactivation. An admin security
-			// suspension (AccountSuspended) is sticky: routine IdP sync, which re-sends
-			// active=true for every active user, must not undo an incident-response
-			// lockout — only an admin clears that, via ReactivateUser.
-			if NormalizeAccountState(user.AccountState) == AccountDeprovisioned {
-				user.AccountState = AccountActive
-			}
-		} else {
-			// Mark the SCIM/IdP deactivation distinctly so a later reactivation can tell
-			// it from an admin-set state. Only an 'active' account moves to deprovisioned:
-			// any admin-set state (suspended, AND the restricted password_reset_required /
-			// pending_first_login states) is preserved, so a routine IdP deactivate→
-			// reactivate cycle cannot silently clear a forced-credential-reset or a
-			// first-login requirement. Login is blocked meanwhile by IsActive=false
-			// (set above) regardless of which state is retained.
-			if NormalizeAccountState(user.AccountState) == AccountActive {
-				user.AccountState = AccountDeprovisioned
-			}
-			deactivated = true
+		user.UpdatedAt = c.now()
+		u, err := tx.UpdateUser(ctx, user)
+		if err != nil {
+			return err
 		}
-	}
-	user.UpdatedAt = c.now()
-	updated, err := c.storage.UpdateUser(ctx, user)
-	if err != nil {
+		updated = u
+		return nil
+	})
+	if txErr != nil {
+		if errors.Is(txErr, storage.ErrUserNotFound) {
+			return nil, fmt.Errorf("%s: %w", i18n.T("ErrorUserNotFound", nil), txErr)
+		}
 		// #120/#218: the email-uniqueness check above is a plain check-then-act read that
 		// races with a concurrent UpdateSCIMUser (or any other create/update) targeting the
 		// identical email — both can pass it before either commits. The DB-level partial
@@ -244,10 +280,10 @@ func (c *KeyorixCore) UpdateSCIMUser(ctx context.Context, actorID, id uint, disp
 		// UpdateUser wraps it in ErrDuplicateEmail; surface the same clean error the check
 		// above already returns for the sequential case, instead of a raw
 		// constraint-violation message.
-		if errors.Is(err, storage.ErrDuplicateEmail) {
+		if errors.Is(txErr, storage.ErrDuplicateEmail) {
 			return nil, fmt.Errorf("%s: email already in use by another user", i18n.T("ErrorValidation", nil))
 		}
-		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), txErr)
 	}
 	if deactivated {
 		// Suspension must be effective immediately, not lingering until tokens expire —

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -87,7 +87,17 @@ type KeyorixCore struct {
 	// already hold the valid bootstrap token (#339) — e.g. different usernames —
 	// cannot both observe an empty user table and each create a "first admin". Zero
 	// value is ready to use. See auth_bootstrap.go.
-	bootstrapMu    sync.Mutex
+	bootstrapMu sync.Mutex
+	// accountStateMu serializes the account_state/is_active read-modify-write shared
+	// by setAccountState (SuspendUser/ReactivateUser/RequirePasswordReset) and
+	// UpdateSCIMUser (#344): without it, an admin's incident-response SuspendUser and a
+	// routine SCIM/IdP resync for the same user can each GetUser before the other's
+	// Save commits, and whichever full-row Save lands last silently clobbers the
+	// other's change — e.g. a suspend committed, then a SCIM sync's stale in-memory
+	// "active" copy overwrites it back to active with no error to either caller.
+	// Combined with the row lock LockUserForUpdate takes on Postgres, this holds
+	// across replicas too. Zero value is ready to use. See account_state.go / scim.go.
+	accountStateMu sync.Mutex
 	auditForwarder AuditForwarder
 	// auditStream is the in-process pub/sub broker that wakes live audit tails
 	// (gRPC StreamAuditLogs) the instant an event is written, replacing fixed-interval


### PR DESCRIPTION
## Summary

- `setAccountState` (backing `SuspendUser`/`ReactivateUser`/`RequirePasswordReset`) and `UpdateSCIMUser` each did a plain `GetUser` → mutate in-memory → full-row `Save`, with no transaction, row lock, or mutex. A routine SCIM/IdP resync's `GetUser` could read a user's row before an admin's incident-response `SuspendUser` committed; if the resync's `Save` then landed *after* the suspend's, the suspension was silently reverted back to active, with no error to either caller and no audit signal distinguishing "still suspended" from "un-suspended by a race".
- Fixes #344 (HIGH) from the security-hardening backlog.

## Fix

- Added `accountStateMu sync.Mutex` on `KeyorixCore` (mirrors the existing `loginFailureMu`/`webauthnCredentialMu` convention) shared by both `setAccountState` and `UpdateSCIMUser`, serializing their account-state read-modify-write against each other in-process.
- Both now re-read the row via `LockUserForUpdate` inside `storage.WithTransaction`, taking a `SELECT ... FOR UPDATE` row lock on Postgres — the identical pattern `recordFailedLogin` already uses for the login-lockout counter (`login_lockout.go`) — so the fix holds across replicas too, not just within one process.
- `UpdateSCIMUser`'s pre-checks (email-collision lookup, last-admin-deactivation guard) run *before* acquiring the lock since they don't touch this user's row; the actual field mutation (displayName/email/active/account_state) is now applied to a freshly lock-guarded read, never a struct fetched before the lock.

## Test plan

- [x] New regression test `internal/core/concurrency_account_suspension_scim_test.go`: many concurrent `(SuspendUser, UpdateSCIMUser)` pairs for distinct users released from a single start barrier, asserting suspension always wins regardless of interleaving. Verified it reliably **fails** against the pre-fix code (stashed the fix locally) and reliably **passes** with the fix, including under `-race`.
- [x] `go build ./...`
- [x] `go test ./...` (full suite) — clean
- [x] `go test ./internal/core/... -race` — clean
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues
- [x] `golangci-lint run ./...` — 0 issues
- [x] `GOWORK=off go build -C operator ./...` — clean (separate module)

🤖 Generated with [Claude Code](https://claude.com/claude-code)