### PR TITLE
fix(core): revert orphaned active membership row when role grant fails (#309)

### DIFF
--- a/internal/core/membership_lifecycle.go
+++ b/internal/core/membership_lifecycle.go
@@ -155,6 +155,17 @@ func (c *KeyorixCore) inviteMemberWithMode(ctx context.Context, projectID, userI
 	// If the mode put us straight into active, grant the role now.
 	if created.State == MembershipActive {
 		if err := c.AddProjectMember(ctx, invitedBy, projectID, userID, role); err != nil {
+			// #309: created just committed as `active` above; if the role grant that's
+			// supposed to back it fails (e.g. the composite user_roles primary key
+			// rejects a grant that already exists via some other, independent path —
+			// the DB-level uniq_project_memberships_active index only dedupes
+			// ProjectMembership rows, not user_roles grants), leaving that row standing
+			// would report a failure to the caller while a live active-looking
+			// membership with no grant behind it persists in ListProjectMemberships/
+			// ListUserProjectMemberships indefinitely. There's no earlier state to fall
+			// back to (this row didn't exist before this call), so revert straight to
+			// revoked.
+			c.revertFailedActivation(ctx, created, MembershipRevoked)
 			return nil, fmt.Errorf("failed to grant role on activation: %w", err)
 		}
 	}
@@ -207,6 +218,7 @@ func (c *KeyorixCore) TransitionMembership(ctx context.Context, projectID, membe
 		}
 	}
 
+	prevState := m.State
 	now := c.now()
 	m.State = to
 	m.UpdatedAt = now
@@ -224,6 +236,13 @@ func (c *KeyorixCore) TransitionMembership(ctx context.Context, projectID, membe
 	switch to {
 	case MembershipActive:
 		if err := c.AddProjectMember(ctx, actorID, m.ProjectID, m.UserID, m.Role); err != nil {
+			// #309: m just committed as `active` above; if the role grant fails, revert
+			// to the state m held before this transition (not straight to revoked) —
+			// unlike inviteMemberWithMode's straight-to-active create, this row already
+			// existed in a legitimate pending state, so a failed activation attempt
+			// should leave it retriable rather than terminally revoked. See
+			// revertFailedActivation.
+			c.revertFailedActivation(ctx, m, prevState)
 			return nil, fmt.Errorf("failed to grant role on activation: %w", err)
 		}
 	case MembershipRevoked:
@@ -285,4 +304,43 @@ func (c *KeyorixCore) logMembershipEvent(ctx context.Context, eventType string, 
 	aid, pid := actorID, m.ProjectID
 	c.writeAuditEventFull(ctx, eventType, &aid, nil, &pid, "",
 		fmt.Sprintf("membership %d for user %d in project %d → %s", m.ID, m.UserID, m.ProjectID, m.State))
+}
+
+// revertFailedActivation reverts a ProjectMembership row that was just persisted as
+// `active` back to a non-active state, after the role grant that's supposed to back
+// that `active` row failed (#309). Without this, a caller-visible error ("failed to
+// grant role on activation") would still leave a live state=active row behind —
+// ListProjectMemberships/ListUserProjectMemberships would keep reporting the user as
+// an active project member indefinitely, with no role grant behind it and no way to
+// revoke a grant that was never made. This can happen without any TOCTOU: the
+// uniq_project_memberships_active partial index only dedupes ProjectMembership rows,
+// not user_roles grants, so a role already held via an independent path (a direct
+// /user-roles grant, another membership's activation, etc.) still makes
+// AssignRole's composite primary key reject this grant after the row committed.
+//
+// toState is the state to fall back to: inviteMemberWithMode has no earlier state to
+// return to (the row didn't exist before this call) and passes MembershipRevoked;
+// TransitionMembership passes the membership's own pre-transition state, so a
+// legitimate retry of the activation is still possible.
+//
+// Best-effort and mirrors revokeInvitationGrants (invitations.go): m is already on a
+// path that's about to return an error to its caller, so a failure to revert is
+// audited (flagged for manual cleanup) rather than returned or retried — a partial
+// revert is strictly better than silently leaving the active row standing.
+func (c *KeyorixCore) revertFailedActivation(ctx context.Context, m *models.ProjectMembership, toState string) {
+	m.State = toState
+	m.UpdatedAt = c.now()
+	if toState == MembershipRevoked {
+		t := c.now()
+		m.RevokedAt = &t
+	} else {
+		m.ActivatedAt = nil
+	}
+	if err := c.storage.UpdateProjectMembership(ctx, m); err != nil {
+		c.auditProjectScoped(ctx, "membership.activation_race_revert_failed", m.UserID, m.ProjectID,
+			fmt.Sprintf("failed to revert orphaned active membership %d for user %d in project %d (state %s) after a role-grant failure: %v — MANUAL CLEANUP REQUIRED",
+				m.ID, m.UserID, m.ProjectID, toState, err))
+		return
+	}
+	c.logMembershipEvent(ctx, "membership.activation_reverted", m, 0)
 }

--- a/internal/core/membership_lifecycle_test.go
+++ b/internal/core/membership_lifecycle_test.go
@@ -118,6 +118,88 @@ func TestTransitionMembership_RejectsIllegalJump(t *testing.T) {
 	store.AssertNotCalled(t, "UpdateProjectMembership", mock.Anything, mock.Anything)
 }
 
+// TestInviteMember_OpenActivationFailure_RevertsOrphanedActiveMembership is the
+// (#309) losing-racer regression: open-mode InviteMember commits a `state=active`
+// ProjectMembership row first, then grants the role. This deterministically
+// simulates the losing racer of a concurrent invite race (or any other path that
+// already holds the role independently of this membership) by making the role
+// grant itself fail with the exact composite-primary-key rejection message a real
+// SQLite/Postgres backend returns ("Role already assigned") — reproducing the
+// interleaving without needing real goroutines. It asserts (a) the caller still
+// sees the error (existing, correct behavior) and (b) the just-created row no
+// longer reads as active — it must not survive as an orphaned "ghost" active
+// membership behind a reported failure.
+func TestInviteMember_OpenActivationFailure_RevertsOrphanedActiveMembership(t *testing.T) {
+	store := new(MockStorage)
+	c := newMembershipCore(store)
+	c.membershipValidationMode = ValidationModeOpen
+	ctx := context.Background()
+
+	store.On("GetRoleByName", ctx, "project_viewer").Return(&models.Role{ID: 6, Name: "project_viewer"}, nil)
+	store.On("GetActiveProjectMembership", ctx, uint(1), uint(2)).Return(nil, fmt.Errorf("not found"))
+	created := &models.ProjectMembership{ID: 51, ProjectID: 1, UserID: 2, Role: "project_viewer", State: MembershipActive}
+	store.On("CreateProjectMembership", ctx, mock.MatchedBy(func(m *models.ProjectMembership) bool {
+		return m.State == MembershipActive && m.ProjectID == 1 && m.UserID == 2
+	})).Return(created, nil)
+	// The composite user_roles primary key rejects the grant — the losing racer (or
+	// any caller whose role is already held via an independent path).
+	store.On("AssignRole", ctx, uint(2), uint(6), storage.Scope{ProjectID: 1}).
+		Return(fmt.Errorf("Role already assigned"))
+	store.On("UpdateProjectMembership", ctx, mock.MatchedBy(func(m *models.ProjectMembership) bool {
+		return m.ID == 51 && m.State == MembershipRevoked && m.RevokedAt != nil
+	})).Return(nil)
+	store.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
+
+	m, err := c.InviteMember(ctx, 1, 2, "project_viewer", 9, false)
+
+	// (a) the error still propagates to the caller.
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to grant role on activation")
+	assert.Nil(t, m)
+
+	// (b) the just-created row was actually reverted, not left standing active.
+	store.AssertNumberOfCalls(t, "UpdateProjectMembership", 1)
+	assert.Equal(t, MembershipRevoked, created.State, "orphaned row must not still read as active")
+	assert.NotNil(t, created.RevokedAt)
+}
+
+// TestTransitionMembership_ActivationFailure_RevertsToPriorState is the (#309)
+// companion for the non-Open validation modes: an admin's explicit
+// TransitionMembership(..., MembershipActive, ...) call persists `active` first,
+// then grants the role — the identical ordering, and identical orphan risk, as
+// inviteMemberWithMode. Unlike a brand-new invite, this row already existed in a
+// legitimate pending state before the failed activation attempt, so the revert
+// must restore THAT state (leaving the membership retriable) rather than jumping
+// straight to the terminal `revoked` state.
+func TestTransitionMembership_ActivationFailure_RevertsToPriorState(t *testing.T) {
+	store := new(MockStorage)
+	c := newMembershipCore(store)
+	ctx := context.Background()
+
+	existing := &models.ProjectMembership{ID: 50, ProjectID: 1, UserID: 2, Role: "project_viewer", State: MembershipProvisioned}
+	store.On("GetProjectMembership", ctx, uint(50)).Return(existing, nil)
+	store.On("GetRoleByName", ctx, "project_viewer").Return(&models.Role{ID: 6, Name: "project_viewer"}, nil)
+	// First write: persists the (about to be reverted) active state.
+	store.On("UpdateProjectMembership", ctx, mock.MatchedBy(func(m *models.ProjectMembership) bool {
+		return m.ID == 50 && m.State == MembershipActive
+	})).Return(nil).Once()
+	store.On("AssignRole", ctx, uint(2), uint(6), storage.Scope{ProjectID: 1}).
+		Return(fmt.Errorf("Role already assigned"))
+	// Revert write: must go back to `provisioned`, not `revoked`.
+	store.On("UpdateProjectMembership", ctx, mock.MatchedBy(func(m *models.ProjectMembership) bool {
+		return m.ID == 50 && m.State == MembershipProvisioned
+	})).Return(nil).Once()
+	store.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
+
+	m, err := c.TransitionMembership(ctx, 1, 50, MembershipActive, 9)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to grant role on activation")
+	assert.Nil(t, m)
+	assert.Equal(t, MembershipProvisioned, existing.State, "must revert to the pre-transition state, not stay active or jump to revoked")
+	store.AssertNumberOfCalls(t, "UpdateProjectMembership", 2)
+}
+
 // Cross-project guard: a membership in project 2 must not be transitionable when
 // the caller is authorized for project 1 (would otherwise grant a role in 2).
 func TestTransitionMembership_RejectsOtherProject(t *testing.T) {

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -1125,9 +1125,15 @@ type ProjectMembership struct {
 	UserID    uint `gorm:"index"`
 	Role      string
 	State     string // invited | identity_verified | provisioned | active | revoked
-	// Uniqueness of a non-revoked membership per (project, user) is enforced in
-	// core (see InviteMember), not by a DB constraint — so a revoked membership
-	// can be followed by a fresh invite without a unique-index collision.
+	// Uniqueness of a non-revoked membership per (project, user) is enforced by a
+	// DB-level partial unique index (uniq_project_memberships_active, factory.go's
+	// ensureProjectMembershipIndex, scoped to state <> 'revoked') so a revoked
+	// membership can be followed by a fresh invite without a unique-index collision,
+	// while two concurrent invites for the same (project, user) can't both commit a
+	// row (#309). That index only dedupes this table, though — it says nothing about
+	// the user_roles grant a membership is supposed to carry once active; see
+	// KeyorixCore.revertFailedActivation for what happens when that grant fails
+	// after this row already committed as active.
 	InvitedBy   uint
 	InvitedAt   time.Time
 	ActivatedAt *time.Time


### PR DESCRIPTION
## Summary

- `inviteMemberWithMode` (open-mode `InviteMember`) and `TransitionMembership` both persist a `ProjectMembership` row as `active` and only afterward grant the backing role via `AddProjectMember`. If that role grant fails after the row already committed as active — e.g. the composite `user_roles` primary key rejects a grant already held via an independent path, such as the losing side of a concurrent invite race — the row was left standing as `active` with no grant behind it, even though the caller sees an error implying nothing was persisted. `ListProjectMemberships`/`ListUserProjectMemberships` would then keep reporting the user as an active project member indefinitely — an access-review/compliance-audit-accuracy gap (#309).
- Added `revertFailedActivation`, invoked from both call sites when the role grant fails. `inviteMemberWithMode` reverts its freshly-created row to `revoked` (no earlier state exists to fall back to); `TransitionMembership` reverts to the membership's own pre-transition state so a legitimate retry stays possible. Both mirror the existing `revokeInvitationGrants` idiom: best-effort, audited (with a "MANUAL CLEANUP REQUIRED" message) on failure rather than returned/retried, since the caller is already on a fail-closed path.
- Corrected a stale `ProjectMembership` doc comment claiming uniqueness is "not [enforced by] a DB constraint" — a partial unique index (`uniq_project_memberships_active`) already closes that specific race (landed in #599); this fix addresses the separate, still-open gap where the role-grant step can fail *after* that row legitimately committed.

Note: the original duplicate-active-membership-row race (two concurrent invites both creating a row) was already closed by `uniq_project_memberships_active` (#599). This PR fixes the residual, sharper gap identified afterward: even with only one membership row ever created, its backing role grant can still fail (e.g. the role is already held via an unrelated path), and that failure wasn't reverting the row.

## Test plan

- [x] Added `TestInviteMember_OpenActivationFailure_RevertsOrphanedActiveMembership`: deterministically simulates a role-grant failure (`AssignRole` returns the exact composite-primary-key rejection message) after the membership row committed as active; asserts the error is still returned to the caller AND the row is reverted to `revoked` rather than left active.
- [x] Added `TestTransitionMembership_ActivationFailure_RevertsToPriorState`: same scenario via the explicit-transition path (allowlist/idp modes); asserts the row reverts to its pre-transition state (not `revoked`), keeping it retriable.
- [x] `go build ./...`, `go vet ./...` clean.
- [x] `go test ./internal/core/... ./internal/storage/...` — all pass.
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues.