### PR TITLE
fix(ci): authenticate to GHCR for cosign chart signing in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,6 +79,19 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3.10.0
 
+      # `helm registry login` below only populates Helm's own credential store
+      # (~/.config/helm/registry/config.json) — cosign resolves registry auth via
+      # the standard Docker config (~/.docker/config.json), which stays empty
+      # without this, so `cosign sign` fails with UNAUTHORIZED even though the
+      # preceding `helm push` calls succeed. docker-publish.yml already does this
+      # correctly for the image cosign-signing steps; mirrors that here.
+      - name: Log in to GHCR (for cosign)
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Package + push charts to GHCR (OCI)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

`release`'s `publish-chart` job failed on the `v0.87.0` tag: all 3 `helm push` calls succeeded, but the first `cosign sign` call failed with:

```
Error: signing [ghcr.io/keyorixhq/charts/keyorix:0.87.0]: recursively signing: signing digest: POST https://ghcr.io/v2/keyorixhq/charts/keyorix/blobs/uploads/: UNAUTHORIZED: unauthenticated: User cannot be authenticated with the token provided.
```

Root cause: `helm registry login` only populates Helm's own credential store (`~/.config/helm/registry/config.json`). `cosign` resolves registry auth via the standard Docker config (`~/.docker/config.json`), which stays empty without a `docker login` step — so cosign has no credential to use even though the preceding `helm push` succeeded.

## Fix

Adds a `docker/login-action` step before the push+sign block, mirroring the identical, already-working pattern `docker-publish.yml` uses for its own image-signing cosign calls.

**Note on `v0.87.0`**: the 3 charts are live in GHCR at the correct digests but unsigned. Not retroactively fixable without mutating an already-published tag — this fixes it forward for the next release.

## Test plan

- [x] Validated YAML syntax (`YAML.load_file`)
- [ ] Verify `publish-chart` succeeds end-to-end (helm push + cosign sign) on the next `v*` tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)