### PR TITLE
fix(authz): close CreateUserWithAssignments admin-rank-ceiling gap (#480)

### DIFF
--- a/internal/core/users.go
+++ b/internal/core/users.go
@@ -127,7 +127,15 @@ func (c *KeyorixCore) CreateUser(ctx context.Context, req *CreateUserRequest) (*
 // names and project IDs are resolved and validated up front, so an invalid input
 // fails before anything is written; a storage failure mid-way rolls everything
 // back. systemRole defaults to system_viewer when empty.
-func (c *KeyorixCore) CreateUserWithAssignments(ctx context.Context, req *CreateUserRequest, systemRole string, assignments []ProjectAssignment) (*models.User, error) {
+//
+// #480: this is InviteGlobal's sibling — both mint a system role plus a set of
+// project assignments in one call, and both need the identical escalation-by-proxy
+// ceiling (requireAuthorityForRole): the generic roles.assign permission that gates
+// the HTTP/gRPC entry points is a plain, non-admin-gated permission grantable to
+// any custom role, so without this check a non-admin roles.assign holder could
+// mint a brand-new super_admin account directly — no invite/accept step an admin
+// could notice or revoke in between, unlike InviteGlobal.
+func (c *KeyorixCore) CreateUserWithAssignments(ctx context.Context, req *CreateUserRequest, systemRole string, assignments []ProjectAssignment, actorID uint) (*models.User, error) {
 	user, hash, err := c.buildUserForCreate(ctx, req)
 	if err != nil {
 		return nil, err
@@ -154,6 +162,12 @@ func (c *KeyorixCore) CreateUserWithAssignments(ctx context.Context, req *Create
 	if err != nil {
 		return nil, fmt.Errorf("%s: unknown role %q (system)", i18n.T("ErrorValidation", nil), sysRole)
 	}
+	// Escalation-by-proxy guard (#480), mirroring InviteGlobal (#231): a global
+	// system role is the most powerful grant this flow can mint, so it needs the
+	// same admin-authority ceiling check, at global scope (projectID 0).
+	if err := c.requireAuthorityForRole(ctx, actorID, 0, sysRole); err != nil {
+		return nil, err
+	}
 	addGrant(sr.ID, 0)
 
 	for _, a := range assignments {
@@ -166,6 +180,12 @@ func (c *KeyorixCore) CreateUserWithAssignments(ctx context.Context, req *Create
 		r, err := c.storage.GetRoleByName(ctx, a.Role)
 		if err != nil {
 			return nil, fmt.Errorf("%s: unknown role %q", i18n.T("ErrorValidation", nil), a.Role)
+		}
+		// Same ceiling check InviteGlobal applies to each of its own project
+		// assignments — without this, a non-admin roles.assign holder could bundle
+		// an admin-conferring project assignment into an otherwise-innocuous create.
+		if err := c.requireAuthorityForRole(ctx, actorID, a.ProjectID, a.Role); err != nil {
+			return nil, err
 		}
 		addGrant(r.ID, a.ProjectID)
 	}

--- a/internal/core/users_atomic_ceiling_test.go
+++ b/internal/core/users_atomic_ceiling_test.go
@@ -1,0 +1,95 @@
+// users_atomic_ceiling_test.go — #480: CreateUserWithAssignments is InviteGlobal's
+// sibling (both mint a system role plus a set of project assignments in one call),
+// and needed the identical escalation-by-proxy ceiling (requireAuthorityForRole).
+// These tests mirror TestInviteGlobal_RejectsNonAdminGranting* (#231) exactly.
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// #480: CreateUserWithAssignments must refuse a non-admin actor granting a global
+// admin system role — mirrors TestInviteGlobal_RejectsNonAdminGrantingGlobalAdminRole.
+func TestCreateUserWithAssignments_RejectsNonAdminGrantingGlobalAdminRole(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	ctx := context.Background()
+
+	// A non-admin actor holding only project_developer (no admin-tier role anywhere,
+	// but plausibly also holding roles.assign via a custom role in the real HTTP/gRPC
+	// deployment) must not be able to mint an admin account in one call.
+	nonAdminID := seedUserWithRole(t, st, "cua-attacker", "project_developer", storage.Scope{})
+
+	_, err := c.CreateUserWithAssignments(ctx, &CreateUserRequest{
+		Username: "cua-mallory", Email: "cua-mallory@acme.io", Password: "Qr7#Kp2$Lm5@Vn9!",
+	}, "admin", nil, nonAdminID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "only an administrator can grant")
+}
+
+// #480: the per-project assignments bundled into an atomic create must be
+// individually ceiling-checked too — mirrors
+// TestInviteGlobal_RejectsNonAdminGrantingProjectAdminAssignment.
+func TestCreateUserWithAssignments_RejectsNonAdminGrantingProjectAdminAssignment(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	ctx := context.Background()
+
+	nonAdminID := seedUserWithRole(t, st, "cua-attacker-2", "project_developer", storage.Scope{})
+	proj, err := st.CreateProject(ctx, &models.Project{Name: "cua-target-project"})
+	require.NoError(t, err)
+
+	_, err = c.CreateUserWithAssignments(ctx, &CreateUserRequest{
+		Username: "cua-mallory-2", Email: "cua-mallory-2@acme.io", Password: "Qr7#Kp2$Lm5@Vn9!",
+	}, "system_viewer", []ProjectAssignment{
+		{ProjectID: proj.ID, Role: "project_admin"},
+	}, nonAdminID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "only an administrator can grant")
+}
+
+// #480 positive control: a genuinely admin actor can still mint an account with a
+// system role and project assignments in one call — no regression for the
+// legitimate case.
+func TestCreateUserWithAssignments_AdminActorAllowed(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	ctx := context.Background()
+
+	admin := seedUserWithRole(t, st, "cua-admin", "admin", storage.Scope{})
+	proj, err := st.CreateProject(ctx, &models.Project{Name: "cua-legit-project"})
+	require.NoError(t, err)
+
+	created, err := c.CreateUserWithAssignments(ctx, &CreateUserRequest{
+		Username: "cua-newbie", Email: "cua-newbie@acme.io", Password: "Qr7#Kp2$Lm5@Vn9!",
+	}, "system_admin", []ProjectAssignment{
+		{ProjectID: proj.ID, Role: "project_admin"},
+	}, admin)
+	require.NoError(t, err)
+	assert.Equal(t, "cua-newbie", created.Username)
+}
+
+// #480 positive control: a non-admin actor CAN still atomically create a user with
+// a non-admin-tier system role and non-admin-tier project assignments — the ceiling
+// only bites on admin-tier grants (isAdminRoleName), so the common onboarding case
+// (e.g. a project_developer-holding manager provisioning another developer) is
+// unaffected.
+func TestCreateUserWithAssignments_NonAdminRoleAllowed(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	ctx := context.Background()
+
+	actor := seedUserWithRole(t, st, "cua-actor", "project_developer", storage.Scope{ProjectID: 1})
+	proj, err := st.CreateProject(ctx, &models.Project{Name: "cua-nonadmin-project"})
+	require.NoError(t, err)
+
+	created, err := c.CreateUserWithAssignments(ctx, &CreateUserRequest{
+		Username: "cua-teammate", Email: "cua-teammate@acme.io", Password: "Qr7#Kp2$Lm5@Vn9!",
+	}, "system_viewer", []ProjectAssignment{
+		{ProjectID: proj.ID, Role: "project_developer"},
+	}, actor)
+	require.NoError(t, err)
+	assert.Equal(t, "cua-teammate", created.Username)
+}

--- a/server/grpc/services/user_service.go
+++ b/server/grpc/services/user_service.go
@@ -113,7 +113,7 @@ func (s *UserGRPCService) CreateUser(ctx context.Context, req *pb.CreateUserRequ
 		if req.GetPassword() == "" {
 			return nil, status.Error(codes.InvalidArgument, "password is required unless deliver_setup_link or generate_one_time_password is set")
 		}
-		u, err = s.core.CreateUserWithAssignments(ctx, coreReq, role, assignments)
+		u, err = s.core.CreateUserWithAssignments(ctx, coreReq, role, assignments, actor.UserID)
 	}
 	if err != nil {
 		return nil, mapUserError(err)
@@ -294,6 +294,8 @@ func mapUserError(err error) error {
 		return status.Error(codes.NotFound, "user not found")
 	case strings.Contains(msg, "already exists"), strings.Contains(msg, "duplicate"):
 		return status.Error(codes.AlreadyExists, "a user with that username or email already exists")
+	case strings.Contains(msg, "administrator can grant"):
+		return status.Error(codes.PermissionDenied, err.Error())
 	case strings.Contains(msg, "validation"), strings.Contains(msg, "required"), strings.Contains(msg, "invalid"), strings.Contains(msg, "must be"):
 		return status.Error(codes.InvalidArgument, err.Error())
 	default:

--- a/server/http/deployment_disclosure_family_test.go
+++ b/server/http/deployment_disclosure_family_test.go
@@ -56,7 +56,7 @@ func createAuditorToken(t *testing.T, c *core.KeyorixCore) string {
 	ctx := context.Background()
 	_, err := c.CreateUserWithAssignments(ctx, &core.CreateUserRequest{
 		Username: "family_auditor", Email: "family_auditor@example.com", Password: "Qr7#Kp2$Lm5@Vn9!",
-	}, "system_auditor", nil)
+	}, "system_auditor", nil, 0)
 	require.NoError(t, err)
 	sess, _, err := c.Login(ctx, &core.LoginRequest{Username: "family_auditor", Password: "Qr7#Kp2$Lm5@Vn9!"})
 	require.NoError(t, err)

--- a/server/http/handlers/users_crud.go
+++ b/server/http/handlers/users_crud.go
@@ -165,7 +165,7 @@ func (h *UserHandler) CreateUser(w http.ResponseWriter, r *http.Request) {
 		for _, a := range body.ProjectAssignments {
 			assignments = append(assignments, core.ProjectAssignment{ProjectID: a.ProjectID, Role: a.Role})
 		}
-		created, err = h.coreService.CreateUserWithAssignments(r.Context(), req, body.Role, assignments)
+		created, err = h.coreService.CreateUserWithAssignments(r.Context(), req, body.Role, assignments, userCtx.UserID)
 	} else {
 		created, err = h.coreService.CreateUser(r.Context(), req)
 	}
@@ -174,6 +174,8 @@ func (h *UserHandler) CreateUser(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case strings.Contains(err.Error(), "already exists"):
 			sendError(w, "ConflictError", "User already exists", http.StatusConflict, nil)
+		case strings.Contains(err.Error(), "only an administrator can grant"):
+			sendError(w, "Forbidden", err.Error(), http.StatusForbidden, nil)
 		case strings.Contains(err.Error(), "unknown role"), strings.Contains(err.Error(), "unknown project"),
 			strings.Contains(err.Error(), "each project assignment"):
 			sendError(w, "ValidationError", err.Error(), http.StatusBadRequest, nil)


### PR DESCRIPTION
## Summary

Closes #480 (HIGH) -- an adversarial regression audit of this session's #231 fix (`InviteGlobal`'s escalation-by-proxy ceiling) found the identical gap in its sibling, `CreateUserWithAssignments` (`internal/core/users.go`). That function grants a system role plus a set of project-scoped roles in ONE transaction, gated only by the plain, non-admin-gated `roles.assign` permission (the same insufficient gate the #93/#107/#141/#231 family closed elsewhere).

**Reproduction (pre-fix):** a custom role with `{users.write, roles.assign}` at global scope (not one of `super_admin/admin/system_admin/project_admin`) assigned to an attacker account let `POST /api/v1/users {username, email, password, role:"super_admin"}` succeed in one call -- no invite/accept step an admin could notice or revoke, unlike #231's invitation-based flow.

- Add the same `requireAuthorityForRole` ceiling check `InviteGlobal` (#231) uses: once for the system role at global scope (project 0), and once per project assignment at its project's scope.
- Thread `actorID` through to `CreateUserWithAssignments`'s HTTP (`POST /api/v1/users`) and gRPC (`UserService.CreateUser`) callers.
- Map the new "administrator can grant" error to HTTP 403 / gRPC `PermissionDenied` on both transports (mirroring `groups_members.go`'s existing pattern).

## Test plan

- [x] New regression tests in `internal/core/users_atomic_ceiling_test.go` mirroring #231's own style: non-admin actor refused when the system role is admin-tier; refused when a project assignment's role is admin-tier; admin actor and non-admin-tier-role cases still succeed (no regression).
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/core/... ./server/http/handlers/... ./server/grpc/services/...`
- [x] `gosec -severity medium -exclude-generated ./internal/core/...` (0 issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)