### PR TITLE
fix: session refresh reuse-detection + WebAuthn clone-detection (#211, #212)

### DIFF
--- a/internal/core/auth.go
+++ b/internal/core/auth.go
@@ -112,11 +112,19 @@ func (c *KeyorixCore) mintSession(ctx context.Context, userID uint, userAgent, i
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate session token: %w", err)
 	}
+	// FamilyID starts a new lineage at login and is carried unchanged through every
+	// RefreshSession rotation, so a detected refresh-token reuse can revoke the whole
+	// chain in one shot (#211).
+	familyID, err := generateSecureToken()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate session family id: %w", err)
+	}
 	now := c.now()
 	expiresAt := now.Add(c.accessTTL())
 	session := &models.Session{
 		UserID:       userID,
 		SessionToken: token,
+		FamilyID:     familyID,
 		UserAgent:    userAgent,
 		IPAddress:    ip,
 		LastSeenAt:   &now,
@@ -161,18 +169,39 @@ func (c *KeyorixCore) Logout(ctx context.Context, token string) error {
 	return c.storage.DeleteSession(ctx, session.ID)
 }
 
+// EventSessionReuseDetected audits a refresh attempt against an already-rotated
+// session token (#211) — distinct from the generic "session not found" a caller
+// sees, since a rotated-away token is either a genuine refresh-token-reuse replay
+// (a standard OAuth compromise signal) or a benign concurrent-refresh race loser;
+// the DB alone cannot tell those apart, so both are treated as suspicious and the
+// whole session family is revoked.
+const EventSessionReuseDetected = "auth.session_reuse_detected" // #nosec G101 -- audit event type, not a credential
+
 // RefreshSession rotates an existing session to a new token with a fresh access
 // window. The access window may have lapsed — that is the normal silent-refresh
 // case — but refresh is refused once the session's absolute ceiling is reached, so
 // rotating the token can never extend a session indefinitely. The ceiling is
 // carried unchanged onto the new session, and the new access window is clamped so
 // it never overruns that ceiling.
+//
+// Rotation is atomic (RotateSession is a single DB transaction with a CAS guard —
+// #211): a replay of a token that has already been rotated away, or a race where
+// two concurrent refreshes target the same not-yet-rotated token, both surface here
+// as "lost the rotation" and are handled identically — audited distinctly from
+// ordinary expiry and the whole session family (every session descended from the
+// same login) is revoked, not just the one replayed row.
 func (c *KeyorixCore) RefreshSession(ctx context.Context, token string) (*models.Session, error) {
-	old, err := c.storage.GetSession(ctx, token)
+	old, err := c.storage.GetSessionAny(ctx, token)
 	if err != nil {
 		return nil, fmt.Errorf("session not found or expired")
 	}
 	now := c.now()
+	if old.RotatedAt != nil {
+		// The token maps to a session that was already rotated away by an earlier,
+		// successful refresh — a reuse of a stale refresh token.
+		c.handleSessionReuse(ctx, old)
+		return nil, fmt.Errorf("session not found or expired")
+	}
 	if old.AbsoluteExpiresAt != nil && !now.Before(*old.AbsoluteExpiresAt) {
 		// Past the hard ceiling — re-authentication required, not another refresh.
 		_ = c.storage.DeleteSession(ctx, old.ID)
@@ -208,21 +237,62 @@ func (c *KeyorixCore) RefreshSession(ctx context.Context, token string) (*models
 	if old.AbsoluteExpiresAt != nil && expiresAt.After(*old.AbsoluteExpiresAt) {
 		expiresAt = *old.AbsoluteExpiresAt
 	}
+	familyID := old.FamilyID
+	if familyID == "" {
+		// Legacy row minted before FamilyID existed — start a fresh lineage from here
+		// rather than leaving it empty (an empty FamilyID would otherwise group every
+		// legacy session together under family-wide revocation).
+		familyID, err = generateSecureToken()
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate token: %w", err)
+		}
+	}
 	session := &models.Session{
 		UserID:            old.UserID,
 		SessionToken:      newToken,
+		FamilyID:          familyID,
 		UserAgent:         old.UserAgent,
 		IPAddress:         old.IPAddress,
 		LastSeenAt:        &now,
 		ExpiresAt:         &expiresAt,
 		AbsoluteExpiresAt: old.AbsoluteExpiresAt,
 	}
-	created, err := c.storage.CreateSession(ctx, session)
+	created, won, err := c.storage.RotateSession(ctx, old.ID, session, now)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create session: %w", err)
+		return nil, fmt.Errorf("failed to rotate session: %w", err)
 	}
-	_ = c.storage.DeleteSession(ctx, old.ID)
+	if !won {
+		// Lost the CAS: a concurrent refresh of this exact token won first between
+		// our read and our write. Same signal as an out-of-band replay.
+		c.handleSessionReuse(ctx, old)
+		return nil, fmt.Errorf("session not found or expired")
+	}
 	return created, nil
+}
+
+// handleSessionReuse responds to a refresh attempt that targeted an already-rotated
+// session token (#211): audits it distinctly from ordinary "not found"/expiry, and
+// revokes every session descended from the same login (FamilyID) — not just the one
+// replayed row — mirroring standard OAuth refresh-token-family revocation. Each
+// revoked session's token hash is evicted from the HTTP auth cache immediately, so
+// the attacker's already-rotated descendant session (if any) stops authenticating on
+// the very next request rather than lingering for the cache TTL.
+func (c *KeyorixCore) handleSessionReuse(ctx context.Context, old *models.Session) {
+	uid := old.UserID
+	c.writeAuditEventFull(ctx, EventSessionReuseDetected, &uid, nil, nil, old.IPAddress,
+		fmt.Sprintf("refresh attempted with an already-rotated session token for user %d — revoking the session family", old.UserID))
+	if old.FamilyID == "" {
+		// Legacy row predating FamilyID — fall back to revoking just this one row.
+		_ = c.storage.DeleteSession(ctx, old.ID)
+		return
+	}
+	hashes, _ := c.storage.ListSessionTokenHashesByFamily(ctx, old.FamilyID)
+	_ = c.storage.DeleteSessionsByFamily(ctx, old.FamilyID)
+	for _, h := range hashes {
+		if h != "" {
+			c.invalidateTokenCache(h)
+		}
+	}
 }
 
 // ValidateSessionToken looks up a session token, checks expiry, and returns the user and

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -1198,6 +1198,35 @@ func (m *MockStorage) GetSession(ctx context.Context, token string) (*models.Ses
 	return args.Get(0).(*models.Session), args.Error(1)
 }
 
+func (m *MockStorage) GetSessionAny(ctx context.Context, token string) (*models.Session, error) {
+	args := m.Called(ctx, token)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.Session), args.Error(1)
+}
+
+func (m *MockStorage) RotateSession(ctx context.Context, oldID uint, newSession *models.Session, now time.Time) (*models.Session, bool, error) {
+	args := m.Called(ctx, oldID, newSession, now)
+	if args.Get(0) == nil {
+		return nil, args.Bool(1), args.Error(2)
+	}
+	return args.Get(0).(*models.Session), args.Bool(1), args.Error(2)
+}
+
+func (m *MockStorage) ListSessionTokenHashesByFamily(ctx context.Context, familyID string) ([]string, error) {
+	args := m.Called(ctx, familyID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]string), args.Error(1)
+}
+
+func (m *MockStorage) DeleteSessionsByFamily(ctx context.Context, familyID string) error {
+	args := m.Called(ctx, familyID)
+	return args.Error(0)
+}
+
 func (m *MockStorage) DeleteSession(ctx context.Context, id uint) error {
 	args := m.Called(ctx, id)
 	return args.Error(0)

--- a/internal/core/session_ttl_test.go
+++ b/internal/core/session_ttl_test.go
@@ -37,6 +37,20 @@ func captureCreatedSession(store *MockStorage) *models.Session {
 	return captured
 }
 
+// captureRotatedSession records the replacement session handed to RotateSession (so
+// the test can assert on the computed expiry fields) and reports the CAS a win,
+// echoing the same pointer back as "created". Use for RefreshSession success-path
+// tests; the old row's id must equal oldID for the mock to match.
+func captureRotatedSession(store *MockStorage, oldID uint) *models.Session {
+	captured := &models.Session{}
+	store.On("RotateSession", mock.Anything, oldID, mock.AnythingOfType("*models.Session"), mock.Anything).
+		Run(func(args mock.Arguments) {
+			*captured = *args.Get(2).(*models.Session)
+		}).
+		Return(captured, true, nil)
+	return captured
+}
+
 // mintSession with no absolute TTL configured stamps only the access window.
 func TestMintSession_AccessTTLOnly(t *testing.T) {
 	store := new(MockStorage)
@@ -94,36 +108,35 @@ func TestMintSession_DefaultAccessTTL(t *testing.T) {
 // session and starts a fresh access window. The old session is deleted.
 func TestRefreshSession_CarriesCeiling(t *testing.T) {
 	store := new(MockStorage)
-	captured := captureCreatedSession(store)
+	captured := captureRotatedSession(store, 7)
 	c := newSessionCore(store, 30*time.Minute, 12*time.Hour)
 
 	ceiling := sessionTestNow.Add(8 * time.Hour) // still within the window
 	oldExpiry := sessionTestNow.Add(-5 * time.Minute)
-	old := &models.Session{ID: 7, UserID: 1, SessionToken: "old", ExpiresAt: &oldExpiry, AbsoluteExpiresAt: &ceiling}
-	store.On("GetSession", mock.Anything, "old").Return(old, nil)
+	old := &models.Session{ID: 7, UserID: 1, SessionToken: "old", FamilyID: "fam-1", ExpiresAt: &oldExpiry, AbsoluteExpiresAt: &ceiling}
+	store.On("GetSessionAny", mock.Anything, "old").Return(old, nil)
 	store.On("GetUser", mock.Anything, uint(1)).Return(&models.User{ID: 1, IsActive: true, AccountState: AccountActive}, nil)
-	store.On("DeleteSession", mock.Anything, uint(7)).Return(nil)
 
 	out, err := c.RefreshSession(context.Background(), "old")
 	require.NoError(t, err)
 	require.NotEqual(t, "old", out.SessionToken, "token rotated")
+	require.Equal(t, "fam-1", captured.FamilyID, "family id carried unchanged")
 	require.Equal(t, sessionTestNow.Add(30*time.Minute), *captured.ExpiresAt, "fresh access window")
 	require.NotNil(t, captured.AbsoluteExpiresAt)
 	require.Equal(t, ceiling, *captured.AbsoluteExpiresAt, "ceiling unchanged")
-	store.AssertCalled(t, "DeleteSession", mock.Anything, uint(7))
+	store.AssertCalled(t, "RotateSession", mock.Anything, uint(7), mock.Anything, mock.Anything)
 }
 
 // The last access window before the ceiling is clamped so it cannot overrun it.
 func TestRefreshSession_ClampsLastWindowToCeiling(t *testing.T) {
 	store := new(MockStorage)
-	captured := captureCreatedSession(store)
+	captured := captureRotatedSession(store, 7)
 	c := newSessionCore(store, 30*time.Minute, 12*time.Hour)
 
 	ceiling := sessionTestNow.Add(10 * time.Minute) // less than one access window away
 	old := &models.Session{ID: 7, UserID: 1, SessionToken: "old", AbsoluteExpiresAt: &ceiling}
-	store.On("GetSession", mock.Anything, "old").Return(old, nil)
+	store.On("GetSessionAny", mock.Anything, "old").Return(old, nil)
 	store.On("GetUser", mock.Anything, uint(1)).Return(&models.User{ID: 1, IsActive: true, AccountState: AccountActive}, nil)
-	store.On("DeleteSession", mock.Anything, uint(7)).Return(nil)
 
 	_, err := c.RefreshSession(context.Background(), "old")
 	require.NoError(t, err)
@@ -138,7 +151,7 @@ func TestRefreshSession_RefusedPastCeiling(t *testing.T) {
 
 	ceiling := sessionTestNow.Add(-1 * time.Minute) // already past
 	old := &models.Session{ID: 7, UserID: 1, SessionToken: "old", AbsoluteExpiresAt: &ceiling}
-	store.On("GetSession", mock.Anything, "old").Return(old, nil)
+	store.On("GetSessionAny", mock.Anything, "old").Return(old, nil)
 	store.On("DeleteSession", mock.Anything, uint(7)).Return(nil)
 
 	_, err := c.RefreshSession(context.Background(), "old")
@@ -157,7 +170,7 @@ func TestRefreshSession_RefusesImpersonationSession(t *testing.T) {
 
 	admin := uint(9)
 	old := &models.Session{ID: 7, UserID: 1, SessionToken: "imp", ImpersonatedBy: &admin}
-	store.On("GetSession", mock.Anything, "imp").Return(old, nil)
+	store.On("GetSessionAny", mock.Anything, "imp").Return(old, nil)
 
 	_, err := c.RefreshSession(context.Background(), "imp")
 	require.Error(t, err)
@@ -168,13 +181,12 @@ func TestRefreshSession_RefusesImpersonationSession(t *testing.T) {
 // With no ceiling (legacy behaviour) a session refreshes indefinitely.
 func TestRefreshSession_NoCeilingRefreshesForever(t *testing.T) {
 	store := new(MockStorage)
-	captured := captureCreatedSession(store)
+	captured := captureRotatedSession(store, 7)
 	c := newSessionCore(store, 24*time.Hour, 0)
 
 	old := &models.Session{ID: 7, UserID: 1, SessionToken: "old"} // AbsoluteExpiresAt nil
-	store.On("GetSession", mock.Anything, "old").Return(old, nil)
+	store.On("GetSessionAny", mock.Anything, "old").Return(old, nil)
 	store.On("GetUser", mock.Anything, uint(1)).Return(&models.User{ID: 1, IsActive: true, AccountState: AccountActive}, nil)
-	store.On("DeleteSession", mock.Anything, uint(7)).Return(nil)
 
 	_, err := c.RefreshSession(context.Background(), "old")
 	require.NoError(t, err)
@@ -201,7 +213,7 @@ func TestRefreshSession_RefusedForInactiveOrBlockedAccount(t *testing.T) {
 
 			ceiling := sessionTestNow.Add(8 * time.Hour) // still within the window
 			old := &models.Session{ID: 7, UserID: 1, SessionToken: "old", AbsoluteExpiresAt: &ceiling}
-			store.On("GetSession", mock.Anything, "old").Return(old, nil)
+			store.On("GetSessionAny", mock.Anything, "old").Return(old, nil)
 			store.On("GetUser", mock.Anything, uint(1)).Return(tc.user, nil)
 			store.On("DeleteSession", mock.Anything, uint(7)).Return(nil)
 
@@ -257,4 +269,63 @@ func TestValidateSessionToken_AbsoluteCeilingEnforcedAtBoundary(t *testing.T) {
 		require.Equal(t, uint(2), user.ID)
 		require.Equal(t, []string{"viewer"}, roles)
 	})
+}
+
+// A replay of an already-rotated session token (#211) must be detected distinctly
+// from ordinary "not found"/expiry — audited as a reuse event, with the whole
+// session family (every session descended from the same login) revoked, not just
+// silently treated as an unknown token. The client-facing error stays the generic
+// "not found or expired" (no oracle distinguishing reuse from a garbage token).
+func TestRefreshSession_ReplayOfRotatedTokenDetectedAndFamilyRevoked(t *testing.T) {
+	store := new(MockStorage)
+	c := newSessionCore(store, 30*time.Minute, 0)
+
+	rotatedAt := sessionTestNow.Add(-time.Minute)
+	old := &models.Session{ID: 7, UserID: 1, SessionToken: "stale", FamilyID: "fam-1", RotatedAt: &rotatedAt, IPAddress: "203.0.113.5"}
+	store.On("GetSessionAny", mock.Anything, "stale").Return(old, nil)
+	store.On("ListSessionTokenHashesByFamily", mock.Anything, "fam-1").Return([]string{"hash-a", "hash-b"}, nil)
+	store.On("DeleteSessionsByFamily", mock.Anything, "fam-1").Return(nil)
+	var loggedType string
+	store.On("LogAuditEvent", mock.Anything, mock.AnythingOfType("*models.AuditEvent")).
+		Run(func(args mock.Arguments) { loggedType = args.Get(1).(*models.AuditEvent).EventType }).
+		Return(nil)
+
+	_, err := c.RefreshSession(context.Background(), "stale")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not found or expired", "the client-facing error stays generic (no oracle)")
+	require.Equal(t, EventSessionReuseDetected, loggedType, "a reuse of an already-rotated token must be audited distinctly")
+	store.AssertCalled(t, "DeleteSessionsByFamily", mock.Anything, "fam-1")
+	store.AssertNotCalled(t, "CreateSession", mock.Anything, mock.Anything)
+	store.AssertNotCalled(t, "RotateSession", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+}
+
+// A concurrent-refresh race — two refreshes of the SAME not-yet-rotated token,
+// racing the atomic RotateSession CAS — must let only ONE succeed (#211). The
+// loser is treated exactly like a reuse-of-an-already-rotated-token replay: audited
+// distinctly and the session family revoked, so it can't silently mint a second
+// live session from one token use.
+func TestRefreshSession_LosingRotationRaceIsTreatedAsReuse(t *testing.T) {
+	store := new(MockStorage)
+	c := newSessionCore(store, 30*time.Minute, 0)
+
+	old := &models.Session{ID: 7, UserID: 1, SessionToken: "old", FamilyID: "fam-1"}
+	store.On("GetSessionAny", mock.Anything, "old").Return(old, nil)
+	store.On("GetUser", mock.Anything, uint(1)).Return(&models.User{ID: 1, IsActive: true, AccountState: AccountActive}, nil)
+	// The CAS in RotateSession is what a concurrent racer already won — this call
+	// reports the loss (won=false, created=nil), exactly like the local_auth.go
+	// implementation would when another goroutine's UPDATE already flipped
+	// rotated_at first.
+	store.On("RotateSession", mock.Anything, uint(7), mock.AnythingOfType("*models.Session"), mock.Anything).
+		Return(nil, false, nil)
+	store.On("ListSessionTokenHashesByFamily", mock.Anything, "fam-1").Return([]string{"hash-a"}, nil)
+	store.On("DeleteSessionsByFamily", mock.Anything, "fam-1").Return(nil)
+	var loggedType string
+	store.On("LogAuditEvent", mock.Anything, mock.AnythingOfType("*models.AuditEvent")).
+		Run(func(args mock.Arguments) { loggedType = args.Get(1).(*models.AuditEvent).EventType }).
+		Return(nil)
+
+	_, err := c.RefreshSession(context.Background(), "old")
+	require.Error(t, err, "the losing side of a rotation race must not mint a second session")
+	require.Equal(t, EventSessionReuseDetected, loggedType)
+	store.AssertCalled(t, "DeleteSessionsByFamily", mock.Anything, "fam-1")
 }

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -576,7 +576,15 @@ type Storage interface {
 
 	// Session Management
 	CreateSession(ctx context.Context, session *models.Session) (*models.Session, error)
+	// GetSession looks up a LIVE (not-yet-rotated) session by token. A token
+	// belonging to a session RefreshSession has since rotated away must behave
+	// exactly like a deleted one here (see RotatedAt on models.Session) — used on
+	// every authenticated request and on Logout.
 	GetSession(ctx context.Context, token string) (*models.Session, error)
+	// GetSessionAny looks up a session by token regardless of rotation state.
+	// Used only by RefreshSession's reuse-detection path (#211), which must tell an
+	// already-rotated token (a reuse signal) apart from one that never existed.
+	GetSessionAny(ctx context.Context, token string) (*models.Session, error)
 	GetSessionByID(ctx context.Context, id uint) (*models.Session, error)
 	ListSessionsByUser(ctx context.Context, userID uint) ([]*models.Session, error)
 	// EnforceSessionLimit deletes a user's oldest sessions beyond the `keep` most-recent
@@ -590,6 +598,17 @@ type Storage interface {
 	// hashes — equal to the auth-cache key) for every session owned by or impersonating
 	// userID, so a state change can evict them from the auth cache immediately.
 	ListSessionTokenHashesForUser(ctx context.Context, userID uint) ([]string, error)
+	// RotateSession atomically supersedes the session at oldID with newSession inside
+	// a single DB transaction (#211): the CAS guard (rotated_at IS NULL) makes
+	// rotation race-free under concurrent refreshes of the same token — at most one
+	// caller wins (won=true). The loser must treat the loss as a reuse signal exactly
+	// like an out-of-band replay of an already-rotated token.
+	RotateSession(ctx context.Context, oldID uint, newSession *models.Session, now time.Time) (created *models.Session, won bool, err error)
+	// ListSessionTokenHashesByFamily / DeleteSessionsByFamily revoke every session
+	// descended from the same login (see FamilyID on models.Session) — used to kill
+	// the whole lineage when a refresh-token reuse is detected (#211).
+	ListSessionTokenHashesByFamily(ctx context.Context, familyID string) ([]string, error)
+	DeleteSessionsByFamily(ctx context.Context, familyID string) error
 	// TouchSession bumps last_seen_at only when it is older than the given staleness
 	// window (no-op otherwise) so the auth hot path is not turned into a write per request.
 	TouchSession(ctx context.Context, id uint, seenAt time.Time, staleness time.Duration) error

--- a/internal/core/webauthn.go
+++ b/internal/core/webauthn.go
@@ -454,7 +454,9 @@ func (c *KeyorixCore) rejectIfCloned(ctx context.Context, userID uint, cred *web
 	if !cred.Authenticator.CloneWarning {
 		return nil
 	}
-	if row, err := c.storage.GetWebAuthnCredentialByCredID(ctx, cred.ID); err == nil && row.UserID == userID {
+	// Scoped to userID (#307) — the lookup itself enforces ownership, so no separate
+	// row.UserID check is needed here.
+	if row, err := c.storage.GetWebAuthnCredentialByCredID(ctx, cred.ID, userID); err == nil {
 		row.Disabled = true
 		_ = c.storage.UpdateWebAuthnCredential(ctx, row)
 	}

--- a/internal/core/webauthn.go
+++ b/internal/core/webauthn.go
@@ -25,6 +25,19 @@ var ErrWebAuthnDisabled = errors.New("webauthn is not enabled on this server")
 
 const webauthnSessionTTL = 5 * time.Minute
 
+// EventWebAuthnCloneDetected is the loud, authentication-rejecting audit event
+// fired when go-webauthn's signature-counter clone-detection signal
+// (Authenticator.CloneWarning) fires (#212). The library itself already excludes
+// the one legitimate always-zero-counter case (see its UpdateCounter: both the
+// stored and asserted counts must be zero for the warning to be waived), so any
+// warning reaching here is a genuine regression, not a benign authenticator that
+// never implemented a counter.
+const EventWebAuthnCloneDetected = "webauthn.clone_detected" // #nosec G101 -- audit event type, not a credential
+
+// NotificationWebAuthnCloneDetected is the in-app/email notification type sent to
+// the affected account owner alongside EventWebAuthnCloneDetected.
+const NotificationWebAuthnCloneDetected = EventWebAuthnCloneDetected
+
 // webauthnUser adapts a Keyorix user + its stored credentials to the
 // webauthn.User interface the library expects.
 type webauthnUser struct {
@@ -54,6 +67,13 @@ func (c *KeyorixCore) loadWebAuthnUser(ctx context.Context, userID uint) (*webau
 	}
 	creds := make([]webauthn.Credential, 0, len(rows))
 	for _, r := range rows {
+		if r.Disabled {
+			// Flagged by clone-detection (#212, signature-counter regression) —
+			// excluded from every ceremony (login candidate set AND registration
+			// exclusion list) until the owner deletes it and registers a fresh
+			// passkey using the genuine physical authenticator.
+			continue
+		}
 		var cred webauthn.Credential
 		if err := json.Unmarshal(r.CredentialBlob, &cred); err != nil {
 			continue // skip an unreadable row rather than fail the whole ceremony
@@ -283,10 +303,19 @@ func (c *KeyorixCore) FinishWebAuthnLogin(ctx context.Context, challenge, sessio
 		c.recordFailedLogin(ctx, wu.user) // count the failed second factor toward the lockout
 		return nil, nil, fmt.Errorf("assertion verification failed: %w", err)
 	}
+	// Clone-detection (#212): a signature-counter regression is a stronger, more
+	// specific signal than a simple bad assertion, so it is checked and refused
+	// FIRST — before the login is otherwise treated as successful in any way,
+	// including clearing the lockout counters below — no session is minted, the
+	// credential is disabled, and the owner is alerted (see rejectIfCloned).
+	if err := c.rejectIfCloned(ctx, ch.UserID, cred, ip); err != nil {
+		return nil, nil, err
+	}
 	// A concurrent burst of failed second-factor attempts against this account may
 	// have tripped the lock since the pre-verification snapshot check above
 	// (TOCTOU). Re-check under the same serialization recordFailedLogin uses
-	// before minting a session.
+	// before minting a session; on success this also clears the lockout counters,
+	// superseding a bare clearLoginFailures call.
 	if err := c.checkLockAndClearLoginFailures(ctx, wu.user); err != nil {
 		return nil, nil, err
 	}
@@ -297,10 +326,6 @@ func (c *KeyorixCore) FinishWebAuthnLogin(ctx context.Context, challenge, sessio
 		return nil, nil, err
 	}
 	uid := ch.UserID
-	if cred.Authenticator.CloneWarning {
-		c.writeAuditEventFull(ctx, "webauthn.clone_warning", &uid, nil, nil, ip,
-			fmt.Sprintf("possible cloned authenticator for user %s (signature counter did not advance)", wu.user.Username))
-	}
 	c.writeAuditEventFull(ctx, "webauthn.login_verified", &uid, nil, nil, ip,
 		fmt.Sprintf("user %s passed WebAuthn", wu.user.Username))
 	return session, wu.user, nil
@@ -369,6 +394,12 @@ func (c *KeyorixCore) FinishWebAuthnPasswordlessLogin(ctx context.Context, sessi
 		c.writeAuditEventFull(ctx, "webauthn.failed", nil, nil, nil, ip, "failed passwordless WebAuthn login")
 		return nil, nil, fmt.Errorf("assertion verification failed: %w", err)
 	}
+	// Clone-detection (#212): refuse before any other gate — a signature-counter
+	// regression means this assertion may come from a cloned authenticator, so it
+	// must never mint a session regardless of account state. See rejectIfCloned.
+	if err := c.rejectIfCloned(ctx, resolved.ID, cred, ip); err != nil {
+		return nil, nil, err
+	}
 	// A passwordless login is still a login: a deactivated or suspended/blocked account
 	// is refused. IsActive is an independent gate from AccountState — an admin
 	// deactivation (is_active=false) leaves AccountState="active", so checking only
@@ -401,13 +432,39 @@ func (c *KeyorixCore) FinishWebAuthnPasswordlessLogin(ctx context.Context, sessi
 		return nil, nil, err
 	}
 	uid := resolved.ID
-	if cred.Authenticator.CloneWarning {
-		c.writeAuditEventFull(ctx, "webauthn.clone_warning", &uid, nil, nil, ip,
-			fmt.Sprintf("possible cloned authenticator for user %s (signature counter did not advance)", resolved.Username))
-	}
 	c.writeAuditEventFull(ctx, "webauthn.passwordless_login", &uid, nil, nil, ip,
 		fmt.Sprintf("user %s logged in passwordlessly via WebAuthn", resolved.Username))
 	return session, resolved, nil
+}
+
+// rejectIfCloned inspects a just-verified assertion's credential for a signature-
+// counter regression — go-webauthn's standard FIDO2 clone-detection signal
+// (Authenticator.CloneWarning), meaning this credential's private key material
+// likely exists on more than one device (#212). Previously this was only ever
+// written to a passive audit line while the login proceeded normally; now the
+// CURRENT authentication is refused (never mints a session on a clone signal), the
+// credential is disabled so it cannot authenticate again until the owner deletes it
+// and registers a fresh passkey (auto re-enabling isn't safe — the stored counter
+// can never again exceed a value a possibly-compromised clone already asserted),
+// and the account owner is alerted loudly: a distinct audit event (superseding the
+// old passive "clone_warning" line) plus an in-app/email notification, rather than
+// only a silent log entry. Returns a rejection error when CloneWarning fired, nil
+// otherwise (the normal, incrementing-counter case).
+func (c *KeyorixCore) rejectIfCloned(ctx context.Context, userID uint, cred *webauthn.Credential, ip string) error {
+	if !cred.Authenticator.CloneWarning {
+		return nil
+	}
+	if row, err := c.storage.GetWebAuthnCredentialByCredID(ctx, cred.ID); err == nil && row.UserID == userID {
+		row.Disabled = true
+		_ = c.storage.UpdateWebAuthnCredential(ctx, row)
+	}
+	uid := userID
+	c.writeAuditEventFull(ctx, EventWebAuthnCloneDetected, &uid, nil, nil, ip,
+		fmt.Sprintf("authentication refused for user %d: signature-counter regression (possible cloned authenticator) — credential disabled pending re-registration", userID))
+	c.notify(ctx, userID, NotificationWebAuthnCloneDetected, "Passkey clone suspected",
+		"A sign-in attempt was blocked because one of your passkeys reported a signature-counter regression — a sign that its private key may exist on more than one device. The passkey has been disabled; please remove it and register a new one.",
+		nil, "/account/security")
+	return fmt.Errorf("assertion verification failed: signature counter did not advance (possible cloned authenticator)")
 }
 
 // persistUpdatedCredential writes back the credential's advanced signature counter

--- a/internal/core/webauthn_test.go
+++ b/internal/core/webauthn_test.go
@@ -26,7 +26,7 @@ func newWebAuthnTestCore(t *testing.T, withRP bool) (*KeyorixCore, *gorm.DB) {
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
 	require.NoError(t, db.AutoMigrate(&models.User{}, &models.Session{}, &models.AuditEvent{},
-		&models.MFAChallenge{}, &models.WebAuthnCredential{}, &models.WebAuthnSession{}))
+		&models.MFAChallenge{}, &models.WebAuthnCredential{}, &models.WebAuthnSession{}, &models.Notification{}))
 	hash, _ := bcrypt.GenerateFromPassword([]byte(webauthnTestPassword), bcrypt.DefaultCost)
 	require.NoError(t, db.Create(&models.User{ID: 1, Username: "alice", Email: "a@b.com",
 		PasswordHash: string(hash), AccountState: "active"}).Error)
@@ -274,4 +274,54 @@ func TestWebAuthn_FinishLoginRejectsMismatchedSession(t *testing.T) {
 
 	_, _, err = c.FinishWebAuthnLogin(ctx, ch, otherToken, "ua", "1.2.3.4", nil)
 	require.Error(t, err, "a webauthn session for another user must not complete this challenge")
+}
+
+// #212: a signature-counter regression (go-webauthn's Authenticator.CloneWarning —
+// the standard FIDO2 clone-detection signal) must refuse the authentication and
+// disable the credential, not just write a passive audit line while login proceeds.
+// This is the actual authentication-time enforcement path both FinishWebAuthnLogin
+// and FinishWebAuthnPasswordlessLogin call once the library's cryptographic
+// assertion check has already succeeded.
+func TestWebAuthn_RejectIfCloned_DisablesCredentialAndRejects(t *testing.T) {
+	c, db := newWebAuthnTestCore(t, true)
+	ctx := context.Background()
+	seedCredential(t, c, db, 1, "cred-1")
+
+	cred := &webauthn.Credential{ID: []byte("cred-1"), Authenticator: webauthn.Authenticator{CloneWarning: true}}
+	err := c.rejectIfCloned(ctx, 1, cred, "203.0.113.9")
+	require.Error(t, err, "a regressed signature counter must refuse the authentication")
+
+	var row models.WebAuthnCredential
+	require.NoError(t, db.Where("credential_id = ?", []byte("cred-1")).First(&row).Error)
+	assert.True(t, row.Disabled, "the flagged credential must be disabled pending re-registration")
+
+	var events int64
+	require.NoError(t, db.Model(&models.AuditEvent{}).Where("event_type = ?", EventWebAuthnCloneDetected).Count(&events).Error)
+	assert.Equal(t, int64(1), events, "the clone must be audited distinctly, not just silently logged")
+
+	// The disabled credential must be excluded from every future ceremony — it can
+	// never authenticate again until the owner re-registers a fresh passkey.
+	wu, err := c.loadWebAuthnUser(ctx, 1)
+	require.NoError(t, err)
+	assert.Empty(t, wu.creds, "a disabled credential must not be offered for future login ceremonies")
+}
+
+// A normal, strictly-incrementing counter must NOT be treated as a clone signal and
+// must leave the credential fully usable.
+func TestWebAuthn_RejectIfCloned_NormalCounterPasses(t *testing.T) {
+	c, db := newWebAuthnTestCore(t, true)
+	ctx := context.Background()
+	seedCredential(t, c, db, 1, "cred-1")
+
+	cred := &webauthn.Credential{ID: []byte("cred-1"), Authenticator: webauthn.Authenticator{CloneWarning: false, SignCount: 42}}
+	err := c.rejectIfCloned(ctx, 1, cred, "203.0.113.9")
+	require.NoError(t, err, "a normal incrementing counter must not be rejected")
+
+	var row models.WebAuthnCredential
+	require.NoError(t, db.Where("credential_id = ?", []byte("cred-1")).First(&row).Error)
+	assert.False(t, row.Disabled, "an un-flagged credential must not be disabled")
+
+	wu, err := c.loadWebAuthnUser(ctx, 1)
+	require.NoError(t, err)
+	assert.Len(t, wu.creds, 1, "an un-flagged credential remains usable")
 }

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -335,6 +335,16 @@ type WebAuthnCredential struct {
 	CredentialBlob []byte // JSON of webauthn.Credential
 	CreatedAt      time.Time
 	LastUsedAt     *time.Time
+
+	// Disabled is set when an authentication attempt against this credential showed
+	// a signature-counter regression (go-webauthn's CloneWarning — #212), the
+	// standard FIDO2 signal that its private key material may exist on more than one
+	// device. A disabled credential is excluded from every future ceremony (it can no
+	// longer authenticate, and won't be offered for exclusion on re-registration
+	// either); the owner must delete it and register a fresh passkey. Never
+	// auto-re-enabled — the stored counter can never again exceed a value a
+	// possibly-compromised clone already asserted.
+	Disabled bool `gorm:"default:false"`
 }
 
 // WebAuthnSession persists the in-flight ceremony state (the go-webauthn
@@ -637,6 +647,25 @@ type Session struct {
 	// frontend can swap back without re-authentication. nil = ordinary session.
 	ImpersonatedBy         *uint
 	ImpersonationStartedAt *time.Time
+
+	// FamilyID links every session descended from the same login through each
+	// refresh-token rotation (#211): stamped once at mintSession and carried
+	// unchanged onto every session RefreshSession rotates it into. Lets a detected
+	// refresh-token-reuse event revoke the WHOLE lineage in one shot (standard
+	// OAuth refresh-token-family revocation), not just the one row that was
+	// replayed. Empty on legacy rows minted before this field existed.
+	FamilyID string `gorm:"index"`
+
+	// RotatedAt marks this row superseded by RefreshSession — a soft, not hard,
+	// delete. Keeping the row instead of deleting it immediately lets a replay of
+	// this now-stale token be told apart from an ordinary "never existed" /
+	// already-swept-up-by-expiry lookup, which is the standard refresh-token-reuse
+	// detection signal. nil = still the live session for its token. GetSession
+	// excludes rotated rows (a rotated token must authenticate nothing); only the
+	// refresh path's reuse-detection lookup (GetSessionAny) sees them. Rotated rows
+	// are still swept up by CleanupExpiredSessions once their (unextended) ExpiresAt
+	// passes, so they don't accumulate indefinitely.
+	RotatedAt *time.Time
 }
 
 // PersonalAccessToken is a long-lived, user-owned bearer credential (ADR-027).

--- a/internal/storage/store/local_auth.go
+++ b/internal/storage/store/local_auth.go
@@ -43,13 +43,91 @@ func (ls *LocalStorage) CreateSession(ctx context.Context, session *models.Sessi
 	return session, nil
 }
 
+// GetSession looks up a LIVE session by the hash of the presented token — the row
+// stores only the hash. A rotated row (RotatedAt set) is excluded: it must
+// authenticate nothing, exactly like a deleted row (#211).
 func (ls *LocalStorage) GetSession(ctx context.Context, token string) (*models.Session, error) {
-	// Look up by the hash of the presented token — the row stores only the hash.
+	var session models.Session
+	if err := ls.db.WithContext(ctx).
+		Where("session_token = ? AND rotated_at IS NULL", hashSessionToken(token)).
+		First(&session).Error; err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorNotFound", nil), err)
+	}
+	return &session, nil
+}
+
+// GetSessionAny looks up a session by token hash regardless of rotation state —
+// used only by RefreshSession's reuse-detection path (#211), which must tell an
+// already-rotated token (a reuse signal) apart from one that never existed.
+func (ls *LocalStorage) GetSessionAny(ctx context.Context, token string) (*models.Session, error) {
 	var session models.Session
 	if err := ls.db.WithContext(ctx).Where("session_token = ?", hashSessionToken(token)).First(&session).Error; err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorNotFound", nil), err)
 	}
 	return &session, nil
+}
+
+// RotateSession atomically supersedes the session at oldID with newSession, inside
+// one DB transaction (#211). The conditional UPDATE's WHERE guard (rotated_at IS
+// NULL) is the CAS: under concurrent refreshes of the same token, only the caller
+// whose UPDATE matches a still-live row wins (won=true) and gets its replacement
+// created in the SAME transaction, so a crash between the two steps can never leave
+// an old row marked rotated with no live descendant. The loser's UPDATE matches zero
+// rows (won=false, created=nil) — the caller must treat that exactly like an
+// out-of-band replay of an already-rotated token.
+func (ls *LocalStorage) RotateSession(ctx context.Context, oldID uint, newSession *models.Session, now time.Time) (*models.Session, bool, error) {
+	var created *models.Session
+	won := false
+	err := ls.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		res := tx.Model(&models.Session{}).
+			Where("id = ? AND rotated_at IS NULL", oldID).
+			Update("rotated_at", now)
+		if res.Error != nil {
+			return res.Error
+		}
+		if res.RowsAffected == 0 {
+			return nil // lost the race / already rotated — won stays false, not an error
+		}
+		won = true
+		plaintext := newSession.SessionToken
+		newSession.SessionToken = hashSessionToken(plaintext)
+		if err := tx.Create(newSession).Error; err != nil {
+			return err
+		}
+		newSession.SessionToken = plaintext
+		created = newSession
+		return nil
+	})
+	if err != nil {
+		return nil, false, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	return created, won, nil
+}
+
+// ListSessionTokenHashesByFamily returns the stored session_token hashes for every
+// (live or rotated) session sharing familyID, so the reuse-detection path can evict
+// each from the auth cache before deleting them (#211).
+func (ls *LocalStorage) ListSessionTokenHashesByFamily(ctx context.Context, familyID string) ([]string, error) {
+	var hashes []string
+	if err := ls.db.WithContext(ctx).Model(&models.Session{}).
+		Where("family_id = ?", familyID).
+		Pluck("session_token", &hashes).Error; err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	return hashes, nil
+}
+
+// DeleteSessionsByFamily removes every session sharing familyID — used to revoke
+// the whole lineage descended from one login when a refresh-token reuse is
+// detected (#211), not just the single replayed row.
+func (ls *LocalStorage) DeleteSessionsByFamily(ctx context.Context, familyID string) error {
+	if familyID == "" {
+		return nil
+	}
+	if err := ls.db.WithContext(ctx).Where("family_id = ?", familyID).Delete(&models.Session{}).Error; err != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	return nil
 }
 
 func (ls *LocalStorage) GetSessionByID(ctx context.Context, id uint) (*models.Session, error) {

--- a/internal/storage/store/local_auth.go
+++ b/internal/storage/store/local_auth.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"gorm.io/gorm"
 )
 
 // --- Sessions ---

--- a/internal/storage/store/remote_auth.go
+++ b/internal/storage/store/remote_auth.go
@@ -91,6 +91,22 @@ func (rs *RemoteStorage) GetSessionByID(_ context.Context, _ uint) (*models.Sess
 	return nil, errUnsupportedRemote
 }
 
+func (rs *RemoteStorage) GetSessionAny(_ context.Context, _ string) (*models.Session, error) {
+	return nil, errUnsupportedRemote
+}
+
+func (rs *RemoteStorage) RotateSession(_ context.Context, _ uint, _ *models.Session, _ time.Time) (*models.Session, bool, error) {
+	return nil, false, errUnsupportedRemote
+}
+
+func (rs *RemoteStorage) ListSessionTokenHashesByFamily(_ context.Context, _ string) ([]string, error) {
+	return nil, errUnsupportedRemote
+}
+
+func (rs *RemoteStorage) DeleteSessionsByFamily(_ context.Context, _ string) error {
+	return errUnsupportedRemote
+}
+
 func (rs *RemoteStorage) ListSessionsByUser(_ context.Context, _ uint) ([]*models.Session, error) {
 	return nil, errUnsupportedRemote
 }

--- a/internal/storage/store/session_rotate_test.go
+++ b/internal/storage/store/session_rotate_test.go
@@ -1,0 +1,158 @@
+// session_rotate_test.go — atomicity and reuse-detection invariants for
+// RotateSession, the CAS at the heart of RefreshSession's fix for #211 (session
+// refresh had no reuse-detection signal and was not atomic).
+package store
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// TestRotateSession_SingleCallerWins is the sequential sanity check: rotating a
+// live session succeeds, marks the old row rotated (excluded from GetSession, but
+// still visible to GetSessionAny), and creates the replacement.
+func TestRotateSession_SingleCallerWins(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.Session{}))
+	ls := NewLocalStorage(db)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	old, err := ls.CreateSession(ctx, &models.Session{UserID: 1, SessionToken: "old-plain", FamilyID: "fam-1"})
+	require.NoError(t, err)
+
+	newSession := &models.Session{UserID: 1, SessionToken: "new-plain", FamilyID: "fam-1"}
+	created, won, err := ls.RotateSession(ctx, old.ID, newSession, now)
+	require.NoError(t, err)
+	assert.True(t, won)
+	require.NotNil(t, created)
+	assert.Equal(t, "new-plain", created.SessionToken, "the plaintext token is handed back to the caller")
+
+	// The old token no longer authenticates via GetSession (rotated == dead for
+	// auth purposes) but is still visible via GetSessionAny for reuse detection.
+	_, err = ls.GetSession(ctx, "old-plain")
+	assert.Error(t, err, "a rotated token must not authenticate")
+
+	rotated, err := ls.GetSessionAny(ctx, "old-plain")
+	require.NoError(t, err)
+	assert.NotNil(t, rotated.RotatedAt, "GetSessionAny must still see the rotated row")
+
+	// The new token is live.
+	live, err := ls.GetSession(ctx, "new-plain")
+	require.NoError(t, err)
+	assert.Nil(t, live.RotatedAt)
+}
+
+// TestRotateSession_LoserGetsNoSession is the CAS guard's negative case: rotating
+// an already-rotated row a second time must not create a second descendant.
+func TestRotateSession_LoserGetsNoSession(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.Session{}))
+	ls := NewLocalStorage(db)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	old := &models.Session{UserID: 1, SessionToken: "old-plain", FamilyID: "fam-1"}
+	require.NoError(t, db.Create(old).Error)
+
+	first := &models.Session{UserID: 1, SessionToken: "first-plain", FamilyID: "fam-1"}
+	_, won1, err := ls.RotateSession(ctx, old.ID, first, now)
+	require.NoError(t, err)
+	require.True(t, won1)
+
+	second := &models.Session{UserID: 1, SessionToken: "second-plain", FamilyID: "fam-1"}
+	created2, won2, err := ls.RotateSession(ctx, old.ID, second, now)
+	require.NoError(t, err)
+	assert.False(t, won2, "a second rotation of the same already-rotated row must lose")
+	assert.Nil(t, created2)
+
+	// Only ONE descendant session exists for this family, not two.
+	var count int64
+	require.NoError(t, db.Model(&models.Session{}).Where("family_id = ? AND rotated_at IS NULL", "fam-1").Count(&count).Error)
+	assert.EqualValues(t, 1, count, "exactly one live descendant, no duplicate mint")
+}
+
+// TestConcurrency_RotateSession_OnlyOneWinnerPerToken drives many goroutines racing
+// to rotate the SAME not-yet-rotated session concurrently against a real,
+// file-backed SQLite DB with genuine multi-connection contention (concurrentDB,
+// shared with the other atomic check-and-act invariant tests in this package).
+// Exactly one must win the CAS and mint a descendant — this is the store-level
+// proof behind #211's "a race on the same token can mint two independently valid
+// sessions" fix.
+func TestConcurrency_RotateSession_OnlyOneWinnerPerToken(t *testing.T) {
+	db := concurrentDB(t)
+	require.NoError(t, db.AutoMigrate(&models.Session{}))
+	ls := NewLocalStorage(db)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	old := &models.Session{UserID: 1, SessionToken: "shared-old-token", FamilyID: "fam-race"}
+	require.NoError(t, db.Create(old).Error)
+
+	const racers = 20
+	var wins int64
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < racers; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			<-start
+			candidate := &models.Session{UserID: 1, SessionToken: fmt.Sprintf("candidate-%d", n), FamilyID: "fam-race"}
+			_, won, err := ls.RotateSession(ctx, old.ID, candidate, now)
+			require.NoError(t, err)
+			if won {
+				atomic.AddInt64(&wins, 1)
+			}
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	assert.EqualValues(t, 1, wins, "exactly one concurrent refresh of the same token may win the rotation")
+
+	var count int64
+	require.NoError(t, db.Model(&models.Session{}).Where("family_id = ? AND rotated_at IS NULL", "fam-race").Count(&count).Error)
+	assert.EqualValues(t, 1, count, "at most one live descendant session must exist, no matter how many racers")
+}
+
+// TestDeleteSessionsByFamily_RevokesWholeLineage pins that family revocation kills
+// every session sharing the family id, not just the row that triggered detection —
+// the "revoke the whole session family" recommendation from #211.
+func TestDeleteSessionsByFamily_RevokesWholeLineage(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.Session{}))
+	ls := NewLocalStorage(db)
+	ctx := context.Background()
+
+	require.NoError(t, db.Create(&models.Session{UserID: 1, SessionToken: "gen1", FamilyID: "fam-x"}).Error)
+	require.NoError(t, db.Create(&models.Session{UserID: 1, SessionToken: "gen2", FamilyID: "fam-x"}).Error)
+	require.NoError(t, db.Create(&models.Session{UserID: 1, SessionToken: "unrelated", FamilyID: "fam-y"}).Error)
+
+	hashes, err := ls.ListSessionTokenHashesByFamily(ctx, "fam-x")
+	require.NoError(t, err)
+	assert.Len(t, hashes, 2)
+
+	require.NoError(t, ls.DeleteSessionsByFamily(ctx, "fam-x"))
+
+	var remaining int64
+	require.NoError(t, db.Model(&models.Session{}).Where("family_id = ?", "fam-x").Count(&remaining).Error)
+	assert.EqualValues(t, 0, remaining, "every session in the family is revoked")
+
+	var other int64
+	require.NoError(t, db.Model(&models.Session{}).Where("family_id = ?", "fam-y").Count(&other).Error)
+	assert.EqualValues(t, 1, other, "a different family is untouched")
+}


### PR DESCRIPTION
Rebase of #571 onto current main. Conflicted with two independently-landed hardening changes in `FinishWebAuthnLogin` and `GetWebAuthnCredentialByCredID`; resolved by combining guarantees rather than picking one side (see the follow-up fixup commit):

- Main had independently added a TOCTOU lockout recheck (`checkLockAndClearLoginFailures`) right before minting a WebAuthn-login session. This PR's clone-detection refusal (#212, `rejectIfCloned`) now runs FIRST (refusing before the lockout counters are ever touched), then the TOCTOU recheck, which also clears the counters on success — superseding the plain `clearLoginFailures` call this PR originally used. This mirrors the ordering `FinishWebAuthnPasswordlessLogin` already uses.
- Main had independently scoped `GetWebAuthnCredentialByCredID` to take `userID` directly (#307, closing a cross-user credential-ID lookup gap) instead of a post-hoc ownership check. `rejectIfCloned` now calls the 3-arg scoped signature.

#211: RefreshSession's read-old/create-new/delete-old was neither atomic nor reuse-aware. RotateSession is now a single DB transaction with a CAS guard; a replay of an already-rotated token and a race between two concurrent refreshes both revoke the whole session family.

#212: go-webauthn's CloneWarning signal was previously only ever written to a passive audit line while login proceeded normally. It now refuses the current authentication, disables the credential, and alerts the account owner.

#154 (TOTP replay) was already fixed on main — verified, no change needed.

Verified locally: `go build ./...`, `go build ./server`, `go test ./...`, `gosec -severity medium -exclude-generated ./...`, `cd operator && GOWORK=off go build ./...` all clean (one pre-existing timing-flaky test, TestHTTPJWKSResolver_CapsKeyCount, passes reliably in isolation/reruns — unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)