### PR TITLE
harden(github-action): checksum-verify pinned installs, pin installer source, mask output-file secrets (#175/#176/#177)

### DIFF
--- a/integrations/github-action/entrypoint.sh
+++ b/integrations/github-action/entrypoint.sh
@@ -26,15 +26,46 @@ install_cli() {
     return
   fi
   if [ -n "$VERSION" ]; then
+    local binary_name checksums_url expected actual
     os="$(uname -s | tr '[:upper:]' '[:lower:]')"
     arch="$(uname -m)"
     case "$arch" in
       x86_64) arch="amd64" ;;
       aarch64 | arm64) arch="arm64" ;;
     esac
-    url="https://github.com/keyorixhq/keyorix/releases/download/${VERSION}/keyorix_${os}_${arch}"
+    binary_name="keyorix_${os}_${arch}"
+    url="https://github.com/keyorixhq/keyorix/releases/download/${VERSION}/${binary_name}"
+    checksums_url="https://github.com/keyorixhq/keyorix/releases/download/${VERSION}/checksums.txt"
     echo "Downloading keyorix ${VERSION} (${os}/${arch})..."
     curl -fsSL "$url" -o /tmp/keyorix
+
+    # Verify SHA-256 against the release's published checksums.txt, same
+    # approach install.sh uses for the "latest" path below — fail closed
+    # (rather than install.sh's skip-if-missing) since this path has no
+    # other integrity signal.
+    echo "Verifying checksum..."
+    expected="$(curl -fsSL "$checksums_url" | awk -v n="$binary_name" '$2==n {print $1}')"
+    if [ -z "$expected" ]; then
+      echo "error: no checksum published for ${binary_name} at ${VERSION}; refusing to install unverified binary" >&2
+      rm -f /tmp/keyorix
+      exit 1
+    fi
+    if command -v sha256sum >/dev/null 2>&1; then
+      actual="$(sha256sum /tmp/keyorix | awk '{print $1}')"
+    elif command -v shasum >/dev/null 2>&1; then
+      actual="$(shasum -a 256 /tmp/keyorix | awk '{print $1}')"
+    else
+      echo "error: no sha256sum/shasum tool found; cannot verify checksum" >&2
+      rm -f /tmp/keyorix
+      exit 1
+    fi
+    if [ "$actual" != "$expected" ]; then
+      echo "error: checksum mismatch for ${binary_name}: expected ${expected}, got ${actual}. Aborting." >&2
+      rm -f /tmp/keyorix
+      exit 1
+    fi
+    echo "Checksum verified"
+
     chmod +x /tmp/keyorix
     if [ -w "$install_dir" ]; then
       mv /tmp/keyorix "${install_dir}/keyorix"
@@ -43,7 +74,11 @@ install_cli() {
     fi
   else
     # Latest release via the official installer (verifies the checksum).
-    curl -fsSL https://raw.githubusercontent.com/keyorixhq/keyorix/main/install.sh | sh
+    # Pinned to a specific commit SHA (not the mutable `main` branch, and
+    # not a movable tag ref) so a future main-branch or tag compromise
+    # can't alter the code piped into `sh` here. Bump deliberately when
+    # install.sh's logic needs to change.
+    curl -fsSL https://raw.githubusercontent.com/keyorixhq/keyorix/6dd9e555125500e76b4e2035a867621e416585a3/install.sh | sh
   fi
   keyorix --version
 }
@@ -109,6 +144,22 @@ if [[ "${BASH_SOURCE[0]:-$0}" == "${0}" ]]; then
   fi
 
   if [ -n "$OUTPUT_FILE" ]; then
+    # Mask every secret value before writing the dotenv file. This must happen
+    # independently of inject_env's masking above, since inject_env (and its
+    # ::add-mask:: calls) is skipped entirely when export-to-env=false, which
+    # is a documented, supported combination with output-file — without this,
+    # a later step that cats/sources the file would print secrets in the clear.
+    output_json="$(keyorix secret export --project "$PROJECT" --env "$ENVIRONMENT" --format json)"
+    if ! printf '%s' "$output_json" | jq empty 2>/dev/null; then
+      echo "error: 'keyorix secret export' did not return valid JSON" >&2
+      exit 1
+    fi
+    while IFS= read -r output_key; do
+      [ -n "$output_key" ] || continue
+      output_val="$(printf '%s' "$output_json" | jq -r --arg k "$output_key" '.[$k]')"
+      echo "::add-mask::$output_val"
+    done < <(printf '%s' "$output_json" | jq -r 'keys[]')
+
     # Reuse the CLI's dotenv writer (handles quoting) for the file form.
     keyorix secret export --project "$PROJECT" --env "$ENVIRONMENT" --format dotenv --output "$OUTPUT_FILE"
     echo "Wrote secrets to ${OUTPUT_FILE}"

