### PR TITLE
fix(validation): make Validator.Validate stateless to close concurrent map race (#476)

### DIFF
--- a/server/validation/validator.go
+++ b/server/validation/validator.go
@@ -11,16 +11,21 @@ import (
 	"github.com/keyorixhq/keyorix/internal/utils/safeconv"
 )
 
-// Validator provides request validation functionality
-type Validator struct {
-	errors map[string][]string
-}
+// Validator provides request validation functionality.
+//
+// Validator instances are constructed once at process startup (see the
+// handler constructors in server/http/handlers) and shared across every
+// subsequent concurrent request for the lifetime of the server process.
+// Validate MUST therefore be stateless: it must never read or write any
+// Validator field across calls. All per-call error accumulation happens in
+// a map that is local to a single Validate call and is returned directly,
+// never stored on the struct — this removes the concurrent map read/write
+// hazard entirely rather than serializing it behind a mutex.
+type Validator struct{}
 
 // NewValidator creates a new validator instance
 func NewValidator() *Validator {
-	return &Validator{
-		errors: make(map[string][]string),
-	}
+	return &Validator{}
 }
 
 // ValidationError represents validation errors
@@ -43,9 +48,14 @@ func (ve ValidationErrors) Error() string {
 	return strings.Join(messages, "; ")
 }
 
-// Validate validates a struct using reflection and validation tags
+// Validate validates a struct using reflection and validation tags. It is
+// stateless: every call builds its own local errs map and never reads or
+// writes any Validator field, so a single shared *Validator instance can be
+// called concurrently by many goroutines/requests without risk of a
+// concurrent map read/write (which the Go runtime treats as fatal) or of one
+// call's in-flight errors being corrupted by another's.
 func (v *Validator) Validate(s interface{}) error {
-	v.errors = make(map[string][]string)
+	errs := make(map[string][]string)
 
 	val := reflect.ValueOf(s)
 	if val.Kind() == reflect.Pointer {
@@ -84,12 +94,12 @@ func (v *Validator) Validate(s interface{}) error {
 		}
 
 		// Validate field
-		v.validateField(fieldName, field, tag)
+		v.validateField(errs, fieldName, field, tag)
 	}
 
-	if len(v.errors) > 0 {
+	if len(errs) > 0 {
 		var validationErrors []ValidationError
-		for field, messages := range v.errors {
+		for field, messages := range errs {
 			for _, message := range messages {
 				validationErrors = append(validationErrors, ValidationError{
 					Field:   field,
@@ -103,8 +113,10 @@ func (v *Validator) Validate(s interface{}) error {
 	return nil
 }
 
-// validateField validates a single field based on validation rules
-func (v *Validator) validateField(fieldName string, field reflect.Value, tag string) {
+// validateField validates a single field based on validation rules,
+// accumulating any failures into errs, which is local to the enclosing
+// Validate call (see the stateless-by-design note on Validate).
+func (v *Validator) validateField(errs map[string][]string, fieldName string, field reflect.Value, tag string) {
 	rules := strings.Split(tag, ",")
 
 	for _, rule := range rules {
@@ -128,7 +140,7 @@ func (v *Validator) validateField(fieldName string, field reflect.Value, tag str
 
 		// Apply validation rule
 		if err := v.applyRule(fieldName, field, ruleName, param); err != nil {
-			v.addError(fieldName, err.Error())
+			addError(errs, fieldName, err.Error())
 		}
 	}
 }
@@ -475,10 +487,13 @@ func (v *Validator) validateOneOf(field reflect.Value, param string) error {
 	return fmt.Errorf("%s: must be one of: %s", i18n.T("ErrorValidation", nil), strings.Join(allowedValues, ", "))
 }
 
-// addError adds a validation error
-func (v *Validator) addError(field, message string) {
-	if v.errors[field] == nil {
-		v.errors[field] = []string{}
+// addError records a validation failure into errs, the map local to a
+// single Validate call (see the stateless-by-design note on Validate). It
+// is a plain function, not a *Validator method, precisely so it cannot be
+// tempted into touching shared struct state.
+func addError(errs map[string][]string, field, message string) {
+	if errs[field] == nil {
+		errs[field] = []string{}
 	}
-	v.errors[field] = append(v.errors[field], message)
+	errs[field] = append(errs[field], message)
 }

--- a/server/validation/validator_test.go
+++ b/server/validation/validator_test.go
@@ -1,8 +1,11 @@
 package validation
 
 import (
+	"fmt"
 	"os"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/keyorixhq/keyorix/internal/i18n"
@@ -360,4 +363,69 @@ func TestValidate_UsesJSONNameForErrorField(t *testing.T) {
 	ve := err.(ValidationErrors)
 	require.Len(t, ve.Errors, 1)
 	assert.Equal(t, "user_name", ve.Errors[0].Field, "json tag name preferred over Go field name")
+}
+
+// --- Concurrent-Validate regression test (#476) ---
+//
+// Validator instances are constructed exactly once at server startup (one
+// per handler, plus a package-level shared instance in
+// server/http/handlers/rbac.go) and then called concurrently by every
+// subsequent HTTP request for the life of the process. Validate must
+// therefore be safe to call concurrently on a single shared *Validator: no
+// data race, and no goroutine result may be corrupted by another
+// goroutine concurrently running Validate.
+//
+// Before the fix, Validate reset and mutated a *Validator-level errors map
+// with zero synchronization. That reliably reported a concurrent map
+// read/write under go test -race here, and separately from the race
+// report, this test could also observe wrong pass/fail verdicts (a valid
+// input spuriously failing, or an invalid input spuriously passing)
+// because one goroutine map reset-then-accumulate sequence could stomp a
+// different concurrent goroutine in-flight accumulation.
+func TestValidate_ConcurrentCallsAreIsolated(t *testing.T) {
+	type payload struct {
+		Name string `json:"name" validate:"required,min=3"`
+	}
+
+	v := NewValidator() // a single shared instance, exactly as in production
+
+	const goroutines = 50
+	const itersPerGoroutine = 20
+
+	var wg sync.WaitGroup
+	var unexpectedNoErr int32 // invalid input that should have failed but did not
+	var unexpectedErr int32   // valid input that should have passed but did not
+
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for i := 0; i < itersPerGoroutine; i++ {
+				valid := (id+i)%2 == 0
+
+				var p payload
+				if valid {
+					p = payload{Name: fmt.Sprintf("valid-name-%d-%d", id, i)}
+				} else {
+					p = payload{Name: ""} // empty: fails required
+				}
+
+				err := v.Validate(&p)
+
+				if valid && err != nil {
+					atomic.AddInt32(&unexpectedErr, 1)
+				}
+				if !valid && err == nil {
+					atomic.AddInt32(&unexpectedNoErr, 1)
+				}
+			}
+		}(g)
+	}
+
+	wg.Wait()
+
+	assert.Equal(t, int32(0), atomic.LoadInt32(&unexpectedErr),
+		"a valid input incorrectly failed validation under concurrency (result corrupted by another concurrent call)")
+	assert.Equal(t, int32(0), atomic.LoadInt32(&unexpectedNoErr),
+		"an invalid input incorrectly passed validation under concurrency (validation bypass)")
 }


### PR DESCRIPTION
## Summary
- `server/validation/validator.go`'s `Validator` held a mutable `errors map[string][]string` field that `Validate()` reset and `addError` mutated with zero synchronization, even though every `*Validator` is constructed once at server startup and then shared by every concurrent HTTP request for the process lifetime (8 handler-owned instances + 1 package-level instance in `server/http/handlers/rbac.go`).
- Two consequences: (1) a concurrent map write is a fatal, unrecoverable Go runtime error — an unauthenticated-reachable DoS if two ordinary requests to the same endpoint race; (2) one goroutine's reset-then-accumulate sequence could stomp a different concurrent goroutine's in-flight errors, letting invalid input silently pass validation.
- Fix: refactored `Validate`/`validateField`/`addError` to build and return a map that is local to each call and never touches struct state, removing the shared mutable state entirely (rather than adding a mutex, which would serialize all concurrent request validation process-wide). The public `Validate(s) error` signature is unchanged, so none of the 23 existing call sites across the 8 handler files needed any changes.
- Added `TestValidate_ConcurrentCallsAreIsolated`, a 50-goroutine concurrent `Validate` test against a single shared `*Validator` (matching production usage) that reliably reports a concurrent map read/write under `-race` on the prior implementation — and also observes corrupted pass/fail verdicts (valid input spuriously failing, invalid input spuriously passing) — and passes cleanly after the fix.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./server/validation/... ./server/http/...` — all pass
- [x] Confirmed the new test fails under `-race` against the pre-fix implementation (data race reported + both corruption assertions non-zero) and passes cleanly after the fix
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues