### PR TITLE
fix(audit): cap Description/Diff length and surface secret-access-log write failures (#381/#382)

### DIFF
--- a/internal/core/audit.go
+++ b/internal/core/audit.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"strings"
 	"time"
 	"unicode"
@@ -299,9 +300,11 @@ func sanitizeAuditText(s string) string {
 	}, s)
 }
 
-// writeAccessLog persists a secret_access_logs row.
+// writeAccessLog persists a secret_access_logs row. A failure here is a gap in the
+// secret-access trail, so it is surfaced loudly rather than silently discarded —
+// mirroring emitAudit's handling of a failed audit_events write.
 func (c *KeyorixCore) writeAccessLog(ctx context.Context, secretID uint, accessedBy, action, ip, ua string) {
-	log := &models.SecretAccessLog{
+	entry := &models.SecretAccessLog{
 		SecretNodeID: secretID,
 		AccessedBy:   accessedBy,
 		AccessTime:   time.Now(),
@@ -309,7 +312,10 @@ func (c *KeyorixCore) writeAccessLog(ctx context.Context, secretID uint, accesse
 		IPAddress:    ip,
 		UserAgent:    ua,
 	}
-	_ = c.storage.CreateSecretAccessLog(ctx, log)
+	if err := c.storage.CreateSecretAccessLog(ctx, entry); err != nil {
+		log.Printf("SECURITY: failed to persist secret access log (secret=%d action=%q accessedBy=%q): %v",
+			secretID, action, accessedBy, err)
+	}
 }
 
 // LogSecretRead writes audit_events + secret_access_logs for a secret read.

--- a/internal/core/audit_write_failure_test.go
+++ b/internal/core/audit_write_failure_test.go
@@ -1,0 +1,190 @@
+package core
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log"
+	"strings"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// captureLog redirects the standard logger's output for the duration of fn and
+// returns everything written to it.
+func captureLog(t *testing.T, fn func()) string {
+	t.Helper()
+	var buf bytes.Buffer
+	prevOut := log.Writer()
+	prevFlags := log.Flags()
+	log.SetOutput(&buf)
+	log.SetFlags(0)
+	defer func() {
+		log.SetOutput(prevOut)
+		log.SetFlags(prevFlags)
+	}()
+	fn()
+	return buf.String()
+}
+
+// fakeAuditForwarder records every event handed to Forward, so tests can assert
+// whether emitAudit called it.
+type fakeAuditForwarder struct {
+	forwarded []*models.AuditEvent
+}
+
+func (f *fakeAuditForwarder) Forward(event *models.AuditEvent) {
+	f.forwarded = append(f.forwarded, event)
+}
+
+// --- #382: a failed local audit write must be logged loudly, and must NOT be
+// forwarded to the SIEM (the DB stays authoritative; a never-persisted event
+// must not leak off-box either). ---
+
+func TestEmitAudit_StorageFailure_LogsWarningAndSkipsSIEMForward(t *testing.T) {
+	ms := new(MockStorage)
+	storageErr := errors.New("disk full")
+	ms.On("LogAuditEvent", mock.Anything, mock.Anything).Return(storageErr)
+
+	fwd := &fakeAuditForwarder{}
+	c := &KeyorixCore{storage: ms, auditForwarder: fwd, auditStream: newAuditBroker()}
+
+	event := &models.AuditEvent{EventType: "secret.read", Description: "User alice read secret db-password"}
+
+	logged := captureLog(t, func() {
+		c.emitAudit(context.Background(), event)
+	})
+
+	assert.Contains(t, logged, "SECURITY", "a failed audit write must be logged loudly, not silently swallowed")
+	assert.Contains(t, logged, "secret.read")
+	assert.Empty(t, fwd.forwarded, "must not forward to SIEM when the local write failed — DB stays authoritative")
+	ms.AssertCalled(t, "LogAuditEvent", mock.Anything, mock.Anything)
+}
+
+func TestEmitAudit_StorageSuccess_ForwardsToSIEMAndDoesNotWarn(t *testing.T) {
+	ms := new(MockStorage)
+	ms.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
+
+	fwd := &fakeAuditForwarder{}
+	c := &KeyorixCore{storage: ms, auditForwarder: fwd, auditStream: newAuditBroker()}
+
+	event := &models.AuditEvent{EventType: "secret.read"}
+
+	logged := captureLog(t, func() {
+		c.emitAudit(context.Background(), event)
+	})
+
+	assert.NotContains(t, logged, "SECURITY", "a successful audit write must not emit a failure warning")
+	require.Len(t, fwd.forwarded, 1, "a durably persisted event must still reach the SIEM")
+	assert.Same(t, event, fwd.forwarded[0])
+}
+
+func TestWriteAccessLog_StorageFailure_LogsWarning(t *testing.T) {
+	ms := new(MockStorage)
+	storageErr := errors.New("connection exhausted")
+	ms.On("CreateSecretAccessLog", mock.Anything, mock.Anything).Return(storageErr)
+
+	c := &KeyorixCore{storage: ms}
+
+	logged := captureLog(t, func() {
+		c.writeAccessLog(context.Background(), 42, "alice", "read", "10.0.0.1", "curl/8")
+	})
+
+	assert.Contains(t, logged, "SECURITY", "a failed access-log write must be logged loudly, not silently swallowed")
+	ms.AssertCalled(t, "CreateSecretAccessLog", mock.Anything, mock.Anything)
+}
+
+func TestWriteAccessLog_StorageSuccess_DoesNotWarn(t *testing.T) {
+	ms := new(MockStorage)
+	ms.On("CreateSecretAccessLog", mock.Anything, mock.Anything).Return(nil)
+
+	c := &KeyorixCore{storage: ms}
+
+	logged := captureLog(t, func() {
+		c.writeAccessLog(context.Background(), 42, "alice", "read", "10.0.0.1", "curl/8")
+	})
+
+	assert.NotContains(t, logged, "SECURITY")
+}
+
+// --- #381: Description/Diff must be capped, independent of secret_name_policy. ---
+
+func TestEmitAudit_TruncatesOversizedDescriptionAndDiff(t *testing.T) {
+	ms := new(MockStorage)
+	var persisted *models.AuditEvent
+	ms.On("LogAuditEvent", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			persisted = args.Get(1).(*models.AuditEvent)
+		}).
+		Return(nil)
+
+	c := &KeyorixCore{storage: ms, auditStream: newAuditBroker()}
+
+	// Simulate an attacker-chosen secret name (no length cap unless
+	// secret_name_policy is configured) flowing into a Description, and an
+	// oversized Diff.
+	hugeName := strings.Repeat("A", 10*1024*1024) // 10 MiB, matches the global body-size cap
+	event := &models.AuditEvent{
+		EventType:   "secret.read",
+		Description: "User alice read secret " + hugeName,
+		Diff:        strings.Repeat("d", 100*1024),
+	}
+
+	c.emitAudit(context.Background(), event)
+
+	require.NotNil(t, persisted)
+	assert.LessOrEqual(t, len(persisted.Description), auditDescriptionMaxLen+len(auditTruncatedMarker))
+	assert.LessOrEqual(t, len(persisted.Diff), auditDiffMaxLen+len(auditTruncatedMarker))
+	assert.True(t, strings.HasSuffix(persisted.Description, auditTruncatedMarker), "truncated Description must carry the marker")
+	assert.True(t, strings.HasSuffix(persisted.Diff, auditTruncatedMarker), "truncated Diff must carry the marker")
+	// The event handed to the caller is mutated in place too (same pointer),
+	// so nothing downstream (e.g. a SIEM forward) can observe the unbounded value.
+	assert.True(t, strings.HasSuffix(event.Description, auditTruncatedMarker))
+}
+
+func TestEmitAudit_NormalLengthDescriptionAndDiffUnaffected(t *testing.T) {
+	ms := new(MockStorage)
+	var persisted *models.AuditEvent
+	ms.On("LogAuditEvent", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			persisted = args.Get(1).(*models.AuditEvent)
+		}).
+		Return(nil)
+
+	c := &KeyorixCore{storage: ms, auditStream: newAuditBroker()}
+
+	desc := "User alice read secret db-password"
+	diff := `{"name":{"old":"db-password","new":"db-password-2"}}`
+	event := &models.AuditEvent{
+		EventType:   "secret.updated",
+		Description: desc,
+		Diff:        diff,
+	}
+
+	c.emitAudit(context.Background(), event)
+
+	require.NotNil(t, persisted)
+	assert.Equal(t, desc, persisted.Description, "a normal-length description must pass through unchanged")
+	assert.Equal(t, diff, persisted.Diff, "a normal-length diff must pass through unchanged")
+}
+
+func TestTruncateAuditField(t *testing.T) {
+	assert.Equal(t, "short", truncateAuditField("short", 100))
+
+	long := strings.Repeat("x", 50)
+	got := truncateAuditField(long, 10)
+	assert.Equal(t, 10+len(auditTruncatedMarker), len(got))
+	assert.True(t, strings.HasPrefix(got, strings.Repeat("x", 10)))
+	assert.True(t, strings.HasSuffix(got, auditTruncatedMarker))
+
+	// Multi-byte rune sitting exactly on the cut boundary must not be split
+	// into an invalid UTF-8 sequence.
+	multibyte := strings.Repeat("a", 9) + "€" // '€' is 3 bytes (U+20AC)
+	truncatedMB := truncateAuditField(multibyte, 10)
+	assert.True(t, strings.HasPrefix(truncatedMB, strings.Repeat("a", 9)))
+	assert.False(t, strings.Contains(truncatedMB[:len(truncatedMB)-len(auditTruncatedMarker)], "€"))
+}

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	"github.com/go-webauthn/webauthn/webauthn"
 	"github.com/keyorixhq/keyorix/internal/connect"
