### PR TITLE
fix: governance & detection controls hardening (#144, #157, #163, #166, #170, #217)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,7 @@ require (
 	golang.org/x/sync v0.21.0
 	golang.org/x/term v0.43.0
 	golang.org/x/text v0.37.0
+	golang.org/x/time v0.15.0
 	google.golang.org/api v0.274.0
 	google.golang.org/grpc v1.80.0
 	google.golang.org/protobuf v1.36.11
@@ -136,7 +137,6 @@ require (
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect
-	golang.org/x/time v0.15.0 // indirect
 	google.golang.org/genproto v0.0.0-20260319201613-d00831a3d3e7 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect

--- a/internal/cli/risk/risk.go
+++ b/internal/cli/risk/risk.go
@@ -30,6 +30,10 @@ type exceptionView struct {
 	Status        string `json:"status"`
 	ExpiresAt     string `json:"expires_at"`
 	CreatedBy     uint   `json:"created_by"`
+	// Approved is dual-control (#170): the exception only suppresses its matched
+	// violation from the compliance posture once a different system.write holder
+	// than the creator approves it (`keyorix risk approve`).
+	Approved bool `json:"approved"`
 }
 
 var listAll bool
@@ -58,7 +62,11 @@ var listCmd = &cobra.Command{
 			return nil
 		}
 		for _, e := range out.Exceptions {
-			fmt.Printf("[%s] #%d %s (category=%s, ref=%q)\n", e.Status, e.ID, e.Title, e.Category, e.Reference)
+			approval := "pending approval"
+			if e.Approved {
+				approval = "approved"
+			}
+			fmt.Printf("[%s, %s] #%d %s (category=%s, ref=%q)\n", e.Status, approval, e.ID, e.Title, e.Category, e.Reference)
 			fmt.Printf("        expires %s — %s\n", e.ExpiresAt, e.Justification)
 		}
 		return nil
@@ -102,6 +110,32 @@ var addCmd = &cobra.Command{
 	},
 }
 
+var approveID uint
+
+var approveCmd = &cobra.Command{
+	Use:   "approve",
+	Short: "Approve a risk exception so it takes effect (dual control — must not be its own creator)",
+	Long: `An exception is inert until approved: it does not suppress its matched
+violation from the compliance posture until a DIFFERENT system.write holder than
+the one who created it approves it. This prevents a single principal from
+unilaterally creating and self-approving a suppression of their own risk.`,
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		if approveID == 0 {
+			return fmt.Errorf("--id is required")
+		}
+		c, ok := common.NewRemoteClient()
+		if !ok {
+			return fmt.Errorf("not connected to a server — run: keyorix connect <server>")
+		}
+		if err := c.Post(context.Background(), fmt.Sprintf("/api/v1/risk-exceptions/%d/approve", approveID), nil, nil); err != nil {
+			return err
+		}
+		fmt.Printf("Risk exception %d approved.\n", approveID)
+		return nil
+	},
+}
+
 var revokeID uint
 
 var revokeCmd = &cobra.Command{
@@ -131,6 +165,7 @@ func init() {
 	addCmd.Flags().StringVar(&addReference, "reference", "", "What it applies to (a user, an SoD pair, a secret)")
 	addCmd.Flags().StringVar(&addJustification, "justification", "", "Why the risk is accepted (required, recorded for audit)")
 	addCmd.Flags().StringVar(&addExpires, "expires", "", "When the exception sunsets (RFC3339, required)")
+	approveCmd.Flags().UintVar(&approveID, "id", 0, "ID of the exception to approve (required)")
 	revokeCmd.Flags().UintVar(&revokeID, "id", 0, "ID of the exception to revoke (required)")
-	RiskCmd.AddCommand(listCmd, addCmd, revokeCmd)
+	RiskCmd.AddCommand(listCmd, addCmd, approveCmd, revokeCmd)
 }

--- a/internal/core/anomaly.go
+++ b/internal/core/anomaly.go
@@ -45,7 +45,9 @@ type StorageInterface = interface {
 	PrincipalSecretFirstSeen(ctx context.Context, since time.Time) (map[string]map[uint]time.Time, error)
 	CreateAnomalyAlert(ctx context.Context, alert *models.AnomalyAlert) error
 	ListAnomalyAlerts(ctx context.Context, acknowledged *bool) ([]models.AnomalyAlert, error)
-	AcknowledgeAnomalyAlert(ctx context.Context, id uint) error
+	// LogAuditEvent backs auditBusinessHoursConfig (#144) — a business-hours config
+	// change must be on the audit record even though it's applied in-memory here.
+	LogAuditEvent(ctx context.Context, event *models.AuditEvent) error
 }
 
 // SetLookback sets how far back each detection pass scans, flooring it at one hour. The
@@ -119,14 +121,23 @@ func (p offHoursPolicy) isOffHours(t time.Time) bool {
 // validHour reports whether h is a valid clock hour [0,23].
 func validHour(h int) bool { return h >= 0 && h <= 23 }
 
+// EventAnomalyBusinessHoursConfigured audits a change to the off_hours rule's
+// timezone/band (#144). A degenerate (start == end) or otherwise narrowed band
+// silently blinds that rule with no other visible symptom, so the config CHANGE
+// itself — not just its effect — must be on the record.
+const EventAnomalyBusinessHoursConfigured = "anomaly.business_hours_configured" // #nosec G101 -- audit event type, not a credential
+
 // SetBusinessHours configures the off_hours rule's timezone and band. tz is an IANA
 // name ("" = UTC); the off-hours band is [startHour, endHour) wrapping midnight, in
 // that timezone. A blank tz keeps UTC, and the band defaults to 22:00–06:00 unless
 // overridden. Because 0 is the config zero value AND a valid hour, both hours being 0
 // is treated as "unset" (a 0–0 band would be empty) — set the timezone alone and the
-// default band is kept. Returns an error only for an unparseable timezone, leaving the
-// prior policy unchanged.
-func (d *AnomalyDetector) SetBusinessHours(tz string, startHour, endHour int) error {
+// default band is kept. Returns an error for an unparseable timezone OR a degenerate
+// band (startHour == endHour for any other, explicitly-supplied pair) — a start==end
+// band matches no hour in isOffHours, which would silently disable the rule with no
+// validation error and no audit trail if allowed through. Either error leaves the
+// prior policy unchanged. On success the new band is recorded as an audit event.
+func (d *AnomalyDetector) SetBusinessHours(ctx context.Context, tz string, startHour, endHour int) error {
 	p := defaultOffHoursPolicy()
 	if tz != "" {
 		loc, err := time.LoadLocation(tz)
@@ -136,6 +147,9 @@ func (d *AnomalyDetector) SetBusinessHours(tz string, startHour, endHour int) er
 		p.loc = loc
 	}
 	if startHour != 0 || endHour != 0 { // both zero = unset → keep the default band
+		if validHour(startHour) && validHour(endHour) && startHour == endHour {
+			return fmt.Errorf("anomaly business_hours: start_hour and end_hour must differ (an equal start/end band is empty and would silently disable the off_hours rule; pass 0,0 to explicitly keep the default band)")
+		}
 		if validHour(startHour) {
 			p.start = startHour
 		}
@@ -144,7 +158,34 @@ func (d *AnomalyDetector) SetBusinessHours(tz string, startHour, endHour int) er
 		}
 	}
 	d.offHours = p
+	d.auditBusinessHoursConfig(ctx, tz, p)
 	return nil
+}
+
+// auditBusinessHoursConfig records the newly-applied off-hours band/timezone as an
+// audit event. Best-effort: a storage failure here must not undo the in-memory
+// policy change SetBusinessHours already applied, but it is logged loudly (a missed
+// audit write for a detection-control config change is itself a small gap).
+func (d *AnomalyDetector) auditBusinessHoursConfig(ctx context.Context, tz string, p offHoursPolicy) {
+	if d.storage == nil {
+		return
+	}
+	tzLabel := tz
+	if tzLabel == "" {
+		tzLabel = "UTC"
+	}
+	ok := true
+	event := &models.AuditEvent{
+		EventType: EventAnomalyBusinessHoursConfigured,
+		Description: fmt.Sprintf("anomaly off-hours band configured: timezone=%s band=%02d:00-%02d:00",
+			tzLabel, p.start, p.end),
+		Success:   &ok,
+		ActorType: "system",
+		EventTime: time.Now(),
+	}
+	if err := d.storage.LogAuditEvent(ctx, event); err != nil {
+		log.Printf("SECURITY: anomaly business-hours config: failed to write audit event: %v", err)
+	}
 }
 
 // accessBaseline holds statistical baseline for a secret's access patterns.
@@ -499,9 +540,4 @@ func FilterAlerts(alerts []models.AnomalyAlert, severity, alertType string) []mo
 		out = append(out, a)
 	}
 	return out
-}
-
-// AcknowledgeAlert marks an alert as acknowledged.
-func (d *AnomalyDetector) AcknowledgeAlert(ctx context.Context, id uint) error {
-	return d.storage.AcknowledgeAnomalyAlert(ctx, id)
 }

