### PR TITLE
harden: LOW-severity CLI hygiene bundle (#348/#350/#351/#353/#354/#356/#357)

### DIFF
--- a/internal/cli/anomalies/anomalies.go
+++ b/internal/cli/anomalies/anomalies.go
@@ -1,12 +1,11 @@
 package anomalies
 
 import (
-	"encoding/json"
+	"context"
 	"fmt"
-	"net/http"
 	"strconv"
 
-	cliconfig "github.com/keyorixhq/keyorix/internal/cli/config"
+	"github.com/keyorixhq/keyorix/internal/cli/common"
 	"github.com/spf13/cobra"
 )
 
@@ -36,55 +35,48 @@ func init() {
 	AnomaliesCmd.AddCommand(acknowledgeCmd)
 }
 
+// anomalyAlert mirrors the alert shape returned by GET /api/v1/audit/anomalies.
+type anomalyAlert struct {
+	ID           uint   `json:"ID"`
+	SecretName   string `json:"SecretName"`
+	AlertType    string `json:"AlertType"`
+	Severity     string `json:"Severity"`
+	Description  string `json:"Description"`
+	AccessedBy   string `json:"AccessedBy"`
+	IPAddress    string `json:"IPAddress"`
+	DetectedAt   string `json:"DetectedAt"`
+	Acknowledged bool   `json:"Acknowledged"`
+}
+
+type anomalyListResponse struct {
+	Alerts []anomalyAlert `json:"alerts"`
+	Total  int            `json:"total"`
+}
+
 func runList(cmd *cobra.Command, args []string) error {
-	cfg, err := cliconfig.LoadCLIConfig("")
-	if err != nil {
+	rc, ok := common.NewRemoteClient()
+	if !ok {
 		return fmt.Errorf("not connected to a server — run: keyorix connect <server>")
 	}
-	url := cfg.Client.Endpoint + "/api/v1/audit/anomalies"
+	return runListRemote(rc)
+}
+
+func runListRemote(rc *common.RemoteClient) error {
+	path := "/api/v1/audit/anomalies"
 	if flagUnacknowledged {
-		url += "?unacknowledged=true"
+		path += "?unacknowledged=true"
 	}
-	req, err := http.NewRequest("GET", url, nil)
-	if err != nil {
+	var result anomalyListResponse
+	if err := rc.Get(context.Background(), path, &result); err != nil {
 		return err
 	}
-	req.Header.Set("Authorization", "Bearer "+cfg.Client.Auth.GetAPIKey())
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return fmt.Errorf("request failed: %w", err)
-	}
-	defer resp.Body.Close() //nolint:errcheck
-	if resp.StatusCode != 200 {
-		return fmt.Errorf("server returned %d", resp.StatusCode)
-	}
-	var result struct {
-		Data struct {
-			Alerts []struct {
-				ID           uint   `json:"ID"`
-				SecretName   string `json:"SecretName"`
-				AlertType    string `json:"AlertType"`
-				Severity     string `json:"Severity"`
-				Description  string `json:"Description"`
-				AccessedBy   string `json:"AccessedBy"`
-				IPAddress    string `json:"IPAddress"`
-				DetectedAt   string `json:"DetectedAt"`
-				Acknowledged bool   `json:"Acknowledged"`
-			} `json:"alerts"`
-			Total int `json:"total"`
-		} `json:"data"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return fmt.Errorf("failed to parse response: %w", err)
-	}
-	alerts := result.Data.Alerts
-	if len(alerts) == 0 {
+	if len(result.Alerts) == 0 {
 		fmt.Println("No anomaly alerts found.")
 		return nil
 	}
-	fmt.Printf("Anomaly Alerts (%d total)\n", result.Data.Total)
+	fmt.Printf("Anomaly Alerts (%d total)\n", result.Total)
 	fmt.Println("======================")
-	for _, a := range alerts {
+	for _, a := range result.Alerts {
 		ack := ""
 		if a.Acknowledged {
 			ack = " [ACK]"
@@ -101,23 +93,17 @@ func runAcknowledge(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("invalid alert ID: %s", args[0])
 	}
-	cfg, err := cliconfig.LoadCLIConfig("")
-	if err != nil {
+	rc, ok := common.NewRemoteClient()
+	if !ok {
 		return fmt.Errorf("not connected to a server — run: keyorix connect <server>")
 	}
-	url := fmt.Sprintf("%s/api/v1/audit/anomalies/%d/acknowledge", cfg.Client.Endpoint, id)
-	req, err := http.NewRequest("POST", url, nil)
-	if err != nil {
+	return runAcknowledgeRemote(rc, id)
+}
+
+func runAcknowledgeRemote(rc *common.RemoteClient, id uint64) error {
+	path := fmt.Sprintf("/api/v1/audit/anomalies/%d/acknowledge", id)
+	if err := rc.Post(context.Background(), path, map[string]interface{}{}, nil); err != nil {
 		return err
-	}
-	req.Header.Set("Authorization", "Bearer "+cfg.Client.Auth.GetAPIKey())
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return fmt.Errorf("request failed: %w", err)
-	}
-	defer resp.Body.Close() //nolint:errcheck
-	if resp.StatusCode != 200 {
-		return fmt.Errorf("server returned %d", resp.StatusCode)
 	}
 	fmt.Printf("Alert %d acknowledged.\n", id)
 	return nil

--- a/internal/cli/anomalies/anomalies_remote_test.go
+++ b/internal/cli/anomalies/anomalies_remote_test.go
@@ -1,0 +1,71 @@
+package anomalies
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAnomaliesUsesSharedRemoteClient guards #348: runList/runAcknowledge must
+// go through common.RemoteClient (a single, shared HTTP client) rather than
+// building their own ad hoc http.DefaultClient.Do(req) — the same duplicate
+// no-timeout hang risk #315 already flags for the shared client.
+func TestAnomaliesUsesSharedRemoteClient(t *testing.T) {
+	var gotPath, gotMethod, gotAuth string
+	status := http.StatusOK
+	body := `{"data":{"alerts":[{"ID":7,"SecretName":"db","AlertType":"new_ip","Severity":"high","Description":"new ip seen","AccessedBy":"alice","IPAddress":"10.0.0.1","DetectedAt":"2026-07-01T00:00:00Z","Acknowledged":false}],"total":1}}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotMethod = r.Method
+		gotAuth = r.Header.Get("Authorization")
+		if status != http.StatusOK {
+			w.WriteHeader(status)
+			return
+		}
+		if r.URL.Path == "/api/v1/audit/anomalies" {
+			_, _ = w.Write([]byte(body))
+			return
+		}
+		_, _ = w.Write([]byte(`{"data":{"acknowledged":true}}`))
+	}))
+	defer srv.Close()
+
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+	rc, ok := common.NewRemoteClient()
+	require.True(t, ok)
+
+	t.Run("list hits the anomalies route with the bearer token via the shared client", func(t *testing.T) {
+		status = http.StatusOK
+		require.NoError(t, runListRemote(rc))
+		assert.Equal(t, "/api/v1/audit/anomalies", gotPath)
+		assert.Equal(t, http.MethodGet, gotMethod)
+		assert.Equal(t, "Bearer test-token", gotAuth)
+	})
+
+	t.Run("list surfaces a server error", func(t *testing.T) {
+		status = http.StatusForbidden
+		err := runListRemote(rc)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "403")
+	})
+
+	t.Run("acknowledge posts to the acknowledge route via the shared client", func(t *testing.T) {
+		status = http.StatusOK
+		require.NoError(t, runAcknowledgeRemote(rc, 7))
+		assert.Equal(t, "/api/v1/audit/anomalies/7/acknowledge", gotPath)
+		assert.Equal(t, http.MethodPost, gotMethod)
+		assert.Equal(t, "Bearer test-token", gotAuth)
+	})
+
+	t.Run("acknowledge surfaces a server error", func(t *testing.T) {
+		status = http.StatusNotFound
+		err := runAcknowledgeRemote(rc, 7)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "404")
+	})
+}

