### PR TITLE
fix(startup): sanitize validateFilePermissions paths, wire --fix (#229)

### DIFF
--- a/examples/system_init/main.go
+++ b/examples/system_init/main.go
@@ -24,8 +24,8 @@ func main() {
 		return
 	}
 
-	// Perform validation
-	result, err := startup.ValidateStartup(configPath)
+	// Perform validation (no --fix equivalent in this example, so no forced autofix)
+	result, err := startup.ValidateStartup(configPath, false)
 	if err != nil {
 		fmt.Printf("❌ Validation failed: %v\n", err)
 		if result != nil {

--- a/internal/cli/system/validate.go
+++ b/internal/cli/system/validate.go
@@ -43,8 +43,11 @@ func runValidate(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("config file not found")
 	}
 
-	// Perform validation
-	result, err := startup.ValidateStartup(configFile)
+	// Perform validation. fixIssues (--fix) is read here and forwarded explicitly,
+	// so the flag actually drives remediation instead of the command silently
+	// depending on the Security.AutoFixFilePermissions field read from the same
+	// config file it is validating.
+	result, err := startup.ValidateStartup(configFile, fixIssues)
 	if err != nil {
 		fmt.Printf("❌ Validation failed: %v\n", err)
 

--- a/internal/startup/validation.go
+++ b/internal/startup/validation.go
@@ -25,8 +25,12 @@ type ValidationResult struct {
 	Errors        []string
 }
 
-// ValidateStartup performs comprehensive startup validation
-func ValidateStartup(configPath string) (*ValidationResult, error) {
+// ValidateStartup performs comprehensive startup validation. forceAutoFix, when
+// true, remediates file-permission issues regardless of the loaded config's
+// Security.AutoFixFilePermissions setting — this is how a caller-supplied
+// intent (e.g. an explicit CLI flag) takes effect without silently depending
+// on a field read from the very config file being validated.
+func ValidateStartup(configPath string, forceAutoFix bool) (*ValidationResult, error) {
 	result := &ValidationResult{
 		ConfigValid:   false,
 		PermissionsOK: false,
@@ -48,7 +52,7 @@ func ValidateStartup(configPath string) (*ValidationResult, error) {
 	result.ConfigValid = true
 
 	if cfg.Security.EnableFilePermissionCheck {
-		if err := validateFilePermissions(cfg, configPath, result); err != nil {
+		if err := validateFilePermissions(cfg, configPath, forceAutoFix, result); err != nil {
 			if !cfg.Security.AllowUnsafeFilePermissions {
 				return result, fmt.Errorf("file permission validation failed: %w", err)
 			}
@@ -81,22 +85,50 @@ func ValidateStartup(configPath string) (*ValidationResult, error) {
 	return result, nil
 }
 
-func validateFilePermissions(cfg *config.Config, configPath string, result *ValidationResult) error {
+// safeFilePermPath cleans path and rejects it if the cleaned form still
+// contains a ".." segment. Unlike validateEncryption/validateDatabase (whose
+// paths come from a small, fixed set of config fields dedicated to a single
+// key/db file), the paths collected here span several independently-authored
+// config fields (config path, key paths, TLS cert/key paths, db path) that
+// FixFilePerms below will Lstat/Chmod/Chown — so every one of them is
+// sanitized the same way before it is ever added to that list, closing off a
+// config-driven path-traversal into chmod/chown of an unintended file.
+func safeFilePermPath(label, path string) (string, error) {
+	clean := filepath.Clean(path)
+	if strings.Contains(clean, "..") {
+		return "", fmt.Errorf("%s path is unsafe (contains '..'): %s", label, path)
+	}
+	return clean, nil
+}
+
+func validateFilePermissions(cfg *config.Config, configPath string, forceAutoFix bool, result *ValidationResult) error {
 	var files []securefiles.FilePermSpec
 
 	// Check the config file that was actually loaded, not a hardcoded "keyorix.yaml":
 	// the loader resolves KEYORIX_CONFIG_PATH / an absolute path, so a fixed relative
 	// name would silently stat a non-existent file and pass. Skip only when truly unknown.
 	if cfgFile := strings.TrimSpace(configPath); cfgFile != "" {
-		files = append(files, securefiles.FilePermSpec{Path: filepath.Clean(cfgFile), Mode: 0600})
+		clean, err := safeFilePermPath("config file", cfgFile)
+		if err != nil {
+			return err
+		}
+		files = append(files, securefiles.FilePermSpec{Path: clean, Mode: 0600})
 	}
 
 	if cfg.Storage.Encryption.Enabled {
 		// The KEK is passphrase-derived and never on disk (ADR-004); the salt and
 		// the wrapped DEK are the only key files to lock down.
+		saltPath, err := safeFilePermPath("KEK salt", cfg.Storage.Encryption.SaltPath)
+		if err != nil {
+			return err
+		}
+		dekPath, err := safeFilePermPath("DEK", cfg.Storage.Encryption.DEKPath)
+		if err != nil {
+			return err
+		}
 		files = append(files,
-			securefiles.FilePermSpec{Path: filepath.Clean(cfg.Storage.Encryption.SaltPath), Mode: 0600},
-			securefiles.FilePermSpec{Path: filepath.Clean(cfg.Storage.Encryption.DEKPath), Mode: 0600},
+			securefiles.FilePermSpec{Path: saltPath, Mode: 0600},
+			securefiles.FilePermSpec{Path: dekPath, Mode: 0600},
 		)
 	}
 
@@ -110,31 +142,52 @@ func validateFilePermissions(cfg *config.Config, configPath string, result *Vali
 		// no local database file to check
 	default: // "local", ""
 		if cfg.Storage.Database.Path != "" {
+			dbPath, err := safeFilePermPath("database", cfg.Storage.Database.Path)
+			if err != nil {
+				return err
+			}
 			files = append(files, securefiles.FilePermSpec{
-				Path: filepath.Clean(cfg.Storage.Database.Path),
+				Path: dbPath,
 				Mode: 0600,
 			})
 		}
 	}
 
 	if cfg.Server.HTTP.TLS.Enabled {
+		certPath, err := safeFilePermPath("HTTP TLS cert", cfg.Server.HTTP.TLS.CertFile)
+		if err != nil {
+			return err
+		}
+		keyPath, err := safeFilePermPath("HTTP TLS key", cfg.Server.HTTP.TLS.KeyFile)
+		if err != nil {
+			return err
+		}
 		files = append(files,
-			securefiles.FilePermSpec{Path: filepath.Clean(cfg.Server.HTTP.TLS.CertFile), Mode: 0600},
-			securefiles.FilePermSpec{Path: filepath.Clean(cfg.Server.HTTP.TLS.KeyFile), Mode: 0600},
+			securefiles.FilePermSpec{Path: certPath, Mode: 0600},
+			securefiles.FilePermSpec{Path: keyPath, Mode: 0600},
 		)
 	}
 	if cfg.Server.GRPC.TLS.Enabled {
+		certPath, err := safeFilePermPath("gRPC TLS cert", cfg.Server.GRPC.TLS.CertFile)
+		if err != nil {
+			return err
+		}
+		keyPath, err := safeFilePermPath("gRPC TLS key", cfg.Server.GRPC.TLS.KeyFile)
+		if err != nil {
+			return err
+		}
 		files = append(files,
-			securefiles.FilePermSpec{Path: filepath.Clean(cfg.Server.GRPC.TLS.CertFile), Mode: 0600},
-			securefiles.FilePermSpec{Path: filepath.Clean(cfg.Server.GRPC.TLS.KeyFile), Mode: 0600},
+			securefiles.FilePermSpec{Path: certPath, Mode: 0600},
+			securefiles.FilePermSpec{Path: keyPath, Mode: 0600},
 		)
 	}
 
-	if err := securefiles.FixFilePerms(files, cfg.Security.AutoFixFilePermissions); err != nil {
+	autoFix := cfg.Security.AutoFixFilePermissions || forceAutoFix
+	if err := securefiles.FixFilePerms(files, autoFix); err != nil {
 		return fmt.Errorf("file permission validation failed: %w", err)
 	}
 
-	if cfg.Security.AutoFixFilePermissions {
+	if autoFix {
 		result.Warnings = append(result.Warnings, "File permissions were automatically fixed")
 	}
 

--- a/internal/startup/validation_test.go
+++ b/internal/startup/validation_test.go
@@ -94,7 +94,7 @@ func TestValidateFilePermissions_UsesActualConfigPath(t *testing.T) {
 	}
 
 	cfg := &config.Config{} // no encryption/DB path configured — isolates the config-file check
-	if err := validateFilePermissions(cfg, configPath, &ValidationResult{}); err != nil {
+	if err := validateFilePermissions(cfg, configPath, false, &ValidationResult{}); err != nil {
 		t.Fatalf("expected the real 0600 config path to pass, got: %v", err)
 	}
 }
@@ -107,9 +107,100 @@ func TestValidateFilePermissions_SkipsDatabasePathForNonLocalStorage(t *testing.
 		cfg := &config.Config{}
 		cfg.Storage.Type = typ
 		// Database.Path intentionally left empty, as it legitimately is for these types.
-		if err := validateFilePermissions(cfg, "", &ValidationResult{}); err != nil {
+		if err := validateFilePermissions(cfg, "", false, &ValidationResult{}); err != nil {
 			t.Errorf("storage.type=%q must not check a local database file, got: %v", typ, err)
 		}
+	}
+}
+
+// #229: validateFilePermissions must reject a ".."-traversal segment in every path it
+// collects — the config file path, key paths, database path, and TLS cert/key paths are
+// all sourced from a config file that may itself be attacker-influenced (e.g. a custom
+// --config pointed at a maliciously-crafted file). Unlike this file's sibling functions
+// (validateEncryption, validateDatabase), validateFilePermissions previously only
+// filepath.Clean()'d these paths with no traversal check before handing them to
+// securefiles.FixFilePerms, which will Lstat/Chmod/Chown whatever path it's given.
+func TestValidateFilePermissions_RejectsPathTraversal(t *testing.T) {
+	dir := t.TempDir()
+	// A relative path that filepath.Clean cannot fully resolve (it climbs above
+	// where it started), so the cleaned form still contains "..". filepath.Join
+	// would clean this away, so it's built by hand to keep the traversal intact.
+	outside := "sub/../../outside-target"
+
+	t.Run("config path", func(t *testing.T) {
+		cfg := &config.Config{}
+		if err := validateFilePermissions(cfg, outside, false, &ValidationResult{}); err == nil {
+			t.Fatal("expected error for a config path containing '..'")
+		}
+	})
+
+	t.Run("encryption salt path", func(t *testing.T) {
+		cfg := encCfg(outside, filepath.Join(dir, "dek.key"))
+		if err := validateFilePermissions(cfg, "", false, &ValidationResult{}); err == nil {
+			t.Fatal("expected error for a KEK salt path containing '..'")
+		}
+	})
+
+	t.Run("encryption dek path", func(t *testing.T) {
+		cfg := encCfg(filepath.Join(dir, "kek.salt"), outside)
+		if err := validateFilePermissions(cfg, "", false, &ValidationResult{}); err == nil {
+			t.Fatal("expected error for a DEK path containing '..'")
+		}
+	})
+
+	t.Run("database path", func(t *testing.T) {
+		cfg := &config.Config{}
+		cfg.Storage.Database.Path = outside
+		if err := validateFilePermissions(cfg, "", false, &ValidationResult{}); err == nil {
+			t.Fatal("expected error for a database path containing '..'")
+		}
+	})
+
+	t.Run("http tls cert/key path", func(t *testing.T) {
+		cfg := &config.Config{}
+		cfg.Server.HTTP.TLS.Enabled = true
+		cfg.Server.HTTP.TLS.CertFile = outside
+		cfg.Server.HTTP.TLS.KeyFile = filepath.Join(dir, "server.key")
+		if err := validateFilePermissions(cfg, "", false, &ValidationResult{}); err == nil {
+			t.Fatal("expected error for an HTTP TLS cert path containing '..'")
+		}
+	})
+
+	t.Run("grpc tls cert/key path", func(t *testing.T) {
+		cfg := &config.Config{}
+		cfg.Server.GRPC.TLS.Enabled = true
+		cfg.Server.GRPC.TLS.CertFile = filepath.Join(dir, "server.crt")
+		cfg.Server.GRPC.TLS.KeyFile = outside
+		if err := validateFilePermissions(cfg, "", false, &ValidationResult{}); err == nil {
+			t.Fatal("expected error for a gRPC TLS key path containing '..'")
+		}
+	})
+}
+
+// #229: forceAutoFix must actually drive remediation independent of the config's
+// Security.AutoFixFilePermissions field — this is what makes `keyorix system validate
+// --fix` do what an operator expects instead of silently depending on a field read from
+// the config file being validated.
+func TestValidateFilePermissions_ForceAutoFixOverridesConfig(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "cfg.yaml")
+	// 0644 is wrong (want 0600); this exercises the fix path.
+	if err := os.WriteFile(configPath, []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Config{} // AutoFixFilePermissions left false/zero-value
+	result := &ValidationResult{}
+	if err := validateFilePermissions(cfg, configPath, true, result); err != nil {
+		t.Fatalf("expected forceAutoFix to remediate the bad mode, got: %v", err)
+	}
+
+	info, err := os.Stat(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0600 {
+		t.Fatalf("expected mode to be fixed to 0600, got %o", info.Mode().Perm())
 	}
 }
 

--- a/server/main.go
+++ b/server/main.go
@@ -1371,7 +1371,9 @@ func runStartupValidation(cfg *config.Config) error {
 		return nil
 	}
 	configPath := config.ResolvedPath("")
-	result, err := startup.ValidateStartup(configPath)
+	// Server startup has no --fix flag; remediation is governed solely by the
+	// config's Security.AutoFixFilePermissions field, as before.
+	result, err := startup.ValidateStartup(configPath, false)
 	if result != nil {
 		for _, w := range result.Warnings {
 			log.Printf("startup validation warning: %s", w)


### PR DESCRIPTION
## Summary

Both bundled sub-items in backlog finding #229 are against **live, reachable code** — `keyorix system validate` is registered on the root command (`internal/cli/main.go` -> `system.SystemCmd` -> `validateCmd` -> `startup.ValidateStartup` -> `validateFilePermissions`), so this fixes the code in place rather than deleting it (unlike some earlier #331/#332-adjacent findings against this same file, which really were dead at the time).

1. **Path traversal in `validateFilePermissions`** (`internal/startup/validation.go`): the function collected the config path, KEK salt/DEK paths, database path, and TLS cert/key paths — all sourced from a config file that may itself be attacker-influenced (e.g. a custom `--config`) — with only `filepath.Clean()`, no `..`-rejection. Its siblings `validateEncryption`/`validateDatabase` in the same file already reject a residual `..` segment; `validateFilePermissions` did not, and its output feeds `securefiles.FixFilePerms`, which `Lstat`/`Chmod`/`Chown`s whatever path it's given. Added a shared `safeFilePermPath` helper applying the same convention to every path collected.

2. **Dead `--fix` flag**: `keyorix system validate --fix` bound `fixIssues` to a variable that was never read anywhere — the real autofix behavior was driven silently by `cfg.Security.AutoFixFilePermissions`, read from the very config file being validated. `ValidateStartup`/`validateFilePermissions` now take an explicit `forceAutoFix bool`, and the CLI forwards `--fix` into it (OR'd with the config field, so config-only behavior is unchanged when `--fix` is absent). Server startup and the `examples/system_init` example pass `false` (no CLI flag there), preserving prior behavior.

## Testing
- `TestValidateFilePermissions_RejectsPathTraversal` — a `..`-traversal path is rejected for each of: config path, KEK salt, DEK, database path, HTTP TLS cert/key, gRPC TLS cert/key.
- `TestValidateFilePermissions_ForceAutoFixOverridesConfig` — `forceAutoFix=true` actually remediates a bad file mode even with `Security.AutoFixFilePermissions` false.
- Existing tests updated for the new `validateFilePermissions` signature; all pass.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/cli/system/... ./internal/startup/...` (all pass, including new tests)
- [x] `go test ./server/...` (unaffected by signature change)
- [x] `gosec -severity medium -exclude-generated` scoped to `internal/cli/system`, `internal/startup`, `internal/securefiles` — 0 issues

Refs #229.