### PR TITLE
harden: misc MEDIUM bundle — machine-identity race, share-revoke-on-delete, dotenv injection, etc (#367/#370/#371/#384/#388/#389/#390)

### DIFF
--- a/internal/cli/secret/export.go
+++ b/internal/cli/secret/export.go
@@ -163,7 +163,18 @@ func fetchSecretValues(ctx context.Context, rc *common.RemoteClient, list []stru
 
 // ── Format writers ────────────────────────────────────────────────────────────
 
+// writeDotenv emits KEY=VALUE lines. The VALUE is quote-escaped above, but a KEY
+// containing an embedded newline (or carriage return) has no native escape in the
+// dotenv format — emitting it raw (#384) would let a secret named e.g.
+// "FOO\nINJECTED=evil" inject an extra, attacker-controlled KEY=VALUE line into an
+// artifact downstream tooling (docker run --env-file, CI --env-file) treats as fully
+// trusted. Refuse the export instead of silently producing an unsafe file.
 func writeDotenv(w io.Writer, secrets []exportedSecret) error {
+	for _, s := range secrets {
+		if strings.ContainsAny(s.Name, "\r\n") {
+			return fmt.Errorf("secret %q (id=%d) has a name containing a newline, which cannot be safely represented as a dotenv key — rename the secret before exporting to dotenv format", s.Name, s.ID)
+		}
+	}
 	fmt.Fprintf(w, "# Exported by Keyorix — %s\n", time.Now().Format("2006-01-02")) //nolint:errcheck
 	for _, s := range secrets {
 		val := s.Value

--- a/internal/cli/secret/export_test.go
+++ b/internal/cli/secret/export_test.go
@@ -1,6 +1,7 @@
 package secret
 
 import (
+	"bytes"
 	"context"
 	"net/http"
 	"net/http/httptest"
@@ -65,4 +66,47 @@ func TestRunExport_OutputFilePermissions(t *testing.T) {
 	data, err := os.ReadFile(outPath) // #nosec G304 -- test-controlled path
 	require.NoError(t, err)
 	assert.Contains(t, string(data), "DB_PASSWORD=s3cr3t")
+}
+
+// #384: writeDotenv quote-escapes the VALUE but historically emitted the NAME raw —
+// a secret named "FOO\nINJECTED=evil" would inject an extra, attacker-controlled
+// KEY=VALUE line into dotenv export output (a documented workflow feeding
+// `docker run --env-file`/CI `--env-file`, both of which treat the file as fully
+// trusted). Since dotenv has no native way to escape a newline inside a key, the
+// export must refuse rather than silently emit an unsafe file.
+func TestWriteDotenv_RejectsNewlineInSecretName(t *testing.T) {
+	var buf bytes.Buffer
+	secrets := []exportedSecret{
+		{ID: 1, Name: "SAFE_KEY", Value: "safe-value"},
+		{ID: 2, Name: "FOO\nINJECTED=evil", Value: "x"},
+	}
+	err := writeDotenv(&buf, secrets)
+	require.Error(t, err, "a secret name containing a newline must be refused")
+	assert.Contains(t, err.Error(), "newline")
+	// Nothing must have been written to the output on the failure path — a partial
+	// dotenv file is itself a hazard if a caller doesn't check the error.
+	assert.Empty(t, buf.String(), "no output should be written when the export is refused")
+}
+
+// A secret name containing a carriage return is equally dangerous (CRLF injection)
+// and must be refused the same way.
+func TestWriteDotenv_RejectsCarriageReturnInSecretName(t *testing.T) {
+	var buf bytes.Buffer
+	secrets := []exportedSecret{{ID: 1, Name: "FOO\rINJECTED=evil", Value: "x"}}
+	err := writeDotenv(&buf, secrets)
+	require.Error(t, err, "a secret name containing a carriage return must be refused")
+}
+
+// The ordinary case — no newline in any name — must still produce the expected
+// KEY=VALUE lines, with the value quote-escaped exactly as before.
+func TestWriteDotenv_NormalNamesUnaffected(t *testing.T) {
+	var buf bytes.Buffer
+	secrets := []exportedSecret{
+		{ID: 1, Name: "DB_PASSWORD", Value: "hello world"},
+		{ID: 2, Name: "API_KEY", Value: "plain"},
+	}
+	require.NoError(t, writeDotenv(&buf, secrets))
+	out := buf.String()
+	assert.Contains(t, out, `DB_PASSWORD="hello world"`)
+	assert.Contains(t, out, "API_KEY=plain")
 }

--- a/internal/core/auth_bootstrap_rbac_test.go
+++ b/internal/core/auth_bootstrap_rbac_test.go
@@ -30,6 +30,7 @@ func newBootstrappedCore(t *testing.T) (*KeyorixCore, *store.LocalStorage) {
 		&models.UserRole{}, &models.Group{}, &models.UserGroup{}, &models.GroupRole{},
 		&models.Project{}, &models.Environment{}, &models.AuditEvent{},
 		&models.AccessRequest{}, &models.AccessRequestApproval{}, &models.ProjectMembership{},
+		&models.SecretNode{},
 	))
 
 	st := store.NewLocalStorage(db)

--- a/internal/core/invitations.go
+++ b/internal/core/invitations.go
@@ -367,6 +367,13 @@ func (c *KeyorixCore) RequestProjectAccess(ctx context.Context, projectID, userI
 			return nil, fmt.Errorf("unknown role %q: %w", suggestedRole, err)
 		}
 	}
+	// The target project must exist and be live — GetProject's default soft-delete scope
+	// excludes a deleted project, so this also refuses a request against one that has been
+	// soft-deleted (#371). Otherwise a request can sit pending against a project an admin
+	// believes is gone, waiting to be approved (and go live) whenever it's restored.
+	if _, err := c.storage.GetProject(ctx, projectID); err != nil {
+		return nil, fmt.Errorf("project %d not found: %w", projectID, err)
+	}
 	now := c.now()
 	expires := now.Add(accessRequestTTL)
 	req := &models.AccessRequest{
@@ -452,6 +459,16 @@ func (c *KeyorixCore) ApproveAccessRequestWithExpiry(ctx context.Context, projec
 	}
 	if req.State != AccessRequestPending {
 		return nil, fmt.Errorf("only a pending request can be approved (state is %s)", req.State)
+	}
+	// The target project must still be live at approval time (#371) — DeleteProject never
+	// touches access_requests, so a request can otherwise sit pending across a project
+	// soft-delete and be approved afterward, producing a role grant scoped to a
+	// nonexistent project that goes live again — against potentially-stale intent — the
+	// moment the project is later restored, with no re-review of whether the original
+	// approval still makes sense. GetProject's default soft-delete scope makes this check
+	// double as the soft-delete check.
+	if _, err := c.storage.GetProject(ctx, req.ProjectID); err != nil {
+		return nil, fmt.Errorf("cannot approve: project %d no longer exists", req.ProjectID)
 	}
 	// Enforce the request's own TTL here, not only on the list path. GetAccessRequest
 	// returns the stored record verbatim, so a request whose expiry has passed is still

--- a/internal/core/invitations_test.go
+++ b/internal/core/invitations_test.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -69,6 +70,7 @@ func TestApproveAccessRequest_GrantsRole(t *testing.T) {
 	store.On("GetAccessRequest", ctx, uint(3)).Return(&models.AccessRequest{
 		ID: 3, ProjectID: 1, UserID: 2, SuggestedRole: "project_viewer", State: AccessRequestPending,
 	}, nil)
+	store.On("GetProject", ctx, uint(1)).Return(&models.Project{ID: 1}, nil)
 	// Admin upgrades the grant to developer.
 	store.On("GetRoleByName", ctx, "project_developer").Return(&models.Role{ID: 5}, nil)
 	store.On("AssignRole", ctx, uint(2), uint(5), storage.Scope{ProjectID: 1}).Return(nil)
@@ -103,6 +105,7 @@ func TestApproveAccessRequest_FallsBackToSuggestedRole(t *testing.T) {
 	store.On("GetAccessRequest", ctx, uint(3)).Return(&models.AccessRequest{
 		ID: 3, ProjectID: 1, UserID: 2, SuggestedRole: "project_viewer", State: AccessRequestPending,
 	}, nil)
+	store.On("GetProject", ctx, uint(1)).Return(&models.Project{ID: 1}, nil)
 	store.On("GetRoleByName", ctx, "project_viewer").Return(&models.Role{ID: 6}, nil)
 	store.On("AssignRole", ctx, uint(2), uint(6), storage.Scope{ProjectID: 1}).Return(nil)
 	store.On("UpdateAccessRequest", ctx, mock.Anything).Return(nil)
@@ -160,6 +163,7 @@ func TestApproveAccessRequest_RejectsAdminGrantByNonAdmin(t *testing.T) {
 	store.On("GetAccessRequest", ctx, uint(3)).Return(&models.AccessRequest{
 		ID: 3, ProjectID: 1, UserID: 2, SuggestedRole: "admin", State: AccessRequestPending,
 	}, nil)
+	store.On("GetProject", ctx, uint(1)).Return(&models.Project{ID: 1}, nil)
 	stubAdminRoleLookups(store, ctx)
 	// Approver 9 holds only a non-admin role (id 6) at the project.
 	store.On("GetUserRoleIDsAt", ctx, uint(9), storage.Scope{ProjectID: 1}).Return([]uint{6}, nil)
@@ -181,6 +185,7 @@ func TestApproveAccessRequest_AdminApproverMayGrantAdmin(t *testing.T) {
 	store.On("GetAccessRequest", ctx, uint(3)).Return(&models.AccessRequest{
 		ID: 3, ProjectID: 1, UserID: 2, SuggestedRole: "admin", State: AccessRequestPending,
 	}, nil)
+	store.On("GetProject", ctx, uint(1)).Return(&models.Project{ID: 1}, nil)
 	stubAdminRoleLookups(store, ctx)
 	// Approver 9 holds the admin role (id 2) at the project.
 	store.On("GetUserRoleIDsAt", ctx, uint(9), storage.Scope{ProjectID: 1}).Return([]uint{2}, nil)
@@ -206,6 +211,7 @@ func TestApproveAccessRequest_RejectsExpired(t *testing.T) {
 	store.On("GetAccessRequest", ctx, uint(3)).Return(&models.AccessRequest{
 		ID: 3, ProjectID: 1, UserID: 2, SuggestedRole: "project_viewer", State: AccessRequestPending, ExpiresAt: &past,
 	}, nil)
+	store.On("GetProject", ctx, uint(1)).Return(&models.Project{ID: 1}, nil)
 	store.On("UpdateAccessRequest", ctx, mock.MatchedBy(func(r *models.AccessRequest) bool {
 		return r.State == AccessRequestExpired
 	})).Return(nil)
@@ -243,6 +249,75 @@ func TestApproveAccessRequest_RejectsOtherProject(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not found")
 	store.AssertNotCalled(t, "AssignRole", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+}
+
+// #371: a request against a project that no longer exists (never created, or already
+// soft-deleted) must be refused at creation time — otherwise it could sit pending
+// against a project retired specifically to shut off further access, waiting to be
+// approved (and go live) whenever the project is restored.
+func TestRequestProjectAccess_RejectsUnknownProject(t *testing.T) {
+	store := new(MockStorage)
+	c := newInviteCore(store)
+	ctx := context.Background()
+	store.On("GetProject", ctx, uint(404)).Return(nil, fmt.Errorf("project not found"))
+
+	_, err := c.RequestProjectAccess(ctx, 404, 2, "", "please")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+	store.AssertNotCalled(t, "CreateAccessRequest", mock.Anything, mock.Anything)
+}
+
+// #371: RequestProjectAccess must refuse a soft-deleted project the same way it refuses
+// an unknown one — GetProject's default soft-delete scope makes this the same check.
+func TestRequestProjectAccess_RejectsSoftDeletedProject(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	ctx := context.Background()
+
+	requester, err := st.CreateUser(ctx, &models.User{Username: "requester", Email: "requester@example.com", IsActive: true})
+	require.NoError(t, err)
+	proj, err := st.CreateProject(ctx, &models.Project{Name: "retiring"})
+	require.NoError(t, err)
+	require.NoError(t, st.DeleteProject(ctx, proj.ID))
+
+	_, err = c.RequestProjectAccess(ctx, proj.ID, requester.ID, "project_viewer", "please")
+	require.Error(t, err, "requesting access to a soft-deleted project must be refused")
+}
+
+// #371: ApproveAccessRequestWithExpiry must refuse to approve a request whose target
+// project has been soft-deleted in the meantime — DeleteProject never touches
+// access_requests, so without this check a stale pending request could be approved
+// after the fact and go live the moment the project is later restored, against
+// potentially-stale intent and with no re-review.
+func TestApproveAccessRequestWithExpiry_RejectsSoftDeletedProject(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	ctx := context.Background()
+
+	approver, err := st.CreateUser(ctx, &models.User{Username: "approver2", Email: "approver2@example.com", IsActive: true})
+	require.NoError(t, err)
+	adminRole, err := st.GetRoleByName(ctx, "admin")
+	require.NoError(t, err)
+	require.NoError(t, st.AssignRole(ctx, approver.ID, adminRole.ID, storage.Scope{}))
+	requester, err := st.CreateUser(ctx, &models.User{Username: "requester2", Email: "requester2@example.com", IsActive: true})
+	require.NoError(t, err)
+
+	proj, err := st.CreateProject(ctx, &models.Project{Name: "retiring2"})
+	require.NoError(t, err)
+	req, err := st.CreateAccessRequest(ctx, &models.AccessRequest{
+		ProjectID: proj.ID, UserID: requester.ID, SuggestedRole: "project_viewer", State: AccessRequestPending,
+	})
+	require.NoError(t, err)
+
+	// The project is soft-deleted AFTER the request was filed, but before it's approved.
+	require.NoError(t, st.DeleteProject(ctx, proj.ID))
+
+	_, err = c.ApproveAccessRequestWithExpiry(ctx, proj.ID, req.ID, approver.ID, "", 0)
+	require.Error(t, err, "approving a request against a soft-deleted project must be refused")
+	assert.Contains(t, err.Error(), "no longer exists")
+
+	// No role grant landed.
+	ids, err := st.GetUserRoleIDsAt(ctx, requester.ID, storage.Scope{ProjectID: proj.ID})
+	require.NoError(t, err)
+	assert.Empty(t, ids)
 }
 
 func TestWithdrawAccessRequest_OwnershipChecked(t *testing.T) {

--- a/internal/core/machine_identities.go
+++ b/internal/core/machine_identities.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
@@ -129,25 +130,47 @@ func (c *KeyorixCore) ListStaleMachineIdentities(ctx context.Context, projectID 
 // enforcing the state machine, and audits the change. The machine must belong to
 // projectID — the caller's authorization is scoped to that project, so a machine
 // in another project must not be reachable through it (cross-project guard).
+//
+// #388: the read-check-write is done inside a transaction against a row obtained via
+// LockMachineIdentityForUpdate, not a plain GetMachineIdentity — without a DB-level
+// guard, two concurrent transitions racing off the same pre-transition state (e.g.
+// one to revoked, one racing back to active from suspended) can each independently
+// pass canTransitionMachine, and whichever plain Save landed last would silently win
+// outright, un-revoking a just-revoked machine identity. The row lock (Postgres:
+// SELECT ... FOR UPDATE) serializes this across replicas; the transaction alone
+// serializes it on SQLite (always single-process).
 func (c *KeyorixCore) TransitionMachineIdentity(ctx context.Context, projectID, id uint, to string, actorID uint) (*models.MachineIdentity, error) {
-	m, err := c.machineInProject(ctx, projectID, id)
+	now := c.now()
+	var result *models.MachineIdentity
+	err := c.storage.WithTransaction(ctx, func(tx storage.Storage) error {
+		m, err := tx.LockMachineIdentityForUpdate(ctx, id)
+		if err != nil {
+			return fmt.Errorf("machine identity not found")
+		}
+		if m.ProjectID != projectID {
+			// Cross-project guard: report as "not found" (not a permission error) to
+			// avoid confirming the machine's existence to a caller scoped elsewhere.
+			return fmt.Errorf("machine identity not found")
+		}
+		if !canTransitionMachine(m.State, to) {
+			return fmt.Errorf("cannot transition machine identity from %s to %s", m.State, to)
+		}
+		m.State = to
+		m.UpdatedAt = now
+		if to == MachineRevoked {
+			m.RevokedAt = &now
+		}
+		if err := tx.UpdateMachineIdentity(ctx, m); err != nil {
+			return fmt.Errorf("failed to update machine identity: %w", err)
+		}
+		result = m
+		return nil
+	})
 	if err != nil {
 		return nil, err
 	}
-	if !canTransitionMachine(m.State, to) {
-		return nil, fmt.Errorf("cannot transition machine identity from %s to %s", m.State, to)
-	}
-	now := c.now()
-	m.State = to
-	m.UpdatedAt = now
-	if to == MachineRevoked {
-		m.RevokedAt = &now
-	}
-	if err := c.storage.UpdateMachineIdentity(ctx, m); err != nil {
-		return nil, fmt.Errorf("failed to update machine identity: %w", err)
-	}
-	c.logMachineEvent(ctx, "machine_identity."+machineVerb(to), m, actorID)
-	return m, nil
+	c.logMachineEvent(ctx, "machine_identity."+machineVerb(to), result, actorID)
+	return result, nil
 }
 
 // ClassifyMachineIdentity sets (or clears, with "") the data-classification label

--- a/internal/core/machine_identities_test.go
+++ b/internal/core/machine_identities_test.go
@@ -84,7 +84,7 @@ func TestTransitionMachineIdentity(t *testing.T) {
 		store := new(MockStorage)
 		c := newMachineCore(store)
 		ctx := context.Background()
-		store.On("GetMachineIdentity", ctx, uint(10)).Return(&models.MachineIdentity{ID: 10, ProjectID: 1, State: MachineActive}, nil)
+		store.On("LockMachineIdentityForUpdate", ctx, uint(10)).Return(&models.MachineIdentity{ID: 10, ProjectID: 1, State: MachineActive}, nil)
 		store.On("UpdateMachineIdentity", ctx, mock.MatchedBy(func(m *models.MachineIdentity) bool {
 			return m.State == MachineSuspended
 		})).Return(nil)
@@ -99,7 +99,7 @@ func TestTransitionMachineIdentity(t *testing.T) {
 		store := new(MockStorage)
 		c := newMachineCore(store)
 		ctx := context.Background()
-		store.On("GetMachineIdentity", ctx, uint(10)).Return(&models.MachineIdentity{ID: 10, ProjectID: 1, State: MachineActive}, nil)
+		store.On("LockMachineIdentityForUpdate", ctx, uint(10)).Return(&models.MachineIdentity{ID: 10, ProjectID: 1, State: MachineActive}, nil)
 		store.On("UpdateMachineIdentity", ctx, mock.MatchedBy(func(m *models.MachineIdentity) bool {
 			return m.State == MachineRevoked && m.RevokedAt != nil
 		})).Return(nil)
@@ -113,7 +113,7 @@ func TestTransitionMachineIdentity(t *testing.T) {
 		store := new(MockStorage)
 		c := newMachineCore(store)
 		ctx := context.Background()
-		store.On("GetMachineIdentity", ctx, uint(10)).Return(&models.MachineIdentity{ID: 10, ProjectID: 1, State: MachineRevoked}, nil)
+		store.On("LockMachineIdentityForUpdate", ctx, uint(10)).Return(&models.MachineIdentity{ID: 10, ProjectID: 1, State: MachineRevoked}, nil)
 
 		_, err := c.TransitionMachineIdentity(ctx, 1, 10, MachineActive, 9)
 		require.Error(t, err)
@@ -127,11 +127,31 @@ func TestTransitionMachineIdentity(t *testing.T) {
 		store := new(MockStorage)
 		c := newMachineCore(store)
 		ctx := context.Background()
-		store.On("GetMachineIdentity", ctx, uint(10)).Return(&models.MachineIdentity{ID: 10, ProjectID: 2, State: MachineActive}, nil)
+		store.On("LockMachineIdentityForUpdate", ctx, uint(10)).Return(&models.MachineIdentity{ID: 10, ProjectID: 2, State: MachineActive}, nil)
 
 		_, err := c.TransitionMachineIdentity(ctx, 1, 10, MachineSuspended, 9)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "not found")
+		store.AssertNotCalled(t, "UpdateMachineIdentity", mock.Anything, mock.Anything)
+	})
+
+	// #388: a concurrent revoke and reactivate racing off the same pre-transition
+	// state must not silently un-revoke — the second transition observes the
+	// FIRST one's already-committed state under the row lock and is rejected as an
+	// illegal transition (revoked is terminal), not applied blindly.
+	t.Run("second racing transition sees the first's committed state, not the stale one", func(t *testing.T) {
+		store := new(MockStorage)
+		c := newMachineCore(store)
+		ctx := context.Background()
+		// Both callers "observed" active/suspended before racing; by the time the second
+		// transition's LockMachineIdentityForUpdate call runs, the first has already
+		// committed revoked — WithTransaction in tests calls fn directly, so this models
+		// the real DB row-lock serializing to reflect the just-committed state.
+		store.On("LockMachineIdentityForUpdate", ctx, uint(10)).Return(&models.MachineIdentity{ID: 10, ProjectID: 1, State: MachineRevoked}, nil)
+
+		_, err := c.TransitionMachineIdentity(ctx, 1, 10, MachineActive, 9)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot transition")
 		store.AssertNotCalled(t, "UpdateMachineIdentity", mock.Anything, mock.Anything)
 	})
 }

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -66,7 +66,16 @@ func (m *MockStorage) ListProjectsWithCounts(_ context.Context, _ bool) ([]stora
 	return nil, nil
 }
 
-func (m *MockStorage) GetProject(_ context.Context, id uint) (*models.Project, error) {
+func (m *MockStorage) GetProject(ctx context.Context, id uint) (*models.Project, error) {
+	for _, c := range m.ExpectedCalls {
+		if c.Method == "GetProject" {
+			args := m.Called(ctx, id)
+			if args.Get(0) == nil {
+				return nil, args.Error(1)
+			}
+			return args.Get(0).(*models.Project), args.Error(1)
+		}
+	}
 	return &models.Project{}, nil
 }
 
@@ -1478,6 +1487,14 @@ func (m *MockStorage) CreateMachineIdentity(ctx context.Context, mi *models.Mach
 }
 
 func (m *MockStorage) GetMachineIdentity(ctx context.Context, id uint) (*models.MachineIdentity, error) {
+	args := m.Called(ctx, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.MachineIdentity), args.Error(1)
+}
+
+func (m *MockStorage) LockMachineIdentityForUpdate(ctx context.Context, id uint) (*models.MachineIdentity, error) {
 	args := m.Called(ctx, id)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)

--- a/internal/core/oidc.go
+++ b/internal/core/oidc.go
@@ -60,6 +60,9 @@ func NewOIDCVerifier(issuers []OIDCTrustedIssuer, jwks JWKSResolver) (*OIDCVerif
 				auds[a] = struct{}{}
 			}
 		}
+		if len(auds) == 0 {
+			return nil, fmt.Errorf("oidc: issuer %q has no usable audiences after filtering empty values — configure at least one non-empty audience", iss.Issuer)
+		}
 		m[iss.Issuer] = auds
 	}
 	return &OIDCVerifier{issuers: m, jwks: jwks, leeway: oidcClockSkew}, nil

--- a/internal/core/oidc_test.go
+++ b/internal/core/oidc_test.go
@@ -56,6 +56,17 @@ func TestNewOIDCVerifier_RequiresAudience(t *testing.T) {
 	require.ErrorContains(t, err, "no audiences")
 }
 
+// TestNewOIDCVerifier_RejectsBlankOnlyAudiences guards #367: an operator
+// supplying only empty-string audience entries (e.g. Audiences: [""]) must be
+// rejected at startup with a clear error, not silently build an issuer entry
+// that can never satisfy its own audience check (permanent fail-closed lockout).
+func TestNewOIDCVerifier_RejectsBlankOnlyAudiences(t *testing.T) {
+	_, err := NewOIDCVerifier([]OIDCTrustedIssuer{{Issuer: "https://x", Audiences: []string{"", ""}}}, staticResolver{})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "https://x")
+	require.ErrorContains(t, err, "no usable audiences")
+}
+
 func TestOIDCVerify_Valid(t *testing.T) {
 	key, _ := rsa.GenerateKey(rand.Reader, 2048)
 	v := newTestVerifier(t, key)

--- a/internal/core/restore_audit_test.go
+++ b/internal/core/restore_audit_test.go
@@ -23,6 +23,9 @@ func TestRestoreOperationsAudit(t *testing.T) {
 	require.NoError(t, db.AutoMigrate(
 		&models.SecretNode{}, &models.SecretVersion{}, &models.Project{}, &models.Environment{}, &models.AuditEvent{},
 		&models.UserRole{}, &models.GroupRole{}, &models.UserGroup{}, &models.Role{}, &models.Group{},
+		// #370: DeleteSecret revokes ShareRecord rows in the same transaction as the
+		// secret's own soft-delete.
+		&models.ShareRecord{},
 	))
 	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
 	ctx := context.Background()

--- a/internal/core/secret_dependencies_test.go
+++ b/internal/core/secret_dependencies_test.go
@@ -71,7 +71,10 @@ func newDepCore(t *testing.T) (*KeyorixCore, *gorm.DB) {
 	t.Helper()
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
-	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretDependency{}, &models.AuditEvent{}, &models.Project{}, &models.Environment{}))
+	// #370: DeleteSecret now revokes ShareRecord rows in the same transaction as the
+	// secret's own soft-delete, so ShareRecord must be migrated even though these
+	// tests never create a share directly.
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretDependency{}, &models.AuditEvent{}, &models.Project{}, &models.Environment{}, &models.ShareRecord{}))
 	// Live parent projects (1, 2) + environment (1): RestoreSecret refuses to restore a
 	// secret into a soft-deleted parent, so the dependency-cascade tests need them present.
 	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "p1"}).Error)

--- a/internal/core/secret_name_policy.go
+++ b/internal/core/secret_name_policy.go
@@ -43,11 +43,23 @@ func (c *KeyorixCore) validateSecretName(name string) error {
 
 // compileNamePattern compiles a name-policy pattern, used by SetSecretNamePolicy and
 // reusable for config validation. Returns nil regexp for an empty pattern.
+//
+// #389: the pattern is unconditionally wrapped in ^(?:…)$ rather than compiled as
+// given. validateSecretName calls MatchString, which succeeds on ANY matching
+// substring, not a whole-string match — an operator writing
+// "[A-Za-z][A-Za-z0-9_-]*" intending "identifier-like names only" would, unanchored,
+// accept virtually any string containing at least one such substring (e.g. a
+// CSV-injection-shaped `=cmd|' /C calc'!A1`, or a name embedding control
+// characters), silently defeating the exact protection several OTHER findings (the
+// #328 CSV/Slack-injection family) depend on this policy to provide once "properly
+// configured". Forcing the anchor here — instead of only advising it in a doc
+// comment — closes that gap unconditionally; wrapping an already-anchored pattern
+// (e.g. "^[A-Z_]+$") in an extra ^(?:...)$ is a no-op.
 func compileNamePattern(pattern string) (*regexp.Regexp, error) {
 	if pattern == "" {
 		return nil, nil
 	}
-	re, err := regexp.Compile(pattern)
+	re, err := regexp.Compile("^(?:" + pattern + ")$")
 	if err != nil {
 		return nil, fmt.Errorf("invalid secret name pattern: %w", err)
 	}

--- a/internal/core/secret_name_policy_test.go
+++ b/internal/core/secret_name_policy_test.go
@@ -42,6 +42,31 @@ func TestSecretNamePolicy_Validate(t *testing.T) {
 		assert.NoError(t, c.validateSecretName("short"))
 		assert.Error(t, c.validateSecretName("toolong"))
 	})
+
+	// #389: an operator-supplied pattern that forgets to anchor (^…$) must still
+	// enforce a whole-string match — MatchString alone succeeds on any matching
+	// substring, so an unanchored "identifier-like" pattern would otherwise accept a
+	// name that merely CONTAINS a conforming substring, silently defeating the
+	// protection other findings (the #328 CSV/Slack-injection family) rely on this
+	// policy to provide.
+	t.Run("an unanchored pattern is enforced as a whole-string match", func(t *testing.T) {
+		c := &KeyorixCore{}
+		require.NoError(t, c.SetSecretNamePolicy(SecretNamePolicy{Enabled: true, Pattern: "[A-Za-z][A-Za-z0-9_-]*"}))
+		assert.NoError(t, c.validateSecretName("DB_PASSWORD"), "a fully-conforming name still passes")
+		assert.Error(t, c.validateSecretName("=cmd|' /C calc'!A1"),
+			"a CSV-injection-shaped name containing a conforming substring must be rejected, not merely matched-somewhere")
+		assert.Error(t, c.validateSecretName("FOO\nINJECTED=evil"),
+			"a name embedding a conforming substring plus a newline must be rejected")
+	})
+
+	// An already-anchored pattern must behave exactly as before — the added
+	// ^(?:...)$ wrap is a no-op on a pattern that already anchors itself.
+	t.Run("an already-anchored pattern is unaffected", func(t *testing.T) {
+		c := &KeyorixCore{}
+		require.NoError(t, c.SetSecretNamePolicy(SecretNamePolicy{Enabled: true, Pattern: "^[A-Z][A-Z0-9_]*$"}))
+		assert.NoError(t, c.validateSecretName("DB_PASSWORD"))
+		assert.Error(t, c.validateSecretName("db-password"))
+	})
 }
 
 func TestCreateSecret_NamePolicy(t *testing.T) {

--- a/internal/core/secret_recycle_bin_test.go
+++ b/internal/core/secret_recycle_bin_test.go
@@ -20,7 +20,9 @@ func TestListDeletedSecrets(t *testing.T) {
 	require.NoError(t, err)
 	sqlDB, _ := db.DB()
 	sqlDB.SetMaxOpenConns(1)
-	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.AuditEvent{}, &models.Project{}, &models.Environment{}))
+	// #370: DeleteSecret revokes ShareRecord rows in the same transaction as the
+	// secret's own soft-delete.
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.AuditEvent{}, &models.Project{}, &models.Environment{}, &models.ShareRecord{}))
 	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
 	ctx := context.Background()
 

--- a/internal/core/secret_tags_test.go
+++ b/internal/core/secret_tags_test.go
@@ -83,3 +83,56 @@ func TestSecretTags(t *testing.T) {
 		require.Error(t, err)
 	})
 }
+
+// TestCreateSecret_AppliesTags guards #390: CreateSecretRequest.Tags was silently
+// accepted and dropped — CreateSecret never read req.Tags or called SetSecretTags,
+// despite both the HTTP and gRPC handlers passing the field through, so a caller
+// intending an immediate "reviewed"/"exempt"-style tag at creation time got no tag
+// and no error.
+func TestCreateSecret_AppliesTags(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	sqlDB, _ := db.DB()
+	sqlDB.SetMaxOpenConns(1)
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.Project{},
+		&models.Environment{}, &models.AuditEvent{}, &models.Tag{}, &models.SecretTag{}))
+	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
+	ctx := context.Background()
+	p, err := c.storage.CreateProject(ctx, &models.Project{Name: "p1"})
+	require.NoError(t, err)
+	e, err := c.storage.CreateEnvironment(ctx, &models.Environment{Name: "production", ProjectID: p.ID})
+	require.NoError(t, err)
+
+	t.Run("tags supplied at create time are persisted, normalized", func(t *testing.T) {
+		created, err := c.CreateSecret(ctx, &CreateSecretRequest{
+			Name: "DB_PASSWORD", Value: []byte("supersecret1"), ProjectID: p.ID, EnvironmentID: e.ID,
+			Type: "password", CreatedBy: "owner", OwnerID: 1, Tags: []string{" Reviewed ", "REVIEWED", "exempt"},
+		})
+		require.NoError(t, err)
+		got, err := c.storage.GetSecretTags(ctx, created.ID)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"exempt", "reviewed"}, got)
+	})
+
+	t.Run("no tags is still a no-op, no error", func(t *testing.T) {
+		created, err := c.CreateSecret(ctx, &CreateSecretRequest{
+			Name: "API_KEY", Value: []byte("supersecret1"), ProjectID: p.ID, EnvironmentID: e.ID,
+			Type: "password", CreatedBy: "owner", OwnerID: 1,
+		})
+		require.NoError(t, err)
+		got, err := c.storage.GetSecretTags(ctx, created.ID)
+		require.NoError(t, err)
+		assert.Empty(t, got)
+	})
+
+	t.Run("an over-long tag at create time is rejected before the secret is persisted", func(t *testing.T) {
+		_, err := c.CreateSecret(ctx, &CreateSecretRequest{
+			Name: "BAD_TAG_SECRET", Value: []byte("supersecret1"), ProjectID: p.ID, EnvironmentID: e.ID,
+			Type: "password", CreatedBy: "owner", OwnerID: 1, Tags: []string{strings.Repeat("a", 51)},
+		})
+		require.Error(t, err)
+		_, getErr := c.storage.GetSecretByName(ctx, "BAD_TAG_SECRET", p.ID, e.ID)
+		require.Error(t, getErr, "the secret must not have been created when its tag list is invalid")
+	})
+}

