### PR TITLE
fix(auth): require re-authentication before MFA/WebAuthn credential changes (#372 HIGH)

### DIFF
--- a/internal/core/dynamic_secrets_test.go
+++ b/internal/core/dynamic_secrets_test.go
@@ -360,6 +360,7 @@ func TestDynamicSecrets_InstallWideMaxLeaseTTLClampsIssue(t *testing.T) {
 	ctx := context.Background()
 	cfg, err := c.CreateDynamicSecretConfig(ctx, &CreateDynamicSecretConfigRequest{
 		Name: "unbounded", ProjectID: 1, BackendType: "postgres", AdminDSN: adminDSNPlain,
+		ActorID: testAdminActorID,
 		// No MaxTTLSeconds — the per-config ceiling is unset/unbounded.
 		ActorID: testAdminActorID,
 	})

--- a/internal/core/dynamic_secrets_test.go
+++ b/internal/core/dynamic_secrets_test.go
@@ -362,7 +362,6 @@ func TestDynamicSecrets_InstallWideMaxLeaseTTLClampsIssue(t *testing.T) {
 		Name: "unbounded", ProjectID: 1, BackendType: "postgres", AdminDSN: adminDSNPlain,
 		ActorID: testAdminActorID,
 		// No MaxTTLSeconds — the per-config ceiling is unset/unbounded.
-		ActorID: testAdminActorID,
 	})
 	require.NoError(t, err)
 

--- a/internal/core/mfa.go
+++ b/internal/core/mfa.go
@@ -62,11 +62,22 @@ func (c *KeyorixCore) BeginMFAEnrollment(ctx context.Context, userID uint) (otpa
 }
 
 // ActivateMFA verifies a TOTP code against the pending secret, enables MFA, and
-// returns N single-use recovery codes (shown once).
-func (c *KeyorixCore) ActivateMFA(ctx context.Context, userID uint, code string) ([]string, error) {
+// returns N single-use recovery codes (shown once). password re-authenticates the
+// caller (#372): code alone is NOT sufficient proof of the account holder here,
+// because it is checked against the PENDING secret that BeginMFAEnrollment just
+// generated — an attacker with a stolen session or PAT can call BeginMFAEnrollment
+// themselves and so always knows a "valid" code for it. Unlike DisableMFA/
+// RegenerateMFARecoveryCodes (which re-authenticate against an already-ACTIVE
+// factor and so accept a current TOTP code OR the password), activation happens
+// before MFA is enabled, so there is no pre-existing TOTP factor to check against —
+// the password is the only trustworthy re-proof available at this step.
+func (c *KeyorixCore) ActivateMFA(ctx context.Context, userID uint, code, password string) ([]string, error) {
 	user, err := c.storage.GetUser(ctx, userID)
 	if err != nil {
 		return nil, fmt.Errorf("user not found")
+	}
+	if err := c.requireReauth(ctx, user, password, "activate_reauth"); err != nil {
+		return nil, err
 	}
 	secret, err := c.loadTOTPSecret(ctx, userID)
 	if err != nil {
@@ -109,28 +120,9 @@ func (c *KeyorixCore) DisableMFA(ctx context.Context, userID uint, codeOrPasswor
 	if !user.MFAEnabled {
 		return fmt.Errorf("MFA is not enabled")
 	}
-	// Per-account lockout gates this self-service re-auth the same way it gates the
-	// second login factor (VerifyMFALogin): a stolen session lets an attacker submit
-	// TOTP guesses without ever having the password, so without this the code check
-	// above is the ONLY throttle on disabling MFA — and it had none. Keyed by user
-	// (not IP), since this is an authenticated-session endpoint, not the pre-auth
-	// login path.
-	if c.loginLocked(user) {
-		return fmt.Errorf("account temporarily locked due to repeated failed logins; try again later")
+	if err := c.requireReauth(ctx, user, codeOrPassword, "disable"); err != nil {
+		return err
 	}
-	ok := false
-	if secret, err := c.loadTOTPSecret(ctx, userID); err == nil && c.validateTOTP(secret, codeOrPassword) {
-		ok = true
-	}
-	if !ok && bcrypt.CompareHashAndPassword([]byte(user.PasswordHash), []byte(codeOrPassword)) == nil {
-		ok = true
-	}
-	if !ok {
-		c.auditMFAFailed(ctx, userID, "disable")
-		c.recordFailedLogin(ctx, user) // count the failed re-auth attempt toward the lockout
-		return fmt.Errorf("invalid code or password")
-	}
-	c.clearLoginFailures(ctx, user)
 	if err := c.storage.SetUserMFAEnabled(ctx, userID, false); err != nil {
 		return err
 	}
@@ -155,25 +147,9 @@ func (c *KeyorixCore) RegenerateMFARecoveryCodes(ctx context.Context, userID uin
 	if !user.MFAEnabled {
 		return nil, fmt.Errorf("MFA is not enabled")
 	}
-	// Same account-level lockout gate as DisableMFA (see comment there): a stolen
-	// session with no lockout gating here would let an attacker brute-force the TOTP
-	// code to regenerate (and so invalidate) the legitimate recovery codes.
-	if c.loginLocked(user) {
-		return nil, fmt.Errorf("account temporarily locked due to repeated failed logins; try again later")
+	if err := c.requireReauth(ctx, user, codeOrPassword, "regenerate_recovery_codes"); err != nil {
+		return nil, err
 	}
-	ok := false
-	if secret, err := c.loadTOTPSecret(ctx, userID); err == nil && c.validateTOTP(secret, codeOrPassword) {
-		ok = true
-	}
-	if !ok && bcrypt.CompareHashAndPassword([]byte(user.PasswordHash), []byte(codeOrPassword)) == nil {
-		ok = true
-	}
-	if !ok {
-		c.auditMFAFailed(ctx, userID, "regenerate_recovery_codes")
-		c.recordFailedLogin(ctx, user) // count the failed re-auth attempt toward the lockout
-		return nil, fmt.Errorf("invalid code or password")
-	}
-	c.clearLoginFailures(ctx, user)
 	codes, hashes, err := generateRecoveryCodes(mfaRecoveryCodeCount)
 	if err != nil {
 		return nil, err
@@ -340,6 +316,42 @@ func (c *KeyorixCore) validateTOTPStep(secret, code string) (int64, bool) {
 func (c *KeyorixCore) auditMFAFailed(ctx context.Context, userID uint, phase string) {
 	uid := userID
 	c.writeAuditEventFull(ctx, "mfa.failed", &uid, nil, nil, "", fmt.Sprintf("failed MFA %s for user %d", phase, userID))
+}
+
+// requireReauth is the shared self-service re-authentication gate (#372) for
+// account-security-factor changes: it verifies codeOrPassword against a CURRENT,
+// already-active TOTP secret (only when user.MFAEnabled — never against an
+// in-flight, not-yet-activated enrolment secret, which an attacker who just called
+// BeginMFAEnrollment/BeginWebAuthnRegistration themselves would already know) or
+// the account password. Every caller (DisableMFA, RegenerateMFARecoveryCodes,
+// ActivateMFA, FinishWebAuthnRegistration, DeleteWebAuthnCredential) is reachable
+// with nothing but a bearer token — a stolen session OR a narrowly-scoped PAT,
+// which ADR-042 exempts from MFA policy entirely — so this check is the only thing
+// standing between a leaked bearer and a full account-security-factor takeover.
+// Feeds the same per-account lockout the second login factor (VerifyMFALogin)
+// uses, keyed by user (not IP, since this is an authenticated-session endpoint):
+// without it, this check would be the only throttle on guessing. phase labels the
+// mfa.failed audit event on a failed attempt.
+func (c *KeyorixCore) requireReauth(ctx context.Context, user *models.User, codeOrPassword, phase string) error {
+	if c.loginLocked(user) {
+		return fmt.Errorf("account temporarily locked due to repeated failed logins; try again later")
+	}
+	ok := false
+	if user.MFAEnabled {
+		if secret, err := c.loadTOTPSecret(ctx, user.ID); err == nil && c.validateTOTP(secret, codeOrPassword) {
+			ok = true
+		}
+	}
+	if !ok && codeOrPassword != "" && bcrypt.CompareHashAndPassword([]byte(user.PasswordHash), []byte(codeOrPassword)) == nil {
+		ok = true
+	}
+	if !ok {
+		c.auditMFAFailed(ctx, user.ID, phase)
+		c.recordFailedLogin(ctx, user) // count the failed re-auth attempt toward the lockout
+		return fmt.Errorf("invalid code or password")
+	}
+	c.clearLoginFailures(ctx, user)
+	return nil
 }
 
 // generateRecoveryCodes returns n human-friendly codes and their SHA-256 hashes.

--- a/internal/core/mfa_test.go
+++ b/internal/core/mfa_test.go
@@ -483,7 +483,7 @@ func TestMFA_TOTPSecretTransplantBetweenUsersFailsToDecrypt(t *testing.T) {
 	require.NoError(t, err)
 	aliceCode, err := totp.GenerateCode(aliceSecret, fixed)
 	require.NoError(t, err)
-	_, err = c.ActivateMFA(ctx, 1, aliceCode)
+	_, err = c.ActivateMFA(ctx, 1, aliceCode, mfaTestPassword)
 	require.NoError(t, err)
 
 	_, _, err = c.BeginMFAEnrollment(ctx, 2)

--- a/internal/core/mfa_test.go
+++ b/internal/core/mfa_test.go
@@ -53,7 +53,7 @@ func TestVerifyMFALogin_RejectsSuspendedAccount(t *testing.T) {
 	require.NoError(t, err)
 	actCode, err := totp.GenerateCode(secret, fixed)
 	require.NoError(t, err)
-	_, err = c.ActivateMFA(ctx, 1, actCode)
+	_, err = c.ActivateMFA(ctx, 1, actCode, mfaTestPassword)
 	require.NoError(t, err)
 
 	// A login is in flight (valid challenge), then the admin suspends the account.
@@ -92,7 +92,7 @@ func TestMFA_FullFlow(t *testing.T) {
 	// ── Activate ──
 	code, err := totp.GenerateCode(secret, fixed)
 	require.NoError(t, err)
-	codes, err := c.ActivateMFA(ctx, 1, code)
+	codes, err := c.ActivateMFA(ctx, 1, code, mfaTestPassword)
 	require.NoError(t, err)
 	assert.Len(t, codes, 10)
 
@@ -152,11 +152,67 @@ func TestMFA_ActivateRejectsWrongCode(t *testing.T) {
 	ctx := context.Background()
 	_, _, err := c.BeginMFAEnrollment(ctx, 1)
 	require.NoError(t, err)
-	_, err = c.ActivateMFA(ctx, 1, "000000")
+	_, err = c.ActivateMFA(ctx, 1, "000000", mfaTestPassword)
 	require.Error(t, err)
 	u, err := c.storage.GetUser(ctx, 1)
 	require.NoError(t, err)
 	assert.False(t, u.MFAEnabled, "a failed activation must not enable MFA")
+}
+
+// #372: ActivateMFA must require the account password to re-authenticate the
+// caller, not just a valid code for the pending secret. A stolen session or PAT
+// can call BeginMFAEnrollment itself and so always knows a "valid" code for the
+// secret it just generated — the code alone proves nothing about who the caller
+// is. Mirrors TestMFA_RegenerateRequiresReauth's structure for the disable/
+// regenerate re-auth gate.
+func TestMFA_ActivateRequiresReauth(t *testing.T) {
+	c, _, fixed := newMFATestCore(t)
+	ctx := context.Background()
+
+	_, secret, err := c.BeginMFAEnrollment(ctx, 1)
+	require.NoError(t, err)
+	code, err := totp.GenerateCode(secret, fixed)
+	require.NoError(t, err)
+
+	// A valid enrolment code with the WRONG password is rejected — this is exactly
+	// the attacker's position with a stolen session/PAT: they can complete
+	// BeginMFAEnrollment and compute a correct code for their own pending secret,
+	// but they do not know the account password.
+	_, err = c.ActivateMFA(ctx, 1, code, "wrong-password")
+	require.Error(t, err, "activation must reject a correct code without the account password")
+
+	u, err := c.storage.GetUser(ctx, 1)
+	require.NoError(t, err)
+	assert.False(t, u.MFAEnabled, "a reauth failure must not enable MFA")
+
+	// The same valid code WITH the correct password succeeds.
+	codes, err := c.ActivateMFA(ctx, 1, code, mfaTestPassword)
+	require.NoError(t, err, "activation must succeed with the correct password")
+	assert.Len(t, codes, 10)
+
+	u, err = c.storage.GetUser(ctx, 1)
+	require.NoError(t, err)
+	assert.True(t, u.MFAEnabled)
+}
+
+// #372: a bearer with a stolen session/PAT cannot bypass the password requirement
+// by re-using the PENDING (not-yet-activated) TOTP secret as its own "re-auth"
+// proof — requireReauth must only ever accept a code against an ALREADY-ACTIVE
+// secret (user.MFAEnabled), never the in-flight enrolment secret being activated.
+func TestMFA_ActivateDoesNotAcceptPendingSecretAsReauth(t *testing.T) {
+	c, _, fixed := newMFATestCore(t)
+	ctx := context.Background()
+
+	_, secret, err := c.BeginMFAEnrollment(ctx, 1)
+	require.NoError(t, err)
+	code, err := totp.GenerateCode(secret, fixed)
+	require.NoError(t, err)
+
+	// Passing the pending secret's own code as BOTH the activation code and the
+	// "password" must still fail — a code is never accepted as a password, and
+	// there is no active TOTP secret yet to validate it against as a code either.
+	_, err = c.ActivateMFA(ctx, 1, code, code)
+	require.Error(t, err, "the pending secret's own code must not double as re-auth")
 }
 
 // activateMFAForTest enrols + activates MFA for user 1 and returns the base32
@@ -168,7 +224,7 @@ func activateMFAForTest(t *testing.T, c *KeyorixCore, fixed time.Time) (secret s
 	require.NoError(t, err)
 	code, err := totp.GenerateCode(secret, fixed)
 	require.NoError(t, err)
-	codes, err = c.ActivateMFA(ctx, 1, code)
+	codes, err = c.ActivateMFA(ctx, 1, code, mfaTestPassword)
 	require.NoError(t, err)
 	return secret, codes
 }
@@ -254,7 +310,7 @@ func TestVerifyMFALogin_RejectsReplayedTOTPCode(t *testing.T) {
 	require.NoError(t, err)
 	actCode, err := totp.GenerateCode(secret, fixed)
 	require.NoError(t, err)
-	_, err = c.ActivateMFA(ctx, 1, actCode)
+	_, err = c.ActivateMFA(ctx, 1, actCode, mfaTestPassword)
 	require.NoError(t, err)
 
 	code, err := totp.GenerateCode(secret, fixed)
@@ -288,7 +344,7 @@ func TestVerifyMFALogin_FailedCodesFeedAccountLockout(t *testing.T) {
 	require.NoError(t, err)
 	actCode, err := totp.GenerateCode(secret, fixed)
 	require.NoError(t, err)
-	_, err = c.ActivateMFA(ctx, 1, actCode)
+	_, err = c.ActivateMFA(ctx, 1, actCode, mfaTestPassword)
 	require.NoError(t, err)
 
 	// Three wrong codes → the account locks.

--- a/internal/core/webauthn.go
+++ b/internal/core/webauthn.go
@@ -143,9 +143,22 @@ func (c *KeyorixCore) BeginWebAuthnRegistration(ctx context.Context, userID uint
 
 // FinishWebAuthnRegistration verifies the attestation, stores the credential, and
 // enables WebAuthn for the user. name is a user-supplied label for the passkey.
-func (c *KeyorixCore) FinishWebAuthnRegistration(ctx context.Context, userID uint, sessionToken, name string, parsed *protocol.ParsedCredentialCreationData) (*models.WebAuthnCredential, error) {
+// codeOrPassword re-authenticates the caller (#372): a current TOTP code (if MFA
+// is already enabled) or the account password, same re-auth as DisableMFA. This
+// is the step that actually adds a new, attacker-controllable trust factor to the
+// account, so — unlike BeginWebAuthnRegistration, which only opens a ceremony with
+// no effect on stored credentials — it must not be reachable by a bearer token
+// alone (a stolen session or a scoped, MFA-policy-exempt PAT per ADR-042).
+func (c *KeyorixCore) FinishWebAuthnRegistration(ctx context.Context, userID uint, sessionToken, name, codeOrPassword string, parsed *protocol.ParsedCredentialCreationData) (*models.WebAuthnCredential, error) {
 	if c.webauthnRP == nil {
 		return nil, ErrWebAuthnDisabled
+	}
+	user, err := c.storage.GetUser(ctx, userID)
+	if err != nil {
+		return nil, fmt.Errorf("user not found")
+	}
+	if err := c.requireReauth(ctx, user, codeOrPassword, "webauthn_register"); err != nil {
+		return nil, err
 	}
 	sess, err := c.storage.ConsumeWebAuthnSession(ctx, sha256Hex(sessionToken), c.now())
 	if err != nil {
@@ -205,8 +218,19 @@ func (c *KeyorixCore) ListWebAuthnCredentials(ctx context.Context, userID uint) 
 }
 
 // DeleteWebAuthnCredential removes one of the caller's passkeys; if it was the
-// last one, WebAuthn is disabled for the account.
-func (c *KeyorixCore) DeleteWebAuthnCredential(ctx context.Context, userID, id uint) error {
+// last one, WebAuthn is disabled for the account. codeOrPassword re-authenticates
+// the caller (#372, same re-auth as DisableMFA): deleting every passkey silently
+// disables WebAuthn account-wide, a full second-factor downgrade that must not be
+// reachable by a bearer token alone (a stolen session or a scoped, MFA-policy-
+// exempt PAT per ADR-042).
+func (c *KeyorixCore) DeleteWebAuthnCredential(ctx context.Context, userID, id uint, codeOrPassword string) error {
+	user, err := c.storage.GetUser(ctx, userID)
+	if err != nil {
+		return fmt.Errorf("user not found")
+	}
+	if err := c.requireReauth(ctx, user, codeOrPassword, "webauthn_delete"); err != nil {
+		return err
+	}
 	if err := c.storage.DeleteWebAuthnCredential(ctx, userID, id); err != nil {
 		return err
 	}

--- a/internal/core/webauthn_test.go
+++ b/internal/core/webauthn_test.go
@@ -129,15 +129,83 @@ func TestWebAuthn_DeleteClearsFlagOnLastAndIsUserScoped(t *testing.T) {
 	var cred models.WebAuthnCredential
 	require.NoError(t, db.Where("user_id = ?", 1).First(&cred).Error)
 
-	// A different user cannot delete user 1's passkey by id.
+	// A different user cannot delete user 1's passkey by id (also fails re-auth:
+	// bob has no password set).
 	require.NoError(t, db.Create(&models.User{ID: 2, Username: "bob", AccountState: "active"}).Error)
-	require.Error(t, c.DeleteWebAuthnCredential(ctx, 2, cred.ID))
+	require.Error(t, c.DeleteWebAuthnCredential(ctx, 2, cred.ID, webauthnTestPassword))
 
 	// The owner deletes their last passkey → WebAuthn disabled.
-	require.NoError(t, c.DeleteWebAuthnCredential(ctx, 1, cred.ID))
+	require.NoError(t, c.DeleteWebAuthnCredential(ctx, 1, cred.ID, webauthnTestPassword))
 	var user models.User
 	require.NoError(t, db.First(&user, 1).Error)
 	assert.False(t, user.WebAuthnEnabled, "removing the last passkey disables WebAuthn")
+}
+
+// #372: DeleteWebAuthnCredential must reject the deletion without a valid current
+// TOTP code or the account password — otherwise a stolen session/PAT alone can
+// wipe every passkey (and, once the last one is gone, silently disable WebAuthn
+// account-wide). Mirrors TestMFA_RegenerateRequiresReauth's structure.
+func TestWebAuthn_DeleteRequiresReauth(t *testing.T) {
+	c, db := newWebAuthnTestCore(t, true)
+	ctx := context.Background()
+	seedCredential(t, c, db, 1, "cred-1")
+
+	var cred models.WebAuthnCredential
+	require.NoError(t, db.Where("user_id = ?", 1).First(&cred).Error)
+
+	// Wrong password → rejected, credential untouched.
+	err := c.DeleteWebAuthnCredential(ctx, 1, cred.ID, "wrong-password")
+	require.Error(t, err, "delete must reject a bad code/password")
+
+	var stillThere models.WebAuthnCredential
+	require.NoError(t, db.Where("user_id = ? AND id = ?", 1, cred.ID).First(&stillThere).Error,
+		"a failed re-auth must not remove the credential")
+
+	var user models.User
+	require.NoError(t, db.First(&user, 1).Error)
+	assert.True(t, user.WebAuthnEnabled, "a failed re-auth must not touch the WebAuthnEnabled flag")
+
+	// Correct password → succeeds.
+	require.NoError(t, c.DeleteWebAuthnCredential(ctx, 1, cred.ID, webauthnTestPassword))
+}
+
+// #372: FinishWebAuthnRegistration must reject completion of the ceremony without
+// a valid current TOTP code or the account password — otherwise a stolen session/
+// PAT alone can register an attacker-controlled passkey. The re-auth gate fires
+// before the (single-use) registration session is consumed or any attestation is
+// parsed, so this is provable without constructing a real WebAuthn attestation:
+// a bad password is rejected with the re-auth error, and a correct password
+// advances past the gate to the ceremony-session check (a different error).
+func TestWebAuthn_FinishRegistrationRequiresReauth(t *testing.T) {
+	c, _ := newWebAuthnTestCore(t, true)
+	ctx := context.Background()
+
+	_, sessionToken, err := c.BeginWebAuthnRegistration(ctx, 1)
+	require.NoError(t, err)
+
+	// Wrong password is rejected by the re-auth gate itself, before the session is
+	// consumed (confirmed below: the session is still single-use-valid afterwards).
+	_, err = c.FinishWebAuthnRegistration(ctx, 1, sessionToken, "laptop", "wrong-password", nil)
+	require.Error(t, err, "finish must reject a bad code/password")
+	assert.Contains(t, err.Error(), "invalid code or password")
+
+	// The registration session was NOT consumed by the failed re-auth attempt: it
+	// is still there, single-use, to be consumed by a subsequent attempt. Directly
+	// consuming it here (bypassing FinishWebAuthnRegistration) proves it — a prior
+	// consume would make this fail.
+	_, err = c.storage.ConsumeWebAuthnSession(ctx, sha256Hex(sessionToken), c.now())
+	require.NoError(t, err, "a failed re-auth must not consume the single-use ceremony session")
+
+	// Start a fresh ceremony (the previous session was just consumed above) and
+	// confirm a correct password advances PAST the re-auth gate: the next failure
+	// is the ceremony/attestation step, not re-auth (proving the gate opened for a
+	// valid password; completing the ceremony itself needs a real attestation
+	// blob, out of scope for this regression test).
+	_, sessionToken2, err := c.BeginWebAuthnRegistration(ctx, 1)
+	require.NoError(t, err)
+	_, err = c.FinishWebAuthnRegistration(ctx, 1, sessionToken2, "laptop", webauthnTestPassword, &protocol.ParsedCredentialCreationData{})
+	require.Error(t, err, "an empty attestation still fails, just not on re-auth")
+	assert.NotContains(t, err.Error(), "invalid code or password")
 }
 
 func TestWebAuthn_PasswordlessBeginIssuesSession(t *testing.T) {

--- a/server/http/handlers/mfa.go
+++ b/server/http/handlers/mfa.go
@@ -31,7 +31,10 @@ func (h *AuthHandler) EnrollMFA(w http.ResponseWriter, r *http.Request) {
 }
 
 // ActivateMFA confirms enrolment with a TOTP code and returns the one-time-shown
-// recovery codes.
+// recovery codes. Requires the account password to re-authenticate the caller
+// (#372): code alone proves control of the just-generated pending secret, which an
+// attacker with a stolen session or PAT could have generated themselves via
+// EnrollMFA, so it is not proof this is really the account holder.
 func (h *AuthHandler) ActivateMFA(w http.ResponseWriter, r *http.Request) {
 	userCtx := middleware.GetUserFromContext(r.Context())
 	if userCtx == nil {
@@ -39,13 +42,14 @@ func (h *AuthHandler) ActivateMFA(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var body struct {
-		Code string `json:"code"`
+		Code     string `json:"code"`
+		Password string `json:"password"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		sendError(w, "BadRequest", "Invalid request body", http.StatusBadRequest, nil)
 		return
 	}
-	codes, err := h.coreService.ActivateMFA(r.Context(), userCtx.UserID, body.Code)
+	codes, err := h.coreService.ActivateMFA(r.Context(), userCtx.UserID, body.Code, body.Password)
 	if err != nil {
 		sendError(w, "Error", err.Error(), http.StatusBadRequest, nil)
 		return

--- a/server/http/handlers/mfa_webauthn_reauth_test.go
+++ b/server/http/handlers/mfa_webauthn_reauth_test.go
@@ -1,0 +1,209 @@
+// mfa_webauthn_reauth_test.go — #372 regression coverage: ActivateMFA,
+// FinishWebAuthnRegistration and DeleteWebAuthnCredential must require a current
+// TOTP code or the account password to re-authenticate the caller, exercised at
+// the HTTP handler layer (request body shape + wiring through to core).
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-webauthn/webauthn/webauthn"
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/encryption"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/keyorixhq/keyorix/server/middleware"
+	"github.com/pquerna/otp/totp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/bcrypt"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+const reauthTestPassword = "Secret#Passw0rd!"
+
+// setupMFAReauthTest builds an AuthHandler over real SQLite with an enabled
+// encryptor (TOTP secrets are encrypted at rest) and a WebAuthn relying party,
+// seeding user id 1 = "alice" with a known password.
+func setupMFAReauthTest(t *testing.T) (*AuthHandler, *core.KeyorixCore, *gorm.DB) {
+	t.Helper()
+	require.NoError(t, i18n.Initialize(&config.Config{Locale: config.LocaleConfig{Language: "en", FallbackLanguage: "en"}}))
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.User{}, &models.MFASecret{}, &models.MFARecoveryCode{},
+		&models.MFAChallenge{}, &models.Session{}, &models.AuditEvent{},
+		&models.WebAuthnCredential{}, &models.WebAuthnSession{}))
+	hash, err := bcrypt.GenerateFromPassword([]byte(reauthTestPassword), bcrypt.DefaultCost)
+	require.NoError(t, err)
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "alice", Email: "a@b.com",
+		PasswordHash: string(hash), AccountState: "active"}).Error)
+
+	enc := encryption.NewService(&config.EncryptionConfig{Enabled: true, DEKPath: "dek.key", SaltPath: "kek.salt"}, t.TempDir())
+	require.NoError(t, enc.Initialize("test-passphrase"))
+
+	coreService := core.NewKeyorixCore(store.NewLocalStorage(db))
+	coreService.SetAuthEncryptor(enc)
+	rp, err := webauthn.New(&webauthn.Config{
+		RPID: "localhost", RPDisplayName: "Keyorix", RPOrigins: []string{"https://localhost"},
+	})
+	require.NoError(t, err)
+	coreService.SetWebAuthn(rp)
+
+	return NewAuthHandler(coreService), coreService, db
+}
+
+func withUserContext(r *http.Request, userID uint) *http.Request {
+	userCtx := &middleware.UserContext{UserID: userID, ActorType: core.ActorTypeUser, SessionAuth: true}
+	return r.WithContext(context.WithValue(r.Context(), middleware.GetUserContextKey(), userCtx))
+}
+
+func postJSON(path string, body interface{}, userID uint) *http.Request {
+	b, _ := json.Marshal(body)
+	r := httptest.NewRequest(http.MethodPost, path, bytes.NewReader(b))
+	return withUserContext(r, userID)
+}
+
+// TestActivateMFAHandler_RequiresPassword confirms the HTTP layer accepts the new
+// "password" re-proof field and wires it through to core.ActivateMFA: a correct
+// enrolment code with no (or a wrong) password is rejected, and the same code
+// succeeds once the correct password is supplied.
+func TestActivateMFAHandler_RequiresPassword(t *testing.T) {
+	h, coreService, _ := setupMFAReauthTest(t)
+	fixed := time.Now()
+
+	_, secret, err := coreService.BeginMFAEnrollment(context.Background(), 1)
+	require.NoError(t, err)
+	code, err := totp.GenerateCode(secret, fixed)
+	require.NoError(t, err)
+
+	t.Run("missing password is rejected", func(t *testing.T) {
+		r := postJSON("/api/v1/auth/mfa/activate", map[string]string{"code": code}, 1)
+		rr := httptest.NewRecorder()
+		h.ActivateMFA(rr, r)
+		assert.Equal(t, http.StatusBadRequest, rr.Code)
+	})
+
+	t.Run("wrong password is rejected", func(t *testing.T) {
+		r := postJSON("/api/v1/auth/mfa/activate", map[string]string{"code": code, "password": "wrong"}, 1)
+		rr := httptest.NewRecorder()
+		h.ActivateMFA(rr, r)
+		assert.Equal(t, http.StatusBadRequest, rr.Code)
+	})
+
+	t.Run("correct password succeeds", func(t *testing.T) {
+		r := postJSON("/api/v1/auth/mfa/activate", map[string]string{"code": code, "password": reauthTestPassword}, 1)
+		rr := httptest.NewRecorder()
+		h.ActivateMFA(rr, r)
+		require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+		assert.Contains(t, rr.Body.String(), "recovery_codes")
+	})
+}
+
+// TestFinishWebAuthnRegistrationHandler_RequiresReauth confirms the HTTP layer
+// accepts and forwards the code/password re-proof: a request with neither is
+// rejected by the core re-auth gate BEFORE the (here, deliberately invalid)
+// attestation is ever evaluated — proving the wiring, not just that a garbled
+// attestation fails for some other reason.
+func TestFinishWebAuthnRegistrationHandler_RequiresReauth(t *testing.T) {
+	h, coreService, _ := setupMFAReauthTest(t)
+	ctx := context.Background()
+
+	_, sessionToken, err := coreService.BeginWebAuthnRegistration(ctx, 1)
+	require.NoError(t, err)
+
+	body := map[string]interface{}{
+		"webauthn_session": sessionToken,
+		"name":             "laptop",
+		// Structurally valid so the request clears attestation parsing and
+		// actually reaches core's re-auth gate — a garbled blob like `{}` would
+		// fail at protocol.ParseCredentialCreationResponseBytes and never
+		// exercise the wiring under test (the values are a well-known
+		// go-webauthn fixture; cryptographic correctness is irrelevant here).
+		"credential": json.RawMessage(validCredentialCreationResponseJSON),
+	}
+	r := postJSON("/api/v1/auth/webauthn/register/finish", body, 1)
+	rr := httptest.NewRecorder()
+	h.FinishWebAuthnRegistration(rr, r)
+	require.Equal(t, http.StatusBadRequest, rr.Code, rr.Body.String())
+	// The failure must be the re-auth gate (core.requireReauth), not attestation
+	// parsing — proving re-auth is checked first, before any ceremony data is
+	// touched.
+	assert.Contains(t, rr.Body.String(), "invalid code or password")
+}
+
+// validCredentialCreationResponseJSON is a structurally-valid WebAuthn
+// PublicKeyCredential JSON blob (borrowed verbatim from go-webauthn's own
+// protocol test suite, credential_test.go's "success" fixture) — enough to
+// clear protocol.ParseCredentialCreationResponseBytes so a handler test can
+// reach the code under test past attestation parsing. Not a real credential.
+const validCredentialCreationResponseJSON = `{
+	"id":"6xrtBhJQW6QU4tOaB4rrHaS2Ks0yDDL_q8jDC16DEjZ-VLVf4kCRkvl2xp2D71sTPYns-exsHQHTy3G-zJRK8g",
+	"rawId":"6xrtBhJQW6QU4tOaB4rrHaS2Ks0yDDL_q8jDC16DEjZ-VLVf4kCRkvl2xp2D71sTPYns-exsHQHTy3G-zJRK8g",
+	"type":"public-key",
+	"authenticatorAttachment":"platform",
+	"clientExtensionResults":{
+		"appid":true
+	},
+	"response":{
+		"attestationObject":"o2NmbXRkbm9uZWdhdHRTdG10oGhhdXRoRGF0YVjEdKbqkhPJnC90siSSsyDPQCYqlMGpUKA5fyklC2CEHvBBAAAAAAAAAAAAAAAAAAAAAAAAAAAAQOsa7QYSUFukFOLTmgeK6x2ktirNMgwy_6vIwwtegxI2flS1X-JAkZL5dsadg-9bEz2J7PnsbB0B08txvsyUSvKlAQIDJiABIVggLKF5xS0_BntttUIrm2Z2tgZ4uQDwllbdIfrrBMABCNciWCDHwin8Zdkr56iSIh0MrB5qZiEzYLQpEOREhMUkY6q4Vw",
+		"clientDataJSON":"eyJjaGFsbGVuZ2UiOiJXOEd6RlU4cEdqaG9SYldyTERsYW1BZnFfeTRTMUNaRzFWdW9lUkxBUnJFIiwib3JpZ2luIjoiaHR0cHM6Ly93ZWJhdXRobi5pbyIsInR5cGUiOiJ3ZWJhdXRobi5jcmVhdGUifQ",
+		"transports":["usb","nfc","fake"]
+	}
+}`
+
+// TestDeleteWebAuthnCredentialHandler_RequiresReauth confirms the DELETE handler
+// accepts code/password in the body and rejects the deletion without a valid one,
+// even for the credential's rightful owner — a leaked bearer alone must not be
+// able to wipe passkeys.
+func TestDeleteWebAuthnCredentialHandler_RequiresReauth(t *testing.T) {
+	h, _, db := setupMFAReauthTest(t)
+
+	blob, _ := json.Marshal(webauthn.Credential{ID: []byte("cred-1")})
+	require.NoError(t, db.Create(&models.WebAuthnCredential{
+		UserID: 1, CredentialID: []byte("cred-1"), Name: "test key", CredentialBlob: blob,
+	}).Error)
+	var cred models.WebAuthnCredential
+	require.NoError(t, db.Where("user_id = ?", 1).First(&cred).Error)
+	credIDParam := fmt.Sprint(cred.ID)
+
+	deleteReq := func(body interface{}) *httptest.ResponseRecorder {
+		var r *http.Request
+		if body == nil {
+			r = httptest.NewRequest(http.MethodDelete, "/api/v1/auth/webauthn/credentials/"+credIDParam, nil)
+		} else {
+			b, _ := json.Marshal(body)
+			r = httptest.NewRequest(http.MethodDelete, "/api/v1/auth/webauthn/credentials/"+credIDParam, bytes.NewReader(b))
+		}
+		r = withUserContext(r, 1)
+		r = withChiParams(r, map[string]string{"id": credIDParam})
+		rr := httptest.NewRecorder()
+		h.DeleteWebAuthnCredential(rr, r)
+		return rr
+	}
+
+	t.Run("no body is rejected", func(t *testing.T) {
+		rr := deleteReq(nil)
+		assert.Equal(t, http.StatusBadRequest, rr.Code)
+	})
+
+	t.Run("wrong password is rejected", func(t *testing.T) {
+		rr := deleteReq(map[string]string{"password": "wrong"})
+		assert.Equal(t, http.StatusBadRequest, rr.Code)
+	})
+
+	t.Run("correct password succeeds", func(t *testing.T) {
+		rr := deleteReq(map[string]string{"password": reauthTestPassword})
+		require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+	})
+}

--- a/server/http/handlers/webauthn.go
+++ b/server/http/handlers/webauthn.go
@@ -42,7 +42,10 @@ func (h *AuthHandler) BeginWebAuthnRegistration(w http.ResponseWriter, r *http.R
 }
 
 // FinishWebAuthnRegistration verifies the attestation and stores the passkey.
-// Body: { webauthn_session, name, credential: <PublicKeyCredential> }.
+// Requires a current TOTP code or the account password to re-authenticate the
+// caller (#372): this is the step that actually adds a new trust factor to the
+// account, so it must not be reachable by a bearer token alone.
+// Body: { webauthn_session, name, code, password, credential: <PublicKeyCredential> }.
 func (h *AuthHandler) FinishWebAuthnRegistration(w http.ResponseWriter, r *http.Request) {
 	userCtx := middleware.GetUserFromContext(r.Context())
 	if userCtx == nil {
@@ -52,6 +55,8 @@ func (h *AuthHandler) FinishWebAuthnRegistration(w http.ResponseWriter, r *http.
 	var body struct {
 		WebAuthnSession string          `json:"webauthn_session"`
 		Name            string          `json:"name"`
+		Code            string          `json:"code"`
+		Password        string          `json:"password"`
 		Credential      json.RawMessage `json:"credential"`
 	}
 	if err := decodeJSON(r, &body); err != nil || len(body.Credential) == 0 {
@@ -63,7 +68,11 @@ func (h *AuthHandler) FinishWebAuthnRegistration(w http.ResponseWriter, r *http.
 		sendError(w, "BadRequest", "Invalid attestation", http.StatusBadRequest, nil)
 		return
 	}
-	cred, err := h.coreService.FinishWebAuthnRegistration(r.Context(), userCtx.UserID, body.WebAuthnSession, strings.TrimSpace(body.Name), parsed)
+	proof := body.Code
+	if proof == "" {
+		proof = body.Password
+	}
+	cred, err := h.coreService.FinishWebAuthnRegistration(r.Context(), userCtx.UserID, body.WebAuthnSession, strings.TrimSpace(body.Name), proof, parsed)
 	if err != nil {
 		h.writeWebAuthnErr(w, err)
 		return
@@ -99,7 +108,11 @@ func (h *AuthHandler) ListWebAuthnCredentials(w http.ResponseWriter, r *http.Req
 	sendSuccess(w, out, "")
 }
 
-// DeleteWebAuthnCredential removes one of the caller's passkeys.
+// DeleteWebAuthnCredential removes one of the caller's passkeys. Requires a
+// current TOTP code or the account password to re-authenticate the caller (#372):
+// deleting the last passkey silently disables WebAuthn account-wide, a full
+// second-factor downgrade that must not be reachable by a bearer token alone.
+// Body: { code, password } (either satisfies the re-auth check).
 func (h *AuthHandler) DeleteWebAuthnCredential(w http.ResponseWriter, r *http.Request) {
 	userCtx := middleware.GetUserFromContext(r.Context())
 	if userCtx == nil {
@@ -111,7 +124,21 @@ func (h *AuthHandler) DeleteWebAuthnCredential(w http.ResponseWriter, r *http.Re
 		sendError(w, "InvalidParameter", "Invalid credential id", http.StatusBadRequest, nil)
 		return
 	}
-	if err := h.coreService.DeleteWebAuthnCredential(r.Context(), userCtx.UserID, uint(id)); err != nil {
+	var body struct {
+		Code     string `json:"code"`
+		Password string `json:"password"`
+	}
+	// An empty body simply fails the re-auth check below; only malformed JSON is a
+	// bad request.
+	if err := decodeJSON(r, &body); err != nil && !errors.Is(err, io.EOF) {
+		sendError(w, "BadRequest", "Invalid request body", http.StatusBadRequest, nil)
+		return
+	}
+	proof := body.Code
+	if proof == "" {
+		proof = body.Password
+	}
+	if err := h.coreService.DeleteWebAuthnCredential(r.Context(), userCtx.UserID, uint(id), proof); err != nil {
 		sendError(w, "Error", err.Error(), http.StatusBadRequest, nil)
 		return
 	}


### PR DESCRIPTION
A stolen bearer token/PAT could previously disable or take over 2FA without proving current possession of a second factor or the account password.

Adds a shared requireReauth gate (current TOTP code checked against an already-active secret, or the account password) guarding ActivateMFA, DisableMFA, RegenerateMFARecoveryCodes, FinishWebAuthnRegistration, and DeleteWebAuthnCredential.

🤖 Generated with [Claude Code](https://claude.com/claude-code)