### PR TITLE
fix(sharing): resolve direct-vs-group share conflicts, reject self-shares (#252)

### DIFF
--- a/internal/core/sharing_test.go
+++ b/internal/core/sharing_test.go
@@ -127,6 +127,19 @@ func TestKeyorixCore_ShareSecret_ValidationError(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			// #252: a user cannot share a secret with themselves — meaningless at
+			// best and a landmine (inflated share/audit counts, risk-scoring noise)
+			// at worst.
+			name: "self-share rejected",
+			req: &ShareSecretRequest{
+				SecretID:    1,
+				RecipientID: 1,
+				Permission:  "read",
+				SharedBy:    1,
+			},
+			wantErr: true,
+		},
 	}
 
 	// Execute and assert
@@ -167,6 +180,69 @@ func TestKeyorixCore_ShareSecret_StorageError(t *testing.T) {
 	// Assert
 	assert.Error(t, err)
 	mockStorage.AssertExpectations(t)
+}
+
+// #252: ShareSecret must reject a self-share (RecipientID == SharedBy) — the
+// storage layer must never be reached — while still allowing an ordinary share to
+// a different user to proceed normally.
+func TestKeyorixCore_ShareSecret_RejectsSelfShare(t *testing.T) {
+	mockStorage := new(MockStorage)
+	core := &KeyorixCore{storage: mockStorage}
+	ctx := context.Background()
+
+	selfShareReq := &ShareSecretRequest{
+		SecretID:    1,
+		RecipientID: 1,
+		IsGroup:     false,
+		Permission:  "read",
+		SharedBy:    1,
+	}
+	_, err := core.ShareSecret(ctx, selfShareReq)
+	require.Error(t, err, "sharing a secret with yourself must be rejected")
+	// No storage calls at all — validation must fail before GetSecret/CreateShareRecord.
+	mockStorage.AssertNotCalled(t, "GetSecret", mock.Anything, mock.Anything)
+	mockStorage.AssertNotCalled(t, "CreateShareRecord", mock.Anything, mock.Anything)
+
+	// A group share whose RecipientID (a group ID) numerically equals SharedBy must
+	// NOT be treated as a self-share — RecipientID identifies a group, not a user.
+	mockTime := time.Date(2025, 7, 1, 12, 0, 0, 0, time.UTC)
+	core.now = func() time.Time { return mockTime }
+	groupSecret := &models.SecretNode{ID: 1, Name: "s", OwnerID: 1}
+	groupShareRecord := &models.ShareRecord{ID: 2, SecretID: 1, OwnerID: 1, RecipientID: 1, IsGroup: true, Permission: "read"}
+	mockStorage.On("GetSecret", ctx, uint(1)).Return(groupSecret, nil)
+	mockStorage.On("CreateShareRecord", ctx, mock.MatchedBy(func(s *models.ShareRecord) bool {
+		return s.SecretID == 1 && s.IsGroup
+	})).Return(groupShareRecord, nil)
+	mockStorage.On("LogAuditEvent", ctx, mock.AnythingOfType("*models.AuditEvent")).Return(nil)
+	mockStorage.On("ListGroupMembers", ctx, uint(1)).Return([]*models.User{}, nil)
+	groupReq := &ShareSecretRequest{
+		SecretID:    1,
+		RecipientID: 1, // group ID, coincides numerically with SharedBy
+		IsGroup:     true,
+		Permission:  "read",
+		SharedBy:    1,
+	}
+	_, err = core.ShareSecret(ctx, groupReq)
+	require.NoError(t, err, "a group share must not be misidentified as a self-share just because RecipientID (group ID) equals SharedBy")
+
+	// A normal share to a different user still succeeds.
+	otherSecret := &models.SecretNode{ID: 3, Name: "s2", OwnerID: 1}
+	otherShareRecord := &models.ShareRecord{ID: 4, SecretID: 3, OwnerID: 1, RecipientID: 2, IsGroup: false, Permission: "read"}
+	mockStorage.On("GetSecret", ctx, uint(3)).Return(otherSecret, nil)
+	mockStorage.On("CreateShareRecord", ctx, mock.MatchedBy(func(s *models.ShareRecord) bool {
+		return s.SecretID == 3 && !s.IsGroup
+	})).Return(otherShareRecord, nil)
+	mockStorage.On("CreateNotification", ctx, mock.AnythingOfType("*models.Notification")).Return(&models.Notification{}, nil)
+	normalReq := &ShareSecretRequest{
+		SecretID:    3,
+		RecipientID: 2,
+		IsGroup:     false,
+		Permission:  "read",
+		SharedBy:    1,
+	}
+	result, err := core.ShareSecret(ctx, normalReq)
+	require.NoError(t, err, "an ordinary share to a different user must still succeed")
+	assert.Equal(t, otherShareRecord, result)
 }
 
 func TestKeyorixCore_UpdateSharePermission(t *testing.T) {

--- a/internal/core/sharing_validation.go
+++ b/internal/core/sharing_validation.go
@@ -19,6 +19,14 @@ func (c *KeyorixCore) validateShareSecretRequest(req *ShareSecretRequest) error 
 	if req.SharedBy == 0 {
 		return fmt.Errorf("sharedBy is required")
 	}
+	// #252: a self-share (sharing a secret with yourself) is meaningless at best and
+	// a landmine at worst — it inflates share/audit counts and confuses risk-scoring
+	// with no real access-boundary crossed. Only applies to direct (non-group) shares:
+	// for group shares RecipientID is a group ID, not a user ID, so it can coincide
+	// with SharedBy's numeric value without meaning anything.
+	if !req.IsGroup && req.RecipientID == req.SharedBy {
+		return fmt.Errorf("cannot share a secret with yourself")
+	}
 	return nil
 }
 

