### PR TITLE
harden(auth): surface login rate-limiting gap under storage.type: remote (#452)

### DIFF
--- a/internal/core/rate_limit.go
+++ b/internal/core/rate_limit.go
@@ -3,11 +3,26 @@
 // across HA replicas (the old limiter was a per-process in-memory map). Rate
 // limiting is a backstop on top of the real password/passkey checks, so a storage
 // error fails OPEN (allow) rather than locking everyone out on a DB hiccup.
+//
+// #452: a plain transient storage error (DB hiccup, network blip) fails open
+// silently by design — that's an acceptable, temporary degradation. But when the
+// active storage.Storage backend can NEVER satisfy CountRecentLoginAttempts (the
+// storage.ErrUnsupportedByBackend sentinel — today only RemoteStorage, when the
+// server itself runs storage.type: remote in a chained deployment; see
+// internal/storage/store/remote_login_attempts.go), the fail-open isn't temporary —
+// it's permanent and total for the life of the process, with no other brute-force
+// throttle unless per-account lockout (ADR-025) is separately enabled. That gap is
+// worth a loud, ONE-TIME operator-visible warning (not per-request log spam, and
+// not blocking login — this is still a backstop, not the auth boundary).
 package core
 
 import (
 	"context"
+	"errors"
+	"log"
 	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
 )
 
 const (
@@ -17,6 +32,30 @@ const (
 	LoginWindow = 15 * time.Minute
 )
 
+// warnRateLimitUnsupportedOnce logs a loud, ONE-TIME operator warning the first
+// time the active storage backend proves it can never satisfy
+// CountRecentLoginAttempts (#452) — as opposed to an ordinary transient error,
+// which stays silent (that's the existing, intentional fail-open backstop
+// behaviour). Safe for concurrent use; only the first call's message is emitted.
+func (c *KeyorixCore) warnRateLimitUnsupportedOnce() {
+	c.rateLimitUnsupportedWarnOnce.Do(func() {
+		log.Printf("WARNING: login/password-reset rate limiting is INERT under the " +
+			"active storage backend (storage.type: remote) — CountRecentLoginAttempts " +
+			"has no implementation to proxy to (ADR-040: login rate limiting is " +
+			"server-side only), so every call fails open. There is NO cluster-wide " +
+			"brute-force login throttle for this deployment unless per-account lockout " +
+			"is separately enabled (see docs on login lockout / ADR-025). This warning " +
+			"is logged once per process; the underlying gap persists for its lifetime.")
+	})
+}
+
+// isUnsupportedByBackend reports whether err indicates the active storage
+// backend has no implementation for the operation at all (permanent, not a
+// transient failure worth staying silent about).
+func isUnsupportedByBackend(err error) bool {
+	return errors.Is(err, storage.ErrUnsupportedByBackend)
+}
+
 // IsLoginRateLimited reports whether an IP has reached the failed-login budget
 // within the window. Fails open (false) on an empty IP or a storage error.
 func (c *KeyorixCore) IsLoginRateLimited(ctx context.Context, ip string) bool {
@@ -25,6 +64,9 @@ func (c *KeyorixCore) IsLoginRateLimited(ctx context.Context, ip string) bool {
 	}
 	n, err := c.storage.CountRecentLoginAttempts(ctx, ip, c.now().Add(-LoginWindow))
 	if err != nil {
+		if isUnsupportedByBackend(err) {
+			c.warnRateLimitUnsupportedOnce()
+		}
 		return false
 	}
 	return n >= LoginMaxAttempts
@@ -75,6 +117,9 @@ func (c *KeyorixCore) IsPasswordResetRateLimited(ctx context.Context, ip string)
 	}
 	n, err := c.storage.CountRecentLoginAttempts(ctx, passwordResetRateLimitPrefix+ip, c.now().Add(-PasswordResetWindow))
 	if err != nil {
+		if isUnsupportedByBackend(err) {
+			c.warnRateLimitUnsupportedOnce()
+		}
 		return false
 	}
 	return n >= PasswordResetMaxAttempts

--- a/internal/core/rate_limit_test.go
+++ b/internal/core/rate_limit_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/remote"
 	"github.com/keyorixhq/keyorix/internal/storage/store"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -72,4 +73,64 @@ func TestRateLimit_PruneRemovesAgedRows(t *testing.T) {
 	n, err := c.storage.CountRecentLoginAttempts(ctx, "1.2.3.4", time.Time{})
 	require.NoError(t, err)
 	assert.Zero(t, n, "table is empty after pruning aged rows")
+}
+
+// newRemoteRateLimitCore builds a KeyorixCore backed by RemoteStorage — the
+// backend a server runs when configured with storage.type: remote — with no
+// HTTP server behind it: CountRecentLoginAttempts/RecordLoginAttempt never make
+// a network call at all, they return store.ErrRemoteUnsupported unconditionally
+// (see internal/storage/store/remote_login_attempts.go).
+func newRemoteRateLimitCore(t *testing.T) *KeyorixCore {
+	t.Helper()
+	rs, err := store.NewRemoteStorage(&remote.Config{
+		BaseURL:        "https://unused.example",
+		APIKey:         "test-key",
+		TimeoutSeconds: 30,
+		RetryAttempts:  0,
+		TLSVerify:      true,
+	})
+	require.NoError(t, err)
+	now := time.Date(2026, 6, 12, 10, 0, 0, 0, time.UTC)
+	return &KeyorixCore{storage: rs, now: func() time.Time { return now }, passwordPolicy: DefaultPasswordPolicy()}
+}
+
+// TestRateLimit_RemoteStorageFailsOpenSilentlyOnlyOnce (#452) proves the fix: a
+// server running storage.type: remote has NO working login-attempt counter
+// (RemoteStorage.CountRecentLoginAttempts always errors, per ADR-040 — see
+// remote_login_attempts.go), so IsLoginRateLimited/IsPasswordResetRateLimited
+// still fail open on every call (unavoidable without a real proxy — see #452's
+// design note there) — but the operator-visible warning about that gap fires
+// exactly ONCE per process, not once per request/login attempt.
+func TestRateLimit_RemoteStorageFailsOpenSilentlyOnlyOnce(t *testing.T) {
+	c := newRemoteRateLimitCore(t)
+	ctx := context.Background()
+
+	// The very first call already fails open (never blocks a login) AND emits
+	// the one-time warning.
+	var limited bool
+	out := captureLog(t, func() {
+		limited = c.IsLoginRateLimited(ctx, "203.0.113.5")
+	})
+	assert.False(t, limited, "fails open: an unsupported-backend error must never block login")
+	assert.Contains(t, out, "rate limiting is INERT", "first call must log the operator warning")
+	assert.Contains(t, out, "storage.type: remote")
+
+	// Every subsequent call (login rate limit AND password-reset rate limit,
+	// which share the same warnRateLimitUnsupportedOnce) keeps failing open, but
+	// must NOT log the warning again — otherwise a brute-force flood would spam
+	// the log once per request, defeating the point of a "loud, ONE-TIME" signal.
+	out2 := captureLog(t, func() {
+		for i := 0; i < 25; i++ {
+			assert.False(t, c.IsLoginRateLimited(ctx, "203.0.113.5"))
+		}
+		assert.False(t, c.IsPasswordResetRateLimited(ctx, "203.0.113.5"))
+	})
+	assert.Empty(t, out2, "the warning must not repeat on subsequent calls")
+
+	// RecordFailedLogin/PruneLoginAttempts are best-effort against the same
+	// always-erroring backend and must never panic or block the caller.
+	assert.NotPanics(t, func() { c.RecordFailedLogin(ctx, "203.0.113.5") })
+	_, err := c.PruneLoginAttempts(ctx)
+	assert.Error(t, err, "PruneLoginAttempts surfaces the storage error (it is not a fail-open path)")
+	assert.True(t, isUnsupportedByBackend(err))
 }

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -126,7 +126,13 @@ type KeyorixCore struct {
 	// Combined with the row lock LockUserForUpdate takes on Postgres, this holds
 	// across replicas too. Zero value is ready to use. See account_state.go / scim.go.
 	accountStateMu sync.Mutex
-	auditForwarder AuditForwarder
+	// rateLimitUnsupportedWarnOnce guards the #452 operator warning logged the
+	// first time IsLoginRateLimited/IsPasswordResetRateLimited observe that the
+	// active storage backend can never satisfy CountRecentLoginAttempts (as
+	// opposed to an ordinary transient storage error) — once per process, not
+	// once per request. Zero value is ready to use. See rate_limit.go.
+	rateLimitUnsupportedWarnOnce sync.Once
+	auditForwarder               AuditForwarder
 	// auditStream is the in-process pub/sub broker that wakes live audit tails
 	// (gRPC StreamAuditLogs) the instant an event is written, replacing fixed-interval
 	// DB polling. Always non-nil (set in the constructors).

--- a/internal/core/storage/errors.go
+++ b/internal/core/storage/errors.go
@@ -62,6 +62,18 @@ var ErrDuplicateProjectName = errors.New("a project with this name already exist
 // the rotation outright on ordinary concurrent contention.
 var ErrDuplicateSecretVersion = errors.New("a secret version with this version number already exists")
 
+// ErrUnsupportedByBackend is returned (wrapped) by a storage.Storage implementation
+// when an operation has no meaningful implementation under the ACTIVE backend —
+// distinct from a transient failure of that backend. The motivating case (#452) is
+// RemoteStorage's login-attempt methods: a server proxying storage.type: remote has
+// no server-side counter to proxy the call to (ADR-040: login rate limiting is
+// server-side only, against LocalStorage), so it can never satisfy
+// CountRecentLoginAttempts/RecordLoginAttempt/PruneLoginAttempts. Callers that treat
+// "storage error" as "fail open" (rate_limit.go) should errors.Is against this to
+// distinguish a permanent architectural gap — worth a loud, one-time operator
+// warning — from an ordinary transient DB/network error that doesn't warrant one.
+var ErrUnsupportedByBackend = errors.New("operation not supported by the active storage backend")
+
 // ErrBreakGlassAlreadyActive is returned (wrapped) by CreateBreakGlassActivation when
 // the partial unique index on (project_id, user_id) WHERE state='active' rejects the
 // insert: a concurrent activation for the same project+user already won the race and

--- a/internal/storage/store/remote_login_attempts.go
+++ b/internal/storage/store/remote_login_attempts.go
@@ -8,6 +8,30 @@ import (
 // Login rate limiting is server-side only (ADR-040) — the limiter runs in the
 // server's auth handlers against LocalStorage; a remote (client) caller never
 // records or counts attempts.
+//
+// #452: this also fires when the SERVER itself is booted with storage.type: remote
+// (a chained deployment proxying to an upstream Keyorix server via
+// internal/storage/factory.go's createRemoteStorage) — the local server's own
+// server/http/handlers/auth.go still calls IsLoginRateLimited/RecordFailedLogin
+// against ITS OWN storage on every login, so these three methods are on the hot
+// path there too, not just an unreachable client-mode corner.
+//
+// A real proxied implementation (having the upstream server expose a login-attempt
+// counter/record REST endpoint for a downstream server to call) was considered and
+// rejected for this PR: no such endpoint exists today, and the upstream server's
+// own login_attempts table is scoped to rate-limiting ITS OWN direct /auth/login
+// traffic (ADR-040) — reusing it for a downstream server's unrelated per-IP budget
+// would need a new endpoint, a new authorization model for a system-to-system
+// (not end-user) caller, and versioned API/client wiring on both sides. That is a
+// legitimate architectural improvement but is materially bigger than this
+// security-hardening PR's scope (#452, HIGH: silent fail-open, not silent-and-
+// unfixable). Instead, CountRecentLoginAttempts continues to return the
+// ErrRemoteUnsupported/ErrUnsupportedByBackend sentinel, and the caller
+// (internal/core/rate_limit.go) now logs a loud, one-time operator warning the
+// first time it observes this sentinel, rather than failing open with zero
+// visibility. Fail-open itself is unavoidable without the real proxy above (rate
+// limiting is a backstop, not the primary auth boundary) — this closes the
+// "silent" half of the gap, not the "fails open" half.
 func (rs *RemoteStorage) RecordLoginAttempt(_ context.Context, _ string, _ time.Time) error {
 	return remoteUnsupported("RecordLoginAttempt")
 }

--- a/internal/storage/store/remote_unsupported.go
+++ b/internal/storage/store/remote_unsupported.go
@@ -1,8 +1,9 @@
 package store
 
 import (
-	"errors"
 	"fmt"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
 )
 
 // ErrRemoteUnsupported is returned by RemoteStorage methods whose operation has
@@ -16,7 +17,12 @@ import (
 // The live data path for these features runs on the server (LocalStorage); the
 // remote client reaches them through higher-level REST endpoints, not raw storage
 // primitives, so faithful one-to-one proxying isn't possible.
-var ErrRemoteUnsupported = errors.New("operation not supported in remote (client) mode")
+//
+// Also wraps the backend-agnostic storage.ErrUnsupportedByBackend, so callers that
+// only know about the storage.Storage interface (e.g. internal/core) can detect
+// "this backend can never do this" without importing this concrete implementation
+// package.
+var ErrRemoteUnsupported = fmt.Errorf("operation not supported in remote (client) mode: %w", storage.ErrUnsupportedByBackend)
 
 // remoteUnsupported wraps ErrRemoteUnsupported with the calling operation's name.
 func remoteUnsupported(op string) error {


### PR DESCRIPTION
## Summary

- **#452 (HIGH)**: `RemoteStorage.CountRecentLoginAttempts` has no server REST endpoint to proxy to and always errors, and `IsLoginRateLimited`/`IsPasswordResetRateLimited` fail open on any storage error — so a server booted with `storage.type: remote` (a chained deployment proxying to an upstream Keyorix server, per `internal/storage/factory.go`) silently has **no cluster-wide brute-force login throttle at all**, with zero operator visibility, unless per-account lockout is separately enabled.
- **Option A vs B**: a real proxied counter (upstream server exposes a login-attempt-count/record REST endpoint for a downstream server to call) was evaluated and rejected for this PR — no such endpoint exists today, the upstream's own `login_attempts` table is scoped to rate-limiting *its own* direct `/auth/login` traffic (ADR-040), and adding a system-to-system endpoint + new authz model + versioned client wiring is a materially bigger architectural change than a hardening PR's scope. Went with **Option B**: keep the existing `remoteUnsupported`/`ErrRemoteUnsupported` sentinel convention, but make it also wrap a new backend-agnostic `storage.ErrUnsupportedByBackend` sentinel so `internal/core` can detect "this backend can never do this" without importing the concrete `store` package.
- The caller (`internal/core/rate_limit.go`) now logs a loud, **one-time per process** (not per-request — that would be log-spam) operator warning the first time it observes that sentinel, via a `sync.Once` on `KeyorixCore`. Fail-open behavior itself is unchanged and unavoidable without Option A (rate limiting is a backstop, not the primary auth boundary) — this closes the "silent" half of the gap, not the "fails open" half.

## Changes

- `internal/core/storage/errors.go` — new `ErrUnsupportedByBackend` sentinel.
- `internal/storage/store/remote_unsupported.go` — `ErrRemoteUnsupported` now wraps it (so every existing `remoteUnsupported(...)` call site across `remote_*.go` gets this detection for free).
- `internal/storage/store/remote_login_attempts.go` — doc comment explaining why Option A was rejected in favor of Option B.
- `internal/core/rate_limit.go` — `IsLoginRateLimited`/`IsPasswordResetRateLimited` now call a one-time warning helper when they see the sentinel.
- `internal/core/service.go` — adds the `sync.Once` guard field on `KeyorixCore`.
- `internal/core/rate_limit_test.go` — new regression test (`TestRateLimit_RemoteStorageFailsOpenSilentlyOnlyOnce`) proving: (1) the backend still fails open (never blocks login), (2) the warning fires on the very first call, and (3) it does **not** repeat on 25+ subsequent calls across both `IsLoginRateLimited` and `IsPasswordResetRateLimited`.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/core/... ./internal/storage/...` (all pass, including the new regression test)
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues