### PR TITLE
harden(legal-hold): require admin-tier to place a hold, record the lift reason (#377/#378/#380)

### DIFF
--- a/internal/cli/legalhold/legalhold.go
+++ b/internal/cli/legalhold/legalhold.go
@@ -80,12 +80,16 @@ var placeCmd = &cobra.Command{
 }
 
 var liftYes bool
+var liftReason string
 
 var liftCmd = &cobra.Command{
 	Use:          "lift",
 	Short:        "Lift the active legal hold (resume purges)",
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, _ []string) error {
+		if liftReason == "" {
+			return fmt.Errorf("--reason is required")
+		}
 		if !liftYes {
 			fmt.Print("Lift the active legal hold? This immediately re-arms purge/retention/JIT-expiry\njobs and cannot be undone from here. Type 'yes' to confirm: ")
 			var answer string
@@ -99,7 +103,7 @@ var liftCmd = &cobra.Command{
 		if !ok {
 			return fmt.Errorf("not connected to a server — run: keyorix connect <server>")
 		}
-		if err := c.Delete(context.Background(), "/api/v1/legal-hold"); err != nil {
+		if err := c.DeleteWithBody(context.Background(), "/api/v1/legal-hold", map[string]string{"reason": liftReason}); err != nil {
 			return err
 		}
 		fmt.Println("Legal hold lifted. Purge jobs will resume on their next tick.")
@@ -110,5 +114,6 @@ var liftCmd = &cobra.Command{
 func init() {
 	placeCmd.Flags().StringVar(&placeReason, "reason", "", "Why the hold is placed (required, recorded for audit)")
 	liftCmd.Flags().BoolVar(&liftYes, "yes", false, "Skip the confirmation prompt")
+	liftCmd.Flags().StringVar(&liftReason, "reason", "", "Why the hold is lifted (required, recorded for audit)")
 	LegalHoldCmd.AddCommand(statusCmd, placeCmd, liftCmd)
 }

--- a/internal/cli/legalhold/legalhold_test.go
+++ b/internal/cli/legalhold/legalhold_test.go
@@ -28,6 +28,9 @@ func TestLiftRequiresConfirmation(t *testing.T) {
 	t.Setenv("KEYORIX_SERVER", srv.URL)
 	t.Setenv("KEYORIX_TOKEN", "test-token")
 
+	liftReason = "test lift reason"
+	defer func() { liftReason = "" }()
+
 	t.Run("declining the prompt aborts without calling the server", func(t *testing.T) {
 		deleteCalls = 0
 		liftYes = false
@@ -54,5 +57,15 @@ func TestLiftRequiresConfirmation(t *testing.T) {
 		cmd.SetIn(strings.NewReader(""))
 		require.NoError(t, liftCmd.RunE(cmd, nil))
 		assert.Equal(t, 1, deleteCalls, "--yes must skip the prompt and lift the hold")
+	})
+
+	t.Run("missing --reason is refused before the prompt", func(t *testing.T) {
+		deleteCalls = 0
+		liftYes = true
+		liftReason = ""
+		defer func() { liftYes = false; liftReason = "test lift reason" }()
+		cmd := &cobra.Command{}
+		require.Error(t, liftCmd.RunE(cmd, nil))
+		assert.Equal(t, 0, deleteCalls, "a missing reason must not lift the hold")
 	})
 }

--- a/internal/core/concurrency_legal_hold_test.go
+++ b/internal/core/concurrency_legal_hold_test.go
@@ -32,7 +32,7 @@ func TestConcurrency_PlaceLegalHold_OnlyOneWins(t *testing.T) {
 	dsn := "file:" + filepath.Join(t.TempDir(), "c.db") + "?_busy_timeout=10000&_journal_mode=WAL&_txlock=immediate"
 	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
 	require.NoError(t, err)
-	require.NoError(t, db.AutoMigrate(&models.LegalHold{}, &models.AuditEvent{}))
+	require.NoError(t, db.AutoMigrate(&models.LegalHold{}, &models.AuditEvent{}, &models.Role{}, &models.UserRole{}))
 	// The production migration (storage.ensureLegalHoldActiveIndex) creates this;
 	// replicate it for the test DB.
 	require.NoError(t, db.Exec(
@@ -41,6 +41,9 @@ func TestConcurrency_PlaceLegalHold_OnlyOneWins(t *testing.T) {
 
 	c := core.NewKeyorixCore(store.NewLocalStorage(db))
 	ctx := context.Background()
+	// #377: placement now requires an admin-tier role.
+	require.NoError(t, db.Create(&models.Role{ID: 2, Name: "admin"}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 2}).Error)
 
 	const callers = 32
 	var succeeded atomic.Int64

--- a/internal/core/data_retention.go
+++ b/internal/core/data_retention.go
@@ -70,8 +70,10 @@ func (c *KeyorixCore) RetentionPolicy() RetentionPolicy {
 // types. When anything was removed it emits one system-actored
 // `data.retention_purged` audit event with the per-type counts.
 //
-// CALLERS MUST gate this on legal-hold status (the scheduler does): an active hold
-// must preserve all records, so this is not invoked while a hold is in effect.
+// #378: the scheduler also gates its own call on legal-hold status, but this function
+// does not rely solely on that caller discipline (a doc-comment invariant checked only
+// upstream is not self-enforcing) — it re-checks the hold itself below, immediately
+// before any delete, so the invariant holds regardless of what future callers do.
 func (c *KeyorixCore) PurgeExpiredComplianceRecords(ctx context.Context, now time.Time, policy RetentionPolicy) (*RetentionResult, error) {
 	// Authoritative legal-hold re-check inside the locked purge (see PurgeExpiredSoftDeletes):
 	// closes the TOCTOU where a hold placed after the scheduler's pre-lock check would not

--- a/internal/core/legal_hold.go
+++ b/internal/core/legal_hold.go
@@ -64,9 +64,24 @@ func (c *KeyorixCore) legalHoldGuard(ctx context.Context) error {
 // and the loser's CreateLegalHold returns storage.ErrLegalHoldAlreadyActive, which
 // is mapped to the same "already active" client error as the pre-check below rather
 // than a 500.
+//
+// #377: placement used to be gated on only the plain system.write permission — the
+// same tier LiftLegalHold used before #157 tightened it — letting any system.write
+// holder place a bogus/decoy hold that halts all four purge/prune schedulers
+// deployment-wide until someone lifts it (reversible griefing, not data loss, but
+// still an under-authorized compliance control). Placement has no prior actor to
+// compare against the way lift compares against the placer, so the direct mirror of
+// #157's "placer-or-admin-tier" rule is: only an admin-tier (permission-bypass)
+// principal may place a hold. A denied placement attempt is itself audited.
 func (c *KeyorixCore) PlaceLegalHold(ctx context.Context, actorID uint, reason string) (*models.LegalHold, error) {
 	if reason == "" {
 		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "a reason is required to place a legal hold")
+	}
+	if c.adminRoleName(ctx, actorID) == "" {
+		c.writeAuditEventFailed(ctx, EventLegalHoldPlaced, actorPtr(actorID), "",
+			fmt.Sprintf("legal hold placement DENIED: actor %d is not an admin-tier principal", actorID))
+		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorPermissionDenied", nil),
+			"only an admin-tier principal may place a legal hold")
 	}
 	if active, err := c.storage.GetActiveLegalHold(ctx); err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
@@ -89,7 +104,15 @@ func (c *KeyorixCore) PlaceLegalHold(ctx context.Context, actorID uint, reason s
 
 // LiftLegalHold releases the active hold so the purge jobs resume. Refuses if no
 // hold is active. actorID is the lifting admin.
-func (c *KeyorixCore) LiftLegalHold(ctx context.Context, actorID uint) error {
+//
+// #380: placement always records a Reason, but lift previously recorded none — the
+// audit trail showed WHO/WHEN a hold was lifted but never WHY. reason is required,
+// mirroring placement's own required-reason precedent, and is persisted on the row
+// (ReleaseReason) and in the audit description.
+func (c *KeyorixCore) LiftLegalHold(ctx context.Context, actorID uint, reason string) error {
+	if reason == "" {
+		return fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "a reason is required to lift a legal hold")
+	}
 	hold, err := c.storage.GetActiveLegalHold(ctx)
 	if err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
@@ -101,10 +124,11 @@ func (c *KeyorixCore) LiftLegalHold(ctx context.Context, actorID uint) error {
 	hold.Released = true
 	hold.ReleasedBy = actorID
 	hold.ReleasedAt = &now
+	hold.ReleaseReason = reason
 	if err := c.storage.UpdateLegalHold(ctx, hold); err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}
 	c.writeAuditEvent(ctx, EventLegalHoldLifted, actorPtr(actorID), nil,
-		fmt.Sprintf("legal hold %d lifted", hold.ID))
+		fmt.Sprintf("legal hold %d lifted: %s", hold.ID, reason))
 	return nil
 }

--- a/internal/core/legal_hold_external_test.go
+++ b/internal/core/legal_hold_external_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/keyorixhq/keyorix/internal/testhelper"
 	"github.com/stretchr/testify/assert"
@@ -17,6 +18,7 @@ func TestLegalHold_PlaceAndLift(t *testing.T) {
 	defer h.Cleanup()
 	require.NoError(t, h.DB.AutoMigrate(&models.LegalHold{}, &models.AuditEvent{}))
 	ctx := context.Background()
+	h.AssignUserRole(t, 1, 2, nil) // #377: placement requires an admin-tier role
 
 	// No hold initially.
 	active, err := h.CoreService.IsLegalHoldActive(ctx)
@@ -40,14 +42,77 @@ func TestLegalHold_PlaceAndLift(t *testing.T) {
 	_, err = h.CoreService.PlaceLegalHold(ctx, 1, "another")
 	require.Error(t, err)
 
+	// Lifting requires a reason too (#380).
+	require.Error(t, h.CoreService.LiftLegalHold(ctx, 1, ""))
+
 	// Lift it.
-	require.NoError(t, h.CoreService.LiftLegalHold(ctx, 1))
+	require.NoError(t, h.CoreService.LiftLegalHold(ctx, 1, "litigation INC-7 resolved"))
 	active, err = h.CoreService.IsLegalHoldActive(ctx)
 	require.NoError(t, err)
 	assert.False(t, active)
 
 	// Lifting again (none active) is refused.
-	require.Error(t, h.CoreService.LiftLegalHold(ctx, 1))
+	require.Error(t, h.CoreService.LiftLegalHold(ctx, 1, "n/a"))
+}
+
+// #377: a plain (non-admin-tier) system.write-only principal must not be able to
+// place a legal hold — placement requires an admin-tier role, mirroring #157's
+// tightening of lift.
+func TestLegalHold_PlaceDeniedForNonAdmin(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(&models.LegalHold{}, &models.AuditEvent{}, &models.User{}, &models.UserRole{}))
+	ctx := context.Background()
+
+	// Actor 9 holds no role at all — not admin-tier.
+	_, err := h.CoreService.PlaceLegalHold(ctx, 9, "bogus decoy hold")
+	require.Error(t, err, "a non-admin-tier actor must not be able to place a legal hold")
+
+	active, aerr := h.CoreService.IsLegalHoldActive(ctx)
+	require.NoError(t, aerr)
+	assert.False(t, active, "the denied placement must not create a hold")
+
+	var failed int64
+	require.NoError(t, h.DB.Model(&models.AuditEvent{}).
+		Where("event_type = ? AND success = ?", core.EventLegalHoldPlaced, false).Count(&failed).Error)
+	assert.Equal(t, int64(1), failed, "the denied placement attempt must be audited")
+
+	// An admin-tier principal may place it.
+	h.AssignUserRole(t, 20, 2, nil) // role 2 = admin (global)
+	hold, err := h.CoreService.PlaceLegalHold(ctx, 20, "litigation INC-9")
+	require.NoError(t, err)
+	assert.False(t, hold.Released)
+}
+
+// #380: lifting a hold records the WHY, not just the who/when — the reason is
+// persisted on the row (ReleaseReason) and appears in the audit description, and an
+// empty reason is rejected just like placement's.
+func TestLegalHold_LiftRecordsReason(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(&models.LegalHold{}, &models.AuditEvent{}))
+	ctx := context.Background()
+	h.AssignUserRole(t, 1, 2, nil) // #377: placement requires an admin-tier role
+
+	hold, err := h.CoreService.PlaceLegalHold(ctx, 1, "litigation INC-11")
+	require.NoError(t, err)
+
+	// No reason -> rejected, hold stays active.
+	require.Error(t, h.CoreService.LiftLegalHold(ctx, 1, ""))
+	active, aerr := h.CoreService.IsLegalHoldActive(ctx)
+	require.NoError(t, aerr)
+	assert.True(t, active)
+
+	require.NoError(t, h.CoreService.LiftLegalHold(ctx, 1, "litigation INC-11 settled, no further preservation needed"))
+
+	var lifted models.LegalHold
+	require.NoError(t, h.DB.First(&lifted, hold.ID).Error)
+	assert.True(t, lifted.Released)
+	assert.Equal(t, "litigation INC-11 settled, no further preservation needed", lifted.ReleaseReason)
+
+	var evt models.AuditEvent
+	require.NoError(t, h.DB.Where("event_type = ? AND success = ?", core.EventLegalHoldLifted, true).First(&evt).Error)
+	assert.Contains(t, evt.Description, "litigation INC-11 settled, no further preservation needed")
 }
 
 // The compliance posture reflects an active legal hold.
@@ -60,6 +125,7 @@ func TestLegalHold_SurfacesInPosture(t *testing.T) {
 		&models.RotationPolicy{}, &models.SoDPolicy{},
 	))
 	ctx := context.Background()
+	h.AssignUserRole(t, 1, 2, nil) // #377: placement requires an admin-tier role
 
 	p, err := h.CoreService.GetCompliancePosture(ctx)
 	require.NoError(t, err)

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -112,13 +112,14 @@ func (SoDPolicy) TableName() string { return "sod_policies" }
 // hold is preserved. Placing/lifting is audited; the row history is the evidence
 // of when holds were in effect.
 type LegalHold struct {
-	ID         uint       `gorm:"primaryKey" json:"id"`
-	Reason     string     `json:"reason"`
-	PlacedBy   uint       `json:"placed_by"`
-	PlacedAt   time.Time  `json:"placed_at"`
-	Released   bool       `gorm:"index" json:"released"` // false = active
-	ReleasedBy uint       `json:"released_by,omitempty"`
-	ReleasedAt *time.Time `json:"released_at,omitempty"`
+	ID            uint       `gorm:"primaryKey" json:"id"`
+	Reason        string     `json:"reason"`
+	PlacedBy      uint       `json:"placed_by"`
+	PlacedAt      time.Time  `json:"placed_at"`
+	Released      bool       `gorm:"index" json:"released"` // false = active
+	ReleasedBy    uint       `json:"released_by,omitempty"`
+	ReleasedAt    *time.Time `json:"released_at,omitempty"`
+	ReleaseReason string     `json:"release_reason,omitempty"` // why the hold was lifted (#380)
 }
 
 // SSOLoginState is the short-lived CSRF/nonce state for an in-flight OIDC

--- a/server/http/handlers/legal_hold.go
+++ b/server/http/handlers/legal_hold.go
@@ -43,8 +43,11 @@ func (h *DashboardHandler) PlaceLegalHold(w http.ResponseWriter, r *http.Request
 	hold, err := h.coreService.PlaceLegalHold(r.Context(), actor.UserID, body.Reason)
 	if err != nil {
 		status := http.StatusInternalServerError
-		if strings.Contains(err.Error(), "required") || strings.Contains(err.Error(), "already active") {
+		switch {
+		case strings.Contains(err.Error(), "required") || strings.Contains(err.Error(), "already active"):
 			status = http.StatusBadRequest
+		case strings.Contains(err.Error(), "admin-tier principal may place"):
+			status = http.StatusForbidden
 		}
 		sendError(w, "Error", err.Error(), status, nil)
 		return
@@ -53,16 +56,27 @@ func (h *DashboardHandler) PlaceLegalHold(w http.ResponseWriter, r *http.Request
 	sendSuccess(w, map[string]interface{}{"hold": hold}, "Legal hold placed")
 }
 
-// LiftLegalHold handles DELETE /api/v1/legal-hold — release the active hold.
+// LiftLegalHold handles DELETE /api/v1/legal-hold — release the active hold. The
+// reason is carried in a JSON body since DELETE requests conventionally have no
+// query-string convention for this codebase's other DELETE-with-body endpoints.
 func (h *DashboardHandler) LiftLegalHold(w http.ResponseWriter, r *http.Request) {
 	actor := middleware.GetUserFromContext(r.Context())
 	if actor == nil {
 		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
 		return
 	}
-	if err := h.coreService.LiftLegalHold(r.Context(), actor.UserID); err != nil {
+	var body struct {
+		Reason string `json:"reason"`
+	}
+	if r.Body != nil {
+		// Body is optional at the transport level; LiftLegalHold itself enforces
+		// that reason is non-empty, mapped to 400 below.
+		_ = json.NewDecoder(r.Body).Decode(&body)
+	}
+	if err := h.coreService.LiftLegalHold(r.Context(), actor.UserID, body.Reason); err != nil {
 		status := http.StatusInternalServerError
-		if strings.Contains(err.Error(), "no legal hold") {
+		switch {
+		case strings.Contains(err.Error(), "no legal hold") || strings.Contains(err.Error(), "a reason is required"):
 			status = http.StatusBadRequest
 		}
 		sendError(w, "Error", err.Error(), status, nil)


### PR DESCRIPTION
## Summary

Companion gaps to the legal-hold control (ISO 27001 A.5.34 / eDiscovery / DORA record-keeping):

- **#377 LOW** — `PlaceLegalHold` was gated on plain `system.write`, the same tier as lift, so any `system.write` holder could place a bogus/decoy hold and halt every purge/prune scheduler deployment-wide until someone lifted it (reversible griefing, but an under-authorized compliance control). Placement now requires an admin-tier (permission-bypass) principal — the direct mirror of the "placer-or-admin-tier" precedent, since placement has no prior actor to compare against. A denied placement attempt is itself audited.
- **#380 LOW** — `LiftLegalHold` recorded who lifted a hold and when, but never *why*, unlike placement's required `Reason`. `--reason` is now required on both the CLI (`keyorix legal-hold lift --reason ...`) and the HTTP `DELETE /api/v1/legal-hold` path, persisted on the row (`ReleaseReason`) and in the audit description. The CLI now sends the reason via `DeleteWithBody`.

Verified against current `main` that the other two findings in this cluster are already closed and need no further change:
- **#378 MEDIUM** (check-then-act purge with no defense-in-depth) — already fixed: `PurgeExpiredSoftDeletes` and `PurgeExpiredComplianceRecords` both re-check `legalHoldGuard` inside the scheduler lock, immediately before their deletes.
- **#379 LOW** (`PlaceLegalHold` TOCTOU letting two concurrent calls both create an active hold) — already fixed by the partial unique index on `legal_holds (released) WHERE released = false`, which surfaces the loser as `storage.ErrLegalHoldAlreadyActive`.

## Test plan
- [x] `go build ./...` and `go build -o .scratch/keyorix-server ./server`
- [x] `go test ./internal/core/... ./internal/cli/legalhold/... ./internal/storage/... ./server/http/...`
- [x] `gosec -severity medium -exclude-generated` on touched packages: 0 issues
- [x] `golangci-lint run` on touched packages: 0 issues
- [x] `cd operator && GOWORK=off go build ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)