--- a/internal/core/anomaly_alerting.go
+++ b/internal/core/anomaly_alerting.go
@@ -9,6 +9,7 @@ package core
 import (
 	"context"
 	"fmt"
+	"log"
 
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
@@ -27,7 +28,7 @@ const EventAnomalyAcknowledged = "security.anomaly_acknowledged" // #nosec G101 
 // the audit trail. actorID is the operator performing the dismissal. The acknowledge is
 // gated at the transport by a write-level permission (it mutates a detection record).
 func (c *KeyorixCore) AcknowledgeAnomalyAlert(ctx context.Context, actorID, alertID uint) error {
-	if err := c.storage.AcknowledgeAnomalyAlert(ctx, alertID); err != nil {
+	if err := c.storage.AcknowledgeAnomalyAlert(ctx, alertID, actorID, c.now()); err != nil {
 		return err
 	}
 	var aid *uint
@@ -73,8 +74,14 @@ func (c *KeyorixCore) AlertNewAnomalies(ctx context.Context) (int, error) {
 		c.writeAuditEventFull(ctx, EventAnomalyDetected, nil, sid, pid, a.IPAddress,
 			fmt.Sprintf("anomaly (%s, %s): %s", a.AlertType, a.Severity, a.Description))
 
-		// In-app: alert the project's approver-role members.
-		c.notifyAnomalyAdmins(ctx, projectID, a)
+		// In-app: alert the project's approver-role members. The audit/SIEM event
+		// above is already durable regardless, so this is a detection-latency gap
+		// on failure, not a control failure — surface it loudly rather than
+		// swallowing it (#166, same silent-fail-on-ListProjectMembers-error pattern
+		// as notifyBreakGlassAdmins).
+		if nerr := c.notifyAnomalyAdmins(ctx, projectID, a); nerr != nil {
+			log.Printf("SECURITY: anomaly alert %d (project %d): admin notification failed: %v", a.ID, projectID, nerr)
+		}
 
 		if err := c.storage.MarkAnomalyAlertAlerted(ctx, a.ID); err != nil {
 			// Couldn't mark alerted — skip counting so a retry re-announces rather
@@ -86,16 +93,18 @@ func (c *KeyorixCore) AlertNewAnomalies(ctx context.Context) (int, error) {
 	return announced, nil
 }
 
-// notifyAnomalyAdmins sends an in-app alert to the project's approver-role members
-// (best-effort). With no resolvable project the in-app notify is skipped (the audit
-// + SIEM event still carries it).
-func (c *KeyorixCore) notifyAnomalyAdmins(ctx context.Context, projectID uint, a *models.AnomalyAlert) {
+// notifyAnomalyAdmins sends an in-app alert to the project's approver-role members.
+// With no resolvable project the in-app notify is skipped (the audit + SIEM event
+// still carries it) — not an error. Individual notify() delivery stays best-effort,
+// but a failure to list the project's members is a distinct, louder failure mode
+// (no admin was even considered), so that's returned as an error (#166).
+func (c *KeyorixCore) notifyAnomalyAdmins(ctx context.Context, projectID uint, a *models.AnomalyAlert) error {
 	if projectID == 0 {
-		return
+		return nil
 	}
 	members, err := c.storage.ListProjectMembers(ctx, projectID)
 	if err != nil {
-		return
+		return fmt.Errorf("list project %d members: %w", projectID, err)
 	}
 	pid := projectID
 	title := fmt.Sprintf("Anomaly detected (%s)", a.Severity)
@@ -107,4 +116,5 @@ func (c *KeyorixCore) notifyAnomalyAdmins(ctx context.Context, projectID uint, a
 		}
 		c.notify(ctx, m.UserID, EventAnomalyDetected, title, msg, &pid, link)
 	}
+	return nil
 }

--- a/internal/core/anomaly_test.go
+++ b/internal/core/anomaly_test.go
@@ -36,10 +36,10 @@ func (c *captureStore) CreateAnomalyAlert(_ context.Context, _ *models.AnomalyAl
 func (c *captureStore) ListAnomalyAlerts(_ context.Context, _ *bool) ([]models.AnomalyAlert, error) {
 	return nil, nil
 }
-func (c *captureStore) AcknowledgeAnomalyAlert(_ context.Context, _ uint) error { return nil }
 func (c *captureStore) PrincipalSecretFirstSeen(_ context.Context, _ time.Time) (map[string]map[uint]time.Time, error) {
 	return nil, nil
 }
+func (c *captureStore) LogAuditEvent(_ context.Context, _ *models.AuditEvent) error { return nil }
 
 // The recent-access scan window must honor the configured lookback (so a longer scan
 // cadence scans a proportionally longer window), and be floored at one hour.
@@ -279,21 +279,31 @@ func TestOffHoursPolicy(t *testing.T) {
 func TestSetBusinessHours(t *testing.T) {
 	d := NewAnomalyDetector(nil)
 
+	ctx := context.Background()
+
 	// Timezone only: the default 22–6 band is kept (both hours 0 = unset).
-	require.NoError(t, d.SetBusinessHours("America/New_York", 0, 0))
+	require.NoError(t, d.SetBusinessHours(ctx, "America/New_York", 0, 0))
 	assert.Equal(t, "America/New_York", d.offHours.loc.String())
 	assert.Equal(t, 22, d.offHours.start)
 	assert.Equal(t, 6, d.offHours.end)
 
 	// Custom band applied.
-	require.NoError(t, d.SetBusinessHours("UTC", 20, 7))
+	require.NoError(t, d.SetBusinessHours(ctx, "UTC", 20, 7))
 	assert.Equal(t, 20, d.offHours.start)
 	assert.Equal(t, 7, d.offHours.end)
 
 	// Invalid timezone: error, and the prior policy is left unchanged.
 	before := d.offHours
-	require.Error(t, d.SetBusinessHours("Not/AZone", 1, 2))
+	require.Error(t, d.SetBusinessHours(ctx, "Not/AZone", 1, 2))
 	assert.Equal(t, before, d.offHours, "an invalid timezone must not mutate the policy")
+
+	// #144: a degenerate non-zero start==end band matches no hour in isOffHours,
+	// silently disabling the rule — must be rejected, and the prior policy kept.
+	before = d.offHours
+	err := d.SetBusinessHours(ctx, "UTC", 9, 9)
+	require.Error(t, err, "an equal, non-zero start/end band must be rejected")
+	assert.Contains(t, err.Error(), "must differ")
+	assert.Equal(t, before, d.offHours, "a rejected degenerate band must not mutate the policy")
 }
 
 func TestVolumeSpike(t *testing.T) {

--- a/internal/core/break_glass.go
+++ b/internal/core/break_glass.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/core/storage"
@@ -161,7 +162,16 @@ func (c *KeyorixCore) ActivateBreakGlass(ctx context.Context, projectID, userID 
 	c.auditProjectScoped(ctx, EventBreakGlassActivated, userID, projectID,
 		fmt.Sprintf("break-glass: user %d self-granted %q until %s — %s",
 			userID, role.Name, expiresAt.UTC().Format(time.RFC3339), justification))
-	c.notifyBreakGlassAdmins(ctx, userID, projectID, role.Name, expiresAt)
+	// The grant is already committed and audited above, so a notification failure here
+	// is a DETECTION-LATENCY gap, not a control failure — don't fail the activation on
+	// it. But silently swallowing it would defeat break-glass's "loud by design" intent
+	// if the notification pipeline itself is down, so surface it loudly (#166): a
+	// SECURITY-prefixed log line, matching the convention emitAudit already uses for a
+	// failed audit write, so an operational alerting pipeline watching logs still pages.
+	if nerr := c.notifyBreakGlassAdmins(ctx, userID, projectID, role.Name, expiresAt); nerr != nil {
+		log.Printf("SECURITY: break-glass activation %d (project %d, user %d): admin notification failed: %v",
+			activation.ID, projectID, userID, nerr)
+	}
 	return activation, nil
 }
 
@@ -232,11 +242,15 @@ func (c *KeyorixCore) RevokeBreakGlass(ctx context.Context, actorID, projectID, 
 }
 
 // notifyBreakGlassAdmins alerts the project's approver-role members that emergency
-// access was activated (best-effort).
-func (c *KeyorixCore) notifyBreakGlassAdmins(ctx context.Context, actorID, projectID uint, roleName string, expiresAt time.Time) {
+// access was activated. Individual notify() delivery is still best-effort (an
+// email/webhook sink hiccup for one admin shouldn't abort the fan-out to the
+// others), but a failure to even LIST the project's members is a distinct, louder
+// failure mode — it means NO admin was considered for the alert at all — so that
+// case is returned as an error (#166) rather than swallowed silently.
+func (c *KeyorixCore) notifyBreakGlassAdmins(ctx context.Context, actorID, projectID uint, roleName string, expiresAt time.Time) error {
 	members, err := c.storage.ListProjectMembers(ctx, projectID)
 	if err != nil {
-		return
+		return fmt.Errorf("list project %d members: %w", projectID, err)
 	}
 	pid := projectID
 	title := "Break-glass emergency access activated"
@@ -249,4 +263,5 @@ func (c *KeyorixCore) notifyBreakGlassAdmins(ctx context.Context, actorID, proje
 		}
 		c.notify(ctx, m.UserID, EventBreakGlassActivated, title, msg, &pid, link)
 	}
+	return nil
 }

--- a/internal/core/compliance_posture.go
+++ b/internal/core/compliance_posture.go
@@ -275,9 +275,11 @@ func (c *KeyorixCore) GetCompliancePosture(ctx context.Context) (*CompliancePost
 		return nil, err
 	}
 
-	// Separation-of-duties violations (A.5.3).
+	// Separation-of-duties violations (A.5.3), net of governed risk exceptions
+	// (#170): an approved, active "sod"-category exception suppresses only the ONE
+	// violation it names, not the whole SoD control.
 	if violations, err := c.DetectSoDViolations(ctx); err == nil {
-		p.AccessGovernance.SoDViolations = len(violations)
+		p.AccessGovernance.SoDViolations = len(c.suppressExceptedSoDViolations(ctx, violations))
 	} else {
 		p.degrade("sod_violations", err)
 	}
@@ -342,6 +344,41 @@ func (c *KeyorixCore) GetCompliancePosture(ctx context.Context) (*CompliancePost
 	p.SupplyChain = sc
 
 	return p, nil
+}
+
+// suppressExceptedSoDViolations drops any violation covered by an active, APPROVED
+// "sod"-category risk exception whose Reference matches it exactly (#170). Before
+// this, a registered exception was purely decorative — GetCompliancePosture
+// reported every raw violation regardless, so the "governed acceptance" mechanism
+// didn't actually accept anything. Fails safe: a lookup error reports every
+// violation unfiltered rather than risking an under-count from a partial exception
+// list.
+func (c *KeyorixCore) suppressExceptedSoDViolations(ctx context.Context, violations []SoDViolation) []SoDViolation {
+	if len(violations) == 0 {
+		return violations
+	}
+	exceptions, err := c.ListRiskExceptions(ctx, true) // active only (not revoked, not expired)
+	if err != nil {
+		return violations
+	}
+	excepted := make(map[string]bool, len(exceptions))
+	for _, e := range exceptions {
+		if e.Category != "sod" || !e.Approved {
+			continue
+		}
+		excepted[e.Reference] = true
+	}
+	if len(excepted) == 0 {
+		return violations
+	}
+	out := make([]SoDViolation, 0, len(violations))
+	for _, v := range violations {
+		if excepted[v.Reference] {
+			continue
+		}
+		out = append(out, v)
+	}
+	return out
 }
 
 // classificationPosture counts secrets per classification level via cheap count

--- a/internal/core/dynamic_secrets_test.go
+++ b/internal/core/dynamic_secrets_test.go
@@ -354,6 +354,7 @@ func TestDynamicSecrets_InstallWideMaxLeaseTTLClampsIssue(t *testing.T) {
 	cfg, err := c.CreateDynamicSecretConfig(ctx, &CreateDynamicSecretConfigRequest{
 		Name: "unbounded", ProjectID: 1, BackendType: "postgres", AdminDSN: adminDSNPlain,
 		// No MaxTTLSeconds — the per-config ceiling is unset/unbounded.
+		ActorID: testAdminActorID,
 	})
 	require.NoError(t, err)
 
@@ -371,6 +372,7 @@ func TestDynamicSecrets_InstallWideMaxLeaseTTLDefaultsWhenUnset(t *testing.T) {
 	ctx := context.Background()
 	cfg, err := c.CreateDynamicSecretConfig(ctx, &CreateDynamicSecretConfigRequest{
 		Name: "unbounded", ProjectID: 1, BackendType: "postgres", AdminDSN: adminDSNPlain,
+		ActorID: testAdminActorID,
 	})
 	require.NoError(t, err)
 
@@ -462,6 +464,7 @@ func TestDynamicSecrets_RenewRespectsInstallWideMaxLeaseTTL(t *testing.T) {
 	cfg, err := c.CreateDynamicSecretConfig(ctx, &CreateDynamicSecretConfigRequest{
 		Name: "unbounded", ProjectID: 1, BackendType: "postgres", AdminDSN: adminDSNPlain,
 		DefaultTTLSeconds: 300, // no MaxTTLSeconds — per-config ceiling unset
+		ActorID:           testAdminActorID,
 	})
 	require.NoError(t, err)
 

--- a/internal/core/legal_hold.go
+++ b/internal/core/legal_hold.go
@@ -109,6 +109,19 @@ func (c *KeyorixCore) PlaceLegalHold(ctx context.Context, actorID uint, reason s
 // audit trail showed WHO/WHEN a hold was lifted but never WHY. reason is required,
 // mirroring placement's own required-reason precedent, and is persisted on the row
 // (ReleaseReason) and in the audit description.
+//
+// Separation of duties (#157): both place and lift are gated on the same
+// system.write permission, so without an additional check whoever placed a hold
+// specifically to preserve evidence could have it lifted by any other system.write
+// holder — including, worst case, an insider under investigation lifting a hold a
+// colleague placed over that insider's own conduct. Rather than a full dual-control
+// workflow (which would need a new approval step this compliance control doesn't
+// otherwise have), the practical restriction is: only the placer OR a principal who
+// holds an admin-tier (permission-bypass) role may lift — mirroring the "different,
+// higher-tier principal" framing without inventing a new permission tier, and
+// without deadlocking release if the original placer is unavailable. A denied
+// attempt is itself audited (distinctly from a successful lift) so the asymmetry
+// between placer and lifter is visible either way.
 func (c *KeyorixCore) LiftLegalHold(ctx context.Context, actorID uint, reason string) error {
 	if reason == "" {
 		return fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "a reason is required to lift a legal hold")
@@ -120,6 +133,12 @@ func (c *KeyorixCore) LiftLegalHold(ctx context.Context, actorID uint, reason st
 	if hold == nil {
 		return fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "no legal hold is active")
 	}
+	if actorID != hold.PlacedBy && c.adminRoleName(ctx, actorID) == "" {
+		c.writeAuditEventFailed(ctx, EventLegalHoldLifted, actorPtr(actorID), "",
+			fmt.Sprintf("legal hold %d lift DENIED: actor %d is neither the placer (%d) nor an admin-tier principal", hold.ID, actorID, hold.PlacedBy))
+		return fmt.Errorf("%s: %s", i18n.T("ErrorPermissionDenied", nil),
+			"only the placing admin or an admin-tier principal may lift this legal hold")
+	}
 	now := c.now()
 	hold.Released = true
 	hold.ReleasedBy = actorID
@@ -129,6 +148,6 @@ func (c *KeyorixCore) LiftLegalHold(ctx context.Context, actorID uint, reason st
 		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}
 	c.writeAuditEvent(ctx, EventLegalHoldLifted, actorPtr(actorID), nil,
-		fmt.Sprintf("legal hold %d lifted: %s", hold.ID, reason))
+		fmt.Sprintf("legal hold %d lifted by %d (originally placed by %d): %s", hold.ID, actorID, hold.PlacedBy, reason))
 	return nil
 }

--- a/internal/core/legal_hold_external_test.go
+++ b/internal/core/legal_hold_external_test.go
@@ -115,6 +115,41 @@ func TestLegalHold_LiftRecordsReason(t *testing.T) {
 	assert.Contains(t, evt.Description, "litigation INC-11 settled, no further preservation needed")
 }
 
+// #157: a third-party system.write holder who neither placed the hold nor holds an
+// admin-tier role must not be able to lift it — only the placer or an admin-tier
+// principal may. The denial is itself audited, and the hold stays active.
+func TestLegalHold_LiftDeniedForThirdParty(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(&models.LegalHold{}, &models.AuditEvent{}, &models.User{}, &models.UserRole{}))
+	ctx := context.Background()
+
+	_, err := h.CoreService.PlaceLegalHold(ctx, 1, "litigation INC-9")
+	require.NoError(t, err)
+
+	// Actor 9 holds no role at all — neither the placer nor admin-tier.
+	err = h.CoreService.LiftLegalHold(ctx, 9)
+	require.Error(t, err, "a non-placer, non-admin actor must not be able to lift the hold")
+
+	active, aerr := h.CoreService.IsLegalHoldActive(ctx)
+	require.NoError(t, aerr)
+	assert.True(t, active, "the hold must remain active after a denied lift attempt")
+
+	// The denial is audited distinctly (event still EventLegalHoldLifted per the
+	// implementation, but with Success=false — verify a failed attempt was recorded).
+	var failed int64
+	require.NoError(t, h.DB.Model(&models.AuditEvent{}).
+		Where("event_type = ? AND success = ?", core.EventLegalHoldLifted, false).Count(&failed).Error)
+	assert.Equal(t, int64(1), failed, "the denied lift attempt must be audited")
+
+	// A DIFFERENT admin-tier principal (not the placer) may still lift it.
+	h.AssignUserRole(t, 20, 2, nil) // role 2 = admin (global)
+	require.NoError(t, h.CoreService.LiftLegalHold(ctx, 20))
+	active, aerr = h.CoreService.IsLegalHoldActive(ctx)
+	require.NoError(t, aerr)
+	assert.False(t, active, "an admin-tier non-placer must be able to lift the hold")
+}
+
 // The compliance posture reflects an active legal hold.
 func TestLegalHold_SurfacesInPosture(t *testing.T) {
 	h := testhelper.NewRBACTestHelper(t)

--- a/internal/core/legal_hold_external_test.go
+++ b/internal/core/legal_hold_external_test.go
@@ -124,11 +124,15 @@ func TestLegalHold_LiftDeniedForThirdParty(t *testing.T) {
 	require.NoError(t, h.DB.AutoMigrate(&models.LegalHold{}, &models.AuditEvent{}, &models.User{}, &models.UserRole{}))
 	ctx := context.Background()
 
+	// #377: placement itself now requires an admin-tier actor — make the placer (1)
+	// admin-tier so PlaceLegalHold succeeds; the point under test here is who may
+	// LIFT relative to the placer, not placement's own authority gate.
+	h.AssignUserRole(t, 1, 2, nil) // role 2 = admin (global)
 	_, err := h.CoreService.PlaceLegalHold(ctx, 1, "litigation INC-9")
 	require.NoError(t, err)
 
 	// Actor 9 holds no role at all — neither the placer nor admin-tier.
-	err = h.CoreService.LiftLegalHold(ctx, 9)
+	err = h.CoreService.LiftLegalHold(ctx, 9, "attempted lift")
 	require.Error(t, err, "a non-placer, non-admin actor must not be able to lift the hold")
 
 	active, aerr := h.CoreService.IsLegalHoldActive(ctx)
@@ -144,7 +148,7 @@ func TestLegalHold_LiftDeniedForThirdParty(t *testing.T) {
 
 	// A DIFFERENT admin-tier principal (not the placer) may still lift it.
 	h.AssignUserRole(t, 20, 2, nil) // role 2 = admin (global)
-	require.NoError(t, h.CoreService.LiftLegalHold(ctx, 20))
+	require.NoError(t, h.CoreService.LiftLegalHold(ctx, 20, "litigation INC-9 resolved by admin"))
 	active, aerr = h.CoreService.IsLegalHoldActive(ctx)
 	require.NoError(t, aerr)
 	assert.False(t, active, "an admin-tier non-placer must be able to lift the hold")

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -1146,8 +1146,8 @@ func (m *MockStorage) ListAnomalyAlerts(ctx context.Context, acknowledged *bool)
 	return args.Get(0).([]models.AnomalyAlert), args.Error(1)
 }
 
-func (m *MockStorage) AcknowledgeAnomalyAlert(ctx context.Context, id uint) error {
-	args := m.Called(ctx, id)
+func (m *MockStorage) AcknowledgeAnomalyAlert(ctx context.Context, id, actorID uint, at time.Time) error {
+	args := m.Called(ctx, id, actorID, at)
 	return args.Error(0)
 }
 

--- a/internal/core/risk_exceptions.go
+++ b/internal/core/risk_exceptions.go
@@ -21,8 +21,9 @@ const (
 	ExceptionStatusExpired = "expired"
 	ExceptionStatusRevoked = "revoked"
 
-	EventRiskExceptionCreated = "risk.exception_created"
-	EventRiskExceptionRevoked = "risk.exception_revoked"
+	EventRiskExceptionCreated  = "risk.exception_created"
+	EventRiskExceptionRevoked  = "risk.exception_revoked"
+	EventRiskExceptionApproved = "risk.exception_approved"
 )
 
 // validExceptionCategories are the risk areas an exception may cover (aligned with
@@ -53,7 +54,13 @@ func exceptionStatus(e *models.RiskException, now time.Time) string {
 const maxRiskExceptionDuration = 365 * 24 * time.Hour
 
 // CreateRiskException records a governed, time-bound acceptance of a control gap.
-// actorID is the accepting owner; expiresAt must be in the future.
+// actorID is the accepting owner; expiresAt must be in the future. The exception
+// does NOT suppress anything yet: it must be separately approved by a DIFFERENT
+// system.write holder (see ApproveRiskException) before it takes effect — dual
+// control (#170), so the creator can't unilaterally suppress a violation of their
+// own. For category "sod", reference should be the matching SoDViolation's
+// Reference field (as returned by GET /sod/violations) so the exception, once
+// approved, suppresses that one violation specifically.
 func (c *KeyorixCore) CreateRiskException(ctx context.Context, actorID uint, title, category, reference, justification string, expiresAt time.Time) (*models.RiskException, error) {
 	if title == "" || justification == "" {
 		return nil, fmt.Errorf("title and justification are required")
@@ -120,6 +127,42 @@ func (c *KeyorixCore) RevokeRiskException(ctx context.Context, actorID, id uint)
 	}
 	c.writeAuditEvent(ctx, EventRiskExceptionRevoked, actorPtr(actorID), nil,
 		fmt.Sprintf("risk exception %d revoked: %q", id, e.Title))
+	return nil
+}
+
+// ApproveRiskException dual-controls an exception (#170): actorID must be a
+// DIFFERENT principal than the one who created it. Only an approved, still-active
+// exception suppresses its matched violation from the compliance posture — before
+// approval the raw violation keeps counting, so a self-dealt exception has no
+// effect. A denied self-approval attempt is itself audited distinctly from a grant.
+func (c *KeyorixCore) ApproveRiskException(ctx context.Context, actorID, id uint) error {
+	e, err := c.storage.GetRiskException(ctx, id)
+	if err != nil {
+		return err
+	}
+	if e.Revoked {
+		return fmt.Errorf("cannot approve a revoked risk exception")
+	}
+	if exceptionStatus(e, c.now()) == ExceptionStatusExpired {
+		return fmt.Errorf("cannot approve an expired risk exception")
+	}
+	if e.Approved {
+		return fmt.Errorf("risk exception %d is already approved", id)
+	}
+	if actorID == e.CreatedBy {
+		c.writeAuditEventFailed(ctx, EventRiskExceptionApproved, actorPtr(actorID), "",
+			fmt.Sprintf("risk exception %d approval DENIED: creator %d cannot self-approve", id, actorID))
+		return fmt.Errorf("the exception's creator cannot approve it (dual control); a different system.write holder must approve")
+	}
+	now := c.now()
+	e.Approved = true
+	e.ApprovedBy = actorID
+	e.ApprovedAt = &now
+	if err := c.storage.UpdateRiskException(ctx, e); err != nil {
+		return err
+	}
+	c.writeAuditEvent(ctx, EventRiskExceptionApproved, actorPtr(actorID), nil,
+		fmt.Sprintf("risk exception %d approved by %d (created by %d): %q", id, actorID, e.CreatedBy, e.Title))
 	return nil
 }
 

--- a/internal/core/risk_exceptions_test.go
+++ b/internal/core/risk_exceptions_test.go
@@ -88,6 +88,59 @@ func TestRevokeRiskException(t *testing.T) {
 	require.NoError(t, c.RevokeRiskException(context.Background(), 3, 5))
 }
 
+// #170: the creator of a risk exception cannot approve their own exception — dual
+// control. The audit trail records the denial distinctly (Success=false) and the
+// exception is left unapproved (no UpdateRiskException call expected).
+func TestApproveRiskException_DeniesSelfApproval(t *testing.T) {
+	now := time.Now()
+	store := new(MockStorage)
+	store.On("GetRiskException", mock.Anything, uint(5)).Return(&models.RiskException{ID: 5, Title: "x", CreatedBy: 9, ExpiresAt: now.Add(24 * time.Hour)}, nil)
+	var audited *models.AuditEvent
+	store.On("LogAuditEvent", mock.Anything, mock.MatchedBy(func(ev *models.AuditEvent) bool {
+		if ev.EventType == EventRiskExceptionApproved {
+			audited = ev
+			return true
+		}
+		return false
+	})).Return(nil)
+
+	c := riskCore(store, now)
+	err := c.ApproveRiskException(context.Background(), 9, 5) // actor 9 == creator 9
+	require.Error(t, err, "the creator must not be able to approve their own exception")
+	assert.Contains(t, err.Error(), "cannot approve it")
+	require.NotNil(t, audited, "the denial must still be audited")
+	require.NotNil(t, audited.Success)
+	assert.False(t, *audited.Success)
+	store.AssertNotCalled(t, "UpdateRiskException", mock.Anything, mock.Anything)
+}
+
+// A DIFFERENT principal than the creator may approve — the exception is marked
+// approved and attributed to the approver.
+func TestApproveRiskException_DifferentActorSucceeds(t *testing.T) {
+	now := time.Now()
+	store := new(MockStorage)
+	store.On("GetRiskException", mock.Anything, uint(5)).Return(&models.RiskException{ID: 5, Title: "x", CreatedBy: 9, ExpiresAt: now.Add(24 * time.Hour)}, nil)
+	store.On("UpdateRiskException", mock.Anything, mock.MatchedBy(func(e *models.RiskException) bool {
+		return e.ID == 5 && e.Approved && e.ApprovedBy == 3 && e.ApprovedAt != nil
+	})).Return(nil)
+	store.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
+
+	c := riskCore(store, now)
+	require.NoError(t, c.ApproveRiskException(context.Background(), 3, 5))
+}
+
+// An already-approved exception cannot be approved again.
+func TestApproveRiskException_RejectsAlreadyApproved(t *testing.T) {
+	now := time.Now()
+	store := new(MockStorage)
+	store.On("GetRiskException", mock.Anything, uint(5)).Return(&models.RiskException{ID: 5, Title: "x", CreatedBy: 9, Approved: true, ExpiresAt: now.Add(24 * time.Hour)}, nil)
+
+	c := riskCore(store, now)
+	err := c.ApproveRiskException(context.Background(), 3, 5)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already approved")
+}
+
 func TestCountActiveRiskExceptions(t *testing.T) {
 	now := time.Date(2026, 6, 14, 0, 0, 0, 0, time.UTC)
 	store := new(MockStorage)

--- a/internal/core/sod.go
+++ b/internal/core/sod.go
@@ -38,6 +38,17 @@ type SoDViolation struct {
 	// Detail explains a non-obvious basis for the violation, e.g. that the principal
 	// holds both sides only by virtue of an admin permission-bypass role.
 	Detail string `json:"detail,omitempty"`
+	// Reference is the stable, matchable identifier for this specific violation
+	// (policy + principal) — copy it verbatim into a "sod"-category risk
+	// exception's Reference field to have that exception suppress THIS violation,
+	// and only this one, from the compliance posture (#170).
+	Reference string `json:"reference"`
+}
+
+// sodViolationReference builds the stable per-(policy, principal) reference a
+// governed risk exception matches against to suppress this specific violation.
+func sodViolationReference(policyID uint, principalType string, principalID uint) string {
+	return fmt.Sprintf("sod:policy:%d:%s:%d", policyID, principalType, principalID)
 }
 
 // CreateSoDPolicy defines a toxic-combination rule. The two permissions must be
@@ -138,7 +149,8 @@ func (c *KeyorixCore) userSoDViolations(ctx context.Context, u *models.User, pol
 				PolicyID: pol.ID, PolicyName: pol.Name,
 				PrincipalType: "user", UserID: u.ID, Username: u.Username, Email: u.Email,
 				PermissionA: pol.PermissionA, PermissionB: pol.PermissionB,
-				Detail: detail,
+				Detail:    detail,
+				Reference: sodViolationReference(pol.ID, "user", u.ID),
 			})
 		}
 		return out
@@ -166,6 +178,7 @@ func (c *KeyorixCore) userSoDViolations(ctx context.Context, u *models.User, pol
 				PolicyID: pol.ID, PolicyName: pol.Name,
 				PrincipalType: "user", UserID: u.ID, Username: u.Username, Email: u.Email,
 				PermissionA: pol.PermissionA, PermissionB: pol.PermissionB,
+				Reference:   sodViolationReference(pol.ID, "user", u.ID),
 			})
 		}
 	}
@@ -209,6 +222,7 @@ func (c *KeyorixCore) machineSoDViolations(ctx context.Context, policies []*mode
 				PolicyID: pol.ID, PolicyName: pol.Name,
 				PrincipalType: "machine", UserID: m.ID, Username: m.Name,
 				PermissionA: pol.PermissionA, PermissionB: pol.PermissionB,
+				Reference:   sodViolationReference(pol.ID, "machine", m.ID),
 			})
 		}
 	}

--- a/internal/core/sod_compliance_external_test.go
+++ b/internal/core/sod_compliance_external_test.go
@@ -3,6 +3,7 @@ package core_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/keyorixhq/keyorix/internal/testhelper"
@@ -35,4 +36,47 @@ func TestSoD_SurfacesInPostureAndEvidence(t *testing.T) {
 	require.NotEmpty(t, ev.SoDViolations)
 	assert.Equal(t, "write-vs-useradmin", ev.SoDViolations[0].PolicyName)
 	assert.Equal(t, "alice", ev.SoDViolations[0].Username)
+}
+
+// #170: an approved, active risk exception matching the violation's Reference
+// suppresses it from the posture's SoDViolations count; before approval (or with a
+// non-matching reference) the violation still counts — a governed exception must
+// actually be granted before it does anything.
+func TestSoD_SuppressedByApprovedRiskException(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(
+		&models.SoDPolicy{}, &models.AuditEvent{}, &models.AccessReviewCampaign{},
+		&models.AccessReviewItem{}, &models.BreakGlassActivation{}, &models.RotationPolicy{},
+		&models.RiskException{},
+	))
+
+	ctx := context.Background()
+	h.CreateTestUser(t, "alice", 10)
+	h.AssignUserRole(t, 10, 3, nil) // editor → secrets.write + users.read
+	_, err := h.CoreService.CreateSoDPolicy(ctx, 1, "write-vs-useradmin", "", "secrets.write", "users.read")
+	require.NoError(t, err)
+
+	p, err := h.CoreService.GetCompliancePosture(ctx)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, p.AccessGovernance.SoDViolations, 1, "unaccepted, the violation counts")
+
+	violations, err := h.CoreService.DetectSoDViolations(ctx)
+	require.NoError(t, err)
+	require.NotEmpty(t, violations)
+	ref := violations[0].Reference
+	require.NotEmpty(t, ref, "every violation must carry a stable reference to except against")
+
+	// Create the exception — NOT yet approved. Still counts.
+	exc, err := h.CoreService.CreateRiskException(ctx, 1, "accept for Q3 migration", "sod", ref, "temporary", time.Now().Add(30*24*time.Hour))
+	require.NoError(t, err)
+	p, err = h.CoreService.GetCompliancePosture(ctx)
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, p.AccessGovernance.SoDViolations, 1, "an unapproved exception must not suppress anything yet")
+
+	// A different actor approves it — now suppressed.
+	require.NoError(t, h.CoreService.ApproveRiskException(ctx, 2, exc.ID))
+	p, err = h.CoreService.GetCompliancePosture(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 0, p.AccessGovernance.SoDViolations, "an approved, matching-reference exception suppresses the violation")
 }

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -531,7 +531,10 @@ type Storage interface {
 	UnusedSecrets(ctx context.Context, projectID *uint, notReadSince time.Time) ([]UnusedSecretStat, error)
 	CreateAnomalyAlert(ctx context.Context, alert *models.AnomalyAlert) error
 	ListAnomalyAlerts(ctx context.Context, acknowledged *bool) ([]models.AnomalyAlert, error)
-	AcknowledgeAnomalyAlert(ctx context.Context, id uint) error
+	// AcknowledgeAnomalyAlert marks an alert acknowledged and stamps who did it and
+	// when directly on the row (#217), alongside the separate audit event the core
+	// layer emits.
+	AcknowledgeAnomalyAlert(ctx context.Context, id, actorID uint, at time.Time) error
 	// ListUnalertedAnomalyAlerts returns alerts not yet pushed out (alerted=false),
 	// and MarkAnomalyAlertAlerted flags one as pushed — for proactive alerting.
 	ListUnalertedAnomalyAlerts(ctx context.Context) ([]models.AnomalyAlert, error)

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -161,6 +161,13 @@ type RiskException struct {
 	Revoked       bool       `gorm:"index" json:"revoked"`    // true = withdrawn before expiry
 	RevokedBy     uint       `json:"revoked_by,omitempty"`
 	RevokedAt     *time.Time `json:"revoked_at,omitempty"`
+	// Approved/ApprovedBy/ApprovedAt implement dual control (#170): an exception
+	// only suppresses its matched violation once a DIFFERENT system.write holder
+	// than the creator approves it, so the same actor can't unilaterally create
+	// and self-approve a suppression of their own risk.
+	Approved   bool       `gorm:"default:false" json:"approved"`
+	ApprovedBy uint       `json:"approved_by,omitempty"`
+	ApprovedAt *time.Time `json:"approved_at,omitempty"`
 }
 
 // BreakGlassActivation records a self-service emergency-access elevation: a user
@@ -989,6 +996,13 @@ type AnomalyAlert struct {
 	IPAddress    string
 	DetectedAt   time.Time `gorm:"index"`
 	Acknowledged bool      `gorm:"default:false"`
+	// AcknowledgedBy/AcknowledgedAt attribute WHO dismissed this alert and WHEN
+	// (#217) — a privileged principal could otherwise suppress evidence of their
+	// own malicious access with the acknowledged flag alone leaving no forensic
+	// trail on the row itself (a separate audit event is also emitted, but the
+	// row-level attribution lets the posture/digest surface it directly).
+	AcknowledgedBy uint       `json:"acknowledged_by,omitempty"`
+	AcknowledgedAt *time.Time `json:"acknowledged_at,omitempty"`
 	// Alerted is set once the anomaly has been pushed out (admin notification +
 	// SIEM forward) so the alerter doesn't re-notify on every scan.
 	Alerted   bool `gorm:"default:false;index"`

--- a/internal/storage/store/anomaly_test.go
+++ b/internal/storage/store/anomaly_test.go
@@ -86,7 +86,7 @@ func TestListAnomalyAlerts_AcknowledgedFilter(t *testing.T) {
 	a2 := &models.AnomalyAlert{SecretNodeID: 2, AlertType: "new_user", AccessedBy: "bob", IPAddress: "10.0.0.2", DetectedAt: now}
 	require.NoError(t, ls.CreateAnomalyAlert(ctx, a1))
 	require.NoError(t, ls.CreateAnomalyAlert(ctx, a2))
-	require.NoError(t, ls.AcknowledgeAnomalyAlert(ctx, a1.ID))
+	require.NoError(t, ls.AcknowledgeAnomalyAlert(ctx, a1.ID, 1, now))
 
 	all, err := ls.ListAnomalyAlerts(ctx, nil)
 	require.NoError(t, err)

--- a/internal/storage/store/local_audit.go
+++ b/internal/storage/store/local_audit.go
@@ -363,8 +363,12 @@ func (ls *LocalStorage) ListAnomalyAlerts(ctx context.Context, acknowledged *boo
 	return alerts, result.Error
 }
 
-func (ls *LocalStorage) AcknowledgeAnomalyAlert(ctx context.Context, id uint) error {
-	res := ls.db.WithContext(ctx).Model(&models.AnomalyAlert{}).Where("id = ?", id).Update("acknowledged", true)
+func (ls *LocalStorage) AcknowledgeAnomalyAlert(ctx context.Context, id, actorID uint, at time.Time) error {
+	res := ls.db.WithContext(ctx).Model(&models.AnomalyAlert{}).Where("id = ?", id).Updates(map[string]interface{}{
+		"acknowledged":    true,
+		"acknowledged_by": actorID,
+		"acknowledged_at": at,
+	})
 	if res.Error != nil {
 		return res.Error
 	}

--- a/internal/storage/store/remote_audit.go
+++ b/internal/storage/store/remote_audit.go
@@ -190,7 +190,7 @@ func (rs *RemoteStorage) ListAnomalyAlerts(_ context.Context, _ *bool) ([]models
 }
 
 // AcknowledgeAnomalyAlert is not available in remote mode.
-func (rs *RemoteStorage) AcknowledgeAnomalyAlert(_ context.Context, _ uint) error {
+func (rs *RemoteStorage) AcknowledgeAnomalyAlert(_ context.Context, _, _ uint, _ time.Time) error {
 	return fmt.Errorf("AcknowledgeAnomalyAlert not available in remote mode")
 }
 

--- a/server/http/authz_share_parity_test.go
+++ b/server/http/authz_share_parity_test.go
@@ -163,7 +163,7 @@ func TestAuthzParity_HTTPvsGRPC_ShareList(t *testing.T) {
 		&models.Project{}, &models.Environment{}, &models.SecretNode{}, &models.SecretVersion{},
 		&models.User{}, &models.Role{}, &models.Permission{}, &models.RolePermission{},
 		&models.UserRole{}, &models.Group{}, &models.UserGroup{}, &models.GroupRole{},
-		&models.Session{}, &models.AuditEvent{}, &models.ShareRecord{},
+		&models.Session{}, &models.AuditEvent{}, &models.ShareRecord{}, &models.SystemMetadata{},
 	))
 	c := core.NewKeyorixCore(store.NewLocalStorage(db))
 	ctx := context.Background()

--- a/server/http/handlers/legal_hold.go
+++ b/server/http/handlers/legal_hold.go
@@ -82,9 +82,12 @@ func (h *DashboardHandler) LiftLegalHold(w http.ResponseWriter, r *http.Request)
 	if err := h.coreService.LiftLegalHold(r.Context(), actor.UserID, body.Reason); err != nil {
 		status := http.StatusInternalServerError
 		msg := err.Error()
-		if strings.Contains(msg, "no legal hold") || strings.Contains(msg, "a reason is required") {
+		switch {
+		case strings.Contains(msg, "no legal hold") || strings.Contains(msg, "a reason is required"):
 			status = http.StatusBadRequest
-		} else {
+		case strings.Contains(msg, "only the placing admin"):
+			status = http.StatusForbidden
+		default:
 			log.Printf("Error lifting legal hold: %v", err)
 			msg = clientSafe(err)
 		}

--- a/server/http/handlers/risk_exceptions.go
+++ b/server/http/handlers/risk_exceptions.go
@@ -72,6 +72,38 @@ func (h *DashboardHandler) CreateRiskException(w http.ResponseWriter, r *http.Re
 	sendSuccess(w, map[string]interface{}{"exception": exc}, "Risk exception recorded")
 }
 
+// ApproveRiskException handles POST /api/v1/risk-exceptions/{id}/approve — dual
+// control (#170): the exception only suppresses its matched violation from the
+// compliance posture once a DIFFERENT system.write holder than the creator
+// approves it.
+func (h *DashboardHandler) ApproveRiskException(w http.ResponseWriter, r *http.Request) {
+	actor := middleware.GetUserFromContext(r.Context())
+	if actor == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		sendError(w, "InvalidParameter", "Invalid exception ID", http.StatusBadRequest, nil)
+		return
+	}
+	if err := h.coreService.ApproveRiskException(r.Context(), actor.UserID, uint(id)); err != nil {
+		status := http.StatusInternalServerError
+		msg := err.Error()
+		switch {
+		case strings.Contains(msg, "dual control"):
+			status = http.StatusForbidden
+		case strings.Contains(msg, "cannot approve") || strings.Contains(msg, "already approved"):
+			status = http.StatusBadRequest
+		case strings.Contains(msg, "not found"):
+			status = http.StatusNotFound
+		}
+		sendError(w, "Error", msg, status, nil)
+		return
+	}
+	sendSuccess(w, nil, "Risk exception approved")
+}
+
 // RevokeRiskException handles DELETE /api/v1/risk-exceptions/{id} — withdraw early.
 func (h *DashboardHandler) RevokeRiskException(w http.ResponseWriter, r *http.Request) {
 	actor := middleware.GetUserFromContext(r.Context())

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -193,6 +193,12 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		r.Use(customMiddleware.NoStore)
 		// Authentication middleware for API routes
 		r.Use(customMiddleware.Authentication(coreService))
+		// General per-principal request budget (#163) — a backstop against one
+		// already-authorized principal hammering expensive endpoints (e.g. the
+		// deployment-wide compliance-posture/secrets-inventory-export handlers), not
+		// an authorization boundary. Runs right after Authentication so the
+		// principal is resolved. No-op unless server.http.ratelimit.enabled is set.
+		r.Use(customMiddleware.PrincipalRateLimit(cfg.Server.HTTP.RateLimit))
 		// Confine restricted (must-change-password) sessions to the password-change
 		// allowlist (ADR-025).
 		r.Use(customMiddleware.EnforceAccountRestriction)
@@ -723,6 +729,7 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		// create/revoke stay system.write.
 		r.With(customMiddleware.RequirePermission("audit.read")).Get("/risk-exceptions", dashboardHandler.ListRiskExceptions)
 		r.With(customMiddleware.RequirePermission("system.write")).Post("/risk-exceptions", dashboardHandler.CreateRiskException)
+		r.With(customMiddleware.RequirePermission("system.write")).Post("/risk-exceptions/{id}/approve", dashboardHandler.ApproveRiskException)
 		r.With(customMiddleware.RequirePermission("system.write")).Delete("/risk-exceptions/{id}", dashboardHandler.RevokeRiskException)
 
 		// Separation of duties (ISO A.5.3): policy definitions (name/permission pair, no

--- a/server/main.go
+++ b/server/main.go
@@ -817,7 +817,7 @@ func startHTTPServer(ctx context.Context, cfg *config.Config) error {
 			if tzLabel == "" {
 				tzLabel = "UTC"
 			}
-			if err := detector.SetBusinessHours(bh.Timezone, bh.OffHoursStart, bh.OffHoursEnd); err != nil {
+			if err := detector.SetBusinessHours(ctx, bh.Timezone, bh.OffHoursStart, bh.OffHoursEnd); err != nil {
 				// Misconfigured timezone: keep the safe UTC default rather than fail startup.
 				log.Printf("Anomaly off-hours config ignored (%v); using UTC 22:00–06:00", err)
 			} else {

--- a/server/middleware/rate_limit.go
+++ b/server/middleware/rate_limit.go
@@ -1,0 +1,131 @@
+package middleware
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"sync"
+	"time"
+
+	"golang.org/x/time/rate"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+)
+
+// PrincipalRateLimit enforces a general per-authenticated-principal request budget
+// across the whole authenticated API surface (#163). Before this, only login had
+// any rate limiting; a handful of system.read-gated endpoints (compliance posture,
+// deployment-wide secrets-inventory export) walk the entire deployment per call, so
+// a broadly-privileged system.read holder could drive up their own deployment's DB
+// load with repeated calls. This is a nuisance backstop, not an authorization
+// boundary: every route it guards is already permission-gated, so the intent is
+// bounding how hard one already-authorized principal can hammer expensive
+// endpoints, not preventing access.
+//
+// Token-bucket per principal (falling back to source IP for the rare request that
+// reaches this middleware unauthenticated), in-memory and per-process — unlike the
+// DB-backed cluster-wide login limiter (rate_limit.go), a self-inflicted-cost
+// nuisance control doesn't need cross-replica coordination, and keeping it
+// in-memory avoids adding DB load to a middleware whose whole point is reducing
+// DB load. Must run AFTER Authentication so the principal is resolved. Disabled by
+// default (cfg.Enabled == false, the config zero value), matching the config
+// schema already documented in server/config/production.yaml and
+// docs/CONFIGURATION.md.
+func PrincipalRateLimit(cfg config.RateLimitConfig) func(http.Handler) http.Handler {
+	if !cfg.Enabled || cfg.RequestsPerSecond <= 0 {
+		return func(next http.Handler) http.Handler { return next }
+	}
+	burst := cfg.Burst
+	if burst <= 0 {
+		burst = cfg.RequestsPerSecond
+	}
+	rl := &principalRateLimiter{
+		rps:      rate.Limit(cfg.RequestsPerSecond),
+		burst:    burst,
+		limiters: make(map[string]*principalBucket),
+	}
+	return rl.middleware
+}
+
+// principalLimiterIdleTTL is how long an idle principal's bucket is kept before a
+// sweep evicts it, bounding memory growth from a long-running process seeing many
+// distinct principals/IPs over time.
+const principalLimiterIdleTTL = 10 * time.Minute
+
+// principalLimiterSweepEvery amortizes the idle-eviction sweep cost by running it
+// only every Nth request rather than on every single one.
+const principalLimiterSweepEvery = 1000
+
+// principalBucket pairs a token-bucket limiter with the time it was last used.
+type principalBucket struct {
+	limiter  *rate.Limiter
+	lastSeen time.Time
+}
+
+type principalRateLimiter struct {
+	mu       sync.Mutex
+	limiters map[string]*principalBucket
+	rps      rate.Limit
+	burst    int
+	requests uint64
+}
+
+func (rl *principalRateLimiter) middleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !rl.allow(rateLimitKey(r)) {
+			w.Header().Set("Retry-After", "1")
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusTooManyRequests)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"error":   "RateLimited",
+				"message": "too many requests; slow down",
+				"code":    http.StatusTooManyRequests,
+			})
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+func (rl *principalRateLimiter) allow(key string) bool {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+	rl.requests++
+	if rl.requests%principalLimiterSweepEvery == 0 {
+		rl.sweepLocked()
+	}
+	b, ok := rl.limiters[key]
+	if !ok {
+		b = &principalBucket{limiter: rate.NewLimiter(rl.rps, rl.burst)}
+		rl.limiters[key] = b
+	}
+	b.lastSeen = time.Now()
+	return b.limiter.Allow()
+}
+
+// sweepLocked evicts buckets idle longer than principalLimiterIdleTTL. Caller must
+// hold rl.mu.
+func (rl *principalRateLimiter) sweepLocked() {
+	cutoff := time.Now().Add(-principalLimiterIdleTTL)
+	for k, b := range rl.limiters {
+		if b.lastSeen.Before(cutoff) {
+			delete(rl.limiters, k)
+		}
+	}
+}
+
+// rateLimitKey identifies the request's budget bucket: the authenticated user or
+// machine identity when present (the overwhelmingly common case on /api/v1, since
+// this middleware runs after Authentication), falling back to the client IP for
+// the rare unauthenticated request that reaches it.
+func rateLimitKey(r *http.Request) string {
+	if uc := GetUserFromContext(r.Context()); uc != nil {
+		if uc.MachineIdentityID != nil {
+			return "machine:" + strconv.FormatUint(uint64(*uc.MachineIdentityID), 10)
+		}
+		if uc.UserID != 0 {
+			return "user:" + strconv.FormatUint(uint64(uc.UserID), 10)
+		}
+	}
+	return "ip:" + hostOnly(r.RemoteAddr)
+}

--- a/server/middleware/rate_limit_test.go
+++ b/server/middleware/rate_limit_test.go
@@ -1,0 +1,74 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newRLRequest(userID uint) *http.Request {
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/compliance/posture", nil)
+	if userID != 0 {
+		uc := &UserContext{UserID: userID}
+		req = req.WithContext(context.WithValue(req.Context(), GetUserContextKey(), uc))
+	}
+	return req
+}
+
+// #163: disabled (the config zero value) is a transparent no-op — every request
+// passes through regardless of volume.
+func TestPrincipalRateLimit_DisabledIsNoOp(t *testing.T) {
+	mw := PrincipalRateLimit(config.RateLimitConfig{})
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }))
+
+	for i := 0; i < 50; i++ {
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, newRLRequest(1))
+		require.Equal(t, http.StatusOK, w.Code)
+	}
+}
+
+// A principal exceeding their burst gets 429; a DIFFERENT principal is unaffected —
+// budgets are per-principal, not shared.
+func TestPrincipalRateLimit_EnforcesPerPrincipalBudget(t *testing.T) {
+	mw := PrincipalRateLimit(config.RateLimitConfig{Enabled: true, RequestsPerSecond: 1, Burst: 3})
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }))
+
+	// User 1 exhausts their burst of 3.
+	for i := 0; i < 3; i++ {
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, newRLRequest(1))
+		require.Equal(t, http.StatusOK, w.Code, "request %d within burst must pass", i)
+	}
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, newRLRequest(1))
+	assert.Equal(t, http.StatusTooManyRequests, w.Code, "the 4th request within the same instant must be limited")
+	assert.NotEmpty(t, w.Header().Get("Retry-After"))
+
+	// User 2 has their own independent budget — unaffected by user 1's exhaustion.
+	w2 := httptest.NewRecorder()
+	handler.ServeHTTP(w2, newRLRequest(2))
+	assert.Equal(t, http.StatusOK, w2.Code, "a different principal must have an independent budget")
+}
+
+// An unauthenticated request (no UserContext) falls back to an IP-keyed budget
+// rather than panicking or bypassing the limiter entirely.
+func TestPrincipalRateLimit_FallsBackToIPForUnauthenticated(t *testing.T) {
+	mw := PrincipalRateLimit(config.RateLimitConfig{Enabled: true, RequestsPerSecond: 1, Burst: 1})
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }))
+
+	req := newRLRequest(0)
+	req.RemoteAddr = "203.0.113.5:1234"
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	w2 := httptest.NewRecorder()
+	handler.ServeHTTP(w2, req)
+	assert.Equal(t, http.StatusTooManyRequests, w2.Code, "a second request from the same IP within burst=1 must be limited")
+}


