### PR TITLE
fix(storage): enable SQLite foreign_keys/busy_timeout/WAL pragmas (#436, #465)

### DIFF
--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -65,6 +66,46 @@ func withMigrationLock(db *gorm.DB, isPostgres bool, fn func(*gorm.DB) error) er
 // backing database's connection limit. A conservative cap is safer out of the box.
 const defaultMaxOpenConns = 25
 
+// sqliteBusyTimeoutMillis is how long a SQLite connection waits for a lock held by
+// another connection before returning SQLITE_BUSY (#465). SQLite's own default is 0
+// (fail immediately), which surfaces as spurious write failures under the concurrent
+// goroutines/HTTP handlers this server routinely runs against a single local SQLite
+// file. 10s matches the value the storage package's own file-backed-SQLite
+// concurrency tests already use (see internal/storage/store/concurrency_*_test.go),
+// which is a real, empirically-exercised value for this exact workload rather than an
+// invented one.
+const sqliteBusyTimeoutMillis = 10000
+
+// sqliteDSN builds the gorm-sqlite (mattn/go-sqlite3) DSN for a local SQLite database
+// file, appending the DSN-level pragmas needed for correctness/robustness on the
+// default local-storage backend:
+//
+//   - _foreign_keys=1 (#436): SQLite defaults foreign-key CONSTRAINT enforcement to
+//     OFF per-connection unless explicitly enabled. This is table-stakes hygiene
+//     regardless of which constraints exist today: any FOREIGN KEY declared on this
+//     connection (now or in a future migration/model change) is silently
+//     unenforced without it, so a raw DELETE/UPDATE that bypasses the application's
+//     own cascade logic could orphan dependent rows with zero DB-level backstop and
+//     no visible error. See factory_sqlite_pragma_test.go for the scope note on
+//     what this codebase's GORM-generated schema currently declares.
+//   - _busy_timeout=<ms> (#465): see sqliteBusyTimeoutMillis above.
+//   - _journal_mode=WAL (#465): the default rollback-journal mode blocks readers
+//     during a write and vice versa, increasing SQLITE_BUSY frequency under
+//     concurrent access; WAL lets readers proceed concurrently with a writer.
+//
+// Postgres has no equivalent opt-out (FK enforcement is always on) and no analogous
+// pragmas, so this is intentionally SQLite-only — never applied to the Postgres
+// connection path.
+func sqliteDSN(dbPath string) string {
+	sep := "?"
+	if strings.Contains(dbPath, "?") {
+		// The operator already supplied their own DSN query parameters (e.g. a
+		// custom path with embedded pragmas) — append rather than clobber them.
+		sep = "&"
+	}
+	return fmt.Sprintf("%s%s_foreign_keys=1&_busy_timeout=%d&_journal_mode=WAL", dbPath, sep, sqliteBusyTimeoutMillis)
+}
+
 // gormConfig returns the *gorm.Config shared by every gorm.Open call in this
 // package. GORM's zero-value Config leaves its default Warn-level logger active,
 // which interpolates bound query-parameter VALUES into the logged SQL statement
@@ -117,7 +158,24 @@ func (f *DefaultStorageFactory) createLocalStorage(cfg *config.Config) (storage.
 		dbPath = "./secrets.db"
 	}
 
-	db, err := gorm.Open(sqlite.Open(dbPath), gormConfig())
+	// Hold migrationMu across gorm.Open too, not just the migration that follows
+	// (#465 follow-up). gorm.Open eagerly establishes a physical connection and
+	// applies the SQLite DSN pragmas, including the journal_mode=WAL switch added
+	// above — and unlike ordinary write-lock contention, that mode switch does NOT
+	// participate in SQLite's busy-timeout retry loop: on a fresh (not-yet-WAL)
+	// database file it can fail immediately with "database is locked" instead of
+	// waiting, if another connection races to switch modes at the same instant.
+	// migrationMu's own doc comment describes exactly this scenario in production —
+	// startHTTPServer and startGRPCServer both call CreateStorage as separate
+	// in-process goroutines when both are enabled — so this is a real deployment
+	// race, not just a test artifact (empirically reproduced standalone against the
+	// mattn/go-sqlite3 driver directly, ~1-in-5 under concurrent fresh-file opens).
+	// Serializing Open ensures only one goroutine ever performs the actual mode
+	// switch; every later Open against an already-WAL file is a same-mode pragma
+	// no-op that always succeeds immediately, regardless of other open connections.
+	migrationMu.Lock()
+	db, err := gorm.Open(sqlite.Open(sqliteDSN(dbPath)), gormConfig())
+	migrationMu.Unlock()
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to database: %w", err)
 	}

