### PR TITLE
fix(storage): add missing companion indexes for raw-SQL-added columns on upgraded installs

### DIFF
--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -380,6 +380,19 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 	if tableExists(db, "secret_nodes") && !columnExists(db, "secret_nodes", "classification") {
 		db.Exec("ALTER TABLE secret_nodes ADD COLUMN classification TEXT DEFAULT ''")
 	}
+	// Companion index: models.SecretNode.Classification carries `gorm:"index"`, so a
+	// fresh AutoMigrate-created install already gets this index automatically, but an
+	// upgraded install only ever reaches the column via the raw ALTER above (AutoMigrate
+	// never re-diffs an existing table's indexes here), so it would otherwise never gain
+	// the index and classification-filtered queries would degrade to a full table scan
+	// as secret_nodes grows. Gated on tableExists only (not columnExists) so it also
+	// converges an install that already has the column from an older deploy of this
+	// migration but predates this index. CREATE INDEX IF NOT EXISTS is idempotent, so
+	// running it unconditionally on every boot (matching the ensure*Index helpers below)
+	// is cheap once the index is in place.
+	if tableExists(db, "secret_nodes") {
+		db.Exec("CREATE INDEX IF NOT EXISTS idx_secret_nodes_classification ON secret_nodes (classification)")
+	}
 	// ADR-046: automated rotation opt-in. Additive auto_rotate (false = off).
 	if tableExists(db, "secret_nodes") && !columnExists(db, "secret_nodes", "auto_rotate") {
 		db.Exec("ALTER TABLE secret_nodes ADD COLUMN auto_rotate BOOLEAN NOT NULL DEFAULT false")
@@ -403,10 +416,20 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 		if !columnExists(db, "secret_nodes", "cert_not_after") {
 			db.Exec("ALTER TABLE secret_nodes ADD COLUMN cert_not_after TIMESTAMP WITH TIME ZONE")
 		}
+		// Companion index (models.SecretNode.CertNotAfter is `gorm:"index"`); see the
+		// classification companion-index comment above for why this runs unconditionally
+		// (gated on the table only) rather than nested inside the ALTER guard above.
+		db.Exec("CREATE INDEX IF NOT EXISTS idx_secret_nodes_cert_not_after ON secret_nodes (cert_not_after)")
 	}
 	// Anomaly alerting: additive `alerted` flag (false = not yet pushed out).
 	if tableExists(db, "anomaly_alerts") && !columnExists(db, "anomaly_alerts", "alerted") {
 		db.Exec("ALTER TABLE anomaly_alerts ADD COLUMN alerted BOOLEAN DEFAULT FALSE")
+	}
+	// Companion index (models.AnomalyAlert.Alerted is `gorm:"default:false;index"`); see
+	// the secret_nodes.classification companion-index comment above for why this is
+	// gated on the table only, not on the ALTER above having just run.
+	if tableExists(db, "anomaly_alerts") {
+		db.Exec("CREATE INDEX IF NOT EXISTS idx_anomaly_alerts_alerted ON anomaly_alerts (alerted)")
 	}
 
 	// Track last successful login per user (nil = never logged in).
@@ -494,6 +517,15 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 		if !columnExists(db, "audit_events", "entry_hash") {
 			db.Exec("ALTER TABLE audit_events ADD COLUMN entry_hash TEXT NOT NULL DEFAULT ''")
 		}
+		// Companion indexes (models.AuditEvent.PrevHash/EntryHash are both
+		// `gorm:"index"`). VerifyAuditChain walks this hash chain as a security
+		// control; without these an upgraded install's audit_events table degrades
+		// to a full table scan on every chain verification as it grows, risking the
+		// check being skipped operationally once it gets too slow to run regularly.
+		// Gated on the table only, not the ALTERs above — see the
+		// secret_nodes.classification companion-index comment for why.
+		db.Exec("CREATE INDEX IF NOT EXISTS idx_audit_events_prev_hash ON audit_events (prev_hash)")
+		db.Exec("CREATE INDEX IF NOT EXISTS idx_audit_events_entry_hash ON audit_events (entry_hash)")
 	}
 
 	// Impersonation sessions carry the initiating admin + start time.
@@ -623,6 +655,12 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 		if tableExists(db, "dynamic_secret_configs") && !columnExists(db, "dynamic_secret_configs", "classification") {
 			db.Exec("ALTER TABLE dynamic_secret_configs ADD COLUMN classification TEXT DEFAULT ''")
 		}
