### PR TITLE
fix(security): extend goSafe panic-recovery to all detached audit goroutines (#481)

### DIFF
--- a/internal/core/audit_context.go
+++ b/internal/core/audit_context.go
@@ -8,7 +8,10 @@
 // DetachedAuditContext to carry the tag past request cancellation.
 package core
 
-import "context"
+import (
+	"context"
+	"log"
+)
 
 // Actor types stamped on every audit event (ADR-023). They distinguish a human
 // user from a non-human machine identity so the audit view can segment and
@@ -71,4 +74,29 @@ func DetachedAuditContext(parent context.Context) context.Context {
 		ctx = WithActorType(ctx, t)
 	}
 	return ctx
+}
+
+// goSafe runs fn in a detached goroutine with panic recovery. Several core
+// methods spawn "fire and forget" goroutines for post-response side effects
+// (audit logging of secret reads/writes, password-reset link provisioning)
+// so the caller isn't blocked on that I/O — but those goroutines run on the
+// hottest request paths (every secret read/write, and — for
+// RequestPasswordReset — even an unauthenticated one) and are NOT covered by
+// the HTTP server's per-request recovery middleware, which only guards the
+// goroutine actually serving the request. A panic in a bare `go
+// c.LogSecret...(...)` here (a future nil-deref, malformed diff content,
+// etc.) would crash the entire process for every connected tenant (backlog
+// #481, an unrecovered-coverage gap in the #243 fix). goSafe closes that gap:
+// any panic in fn is recovered and logged instead of taking the server down.
+// This mirrors server/http/handlers' goSafe, duplicated here because that
+// package cannot be imported from internal/core.
+func goSafe(fn func()) {
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				log.Printf("recovered from panic in background goroutine: %v", r)
+			}
+		}()
+		fn()
+	}()
 }

--- a/internal/core/auth.go
+++ b/internal/core/auth.go
@@ -395,14 +395,14 @@ func (c *KeyorixCore) RequestPasswordReset(ctx context.Context, email string) er
 	// this call, which would cancel a request-scoped ctx before the SMTP send (or
 	// even the throttle check) completes.
 	detached := DetachedAuditContext(ctx)
-	go func() {
+	goSafe(func() {
 		_, _ = c.provisionSetupLinkThrottled(detached, IssueSetupTokenRequest{
 			Purpose:       SetupPurposePasswordResetLink,
 			SubjectEmail:  user.Email,
 			SubjectUserID: &user.ID,
 			CreatedBy:     0, // self-service (no issuing admin)
 		}, user.DisplayName, "")
-	}()
+	})
 	return nil
 }
 

--- a/internal/core/password_reset_test.go
+++ b/internal/core/password_reset_test.go
@@ -140,3 +140,60 @@ func (s *slowFakeDeliverer) DeliverSetupLink(_ context.Context, _ delivery.Setup
 }
 
 func (s *slowFakeDeliverer) Name() string { return "slow-fake" }
