### PR TITLE
harden: storage/rotation/audit integrity bundle — #168, #188, #199, #209

### DIFF
--- a/internal/audit/siem/forwarder.go
+++ b/internal/audit/siem/forwarder.go
@@ -3,8 +3,12 @@
 // It supports Splunk HEC, Datadog Logs intake, and a generic authenticated
 // webhook. Forwarding is asynchronous and best-effort: Forward enqueues onto a
 // bounded buffer and returns immediately, so a slow or unreachable SIEM never
-// blocks or fails an audited operation. If the buffer is full, events are
-// dropped (and counted) rather than applying backpressure to the request path.
+// blocks or fails an audited operation. A small bounded pool of workers (see
+// numWorkers) delivers concurrently, so an ordinary SLOW (not down) SIEM
+// endpoint doesn't serialize the whole system's audit-forward throughput
+// behind one request/response round trip. If the buffer is full, events are
+// dropped (and counted, with the event's ID/type logged for forensic
+// backfill) rather than applying backpressure to the request path.
 //
 // SECURITY: audit events carry no plaintext secret values (the value diff is a
 // {"changed":true} marker only — see internal/core/audit_diff.go), so an audit
@@ -77,6 +81,14 @@ const (
 	// base ≈ 0.5s+1s+2s of backoff before giving up.
 	maxAttempts        = 4
 	defaultBaseBackoff = 500 * time.Millisecond
+	// numWorkers bounds delivery concurrency (#199). A single strictly-serial worker
+	// meant an ordinary SLOW (not even down) SIEM endpoint — worst case ~4 attempts x
+	// 5s timeout + backoff, ≈23.5s per event — throttled the entire system's audit-
+	// forward throughput to roughly one event per round trip, making silent
+	// queue-overflow drops plausible under normal audited-API volume. A small bounded
+	// pool multiplies throughput without letting a wedged endpoint spawn unbounded
+	// concurrent connections.
+	numWorkers = 4
 )
 
 // Forwarder ships audit events to a configured SIEM asynchronously.
@@ -138,8 +150,10 @@ func newForwarder(cfg Config, baseBackoff time.Duration) (*Forwarder, error) {
 		}
 		f.spool = sp
 	}
-	f.wg.Add(1)
-	go f.worker()
+	f.wg.Add(numWorkers)
+	for i := 0; i < numWorkers; i++ {
+		go f.worker()
+	}
 	return f, nil
 }
 
@@ -163,7 +177,10 @@ func (f *Forwarder) Forward(event *models.AuditEvent) {
 		dropped := f.dropped
 		f.mu.Unlock()
 		siemForwards.WithLabelValues(outcomeDropped).Inc()
-		log.Printf("siem: audit forward queue full, dropped event (total dropped: %d)", dropped)
+		// Log the event's ID/EventType (matching the "failed" path's logging), not just
+		// a running counter — without them a lost event can never be identified for
+		// forensic backfill from the durable DB audit trail (#199).
+		log.Printf("siem: audit forward queue full, dropped event %d (type %q, total dropped: %d)", event.ID, event.EventType, dropped)
 	}
 }
 

--- a/internal/audit/siem/forwarder_test.go
+++ b/internal/audit/siem/forwarder_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -282,6 +283,97 @@ func TestForward_DropsAndCountsWhenQueueFull(t *testing.T) {
 	}
 	close(release)
 	f.Close()
