### PR TITLE
chore(deps): add gomod ecosystem to Dependabot (#478)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,13 @@ updates:
     directory: /
     schedule:
       interval: weekly
+  # #478: without a gomod entry, Go dependency/toolchain-minimum drift (e.g. #477)
+  # has no automated forcing function and depends on someone noticing manually.
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+  - package-ecosystem: gomod
+    directory: /operator
+    schedule:
+      interval: weekly


### PR DESCRIPTION
## Summary
- Adds a `gomod` Dependabot ecosystem entry for the root module and a second one for `operator/` (its own separate Go module), alongside the existing `github-actions` entry.

Root-cause fix for #478 from the hardening backlog: without this, Go dependency/toolchain-minimum drift (e.g. #477's stale `go` directive, fixed in #683) has no automated forcing function — it depends entirely on someone noticing and bumping manually.

## Test plan
- [x] Validated YAML syntax (`YAML.load_file`)
- [x] Config-only change, no code paths affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)