### PR TITLE
harden(rbac): close SoD group-permission blindspot in dashboard/CLI views (#374/#375/#376)

### DIFF
--- a/internal/core/rbac.go
+++ b/internal/core/rbac.go
@@ -56,28 +56,50 @@ func (c *KeyorixCore) ListUserRolesByEmail(ctx context.Context, userEmail string
 	return roles, nil
 }
 
-// HasPermissionByEmail checks if a user has a specific permission by email.
+// HasPermissionByEmail checks if a user has a specific permission by email, at
+// ANY scope the user holds a role — the CLI diagnostic used for offboarding and
+// incident-response access checks (#376). It deliberately delegates to Authorize
+// (mirroring scopedRoleIDs in authz.go) at every scope the user has a grant,
+// rather than running its own parallel query, so it stays in lockstep with the
+// live authorization path on all three axes that previously drifted: it honors
+// group-inherited roles, it evaluates the permission per-scope (not a flat,
+// scope-blind "any assignment anywhere" match), and it honors the admin-role
+// bypass Authorize() applies. A role-less user (no grant at any scope) is still
+// checked once at the global scope, matching Authorize's own "no roles, no
+// permission" resolution.
 func (c *KeyorixCore) HasPermissionByEmail(ctx context.Context, userEmail, resource, action string) (bool, error) {
 	user, err := c.storage.GetUserByEmail(ctx, userEmail)
 	if err != nil {
 		return false, fmt.Errorf("%s: %w", i18n.T("ErrorUserNotFound", nil), err)
 	}
-	hasPermission, err := c.storage.CheckPermission(ctx, user.ID, resource, action)
+	permission := resource + "." + action
+	scopes, err := c.storage.GetUserRoleScopes(ctx, user.ID)
 	if err != nil {
 		return false, fmt.Errorf("%s: %w", i18n.T("ErrorInternalServer", nil), err)
 	}
-	return hasPermission, nil
+	if len(scopes) == 0 {
+		scopes = []Scope{{}}
+	}
+	for _, scope := range scopes {
+		ok, aerr := c.Authorize(ctx, user.ID, permission, scope)
+		if aerr != nil {
+			return false, fmt.Errorf("%s: %w", i18n.T("ErrorInternalServer", nil), aerr)
+		}
+		if ok {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
-// ListUserPermissionsByEmail lists permissions for a user by email.
+// ListUserPermissionsByEmail lists a user's effective permission set (direct AND
+// group-derived) for the CLI's `rbac list-permissions` — the same secondary
+// symptom of the #219/#374 root cause called out for the HTTP dashboard endpoint
+// (#375): union both sources rather than reporting direct roles only.
 func (c *KeyorixCore) ListUserPermissionsByEmail(ctx context.Context, userEmail string) ([]*storage.Permission, error) {
 	user, err := c.storage.GetUserByEmail(ctx, userEmail)
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorUserNotFound", nil), err)
 	}
-	permissions, err := c.storage.GetUserPermissions(ctx, user.ID)
-	if err != nil {
-		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
-	}
-	return permissions, nil
+	return c.GetUserPermissionsByID(ctx, user.ID)
 }

--- a/internal/core/rbac_group_permission_external_test.go
+++ b/internal/core/rbac_group_permission_external_test.go
@@ -1,0 +1,152 @@
+package core_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/testhelper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// #375: GetUserPermissionsByID is the "what can this user do" view behind the
+// dashboard/access-review endpoint (GET /api/v1/users/{id}/permissions). It
+// previously reported only DIRECT role grants — a permission held purely via a
+// group role was invisible to a reviewer even though Authorize() genuinely
+// grants it on every live request. This pins the fix: the union of direct AND
+// group-derived permissions.
+func TestGetUserPermissionsByID_IncludesGroupDerivedPermission(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	ctx := context.Background()
+
+	// gina holds viewer (secrets.read, users.read) DIRECTLY, and editor
+	// (secrets.write) ONLY via a group.
+	h.CreateTestUser(t, "gina", 20)
+	h.AssignUserRole(t, 20, 4, nil) // viewer (direct)
+	h.CreateTestGroup(t, "writers", "secrets writers", 40)
+	h.AssignGroupRole(t, 40, 3, nil) // group carries editor → secrets.write
+	h.AssignUserToGroup(t, 20, 40)
+
+	perms, err := h.CoreService.GetUserPermissionsByID(ctx, 20)
+	require.NoError(t, err)
+
+	names := make([]string, 0, len(perms))
+	for _, p := range perms {
+		names = append(names, p.Name)
+	}
+	assert.Contains(t, names, "secrets.read", "direct viewer permission must still be present")
+	assert.Contains(t, names, "secrets.write", "group-derived editor permission must now be visible")
+
+	// De-duplication: a permission held both directly and via a group (e.g.
+	// secrets.read, granted by both viewer directly and — indirectly — nothing
+	// else here) must not be duplicated. Verify no name repeats.
+	seen := map[string]bool{}
+	for _, n := range names {
+		assert.False(t, seen[n], "permission %q must not be duplicated", n)
+		seen[n] = true
+	}
+}
+
+// A user with no group membership at all still gets exactly their direct set —
+// the fix must not fabricate permissions for a user with no groups.
+func TestGetUserPermissionsByID_NoGroups_DirectOnly(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	ctx := context.Background()
+
+	h.CreateTestUser(t, "henry", 21)
+	h.AssignUserRole(t, 21, 4, nil) // viewer only, no groups
+
+	perms, err := h.CoreService.GetUserPermissionsByID(ctx, 21)
+	require.NoError(t, err)
+
+	names := make([]string, 0, len(perms))
+	for _, p := range perms {
+		names = append(names, p.Name)
+	}
+	assert.Contains(t, names, "secrets.read")
+	assert.Contains(t, names, "users.read")
+	assert.NotContains(t, names, "secrets.write")
+}
+
+// #376: HasPermissionByEmail (the CLI `check-permission` diagnostic used for
+// offboarding/incident-response) previously delegated to a raw, scope-blind,
+// group-blind, admin-bypass-blind storage query. It now delegates to Authorize
+// (mirroring scopedRoleIDs) per scope, so it must agree with Authorize on all
+// three axes that had drifted.
+func TestHasPermissionByEmail_GroupDerivedPermission(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	ctx := context.Background()
+
+	h.CreateTestUser(t, "iris", 22)
+	h.CreateTestGroup(t, "writers", "secrets writers", 41)
+	h.AssignGroupRole(t, 41, 3, nil) // group carries editor → secrets.write
+	h.AssignUserToGroup(t, 22, 41)
+
+	ok, err := h.CoreService.HasPermissionByEmail(ctx, "iris@test.com", "secrets", "write")
+	require.NoError(t, err)
+	assert.True(t, ok, "a permission granted only via a group role must be found")
+
+	ok, err = h.CoreService.HasPermissionByEmail(ctx, "iris@test.com", "secrets", "delete")
+	require.NoError(t, err)
+	assert.False(t, ok, "a permission the user does not hold at all must read as false")
+}
+
+// A super_admin with no explicit role_permissions row for the checked
+// permission must still read as "has permission" — Authorize's admin-role
+// bypass applies. Before the fix this read as a false "does NOT have
+// permission", exactly the false-negative the finding describes.
+func TestHasPermissionByEmail_AdminBypass(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	ctx := context.Background()
+
+	h.CreateTestUser(t, "jack", 23)
+	h.AssignUserRole(t, 23, 1, nil) // super_admin, global
+
+	// A permission NOT in the seeded super_admin role_permissions set at all.
+	ok, err := h.CoreService.HasPermissionByEmail(ctx, "jack@test.com", "connect", "write")
+	require.NoError(t, err)
+	assert.True(t, ok, "a super_admin bypasses the per-permission check even for an unlisted permission")
+}
+
+// A grant scoped to a since-soft-deleted project must stop authorizing, exactly
+// like Authorize()/scopedRoleIDs — the storage-blind old query ignored scope
+// validity entirely and would have kept reporting "has permission" regardless.
+func TestHasPermissionByEmail_ScopeRestrictedAssignment_DeletedProjectStopsAuthorizing(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	ctx := context.Background()
+
+	h.CreateTestUser(t, "kate", 24)
+	projID := uint(2) // "production" project, seeded by the helper
+	h.AssignUserRole(t, 24, 3, &projID) // editor, scoped to project 2 → secrets.write
+
+	ok, err := h.CoreService.HasPermissionByEmail(ctx, "kate@test.com", "secrets", "write")
+	require.NoError(t, err)
+	assert.True(t, ok, "a live project-scoped grant authorizes")
+
+	require.NoError(t, h.DB.Delete(&models.Project{}, projID).Error)
+
+	ok, err = h.CoreService.HasPermissionByEmail(ctx, "kate@test.com", "secrets", "write")
+	require.NoError(t, err)
+	assert.False(t, ok, "a grant scoped to a soft-deleted project must stop authorizing")
+}
+
+// A user with no role grants at all (no scope to iterate) must read as false,
+// not error — Authorize's own "no roles, no permission" resolution at the
+// global scope.
+func TestHasPermissionByEmail_NoGrantsAtAll(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	ctx := context.Background()
+
+	h.CreateTestUser(t, "liam", 25)
+
+	ok, err := h.CoreService.HasPermissionByEmail(ctx, "liam@test.com", "secrets", "read")
+	require.NoError(t, err)
+	assert.False(t, ok)
+}

--- a/internal/core/rbac_management.go
+++ b/internal/core/rbac_management.go
@@ -202,13 +202,33 @@ func (c *KeyorixCore) GetUserRolesByID(ctx context.Context, userID uint) ([]*mod
 }
 
 // GetUserPermissionsByID returns a user's effective permission set — the
-// de-duplicated union of permissions across every role assigned to the user. This
-// is the "what can this user do" view for dashboards and access reviews; the CLI's
-// list-permissions assembles the same set client-side. Empty for an unknown user.
+// de-duplicated union of permissions across every DIRECT role assigned to the
+// user AND every role inherited via group membership, mirroring how Authorize
+// resolves scopedRoleIDs (authz.go) before any live permission check. This is
+// the "what can this user do" view for dashboards and access reviews (#375); a
+// permission held only via a group role must be visible here — omitting it let
+// a malicious insider "hide" real, group-derived access from a recertification
+// reviewer even though Authorize() would grant it on every live request. Empty
+// for an unknown user.
 func (c *KeyorixCore) GetUserPermissionsByID(ctx context.Context, userID uint) ([]*storage.Permission, error) {
-	perms, err := c.storage.GetUserPermissions(ctx, userID)
+	direct, err := c.storage.GetUserPermissions(ctx, userID)
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	viaGroups, err := c.storage.GetUserGroupPermissions(ctx, userID)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	seen := make(map[uint]struct{}, len(direct)+len(viaGroups))
+	perms := make([]*storage.Permission, 0, len(direct)+len(viaGroups))
+	for _, list := range [][]*storage.Permission{direct, viaGroups} {
+		for _, p := range list {
+			if _, ok := seen[p.ID]; ok {
+				continue
+			}
+			seen[p.ID] = struct{}{}
+			perms = append(perms, p)
+		}
 	}
 	return perms, nil
 }

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -426,14 +426,20 @@ type Storage interface {
 	// GetUserRoleIDsAt/GetUserGroupRoleIDsAt (via scopedRoleIDs) per scope.
 	GetUserRoleScopes(ctx context.Context, userID uint) ([]Scope, error)
 	RoleSetHasPermission(ctx context.Context, roleIDs []uint, permission string) (bool, error)
+	// CheckPermission is a raw, scope-agnostic role/permission-grant existence
+	// check (direct OR group-inherited role), with NO admin-role bypass — it does
+	// not answer "would Authorize() grant this at scope X". Prefer
+	// core.HasPermissionByEmail (which resolves via Authorize/scopedRoleIDs per
+	// scope) for anything that needs the true live-authorization-equivalent
+	// answer (#376).
 	CheckPermission(ctx context.Context, userID uint, resource, action string) (bool, error)
 	GetUserPermissions(ctx context.Context, userID uint) ([]*Permission, error)
 	// GetUserGroupPermissions returns the permissions a user holds via GROUP
 	// membership (group → group_roles → role_permissions), scope-agnostically and
 	// across all of the user's groups — the counterpart to GetUserPermissions, which
 	// covers only direct user_roles. Callers that need a user's full effective
-	// permission set (e.g. SoD conflict detection) must union both, mirroring how
-	// Authorize unions direct and group-inherited roles.
+	// permission set (e.g. SoD conflict detection, GetUserPermissionsByID) must
+	// union both, mirroring how Authorize unions direct and group-inherited roles.
 	GetUserGroupPermissions(ctx context.Context, userID uint) ([]*Permission, error)
 
 	// Permission queries

--- a/internal/storage/store/local_rbac.go
+++ b/internal/storage/store/local_rbac.go
@@ -472,20 +472,46 @@ func (ls *LocalStorage) RoleSetHasPermission(ctx context.Context, roleIDs []uint
 	return count > 0, nil
 }
 
-// CheckPermission returns true if userID has the given resource/action permission.
-// Resolved transitively: user → role → permission.
+// CheckPermission returns true if userID holds the given resource/action
+// permission via a DIRECT OR group-inherited role, resolved transitively: user
+// (or group membership) → role → permission (#376). It is intentionally
+// scope-blind (an assignment at ANY project/environment counts, matching its
+// pre-existing "any assignment anywhere" contract) and does not apply the
+// admin-role bypass Authorize() grants — this is a raw role/permission-grant
+// existence check, not a live authorization decision. The production diagnostic
+// that needs the FULL Authorize()-equivalent answer (group-inclusive,
+// scope-aware, admin-bypass-aware) is core.HasPermissionByEmail, which resolves
+// it via Authorize/scopedRoleIDs per scope rather than calling this method.
 func (ls *LocalStorage) CheckPermission(ctx context.Context, userID uint, resource, action string) (bool, error) {
+	now := time.Now()
 	var count int64
 	err := ls.db.WithContext(ctx).Table("permissions").
 		Joins("JOIN role_permissions ON permissions.id = role_permissions.permission_id").
 		Joins("JOIN user_roles ON role_permissions.role_id = user_roles.role_id").
 		Where("user_roles.user_id = ? AND permissions.resource = ? AND permissions.action = ?", userID, resource, action).
-		Where("user_roles.expires_at IS NULL OR user_roles.expires_at > ?", time.Now()).
+		Where("user_roles.expires_at IS NULL OR user_roles.expires_at > ?", now).
 		Count(&count).Error
 	if err != nil {
 		return false, fmt.Errorf("%s: %w", i18n.T("ErrorInternalServer", nil), err)
 	}
-	return count > 0, nil
+	if count > 0 {
+		return true, nil
+	}
+
+	var viaGroup int64
+	err = ls.db.WithContext(ctx).Table("permissions").
+		Joins("JOIN role_permissions ON permissions.id = role_permissions.permission_id").
+		Joins("JOIN group_roles ON role_permissions.role_id = group_roles.role_id").
+		Joins("JOIN user_groups ON user_groups.group_id = group_roles.group_id").
+		// A soft-deleted group confers no permissions (matches authz resolution).
+		Joins("JOIN groups ON groups.id = group_roles.group_id AND groups.deleted_at IS NULL").
+		Where("user_groups.user_id = ? AND permissions.resource = ? AND permissions.action = ?", userID, resource, action).
+		Where("group_roles.expires_at IS NULL OR group_roles.expires_at > ?", now).
+		Count(&viaGroup).Error
+	if err != nil {
+		return false, fmt.Errorf("%s: %w", i18n.T("ErrorInternalServer", nil), err)
+	}
+	return viaGroup > 0, nil
 }
 
 // ListPermissions returns all permissions.

--- a/internal/storage/store/local_rbac_scope_test.go
+++ b/internal/storage/store/local_rbac_scope_test.go
@@ -27,7 +27,7 @@ func newRBACScopeTestStore(t *testing.T) *LocalStorage {
 	require.NoError(t, err)
 	require.NoError(t, db.AutoMigrate(
 		&models.UserRole{}, &models.GroupRole{}, &models.UserGroup{}, &models.Role{}, &models.Group{},
-		&models.Project{}, &models.Environment{},
+		&models.Project{}, &models.Environment{}, &models.Permission{}, &models.RolePermission{},
 	))
 	return NewLocalStorage(db)
 }

--- a/internal/storage/store/local_rbac_test.go
+++ b/internal/storage/store/local_rbac_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -72,4 +73,79 @@ func TestAssignRole_SucceedsAfterPriorTimeBoundGrantExpired(t *testing.T) {
 	ids, err := ls.GetUserRoleIDsAt(ctx, 1, sc(5, 0))
 	require.NoError(t, err)
 	assert.Contains(t, ids, uint(10))
+}
+
+// #374/#375/#376: GetUserPermissions and CheckPermission previously joined ONLY
+// user_roles (direct assignments), leaving them blind to a permission granted
+// purely via a group role — unlike the live authorization path (scopedRoleIDs,
+// authz.go), which correctly unions direct and group-inherited roles. These
+// tests pin the fix: a permission held ONLY through group membership must now
+// be visible.
+func TestGetUserPermissions_DirectOnly_DoesNotIncludeGroupGrant(t *testing.T) {
+	ls := newRBACScopeTestStore(t)
+	ctx := context.Background()
+	seedGroupGrantedPermission(t, ls)
+
+	// GetUserPermissions is documented as direct-only; the group-derived
+	// permission must NOT appear here (GetUserGroupPermissions is its
+	// counterpart — callers needing the full effective set must union both).
+	perms, err := ls.GetUserPermissions(ctx, 1)
+	require.NoError(t, err)
+	assert.Empty(t, perms, "a permission granted only via a group role is not direct")
+}
+
+func TestGetUserGroupPermissions_IncludesGroupDerivedPermission(t *testing.T) {
+	ls := newRBACScopeTestStore(t)
+	ctx := context.Background()
+	seedGroupGrantedPermission(t, ls)
+
+	perms, err := ls.GetUserGroupPermissions(ctx, 1)
+	require.NoError(t, err)
+	require.Len(t, perms, 1)
+	assert.Equal(t, "secrets.admin", perms[0].Name)
+}
+
+// CheckPermission must find a permission granted purely via a group role — the
+// storage-layer #376 axis: it previously joined only user_roles, so a group-only
+// grant read as "does NOT have permission" even though Authorize() genuinely
+// grants it.
+func TestCheckPermission_IncludesGroupDerivedPermission(t *testing.T) {
+	ls := newRBACScopeTestStore(t)
+	ctx := context.Background()
+	seedGroupGrantedPermission(t, ls)
+
+	has, err := ls.CheckPermission(ctx, 1, "secrets", "admin")
+	require.NoError(t, err)
+	assert.True(t, has, "a permission granted only via a group role must be found")
+
+	has, err = ls.CheckPermission(ctx, 1, "secrets", "write")
+	require.NoError(t, err)
+	assert.False(t, has, "an unrelated permission must not be reported as held")
+}
+
+// A soft-deleted group must confer no permission, mirroring
+// GetUserGroupRoleIDsAt's own soft-delete gate.
+func TestCheckPermission_SoftDeletedGroupConfersNothing(t *testing.T) {
+	ls := newRBACScopeTestStore(t)
+	ctx := context.Background()
+	seedGroupGrantedPermission(t, ls)
+
+	require.NoError(t, ls.db.Delete(&models.Group{}, 100).Error)
+
+	has, err := ls.CheckPermission(ctx, 1, "secrets", "admin")
+	require.NoError(t, err)
+	assert.False(t, has, "a soft-deleted group's grant must stop authorizing")
+}
+
+// seedGroupGrantedPermission puts user 1 in group 100, which holds role 50
+// globally, which is bundled with permission secrets.admin — i.e. user 1 holds
+// secrets.admin PURELY via group membership, no direct role.
+func seedGroupGrantedPermission(t *testing.T, ls *LocalStorage) {
+	t.Helper()
+	require.NoError(t, ls.db.Create(&models.Role{ID: 50, Name: "group-role"}).Error)
+	require.NoError(t, ls.db.Create(&models.Permission{ID: 1, Name: "secrets.admin", Resource: "secrets", Action: "admin"}).Error)
+	require.NoError(t, ls.db.Create(&models.RolePermission{RoleID: 50, PermissionID: 1}).Error)
+	require.NoError(t, ls.db.Create(&models.Group{ID: 100, Name: "g100"}).Error)
+	require.NoError(t, ls.db.Create(&models.UserGroup{UserID: 1, GroupID: 100}).Error)
+	require.NoError(t, ls.db.Create(&models.GroupRole{GroupID: 100, RoleID: 50, ProjectID: 0, EnvironmentID: 0}).Error)
 }


### PR DESCRIPTION
## Summary
- `GetUserPermissionsByID` (the dashboard/access-review "what can this user do" view) previously reported only DIRECT role grants, so a permission held purely via a group role was invisible to a reviewer even though `Authorize()` genuinely grants it on every live request.
- `HasPermissionByEmail` (the CLI `check-permission` diagnostic used for offboarding/incident-response) previously delegated to a raw, scope-blind, group-blind, admin-bypass-blind storage query. It now delegates to `Authorize()` per scope the user holds a role at (mirroring `scopedRoleIDs`), so it agrees with the live authorization path on group inheritance, per-scope evaluation, and the admin-role bypass.
- `CheckPermission` (storage layer) now also matches group-inherited role grants (with the same soft-deleted-group exclusion the live authz path applies), since other callers still rely on it as a raw existence check.
- This closes the last two blindspots in the family after the SoD-detection fix (`DetectSoDViolations`/`userSoDViolations`) that already unions direct and group-derived permissions.

## Test plan
- [x] `go build ./...` and `go build ./server`
- [x] `go test ./...` (all packages pass; one flaky, unrelated `TestHTTPJWKSResolver_CapsKeyCount` failure reproduced only under full parallel load, passes in isolation and on rerun)
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues
- [x] `golangci-lint run ./...` — 0 issues
- [x] `GOWORK=off go build ./...` in `operator/`
- [x] New tests: `internal/core/rbac_group_permission_external_test.go`, additions to `internal/storage/store/local_rbac_test.go` pin group-derived permission visibility, admin bypass, scope-restricted grant expiry, and no-grant-at-all behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)