### PR TITLE
fix(cli): verify --by actor authority in invite send and request review (#491)

### DIFF
--- a/internal/cli/invite/send.go
+++ b/internal/cli/invite/send.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/spf13/cobra"
 )
 
@@ -56,6 +57,10 @@ func runSend(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if err := requireInviteAuthority(ctx, service, invitedBy, projectID); err != nil {
+		return err
+	}
+
 	inv, prov, err := service.InviteToProjectWithLink(ctx, projectID, sendEmail, sendRole, invitedBy)
 	if err != nil {
 		if inv == nil {
@@ -70,5 +75,27 @@ func runSend(cmd *cobra.Command, args []string) error {
 	fmt.Printf("Invitation sent: id=%d email=%s role=%s project=%s expires=%s\n",
 		inv.ID, inv.Email, inv.Role, projectName, fmtTime(inv.ExpiresAt))
 	common.PrintProvisionResult(prov)
+	return nil
+}
+
+// requireInviteAuthority verifies that actorID — the user resolved from --by —
+// actually holds the authority the equivalent HTTP route requires for this
+// exact operation: POST .../projects/{id}/invitations is gated on roles.assign
+// scoped to the project (see router.go). The local CLI has no
+// session/middleware to enforce this, so --by resolving ANY email — with zero
+// authority check — would let an operator attribute an invitation to an
+// arbitrary or unprivileged account purely for what appears in the audit
+// trail (#264/#491). InviteToProjectWithLink itself does not check
+// permissions (the HTTP handler's job is done by router middleware), so this
+// must be verified here, at the CLI entrypoint, before the resolved actor is
+// credited with the action.
+func requireInviteAuthority(ctx context.Context, svc *core.KeyorixCore, actorID, projectID uint) error {
+	ok, err := svc.Authorize(ctx, actorID, "roles.assign", core.Scope{ProjectID: projectID})
+	if err != nil {
+		return fmt.Errorf("failed to verify --by authority: %w", err)
+	}
+	if !ok {
+		return fmt.Errorf("--by actor does not hold roles.assign at project %d; refusing to attribute this invitation to them", projectID)
+	}
 	return nil
 }

--- a/internal/cli/invite/send_authority_test.go
+++ b/internal/cli/invite/send_authority_test.go
@@ -1,0 +1,99 @@
+// send_authority_test.go — regression coverage for #491 (sibling of #264): the
+// --by actor for `keyorix invite send` must actually hold the authority the
+// equivalent HTTP route requires (roles.assign scoped to the project), not
+// merely resolve to SOME user record.
+package invite
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// newTestInviteCore spins up an in-memory store, runs the production
+// BootstrapSystem (seeding the real RBAC role/permission catalog), and returns
+// the core + storage for authority assertions — mirrors
+// migrate.newTestMigrateCore (internal/cli/migrate/user_to_machine_authority_test.go),
+// reimplemented here since that helper is unexported to this package.
+func newTestInviteCore(t *testing.T) (*core.KeyorixCore, *store.LocalStorage) {
+	t.Helper()
+	require.NoError(t, i18n.Initialize(&config.Config{
+		Locale: config.LocaleConfig{Language: "en", FallbackLanguage: "en"},
+	}))
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.User{}, &models.Role{}, &models.Permission{}, &models.RolePermission{},
+		&models.UserRole{}, &models.Group{}, &models.UserGroup{}, &models.GroupRole{},
+		&models.Project{}, &models.Environment{}, &models.SystemMetadata{},
+		&models.MachineIdentity{}, &models.MachineIdentityRole{},
+		&models.PersonalAccessToken{}, &models.Session{}, &models.AuditEvent{},
+	))
+
+	st := store.NewLocalStorage(db)
+	c := core.NewKeyorixCore(st)
+	c.SetBootstrapToken("test-bootstrap-token")
+	_, err = c.BootstrapSystem(context.Background(), &core.BootstrapRequest{
+		Username: "admin", Email: "admin@example.com", Password: "BootstrapPass123!", DisplayName: "Admin",
+		Token: "test-bootstrap-token",
+	})
+	require.NoError(t, err)
+	return c, st
+}
+
+// seedUserWithRole creates a user and assigns roleName at scope, returning the
+// new user's ID.
+func seedUserWithRole(t *testing.T, st *store.LocalStorage, username, roleName string, scope core.Scope) uint {
+	t.Helper()
+	ctx := context.Background()
+	u, err := st.CreateUser(ctx, &models.User{Username: username, Email: username + "@example.com", IsActive: true})
+	require.NoError(t, err)
+	role, err := st.GetRoleByName(ctx, roleName)
+	require.NoErrorf(t, err, "role %s must be seeded", roleName)
+	require.NoError(t, st.AssignRole(ctx, u.ID, role.ID, scope))
+	return u.ID
+}
+
+// #491 (sibling of #264): an actor holding only a read-only project role (no
+// roles.assign) must be refused — the CLI must not let --by attribute this
+// invitation to an unprivileged account.
+func TestRequireInviteAuthority_UnprivilegedActorRejected(t *testing.T) {
+	c, st := newTestInviteCore(t)
+	ctx := context.Background()
+	actor := seedUserWithRole(t, st, "invite-viewer", "project_viewer", core.Scope{ProjectID: 1})
+
+	err := requireInviteAuthority(ctx, c, actor, 1)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "roles.assign")
+}
+
+// #491 positive control: an actor holding roles.assign at the project (the
+// equivalent HTTP route's requirement) must be allowed through.
+func TestRequireInviteAuthority_AuthorizedActorAllowed(t *testing.T) {
+	c, st := newTestInviteCore(t)
+	ctx := context.Background()
+	actor := seedUserWithRole(t, st, "invite-admin", "project_admin", core.Scope{ProjectID: 1})
+
+	require.NoError(t, requireInviteAuthority(ctx, c, actor, 1))
+}
+
+// #491 positive control: the bootstrap admin created by BootstrapSystem itself
+// (the realistic legitimate --by actor for this command) must pass too.
+func TestRequireInviteAuthority_BootstrapAdminAllowed(t *testing.T) {
+	c, st := newTestInviteCore(t)
+	ctx := context.Background()
+	bootstrapAdmin, err := st.GetUserByEmail(ctx, "admin@example.com")
+	require.NoError(t, err)
+
+	require.NoError(t, requireInviteAuthority(ctx, c, bootstrapAdmin.ID, 1))
+}

