### PR TITLE
harden(rbac): allow group-role reactivation after natural expiry (#471)

### DIFF
--- a/internal/storage/store/local_rbac.go
+++ b/internal/storage/store/local_rbac.go
@@ -642,10 +642,29 @@ func (ls *LocalStorage) assignGroupRole(ctx context.Context, groupID, roleID uin
 	err := ls.db.WithContext(ctx).
 		Where("group_id = ? AND role_id = ? AND project_id = ? AND environment_id = ?",
 			groupID, roleID, scope.ProjectID, scope.EnvironmentID).First(&existing).Error
-	if err == nil {
-		return fmt.Errorf("%s", i18n.T("ErrorRoleAlreadyAssigned", nil))
-	}
-	if err != gorm.ErrRecordNotFound {
+	switch err {
+	case nil:
+		// A row already exists at this exact (group, role, project, environment) key. A
+		// still-live grant (no expiry, or an expiry still in the future) genuinely blocks
+		// a duplicate assignment. But an EXPIRED grant is a stale, un-reaped row — e.g. a
+		// prior break-glass activation whose time-bound grant naturally lapsed — and must
+		// be treated as ABSENT for this check, or a second real-incident activation for
+		// the same group/role/scope is permanently refused with "already assigned" even
+		// though nothing live is actually being duplicated (#263/#471). Delete the stale
+		// row so the composite primary key (group_id, role_id, project_id, environment_id)
+		// is free for the fresh Create below, mirroring assignUserRole's identical fix.
+		if existing.ExpiresAt == nil || existing.ExpiresAt.After(time.Now()) {
+			return fmt.Errorf("%s", i18n.T("ErrorRoleAlreadyAssigned", nil))
+		}
+		if derr := ls.db.WithContext(ctx).
+			Where("group_id = ? AND role_id = ? AND project_id = ? AND environment_id = ?",
+				groupID, roleID, scope.ProjectID, scope.EnvironmentID).
+			Delete(&models.GroupRole{}).Error; derr != nil {
+			return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), derr)
+		}
+	case gorm.ErrRecordNotFound:
+		// no existing row for this key — proceed to create.
+	default:
 		return fmt.Errorf("%s: %w", i18n.T("ErrorInternalServer", nil), err)
 	}
 	groupRole := models.GroupRole{

--- a/internal/storage/store/local_rbac_test.go
+++ b/internal/storage/store/local_rbac_test.go
@@ -75,6 +75,90 @@ func TestAssignRole_SucceedsAfterPriorTimeBoundGrantExpired(t *testing.T) {
 	assert.Contains(t, ids, uint(10))
 }
 
+// #471: assignGroupRole had the identical bug already fixed for assignUserRole in
+// #263 — the existence check matched on (group_id, role_id, project_id,
+// environment_id) with no expires_at filter, so a stale, un-reaped group_roles row
+// from a naturally-expired grant permanently blocked a second real-incident
+// break-glass activation for the same group with "already assigned". The check now
+// treats an expired grant as absent (deleting the stale row before the fresh
+// insert), while a genuinely still-live grant continues to correctly block a
+// duplicate.
+
+// A permanent (non-expiring) group grant still blocks a duplicate AssignRoleToGroup.
+func TestAssignRoleToGroup_BlocksDuplicateOfLiveGrant(t *testing.T) {
+	ls := newRBACScopeTestStore(t)
+	ctx := context.Background()
+	require.NoError(t, ls.db.Create(&models.Group{ID: 200, Name: "g200"}).Error)
+
+	require.NoError(t, ls.AssignRoleToGroup(ctx, 200, 10, sc(5, 0)))
+	err := ls.AssignRoleToGroup(ctx, 200, 10, sc(5, 0))
+	require.Error(t, err, "a duplicate assignment of a permanent, still-live group grant must be refused")
+}
+
+// A group grant that has not yet expired still blocks a duplicate
+// AssignRoleToGroupWithExpiry.
+func TestAssignRoleToGroupWithExpiry_BlocksDuplicateOfLiveGrant(t *testing.T) {
+	ls := newRBACScopeTestStore(t)
+	ctx := context.Background()
+	require.NoError(t, ls.db.Create(&models.Group{ID: 201, Name: "g201"}).Error)
+
+	future := time.Now().Add(time.Hour)
+	require.NoError(t, ls.AssignRoleToGroupWithExpiry(ctx, 201, 10, sc(5, 0), future))
+
+	err := ls.AssignRoleToGroupWithExpiry(ctx, 201, 10, sc(5, 0), time.Now().Add(2*time.Hour))
+	require.Error(t, err, "a duplicate assignment while the first group grant is still live must be refused")
+}
+
+// The core of #471: once the FIRST group grant's expires_at has naturally passed
+// (reproduced here with a real short-lived expiry, per the reproduction recipe in
+// the backlog item), a SECOND activation for the exact same (group, role, project,
+// environment) key must succeed — not fail with "already assigned" against the
+// stale, un-reaped row.
+func TestAssignRoleToGroupWithExpiry_ReactivatesAfterNaturalExpiry(t *testing.T) {
+	ls := newRBACScopeTestStore(t)
+	ctx := context.Background()
+	require.NoError(t, ls.db.Create(&models.Group{ID: 202, Name: "g202"}).Error)
+	require.NoError(t, ls.db.Create(&models.UserGroup{UserID: 1, GroupID: 202}).Error)
+
+	shortLived := time.Now().Add(50 * time.Millisecond)
+	require.NoError(t, ls.AssignRoleToGroupWithExpiry(ctx, 202, 10, sc(5, 0), shortLived),
+		"seed a group grant that will naturally expire almost immediately")
+
+	time.Sleep(150 * time.Millisecond)
+
+	var stale models.GroupRole
+	require.NoError(t, ls.db.Where("group_id = ? AND role_id = ?", 202, 10).First(&stale).Error,
+		"the expired grant's row must still be present (un-reaped) for this to be a real reproduction")
+
+	newExpiry := time.Now().Add(time.Hour)
+	err := ls.AssignRoleToGroupWithExpiry(ctx, 202, 10, sc(5, 0), newExpiry)
+	require.NoError(t, err, "a second activation after the first group grant naturally expired must succeed")
+
+	ids, err := ls.GetUserGroupRoleIDsAt(ctx, 1, sc(5, 0))
+	require.NoError(t, err)
+	assert.Contains(t, ids, uint(10), "the fresh group grant must be live and authorizing")
+}
+
+// Same as above but via the permanent AssignRoleToGroup path re-granting after a
+// PRIOR time-bound group grant (e.g. AssignRoleToGroupWithExpiry) at the same key
+// expired.
+func TestAssignRoleToGroup_SucceedsAfterPriorTimeBoundGrantExpired(t *testing.T) {
+	ls := newRBACScopeTestStore(t)
+	ctx := context.Background()
+	require.NoError(t, ls.db.Create(&models.Group{ID: 203, Name: "g203"}).Error)
+	require.NoError(t, ls.db.Create(&models.UserGroup{UserID: 1, GroupID: 203}).Error)
+
+	past := time.Now().Add(-time.Hour)
+	require.NoError(t, ls.AssignRoleToGroupWithExpiry(ctx, 203, 10, sc(5, 0), past))
+
+	err := ls.AssignRoleToGroup(ctx, 203, 10, sc(5, 0))
+	require.NoError(t, err, "a permanent re-grant after the prior time-bound group grant expired must succeed")
+
+	ids, err := ls.GetUserGroupRoleIDsAt(ctx, 1, sc(5, 0))
+	require.NoError(t, err)
+	assert.Contains(t, ids, uint(10))
+}
+
 // #374/#375/#376: GetUserPermissions and CheckPermission previously joined ONLY
 // user_roles (direct assignments), leaving them blind to a permission granted
 // purely via a group role — unlike the live authorization path (scopedRoleIDs,


### PR DESCRIPTION
## Summary

- Fixes #471: `assignGroupRole` had the same bug already fixed for `assignUserRole` in #263 — its existence check matched on `(group_id, role_id, project_id, environment_id)` with no `expires_at` filter, so a stale, un-reaped `group_roles` row from a naturally-expired grant permanently blocked a second real-incident break-glass activation for the same group with `"Role already assigned"` (`ErrorRoleAlreadyAssigned`).
- Mirrors #263's exact mechanism: when the existing row's `ExpiresAt` is non-nil and in the past, delete the stale row before the fresh `Create`, freeing the composite primary key. A genuinely still-live grant (no expiry, or expiry still in the future) continues to correctly block a duplicate assignment.
- This is an availability/operational-integrity fix, not a privilege escalation — live-permission reads (`GetUserGroupRoleIDsAt`, etc.) already correctly filter on `expires_at`, so the stale row never granted any actual access.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/core/...`
- [x] `go test ./internal/storage/store/...`
- [x] `gosec -severity medium -exclude-generated ./internal/core/... ./internal/storage/...`
- [x] New regression tests in `internal/storage/store/local_rbac_test.go` (mirroring the `#263` tests for `assignUserRole`):
  - `TestAssignRoleToGroup_BlocksDuplicateOfLiveGrant` — permanent grant still blocks a duplicate
  - `TestAssignRoleToGroupWithExpiry_BlocksDuplicateOfLiveGrant` — not-yet-expired grant still blocks a duplicate
  - `TestAssignRoleToGroupWithExpiry_ReactivatesAfterNaturalExpiry` — reproduces the exact recipe (50ms expiry, sleep 150ms, confirm stale row persists, re-assign identical tuple with a fresh expiry) and asserts success
  - `TestAssignRoleToGroup_SucceedsAfterPriorTimeBoundGrantExpired` — permanent re-grant after a prior time-bound grant expired

🤖 Generated with [Claude Code](https://claude.com/claude-code)