### PR TITLE
harden(compliance,rotation,anomaly): close fail-open gaps in the dashboard/posture family (#358-365)

### DIFF
--- a/internal/core/anomaly.go
+++ b/internal/core/anomaly.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"fmt"
+	"log"
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/storage/models"
@@ -144,6 +145,12 @@ func (d *AnomalyDetector) RunDetection(ctx context.Context, secrets []models.Sec
 		// Build 30-day baseline
 		baselineLogs, err := d.storage.ListSecretAccessLogs(ctx, secret.ID, baselineWindow)
 		if err != nil {
+			// #365: the aggregate failure count below already surfaces a non-nil error to
+			// the scheduler (which logs it), but that only says "N secret(s) failed" — log
+			// which secret and which query so an operator can tell a transient DB hiccup
+			// from a genuine gap. Since the detection window is only the last hour, a
+			// skipped secret here is never retroactively re-evaluated.
+			log.Printf("anomaly detection: baseline access-log read for secret %d: %v — skipping detection for this secret this pass", secret.ID, err)
 			failures++
 			continue
 		}
@@ -155,6 +162,7 @@ func (d *AnomalyDetector) RunDetection(ctx context.Context, secrets []models.Sec
 		// Get recent accesses over the lookback window.
 		recentLogs, err := d.storage.ListSecretAccessLogs(ctx, secret.ID, window)
 		if err != nil {
+			log.Printf("anomaly detection: detection-window access-log read for secret %d: %v — skipping detection for this secret this pass", secret.ID, err)
 			failures++
 			continue
 		}

--- a/internal/core/anomaly_test.go
+++ b/internal/core/anomaly_test.go
@@ -81,6 +81,45 @@ type detectionTestErr struct{}
 
 func (*detectionTestErr) Error() string { return "boom" }
 
+// perSecretFailStore fails ListSecretAccessLogs only for a chosen secret ID (on
+// whichever call — baseline or recent-window — comes first for that secret), letting
+// other secrets in the same RunDetection pass succeed normally. Lets a test tell "one
+// secret's read failed" apart from "every read failed".
+type perSecretFailStore struct {
+	*captureStore
+	failSecretID uint
+}
+
+func (s *perSecretFailStore) ListSecretAccessLogs(ctx context.Context, secretID uint, since time.Time) ([]models.SecretAccessLog, error) {
+	if secretID == s.failSecretID {
+		return nil, assertAnErr
+	}
+	return s.captureStore.ListSecretAccessLogs(ctx, secretID, since)
+}
+
+// #365: a ListSecretAccessLogs failure for one secret must (a) be logged with the
+// specific secret ID so an operator can tell a transient hiccup from a genuine gap
+// (the detection window is only the last hour and is never retroactively
+// re-evaluated), and (b) not block detection for a sibling secret in the same pass.
+func TestRunDetection_LogsAndContinuesOnAccessLogReadError(t *testing.T) {
+	store := &perSecretFailStore{captureStore: &captureStore{}, failSecretID: 1}
+	d := NewAnomalyDetector(store)
+
+	buf, restore := captureLog(t)
+	defer restore()
+
+	err := d.RunDetection(context.Background(), []models.SecretNode{{ID: 1, Name: "broken"}, {ID: 2, Name: "healthy"}})
+	require.Error(t, err, "a per-secret read failure must surface as a non-nil pass error, not a silent success")
+	assert.Contains(t, err.Error(), "1 storage failure")
+
+	// The healthy secret's baseline+recent calls both went through despite secret 1's
+	// failure — RunDetection didn't abort the whole pass.
+	assert.GreaterOrEqual(t, len(store.sinces), 2, "the healthy secret's reads still ran")
+
+	logged := buf.String()
+	assert.Contains(t, logged, "secret 1", "the failing secret's ID must appear in the operator-visible log line")
+}
+
 func TestBuildBaseline(t *testing.T) {
 	now := time.Date(2026, 6, 17, 12, 0, 0, 0, time.UTC)
 	windowStart := now.Add(-1 * time.Hour) // the live detection window — excluded from the baseline

--- a/internal/core/anomaly_test.go
+++ b/internal/core/anomaly_test.go
@@ -105,10 +105,10 @@ func TestRunDetection_LogsAndContinuesOnAccessLogReadError(t *testing.T) {
 	store := &perSecretFailStore{captureStore: &captureStore{}, failSecretID: 1}
 	d := NewAnomalyDetector(store)
 
-	buf, restore := captureLog(t)
-	defer restore()
-
-	err := d.RunDetection(context.Background(), []models.SecretNode{{ID: 1, Name: "broken"}, {ID: 2, Name: "healthy"}})
+	var err error
+	logged := captureLog(t, func() {
+		err = d.RunDetection(context.Background(), []models.SecretNode{{ID: 1, Name: "broken"}, {ID: 2, Name: "healthy"}})
+	})
 	require.Error(t, err, "a per-secret read failure must surface as a non-nil pass error, not a silent success")
 	assert.Contains(t, err.Error(), "1 storage failure")
 
@@ -116,7 +116,6 @@ func TestRunDetection_LogsAndContinuesOnAccessLogReadError(t *testing.T) {
 	// failure — RunDetection didn't abort the whole pass.
 	assert.GreaterOrEqual(t, len(store.sinces), 2, "the healthy secret's reads still ran")
 
-	logged := buf.String()
 	assert.Contains(t, logged, "secret 1", "the failing secret's ID must appear in the operator-visible log line")
 }
 

--- a/internal/core/compliance_evidence_test.go
+++ b/internal/core/compliance_evidence_test.go
@@ -1,0 +1,89 @@
+// compliance_evidence_test.go — #362: GenerateComplianceEvidence independently
+// re-queries several of the same signals GetCompliancePosture already rolled up
+// (risk exceptions, SoD violations, rotation status, per-project campaigns/
+// break-glass) rather than reusing the posture's result — so each of those had its
+// OWN copy of the #136 fail-open bug shape. These tests pin that a query failure on
+// the EVIDENCE PACK'S OWN copy of each query now flips ev.Posture.Degraded (via the
+// shared posture.degrade helper) instead of silently leaving the archivable,
+// timestamped evidence pack's slice at its pre-initialized empty value —
+// indistinguishable from "queried, found genuinely none".
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// #362: risk_exceptions — models.RiskException deliberately not migrated.
+func TestGenerateComplianceEvidence_DegradesOnRiskExceptionsQueryError(t *testing.T) {
+	c := compliancePostureCore(t)
+
+	ev, err := c.GenerateComplianceEvidence(context.Background())
+	require.NoError(t, err, "a single failed evidence sub-query must not abort the whole pack")
+
+	assert.Empty(t, ev.RiskExceptions, "the field itself still reads as its pre-initialized empty value")
+	require.NotNil(t, ev.Posture)
+	assert.True(t, ev.Posture.Degraded, "a failed risk-exceptions query must flip the shared Degraded signal")
+	assert.True(t, containsSubstring(ev.Posture.DegradedReasons, "evidence:risk_exceptions"), "got %v", ev.Posture.DegradedReasons)
+}
+
+// #362: sod_violations — models.SoDPolicy deliberately not migrated.
+func TestGenerateComplianceEvidence_DegradesOnSoDViolationsQueryError(t *testing.T) {
+	c := compliancePostureCore(t)
+
+	ev, err := c.GenerateComplianceEvidence(context.Background())
+	require.NoError(t, err)
+
+	assert.Empty(t, ev.SoDViolations)
+	require.NotNil(t, ev.Posture)
+	assert.True(t, ev.Posture.Degraded)
+	assert.True(t, containsSubstring(ev.Posture.DegradedReasons, "evidence:sod_violations"), "got %v", ev.Posture.DegradedReasons)
+}
+
+// #362: rotation_overdue — models.RotationPolicy deliberately not migrated. Before the
+// fix this was the permanently-archivable evidence pack's own copy of #358.
+func TestGenerateComplianceEvidence_DegradesOnRotationOverdueQueryError(t *testing.T) {
+	c := compliancePostureCore(t)
+
+	ev, err := c.GenerateComplianceEvidence(context.Background())
+	require.NoError(t, err)
+
+	assert.Empty(t, ev.RotationOverdue)
+	require.NotNil(t, ev.Posture)
+	assert.True(t, ev.Posture.Degraded)
+	assert.True(t, containsSubstring(ev.Posture.DegradedReasons, "evidence:rotation_overdue"), "got %v", ev.Posture.DegradedReasons)
+}
+
+// #362: campaigns, per project — models.AccessReviewCampaign deliberately not migrated.
+func TestGenerateComplianceEvidence_DegradesOnCampaignsQueryError(t *testing.T) {
+	c, db := compliancePostureCoreWithProject(t)
+	require.NoError(t, db.AutoMigrate(&models.BreakGlassActivation{}, &models.UserRole{}, &models.GroupRole{}, &models.AuditEvent{}))
+
+	ev, err := c.GenerateComplianceEvidence(context.Background())
+	require.NoError(t, err)
+
+	assert.Empty(t, ev.Campaigns)
+	require.NotNil(t, ev.Posture)
+	assert.True(t, ev.Posture.Degraded)
+	assert.True(t, containsSubstring(ev.Posture.DegradedReasons, "evidence:campaigns:project=1"), "got %v", ev.Posture.DegradedReasons)
+}
+
+// #362: break-glass register, per project — models.BreakGlassActivation deliberately
+// not migrated. The evidence pack's break-glass register hiding an active emergency
+// activation is the most severe of this family.
+func TestGenerateComplianceEvidence_DegradesOnBreakGlassQueryError(t *testing.T) {
+	c, db := compliancePostureCoreWithProject(t)
+	require.NoError(t, db.AutoMigrate(&models.AccessReviewCampaign{}, &models.AccessReviewItem{}, &models.UserRole{}, &models.GroupRole{}, &models.AuditEvent{}))
+
+	ev, err := c.GenerateComplianceEvidence(context.Background())
+	require.NoError(t, err)
+
+	assert.Empty(t, ev.BreakGlass, "the register must not silently read as empty (= no emergency access) on a query error")
+	require.NotNil(t, ev.Posture)
+	assert.True(t, ev.Posture.Degraded)
+	assert.True(t, containsSubstring(ev.Posture.DegradedReasons, "evidence:break_glass:project=1"), "got %v", ev.Posture.DegradedReasons)
+}

--- a/internal/core/compliance_posture_test.go
+++ b/internal/core/compliance_posture_test.go
@@ -21,12 +21,21 @@ import (
 // (e.g. from a missing table) are expected to soft-fail into Degraded, not abort.
 func compliancePostureCore(t *testing.T) *KeyorixCore {
 	t.Helper()
+	c, _ := compliancePostureCoreDB(t)
+	return c
+}
+
+// compliancePostureCoreDB is compliancePostureCore but also returns the underlying
+// *gorm.DB, so a test can AutoMigrate additional tables to control precisely which
+// sub-rollup query fails (a not-migrated table) versus succeeds (migrated, empty).
+func compliancePostureCoreDB(t *testing.T) (*KeyorixCore, *gorm.DB) {
+	t.Helper()
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
 	require.NoError(t, db.AutoMigrate(&models.Project{}))
 	c := &KeyorixCore{storage: store.NewLocalStorage(db)}
 	c.now = func() time.Time { return time.Date(2026, 7, 2, 12, 0, 0, 0, time.UTC) }
-	return c
+	return c, db
 }
 
 // failingLegalHoldStore wraps LocalStorage and fails GetActiveLegalHold, simulating a DB
@@ -123,4 +132,123 @@ func containsSubstring(ss []string, sub string) bool {
 		}
 	}
 	return false
+}
+
+// compliancePostureCoreWithProject is compliancePostureCoreDB plus one real project
+// row, so accessGovernancePosture's per-project loop (campaigns / break-glass /
+// dormant grants) actually runs instead of a no-op over zero projects.
+func compliancePostureCoreWithProject(t *testing.T) (*KeyorixCore, *gorm.DB) {
+	t.Helper()
+	c, db := compliancePostureCoreDB(t)
+	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "proj"}).Error)
+	return c, db
+}
+
+// #358: GetRotationStatus's own error (e.g. a rotation-policy listing failure) must
+// flip the posture's Rotation sub-rollup to degraded instead of leaving
+// CoveredSecrets/Overdue/DueSoon at their zero-value "0 secrets overdue" reading.
+func TestGetCompliancePosture_DegradedOnRotationQueryError(t *testing.T) {
+	c := compliancePostureCore(t) // models.RotationPolicy deliberately NOT migrated
+
+	p, err := c.GetCompliancePosture(context.Background())
+	require.NoError(t, err, "a single failed sub-rollup must not abort the whole snapshot")
+
+	assert.Equal(t, RotationPosture{}, p.Rotation, "the field itself still reads as its zero value")
+	assert.True(t, p.Degraded, "a failed rotation query must flip Degraded — 0 overdue is UNKNOWN, not verified-clean")
+	assert.True(t, containsSubstring(p.DegradedReasons, "rotation"), "expected a rotation entry in DegradedReasons, got %v", p.DegradedReasons)
+}
+
+// #359: a failed ListAnomalyAlerts query must not read as "no open alerts" — that masks
+// active, unreviewed high-severity access anomalies.
+func TestGetCompliancePosture_DegradedOnAnomalyQueryError(t *testing.T) {
+	c := compliancePostureCore(t) // models.AnomalyAlert deliberately NOT migrated
+
+	p, err := c.GetCompliancePosture(context.Background())
+	require.NoError(t, err)
+
+	assert.Equal(t, AnomaliesPosture{}, p.Anomalies)
+	assert.True(t, p.Degraded)
+	assert.True(t, containsSubstring(p.DegradedReasons, "anomalies"), "expected an anomalies entry in DegradedReasons, got %v", p.DegradedReasons)
+}
+
+// #360: classificationPosture has three separate Count...ByClassification calls
+// (dynamic configs, machine identities, machine credentials) that each independently
+// fail-opened to a zero (= "fully classified") count. Migrating SecretNode/Environment
+// but NOT the three classification tables isolates exactly those three calls as the
+// failure, demonstrating all three degrade independently in one pass.
+func TestGetCompliancePosture_DegradedOnClassificationCountQueryErrors(t *testing.T) {
+	c, db := compliancePostureCoreDB(t)
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.Environment{}))
+	// models.DynamicSecretConfig / MachineIdentity / MachineIdentityCredential deliberately NOT migrated.
+
+	p, err := c.GetCompliancePosture(context.Background())
+	require.NoError(t, err)
+
+	assert.Equal(t, ClassificationCounts{}, p.Classification.DynamicConfigs)
+	assert.Equal(t, ClassificationCounts{}, p.Classification.MachineIdentities)
+	assert.Equal(t, ClassificationCounts{}, p.Classification.MachineCredentials)
+	assert.True(t, p.Degraded)
+	assert.True(t, containsSubstring(p.DegradedReasons, "classification:dynamic_configs"), "got %v", p.DegradedReasons)
+	assert.True(t, containsSubstring(p.DegradedReasons, "classification:machine_identities"), "got %v", p.DegradedReasons)
+	assert.True(t, containsSubstring(p.DegradedReasons, "classification:machine_credentials"), "got %v", p.DegradedReasons)
+}
+
+// #361(a): a project whose ListAccessReviewCampaigns query errors must not be silently
+// dropped from ProjectsNeverReviewed/ProjectsWithOpenCampaign/PendingItems/ProjectsOverdue.
+func TestGetCompliancePosture_DegradedOnAccessReviewCampaignsQueryError(t *testing.T) {
+	c, db := compliancePostureCoreWithProject(t)
+	require.NoError(t, db.AutoMigrate(&models.BreakGlassActivation{}, &models.UserRole{}, &models.GroupRole{}, &models.AuditEvent{}))
+	// models.AccessReviewCampaign deliberately NOT migrated.
+
+	p, err := c.GetCompliancePosture(context.Background())
+	require.NoError(t, err)
+
+	assert.True(t, p.Degraded)
+	assert.True(t, containsSubstring(p.DegradedReasons, "access_governance:campaigns:project=1"), "got %v", p.DegradedReasons)
+}
+
+// #361(b): a project's ListBreakGlassActivations error must not silently omit it from
+// EmergencyAccess — the most severe of the three, since it hides CURRENTLY-ACTIVE
+// emergency access from the report.
+func TestGetCompliancePosture_DegradedOnBreakGlassQueryError(t *testing.T) {
+	c, db := compliancePostureCoreWithProject(t)
+	require.NoError(t, db.AutoMigrate(&models.AccessReviewCampaign{}, &models.AccessReviewItem{}, &models.UserRole{}, &models.GroupRole{}, &models.AuditEvent{}))
+	// models.BreakGlassActivation deliberately NOT migrated.
+
+	p, err := c.GetCompliancePosture(context.Background())
+	require.NoError(t, err)
+
+	assert.Equal(t, EmergencyAccessPosture{}, p.EmergencyAccess, "the field itself still reads as its zero value — no visible active break-glass")
+	assert.True(t, p.Degraded, "an unqueryable break-glass register must flip Degraded rather than silently read as no emergency access")
+	assert.True(t, containsSubstring(p.DegradedReasons, "emergency_access:project=1"), "got %v", p.DegradedReasons)
+}
+
+// #361(c): countDormantRoleGrants's two internal queries (ListProjectRoleAssignments,
+// LastUserSecretActivity) must each independently degrade rather than silently return 0
+// (undercounting stale privileged access) on a storage error.
+func TestGetCompliancePosture_DegradedOnDormantRoleGrantsAssignmentsQueryError(t *testing.T) {
+	c, db := compliancePostureCoreWithProject(t)
+	require.NoError(t, db.AutoMigrate(&models.AccessReviewCampaign{}, &models.AccessReviewItem{}, &models.BreakGlassActivation{}, &models.AuditEvent{}))
+	// models.UserRole / GroupRole deliberately NOT migrated → ListProjectRoleAssignments fails.
+
+	p, err := c.GetCompliancePosture(context.Background())
+	require.NoError(t, err)
+
+	assert.Equal(t, 0, p.AccessGovernance.DormantRoleGrants)
+	assert.True(t, p.Degraded)
+	assert.True(t, containsSubstring(p.DegradedReasons, "dormant_role_grants:assignments:project=1"), "got %v", p.DegradedReasons)
+}
+
+func TestGetCompliancePosture_DegradedOnDormantRoleGrantsActivityQueryError(t *testing.T) {
+	c, db := compliancePostureCoreWithProject(t)
+	require.NoError(t, db.AutoMigrate(&models.AccessReviewCampaign{}, &models.AccessReviewItem{}, &models.BreakGlassActivation{}, &models.UserRole{}, &models.GroupRole{}))
+	// models.AuditEvent deliberately NOT migrated → LastUserSecretActivity's raw
+	// "audit_events" table query fails.
+
+	p, err := c.GetCompliancePosture(context.Background())
+	require.NoError(t, err)
+
+	assert.Equal(t, 0, p.AccessGovernance.DormantRoleGrants)
+	assert.True(t, p.Degraded)
+	assert.True(t, containsSubstring(p.DegradedReasons, "dormant_role_grants:activity:project=1"), "got %v", p.DegradedReasons)
 }

