### PR TITLE
fix(scim): set ExternalID on SCIM-managed test fixtures

### DIFF
--- a/internal/core/concurrency_scim_update_email_test.go
+++ b/internal/core/concurrency_scim_update_email_test.go
@@ -51,7 +51,7 @@ func TestConcurrency_UpdateSCIMUser_NoDuplicateEmail(t *testing.T) {
 	for i := 0; i < attackers; i++ {
 		require.NoError(t, db.Create(&models.User{
 			ID: uint(i + 1), Username: fmt.Sprintf("user%d", i), Email: fmt.Sprintf("user%d@x.io", i),
-			IsActive: true, AccountState: core.AccountActive,
+			IsActive: true, AccountState: core.AccountActive, ExternalID: fmt.Sprintf("okta|user%d", i),
 		}).Error)
 	}
 

--- a/internal/core/scim_guards_test.go
+++ b/internal/core/scim_guards_test.go
@@ -119,7 +119,7 @@ func TestUpdateSCIMUser_FailsClosedOnTransientEmailLookupError(t *testing.T) {
 func TestUpdateSCIMUser_ProceedsWhenEmailGenuinelyUnused(t *testing.T) {
 	c, db := newSCIMGuardCore(t)
 	ctx := context.Background()
-	require.NoError(t, db.Create(&models.User{ID: 2, Username: "bob", Email: "bob@x.io", IsActive: true, AccountState: AccountActive}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 2, Username: "bob", Email: "bob@x.io", IsActive: true, AccountState: AccountActive, ExternalID: "okta|bob"}).Error)
 
 	newEmail := "unused@x.io"
 	updated, err := c.UpdateSCIMUser(ctx, 9, 2, nil, &newEmail, nil)


### PR DESCRIPTION
## Summary
- Follow-up to #523 (the `scimManaged` guard added to `UpdateSCIMUser`). Two tests — `TestUpdateSCIMUser_ProceedsWhenEmailGenuinelyUnused` and `TestConcurrency_UpdateSCIMUser_NoDuplicateEmail` — create users without an `ExternalID` and call `UpdateSCIMUser` directly, which the new SCIM-managed guard correctly refuses on a non-SCIM-managed account.
- Sets `ExternalID` on the SCIM-managed test users so both keep exercising their original intent instead of failing.

## Test plan
- [x] `go test ./internal/core/...` — green
- [x] `go test ./...` — green
- [x] `go vet ./...` — clean