### PR TITLE
fix(encryption): guard DEK rotate/rewrap with a cross-process exclusive lock (#195)

### DIFF
--- a/internal/encryption/keymanager_filelock.go
+++ b/internal/encryption/keymanager_filelock.go
@@ -1,0 +1,92 @@
+// keymanager_filelock.go — cross-process exclusive lock guarding the DEK
+// read-modify-rename critical sections (#195).
+//
+// RewrapDEK/RewrapDEKWithProvider (the `keyorix encryption migrate-provider`
+// command) and RotateDEKWithSweep (the `keyorix encryption rotate` command)
+// both read the currently-active DEK, compute a new wrapped form, and
+// atomically rename it onto keys/dek.key. Each is a separate, short-lived CLI
+// process with its own KeyManager instance, so KeyManager.mu — an in-process
+// sync.RWMutex — provides no protection against the two racing: if an
+// operator runs `rotate --confirm` and, concurrently, automation runs
+// `migrate-provider --confirm`, the migrate-provider process's Initialize()
+// may have unwrapped the DEK *before* rotate replaces it, then win the
+// rename race *after* rotate commits — silently overwriting the freshly
+// rotated (and now fully re-encrypted-into) DEK with the stale, superseded
+// one. Every row in the database, already durably re-encrypted under the new
+// DEK, becomes permanently unreadable.
+//
+// Fix: an flock(2) advisory lock on a dedicated dek.key.lock file, held for
+// the duration of each operation's critical section, makes the two mutually
+// exclusive across processes. flock locks are owned by the open file
+// descriptor and are released automatically by the kernel when the holding
+// process exits or the fd is closed — including on crash or kill -9 — so
+// there is no stale-lock/PID-liveness bookkeeping to get wrong (unlike a
+// lockfile-with-PID pattern; grepping the repo for an existing single-
+// instance/PID-lock convention to follow instead turned up none). Advisory
+// locking is sufficient here: both operations are privileged, host-level CLI
+// commands that already require local filesystem + host access to run.
+//
+// Mutual exclusion on its own is not quite enough, though: if the SECOND
+// operation to acquire the lock is a RewrapDEK that read a since-superseded
+// DEK before the lock was even contended for, serializing its write after
+// the winner's does not stop it from clobbering the winner's result with
+// stale data. RewrapDEK therefore also re-validates, under the lock, that
+// the on-disk DEK is still the one it started from (see the staleness check
+// in keymanager_rewrap.go) before writing — turning "these two operations
+// never run at the same instant" into the actually-required "the DEK on
+// disk after both finish matches what's in the database".
+package encryption
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+// keyFileLock holds an acquired exclusive flock(2) on the DEK lock file.
+type keyFileLock struct {
+	f *os.File
+}
+
+// release unlocks the flock and closes the underlying file descriptor. Safe
+// to call at most once per successful acquireExclusiveKeyLock (callers defer
+// it immediately after acquiring).
+func (l *keyFileLock) release() {
+	if l == nil || l.f == nil {
+		return
+	}
+	_ = syscall.Flock(int(l.f.Fd()), syscall.LOCK_UN)
+	_ = l.f.Close()
+}
+
+// acquireExclusiveKeyLock takes a blocking exclusive flock(2) on
+// <baseDir>/<dekPath>.lock, serialising every DEK read-modify-rename
+// critical section — RewrapDEK and RotateDEKWithSweep — across ALL
+// processes sharing this key directory, not just goroutines within one
+// process. The lock file itself carries no key material: it exists purely
+// as a mutex handle and is never read for its contents.
+//
+// A non-blocking attempt is tried first purely so a genuine wait (another
+// key-management operation actively in progress) can be logged; if that
+// fails the call falls back to a blocking wait. Both operations this guards
+// are expected to complete in well under a minute, and correctness — never
+// letting the two interleave — matters far more here than failing fast.
+func (km *KeyManager) acquireExclusiveKeyLock() (*keyFileLock, error) {
+	lockPath := filepath.Join(km.baseDir, km.dekPath+".lock")
+	// #nosec G304 -- lockPath is derived from the key manager's own configured
+	// baseDir/dekPath (operator/config controlled), not attacker input.
+	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0600)
+	if err != nil {
+		return nil, fmt.Errorf("open DEK lock file %s: %w", lockPath, err)
+	}
+
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		fmt.Printf("⏳ waiting for exclusive DEK lock — another key-management operation (rotate/migrate-provider) is in progress...\n")
+		if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
+			_ = f.Close()
+			return nil, fmt.Errorf("acquire exclusive DEK lock %s: %w", lockPath, err)
+		}
+	}
+	return &keyFileLock{f: f}, nil
+}

