### PR TITLE
fix(sharing): exclude expired shares from share-listing queries (#402)

### DIFF
--- a/internal/storage/store/local_sharing.go
+++ b/internal/storage/store/local_sharing.go
@@ -177,37 +177,59 @@ func (ls *LocalStorage) DeleteExpiredShareRecords(ctx context.Context, before ti
 	return removed, nil
 }
 
-// ListSharesBySecret lists active share records for a secret.
+// ListSharesBySecret lists currently-active share records for a secret — soft-deleted
+// AND expired (time-bound) shares are excluded, matching the expiry filter every
+// authorization path (CheckSharePermission, CheckSecretPermission via activeShares)
+// already applies. #402: this used to return expired shares too, so reporting/
+// compliance/risk-scoring callers built on it over-counted access that no longer
+// authorizes anything, even though the real permission-check path was never fooled.
 func (ls *LocalStorage) ListSharesBySecret(ctx context.Context, secretID uint) ([]*models.ShareRecord, error) {
 	var shares []*models.ShareRecord
-	if err := ls.db.Where("secret_id = ? AND deleted_at IS NULL", secretID).Find(&shares).Error; err != nil {
+	if err := ls.db.Where(
+		"secret_id = ? AND deleted_at IS NULL AND (expires_at IS NULL OR expires_at > ?)",
+		secretID, time.Now(),
+	).Find(&shares).Error; err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorDatabaseOperation", nil), err)
 	}
 	return shares, nil
 }
 
-// ListSharesByUser lists active share records where userID is the direct recipient.
+// ListSharesByUser lists currently-active share records where userID is the direct
+// recipient. See ListSharesBySecret for why expired shares are excluded (#402).
 func (ls *LocalStorage) ListSharesByUser(ctx context.Context, userID uint) ([]*models.ShareRecord, error) {
 	var shares []*models.ShareRecord
-	if err := ls.db.Where("recipient_id = ? AND is_group = ? AND deleted_at IS NULL", userID, false).Find(&shares).Error; err != nil {
+	if err := ls.db.Where(
+		"recipient_id = ? AND is_group = ? AND deleted_at IS NULL AND (expires_at IS NULL OR expires_at > ?)",
+		userID, false, time.Now(),
+	).Find(&shares).Error; err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorDatabaseOperation", nil), err)
 	}
 	return shares, nil
 }
 
-// ListSharesByOwner lists active share records created by ownerID.
+// ListSharesByOwner lists currently-active share records created by ownerID. See
+// ListSharesBySecret for why expired shares are excluded (#402) — this feeds the
+// dashboard's outgoing-share count and ListSharesByUser's owned-share half, both of
+// which must reflect what actually still grants access, not stale time-bound grants.
 func (ls *LocalStorage) ListSharesByOwner(ctx context.Context, ownerID uint) ([]*models.ShareRecord, error) {
 	var shares []*models.ShareRecord
-	if err := ls.db.Where("owner_id = ? AND deleted_at IS NULL", ownerID).Find(&shares).Error; err != nil {
+	if err := ls.db.Where(
+		"owner_id = ? AND deleted_at IS NULL AND (expires_at IS NULL OR expires_at > ?)",
+		ownerID, time.Now(),
+	).Find(&shares).Error; err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorDatabaseOperation", nil), err)
 	}
 	return shares, nil
 }
 
-// ListSharesByGroup lists active share records where groupID is the recipient.
+// ListSharesByGroup lists currently-active share records where groupID is the
+// recipient. See ListSharesBySecret for why expired shares are excluded (#402).
 func (ls *LocalStorage) ListSharesByGroup(ctx context.Context, groupID uint) ([]*models.ShareRecord, error) {
 	var shares []*models.ShareRecord
-	if err := ls.db.Where("recipient_id = ? AND is_group = ? AND deleted_at IS NULL", groupID, true).Find(&shares).Error; err != nil {
+	if err := ls.db.Where(
+		"recipient_id = ? AND is_group = ? AND deleted_at IS NULL AND (expires_at IS NULL OR expires_at > ?)",
+		groupID, true, time.Now(),
+	).Find(&shares).Error; err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorDatabaseOperation", nil), err)
 	}
 	return shares, nil

--- a/internal/storage/store/local_sharing_test.go
+++ b/internal/storage/store/local_sharing_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/stretchr/testify/assert"
@@ -182,4 +183,114 @@ func TestCheckSharePermission_OwnerZeroGuard(t *testing.T) {
 	perm, err := ls.CheckSharePermission(ctx, 100, 0)
 	require.Error(t, err, "userID=0 must not match an ownerless secret's OwnerID=0")
 	assert.Equal(t, "", perm)
+}
+
+// #402: ListSharesBySecret/ListSharesByUser/ListSharesByGroup/ListSharesByOwner used
+// to return already-EXPIRED (but not-yet-swept) shares alongside genuinely active
+// ones — reporting/compliance-review/risk-scoring callers built on them therefore
+// over-counted access that no longer authorizes anything, even though the real
+// permission-check path (CheckSharePermission) already excluded expired shares.
+// Every listing function must apply the identical expiry filter.
+func TestListShares_ExcludeExpiredIncludeActive(t *testing.T) {
+	db := sharingConcurrentDB(t)
+	ls := NewLocalStorage(db)
+	ctx := context.Background()
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "owner", Email: "o@x.io"}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 2, Username: "grantee-active", Email: "ga@x.io"}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 3, Username: "grantee-time-bound-active", Email: "ge@x.io"}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 4, Username: "grantee-only-expired", Email: "goe@x.io"}).Error)
+	require.NoError(t, db.Create(&models.Group{ID: 1, Name: "g-active"}).Error)
+	require.NoError(t, db.Create(&models.Group{ID: 2, Name: "g-expired"}).Error)
+	require.NoError(t, db.Create(&models.SecretNode{
+		ID: 100, Name: "s", ProjectID: 1, EnvironmentID: 1, OwnerID: 1, Status: "active", Type: "password",
+	}).Error)
+
+	past := time.Now().Add(-1 * time.Hour)
+	future := time.Now().Add(1 * time.Hour)
+
+	// Active direct share (permanent, no expiry).
+	activeDirect, err := ls.CreateShareRecord(ctx, &models.ShareRecord{
+		SecretID: 100, RecipientID: 2, IsGroup: false, OwnerID: 1, Permission: "read",
+	})
+	require.NoError(t, err)
+
+	// Active, time-bound direct share that hasn't expired yet.
+	activeTimeBound, err := ls.CreateShareRecord(ctx, &models.ShareRecord{
+		SecretID: 100, RecipientID: 3, IsGroup: false, OwnerID: 1, Permission: "read", ExpiresAt: &future,
+	})
+	require.NoError(t, err)
+
+	// Direct share to a distinct recipient (4), created permanent then back-dated
+	// directly to simulate a time-bound share whose expiry has already passed but
+	// which hasn't been swept yet (DeleteExpiredShareRecords runs on its own tick).
+	expiredDirect, err := ls.CreateShareRecord(ctx, &models.ShareRecord{
+		SecretID: 100, RecipientID: 4, IsGroup: false, OwnerID: 1, Permission: "write",
+	})
+	require.NoError(t, err)
+	require.NoError(t, db.Model(&models.ShareRecord{}).Where("id = ?", expiredDirect.ID).
+		Update("expires_at", past).Error)
+
+	// Active group share.
+	activeGroup, err := ls.CreateShareRecord(ctx, &models.ShareRecord{
+		SecretID: 100, RecipientID: 1, IsGroup: true, OwnerID: 1, Permission: "read",
+	})
+	require.NoError(t, err)
+
+	// Expired group share (distinct recipient group so it doesn't collide with the
+	// active group share above).
+	expiredGroup, err := ls.CreateShareRecord(ctx, &models.ShareRecord{
+		SecretID: 100, RecipientID: 2, IsGroup: true, OwnerID: 1, Permission: "write",
+	})
+	require.NoError(t, err)
+	require.NoError(t, db.Model(&models.ShareRecord{}).Where("id = ?", expiredGroup.ID).
+		Update("expires_at", past).Error)
+
+	// --- ListSharesBySecret ---
+	bySecret, err := ls.ListSharesBySecret(ctx, 100)
+	require.NoError(t, err)
+	gotIDs := shareIDSet(bySecret)
+	assert.Contains(t, gotIDs, activeDirect.ID, "permanent active share must be listed")
+	assert.Contains(t, gotIDs, activeTimeBound.ID, "not-yet-expired time-bound share must be listed")
+	assert.Contains(t, gotIDs, activeGroup.ID, "active group share must be listed")
+	assert.NotContains(t, gotIDs, expiredDirect.ID, "expired direct share must be excluded")
+	assert.NotContains(t, gotIDs, expiredGroup.ID, "expired group share must be excluded")
+
+	// --- ListSharesByUser (recipient 3: one active time-bound, none expired left there) ---
+	byUser3, err := ls.ListSharesByUser(ctx, 3)
+	require.NoError(t, err)
+	got3 := shareIDSet(byUser3)
+	assert.Contains(t, got3, activeTimeBound.ID, "active time-bound share must be listed for its recipient")
+
+	// --- ListSharesByUser (recipient 4: only an expired share) ---
+	byUser4, err := ls.ListSharesByUser(ctx, 4)
+	require.NoError(t, err)
+	assert.Empty(t, byUser4, "a recipient whose only share is expired must see no active shares")
+
+	// --- ListSharesByGroup ---
+	byGroup1, err := ls.ListSharesByGroup(ctx, 1)
+	require.NoError(t, err)
+	got1 := shareIDSet(byGroup1)
+	assert.Contains(t, got1, activeGroup.ID, "active group share must be listed for its group")
+
+	byGroup2, err := ls.ListSharesByGroup(ctx, 2)
+	require.NoError(t, err)
+	assert.Empty(t, byGroup2, "a group whose only share is expired must see no active shares")
+
+	// --- ListSharesByOwner ---
+	byOwner, err := ls.ListSharesByOwner(ctx, 1)
+	require.NoError(t, err)
+	gotOwner := shareIDSet(byOwner)
+	assert.Contains(t, gotOwner, activeDirect.ID)
+	assert.Contains(t, gotOwner, activeTimeBound.ID)
+	assert.Contains(t, gotOwner, activeGroup.ID)
+	assert.NotContains(t, gotOwner, expiredDirect.ID, "expired share must be excluded from the owner's outgoing list")
+	assert.NotContains(t, gotOwner, expiredGroup.ID, "expired group share must be excluded from the owner's outgoing list")
+}
+
+func shareIDSet(shares []*models.ShareRecord) map[uint]bool {
+	out := make(map[uint]bool, len(shares))
+	for _, s := range shares {
+		out[s.ID] = true
+	}
+	return out
 }


