### PR TITLE
fix(migrate): verify --by actor's authority for user-to-machine migration (#264)

### DIFF
--- a/internal/cli/migrate/user_to_machine.go
+++ b/internal/cli/migrate/user_to_machine.go
@@ -2,9 +2,10 @@
 //
 // Converts a service-account-shaped human user into a project machine identity.
 // Local mode only (operator tool): resolves the acting admin via --by, the
-// project via --project / KEYORIX_PROJECT / the active project, then delegates to
-// core.MigrateUserToMachine. By default the source user is suspended so it can no
-// longer log in; --keep-user leaves it active.
+// project via --project / KEYORIX_PROJECT / the active project, verifies --by
+// actually holds the authority the equivalent HTTP route requires (#264), then
+// delegates to core.MigrateUserToMachine. By default the source user is
+// suspended so it can no longer log in; --keep-user leaves it active.
 package migrate
 
 import (
@@ -66,6 +67,10 @@ func runUserToMachine(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if err := requireMigrationAuthority(ctx, svc, admin.ID, projectID); err != nil {
+		return err
+	}
+
 	m, err := svc.MigrateUserToMachine(ctx, username, projectID, u2mType, u2mName, admin.ID, !u2mKeepUser)
 	if err != nil {
 		return fmt.Errorf("migration failed: %w", err)
@@ -75,6 +80,37 @@ func runUserToMachine(cmd *cobra.Command, args []string) error {
 		username, m.ID, m.Name, m.IdentityType, m.State)
 	if !u2mKeepUser {
 		fmt.Println("Source user suspended (login blocked). Use `keyorix user reactivate` to restore.")
+	}
+	return nil
+}
+
+// requireMigrationAuthority verifies that actorID — the user resolved from
+// --by — actually holds the authority the equivalent HTTP route requires for
+// this exact operation: POST .../machine-identities/migrate-from-user needs
+// BOTH roles.assign (scoped to the target project, for creating the machine
+// identity) AND users.write (global, for suspending the source user). The
+// local CLI has no session/middleware to enforce this, so --by resolving ANY
+// email — with zero authority check — would let an operator attribute a
+// destructive migration to an arbitrary or unprivileged account purely for
+// what appears in the audit trail (#264). MigrateUserToMachine itself does not
+// check permissions (like its sibling CreateMachineIdentity/SuspendUser, it
+// assumes the caller already authorized — the HTTP handler's job is done by
+// router middleware), so this must be verified here, at the CLI entrypoint,
+// before the resolved actor is credited with the action.
+func requireMigrationAuthority(ctx context.Context, svc *core.KeyorixCore, actorID, projectID uint) error {
+	ok, err := svc.Authorize(ctx, actorID, "roles.assign", core.Scope{ProjectID: projectID})
+	if err != nil {
+		return fmt.Errorf("failed to verify --by authority: %w", err)
+	}
+	if !ok {
+		return fmt.Errorf("--by actor does not hold roles.assign at project %d; refusing to attribute this migration to them", projectID)
+	}
+	ok, err = svc.Authorize(ctx, actorID, "users.write", core.Scope{})
+	if err != nil {
+		return fmt.Errorf("failed to verify --by authority: %w", err)
+	}
+	if !ok {
+		return fmt.Errorf("--by actor does not hold users.write; refusing to attribute this migration to them")
 	}
 	return nil
 }

--- a/internal/cli/migrate/user_to_machine_authority_test.go
+++ b/internal/cli/migrate/user_to_machine_authority_test.go
@@ -1,0 +1,113 @@
+// user_to_machine_authority_test.go — regression coverage for #264: the --by
+// actor for `keyorix migrate user-to-machine` must actually hold the authority
+// the equivalent HTTP route requires (roles.assign scoped to the project AND
+// users.write globally), not merely resolve to SOME user record.
+package migrate
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// newTestMigrateCore spins up an in-memory store, runs the production
+// BootstrapSystem (seeding the real RBAC role/permission catalog), and returns
+// the core + storage for authority assertions — mirrors core.newBootstrappedCore
+// (internal/core/auth_bootstrap_rbac_test.go), reimplemented here since that
+// helper is unexported to the core package.
+func newTestMigrateCore(t *testing.T) (*core.KeyorixCore, *store.LocalStorage) {
+	t.Helper()
+	require.NoError(t, i18n.Initialize(&config.Config{
+		Locale: config.LocaleConfig{Language: "en", FallbackLanguage: "en"},
+	}))
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.User{}, &models.Role{}, &models.Permission{}, &models.RolePermission{},
+		&models.UserRole{}, &models.Group{}, &models.UserGroup{}, &models.GroupRole{},
+		&models.Project{}, &models.Environment{}, &models.SystemMetadata{},
+		&models.MachineIdentity{}, &models.MachineIdentityRole{},
+		&models.PersonalAccessToken{}, &models.Session{}, &models.AuditEvent{},
+	))
+
+	st := store.NewLocalStorage(db)
+	c := core.NewKeyorixCore(st)
+	c.SetBootstrapToken("test-bootstrap-token")
+	_, err = c.BootstrapSystem(context.Background(), &core.BootstrapRequest{
+		Username: "admin", Email: "admin@example.com", Password: "BootstrapPass123!", DisplayName: "Admin",
+		Token: "test-bootstrap-token",
+	})
+	require.NoError(t, err)
+	return c, st
+}
+
+// seedUserWithRole creates a user and assigns roleName at scope, returning the
+// new user's ID.
+func seedUserWithRole(t *testing.T, st *store.LocalStorage, username, roleName string, scope core.Scope) uint {
+	t.Helper()
+	ctx := context.Background()
+	u, err := st.CreateUser(ctx, &models.User{Username: username, Email: username + "@example.com", IsActive: true})
+	require.NoError(t, err)
+	role, err := st.GetRoleByName(ctx, roleName)
+	require.NoErrorf(t, err, "role %s must be seeded", roleName)
+	require.NoError(t, st.AssignRole(ctx, u.ID, role.ID, scope))
+	return u.ID
+}
+
+// #264: an actor holding only a read-only project role (no roles.assign, no
+// users.write) must be refused — the CLI must not let --by attribute this
+// migration to an unprivileged account.
+func TestRequireMigrationAuthority_UnprivilegedActorRejected(t *testing.T) {
+	c, st := newTestMigrateCore(t)
+	ctx := context.Background()
+	actor := seedUserWithRole(t, st, "u2m-viewer", "project_viewer", core.Scope{ProjectID: 1})
+
+	err := requireMigrationAuthority(ctx, c, actor, 1)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "roles.assign")
+}
+
+// #264: an actor holding roles.assign at the project but lacking users.write
+// globally must still be refused — the composite operation (create machine
+// identity + suspend the source user) needs both, exactly like the HTTP route.
+func TestRequireMigrationAuthority_MissingUsersWriteRejected(t *testing.T) {
+	c, st := newTestMigrateCore(t)
+	ctx := context.Background()
+	actor := seedUserWithRole(t, st, "u2m-project-admin", "project_admin", core.Scope{ProjectID: 1})
+
+	err := requireMigrationAuthority(ctx, c, actor, 1)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "users.write")
+}
+
+// #264 positive control: a genuinely authorized actor (holding both
+// permissions the HTTP route requires) must still succeed — no regression for
+// the legitimate case.
+func TestRequireMigrationAuthority_AuthorizedActorAllowed(t *testing.T) {
+	c, st := newTestMigrateCore(t)
+	ctx := context.Background()
+	actor := seedUserWithRole(t, st, "u2m-admin", "admin", core.Scope{})
+
+	require.NoError(t, requireMigrationAuthority(ctx, c, actor, 1))
+}
+
+// #264 positive control: the bootstrap admin created by BootstrapSystem itself
+// (the realistic legitimate --by actor for this command) must pass too.
+func TestRequireMigrationAuthority_BootstrapAdminAllowed(t *testing.T) {
+	c, st := newTestMigrateCore(t)
+	ctx := context.Background()
+	bootstrapAdmin, err := st.GetUserByEmail(ctx, "admin@example.com")
+	require.NoError(t, err)
+
+	require.NoError(t, requireMigrationAuthority(ctx, c, bootstrapAdmin.ID, 1))
+}


