### PR TITLE
fix(compliance): degrade supply-chain posture on trust-registry error (#145)

### DIFF
--- a/internal/core/compliance_posture.go
+++ b/internal/core/compliance_posture.go
@@ -333,10 +333,17 @@ func (c *KeyorixCore) GetCompliancePosture(ctx context.Context) (*CompliancePost
 	// Supply-chain integrity (ADR-062/064/065): signed, offline-verifiable updates plus
 	// offline entitlement. A non-release/source build pins no keys (control not in force).
 	sc := SupplyChainPosture{}
-	if reg, rerr := trust.DefaultRegistry(); rerr == nil && reg != nil {
+	if reg, rerr := c.defaultTrustRegistry(); rerr == nil && reg != nil {
 		ids := reg.KeyIDs(trust.PurposeUpdate)
 		sc.TrustedUpdateKeys = len(ids)
 		sc.UpdateSigningTrusted = len(ids) > 0
+	} else if rerr != nil {
+		// DefaultRegistry only errors when the embedded key material itself is
+		// malformed (a build/release integrity problem) — distinct from an
+		// ordinary unsigned/source build, which parses its empty key spec with a
+		// nil error. Left un-degraded, this read the same as "no keys embedded"
+		// (NotConfigured), masking a genuine "couldn't even check" failure.
+		p.degrade("supply_chain", rerr)
 	}
 	ls := c.LicenseStatus()
 	sc.LicenseState = string(ls.State)

--- a/internal/core/compliance_posture_test.go
+++ b/internal/core/compliance_posture_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/keyorixhq/keyorix/internal/trust"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gorm.io/driver/sqlite"
@@ -68,6 +69,31 @@ func TestGetCompliancePosture_DegradedOnLegalHoldQueryError(t *testing.T) {
 	require.NoError(t, err)
 	lh := findControl(t, controls.Controls, "legal-hold")
 	assert.Equal(t, ControlStatusUnknown, lh.Status, "the legal-hold CONTROL must surface as unknown, not silently pass, when its posture signal is degraded")
+}
+
+// #145: trust.DefaultRegistry() only errors when the embedded update/license signing-key
+// material itself is malformed (a build/release integrity problem) — distinct from an
+// ordinary unsigned/source build, which parses its empty key spec with a nil error. Before
+// this fix, a registry-lookup failure left SupplyChain.TrustedUpdateKeys/UpdateSigningTrusted
+// at their zero values — byte-identical to the expected "no keys pinned, ordinary dev build"
+// state — masking a genuine "couldn't even check" failure as benign not-configured.
+func TestGetCompliancePosture_DegradedOnSupplyChainTrustRegistryError(t *testing.T) {
+	c := compliancePostureCore(t)
+	c.SetTrustRegistryFunc(func() (*trust.KeyRegistry, error) {
+		return nil, errors.New("simulated malformed embedded key data")
+	})
+
+	p, err := c.GetCompliancePosture(context.Background())
+	require.NoError(t, err, "a single failed sub-rollup must not abort the whole snapshot")
+
+	assert.False(t, p.SupplyChain.UpdateSigningTrusted, "the field itself still reads as its zero value")
+	assert.True(t, p.Degraded, "a failed trust-registry lookup must flip Degraded — the zero value above is UNKNOWN, not a verified unsigned build")
+	assert.True(t, containsSubstring(p.DegradedReasons, "supply_chain"), "expected a supply_chain entry in DegradedReasons, got %v", p.DegradedReasons)
+
+	controls, err := c.GetComplianceControls(context.Background())
+	require.NoError(t, err)
+	sc := findControl(t, controls.Controls, "supply-chain-integrity")
+	assert.Equal(t, ControlStatusUnknown, sc.Status, "the supply-chain-integrity CONTROL must surface as unknown, not silently not-configured, when its trust-registry lookup failed")
 }
 
 // failingRiskExceptionsStore wraps LocalStorage and fails ListRiskExceptions, simulating

--- a/internal/core/control_framework.go
+++ b/internal/core/control_framework.go
@@ -196,8 +196,8 @@ func EvaluateControls(p *CompliancePosture) []ControlState {
 		},
 		{
 			ID: "supply-chain-integrity", Name: "Software supply-chain integrity (signed, verifiable updates)", Area: "Supply chain",
-			Status:     supplyChainStatus(p.SupplyChain),
-			Detail:     supplyChainDetail(p.SupplyChain),
+			Status:     supplyChainStatus(p),
+			Detail:     supplyChainDetail(p),
 			Frameworks: FrameworkRefs{ISO27001: []string{"A.5.19", "A.5.20", "A.5.21"}, SOC2: []string{"CC8.1"}, NIS2: []string{"Art.21(2)(d)"}, DORA: []string{"Art.28"}, ENS: []string{"op.pl.2", "op.exp.2"}},
 		},
 	}
@@ -205,12 +205,22 @@ func EvaluateControls(p *CompliancePosture) []ControlState {
 
 // supplyChainStatus is Pass when this deployment verifies updates against a pinned signing
 // key (a signed release). A source/dev build pins no key, so the control is "not configured"
-// (it does not apply to an unsigned build) rather than a gap.
-func supplyChainStatus(s SupplyChainPosture) ControlStatus {
-	return statusFromBool(s.UpdateSigningTrusted)
+// (it does not apply to an unsigned build) rather than a gap. But if the trust-registry
+// lookup itself failed this run (#145 — the embedded key material was malformed, a
+// build/release integrity problem, not an ordinary unsigned build), that must surface as
+// Unknown rather than silently reading identical to "not configured".
+func supplyChainStatus(p *CompliancePosture) ControlStatus {
+	if p.DegradedArea("supply_chain") {
+		return ControlStatusUnknown
+	}
+	return statusFromBool(p.SupplyChain.UpdateSigningTrusted)
 }
 
-func supplyChainDetail(s SupplyChainPosture) string {
+func supplyChainDetail(p *CompliancePosture) string {
+	s := p.SupplyChain
+	if p.DegradedArea("supply_chain") {
+		return "UNKNOWN — trust-registry lookup failed this run (embedded key material malformed); do not treat as unsigned/not-configured"
+	}
 	if !s.UpdateSigningTrusted {
 		return "no pinned update-signing key (unsigned/source build) — offline bundle verification not in force"
 	}

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -20,6 +20,7 @@ import (
 	"github.com/keyorixhq/keyorix/internal/notary"
 	"github.com/keyorixhq/keyorix/internal/rotation"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/trust"
 )
 
 // KeyorixCore represents the core business logic layer.
@@ -44,6 +45,10 @@ type KeyorixCore struct {
 	// dynamicEngineFactory resolves a dynamic-secrets credential engine by backend
 	// type (ADR-035). nil = the real dynamic.New; overridable in tests with a fake.
 	dynamicEngineFactory func(string) (dynamic.CredentialEngine, error)
+	// trustRegistry resolves the embedded update/license signing-key trust registry
+	// (ADR-062/064). nil = the real trust.DefaultRegistry; overridable in tests to
+	// inject a lookup failure (#145) without mutating trust package internals.
+	trustRegistry func() (*trust.KeyRegistry, error)
 	// dynamicSweepEnabled mirrors config dynamic_secrets.sweep_enabled. Backends
 	// without DB-level expiry (MySQL/MongoDB) rely entirely on the sweeper to
 	// enforce a lease's TTL, so IssueLease refuses to mint from them when it is off
@@ -491,6 +496,21 @@ func (c *KeyorixCore) dynamicEngine(backendType string) (dynamic.CredentialEngin
 		return c.dynamicEngineFactory(backendType)
 	}
 	return dynamic.New(backendType)
+}
+
+// SetTrustRegistryFunc overrides how the update/license signing-key trust registry
+// is resolved (tests inject a failing lookup to exercise #145's degrade path).
+func (c *KeyorixCore) SetTrustRegistryFunc(f func() (*trust.KeyRegistry, error)) {
+	c.trustRegistry = f
+}
+
+// defaultTrustRegistry resolves the trust registry via the override (or the real
+// trust.DefaultRegistry when none is set).
+func (c *KeyorixCore) defaultTrustRegistry() (*trust.KeyRegistry, error) {
+	if c.trustRegistry != nil {
+		return c.trustRegistry()
+	}
+	return trust.DefaultRegistry()
 }
 
 // SetWebAuthn wires the WebAuthn relying party (ADR-036). The server calls this


### PR DESCRIPTION
## Summary
- `GetCompliancePosture`'s `SupplyChain` rollup read `trust.DefaultRegistry()` failing the same as the expected no-keys-embedded state (an ordinary non-release/dev build): both left `TrustedUpdateKeys=0`/`UpdateSigningTrusted=false`. But `DefaultRegistry()` only errors when the *embedded* key material itself is malformed (a build/release integrity problem) — an unsigned dev build parses its empty key spec successfully with a nil error. An operator reading the compliance dashboard had no way to tell "this build was never meant to be signed" apart from "this signed build's key data is corrupt," and `control_framework.go`'s `supplyChainStatus` mapped both to the same benign `ControlStatusNotConfigured`.
- Reuses the `Degraded`/`DegradedReasons` signal the #136 fix added for the same fail-open pattern elsewhere in this rollup: a failed lookup now calls `p.degrade("supply_chain", err)`, and `supplyChainStatus`/`supplyChainDetail` check `DegradedArea("supply_chain")` to surface `ControlStatusUnknown` instead of silently reading as not-configured.
- Adds a `KeyorixCore.trustRegistry` test seam (mirroring the existing `dynamicEngineFactory` pattern) so tests can inject a failing trust-registry lookup without mutating `internal/trust`'s unexported package vars.
- Note: a prior attempt at this (#550) was closed as apparently-superseded, but that closure was mistaken for the #145 half specifically — the `degrade()` call never actually landed on `main`; this PR re-applies it fresh off current `main`.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/core/...`
- [x] New regression test `TestGetCompliancePosture_DegradedOnSupplyChainTrustRegistryError` asserts `Degraded` flips true with a `supply_chain` reason, and that the `supply-chain-integrity` control surfaces as `ControlStatusUnknown`
- [x] `gosec -severity medium -exclude-generated ./internal/core/...` — 0 issues

Refs #145