### PR TITLE
fix(import): reject control chars/ANSI escapes in parsed keys/values (#295)

### DIFF
--- a/internal/cli/secret/import_parsers.go
+++ b/internal/cli/secret/import_parsers.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"unicode"
 
 	"gopkg.in/yaml.v3"
 )
@@ -31,6 +32,63 @@ func checkImportFileSize(path string) error {
 	}
 	if info.Size() > maxImportFileBytes {
 		return fmt.Errorf("import file %q is %d bytes, which exceeds the %d byte limit", path, info.Size(), maxImportFileBytes)
+	}
+	return nil
+}
+
+// keyHasControlChars reports whether a parsed secret name contains any Unicode
+// control character (C0/C1 controls, including the ESC byte that introduces an
+// ANSI escape sequence). Unlike sanitizeForTerminal (import.go), which only
+// scrubs bytes for terminal DISPLAY, this gates what is actually stored.
+// Secret names are simple identifiers — see core.SecretNamePolicy, whose
+// operator-configured pattern is exactly the kind of convention a name with
+// raw control bytes would already violate — so there is no legitimate case for
+// one to contain control characters. Reject rather than silently strip: a
+// dropped byte could change which existing secret an import collides with.
+func keyHasControlChars(s string) bool {
+	for _, r := range s {
+		if unicode.IsControl(r) {
+			return true
+		}
+	}
+	return false
+}
+
+// valueHasDangerousControlChars reports whether a parsed secret value contains
+// a control character that could manipulate a terminal when the value is
+// later echoed back (dry-run preview, "already exists" listings, an error
+// quoting it) — ESC-introduced ANSI/C1 escape sequences and other
+// non-printable control bytes. Plain \t, \n, and \r are tolerated because
+// real credential material legitimately contains them (PEM-encoded private
+// keys and certificates are multi-line, for example), and this codebase must
+// not silently mangle the actual secret bytes it stores on an operator's
+// behalf. Values that trip this check are rejected — never auto-stripped —
+// so a suspicious import fails loudly instead of quietly corrupting
+// credential material.
+func valueHasDangerousControlChars(s string) bool {
+	for _, r := range s {
+		switch r {
+		case '\t', '\n', '\r':
+			continue
+		}
+		if unicode.IsControl(r) {
+			return true
+		}
+	}
+	return false
+}
+
+// validateImportedEntry rejects a parsed key/value pair that contains raw
+// control characters or ANSI escape sequences, naming the offending key so
+// the operator can locate and fix (or knowingly re-export) the source record.
+// See #295: previously only sanitizeForTerminal existed, and it cleaned
+// display output only — the value actually sent to the server was untouched.
+func validateImportedEntry(e secretEntry) error {
+	if keyHasControlChars(e.Name) {
+		return fmt.Errorf("secret name %q contains control characters or ANSI escape sequences; rejecting import", sanitizeForTerminal(e.Name))
+	}
+	if valueHasDangerousControlChars(e.Value) {
+		return fmt.Errorf("value for secret %q contains control characters or ANSI escape sequences; rejecting import (if this is expected binary-ish data, re-export it without escape bytes)", sanitizeForTerminal(e.Name))
 	}
 	return nil
 }
@@ -84,7 +142,11 @@ func parseDotenv(path string) ([]secretEntry, error) {
 		if key == "" || val == "" {
 			continue
 		}
-		entries = append(entries, secretEntry{Name: key, Value: val})
+		entry := secretEntry{Name: key, Value: val}
+		if err := validateImportedEntry(entry); err != nil {
+			return nil, err
+		}
+		entries = append(entries, entry)
 	}
 	return entries, scanner.Err()
 }
@@ -136,7 +198,11 @@ func parseVault(path string) ([]secretEntry, error) {
 			if fval, isFormat1 := fields["value"]; isFormat1 {
 				val := fmt.Sprintf("%v", fval)
 				if val != "" {
-					entries = append(entries, secretEntry{Name: segment, Value: val})
+					entry := secretEntry{Name: segment, Value: val}
+					if err := validateImportedEntry(entry); err != nil {
+						return nil, err
+					}
+					entries = append(entries, entry)
 				}
 				continue
 			}
@@ -146,7 +212,11 @@ func parseVault(path string) ([]secretEntry, error) {
 			if key == "" || val == "" {
 				continue
 			}
-			entries = append(entries, secretEntry{Name: segment + "-" + key, Value: val})
+			entry := secretEntry{Name: segment + "-" + key, Value: val}
+			if err := validateImportedEntry(entry); err != nil {
+				return nil, err
+			}
+			entries = append(entries, entry)
 		}
 	}
 	return entries, nil
@@ -175,7 +245,11 @@ func parseJSON(path string) ([]secretEntry, error) {
 		if k == "" || val == "" {
 			continue
 		}
-		entries = append(entries, secretEntry{Name: k, Value: val})
+		entry := secretEntry{Name: k, Value: val}
+		if err := validateImportedEntry(entry); err != nil {
+			return nil, err
+		}
+		entries = append(entries, entry)
 	}
 	return entries, nil
 }

