### PR TITLE
fix(rbac): correct system.write permission-catalog description (#227)

### DIFF
--- a/internal/core/auth_bootstrap.go
+++ b/internal/core/auth_bootstrap.go
@@ -56,7 +56,17 @@ var defaultPermissions = []bootstrapPermissionDef{
 	{"roles.assign", "Assign roles to users", "roles", "assign"},
 	{"audit.read", "View audit logs", "audit", "read"},
 	{"system.read", "View system information", "system", "read"},
-	{"system.write", "Manage service accounts and API tokens", "system", "write"},
+	// #227: this permission's blast radius is much broader than "system.write"
+	// sounds — it gates every deployment-wide admin-tier action that isn't a
+	// dedicated resource permission of its own: audit-checkpoint writes and
+	// anomaly-alert acknowledgment, legal-hold place/lift, risk-exception
+	// create/approve/revoke, SoD-policy create/delete, and on-demand admin job
+	// triggers (rotation/expiry reminders, anomaly alerts, compliance digest).
+	// The description must name that footprint so an operator granting a
+	// custom role system.write knows what they're actually handing over — not
+	// just the legacy service-account/API-token routes, which were removed as
+	// dead code (finding #131) and no longer exist.
+	{"system.write", "Manage audit checkpoints/alerts, legal holds, risk exceptions, SoD policies, and admin job triggers", "system", "write"},
 	{"connect.read", "Read secrets from external stores via Keyorix Connect (ADR-043)", "connect", "read"},
 }
 

--- a/internal/core/auth_bootstrap_rbac_test.go
+++ b/internal/core/auth_bootstrap_rbac_test.go
@@ -76,6 +76,22 @@ func TestBootstrapSeedsTwoTierRoleCatalog(t *testing.T) {
 	}
 }
 
+// #227: system.write's catalog description must name its full real footprint —
+// audit checkpoints/alerts, legal holds, risk exceptions, SoD policies, and
+// admin job triggers — not just the legacy service-account/API-token routes
+// (removed as dead code by finding #131). A misleading description here is an
+// informed-consent gap for whoever grants this permission on a custom role.
+func TestSystemWritePermissionDescriptionMatchesFullFootprint(t *testing.T) {
+	for _, def := range defaultPermissions {
+		if def.Name != "system.write" {
+			continue
+		}
+		assert.Equal(t, "Manage audit checkpoints/alerts, legal holds, risk exceptions, SoD policies, and admin job triggers", def.Description)
+		return
+	}
+	t.Fatal("system.write not found in defaultPermissions")
+}
+
 // Authorize must honour the two-tier scope semantics on the sentinel model:
 // system roles assigned globally apply install-wide, project roles apply only
 // within their project, and *_admin roles bypass the per-permission check at the


### PR DESCRIPTION
## Summary
- Finding #227: the `system.write` permission-catalog entry in `internal/core/auth_bootstrap.go` described itself as "Manage service accounts and API tokens" — that surface was removed as dead code by finding #131 (the routes never validated tokens they minted) and no longer exists.
- Verified via grep every enforcement site (`RequirePermission("system.write")` in `server/http/router.go`, `authorizeGlobal(ctx, s.core, actor, "system.write")` in `server/grpc/services/audit_service.go`) to build the real, complete footprint:
  - Audit checkpoint writes — `server/http/router.go:709` (`POST /audit/checkpoint`), mirrored by gRPC `server/grpc/services/audit_service.go:216` (`WriteAuditCheckpoint`)
  - Anomaly-alert acknowledgment — `server/http/router.go:714` (`POST /audit/anomalies/{id}/acknowledge`)
  - Legal-hold place/lift — `server/http/router.go:766-767` (`POST`/`DELETE /legal-hold`)
  - Risk-exception create/approve/revoke — `server/http/router.go:781-783`
  - SoD-policy create/delete — `server/http/router.go:790-791`
  - On-demand admin job triggers (anomaly-alerts, rotation-reminders, expiry-reminders, compliance-digest) — `server/http/router.go:797-802` (`/admin/jobs/*`)
- Updated the description to: "Manage audit checkpoints/alerts, legal holds, risk exceptions, SoD policies, and admin job triggers" — an accurate, concise summary of the full blast radius so an admin granting this permission on a custom role isn't misled into under-estimating what they're handing over.
- Added `TestSystemWritePermissionDescriptionMatchesFullFootprint` (no prior test asserted exact description strings) to catch future drift back toward a misleading description.

Note: per ADR-044, `ReconcileRBACPermissions` is intentionally non-clobbering — it only creates missing permissions and never rewrites an existing row's description, so this fix updates the description for fresh installs going forward; it does not retroactively rewrite the description on already-bootstrapped deployments. That's an existing, documented design tradeoff, out of scope here.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/core/... -run 'Permission|Catalog|Bootstrap' -v` (all pass, including the new test)
- [x] `gosec -severity medium -exclude-generated ./internal/core/...` — 0 issues

🤖 Generated with Claude Code