### PR TITLE
harden(egress): SSRF/redirect/TLS-toggle bundle — #114, #130, #134

### DIFF
--- a/internal/audit/siem/forwarder.go
+++ b/internal/audit/siem/forwarder.go
@@ -118,6 +118,7 @@ func newForwarder(cfg Config, baseBackoff time.Duration) (*Forwarder, error) {
 
 	transport := &http.Transport{}
 	if cfg.InsecureSkipVerify {
+		log.Printf("WARNING: SIEM forwarder %q has TLS verification disabled (insecure_skip_verify); do not use in production", cfg.Endpoint)
 		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} // #nosec G402 — operator opt-in for self-signed SIEM
 	}
 	f := &Forwarder{

--- a/internal/cli/secret/export.go
+++ b/internal/cli/secret/export.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/cli/common"
@@ -20,6 +21,18 @@ var (
 	exportEnv     string
 	exportProject string
 )
+
+// createExportFile opens path for a fresh plaintext-secrets export. O_EXCL
+// refuses to write through a pre-existing path — including a symlink an
+// attacker (with write access to a shared directory, e.g. /tmp) planted at the
+// target ahead of time, which os.Create's default O_TRUNC would silently
+// follow, writing plaintext secrets to wherever the symlink points. O_NOFOLLOW
+// is a second layer against a dangling symlink placed in the instant between
+// the check and the open. 0600 keeps the export from being world/group-
+// readable on disk (#114).
+func createExportFile(path string) (*os.File, error) {
+	return os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC|os.O_EXCL|syscall.O_NOFOLLOW, 0o600) // #nosec G304 -- operator-supplied CLI output path, not attacker input
+}
 
 var exportCmd = &cobra.Command{
 	Use:   "export",
@@ -90,11 +103,9 @@ func runExport(cmd *cobra.Command, args []string) error {
 
 	var out io.Writer = os.Stdout
 	if exportOutput != "" {
-		// 0600: this file holds plaintext secret values — sibling writers
-		// (render.go, scan.go, fix.go) all use the same restrictive mode.
-		f, err := os.OpenFile(exportOutput, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600) // #nosec G304
+		f, err := createExportFile(exportOutput)
 		if err != nil {
-			return fmt.Errorf("cannot create output file %q: %w", exportOutput, err)
+			return fmt.Errorf("cannot create output file %q (it may already exist — remove it or choose a different path): %w", exportOutput, err)
 		}
 		defer f.Close() //nolint:errcheck
 		out = f

--- a/internal/cli/secret/export_file_test.go
+++ b/internal/cli/secret/export_file_test.go
@@ -1,0 +1,52 @@
+package secret
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCreateExportFile_ModeAndSymlinkSafety pins #114: an exported-secrets file
+// was created with os.Create (0644, world-readable) and would silently write
+// through a pre-planted symlink. createExportFile must produce a 0600 file and
+// refuse a symlinked or already-existing target.
+func TestCreateExportFile_ModeAndSymlinkSafety(t *testing.T) {
+	dir := t.TempDir()
+
+	t.Run("creates a 0600 file", func(t *testing.T) {
+		target := filepath.Join(dir, "out.env")
+		f, err := createExportFile(target)
+		require.NoError(t, err)
+		defer f.Close() //nolint:errcheck
+
+		info, err := f.Stat()
+		require.NoError(t, err)
+		if runtime.GOOS != "windows" {
+			assert.Equal(t, os.FileMode(0o600), info.Mode().Perm(), "export file must not be group/world-readable")
+		}
+	})
+
+	t.Run("refuses an already-existing path", func(t *testing.T) {
+		target := filepath.Join(dir, "exists.env")
+		require.NoError(t, os.WriteFile(target, []byte("old"), 0o600))
+		_, err := createExportFile(target)
+		require.Error(t, err, "O_EXCL must refuse to overwrite/write-through a pre-existing path")
+	})
+
+	t.Run("refuses a pre-planted symlink target", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("symlink semantics differ on windows")
+		}
+		evilTarget := filepath.Join(dir, "attacker-owned.txt")
+		link := filepath.Join(dir, "planted-link.env")
+		require.NoError(t, os.Symlink(evilTarget, link))
+		_, err := createExportFile(link)
+		require.Error(t, err, "a symlinked target must be refused, not followed")
+		_, statErr := os.Stat(evilTarget)
+		assert.True(t, os.IsNotExist(statErr), "the symlink target must never have been created/written")
+	})
+}

--- a/internal/cli/secret/source_vault.go
+++ b/internal/cli/secret/source_vault.go
@@ -49,8 +49,18 @@ func newVaultClient() (*vaultClient, error) {
 		token:     token,
 		mount:     strings.Trim(vaultMount, "/"),
 		kvVersion: vaultKVVersion,
-		hc:        &http.Client{},
+		// No redirect is legitimate for a fixed, operator-supplied Vault address — the
+		// default client would otherwise follow a 30x carrying the live X-Vault-Token
+		// header wherever a compromised/misconfigured Vault (or a MITM) points it (#114,
+		// twin of #98's server-side connector).
+		hc: &http.Client{CheckRedirect: refuseVaultRedirect},
 	}, nil
+}
+
+// refuseVaultRedirect makes the client return the first (redirect) response as-is
+// instead of following it — see newVaultClient.
+func refuseVaultRedirect(_ *http.Request, _ []*http.Request) error {
+	return http.ErrUseLastResponse
 }
 
 // fetchFromVault walks the KV tree under --vault-path and returns every field as

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -793,6 +793,9 @@ type EvidenceWebhookConfig struct {
 	Endpoint           string `yaml:"endpoint"`
 	Token              string `yaml:"token"` // use KEYORIX_EVIDENCE_WEBHOOK_TOKEN env var instead
 	InsecureSkipVerify bool   `yaml:"insecure_skip_verify"`
+	// AllowPrivateNetworkTarget opts the endpoint out of the SSRF guard — a
+	// SEPARATE decision from InsecureSkipVerify; see evidencesink.WebhookConfig.
+	AllowPrivateNetworkTarget bool `yaml:"allow_private_network_target"`
 }
 
 // GetToken returns the resolved webhook token, preferring the environment variable.
