### PR TITLE
harden(sso): SSO/OIDC bundle — #96, #100 (lower bound), #102, #127

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -371,6 +371,11 @@ type OIDCIssuerConfig struct {
 	Issuer    string   `yaml:"issuer"`    // must equal the JWT `iss` exactly
 	JWKSURI   string   `yaml:"jwks_uri"`  // where the issuer's signing keys live
 	Audiences []string `yaml:"audiences"` // the JWT `aud` must contain one of these
+	// MaxTokenAgeSeconds bounds (now - iat) for a token from this issuer; unset/0
+	// uses a 24h default. exp alone doesn't bound how long ago a token was
+	// minted, so without this a far-future-exp token (misconfigured or
+	// malicious issuer) would verify indefinitely.
+	MaxTokenAgeSeconds int `yaml:"max_token_age_seconds"`
 }
 
 // GetAPIKey returns the resolved API key, preferring the environment variable.

--- a/internal/core/oidc.go
+++ b/internal/core/oidc.go
@@ -20,6 +20,21 @@ import (
 // oidcClockSkew is the leeway allowed on exp/nbf to tolerate small clock drift.
 const oidcClockSkew = 60 * time.Second
 
+// defaultOIDCMaxTokenAge bounds how old (now - iat) a federated token may be when
+// an issuer doesn't configure its own ceiling. exp alone doesn't bound this: a
+// token minted with a far-future exp (misconfigured or malicious issuer/CI
+// pipeline) would otherwise verify — and be replayable — for as long as that exp,
+// regardless of how long ago it was actually issued.
+const defaultOIDCMaxTokenAge = 24 * time.Hour
+
+// oidcClaims extends the JWT registered claims with azp (authorized party) — an
+// OIDC-specific claim not in the RFC 7519 registered set, needed to disambiguate
+// a multi-audience token's intended recipient.
+type oidcClaims struct {
+	jwt.RegisteredClaims
+	Azp string `json:"azp,omitempty"`
+}
+
 // JWKSResolver returns the public signing key for an (issuer, kid). The
 // production implementation fetches and caches the issuer's JWKS; tests inject a
 // static key.
@@ -28,25 +43,33 @@ type JWKSResolver interface {
 }
 
 // OIDCTrustedIssuer is one operator-configured issuer the verifier will accept.
+// MaxTokenAge bounds (now - iat); zero uses defaultOIDCMaxTokenAge.
 type OIDCTrustedIssuer struct {
-	Issuer    string
-	Audiences []string
+	Issuer      string
+	Audiences   []string
+	MaxTokenAge time.Duration
+}
+
+type oidcIssuerTrust struct {
+	audiences map[string]struct{}
+	maxAge    time.Duration
 }
 
 // OIDCVerifier verifies federated JWTs against an operator-curated set of
 // trusted issuers. It is pure token logic — no storage — so it is unit-testable
 // with a generated key and no network.
 type OIDCVerifier struct {
-	issuers map[string]map[string]struct{} // issuer -> set of allowed audiences
+	issuers map[string]oidcIssuerTrust
 	jwks    JWKSResolver
 	leeway  time.Duration
+	now     func() time.Time
 }
 
 // NewOIDCVerifier builds a verifier over the trusted issuers. An issuer with no
 // configured audiences is rejected at build time — audience binding is required
 // (fail closed), since an unaudienced token is replayable across services.
 func NewOIDCVerifier(issuers []OIDCTrustedIssuer, jwks JWKSResolver) (*OIDCVerifier, error) {
-	m := make(map[string]map[string]struct{}, len(issuers))
+	m := make(map[string]oidcIssuerTrust, len(issuers))
 	for _, iss := range issuers {
 		if strings.TrimSpace(iss.Issuer) == "" {
 			return nil, fmt.Errorf("oidc: an issuer entry has an empty issuer URL")
@@ -63,9 +86,13 @@ func NewOIDCVerifier(issuers []OIDCTrustedIssuer, jwks JWKSResolver) (*OIDCVerif
 		if len(auds) == 0 {
 			return nil, fmt.Errorf("oidc: issuer %q has no usable audiences after filtering empty values — configure at least one non-empty audience", iss.Issuer)
 		}
-		m[iss.Issuer] = auds
+		maxAge := iss.MaxTokenAge
+		if maxAge <= 0 {
+			maxAge = defaultOIDCMaxTokenAge
+		}
+		m[iss.Issuer] = oidcIssuerTrust{audiences: auds, maxAge: maxAge}
 	}
-	return &OIDCVerifier{issuers: m, jwks: jwks, leeway: oidcClockSkew}, nil
+	return &OIDCVerifier{issuers: m, jwks: jwks, leeway: oidcClockSkew, now: time.Now}, nil
 }
 
 // Verify checks the JWT's signature against the issuer's JWKS and validates
@@ -73,7 +100,7 @@ func NewOIDCVerifier(issuers []OIDCTrustedIssuer, jwks JWKSResolver) (*OIDCVerif
 // returns the (issuer, subject) on success. Asymmetric algorithms only — HMAC
 // is rejected so a leaked JWKS document can never be used to forge tokens.
 func (v *OIDCVerifier) Verify(ctx context.Context, raw string) (issuer, subject string, err error) {
-	var claims jwt.RegisteredClaims
+	var claims oidcClaims
 	parser := jwt.NewParser(
 		jwt.WithValidMethods([]string{"RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512"}),
 		jwt.WithLeeway(v.leeway),
@@ -100,13 +127,13 @@ func (v *OIDCVerifier) Verify(ctx context.Context, raw string) (issuer, subject 
 		return "", "", fmt.Errorf("oidc token invalid")
 	}
 
-	auds, ok := v.issuers[claims.Issuer]
+	trust, ok := v.issuers[claims.Issuer]
 	if !ok {
 		return "", "", fmt.Errorf("untrusted issuer")
 	}
 	audOK := false
 	for _, a := range claims.Audience {
-		if _, ok := auds[a]; ok {
+		if _, ok := trust.audiences[a]; ok {
 			audOK = true
 			break
 		}
@@ -114,8 +141,32 @@ func (v *OIDCVerifier) Verify(ctx context.Context, raw string) (issuer, subject 
 	if !audOK {
 		return "", "", fmt.Errorf("oidc token audience not allowed")
 	}
+	// A token naming MORE THAN ONE audience is, per OIDC, ambiguous about which
+	// party it was actually issued to — any one of the audiences matching our
+	// allowlist isn't enough, since a multi-tenant IdP could mint a token shared
+	// across several relying parties and an attacker holding a copy issued to a
+	// DIFFERENT (also-trusted) party could replay it here. azp (authorized party)
+	// disambiguates the true recipient and must itself be one of our trusted
+	// audiences.
+	if len(claims.Audience) > 1 {
+		if claims.Azp == "" {
+			return "", "", fmt.Errorf("oidc token has multiple audiences but no azp claim")
+		}
+		if _, ok := trust.audiences[claims.Azp]; !ok {
+			return "", "", fmt.Errorf("oidc token azp not allowed")
+		}
+	}
 	if strings.TrimSpace(claims.Subject) == "" {
 		return "", "", fmt.Errorf("oidc token has no subject")
+	}
+	// exp alone doesn't bound how long ago a token was minted — a far-future exp
+	// (misconfigured or malicious issuer) would otherwise verify indefinitely.
+	// Require iat and cap its age per-issuer.
+	if claims.IssuedAt == nil {
+		return "", "", fmt.Errorf("oidc token has no iat claim")
+	}
+	if age := v.now().Sub(claims.IssuedAt.Time); age > trust.maxAge+v.leeway {
+		return "", "", fmt.Errorf("oidc token exceeds max age (issued %s ago)", age.Round(time.Second))
 	}
 	return claims.Issuer, claims.Subject, nil
 }
@@ -172,9 +223,22 @@ func (c *KeyorixCore) ValidateOIDCToken(ctx context.Context, raw string) (*model
 // CreateOIDCBinding binds an external (issuer, subject) to a machine identity in
 // the given project. Audited; the machine must belong to the project (the
 // handler also gates roles.assign there).
+//
+// (issuer, subject) is a GLOBAL namespace — GetMachineByOIDCSubject / the token
+// verify path resolve it with no project scoping — but until this check, only
+// project-scoped authority (roles.assign within THAT project) was required to
+// claim a slice of it (#127). A project-A admin could pre-claim another team's
+// well-known, not-yet-bound subject (predictable per issuer, e.g. a Kubernetes
+// service-account or CI workflow identity) for their own machine; the victim
+// workload's genuine token would then authenticate as the attacker's machine
+// identity instead. Creating a binding is therefore gated on GLOBAL admin
+// authority, matching the scope of what it actually claims.
 func (c *KeyorixCore) CreateOIDCBinding(ctx context.Context, projectID, machineID uint, issuer, subject string, actorID uint) (*models.MachineIdentityOIDCBinding, error) {
 	if strings.TrimSpace(issuer) == "" || strings.TrimSpace(subject) == "" {
 		return nil, fmt.Errorf("issuer and subject are required")
+	}
+	if err := c.requireAuthorityForRole(ctx, actorID, 0, "system_admin"); err != nil {
+		return nil, fmt.Errorf("binding an OIDC subject requires install-wide admin authority: %w", err)
 	}
 	// Surface operator typos early: a binding to an issuer Keyorix doesn't trust
 	// would never authenticate (Verify rejects untrusted issuers independently),

--- a/internal/core/oidc_binding_test.go
+++ b/internal/core/oidc_binding_test.go
@@ -1,0 +1,56 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCreateOIDCBinding_RequiresGlobalAdminAuthority pins #127: (issuer, subject)
+// is a GLOBAL namespace — GetMachineByOIDCSubject and the token-verify path
+// resolve it with no project scoping — but binding creation previously required
+// only project-scoped authority (the machine's own project). A project-A admin
+// could pre-claim another team's well-known, not-yet-bound subject for their own
+// machine; the victim workload's genuine token would then authenticate as the
+// attacker's machine identity. Creating a binding must require GLOBAL admin
+// authority, not merely membership/admin rights within the machine's project.
+func TestCreateOIDCBinding_RequiresGlobalAdminAuthority(t *testing.T) {
+	ctx := context.Background()
+	machine := &models.MachineIdentity{ID: 5, ProjectID: 1, State: MachineActive}
+
+	t.Run("project-scoped admin (no global authority) is refused", func(t *testing.T) {
+		store := new(MockStorage)
+		c := NewKeyorixCore(store)
+		c.now = time.Now
+		store.On("GetMachineIdentity", ctx, uint(5)).Return(machine, nil)
+		// Actor 2 has NO role grants at global scope (project_id=0) — only within
+		// project 1, which requireAuthorityForRole(..., projectID=0, ...) never sees.
+		store.On("GetUserRoleIDsAt", ctx, uint(2), mock.MatchedBy(func(s interface{}) bool { return true })).Return([]uint{}, nil)
+
+		_, err := c.CreateOIDCBinding(ctx, 1, 5, "https://idp.test", "system:serviceaccount:victim:ci", 2)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "admin authority")
+		store.AssertNotCalled(t, "CreateOIDCBinding", mock.Anything, mock.Anything)
+	})
+
+	t.Run("global admin authority succeeds", func(t *testing.T) {
+		store := new(MockStorage)
+		c := NewKeyorixCore(store)
+		c.now = time.Now
+		store.On("GetMachineIdentity", ctx, uint(5)).Return(machine, nil)
+		store.On("GetRoleByName", ctx, mock.Anything).Return(&models.Role{ID: 99, Name: "system_admin"}, nil)
+		store.On("GetUserRoleIDsAt", ctx, uint(1), mock.Anything).Return([]uint{99}, nil)
+		store.On("CreateOIDCBinding", ctx, mock.MatchedBy(func(b *models.MachineIdentityOIDCBinding) bool {
+			return b.MachineIdentityID == 5 && b.Issuer == "https://idp.test" && b.Subject == "system:serviceaccount:victim:ci"
+		})).Return(&models.MachineIdentityOIDCBinding{ID: 1, MachineIdentityID: 5}, nil)
+		store.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
+
+		b, err := c.CreateOIDCBinding(ctx, 1, 5, "https://idp.test", "system:serviceaccount:victim:ci", 1)
+		require.NoError(t, err)
+		require.NotNil(t, b)
+	})
+}

--- a/internal/core/oidc_cross_issuer_test.go
+++ b/internal/core/oidc_cross_issuer_test.go
@@ -63,6 +63,7 @@ func TestValidateOIDCToken_CrossIssuerBindingIsolation(t *testing.T) {
 	claims := func(iss string) jwt.MapClaims {
 		return jwt.MapClaims{
 			"iss": iss, "sub": subject, "aud": []string{"keyorix"},
+			"iat": time.Now().Unix(),
 			"exp": time.Now().Add(time.Hour).Unix(),
 		}
 	}

--- a/internal/core/oidc_jwks.go
+++ b/internal/core/oidc_jwks.go
@@ -58,7 +58,16 @@ const maxJWKSKeys = 50
 // a sustained DoS. 8192 bits comfortably exceeds any real-world RSA key size in
 // production use (2048/3072/4096 are standard; NIST's own long-term guidance
 // tops out at 15360) while still rejecting a maliciously oversized modulus.
-const maxRSABits = 8192
+//
+// minRSABits (#100) is the missing lower bound: without it, a compromised or
+// MITM'd issuer could serve a trivially-weak key (e.g. 512 bits) that parses
+// and caches fine but offers no real cryptographic assurance — the check above
+// only ever guarded against a DoS-oversized key, never an undersized one. 2048
+// is the practical minimum still considered acceptable for a signing key today.
+const (
+	maxRSABits = 8192
+	minRSABits = 2048
+)
 
 // jwksStaleGrace bounds how far PAST the TTL a cached key set may still be served
 // as a fallback when a JWKS refetch fails transiently. Without a bound, a key the
@@ -286,8 +295,8 @@ func parseJWK(k jwk) (interface{}, error) {
 		if err != nil {
 			return nil, err
 		}
-		if n.BitLen() > maxRSABits {
-			return nil, fmt.Errorf("rsa modulus too large: %d bits exceeds %d-bit limit", n.BitLen(), maxRSABits)
+		if bits := n.BitLen(); bits < minRSABits || bits > maxRSABits {
+			return nil, fmt.Errorf("rsa modulus size %d bits outside allowed range [%d,%d]", bits, minRSABits, maxRSABits)
 		}
 		eBytes, err := base64.RawURLEncoding.DecodeString(k.E)
 		if err != nil {

--- a/internal/core/oidc_jwks_test.go
+++ b/internal/core/oidc_jwks_test.go
@@ -182,7 +182,7 @@ func TestParseJWK_RejectsOversizedRSAModulus(t *testing.T) {
 	got, err := parseJWK(k)
 	require.Error(t, err, "an oversized RSA modulus must be rejected")
 	assert.Nil(t, got)
-	assert.Contains(t, err.Error(), "too large")
+	assert.Contains(t, err.Error(), "outside allowed range")
 }
 
 // A JWKS response containing an oversized RSA key must not be cached or served: the
@@ -227,4 +227,57 @@ func TestNewHTTPJWKSResolver_RejectsInsecureScheme(t *testing.T) {
 		_, err = NewHTTPJWKSResolver(map[string]string{"https://iss": uri})
 		require.NoErrorf(t, err, "loopback %s should be allowed", uri)
 	}
+}
+
+// syntheticRSAModulus fabricates a big.Int of the given bit length (top bit set)
+// for boundary testing — parseJWK only inspects structural size, so this doesn't
+// need to be a real, factorable RSA modulus.
+func syntheticRSAModulus(bits int) *big.Int {
+	n := new(big.Int).Lsh(big.NewInt(1), uint(bits-1))
+	return n.SetBit(n, 0, 1) // odd, so it round-trips through byte encoding cleanly
+}
+
+// TestParseJWK_RejectsRSAModulusOutOfRange pins #100: an unbounded RSA modulus
+// lets a compromised/MITM'd issuer serve a pathological (e.g. ~8M-bit) signing
+// key — cached and reused for every subsequent token from that kid — turning
+// each signature verification into a multi-second modexp (CPU-DoS amplifier).
+func TestParseJWK_RejectsRSAModulusOutOfRange(t *testing.T) {
+	tooSmall := jwk{Kty: "RSA", Kid: "small", N: base64.RawURLEncoding.EncodeToString(syntheticRSAModulus(1024).Bytes()), E: "AQAB"}
+	_, err := parseJWK(tooSmall)
+	require.ErrorContains(t, err, "outside allowed range")
+
+	tooBig := jwk{Kty: "RSA", Kid: "big", N: base64.RawURLEncoding.EncodeToString(syntheticRSAModulus(1 << 20).Bytes()), E: "AQAB"}
+	_, err = parseJWK(tooBig)
+	require.ErrorContains(t, err, "outside allowed range")
+
+	// A real, in-range key still parses fine.
+	key, _ := rsa.GenerateKey(rand.Reader, 2048)
+	ok := jwk{Kty: "RSA", Kid: "ok",
+		N: base64.RawURLEncoding.EncodeToString(key.PublicKey.N.Bytes()),
+		E: base64.RawURLEncoding.EncodeToString(big.NewInt(int64(key.PublicKey.E)).Bytes())}
+	parsed, err := parseJWK(ok)
+	require.NoError(t, err)
+	require.IsType(t, &rsa.PublicKey{}, parsed)
+}
+
+// TestHTTPJWKSResolver_RejectsOversizedRSAKey confirms the size guard is wired
+// through the full fetch path: a JWKS whose only key has a pathological modulus
+// yields "no usable signing keys", not a cached, verifiable oversized key.
+func TestHTTPJWKSResolver_RejectsOversizedRSAKey(t *testing.T) {
+	huge := syntheticRSAModulus(1 << 20) // ~1M bits
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"keys": []map[string]string{{
+				"kty": "RSA", "kid": "huge", "use": "sig",
+				"n": base64.RawURLEncoding.EncodeToString(huge.Bytes()),
+				"e": "AQAB",
+			}},
+		})
+	}))
+	defer srv.Close()
+	r, err := NewHTTPJWKSResolver(map[string]string{"https://iss": srv.URL})
+	require.NoError(t, err)
+
+	_, err = r.Key(context.Background(), "https://iss", "huge")
+	require.ErrorContains(t, err, "no usable signing keys")
 }

--- a/internal/core/oidc_test.go
+++ b/internal/core/oidc_test.go
@@ -74,6 +74,7 @@ func TestOIDCVerify_Valid(t *testing.T) {
 		"iss": "https://k8s.local",
 		"sub": "system:serviceaccount:ci:deployer",
 		"aud": []string{"keyorix"},
+		"iat": time.Now().Unix(),
 		"exp": time.Now().Add(time.Hour).Unix(),
 	})
 	iss, sub, err := v.Verify(context.Background(), raw)
@@ -89,6 +90,7 @@ func TestOIDCVerify_Rejections(t *testing.T) {
 	base := func() jwt.MapClaims {
 		return jwt.MapClaims{
 			"iss": "https://k8s.local", "sub": "sa", "aud": []string{"keyorix"},
+			"iat": time.Now().Unix(),
 			"exp": time.Now().Add(time.Hour).Unix(),
 		}
 	}
@@ -141,6 +143,61 @@ func TestOIDCVerify_Rejections(t *testing.T) {
 		_, _, err = v.Verify(context.Background(), raw)
 		require.Error(t, err, "HMAC must be rejected (asymmetric only)")
 	})
+
+	// #102: exp alone doesn't bound how long ago a token was minted — a
+	// far-future exp (misconfigured or malicious issuer) must not verify
+	// indefinitely just because it hasn't expired yet.
+	t.Run("missing iat rejected", func(t *testing.T) {
+		c := base()
+		delete(c, "iat")
+		_, _, err := v.Verify(context.Background(), signToken(t, key, "kid-1", c))
+		require.ErrorContains(t, err, "iat")
+	})
+
+	t.Run("stale iat beyond max age rejected despite a still-valid, far-future exp", func(t *testing.T) {
+		c := base()
+		c["iat"] = time.Now().Add(-48 * time.Hour).Unix() // exceeds defaultOIDCMaxTokenAge (24h)
+		c["exp"] = time.Now().Add(10 * 365 * 24 * time.Hour).Unix()
+		_, _, err := v.Verify(context.Background(), signToken(t, key, "kid-1", c))
+		require.ErrorContains(t, err, "max age")
+	})
+
+	t.Run("iat within max age accepted", func(t *testing.T) {
+		c := base()
+		c["iat"] = time.Now().Add(-1 * time.Hour).Unix()
+		_, _, err := v.Verify(context.Background(), signToken(t, key, "kid-1", c))
+		require.NoError(t, err)
+	})
+
+	// #102: a multi-audience token is ambiguous about its intended recipient —
+	// azp must disambiguate and itself be trusted.
+	t.Run("multiple audiences without azp rejected", func(t *testing.T) {
+		c := base()
+		c["aud"] = []string{"keyorix", "some-other-trusted-service"}
+		_, _, err := v.Verify(context.Background(), signToken(t, key, "kid-1", c))
+		require.ErrorContains(t, err, "azp")
+	})
+
+	t.Run("multiple audiences with untrusted azp rejected", func(t *testing.T) {
+		c := base()
+		c["aud"] = []string{"keyorix", "some-other-trusted-service"}
+		c["azp"] = "some-other-trusted-service" // matches an audience, but not the one we expect to be the RP here
+		v2, err := NewOIDCVerifier(
+			[]OIDCTrustedIssuer{{Issuer: "https://k8s.local", Audiences: []string{"keyorix"}}}, // azp not in this issuer's trusted set
+			staticResolver{kid: "kid-1", key: &key.PublicKey},
+		)
+		require.NoError(t, err)
+		_, _, err = v2.Verify(context.Background(), signToken(t, key, "kid-1", c))
+		require.ErrorContains(t, err, "azp")
+	})
+
+	t.Run("multiple audiences with trusted azp accepted", func(t *testing.T) {
+		c := base()
+		c["aud"] = []string{"keyorix", "some-other-trusted-service"}
+		c["azp"] = "keyorix"
+		_, _, err := v.Verify(context.Background(), signToken(t, key, "kid-1", c))
+		require.NoError(t, err)
+	})
 }
 
 func TestValidateOIDCToken_ResolvesMachine(t *testing.T) {
@@ -156,6 +213,7 @@ func TestValidateOIDCToken_ResolvesMachine(t *testing.T) {
 
 	raw := signToken(t, key, "kid-1", jwt.MapClaims{
 		"iss": "https://k8s.local", "sub": "sa", "aud": []string{"keyorix"},
+		"iat": time.Now().Unix(),
 		"exp": time.Now().Add(time.Hour).Unix(),
 	})
 	m, roles, err := c.ValidateOIDCToken(context.Background(), raw)
@@ -168,6 +226,7 @@ func TestValidateOIDCToken_DisabledAndSuspended(t *testing.T) {
 	key, _ := rsa.GenerateKey(rand.Reader, 2048)
 	raw := signToken(t, key, "kid-1", jwt.MapClaims{
 		"iss": "https://k8s.local", "sub": "sa", "aud": []string{"keyorix"},
+		"iat": time.Now().Unix(),
 		"exp": time.Now().Add(time.Hour).Unix(),
 	})
 

--- a/internal/core/sso.go
+++ b/internal/core/sso.go
@@ -609,7 +609,7 @@ func (c *KeyorixCore) reconcileSSORoles(ctx context.Context, p *SSOProvider, use
 	// the point, since authorization here is rooted in the admin-configured
 	// GroupRoleMap and the verified IdP assertion, not in the user's own
 	// roles.assign-derived authority.
-	added, removed := 0, 0
+	added, removed, blocked := 0, 0, 0
 	for role := range managedRoles {
 		r, rerr := c.storage.GetRoleByName(ctx, role)
 		if rerr != nil {
@@ -617,6 +617,16 @@ func (c *KeyorixCore) reconcileSSORoles(ctx context.Context, p *SSOProvider, use
 		}
 		switch {
 		case desiredRoles[role] && !currentSet[role]:
+			// Refuse to grant an admin-tier role from an IdP group mapping (#96) —
+			// the same escalation-by-proxy guard reconcileSSOGroups already applies to
+			// admin-conferring GROUPS. GroupRoleMap is configured once by an admin, but
+			// IdP group membership is frequently self-service or governed by people
+			// who are not Keyorix admins, so a mapping intended for a routine role must
+			// not double as a path to global admin for anyone who can join the group.
+			if isAdminRoleName(role) {
+				blocked++
+				continue
+			}
 			if c.assignUserRoleSystemGrant(ctx, userID, userID, r.ID, Scope{}) == nil {
 				added++
 			}
@@ -626,9 +636,12 @@ func (c *KeyorixCore) reconcileSSORoles(ctx context.Context, p *SSOProvider, use
 			}
 		}
 	}
-	if added > 0 || removed > 0 {
-		c.writeAuditEvent(ctx, EventSSORolesSynced, actorPtr(userID), nil,
-			fmt.Sprintf("SSO role mapping via %s: user %d (+%d/-%d mapped role grants)", p.Name, userID, added, removed))
+	if added > 0 || removed > 0 || blocked > 0 {
+		msg := fmt.Sprintf("SSO role mapping via %s: user %d (+%d/-%d mapped role grants)", p.Name, userID, added, removed)
+		if blocked > 0 {
+			msg += fmt.Sprintf("; %d admin-tier role grant(s) refused (IdP group mapping cannot grant admin)", blocked)
+		}
+		c.writeAuditEvent(ctx, EventSSORolesSynced, actorPtr(userID), nil, msg)
 	}
 }
 

--- a/internal/core/sso_test.go
+++ b/internal/core/sso_test.go
@@ -402,9 +402,12 @@ func TestSyncSSORoles(t *testing.T) {
 		store.On("GetRoleByName", mock.Anything, "secrets_writer").Return(&models.Role{ID: 10, Name: "secrets_writer"}, nil)
 		store.On("GetRoleByName", mock.Anything, "system_auditor").Return(&models.Role{ID: 20, Name: "system_auditor"}, nil)
 		// RemoveUserRole's last-global-admin guard (unrelated to this test's role, but
-		// exercised on every removal) looks up the other install-admin role names too.
+		// exercised on every removal) looks up every install-admin role name
+		// (installAdminRoleNames: super_admin/admin/system_admin) to build the
+		// admin-role-ID set.
 		store.On("GetRoleByName", mock.Anything, "super_admin").Return(nil, assert.AnError)
 		store.On("GetRoleByName", mock.Anything, "admin").Return(nil, assert.AnError)
+		store.On("GetRoleByName", mock.Anything, "system_admin").Return(nil, assert.AnError)
 		store.On("AssignRole", mock.Anything, uint(7), uint(10), mock.Anything).Return(nil)
 		store.On("RemoveRole", mock.Anything, uint(7), uint(20), mock.Anything).Return(nil)
 		store.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)

--- a/internal/core/sso_test.go
+++ b/internal/core/sso_test.go
@@ -392,14 +392,14 @@ func TestReconcileSSOGroups_RefusesAdminGroupEscalation(t *testing.T) {
 func TestSyncSSORoles(t *testing.T) {
 	t.Run("authoritative over mapped roles only", func(t *testing.T) {
 		c, store, key, p := ssoTestCore(t)
-		p.GroupRoleMap = map[string]string{"keyorix-admins": "system_admin", "keyorix-auditors": "system_auditor"}
-		// IdP asserts only keyorix-admins → system_admin desired; system_auditor (mapped,
-		// not asserted) must be removed; system_viewer (NOT mapped) left alone.
-		raw := signToken(t, key, "kid-1", jwt.MapClaims{"groups": []string{"keyorix-admins"}})
+		p.GroupRoleMap = map[string]string{"keyorix-secrets-rw": "secrets_writer", "keyorix-auditors": "system_auditor"}
+		// IdP asserts only keyorix-secrets-rw → secrets_writer desired; system_auditor
+		// (mapped, not asserted) must be removed; system_viewer (NOT mapped) left alone.
+		raw := signToken(t, key, "kid-1", jwt.MapClaims{"groups": []string{"keyorix-secrets-rw"}})
 		store.On("GetUserRoles", mock.Anything, uint(7)).Return([]*models.Role{
 			{ID: 20, Name: "system_auditor"}, {ID: 30, Name: "system_viewer"},
 		}, nil)
-		store.On("GetRoleByName", mock.Anything, "system_admin").Return(&models.Role{ID: 10, Name: "system_admin"}, nil)
+		store.On("GetRoleByName", mock.Anything, "secrets_writer").Return(&models.Role{ID: 10, Name: "secrets_writer"}, nil)
 		store.On("GetRoleByName", mock.Anything, "system_auditor").Return(&models.Role{ID: 20, Name: "system_auditor"}, nil)
 		// RemoveUserRole's last-global-admin guard (unrelated to this test's role, but
 		// exercised on every removal) looks up the other install-admin role names too.
@@ -411,9 +411,28 @@ func TestSyncSSORoles(t *testing.T) {
 
 		c.syncSSORoles(context.Background(), p, 7, raw)
 
-		store.AssertCalled(t, "AssignRole", mock.Anything, uint(7), uint(10), mock.Anything)    // system_admin granted
+		store.AssertCalled(t, "AssignRole", mock.Anything, uint(7), uint(10), mock.Anything)    // secrets_writer granted
 		store.AssertCalled(t, "RemoveRole", mock.Anything, uint(7), uint(20), mock.Anything)    // system_auditor revoked
 		store.AssertNotCalled(t, "RemoveRole", mock.Anything, uint(7), uint(30), mock.Anything) // system_viewer (unmapped) untouched
+	})
+
+	// TestSyncSSORoles/refuses-to-grant-an-admin-tier-role pins #96: GroupRoleMap
+	// mapped a group directly to an admin-tier role with no guard (unlike
+	// reconcileSSOGroups's admin-conferring-GROUP check) — an IdP group that is
+	// frequently self-service or governed by non-Keyorix-admins could grant global
+	// admin to anyone who joins it. AssignRole must never be called for an
+	// admin-tier mapped role.
+	t.Run("refuses to grant an admin-tier role from a group mapping", func(t *testing.T) {
+		c, store, key, p := ssoTestCore(t)
+		p.GroupRoleMap = map[string]string{"keyorix-admins": "system_admin"}
+		raw := signToken(t, key, "kid-1", jwt.MapClaims{"groups": []string{"keyorix-admins"}})
+		store.On("GetUserRoles", mock.Anything, uint(7)).Return([]*models.Role{}, nil)
+		store.On("GetRoleByName", mock.Anything, "system_admin").Return(&models.Role{ID: 10, Name: "system_admin"}, nil)
+		store.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
+
+		c.syncSSORoles(context.Background(), p, 7, raw)
+
+		store.AssertNotCalled(t, "AssignRole", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 	})
 
 	t.Run("absent groups claim → no-op (never touches roles)", func(t *testing.T) {

--- a/server/main.go
+++ b/server/main.go
@@ -700,7 +700,10 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 		trusted := make([]core.OIDCTrustedIssuer, 0, len(oidc.Issuers))
 		jwksURIs := make(map[string]string, len(oidc.Issuers))
 		for _, iss := range oidc.Issuers {
-			trusted = append(trusted, core.OIDCTrustedIssuer{Issuer: iss.Issuer, Audiences: iss.Audiences})
+			trusted = append(trusted, core.OIDCTrustedIssuer{
+				Issuer: iss.Issuer, Audiences: iss.Audiences,
+				MaxTokenAge: time.Duration(iss.MaxTokenAgeSeconds) * time.Second,
+			})
 			jwksURIs[iss.Issuer] = iss.JWKSURI
 		}
 		resolver, rerr := core.NewHTTPJWKSResolver(jwksURIs)


### PR DESCRIPTION
Rebase of #530 onto current main, with #95 dropped (already fixed on main by an equivalent atomic conditional-DELETE, see internal/storage/store/local_sso.go's ConsumeSSOLoginState + TestConcurrency_ConsumeSSOLoginState_OnlyOneWins) and #100 narrowed to just its missing half (main already caps the RSA modulus at 8192 bits; it never had a LOWER bound, so a trivially-weak key was still accepted).

## Summary
- fix(sso): refuse to grant an admin-tier role from an IdP group mapping (#96) — re-applied onto main's newer `assignUserRoleSystemGrant` RBAC choke point (#616), not the old direct `storage.AssignRole` call this PR originally patched
- fix(oidc): add the missing RSA modulus lower bound (2048 bits) to JWKS parsing (#100) — main already had the upper bound (8192 bits); merged into one range check
- fix(oidc): require iat + cap token age; validate azp on multi-audience tokens (#102)
- fix(oidc): require global admin authority to create an OIDC binding (#127)

Also drops the now-duplicate replayMu hunk in internal/audit/siem/spool.go, and fixes two test/mock gaps surfaced by rebasing onto newer RBAC-choke-point code (an incomplete `GetRoleByName` mock for `guardLastGlobalAdmin`'s admin-role-ID lookup, and an oversized-RSA-modulus test's error-message assertion after consolidating the two range checks into one).

Supersedes #530.