--- a/integrations/github-action/test/entrypoint_test.sh
+++ b/integrations/github-action/test/entrypoint_test.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Minimal black-box tests for entrypoint.sh, covering the three fixes in
+# this round (HARDENING-BACKLOG #175/#176/#177):
+#
+#   #175 — a pinned `version` install must abort if the downloaded binary's
+#          checksum doesn't match the release's published checksums.txt.
+#   #176 — the "latest" installer path must not fetch install.sh from the
+#          mutable `main` branch; it must be pinned to an immutable ref.
+#   #177 — secret values must be `::add-mask::`d on the output-file path
+#          even when export-to-env=false (so inject_env's masking is
+#          skipped).
+#
+# Runs entrypoint.sh as a real subprocess against a mocked PATH (fake
+# curl/keyorix, in test/fixtures/), so it exercises the actual script, not
+# a reimplementation of it.
+#
+# Usage: integrations/github-action/test/entrypoint_test.sh
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+entrypoint="${script_dir}/../entrypoint.sh"
+fixtures="${script_dir}/fixtures"
+
+pass=0
+fail=0
+
+ok() {
+  pass=$((pass + 1))
+  echo "ok - $1"
+}
+
+bad() {
+  fail=$((fail + 1))
+  echo "not ok - $1"
+}
+
+# Use $TMPDIR explicitly (rather than a bare `mktemp -d`) since some
+# mktemp implementations fall back to a fixed OS temp dir that ignores
+# $TMPDIR, which trips sandboxes that only allow writes under $TMPDIR.
+workdir="$(mktemp -d "${TMPDIR:-/tmp}/entrypoint_test.XXXXXX")"
+trap 'rm -rf "$workdir"' EXIT
+mockbin="${workdir}/bin"
+mkdir -p "$mockbin"
+
+# --- #176: static check — the "latest" path must not reference the
+# mutable `main` branch, and must be pinned to a 40-char commit SHA.
+if grep -q 'raw\.githubusercontent\.com/keyorixhq/keyorix/main/install\.sh' "$entrypoint"; then
+  bad "#176: installer still fetches install.sh from the mutable main branch"
+else
+  ok "#176: installer no longer fetches install.sh from main"
+fi
+
+if grep -qE 'raw\.githubusercontent\.com/keyorixhq/keyorix/[0-9a-f]{40}/install\.sh' "$entrypoint"; then
+  ok "#176: installer is pinned to an immutable commit SHA"
+else
+  bad "#176: installer is not pinned to a commit SHA"
+fi
+
+# --- #175: a checksum mismatch on the pinned-version path must abort
+# loudly, not proceed to install the (corrupted/tampered) binary.
+cp "${fixtures}/mock_curl_checksum_mismatch.sh" "${mockbin}/curl"
+chmod +x "${mockbin}/curl"
+
+set +e
+PATH="${mockbin}:${PATH}" \
+  KEYORIX_SERVER="https://example.invalid" \
+  KEYORIX_TOKEN="dummy-token" \
+  INPUT_VERSION="v9.9.9" \
+  INPUT_EXPORT_TO_ENV="false" \
+  bash "$entrypoint" >"${workdir}/stdout1.log" 2>"${workdir}/stderr1.log"
+rc1=$?
+set -e
+
+if [ "$rc1" -ne 0 ] && grep -qi "checksum mismatch" "${workdir}/stderr1.log"; then
+  ok "#175: checksum mismatch aborts the pinned-version install"
+else
+  bad "#175: checksum mismatch did not abort as expected (rc=${rc1}); stderr: $(cat "${workdir}/stderr1.log")"
+fi
+
+# --- #177: secret values must be masked on the output-file path even
+# when export-to-env=false skips inject_env (and its masking) entirely.
+cp "${fixtures}/mock_keyorix.sh" "${mockbin}/keyorix"
+chmod +x "${mockbin}/keyorix"
+
+out_file="${workdir}/out.env"
+set +e
+PATH="${mockbin}:${PATH}" \
+  KEYORIX_SERVER="https://example.invalid" \
+  KEYORIX_TOKEN="dummy-token" \
+  INPUT_EXPORT_TO_ENV="false" \
+  INPUT_OUTPUT_FILE="$out_file" \
+  bash "$entrypoint" >"${workdir}/stdout2.log" 2>"${workdir}/stderr2.log"
+rc2=$?
+set -e
+
+if [ "$rc2" -eq 0 ] && grep -q "::add-mask::topsecretvalue123" "${workdir}/stdout2.log"; then
+  ok "#177: output-file path masks secret values even with export-to-env=false"
+else
+  bad "#177: output-file path did not mask secret values as expected (rc=${rc2}); stdout: $(cat "${workdir}/stdout2.log"); stderr: $(cat "${workdir}/stderr2.log")"
+fi
+
+if [ -f "$out_file" ] && grep -q "SUPER_SECRET=topsecretvalue123" "$out_file"; then
+  ok "#177: output file was still written with the secret"
+else
+  bad "#177: output file was not written as expected"
+fi
+
+echo
+echo "${pass} passed, ${fail} failed"
+[ "$fail" -eq 0 ]

