### PR TITLE
fix(rotation): detect no-op rotations, don't bump LastRotatedAt (#408)

### DIFF
--- a/internal/core/rotate_noop_test.go
+++ b/internal/core/rotate_noop_test.go
@@ -1,0 +1,106 @@
+package core_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// newRotateNoopFixture builds an in-memory core with a project/environment/secret
+// ready for rotation, matching the harness used by TestConcurrency_RotateSecret_*.
+// AuditEvent is migrated too since a no-op rotation is expected to audit
+// secret.rotate_noop (see rollback_test.go's rollbackCore for the same precedent).
+func newRotateNoopFixture(t *testing.T) (*core.KeyorixCore, uint, *gorm.DB) {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	sqlDB, _ := db.DB()
+	sqlDB.SetMaxOpenConns(1)
+	require.NoError(t, db.AutoMigrate(&models.Project{}, &models.Environment{}, &models.SecretNode{}, &models.SecretVersion{}, &models.AuditEvent{}))
+	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "p1"}).Error)
+	require.NoError(t, db.Create(&models.Environment{ID: 1, ProjectID: 1, Name: "dev"}).Error)
+
+	c := core.NewKeyorixCore(store.NewLocalStorage(db))
+	ctx := context.Background()
+	sec, err := c.CreateSecret(ctx, &core.CreateSecretRequest{
+		Name: "rotated-secret", Value: []byte("initial-secret-value-123"), ProjectID: 1, EnvironmentID: 1,
+		Type: "password", Classification: "internal", OwnerID: 1, CreatedBy: "owner",
+	})
+	require.NoError(t, err)
+	return c, sec.ID, db
+}
+
+// TestRotateSecret_SameValue_DoesNotBumpLastRotatedAt is the #408 regression:
+// resubmitting the byte-identical value must not reset LastRotatedAt (which would
+// otherwise make dashboards/auditors/risk-scoring believe stale credential material
+// was "just rotated"), even though the codebase's chosen behavior still writes a new
+// version row for audit-trail completeness.
+func TestRotateSecret_SameValue_DoesNotBumpLastRotatedAt(t *testing.T) {
+	c, secretID, db := newRotateNoopFixture(t)
+	ctx := context.Background()
+
+	// First rotation: a genuinely new value, so LastRotatedAt must be set.
+	updated, err := c.RotateSecret(ctx, secretID, []byte("rotated-value-A"), "rotator")
+	require.NoError(t, err)
+	require.NotNil(t, updated.LastRotatedAt)
+	firstRotatedAt := *updated.LastRotatedAt
+
+	versionsBefore, err := c.GetSecretVersions(ctx, secretID)
+	require.NoError(t, err)
+
+	// Sleep to guarantee a distinguishable timestamp if LastRotatedAt were (wrongly)
+	// bumped again below.
+	time.Sleep(5 * time.Millisecond)
+
+	// Second "rotation" resubmits the exact same value — must be a no-op for the
+	// timestamp, but must still store a new version row.
+	updated, err = c.RotateSecret(ctx, secretID, []byte("rotated-value-A"), "rotator")
+	require.NoError(t, err, "rotating to an unchanged value must not be refused")
+	require.NotNil(t, updated.LastRotatedAt)
+	assert.True(t, updated.LastRotatedAt.Equal(firstRotatedAt),
+		"LastRotatedAt must NOT be bumped when the new value is byte-identical to the current version")
+
+	versionsAfter, err := c.GetSecretVersions(ctx, secretID)
+	require.NoError(t, err)
+	assert.Len(t, versionsAfter, len(versionsBefore)+1,
+		"a new version row must still be stored for audit-trail completeness even on a no-op rotation")
+
+	// The no-op is auditable rather than fully silent.
+	var n int64
+	require.NoError(t, db.Model(&models.AuditEvent{}).Where("event_type = ?", core.EventSecretRotateNoop).Count(&n).Error)
+	assert.Equal(t, int64(1), n, "exactly one secret.rotate_noop event should be recorded")
+
+	// A subsequent rotation to a genuinely different value must resume bumping
+	// LastRotatedAt normally.
+	time.Sleep(5 * time.Millisecond)
+	updated, err = c.RotateSecret(ctx, secretID, []byte("rotated-value-B"), "rotator")
+	require.NoError(t, err)
+	require.NotNil(t, updated.LastRotatedAt)
+	assert.True(t, updated.LastRotatedAt.After(firstRotatedAt),
+		"LastRotatedAt must be bumped again once the value genuinely changes")
+}
+
+// TestRotateSecret_DifferentValue_AlwaysBumpsLastRotatedAt is the companion positive
+// case: an ordinary rotation to a new value must behave exactly as before this change.
+func TestRotateSecret_DifferentValue_AlwaysBumpsLastRotatedAt(t *testing.T) {
+	c, secretID, _ := newRotateNoopFixture(t)
+	ctx := context.Background()
+
+	before, err := c.GetSecret(ctx, secretID)
+	require.NoError(t, err)
+	assert.Nil(t, before.LastRotatedAt, "a freshly created secret has never been rotated")
+
+	updated, err := c.RotateSecret(ctx, secretID, []byte("a-genuinely-different-value"), "rotator")
+	require.NoError(t, err)
+	require.NotNil(t, updated.LastRotatedAt)
+}