--- a/internal/core/secrets.go
+++ b/internal/core/secrets.go
@@ -86,6 +86,18 @@ func (c *KeyorixCore) CreateSecret(ctx context.Context, req *CreateSecretRequest
 		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "invalid classification")
 	}
 
+	// #390: normalize req.Tags UP FRONT, before creating anything, so a caller intending
+	// an immediate "reviewed"/"exempt"-style tag at creation time gets a clear validation
+	// error instead of a silently-dropped tag list — CreateSecret previously never read
+	// req.Tags at all despite both the HTTP and gRPC handlers passing it through.
+	var normalizedTags []string
+	if len(req.Tags) > 0 {
+		normalizedTags, err = normalizeTags(req.Tags)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	secret := &models.SecretNode{
 		Name:           req.Name,
 		ProjectID:      req.ProjectID,
@@ -113,6 +125,22 @@ func (c *KeyorixCore) CreateSecret(ctx context.Context, req *CreateSecretRequest
 			log.Printf("warning: failed to cleanup orphaned secret %d after failed version creation: %v", createdSecret.ID, delErr)
 		}
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+
+	// Apply the create-time tags (#390) now that the secret and its first version both
+	// exist. Calling the storage layer directly (not the core SetSecretTags wrapper)
+	// is deliberate: SetSecretTags re-enforces write permission via
+	// EnforceSecretWritePermission, which is redundant here (the caller already had
+	// secrets.write on this scope to reach CreateSecret at all) and would require
+	// resolving an actor ID that CreateSecretRequest doesn't carry uniformly across
+	// every caller (HTTP/gRPC/CLI). Tags were already normalized/validated up front.
+	if len(normalizedTags) > 0 {
+		if err := c.storage.SetSecretTags(ctx, createdSecret.ID, normalizedTags); err != nil {
+			if delErr := c.storage.DeleteSecret(ctx, createdSecret.ID); delErr != nil {
+				log.Printf("warning: failed to cleanup orphaned secret %d after failed tag creation: %v", createdSecret.ID, delErr)
+			}
+			return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+		}
 	}
 
 	return createdSecret, nil

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -183,6 +183,14 @@ type Storage interface {
 	// Machine identities (ADR-023) — non-human project members.
 	CreateMachineIdentity(ctx context.Context, m *models.MachineIdentity) (*models.MachineIdentity, error)
 	GetMachineIdentity(ctx context.Context, id uint) (*models.MachineIdentity, error)
+	// LockMachineIdentityForUpdate re-reads a machine identity by ID, taking a
+	// row-level write lock on backends that support one (Postgres: SELECT … FOR
+	// UPDATE) so a read-modify-write on the row serializes against a concurrent
+	// writer of the same row — mirroring LockUserForUpdate. Use this — not
+	// GetMachineIdentity — inside a WithTransaction whenever a caller conditionally
+	// mutates state (e.g. TransitionMachineIdentity's revoked-is-terminal invariant,
+	// #388) that must not lose an update under concurrency.
+	LockMachineIdentityForUpdate(ctx context.Context, id uint) (*models.MachineIdentity, error)
 	UpdateMachineIdentity(ctx context.Context, m *models.MachineIdentity) error
 	ListMachineIdentities(ctx context.Context, projectID uint) ([]*models.MachineIdentity, error)
 	// ListAllMachineIdentities returns every machine identity across all projects —

--- a/internal/storage/store/local_machine_identities.go
+++ b/internal/storage/store/local_machine_identities.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"fmt"
 
+	"gorm.io/gorm/clause"
+
 	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
@@ -21,6 +23,24 @@ func (ls *LocalStorage) CreateMachineIdentity(ctx context.Context, m *models.Mac
 func (ls *LocalStorage) GetMachineIdentity(ctx context.Context, id uint) (*models.MachineIdentity, error) {
 	var m models.MachineIdentity
 	if err := ls.db.WithContext(ctx).First(&m, id).Error; err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorNotFound", nil), err)
+	}
+	return &m, nil
+}
+
+// LockMachineIdentityForUpdate re-reads a machine identity, adding SELECT … FOR
+// UPDATE on Postgres so a read-modify-write inside a transaction serializes against
+// concurrent writers of the same row (#388: TransitionMachineIdentity relies on this
+// to keep "revoked is terminal" atomic — see machine_identities.go). SQLite has no
+// row-level lock, so the clause is omitted there and the transaction alone
+// serializes it; SQLite is always single-process, so that suffices.
+func (ls *LocalStorage) LockMachineIdentityForUpdate(ctx context.Context, id uint) (*models.MachineIdentity, error) {
+	q := ls.db.WithContext(ctx)
+	if ls.db.Dialector.Name() == "postgres" {
+		q = q.Clauses(clause.Locking{Strength: "UPDATE"})
+	}
+	var m models.MachineIdentity
+	if err := q.First(&m, id).Error; err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorNotFound", nil), err)
 	}
 	return &m, nil

--- a/internal/storage/store/local_secrets.go
+++ b/internal/storage/store/local_secrets.go
@@ -364,16 +364,28 @@ func (ls *LocalStorage) SetSecretCertNotAfter(ctx context.Context, secretID uint
 	return nil
 }
 
-// DeleteSecret deletes a secret by ID.
+// DeleteSecret deletes a secret by ID. #370: ShareRecord rows are a fully
+// independent lifecycle from SecretNode's — left untouched, a share grant would
+// silently reactivate (via CheckSharePermission) the instant the secret is later
+// restored from the recycle bin, with zero re-authorization step, even when the
+// secret was deleted specifically to sever a former grantee's access. "Delete
+// means gone" for sharing too, so revoke every active share for this secret in
+// the same transaction as the secret's own soft-delete.
 func (ls *LocalStorage) DeleteSecret(ctx context.Context, id uint) error {
-	result := ls.db.WithContext(ctx).Delete(&models.SecretNode{}, id)
-	if result.Error != nil {
-		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), result.Error)
-	}
-	if result.RowsAffected == 0 {
-		return fmt.Errorf("%s", i18n.T("ErrorSecretNotFound", nil))
-	}
-	return nil
+	return ls.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		result := tx.Delete(&models.SecretNode{}, id)
+		if result.Error != nil {
+			return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), result.Error)
+		}
+		if result.RowsAffected == 0 {
+			return fmt.Errorf("%s", i18n.T("ErrorSecretNotFound", nil))
+		}
+		if err := tx.Where("secret_id = ? AND deleted_at IS NULL", id).
+			Delete(&models.ShareRecord{}).Error; err != nil {
+			return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+		}
+		return nil
+	})
 }
 
 // GetSecretIncludingDeleted loads a secret even when soft-deleted (Unscoped).

--- a/internal/storage/store/local_sharing_test.go
+++ b/internal/storage/store/local_sharing_test.go
@@ -119,6 +119,55 @@ func TestDeleteShareRecord_RemovesAllDuplicatesForSameTuple(t *testing.T) {
 	assert.Equal(t, int64(0), postCount, "both duplicate rows must be removed by a single revoke")
 }
 
+// #370: DeleteSecret must revoke every active ShareRecord for that secret, not just
+// soft-delete the secret itself — otherwise a share grant silently resurrects with zero
+// re-authorization when the secret is later restored from the recycle bin, even when the
+// secret was deleted specifically to sever a former grantee's access.
+func TestDeleteSecret_RevokesActiveShares(t *testing.T) {
+	db := sharingConcurrentDB(t)
+	require.NoError(t, db.AutoMigrate(&models.Project{}, &models.Environment{}))
+	ls := NewLocalStorage(db)
+	ctx := context.Background()
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "owner", Email: "o@x.io"}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 2, Username: "grantee", Email: "g@x.io"}).Error)
+	proj, err := ls.CreateProject(ctx, &models.Project{Name: "app"})
+	require.NoError(t, err)
+	env, err := ls.CreateEnvironment(ctx, &models.Environment{Name: "prod", ProjectID: proj.ID})
+	require.NoError(t, err)
+	sec, err := ls.CreateSecret(ctx, &models.SecretNode{
+		ProjectID: proj.ID, EnvironmentID: env.ID, Name: "db-pw", IsSecret: true, Type: "text",
+		Status: "active", OwnerID: 1,
+	})
+	require.NoError(t, err)
+
+	share, err := ls.CreateShareRecord(ctx, &models.ShareRecord{
+		SecretID: sec.ID, RecipientID: 2, IsGroup: false, OwnerID: 1, Permission: "read",
+	})
+	require.NoError(t, err)
+
+	// Sanity: the grantee has access before the delete.
+	perm, err := ls.CheckSharePermission(ctx, sec.ID, 2)
+	require.NoError(t, err)
+	assert.Equal(t, "read", perm)
+
+	// Delete the secret specifically to sever the grantee's access.
+	require.NoError(t, ls.DeleteSecret(ctx, sec.ID))
+
+	var deletedShare models.ShareRecord
+	require.NoError(t, db.Unscoped().First(&deletedShare, share.ID).Error)
+	assert.True(t, deletedShare.DeletedAt.Valid, "the share record must be revoked (soft-deleted) alongside the secret")
+
+	// Restore the secret (via project restore, the only supported path once the parent
+	// project stays live — RestoreSecret alone also works when the project is live).
+	require.NoError(t, ls.RestoreSecret(ctx, sec.ID))
+
+	// The previously-revoked share must NOT silently reactivate: CheckSharePermission
+	// must deny the former grantee post-restore with zero new authorization step.
+	perm, err = ls.CheckSharePermission(ctx, sec.ID, 2)
+	require.Error(t, err, "a share revoked by secret delete must not resurrect when the secret is restored")
+	assert.Equal(t, "", perm)
+}
+
 // #136: CheckSharePermission's OwnerID==userID check must not match when both are the
 // zero value. A machine actor's ID is also 0, so an unguarded equality would grant it
 // owner-level "write" on every ownerless (machine-created) secret.

