### PR TITLE
fix(storage): close #276-sibling purge/restore race in Users and Projects purge

### DIFF
--- a/internal/storage/store/concurrency_purge_restore_race_test.go
+++ b/internal/storage/store/concurrency_purge_restore_race_test.go
@@ -1,6 +1,13 @@
-// concurrency_purge_restore_race_test.go — regression coverage for #276: a concurrent
-// RestoreSecret landing in the window between PurgeDeletedSecretsBefore's SELECT (Pluck)
-// and its DELETE must not be silently undone by the purge.
+// concurrency_purge_restore_race_test.go — regression coverage for #276 and its siblings:
+// a concurrent Restore* call landing in the window between a Purge*Before's SELECT
+// (Pluck) and its DELETE must not be silently undone by the purge. Covers
+// PurgeDeletedSecretsBefore (the original #276), PurgeDeletedUsersBefore, and
+// PurgeDeletedProjectsBefore — the other Purge*Before functions that share the same
+// stale-Pluck-then-delete-by-ID-list shape and have a genuine Restore* counterpart.
+// PurgeDeletedEnvironmentsBefore is deliberately NOT covered here: it purges via a
+// single DELETE ... WHERE deleted_at ... statement with no separate SELECT/ID-list step,
+// so it was never exposed to this race in the first place (see its doc comment in
+// local_purge.go).
 package store
 
 import (
@@ -87,4 +94,111 @@ func TestConcurrency_PurgeDeletedSecretsBefore_RestoreWinsRace(t *testing.T) {
 	// Its version (the ciphertext) must survive too.
 	var version models.SecretVersion
 	require.NoError(t, db.First(&version, 10).Error, "the version row must survive — the purge must not have destroyed it")
+}
+
+// TestConcurrency_PurgeDeletedUsersBefore_RestoreWinsRace is the #276-sibling case for
+// PurgeDeletedUsersBefore: it follows the identical stale-Pluck-then-delete-by-ID-list
+// shape as the original PurgeDeletedSecretsBefore bug, and RestoreUser is a real,
+// reachable operation that could race it the same way. Same technique as the secrets
+// test above — see its doc comment for why this drives the callback on the purge's own
+// transaction handle rather than a genuinely separate goroutine/connection.
+func TestConcurrency_PurgeDeletedUsersBefore_RestoreWinsRace(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.User{}, &models.UserRole{}, &models.UserGroup{},
+		&models.ShareRecord{}, &models.PersonalAccessToken{}, &models.Session{}))
+	ls := NewLocalStorage(db)
+	ctx := context.Background()
+
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "race-me"}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1}).Error)
+	// Soft-deleted 40 days ago — squarely past a 30-day retention cutoff, so the purge's
+	// Pluck picks it up as eligible before anyone restores it.
+	require.NoError(t, db.Unscoped().Model(&models.User{}).Where("id = ?", 1).
+		Update("deleted_at", time.Now().AddDate(0, 0, -40)).Error)
+
+	var fired bool
+	require.NoError(t, db.Callback().Delete().Before("gorm:delete").Register(
+		"test:simulate-concurrent-restore-before-user-role-delete",
+		func(tx *gorm.DB) {
+			if fired {
+				return
+			}
+			if _, ok := tx.Statement.Dest.(*models.UserRole); !ok {
+				return
+			}
+			fired = true
+			// Simulate a concurrent RestoreUser landing in the window between the
+			// purge's Pluck (already ran) and this delete, on the purge's own
+			// still-open transaction (see the secrets test above for why).
+			require.NoError(t, tx.Exec("UPDATE users SET deleted_at = NULL WHERE id = ?", 1).Error)
+		},
+	))
+
+	purgedCount, purgeErr := ls.PurgeDeletedUsersBefore(ctx, time.Now().AddDate(0, 0, -30))
+	require.NoError(t, purgeErr)
+	assert.True(t, fired, "the callback must have fired — otherwise this test isn't exercising the race window at all")
+	assert.Equal(t, int64(0), purgedCount, "the concurrently-restored user must be excluded from the purge count")
+
+	// The user must be alive — not hard-deleted despite having been in the stale ID list.
+	var user models.User
+	require.NoError(t, db.First(&user, 1).Error, "a scoped read must find the restored user live")
+	assert.False(t, user.DeletedAt.Valid, "must be live (deleted_at cleared), not soft-deleted")
+
+	// Its role grant must survive too — not orphan-deleted alongside the almost-purged user.
+	var roleCount int64
+	require.NoError(t, db.Model(&models.UserRole{}).Where("user_id = ?", 1).Count(&roleCount).Error)
+	assert.Equal(t, int64(1), roleCount, "the role grant must survive — the purge must not have destroyed it")
+}
+
+// TestConcurrency_PurgeDeletedProjectsBefore_RestoreWinsRace is the #276-sibling case for
+// PurgeDeletedProjectsBefore: same stale-Pluck-then-delete-by-ID-list shape, and
+// RestoreProject is a real, reachable operation (including cascading the restore onto
+// the project's environments/secrets) that could race it the same way.
+func TestConcurrency_PurgeDeletedProjectsBefore_RestoreWinsRace(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.Project{}, &models.UserRole{}, &models.GroupRole{}))
+	ls := NewLocalStorage(db)
+	ctx := context.Background()
+
+	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "race-me"}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1, ProjectID: 1}).Error)
+	// Soft-deleted 40 days ago — squarely past a 30-day retention cutoff, so the purge's
+	// Pluck picks it up as eligible before anyone restores it.
+	require.NoError(t, db.Unscoped().Model(&models.Project{}).Where("id = ?", 1).
+		Update("deleted_at", time.Now().AddDate(0, 0, -40)).Error)
+
+	var fired bool
+	require.NoError(t, db.Callback().Delete().Before("gorm:delete").Register(
+		"test:simulate-concurrent-restore-before-project-role-delete",
+		func(tx *gorm.DB) {
+			if fired {
+				return
+			}
+			if _, ok := tx.Statement.Dest.(*models.UserRole); !ok {
+				return
+			}
+			fired = true
+			// Simulate a concurrent RestoreProject landing in the window between the
+			// purge's Pluck (already ran) and this delete, on the purge's own
+			// still-open transaction (see the secrets test above for why).
+			require.NoError(t, tx.Exec("UPDATE projects SET deleted_at = NULL WHERE id = ?", 1).Error)
+		},
+	))
+
+	purgedCount, purgeErr := ls.PurgeDeletedProjectsBefore(ctx, time.Now().AddDate(0, 0, -30))
+	require.NoError(t, purgeErr)
+	assert.True(t, fired, "the callback must have fired — otherwise this test isn't exercising the race window at all")
+	assert.Equal(t, int64(0), purgedCount, "the concurrently-restored project must be excluded from the purge count")
+
+	// The project must be alive — not hard-deleted despite having been in the stale ID list.
+	var project models.Project
+	require.NoError(t, db.First(&project, 1).Error, "a scoped read must find the restored project live")
+	assert.False(t, project.DeletedAt.Valid, "must be live (deleted_at cleared), not soft-deleted")
+
+	// Its role grant must survive too — not orphan-deleted alongside the almost-purged project.
+	var roleCount int64
+	require.NoError(t, db.Model(&models.UserRole{}).Where("project_id = ?", 1).Count(&roleCount).Error)
+	assert.Equal(t, int64(1), roleCount, "the role grant must survive — the purge must not have destroyed it")
 }

