### PR TITLE
fix(core): degrade instead of silently omitting on group-lookup failure (#417, #407)

### DIFF
--- a/internal/core/rotation_planner.go
+++ b/internal/core/rotation_planner.go
@@ -26,12 +26,19 @@ import (
 // PlannedRotation is one secret's place in the rotation plan, with the rationale an
 // operator needs to act on (or override) it.
 type PlannedRotation struct {
-	SecretID       uint     `json:"secret_id"`
-	SecretName     string   `json:"secret_name"`
-	Status         string   `json:"status"`           // overdue | due_soon
-	DaysOverdue    int      `json:"days_overdue"`     // positive = overdue, negative = days remaining
-	RiskScore      int      `json:"risk_score"`       // 0-100 composite (0 if not computable)
-	RiskBand       string   `json:"risk_band"`        // low | medium | high
+	SecretID    uint   `json:"secret_id"`
+	SecretName  string `json:"secret_name"`
+	Status      string `json:"status"`       // overdue | due_soon
+	DaysOverdue int    `json:"days_overdue"` // positive = overdue, negative = days remaining
+	RiskScore   int    `json:"risk_score"`   // 0-100 composite (0 if not computable)
+	RiskBand    string `json:"risk_band"`    // low | medium | high
+	// RiskDegraded is true when RiskScore/RiskBand were computed from an
+	// incomplete exposure count (#407, SecretRiskScore.Degraded) — ComputeSecretRiskScore
+	// already fails the exposure factor toward its worst case in this situation, so
+	// RiskScore here is a floor, not an inflated or deflated guess; RiskDegraded just
+	// makes that incompleteness visible instead of indistinguishable from a fully
+	// resolved score.
+	RiskDegraded   bool     `json:"risk_degraded"`
 	Urgency        int      `json:"urgency"`          // composite priority; higher rotates sooner
 	AutoRotate     bool     `json:"auto_rotate"`      // self-rotates (ADR-046) vs needs a human
 	AfterSecretIDs []uint   `json:"after_secret_ids"` // in-plan dependencies that must rotate first
@@ -214,19 +221,22 @@ func (c *KeyorixCore) GenerateDeploymentRotationPlan(ctx context.Context) (*Depl
 // planSecret turns a candidate entry into a PlannedRotation with urgency and reasons.
 func (c *KeyorixCore) planSecret(ctx context.Context, e *RotationStatusEntry, deps []uint, candidates map[uint]*RotationStatusEntry) PlannedRotation {
 	riskScore, riskBand := 0, ""
+	riskDegraded := false
 	if r, err := c.ComputeSecretRiskScore(ctx, e.SecretID); err == nil && r != nil {
 		riskScore, riskBand = r.Score, r.Band
+		riskDegraded = r.Degraded
 	}
 
 	pr := PlannedRotation{
-		SecretID:    e.SecretID,
-		SecretName:  e.SecretName,
-		Status:      e.Status,
-		DaysOverdue: e.DaysOverdue,
-		RiskScore:   riskScore,
-		RiskBand:    riskBand,
-		Urgency:     rotationUrgency(e.Status, e.DaysOverdue, riskScore),
-		AutoRotate:  e.AutoRotate,
+		SecretID:     e.SecretID,
+		SecretName:   e.SecretName,
+		Status:       e.Status,
+		DaysOverdue:  e.DaysOverdue,
+		RiskScore:    riskScore,
+		RiskBand:     riskBand,
+		RiskDegraded: riskDegraded,
+		Urgency:      rotationUrgency(e.Status, e.DaysOverdue, riskScore),
+		AutoRotate:   e.AutoRotate,
 	}
 
 	if e.Status == RotationStatusOverdue {
@@ -236,6 +246,9 @@ func (c *KeyorixCore) planSecret(ctx context.Context, e *RotationStatusEntry, de
 	}
 	if riskScore >= 34 {
 		pr.Reasons = append(pr.Reasons, fmt.Sprintf("%s risk (score %d)", riskBand, riskScore))
+	}
+	if riskDegraded {
+		pr.Reasons = append(pr.Reasons, "risk score based on incomplete exposure data (treated as worst-case, not deprioritized)")
 	}
 	if e.AutoRotate {
 		pr.Reasons = append(pr.Reasons, "self-rotating")

--- a/internal/core/secret_access_list.go
+++ b/internal/core/secret_access_list.go
@@ -22,11 +22,39 @@ type SecretAccessor struct {
 	Source     string `json:"source"`     // owner | direct_share | group_share:<group>
 }
 
+// SecretAccessorsResult is the effective access list for a secret plus a signal for
+// whether it is complete. #417: on storage.type: remote, ListGroupMembers is
+// unconditionally unimplemented, so every group-share accessor was silently
+// omitted from this incident-response-critical "who can access secret X" report
+// with no indication anything was missing. Degraded + DegradedReasons make that
+// detectable instead of the result silently looking like a complete accessor
+// list — mirroring CompliancePosture.Degraded (compliance_posture.go) and
+// DashboardStats.Degraded (dashboard.go, #394).
+type SecretAccessorsResult struct {
+	Accessors []SecretAccessor `json:"accessors"`
+	// Degraded is true when at least one group's membership could not be
+	// resolved — Accessors is then an UNDER-count (missing group members), never
+	// verified-complete.
+	Degraded bool `json:"degraded"`
+	// DegradedReasons names each group whose membership failed to resolve, with
+	// the underlying error.
+	DegradedReasons []string `json:"degraded_reasons,omitempty"`
+}
+
+// degrade records that a group's membership could not be resolved: it flips
+// Degraded and appends a human-readable reason, mirroring
+// CompliancePosture.degrade (compliance_posture.go).
+func (r *SecretAccessorsResult) degrade(area string, err error) {
+	r.Degraded = true
+	r.DegradedReasons = append(r.DegradedReasons, fmt.Sprintf("%s: %v", area, err))
+}
+
 var permissionRank = map[string]int{"read": 1, "write": 2, "owner": 3}
 
 // ListSecretAccessors returns the distinct users who can access secretID, strongest
-// grant per user, sorted by username. The actor must be able to read the secret.
-func (c *KeyorixCore) ListSecretAccessors(ctx context.Context, secretID, actorID uint) ([]SecretAccessor, error) {
+// grant per user, sorted by username, plus whether the list is known-complete. The
+// actor must be able to read the secret.
+func (c *KeyorixCore) ListSecretAccessors(ctx context.Context, secretID, actorID uint) (*SecretAccessorsResult, error) {
 	if _, err := c.EnforceSecretReadPermission(ctx, secretID, actorID); err != nil {
 		return nil, err
 	}
@@ -63,6 +91,8 @@ func (c *KeyorixCore) ListSecretAccessors(ctx context.Context, secretID, actorID
 		add(secret.OwnerID, "owner", "owner")
 	}
 
+	result := &SecretAccessorsResult{}
+
 	shares, err := c.storage.ListSharesBySecret(ctx, secretID)
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
@@ -75,7 +105,12 @@ func (c *KeyorixCore) ListSecretAccessors(ctx context.Context, secretID, actorID
 			}
 			members, err := c.storage.ListGroupMembers(ctx, sh.RecipientID)
 			if err != nil {
-				continue // skip an unresolvable group rather than fail the whole list
+				// #417: a group whose membership can't be resolved (deterministically
+				// every group on storage.type: remote, where ListGroupMembers is
+				// unimplemented) must not silently vanish from this report — record
+				// it as an explicit gap instead of continuing unflagged.
+				result.degrade(fmt.Sprintf("group_members:group=%d(%s)", sh.RecipientID, gname), err)
+				continue
 			}
 			for _, m := range members {
 				userNames[m.ID] = m.Username // already loaded; prime the cache
@@ -91,5 +126,6 @@ func (c *KeyorixCore) ListSecretAccessors(ctx context.Context, secretID, actorID
 		out = append(out, a)
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].Username < out[j].Username })
-	return out, nil
+	result.Accessors = out
+	return result, nil
 }

--- a/internal/core/secret_access_list_test.go
+++ b/internal/core/secret_access_list_test.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -57,8 +58,10 @@ func TestListSecretAccessors(t *testing.T) {
 	past := now.Add(-time.Hour)
 	require.NoError(t, db.Create(&models.ShareRecord{SecretID: secret.ID, OwnerID: 1, RecipientID: 5, Permission: "read", ExpiresAt: &past}).Error)
 
-	accessors, err := c.ListSecretAccessors(ctx, secret.ID, 1)
+	result, err := c.ListSecretAccessors(ctx, secret.ID, 1)
 	require.NoError(t, err)
+	require.False(t, result.Degraded)
+	accessors := result.Accessors
 
 	byName := map[string]SecretAccessor{}
 	for _, a := range accessors {
@@ -106,11 +109,69 @@ func TestListSecretAccessors_StrongestGrantWins(t *testing.T) {
 	_, err = c.ShareSecret(ctx, &ShareSecretRequest{SecretID: secret.ID, RecipientID: 2, Permission: "write", SharedBy: 1})
 	require.NoError(t, err)
 
-	accessors, err := c.ListSecretAccessors(ctx, secret.ID, 1)
+	result, err := c.ListSecretAccessors(ctx, secret.ID, 1)
 	require.NoError(t, err)
-	for _, a := range accessors {
+	require.False(t, result.Degraded)
+	for _, a := range result.Accessors {
 		if a.Username == "alice" {
 			assert.Equal(t, "write", a.Permission, "the stronger (write) grant wins over the group read")
 		}
 	}
+}
+
+// failingGroupMembersStore wraps LocalStorage and fails every ListGroupMembers
+// call, simulating storage.type: remote where ListGroupMembers is
+// unconditionally unimplemented (#417).
+type failingGroupMembersStore struct {
+	*store.LocalStorage
+}
+
+func (s *failingGroupMembersStore) ListGroupMembers(_ context.Context, _ uint) ([]*models.User, error) {
+	return nil, errors.New("simulated: ListGroupMembers unimplemented on this backend")
+}
+
+// TestListSecretAccessors_DegradedOnGroupMembersError proves that a failing
+// ListGroupMembers call now surfaces as Degraded instead of silently omitting
+// the entire group's accessors from an incident-response-critical report (#417).
+func TestListSecretAccessors_DegradedOnGroupMembersError(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	sqlDB.SetMaxOpenConns(1)
+	require.NoError(t, db.AutoMigrate(
+		&models.SecretNode{}, &models.SecretVersion{}, &models.User{}, &models.ShareRecord{},
+		&models.Group{}, &models.UserGroup{},
+	))
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "owner", Email: "o@t.com"}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 2, Username: "bob", Email: "b@t.com"}).Error)
+	require.NoError(t, db.Create(&models.Group{ID: 10, Name: "platform"}).Error)
+	require.NoError(t, db.Create(&models.UserGroup{UserID: 2, GroupID: 10}).Error)
+
+	now := time.Now()
+	base := store.NewLocalStorage(db)
+	failing := &failingGroupMembersStore{LocalStorage: base}
+	c := &KeyorixCore{storage: failing, now: func() time.Time { return now }}
+	ctx := context.Background()
+
+	secret, err := base.CreateSecret(ctx, &models.SecretNode{
+		Name: "db", ProjectID: 1, EnvironmentID: 1, Type: "password", OwnerID: 1, IsSecret: true,
+		CreatedAt: now, UpdatedAt: now,
+	})
+	require.NoError(t, err)
+	_, err = c.ShareSecretWithGroup(ctx, &GroupShareSecretRequest{SecretID: secret.ID, GroupID: 10, Permission: "read", SharedBy: 1})
+	require.NoError(t, err)
+
+	result, err := c.ListSecretAccessors(ctx, secret.ID, 1)
+	require.NoError(t, err)
+	assert.True(t, result.Degraded, "a failed ListGroupMembers call must flip Degraded")
+	require.NotEmpty(t, result.DegradedReasons)
+	assert.Contains(t, result.DegradedReasons[0], "group_members:group=10")
+	byName := map[string]SecretAccessor{}
+	for _, a := range result.Accessors {
+		byName[a.Username] = a
+	}
+	assert.NotContains(t, byName, "bob", "bob's group-share access must not silently appear as verified-absent")
+	assert.Contains(t, byName, "owner")
 }

--- a/internal/core/secret_risk.go
+++ b/internal/core/secret_risk.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/storage/models"
@@ -27,12 +28,26 @@ type SecretRiskFactor struct {
 
 // SecretRiskScore is a per-secret risk assessment combining expiry, rotation
 // age, usage (read activity), and exposure (how many principals can read it).
+//
+// #407: the exposure factor depends on ListSharesBySecret/ListGroupMembers, and a
+// failure there is an UNDER-count (never an over-count) — a secret that's
+// actually widely shared could get incorrectly deprioritized for rotation if its
+// exposure silently read as low. Degraded + DegradedReasons make an incomplete
+// exposure count detectable, mirroring CompliancePosture.Degraded
+// (compliance_posture.go). ComputeSecretRiskScore additionally fails the exposure
+// factor toward the worst case when degraded, so a degraded score is never
+// LOWER than a fully-computed one would be.
 type SecretRiskScore struct {
 	SecretID   uint               `json:"secret_id"`
 	SecretName string             `json:"secret_name"`
 	Score      int                `json:"score"` // 0-100 weighted composite (higher = riskier)
 	Band       string             `json:"band"`  // low | medium | high
 	Factors    []SecretRiskFactor `json:"factors"`
+	// Degraded is true when the exposure factor could not be fully computed —
+	// treat Score/Band as a floor (best-case), not a verified value.
+	Degraded bool `json:"degraded"`
+	// DegradedReasons names each failed lookup behind the exposure factor.
+	DegradedReasons []string `json:"degraded_reasons,omitempty"`
 }
 
 func riskBand(score int) string {
@@ -58,7 +73,19 @@ func (c *KeyorixCore) ComputeSecretRiskScore(ctx context.Context, secretID uint)
 	expScore, expDetail := expiryRisk(secret.Expiration, now)
 	rotScore, rotDetail := rotationRisk(secret.LastRotatedAt, secret.CreatedAt, now)
 	usageScore, usageDetail := usageRisk(c.countReads(ctx, secretID, now.AddDate(0, 0, -30)))
-	expoScore, expoDetail := exposureRisk(c.countPrincipals(ctx, secret))
+
+	principalCount, expoDegraded, expoReasons := c.countPrincipals(ctx, secret)
+	expoScore, expoDetail := exposureRisk(principalCount)
+	if expoDegraded {
+		// #407: a share/group-membership lookup failed, so principalCount is an
+		// UNDER-count at best — never trust it as a verified low-exposure reading.
+		// Fail toward caution: force the worst exposure tier so a widely-shared
+		// secret whose exposure lookup errored is never scored as LESS risky (and
+		// so never incorrectly deprioritized for rotation) than a fully-resolved
+		// equivalent would be.
+		expoScore, _ = exposureRisk(1 << 30)
+		expoDetail = fmt.Sprintf("Exposure data incomplete (%s) — treated as worst-case until resolved", strings.Join(expoReasons, "; "))
+	}
 
 	factors := []SecretRiskFactor{
 		{Key: "expiry", Label: "Expiry", Score: expScore, Weight: 0.30, Detail: expDetail},
@@ -73,13 +100,20 @@ func (c *KeyorixCore) ComputeSecretRiskScore(ctx context.Context, secretID uint)
 	}
 	score := int(composite + 0.5)
 
-	return &SecretRiskScore{
+	out := &SecretRiskScore{
 		SecretID:   secret.ID,
 		SecretName: secret.Name,
 		Score:      score,
 		Band:       riskBand(score),
 		Factors:    factors,
-	}, nil
+	}
+	if expoDegraded {
+		out.Degraded = true
+		for _, r := range expoReasons {
+			out.DegradedReasons = append(out.DegradedReasons, "exposure:"+r)
+		}
+	}
+	return out, nil
 }
 
 func expiryRisk(exp *time.Time, now time.Time) (int, string) {
@@ -170,19 +204,27 @@ func (c *KeyorixCore) countReads(ctx context.Context, secretID uint, since time.
 
 // countPrincipals counts the distinct users that can read a secret: the owner
 // plus direct share recipients plus the members of any group it is shared with.
-func (c *KeyorixCore) countPrincipals(ctx context.Context, secret *models.SecretNode) int {
+// degraded is true when a ListSharesBySecret/ListGroupMembers lookup failed — the
+// returned count is then an UNDER-count (a share or group's members are missing
+// from the tally), never a verified low-exposure reading. See #407: this used to
+// silently fall back to an owner-only (or partial) count on any such error,
+// deflating the exposure factor that both the risk dashboard and auto-rotation
+// prioritization (rotation_planner.go) rely on.
+func (c *KeyorixCore) countPrincipals(ctx context.Context, secret *models.SecretNode) (count int, degraded bool, reasons []string) {
 	principals := map[uint]struct{}{}
 	if secret.OwnerID != 0 { // an ownerless (machine-created) secret has no owner principal
 		principals[secret.OwnerID] = struct{}{}
 	}
 	shares, err := c.storage.ListSharesBySecret(ctx, secret.ID)
 	if err != nil {
-		return len(principals)
+		return len(principals), true, []string{fmt.Sprintf("shares: %v", err)}
 	}
 	for _, sh := range shares {
 		if sh.IsGroup {
 			members, err := c.storage.ListGroupMembers(ctx, sh.RecipientID)
 			if err != nil {
+				degraded = true
+				reasons = append(reasons, fmt.Sprintf("group_members:group=%d: %v", sh.RecipientID, err))
 				continue
 			}
 			for _, m := range members {
@@ -192,5 +234,5 @@ func (c *KeyorixCore) countPrincipals(ctx context.Context, secret *models.Secret
 			principals[sh.RecipientID] = struct{}{}
 		}
 	}
-	return len(principals)
+	return len(principals), degraded, reasons
 }

--- a/internal/core/secret_risk_test.go
+++ b/internal/core/secret_risk_test.go
@@ -2,10 +2,12 @@ package core
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
@@ -78,4 +80,61 @@ func TestComputeSecretRiskScore_LowRisk(t *testing.T) {
 	require.Equal(t, 10, factorByKey(got, "rotation").Score)
 	require.Equal(t, 10, factorByKey(got, "usage").Score, "12 reads, update excluded")
 	require.Equal(t, 10, factorByKey(got, "exposure").Score, "owner only")
+	require.False(t, got.Degraded)
+}
+
+// TestComputeSecretRiskScore_DegradedOnListSharesError proves that a failing
+// ListSharesBySecret call no longer silently deflates the exposure factor to an
+// owner-only count — it now flips Degraded and forces exposure to the worst-case
+// score, so a secret that is actually widely shared can't be incorrectly
+// deprioritized for rotation because its exposure looked artificially low (#407).
+func TestComputeSecretRiskScore_DegradedOnListSharesError(t *testing.T) {
+	now := time.Date(2026, 6, 8, 12, 0, 0, 0, time.UTC)
+	future := now.AddDate(0, 0, 200)
+	rotated := now.AddDate(0, 0, -5)
+	store := new(MockStorage)
+
+	store.On("GetSecret", mock.Anything, uint(3)).Return(&models.SecretNode{
+		ID: 3, Name: "widely-shared-key", OwnerID: 9, Expiration: &future, LastRotatedAt: &rotated, CreatedAt: now.AddDate(0, 0, -10),
+	}, nil)
+	store.On("ListSecretAccessLogs", mock.Anything, uint(3), mock.Anything).Return([]models.SecretAccessLog{}, nil)
+	store.On("ListSharesBySecret", mock.Anything, uint(3)).Return(nil, errors.New("simulated shares query failure"))
+
+	c := NewKeyorixCore(store)
+	c.now = func() time.Time { return now }
+
+	got, err := c.ComputeSecretRiskScore(context.Background(), 3)
+	require.NoError(t, err)
+	assert.True(t, got.Degraded, "a failed ListSharesBySecret call must flip Degraded")
+	require.NotEmpty(t, got.DegradedReasons)
+	assert.Contains(t, got.DegradedReasons[0], "exposure:shares")
+	assert.Equal(t, 90, factorByKey(got, "exposure").Score, "an incomplete exposure count must fail toward the worst-case score, not an owner-only low score")
+}
+
+// TestComputeSecretRiskScore_DegradedOnListGroupMembersError proves that a failing
+// ListGroupMembers call no longer silently skips that group's members from the
+// exposure count — it now flips Degraded and forces exposure to the worst-case
+// score (#407).
+func TestComputeSecretRiskScore_DegradedOnListGroupMembersError(t *testing.T) {
+	now := time.Date(2026, 6, 8, 12, 0, 0, 0, time.UTC)
+	future := now.AddDate(0, 0, 200)
+	rotated := now.AddDate(0, 0, -5)
+	store := new(MockStorage)
+
+	store.On("GetSecret", mock.Anything, uint(4)).Return(&models.SecretNode{
+		ID: 4, Name: "group-shared-key", OwnerID: 9, Expiration: &future, LastRotatedAt: &rotated, CreatedAt: now.AddDate(0, 0, -10),
+	}, nil)
+	store.On("ListSecretAccessLogs", mock.Anything, uint(4), mock.Anything).Return([]models.SecretAccessLog{}, nil)
+	store.On("ListSharesBySecret", mock.Anything, uint(4)).Return([]*models.ShareRecord{{IsGroup: true, RecipientID: 7}}, nil)
+	store.On("ListGroupMembers", mock.Anything, uint(7)).Return(nil, errors.New("simulated: ListGroupMembers unimplemented on this backend"))
+
+	c := NewKeyorixCore(store)
+	c.now = func() time.Time { return now }
+
+	got, err := c.ComputeSecretRiskScore(context.Background(), 4)
+	require.NoError(t, err)
+	assert.True(t, got.Degraded, "a failed ListGroupMembers call must flip Degraded")
+	require.NotEmpty(t, got.DegradedReasons)
+	assert.Contains(t, got.DegradedReasons[0], "exposure:group_members:group=7")
+	assert.Equal(t, 90, factorByKey(got, "exposure").Score, "an incomplete exposure count must fail toward the worst-case score")
 }

--- a/server/http/handlers/secrets_access_list.go
+++ b/server/http/handlers/secrets_access_list.go
@@ -26,7 +26,7 @@ func (h *SecretHandler) ListAccessors(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	accessors, err := h.coreService.ListSecretAccessors(r.Context(), uint(id), userCtx.UserID)
+	result, err := h.coreService.ListSecretAccessors(r.Context(), uint(id), userCtx.UserID)
 	if err != nil {
 		switch {
 		case strings.Contains(err.Error(), "not found"):
@@ -38,5 +38,13 @@ func (h *SecretHandler) ListAccessors(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
-	h.sendSuccess(w, map[string]interface{}{"accessors": accessors, "total": len(accessors)}, "")
+	// #417: degraded/degraded_reasons must reach API consumers — a report that
+	// silently dropped a group's members would look identical to a fully-resolved
+	// one otherwise.
+	h.sendSuccess(w, map[string]interface{}{
+		"accessors":        result.Accessors,
+		"total":            len(result.Accessors),
+		"degraded":         result.Degraded,
+		"degraded_reasons": result.DegradedReasons,
+	}, "")
 }


### PR DESCRIPTION
## Summary

Fixes two instances of the "fail-open" family already partially addressed by `CompliancePosture.degrade` (compliance_posture.go) and `DashboardStats.degrade` (dashboard.go, #394).

- **#417** — `ListSecretAccessors` silently skipped an entire group's members whenever `ListGroupMembers` errored. This is deterministic (not just transient) on `storage.type: remote` deployments, where `ListGroupMembers` is unconditionally unimplemented — every group-share accessor was invisibly omitted from this incident-response-critical "who can access secret X" report, with no incompleteness signal.
- **#407** — `countPrincipals` (feeding `ComputeSecretRiskScore`'s exposure factor) had the same shape: a `ListSharesBySecret` error silently fell back to an owner-only count, and a `ListGroupMembers` error silently skipped that group's members — deflating the exposure factor consumed by both the risk dashboard and auto-rotation prioritization.

## What changed

- `ListSecretAccessors` now returns `*SecretAccessorsResult{Accessors, Degraded, DegradedReasons}` instead of a bare slice. A group whose membership can't be resolved is recorded as an explicit gap instead of silently vanishing. The `GET /api/v1/secrets/{id}/access` handler surfaces `degraded`/`degraded_reasons` in the response.
- `countPrincipals` now returns `(count, degraded, reasons)`. `ComputeSecretRiskScore`'s exposure factor fails toward the **worst case** (not the incomplete/under-counted value) when degraded, and `SecretRiskScore` carries `Degraded`/`DegradedReasons` — so a degraded score is never lower than a fully-resolved one would be. `GET /api/v1/secrets/{id}/risk` already returns the whole struct, so these fields reach API consumers automatically.
- The rotation planner (`planSecret`) now records `PlannedRotation.RiskDegraded` and appends a human-readable reason, so an operator can see when a secret's urgency was computed from incomplete exposure data (which the planner never uses to *deprioritize*, since the underlying score already floors to worst-case).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/core/...` (includes new `TestListSecretAccessors_DegradedOnGroupMembersError`, `TestComputeSecretRiskScore_DegradedOnListSharesError`, `TestComputeSecretRiskScore_DegradedOnListGroupMembersError`, plus updated existing accessor/risk tests for the new return shapes)
- [x] `go test ./server/http/handlers/...`
- [x] `gosec -severity medium -exclude-generated` scoped to `internal/core/...` and `server/http/handlers/...` — 0 issues across 209 files
- [x] `gofmt -l` clean on all touched files

Refs #417, #407.