+}
+
+// #199: a single strictly-serial worker meant an ordinary SLOW (not down) SIEM
+// throttled the whole system's audit-forward throughput to ~one event per round
+// trip. Proves delivery now happens with real concurrency (a bounded worker pool),
+// not one event at a time.
+func TestForward_DeliversWithBoundedConcurrency(t *testing.T) {
+	var inFlight, maxInFlight atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		n := inFlight.Add(1)
+		for {
+			old := maxInFlight.Load()
+			if n <= old || maxInFlight.CompareAndSwap(old, n) {
+				break
+			}
+		}
+		time.Sleep(50 * time.Millisecond) // hold the request open long enough for others to overlap
+		inFlight.Add(-1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	f, err := newForwarder(Config{Enabled: true, Provider: ProviderWebhook, Endpoint: srv.URL}, time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < numWorkers*3; i++ {
+		f.Forward(sampleEvent())
+	}
+	f.Close()
+
+	if got := maxInFlight.Load(); got <= 1 {
+		t.Errorf("max concurrent SIEM deliveries = %d, want > 1 (a single serial worker throttles throughput behind one slow endpoint)", got)
+	}
+}
+
+// #199: the queue-full drop path must log enough to identify the specific lost
+// event for forensic backfill from the durable DB audit trail — not just a
+// running counter.
+func TestForward_DropLogIncludesEventIdentity(t *testing.T) {
+	release := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		<-release // wedge every worker so the queue backs up
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	f, err := newForwarder(Config{Enabled: true, Provider: ProviderWebhook, Endpoint: srv.URL}, time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var logBuf syncBuffer
+	origOut := log.Writer()
+	log.SetOutput(&logBuf)
+	defer log.SetOutput(origOut)
+
+	for i := 0; i < queueSize+numWorkers+5; i++ {
+		f.Forward(sampleEvent()) // sampleEvent has ID 42, EventType "secret.updated"
+	}
+
+	out := logBuf.String()
+	if !strings.Contains(out, "dropped event 42") {
+		t.Errorf("drop log missing the event ID for forensic backfill; got: %s", out)
+	}
+	if !strings.Contains(out, `"secret.updated"`) {
+		t.Errorf("drop log missing the event type for forensic backfill; got: %s", out)
+	}
+
+	// Release the wedged workers so Close (which waits for them) doesn't deadlock —
+	// must happen BEFORE Close, not deferred after it (defers run LIFO).
+	close(release)
+	f.Close()
+}
+
+// syncBuffer is a goroutine-safe io.Writer for capturing concurrently-written log output.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf strings.Builder
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
 }
 
 // containsValueLeak reports whether the JSON appears to carry a plaintext value

--- a/internal/core/access_review_external_test.go
+++ b/internal/core/access_review_external_test.go
@@ -218,3 +218,92 @@ func TestRevokeAccessReviewGrant_RequiresProject(t *testing.T) {
 	err := h.CoreService.RevokeAccessReviewGrant(context.Background(), 1, 0, core.AccessReviewDecision{Source: "role"})
 	require.Error(t, err)
 }
+
+// #209: attesting a role grant that has since been revoked (or never existed) must
+// be refused, not silently recorded as clean compliance evidence — an attestation
+// certifies "I reviewed and confirmed this access is still needed," which would be a
+// false statement for a grant that's already gone.
+func TestAttestAccessReviewGrant_RefusesRevokedRoleGrant(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(&models.AuditEvent{}))
+
+	const proj = uint(2)
+	h.CreateTestUser(t, "alice", 10)
+	h.AssignUserRole(t, 10, 3, uptr(proj))
+
+	ctx := context.Background()
+	// The grant is revoked through a path unrelated to the (now-stale) campaign item...
+	require.NoError(t, h.CoreService.RevokeAccessReviewGrant(ctx, 1, proj, core.AccessReviewDecision{
+		Source: "role", PrincipalType: "user", PrincipalID: 10, RoleID: 3,
+	}))
+
+	// ...so attesting the same decision (as a reviewer acting on stale campaign data
+	// would) must be refused, not recorded as clean evidence.
+	err := h.CoreService.AttestAccessReviewGrant(ctx, 1, proj, core.AccessReviewDecision{
+		Source: "role", PrincipalType: "user", PrincipalID: 10, RoleID: 3,
+	})
+	require.Error(t, err, "attesting a grant that no longer exists must be refused")
+
+	var count int64
+	require.NoError(t, h.DB.Model(&models.AuditEvent{}).
+		Where("event_type = ?", core.EventAccessReviewAttested).Count(&count).Error)
+	assert.Equal(t, int64(0), count, "no fabricated attestation evidence must be recorded")
+}
+
+// #209: attesting an outright fabricated tuple (a role never assigned to this
+// principal) must be refused the same way — the campaign item's cached fields alone
+// are not sufficient evidence a grant exists.
+func TestAttestAccessReviewGrant_RefusesFabricatedRoleGrant(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(&models.AuditEvent{}))
+
+	const proj = uint(2)
+	h.CreateTestUser(t, "alice", 10)
+	// alice is never actually granted role 3 at project 2.
+
+	err := h.CoreService.AttestAccessReviewGrant(context.Background(), 1, proj, core.AccessReviewDecision{
+		Source: "role", PrincipalType: "user", PrincipalID: 10, RoleID: 3,
+	})
+	require.Error(t, err, "attesting a grant that was never real must be refused")
+
+	var count int64
+	require.NoError(t, h.DB.Model(&models.AuditEvent{}).
+		Where("event_type = ?", core.EventAccessReviewAttested).Count(&count).Error)
+	assert.Equal(t, int64(0), count, "no fabricated attestation evidence must be recorded")
+}
+
+// A live share attestation still succeeds, and a stale/revoked share attestation is
+// refused the same way as a role grant.
+func TestAttestAccessReviewGrant_Share(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(&models.SecretNode{}, &models.Environment{}, &models.ShareRecord{}, &models.AuditEvent{}))
+
+	const proj = uint(2)
+	h.CreateTestUser(t, "alice", 10) // owner
+	h.CreateTestUser(t, "bob", 11)   // direct-share recipient
+	require.NoError(t, h.DB.Create(&models.Environment{ID: 20, ProjectID: proj, Name: "prod"}).Error)
+	require.NoError(t, h.DB.Create(&models.SecretNode{
+		ID: 500, ProjectID: proj, EnvironmentID: 20, OwnerID: 10, Name: "db-pw", Type: "password", Status: "active", IsSecret: true,
+	}).Error)
+	require.NoError(t, h.DB.Create(&models.ShareRecord{SecretID: 500, RecipientID: 11, IsGroup: false, Permission: "read"}).Error)
+
+	ctx := context.Background()
+	// A live share attests cleanly.
+	require.NoError(t, h.CoreService.AttestAccessReviewGrant(ctx, 1, proj, core.AccessReviewDecision{
+		Source: "direct_share", PrincipalID: 11, SecretID: 500,
+	}))
+
+	// A share that was never granted (fabricated recipient) is refused.
+	err := h.CoreService.AttestAccessReviewGrant(ctx, 1, proj, core.AccessReviewDecision{
+		Source: "direct_share", PrincipalID: 999, SecretID: 500,
+	})
+	require.Error(t, err)
+
+	var count int64
+	require.NoError(t, h.DB.Model(&models.AuditEvent{}).
+		Where("event_type = ?", core.EventAccessReviewAttested).Count(&count).Error)
+	assert.Equal(t, int64(1), count, "exactly the one live attestation was recorded")
+}