--- a/internal/cli/request/review.go
+++ b/internal/cli/request/review.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/spf13/cobra"
 )
 
@@ -65,6 +66,10 @@ func runReview(cmd *cobra.Command, args []string) error {
 	}
 	projectID := existing.ProjectID
 
+	if err := requireReviewAuthority(ctx, service, approverID, projectID); err != nil {
+		return err
+	}
+
 	switch reviewAction {
 	case "approve":
 		var ttl time.Duration
@@ -96,6 +101,28 @@ func runReview(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("failed to reject access request: %w", err)
 		}
 		fmt.Printf("Access request %d rejected.\n", req.ID)
+	}
+	return nil
+}
+
+// requireReviewAuthority verifies that actorID — the user resolved from --by —
+// actually holds the authority the equivalent HTTP route requires for this
+// exact operation: PUT .../projects/{id}/access-requests/{requestId} is gated
+// on roles.assign scoped to the project (see router.go). The local CLI has no
+// session/middleware to enforce this, so --by resolving ANY email — with zero
+// authority check — would let an operator attribute an approval/rejection to
+// an arbitrary or unprivileged account purely for what appears in the audit
+// trail (#264/#491). ApproveAccessRequestWithExpiry/RejectAccessRequest
+// themselves do not check permissions (the HTTP handler's job is done by
+// router middleware), so this must be verified here, at the CLI entrypoint,
+// before the resolved actor is credited with the action.
+func requireReviewAuthority(ctx context.Context, svc *core.KeyorixCore, actorID, projectID uint) error {
+	ok, err := svc.Authorize(ctx, actorID, "roles.assign", core.Scope{ProjectID: projectID})
+	if err != nil {
+		return fmt.Errorf("failed to verify --by authority: %w", err)
+	}
+	if !ok {
+		return fmt.Errorf("--by actor does not hold roles.assign at project %d; refusing to attribute this review to them", projectID)
 	}
 	return nil
 }

