### PR TITLE
fix(rbac): scope roles.assign check to target project on user-roles HTTP route (#342)

### DIFF
--- a/server/http/router.go
+++ b/server/http/router.go
@@ -683,10 +683,16 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 
 		// User roles endpoints
 		r.Route("/user-roles", func(r chi.Router) {
-			r.Use(customMiddleware.RequirePermission("roles.assign"))
-			r.Post("/", rbacHandler.AssignRole)
-			r.Delete("/", rbacHandler.RemoveRole)
-			r.Get("/user/{userId}", rbacHandler.GetUserRoles)
+			// Assign/remove are gated on roles.assign AT THE REQUEST BODY'S TARGET
+			// scope (project_id/environment_id, 0 = global) — mirroring
+			// RoleGRPCService.AssignRole/RemoveRole, which authorize at the target
+			// scope rather than a flat global permission. Before this (#342), these
+			// routes used the group-level RequirePermission("roles.assign"), which
+			// always checked the GLOBAL scope regardless of the body's actual
+			// target, a parity gap with the gRPC path.
+			r.With(customMiddleware.RequireScopedPermission("roles.assign", customMiddleware.ScopeFromRoleAssignmentBody)).Post("/", rbacHandler.AssignRole)
+			r.With(customMiddleware.RequireScopedPermission("roles.assign", customMiddleware.ScopeFromRoleAssignmentBody)).Delete("/", rbacHandler.RemoveRole)
+			r.With(customMiddleware.RequirePermission("roles.assign")).Get("/user/{userId}", rbacHandler.GetUserRoles)
 		})
 
 		// Audit logs endpoints

--- a/server/http/user_roles_scope_test.go
+++ b/server/http/user_roles_scope_test.go
@@ -1,0 +1,140 @@
+package http
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// setupUserRolesScopeCore builds a core with two projects (A=1, B=2), a
+// "target" user (3) to have roles granted/removed on them, a "granter" user (2)
+// who holds roles.assign scoped ONLY to project A (never globally), and a
+// permission-less "grantee" role (3) — so granting/removing it exercises purely
+// the roles.assign scope gate under test, not the separate bundled-permission
+// ceiling check (requireGranterHoldsRolePermissions, #93/#107/#141).
+func setupUserRolesScopeCore(t *testing.T) *core.KeyorixCore {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.Project{}, &models.Environment{}, &models.User{},
+		&models.Role{}, &models.Permission{}, &models.RolePermission{},
+		&models.UserRole{}, &models.Group{}, &models.UserGroup{}, &models.GroupRole{},
+		&models.AuditEvent{}, &models.Session{},
+	))
+
+	now := time.Now()
+	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "project-a"}).Error)
+	require.NoError(t, db.Create(&models.Project{ID: 2, Name: "project-b"}).Error)
+
+	require.NoError(t, db.Create(&models.User{ID: 2, Username: "granter", Email: "granter@test.com", IsActive: true, CreatedAt: now, UpdatedAt: now}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 3, Username: "target", Email: "target@test.com", IsActive: true, CreatedAt: now, UpdatedAt: now}).Error)
+
+	// "project-manager" bundles only roles.assign; "grantee" bundles nothing.
+	require.NoError(t, db.Create(&models.Role{ID: 1, Name: "project-manager"}).Error)
+	require.NoError(t, db.Create(&models.Role{ID: 2, Name: "grantee"}).Error)
+	require.NoError(t, db.Create(&models.Permission{ID: 1, Name: "roles.assign", Resource: "roles", Action: "assign"}).Error)
+	require.NoError(t, db.Create(&models.RolePermission{RoleID: 1, PermissionID: 1}).Error)
+
+	// granter holds roles.assign scoped to project A ONLY — never globally.
+	require.NoError(t, db.Create(&models.UserRole{UserID: 2, RoleID: 1, ProjectID: 1}).Error)
+
+	seedSession(t, db, 2, "granter-tok")
+
+	return core.NewKeyorixCore(store.NewLocalStorage(db))
+}
+
+// Regression (#342): POST/DELETE /api/v1/user-roles must authorize roles.assign
+// at the request body's TARGET scope (project_id/environment_id), exactly like
+// RoleGRPCService.AssignRole/RemoveRole already do — not at a flat GLOBAL scope
+// that ignores the body entirely. Before the fix, the route's group-level
+// RequirePermission("roles.assign") always checked global scope, so a caller
+// scoped only to project A could never use this HTTP route at all (even for
+// their own project), a functional/authorization parity gap with gRPC that this
+// test locks in the corrected direction for: allowed at the caller's own scope,
+// refused at a scope they do not hold.
+func TestAssignRoleHTTPScopedToTargetProject(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	router, err := NewRouter(&config.Config{}, setupUserRolesScopeCore(t))
+	require.NoError(t, err)
+	server := httptest.NewServer(router)
+	defer server.Close()
+	client := &http.Client{Timeout: 5 * time.Second}
+
+	assign := func(t *testing.T, projectID int) int {
+		t.Helper()
+		body := `{"user_id":3,"role_id":2,"project_id":` + strconv.Itoa(projectID) + `}`
+		req, err := http.NewRequest(http.MethodPost, server.URL+"/api/v1/user-roles", strings.NewReader(body))
+		require.NoError(t, err)
+		req.Header.Set("Authorization", "Bearer granter-tok")
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+		return resp.StatusCode
+	}
+
+	// Granter scoped to project A must be REFUSED when the body targets project B.
+	assert.Equal(t, http.StatusForbidden, assign(t, 2),
+		"a roles.assign holder scoped to project A must not assign a role at project B")
+	// Granter scoped to project A must be ALLOWED when the body targets project A.
+	assert.Equal(t, http.StatusCreated, assign(t, 1),
+		"a roles.assign holder scoped to project A must be allowed to assign a role at project A")
+}
+
+// Regression (#342): same scope gate as TestAssignRoleHTTPScopedToTargetProject,
+// for the DELETE /api/v1/user-roles route, mirroring RoleGRPCService.RemoveRole.
+func TestRemoveRoleHTTPScopedToTargetProject(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	c := setupUserRolesScopeCore(t)
+	// Pre-assign the "grantee" role to the target user at BOTH project A and
+	// project B (bypassing HTTP, via the core choke point directly with the
+	// system pseudo-actor) so the removal attempts below only exercise the
+	// roles.assign scope gate, not the assignment step.
+	require.NoError(t, c.AssignUserRole(context.Background(), 0, 3, 2, core.Scope{ProjectID: 1}))
+	require.NoError(t, c.AssignUserRole(context.Background(), 0, 3, 2, core.Scope{ProjectID: 2}))
+
+	router, err := NewRouter(&config.Config{}, c)
+	require.NoError(t, err)
+	server := httptest.NewServer(router)
+	defer server.Close()
+	client := &http.Client{Timeout: 5 * time.Second}
+
+	remove := func(t *testing.T, projectID int) int {
+		t.Helper()
+		body := `{"user_id":3,"role_id":2,"project_id":` + strconv.Itoa(projectID) + `}`
+		req, err := http.NewRequest(http.MethodDelete, server.URL+"/api/v1/user-roles", strings.NewReader(body))
+		require.NoError(t, err)
+		req.Header.Set("Authorization", "Bearer granter-tok")
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+		return resp.StatusCode
+	}
+
+	// Granter scoped to project A must be REFUSED when the body targets project B.
+	assert.Equal(t, http.StatusForbidden, remove(t, 2),
+		"a roles.assign holder scoped to project A must not remove a role grant at project B")
+	// Granter scoped to project A must be ALLOWED when the body targets project A.
+	assert.Equal(t, http.StatusNoContent, remove(t, 1),
+		"a roles.assign holder scoped to project A must be allowed to remove a role grant at project A")
+}