--- a/internal/core/access_review_revoke.go
+++ b/internal/core/access_review_revoke.go
@@ -129,6 +129,14 @@ func (c *KeyorixCore) revokeReviewShare(ctx context.Context, projectID uint, d A
 // AttestAccessReviewGrant records that the reviewer examined the grant and chose to
 // keep it. It changes no state — the access_review.attested event is the evidence
 // that the recertification was performed. actorID is the reviewer.
+//
+// Before recording that evidence, the referenced grant is re-verified against a live
+// lookup (mirroring RevokeAccessReviewGrant's validated branches), not just trusted
+// from the campaign item's cached snapshot — the grant could have been revoked
+// through an unrelated path since the campaign was generated, or the campaign data
+// could simply be stale/wrong. An attestation asserts "I reviewed and confirmed this
+// access is still needed and correct"; recording it for a grant that no longer exists
+// would certify a false state in the compliance evidence trail (#209).
 func (c *KeyorixCore) AttestAccessReviewGrant(ctx context.Context, actorID, projectID uint, d AccessReviewDecision) error {
 	if projectID == 0 {
 		return fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "project ID is required")
@@ -136,8 +144,70 @@ func (c *KeyorixCore) AttestAccessReviewGrant(ctx context.Context, actorID, proj
 	if d.Source == "" {
 		return fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "source is required")
 	}
+	if err := c.verifyAccessReviewGrantExists(ctx, projectID, d); err != nil {
+		return err
+	}
 	c.logAccessReviewDecision(ctx, EventAccessReviewAttested, "attested", actorID, projectID, d)
 	return nil
+}
+
+// verifyAccessReviewGrantExists re-queries the actual grant a decision references —
+// the role assignment, share, or ownership row — rather than trusting the decision's
+// (possibly stale) fields. Returns a clear "no longer exists, re-sync" error when the
+// live lookup finds nothing, mirroring the same real removal calls
+// RevokeAccessReviewGrant uses (which likewise fail when the grant is already gone).
+func (c *KeyorixCore) verifyAccessReviewGrantExists(ctx context.Context, projectID uint, d AccessReviewDecision) error {
+	switch d.Source {
+	case "role":
+		if d.PrincipalID == 0 || d.RoleID == 0 {
+			return fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "principal_id and role_id are required to attest a role grant")
+		}
+		assignments, err := c.storage.ListProjectRoleAssignments(ctx, projectID)
+		if err != nil {
+			return fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+		}
+		wantGroup := d.PrincipalType == "group"
+		for _, a := range assignments {
+			if (a.PrincipalType == "group") == wantGroup && a.PrincipalID == d.PrincipalID &&
+				a.RoleID == d.RoleID && a.EnvironmentID == d.EnvironmentID {
+				return nil
+			}
+		}
+		return fmt.Errorf("%s: %s", i18n.T("ErrorNotFound", nil),
+			"the role grant being attested no longer exists — the review is stale, re-sync and try again")
+	case "direct_share", "group_share":
+		if d.PrincipalID == 0 || d.SecretID == 0 {
+			return fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "principal_id and secret_id are required to attest a share")
+		}
+		isGroup := d.Source == "group_share"
+		shares, err := c.storage.ListSharesBySecret(ctx, d.SecretID)
+		if err != nil {
+			return fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+		}
+		for _, sh := range shares {
+			if sh.RecipientID == d.PrincipalID && sh.IsGroup == isGroup {
+				return nil
+			}
+		}
+		return fmt.Errorf("%s: %s", i18n.T("ErrorNotFound", nil),
+			"the share being attested no longer exists — the review is stale, re-sync and try again")
+	case "owner":
+		if d.PrincipalID == 0 || d.SecretID == 0 {
+			return fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "principal_id and secret_id are required to attest ownership")
+		}
+		secret, err := c.storage.GetSecret(ctx, d.SecretID)
+		if err != nil || secret == nil {
+			return fmt.Errorf("%s: %s", i18n.T("ErrorNotFound", nil),
+				"the secret being attested no longer exists — the review is stale, re-sync and try again")
+		}
+		if secret.OwnerID != d.PrincipalID {
+			return fmt.Errorf("%s: %s", i18n.T("ErrorNotFound", nil),
+				"the ownership grant being attested no longer exists — the review is stale, re-sync and try again")
+		}
+		return nil
+	default:
+		return fmt.Errorf("%s: unknown access-review source %q", i18n.T("ErrorValidation", nil), d.Source)
+	}
 }
 
 // logAccessReviewDecision writes the recertification audit event (actor as UserID,

