### PR TITLE
fix(http): gate /openapi.yaml on swagger_enabled like the Swagger UI (#224)

### DIFF
--- a/server/http/router.go
+++ b/server/http/router.go
@@ -790,13 +790,15 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		})
 	})
 
-	// Swagger UI (optional, based on config)
+	// Swagger UI and the raw OpenAPI spec are both dev/docs surfaces gated by the
+	// same swagger_enabled toggle (#224). The spec was previously registered
+	// unconditionally, so disabling swagger_enabled in production hid the UI but
+	// still served /openapi.yaml — a full unauthenticated map of every API route
+	// and schema. Register both, or neither, behind the one config check.
 	if cfg.Server.HTTP.SwaggerEnabled {
 		r.Mount("/swagger/", handlers.SwaggerHandler())
+		r.Get("/openapi.yaml", handlers.OpenAPISpec)
 	}
-
-	// OpenAPI spec endpoint
-	r.Get("/openapi.yaml", handlers.OpenAPISpec)
 
 	// Serve the web dashboard. Prefer an on-disk build (mounted in the Docker
 	// stack, or present in dev); otherwise fall back to the build embedded in the

--- a/server/http/static_hardening_test.go
+++ b/server/http/static_hardening_test.go
@@ -99,3 +99,50 @@ func TestNotFound_BackendRoutePrefixesReturn404(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Contains(t, body, "Keyorix")
 }
+
+// TestOpenAPISpec_RespectsSwaggerEnabled pins #224: /openapi.yaml used to be
+// registered unconditionally, so it stayed fully reachable (unauthenticated)
+// even with swagger_enabled turned off for production hardening — silently
+// bypassing the very toggle meant to disable it. It must now be gated by the
+// same swagger_enabled config as the Swagger UI mount, with matching
+// on/off behavior (404 when disabled, served when enabled).
+func TestOpenAPISpec_RespectsSwaggerEnabled(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	t.Cleanup(i18n.ResetForTesting)
+	client := &http.Client{}
+
+	t.Run("disabled by default", func(t *testing.T) {
+		cfg := &config.Config{}
+		router, err := NewRouter(cfg, newTestCore(t))
+		require.NoError(t, err)
+		srv := httptest.NewServer(router)
+		t.Cleanup(srv.Close)
+
+		resp, err := client.Get(srv.URL + "/openapi.yaml")
+		require.NoError(t, err)
+		_ = resp.Body.Close()
+		assert.Equal(t, http.StatusNotFound, resp.StatusCode, "GET /openapi.yaml must 404 when swagger_enabled is off")
+
+		// The Swagger UI mount must be gated the same way.
+		resp, err = client.Get(srv.URL + "/swagger/")
+		require.NoError(t, err)
+		_ = resp.Body.Close()
+		assert.Equal(t, http.StatusNotFound, resp.StatusCode, "GET /swagger/ must 404 when swagger_enabled is off")
+	})
+
+	t.Run("enabled", func(t *testing.T) {
+		cfg := &config.Config{}
+		cfg.Server.HTTP.SwaggerEnabled = true
+		router, err := NewRouter(cfg, newTestCore(t))
+		require.NoError(t, err)
+		srv := httptest.NewServer(router)
+		t.Cleanup(srv.Close)
+
+		resp, err := client.Get(srv.URL + "/openapi.yaml")
+		require.NoError(t, err)
+		body := readAll(t, resp.Body)
+		_ = resp.Body.Close()
+		assert.Equal(t, http.StatusOK, resp.StatusCode, "GET /openapi.yaml must be served normally when swagger_enabled is on")
+		assert.NotEmpty(t, body)
+	})
+}


### PR DESCRIPTION
## Summary
- `/openapi.yaml` was registered unconditionally in `server/http/router.go`, right after the `swagger_enabled`-gated Swagger UI mount, so it stayed fully reachable and unauthenticated in production even when `swagger_enabled` was turned off for hardening (#224).
- Moved `r.Get("/openapi.yaml", handlers.OpenAPISpec)` inside the same `if cfg.Server.HTTP.SwaggerEnabled` block as the `/swagger/` mount, so both are registered, or neither is.
- When disabled, `/openapi.yaml` now hits the router's existing `NotFound` handler (already covers `/openapi.yaml` in `backendRoutePrefixes`) and returns a clean 404 — the same behavior `/swagger/` already had when disabled. No default value for `swagger_enabled` changed (still off unless explicitly set, per `docs/CONFIGURATION.md`).

## Test plan
- [x] Added `TestOpenAPISpec_RespectsSwaggerEnabled` in `server/http/static_hardening_test.go`: 404 for `/openapi.yaml` and `/swagger/` when `swagger_enabled` is off (default), 200 with a real spec body when it's on.
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./server/...`
- [x] `gosec -severity medium -exclude-generated ./server/...` (0 issues)