### PR TITLE
harden: storage pagination clamp, argv-safe api-key resolution (#173/#207)

### DIFF
--- a/internal/cli/auth/auth.go
+++ b/internal/cli/auth/auth.go
@@ -2,12 +2,10 @@ package auth
 
 import (
 	"fmt"
-	"syscall"
 
 	"github.com/keyorixhq/keyorix/internal/cli/common"
 	"github.com/keyorixhq/keyorix/internal/config"
 	"github.com/spf13/cobra"
-	"golang.org/x/term"
 )
 
 // AuthCmd represents the auth command
@@ -39,8 +37,10 @@ var statusCmd = &cobra.Command{
 }
 
 func init() {
-	// Add flags for login command
-	loginCmd.Flags().String("api-key", "", "API key for authentication (optional, will prompt if not provided)")
+	// Add flags for login command. --api-key is INSECURE on the command line (visible
+	// via ps/proc and saved in shell history); prefer the KEYORIX_API_KEY env var, or
+	// omit it to be prompted.
+	loginCmd.Flags().String("api-key", "", "API key for authentication (INSECURE on the command line — prefer KEYORIX_API_KEY env var, or omit to be prompted)")
 	loginCmd.Flags().String("server", "", "Server URL to authenticate with")
 
 	// Add subcommands
@@ -50,10 +50,7 @@ func init() {
 }
 
 func runLogin(cmd *cobra.Command, args []string) error {
-	apiKey, _ := cmd.Flags().GetString("api-key")
 	server, _ := cmd.Flags().GetString("server")
-
-	common.WarnInsecureFlag(cmd, "api-key", "omit the flag to be prompted instead, or set KEYORIX_REMOTE_API_KEY.")
 
 	// Load current configuration
 	cfg, err := config.Load("keyorix.yaml")
@@ -79,15 +76,12 @@ func runLogin(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Get API key if not provided
-	if apiKey == "" {
-		fmt.Print("Enter API key: ")
-		bytePassword, err := term.ReadPassword(int(syscall.Stdin))
-		if err != nil {
-			return fmt.Errorf("failed to read API key: %w", err)
-		}
-		apiKey = string(bytePassword)
-		fmt.Println() // Add newline after password input
+	// Resolve the API key without ever requiring it on the command line: the
+	// (insecure, warned) --api-key flag if set, else KEYORIX_API_KEY, else an
+	// interactive no-echo prompt.
+	apiKey, err := common.ResolveAPIKey(cmd, true)
+	if err != nil {
+		return err
 	}
 
 	if apiKey == "" {

--- a/internal/cli/common/api_key.go
+++ b/internal/cli/common/api_key.go
@@ -1,0 +1,48 @@
+package common
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/term"
+)
+
+// APIKeyEnvVar is the NAME of the environment variable an API key should be read
+// from instead of a command-line flag, so the key itself never appears in
+// `ps`/`/proc` output or shell history. This is an identifier, not a credential
+// value.
+const APIKeyEnvVar = "KEYORIX_API_KEY" // #nosec G101 -- env var name, not a secret value
+
+// ResolveAPIKey resolves an API key in order of preference:
+//  1. the (insecure, warned) --api-key flag, if set;
+//  2. the KEYORIX_API_KEY environment variable;
+//  3. when prompt is true and neither of the above is set, an interactive no-echo
+//     prompt.
+//
+// A literal --api-key value is visible via `ps`/`/proc` and gets saved in shell
+// history, so its use is flagged with a warning on stderr — the same pattern
+// `keyorix connect`'s resolveAPIKey already applies. Set prompt to false for a
+// command where the API key is optional (e.g. `config set-remote`, which is fine
+// proceeding with an empty key); set it to true where a key is required (e.g.
+// `auth login`).
+func ResolveAPIKey(cmd *cobra.Command, prompt bool) (string, error) {
+	if k, _ := cmd.Flags().GetString("api-key"); k != "" {
+		fmt.Fprintln(os.Stderr, "⚠️  Passing --api-key on the command line is insecure (visible via ps/proc and saved in shell history); prefer the KEYORIX_API_KEY environment variable.")
+		return k, nil
+	}
+	if k := os.Getenv(APIKeyEnvVar); k != "" {
+		return k, nil
+	}
+	if !prompt {
+		return "", nil
+	}
+	fmt.Fprint(os.Stderr, "Enter API key: ")
+	b, err := term.ReadPassword(int(syscall.Stdin))
+	fmt.Fprintln(os.Stderr)
+	if err != nil {
+		return "", fmt.Errorf("failed to read API key: %w", err)
+	}
+	return string(b), nil
+}

--- a/internal/cli/common/api_key_test.go
+++ b/internal/cli/common/api_key_test.go
@@ -1,0 +1,53 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func newAPIKeyCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().String("api-key", "", "")
+	return cmd
+}
+
+func TestResolveAPIKey_FlagWins(t *testing.T) {
+	cmd := newAPIKeyCmd()
+	_ = cmd.Flags().Set("api-key", "flag-secret")
+	t.Setenv(APIKeyEnvVar, "env-secret")
+
+	got, err := ResolveAPIKey(cmd, false)
+	if err != nil {
+		t.Fatalf("ResolveAPIKey returned error: %v", err)
+	}
+	if got != "flag-secret" {
+		t.Errorf("ResolveAPIKey() = %q; want the --api-key flag value", got)
+	}
+}
+
+func TestResolveAPIKey_FallsBackToEnvVar(t *testing.T) {
+	cmd := newAPIKeyCmd()
+	t.Setenv(APIKeyEnvVar, "env-secret")
+
+	got, err := ResolveAPIKey(cmd, false)
+	if err != nil {
+		t.Fatalf("ResolveAPIKey returned error: %v", err)
+	}
+	if got != "env-secret" {
+		t.Errorf("ResolveAPIKey() = %q; want the KEYORIX_API_KEY env var value", got)
+	}
+}
+
+func TestResolveAPIKey_EmptyWithoutPromptWhenNeitherSet(t *testing.T) {
+	cmd := newAPIKeyCmd()
+	t.Setenv(APIKeyEnvVar, "")
+
+	got, err := ResolveAPIKey(cmd, false)
+	if err != nil {
+		t.Fatalf("ResolveAPIKey returned error: %v", err)
+	}
+	if got != "" {
+		t.Errorf("ResolveAPIKey() = %q; want empty string when prompt=false and nothing is set", got)
+	}
+}

--- a/internal/cli/config/api_key_test.go
+++ b/internal/cli/config/api_key_test.go
@@ -1,0 +1,41 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func newAPIKeyCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().String("api-key", "", "")
+	return cmd
+}
+
+func TestResolveAPIKey_FlagWins(t *testing.T) {
+	cmd := newAPIKeyCmd()
+	_ = cmd.Flags().Set("api-key", "flag-secret")
+	t.Setenv("KEYORIX_API_KEY", "env-secret")
+
+	if got := resolveAPIKey(cmd); got != "flag-secret" {
+		t.Errorf("resolveAPIKey() = %q; want the --api-key flag value", got)
+	}
+}
+
+func TestResolveAPIKey_FallsBackToEnvVar(t *testing.T) {
+	cmd := newAPIKeyCmd()
+	t.Setenv("KEYORIX_API_KEY", "env-secret")
+
+	if got := resolveAPIKey(cmd); got != "env-secret" {
+		t.Errorf("resolveAPIKey() = %q; want the KEYORIX_API_KEY env var value", got)
+	}
+}
+
+func TestResolveAPIKey_EmptyWhenNeitherSet(t *testing.T) {
+	cmd := newAPIKeyCmd()
+	t.Setenv("KEYORIX_API_KEY", "")
+
+	if got := resolveAPIKey(cmd); got != "" {
+		t.Errorf("resolveAPIKey() = %q; want empty string (api-key stays optional for set-remote)", got)
+	}
+}

--- a/internal/cli/config/config.go
+++ b/internal/cli/config/config.go
@@ -45,9 +45,11 @@ var testConnectionCmd = &cobra.Command{
 }
 
 func init() {
-	// Add flags for set-remote command
+	// Add flags for set-remote command. --api-key is INSECURE on the command line
+	// (visible via ps/proc and saved in shell history); prefer the KEYORIX_API_KEY
+	// env var.
 	setRemoteCmd.Flags().String("url", "", "Remote server URL (required)")
-	setRemoteCmd.Flags().String("api-key", "", "API key for authentication (optional)")
+	setRemoteCmd.Flags().String("api-key", "", "API key for authentication (optional; INSECURE on the command line — prefer KEYORIX_API_KEY env var)")
 	setRemoteCmd.Flags().Int("timeout", 30, "Request timeout in seconds")
 	_ = setRemoteCmd.MarkFlagRequired("url") // #nosec G104
 
@@ -92,11 +94,15 @@ func runStatus(cmd *cobra.Command, args []string) error {
 
 func runSetRemote(cmd *cobra.Command, args []string) error {
 	url, _ := cmd.Flags().GetString("url")
-	apiKey, _ := cmd.Flags().GetString("api-key")
 	timeout, _ := cmd.Flags().GetInt("timeout")
 
-	cfg, err := config.Load("keyorix.yaml")
-	if err != nil {
+	// Resolve the API key without ever requiring it on the command line: the
+	// (insecure, warned) --api-key flag if set, else KEYORIX_API_KEY. The key is
+	// optional here, so an unset value is left empty rather than prompted for.
+	apiKey := resolveAPIKey(cmd)
+
+	cfg, cerr := config.Load("keyorix.yaml")
+	if cerr != nil {
 		// Create default config if it doesn't exist
 		cfg = &config.Config{}
 	}
@@ -118,7 +124,7 @@ func runSetRemote(cmd *cobra.Command, args []string) error {
 	fmt.Printf("✅ Configuration updated successfully!\n")
 	fmt.Printf("🌐 CLI now uses remote server: %s\n", url)
 	if apiKey == "" {
-		fmt.Printf("💡 Tip: Set API key with --api-key flag if server requires authentication\n")
+		fmt.Printf("💡 Tip: set the KEYORIX_API_KEY environment variable if the server requires authentication (preferred over --api-key, which leaks via ps/history)\n")
 	}
 
 	return nil
@@ -214,6 +220,17 @@ func testLocalConnection(cfg *config.Config) error {
 	}
 
 	return nil
+}
+
+// resolveAPIKey returns the API key from the (insecure, warned) --api-key flag if set,
+// else from the KEYORIX_API_KEY env var. A literal flag value is visible via ps and the
+// shell history, so its use is flagged — mirrors `keyorix connect`'s resolveAPIKey.
+func resolveAPIKey(cmd *cobra.Command) string {
+	if k, _ := cmd.Flags().GetString("api-key"); k != "" {
+		fmt.Fprintln(os.Stderr, "⚠️  Passing --api-key on the command line is insecure (visible via ps/proc and saved in shell history); prefer the KEYORIX_API_KEY environment variable.")
+		return k
+	}
+	return os.Getenv("KEYORIX_API_KEY")
 }
 
 func maskAPIKey(apiKey string) string {

--- a/internal/core/license_expiry.go
+++ b/internal/core/license_expiry.go
@@ -64,24 +64,35 @@ func (c *KeyorixCore) ScanLicenseExpiry(ctx context.Context, leadDays int) (int,
 	return sent, nil
 }
 
+// globalAdminIDsPageSize bounds each page of the active-users walk in globalAdminIDs.
+// A single fixed-size page silently under-lists admins once the install has more
+// active users than the page size; paginating through every page instead keeps
+// this correct at any install scale.
+const globalAdminIDsPageSize = 500
+
 // globalAdminIDs returns the user IDs of every active install-wide admin.
 func (c *KeyorixCore) globalAdminIDs(ctx context.Context) ([]uint, error) {
 	active := true
-	users, _, err := c.storage.ListUsers(ctx, &storage.UserFilter{IsActive: &active, Page: 1, PageSize: 1000})
-	if err != nil {
-		return nil, err
-	}
 	var ids []uint
-	for _, u := range users {
-		roles, rerr := c.storage.GetUserRoles(ctx, u.ID)
-		if rerr != nil {
-			continue
+	for page := 1; ; page++ {
+		users, total, err := c.storage.ListUsers(ctx, &storage.UserFilter{IsActive: &active, Page: page, PageSize: globalAdminIDsPageSize})
+		if err != nil {
+			return nil, err
 		}
-		for _, r := range roles {
-			if _, ok := globalAdminRoleNames[r.Name]; ok {
-				ids = append(ids, u.ID)
-				break
+		for _, u := range users {
+			roles, rerr := c.storage.GetUserRoles(ctx, u.ID)
+			if rerr != nil {
+				continue
 			}
+			for _, r := range roles {
+				if _, ok := globalAdminRoleNames[r.Name]; ok {
+					ids = append(ids, u.ID)
+					break
+				}
+			}
+		}
+		if len(users) < globalAdminIDsPageSize || int64(page*globalAdminIDsPageSize) >= total {
+			break
 		}
 	}
 	return ids, nil

--- a/internal/core/license_expiry_test.go
+++ b/internal/core/license_expiry_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/license"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/keyorixhq/keyorix/internal/trust"
@@ -86,6 +87,47 @@ func TestScanLicenseExpiry_Dedup_NoResend(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 0, n)
 	ms.AssertNotCalled(t, "CreateNotification", mock.Anything, mock.Anything)
+}
+
+// TestGlobalAdminIDs_PaginatesActiveUsersBeyondOnePage pins the fix for an install
+// with more active users than a single storage page: globalAdminIDs must walk every
+// page of active users rather than stopping after the first
+// globalAdminIDsPageSize-sized page, or an admin beyond that page would silently
+// never receive the license-expiry notification.
+func TestGlobalAdminIDs_PaginatesActiveUsersBeyondOnePage(t *testing.T) {
+	ctx := context.Background()
+	ms := new(MockStorage)
+	c := NewKeyorixCore(ms)
+	c.SetLicenseGate(gateWithExpiry(t, time.Now().Add(5*24*time.Hour)))
+
+	firstPage := make([]*models.User, globalAdminIDsPageSize)
+	for i := range firstPage {
+		firstPage[i] = &models.User{ID: uint(i + 1)}
+	}
+	total := int64(globalAdminIDsPageSize + 1)
+	lateAdminID := uint(globalAdminIDsPageSize + 1)
+
+	ms.On("ListUsers", ctx, mock.MatchedBy(func(f *storage.UserFilter) bool {
+		return f.Page == 1 && f.PageSize == globalAdminIDsPageSize
+	})).Return(firstPage, total, nil)
+	ms.On("ListUsers", ctx, mock.MatchedBy(func(f *storage.UserFilter) bool {
+		return f.Page == 2 && f.PageSize == globalAdminIDsPageSize
+	})).Return([]*models.User{{ID: lateAdminID}}, total, nil)
+
+	// Every user on page 1 is a non-admin; only the page-2 user is a global admin.
+	for i := range firstPage {
+		ms.On("GetUserRoles", ctx, firstPage[i].ID).Return([]*models.Role{{Name: "member"}}, nil)
+	}
+	ms.On("GetUserRoles", ctx, lateAdminID).Return([]*models.Role{{Name: "super_admin"}}, nil)
+	ms.On("ListNotifications", ctx, lateAdminID, true, 100).Return([]*models.Notification{}, nil)
+	ms.On("CreateNotification", ctx, mock.MatchedBy(func(n *models.Notification) bool {
+		return n.Type == NotificationLicenseExpiry && n.UserID == lateAdminID
+	})).Return(&models.Notification{ID: 1}, nil)
+
+	n, err := c.ScanLicenseExpiry(ctx, 30)
+	require.NoError(t, err)
+	assert.Equal(t, 1, n, "the admin on the second page must still be notified")
+	ms.AssertNumberOfCalls(t, "ListUsers", 2)
 }
 
 func TestScanLicenseExpiry_SkipsProjectScopedAdmin(t *testing.T) {

--- a/internal/core/list_user_permissions_test.go
+++ b/internal/core/list_user_permissions_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -86,6 +87,44 @@ func TestListUserPermissions_ExcludesExpiredShares(t *testing.T) {
 	assert.True(t, secrets[4], "non-expired group share should be listed")
 	assert.False(t, secrets[3], "expired direct share must NOT be listed")
 	assert.False(t, secrets[5], "expired group share must NOT be listed")
+}
+
+// TestListUserPermissions_PaginatesOwnedSecretsBeyondOnePage pins the fix for a user
+// who owns more secrets than a single storage page: ListUserPermissions must walk
+// every page of owned secrets rather than stopping after the first
+// listUserPermissionsOwnedPageSize-sized page, or ownership beyond that page would be
+// silently dropped from the listing.
+func TestListUserPermissions_PaginatesOwnedSecretsBeyondOnePage(t *testing.T) {
+	ctx := context.Background()
+	const userID = uint(11)
+	ms := new(MockStorage)
+	c := NewKeyorixCore(ms)
+
+	// Page 1 is a full page (exactly the page size) with total > page size, so the
+	// loop must keep going; page 2 returns the remainder.
+	firstPage := make([]*models.SecretNode, listUserPermissionsOwnedPageSize)
+	for i := range firstPage {
+		firstPage[i] = &models.SecretNode{ID: uint(i + 1)}
+	}
+	total := int64(listUserPermissionsOwnedPageSize + 3)
+
+	ms.On("ListSecrets", ctx, mock.MatchedBy(func(f *storage.SecretFilter) bool {
+		return f.Page == 1 && f.PageSize == listUserPermissionsOwnedPageSize
+	})).Return(firstPage, total, nil)
+	ms.On("ListSecrets", ctx, mock.MatchedBy(func(f *storage.SecretFilter) bool {
+		return f.Page == 2 && f.PageSize == listUserPermissionsOwnedPageSize
+	})).Return([]*models.SecretNode{
+		{ID: uint(listUserPermissionsOwnedPageSize + 1)},
+		{ID: uint(listUserPermissionsOwnedPageSize + 2)},
+		{ID: uint(listUserPermissionsOwnedPageSize + 3)},
+	}, total, nil)
+	ms.On("ListSharesByUser", ctx, userID).Return([]*models.ShareRecord{}, nil)
+	ms.On("GetUserGroups", ctx, userID).Return([]*models.Group{}, nil)
+
+	perms, err := c.ListUserPermissions(ctx, userID)
+	require.NoError(t, err)
+	assert.Len(t, perms, int(total), "every owned secret across both pages must be listed")
+	ms.AssertNumberOfCalls(t, "ListSecrets", 2)
 }
 
 func TestListUserPermissions_NoGroups(t *testing.T) {

--- a/internal/core/permissions.go
+++ b/internal/core/permissions.go
@@ -217,6 +217,12 @@ func (c *KeyorixCore) GetEffectivePermission(ctx context.Context, secretID, user
 	return permCtx.Permission, nil
 }
 
+// listUserPermissionsOwnedPageSize bounds each page of the owned-secrets walk in
+// ListUserPermissions. A single fixed-size page silently under-lists a user who owns
+// more than the page size; paginating through every page instead keeps this correct
+// at any scale.
+const listUserPermissionsOwnedPageSize = 500
+
 // ListUserPermissions returns all secrets a user has access to with their permission levels.
 func (c *KeyorixCore) ListUserPermissions(ctx context.Context, userID uint) ([]*models.UserSecretPermission, error) {
 	if userID == 0 {
@@ -226,20 +232,26 @@ func (c *KeyorixCore) ListUserPermissions(ctx context.Context, userID uint) ([]*
 	var permissions []*models.UserSecretPermission
 
 	// Owned == owner_id (the canonical ownership), not created_by (a username
-	// string). Page 1 with an explicit size; a zero PageSize would emit LIMIT 0.
-	ownedSecrets, _, err := c.storage.ListSecrets(ctx, &storage.SecretFilter{
-		OwnerID: &userID, Page: 1, PageSize: 10000,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
-	}
-	for _, secret := range ownedSecrets {
-		permissions = append(permissions, &models.UserSecretPermission{
-			SecretID:   secret.ID,
-			UserID:     userID,
-			Permission: string(PermissionOwner),
-			Source:     "owner",
+	// string). Page through every owned secret so a user who owns more than
+	// listUserPermissionsOwnedPageSize secrets isn't silently truncated.
+	for page := 1; ; page++ {
+		ownedSecrets, total, err := c.storage.ListSecrets(ctx, &storage.SecretFilter{
+			OwnerID: &userID, Page: page, PageSize: listUserPermissionsOwnedPageSize,
 		})
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+		}
+		for _, secret := range ownedSecrets {
+			permissions = append(permissions, &models.UserSecretPermission{
+				SecretID:   secret.ID,
+				UserID:     userID,
+				Permission: string(PermissionOwner),
+				Source:     "owner",
+			})
+		}
+		if len(ownedSecrets) < listUserPermissionsOwnedPageSize || int64(page*listUserPermissionsOwnedPageSize) >= total {
+			break
+		}
 	}
 
 	// A time-bound share stops granting access the instant it expires, so it must

--- a/internal/storage/store/entry.go
+++ b/internal/storage/store/entry.go
@@ -56,6 +56,28 @@ import (
 	"gorm.io/gorm"
 )
 
+// maxStoragePageSize is a defense-in-depth ceiling applied directly inside
+// LocalStorage's paginated queries (secrets, users, audit events), on top of
+// whatever clamp (if any) the caller already applied. External HTTP/gRPC
+// handlers already clamp page_size to <=100 before it reaches storage, but
+// several trusted internal callers intentionally request larger single-shot
+// pages (e.g. secretInventoryMaxRows/csvExportMaxRows = 10000, ListSecrets
+// with OwnerID PageSize 10000). 10000 is chosen to sit above every current
+// legitimate call site in the repo — this clamp is a true no-op for existing
+// behavior today, and only guards a FUTURE caller that forgets to clamp
+// (or passes a hostile/overflowed value) from forcing an unbounded SQL LIMIT.
+const maxStoragePageSize = 10000
+
+// clampPageSize bounds a caller-supplied page size to (0, maxStoragePageSize].
+// A non-positive size is passed through unchanged — several callers rely on
+// their own default/zero-value handling before this clamp runs.
+func clampPageSize(pageSize int) int {
+	if pageSize > maxStoragePageSize {
+		return maxStoragePageSize
+	}
+	return pageSize
+}
+
 // RemoteStorage implements storage.Storage via the Keyorix REST API.
 type RemoteStorage struct {
 	client *remote.HTTPClient

--- a/internal/storage/store/local_audit.go
+++ b/internal/storage/store/local_audit.go
@@ -281,6 +281,7 @@ func (ls *LocalStorage) GetAuditLogs(ctx context.Context, filter *storage.AuditF
 			pageSize = filter.PageSize
 		}
 	}
+	pageSize = clampPageSize(pageSize)
 
 	var total int64
 	query.Count(&total)

--- a/internal/storage/store/local_secrets.go
+++ b/internal/storage/store/local_secrets.go
@@ -526,8 +526,9 @@ func (ls *LocalStorage) ListSecrets(ctx context.Context, filter *storage.SecretF
 		return nil, 0, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
 	}
 
-	offset := (filter.Page - 1) * filter.PageSize
-	query = query.Offset(offset).Limit(filter.PageSize)
+	pageSize := clampPageSize(filter.PageSize)
+	offset := (filter.Page - 1) * pageSize
+	query = query.Offset(offset).Limit(pageSize)
 
 	var secrets []*models.SecretNode
 	if err := query.Find(&secrets).Error; err != nil {

--- a/internal/storage/store/local_users.go
+++ b/internal/storage/store/local_users.go
@@ -265,11 +265,12 @@ func (ls *LocalStorage) ListUsers(ctx context.Context, filter *storage.UserFilte
 		return nil, 0, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
 	}
 
-	offset := (filter.Page - 1) * filter.PageSize
+	pageSize := clampPageSize(filter.PageSize)
+	offset := (filter.Page - 1) * pageSize
 	if filter.Offset > 0 {
 		offset = filter.Offset
 	}
-	query = query.Offset(offset).Limit(filter.PageSize)
+	query = query.Offset(offset).Limit(pageSize)
 
 	var users []*models.User
 	if err := query.Find(&users).Error; err != nil {

--- a/internal/storage/store/pagination_clamp_test.go
+++ b/internal/storage/store/pagination_clamp_test.go
@@ -1,0 +1,64 @@
+package store
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// TestClampPageSize pins the defense-in-depth ceiling LocalStorage applies to every
+// paginated query, independent of whatever clamp (if any) the caller already applied.
+func TestClampPageSize(t *testing.T) {
+	cases := []struct {
+		name string
+		in   int
+		want int
+	}{
+		{"typical page size unaffected", 20, 20},
+		{"exactly at the ceiling unaffected", maxStoragePageSize, maxStoragePageSize},
+		{"one over the ceiling clamped down", maxStoragePageSize + 1, maxStoragePageSize},
+		{"wildly oversized clamped down", 1 << 30, maxStoragePageSize},
+		{"zero passed through (caller's own default applies)", 0, 0},
+		{"negative passed through (caller's own default applies)", -1, -1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, clampPageSize(tc.in))
+		})
+	}
+}
+
+// TestListSecrets_PageSizeClampedAtStorage confirms a future caller that forgets to
+// clamp PageSize itself (bypassing the ≤100 clamp every current HTTP/gRPC handler
+// applies before reaching storage) cannot force an unbounded SQL LIMIT — the storage
+// layer's own ceiling still applies, and the call succeeds rather than erroring or
+// hanging on a hostile/overflowed value.
+func TestListSecrets_PageSizeClampedAtStorage(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.Environment{}))
+	ls := NewLocalStorage(db)
+	ctx := context.Background()
+
+	require.NoError(t, db.Create(&models.Environment{ID: 1, ProjectID: 1, Name: "dev"}).Error)
+	for i := 0; i < 5; i++ {
+		require.NoError(t, db.Create(&models.SecretNode{
+			ProjectID: 1, EnvironmentID: 1, Name: fmt.Sprintf("secret-%d", i),
+			IsSecret: true, Type: "api_key", Status: "active",
+		}).Error)
+	}
+
+	secrets, total, err := ls.ListSecrets(ctx, &storage.SecretFilter{
+		Page: 1, PageSize: 1 << 30, // a caller that forgot to clamp
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int64(5), total)
+	assert.Len(t, secrets, 5)
+}


### PR DESCRIPTION
## Summary

Recreates #579 (closed after its branch had to be deleted/recreated during a rebase onto current `main`, which GitHub does not allow reopening after).

- **#173(a)** — `LocalStorage.ListSecrets`/`ListUsers`/`GetAuditLogs` now clamp `PageSize` to a shared ceiling (`maxStoragePageSize = 10000`) directly at the storage layer, as defense-in-depth. Every current HTTP/gRPC handler already clamps to <=100 before reaching storage, so this is a no-op for existing behavior; the ceiling is set at 10000 (not 100) because several trusted internal callers legitimately request larger single-shot pages (e.g. CSV audit export up to 10000 rows).
- **#173(b)** — `ListUserPermissions` (owned-secrets lookup) and `globalAdminIDs` each read a single fixed-size page (10,000 / 1,000 respectively) that would silently under-list results past that threshold. Both now page through the full result set.
- **#207** — `keyorix config set-remote --api-key` had no safe alternative to putting the key on argv (visible via `ps`/`/proc`, saved in shell history). It now resolves via `--api-key` (warned) -> `KEYORIX_API_KEY` env var, the same pattern `keyorix connect` already uses. `keyorix auth login --api-key` now goes through the same flag -> env var -> masked-prompt resolution order (dropping a stale, non-functional `KEYORIX_REMOTE_API_KEY` reference in the warning that was never actually wired up).
- **#208 dropped** — already superseded on `main` by a stronger typed-name confirmation gate on `machine revoke` (`--force`, matching `secret delete`'s convention), landed since this branch was opened.

## Test plan

- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `go build ./server`
- [x] `GOWORK=off go build ./...` (operator module)
- [x] `go test ./internal/cli/... ./internal/core/... ./internal/storage/...` — full suite passes
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)