### PR TITLE
fix(ci): add docker/setup-buildx-action to fix broken image publishing

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -28,6 +28,12 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # provenance/sbom attestations below require the docker-container driver;
+      # the runner's default `docker` driver doesn't support them and fails the
+      # build with "Attestation is not supported for the docker driver."
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+
       - name: Image metadata (tags, labels)
         id: meta
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
@@ -83,6 +89,12 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # provenance/sbom attestations below require the docker-container driver;
+      # the runner's default `docker` driver doesn't support them and fails the
+      # build with "Attestation is not supported for the docker driver."
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+
       - name: Image metadata (tags, labels)
         id: meta
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
@@ -133,6 +145,12 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # provenance/sbom attestations below require the docker-container driver;
+      # the runner's default `docker` driver doesn't support them and fails the
+      # build with "Attestation is not supported for the docker driver."
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+
       - name: Image metadata (tags, labels)
         id: meta
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
@@ -179,6 +197,12 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      # provenance/sbom attestations below require the docker-container driver;
+      # the runner's default `docker` driver doesn't support them and fails the
+      # build with "Attestation is not supported for the docker driver."
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Image metadata (tags, labels)
         id: meta


### PR DESCRIPTION
## Summary

`docker-publish` has been failing **100% of the time since ~2026-07-03 21:25** — every single run since, across all 4 image jobs (server, k8s-sync, operator, mcp):

```
ERROR: failed to build: Attestation is not supported for the docker driver.
```

Root cause: the "supply-chain hardening" change that added `provenance: mode=max`/`sbom: true` to `build-push-action` (`7dc44f8`) didn't also switch the buildx driver. Attestations require the `docker-container` driver; GitHub Actions runners default to the plain `docker` driver, which doesn't support them.

**This has been silently blocking every image publish to GHCR** since the regression landed — no server/k8s-sync/operator/mcp image has actually been built or pushed in that window, even though other CI checks report green. Cutting a release tag right now would hit the identical failure in the tag-triggered run and produce a GitHub release with no images behind it.

## Fix

Adds a `docker/setup-buildx-action` step (defaults to the `docker-container` driver) before each of the 4 `build-push-action` calls.

## Test plan

- [x] Validated YAML syntax (`YAML.load_file`)
- [x] Confirmed via `gh run list --workflow docker-publish.yml` that every run since 2026-07-03T21:25 has failed with this exact error
- [ ] Verify the next push to `main` (this PR merging) produces a green `docker-publish` run

🤖 Generated with [Claude Code](https://claude.com/claude-code)