+
+// panicDeliverer panics inside DeliverSetupLink to simulate a bug surfacing
+// in the detached goroutine RequestPasswordReset spawns to issue+deliver the
+// reset link.
+type panicDeliverer struct {
+	done chan struct{}
+}
+
+func (p *panicDeliverer) DeliverSetupLink(_ context.Context, _ delivery.SetupLinkRequest) (delivery.DeliveryResult, error) {
+	defer close(p.done)
+	panic("simulated panic in credential delivery")
+}
+
+func (p *panicDeliverer) Name() string { return "panic-fake" }
+
+// TestRequestPasswordReset_PanicInDetachedGoroutineDoesNotCrash proves backlog
+// #481: RequestPasswordReset issues+delivers the reset link from a detached
+// goroutine (#117, closing a timing side-channel), reachable by a completely
+// unauthenticated caller via POST /auth/password-reset. Before this fix, that
+// goroutine was a bare `go func(){...}()` with no panic recovery — a panic
+// there is NOT caught by the HTTP server's per-request recovery middleware
+// (which only guards the goroutine serving the request) and crashes the
+// entire process for every connected tenant. If goSafe's recover() didn't
+// wrap this call site, this test binary itself would crash before reaching
+// the assertions below.
+func TestRequestPasswordReset_PanicInDetachedGoroutineDoesNotCrash(t *testing.T) {
+	ctx := context.Background()
+	const email = "reset-panic@acme.io"
+	fixed := time.Date(2026, 6, 6, 12, 0, 0, 0, time.UTC)
+
+	done := make(chan struct{})
+	panicker := &panicDeliverer{done: done}
+	ms := new(MockStorage)
+	c := NewKeyorixCore(ms)
+	c.now = func() time.Time { return fixed }
+	c.SetCredentialDelivery(panicker, testBaseURL)
+	anyAudit(ms)
+
+	activeUser := &models.User{ID: 11, Email: email, DisplayName: "Panicker", AccountState: AccountActive}
+	ms.On("GetUserByEmail", ctx, email).Return(activeUser, nil)
+	ms.On("CountSetupTokensSince", ctx, SetupPurposePasswordResetLink, email, fixed.Add(-24*time.Hour)).Return(int64(0), nil)
+	ms.On("CountSetupTokensSince", ctx, SetupPurposePasswordResetLink, email, fixed.Add(-resendMinInterval)).Return(int64(0), nil)
+	ms.On("SupersedeActiveSetupTokens", ctx, SetupPurposePasswordResetLink, email).Return(nil)
+	ms.On("CreateSetupToken", ctx, mock.AnythingOfType("*models.SetupToken")).Return(&models.SetupToken{ID: 1}, nil)
+
+	// The enumeration-safe contract holds regardless: RequestPasswordReset
+	// always returns nil.
+	require.NoError(t, c.RequestPasswordReset(ctx, email))
+
+	select {
+	case <-done:
+		// The detached goroutine panicked and goSafe's recover() caught it —
+		// the process (and this test binary) is still alive to reach here.
+	case <-time.After(2 * time.Second):
+		t.Fatal("detached delivery goroutine never ran")
+	}
+}

--- a/internal/core/secret_render.go
+++ b/internal/core/secret_render.go
@@ -71,7 +71,9 @@ func (c *KeyorixCore) RenderSecretTemplate(ctx context.Context, template string,
 		// Record the read like the single-secret read path does, so a bulk render is
 		// auditable and visible to the anomaly detector (detached so it survives the
 		// request and never blocks the render).
-		go c.LogSecretReadWithProject(DetachedAuditContext(ctx), userID, secret.ID, projectID, username, secretName, ip, ua) // #nosec G118
+		goSafe(func() {
+			c.LogSecretReadWithProject(DetachedAuditContext(ctx), userID, secret.ID, projectID, username, secretName, ip, ua)
+		}) // #nosec G118
 		return string(val), nil
 	})
 }

--- a/server/grpc/services/conversions.go
+++ b/server/grpc/services/conversions.go
@@ -8,6 +8,7 @@ package services
 import (
 	"context"
 	"encoding/json"
+	"log"
 	"strings"
 	"time"
 
@@ -37,6 +38,29 @@ func clientSafe(err error) string {
 		return ""
 	}
 	return "an internal error occurred; please try again or contact support if the problem persists"
+}
+
+// goSafe runs fn in a detached goroutine with panic recovery. secret_service.go
+// spawns "fire and forget" goroutines to audit-log secret reads/writes over
+// gRPC (mirroring the HTTP handlers) so the RPC response isn't blocked on that
+// I/O — but those goroutines run on the hottest secret CRUD paths and are NOT
+// covered by any per-RPC recovery interceptor, which only guards the goroutine
+// actually serving the RPC. A panic in a bare `go s.core.LogSecret...(...)`
+// here would crash the entire process for every connected tenant (backlog
+// #481, an unrecovered-coverage gap in the #243 fix, which only covered
+// server/http/handlers). goSafe closes that gap: any panic in fn is recovered
+// and logged instead of taking the server down. Mirrors
+// server/http/handlers.goSafe / internal/core.goSafe, duplicated here because
+// this package cannot import the handlers package.
+func goSafe(fn func()) {
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				log.Printf("recovered from panic in background goroutine: %v", r)
+			}
+		}()
+		fn()
+	}()
 }
 
 // isSafeConnectError mirrors the HTTP handlers' connect.go allowlist: it

