### PR TITLE
fix(grpc): mirror HTTP's role Name/Description length bounds (#191)

### DIFF
--- a/server/grpc/services/role_service.go
+++ b/server/grpc/services/role_service.go
@@ -12,6 +12,18 @@ import (
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
+// Role Name/Description length bounds. gRPC has no shared internal/core
+// validation layer to inherit these from (unlike other resources), so they
+// are mirrored here exactly from the HTTP-side struct tags in
+// server/http/handlers/rbac.go (CreateRoleRequest/UpdateRoleRequest) to keep
+// the two transports' accepted input identical (#191).
+const (
+	roleNameMinLen        = 3
+	roleNameMaxLen        = 50
+	roleDescriptionMinLen = 1
+	roleDescriptionMaxLen = 200
+)
+
 // RoleGRPCService implements pb.RoleServiceServer, backing each RPC with the
 // shared core service (role CRUD + permission wiring via storage, reads via the
 // core RBAC helpers).
@@ -37,8 +49,14 @@ func (s *RoleGRPCService) CreateRole(ctx context.Context, req *pb.CreateRoleRequ
 	if err := authorizeGlobal(ctx, s.core, actor, "roles.write"); err != nil {
 		return nil, err
 	}
-	if req.GetName() == "" || req.GetDescription() == "" || len(req.GetPermissions()) == 0 {
-		return nil, status.Error(codes.InvalidArgument, "name, description and at least one permission are required")
+	if len(req.GetPermissions()) == 0 {
+		return nil, status.Error(codes.InvalidArgument, "at least one permission is required")
+	}
+	if err := validateRoleName(req.GetName()); err != nil {
+		return nil, err
+	}
+	if err := validateRoleDescription(req.GetDescription()); err != nil {
+		return nil, err
 	}
 	// #294: reserved role names must never be creatable — see the identical guard (with
 	// full rationale) in the HTTP RBACHandler.CreateRole. This closes the same gap over
@@ -91,6 +109,11 @@ func (s *RoleGRPCService) UpdateRole(ctx context.Context, req *pb.UpdateRoleRequ
 	}
 	if req.GetId() == 0 {
 		return nil, status.Error(codes.InvalidArgument, "id is required")
+	}
+	if req.Description != nil {
+		if err := validateRoleDescription(req.GetDescription()); err != nil {
+			return nil, err
+		}
 	}
 
 	role, current, err := s.core.GetRoleWithPermissions(ctx, uint(req.GetId()))
@@ -339,6 +362,25 @@ func permissionToProto(p *models.Permission) *pb.Permission {
 		Resource:    p.Resource,
 		Action:      p.Action,
 	}
+}
+
+// validateRoleName mirrors HTTP's CreateRoleRequest.Name `min=3,max=50` bound
+// (server/http/handlers/rbac.go) so a role name accepted over gRPC is never
+// shorter/longer than one accepted over HTTP (#191).
+func validateRoleName(name string) error {
+	if len(name) < roleNameMinLen || len(name) > roleNameMaxLen {
+		return status.Errorf(codes.InvalidArgument, "name must be between %d and %d characters", roleNameMinLen, roleNameMaxLen)
+	}
+	return nil
+}
+
+// validateRoleDescription mirrors HTTP's Role Description `min=1,max=200`
+// bound (server/http/handlers/rbac.go) for the same reason (#191).
+func validateRoleDescription(description string) error {
+	if len(description) < roleDescriptionMinLen || len(description) > roleDescriptionMaxLen {
+		return status.Errorf(codes.InvalidArgument, "description must be between %d and %d characters", roleDescriptionMinLen, roleDescriptionMaxLen)
+	}
+	return nil
 }
 
 // mapRoleError translates core/storage role errors into gRPC status codes.

--- a/server/grpc/services/role_service_test.go
+++ b/server/grpc/services/role_service_test.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/keyorixhq/keyorix/internal/storage/models"
@@ -76,10 +77,57 @@ func TestRoleService_CreateRole_MissingFields(t *testing.T) {
 	assert.Equal(t, codes.InvalidArgument, status.Code(err))
 }
 
+// TestRoleService_CreateRole_NameTooShort mirrors HTTP's CreateRoleRequest.Name
+// `min=3` bound (server/http/handlers/rbac.go) — gRPC must reject the same
+// input HTTP would (#191).
+func TestRoleService_CreateRole_NameTooShort(t *testing.T) {
+	svc, h := newRoleService(t)
+	_, err := svc.CreateRole(roleAdminCtx(), &pb.CreateRoleRequest{
+		Name: "ab", Description: "a valid description", Permissions: []string{somePermission(t, h)},
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
+// TestRoleService_CreateRole_NameTooLong mirrors HTTP's `max=50` bound (#191).
+func TestRoleService_CreateRole_NameTooLong(t *testing.T) {
+	svc, h := newRoleService(t)
+	_, err := svc.CreateRole(roleAdminCtx(), &pb.CreateRoleRequest{
+		Name: strings.Repeat("a", 51), Description: "a valid description", Permissions: []string{somePermission(t, h)},
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
+// TestRoleService_CreateRole_DescriptionTooLong mirrors HTTP's
+// `max=200` bound on Description (#191).
+func TestRoleService_CreateRole_DescriptionTooLong(t *testing.T) {
+	svc, h := newRoleService(t)
+	_, err := svc.CreateRole(roleAdminCtx(), &pb.CreateRoleRequest{
+		Name: "valid-role-name", Description: strings.Repeat("d", 201), Permissions: []string{somePermission(t, h)},
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
+func TestRoleService_UpdateRole_DescriptionTooLong(t *testing.T) {
+	svc, h := newRoleService(t)
+	created, err := svc.CreateRole(roleAdminCtx(), &pb.CreateRoleRequest{
+		Name: "u-role-len", Description: "old", Permissions: []string{somePermission(t, h)},
+	})
+	require.NoError(t, err)
+
+	_, err = svc.UpdateRole(roleAdminCtx(), &pb.UpdateRoleRequest{
+		Id: created.GetId(), Description: strPtr(strings.Repeat("d", 201)),
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
 func TestRoleService_CreateRole_UnknownPermission(t *testing.T) {
 	svc, _ := newRoleService(t)
 	_, err := svc.CreateRole(roleAdminCtx(), &pb.CreateRoleRequest{
-		Name: "x", Description: "y", Permissions: []string{"does.not.exist"},
+		Name: "unknown-perm-role", Description: "y", Permissions: []string{"does.not.exist"},
 	})
 	require.Error(t, err)
 	assert.Equal(t, codes.InvalidArgument, status.Code(err))


### PR DESCRIPTION
Rebase of #572 onto current main. That PR's first commit (#169 CRITICAL — require the actor already hold a permission before bundling it into a role) had already landed on main independently (\`AssignPermissionToRole\`/\`resolvePermissionIDs\` already carry the self-permission check). Dropped that commit via \`git rebase --onto\` and kept only the second commit, #191, rebased cleanly on top of main's existing #169 fix.

#191: gRPC's CreateRole/UpdateRole call \`s.core.Storage().CreateRole(...)\` directly with no core.CreateRole business-logic wrapper to inherit validation from, so they only checked non-empty — a 1-character name or an unbounded description was accepted over gRPC while HTTP's validator tags (min=3,max=50 / min=1,max=200) reject the same input. Mirrors the exact HTTP-side bounds in the gRPC handler.

Verified locally: `go build ./...`, `go build ./server`, `go test ./...`, `gosec -severity medium -exclude-generated ./...`, `cd operator && GOWORK=off go build ./...` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)