### PR TITLE
fix(server): stop leaking admin bootstrap password via wget argv (#241)

### DIFF
--- a/server/entrypoint.sh
+++ b/server/entrypoint.sh
@@ -28,11 +28,28 @@ if [ -n "$KEYORIX_ADMIN_PASSWORD" ]; then
     ADMIN_USER="${KEYORIX_ADMIN_USERNAME:-admin}"
     ADMIN_EMAIL="${KEYORIX_ADMIN_EMAIL:-admin@keyorix.local}"
     echo "Bootstrapping admin user '$ADMIN_USER' (idempotent)..."
+    # Write the POST body (which embeds the admin password) to a private temp
+    # file and hand it to wget via --post-file instead of --post-data: argv is
+    # visible to any process sharing this container's PID namespace via
+    # `ps`/`/proc/<pid>/cmdline`, so passing the password inline as a wget flag
+    # would leak it on every first boot. `mktemp -d` creates the directory with
+    # 0700 permissions (only this UID can traverse it), and the payload file
+    # inside it is additionally chmod'd 0600 as defense in depth. The whole
+    # directory is removed as soon as the request completes (or the shell exits).
+    BOOTSTRAP_TMPDIR=$(mktemp -d)
+    trap 'rm -rf "$BOOTSTRAP_TMPDIR"' EXIT
+    BOOTSTRAP_PAYLOAD_FILE="$BOOTSTRAP_TMPDIR/bootstrap.json"
+    : > "$BOOTSTRAP_PAYLOAD_FILE"
+    chmod 600 "$BOOTSTRAP_PAYLOAD_FILE"
+    printf '{"username":"%s","email":"%s","password":"%s","display_name":"Administrator"}' \
+        "$ADMIN_USER" "$ADMIN_EMAIL" "$KEYORIX_ADMIN_PASSWORD" > "$BOOTSTRAP_PAYLOAD_FILE"
     wget --quiet -O- \
         --header='Content-Type: application/json' \
-        --post-data="{\"username\":\"$ADMIN_USER\",\"email\":\"$ADMIN_EMAIL\",\"password\":\"$KEYORIX_ADMIN_PASSWORD\",\"display_name\":\"Administrator\"}" \
+        --post-file="$BOOTSTRAP_PAYLOAD_FILE" \
         http://localhost:8080/system/init 2>/dev/null || \
         echo "Bootstrap call failed (server may already be initialised) — continuing."
+    rm -rf "$BOOTSTRAP_TMPDIR"
+    trap - EXIT
 else
     echo "KEYORIX_ADMIN_PASSWORD not set — skipping auto-bootstrap."
     echo "Initialise manually: keyorix system init --server http://<host>:8080"

--- a/server/entrypoint_test.sh
+++ b/server/entrypoint_test.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# entrypoint_test.sh — regression test for #241: entrypoint.sh's first-boot admin
+# bootstrap used to pass the admin password to wget via --post-data, which puts it
+# straight into the process's argv — visible to any process/user sharing the
+# container's PID namespace via `ps`/`/proc/<pid>/cmdline` on literally every
+# production first boot. It must now be written to a private (0600, owner-only)
+# temp file and sent via --post-file instead.
+#
+# entrypoint.sh is a top-to-bottom `/bin/sh` script (no functions, no
+# BASH_SOURCE guard), so it can't be sourced side-effect-free the way
+# integrations/github-action/entrypoint_test.sh sources its target. Instead this
+# test extracts the exact bootstrap `if [ -n "$KEYORIX_ADMIN_PASSWORD" ]; ...; fi`
+# block verbatim and executes it under `sh` with a stub `wget` on PATH that
+# records its own argv and snapshots whatever body it was asked to send — so the
+# real production code path is exercised, not a reimplementation of it.
+#
+# Run directly: ./entrypoint_test.sh
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+entrypoint="$script_dir/entrypoint.sh"
+
+fail=0
+note() { echo "ok   - $1"; }
+bad() { echo "FAIL - $1"; fail=1; }
+
+work_dir="$(mktemp -d "${TMPDIR:-/tmp}/entrypoint-test.XXXXXX")"
+trap 'rm -rf "$work_dir"' EXIT
+
+# --- Stub wget: log every argv token, and if invoked with --post-file=FILE,
+# snapshot that file's content + mode before returning, so we can inspect what
+# was actually about to be sent over the wire without a real network call. ---
+stub_bin="$work_dir/bin"
+mkdir -p "$stub_bin"
+
+# Test-harness-only shim: on macOS, a bare `mktemp -d` (no template) ignores
+# $TMPDIR and resolves to the Darwin per-user temp dir, which this sandboxed
+# test runner may not be permitted to write to. Give it an explicit
+# $TMPDIR-based template so the *unmodified* entrypoint.sh code under test can
+# create its private tmpdir exactly as it does on the real (Linux/BusyBox)
+# container, where plain `mktemp -d` already honors $TMPDIR/defaults to /tmp.
+# (Built with printf rather than a heredoc: some sandboxed shells disallow the
+# temp file bash normally creates internally to expand a heredoc's body.)
+mktemp_stub=$'#!/bin/sh\n'
+mktemp_stub+=$'real_mktemp="$(command -v /usr/bin/mktemp || command -v /bin/mktemp)"\n'
+mktemp_stub+=$'case "$1" in\n'
+mktemp_stub+=$'    -d) exec "$real_mktemp" -d "${TMPDIR:-/tmp}/entrypoint-test-inner.XXXXXX" ;;\n'
+mktemp_stub+=$'    *) exec "$real_mktemp" "${TMPDIR:-/tmp}/entrypoint-test-inner.XXXXXX" ;;\n'
+mktemp_stub+=$'esac\n'
+printf '%s' "$mktemp_stub" >"$stub_bin/mktemp"
+chmod +x "$stub_bin/mktemp"
+
+argv_log="$work_dir/wget_argv.log"
+payload_snapshot="$work_dir/payload_snapshot.json"
+payload_path_file="$work_dir/payload_path.txt"
+payload_mode_file="$work_dir/payload_mode.txt"
+: >"$argv_log"
+
+wget_stub=$'#!/bin/sh\n'
+wget_stub+=$'for a in "$@"; do\n'
+wget_stub+=$'    printf \'%s\\n\' "$a" >>"$WGET_ARGV_LOG"\n'
+wget_stub+=$'    case "$a" in\n'
+wget_stub+=$'        --post-file=*)\n'
+wget_stub+=$'            f="${a#--post-file=}"\n'
+wget_stub+=$'            cp "$f" "$WGET_PAYLOAD_SNAPSHOT"\n'
+wget_stub+=$'            printf \'%s\\n\' "$f" >"$WGET_PAYLOAD_PATH_FILE"\n'
+wget_stub+=$'            stat -c \'%a\' "$f" >"$WGET_PAYLOAD_MODE_FILE" 2>/dev/null || \\\n'
+wget_stub+=$'                stat -f \'%Lp\' "$f" >"$WGET_PAYLOAD_MODE_FILE"\n'
+wget_stub+=$'            ;;\n'
+wget_stub+=$'    esac\n'
+wget_stub+=$'done\n'
+wget_stub+=$'exit 0\n'
+printf '%s' "$wget_stub" >"$stub_bin/wget"
+chmod +x "$stub_bin/wget"
+
+# --- Extract the exact bootstrap block from entrypoint.sh verbatim. ---
+# The single-quoted sed pattern intentionally matches the literal text
+# '$KEYORIX_ADMIN_PASSWORD' as it appears in entrypoint.sh; it must not expand.
+# shellcheck disable=SC2016
+block="$(sed -n '/^if \[ -n "\$KEYORIX_ADMIN_PASSWORD" \]; then$/,/^fi$/p' "$entrypoint")"
+if [ -z "$block" ]; then
+    echo "FAIL - could not locate the KEYORIX_ADMIN_PASSWORD bootstrap block in $entrypoint"
+    exit 1
+fi
+
+password='S3cr3t-Test-P@ssw0rd!'
+
+env -i \
+    PATH="$stub_bin:/usr/bin:/bin" \
+    TMPDIR="${TMPDIR:-/tmp}" \
+    WGET_ARGV_LOG="$argv_log" \
+    WGET_PAYLOAD_SNAPSHOT="$payload_snapshot" \
+    WGET_PAYLOAD_PATH_FILE="$payload_path_file" \
+    WGET_PAYLOAD_MODE_FILE="$payload_mode_file" \
+    KEYORIX_ADMIN_PASSWORD="$password" \
+    KEYORIX_ADMIN_USERNAME="admin" \
+    KEYORIX_ADMIN_EMAIL="admin@example.test" \
+    sh -c "$block"
+
+# --- The password must never appear in wget's own argv. ---
+if grep -qF -- "$password" "$argv_log"; then
+    bad "admin password found in wget argv (this is the #241 leak)"
+else
+    note "admin password absent from wget argv"
+fi
+
+# --- ...but it must still reach the request body, via the --post-file. ---
+if [ ! -s "$payload_snapshot" ]; then
+    bad "wget was never invoked with --post-file; bootstrap payload was not captured"
+elif grep -qF -- "$password" "$payload_snapshot"; then
+    note "admin password present in the POST body sent via --post-file"
+else
+    bad "admin password missing from the captured POST body"
+fi
+
+if grep -q '"username":"admin"' "$payload_snapshot" && \
+   grep -q '"email":"admin@example.test"' "$payload_snapshot"; then
+    note "username/email still populated correctly in the POST body"
+else
+    bad "username/email missing or malformed in the POST body"
+fi
+
+# --- The payload file must have been private (owner-only) while it existed. ---
+if [ -f "$payload_mode_file" ]; then
+    mode="$(cat "$payload_mode_file")"
+    if [ "$mode" = "600" ]; then
+        note "payload temp file was created with mode 0600"
+    else
+        bad "payload temp file mode was '$mode', expected 600"
+    fi
+fi
+
+# --- The temp file (and its containing dir) must be cleaned up afterwards. ---
+if [ -f "$payload_path_file" ]; then
+    payload_path="$(cat "$payload_path_file")"
+    payload_dir="$(dirname "$payload_path")"
+    if [ -e "$payload_path" ]; then
+        bad "bootstrap payload file was not removed after use: $payload_path"
+    else
+        note "bootstrap payload file was removed after use"
+    fi
+    if [ -e "$payload_dir" ]; then
+        bad "bootstrap temp directory was not removed after use: $payload_dir"
+    else
+        note "bootstrap temp directory was removed after use"
+    fi
+fi
+
+if [ "$fail" -ne 0 ]; then
+    echo
+    echo "entrypoint_test.sh: FAILED"
+    exit 1
+fi
+
+echo
+echo "entrypoint_test.sh: all checks passed"


### PR DESCRIPTION
## Summary

Closes #241. `server/entrypoint.sh`'s first-boot admin bootstrap passed the
admin password to `wget` via `--post-data`, which embeds the value directly
in the process's argv. This bootstrap runs automatically and unconditionally
on **every** first boot of the shipped production container image (not an
optional operator action like #103/#207/#357), so the password was routinely
visible via `ps`/`/proc/<pid>/cmdline` to anything sharing the container's PID
namespace — a much lower bar than requiring root/same-UID access to
`/proc/<pid>/environ`.

## Fix

- Write the POST body (JSON containing the password) to a private temp file
  instead of an inline wget flag: `mktemp -d` (0700 dir) + `chmod 600` on the
  file, both removed immediately after the request completes (or via an
  `EXIT` trap if the shell exits early).
- Send it with `wget --post-file=<file>` instead of `--post-data=...`.
  Verified the runtime image's BusyBox `wget` (alpine:3.24) supports
  `--post-file`.
- Verified end-to-end against a mock listener that the resulting HTTP
  request (method, `Content-Type` header, JSON body reaching
  `POST /system/init`) is byte-for-byte identical to what `--post-data`
  produced — `InitSystem` just does `json.NewDecoder(r.Body).Decode(...)`, so
  behavior is unchanged.

## Test plan

- [x] Added `server/entrypoint_test.sh`, which extracts the real bootstrap
      `if [ -n "$KEYORIX_ADMIN_PASSWORD" ]; ...; fi` block from
      `entrypoint.sh` verbatim and executes it under `sh` against a stub
      `wget` that records its own argv and snapshots the `--post-file` body.
      Asserts: password absent from wget's argv, password present in the
      captured POST body, username/email correctly populated, payload file
      created with mode 0600, and both the payload file and its temp
      directory are removed after use.
- [x] `shellcheck` clean on both `server/entrypoint.sh` and
      `server/entrypoint_test.sh` (no existing shellcheck CI gate in this
      repo, ran locally).
- [x] Manually verified with `docker run alpine:3.24` + `nc` that
      `wget --post-file` sends the same request line/headers/body as the old
      `--post-data` invocation.
