### PR TITLE
harden(storage,github-action): GORM value-logging, remote-storage stub, multi-line secret masking (#464/#455/#466)

### DIFF
--- a/integrations/github-action/entrypoint.sh
+++ b/integrations/github-action/entrypoint.sh
@@ -97,6 +97,20 @@ validate_secret_name() {
   [[ "$1" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]
 }
 
+# mask_value registers a GitHub Actions log mask for every line of a (possibly
+# multi-line) secret value. `::add-mask::` operates per-LINE: one directive
+# redacts exactly one line-oriented string, so a multi-line secret (e.g. a PEM
+# private key or a multi-line config blob) previously only had its FIRST line
+# masked — every subsequent line of the same secret would still appear in
+# plaintext in the job log (#466). Emit a mask for each line individually so
+# the whole value is covered no matter how many lines it spans.
+mask_value() {
+  local val="$1" line
+  while IFS= read -r line; do
+    [ -n "$line" ] && echo "::add-mask::$line"
+  done <<<"$val"
+}
+
 inject_env() {
   local json key val delim count
   json="$(keyorix secret export --project "$PROJECT" --env "$ENVIRONMENT" --format json)"
@@ -116,8 +130,9 @@ inject_env() {
       exit 1
     fi
     val="$(printf '%s' "$json" | jq -r --arg k "$key" '.[$k]')"
-    # Mask the value everywhere it might appear in the logs.
-    echo "::add-mask::$val"
+    # Mask the value everywhere it might appear in the logs, one line at a
+    # time so multi-line secrets are fully covered (#466).
+    mask_value "$val"
     if [ "$EXPORT_TO_ENV" = "true" ]; then
       # Heredoc form so multi-line values survive the GITHUB_ENV file format.
       delim="KEYORIX_EOF_${RANDOM}${RANDOM}"
@@ -157,7 +172,7 @@ if [[ "${BASH_SOURCE[0]:-$0}" == "${0}" ]]; then
     while IFS= read -r output_key; do
       [ -n "$output_key" ] || continue
       output_val="$(printf '%s' "$output_json" | jq -r --arg k "$output_key" '.[$k]')"
-      echo "::add-mask::$output_val"
+      mask_value "$output_val"
     done < <(printf '%s' "$output_json" | jq -r 'keys[]')
 
     # Reuse the CLI's dotenv writer (handles quoting) for the file form.

--- a/integrations/github-action/test/entrypoint_test.sh
+++ b/integrations/github-action/test/entrypoint_test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Minimal black-box tests for entrypoint.sh, covering the three fixes in
-# this round (HARDENING-BACKLOG #175/#176/#177):
+# Minimal black-box tests for entrypoint.sh, covering fixes across rounds
+# (HARDENING-BACKLOG #175/#176/#177, #466):
 #
 #   #175 — a pinned `version` install must abort if the downloaded binary's
 #          checksum doesn't match the release's published checksums.txt.
@@ -9,6 +9,9 @@
 #   #177 — secret values must be `::add-mask::`d on the output-file path
 #          even when export-to-env=false (so inject_env's masking is
 #          skipped).
+#   #466 — a multi-line secret value (e.g. a private key) must have EVERY
+#          line masked, not just the first — GitHub Actions' ::add-mask::
+#          operates per-line.
 #
 # Runs entrypoint.sh as a real subprocess against a mocked PATH (fake
 # curl/keyorix, in test/fixtures/), so it exercises the actual script, not
@@ -103,6 +106,31 @@ if [ -f "$out_file" ] && grep -q "SUPER_SECRET=topsecretvalue123" "$out_file"; t
   ok "#177: output file was still written with the secret"
 else
   bad "#177: output file was not written as expected"
+fi
+
+# --- #466: a multi-line secret value must have EVERY line masked, not just
+# the first. ::add-mask:: registers exactly one line-oriented string per
+# call, so a naive single `::add-mask::$val` on a value containing embedded
+# newlines only redacts its first line in the job log.
+cp "${fixtures}/mock_keyorix_multiline.sh" "${mockbin}/keyorix"
+
+set +e
+PATH="${mockbin}:${PATH}" \
+  KEYORIX_SERVER="https://example.invalid" \
+  KEYORIX_TOKEN="dummy-token" \
+  INPUT_EXPORT_TO_ENV="true" \
+  GITHUB_ENV="${workdir}/github_env" \
+  bash "$entrypoint" >"${workdir}/stdout3.log" 2>"${workdir}/stderr3.log"
+rc3=$?
+set -e
+
+if [ "$rc3" -eq 0 ] \
+  && grep -q "::add-mask::line-one-secret" "${workdir}/stdout3.log" \
+  && grep -q "::add-mask::line-two-secret" "${workdir}/stdout3.log" \
+  && grep -q "::add-mask::line-three-secret" "${workdir}/stdout3.log"; then
+  ok "#466: every line of a multi-line secret is masked"
+else
+  bad "#466: multi-line secret was not fully masked (rc=${rc3}); stdout: $(cat "${workdir}/stdout3.log")"
 fi
 
 echo

--- a/integrations/github-action/test/fixtures/mock_keyorix_multiline.sh
+++ b/integrations/github-action/test/fixtures/mock_keyorix_multiline.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Mock keyorix CLI used by entrypoint_test.sh's #466 case: already
+# "installed" (so install_cli short-circuits without touching the
+# network); returns a secret VALUE that spans multiple lines (simulating,
+# e.g., a PEM private key), so the test can verify every line gets its own
+# ::add-mask:: directive, not just the first.
+if [ "$1" = "--version" ]; then
+  echo "keyorix version mock-1.0.0"
+  exit 0
+fi
+if [ "$1" = "secret" ] && [ "$2" = "export" ]; then
+  fmt=""
+  args=("$@")
+  for ((i = 0; i < ${#args[@]}; i++)); do
+    case "${args[$i]}" in
+      --format) fmt="${args[$((i + 1))]}" ;;
+    esac
+  done
+  case "$fmt" in
+    json)
+      printf '{"MULTI_LINE_SECRET":"line-one-secret\\nline-two-secret\\nline-three-secret"}'
+      exit 0
+      ;;
+  esac
+fi
+echo "mock keyorix: unhandled args: $*" >&2
+exit 1

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -12,12 +12,24 @@ import (
 	"gorm.io/driver/postgres"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
 )
 
 // defaultMaxOpenConns bounds the DB connection pool when the operator hasn't set
 // max_open_conns — Go's own default is unlimited, which lets a request flood exhaust the
 // backing database's connection limit. A conservative cap is safer out of the box.
 const defaultMaxOpenConns = 25
+
+// gormConfig returns the *gorm.Config shared by every gorm.Open call in this
+// package. GORM's zero-value Config leaves its default Warn-level logger active,
+// which interpolates bound query-parameter VALUES into the logged SQL statement
+// whenever a query errors or exceeds the slow-query threshold — meaning secret
+// ciphertext, token hashes, and other sensitive bound parameters would otherwise
+// get written to stdout/logs on any query error or slow query. Silence it here
+// so that never happens by default (#464).
+func gormConfig() *gorm.Config {
+	return &gorm.Config{Logger: logger.Default.LogMode(logger.Silent)}
+}
 
 // StorageFactory creates storage instances based on configuration
 type StorageFactory interface {
@@ -51,7 +63,7 @@ func (f *DefaultStorageFactory) createLocalStorage(cfg *config.Config) (storage.
 		dbPath = "./secrets.db"
 	}
 
-	db, err := gorm.Open(sqlite.Open(dbPath), &gorm.Config{})
+	db, err := gorm.Open(sqlite.Open(dbPath), gormConfig())
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to database: %w", err)
 	}
@@ -74,7 +86,7 @@ func (f *DefaultStorageFactory) createPostgresStorage(cfg *config.Config) (stora
 		return nil, fmt.Errorf("postgres storage requires a DSN or host/name/user fields")
 	}
 
-	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+	db, err := gorm.Open(postgres.Open(dsn), gormConfig())
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to postgres: %w", err)
 	}

--- a/internal/storage/gormdb.go
+++ b/internal/storage/gormdb.go
@@ -34,7 +34,7 @@ func OpenGormDB(cfg *config.Config) (*gorm.DB, error) {
 		if dsn == "" {
 			return nil, fmt.Errorf("postgres storage requires a DSN or host/name/user fields")
 		}
-		db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+		db, err := gorm.Open(postgres.Open(dsn), gormConfig())
 		if err != nil {
 			return nil, fmt.Errorf("failed to connect to postgres: %w", err)
 		}
@@ -47,7 +47,7 @@ func OpenGormDB(cfg *config.Config) (*gorm.DB, error) {
 		if dbPath == "" {
 			dbPath = "./secrets.db"
 		}
-		db, err := gorm.Open(sqlite.Open(dbPath), &gorm.Config{})
+		db, err := gorm.Open(sqlite.Open(dbPath), gormConfig())
 		if err != nil {
 			return nil, fmt.Errorf("failed to connect to database: %w", err)
 		}

--- a/internal/storage/store/remote_sharing.go
+++ b/internal/storage/store/remote_sharing.go
@@ -114,9 +114,14 @@ func (rs *RemoteStorage) ListSharesByUser(ctx context.Context, userID uint) ([]*
 	return result, nil
 }
 
-// ListSharesByOwner lists share records by owner. Not yet implemented; returns empty slice.
+// ListSharesByOwner is not implemented for remote storage: there is no server REST
+// endpoint to proxy this to. Returning an empty slice here would make a caller (and
+// any authz/audit logic downstream) see "user has zero shares" when the truth is
+// "we don't know" — potentially masking access it should have surfaced (#455).
+// Surface the unsupported-operation error instead, matching every sibling stub in
+// this file.
 func (rs *RemoteStorage) ListSharesByOwner(_ context.Context, _ uint) ([]*models.ShareRecord, error) {
-	return []*models.ShareRecord{}, nil
+	return nil, remoteUnsupported("ListSharesByOwner")
 }
 
 // ListSharesByGroup lists all share records where groupID is the recipient via remote API.


### PR DESCRIPTION
## Summary
- **#464** — Every `gorm.Open()` call in `internal/storage/factory.go` and `internal/storage/gormdb.go` passed a bare `&gorm.Config{}`, leaving GORM's default Warn-level logger active. That logger interpolates bound query-parameter VALUES into logged SQL on any query error or slow query, so secret ciphertext / token hashes could get written to stdout/logs. Fixed by introducing a shared `gormConfig()` helper (`Logger: logger.Default.LogMode(logger.Silent)`) used at every `gorm.Open` call site in both files.
- **#455** — `RemoteStorage.ListSharesByOwner` faked a successful empty share list (`return []*models.ShareRecord{}, nil`) instead of surfacing that the operation is genuinely unsupported under `storage.type: remote`. A caller (and any authz/audit logic downstream) would see "user has zero shares" when the truth is "we don't know." Now returns `remoteUnsupported("ListSharesByOwner")`, matching every sibling stub in `remote_sharing.go`.
- **#466** — `integrations/github-action/entrypoint.sh` only masked the FIRST line of a secret value via `::add-mask::` (which operates per-line in GitHub Actions logs), so a multi-line secret (e.g. a private key) would leak its remaining lines in plaintext build logs. Added a `mask_value()` helper that emits a mask per line, used at both call sites (`inject_env` and the output-file path). Added a regression test + mock fixture proving every line of a multi-line secret is masked.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/storage/...` — all pass
- [x] `go test ./internal/core/...` — all pass (exercises `ListSharesByOwner` callers via MockStorage)
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues
- [x] `integrations/github-action/entrypoint_test.sh` (secret-name validation harness) — all pass
- [x] `integrations/github-action/test/entrypoint_test.sh` (black-box install/mask harness, incl. new #466 case) — all pass except the pre-existing `#175` checksum-mismatch case, which fails only in this sandboxed dev environment (writes to the hardcoded `/tmp/keyorix` path are blocked); confirmed pre-existing by reproducing the same failure on a clean `git stash` of this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)