### PR TITLE
fix(storage): stop silently dropping account_state/lockout writes under remote storage (#454)

### DIFF
--- a/internal/core/account_state.go
+++ b/internal/core/account_state.go
@@ -163,6 +163,12 @@ func (c *KeyorixCore) RequirePasswordReset(ctx context.Context, adminID, userID 
 // UpdateSCIMUser in-process, and LockUserForUpdate's row lock (Postgres: SELECT ...
 // FOR UPDATE) does the same across replicas — the identical pattern recordFailedLogin
 // uses for the login-lockout counter (see login_lockout.go).
+//
+// #454: persists via SetAccountState, not the generic UpdateUser — an admin
+// suspend/reactivate is an explicit security directive, so a backend that cannot
+// actually persist account_state (RemoteStorage, storage.type: remote) must fail this
+// call outright rather than silently succeed while the account stays unchanged. See
+// SetAccountState's doc comment on storage.Storage.
 func (c *KeyorixCore) setAccountState(ctx context.Context, adminID, userID uint, state, eventType string) error {
 	if userID == 0 {
 		return fmt.Errorf("user ID is required")
@@ -172,8 +178,9 @@ func (c *KeyorixCore) setAccountState(ctx context.Context, adminID, userID uint,
 
 	var sessionHashes []string
 	err := c.storage.WithTransaction(ctx, func(tx storage.Storage) error {
-		user, err := tx.LockUserForUpdate(ctx, userID)
-		if err != nil {
+		// The lock-guarded read is still needed for serialization (row lock + existence
+		// check) even though its returned user struct is no longer written back wholesale.
+		if _, err := tx.LockUserForUpdate(ctx, userID); err != nil {
 			return err
 		}
 		// Capture the user's current session-token HASHES BEFORE mutating so we can evict
@@ -184,9 +191,7 @@ func (c *KeyorixCore) setAccountState(ctx context.Context, adminID, userID uint,
 		// SHA-256 hash, which is exactly the cache key.
 		sessionHashes, _ = tx.ListSessionTokenHashesForUser(ctx, userID)
 
-		user.AccountState = state
-		user.UpdatedAt = c.now()
-		if _, err := tx.UpdateUser(ctx, user); err != nil {
+		if err := tx.SetAccountState(ctx, userID, state, c.now()); err != nil {
 			return err
 		}
 		// A state that blocks login must also terminate the user's existing sessions AND

--- a/internal/core/account_state_test.go
+++ b/internal/core/account_state_test.go
@@ -95,9 +95,7 @@ func TestAdminAccountTransitions(t *testing.T) {
 			c := newAccountCore(store)
 			ctx := context.Background()
 			store.On("GetUser", ctx, uint(2)).Return(&models.User{ID: 2, AccountState: AccountActive}, nil)
-			store.On("UpdateUser", ctx, mock.MatchedBy(func(u *models.User) bool {
-				return u.AccountState == tc.wantState
-			})).Return(&models.User{ID: 2}, nil)
+			store.On("SetAccountState", ctx, uint(2), tc.wantState, mock.Anything).Return(nil)
 			store.On("LogAuditEvent", ctx, mock.MatchedBy(func(e *models.AuditEvent) bool {
 				return e.EventType == tc.event
 			})).Return(nil)

--- a/internal/core/login_lockout.go
+++ b/internal/core/login_lockout.go
@@ -11,6 +11,7 @@ package core
 import (
 	"context"
 	"fmt"
+	"log"
 	"sync"
 	"time"
 
@@ -64,6 +65,25 @@ func (p LoginLockoutPolicy) cooldownFor(lockoutCount int) time.Duration {
 	return cd
 }
 
+// warnLockoutUnsupportedOnce logs a loud, ONE-TIME operator warning the first time the
+// active storage backend proves it can never persist login-lockout accounting (#454) —
+// as opposed to an ordinary transient storage error, which stays silent (the existing,
+// intentional fail-open backstop behaviour). Mirrors warnRateLimitUnsupportedOnce
+// (rate_limit.go, #452) for the identical class of gap on the other brute-force
+// backstop. Safe for concurrent use; only the first call's message is emitted.
+func (c *KeyorixCore) warnLockoutUnsupportedOnce() {
+	c.loginLockoutUnsupportedWarnOnce.Do(func() {
+		log.Printf("WARNING: per-account login lockout accounting is INERT under the " +
+			"active storage backend (storage.type: remote) — UpdateLoginLockoutState has " +
+			"no implementation to proxy to (the upstream server's PUT /api/v1/users/{id} " +
+			"wire format cannot carry these fields), so every failed-login/clear write " +
+			"fails and is silently skipped. There is NO per-account lockout protection for " +
+			"this deployment unless the cluster-wide per-IP rate limiter is relied on " +
+			"instead (see ADR-040 / #452). This warning is logged once per process; the " +
+			"underlying gap persists for its lifetime.")
+	})
+}
+
 // recordFailedLogin increments the user's failed-attempt counter (resetting it when
 // the previous failure is older than the window) and locks the account once it
 // reaches MaxAttempts. Best-effort persistence: a storage error must not change the
@@ -111,22 +131,38 @@ func (c *KeyorixCore) recordFailedLogin(ctx context.Context, user *models.User) 
 		u.FailedLoginAttempts++
 		u.LastFailedLoginAt = &now
 
-		if u.FailedLoginAttempts >= c.loginLockout.MaxAttempts {
+		tripped := u.FailedLoginAttempts >= c.loginLockout.MaxAttempts
+		if tripped {
 			u.LoginLockoutCount++
 			until := now.Add(c.loginLockout.cooldownFor(u.LoginLockoutCount))
 			u.LoginLockedUntil = &until
 			u.FailedLoginAttempts = 0 // window counter resets; the lock now gates
-			locked, lockedUntil, lockoutNum = true, until, u.LoginLockoutCount
 		}
-		if _, err := tx.UpdateUser(ctx, u); err != nil {
+		// #454: persist via the narrow UpdateLoginLockoutState, not the generic
+		// UpdateUser — RemoteStorage can never express these columns in its wire format,
+		// so it always returns storage.ErrUnsupportedByBackend here. Unlike
+		// setAccountState/UpdateSCIMUser's hard fail, lockout accounting is a passive
+		// backstop (#452's identical rationale for the per-IP rate limiter): log once and
+		// fail open, rather than erroring the caller (which would otherwise refuse every
+		// login attempt for a storage backend that can never persist this).
+		if err := tx.UpdateLoginLockoutState(ctx, uid, u.FailedLoginAttempts, u.LastFailedLoginAt, u.LoginLockedUntil, u.LoginLockoutCount); err != nil {
+			if isUnsupportedByBackend(err) {
+				c.warnLockoutUnsupportedOnce()
+				return nil
+			}
 			return err
 		}
 		// Reflect the persisted lockout fields back onto the caller's struct (it was
-		// loaded before the lock), without clobbering preloaded associations.
+		// loaded before the lock), without clobbering preloaded associations. Only reached
+		// when the write above actually committed, so a struct mutated in memory always
+		// matches what was (or, on the unsupported-backend path above, was not) persisted.
 		user.FailedLoginAttempts = u.FailedLoginAttempts
 		user.LastFailedLoginAt = u.LastFailedLoginAt
 		user.LoginLockedUntil = u.LoginLockedUntil
 		user.LoginLockoutCount = u.LoginLockoutCount
+		if tripped {
+			locked, lockedUntil, lockoutNum = true, *u.LoginLockedUntil, u.LoginLockoutCount
+		}
 		return nil
 	})
 	if err != nil {
@@ -164,6 +200,13 @@ func (c *KeyorixCore) recordFailedLogin(ctx context.Context, user *models.User) 
 // (VerifyMFALogin), and WebAuthn (FinishWebAuthnLogin /
 // FinishWebAuthnPasswordlessLogin) — recordFailedLogin feeds the same counter
 // from all of them, so the recheck must cover all of them too.
+//
+// #454: when clearing accumulated failures, a backend that can never persist the
+// clear (RemoteStorage) is treated the same as "nothing to clear" — logged once via
+// warnLockoutUnsupportedOnce and NOT surfaced as the fail-closed "unable to verify"
+// error, since lockout is a backstop, not the primary auth boundary (mirrors #452's
+// identical fail-open-but-loud tradeoff for the per-IP rate limiter). A genuine
+// transient storage error is unaffected and still fails closed below.
 func (c *KeyorixCore) checkLockAndClearLoginFailures(ctx context.Context, user *models.User) error {
 	if !c.loginLockout.Enabled {
 		c.clearLoginFailures(ctx, user)
@@ -193,11 +236,11 @@ func (c *KeyorixCore) checkLockAndClearLoginFailures(ctx context.Context, user *
 		if u.FailedLoginAttempts == 0 && u.LoginLockedUntil == nil && u.LoginLockoutCount == 0 {
 			return nil // nothing to clear
 		}
-		u.FailedLoginAttempts = 0
-		u.LastFailedLoginAt = nil
-		u.LoginLockedUntil = nil
-		u.LoginLockoutCount = 0
-		if _, err := tx.UpdateUser(ctx, u); err != nil {
+		if err := tx.UpdateLoginLockoutState(ctx, uid, 0, nil, nil, 0); err != nil {
+			if isUnsupportedByBackend(err) {
+				c.warnLockoutUnsupportedOnce()
+				return nil // can't clear counters on this backend; fail OPEN (not locked), not closed
+			}
 			return err
 		}
 		user.FailedLoginAttempts = 0
@@ -217,16 +260,23 @@ func (c *KeyorixCore) checkLockAndClearLoginFailures(ctx context.Context, user *
 
 // clearLoginFailures resets the lockout state after a successful authentication.
 // It writes only when there is something to clear, so the happy path adds no extra
-// write on every login.
+// write on every login. #454: persists via UpdateLoginLockoutState, not the generic
+// UpdateUser, so a backend that can never express these columns (RemoteStorage) is
+// visibly reported (a one-time operator warning) instead of silently no-op'd.
 func (c *KeyorixCore) clearLoginFailures(ctx context.Context, user *models.User) {
 	if user.FailedLoginAttempts == 0 && user.LoginLockedUntil == nil && user.LoginLockoutCount == 0 {
+		return
+	}
+	if err := c.storage.UpdateLoginLockoutState(ctx, user.ID, 0, nil, nil, 0); err != nil {
+		if isUnsupportedByBackend(err) {
+			c.warnLockoutUnsupportedOnce()
+		}
 		return
 	}
 	user.FailedLoginAttempts = 0
 	user.LastFailedLoginAt = nil
 	user.LoginLockedUntil = nil
 	user.LoginLockoutCount = 0
-	_, _ = c.storage.UpdateUser(ctx, user)
 }
 
 // UnlockUser clears a user's login-lockout state (admin action; audited). It does

--- a/internal/core/login_lockout_remote_test.go
+++ b/internal/core/login_lockout_remote_test.go
@@ -1,0 +1,96 @@
+package core
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/remote"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// apiOKUser writes a successful envelope response wrapping user, matching the format
+// RemoteStorage.GetUser (and so LockUserForUpdate, which is just GetUser — see
+// remote_users.go) expects.
+func apiOKUser(t *testing.T, w http.ResponseWriter, user *models.User) {
+	t.Helper()
+	type resp struct {
+		Success bool         `json:"success"`
+		Data    *models.User `json:"data"`
+	}
+	require.NoError(t, json.NewEncoder(w).Encode(resp{Success: true, Data: user}))
+}
+
+// newRemoteLockoutCore builds a KeyorixCore backed by RemoteStorage against a real
+// httptest server that only serves GET /api/v1/users/{id} (LockUserForUpdate's
+// underlying call, per remote_users.go) — always returning `user` unchanged, since
+// nothing this test does can ever actually persist anything server-side.
+// UpdateLoginLockoutState never has a wire endpoint to call at all (#454): it always
+// returns storage.ErrUnsupportedByBackend regardless of what the test server does.
+func newRemoteLockoutCore(t *testing.T, user *models.User, policy LoginLockoutPolicy) *KeyorixCore {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		apiOKUser(t, w, user)
+	}))
+	t.Cleanup(srv.Close)
+
+	rs, err := store.NewRemoteStorage(&remote.Config{
+		BaseURL: srv.URL, APIKey: "test-key", TimeoutSeconds: 5, RetryAttempts: 0, TLSVerify: false,
+	})
+	require.NoError(t, err)
+	now := time.Date(2026, 6, 12, 10, 0, 0, 0, time.UTC)
+	c := &KeyorixCore{storage: rs, now: func() time.Time { return now }, passwordPolicy: DefaultPasswordPolicy()}
+	c.SetLoginLockoutPolicy(policy)
+	return c
+}
+
+// TestLockout_RemoteStorageFailsOpenLoudlyOnce is the (#454) regression for the
+// "passive accounting" half of the fix: under storage.type: remote,
+// UpdateLoginLockoutState can never persist anything (the upstream wire format has no
+// field for these columns), so recordFailedLogin/checkLockAndClearLoginFailures must
+// (a) never panic or block a login over it, and (b) log the operator-visible warning
+// exactly ONCE per process — mirroring #452's identical treatment of the per-IP rate
+// limiter's RemoteStorage gap.
+func TestLockout_RemoteStorageFailsOpenLoudlyOnce(t *testing.T) {
+	// MaxAttempts=1 so a single recordFailedLogin call already tries to trip the lock,
+	// forcing an immediate attempt to persist via UpdateLoginLockoutState.
+	policy := LoginLockoutPolicy{Enabled: true, MaxAttempts: 1, Window: 15 * time.Minute, BaseCooldown: time.Minute, MaxCooldown: time.Hour}
+	user := &models.User{ID: 42, Username: "bob", AccountState: AccountActive, IsActive: true}
+	c := newRemoteLockoutCore(t, user, policy)
+	ctx := context.Background()
+
+	out := captureLog(t, func() {
+		assert.NotPanics(t, func() { c.recordFailedLogin(ctx, user) })
+	})
+	assert.Contains(t, out, "login lockout accounting is INERT", "first call must log the operator warning")
+	assert.Contains(t, out, "storage.type: remote")
+	// Nothing was actually persisted, so the caller's in-memory struct must not be
+	// mutated to falsely reflect a lock that was never recorded anywhere.
+	assert.Nil(t, user.LoginLockedUntil, "must not claim a lock was applied when persistence failed")
+
+	// The warning fires once per process, not once per call.
+	out2 := captureLog(t, func() {
+		for i := 0; i < 5; i++ {
+			c.recordFailedLogin(ctx, user)
+		}
+	})
+	assert.Empty(t, out2, "the warning must not repeat on subsequent calls")
+
+	// checkLockAndClearLoginFailures must fail OPEN (allow the login) rather than
+	// return its "unable to verify account lock state" fail-closed error — the backend
+	// being permanently unable to clear the counters is not the same as a transient
+	// storage error, and lockout is a backstop, not the primary auth boundary.
+	lockedUser := &models.User{ID: 43, Username: "carol", AccountState: AccountActive, IsActive: true, FailedLoginAttempts: 2}
+	c2 := newRemoteLockoutCore(t, lockedUser, policy)
+	out3 := captureLog(t, func() {
+		err := c2.checkLockAndClearLoginFailures(ctx, lockedUser)
+		assert.NoError(t, err, "must not block login just because lockout accounting can't be persisted")
+	})
+	assert.Contains(t, out3, "login lockout accounting is INERT")
+}

--- a/internal/core/migrate_user_to_machine_test.go
+++ b/internal/core/migrate_user_to_machine_test.go
@@ -22,13 +22,11 @@ func TestMigrateUserToMachine(t *testing.T) {
 		store.On("CreateMachineIdentity", ctx, mock.MatchedBy(func(m *models.MachineIdentity) bool {
 			return m.ProjectID == 3 && m.Name == "ci-bot" && m.IdentityType == MachineTypeService && m.State == MachineActive
 		})).Return(&models.MachineIdentity{ID: 20, ProjectID: 3, Name: "ci-bot", IdentityType: MachineTypeService, State: MachineActive}, nil)
-		// SuspendUser path: GetUser → UpdateUser(account_state=suspended) →
+		// SuspendUser path: LockUserForUpdate → SetAccountState(account_state=suspended) →
 		// purge the migrated user's sessions (suspension revokes existing tokens).
 		store.On("GetUser", ctx, uint(7)).
 			Return(&models.User{ID: 7, Username: "ci-bot", AccountState: "active"}, nil)
-		store.On("UpdateUser", ctx, mock.MatchedBy(func(u *models.User) bool {
-			return u.ID == 7 && u.AccountState == AccountSuspended
-		})).Return(&models.User{ID: 7, AccountState: AccountSuspended}, nil)
+		store.On("SetAccountState", ctx, uint(7), AccountSuspended, mock.Anything).Return(nil)
 		store.On("DeleteSessionsForUserExcept", ctx, uint(7), uint(0)).Return(nil)
 		// Suspension also evicts the user's cached session tokens and revokes their PATs.
 		store.On("ListSessionTokenHashesForUser", ctx, uint(7)).Return([]string{}, nil)
@@ -64,7 +62,7 @@ func TestMigrateUserToMachine(t *testing.T) {
 
 		_, err := c.MigrateUserToMachine(ctx, "svc", 1, MachineTypeAutomation, "renamed", 9, false)
 		require.NoError(t, err)
-		store.AssertNotCalled(t, "UpdateUser", mock.Anything, mock.Anything)
+		store.AssertNotCalled(t, "SetAccountState", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 		store.AssertExpectations(t)
 	})
 

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -744,6 +744,16 @@ func (m *MockStorage) UpdateLastLogin(ctx context.Context, userID uint, loginAt 
 	return args.Error(0)
 }
 
+func (m *MockStorage) SetAccountState(ctx context.Context, id uint, state string, updatedAt time.Time) error {
+	args := m.Called(ctx, id, state, updatedAt)
+	return args.Error(0)
+}
+
+func (m *MockStorage) UpdateLoginLockoutState(ctx context.Context, id uint, attempts int, lastFailedAt, lockedUntil *time.Time, lockoutCount int) error {
+	args := m.Called(ctx, id, attempts, lastFailedAt, lockedUntil, lockoutCount)
+	return args.Error(0)
+}
+
 func (m *MockStorage) DeleteUser(ctx context.Context, id uint) error {
 	args := m.Called(ctx, id)
 	return args.Error(0)

--- a/internal/core/remote_account_state_hardfail_test.go
+++ b/internal/core/remote_account_state_hardfail_test.go
@@ -1,0 +1,98 @@
+package core
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	corestorage "github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// errRemoteAccountState simulates exactly what RemoteStorage.SetAccountState returns
+// in production (see internal/storage/store/remote_users.go): a hard error wrapping
+// storage.ErrUnsupportedByBackend, since account_state has no field in the wire
+// format the upstream PUT /api/v1/users/{id} handler decodes.
+var errRemoteAccountState = fmt.Errorf("account_state cannot be persisted through remote storage: "+
+	"the upstream PUT /api/v1/users/{id} endpoint does not accept this field: %w",
+	corestorage.ErrUnsupportedByBackend)
+
+// TestSuspendUser_HardFailsWhenBackendCannotPersistAccountState is the (#454)
+// regression for the "explicit security directive" half of the fix: an admin
+// suspending a user against a storage backend that can never persist account_state
+// (RemoteStorage, storage.type: remote) must see the call FAIL — never a silent
+// "success" that leaves the account state unchanged and the admin believing the
+// suspension took effect.
+func TestSuspendUser_HardFailsWhenBackendCannotPersistAccountState(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	store := new(MockStorage)
+	c := newAccountCore(store)
+	ctx := context.Background()
+
+	store.On("GetUser", ctx, uint(2)).Return(&models.User{ID: 2, AccountState: AccountActive}, nil)
+	store.On("ListSessionTokenHashesForUser", ctx, uint(2)).Return([]string{}, nil)
+	store.On("SetAccountState", ctx, uint(2), AccountSuspended, mock.Anything).Return(errRemoteAccountState)
+
+	err := c.SuspendUser(ctx, 1, 2)
+	require.Error(t, err, "SuspendUser must fail, not silently succeed, when the backend can't persist account_state")
+	require.ErrorIs(t, err, corestorage.ErrUnsupportedByBackend)
+
+	// The write must never have escalated to session/PAT revocation on a failed state
+	// change (nothing was actually suspended, so nothing should be torn down either).
+	store.AssertNotCalled(t, "DeleteSessionsForUserExcept", mock.Anything, mock.Anything, mock.Anything)
+	store.AssertNotCalled(t, "LogAuditEvent", mock.Anything, mock.Anything)
+}
+
+// TestUpdateSCIMUser_HardFailsWhenBackendCannotPersistDeprovision is the (#454)
+// regression for UpdateSCIMUser's deactivation path: a SCIM/IdP deprovision under a
+// backend that cannot persist account_state must fail closed, not report success
+// while the account silently stays reachable.
+func TestUpdateSCIMUser_HardFailsWhenBackendCannotPersistDeprovision(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	store := new(MockStorage)
+	c := NewKeyorixCore(store)
+	ctx := context.Background()
+
+	target := &models.User{ID: 2, Username: "bob", IsActive: true, AccountState: AccountActive, ExternalID: "okta|bob"}
+	store.On("GetUser", ctx, uint(2)).Return(target, nil)
+	store.On("GetUserRoleIDsAt", ctx, uint(2), Scope{}).Return([]uint{}, nil)
+	store.On("GetUserGroupRoleIDsAt", ctx, uint(2), Scope{}).Return([]uint{}, nil)
+	store.On("SetAccountState", ctx, uint(2), AccountDeprovisioned, mock.Anything).Return(errRemoteAccountState)
+
+	no := false
+	_, err := c.UpdateSCIMUser(ctx, 9, 2, nil, nil, &no)
+	require.Error(t, err, "a SCIM deactivation must fail, not silently succeed, when the backend can't persist account_state")
+	require.ErrorIs(t, err, corestorage.ErrUnsupportedByBackend)
+
+	// Since SetAccountState is attempted (and fails) BEFORE the generic wire-field
+	// write, nothing should have been partially applied either.
+	store.AssertNotCalled(t, "UpdateUser", mock.Anything, mock.Anything)
+}
+
+// TestUpdateSCIMUser_NoStateChange_DoesNotConsultSetAccountState confirms the #454
+// fix didn't turn every SCIM update into a hard failure: a PATCH that never touches
+// account_state (e.g. displayName-only) must still succeed under a backend that can't
+// persist account_state, since SetAccountState is only invoked when the state
+// actually changes.
+func TestUpdateSCIMUser_NoStateChange_DoesNotConsultSetAccountState(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	store := new(MockStorage)
+	c := NewKeyorixCore(store)
+	ctx := context.Background()
+
+	target := &models.User{ID: 2, Username: "bob", IsActive: true, AccountState: AccountActive, ExternalID: "okta|bob"}
+	store.On("GetUser", ctx, uint(2)).Return(target, nil)
+	store.On("UpdateUser", ctx, mock.MatchedBy(func(u *models.User) bool {
+		return u.DisplayName == "Bob Smith"
+	})).Return(&models.User{ID: 2, DisplayName: "Bob Smith"}, nil)
+	store.On("LogAuditEvent", ctx, mock.Anything).Return(nil)
+
+	name := "Bob Smith"
+	updated, err := c.UpdateSCIMUser(ctx, 9, 2, &name, nil, nil)
+	require.NoError(t, err)
+	require.Equal(t, "Bob Smith", updated.DisplayName)
+	store.AssertNotCalled(t, "SetAccountState", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+}

--- a/internal/core/scim.go
+++ b/internal/core/scim.go
@@ -280,6 +280,11 @@ func (c *KeyorixCore) UpdateSCIMUser(ctx context.Context, actorID, id uint, disp
 		if !scimManaged(user) {
 			return storage.ErrUserNotFound
 		}
+		// Captured before any mutation below, so we can tell whether this call actually
+		// changes account_state (#454) — SetAccountState is only invoked when it does,
+		// avoiding an unnecessary hard failure under RemoteStorage for a plain
+		// displayName/email SCIM PATCH that never touches the lifecycle state at all.
+		origState := user.AccountState
 		if displayName != nil {
 			user.DisplayName = *displayName
 		}
@@ -310,6 +315,17 @@ func (c *KeyorixCore) UpdateSCIMUser(ctx context.Context, actorID, id uint, disp
 					user.AccountState = AccountDeprovisioned
 				}
 				deactivated = true
+			}
+		}
+		// #454: a SCIM deprovision/reactivate is an explicit security-relevant directive,
+		// not passive accounting — persist the state transition through SetAccountState
+		// FIRST (before any other write) and abort the whole update if the backend cannot
+		// actually persist it (RemoteStorage), rather than let a false "success" leave the
+		// account's login-blocking state silently unchanged. Ordered first so no partial
+		// effect (e.g. IsActive alone) is committed when this fails.
+		if user.AccountState != origState {
+			if err := tx.SetAccountState(ctx, id, user.AccountState, c.now()); err != nil {
+				return err
 			}
 		}
 		user.UpdatedAt = c.now()

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -132,6 +132,13 @@ type KeyorixCore struct {
 	// opposed to an ordinary transient storage error) — once per process, not
 	// once per request. Zero value is ready to use. See rate_limit.go.
 	rateLimitUnsupportedWarnOnce sync.Once
+	// loginLockoutUnsupportedWarnOnce guards the #454 operator warning logged the
+	// first time recordFailedLogin/checkLockAndClearLoginFailures/clearLoginFailures
+	// observe that the active storage backend can never satisfy
+	// UpdateLoginLockoutState (as opposed to an ordinary transient storage error) —
+	// once per process, not once per login attempt. Zero value is ready to use. See
+	// login_lockout.go.
+	loginLockoutUnsupportedWarnOnce sync.Once
 	auditForwarder               AuditForwarder
 	// auditStream is the in-process pub/sub broker that wakes live audit tails
 	// (gRPC StreamAuditLogs) the instant an event is written, replacing fixed-interval

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -369,6 +369,31 @@ type Storage interface {
 	// UpdateLastLogin stamps the user's last_login_at column without touching any
 	// other field (no updated_at bump). Called on every successful login.
 	UpdateLastLogin(ctx context.Context, userID uint, loginAt time.Time) error
+	// SetAccountState persists ONLY the account_state column (plus updated_at) —
+	// narrower than the generic UpdateUser, and deliberately so (#454): RemoteStorage's
+	// wire format (core.UpdateUserRequest, decoded by the upstream server's PUT
+	// /api/v1/users/{id} handler) carries only username/email/display_name/active, so a
+	// caller going through the generic LockUserForUpdate + UpdateUser read-modify-write to
+	// change account_state succeeds against LocalStorage but silently no-ops under
+	// storage.type: remote — the field is simply absent from the request body the upstream
+	// handler decodes, so it re-persists whatever account_state was already there. An admin
+	// suspend/reactivate (setAccountState) or a SCIM deprovision/reactivate (UpdateSCIMUser)
+	// is an explicit, security-relevant directive, not passive accounting — the caller must
+	// see a hard error rather than a false "success" that leaves the account state
+	// unchanged. LocalStorage performs the real column update; RemoteStorage always
+	// returns storage.ErrUnsupportedByBackend (wrapped) so the caller fails closed.
+	SetAccountState(ctx context.Context, id uint, state string, updatedAt time.Time) error
+	// UpdateLoginLockoutState persists ONLY the four login-lockout accounting columns
+	// (failed_login_attempts, last_failed_login_at, login_locked_until,
+	// login_lockout_count) — the same #454 rationale as SetAccountState above, since none
+	// of these fields are expressible in RemoteStorage's wire format either. Unlike
+	// SetAccountState, though, lockout accounting is a passive backstop counter, not an
+	// explicit security directive (mirrors #452's identical call on
+	// CountRecentLoginAttempts/RecordLoginAttempt): LocalStorage performs the real column
+	// update; RemoteStorage always returns storage.ErrUnsupportedByBackend (wrapped), and
+	// the core caller (login_lockout.go) logs a loud one-time operator warning and fails
+	// OPEN rather than blocking every login under this backend.
+	UpdateLoginLockoutState(ctx context.Context, id uint, attempts int, lastFailedAt, lockedUntil *time.Time, lockoutCount int) error
 	DeleteUser(ctx context.Context, id uint) error
 	RestoreUser(ctx context.Context, id uint) error
 	// PurgeDeleted*Before hard-delete soft-deleted rows whose deleted_at is

--- a/internal/storage/store/local_users.go
+++ b/internal/storage/store/local_users.go
@@ -195,6 +195,40 @@ func (ls *LocalStorage) UpdateLastLogin(ctx context.Context, userID uint, loginA
 	return nil
 }
 
+// SetAccountState persists ONLY account_state (and updated_at) via a direct column
+// update, rather than a full-row Save — see the storage.Storage interface doc comment
+// (#454) for why this narrower primitive exists alongside the generic UpdateUser.
+func (ls *LocalStorage) SetAccountState(ctx context.Context, id uint, state string, updatedAt time.Time) error {
+	result := ls.db.WithContext(ctx).Model(&models.User{}).Where("id = ?", id).
+		Updates(map[string]interface{}{"account_state": state, "updated_at": updatedAt})
+	if result.Error != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), result.Error)
+	}
+	if result.RowsAffected == 0 {
+		return fmt.Errorf("%s", i18n.T("ErrorUserNotFound", nil))
+	}
+	return nil
+}
+
+// UpdateLoginLockoutState persists ONLY the four login-lockout accounting columns via a
+// direct column update — see the storage.Storage interface doc comment (#454).
+func (ls *LocalStorage) UpdateLoginLockoutState(ctx context.Context, id uint, attempts int, lastFailedAt, lockedUntil *time.Time, lockoutCount int) error {
+	result := ls.db.WithContext(ctx).Model(&models.User{}).Where("id = ?", id).
+		Updates(map[string]interface{}{
+			"failed_login_attempts": attempts,
+			"last_failed_login_at":  lastFailedAt,
+			"login_locked_until":    lockedUntil,
+			"login_lockout_count":   lockoutCount,
+		})
+	if result.Error != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), result.Error)
+	}
+	if result.RowsAffected == 0 {
+		return fmt.Errorf("%s", i18n.T("ErrorUserNotFound", nil))
+	}
+	return nil
+}
+
 // ListUsersInStateBefore returns users whose account_state equals state and who
 // were created before the cutoff, oldest first (ADR-025 stale-account warnings).
 // Legacy rows with an empty account_state normalise to "active" at the read

--- a/internal/storage/store/remote_unsupported_test.go
+++ b/internal/storage/store/remote_unsupported_test.go
@@ -6,7 +6,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
+	corestorage "github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/keyorixhq/keyorix/internal/storage/store"
 	"github.com/stretchr/testify/assert"
@@ -34,6 +36,38 @@ func TestRemoteStorage_UnsupportedSentinel(t *testing.T) {
 		assert.True(t, errors.Is(err, store.ErrRemoteUnsupported),
 			"%s should wrap ErrRemoteUnsupported, got %v", name, err)
 	}
+}
+
+// TestRemoteStorage_SetAccountState_HardFails proves the #454 fix: since
+// account_state has no field in the wire format UpdateUser sends (only
+// username/email/display_name/active — see core.UpdateUserRequest), RemoteStorage
+// must refuse the write outright rather than silently no-op it. No httptest server is
+// needed at all: SetAccountState never makes an HTTP call — the whole point is that
+// there is nowhere to send this field.
+func TestRemoteStorage_SetAccountState_HardFails(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("https://unused.example"))
+	require.NoError(t, err)
+
+	err = rs.SetAccountState(context.Background(), 1, "suspended", time.Now())
+	require.Error(t, err, "an account_state change must hard-fail under remote storage, not silently succeed")
+	assert.True(t, errors.Is(err, store.ErrRemoteUnsupported))
+	assert.True(t, errors.Is(err, corestorage.ErrUnsupportedByBackend))
+}
+
+// TestRemoteStorage_UpdateLoginLockoutState_ReturnsUnsupportedSentinel proves the
+// #454 fix for the lockout-accounting columns: same wire-format gap as
+// SetAccountState, but this one is a passive backstop counter, not an explicit
+// security directive — the caller (login_lockout.go) distinguishes it from
+// SetAccountState's hard-fail treatment by matching storage.ErrUnsupportedByBackend
+// via isUnsupportedByBackend, so it must errors.Is-wrap that sentinel too.
+func TestRemoteStorage_UpdateLoginLockoutState_ReturnsUnsupportedSentinel(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("https://unused.example"))
+	require.NoError(t, err)
+
+	err = rs.UpdateLoginLockoutState(context.Background(), 1, 3, nil, nil, 1)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, store.ErrRemoteUnsupported))
+	assert.True(t, errors.Is(err, corestorage.ErrUnsupportedByBackend))
 }
 
 func TestRemoteStorage_MarkAllNotificationsRead(t *testing.T) {

--- a/internal/storage/store/remote_users.go
+++ b/internal/storage/store/remote_users.go
@@ -112,6 +112,29 @@ func (rs *RemoteStorage) UpdateLastLogin(_ context.Context, _ uint, _ time.Time)
 	return fmt.Errorf("UpdateLastLogin not available in remote mode")
 }
 
+// SetAccountState always hard-fails: account_state has no field in the wire format
+// UpdateUser sends (core.UpdateUserRequest only carries username/email/display_name/
+// active — see server/http/handlers/users_crud.go and core.UpdateUser), so there is no
+// way to actually persist this upstream. Returning an error here — instead of silently
+// falling through to a generic write that would just no-op the field — is the whole
+// point of this method (#454): setAccountState (admin suspend/reactivate) and
+// UpdateSCIMUser (SCIM deprovision/reactivate) must see a hard failure, not a false
+// "success" that leaves the account's login-blocking state unchanged.
+func (rs *RemoteStorage) SetAccountState(_ context.Context, _ uint, _ string, _ time.Time) error {
+	return fmt.Errorf("account_state cannot be persisted through remote storage: the "+
+		"upstream PUT /api/v1/users/{id} endpoint does not accept this field: %w", ErrRemoteUnsupported)
+}
+
+// UpdateLoginLockoutState always returns ErrRemoteUnsupported: none of the four
+// login-lockout columns are expressible in the wire format either (#454), so, unlike
+// SetAccountState above, the caller (login_lockout.go) treats this as the same
+// "permanent architectural gap" #452 already established for the login rate limiter —
+// log a loud one-time operator warning and fail OPEN, rather than blocking every login
+// under storage.type: remote.
+func (rs *RemoteStorage) UpdateLoginLockoutState(_ context.Context, _ uint, _ int, _, _ *time.Time, _ int) error {
+	return remoteUnsupported("UpdateLoginLockoutState")
+}
+
 // DeleteUser deletes a user via remote API.
 func (rs *RemoteStorage) DeleteUser(ctx context.Context, id uint) error {
 	path := fmt.Sprintf("/api/v1/users/%d", id)


### PR DESCRIPTION
## Summary

Under `storage.type: remote` (a Keyorix server proxying to an upstream Keyorix server over HTTP), four callers persisted user state via a generic `LockUserForUpdate` + `UpdateUser` read-modify-write. The upstream `PUT /api/v1/users/{id}` handler decodes into `core.UpdateUserRequest`, which only carries `username/email/display_name/active` — so every write to `AccountState`, `FailedLoginAttempts`, `LastFailedLoginAt`, `LoginLockedUntil`, or `LoginLockoutCount` silently no-op'd, deterministically, every time — not just under concurrency:

- `recordFailedLogin` / `checkLockAndClearLoginFailures` (`internal/core/login_lockout.go`) — login-lockout accounting
- `setAccountState` (admin suspend/reactivate) and `UpdateSCIMUser` (SCIM deprovision) (`internal/core/account_state.go`, `internal/core/scim.go`)

**Fix**, split by severity (mirroring #452's precedent for the identical class of gap on the per-IP rate limiter — a real proxied atomic endpoint was out of scope there and is here too):

- Added two narrow `storage.Storage` primitives, `SetAccountState` and `UpdateLoginLockoutState` (Local does the real column update; RemoteStorage always errors, since neither field exists on the wire) — same Local/Remote-divergence pattern as `CountRecentLoginAttempts`.
- `setAccountState` / `UpdateSCIMUser` are explicit security directives — they now **hard-fail (fail closed)** when the backend can't persist the state transition, instead of reporting false success while the account stays unchanged.
- `recordFailedLogin` / `checkLockAndClearLoginFailures` / `clearLoginFailures` are a passive backstop — they now log a **one-time `warnLockoutUnsupportedOnce` operator warning** and fail open, rather than blocking every login under this backend (mirrors `warnRateLimitUnsupportedOnce` from #452).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/core/... ./internal/storage/store/...` (all pass; one pre-existing, unrelated concurrency flake — `TestConcurrency_RequestPasswordReset_BurstIsThrottled` — confirmed to also flake on unmodified `main`)
- [x] `gosec -severity medium -exclude-generated ./internal/core/... ./internal/storage/store/...` — 0 issues
- [x] `golangci-lint run` on touched packages — 0 issues
- [x] New regression tests:
  - `TestRemoteStorage_SetAccountState_HardFails` / `TestRemoteStorage_UpdateLoginLockoutState_ReturnsUnsupportedSentinel` (storage-layer sentinel wrapping)
  - `TestSuspendUser_HardFailsWhenBackendCannotPersistAccountState` / `TestUpdateSCIMUser_HardFailsWhenBackendCannotPersistDeprovision` (hard-fail, not silent success)
  - `TestUpdateSCIMUser_NoStateChange_DoesNotConsultSetAccountState` (no regression for state-preserving SCIM updates)
  - `TestLockout_RemoteStorageFailsOpenLoudlyOnce` (one-time warning, no panic/block, against a real `RemoteStorage` + httptest server)

Refs #454.