### PR TITLE
fix(retention): never purge unacknowledged anomaly alerts by age (#415)

### DIFF
--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -411,6 +411,9 @@ type Storage interface {
 	// (ISO A.5.33 / GDPR), returning the number removed. Unlike the soft-delete
 	// purge these age out live records by a time column, never touch active rows,
 	// and cascade to dependent rows where noted. Irreversible.
+	// DeleteAnomalyAlertsBefore only removes ALREADY-ACKNOWLEDGED alerts
+	// (detected_at < before AND acknowledged = true) — an old but never-acknowledged
+	// alert is still a live, unreviewed signal and is never purged by age alone.
 	DeleteAnomalyAlertsBefore(ctx context.Context, before time.Time) (int64, error)
 	// DeleteClosedAccessReviewsBefore removes closed campaigns (closed_at < before)
 	// and their snapshot items, returning (campaigns, items) removed.

--- a/internal/storage/store/local_purge.go
+++ b/internal/storage/store/local_purge.go
@@ -244,9 +244,20 @@ func (ls *LocalStorage) PurgeDeletedSecretsBefore(ctx context.Context, before ti
 // so an in-flight record is never destroyed by a too-short window.
 
 // DeleteAnomalyAlertsBefore hard-deletes anomaly alerts detected before the cutoff.
+// Unlike a plain age purge, this only removes ALREADY-ACKNOWLEDGED alerts
+// (Acknowledged = true) — matching every sibling purge in this section, which
+// excludes in-flight rows (open campaigns, active break-glass, pending access
+// requests) from age-based deletion. An old alert nobody has ever acknowledged is
+// exactly the in-flight case here: it is still a live, unreviewed security signal,
+// not a resolved record, so it stays until a human acknowledges it (or is handled
+// by some separate abandoned-alert mechanism, if one is ever added). Without this
+// gate, a retention window shorter than the real review cadence would silently
+// hard-delete a genuine, never-reviewed high-severity alert — and the compliance
+// dashboard would then report FEWER unacknowledged anomalies, masking the fact
+// that a real signal was destroyed rather than resolved.
 func (ls *LocalStorage) DeleteAnomalyAlertsBefore(ctx context.Context, before time.Time) (int64, error) {
 	result := ls.db.WithContext(ctx).
-		Where("detected_at < ?", before).
+		Where("acknowledged = ? AND detected_at < ?", true, before).
 		Delete(&models.AnomalyAlert{})
 	if result.Error != nil {
 		return 0, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), result.Error)

--- a/internal/storage/store/local_retention_test.go
+++ b/internal/storage/store/local_retention_test.go
@@ -34,11 +34,38 @@ func TestDeleteAnomalyAlertsBefore(t *testing.T) {
 
 	n, err := ls.DeleteAnomalyAlertsBefore(ctx, now.AddDate(0, 0, -30))
 	require.NoError(t, err)
-	assert.Equal(t, int64(1), n, "only the 40-day-old alert is purged")
+	assert.Equal(t, int64(0), n, "neither alert is acknowledged, so nothing is purged regardless of age")
 
 	var remaining int64
 	require.NoError(t, ls.db.Model(&models.AnomalyAlert{}).Count(&remaining).Error)
-	assert.Equal(t, int64(1), remaining)
+	assert.Equal(t, int64(2), remaining)
+}
+
+// #415: a never-acknowledged alert is a live, unreviewed security signal — it must
+// survive age-based purge even when well past the retention window. Only an
+// already-acknowledged alert is eligible for deletion once it's old enough.
+func TestDeleteAnomalyAlertsBefore_SkipsUnacknowledged(t *testing.T) {
+	ls := newRetentionTestStore(t)
+	ctx := context.Background()
+	now := time.Now()
+	require.NoError(t, ls.db.Create(&models.AnomalyAlert{
+		ID: 1, DetectedAt: now.AddDate(0, 0, -40), Acknowledged: true,
+	}).Error)
+	require.NoError(t, ls.db.Create(&models.AnomalyAlert{
+		ID: 2, DetectedAt: now.AddDate(0, 0, -40), Acknowledged: false,
+	}).Error)
+
+	n, err := ls.DeleteAnomalyAlertsBefore(ctx, now.AddDate(0, 0, -30))
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), n, "only the acknowledged, old alert is purged")
+
+	var remaining models.AnomalyAlert
+	require.NoError(t, ls.db.Where("id = ?", 2).First(&remaining).Error)
+	assert.False(t, remaining.Acknowledged)
+
+	var count int64
+	require.NoError(t, ls.db.Model(&models.AnomalyAlert{}).Where("id = ?", 1).Count(&count).Error)
+	assert.Equal(t, int64(0), count, "the acknowledged alert must be gone")
 }
 
 func TestDeleteClosedAccessReviewsBefore_CascadesItemsAndSkipsOpen(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes #415: `DeleteAnomalyAlertsBefore` (in `internal/storage/store/local_purge.go`) purged anomaly alerts purely by `detected_at` age, with no gate on `Acknowledged` — unlike every sibling purge in the same file, which excludes in-flight rows (open access-review campaigns, active break-glass activations, pending access requests) from age-based deletion.

A retention window shorter than the real security-review cadence could hard-delete a genuine, never-reviewed high-severity anomaly alert with zero human involvement. After that, the compliance dashboard would report *fewer* unacknowledged anomalies — masking the fact that a real, unreviewed signal was silently destroyed rather than actually resolved. This is distinct from the already-fixed #217 (which added `AcknowledgedBy`/`AcknowledgedAt` attribution to the row itself).

## Changes

- `DeleteAnomalyAlertsBefore` now requires `acknowledged = true` in addition to `detected_at < before`, matching the "only purge already-resolved/reviewed rows" convention used by every sibling purge (`DeleteClosedAccessReviewsBefore`, `DeleteExpiredBreakGlassBefore`, `DeleteResolvedAccessRequestsBefore`).
- Updated the doc comment on the storage interface method to make the gate explicit for future callers.
- Checked the caller (`core.PurgeExpiredComplianceRecords`): it only logs/reports the returned count, it does not assume "purge count == age-eligible count," so no downstream fix was needed there.
- Extended the existing regression test and added a new one (`TestDeleteAnomalyAlertsBefore_SkipsUnacknowledged`) that seeds an old acknowledged alert (must be purged) and an old unacknowledged alert (must survive).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/storage/store/... ./internal/core/...` (one pre-existing, unrelated timing flake in `TestConcurrency_RequestPasswordReset_BurstIsThrottled` confirmed via repeated runs — passes standalone; not touched by this change)
- [x] `gosec -severity medium -exclude-generated ./internal/storage/store/...` — 0 issues