### PR TITLE
fix(core): degrade access-review report on last-used query error (#453)

### DIFF
--- a/internal/core/access_review.go
+++ b/internal/core/access_review.go
@@ -41,6 +41,34 @@ type AccessReviewEntry struct {
 	LastUsedAt *time.Time `json:"last_used_at,omitempty"`
 }
 
+// AccessReviewReport is the full access-review result for a project: every
+// grant (Entries) plus a signal for whether it is complete. #453: on
+// storage.type: remote, LastUserSecretActivity is unconditionally unimplemented
+// (see internal/storage/store/remote_access_activity.go), so this
+// human-facing, compliance-critical report's dormant-access signal
+// (LastUsedAt) was silently left nil for every entry with no indication
+// anything was missing — indistinguishable from "genuinely never used" for
+// the deployment's entire lifetime under that backend. Degraded +
+// DegradedReasons make that detectable, mirroring CompliancePosture.Degraded
+// (compliance_posture.go) and SecretAccessorsResult.Degraded
+// (secret_access_list.go, #417).
+type AccessReviewReport struct {
+	Entries []*AccessReviewEntry `json:"entries"`
+	// Degraded is true when the last-secret-access lookup could not be queried —
+	// every entry's LastUsedAt is then unknown, never verified "never used".
+	Degraded bool `json:"degraded"`
+	// DegradedReasons names the failed sub-query with its underlying error.
+	DegradedReasons []string `json:"degraded_reasons,omitempty"`
+}
+
+// degrade records that a sub-query of the access review could not be answered:
+// it flips Degraded and appends a human-readable reason, mirroring
+// CompliancePosture.degrade (compliance_posture.go).
+func (r *AccessReviewReport) degrade(area string, err error) {
+	r.Degraded = true
+	r.DegradedReasons = append(r.DegradedReasons, fmt.Sprintf("%s: %v", area, err))
+}
+
 // secretsActionRank orders secrets.* actions so a review reports the strongest
 // access a role confers.
 var secretsActionRank = map[string]int{"read": 1, "write": 2, "delete": 3, "admin": 4}
@@ -63,8 +91,11 @@ func highestSecretsAction(perms []*models.Permission) string {
 // GenerateProjectAccessReview returns every grant of access to a project's secrets
 // (ISO 27001 A.5.18): the role-based standing access (project-scoped role grants
 // whose role confers a secrets.* permission) and the per-secret grants (ownership
-// and direct/group shares). Each entry's Source identifies the mechanism.
-func (c *KeyorixCore) GenerateProjectAccessReview(ctx context.Context, projectID uint) ([]*AccessReviewEntry, error) {
+// and direct/group shares). Each entry's Source identifies the mechanism. The
+// returned report's Degraded/DegradedReasons signal when the dormant-access
+// annotation (LastUsedAt) could not be computed, rather than silently reading as
+// "no entry has ever been used" (#453).
+func (c *KeyorixCore) GenerateProjectAccessReview(ctx context.Context, projectID uint) (*AccessReviewReport, error) {
 	if projectID == 0 {
 		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "project ID is required")
 	}
@@ -205,8 +236,14 @@ func (c *KeyorixCore) GenerateProjectAccessReview(ctx context.Context, projectID
 		}
 	}
 
+	report := &AccessReviewReport{Entries: entries}
+
 	// Annotate user principals with their last secret-access time (dormant-access
-	// detection). Best-effort: a lookup failure simply leaves LastUsedAt nil.
+	// detection). #453: on storage.type: remote, LastUserSecretActivity is
+	// unconditionally unimplemented, so a lookup failure must not silently leave
+	// every LastUsedAt at nil with no signal — that reads identically to
+	// "genuinely never used" for this compliance-critical report's entire
+	// lifetime under that backend. Record the gap instead.
 	if activity, err := c.storage.LastUserSecretActivity(ctx, projectID); err == nil {
 		for _, e := range entries {
 			if e.PrincipalType == "user" {
@@ -216,8 +253,10 @@ func (c *KeyorixCore) GenerateProjectAccessReview(ctx context.Context, projectID
 				}
 			}
 		}
+	} else {
+		report.degrade(fmt.Sprintf("last_used:project=%d", projectID), err)
 	}
-	return entries, nil
+	return report, nil
 }
 
 // listAllProjectSecrets pages through every secret in a project (no silent cap).

--- a/internal/core/access_review_campaign.go
+++ b/internal/core/access_review_campaign.go
@@ -78,10 +78,11 @@ func (c *KeyorixCore) OpenAccessReviewCampaign(ctx context.Context, actorID, pro
 	if projectID == 0 {
 		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "project ID is required")
 	}
-	entries, err := c.GenerateProjectAccessReview(ctx, projectID)
+	report, err := c.GenerateProjectAccessReview(ctx, projectID)
 	if err != nil {
 		return nil, err
 	}
+	entries := report.Entries
 	if name == "" {
 		name = "Access review"
 	}

--- a/internal/core/access_review_campaign_external_test.go
+++ b/internal/core/access_review_campaign_external_test.go
@@ -82,10 +82,10 @@ func TestDecideAccessReviewItem_AttestAndRevoke(t *testing.T) {
 	assert.Equal(t, 0, after.Progress.Pending)
 
 	// bob's editor/viewer grant is actually gone from the live review; alice's stays.
-	review, err := h.CoreService.GenerateProjectAccessReview(ctx, proj)
+	report, err := h.CoreService.GenerateProjectAccessReview(ctx, proj)
 	require.NoError(t, err)
 	var names []string
-	for _, e := range review {
+	for _, e := range report.Entries {
 		names = append(names, e.PrincipalName)
 	}
 	assert.Contains(t, names, "alice")

--- a/internal/core/access_review_external_test.go
+++ b/internal/core/access_review_external_test.go
@@ -34,12 +34,12 @@ func TestGenerateProjectAccessReview(t *testing.T) {
 	h.CreateTestGroup(t, "devs", "", 100)
 	h.AssignGroupRole(t, 100, 4, uptr(proj))
 
-	review, err := h.CoreService.GenerateProjectAccessReview(context.Background(), proj)
+	report, err := h.CoreService.GenerateProjectAccessReview(context.Background(), proj)
 	require.NoError(t, err)
 
 	type got struct{ typ, name, level string }
 	var rows []got
-	for _, e := range review {
+	for _, e := range report.Entries {
 		rows = append(rows, got{e.PrincipalType, e.PrincipalName, e.AccessLevel})
 	}
 	assert.ElementsMatch(t, []got{
@@ -67,11 +67,11 @@ func TestGenerateProjectAccessReview_IncludesMachineIdentities(t *testing.T) {
 		MachineIdentityID: 50, RoleID: 3, ProjectID: proj,
 	}).Error)
 
-	review, err := h.CoreService.GenerateProjectAccessReview(context.Background(), proj)
+	report, err := h.CoreService.GenerateProjectAccessReview(context.Background(), proj)
 	require.NoError(t, err)
 
 	var found *core.AccessReviewEntry
-	for _, e := range review {
+	for _, e := range report.Entries {
 		if e.PrincipalType == "machine" {
 			found = e
 		}
@@ -126,12 +126,12 @@ func TestGenerateProjectAccessReview_SharesAndOwnership(t *testing.T) {
 	require.NoError(t, h.DB.Create(&models.ShareRecord{SecretID: 500, RecipientID: 11, IsGroup: false, Permission: "read"}).Error)
 	require.NoError(t, h.DB.Create(&models.ShareRecord{SecretID: 500, RecipientID: 100, IsGroup: true, Permission: "write"}).Error)
 
-	review, err := h.CoreService.GenerateProjectAccessReview(context.Background(), proj)
+	report, err := h.CoreService.GenerateProjectAccessReview(context.Background(), proj)
 	require.NoError(t, err)
 
 	type got struct{ source, typ, name, level, secret string }
 	var rows []got
-	for _, e := range review {
+	for _, e := range report.Entries {
 		rows = append(rows, got{e.Source, e.PrincipalType, e.PrincipalName, e.AccessLevel, e.SecretName})
 	}
 	assert.Contains(t, rows, got{"owner", "user", "alice", "owner", "db-pw"})
@@ -159,7 +159,7 @@ func TestRevokeAccessReviewGrant_Role(t *testing.T) {
 	ctx := context.Background()
 	before, err := h.CoreService.GenerateProjectAccessReview(ctx, proj)
 	require.NoError(t, err)
-	require.Len(t, before, 1, "alice's editor grant is present before revoke")
+	require.Len(t, before.Entries, 1, "alice's editor grant is present before revoke")
 
 	err = h.CoreService.RevokeAccessReviewGrant(ctx, 1, proj, core.AccessReviewDecision{
 		Source: "role", PrincipalType: "user", PrincipalID: 10, RoleID: 3,
@@ -168,7 +168,7 @@ func TestRevokeAccessReviewGrant_Role(t *testing.T) {
 
 	after, err := h.CoreService.GenerateProjectAccessReview(ctx, proj)
 	require.NoError(t, err)
-	assert.Empty(t, after, "alice's role grant is gone after revoke")
+	assert.Empty(t, after.Entries, "alice's role grant is gone after revoke")
 }
 
 // Revoking a group share removes that ShareRecord; revoking ownership is refused.
@@ -193,9 +193,9 @@ func TestRevokeAccessReviewGrant_ShareAndOwner(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	review, err := h.CoreService.GenerateProjectAccessReview(ctx, proj)
+	report, err := h.CoreService.GenerateProjectAccessReview(ctx, proj)
 	require.NoError(t, err)
-	for _, e := range review {
+	for _, e := range report.Entries {
 		assert.NotEqual(t, "group_share", e.Source, "the group share is gone after revoke")
 	}
 
@@ -262,9 +262,9 @@ func TestAttestAccessReviewGrant_AuditsDecision(t *testing.T) {
 	require.NoError(t, err)
 
 	// The grant is untouched — still in the review.
-	review, err := h.CoreService.GenerateProjectAccessReview(ctx, proj)
+	report, err := h.CoreService.GenerateProjectAccessReview(ctx, proj)
 	require.NoError(t, err)
-	assert.Len(t, review, 1, "attest does not change access")
+	assert.Len(t, report.Entries, 1, "attest does not change access")
 
 	var count int64
 	require.NoError(t, h.DB.Model(&models.AuditEvent{}).

--- a/internal/core/dormant_access_external_test.go
+++ b/internal/core/dormant_access_external_test.go
@@ -34,11 +34,12 @@ func TestGenerateProjectAccessReview_AnnotatesLastUsed(t *testing.T) {
 	require.NoError(t, h.DB.Create(&models.AuditEvent{EventType: "secret.read", UserID: &aid, ProjectID: &pid, EventTime: older}).Error)
 	require.NoError(t, h.DB.Create(&models.AuditEvent{EventType: "secret.read", UserID: &aid, ProjectID: &pid, EventTime: newer}).Error)
 
-	review, err := h.CoreService.GenerateProjectAccessReview(ctx, proj)
+	report, err := h.CoreService.GenerateProjectAccessReview(ctx, proj)
 	require.NoError(t, err)
+	require.False(t, report.Degraded, "audit_events is migrated with valid data — the lookup must not degrade")
 
 	var alice, bob *core.AccessReviewEntry
-	for _, e := range review {
+	for _, e := range report.Entries {
 		switch e.PrincipalName {
 		case "alice":
 			alice = e
@@ -70,8 +71,38 @@ func TestGenerateProjectAccessReview_LastUsedIsProjectScoped(t *testing.T) {
 		EventType: "secret.read", UserID: &aid, ProjectID: &otherProj, EventTime: time.Now(),
 	}).Error)
 
-	review, err := h.CoreService.GenerateProjectAccessReview(ctx, proj)
+	report, err := h.CoreService.GenerateProjectAccessReview(ctx, proj)
 	require.NoError(t, err)
-	require.Len(t, review, 1)
-	assert.Nil(t, review[0].LastUsedAt, "activity in project 3 doesn't count for project 2")
+	require.Len(t, report.Entries, 1)
+	assert.Nil(t, report.Entries[0].LastUsedAt, "activity in project 3 doesn't count for project 2")
+}
+
+// #453: on storage.type: remote, LastUserSecretActivity is unconditionally
+// unimplemented (internal/storage/store/remote_access_activity.go), and the
+// access-review report's caller previously silently swallowed that error —
+// every entry's LastUsedAt read as nil with no signal, indistinguishable from
+// "genuinely never used". Simulating the same failure mode locally (the
+// audit_events table is unmigrated, so the underlying query errors) must now
+// flip Degraded rather than silently produce a report that looks complete.
+func TestGenerateProjectAccessReview_DegradedOnLastUsedQueryError(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	// models.AuditEvent deliberately NOT migrated → LastUserSecretActivity's raw
+	// "audit_events" table query fails, mirroring
+	// TestGetCompliancePosture_DegradedOnDormantRoleGrantsActivityQueryError
+	// (compliance_posture_test.go).
+
+	const proj = uint(2)
+	ctx := context.Background()
+	h.CreateTestUser(t, "alice", 10)
+	h.AssignUserRole(t, 10, 3, uptr(proj)) // editor → write
+
+	report, err := h.CoreService.GenerateProjectAccessReview(ctx, proj)
+	require.NoError(t, err)
+
+	require.Len(t, report.Entries, 1)
+	assert.Nil(t, report.Entries[0].LastUsedAt, "the field itself still reads as its zero value — no visible dormant/active signal")
+	assert.True(t, report.Degraded, "an unqueryable last-used lookup must flip Degraded rather than silently read as no entry ever used")
+	require.NotEmpty(t, report.DegradedReasons)
+	assert.Contains(t, report.DegradedReasons[0], "last_used:project=2")
 }

--- a/server/http/handlers/project_members.go
+++ b/server/http/handlers/project_members.go
@@ -38,13 +38,21 @@ func (h *CatalogHandler) GetProjectAccessReview(w http.ResponseWriter, r *http.R
 		sendError(w, "InvalidParameter", "Invalid project ID", http.StatusBadRequest, nil)
 		return
 	}
-	entries, err := h.coreService.GenerateProjectAccessReview(r.Context(), uint(id))
+	report, err := h.coreService.GenerateProjectAccessReview(r.Context(), uint(id))
 	if err != nil {
 		log.Printf("Error generating access review for project %d: %v", id, err)
 		sendError(w, "Error", clientSafe(err), http.StatusInternalServerError, nil)
 		return
 	}
-	sendSuccess(w, map[string]interface{}{"entries": entries, "count": len(entries)}, "")
+	// #453: degraded/degraded_reasons must reach API consumers — a report whose
+	// dormant-access annotation silently failed would otherwise look identical to
+	// one where every entry genuinely has no recorded access.
+	sendSuccess(w, map[string]interface{}{
+		"entries":          report.Entries,
+		"count":            len(report.Entries),
+		"degraded":         report.Degraded,
+		"degraded_reasons": report.DegradedReasons,
+	}, "")
 }
 
 // accessReviewDecisionBody is the request body for a recertification decision on


### PR DESCRIPTION
## Summary
- `GenerateProjectAccessReview` silently swallowed `LastUserSecretActivity`'s error — genuinely unimplemented on `storage.type: remote` (`internal/storage/store/remote_access_activity.go`) — leaving every entry's `LastUsedAt` at nil with no signal, indistinguishable from "genuinely never used" for the deployment's entire lifetime under that backend.
- Same underlying storage call as `compliance_posture.go`'s `countDormantRoleGrants`, already fixed via the `Degraded`/`DegradedReasons` mechanism (`cp.degrade(...)`) — this was the one remaining consumer.
- `GenerateProjectAccessReview` now returns a new `AccessReviewReport` (`Entries` + `Degraded`/`DegradedReasons`) instead of a bare `[]*AccessReviewEntry`, mirroring `CompliancePosture.degrade` and `SecretAccessorsResult.degrade` (#417).
- `GetProjectAccessReview` HTTP handler (`GET /api/v1/projects/{id}/access-review`) now surfaces `degraded`/`degraded_reasons` alongside `entries`/`count`.
- Updated all existing callers/tests to the new return type (`OpenAccessReviewCampaign`, `access_review_external_test.go`, `access_review_campaign_external_test.go`, `dormant_access_external_test.go`).

## Test plan
- [x] Added `TestGenerateProjectAccessReview_DegradedOnLastUsedQueryError` — leaves `AuditEvent` unmigrated (mirroring `TestGetCompliancePosture_DegradedOnDormantRoleGrantsActivityQueryError`) so `LastUserSecretActivity`'s raw query fails, and asserts `Degraded == true` with a `last_used:project=...` reason instead of a silently-complete-looking report.
- [x] Added an explicit `Degraded == false` assertion to the existing happy-path `TestGenerateProjectAccessReview_AnnotatesLastUsed`.
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/core/... ./internal/storage/store/... ./server/http/handlers/...` — all pass
- [x] `gosec -severity medium -exclude-generated` scoped to touched packages — 0 issues (some sandbox-local build-cache noise for the `core` package's SSA pass, unrelated to this change)

Refs #453