### PR DESCRIPTION
## Summary

- `ListSharesBySecret`/`ListSharesByUser`/`ListSharesByGroup`/`ListSharesByOwner` in `internal/storage/store/local_sharing.go` filtered only `deleted_at IS NULL`, unlike the actual authorization path in the same file (`CheckSharePermission`) and the core-layer `activeShares`/`shareActive` helpers, which already exclude shares past their `expires_at`.
- Result: already-EXPIRED (but not-yet-swept) shares appeared as currently-active grants in reporting/compliance/risk views built on these listers — `secret_listing_query.go`, `access_review.go`, `secret_risk.go`'s `countPrincipals`, `group_sharing.go`'s `ListGroupShares`, `secret_listing_sharing.go`'s `GetSecretSharingStatus`, and `dashboard.go`'s outgoing/incoming share counts. This is a metadata/reporting-exposure gap, not a live privilege-escalation bug — the real permission-check path was never fooled.
- Added the identical expiry predicate (`expires_at IS NULL OR expires_at > ?`, bound to `time.Now()`) to all four listing functions.

## Why source-level fix over per-caller patches

Grepped every non-test caller of the four functions across the repo. Every current caller either:
1. Already re-filters expired shares in memory via `activeShares`/`shareActive` (e.g. `CheckSecretPermission`, `ListUserPermissions`, `ListSecretShares`, `GetSecretSharingStatusWithIndicators`, `GetUserSecretPermission`, `ListGroupSharedSecrets`, `secret_access_list.go`) — fixing at the source makes this filtering a harmless no-op there, or
2. Was a genuine instance of the bug (the 5 backlog-named consumers, plus `dashboard.go`'s share counts and `sharing_query.go`'s core `ListSharesByUser`, which composes `ListSharesByUser`+`ListSharesByOwner` — same bug, not explicitly named in the backlog but same file/pattern).

