### PR TITLE
fix(crypto): reject group-/world-readable KEK files before trusting them

### DIFF
--- a/internal/crypto/keyprovider_test.go
+++ b/internal/crypto/keyprovider_test.go
@@ -113,6 +113,42 @@ func TestFileKeyProvider_Errors(t *testing.T) {
 	}
 }
 
+func TestFileKeyProvider_RejectsPermissiveMode(t *testing.T) {
+	dir := t.TempDir()
+	raw := make([]byte, KEKSize)
+	for i := range raw {
+		raw[i] = byte(i + 1)
+	}
+
+	for _, mode := range []os.FileMode{0644, 0666, 0640, 0604} {
+		t.Run(mode.String(), func(t *testing.T) {
+			path := filepath.Join(dir, "permissive-"+mode.String()+".key")
+			require.NoError(t, os.WriteFile(path, raw, mode))
+			_, err := NewFileKeyProvider(path).KEK()
+			require.Error(t, err, "a KEK file readable/writable beyond its owner must be rejected")
+			assert.Contains(t, err.Error(), "beyond its owner")
+		})
+	}
+}
+
+func TestFileKeyProvider_AcceptsOwnerOnlyMode(t *testing.T) {
+	dir := t.TempDir()
+	raw := make([]byte, KEKSize)
+	for i := range raw {
+		raw[i] = byte(255 - i)
+	}
+
+	for _, mode := range []os.FileMode{0600, 0400} {
+		t.Run(mode.String(), func(t *testing.T) {
+			path := filepath.Join(dir, "owner-only-"+mode.String()+".key")
+			require.NoError(t, os.WriteFile(path, raw, mode))
+			kek, err := NewFileKeyProvider(path).KEK()
+			require.NoError(t, err, "an owner-only-permissioned KEK file must still load")
+			assert.Equal(t, raw, kek)
+		})
+	}
+}
+
 func TestEnvKeyProvider(t *testing.T) {
 	raw := make([]byte, KEKSize)
 	for i := range raw {

--- a/internal/crypto/raw_providers.go
+++ b/internal/crypto/raw_providers.go
@@ -50,7 +50,20 @@ func (p *FileKeyProvider) KEK() ([]byte, error) {
 	if p.path == "" {
 		return nil, fmt.Errorf("file key provider: file_path is required")
 	}
-	data, err := os.ReadFile(p.path) // #nosec G304 -- operator-configured trusted KEK path
+	// Reject a group-/world-readable (or -writable) KEK file before ever trusting its
+	// contents. Mirrors the mode-bit threshold server/main.go's enforceKeyFilePermissions
+	// already uses for the wrapped DEK / salt / TLS key files (perm&0o077 != 0). Unlike
+	// that check — which only warns by default — the KEK is the root of the encryption
+	// key hierarchy, so a bad permission here fails closed unconditionally: an
+	// operator-fixable chmod, not a runtime toggle, is the correct remedy.
+	info, err := os.Stat(p.path)
+	if err != nil {
+		return nil, fmt.Errorf("file key provider: failed to stat %s: %w", p.path, err)
+	}
+	if info.Mode().Perm()&0o077 != 0 {
+		return nil, fmt.Errorf("file key provider: %s is readable/writable beyond its owner (mode %o) — refusing to trust it as key material; chmod it to 0600 (or 0400)", p.path, info.Mode().Perm())
+	}
+	data, err := os.ReadFile(p.path) // #nosec G304 -- operator-configured trusted KEK path, permission-checked above
 	if err != nil {
 		return nil, fmt.Errorf("file key provider: failed to read %s: %w", p.path, err)
 	}


### PR DESCRIPTION
## Summary

- Fixes #430: `FileKeyProvider.KEK()` in `internal/crypto/raw_providers.go` read an externally-supplied KEK file via a plain `os.ReadFile` (under a `#nosec G304` suppression) with no check of the file's permission bits, so a group- or world-readable KEK (operator mistake, restored backup, loose provisioning umask) was silently trusted rather than rejected.
- `KEK()` now `os.Stat`s the file first and fails closed if `mode.Perm()&0o077 != 0` (readable/writable beyond the owner), mirroring the exact threshold `server/main.go`'s `enforceKeyFilePermissions` already uses for the wrapped DEK / salt / TLS key files.
- Unlike that existing check (which only warns unless `security.enable_file_permission_check` is opted in), this one fails closed unconditionally with no override: the KEK is the root of the encryption key hierarchy, `internal/crypto` has no dependency on `internal/config` (and shouldn't gain one for this), and every existing test fixture already writes KEK files at `0600`, so there's no legitimate case that needs an escape hatch — a `chmod` is the correct remedy, not a runtime toggle.
- Added regression tests: `0644`/`0666`/`0640`/`0604` KEK files are rejected with a clear "beyond its owner" error; `0600`/`0400` files still load successfully (no regression for the legitimate case).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/crypto/...` (and `./internal/encryption/...`, which exercises `FileKeyProvider` heavily)
- [x] `gosec -severity medium -exclude-generated ./internal/crypto/...` — 0 issues