### PR TITLE
fix(operator): wipe target Secret when upstream reports it gone (#428)

### DIFF
--- a/operator/internal/controller/keyorixsecret_controller.go
+++ b/operator/internal/controller/keyorixsecret_controller.go
@@ -9,6 +9,7 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"net/url"
 	"sort"
@@ -142,17 +143,31 @@ func (r *KeyorixSecretReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		interval = minRefreshInterval
 	}
 
-	desired, err := r.buildDesired(ctx, &ks)
-	if err != nil {
-		logger.Error(err, "failed to assemble secret data")
-		return r.fail(ctx, &ks, err)
-	}
-
-	hash := hashData(r.hashKey, desired)
 	secretName := ks.Spec.Target.Name
 	if secretName == "" {
 		secretName = ks.Name
 	}
+
+	desired, err := r.buildDesired(ctx, &ks)
+	if err != nil {
+		logger.Error(err, "failed to assemble secret data")
+		if errors.Is(err, keyorix.ErrSecretGone) {
+			// The upstream Keyorix server AFFIRMATIVELY reported (404/403) that a
+			// referenced secret no longer exists or is no longer accessible — as
+			// opposed to a transient failure (network error, timeout, 5xx, or a bad
+			// token) where the target Secret must be left untouched. Without this,
+			// a revoked/deleted upstream secret leaves the previously synced target
+			// Secret sitting in the cluster indefinitely, fully readable by every
+			// workload that mounts it, with no indication anything is wrong (#428).
+			if wipeErr := r.wipeTargetSecret(ctx, &ks, secretName); wipeErr != nil {
+				logger.Error(wipeErr, "failed to wipe target Secret after upstream secret became inaccessible")
+			}
+			return r.failGone(ctx, &ks, err)
+		}
+		return r.fail(ctx, &ks, err)
+	}
+
+	hash := hashData(r.hashKey, desired)
 
 	if err := r.applySecret(ctx, &ks, secretName, desired); err != nil {
 		logger.Error(err, "failed to apply target Secret")
@@ -294,6 +309,39 @@ func (r *KeyorixSecretReconciler) fail(ctx context.Context, ks *secretsv1alpha1.
 	}
 	// Return the cause so the controller's rate-limited workqueue backs off.
 	return ctrl.Result{}, cause
+}
+
+// failGone is fail's counterpart for a confirmed-gone upstream secret (#428): it
+// records a distinct reason ("UpstreamSecretGone" rather than the generic
+// "SyncError") so the CR's status makes the wipe visible and explicable, rather than
+// looking like an ordinary transient sync failure. The target Secret has already been
+// wiped by wipeTargetSecret before this is called.
+func (r *KeyorixSecretReconciler) failGone(ctx context.Context, ks *secretsv1alpha1.KeyorixSecret, cause error) (ctrl.Result, error) {
+	r.setReady(ks, metav1.ConditionFalse, "UpstreamSecretGone", cause.Error())
+	if err := r.Status().Update(ctx, ks); err != nil {
+		return ctrl.Result{}, err
+	}
+	// Still return the cause so the workqueue keeps retrying (with backoff): if the
+	// secret or access is restored upstream, the next successful reconcile re-syncs it.
+	return ctrl.Result{}, cause
+}
+
+// wipeTargetSecret deletes the target Secret when the upstream Keyorix reference has
+// been confirmed gone (404/403 — see the ErrSecretGone handling in Reconcile). Only a
+// Secret this operator actually manages (carries ManagedByLabel) is ever touched:
+// applySecret already refuses to adopt a pre-existing unmanaged Secret sharing the
+// target name, so wiping it here too would risk deleting an unrelated workload's own
+// Secret that merely happens to collide on name. A missing target Secret is a no-op.
+func (r *KeyorixSecretReconciler) wipeTargetSecret(ctx context.Context, ks *secretsv1alpha1.KeyorixSecret, name string) error {
+	var secret corev1.Secret
+	key := types.NamespacedName{Namespace: ks.Namespace, Name: name}
+	if err := r.Get(ctx, key, &secret); err != nil {
+		return client.IgnoreNotFound(err)
+	}
+	if secret.Labels[ManagedByLabel] != ManagedByValue {
+		return nil
+	}
+	return client.IgnoreNotFound(r.Delete(ctx, &secret))
 }
 
 // succeed records Ready=True and the synced fingerprint.

--- a/operator/internal/controller/keyorixsecret_controller_test.go
+++ b/operator/internal/controller/keyorixsecret_controller_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -21,15 +22,23 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	secretsv1alpha1 "github.com/keyorixhq/keyorix/operator/api/v1alpha1"
+	"github.com/keyorixhq/keyorix/operator/internal/keyorix"
 )
 