--- a/internal/cli/common/remote_client.go
+++ b/internal/cli/common/remote_client.go
@@ -162,7 +162,9 @@ func (c *RemoteClient) GetRaw(ctx context.Context, path string) ([]byte, error) 
 	return body, nil
 }
 
-// Post serialises body as JSON, POSTs to path, strips the envelope, and decodes into out.
+// Post serialises body as JSON, POSTs to path, strips the envelope, and decodes
+// into out (out may be nil, matching Put/Patch, when the caller doesn't need the
+// response body).
 func (c *RemoteClient) Post(ctx context.Context, path string, body interface{}, out interface{}) error {
 	data, err := json.Marshal(body)
 	if err != nil {
@@ -186,7 +188,10 @@ func (c *RemoteClient) Post(ctx context.Context, path string, body interface{}, 
 	if resp.StatusCode >= 400 {
 		return fmt.Errorf("server returned HTTP %d for %s", resp.StatusCode, path)
 	}
-	return decodeEnvelope(resp, out, path)
+	if out != nil {
+		return decodeEnvelope(resp, out, path)
+	}
+	return nil
 }
 
 // decodeEnvelope strips {"data":…} and unmarshals the inner payload into out.

--- a/internal/cli/legalhold/legalhold.go
+++ b/internal/cli/legalhold/legalhold.go
@@ -79,11 +79,22 @@ var placeCmd = &cobra.Command{
 	},
 }
 
+var liftYes bool
+
 var liftCmd = &cobra.Command{
 	Use:          "lift",
 	Short:        "Lift the active legal hold (resume purges)",
 	SilenceUsage: true,
-	RunE: func(_ *cobra.Command, _ []string) error {
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		if !liftYes {
+			fmt.Print("Lift the active legal hold? This immediately re-arms purge/retention/JIT-expiry\njobs and cannot be undone from here. Type 'yes' to confirm: ")
+			var answer string
+			_, _ = fmt.Fscanln(cmd.InOrStdin(), &answer)
+			if answer != "yes" {
+				fmt.Println("Aborted.")
+				return nil
+			}
+		}
 		c, ok := common.NewRemoteClient()
 		if !ok {
 			return fmt.Errorf("not connected to a server — run: keyorix connect <server>")
@@ -98,5 +109,6 @@ var liftCmd = &cobra.Command{
 
 func init() {
 	placeCmd.Flags().StringVar(&placeReason, "reason", "", "Why the hold is placed (required, recorded for audit)")
+	liftCmd.Flags().BoolVar(&liftYes, "yes", false, "Skip the confirmation prompt")
 	LegalHoldCmd.AddCommand(statusCmd, placeCmd, liftCmd)
 }

--- a/internal/cli/legalhold/legalhold_test.go
+++ b/internal/cli/legalhold/legalhold_test.go
@@ -1,0 +1,58 @@
+package legalhold
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLiftRequiresConfirmation guards #350: `legal-hold lift` re-arms the
+// purge/retention/JIT-expiry jobs a hold exists to block, so it must not fire
+// on the server without either an interactive "yes" or --yes, matching the
+// `dynamic-secret revoke-all --yes` convention.
+func TestLiftRequiresConfirmation(t *testing.T) {
+	var deleteCalls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete && r.URL.Path == "/api/v1/legal-hold" {
+			deleteCalls++
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+
+	t.Run("declining the prompt aborts without calling the server", func(t *testing.T) {
+		deleteCalls = 0
+		liftYes = false
+		cmd := &cobra.Command{}
+		cmd.SetIn(strings.NewReader("no\n"))
+		require.NoError(t, liftCmd.RunE(cmd, nil))
+		assert.Equal(t, 0, deleteCalls, "declining the prompt must not lift the hold")
+	})
+
+	t.Run("typing yes at the prompt lifts the hold", func(t *testing.T) {
+		deleteCalls = 0
+		liftYes = false
+		cmd := &cobra.Command{}
+		cmd.SetIn(strings.NewReader("yes\n"))
+		require.NoError(t, liftCmd.RunE(cmd, nil))
+		assert.Equal(t, 1, deleteCalls, "confirming at the prompt must lift the hold")
+	})
+
+	t.Run("--yes skips the prompt and lifts the hold", func(t *testing.T) {
+		deleteCalls = 0
+		liftYes = true
+		defer func() { liftYes = false }()
+		cmd := &cobra.Command{}
+		cmd.SetIn(strings.NewReader(""))
+		require.NoError(t, liftCmd.RunE(cmd, nil))
+		assert.Equal(t, 1, deleteCalls, "--yes must skip the prompt and lift the hold")
+	})
+}

--- a/internal/cli/machine/lifecycle.go
+++ b/internal/cli/machine/lifecycle.go
@@ -1,11 +1,14 @@
 package machine
 
 import (
+	"bufio"
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/keyorixhq/keyorix/internal/cli/common"
 	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/spf13/cobra"
 )
 
@@ -25,21 +28,24 @@ var reactivateCmd = &cobra.Command{
 	RunE:  lifecycleRunE("activate", core.MachineActive),
 }
 
+var revokeForce bool
+
 var revokeCmd = &cobra.Command{
 	Use:   "revoke <name|id>",
 	Short: "Revoke a machine identity (terminal)",
 	Args:  cobra.ExactArgs(1),
-	RunE:  lifecycleRunE("revoke", core.MachineRevoked),
+	RunE:  runRevoke,
 }
 
 func init() {
 	for _, c := range []*cobra.Command{suspendCmd, reactivateCmd, revokeCmd} {
 		c.Flags().StringVar(&lifecycleProjectName, "project", "", "Project name (defaults to the active project)")
 	}
+	revokeCmd.Flags().BoolVar(&revokeForce, "force", false, "Skip the confirmation prompt")
 }
 
 // lifecycleRunE returns a RunE that transitions the referenced machine identity
-// to targetState. action is the API verb (activate/suspend/revoke).
+// to targetState. action is the API verb (activate/suspend).
 func lifecycleRunE(action, targetState string) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
 		ctx := context.Background()
@@ -51,24 +57,59 @@ func lifecycleRunE(action, targetState string) func(*cobra.Command, []string) er
 		if err != nil {
 			return err
 		}
+		return transitionMachine(ctx, projectID, m, action, targetState)
+	}
+}
 
-		if rc, ok := common.NewRemoteClient(); ok {
-			path := fmt.Sprintf("/api/v1/projects/%d/machine-identities/%d", projectID, m.ID)
-			if err := rc.Put(ctx, path, map[string]interface{}{"action": action}, nil); err != nil {
-				return fmt.Errorf("failed to %s machine identity: %w", action, err)
-			}
-			fmt.Printf("Machine identity %q → %s\n", m.Name, targetState)
+// runRevoke resolves the referenced machine identity and, unless --force is
+// set, requires the operator to type its name back before revoking it — revoke
+// is a one-way, irreversible credential-kill action (see canTransitionMachine:
+// MachineRevoked has no outgoing transitions), matching the typed-name
+// confirmation convention used by `secret delete`.
+func runRevoke(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+	_, projectID, err := resolveProjectContext(lifecycleProjectName)
+	if err != nil {
+		return err
+	}
+	m, err := findMachineByRef(ctx, projectID, args[0])
+	if err != nil {
+		return err
+	}
+	return revokeMachine(cmd, ctx, projectID, m)
+}
+
+func revokeMachine(cmd *cobra.Command, ctx context.Context, projectID uint, m *models.MachineIdentity) error {
+	if !revokeForce {
+		fmt.Printf("Revoking %q is permanent — the machine identity cannot be reactivated afterward.\nType the machine identity name to confirm: ", m.Name)
+		reader := bufio.NewReader(cmd.InOrStdin())
+		input, _ := reader.ReadString('\n')
+		if strings.TrimSpace(input) != m.Name {
+			fmt.Println("Name mismatch — revoke aborted.")
 			return nil
 		}
+	}
+	return transitionMachine(ctx, projectID, m, "revoke", core.MachineRevoked)
+}
 
-		svc, err := common.InitializeCoreService()
-		if err != nil {
-			return fmt.Errorf("failed to initialize service: %w", err)
-		}
-		if _, err := svc.TransitionMachineIdentity(ctx, m.ProjectID, m.ID, targetState, 0); err != nil {
+// transitionMachine performs the actual state transition (remote or local).
+func transitionMachine(ctx context.Context, projectID uint, m *models.MachineIdentity, action, targetState string) error {
+	if rc, ok := common.NewRemoteClient(); ok {
+		path := fmt.Sprintf("/api/v1/projects/%d/machine-identities/%d", projectID, m.ID)
+		if err := rc.Put(ctx, path, map[string]interface{}{"action": action}, nil); err != nil {
 			return fmt.Errorf("failed to %s machine identity: %w", action, err)
 		}
 		fmt.Printf("Machine identity %q → %s\n", m.Name, targetState)
 		return nil
 	}
+
+	svc, err := common.InitializeCoreService()
+	if err != nil {
+		return fmt.Errorf("failed to initialize service: %w", err)
+	}
+	if _, err := svc.TransitionMachineIdentity(ctx, m.ProjectID, m.ID, targetState, 0); err != nil {
+		return fmt.Errorf("failed to %s machine identity: %w", action, err)
+	}
+	fmt.Printf("Machine identity %q → %s\n", m.Name, targetState)
+	return nil
 }

--- a/internal/cli/machine/lifecycle_test.go
+++ b/internal/cli/machine/lifecycle_test.go
@@ -1,0 +1,71 @@
+package machine
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRevokeMachineRequiresConfirmation guards #351: `machine revoke` is a
+// one-way, irreversible credential-kill action (MachineRevoked has no
+// outgoing transitions) and must not fire on the server without either a
+// correctly typed machine name or --force, matching `secret delete`'s
+// typed-name confirmation convention.
+func TestRevokeMachineRequiresConfirmation(t *testing.T) {
+	var putCalls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPut && r.URL.Path == "/api/v1/projects/3/machine-identities/5" {
+			putCalls++
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+
+	m := &models.MachineIdentity{Name: "ci-runner"}
+	m.ID = 5
+	m.ProjectID = 3
+
+	t.Run("wrong name aborts without calling the server", func(t *testing.T) {
+		putCalls = 0
+		revokeForce = false
+		cmd := &cobra.Command{}
+		cmd.SetIn(strings.NewReader("not-the-name\n"))
+		require.NoError(t, revokeMachine(cmd, context.Background(), 3, m))
+		assert.Equal(t, 0, putCalls, "a name mismatch must not revoke the machine identity")
+	})
+
+	t.Run("typing the correct name revokes", func(t *testing.T) {
+		putCalls = 0
+		revokeForce = false
+		cmd := &cobra.Command{}
+		cmd.SetIn(strings.NewReader("ci-runner\n"))
+		require.NoError(t, revokeMachine(cmd, context.Background(), 3, m))
+		assert.Equal(t, 1, putCalls, "typing the correct name must revoke the machine identity")
+	})
+
+	t.Run("--force skips the prompt and revokes", func(t *testing.T) {
+		putCalls = 0
+		revokeForce = true
+		defer func() { revokeForce = false }()
+		cmd := &cobra.Command{}
+		cmd.SetIn(strings.NewReader(""))
+		require.NoError(t, revokeMachine(cmd, context.Background(), 3, m))
+		assert.Equal(t, 1, putCalls, "--force must skip the prompt and revoke")
+	})
+}
+
+func TestRevokeCmd_HasForceFlag(t *testing.T) {
+	revoke, _, err := MachineCmd.Find([]string{"revoke"})
+	require.NoError(t, err)
+	assert.NotNil(t, revoke.Flags().Lookup("force"), "revoke should have a --force flag")
+}

--- a/internal/cli/secret/export.go
+++ b/internal/cli/secret/export.go
@@ -90,7 +90,9 @@ func runExport(cmd *cobra.Command, args []string) error {
 
 	var out io.Writer = os.Stdout
 	if exportOutput != "" {
-		f, err := os.Create(exportOutput) // #nosec G304
+		// 0600: this file holds plaintext secret values — sibling writers
+		// (render.go, scan.go, fix.go) all use the same restrictive mode.
+		f, err := os.OpenFile(exportOutput, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600) // #nosec G304
 		if err != nil {
 			return fmt.Errorf("cannot create output file %q: %w", exportOutput, err)
 		}

--- a/internal/cli/secret/export_test.go
+++ b/internal/cli/secret/export_test.go
@@ -1,0 +1,68 @@
+package secret
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRunExport_OutputFilePermissions guards #353: the plaintext export file
+// must be created with 0600, like every sibling writer in this package
+// (render.go, scan.go, fix.go), not the default os.Create mode.
+func TestRunExport_OutputFilePermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX file-permission bits don't apply on windows")
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/api/v1/projects":
+			_, _ = w.Write([]byte(`{"data":{"projects":[{"id":1,"name":"default"}]}}`))
+		case r.URL.Path == "/api/v1/environments":
+			_, _ = w.Write([]byte(`{"data":{"environments":[{"id":1,"name":"development"}]}}`))
+		case strings.HasPrefix(r.URL.Path, "/api/v1/secrets") && r.URL.Query().Get("project_id") != "":
+			_, _ = w.Write([]byte(`{"data":{"secrets":[{"id":9,"name":"DB_PASSWORD"}]}}`))
+		case r.URL.Path == "/api/v1/secrets/9":
+			_, _ = w.Write([]byte(`{"data":{"value":"s3cr3t"}}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+
+	dir := t.TempDir()
+	outPath := filepath.Join(dir, "secrets.env")
+
+	origFormat, origOutput, origEnv, origProject := exportFormat, exportOutput, exportEnv, exportProject
+	exportFormat = "dotenv"
+	exportOutput = outPath
+	exportEnv = "development"
+	exportProject = "default"
+	defer func() {
+		exportFormat, exportOutput, exportEnv, exportProject = origFormat, origOutput, origEnv, origProject
+	}()
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	require.NoError(t, runExport(cmd, nil))
+
+	info, err := os.Stat(outPath)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0600), info.Mode().Perm(), "export output file must be created with 0600")
+
+	data, err := os.ReadFile(outPath) // #nosec G304 -- test-controlled path
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "DB_PASSWORD=s3cr3t")
+}

--- a/internal/cli/secret/list.go
+++ b/internal/cli/secret/list.go
@@ -2,7 +2,9 @@ package secret
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -232,42 +234,68 @@ func displaySecretsTable(secrets []*models.SecretNode, total int64, filter *core
 	}
 }
 
+// jsonSecretEntry is the per-secret shape for `secret list --format json`.
+// Built and marshaled via encoding/json (not fmt.Printf string interpolation)
+// so a secret name (or any other string field) containing quotes/control
+// characters is correctly escaped rather than able to break out of the JSON
+// string and inject arbitrary keys (#354).
+type jsonSecretEntry struct {
+	ID            uint    `json:"id"`
+	Name          string  `json:"name"`
+	Type          string  `json:"type"`
+	Status        string  `json:"status"`
+	ProjectID     uint    `json:"project_id"`
+	EnvironmentID uint    `json:"environment_id"`
+	CreatedBy     string  `json:"created_by"`
+	CreatedAt     string  `json:"created_at"`
+	UpdatedAt     string  `json:"updated_at"`
+	MaxReads      *int    `json:"max_reads,omitempty"`
+	Expiration    *string `json:"expiration,omitempty"`
+}
+
+type jsonSecretsOutput struct {
+	Total   int64             `json:"total"`
+	Offset  int               `json:"offset"`
+	Limit   int               `json:"limit"`
+	Count   int               `json:"count"`
+	Secrets []jsonSecretEntry `json:"secrets"`
+}
+
 func displaySecretsJSON(secrets []*models.SecretNode, total int64, filter *coreStorage.SecretFilter) {
 	offset := (filter.Page - 1) * filter.PageSize
 
-	fmt.Printf("{\n")
-	fmt.Printf("  \"total\": %d,\n", total)
-	fmt.Printf("  \"offset\": %d,\n", offset)
-	fmt.Printf("  \"limit\": %d,\n", filter.PageSize)
-	fmt.Printf("  \"count\": %d,\n", len(secrets))
-	fmt.Printf("  \"secrets\": [\n")
-
-	for i, secret := range secrets {
-		fmt.Printf("    {\n")
-		fmt.Printf("      \"id\": %d,\n", secret.ID)
-		fmt.Printf("      \"name\": \"%s\",\n", secret.Name)
-		fmt.Printf("      \"type\": \"%s\",\n", secret.Type)
-		fmt.Printf("      \"status\": \"%s\",\n", secret.Status)
-		fmt.Printf("      \"project_id\": %d,\n", secret.ProjectID)
-		fmt.Printf("      \"environment_id\": %d,\n", secret.EnvironmentID)
-		fmt.Printf("      \"created_by\": \"%s\",\n", secret.CreatedBy)
-		fmt.Printf("      \"created_at\": \"%s\",\n", secret.CreatedAt.Format(time.RFC3339))
-		fmt.Printf("      \"updated_at\": \"%s\"", secret.UpdatedAt.Format(time.RFC3339))
-		if secret.MaxReads != nil {
-			fmt.Printf(",\n      \"max_reads\": %d", *secret.MaxReads)
+	out := jsonSecretsOutput{
+		Total:   total,
+		Offset:  offset,
+		Limit:   filter.PageSize,
+		Count:   len(secrets),
+		Secrets: make([]jsonSecretEntry, 0, len(secrets)),
+	}
+	for _, secret := range secrets {
+		entry := jsonSecretEntry{
+			ID:            secret.ID,
+			Name:          secret.Name,
+			Type:          secret.Type,
+			Status:        secret.Status,
+			ProjectID:     secret.ProjectID,
+			EnvironmentID: secret.EnvironmentID,
+			CreatedBy:     secret.CreatedBy,
+			CreatedAt:     secret.CreatedAt.Format(time.RFC3339),
+			UpdatedAt:     secret.UpdatedAt.Format(time.RFC3339),
+			MaxReads:      secret.MaxReads,
 		}
 		if secret.Expiration != nil {
-			fmt.Printf(",\n      \"expiration\": \"%s\"", secret.Expiration.Format(time.RFC3339))
+			exp := secret.Expiration.Format(time.RFC3339)
+			entry.Expiration = &exp
 		}
-		fmt.Printf("\n    }")
-		if i < len(secrets)-1 {
-			fmt.Printf(",")
-		}
-		fmt.Printf("\n")
+		out.Secrets = append(out.Secrets, entry)
 	}
 
-	fmt.Printf("  ]\n")
-	fmt.Printf("}\n")
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(out); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to encode JSON output: %v\n", err)
+	}
 }
 
 func truncateString(s string, maxLen int) string {

--- a/internal/cli/secret/list_json_test.go
+++ b/internal/cli/secret/list_json_test.go
@@ -1,0 +1,63 @@
+package secret
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"testing"
+	"time"
+
+	coreStorage "github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// captureStdout runs fn and returns everything it wrote to os.Stdout.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	orig := os.Stdout
+	os.Stdout = w
+	defer func() { os.Stdout = orig }()
+
+	fn()
+
+	require.NoError(t, w.Close())
+	out, err := io.ReadAll(r)
+	require.NoError(t, err)
+	return string(out)
+}
+
+// TestDisplaySecretsJSON_EscapesSecretName guards #354: a secret name (or any
+// other string field) containing raw quotes/braces must not be able to break
+// out of the JSON string and inject arbitrary keys into `secret list --format
+// json` output.
+func TestDisplaySecretsJSON_EscapesSecretName(t *testing.T) {
+	malicious := `foo", "admin": true, "x":"`
+	secrets := []*models.SecretNode{
+		{
+			ID:            1,
+			Name:          malicious,
+			Type:          "generic",
+			Status:        "active",
+			ProjectID:     1,
+			EnvironmentID: 1,
+			CreatedBy:     "alice",
+			CreatedAt:     time.Now(),
+			UpdatedAt:     time.Now(),
+		},
+	}
+	filter := &coreStorage.SecretFilter{Page: 1, PageSize: 50}
+
+	out := captureStdout(t, func() {
+		displaySecretsJSON(secrets, 1, filter)
+	})
+
+	var parsed jsonSecretsOutput
+	require.NoError(t, json.Unmarshal([]byte(out), &parsed), "output must be valid, well-formed JSON")
+	require.Len(t, parsed.Secrets, 1)
+	assert.Equal(t, malicious, parsed.Secrets[0].Name, "the hostile name must round-trip as a single escaped string value")
+	assert.False(t, parsed.Secrets[0].MaxReads != nil && *parsed.Secrets[0].MaxReads != 0, "no injected keys should have leaked into an unrelated field")
+}

--- a/internal/cli/secret/versions.go
+++ b/internal/cli/secret/versions.go
@@ -2,7 +2,9 @@ package secret
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -120,37 +122,57 @@ func displayVersionsTable(secret *models.SecretNode, versions []*models.SecretVe
 	}
 }
 
+// jsonVersionEntry/jsonVersionsOutput are the `secret versions --format json`
+// shape. Built and marshaled via encoding/json (not fmt.Printf string
+// interpolation) so a secret name/type containing quotes or control
+// characters is correctly escaped rather than able to break out of the JSON
+// string and inject arbitrary keys (#354).
+type jsonVersionEntry struct {
+	ID                 uint            `json:"id"`
+	VersionNumber      int             `json:"version_number"`
+	SizeBytes          int             `json:"size_bytes"`
+	ReadCount          int             `json:"read_count"`
+	CreatedAt          string          `json:"created_at"`
+	EncryptionMetadata json.RawMessage `json:"encryption_metadata,omitempty"`
+}
+
+type jsonVersionsOutput struct {
+	Secret struct {
+		ID   uint   `json:"id"`
+		Name string `json:"name"`
+		Type string `json:"type"`
+	} `json:"secret"`
+	TotalVersions int                `json:"total_versions"`
+	Versions      []jsonVersionEntry `json:"versions"`
+}
+
 func displayVersionsJSON(secret *models.SecretNode, versions []*models.SecretVersion) {
-	fmt.Printf("{\n")
-	fmt.Printf("  \"secret\": {\n")
-	fmt.Printf("    \"id\": %d,\n", secret.ID)
-	fmt.Printf("    \"name\": \"%s\",\n", secret.Name)
-	fmt.Printf("    \"type\": \"%s\"\n", secret.Type)
-	fmt.Printf("  },\n")
-	fmt.Printf("  \"total_versions\": %d,\n", len(versions))
-	fmt.Printf("  \"versions\": [\n")
+	var out jsonVersionsOutput
+	out.Secret.ID = secret.ID
+	out.Secret.Name = secret.Name
+	out.Secret.Type = secret.Type
+	out.TotalVersions = len(versions)
+	out.Versions = make([]jsonVersionEntry, 0, len(versions))
 
-	for i, version := range versions {
-		fmt.Printf("    {\n")
-		fmt.Printf("      \"id\": %d,\n", version.ID)
-		fmt.Printf("      \"version_number\": %d,\n", version.VersionNumber)
-		fmt.Printf("      \"size_bytes\": %d,\n", len(version.EncryptedValue))
-		fmt.Printf("      \"read_count\": %d,\n", version.ReadCount)
-		fmt.Printf("      \"created_at\": \"%s\"", version.CreatedAt.Format(time.RFC3339))
-
+	for _, version := range versions {
+		entry := jsonVersionEntry{
+			ID:            version.ID,
+			VersionNumber: version.VersionNumber,
+			SizeBytes:     len(version.EncryptedValue),
+			ReadCount:     version.ReadCount,
+			CreatedAt:     version.CreatedAt.Format(time.RFC3339),
+		}
 		if len(version.EncryptionMetadata) > 0 {
-			fmt.Printf(",\n      \"encryption_metadata\": %s", string(version.EncryptionMetadata))
+			entry.EncryptionMetadata = json.RawMessage(version.EncryptionMetadata)
 		}
-
-		fmt.Printf("\n    }")
-		if i < len(versions)-1 {
-			fmt.Printf(",")
-		}
-		fmt.Printf("\n")
+		out.Versions = append(out.Versions, entry)
 	}
 
-	fmt.Printf("  ]\n")
-	fmt.Printf("}\n")
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(out); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to encode JSON output: %v\n", err)
+	}
 }
 
 func formatBytes(bytes int) string {

--- a/internal/cli/secret/versions_json_test.go
+++ b/internal/cli/secret/versions_json_test.go
@@ -1,0 +1,56 @@
+package secret
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDisplayVersionsJSON_EscapesSecretName guards #354: a secret name/type
+// containing raw quotes/braces must not be able to break out of the JSON
+// string and inject arbitrary keys into `secret versions --format json`
+// output.
+func TestDisplayVersionsJSON_EscapesSecretName(t *testing.T) {
+	malicious := `foo", "admin": true, "x":"`
+	secret := &models.SecretNode{ID: 1, Name: malicious, Type: "generic"}
+	versions := []*models.SecretVersion{
+		{ID: 10, VersionNumber: 1, ReadCount: 2, CreatedAt: time.Now()},
+	}
+
+	out := captureStdout(t, func() {
+		displayVersionsJSON(secret, versions)
+	})
+
+	var parsed jsonVersionsOutput
+	require.NoError(t, json.Unmarshal([]byte(out), &parsed), "output must be valid, well-formed JSON")
+	assert.Equal(t, malicious, parsed.Secret.Name, "the hostile name must round-trip as a single escaped string value")
+	require.Len(t, parsed.Versions, 1)
+	assert.Equal(t, uint(10), parsed.Versions[0].ID)
+}
+
+// TestDisplayVersionsJSON_EmbedsEncryptionMetadataRaw confirms the existing
+// behavior of inlining EncryptionMetadata (already-serialized JSON bytes) is
+// preserved through the json.RawMessage switch, rather than double-encoding
+// it into an escaped string.
+func TestDisplayVersionsJSON_EmbedsEncryptionMetadataRaw(t *testing.T) {
+	secret := &models.SecretNode{ID: 1, Name: "db", Type: "generic"}
+	versions := []*models.SecretVersion{
+		{ID: 10, VersionNumber: 1, CreatedAt: time.Now(), EncryptionMetadata: models.JSON(`{"algorithm":"AES-256-GCM"}`)},
+	}
+
+	out := captureStdout(t, func() {
+		displayVersionsJSON(secret, versions)
+	})
+
+	var parsed jsonVersionsOutput
+	require.NoError(t, json.Unmarshal([]byte(out), &parsed))
+	require.Len(t, parsed.Versions, 1)
+	require.NotNil(t, parsed.Versions[0].EncryptionMetadata)
+	var meta map[string]string
+	require.NoError(t, json.Unmarshal(parsed.Versions[0].EncryptionMetadata, &meta))
+	assert.Equal(t, "AES-256-GCM", meta["algorithm"])
+}

--- a/internal/cli/user/create.go
+++ b/internal/cli/user/create.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"syscall"
 
 	"github.com/keyorixhq/keyorix/internal/cli/common"
 	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 )
 
 var (
@@ -37,7 +40,7 @@ var createCmd = &cobra.Command{
 func init() {
 	createCmd.Flags().StringVar(&createUsername, "username", "", "Username (required)")
 	createCmd.Flags().StringVar(&createEmail, "email", "", "Email (required)")
-	createCmd.Flags().StringVar(&createPassword, "password", "", "Initial password (required unless --setup-link or --one-time-password)")
+	createCmd.Flags().StringVar(&createPassword, "password", "", "Initial password (INSECURE on the command line — prefer KEYORIX_INITIAL_PASSWORD or the interactive prompt; required in some form unless --setup-link or --one-time-password)")
 	createCmd.Flags().StringVar(&createDisplayName, "display-name", "", "Display name (defaults to username)")
 	createCmd.Flags().BoolVar(&createSetupLink, "setup-link", false, "Provision a setup link instead of an admin-set password (ADR-028)")
 	createCmd.Flags().BoolVar(&createOneTimePassword, "one-time-password", false, "Generate a one-time password instead of an admin-set password (ADR-028 Part E); must be changed on first login")
@@ -54,8 +57,22 @@ func runCreate(cmd *cobra.Command, args []string) error {
 	if createSetupLink && createOneTimePassword {
 		return errors.New("use either --setup-link or --one-time-password, not both")
 	}
-	if !createSetupLink && !createOneTimePassword && createPassword == "" {
-		return errors.New("password is required (use --password), or use --setup-link or --one-time-password")
+
+	// Resolve the initial password without ever requiring it on argv: the
+	// (insecure, warned) --password flag if set, else KEYORIX_INITIAL_PASSWORD, else
+	// an interactive no-echo prompt — mirroring `keyorix connect`'s resolveAPIKey /
+	// resolveConnectPassword pattern. Not needed at all for --setup-link /
+	// --one-time-password, which provision their own credential.
+	var password string
+	if !createSetupLink && !createOneTimePassword {
+		pw, err := resolveInitialPassword(cmd)
+		if err != nil {
+			return err
+		}
+		if pw == "" {
+			return errors.New("password is required (use --password, KEYORIX_INITIAL_PASSWORD, or the interactive prompt), or use --setup-link or --one-time-password")
+		}
+		password = pw
 	}
 
 	// Remote mode: go through the server so the user lands in the SAME store the
@@ -66,7 +83,7 @@ func runCreate(cmd *cobra.Command, args []string) error {
 		if createSetupLink || createOneTimePassword {
 			return errors.New("--setup-link / --one-time-password are not yet supported in remote mode; use --password, or run this command on the server host")
 		}
-		return runCreateRemote(rc)
+		return runCreateRemote(rc, password)
 	}
 
 	service, err := common.InitializeCoreService()
@@ -84,7 +101,7 @@ func runCreate(cmd *cobra.Command, args []string) error {
 		Username:    createUsername,
 		Email:       createEmail,
 		DisplayName: display,
-		Password:    createPassword,
+		Password:    password,
 	}
 
 	if createSetupLink {
@@ -129,7 +146,7 @@ func runCreate(cmd *cobra.Command, args []string) error {
 
 // runCreateRemote creates the user via POST /api/v1/users (password mode), so it
 // lands in the server's store rather than a local SQLite file.
-func runCreateRemote(rc *common.RemoteClient) error {
+func runCreateRemote(rc *common.RemoteClient, password string) error {
 	display := createDisplayName
 	if display == "" {
 		display = createUsername
@@ -138,7 +155,7 @@ func runCreateRemote(rc *common.RemoteClient) error {
 		"username":     createUsername,
 		"email":        createEmail,
 		"display_name": display,
-		"password":     createPassword,
+		"password":     password,
 	}
 	var u struct {
 		ID       uint   `json:"id"`
@@ -150,4 +167,26 @@ func runCreateRemote(rc *common.RemoteClient) error {
 	}
 	fmt.Printf("User created: id=%d username=%s email=%s\n", u.ID, u.Username, u.Email)
 	return nil
+}
+
+// resolveInitialPassword returns the new user's initial password without ever
+// requiring it on argv: the (insecure, warned) --password flag if set, else
+// KEYORIX_INITIAL_PASSWORD, else an interactive no-echo prompt. Mirrors
+// `keyorix connect`'s resolveAPIKey/resolveConnectPassword argv-hygiene pattern
+// (internal/cli/connect/connect.go) established earlier this campaign (#207/#208).
+func resolveInitialPassword(cmd *cobra.Command) (string, error) {
+	if createPassword != "" {
+		fmt.Fprintln(os.Stderr, "⚠️  Passing --password on the command line is insecure (visible via ps/proc and saved in shell history); prefer the KEYORIX_INITIAL_PASSWORD environment variable, or omit it to be prompted.")
+		return createPassword, nil
+	}
+	if pw := os.Getenv("KEYORIX_INITIAL_PASSWORD"); pw != "" {
+		return pw, nil
+	}
+	fmt.Fprint(os.Stderr, "Initial password: ")
+	b, err := term.ReadPassword(int(syscall.Stdin))
+	fmt.Fprintln(os.Stderr)
+	if err != nil {
+		return "", fmt.Errorf("failed to read password: %w", err)
+	}
+	return string(b), nil
 }

--- a/internal/cli/user/create_password_test.go
+++ b/internal/cli/user/create_password_test.go
@@ -1,0 +1,51 @@
+package user
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestResolveInitialPassword_PrefersFlagThenEnv guards #357: `user create`'s
+// initial password must be resolvable via KEYORIX_INITIAL_PASSWORD (not just
+// the argv-visible --password flag), matching the argv-hygiene pattern
+// `keyorix connect` established (resolveAPIKey/resolveConnectPassword).
+func TestResolveInitialPassword_PrefersFlagThenEnv(t *testing.T) {
+	origPassword := createPassword
+	defer func() { createPassword = origPassword }()
+	cmd := &cobra.Command{}
+
+	t.Run("an explicit --password flag value is used (with a warning)", func(t *testing.T) {
+		createPassword = "argv-pass"
+		pw, err := resolveInitialPassword(cmd)
+		require.NoError(t, err)
+		assert.Equal(t, "argv-pass", pw)
+	})
+
+	t.Run("KEYORIX_INITIAL_PASSWORD is used when --password is empty", func(t *testing.T) {
+		createPassword = ""
+		t.Setenv("KEYORIX_INITIAL_PASSWORD", "env-pass")
+		pw, err := resolveInitialPassword(cmd)
+		require.NoError(t, err)
+		assert.Equal(t, "env-pass", pw)
+	})
+
+	t.Run("--password takes priority over the env var when both are set", func(t *testing.T) {
+		createPassword = "argv-pass"
+		t.Setenv("KEYORIX_INITIAL_PASSWORD", "env-pass")
+		pw, err := resolveInitialPassword(cmd)
+		require.NoError(t, err)
+		assert.Equal(t, "argv-pass", pw)
+	})
+}
+
+// TestCreateCmd_PasswordFlagDocumentsSaferAlternative confirms the --password
+// flag's help text still exists for backward compatibility but documents the
+// safer KEYORIX_INITIAL_PASSWORD alternative.
+func TestCreateCmd_PasswordFlagDocumentsSaferAlternative(t *testing.T) {
+	f := createCmd.Flags().Lookup("password")
+	require.NotNil(t, f)
+	assert.Contains(t, f.Usage, "KEYORIX_INITIAL_PASSWORD")
+}

--- a/internal/cli/user/create_remote_test.go
+++ b/internal/cli/user/create_remote_test.go
@@ -31,8 +31,8 @@ func TestRunCreateRemote(t *testing.T) {
 	rc, ok := common.NewRemoteClient()
 	require.True(t, ok)
 
-	createUsername, createEmail, createPassword, createDisplayName = "bob", "bob@test.com", "s3cret-pass", ""
-	require.NoError(t, runCreateRemote(rc))
+	createUsername, createEmail, createDisplayName = "bob", "bob@test.com", ""
+	require.NoError(t, runCreateRemote(rc, "s3cret-pass"))
 
 	assert.Equal(t, "bob", gotBody["username"])
 	assert.Equal(t, "bob@test.com", gotBody["email"])

--- a/internal/cli/user/delete.go
+++ b/internal/cli/user/delete.go
@@ -9,7 +9,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var deleteUserID uint
+var (
+	deleteUserID uint
+	deleteBy     string
+)
 
 var deleteCmd = &cobra.Command{
 	Use:   "delete",
@@ -19,11 +22,17 @@ var deleteCmd = &cobra.Command{
 
 func init() {
 	deleteCmd.Flags().UintVar(&deleteUserID, "id", 0, "User ID (required)")
+	deleteCmd.Flags().StringVar(&deleteBy, "by", "", "Acting admin email (required, for audit)")
+	_ = deleteCmd.MarkFlagRequired("id")
+	_ = deleteCmd.MarkFlagRequired("by")
 }
 
 func runDelete(cmd *cobra.Command, args []string) error {
 	if deleteUserID == 0 {
 		return errors.New("user id is required (use --id)")
+	}
+	if deleteBy == "" {
+		return errors.New("acting admin email is required (use --by)")
 	}
 
 	service, err := common.InitializeCoreService()
@@ -32,7 +41,12 @@ func runDelete(cmd *cobra.Command, args []string) error {
 	}
 	ctx := context.Background()
 
-	if err := service.DeleteUser(ctx, deleteUserID); err != nil {
+	adminID, err := resolveAdminID(ctx, service, deleteBy)
+	if err != nil {
+		return err
+	}
+
+	if err := service.DeleteUser(ctx, adminID, deleteUserID); err != nil {
 		return fmt.Errorf("failed to delete user: %w", err)
 	}
 	fmt.Printf("User %d deleted.\n", deleteUserID)

--- a/internal/cli/user/user_test.go
+++ b/internal/cli/user/user_test.go
@@ -31,6 +31,7 @@ func TestLifecycleRequiredFlags(t *testing.T) {
 		"reactivate":           reactivateCmd,
 		"force-password-reset": forcePasswordResetCmd,
 		"revoke-sessions":      revokeSessionsCmd,
+		"delete":               deleteCmd,
 	}
 	for label, c := range cmds {
 		for _, name := range []string{"id", "by"} {

--- a/internal/core/users.go
+++ b/internal/core/users.go
@@ -240,10 +240,11 @@ func (c *KeyorixCore) UpdateUser(ctx context.Context, req *UpdateUserRequest) (*
 	return updated, nil
 }
 
-// DeleteUser soft-deletes a user by ID.
+// DeleteUser soft-deletes a user by ID, audited under actorID (0 when no
+// actor is known, e.g. an unauthenticated internal caller).
 // The row is retained with deleted_at set; active sessions fail on next request.
 // Soft-deleted users can be restored within the purge retention window (default 30 days).
-func (c *KeyorixCore) DeleteUser(ctx context.Context, id uint) error {
+func (c *KeyorixCore) DeleteUser(ctx context.Context, actorID, id uint) error {
 	if id == 0 {
 		return fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "user ID is required")
 	}
@@ -253,6 +254,12 @@ func (c *KeyorixCore) DeleteUser(ctx context.Context, id uint) error {
 	if err := c.storage.DeleteUser(ctx, id); err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}
+	var aid *uint
+	if actorID != 0 {
+		aid = &actorID
+	}
+	c.writeAuditEventFull(ctx, "user.deleted", aid, nil, nil, "",
+		fmt.Sprintf("user %d deleted", id))
 	return nil
 }
 

--- a/internal/core/users_delete_test.go
+++ b/internal/core/users_delete_test.go
@@ -1,0 +1,47 @@
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDeleteUser_RecordsActorInAuditEvent guards #356: deleting a user must
+// leave an audit trail attributing the actor who performed the deletion (via
+// the threaded actorID parameter), matching the audited convention already
+// used by SuspendUser/ReactivateUser/RequirePasswordReset.
+func TestDeleteUser_RecordsActorInAuditEvent(t *testing.T) {
+	store := new(MockStorage)
+	c := newAccountCore(store)
+	ctx := context.Background()
+
+	store.On("GetUser", ctx, uint(2)).Return(&models.User{ID: 2}, nil)
+	store.On("DeleteUser", ctx, uint(2)).Return(nil)
+	store.On("LogAuditEvent", ctx, mock.MatchedBy(func(e *models.AuditEvent) bool {
+		return e.EventType == "user.deleted" && e.UserID != nil && *e.UserID == uint(7)
+	})).Return(nil)
+
+	require.NoError(t, c.DeleteUser(ctx, 7, 2))
+	store.AssertExpectations(t)
+}
+
+// TestDeleteUser_ZeroActorOmitsAttribution confirms an unset actor (0) is not
+// recorded as a spurious "user 0" attribution — the audit event's UserID is
+// left nil rather than pointing at a nonexistent actor.
+func TestDeleteUser_ZeroActorOmitsAttribution(t *testing.T) {
+	store := new(MockStorage)
+	c := newAccountCore(store)
+	ctx := context.Background()
+
+	store.On("GetUser", ctx, uint(2)).Return(&models.User{ID: 2}, nil)
+	store.On("DeleteUser", ctx, uint(2)).Return(nil)
+	store.On("LogAuditEvent", ctx, mock.MatchedBy(func(e *models.AuditEvent) bool {
+		return e.EventType == "user.deleted" && e.UserID == nil
+	})).Return(nil)
+
+	require.NoError(t, c.DeleteUser(ctx, 0, 2))
+	store.AssertExpectations(t)
+}

--- a/server/grpc/services/user_service.go
+++ b/server/grpc/services/user_service.go
@@ -182,7 +182,7 @@ func (s *UserGRPCService) DeleteUser(ctx context.Context, req *pb.DeleteUserRequ
 	if req.GetId() == 0 {
 		return nil, status.Error(codes.InvalidArgument, "id is required")
 	}
-	if err := s.core.DeleteUser(ctx, uint(req.GetId())); err != nil {
+	if err := s.core.DeleteUser(ctx, actor.UserID, uint(req.GetId())); err != nil {
 		return nil, mapUserError(err)
 	}
 	return &emptypb.Empty{}, nil

--- a/server/http/handlers/users_crud.go
+++ b/server/http/handlers/users_crud.go
@@ -288,7 +288,7 @@ func (h *UserHandler) DeleteUser(w http.ResponseWriter, r *http.Request) {
 		sendError(w, "InvalidParameter", "Invalid user ID", http.StatusBadRequest, nil)
 		return
 	}
-	if err := h.coreService.DeleteUser(r.Context(), uint(id)); err != nil {
+	if err := h.coreService.DeleteUser(r.Context(), userCtx.UserID, uint(id)); err != nil {
 		log.Printf("Error deleting user: %v", err)
 		if strings.Contains(err.Error(), "not found") {
 			sendError(w, "NotFound", "User not found", http.StatusNotFound, nil)


### PR DESCRIPTION
## Summary

Seven independent, LOW-severity CLI hygiene fixes from round 64 of the security-hardening backlog:

- **#348** — `keyorix anomalies list`/`acknowledge` built a raw `http.DefaultClient.Do(req)` instead of the shared `common.RemoteClient`, duplicating #315's no-timeout hang risk in a fresh file. Both now go through `common.RemoteClient` (also fixes `RemoteClient.Post` to skip decoding when the caller passes a nil `out`, matching `Put`/`Patch`, so a no-body POST like `acknowledge` doesn't panic on `json.Unmarshal(nil)`).
- **#350** — `legal-hold lift` had zero confirmation before re-arming purge/retention/JIT-expiry jobs. Added a `--yes` gate with an interactive "type yes" fallback, matching `dynamic-secret revoke-all --yes`.
- **#351** — `machine revoke` had zero confirmation for a one-way, irreversible credential-kill action. Added a typed-name confirmation (or `--force`), matching `secret delete`'s convention. (Verified: PR #579, which added this same fix, is still open/unmerged — this was genuinely still exploitable on `main`.)
- **#353** — `secret export`'s output file used default `os.Create` permissions (typically 0644) instead of 0600, unlike every sibling writer (`render.go`/`scan.go`/`fix.go`). Now opened explicitly with 0600.
- **#354** — `secret list`/`versions --format json` built output via unescaped `fmt.Printf` string interpolation, letting a crafted secret name break out of the JSON string and inject keys. Both now marshal via `encoding/json`.
- **#356** — `user delete` had no `--by` actor-attribution flag (unlike every sibling lifecycle command), and `core.DeleteUser` didn't accept an actor at all. Added `--by`, threaded an `actorID` through `core.DeleteUser`, which now records a `user.deleted` audit event; the HTTP and gRPC delete-user handlers pass their own authenticated actor instead of nothing.
- **#357** — `user create --password` exposed a new user's initial password via argv/`ps`/shell history. It now resolves via the (warned) `--password` flag, else `KEYORIX_INITIAL_PASSWORD`, else an interactive no-echo prompt — mirroring `keyorix connect`'s established `resolveAPIKey`/`resolveConnectPassword` pattern.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` clean (full suite, no flakes hit)
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues
- [x] `golangci-lint run ./...` — 0 issues
- [x] New regression tests per item: shared-client usage + error surfacing (#348), confirmation-gate accept/decline/force (#350, #351), 0600 file mode (#353), JSON round-trip escaping a hostile secret name (#354), audit-event actor attribution (#356), env-var/flag password resolution priority (#357)