### PR TITLE
fix(dynamic-secrets): disable configs and revoke leases on project deletion (#369 HIGH)

### DIFF
--- a/internal/core/auth_bootstrap_rbac_test.go
+++ b/internal/core/auth_bootstrap_rbac_test.go
@@ -33,7 +33,7 @@ func newBootstrappedCore(t *testing.T) (*KeyorixCore, *store.LocalStorage) {
 		&models.PersonalAccessToken{}, &models.Session{}, &models.ShareRecord{},
 		&models.AuditEvent{},
 		&models.AccessRequest{}, &models.AccessRequestApproval{}, &models.ProjectMembership{},
-		&models.SecretNode{},
+		&models.SecretNode{}, &models.DynamicSecretConfig{},
 	))
 
 	st := store.NewLocalStorage(db)

--- a/internal/core/catalog.go
+++ b/internal/core/catalog.go
@@ -126,6 +126,16 @@ func (c *KeyorixCore) ProjectRequiresMFA(ctx context.Context, projectID uint) (b
 // DeleteProject deletes a project by ID.
 // By default (force=false) it returns an error if the project still contains secrets (ADR-019).
 // Pass force=true to delete the project and all its secrets (cascade).
+//
+// #369: the storage-layer cascade (LocalStorage.DeleteProject) also disables every
+// dynamic-secret config scoped to the project in the same transaction, so IssueLease/
+// RenewLease refuse to touch it from the instant the delete commits. Once that commits,
+// this revokes every active (and previously revoke_failed) lease under those configs
+// against their real targets — deliberately AFTER the transaction, and best-effort: each
+// call is real network I/O to an operator-defined external database, which must not hold
+// a DB transaction open, and a target being unreachable must not block the project delete
+// itself (the lease stays revoke_failed/retryable, same as any other RevokeLeasesForConfig
+// use, and is reachable again via the sweep or a manual retry once the target recovers).
 func (c *KeyorixCore) DeleteProject(ctx context.Context, id uint, force bool) error {
 	// #313: the guard count and the cascade delete used to be two separate top-level
 	// storage calls, with core-layer control flow in between — a secret created in that
@@ -133,7 +143,7 @@ func (c *KeyorixCore) DeleteProject(ctx context.Context, id uint, force bool) er
 	// to be rejected. Run the guard and the delete inside one transaction (a nested
 	// savepoint over LocalStorage.DeleteProject's own transaction) so the count that
 	// gates the reject is the same one the cascade acts on, not a stale read.
-	return c.storage.WithTransaction(ctx, func(tx storage.Storage) error {
+	if err := c.storage.WithTransaction(ctx, func(tx storage.Storage) error {
 		if !force {
 			projectID := id
 			_, total, err := tx.ListSecrets(ctx, &storage.SecretFilter{
@@ -149,7 +159,46 @@ func (c *KeyorixCore) DeleteProject(ctx context.Context, id uint, force bool) er
 			}
 		}
 		return tx.DeleteProject(ctx, id)
-	})
+	}); err != nil {
+		return err
+	}
+	c.revokeProjectDynamicSecretLeases(ctx, id)
+	return nil
+}
+
+// revokeProjectDynamicSecretLeases is DeleteProject's post-commit dynamic-secrets
+// cascade (#369): it revokes every active lease under every dynamic-secret config
+// scoped to id (the config rows themselves were already marked Disabled inside
+// DeleteProject's transaction). Best-effort and system-actored (userID 0, like the
+// expiry sweep) — a target-side revoke failure is recorded per-lease (revoke_failed,
+// retryable) by RevokeLeasesForConfig and must not fail project deletion itself, which
+// has already committed by the time this runs.
+func (c *KeyorixCore) revokeProjectDynamicSecretLeases(ctx context.Context, projectID uint) {
+	configs, err := c.storage.ListDynamicSecretConfigs(ctx, projectID, 0)
+	if err != nil {
+		c.writeAuditEventFull(ctx, "dynamic_secret.project_cascade_failed", nil, nil, &projectID, "",
+			fmt.Sprintf("failed to list dynamic-secret configs to revoke after project %d deletion: %v — revoke them manually", projectID, err))
+		return
+	}
+	if len(configs) == 0 {
+		return
+	}
+	var revokedTotal, failedTotal int
+	for _, cfg := range configs {
+		revoked, failed, rerr := c.RevokeLeasesForConfig(ctx, cfg.ID, 0, "project deleted")
+		if rerr != nil {
+			// RevokeLeasesForConfig only errors on a failure to even list the config's
+			// leases (not on a per-lease target failure, which it counts in `failed`
+			// instead) — still non-fatal here; audited below alongside the summary.
+			failedTotal++
+			continue
+		}
+		revokedTotal += revoked
+		failedTotal += failed
+	}
+	c.writeAuditEventFull(ctx, "dynamic_secret.project_cascade_revoke", nil, nil, &projectID, "",
+		fmt.Sprintf("project %d delete disabled %d dynamic-secret config(s) and revoked %d active lease(s) (%d failed — see per-lease audit)",
+			projectID, len(configs), revokedTotal, failedTotal))
 }
 
 // RestoreProject reverses a soft-delete, bringing back the project and the
@@ -165,6 +214,19 @@ func (c *KeyorixCore) DeleteProject(ctx context.Context, id uint, force bool) er
 // before restoring, this checks that aggregate role SET against the actor's own
 // authority — the same treatment #147 applies to group restore. See
 // requireGlobalAdminToReinstateAdminRoles.
+//
+// #369: unlike secrets/environments, this deliberately does NOT re-enable the
+// project's dynamic-secret configs that DeleteProject's cascade disabled. A
+// resurrected dynamic-secret config can immediately mint live database
+// credentials against a real external target the instant it's re-enabled — a
+// materially higher-consequence "silent resurrection" than a restored static
+// secret (whose value is inert until read). Leaving configs disabled-until-
+// manually-re-enabled means an admin must make an explicit, auditable decision
+// (SetDynamicSecretConfigEnabled, per config) rather than a bulk project
+// restore quietly reinstating database-credential issuance nobody explicitly
+// asked to bring back. Restoring leases themselves is not on the table at all
+// — they were revoked against the real target, not just marked; there is no
+// "credential" left to restore.
 func (c *KeyorixCore) RestoreProject(ctx context.Context, actorID, id uint) error {
 	if err := c.requireAuthorityToReinstateProjectRoles(ctx, actorID, id, "project"); err != nil {
 		return err

--- a/internal/core/catalog_delete_project_test.go
+++ b/internal/core/catalog_delete_project_test.go
@@ -188,7 +188,7 @@ func TestDeleteProject_RealStorage_ForceCascadesOverSecrets(t *testing.T) {
 func TestDeleteProject_RealStorage_DisablesDynamicSecretConfigsAndRevokesLeases(t *testing.T) {
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
-	require.NoError(t, db.AutoMigrate(&models.Project{}, &models.Environment{}, &models.SecretNode{}, &models.SecretVersion{}, &models.DynamicSecretConfig{}, &models.DynamicSecretLease{}, &models.AuditEvent{}))
+	require.NoError(t, db.AutoMigrate(&models.Project{}, &models.Environment{}, &models.SecretNode{}, &models.SecretVersion{}, &models.DynamicSecretConfig{}, &models.DynamicSecretLease{}, &models.AuditEvent{}, &models.Role{}, &models.UserRole{}, &models.Group{}, &models.UserGroup{}, &models.GroupRole{}))
 
 	enc := encryption.NewService(&config.EncryptionConfig{Enabled: true, DEKPath: "dek.key", SaltPath: "kek.salt"}, t.TempDir())
 	require.NoError(t, enc.Initialize("test-passphrase"))
@@ -201,6 +201,11 @@ func TestDeleteProject_RealStorage_DisablesDynamicSecretConfigsAndRevokesLeases(
 
 	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "p"}).Error)
 	require.NoError(t, db.Create(&models.Environment{ID: 1, ProjectID: 1, Name: "env"}).Error)
+	// CreateDynamicSecretConfig requires admin authority on the project (#162) — seed
+	// a global admin role and grant it to the requesting actor.
+	require.NoError(t, db.Create(&models.Role{ID: 1, Name: "admin"}).Error)
+	const actorID = uint(42)
+	require.NoError(t, db.Create(&models.UserRole{UserID: actorID, RoleID: 1}).Error)
 
 	cfg, err := c.CreateDynamicSecretConfig(ctx, &core.CreateDynamicSecretConfigRequest{
 		Name:              "app-db",
@@ -211,6 +216,7 @@ func TestDeleteProject_RealStorage_DisablesDynamicSecretConfigsAndRevokesLeases(
 		CreationTemplate:  "GRANT SELECT ON ALL TABLES IN SCHEMA public TO {{name}};",
 		DefaultTTLSeconds: 3600,
 		CreatedBy:         "alice",
+		ActorID:           actorID,
 	})
 	require.NoError(t, err)
 

--- a/internal/core/catalog_delete_project_test.go
+++ b/internal/core/catalog_delete_project_test.go
@@ -5,8 +5,11 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/keyorixhq/keyorix/internal/config"
 	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/dynamic"
+	"github.com/keyorixhq/keyorix/internal/encryption"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/keyorixhq/keyorix/internal/storage/store"
 	"github.com/stretchr/testify/assert"
@@ -40,6 +43,16 @@ type deleteProjectOuterSpy struct {
 func (s *deleteProjectOuterSpy) WithTransaction(ctx context.Context, fn func(storage.Storage) error) error {
 	s.txCalled = true
 	return fn(s.tx)
+}
+
+// ListDynamicSecretConfigs is called on the OUTER (non-transactional) storage by
+// DeleteProject's #369 post-commit dynamic-secrets cascade, deliberately after
+// WithTransaction returns (see revokeProjectDynamicSecretLeases's doc comment) — so,
+// unlike ListSecrets/DeleteProject above, it must be implemented here, not on the tx
+// spy. Returns none: these tests aren't exercising the dynamic-secrets cascade itself
+// (see TestDeleteProject_RealStorage_DisablesDynamicSecretConfigsAndRevokesLeases).
+func (s *deleteProjectOuterSpy) ListDynamicSecretConfigs(_ context.Context, _, _ uint) ([]*models.DynamicSecretConfig, error) {
+	return nil, nil
 }
 
 type deleteProjectTxSpy struct {
@@ -117,7 +130,7 @@ func TestDeleteProject_ForceSkipsGuardButStaysTransactional(t *testing.T) {
 func TestDeleteProject_RealStorage_RejectsWhenSecretsExist(t *testing.T) {
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
-	require.NoError(t, db.AutoMigrate(&models.Project{}, &models.Environment{}, &models.SecretNode{}, &models.SecretVersion{}))
+	require.NoError(t, db.AutoMigrate(&models.Project{}, &models.Environment{}, &models.SecretNode{}, &models.SecretVersion{}, &models.DynamicSecretConfig{}, &models.DynamicSecretLease{}, &models.AuditEvent{}))
 	c := core.NewKeyorixCore(store.NewLocalStorage(db))
 	ctx := context.Background()
 
@@ -136,7 +149,7 @@ func TestDeleteProject_RealStorage_RejectsWhenSecretsExist(t *testing.T) {
 func TestDeleteProject_RealStorage_EmptyProjectSucceeds(t *testing.T) {
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
-	require.NoError(t, db.AutoMigrate(&models.Project{}, &models.Environment{}, &models.SecretNode{}, &models.SecretVersion{}))
+	require.NoError(t, db.AutoMigrate(&models.Project{}, &models.Environment{}, &models.SecretNode{}, &models.SecretVersion{}, &models.DynamicSecretConfig{}, &models.DynamicSecretLease{}, &models.AuditEvent{}))
 	c := core.NewKeyorixCore(store.NewLocalStorage(db))
 	ctx := context.Background()
 
@@ -152,7 +165,7 @@ func TestDeleteProject_RealStorage_EmptyProjectSucceeds(t *testing.T) {
 func TestDeleteProject_RealStorage_ForceCascadesOverSecrets(t *testing.T) {
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
-	require.NoError(t, db.AutoMigrate(&models.Project{}, &models.Environment{}, &models.SecretNode{}, &models.SecretVersion{}))
+	require.NoError(t, db.AutoMigrate(&models.Project{}, &models.Environment{}, &models.SecretNode{}, &models.SecretVersion{}, &models.DynamicSecretConfig{}, &models.DynamicSecretLease{}, &models.AuditEvent{}))
 	c := core.NewKeyorixCore(store.NewLocalStorage(db))
 	ctx := context.Background()
 
@@ -165,4 +178,56 @@ func TestDeleteProject_RealStorage_ForceCascadesOverSecrets(t *testing.T) {
 	var liveSecrets int64
 	require.NoError(t, db.Model(&models.SecretNode{}).Where("project_id = ? AND deleted_at IS NULL", 1).Count(&liveSecrets).Error)
 	assert.Zero(t, liveSecrets, "force=true must cascade-delete the secret along with the project")
+}
+
+// TestDeleteProject_RealStorage_DisablesDynamicSecretConfigsAndRevokesLeases exercises
+// the #369 fix end to end: deleting a project must not leave its dynamic-secret
+// configs live (able to mint new credentials) or their outstanding leases active
+// (real target credentials that should stop working) behind an orphaned/soft-deleted
+// project.
+func TestDeleteProject_RealStorage_DisablesDynamicSecretConfigsAndRevokesLeases(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.Project{}, &models.Environment{}, &models.SecretNode{}, &models.SecretVersion{}, &models.DynamicSecretConfig{}, &models.DynamicSecretLease{}, &models.AuditEvent{}))
+
+	enc := encryption.NewService(&config.EncryptionConfig{Enabled: true, DEKPath: "dek.key", SaltPath: "kek.salt"}, t.TempDir())
+	require.NoError(t, enc.Initialize("test-passphrase"))
+	fake := &dynamic.FakeEngine{NativeExpiry: true}
+
+	c := core.NewKeyorixCore(store.NewLocalStorage(db))
+	c.SetAuthEncryptor(enc)
+	c.SetDynamicEngineFactory(func(string) (dynamic.CredentialEngine, error) { return fake, nil })
+	ctx := context.Background()
+
+	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "p"}).Error)
+	require.NoError(t, db.Create(&models.Environment{ID: 1, ProjectID: 1, Name: "env"}).Error)
+
+	cfg, err := c.CreateDynamicSecretConfig(ctx, &core.CreateDynamicSecretConfigRequest{
+		Name:              "app-db",
+		ProjectID:         1,
+		EnvironmentID:     1,
+		BackendType:       "postgres",
+		AdminDSN:          "postgres://admin:s3cr3t@db.internal:5432/app",
+		CreationTemplate:  "GRANT SELECT ON ALL TABLES IN SCHEMA public TO {{name}};",
+		DefaultTTLSeconds: 3600,
+		CreatedBy:         "alice",
+	})
+	require.NoError(t, err)
+
+	lease, err := c.IssueLease(ctx, cfg.ID, 0, 7)
+	require.NoError(t, err)
+
+	require.NoError(t, c.DeleteProject(ctx, 1, false))
+
+	disabled, err := c.GetDynamicSecretConfig(ctx, cfg.ID)
+	require.NoError(t, err)
+	assert.True(t, disabled.Disabled, "the config must be disabled so it can no longer mint new credentials")
+
+	var leaseAfter models.DynamicSecretLease
+	require.NoError(t, db.Where("lease_id = ?", lease.LeaseID).First(&leaseAfter).Error)
+	assert.Equal(t, "revoked", leaseAfter.Status, "the outstanding lease must be revoked, not left active")
+	assert.Contains(t, fake.Revoked, leaseAfter.RoleName, "the real backend credential must have been revoked too")
+
+	_, err = c.IssueLease(ctx, cfg.ID, 0, 7)
+	assert.Error(t, err, "issuing against a disabled config must be refused")
 }

--- a/internal/core/dynamic_secrets.go
+++ b/internal/core/dynamic_secrets.go
@@ -162,6 +162,44 @@ func (c *KeyorixCore) ListDynamicSecretLeases(ctx context.Context, configID uint
 	return c.storage.ListDynamicSecretLeases(ctx, configID)
 }
 
+// SetDynamicSecretConfigEnabled toggles a config's Disabled flag and audits the
+// change with a before/after diff (mirrors ClassifyDynamicSecretConfig). A
+// disabled config refuses new IssueLease/RenewLease calls (#369). DeleteProject's
+// cascade sets this automatically when the owning project is soft-deleted; this
+// is also how an admin deliberately disables a config directly (e.g. incident
+// response short of a full RevokeLeasesForConfig kill switch) or re-enables one
+// afterward — including after restoring a project, which deliberately does NOT
+// re-enable its configs on its own (see RestoreProject).
+func (c *KeyorixCore) SetDynamicSecretConfigEnabled(ctx context.Context, actorID uint, configID uint, enabled bool) (*models.DynamicSecretConfig, error) {
+	if configID == 0 {
+		return nil, fmt.Errorf("config id is required")
+	}
+	cfg, err := c.storage.GetDynamicSecretConfig(ctx, configID)
+	if err != nil {
+		return nil, fmt.Errorf("dynamic-secret config not found: %w", err)
+	}
+	disabled := !enabled
+	if cfg.Disabled == disabled {
+		return cfg, nil // no-op
+	}
+	old := cfg.Disabled
+	cfg.Disabled = disabled
+	cfg.UpdatedAt = c.now()
+	if err := c.storage.UpdateDynamicSecretConfig(ctx, cfg); err != nil {
+		return nil, err
+	}
+	aid := actorID
+	pid := cfg.ProjectID
+	state := "enabled"
+	if disabled {
+		state = "disabled"
+	}
+	diff := fmt.Sprintf(`{"disabled":{"before":%t,"after":%t}}`, old, disabled)
+	c.writeAuditEventDiff(ctx, "dynamic_secret.config_"+state, &aid, nil, &pid, "",
+		fmt.Sprintf("dynamic-secret config %q %s", cfg.Name, state), diff)
+	return cfg, nil
+}
+
 func (c *KeyorixCore) GetDynamicSecretLease(ctx context.Context, leaseID string) (*models.DynamicSecretLease, error) {
 	return c.storage.GetDynamicSecretLease(ctx, leaseID)
 }
@@ -184,6 +222,18 @@ func (c *KeyorixCore) IssueLease(ctx context.Context, configID uint, ttlSeconds 
 	cfg, err := c.storage.GetDynamicSecretConfig(ctx, configID)
 	if err != nil {
 		return nil, fmt.Errorf("dynamic-secret config not found")
+	}
+	// #369: refuse to mint against a config DeleteProject's cascade (or an admin)
+	// disabled, and refuse when the owning project/environment has since been
+	// soft-deleted directly — a principal who still holds a role scoped to a
+	// "deleted" project must not be able to keep minting fresh database
+	// credentials against it just because the RBAC join that resolved their
+	// authority doesn't itself check project liveness.
+	if cfg.Disabled {
+		return nil, fmt.Errorf("dynamic-secret config is disabled")
+	}
+	if err := c.requireLiveProjectAndEnvironment(ctx, cfg.ProjectID, cfg.EnvironmentID); err != nil {
+		return nil, err
 	}
 	engine, err := c.dynamicEngine(cfg.BackendType)
 	if err != nil {
@@ -445,6 +495,25 @@ func (c *KeyorixCore) RevokeLeasesForConfig(ctx context.Context, configID, userI
 	return revoked, failed, nil
 }
 
+// requireLiveProjectAndEnvironment refuses when projectID or (if non-zero)
+// environmentID is missing or soft-deleted — GetProject/GetEnvironment apply
+// GORM's default soft-delete scope (models.Project/Environment use gorm.DeletedAt),
+// so a soft-deleted row already surfaces as "not found" here without a separate
+// deleted_at predicate. Shared by IssueLease and RenewLease (#369): a project's
+// soft-delete does not, on its own, revoke the role grants scoped to it, so
+// issuance/renewal need their own explicit liveness gate independent of RBAC.
+func (c *KeyorixCore) requireLiveProjectAndEnvironment(ctx context.Context, projectID, environmentID uint) error {
+	if _, err := c.storage.GetProject(ctx, projectID); err != nil {
+		return fmt.Errorf("cannot issue lease: project not found or deleted")
+	}
+	if environmentID != 0 {
+		if _, err := c.storage.GetEnvironment(ctx, environmentID); err != nil {
+			return fmt.Errorf("cannot issue lease: environment not found or deleted")
+		}
+	}
+	return nil
+}
+
 // dynamicTTL resolves the requested TTL (override, else config default, else 1h),
 // clamps it to the config's MaxTTLSeconds ceiling when one is set, and always clamps
 // it to the install-wide max-lease-TTL ceiling on top (#97) — the per-config ceiling
@@ -498,6 +567,19 @@ func (c *KeyorixCore) RenewLease(ctx context.Context, leaseID string, ttlSeconds
 	cfg, err := c.storage.GetDynamicSecretConfig(ctx, lease.ConfigID)
 	if err != nil {
 		return time.Time{}, fmt.Errorf("config not found")
+	}
+	// #369: mirrors IssueLease — a renewal is functionally a fresh mint of trust
+	// (it extends how long the credential stays live), so it gets the same
+	// disabled-config / soft-deleted-project-or-environment refusal. In the
+	// ordinary case DeleteProject's cascade will already have revoked this lease
+	// (flipping its status away from "active", which the check above already
+	// catches); this closes the race window between that cascade committing and
+	// its best-effort revoke actually reaching the target.
+	if cfg.Disabled {
+		return time.Time{}, fmt.Errorf("dynamic-secret config is disabled")
+	}
+	if err := c.requireLiveProjectAndEnvironment(ctx, cfg.ProjectID, cfg.EnvironmentID); err != nil {
+		return time.Time{}, err
 	}
 	// Cloud-IAM backends (AWS STS) mint self-expiring credentials whose lifetime is
 	// fixed by the provider at issue — they cannot be renewed; issue a new lease.

--- a/internal/core/dynamic_secrets_test.go
+++ b/internal/core/dynamic_secrets_test.go
@@ -38,6 +38,13 @@ func newDynamicTestCore(t *testing.T) (*KeyorixCore, *gorm.DB, *dynamic.FakeEngi
 	))
 	require.NoError(t, db.Create(&models.Role{ID: 1, Name: "admin"}).Error)
 	require.NoError(t, db.Create(&models.UserRole{UserID: testAdminActorID, RoleID: 1}).Error)
+	// Every config created via mkConfig (or inline in these tests) targets
+	// ProjectID 1 / EnvironmentID 2 — seed real, live rows so IssueLease/
+	// RenewLease's #369 project-liveness check passes for the ordinary-path
+	// tests (project soft-delete behavior itself is exercised separately in
+	// catalog_delete_project_test.go / a dedicated dynamic-secrets test below).
+	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "dyn-test-project"}).Error)
+	require.NoError(t, db.Create(&models.Environment{ID: 2, ProjectID: 1, Name: "dyn-test-env"}).Error)
 
 	enc := encryption.NewService(&config.EncryptionConfig{Enabled: true, DEKPath: "dek.key", SaltPath: "kek.salt"}, t.TempDir())
 	require.NoError(t, enc.Initialize("test-passphrase"))

--- a/internal/core/restore_admin_ceiling_test.go
+++ b/internal/core/restore_admin_ceiling_test.go
@@ -29,6 +29,7 @@ func newRestoreCeilingCore(t *testing.T) (*KeyorixCore, *gorm.DB) {
 		&models.UserRole{}, &models.Group{}, &models.UserGroup{}, &models.GroupRole{},
 		&models.Project{}, &models.Environment{}, &models.AuditEvent{},
 		&models.SecretNode{}, &models.SecretVersion{},
+		&models.DynamicSecretConfig{}, &models.DynamicSecretLease{},
 	))
 	require.NoError(t, db.Create(&models.Role{ID: 1, Name: "admin"}).Error)
 	require.NoError(t, db.Create(&models.Role{ID: 2, Name: "viewer"}).Error)

--- a/internal/core/restore_audit_test.go
+++ b/internal/core/restore_audit_test.go
@@ -26,6 +26,7 @@ func TestRestoreOperationsAudit(t *testing.T) {
 		// #370: DeleteSecret revokes ShareRecord rows in the same transaction as the
 		// secret's own soft-delete.
 		&models.ShareRecord{},
+		&models.DynamicSecretConfig{}, &models.DynamicSecretLease{},
 	))
 	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
 	ctx := context.Background()

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -404,6 +404,13 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 		if tableExists(db, "dynamic_secret_configs") && !columnExists(db, "dynamic_secret_configs", "classification") {
 			db.Exec("ALTER TABLE dynamic_secret_configs ADD COLUMN classification TEXT DEFAULT ''")
 		}
+		// Disabled (#369): refuses new leases once the owning project is soft-deleted.
+		// Additive (defaults false = every pre-existing config stays enabled).
+		if !m.HasColumn(&models.DynamicSecretConfig{}, "Disabled") {
+			if err := m.AddColumn(&models.DynamicSecretConfig{}, "Disabled"); err != nil {
+				return fmt.Errorf("failed to add dynamic_secret_configs.disabled column: %w", err)
+			}
+		}
 	}
 	if !dynLeaseExists {
 		if err := db.AutoMigrate(&models.DynamicSecretLease{}); err != nil {

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -594,9 +594,18 @@ type DynamicSecretConfig struct {
 	// public|internal|confidential|restricted. Folds into the classification posture
 	// so dynamic credentials are covered alongside static secrets.
 	Classification string `gorm:"index"`
-	CreatedBy      string
-	CreatedAt      time.Time
-	UpdatedAt      time.Time
+	// Disabled refuses new IssueLease calls against this config (#369). Set
+	// automatically when the owning project is soft-deleted (DeleteProject's
+	// cascade), so a principal who still holds a role scoped to the "deleted"
+	// project cannot keep minting fresh database credentials against it. Not
+	// cleared automatically by RestoreProject — re-enabling a dynamic-secret
+	// config (which can mint live database credentials) is a higher-consequence
+	// action than restoring a static secret, so it requires an explicit,
+	// deliberate re-enable rather than silently resurrecting with the project.
+	Disabled  bool `gorm:"default:false"`
+	CreatedBy string
+	CreatedAt time.Time
+	UpdatedAt time.Time
 }
 
 // DynamicSecretLease is one issued credential: a short-lived role on the target

--- a/internal/storage/store/local_secrets.go
+++ b/internal/storage/store/local_secrets.go
@@ -173,6 +173,19 @@ func (ls *LocalStorage) DeleteProject(ctx context.Context, id uint) error {
 			Where("project_id = ?", id).Update("deleted_at", deletedAt).Error; err != nil {
 			return fmt.Errorf("failed to soft-delete project environments: %w", err)
 		}
+		// Disable every dynamic-secret config scoped to the project (#369): a
+		// disabled project must not go on minting live database credentials.
+		// IssueLease/RenewLease refuse against a Disabled config; the caller
+		// (core.DeleteProject) revokes the configs' outstanding active leases
+		// against their real targets AFTER this transaction commits — that's
+		// network I/O to arbitrary external systems and must not hold this DB
+		// transaction open. Unlike secrets/environments, Disabled is a plain
+		// boolean with no cascade timestamp: RestoreProject deliberately does
+		// NOT clear it (see the Disabled field doc on DynamicSecretConfig).
+		if err := tx.Model(&models.DynamicSecretConfig{}).
+			Where("project_id = ? AND disabled = ?", id, false).Update("disabled", true).Error; err != nil {
+			return fmt.Errorf("failed to disable project dynamic-secret configs: %w", err)
+		}
 		// Soft-delete the project itself with the same timestamp.
 		result := tx.Model(&models.Project{}).
 			Where("id = ?", id).Update("deleted_at", deletedAt)

--- a/internal/storage/store/restore_test.go
+++ b/internal/storage/store/restore_test.go
@@ -18,7 +18,7 @@ func newRestoreTestStore(t *testing.T) *LocalStorage {
 	require.NoError(t, err)
 	// #370: DeleteSecret revokes ShareRecord rows in the same transaction as the
 	// secret's own soft-delete.
-	require.NoError(t, db.AutoMigrate(&models.Project{}, &models.Environment{}, &models.SecretNode{}, &models.ShareRecord{}))
+	require.NoError(t, db.AutoMigrate(&models.Project{}, &models.Environment{}, &models.SecretNode{}, &models.ShareRecord{}, &models.DynamicSecretConfig{}))
 	return NewLocalStorage(db)
 }
 

--- a/server/grpc/services/secret_service_test.go
+++ b/server/grpc/services/secret_service_test.go
@@ -47,6 +47,7 @@ func newSecretTestRig(t *testing.T) *secretTestRig {
 		&models.SecretVersion{}, &models.User{}, &models.Role{}, &models.ShareRecord{},
 		&models.Permission{}, &models.RolePermission{}, &models.UserRole{},
 		&models.Group{}, &models.UserGroup{}, &models.GroupRole{},
+		&models.DynamicSecretConfig{},
 	))
 	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "default"}).Error)
 	require.NoError(t, db.Create(&models.Environment{ID: 1, ProjectID: 1, Name: "development"}).Error)

--- a/server/http/handlers/dynamic_secrets.go
+++ b/server/http/handlers/dynamic_secrets.go
@@ -316,6 +316,32 @@ func (h *DynamicSecretHandler) ClassifyConfig(w http.ResponseWriter, r *http.Req
 	sendSuccess(w, sanitizeConfig(updated), "Classification updated.")
 }
 
+// SetConfigEnabled handles PATCH /api/v1/dynamic-secrets/configs/{id}/enabled —
+// manually enables or disables a config (#369). DeleteProject's cascade disables
+// a project's configs automatically; this is how an admin re-enables one
+// afterward (project restore deliberately does not do so on its own), or
+// disables one directly outside of a project delete.
+func (h *DynamicSecretHandler) SetConfigEnabled(w http.ResponseWriter, r *http.Request) {
+	userCtx := middleware.GetUserFromContext(r.Context())
+	cfg, ok := h.loadAuthorizedConfig(w, r, "secrets.write")
+	if !ok {
+		return
+	}
+	var body struct {
+		Enabled bool `json:"enabled"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		sendError(w, "BadRequest", "Invalid request body", http.StatusBadRequest, nil)
+		return
+	}
+	updated, err := h.coreService.SetDynamicSecretConfigEnabled(r.Context(), userCtx.UserID, cfg.ID, body.Enabled)
+	if err != nil {
+		sendError(w, "Error", err.Error(), http.StatusBadRequest, nil)
+		return
+	}
+	sendSuccess(w, sanitizeConfig(updated), "Config enabled state updated.")
+}
+
 // loadAuthorizedConfig loads the {id} config and authorizes the caller against
 // its scope. It writes the error response and returns ok=false on failure.
 func (h *DynamicSecretHandler) loadAuthorizedConfig(w http.ResponseWriter, r *http.Request, perm string) (*models.DynamicSecretConfig, bool) {
@@ -351,6 +377,7 @@ func sanitizeConfig(c *models.DynamicSecretConfig) map[string]interface{} {
 		"max_ttl_seconds":     c.MaxTTLSeconds,
 		"max_active_leases":   c.MaxActiveLeases,
 		"classification":      c.Classification,
+		"disabled":            c.Disabled,
 		"created_by":          c.CreatedBy,
 		"created_at":          c.CreatedAt,
 	}

--- a/server/http/restore_route_authz_test.go
+++ b/server/http/restore_route_authz_test.go
@@ -108,6 +108,7 @@ func TestRestoreProjectAndEnvironmentRoutesRequireRolesAssign(t *testing.T) {
 		&models.UserRole{}, &models.Group{}, &models.UserGroup{}, &models.GroupRole{},
 		&models.AuditEvent{}, &models.Session{}, &models.Project{}, &models.Environment{},
 		&models.SecretNode{}, &models.SecretVersion{},
+		&models.DynamicSecretConfig{}, &models.DynamicSecretLease{},
 	))
 	now := time.Now()
 	require.NoError(t, db.Create(&models.User{ID: 1, Username: "admin", Email: "a@t.com", IsActive: true, CreatedAt: now, UpdatedAt: now}).Error)

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -517,6 +517,7 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.Get("/configs", dynamicSecretHandler.ListConfigs)
 			r.Get("/configs/{id}", dynamicSecretHandler.GetConfig)
 			r.Patch("/configs/{id}/classification", dynamicSecretHandler.ClassifyConfig)
+			r.Patch("/configs/{id}/enabled", dynamicSecretHandler.SetConfigEnabled)
 			r.Post("/configs/{id}/issue", dynamicSecretHandler.IssueLease)
 			r.Get("/configs/{id}/leases", dynamicSecretHandler.ListLeases)
 			r.Post("/configs/{id}/revoke-all", dynamicSecretHandler.RevokeAllLeases)


### PR DESCRIPTION
Deleting a project previously left its dynamic-secret configs and outstanding leases live, orphaning real backend credentials indefinitely.

- DeleteProject's transaction now disables every DynamicSecretConfig scoped to the project.
- Post-commit, revokeProjectDynamicSecretLeases best-effort revokes all active/revoke_failed leases against their real targets (audited).
- IssueLease/RenewLease refuse against a Disabled config or a soft-deleted project/environment.
- RestoreProject deliberately does not re-enable configs — a new PATCH /configs/{id}/enabled endpoint requires an explicit admin decision, since silent re-enable could mint live credentials again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)