-// fakeFetcher serves values from a map; refs absent from it (or in failRefs) error.
+// fakeFetcher serves values from a map. Refs in failRefs error with a plain
+// (non-ErrSecretGone) error, simulating a transient failure (network/5xx/401). Refs in
+// goneRefs error wrapping keyorix.ErrSecretGone, simulating a confirmed 404/403 from
+// the upstream Keyorix server (#428).
 type fakeFetcher struct {
 	values   map[string][]byte
 	failRefs map[string]bool
+	goneRefs map[string]bool
 }
 
 func (f *fakeFetcher) FetchValue(_ context.Context, ref string) ([]byte, error) {
+	if f.goneRefs[ref] {
+		return nil, fmt.Errorf("ref %q gone: %w", ref, keyorix.ErrSecretGone)
+	}
 	if f.failRefs[ref] {
 		return nil, errors.New("boom")
 	}
@@ -208,6 +217,101 @@ func TestReconcile_FetchFailureFailsClosed(t *testing.T) {
 	require.Len(t, ks.Status.Conditions, 1)
 	assert.Equal(t, metav1.ConditionFalse, ks.Status.Conditions[0].Status)
 	assert.Equal(t, "SyncError", ks.Status.Conditions[0].Reason)
+}
+
+// TestReconcile_UpstreamGoneWipesTargetSecret pins #428: a fetch failure that
+// AFFIRMATIVELY indicates the upstream secret is gone (404/403, wrapped as
+// keyorix.ErrSecretGone) must actively delete the previously synced target Secret —
+// otherwise every workload mounting it goes on reading a revoked/deleted value
+// indefinitely, with the CR's Ready condition the only (easy-to-miss) hint anything is
+// wrong.
+func TestReconcile_UpstreamGoneWipesTargetSecret(t *testing.T) {
+	// First reconcile succeeds and creates the target Secret normally.
+	fetcher := &fakeFetcher{values: map[string][]byte{
+		"app/production/db-password": []byte("p4ss"),
+		"app/production/api-key":     []byte("k3y"),
+	}}
+	r, c := newReconciler(t, fetcher, ksFixture(), tokenSecret())
+	_, err := reconcile(t, r)
+	require.NoError(t, err)
+
+	var got corev1.Secret
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "db-creds", Namespace: "app"}, &got),
+		"precondition: the target Secret exists after a successful sync")
+
+	// The upstream secret is now confirmed gone (404/403) on the next reconcile.
+	fetcher.goneRefs = map[string]bool{"app/production/db-password": true}
+
+	_, err = reconcile(t, r)
+	require.Error(t, err, "a confirmed-gone upstream ref still requeues with error for backoff")
+	assert.True(t, errors.Is(err, keyorix.ErrSecretGone))
+
+	err = c.Get(context.Background(), types.NamespacedName{Name: "db-creds", Namespace: "app"}, &got)
+	assert.Error(t, err, "the target Secret must be wiped once the upstream secret is confirmed gone")
+
+	var ks secretsv1alpha1.KeyorixSecret
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "db", Namespace: "app"}, &ks))
+	require.Len(t, ks.Status.Conditions, 1)
+	assert.Equal(t, metav1.ConditionFalse, ks.Status.Conditions[0].Status)
+	assert.Equal(t, "UpstreamSecretGone", ks.Status.Conditions[0].Reason,
+		"the status reason must distinguish a confirmed wipe from an ordinary SyncError")
+}
+
+// TestReconcile_TransientFetchFailureLeavesTargetSecretUntouched pins #428's other
+// half: a transient failure (network error, timeout, 5xx, or an ambiguous 401) must
+// NOT touch a previously synced target Secret. Wiping it on every hiccup would cause
+// unnecessary outages for every workload depending on it.
+func TestReconcile_TransientFetchFailureLeavesTargetSecretUntouched(t *testing.T) {
+	fetcher := &fakeFetcher{values: map[string][]byte{
+		"app/production/db-password": []byte("p4ss"),
+		"app/production/api-key":     []byte("k3y"),
+	}}
+	r, c := newReconciler(t, fetcher, ksFixture(), tokenSecret())
+	_, err := reconcile(t, r)
+	require.NoError(t, err)
+
+	var before corev1.Secret
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "db-creds", Namespace: "app"}, &before))
+
+	// A transient failure on the next reconcile — NOT wrapping ErrSecretGone.
+	fetcher.failRefs = map[string]bool{"app/production/db-password": true}
+
+	_, err = reconcile(t, r)
+	require.Error(t, err)
+	assert.False(t, errors.Is(err, keyorix.ErrSecretGone), "a transient failure must not be classified as gone")
+
+	var after corev1.Secret
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "db-creds", Namespace: "app"}, &after),
+		"the target Secret must still exist after a transient fetch failure")
+	assert.Equal(t, before.Data, after.Data, "a transient failure must not alter the previously synced values")
+
+	var ks secretsv1alpha1.KeyorixSecret
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "db", Namespace: "app"}, &ks))
+	require.Len(t, ks.Status.Conditions, 1)
+	assert.Equal(t, metav1.ConditionFalse, ks.Status.Conditions[0].Status)
+	assert.Equal(t, "SyncError", ks.Status.Conditions[0].Reason, "a transient failure keeps the generic SyncError reason")
+}
+
+// A target Secret this operator does NOT manage (no ManagedByLabel — applySecret
+// already refuses to adopt it) must never be deleted, even when the upstream secret is
+// confirmed gone: it isn't ours to touch, and it may belong to an unrelated workload
+// that merely collides on name.
+func TestReconcile_UpstreamGoneDoesNotDeleteUnmanagedSecret(t *testing.T) {
+	foreign := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "db-creds", Namespace: "app"},
+		Data:       map[string][]byte{"OTHER": []byte("do-not-touch")},
+	}
+	fetcher := &fakeFetcher{goneRefs: map[string]bool{"app/production/db-password": true}}
+	r, c := newReconciler(t, fetcher, ksFixture(), tokenSecret(), foreign)
+
+	_, err := reconcile(t, r)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, keyorix.ErrSecretGone))
+
+	var got corev1.Secret
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "db-creds", Namespace: "app"}, &got),
+		"an unmanaged Secret sharing the target name must not be deleted")
+	assert.Equal(t, []byte("do-not-touch"), got.Data["OTHER"])
 }
 
 // TestReconcile_TokenSecretReadUsesAPIReader pins #124: the token Secret lookup

