### PR TITLE
feat(grpc): add server-side keepalive to reclaim idle connections (#222, #435)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -244,6 +244,59 @@ type ServerInstanceConfig struct {
 	WebAssetsPath  string   `yaml:"web_assets_path,omitempty"`
 	AllowedOrigins []string `yaml:"allowed_origins,omitempty"`
 	Domain         string   `yaml:"domain,omitempty"`
+	// Keepalive tunes server-side connection keepalive/idle-reclaim (#222/#435). GRPC
+	// only — an authenticated credential holder can otherwise open many long-lived,
+	// mostly-idle connections that the server has no way to detect and reclaim, a
+	// slow-drip goroutine/fd exhaustion surface distinct from the per-principal
+	// concurrency cap already applied to StreamAuditLogs.
+	Keepalive GRPCKeepaliveConfig `yaml:"keepalive,omitempty"`
+}
+
+// GRPCKeepaliveConfig tunes the gRPC server's keepalive ping and enforcement policy
+// (#222/#435). Every field is a Go duration string (e.g. "5m", "20s"); empty/unparseable
+// values fall back to the documented default via the Get* accessors below.
+type GRPCKeepaliveConfig struct {
+	// Time is how long the server waits on an idle connection before sending a
+	// keepalive ping to check it's still alive. Default 5m when unset/unparseable.
+	Time string `yaml:"time,omitempty"`
+	// Timeout is how long the server waits for a ping ack before closing the
+	// connection as dead. Default 20s when unset/unparseable.
+	Timeout string `yaml:"timeout,omitempty"`
+	// MinTime is the minimum interval a client is allowed to send keepalive pings on;
+	// a client pinging more often than this is judged abusive and sent GOAWAY
+	// ENHANCE_YOUR_CALM. Default 5m when unset/unparseable.
+	MinTime string `yaml:"min_time,omitempty"`
+	// PermitWithoutStream, if true, lets a client send keepalive pings even with no
+	// active RPC/stream open. No client in this codebase pings without an active
+	// call (StreamAuditLogs keeps its stream open for the duration it needs pings),
+	// so this defaults to false — rejecting streamless pings closes off a cheap
+	// ping-flood vector from a valid credential holder that never opens an RPC.
+	PermitWithoutStream bool `yaml:"permit_without_stream,omitempty"`
+}
+
+// defaultGRPCKeepaliveTime/Timeout/MinTime are the server-side keepalive defaults
+// applied when the operator hasn't configured server.grpc.keepalive.* (#222/#435).
+const (
+	defaultGRPCKeepaliveTime    = 5 * time.Minute
+	defaultGRPCKeepaliveTimeout = 20 * time.Second
+	defaultGRPCKeepaliveMinTime = 5 * time.Minute
+)
+
+// GetTime returns the idle-before-ping interval (default 5m).
+func (c GRPCKeepaliveConfig) GetTime() time.Duration {
+	return parseDurationDefault(c.Time, defaultGRPCKeepaliveTime)
+}
+
+// GetTimeout returns the ping-ack wait before the connection is closed as dead
+// (default 20s).
+func (c GRPCKeepaliveConfig) GetTimeout() time.Duration {
+	return parseDurationDefault(c.Timeout, defaultGRPCKeepaliveTimeout)
+}
+
+// GetMinTime returns the minimum interval a client may send keepalive pings on
+// before being treated as abusive (default 5m).
+func (c GRPCKeepaliveConfig) GetMinTime() time.Duration {
+	return parseDurationDefault(c.MinTime, defaultGRPCKeepaliveMinTime)
 }
 
 // defaultMaxRequestBodyBytes is the request-body cap when none is configured.

--- a/internal/config/grpc_keepalive_config_test.go
+++ b/internal/config/grpc_keepalive_config_test.go
@@ -1,0 +1,29 @@
+package config
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// #222/#435: the gRPC server has no way to detect and reclaim idle/abandoned
+// connections without keepalive, a slow-drip goroutine/fd exhaustion surface. These
+// accessors are what NewServer wires into grpc.KeepaliveParams / KeepaliveEnforcementPolicy.
+func TestGRPCKeepaliveConfig_GetTime(t *testing.T) {
+	assert.Equal(t, 5*time.Minute, GRPCKeepaliveConfig{}.GetTime(), "default when unset")
+	assert.Equal(t, 5*time.Minute, GRPCKeepaliveConfig{Time: "garbage"}.GetTime(), "unparseable falls back")
+	assert.Equal(t, 2*time.Minute, GRPCKeepaliveConfig{Time: "2m"}.GetTime())
+}
+
+func TestGRPCKeepaliveConfig_GetTimeout(t *testing.T) {
+	assert.Equal(t, 20*time.Second, GRPCKeepaliveConfig{}.GetTimeout(), "default when unset")
+	assert.Equal(t, 20*time.Second, GRPCKeepaliveConfig{Timeout: "garbage"}.GetTimeout(), "unparseable falls back")
+	assert.Equal(t, 10*time.Second, GRPCKeepaliveConfig{Timeout: "10s"}.GetTimeout())
+}
+
+func TestGRPCKeepaliveConfig_GetMinTime(t *testing.T) {
+	assert.Equal(t, 5*time.Minute, GRPCKeepaliveConfig{}.GetMinTime(), "default when unset")
+	assert.Equal(t, 5*time.Minute, GRPCKeepaliveConfig{MinTime: "garbage"}.GetMinTime(), "unparseable falls back")
+	assert.Equal(t, 30*time.Second, GRPCKeepaliveConfig{MinTime: "30s"}.GetMinTime())
+}

