### PR TITLE
fix(config): reject unrecognized storage.type instead of silently defaulting to SQLite (#463)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1514,10 +1514,18 @@ func (c *Config) Validate() error {
 		if db.DSN == "" && (db.Host == "" || db.Name == "" || db.User == "") {
 			return fmt.Errorf("postgres storage requires either database.dsn or all of host, name, and user to be set")
 		}
-	default: // "local", ""
+	case "local", "":
 		if c.Storage.Database.Path == "" {
 			return fmt.Errorf("database path is not specified")
 		}
+	default:
+		// #463: an unrecognized storage.type (e.g. a typo like "postgress" or
+		// "remot") used to fall through silently to the SQLite default in both
+		// this validator and the storage factory — in a multi-replica HA
+		// deployment intending shared Postgres/remote storage, that produced
+		// per-replica split-brain SQLite instances with no operator-visible
+		// signal. Fail fast at config-validation time instead.
+		return fmt.Errorf("invalid storage.type %q: must be one of \"local\", \"postgres\", \"postgresql\", or \"remote\"", c.Storage.Type)
 	}
 
 	if c.Locale.Language == "" {

--- a/internal/config/config_load_test.go
+++ b/internal/config/config_load_test.go
@@ -149,3 +149,35 @@ func TestValidate_AcceptsExplicitAllowedOrigins(t *testing.T) {
 	c.Server.HTTP.AllowedOrigins = []string{"https://app.example.com", "http://localhost:3000"}
 	require.NoError(t, c.Validate())
 }
+
+// #463: an unrecognized storage.type (e.g. a typo like "postgres_typo") used to
+// be silently accepted by Validate and fall through to the SQLite default
+// everywhere downstream — in a multi-replica HA deployment intending shared
+// Postgres/remote storage, that produces per-replica split-brain SQLite
+// instances with no operator-visible signal. Validate must reject it clearly.
+func TestValidate_RejectsUnknownStorageType(t *testing.T) {
+	c := &Config{}
+	c.Storage.Type = "postgres_typo"
+	err := c.Validate()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "storage.type")
+	require.Contains(t, err.Error(), "postgres_typo")
+}
+
+// Companion to TestValidate_RejectsUnknownStorageType: every genuinely-supported
+// storage.type value must still validate cleanly — a validation change that's
+// too aggressive is as dangerous as one that's too permissive.
+func TestValidate_AcceptsValidStorageTypes(t *testing.T) {
+	for _, storageType := range []string{"", "local", "postgres", "postgresql", "remote"} {
+		c := &Config{}
+		c.Storage.Type = storageType
+		switch storageType {
+		case "postgres", "postgresql":
+			c.Storage.Database.DSN = "postgres://user:pass@localhost/db"
+		case "local", "":
+			c.Storage.Database.Path = "/tmp/keyorix.db"
+		}
+		err := c.Validate()
+		require.NoErrorf(t, err, "storage.type %q should be accepted", storageType)
+	}
+}

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -96,8 +96,17 @@ func (f *DefaultStorageFactory) CreateStorage(cfg *config.Config) (storage.Stora
 		return f.createRemoteStorage(cfg)
 	case "postgres", "postgresql":
 		return f.createPostgresStorage(cfg)
-	default: // "local", "" or any other value defaults to SQLite
+	case "local", "":
 		return f.createLocalStorage(cfg)
+	default:
+		// #463: defense in depth. Config.Validate() rejects an unrecognized
+		// storage.type at boot, but this factory can also be invoked directly
+		// (e.g. by tests or other code paths that don't call Validate() first)
+		// — a typo like "postgress" must never silently fall back to SQLite,
+		// since in a multi-replica HA deployment intending shared Postgres/
+		// remote storage that produces per-replica split-brain SQLite
+		// instances with no operator-visible signal.
+		return nil, fmt.Errorf("invalid storage.type %q: must be one of \"local\", \"postgres\", \"postgresql\", or \"remote\"", cfg.Storage.Type)
 	}
 }
 