--- a/operator/internal/keyorix/client.go
+++ b/operator/internal/keyorix/client.go
@@ -6,12 +6,25 @@ package keyorix
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
 	"time"
 )
+
+// ErrSecretGone is wrapped into the error FetchValue returns when the Keyorix server
+// AFFIRMATIVELY reports the referenced secret no longer exists or is no longer
+// accessible (HTTP 404 Not Found — the server's ref resolution already collapses
+// "never existed" and "soft-deleted" into 404 — or HTTP 403 Forbidden, meaning the
+// caller's own scope was denied for that specific reference, e.g. a revoked
+// machine-identity role). Callers use errors.Is(err, ErrSecretGone) to distinguish
+// this confirmed case from a transient failure (network error, timeout, 5xx, or a 401
+// — which only says the bearer token itself is bad/expired and says nothing about the
+// referenced secret's fate) where taking a destructive action on a previously synced
+// target would cause an unnecessary outage for workloads that depend on it.
+var ErrSecretGone = errors.New("secret reference no longer exists or is not accessible")
 
 // Client reads secret values from a Keyorix server with a bearer (machine-identity)
 // token. The token is sent on every request and never logged.
@@ -49,10 +62,21 @@ func (c *Client) FetchValue(ctx context.Context, ref string) ([]byte, error) {
 	defer resp.Body.Close() //nolint:errcheck
 
 	switch {
-	case resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden:
-		return nil, fmt.Errorf("not authorized (HTTP %d) — check the token and its secrets.read permission", resp.StatusCode)
 	case resp.StatusCode == http.StatusNotFound:
-		return nil, fmt.Errorf("secret reference %q not found", ref)
+		// The server's ref-resolution collapses "never existed" and "soft-deleted"
+		// into an identical 404 (closing an existence oracle) — either way the
+		// secret this reference names is gone.
+		return nil, fmt.Errorf("secret reference %q not found: %w", ref, ErrSecretGone)
+	case resp.StatusCode == http.StatusForbidden:
+		// Distinct from 401: this means the request was authenticated but the
+		// caller's own scope/grant for THIS reference was denied — e.g. a revoked
+		// machine-identity role or a suspended secret. Treated the same as "gone".
+		return nil, fmt.Errorf("secret reference %q forbidden (HTTP 403) — access revoked: %w", ref, ErrSecretGone)
+	case resp.StatusCode == http.StatusUnauthorized:
+		// Unlike 403, a 401 says the token itself is invalid/expired — it says
+		// nothing about whether the referenced secret still exists or is still
+		// permitted, so this must NOT be treated as ErrSecretGone.
+		return nil, fmt.Errorf("not authorized (HTTP 401) — check the token is valid")
 	case resp.StatusCode == http.StatusBadRequest:
 		return nil, fmt.Errorf("invalid reference %q (want project/environment/name)", ref)
 	case resp.StatusCode >= 400:

--- a/operator/internal/keyorix/client_test.go
+++ b/operator/internal/keyorix/client_test.go
@@ -2,6 +2,7 @@ package keyorix
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -27,7 +28,7 @@ func TestClient_FetchValue(t *testing.T) {
 func TestClient_FetchValueErrors(t *testing.T) {
 	cases := map[int]string{
 		http.StatusUnauthorized:        "not authorized",
-		http.StatusForbidden:           "not authorized",
+		http.StatusForbidden:           "forbidden",
 		http.StatusNotFound:            "not found",
 		http.StatusBadRequest:          "invalid reference",
 		http.StatusInternalServerError: "HTTP 500",
@@ -43,4 +44,50 @@ func TestClient_FetchValueErrors(t *testing.T) {
 			assert.Contains(t, err.Error(), want)
 		})
 	}
+}
+
+// TestClient_FetchValueErrorGoneClassification pins the 404/403-vs-everything-else
+// distinction the operator controller relies on (#428): a 404 or 403 must wrap
+// ErrSecretGone so the controller can treat it as "the secret is confirmed gone" and
+// wipe the stale target Secret, while every other failure (401, 400, 5xx, network)
+// must NOT wrap it — those are ambiguous or transient and must never trigger a
+// destructive action against a previously synced Secret.
+func TestClient_FetchValueErrorGoneClassification(t *testing.T) {
+	cases := []struct {
+		status   int
+		wantGone bool
+	}{
+		{http.StatusNotFound, true},
+		{http.StatusForbidden, true},
+		{http.StatusUnauthorized, false},
+		{http.StatusBadRequest, false},
+		{http.StatusInternalServerError, false},
+		{http.StatusBadGateway, false},
+		{http.StatusServiceUnavailable, false},
+	}
+	for _, tc := range cases {
+		t.Run(http.StatusText(tc.status), func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tc.status)
+			}))
+			defer srv.Close()
+			_, err := New(srv.URL, "tok").FetchValue(context.Background(), "a/b/c")
+			require.Error(t, err)
+			assert.Equal(t, tc.wantGone, errors.Is(err, ErrSecretGone),
+				"HTTP %d: errors.Is(err, ErrSecretGone) = %v, want %v", tc.status, errors.Is(err, ErrSecretGone), tc.wantGone)
+		})
+	}
+}
+
+// A genuine network failure (no HTTP response at all — connection refused here) must
+// never be classified as ErrSecretGone: it says nothing about whether the secret
+// still exists, only that this attempt to reach the server failed transiently.
+func TestClient_FetchValueNetworkErrorIsNotGone(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	unreachable := srv.URL
+	srv.Close() // closed before use: connections to this URL are refused
+
+	_, err := New(unreachable, "tok").FetchValue(context.Background(), "a/b/c")
+	require.Error(t, err)
+	assert.False(t, errors.Is(err, ErrSecretGone), "a connection-refused error must not be classified as ErrSecretGone")
 }


