### PR TITLE
fix(cli): honor --config/KEYORIX_CONFIG_PATH in system audit (#228)

### DIFF
--- a/internal/cli/system/audit.go
+++ b/internal/cli/system/audit.go
@@ -3,6 +3,7 @@ package system
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/keyorixhq/keyorix/internal/config"
 	"github.com/keyorixhq/keyorix/internal/securefiles"
@@ -17,26 +18,52 @@ var auditCmd = &cobra.Command{
 	},
 }
 
+// auditConfigFile mirrors the --config flag on `keyorix system validate`: an
+// empty default so an unset flag defers to config.Load's own resolution order
+// (KEYORIX_CONFIG_PATH env var, then "keyorix.yaml"), rather than baking in a
+// literal filename that ignores both the flag and the env var.
+var auditConfigFile string
+
+func init() {
+	auditCmd.Flags().StringVar(&auditConfigFile, "config", "", "Path to config file (defaults to $KEYORIX_CONFIG_PATH or keyorix.yaml)")
+}
+
 // auditCmd is now added to SystemCmd in system.go
 
 func runAudit() {
-	cfg, err := config.Load("keyorix.yaml") // Use default config file name
+	if runAuditNoExit() {
+		os.Exit(1)
+	}
+}
+
+// runAuditNoExit performs the audit and reports the outcome on stdout,
+// returning true if it failed. Splitting this out from runAudit lets tests
+// exercise the real config-path resolution logic (including a deliberate
+// failure) without a failing case tearing down the test binary via os.Exit.
+func runAuditNoExit() bool {
+	// Resolve the same way config.Load will, so the path we report/check below is
+	// the file actually loaded — not a hardcoded "keyorix.yaml" that silently
+	// diverges from --config / KEYORIX_CONFIG_PATH on any non-default deployment.
+	configPath := filepath.Clean(config.ResolvedPath(auditConfigFile))
+	fmt.Printf("Auditing config file: %s\n", configPath)
+
+	cfg, err := config.Load(auditConfigFile)
 	if err != nil {
 		fmt.Println("Failed to load config:", err)
-		os.Exit(1)
+		return true
 	}
 
 	files := []securefiles.FilePermSpec{
-		{Path: "keyorix.yaml", Mode: 0600},
+		{Path: configPath, Mode: 0600},
 		{Path: cfg.Storage.Encryption.SaltPath, Mode: 0600},
 		{Path: cfg.Storage.Encryption.DEKPath, Mode: 0600},
 	}
 
-	err = securefiles.FixFilePerms(files, false) // false = audit only
-	if err != nil {
+	if err := securefiles.FixFilePerms(files, false); err != nil { // false = audit only
 		fmt.Println("\nAudit finished with warnings/errors. Please fix the issues.")
-		os.Exit(1)
+		return true
 	}
 
 	fmt.Println("✅ Audit passed: all critical files have correct permissions and ownership.")
+	return false
 }

--- a/internal/cli/system/audit_test.go
+++ b/internal/cli/system/audit_test.go
@@ -1,0 +1,138 @@
+// audit_test.go — regression coverage for #228: `keyorix system audit` used to
+// hardcode config.Load("keyorix.yaml"), ignoring both --config and
+// KEYORIX_CONFIG_PATH, so it silently audited a nonexistent file (and, worse,
+// could report a false "✅ Audit passed" without ever validating the config the
+// operator actually runs with) on any deployment where the real config isn't a
+// file literally named keyorix.yaml in the current directory.
+package system
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+	defer func() { os.Stdout = orig }()
+
+	fn()
+
+	require.NoError(t, w.Close())
+	out, err := io.ReadAll(r)
+	require.NoError(t, err)
+	return string(out)
+}
+
+func resetAuditConfigFile(t *testing.T) {
+	t.Helper()
+	orig := auditConfigFile
+	t.Cleanup(func() {
+		auditConfigFile = orig
+		auditCmd.Flags().Lookup("config").Changed = false
+	})
+}
+
+// writeAuditableConfig writes a minimal, valid keyorix config (encryption
+// enabled, with a salt/DEK path already present with correct 0600 perms/
+// ownership) at dir/name — deliberately NOT named "keyorix.yaml" — so a pass
+// can only happen if the audit command actually resolved and read this exact
+// file rather than falling back to a hardcoded literal.
+func writeAuditableConfig(t *testing.T, dir, name string) string {
+	t.Helper()
+	saltPath := filepath.Join(dir, "salt.bin")
+	dekPath := filepath.Join(dir, "dek.bin")
+	require.NoError(t, os.WriteFile(saltPath, []byte("salt"), 0600))
+	require.NoError(t, os.WriteFile(dekPath, []byte("dek"), 0600))
+
+	cfgPath := filepath.Join(dir, name)
+	yaml := fmt.Sprintf("storage:\n  encryption:\n    enabled: true\n    salt_path: %s\n    dek_path: %s\n", saltPath, dekPath)
+	require.NoError(t, os.WriteFile(cfgPath, []byte(yaml), 0600))
+	return cfgPath
+}
+
+// The --config flag (mirroring `system validate`) must actually be honoured:
+// pointing it at a real config file with a name other than keyorix.yaml must
+// make the audit read and validate THAT file.
+func TestRunAudit_HonoursConfigFlagNotHardcodedKeyorixYaml(t *testing.T) {
+	resetAuditConfigFile(t)
+	dir := t.TempDir()
+	cfgPath := writeAuditableConfig(t, dir, "production-config.yaml")
+
+	auditConfigFile = cfgPath
+
+	var failed bool
+	out := captureStdout(t, func() {
+		failed = runAuditNoExit()
+	})
+
+	assert.False(t, failed, "audit must succeed against the real config, not fail against a missing keyorix.yaml")
+	assert.Contains(t, out, "Audit passed")
+	assert.Contains(t, out, cfgPath, "the audited config-file path must be the one actually resolved, not a hardcoded literal")
+}
+
+// KEYORIX_CONFIG_PATH must be honoured too, matching config.Load's documented
+// resolution order, when --config is left unset.
+func TestRunAudit_HonoursConfigPathEnvVar(t *testing.T) {
+	resetAuditConfigFile(t)
+	dir := t.TempDir()
+	cfgPath := writeAuditableConfig(t, dir, "env-config.yaml")
+
+	t.Setenv("KEYORIX_CONFIG_PATH", cfgPath)
+	auditConfigFile = "" // simulate --config left at its default (unset)
+
+	var failed bool
+	out := captureStdout(t, func() {
+		failed = runAuditNoExit()
+	})
+
+	assert.False(t, failed)
+	assert.Contains(t, out, "Audit passed")
+	assert.Contains(t, out, cfgPath)
+}
+
+// An explicit --config still wins over KEYORIX_CONFIG_PATH, matching
+// config.Load's own precedence (explicit path beats the env var).
+func TestRunAudit_ConfigFlagBeatsEnvVar(t *testing.T) {
+	resetAuditConfigFile(t)
+	dir := t.TempDir()
+	envCfg := writeAuditableConfig(t, dir, "env-config.yaml")
+	flagDir := t.TempDir()
+	flagCfg := writeAuditableConfig(t, flagDir, "flag-config.yaml")
+
+	t.Setenv("KEYORIX_CONFIG_PATH", envCfg)
+	auditConfigFile = flagCfg
+
+	var failed bool
+	out := captureStdout(t, func() {
+		failed = runAuditNoExit()
+	})
+
+	assert.False(t, failed)
+	assert.Contains(t, out, flagCfg)
+	assert.NotContains(t, out, envCfg)
+}
+
+// A --config pointing at a nonexistent path must fail loudly, not silently
+// report success against nothing (the exact failure mode #228 warned about).
+func TestRunAudit_MissingConfigFails(t *testing.T) {
+	resetAuditConfigFile(t)
+	auditConfigFile = filepath.Join(t.TempDir(), "does-not-exist.yaml")
+
+	var failed bool
+	out := captureStdout(t, func() {
+		failed = runAuditNoExit()
+	})
+
+	assert.True(t, failed, "a missing config file must be reported as a failure, not a false pass")
+	assert.NotContains(t, out, "Audit passed")
+}


### PR DESCRIPTION
## Summary
- `keyorix system audit` hardcoded `config.Load("keyorix.yaml")`, ignoring both the `--config` flag and the `KEYORIX_CONFIG_PATH` env var used by every other command, so on any non-default deployment it silently audited the wrong (or a nonexistent) config file — potentially printing a false "Audit passed" without ever validating the config actually in use.
- Added a `--config` flag (default `""`, mirroring `system validate`'s convention but deferring to `config.ResolvedPath`'s own env-var/default fallback) so an unset flag correctly honors `KEYORIX_CONFIG_PATH`, and an explicit flag still wins.
- The command now resolves the config path the same way `config.Load` will, prints which file it's auditing, and includes that resolved path (not a hardcoded literal) in the file-permission check.
- Split `runAudit` into a testable `runAuditNoExit` helper so tests can assert on both success and failure paths without `os.Exit` tearing down the test binary.

Fixes #228

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/cli/system/...` — includes new regression tests: `--config` flag honored, `KEYORIX_CONFIG_PATH` honored, flag beats env var, missing config fails loudly (not a false pass)
- [x] `gosec -severity medium -exclude-generated ./internal/cli/system/...` — 0 issues