### PR TITLE
fix(notifications): close #488 admin-jobs reminder dedup TOCTOU race

### DIFF
--- a/internal/core/concurrency_rotation_reminder_test.go
+++ b/internal/core/concurrency_rotation_reminder_test.go
@@ -1,0 +1,102 @@
+package core_test
+
+import (
+	"context"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// TestConcurrency_SendRotationReminders_NoDuplicateReminder is the (#488) TOCTOU
+// regression: SendRotationReminders (and its sibling SendExpiryReminders) dedupe an
+// admin's standing reminder with a check-then-act read (GetUnreadNotification)
+// followed by a separate CreateNotification call — two calls with no atomicity
+// between them. The SCHEDULED path is safe (run under WithSchedulerLock,
+// single-replica-gated, ADR-039), but server/http/handlers.AdminJobsHandler's
+// on-demand RunRotationReminders/RunExpiryReminders triggers call the core function
+// directly with NO lock at all, so an operator hitting
+// POST /api/v1/admin/jobs/rotation-reminders twice in quick succession (or racing the
+// scheduler's own tick) against a project with no existing reminder can have both
+// calls pass the "does a reminder already exist" check before either commits,
+// producing duplicate reminder rows.
+//
+// This drives many concurrent SendRotationReminders runs against the same project —
+// through a real file-backed SQLite, migrated the same way factory.go's
+// ensureReminderNotificationDedupIndex does, so the DB-level guard production
+// installs get is actually in place — and asserts exactly one unread
+// rotation.reminder notification row survives for the admin.
+func TestConcurrency_SendRotationReminders_NoDuplicateReminder(t *testing.T) {
+	dsn := "file:" + filepath.Join(t.TempDir(), "rotation-reminders.db") + "?_busy_timeout=10000&_journal_mode=WAL"
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.User{}, &models.Role{}, &models.UserRole{}, &models.Project{},
+		&models.Environment{}, &models.SecretNode{}, &models.RotationPolicy{}, &models.Notification{},
+	))
+	// Mirror factory.go's ensureReminderNotificationDedupIndex exactly, so this test
+	// exercises the same DB-level guard production installs get (rather than only the
+	// in-process check-then-act, which this test demonstrates is not enough on its own).
+	require.NoError(t, db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS uniq_notifications_unread_reminder "+
+		"ON notifications (user_id, type, project_id) "+
+		"WHERE is_read = false AND type IN ('rotation.reminder', 'secret.expiry_reminder')").Error)
+
+	now := time.Now()
+	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "payments"}).Error)
+	require.NoError(t, db.Create(&models.Environment{ID: 2, Name: "production", ProjectID: 1}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 5, Username: "ada", Email: "ada@x.io", IsActive: true}).Error)
+	require.NoError(t, db.Create(&models.Role{ID: 1, Name: "project_admin"}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 5, RoleID: 1, ProjectID: 1}).Error) // admin
+	// A secret created 100 days ago, never rotated → overdue under a 30-day policy, so
+	// every concurrent run finds something to remind the admin about.
+	require.NoError(t, db.Create(&models.SecretNode{
+		ID: 10, Name: "db-password", ProjectID: 1, EnvironmentID: 2, Type: "password",
+		CreatedAt: now.AddDate(0, 0, -100),
+	}).Error)
+	pid := uint(1)
+	require.NoError(t, db.Create(&models.RotationPolicy{
+		Name: "30-day", Scope: "project", ProjectID: &pid,
+		IntervalDays: 30, AlertDaysBefore: 7, IsActive: true, CreatedBy: "ada",
+	}).Error)
+
+	c := core.NewKeyorixCore(store.NewLocalStorage(db))
+
+	// Fire many concurrent on-demand runs at once, exactly as two overlapping admin
+	// requests to POST /api/v1/admin/jobs/rotation-reminders (or one racing the
+	// scheduler's own tick) would.
+	const attackers = 30
+	start := make(chan struct{})
+	errs := make([]error, attackers)
+	var wg sync.WaitGroup
+	for i := 0; i < attackers; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			_, err := c.SendRotationReminders(context.Background())
+			errs[i] = err
+		}(i)
+	}
+	close(start) // release every run at once
+	wg.Wait()
+
+	for _, err := range errs {
+		assert.NoError(t, err, "SendRotationReminders must never surface the benign duplicate-skip as a caller-visible error")
+	}
+
+	// Exactly one unread rotation.reminder row must exist for the admin — no
+	// duplicate from the TOCTOU window between the dedup read and the create.
+	var count int64
+	require.NoError(t, db.Model(&models.Notification{}).
+		Where("user_id = ? AND type = ? AND project_id = ? AND is_read = ?", 5, "rotation.reminder", 1, false).
+		Count(&count).Error)
+	assert.Equal(t, int64(1), count, "exactly one standing rotation reminder must exist despite the concurrent runs")
+}

--- a/internal/core/notifications.go
+++ b/internal/core/notifications.go
@@ -61,11 +61,17 @@ func (c *KeyorixCore) notify(ctx context.Context, userID uint, nType, title, mes
 // standing unread reminder — see upgradeReminder. Notification types that don't
 // participate in escalation-aware dedup should keep using plain notify(), which
 // records NotificationSeverityNone.
+//
+// #488: a failed CreateNotification — including the benign duplicate-skip a
+// concurrent reminder run hits against the unread-reminder dedup index — must not
+// still fire an out-of-band delivery for a row that was never actually persisted,
+// or the race this index closes at the DB layer would still duplicate the
+// user-visible email/webhook. Mirrors upgradeReminder's identical guard (#482).
 func (c *KeyorixCore) notifyWithSeverity(ctx context.Context, userID uint, nType, title, message string, projectID *uint, link string, severity models.NotificationSeverity) {
 	if userID == 0 {
 		return
 	}
-	_, _ = c.storage.CreateNotification(ctx, &models.Notification{
+	if _, err := c.storage.CreateNotification(ctx, &models.Notification{
 		UserID:    userID,
 		ProjectID: projectID,
 		Type:      nType,
@@ -74,7 +80,9 @@ func (c *KeyorixCore) notifyWithSeverity(ctx context.Context, userID uint, nType
 		Link:      link,
 		Severity:  severity,
 		CreatedAt: c.now(),
-	})
+	}); err != nil {
+		return
+	}
 	c.dispatchNotification(ctx, userID, nType, title, message, projectID, link)
 }
 

--- a/internal/core/storage/errors.go
+++ b/internal/core/storage/errors.go
@@ -92,3 +92,18 @@ var ErrBreakGlassAlreadyActive = errors.New("an active break-glass grant already
 // Callers translate this into a clean validation error instead of a raw
 // constraint-violation message.
 var ErrDuplicateDynamicSecretConfig = errors.New("a dynamic-secret config with this name already exists in this project and environment")
+
+// ErrDuplicateReminderNotification is returned (wrapped) by CreateNotification when
+// the insert collides with the partial unique index on notifications (user_id, type,
+// project_id) scoped to unread rotation/expiry reminders (#488). Both
+// SendRotationReminders and SendExpiryReminders dedupe with a check-then-act read
+// (GetUnreadNotification) followed by a separate CreateNotification call, which is a
+// TOCTOU race: unlike the scheduled path (single-replica-gated via WithSchedulerLock,
+// ADR-039), the on-demand admin-jobs HTTP trigger
+// (POST /api/v1/admin/jobs/rotation-reminders or .../expiry-reminders) has no lock at
+// all, so two concurrent runs (or one racing the scheduler's own tick) against a
+// project with no existing reminder can both pass the "does a reminder already exist"
+// check before either commits, producing duplicate reminder rows. The index makes the
+// loser's insert fail here instead of silently duplicating; callers treat this as a
+// benign no-op skip, not a failure.
+var ErrDuplicateReminderNotification = errors.New("an unread reminder notification already exists for this user, type, and project")

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -781,6 +781,16 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 			}
 		}
 	}
+	// At most one unread rotation/expiry reminder may stand per (user, project) at a
+	// time — closing the #488 TOCTOU: the admin-jobs HTTP trigger for these two jobs
+	// runs with no lock at all (unlike the scheduled path, single-replica-gated via
+	// WithSchedulerLock, ADR-039), so two concurrent runs can both pass the
+	// check-then-act "does a reminder already exist" read before either commits its
+	// insert. Close the race at the DB layer regardless of whether the table
+	// pre-existed.
+	if err := ensureReminderNotificationDedupIndex(db); err != nil {
+		return err
+	}
 
 	// Groups gained soft-delete (DeletedAt) + a partial unique index on name. On an
 	// existing DB add the column and swap the plain unique index for the partial one
@@ -1111,6 +1121,34 @@ func ensureProjectNameIndex(db *gorm.DB) error {
 func ensureLegalHoldActiveIndex(db *gorm.DB) error {
 	if err := db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS uniq_legal_holds_active ON legal_holds (released) WHERE released = false").Error; err != nil {
 		return fmt.Errorf("failed to create partial legal_holds active index: %w", err)
+	}
+	return nil
+}
+
+// ensureReminderNotificationDedupIndex creates a partial unique index that permits
+// at most one unread rotation-reminder or expiry-reminder notification per
+// (user_id, type, project_id) at a time (#488). SendRotationReminders and
+// SendExpiryReminders each dedupe with a check-then-act read (an existing unread
+// reminder for the user/project is not re-notified) followed by a separate
+// CreateNotification call — a TOCTOU race. The scheduled path is safe (run under
+// WithSchedulerLock, single-replica-gated, ADR-039), but the on-demand admin-jobs
+// HTTP trigger (POST /api/v1/admin/jobs/rotation-reminders or .../expiry-reminders)
+// calls the core function directly with no lock at all, so two concurrent runs — or
+// one racing the scheduler's own tick — against a project with no existing reminder
+// can both pass the "does a reminder already exist" check before either commits,
+// producing duplicate reminder rows.
+//
+// Scoped to just these two notification types (via the type IN (...) predicate) —
+// unlike rotation.reminder/secret.expiry_reminder, most other notification types
+// (e.g. secret.shared) legitimately create more than one unread notification of the
+// same type for the same user/project (one per distinct secret/event), so a
+// blanket index across the whole table would silently drop those. Idempotent; works
+// on both SQLite and Postgres (both support partial indexes and IF NOT EXISTS).
+func ensureReminderNotificationDedupIndex(db *gorm.DB) error {
+	if err := db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS uniq_notifications_unread_reminder " +
+		"ON notifications (user_id, type, project_id) " +
+		"WHERE is_read = false AND type IN ('rotation.reminder', 'secret.expiry_reminder')").Error; err != nil {
+		return fmt.Errorf("failed to create partial notifications reminder-dedup index: %w", err)
 	}
 	return nil
 }