+		// Companion index (models.DynamicSecretConfig.Classification is `gorm:"index"`);
+		// this whole branch only runs when dynamic_secret_configs already existed (the
+		// upgrade path — a fresh install's AutoMigrate call below already creates the
+		// index), so it's safe to run unconditionally here rather than nesting inside
+		// the ALTER guard above — see the secret_nodes.classification comment for why.
+		db.Exec("CREATE INDEX IF NOT EXISTS idx_dynamic_secret_configs_classification ON dynamic_secret_configs (classification)")
 		// Disabled (#369): refuses new leases once the owning project is soft-deleted.
 		// Additive (defaults false = every pre-existing config stays enabled).
 		if !m.HasColumn(&models.DynamicSecretConfig{}, "Disabled") {
@@ -813,9 +851,17 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 		if err := db.AutoMigrate(&models.MachineIdentity{}); err != nil {
 			return fmt.Errorf("failed to migrate machine_identities table: %w", err)
 		}
-	} else if !columnExists(db, "machine_identities", "classification") {
-		// Data classification (ISO A.5.12). Additive ("" = unclassified).
-		db.Exec("ALTER TABLE machine_identities ADD COLUMN classification TEXT DEFAULT ''")
+	} else {
+		if !columnExists(db, "machine_identities", "classification") {
+			// Data classification (ISO A.5.12). Additive ("" = unclassified).
+			db.Exec("ALTER TABLE machine_identities ADD COLUMN classification TEXT DEFAULT ''")
+		}
+		// Companion index (models.MachineIdentity.Classification is `gorm:"index"`);
+		// this else branch only runs on the upgrade path (a fresh install's
+		// AutoMigrate call above already creates the index) — see the
+		// secret_nodes.classification comment for why this runs unconditionally
+		// rather than nested inside the ALTER guard.
+		db.Exec("CREATE INDEX IF NOT EXISTS idx_machine_identities_classification ON machine_identities (classification)")
 	}
 
 	// Create machine-token tables if missing (ADR-030, additive, safe on existing DBs).
@@ -823,8 +869,14 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 		if err := db.AutoMigrate(&models.MachineIdentityCredential{}); err != nil {
 			return fmt.Errorf("failed to migrate machine_identity_credentials table: %w", err)
 		}
