### PR TITLE
fix(build): eliminate eval-on-VERSION injection in build scripts (#467/#468)

### DIFF
--- a/scripts/build-all-platforms.sh
+++ b/scripts/build-all-platforms.sh
@@ -73,18 +73,21 @@ for platform in "${PLATFORMS[@]}"; do
     fi
     
     # Build flags
-    BUILD_FLAGS="-ldflags='-s -w -X main.Version=$VERSION -X main.BuildTime=$BUILD_TIME -X main.GitCommit=$GIT_COMMIT'"
-    
+    # Use an array (not a string re-parsed via `eval`) so that values such as
+    # $VERSION are passed to `go build` as literal argv entries, never as shell
+    # syntax to be re-interpreted (see #467/#468).
+    BUILD_FLAGS=(-ldflags="-s -w -X main.Version=$VERSION -X main.BuildTime=$BUILD_TIME -X main.GitCommit=$GIT_COMMIT")
+
     # Build CLI
-    if eval "go build $BUILD_FLAGS -o $PLATFORM_DIR/keyorix$EXT ./cmd/keyorix"; then
+    if go build "${BUILD_FLAGS[@]}" -o "$PLATFORM_DIR/keyorix$EXT" ./cmd/keyorix; then
         log_success "CLI built for $os/$arch"
     else
         log_warning "Failed to build CLI for $os/$arch"
         continue
     fi
-    
+
     # Build server
-    if eval "go build $BUILD_FLAGS -o $PLATFORM_DIR/keyorix-server$EXT ./server"; then
+    if go build "${BUILD_FLAGS[@]}" -o "$PLATFORM_DIR/keyorix-server$EXT" ./server; then
         log_success "Server built for $os/$arch"
     else
         log_warning "Failed to build server for $os/$arch"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -52,14 +52,17 @@ log_info "Creating bin directory..."
 mkdir -p bin
 
 # Build flags based on mode
+# Use an array (not a string re-parsed via `eval`) so that values such as
+# $VERSION are passed to `go build` as literal argv entries, never as shell
+# syntax to be re-interpreted (see #467/#468).
+BUILD_FLAGS=()
 if [ "$BUILD_MODE" = "debug" ]; then
-    BUILD_FLAGS="-gcflags='all=-N -l'"
+    BUILD_FLAGS+=(-gcflags="all=-N -l")
     log_info "Debug mode: Including debug symbols"
 elif [ "$BUILD_MODE" = "release" ]; then
-    BUILD_FLAGS="-ldflags='-s -w -X main.Version=$VERSION -X main.BuildTime=$BUILD_TIME -X main.GitCommit=$GIT_COMMIT'"
+    BUILD_FLAGS+=(-ldflags="-s -w -X main.Version=$VERSION -X main.BuildTime=$BUILD_TIME -X main.GitCommit=$GIT_COMMIT")
     log_info "Release mode: Optimized build with version info"
 else
-    BUILD_FLAGS=""
     log_info "Standard build mode"
 fi
 
@@ -69,7 +72,7 @@ export GOARCH="$TARGET_ARCH"
 
 # Build main CLI
 log_info "Building CLI binary (keyorix)..."
-if eval "go build $BUILD_FLAGS -o bin/keyorix ./cmd/keyorix"; then
+if go build "${BUILD_FLAGS[@]}" -o bin/keyorix ./cmd/keyorix; then
     log_success "CLI binary built successfully"
 else
     log_error "Failed to build CLI binary"
@@ -78,7 +81,7 @@ fi
 
 # Build server
 log_info "Building server binary (keyorix-server)..."
-if eval "go build $BUILD_FLAGS -o bin/keyorix-server ./server"; then
+if go build "${BUILD_FLAGS[@]}" -o bin/keyorix-server ./server; then
     log_success "Server binary built successfully"
 else
     log_error "Failed to build server binary"
@@ -88,7 +91,7 @@ fi
 # Build additional tools if they exist
 if [ -d "examples/secret_crud" ]; then
     log_info "Building secret_crud example..."
-    if eval "go build $BUILD_FLAGS -o bin/secret_crud ./examples/secret_crud"; then
+    if go build "${BUILD_FLAGS[@]}" -o bin/secret_crud ./examples/secret_crud; then
         log_success "secret_crud built successfully"
     else
         log_warning "Failed to build secret_crud"
@@ -97,7 +100,7 @@ fi
 
 if [ -d "examples/new-architecture" ]; then
     log_info "Building new-architecture example..."
-    if eval "go build $BUILD_FLAGS -o bin/new-architecture ./examples/new-architecture"; then
+    if go build "${BUILD_FLAGS[@]}" -o bin/new-architecture ./examples/new-architecture; then
         log_success "new-architecture built successfully"
     else
         log_warning "Failed to build new-architecture"
@@ -107,7 +110,7 @@ fi
 # Build validation tools if they exist
 if [ -f "cmd/validate-translations/main.go" ]; then
     log_info "Building translation validator..."
-    if eval "go build $BUILD_FLAGS -o bin/validate-translations ./cmd/validate-translations"; then
+    if go build "${BUILD_FLAGS[@]}" -o bin/validate-translations ./cmd/validate-translations; then
         log_success "validate-translations built successfully"
     else
         log_warning "Failed to build validate-translations"


### PR DESCRIPTION
## Summary

Fixes backlog findings #467 and #468: `scripts/build.sh` and
`scripts/build-all-platforms.sh` both interpolated the env-overridable
`$VERSION` shell variable into a `BUILD_FLAGS` string, which was then
re-parsed by the shell via `eval "go build $BUILD_FLAGS ..."` at multiple
call sites (5 in `build.sh`, 2 in `build-all-platforms.sh`). Any `VERSION`
value containing shell metacharacters (single quotes, `;`, `` ` ``,
`$(...)`, etc.) became live shell syntax executed during the build — a
classic eval-on-untrusted-input injection.

Confirmed via repo-wide search that neither script is invoked by any
Makefile target, GitHub Actions workflow, or Dockerfile, so this is
currently unreachable from CI — but it's a real primitive the moment a
developer runs the script directly with an attacker-influenced `VERSION`
(e.g. a git tag from an untrusted fork), or the script is ever wired into
automation.

## Fix

- Convert `BUILD_FLAGS` from a string to a bash **array**, built up with
  `BUILD_FLAGS+=(...)` instead of string concatenation.
- Replace every `eval "go build $BUILD_FLAGS ..."` call site with
  `go build "${BUILD_FLAGS[@]}" ...`.
- `eval` is now fully removed from both scripts. Each array element
  (including the value of `$VERSION`) is passed to `go build` as a single
  literal argv entry — never re-parsed as shell syntax, regardless of what
  metacharacters it contains.
- No change to build flag semantics, build modes, or output paths.

## Test plan

- [x] `bash -n scripts/build.sh` and `bash -n scripts/build-all-platforms.sh` — both pass.
- [x] `shellcheck` on both files — no new findings introduced by this diff (pre-existing warnings in untouched code, e.g. an unrelated missing heredoc terminator later in `build.sh`, are out of scope for this fix).
- [x] Reproduced the vulnerability against the **original** (pre-fix) code: ran `build.sh` with
      `VERSION="x'; touch /tmp/pwned-marker; echo 'y"` — the injected `touch` executed and created
      the marker file, and the script still logged `[SUCCESS]` even though the real `go build`
      call for that target never ran.
- [x] Ran the **fixed** `build.sh` and `build-all-platforms.sh` with the same malicious `VERSION`
      payload (fresh marker path) — the marker file was **not** created; the value was passed
      through to `go build`'s own `-ldflags` argument parser as inert literal data (which then
      rejects it as a malformed flag value, since it's not valid `-ldflags` syntax — confirming
      the string is never handed back to the shell).
- [x] Also tried a `$(...)`/backtick-style payload against the fixed scripts — no marker created,
      confirming no command substitution occurs either.
- [x] Verified normal-VERSION behavior is unchanged: ran `go build -ldflags="-s -w -X main.Version=1.2.3-test ..." -o ... ./server` (the same flags the array now produces) and confirmed a working binary is produced, matching pre-fix behavior.
- [x] Ran both scripts end-to-end with a normal `VERSION` value; behavior (including an unrelated
      pre-existing failure building `./cmd/keyorix`, which doesn't exist in this repo's current
      layout) is identical before and after the fix, confirming no regression was introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)