### PR TITLE
fix(cli): escape CSV-formula-injection triggers in audit export (#261)

### DIFF
--- a/internal/cli/audit/audit.go
+++ b/internal/cli/audit/audit.go
@@ -238,9 +238,9 @@ since a point in time with --since --all.`,
 						continue
 					}
 					_ = cw.Write([]string{
-						strconv.FormatUint(uint64(row.ID), 10), row.Timestamp, row.EventType,
-						row.Actor, row.ActorType, uintPtrStr(row.UserID), uintPtrStr(row.ProjectID),
-						uintPtrStr(row.SecretID), row.IPAddress, strconv.FormatBool(row.Success), row.Description,
+						strconv.FormatUint(uint64(row.ID), 10), row.Timestamp, common.CSVSafe(row.EventType),
+						common.CSVSafe(row.Actor), row.ActorType, uintPtrStr(row.UserID), uintPtrStr(row.ProjectID),
+						uintPtrStr(row.SecretID), common.CSVSafe(row.IPAddress), strconv.FormatBool(row.Success), common.CSVSafe(row.Description),
 					})
 					continue
 				}

--- a/internal/cli/audit/audit_test.go
+++ b/internal/cli/audit/audit_test.go
@@ -251,3 +251,40 @@ func TestExport_CSV(t *testing.T) {
 	assert.Contains(t, lines[1], "created db")
 	assert.Contains(t, lines[1], "1,2026-06-19T10:00:00Z")
 }
+
+// TestExport_CSV_NeutralizesFormulaInjection is the regression test for #261: an
+// actor name or event description beginning with =, +, -, or @ (the classic
+// CSV-formula-injection trigger, e.g. =cmd|'/c calc'!A1) must be defanged with a
+// leading single quote before it reaches the CSV a compliance reviewer opens in
+// Excel/Sheets/LibreOffice — the same csvSafe convention already applied to the
+// server's own CSV export handlers (#148/#239), reused here via
+// internal/cli/common.CSVSafe. Ordinary text must pass through byte-for-byte
+// unchanged.
+func TestExport_CSV_NeutralizesFormulaInjection(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"events":[
+			{"id":1,"event_type":"secret.created","timestamp":"2026-06-19T10:00:00Z","actor":"=cmd|'/c calc'!A1","actor_type":"user","ip_address":"10.0.0.1","success":true,"description":"+1+1 formula attempt"},
+			{"id":2,"event_type":"secret.deleted","timestamp":"2026-06-19T10:05:00Z","actor":"-2+3 attacker","actor_type":"user","ip_address":"10.0.0.2","success":true,"description":"@SUM(A1) formula attempt"},
+			{"id":3,"event_type":"secret.read","timestamp":"2026-06-19T10:06:00Z","actor":"ordinary-user","actor_type":"user","ip_address":"10.0.0.3","success":true,"description":"nothing suspicious here"}
+		],"count":3,"next_cursor":null}}`))
+	}))
+	defer srv.Close()
+	setRemote(t, srv.URL)
+
+	var out, errOut bytes.Buffer
+	exportCmd.SetOut(&out)
+	exportCmd.SetErr(&errOut)
+	flagSince, flagAfterID, flagLimit, flagAll, flagCSV = "", 0, 100, false, true
+	defer func() { flagCSV = false }()
+	require.NoError(t, exportCmd.RunE(exportCmd, nil))
+
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	require.Len(t, lines, 4, "header + 3 event rows")
+	assert.Contains(t, lines[1], "'=cmd|'/c calc'!A1", "leading = actor is defanged with a single quote")
+	assert.Contains(t, lines[1], "'+1+1 formula attempt", "leading + description is defanged with a single quote")
+	assert.Contains(t, lines[2], "'-2+3 attacker", "leading - actor is defanged with a single quote")
+	assert.Contains(t, lines[2], "'@SUM(A1) formula attempt", "leading @ description is defanged with a single quote")
+	assert.Contains(t, lines[3], "ordinary-user", "ordinary text passes through unchanged")
+	assert.Contains(t, lines[3], "nothing suspicious here", "ordinary text passes through unchanged")
+	assert.NotContains(t, lines[3], "'ordinary-user", "no spurious quote is added to non-formula text")
+}

