### PR TITLE
harden(docker): move keyorix-mcp/keyorix-k8s-sync to distroless, strip apk from server (#242)

### DIFF
--- a/cmd/keyorix-k8s-sync/Dockerfile
+++ b/cmd/keyorix-k8s-sync/Dockerfile
@@ -14,11 +14,10 @@ RUN CGO_ENABLED=0 go build \
     -ldflags "-X github.com/keyorixhq/keyorix/internal/cli.version=${VERSION} -X github.com/keyorixhq/keyorix/internal/version.Version=${VERSION} -X github.com/keyorixhq/keyorix/internal/version.Commit=${GIT_COMMIT}" \
     -trimpath -o /out/keyorix-k8s-sync ./cmd/keyorix-k8s-sync
 
-# Runtime stage — minimal, non-root. ca-certificates lets the agent reach the
-# Keyorix server over HTTPS; the Kubernetes API is trusted via the mounted SA CA.
-FROM alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
-RUN apk add --no-cache ca-certificates tzdata
-RUN addgroup -g 1001 keyorix && adduser -D -s /bin/sh -u 1001 -G keyorix keyorix
+# Runtime stage — distroless static, non-root (no shell, no package manager). The agent
+# reaches the Keyorix server over HTTPS (CA bundle baked into the static base) and the
+# Kubernetes API via the mounted ServiceAccount CA; it needs no shell/wget at runtime.
+FROM gcr.io/distroless/static:nonroot@sha256:963fa6c544fe5ce420f1f54fb88b6fb01479f054c8056d0f74cc2c6000df5240
 COPY --from=builder /out/keyorix-k8s-sync /usr/local/bin/keyorix-k8s-sync
-USER keyorix
+USER 65532:65532
 ENTRYPOINT ["keyorix-k8s-sync"]

--- a/cmd/keyorix-mcp/Dockerfile
+++ b/cmd/keyorix-mcp/Dockerfile
@@ -10,11 +10,10 @@ RUN CGO_ENABLED=0 go build \
     -ldflags "-X main.version=${VERSION}" \
     -trimpath -o /out/keyorix-mcp ./cmd/keyorix-mcp
 
-# Runtime stage — minimal, non-root. ca-certificates lets the server reach the Keyorix
-# API over HTTPS. The MCP server speaks JSON-RPC over stdio, so there is no exposed port.
-FROM alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
-RUN apk add --no-cache ca-certificates tzdata
-RUN addgroup -g 1001 keyorix && adduser -D -s /bin/sh -u 1001 -G keyorix keyorix
+# Runtime stage — distroless static, non-root (no shell, no package manager). The MCP
+# server speaks JSON-RPC over stdio (no exposed port) and reaches the Keyorix API over
+# HTTPS using the CA bundle baked into the static base; it needs no shell/wget at runtime.
+FROM gcr.io/distroless/static:nonroot@sha256:963fa6c544fe5ce420f1f54fb88b6fb01479f054c8056d0f74cc2c6000df5240
 COPY --from=builder /out/keyorix-mcp /usr/local/bin/keyorix-mcp
-USER keyorix
+USER 65532:65532
 ENTRYPOINT ["keyorix-mcp"]

--- a/deploy/helm/keyorix-k8s-sync/templates/deployment.yaml
+++ b/deploy/helm/keyorix-k8s-sync/templates/deployment.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: {{ include "kxsync.serviceAccountName" . }}
       securityContext:
         runAsNonRoot: true
-        runAsUser: 1001
+        runAsUser: 65532  # matches the distroless:nonroot image user
         seccompProfile:
           type: RuntimeDefault
       containers:

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -14,8 +14,20 @@ RUN go build -ldflags "-X github.com/keyorixhq/keyorix/internal/cli.version=${VE
     -o bin/keyorix-server ./server
 
 # Runtime stage
+#
+# NOTE on distroless (backlog #242): entrypoint.sh needs a real shell plus `wget`,
+# `mktemp`, `trap`, and `seq` for its first-boot admin-bootstrap logic (waiting for
+# /health, then POSTing the initial admin via wget --post-file). distroless/static
+# and distroless/base have no shell or busybox utilities at all, so a direct swap
+# would break that bootstrap flow. Moving the bootstrap into the Go binary itself
+# (invoked via a flag) would remove the need for the shell script entirely and let
+# this image go fully distroless, but that's a larger refactor than this hardening
+# round should attempt — tracked as a follow-up. In the meantime we keep Alpine but
+# strip the `apk` package manager (binary + package db) once the packages we need
+# are installed, so RCE inside this container can no longer `apk add` extra tooling.
 FROM alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
-RUN apk add --no-cache ca-certificates tzdata
+RUN apk add --no-cache ca-certificates tzdata && \
+    rm -rf /sbin/apk /etc/apk /lib/apk /usr/share/apk /var/cache/apk
 RUN addgroup -g 1001 keyorix && \
     adduser -D -s /bin/sh -u 1001 -G keyorix keyorix
 WORKDIR /app


### PR DESCRIPTION
## Summary

Backlog #242: `server/Dockerfile`, `cmd/keyorix-mcp/Dockerfile`, and
`cmd/keyorix-k8s-sync/Dockerfile` all shipped a full Alpine runtime (shell +
apk + wget) in their final stage, unlike `operator/Dockerfile`, which already
uses distroless. That gives post-RCE lateral movement (shell to explore, apk
to install more tools, wget to exfiltrate) a container really doesn't need.

**`cmd/keyorix-mcp/Dockerfile` and `cmd/keyorix-k8s-sync/Dockerfile`: moved to
`gcr.io/distroless/static:nonroot`** (same base/pattern as
`operator/Dockerfile`). Both binaries `ENTRYPOINT` straight into the Go
binary — no shell script, no `wget` calls, no `os/user`/tzdata usage anywhere
in their dependency graphs (verified via `go list -deps`). CA certs come
baked into the static base, matching the existing operator comment/pattern.
Also bumped `deploy/helm/keyorix-k8s-sync/templates/deployment.yaml`'s
`runAsUser` from `1001` to `65532` to match the new nonroot UID (mirrors the
`keyorix-operator` chart's existing `runAsUser: 65532` convention).

**`server/Dockerfile`: left on Alpine, hardened in place.**
`server/entrypoint.sh` (post-#241 fix, already merged) genuinely needs a real
shell plus `wget`, `mktemp`, `trap`, and `seq` for its first-boot
admin-bootstrap flow (poll `/health`, then `wget --post-file` the initial
admin). distroless/static and distroless/base ship no shell/busybox at all,
so swapping the base directly would break that bootstrap. Doing it properly
would mean moving the bootstrap logic into the Go binary itself (a CLI flag),
which is a bigger, riskier refactor than this round should attempt — flagged
below as follow-up. Instead, this PR strips the `apk` package manager
(`/sbin/apk`, `/etc/apk`, `/lib/apk`, `/usr/share/apk`, `/var/cache/apk`)
right after installing `ca-certificates`/`tzdata`, so RCE inside the
container can no longer `apk add` extra tooling — `sh`/`wget`/`mktemp`/`seq`
(needed by entrypoint.sh) remain, but the package manager doesn't.

## Verification

Docker is available locally; I built all three images directly:
- `docker build -f server/Dockerfile .` — succeeds; confirmed inside the
  built image that `apk` is gone (`which apk` → not found) while
  `wget`/`sh`/`mktemp`/`seq` (entrypoint.sh's dependencies) are all present.
- `docker build -f cmd/keyorix-mcp/Dockerfile .` — succeeds against the new
  distroless base.
- `docker build -f cmd/keyorix-k8s-sync/Dockerfile .` — succeeds against the
  new distroless base.
- `go build ./...` and `go list -deps` for both cmd packages — clean, and
  confirm neither imports `internal/core` (the only place using
  `time.LoadLocation`, which needs tzdata not present in distroless/static).

## Follow-up (not attempted here)

Move `server/entrypoint.sh`'s first-boot admin-bootstrap logic into the Go
binary (e.g. `keyorix-server --bootstrap-admin`), so the shell script — and
the shell/wget dependency it creates — goes away and `server/Dockerfile` can
also move to distroless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)