--- a/internal/storage/store/remote_machine_identities.go
+++ b/internal/storage/store/remote_machine_identities.go
@@ -20,6 +20,10 @@ func (rs *RemoteStorage) GetMachineIdentity(_ context.Context, _ uint) (*models.
 	return nil, remoteUnsupported("GetMachineIdentity")
 }
 
+func (rs *RemoteStorage) LockMachineIdentityForUpdate(_ context.Context, _ uint) (*models.MachineIdentity, error) {
+	return nil, remoteUnsupported("LockMachineIdentityForUpdate")
+}
+
 func (rs *RemoteStorage) UpdateMachineIdentity(_ context.Context, _ *models.MachineIdentity) error {
 	return remoteUnsupported("UpdateMachineIdentity")
 }

--- a/internal/storage/store/restore_test.go
+++ b/internal/storage/store/restore_test.go
@@ -16,7 +16,9 @@ func newRestoreTestStore(t *testing.T) *LocalStorage {
 	t.Helper()
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
-	require.NoError(t, db.AutoMigrate(&models.Project{}, &models.Environment{}, &models.SecretNode{}))
+	// #370: DeleteSecret revokes ShareRecord rows in the same transaction as the
+	// secret's own soft-delete.
+	require.NoError(t, db.AutoMigrate(&models.Project{}, &models.Environment{}, &models.SecretNode{}, &models.ShareRecord{}))
 	return NewLocalStorage(db)
 }
 