--- a/internal/core/secrets.go
+++ b/internal/core/secrets.go
@@ -6,6 +6,7 @@ package core
 
 import (
 	"context"
+	"crypto/subtle"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -233,7 +234,31 @@ func (c *KeyorixCore) UpdateSecretWithPermissionCheck(ctx context.Context, req *
 	return c.UpdateSecret(ctx, req)
 }
 
+// EventSecretRotateNoop is audited when RotateSecret is invoked with a value that is
+// byte-identical to the secret's current version (#408). Left unaddressed, resubmitting
+// an unchanged credential (a stale automation script, or an operator running `rotate`
+// without actually changing anything) resets LastRotatedAt to "just now" with zero
+// actual credential change, so risk-scoring/dashboards see "recently rotated, low risk"
+// while the underlying secret has genuinely never changed. A new version row is still
+// stored for audit-trail completeness, but LastRotatedAt is deliberately withheld.
+const EventSecretRotateNoop = "secret.rotate_noop"
+
 // RotateSecret creates a new version with a new value and updates LastRotatedAt.
+//
+// #408: if newValue is byte-identical to the CURRENT version's decrypted value, the
+// rotation is treated as a no-op FOR TIMESTAMP PURPOSES ONLY: a new version row is
+// still written (so the attempt is visible in version history / for audit trail
+// completeness — someone did call rotate), but LastRotatedAt is deliberately left
+// untouched so a false "recently rotated, low risk" signal never reaches
+// dashboards/auditors/risk-scoring for material that hasn't actually changed. This
+// silently-skip-the-timestamp behavior (rather than refusing/erroring outright) is
+// deliberate: RotateSecret is also invoked by the auto-rotation scheduler
+// (rotateOneSecret, "system:auto-rotation") and by RollbackSecret, neither of which
+// expects — or gracefully handles — a hard error for what they consider a successful
+// rotation call; erroring here would turn an edge case (a misbehaving rotation
+// backend, or a rollback landing on a value the current version already holds) into an
+// automation-breaking failure. The event is still recorded via EventSecretRotateNoop
+// so the no-op is auditable rather than fully silent.
 func (c *KeyorixCore) RotateSecret(ctx context.Context, id uint, newValue []byte, rotatedBy string) (*models.SecretNode, error) {
 	if err := c.secretValuePolicy.Validate(newValue); err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorValidation", nil), err)
@@ -242,11 +267,41 @@ func (c *KeyorixCore) RotateSecret(ctx context.Context, id uint, newValue []byte
 	if err != nil {
 		return nil, fmt.Errorf("secret not found: %w", err)
 	}
+
+	// Compare against the CURRENT version's decrypted value, mirroring the existing
+	// decrypt-on-read path used by RollbackSecret (direct c.encryption.RetrieveSecret /
+	// raw EncryptedValue) rather than routing through readVersionValue — that helper
+	// also enforces max-reads by incrementing the read counter, which this internal
+	// comparison must NOT do (it would silently burn from a burn-after-N-reads
+	// secret's budget on every rotation attempt). subtle.ConstantTimeCompare matches
+	// this codebase's convention for comparing genuine secret material (see mfa.go,
+	// auth_bootstrap.go, encryption/auth_encryption.go).
+	valueUnchanged := false
+	if latestVersion, verr := c.storage.GetLatestSecretVersion(ctx, id); verr == nil && latestVersion != nil {
+		var currentValue []byte
+		var rerr error
+		if c.encryption != nil {
+			currentValue, rerr = c.encryption.RetrieveSecret(latestVersion.ID)
+		} else {
+			currentValue = latestVersion.EncryptedValue
+		}
+		if rerr == nil && subtle.ConstantTimeCompare(currentValue, newValue) == 1 {
+			valueUnchanged = true
+		}
+	}
+
 	if err := c.storeNextSecretVersion(ctx, secret, newValue); err != nil {
 		return nil, fmt.Errorf("failed to store rotated secret: %w", err)
 	}
 	now := time.Now()
-	secret.LastRotatedAt = &now
+	if valueUnchanged {
+		log.Printf("rotate secret %d: new value identical to the current version; version stored but last_rotated_at was NOT updated", id)
+		sid := id
+		c.writeAuditEvent(ctx, EventSecretRotateNoop, nil, &sid,
+			fmt.Sprintf("rotation of secret %q by %s submitted a value identical to the current version: a new version was stored for audit-trail completeness, but last_rotated_at was not updated", secret.Name, rotatedBy))
+	} else {
+		secret.LastRotatedAt = &now
+	}
 	secret.UpdatedAt = now
 	updatedSecret, err := c.storage.UpdateSecret(ctx, secret)
 	if err != nil {


### PR DESCRIPTION
## Summary

Fixes #408: `RotateSecret` (internal/core/secrets.go) never compared the
incoming value to the CURRENT version's decrypted value before storing a new
version and stamping `LastRotatedAt`. An automation script re-submitting the
same credential, or an operator running `rotate` without actually changing
anything, would reset `LastRotatedAt` to "just now" with zero actual
credential change — so dashboards/auditors/risk-scoring would see "recently
rotated, low risk" while the underlying secret genuinely never changed.

## What changed

- `RotateSecret` now fetches the current latest version and decrypts it via
  the same path `RollbackSecret` already uses directly
  (`c.encryption.RetrieveSecret(version.ID)` / raw `EncryptedValue` when
  encryption is off) — deliberately NOT via `readVersionValue`, since that
  helper also increments the max-reads counter, which an internal comparison
  must not burn from a burn-after-N-reads secret's budget.
- The comparison uses `subtle.ConstantTimeCompare`, matching this codebase's
  existing convention for comparing genuine secret material (`mfa.go`,
  `auth_bootstrap.go`, `encryption/auth_encryption.go`).
- **Behavior chosen: silently skip the timestamp bump, not refuse the
  rotation.** When the value is unchanged, a new version row is still stored
  (audit-trail completeness — the attempt is visible in version history) but
  `LastRotatedAt` is left untouched. A new `secret.rotate_noop` audit event
  plus a log line make the no-op visible rather than fully silent.
  - Rationale: `RotateSecret` is also called internally by the auto-rotation
    scheduler (`rotateOneSecret`, "system:auto-rotation") and by
    `RollbackSecret` — neither expects, or gracefully handles, a hard error
    for what they consider a successful rotation call. Hard-erroring here
    would turn an edge case (a misbehaving/misconfigured rotation backend, or
    a rollback landing on a value the current version already holds) into an
    automation-breaking failure. Skipping the timestamp instead fixes the
    false "recently rotated" signal without risking that regression, while
    the new audit event keeps the no-op fully traceable for auditors.

## Test plan

- [x] Added `internal/core/rotate_noop_test.go`:
  - `TestRotateSecret_SameValue_DoesNotBumpLastRotatedAt` — rotating to the
    byte-identical value does not change `LastRotatedAt`, still stores a new
    version row, and records exactly one `secret.rotate_noop` audit event; a
    subsequent rotation to a genuinely different value resumes bumping the
    timestamp normally.
  - `TestRotateSecret_DifferentValue_AlwaysBumpsLastRotatedAt` — sanity check
    that an ordinary rotation is unaffected.
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/core/...` (full suite, clean)
- [x] `gosec -severity medium -exclude-generated ./internal/core/...` (0 issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)