--- a/internal/encryption/keymanager_lifecycle.go
+++ b/internal/encryption/keymanager_lifecycle.go
@@ -39,7 +39,13 @@ type KeyManager struct {
 	saltPath   string
 	baseDir    string
 	currentDEK []byte
-	keyVersion string
+	// dekSnapshot is the raw wrapped-DEK bytes read from disk at the moment
+	// currentDEK was last set (Initialize/RotateDEKWithSweep/RotateDEK). It
+	// lets RewrapDEK detect — under the exclusive key lock — whether another
+	// process has changed dek.key since, so it never overwrites a
+	// concurrently-completed rotation with a stale value (#195).
+	dekSnapshot []byte
+	keyVersion  string
 	// keyProvider sources the KEK (ADR-038). nil = the legacy passphrase+salt
 	// derivation below; set to a crypto.KeyProvider (password/file/env) by the
 	// Service to obtain the KEK from elsewhere. Either way the KEK still wraps the
@@ -181,6 +187,7 @@ func (km *KeyManager) unwrapDEK(kek []byte) ([]byte, error) {
 	if len(dek) != 32 {
 		return nil, fmt.Errorf("invalid DEK size after unwrap: expected 32 bytes, got %d", len(dek))
 	}
+	km.dekSnapshot = append([]byte(nil), wrapped...)
 	return dek, nil
 }
 

--- a/internal/encryption/keymanager_lock_test.go
+++ b/internal/encryption/keymanager_lock_test.go
@@ -1,0 +1,200 @@
+package encryption
+
+// keymanager_lock_test.go — regression tests for #195: RewrapDEK never
+// participated in the DEK-rotation exclusive-lock coordination, so it could
+// race a concurrent RotateDEKWithSweep and permanently orphan the database's
+// ciphertext.
+//
+// TestAcquireExclusiveKeyLock_MutualExclusion proves the lock primitive
+// itself: many goroutines, each with its own KeyManager (simulating separate
+// CLI processes), race to hold it and never overlap.
+//
+// TestRewrapAndRotate_ConcurrentRace_FinalDEKMatchesDB is the higher-value
+// test: it runs the actual RotateDEKWithSweep and RewrapDEKWithProvider
+// operations concurrently against a shared on-disk DEK and a shared
+// database, and asserts the security property that matters — whichever one
+// "wins" the race, the DEK left on disk once both finish is the one the
+// database was actually re-encrypted under, never a stale, superseded one.
+
+import (
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/crypto"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// TestAcquireExclusiveKeyLock_MutualExclusion proves the flock-based
+// exclusive lock actually serialises concurrent holders. Each goroutine uses
+// its OWN KeyManager instance pointed at the same key directory — mirroring
+// two independently-invoked CLI processes racing for the same
+// dek.key.lock — so nothing but the file lock itself can prevent overlap.
+func TestAcquireExclusiveKeyLock_MutualExclusion(t *testing.T) {
+	dir := t.TempDir()
+
+	const goroutines = 16
+	var (
+		current int32
+		maxSeen int32
+		wg      sync.WaitGroup
+	)
+
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+
+			km := NewKeyManager(dir, "dek.key", "kek.salt")
+			lock, err := km.acquireExclusiveKeyLock()
+			if err != nil {
+				t.Errorf("acquireExclusiveKeyLock: %v", err)
+				return
+			}
+
+			n := atomic.AddInt32(&current, 1)
+			for {
+				m := atomic.LoadInt32(&maxSeen)
+				if n <= m || atomic.CompareAndSwapInt32(&maxSeen, m, n) {
+					break
+				}
+			}
+			// Hold the lock briefly to widen the window in which a broken
+			// implementation would let a second holder in.
+			time.Sleep(5 * time.Millisecond)
+			atomic.AddInt32(&current, -1)
+
+			lock.release()
+		}()
+	}
+	wg.Wait()
+
+	if got := atomic.LoadInt32(&maxSeen); got != 1 {
+		t.Fatalf("exclusive lock allowed %d concurrent holders, want at most 1", got)
+	}
+}
+
+// TestRewrapAndRotate_ConcurrentRace_FinalDEKMatchesDB is the direct
+// regression test for #195. svcA and svcB are two SEPARATE Service/
+// KeyManager instances — simulating the two independent CLI processes behind
+// `keyorix encryption rotate --confirm` and `keyorix encryption
+// migrate-provider --confirm` — both Initialized against the SAME on-disk
+// DEK before racing: A rotates (generates a NEW DEK and re-encrypts the
+// database under it), B re-wraps whatever DEK it already has in memory under
+// a different KEK provider. Regardless of which the OS scheduler lets run
+// first, dek.key on disk once both finish must unwrap to the DEK the
+// database was last actually re-encrypted under.
+func TestRewrapAndRotate_ConcurrentRace_FinalDEKMatchesDB(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.EncryptionConfig{
+		Enabled:  true,
+		DEKPath:  "dek.key",
+		SaltPath: "kek.salt",
+	}
+	db := newTestDB(t)
+
+	// Both "processes" start from the SAME current (password) provider —
+	// exactly how rotate and migrate-provider both Initialize() against the
+	// currently-configured provider before racing.
+	svcA := NewService(cfg, dir)
+	if err := svcA.Initialize("test-passphrase"); err != nil {
+		t.Fatalf("init A (rotate side): %v", err)
+	}
+	svcB := NewService(cfg, dir)
+	if err := svcB.Initialize("test-passphrase"); err != nil {
+		t.Fatalf("init B (rewrap side): %v", err)
+	}
+
+	const projectID = uint(1)
+	nodeID := seedSecretNode(t, db, projectID)
+	versionID := seedSecretVersion(t, db, svcA, nodeID, projectID, 1, "top-secret-race-value")
+
+	// Process B's migration target: a brand-new file-backed KEK provider,
+	// distinct from the current password provider.
+	newKEKPath := filepath.Join(dir, "new.kek")
+	writeHexKEK(t, newKEKPath)
+	newProvider := crypto.NewFileKeyProvider(newKEKPath)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	var rotateErr, rewrapErr error
+	go func() {
+		defer wg.Done()
+		rotateErr = svcA.RotateDEKWithSweep("test-passphrase", db)
+	}()
+	go func() {
+		defer wg.Done()
+		rewrapErr = svcB.RewrapDEKWithProvider(newProvider)
+	}()
+	wg.Wait()
+
+	// Rotate must always succeed — a concurrent rewrap attempt must never be
+	// able to block or corrupt it.
+	if rotateErr != nil {
+		t.Fatalf("RotateDEKWithSweep failed under concurrent rewrap: %v", rotateErr)
+	}
+	// Rewrap either wins cleanly, or correctly detects that the DEK it holds
+	// went stale under it and aborts rather than clobbering the rotated one.
+	// Both are safe outcomes; the invariant checked below is what matters.
+	t.Logf("concurrent RewrapDEKWithProvider result: %v", rewrapErr)
+
+	// Fetch the row rotate's sweep re-encrypted and confirm svcA (which now
+	// holds the freshly-rotated DEK) can still decrypt it — the DB and svcA's
+	// in-memory DEK must agree.
+	var v models.SecretVersion
+	if err := db.First(&v, versionID).Error; err != nil {
+		t.Fatalf("failed to fetch SecretVersion: %v", err)
+	}
+	aad := SecretAAD(nodeID, projectID, 1)
+	plaintext, err := svcA.DecryptSecretWithAAD(v.EncryptedValue, aad)
+	if err != nil {
+		t.Fatalf("decrypt post-rotation row with svcA: %v", err)
+	}
+	if string(plaintext) != "top-secret-race-value" {
+		t.Fatalf("unexpected plaintext after rotation: %q", plaintext)
+	}
+
+	// Now resolve whichever DEK is ACTUALLY on disk right now, independently
+	// of which candidate provider wrapped it, and confirm it is byte-
+	// identical to svcA's post-rotation in-memory DEK — i.e. the file left
+	// behind is never the stale pre-rotation value.
+	finalDEK := resolveFinalDEK(t, dir, cfg, "test-passphrase", newProvider)
+	postRotateDEK := captureCurrentDEK(t, svcA)
+	if string(finalDEK) != string(postRotateDEK) {
+		t.Fatalf("on-disk DEK after the race does not match the DEK the database was re-encrypted under — ciphertext orphaned")
+	}
+}
+
+// resolveFinalDEK unwraps whatever is currently on disk at
+// dir/cfg.DEKPath using WHICHEVER of the two candidate providers — the
+// original password provider (cfg/passphrase), or the rewrap target
+// (newProvider) — actually succeeds, and returns the resulting raw DEK
+// bytes. Exactly one candidate is expected to work: dek.key is wrapped
+// under a single KEK at any moment, so only the matching provider can
+// unwrap it.
+func resolveFinalDEK(t *testing.T, dir string, cfg *config.EncryptionConfig, passphrase string, newProvider crypto.KeyProvider) []byte {
+	t.Helper()
+
+	kmOld := NewKeyManager(dir, cfg.DEKPath, cfg.SaltPath)
+	kmOld.SetKeyProvider(crypto.NewPasswordKeyProvider(passphrase, dir, cfg.SaltPath))
+	errOld := kmOld.Initialize(passphrase)
+
+	kmNew := NewKeyManager(dir, cfg.DEKPath, cfg.SaltPath)
+	kmNew.SetKeyProvider(newProvider)
+	errNew := kmNew.Initialize("")
+
+	switch {
+	case errOld == nil && errNew != nil:
+		return kmOld.GetDEK()
+	case errNew == nil && errOld != nil:
+		return kmNew.GetDEK()
+	case errOld == nil && errNew == nil:
+		t.Fatalf("both the old and new KEK providers unwrapped dek.key — expected exactly one to work")
+	default:
+		t.Fatalf("neither candidate provider could unwrap the final dek.key: old=%v new=%v", errOld, errNew)
+	}
+	return nil
+}

