### PR TITLE
fix(auth): recover panics in detached login-logging goroutines (#243)

### DIFF
--- a/server/http/handlers/auth.go
+++ b/server/http/handlers/auth.go
@@ -143,7 +143,7 @@ func (h *AuthHandler) Login(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		h.recordLoginAttempt(r.Context(), ip)
-		go h.coreService.LogAuthFailure(context.Background(), body.Username, ip) // #nosec G118
+		goSafe(func() { h.coreService.LogAuthFailure(context.Background(), body.Username, ip) }) // #nosec G118
 		sendError(w, "Unauthorized", "Invalid credentials", http.StatusUnauthorized, nil)
 		return
 	}
@@ -153,8 +153,8 @@ func (h *AuthHandler) Login(w http.ResponseWriter, r *http.Request) {
 
 	// Audit log + last-login stamp (both non-blocking)
 	ip, ua := r.RemoteAddr, r.Header.Get("User-Agent")
-	go h.coreService.LogAuthLogin(context.Background(), user.ID, user.Username, ip, ua) // #nosec G118
-	go func() { _ = h.coreService.RecordLogin(context.Background(), user.ID) }()        // #nosec G118
+	goSafe(func() { h.coreService.LogAuthLogin(context.Background(), user.ID, user.Username, ip, ua) }) // #nosec G118
+	goSafe(func() { _ = h.coreService.RecordLogin(context.Background(), user.ID) })                     // #nosec G118
 
 	sendSuccess(w, resp, "Login successful")
 }
@@ -278,8 +278,10 @@ func (h *AuthHandler) ConsumeSetup(w http.ResponseWriter, r *http.Request) {
 
 	resp := h.buildLoginResponse(r.Context(), result.Session, result.User)
 	h.setSessionCookies(w, result.Session)
-	go h.coreService.LogAuthLogin(context.Background(), result.User.ID, result.User.Username, ip, r.Header.Get("User-Agent")) // #nosec G118
-	go func() { _ = h.coreService.RecordLogin(context.Background(), result.User.ID) }()                                       // #nosec G118
+	goSafe(func() {
+		h.coreService.LogAuthLogin(context.Background(), result.User.ID, result.User.Username, ip, r.Header.Get("User-Agent"))
+	}) // #nosec G118
+	goSafe(func() { _ = h.coreService.RecordLogin(context.Background(), result.User.ID) }) // #nosec G118
 
 	sendSuccess(w, resp, "Account setup complete")
 }
@@ -308,7 +310,7 @@ func (h *AuthHandler) Logout(w http.ResponseWriter, r *http.Request) {
 
 	// Audit log (non-blocking)
 	ip, ua := r.RemoteAddr, r.Header.Get("User-Agent")
-	go h.coreService.LogAuthLogout(context.Background(), logoutUserID, logoutUsername, ip, ua) // #nosec G118
+	goSafe(func() { h.coreService.LogAuthLogout(context.Background(), logoutUserID, logoutUsername, ip, ua) }) // #nosec G118
 
 	sendSuccess(w, nil, "Logged out successfully")
 }

--- a/server/http/handlers/helpers.go
+++ b/server/http/handlers/helpers.go
@@ -41,6 +41,29 @@ func clientSafe(err error) string {
 	return "an internal error occurred; please try again or contact support if the problem persists"
 }
 
+// goSafe runs fn in a detached goroutine with panic recovery. Auth handlers
+// spawn "fire and forget" goroutines for side effects (audit logging,
+// last-login stamps) so the HTTP response isn't blocked on that I/O — but
+// those goroutines run on the hottest, lowest-privilege request path (every
+// login attempt), and are NOT covered by the HTTP server's per-request
+// recovery middleware, which only guards the goroutine actually serving the
+// request. A panic in a bare `go func(){...}()` here (nil pointer, index
+// out of range, etc., even in "just logging" code) would crash the entire
+// process for every in-flight user — a low-privilege DoS lever (backlog
+// #243). goSafe closes that gap: any panic in fn is recovered and logged
+// instead of taking the server down. Use it in place of a bare `go` for any
+// detached side-effect goroutine spawned from a request handler.
+func goSafe(fn func()) {
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				log.Printf("recovered from panic in background goroutine: %v", r)
+			}
+		}()
+		fn()
+	}()
+}
+
 // sendError sends an error JSON response
 func sendError(w http.ResponseWriter, errorType, message string, statusCode int, details interface{}) {
 	w.Header().Set("Content-Type", "application/json")

--- a/server/http/handlers/helpers_test.go
+++ b/server/http/handlers/helpers_test.go
@@ -1,0 +1,51 @@
+// helpers_test.go — regression coverage for #243: detached "fire and forget"
+// side-effect goroutines spawned from auth handlers (audit logging,
+// last-login recording) had no panic recovery. A panic there runs on a
+// separate goroutine from the one serving the request, so the HTTP server's
+// per-request recovery middleware never sees it — it takes down the whole
+// process, on every user's login attempt. goSafe closes that gap.
+package handlers
+
+import (
+	"testing"
+	"time"
+)
+
+// TestGoSafe_RecoversPanic proves a panic inside the function passed to
+// goSafe does not crash the test process. Before the #243 fix, the call sites
+// in auth.go/webauthn.go/mfa.go used a bare `go func(){...}()` — a panic
+// there is NOT caught by the HTTP server's request-recovery middleware
+// (which only guards the goroutine serving the request) and would crash the
+// whole process. If goSafe's recover() didn't work, this test binary itself
+// would crash before reaching the assertion below.
+func TestGoSafe_RecoversPanic(t *testing.T) {
+	done := make(chan struct{})
+	goSafe(func() {
+		defer close(done)
+		panic("simulated panic in background goroutine")
+	})
+
+	select {
+	case <-done:
+		// goSafe's recover() caught the panic; the goroutine ran to
+		// completion (via the deferred close) instead of taking the
+		// process down.
+	case <-time.After(2 * time.Second):
+		t.Fatal("goSafe goroutine never completed")
+	}
+}
+
+// TestGoSafe_RunsFunction confirms goSafe still actually runs fn to
+// completion in the non-panicking case — it must not swallow normal work.
+func TestGoSafe_RunsFunction(t *testing.T) {
+	done := make(chan struct{})
+	goSafe(func() {
+		close(done)
+	})
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("goSafe did not run the function")
+	}
+}