--- a/internal/storage/factory_invalid_type_test.go
+++ b/internal/storage/factory_invalid_type_test.go
@@ -1,0 +1,28 @@
+package storage
+
+import (
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCreateStorage_RejectsUnknownStorageType is the defense-in-depth companion
+// to Config.Validate() rejecting an unrecognized storage.type (#463). The
+// factory's own dispatch used to silently fall through to SQLite for any value
+// it didn't recognize ("local", "" or any typo alike) — a config typo like
+// "postgres_typo" or "remot" would then boot each replica against its own,
+// disconnected local database instead of the intended shared backend, with no
+// error anywhere in the chain. CreateStorage must now return an error instead
+// of silently constructing local storage, so that other code paths which build
+// storage without going through Config.Validate() first are still protected.
+func TestCreateStorage_RejectsUnknownStorageType(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Storage.Type = "postgres_typo"
+
+	st, err := NewStorageFactory().CreateStorage(cfg)
+	require.Error(t, err)
+	assert.Nil(t, st)
+	assert.Contains(t, err.Error(), "postgres_typo")
+}

--- a/internal/storage/gormdb.go
+++ b/internal/storage/gormdb.go
@@ -11,8 +11,8 @@ import (
 
 // OpenGormDB opens a raw *gorm.DB for the configured local backend, switching on
 // cfg.Storage.Type with the same mapping the factory uses (postgres/postgresql →
-// Postgres, anything else → SQLite) and applying the same connection-pool
-// settings via applyPoolSettings.
+// Postgres, local/"" → SQLite, anything else rejected — #463) and applying the
+// same connection-pool settings via applyPoolSettings.
 //
 // Unlike the factory's CreateStorage, it deliberately does NOT run migrations: it
 // exists for the handful of CLI admin commands that need a raw *gorm.DB the
@@ -42,7 +42,7 @@ func OpenGormDB(cfg *config.Config) (*gorm.DB, error) {
 			return nil, err
 		}
 		return db, nil
-	default: // "local", "" or any other value → SQLite (mirrors the factory)
+	case "local", "":
 		dbPath := cfg.Storage.Database.Path
 		if dbPath == "" {
 			dbPath = "./secrets.db"
@@ -55,5 +55,11 @@ func OpenGormDB(cfg *config.Config) (*gorm.DB, error) {
 			return nil, err
 		}
 		return db, nil
+	default:
+		// #463: defense in depth, mirroring the factory's own hardening — these
+		// CLI admin commands run without going through Config.Validate() first,
+		// so a typo'd storage.type must not silently open a local SQLite file
+		// disconnected from the operator's intended (e.g. shared Postgres) backend.
+		return nil, fmt.Errorf("invalid storage.type %q: must be one of \"local\", \"postgres\", \"postgresql\", or \"remote\"", cfg.Storage.Type)
 	}
 }


### PR DESCRIPTION
## Summary

- `Config.Validate()` and the storage factory both silently fell through to a local SQLite database for any unrecognized `storage.type` value (e.g. a typo like `postgress` or `remot`) — no error anywhere in the chain.
- In a multi-replica HA deployment intending shared Postgres or remote storage, this meant a single config typo would give **each replica its own disconnected local SQLite database** — split-brain, with zero operator-visible signal until data inconsistency between replicas was discovered.

## Fix

- `Config.Validate()` now rejects any `storage.type` outside `{"", "local", "postgres", "postgresql", "remote"}` with a clear error naming the invalid value and the valid options. This is enforced at boot via the existing `cfg.Validate()` call in `server/main.go` (wired in an earlier round for #445), so a misconfigured deployment now fails fast at startup instead of silently booting each replica against its own SQLite file.
- Defense in depth: the storage factory's `CreateStorage` dispatch and the raw `OpenGormDB` helper (used by CLI admin commands, e.g. auth-encryption stats/migrate, that don't call `Validate()` first) now return an explicit error for an unrecognized type rather than silently constructing local SQLite storage.

## Test plan

- [x] Added `TestValidate_RejectsUnknownStorageType` — `Config.Validate()` rejects `"postgres_typo"` with a clear error naming the bad value.
- [x] Added `TestValidate_AcceptsValidStorageTypes` — companion test confirming every genuinely-supported value (`""`, `"local"`, `"postgres"`, `"postgresql"`, `"remote"`) still validates cleanly.
- [x] Added `TestCreateStorage_RejectsUnknownStorageType` — the storage factory's own dispatch now errors instead of silently constructing SQLite storage.
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./internal/config/... ./internal/storage/... -count=1` passing
- [x] `gosec -severity medium -exclude-generated ./internal/config/... ./internal/storage/...` — 0 issues
- [x] `go test ./... -count=1` — full suite passing (no test relied on the old silent-fallback behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)