### PR TITLE
fix(notifications): stop broadcasting per-user events to chat/webhook (#391 HIGH)

### DIFF
--- a/internal/core/notification_dispatch_test.go
+++ b/internal/core/notification_dispatch_test.go
@@ -21,7 +21,7 @@ func TestNotify_DispatchesToSinkWithResolvedEmail(t *testing.T) {
 
 	c := NewKeyorixCore(store)
 	sink := &fakeSink{}
-	c.SetNotificationSink(sink)
+	c.SetRecipientNotificationSink(sink)
 
 	pid := uint(3)
 	c.notify(context.Background(), 7, NotificationAccessApproved, "Approved", "Your request was approved", &pid, "/projects/3")
@@ -47,7 +47,51 @@ func TestNotify_NoSink_SkipsDispatchAndEmailLookup(t *testing.T) {
 func TestNotify_ZeroUser_DoesNothing(t *testing.T) {
 	store := new(MockStorage)
 	c := NewKeyorixCore(store)
-	c.SetNotificationSink(&fakeSink{})
+	c.SetRecipientNotificationSink(&fakeSink{})
 	c.notify(context.Background(), 0, "x", "t", "m", nil, "")
 	store.AssertNotCalled(t, "CreateNotification", mock.Anything, mock.Anything)
+}
+
+// #391: a per-user/per-project notification must NEVER reach the deployment-wide
+// broadcast sink (the one Slack/Teams/webhook are wired into) — only the
+// recipient-addressable sink (email). Before the fix, notify()/dispatchNotification
+// handed every event straight to the single deployment-wide notificationSink,
+// broadcasting e.g. "secret shared with you" to an entire Slack channel regardless
+// of project membership or secret access.
+func TestNotify_NeverReachesBroadcastSink(t *testing.T) {
+	store := new(MockStorage)
+	store.On("CreateNotification", mock.Anything, mock.Anything).Return(&models.Notification{ID: 1}, nil)
+	store.On("GetUser", mock.Anything, uint(7)).Return(&models.User{ID: 7, Email: "ada@x.io"}, nil)
+
+	c := NewKeyorixCore(store)
+	broadcast := &fakeSink{} // stands in for the Slack/Teams/webhook multi-sink
+	recipient := &fakeSink{} // stands in for the email-only sink
+	c.SetNotificationSink(broadcast)
+	c.SetRecipientNotificationSink(recipient)
+
+	pid := uint(3)
+	c.notify(context.Background(), 7, NotificationSecretShared, "Secret shared with you",
+		`You were granted read access to secret "prod-db-password".`, &pid, "/secrets/1")
+
+	assert.Empty(t, broadcast.events, "a per-user event must never reach the deployment-wide broadcast sink")
+	require.Len(t, recipient.events, 1, "it must still reach the recipient-addressable (email) sink")
+	assert.Equal(t, NotificationSecretShared, recipient.events[0].Type)
+}
+
+// SendComplianceDigest and notifyRotationFailures are the deliberately-deployment-
+// wide, aggregate broadcasts (#391) — they must keep reaching the broadcast sink
+// (Slack/Teams/webhook), never the per-user recipient sink (which they don't
+// address to any specific user).
+func TestSendComplianceDigest_UsesBroadcastSinkNotRecipientSink(t *testing.T) {
+	c, _, _ := newEvidenceExportCore(t) // real store, empty deployment
+	broadcast := &fakeSink{}
+	recipient := &fakeSink{}
+	c.SetNotificationSink(broadcast)
+	c.SetRecipientNotificationSink(recipient)
+
+	sent, err := c.SendComplianceDigest(context.Background())
+	require.NoError(t, err)
+	assert.True(t, sent)
+	assert.Len(t, broadcast.events, 1, "the compliance digest is deployment-wide and belongs on the broadcast sink")
+	assert.Empty(t, recipient.events, "the compliance digest is not addressed to any specific user")
 }

--- a/internal/core/notifications.go
+++ b/internal/core/notifications.go
@@ -3,8 +3,20 @@
 // Notifications are addressed to a single user and surfaced via the header bell.
 // Emission is best-effort: a delivery failure never blocks the action that
 // triggered it (same contract as audit emission). In addition to the in-app row,
-// notify() fans each event out to a configured external channel (email/webhook)
-// when a NotificationSink is wired.
+// notify() fans each event out to a configured external channel when a
+// recipientNotificationSink is wired.
+//
+// #391: every event this file emits (secret shared, share revoked, ownership
+// transferred, access requested, anomaly alert, break-glass activation, …) is
+// addressed to exactly one user — the recipient this file already computed. It is
+// dispatched to recipientNotificationSink, NOT the deployment-wide broadcast
+// notificationSink (used elsewhere for the compliance digest / rotation-failure
+// summaries): chat (Slack/Teams) and generic webhook channels are one fixed
+// destination an operator configures, with no per-user identity mapping to target a
+// specific recipient, so handing them a per-user event would broadcast it to
+// everyone with channel visibility regardless of project membership or secret
+// access. Only recipient-addressable channels (email) are wired into
+// recipientNotificationSink; see SetRecipientNotificationSink and server/main.go.
 package core
 
 import (
@@ -55,11 +67,15 @@ func (c *KeyorixCore) notify(ctx context.Context, userID uint, nType, title, mes
 	c.dispatchNotification(ctx, userID, nType, title, message, projectID, link)
 }
 
-// dispatchNotification fans a notification out to the configured external channel
-// (email/webhook), resolving the recipient's email best-effort. A no-op when no
-// sink is wired; the sink itself is non-blocking, so this never delays the caller.
+// dispatchNotification fans a per-user notification out to the recipient-addressable
+// external channel (email), resolving the recipient's email best-effort. A no-op
+// when no such sink is wired; the sink itself is non-blocking, so this never delays
+// the caller.
+//
+// This deliberately uses recipientNotificationSink, not the deployment-wide
+// notificationSink — see the package comment and #391.
 func (c *KeyorixCore) dispatchNotification(ctx context.Context, userID uint, nType, title, message string, projectID *uint, link string) {
-	if c.notificationSink == nil {
+	if c.recipientNotificationSink == nil {
 		return
 	}
 	ev := NotificationEvent{
@@ -73,7 +89,7 @@ func (c *KeyorixCore) dispatchNotification(ctx context.Context, userID uint, nTy
 	if u, err := c.storage.GetUser(ctx, userID); err == nil && u != nil {
 		ev.Email = u.Email
 	}
-	c.notificationSink.Deliver(ev)
+	c.recipientNotificationSink.Deliver(ev)
 }
 
 // projectLabel returns a human label for a project ("Payments" or "#3").

--- a/internal/core/rotation_executor.go
+++ b/internal/core/rotation_executor.go
@@ -24,12 +24,18 @@ import (
 // EventAutoRotationFailures is audited once per run when one or more secrets failed.
 const EventAutoRotationFailures = "rotation.failures_alerted"
 
-// notifyRotationFailures broadcasts a single summary of the run's rotation failures to
-// the configured notification channel (Slack/Teams/webhook) — a silently-failed
-// credential rotation is a security event operators must see. No-op when no sink is
-// wired or nothing failed; the sink is non-blocking. Also audited.
-func (c *KeyorixCore) notifyRotationFailures(ctx context.Context, failed map[uint]string) {
-	if len(failed) == 0 {
+// notifyRotationFailures broadcasts a single summary of ONE project's rotation
+// failures to the configured deployment-wide notification channel (Slack/Teams/
+// webhook/email) — a silently-failed credential rotation is a security event
+// operators must see. Scoped to a single project: the caller (RunAutoRotation) calls
+// this once per project rather than once per run, so a broadcast never bundles
+// unrelated projects' secret names/failure reasons into one message (#391) — a
+// deployment-wide channel is still an appropriate destination for this event (unlike
+// the per-user events in notifications.go), it just must not cross project
+// boundaries within a single message. No-op when nothing failed for this project;
+// the sink is non-blocking.
+func (c *KeyorixCore) notifyRotationFailures(ctx context.Context, projectID uint, failed map[uint]string) {
+	if len(failed) == 0 || c.notificationSink == nil {
 		return
 	}
 	lines := make([]string, 0, len(failed))
@@ -37,17 +43,13 @@ func (c *KeyorixCore) notifyRotationFailures(ctx context.Context, failed map[uin
 		lines = append(lines, "• "+msg)
 	}
 	sort.Strings(lines) // stable, deterministic ordering
-	sysCtx := WithActorType(ctx, ActorTypeSystem)
-	c.writeAuditEvent(sysCtx, EventAutoRotationFailures, nil, nil,
-		fmt.Sprintf("auto-rotation: %d secret(s) failed to rotate", len(failed)))
-	if c.notificationSink == nil {
-		return
-	}
+	pid := projectID
 	c.notificationSink.Deliver(NotificationEvent{
-		Type:    "rotation.failed",
-		Title:   fmt.Sprintf("Auto-rotation: %d secret(s) failed to rotate", len(failed)),
-		Message: "The following secrets could not be auto-rotated:\n" + strings.Join(lines, "\n"),
-		Link:    "/secrets",
+		Type:      "rotation.failed",
+		Title:     fmt.Sprintf("Auto-rotation: %d secret(s) failed to rotate in %s", len(failed), c.projectLabel(ctx, projectID)),
+		Message:   "The following secrets could not be auto-rotated:\n" + strings.Join(lines, "\n"),
+		ProjectID: &pid,
+		Link:      fmt.Sprintf("/projects/%d/secrets", projectID),
 	})
 }
 
@@ -214,9 +216,12 @@ func (c *KeyorixCore) RunAutoRotation(ctx context.Context) (int, error) {
 
 	// Phase 3 — rotate each project's due secrets in dependency-safe wave order.
 	rotated := 0
-	// failed records why each non-rotated secret did not rotate (a genuine failure or a
-	// dependency-driven deferral); surfaced to operators via notifyRotationFailures.
-	failed := map[uint]string{}
+	// totalFailed accumulates every project's failures for the run-level audit summary
+	// only (a bare count, no secret names/reasons — safe to bundle). The per-project
+	// broadcast notification below uses a fresh, project-scoped map instead, so a
+	// Slack/Teams/webhook message never bundles unrelated projects' secret names or
+	// failure reasons together (#391).
+	totalFailed := 0
 	for _, pid := range projectOrder {
 		ids := byProject[pid]
 		candidateSet := make(map[uint]bool, len(ids))
@@ -251,6 +256,11 @@ func (c *KeyorixCore) RunAutoRotation(ctx context.Context) (int, error) {
 			}
 		}
 
+		// failed records why each non-rotated secret in THIS project did not rotate (a
+		// genuine failure or a dependency-driven deferral). Scoped to this project only
+		// (see totalFailed above / #391) and broadcast right after this project finishes,
+		// before moving on to the next project's map.
+		failed := map[uint]string{}
 		blocked := map[uint]bool{} // due secrets that did not rotate this run (failed or deferred)
 		for _, wave := range waves {
 			for _, id := range wave {
@@ -276,9 +286,15 @@ func (c *KeyorixCore) RunAutoRotation(ctx context.Context) (int, error) {
 				}
 			}
 		}
+		totalFailed += len(failed)
+		c.notifyRotationFailures(ctx, pid, failed)
 	}
 
-	c.notifyRotationFailures(ctx, failed)
+	if totalFailed > 0 {
+		sysCtx := WithActorType(ctx, ActorTypeSystem)
+		c.writeAuditEvent(sysCtx, EventAutoRotationFailures, nil, nil,
+			fmt.Sprintf("auto-rotation: %d secret(s) failed to rotate", totalFailed))
+	}
 	return rotated, nil
 }
 

--- a/internal/core/rotation_executor_test.go
+++ b/internal/core/rotation_executor_test.go
@@ -405,6 +405,80 @@ func TestRunAutoRotation_NoFailuresNoNotify(t *testing.T) {
 	assert.Empty(t, sink.events)
 }
 
+// #391 bonus fix: failures in different projects must broadcast as separate,
+// project-scoped notifications — never bundled into one cross-project message.
+func TestRunAutoRotation_FailuresNotBundledAcrossProjects(t *testing.T) {
+	c, db, fixed := rotationExecCore(t)
+	require.NoError(t, db.Create(&models.Project{ID: 2, Name: "proj-2"}).Error)
+	require.NoError(t, db.Create(&models.Environment{ID: 2, ProjectID: 2, Name: "prod"}).Error)
+
+	pid1, pid2 := uint(1), uint(2)
+	require.NoError(t, db.Create(&models.RotationPolicy{
+		ID: 1, Name: "30-day", Scope: "project", ProjectID: &pid1, IntervalDays: 30, IsActive: true, CreatedBy: "admin",
+	}).Error)
+	require.NoError(t, db.Create(&models.RotationPolicy{
+		ID: 2, Name: "30-day", Scope: "project", ProjectID: &pid2, IntervalDays: 30, IsActive: true, CreatedBy: "admin",
+	}).Error)
+
+	failA := &fakeExecutor{name: "backend-a", err: errors.New("connection refused")}
+	failB := &fakeExecutor{name: "backend-b", err: errors.New("auth denied")}
+	c.SetRotationManager(rotation.NewManager([]rotation.Executor{failA, failB}))
+
+	// Project 1's secret fails via backend-a; project 2's (unrelated) secret fails via
+	// backend-b. Their names/reasons must never land in the same broadcast message.
+	require.NoError(t, db.Create(&models.SecretNode{
+		ID: 1, Name: "proj1-db-password", ProjectID: 1, EnvironmentID: 1, IsSecret: true, Status: "active",
+		AutoRotate: true, RotationBackend: "backend-a", RotationRef: "ref-a",
+		LastRotatedAt: ptrTime(fixed.Add(-60 * 24 * time.Hour)), CreatedAt: fixed.Add(-60 * 24 * time.Hour),
+	}).Error)
+	require.NoError(t, db.Create(&models.SecretVersion{
+		SecretNodeID: 1, VersionNumber: 1, EncryptedValue: []byte("orig1"), EncryptionMetadata: []byte("{}"), CreatedAt: fixed.Add(-60 * 24 * time.Hour),
+	}).Error)
+	require.NoError(t, db.Create(&models.SecretNode{
+		ID: 2, Name: "proj2-api-key", ProjectID: 2, EnvironmentID: 2, IsSecret: true, Status: "active",
+		AutoRotate: true, RotationBackend: "backend-b", RotationRef: "ref-b",
+		LastRotatedAt: ptrTime(fixed.Add(-60 * 24 * time.Hour)), CreatedAt: fixed.Add(-60 * 24 * time.Hour),
+	}).Error)
+	require.NoError(t, db.Create(&models.SecretVersion{
+		SecretNodeID: 2, VersionNumber: 1, EncryptedValue: []byte("orig2"), EncryptionMetadata: []byte("{}"), CreatedAt: fixed.Add(-60 * 24 * time.Hour),
+	}).Error)
+
+	sink := &fakeSink{}
+	c.SetNotificationSink(sink)
+
+	_, err := c.RunAutoRotation(context.Background())
+	require.NoError(t, err)
+
+	require.Len(t, sink.events, 2, "one broadcast per project, never a single bundled message")
+	for _, ev := range sink.events {
+		assert.Equal(t, "rotation.failed", ev.Type)
+		require.NotNil(t, ev.ProjectID)
+		switch *ev.ProjectID {
+		case 1:
+			assert.Contains(t, ev.Message, "proj1-db-password")
+			assert.Contains(t, ev.Message, "connection refused")
+			assert.NotContains(t, ev.Message, "proj2-api-key", "project 1's broadcast must not name project 2's secret")
+			assert.NotContains(t, ev.Message, "auth denied", "project 1's broadcast must not carry project 2's failure reason")
+		case 2:
+			assert.Contains(t, ev.Message, "proj2-api-key")
+			assert.Contains(t, ev.Message, "auth denied")
+			assert.NotContains(t, ev.Message, "proj1-db-password", "project 2's broadcast must not name project 1's secret")
+			assert.NotContains(t, ev.Message, "connection refused", "project 2's broadcast must not carry project 1's failure reason")
+		default:
+			t.Fatalf("unexpected project ID %d", *ev.ProjectID)
+		}
+	}
+
+	// The audit trail still records one run-level summary (aggregate count only — no
+	// secret names/reasons, so bundling it is not itself a leak).
+	var auditEvents []models.AuditEvent
+	require.NoError(t, db.Where("event_type = ?", EventAutoRotationFailures).Find(&auditEvents).Error)
+	require.Len(t, auditEvents, 1)
+	assert.Contains(t, auditEvents[0].Description, "2 secret")
+}
+
+func ptrTime(t time.Time) *time.Time { return &t }
+
 // rotationDriftStore wraps LocalStorage and fails UpdateSecret, so RotateSecret errors AFTER
 // the backend executor has already applied the new credential upstream — the split-brain /
 // drift case.

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -111,9 +111,28 @@ type KeyorixCore struct {
 	// (gRPC StreamAuditLogs) the instant an event is written, replacing fixed-interval
 	// DB polling. Always non-nil (set in the constructors).
 	auditStream *auditBroker
-	// notificationSink fans each in-app notification out to an external channel
-	// (email/webhook). nil = in-app only. Set from config via SetNotificationSink.
+	// notificationSink broadcasts a deployment-wide, aggregate notification (the
+	// compliance digest, an auto-rotation-failure summary) to every enabled external
+	// channel, including Slack/Teams/webhook. nil = no channel configured. Set from
+	// config via SetNotificationSink. Deliberately NOT used for per-user/per-project
+	// events (see recipientNotificationSink) — see #391.
 	notificationSink NotificationSink
+	// recipientNotificationSink fans a per-user/per-project notification (secret
+	// shared, share revoked, ownership transferred, access requested, anomaly alert,
+	// break-glass activation, …) out to external channels that can actually address a
+	// single recipient — currently just email. nil = in-app only.
+	//
+	// #391: chat (Slack/Teams) and generic webhook channels are, by design, ONE fixed
+	// deployment-wide destination an operator configures (there is no per-user chat-
+	// identity mapping in this codebase to DM a specific Slack user). Handing a
+	// per-user event straight to those channels — as the old single notificationSink
+	// did — broadcasts it to every member of that channel regardless of project
+	// membership or secret access, defeating every recipient-scoping computation this
+	// package does for the in-app row. So per-user events are routed ONLY to
+	// recipient-addressable channels (email, which already drops any event with no
+	// resolved address) and never to chat/webhook. Set from config via
+	// SetRecipientNotificationSink.
+	recipientNotificationSink NotificationSink
 	// connectManager proxies read-through federation to external secret stores
 	// (ADR-043). nil = Keyorix Connect disabled. Set via SetConnectManager.
 	connectManager *connect.Manager
@@ -297,10 +316,21 @@ type NotificationSink interface {
 	Deliver(ev NotificationEvent)
 }
 
-// SetNotificationSink wires an external notification sink. The server calls this at
-// startup when the install configures a notifications channel. nil = in-app only.
+// SetNotificationSink wires the broadcast (deployment-wide, aggregate) notification
+// sink used by SendComplianceDigest and notifyRotationFailures — typically every
+// enabled channel (email/Slack/Teams/webhook). The server calls this at startup when
+// the install configures a notifications channel. nil = no channel configured.
 func (c *KeyorixCore) SetNotificationSink(s NotificationSink) {
 	c.notificationSink = s
+}
+
+// SetRecipientNotificationSink wires the sink used for per-user/per-project
+// notifications (see recipientNotificationSink). The server calls this at startup
+// with ONLY the recipient-addressable channels it configured (currently email) —
+// never chat/webhook, which have no per-user identity mapping (#391). nil = in-app
+// only.
+func (c *KeyorixCore) SetRecipientNotificationSink(s NotificationSink) {
+	c.recipientNotificationSink = s
 }
 
 // NewKeyorixCore creates a new instance of the core business logic.

--- a/server/main.go
+++ b/server/main.go
@@ -407,10 +407,23 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 		log.Printf("SIEM audit forwarding enabled (provider=%s)", sc.Provider)
 	}
 
-	// Wire external notification channels if configured. Each in-app notification is
-	// fanned out to every enabled channel (best-effort, async); with none enabled it
-	// stays in-app only.
-	var notifySinks []core.NotificationSink
+	// Wire external notification channels if configured.
+	//
+	// #391: two distinct fan-out sets are built, not one. broadcastSinks (every
+	// enabled channel) backs the deployment-wide, aggregate notifications
+	// (compliance digest, auto-rotation-failure summary) — those are genuinely
+	// relevant to the whole deployment's ops audience. recipientSinks (only
+	// channels that can address a single user — currently email) backs every
+	// per-user/per-project notification (secret shared, share revoked, ownership
+	// transferred, access requested, anomaly alert, break-glass activation, …).
+	// Slack/Teams/webhook are deliberately excluded from recipientSinks: they are
+	// one fixed destination an operator configures, with no per-user chat-identity
+	// mapping in this codebase to target a specific recipient, so routing a
+	// per-user event there would broadcast it to everyone with channel visibility
+	// regardless of project membership or secret access. See
+	// internal/core/notifications.go and internal/core/service.go.
+	var broadcastSinks []core.NotificationSink
+	var recipientSinks []core.NotificationSink
 	if wc := cfg.Notifications.Webhook; wc.Enabled {
 		sink, werr := notifychan.NewWebhook(notifychan.WebhookConfig{
 			Endpoint:           wc.Endpoint,
@@ -421,7 +434,7 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 		if werr != nil {
 			return nil, nil, fmt.Errorf("failed to init notification webhook channel: %w", werr)
 		}
-		notifySinks = append(notifySinks, sink)
+		broadcastSinks = append(broadcastSinks, sink)
 		log.Printf("Notification webhook channel enabled (endpoint=%s)", wc.Endpoint)
 	}
 	if ec := cfg.Notifications.Email; ec.Enabled {
@@ -436,7 +449,8 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 		if eerr != nil {
 			return nil, nil, fmt.Errorf("failed to init notification email channel: %w", eerr)
 		}
-		notifySinks = append(notifySinks, sink)
+		broadcastSinks = append(broadcastSinks, sink)
+		recipientSinks = append(recipientSinks, sink)
 		log.Printf("Notification email channel enabled (host=%s)", ec.Host)
 	}
 	if cfg.Notifications.Slack.Enabled {
@@ -444,7 +458,7 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 		if serr != nil {
 			return nil, nil, fmt.Errorf("failed to init Slack notification channel: %w", serr)
 		}
-		notifySinks = append(notifySinks, sink)
+		broadcastSinks = append(broadcastSinks, sink)
 		log.Printf("Notification Slack channel enabled")
 	}
 	if cfg.Notifications.Teams.Enabled {
@@ -452,11 +466,14 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 		if terr != nil {
 			return nil, nil, fmt.Errorf("failed to init Teams notification channel: %w", terr)
 		}
-		notifySinks = append(notifySinks, sink)
+		broadcastSinks = append(broadcastSinks, sink)
 		log.Printf("Notification Teams channel enabled")
 	}
-	if sink := notifychan.NewMulti(notifySinks...); sink != nil {
+	if sink := notifychan.NewMulti(broadcastSinks...); sink != nil {
 		coreService.SetNotificationSink(sink)
+	}
+	if sink := notifychan.NewMulti(recipientSinks...); sink != nil {
+		coreService.SetRecipientNotificationSink(sink)
 	}
 
 	// Wire Keyorix Connect (ADR-043) read-through federation if enabled.


### PR DESCRIPTION
## Summary

Fixes #391 HIGH: every per-user/per-project notification (secret shared, share
revoked, ownership transferred, access requested, anomaly alert, break-glass
activation) was broadcast unfiltered to the single deployment-wide
notification sink once Slack/Teams/webhook was configured, bypassing every
recipient-scoping computation `internal/core/notifications.go` implements for
the in-app row. `ChatSink`/`WebhookSink` ignore `ev.Email`/`ev.UserID`/
`ev.ProjectID` entirely and POST every event to the one fixed destination —
only `EmailSink` correctly addresses per-recipient.

Also fixes the related bundling bug: `notifyRotationFailures` accumulated
failed-rotation secrets across *every* project in a run before a single
broadcast, mixing unrelated projects' secret names/failure reasons together.

## Design decision

Two directions were considered (see code comments in `internal/core/service.go`
and `internal/core/notifications.go` for the in-code rationale):

- (a) Make `ChatSink`/`WebhookSink` respect per-recipient scoping like
  `EmailSink` — doesn't map cleanly: Slack/Teams/webhook channels are one
  fixed destination an operator configures, and this codebase has no
  per-user chat-identity mapping to DM a specific person.
- (b) **Chosen.** Change *which* events are eligible for chat/webhook
  broadcast. `KeyorixCore` now has two sink fields:
  - `notificationSink` — deployment-wide, aggregate broadcasts only
    (compliance digest, auto-rotation-failure summary). Wired to every
    enabled channel (email/Slack/Teams/webhook), unchanged from before.
  - `recipientNotificationSink` (new) — every per-user/per-project event.
    Wired at startup to *only* recipient-addressable channels (currently
    email), never chat/webhook.

`dispatchNotification` (called from `notify()`, the single choke point every
per-user notification in that file goes through) now uses
`recipientNotificationSink` exclusively. `server/main.go` builds two distinct
sink sets (`broadcastSinks` / `recipientSinks`) instead of one, and wires them
via `SetNotificationSink` / `SetRecipientNotificationSink`.

`notifyRotationFailures` (`internal/core/rotation_executor.go`) is now called
once per project instead of once per run, so a Slack/Teams/webhook message
never bundles unrelated projects' secret names/reasons; the run-level audit
event still reports one aggregate count (no secret names — not itself a
leak).

`SendComplianceDigest` is unchanged (already a deliberate, aggregate-only
broadcast via a direct `Deliver` call, out of scope per the backlog note).

## Test plan

- [x] `TestNotify_NeverReachesBroadcastSink` — a per-user event (secret
      shared) reaches only the recipient sink, never the broadcast sink.
- [x] `TestSendComplianceDigest_UsesBroadcastSinkNotRecipientSink` — the
      compliance digest still reaches the broadcast sink, not the recipient
      sink.
- [x] `TestRunAutoRotation_FailuresNotBundledAcrossProjects` — two projects'
      rotation failures broadcast as two separate, project-scoped messages
      with no cross-project leakage.
- [x] Existing notification/rotation/compliance-digest tests updated and
      passing.
- [x] `go build ./...`, `go test ./...` (full suite, `-count=1`) clean.
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues.
- [x] `golangci-lint run ./...` — 0 issues.
- [x] `GOWORK=off go build -C operator ./...` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)