### PR TITLE
fix(rotation): dedup rotation reminders via a targeted DB query, not top-100 (#399)

### DIFF
--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -1779,6 +1779,11 @@ func (m *MockStorage) CountUnreadNotifications(ctx context.Context, userID uint)
 	return args.Get(0).(int64), args.Error(1)
 }
 
+func (m *MockStorage) HasUnreadNotification(ctx context.Context, userID uint, nType string, projectID uint) (bool, error) {
+	args := m.Called(ctx, userID, nType, projectID)
+	return args.Bool(0), args.Error(1)
+}
+
 func (m *MockStorage) MarkNotificationRead(ctx context.Context, id, userID uint) error {
 	return m.Called(ctx, id, userID).Error(0)
 }

--- a/internal/core/rotation_reminders.go
+++ b/internal/core/rotation_reminders.go
@@ -73,18 +73,17 @@ func (c *KeyorixCore) SendRotationReminders(ctx context.Context) (int, error) {
 }
 
 // hasUnreadRotationReminder reports whether the user already has an unread
-// rotation-reminder notification for the given project.
+// rotation-reminder notification for the given project. This queries at the DB
+// level for exactly this (user, type, project) triple — it does NOT page through
+// "the newest N notifications of any type" — so a user with a large volume of
+// other unrelated unread notifications can't push a genuine standing reminder out
+// of an arbitrary top-N window and defeat the dedup guard (#399).
 func (c *KeyorixCore) hasUnreadRotationReminder(ctx context.Context, userID, projectID uint) bool {
-	notes, err := c.storage.ListNotifications(ctx, userID, true, 100)
+	has, err := c.storage.HasUnreadNotification(ctx, userID, NotificationRotationDue, projectID)
 	if err != nil {
 		return false // on a read error, prefer notifying over silently skipping
 	}
-	for _, n := range notes {
-		if n.Type == NotificationRotationDue && n.ProjectID != nil && *n.ProjectID == projectID {
-			return true
-		}
-	}
-	return false
+	return has
 }
 
 func rotationReminderMessage(project string, overdue, approaching int) string {

--- a/internal/core/rotation_reminders_test.go
+++ b/internal/core/rotation_reminders_test.go
@@ -82,6 +82,48 @@ func TestSendRotationReminders(t *testing.T) {
 	assert.Equal(t, 1, sent, "after reading, a still-overdue secret re-notifies")
 }
 
+// TestHasUnreadRotationReminder_NotBuriedByNotificationVolume is a regression test
+// for #399: the dedup check must find a genuine standing rotation reminder even
+// when it's buried under more than 100 newer, unrelated unread notifications — it
+// must not depend on the reminder happening to fall inside a "newest N of any
+// type" window.
+func TestHasUnreadRotationReminder_NotBuriedByNotificationVolume(t *testing.T) {
+	ctx := context.Background()
+	c, db, now := newRotationReminderCore(t)
+
+	// Seed the genuine rotation reminder first (oldest), then bury it under 150
+	// newer, unrelated unread notifications for the same user.
+	pid := uint(1)
+	require.NoError(t, db.Create(&models.Notification{
+		UserID: 5, ProjectID: &pid, Type: NotificationRotationDue,
+		Title: "Secrets due for rotation", Message: "old standing reminder",
+		IsRead: false, CreatedAt: now.Add(-24 * time.Hour),
+	}).Error)
+	for i := 0; i < 150; i++ {
+		require.NoError(t, db.Create(&models.Notification{
+			UserID: 5, ProjectID: &pid, Type: NotificationAccessRequested,
+			Title: "Unrelated", Message: "noise",
+			IsRead: false, CreatedAt: now.Add(time.Duration(i) * time.Minute),
+		}).Error)
+	}
+
+	assert.True(t, c.hasUnreadRotationReminder(ctx, 5, 1),
+		"the standing reminder must be found even though 150 newer unread notifications of another type exist")
+
+	// The straightforward case (no volume issue, no reminder) still works.
+	assert.False(t, c.hasUnreadRotationReminder(ctx, 6, 1),
+		"a user with no rotation reminder at all must not be reported as having one")
+
+	// SendRotationReminders itself must not duplicate the reminder despite the noise.
+	sent, err := c.SendRotationReminders(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 0, sent, "the buried-but-genuine reminder still dedupes the run")
+	var n int64
+	require.NoError(t, db.Model(&models.Notification{}).
+		Where("type = ? AND user_id = ?", NotificationRotationDue, 5).Count(&n).Error)
+	assert.Equal(t, int64(1), n, "no duplicate rotation reminder was created")
+}
+
 func TestSendRotationReminders_NothingDue(t *testing.T) {
 	ctx := context.Background()
 	c, db, now := newRotationReminderCore(t)

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -274,6 +274,11 @@ type Storage interface {
 	// unreadOnly is set, only unread ones. limit caps the result (0 = default).
 	ListNotifications(ctx context.Context, userID uint, unreadOnly bool, limit int) ([]*models.Notification, error)
 	CountUnreadNotifications(ctx context.Context, userID uint) (int64, error)
+	// HasUnreadNotification reports whether the user has an unread notification of
+	// the given type scoped to the given project. Filters at the DB level (no
+	// unbounded/"top N of everything" fetch), so it finds a match regardless of
+	// how many other unread notifications of other types/projects exist (#399).
+	HasUnreadNotification(ctx context.Context, userID uint, nType string, projectID uint) (bool, error)
 	// MarkNotificationRead marks one notification read, scoped to its owner.
 	MarkNotificationRead(ctx context.Context, id, userID uint) error
 	MarkAllNotificationsRead(ctx context.Context, userID uint) error

--- a/internal/storage/store/local_notifications.go
+++ b/internal/storage/store/local_notifications.go
@@ -6,7 +6,10 @@ package store
 
 import (
 	"context"
+	"errors"
 	"fmt"
+
+	"gorm.io/gorm"
 
 	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
@@ -34,6 +37,26 @@ func (ls *LocalStorage) ListNotifications(ctx context.Context, userID uint, unre
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
 	}
 	return rows, nil
+}
+
+// HasUnreadNotification reports whether userID has an unread notification of
+// nType scoped to projectID. Unlike ListNotifications (newest-N, any type), this
+// filters user_id/is_read/type/project_id at the DB level and stops at the first
+// match, so it can't be defeated by a pile-up of newer, unrelated unread
+// notifications pushing the target one outside a "top N" window (#399).
+func (ls *LocalStorage) HasUnreadNotification(ctx context.Context, userID uint, nType string, projectID uint) (bool, error) {
+	var row models.Notification
+	err := ls.db.WithContext(ctx).
+		Select("id").
+		Where("user_id = ? AND is_read = ? AND type = ? AND project_id = ?", userID, false, nType, projectID).
+		First(&row).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	return true, nil
 }
 
 func (ls *LocalStorage) CountUnreadNotifications(ctx context.Context, userID uint) (int64, error) {

--- a/internal/storage/store/notifications_test.go
+++ b/internal/storage/store/notifications_test.go
@@ -64,3 +64,55 @@ func TestNotifications_CRUD(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), other)
 }
+
+// TestHasUnreadNotification_NotBuriedByVolume is a regression test for #399:
+// unlike ListNotifications (newest-N of any type, dedup callers used to filter
+// client-side), HasUnreadNotification filters user_id/type/project_id/is_read at
+// the DB level, so a genuine match can't be pushed out of a "top N" window by a
+// pile of newer, unrelated unread notifications.
+func TestHasUnreadNotification_NotBuriedByVolume(t *testing.T) {
+	ctx := context.Background()
+	ls := newNotificationStore(t)
+	pid := uint(7)
+
+	// The target notification is the OLDEST row for this user.
+	_, err := ls.CreateNotification(ctx, &models.Notification{
+		UserID: 9, ProjectID: &pid, Type: "rotation.reminder", Title: "T", Message: "target",
+	})
+	require.NoError(t, err)
+
+	// Bury it under 150 newer, unrelated unread notifications for the same user.
+	for i := 0; i < 150; i++ {
+		_, err := ls.CreateNotification(ctx, &models.Notification{
+			UserID: 9, ProjectID: &pid, Type: "access_request.created", Title: "N", Message: "noise",
+		})
+		require.NoError(t, err)
+	}
+
+	has, err := ls.HasUnreadNotification(ctx, 9, "rotation.reminder", 7)
+	require.NoError(t, err)
+	assert.True(t, has, "the target notification must be found despite 150 newer unread rows of another type")
+
+	// Straightforward negative cases: wrong type, wrong project, wrong user.
+	has, err = ls.HasUnreadNotification(ctx, 9, "no.such.type", 7)
+	require.NoError(t, err)
+	assert.False(t, has)
+
+	has, err = ls.HasUnreadNotification(ctx, 9, "rotation.reminder", 99)
+	require.NoError(t, err)
+	assert.False(t, has)
+
+	has, err = ls.HasUnreadNotification(ctx, 42, "rotation.reminder", 7)
+	require.NoError(t, err)
+	assert.False(t, has)
+
+	// A read notification of the right type/project doesn't count as "unread".
+	_, err = ls.CreateNotification(ctx, &models.Notification{
+		UserID: 9, ProjectID: &pid, Type: "rotation.reminder", Title: "T2", Message: "read",
+		IsRead: true,
+	})
+	require.NoError(t, err)
+	has, err = ls.HasUnreadNotification(ctx, 9, "rotation.reminder", 7)
+	require.NoError(t, err)
+	assert.True(t, has, "still true because of the earlier unread target row")
+}

--- a/internal/storage/store/remote_notifications.go
+++ b/internal/storage/store/remote_notifications.go
@@ -23,6 +23,10 @@ func (rs *RemoteStorage) CountUnreadNotifications(_ context.Context, _ uint) (in
 	return 0, remoteUnsupported("CountUnreadNotifications")
 }
 
+func (rs *RemoteStorage) HasUnreadNotification(_ context.Context, _ uint, _ string, _ uint) (bool, error) {
+	return false, remoteUnsupported("HasUnreadNotification")
+}
+
 func (rs *RemoteStorage) MarkNotificationRead(ctx context.Context, id, _ uint) error {
 	// The server scopes the mark to the authenticated user (the client's own
 	// session), so userID is implicit in the endpoint.


### PR DESCRIPTION
## Summary

Fixes #399. `hasUnreadRotationReminder` deduped standing rotation reminders by
calling `ListNotifications(ctx, userID, true, 100)` — the newest 100 unread
notifications of **any** type — then filtering client-side for a rotation
reminder matching the project. A user with more than 100 newer unread
notifications of any other kind (access requests, share notices, etc.) pushes
the genuine standing reminder outside that top-100 window, so the dedup check
never finds it and `SendRotationReminders` creates duplicate standing reminders
for the same user+project on every scheduler run.

- Added `storage.HasUnreadNotification(ctx, userID, type, projectID) (bool, error)`
  to the storage interface, implemented in `LocalStorage` as a targeted,
  DB-level existence query (`user_id`/`is_read`/`type`/`project_id`, `LIMIT 1`
  via `First`) instead of paging through "newest N of everything". Implemented
  as `remoteUnsupported` in `RemoteStorage` (background scheduler jobs only run
  against local storage) and added the mock in `MockStorage`.
- `hasUnreadRotationReminder` now calls this directly instead of
  `ListNotifications` + client-side filtering.

## Test plan

- [x] Regression test in `internal/core/rotation_reminders_test.go`: seeds a
  genuine rotation reminder as the *oldest* row, buries it under 150 newer
  unrelated unread notifications for the same user, and confirms
  `hasUnreadRotationReminder` (and `SendRotationReminders`'s dedup) still find
  it. Also verifies the straightforward no-volume case.
- [x] Regression test in `internal/storage/store/notifications_test.go` for
  `HasUnreadNotification` directly: buried-match case, wrong type/project/user
  negatives, and read-vs-unread handling.
- [x] `go build ./...`, `go vet ./...` clean.
- [x] `go test ./internal/core/... ./internal/storage/store/...` passing.
- [x] `gosec -severity medium -exclude-generated` on touched packages: 0 issues.