### PR TITLE
fix(cli): use securefiles for trust/license key-material writes (#265)

### DIFF
--- a/internal/cli/license/license.go
+++ b/internal/cli/license/license.go
@@ -8,10 +8,12 @@ package license
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
 	ilicense "github.com/keyorixhq/keyorix/internal/license"
+	"github.com/keyorixhq/keyorix/internal/securefiles"
 	"github.com/keyorixhq/keyorix/internal/trust"
 	"github.com/spf13/cobra"
 )
@@ -111,7 +113,11 @@ var installCmd = &cobra.Command{
 		if st.State == ilicense.StateInvalid {
 			return fmt.Errorf("refusing to install an invalid license: %s", st.Reason)
 		}
-		if err := os.WriteFile(installDest, []byte(token+"\n"), 0o600); err != nil {
+		// SecureWriteFileSync (#265) refuses to write through a pre-planted symlink
+		// (O_NOFOLLOW) and enforces the mode even if a file already existed with a
+		// looser one — a plain os.WriteFile silently follows a symlink and never
+		// chmods an existing file.
+		if err := securefiles.SecureWriteFileSync(filepath.Dir(installDest), filepath.Base(installDest), []byte(token+"\n"), 0o600); err != nil {
 			return fmt.Errorf("write license: %w", err)
 		}
 		fmt.Printf("Installed license for %q (plan %s) → %s\n", st.Licensee, st.Plan, installDest)

--- a/internal/cli/trust/keygen_test.go
+++ b/internal/cli/trust/keygen_test.go
@@ -74,6 +74,23 @@ func TestKeygen_RefusesOverwriteWithoutForce_AllowsWithForce(t *testing.T) {
 	assert.NotEqual(t, origPub, newPub, "--force must actually overwrite the public key")
 }
 
+// #265: a dangling symlink planted at the target path (its target not yet existing,
+// so the pre-write os.Stat existence check doesn't catch it) must not be silently
+// written through — the write should fail rather than create the key material at
+// the symlink's target location outside keygenDir.
+func TestKeygen_RefusesToFollowSymlinkAtTarget(t *testing.T) {
+	dir := t.TempDir()
+	outsideTarget := filepath.Join(t.TempDir(), "exfiltrated.private.pem")
+	require.NoError(t, os.Symlink(outsideTarget, filepath.Join(dir, "sym-test.private.pem")))
+
+	keygenPurpose, keygenKeyID, keygenDir, keygenForce = "update", "sym-test", dir, false
+	err := keygenCmd.RunE(keygenCmd, nil)
+	require.Error(t, err, "writing through a pre-planted symlink must be refused")
+
+	_, statErr := os.Stat(outsideTarget)
+	assert.True(t, os.IsNotExist(statErr), "the symlink target must NOT have been created")
+}
+
 func TestKeygen_RejectsBadPurposeAndMissingKeyID(t *testing.T) {
 	keygenPurpose, keygenKeyID, keygenDir = "bogus", "x", t.TempDir()
 	require.Error(t, keygenCmd.RunE(keygenCmd, nil), "an invalid purpose is rejected")

--- a/internal/cli/trust/trust.go
+++ b/internal/cli/trust/trust.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/keyorixhq/keyorix/internal/securefiles"
 	itrust "github.com/keyorixhq/keyorix/internal/trust"
 	"github.com/spf13/cobra"
 )
@@ -85,11 +86,16 @@ var keygenCmd = &cobra.Command{
 		pubPEM := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubDER})
 
 		// Both at 0600 — the private key is a signing secret; the public key need not be
-		// world-readable here (it is published separately).
-		if err := os.WriteFile(privPath, privPEM, 0o600); err != nil {
+		// world-readable here (it is published separately). SecureWriteFileSync (#265)
+		// refuses to write through a pre-planted symlink (O_NOFOLLOW) and enforces the
+		// mode even if a file already existed with a looser one — a plain os.WriteFile
+		// silently follows a symlink and never chmods an existing file, so the ROOT
+		// signing key could land world-readable or redirected to an attacker-controlled
+		// path with no error. Sync'd since this is unrecoverable key material.
+		if err := securefiles.SecureWriteFileSync(keygenDir, keyID+".private.pem", privPEM, 0o600); err != nil {
 			return fmt.Errorf("write private key: %w", err)
 		}
-		if err := os.WriteFile(pubPath, pubPEM, 0o600); err != nil {
+		if err := securefiles.SecureWriteFileSync(keygenDir, keyID+".public.pem", pubPEM, 0o600); err != nil {
 			return fmt.Errorf("write public key: %w", err)
 		}
 


### PR DESCRIPTION
## Summary

`keyorix trust keygen` and `keyorix license install` both wrote security-critical key material via a raw `os.WriteFile`, which silently retains a pre-existing file's mode (`O_TRUNC` alone only applies perm at creation time) and follows a symlink at the target path instead of refusing it — the product's ROOT ed25519 signing key, or an installed license token, could land world-readable or get redirected through an attacker-planted symlink with no error.

## Fix

Switches both to `internal/securefiles.SecureWriteFileSync`, the same `O_NOFOLLOW` + explicit-chmod primitive already used elsewhere in the codebase (e.g. `internal/cli/secret/export.go`) and already thoroughly tested at the primitive level (`TestSecureWriteRefusesDanglingSymlink`, `TestContainmentRejectsSymlinkEscape`). Sync'd since both are unrecoverable/durability-sensitive key material.

## Test plan

- [x] New regression test `TestKeygen_RefusesToFollowSymlinkAtTarget` proves this end-to-end via the real `keygen` CLI command: a dangling symlink planted at the target path (which the pre-write `os.Stat` existence check doesn't catch, since its target doesn't exist yet) is now refused instead of silently written through
- [x] All existing `trust`/`license` tests pass unmodified
- [x] `go build`/`go vet` clean
- [x] `gosec -severity medium` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)