### PR TITLE
fix(compliance): certificate-hygiene control reports not_configured when scanning is off

### DIFF
--- a/internal/core/control_framework.go
+++ b/internal/core/control_framework.go
@@ -155,8 +155,8 @@ func EvaluateControls(p *CompliancePosture) []ControlState {
 		},
 		{
 			ID: "certificate-hygiene", Name: "Certificate expiry hygiene", Area: "Cryptography",
-			Status:     controlStatus(p.DegradedArea("certificates"), p.Certificates.Expired > 0),
-			Detail:     fmt.Sprintf("%d expired, %d expiring soon of %d certificate(s) (%d not yet evaluated)", p.Certificates.Expired, p.Certificates.ExpiringSoon, p.Certificates.TotalCertificates, p.Certificates.NotEvaluated),
+			Status:     certificateHygieneStatus(p),
+			Detail:     certificateHygieneDetail(p),
 			Frameworks: FrameworkRefs{ISO27001: []string{"A.5.15", "A.8.24"}, SOC2: []string{"CC6.1"}, NIS2: []string{"Art.21(2)(h)"}, ENS: []string{"op.exp.11"}},
 		},
 		{
@@ -226,6 +226,38 @@ func supplyChainDetail(p *CompliancePosture) string {
 	}
 	return fmt.Sprintf("update bundles verified offline against %d pinned signing key(s); license: %s",
 		s.TrustedUpdateKeys, s.LicenseState)
+}
+
+// certificateHygieneStatus is Pass/Gap once certificate-expiry scanning (ADR-055) has
+// actually evaluated at least one certificate. That scan is opt-in/off by default, and
+// CertificatePosture.Expired only ever increments for a certificate the scan has parsed
+// — so with the scan disabled, Expired stays permanently 0 and the control would read as
+// a false "pass" even though not a single certificate was ever checked (#397). Mirror the
+// supply-chain-integrity escape hatch above: "never enabled" is not-configured, distinct
+// from "enabled but this run's collection failed", which is Unknown (#136).
+func certificateHygieneStatus(p *CompliancePosture) ControlStatus {
+	if p.DegradedArea("certificates") {
+		return ControlStatusUnknown
+	}
+	c := p.Certificates
+	if c.NotEvaluated == c.TotalCertificates {
+		return ControlStatusNotConfigured
+	}
+	return gapIf(c.Expired > 0)
+}
+
+func certificateHygieneDetail(p *CompliancePosture) string {
+	c := p.Certificates
+	if p.DegradedArea("certificates") {
+		return "UNKNOWN — certificate posture could not be collected this run"
+	}
+	if c.NotEvaluated == c.TotalCertificates {
+		if c.TotalCertificates == 0 {
+			return "no certificate-typed secrets to evaluate"
+		}
+		return fmt.Sprintf("certificate-expiry scanning not enabled — %d certificate(s) never evaluated", c.TotalCertificates)
+	}
+	return fmt.Sprintf("%d expired, %d expiring soon of %d certificate(s) (%d not yet evaluated)", c.Expired, c.ExpiringSoon, c.TotalCertificates, c.NotEvaluated)
 }
 
 // statusFromBool maps an enabled flag to pass / not-configured (an unset optional

--- a/internal/core/control_framework_test.go
+++ b/internal/core/control_framework_test.go
@@ -118,3 +118,49 @@ func TestEvaluateControls_SupplyChainIntegrity(t *testing.T) {
 	assert.Equal(t, ControlStatusNotConfigured, scu.Status)
 	assert.NotEqual(t, ControlStatusGap, scu.Status)
 }
+
+// #397: certificate-expiry scanning (ADR-055) is opt-in/off by default. With it
+// disabled, not a single certificate has ever been evaluated, so the control must read
+// as not-configured — never a permanent, unearned "pass" just because Expired stayed 0.
+func TestEvaluateControls_CertificateHygiene_ScanningNeverEnabled(t *testing.T) {
+	// No certificate secrets at all: trivially nothing to evaluate.
+	none := EvaluateControls(&CompliancePosture{})
+	cn := findControl(t, none, "certificate-hygiene")
+	assert.Equal(t, ControlStatusNotConfigured, cn.Status)
+	assert.NotEqual(t, ControlStatusPass, cn.Status)
+
+	// Certificate-typed secrets exist, but the scan has never parsed one of them
+	// (CertNotAfter cache is empty for every one) — still not-configured, not pass.
+	unscanned := EvaluateControls(&CompliancePosture{
+		Certificates: CertificatePosture{TotalCertificates: 3, NotEvaluated: 3},
+	})
+	cu := findControl(t, unscanned, "certificate-hygiene")
+	assert.Equal(t, ControlStatusNotConfigured, cu.Status)
+	assert.NotEqual(t, ControlStatusPass, cu.Status)
+	assert.Contains(t, cu.Detail, "not enabled")
+}
+
+// Once the scan has evaluated at least one certificate, the control reflects the real
+// data: pass when none are expired, gap when at least one is.
+func TestEvaluateControls_CertificateHygiene_ScanningEnabled(t *testing.T) {
+	healthy := EvaluateControls(&CompliancePosture{
+		Certificates: CertificatePosture{TotalCertificates: 2, ExpiringSoon: 0, Expired: 0, NotEvaluated: 0},
+	})
+	ch := findControl(t, healthy, "certificate-hygiene")
+	assert.Equal(t, ControlStatusPass, ch.Status)
+
+	expired := EvaluateControls(&CompliancePosture{
+		Certificates: CertificatePosture{TotalCertificates: 2, Expired: 1, NotEvaluated: 0},
+	})
+	ce := findControl(t, expired, "certificate-hygiene")
+	assert.Equal(t, ControlStatusGap, ce.Status)
+
+	// Partially scanned (some evaluated, some not) still uses real data rather than
+	// falling back to not-configured, since the scan clearly IS enabled here.
+	partial := EvaluateControls(&CompliancePosture{
+		Certificates: CertificatePosture{TotalCertificates: 3, Expired: 0, NotEvaluated: 1},
+	})
+	cp := findControl(t, partial, "certificate-hygiene")
+	assert.Equal(t, ControlStatusPass, cp.Status)
+	assert.Contains(t, cp.Detail, "1 not yet evaluated")
+}


### PR DESCRIPTION
## Summary
- Fixes #397: the `certificate-hygiene` compliance control (`internal/core/control_framework.go`) showed a permanent PASS when certificate-expiry scanning (ADR-055, opt-in/off by default) was never enabled, because `CertificatePosture.Expired` only ever increments for a certificate the scan has actually parsed — with the scan disabled, no certificate is ever evaluated, but the control still read as passing.
- Mirrors the existing `supply-chain-integrity` escape hatch in the same file: when every certificate-typed secret (or none at all) is unevaluated, the control now reports `ControlStatusNotConfigured` instead of a false `Pass`. Once the scan has evaluated at least one certificate, the control still reports real `Pass`/`Gap` from the data, and `Unknown` on a degraded collection, unchanged.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/core/...`
- [x] `gosec -severity medium -exclude-generated ./internal/core/...` (0 issues)
- [x] Added regression tests: scanning disabled (no certs, and certs present but never evaluated) → `NotConfigured`; scanning enabled with all healthy → `Pass`; scanning enabled with an expired cert → `Gap`; partially-scanned deployment still reports real data, not `NotConfigured`