### PR TITLE
fix(dynamic-secrets): count revoke_failed leases toward MaxActiveLeases (#411)

### DIFF
--- a/internal/core/dynamic_secrets_test.go
+++ b/internal/core/dynamic_secrets_test.go
@@ -234,6 +234,46 @@ func TestDynamicSecrets_MaxActiveLeasesCeiling(t *testing.T) {
 	require.NoError(t, err, "a slot opens after a revoke")
 }
 
+// #411: a lease stuck in revoke_failed still holds a live credential upstream (its
+// earlier revoke attempt failed on the target) — CountActiveLeases must count it toward
+// MaxActiveLeases exactly like an "active" lease, or an attacker (or ordinary backend
+// flakiness) could force revokes to fail at issue time and silently mint past the
+// configured ceiling forever, since every subsequent count would undercount the leftover
+// live credential.
+func TestDynamicSecrets_MaxActiveLeasesCeiling_CountsRevokeFailed(t *testing.T) {
+	c, _, fake, _ := newDynamicTestCore(t)
+	ctx := context.Background()
+	cfg, err := c.CreateDynamicSecretConfig(ctx, &CreateDynamicSecretConfigRequest{
+		Name: "capped-revoke-failed", ProjectID: 1, EnvironmentID: 2, BackendType: "postgres",
+		AdminDSN: adminDSNPlain, CreationTemplate: "GRANT SELECT TO {{name}};",
+		DefaultTTLSeconds: 3600, MaxActiveLeases: 1, CreatedBy: "alice", ActorID: testAdminActorID,
+	})
+	require.NoError(t, err)
+
+	// One lease is allowed at the ceiling of 1.
+	issued, err := c.IssueLease(ctx, cfg.ID, 0, 7)
+	require.NoError(t, err)
+
+	// Force its revoke to fail on the target — the lease is flagged revoke_failed but its
+	// credential is still live upstream.
+	fake.FailRevoke = true
+	require.Error(t, c.RevokeLease(ctx, issued.LeaseID, 7, "manual"))
+	lease, err := c.storage.GetDynamicSecretLease(ctx, issued.LeaseID)
+	require.NoError(t, err)
+	require.Equal(t, "revoke_failed", lease.Status, "precondition: the lease is stuck revoke_failed")
+
+	// CountActiveLeases must reflect the revoke_failed lease as still occupying a slot.
+	active, err := c.storage.CountActiveLeases(ctx, cfg.ID)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), active, "a revoke_failed lease still holds a live credential and must count toward the ceiling")
+
+	// With the sole slot occupied by the revoke_failed lease, issuing another must be
+	// refused — not silently allowed because the lease is no longer literally "active".
+	_, err = c.IssueLease(ctx, cfg.ID, 0, 7)
+	require.Error(t, err, "the ceiling must not be evadable by forcing a revoke to fail")
+	assert.Contains(t, err.Error(), "active-lease limit")
+}
+
 func TestDynamicSecrets_IssueListRevoke(t *testing.T) {
 	c, db, fake, _ := newDynamicTestCore(t)
 	ctx := context.Background()

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -733,8 +733,10 @@ type Storage interface {
 	CreateDynamicSecretLease(ctx context.Context, l *models.DynamicSecretLease) (*models.DynamicSecretLease, error)
 	GetDynamicSecretLease(ctx context.Context, leaseID string) (*models.DynamicSecretLease, error)
 	ListDynamicSecretLeases(ctx context.Context, configID uint) ([]*models.DynamicSecretLease, error)
-	// CountActiveLeases returns how many leases from configID are currently active —
-	// used to enforce the config's MaxActiveLeases ceiling.
+	// CountActiveLeases returns how many leases from configID still hold a live
+	// credential upstream — "active" AND "revoke_failed" (#411: a revoke_failed
+	// lease's earlier revoke attempt failed on the target, so the credential is
+	// still live) — used to enforce the config's MaxActiveLeases ceiling.
 	CountActiveLeases(ctx context.Context, configID uint) (int64, error)
 	UpdateDynamicSecretLease(ctx context.Context, l *models.DynamicSecretLease) error
 	ListExpiredActiveLeases(ctx context.Context, before time.Time) ([]*models.DynamicSecretLease, error)

--- a/internal/storage/store/local_dynamic.go
+++ b/internal/storage/store/local_dynamic.go
@@ -84,11 +84,17 @@ func (ls *LocalStorage) UpdateDynamicSecretLease(ctx context.Context, l *models.
 	return ls.db.WithContext(ctx).Save(l).Error
 }
 
-// CountActiveLeases returns the number of active leases for a config.
+// CountActiveLeases returns the number of leases for a config that still hold a live
+// credential upstream — status "active" AND "revoke_failed" (#411: a revoke_failed
+// lease's earlier revoke attempt failed on the target, so its credential is still live,
+// exactly the same "still live" reasoning ListExpiredActiveLeases documents above). An
+// active-only count would let an attacker (or ordinary backend flakiness) force revokes
+// to fail at issue time and silently exceed MaxActiveLeases forever, since every
+// subsequent ceiling check would undercount the leftover live credentials.
 func (ls *LocalStorage) CountActiveLeases(ctx context.Context, configID uint) (int64, error) {
 	var n int64
 	err := ls.db.WithContext(ctx).Model(&models.DynamicSecretLease{}).
-		Where("config_id = ? AND status = ?", configID, "active").Count(&n).Error
+		Where("config_id = ? AND status IN ?", configID, []string{"active", "revoke_failed"}).Count(&n).Error
 	return n, err
 }
 


### PR DESCRIPTION
## Summary
- `CountActiveLeases` filtered on `status = 'active'` only, excluding `revoke_failed` leases whose earlier revoke attempt failed on the target — meaning the credential is still live upstream. `ListExpiredActiveLeases` in the same file already documents this exact reasoning and includes both `active` and `revoke_failed` for the sweep.
- Because `IssueLease`'s `MaxActiveLeases` ceiling check is the only real caller of `CountActiveLeases`, an attacker (or ordinary backend flakiness) could force revokes to fail at issue time and silently mint past the configured ceiling forever, since every subsequent check would undercount the leftover live credentials.
- Fix: `CountActiveLeases` now counts `status IN ('active', 'revoke_failed')`, matching `ListExpiredActiveLeases`'s precedent. Updated the interface doc comment to match.
- Checked all callers repo-wide: the only production caller is `IssueLease`'s ceiling check (`internal/core/dynamic_secrets.go:263`), which wants both states counted. `RemoteStorage.CountActiveLeases` is unimplemented (`remoteUnsupported`), and the mock test stub is a fixed `0, nil` — neither is affected by the semantics change.

## Test plan
- [x] Added `TestDynamicSecrets_MaxActiveLeasesCeiling_CountsRevokeFailed`: issues a lease up to a ceiling of 1, forces its revoke to fail (`revoke_failed`), confirms `CountActiveLeases` still reports 1, and confirms a further `IssueLease` call is refused with "active-lease limit".
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/storage/... ./internal/core/... -run 'Lease|Dynamic' -v` — all pass
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues

🤖 Generated with Claude Code