--- a/integrations/github-action/test/fixtures/mock_curl_checksum_mismatch.sh
+++ b/integrations/github-action/test/fixtures/mock_curl_checksum_mismatch.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Mock curl used by entrypoint_test.sh's #175 case: serves a fake binary for
+# the release download URL, and a checksums.txt whose recorded hash
+# deliberately does NOT match that binary's real hash, simulating
+# in-transit tampering/corruption.
+os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+arch="$(uname -m)"
+case "$arch" in
+  x86_64) arch="amd64" ;;
+  aarch64 | arm64) arch="arm64" ;;
+esac
+binary_name="keyorix_${os}_${arch}"
+
+out=""
+url=""
+args=("$@")
+for ((i = 0; i < ${#args[@]}; i++)); do
+  case "${args[$i]}" in
+    -o) out="${args[$((i + 1))]}" ;;
+    http*) url="${args[$i]}" ;;
+  esac
+done
+
+case "$url" in
+  */checksums.txt)
+    echo "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef  ${binary_name}"
+    ;;
+  *)
+    printf 'not-the-real-binary-contents' >"$out"
+    ;;
+esac

--- a/integrations/github-action/test/fixtures/mock_keyorix.sh
+++ b/integrations/github-action/test/fixtures/mock_keyorix.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Mock keyorix CLI used by entrypoint_test.sh's #177 case: already
+# "installed" (so install_cli short-circuits without touching the
+# network); handles the two `secret export` forms entrypoint.sh calls.
+if [ "$1" = "--version" ]; then
+  echo "keyorix version mock-1.0.0"
+  exit 0
+fi
+if [ "$1" = "secret" ] && [ "$2" = "export" ]; then
+  fmt=""
+  outfile=""
+  args=("$@")
+  for ((i = 0; i < ${#args[@]}; i++)); do
+    case "${args[$i]}" in
+      --format) fmt="${args[$((i + 1))]}" ;;
+      --output) outfile="${args[$((i + 1))]}" ;;
+    esac
+  done
+  case "$fmt" in
+    json)
+      printf '{"SUPER_SECRET":"topsecretvalue123"}'
+      exit 0
+      ;;
+    dotenv)
+      printf 'SUPER_SECRET=topsecretvalue123\n' >"$outfile"
+      exit 0
+      ;;
+  esac
+fi
+echo "mock keyorix: unhandled args: $*" >&2
+exit 1


### PR DESCRIPTION
## Summary

Recreates #567 (closed after its branch had to be deleted/recreated during a rebase onto current main, which GitHub does not permit reopening after).

Fixes three MEDIUM findings, all in `integrations/github-action/entrypoint.sh`:

- **#175 — version-pinned CLI download skipped checksum verification.** The `version`-pinned install path did a bare `curl | chmod +x | mv` with no integrity check. It now downloads and verifies the release's `checksums.txt` before making the binary executable, and fails closed if no checksum is published or the hash doesn't match.
- **#176 — default installer fetched from the mutable `main` branch.** The default ("latest") path piped `install.sh` from `raw.githubusercontent.com/.../main/install.sh` into `sh`. It's now pinned to a specific immutable commit SHA rather than `main`.
- **#177 — `--output-file` (dotenv) path never masked secret values.** `::add-mask::` was only ever registered inside `inject_env`, which is skipped entirely when `export-to-env=false` — a documented, supported combination with `output-file`. The output-file path now masks every secret value independently.

Rebased cleanly against main's independent #174 fix (unsanitized secret names in `inject_env`) — that function is untouched here.

## Test plan

- [x] Added `integrations/github-action/test/entrypoint_test.sh` — a black-box harness against mocked `curl`/`keyorix` fixtures
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `go build ./server`
- [x] `GOWORK=off go build ./...` (operator module)
- [x] `go test ./...` — full suite passes (this PR touches no Go files)
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)