--- a/server/grpc/services/secret_service.go
+++ b/server/grpc/services/secret_service.go
@@ -70,7 +70,11 @@ func (s *SecretGRPCService) CreateSecret(ctx context.Context, req *pb.CreateSecr
 	// Audit the create the same way the HTTP handler does — the core method does not
 	// audit internally, so without this a secret created over gRPC left no audit
 	// trail. Detached + async (see GetSecretValue).
-	go s.core.LogSecretCreatedWithProject(core.DetachedAuditContext(ctx), user.UserID, secret.ID, secret.ProjectID, user.Username, secret.Name, interceptors.PeerIP(ctx), interceptors.ClientUserAgent(ctx)) // #nosec G118
+	auditCtx := core.DetachedAuditContext(ctx)
+	ip, ua := interceptors.PeerIP(ctx), interceptors.ClientUserAgent(ctx)
+	goSafe(func() {
+		s.core.LogSecretCreatedWithProject(auditCtx, user.UserID, secret.ID, secret.ProjectID, user.Username, secret.Name, ip, ua)
+	}) // #nosec G118
 	return secretNodeToProto(secret), nil
 }
 
@@ -151,7 +155,11 @@ func (s *SecretGRPCService) GetSecretValue(ctx context.Context, req *pb.GetSecre
 	// anomaly detection. Detached + async like HTTP, so it neither blocks the RPC nor
 	// dies on its cancellation; DetachedAuditContext preserves the actor-type and
 	// impersonation tags the interceptor set.
-	go s.core.LogSecretReadWithProject(core.DetachedAuditContext(ctx), user.UserID, uint(req.GetId()), secret.ProjectID, user.Username, secret.Name, interceptors.PeerIP(ctx), interceptors.ClientUserAgent(ctx)) // #nosec G118
+	auditCtx := core.DetachedAuditContext(ctx)
+	ip, ua := interceptors.PeerIP(ctx), interceptors.ClientUserAgent(ctx)
+	goSafe(func() {
+		s.core.LogSecretReadWithProject(auditCtx, user.UserID, uint(req.GetId()), secret.ProjectID, user.Username, secret.Name, ip, ua)
+	}) // #nosec G118
 	return &pb.SecretValue{
 		Id:    req.GetId(),
 		Name:  secret.Name,
@@ -196,7 +204,11 @@ func (s *SecretGRPCService) UpdateSecret(ctx context.Context, req *pb.UpdateSecr
 	// Audit the update with a before/after diff, mirroring the HTTP handler — the
 	// core method does not audit internally. Detached + async (see GetSecretValue).
 	diff := core.BuildSecretUpdateDiff(oldSecret, updateReq, req.GetValue() != "")
-	go s.core.LogSecretUpdatedWithDiff(core.DetachedAuditContext(ctx), user.UserID, uint(req.GetId()), secret.ProjectID, user.Username, secret.Name, interceptors.PeerIP(ctx), interceptors.ClientUserAgent(ctx), diff) // #nosec G118
+	auditCtx := core.DetachedAuditContext(ctx)
+	ip, ua := interceptors.PeerIP(ctx), interceptors.ClientUserAgent(ctx)
+	goSafe(func() {
+		s.core.LogSecretUpdatedWithDiff(auditCtx, user.UserID, uint(req.GetId()), secret.ProjectID, user.Username, secret.Name, ip, ua, diff)
+	}) // #nosec G118
 	return secretNodeToProto(secret), nil
 }
 
@@ -225,7 +237,11 @@ func (s *SecretGRPCService) DeleteSecret(ctx context.Context, req *pb.DeleteSecr
 	}
 	// Audit the delete the same way the HTTP handler does — the core method does not
 	// audit internally. Detached + async (see GetSecretValue).
-	go s.core.LogSecretDeletedWithProject(core.DetachedAuditContext(ctx), user.UserID, uint(req.GetId()), secretProjectID, user.Username, secretName, interceptors.PeerIP(ctx), interceptors.ClientUserAgent(ctx)) // #nosec G118
+	auditCtx := core.DetachedAuditContext(ctx)
+	ip, ua := interceptors.PeerIP(ctx), interceptors.ClientUserAgent(ctx)
+	goSafe(func() {
+		s.core.LogSecretDeletedWithProject(auditCtx, user.UserID, uint(req.GetId()), secretProjectID, user.Username, secretName, ip, ua)
+	}) // #nosec G118
 	return &emptypb.Empty{}, nil
 }
 
@@ -327,7 +343,11 @@ func (s *SecretGRPCService) GetSecretVersions(ctx context.Context, req *pb.GetSe
 	// an HTTP<->gRPC audit-parity gap invisible to anomaly detection (#168).
 	// Best-effort metadata fetch, same as HTTP: a miss just skips the audit call.
 	if secret, sErr := s.core.GetSecretWithPermissionCheck(ctx, uint(req.GetId()), user.UserID); sErr == nil && secret != nil {
-		go s.core.LogSecretReadWithProject(core.DetachedAuditContext(ctx), user.UserID, uint(req.GetId()), secret.ProjectID, user.Username, secret.Name, interceptors.PeerIP(ctx), interceptors.ClientUserAgent(ctx)) // #nosec G118
+		auditCtx := core.DetachedAuditContext(ctx)
+		ip, ua := interceptors.PeerIP(ctx), interceptors.ClientUserAgent(ctx)
+		goSafe(func() {
+			s.core.LogSecretReadWithProject(auditCtx, user.UserID, uint(req.GetId()), secret.ProjectID, user.Username, secret.Name, ip, ua)
+		}) // #nosec G118
 	}
 	out := make([]*pb.SecretVersion, 0, len(versions))
 	for _, v := range versions {

--- a/server/http/handlers/secrets_crud.go
+++ b/server/http/handlers/secrets_crud.go
@@ -94,7 +94,10 @@ func (h *SecretHandler) CreateSecret(w http.ResponseWriter, r *http.Request) {
 
 	uid, sID, uname, sname := userCtx.UserID, response.ID, userCtx.Username, response.Name
 	ip, ua := r.RemoteAddr, r.Header.Get("User-Agent")
-	go h.coreService.LogSecretCreatedWithProject(core.DetachedAuditContext(r.Context()), uid, sID, response.ProjectID, uname, sname, ip, ua) // #nosec G118
+	auditCtx := core.DetachedAuditContext(r.Context())
+	goSafe(func() {
+		h.coreService.LogSecretCreatedWithProject(auditCtx, uid, sID, response.ProjectID, uname, sname, ip, ua)
+	}) // #nosec G118
 
 	w.WriteHeader(http.StatusCreated)
 	h.sendSuccess(w, response, i18n.T("SuccessSecretCreated", nil))
@@ -252,7 +255,10 @@ func (h *SecretHandler) GetSecret(w http.ResponseWriter, r *http.Request) {
 
 	uid, sID, uname, sname := userCtx.UserID, uint(id), userCtx.Username, secret.Name
 	ip, ua := r.RemoteAddr, r.Header.Get("User-Agent")
-	go h.coreService.LogSecretReadWithProject(core.DetachedAuditContext(r.Context()), uid, sID, secret.ProjectID, uname, sname, ip, ua) // #nosec G118
+	auditCtx := core.DetachedAuditContext(r.Context())
+	goSafe(func() {
+		h.coreService.LogSecretReadWithProject(auditCtx, uid, sID, secret.ProjectID, uname, sname, ip, ua)
+	}) // #nosec G118
 
 	h.sendSuccess(w, response, "")
 }
@@ -304,7 +310,10 @@ func (h *SecretHandler) GetSecretValueByRef(w http.ResponseWriter, r *http.Reque
 
 	uid, sID, uname, sname := userCtx.UserID, secret.ID, userCtx.Username, secret.Name
 	ip, ua := r.RemoteAddr, r.Header.Get("User-Agent")
-	go h.coreService.LogSecretReadWithProject(core.DetachedAuditContext(r.Context()), uid, sID, secret.ProjectID, uname, sname, ip, ua) // #nosec G118
+	auditCtx := core.DetachedAuditContext(r.Context())
+	goSafe(func() {
+		h.coreService.LogSecretReadWithProject(auditCtx, uid, sID, secret.ProjectID, uname, sname, ip, ua)
+	}) // #nosec G118
 
 	h.sendSuccess(w, map[string]interface{}{"secret": secret, "value": string(value)}, "")
 }
@@ -413,7 +422,10 @@ func (h *SecretHandler) UpdateSecret(w http.ResponseWriter, r *http.Request) {
 	uid, sID, uname, sname := userCtx.UserID, uint(id), userCtx.Username, response.Name
 	ip, ua := r.RemoteAddr, r.Header.Get("User-Agent")
 	diff := core.BuildSecretUpdateDiff(oldSecret, req, reqBody.Value != "")
-	go h.coreService.LogSecretUpdatedWithDiff(core.DetachedAuditContext(r.Context()), uid, sID, response.ProjectID, uname, sname, ip, ua, diff) // #nosec G118
+	auditCtx := core.DetachedAuditContext(r.Context())
+	goSafe(func() {
+		h.coreService.LogSecretUpdatedWithDiff(auditCtx, uid, sID, response.ProjectID, uname, sname, ip, ua, diff)
+	}) // #nosec G118
 
 	h.sendSuccess(w, response, i18n.T("SuccessSecretUpdated", nil))
 }
@@ -455,7 +467,10 @@ func (h *SecretHandler) DeleteSecret(w http.ResponseWriter, r *http.Request) {
 
 	uid, sID, uname := userCtx.UserID, uint(id), userCtx.Username
 	ip, ua := r.RemoteAddr, r.Header.Get("User-Agent")
-	go h.coreService.LogSecretDeletedWithProject(core.DetachedAuditContext(r.Context()), uid, sID, secretProjectID, uname, secretName, ip, ua) // #nosec G118
+	auditCtx := core.DetachedAuditContext(r.Context())
+	goSafe(func() {
+		h.coreService.LogSecretDeletedWithProject(auditCtx, uid, sID, secretProjectID, uname, secretName, ip, ua)
+	}) // #nosec G118
 
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/server/http/handlers/secrets_crud_goroutine_panic_test.go
+++ b/server/http/handlers/secrets_crud_goroutine_panic_test.go
@@ -1,0 +1,205 @@
+// secrets_crud_goroutine_panic_test.go — regression coverage for backlog
+// #481: an adversarial regression audit of the #243 goSafe fix found that
+// only auth.go/mfa.go/webauthn.go (goSafe's original 4 covered files) were
+// wrapped, while every detached audit-logging goroutine in the secrets CRUD
+// path — the highest-traffic subsystem — remained a bare `go
+// h.coreService.LogSecret...(...)` with no panic recovery. A panic there
+// (e.g. a future nil-deref inside the audit/SIEM-forwarding pipeline) runs on
+// a goroutine the HTTP server's per-request recovery middleware never sees,
+// and crashes the entire process for every connected tenant.
+//
+// These tests force a panic deep inside the audit write path (via a
+// core.AuditForwarder whose Forward implementation panics — the same
+// injectable seam SetAuditForwarder wires a real SIEM through) and prove
+// each of CreateSecret/GetSecret/UpdateSecret/DeleteSecret still (a) returns
+// its normal successful HTTP response and (b) does not crash the test
+// process — the goSafe wrapper added at each call site recovers the panic
+// instead.
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/keyorixhq/keyorix/server/middleware"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// panicAuditForwarder panics inside Forward to simulate a bug surfacing on
+// the audit-emit path that every LogSecret* call runs through (writeAudit*
+// -> emitAudit -> auditForwarder.Forward). done is closed just before the
+// panic so a test can synchronize with the detached goroutine having reached
+// (and survived) it.
+type panicAuditForwarder struct {
+	done chan struct{}
+}
+
+func (p *panicAuditForwarder) Forward(_ *models.AuditEvent) {
+	defer close(p.done)
+	panic("simulated panic in audit forwarding")
+}
+
+func newPanicTestHandler(t *testing.T) (*SecretHandler, *gorm.DB) {
+	t.Helper()
+	require.NoError(t, i18n.Initialize(&config.Config{Locale: config.LocaleConfig{Language: "en", FallbackLanguage: "en"}}))
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	// A pooled sqlite ":memory:" connection hands out a fresh, empty database
+	// per connection unless pinned to a single connection — pin it so every
+	// query in this test sees the migrated schema.
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	sqlDB.SetMaxOpenConns(1)
+	require.NoError(t, db.AutoMigrate(&models.User{}, &models.Role{}, &models.UserRole{},
+		&models.Permission{}, &models.RolePermission{}, &models.Group{}, &models.GroupRole{},
+		&models.UserGroup{}, &models.Project{}, &models.Environment{}, &models.AuditEvent{},
+		&models.SecretNode{}, &models.SecretVersion{}, &models.SecretAccessLog{}, &models.ShareRecord{}))
+
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "alice", AccountState: "active"}).Error)
+	adminRole := &models.Role{Name: "admin"}
+	require.NoError(t, db.Create(adminRole).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: adminRole.ID}).Error)
+
+	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "proj"}).Error)
+	require.NoError(t, db.Create(&models.Environment{ID: 10, ProjectID: 1, Name: "prod"}).Error)
+
+	coreService := core.NewKeyorixCore(store.NewLocalStorage(db))
+	handler, err := NewSecretHandler(coreService)
+	require.NoError(t, err)
+	return handler, db
+}
+
+func userReq(method, path string, body []byte) *http.Request {
+	var r *http.Request
+	if body != nil {
+		r = httptest.NewRequest(method, path, bytes.NewReader(body))
+	} else {
+		r = httptest.NewRequest(method, path, nil)
+	}
+	userCtx := &middleware.UserContext{UserID: 1, Username: "alice", ActorType: core.ActorTypeUser, SessionAuth: true, MFAEnabled: true}
+	return r.WithContext(context.WithValue(r.Context(), middleware.GetUserContextKey(), userCtx))
+}
+
+func withIDParam(r *http.Request, id uint) *http.Request {
+	rc := chi.NewRouteContext()
+	rc.URLParams.Add("id", strconv.FormatUint(uint64(id), 10))
+	return r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rc))
+}
+
+// TestCreateSecret_PanicInDetachedAuditGoroutineDoesNotCrash covers the #481
+// call site at secrets_crud.go's CreateSecret (audit: secret.created).
+func TestCreateSecret_PanicInDetachedAuditGoroutineDoesNotCrash(t *testing.T) {
+	handler, _ := newPanicTestHandler(t)
+	done := make(chan struct{})
+	handler.coreService.SetAuditForwarder(&panicAuditForwarder{done: done})
+
+	body, _ := json.Marshal(map[string]interface{}{
+		"name": "S1", "value": "v", "project_id": uint(1),
+		"environment_id": uint(10), "type": "static",
+	})
+	r := userReq(http.MethodPost, "/api/v1/secrets", body)
+	rr := httptest.NewRecorder()
+	handler.CreateSecret(rr, r)
+	assert.Equal(t, http.StatusCreated, rr.Code, rr.Body.String())
+
+	select {
+	case <-done:
+		// The detached audit goroutine panicked and goSafe recovered it — the
+		// process (and this test binary) is still alive to reach here.
+	case <-time.After(2 * time.Second):
+		t.Fatal("detached audit goroutine never ran")
+	}
+}
+
+// TestGetSecret_PanicInDetachedAuditGoroutineDoesNotCrash covers the #481
+// call site at secrets_crud.go's GetSecret (audit: secret.read) — the
+// highest-traffic path of the CRUD subsystem.
+func TestGetSecret_PanicInDetachedAuditGoroutineDoesNotCrash(t *testing.T) {
+	handler, _ := newPanicTestHandler(t)
+	created, err := handler.coreService.CreateSecret(context.Background(), &core.CreateSecretRequest{
+		Name: "target", Value: []byte("v"), ProjectID: 1, EnvironmentID: 10, Type: "static",
+		CreatedBy: "alice", OwnerID: 1,
+	})
+	require.NoError(t, err)
+
+	done := make(chan struct{})
+	handler.coreService.SetAuditForwarder(&panicAuditForwarder{done: done})
+
+	r := withIDParam(userReq(http.MethodGet, "/api/v1/secrets/"+strconv.FormatUint(uint64(created.ID), 10), nil), created.ID)
+	rr := httptest.NewRecorder()
+	handler.GetSecret(rr, r)
+	assert.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("detached audit goroutine never ran")
+	}
+}
+
+// TestUpdateSecret_PanicInDetachedAuditGoroutineDoesNotCrash covers the #481
+// call site at secrets_crud.go's UpdateSecret (audit: secret.updated).
+func TestUpdateSecret_PanicInDetachedAuditGoroutineDoesNotCrash(t *testing.T) {
+	handler, _ := newPanicTestHandler(t)
+	created, err := handler.coreService.CreateSecret(context.Background(), &core.CreateSecretRequest{
+		Name: "target", Value: []byte("v"), ProjectID: 1, EnvironmentID: 10, Type: "static",
+		CreatedBy: "alice", OwnerID: 1,
+	})
+	require.NoError(t, err)
+
+	done := make(chan struct{})
+	handler.coreService.SetAuditForwarder(&panicAuditForwarder{done: done})
+
+	body, _ := json.Marshal(map[string]interface{}{"max_reads": 3})
+	r := withIDParam(userReq(http.MethodPut, "/api/v1/secrets/"+strconv.FormatUint(uint64(created.ID), 10), body), created.ID)
+	rr := httptest.NewRecorder()
+	handler.UpdateSecret(rr, r)
+	assert.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("detached audit goroutine never ran")
+	}
+}
+
+// TestDeleteSecret_PanicInDetachedAuditGoroutineDoesNotCrash covers the #481
+// call site at secrets_crud.go's DeleteSecret (audit: secret.deleted).
+func TestDeleteSecret_PanicInDetachedAuditGoroutineDoesNotCrash(t *testing.T) {
+	handler, _ := newPanicTestHandler(t)
+	created, err := handler.coreService.CreateSecret(context.Background(), &core.CreateSecretRequest{
+		Name: "target", Value: []byte("v"), ProjectID: 1, EnvironmentID: 10, Type: "static",
+		CreatedBy: "alice", OwnerID: 1,
+	})
+	require.NoError(t, err)
+
+	done := make(chan struct{})
+	handler.coreService.SetAuditForwarder(&panicAuditForwarder{done: done})
+
+	r := withIDParam(userReq(http.MethodDelete, "/api/v1/secrets/"+strconv.FormatUint(uint64(created.ID), 10), nil), created.ID)
+	rr := httptest.NewRecorder()
+	handler.DeleteSecret(rr, r)
+	assert.Equal(t, http.StatusNoContent, rr.Code, rr.Body.String())
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("detached audit goroutine never ran")
+	}
+}

