### PR TITLE
fix(scim): honor op.Op for filtered members[value eq "X"] PATCH path (#226)

### DIFF
--- a/server/http/handlers/scim_groups.go
+++ b/server/http/handlers/scim_groups.go
@@ -255,10 +255,23 @@ func (h *SCIMHandler) PatchGroup(w http.ResponseWriter, r *http.Request) {
 	for _, op := range patch.Operations {
 		path := strings.TrimSpace(op.Path)
 		lower := strings.ToLower(path)
-		// Filtered remove path: members[value eq "X"].
+		// Filtered single-member path: members[value eq "X"]. The member id comes
+		// from the filter expression itself, not from op.Value — but which side
+		// (add vs. remove) it lands on MUST still be driven by op.Op (RFC 7644
+		// §3.5.2): "remove" deletes that member, while "add"/"replace" ensure that
+		// member is present, mirroring the non-filtered `members` handling below.
+		// Ignoring op.Op here previously treated every filtered-path operation as a
+		// removal regardless of what the client actually requested (#226).
 		if m := scimMemberFilterPath.FindStringSubmatch(path); m != nil {
-			if v, err := strconv.ParseUint(m[1], 10, 32); err == nil {
+			v, err := strconv.ParseUint(m[1], 10, 32)
+			if err != nil {
+				continue
+			}
+			switch {
+			case strings.EqualFold(op.Op, "remove"):
 				removeIDs = append(removeIDs, uint(v))
+			case strings.EqualFold(op.Op, "add"), strings.EqualFold(op.Op, "replace"):
+				addIDs = append(addIDs, uint(v))
 			}
 			continue
 		}

--- a/server/http/handlers/scim_groups_test.go
+++ b/server/http/handlers/scim_groups_test.go
@@ -94,6 +94,46 @@ func TestSCIM_GroupsCreateReplacePatchDelete(t *testing.T) {
 	require.Equal(t, http.StatusNoContent, w.Code)
 }
 
+// TestSCIM_PatchGroupFilteredPathHonorsOp is a regression test for #226: the
+// members[value eq "X"] filtered path previously ignored op.Op and always
+// removed the matched member, even for "add"/"replace" operations.
+func TestSCIM_PatchGroupFilteredPathHonorsOp(t *testing.T) {
+	h, _ := setupSCIMTest(t)
+	u1 := provisionUser(t, h, "carol@corp.com")
+	u2 := provisionUser(t, h, "dave@corp.com")
+
+	// Create a group with only carol as a member.
+	body := `{"schemas":["urn:ietf:params:scim:schemas:core:2.0:Group"],"displayName":"Filtered","members":[{"value":"` + u1 + `"}]}`
+	w := httptest.NewRecorder()
+	h.CreateGroup(w, httptest.NewRequest(http.MethodPost, "/scim/v2/Groups", bytes.NewReader([]byte(body))))
+	require.Equal(t, http.StatusCreated, w.Code, w.Body.String())
+	gid, _ := decodeSCIM(t, w)["id"].(string)
+	require.NotEmpty(t, gid)
+
+	// PATCH add via the filtered path syntax must ADD dave, not remove carol.
+	addPatch := `{"Operations":[{"op":"add","path":"members[value eq \"` + u2 + `\"]"}]}`
+	w = httptest.NewRecorder()
+	h.PatchGroup(w, withID(httptest.NewRequest(http.MethodPatch, "/scim/v2/Groups/"+gid, bytes.NewReader([]byte(addPatch))), gid))
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	assert.ElementsMatch(t, []string{u1, u2}, groupMemberValues(decodeSCIM(t, w)))
+
+	// PATCH replace via the filtered path syntax must also ensure the member is
+	// present (not remove it): re-"replace" dave, who is already a member.
+	replacePatch := `{"Operations":[{"op":"replace","path":"members[value eq \"` + u2 + `\"]"}]}`
+	w = httptest.NewRecorder()
+	h.PatchGroup(w, withID(httptest.NewRequest(http.MethodPatch, "/scim/v2/Groups/"+gid, bytes.NewReader([]byte(replacePatch))), gid))
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	assert.ElementsMatch(t, []string{u1, u2}, groupMemberValues(decodeSCIM(t, w)))
+
+	// PATCH remove via the filtered path syntax must still remove the matched
+	// member (the pre-existing, correct behavior).
+	rmPatch := `{"Operations":[{"op":"remove","path":"members[value eq \"` + u2 + `\"]"}]}`
+	w = httptest.NewRecorder()
+	h.PatchGroup(w, withID(httptest.NewRequest(http.MethodPatch, "/scim/v2/Groups/"+gid, bytes.NewReader([]byte(rmPatch))), gid))
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	assert.ElementsMatch(t, []string{u1}, groupMemberValues(decodeSCIM(t, w)))
+}
+
 func TestSCIM_CreateGroupRequiresDisplayName(t *testing.T) {
 	h, _ := setupSCIMTest(t)
 	w := httptest.NewRecorder()


### PR DESCRIPTION
## Summary

Fixes #226: `PatchGroup`'s filtered-member PATCH path (`members[value eq "X"]`, the form IdPs use to target one member by id) matched only the path shape and unconditionally treated the operation as a removal, never inspecting the operation's `op` field (RFC 7644 §3.5.2 — add/replace/remove).

That meant an `add` or `replace` operation sent with this filter-path form was silently executed as a **removal**, regardless of what the SCIM client actually requested — an identity-provider-driven group-membership add could instead remove that member (or a misrouted remove could silently no-op as an add), a spec-conformance bug with real access-control side effects.

## Fix

- `server/http/handlers/scim_groups.go`: the filtered-path branch in `PatchGroup` now checks `op.Op` (case-insensitively, matching the existing `strings.EqualFold(op.Op, ...)` convention used elsewhere in this handler and in `scim.go`'s `PatchUser`):
  - `remove` → routes to `removeIDs` (unchanged, pre-existing correct behavior)
  - `add` / `replace` → routes to `addIDs`, mirroring how the non-filtered `members` path already handles `add` — the target member id comes from the filter expression match itself (there's no request-body value array in this path form), not from `op.Value`.

## Test plan

- [x] Added `TestSCIM_PatchGroupFilteredPathHonorsOp` in `server/http/handlers/scim_groups_test.go`: proves an `add` op using `members[value eq "X"]` actually adds the member (does not remove any existing member), a `replace` op using the same path form also ensures the member is present, and a `remove` op via the same path form still correctly removes.
- [x] Existing `TestSCIM_GroupsCreateReplacePatchDelete` (filtered-path remove) still passes.
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./server/http/handlers/...` — all pass
- [x] `gosec -severity medium -exclude-generated ./server/http/handlers/...` — 0 issues