### PR TITLE
fix(retention): absolute-age safety net for unacknowledged anomaly alerts (#489)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -443,12 +443,23 @@ single-replica-gated (ADR-039). Two things it deliberately never deletes: the
 ```yaml
 data_retention:
   enabled: true
-  schedule: "24h"                     # Go duration between runs (default 24h)
-  anomaly_alerts_days: 90             # access-anomaly alerts, on detected_at
-  closed_access_reviews_days: 730     # closed recertification campaigns + items, on closed_at
-  break_glass_days: 365               # non-active emergency-access activations, on created_at
-  resolved_access_requests_days: 365  # terminal-state access requests + approvals, on resolved_at
+  schedule: "24h"                              # Go duration between runs (default 24h)
+  anomaly_alerts_days: 90                      # ACKNOWLEDGED access-anomaly alerts, on detected_at
+  anomaly_alerts_unacked_ceiling_days: 730     # UNACKNOWLEDGED alerts — generous absolute-age safety net
+  closed_access_reviews_days: 730              # closed recertification campaigns + items, on closed_at
+  break_glass_days: 365                        # non-active emergency-access activations, on created_at
+  resolved_access_requests_days: 365           # terminal-state access requests + approvals, on resolved_at
 ```
+
+`anomaly_alerts_days` only ages out alerts a human has already **acknowledged** — a
+never-acknowledged alert is still a live, unreviewed signal and is never purged by
+that window alone, no matter how old (#415). `anomaly_alerts_unacked_ceiling_days`
+is a separate, independent, and deliberately much longer window: a safety net so an
+alert stream nobody ever acknowledges cannot accumulate rows forever (a
+disk-exhaustion surface — the creation-time dedup window alone is trivially defeated
+by varying the secret/type/actor/IP). Set it generously (a year or more) so it only
+catches truly-ancient, almost-certainly-abandoned alerts, never a reasonable
+operational review backlog.
 
 The configured windows surface in the compliance posture (`keyorix compliance report`
 → "Data retention") as evidence that storage-limitation is actively enforced.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -769,7 +769,19 @@ type DataRetentionConfig struct {
 	Enabled  bool   `yaml:"enabled"`
 	Schedule string `yaml:"schedule"`
 	// AnomalyAlertsDays ages out resolved/old access-anomaly alerts on detected_at.
+	// Only ACKNOWLEDGED alerts are eligible (#415) — a never-acknowledged alert is
+	// still a live, unreviewed signal and survives this window regardless of age.
 	AnomalyAlertsDays int `yaml:"anomaly_alerts_days"`
+	// AnomalyAlertsUnackedCeilingDays is a separate, much more generous absolute-age
+	// safety net (#489) for alerts that are NEVER acknowledged: without it, an
+	// environment (or an actor deliberately triggering distinct anomalies to defeat
+	// the creation-time dedup window) accumulates unacknowledged alert rows forever,
+	// with no cap — a disk-exhaustion surface and an ever-slower ListAnomalyAlerts
+	// scan. This window is independent of, and does not weaken, AnomalyAlertsDays:
+	// it only catches alerts old enough that they are almost certainly abandoned, not
+	// a reasonable operational review backlog. 0 disables it (kept forever, the
+	// pre-#489 behavior).
+	AnomalyAlertsUnackedCeilingDays int `yaml:"anomaly_alerts_unacked_ceiling_days"`
 	// ClosedAccessReviewsDays ages out closed recertification campaigns (and their
 	// snapshot items) on closed_at. Open campaigns are never purged.
 	ClosedAccessReviewsDays int `yaml:"closed_access_reviews_days"`

--- a/internal/core/data_retention.go
+++ b/internal/core/data_retention.go
@@ -24,16 +24,23 @@ import (
 // compliance posture can share it without core importing the config package. Set
 // at startup via SetRetentionPolicy.
 type RetentionPolicy struct {
-	AnomalyAlertsDays          int
-	ClosedAccessReviewsDays    int
-	BreakGlassDays             int
-	ResolvedAccessRequestsDays int
+	AnomalyAlertsDays int
+	// AnomalyAlertsUnackedCeilingDays is a separate, more generous absolute-age
+	// safety net for alerts that are NEVER acknowledged (#489) — see
+	// config.DataRetentionConfig.AnomalyAlertsUnackedCeilingDays for the rationale.
+	// It does not replace or shorten AnomalyAlertsDays, which still gates only
+	// already-acknowledged alerts.
+	AnomalyAlertsUnackedCeilingDays int
+	ClosedAccessReviewsDays         int
+	BreakGlassDays                  int
+	ResolvedAccessRequestsDays      int
 }
 
 // Configured reports whether at least one retention window is active.
 func (p RetentionPolicy) Configured() bool {
-	return p.AnomalyAlertsDays > 0 || p.ClosedAccessReviewsDays > 0 ||
-		p.BreakGlassDays > 0 || p.ResolvedAccessRequestsDays > 0
+	return p.AnomalyAlertsDays > 0 || p.AnomalyAlertsUnackedCeilingDays > 0 ||
+		p.ClosedAccessReviewsDays > 0 || p.BreakGlassDays > 0 ||
+		p.ResolvedAccessRequestsDays > 0
 }
 
 // RetentionResult reports how many records each per-type retention purge removed.
@@ -68,8 +75,8 @@ func (c *KeyorixCore) SetRetentionPolicy(ctx context.Context, p RetentionPolicy)
 	c.emitAudit(ctx, &models.AuditEvent{
 		EventType: "data_retention.policy_configured",
 		Description: fmt.Sprintf(
-			"Data retention policy applied: anomaly_alerts=%dd closed_access_reviews=%dd break_glass=%dd resolved_access_requests=%dd",
-			p.AnomalyAlertsDays, p.ClosedAccessReviewsDays, p.BreakGlassDays, p.ResolvedAccessRequestsDays,
+			"Data retention policy applied: anomaly_alerts=%dd anomaly_alerts_unacked_ceiling=%dd closed_access_reviews=%dd break_glass=%dd resolved_access_requests=%dd",
+			p.AnomalyAlertsDays, p.AnomalyAlertsUnackedCeilingDays, p.ClosedAccessReviewsDays, p.BreakGlassDays, p.ResolvedAccessRequestsDays,
 		),
 		Success:   &ok,
 		ActorType: ActorTypeSystem,
@@ -108,8 +115,18 @@ func (c *KeyorixCore) PurgeExpiredComplianceRecords(ctx context.Context, now tim
 	}
 	cutoff := func(days int) time.Time { return now.AddDate(0, 0, -days) }
 
-	if policy.AnomalyAlertsDays > 0 {
-		n, err := c.storage.DeleteAnomalyAlertsBefore(ctx, cutoff(policy.AnomalyAlertsDays))
+	if policy.AnomalyAlertsDays > 0 || policy.AnomalyAlertsUnackedCeilingDays > 0 {
+		// Zero time.Time means "no bound" here — DeleteAnomalyAlertsBefore skips
+		// whichever clause is passed the zero value, so a type left at 0 in the
+		// policy is not silently treated as "purge everything before year 1".
+		var ackBefore, unackCeiling time.Time
+		if policy.AnomalyAlertsDays > 0 {
+			ackBefore = cutoff(policy.AnomalyAlertsDays)
+		}
+		if policy.AnomalyAlertsUnackedCeilingDays > 0 {
+			unackCeiling = cutoff(policy.AnomalyAlertsUnackedCeilingDays)
+		}
+		n, err := c.storage.DeleteAnomalyAlertsBefore(ctx, ackBefore, unackCeiling)
 		rec(err)
 		res.AnomalyAlerts = n
 	}

--- a/internal/core/data_retention_test.go
+++ b/internal/core/data_retention_test.go
@@ -13,14 +13,15 @@ import (
 func TestPurgeExpiredComplianceRecords_CountsCutoffsAndAudits(t *testing.T) {
 	now := time.Date(2026, 6, 14, 12, 0, 0, 0, time.UTC)
 	policy := RetentionPolicy{
-		AnomalyAlertsDays:          30,
-		ClosedAccessReviewsDays:    365,
-		BreakGlassDays:             90,
-		ResolvedAccessRequestsDays: 180,
+		AnomalyAlertsDays:               30,
+		AnomalyAlertsUnackedCeilingDays: 730,
+		ClosedAccessReviewsDays:         365,
+		BreakGlassDays:                  90,
+		ResolvedAccessRequestsDays:      180,
 	}
 	store := new(MockStorage)
 	store.On("GetActiveLegalHold", mock.Anything).Return(nil, nil) // no active legal hold
-	store.On("DeleteAnomalyAlertsBefore", mock.Anything, now.AddDate(0, 0, -30)).Return(int64(5), nil)
+	store.On("DeleteAnomalyAlertsBefore", mock.Anything, now.AddDate(0, 0, -30), now.AddDate(0, 0, -730)).Return(int64(5), nil)
 	store.On("DeleteClosedAccessReviewsBefore", mock.Anything, now.AddDate(0, 0, -365)).Return(int64(2), int64(7), nil)
 	store.On("DeleteExpiredBreakGlassBefore", mock.Anything, now.AddDate(0, 0, -90)).Return(int64(1), nil)
 	store.On("DeleteResolvedAccessRequestsBefore", mock.Anything, now.AddDate(0, 0, -180)).Return(int64(3), int64(4), nil)
@@ -62,7 +63,7 @@ func TestPurgeExpiredComplianceRecords_ZeroWindowsSkipped(t *testing.T) {
 	require.Equal(t, int64(0), res.Total())
 
 	// Disabled types are never queried, and a zero-purge run emits no audit event.
-	store.AssertNotCalled(t, "DeleteAnomalyAlertsBefore", mock.Anything, mock.Anything)
+	store.AssertNotCalled(t, "DeleteAnomalyAlertsBefore", mock.Anything, mock.Anything, mock.Anything)
 	store.AssertNotCalled(t, "DeleteClosedAccessReviewsBefore", mock.Anything, mock.Anything)
 	store.AssertNotCalled(t, "DeleteResolvedAccessRequestsBefore", mock.Anything, mock.Anything)
 	store.AssertNotCalled(t, "LogAuditEvent", mock.Anything, mock.Anything)
@@ -71,7 +72,27 @@ func TestPurgeExpiredComplianceRecords_ZeroWindowsSkipped(t *testing.T) {
 func TestRetentionPolicy_Configured(t *testing.T) {
 	require.False(t, RetentionPolicy{}.Configured())
 	require.True(t, RetentionPolicy{AnomalyAlertsDays: 1}.Configured())
+	require.True(t, RetentionPolicy{AnomalyAlertsUnackedCeilingDays: 1}.Configured())
 	require.True(t, RetentionPolicy{ResolvedAccessRequestsDays: 90}.Configured())
+}
+
+// #489: the unacked-ceiling window is independent of AnomalyAlertsDays — a policy
+// that only configures the ceiling (leaving the acknowledged-alert window at 0,
+// i.e. keep-forever) must still call through with a zero ackBefore (disabling that
+// clause) and the ceiling cutoff.
+func TestPurgeExpiredComplianceRecords_AnomalyUnackedCeilingOnly(t *testing.T) {
+	now := time.Date(2026, 6, 14, 12, 0, 0, 0, time.UTC)
+	policy := RetentionPolicy{AnomalyAlertsUnackedCeilingDays: 730}
+	store := new(MockStorage)
+	store.On("GetActiveLegalHold", mock.Anything).Return(nil, nil)
+	store.On("DeleteAnomalyAlertsBefore", mock.Anything, time.Time{}, now.AddDate(0, 0, -730)).Return(int64(2), nil)
+	store.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
+
+	c := NewKeyorixCore(store)
+	res, err := c.PurgeExpiredComplianceRecords(context.Background(), now, policy)
+	require.NoError(t, err)
+	require.Equal(t, int64(2), res.AnomalyAlerts)
+	store.AssertExpectations(t)
 }
 
 // #160: applying the retention policy at startup must leave an audit trail of the
@@ -80,10 +101,11 @@ func TestRetentionPolicy_Configured(t *testing.T) {
 // of the CHANGE itself.
 func TestSetRetentionPolicy_EmitsAuditEvent(t *testing.T) {
 	policy := RetentionPolicy{
-		AnomalyAlertsDays:          30,
-		ClosedAccessReviewsDays:    365,
-		BreakGlassDays:             90,
-		ResolvedAccessRequestsDays: 180,
+		AnomalyAlertsDays:               30,
+		AnomalyAlertsUnackedCeilingDays: 730,
+		ClosedAccessReviewsDays:         365,
+		BreakGlassDays:                  90,
+		ResolvedAccessRequestsDays:      180,
 	}
 	store := new(MockStorage)
 	var captured *models.AuditEvent
@@ -104,6 +126,7 @@ func TestSetRetentionPolicy_EmitsAuditEvent(t *testing.T) {
 	require.NotNil(t, captured.Success)
 	require.True(t, *captured.Success)
 	require.Contains(t, captured.Description, "anomaly_alerts=30d")
+	require.Contains(t, captured.Description, "anomaly_alerts_unacked_ceiling=730d")
 	require.Contains(t, captured.Description, "closed_access_reviews=365d")
 	require.Contains(t, captured.Description, "break_glass=90d")
 	require.Contains(t, captured.Description, "resolved_access_requests=180d")

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -524,8 +524,8 @@ func (m *MockStorage) PurgeDeletedSecretsBefore(ctx context.Context, before time
 	return args.Get(0).(int64), args.Error(1)
 }
 
-func (m *MockStorage) DeleteAnomalyAlertsBefore(ctx context.Context, before time.Time) (int64, error) {
-	args := m.Called(ctx, before)
+func (m *MockStorage) DeleteAnomalyAlertsBefore(ctx context.Context, ackBefore, unackCeiling time.Time) (int64, error) {
+	args := m.Called(ctx, ackBefore, unackCeiling)
 	return args.Get(0).(int64), args.Error(1)
 }
 

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -449,10 +449,15 @@ type Storage interface {
 	// (ISO A.5.33 / GDPR), returning the number removed. Unlike the soft-delete
 	// purge these age out live records by a time column, never touch active rows,
 	// and cascade to dependent rows where noted. Irreversible.
-	// DeleteAnomalyAlertsBefore only removes ALREADY-ACKNOWLEDGED alerts
-	// (detected_at < before AND acknowledged = true) — an old but never-acknowledged
-	// alert is still a live, unreviewed signal and is never purged by age alone.
-	DeleteAnomalyAlertsBefore(ctx context.Context, before time.Time) (int64, error)
+	// DeleteAnomalyAlertsBefore removes an anomaly alert when EITHER: it is
+	// ALREADY-ACKNOWLEDGED and detected_at < ackBefore (the normal, short window —
+	// an old but never-acknowledged alert is still a live, unreviewed signal and is
+	// never purged by this clause alone); OR it is unacknowledged and detected_at <
+	// unackCeiling, a separate and much more generous absolute-age safety net (#489)
+	// so an alert nobody ever acknowledges cannot accumulate forever (disk
+	// exhaustion / unbounded ListAnomalyAlerts scans). A zero time.Time for either
+	// parameter disables that clause entirely (matches it against nothing).
+	DeleteAnomalyAlertsBefore(ctx context.Context, ackBefore, unackCeiling time.Time) (int64, error)
 	// DeleteClosedAccessReviewsBefore removes closed campaigns (closed_at < before)
 	// and their snapshot items, returning (campaigns, items) removed.
 	DeleteClosedAccessReviewsBefore(ctx context.Context, before time.Time) (campaigns int64, items int64, err error)

--- a/internal/storage/store/local_purge.go
+++ b/internal/storage/store/local_purge.go
@@ -9,6 +9,7 @@ package store
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"gorm.io/gorm"
@@ -243,21 +244,49 @@ func (ls *LocalStorage) PurgeDeletedSecretsBefore(ctx context.Context, before ti
 // delete (no Unscoped needed). Active/open/pending rows are excluded by predicate
 // so an in-flight record is never destroyed by a too-short window.
 
-// DeleteAnomalyAlertsBefore hard-deletes anomaly alerts detected before the cutoff.
-// Unlike a plain age purge, this only removes ALREADY-ACKNOWLEDGED alerts
-// (Acknowledged = true) — matching every sibling purge in this section, which
-// excludes in-flight rows (open campaigns, active break-glass, pending access
-// requests) from age-based deletion. An old alert nobody has ever acknowledged is
-// exactly the in-flight case here: it is still a live, unreviewed security signal,
-// not a resolved record, so it stays until a human acknowledges it (or is handled
-// by some separate abandoned-alert mechanism, if one is ever added). Without this
-// gate, a retention window shorter than the real review cadence would silently
-// hard-delete a genuine, never-reviewed high-severity alert — and the compliance
-// dashboard would then report FEWER unacknowledged anomalies, masking the fact
-// that a real signal was destroyed rather than resolved.
-func (ls *LocalStorage) DeleteAnomalyAlertsBefore(ctx context.Context, before time.Time) (int64, error) {
+// DeleteAnomalyAlertsBefore hard-deletes anomaly alerts matching either of two
+// independent conditions:
+//
+//   - acknowledged = true AND detected_at < ackBefore — the normal, short
+//     retention window. Matching every sibling purge in this section, which
+//     excludes in-flight rows (open campaigns, active break-glass, pending access
+//     requests) from age-based deletion, an old alert nobody has ever acknowledged
+//     is exactly the in-flight case here: it is still a live, unreviewed security
+//     signal, not a resolved record, so it is NOT matched by this clause alone.
+//     Without this gate, a retention window shorter than the real review cadence
+//     would silently hard-delete a genuine, never-reviewed high-severity alert —
+//     and the compliance dashboard would then report FEWER unacknowledged
+//     anomalies, masking the fact that a real signal was destroyed rather than
+//     resolved.
+//   - acknowledged = false AND detected_at < unackCeiling — a separate, much more
+//     generous absolute-age safety net (#489). The creation-time dedup window
+//     (CreateAnomalyAlert) only collapses alerts sharing the same secret/type/
+//     actor/IP within an hour; varying any one of those fields defeats it, so
+//     without this ceiling an alert stream that is never acknowledged (or an
+//     actor deliberately triggering distinct anomalies) accumulates rows forever
+//     with no cap — a disk-exhaustion surface, and ListAnomalyAlerts scans grow
+//     correspondingly slower over time. unackCeiling is expected to be configured
+//     far longer than ackBefore precisely so it only catches truly-ancient,
+//     almost-certainly-abandoned alerts, never a reasonable operational backlog.
+//
+// A zero time.Time for either parameter disables that clause (it matches nothing,
+// rather than being misread as "purge everything before year 1").
+func (ls *LocalStorage) DeleteAnomalyAlertsBefore(ctx context.Context, ackBefore, unackCeiling time.Time) (int64, error) {
+	var conds []string
+	var args []interface{}
+	if !ackBefore.IsZero() {
+		conds = append(conds, "(acknowledged = ? AND detected_at < ?)")
+		args = append(args, true, ackBefore)
+	}
+	if !unackCeiling.IsZero() {
+		conds = append(conds, "(acknowledged = ? AND detected_at < ?)")
+		args = append(args, false, unackCeiling)
+	}
+	if len(conds) == 0 {
+		return 0, nil
+	}
 	result := ls.db.WithContext(ctx).
-		Where("acknowledged = ? AND detected_at < ?", true, before).
+		Where(strings.Join(conds, " OR "), args...).
 		Delete(&models.AnomalyAlert{})
 	if result.Error != nil {
 		return 0, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), result.Error)

--- a/internal/storage/store/local_retention_test.go
+++ b/internal/storage/store/local_retention_test.go
@@ -32,9 +32,9 @@ func TestDeleteAnomalyAlertsBefore(t *testing.T) {
 	require.NoError(t, ls.db.Create(&models.AnomalyAlert{ID: 1, DetectedAt: now.AddDate(0, 0, -40)}).Error)
 	require.NoError(t, ls.db.Create(&models.AnomalyAlert{ID: 2, DetectedAt: now.AddDate(0, 0, -5)}).Error)
 
-	n, err := ls.DeleteAnomalyAlertsBefore(ctx, now.AddDate(0, 0, -30))
+	n, err := ls.DeleteAnomalyAlertsBefore(ctx, now.AddDate(0, 0, -30), time.Time{})
 	require.NoError(t, err)
-	assert.Equal(t, int64(0), n, "neither alert is acknowledged, so nothing is purged regardless of age")
+	assert.Equal(t, int64(0), n, "neither alert is acknowledged, and the unacked ceiling is disabled (zero), so nothing is purged")
 
 	var remaining int64
 	require.NoError(t, ls.db.Model(&models.AnomalyAlert{}).Count(&remaining).Error)
@@ -55,9 +55,9 @@ func TestDeleteAnomalyAlertsBefore_SkipsUnacknowledged(t *testing.T) {
 		ID: 2, DetectedAt: now.AddDate(0, 0, -40), Acknowledged: false,
 	}).Error)
 
-	n, err := ls.DeleteAnomalyAlertsBefore(ctx, now.AddDate(0, 0, -30))
+	n, err := ls.DeleteAnomalyAlertsBefore(ctx, now.AddDate(0, 0, -30), time.Time{})
 	require.NoError(t, err)
-	assert.Equal(t, int64(1), n, "only the acknowledged, old alert is purged")
+	assert.Equal(t, int64(1), n, "only the acknowledged, old alert is purged; the unacked ceiling is disabled (zero)")
 
 	var remaining models.AnomalyAlert
 	require.NoError(t, ls.db.Where("id = ?", 2).First(&remaining).Error)
@@ -66,6 +66,67 @@ func TestDeleteAnomalyAlertsBefore_SkipsUnacknowledged(t *testing.T) {
 	var count int64
 	require.NoError(t, ls.db.Model(&models.AnomalyAlert{}).Where("id = ?", 1).Count(&count).Error)
 	assert.Equal(t, int64(0), count, "the acknowledged alert must be gone")
+}
+
+// #489: unacknowledged alerts must not accumulate forever. A separate, much more
+// generous absolute-age ceiling is a safety net independent of acknowledgment:
+// an unacknowledged alert younger than the ceiling survives (preserving the #415
+// guarantee that a reasonable operational backlog is never silently discarded),
+// but one older than the ceiling is purged (closing the disk-exhaustion / unbounded
+// ListAnomalyAlerts-scan surface). An acknowledged alert past the pre-existing,
+// much shorter acknowledged-retention window is purged exactly as before.
+func TestDeleteAnomalyAlertsBefore_UnackedCeilingSafetyNet(t *testing.T) {
+	ls := newRetentionTestStore(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	// Unacknowledged, well within the ceiling (e.g. a normal operational review
+	// backlog) — must survive.
+	require.NoError(t, ls.db.Create(&models.AnomalyAlert{
+		ID: 1, DetectedAt: now.AddDate(0, 0, -60), Acknowledged: false,
+	}).Error)
+	// Unacknowledged, older than the ceiling — truly ancient, almost certainly
+	// abandoned — must be purged by the new safety net.
+	require.NoError(t, ls.db.Create(&models.AnomalyAlert{
+		ID: 2, DetectedAt: now.AddDate(0, 0, -800), Acknowledged: false,
+	}).Error)
+	// Acknowledged, past the pre-existing (much shorter) acknowledged-retention
+	// window but well within the unacked ceiling — must still be purged as before
+	// (non-regression), via the acknowledged clause, not the ceiling clause.
+	require.NoError(t, ls.db.Create(&models.AnomalyAlert{
+		ID: 3, DetectedAt: now.AddDate(0, 0, -40), Acknowledged: true,
+	}).Error)
+	// Acknowledged, recent — within the acknowledged window — must survive.
+	require.NoError(t, ls.db.Create(&models.AnomalyAlert{
+		ID: 4, DetectedAt: now.AddDate(0, 0, -5), Acknowledged: true,
+	}).Error)
+
+	ackBefore := now.AddDate(0, 0, -30)     // acknowledged-alert retention window
+	unackCeiling := now.AddDate(0, 0, -730) // generous absolute-age safety net
+
+	n, err := ls.DeleteAnomalyAlertsBefore(ctx, ackBefore, unackCeiling)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), n, "the ancient-unacknowledged alert and the old-acknowledged alert are purged")
+
+	var remainingIDs []uint
+	require.NoError(t, ls.db.Model(&models.AnomalyAlert{}).Order("id").Pluck("id", &remainingIDs).Error)
+	assert.Equal(t, []uint{1, 4}, remainingIDs, "the recent-unacknowledged and recent-acknowledged alerts survive")
+}
+
+// #489: with the unacked ceiling disabled (zero value), behavior is unchanged from
+// pre-#489: an unacknowledged alert survives no matter how old it is.
+func TestDeleteAnomalyAlertsBefore_UnackedCeilingDisabledKeepsForever(t *testing.T) {
+	ls := newRetentionTestStore(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	require.NoError(t, ls.db.Create(&models.AnomalyAlert{
+		ID: 1, DetectedAt: now.AddDate(-5, 0, 0), Acknowledged: false,
+	}).Error)
+
+	n, err := ls.DeleteAnomalyAlertsBefore(ctx, now.AddDate(0, 0, -30), time.Time{})
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), n, "unacked ceiling disabled (zero) means unacknowledged alerts are kept forever, as before #489")
 }
 
 func TestDeleteClosedAccessReviewsBefore_CascadesItemsAndSkipsOpen(t *testing.T) {

--- a/internal/storage/store/remote_secrets.go
+++ b/internal/storage/store/remote_secrets.go
@@ -124,7 +124,7 @@ func (rs *RemoteStorage) PurgeDeletedSecretsBefore(_ context.Context, _ time.Tim
 }
 
 // Data-retention purges run server-side (the scheduler); not available remotely.
-func (rs *RemoteStorage) DeleteAnomalyAlertsBefore(_ context.Context, _ time.Time) (int64, error) {
+func (rs *RemoteStorage) DeleteAnomalyAlertsBefore(_ context.Context, _, _ time.Time) (int64, error) {
 	return 0, remoteUnsupported("DeleteAnomalyAlertsBefore")
 }
 

--- a/server/main.go
+++ b/server/main.go
@@ -51,8 +51,8 @@ import (
 	"github.com/keyorixhq/keyorix/internal/notifychan"
 	"github.com/keyorixhq/keyorix/internal/rotation"
 	samlpkg "github.com/keyorixhq/keyorix/internal/saml"
-	appstorage "github.com/keyorixhq/keyorix/internal/storage"
 	"github.com/keyorixhq/keyorix/internal/startup"
+	appstorage "github.com/keyorixhq/keyorix/internal/storage"
 	"github.com/keyorixhq/keyorix/internal/trust"
 	"github.com/keyorixhq/keyorix/server/grpc"
 	httpServer "github.com/keyorixhq/keyorix/server/http"
@@ -684,10 +684,11 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 	// reports them; the scheduler below drives the actual purge. Audited (#160) so a
 	// shortened window is on the record, not just its eventual purge counts.
 	coreService.SetRetentionPolicy(context.Background(), core.RetentionPolicy{
-		AnomalyAlertsDays:          cfg.DataRetention.AnomalyAlertsDays,
-		ClosedAccessReviewsDays:    cfg.DataRetention.ClosedAccessReviewsDays,
-		BreakGlassDays:             cfg.DataRetention.BreakGlassDays,
-		ResolvedAccessRequestsDays: cfg.DataRetention.ResolvedAccessRequestsDays,
+		AnomalyAlertsDays:               cfg.DataRetention.AnomalyAlertsDays,
+		AnomalyAlertsUnackedCeilingDays: cfg.DataRetention.AnomalyAlertsUnackedCeilingDays,
+		ClosedAccessReviewsDays:         cfg.DataRetention.ClosedAccessReviewsDays,
+		BreakGlassDays:                  cfg.DataRetention.BreakGlassDays,
+		ResolvedAccessRequestsDays:      cfg.DataRetention.ResolvedAccessRequestsDays,
 	})
 
 	// Wire the access-recertification cadence (A.5.18) so the posture flags overdue
@@ -922,17 +923,18 @@ func startHTTPServer(ctx context.Context, cfg *config.Config) error {
 	// touched (append-only). Runs only when at least one window is configured.
 	if cfg.DataRetention.Enabled {
 		policy := core.RetentionPolicy{
-			AnomalyAlertsDays:          cfg.DataRetention.AnomalyAlertsDays,
-			ClosedAccessReviewsDays:    cfg.DataRetention.ClosedAccessReviewsDays,
-			BreakGlassDays:             cfg.DataRetention.BreakGlassDays,
-			ResolvedAccessRequestsDays: cfg.DataRetention.ResolvedAccessRequestsDays,
+			AnomalyAlertsDays:               cfg.DataRetention.AnomalyAlertsDays,
+			AnomalyAlertsUnackedCeilingDays: cfg.DataRetention.AnomalyAlertsUnackedCeilingDays,
+			ClosedAccessReviewsDays:         cfg.DataRetention.ClosedAccessReviewsDays,
+			BreakGlassDays:                  cfg.DataRetention.BreakGlassDays,
+			ResolvedAccessRequestsDays:      cfg.DataRetention.ResolvedAccessRequestsDays,
 		}
 		if !policy.Configured() {
 			log.Printf("Data-retention scheduler enabled but no retention windows are set; nothing to purge")
 		} else {
 			interval := cfg.DataRetention.GetInterval()
-			log.Printf("Data-retention scheduler enabled: every %s (anomaly_alerts=%dd, closed_reviews=%dd, break_glass=%dd, access_requests=%dd; 0=keep)",
-				interval, policy.AnomalyAlertsDays, policy.ClosedAccessReviewsDays, policy.BreakGlassDays, policy.ResolvedAccessRequestsDays)
+			log.Printf("Data-retention scheduler enabled: every %s (anomaly_alerts=%dd, anomaly_alerts_unacked_ceiling=%dd, closed_reviews=%dd, break_glass=%dd, access_requests=%dd; 0=keep)",
+				interval, policy.AnomalyAlertsDays, policy.AnomalyAlertsUnackedCeilingDays, policy.ClosedAccessReviewsDays, policy.BreakGlassDays, policy.ResolvedAccessRequestsDays)
 			runScheduler(ctx, "data_retention", interval, func() middleware.SchedulerOutcome {
 				if legalHoldBlocks("Data-retention purge") {
 					return middleware.SchedulerSkipped


### PR DESCRIPTION
## Summary

Fixes backlog finding #489: `DeleteAnomalyAlertsBefore` (in `internal/storage/store/local_purge.go`) was fixed in an earlier round (#415) to never purge unacknowledged alerts by age alone — it only removes rows where `acknowledged = true AND detected_at < before`. That fix was correct on its own terms, but left it as the *only* purge path for `AnomalyAlert` rows, with **no absolute-age ceiling at all** for alerts that are never acknowledged.

The only other backstop is creation-time dedup (`CreateAnomalyAlert`) within a 1-hour window keyed on `(secret_node_id, alert_type, accessed_by, ip_address)` — trivially defeated by varying any one of those fields. An environment (or an actor deliberately triggering distinct anomalies) that never acknowledges alerts accumulates rows **forever**, with no cap: a disk-exhaustion surface, and `ListAnomalyAlerts` scans grow correspondingly slower over time.

## Fix

`DeleteAnomalyAlertsBefore` now purges an anomaly alert when EITHER:

- it's **acknowledged** and `detected_at < ackBefore` (unchanged, pre-existing, short window), OR
- it's **unacknowledged** and `detected_at < unackCeiling` — a new, separate, much more generous absolute-age safety net.

The new window is wired through the same opt-in, per-record-type-days convention every other retention window already uses in this codebase:

- `config.DataRetentionConfig.AnomalyAlertsUnackedCeilingDays` (yaml: `anomaly_alerts_unacked_ceiling_days`)
- `core.RetentionPolicy.AnomalyAlertsUnackedCeilingDays`
- Both wiring sites in `server/main.go` (posture reporting at startup + the scheduler)

`0` disables it (kept forever — matches pre-#489 behavior exactly), same as every sibling `*Days` field. It is independent of, and does not weaken or replace, the pre-existing `AnomalyAlertsDays` acknowledged-alert window. Set it generously (a year or more is the intent) so it only catches truly-ancient, almost-certainly-abandoned alerts — never a reasonable operational review backlog.

`compliance_posture.go`'s `RetentionPosture` (used by the compliance-dashboard/proto/CLI reporting surface) is deliberately left untouched — that's a separate, cosmetic reporting concern, not required for the security fix, and touching it would mean a proto regen for an unrelated surface.

## Testing

Extended `internal/storage/store/local_retention_test.go`:
- `TestDeleteAnomalyAlertsBefore_UnackedCeilingSafetyNet` — proves all three required invariants in one scenario: an unacknowledged alert younger than the ceiling survives; an unacknowledged alert older than the ceiling is purged; an acknowledged alert past the (shorter) acknowledged window is still purged as before.
- `TestDeleteAnomalyAlertsBefore_UnackedCeilingDisabledKeepsForever` — with the new field at its zero value, an ancient unacknowledged alert still survives (no behavior change for installs that don't configure it).
- Updated the two pre-existing tests for the new function signature.

Extended `internal/core/data_retention_test.go` for the `RetentionPolicy`/`PurgeExpiredComplianceRecords` wiring, including a case where only the new ceiling field is configured (not `AnomalyAlertsDays`).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/storage/... ./internal/core/... ./internal/config/... -count=1`
- [x] `gosec -severity medium -exclude-generated ./internal/storage/... ./internal/core/...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)