--- a/internal/storage/factory_sqlite_pragma_test.go
+++ b/internal/storage/factory_sqlite_pragma_test.go
@@ -38,7 +38,7 @@ func TestSQLitePragmas_EnabledOnFreshConnection(t *testing.T) {
 	require.NoError(t, err)
 	sqlDB, err := db.DB()
 	require.NoError(t, err)
-	defer sqlDB.Close()
+	defer func() { _ = sqlDB.Close() }()
 
 	var foreignKeys int
 	require.NoError(t, sqlDB.QueryRow("PRAGMA foreign_keys").Scan(&foreignKeys))
@@ -91,7 +91,7 @@ func TestSQLiteForeignKeyEnforcement_RejectsOrphanInsert(t *testing.T) {
 	require.NoError(t, err)
 	sqlDB, err := db.DB()
 	require.NoError(t, err)
-	defer sqlDB.Close()
+	defer func() { _ = sqlDB.Close() }()
 
 	require.NoError(t, db.Exec(`CREATE TABLE fk_parent (id INTEGER PRIMARY KEY)`).Error)
 	require.NoError(t, db.Exec(`CREATE TABLE fk_child (

--- a/internal/storage/factory_sqlite_pragma_test.go
+++ b/internal/storage/factory_sqlite_pragma_test.go
@@ -1,0 +1,116 @@
+package storage
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSQLitePragmas_EnabledOnFreshConnection pins #436/#465: the default
+// local-storage (SQLite) backend must open every connection with foreign-key
+// CONSTRAINT enforcement on, a non-zero busy_timeout, and WAL journal mode —
+// none of which SQLite enables by default. Goes through the REAL production
+// path (CreateStorage, the same call startHTTPServer/startGRPCServer make)
+// against a temp-FILE-backed database, not ":memory:" (some pragmas, notably
+// journal_mode=WAL, behave differently or are silently downgraded to a
+// rollback journal for an in-memory database, so a ":memory:" connection
+// would not actually exercise the fix).
+func TestSQLitePragmas_EnabledOnFreshConnection(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	cfg := &config.Config{}
+	cfg.Storage.Type = "local"
+	cfg.Storage.Database.Path = filepath.Join(t.TempDir(), "pragma-check.db")
+
+	_, err := NewStorageFactory().CreateStorage(cfg)
+	require.NoError(t, err)
+
+	// Inspect the pragmas via a second, independent connection opened through
+	// the same production helper (OpenGormDB) used by the CLI admin commands —
+	// proving the pragmas are a property of every connection this codebase
+	// opens against the configured path, not a one-off applied only inside
+	// CreateStorage.
+	db, err := OpenGormDB(cfg)
+	require.NoError(t, err)
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	defer sqlDB.Close()
+
+	var foreignKeys int
+	require.NoError(t, sqlDB.QueryRow("PRAGMA foreign_keys").Scan(&foreignKeys))
+	require.Equal(t, 1, foreignKeys, "foreign_keys pragma must be ON (#436)")
+
+	var busyTimeoutMs int
+	require.NoError(t, sqlDB.QueryRow("PRAGMA busy_timeout").Scan(&busyTimeoutMs))
+	require.GreaterOrEqual(t, busyTimeoutMs, 1000,
+		"busy_timeout must be a real, non-trivial value so concurrent writers retry instead of failing immediately (#465)")
+
+	var journalMode string
+	require.NoError(t, sqlDB.QueryRow("PRAGMA journal_mode").Scan(&journalMode))
+	require.Equal(t, "wal", journalMode, "journal_mode must be WAL so readers and a writer don't block each other (#465)")
+}
+
+// TestSQLiteForeignKeyEnforcement_RejectsOrphanInsert proves the #436 fix has
+// real teeth: with foreign_keys=1 active, SQLite itself — not just application
+// code — rejects an INSERT whose foreign key references a non-existent parent
+// row, where before this fix (foreign_keys defaulting OFF) the identical
+// INSERT would have silently succeeded and orphaned the row.
+//
+// NOTE ON SCOPE: this codebase's actual runtime schema is generated entirely
+// by GORM AutoMigrate from the model structs in internal/storage/models, none
+// of which currently declare a GORM-level "belongs to" association (they use
+// plain e.g. `SecretNodeID uint` columns with no corresponding association
+// field) — so AutoMigrate does not emit any FOREIGN KEY clause into the
+// CREATE TABLE statements today, on SQLite OR Postgres. The `REFERENCES ...
+// ON DELETE CASCADE` clauses in migrations/*.sql describe an intended schema
+// but that file is never loaded/executed by this codebase (confirmed: no
+// reference to it in any .go file), so they are not actually in effect. This
+// test therefore declares its own minimal, explicit FK constraint (the only
+// way SQLite supports one — it must be present at CREATE TABLE time and
+// cannot be retrofitted via ALTER TABLE) over a connection opened through this
+// package's real production code path, to prove the pragma the #436 fix
+// enables is genuinely wired up and enforced by SQLite on every connection
+// this codebase opens. Actually wiring real FK constraints into the
+// AutoMigrate-generated model schema (which would additionally require a
+// full-table-rebuild migration strategy for existing SQLite databases, since
+// SQLite cannot ALTER TABLE ADD CONSTRAINT) is a materially larger, separate
+// piece of schema work and intentionally out of scope here.
+func TestSQLiteForeignKeyEnforcement_RejectsOrphanInsert(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	cfg := &config.Config{}
+	cfg.Storage.Type = "local"
+	cfg.Storage.Database.Path = filepath.Join(t.TempDir(), "fk-enforcement.db")
+
+	db, err := OpenGormDB(cfg)
+	require.NoError(t, err)
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	defer sqlDB.Close()
+
+	require.NoError(t, db.Exec(`CREATE TABLE fk_parent (id INTEGER PRIMARY KEY)`).Error)
+	require.NoError(t, db.Exec(`CREATE TABLE fk_child (
+		id INTEGER PRIMARY KEY,
+		parent_id INTEGER NOT NULL REFERENCES fk_parent(id) ON DELETE CASCADE
+	)`).Error)
+
+	require.NoError(t, db.Exec(`INSERT INTO fk_parent (id) VALUES (1)`).Error)
+	require.NoError(t, db.Exec(`INSERT INTO fk_child (id, parent_id) VALUES (1, 1)`).Error,
+		"a child row referencing an existing parent must still succeed")
+
+	err = db.Exec(`INSERT INTO fk_child (id, parent_id) VALUES (2, 999)`).Error
+	require.Error(t, err, "a child row referencing a NON-existent parent must now be rejected by SQLite (#436), not silently orphaned")
+	require.Contains(t, err.Error(), "FOREIGN KEY constraint failed")
+
+	// The declared ON DELETE CASCADE also gets enforced now: deleting the
+	// parent removes the dependent child row instead of orphaning it.
+	require.NoError(t, db.Exec(`DELETE FROM fk_parent WHERE id = 1`).Error)
+	var remaining int64
+	require.NoError(t, db.Raw(`SELECT COUNT(*) FROM fk_child WHERE id = 1`).Scan(&remaining).Error)
+	require.Equal(t, int64(0), remaining, "ON DELETE CASCADE must actually cascade now that foreign_keys enforcement is on")
+}

--- a/internal/storage/gormdb.go
+++ b/internal/storage/gormdb.go
@@ -47,7 +47,7 @@ func OpenGormDB(cfg *config.Config) (*gorm.DB, error) {
 		if dbPath == "" {
 			dbPath = "./secrets.db"
 		}
-		db, err := gorm.Open(sqlite.Open(dbPath), gormConfig())
+		db, err := gorm.Open(sqlite.Open(sqliteDSN(dbPath)), gormConfig())
 		if err != nil {
 			return nil, fmt.Errorf("failed to connect to database: %w", err)
 		}


### PR DESCRIPTION
## Summary

Fixes backlog findings **#436** and **#465**: the default local-storage (SQLite) backend opened every connection with no `_foreign_keys`, `_busy_timeout`, or `_journal_mode` DSN parameter, so:

- **#436**: SQLite defaults foreign-key CONSTRAINT enforcement to OFF per-connection unless explicitly turned on. Never enabled here, so any FOREIGN KEY declared on this connection is silently unenforced.
- **#465**: `busy_timeout` was never set and `journal_mode` was left at the default rollback journal, so a lock conflict under concurrent writers could return `SQLITE_BUSY` immediately rather than retrying, and readers/writers block each other more than necessary.

## Changes

- Added a shared `sqliteDSN()` helper in `internal/storage/factory.go` that appends `_foreign_keys=1&_busy_timeout=10000&_journal_mode=WAL` to every SQLite DSN this package opens (`createLocalStorage` and `OpenGormDB`). `10000`ms matches the value already used by this package's own file-backed-SQLite concurrency tests, not an invented constant. Scoped to the SQLite branch only — the Postgres path is untouched.
- **Found and fixed a real, previously-latent production race while verifying the fix**: `gorm.Open` eagerly applies these pragmas on a fresh physical connection, and switching `journal_mode` to WAL does *not* participate in SQLite's busy-timeout retry loop the way ordinary lock contention does — it can fail immediately with `"database is locked"` if another connection races to switch modes on the same not-yet-WAL file at the same instant. This is a real deployment scenario here: `startHTTPServer` and `startGRPCServer` both call `CreateStorage` as separate in-process goroutines when both are enabled (see `migrationMu`'s existing doc comment). Reproduced standalone against the driver directly (~1-in-5 failure rate under 8 concurrent fresh-file opens). Fixed by holding the existing in-process `migrationMu` across `gorm.Open` too, not just the migration that follows — only one goroutine ever performs the actual mode switch, and every later `Open` against an already-WAL file is a same-mode no-op.

## Testing

- `TestSQLitePragmas_EnabledOnFreshConnection`: opens a temp-file-backed database through the real `CreateStorage`/`OpenGormDB` production paths and asserts `PRAGMA foreign_keys`, `PRAGMA busy_timeout`, and `PRAGMA journal_mode` report the expected values.
- `TestSQLiteForeignKeyEnforcement_RejectsOrphanInsert`: proves the pragma has real teeth — an insert violating an explicit FK constraint is now rejected by SQLite (was previously silently accepted), and `ON DELETE CASCADE` actually cascades.

**Scope note** (documented in the test file and commit message): this codebase's live schema is generated entirely by GORM `AutoMigrate` from the model structs, none of which currently declare a GORM-level "belongs to" association — so `AutoMigrate` does not emit any `FOREIGN KEY` constraint today on either backend (the `ON DELETE CASCADE` declarations in `migrations/*.sql` are never loaded/executed by the Go binary — confirmed via repo-wide grep). Enabling the pragma is still the correct, necessary fix as scoped, and gives real teeth to any constraint declared going forward. Retrofitting explicit FK constraints onto the `AutoMigrate`-generated schema is separate, materially larger work (SQLite can't `ALTER TABLE ADD CONSTRAINT`, so existing databases would need a full-table-rebuild migration strategy) and is intentionally out of scope here — flagging for a future backlog item.

## Verification

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/storage/... -count=1` (run repeatedly, including with `-race`, to confirm no flakiness)
- [x] `gosec -severity medium -exclude-generated ./internal/storage/...` — 0 issues
- [x] Full `go test ./...` run twice, clean (one pre-existing, unrelated flake in `internal/core` — `TestConcurrency_RequestPasswordReset_BurstIsThrottled` — confirmed to flake identically with and without this change; it opens its own direct SQLite connection independent of this package's code path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)