### PR TITLE
feat(compliance): add risk-exception-hygiene control (#395)

### DIFF
--- a/internal/core/compliance_posture.go
+++ b/internal/core/compliance_posture.go
@@ -140,6 +140,12 @@ type RetentionPosture struct {
 type RiskPosture struct {
 	ActiveExceptions int `json:"active_exceptions"`
 	ExpiringSoon     int `json:"expiring_soon"` // active exceptions expiring within the soon window
+	// Expired counts exceptions that have passed their expiry but are still marked
+	// non-revoked (#395) — a stale, never-renewed acceptance whose underlying risk is
+	// unmitigated again. These already drop out of ActiveExceptions above, so without
+	// this field a lapsed exception becomes invisible to compliance posture/evidence
+	// the instant it expires, rather than surfacing as a gap needing attention.
+	Expired int `json:"expired"`
 }
 
 // CertificatePosture reports certificate hygiene from the cached cert expiry (ADR-056).
@@ -253,9 +259,14 @@ type complianceSnapshot struct {
 	sodReport *SoDViolationsReport
 	sodErr    error
 
-	// riskExceptionsActive is ListRiskExceptions(ctx, true) — active-only exceptions.
-	riskExceptionsActive []*RiskExceptionView
-	riskExceptionsErr    error
+	// riskExceptionsActive and riskExceptionsExpired both come from the SAME single
+	// listRiskExceptionRows(ctx, true) read (#256) — active-only exceptions, and a
+	// count of non-revoked exceptions whose expiry has already passed (#395), i.e.
+	// stale acceptances that dropped out of riskExceptionsActive with no compliance
+	// visibility. One storage read, two derived views.
+	riskExceptionsActive  []*RiskExceptionView
+	riskExceptionsExpired int
+	riskExceptionsErr     error
 
 	// Per-project results, keyed by project ID.
 	campaignsByProject     map[uint][]*CampaignWithProgress
@@ -284,7 +295,18 @@ func (c *KeyorixCore) buildComplianceSnapshot(ctx context.Context) (*complianceS
 	snap.auditChain, snap.auditChainErr = c.VerifyAuditChain(ctx)
 	snap.rotationStatuses, snap.rotationErr = c.GetRotationStatus(ctx, nil, nil)
 	snap.sodReport, snap.sodErr = c.DetectSoDViolations(ctx)
-	snap.riskExceptionsActive, snap.riskExceptionsErr = c.ListRiskExceptions(ctx, true)
+	if views, err := c.listRiskExceptionRows(ctx, true); err == nil {
+		for _, v := range views {
+			switch v.Status {
+			case ExceptionStatusActive:
+				snap.riskExceptionsActive = append(snap.riskExceptionsActive, v)
+			case ExceptionStatusExpired:
+				snap.riskExceptionsExpired++
+			}
+		}
+	} else {
+		snap.riskExceptionsErr = err
+	}
 
 	for _, proj := range projects {
 		pid := proj.ID
@@ -399,8 +421,12 @@ func (c *KeyorixCore) compliancePostureFromSnapshot(ctx context.Context, snap *c
 	}
 
 	// Risk register — governed, time-bound exceptions (A.5.8). Derived from the same
-	// ListRiskExceptions(ctx, true) read as suppressExceptedSoDViolations above and as
-	// the evidence pack's RiskExceptions field — one query, three consumers.
+	// listRiskExceptionRows(ctx, true) read as suppressExceptedSoDViolations above and
+	// as the evidence pack's RiskExceptions field — one query, several consumers.
+	// Expired (#395) comes from that identical read: a stale, never-renewed exception
+	// means the risk it accepted is unmitigated again, so it must stay visible to the
+	// control matrix rather than silently reading as "no exceptions" the moment
+	// expiry passes.
 	if snap.riskExceptionsErr == nil {
 		active, soon := 0, 0
 		cutoff := c.now().Add(riskExpiringSoonWindow)
@@ -410,7 +436,7 @@ func (c *KeyorixCore) compliancePostureFromSnapshot(ctx context.Context, snap *c
 				soon++
 			}
 		}
-		p.Risk = RiskPosture{ActiveExceptions: active, ExpiringSoon: soon}
+		p.Risk = RiskPosture{ActiveExceptions: active, ExpiringSoon: soon, Expired: snap.riskExceptionsExpired}
 	} else {
 		p.degrade("risk", snap.riskExceptionsErr)
 	}

--- a/internal/core/control_framework.go
+++ b/internal/core/control_framework.go
@@ -195,6 +195,17 @@ func EvaluateControls(p *CompliancePosture) []ControlState {
 			Frameworks: FrameworkRefs{ISO27001: []string{"A.5.34"}, DORA: []string{"Art.12"}, ENS: []string{"mp.info.6"}},
 		},
 		{
+			ID: "risk-exception-hygiene", Name: "Risk-exception register hygiene (no stale, unrenewed acceptances)", Area: "Risk governance",
+			// #395: a risk exception is a governed, time-bound acceptance of a control
+			// gap — once it expires with no renewal or revocation, the risk it was
+			// excepting is unmitigated again. It simply drops out of ActiveExceptions
+			// at that point, so without this control an auditor has no visibility into
+			// the lapsed acceptance at all.
+			Status:     controlStatus(p.DegradedArea("risk"), p.Risk.Expired > 0),
+			Detail:     fmt.Sprintf("%d active exception(s), %d expired but not yet revoked/renewed", p.Risk.ActiveExceptions, p.Risk.Expired),
+			Frameworks: FrameworkRefs{ISO27001: []string{"A.5.8"}, SOC2: []string{"CC3.2"}, DORA: []string{"Art.6"}, ENS: []string{"org.3"}},
+		},
+		{
 			ID: "supply-chain-integrity", Name: "Software supply-chain integrity (signed, verifiable updates)", Area: "Supply chain",
 			Status:     supplyChainStatus(p),
 			Detail:     supplyChainDetail(p),

--- a/internal/core/control_framework_test.go
+++ b/internal/core/control_framework_test.go
@@ -140,6 +140,37 @@ func TestEvaluateControls_CertificateHygiene_ScanningNeverEnabled(t *testing.T) 
 	assert.Contains(t, cu.Detail, "not enabled")
 }
 
+// #395: a risk exception is a governed, time-bound acceptance of a control gap — once
+// it expires without renewal or revocation, the risk it was excepting is unmitigated
+// again. Zero exceptions, or exceptions that are all current, must pass; any
+// expired-but-not-yet-revoked exception must surface as a gap naming the count.
+func TestEvaluateControls_RiskExceptionHygiene(t *testing.T) {
+	none := EvaluateControls(&CompliancePosture{})
+	rn := findControl(t, none, "risk-exception-hygiene")
+	assert.Equal(t, ControlStatusPass, rn.Status)
+
+	current := EvaluateControls(&CompliancePosture{
+		Risk: RiskPosture{ActiveExceptions: 2, ExpiringSoon: 1, Expired: 0},
+	})
+	rc := findControl(t, current, "risk-exception-hygiene")
+	assert.Equal(t, ControlStatusPass, rc.Status, "all-current exceptions must not gap the control")
+
+	stale := EvaluateControls(&CompliancePosture{
+		Risk: RiskPosture{ActiveExceptions: 1, Expired: 3},
+	})
+	rs := findControl(t, stale, "risk-exception-hygiene")
+	assert.Equal(t, ControlStatusGap, rs.Status)
+	assert.Contains(t, rs.Detail, "3 expired but not yet revoked/renewed")
+
+	// A degraded expired-exception collection must surface as unknown, never a false
+	// pass just because Expired's zero value looks clean (#136).
+	degraded := EvaluateControls(&CompliancePosture{
+		DegradedReasons: []string{"risk: simulated db failure"},
+	})
+	rd := findControl(t, degraded, "risk-exception-hygiene")
+	assert.Equal(t, ControlStatusUnknown, rd.Status)
+}
+
 // Once the scan has evaluated at least one certificate, the control reflects the real
 // data: pass when none are expired, gap when at least one is.
 func TestEvaluateControls_CertificateHygiene_ScanningEnabled(t *testing.T) {

--- a/internal/core/risk_exceptions.go
+++ b/internal/core/risk_exceptions.go
@@ -89,10 +89,12 @@ func (c *KeyorixCore) CreateRiskException(ctx context.Context, actorID uint, tit
 	return created, nil
 }
 
-// ListRiskExceptions returns exceptions with their effective status. When activeOnly
-// is set, only currently-active (not revoked, not expired) exceptions are returned;
-// otherwise every non-revoked exception is returned (expired included, for history).
-func (c *KeyorixCore) ListRiskExceptions(ctx context.Context, activeOnly bool) ([]*RiskExceptionView, error) {
+// listRiskExceptionRows is the one storage read shared by ListRiskExceptions,
+// CountExpiredRiskExceptions, and the compliance snapshot's own risk-register
+// rollup: every row gets its effective status computed here, so a caller needing a
+// different slice of that status (active only, expired only, or every non-revoked
+// row) never has to re-query storage to get it (#256, #395).
+func (c *KeyorixCore) listRiskExceptionRows(ctx context.Context, activeOnly bool) ([]*RiskExceptionView, error) {
 	rows, err := c.storage.ListRiskExceptions(ctx, activeOnly) // activeOnly excludes revoked at storage
 	if err != nil {
 		return nil, err
@@ -100,13 +102,51 @@ func (c *KeyorixCore) ListRiskExceptions(ctx context.Context, activeOnly bool) (
 	now := c.now()
 	out := make([]*RiskExceptionView, 0, len(rows))
 	for _, e := range rows {
-		st := exceptionStatus(e, now)
-		if activeOnly && st != ExceptionStatusActive {
-			continue // storage dropped revoked; drop expired here too
-		}
-		out = append(out, &RiskExceptionView{RiskException: e, Status: st})
+		out = append(out, &RiskExceptionView{RiskException: e, Status: exceptionStatus(e, now)})
 	}
 	return out, nil
+}
+
+// ListRiskExceptions returns exceptions with their effective status. When activeOnly
+// is set, only currently-active (not revoked, not expired) exceptions are returned;
+// otherwise every non-revoked exception is returned (expired included, for history).
+func (c *KeyorixCore) ListRiskExceptions(ctx context.Context, activeOnly bool) ([]*RiskExceptionView, error) {
+	views, err := c.listRiskExceptionRows(ctx, activeOnly)
+	if err != nil {
+		return nil, err
+	}
+	if !activeOnly {
+		return views, nil
+	}
+	out := make([]*RiskExceptionView, 0, len(views))
+	for _, v := range views {
+		if v.Status == ExceptionStatusActive {
+			out = append(out, v) // storage dropped revoked; drop expired here too
+		}
+	}
+	return out, nil
+}
+
+// CountExpiredRiskExceptions returns how many stored risk exceptions have passed
+// their expiry but are still marked non-revoked — i.e. a governed acceptance whose
+// sunset came and went with no renewal or explicit revocation (#395). The risk it
+// was excepting is unmitigated again the moment expiry passes, but without this
+// count the compliance matrix has no visibility into that: the exception simply
+// drops out of the "active" tally (see ListRiskExceptions/CountActiveRiskExceptions)
+// as if it had never existed, rather than surfacing as a stale acceptance an
+// auditor needs to see.
+func (c *KeyorixCore) CountExpiredRiskExceptions(ctx context.Context) (int, error) {
+	views, err := c.listRiskExceptionRows(ctx, true) // excludes revoked; expiry computed here
+	if err != nil {
+		return 0, err
+	}
+	expired := 0
+	for _, v := range views {
+		if v.Status == ExceptionStatusExpired {
+			expired++
+		}
+	}
+	return expired, nil
 }
 
 // RevokeRiskException withdraws an exception before its expiry. actorID is the admin.

--- a/internal/core/risk_exceptions_test.go
+++ b/internal/core/risk_exceptions_test.go
@@ -156,3 +156,35 @@ func TestCountActiveRiskExceptions(t *testing.T) {
 	assert.Equal(t, 2, active)
 	assert.Equal(t, 1, soon)
 }
+
+// #395: an exception past its expiry but still non-revoked counts as expired,
+// distinct from a genuinely-active one — it dropped out of the active tally with no
+// other signal that its accepted risk is unmitigated again.
+func TestCountExpiredRiskExceptions(t *testing.T) {
+	now := time.Date(2026, 6, 14, 0, 0, 0, 0, time.UTC)
+	store := new(MockStorage)
+	store.On("ListRiskExceptions", mock.Anything, true).Return([]*models.RiskException{
+		{ID: 1, ExpiresAt: now.AddDate(0, 0, 3)},   // active, not expired
+		{ID: 2, ExpiresAt: now.AddDate(0, 0, -1)},  // expired, still non-revoked
+		{ID: 3, ExpiresAt: now.AddDate(0, 0, -30)}, // expired, still non-revoked
+	}, nil)
+
+	c := riskCore(store, now)
+	expired, err := c.CountExpiredRiskExceptions(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 2, expired)
+}
+
+// Zero stored exceptions, or exceptions that are all current, count zero expired.
+func TestCountExpiredRiskExceptions_NoneExpired(t *testing.T) {
+	now := time.Date(2026, 6, 14, 0, 0, 0, 0, time.UTC)
+	store := new(MockStorage)
+	store.On("ListRiskExceptions", mock.Anything, true).Return([]*models.RiskException{
+		{ID: 1, ExpiresAt: now.AddDate(0, 0, 3)},
+	}, nil)
+
+	c := riskCore(store, now)
+	expired, err := c.CountExpiredRiskExceptions(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 0, expired)
+}


### PR DESCRIPTION
## Summary
- #395: the compliance control matrix has no control for the risk-exception register — an expired, never-renewed risk exception (revoked=false, expiry passed) silently drops out of `RiskPosture.ActiveExceptions` and becomes invisible to compliance posture/evidence, even though the risk it was excepting is unmitigated again.
- Add `RiskPosture.Expired`, derived from the same single risk-exceptions storage read already shared by `suppressExceptedSoDViolations` and the evidence pack's `RiskExceptions` field, preserving the #256 "exactly once per generation" snapshot invariant (verified by the existing `TestGenerateComplianceEvidence_RiskExceptionsConsistentWithPostureAcrossConcurrentChange` test).
- Add a new `risk-exception-hygiene` control (ISO 27001 A.5.8 / SOC2 CC3.2 / DORA Art.6 / ENS org.3) that gaps whenever any stale, unrenewed exception exists, naming the count in its detail; correctly surfaces `unknown` (not a false pass) if the underlying read is degraded.

## Files touched
- `internal/core/risk_exceptions.go`: factor the shared row-fetch into `listRiskExceptionRows`; add `CountExpiredRiskExceptions`.
- `internal/core/compliance_posture.go`: add `RiskPosture.Expired`; derive both active-exception views and the expired count from one snapshot read.
- `internal/core/control_framework.go`: new `risk-exception-hygiene` control entry.
- `internal/core/control_framework_test.go`, `internal/core/risk_exceptions_test.go`: new tests.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/core/... -run 'Compliance|Control|RiskException' -v` (all pass, including the pre-existing single-read invariant test)
- [x] `go test ./internal/core/...` (full package suite passes)
- [x] `gosec -severity medium -exclude-generated ./internal/core/...` — 0 issues
- New tests: zero/all-current exceptions pass the control; an expired-but-active exception gaps it and names the count; a degraded underlying read surfaces as unknown.

🤖 Generated with Claude Code