### PR TITLE
harden(tls,k8ssync,helm): apply hardened TLS to AutoCert, verify k8ssync HTTPS enforcement, scope k8s-sync RBAC to cleanup (#172/#178/#186)

### DIFF
--- a/deploy/helm/keyorix-k8s-sync/templates/rbac.yaml
+++ b/deploy/helm/keyorix-k8s-sync/templates/rbac.yaml
@@ -13,9 +13,10 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["secrets"]
-    # list + delete are needed only for orphan cleanup (cleanup: true); they are
-    # harmless when cleanup is off, and keeping one role avoids a conditional rule.
-    verbs: ["get", "list", "create", "patch", "delete"]
+    # list + delete are needed only for orphan cleanup (cleanup: true) — granted only
+    # when that behavior is actually enabled, so RBAC matches the configured
+    # capability instead of granting secrets:delete cluster-wide by default (#186).
+    verbs: ["get", "create", "patch"{{ if .Values.cleanup }}, "list", "delete"{{ end }}]
 ---
 {{- $ns := .Values.targetNamespaces | default (list .Release.Namespace) }}
 {{- $root := . }}

--- a/internal/k8ssync/config_test.go
+++ b/internal/k8ssync/config_test.go
@@ -92,6 +92,37 @@ func TestLoadConfig_MissingFile(t *testing.T) {
 	assert.Error(t, err)
 }
 
+// #178: a non-https keyorix_url must be rejected, UNLESS the host is loopback (local
+// development against a Keyorix instance on the same machine) — matching the
+// established #122/#544 convention (internal/mcp.NewKeyorixClient).
+func TestLoadConfig_KeyorixURLScheme(t *testing.T) {
+	mappings := `
+mappings:
+  - {ref: e/n, namespace: ns, name: s, key: K}
+`
+	cases := map[string]struct {
+		url     string
+		wantErr bool
+	}{
+		"https allowed":            {"https://keyorix.internal", false},
+		"http non-loopback denied": {"http://keyorix.internal", true},
+		"http localhost allowed":   {"http://localhost:8080", false},
+		"http 127.0.0.1 allowed":   {"http://127.0.0.1:8080", false},
+		"http ::1 allowed":         {"http://[::1]:8080", false},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			cfg, err := LoadConfig(writeConfig(t, "keyorix_url: "+tc.url+mappings))
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tc.url, cfg.KeyorixURL)
+			}
+		})
+	}
+}
+
 func TestSync_LogsSummary(t *testing.T) {
 	var lines []string
 	logf := func(format string, args ...interface{}) {

--- a/server/grpc/server.go
+++ b/server/grpc/server.go
@@ -100,14 +100,34 @@ func NewServer(cfg *config.Config, coreService *core.KeyorixCore) (*grpc.Server,
 	return server, nil
 }
 
+// hardenedCipherSuites is the explicit AEAD-only cipher suite allowlist applied to
+// every gRPC TLS listener, regardless of how its certificate is sourced.
+var hardenedCipherSuites = []uint16{
+	tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+	tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
+	tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+}
+
+// applyTLSHardening layers the deliberately hardened MinVersion/CipherSuites onto
+// tlsConfig in place. The protocol-version floor and cipher-suite allowlist are
+// independent of how the certificate itself is sourced, so this must be applied
+// uniformly on both the AutoCert and non-AutoCert paths below — AutoCert should only
+// supply the certificate, not silently determine the rest of the TLS posture too
+// (#172).
+func applyTLSHardening(tlsConfig *tls.Config) {
+	tlsConfig.MinVersion = tls.VersionTLS12
+	tlsConfig.CipherSuites = hardenedCipherSuites
+}
+
 // createGRPCTLSConfig creates TLS configuration for gRPC server
 func createGRPCTLSConfig(cfg *config.Config) (*tls.Config, error) {
 	if cfg.Server.GRPC.TLS.AutoCert {
-		// For gRPC, autocert is more complex and typically not used
-		// Return a basic TLS config for now
-		return &tls.Config{
-			MinVersion: tls.VersionTLS12,
-		}, nil
+		// For gRPC, autocert (certificate acquisition) is more complex and typically
+		// not wired up here — but the hardened MinVersion/CipherSuites below must
+		// still apply, matching the non-AutoCert path's posture (#172).
+		tlsConfig := &tls.Config{}
+		applyTLSHardening(tlsConfig)
+		return tlsConfig, nil
 	}
 
 	// Load certificate and key
@@ -116,13 +136,7 @@ func createGRPCTLSConfig(cfg *config.Config) (*tls.Config, error) {
 		return nil, fmt.Errorf("failed to load gRPC TLS certificate: %w", err)
 	}
 
-	return &tls.Config{
-		Certificates: []tls.Certificate{cert},
-		MinVersion:   tls.VersionTLS12,
-		CipherSuites: []uint16{
-			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-			tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
-			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-		},
-	}, nil
+	tlsConfig := &tls.Config{Certificates: []tls.Certificate{cert}}
+	applyTLSHardening(tlsConfig)
+	return tlsConfig, nil
 }

--- a/server/grpc/server_test.go
+++ b/server/grpc/server_test.go
@@ -1,0 +1,28 @@
+package grpc
+
+import (
+	"crypto/tls"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+)
+
+// #172: gRPC AutoCert mode must not silently discard the hardened
+// MinVersion/CipherSuites — createGRPCTLSConfig must apply the same hardening on the
+// AutoCert branch as it does on the non-AutoCert (manual cert/key) branch below.
+func TestCreateGRPCTLSConfig_AutoCertAppliesHardening(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Server.GRPC.TLS.Enabled = true
+	cfg.Server.GRPC.TLS.AutoCert = true
+
+	tlsConfig, err := createGRPCTLSConfig(cfg)
+	if err != nil {
+		t.Fatalf("createGRPCTLSConfig: %v", err)
+	}
+	if tlsConfig.MinVersion != tls.VersionTLS12 {
+		t.Errorf("MinVersion = %v, want tls.VersionTLS12", tlsConfig.MinVersion)
+	}
+	if len(tlsConfig.CipherSuites) == 0 {
+		t.Fatal("CipherSuites must not be empty on the AutoCert branch")
+	}
+}

--- a/server/main.go
+++ b/server/main.go
@@ -1266,12 +1266,7 @@ func startHTTPServer(ctx context.Context, cfg *config.Config) error {
 		var serveErr error
 		if cfg.Server.HTTP.TLS.Enabled {
 			if cfg.Server.HTTP.TLS.AutoCert {
-				m := &autocert.Manager{
-					Cache:      autocert.DirCache("certs"),
-					Prompt:     autocert.AcceptTOS,
-					HostPolicy: autocert.HostWhitelist(cfg.Server.HTTP.TLS.Domains...),
-				}
-				server.TLSConfig = m.TLSConfig()
+				server.TLSConfig = buildAutoCertTLSConfig(cfg.Server.HTTP.TLS.Domains)
 				serveErr = server.ServeTLS(ln, "", "")
 			} else {
 				serveErr = server.ServeTLS(ln, cfg.Server.HTTP.TLS.CertFile, cfg.Server.HTTP.TLS.KeyFile)
@@ -1455,7 +1450,8 @@ func startGRPCServer(ctx context.Context, cfg *config.Config) error {
 
 func createTLSConfig(cfg *config.Config) (*tls.Config, error) {
 	if cfg.Server.HTTP.TLS.AutoCert {
-		// Autocert will handle TLS config
+		// AutoCert mode builds its tls.Config separately, from the autocert.Manager
+		// (see buildAutoCertTLSConfig) — it still gets the same hardening applied.
 		return nil, nil
 	}
 
@@ -1465,15 +1461,45 @@ func createTLSConfig(cfg *config.Config) (*tls.Config, error) {
 		return nil, fmt.Errorf("failed to load TLS certificate: %w", err)
 	}
 
-	return &tls.Config{
-		Certificates: []tls.Certificate{cert},
-		MinVersion:   tls.VersionTLS12,
-		CipherSuites: []uint16{
-			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-			tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
-			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-		},
-	}, nil
+	tlsConfig := &tls.Config{Certificates: []tls.Certificate{cert}}
+	applyTLSHardening(tlsConfig)
+	return tlsConfig, nil
+}
+
+// hardenedCipherSuites is the explicit AEAD-only cipher suite allowlist applied to
+// every HTTP TLS listener, regardless of how its certificate is sourced.
+var hardenedCipherSuites = []uint16{
+	tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+	tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
+	tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+}
+
+// applyTLSHardening layers the deliberately hardened MinVersion/CipherSuites onto
+// tlsConfig in place. The protocol-version floor and cipher-suite allowlist are
+// independent of how the certificate itself is sourced, so this must be applied
+// uniformly whether tlsConfig came from a manually configured cert/key pair
+// (createTLSConfig) or from an autocert.Manager (buildAutoCertTLSConfig) — AutoCert
+// should only supply the certificate, not silently determine the rest of the TLS
+// posture too (#172).
+func applyTLSHardening(tlsConfig *tls.Config) {
+	tlsConfig.MinVersion = tls.VersionTLS12
+	tlsConfig.CipherSuites = hardenedCipherSuites
+}
+
+// buildAutoCertTLSConfig builds the tls.Config for HTTP AutoCert (Let's Encrypt-style
+// automatic certificate management) mode: the autocert.Manager supplies the
+// certificate (via GetCertificate/NextProtos), and the same hardened
+// MinVersion/CipherSuites as the non-AutoCert path (createTLSConfig) are layered on
+// top instead of being silently discarded (#172).
+func buildAutoCertTLSConfig(domains []string) *tls.Config {
+	m := &autocert.Manager{
+		Cache:      autocert.DirCache("certs"),
+		Prompt:     autocert.AcceptTOS,
+		HostPolicy: autocert.HostWhitelist(domains...),
+	}
+	tlsConfig := m.TLSConfig()
+	applyTLSHardening(tlsConfig)
+	return tlsConfig
 }
 
 // resolveOutboundIP returns the machine's preferred outbound IP address.

--- a/server/transport_tls_test.go
+++ b/server/transport_tls_test.go
@@ -2,14 +2,66 @@ package main
 
 import (
 	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
 	"log"
+	"math/big"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/keyorixhq/keyorix/internal/config"
 )
+
+// writeSelfSignedCert generates a throwaway self-signed cert/key pair under dir and
+// returns their paths, for exercising the non-AutoCert TLS config-building path
+// without a real CA.
+func writeSelfSignedCert(t *testing.T, dir string) (certFile, keyFile string) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create certificate: %v", err)
+	}
+
+	certFile = filepath.Join(dir, "cert.pem")
+	keyFile = filepath.Join(dir, "key.pem")
+	certOut, err := os.Create(certFile) // #nosec G304 -- test-only temp dir
+	if err != nil {
+		t.Fatalf("create cert file: %v", err)
+	}
+	defer certOut.Close() //nolint:errcheck
+	if err := pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: der}); err != nil {
+		t.Fatalf("encode cert: %v", err)
+	}
+
+	keyOut, err := os.OpenFile(keyFile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600) // #nosec G304 -- test-only temp dir
+	if err != nil {
+		t.Fatalf("create key file: %v", err)
+	}
+	defer keyOut.Close() //nolint:errcheck
+	if err := pem.Encode(keyOut, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)}); err != nil {
+		t.Fatalf("encode key: %v", err)
+	}
+	return certFile, keyFile
+}
 
 // A group/world-readable key file must fail closed when the permission check is enabled,
 // warn (no error) by default, and be allowed when explicitly overridden. A 0600 file or a
