### PR TITLE
fix(core): degrade SoD scan on machine sub-check errors (#492)

### DIFF
--- a/internal/core/sod.go
+++ b/internal/core/sod.go
@@ -165,7 +165,7 @@ func (c *KeyorixCore) DetectSoDViolations(ctx context.Context) (*SoDViolationsRe
 		}
 	}
 
-	report.Violations = append(report.Violations, c.machineSoDViolations(ctx, policies)...)
+	c.machineSoDViolations(ctx, report, policies)
 	return report, nil
 }
 
@@ -226,24 +226,35 @@ func (c *KeyorixCore) userSoDViolations(ctx context.Context, u *models.User, pol
 	return out, nil
 }
 
-// machineSoDViolations scans active machine identities. Machines resolve permissions
-// from machine_identity_roles and receive NO admin-role bypass (a leaked machine token
-// is bounded to its explicit grants), so the held-set is just the union of its roles'
-// permissions. Best-effort: if machine identities can't be listed (e.g. the table
-// isn't provisioned in this deployment), machine scanning is skipped rather than
-// failing the whole detection.
-func (c *KeyorixCore) machineSoDViolations(ctx context.Context, policies []*models.SoDPolicy) []SoDViolation {
+// machineSoDViolations scans active machine identities, appending any violations
+// found directly onto report.Violations. Machines resolve permissions from
+// machine_identity_roles and receive NO admin-role bypass (a leaked machine token
+// is bounded to its explicit grants), so the held-set is just the union of its
+// roles' permissions.
+//
+// #492: sibling of userSoDViolations/#420 — every sub-check error here was
+// previously silently discarded (ListAllMachineIdentities returning nil,
+// GetMachineRoles/RoleSetHasPermission folded into a bare `continue`), so a
+// machine identity that actually held a toxic combination could be dropped from
+// the scan while the report still looked clean. Each failure now flips
+// report.Degraded via report.degrade, named for the machine (and policy, for the
+// permission checks) that couldn't be evaluated, instead of looking clean.
+func (c *KeyorixCore) machineSoDViolations(ctx context.Context, report *SoDViolationsReport, policies []*models.SoDPolicy) {
 	machines, err := c.storage.ListAllMachineIdentities(ctx)
 	if err != nil {
-		return nil
+		report.degrade("machine_identities", err)
+		return
 	}
-	var out []SoDViolation
 	for _, m := range machines {
 		if m.State != "active" {
 			continue
 		}
 		roles, err := c.storage.GetMachineRoles(ctx, m.ID)
-		if err != nil || len(roles) == 0 {
+		if err != nil {
+			report.degrade(fmt.Sprintf("machine_roles:machine=%d", m.ID), err)
+			continue
+		}
+		if len(roles) == 0 {
 			continue
 		}
 		roleIDs := make([]uint, 0, len(roles))
@@ -252,14 +263,22 @@ func (c *KeyorixCore) machineSoDViolations(ctx context.Context, policies []*mode
 		}
 		for _, pol := range policies {
 			hasA, err := c.storage.RoleSetHasPermission(ctx, roleIDs, pol.PermissionA)
-			if err != nil || !hasA {
+			if err != nil {
+				report.degrade(fmt.Sprintf("machine_permission:machine=%d:policy=%d", m.ID, pol.ID), err)
+				continue
+			}
+			if !hasA {
 				continue
 			}
 			hasB, err := c.storage.RoleSetHasPermission(ctx, roleIDs, pol.PermissionB)
-			if err != nil || !hasB {
+			if err != nil {
+				report.degrade(fmt.Sprintf("machine_permission:machine=%d:policy=%d", m.ID, pol.ID), err)
 				continue
 			}
-			out = append(out, SoDViolation{
+			if !hasB {
+				continue
+			}
+			report.Violations = append(report.Violations, SoDViolation{
 				PolicyID: pol.ID, PolicyName: pol.Name,
 				PrincipalType: "machine", UserID: m.ID, Username: m.Name,
 				PermissionA: pol.PermissionA, PermissionB: pol.PermissionB,
@@ -267,7 +286,6 @@ func (c *KeyorixCore) machineSoDViolations(ctx context.Context, policies []*mode
 			})
 		}
 	}
-	return out
 }
 
 // adminRoleName returns the name of an admin (permission-bypass) role the user holds

--- a/internal/core/sod_degraded_test.go
+++ b/internal/core/sod_degraded_test.go
@@ -67,6 +67,79 @@ func TestDetectSoDViolations_DegradedOnUserPermissionsError(t *testing.T) {
 	store.AssertNotCalled(t, "GetUserGroupPermissions", ctx, uint(11))
 }
 
+// #492: machineSoDViolations is the sibling of userSoDViolations/#420 for
+// machine identities, but its sub-check errors (GetMachineRoles,
+// RoleSetHasPermission) were previously folded into a bare `continue` — a
+// machine that couldn't be evaluated was silently dropped with the report
+// still looking clean. This proves a GetMachineRoles error now flips Degraded
+// with a reason naming the machine, while a real human violation is still
+// correctly detected.
+func TestDetectSoDViolations_DegradedOnMachineRolesError(t *testing.T) {
+	ctx := context.Background()
+	store := new(MockStorage)
+	c := NewKeyorixCore(store)
+
+	store.On("ListSoDPolicies", ctx).Return([]*models.SoDPolicy{
+		{ID: 1, Name: "write-vs-useradmin", PermissionA: "secrets.write", PermissionB: "users.read"},
+	}, nil)
+	store.On("ListUsers", ctx, mock.Anything).Return([]*models.User{
+		{ID: 10, Username: "alice", IsActive: true},
+	}, int64(1), nil)
+	store.On("GetUserRoles", ctx, uint(10)).Return([]*models.Role{}, nil)
+	store.On("GetUserPermissions", ctx, uint(10)).Return([]*storage.Permission{
+		{Name: "secrets.write"}, {Name: "users.read"},
+	}, nil)
+	store.On("GetUserGroupPermissions", ctx, uint(10)).Return([]*storage.Permission{}, nil)
+
+	store.On("ListAllMachineIdentities", ctx).Return([]*models.MachineIdentity{
+		{ID: 20, Name: "ci-runner", State: "active"},
+	}, nil)
+	store.On("GetMachineRoles", ctx, uint(20)).Return(nil, errors.New("simulated: machine role lookup unavailable"))
+
+	report, err := c.DetectSoDViolations(ctx)
+	require.NoError(t, err)
+
+	require.True(t, report.Degraded, "a machine whose roles couldn't be read must flip Degraded")
+	require.NotEmpty(t, report.DegradedReasons)
+	assert.Contains(t, report.DegradedReasons[len(report.DegradedReasons)-1], "machine=20")
+
+	var users []string
+	for _, v := range report.Violations {
+		users = append(users, v.Username)
+	}
+	assert.Contains(t, users, "alice", "alice's real violation must still be detected")
+	assert.NotContains(t, users, "ci-runner", "ci-runner can't be evaluated without its roles")
+}
+
+// A RoleSetHasPermission error (rather than GetMachineRoles) must also flip
+// Degraded, named for the machine and policy that couldn't be evaluated.
+func TestDetectSoDViolations_DegradedOnMachinePermissionError(t *testing.T) {
+	ctx := context.Background()
+	store := new(MockStorage)
+	c := NewKeyorixCore(store)
+
+	store.On("ListSoDPolicies", ctx).Return([]*models.SoDPolicy{
+		{ID: 1, Name: "write-vs-useradmin", PermissionA: "secrets.write", PermissionB: "users.read"},
+	}, nil)
+	store.On("ListUsers", ctx, mock.Anything).Return([]*models.User{}, int64(0), nil)
+
+	store.On("ListAllMachineIdentities", ctx).Return([]*models.MachineIdentity{
+		{ID: 21, Name: "deploy-bot", State: "active"},
+	}, nil)
+	store.On("GetMachineRoles", ctx, uint(21)).Return([]*models.Role{{ID: 5, Name: "deployer"}}, nil)
+	store.On("RoleSetHasPermission", ctx, []uint{5}, "secrets.write").
+		Return(false, errors.New("simulated: permission check unavailable"))
+
+	report, err := c.DetectSoDViolations(ctx)
+	require.NoError(t, err)
+
+	require.True(t, report.Degraded, "a machine whose permission check errored must flip Degraded")
+	require.NotEmpty(t, report.DegradedReasons)
+	assert.Contains(t, report.DegradedReasons[0], "machine=21")
+	assert.Contains(t, report.DegradedReasons[0], "policy=1")
+	assert.Empty(t, report.Violations, "no violation can be confirmed without a successful permission check")
+}
+
 // A clean scan (every principal's permissions resolve) must not be marked
 // Degraded — the signal must not fire on the happy path.
 func TestDetectSoDViolations_NotDegradedOnCleanScan(t *testing.T) {


### PR DESCRIPTION
## Summary
- `machineSoDViolations` is the sibling of `userSoDViolations`/#420 for machine identities, but its sub-check errors were previously discarded silently (`ListAllMachineIdentities` returning `nil`, `GetMachineRoles`/`RoleSetHasPermission` folded into a bare `continue`) — a machine that actually held a toxic combination could be dropped from the scan while `SoDViolationsReport` still looked clean.
- Threads the report into `machineSoDViolations` so each failure calls `report.degrade(area, err)` — same field names (`Degraded`/`DegradedReasons`) and area-string style (`machine_identities`, `machine_roles:machine=%d`, `machine_permission:machine=%d:policy=%d`) that #420 used for the human-user path in `userSoDViolations`/`DetectSoDViolations`.
- No new pattern invented; identical `degrade()` method already on `SoDViolationsReport`.

## Test plan
- [x] Added `TestDetectSoDViolations_DegradedOnMachineRolesError` — a `GetMachineRoles` error flips `Degraded` with a reason naming the machine, while a genuine human violation in the same scan is still detected.
- [x] Added `TestDetectSoDViolations_DegradedOnMachinePermissionError` — a `RoleSetHasPermission` error flips `Degraded` with a reason naming the machine and policy.
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/core/... -run 'SoD|Violation' -v` — all pass, including the pre-existing #420 tests.
- [x] `gosec -severity medium -exclude-generated ./internal/core/...` — 0 issues.

🤖 Generated with Claude Code