--- a/internal/core/rotation_executor.go
+++ b/internal/core/rotation_executor.go
@@ -178,6 +178,12 @@ func (c *KeyorixCore) RunAutoRotation(ctx context.Context) (int, error) {
 		}
 		secrets, err := c.scopedPolicySecrets(ctx, policy, nil)
 		if err != nil {
+			// #364: unlike the dependency-list error below (which degrades gracefully
+			// and logs), this was previously a silent skip — auto-rotate-enabled,
+			// possibly critically-overdue secrets under this policy's scope would not
+			// even be considered for rotation this run, with no trace anywhere that it
+			// happened. Log so an operator can see it, matching the sibling handling.
+			log.Printf("auto-rotation: list scoped secrets for policy %d (%q): %v — skipping this policy's secrets this run", policy.ID, policy.Name, err)
 			continue
 		}
 		for _, secret := range secrets {

--- a/internal/core/rotation_executor_test.go
+++ b/internal/core/rotation_executor_test.go
@@ -432,15 +432,14 @@ func TestRunAutoRotation_LogsAndContinuesOnScopedSecretsError(t *testing.T) {
 	c := &KeyorixCore{storage: &failingProjectSecretsStore{LocalStorage: store.NewLocalStorage(db), failProject: pid2}}
 	c.now = func() time.Time { return fixed }
 
-	buf, restore := captureLog(t)
-	defer restore()
-
-	n, err := c.RunAutoRotation(context.Background())
+	var n int
+	logged := captureLog(t, func() {
+		n, err = c.RunAutoRotation(context.Background())
+	})
 	require.NoError(t, err, "a single policy's scope-listing failure must not abort the whole run")
 	assert.Equal(t, 1, n, "the healthy policy's due secret still rotates")
 	assert.Equal(t, 1, latestVersion(t, db, 2).VersionNumber, "the secret under the broken policy's scope was never even considered, so it's untouched")
 
-	logged := buf.String()
 	assert.Contains(t, logged, "broken-policy", "the failing policy's name must appear in the operator-visible log line")
 	assert.Contains(t, logged, "simulated storage failure")
 }

--- a/internal/core/rotation_executor_test.go
+++ b/internal/core/rotation_executor_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/rotation"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/keyorixhq/keyorix/internal/storage/store"
@@ -370,6 +371,81 @@ func TestRunAutoRotation_GenerateUpstreamFailureNotStored(t *testing.T) {
 	assert.Equal(t, 0, n)
 	assert.Equal(t, 1, latestVersion(t, db, 1).VersionNumber)
 }
+
+// failingProjectSecretsStore wraps LocalStorage and fails ListSecrets only for
+// filter.ProjectID == failProject, simulating a transient storage error scoped to
+// exactly one rotation policy's scope while a sibling project's policy still succeeds.
+type failingProjectSecretsStore struct {
+	*store.LocalStorage
+	failProject uint
+}
+
+func (s *failingProjectSecretsStore) ListSecrets(ctx context.Context, filter *storage.SecretFilter) ([]*models.SecretNode, int64, error) {
+	if filter.ProjectID != nil && *filter.ProjectID == s.failProject {
+		return nil, 0, errors.New("simulated storage failure")
+	}
+	return s.LocalStorage.ListSecrets(ctx, filter)
+}
+
+// #364: before the fix, a scopedPolicySecrets failure for one policy silently skipped
+// every auto-rotate-enabled, possibly critically-overdue secret in its scope with ZERO
+// operator-visible trace — contrast the dependency-list error a few lines later in the
+// same function, which already logged and degraded gracefully. This pins that (a) a
+// healthy policy's overdue secret still rotates (the run doesn't abort), and (b) the
+// failure is now logged, unlike before.
+func TestRunAutoRotation_LogsAndContinuesOnScopedSecretsError(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.SecretNode{}, &models.SecretVersion{}, &models.RotationPolicy{}, &models.AuditEvent{},
+		&models.Project{}, &models.Environment{},
+	))
+	fixed := time.Date(2026, 6, 16, 12, 0, 0, 0, time.UTC)
+	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "healthy-proj"}).Error)
+	require.NoError(t, db.Create(&models.Project{ID: 2, Name: "broken-proj"}).Error)
+	require.NoError(t, db.Create(&models.Environment{ID: 1, ProjectID: 1, Name: "prod"}).Error)
+	require.NoError(t, db.Create(&models.Environment{ID: 2, ProjectID: 2, Name: "prod"}).Error)
+	pid1, pid2 := uint(1), uint(2)
+	require.NoError(t, db.Create(&models.RotationPolicy{
+		ID: 1, Name: "healthy-policy", Scope: "project", ProjectID: &pid1, IntervalDays: 30, IsActive: true, CreatedBy: "admin",
+	}).Error)
+	require.NoError(t, db.Create(&models.RotationPolicy{
+		ID: 2, Name: "broken-policy", Scope: "project", ProjectID: &pid2, IntervalDays: 30, IsActive: true, CreatedBy: "admin",
+	}).Error)
+	require.NoError(t, db.Create(&models.SecretNode{
+		ID: 1, Name: "due-healthy", ProjectID: 1, EnvironmentID: 1, IsSecret: true, Status: "active",
+		AutoRotate: true, LastRotatedAt: timePtr(fixed.Add(-60 * 24 * time.Hour)), CreatedAt: fixed.Add(-60 * 24 * time.Hour),
+	}).Error)
+	require.NoError(t, db.Create(&models.SecretVersion{
+		SecretNodeID: 1, VersionNumber: 1, EncryptedValue: []byte("orig"), EncryptionMetadata: []byte("{}"), CreatedAt: fixed.Add(-60 * 24 * time.Hour),
+	}).Error)
+	// A due, auto-rotate-enabled secret under the BROKEN policy's scope — this must be
+	// skipped (its ListSecrets call errors before this row is ever seen), never rotated.
+	require.NoError(t, db.Create(&models.SecretNode{
+		ID: 2, Name: "due-broken", ProjectID: 2, EnvironmentID: 2, IsSecret: true, Status: "active",
+		AutoRotate: true, LastRotatedAt: timePtr(fixed.Add(-90 * 24 * time.Hour)), CreatedAt: fixed.Add(-90 * 24 * time.Hour),
+	}).Error)
+	require.NoError(t, db.Create(&models.SecretVersion{
+		SecretNodeID: 2, VersionNumber: 1, EncryptedValue: []byte("orig"), EncryptionMetadata: []byte("{}"), CreatedAt: fixed.Add(-90 * 24 * time.Hour),
+	}).Error)
+
+	c := &KeyorixCore{storage: &failingProjectSecretsStore{LocalStorage: store.NewLocalStorage(db), failProject: pid2}}
+	c.now = func() time.Time { return fixed }
+
+	buf, restore := captureLog(t)
+	defer restore()
+
+	n, err := c.RunAutoRotation(context.Background())
+	require.NoError(t, err, "a single policy's scope-listing failure must not abort the whole run")
+	assert.Equal(t, 1, n, "the healthy policy's due secret still rotates")
+	assert.Equal(t, 1, latestVersion(t, db, 2).VersionNumber, "the secret under the broken policy's scope was never even considered, so it's untouched")
+
+	logged := buf.String()
+	assert.Contains(t, logged, "broken-policy", "the failing policy's name must appear in the operator-visible log line")
+	assert.Contains(t, logged, "simulated storage failure")
+}
+
+func timePtr(t time.Time) *time.Time { return &t }
 
 // A rotation failure broadcasts a single summary notification (fakeSink is defined in
 // notification_dispatch_test.go).

