### PR TITLE
harden(dynamic-secrets): enforce one config per (project, env, name) (#462)

### DIFF
--- a/internal/core/dynamic_secrets.go
+++ b/internal/core/dynamic_secrets.go
@@ -7,10 +7,12 @@ package core
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"time"
 
+	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/dynamic"
 	"github.com/keyorixhq/keyorix/internal/encryption"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
@@ -103,6 +105,14 @@ func (c *KeyorixCore) CreateDynamicSecretConfig(ctx context.Context, req *Create
 		UpdatedAt:         c.now(),
 	})
 	if err != nil {
+		// #462: DynamicSecretConfig's doc comment states "one per (project, env,
+		// name)"; the unique index uniq_dynamic_secret_configs_project_env_name backs
+		// that up at the DB layer and CreateDynamicSecretConfig wraps a violation in
+		// storage.ErrDuplicateDynamicSecretConfig. Surface a clean validation error
+		// instead of a raw constraint-violation message.
+		if errors.Is(err, storage.ErrDuplicateDynamicSecretConfig) {
+			return nil, fmt.Errorf("a dynamic-secret config named %q already exists in this project and environment", req.Name)
+		}
 		return nil, err
 	}
 	dsnEnc, dsnMeta, err := c.encryptAuthSecret(req.AdminDSN, encryption.DynamicSecretConfigAAD(cfg.ID, cfg.ProjectID, cfg.EnvironmentID))

--- a/internal/core/dynamic_secrets_test.go
+++ b/internal/core/dynamic_secrets_test.go
@@ -36,6 +36,11 @@ func newDynamicTestCore(t *testing.T) (*KeyorixCore, *gorm.DB, *dynamic.FakeEngi
 		&models.Role{}, &models.UserRole{}, &models.Group{}, &models.UserGroup{}, &models.GroupRole{},
 		&models.Project{}, &models.Environment{},
 	))
+	// Mirror factory.go's ensureDynamicSecretConfigNameIndex exactly (#462), so tests in
+	// this file exercise the same DB-level "one per (project, env, name)" guard
+	// production installs get.
+	require.NoError(t, db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS uniq_dynamic_secret_configs_project_env_name "+
+		"ON dynamic_secret_configs (project_id, environment_id, name)").Error)
 	require.NoError(t, db.Create(&models.Role{ID: 1, Name: "admin"}).Error)
 	require.NoError(t, db.Create(&models.UserRole{UserID: testAdminActorID, RoleID: 1}).Error)
 	// Every config created via mkConfig (or inline in these tests) targets