--- a/internal/storage/store/secret_soft_delete_test.go
+++ b/internal/storage/store/secret_soft_delete_test.go
@@ -17,7 +17,9 @@ func newSoftDeleteTestStore(t *testing.T) *LocalStorage {
 	t.Helper()
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
-	require.NoError(t, db.AutoMigrate(&models.Project{}, &models.SecretNode{}, &models.SecretVersion{}, &models.Environment{}, &models.SecretDependency{}))
+	// #370: DeleteSecret revokes ShareRecord rows in the same transaction as the
+	// secret's own soft-delete.
+	require.NoError(t, db.AutoMigrate(&models.Project{}, &models.SecretNode{}, &models.SecretVersion{}, &models.Environment{}, &models.SecretDependency{}, &models.ShareRecord{}))
 	return NewLocalStorage(db)
 }
 

--- a/server/http/integration_test.go
+++ b/server/http/integration_test.go
@@ -65,6 +65,10 @@ func newTestCore(t *testing.T) *core.KeyorixCore {
 		&models.LoginAttempt{},
 		&models.PasswordHistory{},
 		&models.PersonalAccessToken{},
+		// #390: CreateSecret now applies req.Tags via storage.SetSecretTags, which
+		// needs both the global Tag table and the per-secret SecretTag join table.
+		&models.Tag{},
+		&models.SecretTag{},
 	)
 	require.NoError(t, err)
 	return core.NewKeyorixCore(store.NewLocalStorage(db))