--- a/server/grpc/server.go
+++ b/server/grpc/server.go
@@ -14,6 +14,7 @@ import (
 	pb "github.com/keyorixhq/keyorix/server/proto/pb"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/reflection"
 )
 
@@ -68,6 +69,32 @@ func NewServer(cfg *config.Config, coreService *core.KeyorixCore) (*grpc.Server,
 		maxMsg = math.MaxInt32
 	}
 	opts = append(opts, grpc.MaxRecvMsgSize(int(maxMsg)))
+
+	// Detect and reclaim idle/abandoned connections (#222/#435). Without server-side
+	// keepalive, a valid audit.read (or any other) credential holder can open many
+	// long-lived, mostly-idle connections that the server can never detect as dead —
+	// a slow-drip goroutine/fd exhaustion surface distinct from the per-principal
+	// concurrency cap already applied to StreamAuditLogs (which only bounds "many
+	// streams from one principal", not "idle connections nobody ever closes").
+	ka := cfg.Server.GRPC.Keepalive
+	opts = append(opts,
+		grpc.KeepaliveParams(keepalive.ServerParameters{
+			// Ping an idle connection after this long to check it's still alive.
+			Time: ka.GetTime(),
+			// Close the connection if the ping isn't ack'd within this long.
+			Timeout: ka.GetTimeout(),
+		}),
+		grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
+			// Reject a client that pings more often than this as abusive (GOAWAY
+			// ENHANCE_YOUR_CALM) rather than let ping frequency itself become a DoS
+			// vector.
+			MinTime: ka.GetMinTime(),
+			// No client here legitimately pings with zero active RPCs/streams — even
+			// StreamAuditLogs keeps its stream open for as long as it needs pings — so
+			// streamless pings are rejected outright rather than tolerated.
+			PermitWithoutStream: ka.PermitWithoutStream,
+		}),
+	)
 
 	// Add TLS if enabled
 	if cfg.Server.GRPC.TLS.Enabled {

--- a/server/grpc/server_integration_test.go
+++ b/server/grpc/server_integration_test.go
@@ -2,7 +2,9 @@ package grpc_test
 
 import (
 	"context"
+	"errors"
 	"net"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -14,6 +16,7 @@ import (
 	pb "github.com/keyorixhq/keyorix/server/proto/pb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/net/http2"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
@@ -194,4 +197,65 @@ func TestGRPCServer_HonorsConfiguredMaxRecvMsgSize(t *testing.T) {
 	require.Error(t, err)
 	assert.Equal(t, codes.Unauthenticated, status.Code(err),
 		"a small request clears the size cap and is then rejected by auth")
+}
+
+// TestGRPCServer_KeepaliveReclaimsAbandonedConnection proves grpc.KeepaliveParams is
+// actually wired from server.grpc.keepalive (#222/#435), not just constructed and
+// discarded: an abandoned connection — one that never sends another frame and never
+// ACKs a keepalive ping, exactly the "credential holder opens a connection and never
+// closes it" scenario the finding describes — must be detected and torn down within
+// Time+Timeout, rather than held open indefinitely (the pre-fix behavior, a slow-drip
+// goroutine/fd exhaustion surface).
+//
+// A real grpc-go client can't be used to simulate this: its HTTP/2 transport always
+// ACKs pings automatically regardless of the client's own keepalive settings, so it
+// can never look "dead" to the server. Instead this dials a raw net.Conn, completes
+// just enough of the HTTP/2 handshake (client preface + an empty SETTINGS frame) to
+// pass the server's handshake, and then goes silent — never reading, never writing,
+// never ACKing. That is a faithful stand-in for an abandoned connection, and the
+// server closing it (observed as the raw conn's Read unblocking with EOF/reset) is a
+// genuine behavioral proof of the configured Time/Timeout keepalive, not just a
+// construction check.
+func TestGRPCServer_KeepaliveReclaimsAbandonedConnection(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	t.Cleanup(h.Cleanup)
+
+	cfg := &config.Config{}
+	// 1s is the floor grpc-go enforces on the server's keepalive Time (values below it
+	// are silently raised with a warning), so this is the fastest this is practically
+	// observable; Timeout is independent and can be shorter.
+	cfg.Server.GRPC.Keepalive.Time = "1s"
+	cfg.Server.GRPC.Keepalive.Timeout = "500ms"
+
+	srv, err := keyorixgrpc.NewServer(cfg, h.CoreService)
+	require.NoError(t, err)
+	lis := bufconn.Listen(1024 * 1024)
+	go func() { _ = srv.Serve(lis) }()
+	t.Cleanup(srv.Stop)
+
+	raw, err := lis.Dial()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = raw.Close() })
+
+	// Minimal HTTP/2 handshake: client preface + an empty SETTINGS frame (required
+	// before the server will treat this as a valid connection), then nothing else —
+	// no reads, no writes, no ping ACKs, ever.
+	_, err = raw.Write([]byte(http2.ClientPreface))
+	require.NoError(t, err)
+	require.NoError(t, http2.NewFramer(raw, raw).WriteSettings())
+
+	// The server must notice the silence, ping, get no ACK within Timeout, and close
+	// the connection well before our own read deadline (Time + Timeout + generous
+	// slack). Drain and discard whatever the server sends (its own SETTINGS frame,
+	// SETTINGS ACK, keepalive PINGs, GOAWAY, ...) without ever writing another byte
+	// ourselves — an abandoned connection reads nothing back either — until the read
+	// finally errors out because the server tore the connection down.
+	require.NoError(t, raw.SetReadDeadline(time.Now().Add(5*time.Second)))
+	buf := make([]byte, 256)
+	var readErr error
+	for readErr == nil {
+		_, readErr = raw.Read(buf)
+	}
+	assert.False(t, errors.Is(readErr, os.ErrDeadlineExceeded),
+		"the read must unblock because the SERVER closed the connection, not because our own read deadline fired first (got: %v)", readErr)
 }


### PR DESCRIPTION
## Summary

- `server/grpc/server.go`'s `grpc.NewServer(...)` configured TLS, `MaxRecvMsgSize`, and unary/stream interceptors, but never set `grpc.KeepaliveParams`/`grpc.KeepaliveEnforcementPolicy` — a valid credential holder (`audit.read` or otherwise) could open many long-lived, mostly-idle gRPC connections that the server had no way to detect and reclaim, a slow-drip goroutine/fd exhaustion surface distinct from the per-principal concurrency cap already applied to `StreamAuditLogs` (round 97).
- Adds `grpc.KeepaliveParams(keepalive.ServerParameters{Time, Timeout})` to ping an idle connection and close it if unACKed, and `grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{MinTime, PermitWithoutStream})` to reject excessively frequent client pings as abusive.
- Wired as configurable via a new `server.grpc.keepalive.{time,timeout,min_time,permit_without_stream}` YAML block on `GRPCKeepaliveConfig` (mirrors the existing `Get*()`-accessor/duration-string convention already used elsewhere in `internal/config/config.go`), with defaults of `Time=5m`, `Timeout=20s`, `MinTime=5m` when unset.
- `PermitWithoutStream` defaults to `false`: no client in this codebase pings with zero active RPCs/streams (even `StreamAuditLogs` keeps its stream open for as long as it needs pings), so streamless pings are rejected outright by default rather than tolerated.

## Testing

- `internal/config/grpc_keepalive_config_test.go`: unit tests for the `Get*()` accessors' default/parse/fallback behavior.
- `server/grpc/server_integration_test.go` (`TestGRPCServer_KeepaliveReclaimsAbandonedConnection`): a real behavioral proof, not just a construction check. A real grpc-go client always auto-ACKs pings at the transport layer regardless of its own keepalive settings, so it can never simulate an abandoned connection. Instead this dials a raw `net.Conn` against the real `NewServer`-constructed server (over `bufconn`), completes just the HTTP/2 handshake (client preface + an empty SETTINGS frame), then goes silent forever — the actual "credential holder opens a connection and never closes it" scenario from the finding. With `Time=1s` (the floor grpc-go enforces on the server side) / `Timeout=500ms` configured, the server pings the silent connection, gets no ACK, and tears it down — observed as the abandoned side's blocked `Read` unblocking with a real error before its own 5s safety-net deadline fires.
- Note: `grpc.KeepaliveEnforcementPolicy`'s `MinTime` (ping-frequency abuse) path was **not** covered by a fast timing-based test — grpc-go itself enforces a hard 10s floor on `grpc.WithKeepaliveParams`' client-side `Time` (deliberately, to prevent exactly this kind of misconfigured "aggressive ping" scenario), so reliably triggering a `MinTime` violation from a real client requires tens of seconds of real wall-clock time, which isn't a good fit for a fast/deterministic unit test. The `EnforcementPolicy` option is still wired and reviewed by hand; the idle-reclaim (`KeepaliveParams`) path is the one behaviorally verified.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./server/grpc/... -v` (all passing, including the new keepalive test)
- [x] `go test ./internal/config/... -run GRPCKeepalive -v`
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)