@@ -255,9 +256,48 @@ func (c *KeyorixCore) AuditLicenseState(ctx context.Context) {
 	})
 }
 
+// Audit field length caps (#381). Neither models.AuditEvent.Description nor .Diff
+// carries a DB-level size limit, and secret/project/role names feeding into a
+// Description have no length cap unless an operator opts into secret_name_policy
+// (off by default) — so an attacker-chosen name could otherwise blow up every
+// audit row that mentions it, and (since the audit-chain writer is a single
+// process-wide serialized writer) degrade audit throughput for every OTHER write
+// in the system. These ceilings comfortably fit any Description/Diff this
+// codebase's own call sites actually generate (short templated sentences and
+// small structured before/after JSON), so legitimate audit content is never
+// affected.
+const (
+	auditDescriptionMaxLen = 4096 // ~4 KiB
+	auditDiffMaxLen        = 8192 // ~8 KiB
+)
+
+// auditTruncatedMarker is appended to a field truncated by truncateAuditField.
+const auditTruncatedMarker = "...[truncated]"
+
+// truncateAuditField caps s at maxLen bytes, appending auditTruncatedMarker when
+// truncation occurs. Audit writes must never fail (or reject) the underlying
+// business operation just because a caller-supplied description/diff got too
+// long, so this truncates rather than erroring. The cut point is walked back to
+// a valid UTF-8 boundary so truncation never produces an invalid string.
+func truncateAuditField(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	cut := maxLen
+	for cut > 0 && !utf8.ValidString(s[:cut]) {
+		cut--
+	}
+	return s[:cut] + auditTruncatedMarker
+}
+
 // emitAudit persists an audit event and forwards it to the configured sink.
