### PR TITLE
harden(validation): blank-name bypass, HTTP/gRPC name-length parity — #189/#190

### DIFF
--- a/internal/core/groups.go
+++ b/internal/core/groups.go
@@ -189,12 +189,18 @@ func (c *KeyorixCore) validateCreateGroupRequest(req *CreateGroupRequest) error 
 	if req.Name == "" {
 		return fmt.Errorf("group name is required")
 	}
+	if err := validateNameLength("group name", req.Name); err != nil {
+		return err
+	}
 	return validateDescription(req.Description)
 }
 
 func (c *KeyorixCore) validateUpdateGroupRequest(req *UpdateGroupRequest) error {
 	if req.ID == 0 {
 		return fmt.Errorf("group ID is required")
+	}
+	if err := validateNameLength("group name", req.Name); err != nil {
+		return err
 	}
 	return validateDescription(req.Description)
 }

--- a/internal/core/secret_description.go
+++ b/internal/core/secret_description.go
@@ -26,6 +26,24 @@ func validateDescription(description string) error {
 	return nil
 }
 
+// maxResourceNameLen bounds a resource Name (group, secret) at the core layer,
+// matching the HTTP-side `validate:"...,max=255"` cap (server/http/handlers/
+// groups_handler.go, secrets_crud.go). HTTP's byte-length semantics
+// (server/validation.Validator's `max` rule uses len(string), not rune count) are
+// mirrored here with len(name) so the two transports agree exactly. gRPC never runs
+// the HTTP validator, so without this the core layer was the only enforcement point
+// gRPC could inherit from — this closes that HTTP/gRPC parity gap (backlog #190).
+const maxResourceNameLen = 255
+
+// validateNameLength bounds a resource Name to maxResourceNameLen bytes, matching
+// HTTP's cap exactly. kind labels the error ("group name", "secret name", ...).
+func validateNameLength(kind, name string) error {
+	if len(name) > maxResourceNameLen {
+		return fmt.Errorf("%s exceeds %d characters", kind, maxResourceNameLen)
+	}
+	return nil
+}
+
 // SetSecretDescription sets (or clears, with "") the secret's description. The actor
 // must be able to write the secret. The note is trimmed and length-bounded. Audited.
 func (c *KeyorixCore) SetSecretDescription(ctx context.Context, actorID, secretID uint, description string) (*models.SecretNode, error) {

--- a/internal/core/secrets_validation.go
+++ b/internal/core/secrets_validation.go
@@ -13,6 +13,9 @@ func (c *KeyorixCore) validateCreateSecretRequest(req *CreateSecretRequest) erro
 	if req.Name == "" {
 		return fmt.Errorf("%s", i18n.T("LabelName", nil))
 	}
+	if err := validateNameLength("secret name", req.Name); err != nil {
+		return err
+	}
 	if len(req.Value) == 0 {
 		return fmt.Errorf("%s", i18n.T("LabelValue", nil))
 	}

--- a/server/grpc/services/group_service.go
+++ b/server/grpc/services/group_service.go
@@ -204,7 +204,7 @@ func groupError(err error) error {
 		return status.Error(codes.NotFound, err.Error())
 	case strings.Contains(msg, "already exists") || strings.Contains(msg, "duplicate") || strings.Contains(msg, "in use"):
 		return status.Error(codes.AlreadyExists, err.Error())
-	case strings.Contains(msg, "required") || strings.Contains(msg, "invalid"):
+	case strings.Contains(msg, "required") || strings.Contains(msg, "invalid") || strings.Contains(msg, "exceeds"):
 		return status.Error(codes.InvalidArgument, err.Error())
 	case strings.Contains(msg, "permission") || strings.Contains(msg, "denied"):
 		return status.Error(codes.PermissionDenied, "access denied")

--- a/server/grpc/services/group_service_test.go
+++ b/server/grpc/services/group_service_test.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/keyorixhq/keyorix/internal/testhelper"
@@ -73,6 +74,26 @@ func TestGroupService_Members(t *testing.T) {
 	members, err = svc.GetGroupMembers(groupCtx(), &pb.GetGroupMembersRequest{Id: g.GetId()})
 	require.NoError(t, err)
 	assert.Empty(t, members.GetMembers())
+}
+
+// TestGroupService_NameLengthMatchesHTTP verifies gRPC rejects an over-255-char Name
+// with the same limit HTTP's `validate:"...,max=255"` tag enforces (backlog #190) —
+// the core-layer CreateGroup/UpdateGroup validation both transports call must reject
+// it, not just the (gRPC-bypassed) HTTP validator.
+func TestGroupService_NameLengthMatchesHTTP(t *testing.T) {
+	svc, _ := newGroupService(t)
+	tooLong := strings.Repeat("a", 256)
+
+	_, err := svc.CreateGroup(groupCtx(), &pb.CreateGroupRequest{Name: tooLong})
+	require.Error(t, err, "a 256-char group name must be rejected over gRPC, matching HTTP's 255-char cap")
+
+	// A name at exactly the limit is still accepted.
+	g, err := svc.CreateGroup(groupCtx(), &pb.CreateGroupRequest{Name: strings.Repeat("a", 255)})
+	require.NoError(t, err)
+
+	// UpdateGroup enforces the same cap.
+	_, err = svc.UpdateGroup(groupCtx(), &pb.UpdateGroupRequest{Id: g.GetId(), Name: tooLong})
+	require.Error(t, err, "a 256-char rename must be rejected over gRPC, matching HTTP's 255-char cap")
 }
 
 func TestGroupService_Unauthenticated(t *testing.T) {

--- a/server/grpc/services/secret_service.go
+++ b/server/grpc/services/secret_service.go
@@ -370,7 +370,7 @@ func mapSecretError(err error) error {
 		return status.Error(codes.AlreadyExists, "secret with this name already exists")
 	case strings.Contains(msg, "unknown rotation charset"), strings.Contains(msg, "out of range"),
 		strings.Contains(msg, "must be set together"), strings.Contains(msg, "unknown rotation backend"),
-		strings.Contains(msg, "no rotation backends"):
+		strings.Contains(msg, "no rotation backends"), strings.Contains(msg, "exceeds"):
 		return status.Error(codes.InvalidArgument, msg)
 	default:
 		return status.Error(codes.Internal, "secret operation failed")

--- a/server/grpc/services/secret_service_test.go
+++ b/server/grpc/services/secret_service_test.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -274,6 +275,27 @@ func TestSecretService_CreateSecret_Validation(t *testing.T) {
 	})
 	require.Error(t, err)
 	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
+// TestSecretService_CreateSecret_NameLengthMatchesHTTP verifies gRPC rejects an
+// over-255-char secret Name with the same limit HTTP's `validate:"...,max=255"` tag
+// enforces (backlog #190) — internal/core.CreateSecret, which both transports call,
+// must reject it rather than only the (gRPC-bypassed) HTTP validator.
+func TestSecretService_CreateSecret_NameLengthMatchesHTTP(t *testing.T) {
+	r := newSecretTestRig(t)
+	ctx := authCtx(1, "writer", "secrets.write", "secrets.read")
+
+	_, err := r.svc.CreateSecret(ctx, &pb.CreateSecretRequest{
+		Name: strings.Repeat("a", 256), Value: "v", ProjectId: 1, EnvironmentId: 1, Type: "password",
+	})
+	require.Error(t, err, "a 256-char secret name must be rejected over gRPC, matching HTTP's 255-char cap")
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+
+	// A name at exactly the limit is still accepted.
+	_, err = r.svc.CreateSecret(ctx, &pb.CreateSecretRequest{
+		Name: strings.Repeat("a", 255), Value: "v", ProjectId: 1, EnvironmentId: 1, Type: "password",
+	})
+	require.NoError(t, err)
 }
 
 func TestSecretService_GetSecret(t *testing.T) {

--- a/server/validation/validator.go
+++ b/server/validation/validator.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"regexp"
 	"strings"
+	"unicode"
 
 	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/utils/safeconv"
@@ -155,9 +156,25 @@ func (v *Validator) applyRule(fieldName string, field reflect.Value, ruleName, p
 		return v.validateNumeric(field)
 	case "oneof":
 		return v.validateOneOf(field, param)
+	case "identifier":
+		return v.validateIdentifier(field)
 	}
 
 	return nil
+}
+
+// isBlank reports whether s has no visible content once ordinary whitespace and
+// Unicode zero-width/format (Cf) and control (Cc) characters (e.g. U+200B ZERO WIDTH
+// SPACE) are disregarded. Used by isEmpty so a whitespace-only or zero-width-only
+// string doesn't pass a `required` check.
+func isBlank(s string) bool {
+	for _, r := range s {
+		if unicode.IsSpace(r) || unicode.Is(unicode.Cf, r) || unicode.Is(unicode.Cc, r) {
+			continue
+		}
+		return false
+	}
+	return true
 }
 
 // isEmpty checks if a field is empty. A nil pointer/interface is empty (and
@@ -169,10 +186,13 @@ func (v *Validator) applyRule(fieldName string, field reflect.Value, ruleName, p
 // from "explicitly set to the zero value" (non-nil — must still satisfy
 // every other rule, e.g. reject a `max_reads: 0` that a `min=1` tag forbids,
 // rather than silently letting the zero value pass as if it were absent).
+// A string field is additionally treated as empty when it is blank per isBlank
+// (whitespace-only or composed solely of Unicode zero-width/format/control
+// characters), so such a value can't slip past a `required` check.
 func (v *Validator) isEmpty(field reflect.Value) bool {
 	switch field.Kind() {
 	case reflect.String:
-		return field.String() == ""
+		return isBlank(field.String())
 	case reflect.Slice, reflect.Map, reflect.Array:
 		return field.Len() == 0
 	case reflect.Pointer, reflect.Interface:
@@ -395,6 +415,35 @@ func (v *Validator) validateNumeric(field reflect.Value) error {
 	numericRegex := regexp.MustCompile(`^[0-9]+$`)
 	if !numericRegex.MatchString(str) {
 		return fmt.Errorf("%s: must contain only numeric characters", i18n.T("ErrorValidation", nil))
+	}
+
+	return nil
+}
+
+// identifierRegex matches a safe resource-identifier charset: letters, digits,
+// spaces, `-`, and `_`. Deliberately excludes punctuation with special meaning
+// elsewhere (CSV-formula triggers, path separators, shell/URL metacharacters) and
+// any character outside this allowlist, so it also rejects zero-width/homograph
+// characters that could otherwise render a name blank or visually deceptive.
+var identifierRegex = regexp.MustCompile(`^[a-zA-Z0-9 _-]+$`)
+
+// validateIdentifier validates that a string is a safe resource identifier: letters,
+// digits, spaces, `-`, `_` only (see identifierRegex). Opt-in via `validate:"identifier"`
+// for Name-like fields that should be restricted to a safe, unambiguous charset — not
+// applied globally, since some fields (e.g. free-form secret names) intentionally allow
+// a broader charset.
+func (v *Validator) validateIdentifier(field reflect.Value) error {
+	if field.Kind() != reflect.String {
+		return nil
+	}
+
+	str := field.String()
+	if str == "" {
+		return nil
+	}
+
+	if !identifierRegex.MatchString(str) {
+		return fmt.Errorf("%s: must contain only letters, digits, spaces, - or _", i18n.T("ErrorValidation", nil))
 	}
 
 	return nil

--- a/server/validation/validator_test.go
+++ b/server/validation/validator_test.go
@@ -46,6 +46,47 @@ func TestValidate_Required(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestValidate_Required_RejectsWhitespaceAndZeroWidthOnly(t *testing.T) {
+	type payload struct {
+		Name string `json:"name" validate:"required"`
+	}
+	v := NewValidator()
+
+	// Positive case: real content still passes.
+	require.NoError(t, v.Validate(payload{Name: "Payments"}))
+
+	for name, bad := range map[string]string{
+		"pure whitespace":      "   \t\n  ",
+		"zero-width space":     "\u200b\u200b",
+		"zero-width + spaces":  "  \u200b \u200b  ",
+		"non-breaking + ZWNBS": "\u00a0\ufeff",
+	} {
+		err := v.Validate(payload{Name: bad})
+		require.Error(t, err, name)
+	}
+}
+
+func TestValidate_Identifier(t *testing.T) {
+	type payload struct {
+		Name string `json:"name" validate:"omitempty,identifier"`
+	}
+	v := NewValidator()
+
+	for _, good := range []string{"", "Payments", "prod-db_01", "team 42"} {
+		require.NoError(t, v.Validate(payload{Name: good}), good)
+	}
+	zwsp := string(rune(0x200B)) // ZERO WIDTH SPACE
+	for _, bad := range []string{
+		"=cmd|'/c calc'!A1",
+		"name" + zwsp + "with" + zwsp + "zero" + zwsp + "width",
+		"path/traversal",
+		"<script>",
+		"semicolon;here",
+	} {
+		require.Error(t, v.Validate(payload{Name: bad}), bad)
+	}
+}
+
 func TestValidate_Omitempty_SkipsRemainingRules(t *testing.T) {
 	type payload struct {
 		Nickname string `json:"nickname" validate:"omitempty,min=3"`


### PR DESCRIPTION
Replaces #565 (that PR's head branch had to be deleted/recreated during a rebase in this environment, which GitHub does not allow reopening after).

Rebased onto current main and trimmed to just the still-needed parts:
- #189: server/validation's `required` rule now trims and rejects Unicode zero-width/format (Cf) and control (Cc) characters, so a whitespace-only or invisible-character name no longer passes presence validation; adds an opt-in `identifier` rule for Name-like fields restricted to a safe charset.
- #190: enforce the 255-char Name cap in internal/core (CreateGroup/UpdateGroup/CreateSecret) so gRPC — which never runs the HTTP validator — inherits the same limit HTTP already enforces; fixes gRPC error-mapping helpers to surface this as InvalidArgument instead of Internal.

Dropped from the original PR: #148 (CSV formula injection) and #158 (Slack/Teams mrkdwn escaping) — both already fixed on main by #607 and #609 respectively.