### PR TITLE
harden(rotation): close dependency-graph race + O(V²) rotation-wave blowup (#260/#368)

### DIFF
--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -313,6 +313,13 @@ func (m *MockStorage) ListSecretDependenciesForProject(ctx context.Context, proj
 	return args.Get(0).([]*models.SecretDependency), args.Error(1)
 }
 
+// ListSecretDependenciesForProjectForUpdate has no row lock in the mock; it
+// reuses the ListSecretDependenciesForProject expectation, mirroring
+// LockUserForUpdate above.
+func (m *MockStorage) ListSecretDependenciesForProjectForUpdate(ctx context.Context, projectID uint) ([]*models.SecretDependency, error) {
+	return m.ListSecretDependenciesForProject(ctx, projectID)
+}
+
 func (m *MockStorage) DeleteSecretDependency(ctx context.Context, id uint) error {
 	args := m.Called(ctx, id)
 	return args.Error(0)

--- a/internal/core/rotation_planner.go
+++ b/internal/core/rotation_planner.go
@@ -15,6 +15,7 @@ package core
 import (
 	"context"
 	"fmt"
+	"log"
 	"sort"
 	"strings"
 
@@ -141,12 +142,37 @@ type DeploymentRotationPlan struct {
 	OverdueCount     int            `json:"overdue_count"`
 	DueSoonCount     int            `json:"due_soon_count"`
 	Projects         []RotationPlan `json:"projects"` // most-overdue project first; only projects with work
+	// BrokenProjects flags every project whose plan could not be computed (in
+	// practice: a cyclic dependency graph — cycles are rejected at add, ADR-052,
+	// so this should not happen, but a persisted cycle should never take down the
+	// whole deployment-wide view, #260) rather than aborting the entire roll-up —
+	// mirroring CompliancePosture's Degraded/DegradedReasons pattern
+	// (compliance_posture.go): a per-project failure surfaces as an explicit,
+	// named gap in an otherwise-complete result, not a hard error for every other
+	// project's viewers.
+	BrokenProjects []BrokenRotationProject `json:"broken_projects,omitempty"`
+}
+
+// BrokenRotationProject names a project GenerateDeploymentRotationPlan could not
+// compute a plan for, with the underlying error, so an operator can find and fix
+// it (e.g. locate and delete a stuck cyclic edge) without every other project's
+// viewers losing the deployment-wide rotation plan in the meantime.
+type BrokenRotationProject struct {
+	ProjectID uint   `json:"project_id"`
+	Error     string `json:"error"`
 }
 
 // GenerateDeploymentRotationPlan builds the deployment-wide rotation plan by aggregating
 // every project's plan (ADR-053). Projects with nothing to rotate are omitted from the
 // list but still counted in ProjectsScanned. Projects are ordered most-overdue first so the
 // install's most pressing rotation work surfaces at the top.
+//
+// A project whose plan fails to compute (in practice, a cyclic dependency graph
+// slipping past AddSecretDependency's cycle check via a race, #260) is skipped and
+// flagged in BrokenProjects rather than aborting the whole call: without this, one
+// project's stuck cycle 500s the install-wide GET /rotation-plan endpoint for every
+// viewer across the entire deployment. Mirrors RunAutoRotation's graceful
+// degrade-and-log behaviour on the same condition (rotation_executor.go).
 func (c *KeyorixCore) GenerateDeploymentRotationPlan(ctx context.Context) (*DeploymentRotationPlan, error) {
 	projects, err := c.storage.ListProjects(ctx)
 	if err != nil {
@@ -158,7 +184,9 @@ func (c *KeyorixCore) GenerateDeploymentRotationPlan(ctx context.Context) (*Depl
 		dp.ProjectsScanned++
 		plan, err := c.GenerateRotationPlan(ctx, p.ID)
 		if err != nil {
-			return nil, fmt.Errorf("project %d: %w", p.ID, err)
+			log.Printf("deployment rotation plan: project %d: %v — skipping this project, continuing the deployment-wide roll-up", p.ID, err)
+			dp.BrokenProjects = append(dp.BrokenProjects, BrokenRotationProject{ProjectID: p.ID, Error: err.Error()})
+			continue
 		}
 		if plan.TotalSecrets == 0 {
 			continue // nothing to rotate here — keep the deployment view focused
@@ -176,6 +204,9 @@ func (c *KeyorixCore) GenerateDeploymentRotationPlan(ctx context.Context) (*Depl
 			return dp.Projects[i].OverdueCount > dp.Projects[j].OverdueCount
 		}
 		return dp.Projects[i].ProjectID < dp.Projects[j].ProjectID
+	})
+	sort.Slice(dp.BrokenProjects, func(i, j int) bool {
+		return dp.BrokenProjects[i].ProjectID < dp.BrokenProjects[j].ProjectID
 	})
 	return dp, nil
 }
@@ -265,6 +296,14 @@ func rotationUrgency(status string, daysOverdue, riskScore int) int {
 // candidates: wave 0 holds candidates with no in-plan dependency, and a candidate
 // appears one wave after the last candidate it depends on. ok is false if a cycle
 // prevents a complete ordering (not expected: the graph is acyclic by construction).
+//
+// Uses the same ready-queue approach as topologicalRotationOrder (#368): each wave's
+// members are exactly the nodes a PRIOR wave's processing just brought to indegree
+// zero, discovered by walking only THOSE nodes' outgoing edges — never a rescan of
+// every remaining candidate. Each node is placed into exactly one wave and each edge
+// is walked exactly once over the whole call, so the total work is O(V+E) rather
+// than the O(V) per-wave rescan (up to O(V) waves deep) the prior implementation
+// did, which made a long dependency chain O(V²).
 func rotationWaves(edges []*models.SecretDependency, candidates map[uint]bool) (waves [][]uint, ok bool) {
 	adj := map[uint][]uint{} // dependsOn -> dependents, among candidates
 	indeg := make(map[uint]int, len(candidates))
@@ -278,29 +317,31 @@ func rotationWaves(edges []*models.SecretDependency, candidates map[uint]bool) (
 		}
 	}
 
-	placed := make(map[uint]bool, len(candidates))
-	remaining := len(candidates)
-	for remaining > 0 {
-		level := []uint{}
-		for id := range candidates {
-			if !placed[id] && indeg[id] == 0 {
-				level = append(level, id)
-			}
+	// Seed wave 0 with every candidate that has no in-plan dependency, smallest id
+	// first for a deterministic, stable ordering.
+	current := make([]uint, 0, len(candidates))
+	for id := range candidates {
+		if indeg[id] == 0 {
+			current = append(current, id)
 		}
-		if len(level) == 0 {
-			return waves, false // cycle
-		}
-		sort.Slice(level, func(i, j int) bool { return level[i] < level[j] })
-		for _, id := range level {
-			placed[id] = true
-			remaining--
-		}
-		for _, id := range level {
+	}
+	sort.Slice(current, func(i, j int) bool { return current[i] < current[j] })
+
+	placed := 0
+	for len(current) > 0 {
+		waves = append(waves, current)
+		placed += len(current)
+		next := []uint{}
+		for _, id := range current {
 			for _, dep := range adj[id] {
 				indeg[dep]--
+				if indeg[dep] == 0 {
+					next = append(next, dep)
+				}
 			}
 		}
-		waves = append(waves, level)
+		sort.Slice(next, func(i, j int) bool { return next[i] < next[j] })
+		current = next
 	}
-	return waves, true
+	return waves, placed == len(candidates) // false = a cycle prevented a complete ordering
 }

--- a/internal/core/rotation_planner_test.go
+++ b/internal/core/rotation_planner_test.go
@@ -213,6 +213,62 @@ func TestGenerateDeploymentRotationPlan(t *testing.T) {
 	assert.Equal(t, 1, dp.Projects[1].DueSoonCount)
 }
 
+// A cyclic dependency graph in ONE project (which the add path normally rejects,
+// ADR-052, but can slip past a racing AddSecretDependency call, #260) must not 500
+// the whole deployment-wide roll-up for every other project's viewers: it is
+// skipped and flagged in BrokenProjects, while every other project's plan still
+// comes back normally.
+func TestGenerateDeploymentRotationPlan_CyclicProjectIsSkippedNotFatal(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 6, 22, 12, 0, 0, 0, time.UTC)
+	c, db := newPlannerCore(t, now)
+	daysAgo := func(d int) *time.Time { tt := now.Add(-time.Duration(d) * 24 * time.Hour); return &tt }
+
+	mkProject := func(id uint, name string) {
+		require.NoError(t, db.Create(&models.Project{ID: id, Name: name}).Error)
+		require.NoError(t, db.Create(&models.Environment{ID: id, ProjectID: id, Name: name + "-env"}).Error)
+		pid := id
+		require.NoError(t, db.Create(&models.RotationPolicy{
+			Name: name + "-90d", Scope: "project", ProjectID: &pid, IntervalDays: 90, AlertDaysBefore: 14, IsActive: true,
+		}).Error)
+	}
+	mkSecret := func(id, projID, envID uint, name string, last *time.Time) {
+		require.NoError(t, db.Create(&models.SecretNode{
+			ID: id, Name: name, ProjectID: projID, EnvironmentID: envID, IsSecret: true, Status: "active",
+			OwnerID: 1, LastRotatedAt: last,
+		}).Error)
+	}
+
+	// Project 1 (broken): two overdue secrets with a cyclic edge inserted directly,
+	// bypassing AddSecretDependency's normal cycle guard — simulating #260's raced
+	// cycle.
+	mkProject(1, "broken")
+	mkSecret(1, 1, 1, "broken-a", daysAgo(120))
+	mkSecret(2, 1, 1, "broken-b", daysAgo(200))
+	require.NoError(t, db.Create(&models.SecretDependency{ProjectID: 1, DependentSecretID: 1, DependsOnSecretID: 2}).Error)
+	require.NoError(t, db.Create(&models.SecretDependency{ProjectID: 1, DependentSecretID: 2, DependsOnSecretID: 1}).Error)
+
+	// Project 2 (healthy): one overdue secret, no dependency graph issues.
+	mkProject(2, "healthy")
+	mkSecret(3, 2, 2, "healthy-overdue", daysAgo(150))
+
+	dp, err := c.GenerateDeploymentRotationPlan(ctx)
+	require.NoError(t, err, "one project's cycle must not fail the whole deployment-wide roll-up")
+
+	assert.Equal(t, 2, dp.ProjectsScanned)
+	require.Len(t, dp.BrokenProjects, 1, "the cyclic project is flagged, not silently dropped")
+	assert.Equal(t, uint(1), dp.BrokenProjects[0].ProjectID)
+	assert.Contains(t, dp.BrokenProjects[0].Error, "cycle")
+
+	// The healthy project's plan is still present and correct — the deployment view
+	// is not entirely blank just because one project is broken.
+	assert.Equal(t, 1, dp.ProjectsWithWork)
+	assert.Equal(t, 1, dp.TotalSecrets)
+	assert.Equal(t, 1, dp.OverdueCount)
+	require.Len(t, dp.Projects, 1)
+	assert.Equal(t, uint(2), dp.Projects[0].ProjectID)
+}
+
 func TestGenerateDeploymentRotationPlan_NothingDueAnywhere(t *testing.T) {
 	ctx := context.Background()
 	now := time.Date(2026, 6, 22, 12, 0, 0, 0, time.UTC)

--- a/internal/core/secret_dependencies.go
+++ b/internal/core/secret_dependencies.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
@@ -71,6 +72,18 @@ type RotationOrder struct {
 // AddSecretDependency declares that dependentID depends on dependsOnID. Both must be
 // real secrets in the same project; self-edges, duplicates, and edges that would
 // introduce a cycle are rejected. actorID is the acting principal.
+//
+// The cycle-check read and the edge write run inside a single storage transaction,
+// held under secretDependencyMu for its whole duration (#260): without this, two
+// concurrent calls adding A→B and B→A in the same project could each observe "no
+// cycle" from the pre-write graph before either write commits, both succeed, and
+// persist a 2-node cycle that GetProjectRotationOrder then hard-errors on forever
+// (nothing else detects or heals a stuck edge). The transaction's
+// ListSecretDependenciesForProjectForUpdate read takes a row-level lock on every
+// existing edge in the project on backends that support one (Postgres), serializing
+// HA replicas; secretDependencyMu serializes same-process callers — the same
+// two-layer pattern login_lockout.go's recordFailedLogin and RemoveUserRole's
+// guardLastGlobalAdmin use.
 func (c *KeyorixCore) AddSecretDependency(ctx context.Context, actorID, dependentID, dependsOnID uint, note string) (*models.SecretDependency, error) {
 	if dependentID == dependsOnID {
 		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "a secret cannot depend on itself")
@@ -91,31 +104,42 @@ func (c *KeyorixCore) AddSecretDependency(ctx context.Context, actorID, dependen
 		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "the dependency target must be a secret in the same project and environment")
 	}
 
-	edges, err := c.storage.ListSecretDependenciesForProject(ctx, dependent.ProjectID)
-	if err != nil {
-		return nil, err
-	}
-	for _, e := range edges {
-		if e.DependentSecretID == dependentID && e.DependsOnSecretID == dependsOnID {
-			return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "this dependency already exists")
-		}
-	}
-	// A cycle would form iff dependsOnID can already reach dependentID over existing
-	// edges (then dependent → dependsOn → … → dependent closes the loop).
-	if dependencyReachable(edges, dependsOnID, dependentID) {
-		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "this dependency would create a cycle")
-	}
+	c.secretDependencyMu.Lock()
+	defer c.secretDependencyMu.Unlock()
 
-	created, err := c.storage.CreateSecretDependency(ctx, &models.SecretDependency{
-		ProjectID:         dependent.ProjectID,
-		DependentSecretID: dependentID,
-		DependsOnSecretID: dependsOnID,
-		Note:              note,
-		CreatedBy:         actorID,
-		CreatedAt:         c.now(),
+	var created *models.SecretDependency
+	err = c.storage.WithTransaction(ctx, func(tx storage.Storage) error {
+		edges, lerr := tx.ListSecretDependenciesForProjectForUpdate(ctx, dependent.ProjectID)
+		if lerr != nil {
+			return lerr
+		}
+		for _, e := range edges {
+			if e.DependentSecretID == dependentID && e.DependsOnSecretID == dependsOnID {
+				return fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "this dependency already exists")
+			}
+		}
+		// A cycle would form iff dependsOnID can already reach dependentID over existing
+		// edges (then dependent → dependsOn → … → dependent closes the loop).
+		if dependencyReachable(edges, dependsOnID, dependentID) {
+			return fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "this dependency would create a cycle")
+		}
+
+		c1, cerr := tx.CreateSecretDependency(ctx, &models.SecretDependency{
+			ProjectID:         dependent.ProjectID,
+			DependentSecretID: dependentID,
+			DependsOnSecretID: dependsOnID,
+			Note:              note,
+			CreatedBy:         actorID,
+			CreatedAt:         c.now(),
+		})
+		if cerr != nil {
+			return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), cerr)
+		}
+		created = c1
+		return nil
 	})
 	if err != nil {
-		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+		return nil, err
 	}
 	c.writeAuditEvent(ctx, EventSecretDependencyAdded, actorPtr(actorID), &dependentID,
 		fmt.Sprintf("declared secret %q depends on %q", dependent.Name, dependsOn.Name))

--- a/internal/core/secret_dependencies_test.go
+++ b/internal/core/secret_dependencies_test.go
@@ -2,6 +2,8 @@ package core
 
 import (
 	"context"
+	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -244,4 +246,59 @@ func TestSecretDependencyImpactAndOrderAndRemove(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, impact.Affected, 1)
 	assert.Equal(t, "intermediate", impact.Affected[0].SecretName)
+}
+
+// --- concurrency: #260 ---
+
+// TestAddSecretDependency_ConcurrentRaceCannotPersistACycle empirically reproduces
+// #260: two goroutines racing to add A→B and B→A in the same project must never
+// BOTH succeed — that would persist a 2-node cycle that GetProjectRotationOrder
+// (and, transitively, the deployment-wide rotation-plan roll-up) hard-errors on
+// forever, with nothing else able to detect or heal the stuck edge. Repeated across
+// many fresh secret pairs on a single-connection DB (forcing the two goroutines'
+// individual statements to interleave through the same connection, the same
+// technique that originally reproduced the race deterministically) so the narrow
+// pre-fix race window is reliably exercised, not just occasionally hit.
+func TestAddSecretDependency_ConcurrentRaceCannotPersistACycle(t *testing.T) {
+	ctx := context.Background()
+	c, db := newDepCore(t)
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	sqlDB.SetMaxOpenConns(1)
+
+	const iterations = 50
+	for i := 0; i < iterations; i++ {
+		a := mkSecret(t, db, 1, fmt.Sprintf("a-%d", i))
+		b := mkSecret(t, db, 1, fmt.Sprintf("b-%d", i))
+
+		var wg sync.WaitGroup
+		start := make(chan struct{})
+		results := make([]error, 2)
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			<-start
+			_, results[0] = c.AddSecretDependency(ctx, 1, a, b, "")
+		}()
+		go func() {
+			defer wg.Done()
+			<-start
+			_, results[1] = c.AddSecretDependency(ctx, 1, b, a, "")
+		}()
+		close(start)
+		wg.Wait()
+
+		successes := 0
+		for _, e := range results {
+			if e == nil {
+				successes++
+			}
+		}
+		require.Equal(t, 1, successes,
+			"iteration %d: exactly one of A→B / B→A must win the race — both winning would persist a cycle, both losing would lose a legitimate edge", i)
+
+		// No cycle was persisted: rotation ordering for the project must still succeed.
+		_, err := c.GetProjectRotationOrder(ctx, 1)
+		require.NoError(t, err, "iteration %d: no lingering cycle in the persisted graph", i)
+	}
 }

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -97,6 +97,14 @@ type KeyorixCore struct {
 	// cannot both observe an empty user table and each create a "first admin". Zero
 	// value is ready to use. See auth_bootstrap.go.
 	bootstrapMu sync.Mutex
+	// secretDependencyMu serializes AddSecretDependency's cycle-check read through
+	// the edge it writes (#260), so two concurrent callers racing to add A→B and
+	// B→A in the same project cannot both pass the pre-write cycle check before
+	// either commits, persisting a cycle that later hard-errors rotation planning
+	// for that project. Combined with the row lock
+	// ListSecretDependenciesForProjectForUpdate takes on Postgres, this holds
+	// across replicas too. Zero value is ready to use. See secret_dependencies.go.
+	secretDependencyMu sync.Mutex
 	// accountStateMu serializes the account_state/is_active read-modify-write shared
 	// by setAccountState (SuspendUser/ReactivateUser/RequirePasswordReset) and
 	// UpdateSCIMUser (#344): without it, an admin's incident-response SuspendUser and a

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -147,6 +147,14 @@ type Storage interface {
 	GetSecretDependency(ctx context.Context, id uint) (*models.SecretDependency, error)
 	ListSecretDependenciesForProject(ctx context.Context, projectID uint) ([]*models.SecretDependency, error)
 	DeleteSecretDependency(ctx context.Context, id uint) error
+	// ListSecretDependenciesForProjectForUpdate is ListSecretDependenciesForProject,
+	// taking a row-level write lock on every returned edge on backends that support
+	// one (Postgres FOR UPDATE), mirroring LockUserForUpdate/
+	// ListGlobalAdminAssignmentsForUpdate (#260). Used inside a WithTransaction so
+	// AddSecretDependency's cycle-check read and the edge it writes serialize
+	// against a concurrent racing edge addition for the same project on Postgres/HA;
+	// secretDependencyMu covers same-process callers (SQLite, single instance).
+	ListSecretDependenciesForProjectForUpdate(ctx context.Context, projectID uint) ([]*models.SecretDependency, error)
 
 	// Legal hold (ISO 27001 A.5.34 / eDiscovery) — a deployment-wide hold that
 	// blocks the purge jobs from hard-deleting records while active.

--- a/internal/storage/store/local_secret_dependencies.go
+++ b/internal/storage/store/local_secret_dependencies.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"gorm.io/gorm/clause"
 )
 
 func (ls *LocalStorage) CreateSecretDependency(ctx context.Context, d *models.SecretDependency) (*models.SecretDependency, error) {
@@ -30,6 +31,24 @@ func (ls *LocalStorage) GetSecretDependency(ctx context.Context, id uint) (*mode
 func (ls *LocalStorage) ListSecretDependenciesForProject(ctx context.Context, projectID uint) ([]*models.SecretDependency, error) {
 	var rows []*models.SecretDependency
 	if err := ls.db.WithContext(ctx).Where("project_id = ?", projectID).Order("id ASC").Find(&rows).Error; err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	return rows, nil
+}
+
+// ListSecretDependenciesForProjectForUpdate is ListSecretDependenciesForProject,
+// adding SELECT … FOR UPDATE on Postgres so a cycle-check read inside a
+// transaction serializes against a concurrent writer racing to add an edge in the
+// same project (#260 — see AddSecretDependency). SQLite has no row-level lock, so
+// the clause is omitted there and the caller (secretDependencyMu) serializes
+// in-process; SQLite is always single-process, so that suffices.
+func (ls *LocalStorage) ListSecretDependenciesForProjectForUpdate(ctx context.Context, projectID uint) ([]*models.SecretDependency, error) {
+	q := ls.db.WithContext(ctx)
+	if ls.db.Dialector.Name() == "postgres" {
+		q = q.Clauses(clause.Locking{Strength: "UPDATE"})
+	}
+	var rows []*models.SecretDependency
+	if err := q.Where("project_id = ?", projectID).Order("id ASC").Find(&rows).Error; err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
 	}
 	return rows, nil

--- a/internal/storage/store/remote_secret_dependencies.go
+++ b/internal/storage/store/remote_secret_dependencies.go
@@ -20,6 +20,10 @@ func (rs *RemoteStorage) ListSecretDependenciesForProject(_ context.Context, _ u
 	return nil, remoteUnsupported("ListSecretDependenciesForProject")
 }
 
+func (rs *RemoteStorage) ListSecretDependenciesForProjectForUpdate(_ context.Context, _ uint) ([]*models.SecretDependency, error) {
+	return nil, remoteUnsupported("ListSecretDependenciesForProjectForUpdate")
+}
+
 func (rs *RemoteStorage) DeleteSecretDependency(_ context.Context, _ uint) error {
 	return remoteUnsupported("DeleteSecretDependency")
 }


### PR DESCRIPTION
## Summary
- **#260 (race):** two concurrent `AddSecretDependency` calls (e.g. adding A→B and B→A in the same project at once) could each pass the pre-write cycle check before either commit, persisting a 2-node cycle that `GetProjectRotationOrder` then hard-errors on forever, with nothing else able to detect or heal it. The cycle-check read and the edge write now run inside a single storage transaction, held under a new `secretDependencyMu` for same-process callers; a new `ListSecretDependenciesForProjectForUpdate` takes a Postgres row lock so HA replicas serialize too — the same two-layer pattern `login_lockout.go` and `RemoveUserRole` already use.
- **#368 (quadratic blowup):** `rotationWaves` rescanned every remaining candidate on each wave — O(V) waves deep for a long dependency chain, each an O(V) scan — making project-wide rotation planning O(V²), a pathological dependency chain could blow up rotation-plan generation. It now only walks the outgoing edges of nodes a prior wave just brought to indegree zero (proper Kahn's-algorithm BFS), so the whole call is O(V+E).
- As a belt-and-suspenders follow-on, `GenerateDeploymentRotationPlan` no longer 500s the entire deployment-wide view if one project's graph is (still, via some other path) cyclic — that project is skipped and reported in a new `BrokenProjects` field, mirroring `CompliancePosture`'s `Degraded`/`DegradedReasons` pattern.

## Test plan
- [x] `go build ./...` and `go build ./server`
- [x] `go test ./...` (full suite green)
- [x] `go test -race ./internal/core/...` (green, including a new `TestAddSecretDependency_ConcurrentRaceCannotPersistACycle` that reproduces the pre-fix race deterministically over 50 iterations on a single-connection DB)
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues
- [x] `golangci-lint run` on changed packages — 0 issues
- [x] `cd operator && GOWORK=off go build ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)