--- a/server/http/handlers/mfa.go
+++ b/server/http/handlers/mfa.go
@@ -161,7 +161,9 @@ func (h *AuthHandler) VerifyMFA(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	resp := h.buildLoginResponse(r.Context(), session, user)
-	go h.coreService.LogAuthLogin(context.Background(), user.ID, user.Username, ip, r.Header.Get("User-Agent")) // #nosec G118
-	go func() { _ = h.coreService.RecordLogin(context.Background(), user.ID) }()                                // #nosec G118
+	goSafe(func() {
+		h.coreService.LogAuthLogin(context.Background(), user.ID, user.Username, ip, r.Header.Get("User-Agent"))
+	}) // #nosec G118
+	goSafe(func() { _ = h.coreService.RecordLogin(context.Background(), user.ID) }) // #nosec G118
 	sendSuccess(w, resp, "Login successful")
 }

--- a/server/http/handlers/webauthn.go
+++ b/server/http/handlers/webauthn.go
@@ -201,8 +201,10 @@ func (h *AuthHandler) FinishWebAuthnLogin(w http.ResponseWriter, r *http.Request
 		return
 	}
 	resp := h.buildLoginResponse(r.Context(), session, user)
-	go h.coreService.LogAuthLogin(context.Background(), user.ID, user.Username, ip, r.Header.Get("User-Agent")) // #nosec G118
-	go func() { _ = h.coreService.RecordLogin(context.Background(), user.ID) }()                                // #nosec G118
+	goSafe(func() {
+		h.coreService.LogAuthLogin(context.Background(), user.ID, user.Username, ip, r.Header.Get("User-Agent"))
+	}) // #nosec G118
+	goSafe(func() { _ = h.coreService.RecordLogin(context.Background(), user.ID) }) // #nosec G118
 	sendSuccess(w, resp, "Login successful")
 }
 
@@ -253,8 +255,10 @@ func (h *AuthHandler) FinishWebAuthnPasswordlessLogin(w http.ResponseWriter, r *
 		return
 	}
 	resp := h.buildLoginResponse(r.Context(), session, user)
-	go h.coreService.LogAuthLogin(context.Background(), user.ID, user.Username, ip, r.Header.Get("User-Agent")) // #nosec G118
-	go func() { _ = h.coreService.RecordLogin(context.Background(), user.ID) }()                                // #nosec G118
+	goSafe(func() {
+		h.coreService.LogAuthLogin(context.Background(), user.ID, user.Username, ip, r.Header.Get("User-Agent"))
+	}) // #nosec G118
+	goSafe(func() { _ = h.coreService.RecordLogin(context.Background(), user.ID) }) // #nosec G118
 	sendSuccess(w, resp, "Login successful")
 }
 


### PR DESCRIPTION
## Summary

- `server/http/handlers/auth.go`, `webauthn.go`, and `mfa.go` spawn detached, fire-and-forget `go func(){...}()` goroutines on every login/logout for audit logging (`LogAuthLogin`/`LogAuthFailure`/`LogAuthLogout`) and last-login recording (`RecordLogin`). This keeps the HTTP response from blocking on that I/O, which is the right shape — but none of these goroutines had panic recovery.
- A panic on a separately-spawned goroutine is **not** caught by the HTTP server's per-request recovery middleware (that only guards the goroutine actually serving the request). Since these goroutines run on the hottest, lowest-privilege request path — every login attempt, authenticated or not — any panic there (nil pointer, out-of-bounds, etc., even in "just logging" code) crashes the entire process for every user in flight: a low-privilege DoS lever (backlog #243).
- Added a `goSafe(func())` helper in `server/http/handlers/helpers.go` that runs `fn` in a goroutine with a `recover()` that logs (via `log.Printf`, matching the existing convention in this package) instead of propagating, and swapped every affected bare `go func(){...}()` / `go h.coreService.Xxx(...)` call site (auth.go x4, webauthn.go x2, mfa.go x1) over to it. No behavioral change otherwise — same async fire-and-forget semantics, just panic-safe.
- Checked `server/scheduler_run.go` as instructed: the identical root cause there (background job goroutines with no recovery) was already fixed under a separate finding (#314, PR #585) — `runScheduler`'s `run()` already wraps every job's `tick()` call in its own `recover()`, with its own regression test. Left untouched; out of scope for this PR.

## Test plan

- [x] Added `server/http/handlers/helpers_test.go`: `TestGoSafe_RecoversPanic` proves a panic inside `goSafe`'s function does not crash the test process (if recovery didn't work, the test binary itself would crash), and `TestGoSafe_RunsFunction` confirms normal (non-panicking) work still runs to completion.
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./server/... -count=1` — all packages pass
- [x] `gosec -severity medium -exclude-generated ./server/...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)