-	} else if !columnExists(db, "machine_identity_credentials", "classification") {
-		db.Exec("ALTER TABLE machine_identity_credentials ADD COLUMN classification TEXT DEFAULT ''")
+	} else {
+		if !columnExists(db, "machine_identity_credentials", "classification") {
+			db.Exec("ALTER TABLE machine_identity_credentials ADD COLUMN classification TEXT DEFAULT ''")
+		}
+		// Companion index (models.MachineIdentityCredential.Classification is
+		// `gorm:"index"`); see the machine_identities.classification comment above
+		// for why this runs unconditionally in this (upgrade-only) branch.
+		db.Exec("CREATE INDEX IF NOT EXISTS idx_machine_identity_credentials_classification ON machine_identity_credentials (classification)")
 	}
 	if !machineRoleExists {
 		if err := db.AutoMigrate(&models.MachineIdentityRole{}); err != nil {

--- a/internal/storage/factory_companion_index_test.go
+++ b/internal/storage/factory_companion_index_test.go
@@ -1,0 +1,84 @@
+package storage
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCompanionIndexes_CreatedOnUpgrade pins the gap left behind by the #490/#761
+// columnExists/tableExists SQLite fix: several columns models/models.go tags
+// `gorm:"index"` are added to an EXISTING table only via a raw `ALTER TABLE ADD
+// COLUMN` (gated on columnExists), never through AutoMigrate — migrateDatabase's
+// full, struct-driven `db.AutoMigrate(...)` block only ever runs once, on a
+// genuinely fresh install (`if projectsExists { return nil }` short-circuits it
+// for every upgrade). A fresh install therefore gets the companion index for
+// free via AutoMigrate; an upgraded install previously never did, silently
+// degrading classification/certificate-expiry/audit-chain queries to full table
+// scans as these tables grow.
+//
+// Simulate an upgraded install by: booting once against a fresh file (which
+// creates the full, fully-indexed schema, exactly like any real fresh install),
+// dropping just the target companion index to stand in for "this deployment
+// predates the fix that added it" (the column, added many releases ago via the
+// same raw-ALTER path, is already present either way), then re-running
+// migrateDatabase directly against the same *gorm.DB — the exact call a second
+// process boot makes — and confirming the companion index re-converges.
+func TestCompanionIndexes_CreatedOnUpgrade(t *testing.T) {
+	// idxName -> the table it lives on, purely for the DROP INDEX statement
+	// (SQLite's DROP INDEX takes only the index name, but this documents intent).
+	cases := []struct {
+		name    string
+		idxName string
+	}{
+		{"secret_nodes.classification", "idx_secret_nodes_classification"},
+		{"secret_nodes.cert_not_after", "idx_secret_nodes_cert_not_after"},
+		{"machine_identities.classification", "idx_machine_identities_classification"},
+		{"machine_identity_credentials.classification", "idx_machine_identity_credentials_classification"},
+		{"dynamic_secret_configs.classification", "idx_dynamic_secret_configs_classification"},
+		{"anomaly_alerts.alerted", "idx_anomaly_alerts_alerted"},
+		// ADR-029 tamper-evidence hash chain — the highest-stakes case: VerifyAuditChain
+		// is a security control, and an unindexed prev_hash/entry_hash lookup degrading
+		// to a full table scan as audit_events grows risks the check being skipped
+		// operationally once it's too slow to run regularly.
+		{"audit_events.prev_hash", "idx_audit_events_prev_hash"},
+		{"audit_events.entry_hash", "idx_audit_events_entry_hash"},
+	}
+
+	dbPath := filepath.Join(t.TempDir(), "companion-index.db")
+	db, err := gormOpenForTest(t, dbPath)
+	require.NoError(t, err)
+
+	f := &DefaultStorageFactory{}
+
+	// First boot: a genuinely fresh database. projects doesn't exist yet, so the
+	// full AutoMigrate block runs and creates every table (including secret_nodes,
+	// audit_events, machine_identities, etc.) with all of their `gorm:"index"`
+	// companion indexes already in place — the fresh-install baseline.
+	require.NoError(t, f.migrateDatabase(db))
+
+	for _, tc := range cases {
+		assert.True(t, indexExists(db, tc.idxName), "%s: fresh install must already have this index via AutoMigrate", tc.name)
+	}
+
+	// Drop every companion index under test, standing in for an install that
+	// upgraded through the raw-ALTER-only path in an older binary that predates
+	// this fix (column present, index never created).
+	for _, tc := range cases {
+		require.NoError(t, db.Exec("DROP INDEX "+tc.idxName).Error, "failed to drop %s to simulate a pre-fix upgraded install", tc.idxName)
+		require.False(t, indexExists(db, tc.idxName), "%s: index must actually be gone before re-running the migration", tc.name)
+	}
+
+	// Second run: mirrors exactly what a real process boot does on an existing
+	// (projects table present) database — migrateDatabase takes the
+	// columnExists-gated raw-ALTER path for every column above (the column is
+	// already present, so no ALTER runs), and must independently re-create each
+	// companion index.
+	require.NoError(t, f.migrateDatabase(db))
+
+	for _, tc := range cases {
+		assert.True(t, indexExists(db, tc.idxName), "%s: companion index must be re-created on an upgraded install, not just a fresh one", tc.name)
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up to #761 (#490). That fix corrected `columnExists`/`tableExists` to branch by SQL dialect instead of silently returning `false` on SQLite. Auditing the fallout surfaced a distinct gap: several columns whose struct tag in `internal/storage/models/models.go` carries `gorm:"index"` are added to an **existing** table only via `migrateDatabase`'s raw `ALTER TABLE ADD COLUMN` path — which never calls `AutoMigrate` against a pre-existing table (`migrateDatabase` short-circuits its struct-driven `AutoMigrate` block once `projects` already exists) and so never creates the companion index a **fresh** install gets automatically.

Net effect: an upgraded (not freshly-installed) deployment permanently lacked these indexes even after upgrading past the version that added the column, degrading classification/certificate-expiry/audit-chain-verification queries to full table scans as these tables grow — most notably `VerifyAuditChain` (ADR-029), a security control that risks being skipped operationally if it becomes too slow to run regularly.

- Columns confirmed to have `gorm:"index"` **and** be added via a raw ALTER on an existing table (all fixed):
  - `secret_nodes.classification` → `idx_secret_nodes_classification`
  - `secret_nodes.cert_not_after` → `idx_secret_nodes_cert_not_after`
  - `dynamic_secret_configs.classification` → `idx_dynamic_secret_configs_classification`
  - `machine_identities.classification` → `idx_machine_identities_classification`
  - `machine_identity_credentials.classification` → `idx_machine_identity_credentials_classification`
  - `anomaly_alerts.alerted` → `idx_anomaly_alerts_alerted`
  - `audit_events.prev_hash` → `idx_audit_events_prev_hash`
  - `audit_events.entry_hash` → `idx_audit_events_entry_hash`
- Each gets a `CREATE INDEX IF NOT EXISTS <name> ON <table> (<column>)` immediately after its ALTER block, matching this file's existing plain-`IF NOT EXISTS` idempotency convention (mirrors the `CREATE UNIQUE INDEX IF NOT EXISTS` pattern already used by the `ensure*Index` helpers) and GORM's own default `idx_<table>_<column>` naming, so fresh and upgraded schemas converge on the *same* index — verified against GORM's `NamingStrategy.IndexName`.
- Gated on the table's existence only (not on the column having just been added by the ALTER above), so it also converges installs that already picked up the column from an older release but predate this fix. `CREATE INDEX IF NOT EXISTS` is cheap/idempotent to re-run on every boot.

## Test plan
- [x] New test `TestCompanionIndexes_CreatedOnUpgrade` in `internal/storage/factory_companion_index_test.go`: boots against a fresh DB (confirms AutoMigrate already creates each index), drops each index to simulate a pre-fix upgraded install, re-runs `migrateDatabase` directly, and confirms every companion index (including both `audit_events` hash-chain indexes) is re-created.
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/storage/... -run 'Index|Migrate' -v` and full `go test ./internal/storage/...`
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues

🤖 Generated with Claude Code