--- a/internal/cli/secret/import_parsers_test.go
+++ b/internal/cli/secret/import_parsers_test.go
@@ -1,6 +1,7 @@
 package secret
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -8,7 +9,13 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
+
+// esc is the ANSI/terminal escape-introducer byte (0x1B), built from a hex
+// rune literal rather than a string escape so test fixtures below can embed
+// it in generated file content without hand-writing raw escape sequences.
+const esc = rune(0x1B)
 
 // ── #295: file-size cap ─────────────────────────────────────────────────────
 
@@ -83,12 +90,12 @@ func TestSanitizeForTerminal_StripsControlAndANSI(t *testing.T) {
 		want string
 	}{
 		{"plain", "hello", "hello"},
-		{"ansi_escape", "\x1b[2Khidden\x1b[0m", "[2Khidden[0m"},
+		{"ansi_escape", string(esc) + "[2Khidden" + string(esc) + "[0m", "[2Khidden[0m"},
 		{"cr_lf", "line1\r\nline2", "line1line2"},
 		{"nul", "a\x00b", "ab"},
 		{"tab_normalized", "a\tb", "a b"},
 		{"bell", "a\x07b", "ab"},
-		{"c1_control", "a\u009bb", "ab"}, // C1 CSI (escape avoids an unprintable byte in the source file)
+		{"c1_control", "a" + string(rune(0x9b)) + "b", "ab"}, // C1 CSI, built from a hex rune literal to avoid an unprintable byte in the source file
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -101,8 +108,177 @@ func TestSanitizeForTerminal_NeutralizesCursorHidingSequence(t *testing.T) {
 	// A crafted value trying to move the cursor up and overwrite the CLI's own
 	// status line: ESC[1A ESC[2K <fake status>. Stripping the ESC byte breaks
 	// the escape sequence into inert printable text.
-	malicious := "\x1b[1A\x1b[2K  + Imported everything (id=999)\n"
+	malicious := string(esc) + "[1A" + string(esc) + "[2K  + Imported everything (id=999)\n"
 	out := sanitizeForTerminal(malicious)
-	assert.NotContains(t, out, "\x1b")
-	assert.False(t, strings.ContainsRune(out, 0x1b))
+	assert.NotContains(t, out, string(esc))
+	assert.False(t, strings.ContainsRune(out, esc))
+}
+
+// ── #295: reject (not silently strip) control chars/ANSI in parsed keys/values ──
+
+func TestParseDotenv_RejectsANSIEscapeInKey(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".env")
+	content := "DB_" + string(esc) + "[2KPASSWORD=hunter2\n"
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+	_, err := parseDotenv(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "secret name")
+}
+
+func TestParseDotenv_RejectsANSIEscapeInValue(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".env")
+	content := "API_KEY=sk_live_" + string(esc) + "[1A" + string(esc) + "[2Kabc123\n"
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+	_, err := parseDotenv(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "API_KEY")
+}
+
+func TestParseDotenv_AllowsOrdinaryUTF8(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".env")
+	content := "GREETING=héllo wörld 你好\nDB_PASSWORD=supersecret123\n"
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+	entries, err := parseDotenv(path)
+	require.NoError(t, err)
+	require.Len(t, entries, 2)
+}
+
+func TestParseDotenv_AllowsMultilineValueWithNewlinesAndTabs(t *testing.T) {
+	// Multi-line credential material (e.g. a PEM private key exported as a
+	// single quoted dotenv value) legitimately contains \n and \t; these must
+	// not be rejected as "dangerous" the way an ESC-introduced ANSI sequence
+	// would be.
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".env")
+	content := "TLS_KEY=\"-----BEGIN KEY-----\nline\twith\ttabs\n-----END KEY-----\"\n"
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+	_, err := parseDotenv(path)
+	require.NoError(t, err)
+}
+
+func TestParseJSON_RejectsANSIEscapeInKey(t *testing.T) {
+	// Raw, unescaped control bytes are already invalid JSON per encoding/json's
+	// own grammar (confirmed by TestParseJSON_RawControlByteIsInvalidJSON
+	// below); a crafted real-world import instead carries the standard JSON
+	// numeric escape for the byte, which decodes to a real ESC rune during
+	// json.Unmarshal -- that's what our post-decode check has to catch. Using
+	// json.Marshal to produce the fixture (rather than hand-writing the escape
+	// in source) guarantees we're testing exactly that decoded form.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secrets.json")
+	data, err := json.Marshal(map[string]string{
+		"DB_" + string(esc) + "[2KPASSWORD": "hunter2",
+	})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(path, data, 0o600))
+
+	_, err = parseJSON(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "secret name")
+}
+
+func TestParseJSON_RejectsANSIEscapeInValue(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secrets.json")
+	data, err := json.Marshal(map[string]string{
+		"API_KEY": "sk_live_" + string(esc) + "[1A" + string(esc) + "[2Kabc123",
+	})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(path, data, 0o600))
+
+	_, err = parseJSON(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "API_KEY")
+}
+
+func TestParseJSON_RawControlByteIsInvalidJSON(t *testing.T) {
+	// Documents why the two tests above must go through json.Marshal instead
+	// of embedding a literal control byte in a hand-written JSON fixture: the
+	// standard library itself already refuses raw unescaped control bytes in
+	// a JSON string, independent of anything this package adds.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secrets.json")
+	raw := []byte(`{"API_KEY":"sk_live_`)
+	raw = append(raw, byte(esc))
+	raw = append(raw, []byte(`abc123"}`)...)
+	require.NoError(t, os.WriteFile(path, raw, 0o600))
+
+	_, err := parseJSON(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid JSON")
+}
+
+func TestParseJSON_AllowsOrdinaryUTF8(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secrets.json")
+	require.NoError(t, os.WriteFile(path, []byte(`{"GREETING":"héllo wörld 你好","DB_PASSWORD":"supersecret123"}`), 0o600))
+
+	entries, err := parseJSON(path)
+	require.NoError(t, err)
+	require.Len(t, entries, 2)
+}
+
+func TestParseVault_RejectsANSIEscapeInKey(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "vault.yaml")
+	data, err := yaml.Marshal(map[string]map[string]string{
+		"secret/production/database": {
+			"pass" + string(esc) + "[2Kword": "REPLACE_ME",
+		},
+	})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(path, data, 0o600))
+
+	_, err = parseVault(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "secret name")
+}
+
+func TestParseVault_RejectsANSIEscapeInValue(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "vault.yaml")
+	data, err := yaml.Marshal(map[string]map[string]string{
+		"secret/production/database-password": {
+			"value": "hunter2" + string(esc) + "[2Kfake",
+		},
+	})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(path, data, 0o600))
+
+	_, err = parseVault(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "database-password")
+}
+
+func TestParseVault_AllowsOrdinaryUTF8(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "vault.yaml")
+	content := "secret/production/database-password:\n  value: supersecret123\n"
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+	entries, err := parseVault(path)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+}
+
+func TestKeyHasControlChars(t *testing.T) {
+	assert.True(t, keyHasControlChars("db"+string(esc)+"[2Kpassword"))
+	assert.True(t, keyHasControlChars("a\nb"))
+	assert.False(t, keyHasControlChars("DB_PASSWORD"))
+	assert.False(t, keyHasControlChars("héllo"))
+}
+
+func TestValueHasDangerousControlChars(t *testing.T) {
+	assert.True(t, valueHasDangerousControlChars("hunter2"+string(esc)+"[2K"))
+	assert.True(t, valueHasDangerousControlChars("a\x00b"))
+	assert.True(t, valueHasDangerousControlChars("a\x07b")) // bell
+	assert.False(t, valueHasDangerousControlChars("line1\nline2\r\nwith\ttab"))
+	assert.False(t, valueHasDangerousControlChars("-----BEGIN KEY-----\nabc\n-----END KEY-----"))
 }


