### PR TITLE
fix(core): degrade access-review report/campaign on share-lookup error (#483)

### DIFF
--- a/internal/cli/accessreview/campaign.go
+++ b/internal/cli/accessreview/campaign.go
@@ -20,6 +20,25 @@ type campaignView struct {
 	ProjectID uint   `json:"project_id"`
 	Name      string `json:"name"`
 	State     string `json:"state"`
+	// Degraded/DegradedReasons (#483): true when the snapshot this campaign was
+	// opened from couldn't fully read every secret's shares — the campaign may be
+	// MISSING a direct/group-share item for the affected secret(s).
+	Degraded        bool     `json:"degraded"`
+	DegradedReasons []string `json:"degraded_reasons"`
+}
+
+// printCampaignDegradedWarning surfaces a degraded snapshot instead of letting it
+// pass unnoticed, mirroring the sod/compliance CLI degrade warnings.
+func printCampaignDegradedWarning(c campaignView) {
+	if !c.Degraded {
+		return
+	}
+	fmt.Println("*** DEGRADED SNAPSHOT — one or more secrets' shares could not be read when this campaign was opened ***")
+	fmt.Println("*** This campaign may be MISSING a direct/group-share item for them.                                ***")
+	for _, reason := range c.DegradedReasons {
+		fmt.Printf("    - %s\n", reason)
+	}
+	fmt.Println()
 }
 
 type progressView struct {
@@ -87,6 +106,7 @@ var campaignOpenCmd = &cobra.Command{
 		if err := c.Post(context.Background(), campaignBase(cProject), map[string]string{"name": cName}, &out); err != nil {
 			return err
 		}
+		printCampaignDegradedWarning(out.Campaign)
 		fmt.Printf("Opened campaign %d (%q) for project %d — %s.\n", out.Campaign.ID, out.Campaign.Name, cProject, progressStr(out.Progress))
 		fmt.Printf("Review items: keyorix access-review campaign show --project-id %d --campaign-id %d\n", cProject, out.Campaign.ID)
 		return nil
@@ -121,8 +141,19 @@ var campaignListCmd = &cobra.Command{
 		}
 		fmt.Printf("Access-review campaigns — project %d:\n\n", cProject)
 		fmt.Printf("%-5s %-8s %-28s %s\n", "ID", "STATE", "NAME", "PROGRESS")
+		anyDegraded := false
 		for _, c := range out.Campaigns {
-			fmt.Printf("%-5d %-8s %-28s %s\n", c.Campaign.ID, c.Campaign.State, truncate(c.Campaign.Name, 28), progressStr(c.Progress))
+			state := c.Campaign.State
+			if c.Campaign.Degraded {
+				// #483: this campaign's opening snapshot couldn't fully read every
+				// secret's shares — it may be missing a share item.
+				state += "*"
+				anyDegraded = true
+			}
+			fmt.Printf("%-5d %-8s %-28s %s\n", c.Campaign.ID, state, truncate(c.Campaign.Name, 28), progressStr(c.Progress))
+		}
+		if anyDegraded {
+			fmt.Println("\n(* = degraded snapshot; run `campaign show` on it for details)")
 		}
 		return nil
 	},
@@ -149,6 +180,7 @@ var campaignShowCmd = &cobra.Command{
 			return err
 		}
 		fmt.Printf("Campaign %d (%q) — %s — %s\n\n", out.Campaign.ID, out.Campaign.Name, out.Campaign.State, progressStr(out.Progress))
+		printCampaignDegradedWarning(out.Campaign)
 		if len(out.Items) == 0 {
 			fmt.Println("No items.")
 			return nil
@@ -215,6 +247,7 @@ var campaignCloseCmd = &cobra.Command{
 			return err
 		}
 		fmt.Printf("Closed campaign %d — %s.\n", out.Campaign.ID, progressStr(out.Progress))
+		printCampaignDegradedWarning(out.Campaign)
 		return nil
 	},
 }

--- a/internal/core/access_review.go
+++ b/internal/core/access_review.go
@@ -215,6 +215,7 @@ func (c *KeyorixCore) GenerateProjectAccessReview(ctx context.Context, projectID
 		return n
 	}
 
+	report := &AccessReviewReport{}
 	var entries []*AccessReviewEntry
 
 	// (1) Role-based standing access — project-scoped role grants whose role confers
@@ -263,6 +264,14 @@ func (c *KeyorixCore) GenerateProjectAccessReview(ctx context.Context, projectID
 		}
 		shares, err := c.storage.ListSharesBySecret(ctx, s.ID)
 		if err != nil {
+			// #483: a transient error reading ONE secret's shares must not silently drop
+			// its direct/group grants from the report with no signal — that reads
+			// identically to "this secret has no shares" to every downstream consumer
+			// (the campaign snapshot, the API/CLI), exactly the fail-open pattern #453
+			// already fixed for LastUserSecretActivity below. The secret's shares still
+			// can't be reported (there's nothing else to do without the data), but the
+			// caller must now be told coverage is incomplete.
+			report.degrade(fmt.Sprintf("shares:secret=%d", s.ID), err)
 			continue // best-effort; a secret whose shares can't be read is skipped
 		}
 		for _, sh := range shares {
@@ -281,7 +290,7 @@ func (c *KeyorixCore) GenerateProjectAccessReview(ctx context.Context, projectID
 		}
 	}
 
-	report := &AccessReviewReport{Entries: entries}
+	report.Entries = entries
 
 	// Annotate user principals with their last secret-access time (dormant-access
 	// detection). #453: on storage.type: remote, LastUserSecretActivity is

--- a/internal/core/access_review_campaign.go
+++ b/internal/core/access_review_campaign.go
@@ -86,12 +86,19 @@ func (c *KeyorixCore) OpenAccessReviewCampaign(ctx context.Context, actorID, pro
 	if name == "" {
 		name = "Access review"
 	}
+	// #483: report.Degraded/DegradedReasons signal a transient storage error mid-
+	// snapshot (e.g. one secret's shares couldn't be read); persist them onto the
+	// campaign row itself instead of discarding them the instant the report is
+	// consumed — an ephemeral return value is not a durable record that this
+	// recertification cycle's evidence snapshot was incomplete.
 	campaign, err := c.storage.CreateAccessReviewCampaign(ctx, &models.AccessReviewCampaign{
-		ProjectID: projectID,
-		Name:      name,
-		State:     CampaignStateOpen,
-		CreatedBy: actorID,
-		CreatedAt: c.now(),
+		ProjectID:       projectID,
+		Name:            name,
+		State:           CampaignStateOpen,
+		CreatedBy:       actorID,
+		CreatedAt:       c.now(),
+		Degraded:        report.Degraded,
+		DegradedReasons: report.DegradedReasons,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)

--- a/internal/core/access_review_campaign_external_test.go
+++ b/internal/core/access_review_campaign_external_test.go
@@ -278,3 +278,40 @@ func TestOpenAccessReviewCampaign_RequiresProject(t *testing.T) {
 	_, err := h.CoreService.OpenAccessReviewCampaign(context.Background(), 1, 0, "x")
 	require.Error(t, err)
 }
+
+// #483: OpenAccessReviewCampaign previously took report.Entries and discarded
+// report.Degraded/DegradedReasons entirely — the #453 degrade signal evaporated the
+// instant a campaign was opened, even though models.AccessReviewCampaign had no field
+// to carry it forward anyway. A degraded snapshot must now leave a DURABLE record on
+// the campaign row itself, verified by reading the row back from storage (not just
+// trusting the in-memory return value).
+func TestOpenAccessReviewCampaign_PersistsDegradedFromReport(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	// Only the campaign tables are migrated — models.AuditEvent is deliberately NOT
+	// migrated, so GenerateProjectAccessReview's LastUserSecretActivity lookup fails
+	// and the report it returns comes back Degraded=true (same trick as
+	// TestGenerateProjectAccessReview_DegradedOnLastUsedQueryError).
+	require.NoError(t, h.DB.AutoMigrate(&models.AccessReviewCampaign{}, &models.AccessReviewItem{}))
+
+	const proj = uint(2)
+	ctx := context.Background()
+	h.CreateTestUser(t, "alice", 10)
+	h.AssignUserRole(t, 10, 3, uptr(proj)) // editor → write
+
+	report, err := h.CoreService.GenerateProjectAccessReview(ctx, proj)
+	require.NoError(t, err)
+	require.True(t, report.Degraded, "sanity: the report itself must be degraded for this test to be meaningful")
+
+	res, err := h.CoreService.OpenAccessReviewCampaign(ctx, 1, proj, "degraded review")
+	require.NoError(t, err)
+	assert.True(t, res.Campaign.Degraded, "the campaign returned by Open must carry the degraded signal")
+	assert.NotEmpty(t, res.Campaign.DegradedReasons)
+
+	// Read the row back from storage — not just the in-memory return value — to
+	// confirm it's a durable record, not an ephemeral one.
+	stored, err := h.Storage.GetAccessReviewCampaign(ctx, res.Campaign.ID)
+	require.NoError(t, err)
+	assert.True(t, stored.Degraded, "Degraded must be persisted on the campaign row")
+	assert.Equal(t, res.Campaign.DegradedReasons, stored.DegradedReasons)
+}

--- a/internal/core/access_review_shares_degrade_test.go
+++ b/internal/core/access_review_shares_degrade_test.go
@@ -1,0 +1,59 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// #483: GenerateProjectAccessReview previously silently `continue`d past a secret
+// whose ListSharesBySecret call errored — that secret's direct/group shares were
+// dropped from the report with no signal, the identical fail-open shape #453 fixed
+// for LastUserSecretActivity, but in a SEPARATE call in the SAME function. A
+// transient error reading ONE secret's shares must flip Degraded while every OTHER
+// secret's shares are still correctly reported.
+func TestGenerateProjectAccessReview_DegradedOnShareLookupError(t *testing.T) {
+	const proj = uint(2)
+	ctx := context.Background()
+
+	ms := &MockStorage{}
+	ms.On("ListProjectRoleAssignments", ctx, proj).Return([]storage.RoleAssignment{}, nil)
+	ms.On("ListProjectMachineRoleAssignments", ctx, proj).Return([]storage.RoleAssignment{}, nil)
+	ms.On("ListSecrets", ctx, mock.Anything).Return([]*models.SecretNode{
+		{ID: 500, ProjectID: proj, Name: "good-secret"},
+		{ID: 501, ProjectID: proj, Name: "bad-secret"},
+	}, int64(2), nil)
+	ms.On("ListSharesBySecret", ctx, uint(500)).Return([]*models.ShareRecord{
+		{SecretID: 500, RecipientID: 100, IsGroup: true, Permission: "write"},
+	}, nil)
+	ms.On("ListSharesBySecret", ctx, uint(501)).Return(nil, errors.New("connection reset"))
+	ms.On("GetGroup", ctx, uint(100)).Return(&models.Group{ID: 100, Name: "devs"}, nil)
+	ms.On("LastUserSecretActivity", ctx, proj).Return(map[uint]time.Time{}, nil)
+
+	c := NewKeyorixCore(ms)
+	report, err := c.GenerateProjectAccessReview(ctx, proj)
+	require.NoError(t, err)
+
+	assert.True(t, report.Degraded, "a failed per-secret share lookup must flip Degraded")
+	require.NotEmpty(t, report.DegradedReasons)
+	assert.Contains(t, report.DegradedReasons[0], "shares:secret=501")
+
+	// The OTHER secret's share is still correctly reported.
+	var found bool
+	for _, e := range report.Entries {
+		if e.Source == "group_share" && e.SecretID == 500 && e.PrincipalName == "devs" && e.AccessLevel == "write" {
+			found = true
+		}
+		assert.NotEqual(t, uint(501), e.SecretID, "the errored secret contributes no share entries")
+	}
+	assert.True(t, found, "secret 500's group share must still appear in the report")
+
+	ms.AssertExpectations(t)
+}

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -634,6 +634,19 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 		if err := db.AutoMigrate(&models.AccessReviewCampaign{}, &models.AccessReviewItem{}); err != nil {
 			return fmt.Errorf("failed to migrate access_review_campaign tables: %w", err)
 		}
+	} else {
+		// #483: Degraded/DegradedReasons were added to AccessReviewCampaign after this
+		// table could already exist in the field (same pgx hazard as project_invitations
+		// above — never full-AutoMigrate an existing table here); add the new columns
+		// via the Migrator so an existing deployment's campaigns table picks them up.
+		m := db.Migrator()
+		for _, col := range []string{"Degraded", "DegradedReasons"} {
+			if !m.HasColumn(&models.AccessReviewCampaign{}, col) {
+				if err := m.AddColumn(&models.AccessReviewCampaign{}, col); err != nil {
+					return fmt.Errorf("failed to add access_review_campaigns.%s column: %w", col, err)
+				}
+			}
+		}
 	}
 
 	// Create the break-glass activations table if missing (additive).

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -209,6 +209,18 @@ type AccessReviewCampaign struct {
 	CreatedAt time.Time  `json:"created_at"`
 	ClosedBy  uint       `json:"closed_by,omitempty"`
 	ClosedAt  *time.Time `json:"closed_at,omitempty"`
+	// Degraded/DegradedReasons carry forward AccessReviewReport.Degraded/
+	// DegradedReasons (access_review.go) from the snapshot this campaign was
+	// opened from (#483). Without this, a transient storage error mid-snapshot
+	// (e.g. ListSharesBySecret failing for one secret) produces a campaign
+	// evidence row indistinguishable from a fully-covered review — the ephemeral
+	// report signal would otherwise be discarded the instant the campaign is
+	// created, undermining the very control (ISO 27001 A.5.18 recertification
+	// coverage) the #453 degrade signal exists to protect.
+	Degraded bool `gorm:"default:false" json:"degraded"`
+	// DegradedReasons is JSON-serialized (gorm serializer) so it round-trips as a
+	// native []string, mirroring AccessReviewReport.DegradedReasons.
+	DegradedReasons []string `gorm:"serializer:json" json:"degraded_reasons,omitempty"`
 }
 
 // AccessReviewItem is one access grant captured in a campaign at open time, plus


### PR DESCRIPTION
## Summary

Fixes backlog #483 (HIGH) — two compounding fail-open gaps found by an
adversarial regression audit of this session's own #453 fix (PR #728),
one function away in the same file:

1. **`GenerateProjectAccessReview`** (`internal/core/access_review.go`):
   `ListSharesBySecret` erroring for one secret silently `continue`d past
   it, dropping all of that secret's direct/group share entries from the
   report with **no `Degraded` signal** — #453 only added `degrade()` for
   the `LastUserSecretActivity` failure mode, not this separate one in the
   same function. Now calls `report.degrade("shares:secret=<id>", err)`
   before `continue`, exactly mirroring the existing pattern.

2. **`OpenAccessReviewCampaign`** (`internal/core/access_review_campaign.go`):
   took `report.Entries` but discarded `report.Degraded`/`DegradedReasons`
   entirely — `models.AccessReviewCampaign` had no field for it, so even the
   one degrade path #453 added evaporated the instant a campaign was opened.
   A transient storage error during an actual recertification event could
   permanently freeze a campaign missing real access-review entries with no
   durable record anywhere that the snapshot was incomplete — undermining the
   ISO 27001 A.5.18 recertification-coverage control the whole #453 fix
   family exists to harden.

   Fixed by adding `Degraded bool` / `DegradedReasons []string` (GORM JSON
   serializer) to `models.AccessReviewCampaign` and persisting the report's
   signal onto the created campaign row. `factory.go`'s campaign-table
   migration is gated on table-not-exists (same pgx hazard as
   `project_invitations`), so existing deployments get the new columns via
   an explicit `Migrator().AddColumn` else-branch. The access-review CLI
   (`internal/cli/accessreview/campaign.go`) surfaces the field with a
   degraded-snapshot warning, mirroring the sod/compliance CLI degrade
   warnings — the HTTP handlers already pass the whole campaign model
   through, so no handler change was needed.

## Test plan

- [x] `TestGenerateProjectAccessReview_DegradedOnShareLookupError` (new,
      `MockStorage`-based): a failing `ListSharesBySecret` for one secret
      among two flips `Degraded` while the other secret's group share is
      still correctly reported.
- [x] `TestOpenAccessReviewCampaign_PersistsDegradedFromReport` (new): opens
      a campaign from a degraded report and reads the row back from storage
      to confirm `Degraded`/`DegradedReasons` are durably persisted, not just
      returned in-memory.
- [x] `go build ./...`, `go vet ./...` clean.
- [x] `go test ./internal/core/... ./internal/storage/store/... ./server/http/handlers/...`
      clean (one rerun of the documented pre-existing flake
      `TestConcurrency_RequestPasswordReset_BurstIsThrottled`, confirmed
      unrelated and passing in isolation).
- [x] `gosec -severity medium -exclude-generated ./internal/core/...`: 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)