### PR TITLE
fix(core): close invitation/access-request accept-vs-revoke TOCTOU (#412/#277)

### DIFF
--- a/internal/core/concurrency_invitation_revoke_accept_test.go
+++ b/internal/core/concurrency_invitation_revoke_accept_test.go
@@ -1,0 +1,156 @@
+package core
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// TestConcurrency_RevokeInvitation_RacesAccept is the #412 TOCTOU regression: an
+// admin's RevokeInvitation and a concurrent holder's completeInvitationAccept (via
+// CompleteSetup) both read the same pending invitation, mutate it in memory, and
+// used to persist with a bare read-mutate-Save (UpdateProjectInvitation) with no
+// WHERE-state guard — so whichever write landed second silently clobbered the
+// other's transition, with no error on either side, and could leave the
+// just-accepted membership/role grant live behind an invitation that reads
+// "revoked". This drives BOTH paths concurrently against the SAME invitation, many
+// times over, against a real file-backed SQLite (the same conditional-UPDATE code
+// path production uses) and asserts: exactly one side ever wins, the loser gets a
+// clean "concurrently modified" error rather than a silent no-op, the persisted
+// invitation state exactly matches the winner, and — the security invariant that
+// matters — no live project role grant for the invited user survives when revoke
+// wins the race.
+func TestConcurrency_RevokeInvitation_RacesAccept(t *testing.T) {
+	require.NoError(t, i18n.Initialize(&config.Config{
+		Locale: config.LocaleConfig{Language: "en", FallbackLanguage: "en"},
+	}))
+
+	const iterations = 25
+	for i := 0; i < iterations; i++ {
+		i := i
+		// Named explicitly (not the anonymous t.Run("", ...) form): Go names an
+		// anonymous subtest "#00", "#01", ... and that literal "#" then lands in
+		// t.TempDir()'s path. Embedded into a "file:" URI DSN, SQLite (per its
+		// documented URI-filename parsing) treats everything from the first "#"
+		// onward as an ignored fragment — silently truncating the path AND
+		// dropping the "?_busy_timeout=..." query string — so every iteration
+		// collided on the same truncated path instead of getting its own database.
+		t.Run(fmt.Sprintf("iter%d", i), func(t *testing.T) {
+			dsn := "file:" + filepath.Join(t.TempDir(), fmt.Sprintf("invite-revoke-accept-race-%d.db", i)) +
+				"?_busy_timeout=10000&_journal_mode=WAL&_txlock=immediate"
+			db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+			require.NoError(t, err)
+			require.NoError(t, db.AutoMigrate(
+				&models.User{}, &models.Role{}, &models.Permission{}, &models.RolePermission{},
+				&models.UserRole{}, &models.Group{}, &models.UserGroup{}, &models.GroupRole{},
+				&models.Project{}, &models.Environment{}, &models.SystemMetadata{},
+				&models.ProjectMembership{}, &models.ProjectInvitation{}, &models.SetupToken{},
+				&models.PasswordHistory{}, &models.AuditEvent{},
+			))
+
+			st := store.NewLocalStorage(db)
+			c := NewKeyorixCore(st)
+			c.SetBootstrapToken("test-bootstrap-token")
+			boot, err := c.BootstrapSystem(context.Background(), &BootstrapRequest{
+				Username: "admin", Email: "admin@example.com", Password: "BootstrapPass123!",
+				DisplayName: "Admin", Token: "test-bootstrap-token",
+			})
+			require.NoError(t, err)
+			adminID := boot.User.ID
+			projID := boot.Project.ID
+			// Open mode: acceptance grants the role immediately, so there's a real live
+			// grant at stake if the race is lost.
+			c.SetMembershipValidationMode(ValidationModeOpen)
+
+			ctx := context.Background()
+			now := c.now()
+			future := now.Add(24 * time.Hour)
+			email := "racer@example.com"
+			inv, err := st.CreateProjectInvitation(ctx, &models.ProjectInvitation{
+				ProjectID: projID, Email: email, Role: "project_developer", State: InvitationPending,
+				InvitedBy: adminID, ValidationModeAtInvite: ValidationModeOpen, ExpiresAt: &future, CreatedAt: now,
+			})
+			require.NoError(t, err)
+
+			raw := setupPrefix + "revoke-accept-race"
+			_, err = st.CreateSetupToken(ctx, &models.SetupToken{
+				TokenHash: sha256Hex(raw), Purpose: SetupPurposeInvitationAccept, SubjectEmail: email,
+				InvitationID: &inv.ID, State: SetupTokenActive, ExpiresAt: future, CreatedBy: adminID,
+			})
+			require.NoError(t, err)
+
+			var revokeErr, acceptErr error
+			start := make(chan struct{})
+			var wg sync.WaitGroup
+			wg.Add(2)
+			go func() {
+				defer wg.Done()
+				<-start
+				revokeErr = c.RevokeInvitation(ctx, projID, inv.ID, adminID)
+			}()
+			go func() {
+				defer wg.Done()
+				<-start
+				_, acceptErr = c.CompleteSetup(ctx, raw, strongPw, "ua", "1.2.3.4")
+			}()
+			close(start)
+			wg.Wait()
+
+			revokeWon := revokeErr == nil
+			acceptWon := acceptErr == nil
+			require.NotEqual(t, revokeWon, acceptWon,
+				"iteration %d: exactly one of revoke/accept must win, never both or neither (revokeErr=%v acceptErr=%v)",
+				i, revokeErr, acceptErr)
+
+			final, err := st.GetProjectInvitation(ctx, inv.ID)
+			require.NoError(t, err)
+
+			if revokeWon {
+				assert.Error(t, acceptErr)
+				assert.Equal(t, InvitationRevoked, final.State,
+					"iteration %d: the winning revoke must be the persisted state", i)
+
+				// The security invariant #412 closes: a revoked invitation must not leave
+				// a live project role grant behind, even if the accept raced far enough to
+				// create the account before losing the final conditional write.
+				//
+				// GetUserRoleIDsExact (not GetUserRoleIDsAt) — every new account also
+				// carries the install-wide "system_viewer" baseline role (ADR-021, granted
+				// at project_id=0 by CreateUser regardless of any project invitation), and
+				// GetUserRoleIDsAt's scope match treats project_id=0 as "applies
+				// everywhere", so it would always find that unrelated global grant and make
+				// this assertion vacuously fail. GetUserRoleIDsExact matches the invitation
+				// grant's PROJECT-scoped key (project_id=projID, environment_id=0) only.
+				newUser, uerr := st.GetUserByEmail(ctx, email)
+				if uerr == nil && newUser != nil {
+					ids, err := st.GetUserRoleIDsExact(ctx, newUser.ID, Scope{ProjectID: projID})
+					require.NoError(t, err)
+					assert.Empty(t, ids, "iteration %d: a revoked invitation must not leave a live project role grant behind", i)
+				}
+			} else {
+				assert.Error(t, revokeErr)
+				assert.Equal(t, InvitationAccepted, final.State,
+					"iteration %d: the winning accept must be the persisted state", i)
+
+				// The winning accept must have actually landed the grant it claims.
+				newUser, uerr := st.GetUserByEmail(ctx, email)
+				require.NoError(t, uerr)
+				ids, err := st.GetUserRoleIDsAt(ctx, newUser.ID, Scope{ProjectID: projID})
+				require.NoError(t, err)
+				assert.NotEmpty(t, ids, "iteration %d: a successfully accepted invitation must have granted the role", i)
+			}
+		})
+	}
+}

--- a/internal/core/invitation_accept_test.go
+++ b/internal/core/invitation_accept_test.go
@@ -53,7 +53,7 @@ func TestCompleteInvitationAccept(t *testing.T) {
 		ms.On("CreateProjectMembership", ctx, mock.AnythingOfType("*models.ProjectMembership")).
 			Return(&models.ProjectMembership{ID: 1, ProjectID: 5, UserID: 20, Role: "developer", State: MembershipActive}, nil)
 		ms.On("AssignRole", ctx, uint(20), uint(9), mock.Anything).Return(nil)
-		ms.On("UpdateProjectInvitation", ctx, mock.AnythingOfType("*models.ProjectInvitation")).Return(nil)
+		ms.On("UpdateProjectInvitation", ctx, mock.AnythingOfType("*models.ProjectInvitation")).Return(true, nil)
 		ms.On("CreateSession", ctx, mock.AnythingOfType("*models.Session")).
 			Return(&models.Session{ID: 1, UserID: 20, SessionToken: "sess-bob"}, nil)
 
@@ -87,7 +87,7 @@ func TestCompleteInvitationAccept(t *testing.T) {
 		ms.On("GetActiveProjectMembership", ctx, uint(5), uint(21)).Return(nil, assertNotFoundErr())
 		ms.On("CreateProjectMembership", ctx, mock.AnythingOfType("*models.ProjectMembership")).
 			Return(&models.ProjectMembership{ID: 2, ProjectID: 5, UserID: 21, Role: "developer", State: MembershipInvited}, nil)
-		ms.On("UpdateProjectInvitation", ctx, mock.AnythingOfType("*models.ProjectInvitation")).Return(nil)
+		ms.On("UpdateProjectInvitation", ctx, mock.AnythingOfType("*models.ProjectInvitation")).Return(true, nil)
 		ms.On("CreateSession", ctx, mock.AnythingOfType("*models.Session")).
 			Return(&models.Session{ID: 2, UserID: 21, SessionToken: "sess-bob2"}, nil)
 

--- a/internal/core/invitations.go
+++ b/internal/core/invitations.go
@@ -284,6 +284,47 @@ func (c *KeyorixCore) applyInvitationGrants(ctx context.Context, inv *models.Pro
 	return err
 }
 
+// revokeInvitationGrants best-effort undoes applyInvitationGrants for userID. Used
+// exclusively by completeInvitationAccept when it discovers, only after granting,
+// that the invitation was concurrently revoked (#412): the conditional
+// UpdateProjectInvitation write that would flip the row to accepted lost the race,
+// so whatever was just granted must not be left standing behind an invitation that
+// no longer reads as accepted. actorID 0 attributes the reversal to the system
+// (mirroring applyInvitationGrants' own actorID-0-eligible AssignUserRole/
+// inviteMemberWithMode calls), and every removal is independently best-effort — a
+// failure on one project assignment must not stop the others from being reverted.
+// Errors are audited, not returned or retried: the caller is already on a fail-closed
+// path and a partial rollback is strictly better than leaving every grant live.
+func (c *KeyorixCore) revokeInvitationGrants(ctx context.Context, inv *models.ProjectInvitation, userID uint) {
+	if inv.SystemRole != "" || inv.AssignmentsJSON != "" {
+		if inv.SystemRole != "" {
+			if role, err := c.storage.GetRoleByName(ctx, inv.SystemRole); err == nil {
+				if err := c.RemoveUserRole(ctx, 0, userID, role.ID, Scope{ProjectID: 0}); err != nil {
+					c.auditProjectScoped(ctx, "invitation.accept_race_revoke_failed", userID, 0,
+						fmt.Sprintf("failed to revert system role %q granted to user %d by invitation %d: %v — MANUAL CLEANUP REQUIRED", inv.SystemRole, userID, inv.ID, err))
+				}
+			}
+		}
+		if inv.AssignmentsJSON != "" {
+			var assignments []ProjectAssignment
+			if err := json.Unmarshal([]byte(inv.AssignmentsJSON), &assignments); err == nil {
+				for _, a := range assignments {
+					if err := c.RemoveProjectMember(ctx, 0, a.ProjectID, userID); err != nil {
+						c.auditProjectScoped(ctx, "invitation.accept_race_revoke_failed", userID, a.ProjectID,
+							fmt.Sprintf("failed to revert project assignment %q granted to user %d by invitation %d: %v — MANUAL CLEANUP REQUIRED", a.Role, userID, inv.ID, err))
+					}
+				}
+			}
+		}
+		return
+	}
+	// Project-scoped invite: revert the single project membership/role.
+	if err := c.RemoveProjectMember(ctx, 0, inv.ProjectID, userID); err != nil {
+		c.auditProjectScoped(ctx, "invitation.accept_race_revoke_failed", userID, inv.ProjectID,
+			fmt.Sprintf("failed to revert project role %q granted to user %d by invitation %d: %v — MANUAL CLEANUP REQUIRED", inv.Role, userID, inv.ID, err))
+	}
+}
+
 // ResendInvitationLink reissues the accept link for a still-pending invitation
 // (superseding the prior token) and re-delivers it. Throttled per ADR-028.
 func (c *KeyorixCore) ResendInvitationLink(ctx context.Context, projectID, invitationID, actorID uint) (*ProvisionSetupResult, error) {
@@ -296,10 +337,12 @@ func (c *KeyorixCore) ResendInvitationLink(ctx context.Context, projectID, invit
 	if inv.ProjectID != projectID {
 		return nil, fmt.Errorf("invitation not found")
 	}
-	// Lazy-expire an overdue invite so a resend can't revive a dead one.
+	// Lazy-expire an overdue invite so a resend can't revive a dead one. Best-effort:
+	// if the conditional write loses to a concurrent transition (accept/revoke), that
+	// transition is authoritative and the state check below still refuses the resend.
 	if inv.State == InvitationPending && inv.ExpiresAt != nil && c.now().After(*inv.ExpiresAt) {
 		inv.State = InvitationExpired
-		_ = c.storage.UpdateProjectInvitation(ctx, inv)
+		_, _ = c.storage.UpdateProjectInvitation(ctx, inv)
 	}
 	if inv.State != InvitationPending {
 		return nil, fmt.Errorf("only a pending invitation can be resent (state is %s)", inv.State)
@@ -323,7 +366,11 @@ func (c *KeyorixCore) ListProjectInvitations(ctx context.Context, projectID uint
 	for _, inv := range rows {
 		if inv.State == InvitationPending && inv.ExpiresAt != nil && now.After(*inv.ExpiresAt) {
 			inv.State = InvitationExpired
-			_ = c.storage.UpdateProjectInvitation(ctx, inv)
+			// Best-effort: if a concurrent accept/revoke already resolved this
+			// invitation, that transition is authoritative — the conditional write
+			// no-ops here rather than clobbering it, but the row we return this
+			// call is still fine to display with the intended lazy-expiry state.
+			_, _ = c.storage.UpdateProjectInvitation(ctx, inv)
 		}
 	}
 	return rows, nil
@@ -344,8 +391,16 @@ func (c *KeyorixCore) RevokeInvitation(ctx context.Context, projectID, invitatio
 	now := c.now()
 	inv.State = InvitationRevoked
 	inv.RevokedAt = &now
-	if err := c.storage.UpdateProjectInvitation(ctx, inv); err != nil {
+	ok, err := c.storage.UpdateProjectInvitation(ctx, inv)
+	if err != nil {
 		return fmt.Errorf("failed to revoke invitation: %w", err)
+	}
+	if !ok {
+		// The invitation stopped being pending between the read above and this
+		// write — most likely a concurrent accept (completeInvitationAccept) won
+		// the race. Refuse rather than silently reporting success while the
+		// invitation (and whatever it granted) is left untouched (#412).
+		return fmt.Errorf("invitation is no longer pending (it was concurrently accepted or resolved)")
 	}
 	c.auditProjectScoped(ctx, "invitation.revoked", actorID, inv.ProjectID,
 		fmt.Sprintf("revoked invitation %d (%s)", inv.ID, inv.Email))
@@ -420,7 +475,9 @@ func (c *KeyorixCore) ListAccessRequests(ctx context.Context, projectID uint) ([
 	for _, req := range rows {
 		if req.State == AccessRequestPending && req.ExpiresAt != nil && now.After(*req.ExpiresAt) {
 			req.State = AccessRequestExpired
-			_ = c.storage.UpdateAccessRequest(ctx, req)
+			// Best-effort lazy expiry: a concurrent approve/reject/withdraw that
+			// already resolved this request wins and the conditional write no-ops.
+			_, _ = c.storage.UpdateAccessRequest(ctx, req)
 		}
 		// Annotate the dual-control progress for a pending request.
 		if req.State == AccessRequestPending {
@@ -489,7 +546,10 @@ func (c *KeyorixCore) ApproveAccessRequestWithExpiry(ctx context.Context, projec
 	// stale request that should have lapsed. Expire it lazily and refuse.
 	if req.ExpiresAt != nil && c.now().After(*req.ExpiresAt) {
 		req.State = AccessRequestExpired
-		_ = c.storage.UpdateAccessRequest(ctx, req)
+		// Best-effort: if a concurrent approve/reject/withdraw already resolved this
+		// request, the "has expired" refusal below still stands — no role was
+		// granted on this path, so there's nothing to unwind either way.
+		_, _ = c.storage.UpdateAccessRequest(ctx, req)
 		return nil, fmt.Errorf("access request has expired")
 	}
 	if grantTTL < 0 {
@@ -589,8 +649,25 @@ func (c *KeyorixCore) ApproveAccessRequestWithExpiry(ctx context.Context, projec
 	req.GrantedRole = role
 	req.ResolvedBy = approverID
 	req.ResolvedAt = &now
-	if err := c.storage.UpdateAccessRequest(ctx, req); err != nil {
+	ok, err := c.storage.UpdateAccessRequest(ctx, req)
+	if err != nil {
 		return nil, fmt.Errorf("failed to update access request: %w", err)
+	}
+	if !ok {
+		// The request stopped being pending between the read above and this write —
+		// most likely a concurrent WithdrawAccessRequest or RejectAccessRequest won
+		// the race after the role grant above already landed. The grant must not
+		// outlive a request that no longer reads as approved (#277): revoke it and
+		// fail closed rather than reporting success with a stale/contradictory
+		// request state.
+		if rerr := c.RemoveUserRole(ctx, approverID, req.UserID, roleModel.ID, scope); rerr != nil {
+			c.auditProjectScoped(ctx, "access_request.approval_race_revoke_failed", approverID, req.ProjectID,
+				fmt.Sprintf("access request %d was concurrently withdrawn/rejected after granting %s to user %d, and reverting the grant failed: %v — MANUAL CLEANUP REQUIRED", req.ID, role, req.UserID, rerr))
+		} else {
+			c.auditProjectScoped(ctx, "access_request.approval_race_reverted", approverID, req.ProjectID,
+				fmt.Sprintf("access request %d was concurrently withdrawn/rejected; reverted the %s grant just made to user %d", req.ID, role, req.UserID))
+		}
+		return nil, fmt.Errorf("access request was concurrently withdrawn or resolved; the role grant was reverted")
 	}
 	c.auditProjectScoped(ctx, "access_request.approved", approverID, req.ProjectID,
 		fmt.Sprintf("approved access request %d for user %d as %s (%d approval(s))", req.ID, req.UserID, grantDesc, received))
@@ -636,8 +713,16 @@ func (c *KeyorixCore) RejectAccessRequest(ctx context.Context, projectID, reques
 	req.Reason = reason
 	req.ResolvedBy = approverID
 	req.ResolvedAt = &now
-	if err := c.storage.UpdateAccessRequest(ctx, req); err != nil {
+	ok, err := c.storage.UpdateAccessRequest(ctx, req)
+	if err != nil {
 		return nil, fmt.Errorf("failed to update access request: %w", err)
+	}
+	if !ok {
+		// The request stopped being pending between the read above and this write —
+		// e.g. a concurrent approval already granted the role and moved it to
+		// approved. Refuse rather than silently reporting a rejection that never
+		// took effect (#277's TOCTOU pattern, applied here too).
+		return nil, fmt.Errorf("access request is no longer pending (it was concurrently approved or resolved)")
 	}
 	c.auditProjectScoped(ctx, "access_request.rejected", approverID, req.ProjectID,
 		fmt.Sprintf("rejected access request %d for user %d", req.ID, req.UserID))
@@ -660,8 +745,16 @@ func (c *KeyorixCore) WithdrawAccessRequest(ctx context.Context, requestID, user
 	now := c.now()
 	req.State = AccessRequestWithdrawn
 	req.ResolvedAt = &now
-	if err := c.storage.UpdateAccessRequest(ctx, req); err != nil {
+	ok, err := c.storage.UpdateAccessRequest(ctx, req)
+	if err != nil {
 		return fmt.Errorf("failed to update access request: %w", err)
+	}
+	if !ok {
+		// The request stopped being pending between the read above and this write —
+		// e.g. a concurrent approval already granted the role and moved it to
+		// approved. Refuse rather than silently reporting a withdrawal that never
+		// took effect while a role grant is live behind it (#277).
+		return fmt.Errorf("access request is no longer pending (it was concurrently approved or resolved)")
 	}
 	c.auditProjectScoped(ctx, "access_request.withdrawn", userID, req.ProjectID,
 		fmt.Sprintf("withdrew access request %d", req.ID))

--- a/internal/core/invitations_test.go
+++ b/internal/core/invitations_test.go
@@ -76,7 +76,7 @@ func TestApproveAccessRequest_GrantsRole(t *testing.T) {
 	store.On("AssignRole", ctx, uint(2), uint(5), storage.Scope{ProjectID: 1}).Return(nil)
 	store.On("UpdateAccessRequest", ctx, mock.MatchedBy(func(r *models.AccessRequest) bool {
 		return r.State == AccessRequestApproved && r.GrantedRole == "project_developer" && r.ResolvedBy == 9
-	})).Return(nil)
+	})).Return(true, nil)
 	store.On("LogAuditEvent", ctx, mock.MatchedBy(func(e *models.AuditEvent) bool {
 		return e.EventType == "access_request.approved"
 	})).Return(nil)
@@ -108,7 +108,7 @@ func TestApproveAccessRequest_FallsBackToSuggestedRole(t *testing.T) {
 	store.On("GetProject", ctx, uint(1)).Return(&models.Project{ID: 1}, nil)
 	store.On("GetRoleByName", ctx, "project_viewer").Return(&models.Role{ID: 6}, nil)
 	store.On("AssignRole", ctx, uint(2), uint(6), storage.Scope{ProjectID: 1}).Return(nil)
-	store.On("UpdateAccessRequest", ctx, mock.Anything).Return(nil)
+	store.On("UpdateAccessRequest", ctx, mock.Anything).Return(true, nil)
 	store.On("LogAuditEvent", ctx, mock.Anything).Return(nil)
 	store.On("ListAccessRequestApprovals", ctx, uint(3)).Return([]*models.AccessRequestApproval{}, nil)
 	store.On("CreateAccessRequestApproval", ctx, mock.Anything).Return(nil)
@@ -190,7 +190,7 @@ func TestApproveAccessRequest_AdminApproverMayGrantAdmin(t *testing.T) {
 	// Approver 9 holds the admin role (id 2) at the project.
 	store.On("GetUserRoleIDsAt", ctx, uint(9), storage.Scope{ProjectID: 1}).Return([]uint{2}, nil)
 	store.On("AssignRole", ctx, uint(2), uint(2), storage.Scope{ProjectID: 1}).Return(nil)
-	store.On("UpdateAccessRequest", ctx, mock.Anything).Return(nil)
+	store.On("UpdateAccessRequest", ctx, mock.Anything).Return(true, nil)
 	store.On("LogAuditEvent", ctx, mock.Anything).Return(nil)
 	store.On("ListAccessRequestApprovals", ctx, uint(3)).Return([]*models.AccessRequestApproval{}, nil)
 	store.On("CreateAccessRequestApproval", ctx, mock.Anything).Return(nil)
@@ -214,7 +214,7 @@ func TestApproveAccessRequest_RejectsExpired(t *testing.T) {
 	store.On("GetProject", ctx, uint(1)).Return(&models.Project{ID: 1}, nil)
 	store.On("UpdateAccessRequest", ctx, mock.MatchedBy(func(r *models.AccessRequest) bool {
 		return r.State == AccessRequestExpired
-	})).Return(nil)
+	})).Return(true, nil)
 
 	_, err := c.ApproveAccessRequest(ctx, 1, 3, 9, "")
 	require.Error(t, err)
@@ -344,7 +344,7 @@ func TestListProjectInvitations_LazyExpire(t *testing.T) {
 	// The expired pending invite is persisted as expired.
 	store.On("UpdateProjectInvitation", ctx, mock.MatchedBy(func(inv *models.ProjectInvitation) bool {
 		return inv.State == InvitationExpired
-	})).Return(nil)
+	})).Return(true, nil)
 
 	out, err := c.ListProjectInvitations(ctx, 1)
 	require.NoError(t, err)

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -167,9 +167,9 @@ func (m *MockStorage) GetProjectInvitation(ctx context.Context, id uint) (*model
 	return args.Get(0).(*models.ProjectInvitation), args.Error(1)
 }
 
-func (m *MockStorage) UpdateProjectInvitation(ctx context.Context, inv *models.ProjectInvitation) error {
+func (m *MockStorage) UpdateProjectInvitation(ctx context.Context, inv *models.ProjectInvitation) (bool, error) {
 	args := m.Called(ctx, inv)
-	return args.Error(0)
+	return args.Bool(0), args.Error(1)
 }
 
 func (m *MockStorage) ListProjectInvitations(ctx context.Context, projectID uint) ([]*models.ProjectInvitation, error) {
@@ -196,9 +196,9 @@ func (m *MockStorage) GetAccessRequest(ctx context.Context, id uint) (*models.Ac
 	return args.Get(0).(*models.AccessRequest), args.Error(1)
 }
 
-func (m *MockStorage) UpdateAccessRequest(ctx context.Context, req *models.AccessRequest) error {
+func (m *MockStorage) UpdateAccessRequest(ctx context.Context, req *models.AccessRequest) (bool, error) {
 	args := m.Called(ctx, req)
-	return args.Error(0)
+	return args.Bool(0), args.Error(1)
 }
 
 func (m *MockStorage) ListAccessRequests(ctx context.Context, projectID uint) ([]*models.AccessRequest, error) {

--- a/internal/core/setup_consume.go
+++ b/internal/core/setup_consume.go
@@ -165,10 +165,13 @@ func (c *KeyorixCore) completeInvitationAccept(ctx context.Context, tok *models.
 	if err != nil {
 		return nil, fmt.Errorf("%s: invitation not found", i18n.T("ErrorNotFound", nil))
 	}
-	// Lazy-expire an overdue invite, then require it still be pending.
+	// Lazy-expire an overdue invite, then require it still be pending. Best-effort:
+	// if a concurrent revoke/accept already resolved this invitation, that
+	// transition wins and the conditional write no-ops; the state check below
+	// still refuses to proceed either way.
 	if inv.State == InvitationPending && inv.ExpiresAt != nil && c.now().After(*inv.ExpiresAt) {
 		inv.State = InvitationExpired
-		_ = c.storage.UpdateProjectInvitation(ctx, inv)
+		_, _ = c.storage.UpdateProjectInvitation(ctx, inv)
 	}
 	if inv.State != InvitationPending {
 		return nil, fmt.Errorf("%s: invitation is %s", i18n.T("ErrorValidation", nil), inv.State)
@@ -238,10 +241,28 @@ func (c *KeyorixCore) completeInvitationAccept(ctx context.Context, tok *models.
 	}
 
 	// Mark the invitation accepted (only now that account + membership both exist).
+	// Conditional on the invitation still being pending (#412): the grants above
+	// were already applied, so if an admin's RevokeInvitation won a concurrent race
+	// and flipped the row to revoked in the window since the pending check at the
+	// top of this function, this write must not silently re-establish "accepted"
+	// over a revoke — and the grant that already landed must not survive it.
 	now := c.now()
 	inv.State = InvitationAccepted
 	inv.AcceptedAt = &now
-	_ = c.storage.UpdateProjectInvitation(ctx, inv)
+	ok, uerr := c.storage.UpdateProjectInvitation(ctx, inv)
+	if uerr != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), uerr)
+	}
+	if !ok {
+		// Lost the race: the invitation was concurrently revoked (or lazily
+		// expired) after the grants above were applied. Best-effort revoke the
+		// membership/role(s) just granted so a revoked invitation can't leave a
+		// live grant behind, then fail closed — no session is minted below.
+		c.revokeInvitationGrants(ctx, inv, user.ID)
+		c.auditProjectScoped(ctx, "invitation.accept_race_reverted", user.ID, inv.ProjectID,
+			fmt.Sprintf("invitation %d was concurrently revoked/resolved while %s (user %d) was accepting it; reverted the grant(s) just made", inv.ID, inv.Email, user.ID))
+		return nil, fmt.Errorf("%s: this invitation was revoked", i18n.T("ErrorValidation", nil))
+	}
 
 	c.auditProjectScoped(ctx, "invitation.accepted", user.ID, inv.ProjectID,
 		fmt.Sprintf("invitation %d accepted by %s (user %d)", inv.ID, inv.Email, user.ID))

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -108,13 +108,25 @@ type Storage interface {
 	// Project invitations (ADR-024).
 	CreateProjectInvitation(ctx context.Context, inv *models.ProjectInvitation) (*models.ProjectInvitation, error)
 	GetProjectInvitation(ctx context.Context, id uint) (*models.ProjectInvitation, error)
-	UpdateProjectInvitation(ctx context.Context, inv *models.ProjectInvitation) error
+	// UpdateProjectInvitation persists an invitation state transition with a
+	// conditional UPDATE (only an invitation whose CURRENT stored state is still
+	// "pending" may be transitioned). The bool reports whether the row matched and
+	// was updated; false means the invitation was already resolved (accepted,
+	// revoked, or expired) by a prior or racing call and this write was rejected,
+	// not silently applied (#412).
+	UpdateProjectInvitation(ctx context.Context, inv *models.ProjectInvitation) (bool, error)
 	ListProjectInvitations(ctx context.Context, projectID uint) ([]*models.ProjectInvitation, error)
 
 	// Access requests (ADR-024).
 	CreateAccessRequest(ctx context.Context, req *models.AccessRequest) (*models.AccessRequest, error)
 	GetAccessRequest(ctx context.Context, id uint) (*models.AccessRequest, error)
-	UpdateAccessRequest(ctx context.Context, req *models.AccessRequest) error
+	// UpdateAccessRequest persists an access-request state transition with a
+	// conditional UPDATE (only a request whose CURRENT stored state is still
+	// "pending" may be transitioned). The bool reports whether the row matched and
+	// was updated; false means the request was already resolved (approved,
+	// rejected, withdrawn, or expired) by a prior or racing call and this write was
+	// rejected, not silently applied (#277).
+	UpdateAccessRequest(ctx context.Context, req *models.AccessRequest) (bool, error)
 	ListAccessRequests(ctx context.Context, projectID uint) ([]*models.AccessRequest, error)
 	// Access-request approvals (N-of-M dual control). One row per approver sign-off.
 	CreateAccessRequestApproval(ctx context.Context, a *models.AccessRequestApproval) error

--- a/internal/storage/store/invitations_test.go
+++ b/internal/storage/store/invitations_test.go
@@ -37,7 +37,9 @@ func TestProjectInvitation_RoundTrip(t *testing.T) {
 	assert.Equal(t, "pending", got.State)
 
 	got.State = "revoked"
-	require.NoError(t, ls.UpdateProjectInvitation(ctx, got))
+	ok, err := ls.UpdateProjectInvitation(ctx, got)
+	require.NoError(t, err)
+	require.True(t, ok)
 
 	// Scoped list.
 	_, err = ls.CreateProjectInvitation(ctx, &models.ProjectInvitation{ProjectID: 2, Email: "c@d.com", State: "pending", CreatedAt: now})
@@ -61,7 +63,9 @@ func TestAccessRequest_RoundTrip(t *testing.T) {
 
 	created.State = "approved"
 	created.GrantedRole = "project_viewer"
-	require.NoError(t, ls.UpdateAccessRequest(ctx, created))
+	ok, err := ls.UpdateAccessRequest(ctx, created)
+	require.NoError(t, err)
+	require.True(t, ok)
 
 	got, err := ls.GetAccessRequest(ctx, created.ID)
 	require.NoError(t, err)
@@ -70,4 +74,80 @@ func TestAccessRequest_RoundTrip(t *testing.T) {
 	list, err := ls.ListAccessRequests(ctx, 1)
 	require.NoError(t, err)
 	assert.Len(t, list, 1)
+}
+
+// TestUpdateProjectInvitation_ConditionalOnPending_Sequential proves the storage
+// guard itself (#412): a second write against a row that's no longer "pending"
+// (because the first write already moved it) reports RowsAffected==0 via the bool,
+// rather than silently clobbering the winner the way the old unconditional Save did.
+func TestUpdateProjectInvitation_ConditionalOnPending_Sequential(t *testing.T) {
+	ctx := context.Background()
+	ls := newInviteStore(t)
+	now := time.Date(2026, 6, 5, 9, 0, 0, 0, time.UTC)
+
+	created, err := ls.CreateProjectInvitation(ctx, &models.ProjectInvitation{
+		ProjectID: 1, Email: "a@b.com", Role: "project_developer", State: "pending", CreatedAt: now,
+	})
+	require.NoError(t, err)
+
+	// The "revoke" read-mutate-write.
+	revokeCopy, err := ls.GetProjectInvitation(ctx, created.ID)
+	require.NoError(t, err)
+	revokeCopy.State = "revoked"
+
+	// The "accept" read-mutate-write, reading the SAME still-pending row before
+	// either write lands (the TOCTOU window #412 closes).
+	acceptCopy, err := ls.GetProjectInvitation(ctx, created.ID)
+	require.NoError(t, err)
+	acceptCopy.State = "accepted"
+
+	// Revoke lands first and wins.
+	ok, err := ls.UpdateProjectInvitation(ctx, revokeCopy)
+	require.NoError(t, err)
+	require.True(t, ok, "the first writer (revoke) must win")
+
+	// Accept's write, against a row that is no longer pending, must be rejected —
+	// not silently applied over the revoke.
+	ok, err = ls.UpdateProjectInvitation(ctx, acceptCopy)
+	require.NoError(t, err)
+	require.False(t, ok, "the second writer (accept) must lose, not clobber the revoke")
+
+	final, err := ls.GetProjectInvitation(ctx, created.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "revoked", final.State, "the winning revoke must be the persisted state")
+}
+
+// TestUpdateAccessRequest_ConditionalOnPending_Sequential is the access-request
+// analogue (#277): a second write against a row no longer "pending" is rejected,
+// not silently applied over the winner.
+func TestUpdateAccessRequest_ConditionalOnPending_Sequential(t *testing.T) {
+	ctx := context.Background()
+	ls := newInviteStore(t)
+	now := time.Date(2026, 6, 5, 9, 0, 0, 0, time.UTC)
+
+	created, err := ls.CreateAccessRequest(ctx, &models.AccessRequest{
+		ProjectID: 1, UserID: 2, SuggestedRole: "project_viewer", State: "pending", CreatedAt: now,
+	})
+	require.NoError(t, err)
+
+	approveCopy, err := ls.GetAccessRequest(ctx, created.ID)
+	require.NoError(t, err)
+	approveCopy.State = "approved"
+	approveCopy.GrantedRole = "project_viewer"
+
+	withdrawCopy, err := ls.GetAccessRequest(ctx, created.ID)
+	require.NoError(t, err)
+	withdrawCopy.State = "withdrawn"
+
+	ok, err := ls.UpdateAccessRequest(ctx, approveCopy)
+	require.NoError(t, err)
+	require.True(t, ok, "the first writer (approve) must win")
+
+	ok, err = ls.UpdateAccessRequest(ctx, withdrawCopy)
+	require.NoError(t, err)
+	require.False(t, ok, "the second writer (withdraw) must lose, not clobber the approval")
+
+	final, err := ls.GetAccessRequest(ctx, created.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "approved", final.State, "the winning approval must be the persisted state")
 }

--- a/internal/storage/store/local_invitations.go
+++ b/internal/storage/store/local_invitations.go
@@ -12,6 +12,19 @@ import (
 	"gorm.io/gorm/clause"
 )
 
+// invitationStatePending / accessRequestStatePending mirror the "pending" state
+// literal from internal/core (invitations.go's InvitationPending /
+// AccessRequestPending). Duplicated here rather than imported — storage must not
+// depend on core — matching the existing accessReviewCampaignOpen /
+// accessReviewItemPending convention in local_access_review_campaigns.go. Every
+// mutation of a ProjectInvitation or AccessRequest transitions FROM pending (see
+// invitations.go), so gating the write on the persisted row still being pending is
+// sufficient to guard every transition, not just a specific one.
+const (
+	invitationStatePending    = "pending"
+	accessRequestStatePending = "pending"
+)
+
 // --- Project invitations ---
 
 func (ls *LocalStorage) CreateProjectInvitation(ctx context.Context, inv *models.ProjectInvitation) (*models.ProjectInvitation, error) {
@@ -29,11 +42,25 @@ func (ls *LocalStorage) GetProjectInvitation(ctx context.Context, id uint) (*mod
 	return &inv, nil
 }
 
-func (ls *LocalStorage) UpdateProjectInvitation(ctx context.Context, inv *models.ProjectInvitation) error {
-	if err := ls.db.WithContext(ctx).Save(inv).Error; err != nil {
-		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+// UpdateProjectInvitation persists an invitation state transition with a
+// conditional UPDATE (`WHERE id = ? AND state = 'pending'`), not the prior
+// unconditional Save (#412). A bare Save let an admin's RevokeInvitation and a
+// concurrent holder's completeInvitationAccept race: both read the same pending
+// row, both mutated it in memory, and whichever Save landed second silently
+// clobbered the other's transition — an admin's revoke could be undone by an
+// in-flight accept, or vice versa, with no error on either side. Gating the write
+// on the row's CURRENT persisted state still being pending closes that: whichever
+// write lands first wins (RowsAffected==1); the loser's UPDATE matches zero rows
+// and is told so via the bool, instead of silently overwriting the winner.
+func (ls *LocalStorage) UpdateProjectInvitation(ctx context.Context, inv *models.ProjectInvitation) (bool, error) {
+	res := ls.db.WithContext(ctx).Model(&models.ProjectInvitation{}).
+		Where("id = ? AND state = ?", inv.ID, invitationStatePending).
+		Select("*").
+		Updates(inv)
+	if res.Error != nil {
+		return false, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), res.Error)
 	}
-	return nil
+	return res.RowsAffected == 1, nil
 }
 
 func (ls *LocalStorage) ListProjectInvitations(ctx context.Context, projectID uint) ([]*models.ProjectInvitation, error) {
@@ -65,11 +92,28 @@ func (ls *LocalStorage) GetAccessRequest(ctx context.Context, id uint) (*models.
 	return &req, nil
 }
 
-func (ls *LocalStorage) UpdateAccessRequest(ctx context.Context, req *models.AccessRequest) error {
-	if err := ls.db.WithContext(ctx).Save(req).Error; err != nil {
-		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+// UpdateAccessRequest persists an access-request state transition with a
+// conditional UPDATE (`WHERE id = ? AND state = 'pending'`), not the prior
+// unconditional Save (#277). ApproveAccessRequestWithExpiry grants the role BEFORE
+// this write lands, so a bare Save racing WithdrawAccessRequest's (or
+// RejectAccessRequest's) own read-mutate-Save on the same row let either
+// transition silently clobber the other: a withdrawal could land after an
+// approval's grant, leaving state=withdrawn (or vice versa, state=approved) with
+// no indication anything raced — and, in the approval case, a live role grant
+// behind a request that no longer reads as approved. Gating the write on the row's
+// CURRENT persisted state still being pending closes that: whichever write lands
+// first wins (RowsAffected==1); the loser's UPDATE matches zero rows and is told
+// so via the bool, so it can react (e.g. revoke the grant it just made) instead of
+// silently overwriting the winner.
+func (ls *LocalStorage) UpdateAccessRequest(ctx context.Context, req *models.AccessRequest) (bool, error) {
+	res := ls.db.WithContext(ctx).Model(&models.AccessRequest{}).
+		Where("id = ? AND state = ?", req.ID, accessRequestStatePending).
+		Select("*").
+		Updates(req)
+	if res.Error != nil {
+		return false, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), res.Error)
 	}
-	return nil
+	return res.RowsAffected == 1, nil
 }
 
 func (ls *LocalStorage) ListAccessRequests(ctx context.Context, projectID uint) ([]*models.AccessRequest, error) {

--- a/internal/storage/store/remote_invitations.go
+++ b/internal/storage/store/remote_invitations.go
@@ -18,8 +18,8 @@ func (rs *RemoteStorage) GetProjectInvitation(_ context.Context, _ uint) (*model
 	return nil, remoteUnsupported("GetProjectInvitation")
 }
 
-func (rs *RemoteStorage) UpdateProjectInvitation(_ context.Context, _ *models.ProjectInvitation) error {
-	return remoteUnsupported("UpdateProjectInvitation")
+func (rs *RemoteStorage) UpdateProjectInvitation(_ context.Context, _ *models.ProjectInvitation) (bool, error) {
+	return false, remoteUnsupported("UpdateProjectInvitation")
 }
 
 func (rs *RemoteStorage) ListProjectInvitations(_ context.Context, _ uint) ([]*models.ProjectInvitation, error) {
@@ -34,8 +34,8 @@ func (rs *RemoteStorage) GetAccessRequest(_ context.Context, _ uint) (*models.Ac
 	return nil, remoteUnsupported("GetAccessRequest")
 }
 
-func (rs *RemoteStorage) UpdateAccessRequest(_ context.Context, _ *models.AccessRequest) error {
-	return remoteUnsupported("UpdateAccessRequest")
+func (rs *RemoteStorage) UpdateAccessRequest(_ context.Context, _ *models.AccessRequest) (bool, error) {
+	return false, remoteUnsupported("UpdateAccessRequest")
 }
 
 func (rs *RemoteStorage) ListAccessRequests(_ context.Context, _ uint) ([]*models.AccessRequest, error) {


### PR DESCRIPTION
## Summary
- `UpdateProjectInvitation`/`UpdateAccessRequest` were a bare read-mutate-`Save` with no `WHERE state=...` guard, letting an admin's revoke/reject/withdraw race a concurrent accept/approval — whichever write landed second silently clobbered the other with no error on either side.
- Since the accept/approval path grants the role **before** persisting the terminal state, losing this race could leave a live role grant behind an invitation/request that no longer reads as accepted.
- Both storage methods now do a conditional `UPDATE ... WHERE id = ? AND state = 'pending'` and report whether the row matched via a bool (mirroring the existing `MarkSetupTokenConsumed` pattern). Every caller that loses the race now gets a clear error; the two callers that grant before writing (`completeInvitationAccept`, `ApproveAccessRequestWithExpiry`) additionally revert the grant just made when they lose.

## Test plan
- [x] New empirical concurrent-goroutine regression test against real file-backed SQLite (`TestConcurrency_RevokeInvitation_RacesAccept`), run 4x with `-count=1` to confirm determinism
- [x] Two new sequential-conflict unit tests at the storage layer proving the conditional-update guard itself
- [x] `go build ./...`, `go vet ./...`
- [x] `go test ./internal/core/... ./internal/storage/...` — all pass
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)