### PR TITLE
feat(compliance): surface access-request/approval workflow in posture + evidence (#257)

### DIFF
--- a/internal/core/compliance_evidence.go
+++ b/internal/core/compliance_evidence.go
@@ -59,6 +59,9 @@ type ComplianceEvidence struct {
 	RotationOverdue []EvidenceRotation             `json:"rotation_overdue"`
 	SoDViolations   []SoDViolation                 `json:"sod_violations"`
 	RiskExceptions  []*RiskExceptionView           `json:"risk_exceptions"` // active governed exceptions (A.5.8)
+	// AccessRequests is every project access request (dual-control workflow, #257),
+	// across all projects — the record set the AccessRequests posture rollup counts.
+	AccessRequests []*models.AccessRequest `json:"access_requests"`
 }
 
 // GenerateComplianceEvidence assembles the evidence pack. Like the posture, it is an
@@ -90,6 +93,7 @@ func (c *KeyorixCore) GenerateComplianceEvidence(ctx context.Context) (*Complian
 		RotationOverdue: []EvidenceRotation{},
 		SoDViolations:   []SoDViolation{},
 		RiskExceptions:  []*RiskExceptionView{},
+		AccessRequests:  []*models.AccessRequest{},
 	}
 
 	// Active risk exceptions (the governed-acceptance register) — the snapshot's one
@@ -171,6 +175,11 @@ func (c *KeyorixCore) GenerateComplianceEvidence(ctx context.Context) (*Complian
 			ev.BreakGlass = append(ev.BreakGlass, acts...)
 		} else {
 			posture.degrade(fmt.Sprintf("evidence:break_glass:project=%d", pid), err)
+		}
+		if reqs, err := snap.accessRequestsByProject[pid], snap.accessRequestsErrByProject[pid]; err == nil {
+			ev.AccessRequests = append(ev.AccessRequests, reqs...)
+		} else {
+			posture.degrade(fmt.Sprintf("evidence:access_requests:project=%d", pid), err)
 		}
 	}
 	return ev, nil

--- a/internal/core/compliance_posture.go
+++ b/internal/core/compliance_posture.go
@@ -63,6 +63,28 @@ type EmergencyAccessPosture struct {
 	TotalActivations  int `json:"total_activations"`
 }
 