@@ -917,6 +920,9 @@ type NotificationWebhookConfig struct {
 	Endpoint           string `yaml:"endpoint"`
 	Token              string `yaml:"token"` // use KEYORIX_NOTIFY_WEBHOOK_TOKEN env var instead
 	InsecureSkipVerify bool   `yaml:"insecure_skip_verify"`
+	// AllowPrivateNetworkTarget opts the endpoint out of the SSRF guard — a
+	// SEPARATE decision from InsecureSkipVerify; see notifychan.WebhookConfig.
+	AllowPrivateNetworkTarget bool `yaml:"allow_private_network_target"`
 	// SigningSecret HMAC-signs each payload (X-Keyorix-Signature) so the receiver can
 	// verify authenticity. Use KEYORIX_NOTIFY_WEBHOOK_SIGNING_SECRET instead of the file.
 	SigningSecret string `yaml:"signing_secret"`

--- a/internal/evidencesink/webhook.go
+++ b/internal/evidencesink/webhook.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"log"
 	"net"
 	"net/http"
 	"net/url"
@@ -29,6 +30,10 @@ type WebhookConfig struct {
 	Endpoint           string // full destination URL (POST target)
 	Token              string // optional bearer token
 	InsecureSkipVerify bool   // skip TLS verification (self-signed only)
+	// AllowPrivateNetworkTarget opts the endpoint out of the SSRF guard — a
+	// SEPARATE decision from InsecureSkipVerify (#130); see notifychan's
+	// WebhookConfig.AllowPrivateNetworkTarget for the rationale.
+	AllowPrivateNetworkTarget bool
 }
 
 // Webhook POSTs the evidence pack JSON to an HTTP endpoint. Delivery is synchronous
@@ -55,22 +60,27 @@ func newWebhook(cfg WebhookConfig, baseBackoff time.Duration) (*Webhook, error) 
 	// webhook, this path previously sent the bearer token + the FULL compliance evidence
 	// pack to whatever URL was configured — an http:// endpoint shipped both in cleartext
 	// on every POST, and refuseRedirect only guards bounces, not the initial request.
-	if err := validateEndpoint(cfg.Endpoint, cfg.InsecureSkipVerify); err != nil {
+	if err := validateEndpoint(cfg.Endpoint, cfg.AllowPrivateNetworkTarget); err != nil {
 		return nil, err
 	}
 	transport := &http.Transport{}
 	if cfg.InsecureSkipVerify {
+		log.Printf("WARNING: evidencesink webhook %q has TLS verification disabled (insecure_skip_verify); do not use in production", cfg.Endpoint)
 		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} // #nosec G402 -- opt-in for self-signed endpoints
 	}
 	return &Webhook{cfg: cfg, client: &http.Client{Timeout: webhookTimeout, Transport: transport, CheckRedirect: refuseRedirect}, baseBackoff: baseBackoff}, nil
 }
 
 // validateEndpoint rejects a non-https evidence endpoint (which would send the bearer
