### PR TITLE
harden(authz): require roles.read to view a group's role grants (#262)

### DIFF
--- a/server/http/rbac_route_authz_test.go
+++ b/server/http/rbac_route_authz_test.go
@@ -125,3 +125,65 @@ func TestGetUserRolesRequiresRolesRead(t *testing.T) {
 	assert.NotEqual(t, http.StatusForbidden, get("auditor-tok"),
 		"a roles.read holder should be allowed past the gate")
 }
+
+// Regression (#262): GET /api/v1/groups/{id}/roles must require roles.read, not
+// the group-wide users.read that the baseline viewer role (and nearly every
+// other seeded role) holds — otherwise any low-privilege, globally-assigned
+// viewer could enumerate an arbitrary group's full role-grant list across the
+// entire deployment, discovering exactly which roles (and therefore which
+// permissions) cascade to every member of that group. This mirrors the
+// GetUserRolesForUser fix (#141) for the same class of disclosure at group
+// granularity, and matches the roles.assign gate already required by this
+// route's mutating siblings (AssignRoleToGroup/RemoveRoleFromGroup).
+func TestGetGroupRolesRequiresRolesRead(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.User{}, &models.Role{}, &models.Permission{}, &models.RolePermission{},
+		&models.UserRole{}, &models.Group{}, &models.UserGroup{}, &models.GroupRole{},
+		&models.AuditEvent{}, &models.Session{}, &models.Project{}, &models.Environment{},
+	))
+	now := time.Now()
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "auditor", Email: "a@t.com", IsActive: true, CreatedAt: now, UpdatedAt: now}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 2, Username: "viewer", Email: "v@t.com", IsActive: true, CreatedAt: now, UpdatedAt: now}).Error)
+	// "auditor" holds roles.read; "viewer" holds only the baseline users.read.
+	require.NoError(t, db.Create(&models.Role{ID: 1, Name: "auditor"}).Error)
+	require.NoError(t, db.Create(&models.Role{ID: 2, Name: "viewer"}).Error)
+	require.NoError(t, db.Create(&models.Permission{ID: 1, Name: "users.read", Resource: "users", Action: "read"}).Error)
+	require.NoError(t, db.Create(&models.Permission{ID: 2, Name: "roles.read", Resource: "roles", Action: "read"}).Error)
+	require.NoError(t, db.Create(&models.RolePermission{RoleID: 1, PermissionID: 1}).Error)
+	require.NoError(t, db.Create(&models.RolePermission{RoleID: 1, PermissionID: 2}).Error)
+	require.NoError(t, db.Create(&models.RolePermission{RoleID: 2, PermissionID: 1}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 2, RoleID: 2}).Error)
+	// The group whose role grants are being probed — membership is irrelevant to
+	// this gate; neither caller belongs to it.
+	require.NoError(t, db.Create(&models.Group{ID: 1, Name: "finance-admins"}).Error)
+	require.NoError(t, db.Create(&models.GroupRole{GroupID: 1, RoleID: 1}).Error)
+	seedSession(t, db, 1, "auditor-tok")
+	seedSession(t, db, 2, "viewer-tok")
+
+	router, err := NewRouter(&config.Config{}, core.NewKeyorixCore(store.NewLocalStorage(db)))
+	require.NoError(t, err)
+	server := httptest.NewServer(router)
+	defer server.Close()
+	client := &http.Client{Timeout: 5 * time.Second}
+
+	get := func(token string) int {
+		req, err := http.NewRequest("GET", server.URL+"/api/v1/groups/1/roles", nil)
+		require.NoError(t, err)
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+		return resp.StatusCode
+	}
+
+	assert.Equal(t, http.StatusForbidden, get("viewer-tok"),
+		"users.read holder without roles.read must NOT enumerate a group's role grants")
+	assert.NotEqual(t, http.StatusForbidden, get("auditor-tok"),
+		"a roles.read holder should be allowed past the gate")
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -639,7 +639,14 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			// (matching the group's role-grant routes below), not users.read.
 			r.With(customMiddleware.RequirePermission("roles.assign")).Post("/{id}/members", groupHandler.AddGroupMember)
 			r.With(customMiddleware.RequirePermission("roles.assign")).Delete("/{id}/members/{userId}", groupHandler.RemoveGroupMember)
