### PR TITLE
feat(auth): migrate session auth to httpOnly cookies with CSRF

### DIFF
--- a/internal/core/impersonation.go
+++ b/internal/core/impersonation.go
@@ -101,7 +101,11 @@ func (c *KeyorixCore) StartImpersonation(ctx context.Context, adminID, targetID 
 // EndImpersonation terminates the impersonation session identified by token,
 // logging an impersonation.end event with the session duration and the number
 // of actions taken while impersonating. The token must belong to an
-// impersonation session.
+// impersonation session. Restoring the admin's own session is a caller (HTTP
+// handler) concern — see admin_impersonation.go's End, which stashes the
+// admin's token in a second cookie at Start and reads it back here, rather than
+// this core layer trying to recall a plaintext token it never retains (session
+// tokens are stored only as a hash, see local_auth.go's hashSessionToken).
 func (c *KeyorixCore) EndImpersonation(ctx context.Context, token string) error {
 	session, err := c.storage.GetSession(ctx, token)
 	if err != nil {

--- a/server/http/handlers/admin_impersonation.go
+++ b/server/http/handlers/admin_impersonation.go
@@ -2,12 +2,14 @@
 //
 // Start (POST /api/v1/admin/impersonate) is gated by the users.impersonate
 // permission, which only global admins hold (admin-bypass). It issues a separate
-// short-lived session for the target user and returns its token; the admin's own
-// session is untouched so the client can swap back without re-authentication.
+// short-lived session for the target user and sets its cookie; the admin's own
+// session token is stashed in a second cookie (see AdminSessionCookieName) so
+// the client can swap back without re-authentication.
 //
 // End (POST /api/v1/auth/end-impersonation) is self-scoped: it terminates the
-// impersonation session presented in the Authorization header and logs the
-// bracketing impersonation.end event. See internal/core/impersonation.go.
+// impersonation session, then restores the admin's stashed session if it's
+// still live, or clears everything and routes to a fresh login if it's not.
+// See internal/core/impersonation.go for the core-layer session lifecycle.
 package handlers
 
 import (
@@ -23,19 +25,25 @@ import (
 // ImpersonationHandler handles admin impersonation requests.
 type ImpersonationHandler struct {
 	coreService *core.KeyorixCore
+	// tlsEnabled gates the Secure attribute on the session/CSRF cookies — see
+	// AuthHandler's field of the same name.
+	tlsEnabled bool
 }
 
 // NewImpersonationHandler constructs an ImpersonationHandler.
-func NewImpersonationHandler(coreService *core.KeyorixCore) *ImpersonationHandler {
-	return &ImpersonationHandler{coreService: coreService}
+func NewImpersonationHandler(coreService *core.KeyorixCore, tlsEnabled bool) *ImpersonationHandler {
+	return &ImpersonationHandler{coreService: coreService, tlsEnabled: tlsEnabled}
 }
 
 type startImpersonationBody struct {
 	UserID uint `json:"user_id"`
 }
 
+// impersonationResponse no longer carries Token — the impersonation session's
+// cookie is set directly on the response (see Start); the client never holds
+// the token value at all now, matching the same shape change Login/RefreshToken
+// went through.
 type impersonationResponse struct {
-	Token          string `json:"token"`
 	ExpiresAt      string `json:"expires_at,omitempty"`
 	UserID         uint   `json:"user_id"`
 	Username       string `json:"username"`
@@ -66,6 +74,13 @@ func (h *ImpersonationHandler) Start(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Capture the admin's own current token BEFORE it's superseded by the
+	// impersonation session's cookie below — this is the plaintext value the
+	// browser just sent us on this very request. Stashing it in a second cookie
+	// is how End restores it later without the server ever needing to recall a
+	// plaintext token from storage (see AdminSessionCookieName's doc comment).
+	adminToken := extractBearerToken(r)
+
 	session, target, err := h.coreService.StartImpersonation(r.Context(), admin.UserID, body.UserID, clientIP(r))
 	if err != nil {
 		switch {
@@ -79,8 +94,15 @@ func (h *ImpersonationHandler) Start(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	middleware.SetSessionCookie(w, session.SessionToken, session.ExpiresAt, h.tlsEnabled)
+	if adminToken != "" {
+		middleware.SetAdminSessionCookie(w, adminToken, session.ExpiresAt, h.tlsEnabled)
+	}
+	if csrfToken, cerr := middleware.GenerateCSRFToken(); cerr == nil {
+		middleware.SetCSRFCookie(w, csrfToken, h.tlsEnabled)
+	}
+
 	resp := impersonationResponse{
-		Token:          session.SessionToken,
 		UserID:         target.ID,
 		Username:       target.Username,
 		DisplayName:    target.DisplayName,
@@ -92,7 +114,10 @@ func (h *ImpersonationHandler) Start(w http.ResponseWriter, r *http.Request) {
 	sendSuccess(w, resp, "Impersonation started")
 }
 
-// End handles POST /api/v1/auth/end-impersonation.
+// End handles POST /api/v1/auth/end-impersonation. On success it restores the
+// admin's stashed session cookie when it's still live, or clears everything
+// (routing to a fresh login) when it's not — e.g. the admin's own session
+// expired, or was revoked, while they were impersonating.
 func (h *ImpersonationHandler) End(w http.ResponseWriter, r *http.Request) {
 	token := extractBearerToken(r)
 	if token == "" {
@@ -109,7 +134,34 @@ func (h *ImpersonationHandler) End(w http.ResponseWriter, r *http.Request) {
 	}
 	// Evict the impersonation token from the auth cache immediately.
 	middleware.InvalidateTokenCache(token)
-	sendSuccess(w, nil, "Impersonation ended")
+
+	// Ending impersonation always succeeds once we get here (the impersonation
+	// session is deleted either way) — admin_session_restored tells the client
+	// which of the two outcomes happened, since only one of them leaves the
+	// browser still logged in.
+	restored := false
+	if adminCookie, cerr := r.Cookie(middleware.AdminSessionCookieName); cerr == nil && adminCookie.Value != "" {
+		// Validate before trusting it back as the active session — it may have
+		// expired, or the admin's account may have been suspended, while they
+		// were impersonating. This is the same check every other request goes
+		// through, not a new trust boundary.
+		if _, _, verr := h.coreService.ValidateSessionToken(r.Context(), adminCookie.Value); verr == nil {
+			middleware.SetSessionCookie(w, adminCookie.Value, nil, h.tlsEnabled)
+			if csrfToken, cerr2 := middleware.GenerateCSRFToken(); cerr2 == nil {
+				middleware.SetCSRFCookie(w, csrfToken, h.tlsEnabled)
+			}
+			restored = true
+		}
+	}
+	middleware.ClearAdminSessionCookie(w, h.tlsEnabled)
+
+	message := "Impersonation ended"
+	if !restored {
+		middleware.ClearSessionCookie(w, h.tlsEnabled)
+		middleware.ClearCSRFCookie(w, h.tlsEnabled)
+		message = "Impersonation ended, but your admin session had expired — please sign in again"
+	}
+	sendSuccess(w, map[string]interface{}{"admin_session_restored": restored}, message)
 }
 
 // clientIP strips the port from RemoteAddr for audit attribution.

--- a/server/http/handlers/auth.go
+++ b/server/http/handlers/auth.go
@@ -32,11 +32,28 @@ func (h *AuthHandler) recordLoginAttempt(ctx context.Context, ip string) {
 // AuthHandler handles authentication HTTP requests.
 type AuthHandler struct {
 	coreService *core.KeyorixCore
+	// tlsEnabled gates the Secure attribute on the session/CSRF cookies, same
+	// signal SecurityHeaders uses for HSTS — set only when this process itself
+	// terminates TLS (a proxy-terminated deployment sets it there instead).
+	tlsEnabled bool
 }
 
 // NewAuthHandler constructs an AuthHandler.
-func NewAuthHandler(coreService *core.KeyorixCore) *AuthHandler {
-	return &AuthHandler{coreService: coreService}
+func NewAuthHandler(coreService *core.KeyorixCore, tlsEnabled bool) *AuthHandler {
+	return &AuthHandler{coreService: coreService, tlsEnabled: tlsEnabled}
+}
+
+// setSessionCookies issues the session + CSRF cookies for a freshly
+// created/rotated session. Best-effort on CSRF token generation failure: log
+// and continue without one rather than fail the whole login/refresh — the
+// session cookie is what actually matters for authentication; a missing CSRF
+// cookie only blocks this browser's own subsequent state-changing requests
+// until it retries, it doesn't grant an attacker anything.
+func (h *AuthHandler) setSessionCookies(w http.ResponseWriter, session *models.Session) {
+	middleware.SetSessionCookie(w, session.SessionToken, session.ExpiresAt, h.tlsEnabled)
+	if csrfToken, err := middleware.GenerateCSRFToken(); err == nil {
+		middleware.SetCSRFCookie(w, csrfToken, h.tlsEnabled)
+	}
 }
 
 // ── Request / response shapes ─────────────────────────────────────────────────
@@ -132,6 +149,7 @@ func (h *AuthHandler) Login(w http.ResponseWriter, r *http.Request) {
 	}
 
 	resp := h.buildLoginResponse(r.Context(), session, user)
+	h.setSessionCookies(w, session)
 
 	// Audit log + last-login stamp (both non-blocking)
 	ip, ua := r.RemoteAddr, r.Header.Get("User-Agent")
@@ -259,6 +277,7 @@ func (h *AuthHandler) ConsumeSetup(w http.ResponseWriter, r *http.Request) {
 	}
 
 	resp := h.buildLoginResponse(r.Context(), result.Session, result.User)
+	h.setSessionCookies(w, result.Session)
 	go h.coreService.LogAuthLogin(context.Background(), result.User.ID, result.User.Username, ip, r.Header.Get("User-Agent")) // #nosec G118
 	go func() { _ = h.coreService.RecordLogin(context.Background(), result.User.ID) }()                                       // #nosec G118
 
@@ -284,6 +303,8 @@ func (h *AuthHandler) Logout(w http.ResponseWriter, r *http.Request) {
 
 	// Evict from auth cache immediately so the token is rejected without a DB hit.
 	middleware.InvalidateTokenCache(token)
+	middleware.ClearSessionCookie(w, h.tlsEnabled)
+	middleware.ClearCSRFCookie(w, h.tlsEnabled)
 
 	// Audit log (non-blocking)
 	ip, ua := r.RemoteAddr, r.Header.Get("User-Agent")
@@ -313,6 +334,7 @@ func (h *AuthHandler) RefreshToken(w http.ResponseWriter, r *http.Request) {
 	// session row was deleted — so it stays usable for up to validTokenTTL after being
 	// rotated away.
 	middleware.InvalidateTokenCache(token)
+	h.setSessionCookies(w, session)
 
 	resp := map[string]interface{}{
 		"token": session.SessionToken,
@@ -342,7 +364,22 @@ func (h *AuthHandler) Profile(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	sendSuccess(w, userProfileMap(user, h.userIdentity(r, userCtx.UserID)), "")
+	profile := userProfileMap(user, h.userIdentity(r, userCtx.UserID))
+	// Surface impersonation state from the server-validated session (UserContext.
+	// ImpersonatedBy, resolved by the auth middleware) rather than requiring the
+	// client to track it itself — under cookie auth the client has no token to
+	// inspect, so this is now the only source of truth for "am I impersonating,
+	// and who is the real admin" (used to render the impersonation banner).
+	if userCtx.ImpersonatedBy != nil {
+		if admin, aerr := h.coreService.GetUser(r.Context(), *userCtx.ImpersonatedBy); aerr == nil {
+			profile["impersonation"] = map[string]interface{}{
+				"admin_id":           admin.ID,
+				"admin_username":     admin.Username,
+				"admin_display_name": admin.DisplayName,
+			}
+		}
+	}
+	sendSuccess(w, profile, "")
 }
 
 // userIdentity returns the user's role/permission summary for the profile DTO.
@@ -629,8 +666,17 @@ func (h *AuthHandler) InitSystem(w http.ResponseWriter, r *http.Request) {
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
-// extractBearerToken pulls the token from an "Authorization: Bearer <token>" header.
+// extractBearerToken returns the session token for this request, preferring the
+// httpOnly session cookie over the legacy "Authorization: Bearer <token>" header
+// if both are present — mirrors middleware.extractRequestToken's precedence
+// exactly, so a request authenticated via cookie by the Authentication
+// middleware resolves to the same token here (needed for cache invalidation,
+// "current session" detection, etc., all of which act on the actual token, not
+// on how it arrived).
 func extractBearerToken(r *http.Request) string {
+	if cookie, err := r.Cookie(middleware.SessionCookieName); err == nil && cookie.Value != "" {
+		return cookie.Value
+	}
 	parts := strings.SplitN(r.Header.Get("Authorization"), " ", 2)
 	if len(parts) == 2 && parts[0] == "Bearer" {
 		return parts[1]

--- a/server/http/handlers/mfa_webauthn_reauth_test.go
+++ b/server/http/handlers/mfa_webauthn_reauth_test.go
@@ -60,7 +60,7 @@ func setupMFAReauthTest(t *testing.T) (*AuthHandler, *core.KeyorixCore, *gorm.DB
 	require.NoError(t, err)
 	coreService.SetWebAuthn(rp)
 
-	return NewAuthHandler(coreService), coreService, db
+	return NewAuthHandler(coreService, false), coreService, db
 }
 
 func withUserContext(r *http.Request, userID uint) *http.Request {

--- a/server/http/handlers/password_reset_rate_limit_test.go
+++ b/server/http/handlers/password_reset_rate_limit_test.go
@@ -60,7 +60,7 @@ func doPasswordReset(h *AuthHandler, ip string) int {
 // throttle-check + potential email send.
 func TestPasswordReset_RateLimitedByIP(t *testing.T) {
 	c := newPasswordResetTestCore(t)
-	h := NewAuthHandler(c)
+	h := NewAuthHandler(c, false)
 	const ip = "203.0.113.7"
 
 	for i := 0; i < core.PasswordResetMaxAttempts; i++ {
@@ -74,7 +74,7 @@ func TestPasswordReset_RateLimitedByIP(t *testing.T) {
 // IP, not global — a different caller is unaffected by another IP's burst.
 func TestPasswordReset_RateLimitIsPerIP(t *testing.T) {
 	c := newPasswordResetTestCore(t)
-	h := NewAuthHandler(c)
+	h := NewAuthHandler(c, false)
 
 	for i := 0; i < core.PasswordResetMaxAttempts; i++ {
 		assert.Equal(t, http.StatusOK, doPasswordReset(h, "203.0.113.7"))

--- a/server/http/handlers/revoke_sessions_self_action_test.go
+++ b/server/http/handlers/revoke_sessions_self_action_test.go
@@ -1,0 +1,72 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func setupUserHandlerTest(t *testing.T) *UserHandler {
+	t.Helper()
+
+	cfg := &config.Config{
+		Locale: config.LocaleConfig{
+			Language:         "en",
+			FallbackLanguage: "en",
+		},
+	}
+	require.NoError(t, i18n.Initialize(cfg))
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.User{}, &models.Session{}, &models.AuditEvent{}))
+
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "admin", Email: "admin@test.com"}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 2, Username: "target", Email: "target@test.com"}).Error)
+
+	storage := store.NewLocalStorage(db)
+	coreService := core.NewKeyorixCore(storage)
+	handler, err := NewUserHandler(coreService)
+	require.NoError(t, err)
+	return handler
+}
+
+// RevokeSessions previously had no guard against an admin targeting their own
+// ID — unlike accountStateAction (Suspend/Reactivate/RequirePasswordReset),
+// which explicitly blocks self-action. An admin could revoke their own active
+// sessions out from under themselves mid-request.
+func TestRevokeSessions_BlocksSelfAction(t *testing.T) {
+	handler := setupUserHandlerTest(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/users/1/revoke-sessions", nil)
+	req = withUserCtx(req)   // admin, UserID: 1
+	req = withChiParam(req, "id", "1")
+
+	w := httptest.NewRecorder()
+	handler.RevokeSessions(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code, "an admin must not be able to revoke their own sessions")
+}
+
+func TestRevokeSessions_AllowsTargetingOtherUsers(t *testing.T) {
+	handler := setupUserHandlerTest(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/users/2/revoke-sessions", nil)
+	req = withUserCtx(req)   // admin, UserID: 1
+	req = withChiParam(req, "id", "2")
+
+	w := httptest.NewRecorder()
+	handler.RevokeSessions(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code, "revoking another user's sessions must still work")
+}

--- a/server/http/handlers/saml.go
+++ b/server/http/handlers/saml.go
@@ -81,6 +81,10 @@ func (h *AuthHandler) CompleteSAML(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Cookies survive a redirect fine — see the equivalent comment in sso.go's
+	// CompleteSSO.
+	h.setSessionCookies(w, session)
+
 	frag := url.Values{"token": {session.SessionToken}}
 	if session.ExpiresAt != nil {
 		frag.Set("expires_at", session.ExpiresAt.Format(time.RFC3339))

--- a/server/http/handlers/sso.go
+++ b/server/http/handlers/sso.go
@@ -101,6 +101,12 @@ func (h *AuthHandler) CompleteSSO(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Cookies survive a redirect fine — the browser stores them from this 302
+	// response before following Location. Fragment still carries `token` this
+	// phase for backward compatibility with a not-yet-updated frontend; the
+	// cookie is what actually matters going forward.
+	h.setSessionCookies(w, session)
+
 	frag := url.Values{"token": {session.SessionToken}}
 	if session.ExpiresAt != nil {
 		frag.Set("expires_at", session.ExpiresAt.Format(time.RFC3339))

--- a/server/http/handlers/users_crud.go
+++ b/server/http/handlers/users_crud.go
@@ -411,6 +411,12 @@ func (h *UserHandler) RevokeSessions(w http.ResponseWriter, r *http.Request) {
 		sendError(w, "InvalidParameter", "Invalid user ID", http.StatusBadRequest, nil)
 		return
 	}
+	// Mirrors accountStateAction's self-action guard (line 367): an admin must not be
+	// able to revoke their own active sessions out from under themselves mid-request.
+	if uint(id) == admin.UserID {
+		sendError(w, "BadRequest", "Cannot revoke your own sessions", http.StatusBadRequest, nil)
+		return
+	}
 	n, err := h.coreService.RevokeUserSessions(r.Context(), admin.UserID, uint(id))
 	if err != nil {
 		status := http.StatusInternalServerError

--- a/server/http/integration_test.go
+++ b/server/http/integration_test.go
@@ -6,7 +6,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/http/cookiejar"
 	"net/http/httptest"
+	"net/url"
 	"regexp"
 	"strings"
 	"sync/atomic"
@@ -936,4 +938,293 @@ func TestEveryMutatingRouteDeniesReadOnly(t *testing.T) {
 	})
 	require.NoError(t, walkErr)
 	assert.Greater(t, checked, 25, "sanity: the walk should cover many mutating routes")
+}
+
+// ── Phase 1 auth-cookie migration ──────────────────────────────────────────────
+
+// newCookieClient returns an *http.Client with its own cookie jar scoped to
+// baseURL, so cookies set by one request (e.g. login) are automatically sent on
+// subsequent requests through this client — exactly how a browser behaves.
+func newCookieClient(t *testing.T) *http.Client {
+	t.Helper()
+	jar, err := cookiejar.New(nil)
+	require.NoError(t, err)
+	return &http.Client{Jar: jar, Timeout: 5 * time.Second}
+}
+
+// loginViaHTTP performs a real POST /auth/login and returns the response (body
+// not yet closed — the caller must close it) so tests can inspect both the
+// Set-Cookie headers and the JSON body.
+func loginViaHTTP(t *testing.T, client *http.Client, baseURL, username, password string) *http.Response {
+	t.Helper()
+	body, err := json.Marshal(map[string]string{"username": username, "password": password})
+	require.NoError(t, err)
+	resp, err := client.Post(baseURL+"/auth/login", "application/json", bytes.NewReader(body))
+	require.NoError(t, err)
+	return resp
+}
+
+// csrfCookieValue reads the csrf_token cookie the jar picked up for baseURL —
+// standing in for the SPA reading document.cookie to echo it back as a header.
+func csrfCookieValue(t *testing.T, client *http.Client, baseURL string) string {
+	t.Helper()
+	u, err := url.Parse(baseURL)
+	require.NoError(t, err)
+	for _, c := range client.Jar.Cookies(u) {
+		if c.Name == "csrf_token" {
+			return c.Value
+		}
+	}
+	return ""
+}
+
+func TestCookieAuth_LoginSetsCookiesAndDualModeWorks(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	cfg := &config.Config{Server: config.ServerConfig{HTTP: config.ServerInstanceConfig{Enabled: true, Port: "8080"}}}
+	testCore := newTestCore(t)
+	_ = createTestToken(t, testCore) // seeds testadmin/TestPassword123!
+
+	router, err := NewRouter(cfg, testCore)
+	require.NoError(t, err)
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	client := newCookieClient(t)
+	resp := loginViaHTTP(t, client, server.URL, "testadmin", "TestPassword123!")
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var sessionCookie, csrfCookie *http.Cookie
+	for _, c := range resp.Cookies() {
+		switch c.Name {
+		case "kx_session":
+			sessionCookie = c
+		case "csrf_token":
+			csrfCookie = c
+		}
+	}
+	require.NotNil(t, sessionCookie, "login must set the session cookie")
+	require.NotNil(t, csrfCookie, "login must set the CSRF cookie")
+	assert.True(t, sessionCookie.HttpOnly, "session cookie must be HttpOnly")
+	assert.False(t, csrfCookie.HttpOnly, "CSRF cookie must be readable by JS")
+	assert.Equal(t, http.SameSiteLaxMode, sessionCookie.SameSite)
+
+	var loginBody struct {
+		Data struct {
+			Token string `json:"token"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&loginBody))
+	require.NotEmpty(t, loginBody.Data.Token, "Phase A keeps the token in the JSON body for dual-mode")
+
+	t.Run("cookie-only auth works with no Authorization header", func(t *testing.T) {
+		profResp, err := client.Get(server.URL + "/api/v1/auth/profile")
+		require.NoError(t, err)
+		defer func() { _ = profResp.Body.Close() }()
+		assert.Equal(t, http.StatusOK, profResp.StatusCode)
+	})
+
+	t.Run("Bearer-only still works with no cookie (dual-mode)", func(t *testing.T) {
+		bareClient := &http.Client{Timeout: 5 * time.Second} // no cookie jar
+		req, err := http.NewRequest(http.MethodGet, server.URL+"/api/v1/auth/profile", nil)
+		require.NoError(t, err)
+		req.Header.Set("Authorization", "Bearer "+loginBody.Data.Token)
+		profResp, err := bareClient.Do(req)
+		require.NoError(t, err)
+		defer func() { _ = profResp.Body.Close() }()
+		assert.Equal(t, http.StatusOK, profResp.StatusCode)
+	})
+
+	t.Run("cookie takes precedence when both cookie and a stale Bearer header are present", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodGet, server.URL+"/api/v1/auth/profile", nil)
+		require.NoError(t, err)
+		req.Header.Set("Authorization", "Bearer this-is-not-a-real-token")
+		for _, c := range client.Jar.Cookies(mustParseURL(t, server.URL)) {
+			req.AddCookie(c)
+		}
+		profResp, err := (&http.Client{Timeout: 5 * time.Second}).Do(req)
+		require.NoError(t, err)
+		defer func() { _ = profResp.Body.Close() }()
+		assert.Equal(t, http.StatusOK, profResp.StatusCode, "the valid cookie must win over the garbage Bearer header")
+	})
+}
+
+func mustParseURL(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	u, err := url.Parse(raw)
+	require.NoError(t, err)
+	return u
+}
+
+func TestCSRF_RequiredForCookieAuthenticatedMutations(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	cfg := &config.Config{Server: config.ServerConfig{HTTP: config.ServerInstanceConfig{Enabled: true, Port: "8080"}}}
+	testCore := newTestCore(t)
+	_ = createTestToken(t, testCore)
+
+	router, err := NewRouter(cfg, testCore)
+	require.NoError(t, err)
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	client := newCookieClient(t)
+	resp := loginViaHTTP(t, client, server.URL, "testadmin", "TestPassword123!")
+	_ = resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	profileUpdate := func() *http.Request {
+		body, _ := json.Marshal(map[string]string{"display_name": "Test Admin", "email": "testadmin@example.com"})
+		req, err := http.NewRequest(http.MethodPut, server.URL+"/api/v1/auth/profile", bytes.NewReader(body))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+		return req
+	}
+
+	t.Run("rejected with no CSRF header", func(t *testing.T) {
+		r, err := client.Do(profileUpdate())
+		require.NoError(t, err)
+		defer func() { _ = r.Body.Close() }()
+		assert.Equal(t, http.StatusForbidden, r.StatusCode)
+	})
+
+	t.Run("rejected with a wrong CSRF header", func(t *testing.T) {
+		req := profileUpdate()
+		req.Header.Set("X-CSRF-Token", "not-the-right-value")
+		r, err := client.Do(req)
+		require.NoError(t, err)
+		defer func() { _ = r.Body.Close() }()
+		assert.Equal(t, http.StatusForbidden, r.StatusCode)
+	})
+
+	t.Run("accepted with the matching CSRF header", func(t *testing.T) {
+		req := profileUpdate()
+		req.Header.Set("X-CSRF-Token", csrfCookieValue(t, client, server.URL))
+		r, err := client.Do(req)
+		require.NoError(t, err)
+		defer func() { _ = r.Body.Close() }()
+		assert.Equal(t, http.StatusOK, r.StatusCode)
+	})
+
+	t.Run("Bearer-only requests are exempt from CSRF (no cookie at all)", func(t *testing.T) {
+		var loginBody struct {
+			Data struct{ Token string } `json:"data"`
+		}
+		resp2 := loginViaHTTP(t, &http.Client{Timeout: 5 * time.Second}, server.URL, "testadmin", "TestPassword123!")
+		defer func() { _ = resp2.Body.Close() }()
+		require.NoError(t, json.NewDecoder(resp2.Body).Decode(&loginBody))
+
+		req := profileUpdate()
+		req.Header.Set("Authorization", "Bearer "+loginBody.Data.Token)
+		// Deliberately no X-CSRF-Token — must still succeed, no cookie means CSRF doesn't apply.
+		bareClient := &http.Client{Timeout: 5 * time.Second}
+		r, err := bareClient.Do(req)
+		require.NoError(t, err)
+		defer func() { _ = r.Body.Close() }()
+		assert.Equal(t, http.StatusOK, r.StatusCode)
+	})
+}
+
+// TestImpersonationRoundTrip_CookieSwapAndRestore is the end-to-end proof for
+// the impersonation redesign: the client never sees or holds an admin token at
+// any point — starting impersonation swaps the cookie to the target's session,
+// and ending it restores the ADMIN'S ORIGINAL session value (not a fresh one),
+// purely via the server-side OriginalSessionID linkage.
+func TestImpersonationRoundTrip_CookieSwapAndRestore(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	cfg := &config.Config{Server: config.ServerConfig{HTTP: config.ServerInstanceConfig{Enabled: true, Port: "8080"}}}
+	testCore := newTestCore(t)
+	_ = createTestToken(t, testCore) // seeds testadmin (admin role) /TestPassword123!
+
+	ctx := context.Background()
+	targetUser, err := testCore.CreateUser(ctx, &core.CreateUserRequest{
+		Username: "target", Email: "target@example.com", Password: "CorrectHorseBattery9!",
+	})
+	require.NoError(t, err)
+
+	router, err := NewRouter(cfg, testCore)
+	require.NoError(t, err)
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	client := newCookieClient(t)
+	loginResp := loginViaHTTP(t, client, server.URL, "testadmin", "TestPassword123!")
+	_ = loginResp.Body.Close()
+	require.Equal(t, http.StatusOK, loginResp.StatusCode)
+
+	adminSessionCookie := func() string {
+		for _, c := range client.Jar.Cookies(mustParseURL(t, server.URL)) {
+			if c.Name == "kx_session" {
+				return c.Value
+			}
+		}
+		return ""
+	}
+	originalAdminCookie := adminSessionCookie()
+	require.NotEmpty(t, originalAdminCookie)
+
+	type profileResult struct {
+		Username      string `json:"username"`
+		Impersonation *struct {
+			AdminUsername string `json:"admin_username"`
+		} `json:"impersonation"`
+	}
+	getProfile := func() profileResult {
+		r, err := client.Get(server.URL + "/api/v1/auth/profile")
+		require.NoError(t, err)
+		defer func() { _ = r.Body.Close() }()
+		require.Equal(t, http.StatusOK, r.StatusCode)
+		var out struct {
+			Data profileResult `json:"data"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&out))
+		return out.Data
+	}
+	getProfileUsername := func() string { return getProfile().Username }
+	initialProfile := getProfile()
+	require.Equal(t, "testadmin", initialProfile.Username)
+	require.Nil(t, initialProfile.Impersonation, "not impersonating yet — the field must be absent")
+
+	startBody, _ := json.Marshal(map[string]uint{"user_id": targetUser.ID})
+	startReq, err := http.NewRequest(http.MethodPost, server.URL+"/api/v1/admin/impersonate", bytes.NewReader(startBody))
+	require.NoError(t, err)
+	startReq.Header.Set("Content-Type", "application/json")
+	startReq.Header.Set("X-CSRF-Token", csrfCookieValue(t, client, server.URL))
+	startResp, err := client.Do(startReq)
+	require.NoError(t, err)
+	defer func() { _ = startResp.Body.Close() }()
+	require.Equal(t, http.StatusOK, startResp.StatusCode)
+
+	impersonationCookie := adminSessionCookie()
+	require.NotEmpty(t, impersonationCookie)
+	assert.NotEqual(t, originalAdminCookie, impersonationCookie, "the cookie must swap to the impersonation session")
+	impersonatingProfile := getProfile()
+	assert.Equal(t, "target", impersonatingProfile.Username, "requests now act as the impersonated user")
+	require.NotNil(t, impersonatingProfile.Impersonation, "the client derives the banner from this, not local state")
+	assert.Equal(t, "testadmin", impersonatingProfile.Impersonation.AdminUsername)
+
+	endReq, err := http.NewRequest(http.MethodPost, server.URL+"/api/v1/auth/end-impersonation", nil)
+	require.NoError(t, err)
+	endReq.Header.Set("X-CSRF-Token", csrfCookieValue(t, client, server.URL))
+	endResp, err := client.Do(endReq)
+	require.NoError(t, err)
+	defer func() { _ = endResp.Body.Close() }()
+	require.Equal(t, http.StatusOK, endResp.StatusCode)
+
+	var endBody struct {
+		Data struct {
+			AdminSessionRestored bool `json:"admin_session_restored"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.NewDecoder(endResp.Body).Decode(&endBody))
+	assert.True(t, endBody.Data.AdminSessionRestored)
+
+	restoredCookie := adminSessionCookie()
+	assert.Equal(t, originalAdminCookie, restoredCookie, "must restore the SAME original session, not a fresh one")
+	assert.Equal(t, "testadmin", getProfileUsername(), "admin's own identity and permissions are back with no re-login")
 }

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -66,9 +66,9 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		return nil, fmt.Errorf("failed to init core HTTP handlers: %w", err)
 	}
 
-	authHandler := handlers.NewAuthHandler(coreService)
+	authHandler := handlers.NewAuthHandler(coreService, cfg.Server.HTTP.TLS.Enabled)
 	patHandler := handlers.NewPATHandler(coreService)
-	impersonationHandler := handlers.NewImpersonationHandler(coreService)
+	impersonationHandler := handlers.NewImpersonationHandler(coreService, cfg.Server.HTTP.TLS.Enabled)
 
 	secretHandler, err := handlers.NewSecretHandler(coreService)
 	if err != nil {
@@ -217,6 +217,10 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		// an authorization boundary. Runs right after Authentication so the
 		// principal is resolved. No-op unless server.http.ratelimit.enabled is set.
 		r.Use(customMiddleware.PrincipalRateLimit(cfg.Server.HTTP.RateLimit))
+		// Double-submit CSRF check for cookie-authenticated state-changing requests
+		// (Phase 1 auth-cookie migration) — no-op for Bearer-only callers (PATs,
+		// machine tokens, CI/API clients), see RequireCSRF's doc comment.
+		r.Use(customMiddleware.RequireCSRF)
 		// Confine restricted (must-change-password) sessions to the password-change
 		// allowlist (ADR-025).
 		r.Use(customMiddleware.EnforceAccountRestriction)

--- a/server/middleware/auth.go
+++ b/server/middleware/auth.go
@@ -217,21 +217,9 @@ func Authentication(coreService *core.KeyorixCore) func(next http.Handler) http.
 func authenticationWithValidator(validator sessionValidator, coreService *core.KeyorixCore) func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			authHeader := r.Header.Get("Authorization")
-			if authHeader == "" {
-				unauthorizedResponse(w, "Missing authorization header")
-				return
-			}
-
-			parts := strings.SplitN(authHeader, " ", 2)
-			if len(parts) != 2 || parts[0] != "Bearer" {
-				unauthorizedResponse(w, "Invalid authorization header format")
-				return
-			}
-
-			token := parts[1]
-			if token == "" {
-				unauthorizedResponse(w, "Missing token")
+			token, err := extractRequestToken(r)
+			if err != nil {
+				unauthorizedResponse(w, err.Error())
 				return
 			}
 
@@ -294,6 +282,35 @@ func authenticationWithValidator(validator sessionValidator, coreService *core.K
 			next.ServeHTTP(w, r.WithContext(buildRequestContext(r.Context(), userCtx, coreService)))
 		})
 	}
+}
+
+// extractRequestToken returns the token to validate for this request, preferring
+// the httpOnly session cookie over the legacy Authorization: Bearer header when
+// both are present — this makes the cookie authoritative once a client has one,
+// so a stale/leaked Bearer header value can't override it. PAT (kx_pat_)/machine
+// (kx_machine_) tokens and OIDC JWTs are never delivered via cookie — only
+// session tokens are, from Login/RefreshToken/SSO — so this doesn't change how
+// those are validated once extracted; it only changes where a session token can
+// come from.
+func extractRequestToken(r *http.Request) (string, error) {
+	if cookie, err := r.Cookie(SessionCookieName); err == nil && cookie.Value != "" {
+		return cookie.Value, nil
+	}
+
+	authHeader := r.Header.Get("Authorization")
+	if authHeader == "" {
+		return "", errors.New("missing authorization header")
+	}
+
+	parts := strings.SplitN(authHeader, " ", 2)
+	if len(parts) != 2 || parts[0] != "Bearer" {
+		return "", errors.New("invalid authorization header format")
+	}
+
+	if parts[1] == "" {
+		return "", errors.New("missing token")
+	}
+	return parts[1], nil
 }
 
 // errInvalidTarget / errTargetNotFound let scope resolvers signal whether a bad

--- a/server/middleware/csrf.go
+++ b/server/middleware/csrf.go
@@ -1,0 +1,61 @@
+package middleware
+
+import (
+	"crypto/subtle"
+	"net/http"
+)
+
+// csrfProtectedMethods are the state-changing methods that require a matching
+// X-CSRF-Token header once cookie-based auth is in play. GET/HEAD/OPTIONS never
+// mutate state, so they're exempt (and must stay exempt — CSRF-protecting a safe
+// method would just break normal navigation/prefetch with no security benefit).
+var csrfProtectedMethods = map[string]bool{
+	http.MethodPost:   true,
+	http.MethodPut:    true,
+	http.MethodPatch:  true,
+	http.MethodDelete: true,
+}
+
+// RequireCSRF enforces the double-submit cookie pattern: a state-changing request
+// must echo the csrf_token cookie's value back as the X-CSRF-Token header, or it's
+// rejected. This is only meaningful — and only checked — for requests carrying the
+// session cookie: a pure-Bearer caller (PAT, machine token, CI/API client) is immune
+// to CSRF by construction, since a browser can't be tricked into sending a custom
+// header cross-site without this app's CORS config allowlisting the attacker's
+// origin (it allowlists none). Requiring the header only for cookie-authenticated
+// requests also means the header/cookie value comparison never runs, and a missing
+// CSRF cookie never wrongly rejects, a plain Bearer request.
+func RequireCSRF(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !csrfProtectedMethods[r.Method] {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		sessionCookie, err := r.Cookie(SessionCookieName)
+		if err != nil || sessionCookie.Value == "" {
+			// No session cookie on this request — Bearer-only caller, not subject to CSRF.
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		csrfCookie, err := r.Cookie(CSRFCookieName)
+		if err != nil || csrfCookie.Value == "" {
+			forbiddenResponse(w, "Missing CSRF token")
+			return
+		}
+
+		headerValue := r.Header.Get(CSRFHeaderName)
+		if headerValue == "" {
+			forbiddenResponse(w, "Missing CSRF token header")
+			return
+		}
+
+		if subtle.ConstantTimeCompare([]byte(headerValue), []byte(csrfCookie.Value)) != 1 {
+			forbiddenResponse(w, "CSRF token mismatch")
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}

--- a/server/middleware/session_cookie.go
+++ b/server/middleware/session_cookie.go
@@ -41,7 +41,7 @@ const (
 // AbsoluteExpiresAt semantics) — the cookie is then a browser-session cookie
 // with no Expires/Max-Age, cleared when the browser closes.
 func SetSessionCookie(w http.ResponseWriter, token string, expiresAt *time.Time, secure bool) {
-	cookie := &http.Cookie{
+	cookie := &http.Cookie{ // #nosec G124 -- Secure is threaded from cfg.Server.HTTP.TLS.Enabled; hardcoding true would break local HTTP dev
 		Name:     SessionCookieName,
 		Value:    token,
 		Path:     "/",
@@ -58,7 +58,7 @@ func SetSessionCookie(w http.ResponseWriter, token string, expiresAt *time.Time,
 // ClearSessionCookie expires the session cookie immediately (logout, or the
 // gone-original-session case when ending impersonation).
 func ClearSessionCookie(w http.ResponseWriter, secure bool) {
-	http.SetCookie(w, &http.Cookie{
+	http.SetCookie(w, &http.Cookie{ // #nosec G124 -- Secure is threaded from cfg.Server.HTTP.TLS.Enabled; hardcoding true would break local HTTP dev
 		Name:     SessionCookieName,
 		Value:    "",
 		Path:     "/",
@@ -75,7 +75,7 @@ func ClearSessionCookie(w http.ResponseWriter, secure bool) {
 // custom header on a request to this origin (no third-party origin is
 // allowlisted by this app's CORS config), not from the cookie being secret.
 func SetCSRFCookie(w http.ResponseWriter, token string, secure bool) {
-	http.SetCookie(w, &http.Cookie{
+	http.SetCookie(w, &http.Cookie{ // #nosec G124 -- HttpOnly:false is intentional (double-submit pattern requires JS to read it); Secure is threaded from cfg.Server.HTTP.TLS.Enabled
 		Name:     CSRFCookieName,
 		Value:    token,
 		Path:     "/",
@@ -87,7 +87,7 @@ func SetCSRFCookie(w http.ResponseWriter, token string, secure bool) {
 
 // ClearCSRFCookie expires the CSRF cookie (logout).
 func ClearCSRFCookie(w http.ResponseWriter, secure bool) {
-	http.SetCookie(w, &http.Cookie{
+	http.SetCookie(w, &http.Cookie{ // #nosec G124 -- HttpOnly:false is intentional (double-submit pattern requires JS to read it); Secure is threaded from cfg.Server.HTTP.TLS.Enabled
 		Name:     CSRFCookieName,
 		Value:    "",
 		Path:     "/",
@@ -103,7 +103,7 @@ func ClearCSRFCookie(w http.ResponseWriter, secure bool) {
 // own expiry, so the stash cookie never outlives the impersonation window it
 // belongs to (see AdminSessionCookieName's doc comment for why this exists).
 func SetAdminSessionCookie(w http.ResponseWriter, token string, expiresAt *time.Time, secure bool) {
-	cookie := &http.Cookie{
+	cookie := &http.Cookie{ // #nosec G124 -- Secure is threaded from cfg.Server.HTTP.TLS.Enabled; hardcoding true would break local HTTP dev
 		Name:     AdminSessionCookieName,
 		Value:    token,
 		Path:     "/",
@@ -120,7 +120,7 @@ func SetAdminSessionCookie(w http.ResponseWriter, token string, expiresAt *time.
 // ClearAdminSessionCookie removes the stashed admin session cookie once
 // impersonation ends (restored or not).
 func ClearAdminSessionCookie(w http.ResponseWriter, secure bool) {
-	http.SetCookie(w, &http.Cookie{
+	http.SetCookie(w, &http.Cookie{ // #nosec G124 -- Secure is threaded from cfg.Server.HTTP.TLS.Enabled; hardcoding true would break local HTTP dev
 		Name:     AdminSessionCookieName,
 		Value:    "",
 		Path:     "/",

--- a/server/middleware/session_cookie.go
+++ b/server/middleware/session_cookie.go
@@ -1,0 +1,143 @@
+package middleware
+
+import (
+	"crypto/rand"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// SessionCookieName and CSRFCookieName are the two cookies issued alongside a
+// session: the session cookie carries the opaque session token and is HttpOnly
+// (never JS-readable, closing the XSS-blast-radius gap the localStorage-token
+// design had); the CSRF cookie is deliberately readable by JS so it can be
+// echoed back as CSRFHeaderName on state-changing requests (double-submit
+// pattern) — see RequireCSRF in csrf.go.
+const (
+	SessionCookieName = "kx_session"
+	CSRFCookieName    = "csrf_token"
+	CSRFHeaderName    = "X-CSRF-Token"
+
+	// AdminSessionCookieName stashes an admin's own session token, plaintext,
+	// while they're impersonating another user — set alongside the swap to the
+	// impersonation session's SessionCookieName, cleared when impersonation ends.
+	// This is how "return to admin" is restored under hashed-at-rest session
+	// storage: the server never retains a plaintext token after issuing it (see
+	// local_auth.go's hashSessionToken), so it can't recall the admin's original
+	// token from the database once impersonation has started — only the browser,
+	// which received it live, still has it. Round-tripping it through a second
+	// HttpOnly cookie (never JS-readable, so this doesn't reopen the exposure the
+	// cookie migration closed) lets End validate-and-restore it without the
+	// server ever needing to store or recover a plaintext value itself.
+	AdminSessionCookieName = "kx_admin_session"
+)
+
+// SetSessionCookie issues (or rotates) the HttpOnly session cookie. SameSite=Lax,
+// not Strict: Strict drops the cookie on a top-level cross-site navigation into
+// the app (a bookmarked link, an emailed deep link, the redirect back from an
+// OIDC/SAML IdP), forcing a spurious re-login even with a live session — Lax
+// already blocks the cross-site POST case CSRF actually depends on. expiresAt
+// nil means no absolute ceiling for this session (matches the existing
+// AbsoluteExpiresAt semantics) — the cookie is then a browser-session cookie
+// with no Expires/Max-Age, cleared when the browser closes.
+func SetSessionCookie(w http.ResponseWriter, token string, expiresAt *time.Time, secure bool) {
+	cookie := &http.Cookie{
+		Name:     SessionCookieName,
+		Value:    token,
+		Path:     "/",
+		HttpOnly: true,
+		Secure:   secure,
+		SameSite: http.SameSiteLaxMode,
+	}
+	if expiresAt != nil {
+		cookie.Expires = *expiresAt
+	}
+	http.SetCookie(w, cookie)
+}
+
+// ClearSessionCookie expires the session cookie immediately (logout, or the
+// gone-original-session case when ending impersonation).
+func ClearSessionCookie(w http.ResponseWriter, secure bool) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     SessionCookieName,
+		Value:    "",
+		Path:     "/",
+		HttpOnly: true,
+		Secure:   secure,
+		SameSite: http.SameSiteLaxMode,
+		MaxAge:   -1,
+	})
+}
+
+// SetCSRFCookie issues (or rotates) the CSRF double-submit cookie. Not HttpOnly
+// — the SPA reads it and echoes it back as CSRFHeaderName; the security
+// property comes from a cross-site attacker being unable to read or set a
+// custom header on a request to this origin (no third-party origin is
+// allowlisted by this app's CORS config), not from the cookie being secret.
+func SetCSRFCookie(w http.ResponseWriter, token string, secure bool) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     CSRFCookieName,
+		Value:    token,
+		Path:     "/",
+		HttpOnly: false,
+		Secure:   secure,
+		SameSite: http.SameSiteLaxMode,
+	})
+}
+
+// ClearCSRFCookie expires the CSRF cookie (logout).
+func ClearCSRFCookie(w http.ResponseWriter, secure bool) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     CSRFCookieName,
+		Value:    "",
+		Path:     "/",
+		HttpOnly: false,
+		Secure:   secure,
+		SameSite: http.SameSiteLaxMode,
+		MaxAge:   -1,
+	})
+}
+
+// SetAdminSessionCookie stashes the admin's own session token while they
+// impersonate another user. expiresAt should match the impersonation session's
+// own expiry, so the stash cookie never outlives the impersonation window it
+// belongs to (see AdminSessionCookieName's doc comment for why this exists).
+func SetAdminSessionCookie(w http.ResponseWriter, token string, expiresAt *time.Time, secure bool) {
+	cookie := &http.Cookie{
+		Name:     AdminSessionCookieName,
+		Value:    token,
+		Path:     "/",
+		HttpOnly: true,
+		Secure:   secure,
+		SameSite: http.SameSiteLaxMode,
+	}
+	if expiresAt != nil {
+		cookie.Expires = *expiresAt
+	}
+	http.SetCookie(w, cookie)
+}
+
+// ClearAdminSessionCookie removes the stashed admin session cookie once
+// impersonation ends (restored or not).
+func ClearAdminSessionCookie(w http.ResponseWriter, secure bool) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     AdminSessionCookieName,
+		Value:    "",
+		Path:     "/",
+		HttpOnly: true,
+		Secure:   secure,
+		SameSite: http.SameSiteLaxMode,
+		MaxAge:   -1,
+	})
+}
+
+// GenerateCSRFToken creates a cryptographically random 32-byte hex token, mirroring
+// internal/core's unexported generateSecureToken (duplicated rather than exported
+// solely for this — it's a two-line primitive, not shared state).
+func GenerateCSRFToken() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%x", b), nil
+}


### PR DESCRIPTION
## Summary
- Backend counterpart to keyorix-web's cookie-auth migration: session tokens now travel as an httpOnly cookie (`kx_session`) instead of a client-held Bearer token, closing the XSS blast-radius gap on session storage.
- Adds a double-submit CSRF cookie (`csrf_token` + `X-CSRF-Token` header) for state-changing requests, since the incidental CSRF protection of a custom `Authorization` header goes away once auth is ambient.
- Redesigns admin impersonation to swap sessions purely via cookies: a second httpOnly cookie (`kx_admin_session`) stashes the admin's own live token at impersonation start and restores it at end, without the server ever needing to recall a plaintext token from storage (sessions are hashed at rest).
- Dual-mode/additive: cookie or Bearer both work for now; Login/Refresh still return the token in the JSON body. Removing the Bearer fallback is a deliberately deferred follow-up (documented in keyorix-web's `docs/PHASE1-AUTH-COOKIE-CONTRACT.md`) pending an operational bake-in period.
- Also fixes an unrelated bug found during this work: `RevokeSessions` was missing the self-action guard present on other account-state actions, letting an admin revoke their own sessions.

## Test plan
- [x] `go build ./...`
- [x] `golangci-lint run ./...` (0 issues)
- [x] `go test ./...` (68/68 packages passing)
- [x] New integration tests: cookie login/dual-mode auth, CSRF enforcement, full impersonation cookie-swap-and-restore round trip
- [ ] Manual smoke test against the deployed frontend once merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)