@@ -102,6 +107,61 @@ func TestDynamicSecrets_CreateConfig_RequiresAdminAuthority(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.NotZero(t, cfg.ID)
+}
+
+// TestDynamicSecrets_CreateConfig_DuplicateNameRejected is the (#462) regression:
+// DynamicSecretConfig's doc comment states "one per (project, env, name)" but
+// nothing enforced it. A second CreateDynamicSecretConfig call for the identical
+// (project, environment, name) tuple must fail with a clear validation error, not
+// silently create a duplicate row.
+func TestDynamicSecrets_CreateConfig_DuplicateNameRejected(t *testing.T) {
+	c, _, _, _ := newDynamicTestCore(t)
+	ctx := context.Background()
+	_ = mkConfig(t, c, ctx) // "app-db" on ProjectID 1 / EnvironmentID 2
+
+	_, err := c.CreateDynamicSecretConfig(ctx, &CreateDynamicSecretConfigRequest{
+		Name: "app-db", ProjectID: 1, EnvironmentID: 2, BackendType: "postgres",
+		AdminDSN: adminDSNPlain, DefaultTTLSeconds: 3600, CreatedBy: "bob", ActorID: testAdminActorID,
+	})
+	require.Error(t, err, "a duplicate (project, env, name) config must be rejected")
+	assert.Contains(t, err.Error(), "already exists")
+
+	configs, err := c.storage.ListDynamicSecretConfigs(ctx, 1, 2)
+	require.NoError(t, err)
+	assert.Len(t, configs, 1, "only the original config must exist")
+}
+
+// TestDynamicSecrets_CreateConfig_DifferentScopeAllowed asserts the "one per
+// (project, env, name)" rule (#462) is scoped to the full tuple: a different
+// environment, a different project, or a different name must all succeed
+// independently of an existing config.
+func TestDynamicSecrets_CreateConfig_DifferentScopeAllowed(t *testing.T) {
+	c, db, _, _ := newDynamicTestCore(t)
+	ctx := context.Background()
+	_ = mkConfig(t, c, ctx) // "app-db" on ProjectID 1 / EnvironmentID 2
+
+	// Different environment, same project + name.
+	require.NoError(t, db.Create(&models.Environment{ID: 3, ProjectID: 1, Name: "dyn-test-env-2"}).Error)
+	_, err := c.CreateDynamicSecretConfig(ctx, &CreateDynamicSecretConfigRequest{
+		Name: "app-db", ProjectID: 1, EnvironmentID: 3, BackendType: "postgres",
+		AdminDSN: adminDSNPlain, DefaultTTLSeconds: 3600, CreatedBy: "alice", ActorID: testAdminActorID,
+	})
+	assert.NoError(t, err, "the same name in a different environment must succeed")
+
+	// Different project, same environment ID + name.
+	require.NoError(t, db.Create(&models.Project{ID: 4, Name: "dyn-test-project-2"}).Error)
+	_, err = c.CreateDynamicSecretConfig(ctx, &CreateDynamicSecretConfigRequest{
+		Name: "app-db", ProjectID: 4, EnvironmentID: 2, BackendType: "postgres",
+		AdminDSN: adminDSNPlain, DefaultTTLSeconds: 3600, CreatedBy: "alice", ActorID: testAdminActorID,
+	})
+	assert.NoError(t, err, "the same name in a different project must succeed")
+
+	// Same project + environment, different name.
+	_, err = c.CreateDynamicSecretConfig(ctx, &CreateDynamicSecretConfigRequest{
+		Name: "app-db-2", ProjectID: 1, EnvironmentID: 2, BackendType: "postgres",
+		AdminDSN: adminDSNPlain, DefaultTTLSeconds: 3600, CreatedBy: "alice", ActorID: testAdminActorID,
+	})
+	assert.NoError(t, err, "a different name in the same project/environment must succeed")
 }
 
 func TestDynamicSecrets_ConfigEncryptsAdminDSN(t *testing.T) {

--- a/internal/core/storage/errors.go
+++ b/internal/core/storage/errors.go
@@ -84,3 +84,11 @@ var ErrUnsupportedByBackend = errors.New("operation not supported by the active 
 // the same friendly "already active" message a losing racer gets from the earlier
 // application-level check.
 var ErrBreakGlassAlreadyActive = errors.New("an active break-glass grant already exists for this project and user")
+
+// ErrDuplicateDynamicSecretConfig is returned (wrapped) by CreateDynamicSecretConfig
+// when the insert collides with the unique index on dynamic_secret_configs
+// (project_id, environment_id, name, #462), matching DynamicSecretConfig's own doc
+// comment ("one per (project, env, name)") — previously documented but not enforced.
+// Callers translate this into a clean validation error instead of a raw
+// constraint-violation message.
+var ErrDuplicateDynamicSecretConfig = errors.New("a dynamic-secret config with this name already exists in this project and environment")

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -483,6 +483,17 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 			return fmt.Errorf("failed to migrate dynamic_secret_leases table: %w", err)
 		}
 	}