No caller intentionally needs expired shares included (no audit/history view depends on it), so fixing at the source in `local_sharing.go` closes the whole family in one place instead of patching 7+ call sites individually. `ListSharesByOwner` wasn't explicitly named in the backlog's 3 functions but has the identical gap and feeds the same reporting paths, so it's included too.

Two exact-match "find and act on a specific share" callers (`access_review_revoke.go`'s `revokeReviewShare`/`verifyAccessReviewGrantExists`, `sharing.go`'s `RemoveSelfFromShare`) will now report "not found" for a share that has already naturally expired but isn't yet swept — this is a minor, more-correct behavior change (there's nothing live to revoke/remove from), not a regression in any legitimate use case.

## Test plan

- [x] Added `TestListShares_ExcludeExpiredIncludeActive` in `local_sharing_test.go` covering all four listing functions: a permanent active share, a not-yet-expired time-bound share, and an already-expired share, confirming the expired one is excluded from `ListSharesBySecret`/`ListSharesByUser`/`ListSharesByGroup`/`ListSharesByOwner` while active shares remain listed.
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./internal/core/... ./internal/storage/store/...` — all pass (one unrelated known-flaky test, `TestConcurrency_RequestPasswordReset_BurstIsThrottled`, passed on rerun in isolation)
- [x] `gosec -severity medium -exclude-generated` scoped to `internal/core/...` and `internal/storage/store/...` — 0 issues on both

🤖 Generated with [Claude Code](https://claude.com/claude-code)