### PR TITLE
fix(compliance): fold dynamic-configs/machine surfaces into data-classification control (#396)

### DIFF
--- a/internal/core/control_framework.go
+++ b/internal/core/control_framework.go
@@ -161,8 +161,8 @@ func EvaluateControls(p *CompliancePosture) []ControlState {
 		},
 		{
 			ID: "data-classification", Name: "Secret data classification", Area: "Asset management",
-			Status:     controlStatus(p.DegradedArea("classification:"), p.Classification.Unclassified > 0),
-			Detail:     fmt.Sprintf("%d of %d secrets unclassified", p.Classification.Unclassified, p.Classification.TotalSecrets),
+			Status:     classificationStatus(p),
+			Detail:     classificationDetail(p),
 			Frameworks: FrameworkRefs{ISO27001: []string{"A.5.12", "A.5.13"}, SOC2: []string{"CC3.2"}, ENS: []string{"mp.info.2"}},
 		},
 		{
@@ -258,6 +258,36 @@ func certificateHygieneDetail(p *CompliancePosture) string {
 		return fmt.Sprintf("certificate-expiry scanning not enabled — %d certificate(s) never evaluated", c.TotalCertificates)
 	}
 	return fmt.Sprintf("%d expired, %d expiring soon of %d certificate(s) (%d not yet evaluated)", c.Expired, c.ExpiringSoon, c.TotalCertificates, c.NotEvaluated)
+}
+
+// classificationTotals folds all four classifiable surfaces the posture already
+// collects — static secrets, dynamic-secret configs, machine identities, and
+// machine-token credentials — into one unclassified/total pair (#396). Before this,
+// the data-classification control only ever reflected
+// p.Classification.Unclassified/TotalSecrets (static secrets), so a deployment with a
+// perfectly-classified secret store but thousands of unclassified dynamic-secret
+// configs, machine identities, or machine credentials still reported a clean Pass —
+// those sub-counts were collected by classificationPosture but never folded into the
+// control's pass/fail decision.
+func classificationTotals(p *CompliancePosture) (unclassified, total int) {
+	c := p.Classification
+	unclassified = c.Unclassified + c.DynamicConfigs.Unclassified + c.MachineIdentities.Unclassified + c.MachineCredentials.Unclassified
+	total = c.TotalSecrets + c.DynamicConfigs.Total + c.MachineIdentities.Total + c.MachineCredentials.Total
+	return unclassified, total
+}
+
+// classificationStatus is Gap when any classifiable surface — static secrets,
+// dynamic-secret configs, machine identities, or machine-token credentials — has an
+// unclassified item (A.5.12). See classificationTotals for why all four surfaces
+// must be folded in rather than just static secrets (#396).
+func classificationStatus(p *CompliancePosture) ControlStatus {
+	unclassified, _ := classificationTotals(p)
+	return controlStatus(p.DegradedArea("classification:"), unclassified > 0)
+}
+
+func classificationDetail(p *CompliancePosture) string {
+	unclassified, total := classificationTotals(p)
+	return fmt.Sprintf("%d of %d classifiable items unclassified across secrets/dynamic-configs/machine-identities/machine-credentials", unclassified, total)
 }
 
 // statusFromBool maps an enabled flag to pass / not-configured (an unset optional

--- a/internal/core/control_framework_test.go
+++ b/internal/core/control_framework_test.go
@@ -71,6 +71,42 @@ func TestEvaluateControls_GapsFromPosture(t *testing.T) {
 	assert.Equal(t, ControlStatusNotConfigured, findControl(t, controls, "data-retention").Status)
 }
 
+// #396: the data-classification control must fold ALL FOUR classifiable surfaces —
+// static secrets, dynamic-secret configs, machine identities, and machine-token
+// credentials — into its pass/fail decision, not just static secrets. A deployment
+// with a perfectly-classified secret store but a pile of unclassified dynamic
+// configs / machine identities / machine credentials must report a Gap, never a
+// false Pass.
+func TestEvaluateControls_DataClassification_NonSecretSurfaces(t *testing.T) {
+	// Zero unclassified STATIC secrets, but each of the other three surfaces has an
+	// unclassified item.
+	p := &CompliancePosture{
+		Classification: ClassificationPosture{
+			TotalSecrets: 10, Unclassified: 0,
+			DynamicConfigs:     ClassificationCounts{Total: 5, Unclassified: 2},
+			MachineIdentities:  ClassificationCounts{Total: 3, Unclassified: 1},
+			MachineCredentials: ClassificationCounts{Total: 4, Unclassified: 1},
+		},
+	}
+	controls := EvaluateControls(p)
+	dc := findControl(t, controls, "data-classification")
+	assert.Equal(t, ControlStatusGap, dc.Status, "unclassified dynamic-configs/machine-identities/machine-credentials must gap the control even with 0 unclassified static secrets")
+	assert.Contains(t, dc.Detail, "4 of 22 classifiable items unclassified")
+	assert.Contains(t, dc.Detail, "secrets/dynamic-configs/machine-identities/machine-credentials")
+
+	// Fully clean across every surface stays Pass.
+	clean := EvaluateControls(&CompliancePosture{
+		Classification: ClassificationPosture{
+			TotalSecrets:       10,
+			DynamicConfigs:     ClassificationCounts{Total: 5},
+			MachineIdentities:  ClassificationCounts{Total: 3},
+			MachineCredentials: ClassificationCounts{Total: 4},
+		},
+	})
+	dcClean := findControl(t, clean, "data-classification")
+	assert.Equal(t, ControlStatusPass, dcClean.Status)
+}
+
 // Every ENS reference is a well-formed RD 311/2022 measure code: it names one of the
 // three measure frameworks (org. / op. / mp.) so the matrix can't carry a typo'd or
 // stray code that an auditor would reject.


### PR DESCRIPTION
## Summary

- `classificationPosture` in `internal/core/compliance_posture.go` already collects per-classification-level counts for `DynamicConfigs`, `MachineIdentities`, and `MachineCredentials` (in addition to static secrets), but the `data-classification` control in `internal/core/control_framework.go` only ever evaluated `Classification.Unclassified`/`TotalSecrets` — static secrets only.
- A deployment could have zero unclassified static secrets but thousands of unclassified dynamic-secret configs, machine identities, or machine credentials, and the control would still report a clean **Pass** (#396).
- Adds `classificationTotals`/`classificationStatus`/`classificationDetail` (mirroring the existing `certificateHygieneStatus`/`certificateHygieneDetail` pattern already used in the file) that fold all four classifiable surfaces into one unclassified/total pair, used for both the pass/gap decision and the detail text (now: `"N of M classifiable items unclassified across secrets/dynamic-configs/machine-identities/machine-credentials"`).
- No storage/query changes — the sub-counts were already being collected; they just weren't being folded into the control's evaluation.

## Test plan

- [x] Added `TestEvaluateControls_DataClassification_NonSecretSurfaces`: 0 unclassified static secrets + non-zero unclassified dynamic-configs/machine-identities/machine-credentials now reports **Gap** (previously would have been a false Pass); also asserts a fully-clean posture across all four surfaces stays **Pass**.
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/core/... -run 'Compliance|Control|Classification' -v`
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues

🤖 Generated with Claude Code