--- a/internal/core/concurrency_access_review_campaign_close_test.go
+++ b/internal/core/concurrency_access_review_campaign_close_test.go
@@ -34,12 +34,17 @@ func TestConcurrency_DecideAccessReviewItem_RejectsWhenRacingClose(t *testing.T)
 	dsn := "file:" + filepath.Join(t.TempDir(), "arc-close-race.db") + "?_busy_timeout=10000&_journal_mode=WAL&_txlock=immediate"
 	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
 	require.NoError(t, err)
-	require.NoError(t, db.AutoMigrate(&models.AccessReviewCampaign{}, &models.AccessReviewItem{}, &models.AuditEvent{}))
+	require.NoError(t, db.AutoMigrate(&models.AccessReviewCampaign{}, &models.AccessReviewItem{}, &models.AuditEvent{}, &models.UserRole{}, &models.GroupRole{}))
 
 	const proj = uint(2)
 	campaign := &models.AccessReviewCampaign{ProjectID: proj, Name: "close-race", State: core.CampaignStateOpen}
 	require.NoError(t, db.Create(campaign).Error)
-	item := &models.AccessReviewItem{CampaignID: campaign.ID, PrincipalType: "role", Source: "role", Decision: core.ReviewItemPending}
+	// A real role assignment behind the item, so AttestAccessReviewGrant's live
+	// re-verification (#209) finds a genuine grant to certify — this test exercises
+	// the decide/close concurrency race, not attestation validity, so the grant just
+	// needs to actually exist.
+	require.NoError(t, db.Create(&models.UserRole{UserID: 999, RoleID: 1, ProjectID: proj}).Error)
+	item := &models.AccessReviewItem{CampaignID: campaign.ID, PrincipalType: "role", PrincipalID: 999, RoleID: 1, Source: "role", Decision: core.ReviewItemPending}
 	require.NoError(t, db.Create(item).Error)
 
 	c := core.NewKeyorixCore(store.NewLocalStorage(db))