-			r.Get("/{id}/roles", rbacHandler.GetGroupRoles)
+			// Viewing a group's role grants discloses the same privilege-escalation
+			// topology as a single user's role list, so gate on roles.read (#262) —
+			// not the group-wide users.read (held by nearly every seeded role,
+			// including the baseline viewer). This matches GetUserRolesForUser above
+			// (#141) and the roles.read gate the /roles route group itself uses for
+			// GetRolePermissions; the mutating siblings (AssignRoleToGroup,
+			// RemoveRoleFromGroup) already require the more privileged roles.assign.
+			r.With(customMiddleware.RequirePermission("roles.read")).Get("/{id}/roles", rbacHandler.GetGroupRoles)
 			r.With(customMiddleware.RequirePermission("roles.assign")).Post("/{id}/roles", rbacHandler.AssignRoleToGroup)
 			r.With(customMiddleware.RequirePermission("roles.assign")).Delete("/{id}/roles/{roleId}", rbacHandler.RemoveRoleFromGroup)
 		})


### PR DESCRIPTION
## Summary

Backlog #262: `GET /api/v1/groups/{id}/roles` inherited only the group-wide `users.read` gate applied to the whole `/groups` subtree. `users.read` is held by nearly every seeded role — including the baseline `viewer` — so any globally-assigned viewer could enumerate an arbitrary group's full role-grant list across the entire deployment, discovering exactly which roles (and therefore permissions) cascade to every member of that group. That's reconnaissance value for targeted privilege escalation, not the "who's in this group" directory info `users.read` is meant to gate.

**Before:** `/groups/{id}/roles` → `users.read` (inherited from the `/groups` group middleware).
**After:** `/groups/{id}/roles` → `roles.read` (explicit override), matching:
- `GetUserRolesForUser` (`/users/{id}/roles`), already fixed in #141 for the identical disclosure at user granularity.
- The `/roles` route group's own `roles.read` gate (e.g. `GetRolePermissions`).
- This route's mutating siblings `AssignRoleToGroup`/`RemoveRoleFromGroup`, which already require the more privileged `roles.assign`.

`roles.read` is held by `system_admin`/`system_auditor`/`project_admin` — not by `viewer`/`editor`/`project_viewer`/`project_developer`/`project_auditor` — so it correctly excludes the baseline persona this finding is about.

`ListGroups`/`GetGroup`/`GetGroupMembers` are deliberately left on `users.read`: they disclose the same class of identity/roster info as `ListUsers`/`GetUser` (already `users.read`-gated), so no new gap there — only the role-grant view carries the privilege-topology disclosure this repo has repeatedly elevated above the baseline (per #141, #147).

I checked the gRPC `GroupGRPCService` for comparison: it has no group-role-listing RPC at all (only `ListGroups`/`GetGroup`/`GetGroupMembers`/membership mutations, all correctly on `users.read`/`roles.assign` and consistent with the HTTP CRUD routes), so the real inconsistency was HTTP-internal — this route vs. its already-fixed user-level sibling — not an HTTP/gRPC mismatch.

No existing `groups.read`-style permission exists in the catalog (`internal/core/auth_bootstrap.go`), so this reuses `roles.read` rather than inventing a new permission, since the disclosed data (role grants) is exactly what `roles.read` already gates elsewhere.

## Test plan

- [x] Added `TestGetGroupRolesRequiresRolesRead` in `server/http/rbac_route_authz_test.go`: a `users.read`-only viewer gets 403 on `GET /groups/1/roles`; a `roles.read` holder is let through — mirrors the existing `TestGetUserRolesRequiresRolesRead` harness.
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./server/... ./internal/core/...` — all pass
- [x] `gosec -severity medium -exclude-generated ./server/...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)