### PR TITLE
fix(rbac): close InviteGlobal's admin-rank-ceiling gap (#231)

### DIFF
--- a/internal/core/invitation_global_test.go
+++ b/internal/core/invitation_global_test.go
@@ -82,6 +82,42 @@ func TestInviteGlobal_RejectsAssignmentMissingRole(t *testing.T) {
 	store.AssertNotCalled(t, "CreateProjectInvitation", mock.Anything, mock.Anything)
 }
 
+// #231: InviteGlobal must refuse to let a non-admin actor mint a global admin
+// system role, mirroring the ceiling check InviteToProject already applies to
+// its own role parameter. Uses real storage since the check goes through
+// GetUserRoleIDsAt, not a mockable single call.
+func TestInviteGlobal_RejectsNonAdminGrantingGlobalAdminRole(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	ctx := context.Background()
+
+	// A non-admin actor holding only roles.write-adjacent permissions (project_developer,
+	// no admin-tier role anywhere) must not be able to mint an "admin" invitation.
+	nonAdminID := seedUserWithRole(t, st, "non-admin-inviter", "project_developer", storage.Scope{})
+
+	_, err := c.InviteGlobal(ctx, "mallory@acme.io", "admin", nil, nonAdminID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "only an administrator can grant")
+}
+
+// #231: the per-project assignments bundled into a global invite must be
+// individually ceiling-checked too — a non-admin actor shouldn't be able to
+// smuggle an admin-conferring project assignment into an otherwise-plain
+// global invite.
+func TestInviteGlobal_RejectsNonAdminGrantingProjectAdminAssignment(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	ctx := context.Background()
+
+	nonAdminID := seedUserWithRole(t, st, "non-admin-inviter-2", "project_developer", storage.Scope{})
+	proj, err := st.CreateProject(ctx, &models.Project{Name: "target-project"})
+	require.NoError(t, err)
+
+	_, err = c.InviteGlobal(ctx, "mallory2@acme.io", "system_viewer", []ProjectAssignment{
+		{ProjectID: proj.ID, Role: "project_admin"},
+	}, nonAdminID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "only an administrator can grant")
+}
+
 func TestInviteGlobal_DefaultsSystemViewer(t *testing.T) {
 	store := new(MockStorage)
 	c := newInviteCore(store)

--- a/internal/core/invitations.go
+++ b/internal/core/invitations.go
@@ -169,6 +169,12 @@ func (c *KeyorixCore) InviteGlobal(ctx context.Context, email, systemRole string
 	if _, err := c.storage.GetRoleByName(ctx, sysRole); err != nil {
 		return nil, fmt.Errorf("unknown role %q (system): %w", sysRole, err)
 	}
+	// Escalation-by-proxy guard (#231), mirroring InviteToProject: a global system
+	// role is the most powerful grant this flow can mint, so it needs the same
+	// admin-authority ceiling check, at global scope (projectID 0).
+	if err := c.requireAuthorityForRole(ctx, invitedBy, 0, sysRole); err != nil {
+		return nil, err
+	}
 
 	// Validate + dedup assignments before persisting anything.
 	seen := map[uint]bool{}
@@ -186,6 +192,13 @@ func (c *KeyorixCore) InviteGlobal(ctx context.Context, email, systemRole string
 		}
 		if _, err := c.storage.GetRoleByName(ctx, a.Role); err != nil {
 			return nil, fmt.Errorf("unknown role %q: %w", a.Role, err)
+		}
+		// Same ceiling check InviteToProject applies to its own role parameter —
+		// without this, a non-admin roles.assign holder could bundle an
+		// admin-conferring project assignment into an otherwise-innocuous global
+		// invite.
+		if err := c.requireAuthorityForRole(ctx, invitedBy, a.ProjectID, a.Role); err != nil {
+			return nil, err
 		}
 		clean = append(clean, ProjectAssignment{ProjectID: a.ProjectID, Role: a.Role})
 	}


### PR DESCRIPTION
## Summary

`InviteGlobal` grants a global `SystemRole` plus a set of per-project assignments, but unlike its sibling `InviteToProject`, it never called `requireAuthorityForRole` — a non-admin `roles.assign` holder could invite someone into any global system role (including `super_admin`), or bundle an admin-conferring project assignment into an otherwise-plain global invite, with no ceiling check anywhere in the chain. This is the most severe remaining instance of the admin-rank-ceiling family already closed elsewhere (#93/#107/#141/#169/#230).

## Fix

Adds the same `requireAuthorityForRole` check `InviteToProject` already applies: once at global scope (`projectID 0`) for the system role, and once per project assignment for its role — both no-ops for non-admin roles (`isAdminRoleName` short-circuits), so this doesn't change behavior for the common case.

## Test plan

- [x] Two new regression tests: a non-admin actor is rejected both when requesting a global `admin` system role and when bundling a `project_admin` project assignment into an otherwise-plain invite
- [x] All existing `InviteGlobal`/invitation tests still pass unmodified
- [x] `go build`/`go vet` clean
- [x] `gosec -severity medium` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)