### PR DESCRIPTION
## Summary

Closes the residual half of #295 (the file-size-cap half was already fixed in an earlier round; confirmed `checkImportFileSize` is already applied in both `parseVault` and `parseJSON` and left untouched).

`sanitizeForTerminal` (in `import.go`) only scrubs bytes for terminal **display** in the dry-run preview and progress lines — the actual `secretEntry.Name`/`.Value` sent to `/api/v1/secrets` were never checked. A crafted import file (dotenv, vault YAML, or JSON) could embed raw control bytes or ANSI escape sequences in a parsed key/value that get stored as-is, and later spoof the terminal when echoed back by any tool in this codebase that displays them (`keyorix secret list`, another import run's dry-run preview, an error message quoting the name, etc.).

## Design: reject, not silently strip — and keys vs. values get different treatment

- **Keys** (`keyHasControlChars`): reject if the name contains **any** Unicode control character. Secret names are simple identifiers (see `core.SecretNamePolicy`) — there's no legitimate reason for one to contain a raw control byte, so this is unconditional.
- **Values** (`valueHasDangerousControlChars`): reject only the genuinely dangerous control characters — ESC/ANSI/C1 escape sequences and other non-printable control bytes — while **tolerating** `\t`, `\n`, `\r`. Real credential material (PEM private keys, certificates) is legitimately multi-line, so blanket-rejecting/stripping all control chars from values would either break legitimate imports or, worse, silently corrupt real secret bytes. This is a secrets manager: silently mutating what gets stored is worse than the terminal-spoofing risk itself, so a suspicious value fails the import loudly (naming the offending key) instead of being auto-cleaned.

Applied consistently in `parseDotenv`, `parseVault` (both the single-`value` and multi-field YAML shapes), and `parseJSON`, via a shared `validateImportedEntry` helper.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/cli/secret/...` (new regression tests: ANSI-laden key/value rejected per parser, ordinary UTF-8 imports unaffected, multi-line PEM-style values with `\t`/`\n` still accepted)
- [x] `gosec -severity medium -exclude-generated ./internal/cli/secret/...` — 0 issues
- [x] `golangci-lint run ./internal/cli/secret/...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)