--- a/internal/encryption/keymanager_rewrap.go
+++ b/internal/encryption/keymanager_rewrap.go
@@ -8,6 +8,7 @@
 package encryption
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -46,6 +47,35 @@ func (km *KeyManager) RewrapDEK(newProvider crypto.KeyProvider) error {
 		return fmt.Errorf("re-wrap DEK: %s provider returned a %d-byte KEK, expected %d", newProvider.Name(), len(newKEK), crypto.KEKSize)
 	}
 
+	// #195: acquire the cross-process exclusive DEK lock before touching
+	// dek.key.pending at all, so this can never interleave with a concurrent
+	// RotateDEKWithSweep (or another RewrapDEK) running in a different
+	// process — both write to the same dek.key.pending → dek.key path.
+	lock, err := km.acquireExclusiveKeyLock()
+	if err != nil {
+		return fmt.Errorf("re-wrap DEK: %w", err)
+	}
+	defer lock.release()
+
+	// Mutual exclusion alone is not sufficient: km.currentDEK was captured
+	// whenever this process's own Initialize() ran, which may be long before
+	// this call and long before the lock above was even contended for. If a
+	// concurrent RotateDEKWithSweep replaced dek.key with a NEW DEK (and
+	// fully re-encrypted the database under it) in the meantime, our cached
+	// currentDEK is now stale — re-wrapping and promoting it would silently
+	// overwrite the freshly-rotated DEK with the superseded one, orphaning
+	// every row the rotation just re-encrypted. Re-read the on-disk DEK
+	// under the lock and compare it, byte-for-byte, against the snapshot
+	// taken when currentDEK was set: any difference means another process
+	// wrote dek.key since, so fail closed instead of clobbering it.
+	onDisk, err := securefiles.SafeReadFile(km.baseDir, km.dekPath)
+	if err != nil {
+		return fmt.Errorf("re-wrap DEK: re-read active DEK under lock: %w", err)
+	}
+	if !bytes.Equal(onDisk, km.dekSnapshot) {
+		return fmt.Errorf("re-wrap DEK: the on-disk DEK changed since this process started — a concurrent DEK rotation likely completed in the meantime, so the in-memory DEK here is stale. Aborting without writing to avoid discarding the newer key; re-run migrate-provider now that the rotation has finished")
+	}
+
 	wrapped, err := wrapKey(km.currentDEK, newKEK)
 	if err != nil {
 		return fmt.Errorf("re-wrap DEK: wrap DEK with new KEK: %w", err)
@@ -69,5 +99,6 @@ func (km *KeyManager) RewrapDEK(newProvider crypto.KeyProvider) error {
 	if err := securefiles.SyncDir(filepath.Dir(activePath)); err != nil {
 		return fmt.Errorf("re-wrap DEK: fsync key directory after promote: %w", err)
 	}
+	km.dekSnapshot = append([]byte(nil), wrapped...)
 	return nil
 }

--- a/internal/encryption/keymanager_rotation.go
+++ b/internal/encryption/keymanager_rotation.go
@@ -33,6 +33,21 @@ func (km *KeyManager) RotateDEKWithSweep(passphrase string, sweepFn func(oldSvc,
 		return fmt.Errorf("key manager not initialized — cannot rotate")
 	}
 
+	// #195/baseline: acquire the same cross-process exclusive DEK lock as
+	// RewrapDEK. Prior to this fix RotateDEKWithSweep held no cross-process
+	// lock at all (the #92 fix that added one lives only on an unmerged
+	// branch) — a concurrent RewrapDEK/RewrapDEKWithProvider (`migrate-
+	// provider`) racing this rotation could read the DEK being replaced here
+	// and, if its rename landed after this one's, silently overwrite the
+	// freshly-rotated (and now fully re-encrypted-into) DEK with the
+	// superseded one. Both operations write to the same
+	// dek.key.pending → dek.key path, so they must be mutually exclusive.
+	lock, err := km.acquireExclusiveKeyLock()
+	if err != nil {
+		return fmt.Errorf("rotate DEK: %w", err)
+	}
+	defer lock.release()
+
 	kek, err := km.deriveKEK(passphrase)
 	if err != nil {
 		return fmt.Errorf("failed to derive KEK for DEK rotation: %w", err)
@@ -91,6 +106,7 @@ func (km *KeyManager) RotateDEKWithSweep(passphrase string, sweepFn func(oldSvc,
 
 	wipeBytes(km.currentDEK)
 	km.currentDEK = newDEK
+	km.dekSnapshot = append([]byte(nil), wrapped...)
 	km.keyVersion = newKeyVersion
 	km.deleteBackupFiles()
 
@@ -166,6 +182,7 @@ func (km *KeyManager) RotateDEK(passphrase string) error {
 
 	wipeBytes(km.currentDEK)
 	km.currentDEK = newDEK
+	km.dekSnapshot = append([]byte(nil), wrapped...)
 	km.keyVersion = fmt.Sprintf("v%d", time.Now().Unix())
 
 	fmt.Printf("✅ DEK rotated successfully. New version: %s\n", km.keyVersion)


### PR DESCRIPTION
Replaces #561 (that PR's head branch had to be deleted/recreated during a rebase in this environment, which GitHub does not allow reopening after).

Rebased onto current main unchanged — no overlap with anything merged since.

RewrapDEK/RewrapDEKWithProvider (`keyorix encryption migrate-provider`) never participated in any cross-process locking, and RotateDEKWithSweep (`keyorix encryption rotate`) has none on main either. Both write to the same dek.key.pending -> dek.key path from independent, short-lived CLI processes, so a concurrent rotate + migrate-provider could silently overwrite a freshly re-encrypted DEK with a superseded one — permanently orphaning the database's ciphertext.

Adds a per-operation flock(2) exclusive lock on a dedicated dek.key.lock file, held for the duration of each operation's critical section. RewrapDEK additionally re-reads the on-disk DEK under the lock and compares it against a snapshot taken when it was last loaded, aborting instead of clobbering if another process changed it in the meantime.

Note on scope vs #526 (still open, separate PR): that PR adds a *different*, complementary lock — server-lifetime coordination between a live server process and DEK rotation (ADR-010/#92, file `dek.lock`, Service-level, non-blocking refuse-if-held). This PR guards the two *CLI-only* operations (rotate vs migrate-provider) against each other (file `dek.key.lock`, KeyManager-level, blocking wait). Neither supersedes the other; both are needed and use distinct lock files so they can coexist.