--- a/internal/core/rotation_policies.go
+++ b/internal/core/rotation_policies.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"fmt"
+	"log"
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/core/storage"
@@ -237,6 +238,7 @@ func (c *KeyorixCore) GetRotationStatus(ctx context.Context, projectID, environm
 
 	var entries []*RotationStatusEntry
 	now := c.now()
+	var failedPolicies int
 
 	for _, policy := range policies {
 		if !policy.IsActive || !policyAppliesToEnv(policy, environmentID) {
@@ -245,6 +247,15 @@ func (c *KeyorixCore) GetRotationStatus(ctx context.Context, projectID, environm
 
 		secrets, err := c.scopedPolicySecrets(ctx, policy, environmentID)
 		if err != nil {
+			// #363: a per-policy scope-listing failure must not silently vanish that
+			// policy's secrets from the result — every caller here (compliance
+			// posture/evidence, the rotation-plan/status HTTP routes, the reminder
+			// scheduler) already treats a non-nil error as "don't trust this result",
+			// so failing the whole call (after logging + finishing the loop so every
+			// failure is recorded) surfaces as degraded/unknown instead of a silently
+			// short count that reads as "fully covered".
+			log.Printf("rotation status: list secrets for policy %d (%q): %v", policy.ID, policy.Name, err)
+			failedPolicies++
 			continue
 		}
 
@@ -282,6 +293,10 @@ func (c *KeyorixCore) GetRotationStatus(ctx context.Context, projectID, environm
 		}
 	}
 
+	if failedPolicies > 0 {
+		return nil, fmt.Errorf("rotation status: %d rotation polic(y/ies) could not be evaluated due to a storage error — result is incomplete", failedPolicies)
+	}
+
 	return entries, nil
 }
 
@@ -293,6 +308,7 @@ func (c *KeyorixCore) EvaluateRotationPolicies(ctx context.Context, projectID, e
 
 	var evaluations []*RotationPolicyEvaluation
 	now := c.now()
+	var failedPolicies int
 
 	for _, policy := range policies {
 		if !policy.IsActive || !policyAppliesToEnv(policy, environmentID) {
@@ -301,6 +317,12 @@ func (c *KeyorixCore) EvaluateRotationPolicies(ctx context.Context, projectID, e
 
 		secrets, err := c.scopedPolicySecrets(ctx, policy, environmentID)
 		if err != nil {
+			// #363: see the identical handling + rationale in GetRotationStatus above —
+			// this result also feeds the admin-nudge reminder scheduler
+			// (rotation_reminders.go), which already bails out on a non-nil error rather
+			// than sending reminders derived from a silently-incomplete evaluation.
+			log.Printf("rotation evaluate: list secrets for policy %d (%q): %v", policy.ID, policy.Name, err)
+			failedPolicies++
 			continue
 		}
 
@@ -331,6 +353,10 @@ func (c *KeyorixCore) EvaluateRotationPolicies(ctx context.Context, projectID, e
 				})
 			}
 		}
+	}
+
+	if failedPolicies > 0 {
+		return nil, fmt.Errorf("rotation evaluate: %d rotation polic(y/ies) could not be evaluated due to a storage error — result is incomplete", failedPolicies)
 	}
 
 	return evaluations, nil

--- a/internal/core/rotation_policies_fail_open_test.go
+++ b/internal/core/rotation_policies_fail_open_test.go
@@ -10,9 +10,7 @@
 package core
 
 import (
-	"bytes"
 	"context"
-	"log"
 	"testing"
 	"time"
 
@@ -81,43 +79,38 @@ func rotationPoliciesFailOpenCore(t *testing.T) (*KeyorixCore, *gorm.DB, time.Ti
 	return c, db, fixed
 }
 
-// captureLog temporarily redirects the standard logger to a buffer and returns a
-// restore func — used to assert the previously-silent scopedPolicySecrets failure now
-// leaves an operator-visible trace.
-func captureLog(t *testing.T) (*bytes.Buffer, func()) {
-	t.Helper()
-	var buf bytes.Buffer
-	orig := log.Writer()
-	log.SetOutput(&buf)
-	return &buf, func() { log.SetOutput(orig) }
-}
-
 // #363: GetRotationStatus must log the per-policy failure and must not return a
 // silently-short "clean" result — before the fix, this returned (1 entry, nil error),
 // indistinguishable from "rotation coverage is fully known and only 1 secret exists".
 func TestGetRotationStatus_LogsAndFailsOnScopedSecretsError(t *testing.T) {
 	c, _, _ := rotationPoliciesFailOpenCore(t)
-	buf, restore := captureLog(t)
-	defer restore()
 
-	entries, err := c.GetRotationStatus(context.Background(), nil, nil)
+	var entries []*RotationStatusEntry
+	var err error
+	logged := captureLog(t, func() {
+		entries, err = c.GetRotationStatus(context.Background(), nil, nil)
+	})
+
 	require.Error(t, err, "a per-policy scope failure must surface as a whole-call error, not a silently-short result")
 	assert.Nil(t, entries)
-	assert.Contains(t, buf.String(), "broken-policy", "the failing policy's name must appear in the operator-visible log line")
-	assert.Contains(t, buf.String(), "simulated storage failure")
+	assert.Contains(t, logged, "broken-policy", "the failing policy's name must appear in the operator-visible log line")
+	assert.Contains(t, logged, "simulated storage failure")
 }
 
 // #363: same fix, EvaluateRotationPolicies — this result also feeds the admin-nudge
 // reminder scheduler (rotation_reminders.go), which already bails on a non-nil error.
 func TestEvaluateRotationPolicies_LogsAndFailsOnScopedSecretsError(t *testing.T) {
 	c, _, _ := rotationPoliciesFailOpenCore(t)
-	buf, restore := captureLog(t)
-	defer restore()
 
-	evals, err := c.EvaluateRotationPolicies(context.Background(), nil, nil)
+	var evals []*RotationPolicyEvaluation
+	var err error
+	logged := captureLog(t, func() {
+		evals, err = c.EvaluateRotationPolicies(context.Background(), nil, nil)
+	})
+
 	require.Error(t, err)
 	assert.Nil(t, evals)
-	assert.Contains(t, buf.String(), "broken-policy")
+	assert.Contains(t, logged, "broken-policy")
 
 	// The reminder scheduler must not silently send zero reminders while reporting
 	// success — it must propagate the failure too.

--- a/internal/core/rotation_policies_fail_open_test.go
+++ b/internal/core/rotation_policies_fail_open_test.go
@@ -1,0 +1,152 @@
+// rotation_policies_fail_open_test.go — #363: a scopedPolicySecrets failure for one
+// rotation policy must not silently vanish that policy's secrets from the result
+// (undercounting rotation coverage as if the policy's secrets simply didn't exist).
+// Every known caller of GetRotationStatus/EvaluateRotationPolicies already treats a
+// non-nil error as "don't trust this result" (compliance posture/evidence degrade,
+// the HTTP handlers 500, the reminder scheduler sends nothing) — so surfacing the
+// per-policy failure as a whole-call error, after logging it, correctly reads as
+// "incomplete/unknown" everywhere downstream instead of a silently short, falsely
+// clean count.
+package core
+
+import (
+	"bytes"
+	"context"
+	"log"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// failingEnvSecretsStore wraps LocalStorage and fails ListSecrets only when the
+// filter targets failEnv — simulating a transient storage error scoped to exactly
+// one rotation policy while a sibling policy (a different environment) still
+// succeeds, so the test can tell "one policy's query failed" apart from "the whole
+// deployment is down".
+type failingEnvSecretsStore struct {
+	*store.LocalStorage
+	failEnv uint
+}
+
+func (s *failingEnvSecretsStore) ListSecrets(ctx context.Context, filter *storage.SecretFilter) ([]*models.SecretNode, int64, error) {
+	if filter.EnvironmentID != nil && *filter.EnvironmentID == s.failEnv {
+		return nil, 0, assertErrSimulated
+	}
+	return s.LocalStorage.ListSecrets(ctx, filter)
+}
+
+var assertErrSimulated = &simulatedStorageError{"simulated storage failure"}
+
+type simulatedStorageError struct{ msg string }
+
+func (e *simulatedStorageError) Error() string { return e.msg }
+
+func rotationPoliciesFailOpenCore(t *testing.T) (*KeyorixCore, *gorm.DB, time.Time) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.Environment{}, &models.RotationPolicy{}, &models.Project{}))
+	fixed := time.Date(2026, 7, 3, 12, 0, 0, 0, time.UTC)
+	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "proj"}).Error)
+	require.NoError(t, db.Create(&models.Environment{ID: 1, ProjectID: 1, Name: "ok-env"}).Error)
+	require.NoError(t, db.Create(&models.Environment{ID: 2, ProjectID: 1, Name: "broken-env"}).Error)
+	pid := uint(1)
+	okEnv, brokenEnv := uint(1), uint(2)
+	require.NoError(t, db.Create(&models.RotationPolicy{
+		ID: 1, Name: "ok-policy", Scope: "environment", EnvironmentID: &okEnv,
+		IntervalDays: 30, IsActive: true, CreatedBy: "admin",
+	}).Error)
+	require.NoError(t, db.Create(&models.RotationPolicy{
+		ID: 2, Name: "broken-policy", Scope: "environment", EnvironmentID: &brokenEnv,
+		IntervalDays: 30, IsActive: true, CreatedBy: "admin",
+	}).Error)
+	require.NoError(t, db.Create(&models.SecretNode{
+		ID: 1, Name: "healthy-in-ok-env", ProjectID: pid, EnvironmentID: okEnv, IsSecret: true,
+		Status: "active", CreatedAt: fixed.Add(-60 * 24 * time.Hour),
+	}).Error)
+	require.NoError(t, db.Create(&models.SecretNode{
+		ID: 2, Name: "overdue-in-broken-env", ProjectID: pid, EnvironmentID: brokenEnv, IsSecret: true,
+		Status: "active", CreatedAt: fixed.Add(-90 * 24 * time.Hour),
+	}).Error)
+
+	c := &KeyorixCore{storage: &failingEnvSecretsStore{LocalStorage: store.NewLocalStorage(db), failEnv: brokenEnv}}
+	c.now = func() time.Time { return fixed }
+	return c, db, fixed
+}
+
+// captureLog temporarily redirects the standard logger to a buffer and returns a
+// restore func — used to assert the previously-silent scopedPolicySecrets failure now
+// leaves an operator-visible trace.
+func captureLog(t *testing.T) (*bytes.Buffer, func()) {
+	t.Helper()
+	var buf bytes.Buffer
+	orig := log.Writer()
+	log.SetOutput(&buf)
+	return &buf, func() { log.SetOutput(orig) }
+}
+
+// #363: GetRotationStatus must log the per-policy failure and must not return a
+// silently-short "clean" result — before the fix, this returned (1 entry, nil error),
+// indistinguishable from "rotation coverage is fully known and only 1 secret exists".
+func TestGetRotationStatus_LogsAndFailsOnScopedSecretsError(t *testing.T) {
+	c, _, _ := rotationPoliciesFailOpenCore(t)
+	buf, restore := captureLog(t)
+	defer restore()
+
+	entries, err := c.GetRotationStatus(context.Background(), nil, nil)
+	require.Error(t, err, "a per-policy scope failure must surface as a whole-call error, not a silently-short result")
+	assert.Nil(t, entries)
+	assert.Contains(t, buf.String(), "broken-policy", "the failing policy's name must appear in the operator-visible log line")
+	assert.Contains(t, buf.String(), "simulated storage failure")
+}
+
+// #363: same fix, EvaluateRotationPolicies — this result also feeds the admin-nudge
+// reminder scheduler (rotation_reminders.go), which already bails on a non-nil error.
+func TestEvaluateRotationPolicies_LogsAndFailsOnScopedSecretsError(t *testing.T) {
+	c, _, _ := rotationPoliciesFailOpenCore(t)
+	buf, restore := captureLog(t)
+	defer restore()
+
+	evals, err := c.EvaluateRotationPolicies(context.Background(), nil, nil)
+	require.Error(t, err)
+	assert.Nil(t, evals)
+	assert.Contains(t, buf.String(), "broken-policy")
+
+	// The reminder scheduler must not silently send zero reminders while reporting
+	// success — it must propagate the failure too.
+	sent, rerr := c.SendRotationReminders(context.Background())
+	require.Error(t, rerr, "the reminder scheduler must not report success when the underlying evaluation was incomplete")
+	assert.Equal(t, 0, sent)
+}
+
+// A clean run (no failing policy) is unaffected: both functions still return the full
+// result with no error.
+func TestGetRotationStatus_NoErrorWhenAllPoliciesSucceed(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.Environment{}, &models.RotationPolicy{}, &models.Project{}))
+	fixed := time.Date(2026, 7, 3, 12, 0, 0, 0, time.UTC)
+	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "proj"}).Error)
+	require.NoError(t, db.Create(&models.Environment{ID: 1, ProjectID: 1, Name: "env"}).Error)
+	pid := uint(1)
+	require.NoError(t, db.Create(&models.RotationPolicy{
+		ID: 1, Name: "policy", Scope: "project", ProjectID: &pid, IntervalDays: 30, IsActive: true, CreatedBy: "admin",
+	}).Error)
+	require.NoError(t, db.Create(&models.SecretNode{
+		ID: 1, Name: "s", ProjectID: pid, EnvironmentID: 1, IsSecret: true, Status: "active",
+		CreatedAt: fixed.Add(-60 * 24 * time.Hour),
+	}).Error)
+	c := &KeyorixCore{storage: store.NewLocalStorage(db)}
+	c.now = func() time.Time { return fixed }
+
+	entries, err := c.GetRotationStatus(context.Background(), nil, nil)
+	require.NoError(t, err)
+	assert.Len(t, entries, 1)
+}


