### PR TITLE
docs: fix stale follow-up doc comments for shipped auth/crypto paths (#473)

### DIFF
--- a/internal/cli/machine/machine.go
+++ b/internal/cli/machine/machine.go
@@ -7,9 +7,11 @@
 // Each command works in both remote mode (against the server API) and local
 // mode (directly against the core service), mirroring the project CLI. Machine
 // identities are project-scoped, so every command resolves a project from
-// --project / KEYORIX_PROJECT / the active project. Machine-token issuance and
-// authentication are a separate follow-up (they need the machine-principal
-// model); this CLI manages the identity lifecycle.
+// --project / KEYORIX_PROJECT / the active project. Machine-token issuance,
+// authentication, and revocation (ADR-030) are fully implemented and reachable
+// via the HTTP/gRPC APIs (see internal/core/machine_token.go); this package
+// manages the identity lifecycle plus token-hygiene reporting
+// (token_hygiene.go) — it does not yet expose its own issue/revoke subcommand.
 package machine
 
 import (

--- a/internal/core/invitations.go
+++ b/internal/core/invitations.go
@@ -4,8 +4,9 @@
 //
 //   - Invitations: an admin invites an email to a project with an intended role.
 //     State: pending → accepted / revoked / expired. The email/setup-link
-//     consumption (accept) is a follow-up; this tracks the pending invite so it
-//     can be listed, revoked, and aged out.
+//     consumption (accept) is implemented in setup_consume.go
+//     (completeInvitationAccept); this tracks the pending invite so it can be
+//     listed, revoked, and aged out.
 //   - Access requests: a user asks for a role in a project. State: pending →
 //     approved / rejected / withdrawn / expired. Approval grants the (possibly
 //     adjusted) role at the project scope. No auto-approval.

--- a/internal/core/machine_identities.go
+++ b/internal/core/machine_identities.go
@@ -7,9 +7,11 @@
 //	pending → active → suspended ⇄ active        (revoked is terminal, reachable
 //	                                              from any non-revoked state)
 //
-// `pending` is the credential-awaiting state for the (future) machine-token
-// issuance flow; identities created today start `active`. Every transition is
-// audited. Machine-token authentication itself is a deliberate follow-up.
+// `pending` is the credential-awaiting state for the machine-token issuance
+// flow (ADR-030, see machine_token.go); identities created today start
+// `active`. Every transition is audited. Machine-token issuance, hashing,
+// revocation, and validation are fully implemented and wired into both the
+// HTTP and gRPC auth middleware.
 package core
 
 import (

--- a/internal/core/migrate_user_to_machine.go
+++ b/internal/core/migrate_user_to_machine.go
@@ -3,8 +3,8 @@
 //
 // Early deployments often model CI runners, automation, and service accounts as
 // ordinary user records. ADR-023 keeps machine identities separate from humans so
-// the Members view can segment the two and a future machine-token auth path can
-// target them. This helper performs the one-way conversion: it materialises a
+// the Members view can segment the two and the machine-token auth path (ADR-030)
+// can target them. This helper performs the one-way conversion: it materialises a
 // machine identity for the user and (by default) suspends the source account so
 // the human-login path is closed. The user is never deleted — suspension is
 // reversible and preserves audit/ownership history that may still reference it.

--- a/internal/crypto/keyprovider.go
+++ b/internal/crypto/keyprovider.go
@@ -3,8 +3,9 @@
 // data-encryption key (DEK). Abstracting the KEK source lets a deployment choose
 // how the KEK is obtained: derived from a passphrase (the default, unchanged), or
 // supplied as raw key material from a file or environment variable (e.g. injected
-// by a KMS, a sealed/SOPS secret, or a CSI driver). KMS/TPM-backed providers are a
-// future Tier-2 follow-up that implement this same interface.
+// by a KMS, a sealed/SOPS secret, or a CSI driver). KMS-backed (AWS/Azure/GCP,
+// see kms_provider.go) and TPM-backed (see tpm_provider.go) providers already
+// implement this same interface.
 //
 // A KeyProvider only SOURCES the KEK; wrapping/unwrapping the DEK with it stays in
 // the encryption package, so providers carry no dependency on the cipher code.

--- a/internal/delivery/delivery.go
+++ b/internal/delivery/delivery.go
@@ -89,7 +89,8 @@ type CredentialDelivery interface {
 
 // SMTPSettings configures the operator's own mail relay. The password is resolved
 // from KEYORIX_SMTP_PASSWORD by the config layer and passed in here; it is never
-// written to the config file. SMTP transport itself lands in a follow-up — see New.
+// written to the config file. SMTP transport is implemented in smtp.go
+// (newSMTPDelivery) and selected by New below.
 type SMTPSettings struct {
 	Host     string
 	Port     int

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -37,7 +37,8 @@ type Environment struct {
 
 // ProjectInvitation tracks an admin's intent to grant an email address a role in
 // a project (ADR-024). State machine: pending → accepted / revoked / expired.
-// The email/setup-link consumption (accept) is a follow-up; this record tracks
+// The email/setup-link consumption (accept) is implemented in
+// internal/core/setup_consume.go (completeInvitationAccept); this record tracks
 // the pending invite so it can be listed, revoked, and aged out.
 type ProjectInvitation struct {
 	ID                     uint   `gorm:"primaryKey"`
@@ -844,7 +845,7 @@ type AuditEvent struct {
 
 	// ActorType records whether the acting principal is a human user or a
 	// non-human machine identity (ADR-023). It is "user" on every ordinary
-	// event; the (future) machine-token auth path tags the request context so
+	// event; the machine-token auth path (ADR-030) tags the request context so
 	// every event under a machine session is stamped "machine_identity".
 	// "system" marks events with no authenticated principal. Defaults to "user"
 	// so legacy rows and back-compat writers read as human-actored.
@@ -1044,8 +1045,8 @@ type AnomalyAlert struct {
 // MachineIdentity is a non-human project member (ADR-023): a CI runner, a
 // Kubernetes workload, a service, or other automation. It carries its own
 // lifecycle, separate from human users, so the Members view can segment the two.
-// Authentication for a machine identity (its own token) is a follow-up; this is
-// the identity record + lifecycle.
+// This is the identity record + lifecycle; its own token-based authentication
+// (ADR-030) is MachineIdentityCredential below.
 type MachineIdentity struct {
 	ID           uint   `gorm:"primaryKey"`
 	ProjectID    uint   `gorm:"index"`


### PR DESCRIPTION
## Summary

Fixes backlog finding #473: several doc comments described fully-shipped
features as future/not-yet-implemented "follow-up" work — stale enough that a
future security review could mistakenly skip auditing a real, live
auth/crypto path on the assumption it doesn't exist yet.

Pure documentation fix — no code or behavior changes.

### Files updated (5 originally cited + 2 found via grep sweep)

- `internal/core/machine_identities.go` — "Machine-token authentication itself
  is a deliberate follow-up" → now describes ADR-030 issuance/hashing/
  revocation/validation as fully implemented and wired into HTTP + gRPC auth
  middleware.
- `internal/storage/models/models.go` (near `AuditEvent.ActorType`) — "the
  (future) machine-token auth path" → now references ADR-030 as shipped.
- `internal/storage/models/models.go` (`MachineIdentity`) — "Authentication for
  a machine identity ... is a follow-up" → now points to the shipped
  `MachineIdentityCredential` (ADR-030).
- `internal/cli/machine/machine.go` — "Machine-token issuance and
  authentication are a separate follow-up" → now clarifies ADR-030 is fully
  implemented and reachable via HTTP/gRPC APIs; this CLI package specifically
  doesn't yet expose its own issue/revoke subcommand (only token-hygiene
  reporting), which is the accurate residual gap.
- `internal/delivery/delivery.go` — "SMTP transport itself lands in a
  follow-up" → now points to the already-implemented `newSMTPDelivery` in
  `smtp.go`.
- `internal/crypto/keyprovider.go` — "KMS/TPM-backed providers are a future
  Tier-2 follow-up" → now references the already-implemented
  `kms_provider.go`/`tpm_provider.go`.

Additional stale instances found during the grep sweep (same "follow-up"
pattern, same auth-flow area):

- `internal/storage/models/models.go` (`ProjectInvitation`) — "email/setup-link
  consumption (accept) is a follow-up" → invitation acceptance is fully
  implemented in `internal/core/setup_consume.go`.
- `internal/core/invitations.go` — identical stale claim in the package doc
  comment, same fix.
- `internal/core/migrate_user_to_machine.go` — "a future machine-token auth
  path" → now references ADR-030 as shipped.

Also checked: ADR markdown docs (`adr-030-...`, `adr-038-...`) reference
follow-up ADRs (ADR-031 OIDC federation, later KMS/TPM ADRs) by number and are
historically accurate as written (the referenced follow-ups were later
Accepted and implemented) — left unchanged since they aren't misleading about
current state.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] Comment-only diff (no code/behavior changes) — no new tests needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)