--- a/server/middleware/auth.go
+++ b/server/middleware/auth.go
@@ -1,11 +1,13 @@
 package middleware
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"strconv"
@@ -585,6 +587,42 @@ func ScopeFromRotationPolicyParam(param string) ScopeResolver {
 			EnvironmentID: derefUint(policy.EnvironmentID),
 		}, nil
 	}
+}
+
+// roleAssignmentBodyScope is the subset of the user-roles assign/remove request
+// body (both share the same project_id/environment_id shape) needed to resolve
+// the target scope ahead of the handler's own decode.
+type roleAssignmentBodyScope struct {
+	ProjectID     uint `json:"project_id"`
+	EnvironmentID uint `json:"environment_id"`
+}
+
+// ScopeFromRoleAssignmentBody resolves the target scope of a POST/DELETE
+// /api/v1/user-roles request from its own JSON body's "project_id"/
+// "environment_id" fields (0 = global) — mirroring
+// RoleGRPCService.AssignRole/RemoveRole (server/grpc/services/role_service.go),
+// which authorize roles.assign at the request's TARGET scope rather than a flat
+// global permission (#342). Before this, the HTTP route gated on RequirePermission
+// ("roles.assign"), which always checked the GLOBAL scope regardless of the
+// body's actual project/environment target — a parity gap with the gRPC path.
+//
+// The body is read and re-buffered onto r.Body (via a fresh io.NopCloser) so the
+// handler's own json.Decode of the same body still succeeds afterward.
+func ScopeFromRoleAssignmentBody(r *http.Request, _ *core.KeyorixCore) (core.Scope, error) {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return core.Scope{}, errInvalidTarget
+	}
+	_ = r.Body.Close()
+	r.Body = io.NopCloser(bytes.NewReader(body))
+
+	var s roleAssignmentBodyScope
+	if len(body) > 0 {
+		if err := json.Unmarshal(body, &s); err != nil {
+			return core.Scope{}, errInvalidTarget
+		}
+	}
+	return core.Scope{ProjectID: s.ProjectID, EnvironmentID: s.EnvironmentID}, nil
 }
 
 func scopePathUint(r *http.Request, param string) (uint, error) {


### PR DESCRIPTION
## Summary

Fixes #342: `POST`/`DELETE /api/v1/user-roles` (the assign/remove-role-to-user HTTP endpoints) checked `roles.assign` at a flat **GLOBAL** scope via the route-group's `RequirePermission("roles.assign")`, completely ignoring the request body's `project_id`/`environment_id` target. The gRPC equivalents (`RoleGRPCService.AssignRole`/`RemoveRole` in `server/grpc/services/role_service.go`) already build `scope := core.Scope{ProjectID: ..., EnvironmentID: ...}` from the request and authorize `roles.assign` at that **target** scope — an HTTP↔gRPC parity gap, the same class as the already-fixed #141.

Net effect of the bug: a caller who holds `roles.assign` scoped only to a specific project (not globally) could never use the HTTP route at all — even for role grants/removals within their own project — while the gRPC path correctly allows it. This is a correctness/parity fix, tightening the HTTP gate to check the real target scope instead of an unconditional global check, matching gRPC and the scope-hierarchy semantics used by every other scoped route in the codebase.

## What changed

- Added `ScopeFromRoleAssignmentBody` (`server/middleware/auth.go`): a `ScopeResolver` that reads the JSON body's `project_id`/`environment_id` (0 = global) and re-buffers the body (`io.NopCloser` over the read bytes) so the handler's own `json.Decode` of the same request still works afterward.
- `server/http/router.go`: `POST`/`DELETE /api/v1/user-roles` now use `RequireScopedPermission("roles.assign", ScopeFromRoleAssignmentBody)` instead of the group-level, always-global `RequirePermission("roles.assign")`. `GET /user-roles/user/{userId}` is left as-is (no body to scope from).
- Added `server/http/user_roles_scope_test.go`: a caller holding `roles.assign` scoped only to project A is refused (`403`) when the body targets project B, and allowed (`201`/`204`) when it targets project A — for both the assign and remove routes.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./server/... ./internal/core/...` — all pass, including the new regression tests
- [x] `gosec -severity medium -exclude-generated ./server/...` — 0 issues