--- a/internal/storage/store/local_notifications.go
+++ b/internal/storage/store/local_notifications.go
@@ -11,14 +11,28 @@ import (
 
 	"gorm.io/gorm"
 
+	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
 const defaultNotificationLimit = 50
 
+// CreateNotification inserts a notification row. A partial unique index on
+// notifications (user_id, type, project_id) scoped to unread rotation/expiry
+// reminders (see storage.ensureReminderNotificationDedupIndex) allows at most one
+// standing unread reminder per (user, type, project) — closing the #488 TOCTOU:
+// SendRotationReminders/SendExpiryReminders's own "does a reminder already exist"
+// check-then-act read cannot fully exclude a concurrent duplicate (most reliably a
+// second on-demand admin-jobs HTTP trigger racing itself or the scheduler tick), so
+// the losing insert fails here with storage.ErrDuplicateReminderNotification
+// instead of creating a second unread reminder row. Callers treat that as a benign
+// duplicate-skip, not a failure.
 func (ls *LocalStorage) CreateNotification(ctx context.Context, n *models.Notification) (*models.Notification, error) {
 	if err := ls.db.WithContext(ctx).Create(n).Error; err != nil {
+		if isUniqueConstraintErr(err) {
+			return nil, fmt.Errorf("%w: %v", storage.ErrDuplicateReminderNotification, err)
+		}
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}
 	return n, nil


### PR DESCRIPTION
## Summary

- `RunRotationReminders`/`RunExpiryReminders` (`server/http/handlers/admin_jobs.go`) call `SendRotationReminders`/`SendExpiryReminders` directly with **no lock at all**, unlike the scheduled path (`server/main.go`), which runs under `WithSchedulerLock` (ADR-039, single-replica-gated). Two concurrent on-demand runs of the admin-jobs endpoint (or one racing the scheduler's own tick) against a project with no existing reminder can both pass the "does a reminder already exist" check-then-act read before either commits its `CreateNotification`, producing duplicate reminder rows. Most reliably reproducible against Postgres; SQLite's writer lock narrows but doesn't eliminate the window.
- Fixes this at the DB layer (preferred over a lock, per the campaign's established pattern — see `ensureDynamicSecretConfigNameIndex`/`ensureLegalHoldActiveIndex`): a new partial unique index `uniq_notifications_unread_reminder` on `notifications (user_id, type, project_id)`, scoped to unread `rotation.reminder`/`secret.expiry_reminder` rows only (other notification types legitimately create more than one unread notification per user/project, e.g. `secret.shared`).
- `CreateNotification` translates the resulting unique-constraint violation into `storage.ErrDuplicateReminderNotification` instead of a raw DB error.
- `notifyWithSeverity` now skips the out-of-band (email/webhook) dispatch when `CreateNotification` fails, mirroring `upgradeReminder`'s existing guard (#482) — otherwise the losing racer's benign duplicate-skip would still fire a duplicate external notification even though the DB insert didn't happen.

## Test plan

- [x] New concurrency regression test `TestConcurrency_SendRotationReminders_NoDuplicateReminder` (`internal/core/concurrency_rotation_reminder_test.go`): 30 goroutines call `SendRotationReminders` concurrently against a real file-backed SQLite DB (with the same partial unique index production installs, mirroring the existing `TestConcurrency_InviteMember_NoDuplicateActiveMembership` pattern), asserting exactly one unread `rotation.reminder` row survives.
- [x] Verified the test genuinely reproduces the race: with the `CREATE UNIQUE INDEX` line temporarily removed from the test, it failed 4/5 runs with a duplicate row (count=2); restored, it passed 10/10 runs under `-race`, with log output showing the DB actually rejecting the loser's insert (`UNIQUE constraint failed: notifications.user_id, notifications.type, notifications.project_id`).
- [x] `go build ./...`, `go vet ./...` clean.
- [x] `go test ./internal/core/... ./server/http/... ./internal/storage/... -run 'Rotation|Reminder|Notification|Notify|Concurrency' -race` — all pass.
- [x] `go test ./...` (full suite) — all pass.
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues.
- [x] `golangci-lint run` on touched packages — 0 issues.

🤖 Generated with Claude Code