### PR TITLE
fix(http): gate /openapi.yaml behind swagger_enabled (#224)

### DIFF
--- a/server/http/router.go
+++ b/server/http/router.go
@@ -782,13 +782,15 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		})
 	})
 
-	// Swagger UI (optional, based on config)
+	// Swagger UI and the raw OpenAPI spec (optional, based on config). #224: the
+	// spec endpoint was previously registered unconditionally, so disabling
+	// swagger_enabled still leaked the machine-readable API surface even though
+	// the human-facing UI was correctly gated. Both routes must share the same
+	// on/off behavior.
 	if cfg.Server.HTTP.SwaggerEnabled {
 		r.Mount("/swagger/", handlers.SwaggerHandler())
+		r.Get("/openapi.yaml", handlers.OpenAPISpec)
 	}
-
-	// OpenAPI spec endpoint
-	r.Get("/openapi.yaml", handlers.OpenAPISpec)
 
 	// Serve the web dashboard. Prefer an on-disk build (mounted in the Docker
 	// stack, or present in dev); otherwise fall back to the build embedded in the

--- a/server/http/static_hardening_test.go
+++ b/server/http/static_hardening_test.go
@@ -61,6 +61,64 @@ func TestAssetDirListing_Returns404NotListing(t *testing.T) {
 	assert.Equal(t, "console.log(1)", body)
 }
 
+// TestOpenAPISpec_GatedBySwaggerEnabled pins #224: /openapi.yaml was previously
+// registered unconditionally, so disabling swagger_enabled still left the
+// machine-readable OpenAPI spec (internal API surface, parameter names,
+// structure) exposed even though the human-facing /swagger/ UI was correctly
+// gated behind the same toggle. Both routes must share identical on/off
+// behavior.
+func TestOpenAPISpec_GatedBySwaggerEnabled(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	t.Cleanup(i18n.ResetForTesting)
+
+	newRouterWithSwagger := func(t *testing.T, enabled bool) *httptest.Server {
+		t.Helper()
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "index.html"), []byte("<html>Keyorix</html>"), 0644))
+
+		cfg := &config.Config{}
+		cfg.Server.HTTP.WebAssetsPath = dir
+		cfg.Server.HTTP.SwaggerEnabled = enabled
+		router, err := NewRouter(cfg, newTestCore(t))
+		require.NoError(t, err)
+		srv := httptest.NewServer(router)
+		t.Cleanup(srv.Close)
+		return srv
+	}
+
+	t.Run("disabled: both swagger UI and openapi.yaml 404", func(t *testing.T) {
+		srv := newRouterWithSwagger(t, false)
+		client := &http.Client{}
+
+		resp, err := client.Get(srv.URL + "/openapi.yaml")
+		require.NoError(t, err)
+		_ = resp.Body.Close()
+		assert.Equal(t, http.StatusNotFound, resp.StatusCode, "GET /openapi.yaml must 404 when swagger_enabled is false")
+
+		resp, err = client.Get(srv.URL + "/swagger/")
+		require.NoError(t, err)
+		_ = resp.Body.Close()
+		assert.Equal(t, http.StatusNotFound, resp.StatusCode, "GET /swagger/ must 404 when swagger_enabled is false")
+	})
+
+	t.Run("enabled: both swagger UI and openapi.yaml serve", func(t *testing.T) {
+		srv := newRouterWithSwagger(t, true)
+		client := &http.Client{}
+
+		resp, err := client.Get(srv.URL + "/openapi.yaml")
+		require.NoError(t, err)
+		body := readAll(t, resp.Body)
+		_ = resp.Body.Close()
+		assert.Equal(t, http.StatusOK, resp.StatusCode, "GET /openapi.yaml must serve when swagger_enabled is true")
+		assert.NotEmpty(t, body)
+
+		resp, err = client.Get(srv.URL + "/swagger/")
+		require.NoError(t, err)
+		_ = resp.Body.Close()
+		assert.Equal(t, http.StatusOK, resp.StatusCode, "GET /swagger/ must serve when swagger_enabled is true")
+	})
+}
+
 // TestNotFound_BackendRoutePrefixesReturn404 pins #214: an unmatched path under a
 // KNOWN backend route family (not just /api/) must 404, not silently fall through
 // to the SPA shell with a 200.


### PR DESCRIPTION
## Summary

- `/openapi.yaml` was registered unconditionally in `server/http/router.go`, one line below the `/swagger/` UI route which was already correctly gated behind `cfg.Server.HTTP.SwaggerEnabled` (`swagger_enabled` config toggle).
- This meant an operator explicitly disabling swagger/API-docs for a production deployment still had the machine-readable OpenAPI spec served unauthenticated to anyone — leaking internal API surface, parameter names, and structure even though the human-facing UI was hardened off.
- Fix moves the `/openapi.yaml` registration inside the existing `swagger_enabled` gate so both routes now share identical on/off behavior. No other router structure changes.

## Test plan

- [x] Added `TestOpenAPISpec_GatedBySwaggerEnabled` in `server/http/static_hardening_test.go`, following the existing router-test conventions in that file: with `swagger_enabled=false`, both `/openapi.yaml` and `/swagger/` now return 404; with `swagger_enabled=true`, both continue to serve `200`.
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./server/... -count=1`
- [x] `gosec -severity medium -exclude-generated ./server/...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)