### PR TITLE
fix(notifications): redispatch delivery on reminder escalation (#482)

### DIFF
--- a/internal/core/notification_dispatch_test.go
+++ b/internal/core/notification_dispatch_test.go
@@ -78,6 +78,65 @@ func TestNotify_NeverReachesBroadcastSink(t *testing.T) {
 	assert.Equal(t, NotificationSecretShared, recipient.events[0].Type)
 }
 
+// TestUpgradeReminder_RedispatchesOnEscalation is a regression test for #482: an
+// escalation must re-fire the out-of-band delivery channel, not just update the DB
+// row. Before the fix, upgradeReminder only called storage.UpdateNotification —
+// dispatchNotification (the only path that reaches recipientNotificationSink.Deliver)
+// was never invoked on the escalation path, so a Warning reminder silently becoming
+// Critical while unread updated Title/Message/Severity in the DB but never re-sent the
+// email/webhook that would actually alert the user to the more severe state.
+func TestUpgradeReminder_RedispatchesOnEscalation(t *testing.T) {
+	store := new(MockStorage)
+	store.On("UpdateNotification", mock.Anything, mock.Anything).Return(nil)
+	store.On("GetUser", mock.Anything, uint(5)).Return(&models.User{ID: 5, Email: "admin@x.io"}, nil)
+
+	c := NewKeyorixCore(store)
+	sink := &fakeSink{}
+	c.SetRecipientNotificationSink(sink)
+
+	pid := uint(1)
+	existing := &models.Notification{
+		ID: 1, UserID: 5, ProjectID: &pid, Type: NotificationRotationDue,
+		Title: "Secrets due for rotation", Message: "1 secret(s) approaching",
+		Severity: models.NotificationSeverityWarning, Link: "/rotation-policies",
+	}
+
+	ok := c.upgradeReminder(context.Background(), existing, "Secrets due for rotation",
+		"1 secret(s) overdue for rotation.", models.NotificationSeverityCritical)
+	require.True(t, ok)
+
+	require.Len(t, sink.events, 1, "the escalation must re-fire delivery, not just update the DB row")
+	ev := sink.events[0]
+	assert.Equal(t, uint(5), ev.UserID)
+	assert.Equal(t, "admin@x.io", ev.Email)
+	assert.Equal(t, NotificationRotationDue, ev.Type)
+	assert.Equal(t, "1 secret(s) overdue for rotation.", ev.Message, "the redispatched event carries the escalated message, not the stale one")
+	assert.Equal(t, "/rotation-policies", ev.Link)
+	require.NotNil(t, ev.ProjectID)
+	assert.Equal(t, uint(1), *ev.ProjectID)
+
+	// The in-memory row itself was upgraded in place.
+	assert.Equal(t, models.NotificationSeverityCritical, existing.Severity)
+}
+
+// TestUpgradeReminder_UpdateFailure_SkipsDispatch ensures a failed DB update does not
+// still fire an out-of-band delivery for a row that was never actually persisted.
+func TestUpgradeReminder_UpdateFailure_SkipsDispatch(t *testing.T) {
+	store := new(MockStorage)
+	store.On("UpdateNotification", mock.Anything, mock.Anything).Return(assert.AnError)
+
+	c := NewKeyorixCore(store)
+	sink := &fakeSink{}
+	c.SetRecipientNotificationSink(sink)
+
+	existing := &models.Notification{ID: 1, UserID: 5, Type: NotificationRotationDue}
+	ok := c.upgradeReminder(context.Background(), existing, "t", "m", models.NotificationSeverityCritical)
+
+	assert.False(t, ok)
+	assert.Empty(t, sink.events, "a failed persist must not still fire delivery")
+	store.AssertNotCalled(t, "GetUser", mock.Anything, mock.Anything)
+}
+
 // SendComplianceDigest and notifyRotationFailures are the deliberately-deployment-
 // wide, aggregate broadcasts (#391) — they must keep reaching the broadcast sink
 // (Slack/Teams/webhook), never the per-user recipient sink (which they don't

--- a/internal/core/notifications.go
+++ b/internal/core/notifications.go
@@ -85,9 +85,20 @@ func (c *KeyorixCore) notifyWithSeverity(ctx context.Context, userID uint, nType
 // piling up a second unread notification of the same (user, type, project).
 // Returns whether the update succeeded (best-effort — a storage failure here
 // just means the stale reminder stands until the next tick).
+//
+// #482: an escalation must also re-fire the out-of-band channel exactly like a
+// fresh notification does, or a Warning-level reminder silently escalating to
+// Critical (e.g. "expiring soon" → "now expired") would update the DB row but
+// never re-send the email/webhook that made the state change visible in the
+// first place. dispatchNotification is only called after the DB update
+// succeeds, mirroring notifyWithSeverity's create path.
 func (c *KeyorixCore) upgradeReminder(ctx context.Context, n *models.Notification, title, message string, severity models.NotificationSeverity) bool {
 	n.Title, n.Message, n.Severity = title, message, severity
-	return c.storage.UpdateNotification(ctx, n) == nil
+	if c.storage.UpdateNotification(ctx, n) != nil {
+		return false
+	}
+	c.dispatchNotification(ctx, n.UserID, n.Type, title, message, n.ProjectID, n.Link)
+	return true
 }
 
 // dispatchNotification fans a per-user notification out to the recipient-addressable

--- a/internal/core/rotation_reminders_test.go
+++ b/internal/core/rotation_reminders_test.go
@@ -182,6 +182,44 @@ func TestSendRotationReminders_EscalatesOnMoreSevereState(t *testing.T) {
 	assert.False(t, notes[0].IsRead)
 }
 
+// TestSendRotationReminders_EscalationRedispatchesDelivery is a regression test for
+// #482: escalating a standing rotation reminder in place (#250) must also re-fire the
+// out-of-band delivery channel (email/webhook via recipientNotificationSink), not just
+// update the notification row's Severity/Title/Message in the DB. Before the fix,
+// upgradeReminder never called dispatchNotification, so an admin whose "approaching"
+// reminder silently escalated to "overdue" while still unread would never actually
+// receive a second alert — undermining the entire point of escalation-aware reminders.
+func TestSendRotationReminders_EscalationRedispatchesDelivery(t *testing.T) {
+	ctx := context.Background()
+	c, db, now := newRotationReminderCore(t)
+	sink := &fakeSink{}
+	c.SetRecipientNotificationSink(sink)
+
+	// 25 days into a 30-day policy with a 7-day alert window: approaching, not overdue.
+	require.NoError(t, db.Model(&models.SecretNode{}).Where("id = ?", 10).
+		Update("created_at", now.AddDate(0, 0, -25)).Error)
+
+	sent, err := c.SendRotationReminders(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 1, sent)
+	require.Len(t, sink.events, 1, "the initial reminder must be delivered")
+	assert.Contains(t, sink.events[0].Message, "approaching")
+
+	// Now overdue (Critical) while the Warning reminder is still unread: an escalation.
+	require.NoError(t, db.Model(&models.SecretNode{}).Where("id = ?", 10).
+		Update("created_at", now.AddDate(0, 0, -35)).Error)
+
+	sent, err = c.SendRotationReminders(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 1, sent, "the escalation counts as sent")
+
+	require.Len(t, sink.events, 2,
+		"the escalation must re-fire delivery — a Warning reminder silently becoming Critical must not go out unless the channel actually re-sends")
+	assert.Contains(t, sink.events[1].Message, "overdue",
+		"the redispatched event carries the escalated message, not the stale one")
+	assert.Equal(t, NotificationRotationDue, sink.events[1].Type)
+}
+
 // TestSendRotationReminders_NoEscalation_SameOrLowerSeverity_NoNoise is the
 // inverse of the escalation test: once a Critical (overdue) reminder is
 // standing, a recheck that finds the state no worse must not touch it or


### PR DESCRIPTION
## Summary

Fixes backlog finding #482 (HIGH) — a genuine regression found by an adversarial regression audit of this session's own #250 fix (PR #733), not a theoretical/defensive hardening.

`upgradeReminder` (`internal/core/notifications.go`) correctly updates a standing reminder's DB row (Title/Message/Severity) when it escalates to a more severe state (e.g. "expiring soon" → "now expired"), but it never called `dispatchNotification` — the only function that invokes the out-of-band delivery channel (`recipientNotificationSink.Deliver`, email today). `dispatchNotification`'s only other call site is inside `notifyWithSeverity` (the *create* path), so escalating an existing unread reminder changed the DB row but silently never re-fired the actual email/webhook alert.

All 3 escalation-aware call sites are affected via the shared function: `rotation_reminders.go` (approaching → overdue), `expiry_reminders.go` (expiring soon → expired), `license_expiry.go` (expiring soon → expired — this is the exact scenario `ScanLicenseExpiry`'s own doc comment warns about: "a commercial license that lapses silently would disable airgap_updates with no warning").

### Fix

`upgradeReminder` now calls `dispatchNotification` with the escalated title/message after the DB update succeeds, mirroring exactly how `notifyWithSeverity` already does it on create. No changes needed in the 3 call-site files — the fix is centralized.

### Tests

- `TestUpgradeReminder_RedispatchesOnEscalation` / `TestUpgradeReminder_UpdateFailure_SkipsDispatch` — direct unit tests on `upgradeReminder` using the existing `fakeSink` spy (`notification_dispatch_test.go`), asserting the `Deliver` call itself (event count, resolved email, escalated message) — not just the DB row's `Severity` field, which is all #250's original tests checked.
- `TestSendRotationReminders_EscalationRedispatchesDelivery` (`rotation_reminders_test.go`) — end-to-end regression test through the real `SendRotationReminders` scheduler: seeds a real-SQLite core, drives a secret from "approaching" to "overdue" while the reminder is still unread, and asserts `sink.events` grows from 1 to 2 with the escalated ("overdue") message in the second delivery. This reproduces the exact defect: before the fix this test fails because the second event never arrives.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/core/...` (clean; ignored known pre-existing `anomaly_alerts`/`legal_holds`/`dynamic_secret_configs` table-not-found log noise unrelated to this change)
- [x] `gosec -severity medium -exclude-generated ./internal/core/...` — 0 issues