+	// At most one dynamic-secret config may exist per (project, environment, name)
+	// (#462), matching DynamicSecretConfig's own doc comment. The struct carries no
+	// unique-index tag (same reason as the max-TTL/Disabled columns above: this table
+	// is never re-AutoMigrated once it exists), so the index must be created
+	// explicitly here to also reach pre-existing databases. Close the gap at the DB
+	// layer regardless of whether the table pre-existed.
+	if tableExists(db, "dynamic_secret_configs") {
+		if err := ensureDynamicSecretConfigNameIndex(db); err != nil {
+			return err
+		}
+	}
 
 	// Create the WebAuthn tables if missing (ADR-036, additive, safe on existing DBs).
 	if !webauthnCredExists {
@@ -869,6 +880,19 @@ func ensureShareRecordUniqueIndex(db *gorm.DB) error {
 func ensureSecretVersionIndex(db *gorm.DB) error {
 	if err := db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS uniq_secret_versions_node_version ON secret_versions (secret_node_id, version_number)").Error; err != nil {
 		return fmt.Errorf("failed to create secret_versions unique index: %w", err)
+	}
+	return nil
+}
+
+// ensureDynamicSecretConfigNameIndex creates a unique index on
+// dynamic_secret_configs (project_id, environment_id, name), matching
+// DynamicSecretConfig's doc comment ("one per (project, env, name)", #462).
+// DynamicSecretConfig has no soft-delete column, so — unlike the partial indexes
+// above — this is a plain (non-partial) unique index. Idempotent; works on SQLite
+// and Postgres.
+func ensureDynamicSecretConfigNameIndex(db *gorm.DB) error {
+	if err := db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS uniq_dynamic_secret_configs_project_env_name ON dynamic_secret_configs (project_id, environment_id, name)").Error; err != nil {
+		return fmt.Errorf("failed to create dynamic_secret_configs unique index: %w", err)
 	}
 	return nil
 }

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -581,7 +581,11 @@ type SecretVersion struct {
 // DynamicSecretConfig (ADR-035) defines an on-demand database-credential source:
 // Keyorix connects to the target with the (encrypted) admin DSN and runs the
 // creation template to mint a short-lived role per lease. One per (project, env,
-// name).
+// name) — enforced by a unique index on (project_id, environment_id, name)
+// created in migrateDatabase (#462), not a `uniqueIndex` struct tag here: this
+// table is never fully re-AutoMigrated once it exists (same pgx hazard as
+// elsewhere in migrateDatabase), so a struct tag alone would never reach an
+// existing database.
 type DynamicSecretConfig struct {
 	ID            uint   `gorm:"primaryKey"`
 	Name          string `gorm:"not null"`

--- a/internal/storage/store/local_dynamic.go
+++ b/internal/storage/store/local_dynamic.go
@@ -4,13 +4,24 @@ package store
 
 import (
 	"context"
+	"fmt"
 	"time"
 
+	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
 func (ls *LocalStorage) CreateDynamicSecretConfig(ctx context.Context, c *models.DynamicSecretConfig) (*models.DynamicSecretConfig, error) {
 	if err := ls.db.WithContext(ctx).Create(c).Error; err != nil {
+		if isUniqueViolation(err) {
+			// The unique index uniq_dynamic_secret_configs_project_env_name (#462) caught a
+			// duplicate (project, environment, name) tuple — the only unique constraint on
+			// this table, so a bare driver-message match (isUniqueViolation, shared with
+			// CreateProjectMembership) is unambiguous here. Translate to the sentinel so
+			// callers (CreateDynamicSecretConfig in internal/core) can surface a clean
+			// validation error instead of a raw constraint-violation message.
+			return nil, fmt.Errorf("%w: %v", storage.ErrDuplicateDynamicSecretConfig, err)
+		}
 		return nil, err
 	}
 	return c, nil

--- a/internal/storage/store/local_dynamic_test.go
+++ b/internal/storage/store/local_dynamic_test.go
@@ -1,0 +1,89 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	coreStorage "github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// newDynamicConfigTestStore builds a LocalStorage over real SQLite with the
+// dynamic_secret_configs unique index installed, mirroring
+// ensureDynamicSecretConfigNameIndex in factory.go exactly (#462), so these tests
+// exercise the same DB-level guard production installs get.
+func newDynamicConfigTestStore(t *testing.T) *LocalStorage {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.DynamicSecretConfig{}))
+	require.NoError(t, db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS uniq_dynamic_secret_configs_project_env_name "+
+		"ON dynamic_secret_configs (project_id, environment_id, name)").Error)
+	return NewLocalStorage(db)
+}
+
+// TestCreateDynamicSecretConfig_DuplicateNameRejected is the (#462) regression:
+// DynamicSecretConfig's doc comment states "one per (project, env, name)" but
+// nothing enforced it. A second create for the identical (project, environment,
+// name) tuple must fail with the translated sentinel, not silently create a
+// second row nor surface a raw constraint-violation message.
+func TestCreateDynamicSecretConfig_DuplicateNameRejected(t *testing.T) {
+	ctx := context.Background()
+	ls := newDynamicConfigTestStore(t)
+
+	first, err := ls.CreateDynamicSecretConfig(ctx, &models.DynamicSecretConfig{
+		Name: "app-db", ProjectID: 1, EnvironmentID: 2, BackendType: "postgres",
+	})
+	require.NoError(t, err)
+	assert.NotZero(t, first.ID)
+
+	_, err = ls.CreateDynamicSecretConfig(ctx, &models.DynamicSecretConfig{
+		Name: "app-db", ProjectID: 1, EnvironmentID: 2, BackendType: "postgres",
+	})
+	require.Error(t, err, "a second config with the identical (project, env, name) tuple must be rejected")
+	assert.True(t, errors.Is(err, coreStorage.ErrDuplicateDynamicSecretConfig),
+		"the duplicate must be translated to the sentinel, not surfaced as a raw constraint-violation error")
+
+	var count int64
+	require.NoError(t, ls.db.Model(&models.DynamicSecretConfig{}).
+		Where("project_id = ? AND environment_id = ? AND name = ?", 1, 2, "app-db").
+		Count(&count).Error)
+	assert.Equal(t, int64(1), count, "only one row must exist for the duplicate tuple")
+}
+
+// TestCreateDynamicSecretConfig_DifferentScopeAllowed asserts the unique index is
+// scoped to the full (project, environment, name) tuple: different environments,
+// different projects, or a different name for the same (project, environment) must
+// all succeed independently.
+func TestCreateDynamicSecretConfig_DifferentScopeAllowed(t *testing.T) {
+	ctx := context.Background()
+	ls := newDynamicConfigTestStore(t)
+
+	_, err := ls.CreateDynamicSecretConfig(ctx, &models.DynamicSecretConfig{
+		Name: "app-db", ProjectID: 1, EnvironmentID: 2, BackendType: "postgres",
+	})
+	require.NoError(t, err)
+
+	// Same project + name, different environment.
+	_, err = ls.CreateDynamicSecretConfig(ctx, &models.DynamicSecretConfig{
+		Name: "app-db", ProjectID: 1, EnvironmentID: 3, BackendType: "postgres",
+	})
+	assert.NoError(t, err, "the same name in a different environment must succeed")
+
+	// Different project, same environment ID + name.
+	_, err = ls.CreateDynamicSecretConfig(ctx, &models.DynamicSecretConfig{
+		Name: "app-db", ProjectID: 2, EnvironmentID: 2, BackendType: "postgres",
+	})
+	assert.NoError(t, err, "the same name in a different project must succeed")
+
+	// Same project + environment, different name.
+	_, err = ls.CreateDynamicSecretConfig(ctx, &models.DynamicSecretConfig{
+		Name: "other-db", ProjectID: 1, EnvironmentID: 2, BackendType: "postgres",
+	})
+	assert.NoError(t, err, "a different name in the same project/environment must succeed")
+}


### PR DESCRIPTION
## Summary
- Closes #462: `DynamicSecretConfig`'s doc comment claimed "one per (project, env, name)" but there was no unique index or create-time check backing it.
- Adds a unique index `uniq_dynamic_secret_configs_project_env_name` on `(project_id, environment_id, name)`, created explicitly in `migrateDatabase` (not via a struct `uniqueIndex` tag) because this table is never re-`AutoMigrate`d once it exists — the same pgx hazard documented elsewhere in that function. This reaches both fresh and pre-existing databases.
- `LocalStorage.CreateDynamicSecretConfig` translates a violation into the new `storage.ErrDuplicateDynamicSecretConfig` sentinel (mirroring `CreateProjectMembership`'s `isUniqueViolation` pattern), and `core.CreateDynamicSecretConfig` surfaces it as a clean validation error instead of a raw constraint-violation message.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/core/... ./internal/storage/store/... ./internal/storage/...`
- [x] `gosec -severity medium -exclude-generated` on `internal/core` and `internal/storage` — 0 issues
- [x] New regression tests at both layers: duplicate `(project, env, name)` rejected; different project/environment/name still succeed independently.