### PR TITLE
harden(chart): warn when Ingress TLS is left unset (#479)

### DIFF
--- a/deploy/helm/keyorix/templates/NOTES.txt
+++ b/deploy/helm/keyorix/templates/NOTES.txt
@@ -16,6 +16,14 @@ Keyorix has been deployed as release "{{ .Release.Name }}".
 
    kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "keyorix.server.fullname" . }} 8080:{{ .Values.server.service.port }}
 {{- end }}
+{{- if and .Values.ingress.enabled (not .Values.ingress.tls) }}
+
+⚠️  WARNING — ingress.tls is empty, so this Ingress serves plaintext HTTP only.
+    Session cookies, PATs, and login passwords will cross the wire unencrypted
+    unless TLS already terminates upstream (e.g. a cloud load balancer). Set
+    ingress.tls to enable HTTPS at this ingress, or confirm upstream TLS
+    termination is in place.
+{{- end }}
 
 {{- if .Values.auth.adminPassword }}
 

--- a/deploy/helm/keyorix/values.yaml
+++ b/deploy/helm/keyorix/values.yaml
@@ -89,7 +89,12 @@ ingress:
   className: ""
   annotations: {}
   host: keyorix.local
-  tls: []   # e.g. [{ secretName: keyorix-tls, hosts: [keyorix.example.com] }]
+  # e.g. [{ secretName: keyorix-tls, hosts: [keyorix.example.com] }]
+  # #479: left empty, the ingress serves plaintext HTTP only — session cookies,
+  # PATs, and the admin/master passwords entered at login would cross the wire
+  # unencrypted. Only leave this empty if TLS already terminates upstream (e.g.
+  # a cloud load balancer or service mesh) before traffic reaches this ingress.
+  tls: []
 
 # ── Bundled PostgreSQL ────────────────────────────────────────────────────────
 # A minimal in-chart Postgres for evaluation. For production, set enabled:false


### PR DESCRIPTION
## Summary
- `deploy/helm/keyorix`'s Ingress template renders plaintext-HTTP-only when `ingress.tls` is left at its empty default — session cookies, PATs, and login passwords would cross the wire unencrypted, with no signal beyond an easy-to-miss `http`/`https` toggle buried in NOTES.txt (backlog #479, LOW).
- Adds a prominent NOTES.txt warning when `ingress.enabled` but `ingress.tls` is empty, and documents the risk directly on the `values.yaml` field.
- Deliberately a warning, not a hard `fail`: some deployments terminate TLS upstream (cloud LB, service mesh) before traffic reaches this ingress, which is a legitimate configuration.

## Test plan
- [x] `helm lint deploy/helm/keyorix` passes
- [x] `helm install --dry-run` with `ingress.enabled=true` and no `tls` renders the new warning
- [x] `helm install --dry-run` with `ingress.tls` set renders no warning (no false positive)
- [x] `helm install --dry-run` with `ingress.enabled=false` (default) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)