### PR TITLE
harden: close the dynamic-lease revoke_failed error leak + backend rotation bypass on manual rotate (#192/#193)

### DIFF
--- a/internal/core/dynamic_secrets.go
+++ b/internal/core/dynamic_secrets.go
@@ -364,6 +364,7 @@ func (c *KeyorixCore) RevokeLease(ctx context.Context, leaseID string, userID ui
 	}
 	lease.Status = "revoked"
 	lease.RevokeReason = reason
+	lease.RevokeError = "" // clear any error from a prior failed attempt — this retry succeeded
 	lease.RevokedAt = &now
 	if err := c.storage.UpdateDynamicSecretLease(ctx, lease); err != nil {
 		return err

--- a/internal/core/dynamic_secrets_test.go
+++ b/internal/core/dynamic_secrets_test.go
@@ -553,7 +553,8 @@ func TestDynamicSecrets_RevokeLeasesForConfig(t *testing.T) {
 // must NOT be silently skipped — it must be retried right alongside the still-active
 // leases, so an operator responding to "this target/config is compromised" actually
 // kills every outstanding credential, not just the ones that happened to revoke
-// cleanly on the first try.
+// cleanly on the first try. Also pins #192: a successful retry must clear the
+// earlier RevokeError, not leave a stale failure message on a now-clean lease.
 func TestDynamicSecrets_RevokeLeasesForConfigRetriesRevokeFailed(t *testing.T) {
 	c, _, fake, _ := newDynamicTestCore(t)
 	ctx := context.Background()
@@ -571,6 +572,7 @@ func TestDynamicSecrets_RevokeLeasesForConfigRetriesRevokeFailed(t *testing.T) {
 	before, _ := c.storage.GetDynamicSecretLease(ctx, stuck.LeaseID)
 	require.Equal(t, "revoke_failed", before.Status, "precondition: the lease is stuck")
 	require.Nil(t, before.RevokedAt, "precondition: not falsely timestamped as revoked")
+	require.NotEmpty(t, before.RevokeError, "precondition: the earlier failure left a RevokeError message")
 
 	// The target recovers, and an incident responder now believes the whole config is
 	// compromised and pulls the kill switch.
@@ -583,6 +585,7 @@ func TestDynamicSecrets_RevokeLeasesForConfigRetriesRevokeFailed(t *testing.T) {
 	after, _ := c.storage.GetDynamicSecretLease(ctx, stuck.LeaseID)
 	assert.Equal(t, "revoked", after.Status, "the revoke_failed lease is NOT permanently stuck — the kill switch reaches it")
 	assert.NotNil(t, after.RevokedAt, "the now-successful revoke IS timestamped")
+	assert.Empty(t, after.RevokeError, "a successful retry clears the earlier error")
 	assert.Contains(t, fake.Revoked, stuck.Username, "the previously-stranded credential was actually dropped on the target")
 	assert.Contains(t, fake.Revoked, stillActive.Username)
 }

--- a/internal/core/rotation_executor.go
+++ b/internal/core/rotation_executor.go
@@ -24,6 +24,16 @@ import (
 // EventAutoRotationFailures is audited once per run when one or more secrets failed.
 const EventAutoRotationFailures = "rotation.failures_alerted"
 
+// EventSecretRotateFailed and EventSecretRotateIncomplete are audited by
+// RotateSecretOnDemand (#193) when a manual/operator-triggered rotation of a
+// backend-bound secret fails outright, or partially completes (new credential minted
+// but a prior one survived upstream), respectively — distinct from the plain
+// "secret.rotated" success event so an operator can find and act on them.
+const (
+	EventSecretRotateFailed     = "secret.rotate_failed"
+	EventSecretRotateIncomplete = "secret.rotate_incomplete"
+)
+
 // notifyRotationFailures broadcasts a single summary of ONE project's rotation
 // failures to the configured deployment-wide notification channel (Slack/Teams/
 // webhook/email) — a silently-failed credential rotation is a security event
@@ -425,6 +435,65 @@ func (c *KeyorixCore) applyBackendRotation(ctx context.Context, secret *models.S
 		return "", err
 	}
 	return candidate, nil
+}
+
+// RotateSecretOnDemand handles a manual/operator-triggered rotation request (e.g. the
+// POST /secrets/{id}/rotate API) with the same backend awareness as the auto-rotation
+// scheduler (#193): if the secret is bound to a configured rotation backend (ADR-047),
+// the upstream credential is rotated FIRST via applyBackendRotation — the exact machinery
+// rotateOneSecret uses — and the value actually stored in Keyorix is the one the backend
+// produced/confirmed, never an arbitrary caller-supplied value that could silently drift
+// from what's live upstream. Previously this path stored the caller's value verbatim,
+// left the real (possibly suspected-compromised) upstream credential fully untouched, and
+// still reported "rotated successfully" — an actively misleading incident-response tool.
+//
+// newValue is used as the candidate applied upstream for a password-SET backend; for a
+// generate-upstream backend (e.g. a cloud key API) it is ignored — the upstream mints its
+// own value, matching automated-rotation semantics. A secret with no configured backend
+// rotates exactly as before (delegates straight to RotateSecret).
+//
+// If the upstream rotation fails outright, nothing is stored and an error is returned —
+// the caller must never be told "success" while the suspected-compromised credential is
+// still live and untouched. If it only partially completes (a new credential was minted
+// but a prior one could not be removed upstream — rotation.PartialRotationError), the new
+// value is still stored (never orphan a freshly minted credential — a cloud key API often
+// returns key material only once) but an error is still returned, so the HTTP response is
+// never a clean "success" while a leftover credential needs manual operator removal; the
+// audit trail records the partial state distinctly either way.
+func (c *KeyorixCore) RotateSecretOnDemand(ctx context.Context, id uint, newValue []byte, rotatedBy string) (*models.SecretNode, error) {
+	secret, err := c.storage.GetSecret(ctx, id)
+	if err != nil {
+		return nil, fmt.Errorf("secret not found: %w", err)
+	}
+	if secret.RotationBackend == "" {
+		return c.RotateSecret(ctx, id, newValue, rotatedBy)
+	}
+
+	upstreamVal, berr := c.applyBackendRotation(ctx, secret, string(newValue))
+	var partial *rotation.PartialRotationError
+	switch {
+	case errors.As(berr, &partial):
+		// The upstream minted the new credential but a prior, possibly compromised one
+		// could not be removed. Store the new value (discarding it would orphan a live,
+		// untracked credential) but still fail the call — the leftover needs an operator.
+		updated, serr := c.RotateSecret(ctx, id, []byte(partial.Value), rotatedBy)
+		if serr != nil {
+			return nil, serr
+		}
+		sid := id
+		c.writeAuditEvent(ctx, EventSecretRotateIncomplete, nil, &sid,
+			fmt.Sprintf("on-demand rotation INCOMPLETE for secret %q via backend %q ref %q: new credential stored but a prior credential is still live and must be removed manually: %v",
+				secret.Name, secret.RotationBackend, secret.RotationRef, berr))
+		return updated, fmt.Errorf("backend %q rotation for secret %q partially completed: new credential stored but a prior credential is still live upstream and must be removed manually: %w",
+			secret.RotationBackend, secret.Name, berr)
+	case berr != nil:
+		sid := id
+		c.writeAuditEvent(ctx, EventSecretRotateFailed, nil, &sid,
+			fmt.Sprintf("on-demand rotation FAILED for secret %q via backend %q ref %q: %v", secret.Name, secret.RotationBackend, secret.RotationRef, berr))
+		return nil, fmt.Errorf("backend %q rotation failed for secret %q (upstream credential NOT rotated): %w", secret.RotationBackend, secret.Name, berr)
+	default:
+		return c.RotateSecret(ctx, id, []byte(upstreamVal), rotatedBy)
+	}
 }
 
 // knownRotationCharset reports whether name is a recognized charset (or "" = default).

--- a/internal/core/rotation_executor_test.go
+++ b/internal/core/rotation_executor_test.go
@@ -589,3 +589,141 @@ func TestRunAutoRotation_BackendSucceedsStoreFails_AuditsDrift(t *testing.T) {
 	assert.Contains(t, events[0].Description, "DRIFT", "the backend-succeeded-store-failed case must be audited as drift")
 	assert.Contains(t, events[0].Description, "app_svc", "the audit must name the upstream ref to reconcile")
 }
+
+// ── #193: RotateSecretOnDemand — the manual/operator rotation path must actually drive
+// backend rotation for a backend-bound secret, never silently store an arbitrary
+// caller-supplied value while leaving the real upstream credential untouched. ──
+
+// fakePartialGenExecutor is a generate-upstream backend whose GenerateUpstream can
+// return a rotation.PartialRotationError: the new credential is minted upstream but a
+// follow-up cleanup step (deleting the prior one) fails — the new value must still be
+// stored (never orphan a freshly minted, untracked credential).
+type fakePartialGenExecutor struct {
+	name    string
+	value   string
+	partial bool
+	gotRef  string
+}
+
+func (f *fakePartialGenExecutor) Name() string { return f.name }
+func (f *fakePartialGenExecutor) Type() string { return "fakepartial" }
+func (f *fakePartialGenExecutor) Rotate(context.Context, string, string) error {
+	return errors.New("use GenerateUpstream")
+}
+func (f *fakePartialGenExecutor) GenerateUpstream(_ context.Context, ref string) (string, error) {
+	f.gotRef = ref
+	if f.partial {
+		return "", &rotation.PartialRotationError{Value: f.value, Err: errors.New("could not delete prior key")}
+	}
+	return f.value, nil
+}
+
+// A secret with no configured rotation backend rotates exactly as before: the
+// caller-supplied value is stored verbatim.
+func TestRotateSecretOnDemand_NoBackendStoresCallerValue(t *testing.T) {
+	c, db, fixed := rotationExecCore(t)
+	seedRotatableSecret(t, db, 1, "plain", false, fixed.Add(-24*time.Hour))
+
+	updated, err := c.RotateSecretOnDemand(context.Background(), 1, []byte("caller-value"), "alice")
+	require.NoError(t, err)
+	assert.NotNil(t, updated.LastRotatedAt)
+	v := latestVersion(t, db, 1)
+	assert.Equal(t, "caller-value", string(v.EncryptedValue))
+}
+
+// The core #193 regression: a manual on-demand rotate of a backend-bound secret must
+// actually invoke the backend rotation executor (not just overwrite the stored value),
+// and the value stored in Keyorix is the one the backend applied/confirmed.
+func TestRotateSecretOnDemand_AppliesBackend(t *testing.T) {
+	fake := &fakeExecutor{name: "pg"}
+	c, db, fixed := rotationExecCore(t)
+	c.SetRotationManager(rotation.NewManager([]rotation.Executor{fake}))
+	seedBackendSecret(t, db, 1, "pg", "app_svc", fixed.Add(-24*time.Hour))
+
+	updated, err := c.RotateSecretOnDemand(context.Background(), 1, []byte("operator-supplied"), "alice")
+	require.NoError(t, err)
+
+	require.True(t, fake.called, "the manual rotate must actually invoke the backend executor")
+	assert.Equal(t, "app_svc", fake.gotRef)
+	assert.Equal(t, "operator-supplied", fake.gotVal, "the caller's candidate is what gets applied upstream")
+
+	v := latestVersion(t, db, 1)
+	assert.Equal(t, 2, v.VersionNumber)
+	assert.Equal(t, fake.gotVal, string(v.EncryptedValue), "the stored value matches what was actually applied upstream")
+	assert.NotNil(t, updated.LastRotatedAt)
+}
+
+// For a generate-upstream backend the caller's candidate is ignored — the stored value
+// is what the upstream minted, matching automated-rotation semantics.
+func TestRotateSecretOnDemand_GenerateUpstreamIgnoresCandidate(t *testing.T) {
+	fake := &fakePartialGenExecutor{name: "cloud", value: `{"access_key_id":"AKIANEW"}`}
+	c, db, fixed := rotationExecCore(t)
+	c.SetRotationManager(rotation.NewManager([]rotation.Executor{fake}))
+	seedBackendSecret(t, db, 1, "cloud", "svc-app", fixed.Add(-24*time.Hour))
+
+	_, err := c.RotateSecretOnDemand(context.Background(), 1, []byte("ignored-candidate"), "alice")
+	require.NoError(t, err)
+	assert.Equal(t, "svc-app", fake.gotRef)
+	v := latestVersion(t, db, 1)
+	assert.Equal(t, fake.value, string(v.EncryptedValue))
+}
+
+// If the upstream rotation fails outright, nothing is stored — the response must never
+// be a misleading "success" while the suspected-compromised credential is untouched.
+func TestRotateSecretOnDemand_BackendFailureRefused(t *testing.T) {
+	fake := &fakeExecutor{name: "pg", err: errors.New("connection refused")}
+	c, db, fixed := rotationExecCore(t)
+	c.SetRotationManager(rotation.NewManager([]rotation.Executor{fake}))
+	seedBackendSecret(t, db, 1, "pg", "app_svc", fixed.Add(-24*time.Hour))
+
+	_, err := c.RotateSecretOnDemand(context.Background(), 1, []byte("operator-supplied"), "alice")
+	require.Error(t, err, "an upstream rotation failure must never look like success")
+	assert.Contains(t, err.Error(), "backend")
+	assert.Contains(t, err.Error(), "NOT rotated")
+
+	require.True(t, fake.called)
+	v := latestVersion(t, db, 1)
+	assert.Equal(t, 1, v.VersionNumber, "no new value is stored when the upstream apply fails")
+
+	var events []models.AuditEvent
+	require.NoError(t, db.Where("event_type = ?", EventSecretRotateFailed).Find(&events).Error)
+	require.Len(t, events, 1, "the failure is audited distinctly")
+	assert.Contains(t, events[0].Description, "app_svc")
+}
+
+// A partial upstream failure (new credential minted, prior one could not be removed)
+// still stores the new value — discarding it would orphan a live, untracked credential —
+// but the call still returns an error so the caller is never told "success" while a
+// leftover credential needs manual removal.
+func TestRotateSecretOnDemand_PartialFailureStoresButErrors(t *testing.T) {
+	fake := &fakePartialGenExecutor{name: "cloud", value: `{"access_key_id":"AKIANEW"}`, partial: true}
+	c, db, fixed := rotationExecCore(t)
+	c.SetRotationManager(rotation.NewManager([]rotation.Executor{fake}))
+	seedBackendSecret(t, db, 1, "cloud", "svc-app", fixed.Add(-24*time.Hour))
+
+	updated, err := c.RotateSecretOnDemand(context.Background(), 1, []byte("ignored"), "alice")
+	require.Error(t, err, "a partial upstream cleanup failure must not report success")
+	assert.NotNil(t, updated, "the new value is still returned/stored — never orphan a freshly minted credential")
+
+	v := latestVersion(t, db, 1)
+	assert.Equal(t, 2, v.VersionNumber)
+	assert.Equal(t, fake.value, string(v.EncryptedValue), "the newly minted credential is stored despite the partial failure")
+
+	var events []models.AuditEvent
+	require.NoError(t, db.Where("event_type = ?", EventSecretRotateIncomplete).Find(&events).Error)
+	require.Len(t, events, 1, "the partial outcome is audited distinctly from both success and outright failure")
+}
+
+// An unknown backend name (misconfigured after a manager reload) is refused, not
+// silently treated as a plain Keyorix-only rotation.
+func TestRotateSecretOnDemand_UnknownBackendRefused(t *testing.T) {
+	c, db, fixed := rotationExecCore(t)
+	c.SetRotationManager(rotation.NewManager([]rotation.Executor{&fakeExecutor{name: "other"}}))
+	seedBackendSecret(t, db, 1, "pg", "app_svc", fixed.Add(-24*time.Hour))
+
+	_, err := c.RotateSecretOnDemand(context.Background(), 1, []byte("x"), "alice")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown rotation backend")
+	v := latestVersion(t, db, 1)
+	assert.Equal(t, 1, v.VersionNumber, "nothing is stored for an unresolvable backend")
+}

--- a/server/http/handlers/secrets_versions.go
+++ b/server/http/handlers/secrets_versions.go
@@ -87,11 +87,22 @@ func (h *SecretHandler) RotateSecret(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	secret, err := h.coreService.RotateSecret(r.Context(), uint(id), []byte(reqBody.NewValue), userCtx.Username)
+	// RotateSecretOnDemand (#193): for a backend-bound secret this rotates the upstream
+	// credential too (the same machinery the auto-rotation scheduler uses) rather than
+	// just overwriting the stored value — never report success while the real,
+	// potentially compromised credential is still live untouched upstream.
+	secret, err := h.coreService.RotateSecretOnDemand(r.Context(), uint(id), []byte(reqBody.NewValue), userCtx.Username)
 	if err != nil {
-		if strings.Contains(err.Error(), "not found") {
+		switch {
+		case strings.Contains(err.Error(), "not found"):
 			h.sendError(w, "NotFound", "Secret not found", http.StatusNotFound, nil)
-		} else {
+		case strings.Contains(err.Error(), "backend"):
+			// The upstream rotation failed or only partially completed — surfaced
+			// distinctly (502) so the caller never mistakes this for a clean success,
+			// even though a partial attempt may have stored a new value; see the audit
+			// trail (secret.rotate_failed / secret.rotate_incomplete) for the outcome.
+			h.sendError(w, "BackendRotationFailed", err.Error(), http.StatusBadGateway, nil)
+		default:
 			h.sendError(w, "InternalError", "Failed to rotate secret", http.StatusInternalServerError, nil)
 		}
 		return


### PR DESCRIPTION
Replaces #559 (that PR's head branch had to be deleted/recreated during a rebase in this environment, which GitHub does not allow reopening after).

Rebased onto current main; #193 (RotateSecretOnDemand) kept in full, unchanged — not on main at all. #192 was mostly already covered by main's own RevokeLeasesForConfig-retries-revoke_failed regression tests (added by other work), but the actual RevokeError-clearing fix in RevokeLease itself was still missing — this PR's dynamic_secrets.go hunk applied cleanly, and I merged the test coverage (kept main's existing tests, added this PR's RevokeError assertions to them, rather than duplicating near-identical tests).

- #192: RevokeLease now clears the stale RevokeError once a retry succeeds — previously a cleanly re-revoked lease kept showing its earlier failure message.
- #193: the manual POST /secrets/{id}/rotate endpoint now drives the secret's configured rotation backend first via the new RotateSecretOnDemand (reusing the auto-rotation scheduler's applyBackendRotation), instead of just overwriting the stored value while leaving the real upstream credential untouched.

Also resolved a real conflict in rotation_executor.go: main's notifyRotationFailures was since changed to a per-project-scoped signature (#391 fix, PR #628) — kept that signature and added this PR's new EventSecretRotateFailed/EventSecretRotateIncomplete audit-event constants alongside it.

Note: `go test ./internal/core/...` has 3 pre-existing, unrelated failures on main (TestDynamicSecrets_InstallWideMaxLeaseTTL{ClampsIssue,DefaultsWhenUnset}/TestDynamicSecrets_RenewRespectsInstallWideMaxLeaseTTL) — these test requests were never updated with `ActorID: testAdminActorID` after PR #551 added an admin-authority check to CreateDynamicSecretConfig. Not caused by this PR, and not CI-gated (CI's build-and-test job excludes `internal/core` from `go test` entirely). Worth a follow-up fix.