### PR TITLE
harden(catalog): bound project/environment creation, close shadow-project gap (#383/#385/#386)

### DIFF
--- a/internal/cli/project/env.go
+++ b/internal/cli/project/env.go
@@ -101,10 +101,7 @@ func runEnvCreate(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to initialize service: %w", err)
 	}
-	env, err := svc.Storage().CreateEnvironment(ctx, &models.Environment{
-		ProjectID: projectID,
-		Name:      envCreateName,
-	})
+	env, err := svc.CreateEnvironment(ctx, projectID, envCreateName)
 	if err != nil {
 		return fmt.Errorf("failed to create environment: %w", err)
 	}

--- a/internal/core/catalog.go
+++ b/internal/core/catalog.go
@@ -2,11 +2,63 @@ package core
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
+
+// #383: bounds on the project/environment catalog so a single request can't blow
+// past a reasonable working set. maxEnvNamesPerCreate is generous relative to
+// defaultEnvironmentNames' 3-entry convention — a few dozen covers realistic
+// per-region/per-service environment fan-out — while still keeping
+// CreateProjectWithEnvs's loop bounded instead of open to a ~10 MiB request body
+// (a JSON array entry as short as `"a",` fits roughly 1-2 million times in that
+// budget) requesting on the order of a million environments in one call.
+// maxProjectNameLen/maxEnvironmentNameLen cap the unbounded `Name` text columns
+// (Project.Name/Environment.Name) so an oversized name can't compound the same
+// row/index bloat; a few hundred characters is generous for a name field.
+const (
+	maxEnvNamesPerCreate  = 50
+	maxProjectNameLen     = 200
+	maxEnvironmentNameLen = 200
+)
+
+// validateProjectName bounds Project.Name (#383): required, and capped so an
+// unbounded text column can't be used to bloat storage/index size.
+func validateProjectName(name string) error {
+	if name == "" {
+		return fmt.Errorf("%s: project name is required", i18n.T("ErrorValidation", nil))
+	}
+	if len(name) > maxProjectNameLen {
+		return fmt.Errorf("%s: project name exceeds %d characters", i18n.T("ErrorValidation", nil), maxProjectNameLen)
+	}
+	return nil
+}
+
+// validateEnvironmentName bounds Environment.Name (#383), mirroring validateProjectName.
+func validateEnvironmentName(name string) error {
+	if name == "" {
+		return fmt.Errorf("%s: environment name is required", i18n.T("ErrorValidation", nil))
+	}
+	if len(name) > maxEnvironmentNameLen {
+		return fmt.Errorf("%s: environment name exceeds %d characters", i18n.T("ErrorValidation", nil), maxEnvironmentNameLen)
+	}
+	return nil
+}
+
+// translateProjectNameError surfaces storage.ErrDuplicateProjectName (#385, the
+// case-insensitive partial unique index on projects.name) as a clean "name already in
+// use" validation error, mirroring CreateUser's translation of ErrDuplicateEmail (#117),
+// rather than letting a raw constraint-violation message reach the caller.
+func translateProjectNameError(err error) error {
+	if errors.Is(err, storage.ErrDuplicateProjectName) {
+		return fmt.Errorf("%s: a project with this name already exists", i18n.T("ErrorValidation", nil))
+	}
+	return err
+}
 
 // ListProjects returns all projects from storage.
 func (c *KeyorixCore) ListProjects(ctx context.Context) ([]*models.Project, error) {
@@ -29,8 +81,8 @@ func (c *KeyorixCore) GetProject(ctx context.Context, id uint) (*models.Project,
 // requireMFA is non-nil — its per-project MFA requirement (ADR-037). A nil
 // requireMFA leaves the flag unchanged (backward-compatible).
 func (c *KeyorixCore) UpdateProject(ctx context.Context, id uint, name, description string, requireMFA *bool) (*models.Project, error) {
-	if name == "" {
-		return nil, fmt.Errorf("project name is required")
+	if err := validateProjectName(name); err != nil {
+		return nil, err
 	}
 	if err := validateDescription(description); err != nil {
 		return nil, err
@@ -47,7 +99,7 @@ func (c *KeyorixCore) UpdateProject(ctx context.Context, id uint, name, descript
 	}
 	updated, err := c.storage.UpdateProject(ctx, project)
 	if err != nil {
-		return nil, err
+		return nil, translateProjectNameError(err)
 	}
 	if mfaChanged {
 		pid := id
@@ -169,14 +221,17 @@ func (c *KeyorixCore) RestoreEnvironment(ctx context.Context, actorID, projectID
 
 // CreateProject creates a new project and seeds it with default environments.
 func (c *KeyorixCore) CreateProject(ctx context.Context, name, description string) (*models.Project, error) {
-	if name == "" {
-		return nil, fmt.Errorf("project name is required")
+	if err := validateProjectName(name); err != nil {
+		return nil, err
 	}
 	if err := validateDescription(description); err != nil {
 		return nil, err
 	}
 	project, err := c.storage.CreateProject(ctx, &models.Project{Name: name, Description: description})
 	if err != nil {
+		if errors.Is(err, storage.ErrDuplicateProjectName) {
+			return nil, translateProjectNameError(err)
+		}
 		return nil, fmt.Errorf("failed to create project: %w", err)
 	}
 	// Seed default environments for new project
@@ -211,17 +266,45 @@ func (c *KeyorixCore) GetEnvironment(ctx context.Context, id uint) (*models.Envi
 	return c.storage.GetEnvironment(ctx, id)
 }
 
+// CreateEnvironment creates a single environment under an existing project,
+// validating the name (#383). This is the single-environment counterpart to
+// CreateProjectWithEnvs's fan-out create; callers (the HTTP
+// POST /projects/{id}/environments handler, the `keyorix project env create`
+// CLI) previously wrote straight to storage, bypassing any name-length guard.
+func (c *KeyorixCore) CreateEnvironment(ctx context.Context, projectID uint, name string) (*models.Environment, error) {
+	if err := validateEnvironmentName(name); err != nil {
+		return nil, err
+	}
+	return c.storage.CreateEnvironment(ctx, &models.Environment{ProjectID: projectID, Name: name})
+}
+
 // CreateProjectWithEnvs creates a new project seeded with the specified environment names.
 // Used when the CLI --envs flag overrides the default development/staging/production set.
 func (c *KeyorixCore) CreateProjectWithEnvs(ctx context.Context, name, description string, envNames []string) (*models.Project, error) {
-	if name == "" {
-		return nil, fmt.Errorf("project name is required")
+	if err := validateProjectName(name); err != nil {
+		return nil, err
 	}
 	if err := validateDescription(description); err != nil {
 		return nil, err
 	}
+	// #383: cap the environment fan-out before touching storage at all — without
+	// this, a single ~10 MiB request (a JSON array entry as short as `"a",` fits
+	// roughly 1-2 million times in that budget) could request on the order of a
+	// million environments, degrading the shared install for every other tenant.
+	if len(envNames) > maxEnvNamesPerCreate {
+		return nil, fmt.Errorf("%s: at most %d environments per project create (got %d)",
+			i18n.T("ErrorValidation", nil), maxEnvNamesPerCreate, len(envNames))
+	}
+	for _, envName := range envNames {
+		if err := validateEnvironmentName(envName); err != nil {
+			return nil, err
+		}
+	}
 	project, err := c.storage.CreateProject(ctx, &models.Project{Name: name, Description: description})
 	if err != nil {
+		if errors.Is(err, storage.ErrDuplicateProjectName) {
+			return nil, translateProjectNameError(err)
+		}
 		return nil, fmt.Errorf("failed to create project: %w", err)
 	}
 	for _, envName := range envNames {

--- a/internal/core/storage/errors.go
+++ b/internal/core/storage/errors.go
@@ -42,6 +42,16 @@ var ErrDuplicateActiveMembership = errors.New("an active membership already exis
 // constraint-violation message.
 var ErrDuplicateEmail = errors.New("a user with this email already exists")
 
+// ErrDuplicateProjectName is returned (wrapped) by CreateProject/UpdateProject when the
+// write collides with the partial, case-insensitive unique index on projects.name (live
+// rows only, #385). Without this, "Production"/"production" landed as two distinct,
+// both-succeeding rows — and the CLI's project name resolution (resolveProjectID)
+// resolves case-insensitively over an unordered project list, returning the FIRST match —
+// so a same-name-different-case shadow project could silently hijack a later `keyorix
+// secret import/export --project production`. Callers translate this into a clean
+// "project name already in use" error rather than a raw constraint-violation message.
+var ErrDuplicateProjectName = errors.New("a project with this name already exists")
+
 // ErrDuplicateSecretVersion is returned (wrapped) by CreateSecretVersion when the insert
 // collides with the unique index on (secret_node_id, version_number). RotateSecret's
 // GetLatestSecretVersion -> +1 -> storeSecretVersion sequence is a read-then-write race

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -673,6 +673,19 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 		}
 	}
 
+	// Swap the plain unique index on projects.name for a case-insensitive, live-rows-
+	// only partial one (#385): "Production"/"production" previously landed as two
+	// distinct, all-succeeding rows, and the CLI's project name resolution
+	// (resolveProjectID) is case-insensitive and returns the first match — so a
+	// same-name-different-case shadow project the exact-match index didn't block could
+	// silently hijack a later `keyorix secret import/export --project production`.
+	// Additive + idempotent; the full AutoMigrate below covers fresh DBs.
+	if projectsExists {
+		if err := ensureProjectNameIndex(db); err != nil {
+			return err
+		}
+	}
+
 	// Skip full AutoMigrate if already initialised (projects table present).
 	if projectsExists {
 		return nil
@@ -722,9 +735,9 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 	); err != nil {
 		return err
 	}
-	// The Group and User models carry no plain unique tag on name/username; enforce
-	// uniqueness only among live rows via partial indexes (so a soft-deleted name or
-	// username can be reused, e.g. on SCIM re-provisioning).
+	// The Group, User, and Project models carry no plain unique tag on
+	// name/username/name; enforce uniqueness only among live rows via partial indexes
+	// (so a soft-deleted name/username can be reused, e.g. on SCIM re-provisioning).
 	if err := ensureGroupNameIndex(db); err != nil {
 		return err
 	}
@@ -732,6 +745,9 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 		return err
 	}
 	if err := ensureUserEmailIndex(db); err != nil {
+		return err
+	}
+	if err := ensureProjectNameIndex(db); err != nil {
 		return err
 	}
 	if err := ensureShareRecordUniqueIndex(db); err != nil {
@@ -837,6 +853,34 @@ func ensureUserNameIndex(db *gorm.DB) error {
 func ensureUserEmailIndex(db *gorm.DB) error {
 	if err := db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS uniq_users_email_active ON users (LOWER(email)) WHERE deleted_at IS NULL AND email <> ''").Error; err != nil {
 		return fmt.Errorf("failed to create partial users email index: %w", err)
+	}
+	return nil
+}
+
+// ensureProjectNameIndex creates a partial, case-insensitive unique index on
+// projects.name scoped to live (non-deleted) rows with a non-empty name (#385).
+// Project.Name previously carried only a plain, case-sensitive `uniqueIndex` tag, so
+// "Production"/"production" (and any other case variant) were distinct, both-succeeding
+// rows — and the CLI's project name resolution (resolveProjectID, import.go) resolves by
+// case-insensitive comparison over an unordered project list, returning the FIRST match.
+// A secrets.write holder could therefore plant a same-name-different-case shadow project
+// the old index didn't block, and a later `keyorix secret import/export --project
+// production` could silently resolve against the shadow project instead of the intended
+// one. The index is on LOWER(name) so it catches every case variant, mirroring
+// ensureUserEmailIndex's treatment of users.email (#117) for the identical
+// shadow-identity class of bug. Scoped to `deleted_at IS NULL` so a soft-deleted
+// project's name is freed for reuse on re-creation, mirroring ensureGroupNameIndex/
+// ensureUserNameIndex; `name <> ''` so any legacy rows with no name recorded don't
+// collide with each other. Idempotent; works on both SQLite and Postgres.
+//
+// Known residual limitation: this closes the case-folding gap but not the
+// Unicode-homoglyph one — "Prοduction" (Greek omicron, U+03BF) still normalizes to a
+// distinct LOWER() value from "production" and would still create a separate row. Full
+// NFKC normalization plus homoglyph/confusable detection is a materially harder problem
+// (Unicode Technical Standard #39) and is intentionally out of scope here.
+func ensureProjectNameIndex(db *gorm.DB) error {
+	if err := db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS uniq_projects_name_active ON projects (LOWER(name)) WHERE deleted_at IS NULL AND name <> ''").Error; err != nil {
+		return fmt.Errorf("failed to create partial projects name index: %w", err)
 	}
 	return nil
 }

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -7,8 +7,14 @@ import (
 )
 
 type Project struct {
-	ID          uint   `gorm:"primaryKey"`
-	Name        string `gorm:"uniqueIndex;not null"`
+	ID uint `gorm:"primaryKey"`
+	// Name uniqueness is enforced by a case-insensitive PARTIAL unique index
+	// (LOWER(name) WHERE deleted_at IS NULL), created in migrateDatabase (#385) — not
+	// the plain `uniqueIndex` tag — so "Production"/"production" can't land as two
+	// distinct rows (closing a shadow-project confusion vector against the
+	// case-insensitive CLI project-name resolution), while a soft-deleted project's
+	// name is still freed for reuse.
+	Name        string `gorm:"not null"`
 	Description string
 	// RequireMFA, when true, denies interactive (session-authenticated) callers
 	// without a second factor access to this project's scoped resources, even when

--- a/internal/storage/store/local_secrets.go
+++ b/internal/storage/store/local_secrets.go
@@ -13,6 +13,7 @@ package store
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/core/storage"
@@ -23,8 +24,40 @@ import (
 
 // --- Project / Environment ---
 
+// maxEnvironmentListing caps how many environments a single ListEnvironmentsByProject
+// (or ...IncludingDeleted) call returns (#386). This is defense-in-depth behind the
+// creation-time cap on CreateProjectWithEnvs (#383, maxEnvNamesPerCreate in
+// internal/core/catalog.go): that cap bounds a single fan-out create, but a project
+// can still accrete environments one at a time via repeated single-environment-create
+// calls, and this backstop keeps the listing query/response bounded independent of
+// that limit — including for any pre-existing data created before #383 shipped. Set
+// well above the create-time cap so it never trips under normal use.
+const maxEnvironmentListing = 1000
+
+// isDuplicateProjectNameViolation reports whether err is a unique-constraint violation
+// on specifically the partial projects-name index (uniq_projects_name_active, #385), as
+// distinct from any other unique constraint. Both SQLite and Postgres include the
+// violated index name in the driver-native error text for an expression index like this
+// one, mirroring isDuplicateEmailViolation's treatment of users.email (#117).
+func isDuplicateProjectNameViolation(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "uniq_projects_name_active")
+}
+
 func (ls *LocalStorage) CreateProject(ctx context.Context, project *models.Project) (*models.Project, error) {
-	return project, ls.db.WithContext(ctx).Create(project).Error
+	if err := ls.db.WithContext(ctx).Create(project).Error; err != nil {
+		if isDuplicateProjectNameViolation(err) {
+			// The partial unique index uniq_projects_name_active (#385) caught a
+			// case-insensitive duplicate: another project already holds this name (in any
+			// case). Translate to the sentinel so callers can surface a clean "project name
+			// already in use" error instead of a raw constraint-violation message.
+			return nil, fmt.Errorf("%w: %v", storage.ErrDuplicateProjectName, err)
+		}
+		return nil, err
+	}
+	return project, nil
 }
 
 func (ls *LocalStorage) CreateEnvironment(ctx context.Context, env *models.Environment) (*models.Environment, error) {
@@ -111,6 +144,11 @@ func (ls *LocalStorage) GetProject(ctx context.Context, id uint) (*models.Projec
 
 func (ls *LocalStorage) UpdateProject(ctx context.Context, project *models.Project) (*models.Project, error) {
 	if err := ls.db.WithContext(ctx).Save(project).Error; err != nil {
+		if isDuplicateProjectNameViolation(err) {
+			// See CreateProject's comment: a rename collided with the partial
+			// case-insensitive unique index (#385).
+			return nil, fmt.Errorf("%w: %v", storage.ErrDuplicateProjectName, err)
+		}
 		return nil, fmt.Errorf("failed to update project: %w", err)
 	}
 	return project, nil
@@ -205,14 +243,16 @@ func (ls *LocalStorage) ListEnvironments(ctx context.Context) ([]*models.Environ
 
 func (ls *LocalStorage) ListEnvironmentsByProject(ctx context.Context, projectID uint) ([]*models.Environment, error) {
 	var environments []*models.Environment
-	return environments, ls.db.WithContext(ctx).Where("project_id = ?", projectID).Find(&environments).Error
+	return environments, ls.db.WithContext(ctx).Where("project_id = ?", projectID).
+		Limit(maxEnvironmentListing).Find(&environments).Error
 }
 
 // ListEnvironmentsByProjectIncludingDeleted is like ListEnvironmentsByProject but
 // also returns soft-deleted environments (DeletedAt populated), for the restore UI.
 func (ls *LocalStorage) ListEnvironmentsByProjectIncludingDeleted(ctx context.Context, projectID uint) ([]*models.Environment, error) {
 	var environments []*models.Environment
-	return environments, ls.db.WithContext(ctx).Unscoped().Where("project_id = ?", projectID).Find(&environments).Error
+	return environments, ls.db.WithContext(ctx).Unscoped().Where("project_id = ?", projectID).
+		Limit(maxEnvironmentListing).Find(&environments).Error
 }
 
 func (ls *LocalStorage) GetEnvironment(ctx context.Context, id uint) (*models.Environment, error) {

--- a/server/http/handlers/catalog.go
+++ b/server/http/handlers/catalog.go
@@ -232,10 +232,7 @@ func (h *CatalogHandler) CreateProjectEnvironment(w http.ResponseWriter, r *http
 		sendError(w, "NotFound", "Project not found", http.StatusNotFound, nil)
 		return
 	}
-	env, err := h.coreService.Storage().CreateEnvironment(r.Context(), &models.Environment{
-		ProjectID: uint(id),
-		Name:      body.Name,
-	})
+	env, err := h.coreService.CreateEnvironment(r.Context(), uint(id), body.Name)
 	if err != nil {
 		sendError(w, "Error", err.Error(), http.StatusInternalServerError, nil)
 		return


### PR DESCRIPTION
## Summary
- Caps `Project.Name`/`Environment.Name` length and the per-request environment fan-out on `CreateProjectWithEnvs` so a single request can't drive unbounded row/index growth (#383).
- Backstops `ListEnvironmentsByProject`/`...IncludingDeleted` with a hard row limit independent of the creation-time cap, covering pre-existing data and one-at-a-time accretion (#386).
- Replaces the plain unique index on `projects.name` with a case-insensitive partial unique index over live (non-deleted) rows, closing a shadow-project vector: `"Production"`/`"production"` previously landed as two distinct, both-succeeding rows, and the CLI's case-insensitive project-name resolver (`resolveProjectID`) returns the first match — so a same-name-different-case shadow project could silently hijack a later `keyorix secret import/export --project production` (#385).
- Routes the HTTP `POST /projects/{id}/environments` handler and the `keyorix project env create` CLI command through the new `core.CreateEnvironment` (instead of writing to storage directly) so both pick up the new name validation.

## Test plan
- [x] `go build ./...`
- [x] `go build ./server`
- [x] `go test ./...` (full suite green)
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues
- [x] `golangci-lint run ./...` — 0 issues
- [x] `cd operator && GOWORK=off go build ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)