### PR TITLE
harden(rbac): RBAC/access-review parity bundle — #99, #141

### DIFF
--- a/internal/core/access_review_external_test.go
+++ b/internal/core/access_review_external_test.go
@@ -152,6 +152,38 @@ func TestRevokeAccessReviewGrant_ShareAndOwner(t *testing.T) {
 	require.Error(t, err)
 }
 
+// TestRevokeAccessReviewGrant_CrossProjectShareRevokeRefused pins #99: a reviewer
+// authorized on project A must not be able to revoke a share belonging to a
+// secret in project B by passing its SecretID — revokeReviewShare previously
+// looked up the share purely by SecretID with no check that the secret actually
+// belongs to the caller's project (IDOR).
+func TestRevokeAccessReviewGrant_CrossProjectShareRevokeRefused(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(&models.SecretNode{}, &models.Environment{}, &models.ShareRecord{}))
+
+	const projA, projB = uint(2), uint(3)
+	h.CreateTestUser(t, "alice", 10) // owner in project B
+	h.CreateTestUser(t, "bob", 11)   // direct-share recipient in project B
+	require.NoError(t, h.DB.Create(&models.Environment{ID: 30, ProjectID: projB, Name: "prod"}).Error)
+	require.NoError(t, h.DB.Create(&models.SecretNode{
+		ID: 600, ProjectID: projB, EnvironmentID: 30, OwnerID: 10, Name: "b-secret", Type: "password", Status: "active", IsSecret: true,
+	}).Error)
+	require.NoError(t, h.DB.Create(&models.ShareRecord{SecretID: 600, RecipientID: 11, IsGroup: false, Permission: "read"}).Error)
+
+	ctx := context.Background()
+	// A reviewer scoped to project A passes project B's SecretID.
+	err := h.CoreService.RevokeAccessReviewGrant(ctx, 1, projA, core.AccessReviewDecision{
+		Source: "direct_share", PrincipalID: 11, SecretID: 600,
+	})
+	require.Error(t, err, "a secret from a different project must not be revocable")
+
+	// The share still exists — untouched.
+	var count int64
+	require.NoError(t, h.DB.Model(&models.ShareRecord{}).Where("secret_id = ? AND recipient_id = ?", 600, 11).Count(&count).Error)
+	assert.Equal(t, int64(1), count, "the cross-project share must survive the refused revoke attempt")
+}
+
 // Attesting a grant changes no access but records an access_review.attested audit
 // event as the evidence of recertification.
 func TestAttestAccessReviewGrant_AuditsDecision(t *testing.T) {

--- a/internal/core/access_review_revoke.go
+++ b/internal/core/access_review_revoke.go
@@ -83,7 +83,7 @@ func (c *KeyorixCore) RevokeAccessReviewGrant(ctx context.Context, actorID, proj
 		if d.PrincipalID == 0 || d.SecretID == 0 {
 			return fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "principal_id and secret_id are required to revoke a share")
 		}
-		if err := c.revokeReviewShare(ctx, d); err != nil {
+		if err := c.revokeReviewShare(ctx, projectID, d); err != nil {
 			return err
 		}
 	case "owner":
@@ -97,8 +97,19 @@ func (c *KeyorixCore) RevokeAccessReviewGrant(ctx context.Context, actorID, proj
 
 // revokeReviewShare deletes the ShareRecord matching the decision's secret +
 // recipient. It deletes the record directly (not via RevokeShare, which is owner-
-// gated) because access recertification acts on the project scope's authority.
-func (c *KeyorixCore) revokeReviewShare(ctx context.Context, d AccessReviewDecision) error {
+// gated) because access recertification acts on the project scope's authority —
+// which is exactly why the target secret must be verified to belong to THAT
+// project first: without it, a reviewer authorized on project A could pass any
+// SecretID and delete a share belonging to a secret in a DIFFERENT project
+// (IDOR; #99).
+func (c *KeyorixCore) revokeReviewShare(ctx context.Context, projectID uint, d AccessReviewDecision) error {
+	secret, err := c.storage.GetSecret(ctx, d.SecretID)
+	if err != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorNotFound", nil), err)
+	}
+	if secret.ProjectID != projectID {
+		return fmt.Errorf("%s: %s", i18n.T("ErrorNotFound", nil), "secret does not belong to this project")
+	}
 	isGroup := d.Source == "group_share"
 	shares, err := c.storage.ListSharesBySecret(ctx, d.SecretID)
 	if err != nil {

--- a/server/http/rbac_route_authz_test.go
+++ b/server/http/rbac_route_authz_test.go
@@ -70,3 +70,58 @@ func TestUpdateUserRolesRequiresRolesAssign(t *testing.T) {
 	assert.NotEqual(t, http.StatusForbidden, put("admin-tok"),
 		"admin should be allowed past the roles.assign gate")
 }
+
+// Regression (#141): GET /api/v1/users/{id}/roles must require roles.read, not
+// the group-wide users.read that nearly every seeded role holds — otherwise any
+// low-privilege project member can enumerate an arbitrary OTHER user's full role
+// assignment list (reconnaissance for targeted privilege-escalation attempts).
+// This also matches the gRPC RoleService.GetUserRoles gate for the same data.
+func TestGetUserRolesRequiresRolesRead(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.User{}, &models.Role{}, &models.Permission{}, &models.RolePermission{},
+		&models.UserRole{}, &models.Group{}, &models.UserGroup{}, &models.GroupRole{},
+		&models.AuditEvent{}, &models.Session{},
+	))
+	now := time.Now()
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "auditor", Email: "a@t.com", IsActive: true, CreatedAt: now, UpdatedAt: now}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 2, Username: "viewer", Email: "v@t.com", IsActive: true, CreatedAt: now, UpdatedAt: now}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 3, Username: "target", Email: "t@t.com", IsActive: true, CreatedAt: now, UpdatedAt: now}).Error)
+	// "auditor" holds roles.read; "viewer" holds only users.read.
+	require.NoError(t, db.Create(&models.Role{ID: 1, Name: "auditor"}).Error)
+	require.NoError(t, db.Create(&models.Role{ID: 2, Name: "viewer"}).Error)
+	require.NoError(t, db.Create(&models.Permission{ID: 1, Name: "users.read", Resource: "users", Action: "read"}).Error)
+	require.NoError(t, db.Create(&models.Permission{ID: 2, Name: "roles.read", Resource: "roles", Action: "read"}).Error)
+	require.NoError(t, db.Create(&models.RolePermission{RoleID: 1, PermissionID: 1}).Error)
+	require.NoError(t, db.Create(&models.RolePermission{RoleID: 1, PermissionID: 2}).Error)
+	require.NoError(t, db.Create(&models.RolePermission{RoleID: 2, PermissionID: 1}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 2, RoleID: 2}).Error)
+	seedSession(t, db, 1, "auditor-tok")
+	seedSession(t, db, 2, "viewer-tok")
+
+	router, err := NewRouter(&config.Config{}, core.NewKeyorixCore(store.NewLocalStorage(db)))
+	require.NoError(t, err)
+	server := httptest.NewServer(router)
+	defer server.Close()
+	client := &http.Client{Timeout: 5 * time.Second}
+
+	get := func(token string) int {
+		req, err := http.NewRequest("GET", server.URL+"/api/v1/users/3/roles", nil)
+		require.NoError(t, err)
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+		return resp.StatusCode
+	}
+
+	assert.Equal(t, http.StatusForbidden, get("viewer-tok"),
+		"users.read holder without roles.read must NOT enumerate another user's roles")
+	assert.NotEqual(t, http.StatusForbidden, get("auditor-tok"),
+		"a roles.read holder should be allowed past the gate")
+}

