### PR TITLE
harden: CLI/credential hygiene fixes (#152/#164/#183, MED)

### DIFF
--- a/internal/bundle/bundle.go
+++ b/internal/bundle/bundle.go
@@ -320,7 +320,7 @@ func process(r io.Reader, reg *trust.KeyRegistry, opts *extractOpts) (*Manifest,
 				return nil, err
 			}
 		}
-		if err := os.MkdirAll(opts.destDir, 0o750); err != nil {
+		if err := mkdirAllNoSymlink(opts.destDir, opts.destDir); err != nil {
 			return nil, fmt.Errorf("bundle: create destination: %w", err)
 		}
 	}
@@ -448,7 +448,7 @@ func streamComponent(tr io.Reader, comp Component, destDir string) error {
 			return err
 		}
 		finalPath = final
-		if err := os.MkdirAll(filepath.Dir(finalPath), 0o750); err != nil {
+		if err := mkdirAllNoSymlink(destDir, filepath.Dir(finalPath)); err != nil {
 			return fmt.Errorf("bundle: mkdir for %s: %w", comp.Path, err)
 		}
 		tmp, err = os.CreateTemp(filepath.Dir(finalPath), ".kxbundle-*")
@@ -484,6 +484,63 @@ func streamComponent(tr io.Reader, comp Component, destDir string) error {
 		if err := os.Rename(tmpPath, finalPath); err != nil {
 			cleanup()
 			return fmt.Errorf("bundle: stage %s: %w", comp.Path, err)
+		}
+	}
+	return nil
+}
+
+// mkdirAllNoSymlink creates dir (and any missing parents, down to and including root
+// itself) without ever traversing through an existing symlink. Unlike os.MkdirAll — which
+// happily walks through a symlink at any path component and treats it as "the directory
+// already exists" — this Lstats every component and refuses the moment one is a symlink.
+// That closes the classic insecure-staging-directory attack: a local attacker with write
+// access to the destination path pre-plants a symlink (e.g. "<dest>/images" pointing at
+// "/tmp/evil") before a legitimate operator runs a genuinely-signed bundle import; without
+// this check, extraction would follow the symlink and write trusted bundle contents outside
+// the intended staging tree. root is re-checked on every call (including when root == dir,
+// i.e. staging-root creation itself) so a pre-planted symlink AT the staging root's own path
+// is caught too, not just symlinks nested underneath it.
+func mkdirAllNoSymlink(root, dir string) error {
+	rootAbs, err := filepath.Abs(root)
+	if err != nil {
+		return fmt.Errorf("bundle: resolve staging root: %w", err)
+	}
+	dirAbs, err := filepath.Abs(dir)
+	if err != nil {
+		return fmt.Errorf("bundle: resolve target directory: %w", err)
+	}
+	rel, err := filepath.Rel(rootAbs, dirAbs)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return fmt.Errorf("bundle: refusing to create directory %q outside staging root %q", dir, root)
+	}
+
+	var parts []string
+	if rel != "." {
+		parts = strings.Split(filepath.ToSlash(rel), "/")
+	}
+	// Walk from the staging root's own path down to dir, one component at a time.
+	segments := append([]string{filepath.Base(rootAbs)}, parts...)
+	cur := filepath.Dir(rootAbs)
+	for _, part := range segments {
+		if part == "" {
+			continue
+		}
+		cur = filepath.Join(cur, part)
+		fi, statErr := os.Lstat(cur)
+		switch {
+		case statErr == nil:
+			if fi.Mode()&os.ModeSymlink != 0 {
+				return fmt.Errorf("bundle: refusing to follow pre-existing symlink at %q", cur)
+			}
+			if !fi.IsDir() {
+				return fmt.Errorf("bundle: %q exists and is not a directory", cur)
+			}
+		case os.IsNotExist(statErr):
+			if mkErr := os.Mkdir(cur, 0o750); mkErr != nil {
+				return fmt.Errorf("bundle: mkdir %q: %w", cur, mkErr)
+			}
+		default:
+			return fmt.Errorf("bundle: stat %q: %w", cur, statErr)
 		}
 	}
 	return nil