@@ -114,5 +166,48 @@ func TestCheckTransportTLSPosture_WarnsOnDeadAllowedCiphers(t *testing.T) {
 	}
 	if !strings.Contains(buf.String(), "tls.allowed_ciphers") {
 		t.Errorf("expected a warning mentioning tls.allowed_ciphers, got log output: %q", buf.String())
+	}
+}
+
+// #172: AutoCert mode must not silently discard the hardened MinVersion/CipherSuites
+// — buildAutoCertTLSConfig (the AutoCert-mode config builder) must apply the same
+// hardening as the non-AutoCert path (createTLSConfig).
+func TestBuildAutoCertTLSConfig_AppliesHardening(t *testing.T) {
+	tlsConfig := buildAutoCertTLSConfig([]string{"example.com"})
+	if tlsConfig == nil {
+		t.Fatal("buildAutoCertTLSConfig must not return nil")
+	}
+	if tlsConfig.MinVersion != tls.VersionTLS12 {
+		t.Errorf("MinVersion = %v, want tls.VersionTLS12", tlsConfig.MinVersion)
+	}
+	if len(tlsConfig.CipherSuites) == 0 {
+		t.Fatal("CipherSuites must not be empty on the AutoCert-derived config")
+	}
+	// The autocert.Manager must still be the certificate source (GetCertificate set).
+	if tlsConfig.GetCertificate == nil {
+		t.Error("GetCertificate must still be wired from the autocert.Manager")
+	}
+}
+
+// The non-AutoCert path (createTLSConfig) must apply the identical hardening, so both
+// modes converge on the same TLS posture.
+func TestCreateTLSConfig_NonAutoCertAppliesHardening(t *testing.T) {
+	dir := t.TempDir()
+	certFile, keyFile := writeSelfSignedCert(t, dir)
+
+	cfg := &config.Config{}
+	cfg.Server.HTTP.TLS.Enabled = true
+	cfg.Server.HTTP.TLS.CertFile = certFile
+	cfg.Server.HTTP.TLS.KeyFile = keyFile
+
+	tlsConfig, err := createTLSConfig(cfg)
+	if err != nil {
+		t.Fatalf("createTLSConfig: %v", err)
+	}
+	if tlsConfig.MinVersion != tls.VersionTLS12 {
+		t.Errorf("MinVersion = %v, want tls.VersionTLS12", tlsConfig.MinVersion)
+	}
+	if len(tlsConfig.CipherSuites) == 0 {
+		t.Fatal("CipherSuites must not be empty")
 	}
 }


### PR DESCRIPTION
Replaces #563 (that PR's head branch had to be deleted/recreated during a rebase in this environment, which GitHub does not allow reopening after).

Rebased onto current main; kept the full original fix (no overlap with other merged work), resolving one test-file conflict (server/transport_tls_test.go — main had since added an unrelated #333 test in the same file; both kept):
- #172 MED: gRPC and HTTP AutoCert TLS modes were silently discarding the hardened MinVersion/CipherSuites in favor of the autocert manager's defaults — both now layer the hardening on top via a shared applyTLSHardening helper.
- #178 MED: internal/k8ssync already enforced https on keyorix_url (loopback-exempt) from an earlier pass — adds the missing regression test explicitly covering it.
- #186 MED: keyorix-k8s-sync Helm chart's ClusterRole granted list+delete on Secrets unconditionally; now gated behind {{ if .Values.cleanup }} so RBAC matches the configured capability.