### PR TITLE
fix(http): apply Cache-Control: no-store as a global router default

### DIFF
--- a/server/http/no_store_route_test.go
+++ b/server/http/no_store_route_test.go
@@ -3,6 +3,8 @@ package http
 import (
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -13,8 +15,10 @@ import (
 )
 
 // TestNoStore_ScopedToAPI confirms every API response carries Cache-Control: no-store
-// (even an unauthenticated 401, since the middleware runs before auth), while non-API
-// paths keep their own caching — secret values must never sit in a browser/proxy cache.
+// (even an unauthenticated 401, since the middleware runs before auth). It also proves the
+// global no-store default (#433) doesn't clobber a route that deliberately sets its own,
+// different Cache-Control (health's "no-cache") — that handler's later Set() on the same
+// header wins over the router's earlier default.
 func TestNoStore_ScopedToAPI(t *testing.T) {
 	require.NoError(t, i18n.InitializeForTesting())
 	defer i18n.ResetForTesting()
@@ -37,17 +41,81 @@ func TestNoStore_ScopedToAPI(t *testing.T) {
 	assert.Equal(t, http.StatusUnauthorized, code)
 	assert.Equal(t, "no-store", cc, "API responses must be no-store")
 
-	// A non-API path keeps its own cache policy, not no-store (health sets no-cache).
+	// Health explicitly sets its own Cache-Control ("no-cache"), so it keeps that instead
+	// of the global no-store default — a deliberate, documented exception, not a gap.
 	_, cc = cacheCtl("/health")
-	assert.NotEqual(t, "no-store", cc, "non-API responses keep their own cache headers")
+	assert.NotEqual(t, "no-store", cc, "routes with their own explicit Cache-Control keep it")
+}
+
+// TestNoStore_GlobalDefaultCoversNonGroupedRoutes proves the router's top-level no-store
+// default (#433) reaches routes registered OUTSIDE the three route groups that used to
+// carry their own NoStore middleware (the pre-auth auth group, /scim/v2, /api/v1) — e.g.
+// the Prometheus metrics endpoint and the OpenAPI spec — which previously had no
+// Cache-Control at all and so were cacheable by default.
+func TestNoStore_GlobalDefaultCoversNonGroupedRoutes(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	router, err := NewRouter(&config.Config{}, newTestCore(t))
+	require.NoError(t, err)
+	srv := httptest.NewServer(router)
+	defer srv.Close()
+	client := &http.Client{}
+
+	get := func(path string) string {
+		resp, err := client.Get(srv.URL + path)
+		require.NoError(t, err, path)
+		_ = resp.Body.Close()
+		return resp.Header.Get("Cache-Control")
+	}
+
+	for _, path := range []string{
+		"/metrics",
+		"/openapi.yaml",
+	} {
+		assert.Equal(t, "no-store", get(path), "%s must be no-store", path)
+	}
+}
+
+// TestNoStore_StaticAssetExceptionPreserved proves the web UI's own hashed static assets
+// keep their deliberate, long-lived Cache-Control (server/http/router.go's setCacheHeaders)
+// rather than being clobbered by the router's global no-store default (#433). Uses a
+// real on-disk asset (via WebAssetsPath) rather than a missing one — a 404 for a
+// nonexistent file goes through a different, unrelated code path in net/http's
+// FileServer that clears any previously-set Cache-Control regardless of this middleware.
+func TestNoStore_StaticAssetExceptionPreserved(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	webDir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(webDir, "assets"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(webDir, "assets", "app.js"), []byte("console.log('ok')"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(webDir, "index.html"), []byte("<html></html>"), 0o644))
+
+	cfg := &config.Config{}
+	cfg.Server.HTTP.WebAssetsPath = webDir
+
+	router, err := NewRouter(cfg, newTestCore(t))
+	require.NoError(t, err)
+	srv := httptest.NewServer(router)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/assets/app.js")
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	cc := resp.Header.Get("Cache-Control")
+	assert.NotEqual(t, "no-store", cc, "static assets keep their own deliberate Cache-Control")
+	assert.Contains(t, cc, "max-age", "static assets keep their own deliberate Cache-Control")
 }
 
 // TestNoStore_CoversAuthAndTokenEndpoints proves the unauthenticated auth/token
 // routes registered OUTSIDE the /api/v1 group (login, refresh, MFA/WebAuthn verify,
 // system bootstrap, setup-link consumption, the SSO/SAML login+callback surface) also
-// carry Cache-Control: no-store. Several of these responses mint or hand back a
-// session token; without no-store a browser or intermediate cache could retain a
-// response containing one.
+// carry Cache-Control: no-store — now via the router's global default (#433) rather than
+// a group-local one. Several of these responses mint or hand back a session token;
+// without no-store a browser or intermediate cache could retain a response containing one.
 func TestNoStore_CoversAuthAndTokenEndpoints(t *testing.T) {
 	require.NoError(t, i18n.InitializeForTesting())
 	defer i18n.ResetForTesting()

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -42,6 +42,17 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 	r.Use(customMiddleware.ClientIP(cfg.Server.HTTP.TrustedProxies))
 	r.Use(customMiddleware.Logger())
 	r.Use(customMiddleware.SecurityHeaders(cfg.Server.HTTP.TLS.Enabled))
+	// Global default: no-store on every response (#433). This is a secrets manager — a
+	// browser or intermediate proxy must never be allowed to cache anything by default,
+	// including routes registered outside the auth/SCIM/API groups (health/status/metrics,
+	// the OpenAPI spec, swagger docs, the web UI shell) or any route added here later.
+	// Registered early (before per-route handlers/middleware further down the chain) so it
+	// merely sets the header first: a handler that deliberately wants different caching
+	// (the health/readiness checks' own "no-cache", the status pages' own "no-cache", and
+	// the web UI's hashed static assets via setCacheHeaders) calls w.Header().Set on the
+	// same key afterward and wins, since Set replaces rather than appends. Routes with no
+	// opinion of their own keep the safe no-store default instead of silently having none.
+	r.Use(customMiddleware.NoStore)
 	r.Use(customMiddleware.PrometheusMiddleware)
 	r.Use(customMiddleware.MaxBodyBytes(cfg.Server.HTTP.EffectiveMaxRequestBodyBytes()))
 	r.Use(middleware.Timeout(60 * time.Second))
@@ -92,15 +103,12 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 	connectHandler := handlers.NewConnectHandler(coreService)
 	adminJobsHandler := handlers.NewAdminJobsHandler(coreService)
 
-	// Auth endpoints (no authentication middleware). Grouped under NoStore: several of
-	// these mint or hand back a session token (login, refresh, MFA/WebAuthn verify, the
-	// SSO/SAML callbacks) or bootstrap/setup credentials (system/init, setup consume) —
-	// a browser or intermediate cache must never be allowed to cache that response. The
-	// /api/v1 group below has its own NoStore for the same reason; these routes sit
-	// outside that group (no session yet to authenticate against) so they need their
-	// own coverage rather than inheriting it.
+	// Auth endpoints (no authentication middleware). Several of these mint or hand back a
+	// session token (login, refresh, MFA/WebAuthn verify, the SSO/SAML callbacks) or
+	// bootstrap/setup credentials (system/init, setup consume) — a browser or intermediate
+	// cache must never be allowed to cache that response. Covered by the router's global
+	// no-store default (above) rather than a group-local one.
 	r.Group(func(r chi.Router) {
-		r.Use(customMiddleware.NoStore)
 		r.Post("/auth/login", authHandler.Login)
 		r.Post("/auth/logout", authHandler.Logout)
 		r.Post("/auth/refresh", authHandler.RefreshToken)
@@ -193,7 +201,7 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		}
 		scimHandler := handlers.NewSCIMHandler(coreService)
 		r.Route("/scim/v2", func(r chi.Router) {
-			r.Use(customMiddleware.NoStore)
+			// no-store is covered by the router's global default (above).
 			r.Use(customMiddleware.SCIMToken(cfg.SCIM.GetToken()))
 			r.Get("/ServiceProviderConfig", scimHandler.GetServiceProviderConfig)
 			r.Get("/Users", scimHandler.ListUsers)
@@ -213,8 +221,8 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 
 	r.Route("/api/v1", func(r chi.Router) {
 		// Never let any API response (secret values, tokens, …) be cached by a browser or
-		// proxy. Before auth, so even a 401 carries it.
-		r.Use(customMiddleware.NoStore)
+		// proxy. Covered by the router's global no-store default (above), which runs
+		// before Authentication too, so even a 401 carries it.
 		// Authentication middleware for API routes
 		r.Use(customMiddleware.Authentication(coreService))
 		// General per-principal request budget (#163) — a backstop against one

--- a/server/middleware/no_store.go
+++ b/server/middleware/no_store.go
@@ -3,10 +3,13 @@ package middleware
 import "net/http"
 
 // NoStore sets Cache-Control: no-store on every response it wraps, so browsers, proxies,
-// and any shared cache never store the body. API responses here can carry secret values,
-// tokens, and other sensitive data; without this they have no Cache-Control and are
-// cacheable by default. Apply it to the API groups (before auth, so even a 401 carries
-// it). Static assets keep their own cache headers — this is scoped to the API.
+// and any shared cache never store the body. Many responses in this codebase carry secret
+// values, tokens, and other sensitive data; without this they have no Cache-Control and are
+// cacheable by default. Registered as a global, top-level router middleware (#433) rather
+// than on specific route groups, so nothing registered later is silently missed. A handler
+// that deliberately wants a different policy (the health/readiness checks' own "no-cache",
+// the web UI's hashed static assets, the SPA shell) sets Cache-Control itself further down
+// the chain and wins, since http.Header.Set replaces rather than appends.
 func NoStore(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Cache-Control", "no-store")


### PR DESCRIPTION
## Summary

- Backlog #433: `NoStore` (`Cache-Control: no-store`) was only wired onto three specific route groups (the pre-auth auth group, `/scim/v2`, `/api/v1`), so anything registered outside them — health/status/metrics, the OpenAPI spec, swagger docs, the web UI shell, and any route added later — had no `Cache-Control` at all and was cacheable by default.
- Moved `NoStore` to the router's top-level middleware chain (`server/http/router.go`) so every response gets `no-store` unless a handler explicitly sets its own `Cache-Control` afterward. Removed the three now-redundant group-local `r.Use(customMiddleware.NoStore)` registrations and updated their comments to point at the new global default.
- Kept the deliberate exception for the web UI's hashed static assets: `setCacheHeaders` (JS/CSS/fonts/images under `/assets/*`, `/static/*`) still sets its own long-lived `Cache-Control` further down the middleware chain, and `http.Header.Set` replaces rather than appends, so it wins over the earlier global no-store. Same mechanism preserves health/readiness's own `no-cache` and the SPA shell's `no-cache`.
- Updated `NoStore`'s doc comment (`server/middleware/no_store.go`) to describe the new global usage.

## Test plan

- Extended `server/http/no_store_route_test.go`:
  - Updated `TestNoStore_ScopedToAPI` to clarify health's own `no-cache` is a deliberate, preserved exception, not a coverage gap.
  - Added `TestNoStore_GlobalDefaultCoversNonGroupedRoutes` — confirms `/metrics` and `/openapi.yaml` (previously uncovered, outside all three groups) now return `no-store`.
  - Added `TestNoStore_StaticAssetExceptionPreserved` — confirms a real on-disk static asset (via `WebAssetsPath`) still gets its own long-lived `Cache-Control`, not `no-store`.
- `go build ./...`, `go vet ./...` clean.
- `go test ./server/...` — all pass.
- `gosec -severity medium -exclude-generated ./server/...` — 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)