### PR TITLE
fix(notifications): escalate stale reminder severity instead of freezing (#250)

### DIFF
--- a/internal/core/expiry_reminders.go
+++ b/internal/core/expiry_reminders.go
@@ -20,8 +20,13 @@ const NotificationExpiryReminder = "secret.expiry_reminder"
 // SendExpiryReminders finds every secret expiring within leadDays (or already expired)
 // and, for each project with such secrets, sends ONE standing digest notification to
 // each of that project's admins. De-duplicates like rotation reminders: an admin who
-// already has an unread expiry reminder for the project is not re-notified. leadDays <= 0
-// falls back to the default lead window. Returns the number of notifications created.
+// already has an unread expiry reminder for the project is not re-notified. It also
+// compares the newly computed severity (already expired is more severe than merely
+// expiring soon) against what an existing unread reminder was recorded with: an
+// escalation updates the standing reminder in place rather than being silently
+// suppressed, so an unread reminder can't freeze at a stale, now-superseded severity
+// (#250). leadDays <= 0 falls back to the default lead window. Returns the number of
+// notifications created or escalated.
 func (c *KeyorixCore) SendExpiryReminders(ctx context.Context, leadDays int) (int, error) {
 	if leadDays <= 0 {
 		leadDays = defaultExpiryLeadDays
@@ -62,20 +67,36 @@ func (c *KeyorixCore) SendExpiryReminders(ctx context.Context, leadDays int) (in
 			continue
 		}
 		pid := projectID
+		title := "Secrets expiring"
 		msg := expiryReminderMessage(c.projectLabel(ctx, projectID), ct.expired, ct.soon)
+		severity := expirySeverity(ct.expired)
 		for _, mbr := range members {
 			if !isApproverRole(mbr.RoleName) {
 				continue
 			}
-			if c.hasUnreadExpiryReminder(ctx, mbr.UserID, projectID) {
-				continue // a standing reminder already exists — don't pile up
+			if existing := c.unreadExpiryReminder(ctx, mbr.UserID, projectID); existing != nil {
+				if severity <= existing.Severity {
+					continue // no worse than what's already standing — don't pile up
+				}
+				if c.upgradeReminder(ctx, existing, title, msg, severity) {
+					sent++ // escalated in place (#250): expiring soon → now expired
+				}
+				continue
 			}
-			c.notify(ctx, mbr.UserID, NotificationExpiryReminder,
-				"Secrets expiring", msg, &pid, "/secrets/expiry")
+			c.notifyWithSeverity(ctx, mbr.UserID, NotificationExpiryReminder, title, msg, &pid, "/secrets/expiry", severity)
 			sent++
 		}
 	}
 	return sent, nil
+}
+
+// expirySeverity ranks a project's expiry state: any already-expired secret is
+// strictly more severe than merely having secrets expiring soon (#250).
+func expirySeverity(expired int) models.NotificationSeverity {
+	if expired > 0 {
+		return models.NotificationSeverityCritical
+	}
+	return models.NotificationSeverityWarning
 }
 
 const (
@@ -103,19 +124,19 @@ func (c *KeyorixCore) listSecretsExpiringBefore(ctx context.Context, cutoff time
 	return all, nil
 }
 
-// hasUnreadExpiryReminder reports whether the user already has an unread expiry-reminder
-// notification for the given project.
-func (c *KeyorixCore) hasUnreadExpiryReminder(ctx context.Context, userID, projectID uint) bool {
+// unreadExpiryReminder returns the user's existing unread expiry-reminder
+// notification for the given project, or nil if none exists.
+func (c *KeyorixCore) unreadExpiryReminder(ctx context.Context, userID, projectID uint) *models.Notification {
 	notes, err := c.storage.ListNotifications(ctx, userID, true, 100)
 	if err != nil {
-		return false // on a read error, prefer notifying over silently skipping
+		return nil // on a read error, prefer notifying over silently skipping
 	}
 	for _, n := range notes {
 		if n.Type == NotificationExpiryReminder && n.ProjectID != nil && *n.ProjectID == projectID {
-			return true
+			return n
 		}
 	}
-	return false
+	return nil
 }
 
 func expiryReminderMessage(project string, expired, soon int) string {

--- a/internal/core/expiry_reminders_test.go
+++ b/internal/core/expiry_reminders_test.go
@@ -84,6 +84,70 @@ func TestSendExpiryReminders(t *testing.T) {
 	assert.Equal(t, 1, sent, "after reading, still-expiring secrets re-notify")
 }
 
+// TestSendExpiryReminders_EscalatesOnMoreSevereState is a regression test for
+// #250: an unread standing expiry reminder recorded at Warning (expiring soon)
+// must be escalated in place — not silently suppressed — once the secret has
+// genuinely expired (Critical) while that reminder is still unread.
+func TestSendExpiryReminders_EscalatesOnMoreSevereState(t *testing.T) {
+	ctx := context.Background()
+	c, db, _ := newExpiryReminderCore(t)
+	// Drop the already-expired secret; only the "soon" secret remains due →
+	// first run is Warning-only.
+	require.NoError(t, db.Where("id = ?", 10).Delete(&models.SecretNode{}).Error)
+
+	sent, err := c.SendExpiryReminders(ctx, 14)
+	require.NoError(t, err)
+	require.Equal(t, 1, sent)
+
+	var note models.Notification
+	require.NoError(t, db.Where("type = ?", NotificationExpiryReminder).First(&note).Error)
+	assert.Equal(t, models.NotificationSeverityWarning, note.Severity)
+	firstID := note.ID
+
+	// Now that secret has also expired (soon-key's expiry moved into the past)
+	// while the Warning reminder is still unread: escalate to Critical.
+	require.NoError(t, db.Model(&models.SecretNode{}).Where("id = ?", 11).
+		Update("expiration", note.CreatedAt.AddDate(0, 0, -1)).Error)
+
+	sent, err = c.SendExpiryReminders(ctx, 14)
+	require.NoError(t, err)
+	assert.Equal(t, 1, sent, "the escalation to expired must reach the admin")
+
+	var notes []models.Notification
+	require.NoError(t, db.Where("type = ?", NotificationExpiryReminder).Find(&notes).Error)
+	require.Len(t, notes, 1, "the standing reminder was updated in place, not duplicated")
+	assert.Equal(t, firstID, notes[0].ID)
+	assert.Equal(t, models.NotificationSeverityCritical, notes[0].Severity)
+	assert.Contains(t, notes[0].Message, "have expired")
+}
+
+// TestSendExpiryReminders_NoEscalation_SameOrLowerSeverity_NoNoise is the
+// inverse: a recheck that finds the state no worse than what's already
+// standing must not touch the notification or create noise.
+func TestSendExpiryReminders_NoEscalation_SameOrLowerSeverity_NoNoise(t *testing.T) {
+	ctx := context.Background()
+	c, db, _ := newExpiryReminderCore(t)
+
+	// Default fixture already has an expired secret → Critical on first run.
+	sent, err := c.SendExpiryReminders(ctx, 14)
+	require.NoError(t, err)
+	require.Equal(t, 1, sent)
+
+	var before models.Notification
+	require.NoError(t, db.Where("type = ?", NotificationExpiryReminder).First(&before).Error)
+	require.Equal(t, models.NotificationSeverityCritical, before.Severity)
+
+	// Still expired (same severity), still unread: no escalation, no noise.
+	sent, err = c.SendExpiryReminders(ctx, 14)
+	require.NoError(t, err)
+	assert.Equal(t, 0, sent, "an at-or-below-severity recheck must not notify again")
+
+	var after models.Notification
+	require.NoError(t, db.Where("type = ?", NotificationExpiryReminder).First(&after).Error)
+	assert.Equal(t, before.Message, after.Message)
+	assert.Equal(t, before.Severity, after.Severity)
+}
+
 func TestSendExpiryReminders_NothingDue(t *testing.T) {
 	ctx := context.Background()
 	c, db, _ := newExpiryReminderCore(t)

--- a/internal/core/license_expiry.go
+++ b/internal/core/license_expiry.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/license"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
 // NotificationLicenseExpiry is the in-app/external notification type for an offline
@@ -21,9 +22,13 @@ var globalAdminRoleNames = map[string]struct{}{
 
 // ScanLicenseExpiry checks the installed offline license and, when it is within leadDays of
 // expiry or already expired, notifies every install-wide admin (deduped so it does not spam
-// on each tick). It returns the number of notifications created. It is the proactive
-// counterpart to the fail-safe gate: a commercial license that lapses silently would
-// disable airgap_updates with no warning, so admins are reminded ahead of the lapse.
+// on each tick). It also compares the newly computed severity (an actually-expired license is
+// more severe than merely expiring soon) against what an existing unread reminder was recorded
+// with: an escalation updates the standing reminder in place rather than being silently
+// suppressed, so an unread reminder can't freeze at a stale, now-superseded severity (#250). It
+// returns the number of notifications created or escalated. It is the proactive counterpart to
+// the fail-safe gate: a commercial license that lapses silently would disable airgap_updates
+// with no warning, so admins are reminded ahead of the lapse.
 //
 // Only a validly-signed license with a real expiry triggers a reminder. No license
 // (community baseline) and an invalid/untrusted token are intentionally silent here — the
@@ -53,15 +58,31 @@ func (c *KeyorixCore) ScanLicenseExpiry(ctx context.Context, leadDays int) (int,
 		return 0, err
 	}
 	title, msg := licenseExpiryNotice(st)
+	severity := licenseExpirySeverity(st)
 	sent := 0
 	for _, uid := range admins {
-		if c.hasUnreadLicenseExpiry(ctx, uid) {
+		if existing := c.unreadLicenseExpiry(ctx, uid); existing != nil {
+			if severity <= existing.Severity {
+				continue // no worse than what's already standing — don't pile up
+			}
+			if c.upgradeReminder(ctx, existing, title, msg, severity) {
+				sent++ // escalated in place (#250): expiring soon → now expired
+			}
 			continue
 		}
-		c.notify(ctx, uid, NotificationLicenseExpiry, title, msg, nil, "/admin/license")
+		c.notifyWithSeverity(ctx, uid, NotificationLicenseExpiry, title, msg, nil, "/admin/license", severity)
 		sent++
 	}
 	return sent, nil
+}
+
+// licenseExpirySeverity ranks the license state: an already-expired license is
+// strictly more severe than merely expiring soon (#250).
+func licenseExpirySeverity(st license.Status) models.NotificationSeverity {
+	if st.State == license.StateExpired {
+		return models.NotificationSeverityCritical
+	}
+	return models.NotificationSeverityWarning
 }
 
 // globalAdminIDsPageSize bounds each page of the active-users walk in globalAdminIDs.
@@ -98,19 +119,20 @@ func (c *KeyorixCore) globalAdminIDs(ctx context.Context) ([]uint, error) {
 	return ids, nil
 }
 
-// hasUnreadLicenseExpiry reports whether the user already has an unread license-expiry
-// reminder, so a standing reminder is not re-created on every scheduler tick.
-func (c *KeyorixCore) hasUnreadLicenseExpiry(ctx context.Context, userID uint) bool {
+// unreadLicenseExpiry returns the user's existing unread license-expiry
+// reminder, or nil if none exists, so a standing reminder is not re-created on
+// every scheduler tick.
+func (c *KeyorixCore) unreadLicenseExpiry(ctx context.Context, userID uint) *models.Notification {
 	notes, err := c.storage.ListNotifications(ctx, userID, true, 100)
 	if err != nil {
-		return false // on read error, prefer notifying over silently skipping
+		return nil // on read error, prefer notifying over silently skipping
 	}
 	for _, n := range notes {
 		if n.Type == NotificationLicenseExpiry {
-			return true
+			return n
 		}
 	}
-	return false
+	return nil
 }
 
 // licenseExpiryNotice builds the admin reminder title + message for the license state.

--- a/internal/core/license_expiry_test.go
+++ b/internal/core/license_expiry_test.go
@@ -79,14 +79,43 @@ func TestScanLicenseExpiry_Dedup_NoResend(t *testing.T) {
 	admin := &models.User{ID: 2, Email: "admin@acme.test"}
 	ms.On("ListUsers", ctx, mock.Anything).Return([]*models.User{admin}, int64(1), nil)
 	ms.On("GetUserRoles", ctx, uint(2)).Return([]*models.Role{{Name: "admin"}}, nil)
-	// Already an unread license-expiry reminder → must not re-create.
+	// Already an unread license-expiry reminder, already at the severity this
+	// (not-yet-expired) gate warrants → must not re-create or escalate.
 	ms.On("ListNotifications", ctx, uint(2), true, 100).
-		Return([]*models.Notification{{ID: 9, Type: NotificationLicenseExpiry}}, nil)
+		Return([]*models.Notification{{ID: 9, Type: NotificationLicenseExpiry, Severity: models.NotificationSeverityWarning}}, nil)
 
 	n, err := c.ScanLicenseExpiry(ctx, 30)
 	require.NoError(t, err)
 	assert.Equal(t, 0, n)
 	ms.AssertNotCalled(t, "CreateNotification", mock.Anything, mock.Anything)
+	ms.AssertNotCalled(t, "UpdateNotification", mock.Anything, mock.Anything)
+}
+
+// TestScanLicenseExpiry_EscalatesOnExpiry is a regression test for #250: an
+// unread license-expiry reminder recorded at Warning (expiring soon) must be
+// escalated in place — not silently suppressed — once the license has
+// genuinely expired (Critical) while that reminder is still unread.
+func TestScanLicenseExpiry_EscalatesOnExpiry(t *testing.T) {
+	ctx := context.Background()
+	ms := new(MockStorage)
+	c := NewKeyorixCore(ms)
+	c.SetLicenseGate(gateWithExpiry(t, time.Now().Add(-3*time.Hour))) // well past NotAfter + grace
+
+	admin := &models.User{ID: 2, Email: "admin@acme.test"}
+	ms.On("ListUsers", ctx, mock.Anything).Return([]*models.User{admin}, int64(1), nil)
+	ms.On("GetUserRoles", ctx, uint(2)).Return([]*models.Role{{Name: "admin"}}, nil)
+	// Standing reminder was created back when the license was merely expiring soon.
+	existing := &models.Notification{ID: 9, UserID: 2, Type: NotificationLicenseExpiry, Severity: models.NotificationSeverityWarning}
+	ms.On("ListNotifications", ctx, uint(2), true, 100).Return([]*models.Notification{existing}, nil)
+	ms.On("UpdateNotification", ctx, mock.MatchedBy(func(n *models.Notification) bool {
+		return n.ID == 9 && n.Severity == models.NotificationSeverityCritical
+	})).Return(nil)
+
+	n, err := c.ScanLicenseExpiry(ctx, 30)
+	require.NoError(t, err)
+	assert.Equal(t, 1, n, "the escalation to expired must reach the admin")
+	ms.AssertNotCalled(t, "CreateNotification", mock.Anything, mock.Anything)
+	ms.AssertExpectations(t)
 }
 
 // TestGlobalAdminIDs_PaginatesActiveUsersBeyondOnePage pins the fix for an install

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -1784,6 +1784,18 @@ func (m *MockStorage) HasUnreadNotification(ctx context.Context, userID uint, nT
 	return args.Bool(0), args.Error(1)
 }
 
+func (m *MockStorage) GetUnreadNotification(ctx context.Context, userID uint, nType string, projectID uint) (*models.Notification, error) {
+	args := m.Called(ctx, userID, nType, projectID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.Notification), args.Error(1)
+}
+
+func (m *MockStorage) UpdateNotification(ctx context.Context, n *models.Notification) error {
+	return m.Called(ctx, n).Error(0)
+}
+
 func (m *MockStorage) MarkNotificationRead(ctx context.Context, id, userID uint) error {
 	return m.Called(ctx, id, userID).Error(0)
 }

--- a/internal/core/notifications.go
+++ b/internal/core/notifications.go
@@ -52,6 +52,16 @@ func isApproverRole(roleName string) bool {
 // notify creates one in-app notification, best-effort (errors are swallowed so a
 // failed insert can't roll back the triggering action).
 func (c *KeyorixCore) notify(ctx context.Context, userID uint, nType, title, message string, projectID *uint, link string) {
+	c.notifyWithSeverity(ctx, userID, nType, title, message, projectID, link, models.NotificationSeverityNone)
+}
+
+// notifyWithSeverity is notify plus a recorded NotificationSeverity (#250):
+// reminder schedulers (expiry/rotation/license) use this so a later recheck can
+// compare a newly computed severity against what's recorded here on the
+// standing unread reminder — see upgradeReminder. Notification types that don't
+// participate in escalation-aware dedup should keep using plain notify(), which
+// records NotificationSeverityNone.
+func (c *KeyorixCore) notifyWithSeverity(ctx context.Context, userID uint, nType, title, message string, projectID *uint, link string, severity models.NotificationSeverity) {
 	if userID == 0 {
 		return
 	}
@@ -62,9 +72,22 @@ func (c *KeyorixCore) notify(ctx context.Context, userID uint, nType, title, mes
 		Title:     title,
 		Message:   message,
 		Link:      link,
+		Severity:  severity,
 		CreatedAt: c.now(),
 	})
 	c.dispatchNotification(ctx, userID, nType, title, message, projectID, link)
+}
+
+// upgradeReminder overwrites Title/Message/Severity on an existing unread
+// standing reminder notification in place and persists it (#250). Used when a
+// recheck finds a strictly more severe state than what the notification was
+// last created/updated with, so the escalation reaches the user without
+// piling up a second unread notification of the same (user, type, project).
+// Returns whether the update succeeded (best-effort — a storage failure here
+// just means the stale reminder stands until the next tick).
+func (c *KeyorixCore) upgradeReminder(ctx context.Context, n *models.Notification, title, message string, severity models.NotificationSeverity) bool {
+	n.Title, n.Message, n.Severity = title, message, severity
+	return c.storage.UpdateNotification(ctx, n) == nil
 }
 
 // dispatchNotification fans a per-user notification out to the recipient-addressable

--- a/internal/core/rotation_reminders.go
+++ b/internal/core/rotation_reminders.go
@@ -6,6 +6,8 @@ package core
 import (
 	"context"
 	"fmt"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
 // NotificationRotationDue marks an in-app rotation-reminder notification.
@@ -16,7 +18,12 @@ const NotificationRotationDue = "rotation.reminder"
 // notification to each of that project's admins. It de-duplicates: an admin who
 // already has an unread rotation reminder for the project is not re-notified, so
 // reminders don't pile up — once they read it (and the secret is still overdue) the
-// next run nudges them again. Returns the number of notifications created.
+// next run nudges them again. It also compares the newly computed severity
+// (overdue is more severe than merely approaching) against what an existing
+// unread reminder was recorded with: an escalation (e.g. approaching → overdue)
+// updates the standing reminder in place rather than being silently suppressed,
+// so an unread reminder can't freeze at a stale, now-superseded severity (#250).
+// Returns the number of notifications created or escalated.
 func (c *KeyorixCore) SendRotationReminders(ctx context.Context) (int, error) {
 	evals, err := c.EvaluateRotationPolicies(ctx, nil, nil)
 	if err != nil {
@@ -56,34 +63,53 @@ func (c *KeyorixCore) SendRotationReminders(ctx context.Context) (int, error) {
 			continue
 		}
 		pid := projectID
+		title := "Secrets due for rotation"
 		msg := rotationReminderMessage(c.projectLabel(ctx, projectID), ct.overdue, ct.approaching)
+		severity := rotationSeverity(ct.overdue)
 		for _, mbr := range members {
 			if !isApproverRole(mbr.RoleName) {
 				continue
 			}
-			if c.hasUnreadRotationReminder(ctx, mbr.UserID, projectID) {
-				continue // a standing reminder already exists — don't pile up
+			if existing := c.unreadRotationReminder(ctx, mbr.UserID, projectID); existing != nil {
+				if severity <= existing.Severity {
+					continue // no worse than what's already standing — don't pile up
+				}
+				if c.upgradeReminder(ctx, existing, title, msg, severity) {
+					sent++ // escalated in place (#250): approaching → now overdue
+				}
+				continue
 			}
-			c.notify(ctx, mbr.UserID, NotificationRotationDue,
-				"Secrets due for rotation", msg, &pid, "/rotation-policies")
+			c.notifyWithSeverity(ctx, mbr.UserID, NotificationRotationDue, title, msg, &pid, "/rotation-policies", severity)
 			sent++
 		}
 	}
 	return sent, nil
 }
 
-// hasUnreadRotationReminder reports whether the user already has an unread
-// rotation-reminder notification for the given project. This queries at the DB
-// level for exactly this (user, type, project) triple — it does NOT page through
-// "the newest N notifications of any type" — so a user with a large volume of
-// other unrelated unread notifications can't push a genuine standing reminder out
-// of an arbitrary top-N window and defeat the dedup guard (#399).
-func (c *KeyorixCore) hasUnreadRotationReminder(ctx context.Context, userID, projectID uint) bool {
-	has, err := c.storage.HasUnreadNotification(ctx, userID, NotificationRotationDue, projectID)
-	if err != nil {
-		return false // on a read error, prefer notifying over silently skipping
+// rotationSeverity ranks a project's rotation state: any overdue secret is
+// strictly more severe than merely having secrets approaching their deadline
+// (#250).
+func rotationSeverity(overdue int) models.NotificationSeverity {
+	if overdue > 0 {
+		return models.NotificationSeverityCritical
 	}
-	return has
+	return models.NotificationSeverityWarning
+}
+
+// unreadRotationReminder returns the user's existing unread rotation-reminder
+// notification for the given project, or nil if none exists (including on a
+// storage read error — on error, prefer notifying over silently skipping).
+// This queries at the DB level for exactly this (user, type, project) triple —
+// it does NOT page through "the newest N notifications of any type" — so a
+// user with a large volume of other unrelated unread notifications can't push
+// a genuine standing reminder out of an arbitrary top-N window and defeat the
+// dedup guard (#399).
+func (c *KeyorixCore) unreadRotationReminder(ctx context.Context, userID, projectID uint) *models.Notification {
+	n, err := c.storage.GetUnreadNotification(ctx, userID, NotificationRotationDue, projectID)
+	if err != nil {
+		return nil
+	}
+	return n
 }
 
 func rotationReminderMessage(project string, overdue, approaching int) string {

--- a/internal/core/rotation_reminders_test.go
+++ b/internal/core/rotation_reminders_test.go
@@ -91,13 +91,16 @@ func TestHasUnreadRotationReminder_NotBuriedByNotificationVolume(t *testing.T) {
 	ctx := context.Background()
 	c, db, now := newRotationReminderCore(t)
 
-	// Seed the genuine rotation reminder first (oldest), then bury it under 150
-	// newer, unrelated unread notifications for the same user.
+	// Seed the genuine rotation reminder first (oldest), already at the severity
+	// the fixture's secret warrants (overdue → Critical) so this run is a pure
+	// anti-burying check, not an escalation. Then bury it under 150 newer,
+	// unrelated unread notifications for the same user.
 	pid := uint(1)
 	require.NoError(t, db.Create(&models.Notification{
 		UserID: 5, ProjectID: &pid, Type: NotificationRotationDue,
 		Title: "Secrets due for rotation", Message: "old standing reminder",
-		IsRead: false, CreatedAt: now.Add(-24 * time.Hour),
+		Severity: models.NotificationSeverityCritical,
+		IsRead:   false, CreatedAt: now.Add(-24 * time.Hour),
 	}).Error)
 	for i := 0; i < 150; i++ {
 		require.NoError(t, db.Create(&models.Notification{
@@ -107,11 +110,11 @@ func TestHasUnreadRotationReminder_NotBuriedByNotificationVolume(t *testing.T) {
 		}).Error)
 	}
 
-	assert.True(t, c.hasUnreadRotationReminder(ctx, 5, 1),
+	assert.NotNil(t, c.unreadRotationReminder(ctx, 5, 1),
 		"the standing reminder must be found even though 150 newer unread notifications of another type exist")
 
 	// The straightforward case (no volume issue, no reminder) still works.
-	assert.False(t, c.hasUnreadRotationReminder(ctx, 6, 1),
+	assert.Nil(t, c.unreadRotationReminder(ctx, 6, 1),
 		"a user with no rotation reminder at all must not be reported as having one")
 
 	// SendRotationReminders itself must not duplicate the reminder despite the noise.
@@ -133,6 +136,79 @@ func TestSendRotationReminders_NothingDue(t *testing.T) {
 	sent, err := c.SendRotationReminders(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, 0, sent)
+}
+
+// TestSendRotationReminders_EscalatesOnMoreSevereState is a regression test for
+// #250: an unread standing reminder must not freeze at a stale severity. First
+// run notes the secret is merely *approaching* its rotation deadline (Warning);
+// once it becomes genuinely *overdue* (Critical) while that reminder is still
+// unread, the next run must escalate the SAME notification row in place rather
+// than silently suppressing the far more consequential state.
+func TestSendRotationReminders_EscalatesOnMoreSevereState(t *testing.T) {
+	ctx := context.Background()
+	c, db, now := newRotationReminderCore(t)
+
+	// 25 days into a 30-day policy with a 7-day alert window: approaching, not
+	// yet overdue (30-25=5 <= 7).
+	require.NoError(t, db.Model(&models.SecretNode{}).Where("id = ?", 10).
+		Update("created_at", now.AddDate(0, 0, -25)).Error)
+
+	sent, err := c.SendRotationReminders(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 1, sent, "the project admin is notified of the approaching deadline")
+
+	var note models.Notification
+	require.NoError(t, db.Where("type = ?", NotificationRotationDue).First(&note).Error)
+	assert.Equal(t, models.NotificationSeverityWarning, note.Severity)
+	assert.Contains(t, note.Message, "approaching")
+	assert.False(t, note.IsRead)
+	firstID := note.ID
+
+	// Now the secret is 35 days old → overdue (Critical) — a strictly more
+	// severe state — while the Warning reminder is STILL UNREAD.
+	require.NoError(t, db.Model(&models.SecretNode{}).Where("id = ?", 10).
+		Update("created_at", now.AddDate(0, 0, -35)).Error)
+
+	sent, err = c.SendRotationReminders(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 1, sent, "the escalation to overdue must reach the admin")
+
+	var notes []models.Notification
+	require.NoError(t, db.Where("type = ?", NotificationRotationDue).Find(&notes).Error)
+	require.Len(t, notes, 1, "the standing reminder was updated in place, not duplicated")
+	assert.Equal(t, firstID, notes[0].ID, "same notification row, upgraded")
+	assert.Equal(t, models.NotificationSeverityCritical, notes[0].Severity)
+	assert.Contains(t, notes[0].Message, "overdue")
+	assert.False(t, notes[0].IsRead)
+}
+
+// TestSendRotationReminders_NoEscalation_SameOrLowerSeverity_NoNoise is the
+// inverse of the escalation test: once a Critical (overdue) reminder is
+// standing, a recheck that finds the state no worse must not touch it or
+// create noise — only a genuine escalation updates the notification.
+func TestSendRotationReminders_NoEscalation_SameOrLowerSeverity_NoNoise(t *testing.T) {
+	ctx := context.Background()
+	c, db, _ := newRotationReminderCore(t)
+
+	// Default fixture: the secret is already overdue → first run creates a
+	// Critical standing reminder.
+	sent, err := c.SendRotationReminders(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 1, sent)
+
+	var before models.Notification
+	require.NoError(t, db.Where("type = ?", NotificationRotationDue).First(&before).Error)
+	require.Equal(t, models.NotificationSeverityCritical, before.Severity)
+
+	// Still overdue (same severity) and still unread: no escalation, no noise.
+	sent, err = c.SendRotationReminders(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 0, sent, "an at-or-below-severity recheck must not notify again")
+
+	var after models.Notification
+	require.NoError(t, db.Where("type = ?", NotificationRotationDue).First(&after).Error)
+	assert.Equal(t, before.Message, after.Message, "the standing reminder is untouched")
+	assert.Equal(t, before.Severity, after.Severity)
 }
 
 func TestRotationReminderMessage(t *testing.T) {

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -279,6 +279,18 @@ type Storage interface {
 	// unbounded/"top N of everything" fetch), so it finds a match regardless of
 	// how many other unread notifications of other types/projects exist (#399).
 	HasUnreadNotification(ctx context.Context, userID uint, nType string, projectID uint) (bool, error)
+	// GetUnreadNotification returns the user's unread notification of the given
+	// type scoped to the given project, or nil if none exists. Unlike
+	// HasUnreadNotification, this returns the full row so a dedup check can also
+	// compare (and, on escalation, update) its recorded Severity instead of only
+	// checking existence (#250).
+	GetUnreadNotification(ctx context.Context, userID uint, nType string, projectID uint) (*models.Notification, error)
+	// UpdateNotification updates an existing notification's Title/Message/Severity
+	// in place, scoped to its owner (id + userID must both match or nothing is
+	// changed). Used to escalate a standing reminder when a recheck finds a more
+	// severe state than what was originally recorded (#250), instead of creating
+	// a second unread notification and piling up.
+	UpdateNotification(ctx context.Context, n *models.Notification) error
 	// MarkNotificationRead marks one notification read, scoped to its owner.
 	MarkNotificationRead(ctx context.Context, id, userID uint) error
 	MarkAllNotificationsRead(ctx context.Context, userID uint) error

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -691,7 +691,7 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 		}
 	} else {
 		m := db.Migrator()
-		for _, col := range []string{"ProjectID", "Title", "Link"} {
+		for _, col := range []string{"ProjectID", "Title", "Link", "Severity"} {
 			if !m.HasColumn(&models.Notification{}, col) {
 				if err := m.AddColumn(&models.Notification{}, col); err != nil {
 					return fmt.Errorf("failed to add notifications.%s column: %w", col, err)

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -800,6 +800,30 @@ type SecretTag struct {
 	TagID        uint `gorm:"primaryKey"`
 }
 
+// NotificationSeverity is a coarse escalation ranking recorded on a standing
+// reminder notification (#250). Reminder schedulers (expiry/rotation/license)
+// compare a newly computed severity against the value recorded here on an
+// existing unread notification of the same (user, type, project): the
+// notification is escalated in place only when the new state is strictly
+// more severe than what was originally recorded, so an unread standing
+// reminder can't freeze forever at a stale, since-superseded severity while
+// still suppressing re-notification when nothing has gotten worse.
+type NotificationSeverity int
+
+const (
+	// NotificationSeverityNone is the default for notification types that don't
+	// participate in escalation-aware dedup.
+	NotificationSeverityNone NotificationSeverity = 0
+	// NotificationSeverityWarning marks a "heads up" state, e.g. a secret
+	// expiring soon, a rotation approaching its deadline, or a license
+	// expiring soon.
+	NotificationSeverityWarning NotificationSeverity = 1
+	// NotificationSeverityCritical marks a materially worse state than
+	// NotificationSeverityWarning, e.g. a secret that has actually expired, a
+	// rotation that is now overdue, or a license that has actually expired.
+	NotificationSeverityCritical NotificationSeverity = 2
+)
+
 // Notification is an in-app notification addressed to a single user (ADR-024).
 // Surfaced via the header bell; delivery is in-app only (email/Slack is M3+).
 type Notification struct {
@@ -811,7 +835,11 @@ type Notification struct {
 	Title        string
 	Message      string
 	Link         string // optional in-app target, e.g. /projects/{id}
-	IsRead       bool   `gorm:"index"`
+	// Severity records the escalation ranking at which this notification was
+	// last created/updated (#250). Zero (NotificationSeverityNone) for
+	// notification types that don't use escalation-aware dedup.
+	Severity NotificationSeverity `gorm:"default:0"`
+	IsRead   bool                 `gorm:"index"`
 	CreatedAt    time.Time
 }
 

--- a/internal/storage/store/local_notifications.go
+++ b/internal/storage/store/local_notifications.go
@@ -45,18 +45,51 @@ func (ls *LocalStorage) ListNotifications(ctx context.Context, userID uint, unre
 // match, so it can't be defeated by a pile-up of newer, unrelated unread
 // notifications pushing the target one outside a "top N" window (#399).
 func (ls *LocalStorage) HasUnreadNotification(ctx context.Context, userID uint, nType string, projectID uint) (bool, error) {
+	n, err := ls.GetUnreadNotification(ctx, userID, nType, projectID)
+	if err != nil {
+		return false, err
+	}
+	return n != nil, nil
+}
+
+// GetUnreadNotification returns userID's unread notification of nType scoped to
+// projectID, or nil if none exists. Same DB-level filter as HasUnreadNotification
+// (#399), but returns the full row so a dedup check can also compare (and, on
+// escalation, update) its recorded Severity instead of only checking existence
+// (#250).
+func (ls *LocalStorage) GetUnreadNotification(ctx context.Context, userID uint, nType string, projectID uint) (*models.Notification, error) {
 	var row models.Notification
 	err := ls.db.WithContext(ctx).
-		Select("id").
 		Where("user_id = ? AND is_read = ? AND type = ? AND project_id = ?", userID, false, nType, projectID).
 		First(&row).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
-		return false, nil
+		return nil, nil
 	}
 	if err != nil {
-		return false, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
 	}
-	return true, nil
+	return &row, nil
+}
+
+// UpdateNotification updates title/message/severity on an existing notification
+// in place, scoped to its owner (#250). Used to escalate a standing reminder
+// instead of creating a second unread notification and piling up.
+func (ls *LocalStorage) UpdateNotification(ctx context.Context, n *models.Notification) error {
+	res := ls.db.WithContext(ctx).Model(&models.Notification{}).
+		Where("id = ? AND user_id = ?", n.ID, n.UserID).
+		Updates(map[string]interface{}{
+			"title":    n.Title,
+			"message":  n.Message,
+			"severity": n.Severity,
+		})
+	if res.Error != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), res.Error)
+	}
+	if res.RowsAffected == 0 {
+		// No row for this (id, user) — not found or not the caller's.
+		return fmt.Errorf("%s", i18n.T("ErrorNotFound", nil))
+	}
+	return nil
 }
 
 func (ls *LocalStorage) CountUnreadNotifications(ctx context.Context, userID uint) (int64, error) {

--- a/internal/storage/store/remote_notifications.go
+++ b/internal/storage/store/remote_notifications.go
@@ -27,6 +27,14 @@ func (rs *RemoteStorage) HasUnreadNotification(_ context.Context, _ uint, _ stri
 	return false, remoteUnsupported("HasUnreadNotification")
 }
 
+func (rs *RemoteStorage) GetUnreadNotification(_ context.Context, _ uint, _ string, _ uint) (*models.Notification, error) {
+	return nil, remoteUnsupported("GetUnreadNotification")
+}
+
+func (rs *RemoteStorage) UpdateNotification(_ context.Context, _ *models.Notification) error {
+	return remoteUnsupported("UpdateNotification")
+}
+
 func (rs *RemoteStorage) MarkNotificationRead(ctx context.Context, id, _ uint) error {
 	// The server scopes the mark to the authenticated user (the client's own
 	// session), so userID is implicit in the endpoint.


### PR DESCRIPTION
## Summary

Fixes #250. `expiry_reminders.go`, `rotation_reminders.go`, and `license_expiry.go` de-duplicate standing reminders with a pure *existence* check ("does an unread reminder of this type already exist for this target") — no comparison against a newly-computed severity. An unread standing reminder therefore freezes at its original severity forever: a secret flagged "expiring soon" creates a reminder, that reminder sits unread, and days later when the secret has genuinely **expired** (a materially more consequential state), the dedup check still finds the old "expiring soon" reminder and silently blocks the "now expired" notification from ever being created. Same shape for rotation (approaching → overdue) and license (expiring soon → expired).

## Changes

- Added `Severity NotificationSeverity` to `models.Notification` (`NotificationSeverityNone/Warning/Critical`), migrated additively via the existing `AddColumn` path in `internal/storage/factory.go` for upgrades of an existing DB (alongside the fresh-install `AutoMigrate` path).
- Added `storage.GetUnreadNotification` (returns the full row, not just a bool) and `storage.UpdateNotification` (title/message/severity, scoped to owner) to the storage interface, `LocalStorage` (gorm), `RemoteStorage` (stub), and the core-package `MockStorage` test double. `HasUnreadNotification` now delegates to `GetUnreadNotification` internally (no behavior change, less duplication).
- `internal/core/notifications.go`: added `notifyWithSeverity` (records a severity on creation) and `upgradeReminder` (updates an existing row's title/message/severity in place) alongside the existing `notify`.
- In each of the three reminder files: on a dedup hit, compare the newly computed severity against the existing unread notification's recorded severity. Strictly more severe → escalate the *same* notification row in place (`upgradeReminder`). Same or less severe → keep suppressing (no new noise). No existing reminder → create fresh with the computed severity (`notifyWithSeverity`).
  - Rotation: overdue > approaching.
  - Expiry: any expired secret > merely expiring soon.
  - License: `StateExpired` > `StateExpiringSoon`/`StateActive`-within-window.

## Design choice: update-in-place, not a second notification

Chose **update-in-place** over creating a second unread notification for the same (user, type, project): the latter would itself be a pile-up (two unread rows for the same standing condition, one stale). Update-in-place required a full-row read (`GetUnreadNotification`) instead of the boolean-only `HasUnreadNotification`, plus a small, targeted `UpdateNotification` storage method — no migration framework changes needed since notifications already use `gorm.AutoMigrate`/additive `AddColumn`.

Kept each file's existing dedup *query shape* untouched (rotation already uses the DB-level `#399`-fixed lookup; expiry/license still scan `ListNotifications(unreadOnly, 100)` client-side) — only added severity comparison on top, per the task's scope boundary. `rotation_reminders.go`'s existence helper was renamed `hasUnreadRotationReminder` → `unreadRotationReminder` (bool → `*Notification`) since it now needs the full row.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/core/... ./internal/storage/store/...` (clean; one hit of the known pre-existing `anomaly_alerts`/`legal_holds`/`dynamic_secret_configs` table-not-found flake, reran clean — unrelated to files touched here)
- [x] `gosec -severity medium -exclude-generated` on `./internal/core/...` and `./internal/storage/...` — 0 issues
- [x] New regression tests: `TestSendRotationReminders_EscalatesOnMoreSevereState` / `_NoEscalation_SameOrLowerSeverity_NoNoise` (thorough, real-SQLite), lighter equivalents in `expiry_reminders_test.go` and `license_expiry_test.go` (`TestScanLicenseExpiry_EscalatesOnExpiry`, updated `TestScanLicenseExpiry_Dedup_NoResend` to seed a matching severity so it stays a true no-escalation case)