### PR DESCRIPTION
## Summary

Extends the existing #136 fail-closed/degraded-state pattern (compliance posture
snapshot) to sibling rotation and anomaly-detection code paths that had the same
fail-open shape: a storage-query error was silently swallowed instead of being
surfaced as "unknown/incomplete", so a transient DB hiccup could read identically
to "checked, found clean" in an auditor-facing report.

- **#363** `GetRotationStatus` / `EvaluateRotationPolicies`: a per-policy
  `scopedPolicySecrets` failure no longer silently drops that policy's secrets
  from the result. The failure is now logged (policy id/name/error) and the whole
  call returns a non-nil error, so every known caller (compliance
  posture/evidence degrade wiring, the rotation-plan/status HTTP routes, the
  reminder scheduler) reads the result as incomplete instead of a silently short
  "fully covered" count.
- **#364** `RunAutoRotation`: a per-policy scoped-secrets listing failure is now
  logged instead of silently skipped, matching the sibling dependency-list error
  handling a few lines below in the same function.
- **#365** `RunDetection` (anomaly detection): logs which secret and which
  access-log query (baseline vs. detection-window) failed, so a transient DB
  hiccup is distinguishable from a genuine gap — the hourly detection window is
  never retroactively re-evaluated.
- Adds regression coverage pinning the existing #136/#358-362 degrade wiring in
  `GetCompliancePosture` and `GenerateComplianceEvidence` (rotation, anomalies,
  classification, access-review campaigns, break-glass, dormant role grants),
  plus new coverage for the #363/#364/#365 fixes above.

## Test plan

- [x] `go build ./...`
- [x] `go build -o .scratch/server ./server`
- [x] `go test ./...` (full suite green)
- [x] `gosec -severity medium -exclude-generated ./internal/core/...` — 0 issues
- [x] `golangci-lint run ./internal/core/...` — 0 issues
- [x] `GOWORK=off go build -C operator ./...` (separate module) — builds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)