### PR TITLE
fix(sso): close account-takeover via JIT provisioning on an unverified email (CRITICAL)

### DIFF
--- a/internal/core/dynamic_secrets_test.go
+++ b/internal/core/dynamic_secrets_test.go
@@ -354,6 +354,7 @@ func TestDynamicSecrets_InstallWideMaxLeaseTTLClampsIssue(t *testing.T) {
 	cfg, err := c.CreateDynamicSecretConfig(ctx, &CreateDynamicSecretConfigRequest{
 		Name: "unbounded", ProjectID: 1, BackendType: "postgres", AdminDSN: adminDSNPlain,
 		// No MaxTTLSeconds — the per-config ceiling is unset/unbounded.
+		ActorID: testAdminActorID,
 	})
 	require.NoError(t, err)
 
@@ -371,6 +372,7 @@ func TestDynamicSecrets_InstallWideMaxLeaseTTLDefaultsWhenUnset(t *testing.T) {
 	ctx := context.Background()
 	cfg, err := c.CreateDynamicSecretConfig(ctx, &CreateDynamicSecretConfigRequest{
 		Name: "unbounded", ProjectID: 1, BackendType: "postgres", AdminDSN: adminDSNPlain,
+		ActorID: testAdminActorID,
 	})
 	require.NoError(t, err)
 
@@ -462,6 +464,7 @@ func TestDynamicSecrets_RenewRespectsInstallWideMaxLeaseTTL(t *testing.T) {
 	cfg, err := c.CreateDynamicSecretConfig(ctx, &CreateDynamicSecretConfigRequest{
 		Name: "unbounded", ProjectID: 1, BackendType: "postgres", AdminDSN: adminDSNPlain,
 		DefaultTTLSeconds: 300, // no MaxTTLSeconds — per-config ceiling unset
+		ActorID:           testAdminActorID,
 	})
 	require.NoError(t, err)
 

--- a/internal/core/sso.go
+++ b/internal/core/sso.go
@@ -192,7 +192,7 @@ func (c *KeyorixCore) CompleteSSO(ctx context.Context, providerName, code, state
 		if !p.AutoProvision {
 			return nil, nil, "", fmt.Errorf("no Keyorix account matches this SSO identity")
 		}
-		if user, err = c.provisionSSOUser(ctx, p, sub, email, name); err != nil {
+		if user, err = c.provisionSSOUser(ctx, p, sub, email, emailVerified, name); err != nil {
 			return nil, nil, "", err
 		}
 	}
@@ -306,7 +306,7 @@ func (c *KeyorixCore) CompleteSAML(ctx context.Context, name string, r *http.Req
 		if !p.AutoProvision {
 			return nil, nil, "", fmt.Errorf("no Keyorix account matches this SSO identity")
 		}
-		if user, err = c.provisionSSOUser(ctx, p, info.Subject, info.Email, info.Name); err != nil {
+		if user, err = c.provisionSSOUser(ctx, p, info.Subject, info.Email, true, info.Name); err != nil {
 			return nil, nil, "", err
 		}
 	}
@@ -398,13 +398,21 @@ func (c *KeyorixCore) resolveSSOUser(ctx context.Context, sub, email string, ema
 // pending_first_login (which would trap an SSO user in a password-change-only
 // restricted session they can never clear). The baseline role is the provider's
 // default_role (system_viewer when unset); an unknown role grants nothing.
-func (c *KeyorixCore) provisionSSOUser(ctx context.Context, p *SSOProvider, sub, email, name string) (*models.User, error) {
+func (c *KeyorixCore) provisionSSOUser(ctx context.Context, p *SSOProvider, sub, email string, emailVerified bool, name string) (*models.User, error) {
 	if strings.TrimSpace(email) == "" {
 		return nil, fmt.Errorf("the IdP returned no email; cannot auto-provision an account")
 	}
-	// Guard against a race / case where a user materialised between the resolve and
-	// here: reuse it rather than create a duplicate.
-	if existing, ferr := c.FindSCIMUser(ctx, sub, email); ferr == nil && existing != nil {
+	// Guard against a race / case where a user materialised between the resolve and here:
+	// reuse it rather than create a duplicate. This MUST go through resolveSSOUser (not a
+	// raw email lookup), so the same guards apply — an EXISTING account is reused via an
+	// email match ONLY when the email is verified, and never when it is bound to a
+	// different federated identity. A raw FindSCIMUser(sub, email) here re-introduced the
+	// unverified-email account-takeover that resolveSSOUser exists to prevent: an IdP that
+	// omits email_verified could assert a victim's email and have the JIT path "reuse"
+	// (i.e. log in as) the victim's existing account.
+	if existing, ferr := c.resolveSSOUser(ctx, sub, email, emailVerified); ferr != nil {
+		return nil, ferr
+	} else if existing != nil {
 		return existing, nil
 	}
 	username, err := c.deriveSCIMUsername(ctx, email)

--- a/internal/core/sso_test.go
+++ b/internal/core/sso_test.go
@@ -209,7 +209,7 @@ func TestProvisionSSOUser(t *testing.T) {
 		store.On("AssignRole", mock.Anything, uint(42), uint(3), mock.Anything).Return(nil)
 		store.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
 
-		u, err := c.provisionSSOUser(context.Background(), p, "okta|123", "ada@x.io", "Ada Lovelace")
+		u, err := c.provisionSSOUser(context.Background(), p, "okta|123", "ada@x.io", true, "Ada Lovelace")
 		require.NoError(t, err)
 		assert.Equal(t, uint(42), u.ID)
 		// Active (not pending_first_login — an SSO user must not be trapped in a
@@ -224,14 +224,42 @@ func TestProvisionSSOUser(t *testing.T) {
 
 	t.Run("refuses when the IdP returned no email", func(t *testing.T) {
 		c, _, _, p := ssoTestCore(t)
-		_, err := c.provisionSSOUser(context.Background(), p, "okta|123", "", "Ada")
+		_, err := c.provisionSSOUser(context.Background(), p, "okta|123", "", true, "Ada")
 		require.Error(t, err)
+	})
+
+	// CRITICAL regression: the JIT path must NOT reuse an existing account matched by an
+	// UNVERIFIED email — that was an account-takeover (an IdP omitting email_verified could
+	// assert a victim's email and be logged in as the victim). With emailVerified=false the
+	// dedup goes through resolveSSOUser, which skips the email branch, so the existing
+	// victim account is NOT returned; a fresh account is created instead.
+	t.Run("does NOT reuse an existing account on an unverified email", func(t *testing.T) {
+		c, store, _, p := ssoTestCore(t)
+		// sub does not match; an existing victim account DOES match the email.
+		store.On("GetUserByExternalID", mock.Anything, "evil|999").Return((*models.User)(nil), notFound())
+		victim := &models.User{ID: 7, Username: "victim", Email: "victim@corp.com", ExternalID: "okta|legit"}
+		store.On("GetUserByEmail", mock.Anything, "victim@corp.com").Return(victim, nil)
+		// A fresh account is provisioned instead of reusing the victim.
+		store.On("GetUserByUsername", mock.Anything, "victim").Return((*models.User)(nil), notFound())
+		var created *models.User
+		store.On("CreateUser", mock.Anything, mock.MatchedBy(func(u *models.User) bool { created = u; return true })).
+			Return(&models.User{ID: 99}, nil)
+		store.On("GetRoleByName", mock.Anything, mock.Anything).Return(&models.Role{ID: 3}, nil)
+		store.On("AssignRole", mock.Anything, uint(99), uint(3), mock.Anything).Return(nil)
+		store.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
+
+		u, err := c.provisionSSOUser(context.Background(), p, "evil|999", "victim@corp.com", false /* email NOT verified */, "Mallory")
+		require.NoError(t, err)
+		assert.Equal(t, uint(99), u.ID, "must be the fresh account, not the victim (id 7)")
+		require.NotNil(t, created)
+		assert.Equal(t, "evil|999", created.ExternalID, "fresh account bound to the asserting subject, not the victim")
+		store.AssertNotCalled(t, "UpdateUser", mock.Anything, mock.Anything) // victim not claimed/reused
 	})
 
 	t.Run("reuses an existing user instead of duplicating", func(t *testing.T) {
 		c, store, _, p := ssoTestCore(t)
 		store.On("GetUserByExternalID", mock.Anything, "okta|123").Return(&models.User{ID: 5}, nil)
-		u, err := c.provisionSSOUser(context.Background(), p, "okta|123", "ada@x.io", "Ada")
+		u, err := c.provisionSSOUser(context.Background(), p, "okta|123", "ada@x.io", true, "Ada")
 		require.NoError(t, err)
 		assert.Equal(t, uint(5), u.ID)
 		store.AssertNotCalled(t, "CreateUser", mock.Anything, mock.Anything)
@@ -248,7 +276,7 @@ func TestProvisionSSOUser(t *testing.T) {
 		store.On("AssignRole", mock.Anything, uint(7), uint(9), mock.Anything).Return(nil)
 		store.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
 
-		_, err := c.provisionSSOUser(context.Background(), p, "okta|123", "ada@x.io", "Ada")
+		_, err := c.provisionSSOUser(context.Background(), p, "okta|123", "ada@x.io", true, "Ada")
 		require.NoError(t, err)
 		store.AssertCalled(t, "GetRoleByName", mock.Anything, "project_admin")
 	})
@@ -263,7 +291,7 @@ func TestProvisionSSOUser(t *testing.T) {
 		store.On("GetRoleByName", mock.Anything, "does_not_exist").Return((*models.Role)(nil), notFound())
 		store.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
 
-		u, err := c.provisionSSOUser(context.Background(), p, "okta|123", "ada@x.io", "Ada")
+		u, err := c.provisionSSOUser(context.Background(), p, "okta|123", "ada@x.io", true, "Ada")
 		require.NoError(t, err)
 		assert.Equal(t, uint(8), u.ID)
 		store.AssertNotCalled(t, "AssignRole", mock.Anything, mock.Anything, mock.Anything, mock.Anything)

--- a/server/http/authz_share_parity_test.go
+++ b/server/http/authz_share_parity_test.go
@@ -163,7 +163,7 @@ func TestAuthzParity_HTTPvsGRPC_ShareList(t *testing.T) {
 		&models.Project{}, &models.Environment{}, &models.SecretNode{}, &models.SecretVersion{},
 		&models.User{}, &models.Role{}, &models.Permission{}, &models.RolePermission{},
 		&models.UserRole{}, &models.Group{}, &models.UserGroup{}, &models.GroupRole{},
-		&models.Session{}, &models.AuditEvent{}, &models.ShareRecord{},
+		&models.Session{}, &models.AuditEvent{}, &models.ShareRecord{}, &models.SystemMetadata{},
 	))
 	c := core.NewKeyorixCore(store.NewLocalStorage(db))
 	ctx := context.Background()


### PR DESCRIPTION
## Summary
`resolveSSOUser` was hardened to refuse matching an EXISTING account by a merely-asserted (unverified) email. But the JIT-provisioning branch — `provisionSSOUser`, reached when `resolveSSOUser` finds no match — re-did the lookup via the unguarded `FindSCIMUser(sub, email)` and returned the existing account regardless of verification. With `auto_provision` enabled and an IdP that omits `email_verified` (e.g. Entra), an attacker asserting a victim's email with a fresh subject would be logged in as the victim, including admins, across IdPs.

- `provisionSSOUser` now takes `emailVerified` and routes its dedup through `resolveSSOUser` instead of the raw `FindSCIMUser`, so the same guards apply: an existing account is reused via an email match only when the email is verified, and never when it's bound to a different federated identity. On an unverified email a fresh account is created instead of reusing the victim's.
- `CompleteSSO` passes the ID token's actual `emailVerified` through; `CompleteSAML` passes `true` (a SAML assertion's attributes are carried inside the IdP-signed, library-verified assertion, so its email is already treated as verified elsewhere in this file).

Cherry-picked forward from the stale `harden/round19-sso-jit-takeover` branch (PR #519), whose other 83 commits have already landed on `main` via separate PRs — closing #519 as superseded, this PR carries just the one fix that branch had not yet merged.

Also fixes two pre-existing test failures on current `main`, unrelated to this change but blocking `go test ./...`:
- `TestDynamicSecrets_InstallWideMaxLeaseTTL*` — missing `ActorID` in test fixtures after #162 (PR #551) added an admin-authority requirement to binding a dynamic-secret backend.
- `TestAuthzParity_HTTPvsGRPC_ShareList` — missing `models.SystemMetadata{}` in its `AutoMigrate` list after #105's bootstrap-marker (PR #521).

## Test plan
- [x] `go build ./...`
- [x] `go build ./server`
- [x] `GOWORK=off go build ./operator/...`
- [x] `go test ./...` — all pass
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues
- [x] New regression test `TestProvisionSSOUser/does_NOT_reuse_an_existing_account_on_an_unverified_email` pins the fix: an attacker asserting a victim's email with an unverified assertion gets a fresh account, not the victim's