--- a/server/http/rbac_route_authz_test.go
+++ b/server/http/rbac_route_authz_test.go
@@ -85,7 +85,7 @@ func TestGetUserRolesRequiresRolesRead(t *testing.T) {
 	require.NoError(t, db.AutoMigrate(
 		&models.User{}, &models.Role{}, &models.Permission{}, &models.RolePermission{},
 		&models.UserRole{}, &models.Group{}, &models.UserGroup{}, &models.GroupRole{},
-		&models.AuditEvent{}, &models.Session{},
+		&models.AuditEvent{}, &models.Session{}, &models.Project{}, &models.Environment{},
 	))
 	now := time.Now()
 	require.NoError(t, db.Create(&models.User{ID: 1, Username: "auditor", Email: "a@t.com", IsActive: true, CreatedAt: now, UpdatedAt: now}).Error)

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -521,7 +521,10 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			// read-only system_auditor persona holds) — these were the missed
 			// siblings of the suspend/reactivate transitions gated below.
 			r.With(customMiddleware.RequirePermission("users.write")).Put("/{id}", handlers.UpdateUser)
-			r.With(customMiddleware.RequirePermission("users.write")).Delete("/{id}", handlers.DeleteUser)
+			// users.delete, not users.write — matches the gRPC UserService.DeleteUser
+			// gate (#141). A custom role granted users.write alone (update, not delete)
+			// could otherwise delete users via HTTP while gRPC correctly refused it.
+			r.With(customMiddleware.RequirePermission("users.delete")).Delete("/{id}", handlers.DeleteUser)
 			r.With(customMiddleware.RequirePermission("users.write")).Post("/{id}/restore", handlers.RestoreUser)
 			r.With(customMiddleware.RequirePermission("users.write")).Post("/{id}/unlock", handlers.UnlockUser)
 			// Admin force-logout: revoke all of a user's sessions (no state change).
@@ -532,9 +535,17 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.With(customMiddleware.RequirePermission("users.write")).Post("/{id}/require-password-reset", handlers.RequirePasswordReset)
 			// Credential-delivery resend (ADR-028): reissue + redeliver a setup link.
 			r.With(customMiddleware.RequirePermission("users.write")).Post("/{id}/resend-setup-link", handlers.ResendSetupLink)
-			r.Get("/{id}/roles", usersRolesHandler.GetUserRolesForUser)
+			// roles.read, not the group-wide users.read (#141) — matches the gRPC
+			// RoleService.GetUserRoles gate for the same data. users.read is held by
+			// nearly every seeded role (project_viewer, editor, …), so gating a user's
+			// full role-assignment list on it let any low-privilege project member
+			// enumerate an arbitrary OTHER user's roles — reconnaissance for targeted
+			// privilege-escalation attempts. roles.read is held by system_admin/
+			// system_auditor/project_admin, the personas that actually manage access.
+			r.With(customMiddleware.RequirePermission("roles.read")).Get("/{id}/roles", usersRolesHandler.GetUserRolesForUser)
 			// Effective permission set (union across the user's roles) — a read, gated
-			// by the group-wide users.read like the roles view above.
+			// by the group-wide users.read like the roles view used to be. Not part of
+			// #141's scope; left as-is.
 			r.Get("/{id}/permissions", usersRolesHandler.GetUserPermissionsForUser)
 			// Replacing a user's roles is a privilege grant — gate on roles.assign,
 			// not the group-wide users.read (which many non-admin roles hold).


### PR DESCRIPTION
Rebase of #531 onto current main. Both findings are still needed and independent of #616 (which closed a different, also-#141-labeled AssignUserRole permission-ceiling gap — verified main's server/http/router.go still gates DELETE /api/v1/users/{id} on users.write, not users.delete, and GET /{id}/roles has no permission gate at all, so #616 does not cover this PR's content).

## Summary
- fix(access-review): reject cross-project share revoke (#99)
- fix(rbac): tighten HTTP DeleteUser and GetUserRoles to match gRPC (#141)

Also drops the now-duplicate replayMu hunk in internal/audit/siem/spool.go (already on main), and fixes an incomplete AutoMigrate list in the new GetUserRoles regression test (main's GetUserRoles query now LEFT JOINs projects/environments).

Supersedes #531.