### PR TITLE
fix(sod): flag Degraded when a principal's permissions can't be read (#420)

### DIFF
--- a/internal/cli/sod/sod.go
+++ b/internal/cli/sod/sod.go
@@ -131,11 +131,23 @@ var violationsCmd = &cobra.Command{
 			return fmt.Errorf("not connected to a server — run: keyorix connect <server>")
 		}
 		var out struct {
-			Violations []violationView `json:"violations"`
-			Count      int             `json:"count"`
+			Violations      []violationView `json:"violations"`
+			Count           int             `json:"count"`
+			Degraded        bool            `json:"degraded"`
+			DegradedReasons []string        `json:"degraded_reasons"`
 		}
 		if err := c.Get(context.Background(), "/api/v1/sod/violations", &out); err != nil {
 			return err
+		}
+		// #420: a scan that couldn't read every principal's permissions may be missing
+		// a violation — surface that instead of a silently-clean report.
+		if out.Degraded {
+			fmt.Println("*** DEGRADED SCAN — one or more principals' permissions could not be read ***")
+			fmt.Println("*** This list may be MISSING a violation for them.                        ***")
+			for _, reason := range out.DegradedReasons {
+				fmt.Printf("    - %s\n", reason)
+			}
+			fmt.Println()
 		}
 		if out.Count == 0 {
 			fmt.Println("No separation-of-duties violations.")

--- a/internal/core/compliance_evidence.go
+++ b/internal/core/compliance_evidence.go
@@ -97,8 +97,15 @@ func (c *KeyorixCore) GenerateComplianceEvidence(ctx context.Context) (*Complian
 	}
 
 	// Separation-of-duties violations (the toxic-combination register).
-	if violations, err := c.DetectSoDViolations(ctx); err == nil {
-		ev.SoDViolations = violations
+	if sod, err := c.DetectSoDViolations(ctx); err == nil {
+		ev.SoDViolations = sod.Violations
+		// #420: a principal whose permissions couldn't be read means this register
+		// may be missing a violation for them — flip the shared posture.Degraded
+		// signal so an evidence-pack consumer catches it, same as every other
+		// sub-query above.
+		for _, reason := range sod.DegradedReasons {
+			posture.degrade("evidence:sod_violations", fmt.Errorf("%s", reason))
+		}
 	} else {
 		posture.degrade("evidence:sod_violations", err)
 	}

--- a/internal/core/compliance_posture.go
+++ b/internal/core/compliance_posture.go
@@ -278,8 +278,14 @@ func (c *KeyorixCore) GetCompliancePosture(ctx context.Context) (*CompliancePost
 	// Separation-of-duties violations (A.5.3), net of governed risk exceptions
 	// (#170): an approved, active "sod"-category exception suppresses only the ONE
 	// violation it names, not the whole SoD control.
-	if violations, err := c.DetectSoDViolations(ctx); err == nil {
-		p.AccessGovernance.SoDViolations = len(c.suppressExceptedSoDViolations(ctx, violations))
+	if sod, err := c.DetectSoDViolations(ctx); err == nil {
+		p.AccessGovernance.SoDViolations = len(c.suppressExceptedSoDViolations(ctx, sod.Violations))
+		// #420: a principal whose permissions couldn't be read means the scan may be
+		// missing a violation for them — the posture rollup must say so too, not just
+		// count what it managed to see.
+		for _, reason := range sod.DegradedReasons {
+			p.degrade("sod_violations", fmt.Errorf("%s", reason))
+		}
 	} else {
 		p.degrade("sod_violations", err)
 	}

--- a/internal/core/sod.go
+++ b/internal/core/sod.go
@@ -51,6 +51,32 @@ func sodViolationReference(policyID uint, principalType string, principalID uint
 	return fmt.Sprintf("sod:policy:%d:%s:%d", policyID, principalType, principalID)
 }
 
+// SoDViolationsReport is the result of a full separation-of-duties scan: every
+// violation found, plus a signal for whether the scan is complete. #420: a user
+// whose effective permissions could not be read was previously silently skipped
+// (`continue`, no logging, no signal) — if that user actually held a toxic
+// permission combination, the violation was silently never reported, exactly the
+// fail-open shape already fixed elsewhere (CompliancePosture.degrade,
+// AccessReviewReport.degrade, SecretAccessorsResult.degrade). Degraded +
+// DegradedReasons make the gap detectable instead.
+type SoDViolationsReport struct {
+	Violations []SoDViolation `json:"violations"`
+	// Degraded is true when at least one principal's permissions could not be read,
+	// so the scan may be missing a violation for that principal.
+	Degraded bool `json:"degraded"`
+	// DegradedReasons names each principal whose permissions failed to resolve,
+	// with the underlying error.
+	DegradedReasons []string `json:"degraded_reasons,omitempty"`
+}
+
+// degrade records that a principal's permissions could not be evaluated for SoD
+// violations: it flips Degraded and appends a human-readable reason, mirroring
+// AccessReviewReport.degrade (access_review.go).
+func (r *SoDViolationsReport) degrade(area string, err error) {
+	r.Degraded = true
+	r.DegradedReasons = append(r.DegradedReasons, fmt.Sprintf("%s: %v", area, err))
+}
+
 // CreateSoDPolicy defines a toxic-combination rule. The two permissions must be
 // present and distinct. actorID is the creating admin.
 func (c *KeyorixCore) CreateSoDPolicy(ctx context.Context, actorID uint, name, description, permA, permB string) (*models.SoDPolicy, error) {
@@ -101,17 +127,19 @@ func (c *KeyorixCore) DeleteSoDPolicy(ctx context.Context, actorID, id uint) err
 // effective permissions and returns each that holds both sides of a policy. Empty
 // when there are no policies. It covers BOTH human users (paged, no silent cap) and
 // machine identities — automation principals hold roles and are authorized too, so
-// omitting them would leave the control blind to a whole class of actor.
-func (c *KeyorixCore) DetectSoDViolations(ctx context.Context) ([]SoDViolation, error) {
+// omitting them would leave the control blind to a whole class of actor. The
+// returned report's Degraded/DegradedReasons signal when a principal's permissions
+// could not be read, rather than silently reading as "scanned, no violation" (#420).
+func (c *KeyorixCore) DetectSoDViolations(ctx context.Context) (*SoDViolationsReport, error) {
 	policies, err := c.storage.ListSoDPolicies(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
 	}
+	report := &SoDViolationsReport{Violations: []SoDViolation{}}
 	if len(policies) == 0 {
-		return []SoDViolation{}, nil
+		return report, nil
 	}
 
-	violations := []SoDViolation{}
 	const pageSize = 500
 	for page := 1; ; page++ {
 		users, total, err := c.storage.ListUsers(ctx, &storage.UserFilter{Page: page, PageSize: pageSize})
@@ -122,15 +150,23 @@ func (c *KeyorixCore) DetectSoDViolations(ctx context.Context) ([]SoDViolation, 
 			if !u.IsActive {
 				continue
 			}
-			violations = append(violations, c.userSoDViolations(ctx, u, policies)...)
+			uv, err := c.userSoDViolations(ctx, u, policies)
+			if err != nil {
+				// #420: the user is still skipped (nothing else can be done without
+				// the data), but the report must say coverage is incomplete instead
+				// of looking like a clean scan that silently missed them.
+				report.degrade(fmt.Sprintf("user_permissions:user=%d", u.ID), err)
+				continue
+			}
+			report.Violations = append(report.Violations, uv...)
 		}
 		if len(users) < pageSize || int64(page*pageSize) >= total {
 			break
 		}
 	}
 
-	violations = append(violations, c.machineSoDViolations(ctx, policies)...)
-	return violations, nil
+	report.Violations = append(report.Violations, c.machineSoDViolations(ctx, policies)...)
+	return report, nil
 }
 
 // userSoDViolations returns the policy violations a single user holds. A user whose
@@ -140,7 +176,12 @@ func (c *KeyorixCore) DetectSoDViolations(ctx context.Context) ([]SoDViolation, 
 // rows may name only one side (or neither). Missing that made the SoD control blind to
 // exactly the most-privileged principals it exists to police. For a non-admin, the
 // held-set unions direct and group-inherited permissions (mirroring Authorize).
-func (c *KeyorixCore) userSoDViolations(ctx context.Context, u *models.User, policies []*models.SoDPolicy) []SoDViolation {
+//
+// #420: an error resolving the user's permissions is returned to the caller rather
+// than silently swallowed — the user genuinely can't be scanned without the data, but
+// the caller (DetectSoDViolations) must record that the scan is incomplete instead of
+// looking clean.
+func (c *KeyorixCore) userSoDViolations(ctx context.Context, u *models.User, policies []*models.SoDPolicy) ([]SoDViolation, error) {
 	if adminRole := c.adminRoleName(ctx, u.ID); adminRole != "" {
 		out := make([]SoDViolation, 0, len(policies))
 		detail := fmt.Sprintf("holds all permissions via admin role %q", adminRole)
@@ -153,16 +194,16 @@ func (c *KeyorixCore) userSoDViolations(ctx context.Context, u *models.User, pol
 				Reference: sodViolationReference(pol.ID, "user", u.ID),
 			})
 		}
-		return out
+		return out, nil
 	}
 
 	perms, err := c.storage.GetUserPermissions(ctx, u.ID)
 	if err != nil {
-		return nil // best-effort; a user whose permissions can't be read is skipped
+		return nil, err
 	}
 	groupPerms, err := c.storage.GetUserGroupPermissions(ctx, u.ID)
 	if err != nil {
-		return nil // best-effort; skip a user whose group permissions can't be read
+		return nil, err
 	}
 	held := make(map[string]bool, len(perms)+len(groupPerms))
 	for _, p := range perms {
@@ -182,7 +223,7 @@ func (c *KeyorixCore) userSoDViolations(ctx context.Context, u *models.User, pol
 			})
 		}
 	}
-	return out
+	return out, nil
 }
 
 // machineSoDViolations scans active machine identities. Machines resolve permissions

--- a/internal/core/sod_compliance_external_test.go
+++ b/internal/core/sod_compliance_external_test.go
@@ -61,10 +61,11 @@ func TestSoD_SuppressedByApprovedRiskException(t *testing.T) {
 	require.NoError(t, err)
 	require.GreaterOrEqual(t, p.AccessGovernance.SoDViolations, 1, "unaccepted, the violation counts")
 
-	violations, err := h.CoreService.DetectSoDViolations(ctx)
+	sod, err := h.CoreService.DetectSoDViolations(ctx)
 	require.NoError(t, err)
-	require.NotEmpty(t, violations)
-	ref := violations[0].Reference
+	require.False(t, sod.Degraded)
+	require.NotEmpty(t, sod.Violations)
+	ref := sod.Violations[0].Reference
 	require.NotEmpty(t, ref, "every violation must carry a stable reference to except against")
 
 	// Create the exception — NOT yet approved. Still counts.

--- a/internal/core/sod_degraded_test.go
+++ b/internal/core/sod_degraded_test.go
@@ -1,0 +1,95 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// #420: before the fix, a per-user GetUserPermissions error was silently
+// swallowed (a bare `continue`, no logging, no signal) — a user whose
+// permissions couldn't be read was dropped from the SoD scan with the report
+// looking exactly like a clean, complete one. This proves the failing user is
+// still skipped (nothing else can be done without the data) but the report now
+// flags Degraded with a reason, while the other user's real violation is still
+// correctly detected.
+func TestDetectSoDViolations_DegradedOnUserPermissionsError(t *testing.T) {
+	ctx := context.Background()
+	store := new(MockStorage)
+	c := NewKeyorixCore(store)
+
+	store.On("ListSoDPolicies", ctx).Return([]*models.SoDPolicy{
+		{ID: 1, Name: "write-vs-useradmin", PermissionA: "secrets.write", PermissionB: "users.read"},
+	}, nil)
+	store.On("ListUsers", ctx, mock.Anything).Return([]*models.User{
+		{ID: 10, Username: "alice", IsActive: true},
+		{ID: 11, Username: "bob", IsActive: true},
+	}, int64(2), nil)
+
+	// Neither user holds an admin permission-bypass role.
+	store.On("GetUserRoles", ctx, uint(10)).Return([]*models.Role{}, nil)
+	store.On("GetUserRoles", ctx, uint(11)).Return([]*models.Role{}, nil)
+
+	// alice: a real, detectable violation.
+	store.On("GetUserPermissions", ctx, uint(10)).Return([]*storage.Permission{
+		{Name: "secrets.write"}, {Name: "users.read"},
+	}, nil)
+	store.On("GetUserGroupPermissions", ctx, uint(10)).Return([]*storage.Permission{}, nil)
+
+	// bob: permissions can't be read at all.
+	store.On("GetUserPermissions", ctx, uint(11)).Return(nil, errors.New("simulated: permission lookup unavailable"))
+
+	// No machine identities to scan.
+	store.On("ListAllMachineIdentities", ctx).Return([]*models.MachineIdentity{}, nil)
+
+	report, err := c.DetectSoDViolations(ctx)
+	require.NoError(t, err)
+
+	require.True(t, report.Degraded, "a user whose permissions couldn't be read must flip Degraded")
+	require.NotEmpty(t, report.DegradedReasons)
+	assert.Contains(t, report.DegradedReasons[0], "user=11")
+
+	var users []string
+	for _, v := range report.Violations {
+		users = append(users, v.Username)
+	}
+	assert.Contains(t, users, "alice", "alice's real violation must still be detected")
+	assert.NotContains(t, users, "bob", "bob can't be evaluated without his permissions")
+
+	// bob's group permissions must never be consulted once his direct permission
+	// lookup already failed.
+	store.AssertNotCalled(t, "GetUserGroupPermissions", ctx, uint(11))
+}
+
+// A clean scan (every principal's permissions resolve) must not be marked
+// Degraded — the signal must not fire on the happy path.
+func TestDetectSoDViolations_NotDegradedOnCleanScan(t *testing.T) {
+	ctx := context.Background()
+	store := new(MockStorage)
+	c := NewKeyorixCore(store)
+
+	store.On("ListSoDPolicies", ctx).Return([]*models.SoDPolicy{
+		{ID: 1, Name: "write-vs-useradmin", PermissionA: "secrets.write", PermissionB: "users.read"},
+	}, nil)
+	store.On("ListUsers", ctx, mock.Anything).Return([]*models.User{
+		{ID: 10, Username: "alice", IsActive: true},
+	}, int64(1), nil)
+	store.On("GetUserRoles", ctx, uint(10)).Return([]*models.Role{}, nil)
+	store.On("GetUserPermissions", ctx, uint(10)).Return([]*storage.Permission{
+		{Name: "secrets.read"},
+	}, nil)
+	store.On("GetUserGroupPermissions", ctx, uint(10)).Return([]*storage.Permission{}, nil)
+	store.On("ListAllMachineIdentities", ctx).Return([]*models.MachineIdentity{}, nil)
+
+	report, err := c.DetectSoDViolations(ctx)
+	require.NoError(t, err)
+	assert.False(t, report.Degraded)
+	assert.Empty(t, report.DegradedReasons)
+	assert.Empty(t, report.Violations)
+}

--- a/internal/core/sod_external_test.go
+++ b/internal/core/sod_external_test.go
@@ -32,7 +32,8 @@ func TestDetectSoDViolations(t *testing.T) {
 	require.NoError(t, err)
 
 	var users []string
-	for _, v := range violations {
+	require.False(t, violations.Degraded)
+	for _, v := range violations.Violations {
 		users = append(users, v.Username)
 		assert.Equal(t, "write-vs-useradmin", v.PolicyName)
 	}
@@ -69,7 +70,8 @@ func TestDetectSoDViolations_GroupInheritedPermission(t *testing.T) {
 	require.NoError(t, err)
 
 	var users []string
-	for _, v := range violations {
+	require.False(t, violations.Degraded)
+	for _, v := range violations.Violations {
 		users = append(users, v.Username)
 	}
 	assert.Contains(t, users, "carol", "carol holds secrets.write via her group and secrets.read directly")
@@ -105,7 +107,8 @@ func TestDetectSoDViolations_AdminBypass(t *testing.T) {
 		detail   string
 		username string
 	}
-	for _, v := range violations {
+	require.False(t, violations.Degraded)
+	for _, v := range violations.Violations {
 		if v.Username == "erin" {
 			erinV = &struct {
 				detail   string
@@ -146,7 +149,8 @@ func TestDetectSoDViolations_MachinePrincipal(t *testing.T) {
 	require.NoError(t, err)
 
 	var found bool
-	for _, v := range violations {
+	require.False(t, violations.Degraded)
+	for _, v := range violations.Violations {
 		if v.PrincipalType == "machine" && v.Username == "ci-bot" {
 			found = true
 			assert.Equal(t, uint(70), v.UserID)
@@ -166,7 +170,8 @@ func TestDetectSoDViolations_NoPolicies(t *testing.T) {
 
 	v, err := h.CoreService.DetectSoDViolations(context.Background())
 	require.NoError(t, err)
-	assert.Empty(t, v)
+	assert.False(t, v.Degraded)
+	assert.Empty(t, v.Violations)
 }
 
 // CreateSoDPolicy validates its inputs.

--- a/server/http/handlers/sod.go
+++ b/server/http/handlers/sod.go
@@ -91,11 +91,19 @@ func (h *CatalogHandler) DeleteSoDPolicy(w http.ResponseWriter, r *http.Request)
 
 // ListSoDViolations handles GET /api/v1/sod/violations.
 func (h *CatalogHandler) ListSoDViolations(w http.ResponseWriter, r *http.Request) {
-	violations, err := h.coreService.DetectSoDViolations(r.Context())
+	report, err := h.coreService.DetectSoDViolations(r.Context())
 	if err != nil {
 		log.Printf("Error detecting SoD violations: %v", err)
 		sendError(w, "Error", clientSafe(err), http.StatusInternalServerError, nil)
 		return
 	}
-	sendSuccess(w, map[string]interface{}{"violations": violations, "count": len(violations)}, "")
+	// #420: degraded/degraded_reasons must reach API consumers — a scan that silently
+	// skipped a principal whose permissions couldn't be read would otherwise look
+	// identical to one that scanned everyone and found nothing for them.
+	sendSuccess(w, map[string]interface{}{
+		"violations":       report.Violations,
+		"count":            len(report.Violations),
+		"degraded":         report.Degraded,
+		"degraded_reasons": report.DegradedReasons,
+	}, "")
 }


### PR DESCRIPTION
## Summary
- `DetectSoDViolations` (`internal/core/sod.go`) silently `continue`d past a per-user `GetUserPermissions`/`GetUserGroupPermissions` error with no logging or signal -- that user was dropped from the SoD scan entirely, so a toxic permission combination held by an unreadable user would never surface (#420), the same fail-open shape already fixed for `CompliancePosture`, `DashboardStats`, `SecretAccessorsResult` (#417), and `AccessReviewReport` (#453).
- `DetectSoDViolations` now returns `*SoDViolationsReport{Violations, Degraded, DegradedReasons}` instead of a bare `[]SoDViolation`, mirroring the `AccessReviewReport`/`SecretAccessorsResult` `degrade()` pattern. The affected user is still skipped (nothing else can be done without the data), but the report now says coverage is incomplete.
- Wired the new signal through: `compliance_posture.go` (`AccessGovernance.SoDViolations` rollup, flips the shared `CompliancePosture.Degraded`), `compliance_evidence.go` (the SoD evidence-pack register, same), the `GET /api/v1/sod/violations` HTTP handler (`degraded`/`degraded_reasons` in the JSON response), and the `keyorix sod violations` CLI command (prints a `DEGRADED SCAN` warning with reasons).

## Test plan
- [x] Added `TestDetectSoDViolations_DegradedOnUserPermissionsError`: one of two users fails `GetUserPermissions`; asserts the report is `Degraded` with a reason naming that user, the other user's real violation is still detected, and the failing user's `GetUserGroupPermissions` is never called.
- [x] Added `TestDetectSoDViolations_NotDegradedOnCleanScan`: a fully-resolving scan is not marked `Degraded`.
- [x] Updated existing `sod_external_test.go`/`sod_compliance_external_test.go` callers for the new return type.
- [x] `go build ./...`, `go vet ./...` clean.
- [x] `go test ./internal/core/...` clean (re-ran once to confirm no flake).
- [x] `gosec -severity medium -exclude-generated ./internal/core/...` — 0 issues.
- [x] `golangci-lint run` on all changed packages — 0 issues.