### PR DESCRIPTION
Rebase of #570 onto current main. Conflicted with four independently-landed hardening changes that touch the same functions; resolved by combining guarantees rather than dropping either side (see the follow-up fixup commits for details):

- `LiftLegalHold`: combined #380 (main, require+persist a lift reason) with this PR's #157 (only the placer or an admin-tier principal may lift, denial audited).
- `server/http/handlers/legal_hold.go`: combined both PRs' HTTP status-code mappings (400 for missing reason/no active hold, 403 for unauthorized lift).
- `GetCompliancePosture`'s SoD-violations block: combined main's fail-safe `p.degrade(...)` on a detection error with this PR's #170 (suppress violations covered by an approved risk exception).
- `internal/core/anomaly.go`'s narrow `StorageInterface`: combined main's `PrincipalSecretFirstSeen` with this PR's `LogAuditEvent` (both needed, `AcknowledgeAnomalyAlert` correctly dropped from this interface by this PR).

Also fixed three pre-existing test gaps surfaced by a full `go test ./...` run (independent of this PR's own changes — see the second commit):
- A legal-hold test needed the placer granted an admin-tier role (#377, already on main, tightened placement itself).
- `TestAuthzParity_HTTPvsGRPC_ShareList` was missing `&models.SystemMetadata{}` in its `AutoMigrate` list.
- Three dynamic-secrets install-wide-max-lease-TTL tests (#97, already on main) never set `ActorID`, against the admin-authority gate #162 (also already on main) added after those tests were written.

#144: business-hours off-hours rule config changes are now audited, and a degenerate (start==end) band is rejected rather than silently disabling the rule.
#157: legal-hold lift requires the placer or an admin-tier principal.
#163: adds a general per-principal request-budget backstop (`PrincipalRateLimit` middleware, opt-in via config).
#166: anomaly/break-glass admin-notification failures (failure to even list project members) are now surfaced loudly instead of silently swallowed.
#170: risk exceptions are dual-control (creator cannot self-approve) and, once approved, actually suppress their matched SoD violation from the compliance posture.
#217: anomaly-alert acknowledgement now attributes who/when on the row itself.

Verified locally: `go build ./...`, `go build ./server`, `go test ./...` (twice, no cache), `gosec -severity medium -exclude-generated ./...`, `cd operator && GOWORK=off go build ./...` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)