### PR TITLE
fix(models): tag remaining TokenHash fields json:"-" (#461)

### DIFF
--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -322,7 +322,7 @@ type MFARecoveryCode struct {
 type MFAChallenge struct {
 	ID        uint   `gorm:"primaryKey"`
 	UserID    uint   `gorm:"index"`
-	TokenHash string `gorm:"uniqueIndex"`
+	TokenHash string `gorm:"uniqueIndex" json:"-"`
 	ExpiresAt time.Time
 	UsedAt    *time.Time
 	CreatedAt time.Time
@@ -376,7 +376,7 @@ type WebAuthnCredential struct {
 type WebAuthnSession struct {
 	ID        uint   `gorm:"primaryKey"`
 	UserID    uint   `gorm:"index"`
-	TokenHash string `gorm:"uniqueIndex"`
+	TokenHash string `gorm:"uniqueIndex" json:"-"`
 	Purpose   string
 	Data      []byte // JSON of webauthn.SessionData
 	ExpiresAt time.Time
@@ -1073,8 +1073,8 @@ type MachineIdentityCredential struct {
 	ID                uint   `gorm:"primaryKey"`
 	MachineIdentityID uint   `gorm:"index;not null"`
 	Name              string // operator-facing label
-	TokenHash         string `gorm:"uniqueIndex;not null"` // SHA-256 hex (never the plaintext)
-	TokenPrefix       string `gorm:"index"`                // leading chars for display ("kx_machine_ab12cd")
+	TokenHash         string `gorm:"uniqueIndex;not null" json:"-"` // SHA-256 hex (never the plaintext)
+	TokenPrefix       string `gorm:"index"`                         // leading chars for display ("kx_machine_ab12cd")
 	LastUsedAt        *time.Time
 	ExpiresAt         *time.Time // nil = never expires
 	Revoked           bool       `gorm:"default:false"`

--- a/internal/storage/models/sensitive_json_test.go
+++ b/internal/storage/models/sensitive_json_test.go
@@ -71,6 +71,21 @@ func TestSensitiveFieldsAreNotJSONSerialized(t *testing.T) {
 			v:       &SetupToken{Purpose: "account_setup", TokenHash: "sha256hash"},
 			secrets: []string{"sha256hash", "TokenHash"},
 		},
+		{
+			name:    "MFAChallenge.TokenHash",
+			v:       &MFAChallenge{UserID: 1, TokenHash: "sha256hash"},
+			secrets: []string{"sha256hash", "TokenHash"},
+		},
+		{
+			name:    "WebAuthnSession.TokenHash",
+			v:       &WebAuthnSession{UserID: 1, TokenHash: "sha256hash", Purpose: "login"},
+			secrets: []string{"sha256hash", "TokenHash"},
+		},
+		{
+			name:    "MachineIdentityCredential.TokenHash",
+			v:       &MachineIdentityCredential{MachineIdentityID: 1, Name: "ci", TokenHash: "sha256hash"},
+			secrets: []string{"sha256hash", "TokenHash"},
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary
- `MFAChallenge.TokenHash`, `WebAuthnSession.TokenHash`, and `MachineIdentityCredential.TokenHash` were missing the `json:"-"` tag already applied to their sibling `PersonalAccessToken.TokenHash`/`SetupToken.TokenHash` (#341/#461).
- Completes the incomplete remediation: not currently exploitable (no handler serializes these models directly today, confirmed by tracing every call site), but closes the landmine for any future handler/DTO that does.
- Extends the existing `TestSensitiveFieldsAreNotJSONSerialized` (`internal/storage/models/sensitive_json_test.go`) to cover all three fields alongside the already-tagged siblings, so a future regression is caught structurally.

Closes #461.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/storage/models/... ./internal/core/... ./server/...` — all pass
- [x] `gosec -severity medium -exclude-generated ./internal/storage/models/...` — 0 issues (SSA-based rules skipped due to a pre-existing local build-cache artifact, reproduced identically on an untouched package, unrelated to this diff)
- [x] Traced every reference to the three models — confirmed no live serialization path exists; only raw string tokens or explicit whitelisted DTO maps are returned to clients today