### PR TITLE
harden(connect): add optional GCP project pin to the Secret Manager connector (#431)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1009,6 +1009,8 @@ connect:
         - keyorix/              # (defense-in-depth on top of the backend's IAM scope)
     - name: prod-gcp
       type: gcp-secret-manager  # ref is the version resource name (creds from ADC)
+      project_id: my-proj       # recommended: pins the connector to one GCP project (#431);
+                                 # a ref naming a different project is rejected before the backend call
       allowed_refs:
         - projects/my-proj/secrets/keyorix-
     - name: prod-azure
@@ -1040,6 +1042,14 @@ connect:
 - Backend credentials come from the **ambient identity chain** (AWS: env /
   instance-profile / IRSA; GCP: ADC; Azure: `DefaultAzureCredential`; Vault:
   `token_env`), never from this config. A backend failure surfaces as `502 Bad Gateway`.
+- Unlike Vault (pinned to one `address`) and Azure Key Vault (pinned to one `address`
+  vault URL), a GCP Secret Manager ref carries **its own project ID**, so a
+  `gcp-secret-manager` connector with no **`project_id`** can address secrets in
+  **any** GCP project the ambient ADC identity can reach — `allowed_refs` is then the
+  only guardrail. Setting `project_id` (#431) pins the connector to one project: any
+  ref naming a different project is rejected before the backend call. It is optional
+  (existing configs keep today's cross-project behavior for compatibility) but
+  strongly recommended; an unset `project_id` logs a startup warning.
 - A federated read is bounded by up to **three** controls: the backend identity's IAM
   policy (the load-bearing one — scope the connector's credentials to exactly the
   intended secrets); optionally the per-connector **`allowed_refs`** prefix allowlist

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -165,6 +165,15 @@ type ConnectorConfig struct {
 	// (e.g. https://vault:8200), or the Key Vault URL for type "azure-key-vault"
 	// (e.g. https://myvault.vault.azure.net/).
 	Address string `yaml:"address"`
+	// ProjectID pins a "gcp-secret-manager" connector to a single GCP project (#431):
+	// every ref must embed this exact project ID
+	// (projects/PROJECT/secrets/NAME/versions/VERSION), or the read is rejected before
+	// reaching the backend. Unlike Address for "vault"/"azure-key-vault", a GCP ref
+	// carries its own project ID, so leaving this unset lets a single connector (and
+	// the ambient ADC identity it runs under) address secrets in ANY project that
+	// identity can reach, relying solely on AllowedRefs to scope reach. Strongly
+	// recommended; left empty only for backward compatibility with an existing config.
+	ProjectID string `yaml:"project_id"`
 	// TokenEnv names the environment variable holding the backend token for type
 	// "vault" (default "VAULT_TOKEN"). The token is read from the environment, never
 	// from this file.

--- a/internal/connect/gcpsm.go
+++ b/internal/connect/gcpsm.go
@@ -4,11 +4,18 @@
 // AccessSecretVersion. Credentials come from Application Default Credentials (ADC) /
 // the workload identity — never from Keyorix config — mirroring the GCP KMS and STS
 // integrations.
+//
+// Unlike the Vault connector (pinned to one address) and the Azure connector (pinned
+// to one vaultURL), the GCP project ID lives entirely inside the caller-supplied ref
+// — so an unpinned connector can address secrets in any project the ambient identity
+// can reach. Setting projectID (#431) pins the connector to a single project and
+// rejects any ref embedding a different one.
 package connect
 
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	secretmanager "cloud.google.com/go/secretmanager/apiv1"
 	"cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
@@ -26,16 +33,42 @@ type gcpSMAccessAPI interface {
 // GCPSecretManagerConnector reads secrets from GCP Secret Manager.
 type GCPSecretManagerConnector struct {
 	name        string
+	projectID   string
 	allowedRefs []string
 	// newClient builds an SM client; nil uses the real client (ADC). Tests inject a fake.
 	newClient func(ctx context.Context) (gcpSMAccessAPI, error)
 }
 
-// NewGCPSecretManagerConnector builds a GCP Secret Manager connector. allowedRefs,
-// when non-empty, restricts readable references to those with one of the given
-// prefixes (a guardrail on top of the workload identity's IAM scope).
-func NewGCPSecretManagerConnector(name string, allowedRefs []string) *GCPSecretManagerConnector {
-	return &GCPSecretManagerConnector{name: name, allowedRefs: allowedRefs}
+// NewGCPSecretManagerConnector builds a GCP Secret Manager connector. projectID,
+// when non-empty, pins the connector to a single GCP project — mirroring how the
+// Vault connector pins an address and the Azure connector pins a vaultURL: every ref
+// passed to GetSecret must embed this exact project ID (`projects/PROJECT/...`), or
+// the read is rejected before ever reaching the backend. Unlike Vault/Azure, a GCP
+// ref carries its own project ID, so without this pin a single configured connector
+// (and the ambient ADC identity it runs under) can address secrets in ANY project
+// that identity can reach, with only allowedRefs standing in the way — leave
+// projectID empty only for backward compatibility with an existing config that
+// intentionally spans multiple projects. allowedRefs, when non-empty, restricts
+// readable references to those with one of the given prefixes (a guardrail on top of
+// the workload identity's IAM scope).
+func NewGCPSecretManagerConnector(name, projectID string, allowedRefs []string) *GCPSecretManagerConnector {
+	return &GCPSecretManagerConnector{name: name, projectID: projectID, allowedRefs: allowedRefs}
+}
+
+// gcpRefProjectID extracts the project ID embedded in a GCP Secret Manager version
+// resource name (`projects/PROJECT/secrets/NAME/versions/VERSION`). It returns ok =
+// false if ref does not start with the expected "projects/" segment.
+func gcpRefProjectID(ref string) (project string, ok bool) {
+	const prefix = "projects/"
+	if !strings.HasPrefix(ref, prefix) {
+		return "", false
+	}
+	rest := ref[len(prefix):]
+	project, _, found := strings.Cut(rest, "/")
+	if !found || project == "" {
+		return "", false
+	}
+	return project, true
 }
 
 func (c *GCPSecretManagerConnector) Name() string { return c.name }
@@ -58,6 +91,15 @@ func (c *GCPSecretManagerConnector) GetSecret(ctx context.Context, ref string) (
 	}
 	if !prefixAllowed(c.allowedRefs, ref) {
 		return "", fmt.Errorf("gcp-secret-manager: ref %q is not permitted by this connector's allowed_refs", ref)
+	}
+	if c.projectID != "" {
+		refProject, ok := gcpRefProjectID(ref)
+		if !ok {
+			return "", fmt.Errorf("gcp-secret-manager: ref %q does not start with projects/PROJECT/... so it cannot be checked against the connector's pinned project %q", ref, c.projectID)
+		}
+		if refProject != c.projectID {
+			return "", fmt.Errorf("gcp-secret-manager: ref %q targets project %q, but this connector is pinned to project %q", ref, refProject, c.projectID)
+		}
 	}
 	cl, err := c.client(ctx)
 	if err != nil {

--- a/internal/connect/gcpsm_test.go
+++ b/internal/connect/gcpsm_test.go
@@ -26,13 +26,19 @@ func (f *fakeGCPSM) AccessSecretVersion(_ context.Context, req *secretmanagerpb.
 func (f *fakeGCPSM) Close() error { f.closed = true; return nil }
 
 func gcpConnectorWith(name string, fake *fakeGCPSM, allowed ...string) *GCPSecretManagerConnector {
-	c := NewGCPSecretManagerConnector(name, allowed)
+	c := NewGCPSecretManagerConnector(name, "", allowed)
+	c.newClient = func(_ context.Context) (gcpSMAccessAPI, error) { return fake, nil }
+	return c
+}
+
+func gcpPinnedConnectorWith(name, projectID string, fake *fakeGCPSM, allowed ...string) *GCPSecretManagerConnector {
+	c := NewGCPSecretManagerConnector(name, projectID, allowed)
 	c.newClient = func(_ context.Context) (gcpSMAccessAPI, error) { return fake, nil }
 	return c
 }
 
 func TestGCPSM_TypeAndName(t *testing.T) {
-	c := NewGCPSecretManagerConnector("prod-gcp", nil)
+	c := NewGCPSecretManagerConnector("prod-gcp", "", nil)
 	assert.Equal(t, "prod-gcp", c.Name())
 	assert.Equal(t, "gcp-secret-manager", c.Type())
 }
@@ -72,4 +78,68 @@ func TestGCPSM_GetSecret_Errors(t *testing.T) {
 		assert.Contains(t, err.Error(), "not permitted")
 		assert.Empty(t, fake.got, "a disallowed ref must not reach the backend")
 	})
+}
+
+// TestGCPSM_ProjectPin covers #431: an unpinned connector (projectID == "", the
+// pre-existing default) may address any project the ADC identity can reach — no
+// regression — while a pinned connector rejects a ref naming a different project and
+// still works normally for its own project's refs.
+func TestGCPSM_ProjectPin(t *testing.T) {
+	t.Run("pinned connector rejects a ref targeting a different project", func(t *testing.T) {
+		fake := &fakeGCPSM{out: &secretmanagerpb.AccessSecretVersionResponse{Payload: &secretmanagerpb.SecretPayload{Data: []byte("x")}}}
+		c := gcpPinnedConnectorWith("gcp", "my-proj", fake)
+		_, err := c.GetSecret(context.Background(), "projects/other-proj/secrets/db/versions/latest")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "pinned to project")
+		assert.Contains(t, err.Error(), "my-proj")
+		assert.Contains(t, err.Error(), "other-proj")
+		assert.Empty(t, fake.got, "a cross-project ref must not reach the backend")
+	})
+
+	t.Run("pinned connector still works for its own project's refs", func(t *testing.T) {
+		fake := &fakeGCPSM{out: &secretmanagerpb.AccessSecretVersionResponse{Payload: &secretmanagerpb.SecretPayload{Data: []byte("g0ph3r")}}}
+		c := gcpPinnedConnectorWith("gcp", "my-proj", fake)
+		ref := "projects/my-proj/secrets/db/versions/latest"
+		val, err := c.GetSecret(context.Background(), ref)
+		require.NoError(t, err)
+		assert.Equal(t, "g0ph3r", val)
+		assert.Equal(t, ref, fake.got)
+	})
+
+	t.Run("pinned connector rejects a ref with no parseable project segment", func(t *testing.T) {
+		fake := &fakeGCPSM{out: &secretmanagerpb.AccessSecretVersionResponse{Payload: &secretmanagerpb.SecretPayload{Data: []byte("x")}}}
+		c := gcpPinnedConnectorWith("gcp", "my-proj", fake)
+		_, err := c.GetSecret(context.Background(), "not-a-project-resource-name")
+		require.Error(t, err)
+		assert.Empty(t, fake.got)
+	})
+
+	t.Run("unpinned connector (legacy/default config) still reads across projects", func(t *testing.T) {
+		fake := &fakeGCPSM{out: &secretmanagerpb.AccessSecretVersionResponse{Payload: &secretmanagerpb.SecretPayload{Data: []byte("g0ph3r")}}}
+		c := gcpConnectorWith("gcp", fake) // projectID == "" — the pre-existing default
+		ref := "projects/some-other-proj/secrets/db/versions/latest"
+		val, err := c.GetSecret(context.Background(), ref)
+		require.NoError(t, err, "no regression: an unpinned connector keeps today's cross-project behavior")
+		assert.Equal(t, "g0ph3r", val)
+	})
+}
+
+func TestGCPRefProjectID(t *testing.T) {
+	tests := []struct {
+		ref     string
+		project string
+		ok      bool
+	}{
+		{"projects/p/secrets/db/versions/latest", "p", true},
+		{"projects/my-proj-123/secrets/x/versions/1", "my-proj-123", true},
+		{"projects/", "", false},
+		{"projects", "", false},
+		{"secrets/db/versions/latest", "", false},
+		{"", "", false},
+	}
+	for _, tt := range tests {
+		project, ok := gcpRefProjectID(tt.ref)
+		assert.Equal(t, tt.ok, ok, "ref %q", tt.ref)
+		assert.Equal(t, tt.project, project, "ref %q", tt.ref)
+	}
 }

--- a/server/main.go
+++ b/server/main.go
@@ -493,7 +493,10 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 			case "aws-secrets-manager":
 				connectors = append(connectors, connect.NewAWSSecretsManagerConnector(cn.Name, cn.Region, cn.AllowedRefs))
 			case "gcp-secret-manager":
-				connectors = append(connectors, connect.NewGCPSecretManagerConnector(cn.Name, cn.AllowedRefs))
+				if cn.ProjectID == "" {
+					log.Printf("Keyorix Connect: gcp-secret-manager connector %q has no project_id configured — reads can reach ANY GCP project the ambient identity can access, relying solely on allowed_refs to scope reach; set project_id to pin the connector to one project (#431)", cn.Name)
+				}
+				connectors = append(connectors, connect.NewGCPSecretManagerConnector(cn.Name, cn.ProjectID, cn.AllowedRefs))
 			case "azure-key-vault":
 				connectors = append(connectors, connect.NewAzureKeyVaultConnector(cn.Name, cn.Address, cn.AllowedRefs))
 			case "vault":


### PR DESCRIPTION
## Summary

Closes #431. The `gcp-secret-manager` connector had no project-pinning field at
all — unlike the Vault connector (pins an `address`) and the Azure connector
(pins a `vaultURL`). The GCP project ID lives entirely in the caller-supplied
`ref` string, so a single configured connector (and the ambient ADC/workload
identity it runs under) could address secrets in **any** GCP project that
identity can reach, relying solely on the connector's `allowed_refs` prefix
allowlist to scope reach. This was a config-trap: an operator assuming the
connector was scoped to one project (the way Vault/Azure connectors are) would
be wrong.

**This is opt-in, backward-compatible hardening — not a breaking change.**
Existing deployments with no `project_id` set keep today's behavior exactly
(cross-project reads still work), they just get a one-line startup warning
recommending the pin.

## What changed

- `internal/connect/gcpsm.go`: added an optional `projectID` field to
  `GCPSecretManagerConnector` (new constructor param). When set, `GetSecret`
  parses the project ID embedded in the `projects/PROJECT/secrets/.../versions/...`
  ref and rejects the read with a clear error if it doesn't match the pinned
  project (checked before the allowed_refs guardrail already in place, and
  before any backend call). When unset, behavior is unchanged.
- `internal/config/config.go`: added `ProjectID string \`yaml:"project_id"\`` to
  the shared `ConnectorConfig` struct, documented alongside `Address`.
- `server/main.go`: wires `cn.ProjectID` into the connector; logs a startup
  warning when a `gcp-secret-manager` connector has no `project_id`, mirroring
  the existing "recommended but not required" warning pattern used for
  `shamir_commitment`.
- `docs/CONFIGURATION.md`: documented `project_id` in the `connect` config
  example and prose, alongside the existing Vault/Azure pinning docs.
- `internal/connect/gcpsm_test.go`: regression tests —
  - a pinned connector rejects a ref targeting a different project
  - a pinned connector still works normally for its own project's refs
  - a pinned connector rejects a ref with no parseable project segment
  - an unpinned (legacy/default) connector keeps today's cross-project
    behavior — no regression
  - unit tests for the new `gcpRefProjectID` ref parser

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/connect/... ./internal/config/... ./internal/core/...` — all pass
- [x] `gosec -severity medium -exclude-generated ./internal/connect/...` — 0 issues (a
      cache-diagnostic message is unrelated environment noise, reproduced identically
      on an untouched package as a baseline)