--- a/internal/cli/common/csv_safe.go
+++ b/internal/cli/common/csv_safe.go
@@ -1,0 +1,19 @@
+package common
+
+// CSVSafe neutralizes spreadsheet formula injection (CWE-1236): a CSV cell
+// beginning with =, +, -, @, TAB, or CR is prefixed with a single quote so
+// Excel / LibreOffice / Sheets treat it as text rather than executing it as a
+// formula. Apply it to any server-supplied free-text field (actor names,
+// event descriptions, etc.) written to a CSV a CLI command emits, mirroring
+// the identical csvSafe convention already applied to the server's own CSV
+// export handlers (server/http/handlers/csv_safe.go, #148/#239).
+func CSVSafe(s string) string {
+	if s == "" {
+		return s
+	}
+	switch s[0] {
+	case '=', '+', '-', '@', '\t', '\r':
+		return "'" + s
+	}
+	return s
+}

--- a/internal/cli/common/csv_safe_test.go
+++ b/internal/cli/common/csv_safe_test.go
@@ -1,0 +1,21 @@
+package common
+
+import "testing"
+
+func TestCSVSafe(t *testing.T) {
+	cases := map[string]string{
+		"":                         "",
+		"db-password":              "db-password",
+		"=HYPERLINK(\"http://x\")": "'=HYPERLINK(\"http://x\")",
+		"+1+1":                     "'+1+1",
+		"-2+3":                     "'-2+3",
+		"@SUM(A1)":                 "'@SUM(A1)",
+		"\tlead-tab":               "'\tlead-tab",
+		"normal=mid":               "normal=mid", // only a LEADING formula char is defanged
+	}
+	for in, want := range cases {
+		if got := CSVSafe(in); got != want {
+			t.Errorf("CSVSafe(%q) = %q, want %q", in, got, want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- `keyorix audit export --csv` wrote the `Actor`, `EventType`, `IPAddress`, and `Description` fields straight into the CSV with zero escaping — a leading `=`, `+`, `-`, or `@` in any of those fields (classic CSV-formula-injection trigger) would execute as a live formula when the export is opened in Excel/Sheets/LibreOffice.
- Adds `internal/cli/common.CSVSafe`, mirroring the identical `csvSafe` convention already applied to the server's own CSV export handlers (`server/http/handlers/csv_safe.go`, fixed for #148/#239: a leading formula-trigger char gets a defanging single-quote prefix), and applies it to the four free-text-ish columns in `internal/cli/audit`'s `--csv` export path.
- Re-verified the backlog's second bullet (`compliance_controls_csv.go:44` / `LegalHold.Reason`): that handler already routes every cell — including the field that carries `LegalHold.Reason` — through the existing `csvSafe` helper, with its own regression test covering exactly this. No change needed there; it was already fixed.

## Changes
- `internal/cli/common/csv_safe.go` (new): exported `CSVSafe`, same escaping convention as `server/http/handlers/csv_safe.go`.
- `internal/cli/common/csv_safe_test.go` (new): unit coverage matching the server-side helper's test cases.
- `internal/cli/audit/audit.go`: `exportCmd`'s `--csv` row now writes `common.CSVSafe(...)` for `EventType`, `Actor`, `IPAddress`, and `Description`.
- `internal/cli/audit/audit_test.go`: regression test asserting a leading `=`/`+`/`-`/`@` in actor/description is defanged with a leading single quote, while ordinary text passes through unchanged.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/cli/audit/... ./internal/cli/common/... ./server/http/handlers/...`
- [x] `gosec -severity medium -exclude-generated` scoped to the touched packages — 0 issues

Refs #261.