### PR TITLE
fix(dashboard): surface storage-query failures as Degraded (#394)

### DIFF
--- a/internal/core/dashboard.go
+++ b/internal/core/dashboard.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"fmt"
 	"math"
 	"sort"
 	"time"
@@ -27,6 +28,15 @@ type StatTrend struct {
 }
 
 // DashboardStats contains summary statistics for the dashboard.
+//
+// #394: every deployment-wide sub-check gated behind hasAuditRead below (and the
+// expiring-secrets rollup) is queried best-effort so one failing signal doesn't
+// abort the whole dashboard — but a query failure must never read the same as
+// "checked, genuinely zero" (e.g. FailedAuthAttempts24h=0 on an audit-log query
+// error looks identical to a clean 24h window and could mask an ongoing
+// incident or audit-log outage). Degraded + DegradedReasons make a partial
+// snapshot detectable instead of indistinguishable from a fully-clean one,
+// mirroring the CompliancePosture.Degraded convention (compliance_posture.go).
 type DashboardStats struct {
 	TotalSecrets          int64            `json:"totalSecrets"`
 	SharedSecrets         int              `json:"sharedSecrets"`
@@ -43,6 +53,23 @@ type DashboardStats struct {
 	SharedWithMeTrend     *StatTrend       `json:"sharedWithMeTrend,omitempty"`
 	ExpiringSecrets       []ExpiringSecret `json:"expiringSecrets,omitempty"`
 	RecentActivity        []ActivityItem   `json:"recentActivity"`
+	// Degraded is true when one or more sub-checks above could not be queried —
+	// the zero/empty values they carry are UNKNOWN, not verified-clean. A
+	// consumer must treat a degraded snapshot as incomplete, not as a clean
+	// read (e.g. FailedAuthAttempts24h=0 does NOT mean "no failed auth" when
+	// Degraded is true).
+	Degraded bool `json:"degraded"`
+	// DegradedReasons names each failed sub-check with its underlying error.
+	DegradedReasons []string `json:"degradedReasons,omitempty"`
+}
+
+// degrade records that a dashboard sub-check could not be queried: it flips
+// Degraded and appends a human-readable reason, so a consumer can tell "queried,
+// genuinely zero" apart from "query failed, treat as unknown" — mirroring
+// CompliancePosture.degrade (compliance_posture.go).
+func (s *DashboardStats) degrade(area string, err error) {
+	s.Degraded = true
+	s.DegradedReasons = append(s.DegradedReasons, fmt.Sprintf("%s: %v", area, err))
 }
 
 // ActivityItem represents a single entry in the activity feed.
@@ -111,71 +138,92 @@ func (c *KeyorixCore) GetDashboardStats(ctx context.Context, userID uint, userna
 		recent = append(recent, mapAuditEventToActivity(e, username))
 	}
 
-	expiringSecrets := c.getExpiringSecrets(ctx, username)
+	stats := &DashboardStats{}
+
+	expiringSecrets, err := c.getExpiringSecrets(ctx, username)
+	if err != nil {
+		stats.degrade("expiring_secrets", err)
+	}
 
 	var activeUsers, auditCount, auditLogins, auditSecretReads, failedAuth24h, inactiveUsers int64
 	if hasAuditRead {
 		// Active users from storage stats.
 		if storageStats, err := c.storage.GetStats(ctx); err == nil {
 			activeUsers = storageStats.TotalUsers
+		} else {
+			stats.degrade("active_users", err)
 		}
 
 		// Audit events in the last 30 days — total count only.
 		thirtyDaysAgo := time.Now().UTC().Add(-30 * 24 * time.Hour)
-		_, auditCount, _ = c.storage.GetAuditLogs(ctx, &storage.AuditFilter{
+		var auditErr error
+		_, auditCount, auditErr = c.storage.GetAuditLogs(ctx, &storage.AuditFilter{
 			StartTime: &thirtyDaysAgo,
 			Page:      1,
 			PageSize:  1,
 		})
+		if auditErr != nil {
+			stats.degrade("audit_count", auditErr)
+		}
 		// Auth events (login/logout) vs secret events in last 30 days.
 		authAction := "auth.login"
-		_, auditLogins, _ = c.storage.GetAuditLogs(ctx, &storage.AuditFilter{
+		_, auditLogins, auditErr = c.storage.GetAuditLogs(ctx, &storage.AuditFilter{
 			StartTime: &thirtyDaysAgo,
 			Action:    &authAction,
 			Page:      1,
 			PageSize:  1,
 		})
+		if auditErr != nil {
+			stats.degrade("audit_logins", auditErr)
+		}
 		secretReadAction := "secret.read"
-		_, auditSecretReads, _ = c.storage.GetAuditLogs(ctx, &storage.AuditFilter{
+		_, auditSecretReads, auditErr = c.storage.GetAuditLogs(ctx, &storage.AuditFilter{
 			StartTime: &thirtyDaysAgo,
 			Action:    &secretReadAction,
 			Page:      1,
 			PageSize:  1,
 		})
+		if auditErr != nil {
+			stats.degrade("audit_secret_reads", auditErr)
+		}
 
 		// Failed auth attempts in the last 24 hours (success=false, any action).
 		twentyFourHoursAgo := time.Now().UTC().Add(-24 * time.Hour)
 		successFalse := false
-		_, failedAuth24h, _ = c.storage.GetAuditLogs(ctx, &storage.AuditFilter{
+		_, failedAuth24h, auditErr = c.storage.GetAuditLogs(ctx, &storage.AuditFilter{
 			StartTime: &twentyFourHoursAgo,
 			Success:   &successFalse,
 			Page:      1,
 			PageSize:  1,
 		})
+		if auditErr != nil {
+			stats.degrade("failed_auth_24h", auditErr)
+		}
 
 		// Inactive users: registered users whose last_login_at is null or older than
 		// 30 days. Counted directly off the users table (no audit-log scan).
 		inactiveCutoff := thirtyDaysAgo
-		_, inactiveUsers, _ = c.storage.ListUsers(ctx, &storage.UserFilter{
+		_, inactiveUsers, auditErr = c.storage.ListUsers(ctx, &storage.UserFilter{
 			InactiveSince: &inactiveCutoff,
 			Page:          1,
 			PageSize:      1,
 		})
+		if auditErr != nil {
+			stats.degrade("inactive_users", auditErr)
+		}
 	}
 
-	stats := &DashboardStats{
-		TotalSecrets:          total,
-		SharedSecrets:         sharedSecrets,
-		SecretsSharedWithMe:   sharedWithMe,
-		ActiveUsers:           activeUsers,
-		AuditEvents30d:        auditCount,
-		AuditLogins30d:        auditLogins,
-		AuditSecretReads30d:   auditSecretReads,
-		FailedAuthAttempts24h: failedAuth24h,
-		InactiveUsers:         inactiveUsers,
-		RecentActivity:        recent,
-		ExpiringSecrets:       expiringSecrets,
-	}
+	stats.TotalSecrets = total
+	stats.SharedSecrets = sharedSecrets
+	stats.SecretsSharedWithMe = sharedWithMe
+	stats.ActiveUsers = activeUsers
+	stats.AuditEvents30d = auditCount
+	stats.AuditLogins30d = auditLogins
+	stats.AuditSecretReads30d = auditSecretReads
+	stats.FailedAuthAttempts24h = failedAuth24h
+	stats.InactiveUsers = inactiveUsers
+	stats.RecentActivity = recent
+	stats.ExpiringSecrets = expiringSecrets
 
 	prev, err := c.storage.GetPreviousStatsSnapshot(ctx, userID)
 	if err == nil && prev != nil {
@@ -230,8 +278,11 @@ func (c *KeyorixCore) GetActivityFeed(ctx context.Context, userID uint, username
 }
 
 // getExpiringSecrets returns secrets expiring within 30 days OR already expired,
-// sorted by expiration ascending (expired first, then soonest-expiring).
-func (c *KeyorixCore) getExpiringSecrets(ctx context.Context, username string) []ExpiringSecret {
+// sorted by expiration ascending (expired first, then soonest-expiring). The
+// returned error (non-nil only when a page fails to load) signals that the
+// result may be truncated — the caller (#394) must surface this as a degraded
+// snapshot rather than silently treating a partial (or empty) list as complete.
+func (c *KeyorixCore) getExpiringSecrets(ctx context.Context, username string) ([]ExpiringSecret, error) {
 	now := time.Now().UTC()
 	cutoff := now.Add(30 * 24 * time.Hour)
 
@@ -249,6 +300,7 @@ func (c *KeyorixCore) getExpiringSecrets(ctx context.Context, username string) [
 	// expired/expiring selection in the query.
 	const pageSize = 200
 	var result []ExpiringSecret
+	var pageErr error
 	for page := 1; ; page++ {
 		secrets, total, err := c.storage.ListSecrets(ctx, &storage.SecretFilter{
 			CreatedBy:     &username,
@@ -257,6 +309,7 @@ func (c *KeyorixCore) getExpiringSecrets(ctx context.Context, username string) [
 			PageSize:      pageSize,
 		})
 		if err != nil {
+			pageErr = err
 			break
 		}
 		for _, s := range secrets {
@@ -287,7 +340,7 @@ func (c *KeyorixCore) getExpiringSecrets(ctx context.Context, username string) [
 		return result[i].ExpiresAt.Before(result[j].ExpiresAt)
 	})
 
-	return result
+	return result, pageErr
 }
 
 // computeTrend calculates percentage change between previous and current values.

--- a/internal/core/dashboard_test.go
+++ b/internal/core/dashboard_test.go
@@ -1,0 +1,140 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// failingDashboardAuditStore wraps LocalStorage and fails every GetAuditLogs
+// call, simulating an audit-log query outage while every other dashboard
+// sub-check still runs for real.
+type failingDashboardAuditStore struct {
+	*store.LocalStorage
+}
+
+func (s *failingDashboardAuditStore) GetAuditLogs(_ context.Context, _ *storage.AuditFilter) ([]*models.AuditEvent, int64, error) {
+	return nil, 0, errors.New("simulated audit log outage")
+}
+
+// failingDashboardStatsStore wraps LocalStorage and fails GetStats, simulating
+// a DB error on the active-users rollup.
+type failingDashboardStatsStore struct {
+	*store.LocalStorage
+}
+
+func (s *failingDashboardStatsStore) GetStats(_ context.Context) (*storage.StorageStats, error) {
+	return nil, errors.New("simulated stats query failure")
+}
+
+// failingDashboardUsersStore wraps LocalStorage and fails ListUsers, simulating
+// a DB error on the inactive-users rollup.
+type failingDashboardUsersStore struct {
+	*store.LocalStorage
+}
+
+func (s *failingDashboardUsersStore) ListUsers(_ context.Context, _ *storage.UserFilter) ([]*models.User, int64, error) {
+	return nil, 0, errors.New("simulated users query failure")
+}
+
+// failingExpiringSecretsStore wraps LocalStorage and fails ListSecrets only
+// when called with the ExpiresBefore filter getExpiringSecrets uses, leaving
+// the unrelated TotalSecrets ListSecrets call (no ExpiresBefore) untouched.
+type failingExpiringSecretsStore struct {
+	*store.LocalStorage
+}
+
+func (s *failingExpiringSecretsStore) ListSecrets(ctx context.Context, filter *storage.SecretFilter) ([]*models.SecretNode, int64, error) {
+	if filter != nil && filter.ExpiresBefore != nil {
+		return nil, 0, errors.New("simulated expiring-secrets query failure")
+	}
+	return s.LocalStorage.ListSecrets(ctx, filter)
+}
+
+// #394: on a real deployment, a failed audit-log/user-count query left every
+// deployment-wide dashboard stat at its zero value — byte-identical to
+// "queried, genuinely zero" (e.g. FailedAuthAttempts24h=0 reads as a clean
+// window even when the query that would report failed logins errored out).
+// These tests prove the sub-checks now surface as Degraded instead.
+func TestGetDashboardStats_DegradedOnAuditLogsQueryError(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	auditorID := seedUserWithRole(t, st, "auditor1", "system_auditor", storage.Scope{})
+	c.storage = &failingDashboardAuditStore{LocalStorage: st}
+
+	stats, err := c.GetDashboardStats(context.Background(), auditorID, "auditor1")
+	require.NoError(t, err, "a single failed sub-check must not abort the whole dashboard")
+
+	assert.Zero(t, stats.AuditEvents30d, "the field itself still reads as its safe-default zero value")
+	assert.Zero(t, stats.AuditLogins30d)
+	assert.Zero(t, stats.AuditSecretReads30d)
+	assert.Zero(t, stats.FailedAuthAttempts24h)
+	assert.True(t, stats.Degraded, "a failed audit-log query must flip Degraded — the zero values above are UNKNOWN, not verified-clean")
+	assert.True(t, containsSubstring(stats.DegradedReasons, "audit_count"), "expected an audit_count entry, got %v", stats.DegradedReasons)
+	assert.True(t, containsSubstring(stats.DegradedReasons, "audit_logins"), "expected an audit_logins entry, got %v", stats.DegradedReasons)
+	assert.True(t, containsSubstring(stats.DegradedReasons, "audit_secret_reads"), "expected an audit_secret_reads entry, got %v", stats.DegradedReasons)
+	assert.True(t, containsSubstring(stats.DegradedReasons, "failed_auth_24h"), "expected a failed_auth_24h entry, got %v", stats.DegradedReasons)
+}
+
+func TestGetDashboardStats_DegradedOnActiveUsersQueryError(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	auditorID := seedUserWithRole(t, st, "auditor2", "system_auditor", storage.Scope{})
+	c.storage = &failingDashboardStatsStore{LocalStorage: st}
+
+	stats, err := c.GetDashboardStats(context.Background(), auditorID, "auditor2")
+	require.NoError(t, err)
+
+	assert.Zero(t, stats.ActiveUsers, "the field itself still reads as its safe-default zero value")
+	assert.True(t, stats.Degraded, "a failed active-users query must flip Degraded")
+	assert.True(t, containsSubstring(stats.DegradedReasons, "active_users"), "expected an active_users entry, got %v", stats.DegradedReasons)
+}
+
+func TestGetDashboardStats_DegradedOnInactiveUsersQueryError(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	auditorID := seedUserWithRole(t, st, "auditor3", "system_auditor", storage.Scope{})
+	c.storage = &failingDashboardUsersStore{LocalStorage: st}
+
+	stats, err := c.GetDashboardStats(context.Background(), auditorID, "auditor3")
+	require.NoError(t, err)
+
+	assert.Zero(t, stats.InactiveUsers, "the field itself still reads as its safe-default zero value")
+	assert.True(t, stats.Degraded, "a failed inactive-users query must flip Degraded")
+	assert.True(t, containsSubstring(stats.DegradedReasons, "inactive_users"), "expected an inactive_users entry, got %v", stats.DegradedReasons)
+}
+
+// #394: getExpiringSecrets paged through ListSecrets and silently discarded
+// whatever it had accumulated so far on a page-load error — this proves the
+// truncation is now surfaced via Degraded even for a baseline caller without
+// audit.read (the expiring-secrets rollup is not gated by hasAuditRead).
+func TestGetDashboardStats_DegradedOnExpiringSecretsQueryError(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	viewerID := seedUserWithRole(t, st, "viewer1", "system_viewer", storage.Scope{})
+	c.storage = &failingExpiringSecretsStore{LocalStorage: st}
+
+	stats, err := c.GetDashboardStats(context.Background(), viewerID, "viewer1")
+	require.NoError(t, err)
+
+	assert.Empty(t, stats.ExpiringSecrets, "the field itself still reads as its safe-default empty value")
+	assert.True(t, stats.Degraded, "a failed expiring-secrets query must flip Degraded")
+	assert.True(t, containsSubstring(stats.DegradedReasons, "expiring_secrets"), "expected an expiring_secrets entry, got %v", stats.DegradedReasons)
+	// A baseline caller (no audit.read) must not see the deployment-wide
+	// aggregates degrade too — expiring_secrets is the only failure injected.
+	assert.False(t, containsSubstring(stats.DegradedReasons, "active_users"))
+}
+
+// A fully-healthy storage must never report Degraded.
+func TestGetDashboardStats_NotDegradedOnSuccess(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	auditorID := seedUserWithRole(t, st, "auditor4", "system_auditor", storage.Scope{})
+
+	stats, err := c.GetDashboardStats(context.Background(), auditorID, "auditor4")
+	require.NoError(t, err)
+
+	assert.False(t, stats.Degraded)
+	assert.Empty(t, stats.DegradedReasons)
+}


### PR DESCRIPTION
## Summary

Fixes the residual gap in backlog finding #394: `GetDashboardStats` (`internal/core/dashboard.go`) silently discarded storage errors to zero/empty for several sub-checks gated behind `hasAuditRead`, indistinguishable from "genuinely zero/empty":

- `GetStats` (active users)
- `GetAuditLogs` × 4 (audit-events-30d, audit-logins-30d, audit-secret-reads-30d, failed-auth-24h)
- `ListUsers` (inactive users)
- `getExpiringSecrets`'s paginated `ListSecrets` loop (silently truncated the accumulated list on a page error)

An admin viewing the compliance/security dashboard had no way to tell "0 failed auths in the last 24h" (good) from "the audit-log query failed and we're hiding that" (bad — could mask an ongoing incident or audit-log outage).

## Changes

- Added `DashboardStats.Degraded bool` + `DegradedReasons []string` and a `degrade(area string, err error)` method, mirroring the already-established `CompliancePosture.Degraded`/`degrade()` convention from #610 (`compliance_posture.go`).
- Replaced every silent error-discard listed above with a `degrade(...)` call using a clear area name (`active_users`, `audit_count`, `audit_logins`, `audit_secret_reads`, `failed_auth_24h`, `inactive_users`, `expiring_secrets`). Safe zero/empty defaults are unchanged — only the failure is now visible.
- `getExpiringSecrets` now returns `([]ExpiringSecret, error)` so a page-load failure (and the resulting truncation) propagates to the caller instead of being swallowed.
- The HTTP handler (`GetStats` in `server/http/handlers/dashboard.go`) needs no change — it JSON-marshals the `DashboardStats` struct directly, so the new `degraded`/`degradedReasons` fields flow through automatically, the same way `CompliancePosture`'s fields do. Confirmed `DashboardStats` has no gRPC/CLI binding to update.

## Test plan

- [x] Added `internal/core/dashboard_test.go` with 5 regression tests against a real bootstrapped sqlite-backed core (mirrors the `compliance_posture_test.go` failing-store-wrapper pattern):
  - `TestGetDashboardStats_DegradedOnAuditLogsQueryError` — all 4 audit-log-derived stats stay 0 and all 4 areas appear in `DegradedReasons`
  - `TestGetDashboardStats_DegradedOnActiveUsersQueryError`
  - `TestGetDashboardStats_DegradedOnInactiveUsersQueryError`
  - `TestGetDashboardStats_DegradedOnExpiringSecretsQueryError` — proves the expiring-secrets rollup degrades even for a baseline (non-audit.read) caller
  - `TestGetDashboardStats_NotDegradedOnSuccess` — a fully-healthy run stays `Degraded == false`
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/core/...` — all pass
- [x] `go test ./server/http/handlers/...` — all pass (no code change needed there, verified passthrough)
- [x] `golangci-lint run ./internal/core/...` — 0 issues
- [x] `gosec -severity medium -exclude-generated ./internal/core/... ./server/http/handlers/...` — 0 issues