+// AccessRequestPosture summarises the dual-control access-request/approval workflow
+// (ADR-024, ISO 27001 A.5.3): how many project access requests exist and in what
+// state, across the deployment. The dual-control invariants themselves — a
+// requester can never approve their own request (maker != checker), and a distinct
+// approver can only sign off once, with the role granted only once
+// RequiredApprovals distinct approvers have done so — are already enforced by
+// ApproveAccessRequestWithExpiry (internal/core/invitations.go); this rollup gives
+// an auditor visibility into the counts that workflow produces, not new
+// enforcement (#257).
+type AccessRequestPosture struct {
+	TotalRequests int `json:"total_requests"`
+	Pending       int `json:"pending"`
+	Approved      int `json:"approved"`
+	Rejected      int `json:"rejected"`
+	Withdrawn     int `json:"withdrawn"`
+	Expired       int `json:"expired"`
+	// RequiredApprovals is the currently-configured N-of-M dual-control threshold
+	// (SetDualControlPolicy): >1 means at least two distinct approvers — never the
+	// requester — must sign off before a request's role grant lands.
+	RequiredApprovals int `json:"required_approvals"`
+}
+
 // LegalHoldPosture reports whether a litigation/investigation hold is in effect
 // (ISO 27001 A.5.34) — while active the purge jobs preserve all records.
 type LegalHoldPosture struct {
@@ -167,6 +189,7 @@ type CompliancePosture struct {
 	Rotation         RotationPosture         `json:"rotation"`
 	Identity         IdentityPosture         `json:"identity"`
 	EmergencyAccess  EmergencyAccessPosture  `json:"emergency_access"`
+	AccessRequests   AccessRequestPosture    `json:"access_requests"`
 	Classification   ClassificationPosture   `json:"classification"`
 	Anomalies        AnomaliesPosture        `json:"anomalies"`
 	LegalHold        LegalHoldPosture        `json:"legal_hold"`
@@ -258,10 +281,12 @@ type complianceSnapshot struct {
 	riskExceptionsErr    error
 
 	// Per-project results, keyed by project ID.
-	campaignsByProject     map[uint][]*CampaignWithProgress
-	campaignsErrByProject  map[uint]error
-	breakGlassByProject    map[uint][]*models.BreakGlassActivation
-	breakGlassErrByProject map[uint]error
+	campaignsByProject         map[uint][]*CampaignWithProgress
+	campaignsErrByProject      map[uint]error
+	breakGlassByProject        map[uint][]*models.BreakGlassActivation
+	breakGlassErrByProject     map[uint]error
+	accessRequestsByProject    map[uint][]*models.AccessRequest
+	accessRequestsErrByProject map[uint]error
 }
 
 // buildComplianceSnapshot fetches every shared sub-query once. ListProjects is the
@@ -274,11 +299,13 @@ func (c *KeyorixCore) buildComplianceSnapshot(ctx context.Context) (*complianceS
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
 	}
 	snap := &complianceSnapshot{
-		projects:               projects,
-		campaignsByProject:     make(map[uint][]*CampaignWithProgress, len(projects)),
-		campaignsErrByProject:  make(map[uint]error, len(projects)),
-		breakGlassByProject:    make(map[uint][]*models.BreakGlassActivation, len(projects)),
-		breakGlassErrByProject: make(map[uint]error, len(projects)),
+		projects:                   projects,
+		campaignsByProject:         make(map[uint][]*CampaignWithProgress, len(projects)),
+		campaignsErrByProject:      make(map[uint]error, len(projects)),
+		breakGlassByProject:        make(map[uint][]*models.BreakGlassActivation, len(projects)),
+		breakGlassErrByProject:     make(map[uint]error, len(projects)),
+		accessRequestsByProject:    make(map[uint][]*models.AccessRequest, len(projects)),
+		accessRequestsErrByProject: make(map[uint]error, len(projects)),
 	}
 
 	snap.auditChain, snap.auditChainErr = c.VerifyAuditChain(ctx)
@@ -295,8 +322,30 @@ func (c *KeyorixCore) buildComplianceSnapshot(ctx context.Context) (*complianceS
 		acts, bErr := c.ListBreakGlassActivations(ctx, pid)
 		snap.breakGlassByProject[pid] = acts
 		snap.breakGlassErrByProject[pid] = bErr
+
+		reqs, rErr := c.storage.ListAccessRequests(ctx, pid)
+		if rErr == nil {
+			applyAccessRequestEffectiveExpiry(reqs, c.now())
+		}
+		snap.accessRequestsByProject[pid] = reqs
+		snap.accessRequestsErrByProject[pid] = rErr
 	}
 	return snap, nil
+}
+
+// applyAccessRequestEffectiveExpiry corrects the in-memory State of any row that is
+// still persisted as pending but whose ExpiresAt has passed — mirroring how
+// ListBreakGlassActivations computes an activation's effective expired state without
+// writing it back. The posture/evidence snapshot is read-only (unlike the core
+// ListAccessRequests method, which lazily persists this same transition on read), so
+// a stale "pending" row must not be reported as still-pending here without also
+// issuing a write this snapshot is not meant to perform.
+func applyAccessRequestEffectiveExpiry(reqs []*models.AccessRequest, now time.Time) {
+	for _, r := range reqs {
+		if r.State == AccessRequestPending && r.ExpiresAt != nil && now.After(*r.ExpiresAt) {
+			r.State = AccessRequestExpired
+		}
+	}
 }
 
 // GetCompliancePosture aggregates the deployment's control posture. It is an
@@ -561,6 +610,7 @@ func (c *KeyorixCore) identityPosture(ctx context.Context) (IdentityPosture, err
 // from the shared complianceSnapshot (#256) rather than a fresh query per call.
 func (c *KeyorixCore) accessGovernancePostureFromSnapshot(ctx context.Context, p *CompliancePosture, snap *complianceSnapshot) {
 	p.AccessGovernance.Projects = len(snap.projects)
+	p.AccessRequests.RequiredApprovals = c.requiredApprovals()
 	recertCutoff := c.now().AddDate(0, 0, -c.recertCadence())
 	for _, proj := range snap.projects {
 		pid := proj.ID
@@ -601,6 +651,26 @@ func (c *KeyorixCore) accessGovernancePostureFromSnapshot(ctx context.Context, p
 			}
 		} else {
 			p.degrade(fmt.Sprintf("emergency_access:project=%d", pid), err)
+		}
+
+		if reqs, err := snap.accessRequestsByProject[pid], snap.accessRequestsErrByProject[pid]; err == nil {
+			p.AccessRequests.TotalRequests += len(reqs)
+			for _, r := range reqs {
+				switch r.State {
+				case AccessRequestPending:
+					p.AccessRequests.Pending++
+				case AccessRequestApproved:
+					p.AccessRequests.Approved++
+				case AccessRequestRejected:
+					p.AccessRequests.Rejected++
+				case AccessRequestWithdrawn:
+					p.AccessRequests.Withdrawn++
+				case AccessRequestExpired:
+					p.AccessRequests.Expired++
+				}
+			}
+		} else {
+			p.degrade(fmt.Sprintf("access_requests:project=%d", pid), err)
 		}
 	}
 }

--- a/internal/core/compliance_posture_external_test.go
+++ b/internal/core/compliance_posture_external_test.go
@@ -61,6 +61,83 @@ func TestGetCompliancePosture_RollsUpControls(t *testing.T) {
 	assert.True(t, p.AuditIntegrity.ChainVerified)
 }
 
+// GetCompliancePosture rolls up the dual-control access-request/approval workflow
+// (#257): total requests plus per-state counts across every project, and the
+// currently-configured dual-control approval threshold. A stale pending request
+// past its ExpiresAt must roll up as expired, not pending, even though the seeded
+// row's persisted State column still literally says "pending" (mirroring how
+// applyAccessRequestEffectiveExpiry — used by the posture/evidence read path —
+// corrects this without a write).
+func TestGetCompliancePosture_AccessRequests(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(
+		&models.AuditEvent{}, &models.AccessReviewCampaign{}, &models.AccessReviewItem{}, &models.BreakGlassActivation{}, &models.RotationPolicy{},
+		&models.AccessRequest{}, &models.AccessRequestApproval{},
+	))
+
+	ctx := context.Background()
+	h.CreateTestUser(t, "requester1", 20)
+	h.CreateTestUser(t, "requester2", 21)
+	h.CreateTestUser(t, "requester3", 22)
+	h.CreateTestUser(t, "requester4", 23)
+	h.CreateTestUser(t, "requester5", 24)
+
+	now := time.Now()
+	future := now.Add(time.Hour)
+	past := now.Add(-time.Hour)
+
+	// Project 1: one still-pending request, one PAST-expiry request that is still
+	// persisted with State="pending" (the lazy-expiry transition hasn't landed yet),
+	// and one withdrawn request.
+	require.NoError(t, h.DB.Create(&models.AccessRequest{
+		ProjectID: 1, UserID: 20, SuggestedRole: "viewer", State: "pending",
+		ExpiresAt: &future, CreatedAt: now,
+	}).Error)
+	require.NoError(t, h.DB.Create(&models.AccessRequest{
+		ProjectID: 1, UserID: 21, SuggestedRole: "viewer", State: "pending",
+		ExpiresAt: &past, CreatedAt: now,
+	}).Error)
+	require.NoError(t, h.DB.Create(&models.AccessRequest{
+		ProjectID: 1, UserID: 24, SuggestedRole: "viewer", State: "withdrawn",
+		CreatedAt: now, ResolvedAt: &now,
+	}).Error)
+
+	// Project 2: one approved request, one rejected request.
+	require.NoError(t, h.DB.Create(&models.AccessRequest{
+		ProjectID: 2, UserID: 22, SuggestedRole: "editor", GrantedRole: "editor", State: "approved",
+		CreatedAt: now, ResolvedAt: &now,
+	}).Error)
+	require.NoError(t, h.DB.Create(&models.AccessRequest{
+		ProjectID: 2, UserID: 23, SuggestedRole: "editor", State: "rejected",
+		CreatedAt: now, ResolvedAt: &now,
+	}).Error)
+
+	p, err := h.CoreService.GetCompliancePosture(ctx)
+	require.NoError(t, err)
+
+	assert.Equal(t, 5, p.AccessRequests.TotalRequests)
+	assert.Equal(t, 1, p.AccessRequests.Pending)
+	assert.Equal(t, 1, p.AccessRequests.Expired) // past-ExpiresAt row rolls up as expired, not pending
+	assert.Equal(t, 1, p.AccessRequests.Approved)
+	assert.Equal(t, 1, p.AccessRequests.Rejected)
+	assert.Equal(t, 1, p.AccessRequests.Withdrawn)
+	// No SetDualControlPolicy call — the default single-approver threshold applies.
+	assert.Equal(t, 1, p.AccessRequests.RequiredApprovals)
+
+	// The evidence pack carries the same underlying rows the posture counted.
+	ev, err := h.CoreService.GenerateComplianceEvidence(ctx)
+	require.NoError(t, err)
+	assert.Len(t, ev.AccessRequests, 5)
+	assert.Equal(t, p.AccessRequests, ev.Posture.AccessRequests)
+
+	// Raising the dual-control threshold surfaces in the posture immediately.
+	h.CoreService.SetDualControlPolicy(2)
+	p2, err := h.CoreService.GetCompliancePosture(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 2, p2.AccessRequests.RequiredApprovals)
+}
+
 // A recent secret access keeps a role grant out of the dormant tally.
 func TestCompliancePosture_RecentActivityNotDormant(t *testing.T) {
 	h := testhelper.NewRBACTestHelper(t)


### PR DESCRIPTION
## Summary

- Every other governance mechanism (legal holds, break-glass activations, recertification campaigns, SoD violations) already rolls up into `CompliancePosture` / the evidence pack, but the dual-control access-request/approval workflow (`AccessRequest` / `AccessRequestApproval`, both already AutoMigrated and enforced in `internal/core/invitations.go`) had zero aggregate visibility.
- Adds `AccessRequestPosture` to `CompliancePosture`: `total_requests`, `pending`, `approved`, `rejected`, `withdrawn`, `expired`, plus `required_approvals` (the current N-of-M dual-control threshold from `SetDualControlPolicy`).
- Counts are built from the same per-project `complianceSnapshot` pass the other rollups already share (#256), not a second query pass, and a stale pending row past its `ExpiresAt` rolls up as expired (computed in-memory, matching the read-only contract of this snapshot — no write, unlike the core `ListAccessRequests` list path).
- Wires the underlying `[]*models.AccessRequest` rows into `ComplianceEvidence.AccessRequests`, mirroring how `BreakGlass` is included.
- This is visibility only — no new self-approval/dual-control enforcement logic is added. The maker≠checker and one-sign-off-per-approver invariants are already enforced by `ApproveAccessRequestWithExpiry`.

## Test plan

- [x] Added `TestGetCompliancePosture_AccessRequests` seeding requests across two projects in every state (pending, past-expiry-but-still-persisted-pending, approved, rejected, withdrawn) and asserting the rollup counts, the `required_approvals` default and after `SetDualControlPolicy(2)`, and that the evidence pack carries the same rows/posture.
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/core/... -run 'Compliance|AccessRequest' -v`
- [x] `go test ./internal/core/...` (full package, 2x with `-count=1`)
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues

🤖 Generated with Claude Code