-// token and the full compliance pack in cleartext), allowing http only for an explicit
-// insecure opt-in or a loopback target. It also refuses a literal private/link-local IP
-// destination unless the insecure opt-in is set (SSRF/exfil hardening: an evidence pack
-// must not be POSTed to cloud metadata or an internal host).
-func validateEndpoint(raw string, allowInsecure bool) error {
+// token and the full compliance pack in cleartext), allowing http only for a loopback
+// target or the explicit allowPrivateNetwork opt-in. It also refuses a destination
+// whose hostname RESOLVES to a private/link-local IP unless allowPrivateNetwork is
+// set (SSRF/exfil hardening: an evidence pack must not be POSTed to cloud metadata or
+// an internal host).
+//
+// allowPrivateNetwork is INTENTIONALLY separate from TLS-certificate verification
+// (#130) — see notifychan's identically-named parameter for the rationale.
+func validateEndpoint(raw string, allowPrivateNetwork bool) error {
 	u, err := url.Parse(raw)
 	if err != nil {
 		return fmt.Errorf("evidencesink: invalid endpoint %q: %w", raw, err)
@@ -79,14 +89,16 @@ func validateEndpoint(raw string, allowInsecure bool) error {
 	case "https":
 		// scheme OK; fall through to the destination-IP check
 	case "http":
-		if !allowInsecure && !isLoopbackHost(u.Hostname()) {
-			return fmt.Errorf("evidencesink: endpoint %q must use https (set insecure_skip_verify only for a trusted self-signed or loopback target)", raw)
+		if !allowPrivateNetwork && !isLoopbackHost(u.Hostname()) {
+			return fmt.Errorf("evidencesink: endpoint %q must use https (set allow_private_network_target only for a trusted internal or loopback target)", raw)
 		}
 	default:
 		return fmt.Errorf("evidencesink: endpoint %q must use https", raw)
 	}
-	if !allowInsecure && isDisallowedIPHost(u.Hostname()) {
-		return fmt.Errorf("evidencesink: endpoint %q targets a private/link-local address; refusing to send evidence to an internal host", raw)
+	if !allowPrivateNetwork {
+		if err := refuseDisallowedHost(u.Hostname()); err != nil {
+			return fmt.Errorf("evidencesink: endpoint %q %w", raw, err)
+		}
 	}
 	return nil
 }
@@ -101,11 +113,39 @@ func isLoopbackHost(host string) bool {
 	return false
 }
 
-// isDisallowedIPHost reports whether host is a literal private or link-local IP (loopback
-// permitted). Hostnames are not resolved here, so this catches the literal-IP SSRF cases.
-func isDisallowedIPHost(host string) bool {
-	ip := net.ParseIP(host)
-	if ip == nil || ip.IsLoopback() {
+// lookupIPAddr resolves a hostname to its IP addresses — a var so tests can
+// substitute a fake resolver without a real DNS query.
+var lookupIPAddr = func(host string) ([]net.IPAddr, error) {
+	return net.DefaultResolver.LookupIPAddr(context.Background(), host)
+}
+
+// refuseDisallowedHost rejects host when it — or any address it RESOLVES to — is a
+// private, link-local, or otherwise disallowed IP (loopback permitted). A literal-
+// IP-only check lets a hostname that resolves to an internal address straight
+// through; this resolves the hostname and checks every returned address.
+func refuseDisallowedHost(host string) error {
+	if ip := net.ParseIP(host); ip != nil {
+		if isDisallowedIP(ip) {
+			return fmt.Errorf("targets a private/link-local address; refusing to send evidence to an internal host")
+		}
+		return nil
+	}
+	addrs, err := lookupIPAddr(host)
+	if err != nil {
+		return fmt.Errorf("could not resolve hostname to verify it is not private/internal: %w", err)
+	}
+	for _, a := range addrs {
+		if isDisallowedIP(a.IP) {
+			return fmt.Errorf("resolves to a private/link-local address (%s); refusing to send evidence to an internal host", a.IP)
+		}
+	}
+	return nil
+}
+
+// isDisallowedIP reports whether ip is a private or link-local address (loopback
+// permitted).
+func isDisallowedIP(ip net.IP) bool {
+	if ip.IsLoopback() {
 		return false
 	}
 	return ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast()

--- a/internal/evidencesink/webhook_test.go
+++ b/internal/evidencesink/webhook_test.go
@@ -3,6 +3,7 @@ package evidencesink
 import (
 	"context"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -18,6 +19,12 @@ import (
 // internal-target destination at construction, so the bearer token + compliance pack
 // are never shipped in cleartext or to an internal host.
 func TestWebhook_RejectsInsecureEndpoints(t *testing.T) {
+	orig := lookupIPAddr
+	defer func() { lookupIPAddr = orig }()
+	lookupIPAddr = func(host string) ([]net.IPAddr, error) {
+		return []net.IPAddr{{IP: net.ParseIP("203.0.113.5")}}, nil // a public TEST-NET-3 address
+	}
+
 	// Cleartext http to a non-loopback host → rejected.
 	_, err := NewWebhook(WebhookConfig{Endpoint: "http://collector.example.com/evidence", Token: "ev-tok"})
 	require.ErrorContains(t, err, "must use https")
@@ -30,9 +37,13 @@ func TestWebhook_RejectsInsecureEndpoints(t *testing.T) {
 	_, err = NewWebhook(WebhookConfig{Endpoint: "https://collector.example.com/evidence"})
 	require.NoError(t, err)
 
-	// The insecure opt-in permits http (trusted self-signed / lab).
+	// #130: InsecureSkipVerify (a TLS-certificate-trust decision) must NOT also
+	// bypass the https/SSRF guard — that coupling was the bug. Only the dedicated
+	// AllowPrivateNetworkTarget opt-in does.
 	_, err = NewWebhook(WebhookConfig{Endpoint: "http://collector.example.com/evidence", InsecureSkipVerify: true})
-	require.NoError(t, err)
+	require.Error(t, err, "InsecureSkipVerify alone must not bypass the https requirement")
+	_, err = NewWebhook(WebhookConfig{Endpoint: "http://collector.example.com/evidence", AllowPrivateNetworkTarget: true})
+	require.NoError(t, err, "AllowPrivateNetworkTarget is the dedicated opt-in for a non-https/internal target")
 }
 
 func TestWebhook_PostsEvidenceWithAuth(t *testing.T) {

--- a/internal/notifychan/secure_transport.go
+++ b/internal/notifychan/secure_transport.go
@@ -1,6 +1,7 @@
 package notifychan
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"net/http"
@@ -8,11 +9,19 @@ import (
 )
 
 // validateEndpoint rejects a non-https notification endpoint — which would send the
-// bearer token and payload in cleartext — allowing http only for an explicit insecure
-// opt-in or a loopback target (local testing). It also refuses a literal private /
-// link-local destination IP (e.g. cloud metadata 169.254.169.254 or an internal host)
-// unless the insecure opt-in is set — SSRF/exfil hardening.
-func validateEndpoint(raw string, allowInsecure bool) error {
+// bearer token and payload in cleartext — allowing http only for a loopback target
+// (local testing) or the explicit allowPrivateNetwork opt-in. It also refuses a
+// destination whose hostname RESOLVES to a private/link-local IP (e.g. cloud metadata
+// 169.254.169.254 or an internal host) unless allowPrivateNetwork is set —
+// SSRF/exfil hardening.
+//
+// allowPrivateNetwork is INTENTIONALLY a separate knob from TLS-certificate
+// verification (#130): "I trust this endpoint's self-signed cert" and "this
+// endpoint is allowed to live on an internal network" are different trust
+// decisions — an operator with a self-signed public webhook receiver should not
+// have to also disable the SSRF guard, and vice versa for a legitimate on-prem
+// receiver with a real cert.
+func validateEndpoint(raw string, allowPrivateNetwork bool) error {
 	u, err := url.Parse(raw)
 	if err != nil {
 		return fmt.Errorf("notifychan: invalid endpoint %q: %w", raw, err)
@@ -21,14 +30,16 @@ func validateEndpoint(raw string, allowInsecure bool) error {
 	case "https":
 		// scheme OK; fall through to the destination-IP check
 	case "http":
-		if !allowInsecure && !isLoopbackHost(u.Hostname()) {
-			return fmt.Errorf("notifychan: endpoint %q must use https (set insecure_skip_verify only for a trusted self-signed or loopback target)", raw)
+		if !allowPrivateNetwork && !isLoopbackHost(u.Hostname()) {
+			return fmt.Errorf("notifychan: endpoint %q must use https (set allow_private_network_target only for a trusted internal or loopback target)", raw)
 		}
 	default:
 		return fmt.Errorf("notifychan: endpoint %q must use https", raw)
 	}
-	if !allowInsecure && isDisallowedIPHost(u.Hostname()) {
-		return fmt.Errorf("notifychan: endpoint %q targets a private/link-local address; refusing to send to an internal host", raw)
+	if !allowPrivateNetwork {
+		if err := refuseDisallowedHost(u.Hostname()); err != nil {
+			return fmt.Errorf("notifychan: endpoint %q %w", raw, err)
+		}
 	}
 	return nil
 }
@@ -43,12 +54,40 @@ func isLoopbackHost(host string) bool {
 	return false
 }
 
-// isDisallowedIPHost reports whether host is a literal private or link-local IP (loopback
-// is permitted as a dev target). Hostnames are not resolved here (no DNS at config time),
-// so this catches the literal-IP SSRF cases without a resolution side effect.
-func isDisallowedIPHost(host string) bool {
-	ip := net.ParseIP(host)
-	if ip == nil || ip.IsLoopback() {
+// lookupIPAddr resolves a hostname to its IP addresses — a var so tests can
+// substitute a fake resolver without a real DNS query.
+var lookupIPAddr = func(host string) ([]net.IPAddr, error) {
+	return net.DefaultResolver.LookupIPAddr(context.Background(), host)
+}
+
+// refuseDisallowedHost rejects host when it — or any address it RESOLVES to — is a
+// private, link-local, or otherwise disallowed IP (loopback is permitted as a dev
+// target). A literal-IP-only check lets a hostname like attacker.example (which
+// resolves to 169.254.169.254 or an RFC 1918 address) straight through; this
+// resolves the hostname and checks every returned address.
+func refuseDisallowedHost(host string) error {
+	if ip := net.ParseIP(host); ip != nil {
+		if isDisallowedIP(ip) {
+			return fmt.Errorf("targets a private/link-local address; refusing to send to an internal host")
+		}
+		return nil
+	}
+	addrs, err := lookupIPAddr(host)
+	if err != nil {
+		return fmt.Errorf("could not resolve hostname to verify it is not private/internal: %w", err)
+	}
+	for _, a := range addrs {
+		if isDisallowedIP(a.IP) {
+			return fmt.Errorf("resolves to a private/link-local address (%s); refusing to send to an internal host", a.IP)
+		}
+	}
+	return nil
+}
+
+// isDisallowedIP reports whether ip is a private or link-local address (loopback is
+// permitted as a dev target).
+func isDisallowedIP(ip net.IP) bool {
+	if ip.IsLoopback() {
 		return false
 	}
 	return ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast()

--- a/internal/notifychan/webhook.go
+++ b/internal/notifychan/webhook.go
@@ -19,6 +19,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
 	"strings"
 	"time"
@@ -36,6 +37,13 @@ type WebhookConfig struct {
 	Endpoint           string // full destination URL (POST target)
 	Token              string // optional bearer token (Authorization: Bearer <token>)
 	InsecureSkipVerify bool   // skip TLS verification (test/self-signed only)
+	// AllowPrivateNetworkTarget opts the endpoint out of the SSRF guard (a literal
+	// or DNS-resolved private/link-local destination is refused by default) — a
+	// SEPARATE decision from InsecureSkipVerify (#130): trusting a self-signed cert
+	// doesn't mean the endpoint should be allowed to live on an internal network,
+	// and a legitimate on-prem receiver with a real cert still needs this to reach
+	// its private address.
+	AllowPrivateNetworkTarget bool
 	// SigningSecret, when set, signs each payload with HMAC-SHA256 so the receiver can
 	// verify it came from Keyorix: header X-Keyorix-Signature: sha256=<hex(hmac(body))>.
 	SigningSecret string
@@ -60,11 +68,12 @@ func newWebhook(cfg WebhookConfig, baseBackoff time.Duration) (*WebhookSink, err
 	if cfg.Endpoint == "" {
 		return nil, fmt.Errorf("notifychan: webhook endpoint is required")
 	}
-	if err := validateEndpoint(cfg.Endpoint, cfg.InsecureSkipVerify); err != nil {
+	if err := validateEndpoint(cfg.Endpoint, cfg.AllowPrivateNetworkTarget); err != nil {
 		return nil, err
 	}
 	transport := &http.Transport{}
 	if cfg.InsecureSkipVerify {
+		log.Printf("WARNING: notifychan webhook %q has TLS verification disabled (insecure_skip_verify); do not use in production", cfg.Endpoint)
 		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} // #nosec G402 -- opt-in for self-signed endpoints
 	}
 	s := &WebhookSink{

--- a/internal/notifychan/webhook_test.go
+++ b/internal/notifychan/webhook_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -197,9 +198,38 @@ func TestNewWebhook_RejectsNonHTTPSEndpoint(t *testing.T) {
 	require.Error(t, err, "a non-loopback http endpoint must be rejected (cleartext token)")
 	assert.Contains(t, err.Error(), "https")
 
-	// Loopback http is allowed (local testing), and explicit insecure opt-in too.
+	// Loopback http is allowed (local testing).
 	_, err = NewWebhook(WebhookConfig{Endpoint: "http://127.0.0.1:9000/hook"})
 	require.NoError(t, err)
+
+	// #130: InsecureSkipVerify (a TLS-certificate-trust decision) must NOT also
+	// bypass the https/SSRF guard — that coupling was the bug. Only the dedicated
+	// AllowPrivateNetworkTarget opt-in does.
 	_, err = NewWebhook(WebhookConfig{Endpoint: "http://siem.example.com/hook", InsecureSkipVerify: true})
-	require.NoError(t, err)
+	require.Error(t, err, "InsecureSkipVerify alone must not bypass the https requirement")
+	_, err = NewWebhook(WebhookConfig{Endpoint: "http://siem.example.com/hook", AllowPrivateNetworkTarget: true})
+	require.NoError(t, err, "AllowPrivateNetworkTarget is the dedicated opt-in for a non-https/internal target")
+}
+
+// TestNewWebhook_RejectsHostnameResolvingToPrivateIP pins #130: the SSRF guard
+// previously only rejected a LITERAL private/link-local IP in the endpoint —
+// a hostname (e.g. attacker-controlled DNS) resolving to one, such as the cloud
+// metadata address, sailed straight through. The guard must resolve the
+// hostname and check every address it returns.
+func TestNewWebhook_RejectsHostnameResolvingToPrivateIP(t *testing.T) {
+	orig := lookupIPAddr
+	defer func() { lookupIPAddr = orig }()
+	lookupIPAddr = func(host string) ([]net.IPAddr, error) {
+		if host == "metadata.attacker.example" {
+			return []net.IPAddr{{IP: net.ParseIP("169.254.169.254")}}, nil
+		}
+		return []net.IPAddr{{IP: net.ParseIP("203.0.113.5")}}, nil // a public TEST-NET-3 address
+	}
+
+	_, err := NewWebhook(WebhookConfig{Endpoint: "https://metadata.attacker.example/hook"})
+	require.Error(t, err, "a hostname resolving to a link-local address must be rejected")
+	assert.Contains(t, err.Error(), "private/link-local")
+
+	_, err = NewWebhook(WebhookConfig{Endpoint: "https://normal.example.com/hook"})
+	require.NoError(t, err, "a hostname resolving to a public address is unaffected")
 }

--- a/server/main.go
+++ b/server/main.go
@@ -426,10 +426,11 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 	var recipientSinks []core.NotificationSink
 	if wc := cfg.Notifications.Webhook; wc.Enabled {
 		sink, werr := notifychan.NewWebhook(notifychan.WebhookConfig{
-			Endpoint:           wc.Endpoint,
-			Token:              wc.GetToken(),
-			InsecureSkipVerify: wc.InsecureSkipVerify,
-			SigningSecret:      wc.GetSigningSecret(),
+			Endpoint:                  wc.Endpoint,
+			Token:                     wc.GetToken(),
+			InsecureSkipVerify:        wc.InsecureSkipVerify,
+			AllowPrivateNetworkTarget: wc.AllowPrivateNetworkTarget,
+			SigningSecret:             wc.GetSigningSecret(),
 		})
 		if werr != nil {
 			return nil, nil, fmt.Errorf("failed to init notification webhook channel: %w", werr)
@@ -596,9 +597,10 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 	var evidenceTargets []evidencesink.Forwarder
 	if ew := cfg.EvidenceDelivery.Webhook; ew.Enabled {
 		fwd, ferr := evidencesink.NewWebhook(evidencesink.WebhookConfig{
-			Endpoint:           ew.Endpoint,
-			Token:              ew.GetToken(),
-			InsecureSkipVerify: ew.InsecureSkipVerify,
+			Endpoint:                  ew.Endpoint,
+			Token:                     ew.GetToken(),
+			InsecureSkipVerify:        ew.InsecureSkipVerify,
+			AllowPrivateNetworkTarget: ew.AllowPrivateNetworkTarget,
 		})
 		if ferr != nil {
 			return nil, nil, fmt.Errorf("failed to init evidence webhook target: %w", ferr)


### PR DESCRIPTION
Rebase of #532 onto current main, with the #98 portion dropped: main already refuses Vault redirects in the server-side connector (internal/connect/vault.go) with equivalent/stronger regression tests (TestVault_GetSecret_RefusesCrossHostRedirect / RefusesSameHostRedirect). This PR keeps everything else from #532.

## Summary
- fix(cli): CLI Vault import client also refuses to follow redirects, and secret export now uses O_EXCL|O_NOFOLLOW (not just 0600) to refuse a pre-existing/symlinked output path (#114)
- fix(egress): resolve hostnames for the notification/evidence-webhook SSRF guard; decouple it from InsecureSkipVerify via a dedicated AllowPrivateNetworkTarget opt-in (#130)
- fix(egress): warn loudly at construction when TLS verification is disabled for the SIEM forwarder, notification webhook, and evidence webhook (#134)

Also drops the now-duplicate replayMu hunk in internal/audit/siem/spool.go (already on main).

Supersedes #532.