### PR DESCRIPTION
## Summary
- \`keyorix migrate user-to-machine --by <email>\` resolved the \`--by\` email to a user record and stamped the migration's audit trail with that user, without ever checking the resolved account actually held any authority — a CLI operator could attribute a destructive user-to-machine migration to an arbitrary or unprivileged account.
- The equivalent HTTP route (\`POST /projects/{id}/machine-identities/migrate-from-user\`) requires **both** \`roles.assign\` (scoped to the project) and \`users.write\` (global) via router middleware; the CLI path had no equivalent check at all.
- Fixes #264.

## Fix
- Added \`requireMigrationAuthority\` in \`internal/cli/migrate/user_to_machine.go\`, called after resolving \`--by\` and the target project, before invoking \`core.MigrateUserToMachine\`. It calls \`core.KeyorixCore.Authorize\` for \`roles.assign\` at the project scope and \`users.write\` at global scope — the same primitive the HTTP middleware chain uses — and refuses with a clear error if either is missing.
- Placed the check in the CLI layer rather than pushing it into \`core.MigrateUserToMachine\`: that core function's siblings (\`CreateMachineIdentity\`, \`SuspendUser\`) don't perform plain permission checks themselves — authorization is the caller's responsibility (HTTP middleware for the HTTP path), a convention also confirmed by the existing handler unit tests, which call the handler directly with no RBAC tables populated and still expect success. Adding a permission check inside the core function would have broken that established boundary and those tests. The CLI is the one caller that bypasses this authorization step entirely, so the fix belongs at its entrypoint.

## Test plan
- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] \`go test ./internal/cli/... ./internal/core/...\` — all pass except the pre-existing, order-independent flake \`TestConcurrency_RequestPasswordReset_BurstIsThrottled\` (confirmed unrelated: fails identically on main without this change, and passes 5/5 on repeated reruns)
- [x] \`gosec -severity medium -exclude-generated\` scoped to \`internal/cli/migrate\` — 0 issues
- [x] New regression tests in \`internal/cli/migrate/user_to_machine_authority_test.go\`:
  - unprivileged actor (read-only role) rejected
  - actor with \`roles.assign\` but no \`users.write\` rejected
  - genuinely authorized actor (admin role) still succeeds
  - the realistic bootstrap admin still succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)