### PR TITLE
fix(security): harden Shamir share writes, break-glass justification, and docs

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -729,7 +729,9 @@ alerted, the grant expires, and an admin can revoke it early.
 ```yaml
 break_glass:
   enabled: true
-  emergency_role: "project_admin"   # role granted on activation
+  emergency_role: "project_developer" # role granted on activation — must be
+                                       # contained (no roles.assign); "project_admin"
+                                       # is REJECTED at activation time
   default_ttl: "4h"                 # grant lifetime when none is requested
   max_ttl: "24h"                    # ceiling on a requested TTL
 ```

--- a/internal/cli/encryption/shamir_split.go
+++ b/internal/cli/encryption/shamir_split.go
@@ -12,10 +12,10 @@ import (
 	cryptorand "crypto/rand"
 	"encoding/hex"
 	"fmt"
-	"os"
 	"path/filepath"
 
 	"github.com/keyorixhq/keyorix/internal/crypto"
+	"github.com/keyorixhq/keyorix/internal/securefiles"
 	"github.com/spf13/cobra"
 )
 
@@ -70,8 +70,15 @@ unrecoverable. Store shares separately and back them up.`,
 				fmt.Printf("  share %d: %s\n", i+1, enc)
 				continue
 			}
-			path := filepath.Join(ssOutDir, fmt.Sprintf("share-%d.hex", i+1))
-			if err := os.WriteFile(path, []byte(enc+"\n"), 0600); err != nil {
+			fileName := fmt.Sprintf("share-%d.hex", i+1)
+			path := filepath.Join(ssOutDir, fileName)
+			// SecureWriteFileSync (#269) refuses to write through a pre-planted symlink
+			// (O_NOFOLLOW) and enforces the mode even if a file already existed with a
+			// looser one — a plain os.WriteFile silently follows a symlink and never
+			// chmods an existing file, so a Shamir key-share could land world-readable
+			// or redirected to an attacker-controlled path with no error. Sync'd since
+			// this is unrecoverable key material (losing shares is permanent data loss).
+			if err := securefiles.SecureWriteFileSync(ssOutDir, fileName, []byte(enc+"\n"), 0o600); err != nil {
 				return fmt.Errorf("write %s: %w", path, err)
 			}
 			fmt.Printf("  share %d -> %s\n", i+1, path)

--- a/internal/cli/encryption/shamir_split_test.go
+++ b/internal/cli/encryption/shamir_split_test.go
@@ -1,0 +1,41 @@
+package encryption
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// #269: a dangling symlink planted at a share output path (its target not yet
+// existing, so a pre-write os.Stat existence check wouldn't catch it) must not
+// be silently written through — the write should fail rather than create the
+// Shamir key-share material at the symlink's target location outside --out-dir.
+func TestShamirSplit_RefusesToFollowSymlinkAtTarget(t *testing.T) {
+	dir := t.TempDir()
+	outsideTarget := filepath.Join(t.TempDir(), "exfiltrated-share-1.hex")
+	require.NoError(t, os.Symlink(outsideTarget, filepath.Join(dir, "share-1.hex")))
+
+	ssShares, ssThreshold, ssOutDir = 5, 3, dir
+	err := shamirSplitCmd.RunE(shamirSplitCmd, nil)
+	require.Error(t, err, "writing through a pre-planted symlink must be refused")
+
+	_, statErr := os.Stat(outsideTarget)
+	assert.True(t, os.IsNotExist(statErr), "the symlink target must NOT have been created")
+}
+
+func TestShamirSplit_WritesSharesWithSecurePermissions(t *testing.T) {
+	dir := t.TempDir()
+	ssShares, ssThreshold, ssOutDir = 5, 3, dir
+	require.NoError(t, shamirSplitCmd.RunE(shamirSplitCmd, nil))
+
+	for i := 1; i <= 5; i++ {
+		path := filepath.Join(dir, fmt.Sprintf("share-%d.hex", i))
+		fi, err := os.Stat(path)
+		require.NoError(t, err)
+		assert.Equal(t, os.FileMode(0o600), fi.Mode().Perm(), "%s must be 0600", path)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1233,7 +1233,7 @@ func (c JITAccessExpiryConfig) GetInterval() time.Duration {
 // (default off — disabled means the endpoint refuses).
 type BreakGlassConfig struct {
 	Enabled       bool   `yaml:"enabled"`
-	EmergencyRole string `yaml:"emergency_role"` // role granted on activation (e.g. "project_admin")
+	EmergencyRole string `yaml:"emergency_role"` // role granted on activation (e.g. "project_developer" — must be contained: no roles.assign, so use a role like project_developer, NOT project_admin)
 	DefaultTTL    string `yaml:"default_ttl"`    // grant lifetime when none requested (e.g. "4h")
 	MaxTTL        string `yaml:"max_ttl"`        // ceiling on a requested TTL (e.g. "24h")
 }

--- a/internal/core/break_glass.go
+++ b/internal/core/break_glass.go
@@ -16,12 +16,20 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
+
+// minBreakGlassJustificationLen is the minimum length, after trimming
+// surrounding whitespace, a break-glass justification must have. This becomes
+// a PERMANENT audit-trail record of why a real security incident required
+// emergency access, so a bare non-empty check (a single space would pass)
+// isn't enough — require something that at least resembles a genuine reason.
+const minBreakGlassJustificationLen = 10
 
 // Break-glass states and audit events.
 const (
@@ -58,8 +66,10 @@ func (c *KeyorixCore) ActivateBreakGlass(ctx context.Context, projectID, userID 
 	if projectID == 0 || userID == 0 {
 		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "project ID and user are required")
 	}
-	if justification == "" {
-		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "a justification is required for emergency access")
+	justification = strings.TrimSpace(justification)
+	if len(justification) < minBreakGlassJustificationLen {
+		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil),
+			fmt.Sprintf("a justification of at least %d characters is required for emergency access", minBreakGlassJustificationLen))
 	}
 	// Only a user already affiliated with the project may break-glass it. Eligibility
 	// must require a role scoped to THIS project (project_id = P), directly or via a

--- a/internal/core/break_glass_external_test.go
+++ b/internal/core/break_glass_external_test.go
@@ -73,7 +73,7 @@ func TestActivateBreakGlass_CapsTTL(t *testing.T) {
 	ctx := context.Background()
 	h.CreateTestUser(t, "alice", 10)
 	makeProjectMember(t, h, 10, 2)
-	act, err := h.CoreService.ActivateBreakGlass(ctx, 2, 10, "incident", "10h")
+	act, err := h.CoreService.ActivateBreakGlass(ctx, 2, 10, "prod incident", "10h")
 	require.NoError(t, err)
 	require.NotNil(t, act.ExpiresAt)
 	assert.WithinDuration(t, time.Now().Add(1*time.Hour), *act.ExpiresAt, 2*time.Minute, "10h request capped at the 1h max")
@@ -91,7 +91,7 @@ func TestActivateBreakGlass_UnsetMaxTTLFloorsToDefault(t *testing.T) {
 	ctx := context.Background()
 	h.CreateTestUser(t, "alice", 10)
 	makeProjectMember(t, h, 10, 2)
-	act, err := h.CoreService.ActivateBreakGlass(ctx, 2, 10, "incident", "720h") // 30-day override
+	act, err := h.CoreService.ActivateBreakGlass(ctx, 2, 10, "prod incident", "720h") // 30-day override
 	require.NoError(t, err)
 	require.NotNil(t, act.ExpiresAt)
 	assert.WithinDuration(t, time.Now().Add(4*time.Hour), *act.ExpiresAt, 2*time.Minute,
@@ -108,13 +108,52 @@ func TestActivateBreakGlass_DisabledAndJustificationRequired(t *testing.T) {
 	h.CreateTestUser(t, "alice", 10)
 
 	// Disabled (default policy) → refused.
-	_, err := h.CoreService.ActivateBreakGlass(ctx, 2, 10, "incident", "")
+	_, err := h.CoreService.ActivateBreakGlass(ctx, 2, 10, "prod incident", "")
 	require.Error(t, err)
 
 	// Enabled but no justification → refused.
 	enableBreakGlass(h, "editor", time.Hour, time.Hour)
 	_, err = h.CoreService.ActivateBreakGlass(ctx, 2, 10, "", "")
 	require.Error(t, err)
+}
+
+// #413: the justification becomes a PERMANENT audit-trail record of why a real
+// security incident required emergency access. A bare non-empty check lets a
+// single whitespace character (or any string under a reasonable minimum length)
+// satisfy it, producing a useless audit record. Whitespace-only and too-short
+// justifications must be refused; a genuine one, including one with leading/
+// trailing whitespace that trims down to a valid length, must be accepted.
+func TestActivateBreakGlass_RejectsWhitespaceOnlyAndTooShortJustification(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	migrateBreakGlass(t, h)
+	enableBreakGlass(h, "editor", time.Hour, time.Hour)
+
+	const proj = uint(2)
+	ctx := context.Background()
+	h.CreateTestUser(t, "alice", 10)
+	makeProjectMember(t, h, 10, proj)
+
+	// A single space (or any whitespace-only string) must not satisfy the check.
+	_, err := h.CoreService.ActivateBreakGlass(ctx, proj, 10, " ", "")
+	require.Error(t, err, "a whitespace-only justification must be refused")
+	assert.Contains(t, err.Error(), "justification")
+
+	// Too short even after trimming (below the minimum length) must be refused.
+	_, err = h.CoreService.ActivateBreakGlass(ctx, proj, 10, "  bad  ", "")
+	require.Error(t, err, "a too-short justification must be refused even with padding whitespace")
+	assert.Contains(t, err.Error(), "justification")
+
+	// No activation was recorded for either rejected attempt.
+	list, err := h.CoreService.ListBreakGlassActivations(ctx, proj)
+	require.NoError(t, err)
+	assert.Empty(t, list)
+
+	// A genuine justification — including one with surrounding whitespace that
+	// trims down to a valid length — is accepted, and the stored value is trimmed.
+	act, err := h.CoreService.ActivateBreakGlass(ctx, proj, 10, "  prod database incident  ", "")
+	require.NoError(t, err, "a genuine justification must be accepted")
+	assert.Equal(t, "prod database incident", act.Justification, "the stored justification must be trimmed")
 }
 
 // Revoking an activation removes the grant early and marks it revoked.
@@ -129,7 +168,7 @@ func TestRevokeBreakGlass_RemovesGrant(t *testing.T) {
 	h.CreateTestUser(t, "alice", 10)
 	makeProjectMember(t, h, 10, proj)
 
-	act, err := h.CoreService.ActivateBreakGlass(ctx, proj, 10, "incident", "")
+	act, err := h.CoreService.ActivateBreakGlass(ctx, proj, 10, "prod incident", "")
 	require.NoError(t, err)
 
 	require.NoError(t, h.CoreService.RevokeBreakGlass(ctx, 1, proj, act.ID))
@@ -164,7 +203,7 @@ func TestRevokeBreakGlassActivation_ConditionalUpdateOnlyFirstAttemptWins(t *tes
 	h.CreateTestUser(t, "alice", 10)
 	makeProjectMember(t, h, 10, proj)
 
-	act, err := h.CoreService.ActivateBreakGlass(ctx, proj, 10, "incident", "")
+	act, err := h.CoreService.ActivateBreakGlass(ctx, proj, 10, "prod incident", "")
 	require.NoError(t, err)
 
 	firstRevokeAt := time.Now().Add(-time.Minute).UTC().Truncate(time.Second)
@@ -201,7 +240,7 @@ func TestRevokeBreakGlass_ConcurrentRevokesOnlyOneWins(t *testing.T) {
 	h.CreateTestUser(t, "alice", 10)
 	makeProjectMember(t, h, 10, proj)
 
-	act, err := h.CoreService.ActivateBreakGlass(ctx, proj, 10, "incident", "")
+	act, err := h.CoreService.ActivateBreakGlass(ctx, proj, 10, "prod incident", "")
 	require.NoError(t, err)
 
 	admins := []uint{100, 200}
@@ -305,7 +344,7 @@ func TestActivateBreakGlass_RejectsNonMember(t *testing.T) {
 	ctx := context.Background()
 	h.CreateTestUser(t, "outsider", 10) // created, but NOT a member of project 2
 
-	_, err := h.CoreService.ActivateBreakGlass(ctx, 2, 10, "incident", "")
+	_, err := h.CoreService.ActivateBreakGlass(ctx, 2, 10, "prod incident", "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "members of the project")
 
@@ -332,7 +371,7 @@ func TestActivateBreakGlass_RejectsConcurrentReactivation(t *testing.T) {
 	require.NoError(t, err)
 
 	// Second activation while the first is still active → refused.
-	_, err = h.CoreService.ActivateBreakGlass(ctx, proj, 10, "again", "")
+	_, err = h.CoreService.ActivateBreakGlass(ctx, proj, 10, "still ongoing", "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "already have an active break-glass grant")
 
@@ -405,7 +444,7 @@ func TestActivateBreakGlass_RejectsGlobalOnlyAffiliation(t *testing.T) {
 	h.CreateTestUser(t, "ssouser", 10)
 	h.AssignUserRole(t, 10, 4, nil) // viewer at GLOBAL scope (project_id = 0), not project-scoped
 
-	_, err := h.CoreService.ActivateBreakGlass(ctx, 2, 10, "incident", "")
+	_, err := h.CoreService.ActivateBreakGlass(ctx, 2, 10, "prod incident", "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "members of the project")
 }
@@ -430,13 +469,13 @@ func TestActivateBreakGlass_RejectsRoleAssignEmergencyRole(t *testing.T) {
 	h.ExecuteRawSQL(t, "INSERT OR IGNORE INTO role_permissions (role_id, permission_id) VALUES (?, ?)", 50, 13)
 
 	enableBreakGlass(h, "delegated_approver", 4*time.Hour, 24*time.Hour)
-	_, err := h.CoreService.ActivateBreakGlass(ctx, proj, 10, "incident", "")
+	_, err := h.CoreService.ActivateBreakGlass(ctx, proj, 10, "prod incident", "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "assign roles")
 
 	// editor is contained (no roles.assign) → allowed.
 	enableBreakGlass(h, "editor", 4*time.Hour, 24*time.Hour)
-	act, err := h.CoreService.ActivateBreakGlass(ctx, proj, 10, "incident", "")
+	act, err := h.CoreService.ActivateBreakGlass(ctx, proj, 10, "prod incident", "")
 	require.NoError(t, err)
 	assert.Equal(t, core.BreakGlassActive, act.State)
 }
@@ -455,7 +494,7 @@ func TestActivateBreakGlass_RejectsInstallAdminEmergencyRole(t *testing.T) {
 	h.CreateTestUser(t, "alice", 10)
 	makeProjectMember(t, h, 10, proj)
 
-	_, err := h.CoreService.ActivateBreakGlass(ctx, proj, 10, "incident", "")
+	_, err := h.CoreService.ActivateBreakGlass(ctx, proj, 10, "prod incident", "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "install-wide administration")
 }


### PR DESCRIPTION
## Summary

Fixes three findings from the hardening backlog:

- **#269** — `keyorix encryption shamir-split` wrote each key-share file via a raw `os.WriteFile`, which follows a pre-planted symlink and never chmods an existing file. Switched to `internal/securefiles.SecureWriteFileSync` (same primitive as the #265 fix), refusing writes through a pre-planted symlink and enforcing 0600 unconditionally.
- **#413** — Break-glass activation validated `justification` with only a non-empty check, so a single space became the permanent audit-trail record for a real incident. `internal/core/break_glass.go` now trims whitespace and requires a minimum length (10 chars) after trimming, at the actual enforcement layer.
- **#414** — `BreakGlassConfig.EmergencyRole`'s documented example (`"project_admin"`) names a role the runtime activation logic always rejects (it carries `roles.assign`). Updated the doc example in both `internal/config/config.go` and `docs/CONFIGURATION.md` to `"project_developer"`, the contained role the rejection message itself already suggests.

## Test plan

- [x] Added `TestShamirSplit_RefusesToFollowSymlinkAtTarget` and `TestShamirSplit_WritesSharesWithSecurePermissions` (`internal/cli/encryption/shamir_split_test.go`)
- [x] Added `TestActivateBreakGlass_RejectsWhitespaceOnlyAndTooShortJustification`, covering whitespace-only, too-short-after-trim, and a genuine (trimmed) justification (`internal/core/break_glass_external_test.go`); updated existing short test justifications to satisfy the new minimum
- [x] `go build ./...` and `go vet ./...` clean
- [x] `go test ./internal/cli/encryption/... ./internal/core/... ./server/http/handlers/...` — all pass
- [x] `go test ./server/grpc/services/... -run BreakGlass` — all pass (confirms the gRPC error-mapping still classifies the new message as `InvalidArgument`)
- [x] `gosec -severity medium -exclude-generated` scoped to touched packages — 0 issues
- [x] Confirmed `project_developer` lacks `roles.assign` (vs `project_admin`, which has it) by reading `auth_bootstrap.go`'s role definitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)