--- a/server/http/handlers/secrets_versions.go
+++ b/server/http/handlers/secrets_versions.go
@@ -49,7 +49,10 @@ func (h *SecretHandler) GetSecretVersions(w http.ResponseWriter, r *http.Request
 	secret, sErr := h.coreService.GetSecret(r.Context(), uint(id))
 	if sErr == nil && secret != nil {
 		ip, ua := r.RemoteAddr, r.Header.Get("User-Agent")
-		go h.coreService.LogSecretReadWithProject(core.DetachedAuditContext(r.Context()), userCtx.UserID, uint(id), secret.ProjectID, userCtx.Username, secret.Name, ip, ua) // #nosec G118
+		auditCtx := core.DetachedAuditContext(r.Context())
+		goSafe(func() {
+			h.coreService.LogSecretReadWithProject(auditCtx, userCtx.UserID, uint(id), secret.ProjectID, userCtx.Username, secret.Name, ip, ua)
+		}) // #nosec G118
 	}
 
 	h.sendSuccess(w, map[string]interface{}{"versions": versions}, "")
@@ -111,7 +114,10 @@ func (h *SecretHandler) RotateSecret(w http.ResponseWriter, r *http.Request) {
 	// Audit the rotation (async, detached) so the rotation inspector and the
 	// activity feed have an attributable secret.rotated event.
 	ip, ua := r.RemoteAddr, r.Header.Get("User-Agent")
-	go h.coreService.LogSecretRotatedWithProject(core.DetachedAuditContext(r.Context()), userCtx.UserID, uint(id), secret.ProjectID, userCtx.Username, secret.Name, ip, ua) // #nosec G118
+	auditCtx := core.DetachedAuditContext(r.Context())
+	goSafe(func() {
+		h.coreService.LogSecretRotatedWithProject(auditCtx, userCtx.UserID, uint(id), secret.ProjectID, userCtx.Username, secret.Name, ip, ua)
+	}) // #nosec G118
 
 	h.sendSuccess(w, secret, "Secret rotated successfully")
 }


### PR DESCRIPTION
## Summary

Closes backlog #481 (HIGH), an unauthenticated DoS-lever gap found by an adversarial regression audit of the #243 `goSafe` fix.

The #243 fix added `goSafe()` (server/http/handlers/helpers.go) — a panic-recovery wrapper for detached "fire and forget" audit-logging goroutines — but only applied it to the 4 files its author already knew about (auth.go/mfa.go/webauthn.go + helpers.go itself). A fresh, repo-wide grep across `server/http/handlers/`, `server/grpc/services/`, and `internal/core/` found every other bare `go func(){...}()` / `go funcName(...)` detached audit goroutine was still unrecovered. None of `LogSecret*`/`writeAuditEvent*` (`internal/core/audit.go`) have their own `recover()` either — a panic there (a future nil-deref, malformed diff content, a panicking SIEM `AuditForwarder`, etc.) is NOT caught by the HTTP server's per-request recovery middleware (which only guards the goroutine serving the request) and crashes the **entire process for every connected tenant**.

Most severe: `internal/core/auth.go`'s `RequestPasswordReset` spawns its detached `provisionSetupLinkThrottled(...)` goroutine unrecovered, and this is reachable by a **completely unauthenticated** caller via `POST /auth/password-reset` — a pre-auth route hit far more often than login.

## Call sites fixed

- `internal/core/auth.go:398` — `RequestPasswordReset` (unauthenticated reachability — highest severity)
- `internal/core/secret_render.go:74` — bulk-render audit (`RenderSecretTemplate`)
- `server/http/handlers/secrets_crud.go` — `CreateSecret`, `GetSecret`, `GetSecretValueByRef`, `UpdateSecret`, `DeleteSecret` (5 sites)
- `server/http/handlers/secrets_versions.go` — `GetSecretVersions`, `RotateSecret` (2 sites)
- `server/grpc/services/secret_service.go` — `CreateSecret`, `GetSecretValue`, `UpdateSecret`, `DeleteSecret`, `GetSecretVersions` (5 sites)

## Approach

`goSafe()` lives in `server/http/handlers` and can't be imported from `internal/core` or `server/grpc/services` (wrong dependency direction / different module boundary), so an identical `goSafe()` helper was added to each of those two packages (`internal/core/audit_context.go`, `server/grpc/services/conversions.go`) — same recover-and-log body, same convention. All 12 non-test detached-goroutine call sites across the three packages are now covered; a repo-wide grep confirms no bare `go func`/`go funcName(...)` audit-side-effect spawn remains in non-test code in these packages.

## Test plan

- [x] Added `TestRequestPasswordReset_PanicInDetachedGoroutineDoesNotCrash` (internal/core) — a panicking `CredentialDelivery` proves the process survives.
- [x] Added 4 secrets-CRUD regression tests (server/http/handlers) — a panicking `core.AuditForwarder` (the same injectable SIEM-forwarding seam `SetAuditForwarder` wires) forces a panic deep in the audit-emit path for Create/Get/Update/Delete, proving each handler still returns its normal success response and the goroutine panic doesn't crash the process.
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./server/... ./internal/core/...` — all pass (one known pre-existing flaky-table rerun, unrelated to this change, passed clean on retry)
- [x] `gosec -severity medium -exclude-generated` — ran cleanly (0 issues across all AST-based rules over 249 files); note SSA-dependent analyzers were skipped in this sandboxed run due to an environment-local go-build-cache permission quirk, not related to this diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)