### PR TITLE
harden(remote-storage): close #484 password/unlock gap in #454's fix

### DIFF
--- a/internal/core/account.go
+++ b/internal/core/account.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"golang.org/x/crypto/bcrypt"
@@ -145,19 +146,48 @@ func (c *KeyorixCore) validateNewPassword(ctx context.Context, user *models.User
 // account state back to active per ADR-025), persists the user, and records the hash
 // in history. It assumes the password has already passed validateNewPassword. Shared
 // by ChangePassword and the setup-token consume flow so password handling is uniform.
+//
+// #484: persists via the narrow SetPasswordHash (and, only when the account state
+// actually needs to clear a restriction, SetAccountState) rather than the generic
+// UpdateUser — RemoteStorage can never express password_hash in its wire format at
+// all (models.User.PasswordHash is json:"-"), so a caller going through the generic
+// read-modify-write succeeds against LocalStorage but silently no-ops under
+// storage.type: remote, leaving the caller told "success" while the password never
+// actually changed. Both writes run inside one transaction so a partial application
+// (hash persisted but the state clear lost, or vice versa) can't happen on backends
+// that support real transactions.
 func (c *KeyorixCore) applyNewPassword(ctx context.Context, user *models.User, newPassword string) error {
 	hash, err := bcrypt.GenerateFromPassword([]byte(newPassword), bcrypt.DefaultCost)
 	if err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}
 	now := c.now()
-	user.PasswordHash = string(hash)
-	user.PasswordChangedAt = &now
-	user.AccountState = clearRestrictionOnPasswordChange(user.AccountState)
-	user.UpdatedAt = now
-	if _, err := c.storage.UpdateUser(ctx, user); err != nil {
+	newState := clearRestrictionOnPasswordChange(user.AccountState)
+	// Compare against the NORMALIZED current state, not the raw field: an unset legacy
+	// AccountState ("") normalizes to AccountActive, exactly like newState does for a
+	// non-restricted user, so a naive raw comparison would spuriously call
+	// SetAccountState (and, on RemoteStorage, hard-fail) for every legacy-row password
+	// change even though nothing is actually changing.
+	stateChanged := newState != NormalizeAccountState(user.AccountState)
+
+	err = c.storage.WithTransaction(ctx, func(tx storage.Storage) error {
+		if err := tx.SetPasswordHash(ctx, user.ID, string(hash), now); err != nil {
+			return err
+		}
+		if stateChanged {
+			if err := tx.SetAccountState(ctx, user.ID, newState, now); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}
+	user.PasswordHash = string(hash)
+	user.PasswordChangedAt = &now
+	user.AccountState = newState
+	user.UpdatedAt = now
 
 	// Record the new hash in history and prune to the configured depth.
 	// Best-effort: the password change itself has already succeeded.

--- a/internal/core/account_state_test.go
+++ b/internal/core/account_state_test.go
@@ -224,9 +224,8 @@ func TestChangePassword_ClearsRestriction(t *testing.T) {
 
 	store.On("GetUser", ctx, uint(1)).Return(user, nil)
 	store.On("RecentPasswordHashes", ctx, uint(1), 5).Return([]string{}, nil)
-	store.On("UpdateUser", ctx, mock.MatchedBy(func(u *models.User) bool {
-		return u.AccountState == AccountActive // restriction cleared
-	})).Return(user, nil)
+	store.On("SetPasswordHash", ctx, uint(1), mock.AnythingOfType("string"), mock.Anything).Return(nil)
+	store.On("SetAccountState", ctx, uint(1), AccountActive, mock.Anything).Return(nil) // restriction cleared
 	store.On("AddPasswordHistory", ctx, uint(1), mock.AnythingOfType("string"), mock.Anything).Return(nil)
 	store.On("PrunePasswordHistory", ctx, uint(1), 5).Return(nil)
 	store.On("GetSession", ctx, "tok").Return(&models.Session{ID: 7, UserID: 1}, nil)

--- a/internal/core/account_test.go
+++ b/internal/core/account_test.go
@@ -119,7 +119,7 @@ func TestChangePassword(t *testing.T) {
 		user := &models.User{ID: 1, Username: acctTestUser, PasswordHash: string(oldHash)}
 
 		ms.On("GetUser", ctx, uint(1)).Return(user, nil)
-		ms.On("UpdateUser", ctx, mock.AnythingOfType("*models.User")).Return(user, nil)
+		ms.On("SetPasswordHash", ctx, uint(1), mock.AnythingOfType("string"), mock.Anything).Return(nil)
 		ms.On("GetSession", ctx, "current-token").Return(&models.Session{ID: 7, UserID: 1}, nil)
 		ms.On("ListSessionTokenHashesForUser", ctx, uint(1)).Return([]string{}, nil)
 		ms.On("DeleteSessionsForUserExcept", ctx, uint(1), uint(7)).Return(nil)
@@ -146,7 +146,7 @@ func TestChangePassword(t *testing.T) {
 		user := &models.User{ID: 1, Username: acctTestUser, PasswordHash: string(oldHash)}
 
 		ms.On("GetUser", ctx, uint(1)).Return(user, nil)
-		ms.On("UpdateUser", ctx, mock.AnythingOfType("*models.User")).Return(user, nil)
+		ms.On("SetPasswordHash", ctx, uint(1), mock.AnythingOfType("string"), mock.Anything).Return(nil)
 		ms.On("GetSession", ctx, "current-token").Return(&models.Session{ID: 7, UserID: 1}, nil)
 		ms.On("ListSessionTokenHashesForUser", ctx, uint(1)).Return([]string{}, nil)
 		ms.On("DeleteSessionsForUserExcept", ctx, uint(1), uint(7)).Return(nil)
@@ -174,7 +174,7 @@ func TestChangePassword(t *testing.T) {
 		err := c.ChangePassword(ctx, 1, "oldpassword", reused, "current-token")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "reuse a recent password")
-		ms.AssertNotCalled(t, "UpdateUser", mock.Anything, mock.Anything)
+		ms.AssertNotCalled(t, "SetPasswordHash", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 	})
 
 	t.Run("rejects reuse of the current password", func(t *testing.T) {
@@ -189,7 +189,7 @@ func TestChangePassword(t *testing.T) {
 		err := c.ChangePassword(ctx, 1, cur, cur, "current-token")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "reuse a recent password")
-		ms.AssertNotCalled(t, "UpdateUser", mock.Anything, mock.Anything)
+		ms.AssertNotCalled(t, "SetPasswordHash", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 	})
 
 	t.Run("rejects an incorrect current password without writing", func(t *testing.T) {
@@ -201,7 +201,7 @@ func TestChangePassword(t *testing.T) {
 		err := c.ChangePassword(ctx, 1, "wrongpassword", "Brandnew#Passw0rd!", "current-token")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "incorrect")
-		ms.AssertNotCalled(t, "UpdateUser", mock.Anything, mock.Anything)
+		ms.AssertNotCalled(t, "SetPasswordHash", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 	})
 
 	t.Run("rejects a new password that violates the policy", func(t *testing.T) {
@@ -216,7 +216,7 @@ func TestChangePassword(t *testing.T) {
 		err := c.ChangePassword(ctx, 1, "oldpassword", "short", "current-token")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "password must")
-		ms.AssertNotCalled(t, "UpdateUser", mock.Anything, mock.Anything)
+		ms.AssertNotCalled(t, "SetPasswordHash", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 	})
 }
 

--- a/internal/core/login_lockout.go
+++ b/internal/core/login_lockout.go
@@ -281,6 +281,18 @@ func (c *KeyorixCore) clearLoginFailures(ctx context.Context, user *models.User)
 
 // UnlockUser clears a user's login-lockout state (admin action; audited). It does
 // not change the account_state — a suspended account stays suspended.
+//
+// #484: persists via the same narrow UpdateLoginLockoutState primitive #454 already
+// established for the automatic clear paths (clearLoginFailures /
+// checkLockAndClearLoginFailures) — not the generic UpdateUser, which silently no-ops
+// every one of these columns under storage.type: remote (they have no field in the
+// wire format at all). UnlockUser clears the exact same four columns those callers
+// do, just admin-triggered instead of triggered by a successful login, so it gets the
+// identical treatment: lockout accounting is a passive backstop, not an explicit
+// security directive (unlike account_state), so a backend that can never persist the
+// clear fails OPEN (logged once via warnLockoutUnsupportedOnce) rather than erroring
+// the admin — the worst case is the lock merely expires on its own cooldown instead of
+// being cleared early.
 func (c *KeyorixCore) UnlockUser(ctx context.Context, adminID, userID uint) error {
 	if userID == 0 {
 		return fmt.Errorf("user ID is required")
@@ -289,13 +301,16 @@ func (c *KeyorixCore) UnlockUser(ctx context.Context, adminID, userID uint) erro
 	if err != nil {
 		return fmt.Errorf("user not found: %w", err)
 	}
-	user.FailedLoginAttempts = 0
-	user.LastFailedLoginAt = nil
-	user.LoginLockedUntil = nil
-	user.LoginLockoutCount = 0
-	user.UpdatedAt = c.now()
-	if _, err := c.storage.UpdateUser(ctx, user); err != nil {
-		return fmt.Errorf("failed to unlock user: %w", err)
+	if err := c.storage.UpdateLoginLockoutState(ctx, userID, 0, nil, nil, 0); err != nil {
+		if !isUnsupportedByBackend(err) {
+			return fmt.Errorf("failed to unlock user: %w", err)
+		}
+		c.warnLockoutUnsupportedOnce()
+	} else {
+		user.FailedLoginAttempts = 0
+		user.LastFailedLoginAt = nil
+		user.LoginLockedUntil = nil
+		user.LoginLockoutCount = 0
 	}
 	aid := adminID
 	c.writeAuditEventFull(ctx, EventAccountUnlocked, &aid, nil, nil, "",

--- a/internal/core/login_lockout_remote_test.go
+++ b/internal/core/login_lockout_remote_test.go
@@ -94,3 +94,31 @@ func TestLockout_RemoteStorageFailsOpenLoudlyOnce(t *testing.T) {
 	})
 	assert.Contains(t, out3, "login lockout accounting is INERT")
 }
+
+// TestUnlockUser_RemoteStorageFailsOpenLoudly is the (#484) regression for the admin
+// UnlockUser path: it clears the identical four lockout-accounting columns that
+// recordFailedLogin/checkLockAndClearLoginFailures clear automatically on a successful
+// login, via the SAME UpdateLoginLockoutState primitive #454 already established for
+// them — so it must get the identical fail-OPEN-but-loud treatment under storage.type:
+// remote (log the operator warning once, return no error to the admin), not a hard
+// failure: this is still passive lockout accounting, not an explicit security
+// directive like account_state, and the worst case of the write silently no-op'ing is
+// merely that the lock expires on its own cooldown instead of clearing early.
+func TestUnlockUser_RemoteStorageFailsOpenLoudly(t *testing.T) {
+	policy := LoginLockoutPolicy{Enabled: true, MaxAttempts: 3, Window: 15 * time.Minute, BaseCooldown: time.Minute, MaxCooldown: time.Hour}
+	user := &models.User{ID: 44, Username: "dave", AccountState: AccountActive, IsActive: true, FailedLoginAttempts: 2, LoginLockoutCount: 1}
+	c := newRemoteLockoutCore(t, user, policy)
+	ctx := context.Background()
+
+	out := captureLog(t, func() {
+		err := c.UnlockUser(ctx, 1, 44)
+		assert.NoError(t, err, "an admin unlock must not fail just because lockout accounting can't be persisted")
+	})
+	assert.Contains(t, out, "login lockout accounting is INERT")
+
+	// The warning fires once per process; a second unlock attempt logs nothing further.
+	out2 := captureLog(t, func() {
+		assert.NoError(t, c.UnlockUser(ctx, 1, 44))
+	})
+	assert.Empty(t, out2, "the warning must not repeat on subsequent calls")
+}

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -757,6 +757,11 @@ func (m *MockStorage) SetAccountState(ctx context.Context, id uint, state string
 	return args.Error(0)
 }
 
+func (m *MockStorage) SetPasswordHash(ctx context.Context, id uint, hash string, changedAt time.Time) error {
+	args := m.Called(ctx, id, hash, changedAt)
+	return args.Error(0)
+}
+
 func (m *MockStorage) UpdateLoginLockoutState(ctx context.Context, id uint, attempts int, lastFailedAt, lockedUntil *time.Time, lockoutCount int) error {
 	args := m.Called(ctx, id, attempts, lastFailedAt, lockedUntil, lockoutCount)
 	return args.Error(0)

--- a/internal/core/password_remote_test.go
+++ b/internal/core/password_remote_test.go
@@ -1,0 +1,110 @@
+// password_remote_test.go — regression coverage for #484: applyNewPassword (shared by
+// self-service ChangePassword and the setup-token consume flow) must persist via the
+// narrow SetPasswordHash/SetAccountState primitives, not the generic UpdateUser, so a
+// backend that can never carry password_hash over the wire (RemoteStorage) hard-fails
+// instead of reporting a false "success". Mirrors #454's own test style: a real
+// RemoteStorage against an httptest server for the remote-storage case, and a real
+// SQLite-backed LocalStorage for the "still works correctly" case.
+package core
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	corestorage "github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/remote"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/bcrypt"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// newRemotePasswordCore builds a KeyorixCore backed by RemoteStorage against a real
+// httptest server that only ever serves GET /api/v1/users/{id} (returning `user`
+// unchanged) — and fails the test outright if anything ever reaches the server with a
+// PUT, proving the #484 fix refuses the write BEFORE attempting the lossy wire
+// round-trip that would otherwise silently drop password_hash (json:"-", never even
+// serialized) and report a false success.
+func newRemotePasswordCore(t *testing.T, user *models.User) *KeyorixCore {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("unexpected %s %s: a password change must hard-fail BEFORE any wire "+
+				"round-trip, since password_hash can never be carried by it", r.Method, r.URL.Path)
+		}
+		apiOKUser(t, w, user)
+	}))
+	t.Cleanup(srv.Close)
+
+	rs, err := store.NewRemoteStorage(&remote.Config{
+		BaseURL: srv.URL, APIKey: "test-key", TimeoutSeconds: 5, RetryAttempts: 0, TLSVerify: false,
+	})
+	require.NoError(t, err)
+	now := time.Date(2026, 6, 20, 9, 0, 0, 0, time.UTC)
+	return &KeyorixCore{storage: rs, now: func() time.Time { return now }, passwordPolicy: DefaultPasswordPolicy()}
+}
+
+// TestApplyNewPassword_HardFailsUnderRemoteStorage is the #484 regression: applyNewPassword
+// — shared by self-service ChangePassword and the setup-token consume flow — must fail
+// closed under storage.type: remote, never report success while the stored hash silently
+// stays unchanged upstream. Calls applyNewPassword directly (as the audit's own scratch
+// repro did), bypassing ChangePassword's own current-password re-verification: that check
+// separately depends on GetUser returning a usable PasswordHash, which RemoteStorage can
+// never do either (PasswordHash is also json:"-", so it can't survive that round-trip),
+// an orthogonal pre-existing gap this fix does not need to touch.
+func TestApplyNewPassword_HardFailsUnderRemoteStorage(t *testing.T) {
+	user := &models.User{ID: 7, Username: "remote-bob", AccountState: AccountActive}
+	c := newRemotePasswordCore(t, user)
+
+	err := c.applyNewPassword(context.Background(), user, "Brandnew#Passw0rd!")
+	require.Error(t, err, "a password change must hard-fail, not silently succeed, under remote storage")
+	assert.ErrorIs(t, err, corestorage.ErrUnsupportedByBackend)
+}
+
+// TestApplyNewPassword_HardFailsUnderRemoteStorage_EvenWithRestrictedState proves the
+// hard-fail also covers the case where the change would additionally need to clear a
+// restricted account state (ADR-025): SetPasswordHash fails first, inside the same
+// transaction, before SetAccountState is ever reached — no partial application either.
+func TestApplyNewPassword_HardFailsUnderRemoteStorage_EvenWithRestrictedState(t *testing.T) {
+	user := &models.User{ID: 8, Username: "remote-carol", AccountState: AccountPasswordResetRequired}
+	c := newRemotePasswordCore(t, user)
+
+	err := c.applyNewPassword(context.Background(), user, "Brandnew#Passw0rd!")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, corestorage.ErrUnsupportedByBackend)
+}
+
+// TestChangePassword_LocalStoragePersistsHashAndClearsRestriction proves LocalStorage
+// still performs the real column update via SetPasswordHash/SetAccountState — the #484
+// fix must not regress the working (non-remote) case.
+func TestChangePassword_LocalStoragePersistsHashAndClearsRestriction(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.User{}, &models.Session{}, &models.PersonalAccessToken{}, &models.PasswordHistory{}))
+	oldHash, err := bcrypt.GenerateFromPassword([]byte("oldpassword"), bcrypt.DefaultCost)
+	require.NoError(t, err)
+	require.NoError(t, db.Create(&models.User{
+		ID: 1, Username: "carol", PasswordHash: string(oldHash), AccountState: AccountPasswordResetRequired,
+	}).Error)
+
+	c := &KeyorixCore{
+		storage:        store.NewLocalStorage(db),
+		now:            func() time.Time { return time.Date(2026, 6, 20, 9, 0, 0, 0, time.UTC) },
+		passwordPolicy: DefaultPasswordPolicy(),
+	}
+
+	const newPw = "Brandnew#Passw0rd!"
+	require.NoError(t, c.ChangePassword(context.Background(), 1, "oldpassword", newPw, ""))
+
+	var u models.User
+	require.NoError(t, db.First(&u, 1).Error)
+	assert.NoError(t, bcrypt.CompareHashAndPassword([]byte(u.PasswordHash), []byte(newPw)),
+		"the new hash must actually be persisted, not silently dropped")
+	assert.Equal(t, AccountActive, u.AccountState, "restricted state must clear to active")
+}

--- a/internal/core/setup_consume_test.go
+++ b/internal/core/setup_consume_test.go
@@ -82,7 +82,8 @@ func TestCompleteSetup(t *testing.T) {
 		ms.On("GetUser", ctx, uid).Return(user, nil)
 		ms.On("RecentPasswordHashes", ctx, uid, 5).Return([]string{}, nil)
 		ms.On("MarkSetupTokenConsumed", ctx, uint(2), mock.AnythingOfType("time.Time")).Return(true, nil)
-		ms.On("UpdateUser", ctx, mock.AnythingOfType("*models.User")).Return(user, nil)
+		ms.On("SetPasswordHash", ctx, uid, mock.AnythingOfType("string"), mock.Anything).Return(nil)
+		ms.On("SetAccountState", ctx, uid, AccountActive, mock.Anything).Return(nil)
 		ms.On("AddPasswordHistory", ctx, uid, mock.AnythingOfType("string"), mock.Anything).Return(nil)
 		ms.On("PrunePasswordHistory", ctx, uid, 5).Return(nil)
 		ms.On("CreateSession", ctx, mock.AnythingOfType("*models.Session")).
@@ -112,7 +113,8 @@ func TestCompleteSetup(t *testing.T) {
 		ms.On("GetUser", ctx, uid).Return(user, nil)
 		ms.On("RecentPasswordHashes", ctx, uid, 5).Return([]string{}, nil)
 		ms.On("MarkSetupTokenConsumed", ctx, uint(2), mock.AnythingOfType("time.Time")).Return(true, nil)
-		ms.On("UpdateUser", ctx, mock.AnythingOfType("*models.User")).Return(user, nil)
+		ms.On("SetPasswordHash", ctx, uid, mock.AnythingOfType("string"), mock.Anything).Return(nil)
+		ms.On("SetAccountState", ctx, uid, AccountActive, mock.Anything).Return(nil)
 		ms.On("AddPasswordHistory", ctx, uid, mock.AnythingOfType("string"), mock.Anything).Return(nil)
 		ms.On("PrunePasswordHistory", ctx, uid, 5).Return(nil)
 		ms.On("RevokeAllPersonalAccessTokensForUser", mock.Anything, mock.Anything).Return(nil, nil)
@@ -143,7 +145,8 @@ func TestCompleteSetup(t *testing.T) {
 		ms.On("GetUser", ctx, uid).Return(user, nil)
 		ms.On("RecentPasswordHashes", ctx, uid, 5).Return([]string{}, nil)
 		ms.On("MarkSetupTokenConsumed", ctx, uint(2), mock.AnythingOfType("time.Time")).Return(true, nil)
-		ms.On("UpdateUser", ctx, mock.AnythingOfType("*models.User")).Return(user, nil)
+		ms.On("SetPasswordHash", ctx, uid, mock.AnythingOfType("string"), mock.Anything).Return(nil)
+		ms.On("SetAccountState", ctx, uid, AccountActive, mock.Anything).Return(nil)
 		ms.On("AddPasswordHistory", ctx, uid, mock.AnythingOfType("string"), mock.Anything).Return(nil)
 		ms.On("PrunePasswordHistory", ctx, uid, 5).Return(nil)
 		ms.On("RevokeAllPersonalAccessTokensForUser", mock.Anything, mock.Anything).Return(nil, nil)
@@ -186,7 +189,7 @@ func TestCompleteSetup(t *testing.T) {
 		// The link must remain usable: the token was never consumed, no session minted.
 		ms.AssertNotCalled(t, "MarkSetupTokenConsumed", mock.Anything, mock.Anything, mock.Anything)
 		ms.AssertNotCalled(t, "CreateSession", mock.Anything, mock.Anything)
-		ms.AssertNotCalled(t, "UpdateUser", mock.Anything, mock.Anything)
+		ms.AssertNotCalled(t, "SetPasswordHash", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 	})
 
 	t.Run("rejects an invitation_accept token (handled by the invitation producer)", func(t *testing.T) {

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -412,6 +412,20 @@ type Storage interface {
 	// unchanged. LocalStorage performs the real column update; RemoteStorage always
 	// returns storage.ErrUnsupportedByBackend (wrapped) so the caller fails closed.
 	SetAccountState(ctx context.Context, id uint, state string, updatedAt time.Time) error
+	// SetPasswordHash persists ONLY the password_hash and password_changed_at columns
+	// (plus updated_at) — narrower than the generic UpdateUser, and deliberately so
+	// (#484, the same rationale as SetAccountState above): models.User.PasswordHash is
+	// tagged json:"-", so it never even reaches the JSON body a RemoteStorage UpdateUser
+	// call sends — there is no way to persist a password change through the remote wire
+	// protocol at all. A password change (applyNewPassword, shared by self-service
+	// ChangePassword and the setup-token consume flow) is exactly the kind of explicit
+	// security directive #454 already treats as needing fail-closed semantics for
+	// account_state: a user must never be told their password changed when it silently
+	// didn't. LocalStorage performs the real column update; RemoteStorage always returns
+	// storage.ErrUnsupportedByBackend (wrapped) so the caller fails closed. Any
+	// accompanying account_state clear (a restricted state resetting to active) is
+	// persisted separately via SetAccountState, not folded into this primitive.
+	SetPasswordHash(ctx context.Context, id uint, hash string, changedAt time.Time) error
 	// UpdateLoginLockoutState persists ONLY the four login-lockout accounting columns
 	// (failed_login_attempts, last_failed_login_at, login_locked_until,
 	// login_lockout_count) — the same #454 rationale as SetAccountState above, since none

--- a/internal/storage/store/local_users.go
+++ b/internal/storage/store/local_users.go
@@ -210,6 +210,26 @@ func (ls *LocalStorage) SetAccountState(ctx context.Context, id uint, state stri
 	return nil
 }
 
+// SetPasswordHash persists ONLY password_hash and password_changed_at (plus
+// updated_at) via a direct column update — see the storage.Storage interface doc
+// comment (#484/#454) for why this narrower primitive exists alongside the generic
+// UpdateUser.
+func (ls *LocalStorage) SetPasswordHash(ctx context.Context, id uint, hash string, changedAt time.Time) error {
+	result := ls.db.WithContext(ctx).Model(&models.User{}).Where("id = ?", id).
+		Updates(map[string]interface{}{
+			"password_hash":       hash,
+			"password_changed_at": changedAt,
+			"updated_at":          changedAt,
+		})
+	if result.Error != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), result.Error)
+	}
+	if result.RowsAffected == 0 {
+		return fmt.Errorf("%s", i18n.T("ErrorUserNotFound", nil))
+	}
+	return nil
+}
+
 // UpdateLoginLockoutState persists ONLY the four login-lockout accounting columns via a
 // direct column update — see the storage.Storage interface doc comment (#454).
 func (ls *LocalStorage) UpdateLoginLockoutState(ctx context.Context, id uint, attempts int, lastFailedAt, lockedUntil *time.Time, lockoutCount int) error {

--- a/internal/storage/store/remote_unsupported_test.go
+++ b/internal/storage/store/remote_unsupported_test.go
@@ -54,6 +54,23 @@ func TestRemoteStorage_SetAccountState_HardFails(t *testing.T) {
 	assert.True(t, errors.Is(err, corestorage.ErrUnsupportedByBackend))
 }
 
+// TestRemoteStorage_SetPasswordHash_HardFails proves the #484 fix: since
+// models.User.PasswordHash is tagged json:"-", it never even reaches the JSON body a
+// RemoteStorage UpdateUser call would send — there is no way to persist a password
+// change through the remote API at all. RemoteStorage must refuse the write outright
+// rather than silently no-op it, exactly mirroring SetAccountState's #454 hard-fail
+// treatment above. No httptest server is needed: SetPasswordHash never makes an HTTP
+// call — the whole point is that there is nowhere to send this field.
+func TestRemoteStorage_SetPasswordHash_HardFails(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("https://unused.example"))
+	require.NoError(t, err)
+
+	err = rs.SetPasswordHash(context.Background(), 1, "$2a$10$fakehash", time.Now())
+	require.Error(t, err, "a password change must hard-fail under remote storage, not silently succeed")
+	assert.True(t, errors.Is(err, store.ErrRemoteUnsupported))
+	assert.True(t, errors.Is(err, corestorage.ErrUnsupportedByBackend))
+}
+
 // TestRemoteStorage_UpdateLoginLockoutState_ReturnsUnsupportedSentinel proves the
 // #454 fix for the lockout-accounting columns: same wire-format gap as
 // SetAccountState, but this one is a passive backstop counter, not an explicit

--- a/internal/storage/store/remote_users.go
+++ b/internal/storage/store/remote_users.go
@@ -125,6 +125,19 @@ func (rs *RemoteStorage) SetAccountState(_ context.Context, _ uint, _ string, _ 
 		"upstream PUT /api/v1/users/{id} endpoint does not accept this field: %w", ErrRemoteUnsupported)
 }
 
+// SetPasswordHash always hard-fails: password_hash is tagged json:"-" on models.User
+// (internal/storage/models/models.go), so it never even reaches the JSON body a
+// RemoteStorage UpdateUser call sends — there is no way to persist a password change
+// through the remote API at all. Returning an error here — instead of falling through
+// to a generic write that would just no-op the field — is the #484 analogue of
+// SetAccountState above (#454): applyNewPassword (self-service ChangePassword and the
+// setup-token consume flow) must see a hard failure, not a false "success" that leaves
+// the stored password hash unchanged.
+func (rs *RemoteStorage) SetPasswordHash(_ context.Context, _ uint, _ string, _ time.Time) error {
+	return fmt.Errorf("password_hash cannot be persisted through remote storage: the "+
+		"upstream PUT /api/v1/users/{id} endpoint does not accept this field: %w", ErrRemoteUnsupported)
+}
+
 // UpdateLoginLockoutState always returns ErrRemoteUnsupported: none of the four
 // login-lockout columns are expressible in the wire format either (#454), so, unlike
 // SetAccountState above, the caller (login_lockout.go) treats this as the same


### PR DESCRIPTION
## Summary

Closes #484 (HIGH). An adversarial regression audit of this session's own #454 fix (PR #704) found that two callers with the *identical* "generic `UpdateUser` silently drops fields the remote wire protocol doesn't carry" shape were not covered:

1. **`applyNewPassword`** (`internal/core/account.go`), shared by self-service `ChangePassword` and the setup-token consume flow, still called `user.PasswordHash = ...; c.storage.UpdateUser(ctx, user)`.
2. **`UnlockUser`** (`internal/core/login_lockout.go`), an admin action, still cleared lockout fields via the same generic `UpdateUser` call.

Since `models.User.PasswordHash` is tagged `json:"-"` (never serialized over the wire) and `AccountState` isn't decoded by the upstream `PUT /api/v1/users/{id}` whitelist either, a password change or admin unlock under `storage.type: remote` reported **success while silently never persisting**.

## What changed

- Added `SetPasswordHash` as a new narrow `storage.Storage` primitive, mirroring `SetAccountState`'s #454 hard-fail treatment exactly: `LocalStorage` does a real column update; `RemoteStorage` always hard-fails (a password change is an explicit security directive — a user must never be told their password changed when it silently didn't).
- `applyNewPassword` now persists via `SetPasswordHash` (and, only when a restricted account state actually needs clearing, the existing `SetAccountState`) inside one transaction, instead of the generic `UpdateUser`.
- `UnlockUser` is wired through the **existing** `UpdateLoginLockoutState` primitive from #454 rather than a new one — it clears the exact same four columns `clearLoginFailures`/`checkLockAndClearLoginFailures` already do, so it gets the identical fail-open-but-loud treatment (passive lockout accounting, not an explicit security directive like account_state — worst case is the lock merely expires on its own cooldown instead of clearing early).
- Regression tests mirror #454's own style: real `RemoteStorage` against `httptest` servers proving the hard-fail / fail-open-loud behavior, and real SQLite-backed `LocalStorage` proving the actual column updates still work.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/core/... ./internal/storage/store/...` (all green)
- [x] `gosec -severity medium -exclude-generated ./internal/core/... ./internal/storage/store/...` (0 issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)