--- a/internal/cli/request/review_authority_test.go
+++ b/internal/cli/request/review_authority_test.go
@@ -1,0 +1,99 @@
+// review_authority_test.go — regression coverage for #491 (sibling of #264):
+// the --by actor for `keyorix request review` must actually hold the
+// authority the equivalent HTTP route requires (roles.assign scoped to the
+// project), not merely resolve to SOME user record.
+package request
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// newTestRequestCore spins up an in-memory store, runs the production
+// BootstrapSystem (seeding the real RBAC role/permission catalog), and returns
+// the core + storage for authority assertions — mirrors
+// migrate.newTestMigrateCore (internal/cli/migrate/user_to_machine_authority_test.go),
+// reimplemented here since that helper is unexported to this package.
+func newTestRequestCore(t *testing.T) (*core.KeyorixCore, *store.LocalStorage) {
+	t.Helper()
+	require.NoError(t, i18n.Initialize(&config.Config{
+		Locale: config.LocaleConfig{Language: "en", FallbackLanguage: "en"},
+	}))
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.User{}, &models.Role{}, &models.Permission{}, &models.RolePermission{},
+		&models.UserRole{}, &models.Group{}, &models.UserGroup{}, &models.GroupRole{},
+		&models.Project{}, &models.Environment{}, &models.SystemMetadata{},
+		&models.MachineIdentity{}, &models.MachineIdentityRole{},
+		&models.PersonalAccessToken{}, &models.Session{}, &models.AuditEvent{},
+	))
+
+	st := store.NewLocalStorage(db)
+	c := core.NewKeyorixCore(st)
+	c.SetBootstrapToken("test-bootstrap-token")
+	_, err = c.BootstrapSystem(context.Background(), &core.BootstrapRequest{
+		Username: "admin", Email: "admin@example.com", Password: "BootstrapPass123!", DisplayName: "Admin",
+		Token: "test-bootstrap-token",
+	})
+	require.NoError(t, err)
+	return c, st
+}
+
+// seedUserWithRole creates a user and assigns roleName at scope, returning the
+// new user's ID.
+func seedUserWithRole(t *testing.T, st *store.LocalStorage, username, roleName string, scope core.Scope) uint {
+	t.Helper()
+	ctx := context.Background()
+	u, err := st.CreateUser(ctx, &models.User{Username: username, Email: username + "@example.com", IsActive: true})
+	require.NoError(t, err)
+	role, err := st.GetRoleByName(ctx, roleName)
+	require.NoErrorf(t, err, "role %s must be seeded", roleName)
+	require.NoError(t, st.AssignRole(ctx, u.ID, role.ID, scope))
+	return u.ID
+}
+
+// #491 (sibling of #264): an actor holding only a read-only project role (no
+// roles.assign) must be refused — the CLI must not let --by attribute this
+// approval/rejection to an unprivileged account.
+func TestRequireReviewAuthority_UnprivilegedActorRejected(t *testing.T) {
+	c, st := newTestRequestCore(t)
+	ctx := context.Background()
+	actor := seedUserWithRole(t, st, "review-viewer", "project_viewer", core.Scope{ProjectID: 1})
+
+	err := requireReviewAuthority(ctx, c, actor, 1)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "roles.assign")
+}
+
+// #491 positive control: an actor holding roles.assign at the project (the
+// equivalent HTTP route's requirement) must be allowed through.
+func TestRequireReviewAuthority_AuthorizedActorAllowed(t *testing.T) {
+	c, st := newTestRequestCore(t)
+	ctx := context.Background()
+	actor := seedUserWithRole(t, st, "review-admin", "project_admin", core.Scope{ProjectID: 1})
+
+	require.NoError(t, requireReviewAuthority(ctx, c, actor, 1))
+}
+
+// #491 positive control: the bootstrap admin created by BootstrapSystem itself
+// (the realistic legitimate --by actor for this command) must pass too.
+func TestRequireReviewAuthority_BootstrapAdminAllowed(t *testing.T) {
+	c, st := newTestRequestCore(t)
+	ctx := context.Background()
+	bootstrapAdmin, err := st.GetUserByEmail(ctx, "admin@example.com")
+	require.NoError(t, err)
+
+	require.NoError(t, requireReviewAuthority(ctx, c, bootstrapAdmin.ID, 1))
+}


### PR DESCRIPTION
## Summary
- #264 fixed `keyorix migrate user-to-machine` so `--by` can't attribute a destructive action to an unprivileged/arbitrary account, but the same unverified-actor pattern was left unfixed in two sibling CLI commands (round 101 regression audit, finding #491): `invite send` and `request review`.
- Mirrors #264's exact mechanism: resolve `--by` to a user, then verify that user actually holds the `roles.assign` authority the equivalent HTTP route requires (`POST /projects/{id}/invitations` and `PUT /projects/{id}/access-requests/{requestId}`, both gated on `roles.assign` scoped to the project in `server/http/router.go`) before crediting them in the audit trail.
- Adds `requireInviteAuthority` (internal/cli/invite/send.go) and `requireReviewAuthority` (internal/cli/request/review.go), each refusing the command with a clear error if the `--by` actor lacks the permission — same shape as `requireMigrationAuthority` from #264.

## Test plan
- [x] Added `internal/cli/invite/send_authority_test.go` (unprivileged actor rejected, authorized project_admin allowed, bootstrap admin allowed) mirroring `internal/cli/migrate/user_to_machine_authority_test.go`.
- [x] Added `internal/cli/request/review_authority_test.go` with the same three cases.
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/cli/... -v` (all packages pass, including invite/request/migrate)
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues repo-wide

🤖 Generated with Claude Code