### PR TITLE
docs(encryption): fix stale comment implying #92 is unfixed

### DIFF
--- a/internal/encryption/keymanager_rotation.go
+++ b/internal/encryption/keymanager_rotation.go
@@ -33,15 +33,18 @@ func (km *KeyManager) RotateDEKWithSweep(passphrase string, sweepFn func(oldSvc,
 		return fmt.Errorf("key manager not initialized — cannot rotate")
 	}
 
-	// #195/baseline: acquire the same cross-process exclusive DEK lock as
-	// RewrapDEK. Prior to this fix RotateDEKWithSweep held no cross-process
-	// lock at all (the #92 fix that added one lives only on an unmerged
-	// branch) — a concurrent RewrapDEK/RewrapDEKWithProvider (`migrate-
-	// provider`) racing this rotation could read the DEK being replaced here
-	// and, if its rename landed after this one's, silently overwrite the
+	// #195: acquire the same cross-process exclusive DEK lock as RewrapDEK.
+	// Prior to this fix RotateDEKWithSweep held no cross-process lock here at
+	// all — a concurrent RewrapDEK/RewrapDEKWithProvider (`migrate-provider`)
+	// racing this rotation could read the DEK being replaced here and, if its
+	// rename landed after this one's, silently overwrite the
 	// freshly-rotated (and now fully re-encrypted-into) DEK with the
 	// superseded one. Both operations write to the same
 	// dek.key.pending → dek.key path, so they must be mutually exclusive.
+	// (Distinct from #92's server-vs-rotation lock in service.go's
+	// AcquireExclusiveKeyLock/`dek.lock`, which guards a live server process
+	// against rotation — that fix is merged; this one guards two
+	// rotation-family CLI ops against each other.)
 	lock, err := km.acquireExclusiveKeyLock()
 	if err != nil {
 		return fmt.Errorf("rotate DEK: %w", err)


### PR DESCRIPTION
## Summary
Backlog round 95's CRITICAL+HIGH reconciliation flagged #92 as "still open," quoting `keymanager_rotation.go`'s comment stating the #92 fix "lives only on an unmerged branch." That's stale: #92's actual fix (PR #526, a cross-process lock in `service.go`'s `AcquireExclusiveKeyLock`/`dek.lock` that mutually excludes a live server from a running rotation) merged the same day as the comment was written (PR #651, #195) but never touched this file — so the comment was never updated and now misleadingly reads as if #92 is unaddressed.

No behavior change — comment-only fix, clarifying that this lock (#195, rotation-vs-migrate-provider) is distinct from #92's lock (server-vs-rotation).

## Test plan
- [x] `go build`/`go vet` clean
- [x] `go test ./internal/encryption/...` passes
- [x] `gosec -severity medium` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)