### PR TITLE
fix(storage): tag remaining TokenHash fields json:"-" (#461)

### DIFF
--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -322,7 +322,7 @@ type MFARecoveryCode struct {
 type MFAChallenge struct {
 	ID        uint   `gorm:"primaryKey"`
 	UserID    uint   `gorm:"index"`
-	TokenHash string `gorm:"uniqueIndex"`
+	TokenHash string `gorm:"uniqueIndex" json:"-"`
 	ExpiresAt time.Time
 	UsedAt    *time.Time
 	CreatedAt time.Time
@@ -376,7 +376,7 @@ type WebAuthnCredential struct {
 type WebAuthnSession struct {
 	ID        uint   `gorm:"primaryKey"`
 	UserID    uint   `gorm:"index"`
-	TokenHash string `gorm:"uniqueIndex"`
+	TokenHash string `gorm:"uniqueIndex" json:"-"`
 	Purpose   string
 	Data      []byte // JSON of webauthn.SessionData
 	ExpiresAt time.Time
@@ -1073,8 +1073,8 @@ type MachineIdentityCredential struct {
 	ID                uint   `gorm:"primaryKey"`
 	MachineIdentityID uint   `gorm:"index;not null"`
 	Name              string // operator-facing label
-	TokenHash         string `gorm:"uniqueIndex;not null"` // SHA-256 hex (never the plaintext)
-	TokenPrefix       string `gorm:"index"`                // leading chars for display ("kx_machine_ab12cd")
+	TokenHash         string `gorm:"uniqueIndex;not null" json:"-"` // SHA-256 hex (never the plaintext)
+	TokenPrefix       string `gorm:"index"`                         // leading chars for display ("kx_machine_ab12cd")
 	LastUsedAt        *time.Time
 	ExpiresAt         *time.Time // nil = never expires
 	Revoked           bool       `gorm:"default:false"`

--- a/internal/storage/models/sensitive_json_test.go
+++ b/internal/storage/models/sensitive_json_test.go
@@ -71,6 +71,21 @@ func TestSensitiveFieldsAreNotJSONSerialized(t *testing.T) {
 			v:       &SetupToken{Purpose: "account_setup", TokenHash: "sha256hash"},
 			secrets: []string{"sha256hash", "TokenHash"},
 		},
+		{
+			name:    "MFAChallenge.TokenHash",
+			v:       &MFAChallenge{UserID: 1, TokenHash: "sha256hash"},
+			secrets: []string{"sha256hash", "TokenHash"},
+		},
+		{
+			name:    "WebAuthnSession.TokenHash",
+			v:       &WebAuthnSession{UserID: 1, TokenHash: "sha256hash", Purpose: "login"},
+			secrets: []string{"sha256hash", "TokenHash"},
+		},
+		{
+			name:    "MachineIdentityCredential.TokenHash",
+			v:       &MachineIdentityCredential{MachineIdentityID: 1, Name: "ci", TokenHash: "sha256hash"},
+			secrets: []string{"sha256hash", "TokenHash"},
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

- `MFAChallenge.TokenHash`, `WebAuthnSession.TokenHash`, and `MachineIdentityCredential.TokenHash` were the three sensitive-hash fields left without `json:"-"` after PR #611's hygiene sweep (which correctly tagged the sibling `PersonalAccessToken.TokenHash` / `SetupToken.TokenHash`).
- Traced reachability: `MFAChallenge`/`WebAuthnSession` aren't currently serialized outside `internal/core` + tests, and `MachineIdentityCredential` is only surfaced via `machineTokenToProto`, which already manually excludes `TokenHash` — so this isn't a live leak today, but it's a real gap in the codebase's own stated "every sensitive hash field carries `json:"-"`" convention and a landmine for the next handler/DTO that naively serializes one of these models directly.
- Adds `json:"-"` to all three fields, matching the exact style already used on the sibling fields in the same file.
- Extends the existing `TestSensitiveFieldsAreNotJSONSerialized` regression test (`internal/storage/models/sensitive_json_test.go`) with a case per field, asserting the token hash never appears in the marshaled output.

Addresses backlog finding #461.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/storage/... -count=1`
- [x] `gosec -severity medium -exclude-generated ./internal/storage/...` (0 issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)