### PR TITLE
fix(crypto): verify Shamir-reconstructed KEK with a real HMAC commitment (#429)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -145,6 +145,11 @@ storage:
       # via files and/or env vars. Generate with `keyorix encryption shamir-split`.
       # shamir_share_files: [/etc/keyorix/share-1.hex, /etc/keyorix/share-2.hex, /etc/keyorix/share-3.hex]
       # shamir_share_env: [KX_KEK_SHARE_1, KX_KEK_SHARE_2]
+      # shamir_commitment is also printed by shamir-split — set it so reconstruction
+      # is verified by a real HMAC commitment, not just a forgeable framing check
+      # (#429). Safe to store here in the clear: it's one-way, reveals nothing about
+      # the KEK.
+      # shamir_commitment: 3f9a…
 
       # type: tpm — seal the KEK to the host TPM 2.0. The KEK is generated and sealed
       # on first start; only the sealed blob (wrapped_key_path) is on disk, and it is
@@ -177,12 +182,17 @@ storage:
   threshold, so no single custodian holds it and at least K must combine to unseal
   (separation of duties for the master key). Generate with `keyorix encryption
   shamir-split --shares N --threshold K` (the KEK is never printed/stored — only the
-  shares are). Provide at least K shares at startup via `shamir_share_files` and/or
-  `shamir_share_env` (each a hex/base64 share); the server reconstructs the KEK in
-  memory. `KEYORIX_MASTER_PASSWORD` is **not** required. Move an existing install
-  onto it with `keyorix encryption migrate-provider --to-type shamir
-  --to-shamir-share-files …`. ⚠️ Losing more than N-K shares makes the KEK — and all
-  data — permanently unrecoverable; store and back up shares separately.
+  shares are, plus a `shamir_commitment` value). Provide at least K shares at
+  startup via `shamir_share_files` and/or `shamir_share_env` (each a hex/base64
+  share); the server reconstructs the KEK in memory. Also set `shamir_commitment` —
+  without it, reconstruction falls back to a 4-byte magic check that (#429) an
+  attacker holding threshold-1 genuine shares can forge to make ANY chosen value
+  reconstruct; with it, the reconstructed KEK is verified against a real HMAC-SHA256
+  commitment computed at split time. `KEYORIX_MASTER_PASSWORD` is **not** required.
+  Move an existing install onto it with `keyorix encryption migrate-provider
+  --to-type shamir --to-shamir-share-files … --to-shamir-commitment …`. ⚠️ Losing
+  more than N-K shares makes the KEK — and all data — permanently unrecoverable;
+  store and back up shares separately.
 - **`tpm`**: the KEK is **sealed to the host TPM 2.0** (`tpm_device`, default
   `/dev/tpmrm0`) and only unsealable on that machine. A random KEK is generated and
   sealed on first start; only the **sealed blob** (`wrapped_key_path`) touches disk,

--- a/internal/cli/encryption/migrate_provider.go
+++ b/internal/cli/encryption/migrate_provider.go
@@ -40,6 +40,7 @@ var (
 	mpToExecCommand          []string
 	mpToShareFiles           []string
 	mpToShareEnv             []string
+	mpToShareCommitment      string
 	mpToTPMDevice            string
 	mpToSaltPath             string
 	mpConfirm                bool
@@ -106,6 +107,7 @@ func init() {
 	f.StringSliceVar(&mpToExecCommand, "to-exec-command", nil, "resolver argv whose stdout supplies the KEK (exec type), e.g. op,read,op://vault/kek/value")
 	f.StringSliceVar(&mpToShareFiles, "to-shamir-share-files", nil, "paths to >=threshold Shamir share files (shamir type)")
 	f.StringSliceVar(&mpToShareEnv, "to-shamir-share-env", nil, "env var names holding Shamir shares (shamir type)")
+	f.StringVar(&mpToShareCommitment, "to-shamir-commitment", "", "hex KEK commitment printed by `shamir-split` for these shares (shamir type; recommended — #429)")
 	f.StringVar(&mpToTPMDevice, "to-tpm-device", "", "TPM 2.0 device path (tpm type; default /dev/tpmrm0)")
 	f.StringVar(&mpToSaltPath, "to-salt-path", "", "salt path for the target password provider (default: current salt_path)")
 	f.BoolVar(&mpConfirm, "confirm", false, "required acknowledgement before re-wrapping the DEK")
@@ -203,6 +205,7 @@ type migrateOpts struct {
 	toExecCommand          []string
 	toShareFiles           []string
 	toShareEnv             []string
+	toShareCommitment      string
 	toTPMDevice            string
 	toSaltPath             string
 }
@@ -222,6 +225,7 @@ func runMigrateProvider(cmd *cobra.Command, args []string) error {
 		toExecCommand:          mpToExecCommand,
 		toShareFiles:           mpToShareFiles,
 		toShareEnv:             mpToShareEnv,
+		toShareCommitment:      mpToShareCommitment,
 		toTPMDevice:            mpToTPMDevice,
 		toSaltPath:             mpToSaltPath,
 	}
@@ -261,6 +265,7 @@ func targetEncryptionConfig(cur *config.EncryptionConfig, opts migrateOpts) (con
 		}
 		kp.ShamirShareFiles = opts.toShareFiles
 		kp.ShamirShareEnv = opts.toShareEnv
+		kp.ShamirCommitment = opts.toShareCommitment
 	case "tpm":
 		if opts.toWrappedKeyPath == "" {
 			return tgt, fmt.Errorf("--to-wrapped-key-path is required for --to-type tpm (where the sealed KEK blob lives)")
@@ -480,6 +485,14 @@ func printMigrateSummary(tgt config.EncryptionConfig, backupRel string) {
 		}
 		if len(kp.ShamirShareEnv) > 0 {
 			fmt.Printf("      shamir_share_env: %v\n", kp.ShamirShareEnv)
+		}
+		if kp.ShamirCommitment != "" {
+			fmt.Printf("      shamir_commitment: %s\n", kp.ShamirCommitment)
+		} else {
+			fmt.Println("      # shamir_commitment: not set — pass --to-shamir-commitment (the value")
+			fmt.Println("      # printed by `shamir-split` for these shares) for real cryptographic")
+			fmt.Println("      # verification of the reconstructed KEK (#429); without it, unseal falls")
+			fmt.Println("      # back to a weaker, forgeable check and logs a loud warning at startup.")
 		}
 	case "tpm":
 		if kp.TPMDevice != "" {

--- a/internal/cli/encryption/shamir_split.go
+++ b/internal/cli/encryption/shamir_split.go
@@ -60,6 +60,13 @@ unrecoverable. Store shares separately and back them up.`,
 		if err != nil {
 			return err
 		}
+		// #429: the magic byte embedded in the split payload is forgeable by an
+		// attacker holding threshold-1 genuine shares (see combineKEK's doc comment),
+		// so also emit a real cryptographic commitment to the KEK, computed here from
+		// the actual (never-split) secret and verified against the RECONSTRUCTED KEK
+		// at unseal time. It reveals nothing about the KEK, so printing/storing it in
+		// the clear next to the shares is safe.
+		commitment := hex.EncodeToString(crypto.CommitKEK(kek))
 
 		fmt.Printf("Generated a new 32-byte KEK split into %d shares (threshold %d).\n", ssShares, ssThreshold)
 		fmt.Println("The KEK itself is not stored — keep at least the threshold many shares safe.")
@@ -84,7 +91,21 @@ unrecoverable. Store shares separately and back them up.`,
 			fmt.Printf("  share %d -> %s\n", i+1, path)
 		}
 		fmt.Println()
-		fmt.Printf("Configure: key_provider.type: shamir with at least %d of the shares.\n", ssThreshold)
+		fmt.Println("KEK integrity commitment (safe to store/print in the clear — reveals nothing")
+		fmt.Println("about the KEK; verified against the RECONSTRUCTED key at unseal time so a")
+		fmt.Println("forged/wrong share is rejected rather than silently accepted, #429):")
+		fmt.Printf("  shamir_commitment: %s\n", commitment)
+		if ssOutDir != "" {
+			commitPath := filepath.Join(ssOutDir, "commitment.hex")
+			if err := securefiles.SecureWriteFileSync(ssOutDir, "commitment.hex", []byte(commitment+"\n"), 0o644); err != nil {
+				return fmt.Errorf("write %s: %w", commitPath, err)
+			}
+			fmt.Printf("  -> also written to %s\n", commitPath)
+		}
+		fmt.Println()
+		fmt.Printf("Configure: key_provider.type: shamir with at least %d of the shares, plus\n", ssThreshold)
+		fmt.Println("shamir_commitment (above) — without it, reconstruction falls back to a weaker,")
+		fmt.Println("forgeable check and logs a loud warning at every startup.")
 		return nil
 	},
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -459,6 +459,19 @@ type KeyProviderConfig struct {
 	// single share reveals the KEK.
 	ShamirShareFiles []string `yaml:"shamir_share_files"`
 	ShamirShareEnv   []string `yaml:"shamir_share_env"`
+	// ShamirCommitment is the hex-encoded HMAC-SHA256 commitment to the original KEK
+	// (crypto.CommitKEK), printed by `keyorix encryption shamir-split` alongside the
+	// shares. It is verified against the RECONSTRUCTED KEK at unseal time (#429):
+	// without it, reconstruction is checked only by a 4-byte magic embedded in the
+	// split payload, which an attacker holding threshold-1 genuine shares can forge
+	// (each byte of the reconstructed payload — magic and KEK alike — is
+	// independently retargetable via the forged share's Lagrange coordinate, so a
+	// bigger in-payload check wouldn't help either). The commitment is safe to store
+	// in the clear here — it is one-way and reveals nothing about the KEK. Empty is
+	// accepted for key material split before this field existed, but every startup
+	// then logs a loud warning that verification is reduced to the forgeable magic
+	// check alone.
+	ShamirCommitment string `yaml:"shamir_commitment"`
 	// TPMDevice is the TPM 2.0 device for type "tpm" (default /dev/tpmrm0). The KEK
 	// is sealed to this TPM and the sealed blob stored at WrappedKeyPath.
 	TPMDevice string `yaml:"tpm_device"`

--- a/internal/crypto/shamir_provider.go
+++ b/internal/crypto/shamir_provider.go
@@ -2,9 +2,12 @@ package crypto
 
 import (
 	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
+	"log"
 	"os"
 	"strings"
 )
@@ -16,14 +19,51 @@ import (
 // fail closed even on a FRESH install (where there is no existing wrapped DEK to
 // fail against). The byte after the magic carries the threshold K so the provider
 // can enforce that at least K shares were actually supplied.
+//
+// #429: this magic is NOT a cryptographic integrity check and must never be relied
+// on as one. Because each byte of the split payload is the constant term of an
+// INDEPENDENT Lagrange polynomial evaluated at the same set of share x-coordinates,
+// an attacker holding threshold-1 genuine shares can forge one additional share by
+// picking any x-coordinate and solving, independently per output byte, for the
+// y-value that makes the interpolation land on a chosen byte — including the magic
+// bytes AND every KEK byte simultaneously. Embedding a bigger/stronger check INSIDE
+// the split payload (e.g. a hash of the KEK next to it) would not help: it is just
+// as forgeable, one byte at a time, as the 4-byte magic is. Real protection has to
+// come from a value that is NOT itself reconstructed via interpolation — see
+// kekCommitment below, verified against a value stored outside the Shamir shares.
 const kekShareMagic = "KXK1"
 
 // kekFrameLen is the framed-payload length: magic + 1 threshold byte + KEK.
 const kekFrameLen = len(kekShareMagic) + 1 + KEKSize
 
+// kekCommitmentContext domain-separates the KEK integrity commitment (#429) from any
+// other HMAC/hash use of the same KEK bytes elsewhere in the codebase — it is a
+// fixed, public label, not a secret.
+const kekCommitmentContext = "keyorix-shamir-kek-commitment-v1"
+
+// CommitKEK computes a public, one-way HMAC-SHA256 commitment to kek. Unlike
+// kekShareMagic (embedded IN the Shamir-split payload and therefore forgeable — see
+// its doc comment), this commitment is computed ONCE at split time from the real
+// original KEK and must be stored OUTSIDE the Shamir shares (e.g. in the server's
+// own config, alongside — not as part of — the share files/env vars). At
+// reconstruction time, ShamirKeyProvider recomputes this same commitment over the
+// RECONSTRUCTED KEK and compares it (constant-time) against the stored value: an
+// attacker who forges a share fully controls the interpolated KEK bytes, but cannot
+// make them hash to a commitment they never see and cannot influence, since it isn't
+// part of the interpolation at all. The commitment is safe to store in the clear —
+// it is one-way and reveals nothing about the KEK — so it can live right next to the
+// shares' own metadata/config without weakening anything.
+func CommitKEK(kek []byte) []byte {
+	mac := hmac.New(sha256.New, []byte(kekCommitmentContext))
+	mac.Write(kek)
+	return mac.Sum(nil)
+}
+
 // SplitKEK frames a 32-byte KEK (magic ‖ threshold ‖ KEK) and Shamir-splits it into
 // parts shares with the given threshold. Reconstructing with combineKEK then both
-// recovers the KEK and verifies enough correct shares were combined.
+// recovers the KEK and verifies enough correct shares were combined. Callers should
+// also persist CommitKEK(kek) (see its doc comment) so combineKEK can be given a
+// real cryptographic commitment to verify against, not just the forgeable magic.
 func SplitKEK(kek []byte, parts, threshold int) ([][]byte, error) {
 	if len(kek) != KEKSize {
 		return nil, fmt.Errorf("shamir: KEK must be %d bytes, got %d", KEKSize, len(kek))
@@ -39,9 +79,16 @@ func SplitKEK(kek []byte, parts, threshold int) ([][]byte, error) {
 }
 
 // combineKEK reconstructs a KEK from shares produced by SplitKEK. It fails closed
-// when the magic does not match (too few or incorrect shares were combined) or
-// when fewer than the embedded threshold shares were supplied.
-func combineKEK(shares [][]byte) ([]byte, error) {
+// when the magic does not match (too few or incorrect shares were combined) or when
+// fewer than the embedded threshold shares were supplied. If commitment is non-empty
+// (the operator configured shamir_commitment — see CommitKEK), it ALSO verifies the
+// reconstructed KEK against that commitment in constant time and rejects a mismatch;
+// this is the real cryptographic defense against the share-forgery attack (#429) —
+// the magic check alone cannot catch it. An empty commitment is accepted for
+// backward compatibility with key material split before this check existed; the
+// caller is responsible for warning loudly about the reduced verification strength
+// in that case.
+func combineKEK(shares [][]byte, commitment []byte) ([]byte, error) {
 	payload, err := Combine(shares)
 	if err != nil {
 		return nil, err
@@ -53,7 +100,16 @@ func combineKEK(shares [][]byte) ([]byte, error) {
 	if len(shares) < threshold {
 		return nil, fmt.Errorf("shamir: %d shares supplied but the split requires %d (threshold)", len(shares), threshold)
 	}
-	return validateKEK(payload[len(kekShareMagic)+1:], "shamir")
+	kek, err := validateKEK(payload[len(kekShareMagic)+1:], "shamir")
+	if err != nil {
+		return nil, err
+	}
+	if len(commitment) > 0 {
+		if !hmac.Equal(CommitKEK(kek), commitment) {
+			return nil, fmt.Errorf("shamir: reconstructed KEK failed its commitment check (shamir_commitment mismatch) — this indicates a forged/incorrect share, refusing to unseal")
+		}
+	}
+	return kek, nil
 }
 
 // ShamirKeyProvider reconstructs the KEK from K-of-N Shamir shares (ADR-038): no
@@ -63,14 +119,24 @@ func combineKEK(shares [][]byte) ([]byte, error) {
 // supplied shares (the operator provides at least the threshold many) and combines
 // them; the result must be exactly KEKSize bytes or the unseal fails closed (too
 // few / wrong shares reconstruct garbage rather than the real key).
+//
+// commitmentHex, if set (shamir_commitment in config, also printed by
+// `keyorix encryption shamir-split`), is the hex-encoded CommitKEK output computed
+// at split time; KEK() verifies the reconstructed key against it (#429) — real
+// cryptographic protection against a forged share, unlike the magic-byte framing
+// check alone. Left empty for key material split before this existed; KEK() then
+// logs a loud warning rather than hard-failing an existing legitimate deployment.
 type ShamirKeyProvider struct {
-	shareFiles []string
-	shareEnv   []string
+	shareFiles    []string
+	shareEnv      []string
+	commitmentHex string
 }
 
-// NewShamirKeyProvider builds a provider from share file paths and/or env var names.
-func NewShamirKeyProvider(shareFiles, shareEnv []string) *ShamirKeyProvider {
-	return &ShamirKeyProvider{shareFiles: shareFiles, shareEnv: shareEnv}
+// NewShamirKeyProvider builds a provider from share file paths and/or env var names,
+// and an optional hex-encoded KEK commitment (shamir_commitment; empty = not
+// configured, see the ShamirKeyProvider doc comment for the security implication).
+func NewShamirKeyProvider(shareFiles, shareEnv []string, commitmentHex string) *ShamirKeyProvider {
+	return &ShamirKeyProvider{shareFiles: shareFiles, shareEnv: shareEnv, commitmentHex: commitmentHex}
 }
 
 func (p *ShamirKeyProvider) Name() string { return "shamir" }
@@ -109,10 +175,29 @@ func (p *ShamirKeyProvider) KEK() ([]byte, error) {
 	if len(shares) < 2 {
 		return nil, fmt.Errorf("shamir key provider: need at least 2 shares, got %d", len(shares))
 	}
+
+	var commitment []byte
+	if p.commitmentHex != "" {
+		var err error
+		commitment, err = hex.DecodeString(strings.TrimSpace(p.commitmentHex))
+		if err != nil {
+			return nil, fmt.Errorf("shamir key provider: shamir_commitment is not valid hex: %w", err)
+		}
+	} else {
+		// #429: without a stored commitment, reconstruction is verified ONLY by the
+		// 4-byte magic framing check, which an attacker holding threshold-1 genuine
+		// shares can forge (they fully control the interpolated bytes, magic included).
+		// Not a hard failure — existing key material split before shamir_commitment
+		// existed has no commitment to check — but this is a real reduction in
+		// verification strength that every startup should surface loudly.
+		log.Printf("shamir key provider: no shamir_commitment configured — reconstruction relies solely on the forgeable magic-byte framing check, NOT a cryptographic integrity check (see issue #429); run `keyorix encryption shamir-split` again (or otherwise compute crypto.CommitKEK over the existing KEK) and set shamir_commitment to close this gap")
+	}
 	// combineKEK enforces the embedded threshold and verifies the framing magic, so
 	// a sub-threshold or wrong set of shares fails closed here — including on a fresh
 	// install, where there is no existing wrapped DEK for a wrong KEK to fail against.
-	kek, err := combineKEK(shares)
+	// When commitment is non-empty it also verifies the real cryptographic commitment
+	// (#429), which the magic check alone cannot do.
+	kek, err := combineKEK(shares, commitment)
 	if err != nil {
 		return nil, fmt.Errorf("shamir key provider: %w", err)
 	}

--- a/internal/crypto/shamir_provider_test.go
+++ b/internal/crypto/shamir_provider_test.go
@@ -1,6 +1,7 @@
 package crypto
 
 import (
+	"bytes"
 	"encoding/base64"
 	"encoding/hex"
 	"os"
@@ -12,7 +13,7 @@ import (
 )
 
 func TestShamirKeyProvider_Name(t *testing.T) {
-	assert.Equal(t, "shamir", NewShamirKeyProvider(nil, nil).Name())
+	assert.Equal(t, "shamir", NewShamirKeyProvider(nil, nil, "").Name())
 }
 
 func TestShamirKeyProvider_CombinesSharesFromFilesAndEnv(t *testing.T) {
@@ -28,7 +29,7 @@ func TestShamirKeyProvider_CombinesSharesFromFilesAndEnv(t *testing.T) {
 	require.NoError(t, os.WriteFile(f2, []byte(hex.EncodeToString(shares[1])), 0600))
 	t.Setenv("KX_SHARE_3", base64.StdEncoding.EncodeToString(shares[2]))
 
-	got, err := NewShamirKeyProvider([]string{f1, f2}, []string{"KX_SHARE_3"}).KEK()
+	got, err := NewShamirKeyProvider([]string{f1, f2}, []string{"KX_SHARE_3"}, "").KEK()
 	require.NoError(t, err)
 	assert.Equal(t, kek, got)
 }
@@ -42,7 +43,7 @@ func TestShamirKeyProvider_TooFewSharesFailsClosed(t *testing.T) {
 	require.NoError(t, os.WriteFile(f1, []byte(hex.EncodeToString(shares[0])), 0600))
 
 	// Only one share configured — below the minimum, rejected outright.
-	_, err = NewShamirKeyProvider([]string{f1}, nil).KEK()
+	_, err = NewShamirKeyProvider([]string{f1}, nil, "").KEK()
 	require.Error(t, err)
 }
 
@@ -61,7 +62,7 @@ func TestShamirKeyProvider_SubThresholdRejected(t *testing.T) {
 	require.NoError(t, os.WriteFile(f1, []byte(hex.EncodeToString(shares[0])), 0600))
 	require.NoError(t, os.WriteFile(f2, []byte(hex.EncodeToString(shares[1])), 0600))
 
-	_, err = NewShamirKeyProvider([]string{f1, f2}, nil).KEK()
+	_, err = NewShamirKeyProvider([]string{f1, f2}, nil, "").KEK()
 	require.Error(t, err, "below-threshold shares must fail closed, not reconstruct a wrong KEK")
 }
 
@@ -76,24 +77,62 @@ func TestShamirKeyProvider_UnframedSharesRejected(t *testing.T) {
 	require.NoError(t, os.WriteFile(f1, []byte(hex.EncodeToString(shares[0])), 0600))
 	require.NoError(t, os.WriteFile(f2, []byte(hex.EncodeToString(shares[1])), 0600))
 
-	_, err = NewShamirKeyProvider([]string{f1, f2}, nil).KEK()
+	_, err = NewShamirKeyProvider([]string{f1, f2}, nil, "").KEK()
 	require.Error(t, err, "shares without the KEK framing must be rejected")
 }
 
 func TestShamirKeyProvider_Errors(t *testing.T) {
 	t.Run("missing file", func(t *testing.T) {
-		_, err := NewShamirKeyProvider([]string{filepath.Join(t.TempDir(), "nope")}, nil).KEK()
+		_, err := NewShamirKeyProvider([]string{filepath.Join(t.TempDir(), "nope")}, nil, "").KEK()
 		require.Error(t, err)
 	})
 	t.Run("unset env", func(t *testing.T) {
-		_, err := NewShamirKeyProvider(nil, []string{"KX_SHARE_DOES_NOT_EXIST"}).KEK()
+		_, err := NewShamirKeyProvider(nil, []string{"KX_SHARE_DOES_NOT_EXIST"}, "").KEK()
 		require.Error(t, err)
 	})
 	t.Run("garbage share", func(t *testing.T) {
 		dir := t.TempDir()
 		f := filepath.Join(dir, "g")
 		require.NoError(t, os.WriteFile(f, []byte("!"), 0600))
-		_, err := NewShamirKeyProvider([]string{f}, []string{}).KEK()
+		_, err := NewShamirKeyProvider([]string{f}, []string{}, "").KEK()
 		require.Error(t, err)
 	})
+}
+
+// TestShamirKeyProvider_ForgedShareRejectedWithCommitment is the #429 regression
+// test at the ShamirKeyProvider level (the real code path an operator's configured
+// shamir_share_files hit), mirroring the file-based custodian setup an attacker
+// would actually exploit: they hold threshold-1 genuine share FILES and can
+// write/replace the one remaining configured share source with a forged share.
+func TestShamirKeyProvider_ForgedShareRejectedWithCommitment(t *testing.T) {
+	dir := t.TempDir()
+	kek := testKEK()
+	threshold := 3
+	shares, err := SplitKEK(kek, 5, threshold)
+	require.NoError(t, err)
+	commitmentHex := hex.EncodeToString(CommitKEK(kek))
+
+	genuine := shares[:2] // attacker holds threshold-1 genuine shares
+	fakeKEK := bytes.Repeat([]byte{0x77}, KEKSize)
+	targetPayload := append(append([]byte{}, kekShareMagic...), byte(threshold))
+	targetPayload = append(targetPayload, fakeKEK...)
+	forged := forgeShare(genuine, 210, targetPayload)
+
+	f1 := filepath.Join(dir, "s1")
+	f2 := filepath.Join(dir, "s2")
+	f3 := filepath.Join(dir, "s3-forged") // the attacker-replaced share source
+	require.NoError(t, os.WriteFile(f1, []byte(hex.EncodeToString(genuine[0])), 0600))
+	require.NoError(t, os.WriteFile(f2, []byte(hex.EncodeToString(genuine[1])), 0600))
+	require.NoError(t, os.WriteFile(f3, []byte(hex.EncodeToString(forged)), 0600))
+
+	// Without shamir_commitment configured (legacy behavior): the vulnerability —
+	// the forged share is accepted and the attacker's chosen KEK is returned.
+	legacyKEK, err := NewShamirKeyProvider([]string{f1, f2, f3}, nil, "").KEK()
+	require.NoError(t, err, "demonstrates the vulnerability at the provider level")
+	assert.Equal(t, fakeKEK, legacyKEK)
+
+	// With shamir_commitment configured (the fix): the exact same forged share is
+	// now rejected instead of silently returning the attacker-chosen KEK.
+	_, err = NewShamirKeyProvider([]string{f1, f2, f3}, nil, commitmentHex).KEK()
+	require.Error(t, err, "forged share must be rejected once shamir_commitment is configured")
 }

--- a/internal/crypto/shamir_test.go
+++ b/internal/crypto/shamir_test.go
@@ -93,3 +93,149 @@ func TestGF_FieldAxioms(t *testing.T) {
 		assert.Equal(t, byte(1), gfMul(x, gfInv(x)), "a * a^-1 == 1 for a=%d", a)
 	}
 }
+
+// --- #429 forgery reproduction -------------------------------------------------
+//
+// lagrangeCoeffAtZero and forgeShare implement the SAME backward-Lagrange-
+// interpolation forgery an attacker uses when they hold threshold-1 genuine Shamir
+// shares: pick an arbitrary x-coordinate for a "share" they don't actually have, then
+// solve — independently, one secret byte at a time — for the unique y-value that
+// makes the full set (their real shares + this forged one) interpolate to ANY chosen
+// target byte at x=0. Because every byte of the split payload (magic, threshold, and
+// the KEK itself) is reconstructed via an independent polynomial evaluated at the
+// same x-coordinates, this lets the forger dictate the ENTIRE reconstructed payload,
+// magic bytes included — proving the magic-byte check alone is not a real
+// cryptographic integrity check (see combineKEK's doc comment).
+
+// lagrangeCoeffAtZero returns L_i(0), the Lagrange basis coefficient by which ys[i]
+// is weighted in interpolateAtZero(xs, ys) — i.e. the same product xs[j]/(xs[i]^xs[j])
+// interpolateAtZero computes internally, exposed here so a forger (and this test)
+// can solve for an unknown y rather than only evaluate with known ones.
+func lagrangeCoeffAtZero(xs []byte, i int) byte {
+	num := byte(1)
+	den := byte(1)
+	for j := range xs {
+		if i == j {
+			continue
+		}
+		num = gfMul(num, xs[j])
+		den = gfMul(den, xs[i]^xs[j])
+	}
+	return gfMul(num, gfInv(den))
+}
+
+// forgeShare builds a single additional Shamir share at x-coordinate forgedX that,
+// combined with knownShares (typically threshold-1 genuine shares), reconstructs
+// EXACTLY targetPayload. This is the forgery construction #429 documents: for each
+// byte position, targetPayload's byte = (sum of known shares' Lagrange
+// contributions) XOR (forged share's Lagrange coefficient * forged y-byte); solving
+// for the forged y-byte is a single GF(2^8) division.
+func forgeShare(knownShares [][]byte, forgedX byte, targetPayload []byte) []byte {
+	n := len(knownShares)
+	xs := make([]byte, n+1)
+	for i, s := range knownShares {
+		xs[i] = s[len(s)-1]
+	}
+	xs[n] = forgedX
+
+	forged := make([]byte, len(targetPayload)+1)
+	forged[len(targetPayload)] = forgedX
+	forgedCoeff := lagrangeCoeffAtZero(xs, n)
+	for bi := range targetPayload {
+		var knownSum byte
+		for i, s := range knownShares {
+			knownSum ^= gfMul(lagrangeCoeffAtZero(xs, i), s[bi])
+		}
+		// target = knownSum XOR forgedCoeff*y  =>  y = forgedCoeff^-1 * (target XOR knownSum)
+		forged[bi] = gfMul(gfInv(forgedCoeff), targetPayload[bi]^knownSum)
+	}
+	return forged
+}
+
+// TestShamir_ForgedShare_ReconstructsExactAttackerChosenPayload proves the forgery
+// construction itself works, independent of combineKEK: an attacker with
+// threshold-1 genuine shares picks the ENTIRE reconstructed payload, including bytes
+// that aren't theirs to choose (the magic and threshold framing), not just the KEK.
+func TestShamir_ForgedShare_ReconstructsExactAttackerChosenPayload(t *testing.T) {
+	kek := testKEK()
+	threshold := 3
+	shares, err := SplitKEK(kek, 5, threshold)
+	require.NoError(t, err)
+
+	// Attacker holds only 2 (threshold-1) genuine shares.
+	genuine := [][]byte{shares[0], shares[1]}
+
+	fakeKEK := bytes.Repeat([]byte{0x41}, KEKSize)
+	targetPayload := append(append([]byte{}, kekShareMagic...), byte(threshold))
+	targetPayload = append(targetPayload, fakeKEK...)
+
+	forged := forgeShare(genuine, 250, targetPayload)
+	attackerShares := append(append([][]byte{}, genuine...), forged)
+
+	got, err := Combine(attackerShares)
+	require.NoError(t, err)
+	assert.Equal(t, targetPayload, got, "forged share must make Combine reconstruct the attacker's exact chosen payload, magic bytes included")
+	assert.NotEqual(t, kek, got[len(kekShareMagic)+1:], "the forged reconstruction is NOT the real KEK")
+}
+
+// TestShamir_ForgedShare_FoolsMagicOnlyCheck_ButCommitmentCatchesIt is the core #429
+// regression test: it reproduces the empirically-verified forgery attack end to end
+// through combineKEK and shows (a) the pre-fix magic-only path is fooled into
+// accepting an attacker-chosen KEK, and (b) with a real KEK commitment configured
+// (computed at split time from the true KEK, stored outside the shares), the exact
+// same forged shares are now REJECTED.
+func TestShamir_ForgedShare_FoolsMagicOnlyCheck_ButCommitmentCatchesIt(t *testing.T) {
+	kek := testKEK()
+	threshold := 3
+	shares, err := SplitKEK(kek, 5, threshold)
+	require.NoError(t, err)
+	commitment := CommitKEK(kek) // computed once, at split time, from the REAL KEK
+
+	genuine := [][]byte{shares[0], shares[1]} // threshold-1 genuine shares
+	fakeKEK := bytes.Repeat([]byte{0x99}, KEKSize)
+	require.NotEqual(t, kek, fakeKEK)
+	targetPayload := append(append([]byte{}, kekShareMagic...), byte(threshold))
+	targetPayload = append(targetPayload, fakeKEK...)
+	forged := forgeShare(genuine, 200, targetPayload)
+	attackerShares := append(append([][]byte{}, genuine...), forged)
+
+	// (a) VULNERABILITY: no commitment configured (legacy behavior / pre-existing key
+	// material) — the 4-byte magic + threshold framing is the only check, and the
+	// forged share was built to satisfy it exactly, so this "succeeds" with the
+	// attacker's chosen KEK rather than the real one.
+	legacyKEK, err := combineKEK(attackerShares, nil)
+	require.NoError(t, err, "demonstrates the vulnerability: magic-only verification accepts a forged reconstruction")
+	assert.Equal(t, fakeKEK, legacyKEK, "the accepted KEK is the attacker's chosen value, not the real KEK")
+
+	// (b) FIX: the real commitment (over the true KEK, stored outside the Shamir
+	// shares) is supplied — reconstruction from the SAME forged shares must now be
+	// rejected instead of silently returning the attacker's chosen KEK.
+	_, err = combineKEK(attackerShares, commitment)
+	require.Error(t, err, "forged share reconstructing an attacker-chosen KEK must be rejected once a real commitment is verified")
+}
+
+// TestShamir_CombineKEK_CommitmentRoundTrip proves genuine (non-forged) reconstruction
+// still succeeds and matches the original KEK once a commitment is configured, and
+// that a corrupted/mismatched commitment is itself rejected (it isn't merely
+// computed-and-ignored).
+func TestShamir_CombineKEK_CommitmentRoundTrip(t *testing.T) {
+	kek := testKEK()
+	shares, err := SplitKEK(kek, 5, 3)
+	require.NoError(t, err)
+	commitment := CommitKEK(kek)
+
+	got, err := combineKEK(shares[:3], commitment)
+	require.NoError(t, err)
+	assert.Equal(t, kek, got, "genuine shares + correct commitment must still reconstruct the real KEK")
+
+	badCommitment := append([]byte{}, commitment...)
+	badCommitment[0] ^= 0xff
+	_, err = combineKEK(shares[:3], badCommitment)
+	require.Error(t, err, "a mismatched commitment must be rejected even for a genuine reconstruction")
+
+	// No commitment configured at all: falls back to the legacy magic-only check
+	// (backward compatibility with pre-existing key material) and still succeeds.
+	got, err = combineKEK(shares[:3], nil)
+	require.NoError(t, err)
+	assert.Equal(t, kek, got)
+}

--- a/internal/encryption/keyprovider_compat_test.go
+++ b/internal/encryption/keyprovider_compat_test.go
@@ -101,7 +101,7 @@ func TestKeyProvider_ShamirRoundTrip(t *testing.T) {
 		require.NoError(t, os.WriteFile(p, []byte(hex.EncodeToString(shares[i])), 0600))
 		files = append(files, p)
 	}
-	roundTrip(t, dir, func() crypto.KeyProvider { return crypto.NewShamirKeyProvider(files, nil) })
+	roundTrip(t, dir, func() crypto.KeyProvider { return crypto.NewShamirKeyProvider(files, nil, "") })
 }
 
 // TestKeyProvider_KMSRoundTrip proves a KMS-envelope KEK wraps/unwraps the DEK

--- a/internal/encryption/service.go
+++ b/internal/encryption/service.go
@@ -105,7 +105,7 @@ func NewKeyProviderFromConfig(cfg *config.EncryptionConfig, baseDir, passphrase 
 	case "exec":
 		return crypto.NewExecKeyProvider(kp.ExecCommand), nil
 	case "shamir":
-		return crypto.NewShamirKeyProvider(kp.ShamirShareFiles, kp.ShamirShareEnv), nil
+		return crypto.NewShamirKeyProvider(kp.ShamirShareFiles, kp.ShamirShareEnv, kp.ShamirCommitment), nil
 	case "tpm":
 		return crypto.NewTPMKeyProvider(kp.TPMDevice, baseDir, kp.WrappedKeyPath), nil
 	case "aws-kms":


### PR DESCRIPTION
## Vulnerability (#429)

`combineKEK` (`internal/crypto/shamir_provider.go`) validated a Shamir-reconstructed
KEK **only** via a 4-byte magic value (`kekShareMagic = "KXK1"`) embedded inside the
pre-split payload (`SplitKEK` in the same file). That is not a cryptographic
integrity check, and this PR empirically re-confirms the forgery it enables:

Each byte of the split payload (magic ‖ threshold ‖ KEK) is the constant term of an
**independent** degree-(K-1) polynomial evaluated at the shares' x-coordinates
(`internal/crypto/shamir.go`). An attacker holding `threshold-1` genuine shares can
therefore forge one additional share by picking any x-coordinate and, for each byte
position, solving the Lagrange interpolation backwards for the unique y-value that
lands on ANY chosen target byte — magic bytes and KEK bytes alike, simultaneously.
A bigger/stronger check embedded *inside* the split payload would not have helped;
it is exactly as forgeable, one byte at a time.

This is exploitable whenever an attacker already holds `threshold-1` real shares and
can write to (or intercept/replace) the one remaining configured share source — a
genuine key-substitution attack on the master KEK.

### Proof (new regression tests)

- `TestShamir_ForgedShare_ReconstructsExactAttackerChosenPayload` — the forgery
  construction alone reconstructs the attacker's exact chosen payload from
  threshold-1 genuine shares + 1 forged share.
- `TestShamir_ForgedShare_FoolsMagicOnlyCheck_ButCommitmentCatchesIt` — reproduces the
  attack through `combineKEK` end to end: **without** a commitment configured, the
  forged shares are accepted and the attacker's chosen KEK is returned (`require.NoError`
  — this documents the pre-fix vulnerability); **with** the fix's commitment configured,
  the identical forged shares are now rejected (`require.Error`).
- `TestShamirKeyProvider_ForgedShareRejectedWithCommitment` — same attack at the
  `ShamirKeyProvider` level (file-based shares, the real operator code path).
- `TestShamir_CombineKEK_CommitmentRoundTrip` — genuine (non-forged) reconstruction
  still succeeds and matches the original KEK, and a corrupted/mismatched commitment
  is itself rejected (proving it's actually consulted, not computed-and-ignored).

All four pass, confirming the fix actually catches the forgery rather than merely
adding an inert check.

## Fix

`CommitKEK(kek)` computes `HMAC-SHA256(fixed-context-label, kek)` over the
**original** KEK at split time. Unlike the magic byte, this commitment is stored
**outside** the Shamir-shared payload — it is never part of the interpolation — so a
forged share cannot make the reconstruction match it. It's safe to store in the
clear (one-way, reveals nothing about the KEK).

- `keyorix encryption shamir-split` now also prints/writes this commitment
  (`commitment.hex` alongside `share-N.hex` when `--out-dir` is used).
- New config field `storage.encryption.key_provider.shamir_commitment` (hex).
- `combineKEK` / `ShamirKeyProvider.KEK()` verify the **reconstructed** KEK against
  it with `hmac.Equal` (constant-time) before trusting it, rejecting a mismatch.
- `migrate-provider --to-type shamir` gained `--to-shamir-commitment` to carry it
  over when migrating an existing install onto Shamir shares.

### Backward compatibility

`shamir_commitment` is optional. Key material split **before** this change has no
commitment to check, so `ShamirKeyProvider` falls back to the legacy magic-only
check rather than hard-failing a working deployment — but it now logs a loud warning
at every startup ("reconstruction relies solely on the forgeable magic-byte framing
check ... see issue #429") so the reduced verification strength is visible, not
silent. Operators should re-run `shamir-split` (or otherwise compute `CommitKEK` over
their existing KEK) and set `shamir_commitment` to close the gap.

## Testing

- `go build ./...` — clean
- `go vet ./...` — clean
- `go test ./internal/crypto/... ./internal/cli/encryption/... ./internal/encryption/... ./internal/config/...` — all pass, including the new forgery regression tests above
- `gosec -severity medium -exclude-generated ./internal/crypto/...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)