--- a/internal/core/concurrency_access_review_redecide_test.go
+++ b/internal/core/concurrency_access_review_redecide_test.go
@@ -31,16 +31,17 @@ func TestConcurrency_DecideAccessReviewItem_OnlyOneDecisionWins(t *testing.T) {
 	dsn := "file:" + filepath.Join(t.TempDir(), "arc.db") + "?_busy_timeout=10000&_journal_mode=WAL&_txlock=immediate"
 	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
 	require.NoError(t, err)
-	require.NoError(t, db.AutoMigrate(&models.AccessReviewCampaign{}, &models.AccessReviewItem{}, &models.AuditEvent{}))
+	require.NoError(t, db.AutoMigrate(&models.AccessReviewCampaign{}, &models.AccessReviewItem{}, &models.AuditEvent{}, &models.UserRole{}, &models.GroupRole{}))
 
 	const proj = uint(2)
 	campaign := &models.AccessReviewCampaign{ProjectID: proj, Name: "race", State: core.CampaignStateOpen}
 	require.NoError(t, db.Create(campaign).Error)
 	// PrincipalType "role" (neither "user" nor "group") sidesteps the self-certification
-	// checks, which aren't what this test is about; Source "role" satisfies
-	// AttestAccessReviewGrant's only precondition (a non-empty source) without needing a
-	// real role/share grant to exist.
-	item := &models.AccessReviewItem{CampaignID: campaign.ID, PrincipalType: "role", Source: "role", Decision: core.ReviewItemPending}
+	// checks, which aren't what this test is about. A real role assignment backs the
+	// item so AttestAccessReviewGrant's live re-verification (#209) finds a genuine
+	// grant to certify.
+	require.NoError(t, db.Create(&models.UserRole{UserID: 999, RoleID: 1, ProjectID: proj}).Error)
+	item := &models.AccessReviewItem{CampaignID: campaign.ID, PrincipalType: "role", PrincipalID: 999, RoleID: 1, Source: "role", Decision: core.ReviewItemPending}
 	require.NoError(t, db.Create(item).Error)
 
 	c := core.NewKeyorixCore(store.NewLocalStorage(db))

--- a/internal/core/rotation_executor_test.go
+++ b/internal/core/rotation_executor_test.go
@@ -446,6 +446,47 @@ func TestRunAutoRotation_LogsAndContinuesOnScopedSecretsError(t *testing.T) {
 
 func timePtr(t time.Time) *time.Time { return &t }
 
+// #194: a generate-upstream backend whose old-credential delete failed must NOT be
+// reported as a clean, unconditional success. The new credential is minted upstream
+// (often returned only once, e.g. a cloud key API), so RunAutoRotation MUST still
+// store it — but the run has to surface the leftover credential as a distinct,
+// operator-visible partial-failure signal rather than a normal "auto-rotated" line,
+// so it's neither silently swallowed nor lost from the audit trail. This exercises
+// the orchestration layer (rotateOneSecret's PartialRotationError branch); the
+// per-backend executors (AWS IAM/Azure AD/GCP SA) that construct PartialRotationError
+// are covered individually in internal/rotation/*_test.go.
+func TestRunAutoRotation_GenerateUpstreamPartialDelete_StoresButFlagsIncomplete(t *testing.T) {
+	c, db, fixed := rotationExecCore(t)
+	pid := uint(1)
+	require.NoError(t, db.Create(&models.RotationPolicy{
+		ID: 1, Name: "30-day", Scope: "project", ProjectID: &pid, IntervalDays: 30, IsActive: true, CreatedBy: "admin",
+	}).Error)
+	newCred := `{"access_key_id":"AKIANEW","secret_access_key":"s3cr3t"}`
+	fake := &fakeGenExecutor{name: "cloud", err: &rotation.PartialRotationError{
+		Value: newCred,
+		Err:   errors.New("aws-iam: rotated \"svc-app\" but failed to delete prior access key(s) [AKIAOLD] (the old credential is still live and must be removed manually): AccessDenied"),
+	}}
+	c.SetRotationManager(rotation.NewManager([]rotation.Executor{fake}))
+	seedBackendSecret(t, db, 1, "cloud", "svc-app", fixed.Add(-60*24*time.Hour))
+
+	n, err := c.RunAutoRotation(context.Background())
+	require.NoError(t, err)
+	// The new credential IS stored (it must not be discarded/orphaned)...
+	require.Equal(t, 1, n, "the new credential is still stored despite the incomplete cleanup")
+	v := latestVersion(t, db, 1)
+	assert.Equal(t, 2, v.VersionNumber)
+	assert.Equal(t, newCred, string(v.EncryptedValue))
+
+	// ...but the run must NOT report this as a clean, indistinguishable success: exactly
+	// one auto-rotation audit event, and it must flag the leftover credential distinctly.
+	var events []models.AuditEvent
+	require.NoError(t, db.Where("event_type = ?", EventSecretAutoRotated).Find(&events).Error)
+	require.Len(t, events, 1)
+	assert.Contains(t, events[0].Description, "INCOMPLETE", "a surviving old credential must be a distinct signal, not a silent success")
+	assert.Contains(t, events[0].Description, "AKIAOLD", "the audit trail must name the leftover credential for operator cleanup")
+	assert.NotContains(t, events[0].Description, "auto-rotated secret", "must not read as the normal clean-success line")
+}
+
 // A rotation failure broadcasts a single summary notification (fakeSink is defined in
 // notification_dispatch_test.go).
 func TestRunAutoRotation_NotifiesFailures(t *testing.T) {

--- a/internal/storage/store/remote_secrets.go
+++ b/internal/storage/store/remote_secrets.go
@@ -293,16 +293,32 @@ func (rs *RemoteStorage) IncrementSecretReadCount(ctx context.Context, versionID
 	return nil
 }
 
-// TryIncrementSecretReadCount is server-side enforcement: the authoritative,
-// race-free max-reads gate runs in the server against its local storage. The remote
-// value-read path goes through the server's API (which enforces there), so this
-// method is not on a remote value-read hot path; delegate the increment and report
-// success. Errors propagate so the caller can fail closed.
-func (rs *RemoteStorage) TryIncrementSecretReadCount(ctx context.Context, versionID uint, _ int) (bool, error) {
-	if err := rs.IncrementSecretReadCount(ctx, versionID); err != nil {
-		return false, err
-	}
-	return true, nil
+// TryIncrementSecretReadCount is the max-reads burn-after-N-reads gate
+// (internal/core/storage/interface.go). LocalStorage implements it as a real
+// conditional `UPDATE ... WHERE read_count < maxReads` (local_secrets.go) so
+// concurrent readers can never collectively exceed the cap.
+//
+// The server exposes no REST endpoint for this conditional check-and-increment
+// today — only a plain, non-conditional increment-read-count route is proxyable
+// via IncrementSecretReadCount, and even that route isn't currently registered
+// in router.go (confirmed: no /secret-versions/{id}/increment-read-count route
+// exists server-side). Blindly delegating to the unconditional increment would
+// silently defeat maxReads for any deployment/future code path that reaches this
+// method through storage.type: remote — it would always report success without
+// ever checking the cap. Fail closed instead: report unsupported so the caller
+// (readVersionValue, internal/core/versions.go) takes its existing fail-closed
+// branch and refuses the read, rather than silently granting an unbounded number
+// of reads on a max-reads-limited secret (#188).
+//
+// This method is not on the live remote value-read path today — the CLI's
+// value-read path goes through a separate, already max-reads-enforcing HTTP
+// endpoint on the server, not through core.KeyorixCore/RemoteStorage — so this
+// closes a latent landmine, not a currently-exploitable gap. A real fix that
+// preserves remote-mode support for max-reads secrets would require a new
+// atomic conditional-increment REST endpoint mirroring LocalStorage's semantics;
+// that is a larger scope than this fix and remains a documented gap.
+func (rs *RemoteStorage) TryIncrementSecretReadCount(_ context.Context, _ uint, _ int) (bool, error) {
+	return false, remoteUnsupported("TryIncrementSecretReadCount")
 }
 
 // TryIncrementSecretNodeReadCount mirrors TryIncrementSecretReadCount: the

--- a/server/grpc/services/secret_service.go
+++ b/server/grpc/services/secret_service.go
@@ -322,6 +322,13 @@ func (s *SecretGRPCService) GetSecretVersions(ctx context.Context, req *pb.GetSe
 	if err != nil {
 		return nil, mapSecretError(err)
 	}
+	// Audit as a secret read, mirroring the HTTP handler (secrets_versions.go) —
+	// without this, listing version history over gRPC left no secret.read event,
+	// an HTTP<->gRPC audit-parity gap invisible to anomaly detection (#168).
+	// Best-effort metadata fetch, same as HTTP: a miss just skips the audit call.
+	if secret, sErr := s.core.GetSecretWithPermissionCheck(ctx, uint(req.GetId()), user.UserID); sErr == nil && secret != nil {
+		go s.core.LogSecretReadWithProject(core.DetachedAuditContext(ctx), user.UserID, uint(req.GetId()), secret.ProjectID, user.Username, secret.Name, interceptors.PeerIP(ctx), interceptors.ClientUserAgent(ctx)) // #nosec G118
+	}
 	out := make([]*pb.SecretVersion, 0, len(versions))
 	for _, v := range versions {
 		out = append(out, &pb.SecretVersion{


### PR DESCRIPTION
## Summary

Recreates #569 (closed after its branch had to be deleted/recreated during a rebase onto current main, which GitHub does not permit reopening after). #216 is dropped here since main already fixed it independently (writeAccessLog now logs a loud SECURITY warning on a failed CreateSecretAccessLog write) since this branch was opened; #194 was already fixed on main (PartialRotationError plumbing, via #516) and this PR only adds the missing orchestration-level test coverage for it.

- **#168** — gRPC `GetSecretVersions` didn't emit the `secret.read` audit event its HTTP counterpart does, leaving version-listing invisible to anomaly detection over gRPC. Added the same detached `LogSecretReadWithProject` call.
- **#188** — `RemoteStorage.TryIncrementSecretReadCount` unconditionally incremented and reported success, ignoring maxReads entirely. It now fails closed (`ErrRemoteUnsupported`) so the caller's existing fail-closed branch fires.
- **#194** — verified already fixed on main; added missing orchestration-level test coverage for the generate-upstream partial-delete path in `rotateOneSecret`.
- **#199** — the SIEM forwarder ran exactly one serial worker over a 1024-deep queue, throttling the whole system's audit-forward throughput behind one slow (not down) SIEM endpoint. Added a small bounded worker pool (4), and the queue-full drop log now includes the event ID/type for forensic backfill.
- **#209** — `AttestAccessReviewGrant` recorded recertification evidence for a grant without checking it still exists. It now re-verifies the referenced role assignment/share/ownership against live storage before logging the attestation.

Also fixes two pre-existing `internal/core` concurrency tests (`TestConcurrency_DecideAccessReviewItem_RejectsWhenRacingClose`, `TestConcurrency_DecideAccessReviewItem_OnlyOneDecisionWins`) whose fixtures used a zero-valued `PrincipalID`/`RoleID` — now seeded with a real `UserRole` grant so #209's live re-verification has something genuine to find.

## Test plan

- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `go build ./server`
- [x] `GOWORK=off go build ./...` (operator module)
- [x] `go test ./...` — full suite passes
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)