### PR TITLE
harden(github-action): mask token, verify CLI provenance, strengthen heredoc delimiter (#179)

### DIFF
--- a/integrations/github-action/entrypoint.sh
+++ b/integrations/github-action/entrypoint.sh
@@ -8,9 +8,33 @@
 # stderr) so values are parsed unambiguously with jq.
 set -euo pipefail
 
+# mask_value registers a GitHub Actions log mask for every line of a (possibly
+# multi-line) secret value. `::add-mask::` operates per-LINE: one directive
+# redacts exactly one line-oriented string, so a multi-line secret (e.g. a PEM
+# private key or a multi-line config blob) previously only had its FIRST line
+# masked — every subsequent line of the same secret would still appear in
+# plaintext in the job log (#466). Emit a mask for each line individually so
+# the whole value is covered no matter how many lines it spans.
+#
+# Defined this early (rather than alongside inject_env below) so it's
+# available immediately after KEYORIX_TOKEN is read, for #179 below.
+mask_value() {
+  local val="$1" line
+  while IFS= read -r line; do
+    [ -n "$line" ] && echo "::add-mask::$line"
+  done < <(printf '%s\n' "$val")
+}
+
 : "${KEYORIX_SERVER:?server input is required}"
 : "${KEYORIX_TOKEN:?token input is required}"
 export KEYORIX_SERVER KEYORIX_TOKEN
+
+# Mask the action's own auth token as early as possible (#179). Unlike the
+# SECRET VALUES this action fetches (masked individually by mask_value/
+# inject_env below), KEYORIX_TOKEN itself was never masked — if it were ever
+# echoed by an error message or debug trace (this script's own, the CLI's, or
+# a later step's), it would render in plaintext in the job log.
+mask_value "$KEYORIX_TOKEN"
 
 PROJECT="${INPUT_PROJECT:-default}"
 ENVIRONMENT="${INPUT_ENVIRONMENT:-development}"
@@ -20,13 +44,31 @@ OUTPUT_FILE="${INPUT_OUTPUT_FILE:-}"
 
 install_dir="/usr/local/bin"
 
-install_cli() {
-  if command -v keyorix >/dev/null 2>&1; then
-    echo "Using existing keyorix: $(keyorix --version)"
-    return
+# sha256_of prints the SHA-256 of the given file using whichever of
+# sha256sum/shasum is available, or fails if neither is.
+sha256_of() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | awk '{print $1}'
+  else
+    return 1
   fi
+}
+
+install_cli() {
+  # A `keyorix` binary already on PATH must never be trusted blindly (#179):
+  # a compromised runner image, a poisoned PATH, or a self-hosted runner
+  # shared with other jobs could otherwise substitute a malicious binary that
+  # this action would then execute with the caller's KEYORIX_TOKEN. We only
+  # ever reuse such a binary after verifying ITS SHA-256 against the same
+  # published checksums.txt used for the download path below — which
+  # requires a pinned `version` input. An unpinned "latest" install has no
+  # fixed, known-good hash to check an arbitrary on-PATH binary against, so
+  # that path (the `else` branch) always fetches and verifies a fresh copy
+  # instead of ever considering what's already on PATH.
   if [ -n "$VERSION" ]; then
-    local binary_name checksums_url expected actual
+    local os arch binary_name url checksums_url expected actual tmp_dir tmp_bin existing
     os="$(uname -s | tr '[:upper:]' '[:lower:]')"
     arch="$(uname -m)"
     case "$arch" in
@@ -36,48 +78,66 @@ install_cli() {
     binary_name="keyorix_${os}_${arch}"
     url="https://github.com/keyorixhq/keyorix/releases/download/${VERSION}/${binary_name}"
     checksums_url="https://github.com/keyorixhq/keyorix/releases/download/${VERSION}/checksums.txt"
-    echo "Downloading keyorix ${VERSION} (${os}/${arch})..."
-    curl -fsSL "$url" -o /tmp/keyorix
 
-    # Verify SHA-256 against the release's published checksums.txt, same
-    # approach install.sh uses for the "latest" path below — fail closed
-    # (rather than install.sh's skip-if-missing) since this path has no
-    # other integrity signal.
+    # Fetch the expected checksum first, fail closed (rather than
+    # install.sh's skip-if-missing) since this path has no other integrity
+    # signal — this is required whether we end up reusing an existing binary
+    # or downloading a fresh one.
     echo "Verifying checksum..."
     expected="$(curl -fsSL "$checksums_url" | awk -v n="$binary_name" '$2==n {print $1}')"
     if [ -z "$expected" ]; then
       echo "error: no checksum published for ${binary_name} at ${VERSION}; refusing to install unverified binary" >&2
-      rm -f /tmp/keyorix
       exit 1
     fi
-    if command -v sha256sum >/dev/null 2>&1; then
-      actual="$(sha256sum /tmp/keyorix | awk '{print $1}')"
-    elif command -v shasum >/dev/null 2>&1; then
-      actual="$(shasum -a 256 /tmp/keyorix | awk '{print $1}')"
-    else
+
+    existing="$(command -v keyorix 2>/dev/null || true)"
+    if [ -n "$existing" ]; then
+      if actual="$(sha256_of "$existing" 2>/dev/null)" && [ -n "$actual" ] && [ "$actual" = "$expected" ]; then
+        echo "Using existing keyorix at ${existing} (checksum verified against ${VERSION})"
+        keyorix --version
+        return
+      fi
+      echo "warning: keyorix already on PATH does not match ${VERSION}'s published checksum; ignoring it and installing a fresh, verified copy" >&2
+    fi
+
+    # A fresh, non-predictable directory per run (mirroring install.sh's own
+    # `mktemp -d`, not a fixed, guessable path as this used previously)
+    # closes off a symlink/TOCTOU race where another process on a shared
+    # runner pre-creates or swaps the path between our download, checksum
+    # check, chmod, and mv below. Cleaned up on any exit path via the trap.
+    #
+    # An explicit template under $TMPDIR (rather than a bare `mktemp -d`) so
+    # this respects a caller-set $TMPDIR instead of some implementations'
+    # fixed OS temp dir fallback.
+    tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/keyorix-cli.XXXXXX")"
+    trap 'rm -rf "$tmp_dir"' EXIT
+    tmp_bin="${tmp_dir}/keyorix"
+
+    echo "Downloading keyorix ${VERSION} (${os}/${arch})..."
+    curl -fsSL "$url" -o "$tmp_bin"
+
+    if ! actual="$(sha256_of "$tmp_bin")"; then
       echo "error: no sha256sum/shasum tool found; cannot verify checksum" >&2
-      rm -f /tmp/keyorix
       exit 1
     fi
     if [ "$actual" != "$expected" ]; then
       echo "error: checksum mismatch for ${binary_name}: expected ${expected}, got ${actual}. Aborting." >&2
-      rm -f /tmp/keyorix
       exit 1
     fi
     echo "Checksum verified"
 
-    chmod +x /tmp/keyorix
+    chmod +x "$tmp_bin"
     if [ -w "$install_dir" ]; then
-      mv /tmp/keyorix "${install_dir}/keyorix"
+      mv "$tmp_bin" "${install_dir}/keyorix"
     else
-      sudo mv /tmp/keyorix "${install_dir}/keyorix"
+      sudo mv "$tmp_bin" "${install_dir}/keyorix"
     fi
   else
-    # Latest release via the official installer (verifies the checksum).
-    # Pinned to a specific commit SHA (not the mutable `main` branch, and
-    # not a movable tag ref) so a future main-branch or tag compromise
-    # can't alter the code piped into `sh` here. Bump deliberately when
-    # install.sh's logic needs to change.
+    # Latest release via the official installer (verifies the checksum, and
+    # itself downloads into its own `mktemp -d`). Pinned to a specific commit
+    # SHA (not the mutable `main` branch, and not a movable tag ref) so a
+    # future main-branch or tag compromise can't alter the code piped into
+    # `sh` here. Bump deliberately when install.sh's logic needs to change.
     curl -fsSL https://raw.githubusercontent.com/keyorixhq/keyorix/6dd9e555125500e76b4e2035a867621e416585a3/install.sh | sh
   fi
   keyorix --version
@@ -95,20 +155,6 @@ install_cli() {
 # can ever reach the file.
 validate_secret_name() {
   [[ "$1" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]
-}
-
-# mask_value registers a GitHub Actions log mask for every line of a (possibly
-# multi-line) secret value. `::add-mask::` operates per-LINE: one directive
-# redacts exactly one line-oriented string, so a multi-line secret (e.g. a PEM
-# private key or a multi-line config blob) previously only had its FIRST line
-# masked — every subsequent line of the same secret would still appear in
-# plaintext in the job log (#466). Emit a mask for each line individually so
-# the whole value is covered no matter how many lines it spans.
-mask_value() {
-  local val="$1" line
-  while IFS= read -r line; do
-    [ -n "$line" ] && echo "::add-mask::$line"
-  done <<<"$val"
 }
 
 inject_env() {
@@ -135,7 +181,15 @@ inject_env() {
     mask_value "$val"
     if [ "$EXPORT_TO_ENV" = "true" ]; then
       # Heredoc form so multi-line values survive the GITHUB_ENV file format.
-      delim="KEYORIX_EOF_${RANDOM}${RANDOM}"
+      # The delimiter must be unguessable: if it ever collided with (or were
+      # predictable enough to be engineered to collide with) a line inside
+      # $val, that line would be parsed as the heredoc terminator, truncating
+      # the secret and injecting whatever follows as extra $GITHUB_ENV
+      # content. `$RANDOM` is a 15-bit (0-32767) LCG PRNG — two draws give
+      # only ~30 bits of entropy and are trivially brute-forceable/predictable
+      # (#179) — so derive it from a CSPRNG instead, matching install.sh's use
+      # of /dev/urandom-backed tooling elsewhere in this repo's shell scripts.
+      delim="KEYORIX_EOF_$(openssl rand -hex 16 2>/dev/null || head -c16 /dev/urandom | od -An -tx1 | tr -d ' \n')"
       {
         printf '%s<<%s\n' "$key" "$delim"
         printf '%s\n' "$val"

--- a/integrations/github-action/test/entrypoint_test.sh
+++ b/integrations/github-action/test/entrypoint_test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Minimal black-box tests for entrypoint.sh, covering fixes across rounds
-# (HARDENING-BACKLOG #175/#176/#177, #466):
+# (HARDENING-BACKLOG #175/#176/#177, #179, #466):
 #
 #   #175 — a pinned `version` install must abort if the downloaded binary's
 #          checksum doesn't match the release's published checksums.txt.
@@ -9,6 +9,12 @@
 #   #177 — secret values must be `::add-mask::`d on the output-file path
 #          even when export-to-env=false (so inject_env's masking is
 #          skipped).
+#   #179 — (1) the action's own KEYORIX_TOKEN must be `::add-mask::`d, not
+#          just secret VALUES fetched by it; (2) a `keyorix` already on PATH
+#          must never be trusted without a matching checksum, and the CLI
+#          download path must not use the fixed, guessable /tmp/keyorix;
+#          (3) the $GITHUB_ENV heredoc delimiter must come from a CSPRNG, not
+#          the low-entropy $RANDOM.
 #   #466 — a multi-line secret value (e.g. a private key) must have EVERY
 #          line masked, not just the first — GitHub Actions' ::add-mask::
 #          operates per-line.
@@ -59,6 +65,39 @@ else
   bad "#176: installer is not pinned to a commit SHA"
 fi
 
+# --- #179 (item 2, static): the CLI download path must no longer be the
+# fixed, guessable /tmp/keyorix — it must use a fresh, non-predictable
+# mktemp'd directory instead, closing the "guess the path and race a
+# substitution" angle.
+if grep -q '/tmp/keyorix' "$entrypoint"; then
+  bad "#179: install_cli still downloads to the fixed, guessable /tmp/keyorix"
+else
+  ok "#179: install_cli no longer uses the fixed /tmp/keyorix path"
+fi
+
+if grep -q 'mktemp -d' "$entrypoint"; then
+  ok "#179: install_cli downloads into a fresh mktemp'd directory"
+else
+  bad "#179: install_cli does not use mktemp -d for its download directory"
+fi
+
+# --- #179 (item 3, static): the $GITHUB_ENV heredoc delimiter must no
+# longer be built from the low-entropy (~30-bit) $RANDOM, and must instead
+# come from a CSPRNG.
+# The literal, unexpanded '${RANDOM}${RANDOM}' text is the point of this case.
+# shellcheck disable=SC2016
+if grep -q '${RANDOM}${RANDOM}' "$entrypoint"; then
+  bad "#179: heredoc delimiter still uses the low-entropy \$RANDOM\$RANDOM"
+else
+  ok "#179: heredoc delimiter no longer uses \$RANDOM\$RANDOM"
+fi
+
+if grep -qE 'openssl rand|/dev/urandom' "$entrypoint"; then
+  ok "#179: heredoc delimiter is derived from a CSPRNG (openssl rand/\`/dev/urandom\`)"
+else
+  bad "#179: heredoc delimiter does not appear to use a CSPRNG"
+fi
+
 # --- #175: a checksum mismatch on the pinned-version path must abort
 # loudly, not proceed to install the (corrupted/tampered) binary.
 cp "${fixtures}/mock_curl_checksum_mismatch.sh" "${mockbin}/curl"
@@ -80,16 +119,49 @@ else
   bad "#175: checksum mismatch did not abort as expected (rc=${rc1}); stderr: $(cat "${workdir}/stderr1.log")"
 fi
 
-# --- #177: secret values must be masked on the output-file path even
-# when export-to-env=false skips inject_env (and its masking) entirely.
+# --- #179 (item 2, dynamic): a `keyorix` already on PATH whose checksum
+# does NOT match the pinned version's published checksums.txt must be
+# ignored (with a warning), not silently trusted — install_cli must fall
+# through to a real (verified) download attempt instead.
 cp "${fixtures}/mock_keyorix.sh" "${mockbin}/keyorix"
 chmod +x "${mockbin}/keyorix"
+
+set +e
+PATH="${mockbin}:${PATH}" \
+  KEYORIX_SERVER="https://example.invalid" \
+  KEYORIX_TOKEN="dummy-token" \
+  INPUT_VERSION="v9.9.9" \
+  INPUT_EXPORT_TO_ENV="false" \
+  bash "$entrypoint" >"${workdir}/stdout1b.log" 2>"${workdir}/stderr1b.log"
+rc1b=$?
+set -e
+
+if [ "$rc1b" -ne 0 ] \
+  && grep -qi "does not match .* published checksum" "${workdir}/stderr1b.log" \
+  && grep -qi "checksum mismatch" "${workdir}/stderr1b.log"; then
+  ok "#179: an on-PATH keyorix with a mismatched checksum is not silently trusted"
+else
+  bad "#179: an on-PATH keyorix with a mismatched checksum was not rejected as expected (rc=${rc1b}); stderr: $(cat "${workdir}/stderr1b.log")"
+fi
+
+# --- #177: secret values must be masked on the output-file path even
+# when export-to-env=false skips inject_env (and its masking) entirely.
+#
+# Pairs INPUT_VERSION with mock_curl_checksum_match.sh (which serves the
+# mock keyorix fixture's own SHA-256 as the "published" checksum) so
+# install_cli's checksum-verified reuse path (#179) accepts the already-
+# on-PATH mock without any network access — mock_curl_checksum_match.sh
+# itself fails the test if a download is attempted instead of a reuse.
+cp "${fixtures}/mock_curl_checksum_match.sh" "${mockbin}/curl"
+chmod +x "${mockbin}/curl"
 
 out_file="${workdir}/out.env"
 set +e
 PATH="${mockbin}:${PATH}" \
   KEYORIX_SERVER="https://example.invalid" \
   KEYORIX_TOKEN="dummy-token" \
+  INPUT_VERSION="v1.2.3" \
+  MOCK_KEYORIX_PATH="${mockbin}/keyorix" \
   INPUT_EXPORT_TO_ENV="false" \
   INPUT_OUTPUT_FILE="$out_file" \
   bash "$entrypoint" >"${workdir}/stdout2.log" 2>"${workdir}/stderr2.log"
@@ -108,18 +180,32 @@ else
   bad "#177: output file was not written as expected"
 fi
 
+# --- #179 (item 1): the action's own KEYORIX_TOKEN must be masked, not
+# just the secret VALUES it fetches — checked against the same run as #177
+# above, since KEYORIX_TOKEN is masked unconditionally near the top of the
+# script, before install_cli/inject_env even run.
+if grep -q "::add-mask::dummy-token" "${workdir}/stdout2.log"; then
+  ok "#179: the action's own KEYORIX_TOKEN is masked"
+else
+  bad "#179: KEYORIX_TOKEN was not masked; stdout: $(cat "${workdir}/stdout2.log")"
+fi
+
 # --- #466: a multi-line secret value must have EVERY line masked, not just
 # the first. ::add-mask:: registers exactly one line-oriented string per
 # call, so a naive single `::add-mask::$val` on a value containing embedded
 # newlines only redacts its first line in the job log.
 cp "${fixtures}/mock_keyorix_multiline.sh" "${mockbin}/keyorix"
+chmod +x "${mockbin}/keyorix"
 
+github_env="${workdir}/github_env"
 set +e
 PATH="${mockbin}:${PATH}" \
   KEYORIX_SERVER="https://example.invalid" \
   KEYORIX_TOKEN="dummy-token" \
+  INPUT_VERSION="v1.2.3" \
+  MOCK_KEYORIX_PATH="${mockbin}/keyorix" \
   INPUT_EXPORT_TO_ENV="true" \
-  GITHUB_ENV="${workdir}/github_env" \
+  GITHUB_ENV="$github_env" \
   bash "$entrypoint" >"${workdir}/stdout3.log" 2>"${workdir}/stderr3.log"
 rc3=$?
 set -e
@@ -131,6 +217,18 @@ if [ "$rc3" -eq 0 ] \
   ok "#466: every line of a multi-line secret is masked"
 else
   bad "#466: multi-line secret was not fully masked (rc=${rc3}); stdout: $(cat "${workdir}/stdout3.log")"
+fi
+
+# --- #179 (item 3, dynamic): the heredoc delimiter written to $GITHUB_ENV
+# must carry meaningfully more entropy than the old $RANDOM-based one (two
+# $RANDOM draws yield at most a 10-digit decimal string; a 16-byte
+# CSPRNG value hex-encodes to 32 hex characters).
+delim_line="$(grep -o 'KEYORIX_EOF_[0-9a-f]*' "$github_env" | head -1)"
+delim_suffix="${delim_line#KEYORIX_EOF_}"
+if [ "${#delim_suffix}" -ge 32 ]; then
+  ok "#179: heredoc delimiter has >=32 hex characters of entropy (got ${#delim_suffix})"
+else
+  bad "#179: heredoc delimiter entropy looks too low (delimiter: '${delim_line}', suffix length: ${#delim_suffix})"
 fi
 
 echo

--- a/integrations/github-action/test/fixtures/mock_curl_checksum_match.sh
+++ b/integrations/github-action/test/fixtures/mock_curl_checksum_match.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Mock curl used by entrypoint_test.sh's #177/#466 cases: entrypoint.sh's
+# install_cli (#179) verifies an already-on-PATH `keyorix` binary's SHA-256
+# against the pinned version's published checksums.txt before reusing it. To
+# exercise that reuse path (and avoid a real network install) without
+# actually needing a real release, this serves a checksums.txt whose
+# recorded hash matches the SHA-256 of $MOCK_KEYORIX_PATH, which the test
+# script points at its own mock_keyorix(.sh) fixture already placed on PATH.
+os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+arch="$(uname -m)"
+case "$arch" in
+  x86_64) arch="amd64" ;;
+  aarch64 | arm64) arch="arm64" ;;
+esac
+binary_name="keyorix_${os}_${arch}"
+
+for arg in "$@"; do
+  case "$arg" in
+    */checksums.txt)
+      if command -v sha256sum >/dev/null 2>&1; then
+        sum="$(sha256sum "$MOCK_KEYORIX_PATH" | awk '{print $1}')"
+      else
+        sum="$(shasum -a 256 "$MOCK_KEYORIX_PATH" | awk '{print $1}')"
+      fi
+      echo "${sum}  ${binary_name}"
+      ;;
+    http*)
+      echo "mock_curl_checksum_match: unexpected download URL ${arg} (existing binary should have been reused, not downloaded)" >&2
+      exit 1
+      ;;
+  esac
+done

--- a/integrations/github-action/test/fixtures/mock_keyorix.sh
+++ b/integrations/github-action/test/fixtures/mock_keyorix.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
-# Mock keyorix CLI used by entrypoint_test.sh's #177 case: already
-# "installed" (so install_cli short-circuits without touching the
-# network); handles the two `secret export` forms entrypoint.sh calls.
+# Mock keyorix CLI used by entrypoint_test.sh's #177/#466 cases: placed on
+# PATH before entrypoint.sh runs, paired with INPUT_VERSION and
+# mock_curl_checksum_match.sh (which serves this exact file's SHA-256 as the
+# published checksum) so install_cli's checksum-verified reuse path (#179)
+# accepts it without touching the network. Handles the two `secret export`
+# forms entrypoint.sh calls.
 if [ "$1" = "--version" ]; then
   echo "keyorix version mock-1.0.0"
   exit 0

--- a/integrations/github-action/test/fixtures/mock_keyorix_multiline.sh
+++ b/integrations/github-action/test/fixtures/mock_keyorix_multiline.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
-# Mock keyorix CLI used by entrypoint_test.sh's #466 case: already
-# "installed" (so install_cli short-circuits without touching the
-# network); returns a secret VALUE that spans multiple lines (simulating,
-# e.g., a PEM private key), so the test can verify every line gets its own
-# ::add-mask:: directive, not just the first.
+# Mock keyorix CLI used by entrypoint_test.sh's #466 case: placed on PATH
+# before entrypoint.sh runs, paired with INPUT_VERSION and
+# mock_curl_checksum_match.sh (which serves this exact file's SHA-256 as the
+# published checksum) so install_cli's checksum-verified reuse path (#179)
+# accepts it without touching the network. Returns a secret VALUE that spans
+# multiple lines (simulating, e.g., a PEM private key), so the test can
+# verify every line gets its own ::add-mask:: directive, not just the first.
 if [ "$1" = "--version" ]; then
   echo "keyorix version mock-1.0.0"
   exit 0


### PR DESCRIPTION
## Summary

Closes HARDENING-BACKLOG #179, a 3-item bundle in `integrations/github-action/entrypoint.sh`:

**1. KEYORIX_TOKEN was never masked.** Individual secret VALUES fetched by the action were already masked via `mask_value`/`::add-mask::` (per #466), but the action's own auth token was not. Fixed by calling `mask_value "$KEYORIX_TOKEN"` immediately after the token is read/validated — before anything else runs — so it can never leak in plaintext through a later error message or debug trace.

**2. `install_cli` blindly trusted any pre-existing `keyorix` on PATH, and downloaded to a fixed, guessable `/tmp/keyorix`.** Both are addressed:
- An on-PATH `keyorix` is no longer trusted unconditionally. When a `version` is pinned, it's only reused if its SHA-256 matches the release's published `checksums.txt` (the same source of truth already used to verify a fresh download). A mismatch logs a warning and falls through to a fresh, verified download instead of silently trusting the existing binary.
- The unpinned "latest" path (no `version` input) always fetches+verifies a fresh copy via the pinned-commit `install.sh`, since there's no fixed checksum to check an arbitrary on-PATH binary against in that case.
- The download itself now lands in a fresh `mktemp`'d directory instead of the fixed `/tmp/keyorix`, closing a symlink/TOCTOU race where a shared/compromised runner could pre-create or swap that path.

**3. The `$GITHUB_ENV` heredoc delimiter used two `$RANDOM` draws (~30 bits, a predictable LCG).** Replaced with `openssl rand -hex 16` (falling back to `/dev/urandom` if `openssl` is unavailable), giving 128 bits from a CSPRNG.

## Residual risk (being upfront)

- Item 2's checksum verification depends on `curl` and the GitHub release checksums.txt being trustworthy in the execution context — if PATH itself is poisoned such that `curl` is also compromised, the checksum check can be defeated. This is an inherent limit of any in-script provenance check; a stronger guarantee would require verifying the `cosign` signature this repo's release pipeline already produces over `checksums.txt` (`checksums.txt.sig`/`.pem`, see `release.yml`), but that would add a hard `cosign` binary dependency to every consumer of this action, which felt out of scope here. Flagging as a natural follow-up.
- The "latest" (unpinned) path still has no fixed checksum to verify an on-PATH binary against, so it intentionally never reuses one — always re-downloads+verifies via `install.sh` instead.

## Test plan

- [x] Extended `integrations/github-action/test/entrypoint_test.sh` (mocked-PATH black-box harness) with regression coverage for all three items: token masking, checksum-verified-or-rejected reuse of an existing binary, no more fixed `/tmp/keyorix` path, and heredoc delimiter entropy (>=32 hex chars vs. the old ~10-digit decimal). All 13 checks pass locally.
- [x] `integrations/github-action/entrypoint_test.sh` (secret-name validation tests) still passes.
- [x] `shellcheck` run on all touched files (`entrypoint.sh`, both test scripts, new fixture) — clean, no new warnings.