-// All core audit writers funnel through here so SIEM forwarding is uniform.
+// All core audit writers funnel through here so SIEM forwarding is uniform —
+// which also makes it the single choke point to cap Description/Diff length
+// (#381), independent of which helper (writeAuditEvent*, writeImpersonationEvent,
+// AuditLicenseState, ...) produced the event.
 func (c *KeyorixCore) emitAudit(ctx context.Context, event *models.AuditEvent) {
+	event.Description = truncateAuditField(event.Description, auditDescriptionMaxLen)
+	event.Diff = truncateAuditField(event.Diff, auditDiffMaxLen)
 	if err := c.storage.LogAuditEvent(ctx, event); err != nil {
 		// A failed chain-write is an audit gap that VerifyAuditChain cannot detect — a
 		// never-written event leaves no hole. Surface it loudly instead of swallowing,


### PR DESCRIPTION
## Summary

Fixes two related findings in the shared audit-writing infrastructure (`internal/core/audit.go` / `internal/core/service.go`) from ROUND 66 of the security-hardening backlog.

**#382 HIGH — silent audit-write failures / unconditional SIEM forward on failure.** Re-verified against current `main`: `emitAudit` (`internal/core/service.go`) had *already* been fixed in an earlier merge — it logs `"SECURITY: failed to persist audit event ..."` and returns before calling `c.auditForwarder.Forward(event)`, so a failed local write is never mirrored to an external SIEM (DB stays authoritative, per the design comment). What was still open: `writeAccessLog` (`internal/core/audit.go`) discarded `CreateSecretAccessLog`'s error with `_ = ...`, giving zero operator-visible signal when a `secret_access_logs` row failed to persist. Fixed by logging the same `"SECURITY:"`-prefixed warning there, mirroring `emitAudit`'s handling.

Design decision on the SIEM-forwarding question: kept the existing (already-correct) behavior — **do not forward to SIEM when the local write failed**. This is the safer default for a tool whose SIEM-forwarding design explicitly documents "DB stays authoritative," and there's no evidence in the codebase of an intentional "SIEM as last-resort durability path" design.

**#381 MEDIUM — no length cap on `Description`/`Diff` before persisting.** Confirmed still open on `main`. Added a length cap enforced centrally in `emitAudit` — the single funnel every audit writer (`writeAuditEvent`/`writeAuditEventFull`/`writeAuditEventDiff`, `writeImpersonationEvent`, `AuditLicenseState`, ...) already goes through, per its own doc comment. `Description` is capped at ~4 KiB and `Diff` at ~8 KiB, truncated with a `"...[truncated]"` marker rather than rejected (audit writes must never fail the underlying business operation). These ceilings comfortably fit every `Description`/`Diff` this codebase's own call sites generate (short templated sentences, small structured before/after JSON) — verified by inspection of all `writeAuditEventDiff`/RBAC-audit call sites. Centralizing in `emitAudit` (rather than duplicating the cap in the three named helpers) closes the gap for every current and future audit-writing call site, not just those three.

No `gorm:"size"` DB-level tag was added — this codebase doesn't use that convention anywhere in `models.go`, and the truncation at the shared choke point already prevents an oversized value from ever reaching storage.

## Test plan
- [x] New regression tests in `internal/core/audit_write_failure_test.go`:
  - `TestEmitAudit_StorageFailure_LogsWarningAndSkipsSIEMForward` / `TestEmitAudit_StorageSuccess_ForwardsToSIEMAndDoesNotWarn`
  - `TestWriteAccessLog_StorageFailure_LogsWarning` / `TestWriteAccessLog_StorageSuccess_DoesNotWarn`
  - `TestEmitAudit_TruncatesOversizedDescriptionAndDiff` (10 MiB attacker-chosen name / 100 KiB diff → truncated with marker) / `TestEmitAudit_NormalLengthDescriptionAndDiffUnaffected`
  - `TestTruncateAuditField` (unit coverage incl. multi-byte UTF-8 boundary safety)
- [x] `go build ./...` clean
- [x] `go test ./...` full suite clean (no flakes hit)
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues
- [x] `golangci-lint run ./...` — 0 issues
- [x] `GOWORK=off go build -C operator ./...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)