### PR TITLE
harden(account): require current password to change own email (#457)

### DIFF
--- a/internal/core/account.go
+++ b/internal/core/account.go
@@ -19,9 +19,28 @@ import (
 // to UpdateUser (which enforces email uniqueness) but constructs the request from
 // the authenticated userID, so a caller can never change username/is_active or
 // target another user.
-func (c *KeyorixCore) UpdateOwnProfile(ctx context.Context, userID uint, displayName, email string) (*models.User, error) {
+//
+// An email change additionally requires the caller's current password, mirroring
+// ChangePassword's re-authentication check. The email is often the recovery/identity
+// anchor (password reset delivery, SSO account linking — see ADR-052/ADR-053 related
+// fixes) so a hijacked session (stolen cookie/token, unattended device) must not be
+// able to silently repoint it to an attacker-controlled address and ride the
+// password-reset flow to full takeover. Display-name-only changes are unaffected and
+// need no password. currentPassword is ignored when the email is not changing.
+func (c *KeyorixCore) UpdateOwnProfile(ctx context.Context, userID uint, displayName, email, currentPassword string) (*models.User, error) {
 	if userID == 0 {
 		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "user ID is required")
+	}
+	if email != "" {
+		user, err := c.storage.GetUser(ctx, userID)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", i18n.T("ErrorUserNotFound", nil), err)
+		}
+		if email != user.Email {
+			if err := bcrypt.CompareHashAndPassword([]byte(user.PasswordHash), []byte(currentPassword)); err != nil {
+				return nil, fmt.Errorf("%s: current password is incorrect", i18n.T("ErrorValidation", nil))
+			}
+		}
 	}
 	return c.UpdateUser(ctx, &UpdateUserRequest{
 		ID:          userID,

--- a/internal/core/account_test.go
+++ b/internal/core/account_test.go
@@ -17,16 +17,17 @@ const acctTestUser = "alice"
 func TestUpdateOwnProfile(t *testing.T) {
 	ctx := context.Background()
 
-	t.Run("updates display name and email", func(t *testing.T) {
+	t.Run("updates display name and email with the correct current password", func(t *testing.T) {
 		ms := new(MockStorage)
 		c := NewKeyorixCore(ms)
-		existing := &models.User{ID: 1, Username: acctTestUser, Email: "alice@old.com", DisplayName: "Alice"}
+		hash, _ := bcrypt.GenerateFromPassword([]byte("Current#Passw0rd!"), bcrypt.DefaultCost)
+		existing := &models.User{ID: 1, Username: acctTestUser, Email: "alice@old.com", DisplayName: "Alice", PasswordHash: string(hash)}
 
 		ms.On("GetUser", ctx, uint(1)).Return(existing, nil)
 		ms.On("GetUserByEmail", ctx, "alice@new.com").Return(nil, nil)
 		ms.On("UpdateUser", ctx, mock.AnythingOfType("*models.User")).Return(existing, nil)
 
-		_, err := c.UpdateOwnProfile(ctx, 1, "Alice New", "alice@new.com")
+		_, err := c.UpdateOwnProfile(ctx, 1, "Alice New", "alice@new.com", "Current#Passw0rd!")
 		require.NoError(t, err)
 		assert.Equal(t, "alice@new.com", existing.Email)
 		assert.Equal(t, "Alice New", existing.DisplayName)
@@ -34,16 +35,75 @@ func TestUpdateOwnProfile(t *testing.T) {
 		assert.Equal(t, "alice", existing.Username)
 	})
 
+	t.Run("rejects an email change without the current password", func(t *testing.T) {
+		ms := new(MockStorage)
+		c := NewKeyorixCore(ms)
+		hash, _ := bcrypt.GenerateFromPassword([]byte("Current#Passw0rd!"), bcrypt.DefaultCost)
+		existing := &models.User{ID: 1, Username: acctTestUser, Email: "alice@old.com", PasswordHash: string(hash)}
+
+		ms.On("GetUser", ctx, uint(1)).Return(existing, nil)
+
+		_, err := c.UpdateOwnProfile(ctx, 1, "", "alice@new.com", "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "incorrect")
+		assert.Equal(t, "alice@old.com", existing.Email, "email must not change on a rejected request")
+		ms.AssertNotCalled(t, "UpdateUser", mock.Anything, mock.Anything)
+	})
+
+	t.Run("rejects an email change with an incorrect current password", func(t *testing.T) {
+		ms := new(MockStorage)
+		c := NewKeyorixCore(ms)
+		hash, _ := bcrypt.GenerateFromPassword([]byte("Current#Passw0rd!"), bcrypt.DefaultCost)
+		existing := &models.User{ID: 1, Username: acctTestUser, Email: "alice@old.com", PasswordHash: string(hash)}
+
+		ms.On("GetUser", ctx, uint(1)).Return(existing, nil)
+
+		_, err := c.UpdateOwnProfile(ctx, 1, "", "alice@new.com", "wrong-password")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "incorrect")
+		assert.Equal(t, "alice@old.com", existing.Email)
+		ms.AssertNotCalled(t, "UpdateUser", mock.Anything, mock.Anything)
+	})
+
+	t.Run("display-name-only change needs no password", func(t *testing.T) {
+		ms := new(MockStorage)
+		c := NewKeyorixCore(ms)
+		hash, _ := bcrypt.GenerateFromPassword([]byte("Current#Passw0rd!"), bcrypt.DefaultCost)
+		existing := &models.User{ID: 1, Username: acctTestUser, Email: "alice@old.com", DisplayName: "Alice", PasswordHash: string(hash)}
+
+		ms.On("GetUser", ctx, uint(1)).Return(existing, nil)
+		ms.On("UpdateUser", ctx, mock.AnythingOfType("*models.User")).Return(existing, nil)
+
+		_, err := c.UpdateOwnProfile(ctx, 1, "Alice New", "", "")
+		require.NoError(t, err)
+		assert.Equal(t, "Alice New", existing.DisplayName)
+		assert.Equal(t, "alice@old.com", existing.Email)
+	})
+
+	t.Run("re-submitting the same email needs no password", func(t *testing.T) {
+		ms := new(MockStorage)
+		c := NewKeyorixCore(ms)
+		hash, _ := bcrypt.GenerateFromPassword([]byte("Current#Passw0rd!"), bcrypt.DefaultCost)
+		existing := &models.User{ID: 1, Username: acctTestUser, Email: "alice@old.com", PasswordHash: string(hash)}
+
+		ms.On("GetUser", ctx, uint(1)).Return(existing, nil)
+		ms.On("UpdateUser", ctx, mock.AnythingOfType("*models.User")).Return(existing, nil)
+
+		_, err := c.UpdateOwnProfile(ctx, 1, "", "alice@old.com", "")
+		require.NoError(t, err)
+	})
+
 	t.Run("rejects an email already used by another user", func(t *testing.T) {
 		ms := new(MockStorage)
 		c := NewKeyorixCore(ms)
-		existing := &models.User{ID: 1, Username: acctTestUser, Email: "alice@old.com"}
+		hash, _ := bcrypt.GenerateFromPassword([]byte("Current#Passw0rd!"), bcrypt.DefaultCost)
+		existing := &models.User{ID: 1, Username: acctTestUser, Email: "alice@old.com", PasswordHash: string(hash)}
 		other := &models.User{ID: 2, Email: "taken@x.com"}
 
 		ms.On("GetUser", ctx, uint(1)).Return(existing, nil)
 		ms.On("GetUserByEmail", ctx, "taken@x.com").Return(other, nil)
 
-		_, err := c.UpdateOwnProfile(ctx, 1, "", "taken@x.com")
+		_, err := c.UpdateOwnProfile(ctx, 1, "", "taken@x.com", "Current#Passw0rd!")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "already exists")
 	})

--- a/server/http/handlers/auth.go
+++ b/server/http/handlers/auth.go
@@ -384,12 +384,18 @@ func userProfileMap(user *models.User, id core.UserIdentity) map[string]interfac
 
 // updateProfileRequestBody is the self-service profile update — only the fields a
 // user may change about themselves. Username/role/active are intentionally absent.
+// CurrentPassword is required only when Email changes (mirrors changePasswordRequestBody's
+// re-authentication check); a display-name-only update needs no password.
 type updateProfileRequestBody struct {
-	DisplayName string `json:"display_name"`
-	Email       string `json:"email"`
+	DisplayName     string `json:"display_name"`
+	Email           string `json:"email"`
+	CurrentPassword string `json:"current_password,omitempty"`
 }
 
 // UpdateProfile handles PUT /auth/profile — self-scoped display name + email update.
+// Changing the email additionally requires the caller's current password: the email is
+// the anchor for password-reset delivery and SSO account linking, so a hijacked session
+// must not be able to silently repoint it to an attacker-controlled address.
 func (h *AuthHandler) UpdateProfile(w http.ResponseWriter, r *http.Request) {
 	userCtx := middleware.GetUserFromContext(r.Context())
 	if userCtx == nil {
@@ -402,8 +408,12 @@ func (h *AuthHandler) UpdateProfile(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	user, err := h.coreService.UpdateOwnProfile(r.Context(), userCtx.UserID, body.DisplayName, body.Email)
+	user, err := h.coreService.UpdateOwnProfile(r.Context(), userCtx.UserID, body.DisplayName, body.Email, body.CurrentPassword)
 	if err != nil {
+		if strings.Contains(err.Error(), "incorrect") {
+			sendError(w, "Unauthorized", "Current password is incorrect", http.StatusUnauthorized, nil)
+			return
+		}
 		if strings.Contains(err.Error(), "already exists") {
 			sendError(w, "Conflict", "That email is already in use", http.StatusConflict, nil)
 			return


### PR DESCRIPTION
## Summary

- Finding #457: `UpdateOwnProfile` let an authenticated session change its own account's email with **no re-verification**, unlike the sibling `ChangePassword` in the same file which already requires the current password via `bcrypt.CompareHashAndPassword`.
- Email is the anchor for password-reset delivery and SSO account linking (see the #89/#517 fixes elsewhere in this campaign). A hijacked session (XSS, stolen cookie, unattended device) could silently repoint the victim's email to an attacker-controlled address, then use the password-reset flow — delivered to the *new* email — to fully take over the account without ever knowing the victim's password.
- `UpdateOwnProfile` now bcrypt-verifies the caller's current password whenever the requested email differs from the stored one. Display-name-only changes and re-submitting the same email are unaffected — no password required.
- Wired a new `current_password` field through `PUT /auth/profile` (`updateProfileRequestBody`), matching `POST /auth/change-password`'s `current_password`. A wrong/missing password now returns 401 with "Current password is incorrect", same UX as `ChangePassword`.
- No proto/gRPC change was needed: `UpdateOwnProfile` / self-service profile update is HTTP-only (`server/http/handlers/auth.go`); the gRPC `UserService.UpdateUser` RPC is the admin path (`server/grpc/services/user_service.go` → `core.UpdateUser` directly) and intentionally does not require the target's own password, since an admin updates other users.

## Test plan

- [x] `internal/core/account_test.go`: added cases — email change rejected without current password, rejected with wrong current password, accepted with correct current password, display-name-only change needs no password, re-submitting the same email needs no password (existing "email already in use" case updated to supply the password).
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/core/... ./server/http/... ./server/grpc/...` — all pass
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)