--- a/internal/storage/store/local_sharing.go
+++ b/internal/storage/store/local_sharing.go
@@ -270,8 +270,18 @@ func (ls *LocalStorage) ListSharedSecrets(ctx context.Context, userID uint) ([]*
 	return append(secrets, groupSecrets...), nil
 }
 
+// permissionRank mirrors the rank convention established in
+// internal/core/secret_access_list.go (read < write < owner) so that
+// direct-vs-group conflict resolution here stays consistent with the "strongest
+// grant wins" rule used across the codebase. Kept as a local copy — store must
+// not import core (core already imports store).
+var permissionRank = map[string]int{"read": 1, "write": 2, "owner": 3}
+
 // CheckSharePermission returns the effective permission level for userID on secretID.
 // Owner → "write". Direct share → share.Permission. Group share → share.Permission.
+// #252: when a user has BOTH a direct share and a group share on the same secret,
+// the STRONGER of the two wins — a weaker direct grant must never silently
+// override a stronger group grant (or vice versa).
 func (ls *LocalStorage) CheckSharePermission(ctx context.Context, secretID, userID uint) (string, error) {
 	var secret models.SecretNode
 	if err := ls.db.First(&secret, secretID).Error; err != nil {
@@ -294,12 +304,13 @@ func (ls *LocalStorage) CheckSharePermission(ctx context.Context, secretID, user
 	// Skip expired (time-bound) shares — an expired share grants no permission.
 	now := time.Now()
 	var directShare models.ShareRecord
+	haveDirect := false
 	err := ls.db.Where(
 		"secret_id = ? AND recipient_id = ? AND is_group = ? AND deleted_at IS NULL AND (expires_at IS NULL OR expires_at > ?)",
 		secretID, userID, false, now,
 	).First(&directShare).Error
 	if err == nil {
-		return directShare.Permission, nil
+		haveDirect = true
 	} else if !errors.Is(err, gorm.ErrRecordNotFound) {
 		return "", fmt.Errorf("%s: %w", i18n.T("ErrorDatabaseOperation", nil), err)
 	}
@@ -315,10 +326,21 @@ func (ls *LocalStorage) CheckSharePermission(ctx context.Context, secretID, user
 		LIMIT 1
 	`
 	res := ls.db.Raw(groupQuery, secretID, userID, true, now).Scan(&groupShare)
-	if res.Error == nil && groupShare.ID != 0 {
-		return groupShare.Permission, nil
-	} else if res.Error != nil && !errors.Is(res.Error, gorm.ErrRecordNotFound) {
+	haveGroup := res.Error == nil && groupShare.ID != 0
+	if res.Error != nil && !errors.Is(res.Error, gorm.ErrRecordNotFound) {
 		return "", fmt.Errorf("%s: %w", i18n.T("ErrorDatabaseOperation", nil), res.Error)
+	}
+
+	switch {
+	case haveDirect && haveGroup:
+		if permissionRank[groupShare.Permission] > permissionRank[directShare.Permission] {
+			return groupShare.Permission, nil
+		}
+		return directShare.Permission, nil
+	case haveDirect:
+		return directShare.Permission, nil
+	case haveGroup:
+		return groupShare.Permission, nil
 	}
 
 	return "", fmt.Errorf("%s", i18n.T("ErrorNotAuthorized", nil))

--- a/internal/storage/store/local_sharing_test.go
+++ b/internal/storage/store/local_sharing_test.go
@@ -294,3 +294,56 @@ func shareIDSet(shares []*models.ShareRecord) map[uint]bool {
 	}
 	return out
 }
+
+// #252: CheckSharePermission used to resolve a direct-vs-group conflict by returning
+// whichever it happened to check first (the direct share, unconditionally) — so a
+// weaker direct grant could silently override a stronger group grant. It must instead
+// return the STRONGER of the two, mirroring the "strongest grant wins" rank convention
+// in internal/core/secret_access_list.go (read < write < owner). Tested both
+// directions so a naive fix that just flips the bug (always preferring the group
+// share) would also fail.
+func TestCheckSharePermission_DirectVsGroupConflict_StrongestWins(t *testing.T) {
+	db := sharingConcurrentDB(t)
+	ls := NewLocalStorage(db)
+	ctx := context.Background()
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "owner", Email: "o@x.io"}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 2, Username: "member", Email: "m@x.io"}).Error)
+	require.NoError(t, db.Create(&models.Group{ID: 10, Name: "team"}).Error)
+	require.NoError(t, db.Create(&models.UserGroup{UserID: 2, GroupID: 10}).Error)
+
+	t.Run("direct weaker than group", func(t *testing.T) {
+		require.NoError(t, db.Create(&models.SecretNode{
+			ID: 100, Name: "s1", ProjectID: 1, EnvironmentID: 1, OwnerID: 1, Status: "active", Type: "password",
+		}).Error)
+		_, err := ls.CreateShareRecord(ctx, &models.ShareRecord{
+			SecretID: 100, RecipientID: 2, IsGroup: false, OwnerID: 1, Permission: "read",
+		})
+		require.NoError(t, err)
+		_, err = ls.CreateShareRecord(ctx, &models.ShareRecord{
+			SecretID: 100, RecipientID: 10, IsGroup: true, OwnerID: 1, Permission: "write",
+		})
+		require.NoError(t, err)
+
+		perm, err := ls.CheckSharePermission(ctx, 100, 2)
+		require.NoError(t, err)
+		assert.Equal(t, "write", perm, "a stronger group grant must not be shadowed by a weaker direct grant")
+	})
+
+	t.Run("direct stronger than group", func(t *testing.T) {
+		require.NoError(t, db.Create(&models.SecretNode{
+			ID: 101, Name: "s2", ProjectID: 1, EnvironmentID: 1, OwnerID: 1, Status: "active", Type: "password",
+		}).Error)
+		_, err := ls.CreateShareRecord(ctx, &models.ShareRecord{
+			SecretID: 101, RecipientID: 2, IsGroup: false, OwnerID: 1, Permission: "write",
+		})
+		require.NoError(t, err)
+		_, err = ls.CreateShareRecord(ctx, &models.ShareRecord{
+			SecretID: 101, RecipientID: 10, IsGroup: true, OwnerID: 1, Permission: "read",
+		})
+		require.NoError(t, err)
+
+		perm, err := ls.CheckSharePermission(ctx, 101, 2)
+		require.NoError(t, err)
+		assert.Equal(t, "write", perm, "a stronger direct grant must win over a weaker group grant")
+	})
+}


### PR DESCRIPTION
## Summary

Fixes backlog #252 (`internal/storage/store/local_sharing.go`):

- **`CheckSharePermission` conflict resolution**: previously returned a direct
  share's permission immediately on any match, without ever comparing it to a
  group-granted permission on the same secret — so a "read" direct share could
  silently shadow a "write" group grant. It now compares both against the
  `permissionRank` convention (`read` < `write` < `owner`) established in
  `internal/core/secret_access_list.go` and returns the stronger of the two.
  Confirmed via `grep` that this function still has no production caller
  (only test callers), so this closes a landmine rather than a live-exploited bug.
- **Self-share rejection**: `validateShareSecretRequest` now rejects
  `RecipientID == SharedBy` for direct (non-group) shares. Group shares are
  exempt since `RecipientID` there is a group ID, not a user ID, and could
  coincidentally equal `SharedBy`'s numeric value.

## Changes

- `internal/storage/store/local_sharing.go`: `CheckSharePermission` now looks
  up both the direct and group share (if any) and returns the stronger
  permission via a local `permissionRank` map mirroring the core package's.
- `internal/core/sharing_validation.go`: `validateShareSecretRequest` rejects
  self-shares.
- Tests: `TestCheckSharePermission_DirectVsGroupConflict_StrongestWins` (both
  directions — direct weaker than group, and direct stronger than group) and
  `TestKeyorixCore_ShareSecret_RejectsSelfShare` (rejects self-share, exempts
  group shares whose RecipientID coincides with SharedBy, still allows an
  ordinary share to a different user).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/core/... ./internal/storage/store/...` — all pass
- [x] `gosec -severity medium -exclude-generated ./internal/core/... ./internal/storage/store/...` — 0 issues