--- a/internal/bundle/bundle_test.go
+++ b/internal/bundle/bundle_test.go
@@ -438,6 +438,62 @@ func TestExtract_FirstInstallOnEmptyDestStillAllowed(t *testing.T) {
 	}
 }
 
+// TestExtract_RefusesPrePlantedSymlink proves the #152 fix: a symlink pre-planted at a path
+// the extraction process would otherwise write into (before the legitimate operator runs a
+// genuinely-signed bundle import) must be refused, not followed — the trusted bundle content
+// must never land outside the staging root.
+func TestExtract_RefusesPrePlantedSymlink(t *testing.T) {
+	raw, reg, _ := signedBundle(t, map[string]string{"images/keyorix-server.tar": "image-bytes"}, "v1.0.0", "update-2026", "")
+
+	dest := t.TempDir()
+	outside := t.TempDir()
+	// Pre-plant "<dest>/images" as a symlink pointing OUTSIDE the staging root, exactly the
+	// classic insecure-staging-directory precondition: an attacker with local write access to
+	// the destination path plants this before the legitimate import runs.
+	if err := os.Symlink(outside, filepath.Join(dest, "images")); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	if _, err := Extract(bytes.NewReader(raw), reg, dest, ""); err == nil {
+		t.Fatalf("Extract must refuse to follow a pre-planted symlink, got nil error")
+	}
+
+	// Nothing must have been written through the symlink into the outside directory.
+	entries, err := os.ReadDir(outside)
+	if err != nil {
+		t.Fatalf("readdir outside: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("bundle content escaped the staging root into %s: %v", outside, entries)
+	}
+}
+
+// TestExtract_RefusesSymlinkedStagingRoot proves the staging ROOT itself (not just a nested
+// component) is checked: if the operator-supplied --dest path has been pre-planted as a
+// symlink, Extract must refuse rather than stage trusted content through it.
+func TestExtract_RefusesSymlinkedStagingRoot(t *testing.T) {
+	raw, reg, _ := signedBundle(t, map[string]string{"images/a.tar": "x"}, "v1.0.0", "update-2026", "")
+
+	parent := t.TempDir()
+	outside := t.TempDir()
+	dest := filepath.Join(parent, "staging")
+	if err := os.Symlink(outside, dest); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	if _, err := Extract(bytes.NewReader(raw), reg, dest, ""); err == nil {
+		t.Fatalf("Extract must refuse a symlinked staging root, got nil error")
+	}
+
+	entries, err := os.ReadDir(outside)
+	if err != nil {
+		t.Fatalf("readdir outside: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("bundle content escaped through the symlinked root into %s: %v", outside, entries)
+	}
+}
+
 // assertDirEmpty fails if dir contains any regular file (temp files included), proving a
 // fail-closed Extract staged nothing.
 func assertDirEmpty(t *testing.T, dir string) {

--- a/internal/cli/run/run.go
+++ b/internal/cli/run/run.go
@@ -17,9 +17,10 @@ import (
 )
 
 var (
-	runEnv     string
-	runProject string
-	runToken   string
+	runEnv      string
+	runProject  string
+	runToken    string
+	runCleanEnv bool
 )
 
 // RunCmd is the top-level 'run' command.
@@ -46,7 +47,16 @@ Authentication:
   • Session tokens written by 'keyorix auth login' are used automatically
     when the CLI is in client mode.
   • For service accounts / CI/CD, set KEYORIX_TOKEN (or --token) and
-    point the CLI at a server with 'keyorix connect' or KEYORIX_SERVER.`,
+    point the CLI at a server with 'keyorix connect' or KEYORIX_SERVER.
+
+Environment isolation:
+  • By default the child process inherits the FULL parent environment plus
+    the injected secrets, matching how most shells/tools behave.
+  • Pass --clean-env to start the child from ONLY the injected secrets
+    (plus a minimal PATH/HOME baseline) instead — use this when you don't
+    want the child to also see whatever else is already exported in the
+    invoking shell (a leftover token from a prior 'keyorix run', an
+    unrelated CI secret, etc.).`,
 	Args: cobra.MinimumNArgs(1),
 	RunE: runRun,
 }
@@ -55,6 +65,7 @@ func init() {
 	RunCmd.Flags().StringVar(&runEnv, "env", "development", "Environment name (e.g. production)")
 	RunCmd.Flags().StringVar(&runProject, "project", "", "Project name (overrides KEYORIX_PROJECT and active project)")
 	RunCmd.Flags().StringVar(&runToken, "token", "", "Service or session token (overrides KEYORIX_TOKEN env var)")
+	RunCmd.Flags().BoolVar(&runCleanEnv, "clean-env", false, "Start the child process with ONLY the injected secrets (plus a minimal PATH/HOME baseline) instead of the full inherited parent environment")
 }
 
 func runRun(cmd *cobra.Command, args []string) error {
@@ -90,7 +101,7 @@ func runRun(cmd *cobra.Command, args []string) error {
 		return fetchErr
 	}
 
-	return execChild(args, envVars)
+	return execChild(args, envVars, runCleanEnv)
 }
 
 // ── Embedded mode ─────────────────────────────────────────────────────────────
@@ -338,12 +349,18 @@ func isSensitiveKeyorixEnv(key string) bool {
 	return false
 }
 
-// execChild builds the child environment and executes the command.
-func execChild(args []string, extraEnv map[string]string) error {
-	childEnv := filterSensitiveEnv(os.Environ())
-	for k, v := range extraEnv {
-		childEnv = append(childEnv, k+"="+v)
-	}
+// execChild builds the child environment and executes the command. By default (cleanEnv
+// false) the child inherits the FULL parent environment (minus Keyorix's own credential
+// vars — filterSensitiveEnv, #103) plus the injected secrets — the long-standing,
+// backward-compatible behavior. With cleanEnv true (--clean-env), the child starts from
+// ONLY the injected secrets plus a minimal PATH/HOME baseline so it can still locate
+// binaries and its home directory; every other variable already present in the invoking
+// shell (a leftover token from a prior `keyorix run`, an unrelated CI secret, etc.) is NOT
+// inherited. This is opt-in hardening for #164 — broader than #103's Keyorix-specific
+// filtering, for callers who don't want the child to see the invoking shell's environment
+// at all.
+func execChild(args []string, extraEnv map[string]string, cleanEnv bool) error {
+	childEnv := buildChildEnv(extraEnv, cleanEnv)
 
 	c := exec.Command(args[0], args[1:]...) // #nosec G204
 	c.Stdin = os.Stdin
@@ -359,4 +376,27 @@ func execChild(args []string, extraEnv map[string]string) error {
 		return fmt.Errorf("command failed: %w", err)
 	}
 	return nil
+}
+
+// buildChildEnv computes the environment slice passed to the child process. By default
+// (cleanEnv false) it starts from the FULL parent environment minus Keyorix's own
+// credential vars (filterSensitiveEnv, #103) — the long-standing, backward-compatible
+// behavior. With cleanEnv true it starts from ONLY a minimal PATH/HOME baseline (so the
+// child can still locate binaries and its home directory), NOT the rest of the parent
+// environment. In both cases extraEnv (the injected secrets) is appended last.
+func buildChildEnv(extraEnv map[string]string, cleanEnv bool) []string {
+	var childEnv []string
+	if cleanEnv {
+		for _, k := range []string{"PATH", "HOME"} {
+			if v, ok := os.LookupEnv(k); ok {
+				childEnv = append(childEnv, k+"="+v)
+			}
+		}
+	} else {
+		childEnv = filterSensitiveEnv(os.Environ())
+	}
+	for k, v := range extraEnv {
+		childEnv = append(childEnv, k+"="+v)
+	}
+	return childEnv
 }

--- a/internal/cli/run/run_test.go
+++ b/internal/cli/run/run_test.go
@@ -1,6 +1,8 @@
 package run
 
 import (
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -68,4 +70,85 @@ func TestIsSensitiveKeyorixEnv(t *testing.T) {
 	for key, want := range cases {
 		assert.Equal(t, want, isSensitiveKeyorixEnv(key), "key=%s", key)
 	}
+}
+
+// TestBuildChildEnv_Default_InheritsFullParentEnv proves the long-standing, backward-
+// compatible default: with cleanEnv=false, the child gets the parent environment (minus
+// Keyorix's own credential vars — filterSensitiveEnv, #103) plus the injected secrets.
+func TestBuildChildEnv_Default_InheritsFullParentEnv(t *testing.T) {
+	t.Setenv("KEYORIX_RUN_TEST_UNRELATED", "leftover-from-shell")
+
+	got := buildChildEnv(map[string]string{"DB_PASSWORD": "s3cr3t"}, false)
+
+	if !containsEnv(got, "KEYORIX_RUN_TEST_UNRELATED", "leftover-from-shell") {
+		t.Fatalf("default (no --clean-env) must still inherit unrelated parent vars, got: %v", got)
+	}
+	if !containsEnv(got, "DB_PASSWORD", "s3cr3t") {
+		t.Fatalf("injected secret missing from child env: %v", got)
+	}
+}
+
+// TestBuildChildEnv_Default_StillFiltersSensitiveKeyorixVars proves the #103 fix survives
+// #164's refactor: even in the default (cleanEnv=false) path, Keyorix's own credential
+// vars must still be stripped from the child environment.
+func TestBuildChildEnv_Default_StillFiltersSensitiveKeyorixVars(t *testing.T) {
+	t.Setenv("KEYORIX_TOKEN", "should-not-leak-by-default-either")
+
+	got := buildChildEnv(nil, false)
+
+	if containsEnv(got, "KEYORIX_TOKEN", "should-not-leak-by-default-either") {
+		t.Fatalf("default (no --clean-env) must still filter Keyorix's own credential vars, got: %v", got)
+	}
+}
+
+// TestBuildChildEnv_CleanEnv_OnlyInjectedSecretsAndBaseline proves the #164 fix: with
+// cleanEnv=true (--clean-env), the child must NOT inherit unrelated parent environment
+// variables — only the explicitly injected secrets plus the minimal PATH/HOME baseline.
+func TestBuildChildEnv_CleanEnv_OnlyInjectedSecretsAndBaseline(t *testing.T) {
+	t.Setenv("KEYORIX_RUN_TEST_UNRELATED", "leftover-from-shell")
+	t.Setenv("KEYORIX_TOKEN", "should-not-leak-into-clean-child")
+
+	got := buildChildEnv(map[string]string{"DB_PASSWORD": "s3cr3t"}, true)
+
+	if containsEnv(got, "KEYORIX_RUN_TEST_UNRELATED", "leftover-from-shell") {
+		t.Fatalf("--clean-env must NOT inherit unrelated parent vars, got: %v", got)
+	}
+	if containsEnv(got, "KEYORIX_TOKEN", "should-not-leak-into-clean-child") {
+		t.Fatalf("--clean-env must NOT leak the parent's KEYORIX_TOKEN, got: %v", got)
+	}
+	if !containsEnv(got, "DB_PASSWORD", "s3cr3t") {
+		t.Fatalf("injected secret missing from clean child env: %v", got)
+	}
+
+	// Only PATH/HOME (if set) plus the one injected secret should be present.
+	for _, kv := range got {
+		key := strings.SplitN(kv, "=", 2)[0]
+		if key != "PATH" && key != "HOME" && key != "DB_PASSWORD" {
+			t.Fatalf("--clean-env leaked unexpected variable %q into child env: %v", key, got)
+		}
+	}
+}
+
+// TestBuildChildEnv_CleanEnv_BaselineMatchesParent confirms the minimal PATH/HOME baseline
+// is actually populated from the parent when clean-env is requested, so the child can still
+// locate binaries and its home directory.
+func TestBuildChildEnv_CleanEnv_BaselineMatchesParent(t *testing.T) {
+	wantPath, ok := os.LookupEnv("PATH")
+	if !ok {
+		t.Skip("PATH not set in test environment")
+	}
+	got := buildChildEnv(nil, true)
+	if !containsEnv(got, "PATH", wantPath) {
+		t.Fatalf("--clean-env must carry over the parent PATH baseline, got: %v", got)
+	}
+}
+
+func containsEnv(env []string, key, val string) bool {
+	target := key + "=" + val
+	for _, kv := range env {
+		if kv == target {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/core/setup_delivery.go
+++ b/internal/core/setup_delivery.go
@@ -55,33 +55,20 @@ type ProvisionSetupResult struct {
 // provisionSetupLink issues a setup token for the request's subject and delivers it
 // via the configured channel, returning the outcome. Requires a configured base URL
 // (a relative link is a misconfiguration, not a fallback).
+//
+// Always enforces the per-subject resend throttle (ADR-028 abuse section,
+// checkResendThrottle) — including on what looks like an "initial" provision, not just
+// explicit resends. Without this, a create→soft-delete→recreate loop against the same
+// email would bypass the throttle entirely: DeleteUser is an unconditional soft delete
+// and GetUserByEmail excludes soft-deleted rows, so the same address becomes immediately
+// reusable for another "initial" CreateUserWithSetupLink, each one an unthrottled SMTP
+// send against the org's own mail relay (#183). checkResendThrottle is keyed on the raw
+// email address in the setup-token store, independent of the (deletable/recreatable) user
+// row, so the count survives the delete. The count-then-act window (check, then
+// IssueSetupToken) is serialized under setupResendMu so a concurrent burst for the same
+// (purpose, email) can't all observe a sub-cap count before any of them writes the token
+// that would push the next check over the cap.
 func (c *KeyorixCore) provisionSetupLink(ctx context.Context, req IssueSetupTokenRequest, displayName, assignmentSummary string) (*ProvisionSetupResult, error) {
-	if c.setupBaseURL == "" {
-		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorValidation", nil), ErrSetupBaseURLRequired)
-	}
-	issued, err := c.IssueSetupToken(ctx, req)
-	if err != nil {
-		return nil, err
-	}
-	return c.deliverSetupLink(ctx, issued, req, displayName, assignmentSummary)
-}
-
-// provisionSetupLinkThrottled is provisionSetupLink with the per-subject resend
-// throttle (ADR-028 abuse section) applied atomically. The throttle check counts
-// recent tokens and then a new token is minted; without serialization two concurrent
-// resends for the same (purpose, email) both see a sub-cap count and both mint,
-// exceeding the daily cap / min-interval (the count-then-act is the only way past
-// the cap, so the race defeats the sole mail-bombing control). setupResendMu is held
-// across the check + IssueSetupToken so the count and the write that the next count
-// will see are one critical section. Delivery runs after the lock is released — a
-// slow SMTP send must not block every other resend. Used by every resend path and by
-// the invitation initial-send paths (InviteToProjectWithLink / InviteGlobalWithLink,
-// #345) — a loop-called initial invite is otherwise indistinguishable from a
-// loop-called resend as an SMTP-relay abuse vector, so both are held to the same
-// per-(purpose, email) limit. CreateUserWithSetupLink is the one caller that still
-// goes through the unthrottled provisionSetupLink: it runs only once CreateUser has
-// already claimed the (unique) email, so it cannot be looped for the same subject.
-func (c *KeyorixCore) provisionSetupLinkThrottled(ctx context.Context, req IssueSetupTokenRequest, displayName, assignmentSummary string) (*ProvisionSetupResult, error) {
 	if c.setupBaseURL == "" {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorValidation", nil), ErrSetupBaseURLRequired)
 	}
@@ -96,6 +83,14 @@ func (c *KeyorixCore) provisionSetupLinkThrottled(ctx context.Context, req Issue
 		return nil, err
 	}
 	return c.deliverSetupLink(ctx, issued, req, displayName, assignmentSummary)
+}
+
+// provisionSetupLinkThrottled is now a thin alias for provisionSetupLink, kept as an
+// explicitly-named entry point at resend/reset call sites where the throttle is the whole
+// point — provisionSetupLink itself always enforces checkResendThrottle (see above), so
+// there is no longer a distinct unthrottled variant to be paired with.
+func (c *KeyorixCore) provisionSetupLinkThrottled(ctx context.Context, req IssueSetupTokenRequest, displayName, assignmentSummary string) (*ProvisionSetupResult, error) {
+	return c.provisionSetupLink(ctx, req, displayName, assignmentSummary)
 }
 
 // deliverSetupLink builds the absolute setup link from a freshly issued token and

--- a/internal/core/setup_delivery_test.go
+++ b/internal/core/setup_delivery_test.go
@@ -155,6 +155,8 @@ func TestCreateUserWithSetupLink(t *testing.T) {
 	ctx := context.Background()
 	ms := new(MockStorage)
 	c := NewKeyorixCore(ms)
+	fixed := time.Date(2026, 6, 5, 12, 0, 0, 0, time.UTC)
+	c.now = func() time.Time { return fixed }
 	c.SetCredentialDelivery(&fakeDeliverer{echoLink: true, result: delivery.DeliveryResult{Channel: delivery.ChannelOutOfBand}}, testBaseURL)
 	anyAudit(ms)
 
@@ -170,6 +172,10 @@ func TestCreateUserWithSetupLink(t *testing.T) {
 	})).Return(created, nil)
 	ms.On("AddPasswordHistory", ctx, uint(9), mock.AnythingOfType("string"), mock.Anything).Return(nil)
 	ms.On("GetRoleByName", ctx, "system_viewer").Return(nil, notFound())
+	// The initial provision is throttle-checked too (#183) — a fresh email with no
+	// prior tokens clears both checks.
+	ms.On("CountSetupTokensSince", ctx, SetupPurposeAccountSetup, "dana@acme.io", fixed.Add(-24*time.Hour)).Return(int64(0), nil)
+	ms.On("CountSetupTokensSince", ctx, SetupPurposeAccountSetup, "dana@acme.io", fixed.Add(-resendMinInterval)).Return(int64(0), nil)
 	ms.On("SupersedeActiveSetupTokens", ctx, SetupPurposeAccountSetup, "dana@acme.io").Return(nil)
 	ms.On("CreateSetupToken", ctx, mock.AnythingOfType("*models.SetupToken")).Return(&models.SetupToken{ID: 1}, nil)
 
@@ -181,6 +187,65 @@ func TestCreateUserWithSetupLink(t *testing.T) {
 	ms.AssertNotCalled(t, "UpdateUser", mock.Anything, mock.Anything)
 	require.NotNil(t, prov)
 	assert.True(t, strings.HasPrefix(prov.LinkForAdmin, testBaseURL+"/auth/setup/"+setupPrefix))
+}
+
+// TestCreateUserWithSetupLink_ThrottlesCreateDeleteRecreateLoop proves the #183 fix: a
+// create→soft-delete→recreate loop against the SAME email must be throttled on the Nth
+// attempt within the cooldown window, exactly like an explicit resend — because
+// DeleteUser is an unconditional soft delete and GetUserByEmail excludes soft-deleted
+// rows, the email is immediately reusable for another CreateUserWithSetupLink call, and
+// without this fix each such "recreate" would look like a fresh, unthrottled initial
+// provision and send another email with no cooldown and no daily cap.
+func TestCreateUserWithSetupLink_ThrottlesCreateDeleteRecreateLoop(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	ctx := context.Background()
+	ms := new(MockStorage)
+	c := NewKeyorixCore(ms)
+	fixed := time.Date(2026, 6, 5, 12, 0, 0, 0, time.UTC)
+	c.now = func() time.Time { return fixed }
+	c.SetCredentialDelivery(&fakeDeliverer{echoLink: true, result: delivery.DeliveryResult{Channel: delivery.ChannelOutOfBand}}, testBaseURL)
+	anyAudit(ms)
+
+	notFound := func() error { return assertNotFoundErr() }
+	req := &CreateUserRequest{Username: "dana", Email: "dana@acme.io", DisplayName: "Dana"}
+
+	// First create→provision succeeds (the recreated user gets a fresh row/ID after the
+	// prior one was soft-deleted, but the email — and so the throttle key — is the same).
+	ms.On("GetUserByUsername", ctx, "dana").Return(nil, notFound())
+	ms.On("GetUserByEmail", ctx, "dana@acme.io").Return(nil, notFound())
+	ms.On("CreateUser", ctx, mock.MatchedBy(func(u *models.User) bool {
+		return u.AccountState == AccountPendingFirstLogin
+	})).Return(&models.User{ID: 20, Username: "dana", Email: "dana@acme.io", AccountState: AccountPendingFirstLogin}, nil).Once()
+	ms.On("AddPasswordHistory", ctx, uint(20), mock.AnythingOfType("string"), mock.Anything).Return(nil).Once()
+	ms.On("GetRoleByName", ctx, "system_viewer").Return(nil, notFound())
+	ms.On("CountSetupTokensSince", ctx, SetupPurposeAccountSetup, "dana@acme.io", fixed.Add(-24*time.Hour)).Return(int64(0), nil).Once()
+	ms.On("CountSetupTokensSince", ctx, SetupPurposeAccountSetup, "dana@acme.io", fixed.Add(-resendMinInterval)).Return(int64(0), nil).Once()
+	ms.On("SupersedeActiveSetupTokens", ctx, SetupPurposeAccountSetup, "dana@acme.io").Return(nil).Once()
+	ms.On("CreateSetupToken", ctx, mock.AnythingOfType("*models.SetupToken")).Return(&models.SetupToken{ID: 1}, nil).Once()
+
+	_, prov1, err := c.CreateUserWithSetupLink(ctx, req, 7)
+	require.NoError(t, err)
+	require.NotNil(t, prov1)
+
+	// Simulate the soft-delete: the recreated account is a "new" user again as far as
+	// CreateUser's own checks are concerned (GetUserByUsername/Email miss again), but the
+	// setup-token store — keyed on the raw email, independent of the user row — now
+	// reflects the one token just issued, so the throttle must fire on this second attempt.
+	ms.On("GetUserByUsername", ctx, "dana").Return(nil, notFound())
+	ms.On("GetUserByEmail", ctx, "dana@acme.io").Return(nil, notFound())
+	ms.On("CreateUser", ctx, mock.MatchedBy(func(u *models.User) bool {
+		return u.AccountState == AccountPendingFirstLogin
+	})).Return(&models.User{ID: 21, Username: "dana", Email: "dana@acme.io", AccountState: AccountPendingFirstLogin}, nil).Once()
+	ms.On("AddPasswordHistory", ctx, uint(21), mock.AnythingOfType("string"), mock.Anything).Return(nil).Once()
+	ms.On("CountSetupTokensSince", ctx, SetupPurposeAccountSetup, "dana@acme.io", fixed.Add(-24*time.Hour)).Return(int64(1), nil).Once()
+	ms.On("CountSetupTokensSince", ctx, SetupPurposeAccountSetup, "dana@acme.io", fixed.Add(-resendMinInterval)).Return(int64(1), nil).Once()
+
+	_, prov2, err := c.CreateUserWithSetupLink(ctx, req, 7)
+	require.Error(t, err, "the recreate must be throttled by the still-live min-interval window")
+	assert.Contains(t, err.Error(), "wait")
+	assert.Nil(t, prov2)
+	// Throttled means no second setup token was minted and no second email sent.
+	ms.AssertNumberOfCalls(t, "CreateSetupToken", 1)
 }
 
 func TestCreateUserWithOneTimePassword(t *testing.T) {


### PR DESCRIPTION
## Summary

Recreates #566 (closed after its branch had to be deleted/recreated during a rebase onto current main, which GitHub does not permit reopening after). #206 is dropped here since main already fixed it independently (both `SecureWriteFile` and `SaveCLIConfig`, the latter now routing through `SecureWriteFile` entirely) since this branch was opened.

- **#152 — Bundle extraction follows a pre-planted symlink in the staging directory.** `os.MkdirAll` happily walks through an existing symlink. Added `mkdirAllNoSymlink`, which `os.Lstat`s every path component (including the staging root itself) and refuses to create through/over an existing symlink.
- **#164 — `keyorix run` injects secrets into the FULL inherited parent environment.** Added an opt-in `--clean-env` flag that starts the child from only the injected secrets plus a minimal PATH/HOME baseline. Rebased to compose with main's independent #103 fix (`filterSensitiveEnv`, which strips Keyorix's own credential vars in the default path) — the default path now applies both: filtered inheritance, or (`--clean-env`) a minimal baseline.
- **#183 — Unthrottled SMTP-send loop via create→soft-delete→recreate bypasses the ADR-028 resend throttle.** Moved the throttle check into the shared `provisionSetupLink` helper, keyed on the raw email address independent of the deletable user row.

## Test plan

- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `go build ./server`
- [x] `GOWORK=off go build ./...` (operator module)
- [x] `go test ./...` — full suite passes
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)