### PR DESCRIPTION
## Summary

Resumes an interrupted round-65/66 misc-medium bundle and closes all 7 backlog findings it was scoped for:

- **#367 LOW** — `NewOIDCVerifier` tested `Audiences` length before filtering empty strings, so an operator-supplied `Audiences: [""]` built an issuer that could never satisfy its own audience check (permanent fail-closed lockout). Now rejected at construction time with a clear error.
- **#370 MEDIUM** — `DeleteSecret` only touched `secret_nodes.deleted_at`; `ShareRecord` rows were a fully independent lifecycle, so a share grant silently resurrected with zero re-authorization the moment a soft-deleted secret was restored — even when the secret was deleted specifically to sever a grantee's access. `DeleteSecret` now revokes every active share for the secret in the same transaction as the secret's own soft-delete.
- **#371 MEDIUM** — `RequestProjectAccess`/`ApproveAccessRequestWithExpiry` never checked the target project exists/isn't soft-deleted, and `DeleteProject` never touched `access_requests`. Both now require `GetProject` to succeed (which doubles as the soft-delete check), so a request can no longer sit dormant against a retired project and go live with no re-review when it's later restored.
- **#384 MEDIUM** — `writeDotenv` quote-escaped the VALUE but emitted the NAME raw; a secret named `"FOO\nINJECTED=evil"` injected an attacker-controlled extra `KEY=VALUE` line into dotenv export output, a documented workflow feeding `docker run --env-file`/CI `--env-file`. The export now refuses rather than silently producing an unsafe file.
- **#388 MEDIUM** — `TransitionMachineIdentity` was a plain read-check-write with no DB-level guard, so two concurrent transitions racing off the same pre-transition state (one to revoked, one racing back to active) could each pass the state-machine check independently, and whichever `Save` landed last won outright — silently un-revoking a just-revoked machine identity. Added `LockMachineIdentityForUpdate` (row lock on Postgres, mirroring `LockUserForUpdate`) and moved the whole read-check-write inside a `WithTransaction`.
- **#389 MEDIUM** — `validateSecretName`'s regex check used `MatchString`, which succeeds on any matching substring, not a whole-string match. An operator forgetting to anchor their pattern (only advised via a doc comment) would silently accept any name containing a conforming substring — defeating the exact protection other findings (the #328 CSV/Slack-injection family) rely on this policy to provide. `compileNamePattern` now wraps every pattern in `^(?:…)$` unconditionally.
- **#390 LOW** — `CreateSecret` never read `req.Tags` or called `SetSecretTags`, despite both the HTTP and gRPC handlers passing the field through — a caller intending an immediate "reviewed"/"exempt"-style tag at creation time silently got no tag and no error. Tags are now normalized up front (so an invalid tag list fails before anything is persisted) and applied once the secret and its first version exist. `UpdateSecret`'s `Tags` remains out of scope — that's tracked separately as #285.

Also fixes several test-only `AutoMigrate` lists (the `server/http` integration test, `internal/core` dependency-cascade/restore/recycle-bin tests, `internal/storage/store` restore/soft-delete tests) that were missing `Tag`/`SecretTag`/`ShareRecord` — latent gaps the #370/#390 fixes newly exercise.

## Test plan

- [x] `go build ./...` and `go build ./server`
- [x] `go test ./...` — full suite green (one pre-existing flaky timing test, `TestHTTPJWKSResolver_CapsKeyCount`, passes in isolation and on repeat full-suite runs)
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues
- [x] `golangci-lint run ./...` — 0 issues
- [x] `cd operator && GOWORK=off go build ./...`
- [x] New regression tests for each finding (machine-identity race, share-revoke-on-restore, project-soft-delete-vs-access-request, dotenv newline injection, unanchored name-policy, create-time tags, blank-audience OIDC lockout)