### PR DESCRIPTION
## Summary
- Fetch-before-write ordering meant a confirmed-gone upstream secret (HTTP 404/403) never reached the write step, leaving the previously synced target Secret in the cluster indefinitely and fully readable by every workload that mounts it, with no indication anything was wrong.
- `FetchValue` now wraps 404/403 as `keyorix.ErrSecretGone`, distinct from a 401 (bad token — says nothing about the secret's fate) or a transient network/5xx error.
- `Reconcile` actively wipes the target Secret when it observes `ErrSecretGone`, restricted to Secrets carrying this operator's `ManagedByLabel` (never touches an unmanaged/foreign Secret that happens to collide on name), and records a distinct `UpstreamSecretGone` status reason so it's visibly different from an ordinary transient `SyncError`.
- A transient fetch failure still leaves the target Secret completely untouched.

## Test plan
- [x] `GOWORK=off go build ./...` (operator module)
- [x] `GOWORK=off go vet ./...`
- [x] `GOWORK=off go test ./...` — all pass, including 3 new regression tests: confirmed-gone wipes the Secret, transient failure leaves it untouched, unmanaged Secret is never deleted
- [x] `GOWORK=off gosec -severity medium -exclude-generated ./...` — 0 issues
- [x] Main module `go build ./...` unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)