--- a/internal/storage/store/local_purge.go
+++ b/internal/storage/store/local_purge.go
@@ -36,6 +36,16 @@ func (ls *LocalStorage) purgeDeletedBefore(ctx context.Context, model interface{
 // that could collide with a future reused ID, a PAT/session row that (before the
 // core.DeleteUser fix) may still be live, and a share the user received sitting
 // unreachable but undestroyed. Returns the number of users purged.
+//
+// #276-sibling: like PurgeDeletedSecretsBefore, the eligible-ID list is gathered by a
+// SELECT (Pluck) and the deletes run moments later — a window in which a concurrent
+// RestoreUser can flip deleted_at back to NULL on one of those IDs. Deleting purely
+// off the stale ID list would hard-delete that already-restored user (and cascade
+// through its role grants, memberships, sessions and PATs) anyway, silently undoing a
+// restore that already reported success. Every delete below therefore re-applies the
+// same "deleted_at IS NOT NULL AND deleted_at < before" predicate the SELECT used,
+// keyed on id — not just the ID list — so a user a restore raced out from under the
+// purge is left alone.
 func (ls *LocalStorage) PurgeDeletedUsersBefore(ctx context.Context, before time.Time) (int64, error) {
 	var purged int64
 	err := ls.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
@@ -48,24 +58,36 @@ func (ls *LocalStorage) PurgeDeletedUsersBefore(ctx context.Context, before time
 		if len(ids) == 0 {
 			return nil
 		}
-		if e := tx.Where("user_id IN ?", ids).Delete(&models.UserRole{}).Error; e != nil {
+		// Re-scoped to still-deleted-and-eligible users only, via a subquery against
+		// users' live deleted_at rather than the stale `ids` list, so a user restored
+		// after the SELECT above is excluded from every delete below it. A fresh
+		// subquery builder is used per reference since a *gorm.DB is stateful and must
+		// not be shared across clauses.
+		stillEligible := func() *gorm.DB {
+			return tx.Unscoped().Model(&models.User{}).
+				Select("id").
+				Where("id IN ? AND deleted_at IS NOT NULL AND deleted_at < ?", ids, before)
+		}
+		if e := tx.Where("user_id IN (?)", stillEligible()).Delete(&models.UserRole{}).Error; e != nil {
 			return e
 		}
-		if e := tx.Where("user_id IN ?", ids).Delete(&models.UserGroup{}).Error; e != nil {
+		if e := tx.Where("user_id IN (?)", stillEligible()).Delete(&models.UserGroup{}).Error; e != nil {
 			return e
 		}
 		// ShareRecord carries its own DeletedAt (soft-delete) — Unscoped so this is a
 		// true hard delete, not another soft-deleted orphan nothing else purges.
-		if e := tx.Unscoped().Where("recipient_id IN ? AND is_group = ?", ids, false).Delete(&models.ShareRecord{}).Error; e != nil {
+		if e := tx.Unscoped().Where("recipient_id IN (?) AND is_group = ?", stillEligible(), false).Delete(&models.ShareRecord{}).Error; e != nil {
 			return e
 		}
-		if e := tx.Where("user_id IN ?", ids).Delete(&models.PersonalAccessToken{}).Error; e != nil {
+		if e := tx.Where("user_id IN (?)", stillEligible()).Delete(&models.PersonalAccessToken{}).Error; e != nil {
 			return e
 		}
-		if e := tx.Where("user_id IN ? OR impersonated_by IN ?", ids, ids).Delete(&models.Session{}).Error; e != nil {
+		if e := tx.Where("user_id IN (?) OR impersonated_by IN (?)", stillEligible(), stillEligible()).Delete(&models.Session{}).Error; e != nil {
 			return e
 		}
-		ru := tx.Unscoped().Where("id IN ?", ids).Delete(&models.User{})
+		ru := tx.Unscoped().
+			Where("id IN ? AND deleted_at IS NOT NULL AND deleted_at < ?", ids, before).
+			Delete(&models.User{})
 		if ru.Error != nil {
 			return ru.Error
 		}
@@ -86,6 +108,18 @@ func (ls *LocalStorage) PurgeDeletedUsersBefore(ctx context.Context, before time
 // no longer exists anywhere, since IDs are never reused): dead weight in every "who
 // has access" report and role/access-review listing forever after. Global-scope
 // grants (ProjectID 0) are untouched — they aren't project-scoped.
+//
+// #276-sibling: like PurgeDeletedSecretsBefore, the eligible-ID list is gathered by a
+// SELECT (Pluck) and the deletes run moments later — a window in which a concurrent
+// RestoreProject can flip deleted_at back to NULL on one of those IDs (and cascade the
+// restore onto its environments/secrets, see LocalStorage.RestoreProject). Deleting
+// purely off the stale ID list would hard-delete that already-restored project anyway,
+// silently undoing a restore that already reported success — and orphaning the very
+// environments/secrets RestoreProject just brought back, which would reference a
+// project ID that no longer exists. Every delete below therefore re-applies the same
+// "deleted_at IS NOT NULL AND deleted_at < before" predicate the SELECT used, keyed on
+// id — not just the ID list — so a project a restore raced out from under the purge is
+// left alone.
 func (ls *LocalStorage) PurgeDeletedProjectsBefore(ctx context.Context, before time.Time) (int64, error) {
 	var purged int64
 	err := ls.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
@@ -98,13 +132,25 @@ func (ls *LocalStorage) PurgeDeletedProjectsBefore(ctx context.Context, before t
 		if len(ids) == 0 {
 			return nil
 		}
-		if e := tx.Where("project_id IN ?", ids).Delete(&models.UserRole{}).Error; e != nil {
+		// Re-scoped to still-deleted-and-eligible projects only, via a subquery against
+		// projects' live deleted_at rather than the stale `ids` list, so a project
+		// restored after the SELECT above is excluded from every delete below it. A
+		// fresh subquery builder is used per reference since a *gorm.DB is stateful and
+		// must not be shared across clauses.
+		stillEligible := func() *gorm.DB {
+			return tx.Unscoped().Model(&models.Project{}).
+				Select("id").
+				Where("id IN ? AND deleted_at IS NOT NULL AND deleted_at < ?", ids, before)
+		}
+		if e := tx.Where("project_id IN (?)", stillEligible()).Delete(&models.UserRole{}).Error; e != nil {
 			return e
 		}
-		if e := tx.Where("project_id IN ?", ids).Delete(&models.GroupRole{}).Error; e != nil {
+		if e := tx.Where("project_id IN (?)", stillEligible()).Delete(&models.GroupRole{}).Error; e != nil {
 			return e
 		}
-		rp := tx.Unscoped().Where("id IN ?", ids).Delete(&models.Project{})
+		rp := tx.Unscoped().
+			Where("id IN ? AND deleted_at IS NOT NULL AND deleted_at < ?", ids, before).
+			Delete(&models.Project{})
 		if rp.Error != nil {
 			return rp.Error
 		}
@@ -117,6 +163,12 @@ func (ls *LocalStorage) PurgeDeletedProjectsBefore(ctx context.Context, before t
 	return purged, nil
 }
 
+// PurgeDeletedEnvironmentsBefore is NOT #276-sibling-affected despite RestoreEnvironment
+// existing: unlike the Pluck-then-delete-by-ID-list shape used above, purgeDeletedBefore
+// issues a single DELETE ... WHERE deleted_at IS NOT NULL AND deleted_at < before
+// statement — there is no separate SELECT and no stale ID list for a concurrent restore
+// to race against, so the predicate is necessarily evaluated against live row state at
+// delete time already.
 func (ls *LocalStorage) PurgeDeletedEnvironmentsBefore(ctx context.Context, before time.Time) (int64, error) {
 	return ls.purgeDeletedBefore(ctx, &models.Environment{}, before)
 }


### PR DESCRIPTION
## Summary
- `PurgeDeletedUsersBefore` and `PurgeDeletedProjectsBefore` had the identical race already fixed for `PurgeDeletedSecretsBefore` (#276): both Pluck an eligible-ID list via a SELECT, then delete moments later keyed only on that stale list. A concurrent `RestoreUser`/`RestoreProject` landing in that window (both real, reachable operations) could flip `deleted_at` back to `NULL`, and the purge would hard-delete the row anyway — silently undoing a restore that had already reported success to its caller.
- Every delete in both functions now re-applies the `deleted_at IS NOT NULL AND deleted_at < before` predicate via a subquery keyed on id, mirroring the style established in `PurgeDeletedSecretsBefore`.
- `PurgeDeletedEnvironmentsBefore` was audited too and found NOT affected: it purges via a single `DELETE ... WHERE deleted_at ...` statement with no separate SELECT/ID-list step, so there's no stale-list window for `RestoreEnvironment` to race — left unchanged, with a comment explaining why.
- No `PurgeDeletedGroupsBefore` exists (`RestoreGroup` has no corresponding purge path), so there's nothing to fix there either.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/storage/...`
- [x] `gosec -severity medium -exclude-generated ./...` — clean
- [x] New regression tests (`TestConcurrency_PurgeDeletedUsersBefore_RestoreWinsRace`, `TestConcurrency_PurgeDeletedProjectsBefore_RestoreWinsRace`) verified to fail against the pre-fix code and pass against the fix