### PR TITLE
harden(rbac): delete dead scope/admin-blind CheckPermission (#376)

### DIFF
--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -1053,11 +1053,6 @@ func (m *MockStorage) RoleSetHasPermission(ctx context.Context, roleIDs []uint, 
 	return args.Bool(0), args.Error(1)
 }
 
-func (m *MockStorage) CheckPermission(ctx context.Context, userID uint, resource, action string) (bool, error) {
-	args := m.Called(ctx, userID, resource, action)
-	return args.Bool(0), args.Error(1)
-}
-
 func (m *MockStorage) GetUserPermissions(ctx context.Context, userID uint) ([]*storage.Permission, error) {
 	args := m.Called(ctx, userID)
 	if args.Get(0) == nil {

--- a/internal/core/rbac_group_permission_external_test.go
+++ b/internal/core/rbac_group_permission_external_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/keyorixhq/keyorix/internal/testhelper"
 	"github.com/stretchr/testify/assert"
@@ -149,4 +150,78 @@ func TestHasPermissionByEmail_NoGrantsAtAll(t *testing.T) {
 	ok, err := h.CoreService.HasPermissionByEmail(ctx, "liam@test.com", "secrets", "read")
 	require.NoError(t, err)
 	assert.False(t, ok)
+}
+
+// #376: a project-scoped grant must correctly authorize AT its own scope — the
+// old storage-layer CheckPermission was reachable from HasPermissionByEmail
+// pre-#630 and was scope-blind by construction (it never looked at
+// project_id/environment_id at all), so it could not distinguish "granted at
+// project X" from "granted globally". HasPermissionByEmail now discovers the
+// user's real scopes (GetUserRoleScopes) and re-validates each one through
+// Authorize, so a grant scoped to a single project is still found.
+func TestHasPermissionByEmail_ProjectScopedGrant_HasAccessAtGrantedScope(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	ctx := context.Background()
+	projStaging := uint(3) // "staging", seeded by the helper
+
+	h.CreateTestUser(t, "mona", 26)
+	h.AssignUserRole(t, 26, 3, &projStaging) // editor, scoped to project 3 only → secrets.write
+
+	ok, err := h.CoreService.HasPermissionByEmail(ctx, "mona@test.com", "secrets", "write")
+	require.NoError(t, err)
+	assert.True(t, ok, "a grant scoped to project 3 must authorize when checked via HasPermissionByEmail")
+}
+
+// #376: the flip side of the above — a grant scoped to ONE project must not
+// leak into a DIFFERENT, unrelated project. This is the exact false-positive
+// shape "ignoring scope" would produce: the pre-#630 raw query matched on
+// user_id/resource/action alone, so ANY project-scoped grant would have looked
+// identical to a global one to a caller that (incorrectly) treated "has the
+// permission somewhere" as "has the permission at project Y". Authorize — the
+// live path HasPermissionByEmail delegates to per discovered scope — must
+// still deny an explicit, different project scope for the same user and grant.
+func TestHasPermissionByEmail_ProjectScopedGrant_DifferentProjectNotAuthorized(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	ctx := context.Background()
+	projStaging := uint(3)    // "staging", seeded by the helper
+	projProduction := uint(2) // "production", seeded by the helper
+
+	user := h.CreateTestUser(t, "nate", 27)
+	h.AssignUserRole(t, 27, 3, &projStaging) // editor, scoped to project 3 only → secrets.write
+
+	// HasPermissionByEmail (the CLI diagnostic) correctly reports access — the
+	// user's own scope (project 3) does grant it.
+	ok, err := h.CoreService.HasPermissionByEmail(ctx, "nate@test.com", "secrets", "write")
+	require.NoError(t, err)
+	assert.True(t, ok, "the user's own project-3 grant must authorize")
+
+	// But a caller asking Authorize about a DIFFERENT project the user holds no
+	// grant at must be denied, not falsely authorized by an unscoped match.
+	denied, err := h.CoreService.Authorize(ctx, user.ID, "secrets.write", core.Scope{ProjectID: projProduction})
+	require.NoError(t, err)
+	assert.False(t, denied, "a grant scoped to project 3 must not authorize project 2")
+}
+
+// #376: a PROJECT-SCOPED admin (not just a global super_admin, already pinned
+// by TestHasPermissionByEmail_AdminBypass) must also bypass the per-permission
+// check within its own scope when reached through HasPermissionByEmail — the
+// pre-#630 raw storage query had no admin-bypass concept at all, so an admin
+// with no explicit role_permissions row for the checked permission would have
+// incorrectly read as "does NOT have permission".
+func TestHasPermissionByEmail_ProjectScopedAdminBypass(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	ctx := context.Background()
+	projProduction := uint(2) // "production", seeded by the helper
+
+	h.CreateTestUser(t, "olga", 28)
+	h.AssignUserRole(t, 28, 2, &projProduction) // admin, scoped to project 2 only
+
+	// "connect.read" is not in the seeded "admin" role's role_permissions set —
+	// only the admin-role bypass in Authorize() can grant it.
+	ok, err := h.CoreService.HasPermissionByEmail(ctx, "olga@test.com", "connect", "read")
+	require.NoError(t, err)
+	assert.True(t, ok, "a project-scoped admin bypasses the per-permission check within its own scope")
 }

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -531,13 +531,6 @@ type Storage interface {
 	// GetUserRoleIDsAt/GetUserGroupRoleIDsAt (via scopedRoleIDs) per scope.
 	GetUserRoleScopes(ctx context.Context, userID uint) ([]Scope, error)
 	RoleSetHasPermission(ctx context.Context, roleIDs []uint, permission string) (bool, error)
-	// CheckPermission is a raw, scope-agnostic role/permission-grant existence
-	// check (direct OR group-inherited role), with NO admin-role bypass — it does
-	// not answer "would Authorize() grant this at scope X". Prefer
-	// core.HasPermissionByEmail (which resolves via Authorize/scopedRoleIDs per
-	// scope) for anything that needs the true live-authorization-equivalent
-	// answer (#376).
-	CheckPermission(ctx context.Context, userID uint, resource, action string) (bool, error)
 	GetUserPermissions(ctx context.Context, userID uint) ([]*Permission, error)
 	// GetUserGroupPermissions returns the permissions a user holds via GROUP
 	// membership (group → group_roles → role_permissions), scope-agnostically and

--- a/internal/storage/store/local_rbac.go
+++ b/internal/storage/store/local_rbac.go
@@ -3,7 +3,7 @@
 // Covers: CreatePermission, AssignPermissionToRole,
 //
 //	CreateRole, GetRole, GetRoleByName, UpdateRole, DeleteRole, ListRoles,
-//	AssignRole, RemoveRole, GetUserRoles, CheckPermission, GetUserPermissions.
+//	AssignRole, RemoveRole, GetUserRoles, GetUserPermissions.
 //
 // All operations use direct GORM queries.
 // For the remote (HTTP) equivalent see remote_rbac.go.
@@ -488,48 +488,6 @@ func (ls *LocalStorage) RoleSetHasPermission(ctx context.Context, roleIDs []uint
 		return false, fmt.Errorf("%s: %w", i18n.T("ErrorInternalServer", nil), err)
 	}
 	return count > 0, nil
-}
-
-// CheckPermission returns true if userID holds the given resource/action
-// permission via a DIRECT OR group-inherited role, resolved transitively: user
-// (or group membership) → role → permission (#376). It is intentionally
-// scope-blind (an assignment at ANY project/environment counts, matching its
-// pre-existing "any assignment anywhere" contract) and does not apply the
-// admin-role bypass Authorize() grants — this is a raw role/permission-grant
-// existence check, not a live authorization decision. The production diagnostic
-// that needs the FULL Authorize()-equivalent answer (group-inclusive,
-// scope-aware, admin-bypass-aware) is core.HasPermissionByEmail, which resolves
-// it via Authorize/scopedRoleIDs per scope rather than calling this method.
-func (ls *LocalStorage) CheckPermission(ctx context.Context, userID uint, resource, action string) (bool, error) {
-	now := time.Now()
-	var count int64
-	err := ls.db.WithContext(ctx).Table("permissions").
-		Joins("JOIN role_permissions ON permissions.id = role_permissions.permission_id").
-		Joins("JOIN user_roles ON role_permissions.role_id = user_roles.role_id").
-		Where("user_roles.user_id = ? AND permissions.resource = ? AND permissions.action = ?", userID, resource, action).
-		Where("user_roles.expires_at IS NULL OR user_roles.expires_at > ?", now).
-		Count(&count).Error
-	if err != nil {
-		return false, fmt.Errorf("%s: %w", i18n.T("ErrorInternalServer", nil), err)
-	}
-	if count > 0 {
-		return true, nil
-	}
-
-	var viaGroup int64
-	err = ls.db.WithContext(ctx).Table("permissions").
-		Joins("JOIN role_permissions ON permissions.id = role_permissions.permission_id").
-		Joins("JOIN group_roles ON role_permissions.role_id = group_roles.role_id").
-		Joins("JOIN user_groups ON user_groups.group_id = group_roles.group_id").
-		// A soft-deleted group confers no permissions (matches authz resolution).
-		Joins("JOIN groups ON groups.id = group_roles.group_id AND groups.deleted_at IS NULL").
-		Where("user_groups.user_id = ? AND permissions.resource = ? AND permissions.action = ?", userID, resource, action).
-		Where("group_roles.expires_at IS NULL OR group_roles.expires_at > ?", now).
-		Count(&viaGroup).Error
-	if err != nil {
-		return false, fmt.Errorf("%s: %w", i18n.T("ErrorInternalServer", nil), err)
-	}
-	return viaGroup > 0, nil
 }
 
 // ListPermissions returns all permissions.

--- a/internal/storage/store/local_rbac_test.go
+++ b/internal/storage/store/local_rbac_test.go
@@ -159,12 +159,12 @@ func TestAssignRoleToGroup_SucceedsAfterPriorTimeBoundGrantExpired(t *testing.T)
 	assert.Contains(t, ids, uint(10))
 }
 
-// #374/#375/#376: GetUserPermissions and CheckPermission previously joined ONLY
-// user_roles (direct assignments), leaving them blind to a permission granted
-// purely via a group role — unlike the live authorization path (scopedRoleIDs,
-// authz.go), which correctly unions direct and group-inherited roles. These
-// tests pin the fix: a permission held ONLY through group membership must now
-// be visible.
+// #374/#375/#376: GetUserPermissions previously joined ONLY user_roles (direct
+// assignments), leaving it blind to a permission granted purely via a group
+// role — unlike the live authorization path (scopedRoleIDs, authz.go), which
+// correctly unions direct and group-inherited roles. This test pins the fix:
+// a permission held ONLY through group membership must now be visible via
+// GetUserGroupPermissions, its group-derived counterpart.
 func TestGetUserPermissions_DirectOnly_DoesNotIncludeGroupGrant(t *testing.T) {
 	ls := newRBACScopeTestStore(t)
 	ctx := context.Background()
@@ -187,38 +187,6 @@ func TestGetUserGroupPermissions_IncludesGroupDerivedPermission(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, perms, 1)
 	assert.Equal(t, "secrets.admin", perms[0].Name)
-}
-
-// CheckPermission must find a permission granted purely via a group role — the
-// storage-layer #376 axis: it previously joined only user_roles, so a group-only
-// grant read as "does NOT have permission" even though Authorize() genuinely
-// grants it.
-func TestCheckPermission_IncludesGroupDerivedPermission(t *testing.T) {
-	ls := newRBACScopeTestStore(t)
-	ctx := context.Background()
-	seedGroupGrantedPermission(t, ls)
-
-	has, err := ls.CheckPermission(ctx, 1, "secrets", "admin")
-	require.NoError(t, err)
-	assert.True(t, has, "a permission granted only via a group role must be found")
-
-	has, err = ls.CheckPermission(ctx, 1, "secrets", "write")
-	require.NoError(t, err)
-	assert.False(t, has, "an unrelated permission must not be reported as held")
-}
-
-// A soft-deleted group must confer no permission, mirroring
-// GetUserGroupRoleIDsAt's own soft-delete gate.
-func TestCheckPermission_SoftDeletedGroupConfersNothing(t *testing.T) {
-	ls := newRBACScopeTestStore(t)
-	ctx := context.Background()
-	seedGroupGrantedPermission(t, ls)
-
-	require.NoError(t, ls.db.Delete(&models.Group{}, 100).Error)
-
-	has, err := ls.CheckPermission(ctx, 1, "secrets", "admin")
-	require.NoError(t, err)
-	assert.False(t, has, "a soft-deleted group's grant must stop authorizing")
 }
 
 // seedGroupGrantedPermission puts user 1 in group 100, which holds role 50

--- a/internal/storage/store/remote_rbac.go
+++ b/internal/storage/store/remote_rbac.go
@@ -2,7 +2,7 @@
 //
 // Covers: CreateRole, GetRole, GetRoleByName, UpdateRole, DeleteRole, ListRoles,
 //
-//	AssignRole, RemoveRole, GetUserRoles, CheckPermission, GetUserPermissions,
+//	AssignRole, RemoveRole, GetUserRoles, GetUserPermissions,
 //	CreatePermission, AssignPermissionToRole,
 //	Project/Environment stubs.
 //
@@ -199,25 +199,6 @@ func (rs *RemoteStorage) GetUserRoles(ctx context.Context, userID uint) ([]*mode
 		return nil, fmt.Errorf("failed to parse response: %w", err)
 	}
 	return result, nil
-}
-
-// CheckPermission checks if a user has a specific resource/action permission via remote API.
-func (rs *RemoteStorage) CheckPermission(ctx context.Context, userID uint, resource, action string) (bool, error) {
-	path := fmt.Sprintf("/api/v1/rbac/check-permission?user_id=%d&resource=%s&action=%s", userID, url.QueryEscape(resource), url.QueryEscape(action))
-	resp, err := rs.client.Get(ctx, path)
-	if err != nil {
-		return false, fmt.Errorf("failed to check permission: %w", err)
-	}
-	if !resp.Success {
-		return false, fmt.Errorf("check permission failed: %s", resp.Error.Error())
-	}
-	var result struct {
-		HasPermission bool `json:"has_permission"`
-	}
-	if err := json.Unmarshal(resp.Data, &result); err != nil {
-		return false, fmt.Errorf("failed to parse response: %w", err)
-	}
-	return result.HasPermission, nil
 }
 
 // GetUserPermissions retrieves all permissions for a user via remote API.


### PR DESCRIPTION
## Summary

Closes backlog #376. Re-verified against current `origin/main`: the group-omission axis was already fixed (PR #630), and `core.HasPermissionByEmail` — the CLI `check-permission` diagnostic's actual production path — already delegates to `Authorize()` per scope, so it correctly inherits scope-awareness and the admin-role bypass from the SAME live authorization logic (no drift possible by construction).

That left `storage.CheckPermission` (the raw, scope-blind, admin-bypass-blind existence check the finding describes) as the only place still missing the two axes. A repo-wide audit found it has **zero production callers**:
- The local CLI path calls `HasPermissionByEmail`, not `CheckPermission`.
- The remote CLI path (`runCheckPermissionRemote`) calls `userEffectivePermissions` via gRPC, not `RemoteStorage.CheckPermission`.
- `RemoteStorage.CheckPermission` itself targets `/api/v1/rbac/check-permission`, an HTTP route that doesn't exist anywhere in `server/` — it was unreachable even if something did call it.
- Only unit tests invoked `storage.CheckPermission` directly, testing the function against itself.

Given it's confirmed-dead and would only be a landmine if "fixed" in place (mirroring this session's established precedent for #472/#418), this PR **deletes** `CheckPermission` entirely — the interface method, `LocalStorage`/`RemoteStorage`/`MockStorage` implementations, and the two unit tests that only exercised the deleted function (their group-inheritance coverage intent lives on via `TestGetUserGroupPermissions_IncludesGroupDerivedPermission` and `TestHasPermissionByEmail_GroupDerivedPermission`).

Adds three new regression tests at the real (`HasPermissionByEmail`) entry point:
- a project-scoped grant authorizes at its own scope (no false negative from over-restricting)
- that same grant does NOT leak into a different project via `Authorize()` (no false positive from ignoring scope)
- a project-scoped `admin` role bypasses the per-permission check within its own scope (complementing the existing global `super_admin` bypass test)

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/storage/store/... ./internal/core/... ./internal/cli/...` — all pass, including the 3 new tests
- [x] `gosec -severity medium -exclude-generated` on touched packages — 0 issues (sandbox limited SSA-based cache reuse identically on unrelated code, confirmed pre-existing/environmental, not diff-related)

🤖 Generated with [Claude Code](https://claude.com/claude-code)